### PR TITLE
docs: Contributing CTA in README + dashboard design mockup

### DIFF
--- a/README.md
+++ b/README.md
@@ -965,10 +965,27 @@ cd reasonix
 npm install
 npm run dev code        # run CLI from source via tsx
 npm run build           # tsup to dist/
-npm test                # vitest (1482 tests)
+npm test                # vitest (1665 tests)
 npm run lint            # biome
 npm run typecheck       # tsc --noEmit
 ```
+
+---
+
+## Contributing
+
+Looking for somewhere to start? These are scoped, well-described, and don't need deep familiarity with the loop or rendering pipeline:
+
+- [#15 — Add `--json` flag to `reasonix doctor`](https://github.com/esengine/reasonix/issues/15) · CLI · 2-3h
+- [#16 — Make `web_search` / `web_fetch` errors actionable](https://github.com/esengine/reasonix/issues/16) · tools · 2-3h
+- [#17 — Suggest the closest slash command on "unknown command"](https://github.com/esengine/reasonix/issues/17) · TUI · 2-3h
+- [#18 — Unit tests for `clipboard.ts`](https://github.com/esengine/reasonix/issues/18) · tests · 2-3h
+
+Each issue has background, current behaviour, expected behaviour, file pointers with line numbers, acceptance criteria, and hints. Browse all [`good first issue`](https://github.com/esengine/reasonix/labels/good%20first%20issue)s.
+
+Have an opinion on what Reasonix should be? The [Discussions](https://github.com/esengine/reasonix/discussions) are open — CLI design, dashboard design, and the future-features wishlist all want input.
+
+The repo's code style is enforced by `tests/comment-policy.test.ts` and `npm run verify` (the pre-push gate). Read [`CLAUDE.md`](./CLAUDE.md) before your first PR — short rules, strictly enforced.
 
 ---
 

--- a/design/agent-dashboard.html
+++ b/design/agent-dashboard.html
@@ -1,0 +1,3280 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Reasonix · Dashboard · Web-companion design</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+/* ============================================================================
+   Reasonix Dashboard — design anchor for the web companion to the TUI.
+
+   Positioning: NOT a TUI mirror. Does what the TUI cannot:
+     - long-form session reading
+     - real charts (usage / cost / latency)
+     - multi-file editing
+     - browsing inventories (tools, MCP servers, skills, memory)
+
+   Aesthetic: TUI heritage (palette, glyph icons, sharp edges) + web fluency
+     (sans-serif body, real form controls, hover states, modal dialogs).
+     NOT slavish terminal mimicry — that's a portfolio gimmick, not a tool.
+   ============================================================================ */
+:root {
+  /* Surfaces — same family as TUI, slightly lifted for screen comfort */
+  --bg:         #0a0c10;
+  --bg-elev:    #11141a;
+  --bg-elev-2:  #161a22;
+  --bg-input:   #0d1015;
+  --bg-code:    #06080c;
+  --bg-hover:   #1a1f29;
+
+  /* Text */
+  --fg-0:       #e6edf3;   /* primary */
+  --fg-1:       #c9d1d9;   /* body */
+  --fg-2:       #8b949e;   /* secondary */
+  --fg-3:       #6e7681;   /* dim */
+  --fg-4:       #484f58;   /* very dim, separators in text */
+
+  /* Accents — TUI lineage, unchanged */
+  --c-brand:    #79c0ff;   /* sky      — in-progress, links */
+  --c-accent:   #d2a8ff;   /* purple   — reasoning, plan */
+  --c-violet:   #b395f5;   /* violet   — sub-agent */
+  --c-ok:       #7ee787;   /* green    — success */
+  --c-warn:     #f0b07d;   /* amber    — warning, approval */
+  --c-err:      #ff8b81;   /* coral    — error */
+  --c-info:     #79c0ff;
+
+  /* Chart spectrum — for series; 6-stop gradient that reads in dark mode */
+  --s1: #79c0ff;  /* sky */
+  --s2: #56d4dd;  /* teal */
+  --s3: #7ee787;  /* mint */
+  --s4: #f0b07d;  /* amber */
+  --s5: #ff8b81;  /* coral */
+  --s6: #d2a8ff;  /* purple */
+
+  /* Borders */
+  --bd:         #1a1d24;
+  --bd-strong:  #232831;
+
+  --font-sans:  'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  --font-mono:  'JetBrains Mono', ui-monospace, 'SF Mono', 'Cascadia Code', Menlo, Consolas, monospace;
+
+  /* Spacing / radius — tiny radius (2px) keeps web feel without going SaaS */
+  --r:    2px;
+  --r-md: 4px;
+}
+
+* { box-sizing: border-box; }
+html, body { background: var(--bg); color: var(--fg-1); margin: 0; padding: 0; }
+body {
+  font-family: var(--font-sans);
+  font-size: 14px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+code, .mono { font-family: var(--font-mono); }
+
+a { color: var(--c-brand); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+/* ── Doc chrome ─────────────────────────────────────────────────────────── */
+.page {
+  display: grid;
+  grid-template-columns: 240px minmax(0, 1fr);
+  max-width: 1320px;
+  margin: 0 auto;
+  min-height: 100vh;
+}
+.toc {
+  position: sticky; top: 0; align-self: start;
+  height: 100vh; overflow-y: auto;
+  border-right: 1px solid var(--bd);
+  padding: 28px 18px;
+  background: var(--bg);
+}
+.toc h1 { font-size: 14px; font-weight: 700; margin: 0 0 4px; color: var(--fg-0); letter-spacing: .03em; font-family: var(--font-mono); }
+.toc h1 .dot { color: var(--c-brand); margin-right: 8px; }
+.toc .sub { font-size: 11px; color: var(--fg-3); margin: 0 0 18px; letter-spacing: .04em; }
+.toc-section { font-size: 10px; text-transform: uppercase; letter-spacing: .14em; color: var(--fg-4); margin: 22px 0 6px; font-weight: 700; }
+.toc-section:first-of-type { margin-top: 0; }
+.toc ul { list-style: none; padding: 0; margin: 0; }
+.toc li a {
+  display: block; padding: 3px 8px; margin: 1px 0;
+  color: var(--fg-2); font-size: 12.5px; border-radius: var(--r);
+}
+.toc li a:hover { color: var(--fg-0); background: var(--bg-elev); text-decoration: none; }
+
+main { padding: 32px 40px 60px 32px; min-width: 0; }
+.section { padding: 28px 0 36px; border-bottom: 1px solid #14171e; }
+.section:last-child { border-bottom: none; }
+.section > h2 {
+  font-size: 22px; font-weight: 700; color: var(--fg-0);
+  margin: 0 0 4px; letter-spacing: -.005em; font-family: var(--font-mono);
+}
+.section > h2 .num { color: var(--fg-4); margin-right: 10px; font-weight: 500; }
+.section > .lede {
+  color: var(--fg-2); margin: 0 0 22px; font-size: 13px; max-width: 700px; line-height: 1.6;
+}
+.subsec { margin-bottom: 22px; }
+.subsec > h3 {
+  font-size: 13px; font-weight: 700; color: var(--fg-1);
+  margin: 24px 0 4px; letter-spacing: .04em; text-transform: uppercase;
+  font-family: var(--font-mono);
+}
+.subsec > h3 .desc { color: var(--fg-3); font-weight: 400; margin-left: 10px; font-size: 12px; text-transform: none; letter-spacing: 0; }
+.subsec > p { color: var(--fg-3); font-size: 12.5px; margin: 0 0 12px; max-width: 720px; line-height: 1.6; }
+
+/* "Mock" — a faux-window frame to display dashboard pieces inside the design doc */
+.mock {
+  background: var(--bg-elev);
+  border: 1px solid var(--bd);
+  border-radius: var(--r);
+  margin: 14px 0;
+  overflow: hidden;
+}
+.mock-cap {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-3);
+  margin: 18px 0 6px;
+  letter-spacing: .06em;
+}
+
+/* ── §1 Tokens display ─────────────────────────────────────────────────── */
+.swatches { display: grid; grid-template-columns: repeat(auto-fill, minmax(170px, 1fr)); gap: 8px; margin: 8px 0 14px; }
+.swatch {
+  background: var(--bg-elev); border: 1px solid var(--bd); padding: 10px 12px; border-radius: var(--r);
+  display: flex; align-items: center; gap: 10px;
+  font-family: var(--font-mono); font-size: 11.5px;
+}
+.swatch .chip { width: 22px; height: 22px; border-radius: var(--r); flex-shrink: 0; border: 1px solid rgba(255,255,255,.04); }
+.swatch .meta { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
+.swatch .name { color: var(--fg-1); font-size: 11.5px; }
+.swatch .hex { color: var(--fg-3); font-size: 10.5px; }
+
+.scale-row { display: flex; align-items: baseline; gap: 16px; padding: 6px 0; border-bottom: 1px dashed #181b22; }
+.scale-row:last-child { border-bottom: none; }
+.scale-row .lbl { font-family: var(--font-mono); font-size: 10.5px; color: var(--fg-3); width: 70px; flex-shrink: 0; }
+.scale-row .ex { color: var(--fg-1); }
+
+.glyph-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(110px, 1fr)); gap: 6px; }
+.glyph-cell {
+  background: var(--bg-elev); border: 1px solid var(--bd); padding: 8px 10px; border-radius: var(--r);
+  display: flex; align-items: center; gap: 10px; font-family: var(--font-mono); font-size: 12px;
+}
+.glyph-cell .g { color: var(--c-brand); font-size: 16px; width: 18px; text-align: center; }
+.glyph-cell .n { color: var(--fg-2); font-size: 11px; }
+
+/* ── App shell — sidebar / topbar / statusrow ──────────────────────────── */
+.app {
+  display: grid;
+  grid-template-columns: 220px minmax(0, 1fr);
+  grid-template-rows: 44px 1fr 26px;
+  grid-template-areas:
+    "side  top"
+    "side  body"
+    "side  status";
+  height: 640px;
+  background: var(--bg);
+  font-size: 13px;
+}
+.app.collapsed { grid-template-columns: 56px minmax(0, 1fr); }
+
+/* Sidebar */
+.app-side {
+  grid-area: side;
+  background: var(--bg-elev);
+  border-right: 1px solid var(--bd);
+  display: flex; flex-direction: column;
+}
+.app-side .brand {
+  padding: 14px 16px 12px; display: flex; align-items: center; gap: 8px;
+  font-family: var(--font-mono); font-size: 13px; font-weight: 700; color: var(--fg-0);
+  letter-spacing: .08em;
+}
+.app-side .brand .glyph { color: var(--c-brand); font-size: 16px; }
+.app-side .brand .ver { color: var(--fg-4); font-size: 10.5px; margin-left: auto; font-weight: 400; letter-spacing: .04em; }
+.app.collapsed .app-side .brand .label,
+.app.collapsed .app-side .brand .ver { display: none; }
+
+.side-tabs { padding: 6px 8px; flex: 1; overflow-y: auto; }
+.side-tab {
+  display: flex; align-items: center; gap: 10px;
+  padding: 6px 10px; margin: 1px 0;
+  color: var(--fg-2); font-family: var(--font-mono); font-size: 12px;
+  border-radius: var(--r); cursor: pointer;
+  border-left: 2px solid transparent;
+  letter-spacing: .02em;
+}
+.side-tab .g { font-family: var(--font-mono); font-size: 13px; width: 16px; text-align: center; color: var(--fg-3); flex-shrink: 0; }
+.side-tab:hover { background: var(--bg-hover); color: var(--fg-0); }
+.side-tab:hover .g { color: var(--fg-1); }
+.side-tab.active { background: var(--bg-hover); color: var(--fg-0); border-left-color: var(--c-brand); }
+.side-tab.active .g { color: var(--c-brand); }
+.side-tab .badge { margin-left: auto; font-family: var(--font-mono); font-size: 10px; color: var(--fg-3); background: var(--bg-elev-2); padding: 1px 5px; border-radius: 8px; }
+.app.collapsed .side-tab .label,
+.app.collapsed .side-tab .badge { display: none; }
+.app.collapsed .side-tab { justify-content: center; padding: 8px; }
+
+.side-section { font-family: var(--font-mono); font-size: 10px; color: var(--fg-4); padding: 14px 14px 4px; letter-spacing: .12em; text-transform: uppercase; font-weight: 600; }
+.app.collapsed .side-section { display: none; }
+
+.side-foot {
+  padding: 8px; border-top: 1px solid var(--bd); display: flex; align-items: center; gap: 8px;
+  font-family: var(--font-mono); font-size: 11px; color: var(--fg-3);
+}
+.side-foot .toggle { margin-left: auto; cursor: pointer; color: var(--fg-3); padding: 2px 6px; border-radius: var(--r); }
+.side-foot .toggle:hover { color: var(--fg-1); background: var(--bg-hover); }
+.app.collapsed .side-foot .label { display: none; }
+
+/* Top bar */
+.app-top {
+  grid-area: top;
+  display: flex; align-items: center; gap: 12px;
+  padding: 0 16px;
+  background: var(--bg-elev);
+  border-bottom: 1px solid var(--bd);
+  font-family: var(--font-mono); font-size: 12px;
+}
+.app-top .ws { color: var(--fg-1); display: flex; align-items: center; gap: 6px; }
+.app-top .ws .path { color: var(--fg-2); }
+.app-top .ws .branch { color: var(--c-ok); padding: 1px 5px; background: rgba(126,231,135,.08); border-radius: var(--r); font-size: 10.5px; }
+.app-top .sep { color: var(--fg-4); margin: 0 4px; }
+.app-top .session { color: var(--c-accent); }
+.app-top .grow { flex: 1; }
+.app-top .meter { display: flex; align-items: center; gap: 6px; color: var(--fg-2); }
+.app-top .meter .v { color: var(--fg-0); font-weight: 600; }
+.app-top .meter .lbl { color: var(--fg-4); font-size: 10.5px; }
+
+/* Body / panel content slot */
+.app-body {
+  grid-area: body;
+  overflow-y: auto;
+  padding: 24px 28px;
+}
+
+/* Status row */
+.app-status {
+  grid-area: status;
+  display: flex; align-items: center; gap: 14px;
+  padding: 0 14px;
+  background: var(--bg-elev);
+  border-top: 1px solid var(--bd);
+  font-family: var(--font-mono); font-size: 11px; color: var(--fg-3);
+}
+.app-status .item { display: flex; align-items: center; gap: 4px; }
+.app-status .item .v { color: var(--fg-1); }
+.app-status .item .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--c-ok); }
+.app-status .item .dot.warn { background: var(--c-warn); }
+.app-status .item .dot.err { background: var(--c-err); }
+.app-status .grow { flex: 1; }
+
+/* ── §3 Components ─────────────────────────────────────────────────────── */
+
+/* Card */
+.card {
+  background: var(--bg-elev);
+  border: 1px solid var(--bd);
+  border-radius: var(--r);
+  padding: 14px 16px;
+}
+.card.accent-brand   { border-left: 2px solid var(--c-brand); }
+.card.accent-accent  { border-left: 2px solid var(--c-accent); }
+.card.accent-warn    { border-left: 2px solid var(--c-warn); }
+.card.accent-err     { border-left: 2px solid var(--c-err); }
+.card-h { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; }
+.card-h .glyph { font-family: var(--font-mono); color: var(--c-brand); font-size: 14px; }
+.card-h .title { color: var(--fg-0); font-weight: 600; font-size: 13px; }
+.card-h .meta { margin-left: auto; color: var(--fg-3); font-family: var(--font-mono); font-size: 11px; }
+.card-b { color: var(--fg-1); font-size: 13px; line-height: 1.55; }
+
+/* Pill */
+.pill {
+  display: inline-flex; align-items: center; gap: 4px;
+  font-family: var(--font-mono); font-size: 10.5px; font-weight: 600;
+  padding: 1px 7px;
+  border-radius: 9px;
+  background: var(--bg-elev-2);
+  color: var(--fg-2);
+  letter-spacing: .04em;
+}
+.pill .g { font-size: 9px; }
+.pill.ok   { color: var(--c-ok);     background: rgba(126,231,135,.08); }
+.pill.warn { color: var(--c-warn);   background: rgba(240,176,125,.10); }
+.pill.err  { color: var(--c-err);    background: rgba(255,139,129,.10); }
+.pill.info { color: var(--c-brand);  background: rgba(121,192,255,.10); }
+.pill.acc  { color: var(--c-accent); background: rgba(210,168,255,.10); }
+
+/* Table */
+.tbl { width: 100%; border-collapse: collapse; font-size: 12.5px; }
+.tbl th, .tbl td { padding: 8px 10px; text-align: left; border-bottom: 1px solid var(--bd); }
+.tbl th { font-family: var(--font-mono); font-size: 10.5px; font-weight: 600; color: var(--fg-3); text-transform: uppercase; letter-spacing: .08em; background: var(--bg-elev); }
+.tbl td { color: var(--fg-1); }
+.tbl tbody tr:hover { background: var(--bg-hover); }
+.tbl td.num { font-family: var(--font-mono); text-align: right; color: var(--fg-0); font-variant-numeric: tabular-nums; }
+.tbl td.dim { color: var(--fg-3); }
+.tbl td.path { font-family: var(--font-mono); font-size: 11.5px; color: var(--fg-2); }
+
+/* Toast */
+.toast-wrap { display: flex; flex-direction: column; gap: 8px; max-width: 360px; }
+.toast {
+  background: var(--bg-elev-2); border: 1px solid var(--bd);
+  border-left: 2px solid var(--c-brand);
+  padding: 10px 12px; border-radius: var(--r);
+  display: flex; align-items: flex-start; gap: 8px;
+  font-size: 12.5px; color: var(--fg-1);
+}
+.toast .g { font-family: var(--font-mono); color: var(--c-brand); font-size: 13px; flex-shrink: 0; margin-top: 1px; }
+.toast.ok { border-left-color: var(--c-ok); } .toast.ok .g { color: var(--c-ok); }
+.toast.warn { border-left-color: var(--c-warn); } .toast.warn .g { color: var(--c-warn); }
+.toast.err  { border-left-color: var(--c-err); }  .toast.err .g  { color: var(--c-err); }
+.toast .x { margin-left: auto; color: var(--fg-3); cursor: pointer; }
+.toast .x:hover { color: var(--fg-0); }
+
+/* Code block */
+.code {
+  background: var(--bg-code);
+  border: 1px solid var(--bd);
+  border-radius: var(--r);
+  padding: 10px 14px;
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  color: var(--fg-1);
+  white-space: pre;
+  overflow-x: auto;
+  line-height: 1.6;
+}
+.code .ln { color: var(--fg-4); user-select: none; padding-right: 14px; }
+.code .kw { color: var(--c-accent); }
+.code .str { color: var(--c-ok); }
+.code .com { color: var(--fg-3); font-style: italic; }
+.code .num { color: var(--c-warn); }
+
+/* Diff */
+.diff {
+  background: var(--bg-code); border: 1px solid var(--bd); border-radius: var(--r);
+  font-family: var(--font-mono); font-size: 12px; line-height: 1.55;
+  overflow: hidden;
+}
+.diff-h { padding: 6px 12px; background: var(--bg-elev); color: var(--fg-2); font-size: 11px; border-bottom: 1px solid var(--bd); display: flex; gap: 12px; align-items: center; }
+.diff-h .file { color: var(--fg-1); }
+.diff-h .stat { margin-left: auto; }
+.diff-h .stat .add { color: var(--c-ok); }
+.diff-h .stat .rem { color: var(--c-err); }
+.diff-row { display: grid; grid-template-columns: 32px 32px 1fr; }
+.diff-row .gut { color: var(--fg-4); padding: 0 8px; text-align: right; user-select: none; }
+.diff-row .txt { padding: 0 10px; white-space: pre; }
+.diff-row.add { background: rgba(126,231,135,.06); }
+.diff-row.add .gut { color: var(--c-ok); }
+.diff-row.add .txt { color: var(--c-ok); }
+.diff-row.rem { background: rgba(255,139,129,.05); }
+.diff-row.rem .gut { color: var(--c-err); }
+.diff-row.rem .txt { color: var(--c-err); }
+.diff-row.ctx .txt { color: var(--fg-2); }
+.diff-row.hunk { background: var(--bg-elev); color: var(--fg-3); }
+.diff-row.hunk .txt, .diff-row.hunk .gut { color: var(--fg-3); }
+
+/* Chart frame */
+.chart {
+  background: var(--bg-elev); border: 1px solid var(--bd); border-radius: var(--r); padding: 14px 16px;
+}
+.chart-h { display: flex; align-items: baseline; gap: 8px; margin-bottom: 8px; }
+.chart-h .title { color: var(--fg-3); font-family: var(--font-mono); font-size: 11px; text-transform: uppercase; letter-spacing: .08em; }
+.chart-h .delta { margin-left: auto; font-family: var(--font-mono); font-size: 11px; }
+.chart-h .delta.up { color: var(--c-ok); }
+.chart-h .delta.down { color: var(--c-err); }
+.chart-v { font-family: var(--font-mono); font-size: 22px; font-weight: 700; color: var(--fg-0); margin-bottom: 4px; letter-spacing: -.01em; }
+.chart-v .unit { color: var(--fg-3); font-size: 13px; font-weight: 400; margin-left: 4px; }
+.chart-spark svg { width: 100%; height: 38px; display: block; }
+
+/* Form */
+.form-row { display: flex; flex-direction: column; gap: 4px; margin-bottom: 14px; }
+.form-row .lbl { font-family: var(--font-mono); font-size: 10.5px; color: var(--fg-3); text-transform: uppercase; letter-spacing: .08em; }
+.form-row .help { color: var(--fg-3); font-size: 11.5px; margin-top: 2px; }
+.input, .select, .textarea {
+  background: var(--bg-input); border: 1px solid var(--bd); border-radius: var(--r);
+  padding: 6px 10px; color: var(--fg-0); font-family: var(--font-mono); font-size: 12.5px;
+  outline: none; width: 100%;
+}
+.input:focus, .select:focus, .textarea:focus { border-color: var(--c-brand); }
+.checkbox-row { display: flex; align-items: center; gap: 8px; font-size: 12.5px; color: var(--fg-1); }
+.checkbox-row .box { width: 13px; height: 13px; border: 1px solid var(--bd-strong); border-radius: var(--r); display: inline-flex; align-items: center; justify-content: center; background: var(--bg-input); }
+.checkbox-row .box.on { background: var(--c-brand); border-color: var(--c-brand); color: var(--bg); font-family: var(--font-mono); font-size: 10px; font-weight: 700; }
+
+.btn {
+  display: inline-flex; align-items: center; gap: 6px;
+  background: var(--bg-elev-2); border: 1px solid var(--bd-strong); color: var(--fg-1);
+  padding: 5px 12px; border-radius: var(--r);
+  font-family: var(--font-mono); font-size: 12px; font-weight: 600; cursor: pointer;
+  letter-spacing: .02em;
+}
+.btn:hover { background: var(--bg-hover); color: var(--fg-0); border-color: var(--fg-4); }
+.btn.primary { background: var(--c-brand); color: var(--bg); border-color: var(--c-brand); }
+.btn.primary:hover { background: #94cdff; border-color: #94cdff; color: var(--bg); }
+.btn.ghost { background: transparent; }
+.btn .g { font-size: 11px; }
+
+/* ── Progress ─────────────────────────────────────────────────────────── */
+/* Linear bar */
+.progress {
+  width: 100%; height: 6px; background: var(--bg-input);
+  border-radius: 3px; overflow: hidden; position: relative;
+}
+.progress-fill {
+  height: 100%; background: var(--c-brand);
+  transition: width .3s ease; border-radius: 3px;
+}
+.progress.thin  { height: 3px; }
+.progress.thick { height: 10px; }
+.progress.ok   .progress-fill { background: var(--c-ok); }
+.progress.warn .progress-fill { background: var(--c-warn); }
+.progress.err  .progress-fill { background: var(--c-err); }
+.progress.acc  .progress-fill { background: var(--c-accent); }
+
+/* Indeterminate — shimmer slice loops left-to-right */
+.progress.indet .progress-fill {
+  width: 30%; animation: progress-indet 1.4s linear infinite;
+}
+@keyframes progress-indet {
+  0%   { transform: translateX(-100%); }
+  100% { transform: translateX(400%); }
+}
+
+/* Segmented — multiple fills side by side, e.g. cache-hit / cache-miss split */
+.progress.segmented { display: flex; gap: 1px; background: transparent; padding: 0; height: 6px; }
+.progress.segmented .progress-seg { height: 100%; }
+.progress.segmented .progress-seg.s1 { background: var(--s1); }
+.progress.segmented .progress-seg.s2 { background: var(--s2); }
+.progress.segmented .progress-seg.s3 { background: var(--s3); }
+.progress.segmented .progress-seg.s4 { background: var(--s4); }
+.progress.segmented .progress-seg.s5 { background: var(--s5); }
+.progress.segmented .progress-seg.dim { background: var(--bg-input); }
+
+/* Progress with caption row */
+.progress-row { display: flex; align-items: center; gap: 10px; padding: 4px 0; }
+.progress-row .lbl { font-family: var(--font-mono); font-size: 11px; color: var(--fg-3); flex-shrink: 0; min-width: 110px; }
+.progress-row .v   { font-family: var(--font-mono); font-size: 11.5px; color: var(--fg-0); flex-shrink: 0; min-width: 60px; text-align: right; }
+.progress-row .progress { flex: 1; }
+
+/* Step progress — numbered dots connected by lines */
+.steps { display: flex; align-items: center; gap: 0; padding: 4px 0; }
+.step-dot {
+  width: 22px; height: 22px; border-radius: 50%; flex-shrink: 0;
+  background: var(--bg-input); border: 1px solid var(--bd-strong);
+  display: flex; align-items: center; justify-content: center;
+  font-family: var(--font-mono); font-size: 11px; color: var(--fg-3); font-weight: 600;
+}
+.step-dot.done   { background: var(--c-ok);    border-color: var(--c-ok);    color: var(--bg); }
+.step-dot.active { background: var(--c-brand); border-color: var(--c-brand); color: var(--bg); }
+.step-dot.fail   { background: var(--c-err);   border-color: var(--c-err);   color: var(--bg); }
+.step-line { flex: 1; height: 1px; background: var(--bd-strong); margin: 0 -1px; }
+.step-line.done   { background: var(--c-ok); }
+.step-line.active { background: linear-gradient(90deg, var(--c-ok), var(--c-brand)); }
+
+/* Ring — circular progress, anchors its own value text */
+.ring { position: relative; display: inline-block; line-height: 0; }
+.ring svg { transform: rotate(-90deg); display: block; }
+.ring-bg { fill: none; stroke: var(--bg-input); }
+.ring-fill { fill: none; stroke: var(--c-brand); stroke-linecap: round; transition: stroke-dashoffset .4s ease; }
+.ring.ok   .ring-fill { stroke: var(--c-ok); }
+.ring.warn .ring-fill { stroke: var(--c-warn); }
+.ring.err  .ring-fill { stroke: var(--c-err); }
+.ring-label { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; flex-direction: column; line-height: 1.1; }
+.ring-label .v { font-family: var(--font-mono); font-size: 14px; font-weight: 700; color: var(--fg-0); }
+.ring-label .u { font-family: var(--font-mono); font-size: 9px; color: var(--fg-3); text-transform: uppercase; letter-spacing: .08em; }
+
+/* ── Modal / Overlay ──────────────────────────────────────────────────── */
+.overlay {
+  position: relative;
+  background: rgba(6,8,12,.78);
+  padding: 28px;
+  border-radius: var(--r);
+  min-height: 280px;
+  display: flex; align-items: center; justify-content: center;
+}
+.overlay::before {
+  /* Box-drawing corner ticks at the four corners — TUI signature */
+  content: "";
+  position: absolute; inset: 8px;
+  border: 1px solid #14171e;
+  pointer-events: none;
+  border-radius: var(--r);
+}
+.dialog {
+  background: var(--bg-elev);
+  border: 1px solid var(--bd-strong);
+  border-radius: var(--r);
+  width: 100%; max-width: 540px;
+  box-shadow: 0 18px 48px rgba(0,0,0,.5), 0 0 0 1px rgba(255,255,255,.02);
+}
+.dialog-h {
+  padding: 11px 16px; border-bottom: 1px solid var(--bd);
+  display: flex; align-items: center; gap: 10px; font-family: var(--font-mono);
+}
+.dialog-h .glyph { font-size: 14px; color: var(--c-brand); }
+.dialog-h .title { color: var(--fg-0); font-weight: 600; font-size: 12.5px; letter-spacing: .04em; text-transform: uppercase; }
+.dialog-h .meta  { margin-left: auto; font-size: 11px; color: var(--fg-3); }
+.dialog-b { padding: 14px 16px; }
+.dialog-f { padding: 10px 16px; border-top: 1px solid var(--bd); display: flex; align-items: center; gap: 8px; }
+.dialog-f .grow { flex: 1; }
+.dialog-f .hint { font-family: var(--font-mono); font-size: 10.5px; color: var(--fg-4); }
+
+.dialog.warn .dialog-h .glyph,
+.dialog.warn .dialog-h .title { color: var(--c-warn); }
+.dialog.warn { border-top: 2px solid var(--c-warn); }
+
+.dialog.acc .dialog-h .glyph,
+.dialog.acc .dialog-h .title { color: var(--c-accent); }
+.dialog.acc { border-top: 2px solid var(--c-accent); }
+
+/* Command palette — centered, larger, search-driven */
+.cmd-palette {
+  background: var(--bg-elev);
+  border: 1px solid var(--bd-strong);
+  border-radius: var(--r);
+  width: 100%; max-width: 560px;
+  box-shadow: 0 24px 64px rgba(0,0,0,.6);
+  overflow: hidden;
+}
+.cmd-palette .cmd-input-row {
+  display: flex; align-items: center; gap: 10px; padding: 11px 16px;
+  border-bottom: 1px solid var(--bd);
+}
+.cmd-palette .cmd-input-row .g { font-family: var(--font-mono); color: var(--c-brand); font-size: 14px; }
+.cmd-palette .cmd-input-row input {
+  flex: 1; background: transparent; border: none; outline: none;
+  color: var(--fg-0); font-family: var(--font-mono); font-size: 14px;
+}
+.cmd-palette .cmd-input-row .kbd {
+  font-family: var(--font-mono); font-size: 10.5px; color: var(--fg-3);
+  border: 1px solid var(--bd); padding: 1px 5px; border-radius: var(--r); background: var(--bg-input);
+}
+.cmd-palette .cmd-list { padding: 4px 0; max-height: 320px; overflow-y: auto; }
+.cmd-row {
+  display: flex; align-items: center; gap: 10px; padding: 6px 16px;
+  cursor: pointer; font-size: 13px; color: var(--fg-1);
+}
+.cmd-row:hover, .cmd-row.sel { background: var(--bg-hover); }
+.cmd-row.sel { border-left: 2px solid var(--c-brand); padding-left: 14px; }
+.cmd-row .g { font-family: var(--font-mono); color: var(--c-brand); font-size: 12px; width: 14px; flex-shrink: 0; }
+.cmd-row .name { font-family: var(--font-mono); color: var(--fg-0); }
+.cmd-row .desc { color: var(--fg-3); font-size: 12px; margin-left: auto; }
+.cmd-row .kbd { font-family: var(--font-mono); font-size: 10.5px; color: var(--fg-3); border: 1px solid var(--bd); padding: 1px 5px; border-radius: var(--r); background: var(--bg-input); }
+.cmd-section-h { font-family: var(--font-mono); font-size: 10px; color: var(--fg-4); padding: 8px 16px 4px; text-transform: uppercase; letter-spacing: .12em; }
+
+/* Popover — anchored dropdown for slash / @ menus */
+.popover {
+  background: var(--bg-elev-2);
+  border: 1px solid var(--bd-strong);
+  border-radius: var(--r);
+  box-shadow: 0 12px 32px rgba(0,0,0,.5);
+  padding: 4px 0; min-width: 240px; max-width: 360px;
+}
+.popover-h { padding: 6px 12px 4px; font-family: var(--font-mono); font-size: 10px; color: var(--fg-4); text-transform: uppercase; letter-spacing: .12em; }
+.popover-row {
+  padding: 5px 12px; display: flex; align-items: center; gap: 8px;
+  font-size: 12.5px; color: var(--fg-1); cursor: pointer;
+}
+.popover-row:hover, .popover-row.sel { background: var(--bg-hover); }
+.popover-row.sel { border-left: 2px solid var(--c-brand); padding-left: 10px; }
+.popover-row .g { font-family: var(--font-mono); color: var(--c-brand); font-size: 12px; width: 14px; flex-shrink: 0; }
+.popover-row .name { font-family: var(--font-mono); color: var(--fg-0); }
+.popover-row .meta { margin-left: auto; color: var(--fg-3); font-family: var(--font-mono); font-size: 11px; }
+
+/* ── Composer (chat input, multi-line, with chips) ────────────────────── */
+.composer {
+  background: var(--bg-input); border: 1px solid var(--bd);
+  border-radius: var(--r); padding: 8px 10px;
+  display: flex; flex-direction: column; gap: 6px;
+}
+.composer:focus-within { border-color: var(--c-brand); }
+.composer-tags { display: flex; flex-wrap: wrap; gap: 4px; }
+.composer-chip {
+  display: inline-flex; align-items: center; gap: 4px;
+  background: var(--bg-elev-2); padding: 2px 6px 2px 8px;
+  border-radius: var(--r); font-family: var(--font-mono); font-size: 11px;
+  border: 1px solid var(--bd);
+}
+.composer-chip.attach { color: var(--c-brand); border-color: rgba(121,192,255,.25); }
+.composer-chip.paste  { color: var(--c-accent); border-color: rgba(210,168,255,.25); }
+.composer-chip .x { color: var(--fg-3); cursor: pointer; padding: 0 2px; }
+.composer-chip .x:hover { color: var(--fg-0); }
+.composer-text {
+  background: transparent; border: none; outline: none;
+  color: var(--fg-0); font-family: var(--font-mono); font-size: 13px;
+  width: 100%; resize: none; min-height: 22px; line-height: 1.6;
+  padding: 4px 0;
+}
+.composer-text .caret { display: inline-block; width: 8px; height: 16px; background: var(--c-brand); vertical-align: text-bottom; animation: caret 1s steps(2) infinite; margin-left: 1px; }
+@keyframes caret { 50% { opacity: 0; } }
+.composer-foot {
+  display: flex; align-items: center; gap: 14px; padding-top: 4px;
+  font-family: var(--font-mono); font-size: 10.5px; color: var(--fg-4);
+  border-top: 1px solid #14171e;
+}
+.composer-foot .grow { flex: 1; }
+.composer-foot .hint .kbd {
+  border: 1px solid var(--bd); padding: 0 4px; border-radius: var(--r);
+  color: var(--fg-3); margin: 0 2px; background: var(--bg-elev);
+}
+.composer-foot .send { color: var(--c-brand); cursor: pointer; }
+
+/* TUI status indicator (small pill in topbar) */
+.tui-status {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--font-mono); font-size: 10.5px;
+  padding: 2px 8px; border-radius: 9px;
+  background: var(--bg-elev-2); color: var(--fg-3); border: 1px solid var(--bd);
+}
+.tui-status .dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
+.tui-status.online  { color: var(--c-ok);   } .tui-status.online  .dot { background: var(--c-ok);   box-shadow: 0 0 6px rgba(126,231,135,.5); }
+.tui-status.laggy   { color: var(--c-warn); } .tui-status.laggy   .dot { background: var(--c-warn); }
+.tui-status.offline { color: var(--c-err);  } .tui-status.offline .dot { background: var(--c-err);  }
+
+/* ── Breadcrumbs — replace topbar `·` with `›` for crumb-style flow ───── */
+.crumbs { display: flex; align-items: center; gap: 6px; font-family: var(--font-mono); font-size: 12px; }
+.crumbs .crumb { color: var(--fg-1); }
+.crumbs .crumb.dim { color: var(--fg-3); }
+.crumbs .sep { color: var(--fg-4); }
+
+/* ── Sessions panel ──────────────────────────────────────────────────── */
+.sessions-grid { display: grid; grid-template-columns: 320px minmax(0, 1fr); gap: 14px; min-height: 540px; }
+.sessions-list { background: var(--bg-elev); border: 1px solid var(--bd); border-radius: var(--r); display: flex; flex-direction: column; overflow: hidden; }
+.sessions-list .ssl-h { padding: 10px 12px; border-bottom: 1px solid var(--bd); display: flex; align-items: center; gap: 8px; }
+.sessions-list .ssl-h input {
+  flex: 1; background: var(--bg-input); border: 1px solid var(--bd); border-radius: var(--r);
+  padding: 4px 8px; font-family: var(--font-mono); font-size: 12px; color: var(--fg-0); outline: none;
+}
+.sessions-list .ssl-h input:focus { border-color: var(--c-brand); }
+.sessions-list .ssl-rows { flex: 1; overflow-y: auto; }
+.ssl-row {
+  padding: 8px 12px; border-bottom: 1px solid #14171e; cursor: pointer;
+  display: flex; flex-direction: column; gap: 3px;
+}
+.ssl-row:hover { background: var(--bg-hover); }
+.ssl-row.sel { background: var(--bg-hover); border-left: 2px solid var(--c-brand); padding-left: 10px; }
+.ssl-row .name { font-family: var(--font-mono); font-size: 12.5px; color: var(--fg-0); }
+.ssl-row .preview { font-size: 11.5px; color: var(--fg-3); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.ssl-row .meta { display: flex; gap: 10px; font-family: var(--font-mono); font-size: 10.5px; color: var(--fg-4); margin-top: 2px; }
+.ssl-row .meta .v { color: var(--fg-2); }
+
+.sessions-detail { background: var(--bg-elev); border: 1px solid var(--bd); border-radius: var(--r); padding: 14px 16px; overflow: auto; }
+.sessions-detail-h { display: flex; align-items: baseline; gap: 12px; margin-bottom: 12px; padding-bottom: 12px; border-bottom: 1px solid var(--bd); }
+.sessions-detail-h .name { font-family: var(--font-mono); font-size: 14px; color: var(--fg-0); font-weight: 600; }
+.sessions-detail-h .ws   { font-family: var(--font-mono); font-size: 11px; color: var(--fg-3); }
+.sessions-detail-h .actions { margin-left: auto; display: flex; gap: 6px; }
+.sessions-detail-kpis { display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px; margin-bottom: 14px; }
+.sessions-detail-kpis .kp { padding: 8px 10px; background: var(--bg-input); border-radius: var(--r); }
+.sessions-detail-kpis .kp .lbl { font-family: var(--font-mono); font-size: 10px; color: var(--fg-4); text-transform: uppercase; letter-spacing: .1em; }
+.sessions-detail-kpis .kp .v   { font-family: var(--font-mono); font-size: 16px; color: var(--fg-0); font-weight: 600; margin-top: 2px; }
+
+/* ── File tree (Editor panel) ────────────────────────────────────────── */
+.tree { font-family: var(--font-mono); font-size: 12px; padding: 6px 0; user-select: none; }
+.tree-node {
+  padding: 3px 8px 3px 0; cursor: pointer; display: flex; align-items: center; gap: 4px;
+  color: var(--fg-2); border-left: 2px solid transparent;
+}
+.tree-node:hover { background: var(--bg-hover); color: var(--fg-1); }
+.tree-node.sel { background: var(--bg-hover); color: var(--c-brand); border-left-color: var(--c-brand); }
+.tree-node .indent { display: inline-block; width: 10px; flex-shrink: 0; }
+.tree-node .arrow { width: 10px; color: var(--fg-3); }
+.tree-node.open .arrow { color: var(--c-brand); }
+.tree-node .icon { width: 12px; color: var(--fg-3); flex-shrink: 0; }
+.tree-node .icon.dir { color: var(--c-brand); }
+.tree-node .icon.tsx { color: var(--c-brand); }
+.tree-node .icon.css { color: var(--c-accent); }
+.tree-node .icon.md  { color: var(--c-warn); }
+.tree-node .icon.json { color: var(--c-violet); }
+.tree-node .name { flex: 1; }
+.tree-node .badge { font-size: 9px; color: var(--c-warn); margin-left: 4px; }
+.tree-node .modified { color: var(--c-warn); font-size: 14px; line-height: 0.5; margin-left: 4px; }
+
+/* ── Editor tabs ─────────────────────────────────────────────────────── */
+.editor-tabs {
+  display: flex; border-bottom: 1px solid var(--bd); background: var(--bg-elev);
+  overflow-x: auto; scrollbar-width: none;
+}
+.editor-tabs::-webkit-scrollbar { display: none; }
+.editor-tab {
+  padding: 7px 14px; font-family: var(--font-mono); font-size: 12px;
+  color: var(--fg-3); border-right: 1px solid var(--bd);
+  display: flex; align-items: center; gap: 6px; cursor: pointer;
+  border-bottom: 2px solid transparent; margin-bottom: -1px; flex-shrink: 0;
+}
+.editor-tab:hover { color: var(--fg-1); background: var(--bg-hover); }
+.editor-tab.active { color: var(--fg-0); background: var(--bg); border-bottom-color: var(--c-brand); }
+.editor-tab .x { color: var(--fg-4); font-size: 10px; padding: 0 2px; border-radius: var(--r); }
+.editor-tab .x:hover { color: var(--fg-0); background: var(--bd); }
+.editor-tab .dot { width: 5px; height: 5px; border-radius: 50%; background: var(--c-warn); flex-shrink: 0; }
+
+/* ── Code editor area ────────────────────────────────────────────────── */
+.editor-area {
+  background: var(--bg-code); padding: 8px 0;
+  font-family: var(--font-mono); font-size: 12.5px; line-height: 1.6;
+  color: var(--fg-1); overflow: auto;
+  flex: 1; min-height: 0;
+}
+.editor-line {
+  display: grid; grid-template-columns: 44px 1fr;
+  padding: 0; white-space: pre;
+}
+.editor-line:hover { background: rgba(121,192,255,.04); }
+.editor-line.cur { background: rgba(121,192,255,.06); }
+.editor-line .lineno { color: var(--fg-4); text-align: right; padding-right: 14px; user-select: none; font-variant-numeric: tabular-nums; }
+.editor-line .ln-content { color: var(--fg-1); }
+.editor-line .ln-content .kw  { color: var(--c-accent); }
+.editor-line .ln-content .str { color: var(--c-ok); }
+.editor-line .ln-content .com { color: var(--fg-3); font-style: italic; }
+.editor-line .ln-content .num { color: var(--c-warn); }
+.editor-line .ln-content .typ { color: var(--c-violet); }
+.editor-line .ln-content .fn  { color: var(--c-brand); }
+.editor-line .ln-content .gut { color: var(--fg-4); }
+
+.editor-status {
+  display: flex; align-items: center; gap: 12px; padding: 4px 14px;
+  background: var(--bg-elev); border-top: 1px solid var(--bd);
+  font-family: var(--font-mono); font-size: 10.5px; color: var(--fg-3);
+}
+.editor-status .v { color: var(--fg-1); }
+.editor-status .grow { flex: 1; }
+.editor-status .glyph { color: var(--c-brand); }
+
+/* ── Filter chips ────────────────────────────────────────────────────── */
+.chips { display: flex; flex-wrap: wrap; gap: 6px; padding: 4px 0 8px; }
+.chip-f {
+  font-family: var(--font-mono); font-size: 11px; padding: 3px 9px;
+  border: 1px solid var(--bd); border-radius: 12px; cursor: pointer;
+  color: var(--fg-2); background: var(--bg-elev);
+  display: inline-flex; align-items: center; gap: 5px;
+}
+.chip-f:hover { background: var(--bg-hover); color: var(--fg-1); }
+.chip-f.active { color: var(--c-brand); border-color: var(--c-brand); background: rgba(121,192,255,.08); }
+.chip-f .ct { color: var(--fg-4); font-size: 10px; }
+.chip-f.active .ct { color: var(--c-brand); }
+.chip-f .x { color: var(--fg-4); padding: 0 2px; }
+
+/* ── Stacked bar (chart) ─────────────────────────────────────────────── */
+.stacked-bar { width: 100%; height: 12px; background: var(--bg-input); border-radius: var(--r); overflow: hidden; display: flex; }
+.stacked-bar > div { height: 100%; }
+
+/* ── Form sub-tabs ───────────────────────────────────────────────────── */
+.form-tabs {
+  display: flex; border-bottom: 1px solid var(--bd); margin-bottom: 14px; gap: 0;
+}
+.form-tab {
+  padding: 8px 14px; font-family: var(--font-mono); font-size: 12px;
+  color: var(--fg-3); cursor: pointer; border-bottom: 2px solid transparent;
+  margin-bottom: -1px; letter-spacing: .04em; text-transform: uppercase; font-size: 11px;
+}
+.form-tab:hover { color: var(--fg-1); }
+.form-tab.active { color: var(--fg-0); border-bottom-color: var(--c-brand); }
+
+/* ── Schema (JSON-like display) ──────────────────────────────────────── */
+.schema {
+  font-family: var(--font-mono); font-size: 11.5px; color: var(--fg-1); line-height: 1.7;
+  padding: 10px 14px; background: var(--bg-code); border-radius: var(--r);
+  border: 1px solid var(--bd); white-space: pre; overflow-x: auto;
+}
+.schema .key { color: var(--c-brand); }
+.schema .typ { color: var(--c-violet); }
+.schema .req { color: var(--c-warn); font-style: italic; font-size: 10px; }
+.schema .com { color: var(--fg-3); font-style: italic; }
+.schema .str { color: var(--c-ok); }
+
+/* ── Log tail ────────────────────────────────────────────────────────── */
+.log-tail {
+  font-family: var(--font-mono); font-size: 11.5px; color: var(--fg-2);
+  padding: 10px 14px; background: var(--bg-code); border: 1px solid var(--bd);
+  border-radius: var(--r); line-height: 1.7; max-height: 240px; overflow-y: auto;
+  white-space: pre;
+}
+.log-tail .ts   { color: var(--fg-4); }
+.log-tail .lvl  { display: inline-block; width: 50px; }
+.log-tail .info { color: var(--c-info); }
+.log-tail .warn { color: var(--c-warn); }
+.log-tail .err  { color: var(--c-err); }
+.log-tail .ok   { color: var(--c-ok); }
+.log-tail .src  { color: var(--c-accent); }
+
+/* ── Search result card ──────────────────────────────────────────────── */
+.sr-card { padding: 10px 14px; border-bottom: 1px solid #14171e; cursor: pointer; }
+.sr-card:hover { background: var(--bg-hover); }
+.sr-card .sr-h { display: flex; align-items: baseline; gap: 8px; margin-bottom: 4px; }
+.sr-card .sr-path  { font-family: var(--font-mono); font-size: 12px; color: var(--c-brand); }
+.sr-card .sr-loc   { font-family: var(--font-mono); font-size: 10.5px; color: var(--fg-3); }
+.sr-card .sr-score { font-family: var(--font-mono); font-size: 10.5px; color: var(--fg-4); margin-left: auto; }
+.sr-card .sr-snip  { font-family: var(--font-mono); font-size: 11.5px; color: var(--fg-2); padding: 4px 0 0; white-space: pre; overflow-x: auto; }
+.sr-card .sr-snip mark { background: rgba(240,176,125,.18); color: var(--c-warn); padding: 0 2px; border-radius: 1px; }
+
+/* ── Health grid ─────────────────────────────────────────────────────── */
+.health-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 8px; }
+.health-item {
+  padding: 10px 12px; background: var(--bg-elev); border: 1px solid var(--bd);
+  border-left: 2px solid var(--c-ok); border-radius: var(--r);
+}
+.health-item.warn { border-left-color: var(--c-warn); }
+.health-item.err  { border-left-color: var(--c-err); }
+.health-item .lbl { font-family: var(--font-mono); font-size: 10.5px; color: var(--fg-3); text-transform: uppercase; letter-spacing: .08em; display: flex; align-items: center; gap: 6px; }
+.health-item .lbl .pill { font-size: 9px; padding: 0 5px; }
+.health-item .v    { font-family: var(--font-mono); font-size: 13px; color: var(--fg-0); margin-top: 4px; }
+.health-item .meta { font-family: var(--font-mono); font-size: 10.5px; color: var(--fg-3); margin-top: 2px; }
+
+/* ── Plan timeline (horizontal step bar with detail) ─────────────────── */
+.plan-timeline {
+  display: grid; grid-auto-flow: column; grid-auto-columns: 1fr;
+  gap: 0; padding: 6px 0;
+}
+.plan-step {
+  position: relative; padding: 8px 10px;
+  border-top: 2px solid var(--bd-strong);
+  display: flex; flex-direction: column; gap: 2px;
+}
+.plan-step.done   { border-top-color: var(--c-ok); }
+.plan-step.active { border-top-color: var(--c-brand); }
+.plan-step.fail   { border-top-color: var(--c-err); }
+.plan-step::before {
+  content: ""; position: absolute; top: -5px; left: 0;
+  width: 8px; height: 8px; border-radius: 50%; background: var(--bd-strong);
+}
+.plan-step.done::before   { background: var(--c-ok); }
+.plan-step.active::before { background: var(--c-brand); box-shadow: 0 0 0 3px rgba(121,192,255,.18); }
+.plan-step.fail::before   { background: var(--c-err); }
+.plan-step .lbl  { font-family: var(--font-mono); font-size: 10px; color: var(--fg-4); text-transform: uppercase; letter-spacing: .08em; }
+.plan-step .name { font-family: var(--font-mono); font-size: 12px; color: var(--fg-1); }
+.plan-step.active .name { color: var(--fg-0); }
+.plan-step.done   .name { color: var(--fg-2); }
+.plan-step .meta { font-family: var(--font-mono); font-size: 10.5px; color: var(--fg-3); }
+
+/* ── Donut chart (SVG inline) ────────────────────────────────────────── */
+.donut-legend { display: grid; grid-template-columns: 1fr; gap: 4px; padding-left: 8px; font-family: var(--font-mono); font-size: 11px; }
+.donut-legend .row { display: flex; align-items: center; gap: 6px; color: var(--fg-2); }
+.donut-legend .row .dot { width: 8px; height: 8px; border-radius: 2px; flex-shrink: 0; }
+.donut-legend .row .v { color: var(--fg-0); margin-left: auto; }
+
+/* ── Two-column inventory layout ─────────────────────────────────────── */
+.inv-grid { display: grid; grid-template-columns: minmax(0, 1fr) 320px; gap: 14px; }
+
+/* ── Sub-tabs sidebar variant for Configuration ──────────────────────── */
+.cfg-grid { display: grid; grid-template-columns: 200px minmax(0, 1fr); gap: 14px; }
+.cfg-nav  { background: var(--bg-elev); border: 1px solid var(--bd); border-radius: var(--r); padding: 6px; }
+.cfg-nav .cfg-item {
+  padding: 6px 10px; font-family: var(--font-mono); font-size: 12px;
+  color: var(--fg-2); cursor: pointer; border-radius: var(--r);
+  display: flex; align-items: center; gap: 8px;
+  border-left: 2px solid transparent; padding-left: 8px;
+}
+.cfg-nav .cfg-item:hover { background: var(--bg-hover); color: var(--fg-1); }
+.cfg-nav .cfg-item.active { background: var(--bg-hover); color: var(--c-brand); border-left-color: var(--c-brand); }
+.cfg-content { background: var(--bg-elev); border: 1px solid var(--bd); border-radius: var(--r); padding: 16px 18px; }
+
+/* ── Hook event matrix ───────────────────────────────────────────────── */
+.matrix { font-family: var(--font-mono); font-size: 11px; }
+.matrix .row { display: grid; grid-template-columns: 160px repeat(6, 1fr); border-bottom: 1px solid var(--bd); }
+.matrix .row.h { color: var(--fg-3); padding-bottom: 4px; text-transform: uppercase; letter-spacing: .08em; font-size: 10px; }
+.matrix .row.h > div { padding: 6px 8px; text-align: center; }
+.matrix .row.h > div:first-child { text-align: left; }
+.matrix .cell {
+  padding: 6px 8px; text-align: center; color: var(--fg-3);
+  border-left: 1px solid var(--bd);
+  display: flex; align-items: center; justify-content: center; min-height: 28px;
+}
+.matrix .cell:first-child { border-left: none; text-align: left; justify-content: flex-start; color: var(--fg-1); }
+.matrix .cell.on  { color: var(--c-brand); background: rgba(121,192,255,.05); }
+.matrix .cell.off { color: var(--fg-4); }
+
+/* ── §4 Chat panel ─────────────────────────────────────────────────────── */
+.chat-banner {
+  background: rgba(121,192,255,.06);
+  border: 1px solid rgba(121,192,255,.18);
+  border-radius: var(--r);
+  padding: 10px 14px;
+  display: flex; align-items: center; gap: 12px;
+  margin-bottom: 16px;
+  font-size: 12.5px;
+}
+.chat-banner .g { color: var(--c-brand); font-family: var(--font-mono); font-size: 14px; }
+.chat-banner .txt { color: var(--fg-1); }
+.chat-banner .txt b { color: var(--fg-0); }
+.chat-banner .takeover { margin-left: auto; }
+
+.chat-grid { display: grid; grid-template-columns: minmax(0, 1fr) 280px; gap: 20px; }
+
+.chat-stream { display: flex; flex-direction: column; gap: 12px; }
+
+/* Chat cards — web-flavored cards, more breathing room than the TUI */
+.cc {
+  background: var(--bg-elev); border: 1px solid var(--bd); border-radius: var(--r);
+  padding: 12px 14px;
+}
+.cc-h { display: flex; align-items: center; gap: 8px; margin-bottom: 6px; font-family: var(--font-mono); font-size: 11.5px; }
+.cc-h .glyph { font-size: 13px; width: 14px; text-align: center; }
+.cc-h .role { font-weight: 600; letter-spacing: .04em; text-transform: uppercase; font-size: 10.5px; }
+.cc-h .meta { margin-left: auto; color: var(--fg-3); font-size: 10.5px; }
+.cc-b { color: var(--fg-1); font-size: 13.5px; line-height: 1.65; }
+.cc-b p { margin: 0 0 6px; }
+.cc-b p:last-child { margin-bottom: 0; }
+.cc-b code.inline { background: var(--bg-code); padding: 1px 5px; border-radius: var(--r); font-size: 12px; color: var(--c-accent); }
+
+.cc.user .cc-h .glyph, .cc.user .cc-h .role { color: var(--c-brand); }
+.cc.assistant .cc-h .glyph, .cc.assistant .cc-h .role { color: var(--c-ok); }
+.cc.tool .cc-h .glyph, .cc.tool .cc-h .role { color: var(--c-warn); }
+.cc.reasoning .cc-h .glyph, .cc.reasoning .cc-h .role { color: var(--c-accent); }
+.cc.reasoning .cc-b { color: var(--fg-2); font-size: 12.5px; font-style: italic; }
+
+.cc.tool .tool-args { margin-top: 6px; font-family: var(--font-mono); font-size: 11.5px; color: var(--fg-2); padding: 4px 8px; background: var(--bg-code); border-radius: var(--r); }
+.cc.tool .tool-out { margin-top: 8px; }
+
+/* Chat side rail */
+.chat-rail { display: flex; flex-direction: column; gap: 12px; }
+.rail-card {
+  background: var(--bg-elev); border: 1px solid var(--bd); border-radius: var(--r);
+  padding: 10px 12px;
+}
+.rail-card .rh {
+  font-family: var(--font-mono); font-size: 10px; color: var(--fg-4);
+  text-transform: uppercase; letter-spacing: .12em; margin-bottom: 8px;
+}
+.rail-step {
+  display: flex; align-items: flex-start; gap: 8px;
+  padding: 4px 0; font-size: 12.5px;
+}
+.rail-step .g { font-family: var(--font-mono); color: var(--fg-3); width: 14px; flex-shrink: 0; }
+.rail-step.done .g { color: var(--c-ok); }
+.rail-step.active .g { color: var(--c-brand); }
+.rail-step.active { color: var(--fg-0); }
+.rail-step.done { color: var(--fg-2); text-decoration: line-through; text-decoration-color: var(--fg-4); }
+
+.rail-kv { display: flex; justify-content: space-between; padding: 2px 0; font-family: var(--font-mono); font-size: 11.5px; }
+.rail-kv .k { color: var(--fg-3); }
+.rail-kv .v { color: var(--fg-0); }
+
+/* ── §5 Overview cockpit ────────────────────────────────────────────────── */
+.cockpit { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 14px; }
+.cock-w-1 { grid-column: span 1; }
+.cock-w-2 { grid-column: span 2; }
+.cock-w-3 { grid-column: span 3; }
+.cock-w-4 { grid-column: span 4; }
+
+.kpi {
+  background: var(--bg-elev); border: 1px solid var(--bd); border-radius: var(--r); padding: 14px 16px;
+}
+.kpi .label { font-family: var(--font-mono); font-size: 10.5px; color: var(--fg-3); text-transform: uppercase; letter-spacing: .1em; margin-bottom: 6px; }
+.kpi .value { font-family: var(--font-mono); font-size: 24px; color: var(--fg-0); font-weight: 700; letter-spacing: -.01em; }
+.kpi .value .unit { font-size: 13px; color: var(--fg-3); font-weight: 400; margin-left: 4px; }
+.kpi .delta { font-family: var(--font-mono); font-size: 11px; margin-top: 4px; }
+.kpi .delta.up { color: var(--c-ok); }
+.kpi .delta.down { color: var(--c-err); }
+.kpi .delta.flat { color: var(--fg-3); }
+
+.cock-list {
+  background: var(--bg-elev); border: 1px solid var(--bd); border-radius: var(--r); padding: 12px 14px;
+}
+.cock-list .ch { display: flex; align-items: center; gap: 8px; padding-bottom: 8px; border-bottom: 1px solid var(--bd); margin-bottom: 8px; }
+.cock-list .ch .ttl { font-family: var(--font-mono); font-size: 11px; color: var(--fg-3); text-transform: uppercase; letter-spacing: .1em; }
+.cock-list .ch a { margin-left: auto; font-family: var(--font-mono); font-size: 11px; color: var(--c-brand); }
+
+.feed-row {
+  display: grid; grid-template-columns: 14px 1fr auto; gap: 8px;
+  padding: 5px 0; font-size: 12.5px; align-items: center;
+}
+.feed-row .g { font-family: var(--font-mono); color: var(--fg-3); }
+.feed-row.ok .g { color: var(--c-ok); }
+.feed-row.warn .g { color: var(--c-warn); }
+.feed-row.err .g { color: var(--c-err); }
+.feed-row .name { color: var(--fg-1); font-family: var(--font-mono); font-size: 12px; }
+.feed-row .when { color: var(--fg-4); font-family: var(--font-mono); font-size: 10.5px; }
+.feed-row .name .args { color: var(--fg-3); }
+
+/* Notes / "why" callouts */
+.why {
+  font-size: 12px; color: var(--fg-3); padding: 8px 12px;
+  border-left: 2px solid var(--c-accent); background: rgba(210,168,255,.04);
+  border-radius: 0 var(--r) var(--r) 0;
+  margin: 14px 0;
+}
+.why b { color: var(--fg-1); font-weight: 600; }
+</style>
+</head>
+
+<body>
+<div class="page">
+
+<aside class="toc">
+  <h1><span class="dot">◈</span>REASONIX</h1>
+  <p class="sub">dashboard · web-companion design</p>
+
+  <div class="toc-section">design</div>
+  <ul>
+    <li><a href="#tokens">§1 Tokens</a></li>
+    <li><a href="#shell">§2 Shell</a></li>
+    <li><a href="#components">§3 Components</a></li>
+  </ul>
+
+  <div class="toc-section">primary</div>
+  <ul>
+    <li><a href="#chat">§4 Chat</a></li>
+    <li><a href="#overview">§5 Overview</a></li>
+    <li><a href="#sessions">§6 Sessions</a></li>
+    <li><a href="#editor">§7 Editor</a></li>
+    <li><a href="#plans">§8 Plans</a></li>
+  </ul>
+
+  <div class="toc-section">observe</div>
+  <ul>
+    <li><a href="#usage">§9 Usage</a></li>
+    <li><a href="#system">§11 System</a></li>
+    <li><a href="#semantic">§12 Semantic</a></li>
+  </ul>
+
+  <div class="toc-section">configure</div>
+  <ul>
+    <li><a href="#inventories">§10 Inventories</a></li>
+    <li><a href="#configuration">§13 Hooks &amp; Settings</a></li>
+  </ul>
+
+  <div class="toc-section">notes</div>
+  <ul>
+    <li><a href="#positioning">§0 Positioning</a></li>
+    <li><a href="#open-questions">§14 Open questions</a></li>
+  </ul>
+</aside>
+
+<main>
+
+<section class="section" id="positioning">
+  <h2><span class="num">§0</span>Positioning</h2>
+  <p class="lede">
+    Reasonix's dashboard is the <b>rich-medium companion</b> to the TUI — not a mirror,
+    not a replacement. It does what a 13-row terminal pane cannot:
+    long-form reading, real charts, multi-file editing, large-table inventory browsing.
+    The TUI keeps the things terminals are good at — instant feedback, slash commands,
+    typing-loop latency.
+  </p>
+  <div class="why">
+    <b>Why not mirror the TUI?</b> Slavishly recreating the terminal in a browser
+    produces an unusable portfolio gimmick. Charts, hover tooltips, drag, and dense
+    tables are web-native; pretending otherwise wastes the medium.
+    <br><br>
+    <b>Why not replace the TUI?</b> Web input + AI streaming has higher latency than
+    a raw stdin keystroke loop. The TUI wins on responsiveness and stays the primary
+    surface; the dashboard is opened in a second tab when you want to read, look,
+    or configure.
+  </div>
+</section>
+
+<!-- ─────────────────────────────────────────────────────────────────────── -->
+<section class="section" id="tokens">
+  <h2><span class="num">§1</span>Tokens</h2>
+  <p class="lede">
+    Same core palette as the TUI mockup so that switching between TUI and dashboard
+    feels like one product. Slightly higher chroma allowed for chart series.
+  </p>
+
+  <div class="subsec">
+    <h3>Surfaces</h3>
+    <div class="swatches">
+      <div class="swatch"><div class="chip" style="background:#0a0c10"></div><div class="meta"><span class="name">--bg</span><span class="hex">#0a0c10</span></div></div>
+      <div class="swatch"><div class="chip" style="background:#11141a"></div><div class="meta"><span class="name">--bg-elev</span><span class="hex">#11141a</span></div></div>
+      <div class="swatch"><div class="chip" style="background:#161a22"></div><div class="meta"><span class="name">--bg-elev-2</span><span class="hex">#161a22</span></div></div>
+      <div class="swatch"><div class="chip" style="background:#0d1015"></div><div class="meta"><span class="name">--bg-input</span><span class="hex">#0d1015</span></div></div>
+      <div class="swatch"><div class="chip" style="background:#06080c"></div><div class="meta"><span class="name">--bg-code</span><span class="hex">#06080c</span></div></div>
+      <div class="swatch"><div class="chip" style="background:#1a1f29"></div><div class="meta"><span class="name">--bg-hover</span><span class="hex">#1a1f29</span></div></div>
+    </div>
+  </div>
+
+  <div class="subsec">
+    <h3>Text</h3>
+    <div class="swatches">
+      <div class="swatch"><div class="chip" style="background:#e6edf3"></div><div class="meta"><span class="name">--fg-0 primary</span><span class="hex">#e6edf3</span></div></div>
+      <div class="swatch"><div class="chip" style="background:#c9d1d9"></div><div class="meta"><span class="name">--fg-1 body</span><span class="hex">#c9d1d9</span></div></div>
+      <div class="swatch"><div class="chip" style="background:#8b949e"></div><div class="meta"><span class="name">--fg-2 secondary</span><span class="hex">#8b949e</span></div></div>
+      <div class="swatch"><div class="chip" style="background:#6e7681"></div><div class="meta"><span class="name">--fg-3 dim</span><span class="hex">#6e7681</span></div></div>
+      <div class="swatch"><div class="chip" style="background:#484f58"></div><div class="meta"><span class="name">--fg-4 separator</span><span class="hex">#484f58</span></div></div>
+    </div>
+  </div>
+
+  <div class="subsec">
+    <h3>Accents <span class="desc">role-coded — same meanings as TUI</span></h3>
+    <div class="swatches">
+      <div class="swatch"><div class="chip" style="background:#79c0ff"></div><div class="meta"><span class="name">--c-brand sky</span><span class="hex">in-progress, links</span></div></div>
+      <div class="swatch"><div class="chip" style="background:#d2a8ff"></div><div class="meta"><span class="name">--c-accent purple</span><span class="hex">reasoning, plan</span></div></div>
+      <div class="swatch"><div class="chip" style="background:#b395f5"></div><div class="meta"><span class="name">--c-violet</span><span class="hex">sub-agent</span></div></div>
+      <div class="swatch"><div class="chip" style="background:#7ee787"></div><div class="meta"><span class="name">--c-ok green</span><span class="hex">success</span></div></div>
+      <div class="swatch"><div class="chip" style="background:#f0b07d"></div><div class="meta"><span class="name">--c-warn amber</span><span class="hex">approval, warning</span></div></div>
+      <div class="swatch"><div class="chip" style="background:#ff8b81"></div><div class="meta"><span class="name">--c-err coral</span><span class="hex">error</span></div></div>
+    </div>
+  </div>
+
+  <div class="subsec">
+    <h3>Chart spectrum <span class="desc">six-stop series — distinguishes without shouting</span></h3>
+    <div class="swatches">
+      <div class="swatch"><div class="chip" style="background:#79c0ff"></div><div class="meta"><span class="name">s1 sky</span><span class="hex">primary</span></div></div>
+      <div class="swatch"><div class="chip" style="background:#56d4dd"></div><div class="meta"><span class="name">s2 teal</span><span class="hex">secondary</span></div></div>
+      <div class="swatch"><div class="chip" style="background:#7ee787"></div><div class="meta"><span class="name">s3 mint</span><span class="hex">tertiary</span></div></div>
+      <div class="swatch"><div class="chip" style="background:#f0b07d"></div><div class="meta"><span class="name">s4 amber</span><span class="hex">quaternary</span></div></div>
+      <div class="swatch"><div class="chip" style="background:#ff8b81"></div><div class="meta"><span class="name">s5 coral</span><span class="hex">accent / negative</span></div></div>
+      <div class="swatch"><div class="chip" style="background:#d2a8ff"></div><div class="meta"><span class="name">s6 purple</span><span class="hex">model boundary</span></div></div>
+    </div>
+  </div>
+
+  <div class="subsec">
+    <h3>Type</h3>
+    <p>Sans-serif (Inter) for prose; monospace (JetBrains Mono) for code, data, file paths, counts, glyphs, and section labels. Smaller text steps below 12px stay monospace — readability holds better at small sizes than narrow sans.</p>
+    <div class="scale-row"><span class="lbl">28 / 700</span><span class="ex" style="font-size:28px;color:var(--fg-0);font-weight:700;letter-spacing:-.01em">Headline · 28px</span></div>
+    <div class="scale-row"><span class="lbl">22 / 700 mono</span><span class="ex mono" style="font-size:22px;color:var(--fg-0);font-weight:700">Section title · 22px</span></div>
+    <div class="scale-row"><span class="lbl">14 / 400</span><span class="ex" style="font-size:14px;color:var(--fg-1)">Body — default reading size for prose. 14px Inter at 1.55 line-height.</span></div>
+    <div class="scale-row"><span class="lbl">12.5 / 400 mono</span><span class="ex mono" style="font-size:12.5px;color:var(--fg-1)">Code / data — JetBrains Mono</span></div>
+    <div class="scale-row"><span class="lbl">11 / 600 mono</span><span class="ex mono" style="font-size:11px;color:var(--fg-3);text-transform:uppercase;letter-spacing:.1em">SECTION LABEL · 11PX UPPERCASE</span></div>
+  </div>
+
+  <div class="subsec">
+    <h3>Glyphs <span class="desc">single-char icons reused from the TUI</span></h3>
+    <div class="glyph-grid">
+      <div class="glyph-cell"><span class="g">◈</span><span class="n">brand</span></div>
+      <div class="glyph-cell"><span class="g">◆</span><span class="n">chat</span></div>
+      <div class="glyph-cell"><span class="g">✎</span><span class="n">editor</span></div>
+      <div class="glyph-cell"><span class="g">⊞</span><span class="n">plan</span></div>
+      <div class="glyph-cell"><span class="g">›</span><span class="n">sessions</span></div>
+      <div class="glyph-cell"><span class="g">$</span><span class="n">usage</span></div>
+      <div class="glyph-cell"><span class="g">▣</span><span class="n">tools</span></div>
+      <div class="glyph-cell"><span class="g">▎</span><span class="n">permissions</span></div>
+      <div class="glyph-cell"><span class="g">+</span><span class="n">system</span></div>
+      <div class="glyph-cell"><span class="g">≈</span><span class="n">semantic</span></div>
+      <div class="glyph-cell"><span class="g">M</span><span class="n">mcp</span></div>
+      <div class="glyph-cell"><span class="g">S</span><span class="n">skills</span></div>
+      <div class="glyph-cell"><span class="g">·</span><span class="n">memory</span></div>
+      <div class="glyph-cell"><span class="g">H</span><span class="n">hooks</span></div>
+      <div class="glyph-cell"><span class="g">⌘</span><span class="n">settings</span></div>
+      <div class="glyph-cell"><span class="g">⏵</span><span class="n">streaming</span></div>
+      <div class="glyph-cell"><span class="g">↻</span><span class="n">reload</span></div>
+      <div class="glyph-cell"><span class="g">▲</span><span class="n">delta-up</span></div>
+      <div class="glyph-cell"><span class="g">▼</span><span class="n">delta-down</span></div>
+      <div class="glyph-cell"><span class="g">●</span><span class="n">status-dot</span></div>
+    </div>
+  </div>
+</section>
+
+<!-- ─────────────────────────────────────────────────────────────────────── -->
+<section class="section" id="shell">
+  <h2><span class="num">§2</span>Shell</h2>
+  <p class="lede">
+    The frame: sidebar, top context bar, body, status row.
+    Sidebar collapses to icon-only at narrow widths or on user toggle (state persisted).
+    Top bar carries the high-frequency context — workspace path, session, model, cost
+    — so panel content can be uncluttered.
+  </p>
+
+  <p class="mock-cap">— Default: sidebar expanded, Chat panel active</p>
+  <div class="mock">
+    <div class="app">
+      <aside class="app-side">
+        <div class="brand">
+          <span class="glyph">◈</span><span class="label">REASONIX</span>
+          <span class="ver">0.18.1</span>
+        </div>
+        <div class="side-section">workspace</div>
+        <div class="side-tabs">
+          <div class="side-tab active"><span class="g">◆</span><span class="label">Chat</span></div>
+          <div class="side-tab"><span class="g">✎</span><span class="label">Editor</span><span class="badge">3</span></div>
+          <div class="side-tab"><span class="g">⊞</span><span class="label">Plans</span><span class="badge">1</span></div>
+          <div class="side-tab"><span class="g">›</span><span class="label">Sessions</span></div>
+
+          <div class="side-section">observe</div>
+          <div class="side-tab"><span class="g">◈</span><span class="label">Overview</span></div>
+          <div class="side-tab"><span class="g">$</span><span class="label">Usage</span></div>
+          <div class="side-tab"><span class="g">+</span><span class="label">System</span></div>
+
+          <div class="side-section">configure</div>
+          <div class="side-tab"><span class="g">▣</span><span class="label">Tools</span></div>
+          <div class="side-tab"><span class="g">▎</span><span class="label">Permissions</span></div>
+          <div class="side-tab"><span class="g">M</span><span class="label">MCP</span><span class="badge">2</span></div>
+          <div class="side-tab"><span class="g">S</span><span class="label">Skills</span></div>
+          <div class="side-tab"><span class="g">·</span><span class="label">Memory</span></div>
+          <div class="side-tab"><span class="g">H</span><span class="label">Hooks</span></div>
+          <div class="side-tab"><span class="g">⌘</span><span class="label">Settings</span></div>
+        </div>
+        <div class="side-foot">
+          <span class="label">localhost:8742</span>
+          <span class="toggle" title="collapse">«</span>
+        </div>
+      </aside>
+
+      <header class="app-top">
+        <div class="crumbs">
+          <span class="crumb dim">~/work/reasonix</span>
+          <span class="sep">›</span>
+          <span class="crumb" style="color:var(--c-ok)">feat/dashboard-v2</span>
+          <span class="sep">›</span>
+          <span class="crumb" style="color:var(--c-accent)">2026-04-30-2014</span>
+        </div>
+        <span class="grow"></span>
+        <span class="tui-status online"><span class="dot"></span>TUI · #2</span>
+        <span class="meter"><span class="lbl">model</span><span class="v">deepseek-chat</span></span>
+        <span class="meter"><span class="lbl">balance</span><span class="v" style="color:var(--c-ok)">¥48.20</span></span>
+        <span class="meter"><span class="lbl">turn</span><span class="v">12</span></span>
+      </header>
+
+      <div class="app-body" style="display:flex;align-items:center;justify-content:center;color:var(--fg-3);font-family:var(--font-mono);font-size:12px">
+        — panel content slot —
+      </div>
+
+      <footer class="app-status">
+        <span class="item"><span class="dot"></span><span>tools <span class="v">23</span></span></span>
+        <span class="item"><span class="dot"></span><span>mcp <span class="v">2</span></span></span>
+        <span class="item"><span class="dot warn"></span><span>1 deferred</span></span>
+        <span class="grow"></span>
+        <span class="item">last event <span class="v">12s ago</span></span>
+      </footer>
+    </div>
+  </div>
+
+  <p class="mock-cap">— Sidebar collapsed (icon-only)</p>
+  <div class="mock">
+    <div class="app collapsed" style="height:340px">
+      <aside class="app-side">
+        <div class="brand"><span class="glyph">◈</span></div>
+        <div class="side-tabs">
+          <div class="side-tab active" title="Chat"><span class="g">◆</span></div>
+          <div class="side-tab" title="Editor"><span class="g">✎</span></div>
+          <div class="side-tab" title="Plans"><span class="g">⊞</span></div>
+          <div class="side-tab" title="Sessions"><span class="g">›</span></div>
+          <div class="side-tab" title="Overview"><span class="g">◈</span></div>
+          <div class="side-tab" title="Usage"><span class="g">$</span></div>
+          <div class="side-tab" title="System"><span class="g">+</span></div>
+          <div class="side-tab" title="Tools"><span class="g">▣</span></div>
+          <div class="side-tab" title="MCP"><span class="g">M</span></div>
+          <div class="side-tab" title="Settings"><span class="g">⌘</span></div>
+        </div>
+        <div class="side-foot">
+          <span class="toggle" title="expand">»</span>
+        </div>
+      </aside>
+      <header class="app-top">
+        <div class="crumbs">
+          <span class="crumb dim">~/work/reasonix</span>
+          <span class="sep">›</span>
+          <span class="crumb" style="color:var(--c-ok)">feat/dashboard-v2</span>
+        </div>
+        <span class="grow"></span>
+        <span class="tui-status online"><span class="dot"></span>TUI · #2</span>
+        <span class="meter"><span class="v" style="color:var(--c-ok)">¥48.20</span></span>
+      </header>
+      <div class="app-body" style="display:flex;align-items:center;justify-content:center;color:var(--fg-3);font-family:var(--font-mono);font-size:12px">— collapsed sidebar trades labels for icons; tooltips on hover —</div>
+      <footer class="app-status">
+        <span class="item">23 tools · 2 mcp · last 12s</span>
+      </footer>
+    </div>
+  </div>
+
+  <div class="why">
+    <b>Why a left sidebar instead of top tabs?</b>
+    14 panels won't fit horizontally. Vertical also lets us section them
+    (workspace · observe · configure) so muscle memory builds. Collapse-to-icons
+    keeps the option of tight-vertical dashboards (laptop) without losing the layout.
+  </div>
+</section>
+
+<!-- ─────────────────────────────────────────────────────────────────────── -->
+<section class="section" id="components">
+  <h2><span class="num">§3</span>Components</h2>
+  <p class="lede">
+    Building blocks every panel composes. Sharp corners and 1px hairlines
+    inherited from the TUI; web affordances (hover, focus rings, real form controls)
+    are added rather than emulated.
+  </p>
+
+  <div class="subsec">
+    <h3>Cards</h3>
+    <p>Every panel is a stack or grid of cards. The 2px left border encodes role: brand for in-progress, accent for plan/reasoning, warn for approval, err for failures.</p>
+    <div style="display:grid;grid-template-columns:repeat(2, 1fr);gap:12px">
+      <div class="card accent-brand">
+        <div class="card-h"><span class="glyph">⏵</span><span class="title">streaming · assistant</span><span class="meta">2.3s · 1.2k tok</span></div>
+        <div class="card-b">Looking up the exit code Windows uses when SIGTERM is delivered to a console subsystem process…</div>
+      </div>
+      <div class="card accent-accent">
+        <div class="card-h"><span class="glyph" style="color:var(--c-accent)">⊞</span><span class="title" style="color:var(--c-accent)">plan · awaiting approval</span><span class="meta">5 steps</span></div>
+        <div class="card-b">Refactor session sidecar lifecycle so <code class="mono" style="color:var(--c-accent)">.events.jsonl</code> rename/delete tracks the parent.</div>
+      </div>
+      <div class="card accent-warn">
+        <div class="card-h"><span class="glyph" style="color:var(--c-warn)">▲</span><span class="title" style="color:var(--c-warn)">shell · awaiting approval</span><span class="meta">deepseek</span></div>
+        <div class="card-b mono" style="font-size:12.5px">npm publish</div>
+      </div>
+      <div class="card accent-err">
+        <div class="card-h"><span class="glyph" style="color:var(--c-err)">✕</span><span class="title" style="color:var(--c-err)">tool error · run_command</span><span class="meta">exit 1</span></div>
+        <div class="card-b">Cannot publish over the previously published versions: 0.18.0.</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="subsec">
+    <h3>Pills</h3>
+    <p>Status chips. Always uppercase mono, always small. Use sparingly — too many pills in one row turns into noise.</p>
+    <div style="display:flex;flex-wrap:wrap;gap:6px">
+      <span class="pill ok">● ok</span>
+      <span class="pill warn">▲ warn</span>
+      <span class="pill err">✕ error</span>
+      <span class="pill info">⏵ active</span>
+      <span class="pill acc">⊞ plan</span>
+      <span class="pill">idle</span>
+      <span class="pill ok">passed 1665</span>
+      <span class="pill warn">deprecated</span>
+      <span class="pill err">retry 3/3</span>
+    </div>
+  </div>
+
+  <div class="subsec">
+    <h3>Tables</h3>
+    <p>Dense by default. Numeric columns are tabular-nums and right-aligned. Path / id columns get monospace. Header is uppercase 10.5px to keep the eye on the data.</p>
+    <div class="mock"><table class="tbl">
+      <thead><tr><th>Tool</th><th>Source</th><th class="mono">last call</th><th class="mono" style="text-align:right">calls</th><th class="mono" style="text-align:right">avg ms</th></tr></thead>
+      <tbody>
+        <tr><td><code class="mono">read_file</code></td><td class="dim">native · fs</td><td class="path">src/cli/ui/App.tsx</td><td class="num">142</td><td class="num">8</td></tr>
+        <tr><td><code class="mono">edit_file</code></td><td class="dim">native · fs</td><td class="path">src/cli/ui/PromptInput.tsx</td><td class="num">38</td><td class="num">14</td></tr>
+        <tr><td><code class="mono">run_command</code></td><td class="dim">native · shell</td><td class="path">npm run verify</td><td class="num">11</td><td class="num">23,400</td></tr>
+        <tr><td><code class="mono">grep_files</code></td><td class="dim">native · fs</td><td class="path">"workspace" src/</td><td class="num">9</td><td class="num">42</td></tr>
+        <tr><td><code class="mono">github__get_pr</code></td><td class="dim">mcp · github</td><td class="path">esengine/reasonix#13</td><td class="num">4</td><td class="num">280</td></tr>
+      </tbody>
+    </table></div>
+  </div>
+
+  <div class="subsec">
+    <h3>Toasts</h3>
+    <p>Top-right stack, auto-dismiss in 3s. Border-left encodes kind. One-line by default; expandable for tracebacks.</p>
+    <div class="toast-wrap" style="margin:6px 0 8px">
+      <div class="toast ok"><span class="g">●</span><div>Published <code class="mono" style="color:var(--c-ok)">reasonix@0.18.1</code> to npm</div><span class="x">×</span></div>
+      <div class="toast"><span class="g">⏵</span><div>3 events forwarded to <code class="mono">events.jsonl</code></div><span class="x">×</span></div>
+      <div class="toast warn"><span class="g">▲</span><div>0.18.0 has a deprecation notice — surface to users on launch?</div><span class="x">×</span></div>
+      <div class="toast err"><span class="g">✕</span><div>Failed to load skill <code class="mono">@reasonix/python-runner</code> — ENOENT</div><span class="x">×</span></div>
+    </div>
+  </div>
+
+  <div class="subsec">
+    <h3>Code blocks</h3>
+    <p>Kept close to the TUI's terminal feel — slightly darker than the panel surface, monospace, no ligatures-from-noise. Inline highlighting reuses accent colors.</p>
+<div class="code"><span class="ln">  1</span><span class="kw">export function</span> <span style="color:var(--fg-0)">listSessionsForWorkspace</span>(workspace<span class="kw">:</span> <span class="kw">string</span>)<span class="kw">:</span> <span class="kw">SessionInfo</span>[] {
+<span class="ln">  2</span>  <span class="com">// Strict match — legacy untagged sessions are hidden;</span>
+<span class="ln">  3</span>  <span class="com">// resume by name still works.</span>
+<span class="ln">  4</span>  <span class="kw">return</span> listSessions().filter((s) <span class="kw">=&gt;</span> s.meta.workspace <span class="kw">===</span> workspace);
+<span class="ln">  5</span>}</div>
+  </div>
+
+  <div class="subsec">
+    <h3>Diff view</h3>
+    <p>Unified by default; side-by-side available behind a toggle (Editor panel only). Add/remove rows tinted ~6% opacity over the code surface.</p>
+    <div class="diff">
+      <div class="diff-h"><span class="file mono">src/cli/commands/chat.tsx</span><span class="stat mono"><span class="add">+1</span> · <span class="rem">-2</span></span></div>
+      <div class="diff-row hunk"><span class="gut">@@</span><span class="gut"></span><span class="txt">@@ -346,8 +346,7 @@ export async function chatCommand</span></div>
+      <div class="diff-row ctx"><span class="gut">346</span><span class="gut">346</span><span class="txt">      session={resolvedSession}</span></div>
+      <div class="diff-row ctx"><span class="gut">347</span><span class="gut">347</span><span class="txt">    /&gt;,</span></div>
+      <div class="diff-row ctx"><span class="gut">348</span><span class="gut">348</span><span class="txt">    // patchConsole:false — winpty/MINTTY redraw-glitch source.</span></div>
+      <div class="diff-row rem"><span class="gut">349</span><span class="gut"></span><span class="txt">    // debug:true forces full-frame writes; log-update's diff drops frames…</span></div>
+      <div class="diff-row rem"><span class="gut">350</span><span class="gut"></span><span class="txt">    { exitOnCtrlC: true, patchConsole: false, debug: true },</span></div>
+      <div class="diff-row add"><span class="gut"></span><span class="gut">349</span><span class="txt">    { exitOnCtrlC: true, patchConsole: false },</span></div>
+      <div class="diff-row ctx"><span class="gut">351</span><span class="gut">350</span><span class="txt">  );</span></div>
+    </div>
+  </div>
+
+  <div class="subsec">
+    <h3>Charts</h3>
+    <p>Title in 11px uppercase mono · current value in 22px mono · sparkline below. Hover drives a tooltip with the date and exact value (handled by the chart lib at impl time, not in the mockup). Series follow the spectrum tokens.</p>
+    <div style="display:grid;grid-template-columns:repeat(3, 1fr);gap:12px">
+      <div class="chart">
+        <div class="chart-h"><span class="title">cost · 7 day</span><span class="delta up">▲ 12%</span></div>
+        <div class="chart-v">¥18.40<span class="unit">/day</span></div>
+        <div class="chart-spark">
+          <svg viewBox="0 0 200 38" preserveAspectRatio="none">
+            <polyline fill="none" stroke="#79c0ff" stroke-width="1.5" points="0,28 25,22 50,26 75,18 100,20 125,12 150,14 175,8 200,10"/>
+            <polyline fill="rgba(121,192,255,.10)" stroke="none" points="0,28 25,22 50,26 75,18 100,20 125,12 150,14 175,8 200,10 200,38 0,38"/>
+          </svg>
+        </div>
+      </div>
+      <div class="chart">
+        <div class="chart-h"><span class="title">tokens in · 7 day</span><span class="delta down">▼ 4%</span></div>
+        <div class="chart-v">142k<span class="unit">/day</span></div>
+        <div class="chart-spark">
+          <svg viewBox="0 0 200 38" preserveAspectRatio="none">
+            <polyline fill="none" stroke="#7ee787" stroke-width="1.5" points="0,12 25,18 50,14 75,22 100,16 125,24 150,20 175,28 200,22"/>
+            <polyline fill="rgba(126,231,135,.08)" stroke="none" points="0,12 25,18 50,14 75,22 100,16 125,24 150,20 175,28 200,22 200,38 0,38"/>
+          </svg>
+        </div>
+      </div>
+      <div class="chart">
+        <div class="chart-h"><span class="title">latency p95</span><span class="delta flat">— flat</span></div>
+        <div class="chart-v">2.4<span class="unit">s</span></div>
+        <div class="chart-spark">
+          <svg viewBox="0 0 200 38" preserveAspectRatio="none">
+            <polyline fill="none" stroke="#f0b07d" stroke-width="1.5" points="0,20 25,18 50,22 75,20 100,19 125,21 150,20 175,22 200,20"/>
+            <polyline fill="rgba(240,176,125,.08)" stroke="none" points="0,20 25,18 50,22 75,20 100,19 125,21 150,20 175,22 200,20 200,38 0,38"/>
+          </svg>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="subsec">
+    <h3>Progress <span class="desc">replaces every default browser bar</span></h3>
+    <p>The current dashboard leans on <code class="mono">&lt;progress&gt;</code> default styling — chrome-grey trough, OS-tinted fill, no role coding. Replace with a single <code class="mono">.progress</code> primitive: 6px tall, 3px thin variant, 10px thick variant, role tints (ok / warn / err / acc). Always paired with a tabular-nums numeric label. Indeterminate is a shimmer slice, not a spinning circle.</p>
+
+    <div style="display:grid;grid-template-columns:1fr 1fr;gap:24px;max-width:880px">
+      <div>
+        <div style="font-family:var(--font-mono);font-size:10px;color:var(--fg-3);text-transform:uppercase;letter-spacing:.1em;margin-bottom:6px">linear · with caption</div>
+        <div class="progress-row"><span class="lbl">turn iters</span><div class="progress"><div class="progress-fill" style="width:30%"></div></div><span class="v">3 / 10</span></div>
+        <div class="progress-row"><span class="lbl">budget</span><div class="progress warn"><div class="progress-fill" style="width:78%"></div></div><span class="v" style="color:var(--c-warn)">¥78 / 100</span></div>
+        <div class="progress-row"><span class="lbl">over cap</span><div class="progress err"><div class="progress-fill" style="width:103%"></div></div><span class="v" style="color:var(--c-err)">103%</span></div>
+        <div class="progress-row"><span class="lbl">cache hit</span><div class="progress ok"><div class="progress-fill" style="width:94%"></div></div><span class="v" style="color:var(--c-ok)">94%</span></div>
+        <div class="progress-row"><span class="lbl">reasoning</span><div class="progress acc"><div class="progress-fill" style="width:50%"></div></div><span class="v" style="color:var(--c-accent)">streaming</span></div>
+
+        <div style="font-family:var(--font-mono);font-size:10px;color:var(--fg-3);text-transform:uppercase;letter-spacing:.1em;margin:20px 0 6px">indeterminate · for unknown duration</div>
+        <div class="progress-row">
+          <span class="lbl">npm install</span>
+          <div class="progress indet"><div class="progress-fill"></div></div>
+          <span class="v" style="color:var(--fg-3)">…</span>
+        </div>
+        <p style="font-size:11.5px;color:var(--fg-3);margin:6px 0 0">A 30%-wide slice slides left-to-right on a 1.4s loop. No spinner — spinners read as "tab is busy"; a sliding bar reads as "this specific task is in flight."</p>
+
+        <div style="font-family:var(--font-mono);font-size:10px;color:var(--fg-3);text-transform:uppercase;letter-spacing:.1em;margin:20px 0 6px">thin · inline beside text</div>
+        <div style="font-size:12.5px;color:var(--fg-1);display:flex;align-items:center;gap:8px">
+          <span style="color:var(--fg-3);font-family:var(--font-mono);font-size:11px">verify</span>
+          <div class="progress thin ok" style="width:80px;flex-shrink:0"><div class="progress-fill" style="width:100%"></div></div>
+          <span style="color:var(--c-ok);font-family:var(--font-mono);font-size:11px">1665 / 1665</span>
+        </div>
+      </div>
+
+      <div>
+        <div style="font-family:var(--font-mono);font-size:10px;color:var(--fg-3);text-transform:uppercase;letter-spacing:.1em;margin-bottom:6px">segmented · breakdown of one whole</div>
+        <p style="font-size:11.5px;color:var(--fg-3);margin:0 0 6px">For ratios where each slice has its own meaning. Cache-hit / cache-miss is the canonical case.</p>
+        <div class="progress-row">
+          <span class="lbl">cache · 7d</span>
+          <div class="progress segmented" style="height:8px">
+            <div class="progress-seg s3" style="width:74%"></div>
+            <div class="progress-seg s4" style="width:18%"></div>
+            <div class="progress-seg s5" style="width:8%"></div>
+          </div>
+          <span class="v">100%</span>
+        </div>
+        <div style="display:flex;gap:14px;font-family:var(--font-mono);font-size:10.5px;margin-top:6px">
+          <span style="color:var(--s3)">● hit · 74%</span>
+          <span style="color:var(--s4)">● miss · 18%</span>
+          <span style="color:var(--s5)">● error · 8%</span>
+        </div>
+
+        <div style="font-family:var(--font-mono);font-size:10px;color:var(--fg-3);text-transform:uppercase;letter-spacing:.1em;margin:20px 0 6px">step · plan / wizard progress</div>
+        <div class="steps">
+          <div class="step-dot done">1</div>
+          <div class="step-line done"></div>
+          <div class="step-dot done">2</div>
+          <div class="step-line active"></div>
+          <div class="step-dot active">3</div>
+          <div class="step-line"></div>
+          <div class="step-dot">4</div>
+          <div class="step-line"></div>
+          <div class="step-dot">5</div>
+        </div>
+        <div style="display:flex;justify-content:space-between;font-family:var(--font-mono);font-size:10.5px;color:var(--fg-3);margin-top:4px">
+          <span>plan</span><span>review</span><span style="color:var(--c-brand)">approve</span><span>execute</span><span>commit</span>
+        </div>
+
+        <div style="font-family:var(--font-mono);font-size:10px;color:var(--fg-3);text-transform:uppercase;letter-spacing:.1em;margin:20px 0 6px">ring · for KPIs that compress to a single number</div>
+        <div style="display:flex;gap:14px;align-items:center">
+          <div class="ring ok" style="width:64px;height:64px">
+            <svg width="64" height="64" viewBox="0 0 64 64">
+              <circle class="ring-bg"   cx="32" cy="32" r="26" stroke-width="5"/>
+              <circle class="ring-fill" cx="32" cy="32" r="26" stroke-width="5" stroke-dasharray="163.36" stroke-dashoffset="9.8"/>
+            </svg>
+            <div class="ring-label"><span class="v">94<span style="font-size:9px;color:var(--fg-3)">%</span></span><span class="u">cache</span></div>
+          </div>
+          <div class="ring" style="width:64px;height:64px">
+            <svg width="64" height="64" viewBox="0 0 64 64">
+              <circle class="ring-bg"   cx="32" cy="32" r="26" stroke-width="5"/>
+              <circle class="ring-fill" cx="32" cy="32" r="26" stroke-width="5" stroke-dasharray="163.36" stroke-dashoffset="49"/>
+            </svg>
+            <div class="ring-label"><span class="v">3<span style="font-size:9px;color:var(--fg-3)">/10</span></span><span class="u">iters</span></div>
+          </div>
+          <div class="ring warn" style="width:64px;height:64px">
+            <svg width="64" height="64" viewBox="0 0 64 64">
+              <circle class="ring-bg"   cx="32" cy="32" r="26" stroke-width="5"/>
+              <circle class="ring-fill" cx="32" cy="32" r="26" stroke-width="5" stroke-dasharray="163.36" stroke-dashoffset="36"/>
+            </svg>
+            <div class="ring-label"><span class="v" style="color:var(--c-warn)">78<span style="font-size:9px;color:var(--fg-3)">%</span></span><span class="u">budget</span></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="subsec">
+    <h3>Form controls</h3>
+    <p>Monospace inputs; the focus ring is a 1px brand-color border, no glow. Labels in 10.5px uppercase mono so they sit visually as "field tags" rather than competing with the input itself.</p>
+    <div style="display:grid;grid-template-columns:repeat(2, 1fr);gap:18px;max-width:680px">
+      <div>
+        <div class="form-row">
+          <label class="lbl">Workspace path</label>
+          <input class="input mono" value="/Users/yuhuahui/work/reasonix" />
+        </div>
+        <div class="form-row">
+          <label class="lbl">Model</label>
+          <select class="select mono">
+            <option>deepseek-chat</option>
+            <option>deepseek-reasoner</option>
+            <option>claude-opus-4-7</option>
+          </select>
+        </div>
+        <div class="form-row">
+          <label class="lbl">Budget cap (CNY)</label>
+          <input class="input mono" value="100" />
+          <span class="help">Soft cap; warn at 80%, refuse new turn at 100%.</span>
+        </div>
+      </div>
+      <div>
+        <div class="form-row" style="margin-bottom:8px"><label class="lbl">Code mode</label></div>
+        <div class="checkbox-row" style="margin-bottom:8px"><span class="box on">✓</span><span>Enable plan-then-edit flow</span></div>
+        <div class="checkbox-row" style="margin-bottom:8px"><span class="box on">✓</span><span>Auto-launch dashboard on <code class="mono">reasonix code</code></span></div>
+        <div class="checkbox-row" style="margin-bottom:8px"><span class="box"></span><span>Use streaming for sub-agents</span></div>
+        <div style="display:flex;gap:8px;margin-top:18px">
+          <button class="btn primary"><span>Save</span></button>
+          <button class="btn">Cancel</button>
+          <button class="btn ghost"><span class="g">↻</span><span>Reset</span></button>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ─────────────────────────────────────────────────────────────────────── -->
+<section class="section" id="chat">
+  <h2><span class="num">§4</span>Chat</h2>
+  <p class="lede">
+    A <b>first-class chat surface</b>, not a viewer. Full composer, slash menu, file
+    attachments, paste handling. The dashboard wins anywhere the TUI's renderer
+    breaks down — older PowerShell, non-ConPTY consoles, mosh-over-flaky-network,
+    or terminals where Ink redraws the same row twice. A small status pill in the
+    topbar tells you which surface the loop currently considers "active writer."
+  </p>
+
+  <div class="why">
+    <b>Why does the dashboard need its own chat?</b>
+    The TUI assumes a modern terminal — true cursor reporting, ConPTY, raw stdin.
+    On legacy PowerShell hosts (Win10 cmd, ConEmu, very-old WT builds) Ink's
+    diff-based renderer can re-paint the same card row, leak ANSI sequences,
+    or drop frames mid-stream. The dashboard's chat is HTML — it can't have
+    those bugs. Treating it as fallback-only means users hit the bugs first
+    and only then discover the workaround. Better: full peer.
+    <br><br>
+    <b>Single-writer is still enforced</b>: only one of {TUI, dashboard} owns
+    the input lock at a time. The pill says which. Switching is one click;
+    re-entering the TUI on first keystroke is automatic.
+  </div>
+
+  <p class="mock-cap">— TUI online, dashboard reading; user can submit from either</p>
+  <div class="mock">
+    <div class="app">
+      <aside class="app-side">
+        <div class="brand"><span class="glyph">◈</span><span class="label">REASONIX</span><span class="ver">0.18.1</span></div>
+        <div class="side-tabs">
+          <div class="side-tab active"><span class="g">◆</span><span class="label">Chat</span></div>
+          <div class="side-tab"><span class="g">✎</span><span class="label">Editor</span></div>
+          <div class="side-tab"><span class="g">⊞</span><span class="label">Plans</span><span class="badge">1</span></div>
+          <div class="side-tab"><span class="g">›</span><span class="label">Sessions</span></div>
+          <div class="side-section">observe</div>
+          <div class="side-tab"><span class="g">◈</span><span class="label">Overview</span></div>
+          <div class="side-tab"><span class="g">$</span><span class="label">Usage</span></div>
+        </div>
+        <div class="side-foot"><span class="label">localhost:8742</span><span class="toggle">«</span></div>
+      </aside>
+
+      <header class="app-top">
+        <div class="crumbs">
+          <span class="crumb dim">~/work/reasonix</span>
+          <span class="sep">›</span>
+          <span class="crumb" style="color:var(--c-ok)">feat/dashboard-v2</span>
+          <span class="sep">›</span>
+          <span class="crumb" style="color:var(--c-accent)">2026-04-30-2014</span>
+        </div>
+        <span class="grow"></span>
+        <span class="tui-status online" title="TUI is the active writer"><span class="dot"></span>TUI · terminal #2</span>
+        <span class="meter"><span class="lbl">balance</span><span class="v" style="color:var(--c-ok)">¥48.20</span></span>
+      </header>
+
+      <div class="app-body" style="display:flex;flex-direction:column;gap:14px;padding-bottom:14px">
+
+        <div class="chat-grid" style="flex:1;min-height:0">
+          <div class="chat-stream">
+            <div class="cc user">
+              <div class="cc-h"><span class="glyph">◆</span><span class="role">user</span><span class="meta">20:12:33</span></div>
+              <div class="cc-b">npm publish 报 0.18.0 已存在，但我没看到之前 publish 成功，能不能查一下 registry？</div>
+            </div>
+            <div class="cc reasoning">
+              <div class="cc-h"><span class="glyph">⊞</span><span class="role">reasoning</span><span class="meta">3 paragraphs · 240 tok</span></div>
+              <div class="cc-b">The user reports a publish conflict. Root-cause direction: did the earlier rejected tool actually upload before the rejection signal landed? Plan: query the registry for 0.18.0 timestamp + gitHead, compare against local commit history…</div>
+            </div>
+            <div class="cc tool">
+              <div class="cc-h"><span class="glyph">▣</span><span class="role">run_command</span><span class="meta">240ms · ok</span></div>
+              <div class="cc-b">
+                <div class="tool-args">npm view reasonix@0.18.0 time gitHead</div>
+                <div class="tool-out mono" style="color:var(--fg-2);font-size:12px">{"0.18.0":"2026-05-01T03:20:58.310Z"}<br>gitHead = 'f8e156c898…'</div>
+              </div>
+            </div>
+            <div class="cc assistant">
+              <div class="cc-h"><span class="glyph">⏵</span><span class="role">assistant</span><span class="meta">streaming · 1.2k tok</span></div>
+              <div class="cc-b">
+                <p>0.18.0 was published at <code class="inline">03:20:58Z</code>, with <code class="inline">gitHead=f8e156c</code> — the local "release: 0.18.0" commit from <i>before</i> the bug fix. So the rejected tool actually uploaded to the registry; the rejection signal stopped the local CLI before the confirmation print.</p>
+                <p>Next step: bump to 0.18.1 with the fix, then deprecate 0.18.0 on the registry…</p>
+                <div class="progress indet" style="margin-top:8px"><div class="progress-fill"></div></div>
+              </div>
+            </div>
+          </div>
+
+          <aside class="chat-rail">
+            <div class="rail-card">
+              <div class="rh">Active plan</div>
+              <div class="steps" style="margin-bottom:8px">
+                <div class="step-dot done">1</div>
+                <div class="step-line done"></div>
+                <div class="step-dot done">2</div>
+                <div class="step-line active"></div>
+                <div class="step-dot active">3</div>
+                <div class="step-line"></div>
+                <div class="step-dot">4</div>
+              </div>
+              <div class="rail-step done"><span class="g">✓</span><span>investigate registry timestamp</span></div>
+              <div class="rail-step done"><span class="g">✓</span><span>confirm gitHead = pre-fix commit</span></div>
+              <div class="rail-step active"><span class="g">⏵</span><span>release 0.18.1 with the fix</span></div>
+              <div class="rail-step"><span class="g">○</span><span>deprecate 0.18.0 on registry</span></div>
+            </div>
+            <div class="rail-card">
+              <div class="rh">Session</div>
+              <div class="rail-kv"><span class="k">turns</span><span class="v">12</span></div>
+              <div class="rail-kv"><span class="k">prompt tok</span><span class="v">42,318</span></div>
+              <div class="rail-kv"><span class="k">completion</span><span class="v">8,041</span></div>
+              <div class="rail-kv"><span class="k">cost</span><span class="v">¥1.84</span></div>
+              <div class="progress-row" style="margin-top:8px;padding:0">
+                <span class="lbl">cache hit</span>
+                <div class="progress ok"><div class="progress-fill" style="width:94%"></div></div>
+                <span class="v" style="color:var(--c-ok)">94%</span>
+              </div>
+            </div>
+            <div class="rail-card">
+              <div class="rh">Tool budget</div>
+              <div class="progress-row"><span class="lbl">turn iters</span><div class="progress"><div class="progress-fill" style="width:30%"></div></div><span class="v">3 / 10</span></div>
+              <div class="progress-row"><span class="lbl">tok this turn</span><div class="progress acc"><div class="progress-fill" style="width:42%"></div></div><span class="v">3.4k / 8k</span></div>
+              <div class="progress-row"><span class="lbl">budget</span><div class="progress warn"><div class="progress-fill" style="width:78%"></div></div><span class="v" style="color:var(--c-warn)">¥78 / ¥100</span></div>
+            </div>
+          </aside>
+        </div>
+
+        <!-- Composer with slash popover floating above -->
+        <div style="position:relative">
+          <div class="popover" style="position:absolute;bottom:calc(100% + 6px);left:0;width:380px">
+            <div class="popover-h">slash commands</div>
+            <div class="popover-row sel"><span class="g">/</span><span class="name">/plan</span><span class="meta">draft a step-by-step plan</span></div>
+            <div class="popover-row"><span class="g">/</span><span class="name">/budget</span><span class="meta">set or clear the cost cap</span></div>
+            <div class="popover-row"><span class="g">/</span><span class="name">/sessions</span><span class="meta">switch / rename / forget</span></div>
+            <div class="popover-row"><span class="g">/</span><span class="name">/cwd</span><span class="meta" style="color:var(--c-err)">deprecated</span></div>
+            <div class="popover-row"><span class="g">/</span><span class="name">/diff</span><span class="meta">unsubmitted edits since last turn</span></div>
+          </div>
+          <div class="composer">
+            <div class="composer-tags">
+              <span class="composer-chip attach">@ src/cli/ui/PromptInput.tsx<span class="x">×</span></span>
+              <span class="composer-chip paste">[paste · 248 lines]<span class="x">×</span></span>
+            </div>
+            <div class="composer-text">/p<span class="caret"></span></div>
+            <div class="composer-foot">
+              <span class="hint"><span class="kbd">↵</span> send · <span class="kbd">⇧↵</span> newline · <span class="kbd">⌘K</span> commands · <span class="kbd">@</span> attach</span>
+              <span class="grow"></span>
+              <span>3.4k tok · ¥0.21 est</span>
+              <span class="send">send →</span>
+            </div>
+          </div>
+        </div>
+
+      </div>
+
+      <footer class="app-status">
+        <span class="item"><span class="dot"></span><span>tools <span class="v">23</span></span></span>
+        <span class="item"><span class="dot"></span><span>mcp <span class="v">2</span></span></span>
+        <span class="grow"></span>
+        <span class="item">last event <span class="v">2s ago</span></span>
+      </footer>
+    </div>
+  </div>
+
+  <p class="mock-cap">— TUI offline (renderer hung); dashboard auto-promoted to active writer</p>
+  <div class="mock">
+    <div class="app" style="height:280px">
+      <aside class="app-side">
+        <div class="brand"><span class="glyph">◈</span><span class="label">REASONIX</span><span class="ver">0.18.1</span></div>
+        <div class="side-tabs">
+          <div class="side-tab active"><span class="g">◆</span><span class="label">Chat</span></div>
+          <div class="side-tab"><span class="g">⊞</span><span class="label">Plans</span></div>
+          <div class="side-tab"><span class="g">›</span><span class="label">Sessions</span></div>
+        </div>
+        <div class="side-foot"><span class="toggle">«</span></div>
+      </aside>
+      <header class="app-top">
+        <div class="crumbs">
+          <span class="crumb dim">~/work/reasonix</span>
+          <span class="sep">›</span>
+          <span class="crumb" style="color:var(--c-accent)">2026-04-30-2014</span>
+        </div>
+        <span class="grow"></span>
+        <span class="tui-status offline" title="TUI process not responding"><span class="dot"></span>TUI offline · 14s</span>
+        <span class="meter"><span class="v" style="color:var(--c-ok)">¥48.20</span></span>
+      </header>
+      <div class="app-body" style="padding:14px 18px">
+        <div style="background:rgba(255,139,129,.06);border:1px solid rgba(255,139,129,.18);border-radius:var(--r);padding:10px 14px;margin-bottom:14px;display:flex;align-items:center;gap:12px;font-size:12.5px">
+          <span style="font-family:var(--font-mono);color:var(--c-err);font-size:14px">●</span>
+          <span style="color:var(--fg-1)">TUI hasn't drained its event queue in <b>14 seconds</b> — likely a renderer hang. Dashboard now owns input. <a style="color:var(--c-err)">force-quit TUI</a> · <a>reattach</a></span>
+        </div>
+        <div class="cc assistant">
+          <div class="cc-h"><span class="glyph">⏵</span><span class="role">assistant</span><span class="meta">streaming continues here</span></div>
+          <div class="cc-b">…the deprecate command will mark <code class="inline">0.18.0</code> with the warning text on the registry. Once it's done, anyone who runs <code class="inline">npm install reasonix@0.18.0</code> will see the deprecation banner and get pointed at <code class="inline">0.18.1</code>.</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="subsec">
+    <h3>Composer states <span class="desc">how the input bar reads in different conditions</span></h3>
+    <p>One composer, four states. Border + foot copy carry the difference; geometry stays put so the eye doesn't reorient.</p>
+
+    <div style="display:flex;flex-direction:column;gap:10px;max-width:680px">
+      <div>
+        <div style="font-family:var(--font-mono);font-size:10px;color:var(--fg-3);margin-bottom:4px;text-transform:uppercase;letter-spacing:.1em">idle</div>
+        <div class="composer">
+          <div class="composer-text" style="color:var(--fg-3)">type a message · slash for commands · at-sign for files</div>
+          <div class="composer-foot"><span class="hint"><span class="kbd">↵</span> send · <span class="kbd">⌘K</span> commands</span><span class="grow"></span><span>0 tok</span></div>
+        </div>
+      </div>
+
+      <div>
+        <div style="font-family:var(--font-mono);font-size:10px;color:var(--fg-3);margin-bottom:4px;text-transform:uppercase;letter-spacing:.1em">composing · with attachments</div>
+        <div class="composer" style="border-color:var(--c-brand)">
+          <div class="composer-tags">
+            <span class="composer-chip attach">@ src/cli/ui/App.tsx<span class="x">×</span></span>
+            <span class="composer-chip attach">@ src/cli/ui/PromptInput.tsx<span class="x">×</span></span>
+            <span class="composer-chip paste">[paste · 84 lines]<span class="x">×</span></span>
+          </div>
+          <div class="composer-text">find every place we still pass <code class="inline">debug:true</code> to ink and replace with the default<span class="caret"></span></div>
+          <div class="composer-foot"><span class="hint"><span class="kbd">↵</span> send · <span class="kbd">⇧↵</span> newline</span><span class="grow"></span><span>1.2k tok · ¥0.07 est</span><span class="send">send →</span></div>
+        </div>
+      </div>
+
+      <div>
+        <div style="font-family:var(--font-mono);font-size:10px;color:var(--fg-3);margin-bottom:4px;text-transform:uppercase;letter-spacing:.1em">disabled · model is responding</div>
+        <div class="composer" style="opacity:.6">
+          <div class="composer-text" style="color:var(--fg-3)">…waiting for response · <span class="kbd" style="border:1px solid var(--bd);padding:0 4px;border-radius:var(--r);color:var(--c-warn)">esc</span> to abort</div>
+          <div class="composer-foot"><span class="hint">streaming · 240 tok so far</span><span class="grow"></span><span>elapsed 2.1s</span></div>
+        </div>
+      </div>
+
+      <div>
+        <div style="font-family:var(--font-mono);font-size:10px;color:var(--fg-3);margin-bottom:4px;text-transform:uppercase;letter-spacing:.1em">locked · TUI owns input</div>
+        <div class="composer" style="opacity:.5;background:transparent">
+          <div class="composer-text" style="color:var(--fg-3)">TUI · terminal #2 has the input lock. <a>take over here</a> →</div>
+          <div class="composer-foot"><span class="hint">switching is one click; releasing back to TUI is automatic on focus</span></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="subsec">
+    <h3>Approval modal <span class="desc">tool-call confirmations mirror from the loop</span></h3>
+    <p>When the model wants to run a non-allowlisted command, both the TUI and the dashboard show the same approval. Either side can resolve. The dashboard frames it as a centered dialog (more body, can show full diff/output preview), the TUI shows it inline as a card. Same dispatch path either way.</p>
+
+    <div class="mock">
+      <div class="overlay" style="height:280px;background:var(--bg)">
+        <div class="dialog warn">
+          <div class="dialog-h"><span class="glyph">▲</span><span class="title">approve · run_command</span><span class="meta">deepseek · turn 14</span></div>
+          <div class="dialog-b">
+            <p style="color:var(--fg-2);font-size:12.5px;margin:0 0 8px">The model wants to run a command that is not on the auto-approve allowlist:</p>
+            <div class="code" style="margin:0 0 10px">npm publish</div>
+            <div style="font-family:var(--font-mono);font-size:11.5px;color:var(--fg-3)">
+              cwd: <span style="color:var(--fg-1)">~/work/reasonix</span><br>
+              prefix used by allowlist match: <span style="color:var(--fg-1)">npm</span>
+            </div>
+          </div>
+          <div class="dialog-f">
+            <span class="hint"><span class="kbd" style="border:1px solid var(--bd);padding:0 4px;border-radius:var(--r);color:var(--fg-3)">y</span> approve · <span class="kbd" style="border:1px solid var(--bd);padding:0 4px;border-radius:var(--r);color:var(--fg-3)">a</span> always for prefix · <span class="kbd" style="border:1px solid var(--bd);padding:0 4px;border-radius:var(--r);color:var(--fg-3)">n</span> deny</span>
+            <span class="grow"></span>
+            <button class="btn">deny</button>
+            <button class="btn">approve once</button>
+            <button class="btn primary">approve & remember</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="subsec">
+    <h3>Command palette <span class="desc">Ctrl/⌘+K opens a global jump bar</span></h3>
+    <p>Slash commands, panels, sessions, even MCP tools — all addressable through one fuzzy search. The popover from inside the composer is the same component, just anchored differently and pre-filtered to slash commands. Avoids the dashboard ever needing menus.</p>
+
+    <div class="mock">
+      <div class="overlay" style="height:340px;align-items:flex-start;padding-top:48px;background:var(--bg)">
+        <div class="cmd-palette">
+          <div class="cmd-input-row">
+            <span class="g">⌘</span>
+            <input value="dep" />
+            <span class="kbd">esc</span>
+          </div>
+          <div class="cmd-list">
+            <div class="cmd-section-h">slash commands</div>
+            <div class="cmd-row sel"><span class="g">/</span><span class="name">/deprecate</span><span class="desc">mark a published version as deprecated</span><span class="kbd">↵</span></div>
+            <div class="cmd-section-h">panels</div>
+            <div class="cmd-row"><span class="g">▣</span><span class="name">Tools</span><span class="desc">browse registered tools</span></div>
+            <div class="cmd-row"><span class="g">▎</span><span class="name">Permissions</span><span class="desc">edit allowlist</span></div>
+            <div class="cmd-section-h">recent sessions</div>
+            <div class="cmd-row"><span class="g">›</span><span class="name">2026-04-30-1908</span><span class="desc">tui-card-stream redesign</span></div>
+            <div class="cmd-row"><span class="g">›</span><span class="name">2026-04-29-1602</span><span class="desc">v0.14 event-log kernel</span></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ─────────────────────────────────────────────────────────────────────── -->
+<section class="section" id="overview">
+  <h2><span class="num">§5</span>Overview</h2>
+  <p class="lede">
+    The cockpit. A four-column widget grid that answers "what's the system doing
+    right now, what did it just do, what should I worry about" in one screen.
+    Every widget is a link into the corresponding panel for depth.
+  </p>
+
+  <div class="mock">
+    <div class="app">
+      <aside class="app-side">
+        <div class="brand"><span class="glyph">◈</span><span class="label">REASONIX</span><span class="ver">0.18.1</span></div>
+        <div class="side-tabs">
+          <div class="side-tab"><span class="g">◆</span><span class="label">Chat</span></div>
+          <div class="side-tab"><span class="g">✎</span><span class="label">Editor</span></div>
+          <div class="side-tab"><span class="g">⊞</span><span class="label">Plans</span></div>
+          <div class="side-tab"><span class="g">›</span><span class="label">Sessions</span></div>
+          <div class="side-section">observe</div>
+          <div class="side-tab active"><span class="g">◈</span><span class="label">Overview</span></div>
+          <div class="side-tab"><span class="g">$</span><span class="label">Usage</span></div>
+          <div class="side-tab"><span class="g">+</span><span class="label">System</span></div>
+        </div>
+        <div class="side-foot"><span class="label">localhost:8742</span><span class="toggle">«</span></div>
+      </aside>
+
+      <header class="app-top">
+        <div class="crumbs">
+          <span class="crumb dim">~/work/reasonix</span>
+          <span class="sep">›</span>
+          <span class="crumb" style="color:var(--c-ok)">feat/dashboard-v2</span>
+          <span class="sep">›</span>
+          <span class="crumb" style="color:var(--c-accent)">2026-04-30-2014</span>
+        </div>
+        <span class="grow"></span>
+        <span class="tui-status online"><span class="dot"></span>TUI · #2</span>
+        <span class="meter"><span class="lbl">model</span><span class="v">deepseek-chat</span></span>
+        <span class="meter"><span class="lbl">balance</span><span class="v" style="color:var(--c-ok)">¥48.20</span></span>
+      </header>
+
+      <div class="app-body">
+        <div class="cockpit">
+
+          <!-- Row 1: KPIs -->
+          <div class="kpi cock-w-1">
+            <div class="label">balance</div>
+            <div class="value">¥48.20</div>
+            <div class="delta down">▼ ¥1.84 today</div>
+          </div>
+          <div class="kpi cock-w-1">
+            <div class="label">tokens · 7d</div>
+            <div class="value">994k</div>
+            <div class="delta up">▲ 12% vs prior</div>
+          </div>
+          <div class="kpi cock-w-1">
+            <div class="label">cache hit</div>
+            <div class="value">94<span class="unit">%</span></div>
+            <div class="delta flat">— stable</div>
+          </div>
+          <div class="kpi cock-w-1">
+            <div class="label">tool calls · 24h</div>
+            <div class="value">412</div>
+            <div class="delta up">▲ 38</div>
+          </div>
+
+          <!-- Row 2: Current session (wide) + cost trend -->
+          <div class="cock-list cock-w-2">
+            <div class="ch"><span class="ttl">current session</span><a>open in chat →</a></div>
+            <div class="card accent-brand" style="margin:0 0 8px;background:transparent;border:none;padding:0">
+              <div class="card-h"><span class="glyph">◆</span><span class="title">2026-04-30-2014</span><span class="meta">started 19:08 · 12 turns</span></div>
+              <div class="card-b" style="font-size:12.5px;color:var(--fg-2)">
+                Investigating npm publish conflict; deprecating 0.18.0 and shipping 0.18.1 with the ghost-frame fix.
+              </div>
+            </div>
+            <div style="display:grid;grid-template-columns:repeat(4, 1fr);gap:8px;font-family:var(--font-mono);font-size:11px">
+              <div><span style="color:var(--fg-3)">prompt tok</span><div style="color:var(--fg-0);font-size:13px;font-weight:600">42,318</div></div>
+              <div><span style="color:var(--fg-3)">completion tok</span><div style="color:var(--fg-0);font-size:13px;font-weight:600">8,041</div></div>
+              <div><span style="color:var(--fg-3)">cost</span><div style="color:var(--fg-0);font-size:13px;font-weight:600">¥1.84</div></div>
+              <div><span style="color:var(--fg-3)">avg latency</span><div style="color:var(--fg-0);font-size:13px;font-weight:600">2.1s</div></div>
+            </div>
+          </div>
+
+          <div class="chart cock-w-2">
+            <div class="chart-h"><span class="title">cost · 14 day</span><span class="delta up">▲ 12%</span></div>
+            <div class="chart-v">¥18.40<span class="unit">/day avg</span></div>
+            <div class="chart-spark">
+              <svg viewBox="0 0 400 60" preserveAspectRatio="none">
+                <polyline fill="none" stroke="#79c0ff" stroke-width="1.5" points="0,40 28,36 56,42 84,30 112,34 140,28 168,22 196,30 224,18 252,22 280,12 308,16 336,10 364,14 400,8"/>
+                <polyline fill="rgba(121,192,255,.10)" stroke="none" points="0,40 28,36 56,42 84,30 112,34 140,28 168,22 196,30 224,18 252,22 280,12 308,16 336,10 364,14 400,8 400,60 0,60"/>
+              </svg>
+            </div>
+          </div>
+
+          <!-- Row 3: Recent plans (wide) + tool feed -->
+          <div class="cock-list cock-w-2">
+            <div class="ch"><span class="ttl">recent plans</span><a>see all →</a></div>
+            <div class="rail-step done"><span class="g">✓</span><span>finalize card-stream migration · 4 steps</span><span style="margin-left:auto;color:var(--fg-4);font-family:var(--font-mono);font-size:10.5px">2h ago</span></div>
+            <div class="rail-step done"><span class="g">✓</span><span>events.jsonl sidecar lifecycle · 3 steps</span><span style="margin-left:auto;color:var(--fg-4);font-family:var(--font-mono);font-size:10.5px">1h ago</span></div>
+            <div class="rail-step active"><span class="g">⏵</span><span>release 0.18.1 + deprecate 0.18.0 · 5 steps · 3/5</span><span style="margin-left:auto;color:var(--fg-4);font-family:var(--font-mono);font-size:10.5px">now</span></div>
+            <div class="rail-step"><span class="g">○</span><span>dashboard redesign · drafted</span><span style="margin-left:auto;color:var(--fg-4);font-family:var(--font-mono);font-size:10.5px">queued</span></div>
+          </div>
+
+          <div class="cock-list cock-w-2">
+            <div class="ch"><span class="ttl">tool activity · last hour</span><a>full feed →</a></div>
+            <div class="feed-row ok"><span class="g">●</span><span class="name">run_command <span class="args">npm publish</span></span><span class="when">02:31</span></div>
+            <div class="feed-row ok"><span class="g">●</span><span class="name">run_command <span class="args">git push --follow-tags</span></span><span class="when">02:31</span></div>
+            <div class="feed-row warn"><span class="g">▲</span><span class="name">run_command <span class="args">npm publish (rejected)</span></span><span class="when">02:30</span></div>
+            <div class="feed-row ok"><span class="g">●</span><span class="name">edit_file <span class="args">src/cli/commands/chat.tsx</span></span><span class="when">02:28</span></div>
+            <div class="feed-row ok"><span class="g">●</span><span class="name">run_command <span class="args">npm run verify</span></span><span class="when">02:25</span></div>
+            <div class="feed-row err"><span class="g">✕</span><span class="name">run_command <span class="args">npm publish (over taken)</span></span><span class="when">02:22</span></div>
+          </div>
+
+          <!-- Row 4: System health (full row) -->
+          <div class="kpi cock-w-1">
+            <div class="label">tools loaded</div>
+            <div class="value">23<span class="unit">/24</span></div>
+            <div class="delta flat">native 14 · mcp 9</div>
+          </div>
+          <div class="kpi cock-w-1">
+            <div class="label">mcp servers</div>
+            <div class="value">2<span class="unit">/2</span></div>
+            <div class="delta up">all up</div>
+          </div>
+          <div class="kpi cock-w-1">
+            <div class="label">memory entries</div>
+            <div class="value">14</div>
+            <div class="delta flat">+1 this session</div>
+          </div>
+          <div class="kpi cock-w-1">
+            <div class="label">version</div>
+            <div class="value mono" style="font-size:18px">0.18.1</div>
+            <div class="delta up">latest</div>
+          </div>
+
+        </div>
+      </div>
+
+      <footer class="app-status">
+        <span class="item"><span class="dot"></span><span>tools <span class="v">23</span></span></span>
+        <span class="item"><span class="dot"></span><span>mcp <span class="v">2</span></span></span>
+        <span class="grow"></span>
+        <span class="item">last event <span class="v">2s ago</span></span>
+      </footer>
+    </div>
+  </div>
+
+  <div class="subsec">
+    <h3>Layout principles</h3>
+    <p><b>Top row</b>: 4 KPIs (balance · token volume · cache hit · tool calls) — the four numbers you check first when picking up an in-progress agent. <b>Wider middle</b>: current session + cost trend, side by side. <b>Lower middle</b>: plan history + tool feed — the "what's been happening" pair. <b>Bottom KPIs</b>: configuration health (tools / MCP / memory / version).</p>
+    <p>Every widget is a link into the corresponding panel. Hover reveals "open" affordance; click opens the deeper view.</p>
+  </div>
+</section>
+
+<!-- ─────────────────────────────────────────────────────────────────────── -->
+<section class="section" id="sessions">
+  <h2><span class="num">§6</span>Sessions</h2>
+  <p class="lede">
+    The high-traffic browse view. List on the left (filter, sort, search), detail
+    on the right. Designed so you can land here a week later, find the session you
+    half-remember, and either resume it, copy a prompt out, or delete the whole
+    branch of dead-end work.
+  </p>
+
+  <div class="why">
+    <b>Why list+detail and not a card grid?</b>
+    Sessions have a strong temporal axis (you almost always want "what did I do
+    today" or "what was that thing last week"). A vertical list with date affordances
+    beats a card grid for that. The detail pane on the right gives room for the
+    transcript preview + plan history + cost breakdown that you actually came here for.
+  </div>
+
+  <div class="mock">
+    <div class="app">
+      <aside class="app-side">
+        <div class="brand"><span class="glyph">◈</span><span class="label">REASONIX</span><span class="ver">0.18.1</span></div>
+        <div class="side-tabs">
+          <div class="side-tab"><span class="g">◆</span><span class="label">Chat</span></div>
+          <div class="side-tab"><span class="g">✎</span><span class="label">Editor</span></div>
+          <div class="side-tab"><span class="g">⊞</span><span class="label">Plans</span></div>
+          <div class="side-tab active"><span class="g">›</span><span class="label">Sessions</span><span class="badge">42</span></div>
+          <div class="side-section">observe</div>
+          <div class="side-tab"><span class="g">◈</span><span class="label">Overview</span></div>
+          <div class="side-tab"><span class="g">$</span><span class="label">Usage</span></div>
+        </div>
+        <div class="side-foot"><span class="label">localhost:8742</span><span class="toggle">«</span></div>
+      </aside>
+
+      <header class="app-top">
+        <div class="crumbs">
+          <span class="crumb dim">~/work/reasonix</span>
+          <span class="sep">›</span>
+          <span class="crumb">sessions</span>
+          <span class="sep">›</span>
+          <span class="crumb" style="color:var(--c-accent)">2026-04-30-2014</span>
+        </div>
+        <span class="grow"></span>
+        <span class="meter"><span class="lbl">total</span><span class="v">42 sessions</span></span>
+        <span class="meter"><span class="lbl">disk</span><span class="v">128 MB</span></span>
+        <span class="meter"><span class="lbl">balance</span><span class="v" style="color:var(--c-ok)">¥48.20</span></span>
+      </header>
+
+      <div class="app-body" style="padding:14px 18px">
+        <div class="sessions-grid">
+
+          <div class="sessions-list">
+            <div class="ssl-h">
+              <input placeholder="filter · name / message / branch" />
+              <button class="btn ghost"><span class="g">↓</span></button>
+            </div>
+            <div class="ssl-rows">
+              <div class="ssl-row sel">
+                <span class="name">2026-04-30-2014 <span class="pill info" style="margin-left:4px">active</span></span>
+                <span class="preview">Investigating npm publish conflict; deprecating 0.18.0…</span>
+                <span class="meta"><span class="v">12</span> turns · <span class="v">¥1.84</span> · 1h ago</span>
+              </div>
+              <div class="ssl-row">
+                <span class="name">2026-04-30-1908</span>
+                <span class="preview">tui-card-stream redesign; finalize migration + drop workspace tool</span>
+                <span class="meta"><span class="v">38</span> turns · <span class="v">¥4.20</span> · today</span>
+              </div>
+              <div class="ssl-row">
+                <span class="name">2026-04-29-1602</span>
+                <span class="preview">v0.14 event-log kernel — approach D; reducer + sidecar</span>
+                <span class="meta"><span class="v">52</span> turns · <span class="v">¥6.10</span> · yesterday</span>
+              </div>
+              <div class="ssl-row">
+                <span class="name">2026-04-28-2244</span>
+                <span class="preview">0.12.16 → 0.12.22 perf + budget + doctor + commit</span>
+                <span class="meta"><span class="v">71</span> turns · <span class="v">¥8.94</span> · 2d ago</span>
+              </div>
+              <div class="ssl-row">
+                <span class="name">2026-04-28-1130</span>
+                <span class="preview">dashboard sidebar Editor tab — file tree + CodeMirror</span>
+                <span class="meta"><span class="v">45</span> turns · <span class="v">¥5.30</span> · 2d ago</span>
+              </div>
+              <div class="ssl-row">
+                <span class="name">2026-04-27-1922 <span class="pill warn" style="margin-left:4px">stale</span></span>
+                <span class="preview">scrollback redraw fix — still broken on Win10 cmd</span>
+                <span class="meta"><span class="v">8</span> turns · <span class="v">¥0.42</span> · 3d ago</span>
+              </div>
+              <div class="ssl-row">
+                <span class="name">2026-04-26-1015</span>
+                <span class="preview">semantic index v2; chunk by logical block instead of LOC</span>
+                <span class="meta"><span class="v">22</span> turns · <span class="v">¥2.10</span> · 4d ago</span>
+              </div>
+              <div class="ssl-row">
+                <span class="name">2026-04-25-2030</span>
+                <span class="preview">memory system spec — auto + manual; types: user/feedback/project/reference</span>
+                <span class="meta"><span class="v">31</span> turns · <span class="v">¥3.20</span> · 5d ago</span>
+              </div>
+            </div>
+          </div>
+
+          <div class="sessions-detail">
+            <div class="sessions-detail-h">
+              <span class="name">2026-04-30-2014</span>
+              <span class="ws">~/work/reasonix · feat/dashboard-v2</span>
+              <span class="actions">
+                <button class="btn"><span class="g">↻</span><span>resume</span></button>
+                <button class="btn ghost">rename</button>
+                <button class="btn ghost" style="color:var(--c-err)">delete</button>
+              </span>
+            </div>
+
+            <div class="sessions-detail-kpis">
+              <div class="kp"><div class="lbl">turns</div><div class="v">12</div></div>
+              <div class="kp"><div class="lbl">prompt tok</div><div class="v">42,318</div></div>
+              <div class="kp"><div class="lbl">cost</div><div class="v">¥1.84</div></div>
+              <div class="kp"><div class="lbl">cache hit</div><div class="v" style="color:var(--c-ok)">94%</div></div>
+            </div>
+
+            <div class="subsec" style="margin:0 0 14px">
+              <h3 style="margin:0 0 6px">Activity · last 4h</h3>
+              <div class="progress segmented" style="height:10px;margin:6px 0 4px">
+                <div class="progress-seg s1" style="width:18%"></div>
+                <div class="progress-seg s2" style="width:6%"></div>
+                <div class="progress-seg s3" style="width:24%"></div>
+                <div class="progress-seg s4" style="width:8%"></div>
+                <div class="progress-seg s1" style="width:14%"></div>
+                <div class="progress-seg s5" style="width:4%"></div>
+                <div class="progress-seg s3" style="width:18%"></div>
+                <div class="progress-seg dim" style="width:8%"></div>
+              </div>
+              <div style="display:flex;gap:14px;font-family:var(--font-mono);font-size:10.5px;color:var(--fg-3)">
+                <span style="color:var(--s1)">● tools</span>
+                <span style="color:var(--s3)">● assistant</span>
+                <span style="color:var(--s4)">● reasoning</span>
+                <span style="color:var(--s5)">● errors</span>
+                <span style="color:var(--fg-4)">● idle</span>
+              </div>
+            </div>
+
+            <div class="subsec" style="margin:0 0 14px">
+              <h3 style="margin:0 0 6px">Recent turns</h3>
+              <div style="font-family:var(--font-mono);font-size:11.5px;color:var(--fg-2);line-height:1.7">
+                <div><span style="color:var(--c-brand)">12 ›</span> /deprecate reasonix@0.18.0</div>
+                <div><span style="color:var(--c-brand)">11 ›</span> 没问题，开始 npm publish</div>
+                <div><span style="color:var(--c-brand)">10 ›</span> 可以的，按推荐路径</div>
+                <div><span style="color:var(--c-brand)">9 ›</span> 帮我查一下 0.18.0 是怎么发出去的</div>
+                <div><span style="color:var(--c-brand)">8 ›</span> publish 居然成功了？我以为我拒绝了</div>
+                <div><span style="color:var(--fg-4)">…</span></div>
+              </div>
+            </div>
+
+            <div>
+              <h3 style="margin:0 0 6px;font-family:var(--font-mono);font-size:13px;text-transform:uppercase;letter-spacing:.04em;color:var(--fg-1)">Plans in this session</h3>
+              <div class="rail-step done"><span class="g">✓</span><span>release 0.18.1 + deprecate 0.18.0</span><span style="margin-left:auto;color:var(--fg-4);font-family:var(--font-mono);font-size:10.5px">5 / 5</span></div>
+              <div class="rail-step active"><span class="g">⏵</span><span>dashboard redesign · drafted</span><span style="margin-left:auto;color:var(--fg-4);font-family:var(--font-mono);font-size:10.5px">in progress</span></div>
+            </div>
+          </div>
+
+        </div>
+      </div>
+
+      <footer class="app-status">
+        <span class="item"><span class="dot"></span><span>tools <span class="v">23</span></span></span>
+        <span class="item"><span class="dot"></span><span>mcp <span class="v">2</span></span></span>
+        <span class="grow"></span>
+        <span class="item">42 sessions · 128 MB</span>
+      </footer>
+    </div>
+  </div>
+
+  <div class="subsec">
+    <h3>Empty state <span class="desc">first launch / fresh workspace</span></h3>
+    <p>Don't show a sad cloud illustration — show what the user can do next.</p>
+    <div class="mock" style="padding:48px 32px;display:flex;flex-direction:column;align-items:center;text-align:center;gap:12px">
+      <div style="font-family:var(--font-mono);font-size:32px;color:var(--c-brand);letter-spacing:.2em">› ›</div>
+      <div style="color:var(--fg-0);font-size:15px;font-family:var(--font-mono)">No sessions yet in this workspace</div>
+      <div style="color:var(--fg-3);font-size:12.5px;max-width:380px">Sessions are scoped to the launch directory. Open one with <code class="mono" style="color:var(--c-brand)">reasonix code</code> in the terminal, or import a transcript from another machine.</div>
+      <div style="display:flex;gap:8px;margin-top:6px">
+        <button class="btn primary">copy launch command</button>
+        <button class="btn">import transcript</button>
+      </div>
+    </div>
+  </div>
+
+  <div class="subsec">
+    <h3>Bulk operations</h3>
+    <p>Select multiple rows (shift-click range, ⌘-click toggle) → action bar slides in at the bottom of the list pane: <b>delete</b>, <b>archive</b> (move to <code class="mono">.archive/</code>, hidden by default), <b>export</b> (zip with sidecars), <b>tag</b>. No bulk-rename — one session at a time keeps the timestamp invariant intact.</p>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<section class="section" id="editor">
+  <h2><span class="num">§7</span>Editor</h2>
+  <p class="lede">
+    The dashboard's <b>web-only</b> value lives most visibly here. A 13-row
+    terminal can't host real syntax-highlighted multi-file editing; the dashboard
+    can. Tree on the left, tabs across the top, CodeMirror-class code area below,
+    line/col + git status in the foot. Cmd-P opens a fuzzy file picker — same
+    component as the global command palette, anchored to file mode.
+  </p>
+
+  <div class="why">
+    <b>Not a replacement for VS Code.</b>
+    The Editor is for the small, <i>relevant</i> set of files the agent is touching.
+    It always opens at the cursor location the model returned, scrolls to the
+    diff range, and shows pending edits as ghost overlays before approval.
+    For deep refactors, the user keeps their own editor — the dashboard is the
+    "see what the agent is about to do" surface.
+  </div>
+
+  <div class="mock">
+    <div class="app">
+      <aside class="app-side">
+        <div class="brand"><span class="glyph">◈</span><span class="label">REASONIX</span><span class="ver">0.18.1</span></div>
+        <div class="side-tabs">
+          <div class="side-tab"><span class="g">◆</span><span class="label">Chat</span></div>
+          <div class="side-tab active"><span class="g">✎</span><span class="label">Editor</span><span class="badge">3</span></div>
+          <div class="side-tab"><span class="g">⊞</span><span class="label">Plans</span></div>
+          <div class="side-tab"><span class="g">›</span><span class="label">Sessions</span></div>
+          <div class="side-section">observe</div>
+          <div class="side-tab"><span class="g">◈</span><span class="label">Overview</span></div>
+        </div>
+        <div class="side-foot"><span class="label">localhost:8742</span><span class="toggle">«</span></div>
+      </aside>
+
+      <header class="app-top">
+        <div class="crumbs">
+          <span class="crumb dim">~/work/reasonix</span>
+          <span class="sep">›</span>
+          <span class="crumb">src/cli/ui</span>
+          <span class="sep">›</span>
+          <span class="crumb" style="color:var(--c-brand)">PromptInput.tsx</span>
+        </div>
+        <span class="grow"></span>
+        <span class="tui-status online"><span class="dot"></span>TUI · #2</span>
+        <span class="meter"><span class="lbl">3 unsaved</span></span>
+      </header>
+
+      <div class="app-body" style="padding:0;display:grid;grid-template-columns:240px minmax(0,1fr);gap:0;min-height:0">
+
+        <!-- File tree -->
+        <div style="border-right:1px solid var(--bd);background:var(--bg-elev);overflow-y:auto">
+          <div style="padding:8px 12px;border-bottom:1px solid var(--bd);display:flex;align-items:center;gap:6px">
+            <input class="input mono" placeholder="filter / fuzzy" style="font-size:11.5px;padding:3px 6px" />
+            <button class="btn ghost" style="padding:3px 6px"><span class="g">↻</span></button>
+          </div>
+          <div class="tree">
+            <div class="tree-node open"><span class="indent"></span><span class="arrow">▾</span><span class="icon dir">▣</span><span class="name">src</span></div>
+            <div class="tree-node open"><span class="indent"></span><span class="indent"></span><span class="arrow">▾</span><span class="icon dir">▣</span><span class="name">cli</span></div>
+            <div class="tree-node open"><span class="indent"></span><span class="indent"></span><span class="indent"></span><span class="arrow">▾</span><span class="icon dir">▣</span><span class="name">ui</span></div>
+            <div class="tree-node"><span class="indent"></span><span class="indent"></span><span class="indent"></span><span class="indent"></span><span class="arrow"></span><span class="icon tsx">›</span><span class="name">App.tsx</span><span class="modified">●</span></div>
+            <div class="tree-node sel"><span class="indent"></span><span class="indent"></span><span class="indent"></span><span class="indent"></span><span class="arrow"></span><span class="icon tsx">›</span><span class="name">PromptInput.tsx</span><span class="modified">●</span></div>
+            <div class="tree-node"><span class="indent"></span><span class="indent"></span><span class="indent"></span><span class="indent"></span><span class="arrow"></span><span class="icon tsx">›</span><span class="name">SessionPicker.tsx</span></div>
+            <div class="tree-node open"><span class="indent"></span><span class="indent"></span><span class="indent"></span><span class="indent"></span><span class="arrow">▾</span><span class="icon dir">▣</span><span class="name">cards</span><span class="badge">14</span></div>
+            <div class="tree-node"><span class="indent"></span><span class="indent"></span><span class="indent"></span><span class="indent"></span><span class="indent"></span><span class="arrow"></span><span class="icon tsx">›</span><span class="name">ApprovalCard.tsx</span></div>
+            <div class="tree-node"><span class="indent"></span><span class="indent"></span><span class="indent"></span><span class="indent"></span><span class="indent"></span><span class="arrow"></span><span class="icon tsx">›</span><span class="name">PlanCard.tsx</span></div>
+            <div class="tree-node"><span class="indent"></span><span class="indent"></span><span class="indent"></span><span class="indent"></span><span class="indent"></span><span class="arrow"></span><span class="icon tsx">›</span><span class="name">SubAgentCard.tsx</span></div>
+            <div class="tree-node"><span class="indent"></span><span class="indent"></span><span class="indent"></span><span class="indent"></span><span class="arrow">▸</span><span class="icon dir">▣</span><span class="name">layout</span></div>
+            <div class="tree-node"><span class="indent"></span><span class="indent"></span><span class="indent"></span><span class="indent"></span><span class="arrow">▸</span><span class="icon dir">▣</span><span class="name">state</span></div>
+            <div class="tree-node"><span class="indent"></span><span class="indent"></span><span class="indent"></span><span class="arrow">▸</span><span class="icon dir">▣</span><span class="name">commands</span></div>
+            <div class="tree-node"><span class="indent"></span><span class="indent"></span><span class="arrow">▸</span><span class="icon dir">▣</span><span class="name">code</span></div>
+            <div class="tree-node"><span class="indent"></span><span class="indent"></span><span class="arrow">▸</span><span class="icon dir">▣</span><span class="name">tools</span></div>
+            <div class="tree-node"><span class="indent"></span><span class="indent"></span><span class="arrow"></span><span class="icon tsx">›</span><span class="name">loop.ts</span></div>
+            <div class="tree-node"><span class="indent"></span><span class="arrow">▸</span><span class="icon dir">▣</span><span class="name">design</span></div>
+            <div class="tree-node"><span class="indent"></span><span class="arrow">▸</span><span class="icon dir">▣</span><span class="name">tests</span></div>
+            <div class="tree-node"><span class="indent"></span><span class="arrow"></span><span class="icon md">›</span><span class="name">CLAUDE.md</span></div>
+            <div class="tree-node"><span class="indent"></span><span class="arrow"></span><span class="icon json">›</span><span class="name">package.json</span></div>
+          </div>
+        </div>
+
+        <!-- Editor pane: tabs + code + status -->
+        <div style="display:flex;flex-direction:column;min-height:0">
+          <div class="editor-tabs">
+            <div class="editor-tab"><span class="dot"></span><span>App.tsx</span><span class="x">×</span></div>
+            <div class="editor-tab active"><span class="dot"></span><span>PromptInput.tsx</span><span class="x">×</span></div>
+            <div class="editor-tab"><span>chat.tsx</span><span class="x">×</span></div>
+          </div>
+          <div class="editor-area">
+            <div class="editor-line"><span class="lineno">47</span><span class="ln-content">  <span class="kw">const</span> pastesRef <span class="kw">=</span> <span class="fn">useRef</span>&lt;<span class="typ">Map</span>&lt;<span class="typ">number</span>, <span class="typ">PasteEntry</span>&gt;&gt;(<span class="kw">new</span> <span class="typ">Map</span>());</span></div>
+            <div class="editor-line"><span class="lineno">48</span><span class="ln-content">  <span class="kw">const</span> nextPasteIdRef <span class="kw">=</span> <span class="fn">useRef</span>&lt;<span class="typ">number</span>&gt;(<span class="num">0</span>);</span></div>
+            <div class="editor-line"><span class="lineno">49</span><span class="ln-content"></span></div>
+            <div class="editor-line"><span class="lineno">50</span><span class="ln-content">  <span class="com">// Refs (not props/state) — multiple keystrokes in one stdin chunk dispatch</span></span></div>
+            <div class="editor-line"><span class="lineno">51</span><span class="ln-content">  <span class="com">// before re-render, so the handler must read the latest value/cursor.</span></span></div>
+            <div class="editor-line cur"><span class="lineno">52</span><span class="ln-content">  <span class="kw">const</span> lastLocalValueRef <span class="kw">=</span> <span class="fn">useRef</span>(value);</span></div>
+            <div class="editor-line"><span class="lineno">53</span><span class="ln-content">  <span class="kw">const</span> cursorRef <span class="kw">=</span> <span class="fn">useRef</span>(cursor);</span></div>
+            <div class="editor-line"><span class="lineno">54</span><span class="ln-content">  cursorRef.current <span class="kw">=</span> cursor;</span></div>
+            <div class="editor-line"><span class="lineno">55</span><span class="ln-content">  <span class="kw">if</span> (value <span class="kw">!==</span> lastLocalValueRef.current) {</span></div>
+            <div class="editor-line"><span class="lineno">56</span><span class="ln-content">    lastLocalValueRef.current <span class="kw">=</span> value;</span></div>
+            <div class="editor-line"><span class="lineno">57</span><span class="ln-content">    <span class="kw">if</span> (cursor <span class="kw">!==</span> value.length) <span class="fn">setCursor</span>(value.length);</span></div>
+            <div class="editor-line"><span class="lineno">58</span><span class="ln-content">  }</span></div>
+            <div class="editor-line"><span class="lineno">59</span><span class="ln-content"></span></div>
+            <div class="editor-line"><span class="lineno">60</span><span class="ln-content">  <span class="com">// History recall callbacks…</span></span></div>
+            <div class="editor-line"><span class="lineno">61</span><span class="ln-content">  <span class="kw">const</span> <span class="fn">recallPrev</span> <span class="kw">=</span> () <span class="kw">=&gt;</span> {</span></div>
+            <div class="editor-line"><span class="lineno">62</span><span class="ln-content">    <span class="kw">if</span> (!history?.length) <span class="kw">return</span>;</span></div>
+            <div class="editor-line"><span class="lineno">63</span><span class="ln-content">    <span class="kw">const</span> idx <span class="kw">=</span> historyIdx ?? history.length;</span></div>
+          </div>
+          <div class="editor-status">
+            <span><span class="glyph">●</span> <span class="v">PromptInput.tsx</span></span>
+            <span>typescript-react · LF · UTF-8</span>
+            <span style="color:var(--c-warn)">unsaved</span>
+            <span class="grow"></span>
+            <span>Ln <span class="v">52</span>, Col <span class="v">17</span></span>
+            <span>· <span class="v" style="color:var(--c-ok)">+1</span> <span class="v" style="color:var(--c-err)">−2</span></span>
+            <span>· main</span>
+          </div>
+        </div>
+
+      </div>
+
+      <footer class="app-status">
+        <span class="item"><span class="dot"></span><span>tools <span class="v">23</span></span></span>
+        <span class="grow"></span>
+        <span class="item">3 files unsaved</span>
+      </footer>
+    </div>
+  </div>
+
+  <div class="subsec">
+    <h3>Cmd-P file picker</h3>
+    <p>Reuses the command palette component. Pre-filtered to files. Recently-touched-by-agent files are pinned to the top with a glyph; followed by recently-opened-by-user; followed by everything else fuzzy-matched.</p>
+    <div class="mock">
+      <div class="overlay" style="height:300px;background:var(--bg);align-items:flex-start;padding-top:48px">
+        <div class="cmd-palette">
+          <div class="cmd-input-row">
+            <span class="g">›</span>
+            <input value="prom" />
+            <span class="kbd">esc</span>
+          </div>
+          <div class="cmd-list">
+            <div class="cmd-section-h">touched by agent · this session</div>
+            <div class="cmd-row sel"><span class="g">›</span><span class="name">PromptInput.tsx</span><span class="desc">src/cli/ui · modified · ↵ to open</span></div>
+            <div class="cmd-row"><span class="g">›</span><span class="name">prompt.ts</span><span class="desc">src/code · modified</span></div>
+            <div class="cmd-section-h">recently opened</div>
+            <div class="cmd-row"><span class="g">›</span><span class="name">PlanCard.tsx</span><span class="desc">src/cli/ui/cards</span></div>
+            <div class="cmd-row"><span class="g">›</span><span class="name">prompt-viewport.ts</span><span class="desc">src/cli/ui</span></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<section class="section" id="plans">
+  <h2><span class="num">§8</span>Plans</h2>
+  <p class="lede">
+    Plans live longer than a turn — they survive across sessions if the work
+    isn't done. The Plans panel is where they're browsed (left list), inspected
+    (right detail), and resumed. The headline element is the <b>horizontal step
+    timeline</b> at the top of the detail — done / active / pending / failed at
+    a glance, click a step to drill into its dispatched tool calls and outputs.
+  </p>
+
+  <div class="mock">
+    <div class="app">
+      <aside class="app-side">
+        <div class="brand"><span class="glyph">◈</span><span class="label">REASONIX</span><span class="ver">0.18.1</span></div>
+        <div class="side-tabs">
+          <div class="side-tab"><span class="g">◆</span><span class="label">Chat</span></div>
+          <div class="side-tab"><span class="g">✎</span><span class="label">Editor</span></div>
+          <div class="side-tab active"><span class="g">⊞</span><span class="label">Plans</span><span class="badge">2</span></div>
+          <div class="side-tab"><span class="g">›</span><span class="label">Sessions</span></div>
+          <div class="side-section">observe</div>
+          <div class="side-tab"><span class="g">◈</span><span class="label">Overview</span></div>
+        </div>
+        <div class="side-foot"><span class="label">localhost:8742</span><span class="toggle">«</span></div>
+      </aside>
+
+      <header class="app-top">
+        <div class="crumbs">
+          <span class="crumb dim">~/work/reasonix</span>
+          <span class="sep">›</span>
+          <span class="crumb">plans</span>
+          <span class="sep">›</span>
+          <span class="crumb" style="color:var(--c-accent)">release 0.18.1</span>
+        </div>
+        <span class="grow"></span>
+        <span class="tui-status online"><span class="dot"></span>TUI · #2</span>
+        <span class="meter"><span class="lbl">balance</span><span class="v" style="color:var(--c-ok)">¥48.20</span></span>
+      </header>
+
+      <div class="app-body" style="padding:14px 18px">
+        <div class="sessions-grid">
+
+          <div class="sessions-list">
+            <div class="ssl-h">
+              <input placeholder="filter plans" />
+            </div>
+            <div class="chips" style="padding:0 12px 8px">
+              <span class="chip-f active">all <span class="ct">2</span></span>
+              <span class="chip-f">active <span class="ct">1</span></span>
+              <span class="chip-f">archived <span class="ct">12</span></span>
+              <span class="chip-f">failed <span class="ct">3</span></span>
+            </div>
+            <div class="ssl-rows">
+              <div class="ssl-row sel">
+                <span class="name">release 0.18.1 + deprecate 0.18.0 <span class="pill info" style="margin-left:4px">active</span></span>
+                <span class="preview">Drop zombie commit, bump 0.18.1, publish, deprecate previous</span>
+                <span class="meta"><span class="v">5</span> steps · <span class="v">3 / 5</span> done · 4m</span>
+              </div>
+              <div class="ssl-row">
+                <span class="name">dashboard redesign · drafted</span>
+                <span class="preview">Build §1-§13 design mockups for web companion</span>
+                <span class="meta"><span class="v">8</span> steps · <span class="v">5 / 8</span> done · 1h</span>
+              </div>
+              <div class="ssl-row">
+                <span class="name">tui-card-stream finalize <span class="pill ok" style="margin-left:4px">done</span></span>
+                <span class="preview">Migrate last UI surfaces onto card pipeline; drop legacy modules</span>
+                <span class="meta"><span class="v">6 / 6</span> done · today</span>
+              </div>
+              <div class="ssl-row">
+                <span class="name">events.jsonl sidecar lifecycle <span class="pill ok" style="margin-left:4px">done</span></span>
+                <span class="preview">Filter from listing; rename/delete moves; drop model.delta</span>
+                <span class="meta"><span class="v">3 / 3</span> done · today</span>
+              </div>
+              <div class="ssl-row">
+                <span class="name">remove change_workspace tool <span class="pill ok" style="margin-left:4px">done</span></span>
+                <span class="preview">Drop racy mid-session cwd switch; pin workspace at launch</span>
+                <span class="meta"><span class="v">4 / 4</span> done · today</span>
+              </div>
+              <div class="ssl-row">
+                <span class="name">dashboard sidebar Editor <span class="pill ok" style="margin-left:4px">done</span></span>
+                <span class="preview">File tree + CodeMirror integration in dashboard</span>
+                <span class="meta"><span class="v">5 / 5</span> done · 2d ago</span>
+              </div>
+              <div class="ssl-row">
+                <span class="name">scrollback wheel scroll fix <span class="pill err" style="margin-left:4px">failed</span></span>
+                <span class="preview">Couldn't reproduce on Win10 cmd; needs different repro env</span>
+                <span class="meta"><span class="v">2 / 6</span> · 3d ago</span>
+              </div>
+            </div>
+          </div>
+
+          <div class="sessions-detail">
+            <div class="sessions-detail-h">
+              <span class="name">release 0.18.1 + deprecate 0.18.0</span>
+              <span class="ws">2026-04-30-2014 · 4m elapsed</span>
+              <span class="actions">
+                <button class="btn"><span class="g">⏵</span><span>resume</span></button>
+                <button class="btn ghost">archive</button>
+              </span>
+            </div>
+
+            <h3 style="margin:0 0 6px;font-family:var(--font-mono);font-size:11px;color:var(--fg-3);text-transform:uppercase;letter-spacing:.1em">Step timeline</h3>
+            <div class="plan-timeline" style="margin-bottom:14px">
+              <div class="plan-step done">
+                <span class="lbl">step 1</span>
+                <span class="name">drop zombie commit</span>
+                <span class="meta">git reset · 2s</span>
+              </div>
+              <div class="plan-step done">
+                <span class="lbl">step 2</span>
+                <span class="name">bump 0.18.1</span>
+                <span class="meta">npm version · 4s</span>
+              </div>
+              <div class="plan-step active">
+                <span class="lbl">step 3</span>
+                <span class="name">build &amp; verify</span>
+                <span class="meta">in progress · 23s</span>
+              </div>
+              <div class="plan-step">
+                <span class="lbl">step 4</span>
+                <span class="name">npm publish</span>
+                <span class="meta">pending</span>
+              </div>
+              <div class="plan-step">
+                <span class="lbl">step 5</span>
+                <span class="name">deprecate 0.18.0</span>
+                <span class="meta">pending</span>
+              </div>
+            </div>
+
+            <div class="sessions-detail-kpis">
+              <div class="kp"><div class="lbl">steps done</div><div class="v">3 / 5</div></div>
+              <div class="kp"><div class="lbl">elapsed</div><div class="v">4m 12s</div></div>
+              <div class="kp"><div class="lbl">tokens used</div><div class="v">12,840</div></div>
+              <div class="kp"><div class="lbl">cost</div><div class="v">¥0.62</div></div>
+            </div>
+
+            <h3 style="margin:0 0 6px;font-family:var(--font-mono);font-size:11px;color:var(--fg-3);text-transform:uppercase;letter-spacing:.1em">Step 3 · build &amp; verify <span style="color:var(--c-brand);font-weight:600;text-transform:none;letter-spacing:.04em;font-size:12px">› in progress</span></h3>
+            <div class="card accent-brand" style="margin:0 0 8px">
+              <div class="card-h"><span class="glyph">▣</span><span class="title">run_command</span><span class="meta">npm run verify · 23s elapsed</span></div>
+              <div class="card-b mono" style="font-size:11.5px;color:var(--fg-2);max-height:80px;overflow:hidden">
+                ✓ tests/session.test.ts (8)<br>
+                ✓ tests/loop.test.ts (12)<br>
+                ✓ tests/event-sink-jsonl.test.ts (4)<br>
+                ✓ tests/hydrate-cards.test.ts (8)<br>
+                <span style="color:var(--c-brand)">⏵ tests/jobs.test.ts (running…)</span>
+              </div>
+              <div class="progress indet" style="margin-top:8px"><div class="progress-fill"></div></div>
+            </div>
+          </div>
+
+        </div>
+      </div>
+
+      <footer class="app-status">
+        <span class="item"><span class="dot"></span><span>tools <span class="v">23</span></span></span>
+        <span class="grow"></span>
+        <span class="item">2 active plans</span>
+      </footer>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<section class="section" id="usage">
+  <h2><span class="num">§9</span>Usage</h2>
+  <p class="lede">
+    Cost &amp; token analytics. Time-range tabs at the top, big stacked area chart
+    in the middle (cost-per-day, stacked by tool source), donut breakdown for the
+    selected range, and a top-N tools table at the bottom. The four KPI cards
+    above the chart are the same set used on Overview — consistency, not duplication.
+  </p>
+
+  <div class="mock">
+    <div class="app">
+      <aside class="app-side">
+        <div class="brand"><span class="glyph">◈</span><span class="label">REASONIX</span><span class="ver">0.18.1</span></div>
+        <div class="side-tabs">
+          <div class="side-tab"><span class="g">◆</span><span class="label">Chat</span></div>
+          <div class="side-tab"><span class="g">⊞</span><span class="label">Plans</span></div>
+          <div class="side-tab"><span class="g">›</span><span class="label">Sessions</span></div>
+          <div class="side-section">observe</div>
+          <div class="side-tab"><span class="g">◈</span><span class="label">Overview</span></div>
+          <div class="side-tab active"><span class="g">$</span><span class="label">Usage</span></div>
+          <div class="side-tab"><span class="g">+</span><span class="label">System</span></div>
+        </div>
+        <div class="side-foot"><span class="label">localhost:8742</span><span class="toggle">«</span></div>
+      </aside>
+
+      <header class="app-top">
+        <div class="crumbs">
+          <span class="crumb dim">~/work/reasonix</span>
+          <span class="sep">›</span>
+          <span class="crumb">usage</span>
+          <span class="sep">›</span>
+          <span class="crumb" style="color:var(--c-brand)">last 14 days</span>
+        </div>
+        <span class="grow"></span>
+        <span class="meter"><span class="lbl">balance</span><span class="v" style="color:var(--c-ok)">¥48.20</span></span>
+        <span class="meter"><span class="lbl">budget</span><span class="v" style="color:var(--c-warn)">78 / 100</span></span>
+      </header>
+
+      <div class="app-body" style="padding:14px 18px">
+        <!-- Range tabs -->
+        <div class="form-tabs" style="margin-bottom:14px">
+          <span class="form-tab">24h</span>
+          <span class="form-tab">7d</span>
+          <span class="form-tab active">14d</span>
+          <span class="form-tab">30d</span>
+          <span class="form-tab">all</span>
+          <span style="margin-left:auto;display:flex;gap:6px;align-items:center;font-family:var(--font-mono);font-size:11px;color:var(--fg-3);padding:4px 0">
+            <span>group by</span>
+            <select class="select mono" style="padding:2px 6px;width:auto;font-size:11px"><option>tool source</option><option>session</option><option>direction</option></select>
+          </span>
+        </div>
+
+        <!-- KPI strip -->
+        <div class="cockpit" style="grid-template-columns:repeat(4, 1fr);margin-bottom:14px">
+          <div class="kpi"><div class="label">total cost</div><div class="value">¥31.84</div><div class="delta up">▲ 12% vs prior 14d</div></div>
+          <div class="kpi"><div class="label">tokens · in</div><div class="value">1.42M</div><div class="delta up">▲ 8%</div></div>
+          <div class="kpi"><div class="label">tokens · out</div><div class="value">186k</div><div class="delta flat">— flat</div></div>
+          <div class="kpi"><div class="label">cache hit</div><div class="value">94<span class="unit">%</span></div><div class="delta up">▲ 2 pts</div></div>
+        </div>
+
+        <!-- Stacked area chart -->
+        <div class="chart" style="margin-bottom:14px">
+          <div class="chart-h"><span class="title">cost · 14 day · stacked by source</span><span class="delta" style="color:var(--fg-3)">¥18.40 / day avg</span></div>
+          <div style="display:grid;grid-template-columns:1fr 180px;gap:18px;align-items:center">
+            <svg viewBox="0 0 600 140" preserveAspectRatio="none" style="width:100%;height:140px">
+              <!-- Grid lines -->
+              <g stroke="#14171e" stroke-width="0.5">
+                <line x1="0" y1="35"  x2="600" y2="35"  />
+                <line x1="0" y1="70"  x2="600" y2="70"  />
+                <line x1="0" y1="105" x2="600" y2="105" />
+              </g>
+              <!-- Bottom layer: native fs (s3 mint) -->
+              <polygon fill="rgba(126,231,135,.45)" points="0,140 0,105 43,108 86,100 129,110 172,98 215,103 258,92 301,95 344,88 387,93 430,80 473,84 516,75 559,80 600,72 600,140" />
+              <!-- Middle layer: shell (s1 sky) -->
+              <polygon fill="rgba(121,192,255,.45)" points="0,105 43,108 86,100 129,110 172,98 215,103 258,92 301,95 344,88 387,93 430,80 473,84 516,75 559,80 600,72
+                                                              600,55 559,62 516,55 473,64 430,58 387,72 344,65 301,73 258,68 215,80 172,72 129,84 86,76 43,84 0,80" />
+              <!-- Top layer: mcp (s4 amber) -->
+              <polygon fill="rgba(240,176,125,.45)" points="0,80 43,84 86,76 129,84 172,72 215,80 258,68 301,73 344,65 387,72 430,58 473,64 430,58 387,72 344,65 301,73 258,68 215,80 172,72 129,84 86,76 43,84 0,80
+                                                              0,55 43,58 86,52 129,60 172,50 215,55 258,45 301,52 344,40 387,48 430,35 473,42 516,30 559,38 600,28
+                                                              600,55 559,62 516,55 473,64 430,58 387,72 344,65 301,73 258,68 215,80 172,72 129,84 86,76 43,84 0,80" />
+              <!-- Top stroke for visibility -->
+              <polyline fill="none" stroke="#f0b07d" stroke-width="1" points="0,55 43,58 86,52 129,60 172,50 215,55 258,45 301,52 344,40 387,48 430,35 473,42 516,30 559,38 600,28" />
+            </svg>
+            <div class="donut-legend">
+              <div class="row"><span class="dot" style="background:#7ee787"></span><span>native · fs</span><span class="v">¥14.20</span></div>
+              <div class="row"><span class="dot" style="background:#79c0ff"></span><span>native · shell</span><span class="v">¥10.40</span></div>
+              <div class="row"><span class="dot" style="background:#f0b07d"></span><span>mcp · *</span><span class="v">¥4.80</span></div>
+              <div class="row"><span class="dot" style="background:#d2a8ff"></span><span>subagent</span><span class="v">¥2.44</span></div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Donut + Top-N -->
+        <div style="display:grid;grid-template-columns:240px 1fr;gap:14px">
+          <div class="card">
+            <div class="card-h"><span class="title">cost share · 14d</span></div>
+            <div style="display:flex;align-items:center;gap:14px;padding:8px 0">
+              <svg width="120" height="120" viewBox="0 0 120 120" style="transform:rotate(-90deg)">
+                <circle cx="60" cy="60" r="44" fill="none" stroke="#11141a" stroke-width="14"/>
+                <circle cx="60" cy="60" r="44" fill="none" stroke="#7ee787" stroke-width="14" stroke-dasharray="276.5" stroke-dashoffset="153" />
+                <circle cx="60" cy="60" r="44" fill="none" stroke="#79c0ff" stroke-width="14" stroke-dasharray="276.5" stroke-dashoffset="186" transform="rotate(160 60 60)"/>
+                <circle cx="60" cy="60" r="44" fill="none" stroke="#f0b07d" stroke-width="14" stroke-dasharray="276.5" stroke-dashoffset="234" transform="rotate(265 60 60)"/>
+                <circle cx="60" cy="60" r="44" fill="none" stroke="#d2a8ff" stroke-width="14" stroke-dasharray="276.5" stroke-dashoffset="252" transform="rotate(322 60 60)"/>
+              </svg>
+              <div style="font-family:var(--font-mono);font-size:11px;color:var(--fg-2);line-height:1.7">
+                <div><span style="color:#7ee787">●</span> fs <span style="color:var(--fg-0)">45%</span></div>
+                <div><span style="color:#79c0ff">●</span> shell <span style="color:var(--fg-0)">33%</span></div>
+                <div><span style="color:#f0b07d">●</span> mcp <span style="color:var(--fg-0)">15%</span></div>
+                <div><span style="color:#d2a8ff">●</span> subagent <span style="color:var(--fg-0)">7%</span></div>
+              </div>
+            </div>
+          </div>
+
+          <div class="card">
+            <div class="card-h"><span class="title">top tools · by cost</span><span class="meta">14d</span></div>
+            <table class="tbl" style="margin-top:6px">
+              <thead><tr><th>Tool</th><th>Source</th><th class="mono" style="text-align:right">calls</th><th class="mono" style="text-align:right">tokens</th><th class="mono" style="text-align:right">cost</th><th></th></tr></thead>
+              <tbody>
+                <tr><td><code class="mono">read_file</code></td><td class="dim">native · fs</td><td class="num">3,420</td><td class="num">812k</td><td class="num">¥9.40</td><td><div class="progress thin" style="width:60px"><div class="progress-fill" style="width:100%"></div></div></td></tr>
+                <tr><td><code class="mono">edit_file</code></td><td class="dim">native · fs</td><td class="num">412</td><td class="num">340k</td><td class="num">¥4.20</td><td><div class="progress thin" style="width:60px"><div class="progress-fill" style="width:45%"></div></div></td></tr>
+                <tr><td><code class="mono">run_command</code></td><td class="dim">native · shell</td><td class="num">128</td><td class="num">280k</td><td class="num">¥3.10</td><td><div class="progress thin" style="width:60px"><div class="progress-fill" style="width:33%"></div></div></td></tr>
+                <tr><td><code class="mono">grep_files</code></td><td class="dim">native · fs</td><td class="num">62</td><td class="num">42k</td><td class="num">¥0.68</td><td><div class="progress thin" style="width:60px"><div class="progress-fill" style="width:7%"></div></div></td></tr>
+                <tr><td><code class="mono">github__get_pr</code></td><td class="dim">mcp · github</td><td class="num">14</td><td class="num">38k</td><td class="num">¥0.52</td><td><div class="progress thin" style="width:60px"><div class="progress-fill" style="width:5%"></div></div></td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+      </div>
+
+      <footer class="app-status">
+        <span class="item"><span class="dot"></span><span>tools <span class="v">23</span></span></span>
+        <span class="grow"></span>
+        <span class="item">refreshed 12s ago</span>
+      </footer>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<section class="section" id="inventories">
+  <h2><span class="num">§10</span>Inventories</h2>
+  <p class="lede">
+    Five panels share one pattern: <b>filter chips → big table → detail drawer</b>.
+    Tools, MCP servers, Skills, Memory entries, Permissions allowlist. The schema
+    of the data differs; the layout doesn't. Build one component, parameterize it.
+    Showing Tools as the master mock; the variants below render the same surface
+    with different data.
+  </p>
+
+  <p class="mock-cap">— Tools panel: master mock</p>
+  <div class="mock">
+    <div class="app">
+      <aside class="app-side">
+        <div class="brand"><span class="glyph">◈</span><span class="label">REASONIX</span><span class="ver">0.18.1</span></div>
+        <div class="side-tabs">
+          <div class="side-tab"><span class="g">◆</span><span class="label">Chat</span></div>
+          <div class="side-section">configure</div>
+          <div class="side-tab active"><span class="g">▣</span><span class="label">Tools</span><span class="badge">23</span></div>
+          <div class="side-tab"><span class="g">▎</span><span class="label">Permissions</span></div>
+          <div class="side-tab"><span class="g">M</span><span class="label">MCP</span></div>
+          <div class="side-tab"><span class="g">S</span><span class="label">Skills</span></div>
+          <div class="side-tab"><span class="g">·</span><span class="label">Memory</span></div>
+        </div>
+        <div class="side-foot"><span class="label">localhost:8742</span><span class="toggle">«</span></div>
+      </aside>
+
+      <header class="app-top">
+        <div class="crumbs">
+          <span class="crumb dim">~/work/reasonix</span>
+          <span class="sep">›</span>
+          <span class="crumb">tools</span>
+          <span class="sep">›</span>
+          <span class="crumb" style="color:var(--c-brand)">edit_file</span>
+        </div>
+        <span class="grow"></span>
+        <span class="meter"><span class="lbl">loaded</span><span class="v">23 / 24</span></span>
+      </header>
+
+      <div class="app-body" style="padding:14px 18px">
+        <div class="chips">
+          <span class="chip-f active">all <span class="ct">23</span></span>
+          <span class="chip-f">native · fs <span class="ct">7</span></span>
+          <span class="chip-f">native · shell <span class="ct">3</span></span>
+          <span class="chip-f">native · web <span class="ct">2</span></span>
+          <span class="chip-f">mcp · github <span class="ct">5</span></span>
+          <span class="chip-f">mcp · slack <span class="ct">4</span></span>
+          <span class="chip-f">subagent <span class="ct">2</span></span>
+          <span class="chip-f" style="border-color:var(--c-err);color:var(--c-err)">failed <span class="ct">1</span><span class="x">×</span></span>
+        </div>
+
+        <div class="inv-grid">
+          <div class="card" style="padding:0;overflow:hidden">
+            <table class="tbl">
+              <thead><tr><th>Tool</th><th>Source</th><th>Last call</th><th class="mono" style="text-align:right">calls · 7d</th><th></th></tr></thead>
+              <tbody>
+                <tr><td><code class="mono">read_file</code></td><td class="dim">native · fs</td><td class="path">App.tsx</td><td class="num">1,420</td><td><span class="pill ok">ok</span></td></tr>
+                <tr style="background:var(--bg-hover)"><td><code class="mono">edit_file</code></td><td class="dim">native · fs</td><td class="path">PromptInput.tsx</td><td class="num">312</td><td><span class="pill ok">ok</span></td></tr>
+                <tr><td><code class="mono">grep_files</code></td><td class="dim">native · fs</td><td class="path">"workspace"</td><td class="num">62</td><td><span class="pill ok">ok</span></td></tr>
+                <tr><td><code class="mono">run_command</code></td><td class="dim">native · shell</td><td class="path">npm run verify</td><td class="num">128</td><td><span class="pill ok">ok</span></td></tr>
+                <tr><td><code class="mono">run_background</code></td><td class="dim">native · shell</td><td class="path">npm run dev</td><td class="num">14</td><td><span class="pill ok">ok</span></td></tr>
+                <tr><td><code class="mono">github__get_pr</code></td><td class="dim">mcp · github</td><td class="path">esengine/reasonix#13</td><td class="num">8</td><td><span class="pill ok">ok</span></td></tr>
+                <tr><td><code class="mono">github__create_pr</code></td><td class="dim">mcp · github</td><td class="path">—</td><td class="num">0</td><td><span class="pill">idle</span></td></tr>
+                <tr><td><code class="mono">slack__post_message</code></td><td class="dim">mcp · slack</td><td class="path">#dev</td><td class="num">3</td><td><span class="pill ok">ok</span></td></tr>
+                <tr><td><code class="mono">python_runner</code></td><td class="dim">subagent</td><td class="path">—</td><td class="num">0</td><td><span class="pill err">load fail</span></td></tr>
+              </tbody>
+            </table>
+          </div>
+
+          <!-- Detail drawer for selected tool -->
+          <aside style="display:flex;flex-direction:column;gap:10px">
+            <div class="card accent-brand">
+              <div class="card-h"><span class="glyph">▣</span><span class="title">edit_file</span><span class="meta">native · fs</span></div>
+              <p style="margin:0;font-size:12px;color:var(--fg-2)">SEARCH/REPLACE block editor; the safe mode wraps every edit in a content hash check before write.</p>
+            </div>
+
+            <div class="card">
+              <div class="card-h"><span class="title">schema</span></div>
+              <div class="schema"><span class="key">"file_path"</span>: <span class="typ">string</span> <span class="req">// required</span>
+<span class="key">"old_string"</span>: <span class="typ">string</span> <span class="req">// required</span>
+<span class="key">"new_string"</span>: <span class="typ">string</span> <span class="req">// required</span>
+<span class="key">"replace_all"</span>: <span class="typ">boolean</span>  <span class="com">// default false</span></div>
+            </div>
+
+            <div class="card">
+              <div class="card-h"><span class="title">recent calls</span></div>
+              <div style="font-family:var(--font-mono);font-size:11px;color:var(--fg-2);line-height:1.7">
+                <div><span style="color:var(--fg-4)">02:31</span> · PromptInput.tsx · <span style="color:var(--c-ok)">ok</span></div>
+                <div><span style="color:var(--fg-4)">02:28</span> · chat.tsx · <span style="color:var(--c-ok)">ok</span></div>
+                <div><span style="color:var(--fg-4)">02:22</span> · App.tsx · <span style="color:var(--c-ok)">ok</span></div>
+                <div><span style="color:var(--fg-4)">02:14</span> · session.ts · <span style="color:var(--c-warn)">retry 1</span></div>
+              </div>
+            </div>
+          </aside>
+        </div>
+      </div>
+
+      <footer class="app-status">
+        <span class="item"><span class="dot"></span><span>23 of 24 loaded</span></span>
+        <span class="item"><span class="dot err"></span><span>1 failed</span></span>
+        <span class="grow"></span>
+        <span class="item">last refresh 8s</span>
+      </footer>
+    </div>
+  </div>
+
+  <p class="mock-cap">— Same pattern, different data: MCP, Skills, Memory, Permissions</p>
+  <div style="display:grid;grid-template-columns:repeat(2, 1fr);gap:14px">
+
+    <div>
+      <div style="font-family:var(--font-mono);font-size:10px;color:var(--fg-3);text-transform:uppercase;letter-spacing:.1em;margin-bottom:6px">M · MCP servers</div>
+      <div class="card" style="padding:0;overflow:hidden">
+        <div class="chips" style="padding:8px 12px 6px;border-bottom:1px solid var(--bd)">
+          <span class="chip-f active">running <span class="ct">2</span></span>
+          <span class="chip-f">stopped <span class="ct">0</span></span>
+          <span class="chip-f">errored <span class="ct">0</span></span>
+        </div>
+        <table class="tbl">
+          <thead><tr><th>Server</th><th>Transport</th><th class="mono" style="text-align:right">tools</th><th>State</th></tr></thead>
+          <tbody>
+            <tr><td><code class="mono">github</code></td><td class="dim">stdio</td><td class="num">5</td><td><span class="pill ok">● up · 14m</span></td></tr>
+            <tr><td><code class="mono">slack</code></td><td class="dim">streamable-http</td><td class="num">4</td><td><span class="pill ok">● up · 14m</span></td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div>
+      <div style="font-family:var(--font-mono);font-size:10px;color:var(--fg-3);text-transform:uppercase;letter-spacing:.1em;margin-bottom:6px">S · Skills</div>
+      <div class="card" style="padding:0;overflow:hidden">
+        <div class="chips" style="padding:8px 12px 6px;border-bottom:1px solid var(--bd)">
+          <span class="chip-f active">all <span class="ct">8</span></span>
+          <span class="chip-f">subagent <span class="ct">2</span></span>
+          <span class="chip-f">inline <span class="ct">6</span></span>
+        </div>
+        <table class="tbl">
+          <thead><tr><th>Skill</th><th>Kind</th><th class="mono" style="text-align:right">runs</th></tr></thead>
+          <tbody>
+            <tr><td><code class="mono">init</code></td><td class="dim">inline</td><td class="num">3</td></tr>
+            <tr><td><code class="mono">review</code></td><td class="dim">inline</td><td class="num">12</td></tr>
+            <tr><td><code class="mono">security-review</code></td><td class="dim">subagent</td><td class="num">2</td></tr>
+            <tr><td><code class="mono">simplify</code></td><td class="dim">inline</td><td class="num">8</td></tr>
+            <tr><td><code class="mono">claude-api</code></td><td class="dim">inline</td><td class="num">4</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div>
+      <div style="font-family:var(--font-mono);font-size:10px;color:var(--fg-3);text-transform:uppercase;letter-spacing:.1em;margin-bottom:6px">· Memory entries</div>
+      <div class="card" style="padding:0;overflow:hidden">
+        <div class="chips" style="padding:8px 12px 6px;border-bottom:1px solid var(--bd)">
+          <span class="chip-f active">all <span class="ct">14</span></span>
+          <span class="chip-f">user <span class="ct">3</span></span>
+          <span class="chip-f">feedback <span class="ct">5</span></span>
+          <span class="chip-f">project <span class="ct">5</span></span>
+          <span class="chip-f">reference <span class="ct">1</span></span>
+        </div>
+        <div style="padding:8px 12px;font-family:var(--font-mono);font-size:11px;color:var(--fg-2);line-height:1.7;max-height:160px;overflow:auto">
+          <div><span class="pill warn" style="font-size:9px">FB</span> No Co-Authored-By trailer</div>
+          <div><span class="pill warn" style="font-size:9px">FB</span> No conversation in code comments</div>
+          <div><span class="pill warn" style="font-size:9px">FB</span> Tokenization facts (DeepSeek BPE)</div>
+          <div><span class="pill info" style="font-size:9px">PJ</span> v0.18 dashboard redesign queue</div>
+          <div><span class="pill info" style="font-size:9px">PJ</span> 0.18.1 ghost-frame deprecation</div>
+          <div><span class="pill ok" style="font-size:9px">U</span> User env: PowerShell + RMB</div>
+        </div>
+      </div>
+    </div>
+
+    <div>
+      <div style="font-family:var(--font-mono);font-size:10px;color:var(--fg-3);text-transform:uppercase;letter-spacing:.1em;margin-bottom:6px">▎ Permissions allowlist</div>
+      <div class="card" style="padding:0;overflow:hidden">
+        <div class="chips" style="padding:8px 12px 6px;border-bottom:1px solid var(--bd)">
+          <span class="chip-f">deny <span class="ct">2</span></span>
+          <span class="chip-f active">allow <span class="ct">18</span></span>
+          <span class="chip-f">ask <span class="ct">5</span></span>
+        </div>
+        <table class="tbl">
+          <thead><tr><th>Pattern</th><th>Verdict</th><th class="mono" style="text-align:right">hits</th></tr></thead>
+          <tbody>
+            <tr><td><code class="mono">npm *</code></td><td><span class="pill ok">allow</span></td><td class="num">128</td></tr>
+            <tr><td><code class="mono">git *</code></td><td><span class="pill ok">allow</span></td><td class="num">94</td></tr>
+            <tr><td><code class="mono">npm publish</code></td><td><span class="pill warn">ask</span></td><td class="num">3</td></tr>
+            <tr><td><code class="mono">rm -rf *</code></td><td><span class="pill err">deny</span></td><td class="num">0</td></tr>
+            <tr><td><code class="mono">git push --force *</code></td><td><span class="pill err">deny</span></td><td class="num">0</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<section class="section" id="system">
+  <h2><span class="num">§11</span>System</h2>
+  <p class="lede">
+    The diagnostic surface — answering "is anything wrong" in one screen. A health
+    grid (each check is a labeled card with a left-edge state stripe), an environment
+    info table, and a live log tail at the bottom for the agent's own structured
+    events. When something's broken, this is the first place a user looks.
+  </p>
+
+  <div class="mock">
+    <div class="app">
+      <aside class="app-side">
+        <div class="brand"><span class="glyph">◈</span><span class="label">REASONIX</span><span class="ver">0.18.1</span></div>
+        <div class="side-tabs">
+          <div class="side-tab"><span class="g">◆</span><span class="label">Chat</span></div>
+          <div class="side-section">observe</div>
+          <div class="side-tab"><span class="g">◈</span><span class="label">Overview</span></div>
+          <div class="side-tab"><span class="g">$</span><span class="label">Usage</span></div>
+          <div class="side-tab active"><span class="g">+</span><span class="label">System</span><span class="badge" style="color:var(--c-warn)">!</span></div>
+        </div>
+        <div class="side-foot"><span class="label">localhost:8742</span><span class="toggle">«</span></div>
+      </aside>
+
+      <header class="app-top">
+        <div class="crumbs">
+          <span class="crumb dim">~/work/reasonix</span>
+          <span class="sep">›</span>
+          <span class="crumb">system</span>
+          <span class="sep">›</span>
+          <span class="crumb" style="color:var(--c-warn)">1 warning</span>
+        </div>
+        <span class="grow"></span>
+        <span class="meter"><span class="lbl">uptime</span><span class="v">2h 14m</span></span>
+      </header>
+
+      <div class="app-body" style="padding:14px 18px">
+
+        <h3 style="margin:0 0 10px;font-family:var(--font-mono);font-size:11px;color:var(--fg-3);text-transform:uppercase;letter-spacing:.1em">Health checks</h3>
+        <div class="health-grid" style="margin-bottom:18px">
+          <div class="health-item"><div class="lbl">api · deepseek <span class="pill ok">● ok</span></div><div class="v">240ms p50</div><div class="meta">last call 2s ago</div></div>
+          <div class="health-item"><div class="lbl">mcp · github <span class="pill ok">● up</span></div><div class="v">stdio · 14m</div><div class="meta">5 tools loaded</div></div>
+          <div class="health-item"><div class="lbl">mcp · slack <span class="pill ok">● up</span></div><div class="v">streamable-http · 14m</div><div class="meta">4 tools loaded</div></div>
+          <div class="health-item warn"><div class="lbl">subagent · python_runner <span class="pill warn">▲ load fail</span></div><div class="v">ENOENT</div><div class="meta">retry in 30s · 3rd attempt</div></div>
+          <div class="health-item"><div class="lbl">disk · sessions <span class="pill ok">● ok</span></div><div class="v">128 / 50,000 MB</div><div class="meta">42 sessions · 0.3% used</div></div>
+          <div class="health-item"><div class="lbl">events.jsonl sidecar <span class="pill ok">● flushing</span></div><div class="v">12,840 events buffered</div><div class="meta">flush every 5s · 100ms p99</div></div>
+          <div class="health-item"><div class="lbl">hooks <span class="pill ok">● 4 active</span></div><div class="v">PreToolUse · PostToolUse · UserPromptSubmit · Stop</div></div>
+          <div class="health-item"><div class="lbl">version <span class="pill info">● latest</span></div><div class="v">0.18.1</div><div class="meta">released 14m ago</div></div>
+        </div>
+
+        <div style="display:grid;grid-template-columns:280px 1fr;gap:14px">
+          <div class="card">
+            <div class="card-h"><span class="title">environment</span></div>
+            <table class="tbl" style="margin-top:6px">
+              <tbody style="font-size:11.5px">
+                <tr><td class="dim" style="padding:5px 8px">platform</td><td class="path">win32 · 10.0.26200</td></tr>
+                <tr><td class="dim" style="padding:5px 8px">node</td><td class="path">v22.7.0</td></tr>
+                <tr><td class="dim" style="padding:5px 8px">terminal</td><td class="path">Windows Terminal · ConPTY</td></tr>
+                <tr><td class="dim" style="padding:5px 8px">cwd</td><td class="path">~/work/reasonix</td></tr>
+                <tr><td class="dim" style="padding:5px 8px">tmpdir</td><td class="path">$LOCALAPPDATA/Temp</td></tr>
+                <tr><td class="dim" style="padding:5px 8px">memory</td><td class="path">1.4 / 16 GB</td></tr>
+                <tr><td class="dim" style="padding:5px 8px">tz</td><td class="path">Asia/Shanghai · +08:00</td></tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div class="card" style="padding:0">
+            <div class="card-h" style="padding:12px 14px 6px"><span class="title">events · last 50</span><span class="meta"><a>open events.jsonl</a></span></div>
+            <div class="log-tail" style="border:none;border-radius:0;border-top:1px solid var(--bd)">
+<span class="ts">02:34:18</span> <span class="lvl ok">ok</span> <span class="src">subagent</span>  spawn end · python_runner · 2.4s · 240 tok
+<span class="ts">02:34:14</span> <span class="lvl info">info</span> <span class="src">tool</span>      run_command · npm publish · started
+<span class="ts">02:33:58</span> <span class="lvl warn">warn</span> <span class="src">loop</span>     turn 14 · iter 3/10 · approval pending
+<span class="ts">02:33:41</span> <span class="lvl ok">ok</span> <span class="src">tool</span>      edit_file · PromptInput.tsx · 1+ 2-
+<span class="ts">02:33:22</span> <span class="lvl info">info</span> <span class="src">model</span>     deepseek-chat · streaming · 1.2k tok
+<span class="ts">02:33:12</span> <span class="lvl err">err</span> <span class="src">subagent</span>  spawn fail · python_runner · ENOENT
+<span class="ts">02:32:48</span> <span class="lvl ok">ok</span> <span class="src">session</span>   appendMessage · 2026-04-30-2014.jsonl
+<span class="ts">02:32:48</span> <span class="lvl ok">ok</span> <span class="src">events</span>    flush · 14 events · 8ms
+<span class="ts">02:32:34</span> <span class="lvl info">info</span> <span class="src">user</span>      prompt submit · 248 chars
+<span class="ts">02:31:12</span> <span class="lvl ok">ok</span> <span class="src">cache</span>     hit · 412 tok · saved 280ms</div>
+          </div>
+        </div>
+
+      </div>
+
+      <footer class="app-status">
+        <span class="item"><span class="dot warn"></span><span>1 warn · python_runner</span></span>
+        <span class="grow"></span>
+        <span class="item">tail · streaming</span>
+      </footer>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<section class="section" id="semantic">
+  <h2><span class="num">§12</span>Semantic</h2>
+  <p class="lede">
+    The semantic-search panel: a search bar at the top, an indexing-status sidebar,
+    and result cards with snippets and highlight. Distinct from the global
+    command palette — the palette navigates <i>known</i> things; semantic search
+    finds code by what it <i>means</i>, given a vector index over the project.
+  </p>
+
+  <div class="mock">
+    <div class="app">
+      <aside class="app-side">
+        <div class="brand"><span class="glyph">◈</span><span class="label">REASONIX</span><span class="ver">0.18.1</span></div>
+        <div class="side-tabs">
+          <div class="side-tab"><span class="g">◆</span><span class="label">Chat</span></div>
+          <div class="side-tab"><span class="g">✎</span><span class="label">Editor</span></div>
+          <div class="side-section">observe</div>
+          <div class="side-tab active"><span class="g">≈</span><span class="label">Semantic</span></div>
+          <div class="side-tab"><span class="g">$</span><span class="label">Usage</span></div>
+        </div>
+        <div class="side-foot"><span class="label">localhost:8742</span><span class="toggle">«</span></div>
+      </aside>
+
+      <header class="app-top">
+        <div class="crumbs">
+          <span class="crumb dim">~/work/reasonix</span>
+          <span class="sep">›</span>
+          <span class="crumb">semantic</span>
+        </div>
+        <span class="grow"></span>
+        <span class="meter"><span class="lbl">indexed</span><span class="v">1,842 chunks</span></span>
+        <span class="meter"><span class="lbl">last build</span><span class="v">42m ago</span></span>
+      </header>
+
+      <div class="app-body" style="padding:14px 18px">
+        <div style="display:grid;grid-template-columns:minmax(0, 1fr) 280px;gap:14px">
+
+          <div>
+            <!-- Search bar -->
+            <div style="position:relative;margin-bottom:10px">
+              <div style="position:absolute;left:14px;top:50%;transform:translateY(-50%);color:var(--c-brand);font-family:var(--font-mono);font-size:14px;pointer-events:none">≈</div>
+              <input class="input mono" style="padding:10px 14px 10px 38px;font-size:13.5px" value="how does the loop handle abort signals during a parallel tool batch" />
+            </div>
+            <div style="font-family:var(--font-mono);font-size:11px;color:var(--fg-3);margin-bottom:8px;display:flex;align-items:center;gap:8px">
+              <span>14 results · 0.18s · cosine ≥ 0.62</span>
+              <span class="grow"></span>
+              <span>sort by</span>
+              <select class="select mono" style="padding:2px 6px;width:auto;font-size:11px"><option>relevance</option><option>file path</option><option>recent</option></select>
+            </div>
+
+            <div class="card" style="padding:0">
+              <div class="sr-card">
+                <div class="sr-h">
+                  <span class="sr-path">src/loop.ts</span>
+                  <span class="sr-loc">L1208 – L1288 · CacheFirstLoop.step</span>
+                  <span class="sr-score">0.91</span>
+                </div>
+                <div class="sr-snip">  <span style="color:var(--fg-3)">// When change_workspace fires its WorkspaceConfirmationError,</span>
+  <span style="color:var(--fg-3)">// any subsequent calls in the same parallel batch would dispatch</span>
+  <span style="color:var(--fg-3)">// against the OLD sandbox before the user has approved…</span>
+  <span style="color:var(--c-accent)">let</span> <mark>workspaceSwitchPending</mark> = <span style="color:var(--c-warn)">false</span>;
+  <span style="color:var(--c-accent)">for</span> (<span style="color:var(--c-accent)">const</span> call <span style="color:var(--c-accent)">of</span> repairedCalls) {</div>
+              </div>
+
+              <div class="sr-card">
+                <div class="sr-h">
+                  <span class="sr-path">src/tools/shell.ts</span>
+                  <span class="sr-loc">L277 – L298 · runCommand</span>
+                  <span class="sr-score">0.84</span>
+                </div>
+                <div class="sr-snip">    <span style="color:var(--c-accent)">const</span> onAbort = () =&gt; {
+      aborted = <span style="color:var(--c-warn)">true</span>;
+      killChildTree();
+    };
+    <span style="color:var(--fg-3)">// Check synchronously first — if the signal aborted before listener attach</span>
+    <span style="color:var(--c-accent)">if</span> (opts.<mark>signal</mark>?.aborted) onAbort();</div>
+              </div>
+
+              <div class="sr-card">
+                <div class="sr-h">
+                  <span class="sr-path">src/tools/jobs.ts</span>
+                  <span class="sr-loc">L240 – L252 · JobRegistry.spawn</span>
+                  <span class="sr-score">0.78</span>
+                </div>
+                <div class="sr-snip">    <span style="color:var(--c-accent)">const</span> onAbort = () =&gt; <span style="color:var(--c-brand)">this</span>.stop(id, { graceMs: <span style="color:var(--c-warn)">100</span> });
+    <span style="color:var(--c-accent)">if</span> (opts.<mark>signal</mark>?.aborted) {
+      onAbort();
+    } <span style="color:var(--c-accent)">else</span> {
+      opts.<mark>signal</mark>?.addEventListener(<span style="color:var(--c-ok)">"abort"</span>, onAbort, { once: <span style="color:var(--c-warn)">true</span> });
+    }</div>
+              </div>
+
+              <div class="sr-card">
+                <div class="sr-h">
+                  <span class="sr-path">src/tools/subagent.ts</span>
+                  <span class="sr-loc">L150 – L175 · spawnSubagent</span>
+                  <span class="sr-score">0.71</span>
+                </div>
+                <div class="sr-snip">  <span style="color:var(--fg-3)">// Wire parent-abort → child-abort. Two pitfalls we have to handle:</span>
+  <span style="color:var(--fg-3)">//   1. The signal may already be aborted at attach time…</span>
+  <span style="color:var(--c-accent)">const</span> abortChild = () =&gt; childLoop.cancel(<mark>parentSignal</mark>.reason);</div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Index status sidebar -->
+          <aside style="display:flex;flex-direction:column;gap:10px">
+            <div class="card">
+              <div class="card-h"><span class="title">index status</span><span class="meta"><span class="pill ok">● fresh</span></span></div>
+              <div class="rail-kv"><span class="k">chunks</span><span class="v">1,842</span></div>
+              <div class="rail-kv"><span class="k">files</span><span class="v">312</span></div>
+              <div class="rail-kv"><span class="k">model</span><span class="v">bge-small-zh-v1.5</span></div>
+              <div class="rail-kv"><span class="k">dim</span><span class="v">512</span></div>
+              <div class="rail-kv"><span class="k">size</span><span class="v">14 MB</span></div>
+              <div class="rail-kv"><span class="k">last build</span><span class="v">42m ago</span></div>
+              <div class="progress-row" style="margin-top:8px;padding:0">
+                <span class="lbl">stale chunks</span>
+                <div class="progress warn"><div class="progress-fill" style="width:8%"></div></div>
+                <span class="v" style="color:var(--c-warn)">8%</span>
+              </div>
+            </div>
+
+            <div class="card">
+              <div class="card-h"><span class="title">excluded by patterns</span></div>
+              <div style="font-family:var(--font-mono);font-size:11px;color:var(--fg-2);line-height:1.7">
+                <div><code class="mono">node_modules/</code></div>
+                <div><code class="mono">dist/</code></div>
+                <div><code class="mono">.git/</code></div>
+                <div><code class="mono">*.lock</code></div>
+                <div><code class="mono">*.snap</code></div>
+              </div>
+            </div>
+
+            <button class="btn primary" style="width:100%;justify-content:center"><span class="g">↻</span><span>rebuild index</span></button>
+          </aside>
+
+        </div>
+      </div>
+
+      <footer class="app-status">
+        <span class="item"><span class="dot"></span><span>index fresh</span></span>
+        <span class="grow"></span>
+        <span class="item">14 results · 0.18s</span>
+      </footer>
+    </div>
+  </div>
+
+  <div class="subsec">
+    <h3>Build progress <span class="desc">when index is being rebuilt</span></h3>
+    <div class="mock" style="padding:24px">
+      <div class="card" style="max-width:440px;margin:0 auto">
+        <div class="card-h"><span class="glyph">≈</span><span class="title">building index · 312 files</span></div>
+        <div class="progress-row" style="margin-top:8px;padding:0"><span class="lbl">scan</span><div class="progress ok"><div class="progress-fill" style="width:100%"></div></div><span class="v" style="color:var(--c-ok)">312 / 312</span></div>
+        <div class="progress-row" style="padding:0"><span class="lbl">chunk</span><div class="progress ok"><div class="progress-fill" style="width:100%"></div></div><span class="v" style="color:var(--c-ok)">1,842 / 1,842</span></div>
+        <div class="progress-row" style="padding:0"><span class="lbl">embed</span><div class="progress"><div class="progress-fill" style="width:62%"></div></div><span class="v">1,142 / 1,842</span></div>
+        <div class="progress-row" style="padding:0"><span class="lbl">write</span><div class="progress dim"><div class="progress-fill" style="width:0%"></div></div><span class="v" style="color:var(--fg-3)">pending</span></div>
+        <div style="font-family:var(--font-mono);font-size:11px;color:var(--fg-3);margin-top:10px;text-align:center">38s elapsed · ~22s remaining</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<section class="section" id="configuration">
+  <h2><span class="num">§13</span>Configuration</h2>
+  <p class="lede">
+    Hooks and Settings share a layout: a left rail with sub-sections, a
+    main pane with the form. Hooks gets an extra concept — the <b>event
+    matrix</b> — showing at a glance which hook script fires on which
+    LoopEvent. Settings is mostly form-controls; the only non-trivial widget
+    is the JSON view on the raw <code class="mono">settings.json</code>.
+  </p>
+
+  <div class="mock">
+    <div class="app">
+      <aside class="app-side">
+        <div class="brand"><span class="glyph">◈</span><span class="label">REASONIX</span><span class="ver">0.18.1</span></div>
+        <div class="side-tabs">
+          <div class="side-tab"><span class="g">◆</span><span class="label">Chat</span></div>
+          <div class="side-section">configure</div>
+          <div class="side-tab"><span class="g">▣</span><span class="label">Tools</span></div>
+          <div class="side-tab"><span class="g">▎</span><span class="label">Permissions</span></div>
+          <div class="side-tab active"><span class="g">H</span><span class="label">Hooks</span></div>
+          <div class="side-tab"><span class="g">⌘</span><span class="label">Settings</span></div>
+        </div>
+        <div class="side-foot"><span class="label">localhost:8742</span><span class="toggle">«</span></div>
+      </aside>
+
+      <header class="app-top">
+        <div class="crumbs">
+          <span class="crumb dim">~/work/reasonix</span>
+          <span class="sep">›</span>
+          <span class="crumb">hooks</span>
+          <span class="sep">›</span>
+          <span class="crumb" style="color:var(--c-brand)">event matrix</span>
+        </div>
+        <span class="grow"></span>
+        <span class="meter"><span class="lbl">active</span><span class="v">4 hooks</span></span>
+      </header>
+
+      <div class="app-body" style="padding:14px 18px">
+        <div class="cfg-grid">
+
+          <div class="cfg-nav">
+            <div class="cfg-item active"><span class="g" style="font-family:var(--font-mono);color:var(--c-brand)">⊞</span><span>Event matrix</span></div>
+            <div class="cfg-item"><span class="g" style="font-family:var(--font-mono);color:var(--fg-3)">+</span><span>Add hook</span></div>
+            <div class="cfg-item"><span class="g" style="font-family:var(--font-mono);color:var(--fg-3)">↻</span><span>Reload</span></div>
+            <div class="cfg-item"><span class="g" style="font-family:var(--font-mono);color:var(--fg-3)">⚠</span><span>Recent failures<span style="margin-left:auto;font-size:9px;color:var(--c-err)">3</span></span></div>
+            <div style="padding:14px 8px 4px;font-family:var(--font-mono);font-size:10px;color:var(--fg-4);text-transform:uppercase;letter-spacing:.12em">jump · settings</div>
+            <div class="cfg-item"><span class="g" style="font-family:var(--font-mono);color:var(--fg-3)">⌘</span><span>General</span></div>
+            <div class="cfg-item"><span class="g" style="font-family:var(--font-mono);color:var(--fg-3)">$</span><span>Budget</span></div>
+            <div class="cfg-item"><span class="g" style="font-family:var(--font-mono);color:var(--fg-3)">▎</span><span>Permissions</span></div>
+            <div class="cfg-item"><span class="g" style="font-family:var(--font-mono);color:var(--fg-3)">M</span><span>MCP servers</span></div>
+            <div class="cfg-item"><span class="g" style="font-family:var(--font-mono);color:var(--fg-3)">{}</span><span>Raw settings.json</span></div>
+          </div>
+
+          <div class="cfg-content">
+            <h3 style="margin:0 0 4px;font-family:var(--font-mono);font-size:14px;color:var(--fg-0)">Event matrix</h3>
+            <p style="font-size:12.5px;color:var(--fg-3);margin:0 0 14px">Which hook script fires on which LoopEvent. Click a cell to edit timing, glob, or to disable. Adding a new hook (left rail) drops a row; the script lives in <code class="mono" style="color:var(--c-brand)">.reasonix/hooks/</code>.</p>
+
+            <div class="matrix">
+              <div class="row h">
+                <div>script</div>
+                <div>PreToolUse</div>
+                <div>PostToolUse</div>
+                <div>UserPromptSubmit</div>
+                <div>Stop</div>
+                <div>Notification</div>
+                <div>SessionEnd</div>
+              </div>
+              <div class="row">
+                <div class="cell"><code class="mono">format-on-edit.sh</code></div>
+                <div class="cell off">—</div>
+                <div class="cell on">edit_file</div>
+                <div class="cell off">—</div>
+                <div class="cell off">—</div>
+                <div class="cell off">—</div>
+                <div class="cell off">—</div>
+              </div>
+              <div class="row">
+                <div class="cell"><code class="mono">block-secrets.sh</code></div>
+                <div class="cell on">edit_file<br><span style="color:var(--c-warn);font-size:10px">/\.env/</span></div>
+                <div class="cell off">—</div>
+                <div class="cell off">—</div>
+                <div class="cell off">—</div>
+                <div class="cell off">—</div>
+                <div class="cell off">—</div>
+              </div>
+              <div class="row">
+                <div class="cell"><code class="mono">notify-slack.sh</code></div>
+                <div class="cell off">—</div>
+                <div class="cell off">—</div>
+                <div class="cell off">—</div>
+                <div class="cell on">always</div>
+                <div class="cell off">—</div>
+                <div class="cell off">—</div>
+              </div>
+              <div class="row">
+                <div class="cell"><code class="mono">archive-session.sh</code></div>
+                <div class="cell off">—</div>
+                <div class="cell off">—</div>
+                <div class="cell off">—</div>
+                <div class="cell off">—</div>
+                <div class="cell off">—</div>
+                <div class="cell on">always</div>
+              </div>
+            </div>
+
+            <div style="margin-top:18px">
+              <h3 style="margin:0 0 6px;font-family:var(--font-mono);font-size:11px;color:var(--fg-3);text-transform:uppercase;letter-spacing:.1em">Recent runs</h3>
+              <div class="log-tail">
+<span class="ts">02:34:18</span> <span class="lvl ok">ok</span> <span class="src">PostToolUse</span>  format-on-edit.sh · 42ms · edit_file PromptInput.tsx
+<span class="ts">02:33:41</span> <span class="lvl ok">ok</span> <span class="src">PostToolUse</span>  format-on-edit.sh · 38ms · edit_file chat.tsx
+<span class="ts">02:32:18</span> <span class="lvl err">err</span> <span class="src">PreToolUse</span>   block-secrets.sh · denied · edit_file .env.local
+<span class="ts">02:30:04</span> <span class="lvl ok">ok</span> <span class="src">Stop</span>          notify-slack.sh · 280ms · #dev</div>
+            </div>
+          </div>
+
+        </div>
+      </div>
+
+      <footer class="app-status">
+        <span class="item"><span class="dot"></span><span>4 hooks active</span></span>
+        <span class="grow"></span>
+        <span class="item">last fired 12s</span>
+      </footer>
+    </div>
+  </div>
+
+  <div class="subsec">
+    <h3>Settings · Raw JSON view <span class="desc">when forms aren't enough</span></h3>
+    <p>For everything not exposed via form (custom keymap, env passthroughs, exotic MCP transport overrides), the raw editor is one click away — same CodeMirror as the Editor panel, with JSON schema validation for autocomplete and warnings.</p>
+    <div class="mock" style="padding:0">
+      <div class="editor-tabs">
+        <div class="editor-tab active"><span>settings.json</span></div>
+        <div class="editor-tab"><span>~/.claude/settings.json</span><span class="dim" style="color:var(--fg-4);font-size:10px;margin-left:4px">user</span></div>
+      </div>
+      <div class="editor-area" style="height:280px">
+        <div class="editor-line"><span class="lineno">1</span><span class="ln-content">{</span></div>
+        <div class="editor-line"><span class="lineno">2</span><span class="ln-content">  <span class="str">"$schema"</span>: <span class="str">"https://reasonix.dev/schema/settings.json"</span>,</span></div>
+        <div class="editor-line"><span class="lineno">3</span><span class="ln-content">  <span class="str">"model"</span>: <span class="str">"deepseek-chat"</span>,</span></div>
+        <div class="editor-line"><span class="lineno">4</span><span class="ln-content">  <span class="str">"budgetUsd"</span>: <span class="num">100</span>,</span></div>
+        <div class="editor-line"><span class="lineno">5</span><span class="ln-content">  <span class="str">"hooks"</span>: {</span></div>
+        <div class="editor-line"><span class="lineno">6</span><span class="ln-content">    <span class="str">"PostToolUse"</span>: [</span></div>
+        <div class="editor-line"><span class="lineno">7</span><span class="ln-content">      { <span class="str">"matcher"</span>: <span class="str">"edit_file"</span>, <span class="str">"command"</span>: <span class="str">"./scripts/format-on-edit.sh"</span> }</span></div>
+        <div class="editor-line"><span class="lineno">8</span><span class="ln-content">    ]</span></div>
+        <div class="editor-line"><span class="lineno">9</span><span class="ln-content">  },</span></div>
+        <div class="editor-line"><span class="lineno">10</span><span class="ln-content">  <span class="str">"permissions"</span>: {</span></div>
+        <div class="editor-line"><span class="lineno">11</span><span class="ln-content">    <span class="str">"deny"</span>: [<span class="str">"rm -rf *"</span>, <span class="str">"git push --force *"</span>],</span></div>
+        <div class="editor-line"><span class="lineno">12</span><span class="ln-content">    <span class="str">"allow"</span>: [<span class="str">"npm *"</span>, <span class="str">"git *"</span>, <span class="str">"yarn *"</span>]</span></div>
+        <div class="editor-line"><span class="lineno">13</span><span class="ln-content">  }</span></div>
+        <div class="editor-line"><span class="lineno">14</span><span class="ln-content">}</span></div>
+      </div>
+      <div class="editor-status">
+        <span><span class="glyph">●</span> <span class="v">settings.json</span></span>
+        <span>json · LF · UTF-8</span>
+        <span style="color:var(--c-ok)">saved · hot-reloaded</span>
+        <span class="grow"></span>
+        <span>Ln <span class="v">7</span>, Col <span class="v">42</span></span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<section class="section" id="open-questions">
+  <h2><span class="num">§14</span>Open questions</h2>
+  <p class="lede">Decisions deliberately deferred until implementation begins.</p>
+
+  <div class="subsec">
+    <h3>Take-over UX</h3>
+    <p>When the dashboard takes input, does the TUI show the streaming response live (read-only), or pause until the dashboard releases? Lean toward <b>live read</b> so terminal-2 keeps reading while terminal-1 has the keyboard.</p>
+  </div>
+
+  <div class="subsec">
+    <h3>Sidebar grouping</h3>
+    <p>Three groups (workspace · observe · configure) feel natural now. If the panel count grows past 14, may need a second axis (collapsible sub-sections) — defer until pressure exists.</p>
+  </div>
+
+  <div class="subsec">
+    <h3>Mobile / narrow</h3>
+    <p>Out of scope for v1. The dashboard is a localhost development tool; phone-screen layout would only matter if Reasonix ever runs as a hosted service.</p>
+  </div>
+
+  <div class="subsec">
+    <h3>Theming</h3>
+    <p>Single dark theme for v1. Light theme is a 1-week effort and not on the path right now — the TUI is dark-only too, theme parity is a non-goal.</p>
+  </div>
+
+  <div class="subsec">
+    <h3>Editor panel</h3>
+    <p>Not mocked here. Lives in the same shell, but its core is a CodeMirror instance + tabs + tree view — those have their own design language already (CodeMirror's default dark + our palette overrides). A separate doc when we touch Editor.</p>
+  </div>
+</section>
+
+</main>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
Two doc-only additions:
1. **README → Contributing section** linking the four good-first-issues (#15-18) and the Discussions page, plus bumping the test count to 1665.
2. **`design/agent-dashboard.html`** — sibling to `design/agent-tui-terminal.html`. Web-companion mockup, 14 sections covering shell, components, panels, and the open-question deferrals. Anchor for the upcoming dashboard framework rewrite (not a re-implementation, just the design contract).

## Why now
- The four good-first-issues (#15-18) have no discoverability path until the README points at them.
- The dashboard mockup has been sitting in the working tree across multiple sessions; pinning it in `design/` makes it linkable from the upcoming Discussions posts.

## Test plan
- [x] No code changes — `npm run verify` not required (CI will re-run anyway)
- [x] Browser-render `design/agent-dashboard.html` locally — 14 sections + TOC scroll cleanly