### PR TITLE
chore(ci): drop Node 20 from CI matrix; bump engines to >=22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ["20", "22"]
+        node: ["22"]
     steps:
       - uses: actions/checkout@v4
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ npm install
 npm run dev          # tsx src/cli/index.ts — live source
 ```
 
-Node ≥ 20.10. No global install needed during development.
+Node ≥ 22. No global install needed during development.
 
 For stack, layout, scripts, see [`REASONIX.md`](./REASONIX.md).
 
@@ -120,7 +120,7 @@ wrapper — don't fork a local table.
 - Branch off `main`. One logical change per PR.
 - `npm run verify` must pass locally (lint + typecheck + tests +
   comment-policy gate). Pre-push hook runs this; CI runs it on
-  Node 20 and 22.
+  Node 22.
 - Don't touch `CHANGELOG.md` — release notes are written by the
   maintainer at release time, drawn from commit history. PR
   descriptions are the authoritative record while the work is in

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ src/users.ts
 ▸ 1 pending edit · /apply to write, /discard to drop
 ```
 
-Edits stay in memory until you type `/apply` — nothing hits disk by default. Requires Node ≥ 20.10. Tested on macOS, Linux, and Windows (PowerShell, Git Bash, Windows Terminal).
+Edits stay in memory until you type `/apply` — nothing hits disk by default. Requires Node ≥ 22. Tested on macOS, Linux, and Windows (PowerShell, Git Bash, Windows Terminal).
 
 ### Appending code-mode system instructions
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -49,7 +49,7 @@ src/users.ts
 ▸ 1 处待应用编辑 · /apply 写入 · /discard 丢弃
 ```
 
-不 `/apply`，磁盘不会被改。要求 Node ≥ 20.10。已在 macOS、Linux、Windows（PowerShell · Git Bash · Windows Terminal）测过。
+不 `/apply`，磁盘不会被改。要求 Node ≥ 22。已在 macOS、Linux、Windows（PowerShell · Git Bash · Windows Terminal）测过。
 
 ---
 

--- a/REASONIX.md
+++ b/REASONIX.md
@@ -1,7 +1,7 @@
 # Reasonix — working knowledge
 
 TypeScript project. DeepSeek-native coding agent, cache-first loop.
-MIT-licensed. Node ≥20.10 required.
+MIT-licensed. Node ≥22 required.
 
 ## Stack
 

--- a/docs/i18n.js
+++ b/docs/i18n.js
@@ -69,7 +69,7 @@
       "qs.step3.body":
         "The model proposes edits as SEARCH/REPLACE blocks — nothing hits disk until you <code>/apply</code>.",
       "qs.req":
-        "Requires Node ≥ 20.10. macOS, Linux, Windows (PowerShell · Git Bash · Windows Terminal). Press <kbd>Esc</kbd> anytime to abort; <code>/help</code> for the full command list.",
+        "Requires Node ≥ 22. macOS, Linux, Windows (PowerShell · Git Bash · Windows Terminal). Press <kbd>Esc</kbd> anytime to abort; <code>/help</code> for the full command list.",
 
       "feat.title": "In the box",
       "feat.code.title": "Pair programmer mode",
@@ -196,7 +196,7 @@
       "qs.step3.body":
         "模型会以 SEARCH/REPLACE 块的形式提出编辑——你不 <code>/apply</code>，磁盘不会被改。",
       "qs.req":
-        "需要 Node ≥ 20.10。支持 macOS、Linux、Windows（PowerShell · Git Bash · Windows Terminal）。任何时候按 <kbd>Esc</kbd> 中断；<code>/help</code> 查看完整命令。",
+        "需要 Node ≥ 22。支持 macOS、Linux、Windows（PowerShell · Git Bash · Windows Terminal）。任何时候按 <kbd>Esc</kbd> 中断；<code>/help</code> 查看完整命令。",
 
       "feat.title": "开箱即用",
       "feat.code.title": "结对编程模式",

--- a/docs/index.html
+++ b/docs/index.html
@@ -222,7 +222,7 @@ npx reasonix code</code></pre>
           </ol>
 
           <p class="req" data-i18n="qs.req">
-            Requires Node ≥ 20.10. macOS, Linux, Windows (PowerShell · Git Bash · Windows
+            Requires Node ≥ 22. macOS, Linux, Windows (PowerShell · Git Bash · Windows
             Terminal). Press <kbd>Esc</kbd> anytime to abort; <code>/help</code> for the
             full command list.
           </p>

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "homepage": "https://github.com/esengine/reasonix#readme",
   "engines": {
-    "node": ">=20.10"
+    "node": ">=22"
   },
   "dependencies": {
     "cli-highlight": "^2.1.11",

--- a/tests/mcp-integration.test.ts
+++ b/tests/mcp-integration.test.ts
@@ -7,7 +7,7 @@ import { StdioTransport } from "../src/mcp/stdio.js";
 import { ToolRegistry } from "../src/tools.js";
 
 // Spawning `tsx` directly needs a cross-platform approach. `node --import tsx`
-// works everywhere Node 20+ is installed (which is our engines target) and
+// works everywhere Node 22+ is installed (which is our engines target) and
 // avoids the Windows `.cmd` resolution gotcha in child_process.spawn.
 const NODE_CMD = process.execPath;
 const DEMO_SERVER_ARGS = ["--import", "tsx", "examples/mcp-server-demo.ts"];

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -7,7 +7,7 @@ export default defineConfig([
     dts: true,
     clean: true,
     sourcemap: true,
-    target: "node20",
+    target: "node22",
     outDir: "dist",
   },
   {
@@ -16,7 +16,7 @@ export default defineConfig([
     dts: false,
     clean: false,
     sourcemap: true,
-    target: "node20",
+    target: "node22",
     outDir: "dist/cli",
     banner: { js: "#!/usr/bin/env node" },
   },


### PR DESCRIPTION
## Summary

Node 20 reached end-of-life on 2026-04-30. The CI matrix kept it green for users on the prior LTS; with EOL passed, the verification cost is no longer paying back.

- `engines.node`: `">=20.10"` → `">=22"`
- CI matrix: `["20", "22"]` → `["22"]`
- `tsup` target: `node20` → `node22`
- README / README.zh-CN / CONTRIBUTING / REASONIX / docs: text bumped to `Node ≥ 22`

## Test plan

- [x] `npm run verify` green locally (1730 tests, lint, typecheck, build)
- [x] CI green on the single remaining `build (node 22)` job
- [ ] Confirm `engines` warning appears for users on Node 20 (npm prints it but doesn't block install)