### PR TITLE
feat(renderer): react-reconciler integration — useState drives paints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reasonix",
-  "version": "0.18.1",
+  "version": "0.23.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reasonix",
-      "version": "0.18.1",
+      "version": "0.23.1",
       "license": "MIT",
       "dependencies": {
         "cli-highlight": "^2.1.11",
@@ -18,6 +18,7 @@
         "ink-text-input": "^6.0.0",
         "picomatch": "^4.0.4",
         "react": "^18.3.1",
+        "react-reconciler": "^0.29.2",
         "string-width": "^7.2.0",
         "zod": "^4.4.1"
       },
@@ -29,6 +30,7 @@
         "@types/node": "^22.9.0",
         "@types/picomatch": "^4.0.3",
         "@types/react": "^18.3.12",
+        "@types/react-reconciler": "^0.28.9",
         "esbuild": "^0.21.5",
         "highlight.js": "^11.10.0",
         "htm": "^3.1.1",
@@ -42,7 +44,7 @@
         "vitest": "^2.1.5"
       },
       "engines": {
-        "node": ">=20.10"
+        "node": ">=22"
       }
     },
     "node_modules/@alcalzone/ansi-tokenize": {
@@ -1081,18 +1083,28 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@vitest/expect": {
@@ -1677,7 +1689,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "ink-text-input": "^6.0.0",
     "picomatch": "^4.0.4",
     "react": "^18.3.1",
+    "react-reconciler": "^0.29.2",
     "string-width": "^7.2.0",
     "zod": "^4.4.1"
   },
@@ -83,6 +84,7 @@
     "@types/node": "^22.9.0",
     "@types/picomatch": "^4.0.3",
     "@types/react": "^18.3.12",
+    "@types/react-reconciler": "^0.28.9",
     "esbuild": "^0.21.5",
     "highlight.js": "^11.10.0",
     "htm": "^3.1.1",

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -15,3 +15,4 @@ export { type DiffPools, diffFrames } from "./diff/diff-frames.js";
 export { serializePatches } from "./diff/serialize.js";
 export { Renderer, type RendererOptions } from "./runtime/renderer.js";
 export { type TestWriter, makeTestWriter } from "./runtime/test-writer.js";
+export { type Handle, type MountOptions, mount } from "./reconciler/mount.js";

--- a/src/renderer/react/components.ts
+++ b/src/renderer/react/components.ts
@@ -1,6 +1,9 @@
-import type { ReactNode } from "react";
+import React, { type ReactElement, type ReactNode } from "react";
 import type { BorderStyle, BorderStyleName } from "../layout/borders.js";
 import type { AnsiCode } from "../pools/style-pool.js";
+
+export const HOST_BOX = "rsx-box" as const;
+export const HOST_TEXT = "rsx-text" as const;
 
 export interface BoxProps {
   readonly children?: ReactNode;
@@ -31,12 +34,10 @@ export interface TextProps {
   readonly hyperlink?: string;
 }
 
-const HOST_GUARD = "Reasonix renderer host element — only rendered through cell-tui's render().";
-
-export function Box(_props: BoxProps): never {
-  throw new Error(HOST_GUARD);
+export function Box(props: BoxProps): ReactElement {
+  return React.createElement(HOST_BOX, props);
 }
 
-export function Text(_props: TextProps): never {
-  throw new Error(HOST_GUARD);
+export function Text(props: TextProps): ReactElement {
+  return React.createElement(HOST_TEXT, props);
 }

--- a/src/renderer/react/render.ts
+++ b/src/renderer/react/render.ts
@@ -2,7 +2,7 @@ import { Fragment, type ReactElement, type ReactNode, isValidElement } from "rea
 import { type RenderPools, renderToScreen } from "../layout/layout.js";
 import type { BoxNode, LayoutNode, TextNode } from "../layout/node.js";
 import type { Screen } from "../screen/screen.js";
-import { Box, type BoxProps, Text, type TextProps } from "./components.js";
+import { type BoxProps, HOST_BOX, HOST_TEXT, type TextProps } from "./components.js";
 
 export interface RenderOptions {
   readonly width: number;
@@ -33,7 +33,7 @@ function elementToLayoutNode(element: ReactElement): LayoutNode | null {
   const type = element.type;
   const props = element.props as { children?: ReactNode };
 
-  if (type === Box) {
+  if (type === HOST_BOX) {
     const boxProps = element.props as BoxProps;
     const children = childrenToLayoutNodes(props.children);
     const padding = resolvePadding(boxProps);
@@ -44,7 +44,7 @@ function elementToLayoutNode(element: ReactElement): LayoutNode | null {
     return { kind: "box", children, ...flex, ...padding, ...border } satisfies BoxNode;
   }
 
-  if (type === Text) {
+  if (type === HOST_TEXT) {
     const textProps = element.props as TextProps;
     return {
       kind: "text",

--- a/src/renderer/reconciler/host-config.ts
+++ b/src/renderer/reconciler/host-config.ts
@@ -1,0 +1,189 @@
+import ReactReconciler from "react-reconciler";
+import { type BoxProps, HOST_BOX, HOST_TEXT, type TextProps } from "../react/components.js";
+import {
+  type HostBox,
+  type HostNode,
+  type HostText,
+  hostToLayoutNode,
+  makeHostBox,
+  makeHostRawText,
+  makeHostText,
+} from "./host-node.js";
+
+export interface HostRoot {
+  readonly children: HostNode[];
+  onCommit: () => void;
+}
+
+type Container = HostRoot;
+type Type = typeof HOST_BOX | typeof HOST_TEXT | string;
+type Props = BoxProps | TextProps;
+type Instance = HostBox | HostText;
+type TextInstance = ReturnType<typeof makeHostRawText>;
+type PublicInstance = Instance;
+type HostContext = Record<string, never>;
+type UpdatePayload = Props;
+type ChildSet = never;
+type TimeoutHandle = ReturnType<typeof setTimeout>;
+type NoTimeout = -1;
+
+const hostConfig: ReactReconciler.HostConfig<
+  Type,
+  Props,
+  Container,
+  Instance,
+  TextInstance,
+  never,
+  never,
+  PublicInstance,
+  HostContext,
+  UpdatePayload,
+  ChildSet,
+  TimeoutHandle,
+  NoTimeout
+> = {
+  supportsMutation: true,
+  supportsPersistence: false,
+  supportsHydration: false,
+  isPrimaryRenderer: false,
+  noTimeout: -1,
+
+  createInstance(type, props) {
+    if (type === HOST_BOX) return makeHostBox(props as BoxProps);
+    if (type === HOST_TEXT) return makeHostText(props as TextProps);
+    throw new Error(`Reasonix renderer: unsupported element type: ${String(type)}`);
+  },
+
+  createTextInstance(text) {
+    return makeHostRawText(text);
+  },
+
+  appendInitialChild(parent, child) {
+    parent.children.push(child as HostNode);
+    (child as HostNode).parent = parent;
+  },
+
+  appendChild(parent, child) {
+    parent.children.push(child as HostNode);
+    (child as HostNode).parent = parent;
+  },
+
+  appendChildToContainer(container, child) {
+    container.children.push(child as HostNode);
+    (child as HostNode).parent = null;
+  },
+
+  insertBefore(parent, child, beforeChild) {
+    const idx = parent.children.indexOf(beforeChild as HostNode);
+    if (idx < 0) parent.children.push(child as HostNode);
+    else parent.children.splice(idx, 0, child as HostNode);
+    (child as HostNode).parent = parent;
+  },
+
+  insertInContainerBefore(container, child, beforeChild) {
+    const idx = container.children.indexOf(beforeChild as HostNode);
+    if (idx < 0) container.children.push(child as HostNode);
+    else container.children.splice(idx, 0, child as HostNode);
+    (child as HostNode).parent = null;
+  },
+
+  removeChild(parent, child) {
+    const idx = parent.children.indexOf(child as HostNode);
+    if (idx >= 0) parent.children.splice(idx, 1);
+    (child as HostNode).parent = null;
+  },
+
+  removeChildFromContainer(container, child) {
+    const idx = container.children.indexOf(child as HostNode);
+    if (idx >= 0) container.children.splice(idx, 1);
+  },
+
+  finalizeInitialChildren() {
+    return false;
+  },
+
+  prepareUpdate(_instance, _type, _oldProps, newProps) {
+    return newProps;
+  },
+
+  commitUpdate(instance, payload) {
+    instance.props = payload;
+  },
+
+  commitTextUpdate(textInstance, _oldText, newText) {
+    textInstance.text = newText;
+  },
+
+  resetTextContent() {
+    /* no-op */
+  },
+
+  shouldSetTextContent() {
+    return false;
+  },
+
+  getRootHostContext() {
+    return {};
+  },
+
+  getChildHostContext() {
+    return {};
+  },
+
+  getPublicInstance(instance) {
+    return instance as Instance;
+  },
+
+  prepareForCommit() {
+    return null;
+  },
+
+  resetAfterCommit(container) {
+    container.onCommit();
+  },
+
+  preparePortalMount() {
+    /* no-op */
+  },
+
+  scheduleTimeout: setTimeout,
+  cancelTimeout: clearTimeout,
+
+  getCurrentEventPriority() {
+    return DefaultEventPriority;
+  },
+
+  getInstanceFromNode() {
+    return null;
+  },
+
+  beforeActiveInstanceBlur() {
+    /* no-op */
+  },
+
+  afterActiveInstanceBlur() {
+    /* no-op */
+  },
+
+  prepareScopeUpdate() {
+    /* no-op */
+  },
+
+  getInstanceFromScope() {
+    return null;
+  },
+
+  detachDeletedInstance() {
+    /* no-op */
+  },
+
+  clearContainer(container) {
+    container.children.length = 0;
+  },
+};
+
+const DefaultEventPriority = 16;
+
+export const reconciler = ReactReconciler(hostConfig);
+
+export { hostToLayoutNode };

--- a/src/renderer/reconciler/host-node.ts
+++ b/src/renderer/reconciler/host-node.ts
@@ -1,0 +1,97 @@
+import type { BoxNode, LayoutNode, TextNode } from "../layout/node.js";
+import type { BoxProps, TextProps } from "../react/components.js";
+
+export type HostType = "box" | "text" | "raw-text";
+
+export interface HostBox {
+  readonly type: "box";
+  props: BoxProps;
+  children: HostNode[];
+  parent: HostBox | null;
+}
+
+export interface HostText {
+  readonly type: "text";
+  props: TextProps;
+  children: HostNode[];
+  parent: HostBox | null;
+}
+
+export interface HostRawText {
+  readonly type: "raw-text";
+  text: string;
+  parent: HostBox | HostText | null;
+}
+
+export type HostNode = HostBox | HostText | HostRawText;
+
+export function makeHostBox(props: BoxProps): HostBox {
+  return { type: "box", props, children: [], parent: null };
+}
+
+export function makeHostText(props: TextProps): HostText {
+  return { type: "text", props, children: [], parent: null };
+}
+
+export function makeHostRawText(text: string): HostRawText {
+  return { type: "raw-text", text, parent: null };
+}
+
+export function hostToLayoutNode(node: HostNode): LayoutNode | null {
+  if (node.type === "raw-text") {
+    return { kind: "text", content: node.text };
+  }
+  if (node.type === "text") {
+    return {
+      kind: "text",
+      content: collectText(node.children),
+      ...(node.props.style ? { style: node.props.style } : {}),
+      ...(node.props.hyperlink ? { hyperlink: node.props.hyperlink } : {}),
+    } satisfies TextNode;
+  }
+  const layoutChildren: LayoutNode[] = [];
+  for (const c of node.children) {
+    const child = hostToLayoutNode(c);
+    if (child) layoutChildren.push(child);
+  }
+  const p = node.props;
+  const out: BoxNode = { kind: "box", children: layoutChildren };
+  return assignBoxProps(out, p);
+}
+
+function collectText(children: HostNode[]): string {
+  let out = "";
+  for (const child of children) {
+    if (child.type === "raw-text") out += child.text;
+    else if (child.type === "text") out += collectText(child.children);
+  }
+  return out;
+}
+
+function assignBoxProps(node: BoxNode, props: BoxProps): BoxNode {
+  const result: { -readonly [K in keyof BoxNode]: BoxNode[K] } = { ...node };
+  const all = props.padding;
+  const x = props.paddingX ?? all;
+  const y = props.paddingY ?? all;
+  const top = props.paddingTop ?? y;
+  const bottom = props.paddingBottom ?? y;
+  const left = props.paddingLeft ?? x;
+  const right = props.paddingRight ?? x;
+  if (top !== undefined) result.paddingTop = top;
+  if (bottom !== undefined) result.paddingBottom = bottom;
+  if (left !== undefined) result.paddingLeft = left;
+  if (right !== undefined) result.paddingRight = right;
+  if (props.flexDirection !== undefined) result.flexDirection = props.flexDirection;
+  if (props.flexGrow !== undefined) result.flexGrow = props.flexGrow;
+  if (props.borderStyle !== undefined) result.borderStyle = props.borderStyle;
+  if (props.borderTop !== undefined) result.borderTop = props.borderTop;
+  if (props.borderBottom !== undefined) result.borderBottom = props.borderBottom;
+  if (props.borderLeft !== undefined) result.borderLeft = props.borderLeft;
+  if (props.borderRight !== undefined) result.borderRight = props.borderRight;
+  if (props.borderColor !== undefined) result.borderColor = props.borderColor;
+  if (props.borderTopColor !== undefined) result.borderTopColor = props.borderTopColor;
+  if (props.borderBottomColor !== undefined) result.borderBottomColor = props.borderBottomColor;
+  if (props.borderLeftColor !== undefined) result.borderLeftColor = props.borderLeftColor;
+  if (props.borderRightColor !== undefined) result.borderRightColor = props.borderRightColor;
+  return result;
+}

--- a/src/renderer/reconciler/mount.ts
+++ b/src/renderer/reconciler/mount.ts
@@ -1,0 +1,100 @@
+import type { ReactNode } from "react";
+import { type DiffPools, diffFrames } from "../diff/diff-frames.js";
+import { type Cursor, type Frame, emptyFrame } from "../diff/frame.js";
+import { serializePatches } from "../diff/serialize.js";
+import { renderToScreen } from "../layout/layout.js";
+import type { LayoutNode } from "../layout/node.js";
+import { type HostRoot, hostToLayoutNode, reconciler } from "./host-config.js";
+
+export interface MountOptions {
+  readonly viewportWidth: number;
+  readonly viewportHeight: number;
+  readonly pools: DiffPools;
+  readonly write: (bytes: string) => void;
+  readonly cursor?: () => Cursor;
+}
+
+export interface Handle {
+  update(element: ReactNode): void;
+  resize(width: number, height: number): void;
+  destroy(): void;
+}
+
+const RESET_SGR = "\x1b[0m";
+const CLOSE_HYPERLINK = "\x1b]8;;\x1b\\";
+
+export function mount(element: ReactNode, opts: MountOptions): Handle {
+  let viewportWidth = opts.viewportWidth;
+  let viewportHeight = opts.viewportHeight;
+  let frame: Frame = emptyFrame(viewportWidth, viewportHeight);
+  let destroyed = false;
+
+  const root: HostRoot = {
+    children: [],
+    onCommit: () => {
+      if (destroyed) return;
+      const layout = collectRootLayout(root.children);
+      const screen = renderToScreen(layout, viewportWidth, opts.pools);
+      const next: Frame = {
+        screen,
+        viewportWidth,
+        viewportHeight,
+        cursor: opts.cursor?.() ?? { x: 0, y: screen.height, visible: true },
+      };
+      const patches = diffFrames(frame, next, opts.pools);
+      if (patches.length > 0) opts.write(serializePatches(patches));
+      frame = next;
+    },
+  };
+
+  const container = reconciler.createContainer(
+    root,
+    0,
+    null,
+    false,
+    null,
+    "rsx",
+    () => {
+      /* recoverable error */
+    },
+    null,
+  );
+
+  reconciler.updateContainer(element, container, null, () => {
+    /* committed */
+  });
+
+  return {
+    update(nextElement: ReactNode): void {
+      if (destroyed) return;
+      reconciler.updateContainer(nextElement, container, null, () => {
+        /* committed */
+      });
+    },
+    resize(width: number, height: number): void {
+      if (destroyed) return;
+      viewportWidth = width;
+      viewportHeight = height;
+      // Trigger a fresh paint at the new viewport.
+      root.onCommit();
+    },
+    destroy(): void {
+      if (destroyed) return;
+      destroyed = true;
+      reconciler.updateContainer(null, container, null, () => {
+        /* committed */
+      });
+      opts.write(`${RESET_SGR}${CLOSE_HYPERLINK}`);
+    },
+  };
+}
+
+function collectRootLayout(children: ReadonlyArray<unknown>): LayoutNode {
+  const layoutChildren: LayoutNode[] = [];
+  for (const c of children) {
+    const child = hostToLayoutNode(c as Parameters<typeof hostToLayoutNode>[0]);
+    if (child) layoutChildren.push(child);
+  }
+  if (layoutChildren.length === 1) return layoutChildren[0]!;
+  return { kind: "box", children: layoutChildren };
+}

--- a/tests/renderer/react.test.tsx
+++ b/tests/renderer/react.test.tsx
@@ -171,12 +171,14 @@ describe("render — style + hyperlink threading", () => {
   });
 });
 
-describe("render — direct host invocation throws", () => {
-  it("calling Box() directly throws (host marker, not real component)", () => {
-    expect(() => Box({})).toThrow(/host element/i);
+describe("render — Box / Text are host-typed elements", () => {
+  it("Box returns a React element with the host-box type", () => {
+    const el = Box({});
+    expect(el.type).toBe("rsx-box");
   });
 
-  it("calling Text() directly throws", () => {
-    expect(() => Text({})).toThrow(/host element/i);
+  it("Text returns a React element with the host-text type", () => {
+    const el = Text({});
+    expect(el.type).toBe("rsx-text");
   });
 });

--- a/tests/renderer/reconciler/mount.test.tsx
+++ b/tests/renderer/reconciler/mount.test.tsx
@@ -1,0 +1,182 @@
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React, { useEffect, useState } from "react";
+import { describe, expect, it } from "vitest";
+import { CharPool } from "../../../src/renderer/pools/char-pool.js";
+import { HyperlinkPool } from "../../../src/renderer/pools/hyperlink-pool.js";
+import { type AnsiCode, StylePool } from "../../../src/renderer/pools/style-pool.js";
+import { Box, Text } from "../../../src/renderer/react/components.js";
+import { mount } from "../../../src/renderer/reconciler/mount.js";
+import { makeTestWriter } from "../../../src/renderer/runtime/test-writer.js";
+
+const RED: AnsiCode = { apply: "\x1b[31m", revert: "\x1b[39m" };
+
+function pools() {
+  return {
+    char: new CharPool(),
+    style: new StylePool(),
+    hyperlink: new HyperlinkPool(),
+  };
+}
+
+function flush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("mount — initial render", () => {
+  it("paints the initial element via the reconciler", async () => {
+    const w = makeTestWriter();
+    const handle = mount(<Text>hi</Text>, {
+      viewportWidth: 5,
+      viewportHeight: 1,
+      pools: pools(),
+      write: w.write,
+    });
+    await flush();
+    expect(w.output()).toContain("hi");
+    handle.destroy();
+  });
+
+  it("renders Box composition", async () => {
+    const w = makeTestWriter();
+    const handle = mount(
+      <Box flexDirection="row">
+        <Text>L</Text>
+        <Text>R</Text>
+      </Box>,
+      { viewportWidth: 10, viewportHeight: 1, pools: pools(), write: w.write },
+    );
+    await flush();
+    const out = w.output();
+    expect(out).toContain("L");
+    expect(out).toContain("R");
+    handle.destroy();
+  });
+});
+
+describe("mount — explicit update()", () => {
+  it("rendering the same tree again writes nothing", async () => {
+    const w = makeTestWriter();
+    const handle = mount(<Text>same</Text>, {
+      viewportWidth: 5,
+      viewportHeight: 1,
+      pools: pools(),
+      write: w.write,
+    });
+    await flush();
+    w.flush();
+    handle.update(<Text>same</Text>);
+    await flush();
+    expect(w.output()).toBe("");
+    handle.destroy();
+  });
+
+  it("rendering a changed tree writes only the diff", async () => {
+    const w = makeTestWriter();
+    const handle = mount(<Text>aaaa</Text>, {
+      viewportWidth: 5,
+      viewportHeight: 1,
+      pools: pools(),
+      write: w.write,
+    });
+    await flush();
+    w.flush();
+    handle.update(<Text>aaba</Text>);
+    await flush();
+    const out = w.output();
+    expect(out).toContain("b");
+    expect(out).not.toContain("a");
+    handle.destroy();
+  });
+});
+
+describe("mount — useState drives re-render", () => {
+  it("a setState call triggers a paint without the caller calling update", async () => {
+    const w = makeTestWriter();
+    let setCount: ((n: number) => void) | null = null;
+    function Counter() {
+      const [count, setC] = useState(0);
+      setCount = setC;
+      return <Text>{`n=${count}`}</Text>;
+    }
+    const handle = mount(<Counter />, {
+      viewportWidth: 10,
+      viewportHeight: 1,
+      pools: pools(),
+      write: w.write,
+    });
+    await flush();
+    expect(w.output()).toContain("n=0");
+    w.flush();
+    setCount?.(7);
+    await flush();
+    expect(w.output()).toContain("7");
+    handle.destroy();
+  });
+
+  it("useEffect runs and its setState triggers a second paint", async () => {
+    const w = makeTestWriter();
+    function Async() {
+      const [v, setV] = useState("init");
+      useEffect(() => {
+        setV("done");
+      }, []);
+      return <Text>{v}</Text>;
+    }
+    const handle = mount(<Async />, {
+      viewportWidth: 10,
+      viewportHeight: 1,
+      pools: pools(),
+      write: w.write,
+    });
+    await flush();
+    expect(w.output()).toContain("done");
+    handle.destroy();
+  });
+});
+
+describe("mount — destroy", () => {
+  it("emits SGR reset on destroy", async () => {
+    const w = makeTestWriter();
+    const handle = mount(<Text>x</Text>, {
+      viewportWidth: 5,
+      viewportHeight: 1,
+      pools: pools(),
+      write: w.write,
+    });
+    await flush();
+    w.flush();
+    handle.destroy();
+    expect(w.output()).toContain("\x1b[0m");
+  });
+
+  it("update after destroy is a no-op", async () => {
+    const w = makeTestWriter();
+    const handle = mount(<Text>x</Text>, {
+      viewportWidth: 5,
+      viewportHeight: 1,
+      pools: pools(),
+      write: w.write,
+    });
+    await flush();
+    handle.destroy();
+    w.flush();
+    handle.update(<Text>ignored</Text>);
+    await flush();
+    expect(w.output()).toBe("");
+  });
+});
+
+describe("mount — style pass-through", () => {
+  it("RED text writes the ANSI sequence to the byte stream", async () => {
+    const w = makeTestWriter();
+    const handle = mount(<Text style={[RED]}>x</Text>, {
+      viewportWidth: 3,
+      viewportHeight: 1,
+      pools: pools(),
+      write: w.write,
+    });
+    await flush();
+    expect(w.output()).toContain("\x1b[31m");
+    handle.destroy();
+  });
+});


### PR DESCRIPTION
**The biggest jump in #160's pipeline.** `useState` / `useEffect` / re-render-on-state now drive paints automatically; the caller doesn't have to call `update()` after every state change. React's reconciler maintains the host node tree, fires our \`resetAfterCommit\` hook, and the hook walks the tree → LayoutNode → diff → bytes.

```tsx
function Counter() {
  const [n, setN] = useState(0);
  return <Text>{`n=${n}`}</Text>;
}

const handle = mount(<Counter />, { viewportWidth, viewportHeight, pools, write });
// setState inside Counter now triggers a paint without the caller doing anything.
handle.update(<NewApp />);   // explicit replace still works
handle.resize(cols, rows);
handle.destroy();
```

## Box / Text are now string-typed JSX intrinsics

To make the reconciler treat them as host elements (not function components it tries to invoke), `<Box>` and `<Text>` now return `React.createElement("rsx-box" / "rsx-text", props)`. Same approach Ink uses with `<ink-box>` / `<ink-text>` — the user-facing component is a thin wrapper, the actual host type is a string.

Reconciler's `createInstance` matches by string and constructs `HostBox` / `HostText` nodes. The existing no-reconciler walker in `react/render.ts` matches the same strings — both paths converge on the same identifiers.

## Host node tree

`HostBox` / `HostText` / `HostRawText` mirror the LayoutNode shape but mutable, so the reconciler's `commitUpdate` / `commitTextUpdate` / `appendChild` / `removeChild` / `insertBefore` callbacks operate on them directly. After every commit, `hostToLayoutNode` walks the tree and produces an immutable `LayoutNode` for the layout pass.

## What's still pending

- **Phase 5c**: stdin → keystroke events into the React tree (focus, key handlers).
- **Phase 5d**: replace Ink in Reasonix's CLI behind a feature flag.

## Test plan

- [x] `npm run verify` — 1985/1985 (added 9 reconciler-driven cases including `useState` triggering automatic re-paint, `useEffect` chaining a setState, post-destroy no-ops, style + Box composition through the reconciler)
- [ ] CI green

## Refs

- #160 — RFC + phased plan
- #170 — Renderer runtime this builds on top of
- Adds `react-reconciler@^0.29.2` + `@types/react-reconciler` as direct deps