### PR TITLE
fix(cards): pad streaming/reasoning preview to constant row count

### DIFF
--- a/src/cli/ui/cards/ReasoningCard.tsx
+++ b/src/cli/ui/cards/ReasoningCard.tsx
@@ -103,7 +103,15 @@ interface BodyProps {
 function StreamingPreview({ card, allLines, lineCells }: BodyProps): React.ReactElement {
   const visualLines = allLines.flatMap((l) => wrapToCells(l, lineCells));
   const visible = visualLines.slice(-STREAMING_PREVIEW_LINES);
-  return <BodyLines card={card} lines={visible} lineCells={lineCells} cursorOnLast />;
+  const padCount = Math.max(0, STREAMING_PREVIEW_LINES - visible.length);
+  return (
+    <>
+      <BodyLines card={card} lines={visible} lineCells={lineCells} cursorOnLast />
+      {Array.from({ length: padCount }, (_, i) => (
+        <Box key={`${card.id}:pad:${i}`} height={1} />
+      ))}
+    </>
+  );
 }
 
 function SettledPreview({ card, allLines, lineCells }: BodyProps): React.ReactElement {

--- a/src/cli/ui/cards/StreamingCard.tsx
+++ b/src/cli/ui/cards/StreamingCard.tsx
@@ -37,6 +37,8 @@ export function StreamingCard({ card }: { card: StreamingCardData }): React.Reac
   const allLines = card.text.length > 0 ? card.text.split("\n") : [""];
   const visualLines = allLines.flatMap((l) => wrapToCells(l, lineCells));
   const visible = visualLines.slice(-STREAMING_PREVIEW_LINES);
+  const padCount = Math.max(0, STREAMING_PREVIEW_LINES - visible.length);
+  const startIndex = allLines.length - visible.length;
 
   return (
     <CardBox color={card.aborted ? FG.faint : CARD.streaming.color}>
@@ -50,13 +52,12 @@ export function StreamingCard({ card }: { card: StreamingCardData }): React.Reac
         </Box>
       )}
       {visible.map((line, i) => (
-        <Box
-          key={`${card.id}:${allLines.length - visible.length + i}`}
-          paddingLeft={BODY_PAD}
-          flexDirection="row"
-        >
+        <Box key={`${card.id}:${startIndex + i}`} paddingLeft={BODY_PAD} flexDirection="row">
           <Text color={card.aborted ? FG.meta : FG.body}>{clipToCells(line, lineCells)}</Text>
         </Box>
+      ))}
+      {Array.from({ length: padCount }, (_, i) => (
+        <Box key={`${card.id}:pad:${i}`} height={1} />
       ))}
       {card.aborted && (
         <Box paddingLeft={BODY_PAD}>


### PR DESCRIPTION
## Summary

Fixes the up-down screen jitter the user reported when a plan card is mid-execution and a streaming card renders alongside it.

## Root cause

`CardStream.tsx:9-23` defines `isSettled`:
- Active plan card → not settled until **every** step is done/skipped
- Live region is a prefix slice (`cutoff = i; break` in `CardStream.tsx:28-34`) — once a card is live, **every card after it is live too**

So during plan execution, the streaming card lives in the redraw region. Each stream chunk forces Ink to erase + reprint the entire live region.

That alone wouldn't jitter if the live region's total height were constant. But it isn't:

- `StreamingCard.tsx:39` — `visible = visualLines.slice(-STREAMING_PREVIEW_LINES)` — during the first wave of output, `visible.length` goes 1 → 2 → 3 → 4 across chunks
- Card rendered height: `header(1) + visible.length` → **2 → 3 → 4 → 5 rows** as the stream ramps
- `ReasoningCard.tsx:103-107` `StreamingPreview` has the same ramp shape

Each chunk during the ramp shifts every card above (PlanCard included) by 1 row → visible jitter.

## Fix

Pad the preview region to `STREAMING_PREVIEW_LINES` (4) so the rendered height is constant 5 rows for the whole streaming lifetime. Empty 1-row `<Box height={1} />` (consistent with the existing spacer pattern at `ReasoningCard.tsx:39`). `CardBox`'s `borderLeft` keeps drawing the `▎` accent across pad rows.

Done state is untouched — that branch returns full `<Markdown>` body, ends up in Static, never redraws.

## Test plan

- [x] `npm run verify` — 1829/1829 tests pass
- [ ] CI green
- [ ] Visual: trigger a plan with steps + observe streaming during execution. Plan card should sit still while stream chunks arrive (no up-down shift).

## Related

- PR #124 — earlier viewport budget work that addressed modal-vs-stream jitter; this is the same class of bug for the streaming-ramp case
- PR #145 — card polish that removed PlanCard's variable-height footer (also a jitter contributor when plan settled)