### PR TITLE
build(dashboard): bundle via tsup so refactor can use TypeScript modules

### DIFF
--- a/dashboard/tsconfig.json
+++ b/dashboard/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "dist",
+    "noEmit": true,
+    "declaration": false,
+    "declarationMap": false,
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "types": [],
+    "allowJs": true,
+    "checkJs": false
+  },
+  "include": ["src/**/*", "app.js"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "dist",
     "data/deepseek-tokenizer.json.gz",
     "dashboard/index.html",
-    "dashboard/app.js",
     "dashboard/app.css",
     "dashboard/codemirror.js",
+    "dashboard/dist",
     "README.md",
     "LICENSE"
   ],
@@ -35,8 +35,8 @@
     "lint": "biome check src tests",
     "lint:fix": "biome check --write src tests",
     "format": "biome format --write src tests",
-    "typecheck": "tsc --noEmit",
-    "verify": "npm run lint && npm run typecheck && npm run test --silent",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p dashboard",
+    "verify": "npm run build && npm run lint && npm run typecheck && npm run test --silent",
     "prepare": "simple-git-hooks || true",
     "prepublishOnly": "npm run lint && npm run typecheck && npm run test && npm run build"
   },

--- a/src/server/assets.ts
+++ b/src/server/assets.ts
@@ -31,6 +31,7 @@ const ASSET_DIR = resolveAssetDir();
 
 let cachedIndex: string | null = null;
 let cachedApp: string | null = null;
+let cachedAppMap: string | null = null;
 let cachedCss: string | null = null;
 let cachedCm: string | null = null;
 
@@ -42,8 +43,18 @@ function loadIndexTemplate(): string {
 
 function loadApp(): string {
   if (cachedApp) return cachedApp;
-  cachedApp = readFileSync(join(ASSET_DIR, "app.js"), "utf8");
+  cachedApp = readFileSync(join(ASSET_DIR, "dist", "app.js"), "utf8");
   return cachedApp;
+}
+
+function loadAppMap(): string | null {
+  if (cachedAppMap) return cachedAppMap;
+  try {
+    cachedAppMap = readFileSync(join(ASSET_DIR, "dist", "app.js.map"), "utf8");
+    return cachedAppMap;
+  } catch {
+    return null;
+  }
 }
 
 function loadCss(): string {
@@ -74,6 +85,10 @@ export function renderIndexHtml(token: string, mode: "standalone" | "attached"):
 export function serveAsset(name: string): { body: string; contentType: string } | null {
   if (name === "app.js") {
     return { body: loadApp(), contentType: "application/javascript; charset=utf-8" };
+  }
+  if (name === "app.js.map") {
+    const body = loadAppMap();
+    return body == null ? null : { body, contentType: "application/json; charset=utf-8" };
   }
   if (name === "app.css") {
     return { body: loadCss(), contentType: "text/css; charset=utf-8" };

--- a/tests/server-dashboard.test.ts
+++ b/tests/server-dashboard.test.ts
@@ -396,7 +396,8 @@ describe("dashboard server: SPA shell", () => {
     expect(noToken.status).toBe(401);
   });
 
-  it("GET /assets/app.js serves the script when authed", async () => {
+  const dashAppExists = existsSync(join(process.cwd(), "dashboard", "dist", "app.js"));
+  (dashAppExists ? it : it.skip)("GET /assets/app.js serves the script when authed", async () => {
     const r = await call(`${handle!.url.split("?")[0]}assets/app.js`, { token: TOKEN });
     expect(r.status).toBe(200);
     expect(r.headers.get("content-type")).toMatch(/javascript/);

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -20,4 +20,15 @@ export default defineConfig([
     outDir: "dist/cli",
     banner: { js: "#!/usr/bin/env node" },
   },
+  {
+    entry: { app: "dashboard/app.js" },
+    format: ["esm"],
+    dts: false,
+    clean: true,
+    sourcemap: true,
+    target: "es2022",
+    platform: "browser",
+    outDir: "dashboard/dist",
+    external: [/^https:\/\//],
+  },
 ]);


### PR DESCRIPTION
## Why

The dashboard refactor ([#28](https://github.com/esengine/reasonix/issues/28)) needs to extract panels into typed modules under `dashboard/src/`. Plain ESM-from-CDN can't follow `import { x } from "./lib/format"` to local sibling files at request time, so `app.js` has to be bundled before it lands on the browser.

The original tracking issue mistakenly listed "no build step" as a constraint. That's wrong for a TypeScript-everywhere project — `src/` is already strict TS, but the dashboard was the only directory with plain `.js`. This PR removes that inconsistency by reusing the existing tsup pipeline.

**This PR is pure infrastructure.** No behavior change to the dashboard itself — `dashboard/app.js` passes through esbuild unmodified; CDN imports stay as live `https://esm.sh/...` URLs in the bundled output. The first real TS module extraction (`dashboard/src/lib/format.ts`) lands in the next PR.

## Changes

- **`tsup.config.ts`** — third entry: `dashboard/app.js` → `dashboard/dist/app.js`. `target: es2022`, `platform: browser`, `external: [/^https:\/\//]` so esm.sh imports stay as live URLs.
- **`dashboard/tsconfig.json`** (new) — extends root config; swaps `types: ["node"]` for browser `lib: ["ES2023", "DOM", "DOM.Iterable"]`; `allowJs: true` so the legacy `app.js` compiles unmodified while new TS modules under `dashboard/src/` get strict checks.
- **`src/server/assets.ts`** — `loadApp()` reads from `dashboard/dist/app.js`; new `loadAppMap()` serves the sourcemap (404s if missing).
- **`package.json`**:
  - `files` ships `dashboard/dist/` instead of the raw source `app.js`.
  - `typecheck` chains `tsc --noEmit && tsc --noEmit -p dashboard`.
  - `verify` now runs `npm run build` first, matching the pattern `tests/bundle-smoke.test.ts` already assumes.
- **`tests/server-dashboard.test.ts`** — the asset-serving test skips when `dashboard/dist/app.js` is missing, mirroring the bundle-smoke convention.

## Out of scope

- No TypeScript module extraction yet — that's PR 1.0b.
- `dashboard/app.js` content is unchanged (just bundled).
- No new files under `dashboard/src/` yet — the directory is reserved for the next PR.
- `dashboard/codemirror.js` ships as-is; Stage 2 of #28 deletes it with the editor surface.

## Test plan

- [x] `npm run build` produces `dashboard/dist/app.js` (~136 KB) + sourcemap.
- [x] `npm run typecheck` passes both root + dashboard projects.
- [x] `npm run lint` clean (6 pre-existing warnings unrelated to this PR).
- [x] `npm test` — 1665/1665 pass.
- [x] CDN imports in the bundled output stay as `https://esm.sh/...` (verified via `head dashboard/dist/app.js`).
- [ ] Manual: open the dashboard locally, confirm browser still renders the same SPA.
