### PR TITLE
feat(slash): /cost <text> — pre-turn cost estimate

### DIFF
--- a/src/cli/ui/slash/commands.ts
+++ b/src/cli/ui/slash/commands.ts
@@ -98,7 +98,12 @@ export const SLASH_COMMANDS: readonly SlashCommandSpec[] = [
     summary:
       "cross-session cost dashboard (today / week / month / all-time · cache hit · vs Claude)",
   },
-  { cmd: "cost", summary: "show the most recent turn's token + spend breakdown (Usage card)" },
+  {
+    cmd: "cost",
+    argsHint: "[text]",
+    summary:
+      "bare → last turn's spend (Usage card); with text → estimate cost of sending it next (worst-case + likely-cache)",
+  },
   { cmd: "doctor", summary: "health check (api / config / api-reach / index / hooks / project)" },
   { cmd: "think", summary: "dump the last turn's full R1 reasoning (reasoner only)" },
   {

--- a/src/cli/ui/slash/handlers/basic.ts
+++ b/src/cli/ui/slash/handlers/basic.ts
@@ -83,6 +83,7 @@ const help: SlashHandler = () => ({
     "  /compact [tokens]        shrink large tool results in history (default 4000 tokens/result)",
     "  /think                   dump the most recent turn's full R1 reasoning (reasoner only)",
     "  /tool [N]                list tool calls (or dump full output of #N, 1=most recent)",
+    "  /cost [text]             bare → last turn's spend; with text → estimate cost of sending it next",
     "  /memory [sub]            show pinned memory (REASONIX.md + ~/.reasonix/memory).",
     "                            subs: list | show <name> | forget <name> | clear <scope> confirm",
     "  /skill [sub]             list / run user skills (project/.reasonix/skills + ~/.reasonix/skills).",

--- a/src/cli/ui/slash/handlers/observability.ts
+++ b/src/cli/ui/slash/handlers/observability.ts
@@ -1,4 +1,9 @@
-import { DEEPSEEK_CONTEXT_TOKENS, DEFAULT_CONTEXT_TOKENS } from "../../../../telemetry/stats.js";
+import {
+  DEEPSEEK_CONTEXT_TOKENS,
+  DEEPSEEK_PRICING,
+  DEFAULT_CONTEXT_TOKENS,
+} from "../../../../telemetry/stats.js";
+import { countTokens } from "../../../../tokenizer.js";
 import { computeCtxBreakdown } from "../../ctx-breakdown.js";
 import type { SlashHandler } from "../dispatch.js";
 import { compactNum, formatToolList } from "../helpers.js";
@@ -161,7 +166,10 @@ const compact: SlashHandler = (args, loop) => {
   };
 };
 
-const cost: SlashHandler = (_args, loop, ctx) => {
+const cost: SlashHandler = (args, loop, ctx) => {
+  if (args.length > 0) {
+    return estimateCost(args.join(" "), loop);
+  }
   const t = loop.stats.turns[loop.stats.turns.length - 1];
   if (!t) {
     return { info: "no turn yet — `/cost` shows the most recent turn's token + spend breakdown." };
@@ -183,6 +191,45 @@ const cost: SlashHandler = (_args, loop, ctx) => {
   });
   return {};
 };
+
+/** /cost <text> — pre-turn estimate. Pairs with /budget for the cost-aware-prompt loop. */
+function estimateCost(userText: string, loop: import("../../../../loop.js").CacheFirstLoop) {
+  const pricing = DEEPSEEK_PRICING[loop.model];
+  if (!pricing) {
+    return {
+      info: `▸ /cost: no pricing table for model "${loop.model}". Add one to telemetry/stats.ts.`,
+    };
+  }
+  const userTokens = countTokens(userText);
+  const breakdown = computeCtxBreakdown(loop);
+  const promptTokens =
+    breakdown.systemTokens + breakdown.toolsTokens + breakdown.logTokens + userTokens;
+
+  const turns = loop.stats.turns;
+  const avgOutput =
+    turns.length > 0
+      ? Math.round(turns.reduce((s, t) => s + t.usage.completionTokens, 0) / turns.length)
+      : 800;
+  const cacheHit = loop.stats.summary().cacheHitRatio;
+
+  const inputUsdMiss = (promptTokens * pricing.inputCacheMiss) / 1_000_000;
+  const inputUsdLikely =
+    (promptTokens * ((1 - cacheHit) * pricing.inputCacheMiss + cacheHit * pricing.inputCacheHit)) /
+    1_000_000;
+  const outputUsd = (avgOutput * pricing.output) / 1_000_000;
+
+  const fmt = (n: number) => `$${n < 0.01 ? n.toFixed(5) : n.toFixed(4)}`;
+  const lines = [
+    `▸ /cost estimate · ${loop.model} · ${promptTokens.toLocaleString()} prompt tokens` +
+      ` (sys ${compactNum(breakdown.systemTokens)} + tools ${compactNum(breakdown.toolsTokens)}` +
+      ` + log ${compactNum(breakdown.logTokens)} + msg ${compactNum(userTokens)})`,
+    `  worst case (full miss): ${fmt(inputUsdMiss)} input + ~${fmt(outputUsd)} output (${avgOutput.toLocaleString()} avg) ≈ ${fmt(inputUsdMiss + outputUsd)}`,
+    turns.length > 0
+      ? `  likely (${Math.round(cacheHit * 100)}% session cache hit): ${fmt(inputUsdLikely)} input + ~${fmt(outputUsd)} output ≈ ${fmt(inputUsdLikely + outputUsd)}`
+      : "  likely: matches worst case until cache fills (no completed turns yet)",
+  ];
+  return { info: lines.join("\n") };
+}
 
 export const handlers: Record<string, SlashHandler> = {
   think,

--- a/tests/slash.test.ts
+++ b/tests/slash.test.ts
@@ -840,6 +840,29 @@ describe("handleSlash", () => {
     expect(r.info).toMatch(/context:/);
   });
 
+  it("/cost with text estimates worst-case + likely cost for the prospective prompt", () => {
+    const loop = makeLoop();
+    loop.stats.record(1, loop.model, new Usage(10_000, 500, 10_500, 8_000, 2_000));
+    loop.log.append({ role: "user", content: "earlier message" });
+    loop.log.append({ role: "assistant", content: "earlier reply" });
+    const r = handleSlash("cost", ["draft", "this", "long", "prompt", "right", "here"], loop);
+    expect(r.info).toMatch(/\/cost estimate/);
+    expect(r.info).toMatch(/prompt tokens/);
+    expect(r.info).toMatch(/worst case.*\$/);
+    expect(r.info).toMatch(/likely.*cache hit/);
+  });
+
+  it("/cost with text but no completed turns notes cache hasn't filled yet", () => {
+    const r = handleSlash("cost", ["hello"], makeLoop());
+    expect(r.info).toMatch(/worst case/);
+    expect(r.info).toMatch(/no completed turns yet/);
+  });
+
+  it("/cost with no args + no completed turns falls through to the existing post-turn message", () => {
+    const r = handleSlash("cost", [], makeLoop());
+    expect(r.info).toMatch(/no turn yet/);
+  });
+
   it("/status with pendingEditCount=0 hides the edits line", () => {
     const r = handleSlash("status", [], makeLoop(), { pendingEditCount: 0 });
     expect(r.info).not.toMatch(/pending/);


### PR DESCRIPTION
## Summary

Closes the budget loop with `/budget`. Bare `/cost` keeps showing the last turn's spend; with text, it estimates what sending it next would cost.

- Tokenize `system + tools + log + msg` via the existing `computeCtxBreakdown` walker.
- Worst-case (full miss) and likely (apply session's running cache-hit ratio) input cost.
- Output cost ≈ session's average completion length × pricing, default 800 tokens when no turns yet.

Pulled from the next-session feature queue (item #4 — pre-turn estimator part).

## Example

```
> /cost should we add MCP retry logic for transient 500s
▸ /cost estimate · deepseek-v4-flash · 12,485 prompt tokens (sys 1.2K + tools 8.1K + log 3.1K + msg 32)
  worst case (full miss): $0.0017 input + ~$0.0002 output (800 avg) ≈ $0.0019
  likely (62% session cache hit): $0.0008 input + ~$0.0002 output ≈ $0.0010
```

## Test plan

- [x] `npm run verify` — 1685 tests pass (1682 baseline + 3 new in `tests/slash.test.ts`)
- [x] Tests cover: with-text estimate (worst + likely), text but no completed turns, bare `/cost` with no turns