### PR TITLE
refactor(dashboard): extract api()/TOKEN/MODE → src/lib/api.ts

### DIFF
--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -11,6 +11,7 @@ import {
   useRef,
   useState,
 } from "https://esm.sh/preact@10.22.0/hooks";
+import { MODE, TOKEN, api } from "./src/lib/api";
 import { fmtBytes, fmtNum, fmtPct, fmtRelativeTime, fmtUsd } from "./src/lib/format";
 
 const html = htm.bind(h);
@@ -158,42 +159,6 @@ previewMarked.use({
     },
   },
 });
-
-// ---------- bootstrapping ----------
-
-const TOKEN = document.querySelector('meta[name="reasonix-token"]')?.getAttribute("content") ?? "";
-const MODE =
-  document.querySelector('meta[name="reasonix-mode"]')?.getAttribute("content") ?? "standalone";
-
-// Helper: every fetch tacks the token onto the URL (reads) and the
-// header (mutations). Server logic in src/server/index.ts requires
-// the header form for any non-GET.
-async function api(path, opts = {}) {
-  const method = opts.method ?? "GET";
-  const url = `/api${path}${path.includes("?") ? "&" : "?"}token=${TOKEN}`;
-  const headers = { ...(opts.headers ?? {}) };
-  headers["X-Reasonix-Token"] = TOKEN;
-  if (opts.body !== undefined) headers["Content-Type"] = "application/json";
-  const res = await fetch(url, {
-    method,
-    headers,
-    body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
-  });
-  const text = await res.text();
-  let parsed = null;
-  try {
-    parsed = text ? JSON.parse(text) : null;
-  } catch {
-    parsed = { error: text };
-  }
-  if (!res.ok) {
-    const err = new Error(parsed?.error ?? `${res.status} ${res.statusText}`);
-    err.status = res.status;
-    err.body = parsed;
-    throw err;
-  }
-  return parsed;
-}
 
 // usePoll: re-fetch a GET endpoint every `intervalMs`, returning
 // `{ data, error, loading, refresh }`. v0.13 swaps this for SSE.

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -1,0 +1,48 @@
+export const TOKEN: string =
+  document.querySelector('meta[name="reasonix-token"]')?.getAttribute("content") ?? "";
+
+export const MODE: "standalone" | "attached" =
+  (document.querySelector('meta[name="reasonix-mode"]')?.getAttribute("content") as
+    | "standalone"
+    | "attached"
+    | null) ?? "standalone";
+
+export interface ApiOptions {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+}
+
+export interface ApiError extends Error {
+  status: number;
+  body: unknown;
+}
+
+export async function api<T = unknown>(path: string, opts: ApiOptions = {}): Promise<T> {
+  const method = opts.method ?? "GET";
+  const url = `/api${path}${path.includes("?") ? "&" : "?"}token=${TOKEN}`;
+  const headers: Record<string, string> = { ...(opts.headers ?? {}) };
+  headers["X-Reasonix-Token"] = TOKEN;
+  if (opts.body !== undefined) headers["Content-Type"] = "application/json";
+  const res = await fetch(url, {
+    method,
+    headers,
+    body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+  });
+  const text = await res.text();
+  let parsed: unknown = null;
+  try {
+    parsed = text ? JSON.parse(text) : null;
+  } catch {
+    parsed = { error: text };
+  }
+  if (!res.ok) {
+    const errMsg =
+      (parsed as { error?: string } | null)?.error ?? `${res.status} ${res.statusText}`;
+    const err = new Error(errMsg) as ApiError;
+    err.status = res.status;
+    err.body = parsed;
+    throw err;
+  }
+  return parsed as T;
+}


### PR DESCRIPTION
Stage 3 of #28, PR 3.1. Pulls the fetch wrapper (token-on-url for reads, header-too for mutations, JSON parsing, structured `ApiError`) into a typed leaf module. Used by every panel, no Preact dependency.

Net: dashboard/app.js loses ~30 LoC, dashboard/src/lib/api.ts (new) replaces it with named typed exports (`TOKEN`, `MODE`, `ApiOptions`, `ApiError`, `api<T>()`).

Bundle output unchanged byte-wise (esbuild inlines as before). 1682/1682 tests pass.

Closes part of #28.