### PR TITLE
fix(tui): single layout authority for viewport rows

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -115,6 +115,7 @@ import {
 } from "./layout/LiveRows.js";
 import { StatusRow } from "./layout/StatusRow.js";
 import { ToastRail } from "./layout/ToastRail.js";
+import { ViewportBudgetProvider } from "./layout/viewport-budget.js";
 import { formatLoopStatus } from "./loop.js";
 import { applyMcpAppend } from "./mcp-append.js";
 import { handleMcpBrowseSlash } from "./mcp-browse.js";
@@ -3189,82 +3190,83 @@ function AppInner({
           (!busy && !isStreaming)
         }
       >
-        <Box flexDirection="column">
+        <ViewportBudgetProvider>
           <Box flexDirection="column">
-            <CardStream excludeId={activePlanCard?.id} />
-            {/*
+            <Box flexDirection="column">
+              <CardStream excludeId={activePlanCard?.id} />
+              {/*
           Welcome card on the empty state. Visible only when nothing
           has happened yet (no past events, nothing in flight, no
           modal up). Removes the "what do I type?" friction without
           surviving past the first turn.
         */}
-            {!hasConversation && !busy && !isStreaming ? (
-              <WelcomeBanner inCodeMode={!!codeMode} dashboardUrl={dashboardUrl} />
-            ) : null}
-            {/*
+              {!hasConversation && !busy && !isStreaming ? (
+                <WelcomeBanner inCodeMode={!!codeMode} dashboardUrl={dashboardUrl} />
+              ) : null}
+              {/*
           Live rows are hidden while the ShellConfirm modal is up — the
           model's concurrent "please confirm" stream is noise the user
           doesn't need, and the picker shouldn't fight it for visual
           attention. They come back naturally once the user chooses and
           the next turn begins.
         */}
-            {!PLAIN_UI &&
-            !pendingShell &&
-            !pendingPlan &&
-            !pendingReviseEditor &&
-            !pendingSessionsPicker &&
-            !pendingMcpBrowser &&
-            !stagedInput &&
-            !pendingEditReview &&
-            !pendingCheckpoint &&
-            !stagedCheckpointRevise &&
-            ongoingTool ? (
-              <OngoingToolRow tool={ongoingTool} progress={toolProgress} />
-            ) : null}
-            {!PLAIN_UI &&
-            !pendingShell &&
-            !pendingPlan &&
-            !pendingReviseEditor &&
-            !pendingSessionsPicker &&
-            !pendingMcpBrowser &&
-            !stagedInput &&
-            !pendingEditReview &&
-            !pendingCheckpoint &&
-            !stagedCheckpointRevise &&
-            subagentActivity ? (
-              <SubagentRow activity={subagentActivity} />
-            ) : null}
-            {!PLAIN_UI &&
-            !pendingShell &&
-            !pendingPlan &&
-            !pendingReviseEditor &&
-            !pendingSessionsPicker &&
-            !pendingMcpBrowser &&
-            !stagedInput &&
-            !pendingEditReview &&
-            !pendingCheckpoint &&
-            !stagedCheckpointRevise &&
-            !ongoingTool &&
-            statusLine ? (
-              <ThinkingRow text={statusLine} />
-            ) : null}
-            {!PLAIN_UI &&
-            undoBanner &&
-            !pendingShell &&
-            !pendingPlan &&
-            !pendingReviseEditor &&
-            !pendingSessionsPicker &&
-            !pendingMcpBrowser &&
-            !stagedInput &&
-            !pendingEditReview &&
-            !pendingCheckpoint &&
-            !stagedCheckpointRevise &&
-            !pendingChoice &&
-            !stagedChoiceCustom &&
-            !pendingRevision ? (
-              <UndoBanner banner={undoBanner} />
-            ) : null}
-            {/*
+              {!PLAIN_UI &&
+              !pendingShell &&
+              !pendingPlan &&
+              !pendingReviseEditor &&
+              !pendingSessionsPicker &&
+              !pendingMcpBrowser &&
+              !stagedInput &&
+              !pendingEditReview &&
+              !pendingCheckpoint &&
+              !stagedCheckpointRevise &&
+              ongoingTool ? (
+                <OngoingToolRow tool={ongoingTool} progress={toolProgress} />
+              ) : null}
+              {!PLAIN_UI &&
+              !pendingShell &&
+              !pendingPlan &&
+              !pendingReviseEditor &&
+              !pendingSessionsPicker &&
+              !pendingMcpBrowser &&
+              !stagedInput &&
+              !pendingEditReview &&
+              !pendingCheckpoint &&
+              !stagedCheckpointRevise &&
+              subagentActivity ? (
+                <SubagentRow activity={subagentActivity} />
+              ) : null}
+              {!PLAIN_UI &&
+              !pendingShell &&
+              !pendingPlan &&
+              !pendingReviseEditor &&
+              !pendingSessionsPicker &&
+              !pendingMcpBrowser &&
+              !stagedInput &&
+              !pendingEditReview &&
+              !pendingCheckpoint &&
+              !stagedCheckpointRevise &&
+              !ongoingTool &&
+              statusLine ? (
+                <ThinkingRow text={statusLine} />
+              ) : null}
+              {!PLAIN_UI &&
+              undoBanner &&
+              !pendingShell &&
+              !pendingPlan &&
+              !pendingReviseEditor &&
+              !pendingSessionsPicker &&
+              !pendingMcpBrowser &&
+              !stagedInput &&
+              !pendingEditReview &&
+              !pendingCheckpoint &&
+              !stagedCheckpointRevise &&
+              !pendingChoice &&
+              !stagedChoiceCustom &&
+              !pendingRevision ? (
+                <UndoBanner banner={undoBanner} />
+              ) : null}
+              {/*
           Belt-and-suspenders fallback: if we're busy but NONE of the
           specific indicators (streaming, ongoingTool, statusLine) is
           visible, something is still happening — show a generic
@@ -3272,223 +3274,224 @@ function AppInner({
           without a label. Catches micro-gaps between events that the
           targeted status lines don't cover.
         */}
-            {!PLAIN_UI &&
-            !pendingShell &&
-            !pendingPlan &&
-            !pendingReviseEditor &&
-            !pendingSessionsPicker &&
-            !pendingMcpBrowser &&
-            !stagedInput &&
-            !pendingEditReview &&
-            !pendingCheckpoint &&
-            !stagedCheckpointRevise &&
-            busy &&
-            !isStreaming &&
-            !ongoingTool &&
-            !statusLine ? (
-              <ThinkingRow text="processing…" />
-            ) : null}
-            <ToastRail />
-          </Box>
-          {!PLAIN_UI && activePlanCard ? (
-            <Box flexDirection="column" marginY={1}>
-              <PlanCard card={activePlanCard} />
+              {!PLAIN_UI &&
+              !pendingShell &&
+              !pendingPlan &&
+              !pendingReviseEditor &&
+              !pendingSessionsPicker &&
+              !pendingMcpBrowser &&
+              !stagedInput &&
+              !pendingEditReview &&
+              !pendingCheckpoint &&
+              !stagedCheckpointRevise &&
+              busy &&
+              !isStreaming &&
+              !ongoingTool &&
+              !statusLine ? (
+                <ThinkingRow text="processing…" />
+              ) : null}
+              <ToastRail />
             </Box>
-          ) : null}
-          {stagedInput ? (
-            <PlanRefineInput
-              mode={stagedInput.mode}
-              onSubmit={handleStagedInputSubmit}
-              onCancel={handleStagedInputCancel}
-            />
-          ) : stagedCheckpointRevise ? (
-            <PlanRefineInput
-              mode="checkpoint-revise"
-              onSubmit={handleCheckpointReviseSubmit}
-              onCancel={handleCheckpointReviseCancel}
-            />
-          ) : stagedChoiceCustom ? (
-            <PlanRefineInput
-              mode="choice-custom"
-              onSubmit={handleChoiceCustomSubmit}
-              onCancel={handleChoiceCustomCancel}
-            />
-          ) : pendingChoice ? (
-            <ChoiceConfirm
-              question={pendingChoice.question}
-              options={pendingChoice.options}
-              allowCustom={pendingChoice.allowCustom}
-              onChoose={stableHandleChoiceConfirm}
-            />
-          ) : pendingRevision ? (
-            <PlanReviseConfirm
-              reason={pendingRevision.reason}
-              oldRemaining={(planStepsRef.current ?? []).filter(
-                (s) => !completedStepIdsRef.current.has(s.id),
-              )}
-              newRemaining={pendingRevision.remainingSteps}
-              summary={pendingRevision.summary}
-              onChoose={stableHandleReviseConfirm}
-            />
-          ) : pendingCheckpoint ? (
-            <PlanCheckpointConfirm
-              stepId={pendingCheckpoint.stepId}
-              title={pendingCheckpoint.title}
-              completed={pendingCheckpoint.completed}
-              total={pendingCheckpoint.total}
-              steps={planStepsRef.current ?? undefined}
-              completedStepIds={completedStepIdsRef.current}
-              onChoose={stableHandleCheckpointConfirm}
-            />
-          ) : pendingSessionsPicker ? (
-            <SessionPicker
-              sessions={sessionsPickerList}
-              workspace={currentRootDir}
-              onChoose={(outcome) => {
-                if (outcome.kind === "open") {
-                  setPendingSessionsPicker(false);
-                  if (onSwitchSession) {
-                    onSwitchSession(outcome.name);
-                  } else {
-                    log.pushInfo(
-                      `▸ to switch to "${outcome.name}", quit and run: reasonix chat --session ${outcome.name}`,
-                    );
-                  }
-                  return;
-                }
-                if (outcome.kind === "new") {
-                  setPendingSessionsPicker(false);
-                  if (onSwitchSession) {
-                    onSwitchSession(undefined);
-                  } else {
-                    log.pushInfo(
-                      "▸ to start a fresh session, quit and run: reasonix chat (no --session flag)",
-                    );
-                  }
-                  return;
-                }
-                if (outcome.kind === "delete") {
-                  deleteSession(outcome.name);
-                  setSessionsPickerList(listSessionsForWorkspace(currentRootDir));
-                  return;
-                }
-                if (outcome.kind === "rename") {
-                  renameSession(outcome.name, outcome.newName);
-                  setSessionsPickerList(listSessionsForWorkspace(currentRootDir));
-                  return;
-                }
-                if (outcome.kind === "quit") {
-                  setPendingSessionsPicker(false);
-                }
-              }}
-            />
-          ) : pendingMcpBrowser ? (
-            <McpBrowser
-              servers={mcpServers ?? []}
-              configPath={defaultConfigPath()}
-              onClose={() => setPendingMcpBrowser(false)}
-              postInfo={(text) => log.pushInfo(text)}
-              applyAppend={(target, addedTools) => applyMcpAppend(loop, target, addedTools)}
-            />
-          ) : pendingPlan ? (
-            <PlanConfirm
-              plan={pendingPlan}
-              steps={planStepsRef.current ?? undefined}
-              summary={planSummaryRef.current ?? undefined}
-              onChoose={stableHandlePlanConfirm}
-              projectRoot={currentRootDir}
-            />
-          ) : pendingReviseEditor ? (
-            <PlanReviseEditor
-              steps={planStepsRef.current ?? []}
-              completedStepIds={completedStepIdsRef.current}
-              onAccept={(revised, skippedIds) => {
-                planStepsRef.current = revised;
-                for (const id of skippedIds) completedStepIdsRef.current.add(id);
-                persistPlanState();
-                const planText = pendingReviseEditor;
-                setPendingReviseEditor(null);
-                setPendingPlan(planText);
-              }}
-              onCancel={() => {
-                const planText = pendingReviseEditor;
-                setPendingReviseEditor(null);
-                setPendingPlan(planText);
-              }}
-            />
-          ) : pendingShell ? (
-            <ShellConfirm
-              command={pendingShell.command}
-              allowPrefix={derivePrefix(pendingShell.command)}
-              kind={pendingShell.kind}
-              onChoose={handleShellConfirm}
-            />
-          ) : pendingEditReview ? (
-            <EditConfirm
-              block={pendingEditReview}
-              onChoose={(choice, denyContext) => {
-                const resolve = editReviewResolveRef.current;
-                if (resolve) {
-                  editReviewResolveRef.current = null;
-                  resolve({ choice, denyContext });
-                }
-              }}
-            />
-          ) : walkthroughActive && pendingEdits.current.length > 0 ? (
-            <EditConfirm
-              // pendingTick re-keys the modal so each apply/discard
-              // forces a remount with the NEW first block. Without it,
-              // EditConfirm's internal scroll state would persist
-              // across blocks, which is the wrong UX.
-              key={`walk-${pendingTick}`}
-              block={pendingEdits.current[0]!}
-              onChoose={handleWalkChoice}
-            />
-          ) : (
-            <>
-              {codeMode ? (
-                <ModeStatusBar
-                  editMode={editMode}
-                  pendingCount={pendingCount}
-                  flash={modeFlash}
-                  planMode={planMode}
-                  undoArmed={!!undoBanner || hasUndoable()}
-                  jobs={codeMode.jobs}
-                />
-              ) : null}
-              {activeLoop ? <LoopStatusRow loop={activeLoop} /> : null}
-              <StatusRow />
-              <PromptInput
-                value={input}
-                onChange={setInput}
-                onSubmit={handleSubmit}
-                disabled={busy}
-                onHistoryPrev={recallPrev}
-                onHistoryNext={recallNext}
+            {!PLAIN_UI && activePlanCard ? (
+              <Box flexDirection="column" marginY={1}>
+                <PlanCard card={activePlanCard} />
+              </Box>
+            ) : null}
+            {stagedInput ? (
+              <PlanRefineInput
+                mode={stagedInput.mode}
+                onSubmit={handleStagedInputSubmit}
+                onCancel={handleStagedInputCancel}
               />
-              {slashMatches !== null ? (
-                <SlashSuggestions matches={slashMatches} selectedIndex={slashSelected} />
-              ) : null}
-              {atMatches !== null ? (
-                <AtMentionSuggestions
-                  matches={atMatches}
-                  selectedIndex={atSelected}
-                  query={atPicker?.query ?? ""}
+            ) : stagedCheckpointRevise ? (
+              <PlanRefineInput
+                mode="checkpoint-revise"
+                onSubmit={handleCheckpointReviseSubmit}
+                onCancel={handleCheckpointReviseCancel}
+              />
+            ) : stagedChoiceCustom ? (
+              <PlanRefineInput
+                mode="choice-custom"
+                onSubmit={handleChoiceCustomSubmit}
+                onCancel={handleChoiceCustomCancel}
+              />
+            ) : pendingChoice ? (
+              <ChoiceConfirm
+                question={pendingChoice.question}
+                options={pendingChoice.options}
+                allowCustom={pendingChoice.allowCustom}
+                onChoose={stableHandleChoiceConfirm}
+              />
+            ) : pendingRevision ? (
+              <PlanReviseConfirm
+                reason={pendingRevision.reason}
+                oldRemaining={(planStepsRef.current ?? []).filter(
+                  (s) => !completedStepIdsRef.current.has(s.id),
+                )}
+                newRemaining={pendingRevision.remainingSteps}
+                summary={pendingRevision.summary}
+                onChoose={stableHandleReviseConfirm}
+              />
+            ) : pendingCheckpoint ? (
+              <PlanCheckpointConfirm
+                stepId={pendingCheckpoint.stepId}
+                title={pendingCheckpoint.title}
+                completed={pendingCheckpoint.completed}
+                total={pendingCheckpoint.total}
+                steps={planStepsRef.current ?? undefined}
+                completedStepIds={completedStepIdsRef.current}
+                onChoose={stableHandleCheckpointConfirm}
+              />
+            ) : pendingSessionsPicker ? (
+              <SessionPicker
+                sessions={sessionsPickerList}
+                workspace={currentRootDir}
+                onChoose={(outcome) => {
+                  if (outcome.kind === "open") {
+                    setPendingSessionsPicker(false);
+                    if (onSwitchSession) {
+                      onSwitchSession(outcome.name);
+                    } else {
+                      log.pushInfo(
+                        `▸ to switch to "${outcome.name}", quit and run: reasonix chat --session ${outcome.name}`,
+                      );
+                    }
+                    return;
+                  }
+                  if (outcome.kind === "new") {
+                    setPendingSessionsPicker(false);
+                    if (onSwitchSession) {
+                      onSwitchSession(undefined);
+                    } else {
+                      log.pushInfo(
+                        "▸ to start a fresh session, quit and run: reasonix chat (no --session flag)",
+                      );
+                    }
+                    return;
+                  }
+                  if (outcome.kind === "delete") {
+                    deleteSession(outcome.name);
+                    setSessionsPickerList(listSessionsForWorkspace(currentRootDir));
+                    return;
+                  }
+                  if (outcome.kind === "rename") {
+                    renameSession(outcome.name, outcome.newName);
+                    setSessionsPickerList(listSessionsForWorkspace(currentRootDir));
+                    return;
+                  }
+                  if (outcome.kind === "quit") {
+                    setPendingSessionsPicker(false);
+                  }
+                }}
+              />
+            ) : pendingMcpBrowser ? (
+              <McpBrowser
+                servers={mcpServers ?? []}
+                configPath={defaultConfigPath()}
+                onClose={() => setPendingMcpBrowser(false)}
+                postInfo={(text) => log.pushInfo(text)}
+                applyAppend={(target, addedTools) => applyMcpAppend(loop, target, addedTools)}
+              />
+            ) : pendingPlan ? (
+              <PlanConfirm
+                plan={pendingPlan}
+                steps={planStepsRef.current ?? undefined}
+                summary={planSummaryRef.current ?? undefined}
+                onChoose={stableHandlePlanConfirm}
+                projectRoot={currentRootDir}
+              />
+            ) : pendingReviseEditor ? (
+              <PlanReviseEditor
+                steps={planStepsRef.current ?? []}
+                completedStepIds={completedStepIdsRef.current}
+                onAccept={(revised, skippedIds) => {
+                  planStepsRef.current = revised;
+                  for (const id of skippedIds) completedStepIdsRef.current.add(id);
+                  persistPlanState();
+                  const planText = pendingReviseEditor;
+                  setPendingReviseEditor(null);
+                  setPendingPlan(planText);
+                }}
+                onCancel={() => {
+                  const planText = pendingReviseEditor;
+                  setPendingReviseEditor(null);
+                  setPendingPlan(planText);
+                }}
+              />
+            ) : pendingShell ? (
+              <ShellConfirm
+                command={pendingShell.command}
+                allowPrefix={derivePrefix(pendingShell.command)}
+                kind={pendingShell.kind}
+                onChoose={handleShellConfirm}
+              />
+            ) : pendingEditReview ? (
+              <EditConfirm
+                block={pendingEditReview}
+                onChoose={(choice, denyContext) => {
+                  const resolve = editReviewResolveRef.current;
+                  if (resolve) {
+                    editReviewResolveRef.current = null;
+                    resolve({ choice, denyContext });
+                  }
+                }}
+              />
+            ) : walkthroughActive && pendingEdits.current.length > 0 ? (
+              <EditConfirm
+                // pendingTick re-keys the modal so each apply/discard
+                // forces a remount with the NEW first block. Without it,
+                // EditConfirm's internal scroll state would persist
+                // across blocks, which is the wrong UX.
+                key={`walk-${pendingTick}`}
+                block={pendingEdits.current[0]!}
+                onChoose={handleWalkChoice}
+              />
+            ) : (
+              <>
+                {codeMode ? (
+                  <ModeStatusBar
+                    editMode={editMode}
+                    pendingCount={pendingCount}
+                    flash={modeFlash}
+                    planMode={planMode}
+                    undoArmed={!!undoBanner || hasUndoable()}
+                    jobs={codeMode.jobs}
+                  />
+                ) : null}
+                {activeLoop ? <LoopStatusRow loop={activeLoop} /> : null}
+                <StatusRow />
+                <PromptInput
+                  value={input}
+                  onChange={setInput}
+                  onSubmit={handleSubmit}
+                  disabled={busy}
+                  onHistoryPrev={recallPrev}
+                  onHistoryNext={recallNext}
                 />
-              ) : null}
-              {slashArgContext ? (
-                <SlashArgPicker
-                  matches={slashArgMatches}
-                  selectedIndex={slashArgSelected}
-                  spec={slashArgContext.spec}
-                  kind={slashArgContext.kind}
-                  partial={slashArgContext.partial}
-                />
-              ) : null}
-              {/* CtxFooter retired — UsageCard auto-emits per turn covers the same data */}
-            </>
-          )}
-        </Box>
+                {slashMatches !== null ? (
+                  <SlashSuggestions matches={slashMatches} selectedIndex={slashSelected} />
+                ) : null}
+                {atMatches !== null ? (
+                  <AtMentionSuggestions
+                    matches={atMatches}
+                    selectedIndex={atSelected}
+                    query={atPicker?.query ?? ""}
+                  />
+                ) : null}
+                {slashArgContext ? (
+                  <SlashArgPicker
+                    matches={slashArgMatches}
+                    selectedIndex={slashArgSelected}
+                    spec={slashArgContext.spec}
+                    kind={slashArgContext.kind}
+                    partial={slashArgContext.partial}
+                  />
+                ) : null}
+                {/* CtxFooter retired — UsageCard auto-emits per turn covers the same data */}
+              </>
+            )}
+          </Box>
+        </ViewportBudgetProvider>
       </TickerProvider>
     </>
   );

--- a/src/cli/ui/ChoiceConfirm.tsx
+++ b/src/cli/ui/ChoiceConfirm.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import type { ChoiceOption } from "../../tools/choice.js";
 import { SingleSelect } from "./Select.js";
 import { ApprovalCard } from "./cards/ApprovalCard.js";
+import { useReserveRows } from "./layout/viewport-budget.js";
 
 export type ChoiceConfirmChoice =
   | { kind: "pick"; optionId: string }
@@ -22,6 +23,9 @@ const CUSTOM_VALUE = "__custom__";
 const CANCEL_VALUE = "__cancel__";
 
 function ChoiceConfirmInner({ question, options, allowCustom, onChoose }: ChoiceConfirmProps) {
+  const optionRows = options.length + (allowCustom ? 1 : 0) + 1; // +1 for cancel
+  useReserveRows("modal", { min: 6, max: Math.max(10, optionRows + 6) });
+
   const items: Array<{ value: string; label: string; hint?: string }> = options.map((opt) => ({
     value: opt.id,
     label: `${opt.id} · ${opt.title}`,

--- a/src/cli/ui/EditConfirm.tsx
+++ b/src/cli/ui/EditConfirm.tsx
@@ -1,4 +1,4 @@
-import { Box, Text, useStdout } from "ink";
+import { Box, Text } from "ink";
 import React, { useMemo, useState } from "react";
 import { formatEditBlockSplit } from "../../code/diff-preview.js";
 import type { EditBlock } from "../../code/edit-blocks.js";
@@ -6,6 +6,7 @@ import { DenyContextInput } from "./DenyContextInput.js";
 import { SplitDiff } from "./SplitDiff.js";
 import { ApprovalCard } from "./cards/ApprovalCard.js";
 import { useKeystroke } from "./keystroke-context.js";
+import { useReserveRows, useTotalRows } from "./layout/viewport-budget.js";
 
 export type EditReviewChoice = "apply" | "reject" | "apply-rest-of-turn" | "flip-to-auto";
 
@@ -21,9 +22,14 @@ const REVIEW_FOOTER =
   "[y/Enter] apply  ·  [n] reject with reason  ·  [a] apply rest  ·  [A] flip AUTO  ·  [↑↓/Space] scroll  ·  [Esc] abort";
 
 export function EditConfirm({ block, onChoose }: EditConfirmProps) {
-  const { stdout } = useStdout();
-  const rows = stdout?.rows ?? 40;
-  const budget = Math.max(MIN_DIFF_ROWS, rows - MODAL_OVERHEAD_ROWS);
+  const rows = useTotalRows();
+  // Modal zone is highest priority. Min = chrome + minimum useful diff;
+  // max leaves a few rows for the toast rail / streaming-card footer above.
+  const allocated = useReserveRows("modal", {
+    min: MODAL_OVERHEAD_ROWS + MIN_DIFF_ROWS,
+    max: Math.max(MODAL_OVERHEAD_ROWS + MIN_DIFF_ROWS, rows - 4),
+  });
+  const budget = Math.max(MIN_DIFF_ROWS, allocated - MODAL_OVERHEAD_ROWS);
 
   const allRows = useMemo(
     () => formatEditBlockSplit(block, { contextLines: 2, maxLines: 100_000 }),

--- a/src/cli/ui/PlanCheckpointConfirm.tsx
+++ b/src/cli/ui/PlanCheckpointConfirm.tsx
@@ -7,6 +7,7 @@ import type { PlanStep } from "../../tools/plan.js";
 import { PlanStepList, type StepStatus } from "./PlanStepList.js";
 import { SingleSelect } from "./Select.js";
 import { ApprovalCard } from "./cards/ApprovalCard.js";
+import { useReserveRows } from "./layout/viewport-budget.js";
 
 export type CheckpointChoice = "continue" | "revise" | "stop";
 
@@ -31,6 +32,12 @@ function PlanCheckpointConfirmInner({
   completedStepIds,
   onChoose,
 }: PlanCheckpointConfirmProps) {
+  // Step list grows with plan size; cap roughly at 20 visible-step-ish rows
+  // plus the 3 picker options + chrome. This is the lamyc-video trigger:
+  // checkpoint + write_file streaming above.
+  const stepRows = steps?.length ?? 0;
+  useReserveRows("modal", { min: 10, max: Math.max(14, stepRows + 12) });
+
   const label = title ? `${stepId} · ${title}` : stepId;
   const counter = total > 0 ? `${completed}/${total}` : "";
   const isLast = total > 0 && completed >= total;

--- a/src/cli/ui/PlanConfirm.tsx
+++ b/src/cli/ui/PlanConfirm.tsx
@@ -7,6 +7,7 @@ import type { PlanStep } from "../../tools/plan.js";
 import { PlanStepList } from "./PlanStepList.js";
 import { SingleSelect } from "./Select.js";
 import { ApprovalCard } from "./cards/ApprovalCard.js";
+import { useReserveRows } from "./layout/viewport-budget.js";
 import { CARD, TONE } from "./theme/tokens.js";
 
 export type PlanConfirmChoice = "approve" | "refine" | "revise" | "cancel";
@@ -21,6 +22,9 @@ export interface PlanConfirmProps {
 }
 
 function PlanConfirmInner({ plan, steps, onChoose }: PlanConfirmProps) {
+  const stepRows = steps?.length ?? 0;
+  useReserveRows("modal", { min: 10, max: Math.max(16, stepRows + 14) });
+
   const hasOpenQuestions =
     /^#{1,6}\s*(open[-\s]?questions?|risks?|unknowns?|assumptions?|unclear)/im.test(plan) ||
     /^#{1,6}\s*(待确认|开放问题|风险|未知|假设|不确定)/im.test(plan);

--- a/src/cli/ui/PromptInput.tsx
+++ b/src/cli/ui/PromptInput.tsx
@@ -2,6 +2,7 @@ import { Box, Text, useStdout } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React as a runtime value (classic transform compiles JSX to React.createElement)
 import React, { useRef, useState } from "react";
 import { useKeystroke } from "./keystroke-context.js";
+import { useReserveRows } from "./layout/viewport-budget.js";
 import { type MultilineKey, lineAndColumn, processMultilineKey } from "./multiline-keys.js";
 import {
   PASTE_SENTINEL_RANGE,
@@ -43,6 +44,12 @@ export function PromptInput({
   onHistoryPrev,
   onHistoryNext,
 }: PromptInputProps) {
+  // Claim the input zone so the streaming card above clamps when the prompt
+  // grows multi-line. Cap at 24 — the renderItems collapser already hides
+  // content past ~20 logical lines, so the visual height never exceeds that.
+  const inputLineCount = value.length > 0 ? value.split("\n").length : 1;
+  useReserveRows("input", { min: 1, max: Math.min(inputLineCount + 3, 24) });
+
   const [cursor, setCursor] = useState(value.length);
 
   // Paste registry — keyed by sentinel id, holds original content.

--- a/src/cli/ui/ShellConfirm.tsx
+++ b/src/cli/ui/ShellConfirm.tsx
@@ -4,6 +4,7 @@ import React, { useState } from "react";
 import { DenyContextInput } from "./DenyContextInput.js";
 import { SingleSelect } from "./Select.js";
 import { ApprovalCard } from "./cards/ApprovalCard.js";
+import { useReserveRows } from "./layout/viewport-budget.js";
 import { FG, TONE } from "./theme/tokens.js";
 
 export type ShellConfirmChoice = "run_once" | "always_allow" | "deny";
@@ -18,6 +19,11 @@ export interface ShellConfirmProps {
 }
 
 export function ShellConfirm({ command, allowPrefix, kind, onChoose }: ShellConfirmProps) {
+  // Claim modal zone so the streaming card above clamps. Header/footer + 3
+  // options + spacing → ~12 rows max; deny phase swaps to DenyContextInput
+  // which is similar height.
+  useReserveRows("modal", { min: 8, max: 14 });
+
   const isBackground = kind === "run_background";
   const subtitle = isBackground
     ? "long-running process — keeps running after approval, /kill to stop"

--- a/src/cli/ui/cards/StreamingCard.tsx
+++ b/src/cli/ui/cards/StreamingCard.tsx
@@ -2,12 +2,12 @@ import { Box, Text, useStdout } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React from "react";
 import { clipToCells } from "../../../frame/width.js";
+import { useReserveRows } from "../layout/viewport-budget.js";
 import { Markdown } from "../markdown.js";
 import { BarRow, CursorBlock } from "../primitives/BarRow.js";
 import type { StreamingCard as StreamingCardData } from "../state/cards.js";
 import { FG, TONE } from "../theme/tokens.js";
 
-const RESERVED_CHROME_ROWS = 14;
 const BODY_INDENT_CELLS = 5;
 
 export function StreamingCard({ card }: { card: StreamingCardData }): React.ReactElement {
@@ -22,11 +22,13 @@ export function StreamingCard({ card }: { card: StreamingCardData }): React.Reac
   }
 
   const { stdout } = useStdout();
-  const rows = stdout?.rows ?? 40;
   const cols = stdout?.columns ?? 80;
   const lineCells = Math.max(20, cols - BODY_INDENT_CELLS - 1);
   const allLines = card.text.length > 0 ? card.text.split("\n") : [""];
-  const budget = Math.max(8, rows - RESERVED_CHROME_ROWS);
+  // Stream zone soaks whatever rows the higher-priority modal/plan-card/input
+  // didn't claim. Min 4 keeps a "▶ + 3 lines" footer visible even when a modal
+  // takes the whole viewport.
+  const budget = useReserveRows("stream", { min: 4, max: Number.POSITIVE_INFINITY });
   const reserved = (card.aborted ? 2 : 0) + 1;
   const lineSlots = Math.max(4, budget - reserved);
   const overflows = !card.done && allLines.length > lineSlots;

--- a/src/cli/ui/layout/viewport-budget.tsx
+++ b/src/cli/ui/layout/viewport-budget.tsx
@@ -1,0 +1,189 @@
+/**
+ * Viewport row-budget — single layout authority for vertical row allocation.
+ *
+ * Solves the "two components race for the same rows" class of bug by making
+ * row claims explicit. Each component declares `{ min, max }` rows it wants
+ * for its zone; the provider runs a priority-greedy allocator and feeds each
+ * component back its actual allocation. No more magic `RESERVED_CHROME_ROWS = 14`
+ * scattered across files.
+ */
+
+import { useStdout } from "ink";
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React, { createContext, useContext, useEffect, useMemo, useReducer, useRef } from "react";
+
+export type ZoneId = "modal" | "plan-card" | "status" | "input" | "stream" | "safety";
+
+/**
+ * Higher number = claims rows first. Modal wins over stream because user
+ * focus is the modal; stream is "soak the rest". Safety is the lowest
+ * positive number so the unobservable margin always survives.
+ */
+const ZONE_PRIORITY: Record<ZoneId, number> = {
+  modal: 100,
+  "plan-card": 80,
+  status: 60,
+  input: 50,
+  stream: 10,
+  safety: 5,
+};
+
+export interface ClaimSpec {
+  /** Smallest acceptable allocation. May exceed total rows on tiny terminals. */
+  min: number;
+  /** Hard ceiling. `Number.POSITIVE_INFINITY` = "soak whatever's left". */
+  max: number;
+}
+
+interface InternalClaim extends ClaimSpec {
+  zone: ZoneId;
+  priority: number;
+}
+
+/** Pure allocator — used by the provider and tested in isolation. */
+export function allocateRows(
+  claims: ReadonlyArray<InternalClaim>,
+  totalRows: number,
+): ReadonlyMap<ZoneId, number> {
+  const sorted = [...claims].sort((a, b) => b.priority - a.priority);
+  const out = new Map<ZoneId, number>();
+  let remaining = Math.max(0, totalRows);
+  for (const c of sorted) {
+    const want = Math.min(c.max, Math.max(c.min, remaining));
+    out.set(c.zone, want);
+    remaining = Math.max(0, remaining - want);
+  }
+  return out;
+}
+
+interface BudgetState {
+  /** Active claims keyed by zone — one consumer per zone. */
+  claims: ReadonlyMap<ZoneId, ClaimSpec>;
+  totalRows: number;
+}
+
+type BudgetAction =
+  | { type: "claim"; zone: ZoneId; spec: ClaimSpec }
+  | { type: "release"; zone: ZoneId }
+  | { type: "resize"; rows: number };
+
+function reducer(state: BudgetState, action: BudgetAction): BudgetState {
+  switch (action.type) {
+    case "claim": {
+      const next = new Map(state.claims);
+      next.set(action.zone, action.spec);
+      return { ...state, claims: next };
+    }
+    case "release": {
+      if (!state.claims.has(action.zone)) return state;
+      const next = new Map(state.claims);
+      next.delete(action.zone);
+      return { ...state, claims: next };
+    }
+    case "resize":
+      if (action.rows === state.totalRows) return state;
+      return { ...state, totalRows: action.rows };
+  }
+}
+
+interface BudgetContextValue {
+  totalRows: number;
+  allocations: ReadonlyMap<ZoneId, number>;
+  claims: ReadonlyMap<ZoneId, ClaimSpec>;
+  dispatch: React.Dispatch<BudgetAction>;
+}
+
+const BudgetContext = createContext<BudgetContextValue | null>(null);
+
+export interface ViewportBudgetProviderProps {
+  children: React.ReactNode;
+  /** Test seam — bypasses useStdout. */
+  initialRows?: number;
+}
+
+export function ViewportBudgetProvider({
+  children,
+  initialRows,
+}: ViewportBudgetProviderProps): React.ReactElement {
+  const { stdout } = useStdout();
+  const [state, dispatch] = useReducer(reducer, undefined, () => ({
+    claims: new Map<ZoneId, ClaimSpec>(),
+    totalRows: initialRows ?? stdout?.rows ?? 40,
+  }));
+
+  // Single resize listener — children read totalRows from context instead of
+  // each calling useStdout themselves (N-1 fewer re-renders on resize).
+  useEffect(() => {
+    if (initialRows !== undefined) return undefined;
+    if (!stdout) return undefined;
+    const onResize = () => dispatch({ type: "resize", rows: stdout.rows ?? 40 });
+    onResize();
+    stdout.on("resize", onResize);
+    return () => {
+      stdout.off("resize", onResize);
+    };
+  }, [stdout, initialRows]);
+
+  const allocations = useMemo(() => {
+    const list: InternalClaim[] = [];
+    for (const [zone, spec] of state.claims) {
+      list.push({ zone, priority: ZONE_PRIORITY[zone], ...spec });
+    }
+    return allocateRows(list, state.totalRows);
+  }, [state.claims, state.totalRows]);
+
+  const value = useMemo<BudgetContextValue>(
+    () => ({
+      totalRows: state.totalRows,
+      allocations,
+      claims: state.claims,
+      dispatch,
+    }),
+    [state.totalRows, allocations, state.claims],
+  );
+
+  return <BudgetContext.Provider value={value}>{children}</BudgetContext.Provider>;
+}
+
+/**
+ * Reserve rows for a zone. Returns the actual allocation (may differ from `max`
+ * on small terminals or when higher-priority zones claim first). Falls back to
+ * `max` when no provider is mounted (unit tests, plain-UI mode).
+ */
+export function useReserveRows(zone: ZoneId, spec: ClaimSpec): number {
+  const ctx = useContext(BudgetContext);
+  // Stable spec identity — re-dispatch only when min/max actually change.
+  const lastSpecRef = useRef<ClaimSpec | null>(null);
+  const last = lastSpecRef.current;
+  const changed = !last || last.min !== spec.min || last.max !== spec.max;
+  if (changed) lastSpecRef.current = spec;
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: spec identity managed via lastSpecRef
+  useEffect(() => {
+    if (!ctx) return undefined;
+    ctx.dispatch({ type: "claim", zone, spec: lastSpecRef.current ?? spec });
+    return () => {
+      ctx.dispatch({ type: "release", zone });
+    };
+  }, [ctx, zone, changed]);
+
+  if (!ctx) return Number.isFinite(spec.max) ? spec.max : 40;
+  const allocated = ctx.allocations.get(zone);
+  if (allocated !== undefined) return allocated;
+  // Pre-effect first render — return optimistic max so the first frame
+  // doesn't render at min and snap larger after the effect commits.
+  return Number.isFinite(spec.max) ? spec.max : ctx.totalRows;
+}
+
+/** Total terminal rows from the provider; falls back to useStdout if unmounted. */
+export function useTotalRows(): number {
+  const ctx = useContext(BudgetContext);
+  const { stdout } = useStdout();
+  return ctx?.totalRows ?? stdout?.rows ?? 40;
+}
+
+/** True when any modal-priority zone is claimed. Replaces the long !pendingShell && !pendingEdit && ... chains. */
+export function useIsModalActive(): boolean {
+  const ctx = useContext(BudgetContext);
+  return ctx?.claims.has("modal") ?? false;
+}

--- a/src/cli/ui/layout/viewport-budget.tsx
+++ b/src/cli/ui/layout/viewport-budget.tsx
@@ -10,7 +10,7 @@
 
 import { useStdout } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
-import React, { createContext, useContext, useEffect, useMemo, useReducer, useRef } from "react";
+import React, { createContext, useContext, useEffect, useMemo, useReducer } from "react";
 
 export type ZoneId = "modal" | "plan-card" | "status" | "input" | "stream" | "safety";
 
@@ -149,23 +149,22 @@ export function ViewportBudgetProvider({
  * Reserve rows for a zone. Returns the actual allocation (may differ from `max`
  * on small terminals or when higher-priority zones claim first). Falls back to
  * `max` when no provider is mounted (unit tests, plain-UI mode).
+ *
+ * Effect deps key off `dispatch` (stable from useReducer) + spec primitives,
+ * NOT the whole ctx object — ctx identity changes after every claim and would
+ * loop the effect indefinitely.
  */
 export function useReserveRows(zone: ZoneId, spec: ClaimSpec): number {
   const ctx = useContext(BudgetContext);
-  // Stable spec identity — re-dispatch only when min/max actually change.
-  const lastSpecRef = useRef<ClaimSpec | null>(null);
-  const last = lastSpecRef.current;
-  const changed = !last || last.min !== spec.min || last.max !== spec.max;
-  if (changed) lastSpecRef.current = spec;
+  const dispatch = ctx?.dispatch;
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: spec identity managed via lastSpecRef
   useEffect(() => {
-    if (!ctx) return undefined;
-    ctx.dispatch({ type: "claim", zone, spec: lastSpecRef.current ?? spec });
+    if (!dispatch) return undefined;
+    dispatch({ type: "claim", zone, spec: { min: spec.min, max: spec.max } });
     return () => {
-      ctx.dispatch({ type: "release", zone });
+      dispatch({ type: "release", zone });
     };
-  }, [ctx, zone, changed]);
+  }, [dispatch, zone, spec.min, spec.max]);
 
   if (!ctx) return Number.isFinite(spec.max) ? spec.max : 40;
   const allocated = ctx.allocations.get(zone);

--- a/tests/viewport-budget.test.ts
+++ b/tests/viewport-budget.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { type ZoneId, allocateRows } from "../src/cli/ui/layout/viewport-budget.js";
+
+const ZONE_PRIORITY: Record<ZoneId, number> = {
+  modal: 100,
+  "plan-card": 80,
+  status: 60,
+  input: 50,
+  stream: 10,
+  safety: 5,
+};
+
+function claim(zone: ZoneId, min: number, max: number) {
+  return { zone, priority: ZONE_PRIORITY[zone], min, max };
+}
+
+describe("allocateRows — priority-greedy allocation", () => {
+  it("single claim gets exactly its max when terminal is large enough", () => {
+    const out = allocateRows([claim("modal", 18, 30)], 50);
+    expect(out.get("modal")).toBe(30);
+  });
+
+  it("single claim is capped to its max even with rows to spare", () => {
+    const out = allocateRows([claim("status", 1, 1)], 50);
+    expect(out.get("status")).toBe(1);
+  });
+
+  it("modal wins over stream when rows are tight", () => {
+    // Total 30 rows; modal wants 26-26 (fixed), stream wants 4..∞
+    const out = allocateRows(
+      [claim("modal", 26, 26), claim("stream", 4, Number.POSITIVE_INFINITY)],
+      30,
+    );
+    expect(out.get("modal")).toBe(26);
+    // Stream gets the remaining 4
+    expect(out.get("stream")).toBe(4);
+  });
+
+  it("stream soaks remainder when stream max is unbounded", () => {
+    const out = allocateRows([claim("stream", 4, Number.POSITIVE_INFINITY)], 50);
+    expect(out.get("stream")).toBe(50);
+  });
+
+  it("higher priority claim always allocated first regardless of insertion order", () => {
+    // Insert stream before modal — priority sort still puts modal first.
+    const out = allocateRows(
+      [claim("stream", 4, Number.POSITIVE_INFINITY), claim("modal", 20, 25)],
+      30,
+    );
+    expect(out.get("modal")).toBe(25);
+    expect(out.get("stream")).toBe(5);
+  });
+
+  it("low-priority claim may exceed remaining rows when forced to its min", () => {
+    // 30-row term; modal claims 26, plan-card claims 5..5, stream wants min 4
+    const out = allocateRows(
+      [
+        claim("modal", 26, 26),
+        claim("plan-card", 5, 5),
+        claim("stream", 4, Number.POSITIVE_INFINITY),
+      ],
+      30,
+    );
+    expect(out.get("modal")).toBe(26);
+    // After modal, 4 rows left. plan-card forced to its min of 5 (exceeds avail).
+    expect(out.get("plan-card")).toBe(5);
+    // After plan-card forced to 5, stream gets its min of 4.
+    expect(out.get("stream")).toBe(4);
+  });
+
+  it("zero total rows still allocates each claim's min (defensive)", () => {
+    const out = allocateRows([claim("modal", 18, 30), claim("stream", 4, 100)], 0);
+    expect(out.get("modal")).toBe(18);
+    expect(out.get("stream")).toBe(4);
+  });
+
+  it("typical lamyc-video scenario: 50-row term, EditConfirm + streaming card", () => {
+    // EditConfirm: 18 chrome + 8 min diff = 26 min; max = rows - 4 = 46
+    // StreamingCard: 4 min, unbounded max
+    const out = allocateRows(
+      [claim("modal", 26, 46), claim("stream", 4, Number.POSITIVE_INFINITY)],
+      50,
+    );
+    // Modal greedy-grabs 46 of 50.
+    expect(out.get("modal")).toBe(46);
+    // Stream forced to its min of 4 (remaining was 4, min is 4 — fits exactly).
+    expect(out.get("stream")).toBe(4);
+    // Total claimed: 50 — fits the viewport. No race.
+  });
+
+  it("no claims yields empty map", () => {
+    const out = allocateRows([], 50);
+    expect(out.size).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #120.

## Why

`StreamingCard`, `EditConfirm`, `ShellConfirm`, and friends each read `stdout.rows` and computed their own row budget independently. Two scattered constants encoded the assumption: `RESERVED_CHROME_ROWS = 14` (StreamingCard) and `MODAL_OVERHEAD_ROWS = 18` (EditConfirm). Neither knew about the other.

Result: when an approval modal mounted while a tool card was still streaming (lamyc's video — write_file streaming + plan checkpoint approval), both layers claimed rows that together exceeded the viewport. Ink reflowed every frame, producing visible vertical jitter.

The class-of-bug part: every new bottom-anchored component added another independent calculation. A targeted patch would land another magic constant; the next bug just moves to a new component.

## What

- New `src/cli/ui/layout/viewport-budget.tsx` — `ViewportBudgetProvider` + `useReserveRows(zone, { min, max })` hook + pure `allocateRows()` allocator. Priority-greedy: `modal > plan-card > status > input > stream > safety`.
- Migrated `StreamingCard`, `EditConfirm`, `ShellConfirm`, `PlanCheckpointConfirm`, `PlanConfirm`, `ChoiceConfirm`, `PromptInput`. Each declares its zone claim; the provider runs allocation and feeds back actual budgets.
- `RESERVED_CHROME_ROWS` and the standalone `MODAL_OVERHEAD_ROWS` reads are gone. `useTotalRows()` / `useIsModalActive()` replace direct `useStdout` reads in those paths.

## Out of scope (follow-up)

- `PlanCard` anchored render in App.tsx — small height, doesn't trigger this bug, can plug in next pass.
- Status / activity rows (`OngoingToolRow`, `ThinkingRow`, etc.) — already conditionally hidden during modals, don't compete.
- Full-screen pickers (`SessionPicker`, `McpBrowser`, `PlanReviseEditor`) — independently take the viewport, not a competing layer.

## Verification

- `npm run verify` — typecheck, lint, build, 1791 tests all green
- 9 new test cases for the allocator (`tests/viewport-budget.test.ts`) covering single/multi claim, priority order, undersize-terminal fallback, and the lamyc scenario specifically