### PR TITLE
feat(mcp): activate d-keybind in /mcp browser (closes #105)

### DIFF
--- a/src/cli/ui/McpBrowser.tsx
+++ b/src/cli/ui/McpBrowser.tsx
@@ -4,6 +4,7 @@ import { Box, Text } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React, { useState } from "react";
 import { useKeystroke } from "./keystroke-context.js";
+import { toggleMcpDisabled } from "./mcp-disable.js";
 import { type ApplyAppend, kickOffMcpReconnect } from "./mcp-reconnect-kickoff.js";
 import type { McpServerSummary } from "./slash/types.js";
 import { COLOR } from "./theme.js";
@@ -41,6 +42,12 @@ export function McpBrowser({
       // so the line is visible immediately.
       postInfo(kickOffMcpReconnect(target, postInfo, applyAppend));
       onClose();
+    } else if (ev.input === "d") {
+      const target = servers[index];
+      if (!target) return;
+      // Persist `mcpDisabled` and close — takes effect on next launch.
+      postInfo(toggleMcpDisabled("disable", target.label));
+      onClose();
     }
   });
 
@@ -66,7 +73,7 @@ export function McpBrowser({
         )}
       </Box>
       <Box marginTop={1}>
-        <Text dimColor>↑↓ pick · [r] reconnect · [d] disable (TBD) · esc quit</Text>
+        <Text dimColor>↑↓ pick · [r] reconnect · [d] disable · esc quit</Text>
       </Box>
     </Box>
   );

--- a/src/cli/ui/mcp-disable.ts
+++ b/src/cli/ui/mcp-disable.ts
@@ -1,0 +1,26 @@
+/** Persists `mcpDisabled` to ~/.reasonix/config.json — shared between `/mcp disable / enable` slash and the McpBrowser `d` keybind. */
+
+import { readConfig, writeConfig } from "../../config.js";
+
+export function toggleMcpDisabled(action: "disable" | "enable", name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed) {
+    return `usage: /mcp ${action} <name>  ·  pick a name shown in /mcp (anonymous servers can't be named-toggled).`;
+  }
+  const cfg = readConfig();
+  const current = new Set(cfg.mcpDisabled ?? []);
+  if (action === "disable") {
+    if (current.has(trimmed)) {
+      return `▸ ${trimmed} is already disabled — restart to apply, or /mcp enable ${trimmed}.`;
+    }
+    current.add(trimmed);
+    writeConfig({ ...cfg, mcpDisabled: [...current].sort() });
+    return `▸ ${trimmed} disabled — takes effect on next launch. /mcp enable ${trimmed} to revert.`;
+  }
+  if (!current.has(trimmed)) {
+    return `▸ ${trimmed} is not disabled.`;
+  }
+  current.delete(trimmed);
+  writeConfig({ ...cfg, mcpDisabled: current.size > 0 ? [...current].sort() : undefined });
+  return `▸ ${trimmed} re-enabled — takes effect on next launch.`;
+}

--- a/src/cli/ui/slash/handlers/mcp.ts
+++ b/src/cli/ui/slash/handlers/mcp.ts
@@ -1,6 +1,6 @@
-import { readConfig, writeConfig } from "../../../../config.js";
 import type { CacheFirstLoop } from "../../../../loop.js";
 import { applyMcpAppend } from "../../mcp-append.js";
+import { toggleMcpDisabled } from "../../mcp-disable.js";
 import { kickOffMcpReconnect } from "../../mcp-reconnect-kickoff.js";
 import type { SlashHandler } from "../dispatch.js";
 import { appendSection } from "../helpers.js";
@@ -105,24 +105,7 @@ function toggleDisabled(
     const list = [...known].sort().join(", ") || "(none)";
     return { info: `unknown MCP server "${name}". Known: ${list}.` };
   }
-  const cfg = readConfig();
-  const current = new Set(cfg.mcpDisabled ?? []);
-  if (action === "disable") {
-    if (current.has(name)) {
-      return { info: `▸ ${name} is already disabled — restart to apply, or /mcp enable ${name}.` };
-    }
-    current.add(name);
-    writeConfig({ ...cfg, mcpDisabled: [...current].sort() });
-    return {
-      info: `▸ ${name} disabled — takes effect on next launch. /mcp enable ${name} to revert.`,
-    };
-  }
-  if (!current.has(name)) {
-    return { info: `▸ ${name} is not disabled.` };
-  }
-  current.delete(name);
-  writeConfig({ ...cfg, mcpDisabled: current.size > 0 ? [...current].sort() : undefined });
-  return { info: `▸ ${name} re-enabled — takes effect on next launch.` };
+  return { info: toggleMcpDisabled(action, name) };
 }
 
 function parseLabelFromSpec(spec: string): string | null {


### PR DESCRIPTION
Closes #105.

Final stage: the McpBrowser modal's labelled-but-stub `d` keybind now persists `mcpDisabled` to config. Removes the "(TBD)" label from the modal footer.

## Touch

- New `src/cli/ui/mcp-disable.ts` exporting `toggleMcpDisabled` — extracted from the slash handler so the modal can call it directly.
- `src/cli/ui/slash/handlers/mcp.ts` — replaces the inline read/write block with one call to `toggleMcpDisabled`. The unknown-name "Known: …" hint stays in the slash because it has access to `mcpSpecs`.
- `src/cli/ui/McpBrowser.tsx` — `d` key handler persists `mcpDisabled` for the selected server and closes the modal. No unknown-name check needed (user picked from a live list).
- Footer label: `[d] disable (TBD)` → `[d] disable`.

## Closes #105

All stages from the tracking issue are now landed:

- Stage A — lifecycle vocabulary (#106 ✓)
- Stage B — `/mcp` browser modal (#107 ✓)
- Stage C1 — `/mcp disable / enable` + lifecycle (#108 ✓)
- Stage C2a — p95 + slow toast (#109 ✓)
- Stage C2b — `/mcp reconnect` for identity + append drift (#115/#117), `r` keybind (#116), edit/reorder/remove deferred to follow-ups (refused with clear "restart" messages — they're catastrophic for cache anyway)
- This PR — `d` keybind in browser

Stage D (tools sub-pane on browser ⏎) was marked deferred from day one and remains so.

## Test plan

- [x] `npm run verify` passes (1782 tests)
- [x] Slash `/mcp disable <name>` still works — refactored, behaviour unchanged
- [ ] Eyeball: launch with two MCP servers, type `/mcp`, press `d` on one, confirm modal closes and the "▸ X disabled — takes effect on next launch" line lands in scrollback