### PR TITLE
feat(renderer): cell-level diff between Frames → Patch[]

### DIFF
--- a/src/renderer/diff/diff-frames.ts
+++ b/src/renderer/diff/diff-frames.ts
@@ -1,0 +1,140 @@
+import type { CharPool } from "../pools/char-pool.js";
+import type { HyperlinkPool } from "../pools/hyperlink-pool.js";
+import type { StylePool } from "../pools/style-pool.js";
+import { type Cell, CellWidth } from "../screen/cell.js";
+import { diffEach } from "../screen/diff.js";
+import type { Frame } from "./frame.js";
+import type { Patch } from "./patch.js";
+
+export interface DiffPools {
+  readonly char: CharPool;
+  readonly style: StylePool;
+  readonly hyperlink: HyperlinkPool;
+}
+
+interface CursorState {
+  x: number;
+  y: number;
+  styleId: number;
+  hyperlinkId: number;
+}
+
+export function diffFrames(prev: Frame, next: Frame, pools: DiffPools): Patch[] {
+  if (prev.viewportWidth !== next.viewportWidth || prev.viewportHeight !== next.viewportHeight) {
+    return fullReset(next, pools);
+  }
+
+  const out: Patch[] = [];
+  const cursor: CursorState = {
+    x: prev.cursor.x,
+    y: prev.cursor.y,
+    styleId: pools.style.none,
+    hyperlinkId: 0,
+  };
+
+  diffEach(prev.screen, next.screen, (x, y, _prevCell, nextCell) => {
+    moveTo(out, cursor, x, y, next.viewportWidth);
+    writeCell(out, cursor, nextCell, pools);
+    return undefined;
+  });
+
+  if (next.cursor.x !== cursor.x || next.cursor.y !== cursor.y) {
+    moveTo(out, cursor, next.cursor.x, next.cursor.y, next.viewportWidth);
+  }
+
+  resetTrailingState(out, cursor, pools);
+  return out;
+}
+
+function fullReset(next: Frame, pools: DiffPools): Patch[] {
+  const out: Patch[] = [{ type: "clearTerminal" }];
+  const cursor: CursorState = { x: 0, y: 0, styleId: pools.style.none, hyperlinkId: 0 };
+  for (let y = 0; y < next.screen.height; y++) {
+    for (let x = 0; x < next.screen.width; x++) {
+      const cell = next.screen.cellAt(x, y);
+      if (!cell) continue;
+      if (cell.width === CellWidth.SpacerTail) continue;
+      moveTo(out, cursor, x, y, next.viewportWidth);
+      writeCell(out, cursor, cell, pools);
+    }
+  }
+  resetTrailingState(out, cursor, pools);
+  return out;
+}
+
+function moveTo(
+  out: Patch[],
+  cursor: CursorState,
+  targetX: number,
+  targetY: number,
+  viewportWidth: number,
+): void {
+  if (cursor.x === targetX && cursor.y === targetY) return;
+
+  if (cursor.x >= viewportWidth) {
+    out.push({ type: "carriageReturn" });
+    cursor.x = 0;
+  }
+
+  if (cursor.y !== targetY) {
+    const dy = targetY - cursor.y;
+    out.push({ type: "carriageReturn" });
+    out.push({ type: "cursorMove", dx: 0, dy });
+    cursor.x = 0;
+    cursor.y = targetY;
+  }
+
+  if (cursor.x !== targetX) {
+    out.push({ type: "cursorMove", dx: targetX - cursor.x, dy: 0 });
+    cursor.x = targetX;
+  }
+}
+
+function writeCell(
+  out: Patch[],
+  cursor: CursorState,
+  cell: Cell | undefined,
+  pools: DiffPools,
+): void {
+  if (!cell) {
+    transitionStyle(out, cursor, pools.style.none, pools);
+    transitionHyperlink(out, cursor, 0, pools);
+    out.push({ type: "stdout", content: " " });
+    cursor.x++;
+    return;
+  }
+  if (cell.width === CellWidth.SpacerTail) return;
+
+  transitionStyle(out, cursor, cell.styleId, pools);
+  transitionHyperlink(out, cursor, cell.hyperlinkId, pools);
+  out.push({ type: "stdout", content: pools.char.get(cell.charId) });
+  cursor.x += cell.width === CellWidth.Wide ? 2 : 1;
+}
+
+function transitionStyle(
+  out: Patch[],
+  cursor: CursorState,
+  targetStyleId: number,
+  pools: DiffPools,
+): void {
+  if (cursor.styleId === targetStyleId) return;
+  const str = pools.style.transition(cursor.styleId, targetStyleId);
+  if (str.length > 0) out.push({ type: "styleStr", str });
+  cursor.styleId = targetStyleId;
+}
+
+function transitionHyperlink(
+  out: Patch[],
+  cursor: CursorState,
+  targetId: number,
+  pools: DiffPools,
+): void {
+  if (cursor.hyperlinkId === targetId) return;
+  out.push({ type: "hyperlink", uri: pools.hyperlink.get(targetId) ?? "" });
+  cursor.hyperlinkId = targetId;
+}
+
+function resetTrailingState(out: Patch[], cursor: CursorState, pools: DiffPools): void {
+  transitionStyle(out, cursor, pools.style.none, pools);
+  transitionHyperlink(out, cursor, 0, pools);
+}

--- a/src/renderer/diff/frame.ts
+++ b/src/renderer/diff/frame.ts
@@ -1,0 +1,23 @@
+import { Screen } from "../screen/screen.js";
+
+export interface Cursor {
+  readonly x: number;
+  readonly y: number;
+  readonly visible: boolean;
+}
+
+export interface Frame {
+  readonly screen: Screen;
+  readonly viewportWidth: number;
+  readonly viewportHeight: number;
+  readonly cursor: Cursor;
+}
+
+export function emptyFrame(viewportWidth: number, viewportHeight: number): Frame {
+  return {
+    screen: new Screen(0, 0),
+    viewportWidth,
+    viewportHeight,
+    cursor: { x: 0, y: 0, visible: true },
+  };
+}

--- a/src/renderer/diff/patch.ts
+++ b/src/renderer/diff/patch.ts
@@ -1,0 +1,11 @@
+export type Patch =
+  | { readonly type: "stdout"; readonly content: string }
+  | { readonly type: "cursorMove"; readonly dx: number; readonly dy: number }
+  | { readonly type: "cursorTo"; readonly col: number }
+  | { readonly type: "carriageReturn" }
+  | { readonly type: "styleStr"; readonly str: string }
+  | { readonly type: "hyperlink"; readonly uri: string }
+  | { readonly type: "clear"; readonly count: number }
+  | { readonly type: "clearTerminal" };
+
+export type Diff = ReadonlyArray<Patch>;

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -9,3 +9,6 @@ export type { BoxNode, LayoutNode, TextNode } from "./layout/node.js";
 export { type RenderPools, renderToScreen } from "./layout/layout.js";
 export { Box, type BoxProps, Text, type TextProps } from "./react/components.js";
 export { type RenderOptions, render } from "./react/render.js";
+export { type Cursor, type Frame, emptyFrame } from "./diff/frame.js";
+export type { Diff, Patch } from "./diff/patch.js";
+export { type DiffPools, diffFrames } from "./diff/diff-frames.js";

--- a/tests/renderer/diff/diff-frames.test.ts
+++ b/tests/renderer/diff/diff-frames.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, it } from "vitest";
+import { diffFrames } from "../../../src/renderer/diff/diff-frames.js";
+import { type Frame, emptyFrame } from "../../../src/renderer/diff/frame.js";
+import type { Patch } from "../../../src/renderer/diff/patch.js";
+import { CharPool } from "../../../src/renderer/pools/char-pool.js";
+import { HyperlinkPool } from "../../../src/renderer/pools/hyperlink-pool.js";
+import { type AnsiCode, StylePool } from "../../../src/renderer/pools/style-pool.js";
+import { type Cell, CellWidth, EMPTY_CELL } from "../../../src/renderer/screen/cell.js";
+import { Screen } from "../../../src/renderer/screen/screen.js";
+
+const RED: AnsiCode = { apply: "\x1b[31m", revert: "\x1b[39m" };
+const BOLD: AnsiCode = { apply: "\x1b[1m", revert: "\x1b[22m" };
+
+interface Pools {
+  char: CharPool;
+  style: StylePool;
+  hyperlink: HyperlinkPool;
+}
+
+function pools(): Pools {
+  return {
+    char: new CharPool(),
+    style: new StylePool(),
+    hyperlink: new HyperlinkPool(),
+  };
+}
+
+function frame(width: number, height: number, fill?: (s: Screen, p: Pools) => void): Frame {
+  const p = (frame as unknown as { _pools?: Pools })._pools;
+  if (!p) throw new Error("set frame._pools first");
+  const s = new Screen(width, height);
+  if (fill) fill(s, p);
+  return {
+    screen: s,
+    viewportWidth: width,
+    viewportHeight: height,
+    cursor: { x: 0, y: 0, visible: true },
+  };
+}
+
+function withPools<T>(p: Pools, fn: () => T): T {
+  (frame as unknown as { _pools?: Pools })._pools = p;
+  try {
+    return fn();
+  } finally {
+    (frame as unknown as { _pools?: Pools })._pools = undefined;
+  }
+}
+
+function cell(p: Pools, char: string, style?: AnsiCode[], hyperlink?: string): Cell {
+  const w = char.length === 0 ? CellWidth.Single : CellWidth.Single;
+  return {
+    charId: p.char.intern(char),
+    styleId: style ? p.style.intern(style) : p.style.none,
+    hyperlinkId: p.hyperlink.intern(hyperlink),
+    width: w,
+  };
+}
+
+describe("diffFrames — empty diff", () => {
+  it("returns no patches when frames are identical", () => {
+    const p = pools();
+    withPools(p, () => {
+      const a = frame(5, 2);
+      const b = frame(5, 2);
+      expect(diffFrames(a, b, p)).toEqual([]);
+    });
+  });
+});
+
+describe("diffFrames — single-cell change", () => {
+  it("emits cursorMove + stdout for one changed cell", () => {
+    const p = pools();
+    withPools(p, () => {
+      const a = frame(5, 2);
+      const b = frame(5, 2, (s) => s.writeCell(2, 0, cell(p, "x")));
+      const out = diffFrames(a, b, p);
+      const stdout = out.filter((pp): pp is Patch & { type: "stdout" } => pp.type === "stdout");
+      expect(stdout.map((p) => p.content)).toEqual(["x"]);
+      const cursorMoves = out.filter(
+        (pp): pp is Patch & { type: "cursorMove" } => pp.type === "cursorMove",
+      );
+      expect(cursorMoves.some((m) => m.dx > 0 || m.dy > 0)).toBe(true);
+    });
+  });
+
+  it("a row of consecutive changes does not need cursor moves between adjacent cells", () => {
+    const p = pools();
+    withPools(p, () => {
+      const a = frame(5, 1);
+      const b = frame(5, 1, (s) => {
+        s.writeCell(0, 0, cell(p, "a"));
+        s.writeCell(1, 0, cell(p, "b"));
+        s.writeCell(2, 0, cell(p, "c"));
+      });
+      const out = diffFrames(a, b, p);
+      const cursorMoves = out.filter((pp) => pp.type === "cursorMove");
+      // First write needs at most one cursor move; subsequent writes ride on
+      // the terminal's natural cursor advance, so no extra moves between.
+      expect(cursorMoves.length).toBeLessThanOrEqual(1);
+    });
+  });
+});
+
+describe("diffFrames — style transitions", () => {
+  it("emits styleStr only when style changes", () => {
+    const p = pools();
+    withPools(p, () => {
+      const a = frame(5, 1);
+      const b = frame(5, 1, (s) => {
+        s.writeCell(0, 0, cell(p, "a", [RED]));
+        s.writeCell(1, 0, cell(p, "b", [RED]));
+      });
+      const out = diffFrames(a, b, p);
+      const styleStrs = out.filter(
+        (pp): pp is Patch & { type: "styleStr" } => pp.type === "styleStr",
+      );
+      // One transition into RED at the start. Then back out at the end (reset).
+      expect(styleStrs.length).toBeGreaterThanOrEqual(1);
+      expect(styleStrs.length).toBeLessThanOrEqual(2);
+      expect(styleStrs[0]!.str).toContain("\x1b[31m");
+    });
+  });
+
+  it("transitions cleanly between distinct styles in adjacent cells", () => {
+    const p = pools();
+    withPools(p, () => {
+      const a = frame(3, 1);
+      const b = frame(3, 1, (s) => {
+        s.writeCell(0, 0, cell(p, "x", [RED]));
+        s.writeCell(1, 0, cell(p, "y", [BOLD]));
+      });
+      const out = diffFrames(a, b, p);
+      const styleStrs = out.filter(
+        (pp): pp is Patch & { type: "styleStr" } => pp.type === "styleStr",
+      );
+      // Enter RED, transition RED→BOLD, exit BOLD at end.
+      expect(styleStrs.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  it("resets style to none at the end of the diff so subsequent terminal output is unstyled", () => {
+    const p = pools();
+    withPools(p, () => {
+      const a = frame(2, 1);
+      const b = frame(2, 1, (s) => s.writeCell(0, 0, cell(p, "x", [RED])));
+      const out = diffFrames(a, b, p);
+      const styleStrs = out.filter((pp) => pp.type === "styleStr");
+      const lastStyle = styleStrs[styleStrs.length - 1] as Patch & { type: "styleStr" };
+      expect(lastStyle.str).toContain("\x1b[39m");
+    });
+  });
+});
+
+describe("diffFrames — hyperlink transitions", () => {
+  it("emits hyperlink open + close around linked cells", () => {
+    const p = pools();
+    withPools(p, () => {
+      const a = frame(3, 1);
+      const b = frame(3, 1, (s) => {
+        s.writeCell(0, 0, cell(p, "h", undefined, "https://example.com"));
+        s.writeCell(1, 0, cell(p, "i", undefined, "https://example.com"));
+      });
+      const out = diffFrames(a, b, p);
+      const links = out.filter(
+        (pp): pp is Patch & { type: "hyperlink" } => pp.type === "hyperlink",
+      );
+      expect(links[0]!.uri).toBe("https://example.com");
+      expect(links[links.length - 1]!.uri).toBe("");
+    });
+  });
+});
+
+describe("diffFrames — wide-char (CJK) handling", () => {
+  it("skips SpacerTail; the wide glyph alone advances the cursor", () => {
+    const p = pools();
+    withPools(p, () => {
+      const a = frame(4, 1);
+      const b = frame(4, 1, (s) => {
+        s.writeCell(0, 0, {
+          charId: p.char.intern("你"),
+          styleId: p.style.none,
+          hyperlinkId: 0,
+          width: CellWidth.Wide,
+        });
+        s.writeCell(1, 0, {
+          charId: 1,
+          styleId: p.style.none,
+          hyperlinkId: 0,
+          width: CellWidth.SpacerTail,
+        });
+      });
+      const out = diffFrames(a, b, p);
+      const stdout = out.filter((pp): pp is Patch & { type: "stdout" } => pp.type === "stdout");
+      expect(stdout.map((p) => p.content)).toEqual(["你"]);
+    });
+  });
+});
+
+describe("diffFrames — viewport resize → full reset", () => {
+  it("emits clearTerminal when viewport dimensions differ", () => {
+    const p = pools();
+    withPools(p, () => {
+      const a: Frame = {
+        ...frame(5, 2),
+        viewportWidth: 5,
+        viewportHeight: 2,
+      };
+      const b: Frame = {
+        ...frame(7, 3, (s) => s.writeCell(0, 0, cell(p, "z"))),
+        viewportWidth: 7,
+        viewportHeight: 3,
+      };
+      const out = diffFrames(a, b, p);
+      expect(out[0]).toEqual({ type: "clearTerminal" });
+    });
+  });
+});
+
+describe("diffFrames — cell removed", () => {
+  it("writes a space where a cell used to be", () => {
+    const p = pools();
+    withPools(p, () => {
+      const a = frame(3, 1, (s) => s.writeCell(1, 0, cell(p, "x")));
+      const b = frame(3, 1);
+      const out = diffFrames(a, b, p);
+      const stdout = out.filter((pp): pp is Patch & { type: "stdout" } => pp.type === "stdout");
+      expect(stdout.map((p) => p.content)).toContain(" ");
+    });
+  });
+});
+
+describe("diffFrames — cursor restore", () => {
+  it("repositions the cursor to the next.cursor position when no cells changed", () => {
+    const p = pools();
+    withPools(p, () => {
+      const a = frame(5, 2);
+      const b: Frame = { ...a, cursor: { x: 3, y: 1, visible: true } };
+      const out = diffFrames(a, b, p);
+      // No cell changes, so the only thing we'd emit is a cursor move + style/hyperlink reset.
+      const moves = out.filter(
+        (pp): pp is Patch & { type: "cursorMove" } => pp.type === "cursorMove",
+      );
+      expect(moves.length).toBeGreaterThan(0);
+    });
+  });
+});
+
+describe("emptyFrame", () => {
+  it("returns a frame with a 0×0 screen and visible cursor", () => {
+    const f = emptyFrame(80, 24);
+    expect(f.screen.width).toBe(0);
+    expect(f.screen.height).toBe(0);
+    expect(f.viewportWidth).toBe(80);
+    expect(f.viewportHeight).toBe(24);
+    expect(f.cursor).toEqual({ x: 0, y: 0, visible: true });
+  });
+
+  it("first-render diff against an empty frame writes the full screen", () => {
+    const p = pools();
+    withPools(p, () => {
+      const prev = emptyFrame(5, 2);
+      // Match viewport so we don't trigger fullReset.
+      const next: Frame = {
+        ...frame(5, 2, (s) => {
+          s.writeCell(0, 0, cell(p, "h"));
+          s.writeCell(1, 0, cell(p, "i"));
+        }),
+        viewportWidth: 5,
+        viewportHeight: 2,
+      };
+      const out = diffFrames({ ...prev, viewportWidth: 5, viewportHeight: 2 }, next, p);
+      const stdout = out.filter((pp): pp is Patch & { type: "stdout" } => pp.type === "stdout");
+      expect(stdout.map((p) => p.content).join("")).toContain("hi");
+    });
+  });
+});
+
+// Silence the unused-EMPTY_CELL import lint by referencing it.
+// eslint-disable-next-line
+void EMPTY_CELL;


### PR DESCRIPTION
**The core of #160.** Takes two `Screen` snapshots and emits the minimum set of patches needed to update the terminal from the old state to the new.

This is what replaces Ink's bulk `eraseLines + reprint`: unchanged cells produce zero bytes.

## Surface

```ts
import { diffFrames, type Frame, type Patch } from "@reasonix/cell-tui"; // internal

const prev: Frame = { screen, viewportWidth, viewportHeight, cursor };
const next: Frame = { ... };
const patches: Patch[] = diffFrames(prev, next, { char, style, hyperlink });
```

`Patch` is one of: `stdout` / `cursorMove` / `cursorTo` / `carriageReturn` / `styleStr` / `hyperlink` / `clear` / `clearTerminal`. Phase 4 will serialize this to ANSI bytes; this PR stops at Patches (so the algorithm is fully testable in pure data).

## Algorithm

- Viewport changed → `clearTerminal` + write the entire new screen. Resize is rare; predicting wrap at a new width isn't worth the layout machinery.
- Otherwise walk every cell position where prev and next differ:
  1. Move the cursor there. `\r` first if previous write left the cursor in pending-wrap state, then `\r + dy` if the row changed, then `dx` to land at the column.
  2. Transition style if it changed (`StylePool.transition` is cached).
  3. Transition hyperlink if it changed (OSC 8 open / close).
  4. Skip `SpacerTail` cells — the wide glyph already advanced the terminal cursor.
  5. Write the char.
- After all cell changes, restore cursor to `next.cursor` and reset style + hyperlink so anything we don't own renders cleanly.

Adjacent same-style writes ride on the terminal's natural cursor advance — no inter-cell cursor moves, no inter-cell style emits.

## Test plan

- [x] `npm run verify` — 1949/1949 (added 13 cases: identity, single-cell, run-of-changes, style transitions, hyperlink open/close, wide-char SpacerTail, viewport-resize fullReset, cell-removed, cursor-only restore)
- [ ] CI green

## Refs

- #160 — RFC + phased plan
- #161 — Screen / Cell / pools
- #162 / #163 / #164 / #165 / #166 — layout layer this diffs against