### PR TITLE
refactor(dashboard): Plans panel → design vocabulary

### DIFF
--- a/dashboard/src/panels/plans.ts
+++ b/dashboard/src/panels/plans.ts
@@ -25,80 +25,125 @@ interface PlansData {
   plans?: ArchivedPlan[];
 }
 
+function statusPill(p: ArchivedPlan) {
+  if (p.completionRatio >= 1) return html`<span class="pill ok">done</span>`;
+  if (p.completionRatio > 0) return html`<span class="pill info">active</span>`;
+  return html`<span class="pill">idle</span>`;
+}
+
 export function PlansPanel() {
   const { data, error, loading } = usePoll<PlansData>("/plans", 8000);
-  const [open, setOpen] = useState<ArchivedPlan | null>(null);
-  if (loading && !data) return html`<div class="boot">loading plans…</div>`;
-  if (error) return html`<div class="notice err">plans failed: ${error.message}</div>`;
+  const [openIdx, setOpenIdx] = useState<number | null>(null);
+  const [filter, setFilter] = useState("");
+
+  if (loading && !data)
+    return html`<div class="card" style="color:var(--fg-3)">loading plans…</div>`;
+  if (error) return html`<div class="card accent-err">plans failed: ${error.message}</div>`;
   const plans = data?.plans ?? [];
 
-  if (open) {
-    const completedSet = new Set(open.completedStepIds);
-    return html`
-      <div>
-        <div class="panel-header">
-          <h2 class="panel-title">Plan</h2>
-          <span class="panel-subtitle">${open.session} · ${fmtRelativeTime(open.completedAt)}</span>
-          <button onClick=${() => setOpen(null)} style="margin-left: auto;">← back</button>
+  if (plans.length === 0)
+    return html`<div class="card" style="color:var(--fg-3)">
+      No archived plans yet — run a turn that calls <code class="mono">submit_plan</code>
+      and <code class="mono">mark_step_complete</code>.
+    </div>`;
+
+  const filtered = filter.trim()
+    ? plans.filter(
+        (p) =>
+          p.session.toLowerCase().includes(filter.toLowerCase()) ||
+          (p.summary ?? "").toLowerCase().includes(filter.toLowerCase()),
+      )
+    : plans;
+
+  const open = openIdx !== null ? plans[openIdx] : null;
+
+  return html`
+    <div class="sessions-grid">
+      <div class="sessions-list">
+        <div class="ssl-h">
+          <input
+            type="text"
+            placeholder="filter plans"
+            value=${filter}
+            onInput=${(e: Event) => setFilter((e.target as HTMLInputElement).value)}
+            style="flex:1"
+          />
         </div>
-        ${open.summary ? html`<div class="notice">${open.summary}</div>` : null}
-        <div class="card">
-          ${open.steps.map((step) => {
-            const done = completedSet.has(step.id);
+        <div class="chips" style="padding:0 12px 8px">
+          <span class="chip-f active">all <span class="ct">${plans.length}</span></span>
+          <span class="chip-f">
+            active
+            <span class="ct">${plans.filter((p) => p.completionRatio > 0 && p.completionRatio < 1).length}</span>
+          </span>
+          <span class="chip-f">
+            done <span class="ct">${plans.filter((p) => p.completionRatio >= 1).length}</span>
+          </span>
+        </div>
+        <div class="ssl-rows">
+          ${filtered.map((p) => {
+            const idx = plans.indexOf(p);
+            const sel = idx === openIdx;
             return html`
-              <div style="padding: 8px 0; border-bottom: 1px solid var(--border); display: flex; gap: 12px;">
-                <div style="width: 16px; color: ${done ? "var(--ok)" : "var(--fg-3)"}; font-family: var(--mono);">
-                  ${done ? "✓" : "·"}
-                </div>
-                <div style="flex: 1;">
-                  <div style="color: ${done ? "var(--fg-2)" : "var(--fg-0)"}; font-weight: 500;">
-                    ${step.title}
-                  </div>
-                  ${step.action ? html`<div style="color: var(--fg-2); font-size: 12px; margin-top: 2px;">${step.action}</div>` : null}
-                  ${step.risk ? html`<span class="pill pill-${step.risk === "high" ? "err" : step.risk === "medium" ? "warn" : "dim"}" style="margin-top: 4px;">${step.risk}</span>` : null}
-                </div>
+              <div class=${`ssl-row ${sel ? "sel" : ""}`} onClick=${() => setOpenIdx(idx)}>
+                <span class="name">${p.summary ?? p.session} ${statusPill(p)}</span>
+                ${
+                  p.summary && p.session !== p.summary
+                    ? html`<span class="preview">${p.session}</span>`
+                    : null
+                }
+                <span class="meta">
+                  <span><span class="v">${p.totalSteps}</span> steps</span>
+                  <span><span class="v">${p.completedSteps} / ${p.totalSteps}</span> · ${fmtPct(p.completionRatio)}</span>
+                  <span>${fmtRelativeTime(p.completedAt)}</span>
+                </span>
               </div>
             `;
           })}
         </div>
       </div>
-    `;
-  }
 
-  return html`
-    <div>
-      <div class="panel-header">
-        <h2 class="panel-title">Plans</h2>
-        <span class="panel-subtitle">${plans.length} archived · click to view</span>
+      <div class="sessions-detail">
+        ${
+          open == null
+            ? html`<div style="color:var(--fg-3);font-size:13px;text-align:center;padding:60px 20px">
+                Pick a plan on the left.
+              </div>`
+            : html`
+                <div class="sessions-detail-h">
+                  <span class="name">${open.summary ?? "(no title)"}</span>
+                  <span class="ws">${open.session} · ${fmtRelativeTime(open.completedAt)}</span>
+                  <span class="actions">
+                    <button class="btn ghost" onClick=${() => setOpenIdx(null)}>← back</button>
+                  </span>
+                </div>
+
+                <h3 style="margin:0 0 6px;font-family:var(--font-mono);font-size:11px;color:var(--fg-3);text-transform:uppercase;letter-spacing:.1em">
+                  Step timeline · ${open.completedSteps} / ${open.totalSteps}
+                </h3>
+                <div class="plan-timeline" style="margin-bottom:14px">
+                  ${open.steps.map((step, i) => {
+                    const done = open.completedStepIds.includes(step.id);
+                    const cls = done ? "done" : i === open.completedSteps ? "active" : "";
+                    return html`
+                      <div class=${`plan-step ${cls}`}>
+                        <span class="lbl">step ${i + 1}</span>
+                        <span class="name">${step.title}</span>
+                        ${step.action ? html`<span class="meta">${step.action}</span>` : null}
+                        ${
+                          step.risk
+                            ? html`<span
+                                class=${`pill ${step.risk === "high" ? "err" : step.risk === "medium" ? "warn" : ""}`}
+                                style="align-self:flex-start;margin-top:4px"
+                              >${step.risk}</span>`
+                            : null
+                        }
+                      </div>
+                    `;
+                  })}
+                </div>
+              `
+        }
       </div>
-      ${
-        plans.length === 0
-          ? html`<div class="empty">No archived plans yet — run a turn that calls <code>submit_plan</code> + <code>mark_step_complete</code>.</div>`
-          : html`
-          <table>
-            <thead>
-              <tr>
-                <th>session</th>
-                <th>title</th>
-                <th class="numeric">progress</th>
-                <th class="numeric">archived</th>
-              </tr>
-            </thead>
-            <tbody>
-              ${plans.map(
-                (p, i) => html`
-                <tr key=${i} onClick=${() => setOpen(p)} style="cursor: pointer;">
-                  <td><code>${p.session}</code></td>
-                  <td>${p.summary ?? html`<span class="muted">(no title)</span>`}</td>
-                  <td class="numeric">${p.completedSteps}/${p.totalSteps} · ${fmtPct(p.completionRatio)}</td>
-                  <td class="numeric muted">${fmtRelativeTime(p.completedAt)}</td>
-                </tr>
-              `,
-              )}
-            </tbody>
-          </table>
-        `
-      }
     </div>
   `;
 }


### PR DESCRIPTION
Two-column `.sessions-grid` layout:

- **Left**: `.sessions-list` with filter input, status chips (all / active / done), `.ssl-row` per plan with status pill + summary + meta.
- **Right**: `.sessions-detail` with title bar + horizontal `.plan-timeline` / `.plan-step` cards (done / active variants based on completion).

Adds a filter input that searches session id and summary. Step risk shown as a pill (err / warn / dim).

1682 tests pass.