### PR TITLE
fix(code): bridge config.mcp servers in code mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Reasonix. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- fix(code): `reasonix code` now reads configured MCP servers from `~/.reasonix/config.json`. Previously only `reasonix chat` loaded `config.mcp`; `reasonix code` silently skipped them, so servers defined in config were never bridged into code-mode sessions.
+
 ## [0.17.1] — 2026-04-29
 
 **Headline:** Fix a render crash in the dashboard's Editor that triggered

--- a/src/cli/commands/code.tsx
+++ b/src/cli/commands/code.tsx
@@ -19,7 +19,7 @@
  */
 
 import { basename, resolve } from "node:path";
-import { loadEditMode, loadProjectShellAllowed } from "../../config.js";
+import { loadEditMode, loadProjectShellAllowed, readConfig } from "../../config.js";
 import { bootstrapSemanticSearchInCodeMode } from "../../index/semantic/tool.js";
 import { sanitizeName } from "../../memory/session.js";
 import { ToolRegistry } from "../../tools.js";
@@ -160,6 +160,7 @@ export async function codeCommand(opts: CodeOptions = {}): Promise<void> {
     session,
     seedTools: tools,
     codeMode: { rootDir, jobs, reregisterTools: registerRootedTools },
+    mcp: readConfig().mcp,
     forceResume: opts.forceResume,
     forceNew: opts.forceNew,
     noDashboard: opts.noDashboard,


### PR DESCRIPTION
## What

`reasonix code` now reads configured MCP servers from `~/.reasonix/config.json` and bridges them into the session. Previously only `reasonix chat` loaded `config.mcp` — `reasonix code` silently skipped it.

## Why

The config schema explicitly stores MCP specs "in `--mcp` format so one parser handles both flag and config" (`src/config.ts:27`). The `chat` subcommand honored this via `resolveDefaults`. The `code` subcommand did not — a 2-line oversight that meant any MCP servers defined in `config.json` were never available in code-mode sessions.

## How to verify

1. Populate `~/.reasonix/config.json` with an `mcp` array (or run `sync.py generate` from cth.agentsmith)
2. Run `reasonix code`
3. Expected: `▸ MCP[<name>]: N tool(s) from ...` lines on startup

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] CHANGELOG updated under `## [Unreleased]`
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CLAUDE.md (no module-essay headers, no incident history)
