### PR TITLE
feat(renderer): Box padding (top / bottom / left / right + shorthands)

### DIFF
--- a/src/renderer/layout/layout.ts
+++ b/src/renderer/layout/layout.ts
@@ -1,10 +1,10 @@
 import stringWidth from "string-width";
 import type { CharPool } from "../pools/char-pool.js";
 import type { HyperlinkPool } from "../pools/hyperlink-pool.js";
-import type { AnsiCode, StylePool } from "../pools/style-pool.js";
+import type { StylePool } from "../pools/style-pool.js";
 import { type Cell, CellWidth } from "../screen/cell.js";
 import { Screen } from "../screen/screen.js";
-import type { LayoutNode, TextNode } from "./node.js";
+import type { BoxNode, LayoutNode, TextNode } from "./node.js";
 
 export interface RenderPools {
   readonly char: CharPool;
@@ -16,12 +16,21 @@ interface TextRow {
   readonly graphemes: ReadonlyArray<{ glyph: string; width: number }>;
   readonly styleId: number;
   readonly hyperlinkId: number;
+  readonly leftPad: number;
 }
+
+const EMPTY_ROW: TextRow = {
+  graphemes: [],
+  styleId: 0,
+  hyperlinkId: 0,
+  leftPad: 0,
+};
 
 export function renderToScreen(node: LayoutNode, width: number, pools: RenderPools): Screen {
   const w = Math.max(0, width | 0);
   if (w === 0) return new Screen(0, 0);
-  const rows = collectRows(node, w, pools);
+  const rows: TextRow[] = [];
+  walk(node, w, 0, pools, rows);
   const screen = new Screen(w, rows.length);
   for (let y = 0; y < rows.length; y++) {
     blitRow(screen, rows[y]!, y, pools);
@@ -30,32 +39,60 @@ export function renderToScreen(node: LayoutNode, width: number, pools: RenderPoo
   return screen;
 }
 
-function collectRows(node: LayoutNode, width: number, pools: RenderPools): TextRow[] {
-  const out: TextRow[] = [];
-  walk(node, width, pools, out);
-  return out;
-}
-
-function walk(node: LayoutNode, width: number, pools: RenderPools, out: TextRow[]): void {
+function walk(
+  node: LayoutNode,
+  width: number,
+  leftPad: number,
+  pools: RenderPools,
+  out: TextRow[],
+): void {
   if (node.kind === "text") {
-    pushTextRows(node, width, pools, out);
+    pushTextRows(node, width, leftPad, pools, out);
     return;
   }
-  for (const child of node.children) walk(child, width, pools, out);
+  pushBoxRows(node, width, leftPad, pools, out);
 }
 
-function pushTextRows(node: TextNode, width: number, pools: RenderPools, out: TextRow[]): void {
+function pushBoxRows(
+  node: BoxNode,
+  width: number,
+  leftPad: number,
+  pools: RenderPools,
+  out: TextRow[],
+): void {
+  const padTop = clampPad(node.paddingTop);
+  const padBottom = clampPad(node.paddingBottom);
+  const padLeft = clampPad(node.paddingLeft);
+  const padRight = clampPad(node.paddingRight);
+  const innerWidth = Math.max(0, width - padLeft - padRight);
+  const innerLeftPad = leftPad + padLeft;
+
+  for (let i = 0; i < padTop; i++) out.push(EMPTY_ROW);
+  if (innerWidth > 0) {
+    for (const child of node.children) walk(child, innerWidth, innerLeftPad, pools, out);
+  }
+  for (let i = 0; i < padBottom; i++) out.push(EMPTY_ROW);
+}
+
+function pushTextRows(
+  node: TextNode,
+  width: number,
+  leftPad: number,
+  pools: RenderPools,
+  out: TextRow[],
+): void {
+  if (width <= 0) return;
   const styleId = node.style ? pools.style.intern(node.style) : pools.style.none;
   const hyperlinkId = pools.hyperlink.intern(node.hyperlink);
   const segmenter = getSegmenter();
   for (const line of node.content.split("\n")) {
     const wrapped = wrapLine(line, width, segmenter);
     if (wrapped.length === 0) {
-      out.push({ graphemes: [], styleId, hyperlinkId });
+      out.push({ graphemes: [], styleId, hyperlinkId, leftPad });
       continue;
     }
     for (const row of wrapped) {
-      out.push({ graphemes: row, styleId, hyperlinkId });
+      out.push({ graphemes: row, styleId, hyperlinkId, leftPad });
     }
   }
 }
@@ -87,7 +124,7 @@ function wrapLine(
 }
 
 function blitRow(screen: Screen, row: TextRow, y: number, pools: RenderPools): void {
-  let x = 0;
+  let x = row.leftPad;
   for (const { glyph, width } of row.graphemes) {
     if (x >= screen.width) break;
     const charId = pools.char.intern(glyph);
@@ -108,6 +145,12 @@ function blitRow(screen: Screen, row: TextRow, y: number, pools: RenderPools): v
     }
     x += width;
   }
+}
+
+function clampPad(v: number | undefined): number {
+  if (v === undefined) return 0;
+  if (!Number.isFinite(v)) return 0;
+  return Math.max(0, Math.floor(v));
 }
 
 let _segmenter: Intl.Segmenter | undefined;

--- a/src/renderer/layout/node.ts
+++ b/src/renderer/layout/node.ts
@@ -10,6 +10,10 @@ export interface TextNode {
 export interface BoxNode {
   readonly kind: "box";
   readonly children: ReadonlyArray<LayoutNode>;
+  readonly paddingTop?: number;
+  readonly paddingBottom?: number;
+  readonly paddingLeft?: number;
+  readonly paddingRight?: number;
 }
 
 export type LayoutNode = TextNode | BoxNode;

--- a/src/renderer/react/components.ts
+++ b/src/renderer/react/components.ts
@@ -3,6 +3,13 @@ import type { AnsiCode } from "../pools/style-pool.js";
 
 export interface BoxProps {
   readonly children?: ReactNode;
+  readonly paddingTop?: number;
+  readonly paddingBottom?: number;
+  readonly paddingLeft?: number;
+  readonly paddingRight?: number;
+  readonly paddingX?: number;
+  readonly paddingY?: number;
+  readonly padding?: number;
 }
 
 export interface TextProps {

--- a/src/renderer/react/render.ts
+++ b/src/renderer/react/render.ts
@@ -2,7 +2,7 @@ import { Fragment, type ReactElement, type ReactNode, isValidElement } from "rea
 import { type RenderPools, renderToScreen } from "../layout/layout.js";
 import type { BoxNode, LayoutNode, TextNode } from "../layout/node.js";
 import type { Screen } from "../screen/screen.js";
-import { Box, Text, type TextProps } from "./components.js";
+import { Box, type BoxProps, Text, type TextProps } from "./components.js";
 
 export interface RenderOptions {
   readonly width: number;
@@ -34,8 +34,10 @@ function elementToLayoutNode(element: ReactElement): LayoutNode | null {
   const props = element.props as { children?: ReactNode };
 
   if (type === Box) {
+    const boxProps = element.props as BoxProps;
     const children = childrenToLayoutNodes(props.children);
-    return { kind: "box", children } satisfies BoxNode;
+    const padding = resolvePadding(boxProps);
+    return { kind: "box", children, ...padding } satisfies BoxNode;
   }
 
   if (type === Text) {
@@ -86,6 +88,29 @@ function collectText(children: ReactNode): string {
 
 function emptyBox(): BoxNode {
   return { kind: "box", children: [] };
+}
+
+interface ResolvedPadding {
+  paddingTop?: number;
+  paddingBottom?: number;
+  paddingLeft?: number;
+  paddingRight?: number;
+}
+
+function resolvePadding(props: BoxProps): ResolvedPadding {
+  const all = props.padding;
+  const x = props.paddingX ?? all;
+  const y = props.paddingY ?? all;
+  const top = props.paddingTop ?? y;
+  const bottom = props.paddingBottom ?? y;
+  const left = props.paddingLeft ?? x;
+  const right = props.paddingRight ?? x;
+  const out: ResolvedPadding = {};
+  if (top !== undefined) out.paddingTop = top;
+  if (bottom !== undefined) out.paddingBottom = bottom;
+  if (left !== undefined) out.paddingLeft = left;
+  if (right !== undefined) out.paddingRight = right;
+  return out;
 }
 
 function notNull<T>(v: T | null): v is T {

--- a/tests/renderer/padding.test.tsx
+++ b/tests/renderer/padding.test.tsx
@@ -1,0 +1,166 @@
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { CharPool } from "../../src/renderer/pools/char-pool.js";
+import { HyperlinkPool } from "../../src/renderer/pools/hyperlink-pool.js";
+import { StylePool } from "../../src/renderer/pools/style-pool.js";
+import { Box, Text } from "../../src/renderer/react/components.js";
+import { render } from "../../src/renderer/react/render.js";
+import { CellWidth } from "../../src/renderer/screen/cell.js";
+
+function pools() {
+  return {
+    char: new CharPool(),
+    style: new StylePool(),
+    hyperlink: new HyperlinkPool(),
+  };
+}
+
+function read(screen: ReturnType<typeof render>, p: ReturnType<typeof pools>): string[] {
+  const lines: string[] = [];
+  for (let y = 0; y < screen.height; y++) {
+    let line = "";
+    for (let x = 0; x < screen.width; x++) {
+      const cell = screen.cellAt(x, y);
+      if (!cell) break;
+      if (cell.width === CellWidth.SpacerTail) continue;
+      line += p.char.get(cell.charId);
+    }
+    lines.push(line.replace(/ +$/, ""));
+  }
+  return lines;
+}
+
+describe("Box padding — vertical", () => {
+  it("paddingTop adds blank rows above content", () => {
+    const p = pools();
+    const s = render(
+      <Box paddingTop={2}>
+        <Text>hi</Text>
+      </Box>,
+      { width: 5, pools: p },
+    );
+    expect(read(s, p)).toEqual(["", "", "hi"]);
+  });
+
+  it("paddingBottom adds blank rows below content", () => {
+    const p = pools();
+    const s = render(
+      <Box paddingBottom={1}>
+        <Text>hi</Text>
+      </Box>,
+      { width: 5, pools: p },
+    );
+    expect(read(s, p)).toEqual(["hi", ""]);
+  });
+
+  it("paddingY shorthand sets top + bottom", () => {
+    const p = pools();
+    const s = render(
+      <Box paddingY={1}>
+        <Text>x</Text>
+      </Box>,
+      { width: 5, pools: p },
+    );
+    expect(read(s, p)).toEqual(["", "x", ""]);
+  });
+});
+
+describe("Box padding — horizontal", () => {
+  it("paddingLeft offsets each child row to the right", () => {
+    const p = pools();
+    const s = render(
+      <Box paddingLeft={3}>
+        <Text>hi</Text>
+      </Box>,
+      { width: 10, pools: p },
+    );
+    expect(read(s, p)).toEqual(["   hi"]);
+  });
+
+  it("paddingRight reduces effective width so wrapping triggers earlier", () => {
+    const p = pools();
+    const s = render(
+      <Box paddingRight={4}>
+        <Text>abcdef</Text>
+      </Box>,
+      { width: 8, pools: p },
+    );
+    // inner width = 8 - 4 = 4 → wraps after 'abcd'
+    expect(read(s, p)).toEqual(["abcd", "ef"]);
+  });
+
+  it("paddingX shorthand sets left + right", () => {
+    const p = pools();
+    const s = render(
+      <Box paddingX={2}>
+        <Text>hi</Text>
+      </Box>,
+      { width: 6, pools: p },
+    );
+    expect(read(s, p)).toEqual(["  hi"]);
+  });
+});
+
+describe("Box padding — combined", () => {
+  it("padding shorthand sets all four sides", () => {
+    const p = pools();
+    const s = render(
+      <Box padding={1}>
+        <Text>x</Text>
+      </Box>,
+      { width: 5, pools: p },
+    );
+    // 1 row top, then ' x' (1 col left) then bottom row
+    expect(read(s, p)).toEqual(["", " x", ""]);
+  });
+
+  it("specific side overrides shorthand", () => {
+    const p = pools();
+    const s = render(
+      <Box padding={1} paddingLeft={3}>
+        <Text>x</Text>
+      </Box>,
+      { width: 8, pools: p },
+    );
+    expect(read(s, p)).toEqual(["", "   x", ""]);
+  });
+
+  it("nested boxes accumulate padding offsets", () => {
+    const p = pools();
+    const s = render(
+      <Box paddingLeft={2}>
+        <Box paddingLeft={1}>
+          <Text>x</Text>
+        </Box>
+      </Box>,
+      { width: 10, pools: p },
+    );
+    expect(read(s, p)).toEqual(["   x"]);
+  });
+});
+
+describe("Box padding — degenerate cases", () => {
+  it("padding consuming all width yields no content rows but keeps top/bottom", () => {
+    const p = pools();
+    const s = render(
+      <Box paddingX={3} paddingY={1}>
+        <Text>hi</Text>
+      </Box>,
+      { width: 6, pools: p },
+    );
+    // inner width = 6 - 6 = 0 → text is dropped; only padding rows remain
+    expect(read(s, p)).toEqual(["", ""]);
+  });
+
+  it("negative or NaN padding clamps to 0", () => {
+    const p = pools();
+    const s = render(
+      <Box paddingLeft={-3} paddingTop={Number.NaN}>
+        <Text>hi</Text>
+      </Box>,
+      { width: 5, pools: p },
+    );
+    expect(read(s, p)).toEqual(["hi"]);
+  });
+});


### PR DESCRIPTION
Slice of #160 layout work. Adds padding to `Box`:

```tsx
<Box padding={1}>
  <Text>x</Text>
</Box>
```

renders as

```
   ← blank row from paddingTop
 x ← left-pad offset
   ← blank row from paddingBottom
```

## What's here

- `BoxNode` gains `paddingTop` / `paddingBottom` / `paddingLeft` / `paddingRight`.
- `<Box>` props gain the same four, plus shorthands `padding` (all four), `paddingX` (left + right), `paddingY` (top + bottom). Specific side wins over shorthand (`paddingLeft` beats `paddingX` beats `padding`).
- Layout walker pushes blank rows for top/bottom padding, threads a `leftPad` offset down so each row blits at `x = leftPad` instead of `x = 0`. Inner width = container width − paddingLeft − paddingRight, so children wrap accordingly.
- Negative / NaN padding clamps to 0.
- Inner width going to 0 (full-width padding) drops content but keeps top/bottom rows as the user asked for.

## What's not here yet

- `flexDirection: "row"` — next.
- `margin` (collapsing margins / spacer-between-children) — separate concern, defer.
- Border — separate PR after row direction.

## Test plan

- [x] `npm run verify` — 1917/1917 (added 11 padding-specific cases)
- [ ] CI green

## Refs

- #160 — RFC
- #161 / #162 / #163 — prior renderer slices