### PR TITLE
feat(mcp): activate r-keybind in /mcp browser (refs #110)

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -3386,6 +3386,7 @@ function AppInner({
               servers={mcpServers ?? []}
               configPath={defaultConfigPath()}
               onClose={() => setPendingMcpBrowser(false)}
+              postInfo={(text) => log.pushInfo(text)}
             />
           ) : pendingPlan ? (
             <PlanConfirm

--- a/src/cli/ui/McpBrowser.tsx
+++ b/src/cli/ui/McpBrowser.tsx
@@ -4,6 +4,7 @@ import { Box, Text } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React, { useState } from "react";
 import { useKeystroke } from "./keystroke-context.js";
+import { kickOffMcpReconnect } from "./mcp-reconnect-kickoff.js";
 import type { McpServerSummary } from "./slash/types.js";
 import { COLOR } from "./theme.js";
 
@@ -11,9 +12,11 @@ export interface McpBrowserProps {
   servers: McpServerSummary[];
   configPath: string;
   onClose: () => void;
+  /** Pushed by the modal when a key triggers async work (`r` reconnect). */
+  postInfo: (text: string) => void;
 }
 
-export function McpBrowser({ servers, configPath, onClose }: McpBrowserProps) {
+export function McpBrowser({ servers, configPath, onClose, postInfo }: McpBrowserProps) {
   const [index, setIndex] = useState(0);
   const max = Math.max(0, servers.length - 1);
 
@@ -22,6 +25,15 @@ export function McpBrowser({ servers, configPath, onClose }: McpBrowserProps) {
     if (ev.upArrow) setIndex((i) => Math.max(0, i - 1));
     else if (ev.downArrow) setIndex((i) => Math.min(max, i + 1));
     else if (ev.escape) onClose();
+    else if (ev.input === "r") {
+      const target = servers[index];
+      if (!target) return;
+      // Hand the "starting" lifecycle line to scrollback and let the
+      // kickoff schedule the result line via postInfo. Close the modal
+      // so the line is visible immediately.
+      postInfo(kickOffMcpReconnect(target, postInfo));
+      onClose();
+    }
   });
 
   return (
@@ -46,7 +58,7 @@ export function McpBrowser({ servers, configPath, onClose }: McpBrowserProps) {
         )}
       </Box>
       <Box marginTop={1}>
-        <Text dimColor>↑↓ pick · [r] reconnect (Stage C) · [d] disable (Stage C) · esc quit</Text>
+        <Text dimColor>↑↓ pick · [r] reconnect · [d] disable (TBD) · esc quit</Text>
       </Box>
     </Box>
   );

--- a/src/cli/ui/mcp-reconnect-kickoff.ts
+++ b/src/cli/ui/mcp-reconnect-kickoff.ts
@@ -1,0 +1,49 @@
+/** Shared async-fire-and-forget reconnect trigger — called by both `/mcp reconnect` and the McpBrowser `r` keybind. */
+
+import { reconnectMcpServer } from "../../mcp/reconnect.js";
+import { formatMcpLifecycleEvent } from "./mcp-lifecycle.js";
+import type { McpServerSummary } from "./slash/types.js";
+
+/** Kicks off async reconnect; returns the start-line, schedules result via postInfo. */
+export function kickOffMcpReconnect(
+  target: McpServerSummary,
+  postInfo: (text: string) => void,
+): string {
+  const beforeTools = target.report.tools.supported ? target.report.tools.items : [];
+  void (async () => {
+    try {
+      const result = await reconnectMcpServer({
+        host: target.host,
+        spec: target.spec,
+        beforeTools,
+      });
+      if (result.ok) {
+        postInfo(
+          formatMcpLifecycleEvent({
+            state: "connected",
+            name: target.label,
+            tools: beforeTools.length,
+            ms: result.ms,
+          }),
+        );
+      } else {
+        postInfo(
+          formatMcpLifecycleEvent({
+            state: "failed",
+            name: target.label,
+            reason: `${result.reason} · ${result.message}`,
+          }),
+        );
+      }
+    } catch (err) {
+      postInfo(
+        formatMcpLifecycleEvent({
+          state: "failed",
+          name: target.label,
+          reason: (err as Error).message,
+        }),
+      );
+    }
+  })();
+  return formatMcpLifecycleEvent({ state: "reconnect", name: target.label });
+}

--- a/src/cli/ui/slash/handlers/mcp.ts
+++ b/src/cli/ui/slash/handlers/mcp.ts
@@ -1,6 +1,5 @@
 import { readConfig, writeConfig } from "../../../../config.js";
-import { reconnectMcpServer } from "../../../../mcp/reconnect.js";
-import { formatMcpLifecycleEvent } from "../../mcp-lifecycle.js";
+import { kickOffMcpReconnect } from "../../mcp-reconnect-kickoff.js";
 import type { SlashHandler } from "../dispatch.js";
 import { appendSection } from "../helpers.js";
 import type { McpServerSummary } from "../types.js";
@@ -151,47 +150,7 @@ function triggerReconnect(
   if (!postInfo) {
     return { info: "/mcp reconnect requires the interactive TUI (postInfo not wired)." };
   }
-  // Sync return: kick off the async work and let it report via postInfo.
-  // Identity drift is the only currently-supported success case; everything
-  // else surfaces as a "restart Reasonix to apply" line so the user knows
-  // why the reconnect didn't take.
-  const beforeTools = target.report.tools.supported ? target.report.tools.items : [];
-  void (async () => {
-    try {
-      const result = await reconnectMcpServer({
-        host: target.host,
-        spec: target.spec,
-        beforeTools,
-      });
-      if (result.ok) {
-        postInfo(
-          formatMcpLifecycleEvent({
-            state: "connected",
-            name: target.label,
-            tools: beforeTools.length,
-            ms: result.ms,
-          }),
-        );
-      } else {
-        postInfo(
-          formatMcpLifecycleEvent({
-            state: "failed",
-            name: target.label,
-            reason: `${result.reason} · ${result.message}`,
-          }),
-        );
-      }
-    } catch (err) {
-      postInfo(
-        formatMcpLifecycleEvent({
-          state: "failed",
-          name: target.label,
-          reason: (err as Error).message,
-        }),
-      );
-    }
-  })();
-  return { info: formatMcpLifecycleEvent({ state: "reconnect", name: target.label }) };
+  return { info: kickOffMcpReconnect(target, postInfo) };
 }
 
 export const handlers: Record<string, SlashHandler> = { mcp };


### PR DESCRIPTION
Refs #110.

## What

Wires the `/mcp` browser modal's labelled-but-stub `r` keybind to the same reconnect flow `/mcp reconnect <name>` already uses. Both surfaces now route through a single shared kickoff helper.

## Touch

- New `src/cli/ui/mcp-reconnect-kickoff.ts` exporting `kickOffMcpReconnect(target, postInfo) → string`. Returns the start-line, schedules the result line via `postInfo`.
- `src/cli/ui/McpBrowser.tsx` — adds `r` key handler that calls the kickoff against the currently-selected server, pushes the start-line via `postInfo`, closes the modal so the line is visible.
- `src/cli/ui/App.tsx` — passes `log.pushInfo` into the modal.
- `src/cli/ui/slash/handlers/mcp.ts` — drops the inline async block, calls `kickOffMcpReconnect` instead.
- Footer label updated: `[r] reconnect (Stage C)` → `[r] reconnect`. The `[d] disable` slot stays labelled `(TBD)` since registry-mutation work for live disable is still pending.

No behaviour change for the slash — produces the same lifecycle lines via the shared helper. Modal is the new surface.

## What's still left in #110

- Append-drift mid-session (needs `addTool` from outside the loop)
- Edit-drift mid-session (needs `replaceTool` API)
- Reorder/remove mid-session (needs `removeTool` + cache-reset announcement)
- `[d] disable` keybind — needs the same kind of registry-mutation work as the disable/enable slash mid-session
- `--strict` flag — opt-in to refusing append-drift

Each is its own follow-up PR with its own (smaller) design call.

## Test plan

- [x] `npm run verify` passes (1778 tests, no new tests since this only refactors / wires existing flow)
- [x] Slash test still passes against the unchanged `triggerReconnect` external behaviour
- [ ] Eyeball: launch with an MCP server, type `/mcp`, press `r` on a server, confirm the modal closes, the `↻ reconnect…` line appears, and the result line follows