### PR TITLE
feat(mcp): /mcp opens an interactive browser modal (Stage B of #105)

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -74,6 +74,7 @@ import { openTranscriptFile, recordFromLoopEvent, writeRecord } from "../../tran
 import { AtMentionSuggestions } from "./AtMentionSuggestions.js";
 import { ChoiceConfirm, type ChoiceConfirmChoice } from "./ChoiceConfirm.js";
 import { EditConfirm, type EditReviewChoice } from "./EditConfirm.js";
+import { McpBrowser } from "./McpBrowser.js";
 import { type CheckpointChoice, PlanCheckpointConfirm } from "./PlanCheckpointConfirm.js";
 import { PlanConfirm, type PlanConfirmChoice } from "./PlanConfirm.js";
 import { PlanRefineInput } from "./PlanRefineInput.js";
@@ -545,6 +546,8 @@ function AppInner({
   /** True while the SessionPicker is open mid-chat (triggered by `/sessions`). */
   const [pendingSessionsPicker, setPendingSessionsPicker] = useState(false);
   const [sessionsPickerList, setSessionsPickerList] = useState<ReturnType<typeof listSessions>>([]);
+  /** True while the McpBrowser modal is open (triggered by `/mcp`). */
+  const [pendingMcpBrowser, setPendingMcpBrowser] = useState(false);
   // Stashed plan + intent while the user types free-form feedback
   // (refinement or last instructions on approve). When the picker
   // returns "refine" or "approve", we defer the loop-resume and show
@@ -1258,6 +1261,7 @@ function AppInner({
       !pendingPlan &&
       !pendingReviseEditor &&
       !pendingSessionsPicker &&
+      !pendingMcpBrowser &&
       !stagedInput &&
       !pendingEditReview &&
       !walkthroughActive &&
@@ -1293,6 +1297,7 @@ function AppInner({
       !pendingPlan &&
       !pendingReviseEditor &&
       !pendingSessionsPicker &&
+      !pendingMcpBrowser &&
       !stagedInput &&
       !pendingEditReview &&
       !walkthroughActive &&
@@ -2231,6 +2236,11 @@ function AppInner({
           promptHistory.current.push(text);
           return;
         }
+        if (result.openMcpBrowser) {
+          setPendingMcpBrowser(true);
+          promptHistory.current.push(text);
+          return;
+        }
         const outcome = applySlashResult(result, {
           log,
           stdoutWrite: (chunk) => stdout?.write(chunk),
@@ -3158,6 +3168,7 @@ function AppInner({
           !!pendingPlan ||
           !!pendingReviseEditor ||
           pendingSessionsPicker ||
+          pendingMcpBrowser ||
           !!pendingShell ||
           !!pendingEditReview ||
           walkthroughActive ||
@@ -3201,6 +3212,7 @@ function AppInner({
             !pendingPlan &&
             !pendingReviseEditor &&
             !pendingSessionsPicker &&
+            !pendingMcpBrowser &&
             !stagedInput &&
             !pendingEditReview &&
             !pendingCheckpoint &&
@@ -3213,6 +3225,7 @@ function AppInner({
             !pendingPlan &&
             !pendingReviseEditor &&
             !pendingSessionsPicker &&
+            !pendingMcpBrowser &&
             !stagedInput &&
             !pendingEditReview &&
             !pendingCheckpoint &&
@@ -3225,6 +3238,7 @@ function AppInner({
             !pendingPlan &&
             !pendingReviseEditor &&
             !pendingSessionsPicker &&
+            !pendingMcpBrowser &&
             !stagedInput &&
             !pendingEditReview &&
             !pendingCheckpoint &&
@@ -3239,6 +3253,7 @@ function AppInner({
             !pendingPlan &&
             !pendingReviseEditor &&
             !pendingSessionsPicker &&
+            !pendingMcpBrowser &&
             !stagedInput &&
             !pendingEditReview &&
             !pendingCheckpoint &&
@@ -3261,6 +3276,7 @@ function AppInner({
             !pendingPlan &&
             !pendingReviseEditor &&
             !pendingSessionsPicker &&
+            !pendingMcpBrowser &&
             !stagedInput &&
             !pendingEditReview &&
             !pendingCheckpoint &&
@@ -3364,6 +3380,12 @@ function AppInner({
                   setPendingSessionsPicker(false);
                 }
               }}
+            />
+          ) : pendingMcpBrowser ? (
+            <McpBrowser
+              servers={mcpServers ?? []}
+              configPath={defaultConfigPath()}
+              onClose={() => setPendingMcpBrowser(false)}
             />
           ) : pendingPlan ? (
             <PlanConfirm

--- a/src/cli/ui/McpBrowser.tsx
+++ b/src/cli/ui/McpBrowser.tsx
@@ -1,0 +1,94 @@
+/** `/mcp` browser modal — keyboard-driven server list per design §24. */
+
+import { Box, Text } from "ink";
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React, { useState } from "react";
+import { useKeystroke } from "./keystroke-context.js";
+import type { McpServerSummary } from "./slash/types.js";
+import { COLOR } from "./theme.js";
+
+export interface McpBrowserProps {
+  servers: McpServerSummary[];
+  configPath: string;
+  onClose: () => void;
+}
+
+export function McpBrowser({ servers, configPath, onClose }: McpBrowserProps) {
+  const [index, setIndex] = useState(0);
+  const max = Math.max(0, servers.length - 1);
+
+  useKeystroke((ev) => {
+    if (ev.paste) return;
+    if (ev.upArrow) setIndex((i) => Math.max(0, i - 1));
+    else if (ev.downArrow) setIndex((i) => Math.min(max, i + 1));
+    else if (ev.escape) onClose();
+  });
+
+  return (
+    <Box flexDirection="column" paddingX={1}>
+      <Box>
+        <Text bold color={COLOR.brand}>
+          ◈ MCP browser
+        </Text>
+        <Text
+          dimColor
+        >{`  ·  ${configPath}  ·  ${servers.length} server${servers.length === 1 ? "" : "s"}`}</Text>
+      </Box>
+      <Box marginTop={1} flexDirection="column">
+        {servers.length === 0 ? (
+          <Text dimColor>
+            No MCP servers attached. Run `reasonix setup` to pick some, or launch with --mcp.
+          </Text>
+        ) : (
+          servers.map((s, i) => (
+            <ServerRow key={s.label + s.spec} server={s} active={i === index} />
+          ))
+        )}
+      </Box>
+      <Box marginTop={1}>
+        <Text dimColor>↑↓ pick · [r] reconnect (Stage C) · [d] disable (Stage C) · esc quit</Text>
+      </Box>
+    </Box>
+  );
+}
+
+function ServerRow({ server, active }: { server: McpServerSummary; active: boolean }) {
+  const { label, toolCount, report } = server;
+  const resourceCount = report.resources.supported ? report.resources.items.length : 0;
+  const promptCount = report.prompts.supported ? report.prompts.items.length : 0;
+  const elapsed = report.elapsedMs;
+  const health = healthBadge(elapsed);
+  const counts = `${toolCount} tools · ${resourceCount} resources · ${promptCount} prompts`;
+
+  return (
+    <Box flexDirection="column" marginBottom={active ? 1 : 0}>
+      <Box>
+        <Text color={active ? COLOR.brand : undefined}>{active ? "▸  " : "   "}</Text>
+        <Text bold={active} color={active ? "#e6edf3" : undefined}>
+          {label.padEnd(14)}
+        </Text>
+        <Text color={health.color}>{`${health.glyph} ${health.label}`}</Text>
+        <Text dimColor>{`      ${counts}`}</Text>
+      </Box>
+      {active ? (
+        <Box>
+          <Text dimColor>{`     ${capabilityList(server)}`}</Text>
+        </Box>
+      ) : null}
+    </Box>
+  );
+}
+
+function healthBadge(elapsedMs: number): { glyph: string; label: string; color: string } {
+  if (elapsedMs === 0) return { glyph: "✗", label: "no inspect data", color: COLOR.err };
+  if (elapsedMs < 500) return { glyph: "●", label: `healthy · ${elapsedMs}ms`, color: COLOR.ok };
+  if (elapsedMs < 3000) return { glyph: "◌", label: `slow · ${elapsedMs}ms`, color: COLOR.warn };
+  return { glyph: "✗", label: `very slow · ${elapsedMs}ms`, color: COLOR.err };
+}
+
+function capabilityList(s: McpServerSummary): string {
+  const caps: string[] = ["tools/list", "tools/call"];
+  if (s.report.resources.supported) caps.push("resources/list");
+  if (s.report.prompts.supported) caps.push("prompts/list");
+  return caps.join("  ");
+}

--- a/src/cli/ui/slash/handlers/mcp.ts
+++ b/src/cli/ui/slash/handlers/mcp.ts
@@ -1,16 +1,22 @@
 import type { SlashHandler } from "../dispatch.js";
 import { appendSection } from "../helpers.js";
 
-const mcp: SlashHandler = (_args, loop, ctx) => {
+const mcp: SlashHandler = (args, loop, ctx) => {
   const servers = ctx.mcpServers ?? [];
   const specs = ctx.mcpSpecs ?? [];
   const toolSpecs = loop.prefix.toolSpecs ?? [];
+  // `/mcp text` (or non-TTY) falls through to the printed-card path. The
+  // default `/mcp` opens the interactive browser modal.
+  const wantsTextDump = args[0] === "text";
   if (servers.length === 0 && specs.length === 0 && toolSpecs.length === 0) {
     return {
       info:
         "no MCP servers attached. Run `reasonix setup` to pick some, " +
         'or launch with --mcp "<spec>". `reasonix mcp list` shows the catalog.',
     };
+  }
+  if (!wantsTextDump && servers.length > 0) {
+    return { openMcpBrowser: true };
   }
   // Rich path — we have full inspection reports, so show each server
   // with its tools / resources / prompts grouped together.

--- a/src/cli/ui/slash/types.ts
+++ b/src/cli/ui/slash/types.ts
@@ -9,6 +9,8 @@ export interface SlashResult {
   info?: string;
   /** Open the SessionPicker modal mid-chat — used by `/sessions` slash. */
   openSessionsPicker?: boolean;
+  /** Open the MCP browser modal — used by `/mcp` slash in interactive contexts. */
+  openMcpBrowser?: boolean;
   /** Exit the app. */
   exit?: boolean;
   /** Clear the visible history. */

--- a/tests/slash.test.ts
+++ b/tests/slash.test.ts
@@ -733,8 +733,30 @@ describe("handleSlash", () => {
     expect(names).toContain("undo");
   });
 
-  it("/mcp with mcpServers renders per-server tools+resources+prompts", () => {
+  it("/mcp opens the browser modal when servers are attached", () => {
     const r = handleSlash("mcp", [], makeLoop(), {
+      mcpServers: [
+        {
+          label: "fs",
+          spec: "fs=npx -y @scope/fs /tmp",
+          toolCount: 4,
+          report: {
+            protocolVersion: "2024-11-05",
+            serverInfo: { name: "fs-server", version: "1.0.0" },
+            capabilities: { tools: {}, resources: {} },
+            tools: { supported: true, items: [] },
+            resources: { supported: true, items: [] },
+            prompts: { supported: false, reason: "method not found (-32601)" },
+          },
+        },
+      ],
+    });
+    expect(r.openMcpBrowser).toBe(true);
+    expect(r.info).toBeUndefined();
+  });
+
+  it("/mcp text falls through to the printed-card view (non-TTY / replay)", () => {
+    const r = handleSlash("mcp", ["text"], makeLoop(), {
       mcpServers: [
         {
           label: "fs",
@@ -757,6 +779,7 @@ describe("handleSlash", () => {
         },
       ],
     });
+    expect(r.openMcpBrowser).toBeUndefined();
     expect(r.info).toMatch(/\[fs\].*fs-server v1\.0\.0/);
     expect(r.info).toMatch(/tools\s+4/);
     expect(r.info).toMatch(/resources\s+2\s+\[docs, readme\]/);


### PR DESCRIPTION
Stage B of #105.

## What

Replace the `/mcp` text dump with a keyboard-driven modal matching `docs/design/agent-tui-terminal.html` §24. The text-dump path is kept available via `/mcp text` for non-TTY / replay contexts.

```
◈ MCP browser  ·  ~/.reasonix/config.json  ·  4 servers

▸  notion          ● healthy · 142ms      12 tools · 8 resources · 0 prompts
                   tools/list  tools/call  resources/list  prompts/list

   linear          ◌ slow · 4.2s        7 tools · 3 resources · 0 prompts

   github          ● healthy · 88ms     22 tools · 0 resources · 4 prompts

   fs-local        ✗ no inspect data    0 tools · 0 resources · 0 prompts

↑↓ pick · [r] reconnect (Stage C) · [d] disable (Stage C) · esc quit
```

## Why

Closing the second-biggest gap in #105's audit table: design specifies an interactive browser, runtime had a text dump.

## Touch

- New `src/cli/ui/McpBrowser.tsx` — the modal component (manual row rendering, not via `Select.tsx`, so the health-badge color and the second-row capability list under the active server can be styled independently).
- `src/cli/ui/slash/types.ts` — add `openMcpBrowser?: boolean` to the SlashResult union, mirroring the existing `openSessionsPicker`.
- `src/cli/ui/slash/handlers/mcp.ts` — return `{ openMcpBrowser: true }` in the rich-data path; `/mcp text` falls through to the existing printed-card output.
- `src/cli/ui/App.tsx` — `pendingMcpBrowser` state, modal slot in the render tree, gates added to the eight conditional chains that suppress prompt input while a modal is open.
- `tests/slash.test.ts` — split the existing `/mcp` test into one case asserting the modal flag fires and one asserting `/mcp text` still prints the card view.

## Stage C will

- Activate the `r` keybind → `/mcp reconnect <name>` flow
- Activate the `d` keybind → `/mcp disable <name>` flow with config persistence
- Add p95 latency tracking + slow-server toast

The footer currently labels these "(Stage C)" so users know they're coming.

## Test plan

- [x] `npm run verify` passes locally (1738 tests, lint, typecheck, build)
- [x] Slash test split — `/mcp` returns `openMcpBrowser: true`; `/mcp text` returns `info` text
- [ ] Eyeball: launch `npm run dev chat --mcp ...` with one or more servers, type `/mcp`, confirm the modal renders and Esc closes it