### PR TITLE
feat(dashboard): chat composer popovers — slash + @ mention (#81)

### DIFF
--- a/dashboard/src/panels/chat.ts
+++ b/dashboard/src/panels/chat.ts
@@ -6,11 +6,11 @@ import {
   ChoiceModal,
   EditReviewModal,
   type OnResolve,
-  parseToolArgs,
   PlanModal,
   RevisionModal,
   ShellModal,
   WorkspaceModal,
+  parseToolArgs,
 } from "../components/chat-internals.js";
 import { MODE, TOKEN, api } from "../lib/api.js";
 import { appBus, showToast } from "../lib/bus.js";
@@ -51,6 +51,22 @@ interface MessagesResponse {
 
 interface ModalEnvelope {
   modal?: ModalState | null;
+}
+
+interface SlashCommand {
+  cmd: string;
+  summary: string;
+  argsHint?: string;
+  contextual?: "code";
+}
+
+type PopoverKind = "slash" | "mention" | null;
+
+interface PopoverItem {
+  label: string;
+  meta?: string;
+  /** Replacement string inserted in place of the trigger token (without leading / or @). */
+  insert: string;
 }
 
 interface RailPlan {
@@ -101,6 +117,10 @@ export function ChatPanel() {
   const [budgetUsd, setBudgetUsd] = useState<number | null>(null);
   const [activePlan, setActivePlan] = useState<RailPlan | null>(null);
   const [semanticIndex, setSemanticIndex] = useState<boolean | null>(null);
+  const [slashCommands, setSlashCommands] = useState<SlashCommand[]>([]);
+  const [popoverKind, setPopoverKind] = useState<PopoverKind>(null);
+  const [popoverItems, setPopoverItems] = useState<PopoverItem[]>([]);
+  const [popoverSel, setPopoverSel] = useState(0);
   const [semanticBannerDismissed, setSemanticBannerDismissed] = useState<boolean>(() => {
     try {
       return localStorage.getItem("rx.semanticBannerDismissed") === "1";
@@ -148,6 +168,12 @@ export function ChatPanel() {
         if (!cancelled && m.modal) setModal(m.modal);
       } catch {
         /* skip — modal endpoint optional in standalone */
+      }
+      try {
+        const r = await api<{ commands: SlashCommand[] }>("/slash");
+        if (!cancelled) setSlashCommands(r.commands);
+      } catch {
+        /* skip — popover degrades gracefully */
       }
     })();
     return () => {
@@ -315,14 +341,105 @@ export function ChatPanel() {
     }
   }, []);
 
+  const updatePopover = useCallback(
+    async (text: string) => {
+      const slashMatch = /^\/([A-Za-z0-9_-]*)$/.exec(text);
+      if (slashMatch) {
+        const prefix = slashMatch[1]!.toLowerCase();
+        const items: PopoverItem[] = slashCommands
+          .filter((c) => c.cmd.startsWith(prefix))
+          .slice(0, 12)
+          .map((c) => ({
+            label: `/${c.cmd}`,
+            meta: c.summary,
+            insert: `/${c.cmd}${c.argsHint ? " " : ""}`,
+          }));
+        setPopoverKind("slash");
+        setPopoverItems(items);
+        setPopoverSel(0);
+        return;
+      }
+      const mentionMatch = /(?:^|\s)@([^\s@]*)$/.exec(text);
+      if (mentionMatch && MODE === "attached") {
+        const prefix = mentionMatch[1] ?? "";
+        try {
+          const r = await api<{ files: string[] }>("/files", {
+            method: "POST",
+            body: { prefix },
+          });
+          const items: PopoverItem[] = r.files.slice(0, 12).map((f) => ({
+            label: f,
+            insert: `@${f} `,
+          }));
+          setPopoverKind("mention");
+          setPopoverItems(items);
+          setPopoverSel(0);
+        } catch {
+          setPopoverKind(null);
+        }
+        return;
+      }
+      setPopoverKind(null);
+    },
+    [slashCommands],
+  );
+
+  const applyPopover = useCallback(() => {
+    const item = popoverItems[popoverSel];
+    if (!item) return false;
+    if (popoverKind === "slash") {
+      setInput(item.insert);
+    } else if (popoverKind === "mention") {
+      const m = /(?:^|\s)@([^\s@]*)$/.exec(input);
+      if (!m) return false;
+      const start = input.length - m[0].length + (m[0].startsWith(" ") ? 1 : 0);
+      setInput(`${input.slice(0, start)}${item.insert}`);
+    }
+    setPopoverKind(null);
+    return true;
+  }, [popoverItems, popoverSel, popoverKind, input]);
+
+  const onInput = useCallback(
+    (e: Event) => {
+      const v = (e.target as HTMLTextAreaElement).value;
+      setInput(v);
+      updatePopover(v);
+    },
+    [updatePopover],
+  );
+
   const onKeyDown = useCallback(
     (e: KeyboardEvent) => {
+      if (popoverKind && popoverItems.length > 0) {
+        if (e.key === "ArrowDown") {
+          e.preventDefault();
+          setPopoverSel((i) => (i + 1) % popoverItems.length);
+          return;
+        }
+        if (e.key === "ArrowUp") {
+          e.preventDefault();
+          setPopoverSel((i) => (i - 1 + popoverItems.length) % popoverItems.length);
+          return;
+        }
+        if (e.key === "Tab" || (e.key === "Enter" && !e.shiftKey)) {
+          e.preventDefault();
+          if (applyPopover() && e.key === "Enter" && popoverKind === "slash") {
+            send();
+          }
+          return;
+        }
+        if (e.key === "Escape") {
+          e.preventDefault();
+          setPopoverKind(null);
+          return;
+        }
+      }
       if (e.key === "Enter" && !e.shiftKey) {
         e.preventDefault();
         send();
       }
     },
-    [send],
+    [send, popoverKind, popoverItems, applyPopover],
   );
 
   if (bootError) {
@@ -589,12 +706,38 @@ export function ChatPanel() {
             }
           </div>
 
-          <div class="chat-input-area">
+          <div class="chat-input-area" style="position:relative">
+            ${
+              popoverKind && popoverItems.length > 0
+                ? html`
+                  <div class="popover" style="position:absolute;bottom:calc(100% + 6px);left:0;width:380px;max-height:280px;overflow-y:auto;z-index:10">
+                    <div class="popover-h">${popoverKind === "slash" ? "slash commands" : "project files"}</div>
+                    ${popoverItems.map(
+                      (it, i) => html`
+                        <div
+                          class=${`popover-row ${i === popoverSel ? "sel" : ""}`}
+                          onMouseDown=${(e: Event) => {
+                            e.preventDefault();
+                            setPopoverSel(i);
+                            applyPopover();
+                          }}
+                        >
+                          <span class="g">${popoverKind === "slash" ? "/" : "@"}</span>
+                          <span class="name">${it.label}</span>
+                          ${it.meta ? html`<span class="meta">${it.meta}</span>` : null}
+                        </div>
+                      `,
+                    )}
+                  </div>
+                `
+                : null
+            }
             <textarea
-              placeholder=${busy ? "wait for the current turn to finish…" : "Type a prompt — Enter sends, Shift+Enter for a newline"}
+              placeholder=${busy ? "wait for the current turn to finish…" : "Type a prompt — Enter sends, Shift+Enter for a newline · / @ for pickers"}
               value=${input}
-              onInput=${(e: Event) => setInput((e.target as HTMLTextAreaElement).value)}
+              onInput=${onInput}
               onKeyDown=${onKeyDown}
+              onBlur=${() => setTimeout(() => setPopoverKind(null), 150)}
               disabled=${busy}
               rows="2"
             ></textarea>
@@ -708,15 +851,13 @@ function ActivePlanCard({ plan }: { plan: RailPlan }) {
 function summarizeActiveTool(activeTool: ActiveToolState | null): string | null {
   if (!activeTool) return null;
   const name = activeTool.toolName ?? "tool";
-  const args = parseToolArgs(activeTool.args) as
-    | {
-        path?: string;
-        file_path?: string;
-        filename?: string;
-        content?: unknown;
-        command?: unknown;
-      }
-    | null;
+  const args = parseToolArgs(activeTool.args) as {
+    path?: string;
+    file_path?: string;
+    filename?: string;
+    content?: unknown;
+    command?: unknown;
+  } | null;
   const path = args?.path ?? args?.file_path ?? args?.filename;
   if (name === "write_file" && path) {
     const len = typeof args?.content === "string" ? args.content.length : null;
@@ -745,7 +886,14 @@ interface InFlightRowProps {
   tick: number;
 }
 
-function InFlightRow({ streaming, activeTool, startedAt, statusLine, onAbort, tick: _tick }: InFlightRowProps) {
+function InFlightRow({
+  streaming,
+  activeTool,
+  startedAt,
+  statusLine,
+  onAbort,
+  tick: _tick,
+}: InFlightRowProps) {
   const elapsedMs = startedAt ? Date.now() - startedAt : 0;
   const elapsed = (elapsedMs / 1000).toFixed(1);
   const reasoningLen = streaming?.reasoning?.length ?? 0;
@@ -857,5 +1005,3 @@ function ChatStatusBar({ stats, model }: ChatStatusBarProps) {
     </div>
   `;
 }
-
-

--- a/dashboard/src/panels/mcp.ts
+++ b/dashboard/src/panels/mcp.ts
@@ -130,14 +130,17 @@ export function McpPanel() {
         ${error ? html`<div class="card accent-err" style="margin:0 12px 8px">${error}</div>` : null}
 
         <div class="ssl-rows">
-          ${liveCount === 0 && unbridgedCount === 0
-            ? html`<div style="color:var(--fg-3);padding:14px;font-size:12px">
+          ${
+            liveCount === 0 && unbridgedCount === 0
+              ? html`<div style="color:var(--fg-3);padding:14px;font-size:12px">
                 No MCP servers in this session.
               </div>`
-            : null}
+              : null
+          }
           ${
             showLive
-              ? data.servers.map((s) => html`
+              ? data.servers.map(
+                  (s) => html`
                   <div
                     class=${`ssl-row ${open?.label === s.label ? "sel" : ""}`}
                     onClick=${() => {
@@ -149,12 +152,14 @@ export function McpPanel() {
                     <span class="preview">${specCommand(s.spec)}</span>
                     <span class="meta"><span><span class="v">${fmtNum(s.toolCount)}</span> tools</span></span>
                   </div>
-                `)
+                `,
+                )
               : null
           }
           ${
             showUnbridged
-              ? unbridgedSpecs.map((spec) => html`
+              ? unbridgedSpecs.map(
+                  (spec) => html`
                   <div
                     class=${`ssl-row ${openUnbridged === spec ? "sel" : ""}`}
                     onClick=${() => {
@@ -166,7 +171,8 @@ export function McpPanel() {
                     <span class="preview">${specCommand(spec)}</span>
                     <span class="meta"><span class="dim">in config · not loaded</span></span>
                   </div>
-                `)
+                `,
+                )
               : null
           }
         </div>
@@ -202,10 +208,10 @@ export function McpPanel() {
               </div>
             `
             : open == null
-            ? html`<div style="color:var(--fg-3);font-size:13px;text-align:center;padding:60px 20px">
+              ? html`<div style="color:var(--fg-3);font-size:13px;text-align:center;padding:60px 20px">
                 Pick an MCP server on the left to inspect tools / resources / prompts.
               </div>`
-            : html`
+              : html`
                 <div class="sessions-detail-h">
                   <span class="name">${open.label}</span>
                   <span class="ws">${open.serverInfo?.name ?? "—"} ${open.serverInfo?.version ? `v${open.serverInfo.version}` : ""} · ${open.protocolVersion ?? "—"}</span>
@@ -235,7 +241,8 @@ export function McpPanel() {
                     <thead><tr><th>name</th><th>description</th></tr></thead>
                     <tbody>
                       ${open.tools.map(
-                        (t) => html`<tr><td><code class="mono">${t.name}</code></td><td class="dim">${t.description ?? ""}</td></tr>`,
+                        (t) =>
+                          html`<tr><td><code class="mono">${t.name}</code></td><td class="dim">${t.description ?? ""}</td></tr>`,
                       )}
                     </tbody>
                   </table>
@@ -252,7 +259,8 @@ export function McpPanel() {
                           <thead><tr><th>name</th><th>uri</th></tr></thead>
                           <tbody>
                             ${open.resources.map(
-                              (r) => html`<tr><td>${r.name}</td><td class="path">${r.uri}</td></tr>`,
+                              (r) =>
+                                html`<tr><td>${r.name}</td><td class="path">${r.uri}</td></tr>`,
                             )}
                           </tbody>
                         </table>
@@ -272,7 +280,8 @@ export function McpPanel() {
                           <thead><tr><th>name</th><th>description</th></tr></thead>
                           <tbody>
                             ${open.prompts.map(
-                              (p) => html`<tr><td><code class="mono">${p.name}</code></td><td class="dim">${p.description ?? ""}</td></tr>`,
+                              (p) =>
+                                html`<tr><td><code class="mono">${p.name}</code></td><td class="dim">${p.description ?? ""}</td></tr>`,
                             )}
                           </tbody>
                         </table>

--- a/src/server/api/files.ts
+++ b/src/server/api/files.ts
@@ -1,0 +1,96 @@
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { extname, join, relative, sep } from "node:path";
+import type { DashboardContext } from "../context.js";
+import type { ApiResult } from "../router.js";
+
+const RESULT_CAP = 50;
+const MAX_DEPTH = 4;
+const SKIP_DIRS = new Set([
+  "node_modules",
+  ".git",
+  ".reasonix",
+  "dist",
+  "build",
+  "out",
+  ".next",
+  "coverage",
+  ".cache",
+  "__pycache__",
+  ".venv",
+  ".pytest_cache",
+]);
+const SKIP_EXTS = new Set([
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".gif",
+  ".webp",
+  ".ico",
+  ".pdf",
+  ".zip",
+  ".tar",
+  ".gz",
+  ".lock",
+  ".woff",
+  ".woff2",
+  ".ttf",
+]);
+
+export async function handleFiles(
+  method: string,
+  _rest: string[],
+  body: string,
+  ctx: DashboardContext,
+): Promise<ApiResult> {
+  if (method !== "POST") return { status: 405, body: { error: "POST only" } };
+  const cwd = ctx.getCurrentCwd?.();
+  if (!cwd || !existsSync(cwd)) {
+    return { status: 503, body: { error: "@-mention picker requires a code-mode session" } };
+  }
+  let parsed: { prefix?: unknown };
+  try {
+    parsed = JSON.parse(body || "{}");
+  } catch {
+    return { status: 400, body: { error: "body must be JSON" } };
+  }
+  const prefix = typeof parsed.prefix === "string" ? parsed.prefix.trim().toLowerCase() : "";
+  const matches = walk(cwd, prefix);
+  return { status: 200, body: { files: matches } };
+}
+
+function walk(root: string, prefix: string): string[] {
+  const out: string[] = [];
+  const stack: Array<{ path: string; depth: number }> = [{ path: root, depth: 0 }];
+  while (stack.length > 0 && out.length < RESULT_CAP) {
+    const { path, depth } = stack.pop()!;
+    if (depth > MAX_DEPTH) continue;
+    let names: string[];
+    try {
+      names = readdirSync(path);
+    } catch {
+      continue;
+    }
+    for (const name of names) {
+      if (out.length >= RESULT_CAP) break;
+      if (name.startsWith(".") && depth === 0) continue;
+      if (SKIP_DIRS.has(name)) continue;
+      const full = join(path, name);
+      let st: ReturnType<typeof statSync>;
+      try {
+        st = statSync(full);
+      } catch {
+        continue;
+      }
+      if (st.isDirectory()) {
+        stack.push({ path: full, depth: depth + 1 });
+        continue;
+      }
+      if (!st.isFile()) continue;
+      if (SKIP_EXTS.has(extname(name).toLowerCase())) continue;
+      const rel = relative(root, full).split(sep).join("/");
+      if (prefix && !rel.toLowerCase().includes(prefix)) continue;
+      out.push(rel);
+    }
+  }
+  return out.sort((a, b) => a.localeCompare(b));
+}

--- a/src/server/api/slash.ts
+++ b/src/server/api/slash.ts
@@ -1,0 +1,20 @@
+import { SLASH_COMMANDS } from "../../cli/ui/slash/commands.js";
+import type { DashboardContext } from "../context.js";
+import type { ApiResult } from "../router.js";
+
+export async function handleSlash(
+  method: string,
+  _rest: string[],
+  _body: string,
+  ctx: DashboardContext,
+): Promise<ApiResult> {
+  if (method !== "GET") return { status: 405, body: { error: "GET only" } };
+  const codeMode = ctx.getCurrentCwd?.() != null;
+  const commands = SLASH_COMMANDS.filter((c) => c.contextual !== "code" || codeMode).map((c) => ({
+    cmd: c.cmd,
+    summary: c.summary,
+    argsHint: c.argsHint,
+    contextual: c.contextual,
+  }));
+  return { status: 200, body: { commands, codeMode } };
+}

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -1,5 +1,6 @@
 import { handleAbort } from "./api/abort.js";
 import { handleEditMode } from "./api/edit-mode.js";
+import { handleFiles } from "./api/files.js";
 import { handleHealth } from "./api/health.js";
 import { handleHooks } from "./api/hooks.js";
 import { handleIndexConfig } from "./api/index-config.js";
@@ -14,6 +15,7 @@ import { handleSemantic } from "./api/semantic.js";
 import { handleSessions } from "./api/sessions.js";
 import { handleSettings } from "./api/settings.js";
 import { handleSkills } from "./api/skills.js";
+import { handleSlash } from "./api/slash.js";
 import { handleSubmit } from "./api/submit.js";
 import { handleTools } from "./api/tools.js";
 import { handleUsage } from "./api/usage.js";
@@ -74,6 +76,10 @@ export async function handleApi(
         return await handleSemantic(method, rest, body, ctx);
       case "index-config":
         return await handleIndexConfig(method, rest, body, ctx);
+      case "slash":
+        return await handleSlash(method, rest, body, ctx);
+      case "files":
+        return await handleFiles(method, rest, body, ctx);
       default:
         return { status: 404, body: { error: `no such endpoint: /${head}` } };
     }


### PR DESCRIPTION
Adds slash + @ mention popovers above the chat composer. Two new endpoints: GET /api/slash (filtered SLASH_COMMANDS), POST /api/files (project file walker, depth 4, 50 cap). Keyboard-first (↑↓ Tab Enter Esc). 1716 tests pass.

Closes #81.