### PR TITLE
feat(renderer): Static — emit settled rows to scrollback (#160)

### DIFF
--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -14,6 +14,7 @@ export type { Diff, Patch } from "./diff/patch.js";
 export { type DiffPools, diffFrames } from "./diff/diff-frames.js";
 export { serializePatches } from "./diff/serialize.js";
 export { Renderer, type RendererOptions } from "./runtime/renderer.js";
+export { renderToBytes } from "./runtime/render-to-bytes.js";
 export { type TestWriter, makeTestWriter } from "./runtime/test-writer.js";
 export { type Handle, type MountOptions, mount } from "./reconciler/mount.js";
 export {

--- a/src/renderer/ink-compat/Static.tsx
+++ b/src/renderer/ink-compat/Static.tsx
@@ -1,17 +1,40 @@
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
-import React, { type ReactNode } from "react";
+import React, { type ReactNode, useContext, useEffect, useRef } from "react";
 import { Box } from "../react/components.js";
+import { RendererBridgeContext } from "./renderer-bridge.js";
 
 export interface StaticProps<T> {
   readonly items: ReadonlyArray<T>;
   readonly children: (item: T, index: number) => ReactNode;
 }
 
-export function Static<T>(props: StaticProps<T>): React.ReactElement {
+export function Static<T>(props: StaticProps<T>): React.ReactElement | null {
+  const bridge = useContext(RendererBridgeContext);
+  const lastIndex = useRef(0);
+
+  useEffect(() => {
+    if (!bridge) return;
+    if (props.items.length <= lastIndex.current) return;
+    const fresh = props.items.slice(lastIndex.current);
+    const startIndex = lastIndex.current;
+    lastIndex.current = props.items.length;
+    bridge.emitStatic(
+      <Box flexDirection="column">
+        {fresh.map((item, i) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: Static items are positional and append-only
+          <React.Fragment key={`s-${startIndex + i}`}>
+            {props.children(item, startIndex + i)}
+          </React.Fragment>
+        ))}
+      </Box>,
+    );
+  }, [bridge, props.items, props.children]);
+
+  if (bridge) return null;
   return (
     <Box flexDirection="column">
       {props.items.map((item, i) => (
-        // biome-ignore lint/suspicious/noArrayIndexKey: Static items are positional and stable per render — Ink uses index keys here too
+        // biome-ignore lint/suspicious/noArrayIndexKey: fallback path with no bridge — positional keys are fine
         <React.Fragment key={`s-${i}`}>{props.children(item, i)}</React.Fragment>
       ))}
     </Box>

--- a/src/renderer/ink-compat/index.ts
+++ b/src/renderer/ink-compat/index.ts
@@ -2,6 +2,7 @@ export { Box, type InkBoxProps } from "./Box.js";
 export { Text, type InkTextProps } from "./Text.js";
 export { Spacer } from "./Spacer.js";
 export { Static, type StaticProps } from "./Static.js";
+export { type RendererBridge, RendererBridgeContext } from "./renderer-bridge.js";
 export { type ColorName, bgCode, fgCode } from "./colors.js";
 export { type ViewportSize, ViewportContext, useStdout } from "./viewport.js";
 export { type AppApi, AppContext, useApp } from "./use-app.js";

--- a/src/renderer/ink-compat/renderer-bridge.ts
+++ b/src/renderer/ink-compat/renderer-bridge.ts
@@ -1,0 +1,7 @@
+import { type ReactNode, createContext } from "react";
+
+export interface RendererBridge {
+  readonly emitStatic: (element: ReactNode) => void;
+}
+
+export const RendererBridgeContext = createContext<RendererBridge | null>(null);

--- a/src/renderer/reconciler/mount.ts
+++ b/src/renderer/reconciler/mount.ts
@@ -2,10 +2,12 @@ import { type ReactNode, createElement } from "react";
 import { type DiffPools, diffFrames } from "../diff/diff-frames.js";
 import { type Cursor, type Frame, emptyFrame } from "../diff/frame.js";
 import { serializePatches } from "../diff/serialize.js";
+import { RendererBridgeContext } from "../ink-compat/renderer-bridge.js";
 import { ViewportContext } from "../ink-compat/viewport.js";
 import { KeystrokeContext, KeystrokeReader, type KeystrokeSource } from "../input/index.js";
 import { renderToScreen } from "../layout/layout.js";
 import type { LayoutNode } from "../layout/node.js";
+import { renderToBytes } from "../runtime/render-to-bytes.js";
 import { type HostRoot, hostToLayoutNode, reconciler } from "./host-config.js";
 
 export interface MountOptions {
@@ -20,6 +22,7 @@ export interface MountOptions {
 export interface Handle {
   update(element: ReactNode): void;
   resize(width: number, height: number): void;
+  emitStatic(element: ReactNode): void;
   destroy(): void;
 }
 
@@ -66,11 +69,32 @@ export function mount(element: ReactNode, opts: MountOptions): Handle {
     null,
   );
 
+  const emitStatic = (node: ReactNode): void => {
+    if (destroyed) return;
+    const bytes = renderToBytes(node, viewportWidth, opts.pools);
+    if (bytes.length === 0) return;
+    if (frame.screen.height > 0) {
+      opts.write(`\r\x1b[${frame.screen.height}A\x1b[J`);
+    } else {
+      opts.write("\r\x1b[J");
+    }
+    opts.write(bytes);
+    frame = emptyFrame(viewportWidth, viewportHeight);
+    root.onCommit();
+  };
+
+  const bridge = { emitStatic };
+
   const wrap = (node: ReactNode): ReactNode => {
+    const withBridge: ReactNode = createElement(
+      RendererBridgeContext.Provider,
+      { value: bridge },
+      node,
+    );
     const withViewport: ReactNode = createElement(
       ViewportContext.Provider,
       { value: { columns: viewportWidth, rows: viewportHeight } },
-      node,
+      withBridge,
     );
     return reader
       ? createElement(KeystrokeContext.Provider, { value: reader }, withViewport)
@@ -97,6 +121,7 @@ export function mount(element: ReactNode, opts: MountOptions): Handle {
         /* committed */
       });
     },
+    emitStatic,
     destroy(): void {
       if (destroyed) return;
       destroyed = true;

--- a/src/renderer/runtime/render-to-bytes.ts
+++ b/src/renderer/runtime/render-to-bytes.ts
@@ -1,0 +1,48 @@
+import type { ReactNode } from "react";
+import type { DiffPools } from "../diff/diff-frames.js";
+import { render as renderReactTree } from "../react/render.js";
+import { CellWidth } from "../screen/cell.js";
+
+const ESC = "\x1b";
+const ST = `${ESC}\\`;
+
+export function renderToBytes(element: ReactNode, width: number, pools: DiffPools): string {
+  const screen = renderReactTree(element, { width, pools });
+  if (screen.height === 0) return "";
+
+  let out = "";
+  let curStyle = pools.style.none;
+  let curLink = 0;
+
+  for (let y = 0; y < screen.height; y++) {
+    if (y > 0) {
+      out += pools.style.transition(curStyle, pools.style.none);
+      curStyle = pools.style.none;
+      if (curLink !== 0) {
+        out += `${ESC}]8;;${ST}`;
+        curLink = 0;
+      }
+      out += "\r\n";
+    }
+    for (let x = 0; x < screen.width; x++) {
+      const cell = screen.cellAt(x, y);
+      if (!cell) continue;
+      if (cell.width === CellWidth.SpacerTail) continue;
+      if (cell.styleId !== curStyle) {
+        out += pools.style.transition(curStyle, cell.styleId);
+        curStyle = cell.styleId;
+      }
+      if (cell.hyperlinkId !== curLink) {
+        const uri = pools.hyperlink.get(cell.hyperlinkId) ?? "";
+        out += `${ESC}]8;;${uri}${ST}`;
+        curLink = cell.hyperlinkId;
+      }
+      out += pools.char.get(cell.charId);
+    }
+  }
+
+  out += pools.style.transition(curStyle, pools.style.none);
+  if (curLink !== 0) out += `${ESC}]8;;${ST}`;
+  out += "\r\n";
+  return out;
+}

--- a/tests/renderer/ink-compat/static.test.tsx
+++ b/tests/renderer/ink-compat/static.test.tsx
@@ -1,0 +1,170 @@
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React, { useState } from "react";
+import { describe, expect, it } from "vitest";
+import {
+  CharPool,
+  HyperlinkPool,
+  StylePool,
+  inkCompat,
+  mount,
+} from "../../../src/renderer/index.js";
+import { renderToBytes } from "../../../src/renderer/runtime/render-to-bytes.js";
+import { makeTestWriter } from "../../../src/renderer/runtime/test-writer.js";
+
+function pools() {
+  return { char: new CharPool(), style: new StylePool(), hyperlink: new HyperlinkPool() };
+}
+
+function flush(): Promise<void> {
+  return new Promise((r) => setTimeout(r, 0));
+}
+
+describe("renderToBytes — offline render to a flat string", () => {
+  it("emits row content followed by trailing CRLF", () => {
+    const out = renderToBytes(
+      <inkCompat.Box flexDirection="column">
+        <inkCompat.Text>row1</inkCompat.Text>
+        <inkCompat.Text>row2</inkCompat.Text>
+      </inkCompat.Box>,
+      10,
+      pools(),
+    );
+    expect(out).toContain("row1");
+    expect(out).toContain("row2");
+    expect(out).toMatch(/row1[^\n]*\r\n[^\n]*row2/);
+    expect(out.endsWith("\r\n")).toBe(true);
+  });
+
+  it("empty element yields empty string", () => {
+    expect(renderToBytes(null, 10, pools())).toBe("");
+  });
+});
+
+describe("inkCompat.Static — appends rows to scrollback", () => {
+  it("emits each new item batch via emitStatic before live patches", async () => {
+    const w = makeTestWriter();
+    function App({ items }: { items: ReadonlyArray<string> }) {
+      return (
+        <inkCompat.Box flexDirection="column">
+          <inkCompat.Static items={items}>
+            {(item) => <inkCompat.Text>{`static:${item}`}</inkCompat.Text>}
+          </inkCompat.Static>
+          <inkCompat.Text>live</inkCompat.Text>
+        </inkCompat.Box>
+      );
+    }
+    const handle = mount(<App items={["a", "b"]} />, {
+      viewportWidth: 20,
+      viewportHeight: 5,
+      pools: pools(),
+      write: w.write,
+    });
+    await flush();
+    expect(w.output()).toContain("static:a");
+    expect(w.output()).toContain("static:b");
+    expect(w.output()).toContain("live");
+
+    w.flush();
+    handle.update(<App items={["a", "b", "c"]} />);
+    await flush();
+    const after = w.output();
+    expect(after).toContain("static:c");
+    expect(after).not.toContain("static:a");
+    expect(after).not.toContain("static:b");
+    expect(after).toContain("live");
+    handle.destroy();
+  });
+
+  it("appended items only — never re-emits previously-emitted rows", async () => {
+    const w = makeTestWriter();
+    function App({ items }: { items: ReadonlyArray<number> }) {
+      return (
+        <inkCompat.Box flexDirection="column">
+          <inkCompat.Static items={items}>
+            {(n) => <inkCompat.Text>{`s${n}`}</inkCompat.Text>}
+          </inkCompat.Static>
+          <inkCompat.Text>L</inkCompat.Text>
+        </inkCompat.Box>
+      );
+    }
+    const handle = mount(<App items={[]} />, {
+      viewportWidth: 10,
+      viewportHeight: 3,
+      pools: pools(),
+      write: w.write,
+    });
+    await flush();
+    w.flush();
+
+    handle.update(<App items={[1]} />);
+    await flush();
+    expect(w.output()).toContain("s1");
+    w.flush();
+
+    handle.update(<App items={[1, 2]} />);
+    await flush();
+    const out2 = w.output();
+    expect(out2).toContain("s2");
+    expect(out2).not.toContain("s1");
+
+    handle.destroy();
+  });
+
+  it("Static items reach the sink even when the live tree is empty", async () => {
+    const w = makeTestWriter();
+    function App({ items }: { items: ReadonlyArray<string> }) {
+      return (
+        <inkCompat.Static items={items}>
+          {(item) => <inkCompat.Text>{item}</inkCompat.Text>}
+        </inkCompat.Static>
+      );
+    }
+    const handle = mount(<App items={["one"]} />, {
+      viewportWidth: 10,
+      viewportHeight: 3,
+      pools: pools(),
+      write: w.write,
+    });
+    await flush();
+    expect(w.output()).toContain("one");
+    handle.destroy();
+  });
+
+  it("interleaves with state-driven live updates", async () => {
+    const w = makeTestWriter();
+    let pushItem: (s: string) => void = () => {};
+    let bumpCount: () => void = () => {};
+    function App() {
+      const [items, setItems] = useState<string[]>([]);
+      const [count, setCount] = useState(0);
+      pushItem = (s) => setItems((prev) => [...prev, s]);
+      bumpCount = () => setCount((n) => n + 1);
+      return (
+        <inkCompat.Box flexDirection="column">
+          <inkCompat.Static items={items}>
+            {(it) => <inkCompat.Text>{`>${it}`}</inkCompat.Text>}
+          </inkCompat.Static>
+          <inkCompat.Text>{`count=${count}`}</inkCompat.Text>
+        </inkCompat.Box>
+      );
+    }
+    const handle = mount(<App />, {
+      viewportWidth: 20,
+      viewportHeight: 4,
+      pools: pools(),
+      write: w.write,
+    });
+    await flush();
+    bumpCount();
+    await flush();
+    pushItem("alpha");
+    await flush();
+    w.flush();
+    bumpCount();
+    await flush();
+    const after = w.output();
+    expect(w.output().length).toBeGreaterThan(0);
+    expect(after).toContain("2");
+    handle.destroy();
+  });
+});


### PR DESCRIPTION
Phase 5d-6 of the cell-diff renderer (#160).

Wires up the "rendered once and never updated" semantic of `inkCompat.Static`. Previously the shim component just wrapped items in a column Box, which kept them in the live tree and subject to re-diff on every frame. That defeats the entire reason `Static` exists.

## Pipeline

When `Static`'s `items` array grows:

1. New items are sliced out via a `lastIndex` ref.
2. The new items are rendered **offline** via `renderToBytes` — a flat string with row-by-row content, style + hyperlink resets, and `\r\n` between rows.
3. The bytes are handed to `mount`'s new `emitStatic(element)` method on the Handle.
4. `emitStatic` clears the previous live area (`\r CSI nA CSI J`), writes the static bytes (advancing terminal scrollback), then resets the prev frame to empty so the next live commit starts fresh below.

The Handle exposes `emitStatic` directly, and `Static` finds it via a new `RendererBridgeContext` — no global state.

## Public surface

- `mount`'s Handle gains `emitStatic(element: ReactNode): void`
- `renderToBytes(element, width, pools)` is now exported from `src/renderer/index.ts` so apps can stage scrollback content without React (e.g., a one-shot welcome banner before the live loop starts).
- `RendererBridge` + `RendererBridgeContext` exported from `inkCompat`.

## Tests

6 new tests in `tests/renderer/ink-compat/static.test.tsx`:

- `renderToBytes` emits rows separated by CRLF, with trailing CRLF
- `renderToBytes` returns "" on null
- Static appends new items to scrollback, never re-emits old ones
- Across two updates, batches emit independently
- Static items reach the sink even when the live tree is empty
- Static interleaves cleanly with state-driven live updates

## Test plan

- [x] `npm run verify` clean — 2070 passing tests (was 2064)