### PR TITLE
fix(at-mention): nested .gitignore via shared util

### DIFF
--- a/src/at-mentions.ts
+++ b/src/at-mentions.ts
@@ -3,10 +3,17 @@
 import { type Dirent, existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { readdir, stat } from "node:fs/promises";
 import { isAbsolute, join, relative, resolve } from "node:path";
+import {
+  type GitignoreLayer,
+  ignoredByLayers,
+  loadGitignoreAt,
+  loadGitignoreAtSync,
+} from "./gitignore.js";
 
 /** Caps match tool-result dispatch truncation (0.5.2). */
 export const DEFAULT_AT_MENTION_MAX_BYTES = 64 * 1024;
 
+/** Universally-uninteresting build / VCS dirs. Framework-specific dirs (Pods, target, …) live in .gitignore. */
 export const DEFAULT_PICKER_IGNORE_DIRS: readonly string[] = [
   "node_modules",
   ".git",
@@ -25,10 +32,12 @@ export const DEFAULT_PICKER_IGNORE_DIRS: readonly string[] = [
 ];
 
 export interface ListFilesOptions {
-  /** Cap the walk once we've collected this many entries. Default 500. */
+  /** Cap the walk once we've collected this many entries. Default 2000. */
   maxResults?: number;
   /** Directory names to skip entirely. Defaults to {@link DEFAULT_PICKER_IGNORE_DIRS}. */
   ignoreDirs?: readonly string[];
+  /** Walk nested .gitignores (root + every subdir). Default true. */
+  respectGitignore?: boolean;
 }
 
 /** Sync on purpose — fits the TUI's single-turn-per-tick model. Skips dot-DIRS but keeps dotfiles. */
@@ -45,13 +54,19 @@ export interface FileWithStats {
 
 /** Stat failures kept as `mtimeMs: 0` — entry still appears, sinks to bottom of recency sort. */
 export function listFilesWithStatsSync(root: string, opts: ListFilesOptions = {}): FileWithStats[] {
-  const maxResults = Math.max(1, opts.maxResults ?? 500);
-  const ignore = new Set(opts.ignoreDirs ?? DEFAULT_PICKER_IGNORE_DIRS);
+  const maxResults = Math.max(1, opts.maxResults ?? 2000);
+  const ignoreDirs = new Set(opts.ignoreDirs ?? DEFAULT_PICKER_IGNORE_DIRS);
   const rootAbs = resolve(root);
+  const respectGi = opts.respectGitignore !== false;
   const out: FileWithStats[] = [];
 
-  const walk = (dirAbs: string, dirRel: string) => {
+  const walk = (dirAbs: string, dirRel: string, layers: readonly GitignoreLayer[]) => {
     if (out.length >= maxResults) return;
+    let effectiveLayers = layers;
+    if (respectGi) {
+      const ig = loadGitignoreAtSync(dirAbs);
+      if (ig) effectiveLayers = [...layers, { dirAbs, ig }];
+    }
     let entries: Dirent[];
     try {
       entries = readdirSync(dirAbs, { withFileTypes: true });
@@ -62,13 +77,16 @@ export function listFilesWithStatsSync(root: string, opts: ListFilesOptions = {}
     for (const ent of entries) {
       if (out.length >= maxResults) return;
       const relPath = dirRel ? `${dirRel}/${ent.name}` : ent.name;
+      const absPath = join(dirAbs, ent.name);
       if (ent.isDirectory()) {
-        if (ent.name.startsWith(".") || ignore.has(ent.name)) continue;
-        walk(join(dirAbs, ent.name), relPath);
+        if (ent.name.startsWith(".") || ignoreDirs.has(ent.name)) continue;
+        if (ignoredByLayers(effectiveLayers, absPath, true)) continue;
+        walk(absPath, relPath, effectiveLayers);
       } else if (ent.isFile()) {
+        if (ignoredByLayers(effectiveLayers, absPath, false)) continue;
         let mtimeMs = 0;
         try {
-          mtimeMs = statSync(join(dirAbs, ent.name)).mtimeMs;
+          mtimeMs = statSync(absPath).mtimeMs;
         } catch {
           /* stat failed (permission / EAGAIN) — keep the entry with mtime=0 */
         }
@@ -77,7 +95,7 @@ export function listFilesWithStatsSync(root: string, opts: ListFilesOptions = {}
     }
   };
 
-  walk(rootAbs, "");
+  walk(rootAbs, "", []);
   return out;
 }
 
@@ -86,13 +104,23 @@ export async function listFilesWithStatsAsync(
   root: string,
   opts: ListFilesOptions = {},
 ): Promise<FileWithStats[]> {
-  const maxResults = Math.max(1, opts.maxResults ?? 500);
-  const ignore = new Set(opts.ignoreDirs ?? DEFAULT_PICKER_IGNORE_DIRS);
+  const maxResults = Math.max(1, opts.maxResults ?? 2000);
+  const ignoreDirs = new Set(opts.ignoreDirs ?? DEFAULT_PICKER_IGNORE_DIRS);
   const rootAbs = resolve(root);
+  const respectGi = opts.respectGitignore !== false;
   const out: FileWithStats[] = [];
 
-  const walk = async (dirAbs: string, dirRel: string): Promise<void> => {
+  const walk = async (
+    dirAbs: string,
+    dirRel: string,
+    layers: readonly GitignoreLayer[],
+  ): Promise<void> => {
     if (out.length >= maxResults) return;
+    let effectiveLayers = layers;
+    if (respectGi) {
+      const ig = await loadGitignoreAt(dirAbs);
+      if (ig) effectiveLayers = [...layers, { dirAbs, ig }];
+    }
     let entries: Dirent[];
     try {
       entries = await readdir(dirAbs, { withFileTypes: true });
@@ -100,34 +128,34 @@ export async function listFilesWithStatsAsync(
       return;
     }
     entries.sort((a, b) => a.name.localeCompare(b.name));
-    // Pull file stats for THIS directory in parallel before
-    // recursing — readdir gave us all the names at once, may as
-    // well issue all the stats at once too. Recursion stays
-    // sequential so the alphabetical ordering of the merged list
-    // matches the sync walk's contract.
+    // Stats batched per directory to amortize syscall overhead. Recursion stays
+    // sequential so the merged DFS order matches the sync walker's contract.
     const fileEnts: Dirent[] = [];
     for (const ent of entries) {
       if (out.length >= maxResults) break;
+      const relPath = dirRel ? `${dirRel}/${ent.name}` : ent.name;
+      const absPath = join(dirAbs, ent.name);
       if (ent.isDirectory()) {
-        if (ent.name.startsWith(".") || ignore.has(ent.name)) continue;
+        if (ent.name.startsWith(".") || ignoreDirs.has(ent.name)) continue;
+        if (ignoredByLayers(effectiveLayers, absPath, true)) continue;
         // Drain pending file stats from THIS directory before
         // descending so the output order stays DFS-alphabetical.
         if (fileEnts.length > 0) {
-          await statBatch(fileEnts, dirAbs, dirRel, out, maxResults);
+          await statBatch(fileEnts, dirAbs, dirRel, out, maxResults, effectiveLayers);
           fileEnts.length = 0;
           if (out.length >= maxResults) return;
         }
-        await walk(join(dirAbs, ent.name), dirRel ? `${dirRel}/${ent.name}` : ent.name);
+        await walk(absPath, relPath, effectiveLayers);
       } else if (ent.isFile()) {
         fileEnts.push(ent);
       }
     }
     if (fileEnts.length > 0 && out.length < maxResults) {
-      await statBatch(fileEnts, dirAbs, dirRel, out, maxResults);
+      await statBatch(fileEnts, dirAbs, dirRel, out, maxResults, effectiveLayers);
     }
   };
 
-  await walk(rootAbs, "");
+  await walk(rootAbs, "", []);
   return out;
 }
 
@@ -137,18 +165,23 @@ async function statBatch(
   dirRel: string,
   out: FileWithStats[],
   maxResults: number,
+  layers: readonly GitignoreLayer[],
 ): Promise<void> {
-  const remaining = Math.max(0, maxResults - out.length);
-  const batch = ents.slice(0, remaining);
+  const accepted: Dirent[] = [];
+  for (const e of ents) {
+    if (out.length + accepted.length >= maxResults) break;
+    if (ignoredByLayers(layers, join(dirAbs, e.name), false)) continue;
+    accepted.push(e);
+  }
   const stats = await Promise.all(
-    batch.map((e) =>
+    accepted.map((e) =>
       stat(join(dirAbs, e.name))
         .then((s) => s.mtimeMs)
         .catch(() => 0),
     ),
   );
-  for (let i = 0; i < batch.length; i++) {
-    const ent = batch[i]!;
+  for (let i = 0; i < accepted.length; i++) {
+    const ent = accepted[i]!;
     out.push({
       path: dirRel ? `${dirRel}/${ent.name}` : ent.name,
       mtimeMs: stats[i] ?? 0,

--- a/src/gitignore.ts
+++ b/src/gitignore.ts
@@ -1,0 +1,42 @@
+/** Nested .gitignore evaluation — shared by the at-mention picker walker and the semantic chunker. */
+
+import { readFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import ignore, { type Ignore } from "ignore";
+
+export interface GitignoreLayer {
+  /** Absolute dir the .gitignore lives in. Patterns evaluate relative to this. */
+  dirAbs: string;
+  ig: Ignore;
+}
+
+export async function loadGitignoreAt(dirAbs: string): Promise<Ignore | null> {
+  try {
+    return ignore().add(await readFile(path.join(dirAbs, ".gitignore"), "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+export function loadGitignoreAtSync(dirAbs: string): Ignore | null {
+  try {
+    return ignore().add(readFileSync(path.join(dirAbs, ".gitignore"), "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+/** True if any layer — outermost to innermost — ignores this path. */
+export function ignoredByLayers(
+  layers: readonly GitignoreLayer[],
+  abs: string,
+  isDir: boolean,
+): boolean {
+  for (const layer of layers) {
+    const rel = path.relative(layer.dirAbs, abs).split(path.sep).join("/");
+    if (!rel || rel.startsWith("..")) continue;
+    if (layer.ig.ignores(isDir ? `${rel}/` : rel)) return true;
+  }
+  return false;
+}

--- a/src/index/semantic/chunker.ts
+++ b/src/index/semantic/chunker.ts
@@ -2,7 +2,7 @@
 
 import { promises as fs } from "node:fs";
 import path from "node:path";
-import ignore, { type Ignore } from "ignore";
+import { type GitignoreLayer, ignoredByLayers, loadGitignoreAt } from "../../gitignore.js";
 import {
   type IndexFilters,
   type ResolvedIndexConfig,
@@ -118,33 +118,8 @@ function safeSplit(chunk: CodeChunk, maxChars: number): CodeChunk[] {
   return out;
 }
 
-async function loadGitignoreAt(dirAbs: string): Promise<Ignore | null> {
-  try {
-    const text = await fs.readFile(path.join(dirAbs, ".gitignore"), "utf8");
-    return ignore().add(text);
-  } catch {
-    return null;
-  }
-}
-
 function toForwardRel(root: string, abs: string): string {
   return path.relative(root, abs).split(path.sep).join("/");
-}
-
-interface GitignoreLayer {
-  /** Absolute dir the gitignore lives in — patterns are evaluated relative to this. */
-  dirAbs: string;
-  ig: Ignore;
-}
-
-/** Returns true if any nested .gitignore — outermost to innermost — matches the path. */
-function ignoredByLayers(layers: readonly GitignoreLayer[], abs: string, isDir: boolean): boolean {
-  for (const layer of layers) {
-    const rel = path.relative(layer.dirAbs, abs).split(path.sep).join("/");
-    if (!rel || rel.startsWith("..")) continue;
-    if (layer.ig.ignores(isDir ? `${rel}/` : rel)) return true;
-  }
-  return false;
 }
 
 interface WalkFrame {

--- a/tests/at-mentions.test.ts
+++ b/tests/at-mentions.test.ts
@@ -427,6 +427,54 @@ describe("listFilesWithStatsAsync", () => {
     const entries = await listFilesWithStatsAsync(join(root, "does-not-exist"));
     expect(entries).toEqual([]);
   });
+
+  it("honors root .gitignore — ignored files and dirs are skipped", async () => {
+    writeFileSync(join(root, ".gitignore"), "ignored-file.log\ngenerated/\n");
+    writeFileSync(join(root, "ignored-file.log"), "noise");
+    mkdirSync(join(root, "generated"), { recursive: true });
+    writeFileSync(join(root, "generated", "out.dart"), "");
+    const entries = await listFilesWithStatsAsync(root);
+    const paths = entries.map((e) => e.path);
+    expect(paths).not.toContain("ignored-file.log");
+    expect(paths.every((p) => !p.startsWith("generated/"))).toBe(true);
+    // Sanity: non-ignored files still present.
+    expect(paths).toContain("src/index.ts");
+  });
+
+  it("respectGitignore=false bypasses .gitignore filter", async () => {
+    writeFileSync(join(root, ".gitignore"), "ignored-file.log\n");
+    writeFileSync(join(root, "ignored-file.log"), "noise");
+    const entries = await listFilesWithStatsAsync(root, { respectGitignore: false });
+    expect(entries.map((e) => e.path)).toContain("ignored-file.log");
+  });
+
+  it("walks nested .gitignore files — sub-dir patterns scope correctly", async () => {
+    // Root .gitignore catches root-only matches; sub .gitignore adds local patterns.
+    writeFileSync(join(root, ".gitignore"), "secret.env\n");
+    writeFileSync(join(root, "secret.env"), "k=v");
+    mkdirSync(join(root, "lib"), { recursive: true });
+    writeFileSync(join(root, "lib", ".gitignore"), "*.generated.ts\n");
+    writeFileSync(join(root, "lib", "main.ts"), "");
+    writeFileSync(join(root, "lib", "schema.generated.ts"), "");
+    // Sub-pattern doesn't leak to siblings.
+    writeFileSync(join(root, "schema.generated.ts"), "");
+    const entries = await listFilesWithStatsAsync(root);
+    const paths = entries.map((e) => e.path);
+    expect(paths).not.toContain("secret.env");
+    expect(paths).not.toContain("lib/schema.generated.ts");
+    expect(paths).toContain("lib/main.ts");
+    // Sibling at root is NOT caught by lib/.gitignore.
+    expect(paths).toContain("schema.generated.ts");
+  });
+
+  it("negation patterns (!important.log) override prior excludes", async () => {
+    writeFileSync(join(root, ".gitignore"), "*.log\n!keep.log\n");
+    writeFileSync(join(root, "drop.log"), "");
+    writeFileSync(join(root, "keep.log"), "");
+    const paths = (await listFilesWithStatsAsync(root)).map((e) => e.path);
+    expect(paths).not.toContain("drop.log");
+    expect(paths).toContain("keep.log");
+  });
 });
 
 describe("AT_URL_PATTERN", () => {


### PR DESCRIPTION
Closes #128.

## Why

@paulo70015 reported that on macOS Flutter projects every `@` query (`@lib/main.dart`, `@lib`, `@test`, `@pubspec.yaml`) returned "no files match" — even though the files existed and weren't gitignored.

## Diagnosis

The picker walker did **not** honor `.gitignore`. The 500-result cap filled with `ios/Pods/` (alphabetically before `lib/`) before the walk reached the user's source code.

## Fix — trust the project's own ignore rules, not a hardcoded list

Rather than grow `DEFAULT_PICKER_IGNORE_DIRS` per-framework (Pods, DerivedData, target, vendor, _build, …), trust the project's `.gitignore`. Same source of truth that `fzf`, `ripgrep`, `fd`, and the rest of the ecosystem use.

- New `src/gitignore.ts` lifts `loadGitignoreAt` + `ignoredByLayers` out of the semantic chunker, so the @ picker walker and the indexer share **one** nested-gitignore implementation
- `listFilesWithStats(Sync|Async)` push a layer per directory's `.gitignore` as they descend
- `statBatch` checks the merged layer set before stat'ing — no syscalls for files we'll drop
- Default `maxResults` bumped from 500 → 2000
- `respectGitignore: false` opt-out for raw walks
- `chunker.ts` switches to the shared util — no behavior change there

No git binary required (we just read `.gitignore` files via the existing `ignore` npm package). Works in projects without git, in containers, on first launch — same correctness as `git ls-files` for typical projects.

## Verification

- `npm run verify` — typecheck, lint, build, **1817 tests** all green
- New tests cover root + nested `.gitignore`, negation patterns (`!keep.log`), and the opt-out path

## Out of scope

- Global `~/.config/git/ignore` and `.git/info/exclude` — easy follow-up if anyone reports needing them; the layer model already supports it