### PR TITLE
docs(contrib): drop CHANGELOG-per-PR rule

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,6 +15,6 @@
 ## Checklist
 
 - [ ] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
-- [ ] CHANGELOG updated under `## [Unreleased]` if user-visible
 - [ ] No `Co-Authored-By: Claude` trailer in commits
-- [ ] Comments follow CLAUDE.md (no module-essay headers, no incident history)
+- [ ] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
+- [ ] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,6 @@
 All notable changes to Reasonix. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-- feat(code): `--system-append` / `--system-append-file` CLI options append user instructions to the code system prompt without replacing the default prompt. Both can be used together (inline first, then file contents). File read errors surface with their OS error code.
-
 ## [0.17.1] — 2026-04-29
 
 **Headline:** Fix a render crash in the dashboard's Editor that triggered

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,8 +121,10 @@ wrapper — don't fork a local table.
 - `npm run verify` must pass locally (lint + typecheck + tests +
   comment-policy gate). Pre-push hook runs this; CI runs it on
   Node 20 and 22.
-- Update `CHANGELOG.md` under `## [Unreleased]` if user-visible.
-  Maintainers move it under a versioned section at release time.
+- Don't touch `CHANGELOG.md` — release notes are written by the
+  maintainer at release time, drawn from commit history. PR
+  descriptions are the authoritative record while the work is in
+  flight.
 
 ## Code review
 
@@ -139,7 +141,8 @@ None of this is personal — it's how the codebase stays small.
 ## Releasing (maintainers)
 
 1. Bump `package.json` version.
-2. Move `## [Unreleased]` → `## [X.Y.Z] — <date>` in `CHANGELOG.md`.
+2. Add `## [X.Y.Z] — <date>` to `CHANGELOG.md` with a hand-written
+   summary drawn from `git log` since the prior tag.
 3. `chore(release): X.Y.Z — <one-line summary>` commit.
 4. `git tag -a vX.Y.Z -m "..."`, push commit + tag.
 5. Wait for CI green, then `npm publish`.


### PR DESCRIPTION
## What

Remove the per-PR CHANGELOG entry rule. Three coupled changes:

1. **`CONTRIBUTING.md`** — replaces "update CHANGELOG.md under `[Unreleased]`" with "don't touch CHANGELOG.md". The Releasing section now says the maintainer hand-writes release notes from `git log` at release time.
2. **`PULL_REQUEST_TEMPLATE.md`** — replaces the "CHANGELOG updated" checkbox with the inverse: "no edits to CHANGELOG.md".
3. **`CHANGELOG.md`** — drops the lingering `[Unreleased]` section. The `--system-append` feature it described will land in the next versioned section, written by me at release time.

## Why

PR-time CHANGELOG entries had two failure modes in practice:

- **Pile-up.** Releases since 0.18 didn't roll `[Unreleased]` forward, so entries accumulated under one header that never made it into a versioned section. CHANGELOG drifted from package.json by two minors.
- **Soft conflicts.** Concurrent PRs each branched off main and added an entry under `[Unreleased]`. Both diffs touched the same line range; merging the second produced two `[Unreleased]` headers stacked. PR #91 (still open) is the latest example.

PR descriptions are the authoritative record while work is in flight. Release notes are better written once with full context than in pieces during review. Keeps every contributor PR purely code, no maintenance overhead from the CHANGELOG dance.

## How to verify

```
npm run verify
```

No code change; passes are unchanged.

## Follow-up

After this lands, I'll comment on PR #91 asking the contributor to drop the CHANGELOG portion of his diff and rebase off the new main.

## Checklist

- [x] `npm run verify` passes locally
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md
- [x] No edits to `CHANGELOG.md` beyond removing the soon-to-be-stale `[Unreleased]` section
