### PR TITLE
feat(renderer): vertical-stack layout from Box / Text nodes

### DIFF
--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -4,3 +4,5 @@ export { StylePool, type AnsiCode } from "./pools/style-pool.js";
 export { type Cell, CellWidth, EMPTY_CELL, cellsEqual } from "./screen/cell.js";
 export { type Rectangle, Screen } from "./screen/screen.js";
 export { type DiffCallback, diffEach } from "./screen/diff.js";
+export type { BoxNode, LayoutNode, TextNode } from "./layout/node.js";
+export { type RenderPools, renderToScreen } from "./layout/layout.js";

--- a/src/renderer/layout/layout.ts
+++ b/src/renderer/layout/layout.ts
@@ -1,0 +1,118 @@
+import stringWidth from "string-width";
+import type { CharPool } from "../pools/char-pool.js";
+import type { HyperlinkPool } from "../pools/hyperlink-pool.js";
+import type { AnsiCode, StylePool } from "../pools/style-pool.js";
+import { type Cell, CellWidth } from "../screen/cell.js";
+import { Screen } from "../screen/screen.js";
+import type { LayoutNode, TextNode } from "./node.js";
+
+export interface RenderPools {
+  readonly char: CharPool;
+  readonly style: StylePool;
+  readonly hyperlink: HyperlinkPool;
+}
+
+interface TextRow {
+  readonly graphemes: ReadonlyArray<{ glyph: string; width: number }>;
+  readonly styleId: number;
+  readonly hyperlinkId: number;
+}
+
+export function renderToScreen(node: LayoutNode, width: number, pools: RenderPools): Screen {
+  const w = Math.max(0, width | 0);
+  if (w === 0) return new Screen(0, 0);
+  const rows = collectRows(node, w, pools);
+  const screen = new Screen(w, rows.length);
+  for (let y = 0; y < rows.length; y++) {
+    blitRow(screen, rows[y]!, y, pools);
+  }
+  screen.resetDamage();
+  return screen;
+}
+
+function collectRows(node: LayoutNode, width: number, pools: RenderPools): TextRow[] {
+  const out: TextRow[] = [];
+  walk(node, width, pools, out);
+  return out;
+}
+
+function walk(node: LayoutNode, width: number, pools: RenderPools, out: TextRow[]): void {
+  if (node.kind === "text") {
+    pushTextRows(node, width, pools, out);
+    return;
+  }
+  for (const child of node.children) walk(child, width, pools, out);
+}
+
+function pushTextRows(node: TextNode, width: number, pools: RenderPools, out: TextRow[]): void {
+  const styleId = node.style ? pools.style.intern(node.style) : pools.style.none;
+  const hyperlinkId = pools.hyperlink.intern(node.hyperlink);
+  const segmenter = getSegmenter();
+  for (const line of node.content.split("\n")) {
+    const wrapped = wrapLine(line, width, segmenter);
+    if (wrapped.length === 0) {
+      out.push({ graphemes: [], styleId, hyperlinkId });
+      continue;
+    }
+    for (const row of wrapped) {
+      out.push({ graphemes: row, styleId, hyperlinkId });
+    }
+  }
+}
+
+function wrapLine(
+  line: string,
+  width: number,
+  segmenter: Intl.Segmenter,
+): Array<Array<{ glyph: string; width: number }>> {
+  if (width <= 0) return [];
+  const rows: Array<Array<{ glyph: string; width: number }>> = [];
+  let current: Array<{ glyph: string; width: number }> = [];
+  let used = 0;
+  for (const seg of segmenter.segment(line)) {
+    const glyph = seg.segment;
+    const gw = Math.max(0, stringWidth(glyph));
+    if (gw === 0) continue;
+    if (used + gw > width) {
+      if (current.length > 0) rows.push(current);
+      current = [];
+      used = 0;
+      if (gw > width) continue;
+    }
+    current.push({ glyph, width: gw });
+    used += gw;
+  }
+  if (current.length > 0) rows.push(current);
+  return rows;
+}
+
+function blitRow(screen: Screen, row: TextRow, y: number, pools: RenderPools): void {
+  let x = 0;
+  for (const { glyph, width } of row.graphemes) {
+    if (x >= screen.width) break;
+    const charId = pools.char.intern(glyph);
+    const cell: Cell = {
+      charId,
+      styleId: row.styleId,
+      hyperlinkId: row.hyperlinkId,
+      width: width === 2 ? CellWidth.Wide : CellWidth.Single,
+    };
+    screen.writeCell(x, y, cell);
+    if (width === 2 && x + 1 < screen.width) {
+      screen.writeCell(x + 1, y, {
+        charId: 1,
+        styleId: row.styleId,
+        hyperlinkId: row.hyperlinkId,
+        width: CellWidth.SpacerTail,
+      });
+    }
+    x += width;
+  }
+}
+
+let _segmenter: Intl.Segmenter | undefined;
+function getSegmenter(): Intl.Segmenter {
+  if (_segmenter) return _segmenter;
+  _segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+  return _segmenter;
+}

--- a/src/renderer/layout/node.ts
+++ b/src/renderer/layout/node.ts
@@ -1,0 +1,15 @@
+import type { AnsiCode } from "../pools/style-pool.js";
+
+export interface TextNode {
+  readonly kind: "text";
+  readonly content: string;
+  readonly style?: ReadonlyArray<AnsiCode>;
+  readonly hyperlink?: string;
+}
+
+export interface BoxNode {
+  readonly kind: "box";
+  readonly children: ReadonlyArray<LayoutNode>;
+}
+
+export type LayoutNode = TextNode | BoxNode;

--- a/tests/renderer/layout.test.ts
+++ b/tests/renderer/layout.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+import { type RenderPools, renderToScreen } from "../../src/renderer/layout/layout.js";
+import type { LayoutNode } from "../../src/renderer/layout/node.js";
+import { CharPool } from "../../src/renderer/pools/char-pool.js";
+import { HyperlinkPool } from "../../src/renderer/pools/hyperlink-pool.js";
+import { type AnsiCode, StylePool } from "../../src/renderer/pools/style-pool.js";
+import { CellWidth } from "../../src/renderer/screen/cell.js";
+
+const RED: AnsiCode = { apply: "\x1b[31m", revert: "\x1b[39m" };
+
+function pools(): RenderPools {
+  return {
+    char: new CharPool(),
+    style: new StylePool(),
+    hyperlink: new HyperlinkPool(),
+  };
+}
+
+function read(screen: ReturnType<typeof renderToScreen>, p: ReturnType<typeof pools>): string[] {
+  const lines: string[] = [];
+  for (let y = 0; y < screen.height; y++) {
+    let line = "";
+    for (let x = 0; x < screen.width; x++) {
+      const cell = screen.cellAt(x, y);
+      if (!cell) break;
+      if (cell.width === CellWidth.SpacerTail) continue;
+      line += p.char.get(cell.charId);
+    }
+    lines.push(line.trimEnd());
+  }
+  return lines;
+}
+
+describe("renderToScreen — text only", () => {
+  it("single text node fills one row", () => {
+    const p = pools();
+    const node: LayoutNode = { kind: "text", content: "hello" };
+    const s = renderToScreen(node, 10, p);
+    expect(s.height).toBe(1);
+    expect(s.width).toBe(10);
+    expect(read(s, p)).toEqual(["hello"]);
+  });
+
+  it("embedded \\n in content splits to multiple rows", () => {
+    const p = pools();
+    const node: LayoutNode = { kind: "text", content: "hi\nthere" };
+    const s = renderToScreen(node, 10, p);
+    expect(read(s, p)).toEqual(["hi", "there"]);
+  });
+
+  it("char-level wraps when content exceeds width", () => {
+    const p = pools();
+    const node: LayoutNode = { kind: "text", content: "abcdefghij" };
+    const s = renderToScreen(node, 4, p);
+    expect(read(s, p)).toEqual(["abcd", "efgh", "ij"]);
+  });
+
+  it("blank line in content produces an empty row", () => {
+    const p = pools();
+    const node: LayoutNode = { kind: "text", content: "a\n\nb" };
+    const s = renderToScreen(node, 10, p);
+    expect(read(s, p)).toEqual(["a", "", "b"]);
+  });
+});
+
+describe("renderToScreen — box", () => {
+  it("vertically stacks box children", () => {
+    const p = pools();
+    const node: LayoutNode = {
+      kind: "box",
+      children: [
+        { kind: "text", content: "one" },
+        { kind: "text", content: "two" },
+        { kind: "text", content: "three" },
+      ],
+    };
+    const s = renderToScreen(node, 10, p);
+    expect(read(s, p)).toEqual(["one", "two", "three"]);
+  });
+
+  it("nested boxes flatten in source order", () => {
+    const p = pools();
+    const node: LayoutNode = {
+      kind: "box",
+      children: [
+        { kind: "text", content: "a" },
+        {
+          kind: "box",
+          children: [
+            { kind: "text", content: "b" },
+            { kind: "text", content: "c" },
+          ],
+        },
+        { kind: "text", content: "d" },
+      ],
+    };
+    const s = renderToScreen(node, 5, p);
+    expect(read(s, p)).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("empty box yields zero rows", () => {
+    const p = pools();
+    const node: LayoutNode = { kind: "box", children: [] };
+    const s = renderToScreen(node, 5, p);
+    expect(s.height).toBe(0);
+  });
+});
+
+describe("renderToScreen — style + hyperlink threading", () => {
+  it("text style is interned and applied to its cells", () => {
+    const p = pools();
+    const node: LayoutNode = { kind: "text", content: "x", style: [RED] };
+    const s = renderToScreen(node, 5, p);
+    const cell = s.cellAt(0, 0)!;
+    expect(cell.styleId).toBe(p.style.intern([RED]));
+    expect(p.style.transition(p.style.none, cell.styleId)).toBe("\x1b[31m");
+  });
+
+  it("hyperlink uri is interned and applied", () => {
+    const p = pools();
+    const node: LayoutNode = {
+      kind: "text",
+      content: "z",
+      hyperlink: "https://example.com",
+    };
+    const s = renderToScreen(node, 5, p);
+    const cell = s.cellAt(0, 0)!;
+    expect(p.hyperlink.get(cell.hyperlinkId)).toBe("https://example.com");
+  });
+});
+
+describe("renderToScreen — wide-char support", () => {
+  it("CJK glyph occupies two cells with a SpacerTail", () => {
+    const p = pools();
+    const node: LayoutNode = { kind: "text", content: "你好" };
+    const s = renderToScreen(node, 4, p);
+    expect(s.width).toBe(4);
+    expect(s.cellAt(0, 0)?.width).toBe(CellWidth.Wide);
+    expect(s.cellAt(1, 0)?.width).toBe(CellWidth.SpacerTail);
+    expect(s.cellAt(2, 0)?.width).toBe(CellWidth.Wide);
+    expect(s.cellAt(3, 0)?.width).toBe(CellWidth.SpacerTail);
+    expect(p.char.get(s.cellAt(0, 0)!.charId)).toBe("你");
+    expect(p.char.get(s.cellAt(2, 0)!.charId)).toBe("好");
+  });
+
+  it("wide char wraps when it does not fit in remaining columns", () => {
+    const p = pools();
+    const node: LayoutNode = { kind: "text", content: "a你" };
+    const s = renderToScreen(node, 2, p);
+    expect(s.height).toBe(2);
+    expect(read(s, p)).toEqual(["a", "你"]);
+  });
+});
+
+describe("renderToScreen — edge cases", () => {
+  it("zero width yields zero rows", () => {
+    const p = pools();
+    const node: LayoutNode = { kind: "text", content: "abc" };
+    const s = renderToScreen(node, 0, p);
+    expect(s.height).toBe(0);
+  });
+
+  it("damage is reset on the returned Screen", () => {
+    const p = pools();
+    const node: LayoutNode = { kind: "text", content: "hello" };
+    const s = renderToScreen(node, 5, p);
+    expect(s.damage).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Next slice of the cell-diff renderer (#160). Lays out a tree of `Box` / `Text` nodes into a `Screen` of the given width.

## What's here

- **`LayoutNode`** = `BoxNode | TextNode`. `TextNode` carries an optional style stack and hyperlink URI; `BoxNode` carries an array of children.
- **`renderToScreen(node, width, pools)`** walks the tree, stacks children vertically, returns a `Screen`. Height of the returned screen is derived from content.
- Long text lines wrap at the cell boundary. Grapheme split via `Intl.Segmenter`, cell width via `string-width`, so CJK and ZWJ emoji count as one rendered glyph occupying its real number of cells. A wide glyph gets a `CellWidth.SpacerTail` cell next to it; if it doesn't fit in the remaining columns, the row breaks before it.
- Style and hyperlink on a `TextNode` are interned through the pools and threaded through every cell the node produces — sets the diff layer up to compare cells purely by integer ids.

## What's not here yet

- React reconciler — next sub-phase.
- `flexDirection: "row"`, padding, margin, border — after that.
- Word-aware wrapping — Markdown's job, not the layout's.
- Patch emission / terminal serializer — Phase 3 / 4 of #160.

## Test plan

- [x] `npm run verify` — 1892/1892 (added 13 layout tests across text-only, box, style+hyperlink threading, wide-char, edge cases)
- [ ] CI green

## Refs

- #160 — RFC + phased plan
- prior PR #161 — Screen / Cell / pools that this layer reads from