### PR TITLE
feat(index): config-driven excludes + .gitignore + dashboard UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,42 @@
 All notable changes to Reasonix. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+**Headline:** `reasonix index` is now config-driven — what gets walked
+is defined entirely by `~/.reasonix/config.json` (with sensible
+defaults), `.gitignore` is honoured by default, and the dashboard
+Semantic tab gains a Settings card to view, edit, and dry-walk-preview
+the rules without leaving the browser. The previous behaviour
+hardcoded skip lists in `chunker.ts` and duplicated them in
+`directory_tree`; both now read from a single shared source.
+
+- feat(index): new `index` block in `ReasonixConfig` (`excludeDirs`,
+  `excludeFiles`, `excludeExts`, `excludePatterns`, `respectGitignore`,
+  `maxFileBytes`). Any field present fully replaces its default; absent
+  fields keep the default.
+- feat(index): nested `.gitignore` honoured by default — each
+  subdirectory's rules apply scoped to that subdir, so `pkg-a/.gitignore`
+  doesn't leak into `pkg-b/`.
+- feat(index): glob excludes via `picomatch` syntax in
+  `excludePatterns` (e.g. `**/*.gen.ts`, `vendor/**`, with `!negation`
+  supported).
+- feat(cli): `reasonix index` success line now prints a per-reason
+  skip breakdown (`gitignore: A · pattern: B · defaultDir: C · …`) so
+  users see what was filtered and why.
+- feat(dashboard): Semantic tab gains a collapsible **Excludes** card
+  with editable lists, gitignore toggle, max-file-size input, **Save**
+  / **Reset** / **Preview** buttons, and a per-reason sample drilldown
+  in the Preview panel.
+- feat(server): `GET /api/index-config` returns user/resolved/defaults;
+  `POST /api/index-config` persists; `POST /api/index-config/preview`
+  dry-walks the project root with a draft config and returns sample
+  paths + skip buckets.
+- refactor(tools): `directory_tree` now reuses
+  `DEFAULT_INDEX_EXCLUDES` from `src/index/config.ts` instead of its
+  own copy of the dir/binary lists; the two were already drifting.
+- deps: `picomatch ^4`, `ignore ^7`, `@types/picomatch ^4`.
+
 ## [0.16.1] — 2026-04-29
 
 **Headline:** Fix a tool-loop regression on `deepseek-chat` introduced

--- a/dashboard/app.css
+++ b/dashboard/app.css
@@ -665,7 +665,8 @@ button:disabled {
 }
 
 input[type="text"],
-input[type="search"] {
+input[type="search"],
+input[type="number"] {
   background: var(--bg-2);
   border: 1px solid var(--border);
   color: var(--fg-0);
@@ -678,6 +679,7 @@ input[type="search"] {
 
 input[type="text"]:focus,
 input[type="search"]:focus,
+input[type="number"]:focus,
 input[type="password"]:focus {
   border-color: var(--primary);
   outline: none;
@@ -712,7 +714,15 @@ select:focus {
 textarea {
   background: var(--bg-2);
   color: var(--fg-0);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 8px 10px;
   font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.5;
+  resize: vertical;
+  width: 100%;
+  box-sizing: border-box;
 }
 textarea:focus {
   border-color: var(--primary);
@@ -2537,4 +2547,141 @@ code,
   font-size: 13px;
   border: 1px dashed var(--border);
   border-radius: var(--radius-md);
+}
+
+/* ---------- Excludes settings (Semantic tab) ---------- */
+
+.excludes-toggle {
+  margin: 24px 0 12px;
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  cursor: pointer;
+  user-select: none;
+}
+.excludes-toggle:hover {
+  color: var(--primary);
+}
+.excludes-toggle .caret {
+  font-size: 11px;
+  color: var(--fg-3);
+  width: 10px;
+  display: inline-block;
+}
+.excludes-toggle .label {
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+}
+.excludes-toggle:hover .label,
+.excludes-toggle:hover .caret {
+  color: var(--primary);
+}
+.excludes-toggle .hint {
+  font-size: 12px;
+  color: var(--fg-3);
+  font-weight: normal;
+}
+
+.excludes-card {
+  font-size: 13px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.excludes-card .lead {
+  color: var(--fg-2);
+  font-size: 12px;
+  line-height: 1.5;
+}
+.excludes-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 14px;
+}
+.excludes-field label {
+  display: block;
+  font-size: 12px;
+  color: var(--fg-2);
+  margin-bottom: 4px;
+  font-weight: 500;
+}
+.excludes-field textarea {
+  min-height: 90px;
+}
+.excludes-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 18px;
+  align-items: center;
+  padding-top: 4px;
+  font-size: 12px;
+  color: var(--fg-1);
+}
+.excludes-options label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.excludes-options input[type="number"] {
+  width: 110px;
+}
+.excludes-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 4px;
+}
+
+.excludes-preview {
+  margin-top: 4px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+  font-size: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.excludes-preview .summary {
+  font-size: 13px;
+  color: var(--fg-1);
+}
+.excludes-preview details {
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 6px 10px;
+}
+.excludes-preview details[open] {
+  background: var(--bg-3);
+}
+.excludes-preview summary {
+  cursor: pointer;
+  color: var(--fg-1);
+  font-weight: 500;
+}
+.excludes-preview summary:hover {
+  color: var(--primary);
+}
+.excludes-preview ul {
+  margin: 6px 0 0 16px;
+  padding: 0;
+  font-size: 11.5px;
+  color: var(--fg-2);
+}
+.excludes-preview li {
+  margin: 2px 0;
+}
+.excludes-preview li code {
+  font-size: 11.5px;
+  background: transparent;
+  padding: 0;
+  color: var(--fg-1);
+}
+
+.skip-buckets {
+  margin-top: 4px;
+  font-size: 12px;
+  color: var(--fg-2);
 }

--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -3265,8 +3265,222 @@ function SemanticPanel() {
         <button disabled=${busy || running || !ready} onClick=${() => start(true)}>Rebuild (wipe + full)</button>
         <button disabled=${busy || !running} onClick=${stop}>Stop</button>
       </div>
+
+      <${SemanticExcludesCard} />
     </div>
   `;
+}
+
+function SemanticExcludesCard() {
+  const [data, setData] = useState(null);
+  const [draft, setDraft] = useState(null);
+  const [preview, setPreview] = useState(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState(null);
+  const [info, setInfo] = useState(null);
+  const [open, setOpen] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const r = await api("/index-config");
+      setData(r);
+      setDraft(toDraft(r.resolved));
+    } catch (err) {
+      setError(err.message);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (open && !data) load();
+  }, [open, data, load]);
+
+  const reset = useCallback(() => {
+    if (data) setDraft(toDraft(data.defaults));
+    setPreview(null);
+  }, [data]);
+
+  const save = useCallback(async () => {
+    if (!draft) return;
+    setBusy(true);
+    setError(null);
+    setInfo(null);
+    try {
+      const payload = fromDraft(draft);
+      const r = await api("/index-config", { method: "POST", body: payload });
+      setInfo(`saved · ${r.changed.length || 0} fields updated · re-run index to apply`);
+      await load();
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setBusy(false);
+    }
+  }, [draft, load]);
+
+  const runPreview = useCallback(async () => {
+    if (!draft) return;
+    setBusy(true);
+    setError(null);
+    setInfo("running dry walk against project root…");
+    try {
+      const payload = fromDraft(draft);
+      const r = await api("/index-config/preview", { method: "POST", body: payload });
+      setPreview(r);
+      setInfo(null);
+    } catch (err) {
+      setError(err.message);
+      setInfo(null);
+    } finally {
+      setBusy(false);
+    }
+  }, [draft]);
+
+  return html`
+    <div class="section-title" style="margin-top: 18px;">
+      <span style="cursor: pointer;" onClick=${() => setOpen(!open)}>
+        ${open ? "▼" : "▶"} Excludes
+      </span>
+      <span class="muted" style="margin-left: 8px; font-weight: normal; font-size: 12px;">
+        config-driven skip rules applied during indexing
+      </span>
+    </div>
+    ${
+      !open
+        ? null
+        : !draft
+          ? html`<div class="muted">loading…</div>`
+          : html`
+            <div class="card" style="font-size: 13px;">
+              ${info ? html`<div class="notice">${info}</div>` : null}
+              ${error ? html`<div class="notice err">${error}</div>` : null}
+              <div class="muted" style="margin-bottom: 10px;">
+                One value per line. Dirs / files match by basename. Patterns use picomatch (e.g. <code>**/*.generated.ts</code>, <code>vendor/**</code>).
+              </div>
+              <${ExcludesField} label="Exclude dirs" value=${draft.excludeDirs} onChange=${(v) => setDraft({ ...draft, excludeDirs: v })} />
+              <${ExcludesField} label="Exclude files" value=${draft.excludeFiles} onChange=${(v) => setDraft({ ...draft, excludeFiles: v })} />
+              <${ExcludesField} label="Exclude extensions" value=${draft.excludeExts} onChange=${(v) => setDraft({ ...draft, excludeExts: v })} />
+              <${ExcludesField} label="Exclude patterns (glob)" value=${draft.excludePatterns} onChange=${(v) => setDraft({ ...draft, excludePatterns: v })} />
+              <div class="row" style="margin-top: 10px; gap: 16px;">
+                <label style="display: flex; align-items: center; gap: 6px;">
+                  <input type="checkbox" checked=${draft.respectGitignore} onChange=${(e) => setDraft({ ...draft, respectGitignore: e.target.checked })} />
+                  Respect <code>.gitignore</code>
+                </label>
+                <label style="display: flex; align-items: center; gap: 6px;">
+                  Max file size:
+                  <input type="number" min="1024" step="1024" value=${draft.maxFileBytes} onChange=${(e) => setDraft({ ...draft, maxFileBytes: Number(e.target.value) || 0 })} style="width: 110px;" />
+                  <span class="muted">bytes</span>
+                </label>
+              </div>
+              <div class="row" style="margin-top: 12px;">
+                <button class="primary" disabled=${busy} onClick=${save}>Save</button>
+                <button disabled=${busy} onClick=${runPreview}>Preview (dry-walk)</button>
+                <button disabled=${busy} onClick=${reset}>Reset to defaults</button>
+              </div>
+              ${preview ? html`<${ExcludesPreview} preview=${preview} />` : null}
+            </div>
+          `
+    }
+  `;
+}
+
+function ExcludesPreview({ preview }) {
+  const buckets = preview.skipBuckets || {};
+  const samples = preview.skipSamples || {};
+  const totalSkipped = Object.values(buckets).reduce((a, b) => a + (b || 0), 0);
+  const reasons = [
+    "gitignore",
+    "pattern",
+    "defaultDir",
+    "defaultFile",
+    "binaryExt",
+    "binaryContent",
+    "tooLarge",
+    "readError",
+  ].filter((k) => (buckets[k] || 0) > 0);
+  return html`
+    <div style="margin-top: 12px; padding-top: 10px; border-top: 1px solid var(--border, #2a2a2a);">
+      <div style="font-weight: 500; margin-bottom: 6px;">
+        Preview — would index <strong>${preview.filesIncluded}</strong> file(s), skip <strong>${totalSkipped}</strong>
+      </div>
+      ${
+        reasons.length === 0
+          ? html`<div class="muted" style="font-size: 12px;">nothing skipped — all walked files would be indexed.</div>`
+          : html`
+            <div style="font-size: 12px;">
+              ${reasons.map(
+                (r) => html`
+                  <details style="margin-bottom: 6px;">
+                    <summary><strong>${r}: ${buckets[r]}</strong></summary>
+                    <ul style="margin: 4px 0 4px 18px; padding: 0;">
+                      ${(samples[r] || []).map(
+                        (p) => html`<li><code style="font-size: 11.5px;">${p}</code></li>`,
+                      )}
+                      ${
+                        (buckets[r] || 0) > (samples[r] || []).length
+                          ? html`<li class="muted">…${buckets[r] - samples[r].length} more</li>`
+                          : null
+                      }
+                    </ul>
+                  </details>
+                `,
+              )}
+            </div>
+          `
+      }
+      ${
+        preview.sampleIncluded?.length
+          ? html`
+            <details style="margin-top: 8px;">
+              <summary class="muted" style="font-size: 12px;">first ${preview.sampleIncluded.length} included file(s)</summary>
+              <ul style="margin: 4px 0 4px 18px; padding: 0; font-size: 12px;">
+                ${preview.sampleIncluded.map((p) => html`<li><code style="font-size: 11.5px;">${p}</code></li>`)}
+              </ul>
+            </details>
+          `
+          : null
+      }
+    </div>
+  `;
+}
+
+function ExcludesField({ label, value, onChange }) {
+  return html`
+    <div style="margin-bottom: 8px;">
+      <label style="display: block; font-weight: 500; margin-bottom: 4px;">${label}</label>
+      <textarea
+        rows="4"
+        style="width: 100%; font-family: var(--mono, monospace); font-size: 12px;"
+        value=${value}
+        onChange=${(e) => onChange(e.target.value)}
+      ></textarea>
+    </div>
+  `;
+}
+
+function toDraft(c) {
+  return {
+    excludeDirs: (c.excludeDirs ?? []).join("\n"),
+    excludeFiles: (c.excludeFiles ?? []).join("\n"),
+    excludeExts: (c.excludeExts ?? []).join("\n"),
+    excludePatterns: (c.excludePatterns ?? []).join("\n"),
+    respectGitignore: c.respectGitignore !== false,
+    maxFileBytes: c.maxFileBytes ?? 262144,
+  };
+}
+
+function fromDraft(d) {
+  const lines = (s) =>
+    s
+      .split(/\r?\n/)
+      .map((x) => x.trim())
+      .filter((x) => x.length > 0);
+  return {
+    excludeDirs: lines(d.excludeDirs),
+    excludeFiles: lines(d.excludeFiles),
+    excludeExts: lines(d.excludeExts),
+    excludePatterns: lines(d.excludePatterns),
+    respectGitignore: !!d.respectGitignore,
+    maxFileBytes: d.maxFileBytes,
+  };
 }
 
 function SemanticJobView({ job, running }) {
@@ -3321,8 +3535,32 @@ function SemanticJobView({ job, running }) {
             } · ${(job.result.durationMs / 1000).toFixed(1)}s</div>`
           : null
       }
+      ${
+        job.result?.skipBuckets
+          ? html`<${SkipBucketsView} buckets=${job.result.skipBuckets} />`
+          : null
+      }
     </div>
   `;
+}
+
+function SkipBucketsView({ buckets }) {
+  const order = [
+    ["gitignore", "gitignore"],
+    ["pattern", "pattern"],
+    ["defaultDir", "defaultDir"],
+    ["defaultFile", "defaultFile"],
+    ["binaryExt", "binaryExt"],
+    ["binaryContent", "binaryContent"],
+    ["tooLarge", "tooLarge"],
+    ["readError", "readError"],
+  ];
+  const total = order.reduce((a, [k]) => a + (buckets[k] || 0), 0);
+  if (total === 0) return null;
+  const parts = order
+    .filter(([k]) => (buckets[k] || 0) > 0)
+    .map(([k, label]) => `${label}: ${buckets[k]}`);
+  return html`<div><span class="kv-key">skipped</span>${total} files <span class="muted">(${parts.join(", ")})</span></div>`;
 }
 
 function McpPanel() {

--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -3335,42 +3335,41 @@ function SemanticExcludesCard() {
   }, [draft]);
 
   return html`
-    <div class="section-title" style="margin-top: 18px;">
-      <span style="cursor: pointer;" onClick=${() => setOpen(!open)}>
-        ${open ? "▼" : "▶"} Excludes
-      </span>
-      <span class="muted" style="margin-left: 8px; font-weight: normal; font-size: 12px;">
-        config-driven skip rules applied during indexing
-      </span>
+    <div class="excludes-toggle" onClick=${() => setOpen(!open)}>
+      <span class="caret">${open ? "▼" : "▶"}</span>
+      <span class="label">Excludes</span>
+      <span class="hint">config-driven skip rules applied during indexing</span>
     </div>
     ${
       !open
         ? null
         : !draft
-          ? html`<div class="muted">loading…</div>`
+          ? html`<div class="empty">loading…</div>`
           : html`
-            <div class="card" style="font-size: 13px;">
+            <div class="card excludes-card">
               ${info ? html`<div class="notice">${info}</div>` : null}
               ${error ? html`<div class="notice err">${error}</div>` : null}
-              <div class="muted" style="margin-bottom: 10px;">
-                One value per line. Dirs / files match by basename. Patterns use picomatch (e.g. <code>**/*.generated.ts</code>, <code>vendor/**</code>).
+              <div class="lead">
+                One value per line. Dirs / files match by basename. Patterns use picomatch syntax (e.g. <code>**/*.generated.ts</code>, <code>vendor/**</code>, <code>!keep-me</code>).
               </div>
-              <${ExcludesField} label="Exclude dirs" value=${draft.excludeDirs} onChange=${(v) => setDraft({ ...draft, excludeDirs: v })} />
-              <${ExcludesField} label="Exclude files" value=${draft.excludeFiles} onChange=${(v) => setDraft({ ...draft, excludeFiles: v })} />
-              <${ExcludesField} label="Exclude extensions" value=${draft.excludeExts} onChange=${(v) => setDraft({ ...draft, excludeExts: v })} />
-              <${ExcludesField} label="Exclude patterns (glob)" value=${draft.excludePatterns} onChange=${(v) => setDraft({ ...draft, excludePatterns: v })} />
-              <div class="row" style="margin-top: 10px; gap: 16px;">
-                <label style="display: flex; align-items: center; gap: 6px;">
+              <div class="excludes-grid">
+                <${ExcludesField} label="Exclude dirs" value=${draft.excludeDirs} onChange=${(v) => setDraft({ ...draft, excludeDirs: v })} />
+                <${ExcludesField} label="Exclude files" value=${draft.excludeFiles} onChange=${(v) => setDraft({ ...draft, excludeFiles: v })} />
+                <${ExcludesField} label="Exclude extensions" value=${draft.excludeExts} onChange=${(v) => setDraft({ ...draft, excludeExts: v })} />
+                <${ExcludesField} label="Exclude patterns (glob)" value=${draft.excludePatterns} onChange=${(v) => setDraft({ ...draft, excludePatterns: v })} />
+              </div>
+              <div class="excludes-options">
+                <label>
                   <input type="checkbox" checked=${draft.respectGitignore} onChange=${(e) => setDraft({ ...draft, respectGitignore: e.target.checked })} />
                   Respect <code>.gitignore</code>
                 </label>
-                <label style="display: flex; align-items: center; gap: 6px;">
-                  Max file size:
-                  <input type="number" min="1024" step="1024" value=${draft.maxFileBytes} onChange=${(e) => setDraft({ ...draft, maxFileBytes: Number(e.target.value) || 0 })} style="width: 110px;" />
+                <label>
+                  Max file size
+                  <input type="number" min="1024" step="1024" value=${draft.maxFileBytes} onChange=${(e) => setDraft({ ...draft, maxFileBytes: Number(e.target.value) || 0 })} />
                   <span class="muted">bytes</span>
                 </label>
               </div>
-              <div class="row" style="margin-top: 12px;">
+              <div class="excludes-actions">
                 <button class="primary" disabled=${busy} onClick=${save}>Save</button>
                 <button disabled=${busy} onClick=${runPreview}>Preview (dry-walk)</button>
                 <button disabled=${busy} onClick=${reset}>Reset to defaults</button>
@@ -3397,42 +3396,36 @@ function ExcludesPreview({ preview }) {
     "readError",
   ].filter((k) => (buckets[k] || 0) > 0);
   return html`
-    <div style="margin-top: 12px; padding-top: 10px; border-top: 1px solid var(--border, #2a2a2a);">
-      <div style="font-weight: 500; margin-bottom: 6px;">
+    <div class="excludes-preview">
+      <div class="summary">
         Preview — would index <strong>${preview.filesIncluded}</strong> file(s), skip <strong>${totalSkipped}</strong>
       </div>
       ${
         reasons.length === 0
-          ? html`<div class="muted" style="font-size: 12px;">nothing skipped — all walked files would be indexed.</div>`
-          : html`
-            <div style="font-size: 12px;">
-              ${reasons.map(
-                (r) => html`
-                  <details style="margin-bottom: 6px;">
-                    <summary><strong>${r}: ${buckets[r]}</strong></summary>
-                    <ul style="margin: 4px 0 4px 18px; padding: 0;">
-                      ${(samples[r] || []).map(
-                        (p) => html`<li><code style="font-size: 11.5px;">${p}</code></li>`,
-                      )}
-                      ${
-                        (buckets[r] || 0) > (samples[r] || []).length
-                          ? html`<li class="muted">…${buckets[r] - samples[r].length} more</li>`
-                          : null
-                      }
-                    </ul>
-                  </details>
-                `,
-              )}
-            </div>
-          `
+          ? html`<div class="muted">nothing skipped — all walked files would be indexed.</div>`
+          : reasons.map(
+              (r) => html`
+                <details>
+                  <summary><strong>${r}: ${buckets[r]}</strong></summary>
+                  <ul>
+                    ${(samples[r] || []).map((p) => html`<li><code>${p}</code></li>`)}
+                    ${
+                      (buckets[r] || 0) > (samples[r] || []).length
+                        ? html`<li class="muted">…${buckets[r] - samples[r].length} more</li>`
+                        : null
+                    }
+                  </ul>
+                </details>
+              `,
+            )
       }
       ${
         preview.sampleIncluded?.length
           ? html`
-            <details style="margin-top: 8px;">
-              <summary class="muted" style="font-size: 12px;">first ${preview.sampleIncluded.length} included file(s)</summary>
-              <ul style="margin: 4px 0 4px 18px; padding: 0; font-size: 12px;">
-                ${preview.sampleIncluded.map((p) => html`<li><code style="font-size: 11.5px;">${p}</code></li>`)}
+            <details>
+              <summary>first ${preview.sampleIncluded.length} included file(s)</summary>
+              <ul>
+                ${preview.sampleIncluded.map((p) => html`<li><code>${p}</code></li>`)}
               </ul>
             </details>
           `
@@ -3444,14 +3437,9 @@ function ExcludesPreview({ preview }) {
 
 function ExcludesField({ label, value, onChange }) {
   return html`
-    <div style="margin-bottom: 8px;">
-      <label style="display: block; font-weight: 500; margin-bottom: 4px;">${label}</label>
-      <textarea
-        rows="4"
-        style="width: 100%; font-family: var(--mono, monospace); font-size: 12px;"
-        value=${value}
-        onChange=${(e) => onChange(e.target.value)}
-      ></textarea>
+    <div class="excludes-field">
+      <label>${label}</label>
+      <textarea rows="5" value=${value} onChange=${(e) => onChange(e.target.value)}></textarea>
     </div>
   `;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,21 @@
 {
   "name": "reasonix",
-  "version": "0.13.5",
+  "version": "0.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reasonix",
-      "version": "0.13.5",
+      "version": "0.16.1",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0",
         "eventsource-parser": "^3.0.0",
+        "ignore": "^7.0.5",
         "ink": "^5.1.0",
         "ink-spinner": "^5.0.0",
         "ink-text-input": "^6.0.0",
+        "picomatch": "^4.0.4",
         "react": "^18.3.1",
         "string-width": "^7.2.0"
       },
@@ -43,6 +45,7 @@
         "@codemirror/theme-one-dark": "^6.1.2",
         "@codemirror/view": "^6.26.0",
         "@types/node": "^22.9.0",
+        "@types/picomatch": "^4.0.3",
         "@types/react": "^18.3.12",
         "esbuild": "^0.21.5",
         "simple-git-hooks": "^2.13.1",
@@ -1567,6 +1570,13 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-iG0T6+nYJ9FAPmx9SsUlnwcq1ZVRuCXcVEvWnntoPlrOpwtSTKNDC9uVAxTsC3PUvJ+99n4RpAcNgBbHX3JSnQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -2216,6 +2226,15 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/indent-string": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
@@ -2533,7 +2552,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -70,9 +70,11 @@
   "dependencies": {
     "commander": "^12.1.0",
     "eventsource-parser": "^3.0.0",
+    "ignore": "^7.0.5",
     "ink": "^5.1.0",
     "ink-spinner": "^5.0.0",
     "ink-text-input": "^6.0.0",
+    "picomatch": "^4.0.4",
     "react": "^18.3.1",
     "string-width": "^7.2.0"
   },
@@ -99,6 +101,7 @@
     "@codemirror/theme-one-dark": "^6.1.2",
     "@codemirror/view": "^6.26.0",
     "@types/node": "^22.9.0",
+    "@types/picomatch": "^4.0.3",
     "@types/react": "^18.3.12",
     "esbuild": "^0.21.5",
     "simple-git-hooks": "^2.13.1",

--- a/scripts/smoke-index-config.mjs
+++ b/scripts/smoke-index-config.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+// One-shot smoke: walk the repo with default + .gitignore, print bucket counts.
+
+import { resolveIndexConfig } from "../src/index/config.ts";
+import { walkChunks } from "../src/index/semantic/chunker.ts";
+
+const root = process.cwd();
+const buckets = {
+  defaultDir: 0,
+  defaultFile: 0,
+  binaryExt: 0,
+  binaryContent: 0,
+  tooLarge: 0,
+  gitignore: 0,
+  pattern: 0,
+  readError: 0,
+};
+const includedFiles = new Set();
+
+const t0 = Date.now();
+const patternHits = [];
+for await (const chunk of walkChunks(root, {
+  config: resolveIndexConfig({ excludePatterns: ["**/dashboard/**", "**/*.test.ts"] }),
+  onSkip: (p, reason) => {
+    buckets[reason]++;
+    if (reason === "pattern" && patternHits.length < 5) patternHits.push(p);
+  },
+})) {
+  includedFiles.add(chunk.path);
+}
+const elapsed = ((Date.now() - t0) / 1000).toFixed(2);
+
+console.log(`walked ${root} in ${elapsed}s`);
+console.log(`included ${includedFiles.size} files`);
+console.log("skip buckets:");
+for (const [k, v] of Object.entries(buckets)) {
+  if (v > 0) console.log(`  ${k}: ${v}`);
+}
+if (patternHits.length > 0) {
+  console.log("pattern sample:");
+  for (const p of patternHits) console.log(`  ${p}`);
+}

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -1,8 +1,9 @@
 /** `reasonix index` — progress writes go to stderr so stdout stays pipeable. */
 
 import { resolve } from "node:path";
+import { loadIndexConfig } from "../../config.js";
 import { buildIndex } from "../../index/semantic/builder.js";
-import type { BuildProgress, BuildResult } from "../../index/semantic/builder.js";
+import type { BuildProgress, BuildResult, SkipBuckets } from "../../index/semantic/builder.js";
 import { t } from "../../index/semantic/i18n.js";
 import { ollamaPreflight } from "../../index/semantic/preflight.js";
 
@@ -42,6 +43,7 @@ export async function indexCommand(opts: IndexCommandOptions = {}): Promise<void
       rebuild: opts.rebuild,
       model,
       baseUrl: opts.ollamaUrl,
+      indexConfig: loadIndexConfig(),
       onProgress: (p) => writer.update(p),
     });
   } catch (err) {
@@ -64,9 +66,26 @@ export async function indexCommand(opts: IndexCommandOptions = {}): Promise<void
       seconds,
     }),
   );
+  const breakdown = renderSkipBreakdown(result.skipBuckets);
+  if (breakdown) process.stderr.write(`${breakdown}\n`);
   if (result.filesChanged === 0 && !opts.rebuild) {
     process.stderr.write(t("indexNothingToDo"));
   }
+}
+
+function renderSkipBreakdown(buckets: SkipBuckets): string {
+  const total = Object.values(buckets).reduce((a, b) => a + b, 0);
+  if (total === 0) return "";
+  const parts: string[] = [];
+  if (buckets.gitignore) parts.push(`gitignore: ${buckets.gitignore}`);
+  if (buckets.pattern) parts.push(`pattern: ${buckets.pattern}`);
+  if (buckets.defaultDir) parts.push(`defaultDir: ${buckets.defaultDir}`);
+  if (buckets.defaultFile) parts.push(`defaultFile: ${buckets.defaultFile}`);
+  if (buckets.binaryExt) parts.push(`binaryExt: ${buckets.binaryExt}`);
+  if (buckets.binaryContent) parts.push(`binaryContent: ${buckets.binaryContent}`);
+  if (buckets.tooLarge) parts.push(`tooLarge: ${buckets.tooLarge}`);
+  if (buckets.readError) parts.push(`readError: ${buckets.readError}`);
+  return `  · skipped ${total} files (${parts.join(", ")})`;
 }
 
 interface ProgressWriter {

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,11 @@
 import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+import {
+  type IndexUserConfig,
+  type ResolvedIndexConfig,
+  resolveIndexConfig,
+} from "./index/config.js";
 
 /** Legacy `fast|smart|max` kept for back-compat with existing config.json files. */
 export type PresetName = "auto" | "flash" | "pro" | "fast" | "smart" | "max";
@@ -29,6 +34,7 @@ export interface ReasonixConfig {
       shellAllowed?: string[];
     };
   };
+  index?: IndexUserConfig;
 }
 
 export function defaultConfigPath(): string {
@@ -165,6 +171,20 @@ export function saveReasoningEffort(
 ): void {
   const cfg = readConfig(path);
   cfg.reasoningEffort = effort;
+  writeConfig(cfg, path);
+}
+
+export function loadIndexUserConfig(path: string = defaultConfigPath()): IndexUserConfig {
+  return readConfig(path).index ?? {};
+}
+
+export function loadIndexConfig(path: string = defaultConfigPath()): ResolvedIndexConfig {
+  return resolveIndexConfig(readConfig(path).index);
+}
+
+export function saveIndexConfig(user: IndexUserConfig, path: string = defaultConfigPath()): void {
+  const cfg = readConfig(path);
+  cfg.index = user;
   writeConfig(cfg, path);
 }
 

--- a/src/index/config.ts
+++ b/src/index/config.ts
@@ -1,0 +1,163 @@
+/** Shared exclude defaults + resolver — chunker, directory_tree, and dashboard read from here. */
+
+import picomatch from "picomatch";
+
+export interface IndexUserConfig {
+  excludeDirs?: string[];
+  excludeFiles?: string[];
+  excludeExts?: string[];
+  excludePatterns?: string[];
+  respectGitignore?: boolean;
+  maxFileBytes?: number;
+}
+
+/** Plain-data shape — JSON-safe so the dashboard endpoint can serialize. */
+export interface ResolvedIndexConfig {
+  excludeDirs: readonly string[];
+  excludeFiles: readonly string[];
+  excludeExts: readonly string[];
+  excludePatterns: readonly string[];
+  respectGitignore: boolean;
+  maxFileBytes: number;
+}
+
+/** Hot-path lookup wrapper — built once per indexer run, never serialized. */
+export interface IndexFilters {
+  dirSet: ReadonlySet<string>;
+  fileSet: ReadonlySet<string>;
+  extSet: ReadonlySet<string>;
+  patternMatch: (relPath: string) => boolean;
+  respectGitignore: boolean;
+  maxFileBytes: number;
+}
+
+export const DEFAULT_INDEX_EXCLUDES = {
+  dirs: [
+    "node_modules",
+    ".git",
+    ".hg",
+    ".svn",
+    "dist",
+    "build",
+    "out",
+    ".next",
+    ".nuxt",
+    "target",
+    ".venv",
+    "venv",
+    "__pycache__",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".cache",
+    "coverage",
+    ".turbo",
+    ".vercel",
+    ".reasonix",
+  ] as const,
+  files: [
+    "package-lock.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+    "Cargo.lock",
+    "poetry.lock",
+    "Pipfile.lock",
+    "go.sum",
+    ".DS_Store",
+  ] as const,
+  exts: [
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".gif",
+    ".webp",
+    ".bmp",
+    ".ico",
+    ".tiff",
+    ".woff",
+    ".woff2",
+    ".ttf",
+    ".otf",
+    ".eot",
+    ".zip",
+    ".tar",
+    ".gz",
+    ".bz2",
+    ".xz",
+    ".rar",
+    ".7z",
+    ".exe",
+    ".dll",
+    ".so",
+    ".dylib",
+    ".bin",
+    ".class",
+    ".jar",
+    ".war",
+    ".wasm",
+    ".o",
+    ".obj",
+    ".lib",
+    ".a",
+    ".pyc",
+    ".pyo",
+    ".mp3",
+    ".mp4",
+    ".wav",
+    ".ogg",
+    ".webm",
+    ".mov",
+    ".avi",
+    ".pdf",
+    ".sqlite",
+    ".db",
+  ] as const,
+} as const;
+
+export const DEFAULT_MAX_FILE_BYTES = 256 * 1024;
+export const DEFAULT_RESPECT_GITIGNORE = true;
+
+export function defaultIndexConfig(): ResolvedIndexConfig {
+  return {
+    excludeDirs: [...DEFAULT_INDEX_EXCLUDES.dirs],
+    excludeFiles: [...DEFAULT_INDEX_EXCLUDES.files],
+    excludeExts: [...DEFAULT_INDEX_EXCLUDES.exts],
+    excludePatterns: [],
+    respectGitignore: DEFAULT_RESPECT_GITIGNORE,
+    maxFileBytes: DEFAULT_MAX_FILE_BYTES,
+  };
+}
+
+/** A field present in user config fully replaces the default for that field. Absent → default. */
+export function resolveIndexConfig(user?: IndexUserConfig | null): ResolvedIndexConfig {
+  const d = defaultIndexConfig();
+  if (!user) return d;
+  return {
+    excludeDirs: Array.isArray(user.excludeDirs) ? [...user.excludeDirs] : d.excludeDirs,
+    excludeFiles: Array.isArray(user.excludeFiles) ? [...user.excludeFiles] : d.excludeFiles,
+    excludeExts: Array.isArray(user.excludeExts)
+      ? user.excludeExts.map((e) => e.toLowerCase())
+      : d.excludeExts,
+    excludePatterns: Array.isArray(user.excludePatterns) ? [...user.excludePatterns] : [],
+    respectGitignore:
+      typeof user.respectGitignore === "boolean" ? user.respectGitignore : d.respectGitignore,
+    maxFileBytes:
+      typeof user.maxFileBytes === "number" && user.maxFileBytes > 0
+        ? user.maxFileBytes
+        : d.maxFileBytes,
+  };
+}
+
+export function compileFilters(cfg: ResolvedIndexConfig): IndexFilters {
+  const matcher =
+    cfg.excludePatterns.length === 0
+      ? () => false
+      : picomatch(cfg.excludePatterns as string[], { dot: true });
+  return {
+    dirSet: new Set(cfg.excludeDirs),
+    fileSet: new Set(cfg.excludeFiles),
+    extSet: new Set(cfg.excludeExts.map((e) => e.toLowerCase())),
+    patternMatch: matcher as (p: string) => boolean,
+    respectGitignore: cfg.respectGitignore,
+    maxFileBytes: cfg.maxFileBytes,
+  };
+}

--- a/src/index/semantic/builder.ts
+++ b/src/index/semantic/builder.ts
@@ -1,7 +1,8 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
+import { type ResolvedIndexConfig, defaultIndexConfig } from "../config.js";
 import { walkChunks } from "./chunker.js";
-import type { CodeChunk } from "./chunker.js";
+import type { CodeChunk, SkipReason } from "./chunker.js";
 import { embed, embedAll, probeOllama } from "./embedding.js";
 import type { EmbedOptions } from "./embedding.js";
 import { normalize, openStore } from "./store.js";
@@ -11,17 +12,19 @@ import type { IndexEntry, SearchHit } from "./store.js";
 export const INDEX_DIR_NAME = path.join(".reasonix", "semantic");
 
 export interface BuildOptions extends EmbedOptions {
-  /** Skip files larger than this many bytes. Default 256 KB. */
-  maxFileBytes?: number;
   /** Lines per window. Default 60. */
   windowLines?: number;
   /** Window overlap. Default 12. */
   overlap?: number;
   /** Force a full rebuild (drop the existing index first). */
   rebuild?: boolean;
+  /** Resolved exclude/limit settings. Defaults to package defaults. */
+  indexConfig?: ResolvedIndexConfig;
   /** Progress callback for the CLI to render counters. */
   onProgress?: (info: BuildProgress) => void;
 }
+
+export type SkipBuckets = Record<SkipReason, number>;
 
 export interface BuildProgress {
   phase: "scan" | "embed" | "write" | "done";
@@ -30,6 +33,7 @@ export interface BuildProgress {
   chunksDone?: number;
   filesSkipped?: number;
   filesChanged?: number;
+  skipBuckets?: SkipBuckets;
 }
 
 export interface BuildResult {
@@ -40,7 +44,22 @@ export interface BuildResult {
   /** Chunks that failed to embed (Ollama 500, transient errors) and
    *  were skipped. Reported in the success line so users notice. */
   chunksSkipped: number;
+  /** Per-reason file-skip tally from the walk. */
+  skipBuckets: SkipBuckets;
   durationMs: number;
+}
+
+function emptyBuckets(): SkipBuckets {
+  return {
+    defaultDir: 0,
+    defaultFile: 0,
+    binaryExt: 0,
+    binaryContent: 0,
+    tooLarge: 0,
+    gitignore: 0,
+    pattern: 0,
+    readError: 0,
+  };
 }
 
 /** Probes Ollama first so a missing daemon fails before any chunking work. */
@@ -69,10 +88,14 @@ export async function buildIndex(root: string, opts: BuildOptions = {}): Promise
   const fileChunks = new Map<string, { chunks: CodeChunk[]; mtimeMs: number }>();
   let filesScanned = 0;
   let filesSkipped = 0;
+  const skipBuckets = emptyBuckets();
   for await (const chunk of walkChunks(root, {
     windowLines: opts.windowLines,
     overlap: opts.overlap,
-    maxFileBytes: opts.maxFileBytes,
+    config: opts.indexConfig ?? defaultIndexConfig(),
+    onSkip: (_p, reason) => {
+      skipBuckets[reason]++;
+    },
   })) {
     seenPaths.add(chunk.path);
     let bucket = fileChunks.get(chunk.path);
@@ -165,6 +188,7 @@ export async function buildIndex(root: string, opts: BuildOptions = {}): Promise
     filesChanged,
     chunksTotal,
     chunksDone,
+    skipBuckets,
   });
 
   return {
@@ -173,6 +197,7 @@ export async function buildIndex(root: string, opts: BuildOptions = {}): Promise
     chunksAdded,
     chunksRemoved: removed,
     chunksSkipped,
+    skipBuckets,
     durationMs: Date.now() - t0,
   };
 }

--- a/src/index/semantic/chunker.ts
+++ b/src/index/semantic/chunker.ts
@@ -2,6 +2,13 @@
 
 import { promises as fs } from "node:fs";
 import path from "node:path";
+import ignore, { type Ignore } from "ignore";
+import {
+  type IndexFilters,
+  type ResolvedIndexConfig,
+  compileFilters,
+  defaultIndexConfig,
+} from "../config.js";
 
 export interface CodeChunk {
   /** Path relative to the index root, forward slashes. Stable across OS. */
@@ -12,96 +19,31 @@ export interface CodeChunk {
   text: string;
 }
 
+export type SkipReason =
+  | "defaultDir"
+  | "defaultFile"
+  | "binaryExt"
+  | "binaryContent"
+  | "tooLarge"
+  | "gitignore"
+  | "pattern"
+  | "readError";
+
 export interface ChunkOptions {
   /** Lines per window. Default 60. */
   windowLines?: number;
   /** Lines of overlap between consecutive windows. Default 12. */
   overlap?: number;
-  /** Skip files larger than this (bytes). Default 256 KB. */
-  maxFileBytes?: number;
   /** Default 4000 — keeps unicode-heavy slices under nomic-embed-text's 8K-token window. */
   maxChunkChars?: number;
+  /** Resolved exclude/limit settings. Falls back to package defaults when omitted. */
+  config?: ResolvedIndexConfig;
+  /** Tally callback for files that didn't make it into the index. */
+  onSkip?: (relPath: string, reason: SkipReason) => void;
 }
 
 /** Default character cap per chunk — sized for nomic-embed-text. */
 export const DEFAULT_MAX_CHUNK_CHARS = 4000;
-
-/** Keep in sync with src/tools/filesystem.ts directory_tree. */
-const SKIP_DIRS: ReadonlySet<string> = new Set([
-  "node_modules",
-  ".git",
-  "dist",
-  "build",
-  "out",
-  ".next",
-  ".nuxt",
-  "target",
-  ".venv",
-  "venv",
-  "__pycache__",
-  ".pytest_cache",
-  ".mypy_cache",
-  ".cache",
-  "coverage",
-  ".turbo",
-  ".vercel",
-  ".reasonix",
-]);
-
-const SKIP_FILES: ReadonlySet<string> = new Set([
-  "package-lock.json",
-  "yarn.lock",
-  "pnpm-lock.yaml",
-  "Cargo.lock",
-  "poetry.lock",
-  "Pipfile.lock",
-  "go.sum",
-  ".DS_Store",
-]);
-
-const BINARY_EXTS: ReadonlySet<string> = new Set([
-  // Images
-  ".png",
-  ".jpg",
-  ".jpeg",
-  ".gif",
-  ".webp",
-  ".bmp",
-  ".ico",
-  ".tiff",
-  // Fonts
-  ".woff",
-  ".woff2",
-  ".ttf",
-  ".otf",
-  ".eot",
-  // Archives / binaries
-  ".zip",
-  ".tar",
-  ".gz",
-  ".rar",
-  ".7z",
-  ".exe",
-  ".dll",
-  ".so",
-  ".dylib",
-  ".class",
-  ".jar",
-  ".wasm",
-  ".o",
-  ".a",
-  // Media
-  ".mp3",
-  ".mp4",
-  ".wav",
-  ".ogg",
-  ".webm",
-  ".mov",
-  // Other
-  ".pdf",
-  ".sqlite",
-  ".db",
-]);
 
 export function chunkText(
   text: string,
@@ -153,10 +95,8 @@ function safeSplit(chunk: CodeChunk, maxChars: number): CodeChunk[] {
   };
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i] ?? "";
-    const lineLen = line.length + 1; // +newline
+    const lineLen = line.length + 1;
     if (lineLen > maxChars) {
-      // Single line dwarfs the cap. Flush current buffer, then emit
-      // a hard-truncated single-line chunk for this line.
       flush(chunk.startLine + i - 1);
       out.push({
         path: chunk.path,
@@ -178,19 +118,61 @@ function safeSplit(chunk: CodeChunk, maxChars: number): CodeChunk[] {
   return out;
 }
 
+async function loadGitignoreAt(dirAbs: string): Promise<Ignore | null> {
+  try {
+    const text = await fs.readFile(path.join(dirAbs, ".gitignore"), "utf8");
+    return ignore().add(text);
+  } catch {
+    return null;
+  }
+}
+
+function toForwardRel(root: string, abs: string): string {
+  return path.relative(root, abs).split(path.sep).join("/");
+}
+
+interface GitignoreLayer {
+  /** Absolute dir the gitignore lives in — patterns are evaluated relative to this. */
+  dirAbs: string;
+  ig: Ignore;
+}
+
+/** Returns true if any nested .gitignore — outermost to innermost — matches the path. */
+function ignoredByLayers(layers: readonly GitignoreLayer[], abs: string, isDir: boolean): boolean {
+  for (const layer of layers) {
+    const rel = path.relative(layer.dirAbs, abs).split(path.sep).join("/");
+    if (!rel || rel.startsWith("..")) continue;
+    if (layer.ig.ignores(isDir ? `${rel}/` : rel)) return true;
+  }
+  return false;
+}
+
+interface WalkFrame {
+  dir: string;
+  layers: readonly GitignoreLayer[];
+}
+
 export async function* walkChunks(
   root: string,
   opts: ChunkOptions = {},
 ): AsyncGenerator<CodeChunk> {
   const windowLines = opts.windowLines ?? 60;
   const overlap = Math.min(opts.overlap ?? 12, Math.max(0, windowLines - 1));
-  const maxFileBytes = opts.maxFileBytes ?? 256 * 1024;
   const maxChunkChars = opts.maxChunkChars ?? DEFAULT_MAX_CHUNK_CHARS;
+  const filters: IndexFilters = compileFilters(opts.config ?? defaultIndexConfig());
+  const onSkip = opts.onSkip ?? (() => {});
 
-  const stack: string[] = [root];
+  const initial: GitignoreLayer[] = [];
+  if (filters.respectGitignore) {
+    const rootIg = await loadGitignoreAt(root);
+    if (rootIg) initial.push({ dirAbs: root, ig: rootIg });
+  }
+
+  const stack: WalkFrame[] = [{ dir: root, layers: initial }];
   while (stack.length > 0) {
-    const dir = stack.pop();
-    if (!dir) break;
+    const frame = stack.pop();
+    if (!frame) break;
+    const { dir, layers } = frame;
     let entries: import("node:fs").Dirent[];
     try {
       entries = await fs.readdir(dir, { withFileTypes: true });
@@ -199,47 +181,78 @@ export async function* walkChunks(
     }
     for (const entry of entries) {
       const name = entry.name;
+      const abs = path.join(dir, name);
+      const rel = toForwardRel(root, abs);
       if (entry.isDirectory()) {
-        if (SKIP_DIRS.has(name) || name.startsWith(".")) {
-          // .git/.next/.cache etc. plus any hidden dir — same default
-          // as `directory_tree`. Users opt in to dotfiles via a future
-          // flag; MVP keeps the index lean.
-          if (SKIP_DIRS.has(name) || name === ".git") continue;
-          // Allow other dotdirs that aren't in SKIP_DIRS (rare).
+        if (filters.dirSet.has(name)) {
+          onSkip(rel, "defaultDir");
+          continue;
         }
-        stack.push(path.join(dir, name));
+        if (filters.respectGitignore && ignoredByLayers(layers, abs, true)) {
+          onSkip(rel, "gitignore");
+          continue;
+        }
+        if (filters.patternMatch(`${rel}/`) || filters.patternMatch(rel)) {
+          onSkip(rel, "pattern");
+          continue;
+        }
+        const childLayers = filters.respectGitignore ? await extendLayers(layers, abs) : layers;
+        stack.push({ dir: abs, layers: childLayers });
         continue;
       }
       if (!entry.isFile()) continue;
-      if (SKIP_FILES.has(name)) continue;
+      if (filters.fileSet.has(name)) {
+        onSkip(rel, "defaultFile");
+        continue;
+      }
       const ext = path.extname(name).toLowerCase();
-      if (BINARY_EXTS.has(ext)) continue;
-      const abs = path.join(dir, name);
+      if (filters.extSet.has(ext)) {
+        onSkip(rel, "binaryExt");
+        continue;
+      }
+      if (filters.respectGitignore && ignoredByLayers(layers, abs, false)) {
+        onSkip(rel, "gitignore");
+        continue;
+      }
+      if (filters.patternMatch(rel)) {
+        onSkip(rel, "pattern");
+        continue;
+      }
       let stat: import("node:fs").Stats;
       try {
         stat = await fs.stat(abs);
       } catch {
+        onSkip(rel, "readError");
         continue;
       }
-      if (stat.size > maxFileBytes) continue;
-      // Read as utf-8. If decoding ever fails (random binary that
-      // sneaks past the ext check), skip rather than crashing the
-      // whole index build.
+      if (stat.size > filters.maxFileBytes) {
+        onSkip(rel, "tooLarge");
+        continue;
+      }
       let text: string;
       try {
         text = await fs.readFile(abs, "utf8");
       } catch {
+        onSkip(rel, "readError");
         continue;
       }
-      // Quick null-byte sniff — catches binary files with weird /
-      // missing extensions that BINARY_EXTS missed.
-      if (text.indexOf("\0") !== -1) continue;
-      const rel = path.relative(root, abs).split(path.sep).join("/");
+      if (text.indexOf("\0") !== -1) {
+        onSkip(rel, "binaryContent");
+        continue;
+      }
       for (const chunk of chunkText(text, rel, windowLines, overlap, maxChunkChars)) {
         yield chunk;
       }
     }
   }
+}
+
+async function extendLayers(
+  layers: readonly GitignoreLayer[],
+  dirAbs: string,
+): Promise<readonly GitignoreLayer[]> {
+  const ig = await loadGitignoreAt(dirAbs);
+  return ig ? [...layers, { dirAbs, ig }] : layers;
 }
 
 export async function chunkDirectory(root: string, opts: ChunkOptions = {}): Promise<CodeChunk[]> {

--- a/src/server/api/index-config.ts
+++ b/src/server/api/index-config.ts
@@ -1,0 +1,195 @@
+/** GET returns resolved + defaults so the SPA can render a "reset" button without re-implementing them. */
+
+import { loadIndexUserConfig, readConfig, writeConfig } from "../../config.js";
+import {
+  DEFAULT_INDEX_EXCLUDES,
+  DEFAULT_MAX_FILE_BYTES,
+  DEFAULT_RESPECT_GITIGNORE,
+  type IndexUserConfig,
+  resolveIndexConfig,
+} from "../../index/config.js";
+import { type SkipReason, walkChunks } from "../../index/semantic/chunker.js";
+import type { DashboardContext } from "../context.js";
+import type { ApiResult } from "../router.js";
+
+const PREVIEW_INCLUDED_CAP = 50;
+const PREVIEW_PER_REASON_CAP = 10;
+
+interface PostBody {
+  excludeDirs?: unknown;
+  excludeFiles?: unknown;
+  excludeExts?: unknown;
+  excludePatterns?: unknown;
+  respectGitignore?: unknown;
+  maxFileBytes?: unknown;
+}
+
+function parseBody(raw: string): PostBody {
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    return typeof parsed === "object" && parsed !== null ? (parsed as PostBody) : {};
+  } catch {
+    return {};
+  }
+}
+
+function isStringArray(v: unknown): v is string[] {
+  return Array.isArray(v) && v.every((x) => typeof x === "string");
+}
+
+export async function handleIndexConfig(
+  method: string,
+  rest: string[],
+  body: string,
+  ctx: DashboardContext,
+): Promise<ApiResult> {
+  if (rest[0] === "preview" && method === "POST") {
+    return await handlePreview(body, ctx);
+  }
+  if (method === "GET") {
+    const user = loadIndexUserConfig(ctx.configPath);
+    const resolved = resolveIndexConfig(user);
+    return {
+      status: 200,
+      body: {
+        user,
+        resolved,
+        defaults: {
+          excludeDirs: [...DEFAULT_INDEX_EXCLUDES.dirs],
+          excludeFiles: [...DEFAULT_INDEX_EXCLUDES.files],
+          excludeExts: [...DEFAULT_INDEX_EXCLUDES.exts],
+          excludePatterns: [],
+          respectGitignore: DEFAULT_RESPECT_GITIGNORE,
+          maxFileBytes: DEFAULT_MAX_FILE_BYTES,
+        },
+      },
+    };
+  }
+
+  if (method === "POST") {
+    const fields = parseBody(body);
+    const next: IndexUserConfig = {};
+    const changed: string[] = [];
+
+    if (fields.excludeDirs !== undefined) {
+      if (!isStringArray(fields.excludeDirs)) {
+        return { status: 400, body: { error: "excludeDirs must be string[]" } };
+      }
+      next.excludeDirs = fields.excludeDirs;
+      changed.push("excludeDirs");
+    }
+    if (fields.excludeFiles !== undefined) {
+      if (!isStringArray(fields.excludeFiles)) {
+        return { status: 400, body: { error: "excludeFiles must be string[]" } };
+      }
+      next.excludeFiles = fields.excludeFiles;
+      changed.push("excludeFiles");
+    }
+    if (fields.excludeExts !== undefined) {
+      if (!isStringArray(fields.excludeExts)) {
+        return { status: 400, body: { error: "excludeExts must be string[]" } };
+      }
+      next.excludeExts = fields.excludeExts;
+      changed.push("excludeExts");
+    }
+    if (fields.excludePatterns !== undefined) {
+      if (!isStringArray(fields.excludePatterns)) {
+        return { status: 400, body: { error: "excludePatterns must be string[]" } };
+      }
+      next.excludePatterns = fields.excludePatterns;
+      changed.push("excludePatterns");
+    }
+    if (fields.respectGitignore !== undefined) {
+      if (typeof fields.respectGitignore !== "boolean") {
+        return { status: 400, body: { error: "respectGitignore must be boolean" } };
+      }
+      next.respectGitignore = fields.respectGitignore;
+      changed.push("respectGitignore");
+    }
+    if (fields.maxFileBytes !== undefined) {
+      if (typeof fields.maxFileBytes !== "number" || fields.maxFileBytes <= 0) {
+        return { status: 400, body: { error: "maxFileBytes must be a positive number" } };
+      }
+      next.maxFileBytes = fields.maxFileBytes;
+      changed.push("maxFileBytes");
+    }
+
+    const cfg = readConfig(ctx.configPath);
+    cfg.index = { ...(cfg.index ?? {}), ...next };
+    writeConfig(cfg, ctx.configPath);
+    if (changed.length > 0) {
+      ctx.audit?.({ ts: Date.now(), action: "set-index-config", payload: { fields: changed } });
+    }
+    return { status: 200, body: { changed, resolved: resolveIndexConfig(cfg.index) } };
+  }
+
+  return { status: 405, body: { error: "GET or POST only" } };
+}
+
+async function handlePreview(body: string, ctx: DashboardContext): Promise<ApiResult> {
+  const root = ctx.getCurrentCwd?.();
+  if (!root) {
+    return {
+      status: 400,
+      body: { error: "preview requires a code-mode session (no project root attached)" },
+    };
+  }
+  const fields = parseBody(body);
+  const draft: IndexUserConfig = {};
+  if (isStringArray(fields.excludeDirs)) draft.excludeDirs = fields.excludeDirs;
+  if (isStringArray(fields.excludeFiles)) draft.excludeFiles = fields.excludeFiles;
+  if (isStringArray(fields.excludeExts)) draft.excludeExts = fields.excludeExts;
+  if (isStringArray(fields.excludePatterns)) draft.excludePatterns = fields.excludePatterns;
+  if (typeof fields.respectGitignore === "boolean")
+    draft.respectGitignore = fields.respectGitignore;
+  if (typeof fields.maxFileBytes === "number" && fields.maxFileBytes > 0) {
+    draft.maxFileBytes = fields.maxFileBytes;
+  }
+  const resolved = resolveIndexConfig(draft);
+  const skipBuckets: Record<SkipReason, number> = {
+    defaultDir: 0,
+    defaultFile: 0,
+    binaryExt: 0,
+    binaryContent: 0,
+    tooLarge: 0,
+    gitignore: 0,
+    pattern: 0,
+    readError: 0,
+  };
+  const skipSamples: Record<SkipReason, string[]> = {
+    defaultDir: [],
+    defaultFile: [],
+    binaryExt: [],
+    binaryContent: [],
+    tooLarge: [],
+    gitignore: [],
+    pattern: [],
+    readError: [],
+  };
+  const includedFiles = new Set<string>();
+  const sampleIncluded: string[] = [];
+  for await (const chunk of walkChunks(root, {
+    config: resolved,
+    onSkip: (rel, reason) => {
+      skipBuckets[reason]++;
+      const bucket = skipSamples[reason];
+      if (bucket.length < PREVIEW_PER_REASON_CAP) bucket.push(rel);
+    },
+  })) {
+    if (!includedFiles.has(chunk.path)) {
+      includedFiles.add(chunk.path);
+      if (sampleIncluded.length < PREVIEW_INCLUDED_CAP) sampleIncluded.push(chunk.path);
+    }
+  }
+  return {
+    status: 200,
+    body: {
+      filesIncluded: includedFiles.size,
+      sampleIncluded,
+      skipBuckets,
+      skipSamples,
+      resolved,
+    },
+  };
+}

--- a/src/server/api/semantic.ts
+++ b/src/server/api/semantic.ts
@@ -1,5 +1,6 @@
 /** Job state in a module-scoped Map keyed by project root so multi-root dashboards don't collide; CLI `reasonix index` runs independently. */
 
+import { loadIndexConfig } from "../../config.js";
 import { buildIndex, indexExists } from "../../index/semantic/builder.js";
 import type { BuildProgress, BuildResult } from "../../index/semantic/builder.js";
 import {
@@ -255,6 +256,7 @@ async function runIndex(root: string, job: JobRecord, ctx: DashboardContext): Pr
   try {
     const result = await buildIndex(root, {
       rebuild: job.rebuild,
+      indexConfig: loadIndexConfig(ctx.configPath),
       onProgress: (p) => {
         job.phase = p.phase;
         if (p.filesScanned !== undefined) job.filesScanned = p.filesScanned;

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -3,6 +3,7 @@ import { handleEditMode } from "./api/edit-mode.js";
 import { handleFile, handleFiles } from "./api/file.js";
 import { handleHealth } from "./api/health.js";
 import { handleHooks } from "./api/hooks.js";
+import { handleIndexConfig } from "./api/index-config.js";
 import { handleMcp } from "./api/mcp.js";
 import { handleMemory } from "./api/memory.js";
 import { handleMessages } from "./api/messages.js";
@@ -76,6 +77,8 @@ export async function handleApi(
         return await handleFile(method, rest, body, ctx);
       case "semantic":
         return await handleSemantic(method, rest, body, ctx);
+      case "index-config":
+        return await handleIndexConfig(method, rest, body, ctx);
       default:
         return { status: 404, body: { error: `no such endpoint: /${head}` } };
     }

--- a/src/tools/filesystem.ts
+++ b/src/tools/filesystem.ts
@@ -2,6 +2,7 @@
 
 import { promises as fs } from "node:fs";
 import * as pathMod from "node:path";
+import { DEFAULT_INDEX_EXCLUDES } from "../index/config.js";
 import type { ToolRegistry } from "../tools.js";
 
 export interface FilesystemToolsOptions {
@@ -23,71 +24,11 @@ const DEFAULT_AUTO_PREVIEW_LINES = 200;
 const AUTO_PREVIEW_HEAD_LINES = 80;
 const AUTO_PREVIEW_TAIL_LINES = 40;
 
-/** Skipped unless `include_deps:true` — vendored/generated trees dominate match lists otherwise. */
-const SKIP_DIR_NAMES: ReadonlySet<string> = new Set([
-  "node_modules",
-  ".git",
-  ".hg",
-  ".svn",
-  "dist",
-  "build",
-  "out",
-  ".next",
-  ".nuxt",
-  "target", // Rust / Java
-  ".venv",
-  "venv",
-  "__pycache__",
-  ".pytest_cache",
-  ".mypy_cache",
-  ".cache",
-  "coverage",
-]);
+/** Skipped unless `include_deps:true` — shared with the semantic indexer via DEFAULT_INDEX_EXCLUDES. */
+const SKIP_DIR_NAMES: ReadonlySet<string> = new Set(DEFAULT_INDEX_EXCLUDES.dirs);
 
 /** First line of binary defense; NUL-byte sniff is the second (catches mislabeled `.txt`). */
-const BINARY_EXTENSIONS: ReadonlySet<string> = new Set([
-  ".png",
-  ".jpg",
-  ".jpeg",
-  ".gif",
-  ".bmp",
-  ".ico",
-  ".webp",
-  ".tiff",
-  ".pdf",
-  ".zip",
-  ".tar",
-  ".gz",
-  ".bz2",
-  ".xz",
-  ".7z",
-  ".rar",
-  ".exe",
-  ".dll",
-  ".so",
-  ".dylib",
-  ".bin",
-  ".class",
-  ".jar",
-  ".war",
-  ".o",
-  ".obj",
-  ".lib",
-  ".a",
-  ".woff",
-  ".woff2",
-  ".ttf",
-  ".otf",
-  ".eot",
-  ".mp3",
-  ".mp4",
-  ".mov",
-  ".avi",
-  ".webm",
-  ".wasm",
-  ".pyc",
-  ".pyo",
-]);
+const BINARY_EXTENSIONS: ReadonlySet<string> = new Set(DEFAULT_INDEX_EXCLUDES.exts);
 
 function isLikelyBinaryByName(name: string): boolean {
   const dot = name.lastIndexOf(".");

--- a/tests/chunker-excludes.test.ts
+++ b/tests/chunker-excludes.test.ts
@@ -1,0 +1,122 @@
+import { promises as fs } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolveIndexConfig } from "../src/index/config.js";
+import { type SkipReason, chunkDirectory, walkChunks } from "../src/index/semantic/chunker.js";
+
+describe("walkChunks excludes", () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "reasonix-excludes-"));
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("skips files matched by user excludePatterns and reports reason `pattern`", async () => {
+    await fs.writeFile(join(root, "keep.ts"), "ok\n");
+    await fs.writeFile(join(root, "drop.gen.ts"), "noise\n");
+    const reasons: Record<string, SkipReason> = {};
+    const chunks = await chunkDirectory(root, {
+      config: resolveIndexConfig({ excludePatterns: ["**/*.gen.ts"] }),
+      onSkip: (p, r) => {
+        reasons[p] = r;
+      },
+    });
+    const paths = chunks.map((c) => c.path);
+    expect(paths).toContain("keep.ts");
+    expect(paths).not.toContain("drop.gen.ts");
+    expect(reasons["drop.gen.ts"]).toBe("pattern");
+  });
+
+  it("honours .gitignore at the project root by default", async () => {
+    await fs.writeFile(join(root, ".gitignore"), "secret.txt\nbuild-out/\n");
+    await fs.mkdir(join(root, "build-out"), { recursive: true });
+    await fs.writeFile(join(root, "build-out", "x.ts"), "noise\n");
+    await fs.writeFile(join(root, "secret.txt"), "shh\n");
+    await fs.writeFile(join(root, "main.ts"), "ok\n");
+    const reasons: Record<string, SkipReason> = {};
+    const chunks = await chunkDirectory(root, {
+      onSkip: (p, r) => {
+        reasons[p] = r;
+      },
+    });
+    const paths = chunks.map((c) => c.path);
+    expect(paths).toContain("main.ts");
+    expect(paths).not.toContain("secret.txt");
+    expect(paths.some((p) => p.startsWith("build-out/"))).toBe(false);
+    expect(reasons["secret.txt"]).toBe("gitignore");
+  });
+
+  it("does not read .gitignore when respectGitignore is false", async () => {
+    await fs.writeFile(join(root, ".gitignore"), "secret.txt\n");
+    await fs.writeFile(join(root, "secret.txt"), "shh\n");
+    await fs.writeFile(join(root, "main.ts"), "ok\n");
+    const chunks = await chunkDirectory(root, {
+      config: resolveIndexConfig({ respectGitignore: false }),
+    });
+    const paths = chunks.map((c) => c.path);
+    expect(paths).toContain("secret.txt");
+    expect(paths).toContain("main.ts");
+  });
+
+  it("reports `defaultDir` when a built-in dir is skipped", async () => {
+    await fs.mkdir(join(root, "node_modules", "foo"), { recursive: true });
+    await fs.writeFile(join(root, "node_modules", "foo", "x.ts"), "x\n");
+    await fs.writeFile(join(root, "main.ts"), "ok\n");
+    const reasons: Record<string, SkipReason> = {};
+    await chunkDirectory(root, {
+      onSkip: (p, r) => {
+        reasons[p] = r;
+      },
+    });
+    expect(reasons.node_modules).toBe("defaultDir");
+  });
+
+  it("reports `tooLarge` when a file exceeds the configured limit", async () => {
+    await fs.writeFile(join(root, "big.ts"), "x".repeat(2000));
+    const reasons: Record<string, SkipReason> = {};
+    await chunkDirectory(root, {
+      config: resolveIndexConfig({ maxFileBytes: 1000 }),
+      onSkip: (p, r) => {
+        reasons[p] = r;
+      },
+    });
+    expect(reasons["big.ts"]).toBe("tooLarge");
+  });
+
+  it("honours nested .gitignore — patterns are scoped to their own directory", async () => {
+    await fs.mkdir(join(root, "pkg-a"), { recursive: true });
+    await fs.mkdir(join(root, "pkg-b"), { recursive: true });
+    await fs.writeFile(join(root, ".gitignore"), "global-skip.ts\n");
+    await fs.writeFile(join(root, "pkg-a", ".gitignore"), "local-only.ts\n");
+    await fs.writeFile(join(root, "global-skip.ts"), "x\n");
+    await fs.writeFile(join(root, "pkg-a", "local-only.ts"), "x\n");
+    await fs.writeFile(join(root, "pkg-a", "kept.ts"), "x\n");
+    // Same name as pkg-a's local-only — pkg-b doesn't have its own .gitignore
+    // so this file MUST be indexed (proves the nested rule didn't leak).
+    await fs.writeFile(join(root, "pkg-b", "local-only.ts"), "x\n");
+    const chunks = await chunkDirectory(root);
+    const paths = chunks.map((c) => c.path).sort();
+    expect(paths).toContain("pkg-a/kept.ts");
+    expect(paths).toContain("pkg-b/local-only.ts");
+    expect(paths).not.toContain("global-skip.ts");
+    expect(paths).not.toContain("pkg-a/local-only.ts");
+  });
+
+  it("user-supplied excludeDirs FULLY replaces defaults so previously skipped dirs become indexed", async () => {
+    await fs.mkdir(join(root, "node_modules"), { recursive: true });
+    await fs.writeFile(join(root, "node_modules", "x.ts"), "now indexed\n");
+    const chunks: string[] = [];
+    for await (const c of walkChunks(root, {
+      config: resolveIndexConfig({ excludeDirs: ["nothing-skipped"] }),
+    })) {
+      chunks.push(c.path);
+    }
+    expect(chunks.some((p) => p.startsWith("node_modules/"))).toBe(true);
+  });
+});

--- a/tests/index-config.test.ts
+++ b/tests/index-config.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_INDEX_EXCLUDES,
+  DEFAULT_MAX_FILE_BYTES,
+  DEFAULT_RESPECT_GITIGNORE,
+  compileFilters,
+  defaultIndexConfig,
+  resolveIndexConfig,
+} from "../src/index/config.js";
+
+describe("resolveIndexConfig", () => {
+  it("returns full defaults when user config is null", () => {
+    const r = resolveIndexConfig(null);
+    expect(r.excludeDirs).toEqual([...DEFAULT_INDEX_EXCLUDES.dirs]);
+    expect(r.excludeFiles).toEqual([...DEFAULT_INDEX_EXCLUDES.files]);
+    expect(r.excludeExts).toEqual([...DEFAULT_INDEX_EXCLUDES.exts]);
+    expect(r.excludePatterns).toEqual([]);
+    expect(r.respectGitignore).toBe(DEFAULT_RESPECT_GITIGNORE);
+    expect(r.maxFileBytes).toBe(DEFAULT_MAX_FILE_BYTES);
+  });
+
+  it("user-provided field FULLY replaces the default for that field", () => {
+    const r = resolveIndexConfig({ excludeDirs: ["only-this"] });
+    expect(r.excludeDirs).toEqual(["only-this"]);
+    expect(r.excludeFiles).toEqual([...DEFAULT_INDEX_EXCLUDES.files]);
+  });
+
+  it("absent fields fall back to defaults", () => {
+    const r = resolveIndexConfig({ excludePatterns: ["**/*.gen.ts"] });
+    expect(r.excludePatterns).toEqual(["**/*.gen.ts"]);
+    expect(r.excludeDirs).toEqual([...DEFAULT_INDEX_EXCLUDES.dirs]);
+  });
+
+  it("normalises extensions to lowercase", () => {
+    const r = resolveIndexConfig({ excludeExts: [".PNG", ".Mp4"] });
+    expect(r.excludeExts).toEqual([".png", ".mp4"]);
+  });
+
+  it("ignores non-positive maxFileBytes and falls back to default", () => {
+    expect(resolveIndexConfig({ maxFileBytes: 0 }).maxFileBytes).toBe(DEFAULT_MAX_FILE_BYTES);
+    expect(resolveIndexConfig({ maxFileBytes: -5 }).maxFileBytes).toBe(DEFAULT_MAX_FILE_BYTES);
+  });
+
+  it("respectGitignore false sticks (not coerced to default)", () => {
+    expect(resolveIndexConfig({ respectGitignore: false }).respectGitignore).toBe(false);
+  });
+});
+
+describe("compileFilters", () => {
+  it("patternMatch returns false when no patterns are configured", () => {
+    const f = compileFilters(defaultIndexConfig());
+    expect(f.patternMatch("foo/bar.ts")).toBe(false);
+  });
+
+  it("patternMatch honours picomatch glob syntax", () => {
+    const f = compileFilters(resolveIndexConfig({ excludePatterns: ["**/*.gen.ts", "vendor/**"] }));
+    expect(f.patternMatch("src/foo.gen.ts")).toBe(true);
+    expect(f.patternMatch("vendor/lib/x.ts")).toBe(true);
+    expect(f.patternMatch("src/foo.ts")).toBe(false);
+  });
+
+  it("turns extension list into a set with lowercase lookup", () => {
+    const f = compileFilters(resolveIndexConfig({ excludeExts: [".XYZ"] }));
+    expect(f.extSet.has(".xyz")).toBe(true);
+  });
+});

--- a/tests/server-index-config.test.ts
+++ b/tests/server-index-config.test.ts
@@ -1,0 +1,152 @@
+import { promises as fs } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readConfig } from "../src/config.js";
+import { DEFAULT_INDEX_EXCLUDES } from "../src/index/config.js";
+import { handleIndexConfig } from "../src/server/api/index-config.js";
+import type { DashboardContext } from "../src/server/context.js";
+
+function makeCtx(configPath: string): DashboardContext {
+  return {
+    configPath,
+    usageLogPath: configPath.replace(/config\.json$/, "usage.jsonl"),
+    mode: "standalone",
+  };
+}
+
+describe("/api/index-config", () => {
+  let dir: string;
+  let cfg: string;
+  let ctx: DashboardContext;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "reasonix-cfg-"));
+    cfg = join(dir, "config.json");
+    ctx = makeCtx(cfg);
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("GET returns defaults when no user config is set", async () => {
+    const r = await handleIndexConfig("GET", [], "", ctx);
+    expect(r.status).toBe(200);
+    const body = r.body as {
+      user: Record<string, unknown>;
+      resolved: { excludeDirs: string[]; respectGitignore: boolean };
+      defaults: { excludeDirs: string[] };
+    };
+    expect(body.user).toEqual({});
+    expect(body.resolved.excludeDirs).toEqual([...DEFAULT_INDEX_EXCLUDES.dirs]);
+    expect(body.resolved.respectGitignore).toBe(true);
+    expect(body.defaults.excludeDirs).toEqual([...DEFAULT_INDEX_EXCLUDES.dirs]);
+  });
+
+  it("POST persists fields to config.json and round-trips through GET", async () => {
+    const post = await handleIndexConfig(
+      "POST",
+      [],
+      JSON.stringify({
+        excludePatterns: ["**/*.gen.ts"],
+        respectGitignore: false,
+        maxFileBytes: 1024,
+      }),
+      ctx,
+    );
+    expect(post.status).toBe(200);
+    const postBody = post.body as { changed: string[] };
+    expect(postBody.changed.sort()).toEqual([
+      "excludePatterns",
+      "maxFileBytes",
+      "respectGitignore",
+    ]);
+
+    const onDisk = readConfig(cfg);
+    expect(onDisk.index?.excludePatterns).toEqual(["**/*.gen.ts"]);
+    expect(onDisk.index?.respectGitignore).toBe(false);
+    expect(onDisk.index?.maxFileBytes).toBe(1024);
+
+    const get = await handleIndexConfig("GET", [], "", ctx);
+    const body = get.body as {
+      user: { excludePatterns: string[] };
+      resolved: { excludePatterns: string[]; respectGitignore: boolean };
+    };
+    expect(body.user.excludePatterns).toEqual(["**/*.gen.ts"]);
+    expect(body.resolved.respectGitignore).toBe(false);
+  });
+
+  it("POST rejects bad shapes with 400", async () => {
+    const r = await handleIndexConfig(
+      "POST",
+      [],
+      JSON.stringify({ excludeDirs: "not-an-array" }),
+      ctx,
+    );
+    expect(r.status).toBe(400);
+  });
+
+  it("POST rejects non-positive maxFileBytes", async () => {
+    const r = await handleIndexConfig("POST", [], JSON.stringify({ maxFileBytes: 0 }), ctx);
+    expect(r.status).toBe(400);
+  });
+
+  it("non-GET/POST methods return 405", async () => {
+    const r = await handleIndexConfig("DELETE", [], "", ctx);
+    expect(r.status).toBe(405);
+  });
+
+  it("subsequent POST merges with existing config (does not wipe other fields)", async () => {
+    await handleIndexConfig("POST", [], JSON.stringify({ excludePatterns: ["a"] }), ctx);
+    await handleIndexConfig("POST", [], JSON.stringify({ maxFileBytes: 999 }), ctx);
+    const onDisk = readConfig(cfg);
+    expect(onDisk.index?.excludePatterns).toEqual(["a"]);
+    expect(onDisk.index?.maxFileBytes).toBe(999);
+  });
+
+  describe("preview", () => {
+    let project: string;
+
+    beforeEach(async () => {
+      project = await mkdtemp(join(tmpdir(), "reasonix-preview-"));
+      await fs.writeFile(join(project, "main.ts"), "ok\n");
+      await fs.writeFile(join(project, "drop.gen.ts"), "noise\n");
+      await fs.mkdir(join(project, "node_modules"), { recursive: true });
+      await fs.writeFile(join(project, "node_modules", "x.ts"), "x\n");
+      ctx = { ...makeCtx(cfg), getCurrentCwd: () => project };
+    });
+
+    afterEach(async () => {
+      await rm(project, { recursive: true, force: true });
+    });
+
+    it("returns 400 when no project root is attached", async () => {
+      const noRootCtx = makeCtx(cfg);
+      const r = await handleIndexConfig("POST", ["preview"], JSON.stringify({}), noRootCtx);
+      expect(r.status).toBe(400);
+    });
+
+    it("dry-walks the project root and returns sample paths + skip buckets", async () => {
+      const r = await handleIndexConfig(
+        "POST",
+        ["preview"],
+        JSON.stringify({ excludePatterns: ["**/*.gen.ts"] }),
+        ctx,
+      );
+      expect(r.status).toBe(200);
+      const body = r.body as {
+        filesIncluded: number;
+        sampleIncluded: string[];
+        skipBuckets: Record<string, number>;
+        skipSamples: Record<string, string[]>;
+      };
+      expect(body.sampleIncluded).toContain("main.ts");
+      expect(body.sampleIncluded).not.toContain("drop.gen.ts");
+      expect(body.skipBuckets.pattern).toBeGreaterThanOrEqual(1);
+      expect(body.skipBuckets.defaultDir).toBeGreaterThanOrEqual(1);
+      expect(body.skipSamples.pattern).toContain("drop.gen.ts");
+    });
+  });
+});


### PR DESCRIPTION
Closes #9.

## Summary

- **Config-driven excludes** — pulls `SKIP_DIRS` / `SKIP_FILES` / `BINARY_EXTS` / `maxFileBytes` out of `chunker.ts` (and the duplicate copy in `directory_tree`) into a single `src/index/config.ts`. `ReasonixConfig` gains an optional `index` block where any field present **fully replaces** the default for that field.
- **Nested `.gitignore`** honoured by default — each subdir's rules are scoped to that subdir, so `pkg-a/.gitignore` doesn't leak into `pkg-b/`.
- **Glob excludes** via `picomatch` syntax in `excludePatterns` (e.g. `**/*.gen.ts`, `vendor/**`, `!negation`).
- **Skip-reason instrumentation** — `walkChunks` takes an `onSkip(rel, reason)` callback; `buildIndex` aggregates into `result.skipBuckets`; `reasonix index` prints the per-reason breakdown.
- **Dashboard Settings card** — collapsible "Excludes" panel under Semantic tab with editable lists, gitignore toggle, max-file-size, and **Save / Preview / Reset** buttons. Preview dry-walks the project root with the unsaved draft and shows sample paths + per-reason buckets before commit.
- **Two new endpoints** — `GET /api/index-config` (user / resolved / defaults), `POST /api/index-config` (persist), `POST /api/index-config/preview` (dry-walk a draft).
- **`directory_tree` deduplicated** — now reads `DEFAULT_INDEX_EXCLUDES` from the same source as the indexer.

## Why

Community member asked "where do I configure index excludes?" — answer was "edit the source". The skip lists were also already drifted between `chunker.ts` and `directory_tree` (per-tool copies of nearly-identical sets). One source of truth + user config + dashboard UI fixes both.

## Files

- `src/index/config.ts` (new), `src/server/api/index-config.ts` (new)
- `src/index/semantic/chunker.ts` (rewritten — drops constants, accepts resolved config, nested gitignore)
- `src/index/semantic/builder.ts` (skip buckets surfaced)
- `src/cli/commands/index.ts` (loads config, prints skip breakdown)
- `src/tools/filesystem.ts` (uses shared defaults)
- `src/server/{router,api/semantic}.ts` (new route registered, dashboard rebuild honours config)
- `dashboard/app.js` (Settings card + Preview UI + skip-bucket display in job result)
- `tests/{index-config,chunker-excludes,server-index-config}.test.ts` (new — 21 tests)
- `scripts/smoke-index-config.mjs` (one-shot dry-walker for debugging)
- `package.json` (+`picomatch ^4`, +`ignore ^7`, +`@types/picomatch ^4`)
- `CHANGELOG.md` (Unreleased)

## Test plan

- [x] `npm run verify` — 1784 tests / lint / typecheck all green
- [x] Smoke on this repo: `npx tsx scripts/smoke-index-config.mjs` → 420 files indexed, 4 defaultDir / 3 gitignore / 1 binaryExt / 1 tooLarge buckets populate correctly; adding `excludePatterns: ["**/dashboard/**", "**/*.test.ts"]` shifts to 100 pattern hits as expected
- [x] Manual dashboard run on a real session — open Semantic tab, expand Excludes, edit + Preview + Save, then Rebuild and confirm result panel shows skip-bucket breakdown
- [x] Cross-OS check — picomatch matches forward-slash paths on Windows (the chunker normalises `path.sep` → `/` before matching)

## Migration

None for users — defaults are the union superset of the previous two hardcoded lists, so existing behaviour is preserved when no `index` block exists in `~/.reasonix/config.json`.