### PR TITLE
refactor(dashboard): extract formatters → src/lib/format.ts

### DIFF
--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -1,7 +1,4 @@
-// Reasonix dashboard SPA — Preact 10 + HTM, no build step.
-//
-// CDN imports use esm.sh (provides ESM bundles of npm packages with
-// caching). We pin minor versions; bumping is a deliberate choice.
+// Reasonix dashboard SPA — Preact 10 + HTM, bundled by tsup. CDN imports stay external.
 
 import hljs from "https://esm.sh/highlight.js@11.10.0/lib/common";
 import htm from "https://esm.sh/htm@3.1.1";
@@ -14,6 +11,7 @@ import {
   useRef,
   useState,
 } from "https://esm.sh/preact@10.22.0/hooks";
+import { fmtBytes, fmtNum, fmtPct, fmtRelativeTime, fmtUsd } from "./src/lib/format";
 
 const html = htm.bind(h);
 
@@ -233,44 +231,6 @@ function usePoll(path, intervalMs = 2000) {
   }, [refresh, intervalMs]);
 
   return { data, error, loading, refresh };
-}
-
-// ---------- formatting helpers ----------
-
-function fmtUsd(n) {
-  if (n === null || n === undefined) return "—";
-  if (n === 0) return "$0";
-  return `$${n.toFixed(n < 0.01 ? 6 : 4)}`;
-}
-
-function fmtPct(n) {
-  if (n === null || n === undefined) return "—";
-  return `${(n * 100).toFixed(1)}%`;
-}
-
-function fmtNum(n) {
-  if (n === null || n === undefined) return "—";
-  return n.toLocaleString();
-}
-
-function fmtBytes(n) {
-  if (n === null || n === undefined) return "—";
-  if (n < 1024) return `${n} B`;
-  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
-  if (n < 1024 * 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)} MB`;
-  return `${(n / (1024 * 1024 * 1024)).toFixed(2)} GB`;
-}
-
-function fmtRelativeTime(iso) {
-  if (!iso) return "—";
-  const ms = typeof iso === "number" ? iso : Date.parse(iso);
-  if (!Number.isFinite(ms)) return "—";
-  const dSec = (Date.now() - ms) / 1000;
-  if (dSec < 60) return "just now";
-  if (dSec < 3600) return `${Math.floor(dSec / 60)}m ago`;
-  if (dSec < 86400) return `${Math.floor(dSec / 3600)}h ago`;
-  if (dSec < 30 * 86400) return `${Math.floor(dSec / 86400)}d ago`;
-  return new Date(ms).toISOString().slice(0, 10);
 }
 
 // ---------- panels ----------

--- a/dashboard/src/lib/format.ts
+++ b/dashboard/src/lib/format.ts
@@ -1,0 +1,35 @@
+export function fmtUsd(n: number | null | undefined): string {
+  if (n === null || n === undefined) return "—";
+  if (n === 0) return "$0";
+  return `$${n.toFixed(n < 0.01 ? 6 : 4)}`;
+}
+
+export function fmtPct(n: number | null | undefined): string {
+  if (n === null || n === undefined) return "—";
+  return `${(n * 100).toFixed(1)}%`;
+}
+
+export function fmtNum(n: number | null | undefined): string {
+  if (n === null || n === undefined) return "—";
+  return n.toLocaleString();
+}
+
+export function fmtBytes(n: number | null | undefined): string {
+  if (n === null || n === undefined) return "—";
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(n / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+export function fmtRelativeTime(iso: string | number | null | undefined): string {
+  if (!iso) return "—";
+  const ms = typeof iso === "number" ? iso : Date.parse(iso);
+  if (!Number.isFinite(ms)) return "—";
+  const dSec = (Date.now() - ms) / 1000;
+  if (dSec < 60) return "just now";
+  if (dSec < 3600) return `${Math.floor(dSec / 60)}m ago`;
+  if (dSec < 86400) return `${Math.floor(dSec / 3600)}h ago`;
+  if (dSec < 30 * 86400) return `${Math.floor(dSec / 86400)}d ago`;
+  return new Date(ms).toISOString().slice(0, 10);
+}

--- a/tests/dashboard-format.test.ts
+++ b/tests/dashboard-format.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from "vitest";
+import { fmtBytes, fmtNum, fmtPct, fmtRelativeTime, fmtUsd } from "../dashboard/src/lib/format.js";
+
+describe("fmtUsd", () => {
+  it("returns em-dash for null/undefined", () => {
+    expect(fmtUsd(null)).toBe("—");
+    expect(fmtUsd(undefined)).toBe("—");
+  });
+
+  it("returns $0 for zero", () => {
+    expect(fmtUsd(0)).toBe("$0");
+  });
+
+  it("uses 4 decimals for >= 0.01", () => {
+    expect(fmtUsd(0.01)).toBe("$0.0100");
+    expect(fmtUsd(1.234567)).toBe("$1.2346");
+  });
+
+  it("uses 6 decimals for < 0.01 to keep micro-costs visible", () => {
+    expect(fmtUsd(0.001234)).toBe("$0.001234");
+    expect(fmtUsd(0.000001)).toBe("$0.000001");
+  });
+});
+
+describe("fmtPct", () => {
+  it("returns em-dash for null/undefined", () => {
+    expect(fmtPct(null)).toBe("—");
+    expect(fmtPct(undefined)).toBe("—");
+  });
+
+  it("multiplies by 100 with 1 decimal", () => {
+    expect(fmtPct(0)).toBe("0.0%");
+    expect(fmtPct(0.945)).toBe("94.5%");
+    expect(fmtPct(1)).toBe("100.0%");
+  });
+});
+
+describe("fmtNum", () => {
+  it("returns em-dash for null/undefined", () => {
+    expect(fmtNum(null)).toBe("—");
+    expect(fmtNum(undefined)).toBe("—");
+  });
+
+  it("uses locale separators", () => {
+    expect(fmtNum(0)).toBe("0");
+    expect(fmtNum(1234567)).toBe(Number(1234567).toLocaleString());
+  });
+});
+
+describe("fmtBytes", () => {
+  it("returns em-dash for null/undefined", () => {
+    expect(fmtBytes(null)).toBe("—");
+    expect(fmtBytes(undefined)).toBe("—");
+  });
+
+  it("uses bytes under 1 KiB", () => {
+    expect(fmtBytes(0)).toBe("0 B");
+    expect(fmtBytes(512)).toBe("512 B");
+    expect(fmtBytes(1023)).toBe("1023 B");
+  });
+
+  it("uses KB for 1 KiB to under 1 MiB", () => {
+    expect(fmtBytes(1024)).toBe("1.0 KB");
+    expect(fmtBytes(1536)).toBe("1.5 KB");
+  });
+
+  it("uses MB for 1 MiB to under 1 GiB", () => {
+    expect(fmtBytes(1024 * 1024)).toBe("1.0 MB");
+    expect(fmtBytes(1024 * 1024 * 5.5)).toBe("5.5 MB");
+  });
+
+  it("uses GB for 1 GiB and above", () => {
+    expect(fmtBytes(1024 ** 3)).toBe("1.00 GB");
+    expect(fmtBytes(1024 ** 3 * 2.5)).toBe("2.50 GB");
+  });
+});
+
+describe("fmtRelativeTime", () => {
+  it("returns em-dash for falsy / unparseable", () => {
+    expect(fmtRelativeTime(null)).toBe("—");
+    expect(fmtRelativeTime(undefined)).toBe("—");
+    expect(fmtRelativeTime("")).toBe("—");
+    expect(fmtRelativeTime("not a date")).toBe("—");
+  });
+
+  it("renders bands when given a recent timestamp", () => {
+    const now = new Date("2026-05-01T12:00:00Z").getTime();
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    try {
+      expect(fmtRelativeTime(now - 30 * 1000)).toBe("just now");
+      expect(fmtRelativeTime(now - 5 * 60 * 1000)).toBe("5m ago");
+      expect(fmtRelativeTime(now - 3 * 3600 * 1000)).toBe("3h ago");
+      expect(fmtRelativeTime(now - 2 * 86400 * 1000)).toBe("2d ago");
+    } finally {
+      vi.restoreAllMocks();
+    }
+  });
+
+  it("falls back to ISO date past 30 days", () => {
+    const now = new Date("2026-05-01T12:00:00Z").getTime();
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    try {
+      const sixtyDaysAgo = now - 60 * 86400 * 1000;
+      expect(fmtRelativeTime(sixtyDaysAgo)).toBe(new Date(sixtyDaysAgo).toISOString().slice(0, 10));
+    } finally {
+      vi.restoreAllMocks();
+    }
+  });
+
+  it("accepts numbers and ISO strings interchangeably", () => {
+    const now = new Date("2026-05-01T12:00:00Z").getTime();
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    try {
+      const isoAgo = new Date(now - 90 * 1000).toISOString();
+      expect(fmtRelativeTime(isoAgo)).toBe("1m ago");
+    } finally {
+      vi.restoreAllMocks();
+    }
+  });
+});


### PR DESCRIPTION
## Why

First real TS module extraction after the build-infra PR ([#29](https://github.com/esengine/reasonix/pull/29)). Validates that the new pipeline (tsup bundle, `dashboard/src/lib/`, layered imports) actually works for code that ships, not just on paper.

The five formatters (`fmtUsd`, `fmtPct`, `fmtNum`, `fmtBytes`, `fmtRelativeTime`) are the lowest-blast-radius slice in the entire god file:

- Pure functions, no DOM, no Preact, no buses, no API.
- Used by ~6 panels (Overview, Usage, Sessions, Plans, System, diff blocks) — extraction proves the import path resolves into multiple call-sites.
- Together, ~35 LoC. If something breaks in this PR, the surface to debug is tiny.

Closes part of #28 (Stage 1 PR 1.0b).

## Changes

- **`dashboard/src/lib/format.ts`** (new) — five typed exports. Inputs are `number | null | undefined` (or `string | number | null | undefined` for `fmtRelativeTime`); return type narrows to `string`. Bodies are byte-equivalent to the originals.
- **`dashboard/app.js`** — drops the inline definitions, imports from `./src/lib/format`. File-header comment shrunk from a 4-line essay to one line and corrected (no longer claims "no build step").
- **`tests/dashboard-format.test.ts`** (new) — 17 cases covering the null/undefined branches, locale separators, byte-unit boundaries, and the time-band edges (just-now / m / h / d / fallback ISO). Mocks `Date.now()` for deterministic relative-time tests.

## Bundle verification

Built locally; `dashboard/dist/app.js` contains exactly one copy of each function (esbuild inlines the lib module), CDN imports stay external as before. Bundle size unchanged within rounding.

## Test plan

- [x] `npm run build` — bundles cleanly, format functions inlined, CDN imports preserved.
- [x] `npm run typecheck` — both root + dashboard projects clean.
- [x] `npm run lint` — clean (6 pre-existing warnings unrelated).
- [x] `npm test` — 1682/1682 (was 1665; +17 from the new test file).
- [ ] Manual: open the dashboard locally, confirm Overview / Usage / Sessions panels still format numbers/cost/time correctly.

## What's next

Once this lands, Stage 2 (drop the editor surface, ~−500 LoC) and Stage 3 (extract `api()`, `usePoll`, buses, error boundary, markdown) start in order. Each panel migration in Stage 4 will follow the same shape this PR established.
