### PR TITLE
fix(sidebar): stabilize windowed plan-section height across step transitions

### DIFF
--- a/src/cli/ui/layout/SidebarPanel.tsx
+++ b/src/cli/ui/layout/SidebarPanel.tsx
@@ -95,17 +95,23 @@ function PlanSection({ card }: { card: { steps: PlanStep[]; title: string } }) {
         tone={CARD.plan.color}
       />
       <Divider />
-      {visible.kind === "all" ? null : (
-        <Text color={FG.faint}>{`(${visible.hidden} earlier hidden)`}</Text>
-      )}
+      {visible.kind === "windowed" ? (
+        <HiddenIndicator count={visible.hidden} suffix="earlier hidden" />
+      ) : null}
       {visible.steps.map((s, i) => (
         <StepRow key={s.id} step={s} index={visible.startIndex + i} />
       ))}
-      {visible.kind === "windowed" && visible.hiddenAfter > 0 ? (
-        <Text color={FG.faint}>{`(${visible.hiddenAfter} more)`}</Text>
+      {visible.kind === "windowed" ? (
+        <HiddenIndicator count={visible.hiddenAfter} suffix="more" />
       ) : null}
     </>
   );
+}
+
+/** Always renders one row in windowed mode; shows count when > 0, blank placeholder otherwise. The blank holds the row so the sidebar's total height stays stable as the running step crosses the window edges — without this, the indicator flips on/off mid-execution and Ink's erase-then-reprint leaks the previous frame. */
+function HiddenIndicator({ count, suffix }: { count: number; suffix: string }) {
+  if (count <= 0) return <Box height={1} />;
+  return <Text color={FG.faint}>{`(${count} ${suffix})`}</Text>;
 }
 
 function StepRow({ step, index }: { step: PlanStep; index: number }) {


### PR DESCRIPTION
Root-cause fix for the screen jitter reported in #155 — the actual mechanism, not the cols-based workaround.

## Why

PR #156 moved the plan card into the right sidebar at ≥96 cols, which removed the most visible plan-card-vs-tool-card height fight. But it didn't fix the underlying issue, only relocated it: the **sidebar's** windowed plan-section was itself unstable.

When a plan exceeds the visible window (>11 steps), \`PlanSection\` conditionally rendered \`(N earlier hidden)\` / \`(N more)\` hint rows only when \`N > 0\`. As the running step crossed window boundaries, those rows flipped on/off — each flip = 1 row change in the live region's total height, which is what triggers Ink's erase-then-reprint to leak the previous frame as visible "blinking text underneath".

## Fix

Always render both indicator rows in windowed mode. Show the count when \`N > 0\`, an empty 1-row placeholder (\`<Box height={1} />\`) otherwise.

```diff
-{visible.kind === "all" ? null : (
-  <Text color={FG.faint}>{`(${visible.hidden} earlier hidden)`}</Text>
-)}
+{visible.kind === "windowed" ? (
+  <HiddenIndicator count={visible.hidden} suffix="earlier hidden" />
+) : null}
```

\`HiddenIndicator\` extracted as a small helper that returns either the labelled \`<Text>\` or an invisible 1-row placeholder. Total rendered height of the windowed plan-section is now stable regardless of how the running step moves through the plan.

## Why this is the right place

The fix lives on the plan card data path itself, not behind a screen-width gate. Wide screens (sidebar visible) get the stable height directly. Narrow screens (plan inline) currently don't have this jitter because inline \`PlanCard\` doesn't window — but if that changes later, the same shape of fix applies.

## What's still open

This is one of several live-region row-instability sources. Streaming and reasoning cards have the same shape of bug during their initial output ramp (visible.length goes 1 → 2 → 3 → 4 across chunks). I'll file a tracking issue for the rest after 0.24 ships; this PR is the first concrete step.

## Test plan

- [x] \`npm run verify\` — 1858/1858
- [ ] CI green
- [ ] Visual: plan with >11 steps, watch sidebar as running step moves through; the section's total height should not change. No "blinking text underneath" symptom.

## Refs

- #155 — the reported bug
- #156 — the cols-based workaround that surfaced this as the next layer down