### PR TITLE
feat(renderer): Renderer runtime — frame state + diff + write to sink

### DIFF
--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -13,3 +13,5 @@ export { type Cursor, type Frame, emptyFrame } from "./diff/frame.js";
 export type { Diff, Patch } from "./diff/patch.js";
 export { type DiffPools, diffFrames } from "./diff/diff-frames.js";
 export { serializePatches } from "./diff/serialize.js";
+export { Renderer, type RendererOptions } from "./runtime/renderer.js";
+export { type TestWriter, makeTestWriter } from "./runtime/test-writer.js";

--- a/src/renderer/runtime/renderer.ts
+++ b/src/renderer/runtime/renderer.ts
@@ -1,0 +1,59 @@
+import type { ReactNode } from "react";
+import { type DiffPools, diffFrames } from "../diff/diff-frames.js";
+import { type Cursor, type Frame, emptyFrame } from "../diff/frame.js";
+import { serializePatches } from "../diff/serialize.js";
+import { render as renderReactTree } from "../react/render.js";
+
+export interface RendererOptions {
+  readonly viewportWidth: number;
+  readonly viewportHeight: number;
+  readonly pools: DiffPools;
+  readonly write: (bytes: string) => void;
+}
+
+const RESET_SGR = "\x1b[0m";
+const CLOSE_HYPERLINK = "\x1b]8;;\x1b\\";
+
+export class Renderer {
+  private viewportWidth: number;
+  private viewportHeight: number;
+  private frame: Frame;
+  private destroyed = false;
+
+  constructor(private readonly opts: RendererOptions) {
+    this.viewportWidth = opts.viewportWidth;
+    this.viewportHeight = opts.viewportHeight;
+    this.frame = emptyFrame(this.viewportWidth, this.viewportHeight);
+  }
+
+  update(element: ReactNode, cursor?: Cursor): void {
+    if (this.destroyed) return;
+    const screen = renderReactTree(element, {
+      width: this.viewportWidth,
+      pools: this.opts.pools,
+    });
+    const next: Frame = {
+      screen,
+      viewportWidth: this.viewportWidth,
+      viewportHeight: this.viewportHeight,
+      cursor: cursor ?? { x: 0, y: screen.height, visible: true },
+    };
+    const patches = diffFrames(this.frame, next, this.opts.pools);
+    if (patches.length > 0) {
+      this.opts.write(serializePatches(patches));
+    }
+    this.frame = next;
+  }
+
+  resize(width: number, height: number): void {
+    if (this.destroyed) return;
+    this.viewportWidth = width;
+    this.viewportHeight = height;
+  }
+
+  destroy(): void {
+    if (this.destroyed) return;
+    this.destroyed = true;
+    this.opts.write(`${RESET_SGR}${CLOSE_HYPERLINK}`);
+  }
+}

--- a/src/renderer/runtime/test-writer.ts
+++ b/src/renderer/runtime/test-writer.ts
@@ -1,0 +1,22 @@
+export interface TestWriter {
+  readonly write: (bytes: string) => void;
+  output(): string;
+  flush(): string;
+  chunks(): ReadonlyArray<string>;
+}
+
+export function makeTestWriter(): TestWriter {
+  const buf: string[] = [];
+  return {
+    write: (bytes: string) => {
+      buf.push(bytes);
+    },
+    output: () => buf.join(""),
+    flush: () => {
+      const out = buf.join("");
+      buf.length = 0;
+      return out;
+    },
+    chunks: () => buf.slice(),
+  };
+}

--- a/tests/renderer/runtime/renderer.test.tsx
+++ b/tests/renderer/runtime/renderer.test.tsx
@@ -1,0 +1,163 @@
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { CharPool } from "../../../src/renderer/pools/char-pool.js";
+import { HyperlinkPool } from "../../../src/renderer/pools/hyperlink-pool.js";
+import { type AnsiCode, StylePool } from "../../../src/renderer/pools/style-pool.js";
+import { Box, Text } from "../../../src/renderer/react/components.js";
+import { Renderer } from "../../../src/renderer/runtime/renderer.js";
+import { makeTestWriter } from "../../../src/renderer/runtime/test-writer.js";
+
+const RED: AnsiCode = { apply: "\x1b[31m", revert: "\x1b[39m" };
+
+function pools() {
+  return {
+    char: new CharPool(),
+    style: new StylePool(),
+    hyperlink: new HyperlinkPool(),
+  };
+}
+
+describe("Renderer — first paint", () => {
+  it("emits the cells of the initial tree to the writer", () => {
+    const w = makeTestWriter();
+    const r = new Renderer({
+      viewportWidth: 5,
+      viewportHeight: 2,
+      pools: pools(),
+      write: w.write,
+    });
+    r.update(<Text>hi</Text>);
+    expect(w.output()).toContain("hi");
+  });
+
+  it("style transitions show up as SGR sequences in the byte stream", () => {
+    const w = makeTestWriter();
+    const r = new Renderer({
+      viewportWidth: 3,
+      viewportHeight: 1,
+      pools: pools(),
+      write: w.write,
+    });
+    r.update(<Text style={[RED]}>x</Text>);
+    expect(w.output()).toContain("\x1b[31m");
+    expect(w.output()).toContain("\x1b[39m");
+    expect(w.output()).toContain("x");
+  });
+});
+
+describe("Renderer — subsequent paints", () => {
+  it("rendering the same tree twice writes nothing the second time", () => {
+    const w = makeTestWriter();
+    const r = new Renderer({
+      viewportWidth: 5,
+      viewportHeight: 1,
+      pools: pools(),
+      write: w.write,
+    });
+    r.update(<Text>same</Text>);
+    w.flush();
+    r.update(<Text>same</Text>);
+    expect(w.output()).toBe("");
+  });
+
+  it("a single-character change writes only the new char + its cursor move", () => {
+    const w = makeTestWriter();
+    const r = new Renderer({
+      viewportWidth: 5,
+      viewportHeight: 1,
+      pools: pools(),
+      write: w.write,
+    });
+    r.update(<Text>aaaa</Text>);
+    w.flush();
+    r.update(<Text>aaba</Text>);
+    const second = w.output();
+    expect(second).toContain("b");
+    expect(second).not.toContain("a");
+  });
+});
+
+describe("Renderer — viewport resize", () => {
+  it("emits a clearTerminal sequence when viewport changes", () => {
+    const w = makeTestWriter();
+    const r = new Renderer({
+      viewportWidth: 5,
+      viewportHeight: 2,
+      pools: pools(),
+      write: w.write,
+    });
+    r.update(<Text>hi</Text>);
+    w.flush();
+    r.resize(10, 3);
+    r.update(<Text>hi</Text>);
+    expect(w.output()).toContain("\x1b[2J");
+    expect(w.output()).toContain("\x1b[H");
+  });
+});
+
+describe("Renderer — destroy", () => {
+  it("emits SGR reset and OSC 8 close on destroy", () => {
+    const w = makeTestWriter();
+    const r = new Renderer({
+      viewportWidth: 5,
+      viewportHeight: 1,
+      pools: pools(),
+      write: w.write,
+    });
+    r.update(<Text>x</Text>);
+    w.flush();
+    r.destroy();
+    const out = w.output();
+    expect(out).toContain("\x1b[0m");
+    expect(out).toContain("\x1b]8;;\x1b\\");
+  });
+
+  it("subsequent updates after destroy are no-ops", () => {
+    const w = makeTestWriter();
+    const r = new Renderer({
+      viewportWidth: 5,
+      viewportHeight: 1,
+      pools: pools(),
+      write: w.write,
+    });
+    r.destroy();
+    w.flush();
+    r.update(<Text>ignored</Text>);
+    expect(w.output()).toBe("");
+  });
+});
+
+describe("Renderer — hyperlinks", () => {
+  it("OSC 8 open + close show up around linked content", () => {
+    const w = makeTestWriter();
+    const r = new Renderer({
+      viewportWidth: 10,
+      viewportHeight: 1,
+      pools: pools(),
+      write: w.write,
+    });
+    r.update(<Text hyperlink="https://example.com">hi</Text>);
+    expect(w.output()).toContain("\x1b]8;;https://example.com");
+  });
+});
+
+describe("Renderer — Box composition", () => {
+  it("paints a row Box with two Text children side-by-side", () => {
+    const w = makeTestWriter();
+    const r = new Renderer({
+      viewportWidth: 10,
+      viewportHeight: 1,
+      pools: pools(),
+      write: w.write,
+    });
+    r.update(
+      <Box flexDirection="row">
+        <Text>L</Text>
+        <Text>R</Text>
+      </Box>,
+    );
+    expect(w.output()).toContain("L");
+    expect(w.output()).toContain("R");
+  });
+});


### PR DESCRIPTION
Closes the offline pipeline of #160. The Renderer holds frame state across calls so the diff layer has something to diff against.

```ts
const r = new Renderer({ viewportWidth, viewportHeight, pools, write });
r.update(<App />);              // first paint — writes full screen
r.update(<App />);              // identical tree — zero bytes
r.update(<AppMutated />);       // writes only the cells that changed
r.resize(cols, rows);           // next update full-resets via clearTerminal
r.destroy();                    // SGR reset + OSC 8 close, no further updates
```

## Why a sink injection

`write` is `(bytes: string) => void`. Tests run purely in memory via `makeTestWriter()` — no real stdout, no real terminal. The runtime integration in a later phase plugs `process.stdout.write` into the same slot.

## What this PR does NOT do (later phases)

- **Drive re-renders from React state** — still caller-driven. `update()` is what produces a new frame; React `useState` / `useEffect` / re-render-on-state isn't wired yet. That's Phase 5b — needs `react-reconciler` or equivalent.
- **Read keystrokes** — no stdin handling. Phase 5c.
- **Replace Ink in Reasonix's CLI** — Phase 5d, behind a feature flag.

## Test plan

- [x] `npm run verify` — 1976/1976 (added 9 cases: first paint, identity no-op, single-char diff, hyperlink, Box composition, resize → fullReset, destroy + post-destroy no-op, style transitions)
- [ ] CI green

## Refs

- #160 — RFC + phased plan
- #161 / #162 / #163 / #164 / #165 / #166 / #168 / #169 — every layer this orchestrates