### PR TITLE
refactor(dashboard): Tools panel → design vocabulary; legacy panel utils

### DIFF
--- a/dashboard/app.css
+++ b/dashboard/app.css
@@ -1044,3 +1044,43 @@ main { padding: 32px 40px 60px 32px; min-width: 0; }
 html, body, #root { height: 100%; }
 #root { display: contents; }
 .app { height: 100vh; }
+
+/* ── Legacy panel utilities — bridge classes used by panels that haven't
+ *    been migrated to the design vocabulary yet. Removed in the final
+ *    cleanup PR once every panel has its own design-aligned markup. ── */
+.panel-header { display: flex; align-items: baseline; gap: 12px; margin-bottom: 18px; }
+.panel-title { font-size: 18px; font-weight: 600; color: var(--fg-0); margin: 0; font-family: var(--font-mono); letter-spacing: -.005em; }
+.panel-subtitle { color: var(--fg-3); font-size: 12.5px; }
+.boot { color: var(--fg-3); padding: 24px; text-align: center; font-family: var(--font-mono); font-size: 12px; }
+.empty { color: var(--fg-3); padding: 18px; border: 1px dashed var(--bd); border-radius: var(--r); font-size: 12.5px; }
+.notice { background: var(--bg-elev); border: 1px solid var(--bd); border-left: 2px solid var(--c-brand); border-radius: var(--r); padding: 8px 12px; margin: 8px 0; font-size: 12.5px; color: var(--fg-1); }
+.notice.err { border-left-color: var(--c-err); color: var(--c-err); }
+.notice.warn { border-left-color: var(--c-warn); color: var(--c-warn); }
+.muted { color: var(--fg-3); }
+.section-title { font-family: var(--font-mono); font-size: 11px; color: var(--fg-3); text-transform: uppercase; letter-spacing: .1em; margin: 18px 0 6px; }
+.row { display: flex; align-items: center; gap: 8px; margin: 6px 0; }
+.metric-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 10px; margin-bottom: 18px; }
+.card-title { font-family: var(--font-mono); font-size: 10.5px; color: var(--fg-3); text-transform: uppercase; letter-spacing: .08em; margin-bottom: 4px; }
+.card-value { color: var(--fg-0); font-family: var(--font-mono); font-size: 18px; font-weight: 600; }
+.card-value.muted { color: var(--fg-4); }
+.card-hint { color: var(--fg-3); font-size: 11.5px; margin-top: 4px; }
+.pill-ok { color: var(--c-ok); background: rgba(126,231,135,.08); }
+.pill-warn { color: var(--c-warn); background: rgba(240,176,125,.10); }
+.pill-err { color: var(--c-err); background: rgba(255,139,129,.10); }
+.pill-accent { color: var(--c-accent); background: rgba(210,168,255,.10); }
+.pill-dim { color: var(--fg-3); background: var(--bg-elev-2); }
+.pill-active { color: var(--c-brand); background: rgba(121,192,255,.10); }
+.numeric { font-family: var(--font-mono); text-align: right; font-variant-numeric: tabular-nums; }
+button.primary { background: var(--c-brand); color: var(--bg); border: 1px solid var(--c-brand); padding: 5px 12px; border-radius: var(--r); font-family: var(--font-sans); font-size: 12px; cursor: pointer; }
+button.primary:hover { background: rgba(121,192,255,.85); }
+button.danger { background: transparent; color: var(--c-err); border: 1px solid var(--c-err); padding: 5px 12px; border-radius: var(--r); font-family: var(--font-sans); font-size: 12px; cursor: pointer; }
+button:not(.primary):not(.danger) { background: var(--bg-elev-2); color: var(--fg-1); border: 1px solid var(--bd); padding: 5px 12px; border-radius: var(--r); font-family: var(--font-sans); font-size: 12px; cursor: pointer; }
+button:hover:not(.primary):not(.danger) { background: var(--bg-hover); border-color: var(--bd-strong); }
+input[type=text], input[type=number], input[type=password], textarea, select { background: var(--bg-input); color: var(--fg-0); border: 1px solid var(--bd); border-radius: var(--r); padding: 5px 10px; font-family: var(--font-mono); font-size: 12.5px; outline: none; }
+input:focus, textarea:focus, select:focus { border-color: var(--c-brand); }
+table { width: 100%; border-collapse: collapse; font-size: 12.5px; }
+table th, table td { padding: 8px 10px; text-align: left; border-bottom: 1px solid var(--bd); }
+table th { font-family: var(--font-mono); font-size: 10.5px; font-weight: 600; color: var(--fg-3); text-transform: uppercase; letter-spacing: .08em; background: var(--bg-elev); }
+table td { color: var(--fg-1); }
+table tbody tr:hover { background: var(--bg-hover); }
+table td.numeric { color: var(--fg-0); }

--- a/dashboard/src/panels/tools.ts
+++ b/dashboard/src/panels/tools.ts
@@ -22,49 +22,55 @@ interface ToolsError {
 
 export function ToolsPanel() {
   const { data, error, loading } = usePoll<ToolsData>("/tools", 4000);
-  if (loading && !data) return html`<div class="boot">loading tools…</div>`;
+  if (loading && !data)
+    return html`<div class="card" style="color:var(--fg-3)">loading tools…</div>`;
   const e = error as ToolsError | null;
   if (e?.status === 503) {
-    return html`<div class="notice">${e.body?.error ?? "live tools view requires an attached session"}</div>`;
+    return html`<div class="card accent-warn">${e.body?.error ?? "live tools view requires an attached session"}</div>`;
   }
-  if (e) return html`<div class="notice err">tools failed: ${e.message}</div>`;
+  if (e) return html`<div class="card accent-err">tools failed: ${e.message}</div>`;
   if (!data) return null;
   const t = data;
 
   return html`
-    <div>
-      <div class="panel-header">
-        <h2 class="panel-title">Tools</h2>
-        <span class="panel-subtitle">${t.total} registered ${t.planMode ? html`<span class="pill pill-warn">plan mode — writes gated</span>` : ""}</span>
+    <div style="display:flex;flex-direction:column;gap:14px">
+      <div class="chips">
+        <span class="chip-f active">all <span class="ct">${t.total}</span></span>
+        ${t.planMode ? html`<span class="chip-f" style="border-color:var(--c-warn);color:var(--c-warn)">plan mode — writes gated</span>` : null}
       </div>
+
       ${
         t.tools.length === 0
-          ? html`<div class="empty">No tools registered.</div>`
+          ? html`<div class="card" style="color:var(--fg-3)">No tools registered.</div>`
           : html`
-          <table>
-            <thead>
-              <tr>
-                <th>name</th>
-                <th>flags</th>
-                <th>description</th>
-              </tr>
-            </thead>
-            <tbody>
-              ${t.tools.map(
-                (tool) => html`
-                <tr>
-                  <td><code>${tool.name}</code></td>
-                  <td>
-                    ${tool.readOnly ? html`<span class="pill pill-ok">read-only</span>` : html`<span class="pill pill-accent">write</span>`}
-                    ${tool.flattened ? html` <span class="pill pill-dim">flat</span>` : ""}
-                  </td>
-                  <td>${tool.description ?? ""}</td>
-                </tr>
-              `,
-              )}
-            </tbody>
-          </table>
-        `
+            <div class="card" style="padding:0;overflow:hidden">
+              <table class="tbl">
+                <thead>
+                  <tr>
+                    <th>tool</th>
+                    <th>flags</th>
+                    <th>description</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  ${t.tools.map(
+                    (tool) => html`
+                      <tr>
+                        <td><code class="mono">${tool.name}</code></td>
+                        <td>
+                          ${tool.readOnly
+                            ? html`<span class="pill ok">read-only</span>`
+                            : html`<span class="pill acc">write</span>`}
+                          ${tool.flattened ? html` <span class="pill">flat</span>` : null}
+                        </td>
+                        <td class="dim">${tool.description ?? ""}</td>
+                      </tr>
+                    `,
+                  )}
+                </tbody>
+              </table>
+            </div>
+          `
       }
     </div>
   `;


### PR DESCRIPTION
First per-panel migration of the visual catch-up. Establishes the pattern for the remaining 13 panels.

## Tools panel migrated

- `.chips` + `.chip-f` for the filter row (just `all` for now — category breakdowns need new API fields, follow-up).
- `.tbl` inside `.card` for the table.
- `pill.ok / pill.acc / pill` for read-only / write / flat flags.
- `.card.accent-warn / .card.accent-err` for error states.

## Legacy panel utilities

Added a `Legacy panel utilities` block at the tail of `app.css` that maps the old class vocabulary (`.panel-header`, `.empty`, `.notice`, `.metric-grid`, `.pill-*`, generic `button` / `input` / `table` styling) to design tokens. This keeps the 13 unmigrated panels rendering passably without forcing a 14-panel single PR.

Each subsequent panel migration removes one panel's dependence on these legacy classes. The cleanup PR at the end of the migration deletes the entire legacy block.

## Test plan

- [x] Build / typecheck / 1682 tests pass.
- [ ] Manual: Tools panel matches the design mockup's table styling. Other panels render with the legacy bridge styling — functional but not yet design-aligned.