### PR TITLE
fix(plan): gate sidebar + pinned plan card on modal-active, not step transition

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -119,7 +119,7 @@ import {
 import { SIDEBAR_MIN_TOTAL_COLS, SidebarPanel } from "./layout/SidebarPanel.js";
 import { StatusRow } from "./layout/StatusRow.js";
 import { ToastRail } from "./layout/ToastRail.js";
-import { ViewportBudgetProvider } from "./layout/viewport-budget.js";
+import { ViewportBudgetProvider, useIsModalActive } from "./layout/viewport-budget.js";
 import { formatLoopStatus } from "./loop.js";
 import { applyMcpAppend } from "./mcp-append.js";
 import { handleMcpBrowseSlash } from "./mcp-browse.js";
@@ -295,13 +295,13 @@ function AppInner({
     s.cards.some((c) => c.kind === "user" || c.kind === "streaming"),
   );
   const isStreaming = useAgentState((s) => s.cards.some((c) => c.kind === "streaming" && !c.done));
-  const activePlanCard = useAgentState((s) => {
+  const isModalActive = useIsModalActive();
+  const rawActivePlanCard = useAgentState((s) => {
     for (let i = s.cards.length - 1; i >= 0; i--) {
       const c = s.cards[i];
       if (
         c?.kind === "plan" &&
         c.variant === "active" &&
-        c.steps.some((step) => step.status !== "queued") &&
         c.steps.some((step) => step.status !== "done" && step.status !== "skipped")
       ) {
         return c;
@@ -309,6 +309,9 @@ function AppInner({
     }
     return null;
   });
+  // Approval modals (PlanConfirm etc.) suppress the pinned plan card so
+  // the user reviews the picker, not a preview of an unapproved plan.
+  const activePlanCard = isModalActive ? null : rawActivePlanCard;
   const [input, setInput] = useState("");
   const [busy, setBusy] = useState(false);
   const [languageVersion, setLanguageVersion] = useState(0);

--- a/src/cli/ui/layout/SidebarPanel.tsx
+++ b/src/cli/ui/layout/SidebarPanel.tsx
@@ -6,6 +6,7 @@ import React from "react";
 import type { Card, PlanStep } from "../state/cards.js";
 import { useAgentState } from "../state/provider.js";
 import { CARD, FG, TONE } from "../theme/tokens.js";
+import { useIsModalActive } from "./viewport-budget.js";
 
 export const SIDEBAR_WIDTH = 28;
 /** Below this terminal width, sidebar refuses to render so the main column has room to breathe. */
@@ -21,9 +22,12 @@ export function SidebarPanel({
   subagentActivity,
 }: SidebarPanelProps): React.ReactElement | null {
   const cards = useAgentState((s) => s.cards);
-  const activePlan = findActivePlan(cards);
+  const isModalActive = useIsModalActive();
+  const activePlan = isModalActive ? null : findActivePlan(cards);
 
   // No plan = no sidebar. Tools/usage alone aren't worth eating 28 cols.
+  // Approval modals (PlanConfirm etc.) suppress the sidebar so the
+  // pre-approval plan card doesn't preview before the user accepts.
   if (!activePlan) return null;
 
   return (
@@ -37,15 +41,15 @@ export function SidebarPanel({
 }
 
 export function findActivePlan(cards: ReadonlyArray<Card>) {
-  // Mirrors the App.tsx selector. "Active" means execution-started: at least
-  // one step has left `queued` AND not all steps are done/skipped. Plans
-  // pending user approval have every step in `queued` and must NOT trigger.
+  // Mirrors the App.tsx selector. Returns the latest active plan with work
+  // pending. Approval-pending suppression lives at the call site via
+  // `useIsModalActive()` — finding-an-active-plan doesn't depend on modal
+  // state, so the predicate stays pure and unit-testable.
   for (let i = cards.length - 1; i >= 0; i--) {
     const c = cards[i];
     if (
       c?.kind === "plan" &&
       c.variant === "active" &&
-      c.steps.some((s) => s.status !== "queued") &&
       c.steps.some((s) => s.status !== "done" && s.status !== "skipped")
     ) {
       return c;

--- a/tests/sidebar-panel.test.ts
+++ b/tests/sidebar-panel.test.ts
@@ -68,12 +68,14 @@ describe("windowSteps", () => {
 });
 
 describe("findActivePlan", () => {
-  it("returns null when every step is queued — plan is awaiting approval", () => {
+  it("returns the plan when all steps are queued — pre-execution state", () => {
+    // Approval-pending suppression is the caller's job (via useIsModalActive);
+    // findActivePlan only checks variant + has-pending-work.
     const cards: Card[] = [planCard([step("a"), step("b"), step("c")])];
-    expect(findActivePlan(cards)).toBeNull();
+    expect(findActivePlan(cards)).toBe(cards[0]);
   });
 
-  it("returns the plan once any step has left queued", () => {
+  it("returns the plan while any step is running", () => {
     const cards: Card[] = [planCard([step("a", "running"), step("b"), step("c")])];
     expect(findActivePlan(cards)).toBe(cards[0]);
   });


### PR DESCRIPTION
## What

After accepting a plan in the approval modal, the right-side sidebar didn't appear, even though the plan was active. Same gap on the pinned plan card above the input.

## Root cause

PR #147 fixed the **opposite** bug — sidebar showing during the approval modal — by tightening the predicate to require *at least one step left \`queued\`*. That worked for the modal-up case but introduced a new gap: once the user accepts, plan steps sit in \`queued\` until the model issues its first tool call. During that window the predicate fails and the sidebar stays hidden.

The right discriminator is the approval modal itself, not step transitions:

- Modal up (PlanConfirm) → suppress sidebar / pinned card
- Modal closed → if plan is active and not all-done, show

## Fix

\`useIsModalActive()\` is true exactly while any modal-priority zone is claimed (PlanConfirm, EditConfirm, ShellConfirm, etc.). Drop the \"non-queued\" check from \`findActivePlan\` and gate at the call sites:

\`\`\`ts
// SidebarPanel.tsx
const activePlan = isModalActive ? null : findActivePlan(cards);

// App.tsx
const activePlanCard = isModalActive ? null : rawActivePlanCard;
\`\`\`

\`findActivePlan\` stays pure (no hook usage) so it remains unit-testable.

## Test plan

- [x] \`npm run verify\` — 1851/1851 (one assertion flipped: all-queued plan now returns the plan, modal-gating is the caller's contract)
- [ ] CI green
- [ ] Visual: trigger a plan → modal up, sidebar hidden, plan inline in stream. Click Accept → modal closes, sidebar appears, plan card pins above input. (Earlier behaviour: sidebar stayed hidden post-accept until first step transitioned.)

## Refs

- #147 — the original fix that introduced this regression. The modal-active discriminator is what I should have used the first time.