### PR TITLE
feat(dashboard): hooks recent runs log (Stage 5 of #69)

### DIFF
--- a/dashboard/src/panels/hooks.ts
+++ b/dashboard/src/panels/hooks.ts
@@ -1,11 +1,19 @@
 import { useCallback, useEffect, useState } from "preact/hooks";
 import { api } from "../lib/api.js";
+import { fmtRelativeTime } from "../lib/format.js";
 import { html } from "../lib/html.js";
 
 interface HookHandler {
   command?: string;
   matcher?: string;
   [k: string]: unknown;
+}
+
+interface HookRunRow {
+  hookName: string;
+  phase: "PreToolUse" | "PostToolUse" | "UserPromptSubmit" | "Stop";
+  outcome: "ok" | "blocked" | "modified" | "error";
+  whenMs: number;
 }
 
 interface ScopeMeta {
@@ -49,6 +57,7 @@ interface HooksData {
   events: string[];
   project: ScopeMeta;
   global: ScopeMeta;
+  recentRuns?: ReadonlyArray<HookRunRow> | null;
 }
 
 export function HooksPanel() {
@@ -114,9 +123,10 @@ export function HooksPanel() {
   `;
 
   const matrixRows = buildMatrix(data);
-  const events = data.events.length > 0
-    ? data.events
-    : Array.from(new Set(matrixRows.flatMap((r) => Object.keys(r.cells))));
+  const events =
+    data.events.length > 0
+      ? data.events
+      : Array.from(new Set(matrixRows.flatMap((r) => Object.keys(r.cells))));
   const gridCols = `220px repeat(${Math.max(events.length, 1)}, minmax(0, 1fr))`;
 
   return html`
@@ -195,6 +205,42 @@ export function HooksPanel() {
           }
         `;
       })}
+
+      ${sectionH3("Recent runs", `${data.recentRuns?.length ?? 0}`)}
+      ${
+        !data.recentRuns || data.recentRuns.length === 0
+          ? html`<div class="card" style="color:var(--fg-3)">
+              No hook runs in the recent session log.
+            </div>`
+          : html`
+            <div class="card" style="padding:0;overflow-x:auto">
+              <table class="tbl" style="width:100%;font-family:var(--font-mono);font-size:11.5px">
+                <thead>
+                  <tr>
+                    <th style="text-align:left;padding:8px 12px">when</th>
+                    <th style="text-align:left;padding:8px 12px">phase</th>
+                    <th style="text-align:left;padding:8px 12px">hook</th>
+                    <th style="text-align:left;padding:8px 12px">outcome</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  ${data.recentRuns.map(
+                    (r) => html`
+                      <tr>
+                        <td style="padding:6px 12px;color:var(--fg-3)">${fmtRelativeTime(r.whenMs)}</td>
+                        <td style="padding:6px 12px;color:var(--fg-1)">${r.phase}</td>
+                        <td style="padding:6px 12px;color:var(--fg-1)">${r.hookName}</td>
+                        <td style="padding:6px 12px">
+                          <span class=${`pill ${r.outcome === "ok" ? "ok" : r.outcome === "error" ? "err" : "warn"}`}>${r.outcome}</span>
+                        </td>
+                      </tr>
+                    `,
+                  )}
+                </tbody>
+              </table>
+            </div>
+          `
+      }
     </div>
   `;
 }

--- a/src/adapters/event-source-jsonl.ts
+++ b/src/adapters/event-source-jsonl.ts
@@ -1,7 +1,37 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
 import type { Event } from "../core/events.js";
 import type { EventSource } from "../ports/event-sink.js";
 import { eventLogPath } from "./event-sink-jsonl.js";
+
+const DAY_MS = 86_400_000;
+
+/** Most-recently-modified `*.events.jsonl` files, capped + filtered by stale-mtime cutoff. */
+export function recentEventFiles(dir: string, now: number, cap = 8, staleDays = 30): string[] {
+  if (!existsSync(dir)) return [];
+  let names: string[];
+  try {
+    names = readdirSync(dir);
+  } catch {
+    return [];
+  }
+  const cutoff = now - staleDays * DAY_MS;
+  const candidates: Array<{ path: string; mtime: number }> = [];
+  for (const name of names) {
+    if (!name.endsWith(".events.jsonl")) continue;
+    const path = join(dir, name);
+    let mtime: number;
+    try {
+      mtime = statSync(path).mtimeMs;
+    } catch {
+      continue;
+    }
+    if (mtime < cutoff) continue;
+    candidates.push({ path, mtime });
+  }
+  candidates.sort((a, b) => b.mtime - a.mtime);
+  return candidates.slice(0, cap).map((c) => c.path);
+}
 
 export function readEventLogFile(path: string): Event[] {
   if (!existsSync(path)) return [];

--- a/src/server/api/cockpit-events.ts
+++ b/src/server/api/cockpit-events.ts
@@ -1,6 +1,5 @@
-import { existsSync, readdirSync, statSync } from "node:fs";
-import { join } from "node:path";
-import { readEventLogFile } from "../../adapters/event-source-jsonl.js";
+import { existsSync } from "node:fs";
+import { readEventLogFile, recentEventFiles } from "../../adapters/event-source-jsonl.js";
 import type { Event } from "../../core/events.js";
 import { sessionsDir as defaultSessionsDir } from "../../memory/session.js";
 
@@ -44,7 +43,7 @@ export function computeEventsCockpit(
   if (!existsSync(dir)) {
     return { toolCalls24h: null, recentPlans: null, toolActivity: null };
   }
-  const files = recentEventFiles(dir, now);
+  const files = recentEventFiles(dir, now, RECENT_FILES_CAP);
   if (files.length === 0) {
     return { toolCalls24h: null, recentPlans: null, toolActivity: null };
   }
@@ -75,31 +74,6 @@ export function computeEventsCockpit(
     recentPlans: allPlans.slice(0, PLAN_FEED_CAP),
     toolActivity: allTools.slice(0, TOOL_FEED_CAP),
   };
-}
-
-function recentEventFiles(dir: string, now: number): string[] {
-  let names: string[];
-  try {
-    names = readdirSync(dir);
-  } catch {
-    return [];
-  }
-  const cutoff = now - 30 * DAY_MS;
-  const candidates: Array<{ path: string; mtime: number }> = [];
-  for (const name of names) {
-    if (!name.endsWith(".events.jsonl")) continue;
-    const path = join(dir, name);
-    let mtime: number;
-    try {
-      mtime = statSync(path).mtimeMs;
-    } catch {
-      continue;
-    }
-    if (mtime < cutoff) continue;
-    candidates.push({ path, mtime });
-  }
-  candidates.sort((a, b) => b.mtime - a.mtime);
-  return candidates.slice(0, RECENT_FILES_CAP).map((c) => c.path);
 }
 
 function countToolCalls(

--- a/src/server/api/hooks-events.ts
+++ b/src/server/api/hooks-events.ts
@@ -1,0 +1,40 @@
+import { existsSync } from "node:fs";
+import { readEventLogFile, recentEventFiles } from "../../adapters/event-source-jsonl.js";
+import { sessionsDir as defaultSessionsDir } from "../../memory/session.js";
+
+export interface HookRunRow {
+  hookName: string;
+  phase: "PreToolUse" | "PostToolUse" | "UserPromptSubmit" | "Stop";
+  outcome: "ok" | "blocked" | "modified" | "error";
+  whenMs: number;
+}
+
+const HOOK_LOG_CAP = 12;
+
+export function readRecentHookRuns(
+  now: number = Date.now(),
+  sessionsDirOverride?: string,
+): ReadonlyArray<HookRunRow> | null {
+  const dir = sessionsDirOverride ?? defaultSessionsDir();
+  if (!existsSync(dir)) return null;
+  const files = recentEventFiles(dir, now);
+  if (files.length === 0) return null;
+
+  const rows: HookRunRow[] = [];
+  for (const file of files) {
+    const events = readEventLogFile(file);
+    for (const ev of events) {
+      if (ev.type !== "hook.fired") continue;
+      const ts = Date.parse(ev.ts);
+      if (!Number.isFinite(ts)) continue;
+      rows.push({
+        hookName: ev.hookName,
+        phase: ev.phase,
+        outcome: ev.outcome,
+        whenMs: ts,
+      });
+    }
+  }
+  rows.sort((a, b) => b.whenMs - a.whenMs);
+  return rows.slice(0, HOOK_LOG_CAP);
+}

--- a/src/server/api/hooks.ts
+++ b/src/server/api/hooks.ts
@@ -5,6 +5,7 @@ import { dirname } from "node:path";
 import { HOOK_EVENTS, globalSettingsPath, loadHooks, projectSettingsPath } from "../../hooks.js";
 import type { DashboardContext } from "../context.js";
 import type { ApiResult } from "../router.js";
+import { readRecentHookRuns } from "./hooks-events.js";
 
 interface SaveBody {
   scope?: unknown;
@@ -65,6 +66,7 @@ export async function handleHooks(
         },
         resolved,
         events: HOOK_EVENTS,
+        recentRuns: readRecentHookRuns(undefined, ctx.sessionsDir),
       },
     };
   }


### PR DESCRIPTION
Adds Recent runs table at the bottom of Hooks panel — reads hook.fired events from cross-session events.jsonl, shows 12 newest. Refactors recentEventFiles to a shared helper. 1711 tests pass.

Closes part of #69.