### PR TITLE
docs(readme): replace hardcoded good-first-issue list with label link

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,14 +141,7 @@ Two layers: project-scoped `REASONIX.md` (committed, repo conventions) and user-
 
 ## Contributing
 
-Reasonix is solo-maintained but designed to grow. Scoped starter issues:
-
-- [#15 — `reasonix doctor --json` flag](https://github.com/esengine/reasonix/issues/15) · CLI · 2-3h
-- [#16 — `web_search` / `web_fetch` actionable error messages](https://github.com/esengine/reasonix/issues/16) · tools · 2-3h
-- [#17 — Slash command "did you mean?" suggestion](https://github.com/esengine/reasonix/issues/17) · TUI · 2-3h
-- [#18 — Unit tests for `clipboard.ts`](https://github.com/esengine/reasonix/issues/18) · tests · 2-3h
-
-Each has background, code pointers, acceptance criteria, hints. Browse all [`good first issue`](https://github.com/esengine/reasonix/labels/good%20first%20issue)s.
+Reasonix is solo-maintained but designed to grow. Scoped starter tickets — each with background, code pointers, acceptance criteria, and hints — live under the [`good first issue`](https://github.com/esengine/reasonix/labels/good%20first%20issue) label. Pick anything open.
 
 **Open Discussions** — opinions wanted:
 - [#20 · CLI / TUI design](https://github.com/esengine/reasonix/discussions/20) — what's broken, what's missing, what would you change?

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -129,14 +129,7 @@ src/users.ts
 
 ## 参与贡献
 
-Reasonix 现在主要是单人维护，但是为协作设计的。给新手准备的几个 issue：
-
-- [#15 — 给 `reasonix doctor` 加 `--json` flag](https://github.com/esengine/reasonix/issues/15) · CLI · 2-3 小时
-- [#16 — 让 `web_search` / `web_fetch` 的错误信息可执行](https://github.com/esengine/reasonix/issues/16) · tools · 2-3 小时
-- [#17 — Slash 命令的 "did you mean?" 建议](https://github.com/esengine/reasonix/issues/17) · TUI · 2-3 小时
-- [#18 — `clipboard.ts` 的单元测试](https://github.com/esengine/reasonix/issues/18) · 测试 · 2-3 小时
-
-每个 issue 都有背景说明、代码定位、验收标准、提示。所有 [`good first issue`](https://github.com/esengine/reasonix/labels/good%20first%20issue) 在这。
+Reasonix 现在主要是单人维护，但是为协作设计的。给新手准备的入门 issue —— 每个都带背景说明、代码定位、验收标准、提示 —— 全部挂在 [`good first issue`](https://github.com/esengine/reasonix/labels/good%20first%20issue) 标签下。挑任意一个还没人认领的就行。
 
 **正在征集意见的 Discussions：**
 - [#20 · CLI / TUI 设计](https://github.com/esengine/reasonix/discussions/20) — 哪里坏了、哪里少东西、哪里你会怎么改？


### PR DESCRIPTION
## Summary

The README had a hardcoded list of starter tickets (#15–#18). #18 was closed weeks ago but still listed, which is the predictable failure mode: every closed ticket requires a README edit. Replace the four bullet points with a single sentence pointing at the [`good first issue`](https://github.com/esengine/reasonix/labels/good%20first%20issue) label filter — always fresh, zero maintenance.

The closing line that existed at the bottom of the original block was the better signal anyway; just promoted it to the only line.

Both `README.md` and `README.zh-CN.md` updated.

## Test plan

- [x] Visual diff in markdown preview
- [x] Label-filter URL resolves to current open `good first issue` set (#15, #16, #17 as of merge)