### PR TITLE
fix(dashboard): chat panel missing imports — MODE / TOKEN / appBus / parseToolArgs

### DIFF
--- a/dashboard/src/components/chat-internals.ts
+++ b/dashboard/src/components/chat-internals.ts
@@ -119,7 +119,7 @@ export function renderMessageBody(text: string | null | undefined) {
   return html`<div class="md" dangerouslySetInnerHTML=${{ __html: renderMarkdownToString(text) }}></div>`;
 }
 
-function parseToolArgs(raw: string | null | undefined): Record<string, unknown> | null {
+export function parseToolArgs(raw: string | null | undefined): Record<string, unknown> | null {
   if (!raw) return null;
   try {
     return JSON.parse(raw);

--- a/dashboard/src/panels/chat.ts
+++ b/dashboard/src/panels/chat.ts
@@ -5,13 +5,14 @@ import {
   CheckpointModal,
   ChoiceModal,
   EditReviewModal,
+  parseToolArgs,
   PlanModal,
   RevisionModal,
   ShellModal,
   WorkspaceModal,
 } from "../components/chat-internals.js";
-import { api } from "../lib/api.js";
-import { showToast } from "../lib/bus.js";
+import { MODE, TOKEN, api } from "../lib/api.js";
+import { appBus, showToast } from "../lib/bus.js";
 import { fmtUsd } from "../lib/format.js";
 import { html } from "../lib/html.js";
 


### PR DESCRIPTION
## What broke

Opening the dashboard hit:

```
ReferenceError: MODE is not defined
  at ChatPanel ...
```

(plus three latent siblings — TOKEN, appBus, parseToolArgs — that would have fired on different code paths once MODE was past).

## Why

PR #39 extracted ChatPanel into `panels/chat.ts` under a `@ts-nocheck` pragma. The pragma suppresses `Cannot find name` errors. Four references the inline ChatPanel had via global lexical scope in app.js were silently missed at extraction time:

| Name | Used at | Source module |
|---|---|---|
| `MODE` | line 448 (`MODE === "attached"`) | `../lib/api.js` |
| `TOKEN` | line 126 (SSE EventSource URL) | `../lib/api.js` |
| `appBus` | line 545 (navigate-tab dispatch) | `../lib/bus.js` |
| `parseToolArgs` | line 641 (`summarizeActiveTool`) | `../components/chat-internals.js` (was private; this PR promotes to export) |

## Fix

Restored as named imports. `parseToolArgs` was a private helper inside `chat-internals.ts`; promoted to a named export so `panels/chat.ts` can reach it.

## Verification

Temporarily removed the `@ts-nocheck` from chat.ts and ran typecheck — zero `Cannot find name` errors after this fix. Pragma restored after verification (typing the rest of ChatPanel is the still-pending follow-up tracked in #28). 1682 tests pass.

## Why tests didn't catch this

`tests/server-dashboard.test.ts` only verifies the asset-server endpoints respond 200, not that the bundled `app.js` actually executes without ReferenceError. Adding a smoke check for that is worth a follow-up.