### PR TITLE
fix(cards): restore brand accent on done-state assistant reply

### DIFF
--- a/src/cli/ui/cards/StreamingCard.tsx
+++ b/src/cli/ui/cards/StreamingCard.tsx
@@ -26,7 +26,7 @@ export function StreamingCard({ card }: { card: StreamingCardData }): React.Reac
 
   if (card.done && !card.aborted) {
     return (
-      <CardBox color={FG.faint}>
+      <CardBox color={CARD.streaming.color}>
         <Box paddingLeft={BODY_PAD} flexDirection="column">
           <Markdown text={card.text} />
         </Box>


### PR DESCRIPTION
## Summary

PR #126 (0.23.0) shipped a brand-toned `borderLeft` accent on done assistant Markdown — explicitly responding to lamyc's RFC #20 ask: *"Model response readability — A background highlight on responses (instead of just text color) would make long replies much easier to follow."*

PR #136 (0.23.1) refactored reasoning + streaming cards onto the shared `CardBox` primitive. In that refactor, the **done-state** color was changed from the brand tone to `FG.faint` (`#484f58`, dim grey). The bar is still technically there, but it's so muted it doesn't deliver the contrast that #126 was designed to provide — long replies blend into surrounding scrollback again.

This restores the done state to `CARD.streaming.color` (= `TONE.brand`, `#79c0ff`), matching the streaming state. The bar now reads continuously across the streaming → done flip.

Aborted state stays on `FG.faint` (correctly de-emphasized — that part of #136 was right).

## Diff

One line in `src/cli/ui/cards/StreamingCard.tsx`:

```diff
   if (card.done && !card.aborted) {
     return (
-      <CardBox color={FG.faint}>
+      <CardBox color={CARD.streaming.color}>
```

## Test plan

- [x] `npm run verify` — 1824/1824 tests pass
- [ ] Visual check in actual TUI — confirm the done-state bar is visible against scrollback (this is the whole point)
- [ ] CI green

## Out of scope

- Migrating the other 15 card types onto `CardBox` (separate change — currently only `StreamingCard` and `ReasoningCard` use it)
- True full-width background highlight (lamyc's literal ask) — would require per-line `<Text backgroundColor>` wrapping, separate RFC

## Refs

- RFC discussion #20 (lamyc's readability ask)
- PR #126 — original feat that shipped the brand accent
- PR #136 — refactor that accidentally toned it down