### PR TITLE
feat(code): --system-append / --system-append-file for append-only system prompt customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Reasonix. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- feat(code): `--system-append` / `--system-append-file` CLI options append user instructions to the code system prompt without replacing the default prompt. Both can be used together (inline first, then file contents). File read errors surface with their OS error code.
+
 ## [0.17.1] — 2026-04-29
 
 **Headline:** Fix a render crash in the dashboard's Editor that triggered

--- a/README.md
+++ b/README.md
@@ -51,8 +51,20 @@ src/users.ts
 
 Edits stay in memory until you type `/apply` — nothing hits disk by default. Requires Node ≥ 20.10. Tested on macOS, Linux, and Windows (PowerShell, Git Bash, Windows Terminal).
 
----
+### Appending code-mode system instructions
 
+`reasonix code` supports append-only system prompt customization for users who want to layer personal workflow rules on top of the default Reasonix Code prompt.
+
+```sh
+reasonix code --system-append "Always inspect relevant files before editing."
+reasonix code --system-append-file ./agent-instructions.md
+```
+
+Both options may be used together. When both are provided, the inline `--system-append` text is added first, followed by the `--system-append-file` contents, under a `# User System Append` heading at the end of the generated system prompt.
+
+These options do not replace the default code prompt. They append additional instructions after Reasonix Code's built-in tool-use and edit-protocol instructions. There is no `--system` override for `reasonix code`.
+
+---
 ## How it compares
 
 |                                  | Reasonix         | Claude Code     | Cursor             | Aider            |

--- a/src/cli/commands/code.tsx
+++ b/src/cli/commands/code.tsx
@@ -18,6 +18,7 @@
  *     for SEARCH/REPLACE blocks and applied on disk after each turn.
  */
 
+import { readFileSync } from "node:fs";
 import { basename, resolve } from "node:path";
 import { loadEditMode, loadProjectShellAllowed } from "../../config.js";
 import { bootstrapSemanticSearchInCodeMode } from "../../index/semantic/tool.js";
@@ -61,6 +62,10 @@ export interface CodeOptions {
   budgetUsd?: number;
   /** Suppress the auto-launched embedded web dashboard. */
   noDashboard?: boolean;
+  /** Inline string appended to the code system prompt after the generated base prompt. */
+  systemAppend?: string;
+  /** Path to a UTF-8 text file whose contents are appended to the code system prompt. */
+  systemAppendFile?: string;
 }
 
 export async function codeCommand(opts: CodeOptions = {}): Promise<void> {
@@ -151,11 +156,32 @@ export async function codeCommand(opts: CodeOptions = {}): Promise<void> {
     void jobs.shutdown();
   });
 
+  let systemAppendFileContents: string | undefined;
+  if (opts.systemAppend !== undefined && opts.systemAppend.trim().length === 0) {
+    process.stderr.write("▲ --system-append is empty — no prompt text will be appended\n");
+  }
+  if (opts.systemAppendFile) {
+    const filePath = resolve(opts.systemAppendFile);
+    try {
+      systemAppendFileContents = readFileSync(filePath, "utf8");
+    } catch (err) {
+      const e = err as NodeJS.ErrnoException;
+      process.stderr.write(
+        `Error: cannot read --system-append-file "${filePath}": ${e.code ? `[${e.code}] ` : ""}${e.message}\n`,
+      );
+      process.exit(1);
+    }
+  }
+
   await chatCommand({
     model: opts.model ?? "deepseek-v4-flash",
     harvest: opts.harvest ?? false,
     budgetUsd: opts.budgetUsd,
-    system: codeSystemPrompt(rootDir, { hasSemanticSearch: semantic.enabled }),
+    system: codeSystemPrompt(rootDir, {
+      hasSemanticSearch: semantic.enabled,
+      systemAppend: opts.systemAppend,
+      systemAppendFile: systemAppendFileContents,
+    }),
     transcript: opts.transcript,
     session,
     seedTools: tools,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -125,6 +125,14 @@ program
     "--no-dashboard",
     "Suppress the auto-launched embedded web dashboard. Default behavior boots it on TUI mount and shows the URL in the status bar (clickable in OSC-8-aware terminals).",
   )
+  .option(
+    "--system-append <prompt>",
+    "Append instructions to the code system prompt. Does NOT replace the default prompt — adds after it.",
+  )
+  .option(
+    "--system-append-file <path>",
+    "Append file contents to the code system prompt. Does NOT replace the default prompt. UTF-8, relative to cwd or absolute.",
+  )
   .action(async (dir: string | undefined, opts) => {
     await codeCommand({
       dir,
@@ -136,6 +144,8 @@ program
       harvest: !!opts.harvest,
       budgetUsd: parseBudgetFlag(opts.budget),
       noDashboard: opts.dashboard === false,
+      systemAppend: opts.systemAppend,
+      systemAppendFile: opts.systemAppendFile,
     });
   });
 

--- a/src/code/prompt.ts
+++ b/src/code/prompt.ts
@@ -209,6 +209,12 @@ export interface CodeSystemPromptOptions {
    *  explicit routing fragment so the model picks it for intent-style
    *  queries instead of defaulting to grep. */
   hasSemanticSearch?: boolean;
+  /** Inline string appended after the generated code system prompt.
+   *  Preserves the default prompt — this is append-only, not a replacement. */
+  systemAppend?: string;
+  /** UTF-8 file contents appended after the generated code system prompt.
+   *  Preserves the default prompt — this is append-only, not a replacement. */
+  systemAppendFile?: string;
 }
 
 export function codeSystemPrompt(rootDir: string, opts: CodeSystemPromptOptions = {}): string {
@@ -217,26 +223,26 @@ export function codeSystemPrompt(rootDir: string, opts: CodeSystemPromptOptions 
     : CODE_SYSTEM_PROMPT;
   const withMemory = applyMemoryStack(base, rootDir);
   const gitignorePath = join(rootDir, ".gitignore");
-  if (!existsSync(gitignorePath)) return withMemory;
-  let content: string;
-  try {
-    content = readFileSync(gitignorePath, "utf8");
-  } catch {
-    return withMemory;
+  let result = withMemory;
+  if (existsSync(gitignorePath)) {
+    let content: string | undefined;
+    try {
+      content = readFileSync(gitignorePath, "utf8");
+    } catch {
+      // read failed — content stays undefined, no .gitignore block emitted
+    }
+    if (content !== undefined) {
+      const MAX = 2000;
+      const truncated =
+        content.length > MAX
+          ? `${content.slice(0, MAX)}\n… (truncated ${content.length - MAX} chars)`
+          : content;
+      result = `${result}\n\n# Project .gitignore\n\nThe user's repo ships this .gitignore — treat every pattern as "don't traverse or edit inside these paths unless explicitly asked":\n\n\`\`\`\n${truncated}\n\`\`\`\n`;
+    }
   }
-  const MAX = 2000;
-  const truncated =
-    content.length > MAX
-      ? `${content.slice(0, MAX)}\n… (truncated ${content.length - MAX} chars)`
-      : content;
-  return `${withMemory}
-
-# Project .gitignore
-
-The user's repo ships this .gitignore — treat every pattern as "don't traverse or edit inside these paths unless explicitly asked":
-
-\`\`\`
-${truncated}
-\`\`\`
-`;
+  const appendParts = [opts.systemAppend, opts.systemAppendFile].filter(Boolean);
+  if (appendParts.length > 0) {
+    result = `${result}\n\n# User System Append\n\n${appendParts.join("\n\n")}`;
+  }
+  return result;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -240,6 +240,7 @@ export type {
   EditSnapshot,
 } from "./code/edit-blocks.js";
 export { CODE_SYSTEM_PROMPT, codeSystemPrompt } from "./code/prompt.js";
+export type { CodeSystemPromptOptions } from "./code/prompt.js";
 export {
   MCP_PROTOCOL_VERSION,
   isJsonRpcError,

--- a/tests/code-prompt.test.ts
+++ b/tests/code-prompt.test.ts
@@ -81,4 +81,52 @@ describe("codeSystemPrompt", () => {
       expect(gitignoreAt).toBeGreaterThan(routingAt);
     });
   });
+
+  describe("system append", () => {
+    it("does not add a User System Append section when neither option is provided", () => {
+      const out = codeSystemPrompt(root);
+      expect(out).not.toMatch(/# User System Append/);
+    });
+
+    it("preserves the base system prompt when appending", () => {
+      const out = codeSystemPrompt(root, { systemAppend: "Extra rule." });
+      expect(out).toContain(CODE_SYSTEM_PROMPT);
+    });
+
+    it("appends an inline systemAppend string under a # User System Append heading", () => {
+      const out = codeSystemPrompt(root, {
+        systemAppend: "Always inspect relevant files before editing.",
+      });
+      expect(out).toMatch(/# User System Append/);
+      expect(out).toContain("Always inspect relevant files before editing.");
+    });
+
+    it("appends systemAppendFile contents under the # User System Append heading", () => {
+      const out = codeSystemPrompt(root, { systemAppendFile: "Run tests before committing." });
+      expect(out).toMatch(/# User System Append/);
+      expect(out).toContain("Run tests before committing.");
+    });
+
+    it("appends inline prompt first, then file contents, when both are provided", () => {
+      const out = codeSystemPrompt(root, {
+        systemAppend: "First instruction.",
+        systemAppendFile: "Second instruction.",
+      });
+      expect(out).toMatch(/# User System Append/);
+      const appendIdx = out.indexOf("# User System Append");
+      const firstIdx = out.indexOf("First instruction.", appendIdx);
+      const secondIdx = out.indexOf("Second instruction.", appendIdx);
+      expect(firstIdx).toBeGreaterThan(0);
+      expect(secondIdx).toBeGreaterThan(firstIdx);
+    });
+
+    it("places the append section after the .gitignore section", () => {
+      writeFileSync(join(root, ".gitignore"), "node_modules\n");
+      const out = codeSystemPrompt(root, { systemAppend: "Post-gitignore instruction." });
+      const gitignoreAt = out.indexOf("# Project .gitignore");
+      const appendAt = out.indexOf("# User System Append");
+      expect(gitignoreAt).toBeGreaterThan(0);
+      expect(appendAt).toBeGreaterThan(gitignoreAt);
+    });
+  });
 });


### PR DESCRIPTION
## What

Adds `--system-append <prompt>` and `--system-append-file <path>` CLI options to `reasonix code`. Both append user-provided instructions to the default Reasonix Code system prompt under a `# User System Append` heading, without replacing or weakening the base prompt.

## Why

Users want to layer personal workflow rules (always inspect files before editing, always run linter after changes, etc.) on top of Reasonix Code's built-in tool-use and edit-protocol instructions. The `chat` command has `--system` for full overrides, but `code` mode's prompt is carefully engineered for cache stability — a full override would break that. Append-only is the safe middle ground.

## How to verify

```
npm run verify
```

Manual smoke test:
```
npx reasonix code --system-append "Test instruction"
npx reasonix code --system-append-file ./prompt.md
npx reasonix code --system-append "First" --system-append-file ./prompt.md
```

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] CHANGELOG updated under `## [Unreleased]`
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CLAUDE.md (no module-essay headers, no incident history)
