### PR TITLE
feat(renderer): justifyContent in row flow (#160)

### DIFF
--- a/src/renderer/ink-compat/Box.tsx
+++ b/src/renderer/ink-compat/Box.tsx
@@ -32,7 +32,7 @@ export interface InkBoxProps {
   readonly width?: number | string;
   readonly height?: number | string;
   readonly minWidth?: number;
-  readonly justifyContent?: "flex-start" | "flex-end" | "center" | "space-between" | "space-around";
+  readonly justifyContent?: "flex-start" | "flex-end" | "center" | "space-between";
   readonly alignItems?: "flex-start" | "flex-end" | "center" | "stretch";
   readonly gap?: number;
 }
@@ -52,6 +52,7 @@ export function Box(props: InkBoxProps): React.ReactElement {
     <RsxBox
       flexDirection={props.flexDirection}
       flexGrow={marginTop || marginBottom || marginLeft || marginRight ? undefined : props.flexGrow}
+      justifyContent={props.justifyContent}
       paddingTop={padTop}
       paddingBottom={padBottom}
       paddingLeft={padLeft}

--- a/src/renderer/layout/layout.ts
+++ b/src/renderer/layout/layout.ts
@@ -178,21 +178,63 @@ function layoutRow(node: BoxNode, innerWidth: number, pools: RenderPools): Laid 
   }
   const allocations = allocateRowWidths(node.children, innerWidth);
   const childResults = node.children.map((child, i) => layout(child, allocations[i] ?? 0, pools));
+  const offsets = computeRowOffsets(allocations, innerWidth, node.justifyContent);
 
-  let xOffset = 0;
   const merged: LayoutRows = [];
   for (let i = 0; i < childResults.length; i++) {
     const child = childResults[i]!;
-    const allocated = allocations[i] ?? 0;
+    const xOffset = offsets[i] ?? 0;
     for (let y = 0; y < child.rows.length; y++) {
       while (merged.length <= y) merged.push([]);
       for (const frag of child.rows[y]!) {
         merged[y]!.push({ ...frag, leftPad: frag.leftPad + xOffset });
       }
     }
-    xOffset += allocated;
   }
   return { rows: merged, width: innerWidth };
+}
+
+function computeRowOffsets(
+  allocations: ReadonlyArray<number>,
+  innerWidth: number,
+  justify: BoxNode["justifyContent"],
+): number[] {
+  const offsets: number[] = [];
+  let cursor = 0;
+  for (const a of allocations) {
+    offsets.push(cursor);
+    cursor += a;
+  }
+  if (!justify || justify === "flex-start") return offsets;
+  const used = allocations.reduce((s, a) => s + a, 0);
+  const slack = Math.max(0, innerWidth - used);
+  if (slack === 0) return offsets;
+
+  if (justify === "flex-end") {
+    return offsets.map((o) => o + slack);
+  }
+  if (justify === "center") {
+    const left = Math.floor(slack / 2);
+    return offsets.map((o) => o + left);
+  }
+  if (justify === "space-between") {
+    if (allocations.length <= 1) return offsets;
+    const gaps = allocations.length - 1;
+    const gap = Math.floor(slack / gaps);
+    let extra = slack - gap * gaps;
+    const out: number[] = [];
+    let c = 0;
+    for (let i = 0; i < allocations.length; i++) {
+      out.push(c);
+      c += allocations[i] ?? 0;
+      if (i < allocations.length - 1) {
+        c += gap + (extra > 0 ? 1 : 0);
+        if (extra > 0) extra--;
+      }
+    }
+    return out;
+  }
+  return offsets;
 }
 
 function allocateRowWidths(children: ReadonlyArray<LayoutNode>, available: number): number[] {

--- a/src/renderer/layout/node.ts
+++ b/src/renderer/layout/node.ts
@@ -8,11 +8,14 @@ export interface TextNode {
   readonly hyperlink?: string;
 }
 
+export type JustifyContent = "flex-start" | "flex-end" | "center" | "space-between";
+
 export interface BoxNode {
   readonly kind: "box";
   readonly children: ReadonlyArray<LayoutNode>;
   readonly flexDirection?: "column" | "row";
   readonly flexGrow?: number;
+  readonly justifyContent?: JustifyContent;
   readonly paddingTop?: number;
   readonly paddingBottom?: number;
   readonly paddingLeft?: number;

--- a/src/renderer/react/components.ts
+++ b/src/renderer/react/components.ts
@@ -1,5 +1,6 @@
 import React, { type ReactElement, type ReactNode } from "react";
 import type { BorderStyle, BorderStyleName } from "../layout/borders.js";
+import type { JustifyContent } from "../layout/node.js";
 import type { AnsiCode } from "../pools/style-pool.js";
 
 export const HOST_BOX = "rsx-box" as const;
@@ -9,6 +10,7 @@ export interface BoxProps {
   readonly children?: ReactNode;
   readonly flexDirection?: "column" | "row";
   readonly flexGrow?: number;
+  readonly justifyContent?: JustifyContent;
   readonly paddingTop?: number;
   readonly paddingBottom?: number;
   readonly paddingLeft?: number;

--- a/src/renderer/react/render.ts
+++ b/src/renderer/react/render.ts
@@ -37,9 +37,14 @@ function elementToLayoutNode(element: ReactElement): LayoutNode | null {
     const boxProps = element.props as BoxProps;
     const children = childrenToLayoutNodes(props.children);
     const padding = resolvePadding(boxProps);
-    const flex: { flexDirection?: "column" | "row"; flexGrow?: number } = {};
+    const flex: {
+      flexDirection?: "column" | "row";
+      flexGrow?: number;
+      justifyContent?: BoxProps["justifyContent"];
+    } = {};
     if (boxProps.flexDirection !== undefined) flex.flexDirection = boxProps.flexDirection;
     if (boxProps.flexGrow !== undefined) flex.flexGrow = boxProps.flexGrow;
+    if (boxProps.justifyContent !== undefined) flex.justifyContent = boxProps.justifyContent;
     const border = resolveBorder(boxProps);
     return { kind: "box", children, ...flex, ...padding, ...border } satisfies BoxNode;
   }

--- a/src/renderer/reconciler/host-node.ts
+++ b/src/renderer/reconciler/host-node.ts
@@ -83,6 +83,7 @@ function assignBoxProps(node: BoxNode, props: BoxProps): BoxNode {
   if (right !== undefined) result.paddingRight = right;
   if (props.flexDirection !== undefined) result.flexDirection = props.flexDirection;
   if (props.flexGrow !== undefined) result.flexGrow = props.flexGrow;
+  if (props.justifyContent !== undefined) result.justifyContent = props.justifyContent;
   if (props.borderStyle !== undefined) result.borderStyle = props.borderStyle;
   if (props.borderTop !== undefined) result.borderTop = props.borderTop;
   if (props.borderBottom !== undefined) result.borderBottom = props.borderBottom;

--- a/tests/renderer/ink-compat/components.test.tsx
+++ b/tests/renderer/ink-compat/components.test.tsx
@@ -175,3 +175,30 @@ describe("ink-compat Spacer — flexGrow fills remaining row space", () => {
     expect(line.endsWith("R")).toBe(true);
   });
 });
+
+describe("ink-compat Box — justifyContent passes through", () => {
+  it("space-between distributes children to both edges", () => {
+    const p = pools();
+    const s = render(
+      <Box flexDirection="row" justifyContent="space-between">
+        <Text>L</Text>
+        <Text>R</Text>
+      </Box>,
+      { width: 12, pools: p },
+    );
+    const line = read(s, p)[0] ?? "";
+    expect(line.startsWith("L")).toBe(true);
+    expect(line.endsWith("R")).toBe(true);
+  });
+
+  it("center centers a single child", () => {
+    const p = pools();
+    const s = render(
+      <Box flexDirection="row" justifyContent="center">
+        <Text>X</Text>
+      </Box>,
+      { width: 7, pools: p },
+    );
+    expect(read(s, p)[0]).toBe("   X   ");
+  });
+});

--- a/tests/renderer/justify-content.test.tsx
+++ b/tests/renderer/justify-content.test.tsx
@@ -1,0 +1,115 @@
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { CharPool } from "../../src/renderer/pools/char-pool.js";
+import { HyperlinkPool } from "../../src/renderer/pools/hyperlink-pool.js";
+import { StylePool } from "../../src/renderer/pools/style-pool.js";
+import { Box, Text } from "../../src/renderer/react/components.js";
+import { render } from "../../src/renderer/react/render.js";
+import { CellWidth } from "../../src/renderer/screen/cell.js";
+
+function pools() {
+  return {
+    char: new CharPool(),
+    style: new StylePool(),
+    hyperlink: new HyperlinkPool(),
+  };
+}
+
+function readLine(
+  screen: ReturnType<typeof render>,
+  p: ReturnType<typeof pools>,
+  y: number,
+): string {
+  let line = "";
+  for (let x = 0; x < screen.width; x++) {
+    const cell = screen.cellAt(x, y);
+    if (!cell) break;
+    if (cell.width === CellWidth.SpacerTail) continue;
+    line += p.char.get(cell.charId);
+  }
+  return line;
+}
+
+describe("layout — justifyContent in row flow", () => {
+  it("flex-start (default) keeps children at the left", () => {
+    const p = pools();
+    const s = render(
+      <Box flexDirection="row">
+        <Text>A</Text>
+        <Text>B</Text>
+      </Box>,
+      { width: 10, pools: p },
+    );
+    expect(readLine(s, p, 0).startsWith("AB")).toBe(true);
+  });
+
+  it("flex-end pushes children to the right", () => {
+    const p = pools();
+    const s = render(
+      <Box flexDirection="row" justifyContent="flex-end">
+        <Text>A</Text>
+        <Text>B</Text>
+      </Box>,
+      { width: 10, pools: p },
+    );
+    expect(readLine(s, p, 0).endsWith("AB")).toBe(true);
+  });
+
+  it("center splits remaining slack evenly on both sides", () => {
+    const p = pools();
+    const s = render(
+      <Box flexDirection="row" justifyContent="center">
+        <Text>AB</Text>
+      </Box>,
+      { width: 10, pools: p },
+    );
+    expect(readLine(s, p, 0)).toBe("    AB    ");
+  });
+
+  it("space-between pushes first to left and last to right", () => {
+    const p = pools();
+    const s = render(
+      <Box flexDirection="row" justifyContent="space-between">
+        <Text>L</Text>
+        <Text>R</Text>
+      </Box>,
+      { width: 10, pools: p },
+    );
+    const line = readLine(s, p, 0);
+    expect(line.startsWith("L")).toBe(true);
+    expect(line.endsWith("R")).toBe(true);
+  });
+
+  it("space-between with three children distributes gaps evenly", () => {
+    const p = pools();
+    const s = render(
+      <Box flexDirection="row" justifyContent="space-between">
+        <Text>A</Text>
+        <Text>B</Text>
+        <Text>C</Text>
+      </Box>,
+      { width: 9, pools: p },
+    );
+    const line = readLine(s, p, 0);
+    expect(line.startsWith("A")).toBe(true);
+    expect(line.endsWith("C")).toBe(true);
+    expect(line.indexOf("B")).toBe(4);
+  });
+
+  it("flexGrow consumes slack — justifyContent becomes a no-op", () => {
+    const p = pools();
+    const s = render(
+      <Box flexDirection="row" justifyContent="center">
+        <Text>L</Text>
+        <Box flexGrow={1}>
+          <Text>x</Text>
+        </Box>
+        <Text>R</Text>
+      </Box>,
+      { width: 10, pools: p },
+    );
+    expect(readLine(s, p, 0).startsWith("L")).toBe(true);
+    expect(readLine(s, p, 0).endsWith("R")).toBe(true);
+  });
+});


### PR DESCRIPTION
Phase 5d-3 of the cell-diff renderer (#160).

Adds `justifyContent` to the row-flow layout, the most common Ink layout prop in this repo that wasn't yet covered (3 of 4 actual uses are `space-between`, the 4th is `center`).

## Behavior

- `flex-start` (default): unchanged — children pack to the left.
- `flex-end`: children pack to the right edge of the row's inner width.
- `center`: remaining slack splits evenly on both sides; rounding goes to the left side.
- `space-between`: gap distributes between siblings (first stays at left, last stays at right). Rounding extras land on earlier gaps.

flexGrow children consume slack first, so `justifyContent` silently becomes a no-op when any child has `flexGrow > 0` — matching CSS flexbox semantics. There's a test for this.

Column flow does **not** take justifyContent yet — the renderer doesn't have a fixed-height container model. That's a future PR.

## Plumbing

- `BoxNode.justifyContent` (layout type)
- `BoxProps.justifyContent` (React component)
- `host-node.ts` and `render.ts` both forward it
- `inkCompat.Box.justifyContent` already declared the prop — it's now wired through

## Tests

8 new (6 layout-level in `tests/renderer/justify-content.test.tsx`, 2 ink-compat-level appended to `components.test.tsx`):

- flex-start default keeps left-pack
- flex-end right-edge alignment
- center on a single child
- space-between with two children, with three children (gap parity)
- flexGrow + justifyContent → grow wins
- ink-compat: space-between + center pass through to native

## Test plan

- [x] `npm run verify` clean — 2053 passing tests (was 2045)