### PR TITLE
fix(mcp): allow hyphens in MCP spec name prefix regex

### DIFF
--- a/src/mcp/spec.ts
+++ b/src/mcp/spec.ts
@@ -28,7 +28,7 @@ export interface StreamableHttpMcpSpec {
 
 export type McpSpec = StdioMcpSpec | SseMcpSpec | StreamableHttpMcpSpec;
 
-const NAME_PREFIX = /^([a-zA-Z_][a-zA-Z0-9_]*)=(.*)$/;
+const NAME_PREFIX = /^([a-zA-Z_][a-zA-Z0-9_-]*)=(.*)$/;
 const HTTP_URL = /^https?:\/\//i;
 const STREAMABLE_PREFIX = /^streamable\+(https?:\/\/.+)$/i;
 

--- a/tests/mcp-spec.test.ts
+++ b/tests/mcp-spec.test.ts
@@ -67,6 +67,19 @@ describe("parseMcpSpec: stdio", () => {
     expect(s.name).toBeNull();
     expect(s.command).toBe("2fs=cmd");
   });
+
+  it("allows hyphens in the name (kebab-case is the MCP ecosystem norm)", () => {
+    const spec = parseMcpSpec("sage-wiki=npx -y @scope/sage-wiki");
+    if (spec.transport !== "stdio") throw new Error("unreachable");
+    expect(spec.name).toBe("sage-wiki");
+    expect(spec.command).toBe("npx");
+    expect(spec.args).toEqual(["-y", "@scope/sage-wiki"]);
+    // Leading hyphen → not a valid identifier → whole thing is command
+    const lead = parseMcpSpec("-fs=cmd");
+    if (lead.transport !== "stdio") throw new Error("unreachable");
+    expect(lead.name).toBeNull();
+    expect(lead.command).toBe("-fs=cmd");
+  });
 });
 
 describe("parseMcpSpec: sse", () => {


### PR DESCRIPTION
Closes #97.

## What

The NAME_PREFIX regex in src/mcp/spec.ts excluded hyphens, so kebab-case server names like sage-wiki failed the prefix match. The entire string including the = was treated as a raw command path.

## Why

The MCP ecosystem standardizes on kebab-case names (e.g. @modelcontextprotocol/server-filesystem). One character added to the regex character class.

## How to verify

`
npm run verify
`

## Checklist

- [x] npm run verify passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No Co-Authored-By: Claude trailer in commits
- [x] Comments follow CLAUDE.md (no module-essay headers, no incident history)