### PR TITLE
fix(layout): step visibility + auto-fit rules + edit-mode pill in plan mode

### DIFF
--- a/src/cli/ui/layout/LiveRows.tsx
+++ b/src/cli/ui/layout/LiveRows.tsx
@@ -46,17 +46,21 @@ export function ModeStatusBar({
     running > 0 ? (
       <Text color={TONE.warn} bold>{`  ·  ⏵ ${running} job${running === 1 ? "" : "s"}`}</Text>
     ) : null;
+  const editLabel = editMode === "yolo" ? "YOLO" : editMode === "auto" ? "AUTO" : "REVIEW";
+  const editColor = editMode === "yolo" ? TONE.err : editMode === "auto" ? TONE.accent : TONE.brand;
   if (planMode) {
+    // Show edit-mode alongside PLAN so the user can tell whether post-approve
+    // edits will land hands-off (AUTO/YOLO) or still need per-edit y/n (REVIEW).
     return (
       <ModeBarFrame>
         <ModePill label="PLAN MODE" color={TONE.err} flash={flash} />
-        <Text color={FG.faint}>{"   writes gated · /plan off to leave"}</Text>
+        <Text> </Text>
+        <ModePill label={editLabel} color={editColor} flash={false} />
+        <Text color={FG.faint}>{"   writes gated · Shift+Tab to flip · /plan off to leave"}</Text>
         {jobsTag}
       </ModeBarFrame>
     );
   }
-  const label = editMode === "yolo" ? "YOLO" : editMode === "auto" ? "AUTO" : "REVIEW";
-  const pillColor = editMode === "yolo" ? TONE.err : editMode === "auto" ? TONE.accent : TONE.brand;
   const mid =
     editMode === "yolo"
       ? "edits + shell auto · /undo to roll back"
@@ -67,7 +71,7 @@ export function ModeStatusBar({
           : "edits queued · y apply · n discard";
   return (
     <ModeBarFrame>
-      <ModePill label={label} color={pillColor} flash={flash} />
+      <ModePill label={editLabel} color={editColor} flash={flash} />
       <Text color={FG.faint}>{`   ${mid} · Shift+Tab to flip`}</Text>
       {jobsTag}
     </ModeBarFrame>

--- a/src/cli/ui/layout/LiveRows.tsx
+++ b/src/cli/ui/layout/LiveRows.tsx
@@ -1,4 +1,4 @@
-import { Box, Text, useStdout } from "ink";
+import { Box, Text } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React as a runtime value (classic transform)
 import React from "react";
 import type { ApplyResult } from "../../../code/edit-blocks.js";
@@ -74,15 +74,29 @@ export function ModeStatusBar({
   );
 }
 
+const DASHED_RULE_STYLE = {
+  topLeft: "╌",
+  top: "╌",
+  topRight: "╌",
+  bottomLeft: " ",
+  bottom: " ",
+  bottomRight: " ",
+  left: " ",
+  right: " ",
+} as const;
+
 function ModeBarFrame({ children }: { children: React.ReactNode }) {
-  const { stdout } = useStdout();
-  const cols = stdout?.columns ?? 80;
-  const ruleWidth = Math.max(20, cols - 2);
   return (
     <Box flexDirection="column">
-      <Box paddingX={1}>
-        <Text color={FG.faint}>{"╌".repeat(ruleWidth)}</Text>
-      </Box>
+      <Box
+        paddingX={1}
+        borderStyle={DASHED_RULE_STYLE}
+        borderTop
+        borderRight={false}
+        borderBottom={false}
+        borderLeft={false}
+        borderTopColor={FG.faint}
+      />
       <Box paddingX={1}>{children}</Box>
     </Box>
   );

--- a/src/cli/ui/layout/SidebarPanel.tsx
+++ b/src/cli/ui/layout/SidebarPanel.tsx
@@ -8,9 +8,9 @@ import { useAgentState } from "../state/provider.js";
 import { CARD, FG, TONE } from "../theme/tokens.js";
 import { useIsModalActive } from "./viewport-budget.js";
 
-export const SIDEBAR_WIDTH = 28;
+export const SIDEBAR_WIDTH = 36;
 /** Below this terminal width, sidebar refuses to render so the main column has room to breathe. */
-export const SIDEBAR_MIN_TOTAL_COLS = 88;
+export const SIDEBAR_MIN_TOTAL_COLS = 96;
 
 export interface SidebarPanelProps {
   ongoingTool?: { name: string; args?: string } | null;
@@ -112,10 +112,11 @@ function StepRow({ step, index }: { step: PlanStep; index: number }) {
   const glyph = STATUS_GLYPH[step.status];
   const color = STATUS_COLOR[step.status];
   const num = `${index + 1}.`;
-  const truncated = truncate(step.title, SIDEBAR_WIDTH - 6);
+  // [X] checkbox + " 12. " prefix eats ~8 cols → title gets the rest.
+  const truncated = truncate(step.title, SIDEBAR_WIDTH - 10);
   return (
     <Box>
-      <Text color={color}>{glyph}</Text>
+      <Text color={color}>{`[${glyph}]`}</Text>
       <Text color={step.status === "running" ? FG.strong : FG.sub}>{` ${num} ${truncated}`}</Text>
     </Box>
   );

--- a/src/cli/ui/layout/SidebarPanel.tsx
+++ b/src/cli/ui/layout/SidebarPanel.tsx
@@ -112,8 +112,9 @@ function StepRow({ step, index }: { step: PlanStep; index: number }) {
   const glyph = STATUS_GLYPH[step.status];
   const color = STATUS_COLOR[step.status];
   const num = `${index + 1}.`;
-  // [X] checkbox + " 12. " prefix eats ~8 cols → title gets the rest.
-  const truncated = truncate(step.title, SIDEBAR_WIDTH - 10);
+  // [X] checkbox + " 12. " prefix eats ~8 cols. 2-col safety margin so
+  // wide-char step titles (CJK) can't push the bracket cluster off-screen.
+  const truncated = truncate(step.title, SIDEBAR_WIDTH - 12);
   return (
     <Box>
       <Text color={color}>{`[${glyph}]`}</Text>

--- a/src/cli/ui/layout/StatusRow.tsx
+++ b/src/cli/ui/layout/StatusRow.tsx
@@ -1,13 +1,10 @@
-import { Box, Text, useStdout } from "ink";
+import { Box, Text } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React from "react";
 import { Countdown } from "../primitives/Countdown.js";
 import { useAgentState } from "../state/provider.js";
 import type { Mode, NetworkState, StatusBar } from "../state/state.js";
 import { FG, TONE, USD_TO_CNY } from "../theme/tokens.js";
-
-const RULE_PAD = 4;
-const RULE_MIN = 20;
 
 function balanceColor(cny: number): string {
   if (cny < 5) return TONE.err;
@@ -18,19 +15,21 @@ function balanceColor(cny: number): string {
 export function StatusRow(): React.ReactElement {
   const status = useAgentState((s) => s.status);
   const session = useAgentState((s) => s.session);
-  const { stdout } = useStdout();
-  const cols = stdout?.columns ?? 80;
-  const ruleWidth = Math.max(RULE_MIN, cols - RULE_PAD);
   const turnCny = status.cost * USD_TO_CNY;
   const sessionCny = status.sessionCost * USD_TO_CNY;
   const hasTurn = status.cost > 0;
 
   return (
     <Box flexDirection="column">
-      <Box>
-        <Text>{"  "}</Text>
-        <Text color={FG.faint}>{"─".repeat(ruleWidth)}</Text>
-      </Box>
+      <Box
+        paddingX={1}
+        borderStyle="single"
+        borderTop
+        borderRight={false}
+        borderBottom={false}
+        borderLeft={false}
+        borderTopColor={FG.faint}
+      />
       <Box flexDirection="row">
         <Text>{"  "}</Text>
         {status.recording ? (


### PR DESCRIPTION
Stacked sidebar / status visual fixes from testing #156.

## What's fixed

### 1. Sidebar step status was illegible

\`queued\` had a bare \` \` glyph with no border — invisible. Switched to \`[\${glyph}]\` checkbox pattern matching \`PlanCard\` inline:

| state | before | after |
|---|---|---|
| queued | \` \` (invisible) | \`[ ]\` |
| running | \`▶\` | \`[▶]\` |
| done | \`✓\` | \`[✓]\` |

### 2. Sidebar title text cropped too aggressively

Sidebar was 28 cols. Bumped \`SIDEBAR_WIDTH\` 28 → 36 and \`SIDEBAR_MIN_TOTAL_COLS\` 88 → 96. Title budget ~26 chars now.

### 3. Status & mode rules wrapped on narrow main column

\`StatusRow\`'s \`─\` and \`ModeBarFrame\`'s \`╌\` rules used \`cols - N\` from \`useStdout\` — terminal width, not main-column width. With sidebar eating ~36 cols on the right, rules overflowed and wrapped.

Switched both to \`<Box borderTop>\` which auto-fills the parent's content width. Dashed look preserved via custom \`borderStyle\` object.

### 4. Bracket cluster could overflow on wide-char titles

Title truncation budget was \`SIDEBAR_WIDTH - 10\`. With brackets / index / spaces summing exactly to inner width, CJK content pushed brackets off-screen. Bumped to \`SIDEBAR_WIDTH - 12\` for a 2-col safety margin.

### 5. PLAN MODE pill hid the edit-mode (REVIEW/AUTO/YOLO) state

In plan mode the status bar hid the edit-mode pill entirely, so users couldn't tell whether post-approve edits would land hands-off (AUTO/YOLO) or still need per-edit y/n (REVIEW). Now both pills render side-by-side: \`[PLAN MODE] [REVIEW]\` etc., and the hint text adds \`Shift+Tab to flip\` so users can switch edit-mode without leaving plan mode.

## Test plan

- [x] \`npm run verify\` — 1858/1858
- [ ] CI green
- [ ] Wide screen + sidebar: rules end at sidebar's left edge, no wrapping. Brackets fully visible. Status pills distinct.
- [ ] Narrow screen (no sidebar): no regression — rules span full terminal.
- [ ] \`/plan\` on: see both PLAN MODE and current edit-mode pill. Shift+Tab while in plan mode flips the second pill.

## Refs

- #156 — single-display-position layout (merged)
- RFC #20 — original sidebar discussion