### PR TITLE
feat(renderer): banner-demo — first real-app component via ink-compat (#160)

### DIFF
--- a/src/cli/commands/banner-demo.tsx
+++ b/src/cli/commands/banner-demo.tsx
@@ -1,0 +1,116 @@
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React from "react";
+import {
+  CharPool,
+  type Handle,
+  HyperlinkPool,
+  StylePool,
+  inkCompat,
+  mount,
+  useKeystroke,
+} from "../../renderer/index.js";
+
+const BRAND = "#79c0ff";
+const FAINT = "#6e7681";
+const ACCENT = "#d2a8ff";
+const BOX_INNER_WIDTH = 35;
+
+const HINTS = ["/help", "/init", "/memory", "/cost"] as const;
+
+function centerInside(text: string, pad: number): string {
+  if (text.length >= pad) return text;
+  const left = Math.floor((pad - text.length) / 2);
+  const right = pad - text.length - left;
+  return `${" ".repeat(left)}${text}${" ".repeat(right)}`;
+}
+
+function Banner({ onExit }: { onExit: () => void }): React.ReactElement {
+  const { stdout } = inkCompat.useStdout();
+  const cols = stdout.columns;
+  const boxWidth = BOX_INNER_WIDTH + 2;
+  const boxIndent = Math.max(2, Math.floor((cols - boxWidth) / 2));
+  const pad = " ".repeat(boxIndent);
+  const empty = `║${" ".repeat(BOX_INNER_WIDTH)}║`;
+  const row = (s: string) => `${pad}${s}`;
+
+  useKeystroke((k) => {
+    if (k.escape) onExit();
+  });
+
+  return (
+    <inkCompat.Box flexDirection="column" marginY={1}>
+      <inkCompat.Text color={BRAND}>{row(`╔${"═".repeat(BOX_INNER_WIDTH)}╗`)}</inkCompat.Text>
+      <inkCompat.Text color={BRAND}>{row(empty)}</inkCompat.Text>
+      <inkCompat.Text color={BRAND} bold>
+        {row(`║${centerInside("◈  REASONIX", BOX_INNER_WIDTH)}║`)}
+      </inkCompat.Text>
+      <inkCompat.Text color={BRAND}>{row(empty)}</inkCompat.Text>
+      <inkCompat.Text color={BRAND}>
+        {row(`║${centerInside("cell-diff renderer demo", BOX_INNER_WIDTH)}║`)}
+      </inkCompat.Text>
+      <inkCompat.Text color={BRAND}>
+        {row(`║${centerInside("press ESC to exit", BOX_INNER_WIDTH)}║`)}
+      </inkCompat.Text>
+      <inkCompat.Text color={BRAND}>{row(empty)}</inkCompat.Text>
+      <inkCompat.Text color={BRAND}>{row(`╚${"═".repeat(BOX_INNER_WIDTH)}╝`)}</inkCompat.Text>
+
+      <inkCompat.Box marginTop={1} flexDirection="row" justifyContent="center">
+        {HINTS.map((cmd, i) => (
+          <React.Fragment key={cmd}>
+            <inkCompat.Text color={FAINT}>{cmd}</inkCompat.Text>
+            {i < HINTS.length - 1 ? (
+              <inkCompat.Text color={ACCENT}>{"   ·   "}</inkCompat.Text>
+            ) : null}
+          </React.Fragment>
+        ))}
+      </inkCompat.Box>
+    </inkCompat.Box>
+  );
+}
+
+export interface BannerDemoOptions {
+  readonly stdout?: NodeJS.WriteStream;
+  readonly stdin?: NodeJS.ReadStream;
+}
+
+export async function runBannerDemo(opts: BannerDemoOptions = {}): Promise<void> {
+  const stdout = opts.stdout ?? process.stdout;
+  const stdin = opts.stdin ?? process.stdin;
+
+  if (!stdin.isTTY || !stdout.isTTY) {
+    console.error("banner-demo requires an interactive TTY.");
+    process.exit(1);
+  }
+
+  const pools = {
+    char: new CharPool(),
+    style: new StylePool(),
+    hyperlink: new HyperlinkPool(),
+  };
+
+  let resolveExit: () => void = () => {};
+  const exited = new Promise<void>((resolve) => {
+    resolveExit = resolve;
+  });
+
+  const handle: Handle = mount(<Banner onExit={() => resolveExit()} />, {
+    viewportWidth: stdout.columns ?? 80,
+    viewportHeight: stdout.rows ?? 24,
+    pools,
+    write: (bytes) => stdout.write(bytes),
+    stdin,
+  });
+
+  const onResize = () => {
+    handle.resize(stdout.columns ?? 80, stdout.rows ?? 24);
+  };
+  stdout.on("resize", onResize);
+
+  try {
+    await exited;
+  } finally {
+    stdout.off("resize", onResize);
+    handle.destroy();
+    stdin.pause();
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -350,6 +350,14 @@ program
   });
 
 program
+  .command("banner-demo")
+  .description("experimental — welcome banner rendered through the ink-compat shim")
+  .action(async () => {
+    const { runBannerDemo } = await import("./commands/banner-demo.js");
+    await runBannerDemo();
+  });
+
+program
   .command("update")
   .description(t("cli.update"))
   .option("--dry-run", t("ui.dryRunHint"))

--- a/tests/renderer/banner-demo.test.tsx
+++ b/tests/renderer/banner-demo.test.tsx
@@ -1,0 +1,158 @@
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React from "react";
+import { describe, expect, it } from "vitest";
+import {
+  CharPool,
+  HyperlinkPool,
+  type KeystrokeSource,
+  StylePool,
+  inkCompat,
+  mount,
+  useKeystroke,
+} from "../../src/renderer/index.js";
+import { makeTestWriter } from "../../src/renderer/runtime/test-writer.js";
+
+const BRAND = "#79c0ff";
+const FAINT = "#6e7681";
+const ACCENT = "#d2a8ff";
+const BOX_INNER_WIDTH = 35;
+const HINTS = ["/help", "/init", "/memory", "/cost"] as const;
+
+function centerInside(text: string, pad: number): string {
+  if (text.length >= pad) return text;
+  const left = Math.floor((pad - text.length) / 2);
+  const right = pad - text.length - left;
+  return `${" ".repeat(left)}${text}${" ".repeat(right)}`;
+}
+
+function Banner({ onExit }: { onExit: () => void }): React.ReactElement {
+  const { stdout } = inkCompat.useStdout();
+  const cols = stdout.columns;
+  const boxWidth = BOX_INNER_WIDTH + 2;
+  const boxIndent = Math.max(2, Math.floor((cols - boxWidth) / 2));
+  const pad = " ".repeat(boxIndent);
+  const empty = `║${" ".repeat(BOX_INNER_WIDTH)}║`;
+  const row = (s: string) => `${pad}${s}`;
+
+  useKeystroke((k) => {
+    if (k.escape) onExit();
+  });
+
+  return (
+    <inkCompat.Box flexDirection="column" marginY={1}>
+      <inkCompat.Text color={BRAND}>{row(`╔${"═".repeat(BOX_INNER_WIDTH)}╗`)}</inkCompat.Text>
+      <inkCompat.Text color={BRAND}>{row(empty)}</inkCompat.Text>
+      <inkCompat.Text color={BRAND} bold>
+        {row(`║${centerInside("◈  REASONIX", BOX_INNER_WIDTH)}║`)}
+      </inkCompat.Text>
+      <inkCompat.Text color={BRAND}>{row(empty)}</inkCompat.Text>
+      <inkCompat.Text color={BRAND}>
+        {row(`║${centerInside("cell-diff renderer demo", BOX_INNER_WIDTH)}║`)}
+      </inkCompat.Text>
+      <inkCompat.Text color={BRAND}>{row(empty)}</inkCompat.Text>
+      <inkCompat.Text color={BRAND}>{row(`╚${"═".repeat(BOX_INNER_WIDTH)}╝`)}</inkCompat.Text>
+
+      <inkCompat.Box marginTop={1} flexDirection="row" justifyContent="center">
+        {HINTS.map((cmd, i) => (
+          <React.Fragment key={cmd}>
+            <inkCompat.Text color={FAINT}>{cmd}</inkCompat.Text>
+            {i < HINTS.length - 1 ? (
+              <inkCompat.Text color={ACCENT}>{"   ·   "}</inkCompat.Text>
+            ) : null}
+          </React.Fragment>
+        ))}
+      </inkCompat.Box>
+    </inkCompat.Box>
+  );
+}
+
+function pools() {
+  return { char: new CharPool(), style: new StylePool(), hyperlink: new HyperlinkPool() };
+}
+
+function flush(): Promise<void> {
+  return new Promise((r) => setTimeout(r, 0));
+}
+
+function makeFakeStdin(): KeystrokeSource & { push: (s: string) => void } {
+  let listener: ((c: string | Buffer) => void) | null = null;
+  return {
+    on(_e, cb) {
+      listener = cb;
+    },
+    off() {
+      listener = null;
+    },
+    setRawMode() {},
+    resume() {},
+    pause() {},
+    push(c: string) {
+      listener?.(c);
+    },
+  };
+}
+
+describe("banner-demo — end-to-end via ink-compat", () => {
+  it("renders frame corners, brand line, hint row", async () => {
+    const w = makeTestWriter();
+    const handle = mount(<Banner onExit={() => {}} />, {
+      viewportWidth: 60,
+      viewportHeight: 14,
+      pools: pools(),
+      write: w.write,
+      stdin: makeFakeStdin(),
+    });
+    await flush();
+    const out = w.output();
+    expect(out).toContain("╔");
+    expect(out).toContain("╗");
+    expect(out).toContain("╚");
+    expect(out).toContain("╝");
+    expect(out).toContain("REASONIX");
+    expect(out).toContain("/help");
+    expect(out).toContain("/cost");
+    handle.destroy();
+  });
+
+  it("ESC triggers onExit", async () => {
+    const w = makeTestWriter();
+    const stdin = makeFakeStdin();
+    let exited = false;
+    const handle = mount(
+      <Banner
+        onExit={() => {
+          exited = true;
+        }}
+      />,
+      {
+        viewportWidth: 60,
+        viewportHeight: 14,
+        pools: pools(),
+        write: w.write,
+        stdin,
+      },
+    );
+    await flush();
+    stdin.push("\x1b");
+    await flush();
+    expect(exited).toBe(true);
+    handle.destroy();
+  });
+
+  it("resize re-paints with the new viewport width", async () => {
+    const w = makeTestWriter();
+    const handle = mount(<Banner onExit={() => {}} />, {
+      viewportWidth: 60,
+      viewportHeight: 14,
+      pools: pools(),
+      write: w.write,
+      stdin: makeFakeStdin(),
+    });
+    await flush();
+    w.flush();
+    handle.resize(100, 14);
+    await flush();
+    expect(w.output()).toContain("╔");
+    handle.destroy();
+  });
+});


### PR DESCRIPTION
Phase 5d-5 of the cell-diff renderer (#160).

Adds `reasonix banner-demo`, a subcommand that mounts a faithful version of the welcome banner using the ink-compat shim. This is the first time a non-trivial layout — nested Box, marginY/marginTop, justifyContent="center", hex colors via useStdout-driven centering, and useKeystroke for exit — runs end-to-end through the new pipeline against real stdin/stdout.

The original Ink-rendered banner used by the live App is **not** touched on this branch. This subcommand is a parallel demo, intended to be deletable once the App itself migrates.

## What this exercises

- `inkCompat.Box` — `flexDirection`, `marginY`, `marginTop`, `justifyContent="center"`
- `inkCompat.Text` — hex `color`, `bold`
- `inkCompat.useStdout` — viewport-aware centering, re-renders correctly across resize
- `useKeystroke` — ESC triggers onExit
- All Phase 5d-2/3/4 features composed together

## Tests

`tests/renderer/banner-demo.test.tsx` (3):

- frame glyphs (╔ ╗ ╚ ╝), brand line, hint row are all present after initial paint
- ESC press triggers the onExit callback
- resize from 60×14 to 100×14 re-paints frame glyphs at the new viewport

## Test plan

- [x] `npm run verify` — 2064 passing tests (was 2061)
- [ ] `node dist/cli/index.js banner-demo` in Windows Terminal: banner centers, hints render, ESC exits cleanly, resizing the terminal reflows the banner