### PR TITLE
feat(renderer): serialize Patch[] to ANSI byte stream

### DIFF
--- a/src/renderer/diff/serialize.ts
+++ b/src/renderer/diff/serialize.ts
@@ -1,0 +1,48 @@
+import type { Diff, Patch } from "./patch.js";
+
+const ESC = "\x1b";
+const CSI = `${ESC}[`;
+const ST = `${ESC}\\`;
+
+export function serializePatches(patches: Diff): string {
+  let out = "";
+  for (const patch of patches) {
+    out += serializeOne(patch);
+  }
+  return out;
+}
+
+function serializeOne(patch: Patch): string {
+  switch (patch.type) {
+    case "stdout":
+      return patch.content;
+    case "cursorMove":
+      return cursorMove(patch.dx, patch.dy);
+    case "cursorTo":
+      return `${CSI}${patch.col + 1}G`;
+    case "carriageReturn":
+      return "\r";
+    case "styleStr":
+      return patch.str;
+    case "hyperlink":
+      return `${ESC}]8;;${patch.uri}${ST}`;
+    case "clear":
+      return clearLines(patch.count);
+    case "clearTerminal":
+      return `${CSI}2J${CSI}H`;
+  }
+}
+
+function cursorMove(dx: number, dy: number): string {
+  let out = "";
+  if (dy > 0) out += `${CSI}${dy}B`;
+  else if (dy < 0) out += `${CSI}${-dy}A`;
+  if (dx > 0) out += `${CSI}${dx}C`;
+  else if (dx < 0) out += `${CSI}${-dx}D`;
+  return out;
+}
+
+function clearLines(count: number): string {
+  if (count <= 0) return `\r${CSI}J`;
+  return `\r${CSI}${count}A${CSI}J`;
+}

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -12,3 +12,4 @@ export { type RenderOptions, render } from "./react/render.js";
 export { type Cursor, type Frame, emptyFrame } from "./diff/frame.js";
 export type { Diff, Patch } from "./diff/patch.js";
 export { type DiffPools, diffFrames } from "./diff/diff-frames.js";
+export { serializePatches } from "./diff/serialize.js";

--- a/tests/renderer/diff/serialize.test.ts
+++ b/tests/renderer/diff/serialize.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import type { Patch } from "../../../src/renderer/diff/patch.js";
+import { serializePatches } from "../../../src/renderer/diff/serialize.js";
+
+const ESC = "\x1b";
+const CSI = `${ESC}[`;
+const ST = `${ESC}\\`;
+
+describe("serializePatches — stdout / control", () => {
+  it("stdout writes content verbatim", () => {
+    expect(serializePatches([{ type: "stdout", content: "hello" }])).toBe("hello");
+  });
+
+  it("carriageReturn emits \\r", () => {
+    expect(serializePatches([{ type: "carriageReturn" }])).toBe("\r");
+  });
+
+  it("styleStr writes the precomputed string verbatim", () => {
+    expect(serializePatches([{ type: "styleStr", str: `${CSI}31m` }])).toBe(`${CSI}31m`);
+  });
+
+  it("a sequence of patches concatenates in order", () => {
+    const seq: Patch[] = [
+      { type: "stdout", content: "a" },
+      { type: "carriageReturn" },
+      { type: "stdout", content: "b" },
+    ];
+    expect(serializePatches(seq)).toBe("a\rb");
+  });
+});
+
+describe("serializePatches — cursorMove", () => {
+  it("dx > 0 emits CSI <n> C", () => {
+    expect(serializePatches([{ type: "cursorMove", dx: 3, dy: 0 }])).toBe(`${CSI}3C`);
+  });
+
+  it("dx < 0 emits CSI <n> D", () => {
+    expect(serializePatches([{ type: "cursorMove", dx: -2, dy: 0 }])).toBe(`${CSI}2D`);
+  });
+
+  it("dy > 0 emits CSI <n> B", () => {
+    expect(serializePatches([{ type: "cursorMove", dx: 0, dy: 4 }])).toBe(`${CSI}4B`);
+  });
+
+  it("dy < 0 emits CSI <n> A", () => {
+    expect(serializePatches([{ type: "cursorMove", dx: 0, dy: -1 }])).toBe(`${CSI}1A`);
+  });
+
+  it("dx and dy both 0 emits nothing", () => {
+    expect(serializePatches([{ type: "cursorMove", dx: 0, dy: 0 }])).toBe("");
+  });
+
+  it("dx and dy both nonzero emits vertical first, then horizontal", () => {
+    expect(serializePatches([{ type: "cursorMove", dx: 2, dy: -1 }])).toBe(`${CSI}1A${CSI}2C`);
+  });
+});
+
+describe("serializePatches — cursorTo", () => {
+  it("emits CSI <col+1> G (CHA is 1-based)", () => {
+    expect(serializePatches([{ type: "cursorTo", col: 0 }])).toBe(`${CSI}1G`);
+    expect(serializePatches([{ type: "cursorTo", col: 9 }])).toBe(`${CSI}10G`);
+  });
+});
+
+describe("serializePatches — hyperlink (OSC 8)", () => {
+  it("opens with the URI between the marker and ST", () => {
+    expect(serializePatches([{ type: "hyperlink", uri: "https://example.com" }])).toBe(
+      `${ESC}]8;;https://example.com${ST}`,
+    );
+  });
+
+  it("closes with an empty URI", () => {
+    expect(serializePatches([{ type: "hyperlink", uri: "" }])).toBe(`${ESC}]8;;${ST}`);
+  });
+});
+
+describe("serializePatches — clear", () => {
+  it("count = 0 emits \\r + erase-from-cursor-down (CSI J)", () => {
+    expect(serializePatches([{ type: "clear", count: 0 }])).toBe(`\r${CSI}J`);
+  });
+
+  it("count > 0 moves cursor up that many rows then erases to end of screen", () => {
+    expect(serializePatches([{ type: "clear", count: 3 }])).toBe(`\r${CSI}3A${CSI}J`);
+  });
+});
+
+describe("serializePatches — clearTerminal", () => {
+  it("emits CSI 2J + CSI H (erase entire display + cursor home)", () => {
+    expect(serializePatches([{ type: "clearTerminal" }])).toBe(`${CSI}2J${CSI}H`);
+  });
+});
+
+describe("serializePatches — realistic frame", () => {
+  it("paints a single styled cell at (3, 1) and resets style at the end", () => {
+    const seq: Patch[] = [
+      { type: "carriageReturn" },
+      { type: "cursorMove", dx: 0, dy: 1 },
+      { type: "cursorMove", dx: 3, dy: 0 },
+      { type: "styleStr", str: `${CSI}31m` },
+      { type: "stdout", content: "x" },
+      { type: "styleStr", str: `${CSI}39m` },
+    ];
+    const expected = `\r${CSI}1B${CSI}3C${CSI}31mx${CSI}39m`;
+    expect(serializePatches(seq)).toBe(expected);
+  });
+
+  it("empty patch list emits nothing", () => {
+    expect(serializePatches([])).toBe("");
+  });
+});


### PR DESCRIPTION
Phase 4 of #160. Bridges the Patch layer to the actual bytes a terminal reads.

```ts
const patches: Patch[] = diffFrames(prev, next, pools);
const bytes = serializePatches(patches);
process.stdout.write(bytes);
```

## Mappings

| Patch | Bytes |
|---|---|
| `stdout { content }` | `content` (pass-through) |
| `cursorMove { dx, dy }` | `CSI <dy> A/B` then `CSI <dx> C/D`; dy=0,dx=0 → `""` |
| `cursorTo { col }` | `CSI <col+1> G` (CHA is 1-based) |
| `carriageReturn` | `\r` |
| `styleStr { str }` | `str` (already an SGR sequence from `StylePool.transition`) |
| `hyperlink { uri }` | `OSC 8 ; ; <uri> ST` (empty URI closes the link) |
| `clear { count }` | `\r` + `CSI <count> A` + `CSI J` (move up, erase to end) |
| `clearTerminal` | `CSI 2J` + `CSI H` |

## Notes

- `dx=0, dy=0` cursor moves serialize to `""` so we never emit useless escapes.
- Empty `Patch[]` serializes to `""` — emitting a frame whose diff is empty is a no-op all the way to the terminal.
- Vertical-then-horizontal order on `cursorMove` matches what the diff layer expects (it usually emits one axis at a time, but we handle both being non-zero defensively).

## What's still missing for the full pipeline

- Phase 5: actually wire this to a runtime — render a React tree, capture stdout writes, drive frames on state changes. That's the integration step where the renderer replaces Ink in Reasonix's CLI behind a feature flag.

## Test plan

- [x] `npm run verify` — 1967/1967 (added 18 cases covering each Patch type + edge cases + a realistic styled-cell sequence + empty input)
- [ ] CI green

## Refs

- #160 — RFC + phased plan
- #168 — diff algorithm whose output this serializer consumes