### PR TITLE
feat(renderer): Box borders — presets + custom glyphs + per-side colors

### DIFF
--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -4,6 +4,7 @@ export { StylePool, type AnsiCode } from "./pools/style-pool.js";
 export { type Cell, CellWidth, EMPTY_CELL, cellsEqual } from "./screen/cell.js";
 export { type Rectangle, Screen } from "./screen/screen.js";
 export { type DiffCallback, diffEach } from "./screen/diff.js";
+export type { BorderStyle, BorderStyleName } from "./layout/borders.js";
 export type { BoxNode, LayoutNode, TextNode } from "./layout/node.js";
 export { type RenderPools, renderToScreen } from "./layout/layout.js";
 export { Box, type BoxProps, Text, type TextProps } from "./react/components.js";

--- a/src/renderer/layout/borders.ts
+++ b/src/renderer/layout/borders.ts
@@ -1,0 +1,73 @@
+export interface BorderStyle {
+  readonly topLeft: string;
+  readonly top: string;
+  readonly topRight: string;
+  readonly left: string;
+  readonly right: string;
+  readonly bottomLeft: string;
+  readonly bottom: string;
+  readonly bottomRight: string;
+}
+
+export type BorderStyleName = "single" | "double" | "round" | "bold" | "ascii";
+
+const BORDER_PRESETS: Record<BorderStyleName, BorderStyle> = {
+  single: {
+    topLeft: "┌",
+    top: "─",
+    topRight: "┐",
+    left: "│",
+    right: "│",
+    bottomLeft: "└",
+    bottom: "─",
+    bottomRight: "┘",
+  },
+  double: {
+    topLeft: "╔",
+    top: "═",
+    topRight: "╗",
+    left: "║",
+    right: "║",
+    bottomLeft: "╚",
+    bottom: "═",
+    bottomRight: "╝",
+  },
+  round: {
+    topLeft: "╭",
+    top: "─",
+    topRight: "╮",
+    left: "│",
+    right: "│",
+    bottomLeft: "╰",
+    bottom: "─",
+    bottomRight: "╯",
+  },
+  bold: {
+    topLeft: "┏",
+    top: "━",
+    topRight: "┓",
+    left: "┃",
+    right: "┃",
+    bottomLeft: "┗",
+    bottom: "━",
+    bottomRight: "┛",
+  },
+  ascii: {
+    topLeft: "+",
+    top: "-",
+    topRight: "+",
+    left: "|",
+    right: "|",
+    bottomLeft: "+",
+    bottom: "-",
+    bottomRight: "+",
+  },
+};
+
+export function resolveBorderStyle(
+  style: BorderStyle | BorderStyleName | undefined,
+): BorderStyle | undefined {
+  if (style === undefined) return undefined;
+  if (typeof style === "string") return BORDER_PRESETS[style];
+  return style;
+}

--- a/src/renderer/layout/layout.ts
+++ b/src/renderer/layout/layout.ts
@@ -1,9 +1,10 @@
 import stringWidth from "string-width";
 import type { CharPool } from "../pools/char-pool.js";
 import type { HyperlinkPool } from "../pools/hyperlink-pool.js";
-import type { StylePool } from "../pools/style-pool.js";
+import type { AnsiCode, StylePool } from "../pools/style-pool.js";
 import { type Cell, CellWidth } from "../screen/cell.js";
 import { Screen } from "../screen/screen.js";
+import { type BorderStyle, resolveBorderStyle } from "./borders.js";
 import type { BoxNode, LayoutNode, TextNode } from "./node.js";
 
 export interface RenderPools {
@@ -45,24 +46,121 @@ function layout(node: LayoutNode, availableWidth: number, pools: RenderPools): L
 }
 
 function layoutBox(node: BoxNode, availableWidth: number, pools: RenderPools): Laid {
+  const border = resolveBorderStyle(node.borderStyle);
+  const useTop = border !== undefined && node.borderTop !== false;
+  const useBottom = border !== undefined && node.borderBottom !== false;
+  const useLeft = border !== undefined && node.borderLeft !== false;
+  const useRight = border !== undefined && node.borderRight !== false;
+
   const padTop = clampPad(node.paddingTop);
   const padBottom = clampPad(node.paddingBottom);
   const padLeft = clampPad(node.paddingLeft);
   const padRight = clampPad(node.paddingRight);
-  const innerWidth = Math.max(0, availableWidth - padLeft - padRight);
+  const horizBorder = (useLeft ? 1 : 0) + (useRight ? 1 : 0);
+  const innerWidth = Math.max(0, availableWidth - horizBorder - padLeft - padRight);
 
   const inner =
     node.flexDirection === "row"
       ? layoutRow(node, innerWidth, pools)
       : layoutColumn(node, innerWidth, pools);
 
-  const shifted = shiftFragments(inner.rows, padLeft);
-  const top = blanks(padTop);
-  const bottom = blanks(padBottom);
+  const contentRows: LayoutRows = [
+    ...blanks(padTop),
+    ...shiftFragments(inner.rows, padLeft + (useLeft ? 1 : 0)),
+    ...blanks(padBottom),
+  ];
+
+  if (useLeft || useRight) {
+    const leftStyle = node.borderLeftColor ?? node.borderColor;
+    const rightStyle = node.borderRightColor ?? node.borderColor;
+    const leftStyleId = leftStyle ? pools.style.intern(leftStyle) : pools.style.none;
+    const rightStyleId = rightStyle ? pools.style.intern(rightStyle) : pools.style.none;
+    for (let i = 0; i < contentRows.length; i++) {
+      const row = contentRows[i]!;
+      const next: typeof row = [];
+      if (useLeft && border) {
+        next.push(makeBorderFragment(border.left, 0, leftStyleId));
+      }
+      next.push(...row);
+      if (useRight && border) {
+        next.push(makeBorderFragment(border.right, availableWidth - 1, rightStyleId));
+      }
+      contentRows[i] = next;
+    }
+  }
+
+  const allRows: LayoutRows = [];
+  if (useTop && border) {
+    allRows.push(
+      makeBorderEdge(
+        border,
+        "top",
+        availableWidth,
+        useLeft,
+        useRight,
+        node.borderTopColor ?? node.borderColor,
+        pools,
+      ),
+    );
+  }
+  allRows.push(...contentRows);
+  if (useBottom && border) {
+    allRows.push(
+      makeBorderEdge(
+        border,
+        "bottom",
+        availableWidth,
+        useLeft,
+        useRight,
+        node.borderBottomColor ?? node.borderColor,
+        pools,
+      ),
+    );
+  }
+
+  return { rows: allRows, width: availableWidth };
+}
+
+function makeBorderFragment(glyph: string, leftPad: number, styleId: number): RowFragment {
+  const w = Math.max(1, stringWidth(glyph));
   return {
-    rows: [...top, ...shifted, ...bottom],
-    width: availableWidth,
+    graphemes: [{ glyph, width: w }],
+    styleId,
+    hyperlinkId: 0,
+    leftPad,
   };
+}
+
+function makeBorderEdge(
+  style: BorderStyle,
+  side: "top" | "bottom",
+  width: number,
+  useLeft: boolean,
+  useRight: boolean,
+  color: ReadonlyArray<AnsiCode> | undefined,
+  pools: RenderPools,
+): RowFragment[] {
+  if (width <= 0) return [];
+  const corners =
+    side === "top" ? [style.topLeft, style.topRight] : [style.bottomLeft, style.bottomRight];
+  const edge = side === "top" ? style.top : style.bottom;
+  const styleId = color ? pools.style.intern(color) : pools.style.none;
+  const graphemes: Array<{ glyph: string; width: number }> = [];
+  for (let x = 0; x < width; x++) {
+    let glyph: string;
+    if (x === 0 && useLeft) glyph = corners[0]!;
+    else if (x === width - 1 && useRight) glyph = corners[1]!;
+    else glyph = edge;
+    graphemes.push({ glyph, width: Math.max(1, stringWidth(glyph)) });
+  }
+  return [
+    {
+      graphemes,
+      styleId,
+      hyperlinkId: 0,
+      leftPad: 0,
+    },
+  ];
 }
 
 function layoutColumn(node: BoxNode, innerWidth: number, pools: RenderPools): Laid {
@@ -146,16 +244,19 @@ function intrinsicWidth(node: LayoutNode): number {
   }
   const padLeft = clampPad(node.paddingLeft);
   const padRight = clampPad(node.paddingRight);
-  if (node.children.length === 0) return padLeft + padRight;
+  const border = resolveBorderStyle(node.borderStyle);
+  const borderH =
+    (border && node.borderLeft !== false ? 1 : 0) + (border && node.borderRight !== false ? 1 : 0);
+  if (node.children.length === 0) return padLeft + padRight + borderH;
   if (node.flexDirection === "row") {
-    return padLeft + padRight + node.children.reduce((s, c) => s + intrinsicWidth(c), 0);
+    return padLeft + padRight + borderH + node.children.reduce((s, c) => s + intrinsicWidth(c), 0);
   }
   let max = 0;
   for (const c of node.children) {
     const w = intrinsicWidth(c);
     if (w > max) max = w;
   }
-  return padLeft + padRight + max;
+  return padLeft + padRight + borderH + max;
 }
 
 function layoutText(node: TextNode, width: number, pools: RenderPools): Laid {

--- a/src/renderer/layout/node.ts
+++ b/src/renderer/layout/node.ts
@@ -1,4 +1,5 @@
 import type { AnsiCode } from "../pools/style-pool.js";
+import type { BorderStyle, BorderStyleName } from "./borders.js";
 
 export interface TextNode {
   readonly kind: "text";
@@ -16,6 +17,16 @@ export interface BoxNode {
   readonly paddingBottom?: number;
   readonly paddingLeft?: number;
   readonly paddingRight?: number;
+  readonly borderStyle?: BorderStyle | BorderStyleName;
+  readonly borderTop?: boolean;
+  readonly borderBottom?: boolean;
+  readonly borderLeft?: boolean;
+  readonly borderRight?: boolean;
+  readonly borderColor?: ReadonlyArray<AnsiCode>;
+  readonly borderTopColor?: ReadonlyArray<AnsiCode>;
+  readonly borderBottomColor?: ReadonlyArray<AnsiCode>;
+  readonly borderLeftColor?: ReadonlyArray<AnsiCode>;
+  readonly borderRightColor?: ReadonlyArray<AnsiCode>;
 }
 
 export type LayoutNode = TextNode | BoxNode;

--- a/src/renderer/react/components.ts
+++ b/src/renderer/react/components.ts
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import type { BorderStyle, BorderStyleName } from "../layout/borders.js";
 import type { AnsiCode } from "../pools/style-pool.js";
 
 export interface BoxProps {
@@ -12,6 +13,16 @@ export interface BoxProps {
   readonly paddingX?: number;
   readonly paddingY?: number;
   readonly padding?: number;
+  readonly borderStyle?: BorderStyle | BorderStyleName;
+  readonly borderTop?: boolean;
+  readonly borderBottom?: boolean;
+  readonly borderLeft?: boolean;
+  readonly borderRight?: boolean;
+  readonly borderColor?: ReadonlyArray<AnsiCode>;
+  readonly borderTopColor?: ReadonlyArray<AnsiCode>;
+  readonly borderBottomColor?: ReadonlyArray<AnsiCode>;
+  readonly borderLeftColor?: ReadonlyArray<AnsiCode>;
+  readonly borderRightColor?: ReadonlyArray<AnsiCode>;
 }
 
 export interface TextProps {

--- a/src/renderer/react/render.ts
+++ b/src/renderer/react/render.ts
@@ -40,7 +40,8 @@ function elementToLayoutNode(element: ReactElement): LayoutNode | null {
     const flex: { flexDirection?: "column" | "row"; flexGrow?: number } = {};
     if (boxProps.flexDirection !== undefined) flex.flexDirection = boxProps.flexDirection;
     if (boxProps.flexGrow !== undefined) flex.flexGrow = boxProps.flexGrow;
-    return { kind: "box", children, ...flex, ...padding } satisfies BoxNode;
+    const border = resolveBorder(boxProps);
+    return { kind: "box", children, ...flex, ...padding, ...border } satisfies BoxNode;
   }
 
   if (type === Text) {
@@ -98,6 +99,34 @@ interface ResolvedPadding {
   paddingBottom?: number;
   paddingLeft?: number;
   paddingRight?: number;
+}
+
+interface ResolvedBorder {
+  borderStyle?: BoxProps["borderStyle"];
+  borderTop?: boolean;
+  borderBottom?: boolean;
+  borderLeft?: boolean;
+  borderRight?: boolean;
+  borderColor?: BoxProps["borderColor"];
+  borderTopColor?: BoxProps["borderTopColor"];
+  borderBottomColor?: BoxProps["borderBottomColor"];
+  borderLeftColor?: BoxProps["borderLeftColor"];
+  borderRightColor?: BoxProps["borderRightColor"];
+}
+
+function resolveBorder(props: BoxProps): ResolvedBorder {
+  const out: ResolvedBorder = {};
+  if (props.borderStyle !== undefined) out.borderStyle = props.borderStyle;
+  if (props.borderTop !== undefined) out.borderTop = props.borderTop;
+  if (props.borderBottom !== undefined) out.borderBottom = props.borderBottom;
+  if (props.borderLeft !== undefined) out.borderLeft = props.borderLeft;
+  if (props.borderRight !== undefined) out.borderRight = props.borderRight;
+  if (props.borderColor !== undefined) out.borderColor = props.borderColor;
+  if (props.borderTopColor !== undefined) out.borderTopColor = props.borderTopColor;
+  if (props.borderBottomColor !== undefined) out.borderBottomColor = props.borderBottomColor;
+  if (props.borderLeftColor !== undefined) out.borderLeftColor = props.borderLeftColor;
+  if (props.borderRightColor !== undefined) out.borderRightColor = props.borderRightColor;
+  return out;
 }
 
 function resolvePadding(props: BoxProps): ResolvedPadding {

--- a/tests/renderer/border.test.tsx
+++ b/tests/renderer/border.test.tsx
@@ -1,0 +1,173 @@
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React from "react";
+import { describe, expect, it } from "vitest";
+import type { BorderStyle } from "../../src/renderer/layout/borders.js";
+import { CharPool } from "../../src/renderer/pools/char-pool.js";
+import { HyperlinkPool } from "../../src/renderer/pools/hyperlink-pool.js";
+import { type AnsiCode, StylePool } from "../../src/renderer/pools/style-pool.js";
+import { Box, Text } from "../../src/renderer/react/components.js";
+import { render } from "../../src/renderer/react/render.js";
+import { CellWidth } from "../../src/renderer/screen/cell.js";
+
+const RED: AnsiCode = { apply: "\x1b[31m", revert: "\x1b[39m" };
+
+function pools() {
+  return {
+    char: new CharPool(),
+    style: new StylePool(),
+    hyperlink: new HyperlinkPool(),
+  };
+}
+
+function read(screen: ReturnType<typeof render>, p: ReturnType<typeof pools>): string[] {
+  const lines: string[] = [];
+  for (let y = 0; y < screen.height; y++) {
+    let line = "";
+    for (let x = 0; x < screen.width; x++) {
+      const cell = screen.cellAt(x, y);
+      if (!cell) break;
+      if (cell.width === CellWidth.SpacerTail) continue;
+      line += p.char.get(cell.charId);
+    }
+    lines.push(line.replace(/ +$/, ""));
+  }
+  return lines;
+}
+
+describe("Box border — preset 'single'", () => {
+  it("draws a complete frame around content", () => {
+    const p = pools();
+    const s = render(
+      <Box borderStyle="single">
+        <Text>hi</Text>
+      </Box>,
+      { width: 6, pools: p },
+    );
+    expect(read(s, p)).toEqual(["┌────┐", "│hi  │", "└────┘"]);
+  });
+
+  it("disabling a single side suppresses just that edge", () => {
+    const p = pools();
+    const s = render(
+      <Box borderStyle="single" borderTop={false} borderRight={false} borderBottom={false}>
+        <Text>x</Text>
+      </Box>,
+      { width: 5, pools: p },
+    );
+    expect(read(s, p)).toEqual(["│x"]);
+  });
+});
+
+describe("Box border — preset 'round'", () => {
+  it("uses round corner glyphs", () => {
+    const p = pools();
+    const s = render(
+      <Box borderStyle="round">
+        <Text>x</Text>
+      </Box>,
+      { width: 5, pools: p },
+    );
+    expect(read(s, p)).toEqual(["╭───╮", "│x  │", "╰───╯"]);
+  });
+});
+
+describe("Box border — custom style object", () => {
+  it("CardBox-style left bar with whitespace corners", () => {
+    const p = pools();
+    const BAR: BorderStyle = {
+      topLeft: " ",
+      top: " ",
+      topRight: " ",
+      right: " ",
+      bottomLeft: " ",
+      bottom: " ",
+      bottomRight: " ",
+      left: "▎",
+    };
+    const s = render(
+      <Box borderStyle={BAR} borderTop={false} borderRight={false} borderBottom={false}>
+        <Text>{"line1\nline2"}</Text>
+      </Box>,
+      { width: 8, pools: p },
+    );
+    expect(read(s, p)).toEqual(["▎line1", "▎line2"]);
+  });
+});
+
+describe("Box border — width / wrapping interaction", () => {
+  it("inner content wraps to width minus borders", () => {
+    const p = pools();
+    const s = render(
+      <Box borderStyle="single">
+        <Text>abcdef</Text>
+      </Box>,
+      { width: 6, pools: p },
+    );
+    // total width 6, borders eat 2 → inner = 4
+    expect(read(s, p)).toEqual(["┌────┐", "│abcd│", "│ef  │", "└────┘"]);
+  });
+
+  it("border + padding compose: padding is inside the border", () => {
+    const p = pools();
+    const s = render(
+      <Box borderStyle="single" paddingX={1}>
+        <Text>x</Text>
+      </Box>,
+      { width: 7, pools: p },
+    );
+    expect(read(s, p)).toEqual(["┌─────┐", "│ x   │", "└─────┘"]);
+  });
+});
+
+describe("Box border — color threading", () => {
+  it("borderColor applies to all borders", () => {
+    const p = pools();
+    const s = render(
+      <Box borderStyle="single" borderColor={[RED]}>
+        <Text>x</Text>
+      </Box>,
+      { width: 5, pools: p },
+    );
+    const topLeft = s.cellAt(0, 0)!;
+    expect(p.style.transition(p.style.none, topLeft.styleId)).toBe("\x1b[31m");
+    const sideBar = s.cellAt(0, 1)!;
+    expect(p.style.transition(p.style.none, sideBar.styleId)).toBe("\x1b[31m");
+  });
+
+  it("per-side color overrides the catch-all", () => {
+    const p = pools();
+    const BLUE: AnsiCode = { apply: "\x1b[34m", revert: "\x1b[39m" };
+    const s = render(
+      <Box borderStyle="single" borderColor={[RED]} borderLeftColor={[BLUE]}>
+        <Text>x</Text>
+      </Box>,
+      { width: 5, pools: p },
+    );
+    const leftBar = s.cellAt(0, 1)!;
+    expect(p.style.transition(p.style.none, leftBar.styleId)).toBe("\x1b[34m");
+  });
+});
+
+describe("Box border — degenerate cases", () => {
+  it("no borderStyle = no borders even if borderTop is true", () => {
+    const p = pools();
+    const s = render(
+      <Box borderTop={true}>
+        <Text>x</Text>
+      </Box>,
+      { width: 5, pools: p },
+    );
+    expect(read(s, p)).toEqual(["x"]);
+  });
+
+  it("border on a width-1 box collapses inner area to 0 but still renders edges if both sides set", () => {
+    const p = pools();
+    const s = render(
+      <Box borderStyle="single">
+        <Text>x</Text>
+      </Box>,
+      { width: 2, pools: p },
+    );
+    expect(read(s, p)).toEqual(["┌┐", "└┘"]);
+  });
+});


### PR DESCRIPTION
Closes out the layout feature surface for #160.

```tsx
<Box borderStyle="single">
  <Text>hi</Text>
</Box>
```

renders as

```
┌────┐
│hi  │
└────┘
```

## What's here

- **Five preset styles**: `"single"`, `"double"`, `"round"`, `"bold"`, `"ascii"` — full Unicode box-drawing where the terminal supports it, ASCII fallback when it doesn't.
- **Custom glyph objects**: `borderStyle={{ topLeft, top, topRight, left, right, bottomLeft, bottom, bottomRight }}` — used for the existing CardBox-style left accent (`▎`) where corners and other edges are whitespace.
- **Per-side toggles**: `borderTop` / `borderBottom` / `borderLeft` / `borderRight`. Default-on when `borderStyle` is set, default-off otherwise. Setting `borderTop={false}` etc. suppresses just that edge.
- **Per-side color**: `borderColor` for all sides, `borderTopColor` / `borderLeftColor` / etc. override per-side. Color is `AnsiCode[]` and threads through the StylePool the same way text styles do.

## Composition with padding

Borders sit outside padding. A `<Box borderStyle="single" paddingX={1}>` has the border cells at the box's outer edge, then 1 column of padding inside, then content. Inner content width = available − borders − padding.

## intrinsicWidth update

`intrinsicWidth` now adds border thickness, so `flexDirection: "row"` parents allocate the right slot width to bordered children — without this, a bordered child gets only its content's intrinsic and overflows.

## Test plan

- [x] `npm run verify` — 1936/1936 (added 10 new border cases on top of existing layout / padding / flex-row / react)
- [ ] CI green

## Refs

- #160 — RFC
- #161 / #162 / #163 / #164 / #165 — prior renderer slices