### PR TITLE
refactor(dashboard): Settings panel → design vocabulary

### DIFF
--- a/dashboard/src/panels/settings.ts
+++ b/dashboard/src/panels/settings.ts
@@ -50,103 +50,133 @@ export function SettingsPanel() {
     [load],
   );
 
-  if (!data && !error) return html`<div class="boot">loading settings…</div>`;
-  if (error && !data) return html`<div class="notice err">${error}</div>`;
+  if (!data && !error)
+    return html`<div class="card" style="color:var(--fg-3)">loading settings…</div>`;
+  if (error && !data) return html`<div class="card accent-err">${error}</div>`;
   if (!data) return null;
   const v = data;
 
+  const sectionH3 = (text: string) => html`
+    <h3 style="margin:18px 0 8px;font-family:var(--font-mono);font-size:11px;color:var(--fg-3);text-transform:uppercase;letter-spacing:.1em">${text}</h3>
+  `;
+  const fieldRow = (
+    label: string,
+    control: unknown,
+    note?: string,
+  ) => html`
+    <div style="display:flex;align-items:center;gap:10px;padding:6px 0">
+      <span style="flex:0 0 110px;font-family:var(--font-mono);font-size:11.5px;color:var(--fg-3)">${label}</span>
+      <div style="flex:1;display:flex;align-items:center;gap:8px">${control}</div>
+      ${note ? html`<span style="color:var(--fg-3);font-size:11px">${note}</span>` : null}
+    </div>
+  `;
+
   return html`
-    <div>
-      <div class="panel-header">
-        <h2 class="panel-title">Settings</h2>
-        <span class="panel-subtitle">~/.reasonix/config.json · most fields apply next session</span>
-      </div>
-      ${saved ? html`<div class="notice">${saved}</div>` : null}
-      ${error ? html`<div class="notice err">${error}</div>` : null}
+    <div style="max-width:760px;display:flex;flex-direction:column;gap:6px">
+      ${
+        saved ? html`<div><span class="pill ok">${saved}</span></div>` : null
+      }
+      ${
+        error ? html`<div class="card accent-err">${error}</div>` : null
+      }
 
-      <div class="section-title">DeepSeek API</div>
+      ${sectionH3("DeepSeek API")}
       <div class="card">
-        <div class="row">
-          <span class="card-title" style="margin: 0;">API key</span>
-          <code style="margin-left: auto;">${v.apiKey ?? "(not set)"}</code>
-        </div>
-        <div class="row" style="margin-top: 8px;">
-          <input
-            type="password"
-            placeholder="paste a fresh sk-… token to replace"
-            value=${draft.apiKey ?? ""}
-            onInput=${(e: Event) => setDraft({ ...draft, apiKey: (e.target as HTMLInputElement).value })}
-          />
-          <button
-            class="primary"
-            disabled=${saving || !(draft.apiKey ?? "").trim()}
-            onClick=${() => save({ apiKey: draft.apiKey })}
-          >Save key</button>
-        </div>
-        <div class="row" style="margin-top: 12px;">
-          <span class="card-title" style="margin: 0;">Base URL</span>
-          <input
-            type="text"
-            value=${draft.baseUrl ?? v.baseUrl ?? ""}
-            placeholder="https://api.deepseek.com (default)"
-            onInput=${(e: Event) => setDraft({ ...draft, baseUrl: (e.target as HTMLInputElement).value })}
-          />
-          <button
-            disabled=${saving || (draft.baseUrl ?? v.baseUrl ?? "") === (v.baseUrl ?? "")}
-            onClick=${() => save({ baseUrl: draft.baseUrl })}
-          >Save</button>
-        </div>
-      </div>
-
-      <div class="section-title">Defaults</div>
-      <div class="card">
-        <div class="row">
-          <span class="card-title" style="margin: 0; flex: 0 0 110px;">Preset</span>
-          <select
-            value=${["auto", "flash", "pro"].includes(v.preset ?? "") ? v.preset : "auto"}
-            onChange=${(e: Event) => save({ preset: (e.target as HTMLSelectElement).value })}
-            disabled=${saving}
-          >
-            <option value="auto">auto — flash → pro on hard turns (default)</option>
-            <option value="flash">flash — always flash, no auto-escalate</option>
-            <option value="pro">pro — always pro</option>
-          </select>
-          <span class="muted" style="margin-left: auto; font-size: 12px;">applies next turn</span>
-        </div>
-        <div class="row" style="margin-top: 12px;">
-          <span class="card-title" style="margin: 0; flex: 0 0 110px;">Effort</span>
-          <select
-            value=${v.reasoningEffort}
-            onChange=${(e: Event) => save({ reasoningEffort: (e.target as HTMLSelectElement).value })}
-            disabled=${saving}
-          >
-            <option value="max">max (default — best)</option>
-            <option value="high">high (cheaper / faster)</option>
-          </select>
-          <span class="muted" style="margin-left: auto; font-size: 12px;">applies next turn</span>
-        </div>
-        <div class="row" style="margin-top: 12px;">
-          <span class="card-title" style="margin: 0; flex: 0 0 110px;">Web search</span>
-          <button
-            class=${v.search ? "primary" : ""}
-            onClick=${() => save({ search: !v.search })}
-            disabled=${saving}
-          >${v.search ? "ON" : "off"}</button>
-          <span class="muted" style="margin-left: auto; font-size: 12px;">web_fetch + web_search tools</span>
-        </div>
+        ${fieldRow(
+          "API key",
+          html`<code class="mono" style="color:var(--fg-2);font-size:11.5px">${v.apiKey ?? "(not set)"}</code>`,
+        )}
+        ${fieldRow(
+          "replace",
+          html`
+            <input
+              type="password"
+              placeholder="paste a fresh sk-… token"
+              value=${draft.apiKey ?? ""}
+              onInput=${(e: Event) => setDraft({ ...draft, apiKey: (e.target as HTMLInputElement).value })}
+              style="flex:1"
+            />
+            <button
+              class="btn primary"
+              disabled=${saving || !(draft.apiKey ?? "").trim()}
+              onClick=${() => save({ apiKey: draft.apiKey })}
+            >Save key</button>
+          `,
+        )}
+        ${fieldRow(
+          "base url",
+          html`
+            <input
+              type="text"
+              value=${draft.baseUrl ?? v.baseUrl ?? ""}
+              placeholder="https://api.deepseek.com (default)"
+              onInput=${(e: Event) => setDraft({ ...draft, baseUrl: (e.target as HTMLInputElement).value })}
+              style="flex:1"
+            />
+            <button
+              class="btn"
+              disabled=${saving || (draft.baseUrl ?? v.baseUrl ?? "") === (v.baseUrl ?? "")}
+              onClick=${() => save({ baseUrl: draft.baseUrl })}
+            >Save</button>
+          `,
+        )}
       </div>
 
-      <div class="section-title">Runtime</div>
+      ${sectionH3("Defaults")}
       <div class="card">
-        <div class="row">
-          <span class="card-title" style="margin: 0; flex: 0 0 110px;">Active model</span>
-          <code>${v.model ?? "—"}</code>
-        </div>
-        <div class="row" style="margin-top: 8px;">
-          <span class="card-title" style="margin: 0; flex: 0 0 110px;">Edit mode</span>
-          <code>${v.editMode}</code>
-          <span class="muted" style="margin-left: auto; font-size: 12px;">switch from the Chat tab header</span>
-        </div>
+        ${fieldRow(
+          "preset",
+          html`
+            <select
+              value=${["auto", "flash", "pro"].includes(v.preset ?? "") ? v.preset : "auto"}
+              onChange=${(e: Event) => save({ preset: (e.target as HTMLSelectElement).value })}
+              disabled=${saving}
+            >
+              <option value="auto">auto — flash → pro on hard turns</option>
+              <option value="flash">flash — always flash, no auto-escalate</option>
+              <option value="pro">pro — always pro</option>
+            </select>
+          `,
+          "applies next turn",
+        )}
+        ${fieldRow(
+          "effort",
+          html`
+            <select
+              value=${v.reasoningEffort}
+              onChange=${(e: Event) => save({ reasoningEffort: (e.target as HTMLSelectElement).value })}
+              disabled=${saving}
+            >
+              <option value="max">max (default — best)</option>
+              <option value="high">high (cheaper / faster)</option>
+            </select>
+          `,
+          "applies next turn",
+        )}
+        ${fieldRow(
+          "web search",
+          html`
+            <button
+              class=${`btn ${v.search ? "primary" : ""}`}
+              onClick=${() => save({ search: !v.search })}
+              disabled=${saving}
+            >${v.search ? "ON" : "off"}</button>
+          `,
+          "web_fetch + web_search tools",
+        )}
+      </div>
+
+      ${sectionH3("Runtime")}
+      <div class="card">
+        ${fieldRow(
+          "active model",
+          html`<code class="mono">${v.model ?? "—"}</code>`,
+        )}
+        ${fieldRow(
+          "edit mode",
+          html`<code class="mono">${v.editMode}</code>`,
+          "switch from the Chat tab header",
+        )}
       </div>
     </div>
   `;


### PR DESCRIPTION
Three `.card` sections (DeepSeek API / Defaults / Runtime). Each row uses a 110px label gutter + control + optional right-aligned note. `.btn` and `.btn.primary` from design instead of legacy buttons.