### PR TITLE
fix(plan-mode): sharpen bounce + show write_file size while running

### DIFF
--- a/src/cli/ui/cards/ToolCard.tsx
+++ b/src/cli/ui/cards/ToolCard.tsx
@@ -25,7 +25,7 @@ export function ToolCard({ card }: { card: ToolCardData }): React.ReactElement {
   const { stdout } = useStdout();
   const cols = stdout?.columns ?? 80;
   const lineCells = Math.max(20, cols - BODY_INDENT_CELLS - 1);
-  const argsLabel = formatArgsSummary(card.args);
+  const argsLabel = formatArgsSummary(card.name, card.args);
   const meta = formatMeta(card);
   const allLines = card.output.length > 0 ? card.output.split("\n") : [];
   const tail = tailLinesFor(card.name);
@@ -71,7 +71,15 @@ export function ToolCard({ card }: { card: ToolCardData }): React.ReactElement {
   );
 }
 
-function formatArgsSummary(args: unknown): string {
+function formatArgsSummary(name: string, args: unknown): string {
+  // write_file: surface byte count alongside the path so the user sees progress
+  // intent the moment dispatch starts, instead of staring at a silent spinner.
+  if (name === "write_file" && args && typeof args === "object") {
+    const a = args as Record<string, unknown>;
+    if (typeof a.path === "string" && typeof a.content === "string") {
+      return `${a.path}  · ${a.content.length.toLocaleString()} chars`;
+    }
+  }
   if (typeof args === "string") return args.length > 60 ? `${args.slice(0, 60)}…` : args;
   if (args && typeof args === "object") {
     const keys = Object.keys(args as Record<string, unknown>);

--- a/src/code/prompt.ts
+++ b/src/code/prompt.ts
@@ -54,7 +54,7 @@ Each option: short stable id (A/B/C), one-line title, optional summary. \`allowC
 # Plan mode (/plan)
 
 The user can ALSO enter "plan mode" via /plan, which is a stronger, explicit constraint:
-- Write tools (edit_file, write_file, create_directory, move_file) and non-allowlisted run_command calls are BOUNCED at dispatch — you'll get a tool result like "unavailable in plan mode". Don't retry them.
+- Write tools (edit_file, write_file, create_directory, move_file) and non-allowlisted run_command calls are BOUNCED at dispatch — you'll get a tool result starting with "BLOCKED in plan mode". Don't retry them.
 - Read tools (read_file, list_directory, search_files, directory_tree, get_file_info) and allowlisted read-only / test shell commands still work — use them to investigate.
 - You MUST call submit_plan before anything will execute. Approve exits plan mode; Refine stays in; Cancel exits without implementing.
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -136,7 +136,7 @@ export class ToolRegistry {
     // `run_command` is read-only iff the command matches its allowlist).
     if (this._planMode && !isReadOnlyCall(tool, args)) {
       return JSON.stringify({
-        error: `${name}: unavailable in plan mode — this is a read-only exploration phase. Use read_file / list_directory / search_files / directory_tree / web_search / allowlisted shell commands to investigate. Call submit_plan with your proposed plan when you're ready for the user's review.`,
+        error: `${name}: BLOCKED in plan mode. Call submit_plan now with your proposed plan — writes execute only after user approval. Do NOT retry write tools this turn.`,
       });
     }
 

--- a/tests/plan.test.ts
+++ b/tests/plan.test.ts
@@ -38,7 +38,7 @@ describe("ToolRegistry plan mode", () => {
     const out = await reg.dispatch("mutate", "{}");
     expect(ran).toBe(false);
     const payload = JSON.parse(out);
-    expect(payload.error).toMatch(/unavailable in plan mode/);
+    expect(payload.error).toMatch(/plan mode/i);
     expect(payload.error).toMatch(/submit_plan/);
   });
 
@@ -67,7 +67,7 @@ describe("ToolRegistry plan mode", () => {
     expect(readOut).toBe("did-read");
     // Write call: refused.
     const writeOut = await reg.dispatch("maybe_read", '{"kind":"write"}');
-    expect(JSON.parse(writeOut).error).toMatch(/unavailable in plan mode/);
+    expect(JSON.parse(writeOut).error).toMatch(/plan mode/i);
   });
 
   it("readOnlyCheck takes precedence over readOnly when both are set", async () => {

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -244,7 +244,7 @@ describe("ToolRegistry", () => {
       });
       reg.setPlanMode(true);
       const out = await reg.dispatch("edit_file", '{"path":"x"}');
-      expect(JSON.parse(out).error).toMatch(/unavailable in plan mode/);
+      expect(JSON.parse(out).error).toMatch(/plan mode/i);
       expect(interceptorCalled).toBe(false);
     });
 


### PR DESCRIPTION
Closes #150.

## Two fixes from issue #150

### 1. Sharpen plan-mode bounce copy

`src/tools.ts:139` previously read like advice:

> *unavailable in plan mode — this is a read-only exploration phase. ... Call submit_plan with your proposed plan when you're ready for the user's review.*

"When you're ready" left room for the model to attempt more writes first. Tightened to an imperative:

> *BLOCKED in plan mode. Call submit_plan now with your proposed plan — writes execute only after user approval. Do NOT retry write tools this turn.*

System-prompt mirror at `src/code/prompt.ts:57` updated to reference the new opening (`"BLOCKED in plan mode"`) so the model recognizes the bounce marker.

Existing tests asserted the literal old phrase (`/unavailable in plan mode/`). Switched to case-insensitive `/plan mode/i` so future copy edits don't drag the test suite.

### 2. `write_file` size in the running subtitle

`ToolCard`'s generic args summary picked the first key, so for `write_file({ path, content })` users saw `"foo.ts  +1"` — nothing about the actual write size. The spinner ran silent until completion.

Per-tool summary in `formatArgsSummary`:

```ts
if (name === "write_file" && args && typeof args === "object") {
  const a = args as Record<string, unknown>;
  if (typeof a.path === "string" && typeof a.content === "string") {
    return `${a.path}  · ${a.content.length.toLocaleString()} chars`;
  }
}
```

Now the running tool card reads `▣ write_file  foo.ts · 1,240 chars` from dispatch — no more "did it hang?" moment.

## Test plan

- [x] `npm run verify` — 1851/1851 (existing assertions relaxed to wording-agnostic `/plan mode/i`)
- [ ] CI green
- [ ] Manual: with `/plan` on, ask the model to edit a file → bounce reads "BLOCKED in plan mode...". Outside plan mode, ask it to `write_file` a long string → ToolCard subtitle shows path + char count while spinner runs.

## Out of scope

- Generic per-tool `progress` channel (RFC territory — would need a tool primitive change).
- Surfacing the bounce as a banner / live card (option (b) in #150 — deferred; (a) sharpen + (a) write subtitle are the cheap wins).