### PR TITLE
fix(dashboard): skills row clipping + session resume hint

### DIFF
--- a/dashboard/src/panels/sessions.ts
+++ b/dashboard/src/panels/sessions.ts
@@ -107,6 +107,13 @@ export function SessionsPanel() {
                     <button class="btn ghost" onClick=${() => setOpen(null)}>← back</button>
                   </span>
                 </div>
+                <div class="card accent-brand" style="margin-bottom:10px">
+                  <div class="card-h"><span class="title">Resume in TUI</span></div>
+                  <div class="card-b" style="font-size:12.5px;color:var(--fg-2)">
+                    Mid-session swap requires a restart so the message log can rewind cleanly. Quit your current session, then run:
+                    <code class="mono" style="display:block;margin-top:8px;padding:8px 10px;background:var(--bg-input);border-radius:var(--r);color:var(--fg-0);font-size:12px;user-select:all">reasonix chat --session ${open.name}</code>
+                  </div>
+                </div>
                 ${
                   openLoading
                     ? html`<div style="color:var(--fg-3)">loading transcript…</div>`

--- a/dashboard/src/panels/skills.ts
+++ b/dashboard/src/panels/skills.ts
@@ -145,11 +145,11 @@ export function SkillsPanel() {
           <span class="chip-f">builtin <span class="ct">${data.builtin.length}</span></span>
         </div>
 
-        <div style="padding:0 12px 8px;display:flex;gap:6px">
+        <div style="padding:0 12px 8px;display:flex;gap:6px;flex-wrap:wrap">
           <select
             value=${newScope}
             onChange=${(e: Event) => setNewScope((e.target as HTMLSelectElement).value as "global" | "project")}
-            style="flex:0 0 auto"
+            style="flex:0 0 auto;font-size:11.5px;padding:5px 6px"
           >
             <option value="global">global</option>
             ${data.paths.project ? html`<option value="project">project</option>` : null}
@@ -159,9 +159,9 @@ export function SkillsPanel() {
             placeholder="new skill"
             value=${newName}
             onInput=${(e: Event) => setNewName((e.target as HTMLInputElement).value)}
-            style="flex:1"
+            style="flex:1;min-width:0"
           />
-          <button class="btn primary" disabled=${busy || !newName.trim()} onClick=${create}>+</button>
+          <button class="btn primary" disabled=${busy || !newName.trim()} onClick=${create} style="flex:0 0 auto">+</button>
         </div>
 
         <div class="ssl-rows">


### PR DESCRIPTION
Two UX fixes:

1. **Skills + button clipped**: input had no min-width:0 so the create button could overflow the 320px column. Added flex-wrap and min-width:0.
2. **No way to resume a session from dashboard**: added a copy-friendly card in Sessions detail showing the `reasonix chat --session <name>` command. Matches how /resume surfaces in the TUI.