### PR TITLE
feat(mcp): p95 latency tracker + slow-server warn toast (Stage C2a of #105)

### DIFF
--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -24,6 +24,7 @@ import { SessionPicker } from "../ui/SessionPicker.js";
 import { Setup } from "../ui/Setup.js";
 import { KeystrokeProvider } from "../ui/keystroke-context.js";
 import { formatMcpLifecycleEvent } from "../ui/mcp-lifecycle.js";
+import { formatMcpSlowToast } from "../ui/mcp-toast.js";
 import type { McpServerSummary } from "../ui/slash.js";
 
 export interface ProgressInfo {
@@ -233,7 +234,12 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
         const bridge = await bridgeMcpTools(mcp, {
           registry: tools,
           namePrefix: prefix,
+          serverName: label,
           onProgress: (info) => progressSink.current?.(info),
+          onSlow: (info) =>
+            process.stderr.write(
+              `${formatMcpSlowToast({ name: info.serverName, p95Ms: info.p95Ms, sampleSize: info.sampleSize })}\n`,
+            ),
         });
         // Inspect collects resources + prompts once so `/mcp` can render them
         // synchronously. Servers that don't support these fall through as

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -20,6 +20,7 @@ import { appendUsage } from "../../telemetry/usage.js";
 import { ToolRegistry } from "../../tools.js";
 import { openTranscriptFile, recordFromLoopEvent, writeRecord } from "../../transcript/log.js";
 import { formatMcpLifecycleEvent } from "../ui/mcp-lifecycle.js";
+import { formatMcpSlowToast } from "../ui/mcp-toast.js";
 
 export interface RunOptions {
   task: string;
@@ -109,7 +110,15 @@ export async function runCommand(opts: RunOptions): Promise<void> {
               : new StdioTransport({ command: spec.command, args: spec.args });
         const mcp = new McpClient({ transport });
         await mcp.initialize();
-        const bridge = await bridgeMcpTools(mcp, { registry: tools, namePrefix: prefix });
+        const bridge = await bridgeMcpTools(mcp, {
+          registry: tools,
+          namePrefix: prefix,
+          serverName: label,
+          onSlow: (info) =>
+            process.stderr.write(
+              `${formatMcpSlowToast({ name: info.serverName, p95Ms: info.p95Ms, sampleSize: info.sampleSize })}\n`,
+            ),
+        });
         process.stderr.write(
           `${formatMcpLifecycleEvent({
             state: "connected",

--- a/src/cli/ui/mcp-toast.ts
+++ b/src/cli/ui/mcp-toast.ts
@@ -1,0 +1,12 @@
+/** One-line warn toast emitted when an MCP server's p95 crosses the slow threshold (design §32). */
+
+export interface McpSlowToast {
+  name: string;
+  p95Ms: number;
+  sampleSize: number;
+}
+
+export function formatMcpSlowToast(t: McpSlowToast): string {
+  const seconds = (t.p95Ms / 1000).toFixed(1);
+  return `⚠ MCP \`${t.name}\` slow · ${seconds}s p95 over the last ${t.sampleSize} calls`;
+}

--- a/src/mcp/latency.ts
+++ b/src/mcp/latency.ts
@@ -1,0 +1,50 @@
+/** Per-server ring-buffered latency tracker; emits a "slow" event on threshold cross only. */
+
+const SAMPLE_SIZE = 5;
+const DEFAULT_THRESHOLD_MS = 4000;
+
+export interface SlowEvent {
+  serverName: string;
+  p95Ms: number;
+  sampleSize: number;
+}
+
+export interface LatencyTrackerOptions {
+  thresholdMs?: number;
+  onSlow?: (ev: SlowEvent) => void;
+}
+
+export class LatencyTracker {
+  private samples: number[] = [];
+  private wasOverThreshold = false;
+  private readonly thresholdMs: number;
+  private readonly onSlow?: (ev: SlowEvent) => void;
+
+  constructor(
+    private readonly serverName: string,
+    opts: LatencyTrackerOptions = {},
+  ) {
+    this.thresholdMs = opts.thresholdMs ?? DEFAULT_THRESHOLD_MS;
+    this.onSlow = opts.onSlow;
+  }
+
+  record(elapsedMs: number): void {
+    this.samples.push(elapsedMs);
+    if (this.samples.length > SAMPLE_SIZE) this.samples.shift();
+    if (this.samples.length < SAMPLE_SIZE) return;
+    const p95 = computeP95(this.samples);
+    const nowOver = p95 > this.thresholdMs;
+    if (nowOver && !this.wasOverThreshold) {
+      this.onSlow?.({ serverName: this.serverName, p95Ms: p95, sampleSize: this.samples.length });
+    }
+    this.wasOverThreshold = nowOver;
+  }
+}
+
+/** Plain p95 — sort the buffer and pick the index at floor(N * 0.95). */
+export function computeP95(samples: readonly number[]): number {
+  if (samples.length === 0) return 0;
+  const sorted = [...samples].sort((a, b) => a - b);
+  const idx = Math.min(sorted.length - 1, Math.floor(sorted.length * 0.95));
+  return sorted[idx] ?? 0;
+}

--- a/src/mcp/registry.ts
+++ b/src/mcp/registry.ts
@@ -2,6 +2,7 @@ import { countTokens } from "../tokenizer.js";
 import { ToolRegistry } from "../tools.js";
 import type { JSONSchema } from "../types.js";
 import type { McpClient } from "./client.js";
+import { LatencyTracker, type SlowEvent } from "./latency.js";
 import type { CallToolResult, McpContentBlock } from "./types.js";
 
 export interface BridgeOptions {
@@ -20,6 +21,12 @@ export interface BridgeOptions {
     total?: number;
     message?: string;
   }) => void;
+  /** Server name used to tag latency samples + slow events. Falls through to namePrefix without trailing `_`. */
+  serverName?: string;
+  /** p95 cutoff in ms before a slow event fires — defaults to 4000. */
+  slowThresholdMs?: number;
+  /** Fired exactly when the per-server p95 transitions over `slowThresholdMs`. */
+  onSlow?: (ev: SlowEvent) => void;
 }
 
 export const DEFAULT_MAX_RESULT_CHARS = 32_000;
@@ -44,6 +51,10 @@ export async function bridgeMcpTools(
   const maxResultChars = opts.maxResultChars ?? DEFAULT_MAX_RESULT_CHARS;
   const result: BridgeResult = { registry, registeredNames: [], skipped: [] };
 
+  const serverName = opts.serverName ?? prefix.replace(/_$/, "") ?? "anon";
+  const tracker = opts.onSlow
+    ? new LatencyTracker(serverName, { thresholdMs: opts.slowThresholdMs, onSlow: opts.onSlow })
+    : null;
   const listed = await client.listTools();
   for (const mcpTool of listed.tools) {
     if (!mcpTool.name) {
@@ -56,6 +67,7 @@ export async function bridgeMcpTools(
       description: mcpTool.description ?? "",
       parameters: mcpTool.inputSchema as JSONSchema,
       fn: async (args: Record<string, unknown>, ctx) => {
+        const t0 = tracker ? Date.now() : 0;
         const toolResult = await client.callTool(mcpTool.name, args, {
           // Forward server-side progress frames to the bridge caller,
           // tagged with the registered name so multi-server UIs can
@@ -71,6 +83,7 @@ export async function bridgeMcpTools(
           // pending promise immediately, no "wait for subprocess".
           signal: ctx?.signal,
         });
+        if (tracker) tracker.record(Date.now() - t0);
         return flattenMcpResult(toolResult, { maxChars: maxResultChars });
       },
     });

--- a/tests/mcp-latency.test.ts
+++ b/tests/mcp-latency.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+import { formatMcpSlowToast } from "../src/cli/ui/mcp-toast.js";
+import { LatencyTracker, computeP95 } from "../src/mcp/latency.js";
+
+describe("computeP95", () => {
+  it("returns 0 on an empty buffer", () => {
+    expect(computeP95([])).toBe(0);
+  });
+
+  it("returns the largest sample for tiny buffers", () => {
+    expect(computeP95([100, 200, 300])).toBe(300);
+  });
+
+  it("picks the floor(N*0.95) index of the sorted sample", () => {
+    expect(computeP95([100, 200, 300, 400, 500])).toBe(500);
+    expect(computeP95([10, 20, 30, 40, 50, 60, 70, 80, 90, 100])).toBe(100);
+  });
+});
+
+describe("LatencyTracker", () => {
+  it("does not fire onSlow before the buffer fills (5 samples)", () => {
+    const onSlow = vi.fn();
+    const t = new LatencyTracker("notion", { thresholdMs: 1000, onSlow });
+    for (const ms of [9000, 9000, 9000, 9000]) t.record(ms);
+    expect(onSlow).not.toHaveBeenCalled();
+  });
+
+  it("fires onSlow exactly once on the first sample that crosses the threshold", () => {
+    const onSlow = vi.fn();
+    const t = new LatencyTracker("notion", { thresholdMs: 1000, onSlow });
+    for (const ms of [9000, 9000, 9000, 9000, 9000]) t.record(ms);
+    expect(onSlow).toHaveBeenCalledTimes(1);
+    expect(onSlow.mock.calls[0]?.[0]).toMatchObject({
+      serverName: "notion",
+      p95Ms: 9000,
+      sampleSize: 5,
+    });
+    // Subsequent samples that stay over threshold do NOT re-fire.
+    t.record(9000);
+    t.record(9000);
+    expect(onSlow).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires again when p95 dips below and crosses back over", () => {
+    const onSlow = vi.fn();
+    const t = new LatencyTracker("notion", { thresholdMs: 1000, onSlow });
+    for (const ms of [9000, 9000, 9000, 9000, 9000]) t.record(ms);
+    expect(onSlow).toHaveBeenCalledTimes(1);
+    // Drain the buffer with fast samples so p95 drops below.
+    for (const ms of [100, 100, 100, 100, 100]) t.record(ms);
+    expect(onSlow).toHaveBeenCalledTimes(1);
+    // Slow again — should re-fire.
+    for (const ms of [9000, 9000, 9000, 9000, 9000]) t.record(ms);
+    expect(onSlow).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses the default 4000ms threshold when none is given", () => {
+    const onSlow = vi.fn();
+    const t = new LatencyTracker("notion", { onSlow });
+    for (const ms of [3000, 3000, 3000, 3000, 3000]) t.record(ms);
+    expect(onSlow).not.toHaveBeenCalled();
+    for (const ms of [5000, 5000, 5000, 5000, 5000]) t.record(ms);
+    expect(onSlow).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("formatMcpSlowToast", () => {
+  it("renders the p95-over-N-calls warn line", () => {
+    expect(formatMcpSlowToast({ name: "notion", p95Ms: 8400, sampleSize: 5 })).toBe(
+      "⚠ MCP `notion` slow · 8.4s p95 over the last 5 calls",
+    );
+  });
+
+  it("rounds to one decimal place", () => {
+    expect(formatMcpSlowToast({ name: "linear", p95Ms: 4250, sampleSize: 5 })).toBe(
+      "⚠ MCP `linear` slow · 4.3s p95 over the last 5 calls",
+    );
+  });
+});


### PR DESCRIPTION
Stage C2a of #105.

## What

Per-server ring-buffered latency tracker, plus the one-line warn toast specified in design §32:

```
⚠ MCP `notion` slow · 8.4s p95 over the last 5 calls
```

Fires exactly when the per-server p95 transitions over the threshold (default 4000ms). Idempotent within a "slow window" — won't re-fire on every over-cap call. Re-fires only after p95 dips below and crosses back over.

## Touch

- New `src/mcp/latency.ts` — `LatencyTracker` with size-5 ring buffer + p95 helper. Tracks a `wasOverThreshold` boolean so emission is gated on the *transition*, not on every over-cap call.
- `src/mcp/registry.ts` — `BridgeOptions` gains `serverName`, `slowThresholdMs`, `onSlow`. The bridged tool's `fn` records per-call elapsed time when a tracker is configured. Default threshold 4000ms.
- New `src/cli/ui/mcp-toast.ts` exporting `formatMcpSlowToast`.
- `src/cli/commands/chat.tsx` + `src/cli/commands/run.ts` — wire `serverName` and `onSlow` callback so the warn line lands on stderr.
- `tests/mcp-latency.test.ts` — 9 cases.

## Why C2 was split (C2a here, C2b separate)

The original Stage C scope bundled `/mcp reconnect <name>` with the slow-toast work. Reconnect is much harder than I initially thought: it tears down a live `McpClient` and re-bridges its tools mid-session, but Reasonix's whole architecture is built around the byte-stable prompt prefix → cache hit invariant. If the reconnected server's tool surface changed (different tool list, new schemas), the prefix breaks and the next turn cache-misses entirely. That needs a deliberate design — refuse the reconnect? accept and announce a cache reset? — which is RFC territory, not just code.

So C2a (this PR) ships the no-architecture-risk piece. C2b (reconnect, with cache-invariant handling) becomes its own RFC issue.

## Test plan

- [x] `npm run verify` passes locally (1754 tests, lint, typecheck, build)
- [x] Tracker fires exactly once on threshold cross; re-fires after dip-and-cross
- [x] Toast format matches design §32 byte-for-byte
- [ ] Eyeball: launch with a deliberately slow MCP server (e.g., a sleep-injecting wrapper), call its tools 5+ times, confirm the toast lands on stderr