### PR TITLE
feat(mcp): lifecycle line cards match design doc §37 (Stage A of #105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,57 @@
 All notable changes to Reasonix. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.0] — 2026-05-02
+
+**Headline:** Drops Node 20 support (EOL'd 2026-04-30). The README has been
+overhauled with hero-terminal / hero-stats / feature-grid SVGs that match
+the design-doc palette, plus contributor-avatar grid, Code of Conduct, and
+SECURITY policy.
+
+**Breaking:**
+
+- `engines.node` bumped from `>=20.10` to `>=22`. Node 20 reached
+  end-of-life on 2026-04-30; `npm install reasonix` on Node 20 will now
+  print an `EBADENGINE` warning. Tested CI surface trimmed to a single
+  Node 22 job. (#98)
+
+**Fixes:**
+
+- fix(code): `reasonix code` now bridges MCP servers from
+  `~/.reasonix/config.json`, matching `reasonix chat` behaviour.
+  Previously any servers defined in config were silently skipped in
+  code-mode sessions. (#91)
+- fix(mcp): `NAME_PREFIX` regex in `parseMcpSpec` accepts hyphens, so
+  kebab-case server names like `sage-wiki=npx -y @scope/sage-wiki`
+  parse correctly. Previously the entire string was treated as a raw
+  command path. Regression test in `tests/mcp-spec.test.ts`. (#96)
+
+**Docs / project hygiene:**
+
+- docs(readme): introduce three new SVG assets that anchor the README's
+  visual rhythm to the design-doc palette — `hero-terminal.svg`
+  (faithful to `formatPendingPreview` unified-diff output),
+  `hero-stats.svg` (94% / ~30× / MIT), and `feature-grid.svg` (six-card
+  3×2 grid). Bilingual `*.zh-CN.svg` siblings ship for the zh README.
+  All SVGs live under `docs/assets/`. (#102)
+- docs(readme): designer pass — drop redundant `# Reasonix` H1 (the
+  logo wordmark says it), drop the duplicated tagline, center the
+  badges + description under one column, trim the comparison table
+  to differentiating rows only, drop the `--system-append` doc
+  subsection (lives in `--help`). (#102)
+- docs: design mockups (`agent-dashboard.html`, `agent-tui-terminal.html`)
+  moved into `docs/design/` so README links resolve to the rendered
+  GitHub Pages page instead of HTML source view. (#102)
+- docs(readme): replace the hardcoded `good-first-issue` ticket list
+  with a single label-filter link — auto-fresh as tickets close. (#99)
+- docs(readme): drop "DeepSeek free credit on signup" claim from
+  README, website, TUI Setup / Wizard prompts — perk no longer
+  offered. (#102)
+- docs(readme): add `contrib.rocks` contributor-avatar grid; add
+  GitHub stars + Discussions badges. (#102)
+- docs: add `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1) and
+  `SECURITY.md` (private-disclosure policy with explicit scope). (#102)
+
 ## [0.17.1] — 2026-04-29
 
 **Headline:** Fix a render crash in the dashboard's Editor that triggered

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reasonix",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "DeepSeek-native coding agent: cache-first loop, flash-first cost control, tool-call repair.",
   "type": "module",
   "bin": {

--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -23,6 +23,7 @@ import { App } from "../ui/App.js";
 import { SessionPicker } from "../ui/SessionPicker.js";
 import { Setup } from "../ui/Setup.js";
 import { KeystrokeProvider } from "../ui/keystroke-context.js";
+import { formatMcpLifecycleEvent } from "../ui/mcp-lifecycle.js";
 import type { McpServerSummary } from "../ui/slash.js";
 
 export interface ProgressInfo {
@@ -205,8 +206,12 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
   if (requestedSpecs.length > 0) {
     if (!tools) tools = new ToolRegistry();
     for (const raw of requestedSpecs) {
+      let label = "anon";
       try {
         const spec = parseMcpSpec(raw);
+        label = spec.name ?? "anon";
+        process.stderr.write(`${formatMcpLifecycleEvent({ state: "handshake", name: label })}\n`);
+        const t0 = Date.now();
         const prefix = spec.name
           ? `${spec.name}_`
           : requestedSpecs.length === 1 && opts.mcpPrefix
@@ -225,17 +230,13 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
           namePrefix: prefix,
           onProgress: (info) => progressSink.current?.(info),
         });
-        // Collect resources + prompts once at startup so the /mcp
-        // slash can render them synchronously. Servers that don't
-        // support these fall through as `{supported: false}` instead
-        // of throwing — see inspectMcpServer.
+        // Inspect collects resources + prompts once so `/mcp` can render them
+        // synchronously. Servers that don't support these fall through as
+        // `{supported: false}` instead of throwing.
         let report: InspectionReport;
         try {
           report = await inspectMcpServer(mcp);
         } catch {
-          // If the inspect call itself fails (rare — shouldn't happen
-          // since inspectMcpServer swallows -32601), synthesize a
-          // minimal report so `/mcp` still has something to render.
           report = {
             protocolVersion: mcp.protocolVersion,
             serverInfo: mcp.serverInfo,
@@ -246,13 +247,18 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
             elapsedMs: 0,
           };
         }
-        const label = spec.name ?? "anon";
-        const source =
-          spec.transport === "sse" || spec.transport === "streamable-http"
-            ? spec.url
-            : `${spec.command} ${spec.args.join(" ")}`;
+        const ms = Date.now() - t0;
+        const resourceCount = report.resources.supported ? report.resources.items.length : 0;
+        const promptCount = report.prompts.supported ? report.prompts.items.length : 0;
         process.stderr.write(
-          `▸ MCP[${label}]: ${bridge.registeredNames.length} tool(s) from ${source}\n`,
+          `${formatMcpLifecycleEvent({
+            state: "connected",
+            name: label,
+            tools: bridge.registeredNames.length,
+            resources: resourceCount,
+            prompts: promptCount,
+            ms,
+          })}\n`,
         );
         clients.push(mcp);
         successfulSpecs.push(raw);
@@ -265,14 +271,13 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
         });
       } catch (err) {
         // Per-server failure is non-fatal: one broken server shouldn't
-        // kill a chat that has working servers configured. We record
-        // the failure, show a visible warning, and keep going. User
-        // can fix via `reasonix setup` (unchecks the broken entry)
-        // without losing their other servers.
+        // kill a chat that has working servers configured. Recover by
+        // recording the failure and continuing; user fixes via `reasonix
+        // setup` without losing their other servers.
         const reason = (err as Error).message;
         failedSpecs.push({ spec: raw, reason });
         process.stderr.write(
-          `▸ MCP setup SKIPPED for "${raw}": ${reason}\n  → this server will not be available this session. Run \`reasonix setup\` to remove it, or fix the underlying issue (missing npm package, network, etc.).\n`,
+          `${formatMcpLifecycleEvent({ state: "failed", name: label, reason })}\n  → run \`reasonix setup\` to remove this entry, or fix the underlying issue (missing npm package, network, etc.).\n`,
         );
       }
     }

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -13,6 +13,7 @@ import { StreamableHttpTransport } from "../../mcp/streamable-http.js";
 import { appendUsage } from "../../telemetry/usage.js";
 import { ToolRegistry } from "../../tools.js";
 import { openTranscriptFile, recordFromLoopEvent, writeRecord } from "../../transcript/log.js";
+import { formatMcpLifecycleEvent } from "../ui/mcp-lifecycle.js";
 
 export interface RunOptions {
   task: string;
@@ -78,8 +79,12 @@ export async function runCommand(opts: RunOptions): Promise<void> {
   if (requestedSpecs.length > 0) {
     tools = new ToolRegistry();
     for (const raw of requestedSpecs) {
+      let label = "anon";
       try {
         const spec = parseMcpSpec(raw);
+        label = spec.name ?? "anon";
+        process.stderr.write(`${formatMcpLifecycleEvent({ state: "handshake", name: label })}\n`);
+        const t0 = Date.now();
         const prefix = spec.name
           ? `${spec.name}_`
           : requestedSpecs.length === 1 && opts.mcpPrefix
@@ -94,12 +99,13 @@ export async function runCommand(opts: RunOptions): Promise<void> {
         const mcp = new McpClient({ transport });
         await mcp.initialize();
         const bridge = await bridgeMcpTools(mcp, { registry: tools, namePrefix: prefix });
-        const source =
-          spec.transport === "sse" || spec.transport === "streamable-http"
-            ? spec.url
-            : `${spec.command} ${spec.args.join(" ")}`;
         process.stderr.write(
-          `▸ MCP[${spec.name ?? "anon"}]: ${bridge.registeredNames.length} tool(s) from ${source}\n`,
+          `${formatMcpLifecycleEvent({
+            state: "connected",
+            name: label,
+            tools: bridge.registeredNames.length,
+            ms: Date.now() - t0,
+          })}\n`,
         );
         clients.push(mcp);
         successCount++;
@@ -109,7 +115,7 @@ export async function runCommand(opts: RunOptions): Promise<void> {
         // fails the whole run over a side-concern tool the task might
         // not even touch.
         process.stderr.write(
-          `▸ MCP setup SKIPPED for "${raw}": ${(err as Error).message}\n  → run \`reasonix setup\` to remove broken entries from your saved config.\n`,
+          `${formatMcpLifecycleEvent({ state: "failed", name: label, reason: (err as Error).message })}\n  → run \`reasonix setup\` to remove broken entries from your saved config.\n`,
         );
       }
     }

--- a/src/cli/ui/mcp-lifecycle.ts
+++ b/src/cli/ui/mcp-lifecycle.ts
@@ -1,0 +1,40 @@
+/** Formats one-liner MCP lifecycle events per `docs/design/agent-tui-terminal.html` §37. */
+
+export type McpLifecycleEvent =
+  | { state: "handshake"; name: string }
+  | {
+      state: "connected";
+      name: string;
+      tools: number;
+      resources?: number;
+      prompts?: number;
+      ms: number;
+    }
+  | { state: "failed"; name: string; reason: string };
+
+const STATE: Record<McpLifecycleEvent["state"], { glyph: string; label: string }> = {
+  handshake: { glyph: "↻", label: "handshake…" },
+  connected: { glyph: "✓", label: "connected" },
+  failed: { glyph: "✖", label: "failed" },
+};
+
+const NAME_COL = 22;
+const STATE_COL = 15;
+
+export function formatMcpLifecycleEvent(ev: McpLifecycleEvent): string {
+  const { glyph, label } = STATE[ev.state];
+  const namePart = `MCP · ${ev.name}`;
+  const namePad = " ".repeat(Math.max(1, NAME_COL - namePart.length));
+  const stateField = `${glyph} ${label}`.padEnd(STATE_COL);
+  return `⌘ ${namePart}${namePad}${stateField}${describeDetail(ev)}`;
+}
+
+function describeDetail(ev: McpLifecycleEvent): string {
+  if (ev.state === "handshake") return "initialise → tools/list → resources/list";
+  if (ev.state === "failed") return ev.reason;
+  const parts: string[] = [`${ev.tools} tools`];
+  if (ev.resources && ev.resources > 0) parts.push(`${ev.resources} resources`);
+  if (ev.prompts && ev.prompts > 0) parts.push(`${ev.prompts} prompts`);
+  parts.push(`${ev.ms}ms`);
+  return parts.join(" · ");
+}

--- a/tests/mcp-lifecycle.test.ts
+++ b/tests/mcp-lifecycle.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { formatMcpLifecycleEvent } from "../src/cli/ui/mcp-lifecycle.js";
+
+describe("formatMcpLifecycleEvent", () => {
+  it("renders the handshake state", () => {
+    expect(formatMcpLifecycleEvent({ state: "handshake", name: "notion" })).toBe(
+      "⌘ MCP · notion          ↻ handshake…   initialise → tools/list → resources/list",
+    );
+  });
+
+  it("renders the connected state with full counts", () => {
+    expect(
+      formatMcpLifecycleEvent({
+        state: "connected",
+        name: "notion",
+        tools: 12,
+        resources: 8,
+        prompts: 0,
+        ms: 142,
+      }),
+    ).toBe("⌘ MCP · notion          ✓ connected    12 tools · 8 resources · 142ms");
+  });
+
+  it("omits resource/prompt counts when zero", () => {
+    expect(formatMcpLifecycleEvent({ state: "connected", name: "fs", tools: 5, ms: 88 })).toBe(
+      "⌘ MCP · fs              ✓ connected    5 tools · 88ms",
+    );
+  });
+
+  it("renders the failed state", () => {
+    expect(
+      formatMcpLifecycleEvent({
+        state: "failed",
+        name: "fs-local",
+        reason: "ENOENT: server binary missing",
+      }),
+    ).toBe("⌘ MCP · fs-local        ✖ failed       ENOENT: server binary missing");
+  });
+
+  it("keeps a minimum 1-space gap when the name overflows the alignment column", () => {
+    const out = formatMcpLifecycleEvent({
+      state: "connected",
+      name: "very-long-server-name-overflow",
+      tools: 3,
+      ms: 50,
+    });
+    expect(out.startsWith("⌘ MCP · very-long-server-name-overflow ✓")).toBe(true);
+  });
+
+  it("each rendered line is a single newline-free string", () => {
+    const samples = [
+      formatMcpLifecycleEvent({ state: "handshake", name: "x" }),
+      formatMcpLifecycleEvent({ state: "connected", name: "x", tools: 1, ms: 1 }),
+      formatMcpLifecycleEvent({ state: "failed", name: "x", reason: "boom" }),
+    ];
+    for (const s of samples) expect(s).not.toContain("\n");
+  });
+});


### PR DESCRIPTION
Stage A of #105.

## What

Replace the two ad-hoc startup strings in `chat.tsx` and `run.ts` with the lifecycle vocabulary documented in `docs/design/agent-tui-terminal.html` §37. This stage wires the three states that already fire today; B and C will wire the rest.

**Before:**

```
▸ MCP[notion]: 12 tool(s) from npx -y @modelcontextprotocol/server-...
▸ MCP setup SKIPPED for "fs": ENOENT
  → run `reasonix setup` ...
```

**After:**

```
⌘ MCP · notion          ↻ handshake…   initialise → tools/list → resources/list
⌘ MCP · notion          ✓ connected    12 tools · 8 resources · 142ms
⌘ MCP · fs              ✖ failed       ENOENT: server binary missing
  → run `reasonix setup` ...
```

## Why

The runtime drifted from the design doc. This stage closes the gap on lifecycle vocabulary and lays the formatter that Stage B (browser modal) and Stage C (disable / enable / reconnect / slow-toast) will reuse.

## Touch

- New `src/cli/ui/mcp-lifecycle.ts` exporting a typed `formatMcpLifecycleEvent` so chat / run / future surfaces share one formatter.
- `src/cli/commands/chat.tsx`: emit `handshake` before `mcp.initialize()`, emit `connected` after bridge + inspect with resource / prompt counts and elapsed ms, emit `failed` in the catch path.
- `src/cli/commands/run.ts`: same pattern.
- `tests/mcp-lifecycle.test.ts`: 6 cases pinning the layout (column alignment for short/long names, minimum-gap fallback, no embedded newlines).

## Test plan

- [x] `npm run verify` passes locally (1737 tests, lint, typecheck, build)
- [x] No consumers of the old `▸ MCP[...]` / `▸ MCP setup SKIPPED` format outside the two files I'm editing (greppable)
- [ ] Eyeball `npm run dev chat --mcp ...` startup against the design §37 mockup