### PR TITLE
refactor(dashboard): MCP panel → design vocabulary

### DIFF
--- a/dashboard/src/panels/mcp.ts
+++ b/dashboard/src/panels/mcp.ts
@@ -79,128 +79,150 @@ export function McpPanel() {
     [load],
   );
 
-  if (!data && !error) return html`<div class="boot">loading MCP…</div>`;
-  if (error && !data) return html`<div class="notice err">${error}</div>`;
+  if (!data && !error) return html`<div class="card" style="color:var(--fg-3)">loading MCP…</div>`;
+  if (error && !data) return html`<div class="card accent-err">${error}</div>`;
   if (!data) return null;
 
-  if (open) {
-    return html`
-      <div>
-        <div class="panel-header">
-          <h2 class="panel-title">MCP · ${open.label}</h2>
-          <button onClick=${() => setOpen(null)} style="margin-left: auto;">← back</button>
-        </div>
-        <div class="card">
-          <div class="row"><span class="card-title" style="margin: 0; flex: 0 0 110px;">spec</span><code>${open.spec}</code></div>
-          <div class="row"><span class="card-title" style="margin: 0; flex: 0 0 110px;">server</span><span>${open.serverInfo?.name ?? "—"} ${open.serverInfo?.version ? `v${open.serverInfo.version}` : ""}</span></div>
-          <div class="row"><span class="card-title" style="margin: 0; flex: 0 0 110px;">protocol</span><code>${open.protocolVersion}</code></div>
-        </div>
-        ${open.instructions ? html`<div class="notice">${open.instructions}</div>` : null}
-        <div class="section-title">Tools (${open.tools.length})</div>
-        <table>
-          <thead><tr><th>name</th><th>description</th></tr></thead>
-          <tbody>
-            ${open.tools.map((t) => html`<tr><td><code>${t.name}</code></td><td>${t.description ?? ""}</td></tr>`)}
-          </tbody>
-        </table>
-        ${
-          open.resources.length > 0
-            ? html`
-          <div class="section-title">Resources (${open.resources.length})</div>
-          <table>
-            <thead><tr><th>name</th><th>uri</th></tr></thead>
-            <tbody>
-              ${open.resources.map((r) => html`<tr><td>${r.name}</td><td><code>${r.uri}</code></td></tr>`)}
-            </tbody>
-          </table>
-        `
-            : null
-        }
-        ${
-          open.prompts.length > 0
-            ? html`
-          <div class="section-title">Prompts (${open.prompts.length})</div>
-          <table>
-            <thead><tr><th>name</th><th>description</th></tr></thead>
-            <tbody>
-              ${open.prompts.map((p) => html`<tr><td><code>${p.name}</code></td><td>${p.description ?? ""}</td></tr>`)}
-            </tbody>
-          </table>
-        `
-            : null
-        }
-      </div>
-    `;
-  }
-
   return html`
-    <div>
-      <div class="panel-header">
-        <h2 class="panel-title">MCP</h2>
-        <span class="panel-subtitle">${data.servers.length} bridged · ${specs?.length ?? 0} in config</span>
-      </div>
-      ${info ? html`<div class="notice">${info}</div>` : null}
-      ${error ? html`<div class="notice err">${error}</div>` : null}
+    <div class="sessions-grid">
+      <div class="sessions-list">
+        <div class="ssl-h" style="font-family:var(--font-mono);font-size:11px;color:var(--fg-3);text-transform:uppercase;letter-spacing:.1em">
+          MCP servers · ${data.servers.length} bridged
+        </div>
+        <div style="padding:8px 12px;display:flex;gap:6px">
+          <input
+            type="text"
+            placeholder='spec — e.g. fs=npx -y @modelcontextprotocol/...'
+            value=${newSpec}
+            onInput=${(e: Event) => setNewSpec((e.target as HTMLInputElement).value)}
+            style="flex:1;font-size:11px"
+          />
+          <button class="btn primary" disabled=${busy || !newSpec.trim()} onClick=${addSpec}>+</button>
+        </div>
+        ${info ? html`<div style="padding:0 12px 8px"><span class="pill ok">${info}</span></div>` : null}
+        ${error ? html`<div class="card accent-err" style="margin:0 12px 8px">${error}</div>` : null}
 
-      <div class="section-title">Add server</div>
-      <div class="card row">
-        <input
-          type="text"
-          placeholder='spec — e.g. "fs=npx -y @modelcontextprotocol/server-filesystem /tmp/safe"'
-          value=${newSpec}
-          onInput=${(e: Event) => setNewSpec((e.target as HTMLInputElement).value)}
-        />
-        <button class="primary" disabled=${busy || !newSpec.trim()} onClick=${addSpec}>Add</button>
-      </div>
-
-      <div class="section-title">Bridged (${data.servers.length})</div>
-      ${
-        data.servers.length === 0
-          ? html`<div class="empty">No MCP servers in this session.</div>`
-          : html`
-          <table>
-            <thead><tr><th>label</th><th>spec</th><th class="numeric">tools</th><th></th></tr></thead>
-            <tbody>
-              ${data.servers.map(
-                (s) => html`
-                <tr key=${s.label} style="cursor: pointer;" onClick=${() => setOpen(s)}>
-                  <td><code>${s.label}</code></td>
-                  <td><code style="font-size: 11px;">${s.spec}</code></td>
-                  <td class="numeric">${fmtNum(s.toolCount)}</td>
-                  <td></td>
-                </tr>
-              `,
-              )}
-            </tbody>
-          </table>
-        `
-      }
-
-      <div class="section-title">Persisted specs (config.json)</div>
-      ${
-        (specs ?? []).length === 0
-          ? html`<div class="empty">No MCP specs persisted in <code>~/.reasonix/config.json</code>.</div>`
-          : html`
-          <table>
-            <thead><tr><th>spec</th><th></th></tr></thead>
-            <tbody>
-              ${(specs ?? []).map(
-                (spec) => html`
-                <tr key=${spec}>
-                  <td><code>${spec}</code></td>
-                  <td class="numeric">
-                    <button class="danger" disabled=${busy} onClick=${(e: Event) => {
+        <div class="ssl-rows">
+          ${data.servers.length === 0
+            ? html`<div style="color:var(--fg-3);padding:14px;font-size:12px">
+                No MCP servers in this session.
+              </div>`
+            : data.servers.map((s) => html`
+              <div
+                class=${`ssl-row ${open?.label === s.label ? "sel" : ""}`}
+                onClick=${() => setOpen(s)}
+              >
+                <span class="name">${s.label} <span class="pill ok">live</span></span>
+                <span class="preview">${s.spec}</span>
+                <span class="meta"><span><span class="v">${fmtNum(s.toolCount)}</span> tools</span></span>
+              </div>
+            `)}
+          ${(specs ?? [])
+            .filter((spec) => !data.servers.some((s) => s.spec === spec))
+            .map((spec) => html`
+              <div class="ssl-row" style="cursor:default">
+                <span class="name">(unbridged) <span class="pill">config</span></span>
+                <span class="preview">${spec}</span>
+                <span class="meta">
+                  <button
+                    class="btn ghost"
+                    style="font-size:10.5px;padding:2px 6px;color:var(--c-err);border-color:var(--c-err)"
+                    disabled=${busy}
+                    onClick=${(e: Event) => {
                       e.stopPropagation();
                       removeSpec(spec);
-                    }}>remove</button>
-                  </td>
-                </tr>
-              `,
-              )}
-            </tbody>
-          </table>
-        `
-      }
+                    }}
+                  >remove</button>
+                </span>
+              </div>
+            `)}
+        </div>
+      </div>
+
+      <div class="sessions-detail">
+        ${
+          open == null
+            ? html`<div style="color:var(--fg-3);font-size:13px;text-align:center;padding:60px 20px">
+                Pick an MCP server on the left to inspect tools / resources / prompts.
+              </div>`
+            : html`
+                <div class="sessions-detail-h">
+                  <span class="name">${open.label}</span>
+                  <span class="ws">${open.serverInfo?.name ?? "—"} ${open.serverInfo?.version ? `v${open.serverInfo.version}` : ""} · ${open.protocolVersion ?? "—"}</span>
+                  <span class="actions">
+                    <button class="btn ghost" onClick=${() => setOpen(null)}>← back</button>
+                  </span>
+                </div>
+
+                <div class="card" style="margin-bottom:12px">
+                  <div class="card-h"><span class="title">spec</span></div>
+                  <code class="mono" style="font-size:11.5px;color:var(--fg-2)">${open.spec}</code>
+                </div>
+
+                ${
+                  open.instructions
+                    ? html`<div class="card accent-brand" style="margin-bottom:12px">
+                        <div class="card-b">${open.instructions}</div>
+                      </div>`
+                    : null
+                }
+
+                <h3 style="margin:18px 0 6px;font-family:var(--font-mono);font-size:11px;color:var(--fg-3);text-transform:uppercase;letter-spacing:.1em">
+                  Tools · ${open.tools.length}
+                </h3>
+                <div class="card" style="padding:0;overflow:hidden">
+                  <table class="tbl">
+                    <thead><tr><th>name</th><th>description</th></tr></thead>
+                    <tbody>
+                      ${open.tools.map(
+                        (t) => html`<tr><td><code class="mono">${t.name}</code></td><td class="dim">${t.description ?? ""}</td></tr>`,
+                      )}
+                    </tbody>
+                  </table>
+                </div>
+
+                ${
+                  open.resources.length > 0
+                    ? html`
+                      <h3 style="margin:18px 0 6px;font-family:var(--font-mono);font-size:11px;color:var(--fg-3);text-transform:uppercase;letter-spacing:.1em">
+                        Resources · ${open.resources.length}
+                      </h3>
+                      <div class="card" style="padding:0;overflow:hidden">
+                        <table class="tbl">
+                          <thead><tr><th>name</th><th>uri</th></tr></thead>
+                          <tbody>
+                            ${open.resources.map(
+                              (r) => html`<tr><td>${r.name}</td><td class="path">${r.uri}</td></tr>`,
+                            )}
+                          </tbody>
+                        </table>
+                      </div>
+                    `
+                    : null
+                }
+
+                ${
+                  open.prompts.length > 0
+                    ? html`
+                      <h3 style="margin:18px 0 6px;font-family:var(--font-mono);font-size:11px;color:var(--fg-3);text-transform:uppercase;letter-spacing:.1em">
+                        Prompts · ${open.prompts.length}
+                      </h3>
+                      <div class="card" style="padding:0;overflow:hidden">
+                        <table class="tbl">
+                          <thead><tr><th>name</th><th>description</th></tr></thead>
+                          <tbody>
+                            ${open.prompts.map(
+                              (p) => html`<tr><td><code class="mono">${p.name}</code></td><td class="dim">${p.description ?? ""}</td></tr>`,
+                            )}
+                          </tbody>
+                        </table>
+                      </div>
+                    `
+                    : null
+                }
+              `
+        }
+      </div>
     </div>
   `;
 }


### PR DESCRIPTION
Same `.sessions-grid` pattern. Left list merges live-bridged servers and config-only specs into one feed; add-spec form in the list head. Right detail has spec card + instructions + tools/resources/prompts tables.