### PR TITLE
feat(cli): reasonix events <name> — first user-facing consumer of the event log

### DIFF
--- a/src/adapters/event-sink-jsonl.ts
+++ b/src/adapters/event-sink-jsonl.ts
@@ -1,13 +1,3 @@
-/**
- * Concrete `EventSink` adapter — writes the kernel Event log to a
- * `<sessionsDir>/<name>.events.jsonl` sidecar alongside the existing
- * ChatMessage session file. One Event per line; append-only.
- *
- * Mirrors the design of `src/transcript.ts:openTranscriptFile` so the
- * disk shape is consistent across artifacts (jsonl, durable, parseable
- * by streaming readers).
- */
-
 import { type WriteStream, chmodSync, createWriteStream, mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import type { Event } from "../core/events.js";
@@ -31,11 +21,6 @@ export class JsonlEventSink implements EventSink {
   flush(): Promise<void> {
     return new Promise((resolve) => {
       if (this.buffered === 0) return resolve();
-      // `cork`/`uncork` is the documented way to ask Node to release
-      // batched writes; we rely on the OS to actually fsync. For a
-      // session log that's fine — losing the last few events on a
-      // hard crash is acceptable since the transcript file carries
-      // the same conversation.
       this.stream.uncork();
       this.buffered = 0;
       resolve();
@@ -49,18 +34,13 @@ export class JsonlEventSink implements EventSink {
   }
 }
 
-/**
- * Open (or create) the sidecar file for `sessionName`. Creates parent
- * directory if missing; chmods to 0600 on Unix to match the session
- * file's permissions (chmod no-ops on Windows).
- */
 export function openEventSink(path: string): JsonlEventSink {
   mkdirSync(dirname(path), { recursive: true });
   const stream = createWriteStream(path, { flags: "a" });
   try {
     chmodSync(path, 0o600);
   } catch {
-    /* chmod not supported on this platform */
+    /* chmod no-op on Windows */
   }
   return new JsonlEventSink(stream);
 }

--- a/src/adapters/event-source-jsonl.ts
+++ b/src/adapters/event-source-jsonl.ts
@@ -1,24 +1,8 @@
-/**
- * Concrete `EventSource` adapter — reads the kernel event log sidecar
- * back as a typed Event stream. Matches `JsonlEventSink`'s on-disk
- * format: one JSON Event per line, append-only.
- *
- * Used by replay / projection consumers — anything that wants to
- * reconstruct session state from the durable event log without going
- * through loop or transcript.
- */
-
 import { existsSync, readFileSync } from "node:fs";
 import type { Event } from "../core/events.js";
 import type { EventSource } from "../ports/event-sink.js";
 import { eventLogPath } from "./event-sink-jsonl.js";
 
-/**
- * Parse a JSONL event log file into an Event array. Skips blank lines
- * and unparseable rows silently (the live writer may have crashed mid-
- * line). Caller decides what to do with the result — typically pipe
- * through `core/reducers.ts:apply` to project into views.
- */
 export function readEventLogFile(path: string): Event[] {
   if (!existsSync(path)) return [];
   const raw = readFileSync(path, "utf8");
@@ -32,8 +16,7 @@ export function readEventLogFile(path: string): Event[] {
         out.push(ev);
       }
     } catch {
-      // Malformed line — partial write or truncation. Skip silently
-      // and carry on; replay should be best-effort, not fail-stop.
+      /* malformed mid-line write — best-effort skip */
     }
   }
   return out;

--- a/src/cli/commands/events.ts
+++ b/src/cli/commands/events.ts
@@ -1,0 +1,134 @@
+import { eventLogPath } from "../../adapters/event-sink-jsonl.js";
+import { readEventLogFile } from "../../adapters/event-source-jsonl.js";
+import type { Event } from "../../core/events.js";
+import { replay as replayReducers } from "../../core/reducers.js";
+
+export interface EventsOptions {
+  name: string;
+  type?: string;
+  since?: number;
+  tail?: number;
+  json?: boolean;
+  projection?: boolean;
+}
+
+export function eventsCommand(opts: EventsOptions): void {
+  const path = eventLogPath(opts.name);
+  let events = readEventLogFile(path);
+
+  if (events.length === 0) {
+    console.error(`no events for session "${opts.name}"`);
+    console.error(`looked at: ${path}`);
+    console.error("(sessions auto-create the sidecar on first turn — has this session run yet?)");
+    process.exit(1);
+    return;
+  }
+
+  if (opts.type) events = events.filter((e) => e.type === opts.type);
+  if (opts.since !== undefined && Number.isFinite(opts.since)) {
+    events = events.filter((e) => e.id >= opts.since!);
+  }
+  if (opts.tail !== undefined && Number.isFinite(opts.tail) && opts.tail > 0) {
+    events = events.slice(-opts.tail);
+  }
+
+  if (opts.projection) {
+    const p = replayReducers(events);
+    console.log(JSON.stringify(p, mapReplacer, 2));
+    return;
+  }
+
+  if (opts.json) {
+    for (const e of events) console.log(JSON.stringify(e));
+    return;
+  }
+
+  console.log(`[events] ${opts.name}   ${events.length} event(s)   ${path}`);
+  console.log("");
+  for (const e of events) console.log(formatEvent(e));
+}
+
+function formatEvent(e: Event): string {
+  const id = String(e.id).padStart(4);
+  const turn = `t${e.turn}`.padEnd(4);
+  const ts = e.ts.replace("T", " ").replace(/\.\d+Z$/, "");
+  const type = e.type.padEnd(22);
+  return `[${id}] ${turn} ${ts}  ${type}  ${detailsFor(e)}`;
+}
+
+function detailsFor(e: Event): string {
+  switch (e.type) {
+    case "user.message":
+      return quote(e.text, 80);
+    case "slash.invoked":
+      return `/${e.name} ${e.args}`.trim();
+    case "model.turn.started":
+      return `model=${e.model} effort=${e.reasoningEffort} prefix=${e.prefixHash.slice(0, 8)}`;
+    case "model.delta":
+      return `${e.channel} ${quote(e.text, 60)}`;
+    case "model.final": {
+      const u = e.usage;
+      const tokens = `in=${u.prompt_tokens ?? 0} out=${u.completion_tokens ?? 0}`;
+      const tail = e.forcedSummary ? " [forcedSummary]" : "";
+      return `cost=$${e.costUsd.toFixed(4)} ${tokens}${tail}`;
+    }
+    case "tool.intent":
+      return `${e.callId} ${e.name} args=${truncate(e.args, 60)}`;
+    case "tool.dispatched":
+      return e.callId;
+    case "tool.denied":
+      return `${e.callId} reason=${e.reason}`;
+    case "tool.result":
+      return `${e.callId} ${e.ok ? "ok" : "err"} ${e.output.length}B${e.truncated ? " [trunc]" : ""}`;
+    case "effect.file.touched":
+      return `${e.mode} ${e.path} (${e.bytes}B)`;
+    case "effect.memory.written":
+      return `${e.scope}:${e.key}`;
+    case "plan.submitted":
+      return `${e.steps.length} step(s)`;
+    case "plan.step.completed":
+      return `${e.stepId}${e.title ? ` — ${e.title}` : ""}`;
+    case "checkpoint.created":
+      return `${e.checkpointId} "${e.name}" ${e.fileCount} file(s) ${e.bytes}B`;
+    case "checkpoint.restored":
+      return `${e.checkpointId} restored=${e.restored} removed=${e.removed} skipped=${e.skipped}`;
+    case "hook.fired":
+      return `${e.phase} ${e.hookName} → ${e.outcome}`;
+    case "policy.budget.warning":
+      return `$${e.spentUsd.toFixed(4)} / $${e.capUsd.toFixed(2)}`;
+    case "policy.budget.blocked":
+      return `$${e.spentUsd.toFixed(4)} / $${e.capUsd.toFixed(2)} BLOCKED`;
+    case "policy.escalated":
+      return `${e.fromModel} → ${e.toModel} (${e.reason})${e.rationale ? ` "${e.rationale}"` : ""}`;
+    case "session.opened":
+      return `${e.name} resumed-from-turn=${e.resumedFromTurn}`;
+    case "session.compacted":
+      return `${e.beforeMessages} → ${e.afterMessages} msgs (${e.reason})`;
+    case "capability.registered":
+      return `${e.name} ${e.permission}`;
+    case "capability.removed":
+      return e.name;
+    case "status":
+      return quote(e.text, 80);
+    case "error":
+      return `${e.recoverable ? "[recoverable] " : ""}${quote(e.message, 80)}`;
+    default:
+      return "";
+  }
+}
+
+function quote(s: string, max: number): string {
+  const flat = s.replace(/\s+/g, " ").trim();
+  return flat.length <= max ? `"${flat}"` : `"${flat.slice(0, max - 1)}…"`;
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : `${s.slice(0, max - 1)}…`;
+}
+
+/** WorkspaceView holds files in a Map; default JSON.stringify drops it. */
+function mapReplacer(_key: string, value: unknown): unknown {
+  if (value instanceof Map) return Object.fromEntries(value);
+  if (value instanceof Set) return [...value];
+  return value;
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -9,6 +9,7 @@ import { codeCommand } from "./commands/code.js";
 import { commitCommand } from "./commands/commit.js";
 import { diffCommand } from "./commands/diff.js";
 import { doctorCommand } from "./commands/doctor.js";
+import { eventsCommand } from "./commands/events.js";
 import { indexCommand } from "./commands/index.js";
 import { mcpInspectCommand } from "./commands/mcp-inspect.js";
 import { mcpListCommand } from "./commands/mcp.js";
@@ -319,6 +320,30 @@ program
   .option("-v, --verbose", "Include system prompts + tool-call metadata when inspecting")
   .action((name: string | undefined, opts) => {
     sessionsCommand({ name, verbose: !!opts.verbose });
+  });
+
+program
+  .command("events <name>")
+  .description(
+    "Pretty-print the kernel event-log sidecar (~/.reasonix/sessions/<name>.events.jsonl) — every typed Event the session produced.",
+  )
+  .option("--type <type>", "Show only events of this type (e.g., tool.intent)")
+  .option("--since <id>", "Show only events with id >= N", (v) => Number.parseInt(v, 10))
+  .option("--tail <n>", "Show only the last N events", (v) => Number.parseInt(v, 10))
+  .option("--json", "Emit raw JSONL passthrough instead of formatted lines (for jq pipelines)")
+  .option(
+    "--projection",
+    "Replace the listing with the final reduced ProjectionSet (conversation, budget, plan, …)",
+  )
+  .action((name: string, opts) => {
+    eventsCommand({
+      name,
+      type: opts.type,
+      since: Number.isFinite(opts.since) ? opts.since : undefined,
+      tail: Number.isFinite(opts.tail) ? opts.tail : undefined,
+      json: !!opts.json,
+      projection: !!opts.projection,
+    });
   });
 
 program

--- a/src/core/eventize.ts
+++ b/src/core/eventize.ts
@@ -1,18 +1,3 @@
-/**
- * Translator: LoopEvent stream → typed Event stream.
- *
- * Holds the small amount of state needed to make the conversion
- * deterministic and correlated:
- *   - monotonic event id seq (kernel invariant)
- *   - last turn seen (synthesizes `model.turn.started` on transition)
- *   - per-tool-call id seq (correlates `tool.intent` → `tool.dispatched`
- *     → `tool.result` chains; the LoopEvent stream doesn't surface
- *     `call.id` on `tool_start`, so we mint our own)
- *
- * Pure data — no I/O. Caller (App.tsx) wires Eventizer into the loop's
- * `for await` consumer and forwards each output Event to an EventSink.
- */
-
 import type { LoopEvent } from "../loop.js";
 import type { ChatMessage, RawUsage, ToolCall } from "../types.js";
 import type {
@@ -41,7 +26,6 @@ export class Eventizer {
   private nextId = 0;
   private lastTurn = -1;
   private nextToolSeq = 0;
-  /** Stack so parallel-batch dispatches still pair start ↔ result. */
   private pendingCallIds: string[] = [];
 
   consume(ev: LoopEvent, ctx: EventizeContext): Event[] {
@@ -56,9 +40,7 @@ export class Eventizer {
         if (ev.reasoningDelta) out.push(this.deltaEvent(ev.turn, "reasoning", ev.reasoningDelta));
         break;
       case "tool_call_delta":
-        // No delta text on this LoopEvent — it's a progress signal
-        // (cumulative arg-char count + ready count). Skip; the real
-        // intent + args land on tool_start.
+        // Progress signal only; intent + args land on tool_start.
         break;
       case "assistant_final":
         out.push(this.finalEvent(ev));
@@ -85,10 +67,7 @@ export class Eventizer {
       case "status":
         out.push(this.statusEvent(ev.turn, ev.content));
         break;
-      // `done` is a stream-control marker; no kernel event.
-      // `branch_*` is consistency.ts; not modeled (feature is a candidate
-      //  for retirement, and emitting partial branch state without proper
-      //  reducer support would be misleading).
+      // `done` / `branch_*` intentionally drop — no kernel-level event.
       default:
         break;
     }
@@ -190,10 +169,7 @@ export class Eventizer {
       turn: ev.turn,
       type: "model.final",
       content: ev.content,
-      // LoopEvent.assistant_final doesn't carry toolCalls — they're
-      // surfaced one-by-one via tool_start later in the iter loop. For
-      // the kernel record we leave the array empty here; the
-      // tool.intent events emitted on tool_start carry the actual calls.
+      // toolCalls land later via tool_start → tool.intent — not in this event.
       toolCalls: [] as ReadonlyArray<ToolCall>,
       usage,
       costUsd,
@@ -269,14 +245,7 @@ export class Eventizer {
     };
   }
 
-  /**
-   * Best-effort categorization. The loop yields plain `warning` events
-   * with content strings; we pattern-match to distinguish budget warnings
-   * (policy.budget.*) from escalation notices (policy.escalated) from
-   * everything else (recoverable error). Refining this is a follow-up —
-   * hard-typing warning shapes in LoopEvent would let the mapping
-   * be exact, but that's a loop.ts edit we're keeping out of scope.
-   */
+  /** Pattern-match warning text since LoopEvent doesn't carry a typed kind. */
   private classifyWarning(ev: LoopEvent): Event {
     const c = ev.content;
     if (/\bauto-escalating to\b|\barmed\b.*pro|NEEDS_PRO/.test(c)) {
@@ -306,9 +275,6 @@ export class Eventizer {
 }
 
 function looksLikeToolError(content: string, _toolName: string | undefined): boolean {
-  // The loop / tool dispatcher serializes thrown errors to a string
-  // tool result. Two common shapes: a JSON-stringified `{error: "..."}`,
-  // and a plain-text `[hook block] ...` / `... Error: ...` line.
   if (!content) return false;
   if (content.startsWith("ERROR:")) return true;
   if (content.startsWith("[hook block]")) return true;

--- a/tests/event-replay.test.ts
+++ b/tests/event-replay.test.ts
@@ -59,21 +59,16 @@ describe("event-log replay round-trip", () => {
     }
     await sink.close();
 
-    // Read back from disk + project.
     const events = readEventLogFile(path);
     expect(events.length).toBeGreaterThan(0);
     const projections = replay(events);
 
-    // ConversationView reconstruction:
-    //   user message, assistant final, tool result.
     const msgs = projections.conversation.messages;
     expect(msgs.length).toBe(3);
     expect(msgs[0]).toMatchObject({ role: "user", content: "list files in src" });
     expect(msgs[1]).toMatchObject({ role: "assistant", content: "Let me check." });
     expect(msgs[2]).toMatchObject({ role: "tool", content: "App.tsx\nloop.ts\n..." });
     expect(projections.conversation.pendingToolCalls).toEqual([]);
-
-    // SessionMetaView pinned the session name + last turn we touched.
     expect(projections.session.name).toBe("rt");
     expect(projections.session.currentTurn).toBe(1);
   });

--- a/tests/events-command.test.ts
+++ b/tests/events-command.test.ts
@@ -1,0 +1,127 @@
+/**
+ * `reasonix events <name>` command formatter — pure stdout assertions.
+ * The command itself is mostly formatting; this proves the per-event-type
+ * detail rendering hits the right shape, plus the filter / projection
+ * flags work end-to-end.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { eventsCommand } from "../src/cli/commands/events.js";
+import { sessionsDir } from "../src/session.js";
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "reasonix-events-cmd-"));
+  // Override the home dir so eventLogPath resolves into our temp area.
+  process.env.HOME = dir;
+  process.env.USERPROFILE = dir;
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function seed(name: string, lines: string[]): void {
+  const target = join(sessionsDir(), `${name}.events.jsonl`);
+  const fs = require("node:fs") as typeof import("node:fs");
+  fs.mkdirSync(join(target, ".."), { recursive: true });
+  writeFileSync(target, lines.map((l) => `${l}\n`).join(""), "utf8");
+}
+
+const ev = (id: number, type: string, extra: Record<string, unknown>): string =>
+  JSON.stringify({ id, ts: "2026-04-29T12:00:00Z", turn: 1, type, ...extra });
+
+describe("eventsCommand", () => {
+  it("formats common event types with sensible details", () => {
+    seed("demo", [
+      ev(1, "session.opened", { name: "demo", resumedFromTurn: 0 }),
+      ev(2, "user.message", { text: "list src" }),
+      ev(3, "model.turn.started", {
+        model: "deepseek-v4-flash",
+        reasoningEffort: "max",
+        prefixHash: "abcd1234ef",
+      }),
+      ev(4, "tool.intent", { callId: "tc-1", name: "list_directory", args: '{"path":"src"}' }),
+      ev(5, "tool.dispatched", { callId: "tc-1" }),
+      ev(6, "tool.result", { callId: "tc-1", ok: true, output: "App.tsx\n", durationMs: 12 }),
+    ]);
+
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    eventsCommand({ name: "demo" });
+    const out = log.mock.calls.map((c) => String(c[0])).join("\n");
+    log.mockRestore();
+
+    expect(out).toContain("session.opened");
+    expect(out).toContain("user.message");
+    expect(out).toContain('"list src"');
+    expect(out).toContain("model=deepseek-v4-flash");
+    expect(out).toContain("prefix=abcd1234");
+    expect(out).toContain("tc-1 list_directory");
+    expect(out).toContain("tc-1 ok 8B"); // "App.tsx\n".length === 8
+  });
+
+  it("--type filters to one event variant", () => {
+    seed("demo", [
+      ev(1, "user.message", { text: "hi" }),
+      ev(2, "tool.intent", { callId: "tc-1", name: "shell", args: "{}" }),
+      ev(3, "status", { text: "thinking" }),
+    ]);
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    eventsCommand({ name: "demo", type: "tool.intent" });
+    const out = log.mock.calls.map((c) => String(c[0])).join("\n");
+    log.mockRestore();
+    expect(out).toContain("tool.intent");
+    expect(out).not.toContain("user.message");
+    expect(out).not.toContain("status ");
+  });
+
+  it("--tail keeps only the last N", () => {
+    seed("demo", [
+      ev(1, "status", { text: "a" }),
+      ev(2, "status", { text: "b" }),
+      ev(3, "status", { text: "c" }),
+    ]);
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    eventsCommand({ name: "demo", tail: 2 });
+    const out = log.mock.calls.map((c) => String(c[0])).join("\n");
+    log.mockRestore();
+    expect(out).toContain('"b"');
+    expect(out).toContain('"c"');
+    expect(out).not.toContain('"a"');
+  });
+
+  it("--json passes through raw JSONL", () => {
+    seed("demo", [ev(1, "status", { text: "raw" })]);
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    eventsCommand({ name: "demo", json: true });
+    const out = log.mock.calls.map((c) => String(c[0])).join("\n");
+    log.mockRestore();
+    // Must be parseable JSON line, not formatted.
+    const parsed = JSON.parse(out.split("\n").filter((l) => l.trim())[0]!);
+    expect(parsed).toMatchObject({ id: 1, type: "status", text: "raw" });
+  });
+
+  it("--projection emits the reduced ProjectionSet", () => {
+    seed("demo", [ev(1, "user.message", { text: "hi" }), ev(2, "status", { text: "thinking" })]);
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    eventsCommand({ name: "demo", projection: true });
+    const out = log.mock.calls.map((c) => String(c[0])).join("\n");
+    log.mockRestore();
+    const parsed = JSON.parse(out);
+    expect(parsed.conversation.messages[0]).toMatchObject({ role: "user", content: "hi" });
+    expect(parsed.session.currentTurn).toBe(1);
+  });
+
+  it("missing session exits 1 with a helpful message", () => {
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exit = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    eventsCommand({ name: "no-such-session" });
+    expect(exit).toHaveBeenCalledWith(1);
+    const errOut = err.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(errOut).toContain('no events for session "no-such-session"');
+    err.mockRestore();
+    exit.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

Closes the v0.14 kernel loop: events get written by every session (PR #2), and now there's a tool to read them. \`reasonix events <name>\` is the first user-facing consumer of \`~/.reasonix/sessions/<name>.events.jsonl\`.

This is the architecture-value tipping point — events.jsonl is no longer a write-only artifact. It's queryable from the command line.

\`\`\`
$ reasonix events code-reasonix --tail 10
[events] code-reasonix   10 event(s)   ~/.reasonix/sessions/code-reasonix.events.jsonl

[  73] t8   12:41:02  user.message            "show me the test pass count"
[  74] t8   12:41:03  model.turn.started      model=deepseek-v4-flash effort=max prefix=a3f9c012
[  75] t8   12:41:04  model.delta             content "I'll check…"
[  76] t8   12:41:06  tool.intent             tc-12 run_command args={"command":"npm test --silent"}
[  77] t8   12:41:06  tool.dispatched         tc-12
[  78] t8   12:41:24  tool.result             tc-12 ok 1832B
[  79] t8   12:41:25  model.delta             content "1753 tests pass."
[  80] t8   12:41:26  model.final             cost=\$0.0009 in=14328 out=42
\`\`\`

## Flags

- \`--type <type>\` — filter to one event variant (e.g., \`tool.intent\`)
- \`--since <id>\` — only events with id ≥ N
- \`--tail <n>\` — last N events
- \`--json\` — raw JSONL passthrough (jq-friendly)
- \`--projection\` — dump the final reduced ProjectionSet (conversation / budget / plan / workspace / capabilities / status / session)

## Files

**New:**
- \`src/cli/commands/events.ts\` — formatter + per-type detail table for all 25 Event variants
- \`tests/events-command.test.ts\` — 6 tests pinning the formatter + each flag

**Modified (additive):**
- \`src/cli/index.ts\` — command registration

**Cleanup pass** (per the architect-cleanliness rule the user just reinforced):
- \`src/core/eventize.ts\` — removed verbose module header, redundant per-method jsdocs, restated-the-code comments
- \`src/adapters/event-sink-jsonl.ts\` — same
- \`src/adapters/event-source-jsonl.ts\` — same
- \`tests/event-replay.test.ts\` — restated-the-asserts comments dropped

~80 lines of comment cruft gone, no logic touched.

## Test plan

- [x] \`npm run verify\` — 1753 tests pass (was 1747 + 6 new)
- [x] \`npm run lint\` clean
- [x] \`npm run typecheck\` clean
- [ ] Manual: run a session, then \`reasonix events <name>\` to inspect; \`--projection\` to see the reduced view; \`--tail 5\` to scope; \`--json | jq '.type'\` to verify pipeline-friendliness

## What this unlocks

events.jsonl is now a debuggable, scriptable, replayable artifact. Future work can layer on:
- TUI \`/replay-events\` to load a past session into a projection-driven view
- Web dashboard reading from event log instead of LoopEvent
- Multi-agent event trees with parent correlation

But each future PR is now optional. The kernel and its first consumer ship together. Mission accomplished.