### PR TITLE
fix(plan): only treat plan as 'active' once execution has started

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -300,6 +300,7 @@ function AppInner({
       if (
         c?.kind === "plan" &&
         c.variant === "active" &&
+        c.steps.some((step) => step.status !== "queued") &&
         c.steps.some((step) => step.status !== "done" && step.status !== "skipped")
       ) {
         return c;

--- a/src/cli/ui/layout/SidebarPanel.tsx
+++ b/src/cli/ui/layout/SidebarPanel.tsx
@@ -36,14 +36,16 @@ export function SidebarPanel({
   );
 }
 
-function findActivePlan(cards: ReadonlyArray<Card>) {
-  // Mirrors the App.tsx selector. Cancelled plans flip variant via plan.drop,
-  // so checking variant === "active" + "not all done" is enough.
+export function findActivePlan(cards: ReadonlyArray<Card>) {
+  // Mirrors the App.tsx selector. "Active" means execution-started: at least
+  // one step has left `queued` AND not all steps are done/skipped. Plans
+  // pending user approval have every step in `queued` and must NOT trigger.
   for (let i = cards.length - 1; i >= 0; i--) {
     const c = cards[i];
     if (
       c?.kind === "plan" &&
       c.variant === "active" &&
+      c.steps.some((s) => s.status !== "queued") &&
       c.steps.some((s) => s.status !== "done" && s.status !== "skipped")
     ) {
       return c;

--- a/tests/sidebar-panel.test.ts
+++ b/tests/sidebar-panel.test.ts
@@ -1,9 +1,20 @@
 import { describe, expect, it } from "vitest";
-import { windowSteps } from "../src/cli/ui/layout/SidebarPanel.js";
-import type { PlanStep } from "../src/cli/ui/state/cards.js";
+import { findActivePlan, windowSteps } from "../src/cli/ui/layout/SidebarPanel.js";
+import type { Card, PlanCard, PlanStep } from "../src/cli/ui/state/cards.js";
 
 function step(id: string, status: PlanStep["status"] = "queued"): PlanStep {
   return { id, title: `step ${id}`, status };
+}
+
+function planCard(steps: PlanStep[], variant: PlanCard["variant"] = "active"): PlanCard {
+  return {
+    kind: "plan",
+    id: "p1",
+    ts: 0,
+    variant,
+    title: "test plan",
+    steps,
+  };
 }
 
 describe("windowSteps", () => {
@@ -53,5 +64,34 @@ describe("windowSteps", () => {
     expect(r.kind).toBe("windowed");
     if (r.kind !== "windowed") throw new Error("type guard");
     expect(r.startIndex).toBe(0);
+  });
+});
+
+describe("findActivePlan", () => {
+  it("returns null when every step is queued — plan is awaiting approval", () => {
+    const cards: Card[] = [planCard([step("a"), step("b"), step("c")])];
+    expect(findActivePlan(cards)).toBeNull();
+  });
+
+  it("returns the plan once any step has left queued", () => {
+    const cards: Card[] = [planCard([step("a", "running"), step("b"), step("c")])];
+    expect(findActivePlan(cards)).toBe(cards[0]);
+  });
+
+  it("returns null when every step is done or skipped — plan finished", () => {
+    const cards: Card[] = [planCard([step("a", "done"), step("b", "skipped")])];
+    expect(findActivePlan(cards)).toBeNull();
+  });
+
+  it("returns null for non-active variants (resumed / replay)", () => {
+    const running = [step("a", "running")];
+    expect(findActivePlan([planCard(running, "resumed")])).toBeNull();
+    expect(findActivePlan([planCard(running, "replay")])).toBeNull();
+  });
+
+  it("returns the latest active plan when multiple exist", () => {
+    const older = planCard([step("a", "running")]);
+    const newer: typeof older = { ...older, id: "p2", steps: [step("x", "running")] };
+    expect(findActivePlan([older, newer])).toBe(newer);
   });
 });


### PR DESCRIPTION
## Summary

User reported the right-side plan sidebar appears while the `PlanConfirm` approval modal is up — i.e. during the *询问* phase, before the user has clicked accept. Same bug also pins the `<PlanCard>` above the input prematurely.

## Root cause

Both selectors used the same predicate:
- `src/cli/ui/App.tsx:297-309` — `activePlanCard`
- `src/cli/ui/layout/SidebarPanel.tsx:39-53` — `findActivePlan`

```ts
c.variant === "active" &&
c.steps.some((s) => s.status !== "done" && s.status !== "skipped")
```

A fresh plan has **every** step in `queued` — the predicate matches immediately on plan creation, before approval triggers any step transition. The intent was "execution started + not finished", but `!== "done"` is satisfied by `queued` too.

## Fix

Tighten to: at least one step has left `queued` AND not all steps are done/skipped.

```ts
c.variant === "active" &&
c.steps.some((s) => s.status !== "queued") &&
c.steps.some((s) => s.status !== "done" && s.status !== "skipped")
```

Approval-pending (all queued) → null. Finished (all done/skipped) → null. Mid-execution → returns the plan.

Both call sites updated. The "Mirrors the App.tsx selector" comment in SidebarPanel was technically true and stayed true — they're still mirrored.

## Test plan

- [x] `npm run verify` — 1834/1834 (5 new test cases)
- [ ] CI green
- [ ] Visual: trigger a plan, observe approval modal — sidebar stays hidden, plan card stays inline. Click accept — sidebar appears, plan card pins above input.

## Tests added

`tests/sidebar-panel.test.ts` — exported `findActivePlan` and added 5 cases:
1. All-queued plan → null (the regression itself)
2. Any non-queued step → returns plan
3. All done/skipped → null
4. Non-active variants (resumed / replay) → null
5. Multiple active plans → returns latest

## Refs

- PR #127 — original sidebar work
- PR #146 — superseded; that PR's diagnosis (streaming-card height ramp) was wrong, the actual cause was this selector. Closed.