### PR TITLE
feat(renderer): flexDirection row + flexGrow

### DIFF
--- a/src/renderer/layout/layout.ts
+++ b/src/renderer/layout/layout.ts
@@ -12,89 +12,168 @@ export interface RenderPools {
   readonly hyperlink: HyperlinkPool;
 }
 
-interface TextRow {
+interface RowFragment {
   readonly graphemes: ReadonlyArray<{ glyph: string; width: number }>;
   readonly styleId: number;
   readonly hyperlinkId: number;
   readonly leftPad: number;
 }
 
-const EMPTY_ROW: TextRow = {
-  graphemes: [],
-  styleId: 0,
-  hyperlinkId: 0,
-  leftPad: 0,
-};
+type LayoutRows = RowFragment[][];
+
+interface Laid {
+  rows: LayoutRows;
+  width: number;
+}
 
 export function renderToScreen(node: LayoutNode, width: number, pools: RenderPools): Screen {
   const w = Math.max(0, width | 0);
   if (w === 0) return new Screen(0, 0);
-  const rows: TextRow[] = [];
-  walk(node, w, 0, pools, rows);
-  const screen = new Screen(w, rows.length);
-  for (let y = 0; y < rows.length; y++) {
-    blitRow(screen, rows[y]!, y, pools);
+  const laid = layout(node, w, pools);
+  const screen = new Screen(w, laid.rows.length);
+  for (let y = 0; y < laid.rows.length; y++) {
+    for (const frag of laid.rows[y]!) blitFragment(screen, frag, y, pools);
   }
   screen.resetDamage();
   return screen;
 }
 
-function walk(
-  node: LayoutNode,
-  width: number,
-  leftPad: number,
-  pools: RenderPools,
-  out: TextRow[],
-): void {
-  if (node.kind === "text") {
-    pushTextRows(node, width, leftPad, pools, out);
-    return;
-  }
-  pushBoxRows(node, width, leftPad, pools, out);
+function layout(node: LayoutNode, availableWidth: number, pools: RenderPools): Laid {
+  if (availableWidth <= 0) return { rows: [], width: 0 };
+  if (node.kind === "text") return layoutText(node, availableWidth, pools);
+  return layoutBox(node, availableWidth, pools);
 }
 
-function pushBoxRows(
-  node: BoxNode,
-  width: number,
-  leftPad: number,
-  pools: RenderPools,
-  out: TextRow[],
-): void {
+function layoutBox(node: BoxNode, availableWidth: number, pools: RenderPools): Laid {
   const padTop = clampPad(node.paddingTop);
   const padBottom = clampPad(node.paddingBottom);
   const padLeft = clampPad(node.paddingLeft);
   const padRight = clampPad(node.paddingRight);
-  const innerWidth = Math.max(0, width - padLeft - padRight);
-  const innerLeftPad = leftPad + padLeft;
+  const innerWidth = Math.max(0, availableWidth - padLeft - padRight);
 
-  for (let i = 0; i < padTop; i++) out.push(EMPTY_ROW);
-  if (innerWidth > 0) {
-    for (const child of node.children) walk(child, innerWidth, innerLeftPad, pools, out);
-  }
-  for (let i = 0; i < padBottom; i++) out.push(EMPTY_ROW);
+  const inner =
+    node.flexDirection === "row"
+      ? layoutRow(node, innerWidth, pools)
+      : layoutColumn(node, innerWidth, pools);
+
+  const shifted = shiftFragments(inner.rows, padLeft);
+  const top = blanks(padTop);
+  const bottom = blanks(padBottom);
+  return {
+    rows: [...top, ...shifted, ...bottom],
+    width: availableWidth,
+  };
 }
 
-function pushTextRows(
-  node: TextNode,
-  width: number,
-  leftPad: number,
-  pools: RenderPools,
-  out: TextRow[],
-): void {
-  if (width <= 0) return;
+function layoutColumn(node: BoxNode, innerWidth: number, pools: RenderPools): Laid {
+  const rows: LayoutRows = [];
+  for (const child of node.children) {
+    const laid = layout(child, innerWidth, pools);
+    rows.push(...laid.rows);
+  }
+  return { rows, width: innerWidth };
+}
+
+function layoutRow(node: BoxNode, innerWidth: number, pools: RenderPools): Laid {
+  if (innerWidth === 0 || node.children.length === 0) {
+    return { rows: [], width: innerWidth };
+  }
+  const allocations = allocateRowWidths(node.children, innerWidth);
+  const childResults = node.children.map((child, i) => layout(child, allocations[i] ?? 0, pools));
+
+  let xOffset = 0;
+  const merged: LayoutRows = [];
+  for (let i = 0; i < childResults.length; i++) {
+    const child = childResults[i]!;
+    const allocated = allocations[i] ?? 0;
+    for (let y = 0; y < child.rows.length; y++) {
+      while (merged.length <= y) merged.push([]);
+      for (const frag of child.rows[y]!) {
+        merged[y]!.push({ ...frag, leftPad: frag.leftPad + xOffset });
+      }
+    }
+    xOffset += allocated;
+  }
+  return { rows: merged, width: innerWidth };
+}
+
+function allocateRowWidths(children: ReadonlyArray<LayoutNode>, available: number): number[] {
+  const intrinsics = children.map((c) => Math.min(intrinsicWidth(c), available));
+  const grows = children.map((c) => (c.kind === "box" ? Math.max(0, c.flexGrow ?? 0) : 0));
+  const totalIntrinsic = intrinsics.reduce((s, w) => s + w, 0);
+
+  if (totalIntrinsic > available) {
+    const scale = available / totalIntrinsic;
+    const out = intrinsics.map((w) => Math.floor(w * scale));
+    let used = out.reduce((s, w) => s + w, 0);
+    for (let i = 0; used < available && i < out.length; i++) {
+      out[i]!++;
+      used++;
+    }
+    return out;
+  }
+
+  const slack = available - totalIntrinsic;
+  const totalGrow = grows.reduce((s, g) => s + g, 0);
+  if (slack === 0 || totalGrow === 0) return intrinsics;
+
+  const out = intrinsics.slice();
+  let distributed = 0;
+  for (let i = 0; i < out.length; i++) {
+    if (grows[i]! > 0) {
+      const add = Math.floor((slack * grows[i]!) / totalGrow);
+      out[i]! += add;
+      distributed += add;
+    }
+  }
+  for (let i = 0; distributed < slack && i < out.length; i++) {
+    if (grows[i]! > 0) {
+      out[i]!++;
+      distributed++;
+    }
+  }
+  return out;
+}
+
+function intrinsicWidth(node: LayoutNode): number {
+  if (node.kind === "text") {
+    let max = 0;
+    for (const line of node.content.split("\n")) {
+      const w = Math.max(0, stringWidth(line));
+      if (w > max) max = w;
+    }
+    return max;
+  }
+  const padLeft = clampPad(node.paddingLeft);
+  const padRight = clampPad(node.paddingRight);
+  if (node.children.length === 0) return padLeft + padRight;
+  if (node.flexDirection === "row") {
+    return padLeft + padRight + node.children.reduce((s, c) => s + intrinsicWidth(c), 0);
+  }
+  let max = 0;
+  for (const c of node.children) {
+    const w = intrinsicWidth(c);
+    if (w > max) max = w;
+  }
+  return padLeft + padRight + max;
+}
+
+function layoutText(node: TextNode, width: number, pools: RenderPools): Laid {
   const styleId = node.style ? pools.style.intern(node.style) : pools.style.none;
   const hyperlinkId = pools.hyperlink.intern(node.hyperlink);
   const segmenter = getSegmenter();
+  const rows: LayoutRows = [];
   for (const line of node.content.split("\n")) {
     const wrapped = wrapLine(line, width, segmenter);
     if (wrapped.length === 0) {
-      out.push({ graphemes: [], styleId, hyperlinkId, leftPad });
+      rows.push([{ graphemes: [], styleId, hyperlinkId, leftPad: 0 }]);
       continue;
     }
     for (const row of wrapped) {
-      out.push({ graphemes: row, styleId, hyperlinkId, leftPad });
+      rows.push([{ graphemes: row, styleId, hyperlinkId, leftPad: 0 }]);
     }
   }
+  return { rows, width };
 }
 
 function wrapLine(
@@ -123,23 +202,34 @@ function wrapLine(
   return rows;
 }
 
-function blitRow(screen: Screen, row: TextRow, y: number, pools: RenderPools): void {
-  let x = row.leftPad;
-  for (const { glyph, width } of row.graphemes) {
+function shiftFragments(rows: LayoutRows, dx: number): LayoutRows {
+  if (dx === 0) return rows;
+  return rows.map((row) => row.map((frag) => ({ ...frag, leftPad: frag.leftPad + dx })));
+}
+
+function blanks(n: number): LayoutRows {
+  const out: LayoutRows = [];
+  for (let i = 0; i < n; i++) out.push([]);
+  return out;
+}
+
+function blitFragment(screen: Screen, frag: RowFragment, y: number, pools: RenderPools): void {
+  let x = frag.leftPad;
+  for (const { glyph, width } of frag.graphemes) {
     if (x >= screen.width) break;
     const charId = pools.char.intern(glyph);
     const cell: Cell = {
       charId,
-      styleId: row.styleId,
-      hyperlinkId: row.hyperlinkId,
+      styleId: frag.styleId,
+      hyperlinkId: frag.hyperlinkId,
       width: width === 2 ? CellWidth.Wide : CellWidth.Single,
     };
     screen.writeCell(x, y, cell);
     if (width === 2 && x + 1 < screen.width) {
       screen.writeCell(x + 1, y, {
         charId: 1,
-        styleId: row.styleId,
-        hyperlinkId: row.hyperlinkId,
+        styleId: frag.styleId,
+        hyperlinkId: frag.hyperlinkId,
         width: CellWidth.SpacerTail,
       });
     }

--- a/src/renderer/layout/node.ts
+++ b/src/renderer/layout/node.ts
@@ -10,6 +10,8 @@ export interface TextNode {
 export interface BoxNode {
   readonly kind: "box";
   readonly children: ReadonlyArray<LayoutNode>;
+  readonly flexDirection?: "column" | "row";
+  readonly flexGrow?: number;
   readonly paddingTop?: number;
   readonly paddingBottom?: number;
   readonly paddingLeft?: number;

--- a/src/renderer/react/components.ts
+++ b/src/renderer/react/components.ts
@@ -3,6 +3,8 @@ import type { AnsiCode } from "../pools/style-pool.js";
 
 export interface BoxProps {
   readonly children?: ReactNode;
+  readonly flexDirection?: "column" | "row";
+  readonly flexGrow?: number;
   readonly paddingTop?: number;
   readonly paddingBottom?: number;
   readonly paddingLeft?: number;

--- a/src/renderer/react/render.ts
+++ b/src/renderer/react/render.ts
@@ -37,7 +37,10 @@ function elementToLayoutNode(element: ReactElement): LayoutNode | null {
     const boxProps = element.props as BoxProps;
     const children = childrenToLayoutNodes(props.children);
     const padding = resolvePadding(boxProps);
-    return { kind: "box", children, ...padding } satisfies BoxNode;
+    const flex: { flexDirection?: "column" | "row"; flexGrow?: number } = {};
+    if (boxProps.flexDirection !== undefined) flex.flexDirection = boxProps.flexDirection;
+    if (boxProps.flexGrow !== undefined) flex.flexGrow = boxProps.flexGrow;
+    return { kind: "box", children, ...flex, ...padding } satisfies BoxNode;
   }
 
   if (type === Text) {

--- a/tests/renderer/flex-row.test.tsx
+++ b/tests/renderer/flex-row.test.tsx
@@ -1,0 +1,163 @@
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { CharPool } from "../../src/renderer/pools/char-pool.js";
+import { HyperlinkPool } from "../../src/renderer/pools/hyperlink-pool.js";
+import { StylePool } from "../../src/renderer/pools/style-pool.js";
+import { Box, Text } from "../../src/renderer/react/components.js";
+import { render } from "../../src/renderer/react/render.js";
+import { CellWidth } from "../../src/renderer/screen/cell.js";
+
+function pools() {
+  return {
+    char: new CharPool(),
+    style: new StylePool(),
+    hyperlink: new HyperlinkPool(),
+  };
+}
+
+function read(screen: ReturnType<typeof render>, p: ReturnType<typeof pools>): string[] {
+  const lines: string[] = [];
+  for (let y = 0; y < screen.height; y++) {
+    let line = "";
+    for (let x = 0; x < screen.width; x++) {
+      const cell = screen.cellAt(x, y);
+      if (!cell) break;
+      if (cell.width === CellWidth.SpacerTail) continue;
+      line += p.char.get(cell.charId);
+    }
+    lines.push(line.replace(/ +$/, ""));
+  }
+  return lines;
+}
+
+describe("flex direction row", () => {
+  it("places sibling Texts side-by-side at intrinsic widths", () => {
+    const p = pools();
+    const s = render(
+      <Box flexDirection="row">
+        <Text>hi </Text>
+        <Text>there</Text>
+      </Box>,
+      { width: 20, pools: p },
+    );
+    expect(read(s, p)).toEqual(["hi there"]);
+  });
+
+  it("aligns children of differing heights at the top, leaving blanks on the right", () => {
+    const p = pools();
+    const s = render(
+      <Box flexDirection="row">
+        <Text>{"a\nb\nc"}</Text>
+        <Text>X</Text>
+      </Box>,
+      { width: 5, pools: p },
+    );
+    expect(read(s, p)).toEqual(["aX", "b", "c"]);
+  });
+
+  it("nested column inside row stacks vertically within its slot", () => {
+    const p = pools();
+    const s = render(
+      <Box flexDirection="row">
+        <Box>
+          <Text>1</Text>
+          <Text>2</Text>
+        </Box>
+        <Text>|R</Text>
+      </Box>,
+      { width: 10, pools: p },
+    );
+    expect(read(s, p)).toEqual(["1|R", "2"]);
+  });
+
+  it("scales children proportionally when intrinsic widths exceed available", () => {
+    const p = pools();
+    const s = render(
+      <Box flexDirection="row">
+        <Text>aaaa</Text>
+        <Text>bbbb</Text>
+      </Box>,
+      { width: 4, pools: p },
+    );
+    // Each child gets 2 cols (4/2). Text wraps to fit.
+    expect(read(s, p)).toEqual(["aabb", "aabb"]);
+  });
+});
+
+describe("flexGrow — distributes leftover space", () => {
+  it("flexGrow=1 spacer between fixed children fills the gap", () => {
+    const p = pools();
+    const s = render(
+      <Box flexDirection="row">
+        <Text>L</Text>
+        <Box flexGrow={1} />
+        <Text>R</Text>
+      </Box>,
+      { width: 10, pools: p },
+    );
+    expect(read(s, p)).toEqual(["L        R"]);
+  });
+
+  it("two flexGrow children split slack proportionally", () => {
+    const p = pools();
+    const s = render(
+      <Box flexDirection="row">
+        <Box flexGrow={1}>
+          <Text>aaa</Text>
+        </Box>
+        <Box flexGrow={3}>
+          <Text>bbbbbbbbb</Text>
+        </Box>
+      </Box>,
+      { width: 12, pools: p },
+    );
+    // Both children request their intrinsic widths first (3, 9 = 12), leaving 0 slack.
+    expect(read(s, p)).toEqual(["aaabbbbbbbbb"]);
+  });
+
+  it("flexGrow only kicks in when there is slack", () => {
+    const p = pools();
+    const s = render(
+      <Box flexDirection="row">
+        <Text>fixed</Text>
+        <Box flexGrow={1}>
+          <Text>x</Text>
+        </Box>
+      </Box>,
+      { width: 10, pools: p },
+    );
+    // 'fixed' takes 5, x takes 1, slack = 4 distributed to flexGrow=1 → grows to 5
+    expect(read(s, p)).toEqual(["fixedx"]);
+  });
+});
+
+describe("flex row + padding", () => {
+  it("paddingX of an outer row Box reduces the available row width", () => {
+    const p = pools();
+    const s = render(
+      <Box flexDirection="row" paddingX={1}>
+        <Text>L</Text>
+        <Box flexGrow={1} />
+        <Text>R</Text>
+      </Box>,
+      { width: 10, pools: p },
+    );
+    // paddingLeft = paddingRight = 1 → inner = 8 → "L      R", shifted by 1
+    expect(read(s, p)).toEqual([" L      R"]);
+  });
+});
+
+describe("default direction is column", () => {
+  it("Box without flexDirection prop still stacks children vertically", () => {
+    const p = pools();
+    const s = render(
+      <Box>
+        <Text>top</Text>
+        <Text>bottom</Text>
+      </Box>,
+      { width: 10, pools: p },
+    );
+    expect(read(s, p)).toEqual(["top", "bottom"]);
+  });
+});


### PR DESCRIPTION
Layout slice of #160. Adds horizontal flow + flex spacer.

```tsx
<Box flexDirection="row">
  <Pill label="OUTPUT" />
  <Pill label="v4-flash" />
  <Box flexGrow={1} />
  <Text>0.5s</Text>
</Box>
```

renders as

```
[OUTPUT][v4-flash]                                            0.5s
```

## Refactor

The previous "one fragment per row" output shape couldn't express row direction — sibling children share visual rows at different x offsets. Reworked the layout pass to return `RowFragment[][]` (each y holds a list of fragments), so multiple children can contribute to the same row without overwriting each other.

Column direction is unchanged in behavior; the implementation just goes through the new structure.

## Width allocation

For row direction:

1. Compute each child's `intrinsicWidth` (max line width for text; sum / max of children for box, depending on its own direction; plus its own padding).
2. If `sum(intrinsics) ≤ available`: each child gets its intrinsic width, leftover is distributed by `flexGrow` proportions.
3. If `sum(intrinsics) > available`: allocations scale down proportionally and content wraps inside the narrower slots.

`flexGrow` defaults to 0 (no growth). The most useful case — `<Box flexGrow={1} />` as a spacer between fixed content — falls out naturally.

## Test plan

- [x] `npm run verify` — 1926/1926 (added 9 new flex-row + flexGrow + nested-direction cases on top of existing layout / padding / react tests)
- [ ] CI green

## Refs

- #160 — RFC
- #161 / #162 / #163 / #164 — prior renderer slices this builds on