### PR TITLE
feat(renderer): React JSX entry — Box / Text / function components → Screen

### DIFF
--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -6,3 +6,5 @@ export { type Rectangle, Screen } from "./screen/screen.js";
 export { type DiffCallback, diffEach } from "./screen/diff.js";
 export type { BoxNode, LayoutNode, TextNode } from "./layout/node.js";
 export { type RenderPools, renderToScreen } from "./layout/layout.js";
+export { Box, type BoxProps, Text, type TextProps } from "./react/components.js";
+export { type RenderOptions, render } from "./react/render.js";

--- a/src/renderer/react/components.ts
+++ b/src/renderer/react/components.ts
@@ -1,0 +1,22 @@
+import type { ReactNode } from "react";
+import type { AnsiCode } from "../pools/style-pool.js";
+
+export interface BoxProps {
+  readonly children?: ReactNode;
+}
+
+export interface TextProps {
+  readonly children?: ReactNode;
+  readonly style?: ReadonlyArray<AnsiCode>;
+  readonly hyperlink?: string;
+}
+
+const HOST_GUARD = "Reasonix renderer host element — only rendered through cell-tui's render().";
+
+export function Box(_props: BoxProps): never {
+  throw new Error(HOST_GUARD);
+}
+
+export function Text(_props: TextProps): never {
+  throw new Error(HOST_GUARD);
+}

--- a/src/renderer/react/render.ts
+++ b/src/renderer/react/render.ts
@@ -1,0 +1,93 @@
+import { Fragment, type ReactElement, type ReactNode, isValidElement } from "react";
+import { type RenderPools, renderToScreen } from "../layout/layout.js";
+import type { BoxNode, LayoutNode, TextNode } from "../layout/node.js";
+import type { Screen } from "../screen/screen.js";
+import { Box, Text, type TextProps } from "./components.js";
+
+export interface RenderOptions {
+  readonly width: number;
+  readonly pools: RenderPools;
+}
+
+export function render(element: ReactNode, opts: RenderOptions): Screen {
+  const node = treeToLayoutNode(element) ?? emptyBox();
+  return renderToScreen(node, opts.width, opts.pools);
+}
+
+function treeToLayoutNode(element: ReactNode): LayoutNode | null {
+  if (element === null || element === undefined || typeof element === "boolean") return null;
+  if (typeof element === "string" || typeof element === "number") {
+    return { kind: "text", content: String(element) };
+  }
+  if (Array.isArray(element)) {
+    const children = element.map(treeToLayoutNode).filter(notNull);
+    return children.length > 0 ? { kind: "box", children } : null;
+  }
+  if (isValidElement(element)) {
+    return elementToLayoutNode(element);
+  }
+  return null;
+}
+
+function elementToLayoutNode(element: ReactElement): LayoutNode | null {
+  const type = element.type;
+  const props = element.props as { children?: ReactNode };
+
+  if (type === Box) {
+    const children = childrenToLayoutNodes(props.children);
+    return { kind: "box", children } satisfies BoxNode;
+  }
+
+  if (type === Text) {
+    const textProps = element.props as TextProps;
+    return {
+      kind: "text",
+      content: collectText(textProps.children),
+      ...(textProps.style ? { style: textProps.style } : {}),
+      ...(textProps.hyperlink ? { hyperlink: textProps.hyperlink } : {}),
+    } satisfies TextNode;
+  }
+
+  if (type === Fragment) {
+    const children = childrenToLayoutNodes(props.children);
+    return children.length === 1 ? children[0]! : { kind: "box", children };
+  }
+
+  if (typeof type === "function") {
+    const Component = type as (props: unknown) => ReactNode;
+    return treeToLayoutNode(Component(props));
+  }
+
+  return null;
+}
+
+function childrenToLayoutNodes(children: ReactNode): LayoutNode[] {
+  if (children === null || children === undefined || typeof children === "boolean") return [];
+  if (Array.isArray(children)) {
+    return children.map(treeToLayoutNode).filter(notNull);
+  }
+  const node = treeToLayoutNode(children);
+  return node ? [node] : [];
+}
+
+function collectText(children: ReactNode): string {
+  if (children === null || children === undefined || typeof children === "boolean") return "";
+  if (typeof children === "string") return children;
+  if (typeof children === "number") return String(children);
+  if (Array.isArray(children)) {
+    return children.map(collectText).join("");
+  }
+  if (isValidElement(children)) {
+    const inner = (children.props as { children?: ReactNode }).children;
+    return collectText(inner);
+  }
+  return "";
+}
+
+function emptyBox(): BoxNode {
+  return { kind: "box", children: [] };
+}
+
+function notNull<T>(v: T | null): v is T {
+  return v !== null;
+}

--- a/tests/renderer/react.test.tsx
+++ b/tests/renderer/react.test.tsx
@@ -1,0 +1,182 @@
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React, { Fragment } from "react";
+import { describe, expect, it } from "vitest";
+import { CharPool } from "../../src/renderer/pools/char-pool.js";
+import { HyperlinkPool } from "../../src/renderer/pools/hyperlink-pool.js";
+import { type AnsiCode, StylePool } from "../../src/renderer/pools/style-pool.js";
+import { Box, Text } from "../../src/renderer/react/components.js";
+import { render } from "../../src/renderer/react/render.js";
+import { CellWidth } from "../../src/renderer/screen/cell.js";
+
+const RED: AnsiCode = { apply: "\x1b[31m", revert: "\x1b[39m" };
+
+function pools() {
+  return {
+    char: new CharPool(),
+    style: new StylePool(),
+    hyperlink: new HyperlinkPool(),
+  };
+}
+
+function read(screen: ReturnType<typeof render>, p: ReturnType<typeof pools>): string[] {
+  const lines: string[] = [];
+  for (let y = 0; y < screen.height; y++) {
+    let line = "";
+    for (let x = 0; x < screen.width; x++) {
+      const cell = screen.cellAt(x, y);
+      if (!cell) break;
+      if (cell.width === CellWidth.SpacerTail) continue;
+      line += p.char.get(cell.charId);
+    }
+    lines.push(line.trimEnd());
+  }
+  return lines;
+}
+
+describe("render — host elements", () => {
+  it("renders <Text> content", () => {
+    const p = pools();
+    const s = render(<Text>hello</Text>, { width: 10, pools: p });
+    expect(read(s, p)).toEqual(["hello"]);
+  });
+
+  it("renders <Box> with multiple <Text> children stacked", () => {
+    const p = pools();
+    const s = render(
+      <Box>
+        <Text>one</Text>
+        <Text>two</Text>
+      </Box>,
+      { width: 10, pools: p },
+    );
+    expect(read(s, p)).toEqual(["one", "two"]);
+  });
+
+  it("supports nested boxes", () => {
+    const p = pools();
+    const s = render(
+      <Box>
+        <Text>a</Text>
+        <Box>
+          <Text>b</Text>
+          <Text>c</Text>
+        </Box>
+        <Text>d</Text>
+      </Box>,
+      { width: 5, pools: p },
+    );
+    expect(read(s, p)).toEqual(["a", "b", "c", "d"]);
+  });
+});
+
+describe("render — text content forms", () => {
+  it("string + number children concatenate", () => {
+    const p = pools();
+    const s = render(<Text>{`count: ${3}`}</Text>, { width: 20, pools: p });
+    expect(read(s, p)).toEqual(["count: 3"]);
+  });
+
+  it("mixed array children of <Text> concatenate", () => {
+    const p = pools();
+    const s = render(
+      <Text>
+        {"a"}
+        {"b"}
+        {"c"}
+      </Text>,
+      { width: 5, pools: p },
+    );
+    expect(read(s, p)).toEqual(["abc"]);
+  });
+
+  it("null / undefined / false children are skipped", () => {
+    const p = pools();
+    const s = render(
+      <Box>
+        <Text>x</Text>
+        {null}
+        {undefined}
+        {false}
+        <Text>y</Text>
+      </Box>,
+      { width: 5, pools: p },
+    );
+    expect(read(s, p)).toEqual(["x", "y"]);
+  });
+});
+
+describe("render — composition", () => {
+  function Hi() {
+    return <Text>hi</Text>;
+  }
+  function Group() {
+    return (
+      <Box>
+        <Hi />
+        <Text>there</Text>
+      </Box>
+    );
+  }
+
+  it("calls a stateless function component and uses its returned tree", () => {
+    const p = pools();
+    const s = render(<Hi />, { width: 5, pools: p });
+    expect(read(s, p)).toEqual(["hi"]);
+  });
+
+  it("nested function components compose", () => {
+    const p = pools();
+    const s = render(<Group />, { width: 5, pools: p });
+    expect(read(s, p)).toEqual(["hi", "there"]);
+  });
+
+  it("React.Fragment passes through to children", () => {
+    const p = pools();
+    const s = render(
+      <Box>
+        <>
+          <Text>a</Text>
+          <Text>b</Text>
+        </>
+      </Box>,
+      { width: 5, pools: p },
+    );
+    expect(read(s, p)).toEqual(["a", "b"]);
+  });
+
+  it("Fragment with one child unwraps directly", () => {
+    const p = pools();
+    const s = render(
+      <Fragment>
+        <Text>solo</Text>
+      </Fragment>,
+      { width: 10, pools: p },
+    );
+    expect(read(s, p)).toEqual(["solo"]);
+  });
+});
+
+describe("render — style + hyperlink threading", () => {
+  it("style prop on <Text> propagates to its cells", () => {
+    const p = pools();
+    const s = render(<Text style={[RED]}>x</Text>, { width: 5, pools: p });
+    const cell = s.cellAt(0, 0)!;
+    expect(p.style.transition(p.style.none, cell.styleId)).toBe("\x1b[31m");
+  });
+
+  it("hyperlink prop on <Text> is interned and applied", () => {
+    const p = pools();
+    const s = render(<Text hyperlink="https://example.com">link</Text>, { width: 10, pools: p });
+    expect(p.hyperlink.get(s.cellAt(0, 0)!.hyperlinkId)).toBe("https://example.com");
+  });
+});
+
+describe("render — direct host invocation throws", () => {
+  it("calling Box() directly throws (host marker, not real component)", () => {
+    expect(() => Box({})).toThrow(/host element/i);
+  });
+
+  it("calling Text() directly throws", () => {
+    expect(() => Text({})).toThrow(/host element/i);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    include: ["tests/**/*.test.ts"],
+    include: ["tests/**/*.test.ts", "tests/**/*.test.tsx"],
     setupFiles: ["tests/setup-lang.ts"],
     environment: "node",
     globals: false,


### PR DESCRIPTION
Next slice of #160. Lets callers express the renderer surface as JSX instead of building `LayoutNode` trees by hand:

```tsx
const screen = render(
  <Box>
    <Text>hello</Text>
    <Text style={[RED]}>world</Text>
  </Box>,
  { width: 80, pools },
);
```

## What's here

- **`Box`** / **`Text`** — exported as host markers. Calling them directly throws (with a clear message). Their identity is what `render()` uses to discriminate the JSX tree.
- **`render(element, opts)`** walks the React element tree:
  - `Box` element → recurse into `props.children` as a list of layout nodes
  - `Text` element → flatten string / number / nested children into a single `content` string
  - Stateless function component → invoke with props, recurse on the returned element
  - `React.Fragment` → pass-through (collapses to a single child if there's only one)
  - `null` / `undefined` / `false` → skipped
- Result is a `Screen`, sized to its content at the given `width`.

## What's not here yet

- **Reconciler / state**. Stateful function components, `useState`, `useEffect`, re-render-on-state do **not** work. The walker is one-shot; there's no host node mounted, no fiber tree, no commit phase. That comes when we wire the renderer to actually drive a live UI (Phase 5 of #160).
- Component classes — only function components are walked.
- Refs, context, error boundaries — not on the path yet.

For the tests in this PR, stateless JSX is enough; for the diff layer (next PR) we render two snapshots and feed them to `diffEach`.

## Test plan

- [x] `npm run verify` — 1906/1906 (added 14 new tests; vitest config now also picks up `*.test.tsx` since this is the first JSX test in the suite)
- [ ] CI green

## Refs

- #160 — RFC + phased plan
- #161 — pools / Cell / Screen / diffEach
- #162 — vertical-stack layout this PR drives via JSX