### PR TITLE
feat(i18n): default to system locale when no explicit config

### DIFF
--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -8,7 +8,16 @@ const translations: Record<LanguageCode, TranslationSchema> = {
   "zh-CN": zhCN,
 };
 
-let currentLang: LanguageCode = loadLanguage() || "EN";
+/** Map a system locale (e.g. "zh-CN", "en-US") to a supported LanguageCode, or null. */
+export function detectSystemLanguage(
+  locale: string = Intl.DateTimeFormat().resolvedOptions().locale,
+): LanguageCode | null {
+  if (locale.startsWith("zh")) return "zh-CN";
+  if (locale.startsWith("en")) return "EN";
+  return null;
+}
+
+let currentLang: LanguageCode = loadLanguage() ?? detectSystemLanguage() ?? "EN";
 
 type Listener = () => void;
 const listeners: Listener[] = [];

--- a/tests/i18n-detect.test.ts
+++ b/tests/i18n-detect.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { detectSystemLanguage } from "../src/i18n/index.js";
+
+describe("detectSystemLanguage", () => {
+  it("maps zh-CN to zh-CN", () => {
+    expect(detectSystemLanguage("zh-CN")).toBe("zh-CN");
+  });
+
+  it("maps any zh-* variant to zh-CN", () => {
+    expect(detectSystemLanguage("zh-TW")).toBe("zh-CN");
+    expect(detectSystemLanguage("zh-HK")).toBe("zh-CN");
+    expect(detectSystemLanguage("zh")).toBe("zh-CN");
+  });
+
+  it("maps en-* variants to EN", () => {
+    expect(detectSystemLanguage("en-US")).toBe("EN");
+    expect(detectSystemLanguage("en-GB")).toBe("EN");
+    expect(detectSystemLanguage("en")).toBe("EN");
+  });
+
+  it("returns null for unsupported locales", () => {
+    expect(detectSystemLanguage("ja-JP")).toBeNull();
+    expect(detectSystemLanguage("fr-FR")).toBeNull();
+    expect(detectSystemLanguage("de")).toBeNull();
+    expect(detectSystemLanguage("")).toBeNull();
+  });
+
+  it("default arg reads from Intl — returns a valid LanguageCode or null", () => {
+    const result = detectSystemLanguage();
+    expect(result === null || result === "EN" || result === "zh-CN").toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

First-run users with a Chinese (or any non-English) OS locale saw English by default after #144 landed. The only signal `i18n/index.ts` consulted was `config.lang`, which doesn't exist on first launch — falling through to the hardcoded `"EN"`.

This adds a third tier between config and the EN fallback: read the system locale and prefix-map it.

```ts
// before
let currentLang: LanguageCode = loadLanguage() || "EN";

// after
let currentLang: LanguageCode = loadLanguage() ?? detectSystemLanguage() ?? "EN";
```

Priority: **user-set config > system locale > EN fallback**.

## How

`Intl.DateTimeFormat().resolvedOptions().locale` returns the OS locale cross-platform (Windows, macOS, Linux) without env-var spelunking. Prefix-match it:

- `zh*` (zh-CN, zh-TW, zh-HK, zh) → `"zh-CN"`
- `en*` (en-US, en-GB, en) → `"EN"`
- anything else (ja-JP, fr-FR, …) → `null` → falls through to EN

`detectSystemLanguage()` takes the locale string as a parameter (defaults to the `Intl` lookup) so tests pass it explicitly — no mocking globals.

## Test plan

- [x] `npm run verify` — 1851/1851 (added 5 new tests in `tests/i18n-detect.test.ts`)
- [ ] CI green
- [ ] Manual: on a Chinese-locale OS, first-run TUI should display Chinese without `/language zh-CN`. Existing users with `~/.reasonix/config.json` containing `"lang": "EN"` keep English (config wins).

## Refs

- PR #144 — i18n framework
- The `??` chain ensures `config.lang` set to either supported value still wins, even when the system locale is the *other* one.