### PR TITLE
feat(cards): tool card 'rejected' state + input-size meta

### DIFF
--- a/src/cli/ui/cards/ToolCard.tsx
+++ b/src/cli/ui/cards/ToolCard.tsx
@@ -33,7 +33,9 @@ export function ToolCard({ card }: { card: ToolCardData }): React.ReactElement {
   const visible = truncated ? allLines.slice(-tail) : allLines;
   const hidden = truncated ? allLines.length - visible.length : 0;
   const errColor = card.exitCode && card.exitCode !== 0 ? CARD.error.color : FG.sub;
-  const showBody = visible.length > 0;
+  // Rejected calls show a single trailing badge — the verbose JSON error body
+  // is already conveyed by the badge, so dropping the body keeps the card tight.
+  const showBody = !card.rejected && visible.length > 0;
 
   return (
     <Box flexDirection="column">
@@ -43,12 +45,12 @@ export function ToolCard({ card }: { card: ToolCardData }): React.ReactElement {
         title={card.name}
         subtitle={argsLabel || undefined}
         meta={meta || undefined}
-        inline={!card.done ? <Spinner kind="braille" color={CARD.tool.color} bold /> : undefined}
-        trailing={
-          card.retry ? (
-            <Text color={TONE.warn} bold>{`↻ retry ${card.retry.attempt}/${card.retry.max}`}</Text>
+        inline={
+          !card.done && !card.rejected ? (
+            <Spinner kind="braille" color={CARD.tool.color} bold />
           ) : undefined
         }
+        trailing={trailingBadge(card)}
       />
       {showBody && (
         <>
@@ -71,6 +73,20 @@ export function ToolCard({ card }: { card: ToolCardData }): React.ReactElement {
   );
 }
 
+function trailingBadge(card: ToolCardData): React.ReactNode {
+  if (card.rejected) {
+    return (
+      <Text color={CARD.error.color} bold>
+        ✗ rejected
+      </Text>
+    );
+  }
+  if (card.retry) {
+    return <Text color={TONE.warn} bold>{`↻ retry ${card.retry.attempt}/${card.retry.max}`}</Text>;
+  }
+  return undefined;
+}
+
 function formatArgsSummary(args: unknown): string {
   if (typeof args === "string") return args.length > 60 ? `${args.slice(0, 60)}…` : args;
   if (args && typeof args === "object") {
@@ -89,8 +105,12 @@ function formatArgsSummary(args: unknown): string {
 
 function formatMeta(card: ToolCardData): string {
   const parts: string[] = [];
+  const inputBytes = largestStringInputBytes(card.args);
+  if (inputBytes !== null) parts.push(`${formatBytes(inputBytes)} in`);
   if (card.elapsedMs > 0) parts.push(`${(card.elapsedMs / 1000).toFixed(2)}s`);
-  if (card.aborted) {
+  if (card.rejected) {
+    // Trailing badge carries the status; meta stays clean (no "exit N").
+  } else if (card.aborted) {
     parts.push("aborted");
   } else if (card.done) {
     if (card.exitCode === 0) parts.push("exit 0");
@@ -99,4 +119,25 @@ function formatMeta(card: ToolCardData): string {
     parts.push("running");
   }
   return parts.length > 0 ? `· ${parts.join(" · ")}` : "";
+}
+
+const INPUT_SIZE_THRESHOLD = 1024;
+
+/** Largest string field on args, when above threshold. Surfaces input bulk for write_file (content), edit_file (replace), run_command (long stdin), etc. without per-tool special cases. */
+export function largestStringInputBytes(args: unknown): number | null {
+  let max = 0;
+  if (typeof args === "string") {
+    max = args.length;
+  } else if (args && typeof args === "object") {
+    for (const v of Object.values(args as Record<string, unknown>)) {
+      if (typeof v === "string" && v.length > max) max = v.length;
+    }
+  }
+  return max >= INPUT_SIZE_THRESHOLD ? max : null;
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
 }

--- a/src/cli/ui/state/cards.ts
+++ b/src/cli/ui/state/cards.ts
@@ -44,6 +44,8 @@ export interface ToolCard extends CardBase {
   elapsedMs: number;
   retry?: { attempt: number; max: number };
   aborted?: boolean;
+  /** Set when dispatch refused the call (e.g. plan-mode bounce). UI swaps spinner for a red "rejected" badge and hides the verbose error body. */
+  rejected?: boolean;
 }
 
 export interface TaskStep {

--- a/src/cli/ui/state/reducer.ts
+++ b/src/cli/ui/state/reducer.ts
@@ -60,7 +60,9 @@ export function reduce(state: AgentState, event: AgentEvent): AgentState {
     case "tool.chunk":
       return mutateCard(state, event.id, "tool", (c) => ({ ...c, output: c.output + event.text }));
 
-    case "tool.end":
+    case "tool.end": {
+      const finalOutput = event.output ?? "";
+      const rejected = isPlanModeRejection(finalOutput);
       return mutateCard(state, event.id, "tool", (c) => ({
         ...c,
         done: true,
@@ -68,7 +70,9 @@ export function reduce(state: AgentState, event: AgentEvent): AgentState {
         exitCode: event.exitCode,
         elapsedMs: event.elapsedMs,
         ...(event.aborted ? { aborted: true } : {}),
+        ...(rejected ? { rejected: true } : {}),
       }));
+    }
 
     case "tool.retry":
       return mutateCard(state, event.id, "tool", (c) => ({
@@ -379,4 +383,15 @@ function makeLiveCard(
   tone: LiveCard["tone"],
 ): LiveCard {
   return { kind: "live", id: nextId("live"), ts: Date.now(), variant, text, tone };
+}
+
+/** Detect the plan-mode bounce marker emitted by ToolRegistry.dispatch when refusing a write tool. */
+function isPlanModeRejection(output: string): boolean {
+  if (!output) return false;
+  try {
+    const parsed = JSON.parse(output);
+    return parsed?.rejectedReason === "plan-mode";
+  } catch {
+    return false;
+  }
 }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -137,6 +137,7 @@ export class ToolRegistry {
     if (this._planMode && !isReadOnlyCall(tool, args)) {
       return JSON.stringify({
         error: `${name}: unavailable in plan mode — this is a read-only exploration phase. Use read_file / list_directory / search_files / directory_tree / web_search / allowlisted shell commands to investigate. Call submit_plan with your proposed plan when you're ready for the user's review.`,
+        rejectedReason: "plan-mode",
       });
     }
 

--- a/tests/tool-card-meta.test.ts
+++ b/tests/tool-card-meta.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { largestStringInputBytes } from "../src/cli/ui/cards/ToolCard.js";
+
+describe("largestStringInputBytes", () => {
+  it("returns null for short string args (below 1 KB threshold)", () => {
+    expect(largestStringInputBytes({ path: "foo.ts", content: "hello" })).toBeNull();
+    expect(largestStringInputBytes({})).toBeNull();
+    expect(largestStringInputBytes(null)).toBeNull();
+    expect(largestStringInputBytes(undefined)).toBeNull();
+  });
+
+  it("returns the largest string field when at or above 1 KB", () => {
+    const small = "x".repeat(100);
+    const big = "y".repeat(2048);
+    expect(largestStringInputBytes({ path: small, content: big })).toBe(2048);
+  });
+
+  it("ignores non-string fields when picking the largest", () => {
+    const big = "z".repeat(1500);
+    expect(largestStringInputBytes({ count: 9999, content: big, opts: { x: 1 } })).toBe(1500);
+  });
+
+  it("handles a string-typed args directly", () => {
+    expect(largestStringInputBytes("a".repeat(2000))).toBe(2000);
+    expect(largestStringInputBytes("short")).toBeNull();
+  });
+
+  it("returns the LARGEST when multiple fields exceed the threshold", () => {
+    expect(
+      largestStringInputBytes({
+        a: "p".repeat(1100),
+        b: "q".repeat(5000),
+        c: "r".repeat(2000),
+      }),
+    ).toBe(5000);
+  });
+});

--- a/tests/ui-reducer.test.ts
+++ b/tests/ui-reducer.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import type { ReasoningCard, StreamingCard, UserCard } from "../src/cli/ui/state/cards.js";
+import type {
+  ReasoningCard,
+  StreamingCard,
+  ToolCard,
+  UserCard,
+} from "../src/cli/ui/state/cards.js";
 import type { AgentEvent } from "../src/cli/ui/state/events.js";
 import { parseEvent } from "../src/cli/ui/state/events.js";
 import { reduce } from "../src/cli/ui/state/reducer.js";
@@ -70,6 +75,34 @@ describe("ui reducer", () => {
   it("ignores chunks for unknown ids", () => {
     const s = run([{ type: "streaming.chunk", id: "missing", text: "lost" }]);
     expect(s.cards).toHaveLength(0);
+  });
+
+  it("flags tool card as rejected when tool.end output carries plan-mode marker", () => {
+    const planBounce = JSON.stringify({
+      error: "write_file: unavailable in plan mode — ...",
+      rejectedReason: "plan-mode",
+    });
+    const s = run([
+      { type: "tool.start", id: "t1", name: "write_file", args: { path: "x.ts", content: "y" } },
+      { type: "tool.end", id: "t1", output: planBounce, elapsedMs: 2 },
+    ]);
+    const card = s.cards[0] as ToolCard;
+    expect(card.rejected).toBe(true);
+    expect(card.done).toBe(true);
+  });
+
+  it("does not flag rejection on a regular error output", () => {
+    const s = run([
+      { type: "tool.start", id: "t1", name: "edit_file", args: { path: "x" } },
+      {
+        type: "tool.end",
+        id: "t1",
+        output: JSON.stringify({ error: "edit_file: search not found" }),
+        elapsedMs: 5,
+      },
+    ]);
+    const card = s.cards[0] as ToolCard;
+    expect(card.rejected).toBeUndefined();
   });
 
   it("changes mode and accumulates session cost", () => {


### PR DESCRIPTION
Closes #150 (the user-facing half — bounce *wording* stays as-is).

## Diagnosis

Both pain points from #150 are fundamentally **visual**, not behavioural:

- **Plan-mode bounce feels post-hoc.** The gate runs before any fs write (`tools.ts:137-141`), but the user sees a spinner during arg streaming, then a JSON error in the tool body. Reads as "wrote, then failed".
- **`write_file` looks silent.** `formatArgsSummary` picks the first key — for `write_file({path, content})` that's the *path*. The `content` length is invisible until the result line comes back.

Sharpening the bounce wording (closed PR #152) doesn't address either — the user's view is unchanged.

## Fix A — `rejected` visual state

`ToolRegistry.dispatch` now adds `rejectedReason: "plan-mode"` to the bounce JSON. The reducer parses `tool.end.output`, flips `card.rejected = true` on the marker.

`ToolCard` then:
- Swaps the spinner for a red **`✗ rejected`** badge in the trailing slot
- Hides the verbose JSON error body (the badge already conveys the state)

One quick visual cue replaces a faux-write spinner + wall-of-JSON. Distinguishes plan-mode bounces from generic tool errors (which keep their body + exit code).

## Fix B — Input size in meta

`ToolCard.formatMeta` gains a leading `· 1.2 KB in` fragment when any string field on args is **at or above 1 KB**.

```
▣ write_file  foo.ts                              · 1.2 KB in · 0.05s · exit 0
▣ edit_file   src/cli/ui/App.tsx                  · 4.3 KB in · 0.12s · exit 0
▣ run_command npm test                                          · running
```

Generic — no per-tool special case. Threshold filters out short paths so meta stays clean for read tools / list_directory / etc.

## Tests

- `ui-reducer.test.ts` — `tool.end` with plan-mode marker flips `rejected=true`; regular errors don't trigger.
- `tool-card-meta.test.ts` — `largestStringInputBytes` threshold + largest-field selection.

`npm run verify` — 1858/1858.

## Refs

- #150 — original issue (this addresses the visible-symptom half; bounce *wording* unchanged per maintainer direction)
- #152 — earlier attempt (closed) that tried to fix this via wording + per-tool special case