### PR TITLE
feat(cards): UserCard gets CardBox accent + drop dead approval-card type

### DIFF
--- a/src/cli/ui/cards/CardRenderer.tsx
+++ b/src/cli/ui/cards/CardRenderer.tsx
@@ -57,8 +57,6 @@ function renderCard(card: Card): React.ReactElement {
       return <SubAgentCard card={card} />;
     case "search":
       return <SearchCard card={card} />;
-    case "approval":
-      return <FallbackCard card={card} />;
     case "live":
       return <LiveCard card={card} />;
     case "ctx":

--- a/src/cli/ui/cards/UserCard.tsx
+++ b/src/cli/ui/cards/UserCard.tsx
@@ -2,24 +2,27 @@ import { Box, Text } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React from "react";
 import { Markdown } from "../markdown.js";
+import { CardBox } from "../primitives/CardBox.js";
 import type { UserCard as UserCardData } from "../state/cards.js";
-import { FG } from "../theme/tokens.js";
+import { CARD, FG } from "../theme/tokens.js";
 import { formatRelativeTime } from "./time.js";
+
+const HEADER_PAD = 1;
+const BODY_PAD = 4;
 
 export function UserCard({ card }: { card: UserCardData }): React.ReactElement {
   return (
-    <Box flexDirection="column">
-      <Box flexDirection="row">
-        <Text>{"  "}</Text>
+    <CardBox color={CARD.user.color}>
+      <Box paddingLeft={HEADER_PAD} flexDirection="row">
         <Text color={FG.meta}>◇</Text>
         <Text bold color={FG.sub}>
           {" you"}
         </Text>
         <Text color={FG.faint}>{`  · ${formatRelativeTime(card.ts)}`}</Text>
       </Box>
-      <Box flexDirection="column" paddingLeft={4}>
+      <Box paddingLeft={BODY_PAD} flexDirection="column">
         <Markdown text={card.text} />
       </Box>
-    </Box>
+    </CardBox>
   );
 }

--- a/src/cli/ui/state/cards.ts
+++ b/src/cli/ui/state/cards.ts
@@ -157,15 +157,6 @@ export interface SearchCard extends CardBase {
   readonly elapsedMs: number;
 }
 
-export interface ApprovalCard extends CardBase {
-  readonly kind: "approval";
-  readonly variant: "shell" | "edit" | "plan" | "workspace" | "choice" | "deny";
-  readonly title: string;
-  readonly options: ReadonlyArray<{ key: string; label: string; hint: string }>;
-  readonly payload: unknown;
-  resolved?: { choice: string };
-}
-
 export type LiveKind =
   | "thinking"
   | "undo"
@@ -223,7 +214,6 @@ export type Card =
   | MemoryCard
   | SubAgentCard
   | SearchCard
-  | ApprovalCard
   | LiveCard
   | CtxCard
   | BranchCard


### PR DESCRIPTION
## Summary

Two small, related card-stream cleanups discovered while auditing visual consistency after #140.

### 1. UserCard → CardBox

Of the cards that render `<Markdown>` (variable-length, wrap-prone content), `StreamingCard` and `ReasoningCard` use `CardBox` so the `▎` left bar continues across wrap continuations. **UserCard was the odd one out** — long pasted prompts wrapped without an accent and lost rhythm against the now-accented model output. Bringing it in line uses `CARD.user.color` (`FG.meta` / dim slate) — deliberately quieter than the brand-toned streaming bar so user prompts don't compete visually with model replies.

The other 13 cards already get a per-line `▎` via `BarRow`/`CardHeader`; they pre-clip with `clipToCells` so wrap-continuation isn't a concern. They stay as-is.

### 2. Drop dead `approval` card kind

`src/cli/ui/state/cards.ts:160` declared an `ApprovalCard` interface with `kind: "approval"` and routed it through the `Card` union. Audit:

- Zero producers in `src/` or `tests/`
- The CardRenderer case routed to `FallbackCard` (`"approval card · not yet migrated"`)
- The actual approval UI (EditConfirm / ShellConfirm / PlanConfirm) is built on the unrelated `ApprovalCard.tsx` modal HOC — name collision, but no wire-up

Per CLAUDE.md ("certain something is unused → delete it completely"). Removed: the interface, the union member, the orphan `case "approval"`. CardRenderer's `default` branch still catches any future card kind safely.

## Test plan

- [x] `npm run verify` — 1829/1829 tests pass (PR #142's 5 new ones included)
- [ ] Visual: long user prompt now shows continuous `▎` accent against model reply's brand bar
- [ ] CI green

## Out of scope

- Migrating BarRow-using cards to CardBox — they pre-clip, no wrap-continuation gap
- Full-width background highlight (lamyc RFC #20 literal ask) — would need per-line `<Text backgroundColor>` wrapping; separate RFC if pursued
- LiveCard accent — single-row status indicator; bar would be visual noise

## Refs

- RFC discussion #20 — readability ask
- PR #126 — original brand accent on done assistant
- PR #136 — card redesign / CardBox extraction
- PR #140 — restored brand color on done state