### PR TITLE
fix(dashboard): page-level scroll + chat input clipping (Stage 1 of #69)

### DIFF
--- a/dashboard/app.css
+++ b/dashboard/app.css
@@ -179,7 +179,7 @@ main { padding: 32px 40px 60px 32px; min-width: 0; }
     "side  top"
     "side  body"
     "side  status";
-  height: 640px;
+  height: 100vh;
   background: var(--bg);
   font-size: 13px;
 }
@@ -1315,14 +1315,16 @@ input:focus, textarea:focus, select:focus { border-color: var(--c-brand); }
 
 /* ---------- Chat panel ---------- */
 
+/* Subtracts .app-top (44) + .app-status (26) + .app-body padding (24×2). */
 .chat-shell {
   display: flex;
   flex-direction: column;
-  height: calc(100vh - 56px);
+  height: calc(100vh - 44px - 26px - 48px);
 }
 
 .chat-feed {
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
   padding: 4px 4px 16px;
   display: flex;


### PR DESCRIPTION
## Summary

Two CSS fixes that close the layout gaps surfaced when reviewing the dashboard for 0.19.0 release:

### 1. Page-level scrollbar at runtime

\`.app { height: 640px }\` was leftover from the design mockup's fixed-height display box. At runtime it caused a page-level scrollbar on viewports below 640px and dead space above. Switched to \`100vh\` so the dashboard fills the viewport.

### 2. Chat input clipping / wrong scroll surface

\`.chat-shell\` had \`height: calc(100vh - 56px)\` — wrong by the chrome it's supposed to subtract. Now it's \`100vh - 44 (top) - 26 (status) - 48 (body padding)\` so the composer stays in view and only \`.chat-feed\` scrolls. Added \`min-height: 0\` to \`.chat-feed\` for the flex shrink-to-zero gotcha (without it \`flex: 1\` can't shrink to allow internal \`overflow-y: auto\`).

## Test plan

- [x] Build clean
- [ ] Visual: chat scroll only inside the message feed; no page-level scrollbar; sidebar fills viewport

Closes part of #69.