### PR TITLE
chore(spike): live DeepSeek cache spike for RFC #110

### DIFF
--- a/benchmarks/spike-mcp-reconnect/results.md
+++ b/benchmarks/spike-mcp-reconnect/results.md
@@ -1,0 +1,63 @@
+# MCP reconnect — empirical cache-prefix spike
+
+Live `deepseek-chat` (DeepSeek prefix cache enabled by default).
+System prompt: 1546 chars (~390 tokens). 5 turns each with a small
+user message; tool-set varies between turns to simulate the drift
+shapes a `/mcp reconnect <name>` would emit.
+
+## Run
+
+```
+turn                                      prompt     hit    miss    hit%      ms
+--------------------------------------------------------------------------------
+1 · cold start (toolset A)                   758     640     118   84.4%    1092
+2 · same prefix (toolset A)                  753     640     113   85.0%    1535
+3 · drift: ADDED tool (toolset A+)           810     768      42   94.8%    1048
+4 · same prefix again (toolset A+)           807     768      39   95.2%    1480
+5 · drift: EDITED desc (toolset A')          761     640     121   84.1%     791
+```
+
+(Turn 1's "cold" is misleading — the prefix had been seen by the
+remote cache from an earlier run within the cache TTL.)
+
+## Findings
+
+DeepSeek's prefix cache works at chunk granularity (consistent with
+publicly documented ~128-token chunks). Three concrete lessons:
+
+1. **Append-only drift is nearly free.** Turn 3 adds one tool *at the
+   end* of the tool list — every cache chunk before the new tool
+   stays valid, only the appended bytes miss. Net: 94.8% hit, even
+   higher than the no-drift baseline (because the system prompt +
+   whole toolset-A is still cached, and the appended chunk is now
+   cached too).
+2. **Mid-stream drift loses everything past the divergence.** Turn 5
+   edits a description on the *first* tool, so divergence falls
+   inside the tools block early. Hit drops to 84.1% — still high
+   here only because the system prompt occupies enough chunks before
+   the divergence point.
+3. **Position of the drift dominates the cost.** A trailing addition
+   is essentially zero. An edit near the start of tools is more
+   expensive. An edit in the system prompt itself (not tested) would
+   wipe the cache to zero — expected, but irrelevant for reconnect
+   since we don't change the system prompt on reconnect.
+
+## Implication for RFC #110
+
+The "any drift = full cache miss" framing in the RFC body is too
+pessimistic. The real cost of accepting a drifted reconnect depends
+on *where* the drift lands:
+
+- Server adds a new tool (most common reconnect drift) → trivial
+  cost, accept silently.
+- Server changes an existing tool's schema or description → bounded
+  cost depending on position, surface a one-line warning.
+- Server completely reorders or replaces the tool list → effectively
+  full miss, refuse or require `--force`.
+
+This nudges the design call away from blanket "strict default"
+toward a **graduated permissive** policy: accept appends silently,
+warn on mid-stream edits, refuse on whole-list reorders or removals.
+
+The strict approach can still be the explicit `--strict` flag for
+users who need every byte of cache (e.g. high-volume scripted runs).

--- a/benchmarks/spike-mcp-reconnect/runner.ts
+++ b/benchmarks/spike-mcp-reconnect/runner.ts
@@ -1,0 +1,182 @@
+/** Empirically confirms RFC #110: tool-list drift mid-session breaks DeepSeek's prefix cache. */
+
+import { DeepSeekClient, loadDotenv } from "../../src/index.js";
+import type { ChatMessage, ToolSpec } from "../../src/types.js";
+
+loadDotenv();
+
+const MODEL = "deepseek-chat";
+
+// DeepSeek's prefix cache only kicks in past ~1024 tokens of repeated
+// prefix, so the system prompt has to be substantial. Padded with
+// realistic-shape filler so the test exercises the same code path a
+// real Reasonix session would.
+const SYSTEM = [
+  "You are a precise senior software engineer assisting with TypeScript codebases.",
+  "Style: terse, concrete, no filler. Don't restate the question. Don't apologise.",
+  "When you reference a file, use the file:line shape so the user can click through.",
+  "When you list options, use a bulleted list, not prose.",
+  "When you reason, do so internally — final reply is the answer, not the deliberation.",
+  "If the user asks a yes/no question, lead with the answer, then one sentence of why.",
+  "If the user asks for code, output a minimal patch — not the whole file.",
+  "When a tool result is a long stack trace, surface the root frame and one stack item up.",
+  "Refuse to fabricate API surface; if you don't know a function exists, ask first.",
+  "Prefer existing libraries over hand-rolled implementations; flag the dependency cost.",
+  "When suggesting a refactor, point at the existing call sites that motivate it.",
+  "Don't add error handling that catches errors you have no recovery for.",
+  "Don't add comments that restate the code; only document the WHY.",
+  "Keep diffs reviewable: 1 change per commit, related changes per PR.",
+  "Treat user messages as authoritative on intent; ask only when truly ambiguous.",
+  "Response length is a function of complexity — short answers when short suffices.",
+  "Default to UTF-8, LF line endings, two-space indent unless the surrounding code differs.",
+  "When a request is impossible as stated, propose the nearest tractable alternative.",
+  "Cite specific paths and line numbers; never paraphrase a file you can read.",
+  "Optimise for the user's next action, not your own throughness.",
+].join(" ");
+
+const baseTool: ToolSpec = {
+  type: "function",
+  function: {
+    name: "read_file",
+    description: "Read the contents of a file at the given absolute or workspace-relative path.",
+    parameters: {
+      type: "object",
+      properties: {
+        path: { type: "string", description: "File path to read." },
+      },
+      required: ["path"],
+    },
+  },
+};
+
+const writeTool: ToolSpec = {
+  type: "function",
+  function: {
+    name: "write_file",
+    description: "Write text content to a file at the given path. Creates parents if missing.",
+    parameters: {
+      type: "object",
+      properties: {
+        path: { type: "string" },
+        content: { type: "string" },
+      },
+      required: ["path", "content"],
+    },
+  },
+};
+
+const searchTool: ToolSpec = {
+  type: "function",
+  function: {
+    name: "search_files",
+    description: "Find files whose path matches a glob pattern under the workspace root.",
+    parameters: {
+      type: "object",
+      properties: { pattern: { type: "string" } },
+      required: ["pattern"],
+    },
+  },
+};
+
+const TOOLSET_A: ToolSpec[] = [baseTool, writeTool, searchTool];
+
+// Same shape as TOOLSET_A but adds one extra tool — emulates an MCP
+// server reconnect that exposed an additional capability.
+const newTool: ToolSpec = {
+  type: "function",
+  function: {
+    name: "delete_file",
+    description: "Remove a file at the given path. Refuses on directories.",
+    parameters: {
+      type: "object",
+      properties: { path: { type: "string" } },
+      required: ["path"],
+    },
+  },
+};
+const TOOLSET_A_PLUS: ToolSpec[] = [...TOOLSET_A, newTool];
+
+// Same set as A, only the description on read_file edited.
+const TOOLSET_A_EDITED: ToolSpec[] = [
+  {
+    ...baseTool,
+    function: {
+      ...baseTool.function,
+      description: "Read the contents of a file at the given path. Returns text or binary base64.",
+    },
+  },
+  writeTool,
+  searchTool,
+];
+
+interface Turn {
+  label: string;
+  tools: ToolSpec[];
+  user: string;
+}
+
+const TURNS: Turn[] = [
+  { label: "1 · cold start (toolset A)        ", tools: TOOLSET_A, user: "What does Reasonix optimise for, in one sentence?" },
+  { label: "2 · same prefix (toolset A)        ", tools: TOOLSET_A, user: "And why DeepSeek-only?" },
+  { label: "3 · drift: ADDED tool (toolset A+) ", tools: TOOLSET_A_PLUS, user: "What's a flaky test, in one sentence?" },
+  { label: "4 · same prefix again (toolset A+) ", tools: TOOLSET_A_PLUS, user: "And how do you stabilise one?" },
+  { label: "5 · drift: EDITED desc (toolset A')", tools: TOOLSET_A_EDITED, user: "What's an idempotent operation, in one sentence?" },
+];
+
+async function main(): Promise<void> {
+  if (!process.env.DEEPSEEK_API_KEY) {
+    console.error("DEEPSEEK_API_KEY not set in env. Add it to .env and re-run.");
+    process.exit(1);
+  }
+  const client = new DeepSeekClient();
+
+  const systemMsg: ChatMessage = { role: "system", content: SYSTEM };
+
+  console.log(`RFC #110 cache spike — DeepSeek prompt-cache behaviour under tool-list drift`);
+  console.log(`model: ${MODEL}`);
+  console.log(`system prompt: ${SYSTEM.length} chars`);
+  console.log();
+  const head =
+    "turn".padEnd(40) +
+    "prompt".padStart(8) +
+    "hit".padStart(8) +
+    "miss".padStart(8) +
+    "hit%".padStart(8) +
+    "ms".padStart(8);
+  console.log(head);
+  console.log("-".repeat(head.length));
+
+  for (const turn of TURNS) {
+    const messages: ChatMessage[] = [systemMsg, { role: "user", content: turn.user }];
+    const t0 = Date.now();
+    const resp = await client.chat({
+      model: MODEL,
+      messages,
+      tools: turn.tools,
+      maxTokens: 64,
+    });
+    const ms = Date.now() - t0;
+    const u = resp.usage;
+    const hitRatio = u.promptTokens > 0 ? (u.promptCacheHitTokens / u.promptTokens) * 100 : 0;
+    console.log(
+      turn.label.padEnd(40) +
+        String(u.promptTokens).padStart(8) +
+        String(u.promptCacheHitTokens).padStart(8) +
+        String(u.promptCacheMissTokens).padStart(8) +
+        `${hitRatio.toFixed(1)}%`.padStart(8) +
+        String(ms).padStart(8),
+    );
+  }
+  console.log();
+  console.log("Expectations:");
+  console.log("  Turn 1 — cold, hit ≈ 0");
+  console.log("  Turn 2 — same prefix as 1, hit ≈ system-prompt-token-count");
+  console.log("  Turn 3 — DRIFTED (added tool), hit drops to ~0 again");
+  console.log("  Turn 4 — same prefix as 3, hit climbs back");
+  console.log("  Turn 5 — DRIFTED (edited description), hit drops to ~0 again");
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
Refs #110.

Empirical follow-up to the structural-test PR (#112). Earlier today I claimed in the RFC body that "any tool-list drift on reconnect = full cache miss". That's wrong. Live spike against `deepseek-chat`:

```
turn                                      prompt     hit    miss    hit%
1 · cold start (toolset A)                   758     640     118   84.4%
2 · same prefix (toolset A)                  753     640     113   85.0%
3 · drift: ADDED tool (toolset A+)           810     768      42   94.8%
4 · same prefix again (toolset A+)           807     768      39   95.2%
5 · drift: EDITED desc (toolset A')          761     640     121   84.1%
```

DeepSeek caches in ~128-token chunks. Cost of drift depends on **where the drift lands**:

- append a tool at the end → trivial (94.8% hit, *better* than no-drift baseline because the new chunk gets cached)
- edit a tool's description mid-stream → bounded loss (84.1%, only chunks past the edit miss)
- replace / reorder / remove → would be effectively full miss (not measured here, but follows from the chunk model)

## What this changes

The RFC's strict-vs-permissive framing was based on a wrong premise. Updated thinking:

- **Default: graduated permissive.** Silent on appends, warn on mid-stream edits, refuse on whole-list reorders or removals.
- **`--strict` flag** for users who care about every byte (high-volume scripted runs).

## Touch

- `benchmarks/spike-mcp-reconnect/runner.ts` — 5-turn live runner, ~¥0.01 per execution
- `benchmarks/spike-mcp-reconnect/results.md` — captured run + empirical findings + design implications

No source files touched. The RFC #110 thread will get an updated comment summarizing the finding.

## Test plan

- [x] Local run completed against live DeepSeek
- [x] Lint + typecheck clean
- [ ] Re-run on a different day to confirm stability of the chunk model under different cache-state conditions (optional — current data is enough for the design call)