### PR TITLE
Implement language setting synchronization and expand language support

### DIFF
--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -6,7 +6,7 @@ import { useCallback, useEffect, useState } from "preact/hooks";
 import { MODE } from "./src/lib/api";
 import { ToastStack, appBus } from "./src/lib/bus";
 import { ErrorBoundary, ErrorOverlay } from "./src/lib/error-boundary";
-import { t, useLang } from "./src/i18n";
+import { initLangFromServer, t, useLang } from "./src/i18n";
 import { ChatPanel } from "./src/panels/chat";
 import { HooksPanel } from "./src/panels/hooks";
 import { McpPanel } from "./src/panels/mcp";
@@ -60,7 +60,14 @@ function tabSections() {
 
 function App() {
   useLang();
-  const [activeId, setActiveId] = useState("chat");
+  useEffect(() => { initLangFromServer(); }, []);
+  const [activeId, setActiveId] = useState(() => {
+    try {
+      return localStorage.getItem("rx.activeTab") ?? "chat";
+    } catch {
+      return "chat";
+    }
+  });
   const [sidebarCollapsed, setSidebarCollapsed] = useState(() => {
     try {
       return localStorage.getItem("rx.sidebarCollapsed") === "1";
@@ -75,9 +82,19 @@ function App() {
       /* private mode / disabled storage — ignore */
     }
   }, [sidebarCollapsed]);
+  useEffect(() => {
+    try {
+      localStorage.setItem("rx.activeTab", activeId);
+    } catch {
+      /* private mode / disabled storage — ignore */
+    }
+  }, [activeId]);
   const TAB_SECTIONS = tabSections();
   const ALL_TABS = TAB_SECTIONS.flatMap((s) => s.tabs);
   const active = ALL_TABS.find((t) => t.id === activeId) ?? ALL_TABS[0];
+  useEffect(() => {
+    if (active.id !== activeId) setActiveId(active.id);
+  }, [active.id, activeId]);
 
   useEffect(() => {
     const onNav = (ev) => {

--- a/dashboard/src/i18n/index.ts
+++ b/dashboard/src/i18n/index.ts
@@ -2,7 +2,7 @@ import { createT } from "../lib/i18n.js";
 import { en } from "./en.js";
 import { zhCN } from "./zh-CN.js";
 
-export { getLang, setLang, useLang, onLangChange } from "../lib/i18n.js";
+export { getLang, initLangFromServer, setLang, useLang, onLangChange } from "../lib/i18n.js";
 export type { DashboardLang } from "../lib/i18n.js";
 
 export const t = createT({ en, "zh-CN": zhCN });

--- a/dashboard/src/lib/i18n.ts
+++ b/dashboard/src/lib/i18n.ts
@@ -1,21 +1,86 @@
 import { useEffect, useState } from "preact/hooks";
+import { TOKEN, api } from "./api.js";
 
 type Listener = () => void;
 
 export type DashboardLang = "en" | "zh-CN";
 
-const STORAGE_KEY = "rx.lang";
-const listeners: Listener[] = [];
-let currentLang: DashboardLang = loadFromStorage();
+// [dashboardCode, backendCode] — add new languages here.
+const LANG_REGISTRY: [DashboardLang, string][] = [
+  ["en", "EN"],
+  ["zh-CN", "zh-CN"],
+];
 
-function loadFromStorage(): DashboardLang {
+const SUPPORTED = new Set(LANG_REGISTRY.map(([d]) => d));
+const TO_BACKEND = new Map(LANG_REGISTRY);
+const FROM_BACKEND = new Map(LANG_REGISTRY.map(([d, b]) => [b, d]));
+
+const STORAGE_KEY = "rx.lang";
+const EXPLICIT_KEY = "rx.langExplicit";
+const listeners: Listener[] = [];
+let currentLang: DashboardLang = loadFromStorage() ?? "en";
+
+function loadFromStorage(): DashboardLang | null {
   try {
     const v = localStorage.getItem(STORAGE_KEY);
-    if (v === "zh-CN") return "zh-CN";
+    if (v !== null && SUPPORTED.has(v as DashboardLang)) return v as DashboardLang;
   } catch {
     /* private mode */
   }
-  return "en";
+  return null;
+}
+
+function isExplicit(): boolean {
+  try {
+    return localStorage.getItem(EXPLICIT_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function markExplicit(): void {
+  try {
+    localStorage.setItem(EXPLICIT_KEY, "1");
+  } catch {
+    /* ignore */
+  }
+}
+
+function toBackendLang(lang: DashboardLang): string {
+  return TO_BACKEND.get(lang) ?? lang;
+}
+
+function fromBackendLang(raw: string): DashboardLang {
+  return (FROM_BACKEND.get(raw) as DashboardLang) ?? "en";
+}
+
+/** Fetch lang from backend on startup. */
+export async function initLangFromServer(): Promise<void> {
+  try {
+    const stored = loadFromStorage();
+    const res = await api<{ lang?: string }>("/settings");
+    const serverLang = res.lang ? fromBackendLang(res.lang) : null;
+
+    if (!serverLang || stored === serverLang) return;
+
+    if (isExplicit() && stored) {
+      // User explicitly chose a language — push to server.
+      api("/settings", { method: "POST", body: { lang: toBackendLang(stored) } })
+        .catch((err) => console.error("[reasonix dashboard] lang sync:", err));
+      return;
+    }
+
+    // No explicit choice yet (first visit or cleared storage) — adopt server value.
+    currentLang = serverLang;
+    try {
+      localStorage.setItem(STORAGE_KEY, serverLang);
+    } catch {
+      /* ignore */
+    }
+    for (const cb of listeners) cb();
+  } catch {
+    /* offline — keep localStorage value */
+  }
 }
 
 export function getLang(): DashboardLang {
@@ -23,14 +88,22 @@ export function getLang(): DashboardLang {
 }
 
 export function setLang(lang: DashboardLang): void {
-  if (lang !== "en" && lang !== "zh-CN") return;
+  if (!SUPPORTED.has(lang)) return;
   currentLang = lang;
+  markExplicit();
   try {
     localStorage.setItem(STORAGE_KEY, lang);
   } catch {
     /* ignore */
   }
   for (const cb of listeners) cb();
+  // keepalive ensures the request completes even during page unload (refresh).
+  fetch(`/api/settings?token=${TOKEN}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "X-Reasonix-Token": TOKEN },
+    body: JSON.stringify({ lang: toBackendLang(lang) }),
+    keepalive: true,
+  }).catch((err) => console.error("[reasonix dashboard] lang persist:", err));
 }
 
 export function onLangChange(cb: Listener): () => void {
@@ -49,7 +122,7 @@ export function useLang(): DashboardLang {
 
 type Nested = { [k: string]: string | Nested };
 
-function get(translations: Nested, path: string): string | undefined {
+function get(translations: Nested | undefined, path: string): string | undefined {
   let val: string | Nested | undefined = translations;
   for (const part of path.split(".")) {
     if (val === undefined || typeof val === "string") return undefined;
@@ -58,9 +131,9 @@ function get(translations: Nested, path: string): string | undefined {
   return typeof val === "string" ? val : undefined;
 }
 
-export function createT(translations: Record<DashboardLang, Nested>) {
+export function createT(translations: Record<string, Nested>) {
   return function t(path: string, params?: Record<string, string | number>): string {
-    let val = get(translations[currentLang], path);
+    let val = get(translations[currentLang] ?? translations.en, path);
     if (val === undefined) val = get(translations.en, path);
     if (val === undefined) return path;
     if (!params) return val;

--- a/src/server/api/settings.ts
+++ b/src/server/api/settings.ts
@@ -9,12 +9,15 @@ import {
   saveReasoningEffort,
   writeConfig,
 } from "../../config.js";
+import { getLanguage, getSupportedLanguages, setLanguage } from "../../i18n/index.js";
+import type { LanguageCode } from "../../i18n/types.js";
 import type { DashboardContext } from "../context.js";
 import type { ApiResult } from "../router.js";
 
 interface SettingsBody {
   apiKey?: unknown;
   baseUrl?: unknown;
+  lang?: unknown;
   preset?: unknown;
   reasoningEffort?: unknown;
   search?: unknown;
@@ -50,6 +53,7 @@ export async function handleSettings(
         apiKey: cfg.apiKey ? redactKey(cfg.apiKey) : null,
         apiKeySet: Boolean(cfg.apiKey),
         baseUrl: cfg.baseUrl ?? null,
+        lang: getLanguage(),
         preset: cfg.preset ?? "auto",
         reasoningEffort: cfg.reasoningEffort ?? "max",
         search: cfg.search !== false,
@@ -73,6 +77,18 @@ export async function handleSettings(
     const cfg = readConfig(ctx.configPath);
     const changed: string[] = [];
 
+    if (fields.lang !== undefined) {
+      const raw = String(fields.lang);
+      const supported = getSupportedLanguages();
+      const langCode = supported.find((l) => l.toLowerCase() === raw.toLowerCase()) as
+        | LanguageCode
+        | undefined;
+      if (!langCode) {
+        return { status: 400, body: { error: `lang must be one of: ${supported.join(", ")}` } };
+      }
+      setLanguage(langCode);
+      changed.push("lang");
+    }
     if (fields.apiKey !== undefined) {
       if (typeof fields.apiKey !== "string" || !isPlausibleKey(fields.apiKey)) {
         return { status: 400, body: { error: "apiKey must be a plausible sk- token" } };


### PR DESCRIPTION
…nization feature

Add back-end language setting support, including initializing language settings from the server and bidirectional synchronization functionality Expand the language registry to support more languages, and improve language storage and error handling Fix issue of returning to the chat page after refreshing

Add language example: Japanese example (ja):

1. src/i18n/types.ts — Add to type: "EN" | "zh-CN" | "ja"
2. src/i18n/ja.ts — Create a new translation file
3. src/i18n/index.ts — Add to translations and detectSystemLanguage
4. dashboard/src/i18n/ja.ts — Create a new dashboard translation file
5. dashboard/src/lib/i18n.ts — Add a line to LANG_REGISTRY: ["ja", "ja"]
6. dashboard/src/i18n/index.ts — Add to createT call

## What

<!-- One paragraph: what does this change? -->

Add back-end language setting support with bidirectional synchronization between front-end and back-end. Expand the language registry to support more languages, improve language storage and error handling, and fix the issue of returning to the chat page after refreshing.

## Why

<!-- Bug fix? Pre-existing issue? Linked discussion? -->

The front-end previously had language settings but lacked back-end persistence and synchronization. This meant language preferences were lost on page refresh, causing the UI to revert to the default language. The language registry was also limited in supported languages.

## How to verify

<!-- Steps the reviewer can run. `npm run verify` is assumed. -->

1. Run `npm run verify`
2. Start the dev server with `npm run dev`
3. Open the dashboard and change the language setting
4. Refresh the page — the selected language should persist
5. Verify language changes sync correctly between front-end and back-end

## Checklist

- [✅] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [✅] No `Co-Authored-By: Claude` trailer in commits
- [✅] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [✅] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time