### PR TITLE
fix(tui): drop ink debug:true — was leaving ghost-frame trail per keystroke

### DIFF
--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -346,8 +346,7 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
       session={resolvedSession}
     />,
     // patchConsole:false — winpty/MINTTY redraw-glitch source.
-    // debug:true forces full-frame writes; log-update's diff drops frames on Windows ConPTY.
-    { exitOnCtrlC: true, patchConsole: false, debug: true },
+    { exitOnCtrlC: true, patchConsole: false },
   );
   try {
     await waitUntilExit();


### PR DESCRIPTION
## Summary
`debug: true` was added in #13 (commit ba7666c) with a comment claiming it "forces full-frame writes." That's wrong — Ink's docs are explicit:

> debug: If true, each update will be rendered as a separate output, without replacing the previous one.

So every React rerender (i.e. every keystroke into PromptInput) appended a fresh frame to scrollback. After a session of typing, dozens of stale PromptInput frames piled up above. On relaunch, the user typing in the new session looked like it was "syncing" with the ghost frames above — because both the old (already-printed-as-scrollback) and the new (each keystroke also appending) trails grew with the same characters.

## Fix
Remove `debug: true`. Default log-update diff mode is the right behaviour. The original "log-update drops frames on Windows ConPTY" justification was speculative and not backed by a real reproduction.

## Test plan
- [x] `npm run verify` — typecheck + tests clean
- [x] Manual: launch `reasonix code`, type into PromptInput, confirm no frame trail
- [x] Manual: Ctrl+C exit, relaunch, type again — no ghost-sync of input above

This is blocking the 0.18.0 release.