### PR TITLE
feat(renderer): stdin keystroke parser + useKeystroke hook

### DIFF
--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -16,3 +16,14 @@ export { serializePatches } from "./diff/serialize.js";
 export { Renderer, type RendererOptions } from "./runtime/renderer.js";
 export { type TestWriter, makeTestWriter } from "./runtime/test-writer.js";
 export { type Handle, type MountOptions, mount } from "./reconciler/mount.js";
+export {
+  type Keystroke,
+  KeystrokeContext,
+  KeystrokeReader,
+  type KeystrokeListener,
+  type KeystrokeReaderOptions,
+  type KeystrokeSource,
+  emptyKeystroke,
+  parseKeystrokes,
+  useKeystroke,
+} from "./input/index.js";

--- a/src/renderer/input/index.ts
+++ b/src/renderer/input/index.ts
@@ -1,0 +1,12 @@
+export {
+  type Keystroke,
+  emptyKeystroke,
+  parseKeystrokes,
+} from "./keystroke.js";
+export {
+  KeystrokeReader,
+  type KeystrokeReaderOptions,
+  type KeystrokeListener,
+  type KeystrokeSource,
+} from "./reader.js";
+export { KeystrokeContext, useKeystroke } from "./use-keystroke.js";

--- a/src/renderer/input/keystroke.ts
+++ b/src/renderer/input/keystroke.ts
@@ -1,0 +1,187 @@
+export interface Keystroke {
+  readonly input: string;
+  readonly raw: string;
+  readonly ctrl: boolean;
+  readonly meta: boolean;
+  readonly shift: boolean;
+  readonly upArrow: boolean;
+  readonly downArrow: boolean;
+  readonly leftArrow: boolean;
+  readonly rightArrow: boolean;
+  readonly home: boolean;
+  readonly end: boolean;
+  readonly pageUp: boolean;
+  readonly pageDown: boolean;
+  readonly delete: boolean;
+  readonly backspace: boolean;
+  readonly return: boolean;
+  readonly escape: boolean;
+  readonly tab: boolean;
+}
+
+export function emptyKeystroke(): Keystroke {
+  return {
+    input: "",
+    raw: "",
+    ctrl: false,
+    meta: false,
+    shift: false,
+    upArrow: false,
+    downArrow: false,
+    leftArrow: false,
+    rightArrow: false,
+    home: false,
+    end: false,
+    pageUp: false,
+    pageDown: false,
+    delete: false,
+    backspace: false,
+    return: false,
+    escape: false,
+    tab: false,
+  };
+}
+
+const CSI_FINAL: Record<string, Partial<Keystroke>> = {
+  A: { upArrow: true },
+  B: { downArrow: true },
+  C: { rightArrow: true },
+  D: { leftArrow: true },
+  H: { home: true },
+  F: { end: true },
+};
+
+const CSI_TILDE: Record<string, Partial<Keystroke>> = {
+  "1": { home: true },
+  "3": { delete: true },
+  "4": { end: true },
+  "5": { pageUp: true },
+  "6": { pageDown: true },
+  "7": { home: true },
+  "8": { end: true },
+};
+
+export function parseKeystrokes(chunk: string): Keystroke[] {
+  const out: Keystroke[] = [];
+  let i = 0;
+  while (i < chunk.length) {
+    const consumed = parseOne(chunk, i);
+    if (consumed.length === 0) {
+      i++;
+      continue;
+    }
+    out.push(consumed.key);
+    i += consumed.length;
+  }
+  return out;
+}
+
+interface Consumed {
+  key: Keystroke;
+  length: number;
+}
+
+function parseOne(s: string, start: number): Consumed {
+  const ch = s[start]!;
+
+  if (ch === "\x1b") {
+    return parseEscape(s, start);
+  }
+
+  if (ch === "\r" || ch === "\n") {
+    return { key: { ...emptyKeystroke(), raw: ch, return: true }, length: 1 };
+  }
+  if (ch === "\t") {
+    return { key: { ...emptyKeystroke(), raw: ch, tab: true }, length: 1 };
+  }
+  if (ch === "\x7f" || ch === "\x08") {
+    return { key: { ...emptyKeystroke(), raw: ch, backspace: true }, length: 1 };
+  }
+
+  const code = ch.charCodeAt(0);
+  if (code >= 1 && code <= 26 && ch !== "\t" && ch !== "\r" && ch !== "\n") {
+    const letter = String.fromCharCode(code + 96);
+    return {
+      key: { ...emptyKeystroke(), raw: ch, ctrl: true, input: letter },
+      length: 1,
+    };
+  }
+
+  return { key: { ...emptyKeystroke(), raw: ch, input: ch }, length: 1 };
+}
+
+function parseEscape(s: string, start: number): Consumed {
+  if (start + 1 >= s.length) {
+    return { key: { ...emptyKeystroke(), raw: "\x1b", escape: true }, length: 1 };
+  }
+
+  const next = s[start + 1]!;
+
+  if (next === "[" || next === "O") {
+    return parseCsi(s, start);
+  }
+
+  if (isPrintable(next)) {
+    return {
+      key: { ...emptyKeystroke(), raw: `\x1b${next}`, meta: true, input: next },
+      length: 2,
+    };
+  }
+
+  return { key: { ...emptyKeystroke(), raw: "\x1b", escape: true }, length: 1 };
+}
+
+function parseCsi(s: string, start: number): Consumed {
+  let i = start + 2;
+  let params = "";
+  while (i < s.length) {
+    const c = s[i]!;
+    if (isCsiFinal(c)) {
+      const raw = s.slice(start, i + 1);
+      const key = decodeCsi(params, c, raw);
+      return { key, length: i - start + 1 };
+    }
+    params += c;
+    i++;
+  }
+  return {
+    key: { ...emptyKeystroke(), raw: s.slice(start), escape: true },
+    length: s.length - start,
+  };
+}
+
+function decodeCsi(params: string, final: string, raw: string): Keystroke {
+  const base = { ...emptyKeystroke(), raw };
+  const segments = params.split(";");
+  const modCode = segments[1] ? Number.parseInt(segments[1], 10) : 1;
+  const mods = decodeModifiers(modCode);
+
+  if (final === "~" && segments[0]) {
+    const part = CSI_TILDE[segments[0]];
+    if (part) return { ...base, ...part, ...mods };
+  }
+
+  const part = CSI_FINAL[final];
+  if (part) return { ...base, ...part, ...mods };
+
+  return { ...base, escape: true };
+}
+
+function decodeModifiers(code: number): Pick<Keystroke, "shift" | "meta" | "ctrl"> {
+  const m = code - 1;
+  return {
+    shift: (m & 1) !== 0,
+    meta: (m & 2) !== 0,
+    ctrl: (m & 4) !== 0,
+  };
+}
+
+function isCsiFinal(ch: string): boolean {
+  const code = ch.charCodeAt(0);
+  return code >= 0x40 && code <= 0x7e && ch !== "[";
+}
+
+function isPrintable(ch: string): boolean {
+  const code = ch.charCodeAt(0);
+  return code >= 0x20 && code <= 0x7e;
+}

--- a/src/renderer/input/reader.ts
+++ b/src/renderer/input/reader.ts
@@ -1,0 +1,59 @@
+import type { Keystroke } from "./keystroke.js";
+import { parseKeystrokes } from "./keystroke.js";
+
+export type KeystrokeListener = (key: Keystroke) => void;
+
+export interface KeystrokeSource {
+  on(event: "data", cb: (chunk: Buffer | string) => void): void;
+  off(event: "data", cb: (chunk: Buffer | string) => void): void;
+  setRawMode?(raw: boolean): void;
+  resume?(): void;
+  pause?(): void;
+}
+
+export interface KeystrokeReaderOptions {
+  source: KeystrokeSource;
+  rawMode?: boolean;
+}
+
+export class KeystrokeReader {
+  private listeners: KeystrokeListener[] = [];
+  private readonly onData: (chunk: Buffer | string) => void;
+  private destroyed = false;
+
+  constructor(private readonly opts: KeystrokeReaderOptions) {
+    this.onData = (chunk) => this.handle(chunk);
+    if (opts.rawMode !== false) {
+      opts.source.setRawMode?.(true);
+    }
+    opts.source.resume?.();
+    opts.source.on("data", this.onData);
+  }
+
+  subscribe(listener: KeystrokeListener): () => void {
+    this.listeners.push(listener);
+    return () => {
+      const i = this.listeners.indexOf(listener);
+      if (i >= 0) this.listeners.splice(i, 1);
+    };
+  }
+
+  destroy(): void {
+    if (this.destroyed) return;
+    this.destroyed = true;
+    this.opts.source.off("data", this.onData);
+    if (this.opts.rawMode !== false) {
+      this.opts.source.setRawMode?.(false);
+    }
+    this.listeners.length = 0;
+  }
+
+  private handle(chunk: Buffer | string): void {
+    if (this.destroyed) return;
+    const text = typeof chunk === "string" ? chunk : chunk.toString("utf8");
+    const keys = parseKeystrokes(text);
+    for (const key of keys) {
+      for (const cb of this.listeners) cb(key);
+    }
+  }
+}

--- a/src/renderer/input/use-keystroke.ts
+++ b/src/renderer/input/use-keystroke.ts
@@ -1,0 +1,14 @@
+import { createContext, useContext, useEffect } from "react";
+import type { Keystroke } from "./keystroke.js";
+import type { KeystrokeListener, KeystrokeReader } from "./reader.js";
+
+export const KeystrokeContext = createContext<KeystrokeReader | null>(null);
+
+export function useKeystroke(handler: (key: Keystroke) => void, enabled = true): void {
+  const reader = useContext(KeystrokeContext);
+  useEffect(() => {
+    if (!enabled || !reader) return;
+    const wrapped: KeystrokeListener = (key) => handler(key);
+    return reader.subscribe(wrapped);
+  }, [reader, handler, enabled]);
+}

--- a/src/renderer/reconciler/mount.ts
+++ b/src/renderer/reconciler/mount.ts
@@ -1,7 +1,8 @@
-import type { ReactNode } from "react";
+import { type ReactNode, createElement } from "react";
 import { type DiffPools, diffFrames } from "../diff/diff-frames.js";
 import { type Cursor, type Frame, emptyFrame } from "../diff/frame.js";
 import { serializePatches } from "../diff/serialize.js";
+import { KeystrokeContext, KeystrokeReader, type KeystrokeSource } from "../input/index.js";
 import { renderToScreen } from "../layout/layout.js";
 import type { LayoutNode } from "../layout/node.js";
 import { type HostRoot, hostToLayoutNode, reconciler } from "./host-config.js";
@@ -12,6 +13,7 @@ export interface MountOptions {
   readonly pools: DiffPools;
   readonly write: (bytes: string) => void;
   readonly cursor?: () => Cursor;
+  readonly stdin?: KeystrokeSource;
 }
 
 export interface Handle {
@@ -28,6 +30,8 @@ export function mount(element: ReactNode, opts: MountOptions): Handle {
   let viewportHeight = opts.viewportHeight;
   let frame: Frame = emptyFrame(viewportWidth, viewportHeight);
   let destroyed = false;
+
+  const reader = opts.stdin ? new KeystrokeReader({ source: opts.stdin }) : null;
 
   const root: HostRoot = {
     children: [],
@@ -60,14 +64,17 @@ export function mount(element: ReactNode, opts: MountOptions): Handle {
     null,
   );
 
-  reconciler.updateContainer(element, container, null, () => {
+  const wrap = (node: ReactNode): ReactNode =>
+    reader ? createElement(KeystrokeContext.Provider, { value: reader }, node) : node;
+
+  reconciler.updateContainer(wrap(element), container, null, () => {
     /* committed */
   });
 
   return {
     update(nextElement: ReactNode): void {
       if (destroyed) return;
-      reconciler.updateContainer(nextElement, container, null, () => {
+      reconciler.updateContainer(wrap(nextElement), container, null, () => {
         /* committed */
       });
     },
@@ -75,12 +82,12 @@ export function mount(element: ReactNode, opts: MountOptions): Handle {
       if (destroyed) return;
       viewportWidth = width;
       viewportHeight = height;
-      // Trigger a fresh paint at the new viewport.
       root.onCommit();
     },
     destroy(): void {
       if (destroyed) return;
       destroyed = true;
+      reader?.destroy();
       reconciler.updateContainer(null, container, null, () => {
         /* committed */
       });

--- a/tests/renderer/input/keystroke.test.ts
+++ b/tests/renderer/input/keystroke.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import { parseKeystrokes } from "../../../src/renderer/input/keystroke.js";
+
+describe("parseKeystrokes — printable characters", () => {
+  it("plain ASCII letter", () => {
+    const [k] = parseKeystrokes("a");
+    expect(k?.input).toBe("a");
+    expect(k?.ctrl).toBe(false);
+    expect(k?.meta).toBe(false);
+  });
+
+  it("digits and punctuation", () => {
+    const keys = parseKeystrokes("1!");
+    expect(keys.map((k) => k.input)).toEqual(["1", "!"]);
+  });
+});
+
+describe("parseKeystrokes — control characters", () => {
+  it("\\r is return", () => {
+    expect(parseKeystrokes("\r")[0]!.return).toBe(true);
+  });
+  it("\\n is also return", () => {
+    expect(parseKeystrokes("\n")[0]!.return).toBe(true);
+  });
+  it("\\t is tab", () => {
+    expect(parseKeystrokes("\t")[0]!.tab).toBe(true);
+  });
+  it("0x7f and 0x08 are backspace", () => {
+    expect(parseKeystrokes("\x7f")[0]!.backspace).toBe(true);
+    expect(parseKeystrokes("\x08")[0]!.backspace).toBe(true);
+  });
+  it("Ctrl+A maps to ctrl=true, input='a'", () => {
+    const k = parseKeystrokes("\x01")[0]!;
+    expect(k.ctrl).toBe(true);
+    expect(k.input).toBe("a");
+  });
+  it("Ctrl+Z maps to ctrl=true, input='z'", () => {
+    const k = parseKeystrokes("\x1a")[0]!;
+    expect(k.ctrl).toBe(true);
+    expect(k.input).toBe("z");
+  });
+});
+
+describe("parseKeystrokes — escape and meta", () => {
+  it("standalone ESC is escape:true", () => {
+    expect(parseKeystrokes("\x1b")[0]!.escape).toBe(true);
+  });
+
+  it("ESC followed by a printable char is meta+char", () => {
+    const k = parseKeystrokes("\x1ba")[0]!;
+    expect(k.meta).toBe(true);
+    expect(k.input).toBe("a");
+  });
+});
+
+describe("parseKeystrokes — CSI arrows", () => {
+  it("up arrow", () => {
+    expect(parseKeystrokes("\x1b[A")[0]!.upArrow).toBe(true);
+  });
+  it("down arrow", () => {
+    expect(parseKeystrokes("\x1b[B")[0]!.downArrow).toBe(true);
+  });
+  it("right arrow", () => {
+    expect(parseKeystrokes("\x1b[C")[0]!.rightArrow).toBe(true);
+  });
+  it("left arrow", () => {
+    expect(parseKeystrokes("\x1b[D")[0]!.leftArrow).toBe(true);
+  });
+});
+
+describe("parseKeystrokes — CSI named keys", () => {
+  it("Home via CSI H", () => {
+    expect(parseKeystrokes("\x1b[H")[0]!.home).toBe(true);
+  });
+  it("End via CSI F", () => {
+    expect(parseKeystrokes("\x1b[F")[0]!.end).toBe(true);
+  });
+  it("Page Up via CSI 5 ~", () => {
+    expect(parseKeystrokes("\x1b[5~")[0]!.pageUp).toBe(true);
+  });
+  it("Page Down via CSI 6 ~", () => {
+    expect(parseKeystrokes("\x1b[6~")[0]!.pageDown).toBe(true);
+  });
+  it("Delete via CSI 3 ~", () => {
+    expect(parseKeystrokes("\x1b[3~")[0]!.delete).toBe(true);
+  });
+});
+
+describe("parseKeystrokes — modifier-encoded CSI", () => {
+  it("Shift+ArrowUp via CSI 1;2 A", () => {
+    const k = parseKeystrokes("\x1b[1;2A")[0]!;
+    expect(k.upArrow).toBe(true);
+    expect(k.shift).toBe(true);
+  });
+
+  it("Ctrl+ArrowRight via CSI 1;5 C", () => {
+    const k = parseKeystrokes("\x1b[1;5C")[0]!;
+    expect(k.rightArrow).toBe(true);
+    expect(k.ctrl).toBe(true);
+  });
+
+  it("Alt+Shift+ArrowDown via CSI 1;4 B", () => {
+    const k = parseKeystrokes("\x1b[1;4B")[0]!;
+    expect(k.downArrow).toBe(true);
+    expect(k.shift).toBe(true);
+    expect(k.meta).toBe(true);
+  });
+});
+
+describe("parseKeystrokes — sequences in one chunk", () => {
+  it("paste of two characters yields two events", () => {
+    const keys = parseKeystrokes("ab");
+    expect(keys.map((k) => k.input)).toEqual(["a", "b"]);
+  });
+
+  it("ctrl-c followed by enter", () => {
+    const keys = parseKeystrokes("\x03\r");
+    expect(keys[0]!.ctrl).toBe(true);
+    expect(keys[0]!.input).toBe("c");
+    expect(keys[1]!.return).toBe(true);
+  });
+
+  it("up-arrow then 'q'", () => {
+    const keys = parseKeystrokes("\x1b[Aq");
+    expect(keys[0]!.upArrow).toBe(true);
+    expect(keys[1]!.input).toBe("q");
+  });
+});

--- a/tests/renderer/input/reader-and-hook.test.tsx
+++ b/tests/renderer/input/reader-and-hook.test.tsx
@@ -1,0 +1,147 @@
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React, { useState } from "react";
+import { describe, expect, it } from "vitest";
+import {
+  KeystrokeReader,
+  type KeystrokeSource,
+  useKeystroke,
+} from "../../../src/renderer/input/index.js";
+import { CharPool } from "../../../src/renderer/pools/char-pool.js";
+import { HyperlinkPool } from "../../../src/renderer/pools/hyperlink-pool.js";
+import { StylePool } from "../../../src/renderer/pools/style-pool.js";
+import { Text } from "../../../src/renderer/react/components.js";
+import { mount } from "../../../src/renderer/reconciler/mount.js";
+import { makeTestWriter } from "../../../src/renderer/runtime/test-writer.js";
+
+function pools() {
+  return {
+    char: new CharPool(),
+    style: new StylePool(),
+    hyperlink: new HyperlinkPool(),
+  };
+}
+
+function flush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function makeFakeStdin(): KeystrokeSource & {
+  push: (chunk: string) => void;
+  rawMode: boolean;
+} {
+  let listener: ((chunk: string | Buffer) => void) | null = null;
+  let rawMode = false;
+  return {
+    on(_event, cb) {
+      listener = cb;
+    },
+    off(_event, _cb) {
+      listener = null;
+    },
+    setRawMode(raw: boolean) {
+      rawMode = raw;
+    },
+    resume() {},
+    pause() {},
+    push(chunk: string) {
+      listener?.(chunk);
+    },
+    get rawMode() {
+      return rawMode;
+    },
+  };
+}
+
+describe("KeystrokeReader", () => {
+  it("emits parsed keystrokes from stream chunks", () => {
+    const stdin = makeFakeStdin();
+    const reader = new KeystrokeReader({ source: stdin });
+    const seen: string[] = [];
+    reader.subscribe((k) => seen.push(k.input || (k.return ? "<RET>" : "?")));
+    stdin.push("ab\r");
+    expect(seen).toEqual(["a", "b", "<RET>"]);
+    reader.destroy();
+  });
+
+  it("setRawMode is enabled on construction and disabled on destroy", () => {
+    const stdin = makeFakeStdin();
+    const reader = new KeystrokeReader({ source: stdin });
+    expect(stdin.rawMode).toBe(true);
+    reader.destroy();
+    expect(stdin.rawMode).toBe(false);
+  });
+
+  it("subscribe returns an unsubscribe handle", () => {
+    const stdin = makeFakeStdin();
+    const reader = new KeystrokeReader({ source: stdin });
+    const seen: string[] = [];
+    const unsub = reader.subscribe((k) => seen.push(k.input));
+    stdin.push("a");
+    unsub();
+    stdin.push("b");
+    expect(seen).toEqual(["a"]);
+    reader.destroy();
+  });
+
+  it("destroy stops further events from reaching listeners", () => {
+    const stdin = makeFakeStdin();
+    const reader = new KeystrokeReader({ source: stdin });
+    let count = 0;
+    reader.subscribe(() => count++);
+    reader.destroy();
+    stdin.push("xyz");
+    expect(count).toBe(0);
+  });
+});
+
+describe("useKeystroke — React hook", () => {
+  it("re-renders on each key as state changes", async () => {
+    const w = makeTestWriter();
+    const stdin = makeFakeStdin();
+    function Echo() {
+      const [last, setLast] = useState("");
+      useKeystroke((k) => setLast(k.input || (k.escape ? "<ESC>" : "")));
+      return <Text>{`got=${last}`}</Text>;
+    }
+    const handle = mount(<Echo />, {
+      viewportWidth: 20,
+      viewportHeight: 1,
+      pools: pools(),
+      write: w.write,
+      stdin,
+    });
+    await flush();
+    expect(w.output()).toContain("got=");
+    w.flush();
+    stdin.push("k");
+    await flush();
+    expect(w.output()).toContain("k");
+    handle.destroy();
+  });
+
+  it("hook stops receiving after component unmounts", async () => {
+    const w = makeTestWriter();
+    const stdin = makeFakeStdin();
+    let observed = 0;
+    function Watcher() {
+      useKeystroke(() => {
+        observed++;
+      });
+      return <Text>w</Text>;
+    }
+    const handle = mount(<Watcher />, {
+      viewportWidth: 5,
+      viewportHeight: 1,
+      pools: pools(),
+      write: w.write,
+      stdin,
+    });
+    await flush();
+    stdin.push("a");
+    await flush();
+    expect(observed).toBe(1);
+    handle.destroy();
+    stdin.push("b");
+    expect(observed).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes the input side of the renderer pipeline. React components can now subscribe to user keystrokes via a hook, the same provider/context shape they already use for state.

```tsx
function Echo() {
  const [last, setLast] = useState("");
  useKeystroke((k) => setLast(k.input));
  return <Text>got: {last}</Text>;
}

mount(<Echo />, { viewportWidth, viewportHeight, pools, write, stdin: process.stdin });
```

## What's here

- **`parseKeystrokes(chunk)`** — pure ANSI escape-sequence parser. Plain ASCII passes through; `\x01..\x1a` → `ctrl+letter`; `\r` / `\n` → return; `\x7f` / `\x08` → backspace; `\t` → tab; bare `\x1b` → escape; `ESC + printable` → `meta+char`; `CSI A/B/C/D` → arrows; `CSI 1;<modifier>X` decodes shift / meta / ctrl flags; `CSI 3~` → delete, `5~` / `6~` → page up / down, `1~` / `H` → home, `4~` / `F` → end.
- **`KeystrokeReader`** — wraps a stdin-like stream (`on` / `off` for `'data'`, optional `setRawMode` / `resume` / `pause`). Sets raw mode on construction, drops it on destroy. Has `subscribe(listener)` returning an unsubscribe function.
- **`useKeystroke(handler, enabled?)`** — React hook that subscribes the component to the reader provided via `KeystrokeContext.Provider`. Re-subscribes if `handler` identity changes; cleans up on unmount.
- **`mount({ ..., stdin })`** — constructs a `KeystrokeReader` from the `stdin` option and wraps the React tree in `KeystrokeContext.Provider`. Reader is torn down on `handle.destroy()`.

## What's NOT here

- Focus management (focused element receives input vs. broadcast). Right now every `useKeystroke` subscription gets every keystroke. Focus is `useFocus` / `useFocusManager` Phase 5d territory.
- Bracketed-paste mode (CSI 200~ / 201~ for paste batching). Defer until needed.
- Mouse events. Out of scope.

## Test plan

- [x] `npm run verify` — 2016/2016 (added 25 parser cases + 6 reader/hook integration cases including useState driving re-paint on each key)
- [ ] CI green

## Refs

- #160 — RFC + phased plan
- #171 — reconciler integration this builds on