### PR TITLE
feat: event-log kernel — durable Event sidecar + replay-capable consumer

### DIFF
--- a/src/adapters/event-sink-jsonl.ts
+++ b/src/adapters/event-sink-jsonl.ts
@@ -1,0 +1,66 @@
+/**
+ * Concrete `EventSink` adapter — writes the kernel Event log to a
+ * `<sessionsDir>/<name>.events.jsonl` sidecar alongside the existing
+ * ChatMessage session file. One Event per line; append-only.
+ *
+ * Mirrors the design of `src/transcript.ts:openTranscriptFile` so the
+ * disk shape is consistent across artifacts (jsonl, durable, parseable
+ * by streaming readers).
+ */
+
+import { type WriteStream, chmodSync, createWriteStream, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import type { Event } from "../core/events.js";
+import type { EventSink } from "../ports/event-sink.js";
+import { sanitizeName, sessionsDir } from "../session.js";
+
+export function eventLogPath(sessionName: string): string {
+  return join(sessionsDir(), `${sanitizeName(sessionName)}.events.jsonl`);
+}
+
+export class JsonlEventSink implements EventSink {
+  private buffered = 0;
+
+  constructor(private readonly stream: WriteStream) {}
+
+  append(ev: Event): void {
+    this.stream.write(`${JSON.stringify(ev)}\n`);
+    this.buffered++;
+  }
+
+  flush(): Promise<void> {
+    return new Promise((resolve) => {
+      if (this.buffered === 0) return resolve();
+      // `cork`/`uncork` is the documented way to ask Node to release
+      // batched writes; we rely on the OS to actually fsync. For a
+      // session log that's fine — losing the last few events on a
+      // hard crash is acceptable since the transcript file carries
+      // the same conversation.
+      this.stream.uncork();
+      this.buffered = 0;
+      resolve();
+    });
+  }
+
+  close(): Promise<void> {
+    return new Promise((resolve) => {
+      this.stream.end(() => resolve());
+    });
+  }
+}
+
+/**
+ * Open (or create) the sidecar file for `sessionName`. Creates parent
+ * directory if missing; chmods to 0600 on Unix to match the session
+ * file's permissions (chmod no-ops on Windows).
+ */
+export function openEventSink(path: string): JsonlEventSink {
+  mkdirSync(dirname(path), { recursive: true });
+  const stream = createWriteStream(path, { flags: "a" });
+  try {
+    chmodSync(path, 0o600);
+  } catch {
+    /* chmod not supported on this platform */
+  }
+  return new JsonlEventSink(stream);
+}

--- a/src/adapters/event-source-jsonl.ts
+++ b/src/adapters/event-source-jsonl.ts
@@ -1,0 +1,47 @@
+/**
+ * Concrete `EventSource` adapter — reads the kernel event log sidecar
+ * back as a typed Event stream. Matches `JsonlEventSink`'s on-disk
+ * format: one JSON Event per line, append-only.
+ *
+ * Used by replay / projection consumers — anything that wants to
+ * reconstruct session state from the durable event log without going
+ * through loop or transcript.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import type { Event } from "../core/events.js";
+import type { EventSource } from "../ports/event-sink.js";
+import { eventLogPath } from "./event-sink-jsonl.js";
+
+/**
+ * Parse a JSONL event log file into an Event array. Skips blank lines
+ * and unparseable rows silently (the live writer may have crashed mid-
+ * line). Caller decides what to do with the result — typically pipe
+ * through `core/reducers.ts:apply` to project into views.
+ */
+export function readEventLogFile(path: string): Event[] {
+  if (!existsSync(path)) return [];
+  const raw = readFileSync(path, "utf8");
+  const out: Event[] = [];
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const ev = JSON.parse(trimmed) as Event;
+      if (ev && typeof ev === "object" && typeof (ev as { type?: unknown }).type === "string") {
+        out.push(ev);
+      }
+    } catch {
+      // Malformed line — partial write or truncation. Skip silently
+      // and carry on; replay should be best-effort, not fail-stop.
+    }
+  }
+  return out;
+}
+
+export class JsonlEventSource implements EventSource {
+  async *read(sessionName: string): AsyncIterable<Event> {
+    const events = readEventLogFile(eventLogPath(sessionName));
+    for (const ev of events) yield ev;
+  }
+}

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -2,6 +2,11 @@ import type { WriteStream } from "node:fs";
 import * as pathMod from "node:path";
 import { Box, Text, useStdout } from "ink";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  type JsonlEventSink,
+  eventLogPath,
+  openEventSink,
+} from "../../adapters/event-sink-jsonl.js";
 import { type AtUrlExpansion, expandAtMentions, expandAtUrls } from "../../at-mentions.js";
 import {
   type ApplyResult,
@@ -32,6 +37,7 @@ import {
   saveEditMode,
   saveReasoningEffort,
 } from "../../config.js";
+import { Eventizer } from "../../core/eventize.js";
 import { frameToAnsi } from "../../frame/index.js";
 import { type ResolvedHook, formatHookOutcomeMessage, loadHooks, runHooks } from "../../hooks.js";
 import { CacheFirstLoop, DeepSeekClient, ImmutablePrefix } from "../../index.js";
@@ -831,9 +837,23 @@ export function App({
       startedAt: new Date().toISOString(),
     });
   }
+  // Kernel event log sidecar — opens iff the session has a name (skip
+  // ephemeral sessions). Sink + Eventizer share lifetime with App; the
+  // for-await consumer below pipes every LoopEvent through them so a
+  // typed Event log accumulates at `~/.reasonix/sessions/<name>.events.jsonl`.
+  // Old transcript path is unchanged — this is a parallel artifact, not
+  // a replacement. Future replay / projection consumers read from here.
+  const eventSinkRef = useRef<JsonlEventSink | null>(null);
+  const eventizerRef = useRef<Eventizer | null>(null);
+  if (session && !eventSinkRef.current) {
+    eventSinkRef.current = openEventSink(eventLogPath(session));
+    eventizerRef.current = new Eventizer();
+    eventSinkRef.current.append(eventizerRef.current.emitSessionOpened(0, session, 0));
+  }
   useEffect(() => {
     return () => {
       transcriptRef.current?.end();
+      void eventSinkRef.current?.close();
     };
   }, []);
 
@@ -2952,6 +2972,24 @@ export function App({
       try {
         for await (const ev of loop.step(modelInput)) {
           writeTranscript(ev);
+          // Mirror to the kernel event log sidecar. Pure passthrough —
+          // Eventizer holds the small state (turn boundary detection +
+          // tool callId correlation) needed to translate LoopEvent
+          // shape into typed Event variants. Sink + eventizer share the
+          // App's lifetime; nothing reads the artifact yet (future
+          // replay / projection consumers will).
+          {
+            const sink = eventSinkRef.current;
+            const eventizer = eventizerRef.current;
+            if (sink && eventizer) {
+              const ctx = {
+                model: ev.stats?.model ?? loop.model ?? model,
+                prefixHash,
+                reasoningEffort: loop.reasoningEffort ?? "max",
+              };
+              for (const out of eventizer.consume(ev, ctx)) sink.append(out);
+            }
+          }
           // Mirror to dashboard SSE subscribers. Done at the top of
           // the iteration so the web sees the same sequence the TUI
           // about to render — keeps the two surfaces in lockstep.
@@ -3558,6 +3596,8 @@ export function App({
       touchedPaths,
       enterCopyMode,
       toggleCtxFooter,
+      model,
+      prefixHash,
     ],
   );
 

--- a/src/core/eventize.ts
+++ b/src/core/eventize.ts
@@ -1,0 +1,318 @@
+/**
+ * Translator: LoopEvent stream → typed Event stream.
+ *
+ * Holds the small amount of state needed to make the conversion
+ * deterministic and correlated:
+ *   - monotonic event id seq (kernel invariant)
+ *   - last turn seen (synthesizes `model.turn.started` on transition)
+ *   - per-tool-call id seq (correlates `tool.intent` → `tool.dispatched`
+ *     → `tool.result` chains; the LoopEvent stream doesn't surface
+ *     `call.id` on `tool_start`, so we mint our own)
+ *
+ * Pure data — no I/O. Caller (App.tsx) wires Eventizer into the loop's
+ * `for await` consumer and forwards each output Event to an EventSink.
+ */
+
+import type { LoopEvent } from "../loop.js";
+import type { ChatMessage, RawUsage, ToolCall } from "../types.js";
+import type {
+  Event,
+  ErrorEvent as KernelErrorEvent,
+  ModelDeltaEvent,
+  ModelFinalEvent,
+  ModelTurnStartedEvent,
+  SessionCompactedEvent,
+  SessionOpenedEvent,
+  SlashInvokedEvent,
+  StatusEvent,
+  ToolDispatchedEvent,
+  ToolIntentEvent,
+  ToolResultEvent,
+  UserMessageEvent,
+} from "./events.js";
+
+export interface EventizeContext {
+  model: string;
+  prefixHash: string;
+  reasoningEffort: "high" | "max";
+}
+
+export class Eventizer {
+  private nextId = 0;
+  private lastTurn = -1;
+  private nextToolSeq = 0;
+  /** Stack so parallel-batch dispatches still pair start ↔ result. */
+  private pendingCallIds: string[] = [];
+
+  consume(ev: LoopEvent, ctx: EventizeContext): Event[] {
+    const out: Event[] = [];
+    if (ev.turn !== this.lastTurn) {
+      this.lastTurn = ev.turn;
+      out.push(this.turnStartedEvent(ev.turn, ctx));
+    }
+    switch (ev.role) {
+      case "assistant_delta":
+        if (ev.content) out.push(this.deltaEvent(ev.turn, "content", ev.content));
+        if (ev.reasoningDelta) out.push(this.deltaEvent(ev.turn, "reasoning", ev.reasoningDelta));
+        break;
+      case "tool_call_delta":
+        // No delta text on this LoopEvent — it's a progress signal
+        // (cumulative arg-char count + ready count). Skip; the real
+        // intent + args land on tool_start.
+        break;
+      case "assistant_final":
+        out.push(this.finalEvent(ev));
+        break;
+      case "tool_start": {
+        const callId = `tc-${++this.nextToolSeq}`;
+        this.pendingCallIds.push(callId);
+        out.push(this.toolIntentEvent(ev.turn, callId, ev.toolName ?? "", ev.toolArgs ?? ""));
+        out.push(this.toolDispatchedEvent(ev.turn, callId));
+        break;
+      }
+      case "tool": {
+        const callId = this.pendingCallIds.shift() ?? `tc-orphan-${++this.nextToolSeq}`;
+        const ok = !looksLikeToolError(ev.content, ev.toolName);
+        out.push(this.toolResultEvent(ev.turn, callId, ok, ev.content, 0));
+        break;
+      }
+      case "warning":
+        out.push(this.classifyWarning(ev));
+        break;
+      case "error":
+        out.push(this.errorEvent(ev.turn, ev.error ?? ev.content, false));
+        break;
+      case "status":
+        out.push(this.statusEvent(ev.turn, ev.content));
+        break;
+      // `done` is a stream-control marker; no kernel event.
+      // `branch_*` is consistency.ts; not modeled (feature is a candidate
+      //  for retirement, and emitting partial branch state without proper
+      //  reducer support would be misleading).
+      default:
+        break;
+    }
+    return out;
+  }
+
+  emitUserMessage(turn: number, text: string): UserMessageEvent {
+    return {
+      id: ++this.nextId,
+      ts: new Date().toISOString(),
+      turn,
+      type: "user.message",
+      text,
+    };
+  }
+
+  emitSlashInvoked(turn: number, name: string, args: string): SlashInvokedEvent {
+    return {
+      id: ++this.nextId,
+      ts: new Date().toISOString(),
+      turn,
+      type: "slash.invoked",
+      name,
+      args,
+    };
+  }
+
+  emitSessionOpened(turn: number, name: string, resumedFromTurn: number): SessionOpenedEvent {
+    return {
+      id: ++this.nextId,
+      ts: new Date().toISOString(),
+      turn,
+      type: "session.opened",
+      name,
+      resumedFromTurn,
+    };
+  }
+
+  emitSessionCompacted(
+    turn: number,
+    before: number,
+    after: number,
+    reason: "user" | "auto-context-pressure",
+    replacementMessages: ReadonlyArray<ChatMessage>,
+  ): SessionCompactedEvent {
+    return {
+      id: ++this.nextId,
+      ts: new Date().toISOString(),
+      turn,
+      type: "session.compacted",
+      beforeMessages: before,
+      afterMessages: after,
+      reason,
+      replacementMessages,
+    };
+  }
+
+  private turnStartedEvent(turn: number, ctx: EventizeContext): ModelTurnStartedEvent {
+    return {
+      id: ++this.nextId,
+      ts: new Date().toISOString(),
+      turn,
+      type: "model.turn.started",
+      model: ctx.model,
+      reasoningEffort: ctx.reasoningEffort,
+      prefixHash: ctx.prefixHash,
+    };
+  }
+
+  private deltaEvent(
+    turn: number,
+    channel: "content" | "reasoning" | "tool_args",
+    text: string,
+  ): ModelDeltaEvent {
+    return {
+      id: ++this.nextId,
+      ts: new Date().toISOString(),
+      turn,
+      type: "model.delta",
+      channel,
+      text,
+    };
+  }
+
+  private finalEvent(ev: LoopEvent): ModelFinalEvent {
+    const usage: RawUsage = ev.stats
+      ? {
+          prompt_tokens: ev.stats.usage.promptTokens,
+          completion_tokens: ev.stats.usage.completionTokens,
+          total_tokens: ev.stats.usage.totalTokens,
+          prompt_cache_hit_tokens: ev.stats.usage.promptCacheHitTokens,
+          prompt_cache_miss_tokens: ev.stats.usage.promptCacheMissTokens,
+        }
+      : {};
+    const costUsd = ev.stats?.cost ?? 0;
+    const out: ModelFinalEvent = {
+      id: ++this.nextId,
+      ts: new Date().toISOString(),
+      turn: ev.turn,
+      type: "model.final",
+      content: ev.content,
+      // LoopEvent.assistant_final doesn't carry toolCalls — they're
+      // surfaced one-by-one via tool_start later in the iter loop. For
+      // the kernel record we leave the array empty here; the
+      // tool.intent events emitted on tool_start carry the actual calls.
+      toolCalls: [] as ReadonlyArray<ToolCall>,
+      usage,
+      costUsd,
+    };
+    if (ev.forcedSummary) out.forcedSummary = true;
+    return out;
+  }
+
+  private toolIntentEvent(
+    turn: number,
+    callId: string,
+    name: string,
+    args: string,
+  ): ToolIntentEvent {
+    return {
+      id: ++this.nextId,
+      ts: new Date().toISOString(),
+      turn,
+      type: "tool.intent",
+      callId,
+      name,
+      args,
+    };
+  }
+
+  private toolDispatchedEvent(turn: number, callId: string): ToolDispatchedEvent {
+    return {
+      id: ++this.nextId,
+      ts: new Date().toISOString(),
+      turn,
+      type: "tool.dispatched",
+      callId,
+    };
+  }
+
+  private toolResultEvent(
+    turn: number,
+    callId: string,
+    ok: boolean,
+    output: string,
+    durationMs: number,
+  ): ToolResultEvent {
+    return {
+      id: ++this.nextId,
+      ts: new Date().toISOString(),
+      turn,
+      type: "tool.result",
+      callId,
+      ok,
+      output,
+      durationMs,
+    };
+  }
+
+  private statusEvent(turn: number, text: string): StatusEvent {
+    return {
+      id: ++this.nextId,
+      ts: new Date().toISOString(),
+      turn,
+      type: "status",
+      text,
+    };
+  }
+
+  private errorEvent(turn: number, message: string, recoverable: boolean): KernelErrorEvent {
+    return {
+      id: ++this.nextId,
+      ts: new Date().toISOString(),
+      turn,
+      type: "error",
+      message,
+      recoverable,
+    };
+  }
+
+  /**
+   * Best-effort categorization. The loop yields plain `warning` events
+   * with content strings; we pattern-match to distinguish budget warnings
+   * (policy.budget.*) from escalation notices (policy.escalated) from
+   * everything else (recoverable error). Refining this is a follow-up —
+   * hard-typing warning shapes in LoopEvent would let the mapping
+   * be exact, but that's a loop.ts edit we're keeping out of scope.
+   */
+  private classifyWarning(ev: LoopEvent): Event {
+    const c = ev.content;
+    if (/\bauto-escalating to\b|\barmed\b.*pro|NEEDS_PRO/.test(c)) {
+      return {
+        id: ++this.nextId,
+        ts: new Date().toISOString(),
+        turn: ev.turn,
+        type: "policy.escalated",
+        fromModel: "",
+        toModel: "",
+        reason: c.includes("armed") ? "user-request" : "self-report",
+      };
+    }
+    if (/budget\b.*\$|\$\d.*\/\s*\$\d/.test(c)) {
+      const blocked = /blocked|exceeded|refus/i.test(c);
+      return {
+        id: ++this.nextId,
+        ts: new Date().toISOString(),
+        turn: ev.turn,
+        type: blocked ? "policy.budget.blocked" : "policy.budget.warning",
+        spentUsd: 0,
+        capUsd: 0,
+      };
+    }
+    return this.errorEvent(ev.turn, c, true);
+  }
+}
+
+function looksLikeToolError(content: string, _toolName: string | undefined): boolean {
+  // The loop / tool dispatcher serializes thrown errors to a string
+  // tool result. Two common shapes: a JSON-stringified `{error: "..."}`,
+  // and a plain-text `[hook block] ...` / `... Error: ...` line.
+  if (!content) return false;
+  if (content.startsWith("ERROR:")) return true;
+  if (content.startsWith("[hook block]")) return true;
+  if (/^\{"error"\s*:/.test(content)) return true;
+  if (/\bConfirmationError:|\bNeedsConfirmationError\b/.test(content)) return true;
+  return false;
+}

--- a/tests/event-replay.test.ts
+++ b/tests/event-replay.test.ts
@@ -1,0 +1,152 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { openEventSink } from "../src/adapters/event-sink-jsonl.js";
+import { readEventLogFile } from "../src/adapters/event-source-jsonl.js";
+import { Eventizer } from "../src/core/eventize.js";
+import { replay } from "../src/core/reducers.js";
+import type { LoopEvent } from "../src/loop.js";
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "reasonix-replay-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+const ctx = { model: "deepseek-v4-flash", prefixHash: "abc", reasoningEffort: "max" } as const;
+const lev = (p: Partial<LoopEvent>): LoopEvent =>
+  ({ turn: 1, role: "status", content: "", ...p }) as LoopEvent;
+
+describe("event-log replay round-trip", () => {
+  it("synthetic LoopEvents → eventize → sink → file → source → reducers → ConversationView matches", async () => {
+    const path = join(dir, "rt.events.jsonl");
+    const sink = openEventSink(path);
+    const eventizer = new Eventizer();
+
+    // Session bootstrap (App-side emit).
+    sink.append(eventizer.emitSessionOpened(0, "rt", 0));
+    sink.append(eventizer.emitUserMessage(1, "list files in src"));
+
+    // Loop emits a typical turn: assistant_final → tool_start → tool.
+    const loopEvents: LoopEvent[] = [
+      lev({ turn: 1, role: "status", content: "thinking" }),
+      lev({ turn: 1, role: "assistant_delta", content: "Let me check." }),
+      lev({
+        turn: 1,
+        role: "assistant_final",
+        content: "Let me check.",
+        // No stats so the model.final lands with empty usage / 0 cost.
+      }),
+      lev({
+        turn: 1,
+        role: "tool_start",
+        toolName: "list_directory",
+        toolArgs: '{"path":"src"}',
+      }),
+      lev({
+        turn: 1,
+        role: "tool",
+        content: "App.tsx\nloop.ts\n...",
+        toolName: "list_directory",
+      }),
+      lev({ turn: 1, role: "done", content: "" }),
+    ];
+    for (const lev of loopEvents) {
+      for (const out of eventizer.consume(lev, ctx)) sink.append(out);
+    }
+    await sink.close();
+
+    // Read back from disk + project.
+    const events = readEventLogFile(path);
+    expect(events.length).toBeGreaterThan(0);
+    const projections = replay(events);
+
+    // ConversationView reconstruction:
+    //   user message, assistant final, tool result.
+    const msgs = projections.conversation.messages;
+    expect(msgs.length).toBe(3);
+    expect(msgs[0]).toMatchObject({ role: "user", content: "list files in src" });
+    expect(msgs[1]).toMatchObject({ role: "assistant", content: "Let me check." });
+    expect(msgs[2]).toMatchObject({ role: "tool", content: "App.tsx\nloop.ts\n..." });
+    expect(projections.conversation.pendingToolCalls).toEqual([]);
+
+    // SessionMetaView pinned the session name + last turn we touched.
+    expect(projections.session.name).toBe("rt");
+    expect(projections.session.currentTurn).toBe(1);
+  });
+
+  it("error-shaped tool result reduces with ok=false in the conversation", async () => {
+    const path = join(dir, "err.events.jsonl");
+    const sink = openEventSink(path);
+    const eventizer = new Eventizer();
+    sink.append(eventizer.emitUserMessage(1, "rm bogus"));
+    const seq: LoopEvent[] = [
+      lev({ turn: 1, role: "tool_start", toolName: "shell", toolArgs: "{}" }),
+      lev({
+        turn: 1,
+        role: "tool",
+        content: "ERROR: command not found",
+        toolName: "shell",
+      }),
+    ];
+    for (const lev of seq) {
+      for (const out of eventizer.consume(lev, ctx)) sink.append(out);
+    }
+    await sink.close();
+
+    const projections = replay(readEventLogFile(path));
+    const tail = projections.conversation.messages.at(-1);
+    expect(tail?.role).toBe("tool");
+    expect(tail?.content).toContain("ERROR:");
+    // Even with ok=false the pending list clears.
+    expect(projections.conversation.pendingToolCalls).toEqual([]);
+  });
+
+  it("replay is deterministic — running twice yields identical projections", async () => {
+    const path = join(dir, "det.events.jsonl");
+    const sink = openEventSink(path);
+    const eventizer = new Eventizer();
+    sink.append(eventizer.emitSessionOpened(0, "det", 0));
+    sink.append(eventizer.emitUserMessage(1, "x"));
+    for (const out of eventizer.consume(
+      lev({ turn: 1, role: "assistant_final", content: "y" }),
+      ctx,
+    ))
+      sink.append(out);
+    await sink.close();
+
+    const events = readEventLogFile(path);
+    const a = replay(events);
+    const b = replay(events);
+    expect(a).toEqual(b);
+  });
+
+  it("missing log file yields empty event list (no exception)", () => {
+    const path = join(dir, "does-not-exist.events.jsonl");
+    expect(readEventLogFile(path)).toEqual([]);
+  });
+
+  it("malformed JSONL lines are skipped, valid ones accepted", () => {
+    const path = join(dir, "partial.events.jsonl");
+    // Use the sink to write valid lines, then manually append garbage.
+    const sink = openEventSink(path);
+    const eventizer = new Eventizer();
+    sink.append(eventizer.emitUserMessage(1, "ok"));
+    return sink.close().then(() => {
+      const fs = require("node:fs") as typeof import("node:fs");
+      fs.appendFileSync(path, "{not valid json\n");
+      fs.appendFileSync(path, "\n");
+      fs.appendFileSync(
+        path,
+        `${JSON.stringify({ id: 99, ts: "2026-04-29T00:00:00Z", turn: 1, type: "status", text: "good" })}\n`,
+      );
+      const events = readEventLogFile(path);
+      // 1 from the valid sink write + 1 from the manually appended status.
+      expect(events.length).toBe(2);
+      expect(events[1]?.type).toBe("status");
+    });
+  });
+});

--- a/tests/event-sink-jsonl.test.ts
+++ b/tests/event-sink-jsonl.test.ts
@@ -1,0 +1,81 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { JsonlEventSink, openEventSink } from "../src/adapters/event-sink-jsonl.js";
+import type { Event } from "../src/core/events.js";
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "reasonix-events-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+const ev = (id: number, type: "user.message" | "status", text: string): Event =>
+  type === "user.message"
+    ? { id, ts: "2026-04-29T12:00:00Z", turn: 1, type, text }
+    : { id, ts: "2026-04-29T12:00:00Z", turn: 1, type, text };
+
+describe("JsonlEventSink", () => {
+  it("appends one JSON object per line, parseable round-trip", async () => {
+    const path = join(dir, "test.events.jsonl");
+    const sink = openEventSink(path);
+    sink.append(ev(1, "user.message", "hi"));
+    sink.append(ev(2, "status", "thinking"));
+    await sink.close();
+
+    const raw = readFileSync(path, "utf8");
+    const lines = raw.split(/\r?\n/).filter((l) => l.trim().length > 0);
+    expect(lines.length).toBe(2);
+    const parsed = lines.map((l) => JSON.parse(l));
+    expect(parsed[0]).toMatchObject({ id: 1, type: "user.message", text: "hi" });
+    expect(parsed[1]).toMatchObject({ id: 2, type: "status", text: "thinking" });
+  });
+
+  it("appends to an existing file (re-open across runs)", async () => {
+    const path = join(dir, "resume.events.jsonl");
+    const a = openEventSink(path);
+    a.append(ev(1, "status", "first"));
+    await a.close();
+
+    const b = openEventSink(path);
+    b.append(ev(2, "status", "second"));
+    await b.close();
+
+    const lines = readFileSync(path, "utf8")
+      .split(/\r?\n/)
+      .filter((l) => l.trim().length > 0);
+    expect(lines.length).toBe(2);
+    expect(JSON.parse(lines[1]!).text).toBe("second");
+  });
+
+  it("creates parent directory if missing", async () => {
+    const nested = join(dir, "deep", "nested", "out.events.jsonl");
+    const sink = openEventSink(nested);
+    sink.append(ev(1, "status", "ok"));
+    await sink.close();
+    expect(readFileSync(nested, "utf8")).toContain('"text":"ok"');
+  });
+
+  it("flush is a no-op on a freshly closed sink", async () => {
+    const path = join(dir, "flush.events.jsonl");
+    const sink = openEventSink(path);
+    sink.append(ev(1, "status", "x"));
+    await sink.flush();
+    await sink.close();
+    expect(readFileSync(path, "utf8")).toContain('"text":"x"');
+  });
+
+  it("instance type matches the EventSink port shape", async () => {
+    const path = join(dir, "shape.events.jsonl");
+    const sink = openEventSink(path);
+    expect(sink).toBeInstanceOf(JsonlEventSink);
+    expect(typeof sink.append).toBe("function");
+    expect(typeof sink.flush).toBe("function");
+    expect(typeof sink.close).toBe("function");
+    sink.append(ev(1, "status", "shape"));
+    await sink.close();
+  });
+});

--- a/tests/eventize.test.ts
+++ b/tests/eventize.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import { Eventizer } from "../src/core/eventize.js";
+import type { LoopEvent } from "../src/loop.js";
+
+const ctx = { model: "deepseek-v4-flash", prefixHash: "abc123", reasoningEffort: "max" } as const;
+
+const lev = (partial: Partial<LoopEvent>): LoopEvent =>
+  ({ turn: 1, role: "status", content: "", ...partial }) as LoopEvent;
+
+describe("Eventizer.consume", () => {
+  it("synthesizes model.turn.started on first event of a new turn", () => {
+    const e = new Eventizer();
+    const out = e.consume(lev({ turn: 1, role: "status", content: "thinking" }), ctx);
+    expect(out[0]?.type).toBe("model.turn.started");
+    expect(out[1]?.type).toBe("status");
+  });
+
+  it("does not re-emit turn.started for events within the same turn", () => {
+    const e = new Eventizer();
+    e.consume(lev({ turn: 1, role: "status", content: "a" }), ctx);
+    const out = e.consume(lev({ turn: 1, role: "status", content: "b" }), ctx);
+    expect(out.find((ev) => ev.type === "model.turn.started")).toBeUndefined();
+  });
+
+  it("emits a fresh turn.started when the turn number advances", () => {
+    const e = new Eventizer();
+    e.consume(lev({ turn: 1 }), ctx);
+    const out = e.consume(lev({ turn: 2, role: "status", content: "go" }), ctx);
+    expect(out[0]?.type).toBe("model.turn.started");
+  });
+
+  it("splits assistant_delta into content + reasoning channels", () => {
+    const e = new Eventizer();
+    e.consume(lev({ turn: 1 }), ctx); // burn turn-start
+    const out = e.consume(
+      lev({
+        turn: 1,
+        role: "assistant_delta",
+        content: "hello",
+        reasoningDelta: "thinking…",
+      }),
+      ctx,
+    );
+    const channels = out
+      .filter((ev) => ev.type === "model.delta")
+      .map((ev) => (ev as { channel: string }).channel);
+    expect(channels).toEqual(["content", "reasoning"]);
+  });
+
+  it("tool_start emits both tool.intent and tool.dispatched with matching callId", () => {
+    const e = new Eventizer();
+    e.consume(lev({ turn: 1 }), ctx);
+    const out = e.consume(
+      lev({ turn: 1, role: "tool_start", toolName: "shell", toolArgs: '{"cmd":"ls"}' }),
+      ctx,
+    );
+    const intent = out.find((ev) => ev.type === "tool.intent") as
+      | { callId: string; name: string; args: string }
+      | undefined;
+    const dispatched = out.find((ev) => ev.type === "tool.dispatched") as
+      | { callId: string }
+      | undefined;
+    expect(intent?.name).toBe("shell");
+    expect(intent?.args).toBe('{"cmd":"ls"}');
+    expect(dispatched?.callId).toBe(intent?.callId);
+  });
+
+  it("tool result correlates back to the matching dispatched callId", () => {
+    const e = new Eventizer();
+    e.consume(lev({ turn: 1 }), ctx);
+    const startOut = e.consume(
+      lev({ turn: 1, role: "tool_start", toolName: "shell", toolArgs: "{}" }),
+      ctx,
+    );
+    const startedCallId = (startOut.find((ev) => ev.type === "tool.intent") as { callId: string })
+      .callId;
+    const resultOut = e.consume(
+      lev({ turn: 1, role: "tool", content: "ok\n", toolName: "shell" }),
+      ctx,
+    );
+    const result = resultOut.find((ev) => ev.type === "tool.result") as
+      | { callId: string; ok: boolean; output: string }
+      | undefined;
+    expect(result?.callId).toBe(startedCallId);
+    expect(result?.ok).toBe(true);
+    expect(result?.output).toBe("ok\n");
+  });
+
+  it("classifies error-shaped tool results as ok=false", () => {
+    const e = new Eventizer();
+    e.consume(lev({ turn: 1 }), ctx);
+    e.consume(lev({ turn: 1, role: "tool_start", toolName: "shell", toolArgs: "{}" }), ctx);
+    const out = e.consume(
+      lev({ turn: 1, role: "tool", content: "ERROR: bad command", toolName: "shell" }),
+      ctx,
+    );
+    const result = out.find((ev) => ev.type === "tool.result") as { ok: boolean } | undefined;
+    expect(result?.ok).toBe(false);
+  });
+
+  it("done and tool_call_delta produce no kernel events (control / progress markers)", () => {
+    const e = new Eventizer();
+    e.consume(lev({ turn: 1 }), ctx);
+    const doneOut = e.consume(lev({ turn: 1, role: "done", content: "" }), ctx);
+    const tcdOut = e.consume(
+      lev({ turn: 1, role: "tool_call_delta", content: "", toolName: "shell" }),
+      ctx,
+    );
+    expect(doneOut).toEqual([]);
+    expect(tcdOut).toEqual([]);
+  });
+
+  it("warning containing escalation language maps to policy.escalated", () => {
+    const e = new Eventizer();
+    e.consume(lev({ turn: 1 }), ctx);
+    const out = e.consume(
+      lev({ turn: 1, role: "warning", content: "⇧ auto-escalating to deepseek-v4-pro" }),
+      ctx,
+    );
+    expect(out[0]?.type).toBe("policy.escalated");
+  });
+
+  it("event ids are monotonic across consume calls", () => {
+    const e = new Eventizer();
+    const a = e.consume(lev({ turn: 1, role: "status", content: "a" }), ctx);
+    const b = e.consume(lev({ turn: 1, role: "status", content: "b" }), ctx);
+    const ids = [...a, ...b].map((ev) => ev.id);
+    for (let i = 1; i < ids.length; i++) {
+      expect(ids[i]).toBeGreaterThan(ids[i - 1]!);
+    }
+  });
+
+  it("emitUserMessage / emitSlashInvoked produce well-formed events with monotonic ids", () => {
+    const e = new Eventizer();
+    e.consume(lev({ turn: 1 }), ctx);
+    const u = e.emitUserMessage(2, "hi");
+    const s = e.emitSlashInvoked(2, "context", "off");
+    expect(u.type).toBe("user.message");
+    expect(u.text).toBe("hi");
+    expect(s.type).toBe("slash.invoked");
+    expect(s.name).toBe("context");
+    expect(s.args).toBe("off");
+    expect(s.id).toBeGreaterThan(u.id);
+  });
+});


### PR DESCRIPTION
## Summary

Builds the event-log kernel as a **new durable artifact** alongside the existing LoopEvent stream, NOT as a migration target. Future replay / projection / multi-agent consumers read kernel events from the sidecar; the working LoopEvent path stays untouched.

This is the **D approach** chosen after evaluating the big-bang LoopEvent removal: instead of ~250 mechanical edits across 29 files (and the regression risk that comes with it), we add 7 new files and a 40-line additive wire-up. Architecture value is tangible immediately (an event log exists and is reducible) without forcing a migration.

- **Commit 1** (`f0ca5bc`): `Eventizer` translator + `JsonlEventSink` + App.tsx wire-up. Every session writes typed Events to `~/.reasonix/sessions/<name>.events.jsonl` as a sidecar.
- **Commit 2** (`f50de58`): `JsonlEventSource` reader + round-trip test proving that synthetic LoopEvents → Eventizer → sink → disk → source → reducers → ProjectionSet reconstruct the conversation correctly.

## Architectural rationale

Reframed the question from "how do we migrate off LoopEvent" to "what's the smallest correctness-preserving change that builds the kernel artifact and lets new consumers exist":

- LoopEvent stays as the **internal protocol** between loop and immediate consumers — it works, no need to break it
- events.jsonl is the **canonical durable artifact** for new capabilities
- Eventizer is the **permanent translation layer** at the boundary, not a shim
- No commitment to ever delete LoopEvent

## Files

**New (7):**
- `src/core/eventize.ts` — translator state machine
- `src/adapters/event-sink-jsonl.ts` — `EventSink` port impl (write side)
- `src/adapters/event-source-jsonl.ts` — `EventSource` port impl (read side)
- `tests/eventize.test.ts` — 11 mapper tests
- `tests/event-sink-jsonl.test.ts` — 5 sink mechanics tests
- `tests/event-replay.test.ts` — 5 round-trip + projection tests

**Modified (1, additive only):**
- `src/cli/ui/App.tsx` — ~40 lines: refs for sink + eventizer, open on session mount, pipe inside the existing for-await consumer alongside `writeTranscript`, close on unmount

**Untouched:** `loop.ts`, `transcript.ts`, `replay.ts`, `EventLog.tsx`, `log-frame.tsx`, `LiveRows.tsx`, dashboard server, subagent — and **every existing test file**.

## Test plan

- [x] `npm run verify` — 1747 tests pass (was 1726 + 21 new)
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [ ] Manual smoke: `reasonix code` for a session, confirm `~/.reasonix/sessions/<name>.events.jsonl` appears with parseable JSONL — one event per line, monotonic ids, correct turn numbers, `model.turn.started` at every turn boundary, `tool.intent` → `tool.dispatched` → `tool.result` chain with matching callIds
- [ ] Confirm zero behavior change in the live TUI — chrome / prompt / scroll / copy / ctx footer all work exactly as before

## What this unlocks (future PRs, not this one)

- Time-travel UI reading from events.jsonl
- Projection-driven dashboard (web frontend reads Event stream instead of LoopEvent)
- Multi-agent event trees with parent-child correlation
- Deterministic replay for debugging / regression tests