### PR TITLE
test(slash): silence MCP reconnect spawn stderr leak

### DIFF
--- a/tests/slash.test.ts
+++ b/tests/slash.test.ts
@@ -810,7 +810,7 @@ describe("handleSlash", () => {
 
     it("/mcp reconnect <name> emits the lifecycle line on dispatch", () => {
       const r = handleSlash("mcp", ["reconnect", "notion"], makeLoop(), {
-        mcpServers: [summary("notion", "notion=node nope")],
+        mcpServers: [summary("notion", "notion=node -e 0")],
         postInfo: () => {
           /* swallowed for this test */
         },


### PR DESCRIPTION
## Summary

The `/mcp reconnect <name> emits the lifecycle line on dispatch` test in `tests/slash.test.ts` used `notion=node nope` as the MCP server spec. `kickOffMcpReconnect` is fire-and-forget async — it returns the lifecycle line synchronously (which the test asserts on), but the spawned `node nope` then errors with `MODULE_NOT_FOUND` to stderr. The test passes, but the noise leaked into `npm publish` / `npm run verify` output.

Replace the spec with `node -e 0` — a no-op that exits 0 silently, cross-platform.

## Test plan

- [x] `npx vitest run tests/slash.test.ts` — 128/128 pass, no stderr leak
- [ ] CI green