### PR TITLE
chore(quality): expand comment-policy scope + architecture invariants test

### DIFF
--- a/benchmarks/harvest/report.ts
+++ b/benchmarks/harvest/report.ts
@@ -1,13 +1,13 @@
-/**
- * Render a harvest-bench results.json into a markdown report.
- *
- *   npx tsx benchmarks/harvest/report.ts benchmarks/harvest/results-<date>.json
- *   npx tsx benchmarks/harvest/report.ts <input.json> --out report.md
- */
+/** Render a harvest-bench results.json into a markdown report. CLI usage in README. */
 
 import { readFileSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
-import { ALL_MODES, type HarvestBenchReport, type HarvestMode, type HarvestRunResult } from "./types.js";
+import {
+  ALL_MODES,
+  type HarvestBenchReport,
+  type HarvestMode,
+  type HarvestRunResult,
+} from "./types.js";
 
 interface CliArgs {
   input: string;
@@ -82,7 +82,9 @@ export function renderReport(report: HarvestBenchReport): string {
   // Per-mode summary
   lines.push("## Summary by mode");
   lines.push("");
-  lines.push("| mode | runs | pass rate | cache hit | cost / run | harvest turns | subgoals | uncertainties |");
+  lines.push(
+    "| mode | runs | pass rate | cache hit | cost / run | harvest turns | subgoals | uncertainties |",
+  );
   lines.push("|---|---:|---:|---:|---:|---:|---:|---:|");
   for (const mode of ALL_MODES) {
     const rs = report.results.filter((r) => r.mode === mode);
@@ -97,20 +99,23 @@ export function renderReport(report: HarvestBenchReport): string {
   // Pairwise deltas that actually answer the question
   lines.push("## Deltas");
   lines.push("");
-  const modes = ALL_MODES.filter((m) =>
-    report.results.some((r) => r.mode === m),
-  );
+  const modes = ALL_MODES.filter((m) => report.results.some((r) => r.mode === m));
   if (modes.length >= 2) {
     const baseline = aggregate(report.results.filter((r) => r.mode === modes[0]));
     for (let i = 1; i < modes.length; i++) {
       const mode = modes[i]!;
       const agg = aggregate(report.results.filter((r) => r.mode === mode));
-      const passDelta = (agg.passes / Math.max(agg.runs, 1)) - (baseline.passes / Math.max(baseline.runs, 1));
+      const passDelta =
+        agg.passes / Math.max(agg.runs, 1) - baseline.passes / Math.max(baseline.runs, 1);
       const costRatio = baseline.avgCost > 0 ? agg.avgCost / baseline.avgCost : 0;
       lines.push(`- **${modes[0]} → ${mode}**`);
       lines.push(`  - pass rate: ${(passDelta * 100).toFixed(0)}pp`);
-      lines.push(`  - cost: ×${costRatio.toFixed(2)} (each run costs ${costRatio > 1 ? "more" : "less"})`);
-      lines.push(`  - harvest signal / run: ${agg.avgSubgoals.toFixed(1)} subgoals, ${agg.avgUncertainties.toFixed(1)} uncertainties`);
+      lines.push(
+        `  - cost: ×${costRatio.toFixed(2)} (each run costs ${costRatio > 1 ? "more" : "less"})`,
+      );
+      lines.push(
+        `  - harvest signal / run: ${agg.avgSubgoals.toFixed(1)} subgoals, ${agg.avgUncertainties.toFixed(1)} uncertainties`,
+      );
       lines.push("");
     }
   }
@@ -149,15 +154,7 @@ export function renderReport(report: HarvestBenchReport): string {
   return lines.join("\n");
 }
 
-/**
- * Findings section is hand-written into report.md after rendering — the
- * numbers don't interpret themselves, and boilerplate sections full of
- * "TBD — analyse the data" are worse than nothing. Append with append().
- *
- * This section has been updated twice: after the first 9-run set (which
- * bottomed out at V3 on easy tasks) and after this 18-run set (which
- * bottomed out at V3 on *hard* tasks too).
- */
+/** Findings prose lives in report.md (hand-written after rendering); this stub keeps the function shape. */
 export function renderFindings(_report: HarvestBenchReport): string {
   return [
     "",
@@ -165,7 +162,7 @@ export function renderFindings(_report: HarvestBenchReport): string {
     "",
     "Two bands of tasks tried (easy: mod7 / flips / hats; hard: pseudoprime341 / D_7 / Euler quadratic). The hard band was chosen for *known V3 failure modes*. Result:",
     "",
-    "1. **V3 chat passed all six tasks, including the three \"hard\" ones.** DeepSeek V3 knew 341 is the smallest base-2 pseudoprime, computed D_7=1854, and identified n=40 as the first Euler-polynomial failure. The tasks are well-known enough to be in training; the trap-answer variants (561, 265, 41) that the checkers specifically reject didn't fire.",
+    '1. **V3 chat passed all six tasks, including the three "hard" ones.** DeepSeek V3 knew 341 is the smallest base-2 pseudoprime, computed D_7=1854, and identified n=40 as the first Euler-polynomial failure. The tasks are well-known enough to be in training; the trap-answer variants (561, 265, 41) that the checkers specifically reject didn\'t fire.',
     "2. **Reasoner cost 3.04× baseline for identical pass rates (6/6 both sides).** On this task set, R1 adds cost and latency without measurable quality. The cache-hit story *does* extend to reasoner (74.2% mean), so Pillar 1 generalizes to R1 — but that's not a Pillar 2 story.",
     "3. **Harvest produced real signal** (mean 2.8 subgoals, 1.3 uncertainties per run where it fired) but didn't improve outcomes. One run hit the 300s timeout (bumped from 120s), suggesting reasoner-harvest latency is still unpredictable on some problems.",
     "",
@@ -173,8 +170,8 @@ export function renderFindings(_report: HarvestBenchReport): string {
     "",
     "We've now given harvest two shots at showing answer-quality value on pure reasoning tasks. Both times V3 ate its lunch. This isn't a framework bug — it's a positioning signal:",
     "",
-    "- **On well-known math / logic / counting problems, DeepSeek V3 is strong enough that paying for R1 is not justified by accuracy.** Pillar 2's \"smart preset\" cost multiplier (10×) quoted in the README is real but for most single-question Q/A it buys nothing.",
-    "- **Harvest's plausible value surfaces are not \"better math answers\".** More likely: (a) transparency / auditability for developers, (b) planning support when tools are in the mix, (c) driving branch-sampling on cases where uncertainty correlates with wrongness. None of those are tested here.",
+    '- **On well-known math / logic / counting problems, DeepSeek V3 is strong enough that paying for R1 is not justified by accuracy.** Pillar 2\'s "smart preset" cost multiplier (10×) quoted in the README is real but for most single-question Q/A it buys nothing.',
+    '- **Harvest\'s plausible value surfaces are not "better math answers".** More likely: (a) transparency / auditability for developers, (b) planning support when tools are in the mix, (c) driving branch-sampling on cases where uncertainty correlates with wrongness. None of those are tested here.',
     "",
     "### Recommendation",
     "",

--- a/benchmarks/harvest/runner.ts
+++ b/benchmarks/harvest/runner.ts
@@ -1,15 +1,4 @@
-/**
- * Harvest-bench runner.
- *
- * Usage:
- *   npx tsx benchmarks/harvest/runner.ts                      # all tasks, all modes, 1 repeat
- *   npx tsx benchmarks/harvest/runner.ts --task mod7_list
- *   npx tsx benchmarks/harvest/runner.ts --mode reasoner-harvest --repeats 3
- *   npx tsx benchmarks/harvest/runner.ts --transcripts-dir transcripts/
- *   npx tsx benchmarks/harvest/runner.ts --dry                # smoke test wiring, no API
- *
- * Writes results.json. Render report.md with `report.ts`.
- */
+/** Harvest-bench runner — writes results.json. CLI flags + sample invocations in benchmarks/README.md. */
 
 import { type WriteStream, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
@@ -21,11 +10,7 @@ import {
   claudeEquivalentCost,
   loadDotenv,
 } from "../../src/index.js";
-import {
-  openTranscriptFile,
-  recordFromLoopEvent,
-  writeRecord,
-} from "../../src/transcript/log.js";
+import { openTranscriptFile, recordFromLoopEvent, writeRecord } from "../../src/transcript/log.js";
 import { TASKS } from "./tasks.js";
 import type {
   HarvestBenchMeta,
@@ -80,8 +65,6 @@ function parseArgs(argv: string[]): CliArgs {
   return out;
 }
 
-// ---------- model resolution ----------
-
 function modelForMode(mode: HarvestMode): string {
   if (mode === "baseline") return "deepseek-chat";
   return "deepseek-reasoner";
@@ -90,8 +73,6 @@ function modelForMode(mode: HarvestMode): string {
 function harvestForMode(mode: HarvestMode): boolean {
   return mode === "reasoner-harvest";
 }
-
-// ---------- run one task in one mode ----------
 
 async function runOnce(
   task: HarvestTask,
@@ -163,7 +144,9 @@ async function runOnce(
     errorMessage = (err as Error).message;
   }
 
-  const verdict = errorMessage ? { verdict: "fail" as const, note: errorMessage } : task.check(finalText);
+  const verdict = errorMessage
+    ? { verdict: "fail" as const, note: errorMessage }
+    : task.check(finalText);
 
   return {
     taskId: task.id,
@@ -184,8 +167,6 @@ async function runOnce(
     errorMessage,
   };
 }
-
-// ---------- dry mode ----------
 
 function runDry(args: CliArgs): HarvestBenchReport {
   const tasks = filterTasks(args.taskFilter);
@@ -217,8 +198,6 @@ function runDry(args: CliArgs): HarvestBenchReport {
   }
   return { meta: buildMeta(args, tasks.length), results };
 }
-
-// ---------- main ----------
 
 function filterTasks(filter: string | null): HarvestTask[] {
   if (!filter) return TASKS;
@@ -276,13 +255,9 @@ async function main(): Promise<void> {
           stream?.end();
         }
         const elapsed = ((Date.now() - started) / 1000).toFixed(1);
+        const note = result.checkNote ? `  ${result.checkNote}` : "";
         console.log(
-          `[${task.id}/${mode}/r${rep + 1}] verdict=${result.verdict}` +
-            ` cache=${(result.cacheHitRatio * 100).toFixed(1)}%` +
-            ` cost=$${result.costUsd.toFixed(6)}` +
-            ` harvest=${result.harvestedTurns}:${result.totalSubgoals}s/${result.totalUncertainties}u` +
-            ` (${elapsed}s)` +
-            (result.checkNote ? `  ${result.checkNote}` : ""),
+          `[${task.id}/${mode}/r${rep + 1}] verdict=${result.verdict} cache=${(result.cacheHitRatio * 100).toFixed(1)}% cost=$${result.costUsd.toFixed(6)} harvest=${result.harvestedTurns}:${result.totalSubgoals}s/${result.totalUncertainties}u (${elapsed}s)${note}`,
         );
         results.push(result);
       }

--- a/benchmarks/harvest/tasks.ts
+++ b/benchmarks/harvest/tasks.ts
@@ -1,30 +1,10 @@
-/**
- * Seed reasoning tasks for the harvest eval harness.
- *
- * Each task has:
- *   - a minimal system prompt (so the comparison is about the model, not
- *     the prompt)
- *   - a single user question
- *   - a deterministic checker (regex + set/value compare)
- *
- * When adding a new task, prefer problems where:
- *   - the answer has a clean shape (a number, a small set, a yes/no +
- *     explanation) — easier to check
- *   - reasoning actually matters (so harvest has signal to extract);
- *     trivia questions are out of scope
- *   - there's a known-good answer; judgment calls are out of scope
- */
+/** Seed reasoning tasks for harvest-bench — single-turn Q/A with deterministic checkers. */
 
 import type { HarvestTask } from "./types.js";
 
 const CONCISE_SYSTEM = `You are a precise reasoner. Think carefully, then state your final answer on a clearly-labeled line starting with "Answer:".`;
 
-/**
- * Parse all non-negative integers out of a string. Handles commas,
- * ranges written as "2-4" (expands to 2,3,4), and ignores numbers that
- * look like formula references (e.g. "n^2", "mod 7") by only accepting
- * integers after we strip common LaTeX decorations.
- */
+/** Parse non-negative integers; expands "2-4" → 2,3,4; strips LaTeX decorations first. */
 function extractIntegers(text: string): number[] {
   // Strip LaTeX delimiters so n_1 / n^2 / \{ ... \} don't confuse us.
   const cleaned = text
@@ -51,8 +31,6 @@ function extractAnswerLine(text: string): string {
   return matches[matches.length - 1]![1]!.trim();
 }
 
-// ---------- expected answers ----------
-
 /** Positive n ≤ 100 such that n^2 + n + 1 ≡ 0 (mod 7). */
 const MOD7_EXPECTED: number[] = (() => {
   const out: number[] = [];
@@ -62,10 +40,7 @@ const MOD7_EXPECTED: number[] = (() => {
   return out;
 })();
 
-/**
- * Single-integer checker. Pulls the first plausible integer from the last
- * "Answer:" line; compares for exact equality.
- */
+/** Single-integer checker — first plausible int from the last "Answer:" line, exact equality. */
 function checkSingleInt(expected: number) {
   return (reply: string) => {
     const answerLine = extractAnswerLine(reply);
@@ -77,8 +52,6 @@ function checkSingleInt(expected: number) {
   };
 }
 
-// ---------- tasks ----------
-
 export const TASKS: HarvestTask[] = [
   {
     id: "mod7_list",
@@ -86,7 +59,7 @@ export const TASKS: HarvestTask[] = [
       "Number theory — find all positive n ≤ 100 with n^2+n+1 ≡ 0 (mod 7). 29-element set. Classic R1 scratch-work territory.",
     systemPrompt: CONCISE_SYSTEM,
     prompt:
-      "Find all positive integers n with n ≤ 100 such that n^2 + n + 1 is divisible by 7. Briefly justify, then end with the full list on a line starting with \"Answer:\".",
+      'Find all positive integers n with n ≤ 100 such that n^2 + n + 1 is divisible by 7. Briefly justify, then end with the full list on a line starting with "Answer:".',
     check: (reply) => {
       const answerLine = extractAnswerLine(reply);
       const found = new Set(extractIntegers(answerLine).filter((n) => n >= 1 && n <= 100));
@@ -95,7 +68,8 @@ export const TASKS: HarvestTask[] = [
         return { verdict: "fail", note: "no integers extracted from Answer line" };
       }
       // Exact set equality — both containment directions.
-      for (const n of expected) if (!found.has(n)) return { verdict: "fail", note: `missing n=${n}` };
+      for (const n of expected)
+        if (!found.has(n)) return { verdict: "fail", note: `missing n=${n}` };
       for (const n of found) if (!expected.has(n)) return { verdict: "fail", note: `extra n=${n}` };
       return { verdict: "pass" };
     },
@@ -107,7 +81,7 @@ export const TASKS: HarvestTask[] = [
       "Probability — expected coin flips until 3 consecutive heads. Answer: 14. Tests whether R1 derives via recurrence or via memorized result.",
     systemPrompt: CONCISE_SYSTEM,
     prompt:
-      "A fair coin is flipped repeatedly until you see 3 heads in a row. What is the expected number of total flips? Give a single integer on a line starting with \"Answer:\".",
+      'A fair coin is flipped repeatedly until you see 3 heads in a row. What is the expected number of total flips? Give a single integer on a line starting with "Answer:".',
     check: (reply) => {
       const answerLine = extractAnswerLine(reply);
       const nums = extractIntegers(answerLine);
@@ -136,8 +110,6 @@ export const TASKS: HarvestTask[] = [
       return { verdict: "fail", note: "no clear color in Answer line" };
     },
   },
-
-  // ---------- hard tasks (picked for known V3 failure modes) ----------
 
   {
     id: "pseudoprime_base2",

--- a/benchmarks/harvest/types.ts
+++ b/benchmarks/harvest/types.ts
@@ -1,16 +1,4 @@
-/**
- * Types for the harvest eval harness.
- *
- * Scope: this is deliberately NOT τ-bench-lite. These tasks:
- *   - are single-turn Q/A (no user simulator, no DB)
- *   - target reasoning-heavy problems (math, logic, planning)
- *   - use deterministic checkers (regex extraction + set/value compare),
- *     never an LLM judge
- *
- * The point is to measure Pillar 2 (harvest) the same way τ-bench-lite
- * measures Pillar 1 (cache-first): isolate one variable, produce numbers
- * anyone can reproduce.
- */
+/** Harvest-bench types — single-turn Q/A with deterministic checkers; isolates Pillar 2 the way τ-bench-lite isolates Pillar 1. */
 
 export type HarvestMode =
   /** deepseek-chat, no Reasonix tricks. Floor reference for answer quality on reasoning tasks (V3 at its best). */
@@ -22,11 +10,7 @@ export type HarvestMode =
 
 export const ALL_MODES: HarvestMode[] = ["baseline", "reasoner", "reasoner-harvest"];
 
-/**
- * Checker verdict. We don't use boolean directly because "maybe" is real
- * — e.g. "answer in the right shape but can't verify without running the
- * program". For v0.3 we only use {pass, fail}, but the shape leaves room.
- */
+/** Checker verdict — `inconclusive` reserves room for "right shape, can't verify without running it". */
 export type CheckVerdict = "pass" | "fail" | "inconclusive";
 
 export interface HarvestTask {
@@ -37,12 +21,7 @@ export interface HarvestTask {
   systemPrompt: string;
   /** The single question. */
   prompt: string;
-  /**
-   * Check the agent's final reply. Returns pass/fail/inconclusive plus an
-   * optional one-line explanation the report can surface.
-   *
-   * IMPORTANT: must be pure and deterministic. No LLM calls, no file I/O.
-   */
+  /** Pure + deterministic — no LLM calls, no file I/O. Verdict + optional one-line note. */
   check: (agentReply: string) => { verdict: CheckVerdict; note?: string };
 }
 

--- a/benchmarks/tau-bench/baseline.ts
+++ b/benchmarks/tau-bench/baseline.ts
@@ -1,22 +1,4 @@
-/**
- * Naive baseline runner — deliberately does NOT use CacheFirstLoop.
- *
- * For the benchmark comparison to be honest, this runner must reproduce
- * what a "typical" agent framework does that breaks DeepSeek's automatic
- * prefix cache:
- *
- *   1. Inject a fresh timestamp into the system prompt every turn.
- *   2. Re-serialize the tool list each turn with a shuffled key order.
- *   3. Rebuild the full message array each turn rather than appending.
- *
- * These are all things frameworks like LangChain/LangGraph do by default
- * (either directly, or because tool specs are regenerated from Python dicts
- * with non-deterministic ordering, or because a "current_time" placeholder
- * is recommended in common system-prompt recipes).
- *
- * Reuses DeepSeekClient, ToolRegistry, and SessionStats so the *only*
- * difference from the Reasonix run is prefix stability.
- */
+/** Naive baseline — deliberately breaks prefix cache (fresh timestamp + shuffled tool keys + full-rebuild log) so the comparison vs CacheFirstLoop isolates Pillar 1. */
 
 import {
   type ChatMessage,
@@ -26,7 +8,7 @@ import {
   type ToolDefinition,
   ToolRegistry,
   type ToolSpec,
-  Usage,
+  type Usage,
 } from "../../src/index.js";
 import type { Turn } from "./types.js";
 
@@ -50,12 +32,7 @@ export interface BaselineSubCall {
 export interface BaselineTurnResult {
   assistantMessage: string;
   toolCallsExecuted: { name: string; args: string; result: string }[];
-  /**
-   * Per-sub-call breakdown, one entry per client.chat() invocation. Gives
-   * downstream tools (bench transcripts) the same granularity as Reasonix
-   * loop events — without it, diff can't compare model-call counts
-   * apples-to-apples.
-   */
+  /** Per-sub-call breakdown so bench transcripts match Reasonix loop-event granularity. */
   subCalls: BaselineSubCall[];
   /** Turn number (1-based) assigned by the agent. */
   turnNo: number;
@@ -68,10 +45,7 @@ export class BaselineAgent {
   private readonly registry: ToolRegistry;
   private readonly model: string;
   private readonly maxToolIters: number;
-  /**
-   * Previous-turn messages. A naive framework keeps these, but we still
-   * rebuild the prefix around them each turn so the byte prefix churns.
-   */
+  /** Previous-turn messages — kept, but the prefix rebuilds around them every turn so cache churns. */
   private history: ChatMessage[] = [];
   private turnNo = 0;
 
@@ -84,13 +58,7 @@ export class BaselineAgent {
     for (const t of opts.tools) this.registry.register(t);
   }
 
-  /**
-   * Run one user-turn: sends the user message, lets the model do tool
-   * calls until it stops, returns the final assistant text.
-   *
-   * Intentionally non-cache-friendly: rebuilds the prefix with a fresh
-   * timestamp + re-shuffled tool specs every turn.
-   */
+  /** Run one user-turn — intentionally non-cache-friendly (fresh ts + shuffled tool specs every turn). */
   async userTurn(userMessage: string, transcript: Turn[]): Promise<BaselineTurnResult> {
     this.turnNo++;
 
@@ -159,9 +127,7 @@ export class BaselineAgent {
 }
 
 /**
- * Deterministic Fisher–Yates shuffle seeded by an integer. Same turn number
- * → same ordering, so the baseline is reproducible across runs while still
- * being cache-hostile (different turns get different orderings).
+ * Deterministic Fisher–Yates seeded by turn-number — reproducible runs, cache-hostile orderings.
  */
 function shuffle<T>(arr: T[], seed: number): T[] {
   const out = [...arr];

--- a/benchmarks/tau-bench/db.ts
+++ b/benchmarks/tau-bench/db.ts
@@ -1,9 +1,6 @@
 import type { WorldState } from "./types.js";
 
-/**
- * Deep-clone a WorldState so per-run mutations stay isolated.
- * structuredClone is enough — WorldState is JSON-shaped by contract.
- */
+/** Deep-clone a WorldState — `structuredClone` is enough since the type is JSON-shaped by contract. */
 export function cloneDb(db: WorldState): WorldState {
   return structuredClone(db);
 }

--- a/benchmarks/tau-bench/report.ts
+++ b/benchmarks/tau-bench/report.ts
@@ -1,9 +1,4 @@
-/**
- * Render a results-*.json into a human-readable report.md.
- *
- *   npx tsx benchmarks/tau-bench/report.ts benchmarks/tau-bench/results-<date>.json
- *   npx tsx benchmarks/tau-bench/report.ts <input.json> --out report.md
- */
+/** Render τ-bench results.json → report.md. CLI usage in benchmarks/README.md. */
 
 import { readFileSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
@@ -170,8 +165,6 @@ export function renderReport(report: BenchReport): string {
     renderCaveats(),
   ].join("\n");
 }
-
-// ---------- formatting helpers ----------
 
 function pct(num: number, denom: number): string {
   if (denom === 0) return "—";

--- a/benchmarks/tau-bench/runner.ts
+++ b/benchmarks/tau-bench/runner.ts
@@ -1,17 +1,4 @@
-/**
- * τ-bench-lite runner.
- *
- * Usage:
- *   npx tsx benchmarks/tau-bench/runner.ts                         # all tasks, 1 repeat, both modes
- *   npx tsx benchmarks/tau-bench/runner.ts --task t01_address_happy
- *   npx tsx benchmarks/tau-bench/runner.ts --mode reasonix --repeats 3
- *   npx tsx benchmarks/tau-bench/runner.ts --model deepseek-chat --out results.json
- *   npx tsx benchmarks/tau-bench/runner.ts --dry                   # no API calls, smoke-test plumbing
- *
- * Writes a results-<timestamp>.json file (or whatever --out points at).
- * Run `npx tsx benchmarks/tau-bench/report.ts <results.json>` to render
- * report.md.
- */
+/** τ-bench-lite runner — writes results.json. CLI flags + sample invocations in benchmarks/README.md. */
 
 import { type WriteStream, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
@@ -26,11 +13,7 @@ import {
   costUsd,
   loadDotenv,
 } from "../../src/index.js";
-import {
-  openTranscriptFile,
-  recordFromLoopEvent,
-  writeRecord,
-} from "../../src/transcript/log.js";
+import { openTranscriptFile, recordFromLoopEvent, writeRecord } from "../../src/transcript/log.js";
 import { BaselineAgent } from "./baseline.js";
 import { cloneDb } from "./db.js";
 import { TASKS } from "./tasks.js";
@@ -79,8 +62,6 @@ function parseArgs(argv: string[]): CliArgs {
   }
   return out;
 }
-
-// ---------- per-run drivers ----------
 
 interface RunContext {
   client: DeepSeekClient;
@@ -311,8 +292,6 @@ function truncate(s: string, n = 140): string {
   return s.length > n ? `${s.slice(0, n)}…` : s;
 }
 
-// ---------- dry mode (stubs the LLM) ----------
-
 async function runDry(args: CliArgs): Promise<BenchReport> {
   const tasks = filterTasks(args.taskFilter);
   const results: RunResult[] = [];
@@ -360,8 +339,6 @@ function stubArgs(t: {
   for (const k of Object.keys(props)) out[k] = "stub";
   return out;
 }
-
-// ---------- main ----------
 
 function filterTasks(filter: string | null): TaskDefinition[] {
   if (!filter) return TASKS;

--- a/benchmarks/tau-bench/tasks.ts
+++ b/benchmarks/tau-bench/tasks.ts
@@ -1,16 +1,4 @@
-/**
- * Seed task set — retail-flavored, τ-bench-inspired.
- *
- * Why retail: success predicates are checkable by inspecting the end-state
- * DB (did the order's status change? was the refund logged?), which avoids
- * LLM-judge flakiness in the reproducibility report.
- *
- * Each task follows the same shape:
- *   - a small starting DB
- *   - 2–4 stateful tools (read / mutate rows)
- *   - a user-sim persona that will hold back info until asked
- *   - a check() that inspects the end-state DB
- */
+/** Seed retail tasks — DB-end-state predicates avoid LLM-judge flakiness in the reproducibility report. */
 
 import { getRow, setField } from "./db.js";
 import type { TaskDefinition, ToolFactory, WorldState } from "./types.js";
@@ -21,8 +9,6 @@ Rules:
 - Never invent order ids or emails.
 - If a request is outside your tools, say so honestly.
 - Be concise.`;
-
-// ---------- shared world-state factory ----------
 
 function retailSeed(): WorldState {
   return {
@@ -72,8 +58,6 @@ function retailSeed(): WorldState {
     refunds: {},
   };
 }
-
-// ---------- tool factories (closed over a per-run db) ----------
 
 const lookupOrder: ToolFactory = (db) => ({
   name: "lookup_order",
@@ -189,8 +173,6 @@ const ALL_TOOLS = [
   refundOrder,
   listUserOrders,
 ];
-
-// ---------- tasks ----------
 
 export const TASKS: TaskDefinition[] = [
   {

--- a/benchmarks/tau-bench/types.ts
+++ b/benchmarks/tau-bench/types.ts
@@ -1,18 +1,8 @@
-/**
- * Task and result types for the tool-use eval harness.
- *
- * Scope note: this is NOT a full port of Sierra's τ-bench (airline+retail).
- * We mirror its *shape* — multi-turn tool-use with an LLM user simulator and
- * DB-end-state success predicates — so a later port can drop real tasks in
- * without changing the harness. Until then, see `tasks.ts` for our seed set.
- */
+/** Tool-use eval types — shape-compatible with Sierra τ-bench so a later port can drop real tasks in. */
 
 import type { ToolDefinition } from "../../src/index.js";
 
-/**
- * The mutable world state a task's tools operate on. Tasks deep-clone this
- * into a per-run snapshot so runs don't leak state across each other.
- */
+/** Mutable world state — deep-cloned per run so mutations don't leak across runs. */
 export interface WorldState {
   [table: string]: Record<string, Record<string, unknown>>;
 }
@@ -22,18 +12,11 @@ export interface UserPersona {
   style: string;
   /** The concrete goal. The user pursues this until it's met or clearly refused. */
   goal: string;
-  /**
-   * Facts the simulator may reveal when the agent asks. Keep tight — the
-   * user shouldn't volunteer everything up front.
-   */
+  /** Facts the simulator may reveal when asked — kept tight; user shouldn't volunteer everything. */
   knowns: Record<string, string>;
 }
 
-/**
- * A tool factory. We take a factory (not a ToolDefinition directly) because
- * each run needs a fresh closure over its per-run WorldState — otherwise all
- * runs would share (and mutate) the same DB.
- */
+/** Tool factory — fresh closure over per-run WorldState; bare ToolDefinitions would share DBs. */
 export type ToolFactory = (db: WorldState) => ToolDefinition;
 
 export interface TaskDefinition {
@@ -50,10 +33,7 @@ export interface TaskDefinition {
   user: UserPersona;
   /** Max turns of (user → agent) before we give up and mark fail. */
   maxTurns?: number;
-  /**
-   * Success predicate. Given the end-state DB (and optionally the final
-   * agent utterance), return true iff the task is considered solved.
-   */
+  /** Success predicate over end-state DB (+ final agent utterance). */
   check: (ctx: { db: WorldState; finalAgentMessage: string; transcript: Turn[] }) => boolean;
 }
 

--- a/benchmarks/tau-bench/user-sim.ts
+++ b/benchmarks/tau-bench/user-sim.ts
@@ -1,15 +1,4 @@
-/**
- * LLM-backed user simulator for tool-use eval.
- *
- * A cheap V3 call that given (persona, goal, transcript so far) emits either
- * the user's next utterance or the literal sentinel `##STOP##` to end the
- * conversation. Kept intentionally small and low-temperature so dialogue
- * stays on-task and is replayable.
- *
- * We accept "some" non-determinism (DeepSeek samples at T=0.1) — the honest
- * way to deal with run-to-run drift is repeat-per-task in the runner, not
- * trying to pretend the sim is deterministic.
- */
+/** LLM-backed user sim — emits next utterance or `##STOP##`; non-determinism handled by repeat-per-task in the runner. */
 
 import type { ChatMessage, DeepSeekClient } from "../../src/index.js";
 import type { Turn, UserPersona } from "./types.js";
@@ -35,10 +24,7 @@ export class UserSimulator {
     private opts: UserSimOptions = {},
   ) {}
 
-  /**
-   * Given the transcript so far, produce the user's next line, or null if
-   * the simulator decided the conversation is over.
-   */
+  /** Next user line, or null if the sim decided the conversation is over. */
   async next(transcript: Turn[]): Promise<string | null> {
     const knowns = JSON.stringify(this.persona.knowns, null, 2);
     const messages: ChatMessage[] = [

--- a/dashboard/src/components/chat-internals.ts
+++ b/dashboard/src/components/chat-internals.ts
@@ -278,7 +278,6 @@ export function ChatMessage({ msg, streaming }: ChatMessageProps) {
   `;
 }
 
-// ---------- Modal components mirroring the TUI ----------
 //
 // Each component renders a card matching the TUI's ModalCard accent
 // palette: red for shell (run-now), magenta for choice (branching),

--- a/scripts/prepare-tokenizer.ts
+++ b/scripts/prepare-tokenizer.ts
@@ -1,16 +1,5 @@
 #!/usr/bin/env node
-/**
- * Regenerate `data/deepseek-tokenizer.json.gz` from an upstream
- * `tokenizer.json` (as shipped in DeepSeek's deepseek_v3_tokenizer.zip).
- *
- * Why slim+gz: the full tokenizer.json is 7.5MB; we only need four
- * fields (vocab, merges, pre_tokenizer, added_tokens). Strip + gzip
- * drops the committed artifact to ~1.7MB with no loss of fidelity
- * for encode-side token counting.
- *
- * Usage: `node --experimental-strip-types scripts/prepare-tokenizer.ts <path/to/tokenizer.json>`
- * (or via `tsx` / `ts-node`.)
- */
+/** Regenerate `data/deepseek-tokenizer.json.gz` — keeps only encode-side fields, gzipped (7.5MB → ~1.7MB). */
 
 import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";

--- a/tests/architecture-invariants.test.ts
+++ b/tests/architecture-invariants.test.ts
@@ -1,0 +1,119 @@
+/** Pillar invariants — promoted from spike-fork-prefix-rebuild Exp 1 to permanent regression. */
+
+import { describe, expect, it } from "vitest";
+import { type EventizeContext, Eventizer } from "../src/core/eventize.js";
+import type { Event } from "../src/core/events.js";
+import { replay } from "../src/core/reducers.js";
+import type { LoopEvent } from "../src/loop.js";
+import { ImmutablePrefix } from "../src/memory/runtime.js";
+
+const ctx: EventizeContext = {
+  model: "deepseek-v4-flash",
+  reasoningEffort: "max",
+  prefixHash: "test",
+};
+
+function synth(loopEvents: LoopEvent[]): Event[] {
+  const eventizer = new Eventizer();
+  const events: Event[] = [];
+  events.push(eventizer.emitSessionOpened(0, "inv", 0));
+  events.push(eventizer.emitUserMessage(1, "kick off"));
+  for (const lev of loopEvents) {
+    for (const out of eventizer.consume(lev, ctx)) events.push(out);
+  }
+  return events;
+}
+
+function assistantTurn(turn: number, content: string): LoopEvent {
+  return { turn, role: "assistant_final", content } as LoopEvent;
+}
+
+function toolPair(turn: number, name: string, args: string, result: string): LoopEvent[] {
+  return [
+    { turn, role: "tool_start", toolName: name, toolArgs: args } as LoopEvent,
+    { turn, role: "tool", content: result, toolName: name } as LoopEvent,
+  ];
+}
+
+function buildSession(turns: number, toolsPerTurn: (t: number) => number): LoopEvent[] {
+  const out: LoopEvent[] = [];
+  for (let t = 1; t <= turns; t++) {
+    out.push(assistantTurn(t, `assistant turn ${t}`));
+    const n = toolsPerTurn(t);
+    for (let i = 0; i < n; i++) {
+      out.push(...toolPair(t, "read_file", `{"path":"f${t}-${i}.ts"}`, `body ${t}-${i}`));
+    }
+  }
+  return out;
+}
+
+describe("Pillar 1 — ImmutablePrefix.fingerprint determinism", () => {
+  it("same {system, tools, fewShots} inputs yield byte-identical fingerprint", () => {
+    const a = new ImmutablePrefix({
+      system: "you are a coder",
+      toolSpecs: [{ type: "function", function: { name: "echo", parameters: { type: "object" } } }],
+      fewShots: [],
+    });
+    const b = new ImmutablePrefix({
+      system: "you are a coder",
+      toolSpecs: [{ type: "function", function: { name: "echo", parameters: { type: "object" } } }],
+      fewShots: [],
+    });
+    expect(a.fingerprint).toBe(b.fingerprint);
+  });
+
+  it("addTool invalidates fingerprint exactly once", () => {
+    const p = new ImmutablePrefix({ system: "x", toolSpecs: [] });
+    const before = p.fingerprint;
+    const ok = p.addTool({
+      type: "function",
+      function: { name: "new", parameters: { type: "object" } },
+    });
+    expect(ok).toBe(true);
+    expect(p.fingerprint).not.toBe(before);
+  });
+});
+
+describe("Pillar 1 — reducer projection determinism", () => {
+  const shapes: Array<[string, LoopEvent[]]> = [
+    ["quick-fix", buildSession(5, (t) => (t % 2 === 0 ? 1 : 0))],
+    ["local-refactor", buildSession(20, (t) => 3 + (t % 3))],
+    ["long-tail-debug", buildSession(80, (t) => 1 + (t % 2))],
+  ];
+
+  for (const [name, loopEvents] of shapes) {
+    it(`${name}: identical LoopEvent input → byte-identical message projection`, () => {
+      const a = synth(loopEvents);
+      const b = synth(loopEvents);
+      const aJson = JSON.stringify(replay(a).conversation.messages);
+      const bJson = JSON.stringify(replay(b).conversation.messages);
+      expect(aJson).toBe(bJson);
+    });
+  }
+});
+
+describe("Pillar 1 — message-level append-only across turn boundaries", () => {
+  it("replay(events[0..n]).messages is a strict prefix of replay(events[0..m]) for n < m", () => {
+    const events = synth(buildSession(20, (t) => 3 + (t % 3)));
+    const turnBoundaries: number[] = [];
+    let lastTurn = -1;
+    events.forEach((ev, idx) => {
+      if (ev.turn !== lastTurn) {
+        turnBoundaries.push(idx);
+        lastTurn = ev.turn;
+      }
+    });
+
+    let prev: ReturnType<typeof replay>["conversation"]["messages"] | null = null;
+    for (const cut of turnBoundaries) {
+      const cur = replay(events.slice(0, cut)).conversation.messages;
+      if (prev !== null) {
+        expect(cur.length).toBeGreaterThanOrEqual(prev.length);
+        for (let i = 0; i < prev.length; i++) {
+          expect(JSON.stringify(cur[i])).toBe(JSON.stringify(prev[i]));
+        }
+      }
+      prev = cur;
+    }
+  });
+});

--- a/tests/benchmarks.test.ts
+++ b/tests/benchmarks.test.ts
@@ -1,16 +1,4 @@
-/**
- * Smoke tests for the τ-bench-lite harness.
- *
- * The goal is NOT to verify benchmark numbers (those only exist when you
- * point the harness at a real API key). These tests verify the harness
- * itself is robust:
- *   - each seed task's tools actually operate on *its* db snapshot, not a
- *     shared one (i.e. cloneDb isolation works)
- *   - each task's check() predicate is satisfiable when the correct mutation
- *     happens, and refusal tasks stay false-on-no-change
- *   - the baseline agent's shuffle is deterministic per turn-number so
- *     reproducibility holds across runs
- */
+/** Smoke tests for the τ-bench-lite harness — db isolation, check() predicates, baseline shuffle determinism. */
 
 import { describe, expect, it } from "vitest";
 import { cloneDb } from "../benchmarks/tau-bench/db.js";

--- a/tests/bundle-smoke.test.ts
+++ b/tests/bundle-smoke.test.ts
@@ -1,20 +1,4 @@
-/**
- * Post-build smoke test for the bundled `dist/`.
- *
- * Unit tests load modules from `src/`, which means path-resolution
- * bugs that only appear AFTER tsup bundles everything into a different
- * directory layout never surface in the regular test suite. v0.5.4
- * shipped to npm with exactly such a bug — `src/tokenizer.ts` at
- * `dist/cli/index.js` tried to read the tokenizer data file relative
- * to the bundled entry, ended up at `dist/data/...` instead of the
- * package-root `data/...`, and every `reasonix run` crashed on first
- * turn with ENOENT.
- *
- * These tests spawn the bundled output and verify the two bundle
- * layouts (`dist/index.js` library + `dist/cli/index.js` CLI) can
- * both locate the tokenizer data file. They're skipped when the
- * build hasn't run yet (CI always runs `npm run build` first).
- */
+/** Post-build smoke — confirm bundled `dist/{index,cli/index}.js` resolves the tokenizer data file at package-root. */
 
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";

--- a/tests/checkpoints.test.ts
+++ b/tests/checkpoints.test.ts
@@ -1,8 +1,4 @@
-/**
- * Tests for the checkpoint store. Each test uses a fresh temp dir for
- * the workspace and points HOME at another temp dir so the real
- * `~/.reasonix` is never touched.
- */
+/** Checkpoint store tests — fresh temp workspace + redirected HOME so real `~/.reasonix` is untouched. */
 
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/tests/choice.test.ts
+++ b/tests/choice.test.ts
@@ -1,9 +1,4 @@
-/**
- * ask_choice — the branching primitive that keeps A/B/C decisions out
- * of submit_plan. Covers the schema, the sanitization layer (DeepSeek
- * sometimes emits malformed options arrays even with auto-flatten),
- * and the ChoiceRequestedError toToolResult protocol.
- */
+/** ask_choice — schema, sanitization, ChoiceRequestedError → tool_result protocol. */
 
 import { describe, expect, it } from "vitest";
 import { ToolRegistry } from "../src/tools.js";

--- a/tests/code-prompt.test.ts
+++ b/tests/code-prompt.test.ts
@@ -1,7 +1,4 @@
-/**
- * Tests for `codeSystemPrompt` — the .gitignore injection helper.
- * Pure I/O at the edge, so filesystem-backed tests using a temp dir.
- */
+/** codeSystemPrompt — gitignore injection + system-append composition. */
 
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/tests/comment-policy.test.ts
+++ b/tests/comment-policy.test.ts
@@ -2,7 +2,9 @@ import { readFileSync, readdirSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
 import { describe, expect, test } from "vitest";
 
-const SRC = join(process.cwd(), "src");
+const ROOTS = ["src", "tests", "benchmarks", "scripts", "dashboard/src"].map((r) =>
+  join(process.cwd(), r),
+);
 
 function walk(dir: string, out: string[] = []): string[] {
   for (const name of readdirSync(dir)) {
@@ -13,7 +15,13 @@ function walk(dir: string, out: string[] = []): string[] {
   return out;
 }
 
-const FILES = walk(SRC).map((p) => ({
+const FILES = ROOTS.flatMap((root) => {
+  try {
+    return walk(root);
+  } catch {
+    return [];
+  }
+}).map((p) => ({
   path: p,
   rel: relative(process.cwd(), p),
   src: readFileSync(p, "utf8"),

--- a/tests/consistency.test.ts
+++ b/tests/consistency.test.ts
@@ -13,10 +13,6 @@ interface MainCallScript {
   reasoning: string;
 }
 
-/**
- * Fake fetch that returns different main-call responses per branch (keyed by
- * temperature) and a canned plan-state JSON for every harvest call.
- */
 function makeFakeFetch(
   mainByTemp: Record<string, MainCallScript>,
   harvestJson: string | ((reasoning: string) => string),

--- a/tests/edit-blocks.test.ts
+++ b/tests/edit-blocks.test.ts
@@ -1,9 +1,4 @@
-/**
- * Unit tests for SEARCH/REPLACE parsing + application.
- *
- * Filesystem tests use a fresh temp dir per test so they don't collide
- * or leak across runs.
- */
+/** SEARCH/REPLACE parsing + application — fresh temp dir per test. */
 
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/tests/events-command.test.ts
+++ b/tests/events-command.test.ts
@@ -1,9 +1,4 @@
-/**
- * `reasonix events <name>` command formatter — pure stdout assertions.
- * The command itself is mostly formatting; this proves the per-event-type
- * detail rendering hits the right shape, plus the filter / projection
- * flags work end-to-end.
- */
+/** `reasonix events <name>` formatter — per-event-type detail rendering + filter / projection flags. */
 
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/tests/frame.test.ts
+++ b/tests/frame.test.ts
@@ -20,13 +20,7 @@ import {
 } from "../src/frame/index.js";
 import type { Frame } from "../src/frame/index.js";
 
-/**
- * Width invariant — the linchpin every primitive must preserve.
- * Counts the visible width of each row (tail cells contribute 0,
- * regular cells contribute their width) and asserts it equals
- * `Frame.width`. If a primitive ever miscounts, the slicer's
- * arithmetic drifts and we get back the 0.13.x scrolling bugs.
- */
+/** Width invariant — every primitive must preserve `Frame.width`; miscount → slicer drift. */
 function assertWidthInvariant(f: Frame): void {
   for (let i = 0; i < f.rows.length; i++) {
     const row = f.rows[i]!;

--- a/tests/harvest-bench.test.ts
+++ b/tests/harvest-bench.test.ts
@@ -1,11 +1,4 @@
-/**
- * Checker tests for the harvest eval harness.
- *
- * Unlike the bench runner tests (which cover plumbing without API calls),
- * these test the pass/fail verdict logic — the part that determines
- * whether a real run's data is credible. A broken checker silently
- * produces wrong numbers, so the tests here are worth every line.
- */
+/** Harvest-bench checker — pass/fail verdict logic; broken checkers silently corrupt benchmark numbers. */
 
 import { describe, expect, it } from "vitest";
 import { TASKS } from "../benchmarks/harvest/tasks.js";

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -1,8 +1,4 @@
-/**
- * Tests for the hooks module — settings loading, match patterns,
- * outcome decisions, and the runHooks dispatcher with a stubbed
- * spawner. No real subprocesses, no real filesystem outside tmp dirs.
- */
+/** Hooks — settings load, match patterns, outcome decisions, runHooks dispatcher (stubbed spawner). */
 
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/tests/init-slash.test.ts
+++ b/tests/init-slash.test.ts
@@ -6,11 +6,6 @@ import { handleSlash } from "../src/cli/ui/slash/dispatch.js";
 import { CacheFirstLoop, DeepSeekClient, ImmutablePrefix } from "../src/index.js";
 import { ToolRegistry } from "../src/tools.js";
 
-/**
- * Build a minimal loop instance for the slash dispatcher to consume.
- * The handler under test never actually calls the loop — it returns
- * a SlashResult — so this is just structural plumbing.
- */
 function makeLoop(): CacheFirstLoop {
   const tools = new ToolRegistry();
   return new CacheFirstLoop({

--- a/tests/jobs.test.ts
+++ b/tests/jobs.test.ts
@@ -1,9 +1,4 @@
-/**
- * JobRegistry — background-process lifecycle. Each test uses a real
- * child process via `node -e "..."` so we actually exercise the spawn/
- * pipe/kill plumbing. Inline scripts keep fixtures self-contained; no
- * temp files to clean up.
- */
+/** JobRegistry — real spawn/pipe/kill via inline `node -e` scripts. */
 
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/tests/key-normalize.test.ts
+++ b/tests/key-normalize.test.ts
@@ -1,9 +1,4 @@
-/**
- * Tests for the CSI recovery boundary. Every keystroke that flows
- * through Ink's `useInput` runs through `recoverCsiTail` first, so a
- * regression here would silently re-break arrow keys / paste markers
- * / Shift+Tab on Windows ConPTY.
- */
+/** CSI recovery boundary — every Ink keystroke runs through `recoverCsiTail`; regressions here re-break arrows / paste / Shift+Tab on Windows ConPTY. */
 
 import { describe, expect, it } from "vitest";
 import {

--- a/tests/loop-error.test.ts
+++ b/tests/loop-error.test.ts
@@ -1,8 +1,4 @@
-/**
- * Tests for the loop's error-message decorator. Scope is narrow:
- * context-overflow errors get a user-friendly hint, everything else
- * passes through unchanged.
- */
+/** Loop error decorator — context-overflow gets a user hint; everything else passes through. */
 
 import { describe, expect, it } from "vitest";
 import { formatLoopError, healLoadedMessages, stripHallucinatedToolMarkup } from "../src/loop.js";

--- a/tests/loop-hooks.test.ts
+++ b/tests/loop-hooks.test.ts
@@ -1,10 +1,4 @@
-/**
- * Smoke tests for hook wiring inside CacheFirstLoop. The full
- * pass / block / warn matrix is covered in tests/hooks.test.ts with
- * a stubbed spawner — here we just confirm the loop honors the
- * `hooks` option and exposes a mutable list that `/hooks reload`
- * can swap into without reconstructing the loop.
- */
+/** CacheFirstLoop hook wiring — confirms the loop honors `hooks` and exposes a swappable list for `/hooks reload`. */
 
 import { describe, expect, it, vi } from "vitest";
 import { DeepSeekClient } from "../src/client.js";

--- a/tests/loop-r1-reasoning.test.ts
+++ b/tests/loop-r1-reasoning.test.ts
@@ -1,11 +1,4 @@
-/**
- * R1 thinking-mode contract: when a reasoner turn returns both
- * `reasoning_content` and `tool_calls`, the assistant message we
- * persist + send on the NEXT request (the tool-loop continuation)
- * must carry `reasoning_content` back. Otherwise DeepSeek 400s with
- * "The reasoning_content in the thinking mode must be passed back to
- * the API." Reproduces the bug that surfaced in 0.5.14 live usage.
- */
+/** R1 thinking-mode contract — `reasoning_content` must round-trip on the next request or DeepSeek 400s. */
 
 import { describe, expect, it, vi } from "vitest";
 import { DeepSeekClient } from "../src/client.js";

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -1,10 +1,4 @@
-/**
- * Integration tests for CacheFirstLoop.
- *
- * We inject a fake fetch into DeepSeekClient so the loop exercises its real
- * request/response wiring without hitting the network. The non-streaming
- * path is covered here; streaming is exercised by the TUI in practice.
- */
+/** CacheFirstLoop integration — fake-fetch DeepSeekClient, non-streaming path. */
 
 import { describe, expect, it, vi } from "vitest";
 import { DeepSeekClient } from "../src/client.js";

--- a/tests/mcp-inspect.test.ts
+++ b/tests/mcp-inspect.test.ts
@@ -1,8 +1,4 @@
-/**
- * Tests for inspectMcpServer (pure, runs against the fake transport).
- * We don't unit-test the CLI wrapper — that's just argv parsing and
- * stdout printing, covered by the integration story of "types compile".
- */
+/** inspectMcpServer — runs against the fake transport. */
 
 import { describe, expect, it } from "vitest";
 import { McpClient } from "../src/mcp/client.js";

--- a/tests/mcp-integration.test.ts
+++ b/tests/mcp-integration.test.ts
@@ -1,15 +1,4 @@
-/**
- * Integration test: real subprocess + real transport + bridge + dispatch.
- *
- * Distinct from tests/mcp.test.ts (which uses an in-process fake
- * transport). This one actually spawns the bundled demo MCP server as
- * a child process, connects via StdioTransport, bridges tools into a
- * ToolRegistry, and invokes them.
- *
- * We don't put this in CI yet — subprocess tests on Windows can be
- * slow or flaky. Run locally with `npm test`. If it ever becomes
- * flaky, swap the afterEach cleanup to force-kill and move on.
- */
+/** MCP integration — spawns the demo MCP server, bridges tools, invokes them end-to-end. */
 
 import { afterEach, describe, expect, it } from "vitest";
 import { McpClient } from "../src/mcp/client.js";

--- a/tests/mcp-sse.test.ts
+++ b/tests/mcp-sse.test.ts
@@ -1,11 +1,4 @@
-/**
- * SSE transport tests.
- *
- * Strategy: spin up a tiny in-process http.Server that implements the
- * 2024-11-05 MCP HTTP+SSE wire shape — GET emits `event: endpoint` then
- * stays open; POSTs land a JSON-RPC response on the SSE channel. No real
- * MCP server needed.
- */
+/** SSE transport — in-process http.Server speaking the MCP HTTP+SSE wire shape. */
 
 import { type IncomingMessage, type ServerResponse, createServer } from "node:http";
 import type { AddressInfo } from "node:net";

--- a/tests/mcp-streamable-http.test.ts
+++ b/tests/mcp-streamable-http.test.ts
@@ -1,15 +1,4 @@
-/**
- * Streamable HTTP transport tests.
- *
- * Mirrors `mcp-sse.test.ts`'s in-process http.Server pattern. The fake
- * server speaks the 2025-03-26 Streamable HTTP wire shape directly —
- * it accepts POSTs and responds with one of:
- *   - 202 Accepted (notification ack)
- *   - 200 + application/json (single response)
- *   - 200 + text/event-stream (one or more SSE `event: message` frames)
- * It also mints a `Mcp-Session-Id` on the first response so the client
- * has to round-trip the header on subsequent requests.
- */
+/** Streamable HTTP transport — in-process fake server speaking the Streamable HTTP wire shape. */
 
 import { type IncomingMessage, type ServerResponse, createServer } from "node:http";
 import type { AddressInfo } from "node:net";
@@ -34,19 +23,9 @@ interface FakeOptions {
   path?: string;
   /** Hand back this session id on the initialize response. Default "sess-1". */
   sessionId?: string;
-  /**
-   * Return a JSON-RPC reply for an incoming request.
-   *  - If the value is `{ stream: [...] }`, the server writes those frames
-   *    on an SSE response.
-   *  - If `undefined`, the server replies 202 Accepted (notification ack).
-   *  - Otherwise, the value is sent as a single application/json body.
-   */
+  /** `{ stream: [...] }` → SSE frames; `undefined` → 202 ack; else single application/json body. */
   reply?: (body: unknown) => unknown | { stream: unknown[] } | undefined;
-  /**
-   * Sites that need to inject failures for a specific request shape.
-   * Lookup happens after `reply` returns so the failure can short-circuit
-   * the normal path.
-   */
+  /** Failure injection lookup runs after `reply` so it can short-circuit the normal path. */
   forceStatus?: (body: unknown) => { status: number; body?: string } | undefined;
 }
 

--- a/tests/mcp.test.ts
+++ b/tests/mcp.test.ts
@@ -1,11 +1,4 @@
-/**
- * MCP client + bridge tests.
- *
- * Strategy: fake the McpTransport with an in-process pair. The fake
- * server understands initialize / tools/list / tools/call and returns
- * canned responses, letting us verify the client side without spawning
- * a real process.
- */
+/** MCP client + bridge — in-process fake transport answering initialize / tools/list / tools/call. */
 
 import { describe, expect, it } from "vitest";
 import { McpClient } from "../src/mcp/client.js";
@@ -22,8 +15,6 @@ import {
   type McpTool,
   type ReadResourceResult,
 } from "../src/mcp/types.js";
-
-// ---------- fake transport ----------
 
 interface FakeServerOptions {
   tools: McpTool[];
@@ -45,11 +36,7 @@ interface FakeServerOptions {
   capabilities?: Record<string, unknown>;
 }
 
-/**
- * In-process MCP server. Responds directly in `send()` by pushing a
- * response onto the messages queue. Synchronous-enough to make tests
- * deterministic.
- */
+/** In-process MCP transport — responds in `send()` by pushing onto the queue. */
 class FakeMcpTransport implements McpTransport {
   private readonly queue: JsonRpcMessage[] = [];
   private readonly waiters: Array<(m: JsonRpcMessage | null) => void> = [];
@@ -182,8 +169,6 @@ class FakeMcpTransport implements McpTransport {
     else this.queue.push(msg);
   }
 }
-
-// ---------- tests ----------
 
 describe("McpClient: initialize handshake", () => {
   it("completes initialize and sends notifications/initialized", async () => {
@@ -411,12 +396,7 @@ describe("bridgeMcpTools: result-size cap", () => {
 });
 
 describe("McpClient: abort via AbortSignal", () => {
-  /**
-   * Transport that answers initialize and then stalls on tools/call —
-   * never sends a response. Used to exercise client-side abort:
-   * with no response coming, the promise must still reject promptly
-   * when the signal fires.
-   */
+  /** Stalling transport — initialize ok, tools/call never replies; exercises client-side abort. */
   function makeStallingTransport(): { transport: McpTransport; received: JsonRpcRequest[] } {
     const received: JsonRpcRequest[] = [];
     const queue: JsonRpcMessage[] = [];
@@ -512,11 +492,7 @@ describe("McpClient: abort via AbortSignal", () => {
 });
 
 describe("McpClient: progress notifications", () => {
-  /**
-   * Build a transport where tools/call takes multiple "ticks" before
-   * responding — each tick emits a notifications/progress frame tied
-   * to the token the client sent in `_meta.progressToken`.
-   */
+  /** Multi-tick transport — emits notifications/progress frames keyed off `_meta.progressToken`. */
   function makeProgressTransport(
     progressFrames: Array<{ progress: number; total?: number; message?: string }>,
   ): { transport: McpTransport; received: JsonRpcRequest[] } {

--- a/tests/plan-store.test.ts
+++ b/tests/plan-store.test.ts
@@ -1,9 +1,4 @@
-/**
- * plan-store — load/save the structured plan state next to the
- * session JSONL log so plans survive terminal restarts. Tests cover
- * the roundtrip, malformed-file recovery, and the relativeTime
- * helper that powers the resume notice.
- */
+/** plan-store — roundtrip, malformed-file recovery, relativeTime helper. */
 
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/tests/plan.test.ts
+++ b/tests/plan.test.ts
@@ -1,8 +1,4 @@
-/**
- * Plan Mode — the dispatch-level enforcement (ToolRegistry read-only
- * gate) and the submit_plan tool (PlanProposedError + toToolResult
- * protocol).
- */
+/** Plan Mode — read-only dispatch gate + submit_plan tool's PlanProposedError → tool_result protocol. */
 
 import { describe, expect, it } from "vitest";
 import { ToolRegistry } from "../src/tools.js";

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -1,15 +1,4 @@
-/**
- * Preflight context-size check tests.
- *
- * Reactive auto-compact keys off the PREVIOUS turn's prompt_tokens —
- * too late to save a fresh request whose buildMessages already exceeds
- * the model's context window. The preflight estimates locally before
- * sending and compacts first.
- *
- * We set a tiny context budget on a synthetic model id so modestly-
- * sized test content can trip the 95% threshold without churning
- * through ~120k tokens of fake text.
- */
+/** Preflight context-size check — local estimate + auto-compact before send when reactive compact would arrive too late. */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { DeepSeekClient } from "../src/client.js";

--- a/tests/project-memory.test.ts
+++ b/tests/project-memory.test.ts
@@ -1,7 +1,4 @@
-/**
- * Tests for the `REASONIX.md` project-memory loader. Pure I/O at the
- * edge, so filesystem-backed tests using a temp dir.
- */
+/** REASONIX.md project-memory loader — filesystem-backed tests in a temp dir. */
 
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/tests/prompt-viewport.test.ts
+++ b/tests/prompt-viewport.test.ts
@@ -1,11 +1,4 @@
-/**
- * Tests for the viewport-clipping helpers that PromptInput v2 uses
- * to render each logical line as exactly one visual row.
- *
- * The math has to agree with what Ink/Yoga would have rendered (had
- * we let it wrap), so consumers can reason about cell positions.
- * Wide CJK chars count as 2; ASCII is 1; control chars 0.
- */
+/** PromptInput viewport clipping — logical-line → single-visual-row math (CJK=2, ASCII=1, control=0). */
 
 import { describe, expect, it } from "vitest";
 import {

--- a/tests/resolve.test.ts
+++ b/tests/resolve.test.ts
@@ -1,9 +1,4 @@
-/**
- * Precedence test for `resolveDefaults` — the glue between CLI flags
- * and `~/.reasonix/config.json`. Bugs here would look like "my config
- * doesn't do anything" or "--model was ignored"; both would be
- * invisible to the rest of the test suite, which is why this one exists.
- */
+/** resolveDefaults — flags vs config precedence; silent failures here are user-visible "config does nothing" bugs. */
 
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/tests/semantic-embed-tolerant.test.ts
+++ b/tests/semantic-embed-tolerant.test.ts
@@ -13,11 +13,6 @@ describe("embedAll fault tolerance", () => {
     vi.restoreAllMocks();
   });
 
-  /**
-   * Helper: stub global fetch so we can simulate Ollama responses
-   * without spinning up a real daemon. Returns whatever the per-call
-   * predicate produces.
-   */
   function stubFetch(handler: (callIdx: number) => Promise<Response> | Response) {
     let callIdx = 0;
     globalThis.fetch = vi.fn(async () => {

--- a/tests/server-dashboard.test.ts
+++ b/tests/server-dashboard.test.ts
@@ -1,14 +1,4 @@
-/**
- * Dashboard server tests — drive the real http server on an ephemeral
- * port and assert on responses. Covers:
- *   - Token + CSRF gating (header-only for mutations)
- *   - Each v0.12 endpoint's shape (overview / usage / tools / permissions)
- *   - Permissions CRUD round-trip with a temp config file
- *
- * Skipping browser-driven e2e (Playwright) until v0.13 — for v0.12 the
- * SPA is small enough that endpoint contract + the markup file's
- * existence is enough confidence.
- */
+/** Dashboard server — token/CSRF gates, endpoint shapes, permissions CRUD against a real http server. */
 
 import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -1,8 +1,4 @@
-/**
- * Tests for the Skills store + prefix-index composer. Every test runs
- * against a temp `homeDir` (global scope) and a temp `projectRoot`
- * (project scope) so we never touch the developer's real skill dirs.
- */
+/** Skills store + prefix-index composer — temp homeDir / projectRoot per test, no real skill dirs touched. */
 
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/tests/stdin-reader.test.ts
+++ b/tests/stdin-reader.test.ts
@@ -1,12 +1,4 @@
-/**
- * Unit tests for the raw stdin reader's CSI parser. Drives the
- * machine via `feed()` (the test-only injection point) so we can
- * exercise every state transition without touching real stdin.
- *
- * These tests are the safety net for the input layer: any regression
- * here means a class of keyboard bug returns. The cases below mirror
- * every symptom we shipped a patch for in 0.7.x.
- */
+/** Stdin reader CSI parser — drives the state machine via `feed()`; safety net for the input layer. */
 
 import { describe, expect, it } from "vitest";
 import { type KeyEvent, StdinReader } from "../src/cli/ui/stdin-reader.js";

--- a/tests/subagent.test.ts
+++ b/tests/subagent.test.ts
@@ -1,11 +1,4 @@
-/**
- * Subagent tool — registration, child-loop isolation, fork-registry
- * exclusion rules, error path, abort propagation, plan-mode inheritance.
- *
- * The DeepSeek client is faked so we never hit the network. Same shape
- * as `tests/loop.test.ts` so the wire-level expectations stay aligned
- * with the loop's real behavior.
- */
+/** Subagent tool — registration, child-loop isolation, fork-registry exclusion, abort propagation, plan-mode inheritance. */
 
 import { describe, expect, it, vi } from "vitest";
 import { DeepSeekClient } from "../src/client.js";

--- a/tests/tool-call-ready.test.ts
+++ b/tests/tool-call-ready.test.ts
@@ -1,12 +1,4 @@
-/**
- * Tool-call "ready" progress signal during streaming.
- *
- * Matches the 0.5.19 UX fix: as each tool_call's arguments stream into
- * valid JSON we emit `tool_call_delta` with an incrementing
- * `toolCallReadyCount`, so the UI can render "N ready · building call
- * M" instead of a context-free spinner. Dispatch still happens after
- * the stream ends — this is purely a visibility improvement.
- */
+/** Tool-call ready progress — incrementing `toolCallReadyCount` lets the UI render "N ready · building call M". */
 
 import { describe, expect, it } from "vitest";
 import { looksLikeCompleteJson } from "../src/loop.js";

--- a/tests/tool-summary.test.ts
+++ b/tests/tool-summary.test.ts
@@ -1,8 +1,4 @@
-/**
- * summarizeToolResult — the one-line tool-row renderer that powers
- * compact scrollback. Pure function; lives outside Ink so we can
- * test the per-tool-name and structured-payload branches directly.
- */
+/** summarizeToolResult — pure function; per-tool-name + structured-payload branches. */
 
 import { describe, expect, it } from "vitest";
 import { formatDuration, summarizeToolResult } from "../src/cli/ui/tool-summary.js";

--- a/tests/tools-memory.test.ts
+++ b/tests/tools-memory.test.ts
@@ -1,8 +1,4 @@
-/**
- * Tests for the `remember` / `forget` / `recall_memory` tool surface.
- * Dispatches through ToolRegistry like R1 would, so refusals surface
- * as JSON-encoded `{ error: ... }` strings (matching dispatch semantics).
- */
+/** remember / forget / recall_memory — dispatches through ToolRegistry; refusals surface as JSON-encoded `{ error }`. */
 
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/tests/tools-skills.test.ts
+++ b/tests/tools-skills.test.ts
@@ -1,7 +1,4 @@
-/**
- * Tests for the `run_skill` tool. Uses a temp `homeDir` and optional
- * `projectRoot` so the tool never reads real skill dirs.
- */
+/** run_skill — temp homeDir / projectRoot so the tool never reads real skill dirs. */
 
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -10,12 +7,6 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ToolRegistry } from "../src/tools.js";
 import { registerSkillTools } from "../src/tools/skills.js";
 
-/**
- * Write a skill under `<baseDir>/.reasonix/skills/<name>/SKILL.md`.
- * Callers pass their home tmpdir for global-scope skills, or their
- * projectRoot tmpdir for project-scope skills — the on-disk layout is
- * the same either way, only the base directory differs.
- */
 function writeSkill(baseDir: string, name: string, description: string, body: string): void {
   const dir = join(baseDir, ".reasonix", "skills", name);
   mkdirSync(dir, { recursive: true });
@@ -26,10 +17,6 @@ function writeSkill(baseDir: string, name: string, description: string, body: st
   );
 }
 
-/**
- * Write a skill with arbitrary frontmatter — used for subagent-runAs
- * tests where we need `runAs: subagent` and an optional `model:` line.
- */
 function writeSkillWithFrontmatter(
   baseDir: string,
   name: string,

--- a/tests/update-command.test.ts
+++ b/tests/update-command.test.ts
@@ -1,8 +1,4 @@
-/**
- * Tests for the `reasonix update` command — pure decision function
- * + the CLI orchestrator with every side effect mocked via its
- * test seams. No network, no spawn, no process.exit.
- */
+/** reasonix update — pure planUpdate + orchestrator with every side effect mocked via test seams. */
 
 import { describe, expect, it } from "vitest";
 import { planUpdate, updateCommand } from "../src/cli/commands/update.js";

--- a/tests/usage.test.ts
+++ b/tests/usage.test.ts
@@ -1,14 +1,4 @@
-/**
- * Tests for the usage log + aggregator.
- *
- * Covered:
- *   - appendUsage round-trips (record → file → readUsageLog)
- *   - readUsageLog tolerates malformed tail lines + missing file
- *   - aggregateUsage rolls records into today / week / month / all
- *     using rolling windows against an injected `now`
- *   - bucketCacheHitRatio / bucketSavingsFraction handle zero-denominator
- *   - stats dashboard render contains the expected rows
- */
+/** Usage log + aggregator — append round-trip, malformed-tail tolerance, rolling-window rollups, dashboard render. */
 
 import { appendFileSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/tests/user-memory.test.ts
+++ b/tests/user-memory.test.ts
@@ -1,8 +1,4 @@
-/**
- * Tests for the `~/.reasonix/memory/` store and its prefix-loading
- * composer. All I/O goes through a temp `homeDir` so the suite never
- * touches the developer's actual memory files.
- */
+/** `~/.reasonix/memory/` store + prefix-loading composer — temp homeDir per test. */
 
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/tests/version.test.ts
+++ b/tests/version.test.ts
@@ -1,9 +1,4 @@
-/**
- * Tests for the version module — semver compare, npx detection, and
- * the cached latest-version fetcher. Network is fully mocked: every
- * `fetch` call goes through an injected stub so tests work offline
- * and across CI providers without flake risk.
- */
+/** Version module — semver compare, npx detection, cached latest-version fetcher (mocked fetch). */
 
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/tests/wizard.test.ts
+++ b/tests/wizard.test.ts
@@ -1,12 +1,4 @@
-/**
- * Pure-function tests for the wizard. The Ink rendering is tested
- * manually — vitest + ink-testing-library would be another dev dep for
- * negligible coverage (arrow keys → setIndex, already obvious). What
- * we DO test: the data-transform surface, because the wizard's output
- * goes straight into config.json and then straight into the `--mcp`
- * parser — any bug shows up as "my saved config silently doesn't
- * bridge the server I picked".
- */
+/** Wizard data-transform — buildSpec → parseMcpSpec round-trip; bugs here = silent config-save failures. */
 
 import { describe, expect, it } from "vitest";
 import { buildSpec } from "../src/cli/ui/Wizard.js";


### PR DESCRIPTION
## What

Two interlocking quality gates:

1. **Comment-policy expansion.** `tests/comment-policy.test.ts` previously walked `src/` only. Tests, benchmarks, scripts, and `dashboard/src` were policy-free zones — which let multi-paragraph module-essay headers and stale phase-narrative comments accumulate everywhere except `src/`. Expanded the test's roots to `[src, tests, benchmarks, scripts, dashboard/src]` and cleaned the 146 violations that surfaced. Pre-push now blocks new ones.

2. **Architecture invariants test.** New `tests/architecture-invariants.test.ts` promotes two properties from RFC #87's spike (Exp 1) into permanent regression:
   - reducer projection determinism — identical events → byte-identical messages, regardless of timestamp / id / counter state
   - message-level append-only across turn boundaries — every cut is a strict prefix of any later cut

   These are the load-bearing properties of the v0.14 event kernel and the forkable-sessions feature. Encoding them as tests means any reducer or event schema change that violates them fails CI, not a future spike.

## Why

The comment policy was being enforced by reminders ("please follow the comment rules") rather than by the test gate, because the gate didn't actually scan most code dirs. Promoting the spike's invariants to permanent tests does the same thing for the kernel — turning a one-shot validation into a load-bearing CI signal.

Both moves are pure quality / observability — no behavior change in `src/`.

## How to verify

```
npm run verify
```

- 105 test files, 1728 tests pass
- comment-policy now scans 361 files (up from ~200)
- architecture invariants add 6 tests across 3 describe blocks

## Checklist

- [x] `npm run verify` passes locally
- [x] No `Co-Authored-By: Claude` trailer
- [x] No new `*.md` documentation files
- [x] CHANGELOG: not updated — this is internal quality plumbing, not user-visible
