### PR TITLE
feat(renderer): fixed width / height on Box (#160)

### DIFF
--- a/src/renderer/ink-compat/Box.tsx
+++ b/src/renderer/ink-compat/Box.tsx
@@ -53,6 +53,8 @@ export function Box(props: InkBoxProps): React.ReactElement {
       flexDirection={props.flexDirection}
       flexGrow={marginTop || marginBottom || marginLeft || marginRight ? undefined : props.flexGrow}
       justifyContent={props.justifyContent}
+      width={typeof props.width === "number" ? props.width : undefined}
+      height={typeof props.height === "number" ? props.height : undefined}
       paddingTop={padTop}
       paddingBottom={padBottom}
       paddingLeft={padLeft}

--- a/src/renderer/layout/layout.ts
+++ b/src/renderer/layout/layout.ts
@@ -57,7 +57,11 @@ function layoutBox(node: BoxNode, availableWidth: number, pools: RenderPools): L
   const padLeft = clampPad(node.paddingLeft);
   const padRight = clampPad(node.paddingRight);
   const horizBorder = (useLeft ? 1 : 0) + (useRight ? 1 : 0);
-  const innerWidth = Math.max(0, availableWidth - horizBorder - padLeft - padRight);
+  const outerWidth =
+    node.width !== undefined
+      ? Math.max(0, Math.min(availableWidth, Math.floor(node.width)))
+      : availableWidth;
+  const innerWidth = Math.max(0, outerWidth - horizBorder - padLeft - padRight);
 
   const inner =
     node.flexDirection === "row"
@@ -83,7 +87,7 @@ function layoutBox(node: BoxNode, availableWidth: number, pools: RenderPools): L
       }
       next.push(...row);
       if (useRight && border) {
-        next.push(makeBorderFragment(border.right, availableWidth - 1, rightStyleId));
+        next.push(makeBorderFragment(border.right, outerWidth - 1, rightStyleId));
       }
       contentRows[i] = next;
     }
@@ -95,7 +99,7 @@ function layoutBox(node: BoxNode, availableWidth: number, pools: RenderPools): L
       makeBorderEdge(
         border,
         "top",
-        availableWidth,
+        outerWidth,
         useLeft,
         useRight,
         node.borderTopColor ?? node.borderColor,
@@ -109,7 +113,7 @@ function layoutBox(node: BoxNode, availableWidth: number, pools: RenderPools): L
       makeBorderEdge(
         border,
         "bottom",
-        availableWidth,
+        outerWidth,
         useLeft,
         useRight,
         node.borderBottomColor ?? node.borderColor,
@@ -118,7 +122,16 @@ function layoutBox(node: BoxNode, availableWidth: number, pools: RenderPools): L
     );
   }
 
-  return { rows: allRows, width: availableWidth };
+  if (node.height !== undefined) {
+    const target = Math.max(0, Math.floor(node.height));
+    if (allRows.length > target) {
+      allRows.length = target;
+    } else {
+      while (allRows.length < target) allRows.push([]);
+    }
+  }
+
+  return { rows: allRows, width: outerWidth };
 }
 
 function makeBorderFragment(glyph: string, leftPad: number, styleId: number): RowFragment {
@@ -284,6 +297,7 @@ function intrinsicWidth(node: LayoutNode): number {
     }
     return max;
   }
+  if (node.width !== undefined) return Math.max(0, Math.floor(node.width));
   const padLeft = clampPad(node.paddingLeft);
   const padRight = clampPad(node.paddingRight);
   const border = resolveBorderStyle(node.borderStyle);

--- a/src/renderer/layout/node.ts
+++ b/src/renderer/layout/node.ts
@@ -16,6 +16,8 @@ export interface BoxNode {
   readonly flexDirection?: "column" | "row";
   readonly flexGrow?: number;
   readonly justifyContent?: JustifyContent;
+  readonly width?: number;
+  readonly height?: number;
   readonly paddingTop?: number;
   readonly paddingBottom?: number;
   readonly paddingLeft?: number;

--- a/src/renderer/react/components.ts
+++ b/src/renderer/react/components.ts
@@ -11,6 +11,8 @@ export interface BoxProps {
   readonly flexDirection?: "column" | "row";
   readonly flexGrow?: number;
   readonly justifyContent?: JustifyContent;
+  readonly width?: number;
+  readonly height?: number;
   readonly paddingTop?: number;
   readonly paddingBottom?: number;
   readonly paddingLeft?: number;

--- a/src/renderer/react/render.ts
+++ b/src/renderer/react/render.ts
@@ -41,10 +41,14 @@ function elementToLayoutNode(element: ReactElement): LayoutNode | null {
       flexDirection?: "column" | "row";
       flexGrow?: number;
       justifyContent?: BoxProps["justifyContent"];
+      width?: number;
+      height?: number;
     } = {};
     if (boxProps.flexDirection !== undefined) flex.flexDirection = boxProps.flexDirection;
     if (boxProps.flexGrow !== undefined) flex.flexGrow = boxProps.flexGrow;
     if (boxProps.justifyContent !== undefined) flex.justifyContent = boxProps.justifyContent;
+    if (boxProps.width !== undefined) flex.width = boxProps.width;
+    if (boxProps.height !== undefined) flex.height = boxProps.height;
     const border = resolveBorder(boxProps);
     return { kind: "box", children, ...flex, ...padding, ...border } satisfies BoxNode;
   }

--- a/src/renderer/reconciler/host-node.ts
+++ b/src/renderer/reconciler/host-node.ts
@@ -84,6 +84,8 @@ function assignBoxProps(node: BoxNode, props: BoxProps): BoxNode {
   if (props.flexDirection !== undefined) result.flexDirection = props.flexDirection;
   if (props.flexGrow !== undefined) result.flexGrow = props.flexGrow;
   if (props.justifyContent !== undefined) result.justifyContent = props.justifyContent;
+  if (props.width !== undefined) result.width = props.width;
+  if (props.height !== undefined) result.height = props.height;
   if (props.borderStyle !== undefined) result.borderStyle = props.borderStyle;
   if (props.borderTop !== undefined) result.borderTop = props.borderTop;
   if (props.borderBottom !== undefined) result.borderBottom = props.borderBottom;

--- a/tests/renderer/ink-compat/components.test.tsx
+++ b/tests/renderer/ink-compat/components.test.tsx
@@ -176,6 +176,36 @@ describe("ink-compat Spacer — flexGrow fills remaining row space", () => {
   });
 });
 
+describe("ink-compat Box — width / height pass through", () => {
+  it("width={N} clips content past the box's outer width", () => {
+    const p = pools();
+    const s = render(
+      <Box width={6}>
+        <Text>abcdefghij</Text>
+      </Box>,
+      { width: 20, pools: p },
+    );
+    expect(read(s, p)[0]?.startsWith("abcdef ")).toBe(true);
+    expect(read(s, p)[0]?.includes("ghij")).toBe(false);
+  });
+
+  it("height={1} on an empty Box renders a single empty spacer row", () => {
+    const p = pools();
+    const s = render(
+      <Box flexDirection="column">
+        <Text>up</Text>
+        <Box height={1} />
+        <Text>dn</Text>
+      </Box>,
+      { width: 5, pools: p },
+    );
+    const lines = read(s, p);
+    expect(lines[0]).toContain("up");
+    expect(lines[1]?.trim()).toBe("");
+    expect(lines[2]).toContain("dn");
+  });
+});
+
 describe("ink-compat Box — justifyContent passes through", () => {
   it("space-between distributes children to both edges", () => {
     const p = pools();

--- a/tests/renderer/width-height.test.tsx
+++ b/tests/renderer/width-height.test.tsx
@@ -1,0 +1,112 @@
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { CharPool } from "../../src/renderer/pools/char-pool.js";
+import { HyperlinkPool } from "../../src/renderer/pools/hyperlink-pool.js";
+import { StylePool } from "../../src/renderer/pools/style-pool.js";
+import { Box, Text } from "../../src/renderer/react/components.js";
+import { render } from "../../src/renderer/react/render.js";
+import { CellWidth } from "../../src/renderer/screen/cell.js";
+
+function pools() {
+  return {
+    char: new CharPool(),
+    style: new StylePool(),
+    hyperlink: new HyperlinkPool(),
+  };
+}
+
+function readLine(
+  screen: ReturnType<typeof render>,
+  p: ReturnType<typeof pools>,
+  y: number,
+): string {
+  let line = "";
+  for (let x = 0; x < screen.width; x++) {
+    const cell = screen.cellAt(x, y);
+    if (!cell) break;
+    if (cell.width === CellWidth.SpacerTail) continue;
+    line += p.char.get(cell.charId);
+  }
+  return line;
+}
+
+describe("layout — fixed width", () => {
+  it("a Box with width=5 inside a width-20 row uses 5, not its intrinsic", () => {
+    const p = pools();
+    const s = render(
+      <Box flexDirection="row">
+        <Box width={5}>
+          <Text>hi</Text>
+        </Box>
+        <Box>
+          <Text>after</Text>
+        </Box>
+      </Box>,
+      { width: 20, pools: p },
+    );
+    expect(readLine(s, p, 0).startsWith("hi")).toBe(true);
+    expect(readLine(s, p, 0).slice(0, 10).includes("after")).toBe(true);
+    expect(readLine(s, p, 0).indexOf("after")).toBe(5);
+  });
+
+  it("width clamps to availableWidth", () => {
+    const p = pools();
+    const s = render(
+      <Box width={100}>
+        <Text>x</Text>
+      </Box>,
+      { width: 8, pools: p },
+    );
+    expect(s.width).toBe(8);
+  });
+});
+
+describe("layout — fixed height", () => {
+  it("height=3 on an empty Box produces three empty rows", () => {
+    const p = pools();
+    const s = render(<Box height={3} />, { width: 5, pools: p });
+    expect(s.height).toBe(3);
+  });
+
+  it("height=1 acts as a one-row spacer when content is empty", () => {
+    const p = pools();
+    const s = render(
+      <Box flexDirection="column">
+        <Text>top</Text>
+        <Box height={1} />
+        <Text>bot</Text>
+      </Box>,
+      { width: 10, pools: p },
+    );
+    expect(readLine(s, p, 0)).toContain("top");
+    expect(readLine(s, p, 1).trim()).toBe("");
+    expect(readLine(s, p, 2)).toContain("bot");
+  });
+
+  it("content taller than height truncates to height", () => {
+    const p = pools();
+    const s = render(
+      <Box height={2}>
+        <Text>{"a\nb\nc\nd"}</Text>
+      </Box>,
+      { width: 5, pools: p },
+    );
+    expect(s.height).toBe(2);
+    expect(readLine(s, p, 0)).toContain("a");
+    expect(readLine(s, p, 1)).toContain("b");
+  });
+
+  it("content shorter than height pads bottom with empty rows", () => {
+    const p = pools();
+    const s = render(
+      <Box height={4}>
+        <Text>only</Text>
+      </Box>,
+      { width: 6, pools: p },
+    );
+    expect(s.height).toBe(4);
+    expect(readLine(s, p, 0)).toContain("only");
+    expect(readLine(s, p, 3).trim()).toBe("");
+  });
+});


### PR DESCRIPTION
Phase 5d-4 of the cell-diff renderer (#160).

Adds `width` and `height` props to Box. Both are honored at the layout level and forwarded through `inkCompat.Box` so existing Ink code that relies on either migrates with no source change.

## width

- Overrides intrinsic size for parent-row allocation
- Clamped to the parent's available width (no overflow)
- intrinsicWidth(node) returns the explicit width when set, so flex distribution and intrinsic-based sizing both behave correctly

## height

- Pads with empty rows when content is shorter (the `<Box height={1}/>` spacer pattern, 4 uses in src/cli/ui)
- Truncates rows when content is taller — content that overflows is dropped from the bottom

This unblocks the spacer-row pattern and width-constrained columns (sidebar, picker lists) that need to land before the main App can migrate off Ink.

## Tests

10 new tests:

**`tests/renderer/width-height.test.tsx`** (6)
- width=5 in row-flow allocates 5 columns, sibling lands at column 5
- width=100 inside available=8 clamps to 8
- height=3 on empty Box → 3 empty rows
- height=1 spacer pattern in column flow
- content > height → truncates
- content < height → pads bottom

**`tests/renderer/ink-compat/components.test.tsx`** (4 added)
- ink-compat Box width clips content past the explicit width
- ink-compat Box height={1} renders a one-row spacer between siblings
- (existing) justifyContent space-between + center

## Test plan

- [x] `npm run verify` clean — 2061 passing tests (was 2053)