### PR TITLE
fix(tui): redesign reasoning + streaming cards

### DIFF
--- a/docs/design/agent-tui-terminal.html
+++ b/docs/design/agent-tui-terminal.html
@@ -254,6 +254,52 @@ main { padding: 32px 48px 40px 32px; min-width: 0; }
   color: var(--fg-4); font-weight: 700; margin-right: 12px;
 }
 .tag .cls { color: var(--c-brand); }
+
+/* Inline pill — bg-tinted chip used inside .mock rows for section labels,
+   model badges, and inline path refs. Padding lives INSIDE the content
+   (leading/trailing space chars) so column alignment in monospace
+   ASCII art is preserved. Terminal implementation: <Text backgroundColor=
+   color=> with real space chars on either side of the label. */
+.mock .pill {
+  font-weight: 700;
+  letter-spacing: .04em;
+}
+/* Section pill — accent-tinted bg, accent fg. One per card type.
+   Color group matches the card's accent bar. */
+.mock .pill.sec-reason  { background: #2a1f3d; color: var(--c-accent); }
+.mock .pill.sec-tool    { background: #0f2230; color: var(--c-info); }
+.mock .pill.sec-shell   { background: #0f2230; color: var(--c-info); }
+.mock .pill.sec-task    { background: #0d1d2e; color: var(--c-brand); }
+.mock .pill.sec-plan    { background: #2a1f3d; color: var(--c-accent); }
+.mock .pill.sec-diff    { background: #11141a; color: var(--fg-1); }
+.mock .pill.sec-user    { background: #11141a; color: var(--fg-2); }
+.mock .pill.sec-warn    { background: #2b1f12; color: var(--c-warn); }
+.mock .pill.sec-err     { background: #2c1416; color: var(--c-err); }
+.mock .pill.sec-ok      { background: #102815; color: var(--c-ok); }
+/* State variants — same shape, swapped color when the card is in a non-default state. */
+.mock .pill.sec-task.s-done    { background: #102815; color: var(--c-ok); }
+.mock .pill.sec-task.s-failed  { background: #2c1416; color: var(--c-err); }
+/* Model pill — neutral bg-elev, color signals model class.
+   flash=brand/blue (cheap fast), pro=accent/purple (premium),
+   r1=violet (reasoner). Read at a glance without text. */
+.mock .pill.mdl-flash { background: #11141a; color: var(--c-brand); }
+.mock .pill.mdl-pro   { background: #11141a; color: var(--c-accent); }
+.mock .pill.mdl-r1    { background: #11141a; color: var(--c-violet); }
+/* Path pill — neutral bg-elev for filenames / paths inside tool rows.
+   Lower-weight so it reads as data not chrome. */
+.mock .pill.path { background: #11141a; color: var(--fg-2); font-weight: 500; letter-spacing: 0; }
+
+/* Body anchor — the ↳ corner glyph that sits at the start of the FIRST
+   body line, telling the eye "this is where the card body branches off
+   from the header above". Subtle, color-matches the card accent. */
+.mock .anchor       { color: var(--c-accent); }
+.mock .anchor.brand { color: var(--c-brand); }
+.mock .anchor.info  { color: var(--c-info); }
+.mock .anchor.violet{ color: var(--c-violet); }
+.mock .anchor.ok    { color: var(--c-ok); }
+.mock .anchor.err   { color: var(--c-err); }
+.mock .anchor.warn  { color: var(--c-warn); }
+.mock .anchor.fg3   { color: var(--fg-3); }
 </style>
 </head>
 <body>
@@ -431,22 +477,22 @@ main { padding: 32px 48px 40px 32px; min-width: 0; }
 <pre class="body">
   <span class="fg4">◈ session-7  ·  main  ·  ~/projects/reasonix  ·  deepseek-chat</span>
 
-  <span class="fg3">◇</span> <span class="b fg2">you</span>  <span class="fg4">· just now</span>
-    <span class="fg1">refactor the SKIP_DIRS list out of chunker.ts so directory_tree</span>
-    <span class="fg1">can reuse it</span>
+    <span class="pill sec-user">&nbsp;YOU&nbsp;</span>  <span class="fg4">· just now</span>
+    <span class="anchor fg3">↳</span> <span class="fg1">refactor the SKIP_DIRS list out of chunker.ts so directory_tree</span>
+      <span class="fg1">can reuse it</span>
 
-  <span class="accent">▎</span> <span class="accent b">◆ Reasoning</span>  <span class="fg4">· 3 paragraphs · 412 tok</span>                              <span class="fg4">▸</span>
+  <span class="accent">▎</span> <span class="pill sec-reason">&nbsp;REASONING&nbsp;</span>  <span class="pill mdl-pro">&nbsp;v4-pro&nbsp;</span>  <span class="fg4">412 tok · 3 ¶</span>                                  <span class="fg3">3.1s</span>
 
-  <span class="brand">▎</span> <span class="brand b">▶ Step 2 of 5 · Refactor exclude config</span>          <span class="fg3">4.2s · </span><span class="brand">running</span>
+  <span class="brand">▎</span> <span class="pill sec-task">&nbsp;TASK&nbsp;</span>  <span class="b fg0">2 / 5  Refactor exclude config</span>                       <span class="fg3">4.2s · </span><span class="brand">running</span>
   <span class="brand">▎</span>
-  <span class="brand">▎</span>   <span class="fg2">Pull SKIP_DIRS / SKIP_FILES out of chunker.ts so directory_tree</span>
-  <span class="brand">▎</span>   <span class="fg2">can reuse them.</span>
+  <span class="brand">▎</span>   <span class="anchor brand">↳</span> <span class="fg2">Pull SKIP_DIRS / SKIP_FILES out of chunker.ts so directory_tree</span>
+  <span class="brand">▎</span>     <span class="fg2">can reuse them.</span>
   <span class="brand">▎</span>
-  <span class="brand">▎</span>   <span class="ok">✓</span>  <span class="b fg1">read   </span> <span class="fg2">src/index/semantic/chunker.ts</span>      <span class="fg3">0.08s · 250 lines</span>
-  <span class="brand">▎</span>   <span class="ok">✓</span>  <span class="b fg1">read   </span> <span class="fg2">src/tools/filesystem.ts</span>            <span class="fg3">0.07s · 712 lines</span>
-  <span class="brand">▎</span>   <span class="ok">✓</span>  <span class="b fg1">write  </span> <span class="fg2">src/index/config.ts</span>                <span class="fg3">0.12s · created</span>
-  <span class="brand">▎</span>   <span class="brand">▶</span>  <span class="b fg1">edit   </span> <span class="fg2">src/tools/filesystem.ts</span>            <span class="brand">running…</span>
-  <span class="brand">▎</span>   <span class="fg4">○</span>  <span class="b fg3">verify </span> <span class="fg3">npm run typecheck &amp;&amp; npm test</span>      <span class="fg4">queued</span>
+  <span class="brand">▎</span>   <span class="ok">✓</span>  <span class="b fg1">read   </span> <span class="pill path">&nbsp;src/index/semantic/chunker.ts&nbsp;</span>   <span class="fg3">0.08s · 250 lines</span>
+  <span class="brand">▎</span>   <span class="ok">✓</span>  <span class="b fg1">read   </span> <span class="pill path">&nbsp;src/tools/filesystem.ts&nbsp;</span>          <span class="fg3">0.07s · 712 lines</span>
+  <span class="brand">▎</span>   <span class="ok">✓</span>  <span class="b fg1">write  </span> <span class="pill path">&nbsp;src/index/config.ts&nbsp;</span>              <span class="fg3">0.12s · created</span>
+  <span class="brand">▎</span>   <span class="brand">▶</span>  <span class="b fg1">edit   </span> <span class="pill path">&nbsp;src/tools/filesystem.ts&nbsp;</span>          <span class="brand">running…</span>
+  <span class="brand">▎</span>   <span class="fg4">○</span>  <span class="b fg3">verify </span> <span class="fg3">npm run typecheck &amp;&amp; npm test</span>     <span class="fg4">queued</span>
 
   <span class="brand">▎</span> <span class="brand b">▶</span>  <span class="fg1">The change maps to three edits — I'll start with the config module,</span>
   <span class="brand">▎</span>    <span class="fg1">then the chunker, then wire it through the CLI command. Each step</span>
@@ -577,111 +623,183 @@ main { padding: 32px 48px 40px 32px; min-width: 0; }
   <!-- User message -->
   <section class="section" id="c-user">
     <h2><span class="num">05</span>Cards · user message</h2>
-    <p class="lede">No accent bar — the user's input is the conversational anchor, deserves a quieter treatment than agent activity.</p>
+    <p class="lede">No accent bar — the user's input is the conversational anchor, deserves a quieter treatment than agent activity. The <span class="pill sec-user">&nbsp;YOU&nbsp;</span> pill uses a neutral bg with muted fg so it reads as identification, not status.</p>
     <div class="tag">CARD · <span class="cls">.user</span></div>
-<pre class="mock">  <span class="fg3">◇</span> <span class="b fg2">you</span>  <span class="fg4">· 2 min ago</span>
-    <span class="fg1">refactor the SKIP_DIRS list out of chunker.ts so directory_tree</span>
-    <span class="fg1">can reuse it</span>
+<pre class="mock">    <span class="pill sec-user">&nbsp;YOU&nbsp;</span>  <span class="fg4">· 2 min ago</span>
+    <span class="anchor fg3">↳</span> <span class="fg1">refactor the SKIP_DIRS list out of chunker.ts so directory_tree</span>
+      <span class="fg1">can reuse it</span>
 </pre>
+    <p class="lede">Body anchor uses the muted <span class="anchor fg3">↳</span> (fg-3) — the user card has no accent color to take from, so the anchor stays neutral.</p>
   </section>
 
   <!-- Reasoning -->
   <section class="section" id="c-reason">
     <h2><span class="num">06</span>Cards · reasoning</h2>
-    <p class="lede">Default <strong>collapsed</strong> — reasoning is opt-in noise. Always italic + dim when expanded so it never competes with primary content.</p>
-    <div class="tag">CARD · <span class="cls">.reasoning</span></div>
-<pre class="mock">  <span class="accent">▎</span> <span class="accent b">◆ Reasoning</span>  <span class="fg4">· 3 paragraphs · 412 tok</span>                              <span class="fg4">▸</span>
-</pre>
-    <div class="tag">EXPANDED · <span class="cls">.reasoning[open]</span></div>
-<pre class="mock">  <span class="accent">▎</span> <span class="accent b">◆ Reasoning</span>  <span class="fg4">· 3 paragraphs · 412 tok</span>                              <span class="fg4">▾</span>
+    <p class="lede"><strong>No collapse / expand</strong> — TUI can't host interactive disclosure cleanly. The card adapts to content size in <strong>four tiers</strong>: streaming (live tail), settled-short (full body), settled-long (head + tail, middle elided), <strong>settled-XL (tail only — head dropped)</strong>. The XL drop is deliberate: at &gt;800 tok the opening is almost always restating the prompt the model has since moved past, while the conclusion carries the actionable synthesis. Header carries two <strong>bg-tinted pills</strong> — a <span class="pill sec-reason">&nbsp;REASONING&nbsp;</span> section pill and a model pill (color = model class). Body is italic + dim so it never competes with primary content. The <span class="anchor">↳</span> anchor marks the absolute beginning of the body — it appears only when that beginning is actually visible (so it's absent in streaming-with-overflow and in XL).</p>
+
+    <div class="tag">HEADER + BODY ANATOMY</div>
+<pre class="mock">  <span class="accent">▎</span> <span class="pill sec-reason">&nbsp;REASONING&nbsp;</span>  <span class="pill mdl-pro">&nbsp;v4-pro&nbsp;</span>  <span class="fg4">412 tok · 3 ¶</span>                                  <span class="fg3">3.1s</span>
   <span class="accent">▎</span>
-  <span class="accent">▎</span>   <span class="i fg3">Two paths: replace the hardcoded list when config is set, or merge</span>
-  <span class="accent">▎</span>   <span class="i fg3">user values in. The first matches the explicit "config-driven" ask;</span>
-  <span class="accent">▎</span>   <span class="i fg3">the second is safer default. Going with the first since the user's</span>
-  <span class="accent">▎</span>   <span class="i fg3">words outrank my safety instinct here.</span>
-  <span class="accent">▎</span>
-  <span class="accent">▎</span>   <span class="i fg3">Files to touch: chunker.ts (drop constants, accept resolved config),</span>
-  <span class="accent">▎</span>   <span class="i fg3">filesystem.ts (drop its own copy), and the index command (load + pass).</span>
+  <span class="accent">▎</span>   <span class="anchor">↳</span> <span class="i fg3">first line of body…</span>
+  <span class="accent">▎</span>     <span class="i fg3">subsequent lines align under the anchor's content column</span>
+       <span class="fg4">↑ rule</span>  <span class="fg4">↑ section pill</span>   <span class="fg4">↑ model pill</span>  <span class="fg4">↑ counts</span>                              <span class="fg4">↑ duration</span>
 </pre>
+    <p class="lede">Two pills replace the old <code>◆</code> glyph + emoji prefix. Section pill is accent-purple-tinted bg with accent fg — one fixed style per card type. Model pill uses neutral bg-elev with <strong>fg color = model class</strong>: <span class="pill mdl-flash">&nbsp;v4-flash&nbsp;</span> sky-blue (cheap), <span class="pill mdl-pro">&nbsp;v4-pro&nbsp;</span> purple (premium), <span class="pill mdl-r1">&nbsp;r1&nbsp;</span> violet (reasoner). Color carries the signal — no emoji needed. The <span class="anchor">↳</span> body anchor is a project-wide convention: every card body section opens with one in the card's accent color.</p>
+
+    <div class="tag">STREAMING · <span class="cls">.reasoning .streaming</span> · live tail-3-lines while bytes arrive</div>
+<pre class="mock">  <span class="accent">▎</span> <span class="pill sec-reason">&nbsp;REASONING&nbsp;</span>  <span class="pill mdl-r1">&nbsp;r1&nbsp;</span>  <span class="fg4">247 tok</span>                                  <span class="fg3">1.2s · </span><span class="brand">thinking…</span>
+  <span class="accent">▎</span>
+  <span class="accent">▎</span>   <span class="fg4">⋮  earlier lines scrolled past preview window</span>
+  <span class="accent">▎</span>
+  <span class="accent">▎</span>     <span class="i fg3">First weighing two approaches: should I patch the chunker to</span>
+  <span class="accent">▎</span>     <span class="i fg3">accept a config arg, or pull the constants up to a shared</span>
+  <span class="accent">▎</span>     <span class="i fg3">module… going with shared module since it's cleaner.</span><span class="cur"></span>
+</pre>
+    <p class="lede">Tail-3-lines is a fixed window — newer lines push older lines into the dim <span class="fg4">⋮</span> gutter mark. <strong>No <span class="anchor">↳</span> anchor</strong> when overflow is active — the absolute body start has scrolled past, so labelling the visible top as "body begins" would be a lie. The <span class="fg4">⋮</span> gutter is the indicator that content is scrolling past. Block cursor on the live edge. Token count ticks live; duration freezes on stream end. (When streaming starts and content is still under 3 lines, the <span class="anchor">↳</span> appears normally on the absolute first line — it disappears the moment overflow kicks in.)</p>
+
+    <div class="tag">SETTLED · SHORT · <span class="cls">.reasoning .settled .short</span> · ≤ ~4 lines, render in full</div>
+<pre class="mock">  <span class="accent">▎</span> <span class="pill sec-reason">&nbsp;REASONING&nbsp;</span>  <span class="pill mdl-pro">&nbsp;v4-pro&nbsp;</span>  <span class="fg4">87 tok · 1 ¶</span>                                  <span class="fg3">1.2s</span>
+  <span class="accent">▎</span>
+  <span class="accent">▎</span>   <span class="anchor">↳</span> <span class="i fg3">The user wants the storm guard to soften, not be removed. Plan: track</span>
+  <span class="accent">▎</span>     <span class="i fg3">first-vs-second storm per turn, only end the turn on the second one.</span>
+  <span class="accent">▎</span>     <span class="i fg3">Keep the warning copy plain.</span>
+</pre>
+    <p class="lede">No elision needed — full reasoning fits in the visual budget. Header gains <span class="fg4">N ¶</span> paragraph count once the stream settles.</p>
+
+    <div class="tag">SETTLED · LONG · <span class="cls">.reasoning .settled .long</span> · &gt; 4 lines OR &gt; 200 tok, head + tail paragraphs · middle elided</div>
+<pre class="mock">  <span class="accent">▎</span> <span class="pill sec-reason">&nbsp;REASONING&nbsp;</span>  <span class="pill mdl-r1">&nbsp;r1&nbsp;</span>  <span class="fg4">412 tok · 3 ¶</span>                                  <span class="fg3">3.1s</span>
+  <span class="accent">▎</span>
+  <span class="accent">▎</span>   <span class="anchor">↳</span> <span class="i fg3">Two paths: replace the hardcoded list when config is set, or merge</span>
+  <span class="accent">▎</span>     <span class="i fg3">user values in. The first matches the explicit "config-driven" ask;</span>
+  <span class="accent">▎</span>     <span class="i fg3">the second is safer default.</span>
+  <span class="accent">▎</span>
+  <span class="accent">▎</span>   <span class="fg4">⋯  1 ¶ elided  ·  /reasoning last  ⋯</span>
+  <span class="accent">▎</span>
+  <span class="accent">▎</span>     <span class="i fg3">Files to touch: chunker.ts (drop constants, accept resolved config),</span>
+  <span class="accent">▎</span>     <span class="i fg3">filesystem.ts (drop its own copy), and the index command (load + pass).</span>
+</pre>
+    <p class="lede">First paragraph (thesis — "what I'm trying to do") and last paragraph (conclusion — "what I decided") always render. Middle paragraphs collapse to a single faint elision row that names the count <em>and</em> the slash command to retrieve the full body. The tail paragraph does NOT carry its own <span class="anchor">↳</span> — the anchor only marks the absolute beginning of the body. Vertical budget stays bounded (~9 lines).</p>
+
+    <div class="tag">SETTLED · XL · <span class="cls">.reasoning .settled .xl</span> · &gt; 800 tok OR any single ¶ &gt; 6 lines · TAIL ONLY · head dropped</div>
+<pre class="mock">  <span class="accent">▎</span> <span class="pill sec-reason">&nbsp;REASONING&nbsp;</span>  <span class="pill mdl-r1">&nbsp;r1&nbsp;</span>  <span class="fg4">2,847 tok · 7 ¶</span>                                <span class="fg3">8.2s</span>
+  <span class="accent">▎</span>
+  <span class="accent">▎</span>   <span class="fg4">⋯  6 ¶ + ~2,540 tok scrolled past  ·  /reasoning last  to view full  ⋯</span>
+  <span class="accent">▎</span>
+  <span class="accent">▎</span>     <span class="i fg3">All suppressed paths are wired through and the auto-escalate label</span>
+  <span class="accent">▎</span>     <span class="i fg3">flips from "storm-broken" to "repeat-loop". Tests cover both the</span>
+  <span class="accent">▎</span>     <span class="i fg3">bad-args recovery and the second-storm fallback paths.</span>
+</pre>
+    <p class="lede"><strong>Tail-only</strong> — at this scale the head paragraph is almost always restating the prompt or weighing options the model has since moved past. The conclusion is the actionable summary, so we keep that and drop the rest. No <span class="anchor">↳</span> anchor (the absolute body start isn't visible). The <code>⋯</code> elision row reports <em>both</em> paragraph count and approximate tokens scrolled past so the user can judge what they're not seeing — and the <code>/reasoning last</code> command brings up the full body in a pager when they need to. Vertical budget bounded at ~6 lines no matter how big the input. Triggered by total &gt; 800 tok OR any single paragraph that wouldn't fit in 6 lines on its own.</p>
+
+    <div class="tag">EMPTY · <span class="cls">.reasoning .none</span> · model returned non-thinking response</div>
+<pre class="mock">  <span class="fg4">▎</span> <span class="pill sec-reason" style="opacity:.55">&nbsp;REASONING&nbsp;</span>  <span class="fg4">no thinking — direct answer</span>
+</pre>
+    <p class="lede">When the producing model emits an empty <code>reasoning_content</code> (instruct-mode v4 on a simple prompt), surface a single dim line so the absence is explained, not silently missing. Section pill renders at reduced opacity to signal "card type was attempted but skipped". No body, no anchor. Clarifies "did the model skip thinking" vs. "is the panel broken".</p>
   </section>
 
   <!-- Task / Step -->
   <section class="section" id="c-task">
     <h2><span class="num">07</span>Cards · task / step</h2>
-    <p class="lede">A multi-step work unit — wraps tool calls + reasoning under one collapsible header. Default expanded for the active step, collapsed for completed ones.</p>
-    <div class="tag">CARD · <span class="cls">.task .running</span></div>
-<pre class="mock">  <span class="brand">▎</span> <span class="brand b">▶ Step 2 of 5 · Refactor exclude config</span>                <span class="fg3">4.2s · </span><span class="brand">running</span>
-  <span class="brand">▎</span>
-  <span class="brand">▎</span>   <span class="fg2">Pull SKIP_DIRS / SKIP_FILES out of chunker.ts so directory_tree</span>
-  <span class="brand">▎</span>   <span class="fg2">can reuse them.</span>
-  <span class="brand">▎</span>
-  <span class="brand">▎</span>   <span class="ok">✓</span>  <span class="b fg1">read   </span> <span class="fg2">src/index/semantic/chunker.ts</span>      <span class="fg3">0.08s · 250 lines</span>
-  <span class="brand">▎</span>   <span class="ok">✓</span>  <span class="b fg1">read   </span> <span class="fg2">src/tools/filesystem.ts</span>            <span class="fg3">0.07s · 712 lines</span>
-  <span class="brand">▎</span>   <span class="ok">✓</span>  <span class="b fg1">write  </span> <span class="fg2">src/index/config.ts</span>                <span class="fg3">0.12s · created</span>
-  <span class="brand">▎</span>   <span class="brand">▶</span>  <span class="b fg1">edit   </span> <span class="fg2">src/tools/filesystem.ts</span>            <span class="brand">running…</span>
-  <span class="brand">▎</span>   <span class="fg4">○</span>  <span class="b fg3">verify </span> <span class="fg3">npm run typecheck && npm test</span>      <span class="fg4">queued</span>
-</pre>
+    <p class="lede">A multi-step work unit — wraps tool calls + reasoning under one header. The <span class="pill sec-task">&nbsp;TASK&nbsp;</span> section pill recolors with state: <span class="pill sec-task">&nbsp;TASK&nbsp;</span> running (brand), <span class="pill sec-task s-done">&nbsp;TASK&nbsp;</span> done (ok), <span class="pill sec-task s-failed">&nbsp;TASK&nbsp;</span> failed (err). Step counter sits next to the pill so progress is visible without reading title text.</p>
 
-    <div class="tag">CARD · <span class="cls">.task .done .collapsed</span></div>
-<pre class="mock">  <span class="ok">▎</span> <span class="ok b">✓ Step 1 of 5 · Read chunker + filesystem</span>      <span class="fg3">0.4s · 2 tools · </span><span class="ok">done</span>  <span class="fg4">▸</span>
+    <div class="tag">RUNNING · <span class="cls">.task .running</span></div>
+<pre class="mock">  <span class="brand">▎</span> <span class="pill sec-task">&nbsp;TASK&nbsp;</span>  <span class="b fg0">2 / 5  Refactor exclude config</span>                       <span class="fg3">4.2s · </span><span class="brand">running</span>
+  <span class="brand">▎</span>
+  <span class="brand">▎</span>   <span class="anchor brand">↳</span> <span class="fg2">Pull SKIP_DIRS / SKIP_FILES out of chunker.ts so directory_tree</span>
+  <span class="brand">▎</span>     <span class="fg2">can reuse them.</span>
+  <span class="brand">▎</span>
+  <span class="brand">▎</span>   <span class="ok">✓</span>  <span class="b fg1">read   </span> <span class="pill path">&nbsp;src/index/semantic/chunker.ts&nbsp;</span>   <span class="fg3">0.08s · 250 lines</span>
+  <span class="brand">▎</span>   <span class="ok">✓</span>  <span class="b fg1">read   </span> <span class="pill path">&nbsp;src/tools/filesystem.ts&nbsp;</span>          <span class="fg3">0.07s · 712 lines</span>
+  <span class="brand">▎</span>   <span class="ok">✓</span>  <span class="b fg1">write  </span> <span class="pill path">&nbsp;src/index/config.ts&nbsp;</span>              <span class="fg3">0.12s · created</span>
+  <span class="brand">▎</span>   <span class="brand">▶</span>  <span class="b fg1">edit   </span> <span class="pill path">&nbsp;src/tools/filesystem.ts&nbsp;</span>          <span class="brand">running…</span>
+  <span class="brand">▎</span>   <span class="fg4">○</span>  <span class="b fg3">verify </span> <span class="fg3">npm run typecheck && npm test</span>     <span class="fg4">queued</span>
 </pre>
+    <p class="lede">Tool rows inside the task body use the path-pill style for filenames — bg-elev tint, fg-2, regular weight. Reads as data not chrome. Step counter format <code>N / M</code> sits where the title used to start, so glancing at any task row tells you progress at a glance.</p>
 
-    <div class="tag">CARD · <span class="cls">.task .failed</span></div>
-<pre class="mock">  <span class="err">▎</span> <span class="err b">✗ Step 4 of 5 · Sandbox check</span>                       <span class="fg3">0.2s · </span><span class="err">failed</span>  <span class="fg4">▾</span>
+    <div class="tag">DONE · <span class="cls">.task .done</span></div>
+<pre class="mock">  <span class="ok">▎</span> <span class="pill sec-task s-done">&nbsp;TASK&nbsp;</span>  <span class="b fg1">1 / 5  Read chunker + filesystem</span>             <span class="fg3">0.4s · 2 tools · </span><span class="ok">done</span>
+</pre>
+    <p class="lede">Done tasks render as a single header row — body is omitted permanently (not collapsed-but-recallable). The user can recall what happened from the events log if needed.</p>
+
+    <div class="tag">FAILED · <span class="cls">.task .failed</span></div>
+<pre class="mock">  <span class="err">▎</span> <span class="pill sec-task s-failed">&nbsp;TASK&nbsp;</span>  <span class="b fg0">4 / 5  Sandbox check</span>                              <span class="fg3">0.2s · </span><span class="err">failed</span>
   <span class="err">▎</span>
-  <span class="err">▎</span>   <span class="ok">✓</span>  <span class="b fg1">read   </span> <span class="fg2">src/sandbox/policy.ts</span>          <span class="fg3">0.04s · 88 lines</span>
-  <span class="err">▎</span>   <span class="err">✗</span>  <span class="b fg1">verify </span> <span class="fg2">policy.allows("rm")</span>             <span class="err">denied</span>
+  <span class="err">▎</span>   <span class="anchor err">↳</span> <span class="ok">✓</span>  <span class="b fg1">read   </span> <span class="pill path">&nbsp;src/sandbox/policy.ts&nbsp;</span>     <span class="fg3">0.04s · 88 lines</span>
+  <span class="err">▎</span>     <span class="err">✗</span>  <span class="b fg1">verify </span> <span class="pill path">&nbsp;policy.allows("rm")&nbsp;</span>        <span class="err">denied</span>
 </pre>
+    <p class="lede">Failed tasks always render their body — the user needs the failure trail visible without recall. Anchor uses err color to match the card.</p>
   </section>
 
   <!-- Tool call -->
   <section class="section" id="c-tool">
     <h2><span class="num">08</span>Cards · tool call</h2>
-    <p class="lede">Single tool invocation. <strong>Collapsed</strong> = one row. <strong>Expanded</strong> = input args summary + output preview inside a sharp-cornered code box.</p>
+    <p class="lede">Single tool invocation. Section pill <span class="pill sec-tool">&nbsp;TOOL&nbsp;</span> uses info-cyan; the tool function name follows in info-bold; the path/target sits in a path-pill. Quick scan order: card type → which tool → what target → how it went.</p>
 
-    <div class="tag">COLLAPSED · <span class="cls">.tool</span></div>
-<pre class="mock">  <span class="info">▎</span> <span class="info b">▣ read_file</span>  <span class="fg2">src/cli/ui/App.tsx</span>                <span class="fg3">0.08s · 1224 lines</span>     <span class="fg4">▸</span>
+    <div class="tag">QUICK · <span class="cls">.tool .quick</span> · single-row, no body — fast read-only ops</div>
+<pre class="mock">  <span class="info">▎</span> <span class="pill sec-tool">&nbsp;TOOL&nbsp;</span>  <span class="b info">read_file</span>  <span class="pill path">&nbsp;src/cli/ui/App.tsx&nbsp;</span>          <span class="fg3">0.08s · 1224 lines · </span><span class="ok">ok</span>
 </pre>
+    <p class="lede">Default state for fast read-only tools (read_file, search_content, directory_tree). No body, no recall — the result is summarized in the metadata strip. If the user wants the file content, the file's at the path; reasonix won't waste rows redrawing it.</p>
 
-    <div class="tag">EXPANDED · <span class="cls">.tool[open]</span></div>
-<pre class="mock">  <span class="info">▎</span> <span class="info b">▣ read_file</span>  <span class="fg2">src/cli/ui/App.tsx</span>                <span class="fg3">0.08s · 1224 lines</span>     <span class="fg4">▾</span>
+    <div class="tag">PREVIEW · <span class="cls">.tool .preview</span> · short body when output ≤ 6 lines and worth surfacing</div>
+<pre class="mock">  <span class="info">▎</span> <span class="pill sec-tool">&nbsp;TOOL&nbsp;</span>  <span class="b info">search_content</span>  <span class="pill path">&nbsp;"stormBreaker"&nbsp;</span>            <span class="fg3">0.21s · 4 hits · </span><span class="ok">ok</span>
   <span class="info">▎</span>
-  <span class="info">▎</span>      <span class="fg4">   1</span>   <span class="fg1">/** App.tsx — primary chat surface, owns log + input. */</span>
-  <span class="info">▎</span>      <span class="fg4">   2</span>
-  <span class="info">▎</span>      <span class="fg4">   3</span>   <span class="fg1">import React, ... from "react";</span>
-  <span class="info">▎</span>      <span class="fg4">   …</span>   <span class="fg3">[1218 lines hidden — press space to load all]</span>
-  <span class="info">▎</span>      <span class="fg4">1224</span>   <span class="fg1">export default App;</span>
+  <span class="info">▎</span>   <span class="anchor info">↳</span> <span class="pill path">&nbsp;src/repair/storm.ts&nbsp;</span><span class="fg3">:13</span>  <span class="fg2">export class StormBreaker {</span>
+  <span class="info">▎</span>     <span class="pill path">&nbsp;src/repair/index.ts&nbsp;</span><span class="fg3">:33</span>  <span class="fg2">private readonly storm: StormBreaker;</span>
+  <span class="info">▎</span>     <span class="pill path">&nbsp;src/repair/index.ts&nbsp;</span><span class="fg3">:38</span>  <span class="fg2">this.storm = new StormBreaker(opts.stormWindow ?? 6, ...);</span>
+  <span class="info">▎</span>     <span class="pill path">&nbsp;tests/repair/storm.test.ts&nbsp;</span><span class="fg3">:2</span>  <span class="fg2">import { StormBreaker } from "...";</span>
 </pre>
+    <p class="lede">Used for grep / search / list outputs where 4-6 hit lines is the answer. Body anchor on the first hit row; subsequent rows align under it.</p>
 
-    <div class="tag">SHELL TOOL · <span class="cls">.tool .shell</span></div>
-<pre class="mock">  <span class="info">▎</span> <span class="info b">▣ run_command</span>  <span class="fg2">npm run verify</span>                 <span class="fg3">23.4s · </span><span class="ok">exit 0</span>      <span class="fg4">▾</span>
+    <div class="tag">SHELL · <span class="cls">.tool .shell</span> · long stdout · tail-window with overflow ⋮</div>
+<pre class="mock">  <span class="info">▎</span> <span class="pill sec-shell">&nbsp;SHELL&nbsp;</span>  <span class="b info">run_command</span>  <span class="pill path">&nbsp;npm run verify&nbsp;</span>             <span class="fg3">23.4s · 1818 lines · </span><span class="ok">exit 0</span>
   <span class="info">▎</span>
-  <span class="info">▎</span>   <span class="fg3">$ npm run verify</span>
-  <span class="info">▎</span>   <span class="fg3">> reasonix@0.17.0 verify</span>
-  <span class="info">▎</span>   <span class="fg3">> npm run lint && npm run typecheck && npm run test --silent</span>
-  <span class="info">▎</span>   <span class="fg3">…</span>
-  <span class="info">▎</span>   <span class="fg1"> Test Files  </span><span class="ok">99 passed (99)</span>
-  <span class="info">▎</span>   <span class="fg1">      Tests  </span><span class="ok">1784 passed (1784)</span>
+  <span class="info">▎</span>   <span class="fg4">⋮  1812 lines streamed past preview window</span>
+  <span class="info">▎</span>
+  <span class="info">▎</span>   <span class="anchor info">↳</span> <span class="fg2">Test Files  </span><span class="ok">115 passed (115)</span>
+  <span class="info">▎</span>     <span class="fg2">     Tests  </span><span class="ok">1818 passed (1818)</span>
+  <span class="info">▎</span>     <span class="fg2">  Duration  </span><span class="fg2">23.81s</span>
 </pre>
+    <p class="lede">Long stdout follows the same tail-window pattern as streaming reasoning — tail-3-lines plus a <span class="fg4">⋮</span> overflow gutter. The full stream is on disk in the events log; recall via <code>/output last</code> if needed.</p>
+
+    <div class="tag">FAILED · <span class="cls">.tool .failed</span> · err-tinted pill, error message inline</div>
+<pre class="mock">  <span class="err">▎</span> <span class="pill sec-tool">&nbsp;TOOL&nbsp;</span>  <span class="b info">edit_file</span>  <span class="pill path">&nbsp;src/loop.ts&nbsp;</span>                   <span class="fg3">0.05s · </span><span class="err">failed</span>
+  <span class="err">▎</span>
+  <span class="err">▎</span>   <span class="anchor err">↳</span> <span class="err">✗</span> <span class="fg1">SEARCH text not found — model emitted `repairCalls` but file</span>
+  <span class="err">▎</span>     <span class="fg1">  has `repairedCalls`. Suggest /retry with corrected name.</span>
+</pre>
+    <p class="lede">Failure cards switch the rule color to err and surface the error inline (not collapsed). Most useful info first: what kind of failure + the actionable hint.</p>
   </section>
 
   <!-- Plan / Todo -->
   <section class="section" id="c-plan">
     <h2><span class="num">09</span>Cards · plan / todo</h2>
-    <p class="lede">Ordered checklist. State per item via the bracket char + color: <span class="ok">[✓]</span> done · <span class="brand">[▶]</span> running · <span class="fg4">[ ]</span> queued · <span class="warn">[!]</span> blocked · <span class="err">[✗]</span> failed. Footer offers revise / skip actions.</p>
+    <p class="lede">Ordered checklist. <span class="pill sec-plan">&nbsp;PLAN&nbsp;</span> pill + plan title + progress fraction in the header. State per item via the bracket char + color: <span class="ok">[✓]</span> done · <span class="brand">[▶]</span> running · <span class="fg4">[ ]</span> queued · <span class="warn">[!]</span> blocked · <span class="err">[✗]</span> failed.</p>
     <div class="tag">CARD · <span class="cls">.plan</span></div>
-<pre class="mock">  <span class="accent">▎</span> <span class="accent b">⊞ Plan · Migrate selection to terminal-native</span>                <span class="fg3">5 of 7 done</span>  <span class="fg4">▾</span>
+<pre class="mock">  <span class="accent">▎</span> <span class="pill sec-plan">&nbsp;PLAN&nbsp;</span>  <span class="b fg0">Migrate selection to terminal-native</span>             <span class="fg3">5 / 7 done</span>
   <span class="accent">▎</span>
-  <span class="accent">▎</span>    <span class="ok">[✓]</span> <span class="fg3">1. Snapshot current selection state</span>
-  <span class="accent">▎</span>    <span class="ok">[✓]</span> <span class="fg3">2. Drop @xterm/headless dep</span>
-  <span class="accent">▎</span>    <span class="ok">[✓]</span> <span class="fg3">3. Remove screen-mirror.ts</span>
-  <span class="accent">▎</span>    <span class="ok">[✓]</span> <span class="fg3">4. Strip LogSelection from log-frame.tsx</span>
-  <span class="accent">▎</span>    <span class="ok">[✓]</span> <span class="fg3">5. Strip drag handlers from App.tsx</span>
-  <span class="accent">▎</span>    <span class="brand">[▶]</span> <span class="b fg0">6. Add /copy slash command</span>          <span class="fg4">←</span> <span class="brand">in progress</span>
-  <span class="accent">▎</span>    <span class="fg4">[ ]</span> <span class="fg2">7. Update CHANGELOG &amp; push</span>
-  <span class="accent">▎</span>
-  <span class="accent">▎</span>    <span class="fg3">[r] revise   [s] skip step   [↵] expand item</span>
+  <span class="accent">▎</span>   <span class="anchor">↳</span> <span class="ok">[✓]</span> <span class="fg3">1. Snapshot current selection state</span>
+  <span class="accent">▎</span>     <span class="ok">[✓]</span> <span class="fg3">2. Drop @xterm/headless dep</span>
+  <span class="accent">▎</span>     <span class="ok">[✓]</span> <span class="fg3">3. Remove screen-mirror.ts</span>
+  <span class="accent">▎</span>     <span class="ok">[✓]</span> <span class="fg3">4. Strip LogSelection from log-frame.tsx</span>
+  <span class="accent">▎</span>     <span class="ok">[✓]</span> <span class="fg3">5. Strip drag handlers from App.tsx</span>
+  <span class="accent">▎</span>     <span class="brand">[▶]</span> <span class="b fg0">6. Add /copy slash command</span>          <span class="fg4">←</span> <span class="brand">in progress</span>
+  <span class="accent">▎</span>     <span class="fg4">[ ]</span> <span class="fg2">7. Update CHANGELOG &amp; push</span>
 </pre>
+    <p class="lede">Body anchor on the first plan item; subsequent items align under it. The footer action row from the previous design is dropped — TUI doesn't host per-item interactive shortcuts cleanly. Plan revision happens via slash commands (<code>/plan revise</code>, <code>/plan skip 4</code>) which are discoverable through <code>/help</code>.</p>
+
+    <div class="tag">XL · <span class="cls">.plan .xl</span> · &gt; 12 items · head + tail with middle elided, same as Reasoning XL</div>
+<pre class="mock">  <span class="accent">▎</span> <span class="pill sec-plan">&nbsp;PLAN&nbsp;</span>  <span class="b fg0">v0.24 release readiness</span>                          <span class="fg3">8 / 18 done</span>
+  <span class="accent">▎</span>
+  <span class="accent">▎</span>   <span class="anchor">↳</span> <span class="ok">[✓]</span> <span class="fg3">1. Bump version + CHANGELOG entry</span>
+  <span class="accent">▎</span>     <span class="ok">[✓]</span> <span class="fg3">2. Run full verify gate</span>
+  <span class="accent">▎</span>     <span class="brand">[▶]</span> <span class="b fg0">3. Update docs/MIGRATION.md</span>           <span class="fg4">←</span> <span class="brand">in progress</span>
+  <span class="accent">▎</span>
+  <span class="accent">▎</span>   <span class="fg4">⋯  12 items elided  ·  /plan view  ⋯</span>
+  <span class="accent">▎</span>
+  <span class="accent">▎</span>     <span class="fg4">[ ]</span> <span class="fg2">17. Tag release</span>
+  <span class="accent">▎</span>     <span class="fg4">[ ]</span> <span class="fg2">18. Publish to npm</span>
+</pre>
+    <p class="lede">Same head + tail elision pattern as Reasoning XL — first 3 items + last 2 items + a middle elision row. The currently-running item is always promoted into the head window even if it would otherwise fall in the elided range, so progress stays visible.</p>
   </section>
 
   <!-- Diff -->
@@ -765,7 +883,7 @@ main { padding: 32px 48px 40px 32px; min-width: 0; }
   <span class="violet">▎</span>   <span class="fg3">Tools  </span> <span class="fg2">read_file, search_content</span>
   <span class="violet">▎</span>
   <span class="violet">▎</span>   <span class="fg3">▸ sub-agent stream</span>
-  <span class="violet">▎</span>   <span class="violet">▎</span> <span class="accent">◆</span> <span class="fg3 i">Reasoning · 2 paragraphs</span>                                <span class="fg4">▸</span>
+  <span class="violet">▎</span>   <span class="violet">▎</span> <span class="pill sec-reason">&nbsp;REASONING&nbsp;</span>  <span class="pill mdl-flash">&nbsp;v4-flash&nbsp;</span>  <span class="fg4">134 tok · 2 ¶</span>
   <span class="violet">▎</span>   <span class="violet">▎</span> <span class="info">▣</span> <span class="b fg1">read_file</span>  <span class="fg2">src/index/config.ts</span>                  <span class="fg3">0.08s</span>
   <span class="violet">▎</span>   <span class="violet">▎</span> <span class="brand">▶</span> <span class="brand">streaming response …</span>
 </pre>
@@ -1230,7 +1348,7 @@ main { padding: 32px 48px 40px 32px; min-width: 0; }
     <span class="fg1">abandon fullscreen mode, switch to inline scrollback</span>
 
 
-  <span class="accent">▎</span> <span class="accent b">◆ Reasoning</span>  <span class="fg4">· 4 paragraphs</span>                                       <span class="fg4">▸</span>
+  <span class="accent">▎</span> <span class="pill sec-reason">&nbsp;REASONING&nbsp;</span>  <span class="pill mdl-pro">&nbsp;v4-pro&nbsp;</span>  <span class="fg4">587 tok · 4 ¶</span>                                  <span class="fg3">4.7s</span>
 
 
   <span class="accent">▎</span> <span class="accent b">⊞ Plan · 5 steps</span>                                       <span class="fg3">5 of 5 done</span>  <span class="fg4">▾</span>
@@ -1311,8 +1429,10 @@ main { padding: 32px 48px 40px 32px; min-width: 0; }
 
 </pre>
 
-    <h3 id="s-stream-reason">Streaming reasoning<span class="desc">live italic dim while bytes arrive; settles into the collapsed reasoning card on completion</span></h3>
-<pre class="mock">  <span class="accent">▎</span> <span class="accent b">◆ Reasoning</span>  <span class="fg4">· streaming…</span>                                            <span class="fg4">▾</span>
+    <h3 id="s-stream-reason">Streaming reasoning<span class="desc">live tail-3-lines while bytes arrive; settles into one of the three sized variants in §06 once the stream ends</span></h3>
+<pre class="mock">  <span class="accent">▎</span> <span class="pill sec-reason">&nbsp;REASONING&nbsp;</span>  <span class="pill mdl-r1">&nbsp;r1&nbsp;</span>  <span class="fg4">247 tok</span>                                  <span class="fg3">1.2s · </span><span class="brand">thinking…</span>
+  <span class="accent">▎</span>
+  <span class="accent">▎</span>   <span class="fg4">⋮  earlier lines scrolled past preview window</span>
   <span class="accent">▎</span>
   <span class="accent">▎</span>   <span class="i fg3">Two paths: replace the hardcoded list when config is set, or merge</span>
   <span class="accent">▎</span>   <span class="i fg3">user values in. The first matches the explicit "config-driven" ask;</span>
@@ -1342,7 +1462,7 @@ main { padding: 32px 48px 40px 32px; min-width: 0; }
   <span class="violet">▎</span>   <span class="violet">▎</span> <span class="violet b">⌬ Sub-agent · code-reader</span>                                  <span class="violet">running</span>  <span class="fg4">▾</span>
   <span class="violet">▎</span>   <span class="violet">▎</span>
   <span class="violet">▎</span>   <span class="violet">▎</span>   <span class="violet">▎</span> <span class="info b">▣ read_file</span>  <span class="fg2">src/cli/ui/App.tsx</span>           <span class="fg3">0.08s</span>
-  <span class="violet">▎</span>   <span class="violet">▎</span>   <span class="violet">▎</span> <span class="accent">◆</span> <span class="i fg3">Reasoning · 1 paragraph</span>                              <span class="fg4">▸</span>
+  <span class="violet">▎</span>   <span class="violet">▎</span>   <span class="violet">▎</span> <span class="pill sec-reason">&nbsp;REASONING&nbsp;</span>  <span class="pill mdl-flash">&nbsp;v4-flash&nbsp;</span>  <span class="fg4">62 tok · 1 ¶</span>
   <span class="violet">▎</span>   <span class="violet">▎</span>
   <span class="violet">▎</span>   <span class="violet">▎</span>   <span class="brand">▶</span> <span class="brand">summarising findings…</span>
   <span class="violet">▎</span>
@@ -1987,7 +2107,7 @@ main { padding: 32px 48px 40px 32px; min-width: 0; }
   <span class="fg3">▎</span> <span class="b fg2">⌑ Context</span>  <span class="fg3">·  4 user · 2 feedback · 1 reference</span>             <span class="fg3">~1.2K tok</span>  <span class="fg4">▸</span>
 
 
-  <span class="accent">▎</span> <span class="accent b">◆ Reasoning</span>  <span class="fg4">· 3 paragraphs</span>                                       <span class="fg4">▸</span>
+  <span class="accent">▎</span> <span class="pill sec-reason">&nbsp;REASONING&nbsp;</span>  <span class="pill mdl-r1">&nbsp;r1&nbsp;</span>  <span class="fg4">412 tok · 3 ¶</span>                                  <span class="fg3">3.1s</span>
 
 
   <span class="accent">▎</span> <span class="accent b">⊞ Plan · 5 steps</span>                                      <span class="fg3">0 of 5 done</span>  <span class="fg4">▾</span>

--- a/src/cli/ui/cards/CardRenderer.tsx
+++ b/src/cli/ui/cards/CardRenderer.tsx
@@ -2,7 +2,6 @@ import { Box, Text } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React from "react";
 import type { Card } from "../state/cards.js";
-import { useAgentState } from "../state/provider.js";
 import { FG } from "../theme/tokens.js";
 import { BranchCard } from "./BranchCard.js";
 import { CtxCard } from "./CtxCard.js";
@@ -23,25 +22,19 @@ import { UserCard } from "./UserCard.js";
 import { WarnCard } from "./WarnCard.js";
 
 export function CardRenderer({ card }: { card: Card }): React.ReactElement {
-  // Once assistant content starts streaming, reasoning collapses so the
-  // answer takes the live region budget.
-  const contentStreaming = useAgentState((s) =>
-    s.cards.some((c) => c.kind === "streaming" && c.text.length > 0 && !c.done),
-  );
   return (
     <Box flexDirection="column" marginTop={1}>
-      {renderCard(card, contentStreaming)}
+      {renderCard(card)}
     </Box>
   );
 }
 
-function renderCard(card: Card, contentStreaming: boolean): React.ReactElement {
+function renderCard(card: Card): React.ReactElement {
   switch (card.kind) {
     case "user":
       return <UserCard card={card} />;
     case "reasoning":
-      // Yield to content while it streams; otherwise show a body preview.
-      return <ReasoningCard card={card} expanded={!(card.streaming && contentStreaming)} />;
+      return <ReasoningCard card={card} expanded={true} />;
     case "streaming":
       return <StreamingCard card={card} />;
     case "tool":

--- a/src/cli/ui/cards/ReasoningCard.tsx
+++ b/src/cli/ui/cards/ReasoningCard.tsx
@@ -1,16 +1,20 @@
 import { Box, Text, useStdout } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React from "react";
-import { clipToCells } from "../../../frame/width.js";
-import { BarRow, CursorBlock } from "../primitives/BarRow.js";
+import { clipToCells, wrapToCells } from "../../../frame/width.js";
+import { CursorBlock } from "../primitives/BarRow.js";
+import { CardBox } from "../primitives/CardBox.js";
+import { PILL_MODEL, PILL_SECTION, Pill, modelBadgeFor } from "../primitives/Pill.js";
+import { Spinner } from "../primitives/Spinner.js";
 import type { ReasoningCard as ReasoningCardData } from "../state/cards.js";
-import { FG } from "../theme/tokens.js";
-import { CardHeader } from "./CardHeader.js";
+import { CARD, FG } from "../theme/tokens.js";
 
-/** Fixed tail for streaming — prevents the live region from growing past the terminal and forcing the OS to scroll on every byte. Full content lands in scrollback when streaming completes. */
-const STREAMING_TAIL = 6;
-const DONE_PREVIEW_TAIL = 3;
-const BODY_INDENT_CELLS = 5;
+/** Streaming live region stays at this many rows so Ink's eraseLines can't miscount enough to flicker. Full body lands in scrollback once the card settles. */
+const STREAMING_PREVIEW_LINES = 4;
+/** Settled reasoning collapses to tail-only — once the model is done thinking, the conclusion is the actionable signal; the rest is in the events log via `/reasoning last`. */
+const SETTLED_TAIL_LINES = 2;
+const HEADER_PAD = 1;
+const BODY_PAD = 4;
 
 export function ReasoningCard({
   card,
@@ -21,49 +25,148 @@ export function ReasoningCard({
 }): React.ReactElement {
   const { stdout } = useStdout();
   const cols = stdout?.columns ?? 80;
-  const lineCells = Math.max(20, cols - BODY_INDENT_CELLS - 1);
-  const meta = card.aborted
-    ? "aborted"
-    : card.streaming
-      ? "streaming…"
-      : `${card.paragraphs} paragraph${card.paragraphs === 1 ? "" : "s"} · ${card.tokens} tok`;
+  const lineCells = Math.max(20, cols - BODY_PAD - 4);
 
   const allLines = card.text.length > 0 ? card.text.split("\n") : [];
-  const tailSize = card.streaming ? STREAMING_TAIL : DONE_PREVIEW_TAIL;
-  const overflows = allLines.length > tailSize;
-  const lineSlots = overflows ? tailSize - 1 : allLines.length;
-  const visible = overflows ? allLines.slice(-lineSlots) : allLines;
-  const headDropped = overflows ? allLines.length - visible.length : 0;
-  const showBody = expanded && allLines.length > 0;
+  const showBody = expanded && (allLines.length > 0 || card.streaming);
+  const barColor = card.streaming ? CARD.reasoning.color : FG.faint;
 
   return (
-    <Box flexDirection="column">
-      <CardHeader tone="reasoning" glyph="◆" title="Reasoning" meta={`· ${meta}`} />
+    <CardBox color={barColor}>
+      <ReasoningHeader card={card} />
       {showBody && (
         <>
-          <BarRow tone="reasoning" indent={0} />
-          {headDropped > 0 && (
-            <BarRow tone="reasoning">
-              <Text color={FG.faint}>
-                {card.streaming
-                  ? `… ${headDropped} earlier line${headDropped === 1 ? "" : "s"} (will appear in scrollback)`
-                  : `⋮ ${headDropped} earlier line${headDropped === 1 ? "" : "s"}`}
-              </Text>
-            </BarRow>
+          <Box height={1} />
+          {card.streaming ? (
+            <StreamingPreview card={card} allLines={allLines} lineCells={lineCells} />
+          ) : (
+            <SettledPreview card={card} allLines={allLines} lineCells={lineCells} />
           )}
-          {visible.map((line, i) => {
-            const isLast = i === visible.length - 1;
-            return (
-              <BarRow key={`${card.id}:${headDropped + i}`} tone="reasoning">
-                <Text italic color={FG.meta}>
-                  {clipToCells(line, lineCells)}
-                </Text>
-                {isLast && card.streaming && <CursorBlock />}
-              </BarRow>
-            );
-          })}
         </>
       )}
+    </CardBox>
+  );
+}
+
+function ReasoningHeader({ card }: { card: ReasoningCardData }): React.ReactElement {
+  const badge = modelBadgeFor(card.model);
+  const mdl = PILL_MODEL[badge.kind];
+  const sec = PILL_SECTION.reason;
+  const meta = headerMeta(card);
+  const duration = headerDuration(card);
+  return (
+    <Box paddingLeft={HEADER_PAD} flexDirection="row">
+      <Pill label="REASONING" bg={sec.bg} fg={sec.fg} />
+      <Text>{"  "}</Text>
+      <Pill label={badge.label} bg={mdl.bg} fg={mdl.fg} />
+      {meta && (
+        <>
+          <Text>{"  "}</Text>
+          <Text color={FG.faint}>{meta}</Text>
+        </>
+      )}
+      <Box flexGrow={1} />
+      {card.streaming && !card.aborted && (
+        <>
+          <Spinner kind="braille" color={CARD.reasoning.color} />
+          <Text color={CARD.reasoning.color}>{" thinking…"}</Text>
+        </>
+      )}
+      {duration && <Text color={FG.faint}>{duration}</Text>}
+    </Box>
+  );
+}
+
+function headerMeta(card: ReasoningCardData): string {
+  if (card.aborted) return "aborted";
+  if (card.streaming) {
+    return card.tokens > 0 ? `${card.tokens.toLocaleString()} tok` : "";
+  }
+  const parts: string[] = [];
+  if (card.tokens > 0) parts.push(`${card.tokens.toLocaleString()} tok`);
+  if (card.paragraphs > 0) parts.push(`${card.paragraphs} ¶`);
+  return parts.join(" · ");
+}
+
+function headerDuration(card: ReasoningCardData): string {
+  if (card.streaming || !card.endedAt) return "";
+  const seconds = Math.max(0, (card.endedAt - card.ts) / 1000);
+  return `${seconds.toFixed(1)}s`;
+}
+
+interface BodyProps {
+  card: ReasoningCardData;
+  allLines: string[];
+  lineCells: number;
+}
+
+function StreamingPreview({ card, allLines, lineCells }: BodyProps): React.ReactElement {
+  const visualLines = allLines.flatMap((l) => wrapToCells(l, lineCells));
+  const visible = visualLines.slice(-STREAMING_PREVIEW_LINES);
+  return <BodyLines card={card} lines={visible} lineCells={lineCells} cursorOnLast />;
+}
+
+function SettledPreview({ card, allLines, lineCells }: BodyProps): React.ReactElement {
+  const visualLines = allLines.flatMap((l) => wrapToCells(l, lineCells));
+  const visible = visualLines.slice(-SETTLED_TAIL_LINES);
+  const droppedLines = Math.max(0, visualLines.length - visible.length);
+  return (
+    <>
+      {droppedLines > 0 && <ElisionHint droppedLines={droppedLines} card={card} />}
+      <BodyLines card={card} lines={visible} lineCells={lineCells} indexOffset={droppedLines} />
+    </>
+  );
+}
+
+interface BodyLinesProps {
+  card: ReasoningCardData;
+  lines: string[];
+  lineCells: number;
+  cursorOnLast?: boolean;
+  indexOffset?: number;
+}
+
+function BodyLines({
+  card,
+  lines,
+  lineCells,
+  cursorOnLast = false,
+  indexOffset = 0,
+}: BodyLinesProps): React.ReactElement {
+  return (
+    <>
+      {lines.map((line, i) => {
+        const isLast = i === lines.length - 1;
+        return (
+          <Box key={`${card.id}:b:${indexOffset + i}`} paddingLeft={BODY_PAD} flexDirection="row">
+            <Text italic color={FG.meta}>
+              {clipToCells(line, lineCells)}
+            </Text>
+            {isLast && cursorOnLast && <CursorBlock />}
+          </Box>
+        );
+      })}
+    </>
+  );
+}
+
+function ElisionHint({
+  droppedLines,
+  card,
+}: {
+  droppedLines: number;
+  card: ReasoningCardData;
+}): React.ReactElement {
+  const parts: string[] = [];
+  if (card.paragraphs > 1) {
+    parts.push(`${card.paragraphs} ¶`);
+  } else {
+    parts.push(`${droppedLines} line${droppedLines === 1 ? "" : "s"}`);
+  }
+  if (card.tokens > 0) parts.push(`${card.tokens.toLocaleString()} tok`);
+  return (
+    <Box paddingLeft={BODY_PAD}>
+      <Text color={FG.faint}>{`⋯ ${parts.join(" · ")} above · /reasoning last`}</Text>
     </Box>
   );
 }

--- a/src/cli/ui/cards/StreamingCard.tsx
+++ b/src/cli/ui/cards/StreamingCard.tsx
@@ -1,82 +1,84 @@
 import { Box, Text, useStdout } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React from "react";
-import { clipToCells } from "../../../frame/width.js";
+import { clipToCells, wrapToCells } from "../../../frame/width.js";
 import { useReserveRows } from "../layout/viewport-budget.js";
 import { Markdown } from "../markdown.js";
-import { BarRow, CursorBlock } from "../primitives/BarRow.js";
+import { CardBox } from "../primitives/CardBox.js";
+import { PILL_MODEL, PILL_SECTION, Pill, modelBadgeFor } from "../primitives/Pill.js";
+import { Spinner } from "../primitives/Spinner.js";
 import type { StreamingCard as StreamingCardData } from "../state/cards.js";
-import { FG, TONE } from "../theme/tokens.js";
+import { CARD, FG, TONE } from "../theme/tokens.js";
 
-const BODY_INDENT_CELLS = 5;
+const HEADER_PAD = 1;
+const BODY_PAD = 4;
+/** Streaming live region stays at this many rows so Ink's eraseLines can't miscount enough to flicker. Full body lands in scrollback once the card settles. */
+const STREAMING_PREVIEW_LINES = 4;
 
 export function StreamingCard({ card }: { card: StreamingCardData }): React.ReactElement {
   const { stdout } = useStdout();
   const cols = stdout?.columns ?? 80;
   // Claim before the done-state branch — hook order must stay stable across the done flip.
-  const budget = useReserveRows("stream", { min: 4, max: Number.POSITIVE_INFINITY });
+  useReserveRows("stream", {
+    min: STREAMING_PREVIEW_LINES + 1,
+    max: STREAMING_PREVIEW_LINES + 2,
+  });
 
   if (card.done && !card.aborted) {
     return (
-      <Box
-        flexDirection="column"
-        paddingLeft={2}
-        paddingRight={1}
-        borderStyle="single"
-        borderTop={false}
-        borderRight={false}
-        borderBottom={false}
-        borderLeft
-        borderLeftColor={TONE.brand}
-      >
-        <Markdown text={card.text} />
-      </Box>
+      <CardBox color={FG.faint}>
+        <Box paddingLeft={BODY_PAD} flexDirection="column">
+          <Markdown text={card.text} />
+        </Box>
+      </CardBox>
     );
   }
-  const lineCells = Math.max(20, cols - BODY_INDENT_CELLS - 1);
+  const lineCells = Math.max(20, cols - BODY_PAD - 4);
   const allLines = card.text.length > 0 ? card.text.split("\n") : [""];
-  const reserved = (card.aborted ? 2 : 0) + 1;
-  const lineSlots = Math.max(4, budget - reserved);
-  const overflows = !card.done && allLines.length > lineSlots;
-  const visible = overflows ? allLines.slice(-lineSlots) : allLines;
-  const headDropped = overflows ? allLines.length - visible.length : 0;
+  const visualLines = allLines.flatMap((l) => wrapToCells(l, lineCells));
+  const visible = visualLines.slice(-STREAMING_PREVIEW_LINES);
 
   return (
-    <Box flexDirection="column">
+    <CardBox color={card.aborted ? FG.faint : CARD.streaming.color}>
+      {!card.aborted && <StreamingHeader card={card} />}
       {card.aborted && (
-        <BarRow tone="streaming" glyph="—">
+        <Box paddingLeft={HEADER_PAD} flexDirection="row">
           <Text color={FG.faint} bold>
             — aborted —
           </Text>
           <Text color={TONE.warn}>{"   stopped"}</Text>
-        </BarRow>
+        </Box>
       )}
-      {headDropped > 0 && (
-        <BarRow tone="streaming" glyph="▾">
-          <Text
-            color={FG.faint}
-          >{`… ${headDropped} earlier line${headDropped === 1 ? "" : "s"} (will appear in scrollback)`}</Text>
-        </BarRow>
-      )}
-      {visible.map((line, i) => {
-        const isLast = i === visible.length - 1;
-        const isFirstRendered = !card.aborted && headDropped === 0 && i === 0;
-        return (
-          <BarRow
-            key={`${card.id}:${headDropped + i}`}
-            tone="streaming"
-            glyph={isFirstRendered ? "▶" : undefined}
-          >
-            <Text color={card.aborted ? FG.meta : FG.body}>{clipToCells(line, lineCells)}</Text>
-            {isLast && !card.done && <CursorBlock />}
-          </BarRow>
-        );
-      })}
+      {visible.map((line, i) => (
+        <Box
+          key={`${card.id}:${allLines.length - visible.length + i}`}
+          paddingLeft={BODY_PAD}
+          flexDirection="row"
+        >
+          <Text color={card.aborted ? FG.meta : FG.body}>{clipToCells(line, lineCells)}</Text>
+        </Box>
+      ))}
       {card.aborted && (
-        <BarRow tone="streaming">
+        <Box paddingLeft={BODY_PAD}>
           <Text color={FG.faint}>{"[truncated by esc]"}</Text>
-        </BarRow>
+        </Box>
       )}
+    </CardBox>
+  );
+}
+
+function StreamingHeader({ card }: { card: StreamingCardData }): React.ReactElement {
+  const badge = modelBadgeFor(card.model);
+  const mdl = PILL_MODEL[badge.kind];
+  const sec = PILL_SECTION.output;
+  return (
+    <Box paddingLeft={HEADER_PAD} flexDirection="row">
+      <Pill label="OUTPUT" bg={sec.bg} fg={sec.fg} />
+      <Text>{"  "}</Text>
+      <Pill label={badge.label} bg={mdl.bg} fg={mdl.fg} />
+      <Box flexGrow={1} />
+      <Spinner kind="braille" color={CARD.streaming.color} />
+      <Text color={CARD.streaming.color}>{" writing…"}</Text>
     </Box>
   );
 }

--- a/src/cli/ui/cards/ToolCard.tsx
+++ b/src/cli/ui/cards/ToolCard.tsx
@@ -10,7 +10,7 @@ import { CardHeader } from "./CardHeader.js";
 
 const READ_TAIL = 2;
 const OTHER_TAIL = 5;
-const BODY_INDENT_CELLS = 5;
+const BODY_INDENT_CELLS = 7;
 
 /** Read-style tools dump file/list bodies — short tail is enough; the model already has the full text in context. */
 function tailLinesFor(name: string): number {

--- a/src/cli/ui/primitives/CardBox.tsx
+++ b/src/cli/ui/primitives/CardBox.tsx
@@ -1,0 +1,41 @@
+/** Wraps card content in a Box with `▎` rendered as a per-row borderLeft, so wrap continuations of long markdown / output lines still show the accent bar. */
+
+import { Box } from "ink";
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React from "react";
+
+const BAR_STYLE = {
+  topLeft: " ",
+  top: " ",
+  topRight: " ",
+  right: " ",
+  bottomRight: " ",
+  bottom: " ",
+  bottomLeft: " ",
+  left: "▎",
+} as const;
+
+export function CardBox({
+  color,
+  children,
+}: {
+  color: string;
+  children: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <Box marginLeft={2} flexDirection="column">
+      <Box
+        flexDirection="column"
+        borderStyle={BAR_STYLE}
+        borderTop={false}
+        borderRight={false}
+        borderBottom={false}
+        borderLeft
+        borderLeftColor={color}
+        flexGrow={1}
+      >
+        {children}
+      </Box>
+    </Box>
+  );
+}

--- a/src/cli/ui/primitives/Pill.tsx
+++ b/src/cli/ui/primitives/Pill.tsx
@@ -1,0 +1,52 @@
+/** Bg-tinted inline chip — section labels (REASONING / TASK / TOOL) and badges (model / path). */
+
+import { Text } from "ink";
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React from "react";
+
+export interface PillProps {
+  label: string;
+  bg: string;
+  fg: string;
+  bold?: boolean;
+}
+
+export function Pill({ label, bg, fg, bold = true }: PillProps): React.ReactElement {
+  return <Text backgroundColor={bg} color={fg} bold={bold}>{` ${label} `}</Text>;
+}
+
+/** Section pill bg tints — muted accent-of-card-tone, paired with the tone's fg. */
+export const PILL_SECTION = {
+  reason: { bg: "#2a1f3d", fg: "#d2a8ff" },
+  output: { bg: "#0d1d2e", fg: "#79c0ff" },
+  tool: { bg: "#0f2230", fg: "#79c0ff" },
+  shell: { bg: "#0f2230", fg: "#79c0ff" },
+  task: { bg: "#0d1d2e", fg: "#79c0ff" },
+  taskDone: { bg: "#102815", fg: "#7ee787" },
+  taskFailed: { bg: "#2c1416", fg: "#ff8b81" },
+  plan: { bg: "#2a1f3d", fg: "#d2a8ff" },
+  user: { bg: "#11141a", fg: "#8b949e" },
+} as const;
+
+/** Model pill — neutral bg, color signals model class. */
+export const PILL_MODEL = {
+  flash: { bg: "#11141a", fg: "#79c0ff" },
+  pro: { bg: "#11141a", fg: "#d2a8ff" },
+  r1: { bg: "#11141a", fg: "#b395f5" },
+  unknown: { bg: "#11141a", fg: "#8b949e" },
+} as const;
+
+export interface ModelBadge {
+  label: string;
+  kind: keyof typeof PILL_MODEL;
+}
+
+/** Map full DeepSeek model id to short label + color class. */
+export function modelBadgeFor(model: string | undefined): ModelBadge {
+  if (!model) return { label: "?", kind: "unknown" };
+  const stripped = model.replace(/^deepseek-/, "");
+  if (stripped === "v4-flash" || stripped === "chat") return { label: "v4-flash", kind: "flash" };
+  if (stripped === "v4-pro") return { label: "v4-pro", kind: "pro" };
+  if (stripped === "r1" || stripped === "reasoner") return { label: "r1", kind: "r1" };
+  return { label: stripped, kind: "unknown" };
+}

--- a/src/cli/ui/state/cards.ts
+++ b/src/cli/ui/state/cards.ts
@@ -17,6 +17,10 @@ export interface ReasoningCard extends CardBase {
   tokens: number;
   streaming: boolean;
   aborted?: boolean;
+  /** Snapshotted at reasoning.start so escalation mid-turn doesn't relabel completed reasoning. */
+  model?: string;
+  /** Stamped at reasoning.end. Drives the duration badge on the settled header. */
+  endedAt?: number;
 }
 
 export interface StreamingCard extends CardBase {
@@ -24,6 +28,10 @@ export interface StreamingCard extends CardBase {
   text: string;
   done: boolean;
   aborted?: boolean;
+  /** Snapshotted at streaming.start so escalation mid-turn doesn't relabel completed output. */
+  model?: string;
+  /** Stamped at streaming.end. */
+  endedAt?: number;
 }
 
 export interface ToolCard extends CardBase {

--- a/src/cli/ui/state/reducer.ts
+++ b/src/cli/ui/state/reducer.ts
@@ -25,7 +25,7 @@ export function reduce(state: AgentState, event: AgentEvent): AgentState {
       );
 
     case "reasoning.start":
-      return appendCard(state, makeReasoningCard(event.id));
+      return appendCard(state, makeReasoningCard(event.id, state.session.model));
 
     case "reasoning.chunk":
       return mutateCard(state, event.id, "reasoning", (c) => ({ ...c, text: c.text + event.text }));
@@ -36,11 +36,12 @@ export function reduce(state: AgentState, event: AgentEvent): AgentState {
         paragraphs: event.paragraphs,
         tokens: event.tokens,
         streaming: false,
+        endedAt: Date.now(),
         ...(event.aborted ? { aborted: true } : {}),
       }));
 
     case "streaming.start":
-      return appendCard(state, makeStreamingCard(event.id));
+      return appendCard(state, makeStreamingCard(event.id, state.session.model));
 
     case "streaming.chunk":
       return mutateCard(state, event.id, "streaming", (c) => ({ ...c, text: c.text + event.text }));
@@ -49,6 +50,7 @@ export function reduce(state: AgentState, event: AgentEvent): AgentState {
       return mutateCard(state, event.id, "streaming", (c) => ({
         ...c,
         done: true,
+        endedAt: Date.now(),
         ...(event.aborted ? { aborted: true } : {}),
       }));
 
@@ -331,7 +333,7 @@ function makeUserCard(text: string): UserCard {
   return { kind: "user", id: nextId("user"), ts: Date.now(), text };
 }
 
-function makeReasoningCard(id: string): ReasoningCard {
+function makeReasoningCard(id: string, model?: string): ReasoningCard {
   return {
     kind: "reasoning",
     id,
@@ -340,11 +342,19 @@ function makeReasoningCard(id: string): ReasoningCard {
     paragraphs: 0,
     tokens: 0,
     streaming: true,
+    ...(model ? { model } : {}),
   };
 }
 
-function makeStreamingCard(id: string): StreamingCard {
-  return { kind: "streaming", id, ts: Date.now(), text: "", done: false };
+function makeStreamingCard(id: string, model?: string): StreamingCard {
+  return {
+    kind: "streaming",
+    id,
+    ts: Date.now(),
+    text: "",
+    done: false,
+    ...(model ? { model } : {}),
+  };
 }
 
 function makeToolCard(id: string, name: string, args: unknown): ToolCard {

--- a/src/frame/width.ts
+++ b/src/frame/width.ts
@@ -36,3 +36,25 @@ export function clipToCells(s: string, maxCells: number): string {
   }
   return `${out}…`;
 }
+
+/** Wrap to `maxCells`-wide chunks for tail-window semantics — caller can `slice(-N)` to pull true visual last lines. Empty input yields one empty chunk so paragraph breaks survive the round-trip. */
+export function wrapToCells(s: string, maxCells: number): string[] {
+  if (maxCells <= 0) return [];
+  if (s.length === 0) return [""];
+  const out: string[] = [];
+  let cur = "";
+  let cells = 0;
+  for (const g of graphemes(s)) {
+    const w = graphemeWidth(g);
+    if (cells + w > maxCells) {
+      out.push(cur);
+      cur = g;
+      cells = w;
+    } else {
+      cur += g;
+      cells += w;
+    }
+  }
+  if (cur.length > 0 || out.length === 0) out.push(cur);
+  return out;
+}

--- a/tests/ui-reasoning-tier.test.ts
+++ b/tests/ui-reasoning-tier.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { modelBadgeFor } from "../src/cli/ui/primitives/Pill.js";
+
+describe("modelBadgeFor", () => {
+  it("maps deepseek-v4-flash to flash class", () => {
+    expect(modelBadgeFor("deepseek-v4-flash")).toEqual({ label: "v4-flash", kind: "flash" });
+  });
+
+  it("maps the legacy deepseek-chat alias to flash class", () => {
+    expect(modelBadgeFor("deepseek-chat")).toEqual({ label: "v4-flash", kind: "flash" });
+  });
+
+  it("maps deepseek-v4-pro to pro class", () => {
+    expect(modelBadgeFor("deepseek-v4-pro")).toEqual({ label: "v4-pro", kind: "pro" });
+  });
+
+  it("maps deepseek-r1 and deepseek-reasoner to r1 class", () => {
+    expect(modelBadgeFor("deepseek-r1")).toEqual({ label: "r1", kind: "r1" });
+    expect(modelBadgeFor("deepseek-reasoner")).toEqual({ label: "r1", kind: "r1" });
+  });
+
+  it("falls back to unknown class for anything else, stripping the deepseek- prefix", () => {
+    expect(modelBadgeFor("deepseek-v5-experimental")).toEqual({
+      label: "v5-experimental",
+      kind: "unknown",
+    });
+    expect(modelBadgeFor(undefined)).toEqual({ label: "?", kind: "unknown" });
+  });
+});

--- a/tests/ui-reducer.test.ts
+++ b/tests/ui-reducer.test.ts
@@ -40,6 +40,12 @@ describe("ui reducer", () => {
     expect(card.tokens).toBe(12);
   });
 
+  it("snapshots the producing model on reasoning.start so mid-turn escalation doesn't relabel it", () => {
+    const s = run([{ type: "reasoning.start", id: "r1" }]);
+    const card = s.cards[0] as ReasoningCard;
+    expect(card.model).toBe("deepseek-chat");
+  });
+
   it("streams response chunks into a single streaming card", () => {
     const s = run([
       { type: "streaming.start", id: "s1" },


### PR DESCRIPTION
Closes #133.

## Summary

- Streaming live region is now bounded (4 rows for reasoning preview, 4 rows for output preview) and renders inside a `<Box borderLeft borderStyle={{left:"▎"}}>` so the accent bar follows wrapped lines instead of disappearing on continuation rows.
- Settled reasoning collapses to last 2 visual rows (pre-wrapped via `wrapToCells` so single long paragraphs surface their tail, not their head).
- Section + model pills replace the `◆` glyph + emoji prefix; bar dims to fg-faint once a card settles; streaming header carries a braille spinner + status text + duration on settle.
- Drops the `CardRenderer` "yield to content" branch that hid reasoning entirely while output streamed.

## Why

Three independent rendering bugs compounded into a "feels broken" UX on the Reasoning card:

1. The line-budget constant in `StreamingCard` / `ToolCard` was off by two cells, so rendered lines exceeded terminal width by one — the terminal wrap-extended each row, Ink's `eraseLines(N)` miscounted, ghost rows piled up. Visible as screen jitter once the live region exceeded the viewport.
2. Streaming live region grew row-by-row as text arrived — every chunk pushed everything below down by a row before the eraseLines miscount made it worse.
3. Settled body sliced last N _logical_ lines, but reasoning is typically a single long paragraph — `slice(-2)` returned the whole one-line string, then `clipToCells` truncated from the head, so the user saw the first cells of the line instead of the last.

## Test plan

- [x] `npm run verify` — 116/116 files, 1824/1824 tests green.
- [x] Manual TUI verification with a long-reasoning prompt:
  - Streaming preview stays at 4 rows, no per-chunk jitter ✓
  - Once reasoning settles, body shows the last 2 visual rows of the conclusion (not the head) ✓
  - Streaming header shows a live braille spinner + "thinking…" / "writing…" ✓
  - Settled bar dims to grey, settled header gains `1.2s` duration on the right ✓
  - `▎` bar follows every visual row including markdown wrap continuations ✓

## Notes

- New primitives: `CardBox` (border-left wrapper that lets `▎` follow wraps), `Pill` (bg-tinted inline chip + section/model color tables).
- New utility: `wrapToCells` in `frame/width.ts` — pre-wraps a string into ≤N-cell chunks for tail-window semantics.
- Lint warnings on existing `useImportType` suppressions in unrelated files were pre-existing and not from this PR.