### PR TITLE
fix(cards): drop fake key hints + CtxCard CardHeader + TaskCard meta tidy

### DIFF
--- a/src/cli/ui/cards/CtxCard.tsx
+++ b/src/cli/ui/cards/CtxCard.tsx
@@ -3,7 +3,8 @@ import { Box, Text } from "ink";
 import React from "react";
 import { BarRow } from "../primitives/BarRow.js";
 import type { CtxCard as CtxCardData } from "../state/cards.js";
-import { CARD, FG, TONE } from "../theme/tokens.js";
+import { FG, TONE } from "../theme/tokens.js";
+import { CardHeader } from "./CardHeader.js";
 
 const BAR_CELLS = 32;
 
@@ -24,18 +25,11 @@ export function CtxCard({ card }: { card: CtxCardData }): React.ReactElement {
   const cap = Math.max(1, card.ctxMax);
   const used = card.systemTokens + card.toolsTokens + card.logTokens + card.inputTokens;
   const usedPct = (used / cap) * 100;
+  const meta = `· ${used.toLocaleString()} / ${cap.toLocaleString()} (${usedPct.toFixed(1)}%)`;
 
   return (
     <Box flexDirection="column">
-      <Box flexDirection="row">
-        <Text>{"  "}</Text>
-        <Text bold color={CARD.usage.color}>
-          {"⌘ Context window"}
-        </Text>
-        <Text color={FG.faint}>
-          {`  · ${used.toLocaleString()} / ${cap.toLocaleString()} (${usedPct.toFixed(1)}%)`}
-        </Text>
-      </Box>
+      <CardHeader tone="usage" glyph="⌘" title="Context window" meta={meta} />
       <BarRow tone="usage" indent={0} />
       {row("system", card.systemTokens, card.systemTokens / cap, TONE.brand)}
       {row("tools", card.toolsTokens, card.toolsTokens / cap, TONE.warn)}

--- a/src/cli/ui/cards/ErrorCard.tsx
+++ b/src/cli/ui/cards/ErrorCard.tsx
@@ -3,7 +3,7 @@ import { Box, Text } from "ink";
 import React from "react";
 import { BarRow } from "../primitives/BarRow.js";
 import type { ErrorCard as ErrorCardData } from "../state/cards.js";
-import { CARD, FG, TONE } from "../theme/tokens.js";
+import { CARD, FG } from "../theme/tokens.js";
 import { CardHeader } from "./CardHeader.js";
 
 const STACK_TAIL = 5;
@@ -48,13 +48,6 @@ export function ErrorCard({ card }: { card: ErrorCardData }): React.ReactElement
           ))}
         </>
       )}
-      <BarRow tone="error" indent={0} />
-      <BarRow tone="error">
-        <Text bold color={TONE.err}>
-          {"[r] retry"}
-        </Text>
-        <Text color={FG.sub}>{"   [s] skip"}</Text>
-      </BarRow>
     </Box>
   );
 }

--- a/src/cli/ui/cards/PlanCard.tsx
+++ b/src/cli/ui/cards/PlanCard.tsx
@@ -24,14 +24,11 @@ const STATUS_COLOR: Record<PlanStep["status"], string> = {
   skipped: FG.faint,
 };
 
-const ACTIVE_PLAN_FOOTER = "[r] revise   [s] skip step   [↵] expand item";
-
 export function PlanCard({ card }: { card: PlanCardData }): React.ReactElement {
   const doneCount = card.steps.filter((s) => s.status === "done").length;
   const variantTag =
     card.variant === "resumed" ? " · resumed" : card.variant === "replay" ? " · ⏪ archive" : "";
   const meta = `${variantTag}  · ${doneCount} of ${card.steps.length} done`;
-  const showFooter = card.variant === "active";
 
   return (
     <Box flexDirection="column">
@@ -39,7 +36,7 @@ export function PlanCard({ card }: { card: PlanCardData }): React.ReactElement {
       <BarRow tone="plan" indent={0} />
       {card.steps.map((step, i) => {
         const isActive = step.status === "running";
-        const titleColor = isActive ? FG.strong : step.status === "queued" ? FG.sub : FG.sub;
+        const titleColor = isActive ? FG.strong : FG.sub;
         return (
           <BarRow key={step.id} tone="plan">
             <Text color={STATUS_COLOR[step.status]}>{`[${STATUS_GLYPH[step.status]}]`}</Text>
@@ -50,14 +47,6 @@ export function PlanCard({ card }: { card: PlanCardData }): React.ReactElement {
           </BarRow>
         );
       })}
-      {showFooter && (
-        <>
-          <BarRow tone="plan" indent={0} />
-          <BarRow tone="plan">
-            <Text color={FG.meta}>{ACTIVE_PLAN_FOOTER}</Text>
-          </BarRow>
-        </>
-      )}
     </Box>
   );
 }

--- a/src/cli/ui/cards/TaskCard.tsx
+++ b/src/cli/ui/cards/TaskCard.tsx
@@ -41,7 +41,7 @@ export function TaskCard({ card }: { card: TaskCardData }): React.ReactElement {
         tone="task"
         glyph={TASK_GLYPH[card.status]}
         title={`Step ${card.index} of ${card.total} · ${card.title}`}
-        meta={`${elapsed} · `}
+        meta={`${elapsed} ·`}
         trailing={<Text color={TASK_COLOR[card.status]}>{card.status}</Text>}
         barColor={TASK_COLOR[card.status]}
       />


### PR DESCRIPTION
## Summary

Card-stream polish from a full audit of the 14 non-polished cards. Four targeted fixes:

### A. Drop misleading inline keybind hints

`PlanCard` and `ErrorCard` advertised inline keys in their footers but **no handler was ever wired** to scrollback cards. The actual flows go through modal pickers (`PlanConfirm` for revise/skip, prompt-loop for retry).

- `PlanCard.tsx:27` — `[r] revise   [s] skip step   [↵] expand item` — removed footer + the constant
- `ErrorCard.tsx:51-57` — `[r] retry   [s] skip` — removed footer

Affordance contract: if a key is shown, it must work. These didn't, so they go.

### B. CtxCard → CardHeader

`CtxCard.tsx:30-37` hand-rolled a header (raw `<Box>` + `<Text>` with manual indent + custom glyph color) instead of using the shared `CardHeader` primitive every other card uses. Routed through `CardHeader` with `tone="usage"` and the existing `⌘` glyph; rendered output is visually identical, but consistency contract restored.

### C. TaskCard meta double-space

`TaskCard.tsx:44` — `meta={` `${elapsed} · ` `}` (trailing space). `CardHeader` already inserts a space before the trailing badge, producing `X.Xs ·  done` (double space). Trimmed to `${elapsed} ·`.

### D. Dead ternary branch in PlanCard

`PlanCard.tsx:42` had `isActive ? FG.strong : step.status === "queued" ? FG.sub : FG.sub` — both inner arms identical. Collapsed to `isActive ? FG.strong : FG.sub`.

## Test plan

- [x] `npm run verify` — 1829/1829 tests pass
- [ ] CI green
- [ ] Visual: PlanCard / ErrorCard scrollback no longer show key-hint footers; CtxCard header reads identically to other cards

## Out of scope (deferred from audit)

- BranchCard borrowing `tone="streaming"` (cosmetic naming only — colors are equivalent)
- Truncation hint phrasing duplicated across 6 cards (`elisionHint(count, kind)` util refactor)
- Progress-bar reuse between UsageCard / CtxCard / BranchCard (`<ProgressBar>` primitive)
- Adding section `Pill` badges to ErrorCard / WarnCard (would dilute the live-activity-card visual language)

## Refs

- RFC discussion #20 — readability ask thread
- PR #140 — restored brand color on done state
- PR #143 — UserCard CardBox + dead-type cleanup