### PR TITLE
feat(renderer): cell-buffer foundation — Screen, Cell, intern pools

### DIFF
--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -1,0 +1,6 @@
+export { CharPool } from "./pools/char-pool.js";
+export { HyperlinkPool } from "./pools/hyperlink-pool.js";
+export { StylePool, type AnsiCode } from "./pools/style-pool.js";
+export { type Cell, CellWidth, EMPTY_CELL, cellsEqual } from "./screen/cell.js";
+export { type Rectangle, Screen } from "./screen/screen.js";
+export { type DiffCallback, diffEach } from "./screen/diff.js";

--- a/src/renderer/pools/char-pool.ts
+++ b/src/renderer/pools/char-pool.ts
@@ -1,0 +1,48 @@
+const ASCII_TABLE_SIZE = 128;
+const SPACE_ID = 0;
+const EMPTY_ID = 1;
+
+export class CharPool {
+  private readonly strings: string[];
+  private readonly map: Map<string, number>;
+  private readonly ascii: Int32Array;
+
+  constructor() {
+    this.strings = [" ", ""];
+    this.map = new Map([
+      [" ", SPACE_ID],
+      ["", EMPTY_ID],
+    ]);
+    this.ascii = new Int32Array(ASCII_TABLE_SIZE).fill(-1);
+    this.ascii[" ".charCodeAt(0)] = SPACE_ID;
+  }
+
+  intern(s: string): number {
+    if (s.length === 1) {
+      const code = s.charCodeAt(0);
+      if (code < ASCII_TABLE_SIZE) {
+        const cached = this.ascii[code]!;
+        if (cached !== -1) return cached;
+        const id = this.strings.length;
+        this.strings.push(s);
+        this.ascii[code] = id;
+        this.map.set(s, id);
+        return id;
+      }
+    }
+    const existing = this.map.get(s);
+    if (existing !== undefined) return existing;
+    const id = this.strings.length;
+    this.strings.push(s);
+    this.map.set(s, id);
+    return id;
+  }
+
+  get(id: number): string {
+    return this.strings[id] ?? " ";
+  }
+
+  get size(): number {
+    return this.strings.length;
+  }
+}

--- a/src/renderer/pools/hyperlink-pool.ts
+++ b/src/renderer/pools/hyperlink-pool.ts
@@ -1,0 +1,25 @@
+const NO_HYPERLINK = 0;
+
+export class HyperlinkPool {
+  private readonly strings: string[] = [""];
+  private readonly map = new Map<string, number>();
+
+  intern(uri: string | undefined): number {
+    if (!uri) return NO_HYPERLINK;
+    const existing = this.map.get(uri);
+    if (existing !== undefined) return existing;
+    const id = this.strings.length;
+    this.strings.push(uri);
+    this.map.set(uri, id);
+    return id;
+  }
+
+  get(id: number): string | undefined {
+    if (id === NO_HYPERLINK) return undefined;
+    return this.strings[id];
+  }
+
+  get size(): number {
+    return this.strings.length;
+  }
+}

--- a/src/renderer/pools/style-pool.ts
+++ b/src/renderer/pools/style-pool.ts
@@ -1,0 +1,58 @@
+export interface AnsiCode {
+  readonly apply: string;
+  readonly revert: string;
+}
+
+const EMPTY_KEY = "";
+
+export class StylePool {
+  private readonly stacks: ReadonlyArray<AnsiCode>[] = [[]];
+  private readonly idsByKey = new Map<string, number>([[EMPTY_KEY, 0]]);
+  private readonly transitionCache = new Map<number, string>();
+  readonly none = 0;
+
+  intern(codes: ReadonlyArray<AnsiCode>): number {
+    const key = stackKey(codes);
+    const existing = this.idsByKey.get(key);
+    if (existing !== undefined) return existing;
+    const id = this.stacks.length;
+    this.stacks.push(codes);
+    this.idsByKey.set(key, id);
+    return id;
+  }
+
+  transition(fromId: number, toId: number): string {
+    if (fromId === toId) return "";
+    const cacheKey = (fromId << 16) | toId;
+    const cached = this.transitionCache.get(cacheKey);
+    if (cached !== undefined) return cached;
+
+    const from = this.stacks[fromId] ?? [];
+    const to = this.stacks[toId] ?? [];
+    const fromApplies = new Set(from.map((c) => c.apply));
+    const toApplies = new Set(to.map((c) => c.apply));
+
+    let out = "";
+    for (const c of from) {
+      if (!toApplies.has(c.apply)) out += c.revert;
+    }
+    for (const c of to) {
+      if (!fromApplies.has(c.apply)) out += c.apply;
+    }
+
+    this.transitionCache.set(cacheKey, out);
+    return out;
+  }
+
+  get size(): number {
+    return this.stacks.length;
+  }
+}
+
+function stackKey(codes: ReadonlyArray<AnsiCode>): string {
+  if (codes.length === 0) return EMPTY_KEY;
+  // Sort so {RED, BOLD} and {BOLD, RED} hash to the same id — style identity is the SET of codes.
+  const applies = codes.map((c) => c.apply);
+  applies.sort();
+  return applies.join("\x00");
+}

--- a/src/renderer/screen/cell.ts
+++ b/src/renderer/screen/cell.ts
@@ -1,0 +1,31 @@
+export const CellWidth = {
+  Single: 1,
+  Wide: 2,
+  /** Occupies the column following a Wide glyph; renderer must skip it. */
+  SpacerTail: 3,
+} as const;
+
+export type CellWidth = (typeof CellWidth)[keyof typeof CellWidth];
+
+export interface Cell {
+  charId: number;
+  styleId: number;
+  hyperlinkId: number;
+  width: CellWidth;
+}
+
+export const EMPTY_CELL: Cell = Object.freeze({
+  charId: 0,
+  styleId: 0,
+  hyperlinkId: 0,
+  width: CellWidth.Single,
+});
+
+export function cellsEqual(a: Cell, b: Cell): boolean {
+  return (
+    a.charId === b.charId &&
+    a.styleId === b.styleId &&
+    a.hyperlinkId === b.hyperlinkId &&
+    a.width === b.width
+  );
+}

--- a/src/renderer/screen/diff.ts
+++ b/src/renderer/screen/diff.ts
@@ -1,0 +1,24 @@
+import { type Cell, cellsEqual } from "./cell.js";
+import type { Screen } from "./screen.js";
+
+export type DiffCallback = (
+  x: number,
+  y: number,
+  prev: Cell | undefined,
+  next: Cell | undefined,
+) => boolean | undefined;
+
+export function diffEach(prev: Screen, next: Screen, cb: DiffCallback): boolean {
+  const w = Math.max(prev.width, next.width);
+  const h = Math.max(prev.height, next.height);
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      const a = prev.cellAt(x, y);
+      const b = next.cellAt(x, y);
+      if (a === b) continue;
+      if (a !== undefined && b !== undefined && cellsEqual(a, b)) continue;
+      if (cb(x, y, a, b) === true) return true;
+    }
+  }
+  return false;
+}

--- a/src/renderer/screen/screen.ts
+++ b/src/renderer/screen/screen.ts
@@ -1,0 +1,59 @@
+import { type Cell, EMPTY_CELL } from "./cell.js";
+
+export interface Rectangle {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export class Screen {
+  readonly width: number;
+  readonly height: number;
+  readonly cells: Cell[];
+  private _damage: Rectangle | undefined;
+
+  constructor(width: number, height: number) {
+    this.width = Math.max(0, width | 0);
+    this.height = Math.max(0, height | 0);
+    this.cells = new Array<Cell>(this.width * this.height);
+    for (let i = 0; i < this.cells.length; i++) this.cells[i] = EMPTY_CELL;
+    this._damage = undefined;
+  }
+
+  get damage(): Rectangle | undefined {
+    return this._damage;
+  }
+
+  resetDamage(): void {
+    this._damage = undefined;
+  }
+
+  cellAt(x: number, y: number): Cell | undefined {
+    if (x < 0 || x >= this.width || y < 0 || y >= this.height) return undefined;
+    return this.cells[y * this.width + x];
+  }
+
+  writeCell(x: number, y: number, cell: Cell): void {
+    if (x < 0 || x >= this.width || y < 0 || y >= this.height) return;
+    this.cells[y * this.width + x] = cell;
+    this.markDamage(x, y, 1, 1);
+  }
+
+  markDamage(x: number, y: number, w: number, h: number): void {
+    if (w <= 0 || h <= 0) return;
+    if (this._damage === undefined) {
+      this._damage = { x, y, width: w, height: h };
+      return;
+    }
+    const d = this._damage;
+    const x1 = Math.min(d.x, x);
+    const y1 = Math.min(d.y, y);
+    const x2 = Math.max(d.x + d.width, x + w);
+    const y2 = Math.max(d.y + d.height, y + h);
+    d.x = x1;
+    d.y = y1;
+    d.width = x2 - x1;
+    d.height = y2 - y1;
+  }
+}

--- a/tests/renderer/char-pool.test.ts
+++ b/tests/renderer/char-pool.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { CharPool } from "../../src/renderer/pools/char-pool.js";
+
+describe("CharPool", () => {
+  it("seeds id 0 with space and id 1 with empty string", () => {
+    const p = new CharPool();
+    expect(p.get(0)).toBe(" ");
+    expect(p.get(1)).toBe("");
+    expect(p.intern(" ")).toBe(0);
+    expect(p.intern("")).toBe(1);
+  });
+
+  it("intern is idempotent for ASCII fast-path", () => {
+    const p = new CharPool();
+    const a = p.intern("a");
+    const b = p.intern("a");
+    expect(a).toBe(b);
+    expect(p.get(a)).toBe("a");
+  });
+
+  it("intern is idempotent for non-ASCII (CJK, emoji ZWJ)", () => {
+    const p = new CharPool();
+    const cjk1 = p.intern("中");
+    const cjk2 = p.intern("中");
+    const family = p.intern("👨‍👩‍👧");
+    const family2 = p.intern("👨‍👩‍👧");
+    expect(cjk1).toBe(cjk2);
+    expect(family).toBe(family2);
+    expect(cjk1).not.toBe(family);
+    expect(p.get(cjk1)).toBe("中");
+    expect(p.get(family)).toBe("👨‍👩‍👧");
+  });
+
+  it("distinct strings get distinct ids", () => {
+    const p = new CharPool();
+    const a = p.intern("a");
+    const b = p.intern("b");
+    const c = p.intern("ab");
+    expect(new Set([a, b, c]).size).toBe(3);
+  });
+
+  it("size grows with new entries; stays flat on hits", () => {
+    const p = new CharPool();
+    const initial = p.size;
+    p.intern("x");
+    p.intern("x");
+    p.intern("y");
+    expect(p.size).toBe(initial + 2);
+  });
+
+  it("get on an unknown id falls back to space", () => {
+    const p = new CharPool();
+    expect(p.get(9999)).toBe(" ");
+  });
+});

--- a/tests/renderer/diff.test.ts
+++ b/tests/renderer/diff.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest";
+import { type Cell, CellWidth, EMPTY_CELL } from "../../src/renderer/screen/cell.js";
+import { diffEach } from "../../src/renderer/screen/diff.js";
+import { Screen } from "../../src/renderer/screen/screen.js";
+
+function cell(overrides: Partial<Cell> = {}): Cell {
+  return { ...EMPTY_CELL, ...overrides };
+}
+
+describe("diffEach", () => {
+  it("identical screens produce no callbacks", () => {
+    const a = new Screen(3, 2);
+    const b = new Screen(3, 2);
+    const cb = vi.fn();
+    diffEach(a, b, cb);
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("a single-cell difference produces a single callback at that position", () => {
+    const a = new Screen(3, 2);
+    const b = new Screen(3, 2);
+    b.writeCell(1, 1, cell({ charId: 42 }));
+    const calls: Array<[number, number]> = [];
+    diffEach(a, b, (x, y) => {
+      calls.push([x, y]);
+    });
+    expect(calls).toEqual([[1, 1]]);
+  });
+
+  it("returning true halts the walk early", () => {
+    const a = new Screen(3, 3);
+    const b = new Screen(3, 3);
+    b.writeCell(0, 0, cell({ charId: 1 }));
+    b.writeCell(2, 2, cell({ charId: 2 }));
+    let visited = 0;
+    const halted = diffEach(a, b, () => {
+      visited++;
+      return true;
+    });
+    expect(halted).toBe(true);
+    expect(visited).toBe(1);
+  });
+
+  it("structurally identical cells with different object identity are NOT reported", () => {
+    const a = new Screen(2, 1);
+    const b = new Screen(2, 1);
+    const c1 = cell({ charId: 5, styleId: 3 });
+    const c2 = cell({ charId: 5, styleId: 3 });
+    a.writeCell(0, 0, c1);
+    b.writeCell(0, 0, c2);
+    const cb = vi.fn();
+    diffEach(a, b, cb);
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("reports differing widths even when char and style match", () => {
+    const a = new Screen(1, 1);
+    const b = new Screen(1, 1);
+    a.writeCell(0, 0, cell({ charId: 5 }));
+    b.writeCell(0, 0, cell({ charId: 5, width: CellWidth.Wide }));
+    const cb = vi.fn();
+    diffEach(a, b, cb);
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("walks the union of differing dimensions when prev/next aren't the same size", () => {
+    const a = new Screen(1, 1);
+    const b = new Screen(2, 2);
+    b.writeCell(1, 1, cell({ charId: 9 }));
+    const calls: Array<[number, number]> = [];
+    diffEach(a, b, (x, y) => {
+      calls.push([x, y]);
+    });
+    expect(calls).toContainEqual([1, 1]);
+  });
+});

--- a/tests/renderer/hyperlink-pool.test.ts
+++ b/tests/renderer/hyperlink-pool.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { HyperlinkPool } from "../../src/renderer/pools/hyperlink-pool.js";
+
+describe("HyperlinkPool", () => {
+  it("undefined and empty string both map to id 0 (no hyperlink)", () => {
+    const p = new HyperlinkPool();
+    expect(p.intern(undefined)).toBe(0);
+    expect(p.intern("")).toBe(0);
+    expect(p.get(0)).toBeUndefined();
+  });
+
+  it("intern is idempotent", () => {
+    const p = new HyperlinkPool();
+    const a = p.intern("https://example.com");
+    const b = p.intern("https://example.com");
+    expect(a).toBe(b);
+    expect(p.get(a)).toBe("https://example.com");
+  });
+
+  it("distinct uris get distinct ids", () => {
+    const p = new HyperlinkPool();
+    const a = p.intern("https://a.com");
+    const b = p.intern("https://b.com");
+    expect(a).not.toBe(b);
+    expect(p.get(a)).toBe("https://a.com");
+    expect(p.get(b)).toBe("https://b.com");
+  });
+});

--- a/tests/renderer/screen.test.ts
+++ b/tests/renderer/screen.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { type Cell, CellWidth, EMPTY_CELL } from "../../src/renderer/screen/cell.js";
+import { Screen } from "../../src/renderer/screen/screen.js";
+
+function makeCell(overrides: Partial<Cell> = {}): Cell {
+  return { ...EMPTY_CELL, ...overrides };
+}
+
+describe("Screen", () => {
+  it("constructs with width × height empty cells", () => {
+    const s = new Screen(4, 3);
+    expect(s.width).toBe(4);
+    expect(s.height).toBe(3);
+    expect(s.cells).toHaveLength(12);
+    for (const c of s.cells) expect(c).toBe(EMPTY_CELL);
+  });
+
+  it("clamps negative dimensions to 0", () => {
+    const s = new Screen(-5, -2);
+    expect(s.width).toBe(0);
+    expect(s.height).toBe(0);
+    expect(s.cells).toHaveLength(0);
+  });
+
+  it("cellAt returns undefined for out-of-bounds coordinates", () => {
+    const s = new Screen(2, 2);
+    expect(s.cellAt(-1, 0)).toBeUndefined();
+    expect(s.cellAt(0, -1)).toBeUndefined();
+    expect(s.cellAt(2, 0)).toBeUndefined();
+    expect(s.cellAt(0, 2)).toBeUndefined();
+  });
+
+  it("writeCell stores at the row-major index", () => {
+    const s = new Screen(3, 2);
+    const cell = makeCell({ charId: 5 });
+    s.writeCell(1, 1, cell);
+    expect(s.cellAt(1, 1)).toBe(cell);
+    expect(s.cellAt(0, 0)).toBe(EMPTY_CELL);
+  });
+
+  it("writeCell silently ignores out-of-bounds writes", () => {
+    const s = new Screen(2, 2);
+    s.writeCell(99, 99, makeCell({ charId: 1 }));
+    expect(s.damage).toBeUndefined();
+  });
+
+  it("damage starts undefined and grows to union of all writes", () => {
+    const s = new Screen(10, 10);
+    expect(s.damage).toBeUndefined();
+    s.writeCell(2, 2, makeCell());
+    expect(s.damage).toEqual({ x: 2, y: 2, width: 1, height: 1 });
+    s.writeCell(5, 4, makeCell());
+    expect(s.damage).toEqual({ x: 2, y: 2, width: 4, height: 3 });
+  });
+
+  it("resetDamage clears the rect", () => {
+    const s = new Screen(4, 4);
+    s.writeCell(1, 1, makeCell());
+    expect(s.damage).toBeDefined();
+    s.resetDamage();
+    expect(s.damage).toBeUndefined();
+  });
+
+  it("Wide-cell writes carry their CellWidth marker", () => {
+    const s = new Screen(4, 1);
+    const wide = makeCell({ charId: 7, width: CellWidth.Wide });
+    const tail = makeCell({ width: CellWidth.SpacerTail });
+    s.writeCell(0, 0, wide);
+    s.writeCell(1, 0, tail);
+    expect(s.cellAt(0, 0)?.width).toBe(CellWidth.Wide);
+    expect(s.cellAt(1, 0)?.width).toBe(CellWidth.SpacerTail);
+  });
+});

--- a/tests/renderer/style-pool.test.ts
+++ b/tests/renderer/style-pool.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { type AnsiCode, StylePool } from "../../src/renderer/pools/style-pool.js";
+
+const RED: AnsiCode = { apply: "\x1b[31m", revert: "\x1b[39m" };
+const BOLD: AnsiCode = { apply: "\x1b[1m", revert: "\x1b[22m" };
+const UNDERLINE: AnsiCode = { apply: "\x1b[4m", revert: "\x1b[24m" };
+
+describe("StylePool", () => {
+  it("none is id 0 and matches empty stack", () => {
+    const p = new StylePool();
+    expect(p.none).toBe(0);
+    expect(p.intern([])).toBe(0);
+  });
+
+  it("intern is idempotent regardless of insertion order", () => {
+    const p = new StylePool();
+    const a = p.intern([RED, BOLD]);
+    const b = p.intern([BOLD, RED]);
+    expect(a).toBe(b);
+  });
+
+  it("distinct stacks get distinct ids", () => {
+    const p = new StylePool();
+    const a = p.intern([RED]);
+    const b = p.intern([BOLD]);
+    const c = p.intern([RED, BOLD]);
+    expect(new Set([a, b, c]).size).toBe(3);
+  });
+
+  it("transition from none to red emits red apply", () => {
+    const p = new StylePool();
+    const red = p.intern([RED]);
+    expect(p.transition(p.none, red)).toBe("\x1b[31m");
+  });
+
+  it("transition from red to none emits red revert", () => {
+    const p = new StylePool();
+    const red = p.intern([RED]);
+    expect(p.transition(red, p.none)).toBe("\x1b[39m");
+  });
+
+  it("transition between styles emits revert(removed) + apply(added)", () => {
+    const p = new StylePool();
+    const a = p.intern([RED, BOLD]);
+    const b = p.intern([BOLD, UNDERLINE]);
+    const out = p.transition(a, b);
+    // RED dropped → revert it; UNDERLINE added → apply it. BOLD persists.
+    expect(out).toContain("\x1b[39m"); // RED revert
+    expect(out).toContain("\x1b[4m"); // UNDERLINE apply
+    expect(out).not.toContain("\x1b[1m"); // BOLD already on
+    expect(out).not.toContain("\x1b[22m"); // BOLD not reverted
+  });
+
+  it("transition fromId === toId returns empty string", () => {
+    const p = new StylePool();
+    const id = p.intern([RED]);
+    expect(p.transition(id, id)).toBe("");
+  });
+
+  it("transition cache returns identical strings on repeated calls", () => {
+    const p = new StylePool();
+    const a = p.intern([RED]);
+    const b = p.intern([BOLD]);
+    const first = p.transition(a, b);
+    const second = p.transition(a, b);
+    expect(first).toBe(second);
+  });
+});


### PR DESCRIPTION
First step of the cell-diff renderer tracked in #160. Pure data structures — no React, no Ink, no terminal IO.

## What's here

- **CharPool** — grapheme strings → integer ids; ASCII fast path via `Int32Array[code]`. Seeds id 0=' ', id 1='' so empty cells / wide-char tails are zero cost.
- **HyperlinkPool** — OSC 8 URIs → ids; id 0 reserved for "no hyperlink".
- **StylePool** — `AnsiCode[]` stacks → ids, plus a transition cache: given (fromId, toId), returns the byte sequence to switch terminal state. Stack identity is the SET of `apply` strings (insertion order doesn't matter), so style ids stay stable.
- **Cell** — `{ charId, styleId, hyperlinkId, width }`. `CellWidth` discriminates Single / Wide / SpacerTail so wide CJK glyphs and their next-column placeholder are tracked explicitly.
- **Screen** — row-major `Cell[]` with width × height; `cellAt` / `writeCell` are bounds-checked; `damage` rect tracks the union of modified cells.
- **diffEach** — cell-by-cell walk over two screens; emits one callback per differing position; callback returning `true` halts early.

## What's not here yet

- React reconciler (Phase 2 of #160)
- Diff → Patch[] algorithm (Phase 3)
- Terminal byte serializer (Phase 4)
- Ink replacement integration (Phase 5)

`src/renderer/index.ts` exports the public surface but is **not** re-exported from `src/index.ts` — internal-only until the renderer is wired up.

## References

Standard back-buffer + diff pattern:

- ratatui (Rust) — https://github.com/ratatui-org/ratatui
- textual (Python) — https://github.com/Textualize/textual
- blessed / neo-blessed (Node)
- ncurses (1980+)

## Test plan

- [x] `npm run verify` — 1879/1879 (added 31 new tests across 5 files)
- [ ] CI green

## Refs

- #160 — RFC + phased plan