### PR TITLE
chore(code): drop unicode warning prefix + empty-catch comment

### DIFF
--- a/src/cli/commands/code.tsx
+++ b/src/cli/commands/code.tsx
@@ -158,7 +158,7 @@ export async function codeCommand(opts: CodeOptions = {}): Promise<void> {
 
   let systemAppendFileContents: string | undefined;
   if (opts.systemAppend !== undefined && opts.systemAppend.trim().length === 0) {
-    process.stderr.write("▲ --system-append is empty — no prompt text will be appended\n");
+    process.stderr.write("--system-append is empty — no prompt text will be appended\n");
   }
   if (opts.systemAppendFile) {
     const filePath = resolve(opts.systemAppendFile);

--- a/src/code/prompt.ts
+++ b/src/code/prompt.ts
@@ -228,9 +228,7 @@ export function codeSystemPrompt(rootDir: string, opts: CodeSystemPromptOptions 
     let content: string | undefined;
     try {
       content = readFileSync(gitignorePath, "utf8");
-    } catch {
-      // read failed — content stays undefined, no .gitignore block emitted
-    }
+    } catch {}
     if (content !== undefined) {
       const MAX = 2000;
       const truncated =


### PR DESCRIPTION
## What

Two cosmetic cleanups following #86:

1. `src/cli/commands/code.tsx:161` — drop the `▲` prefix from the empty-`--system-append` warning. No other stderr write in the repo (`run.ts` / `commit.ts` / `index.ts`) uses unicode markers; plain text is the established style.
2. `src/code/prompt.ts:232` — drop the empty-catch comment. Per CONTRIBUTING.md §Comments, the default is none, and this restates what the empty body and surrounding code already make clear.

## Why

Internal consistency. Caught these on review of #86 but didn't bounce the PR for it — the contributor's framing of the cache-stability call was excellent and the fix is faster than another review round.

## How to verify

```
npm run verify
```

## Checklist

- [x] `npm run verify` passes locally
- [x] No CHANGELOG entry — pure code style, not user-visible
- [x] No `Co-Authored-By: Claude` trailer
