### PR TITLE
feat(renderer): ink-compat shim — Box / Text / Spacer / Static / hooks (#160)

### DIFF
--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -27,3 +27,4 @@ export {
   parseKeystrokes,
   useKeystroke,
 } from "./input/index.js";
+export * as inkCompat from "./ink-compat/index.js";

--- a/src/renderer/ink-compat/Box.tsx
+++ b/src/renderer/ink-compat/Box.tsx
@@ -1,0 +1,88 @@
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React, { type ReactNode } from "react";
+import type { BorderStyleName } from "../layout/borders.js";
+import { Box as RsxBox } from "../react/components.js";
+import { fgCode } from "./colors.js";
+
+export interface InkBoxProps {
+  readonly children?: ReactNode;
+  readonly flexDirection?: "row" | "column";
+  readonly flexGrow?: number;
+  readonly flexShrink?: number;
+  readonly padding?: number;
+  readonly paddingX?: number;
+  readonly paddingY?: number;
+  readonly paddingTop?: number;
+  readonly paddingBottom?: number;
+  readonly paddingLeft?: number;
+  readonly paddingRight?: number;
+  readonly margin?: number;
+  readonly marginX?: number;
+  readonly marginY?: number;
+  readonly marginTop?: number;
+  readonly marginBottom?: number;
+  readonly marginLeft?: number;
+  readonly marginRight?: number;
+  readonly borderStyle?: BorderStyleName;
+  readonly borderColor?: string;
+  readonly borderTop?: boolean;
+  readonly borderBottom?: boolean;
+  readonly borderLeft?: boolean;
+  readonly borderRight?: boolean;
+  readonly width?: number | string;
+  readonly height?: number | string;
+  readonly minWidth?: number;
+  readonly justifyContent?: "flex-start" | "flex-end" | "center" | "space-between" | "space-around";
+  readonly alignItems?: "flex-start" | "flex-end" | "center" | "stretch";
+  readonly gap?: number;
+}
+
+export function Box(props: InkBoxProps): React.ReactElement {
+  const padTop = pickPad(props.paddingTop, props.paddingY, props.padding);
+  const padBottom = pickPad(props.paddingBottom, props.paddingY, props.padding);
+  const padLeft = pickPad(props.paddingLeft, props.paddingX, props.padding);
+  const padRight = pickPad(props.paddingRight, props.paddingX, props.padding);
+  const marginTop = pickPad(props.marginTop, props.marginY, props.margin);
+  const marginBottom = pickPad(props.marginBottom, props.marginY, props.margin);
+  const marginLeft = pickPad(props.marginLeft, props.marginX, props.margin);
+  const marginRight = pickPad(props.marginRight, props.marginX, props.margin);
+
+  const borderColor = fgCode(props.borderColor);
+  const inner = (
+    <RsxBox
+      flexDirection={props.flexDirection}
+      flexGrow={marginTop || marginBottom || marginLeft || marginRight ? undefined : props.flexGrow}
+      paddingTop={padTop}
+      paddingBottom={padBottom}
+      paddingLeft={padLeft}
+      paddingRight={padRight}
+      borderStyle={props.borderStyle}
+      borderColor={borderColor ? [borderColor] : undefined}
+      borderTop={props.borderTop}
+      borderBottom={props.borderBottom}
+      borderLeft={props.borderLeft}
+      borderRight={props.borderRight}
+    >
+      {props.children}
+    </RsxBox>
+  );
+
+  if (!(marginTop || marginBottom || marginLeft || marginRight)) return inner;
+
+  return (
+    <RsxBox
+      flexGrow={props.flexGrow}
+      paddingTop={marginTop}
+      paddingBottom={marginBottom}
+      paddingLeft={marginLeft}
+      paddingRight={marginRight}
+    >
+      {inner}
+    </RsxBox>
+  );
+}
+
+function pickPad(...values: ReadonlyArray<number | undefined>): number {
+  for (const v of values) if (v !== undefined) return v;
+  return 0;
+}

--- a/src/renderer/ink-compat/Spacer.tsx
+++ b/src/renderer/ink-compat/Spacer.tsx
@@ -1,0 +1,7 @@
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React from "react";
+import { Box } from "../react/components.js";
+
+export function Spacer(): React.ReactElement {
+  return <Box flexGrow={1} />;
+}

--- a/src/renderer/ink-compat/Static.tsx
+++ b/src/renderer/ink-compat/Static.tsx
@@ -1,0 +1,19 @@
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React, { type ReactNode } from "react";
+import { Box } from "../react/components.js";
+
+export interface StaticProps<T> {
+  readonly items: ReadonlyArray<T>;
+  readonly children: (item: T, index: number) => ReactNode;
+}
+
+export function Static<T>(props: StaticProps<T>): React.ReactElement {
+  return (
+    <Box flexDirection="column">
+      {props.items.map((item, i) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: Static items are positional and stable per render — Ink uses index keys here too
+        <React.Fragment key={`s-${i}`}>{props.children(item, i)}</React.Fragment>
+      ))}
+    </Box>
+  );
+}

--- a/src/renderer/ink-compat/Text.tsx
+++ b/src/renderer/ink-compat/Text.tsx
@@ -1,0 +1,42 @@
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React, { type ReactNode } from "react";
+import type { AnsiCode } from "../pools/style-pool.js";
+import { Text as RsxText } from "../react/components.js";
+import { bgCode, fgCode } from "./colors.js";
+
+export interface InkTextProps {
+  readonly children?: ReactNode;
+  readonly color?: string;
+  readonly backgroundColor?: string;
+  readonly bold?: boolean;
+  readonly dimColor?: boolean;
+  readonly italic?: boolean;
+  readonly underline?: boolean;
+  readonly strikethrough?: boolean;
+  readonly inverse?: boolean;
+  readonly wrap?: "wrap" | "truncate" | "truncate-start" | "truncate-middle" | "truncate-end";
+}
+
+const SGR = {
+  bold: { apply: "\x1b[1m", revert: "\x1b[22m" },
+  dim: { apply: "\x1b[2m", revert: "\x1b[22m" },
+  italic: { apply: "\x1b[3m", revert: "\x1b[23m" },
+  underline: { apply: "\x1b[4m", revert: "\x1b[24m" },
+  inverse: { apply: "\x1b[7m", revert: "\x1b[27m" },
+  strikethrough: { apply: "\x1b[9m", revert: "\x1b[29m" },
+} as const;
+
+export function Text(props: InkTextProps): React.ReactElement {
+  const codes: AnsiCode[] = [];
+  const fg = fgCode(props.color);
+  if (fg) codes.push(fg);
+  const bg = bgCode(props.backgroundColor);
+  if (bg) codes.push(bg);
+  if (props.bold) codes.push(SGR.bold);
+  if (props.dimColor) codes.push(SGR.dim);
+  if (props.italic) codes.push(SGR.italic);
+  if (props.underline) codes.push(SGR.underline);
+  if (props.inverse) codes.push(SGR.inverse);
+  if (props.strikethrough) codes.push(SGR.strikethrough);
+  return <RsxText style={codes.length > 0 ? codes : undefined}>{props.children}</RsxText>;
+}

--- a/src/renderer/ink-compat/colors.ts
+++ b/src/renderer/ink-compat/colors.ts
@@ -1,0 +1,87 @@
+import type { AnsiCode } from "../pools/style-pool.js";
+
+export type ColorName =
+  | "black"
+  | "red"
+  | "green"
+  | "yellow"
+  | "blue"
+  | "magenta"
+  | "cyan"
+  | "white"
+  | "gray"
+  | "grey"
+  | "blackBright"
+  | "redBright"
+  | "greenBright"
+  | "yellowBright"
+  | "blueBright"
+  | "magentaBright"
+  | "cyanBright"
+  | "whiteBright";
+
+const FG_BASE: Record<ColorName, number> = {
+  black: 30,
+  red: 31,
+  green: 32,
+  yellow: 33,
+  blue: 34,
+  magenta: 35,
+  cyan: 36,
+  white: 37,
+  gray: 90,
+  grey: 90,
+  blackBright: 90,
+  redBright: 91,
+  greenBright: 92,
+  yellowBright: 93,
+  blueBright: 94,
+  magentaBright: 95,
+  cyanBright: 96,
+  whiteBright: 97,
+};
+
+const FG_RESET = 39;
+const BG_RESET = 49;
+
+export function fgCode(color: string | undefined): AnsiCode | null {
+  if (!color) return null;
+  if (color.startsWith("#")) {
+    const rgb = parseHex(color);
+    if (!rgb) return null;
+    return { apply: `\x1b[38;2;${rgb[0]};${rgb[1]};${rgb[2]}m`, revert: `\x1b[${FG_RESET}m` };
+  }
+  const code = FG_BASE[color as ColorName];
+  if (code === undefined) return null;
+  return { apply: `\x1b[${code}m`, revert: `\x1b[${FG_RESET}m` };
+}
+
+export function bgCode(color: string | undefined): AnsiCode | null {
+  if (!color) return null;
+  if (color.startsWith("#")) {
+    const rgb = parseHex(color);
+    if (!rgb) return null;
+    return { apply: `\x1b[48;2;${rgb[0]};${rgb[1]};${rgb[2]}m`, revert: `\x1b[${BG_RESET}m` };
+  }
+  const base = FG_BASE[color as ColorName];
+  if (base === undefined) return null;
+  const bg = base < 90 ? base + 10 : base + 10;
+  return { apply: `\x1b[${bg}m`, revert: `\x1b[${BG_RESET}m` };
+}
+
+function parseHex(hex: string): [number, number, number] | null {
+  const s = hex.slice(1);
+  if (s.length === 3) {
+    const r = Number.parseInt(s[0]! + s[0]!, 16);
+    const g = Number.parseInt(s[1]! + s[1]!, 16);
+    const b = Number.parseInt(s[2]! + s[2]!, 16);
+    return Number.isNaN(r) ? null : [r, g, b];
+  }
+  if (s.length === 6) {
+    const r = Number.parseInt(s.slice(0, 2), 16);
+    const g = Number.parseInt(s.slice(2, 4), 16);
+    const b = Number.parseInt(s.slice(4, 6), 16);
+    return Number.isNaN(r) ? null : [r, g, b];
+  }
+  return null;
+}

--- a/src/renderer/ink-compat/index.ts
+++ b/src/renderer/ink-compat/index.ts
@@ -1,0 +1,8 @@
+export { Box, type InkBoxProps } from "./Box.js";
+export { Text, type InkTextProps } from "./Text.js";
+export { Spacer } from "./Spacer.js";
+export { Static, type StaticProps } from "./Static.js";
+export { type ColorName, bgCode, fgCode } from "./colors.js";
+export { type ViewportSize, ViewportContext, useStdout } from "./viewport.js";
+export { type AppApi, AppContext, useApp } from "./use-app.js";
+export { type InkInputHandler, type InkKey, type UseInputOptions, useInput } from "./use-input.js";

--- a/src/renderer/ink-compat/use-app.ts
+++ b/src/renderer/ink-compat/use-app.ts
@@ -1,0 +1,11 @@
+import { createContext, useContext } from "react";
+
+export interface AppApi {
+  readonly exit: (error?: Error) => void;
+}
+
+export const AppContext = createContext<AppApi>({ exit: () => {} });
+
+export function useApp(): AppApi {
+  return useContext(AppContext);
+}

--- a/src/renderer/ink-compat/use-input.ts
+++ b/src/renderer/ink-compat/use-input.ts
@@ -1,0 +1,51 @@
+import { type Keystroke, useKeystroke } from "../input/index.js";
+
+export interface InkKey {
+  readonly upArrow: boolean;
+  readonly downArrow: boolean;
+  readonly leftArrow: boolean;
+  readonly rightArrow: boolean;
+  readonly pageDown: boolean;
+  readonly pageUp: boolean;
+  readonly return: boolean;
+  readonly escape: boolean;
+  readonly ctrl: boolean;
+  readonly shift: boolean;
+  readonly tab: boolean;
+  readonly backspace: boolean;
+  readonly delete: boolean;
+  readonly meta: boolean;
+}
+
+export type InkInputHandler = (input: string, key: InkKey) => void;
+
+export interface UseInputOptions {
+  readonly isActive?: boolean;
+}
+
+export function useInput(handler: InkInputHandler, options: UseInputOptions = {}): void {
+  const active = options.isActive !== false;
+  useKeystroke((k: Keystroke) => {
+    if (!active) return;
+    handler(k.input ?? "", toInkKey(k));
+  });
+}
+
+function toInkKey(k: Keystroke): InkKey {
+  return {
+    upArrow: k.upArrow,
+    downArrow: k.downArrow,
+    leftArrow: k.leftArrow,
+    rightArrow: k.rightArrow,
+    pageDown: k.pageDown,
+    pageUp: k.pageUp,
+    return: k.return,
+    escape: k.escape,
+    ctrl: k.ctrl,
+    shift: k.shift,
+    tab: k.tab,
+    backspace: k.backspace,
+    delete: k.delete,
+    meta: k.meta,
+  };
+}

--- a/src/renderer/ink-compat/viewport.ts
+++ b/src/renderer/ink-compat/viewport.ts
@@ -1,0 +1,13 @@
+import { createContext, useContext } from "react";
+
+export interface ViewportSize {
+  readonly columns: number;
+  readonly rows: number;
+}
+
+export const ViewportContext = createContext<ViewportSize>({ columns: 80, rows: 24 });
+
+export function useStdout(): { stdout: { columns: number; rows: number } } {
+  const v = useContext(ViewportContext);
+  return { stdout: { columns: v.columns, rows: v.rows } };
+}

--- a/src/renderer/reconciler/mount.ts
+++ b/src/renderer/reconciler/mount.ts
@@ -2,6 +2,7 @@ import { type ReactNode, createElement } from "react";
 import { type DiffPools, diffFrames } from "../diff/diff-frames.js";
 import { type Cursor, type Frame, emptyFrame } from "../diff/frame.js";
 import { serializePatches } from "../diff/serialize.js";
+import { ViewportContext } from "../ink-compat/viewport.js";
 import { KeystrokeContext, KeystrokeReader, type KeystrokeSource } from "../input/index.js";
 import { renderToScreen } from "../layout/layout.js";
 import type { LayoutNode } from "../layout/node.js";
@@ -30,6 +31,7 @@ export function mount(element: ReactNode, opts: MountOptions): Handle {
   let viewportHeight = opts.viewportHeight;
   let frame: Frame = emptyFrame(viewportWidth, viewportHeight);
   let destroyed = false;
+  let lastElement: ReactNode = element;
 
   const reader = opts.stdin ? new KeystrokeReader({ source: opts.stdin }) : null;
 
@@ -64,8 +66,16 @@ export function mount(element: ReactNode, opts: MountOptions): Handle {
     null,
   );
 
-  const wrap = (node: ReactNode): ReactNode =>
-    reader ? createElement(KeystrokeContext.Provider, { value: reader }, node) : node;
+  const wrap = (node: ReactNode): ReactNode => {
+    const withViewport: ReactNode = createElement(
+      ViewportContext.Provider,
+      { value: { columns: viewportWidth, rows: viewportHeight } },
+      node,
+    );
+    return reader
+      ? createElement(KeystrokeContext.Provider, { value: reader }, withViewport)
+      : withViewport;
+  };
 
   reconciler.updateContainer(wrap(element), container, null, () => {
     /* committed */
@@ -74,6 +84,7 @@ export function mount(element: ReactNode, opts: MountOptions): Handle {
   return {
     update(nextElement: ReactNode): void {
       if (destroyed) return;
+      lastElement = nextElement;
       reconciler.updateContainer(wrap(nextElement), container, null, () => {
         /* committed */
       });
@@ -82,7 +93,9 @@ export function mount(element: ReactNode, opts: MountOptions): Handle {
       if (destroyed) return;
       viewportWidth = width;
       viewportHeight = height;
-      root.onCommit();
+      reconciler.updateContainer(wrap(lastElement), container, null, () => {
+        /* committed */
+      });
     },
     destroy(): void {
       if (destroyed) return;

--- a/tests/renderer/ink-compat/colors.test.ts
+++ b/tests/renderer/ink-compat/colors.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { bgCode, fgCode } from "../../../src/renderer/ink-compat/colors.js";
+
+describe("fgCode — named colors", () => {
+  it("cyan → SGR 36 with 39 revert", () => {
+    expect(fgCode("cyan")).toEqual({ apply: "\x1b[36m", revert: "\x1b[39m" });
+  });
+  it("gray and grey both map to 90", () => {
+    expect(fgCode("gray")?.apply).toBe("\x1b[90m");
+    expect(fgCode("grey")?.apply).toBe("\x1b[90m");
+  });
+  it("redBright maps to 91", () => {
+    expect(fgCode("redBright")?.apply).toBe("\x1b[91m");
+  });
+  it("unknown color returns null", () => {
+    expect(fgCode("plaid")).toBeNull();
+  });
+  it("undefined returns null", () => {
+    expect(fgCode(undefined)).toBeNull();
+  });
+});
+
+describe("fgCode — hex colors", () => {
+  it("#ff8800 → 24-bit fg", () => {
+    expect(fgCode("#ff8800")).toEqual({
+      apply: "\x1b[38;2;255;136;0m",
+      revert: "\x1b[39m",
+    });
+  });
+  it("#fa0 short form expands", () => {
+    expect(fgCode("#fa0")?.apply).toBe("\x1b[38;2;255;170;0m");
+  });
+});
+
+describe("bgCode — named colors", () => {
+  it("blue → SGR 44", () => {
+    expect(bgCode("blue")).toEqual({ apply: "\x1b[44m", revert: "\x1b[49m" });
+  });
+  it("gray → 100", () => {
+    expect(bgCode("gray")?.apply).toBe("\x1b[100m");
+  });
+});
+
+describe("bgCode — hex", () => {
+  it("#001122 → 24-bit bg", () => {
+    expect(bgCode("#001122")?.apply).toBe("\x1b[48;2;0;17;34m");
+  });
+});

--- a/tests/renderer/ink-compat/components.test.tsx
+++ b/tests/renderer/ink-compat/components.test.tsx
@@ -1,0 +1,177 @@
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { Box, Spacer, Text } from "../../../src/renderer/ink-compat/index.js";
+import { CharPool } from "../../../src/renderer/pools/char-pool.js";
+import { HyperlinkPool } from "../../../src/renderer/pools/hyperlink-pool.js";
+import { StylePool } from "../../../src/renderer/pools/style-pool.js";
+import { render } from "../../../src/renderer/react/render.js";
+import { CellWidth } from "../../../src/renderer/screen/cell.js";
+
+function pools() {
+  return {
+    char: new CharPool(),
+    style: new StylePool(),
+    hyperlink: new HyperlinkPool(),
+  };
+}
+
+function read(screen: ReturnType<typeof render>, p: ReturnType<typeof pools>): string[] {
+  const lines: string[] = [];
+  for (let y = 0; y < screen.height; y++) {
+    let line = "";
+    for (let x = 0; x < screen.width; x++) {
+      const cell = screen.cellAt(x, y);
+      if (!cell) break;
+      if (cell.width === CellWidth.SpacerTail) continue;
+      line += p.char.get(cell.charId);
+    }
+    lines.push(line);
+  }
+  return lines;
+}
+
+describe("ink-compat Text — color and styles translate to SGR", () => {
+  it("color='cyan' applies SGR 36 to the cell's style", () => {
+    const p = pools();
+    const s = render(<Text color="cyan">hi</Text>, { width: 5, pools: p });
+    const styleId = s.cellAt(0, 0)?.styleId ?? -1;
+    const expected = p.style.intern([{ apply: "\x1b[36m", revert: "\x1b[39m" }]);
+    expect(styleId).toBe(expected);
+  });
+
+  it("bold + dimColor stack into a non-empty style id", () => {
+    const p = pools();
+    const s = render(
+      <Text bold dimColor>
+        hi
+      </Text>,
+      { width: 5, pools: p },
+    );
+    const styleId = s.cellAt(0, 0)?.styleId ?? -1;
+    expect(styleId).not.toBe(p.style.none);
+    const expected = p.style.intern([
+      { apply: "\x1b[1m", revert: "\x1b[22m" },
+      { apply: "\x1b[2m", revert: "\x1b[22m" },
+    ]);
+    expect(styleId).toBe(expected);
+  });
+
+  it("no styling produces the none style id", () => {
+    const p = pools();
+    const s = render(<Text>plain</Text>, { width: 10, pools: p });
+    expect(s.cellAt(0, 0)?.styleId).toBe(p.style.none);
+  });
+});
+
+describe("ink-compat Box — padding / borders", () => {
+  it("paddingX adds left + right padding", () => {
+    const p = pools();
+    const s = render(
+      <Box paddingX={2}>
+        <Text>x</Text>
+      </Box>,
+      { width: 10, pools: p },
+    );
+    const lines = read(s, p);
+    expect(lines[0]?.startsWith("  x")).toBe(true);
+  });
+
+  it("padding shorthand applies all four sides", () => {
+    const p = pools();
+    const s = render(
+      <Box padding={1}>
+        <Text>z</Text>
+      </Box>,
+      { width: 10, pools: p },
+    );
+    const lines = read(s, p);
+    expect(lines.length).toBeGreaterThanOrEqual(3);
+    expect(lines[1]?.startsWith(" z")).toBe(true);
+  });
+
+  it("borderStyle='single' draws four corners", () => {
+    const p = pools();
+    const s = render(
+      <Box borderStyle="single">
+        <Text>x</Text>
+      </Box>,
+      { width: 5, pools: p },
+    );
+    const lines = read(s, p);
+    expect(lines[0]?.startsWith("┌")).toBe(true);
+    expect(lines[0]?.includes("┐")).toBe(true);
+    expect(lines[lines.length - 1]?.includes("└")).toBe(true);
+  });
+
+  it("borderColor='red' applies SGR 31 to border cells", () => {
+    const p = pools();
+    const s = render(
+      <Box borderStyle="single" borderColor="red">
+        <Text>x</Text>
+      </Box>,
+      { width: 5, pools: p },
+    );
+    const cornerStyle = s.cellAt(0, 0)?.styleId ?? -1;
+    const expected = p.style.intern([{ apply: "\x1b[31m", revert: "\x1b[39m" }]);
+    expect(cornerStyle).toBe(expected);
+  });
+});
+
+describe("ink-compat Box — margins translate to wrapper padding", () => {
+  it("marginTop=2 leaves two empty rows above content", () => {
+    const p = pools();
+    const s = render(
+      <Box marginTop={2}>
+        <Text>hello</Text>
+      </Box>,
+      { width: 10, pools: p },
+    );
+    const lines = read(s, p);
+    expect(lines[0]?.trim()).toBe("");
+    expect(lines[1]?.trim()).toBe("");
+    expect(lines[2]).toContain("hello");
+  });
+
+  it("marginLeft=3 indents the box", () => {
+    const p = pools();
+    const s = render(
+      <Box marginLeft={3}>
+        <Text>hi</Text>
+      </Box>,
+      { width: 10, pools: p },
+    );
+    expect(read(s, p)[0]?.startsWith("   hi")).toBe(true);
+  });
+
+  it("marginY=1 adds one row above and below", () => {
+    const p = pools();
+    const s = render(
+      <Box marginY={1}>
+        <Text>z</Text>
+      </Box>,
+      { width: 5, pools: p },
+    );
+    const lines = read(s, p);
+    expect(lines[0]?.trim()).toBe("");
+    expect(lines[1]).toContain("z");
+    expect(lines[2]?.trim()).toBe("");
+  });
+});
+
+describe("ink-compat Spacer — flexGrow fills remaining row space", () => {
+  it("Spacer between two Text nodes pushes them apart in row flow", () => {
+    const p = pools();
+    const s = render(
+      <Box flexDirection="row">
+        <Text>L</Text>
+        <Spacer />
+        <Text>R</Text>
+      </Box>,
+      { width: 10, pools: p },
+    );
+    const line = read(s, p)[0] ?? "";
+    expect(line.startsWith("L")).toBe(true);
+    expect(line.endsWith("R")).toBe(true);
+  });
+});

--- a/tests/renderer/ink-compat/hooks.test.tsx
+++ b/tests/renderer/ink-compat/hooks.test.tsx
@@ -1,0 +1,176 @@
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React from "react";
+import { describe, expect, it } from "vitest";
+import {
+  AppContext,
+  Text,
+  useApp,
+  useInput,
+  useStdout,
+} from "../../../src/renderer/ink-compat/index.js";
+import type { KeystrokeSource } from "../../../src/renderer/input/index.js";
+import { CharPool } from "../../../src/renderer/pools/char-pool.js";
+import { HyperlinkPool } from "../../../src/renderer/pools/hyperlink-pool.js";
+import { StylePool } from "../../../src/renderer/pools/style-pool.js";
+import { mount } from "../../../src/renderer/reconciler/mount.js";
+import { makeTestWriter } from "../../../src/renderer/runtime/test-writer.js";
+
+function pools() {
+  return {
+    char: new CharPool(),
+    style: new StylePool(),
+    hyperlink: new HyperlinkPool(),
+  };
+}
+
+function flush(): Promise<void> {
+  return new Promise((r) => setTimeout(r, 0));
+}
+
+function makeFakeStdin(): KeystrokeSource & { push: (s: string) => void } {
+  let listener: ((chunk: string | Buffer) => void) | null = null;
+  return {
+    on(_event, cb) {
+      listener = cb;
+    },
+    off(_event, _cb) {
+      listener = null;
+    },
+    setRawMode() {},
+    resume() {},
+    pause() {},
+    push(chunk: string) {
+      listener?.(chunk);
+    },
+  };
+}
+
+describe("useStdout — viewport from mount/resize", () => {
+  it("reads columns/rows from the mount viewport", async () => {
+    const w = makeTestWriter();
+    function Probe() {
+      const { stdout } = useStdout();
+      return <Text>{`cols=${stdout.columns} rows=${stdout.rows}`}</Text>;
+    }
+    const handle = mount(<Probe />, {
+      viewportWidth: 42,
+      viewportHeight: 7,
+      pools: pools(),
+      write: w.write,
+    });
+    await flush();
+    expect(w.output()).toContain("cols=42 rows=7");
+    handle.destroy();
+  });
+
+  it("re-renders with new size after resize()", async () => {
+    const w = makeTestWriter();
+    function Probe() {
+      const { stdout } = useStdout();
+      return <Text>{`cols=${stdout.columns}`}</Text>;
+    }
+    const handle = mount(<Probe />, {
+      viewportWidth: 30,
+      viewportHeight: 4,
+      pools: pools(),
+      write: w.write,
+    });
+    await flush();
+    w.flush();
+    handle.resize(80, 24);
+    await flush();
+    expect(w.output()).toContain("cols=80");
+    handle.destroy();
+  });
+});
+
+describe("useApp — exit via context", () => {
+  it("invokes the AppContext.exit callback when called", async () => {
+    const w = makeTestWriter();
+    let exited = false;
+    function App() {
+      const { exit } = useApp();
+      React.useEffect(() => {
+        exit();
+      }, [exit]);
+      return <Text>app</Text>;
+    }
+    const handle = mount(
+      <AppContext.Provider
+        value={{
+          exit: () => {
+            exited = true;
+          },
+        }}
+      >
+        <App />
+      </AppContext.Provider>,
+      {
+        viewportWidth: 10,
+        viewportHeight: 1,
+        pools: pools(),
+        write: w.write,
+      },
+    );
+    await flush();
+    expect(exited).toBe(true);
+    handle.destroy();
+  });
+});
+
+describe("useInput — Ink-style input + key callback", () => {
+  it("invokes (input, key) on each keystroke", async () => {
+    const w = makeTestWriter();
+    const stdin = makeFakeStdin();
+    const seen: Array<{ input: string; up: boolean; esc: boolean }> = [];
+    function App() {
+      useInput((input, key) => {
+        seen.push({ input, up: key.upArrow, esc: key.escape });
+      });
+      return <Text>x</Text>;
+    }
+    const handle = mount(<App />, {
+      viewportWidth: 10,
+      viewportHeight: 1,
+      pools: pools(),
+      write: w.write,
+      stdin,
+    });
+    await flush();
+    stdin.push("a");
+    stdin.push("\x1b[A");
+    stdin.push("\x1b");
+    await flush();
+    expect(seen[0]).toEqual({ input: "a", up: false, esc: false });
+    expect(seen[1]?.up).toBe(true);
+    expect(seen[2]?.esc).toBe(true);
+    handle.destroy();
+  });
+
+  it("isActive=false disables the handler", async () => {
+    const w = makeTestWriter();
+    const stdin = makeFakeStdin();
+    let count = 0;
+    function App() {
+      useInput(
+        () => {
+          count++;
+        },
+        { isActive: false },
+      );
+      return <Text>x</Text>;
+    }
+    const handle = mount(<App />, {
+      viewportWidth: 10,
+      viewportHeight: 1,
+      pools: pools(),
+      write: w.write,
+      stdin,
+    });
+    await flush();
+    stdin.push("abc");
+    await flush();
+    expect(count).toBe(0);
+    handle.destroy();
+  });
+});


### PR DESCRIPTION
Phase 5d-2 of the cell-diff renderer (#160).

Adds a compatibility layer at `src/renderer/ink-compat/` so components written against Ink's API can render under our renderer with no source changes for the prop set the codebase actually uses today (inventoried before writing the shim — 63 files, see surfacing notes below).

## What's covered

**`<Box>`**
- pass-through: `flexDirection`, `flexGrow`, `padding{X,Y,Top,Bottom,Left,Right}`, `borderStyle` (string presets), `borderTop/Bottom/Left/Right`
- translated: `margin{X,Y,Top,Bottom,Left,Right}` → wrapper Box with corresponding paddings (works in column and row flow)
- `borderColor` accepts color names (`"cyan"`, `"red"`, etc.) and hex (`"#ff8800"`, `"#fa0"`)

**`<Text>`**
- `color`, `backgroundColor` (named + hex)
- `bold`, `dimColor`, `italic`, `underline`, `strikethrough`, `inverse`
- All stack into a single StylePool entry, so the diff stays cheap.

**`<Spacer/>`** — `<Box flexGrow={1}/>`.

**`<Static>`** — currently a `flexDirection="column"` wrapper. The "settled rows stay frozen" semantic isn't in yet; that's a row-level commit boundary that deserves its own PR.

**Hooks**
- `useStdout()` reads `{columns, rows}` from a new `ViewportContext`. `mount()` now provides this context and re-publishes on `resize()` so consumers re-render against the new size.
- `useApp()` returns `{exit}` from `AppContext`. The host owns the actual exit semantics.
- `useInput((input, key) => …, { isActive })` adapts Ink's signature to our `useKeystroke`. `isActive: false` no-ops the handler.

## What's deferred

- `width`, `height`, `minWidth`, `minHeight` — need fixed-size layout in the engine
- `justifyContent`, `alignItems` — same
- `gap`, `columnGap`, `rowGap`
- `Static`'s frozen-rows behavior, `useFocus`, `Transform`, `measureElement`

## Tests

26 new tests across:
- `colors.test.ts` — named + hex translation, fg + bg, gray/grey aliases
- `components.test.tsx` — Box padding/border/borderColor, Text color/bold/dim, Spacer in row flow, marginTop/Left/Y wrapper translation
- `hooks.test.tsx` — useStdout columns/rows on mount + resize, useApp exit via context, useInput callback + isActive gating

## Test plan

- [x] `npm run verify` clean — 2045 passing tests (was 2019), lint + typecheck OK
- [ ] sanity check: existing `reasonix renderer-demo` still works after rebuilding