### PR TITLE
feat(tui): right-side context panel with Ctrl+\ toggle

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -32,9 +32,11 @@ import {
   editModeHintShown,
   loadEditMode,
   loadReasoningEffort,
+  loadSidebarOpen,
   markEditModeHintShown,
   saveEditMode,
   saveReasoningEffort,
+  saveSidebarOpen,
 } from "../../config.js";
 import { Eventizer } from "../../core/eventize.js";
 import { type ResolvedHook, formatHookOutcomeMessage, loadHooks, runHooks } from "../../hooks.js";
@@ -113,6 +115,7 @@ import {
   ThinkingRow,
   UndoBanner,
 } from "./layout/LiveRows.js";
+import { SIDEBAR_MIN_TOTAL_COLS, SidebarPanel } from "./layout/SidebarPanel.js";
 import { StatusRow } from "./layout/StatusRow.js";
 import { ToastRail } from "./layout/ToastRail.js";
 import { ViewportBudgetProvider } from "./layout/viewport-budget.js";
@@ -321,6 +324,23 @@ function AppInner({
   // "▸ tool<X> running…" pulse-spinner row so long tool calls don't
   // look like the app hung.
   const [ongoingTool, setOngoingTool] = useState<{ name: string; args?: string } | null>(null);
+  // Sidebar visibility — persisted in config; auto-init opens on cols ≥ 120.
+  const [sidebarOpen, setSidebarOpen] = useState<boolean>(() => {
+    const stored = loadSidebarOpen();
+    if (typeof stored === "boolean") return stored;
+    return (process.stdout.columns ?? 80) >= 120;
+  });
+  const toggleSidebar = useCallback(() => {
+    setSidebarOpen((cur) => {
+      const next = !cur;
+      try {
+        saveSidebarOpen(next);
+      } catch {
+        /* config write failures shouldn't break the UI */
+      }
+      return next;
+    });
+  }, []);
   // Latest progress frame for the currently-running tool (MCP
   // `notifications/progress`). `null` when no progress has been
   // reported for this tool call — OngoingToolRow still spins, just
@@ -1202,6 +1222,10 @@ function AppInner({
     }
     if (key.ctrl && key.input === "c") {
       quitProcess();
+      return;
+    }
+    if (key.ctrl && key.input === "\\") {
+      toggleSidebar();
       return;
     }
     if (key.escape && busy) {
@@ -3191,82 +3215,83 @@ function AppInner({
         }
       >
         <ViewportBudgetProvider>
-          <Box flexDirection="column">
-            <Box flexDirection="column">
-              <CardStream excludeId={activePlanCard?.id} />
-              {/*
+          <Box flexDirection="row">
+            <Box flexDirection="column" flexGrow={1}>
+              <Box flexDirection="column">
+                <CardStream excludeId={activePlanCard?.id} />
+                {/*
           Welcome card on the empty state. Visible only when nothing
           has happened yet (no past events, nothing in flight, no
           modal up). Removes the "what do I type?" friction without
           surviving past the first turn.
         */}
-              {!hasConversation && !busy && !isStreaming ? (
-                <WelcomeBanner inCodeMode={!!codeMode} dashboardUrl={dashboardUrl} />
-              ) : null}
-              {/*
+                {!hasConversation && !busy && !isStreaming ? (
+                  <WelcomeBanner inCodeMode={!!codeMode} dashboardUrl={dashboardUrl} />
+                ) : null}
+                {/*
           Live rows are hidden while the ShellConfirm modal is up — the
           model's concurrent "please confirm" stream is noise the user
           doesn't need, and the picker shouldn't fight it for visual
           attention. They come back naturally once the user chooses and
           the next turn begins.
         */}
-              {!PLAIN_UI &&
-              !pendingShell &&
-              !pendingPlan &&
-              !pendingReviseEditor &&
-              !pendingSessionsPicker &&
-              !pendingMcpBrowser &&
-              !stagedInput &&
-              !pendingEditReview &&
-              !pendingCheckpoint &&
-              !stagedCheckpointRevise &&
-              ongoingTool ? (
-                <OngoingToolRow tool={ongoingTool} progress={toolProgress} />
-              ) : null}
-              {!PLAIN_UI &&
-              !pendingShell &&
-              !pendingPlan &&
-              !pendingReviseEditor &&
-              !pendingSessionsPicker &&
-              !pendingMcpBrowser &&
-              !stagedInput &&
-              !pendingEditReview &&
-              !pendingCheckpoint &&
-              !stagedCheckpointRevise &&
-              subagentActivity ? (
-                <SubagentRow activity={subagentActivity} />
-              ) : null}
-              {!PLAIN_UI &&
-              !pendingShell &&
-              !pendingPlan &&
-              !pendingReviseEditor &&
-              !pendingSessionsPicker &&
-              !pendingMcpBrowser &&
-              !stagedInput &&
-              !pendingEditReview &&
-              !pendingCheckpoint &&
-              !stagedCheckpointRevise &&
-              !ongoingTool &&
-              statusLine ? (
-                <ThinkingRow text={statusLine} />
-              ) : null}
-              {!PLAIN_UI &&
-              undoBanner &&
-              !pendingShell &&
-              !pendingPlan &&
-              !pendingReviseEditor &&
-              !pendingSessionsPicker &&
-              !pendingMcpBrowser &&
-              !stagedInput &&
-              !pendingEditReview &&
-              !pendingCheckpoint &&
-              !stagedCheckpointRevise &&
-              !pendingChoice &&
-              !stagedChoiceCustom &&
-              !pendingRevision ? (
-                <UndoBanner banner={undoBanner} />
-              ) : null}
-              {/*
+                {!PLAIN_UI &&
+                !pendingShell &&
+                !pendingPlan &&
+                !pendingReviseEditor &&
+                !pendingSessionsPicker &&
+                !pendingMcpBrowser &&
+                !stagedInput &&
+                !pendingEditReview &&
+                !pendingCheckpoint &&
+                !stagedCheckpointRevise &&
+                ongoingTool ? (
+                  <OngoingToolRow tool={ongoingTool} progress={toolProgress} />
+                ) : null}
+                {!PLAIN_UI &&
+                !pendingShell &&
+                !pendingPlan &&
+                !pendingReviseEditor &&
+                !pendingSessionsPicker &&
+                !pendingMcpBrowser &&
+                !stagedInput &&
+                !pendingEditReview &&
+                !pendingCheckpoint &&
+                !stagedCheckpointRevise &&
+                subagentActivity ? (
+                  <SubagentRow activity={subagentActivity} />
+                ) : null}
+                {!PLAIN_UI &&
+                !pendingShell &&
+                !pendingPlan &&
+                !pendingReviseEditor &&
+                !pendingSessionsPicker &&
+                !pendingMcpBrowser &&
+                !stagedInput &&
+                !pendingEditReview &&
+                !pendingCheckpoint &&
+                !stagedCheckpointRevise &&
+                !ongoingTool &&
+                statusLine ? (
+                  <ThinkingRow text={statusLine} />
+                ) : null}
+                {!PLAIN_UI &&
+                undoBanner &&
+                !pendingShell &&
+                !pendingPlan &&
+                !pendingReviseEditor &&
+                !pendingSessionsPicker &&
+                !pendingMcpBrowser &&
+                !stagedInput &&
+                !pendingEditReview &&
+                !pendingCheckpoint &&
+                !stagedCheckpointRevise &&
+                !pendingChoice &&
+                !stagedChoiceCustom &&
+                !pendingRevision ? (
+                  <UndoBanner banner={undoBanner} />
+                ) : null}
+                {/*
           Belt-and-suspenders fallback: if we're busy but NONE of the
           specific indicators (streaming, ongoingTool, statusLine) is
           visible, something is still happening — show a generic
@@ -3274,222 +3299,228 @@ function AppInner({
           without a label. Catches micro-gaps between events that the
           targeted status lines don't cover.
         */}
-              {!PLAIN_UI &&
-              !pendingShell &&
-              !pendingPlan &&
-              !pendingReviseEditor &&
-              !pendingSessionsPicker &&
-              !pendingMcpBrowser &&
-              !stagedInput &&
-              !pendingEditReview &&
-              !pendingCheckpoint &&
-              !stagedCheckpointRevise &&
-              busy &&
-              !isStreaming &&
-              !ongoingTool &&
-              !statusLine ? (
-                <ThinkingRow text="processing…" />
-              ) : null}
-              <ToastRail />
-            </Box>
-            {!PLAIN_UI && activePlanCard ? (
-              <Box flexDirection="column" marginY={1}>
-                <PlanCard card={activePlanCard} />
+                {!PLAIN_UI &&
+                !pendingShell &&
+                !pendingPlan &&
+                !pendingReviseEditor &&
+                !pendingSessionsPicker &&
+                !pendingMcpBrowser &&
+                !stagedInput &&
+                !pendingEditReview &&
+                !pendingCheckpoint &&
+                !stagedCheckpointRevise &&
+                busy &&
+                !isStreaming &&
+                !ongoingTool &&
+                !statusLine ? (
+                  <ThinkingRow text="processing…" />
+                ) : null}
+                <ToastRail />
               </Box>
-            ) : null}
-            {stagedInput ? (
-              <PlanRefineInput
-                mode={stagedInput.mode}
-                onSubmit={handleStagedInputSubmit}
-                onCancel={handleStagedInputCancel}
-              />
-            ) : stagedCheckpointRevise ? (
-              <PlanRefineInput
-                mode="checkpoint-revise"
-                onSubmit={handleCheckpointReviseSubmit}
-                onCancel={handleCheckpointReviseCancel}
-              />
-            ) : stagedChoiceCustom ? (
-              <PlanRefineInput
-                mode="choice-custom"
-                onSubmit={handleChoiceCustomSubmit}
-                onCancel={handleChoiceCustomCancel}
-              />
-            ) : pendingChoice ? (
-              <ChoiceConfirm
-                question={pendingChoice.question}
-                options={pendingChoice.options}
-                allowCustom={pendingChoice.allowCustom}
-                onChoose={stableHandleChoiceConfirm}
-              />
-            ) : pendingRevision ? (
-              <PlanReviseConfirm
-                reason={pendingRevision.reason}
-                oldRemaining={(planStepsRef.current ?? []).filter(
-                  (s) => !completedStepIdsRef.current.has(s.id),
-                )}
-                newRemaining={pendingRevision.remainingSteps}
-                summary={pendingRevision.summary}
-                onChoose={stableHandleReviseConfirm}
-              />
-            ) : pendingCheckpoint ? (
-              <PlanCheckpointConfirm
-                stepId={pendingCheckpoint.stepId}
-                title={pendingCheckpoint.title}
-                completed={pendingCheckpoint.completed}
-                total={pendingCheckpoint.total}
-                steps={planStepsRef.current ?? undefined}
-                completedStepIds={completedStepIdsRef.current}
-                onChoose={stableHandleCheckpointConfirm}
-              />
-            ) : pendingSessionsPicker ? (
-              <SessionPicker
-                sessions={sessionsPickerList}
-                workspace={currentRootDir}
-                onChoose={(outcome) => {
-                  if (outcome.kind === "open") {
-                    setPendingSessionsPicker(false);
-                    if (onSwitchSession) {
-                      onSwitchSession(outcome.name);
-                    } else {
-                      log.pushInfo(
-                        `▸ to switch to "${outcome.name}", quit and run: reasonix chat --session ${outcome.name}`,
-                      );
-                    }
-                    return;
-                  }
-                  if (outcome.kind === "new") {
-                    setPendingSessionsPicker(false);
-                    if (onSwitchSession) {
-                      onSwitchSession(undefined);
-                    } else {
-                      log.pushInfo(
-                        "▸ to start a fresh session, quit and run: reasonix chat (no --session flag)",
-                      );
-                    }
-                    return;
-                  }
-                  if (outcome.kind === "delete") {
-                    deleteSession(outcome.name);
-                    setSessionsPickerList(listSessionsForWorkspace(currentRootDir));
-                    return;
-                  }
-                  if (outcome.kind === "rename") {
-                    renameSession(outcome.name, outcome.newName);
-                    setSessionsPickerList(listSessionsForWorkspace(currentRootDir));
-                    return;
-                  }
-                  if (outcome.kind === "quit") {
-                    setPendingSessionsPicker(false);
-                  }
-                }}
-              />
-            ) : pendingMcpBrowser ? (
-              <McpBrowser
-                servers={mcpServers ?? []}
-                configPath={defaultConfigPath()}
-                onClose={() => setPendingMcpBrowser(false)}
-                postInfo={(text) => log.pushInfo(text)}
-                applyAppend={(target, addedTools) => applyMcpAppend(loop, target, addedTools)}
-              />
-            ) : pendingPlan ? (
-              <PlanConfirm
-                plan={pendingPlan}
-                steps={planStepsRef.current ?? undefined}
-                summary={planSummaryRef.current ?? undefined}
-                onChoose={stableHandlePlanConfirm}
-                projectRoot={currentRootDir}
-              />
-            ) : pendingReviseEditor ? (
-              <PlanReviseEditor
-                steps={planStepsRef.current ?? []}
-                completedStepIds={completedStepIdsRef.current}
-                onAccept={(revised, skippedIds) => {
-                  planStepsRef.current = revised;
-                  for (const id of skippedIds) completedStepIdsRef.current.add(id);
-                  persistPlanState();
-                  const planText = pendingReviseEditor;
-                  setPendingReviseEditor(null);
-                  setPendingPlan(planText);
-                }}
-                onCancel={() => {
-                  const planText = pendingReviseEditor;
-                  setPendingReviseEditor(null);
-                  setPendingPlan(planText);
-                }}
-              />
-            ) : pendingShell ? (
-              <ShellConfirm
-                command={pendingShell.command}
-                allowPrefix={derivePrefix(pendingShell.command)}
-                kind={pendingShell.kind}
-                onChoose={handleShellConfirm}
-              />
-            ) : pendingEditReview ? (
-              <EditConfirm
-                block={pendingEditReview}
-                onChoose={(choice, denyContext) => {
-                  const resolve = editReviewResolveRef.current;
-                  if (resolve) {
-                    editReviewResolveRef.current = null;
-                    resolve({ choice, denyContext });
-                  }
-                }}
-              />
-            ) : walkthroughActive && pendingEdits.current.length > 0 ? (
-              <EditConfirm
-                // pendingTick re-keys the modal so each apply/discard
-                // forces a remount with the NEW first block. Without it,
-                // EditConfirm's internal scroll state would persist
-                // across blocks, which is the wrong UX.
-                key={`walk-${pendingTick}`}
-                block={pendingEdits.current[0]!}
-                onChoose={handleWalkChoice}
-              />
-            ) : (
-              <>
-                {codeMode ? (
-                  <ModeStatusBar
-                    editMode={editMode}
-                    pendingCount={pendingCount}
-                    flash={modeFlash}
-                    planMode={planMode}
-                    undoArmed={!!undoBanner || hasUndoable()}
-                    jobs={codeMode.jobs}
-                  />
-                ) : null}
-                {activeLoop ? <LoopStatusRow loop={activeLoop} /> : null}
-                <StatusRow />
-                <PromptInput
-                  value={input}
-                  onChange={setInput}
-                  onSubmit={handleSubmit}
-                  disabled={busy}
-                  onHistoryPrev={recallPrev}
-                  onHistoryNext={recallNext}
+              {!PLAIN_UI && activePlanCard ? (
+                <Box flexDirection="column" marginY={1}>
+                  <PlanCard card={activePlanCard} />
+                </Box>
+              ) : null}
+              {stagedInput ? (
+                <PlanRefineInput
+                  mode={stagedInput.mode}
+                  onSubmit={handleStagedInputSubmit}
+                  onCancel={handleStagedInputCancel}
                 />
-                {slashMatches !== null ? (
-                  <SlashSuggestions matches={slashMatches} selectedIndex={slashSelected} />
-                ) : null}
-                {atMatches !== null ? (
-                  <AtMentionSuggestions
-                    matches={atMatches}
-                    selectedIndex={atSelected}
-                    query={atPicker?.query ?? ""}
+              ) : stagedCheckpointRevise ? (
+                <PlanRefineInput
+                  mode="checkpoint-revise"
+                  onSubmit={handleCheckpointReviseSubmit}
+                  onCancel={handleCheckpointReviseCancel}
+                />
+              ) : stagedChoiceCustom ? (
+                <PlanRefineInput
+                  mode="choice-custom"
+                  onSubmit={handleChoiceCustomSubmit}
+                  onCancel={handleChoiceCustomCancel}
+                />
+              ) : pendingChoice ? (
+                <ChoiceConfirm
+                  question={pendingChoice.question}
+                  options={pendingChoice.options}
+                  allowCustom={pendingChoice.allowCustom}
+                  onChoose={stableHandleChoiceConfirm}
+                />
+              ) : pendingRevision ? (
+                <PlanReviseConfirm
+                  reason={pendingRevision.reason}
+                  oldRemaining={(planStepsRef.current ?? []).filter(
+                    (s) => !completedStepIdsRef.current.has(s.id),
+                  )}
+                  newRemaining={pendingRevision.remainingSteps}
+                  summary={pendingRevision.summary}
+                  onChoose={stableHandleReviseConfirm}
+                />
+              ) : pendingCheckpoint ? (
+                <PlanCheckpointConfirm
+                  stepId={pendingCheckpoint.stepId}
+                  title={pendingCheckpoint.title}
+                  completed={pendingCheckpoint.completed}
+                  total={pendingCheckpoint.total}
+                  steps={planStepsRef.current ?? undefined}
+                  completedStepIds={completedStepIdsRef.current}
+                  onChoose={stableHandleCheckpointConfirm}
+                />
+              ) : pendingSessionsPicker ? (
+                <SessionPicker
+                  sessions={sessionsPickerList}
+                  workspace={currentRootDir}
+                  onChoose={(outcome) => {
+                    if (outcome.kind === "open") {
+                      setPendingSessionsPicker(false);
+                      if (onSwitchSession) {
+                        onSwitchSession(outcome.name);
+                      } else {
+                        log.pushInfo(
+                          `▸ to switch to "${outcome.name}", quit and run: reasonix chat --session ${outcome.name}`,
+                        );
+                      }
+                      return;
+                    }
+                    if (outcome.kind === "new") {
+                      setPendingSessionsPicker(false);
+                      if (onSwitchSession) {
+                        onSwitchSession(undefined);
+                      } else {
+                        log.pushInfo(
+                          "▸ to start a fresh session, quit and run: reasonix chat (no --session flag)",
+                        );
+                      }
+                      return;
+                    }
+                    if (outcome.kind === "delete") {
+                      deleteSession(outcome.name);
+                      setSessionsPickerList(listSessionsForWorkspace(currentRootDir));
+                      return;
+                    }
+                    if (outcome.kind === "rename") {
+                      renameSession(outcome.name, outcome.newName);
+                      setSessionsPickerList(listSessionsForWorkspace(currentRootDir));
+                      return;
+                    }
+                    if (outcome.kind === "quit") {
+                      setPendingSessionsPicker(false);
+                    }
+                  }}
+                />
+              ) : pendingMcpBrowser ? (
+                <McpBrowser
+                  servers={mcpServers ?? []}
+                  configPath={defaultConfigPath()}
+                  onClose={() => setPendingMcpBrowser(false)}
+                  postInfo={(text) => log.pushInfo(text)}
+                  applyAppend={(target, addedTools) => applyMcpAppend(loop, target, addedTools)}
+                />
+              ) : pendingPlan ? (
+                <PlanConfirm
+                  plan={pendingPlan}
+                  steps={planStepsRef.current ?? undefined}
+                  summary={planSummaryRef.current ?? undefined}
+                  onChoose={stableHandlePlanConfirm}
+                  projectRoot={currentRootDir}
+                />
+              ) : pendingReviseEditor ? (
+                <PlanReviseEditor
+                  steps={planStepsRef.current ?? []}
+                  completedStepIds={completedStepIdsRef.current}
+                  onAccept={(revised, skippedIds) => {
+                    planStepsRef.current = revised;
+                    for (const id of skippedIds) completedStepIdsRef.current.add(id);
+                    persistPlanState();
+                    const planText = pendingReviseEditor;
+                    setPendingReviseEditor(null);
+                    setPendingPlan(planText);
+                  }}
+                  onCancel={() => {
+                    const planText = pendingReviseEditor;
+                    setPendingReviseEditor(null);
+                    setPendingPlan(planText);
+                  }}
+                />
+              ) : pendingShell ? (
+                <ShellConfirm
+                  command={pendingShell.command}
+                  allowPrefix={derivePrefix(pendingShell.command)}
+                  kind={pendingShell.kind}
+                  onChoose={handleShellConfirm}
+                />
+              ) : pendingEditReview ? (
+                <EditConfirm
+                  block={pendingEditReview}
+                  onChoose={(choice, denyContext) => {
+                    const resolve = editReviewResolveRef.current;
+                    if (resolve) {
+                      editReviewResolveRef.current = null;
+                      resolve({ choice, denyContext });
+                    }
+                  }}
+                />
+              ) : walkthroughActive && pendingEdits.current.length > 0 ? (
+                <EditConfirm
+                  // pendingTick re-keys the modal so each apply/discard
+                  // forces a remount with the NEW first block. Without it,
+                  // EditConfirm's internal scroll state would persist
+                  // across blocks, which is the wrong UX.
+                  key={`walk-${pendingTick}`}
+                  block={pendingEdits.current[0]!}
+                  onChoose={handleWalkChoice}
+                />
+              ) : (
+                <>
+                  {codeMode ? (
+                    <ModeStatusBar
+                      editMode={editMode}
+                      pendingCount={pendingCount}
+                      flash={modeFlash}
+                      planMode={planMode}
+                      undoArmed={!!undoBanner || hasUndoable()}
+                      jobs={codeMode.jobs}
+                    />
+                  ) : null}
+                  {activeLoop ? <LoopStatusRow loop={activeLoop} /> : null}
+                  <StatusRow />
+                  <PromptInput
+                    value={input}
+                    onChange={setInput}
+                    onSubmit={handleSubmit}
+                    disabled={busy}
+                    onHistoryPrev={recallPrev}
+                    onHistoryNext={recallNext}
                   />
-                ) : null}
-                {slashArgContext ? (
-                  <SlashArgPicker
-                    matches={slashArgMatches}
-                    selectedIndex={slashArgSelected}
-                    spec={slashArgContext.spec}
-                    kind={slashArgContext.kind}
-                    partial={slashArgContext.partial}
-                  />
-                ) : null}
-                {/* CtxFooter retired — UsageCard auto-emits per turn covers the same data */}
-              </>
-            )}
+                  {slashMatches !== null ? (
+                    <SlashSuggestions matches={slashMatches} selectedIndex={slashSelected} />
+                  ) : null}
+                  {atMatches !== null ? (
+                    <AtMentionSuggestions
+                      matches={atMatches}
+                      selectedIndex={atSelected}
+                      query={atPicker?.query ?? ""}
+                    />
+                  ) : null}
+                  {slashArgContext ? (
+                    <SlashArgPicker
+                      matches={slashArgMatches}
+                      selectedIndex={slashArgSelected}
+                      spec={slashArgContext.spec}
+                      kind={slashArgContext.kind}
+                      partial={slashArgContext.partial}
+                    />
+                  ) : null}
+                  {/* CtxFooter retired — UsageCard auto-emits per turn covers the same data */}
+                </>
+              )}
+            </Box>
+            {!PLAIN_UI &&
+            sidebarOpen &&
+            (process.stdout.columns ?? 80) >= SIDEBAR_MIN_TOTAL_COLS ? (
+              <SidebarPanel ongoingTool={ongoingTool} subagentActivity={subagentActivity} />
+            ) : null}
           </Box>
         </ViewportBudgetProvider>
       </TickerProvider>

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -2853,13 +2853,14 @@ function AppInner({
       planSummaryRef.current = null;
       persistPlanState();
       togglePlanMode(false);
+      agentStore.dispatch({ type: "plan.drop" });
       await syntheticSubmit.post({
         marker: "▸ plan cancelled",
         synthetic:
           "The plan was cancelled. Drop it entirely. Ask me what I actually want before proposing another plan or making any changes.",
       });
     },
-    [pendingPlan, togglePlanMode, syntheticSubmit, persistPlanState],
+    [pendingPlan, togglePlanMode, syntheticSubmit, persistPlanState, agentStore],
   );
 
   // Ref-wrapped stable alias. `handlePlanConfirm` has deps that churn

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -324,11 +324,11 @@ function AppInner({
   // "▸ tool<X> running…" pulse-spinner row so long tool calls don't
   // look like the app hung.
   const [ongoingTool, setOngoingTool] = useState<{ name: string; args?: string } | null>(null);
-  // Sidebar visibility — persisted in config; auto-init opens on cols ≥ 120.
+  // Sidebar visibility — persisted in config; default on (panel self-hides when no plan is active).
   const [sidebarOpen, setSidebarOpen] = useState<boolean>(() => {
     const stored = loadSidebarOpen();
     if (typeof stored === "boolean") return stored;
-    return (process.stdout.columns ?? 80) >= 120;
+    return true;
   });
   const toggleSidebar = useCallback(() => {
     setSidebarOpen((cur) => {

--- a/src/cli/ui/cards/StreamingCard.tsx
+++ b/src/cli/ui/cards/StreamingCard.tsx
@@ -11,8 +11,11 @@ import { FG, TONE } from "../theme/tokens.js";
 const BODY_INDENT_CELLS = 5;
 
 export function StreamingCard({ card }: { card: StreamingCardData }): React.ReactElement {
-  // Done cards render via Markdown in <Static>; live frame stays plain
-  // text since markdown on partial streamed chunks would jitter.
+  const { stdout } = useStdout();
+  const cols = stdout?.columns ?? 80;
+  // Claim before the done-state branch — hook order must stay stable across the done flip.
+  const budget = useReserveRows("stream", { min: 4, max: Number.POSITIVE_INFINITY });
+
   if (card.done && !card.aborted) {
     return (
       <Box flexDirection="column" paddingLeft={3}>
@@ -21,14 +24,8 @@ export function StreamingCard({ card }: { card: StreamingCardData }): React.Reac
     );
   }
 
-  const { stdout } = useStdout();
-  const cols = stdout?.columns ?? 80;
   const lineCells = Math.max(20, cols - BODY_INDENT_CELLS - 1);
   const allLines = card.text.length > 0 ? card.text.split("\n") : [""];
-  // Stream zone soaks whatever rows the higher-priority modal/plan-card/input
-  // didn't claim. Min 4 keeps a "▶ + 3 lines" footer visible even when a modal
-  // takes the whole viewport.
-  const budget = useReserveRows("stream", { min: 4, max: Number.POSITIVE_INFINITY });
   const reserved = (card.aborted ? 2 : 0) + 1;
   const lineSlots = Math.max(4, budget - reserved);
   const overflows = !card.done && allLines.length > lineSlots;

--- a/src/cli/ui/layout/SidebarPanel.tsx
+++ b/src/cli/ui/layout/SidebarPanel.tsx
@@ -60,10 +60,16 @@ function SectionHeader({ glyph, title, tone }: { glyph: string; title: string; t
 }
 
 function Divider() {
+  // Border auto-fills the parent's content width — no hardcoded char repeat.
   return (
-    <Box marginY={0}>
-      <Text color={FG.faint}>{"─".repeat(SIDEBAR_WIDTH - 2)}</Text>
-    </Box>
+    <Box
+      borderStyle="single"
+      borderTop
+      borderRight={false}
+      borderBottom={false}
+      borderLeft={false}
+      borderTopColor={FG.faint}
+    />
   );
 }
 

--- a/src/cli/ui/layout/SidebarPanel.tsx
+++ b/src/cli/ui/layout/SidebarPanel.tsx
@@ -5,7 +5,7 @@ import { Box, Text } from "ink";
 import React from "react";
 import type { Card, PlanStep } from "../state/cards.js";
 import { useAgentState } from "../state/provider.js";
-import { CARD, FG, TONE, formatCNY } from "../theme/tokens.js";
+import { CARD, FG, TONE } from "../theme/tokens.js";
 
 export const SIDEBAR_WIDTH = 28;
 /** Below this terminal width, sidebar refuses to render so the main column has room to breathe. */
@@ -19,18 +19,19 @@ export interface SidebarPanelProps {
 export function SidebarPanel({
   ongoingTool,
   subagentActivity,
-}: SidebarPanelProps): React.ReactElement {
+}: SidebarPanelProps): React.ReactElement | null {
   const cards = useAgentState((s) => s.cards);
   const activePlan = findActivePlan(cards);
-  const lastUsage = findLastUsage(cards);
+
+  // No plan = no sidebar. Tools/usage alone aren't worth eating 28 cols.
+  if (!activePlan) return null;
 
   return (
     <Box flexDirection="column" width={SIDEBAR_WIDTH} marginLeft={1} paddingX={1}>
-      {activePlan ? <PlanSection card={activePlan} /> : null}
+      <PlanSection card={activePlan} />
       {ongoingTool || subagentActivity ? (
         <RunningSection tool={ongoingTool} subagent={subagentActivity} />
       ) : null}
-      {lastUsage ? <UsageSection card={lastUsage} /> : null}
     </Box>
   );
 }
@@ -39,14 +40,6 @@ function findActivePlan(cards: ReadonlyArray<Card>) {
   for (let i = cards.length - 1; i >= 0; i--) {
     const c = cards[i];
     if (c?.kind === "plan" && c.variant === "active") return c;
-  }
-  return null;
-}
-
-function findLastUsage(cards: ReadonlyArray<Card>) {
-  for (let i = cards.length - 1; i >= 0; i--) {
-    const c = cards[i];
-    if (c?.kind === "usage") return c;
   }
   return null;
 }
@@ -155,40 +148,6 @@ function RunningSection({
       ) : null}
     </>
   );
-}
-
-function UsageSection({
-  card,
-}: {
-  card: {
-    tokens: { prompt: number; reason: number; output: number; promptCap: number };
-    cost: number;
-  };
-}) {
-  const totalTok = card.tokens.prompt + card.tokens.reason + card.tokens.output;
-  const ctxPct =
-    card.tokens.promptCap > 0 ? Math.round((card.tokens.prompt / card.tokens.promptCap) * 100) : 0;
-  return (
-    <>
-      <Box marginTop={1}>
-        <Text color={CARD.usage.color} bold>{`${CARD.usage.glyph} Last turn`}</Text>
-      </Box>
-      <Divider />
-      <Box>
-        <Text color={FG.body}>{`${formatCNY(card.cost, 4)} · ${formatTok(totalTok)} tok`}</Text>
-      </Box>
-      {card.tokens.promptCap > 0 ? (
-        <Box>
-          <Text color={ctxPct > 80 ? TONE.warn : FG.sub}>{`ctx ${ctxPct}% used`}</Text>
-        </Box>
-      ) : null}
-    </>
-  );
-}
-
-function formatTok(n: number): string {
-  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
-  return String(n);
 }
 
 function truncate(s: string, max: number): string {

--- a/src/cli/ui/layout/SidebarPanel.tsx
+++ b/src/cli/ui/layout/SidebarPanel.tsx
@@ -37,9 +37,16 @@ export function SidebarPanel({
 }
 
 function findActivePlan(cards: ReadonlyArray<Card>) {
+  // "Active" alone isn't enough — submit_plan creates the card up-front (all
+  // steps queued) before the user picks approve / cancel in PlanConfirm. The
+  // plan must have actually started (some step past "queued") AND still have
+  // work pending, otherwise the card is either awaiting approval or rejected.
   for (let i = cards.length - 1; i >= 0; i--) {
     const c = cards[i];
-    if (c?.kind === "plan" && c.variant === "active") return c;
+    if (c?.kind !== "plan" || c.variant !== "active") continue;
+    const started = c.steps.some((s) => s.status !== "queued");
+    const stillWorking = c.steps.some((s) => s.status !== "done" && s.status !== "skipped");
+    if (started && stillWorking) return c;
   }
   return null;
 }

--- a/src/cli/ui/layout/SidebarPanel.tsx
+++ b/src/cli/ui/layout/SidebarPanel.tsx
@@ -1,0 +1,225 @@
+/** Right-side context panel — plan + running tools + usage snapshot. Read-only, no scroll. */
+
+import { Box, Text } from "ink";
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React from "react";
+import type { Card, PlanStep } from "../state/cards.js";
+import { useAgentState } from "../state/provider.js";
+import { CARD, FG, TONE, formatCNY } from "../theme/tokens.js";
+
+export const SIDEBAR_WIDTH = 28;
+/** Below this terminal width, sidebar refuses to render so the main column has room to breathe. */
+export const SIDEBAR_MIN_TOTAL_COLS = 88;
+
+export interface SidebarPanelProps {
+  ongoingTool?: { name: string; args?: string } | null;
+  subagentActivity?: { task: string; iter: number; phase?: "exploring" | "summarising" } | null;
+}
+
+export function SidebarPanel({
+  ongoingTool,
+  subagentActivity,
+}: SidebarPanelProps): React.ReactElement {
+  const cards = useAgentState((s) => s.cards);
+  const activePlan = findActivePlan(cards);
+  const lastUsage = findLastUsage(cards);
+
+  return (
+    <Box flexDirection="column" width={SIDEBAR_WIDTH} marginLeft={1} paddingX={1}>
+      {activePlan ? <PlanSection card={activePlan} /> : null}
+      {ongoingTool || subagentActivity ? (
+        <RunningSection tool={ongoingTool} subagent={subagentActivity} />
+      ) : null}
+      {lastUsage ? <UsageSection card={lastUsage} /> : null}
+    </Box>
+  );
+}
+
+function findActivePlan(cards: ReadonlyArray<Card>) {
+  for (let i = cards.length - 1; i >= 0; i--) {
+    const c = cards[i];
+    if (c?.kind === "plan" && c.variant === "active") return c;
+  }
+  return null;
+}
+
+function findLastUsage(cards: ReadonlyArray<Card>) {
+  for (let i = cards.length - 1; i >= 0; i--) {
+    const c = cards[i];
+    if (c?.kind === "usage") return c;
+  }
+  return null;
+}
+
+function SectionHeader({ glyph, title, tone }: { glyph: string; title: string; tone: string }) {
+  return (
+    <Box marginBottom={0}>
+      <Text color={tone} bold>{`${glyph} ${title}`}</Text>
+    </Box>
+  );
+}
+
+function Divider() {
+  return (
+    <Box marginY={0}>
+      <Text color={FG.faint}>{"─".repeat(SIDEBAR_WIDTH - 2)}</Text>
+    </Box>
+  );
+}
+
+function PlanSection({ card }: { card: { steps: PlanStep[]; title: string } }) {
+  const total = card.steps.length;
+  const done = card.steps.filter((s) => s.status === "done" || s.status === "skipped").length;
+  const runningIdx = card.steps.findIndex((s) => s.status === "running");
+  // Window of ±5 around the running step keeps long plans glanceable.
+  const visible = windowSteps(card.steps, runningIdx, 5);
+
+  return (
+    <>
+      <SectionHeader
+        glyph={CARD.plan.glyph}
+        title={`Plan  ${done}/${total}`}
+        tone={CARD.plan.color}
+      />
+      <Divider />
+      {visible.kind === "all" ? null : (
+        <Text color={FG.faint}>{`(${visible.hidden} earlier hidden)`}</Text>
+      )}
+      {visible.steps.map((s, i) => (
+        <StepRow key={s.id} step={s} index={visible.startIndex + i} />
+      ))}
+      {visible.kind === "windowed" && visible.hiddenAfter > 0 ? (
+        <Text color={FG.faint}>{`(${visible.hiddenAfter} more)`}</Text>
+      ) : null}
+    </>
+  );
+}
+
+function StepRow({ step, index }: { step: PlanStep; index: number }) {
+  const glyph = STATUS_GLYPH[step.status];
+  const color = STATUS_COLOR[step.status];
+  const num = `${index + 1}.`;
+  const truncated = truncate(step.title, SIDEBAR_WIDTH - 6);
+  return (
+    <Box>
+      <Text color={color}>{glyph}</Text>
+      <Text color={step.status === "running" ? FG.strong : FG.sub}>{` ${num} ${truncated}`}</Text>
+    </Box>
+  );
+}
+
+const STATUS_GLYPH: Record<PlanStep["status"], string> = {
+  queued: " ",
+  running: "▶",
+  done: "✓",
+  failed: "✗",
+  blocked: "!",
+  skipped: "s",
+};
+
+const STATUS_COLOR: Record<PlanStep["status"], string> = {
+  queued: FG.faint,
+  running: TONE.brand,
+  done: TONE.ok,
+  failed: TONE.err,
+  blocked: TONE.warn,
+  skipped: FG.faint,
+};
+
+function RunningSection({
+  tool,
+  subagent,
+}: {
+  tool?: { name: string; args?: string } | null;
+  subagent?: { task: string; iter: number; phase?: "exploring" | "summarising" } | null;
+}) {
+  return (
+    <>
+      <Box marginTop={1}>
+        <Text color={TONE.info} bold>
+          {"◐ Running"}
+        </Text>
+      </Box>
+      <Divider />
+      {tool ? (
+        <Box>
+          <Text color={CARD.tool.color}>{CARD.tool.glyph}</Text>
+          <Text color={FG.body}>{` ${truncate(tool.name, SIDEBAR_WIDTH - 4)}`}</Text>
+        </Box>
+      ) : null}
+      {subagent ? (
+        <Box>
+          <Text color={CARD.subagent.color}>{CARD.subagent.glyph}</Text>
+          <Text color={FG.body}>{` ${truncate(subagent.task, SIDEBAR_WIDTH - 4)}`}</Text>
+        </Box>
+      ) : null}
+    </>
+  );
+}
+
+function UsageSection({
+  card,
+}: {
+  card: {
+    tokens: { prompt: number; reason: number; output: number; promptCap: number };
+    cost: number;
+  };
+}) {
+  const totalTok = card.tokens.prompt + card.tokens.reason + card.tokens.output;
+  const ctxPct =
+    card.tokens.promptCap > 0 ? Math.round((card.tokens.prompt / card.tokens.promptCap) * 100) : 0;
+  return (
+    <>
+      <Box marginTop={1}>
+        <Text color={CARD.usage.color} bold>{`${CARD.usage.glyph} Last turn`}</Text>
+      </Box>
+      <Divider />
+      <Box>
+        <Text color={FG.body}>{`${formatCNY(card.cost, 4)} · ${formatTok(totalTok)} tok`}</Text>
+      </Box>
+      {card.tokens.promptCap > 0 ? (
+        <Box>
+          <Text color={ctxPct > 80 ? TONE.warn : FG.sub}>{`ctx ${ctxPct}% used`}</Text>
+        </Box>
+      ) : null}
+    </>
+  );
+}
+
+function formatTok(n: number): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
+  return String(n);
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return `${s.slice(0, Math.max(1, max - 1))}…`;
+}
+
+export type WindowResult =
+  | { kind: "all"; steps: PlanStep[]; startIndex: 0 }
+  | {
+      kind: "windowed";
+      steps: PlanStep[];
+      startIndex: number;
+      hidden: number;
+      hiddenAfter: number;
+    };
+
+/** Show the focus step ± padding; collapse the rest into "(N hidden)" hints. */
+export function windowSteps(steps: PlanStep[], focusIdx: number, padding: number): WindowResult {
+  if (steps.length <= padding * 2 + 1) {
+    return { kind: "all", steps, startIndex: 0 };
+  }
+  const focus = focusIdx >= 0 ? focusIdx : 0;
+  const start = Math.max(0, focus - padding);
+  const end = Math.min(steps.length, start + padding * 2 + 1);
+  const trimmedStart = Math.max(0, end - (padding * 2 + 1));
+  return {
+    kind: "windowed",
+    steps: steps.slice(trimmedStart, end),
+    startIndex: trimmedStart,
+    hidden: trimmedStart,
+    hiddenAfter: steps.length - end,
+  };
+}

--- a/src/cli/ui/layout/SidebarPanel.tsx
+++ b/src/cli/ui/layout/SidebarPanel.tsx
@@ -37,16 +37,17 @@ export function SidebarPanel({
 }
 
 function findActivePlan(cards: ReadonlyArray<Card>) {
-  // "Active" alone isn't enough — submit_plan creates the card up-front (all
-  // steps queued) before the user picks approve / cancel in PlanConfirm. The
-  // plan must have actually started (some step past "queued") AND still have
-  // work pending, otherwise the card is either awaiting approval or rejected.
+  // Mirrors the App.tsx selector. Cancelled plans flip variant via plan.drop,
+  // so checking variant === "active" + "not all done" is enough.
   for (let i = cards.length - 1; i >= 0; i--) {
     const c = cards[i];
-    if (c?.kind !== "plan" || c.variant !== "active") continue;
-    const started = c.steps.some((s) => s.status !== "queued");
-    const stillWorking = c.steps.some((s) => s.status !== "done" && s.status !== "skipped");
-    if (started && stillWorking) return c;
+    if (
+      c?.kind === "plan" &&
+      c.variant === "active" &&
+      c.steps.some((s) => s.status !== "done" && s.status !== "skipped")
+    ) {
+      return c;
+    }
   }
   return null;
 }

--- a/src/cli/ui/state/events.ts
+++ b/src/cli/ui/state/events.ts
@@ -196,6 +196,10 @@ const planStepComplete = z.object({
   stepId: z.string(),
 });
 
+const planDrop = z.object({
+  type: z.literal("plan.drop"),
+});
+
 const branchStart = z.object({
   type: z.literal("branch.start"),
   id: cardId,
@@ -320,6 +324,7 @@ export const AgentEventSchema = z.discriminatedUnion("type", [
   sessionReset,
   planShow,
   planStepComplete,
+  planDrop,
   ctxShow,
   doctorShow,
   usageShow,

--- a/src/cli/ui/state/reducer.ts
+++ b/src/cli/ui/state/reducer.ts
@@ -172,6 +172,23 @@ export function reduce(state: AgentState, event: AgentEvent): AgentState {
         variant: event.variant,
       });
 
+    case "plan.drop": {
+      // Latest still-active plan flips to "replay" — preserves it in scrollback
+      // but signals "no longer the live plan" to selectors and UI.
+      let dropped = false;
+      const cards = state.cards.map((c, i) => {
+        if (dropped) return c;
+        if (c.kind !== "plan" || c.variant !== "active") return c;
+        // Walk from end — only the LAST active plan should drop.
+        if (state.cards.slice(i + 1).some((cc) => cc.kind === "plan" && cc.variant === "active")) {
+          return c;
+        }
+        dropped = true;
+        return { ...c, variant: "replay" as const };
+      });
+      return dropped ? { ...state, cards } : state;
+    }
+
     case "plan.step.complete": {
       let changed = false;
       const cards = state.cards.map((c) => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,6 +31,8 @@ export interface ReasonixConfig {
   session?: string | null;
   setupCompleted?: boolean;
   search?: boolean;
+  /** Persisted sidebar visibility — undefined = auto (open on cols ≥ 120). */
+  sidebarOpen?: boolean;
   projects?: {
     [absoluteRootDir: string]: {
       shellAllowed?: string[];
@@ -69,6 +71,20 @@ export function writeConfig(cfg: ReasonixConfig, path: string = defaultConfigPat
 export function loadApiKey(path: string = defaultConfigPath()): string | undefined {
   if (process.env.DEEPSEEK_API_KEY) return process.env.DEEPSEEK_API_KEY;
   return readConfig(path).apiKey;
+}
+
+export function loadSidebarOpen(path: string = defaultConfigPath()): boolean | undefined {
+  return readConfig(path).sidebarOpen;
+}
+
+export function saveSidebarOpen(
+  open: boolean | undefined,
+  path: string = defaultConfigPath(),
+): void {
+  const cfg = readConfig(path);
+  if (open === undefined) cfg.sidebarOpen = undefined;
+  else cfg.sidebarOpen = open;
+  writeConfig(cfg, path);
 }
 
 export function searchEnabled(path: string = defaultConfigPath()): boolean {

--- a/tests/sidebar-panel.test.ts
+++ b/tests/sidebar-panel.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { windowSteps } from "../src/cli/ui/layout/SidebarPanel.js";
+import type { PlanStep } from "../src/cli/ui/state/cards.js";
+
+function step(id: string, status: PlanStep["status"] = "queued"): PlanStep {
+  return { id, title: `step ${id}`, status };
+}
+
+describe("windowSteps", () => {
+  it("returns all steps when total ≤ 2*padding+1", () => {
+    const steps = [step("a"), step("b"), step("c")];
+    const r = windowSteps(steps, 1, 5);
+    expect(r.kind).toBe("all");
+    expect(r.steps).toHaveLength(3);
+    expect(r.startIndex).toBe(0);
+  });
+
+  it("windows around focus step in the middle of a long plan", () => {
+    const steps = Array.from({ length: 20 }, (_, i) => step(`s${i}`));
+    const r = windowSteps(steps, 10, 3);
+    expect(r.kind).toBe("windowed");
+    if (r.kind !== "windowed") throw new Error("type guard");
+    expect(r.steps).toHaveLength(7); // 2*3 + 1
+    expect(r.startIndex).toBe(7);
+    expect(r.hidden).toBe(7);
+    expect(r.hiddenAfter).toBe(6);
+  });
+
+  it("clamps window to start when focus is near beginning", () => {
+    const steps = Array.from({ length: 20 }, (_, i) => step(`s${i}`));
+    const r = windowSteps(steps, 0, 3);
+    expect(r.kind).toBe("windowed");
+    if (r.kind !== "windowed") throw new Error("type guard");
+    expect(r.startIndex).toBe(0);
+    expect(r.hidden).toBe(0);
+    expect(r.hiddenAfter).toBe(13);
+  });
+
+  it("clamps window to end when focus is near end", () => {
+    const steps = Array.from({ length: 20 }, (_, i) => step(`s${i}`));
+    const r = windowSteps(steps, 19, 3);
+    expect(r.kind).toBe("windowed");
+    if (r.kind !== "windowed") throw new Error("type guard");
+    expect(r.startIndex).toBe(13);
+    expect(r.hidden).toBe(13);
+    expect(r.hiddenAfter).toBe(0);
+    expect(r.steps).toHaveLength(7);
+  });
+
+  it("falls back to focus=0 when no running step", () => {
+    const steps = Array.from({ length: 20 }, (_, i) => step(`s${i}`));
+    const r = windowSteps(steps, -1, 3);
+    expect(r.kind).toBe("windowed");
+    if (r.kind !== "windowed") throw new Error("type guard");
+    expect(r.startIndex).toBe(0);
+  });
+});


### PR DESCRIPTION
Refs #122 — sidebar half. Bg-highlight is in #126.

## What

A read-only HUD on the right that shows persistent context: current plan steps, running tools, last-turn usage. Frees the main column from re-rendering plan/tool state and makes long plans glanceable on portrait monitors (lamyc's actual pain point).

## Decisions made

- **Right side** (not left). Reading flow is left→right; chat content keeps focus.
- **Fixed 28 cols**. Not user-resizable — one fewer thing to tune.
- **Auto-init** open on cols ≥ 120, off below; manual toggle wins thereafter.
- **Below 88 total cols** the panel hides regardless of preference.
- **Ctrl+\** to toggle. Persisted in `~/.reasonix/config.json.sidebarOpen`.
- **Sections collapse when empty**. No active plan? No plan section.
- **Read-only**. No focus, no scroll, no keys land in it.

## Out of scope (deferred for v2)

- Collapsed-strip indicator (when toggled off, sidebar fully hides — no 2-col stub yet)
- `/sidebar [on|off]` slash fallback when terminal eats Ctrl+\
- Left-side / per-user position preference
- Memory + recent-edits sections

## Carries from #126

The StreamingCard hook-order fix (claim must precede the done-state early return). Independent of bg highlight; will resolve cleanly when #126 merges.

## Verification

- `npm run verify` — typecheck, lint, build, 1805 tests all green
- 5 new test cases for the windowSteps allocator