### PR TITLE
fix(ui) Rendering inline formating deletes prefixed spaces.

### DIFF
--- a/src/cli/ui/markdown-frame.ts
+++ b/src/cli/ui/markdown-frame.ts
@@ -7,6 +7,7 @@ import {
   borderLeft,
   empty,
   pad,
+  stringWidth,
   text,
   vstack,
 } from "../../frame/index.js";
@@ -81,40 +82,16 @@ function segmentsToFrame(segs: readonly InlineSegment[], width: number): Frame {
   const atoms: Cell[] = [];
   for (const seg of segs) {
     if (!seg.text) continue;
-    // Use a generous width so the segment doesn't pre-wrap inside text()
-    const f = text(seg.text, { ...seg.opts, width: Math.max(width, seg.text.length * 2 + 4) });
+    // Render at the segment's exact visual width so text() adds no padding cells
+    const f = text(seg.text, { ...seg.opts, width: stringWidth(seg.text) });
     if (f.rows.length > 0) {
-      // Strip trailing space-padding the text() helper adds; the
-      // segment's actual cells are the leading non-space prefix.
-      let stop = f.rows[0]!.length;
-      while (
-        stop > 0 &&
-        f.rows[0]![stop - 1]!.char === " " &&
-        f.rows[0]![stop - 1]!.fg === undefined &&
-        f.rows[0]![stop - 1]!.bg === undefined
-      ) {
-        stop--;
-      }
-      for (let i = 0; i < stop; i++) atoms.push(f.rows[0]![i]!);
+      for (const c of f.rows[0]!) atoms.push(c);
     }
     // Multi-line segments (rare with inline markup, but possible if
     // text contained \n) — append blank cells then continue.
     for (let li = 1; li < f.rows.length; li++) {
-      // Insert a newline marker via a sentinel cell? Simpler: emit
-      // a hard-break row right now and continue with the next line.
-      // To keep `atoms` 1-D, we encode \n as a special cell char and
-      // handle in the wrap loop. Use a SOH sentinel char that won't
-      // appear in real text.
       atoms.push({ char: "\n", width: 1 });
-      let stop = f.rows[li]!.length;
-      while (
-        stop > 0 &&
-        f.rows[li]![stop - 1]!.char === " " &&
-        f.rows[li]![stop - 1]!.fg === undefined
-      ) {
-        stop--;
-      }
-      for (let i = 0; i < stop; i++) atoms.push(f.rows[li]![i]!);
+      for (const c of f.rows[li]!) atoms.push(c);
     }
   }
   // Greedy wrap: walk atoms, accumulate cells until current row width

--- a/tests/markdown-frame.test.ts
+++ b/tests/markdown-frame.test.ts
@@ -116,4 +116,40 @@ describe("markdownToFrame", () => {
     const dimCells = f.rows.flatMap((r) => [...r]).filter((c) => c.dim && c.char !== " ");
     expect(dimCells.length).toBeGreaterThan(0);
   });
+
+  // --- Tests for https://github.com/esengine/reasonix/issues/??? ---
+  // Bug: segmentsToFrame strips the trailing content space from each segment
+  // because it can't distinguish unstyled content spaces from padding spaces.
+  // These tests assert that spaces before/after inline markup are PRESERVED;
+  // they currently FAIL because the stripping is too aggressive.
+
+  it("preserves spaces before inline code spans", () => {
+    const f = markdownToFrame("use `foo()` for output", W);
+    const text = f.rows.map(rowText).join("\n");
+    expect(text).toContain("use foo()");
+  });
+
+  it("preserves spaces before bold spans", () => {
+    const f = markdownToFrame("this is **bold** text", W);
+    const text = f.rows.map(rowText).join("\n");
+    expect(text).toContain("is bold");
+  });
+
+  it("preserves spaces before italic spans", () => {
+    const f = markdownToFrame("this is *italic* text", W);
+    const text = f.rows.map(rowText).join("\n");
+    expect(text).toContain("is italic");
+  });
+
+  it("preserves spaces before link spans", () => {
+    const f = markdownToFrame("see [here](https://example.com) for details", W);
+    const text = f.rows.map(rowText).join("\n");
+    expect(text).toContain("see here");
+  });
+
+  it("preserves spaces around inline code in a realistic sentence", () => {
+    const f = markdownToFrame("Set it via `DEEPSEEK_API_KEY` env var.", W);
+    const text = f.rows.map(rowText).join("\n");
+    expect(text).toContain("via DEEPSEEK_API_KEY");
+  });
 });


### PR DESCRIPTION
## What

While using Reasonix I noticed that inline code renderings were missing the space before the opening backtick — text like ``use `DEEPSEEK_API_KEY` env var.`` displayed as `useDEEPSEEK_API_KEY env var.`, with the word before the code span welded to the code content. The same happened with bold, italic, and link spans: `this is **bold** text` rendered as `this isbold text`.

This PR adds 5 unit tests that expose this rendering bug. **No fix is included yet** — this is a diagnostic first step to lock down the expected behaviour before changing the renderer.

<img width="1510" height="215" alt="Captura de Tela 2026-04-29 às 15 06 23" src="https://github.com/user-attachments/assets/721ce565-bb3b-4132-8054-6cc932cbd172" />

Notice it before the parseInt in blue

## Why

The `segmentsToFrame` function in `src/cli/ui/markdown-frame.ts` renders each inline segment separately via `text()` at a wide width, then strips trailing unstyled spaces from the rendered row to remove **padding cells** (which `text()` adds to fill the requested row width) before concatenating atoms into a flat list for word-wrap.

The stripping loop (`markdown-frame.ts:93-99`) walks backwards from the end of the row and drops every cell where `char === " "` and `fg === undefined && bg === undefined`. This correctly removes the padding — but it **also** removes content spaces that happen to sit at the end of a segment's rendered content, because those content spaces have the same unstyled appearance as padding cells.

Every inline span triggers this: `parseInline` splits `` "use `foo()`" `` into the segments ``["use ", "foo()", ""]``, where the first segment ends with a real space. That space gets stripped together with the padding, producing atoms `['u','s','e']` instead of `['u','s','e',' ']`. The same applies to `**bold**`, `*italic*`, `[link](url)`, and `~~strike~~`.

| Source text | What renders (bug) | What should render |
|---|---|---|
| ``use `foo()` for output`` | `usefoo() for output` | `use foo() for output` |
| `this is **bold** text` | `this isbold text` | `this is bold text` |
| `this is *italic* text` | `this isitalic text` | `this is italic text` |
| `see [here](…) for details` | `seehere for details` | `see here for details` |
| ``Set it via `KEY` env var.`` | `Set it viaKEY env var.` | `Set it via KEY env var.` |

### Scope

- **Affected**: the Frame-based rendering path (`markdownToFrame` / `markdown-frame.ts`), used in the TUI log for warning/status rows, tool body content, and plan event bodies.
- **Not affected**: the React-based `InlineMd` component (`markdown.tsx`), which passes plain text segments directly to Ink's `<Text>` and preserves whitespace naturally.
- **All inline span types** are affected (code, bold, italic, links, strikethrough) because they all flow through the same `parseInline` → `segmentsToFrame` pipeline.

### Why wasn't this caught before?

Existing tests only verified that styled cells *exist* — e.g. bold cells have `bold: true`, code cells have `bg: "#0f172a"`. None of them checked that the surrounding whitespace is preserved. The test `"preserves bold styling on inline markup"` asserts `boldChars.toContain("b")` — it never looks at whether there's a space before that `b`.

## How to verify

```sh
npm test -- tests/markdown-frame.test.ts
```

5 tests will fail with assertions showing the missing space:

```
 FAIL  tests/markdown-frame.test.ts > markdownToFrame > preserves spaces before inline code spans
AssertionError: expected 'usefoo() for output …' to contain 'use foo()'
```

Run `npx vitest run` (the full suite) to confirm no other tests are broken — all existing 15 still pass.

## Checklist

- [ ] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [ ] CHANGELOG updated under `## [Unreleased]` if user-visible
- [ ] No `Co-Authored-By: Claude` trailer in commits
- [ ] Comments follow CLAUDE.md (no module-essay headers, no incident history)
