### PR TITLE
test: add preset resolution and canonicalization coverage

### DIFF
--- a/tests/presets.test.ts
+++ b/tests/presets.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { PRESETS, canonicalPresetName, resolvePreset } from "../src/cli/ui/presets.js";
+
+describe("resolvePreset", () => {
+  it("resolves built-in presets by canonical name", () => {
+    expect(resolvePreset("auto").model).toBe("deepseek-v4-flash");
+    expect(resolvePreset("flash").autoEscalate).toBe(false);
+    expect(resolvePreset("pro").reasoningEffort).toBe("max");
+  });
+
+  it("maps legacy aliases to current behavior", () => {
+    expect(resolvePreset("fast")).toMatchObject({
+      ...resolvePreset("flash"),
+      reasoningEffort: "high",
+    });
+    expect(resolvePreset("smart")).toMatchObject(resolvePreset("auto"));
+    expect(resolvePreset("max")).toMatchObject(resolvePreset("pro"));
+  });
+
+  it("falls back to auto when given undefined", () => {
+    expect(resolvePreset(undefined)).toMatchObject(resolvePreset("auto"));
+  });
+
+  it("falls back to auto when given unknown values", () => {
+    expect(resolvePreset("definitely-not-a-preset" as unknown as never)).toMatchObject(
+      resolvePreset("auto"),
+    );
+  });
+});
+
+describe("canonicalPresetName", () => {
+  it("returns canonical names for built-ins", () => {
+    expect(canonicalPresetName("auto")).toBe("auto");
+    expect(canonicalPresetName("flash")).toBe("flash");
+    expect(canonicalPresetName("pro")).toBe("pro");
+  });
+
+  it("normalizes legacy names to auto", () => {
+    expect(canonicalPresetName("fast")).toBe("auto");
+    expect(canonicalPresetName("smart")).toBe("auto");
+    expect(canonicalPresetName("max")).toBe("auto");
+  });
+
+  it("normalizes unknown values to auto", () => {
+    expect(canonicalPresetName("old" as unknown as never)).toBe("auto");
+  });
+});
+
+describe("preset invariants", () => {
+  it("keeps branch and harvest fixed across all presets", () => {
+    for (const [name, preset] of Object.entries(PRESETS)) {
+      expect(preset.harvest).toBe(false);
+      expect(preset.branch).toBe(1);
+      expect(["auto", "flash", "pro"]).toContain(name);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds focused test coverage for preset resolution behavior requested in #100.
- Adds three new test suites for `resolvePreset`, `canonicalPresetName`, and preset invariants.

## Changes
- New `tests/presets.test.ts` covering:
  - resolving built-in presets (`auto`, `flash`, `pro`)
  - legacy alias mapping (`fast`, `smart`, `max`)
  - unknown/undefined fallback behavior to `auto`
  - invariant checks for all built-in preset defaults (`harvest === false`, `branch === 1`)

## Testing
- `npm install`
- `npm run test -- tests/presets.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run verify` (passes with existing repository baseline warnings in unrelated files)

## Notes
- Maintains scope to one safe, narrowly-scoped test-only contribution.
- No code paths outside preset resolution behavior are changed.

Closes #100
