### PR TITLE
feat(renderer): reasonix renderer-demo subcommand (#160)

### DIFF
--- a/src/cli/commands/renderer-demo.tsx
+++ b/src/cli/commands/renderer-demo.tsx
@@ -1,0 +1,121 @@
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React, { useState } from "react";
+import {
+  Box,
+  CharPool,
+  HyperlinkPool,
+  type Keystroke,
+  StylePool,
+  Text,
+  mount,
+  useKeystroke,
+} from "../../renderer/index.js";
+
+const ACCENT = { apply: "\x1b[36m", revert: "\x1b[39m" };
+const DIM = { apply: "\x1b[2m", revert: "\x1b[22m" };
+const FAINT_BORDER = [{ apply: "\x1b[90m", revert: "\x1b[39m" }];
+
+function describeKey(k: Keystroke): string {
+  if (k.escape) return "ESC";
+  if (k.return) return "Return";
+  if (k.tab) return "Tab";
+  if (k.backspace) return "Backspace";
+  if (k.delete) return "Delete";
+  if (k.upArrow) return `${modPrefix(k)}↑`;
+  if (k.downArrow) return `${modPrefix(k)}↓`;
+  if (k.leftArrow) return `${modPrefix(k)}←`;
+  if (k.rightArrow) return `${modPrefix(k)}→`;
+  if (k.home) return "Home";
+  if (k.end) return "End";
+  if (k.pageUp) return "PageUp";
+  if (k.pageDown) return "PageDown";
+  if (k.ctrl && k.input) return `Ctrl+${k.input.toUpperCase()}`;
+  if (k.meta && k.input) return `Alt+${k.input}`;
+  return k.input || "?";
+}
+
+function modPrefix(k: Keystroke): string {
+  let p = "";
+  if (k.ctrl) p += "Ctrl+";
+  if (k.meta) p += "Alt+";
+  if (k.shift) p += "Shift+";
+  return p;
+}
+
+function Demo({ onExit }: { onExit: () => void }) {
+  const [count, setCount] = useState(0);
+  const [last, setLast] = useState<string>("(none yet)");
+
+  useKeystroke((k) => {
+    if (k.escape) {
+      onExit();
+      return;
+    }
+    setCount((n) => n + 1);
+    setLast(describeKey(k));
+  });
+
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor={FAINT_BORDER} padding={1}>
+      <Text style={[ACCENT]}>Reasonix cell-diff renderer · demo</Text>
+      <Text style={[DIM]}>Press any key. ESC to exit.</Text>
+      <Box paddingTop={1} flexDirection="row">
+        <Text>{"Count : "}</Text>
+        <Text>{String(count)}</Text>
+      </Box>
+      <Box flexDirection="row">
+        <Text>{"Last  : "}</Text>
+        <Text>{last}</Text>
+      </Box>
+    </Box>
+  );
+}
+
+export interface RendererDemoOptions {
+  /** Optional override for stdout (used by tests). */
+  stdout?: NodeJS.WriteStream;
+  /** Optional override for stdin (used by tests). */
+  stdin?: NodeJS.ReadStream;
+}
+
+export async function runRendererDemo(opts: RendererDemoOptions = {}): Promise<void> {
+  const stdout = opts.stdout ?? process.stdout;
+  const stdin = opts.stdin ?? process.stdin;
+
+  if (!stdin.isTTY || !stdout.isTTY) {
+    console.error("renderer-demo requires an interactive TTY.");
+    process.exit(1);
+  }
+
+  const pools = {
+    char: new CharPool(),
+    style: new StylePool(),
+    hyperlink: new HyperlinkPool(),
+  };
+
+  let resolveExit: () => void = () => {};
+  const exited = new Promise<void>((resolve) => {
+    resolveExit = resolve;
+  });
+
+  const handle = mount(<Demo onExit={() => resolveExit()} />, {
+    viewportWidth: stdout.columns ?? 80,
+    viewportHeight: stdout.rows ?? 24,
+    pools,
+    write: (bytes) => stdout.write(bytes),
+    stdin,
+  });
+
+  const onResize = () => {
+    handle.resize(stdout.columns ?? 80, stdout.rows ?? 24);
+  };
+  stdout.on("resize", onResize);
+
+  try {
+    await exited;
+  } finally {
+    stdout.off("resize", onResize);
+    handle.destroy();
+    stdin.pause();
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -342,6 +342,14 @@ mcp
 program.command("version").description(t("cli.version")).action(versionCommand);
 
 program
+  .command("renderer-demo")
+  .description("experimental — interactive cell-diff renderer demo (separate from the main TUI)")
+  .action(async () => {
+    const { runRendererDemo } = await import("./commands/renderer-demo.js");
+    await runRendererDemo();
+  });
+
+program
   .command("update")
   .description(t("cli.update"))
   .option("--dry-run", t("ui.dryRunHint"))

--- a/tests/renderer/renderer-demo.test.tsx
+++ b/tests/renderer/renderer-demo.test.tsx
@@ -1,0 +1,139 @@
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React from "react";
+import { describe, expect, it } from "vitest";
+import {
+  CharPool,
+  HyperlinkPool,
+  type KeystrokeSource,
+  StylePool,
+  mount,
+} from "../../src/renderer/index.js";
+import { makeTestWriter } from "../../src/renderer/runtime/test-writer.js";
+
+import { useState } from "react";
+// Local copy of the demo component so we exercise the same React tree the CLI mounts,
+// without spinning up a real stdout/TTY.
+import { Box, Text, useKeystroke } from "../../src/renderer/index.js";
+
+function describeKey(k: { input: string; escape: boolean; ctrl: boolean }): string {
+  if (k.escape) return "ESC";
+  if (k.ctrl && k.input) return `Ctrl+${k.input.toUpperCase()}`;
+  return k.input || "?";
+}
+
+function Demo({ onExit }: { onExit: () => void }) {
+  const [count, setCount] = useState(0);
+  const [last, setLast] = useState("(none yet)");
+  useKeystroke((k) => {
+    if (k.escape) {
+      onExit();
+      return;
+    }
+    setCount((n) => n + 1);
+    setLast(describeKey(k));
+  });
+  return (
+    <Box flexDirection="column" padding={1}>
+      <Text>Reasonix demo</Text>
+      <Box flexDirection="row">
+        <Text>{"Count: "}</Text>
+        <Text>{String(count)}</Text>
+      </Box>
+      <Box flexDirection="row">
+        <Text>{"Last:  "}</Text>
+        <Text>{last}</Text>
+      </Box>
+    </Box>
+  );
+}
+
+function pools() {
+  return { char: new CharPool(), style: new StylePool(), hyperlink: new HyperlinkPool() };
+}
+
+function flush(): Promise<void> {
+  return new Promise((r) => setTimeout(r, 0));
+}
+
+function makeFakeStdin(): KeystrokeSource & { push: (s: string) => void } {
+  let listener: ((chunk: string | Buffer) => void) | null = null;
+  return {
+    on(_event, cb) {
+      listener = cb;
+    },
+    off(_event, _cb) {
+      listener = null;
+    },
+    setRawMode() {},
+    resume() {},
+    pause() {},
+    push(chunk: string) {
+      listener?.(chunk);
+    },
+  };
+}
+
+describe("renderer-demo (component-level)", () => {
+  it("paints initial frame with Count: 0 and the placeholder Last", async () => {
+    const w = makeTestWriter();
+    const stdin = makeFakeStdin();
+    const handle = mount(<Demo onExit={() => {}} />, {
+      viewportWidth: 30,
+      viewportHeight: 6,
+      pools: pools(),
+      write: w.write,
+      stdin,
+    });
+    await flush();
+    const out = w.output();
+    expect(out).toContain("Count:");
+    expect(out).toContain("0");
+    expect(out).toContain("(none yet)");
+    handle.destroy();
+  });
+
+  it("a printable keystroke increments count and updates last", async () => {
+    const w = makeTestWriter();
+    const stdin = makeFakeStdin();
+    const handle = mount(<Demo onExit={() => {}} />, {
+      viewportWidth: 30,
+      viewportHeight: 6,
+      pools: pools(),
+      write: w.write,
+      stdin,
+    });
+    await flush();
+    w.flush();
+    stdin.push("k");
+    await flush();
+    const out = w.output();
+    expect(out).toContain("1");
+    expect(out).toContain("k");
+    handle.destroy();
+  });
+
+  it("ESC triggers the onExit callback", async () => {
+    const w = makeTestWriter();
+    const stdin = makeFakeStdin();
+    let exited = false;
+    const handle = mount(
+      <Demo
+        onExit={() => {
+          exited = true;
+        }}
+      />,
+      {
+        viewportWidth: 30,
+        viewportHeight: 6,
+        pools: pools(),
+        write: w.write,
+        stdin,
+      },
+    );
+    await flush();
+    stdin.push("\x1b");
+    await flush();
+    expect(exited).toBe(true);
+    handle.destroy();
+  });
+});


### PR DESCRIPTION
Phase 5d-1 of the cell-diff renderer (#160).

Adds `reasonix renderer-demo` — an interactive subcommand that mounts our renderer against real stdin / stdout. It draws a small bordered card with a counter and the last keystroke; ESC exits. The main Ink-based App is **not** touched.

This is the first time the renderer runs end-to-end outside the test harness, which is a meaningful checkpoint before any migration of real UI surfaces.

## What's in

- `src/cli/commands/renderer-demo.tsx` — `Demo` component (counter + last key) and `runRendererDemo()` that mounts to real `process.stdin` / `process.stdout`, wires resize, and tears down cleanly on ESC.
- `src/cli/index.ts` — registers the subcommand under `reasonix renderer-demo`. Marked `experimental` in the description.
- `tests/renderer/renderer-demo.test.tsx` — 3 component-level tests through the test writer + a fake stdin: initial paint, key increments count, ESC triggers `onExit`.

## Why a subcommand and not a flag on the main TUI

The main App is still Ink-driven; mixing the two renderers in one process would just create coordination headaches. A standalone subcommand lets us prove the renderer end-to-end (real terminal, real keystrokes, real resize) without committing to a migration path yet.

## Future phases (still open)

- 5d-2: Ink-prop compatibility shim so existing components can render under either backend
- 5d-3: migrate one isolated component (e.g., welcome banner) behind a flag
- 5d-4: full top-level swap

## Test plan

- [x] `npm run verify` — 2019 passing tests, lint clean, typecheck clean
- [ ] `node dist/cli/index.js renderer-demo` in Windows Terminal: card renders, keystrokes update counter, ESC exits cleanly
- [ ] resize during demo: layout reflows without flicker