### PR TITLE
feat(prompt): Home/End/Ctrl+K/Alt-word shortcuts

### DIFF
--- a/src/cli/ui/PromptInput.tsx
+++ b/src/cli/ui/PromptInput.tsx
@@ -99,6 +99,8 @@ export function PromptInput({
       escape: ev.escape,
       pageUp: ev.pageUp,
       pageDown: ev.pageDown,
+      home: ev.home,
+      end: ev.end,
     };
     const action = processMultilineKey(lastLocalValueRef.current, cursorRef.current, key);
     if (action.pasteRequest) {

--- a/src/cli/ui/multiline-keys.ts
+++ b/src/cli/ui/multiline-keys.ts
@@ -16,6 +16,8 @@ export interface MultilineKey {
   escape?: boolean;
   pageUp?: boolean;
   pageDown?: boolean;
+  home?: boolean;
+  end?: boolean;
 }
 
 export interface MultilineAction {
@@ -98,12 +100,12 @@ export function processMultilineKey(
     return moved === cursor ? NOOP : { next: null, cursor: moved, submit: false };
   }
 
-  // Emacs-style line jumps (universal across terminals; Home/End aren't
-  // reliably reported by Ink so we don't depend on them).
-  if (key.ctrl && key.input === "a") {
+  // Emacs-style line jumps. Home/End come through our own stdin reader
+  // (see stdin-reader.ts CSI_TAIL_MAP); Ctrl+A/E stay as universal aliases.
+  if ((key.ctrl && key.input === "a") || key.home) {
     return { next: null, cursor: startOfLine(value, cursor), submit: false };
   }
-  if (key.ctrl && key.input === "e") {
+  if ((key.ctrl && key.input === "e") || key.end) {
     return { next: null, cursor: endOfLine(value, cursor), submit: false };
   }
   // Bash / readline conventions:
@@ -111,11 +113,25 @@ export function processMultilineKey(
   //     "clear from cursor to start"; for our text-area we treat it
   //     as "clear all" because there's no ergonomic way to clear a
   //     huge paste otherwise).
-  //   Ctrl+W — delete the word before the cursor.
+  //   Ctrl+K — kill from cursor to end of current line.
+  //   Ctrl+W / Alt+Backspace — delete the word before the cursor.
+  //   Alt+B / Alt+F — jump cursor backward / forward by one word.
   if (key.ctrl && key.input === "u") {
     return value.length === 0 ? NOOP : { next: "", cursor: 0, submit: false };
   }
-  if (key.ctrl && key.input === "w") {
+  if (key.ctrl && key.input === "k") {
+    const lineEnd = endOfLine(value, cursor);
+    if (lineEnd === cursor) return NOOP;
+    return {
+      next: value.slice(0, cursor) + value.slice(lineEnd),
+      cursor,
+      submit: false,
+    };
+  }
+  if (
+    (key.ctrl && key.input === "w") ||
+    (key.meta && (key.backspace || key.input === "\x7f" || key.input === "\b"))
+  ) {
     if (cursor === 0) return NOOP;
     const wordStart = previousWordStart(value, cursor);
     return {
@@ -123,6 +139,14 @@ export function processMultilineKey(
       cursor: wordStart,
       submit: false,
     };
+  }
+  if (key.meta && key.input === "b") {
+    const target = previousWordStart(value, cursor);
+    return target === cursor ? NOOP : { next: null, cursor: target, submit: false };
+  }
+  if (key.meta && key.input === "f") {
+    const target = nextWordEnd(value, cursor);
+    return target === cursor ? NOOP : { next: null, cursor: target, submit: false };
   }
 
   // Paste-burst detection. If `input` contains a newline (or
@@ -236,6 +260,15 @@ function previousWordStart(value: string, cursor: number): number {
   let i = cursor;
   while (i > 0 && /\s/.test(value[i - 1] ?? "")) i--;
   while (i > 0 && !/\s/.test(value[i - 1] ?? "")) i--;
+  return i;
+}
+
+/** Symmetric to previousWordStart: skip leading whitespace, then run to next word boundary. */
+function nextWordEnd(value: string, cursor: number): number {
+  let i = cursor;
+  const n = value.length;
+  while (i < n && /\s/.test(value[i] ?? "")) i++;
+  while (i < n && !/\s/.test(value[i] ?? "")) i++;
   return i;
 }
 

--- a/tests/multiline-keys.test.ts
+++ b/tests/multiline-keys.test.ts
@@ -355,6 +355,60 @@ describe("processMultilineKey — buffer-wide navigation + clear shortcuts", () 
   });
 });
 
+describe("processMultilineKey — Home/End/Ctrl+K/Alt-word", () => {
+  it("Home jumps to start of current line (multi-line)", () => {
+    // mid "two", index 5 → start of "two" at index 4
+    const r = processMultilineKey("one\ntwo\nthree", 5, key({ home: true }));
+    expect(r.cursor).toBe(4);
+  });
+
+  it("End jumps to end of current line (multi-line)", () => {
+    // mid "two", index 5 → end of "two" at index 7
+    const r = processMultilineKey("one\ntwo\nthree", 5, key({ end: true }));
+    expect(r.cursor).toBe(7);
+  });
+
+  it("Ctrl+K kills from cursor to end of current line", () => {
+    const r = processMultilineKey("hello world\nbye", 5, key({ input: "k", ctrl: true }));
+    expect(r.next).toBe("hello\nbye");
+    expect(r.cursor).toBe(5);
+  });
+
+  it("Ctrl+K at end-of-line is a no-op (does not eat the newline)", () => {
+    const r = processMultilineKey("hello\nbye", 5, key({ input: "k", ctrl: true }));
+    expect(r).toEqual({ next: null, cursor: null, submit: false });
+  });
+
+  it("Alt+B moves cursor to start of previous word", () => {
+    const r = processMultilineKey("hello world", 11, key({ input: "b", meta: true }));
+    expect(r.cursor).toBe(6);
+    expect(r.next).toBeNull();
+  });
+
+  it("Alt+B at start of buffer is a no-op", () => {
+    const r = processMultilineKey("hello", 0, key({ input: "b", meta: true }));
+    expect(r).toEqual({ next: null, cursor: null, submit: false });
+  });
+
+  it("Alt+F moves cursor to end of next word", () => {
+    const r = processMultilineKey("hello world", 0, key({ input: "f", meta: true }));
+    expect(r.cursor).toBe(5);
+    expect(r.next).toBeNull();
+  });
+
+  it("Alt+F at end of buffer is a no-op", () => {
+    const v = "hello";
+    const r = processMultilineKey(v, v.length, key({ input: "f", meta: true }));
+    expect(r).toEqual({ next: null, cursor: null, submit: false });
+  });
+
+  it("Alt+Backspace deletes the previous word (Ctrl+W alias)", () => {
+    const r = processMultilineKey("hello world", 11, key({ meta: true, backspace: true }));
+    expect(r.next).toBe("hello ");
+    expect(r.cursor).toBe(6);
+  });
+});
+
 describe("processMultilineKey — paste burst handling", () => {
   it("paste with embedded \\n surfaces a pasteRequest, does NOT submit even with key.return set", () => {
     // Repro of the reported bug: Ink occasionally sets key.return on


### PR DESCRIPTION
Closes #121.

Wires the readline keys long-time CLI users reach for and which were
silently dropped by the prompt input.

## Added

- `Home` / `End` — start / end of current line (joins the existing `Ctrl+A` / `Ctrl+E`)
- `Ctrl+K` — kill from cursor to end of current line
- `Alt+B` / `Alt+F` — jump cursor backward / forward by one word
- `Alt+Backspace` — delete previous word (alias of the existing `Ctrl+W`)

## Not changed

- `Ctrl+U` keeps Reasonix's "clear whole buffer" behavior, not readline's "kill to start of line". The existing comment in `multiline-keys.ts` explains why — clearing a large paste needs an ergonomic single key.

## Verification

- `npm run verify` — typecheck, lint, build, 1791 tests all green
- 8 new test cases in `tests/multiline-keys.test.ts`