### PR TITLE
feat(dashboard): semantic search bar + result cards (#78)

### DIFF
--- a/dashboard/src/panels/semantic.ts
+++ b/dashboard/src/panels/semantic.ts
@@ -163,6 +163,7 @@ export function SemanticPanel() {
 
   return html`
     <div style="display:flex;flex-direction:column;gap:6px">
+      ${data.index?.exists ? html`<${SemanticSearchSection} />` : null}
       <div class="chips">
         <span class=${`chip-f ${data.index?.exists ? "active" : ""}`}>
           ${data.index?.exists ? "index built" : "no index yet"}
@@ -324,6 +325,114 @@ interface PreviewData {
   skipBuckets?: Record<string, number>;
   skipSamples?: Record<string, string[]>;
   sampleIncluded?: string[];
+}
+
+interface SearchHit {
+  path: string;
+  startLine: number;
+  endLine: number;
+  score: number;
+  snippet: string;
+}
+
+interface SearchResponse {
+  hits: SearchHit[];
+  elapsedMs: number;
+  model: string;
+}
+
+function SemanticSearchSection() {
+  const [query, setQuery] = useState("");
+  const [hits, setHits] = useState<SearchHit[] | null>(null);
+  const [meta, setMeta] = useState<{ elapsedMs: number; model: string } | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const runSearch = useCallback(async () => {
+    const q = query.trim();
+    if (!q || busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const r = await api<SearchResponse>("/semantic/search", {
+        method: "POST",
+        body: { query: q, topK: 8, minScore: 0.3 },
+      });
+      setHits(r.hits);
+      setMeta({ elapsedMs: r.elapsedMs, model: r.model });
+    } catch (err) {
+      setError((err as Error).message);
+      setHits(null);
+    } finally {
+      setBusy(false);
+    }
+  }, [query, busy]);
+
+  return html`
+    <div style="margin-bottom:14px">
+      <div style="position:relative">
+        <div style="position:absolute;left:14px;top:50%;transform:translateY(-50%);color:var(--c-brand);font-family:var(--font-mono);font-size:14px;pointer-events:none">≈</div>
+        <input
+          type="text"
+          class="mono"
+          style="width:100%;padding:10px 14px 10px 38px;font-size:13.5px;background:var(--bg-input);border:1px solid var(--bd);border-radius:var(--r);color:var(--fg-0);outline:none"
+          placeholder="describe what to find — 'where do we handle abort signals'"
+          value=${query}
+          disabled=${busy}
+          onInput=${(e: Event) => setQuery((e.target as HTMLInputElement).value)}
+          onKeyDown=${(e: KeyboardEvent) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              runSearch();
+            }
+          }}
+        />
+      </div>
+      ${
+        hits || busy || error
+          ? html`
+            <div style="font-family:var(--font-mono);font-size:11px;color:var(--fg-3);margin:8px 0 6px;display:flex;align-items:center;gap:8px">
+              ${busy
+                ? html`<span>searching…</span>`
+                : error
+                ? html`<span style="color:var(--c-err)">${error}</span>`
+                : hits
+                ? html`<span>${hits.length} result${hits.length === 1 ? "" : "s"} · ${meta?.elapsedMs ?? 0}ms · ${meta?.model ?? ""}</span>`
+                : null}
+            </div>
+            ${
+              hits && hits.length > 0
+                ? html`
+                  <div class="card" style="padding:0;max-height:420px;overflow-y:auto">
+                    ${hits.map(
+                      (h) => html`
+                        <div class="sr-card">
+                          <div class="sr-h">
+                            <span class="sr-path">${h.path}</span>
+                            <span class="sr-loc">L${h.startLine} – L${h.endLine}</span>
+                            <span class="sr-score">${h.score.toFixed(3)}</span>
+                          </div>
+                          <div class="sr-snip">${truncateSnippet(h.snippet)}</div>
+                        </div>
+                      `,
+                    )}
+                  </div>
+                `
+                : hits && hits.length === 0 && !busy
+                ? html`<div class="card" style="color:var(--fg-3);font-size:12px">No matches above the score threshold.</div>`
+                : null
+            }
+          `
+          : null
+      }
+    </div>
+  `;
+}
+
+function truncateSnippet(text: string, maxLines = 8): string {
+  const lines = text.split("\n");
+  if (lines.length <= maxLines) return text;
+  return `${lines.slice(0, maxLines).join("\n")}\n  …(${lines.length - maxLines} more lines)`;
 }
 
 function toDraft(c: IndexConfig): ExcludeDraft {

--- a/src/server/api/semantic.ts
+++ b/src/server/api/semantic.ts
@@ -1,7 +1,7 @@
 /** Job state in a module-scoped Map keyed by project root so multi-root dashboards don't collide; CLI `reasonix index` runs independently. */
 
 import { loadIndexConfig } from "../../config.js";
-import { buildIndex, indexExists } from "../../index/semantic/builder.js";
+import { buildIndex, indexExists, querySemantic } from "../../index/semantic/builder.js";
 import type { BuildProgress, BuildResult } from "../../index/semantic/builder.js";
 import {
   checkOllamaStatus,
@@ -70,7 +70,60 @@ export async function handleSemantic(
     if (action === "start") return await startDaemon();
     if (action === "pull") return await startPull(body);
   }
+  if (sub === "search" && method === "POST") {
+    return await runSearch(body, ctx);
+  }
   return { status: 404, body: { error: "no such semantic endpoint" } };
+}
+
+async function runSearch(rawBody: string, ctx: DashboardContext): Promise<ApiResult> {
+  const root = getRoot(ctx);
+  if (!root) {
+    return { status: 503, body: { error: "search requires an attached code-mode session" } };
+  }
+  let parsed: { query?: unknown; topK?: unknown; minScore?: unknown };
+  try {
+    parsed = JSON.parse(rawBody || "{}");
+  } catch {
+    return { status: 400, body: { error: "body must be JSON" } };
+  }
+  const query = typeof parsed.query === "string" ? parsed.query.trim() : "";
+  if (!query) return { status: 400, body: { error: "query required" } };
+  const topK =
+    typeof parsed.topK === "number" && Number.isFinite(parsed.topK)
+      ? Math.max(1, Math.min(16, Math.floor(parsed.topK)))
+      : 8;
+  const minScore =
+    typeof parsed.minScore === "number" && Number.isFinite(parsed.minScore)
+      ? Math.max(0, Math.min(1, parsed.minScore))
+      : 0.3;
+  const startedAt = Date.now();
+  try {
+    const hits = await querySemantic(root, query, {
+      topK,
+      minScore,
+      model: DEFAULT_EMBED_MODEL,
+    });
+    if (hits === null) {
+      return { status: 404, body: { error: "no semantic index for this project" } };
+    }
+    return {
+      status: 200,
+      body: {
+        hits: hits.map((h) => ({
+          path: h.entry.path,
+          startLine: h.entry.startLine,
+          endLine: h.entry.endLine,
+          score: h.score,
+          snippet: h.entry.text,
+        })),
+        elapsedMs: Date.now() - startedAt,
+        model: DEFAULT_EMBED_MODEL,
+      },
+    };
+  } catch (err) {
+    return { status: 500, body: { error: (err as Error).message } };
+  }
 }
 
 async function getStatus(ctx: DashboardContext): Promise<ApiResult> {


### PR DESCRIPTION
Adds search functionality from design §12 to the Semantic panel.

- Server: POST /api/semantic/search wraps querySemantic
- UI: search input with ≈ icon, Enter to query, result-count + elapsed line, .sr-card list (path / line range / score / 8-line snippet preview)

Closes #78.