### PR TITLE
fix(loop): self-correct on first repeat-loop storm before stopping

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -172,6 +172,7 @@ export class CacheFirstLoop {
   private _escalateThisTurn = false;
   private _turnFailureCount = 0;
   private _turnFailureTypes: Record<string, number> = {};
+  private _turnSelfCorrected = false;
 
   constructor(opts: CacheFirstLoopOptions) {
     this.client = opts.client;
@@ -236,7 +237,12 @@ export class CacheFirstLoop {
       }
       return def.readOnly !== true;
     };
-    this.repair = new ToolCallRepair({ allowedToolNames: allowedNames, isMutating });
+    this.repair = new ToolCallRepair({
+      allowedToolNames: allowedNames,
+      isMutating,
+      stormThreshold: parsePositiveIntEnv(process.env.REASONIX_STORM_THRESHOLD),
+      stormWindow: parsePositiveIntEnv(process.env.REASONIX_STORM_WINDOW),
+    });
 
     // Heal-on-load: oversized tool results would 400 the next call before the user types.
     this.sessionName = opts.session ?? null;
@@ -332,6 +338,23 @@ export class CacheFirstLoop {
         appendSessionMessage(this.sessionName, message);
       } catch {
         /* disk full or permission denied shouldn't kill the chat */
+      }
+    }
+  }
+
+  /** Swap the just-appended assistant entry — used by self-correction to restore the original tool_calls without dropping reasoning_content. */
+  private replaceTailAssistantMessage(message: ChatMessage): void {
+    const entries = this.log.entries;
+    const tail = entries[entries.length - 1];
+    if (!tail || tail.role !== "assistant") return;
+    const kept = entries.slice(0, -1);
+    kept.push(message);
+    this.log.compactInPlace(kept);
+    if (this.sessionName) {
+      try {
+        rewriteSession(this.sessionName, kept);
+      } catch {
+        /* disk issue shouldn't block the in-memory swap */
       }
     }
   }
@@ -454,7 +477,7 @@ export class CacheFirstLoop {
     if (repair) {
       if (repair.scavenged > 0) bump("scavenged", repair.scavenged);
       if (repair.truncationsFixed > 0) bump("truncated", repair.truncationsFixed);
-      if (repair.stormsBroken > 0) bump("storm-broken", repair.stormsBroken);
+      if (repair.stormsBroken > 0) bump("repeat-loop", repair.stormsBroken);
     }
     if (
       bumped &&
@@ -550,6 +573,7 @@ export class CacheFirstLoop {
     // unless the user re-arms or mid-turn escalation triggers).
     this._turnFailureCount = 0;
     this._turnFailureTypes = {};
+    this._turnSelfCorrected = false;
     this._escalateThisTurn = false;
     let armedConsumed = false;
     if (this._proArmedForNextTurn) {
@@ -1083,18 +1107,46 @@ export class CacheFirstLoop {
         };
       }
 
-      // Loud signal when the storm breaker caught a repeat pattern.
-      // The `repair` field on assistant_final already carries the
-      // count as a subtext on the assistant row, but a dedicated
-      // warning row is far more noticeable — and critical when ALL
-      // calls were suppressed, because the turn then ends with no
-      // visible explanation of why nothing happened.
+      const allSuppressed =
+        report.stormsBroken > 0 && repairedCalls.length === 0 && toolCalls.length > 0;
+
+      // First all-suppressed storm: rewrite tail with the original tool_calls
+      // (so the next prompt shows what was attempted), stub tool responses to
+      // keep the API contract, and continue the iter — model gets one shot to
+      // self-correct before the loud-warning path takes over.
+      if (allSuppressed && !this._turnSelfCorrected) {
+        this._turnSelfCorrected = true;
+        this.replaceTailAssistantMessage(
+          this.assistantMessage(
+            assistantContent,
+            toolCalls,
+            this.modelForCurrentCall(),
+            reasoningContent,
+          ),
+        );
+        for (const call of toolCalls) {
+          this.appendAndPersist({
+            role: "tool",
+            tool_call_id: call.id ?? "",
+            name: call.function?.name ?? "",
+            content:
+              "[repeat-loop guard] this call was suppressed because it was identical to a previous call in this turn. Earlier results for it are above — try a meaningfully different approach, or stop and answer if you have enough.",
+          });
+        }
+        yield {
+          turn: this._turn,
+          role: "warning",
+          content:
+            "Caught a repeated tool call — let the model see the issue and retry with a different approach.",
+        };
+        continue;
+      }
+
       if (report.stormsBroken > 0) {
         const noteTail = report.notes.length ? ` — ${report.notes[report.notes.length - 1]}` : "";
-        const allSuppressed = repairedCalls.length === 0 && toolCalls.length > 0;
         const phrase = allSuppressed
-          ? `stopped the model from calling the same tool with identical args repeatedly (all ${toolCalls.length} call(s) this turn were already in the recent-repeat window). Likely a stuck retry — reword your instruction, rule out the underlying blocker, or try /retry after fixing it`
-          : `suppressed ${report.stormsBroken} repeat tool call(s) that had fired 3+ times with identical args in a sliding window`;
+          ? "Stopped a stuck retry loop — the model kept calling the same tool with identical args after a self-correction nudge. Try /retry, rephrase, or rule out the underlying blocker."
+          : `Suppressed ${report.stormsBroken} repeated tool call(s) — same name + args fired 3+ times.`;
         yield {
           turn: this._turn,
           role: "warning",
@@ -1103,17 +1155,6 @@ export class CacheFirstLoop {
       }
 
       if (repairedCalls.length === 0) {
-        // Two sub-cases here:
-        //   (a) Model legitimately produced ZERO tool calls — final
-        //       prose answer, terminate the loop.
-        //   (b) Model emitted tool calls but storm-breaker ate them
-        //       all (allSuppressed). The user sees only the warning
-        //       row and a silent stop, which feels like the agent
-        //       gave up. Route through the forced-summary path so
-        //       the model gets one no-tools call to explain what it
-        //       tried, what blocked it, and what would unblock —
-        //       turning a silent dead-end into actionable feedback.
-        const allSuppressed = report.stormsBroken > 0 && toolCalls.length > 0;
         if (allSuppressed) {
           yield* this.forceSummaryAfterIterLimit({ reason: "stuck" });
           return;
@@ -1450,6 +1491,12 @@ export function stripHallucinatedToolMarkup(s: string): string {
   // different line (seen when R1 truncates mid-call).
   out = out.replace(/<｜DSML｜[\s\S]*$/g, "");
   return out.trim();
+}
+
+function parsePositiveIntEnv(raw: string | undefined): number | undefined {
+  if (!raw) return undefined;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : undefined;
 }
 
 function safeParseToolArgs(raw: string): unknown {

--- a/src/repair/storm.ts
+++ b/src/repair/storm.ts
@@ -43,7 +43,7 @@ export class StormBreaker {
     if (count >= this.threshold - 1) {
       return {
         suppress: true,
-        reason: `call-storm suppressed: ${name} called with identical args ${count + 1} times within window=${this.windowSize}`,
+        reason: `${name} called with identical args ${count + 1} times — repeat-loop guard tripped`,
       };
     }
     this.recent.push({ name, args, readOnly });

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -431,13 +431,7 @@ describe("CacheFirstLoop (non-streaming)", () => {
     expect(events[events.length - 1]!.role).toBe("done");
   });
 
-  it("storm-broken-all-suppressed forces a summary instead of stopping silently", async () => {
-    // Repro of the user-reported "怎么就直接停了" — model loops on the
-    // same broken tool call (e.g. read_file with empty path), the
-    // storm-breaker suppresses every call after the threshold, and
-    // pre-fix the loop would yield `done` with no prose. Fix routes
-    // through forceSummaryAfterIterLimit so the model gets one
-    // no-tools call to explain what was tried + what's blocking.
+  it("first all-suppressed storm self-corrects in-turn instead of stopping", async () => {
     const reg = new ToolRegistry();
     reg.register({
       name: "probe",
@@ -445,8 +439,6 @@ describe("CacheFirstLoop (non-streaming)", () => {
       parameters: { type: "object", properties: {} },
       fn: async () => "ok",
     });
-    // Same (name, args) signature each iter — storm-breaker fires on
-    // the third identical call. Threshold = 3, window = 6 (defaults).
     const dupCall = {
       id: "c1",
       type: "function",
@@ -456,11 +448,7 @@ describe("CacheFirstLoop (non-streaming)", () => {
       { content: "", tool_calls: [dupCall] },
       { content: "", tool_calls: [{ ...dupCall, id: "c2" }] },
       { content: "", tool_calls: [{ ...dupCall, id: "c3" }] },
-      // Forced-summary call — no tools advertised, model just narrates.
-      {
-        content:
-          "I tried probe(no args) three times — same result each call. Need a different approach.",
-      },
+      { content: "got it — done." },
     ];
     const client = makeClient(responses);
     const loop = new CacheFirstLoop({
@@ -476,11 +464,61 @@ describe("CacheFirstLoop (non-streaming)", () => {
       events.push({ role: ev.role, forcedSummary: ev.forcedSummary, content: ev.content });
     }
 
-    // Storm warning fires.
-    expect(events.some((e) => e.role === "warning" && /storm/i.test(e.content ?? ""))).toBe(true);
+    expect(
+      events.some((e) => e.role === "warning" && /repeated tool call/i.test(e.content ?? "")),
+    ).toBe(true);
+    expect(
+      events.some((e) => e.role === "warning" && /stuck retry loop/i.test(e.content ?? "")),
+    ).toBe(false);
 
-    // Final assistant_final must be tagged forcedSummary with the
-    // "stuck" prefix — proves we didn't just yield `done`.
+    const finals = events.filter((e) => e.role === "assistant_final");
+    const final = finals[finals.length - 1];
+    expect(final?.forcedSummary).toBeFalsy();
+    expect(final?.content).toBe("got it — done.");
+
+    const tail = loop.log.entries[loop.log.entries.length - 1];
+    expect(tail?.role).toBe("assistant");
+  });
+
+  it("second all-suppressed storm in same turn falls back to forced summary", async () => {
+    const reg = new ToolRegistry();
+    reg.register({
+      name: "probe",
+      description: "no-op",
+      parameters: { type: "object", properties: {} },
+      fn: async () => "ok",
+    });
+    const dupCall = {
+      id: "c1",
+      type: "function",
+      function: { name: "probe", arguments: "{}" },
+    };
+    const responses: FakeResponseShape[] = [
+      { content: "", tool_calls: [dupCall] },
+      { content: "", tool_calls: [{ ...dupCall, id: "c2" }] },
+      { content: "", tool_calls: [{ ...dupCall, id: "c3" }] },
+      { content: "", tool_calls: [{ ...dupCall, id: "c4" }] },
+      { content: "", tool_calls: [{ ...dupCall, id: "c5" }] },
+      { content: "i would summarize but the harness should override me." },
+    ];
+    const client = makeClient(responses);
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s", toolSpecs: reg.specs() }),
+      tools: reg,
+      stream: false,
+      maxToolIters: 8,
+    });
+
+    const events: { role: string; forcedSummary?: boolean; content?: string }[] = [];
+    for await (const ev of loop.step("explore")) {
+      events.push({ role: ev.role, forcedSummary: ev.forcedSummary, content: ev.content });
+    }
+
+    expect(
+      events.some((e) => e.role === "warning" && /stuck retry loop/i.test(e.content ?? "")),
+    ).toBe(true);
+
     const finals = events.filter((e) => e.role === "assistant_final");
     const summary = finals[finals.length - 1];
     expect(summary?.forcedSummary).toBe(true);

--- a/tests/repair/storm.test.ts
+++ b/tests/repair/storm.test.ts
@@ -19,7 +19,7 @@ describe("StormBreaker", () => {
     sb.inspect(call("x", "{}"));
     const verdict = sb.inspect(call("x", "{}"));
     expect(verdict.suppress).toBe(true);
-    expect(verdict.reason).toMatch(/call-storm/);
+    expect(verdict.reason).toMatch(/repeat-loop guard/);
   });
 
   it("distinguishes different args as different calls", () => {


### PR DESCRIPTION
Closes #132.

## Summary

- First all-suppressed storm in a turn no longer ends the turn — it rewrites the just-persisted assistant message so the original `tool_calls` are preserved, stubs `role:"tool"` responses to honor DeepSeek's "every tool_call needs a tool message" contract, yields a plain-language warning, and continues the iter. The model gets one shot to self-correct before the loud-warning + forced-summary path kicks in on a second storm.
- Softens user-facing copy: "storm-broken" / "recent-repeat window" / "call-storm suppressed" → "repeat-loop guard" / "repeated tool call" / "stuck retry loop". Auto-escalation toast now reads `4× repeat-loop` instead of `4× storm-broken`.
- Adds `REASONIX_STORM_THRESHOLD` / `REASONIX_STORM_WINDOW` env vars so the guard can be triggered at lower thresholds during manual testing.

## Why

`StormBreaker` only checks `(name, args)` sameness — it can't tell a malformed-args bug (e.g. `read_file({path:""})`, model would self-correct if it saw the error) apart from a genuine stuck loop. Pre-fix, both modes hit the same hard stop with a developer-jargon warning, and users reported disengaging the moment the warning appeared.

## Test plan

- [x] `npx vitest run tests/loop.test.ts` — 31 passed (including new `first all-suppressed storm self-corrects in-turn` and `second all-suppressed storm in same turn falls back to forced summary`).
- [x] `npx vitest run tests/repair` — 36 passed (storm reason text matcher updated).
- [x] `npm run verify` — 1818/1818 green.
- [x] Manual TUI verification with `REASONIX_STORM_THRESHOLD=2`:
  - First all-suppressed storm → soft warning, turn continues, model self-corrects ✓
  - Second all-suppressed storm in same turn → loud "Stopped a stuck retry loop" warning, forced summary, turn ends ✓
  - Partial storm → "Suppressed N repeated tool call(s)" with new copy ✓
  - Auto-escalate toast displays "4× repeat-loop" ✓