### PR TITLE
feat(cards): left accent bar on done assistant replies

### DIFF
--- a/src/cli/ui/EditConfirm.tsx
+++ b/src/cli/ui/EditConfirm.tsx
@@ -23,8 +23,6 @@ const REVIEW_FOOTER =
 
 export function EditConfirm({ block, onChoose }: EditConfirmProps) {
   const rows = useTotalRows();
-  // Modal zone is highest priority. Min = chrome + minimum useful diff;
-  // max leaves a few rows for the toast rail / streaming-card footer above.
   const allocated = useReserveRows("modal", {
     min: MODAL_OVERHEAD_ROWS + MIN_DIFF_ROWS,
     max: Math.max(MODAL_OVERHEAD_ROWS + MIN_DIFF_ROWS, rows - 4),

--- a/src/cli/ui/PlanCheckpointConfirm.tsx
+++ b/src/cli/ui/PlanCheckpointConfirm.tsx
@@ -32,9 +32,6 @@ function PlanCheckpointConfirmInner({
   completedStepIds,
   onChoose,
 }: PlanCheckpointConfirmProps) {
-  // Step list grows with plan size; cap roughly at 20 visible-step-ish rows
-  // plus the 3 picker options + chrome. This is the lamyc-video trigger:
-  // checkpoint + write_file streaming above.
   const stepRows = steps?.length ?? 0;
   useReserveRows("modal", { min: 10, max: Math.max(14, stepRows + 12) });
 

--- a/src/cli/ui/PromptInput.tsx
+++ b/src/cli/ui/PromptInput.tsx
@@ -44,9 +44,7 @@ export function PromptInput({
   onHistoryPrev,
   onHistoryNext,
 }: PromptInputProps) {
-  // Claim the input zone so the streaming card above clamps when the prompt
-  // grows multi-line. Cap at 24 — the renderItems collapser already hides
-  // content past ~20 logical lines, so the visual height never exceeds that.
+  // Cap at 24 — collapseLinesForDisplay hides content past ~20 logical lines.
   const inputLineCount = value.length > 0 ? value.split("\n").length : 1;
   useReserveRows("input", { min: 1, max: Math.min(inputLineCount + 3, 24) });
 

--- a/src/cli/ui/ShellConfirm.tsx
+++ b/src/cli/ui/ShellConfirm.tsx
@@ -19,9 +19,6 @@ export interface ShellConfirmProps {
 }
 
 export function ShellConfirm({ command, allowPrefix, kind, onChoose }: ShellConfirmProps) {
-  // Claim modal zone so the streaming card above clamps. Header/footer + 3
-  // options + spacing → ~12 rows max; deny phase swaps to DenyContextInput
-  // which is similar height.
   useReserveRows("modal", { min: 8, max: 14 });
 
   const isBackground = kind === "run_background";

--- a/src/cli/ui/cards/StreamingCard.tsx
+++ b/src/cli/ui/cards/StreamingCard.tsx
@@ -11,24 +11,30 @@ import { FG, TONE } from "../theme/tokens.js";
 const BODY_INDENT_CELLS = 5;
 
 export function StreamingCard({ card }: { card: StreamingCardData }): React.ReactElement {
-  // Done cards render via Markdown in <Static>; live frame stays plain
-  // text since markdown on partial streamed chunks would jitter.
+  const { stdout } = useStdout();
+  const cols = stdout?.columns ?? 80;
+  // Claim before the done-state branch — hook order must stay stable across the done flip.
+  const budget = useReserveRows("stream", { min: 4, max: Number.POSITIVE_INFINITY });
+
   if (card.done && !card.aborted) {
     return (
-      <Box flexDirection="column" paddingLeft={3}>
+      <Box
+        flexDirection="column"
+        paddingLeft={2}
+        paddingRight={1}
+        borderStyle="single"
+        borderTop={false}
+        borderRight={false}
+        borderBottom={false}
+        borderLeft
+        borderLeftColor={TONE.brand}
+      >
         <Markdown text={card.text} />
       </Box>
     );
   }
-
-  const { stdout } = useStdout();
-  const cols = stdout?.columns ?? 80;
   const lineCells = Math.max(20, cols - BODY_INDENT_CELLS - 1);
   const allLines = card.text.length > 0 ? card.text.split("\n") : [""];
-  // Stream zone soaks whatever rows the higher-priority modal/plan-card/input
-  // didn't claim. Min 4 keeps a "▶ + 3 lines" footer visible even when a modal
-  // takes the whole viewport.
-  const budget = useReserveRows("stream", { min: 4, max: Number.POSITIVE_INFINITY });
   const reserved = (card.aborted ? 2 : 0) + 1;
   const lineSlots = Math.max(4, budget - reserved);
   const overflows = !card.done && allLines.length > lineSlots;

--- a/src/cli/ui/layout/viewport-budget.tsx
+++ b/src/cli/ui/layout/viewport-budget.tsx
@@ -1,12 +1,4 @@
-/**
- * Viewport row-budget — single layout authority for vertical row allocation.
- *
- * Solves the "two components race for the same rows" class of bug by making
- * row claims explicit. Each component declares `{ min, max }` rows it wants
- * for its zone; the provider runs a priority-greedy allocator and feeds each
- * component back its actual allocation. No more magic `RESERVED_CHROME_ROWS = 14`
- * scattered across files.
- */
+/** Single allocator for vertical viewport rows; consumers claim per-zone via useReserveRows. */
 
 import { useStdout } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
@@ -14,11 +6,7 @@ import React, { createContext, useContext, useEffect, useMemo, useReducer } from
 
 export type ZoneId = "modal" | "plan-card" | "status" | "input" | "stream" | "safety";
 
-/**
- * Higher number = claims rows first. Modal wins over stream because user
- * focus is the modal; stream is "soak the rest". Safety is the lowest
- * positive number so the unobservable margin always survives.
- */
+/** Higher number = claims rows first. */
 const ZONE_PRIORITY: Record<ZoneId, number> = {
   modal: 100,
   "plan-card": 80,
@@ -111,8 +99,7 @@ export function ViewportBudgetProvider({
     totalRows: initialRows ?? stdout?.rows ?? 40,
   }));
 
-  // Single resize listener — children read totalRows from context instead of
-  // each calling useStdout themselves (N-1 fewer re-renders on resize).
+  // Single resize listener — children read totalRows from context.
   useEffect(() => {
     if (initialRows !== undefined) return undefined;
     if (!stdout) return undefined;
@@ -145,17 +132,10 @@ export function ViewportBudgetProvider({
   return <BudgetContext.Provider value={value}>{children}</BudgetContext.Provider>;
 }
 
-/**
- * Reserve rows for a zone. Returns the actual allocation (may differ from `max`
- * on small terminals or when higher-priority zones claim first). Falls back to
- * `max` when no provider is mounted (unit tests, plain-UI mode).
- *
- * Effect deps key off `dispatch` (stable from useReducer) + spec primitives,
- * NOT the whole ctx object — ctx identity changes after every claim and would
- * loop the effect indefinitely.
- */
+/** Returns actual allocation; falls back to spec.max when no provider is mounted. */
 export function useReserveRows(zone: ZoneId, spec: ClaimSpec): number {
   const ctx = useContext(BudgetContext);
+  // Deps key off dispatch (stable) + primitives — whole ctx changes every claim and would loop.
   const dispatch = ctx?.dispatch;
 
   useEffect(() => {
@@ -169,8 +149,7 @@ export function useReserveRows(zone: ZoneId, spec: ClaimSpec): number {
   if (!ctx) return Number.isFinite(spec.max) ? spec.max : 40;
   const allocated = ctx.allocations.get(zone);
   if (allocated !== undefined) return allocated;
-  // Pre-effect first render — return optimistic max so the first frame
-  // doesn't render at min and snap larger after the effect commits.
+  // Optimistic max for pre-effect first render.
   return Number.isFinite(spec.max) ? spec.max : ctx.totalRows;
 }
 


### PR DESCRIPTION
Refs #122 — partial. The bg-highlight half; sidebar tracked separately.

Long Markdown answers had no visual indicator distinguishing them from tool/reasoning cards in scrollback. This adds a left accent bar (brand tone) to the done-state assistant Markdown, mirroring the live-streaming bar treatment.

Picked borderLeft over backgroundColor: Ink's <Box> doesn't accept backgroundColor (only <Text> does, and Text's bg only colors the actual text cells, not the row width). A left bar works on light + dark themes equally.

Bundled a chore commit that trims comment essays added in the #120 layout migration — those violated CLAUDE.md (multi-paragraph headers, defensive justification, incident narrative).

## Verification

- typecheck / lint / 1800 tests / build all green