### PR TITLE
feat(server): cockpit aggregator on /api/overview (Stage 1A of #64)

### DIFF
--- a/src/server/api/cockpit.ts
+++ b/src/server/api/cockpit.ts
@@ -1,0 +1,149 @@
+import { aggregateUsage, bucketCacheHitRatio, readUsageLog } from "../../telemetry/usage.js";
+import type { DashboardContext, DashboardStats } from "../context.js";
+
+export interface CockpitKpi {
+  total: number;
+  deltaPct: number | null;
+}
+
+export interface CockpitCacheKpi {
+  ratio: number;
+  deltaPp: number | null;
+}
+
+export interface CockpitDailyCost {
+  date: string;
+  usd: number;
+}
+
+export interface CockpitCurrentSession {
+  id: string;
+  turns: number;
+  totalCostUsd: number;
+  lastPromptTokens: number;
+  completionTokens: number;
+}
+
+export interface CockpitData {
+  balance: { currency: string; total: string } | null;
+  tokens7d: CockpitKpi | null;
+  cacheHit7d: CockpitCacheKpi | null;
+  costTrend14d: ReadonlyArray<CockpitDailyCost> | null;
+  currentSession: CockpitCurrentSession | null;
+}
+
+const TTL_MS = 30_000;
+
+interface CacheEntry {
+  ts: number;
+  data: Pick<CockpitData, "tokens7d" | "cacheHit7d" | "costTrend14d">;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+export function _resetCockpitCacheForTests(): void {
+  cache.clear();
+}
+
+export function computeCockpit(ctx: DashboardContext, now: number = Date.now()): CockpitData {
+  return {
+    balance: extractBalance(ctx.getStats?.() ?? null),
+    currentSession: extractCurrentSession(ctx),
+    ...readWarmCached(ctx.usageLogPath, now),
+  };
+}
+
+function extractBalance(stats: DashboardStats | null): CockpitData["balance"] {
+  const first = stats?.balance?.[0];
+  if (!first) return null;
+  return { currency: first.currency, total: first.total_balance };
+}
+
+function extractCurrentSession(ctx: DashboardContext): CockpitData["currentSession"] {
+  const id = ctx.getSessionName?.() ?? null;
+  const stats = ctx.getStats?.() ?? null;
+  const loop = ctx.loop;
+  if (!id || !stats || !loop) return null;
+  let completion = 0;
+  for (const t of loop.stats.turns) completion += t.usage.completionTokens;
+  return {
+    id,
+    turns: stats.turns,
+    totalCostUsd: stats.totalCostUsd,
+    lastPromptTokens: stats.lastPromptTokens,
+    completionTokens: completion,
+  };
+}
+
+function readWarmCached(
+  usageLogPath: string,
+  now: number,
+): Pick<CockpitData, "tokens7d" | "cacheHit7d" | "costTrend14d"> {
+  const hit = cache.get(usageLogPath);
+  if (hit && now - hit.ts < TTL_MS) return hit.data;
+  const data = computeWarm(usageLogPath, now);
+  cache.set(usageLogPath, { ts: now, data });
+  return data;
+}
+
+export function computeWarm(
+  usageLogPath: string,
+  now: number,
+): Pick<CockpitData, "tokens7d" | "cacheHit7d" | "costTrend14d"> {
+  const records = readUsageLog(usageLogPath);
+  if (records.length === 0) {
+    return { tokens7d: null, cacheHit7d: null, costTrend14d: null };
+  }
+  const week = aggregateUsage(records, { now }).buckets[1]!;
+  const priorWeekRecords = records.filter(
+    (r) => r.ts < week.since && r.ts >= week.since - 7 * 86_400_000,
+  );
+  const priorWeek = aggregateUsage(priorWeekRecords, { now: week.since }).buckets[1]!;
+
+  const tokens7dTotal = week.promptTokens + week.completionTokens;
+  const tokens7dPrior = priorWeek.promptTokens + priorWeek.completionTokens;
+  const tokens7d: CockpitKpi = {
+    total: tokens7dTotal,
+    deltaPct: tokens7dPrior > 0 ? ((tokens7dTotal - tokens7dPrior) / tokens7dPrior) * 100 : null,
+  };
+
+  const cacheHitRatio = bucketCacheHitRatio(week);
+  const cacheHit7d: CockpitCacheKpi = {
+    ratio: cacheHitRatio,
+    deltaPp:
+      priorWeek.cacheHitTokens + priorWeek.cacheMissTokens > 0
+        ? (cacheHitRatio - bucketCacheHitRatio(priorWeek)) * 100
+        : null,
+  };
+
+  return { tokens7d, cacheHit7d, costTrend14d: rollupDailyCost(records, now, 14) };
+}
+
+function rollupDailyCost(
+  records: ReadonlyArray<{ ts: number; costUsd: number }>,
+  now: number,
+  days: number,
+): CockpitDailyCost[] {
+  const since = now - days * 86_400_000;
+  const buckets = new Map<string, number>();
+  for (let i = 0; i < days; i++) {
+    buckets.set(localDateKey(now - i * 86_400_000), 0);
+  }
+  for (const r of records) {
+    if (r.ts < since) continue;
+    const key = localDateKey(r.ts);
+    if (!buckets.has(key)) continue;
+    buckets.set(key, (buckets.get(key) ?? 0) + r.costUsd);
+  }
+  return Array.from(buckets.entries())
+    .map(([date, usd]) => ({ date, usd }))
+    .sort((a, b) => (a.date < b.date ? -1 : 1));
+}
+
+function localDateKey(ts: number): string {
+  const d = new Date(ts);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}

--- a/src/server/api/overview.ts
+++ b/src/server/api/overview.ts
@@ -5,6 +5,7 @@ import { indexExists } from "../../index/semantic/builder.js";
 import { VERSION } from "../../version.js";
 import type { DashboardContext, DashboardStats } from "../context.js";
 import type { ApiResult } from "../router.js";
+import { type CockpitData, computeCockpit } from "./cockpit.js";
 
 export interface OverviewResponse {
   /** Reasonix version string (drives the "vs latest" comparison in the SPA). */
@@ -29,6 +30,7 @@ export interface OverviewResponse {
   /** Live session stats — null in standalone mode. */
   stats: DashboardStats | null;
   semanticIndexExists: boolean | null;
+  cockpit: CockpitData;
 }
 
 export async function handleOverview(
@@ -59,6 +61,7 @@ export async function handleOverview(
     reasoningEffort: cfg.reasoningEffort ?? "max",
     stats: ctx.getStats?.() ?? null,
     semanticIndexExists,
+    cockpit: computeCockpit(ctx),
   };
   return { status: 200, body: overview };
 }

--- a/tests/cockpit.test.ts
+++ b/tests/cockpit.test.ts
@@ -1,0 +1,168 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  _resetCockpitCacheForTests,
+  computeCockpit,
+  computeWarm,
+} from "../src/server/api/cockpit.js";
+import type { DashboardContext } from "../src/server/context.js";
+
+const DAY = 86_400_000;
+const NOW = Date.UTC(2026, 4, 1, 12, 0, 0);
+
+function ctxOnly(usageLogPath: string): DashboardContext {
+  return { configPath: "", usageLogPath, mode: "attached" };
+}
+
+function record(opts: {
+  ts: number;
+  prompt?: number;
+  completion?: number;
+  hit?: number;
+  miss?: number;
+  cost?: number;
+  model?: string;
+}): string {
+  return JSON.stringify({
+    ts: opts.ts,
+    session: null,
+    model: opts.model ?? "deepseek-v4-flash",
+    promptTokens: opts.prompt ?? 1000,
+    completionTokens: opts.completion ?? 200,
+    cacheHitTokens: opts.hit ?? 800,
+    cacheMissTokens: opts.miss ?? 200,
+    costUsd: opts.cost ?? 0.001,
+    claudeEquivUsd: 0.01,
+  });
+}
+
+describe("computeWarm", () => {
+  let dir: string;
+  let usagePath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "rx-cockpit-"));
+    usagePath = join(dir, "usage.jsonl");
+    _resetCockpitCacheForTests();
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns nulls when the usage log is empty", () => {
+    const out = computeWarm(usagePath, NOW);
+    expect(out.tokens7d).toBeNull();
+    expect(out.cacheHit7d).toBeNull();
+    expect(out.costTrend14d).toBeNull();
+  });
+
+  it("rolls up tokens7d as prompt + completion across the trailing week", () => {
+    const lines = [
+      record({ ts: NOW - 1 * DAY, prompt: 10_000, completion: 2_000 }),
+      record({ ts: NOW - 5 * DAY, prompt: 30_000, completion: 8_000 }),
+      record({ ts: NOW - 8 * DAY, prompt: 99_999, completion: 99_999 }),
+    ].join("\n");
+    writeFileSync(usagePath, `${lines}\n`);
+    const out = computeWarm(usagePath, NOW);
+    expect(out.tokens7d?.total).toBe(50_000);
+  });
+
+  it("computes tokens7d deltaPct vs the prior 7-day window", () => {
+    const inWeek = record({ ts: NOW - 1 * DAY, prompt: 10_000, completion: 0 });
+    const priorWeek = record({ ts: NOW - 9 * DAY, prompt: 5_000, completion: 0 });
+    writeFileSync(usagePath, `${inWeek}\n${priorWeek}\n`);
+    const out = computeWarm(usagePath, NOW);
+    expect(out.tokens7d?.deltaPct).toBeCloseTo(100, 5);
+  });
+
+  it("returns null deltaPct when the prior week has no records", () => {
+    writeFileSync(usagePath, `${record({ ts: NOW - 1 * DAY })}\n`);
+    const out = computeWarm(usagePath, NOW);
+    expect(out.tokens7d?.deltaPct).toBeNull();
+  });
+
+  it("derives cacheHit7d ratio from the trailing-week bucket", () => {
+    writeFileSync(
+      usagePath,
+      `${record({ ts: NOW - 1 * DAY, hit: 900, miss: 100 })}\n${record({ ts: NOW - 2 * DAY, hit: 100, miss: 900 })}\n`,
+    );
+    const out = computeWarm(usagePath, NOW);
+    expect(out.cacheHit7d?.ratio).toBeCloseTo(0.5, 5);
+  });
+
+  it("sparkline has exactly `days` entries even when most days are empty", () => {
+    writeFileSync(usagePath, `${record({ ts: NOW - 2 * DAY, cost: 0.05 })}\n`);
+    const out = computeWarm(usagePath, NOW);
+    expect(out.costTrend14d).toHaveLength(14);
+    const total = (out.costTrend14d ?? []).reduce((s, d) => s + d.usd, 0);
+    expect(total).toBeCloseTo(0.05, 5);
+  });
+
+  it("sparkline drops records older than the window", () => {
+    writeFileSync(usagePath, `${record({ ts: NOW - 30 * DAY, cost: 99 })}\n`);
+    const out = computeWarm(usagePath, NOW);
+    const total = (out.costTrend14d ?? []).reduce((s, d) => s + d.usd, 0);
+    expect(total).toBe(0);
+  });
+});
+
+describe("computeCockpit", () => {
+  let dir: string;
+  let usagePath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "rx-cockpit-"));
+    usagePath = join(dir, "usage.jsonl");
+    _resetCockpitCacheForTests();
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns null cockpit fields when ctx has no loop, no stats, no log", () => {
+    const out = computeCockpit(ctxOnly(usagePath), NOW);
+    expect(out.balance).toBeNull();
+    expect(out.currentSession).toBeNull();
+    expect(out.tokens7d).toBeNull();
+  });
+
+  it("surfaces balance from getStats", () => {
+    const ctx: DashboardContext = {
+      ...ctxOnly(usagePath),
+      getStats: () => ({
+        turns: 0,
+        totalCostUsd: 0,
+        lastTurnCostUsd: 0,
+        totalInputCostUsd: 0,
+        totalOutputCostUsd: 0,
+        cacheHitRatio: 0,
+        lastPromptTokens: 0,
+        contextCapTokens: 1_000_000,
+        balance: [{ currency: "CNY", total_balance: "48.20" }],
+      }),
+    };
+    const out = computeCockpit(ctx, NOW);
+    expect(out.balance).toEqual({ currency: "CNY", total: "48.20" });
+  });
+
+  it("warm fields are reused from cache within the TTL window", () => {
+    writeFileSync(usagePath, `${record({ ts: NOW - 1 * DAY, prompt: 10_000 })}\n`);
+    const first = computeCockpit(ctxOnly(usagePath), NOW);
+    writeFileSync(usagePath, `${record({ ts: NOW - 1 * DAY, prompt: 999_999 })}\n`);
+    const second = computeCockpit(ctxOnly(usagePath), NOW + 5_000);
+    expect(second.tokens7d?.total).toBe(first.tokens7d?.total);
+  });
+
+  it("warm fields refresh once the TTL has elapsed", () => {
+    writeFileSync(usagePath, `${record({ ts: NOW - 1 * DAY, prompt: 10_000 })}\n`);
+    const first = computeCockpit(ctxOnly(usagePath), NOW);
+    writeFileSync(usagePath, `${record({ ts: NOW - 1 * DAY, prompt: 999_999 })}\n`);
+    const second = computeCockpit(ctxOnly(usagePath), NOW + 60_000);
+    expect(second.tokens7d?.total).not.toBe(first.tokens7d?.total);
+    expect(second.tokens7d?.total).toBeGreaterThan(first.tokens7d?.total ?? 0);
+  });
+});

--- a/tests/server-dashboard.test.ts
+++ b/tests/server-dashboard.test.ts
@@ -212,6 +212,10 @@ describe("dashboard server: endpoints", () => {
     expect(r.body.planMode).toBe(false);
     expect(r.body.pendingEdits).toBe(0);
     expect(r.body.toolCount).toBe(0);
+    expect(r.body.cockpit).toBeDefined();
+    expect(r.body.cockpit.balance).toBeNull();
+    expect(r.body.cockpit.tokens7d).toBeNull();
+    expect(r.body.cockpit.currentSession).toBeNull();
   });
 
   it("GET /api/usage returns aggregateUsage + record count", async () => {


### PR DESCRIPTION
## Summary

First half of issue #64 Stage 1 — the usage-log derived KPIs that the design §5 cockpit needs. The dashboard SPA (Stage 2) doesn't render these yet; Stage 1B follows with the events.jsonl derived feed.

Added to `OverviewResponse`:

- `balance` — currency + total, mirrored from `stats.balance[0]`
- `tokens7d` — 7-day prompt+completion total, with `deltaPct` vs the prior 7-day window
- `cacheHit7d` — trailing-week cache hit ratio with `deltaPp` (percentage points)
- `costTrend14d` — 14 daily \`{ date, usd }\` rows, zero-padded so the sparkline never has gaps
- `currentSession` — id / turns / totalCost / lastPromptTokens / completionTokens

## Caching

`/api/overview` polls every 2.5s. Re-reading the usage-log JSONL each poll is wasteful, so the warm fields (tokens7d, cacheHit7d, costTrend14d) are 30s-cached behind a TTL keyed on `usageLogPath`. Hot fields (balance, currentSession) come from in-memory ctx and refresh per poll.

## Test plan

- [x] `tests/cockpit.test.ts` — 11 unit tests cover empty-log, deltaPct presence/null, cache TTL hit/miss, sparkline padding, out-of-window drop
- [x] `tests/server-dashboard.test.ts` — extends the existing /api/overview shape assertion to expect the cockpit field
- [x] `npm run verify` — 1696 tests pass (1685 + 11 new)

## Out of scope

- `toolCalls24h`, `recentPlans`, `toolActivity` — Stage 1B (separate PR; needs cross-session events.jsonl readers)
- Dashboard UI rendering — Stage 2

Closes part of #64.