### PR TITLE
feat(server): events.jsonl cockpit fields (Stage 1B of #64)

### DIFF
--- a/src/server/api/cockpit-events.ts
+++ b/src/server/api/cockpit-events.ts
@@ -1,0 +1,223 @@
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { readEventLogFile } from "../../adapters/event-source-jsonl.js";
+import type { Event } from "../../core/events.js";
+import { sessionsDir as defaultSessionsDir } from "../../memory/session.js";
+
+export interface CockpitToolCallsKpi {
+  total: number;
+  delta: number | null;
+}
+
+export interface CockpitRecentPlan {
+  id: string;
+  title: string;
+  totalSteps: number;
+  completedSteps: number;
+  status: "active" | "done";
+  whenMs: number;
+}
+
+export interface CockpitToolFeedRow {
+  name: string;
+  args: string;
+  level: "ok" | "warn" | "err";
+  whenMs: number;
+}
+
+export interface EventsCockpit {
+  toolCalls24h: CockpitToolCallsKpi | null;
+  recentPlans: ReadonlyArray<CockpitRecentPlan> | null;
+  toolActivity: ReadonlyArray<CockpitToolFeedRow> | null;
+}
+
+const DAY_MS = 86_400_000;
+const RECENT_FILES_CAP = 8;
+const PLAN_FEED_CAP = 4;
+const TOOL_FEED_CAP = 6;
+
+export function computeEventsCockpit(
+  now: number = Date.now(),
+  sessionsDirOverride?: string,
+): EventsCockpit {
+  const dir = sessionsDirOverride ?? defaultSessionsDir();
+  if (!existsSync(dir)) {
+    return { toolCalls24h: null, recentPlans: null, toolActivity: null };
+  }
+  const files = recentEventFiles(dir, now);
+  if (files.length === 0) {
+    return { toolCalls24h: null, recentPlans: null, toolActivity: null };
+  }
+
+  let calls24h = 0;
+  let callsPrior24h = 0;
+  const cutoff24h = now - DAY_MS;
+  const cutoff48h = now - 2 * DAY_MS;
+  const allTools: CockpitToolFeedRow[] = [];
+  const allPlans: CockpitRecentPlan[] = [];
+
+  for (const file of files) {
+    const events = readEventLogFile(file);
+    if (events.length === 0) continue;
+    countToolCalls(events, cutoff24h, cutoff48h, (in24h) => {
+      if (in24h) calls24h++;
+      else callsPrior24h++;
+    });
+    collectToolActivity(events, allTools);
+    collectPlans(events, allPlans);
+  }
+
+  allTools.sort((a, b) => b.whenMs - a.whenMs);
+  allPlans.sort((a, b) => b.whenMs - a.whenMs);
+
+  return {
+    toolCalls24h: { total: calls24h, delta: calls24h - callsPrior24h },
+    recentPlans: allPlans.slice(0, PLAN_FEED_CAP),
+    toolActivity: allTools.slice(0, TOOL_FEED_CAP),
+  };
+}
+
+function recentEventFiles(dir: string, now: number): string[] {
+  let names: string[];
+  try {
+    names = readdirSync(dir);
+  } catch {
+    return [];
+  }
+  const cutoff = now - 30 * DAY_MS;
+  const candidates: Array<{ path: string; mtime: number }> = [];
+  for (const name of names) {
+    if (!name.endsWith(".events.jsonl")) continue;
+    const path = join(dir, name);
+    let mtime: number;
+    try {
+      mtime = statSync(path).mtimeMs;
+    } catch {
+      continue;
+    }
+    if (mtime < cutoff) continue;
+    candidates.push({ path, mtime });
+  }
+  candidates.sort((a, b) => b.mtime - a.mtime);
+  return candidates.slice(0, RECENT_FILES_CAP).map((c) => c.path);
+}
+
+function countToolCalls(
+  events: ReadonlyArray<Event>,
+  cutoff24h: number,
+  cutoff48h: number,
+  onCall: (in24h: boolean) => void,
+): void {
+  for (const ev of events) {
+    if (ev.type !== "tool.intent") continue;
+    const ts = parseTs(ev.ts);
+    if (ts === null) continue;
+    if (ts >= cutoff24h) onCall(true);
+    else if (ts >= cutoff48h) onCall(false);
+  }
+}
+
+function collectToolActivity(events: ReadonlyArray<Event>, into: CockpitToolFeedRow[]): void {
+  const intentByCallId = new Map<string, { name: string; args: string; ts: number }>();
+  for (const ev of events) {
+    if (ev.type === "tool.intent") {
+      const ts = parseTs(ev.ts);
+      if (ts !== null) intentByCallId.set(ev.callId, { name: ev.name, args: ev.args, ts });
+    } else if (ev.type === "tool.result") {
+      const intent = intentByCallId.get(ev.callId);
+      if (!intent) continue;
+      into.push({
+        name: intent.name,
+        args: summarizeArgs(intent.args),
+        level: ev.ok ? "ok" : "err",
+        whenMs: intent.ts,
+      });
+    } else if (ev.type === "tool.denied") {
+      const intent = intentByCallId.get(ev.callId);
+      if (!intent) continue;
+      into.push({
+        name: intent.name,
+        args: summarizeArgs(intent.args),
+        level: "warn",
+        whenMs: intent.ts,
+      });
+    }
+  }
+}
+
+function collectPlans(events: ReadonlyArray<Event>, into: CockpitRecentPlan[]): void {
+  let current: { id: string; title: string; totalSteps: number; whenMs: number } | null = null;
+  let completed = new Set<string>();
+  for (const ev of events) {
+    if (ev.type === "plan.submitted") {
+      if (current) {
+        into.push(buildPlan(current, completed));
+      }
+      const ts = parseTs(ev.ts);
+      if (ts === null) {
+        current = null;
+        continue;
+      }
+      current = {
+        id: `${ev.id}`,
+        title: planTitle(ev.body, ev.steps),
+        totalSteps: ev.steps.length,
+        whenMs: ts,
+      };
+      completed = new Set();
+    } else if (ev.type === "plan.step.completed") {
+      if (!current) continue;
+      completed.add(ev.stepId);
+    }
+  }
+  if (current) into.push(buildPlan(current, completed));
+}
+
+function buildPlan(
+  current: { id: string; title: string; totalSteps: number; whenMs: number },
+  completed: Set<string>,
+): CockpitRecentPlan {
+  return {
+    id: current.id,
+    title: current.title,
+    totalSteps: current.totalSteps,
+    completedSteps: completed.size,
+    status: completed.size >= current.totalSteps && current.totalSteps > 0 ? "done" : "active",
+    whenMs: current.whenMs,
+  };
+}
+
+function planTitle(body: string, steps: ReadonlyArray<{ title: string }>): string {
+  const firstBodyLine = body.split(/\r?\n/).find((l) => l.trim().length > 0);
+  if (firstBodyLine)
+    return firstBodyLine
+      .replace(/^#+\s*/, "")
+      .trim()
+      .slice(0, 80);
+  if (steps.length > 0 && steps[0]) return steps[0].title.slice(0, 80);
+  return "(plan)";
+}
+
+function summarizeArgs(args: string): string {
+  if (!args) return "";
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(args);
+  } catch {
+    return args.slice(0, 60);
+  }
+  if (parsed && typeof parsed === "object") {
+    const obj = parsed as Record<string, unknown>;
+    const path = obj.path ?? obj.file_path ?? obj.filename;
+    const command = obj.command;
+    if (typeof command === "string")
+      return command.length > 60 ? `${command.slice(0, 60)}…` : command;
+    if (typeof path === "string") return path;
+  }
+  return args.slice(0, 60);
+}
+
+function parseTs(ts: string): number | null {
+  const n = Date.parse(ts);
+  return Number.isFinite(n) ? n : null;
+}

--- a/src/server/api/cockpit.ts
+++ b/src/server/api/cockpit.ts
@@ -1,5 +1,12 @@
 import { aggregateUsage, bucketCacheHitRatio, readUsageLog } from "../../telemetry/usage.js";
 import type { DashboardContext, DashboardStats } from "../context.js";
+import { type EventsCockpit, computeEventsCockpit } from "./cockpit-events.js";
+
+export type {
+  CockpitRecentPlan,
+  CockpitToolCallsKpi,
+  CockpitToolFeedRow,
+} from "./cockpit-events.js";
 
 export interface CockpitKpi {
   total: number;
@@ -24,7 +31,7 @@ export interface CockpitCurrentSession {
   completionTokens: number;
 }
 
-export interface CockpitData {
+export interface CockpitData extends EventsCockpit {
   balance: { currency: string; total: string } | null;
   tokens7d: CockpitKpi | null;
   cacheHit7d: CockpitCacheKpi | null;
@@ -32,11 +39,16 @@ export interface CockpitData {
   currentSession: CockpitCurrentSession | null;
 }
 
+type WarmFields = Pick<
+  CockpitData,
+  "tokens7d" | "cacheHit7d" | "costTrend14d" | "toolCalls24h" | "recentPlans" | "toolActivity"
+>;
+
 const TTL_MS = 30_000;
 
 interface CacheEntry {
   ts: number;
-  data: Pick<CockpitData, "tokens7d" | "cacheHit7d" | "costTrend14d">;
+  data: WarmFields;
 }
 
 const cache = new Map<string, CacheEntry>();
@@ -49,7 +61,7 @@ export function computeCockpit(ctx: DashboardContext, now: number = Date.now()):
   return {
     balance: extractBalance(ctx.getStats?.() ?? null),
     currentSession: extractCurrentSession(ctx),
-    ...readWarmCached(ctx.usageLogPath, now),
+    ...readWarmCached(ctx.usageLogPath, now, ctx.sessionsDir),
   };
 }
 
@@ -75,24 +87,20 @@ function extractCurrentSession(ctx: DashboardContext): CockpitData["currentSessi
   };
 }
 
-function readWarmCached(
-  usageLogPath: string,
-  now: number,
-): Pick<CockpitData, "tokens7d" | "cacheHit7d" | "costTrend14d"> {
-  const hit = cache.get(usageLogPath);
+function readWarmCached(usageLogPath: string, now: number, sessionsDir?: string): WarmFields {
+  const cacheKey = `${usageLogPath}::${sessionsDir ?? ""}`;
+  const hit = cache.get(cacheKey);
   if (hit && now - hit.ts < TTL_MS) return hit.data;
-  const data = computeWarm(usageLogPath, now);
-  cache.set(usageLogPath, { ts: now, data });
+  const data = computeWarm(usageLogPath, now, sessionsDir);
+  cache.set(cacheKey, { ts: now, data });
   return data;
 }
 
-export function computeWarm(
-  usageLogPath: string,
-  now: number,
-): Pick<CockpitData, "tokens7d" | "cacheHit7d" | "costTrend14d"> {
+export function computeWarm(usageLogPath: string, now: number, sessionsDir?: string): WarmFields {
+  const events = computeEventsCockpit(now, sessionsDir);
   const records = readUsageLog(usageLogPath);
   if (records.length === 0) {
-    return { tokens7d: null, cacheHit7d: null, costTrend14d: null };
+    return { tokens7d: null, cacheHit7d: null, costTrend14d: null, ...events };
   }
   const week = aggregateUsage(records, { now }).buckets[1]!;
   const priorWeekRecords = records.filter(
@@ -116,7 +124,12 @@ export function computeWarm(
         : null,
   };
 
-  return { tokens7d, cacheHit7d, costTrend14d: rollupDailyCost(records, now, 14) };
+  return {
+    tokens7d,
+    cacheHit7d,
+    costTrend14d: rollupDailyCost(records, now, 14),
+    ...events,
+  };
 }
 
 function rollupDailyCost(

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -10,6 +10,8 @@ export interface DashboardContext {
   /** Caller resolves via `defaultConfigPath()`; module deliberately avoids `homedir()` so tests can redirect. */
   configPath: string;
   usageLogPath: string;
+  /** Override the sessions dir (events.jsonl readers); production reads `~/.reasonix/sessions`. */
+  sessionsDir?: string;
   mode: "standalone" | "attached";
 
   loop?: CacheFirstLoop;

--- a/tests/cockpit-events.test.ts
+++ b/tests/cockpit-events.test.ts
@@ -1,0 +1,277 @@
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { computeEventsCockpit } from "../src/server/api/cockpit-events.js";
+
+const DAY = 86_400_000;
+const NOW = Date.UTC(2026, 4, 1, 12, 0, 0);
+
+function isoAt(ms: number): string {
+  return new Date(ms).toISOString();
+}
+
+interface MakeEventsArgs {
+  toolIntents?: Array<{ ts: number; callId: string; name: string; args?: string }>;
+  toolResults?: Array<{ ts: number; callId: string; ok: boolean }>;
+  toolDenies?: Array<{ ts: number; callId: string }>;
+  planSubmissions?: Array<{
+    ts: number;
+    id: number;
+    body: string;
+    steps: Array<{ id: string; title: string }>;
+  }>;
+  stepCompletions?: Array<{ ts: number; stepId: string }>;
+}
+
+function eventLines(args: MakeEventsArgs): string {
+  const lines: string[] = [];
+  let id = 1;
+  for (const i of args.toolIntents ?? []) {
+    lines.push(
+      JSON.stringify({
+        id: id++,
+        ts: isoAt(i.ts),
+        turn: 1,
+        type: "tool.intent",
+        callId: i.callId,
+        name: i.name,
+        args: i.args ?? "{}",
+      }),
+    );
+  }
+  for (const r of args.toolResults ?? []) {
+    lines.push(
+      JSON.stringify({
+        id: id++,
+        ts: isoAt(r.ts),
+        turn: 1,
+        type: "tool.result",
+        callId: r.callId,
+        ok: r.ok,
+        output: "",
+        durationMs: 100,
+      }),
+    );
+  }
+  for (const d of args.toolDenies ?? []) {
+    lines.push(
+      JSON.stringify({
+        id: id++,
+        ts: isoAt(d.ts),
+        turn: 1,
+        type: "tool.denied",
+        callId: d.callId,
+        reason: "permission",
+      }),
+    );
+  }
+  for (const p of args.planSubmissions ?? []) {
+    lines.push(
+      JSON.stringify({
+        id: p.id,
+        ts: isoAt(p.ts),
+        turn: 1,
+        type: "plan.submitted",
+        body: p.body,
+        steps: p.steps.map((s) => ({ id: s.id, title: s.title, action: "" })),
+      }),
+    );
+  }
+  for (const c of args.stepCompletions ?? []) {
+    lines.push(
+      JSON.stringify({
+        id: id++,
+        ts: isoAt(c.ts),
+        turn: 1,
+        type: "plan.step.completed",
+        stepId: c.stepId,
+        completion: { kind: "ok" },
+      }),
+    );
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+describe("computeEventsCockpit", () => {
+  let dir: string;
+  let sessionsDir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "rx-cockpit-events-"));
+    sessionsDir = join(dir, "sessions");
+    mkdirSync(sessionsDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writeSession(name: string, body: string): void {
+    const path = join(sessionsDir, `${name}.events.jsonl`);
+    writeFileSync(path, body);
+  }
+
+  it("returns nulls when sessionsDir doesn't exist", () => {
+    const out = computeEventsCockpit(NOW, join(dir, "no-such-dir"));
+    expect(out.toolCalls24h).toBeNull();
+    expect(out.recentPlans).toBeNull();
+    expect(out.toolActivity).toBeNull();
+  });
+
+  it("returns null fields when no event files are present", () => {
+    const out = computeEventsCockpit(NOW, sessionsDir);
+    expect(out.toolCalls24h).toBeNull();
+  });
+
+  it("counts tool.intent events in the trailing 24h", () => {
+    writeSession(
+      "s1",
+      eventLines({
+        toolIntents: [
+          { ts: NOW - 1_000, callId: "c1", name: "run_command" },
+          { ts: NOW - 12 * 60 * 60 * 1000, callId: "c2", name: "edit_file" },
+          { ts: NOW - 26 * 60 * 60 * 1000, callId: "c3", name: "read_file" },
+        ],
+      }),
+    );
+    const out = computeEventsCockpit(NOW, sessionsDir);
+    expect(out.toolCalls24h?.total).toBe(2);
+  });
+
+  it("computes delta vs the prior 24h window", () => {
+    writeSession(
+      "s1",
+      eventLines({
+        toolIntents: [
+          { ts: NOW - 1_000, callId: "c1", name: "x" },
+          { ts: NOW - 12 * 3_600_000, callId: "c2", name: "x" },
+          { ts: NOW - 30 * 3_600_000, callId: "c3", name: "x" },
+        ],
+      }),
+    );
+    const out = computeEventsCockpit(NOW, sessionsDir);
+    expect(out.toolCalls24h?.total).toBe(2);
+    expect(out.toolCalls24h?.delta).toBe(1);
+  });
+
+  it("surfaces recent tool activity newest-first with ok / err / warn levels", () => {
+    writeSession(
+      "s1",
+      eventLines({
+        toolIntents: [
+          {
+            ts: NOW - 5_000,
+            callId: "c1",
+            name: "run_command",
+            args: '{"command":"npm run build"}',
+          },
+          { ts: NOW - 4_000, callId: "c2", name: "edit_file", args: '{"path":"src/index.ts"}' },
+          { ts: NOW - 3_000, callId: "c3", name: "shell", args: '{"command":"rm -rf"}' },
+        ],
+        toolResults: [
+          { ts: NOW - 4_900, callId: "c1", ok: true },
+          { ts: NOW - 3_900, callId: "c2", ok: false },
+        ],
+        toolDenies: [{ ts: NOW - 2_900, callId: "c3" }],
+      }),
+    );
+    const out = computeEventsCockpit(NOW, sessionsDir);
+    expect(out.toolActivity).toHaveLength(3);
+    expect(out.toolActivity![0]!.name).toBe("shell");
+    expect(out.toolActivity![0]!.level).toBe("warn");
+    expect(out.toolActivity![1]!.level).toBe("err");
+    expect(out.toolActivity![2]!.level).toBe("ok");
+  });
+
+  it("rolls up plans with completion ratio + done/active status", () => {
+    writeSession(
+      "s1",
+      eventLines({
+        planSubmissions: [
+          {
+            ts: NOW - 60_000,
+            id: 100,
+            body: "release 0.18.1",
+            steps: [
+              { id: "a", title: "tag" },
+              { id: "b", title: "publish" },
+            ],
+          },
+        ],
+        stepCompletions: [
+          { ts: NOW - 50_000, stepId: "a" },
+          { ts: NOW - 40_000, stepId: "b" },
+        ],
+      }),
+    );
+    const out = computeEventsCockpit(NOW, sessionsDir);
+    expect(out.recentPlans).toHaveLength(1);
+    expect(out.recentPlans![0]!.title).toBe("release 0.18.1");
+    expect(out.recentPlans![0]!.totalSteps).toBe(2);
+    expect(out.recentPlans![0]!.completedSteps).toBe(2);
+    expect(out.recentPlans![0]!.status).toBe("done");
+  });
+
+  it("marks a partially-completed plan as active", () => {
+    writeSession(
+      "s1",
+      eventLines({
+        planSubmissions: [
+          {
+            ts: NOW - 60_000,
+            id: 100,
+            body: "wip",
+            steps: [
+              { id: "a", title: "x" },
+              { id: "b", title: "y" },
+              { id: "c", title: "z" },
+            ],
+          },
+        ],
+        stepCompletions: [{ ts: NOW - 50_000, stepId: "a" }],
+      }),
+    );
+    const out = computeEventsCockpit(NOW, sessionsDir);
+    expect(out.recentPlans![0]!.status).toBe("active");
+    expect(out.recentPlans![0]!.completedSteps).toBe(1);
+  });
+
+  it("aggregates tool calls across multiple session files", () => {
+    writeSession(
+      "s1",
+      eventLines({
+        toolIntents: [{ ts: NOW - 1_000, callId: "a", name: "x" }],
+      }),
+    );
+    writeSession(
+      "s2",
+      eventLines({
+        toolIntents: [{ ts: NOW - 2_000, callId: "b", name: "y" }],
+      }),
+    );
+    const out = computeEventsCockpit(NOW, sessionsDir);
+    expect(out.toolCalls24h?.total).toBe(2);
+  });
+
+  it("skips event files older than 30 days based on mtime", () => {
+    writeSession(
+      "stale",
+      eventLines({
+        toolIntents: [{ ts: NOW - 1_000, callId: "x", name: "should-not-count" }],
+      }),
+    );
+    const stalePath = join(sessionsDir, "stale.events.jsonl");
+    const ancient = (NOW - 31 * DAY) / 1000;
+    utimesSync(stalePath, ancient, ancient);
+
+    writeSession(
+      "fresh",
+      eventLines({
+        toolIntents: [{ ts: NOW - 500, callId: "y", name: "should-count" }],
+      }),
+    );
+    const out = computeEventsCockpit(NOW, sessionsDir);
+    expect(out.toolCalls24h?.total).toBe(1);
+  });
+});

--- a/tests/cockpit.test.ts
+++ b/tests/cockpit.test.ts
@@ -41,10 +41,12 @@ function record(opts: {
 describe("computeWarm", () => {
   let dir: string;
   let usagePath: string;
+  let sessionsDir: string;
 
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), "rx-cockpit-"));
     usagePath = join(dir, "usage.jsonl");
+    sessionsDir = join(dir, "sessions");
     _resetCockpitCacheForTests();
   });
 
@@ -53,7 +55,7 @@ describe("computeWarm", () => {
   });
 
   it("returns nulls when the usage log is empty", () => {
-    const out = computeWarm(usagePath, NOW);
+    const out = computeWarm(usagePath, NOW, sessionsDir);
     expect(out.tokens7d).toBeNull();
     expect(out.cacheHit7d).toBeNull();
     expect(out.costTrend14d).toBeNull();
@@ -66,7 +68,7 @@ describe("computeWarm", () => {
       record({ ts: NOW - 8 * DAY, prompt: 99_999, completion: 99_999 }),
     ].join("\n");
     writeFileSync(usagePath, `${lines}\n`);
-    const out = computeWarm(usagePath, NOW);
+    const out = computeWarm(usagePath, NOW, sessionsDir);
     expect(out.tokens7d?.total).toBe(50_000);
   });
 
@@ -74,13 +76,13 @@ describe("computeWarm", () => {
     const inWeek = record({ ts: NOW - 1 * DAY, prompt: 10_000, completion: 0 });
     const priorWeek = record({ ts: NOW - 9 * DAY, prompt: 5_000, completion: 0 });
     writeFileSync(usagePath, `${inWeek}\n${priorWeek}\n`);
-    const out = computeWarm(usagePath, NOW);
+    const out = computeWarm(usagePath, NOW, sessionsDir);
     expect(out.tokens7d?.deltaPct).toBeCloseTo(100, 5);
   });
 
   it("returns null deltaPct when the prior week has no records", () => {
     writeFileSync(usagePath, `${record({ ts: NOW - 1 * DAY })}\n`);
-    const out = computeWarm(usagePath, NOW);
+    const out = computeWarm(usagePath, NOW, sessionsDir);
     expect(out.tokens7d?.deltaPct).toBeNull();
   });
 
@@ -89,13 +91,13 @@ describe("computeWarm", () => {
       usagePath,
       `${record({ ts: NOW - 1 * DAY, hit: 900, miss: 100 })}\n${record({ ts: NOW - 2 * DAY, hit: 100, miss: 900 })}\n`,
     );
-    const out = computeWarm(usagePath, NOW);
+    const out = computeWarm(usagePath, NOW, sessionsDir);
     expect(out.cacheHit7d?.ratio).toBeCloseTo(0.5, 5);
   });
 
   it("sparkline has exactly `days` entries even when most days are empty", () => {
     writeFileSync(usagePath, `${record({ ts: NOW - 2 * DAY, cost: 0.05 })}\n`);
-    const out = computeWarm(usagePath, NOW);
+    const out = computeWarm(usagePath, NOW, sessionsDir);
     expect(out.costTrend14d).toHaveLength(14);
     const total = (out.costTrend14d ?? []).reduce((s, d) => s + d.usd, 0);
     expect(total).toBeCloseTo(0.05, 5);
@@ -103,7 +105,7 @@ describe("computeWarm", () => {
 
   it("sparkline drops records older than the window", () => {
     writeFileSync(usagePath, `${record({ ts: NOW - 30 * DAY, cost: 99 })}\n`);
-    const out = computeWarm(usagePath, NOW);
+    const out = computeWarm(usagePath, NOW, sessionsDir);
     const total = (out.costTrend14d ?? []).reduce((s, d) => s + d.usd, 0);
     expect(total).toBe(0);
   });
@@ -112,10 +114,12 @@ describe("computeWarm", () => {
 describe("computeCockpit", () => {
   let dir: string;
   let usagePath: string;
+  let sessionsDir: string;
 
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), "rx-cockpit-"));
     usagePath = join(dir, "usage.jsonl");
+    sessionsDir = join(dir, "sessions");
     _resetCockpitCacheForTests();
   });
 
@@ -123,45 +127,53 @@ describe("computeCockpit", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
+  function ctx(extra: Partial<DashboardContext> = {}): DashboardContext {
+    return { ...ctxOnly(usagePath), sessionsDir, ...extra };
+  }
+
   it("returns null cockpit fields when ctx has no loop, no stats, no log", () => {
-    const out = computeCockpit(ctxOnly(usagePath), NOW);
+    const out = computeCockpit(ctx(), NOW);
     expect(out.balance).toBeNull();
     expect(out.currentSession).toBeNull();
     expect(out.tokens7d).toBeNull();
+    expect(out.toolCalls24h).toBeNull();
+    expect(out.recentPlans).toBeNull();
+    expect(out.toolActivity).toBeNull();
   });
 
   it("surfaces balance from getStats", () => {
-    const ctx: DashboardContext = {
-      ...ctxOnly(usagePath),
-      getStats: () => ({
-        turns: 0,
-        totalCostUsd: 0,
-        lastTurnCostUsd: 0,
-        totalInputCostUsd: 0,
-        totalOutputCostUsd: 0,
-        cacheHitRatio: 0,
-        lastPromptTokens: 0,
-        contextCapTokens: 1_000_000,
-        balance: [{ currency: "CNY", total_balance: "48.20" }],
+    const out = computeCockpit(
+      ctx({
+        getStats: () => ({
+          turns: 0,
+          totalCostUsd: 0,
+          lastTurnCostUsd: 0,
+          totalInputCostUsd: 0,
+          totalOutputCostUsd: 0,
+          cacheHitRatio: 0,
+          lastPromptTokens: 0,
+          contextCapTokens: 1_000_000,
+          balance: [{ currency: "CNY", total_balance: "48.20" }],
+        }),
       }),
-    };
-    const out = computeCockpit(ctx, NOW);
+      NOW,
+    );
     expect(out.balance).toEqual({ currency: "CNY", total: "48.20" });
   });
 
   it("warm fields are reused from cache within the TTL window", () => {
     writeFileSync(usagePath, `${record({ ts: NOW - 1 * DAY, prompt: 10_000 })}\n`);
-    const first = computeCockpit(ctxOnly(usagePath), NOW);
+    const first = computeCockpit(ctx(), NOW);
     writeFileSync(usagePath, `${record({ ts: NOW - 1 * DAY, prompt: 999_999 })}\n`);
-    const second = computeCockpit(ctxOnly(usagePath), NOW + 5_000);
+    const second = computeCockpit(ctx(), NOW + 5_000);
     expect(second.tokens7d?.total).toBe(first.tokens7d?.total);
   });
 
   it("warm fields refresh once the TTL has elapsed", () => {
     writeFileSync(usagePath, `${record({ ts: NOW - 1 * DAY, prompt: 10_000 })}\n`);
-    const first = computeCockpit(ctxOnly(usagePath), NOW);
+    const first = computeCockpit(ctx(), NOW);
     writeFileSync(usagePath, `${record({ ts: NOW - 1 * DAY, prompt: 999_999 })}\n`);
-    const second = computeCockpit(ctxOnly(usagePath), NOW + 60_000);
+    const second = computeCockpit(ctx(), NOW + 60_000);
     expect(second.tokens7d?.total).not.toBe(first.tokens7d?.total);
     expect(second.tokens7d?.total).toBeGreaterThan(first.tokens7d?.total ?? 0);
   });


### PR DESCRIPTION
## Summary

Second half of issue #64 Stage 1 — the events-derived cockpit data. Reads `*.events.jsonl` across the user's recent sessions; pairs with Stage 1A's usage-log fields under the same 30s TTL cache.

Added to `OverviewResponse.cockpit`:

- `toolCalls24h` — \`{ total, delta }\` count of `tool.intent` events in the last 24h vs the prior 24h
- `recentPlans` — top 4 plans newest-first; \`{ id, title, totalSteps, completedSteps, status: 'done' | 'active', whenMs }\`
- `toolActivity` — top 6 recent tool calls newest-first; \`{ name, args, level: 'ok' | 'warn' | 'err', whenMs }\` (level: ok = `tool.result` ok, err = `tool.result` !ok, warn = `tool.denied`)

## Performance

- Lists \`*.events.jsonl\` in the sessions dir, filters by mtime ≥ 30 days old, sorts desc, takes top 8
- Each file's full event list is read once, then folded into all three views (counter / activity / plans) in a single pass per file
- All cached behind the same 30s TTL as Stage 1A

## API change

Added optional \`sessionsDir\` to \`DashboardContext\` so tests can isolate from \`~/.reasonix/sessions\`. Production leaves it unset → reads the real path.

## Test plan

- [x] `tests/cockpit-events.test.ts` — 9 unit tests cover: missing dir, empty dir, 24h count, prior-24h delta, ok/err/warn level mapping, plan completion ratio, partial plan = active, cross-session aggregation, mtime-based stale-file skip
- [x] `tests/cockpit.test.ts` — extends to assert all events fields nullable on empty ctx
- [x] `npm run verify` — 1705 tests pass (1696 + 9 new)

## Up next

- Stage 2 — dashboard UI rendering (rows 1-3 of the design §5 cockpit grid)
- Then 0.19.0 release

Closes part of #64.