### PR TITLE
test(mcp): pin RFC #110 cache-prefix claims with 6 unit tests

### DIFF
--- a/tests/mcp-reconnect-prefix-invariant.test.ts
+++ b/tests/mcp-reconnect-prefix-invariant.test.ts
@@ -1,0 +1,91 @@
+/** Pins down the cache-prefix claims in RFC #110 (`/mcp reconnect <name>`). */
+
+import { describe, expect, it } from "vitest";
+import { ImmutablePrefix } from "../src/memory/runtime.js";
+import type { ToolSpec } from "../src/types.js";
+
+function tool(name: string, description = "", params: object = { type: "object" }): ToolSpec {
+  return {
+    type: "function",
+    function: { name, description, parameters: params },
+  };
+}
+
+describe("RFC #110 — cache-prefix invariant under MCP reconnect", () => {
+  it("re-bridging an IDENTICAL tool list yields byte-identical fingerprint (the safe case)", () => {
+    const before = new ImmutablePrefix({
+      system: "s",
+      toolSpecs: [tool("read"), tool("write"), tool("search")],
+    });
+    const after = new ImmutablePrefix({
+      system: "s",
+      toolSpecs: [tool("read"), tool("write"), tool("search")],
+    });
+    expect(after.fingerprint).toBe(before.fingerprint);
+  });
+
+  it("re-bridging with one ADDED tool changes the fingerprint (cache miss next turn)", () => {
+    const before = new ImmutablePrefix({
+      system: "s",
+      toolSpecs: [tool("read"), tool("write")],
+    });
+    const after = new ImmutablePrefix({
+      system: "s",
+      toolSpecs: [tool("read"), tool("write"), tool("delete")],
+    });
+    expect(after.fingerprint).not.toBe(before.fingerprint);
+  });
+
+  it("re-bridging with one REMOVED tool changes the fingerprint", () => {
+    const before = new ImmutablePrefix({
+      system: "s",
+      toolSpecs: [tool("read"), tool("write"), tool("search")],
+    });
+    const after = new ImmutablePrefix({
+      system: "s",
+      toolSpecs: [tool("read"), tool("write")],
+    });
+    expect(after.fingerprint).not.toBe(before.fingerprint);
+  });
+
+  it("a description-only change on an existing tool changes the fingerprint", () => {
+    const before = new ImmutablePrefix({
+      system: "s",
+      toolSpecs: [tool("read", "reads a file")],
+    });
+    const after = new ImmutablePrefix({
+      system: "s",
+      toolSpecs: [tool("read", "reads a file (utf-8)")],
+    });
+    expect(after.fingerprint).not.toBe(before.fingerprint);
+  });
+
+  it("a parameter-schema change on an existing tool changes the fingerprint", () => {
+    const before = new ImmutablePrefix({
+      system: "s",
+      toolSpecs: [tool("read", "", { type: "object", properties: { path: { type: "string" } } })],
+    });
+    const after = new ImmutablePrefix({
+      system: "s",
+      toolSpecs: [
+        tool("read", "", {
+          type: "object",
+          properties: { path: { type: "string" }, encoding: { type: "string" } },
+        }),
+      ],
+    });
+    expect(after.fingerprint).not.toBe(before.fingerprint);
+  });
+
+  it("REORDERING the same tools changes the fingerprint (array order is part of the prefix)", () => {
+    const a = new ImmutablePrefix({
+      system: "s",
+      toolSpecs: [tool("read"), tool("write"), tool("search")],
+    });
+    const b = new ImmutablePrefix({
+      system: "s",
+      toolSpecs: [tool("write"), tool("read"), tool("search")],
+    });
+    expect(b.fingerprint).not.toBe(a.fingerprint);
+  });
+});


### PR DESCRIPTION
Refs #110.

## What

The reconnect RFC's central claim — "re-bridging tools mid-session breaks the prompt prefix when the new tool surface differs from the old" — was an architecture-derived assertion, not an empirical result. Cheap to lock down at the `ImmutablePrefix.fingerprint` layer.

`tests/mcp-reconnect-prefix-invariant.test.ts` covers six cases the RFC directly references:

| case | result |
|---|---|
| identical tool list | fingerprint unchanged (safe-reconnect case) |
| one tool added | fingerprint changes |
| one tool removed | fingerprint changes |
| description-only edit on an existing tool | fingerprint changes |
| parameter-schema edit | fingerprint changes |
| same tools reordered | fingerprint changes (array order is part of the prefix bytes via JSON.stringify) |

## Why

This gives RFC #110 a concrete reference to point at when weighing strict / permissive / `--force` approaches: any drift past the "identical bytes" line is a guaranteed cache miss, full stop. So the design conversation can focus on UX policy ("refuse vs warn vs flag-gated"), not on whether the underlying claim is actually true.

This is a tests-only change, no source files touched. Doesn't unblock C2b implementation by itself — that still needs the design call in #110 first.

## Test plan

- [x] `npm run verify` passes locally (1760 tests, +6)
- [x] All 6 cases pass against the existing `ImmutablePrefix` (no behavior change in src/)