### PR TITLE
fix(code): normalize edit replacements to target line endings

### DIFF
--- a/src/code/edit-blocks.ts
+++ b/src/code/edit-blocks.ts
@@ -93,7 +93,10 @@ export function applyEditBlock(block: EditBlock, rootDir: string): ApplyResult {
         message: "empty SEARCH only creates new files — this file already exists",
       };
     }
-    const idx = content.indexOf(block.search);
+    const le = lineEndingOf(content);
+    const adaptedSearch = block.search.replace(/\r?\n/g, le);
+    const adaptedReplace = block.replace.replace(/\r?\n/g, le);
+    const idx = content.indexOf(adaptedSearch);
     if (idx === -1) {
       return {
         path: block.path,
@@ -106,7 +109,7 @@ export function applyEditBlock(block: EditBlock, rootDir: string): ApplyResult {
     // more surrounding context). Auto-expanding to replace-all is a
     // footgun when the same string legitimately appears in several
     // unrelated places.
-    const replaced = `${content.slice(0, idx)}${block.replace}${content.slice(idx + block.search.length)}`;
+    const replaced = `${content.slice(0, idx)}${adaptedReplace}${content.slice(idx + adaptedSearch.length)}`;
     writeFileSync(absTarget, replaced, "utf8");
     return { path: block.path, status: "applied" };
   } catch (err) {
@@ -199,4 +202,8 @@ export function restoreSnapshots(snapshots: EditSnapshot[], rootDir: string): Ap
 /** Platform separator — `\` on Windows, `/` elsewhere. */
 function sep(): string {
   return process.platform === "win32" ? "\\" : "/";
+}
+
+function lineEndingOf(text: string): string {
+  return text.includes("\r\n") ? "\r\n" : "\n";
 }

--- a/src/tools/filesystem.ts
+++ b/src/tools/filesystem.ts
@@ -533,27 +533,26 @@ Prefer \`list_directory\` for a single-level view, \`search_files\` to find spec
       if (args.search.length === 0) {
         throw new Error("edit_file: search cannot be empty");
       }
-      const firstIdx = before.indexOf(args.search);
+      const le = before.includes("\r\n") ? "\r\n" : "\n";
+      const adaptedSearch = args.search.replace(/\r?\n/g, le);
+      const adaptedReplace = args.replace.replace(/\r?\n/g, le);
+      const firstIdx = before.indexOf(adaptedSearch);
       if (firstIdx < 0) {
         throw new Error(`edit_file: search text not found in ${pathMod.relative(rootDir, abs)}`);
       }
-      const nextIdx = before.indexOf(args.search, firstIdx + 1);
+      const nextIdx = before.indexOf(adaptedSearch, firstIdx + 1);
       if (nextIdx >= 0) {
         throw new Error(
           `edit_file: search text appears multiple times in ${pathMod.relative(rootDir, abs)} — include more context to disambiguate`,
         );
       }
       const after =
-        before.slice(0, firstIdx) + args.replace + before.slice(firstIdx + args.search.length);
+        before.slice(0, firstIdx) + adaptedReplace + before.slice(firstIdx + adaptedSearch.length);
       await fs.writeFile(abs, after, "utf8");
       const rel = pathMod.relative(rootDir, abs);
-      const header = `edited ${rel} (${args.search.length}→${args.replace.length} chars)`;
-      // Starting line number of the search block in the original
-      // file. `split/length` on the prefix gives a 1-based line
-      // count where the match begins, matching git-diff's @@ -N,M
-      // +N,M @@ header convention.
+      const header = `edited ${rel} (${adaptedSearch.length}→${adaptedReplace.length} chars)`;
       const startLine = before.slice(0, firstIdx).split(/\r?\n/).length;
-      const diff = renderEditDiff(args.search, args.replace, startLine);
+      const diff = renderEditDiff(adaptedSearch, adaptedReplace, startLine);
       return `${header}\n${diff}`;
     },
   });

--- a/tests/edit-blocks.test.ts
+++ b/tests/edit-blocks.test.ts
@@ -165,6 +165,26 @@ describe("applyEditBlock", () => {
     // First "foo" replaced, second left alone.
     expect(readFileSync(join(root, "a.txt"), "utf8")).toBe("FOO bar foo\n");
   });
+
+  it("matches LF search against CRLF file content", () => {
+    writeFileSync(join(root, "crlf.txt"), "hello\r\nworld\r\n", "utf8");
+    const result = applyEditBlock(
+      { path: "crlf.txt", search: "hello\nworld", replace: "goodbye\nworld", offset: 0 },
+      root,
+    );
+    expect(result.status).toBe("applied");
+    expect(readFileSync(join(root, "crlf.txt"), "utf8")).toBe("goodbye\r\nworld\r\n");
+  });
+
+  it("preserves LF line endings when file uses LF", () => {
+    writeFileSync(join(root, "lf.txt"), "line1\nline2\n", "utf8");
+    const result = applyEditBlock(
+      { path: "lf.txt", search: "line1\nline2", replace: "LINE1\nLINE2", offset: 0 },
+      root,
+    );
+    expect(result.status).toBe("applied");
+    expect(readFileSync(join(root, "lf.txt"), "utf8")).toBe("LINE1\nLINE2\n");
+  });
 });
 
 describe("snapshotBeforeEdits + restoreSnapshots", () => {

--- a/tests/filesystem-tools.test.ts
+++ b/tests/filesystem-tools.test.ts
@@ -469,6 +469,43 @@ describe("filesystem tools (built-in, sandbox-enforced)", () => {
       );
       expect(out).toMatch(/search cannot be empty/);
     });
+
+    it("matches LF search against a CRLF file and preserves CRLF after write", async () => {
+      await fs.writeFile(join(root, "a.txt"), "hello world\r\ngoodbye world\r\n");
+      const out = await tools.dispatch(
+        "edit_file",
+        JSON.stringify({ path: "a.txt", search: "hello world", replace: "hello WORLD" }),
+      );
+      expect(out).toMatch(/edited/);
+      const disk = await fs.readFile(join(root, "a.txt"), "utf8");
+      expect(disk).toBe("hello WORLD\r\ngoodbye world\r\n");
+    });
+
+    it("matches LF multi-line search against a CRLF file and preserves CRLF", async () => {
+      await fs.writeFile(join(root, "a.txt"), "line one\r\nline two\r\nline three\r\n");
+      const out = await tools.dispatch(
+        "edit_file",
+        JSON.stringify({
+          path: "a.txt",
+          search: "line one\nline two",
+          replace: "line ONE\nline TWO",
+        }),
+      );
+      expect(out).toMatch(/edited/);
+      const disk = await fs.readFile(join(root, "a.txt"), "utf8");
+      expect(disk).toBe("line ONE\r\nline TWO\r\nline three\r\n");
+    });
+
+    it("refuses duplicate match in a CRLF file when search adapted to CRLF", async () => {
+      await fs.writeFile(join(root, "a.txt"), "dup\r\ndup\r\nunique\r\n");
+      const out = await tools.dispatch(
+        "edit_file",
+        JSON.stringify({ path: "a.txt", search: "dup", replace: "fixed" }),
+      );
+      expect(out).toMatch(/multiple times/);
+      const disk = await fs.readFile(join(root, "a.txt"), "utf8");
+      expect(disk).toBe("dup\r\ndup\r\nunique\r\n");
+    });
   });
 
   describe("create_directory + move_file", () => {


### PR DESCRIPTION
## What

Normalizes incoming SEARCH/REPLACE edit text to the target file’s existing line ending before matching and writing.

This covers both edit paths:

- parsed edit blocks in `src/code/edit-blocks.ts`
- native filesystem `edit_file` in `src/tools/filesystem.ts`

Closes #141.

## Why

Reasonix intentionally requires exact edit matches, but model-generated edits usually use LF line endings. On CRLF files, otherwise-correct multi-line edits fail because `\n` does not match `\r\n`.

## How to verify

```sh
npm run verify
```

Added/confirmed regression coverage for:

- LF search matching CRLF files in `applyEditBlock`
- LF files staying LF
- native `edit_file` matching LF multi-line search against CRLF files
- native `edit_file` duplicate detection after CRLF adaptation

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time
