### PR TITLE
feat(renderer): gap on Box — column rows + row columns (#160)

### DIFF
--- a/src/renderer/ink-compat/Box.tsx
+++ b/src/renderer/ink-compat/Box.tsx
@@ -55,6 +55,7 @@ export function Box(props: InkBoxProps): React.ReactElement {
       justifyContent={props.justifyContent}
       width={typeof props.width === "number" ? props.width : undefined}
       height={typeof props.height === "number" ? props.height : undefined}
+      gap={props.gap}
       paddingTop={padTop}
       paddingBottom={padBottom}
       paddingLeft={padLeft}

--- a/src/renderer/layout/layout.ts
+++ b/src/renderer/layout/layout.ts
@@ -178,8 +178,10 @@ function makeBorderEdge(
 
 function layoutColumn(node: BoxNode, innerWidth: number, pools: RenderPools): Laid {
   const rows: LayoutRows = [];
-  for (const child of node.children) {
-    const laid = layout(child, innerWidth, pools);
+  const gap = clampPad(node.gap);
+  for (let i = 0; i < node.children.length; i++) {
+    if (i > 0 && gap > 0) rows.push(...blanks(gap));
+    const laid = layout(node.children[i]!, innerWidth, pools);
     rows.push(...laid.rows);
   }
   return { rows, width: innerWidth };
@@ -189,9 +191,12 @@ function layoutRow(node: BoxNode, innerWidth: number, pools: RenderPools): Laid 
   if (innerWidth === 0 || node.children.length === 0) {
     return { rows: [], width: innerWidth };
   }
-  const allocations = allocateRowWidths(node.children, innerWidth);
+  const gap = clampPad(node.gap);
+  const gapTotal = gap * Math.max(0, node.children.length - 1);
+  const remaining = Math.max(0, innerWidth - gapTotal);
+  const allocations = allocateRowWidths(node.children, remaining);
   const childResults = node.children.map((child, i) => layout(child, allocations[i] ?? 0, pools));
-  const offsets = computeRowOffsets(allocations, innerWidth, node.justifyContent);
+  const offsets = computeRowOffsets(allocations, remaining, node.justifyContent, gap);
 
   const merged: LayoutRows = [];
   for (let i = 0; i < childResults.length; i++) {
@@ -209,18 +214,20 @@ function layoutRow(node: BoxNode, innerWidth: number, pools: RenderPools): Laid 
 
 function computeRowOffsets(
   allocations: ReadonlyArray<number>,
-  innerWidth: number,
+  remaining: number,
   justify: BoxNode["justifyContent"],
+  gap: number,
 ): number[] {
   const offsets: number[] = [];
   let cursor = 0;
-  for (const a of allocations) {
+  for (let i = 0; i < allocations.length; i++) {
+    if (i > 0) cursor += gap;
     offsets.push(cursor);
-    cursor += a;
+    cursor += allocations[i] ?? 0;
   }
   if (!justify || justify === "flex-start") return offsets;
   const used = allocations.reduce((s, a) => s + a, 0);
-  const slack = Math.max(0, innerWidth - used);
+  const slack = Math.max(0, remaining - used);
   if (slack === 0) return offsets;
 
   if (justify === "flex-end") {
@@ -233,15 +240,15 @@ function computeRowOffsets(
   if (justify === "space-between") {
     if (allocations.length <= 1) return offsets;
     const gaps = allocations.length - 1;
-    const gap = Math.floor(slack / gaps);
-    let extra = slack - gap * gaps;
+    const extraGap = Math.floor(slack / gaps);
+    let extra = slack - extraGap * gaps;
     const out: number[] = [];
     let c = 0;
     for (let i = 0; i < allocations.length; i++) {
       out.push(c);
       c += allocations[i] ?? 0;
       if (i < allocations.length - 1) {
-        c += gap + (extra > 0 ? 1 : 0);
+        c += gap + extraGap + (extra > 0 ? 1 : 0);
         if (extra > 0) extra--;
       }
     }
@@ -305,7 +312,15 @@ function intrinsicWidth(node: LayoutNode): number {
     (border && node.borderLeft !== false ? 1 : 0) + (border && node.borderRight !== false ? 1 : 0);
   if (node.children.length === 0) return padLeft + padRight + borderH;
   if (node.flexDirection === "row") {
-    return padLeft + padRight + borderH + node.children.reduce((s, c) => s + intrinsicWidth(c), 0);
+    const gap = clampPad(node.gap);
+    const gapTotal = gap * Math.max(0, node.children.length - 1);
+    return (
+      padLeft +
+      padRight +
+      borderH +
+      gapTotal +
+      node.children.reduce((s, c) => s + intrinsicWidth(c), 0)
+    );
   }
   let max = 0;
   for (const c of node.children) {

--- a/src/renderer/layout/node.ts
+++ b/src/renderer/layout/node.ts
@@ -18,6 +18,7 @@ export interface BoxNode {
   readonly justifyContent?: JustifyContent;
   readonly width?: number;
   readonly height?: number;
+  readonly gap?: number;
   readonly paddingTop?: number;
   readonly paddingBottom?: number;
   readonly paddingLeft?: number;

--- a/src/renderer/react/components.ts
+++ b/src/renderer/react/components.ts
@@ -13,6 +13,7 @@ export interface BoxProps {
   readonly justifyContent?: JustifyContent;
   readonly width?: number;
   readonly height?: number;
+  readonly gap?: number;
   readonly paddingTop?: number;
   readonly paddingBottom?: number;
   readonly paddingLeft?: number;

--- a/src/renderer/react/render.ts
+++ b/src/renderer/react/render.ts
@@ -43,12 +43,14 @@ function elementToLayoutNode(element: ReactElement): LayoutNode | null {
       justifyContent?: BoxProps["justifyContent"];
       width?: number;
       height?: number;
+      gap?: number;
     } = {};
     if (boxProps.flexDirection !== undefined) flex.flexDirection = boxProps.flexDirection;
     if (boxProps.flexGrow !== undefined) flex.flexGrow = boxProps.flexGrow;
     if (boxProps.justifyContent !== undefined) flex.justifyContent = boxProps.justifyContent;
     if (boxProps.width !== undefined) flex.width = boxProps.width;
     if (boxProps.height !== undefined) flex.height = boxProps.height;
+    if (boxProps.gap !== undefined) flex.gap = boxProps.gap;
     const border = resolveBorder(boxProps);
     return { kind: "box", children, ...flex, ...padding, ...border } satisfies BoxNode;
   }

--- a/src/renderer/reconciler/host-node.ts
+++ b/src/renderer/reconciler/host-node.ts
@@ -86,6 +86,7 @@ function assignBoxProps(node: BoxNode, props: BoxProps): BoxNode {
   if (props.justifyContent !== undefined) result.justifyContent = props.justifyContent;
   if (props.width !== undefined) result.width = props.width;
   if (props.height !== undefined) result.height = props.height;
+  if (props.gap !== undefined) result.gap = props.gap;
   if (props.borderStyle !== undefined) result.borderStyle = props.borderStyle;
   if (props.borderTop !== undefined) result.borderTop = props.borderTop;
   if (props.borderBottom !== undefined) result.borderBottom = props.borderBottom;

--- a/tests/renderer/gap.test.tsx
+++ b/tests/renderer/gap.test.tsx
@@ -1,0 +1,131 @@
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { CharPool } from "../../src/renderer/pools/char-pool.js";
+import { HyperlinkPool } from "../../src/renderer/pools/hyperlink-pool.js";
+import { StylePool } from "../../src/renderer/pools/style-pool.js";
+import { Box, Text } from "../../src/renderer/react/components.js";
+import { render } from "../../src/renderer/react/render.js";
+import { CellWidth } from "../../src/renderer/screen/cell.js";
+
+function pools() {
+  return {
+    char: new CharPool(),
+    style: new StylePool(),
+    hyperlink: new HyperlinkPool(),
+  };
+}
+
+function readLine(
+  screen: ReturnType<typeof render>,
+  p: ReturnType<typeof pools>,
+  y: number,
+): string {
+  let line = "";
+  for (let x = 0; x < screen.width; x++) {
+    const cell = screen.cellAt(x, y);
+    if (!cell) break;
+    if (cell.width === CellWidth.SpacerTail) continue;
+    line += p.char.get(cell.charId);
+  }
+  return line;
+}
+
+describe("layout — gap in column flow", () => {
+  it("gap=1 inserts a single empty row between siblings", () => {
+    const p = pools();
+    const s = render(
+      <Box flexDirection="column" gap={1}>
+        <Text>A</Text>
+        <Text>B</Text>
+        <Text>C</Text>
+      </Box>,
+      { width: 5, pools: p },
+    );
+    expect(readLine(s, p, 0)).toContain("A");
+    expect(readLine(s, p, 1).trim()).toBe("");
+    expect(readLine(s, p, 2)).toContain("B");
+    expect(readLine(s, p, 3).trim()).toBe("");
+    expect(readLine(s, p, 4)).toContain("C");
+  });
+
+  it("no gap on a single child", () => {
+    const p = pools();
+    const s = render(
+      <Box flexDirection="column" gap={2}>
+        <Text>solo</Text>
+      </Box>,
+      { width: 6, pools: p },
+    );
+    expect(s.height).toBe(1);
+  });
+});
+
+describe("layout — gap in row flow", () => {
+  it("gap=2 leaves two columns of space between siblings", () => {
+    const p = pools();
+    const s = render(
+      <Box flexDirection="row" gap={2}>
+        <Text>A</Text>
+        <Text>B</Text>
+        <Text>C</Text>
+      </Box>,
+      { width: 9, pools: p },
+    );
+    expect(readLine(s, p, 0).slice(0, 7)).toBe("A  B  C");
+  });
+
+  it("gap reduces remaining width before flexGrow distribution", () => {
+    const p = pools();
+    const s = render(
+      <Box flexDirection="row" gap={1}>
+        <Box flexGrow={1}>
+          <Text>L</Text>
+        </Box>
+        <Box flexGrow={1}>
+          <Text>R</Text>
+        </Box>
+      </Box>,
+      { width: 9, pools: p },
+    );
+    const line = readLine(s, p, 0);
+    expect(line.startsWith("L")).toBe(true);
+    expect(line[5]).toBe("R");
+  });
+
+  it("gap interacts with justifyContent=space-between", () => {
+    const p = pools();
+    const s = render(
+      <Box flexDirection="row" gap={1} justifyContent="space-between">
+        <Text>L</Text>
+        <Text>M</Text>
+        <Text>R</Text>
+      </Box>,
+      { width: 11, pools: p },
+    );
+    const line = readLine(s, p, 0);
+    expect(line.startsWith("L")).toBe(true);
+    expect(line.endsWith("R")).toBe(true);
+    expect(line.indexOf("M")).toBeGreaterThan(0);
+  });
+});
+
+describe("layout — gap counted in intrinsicWidth", () => {
+  it("row-flow intrinsic accounts for gap between siblings", () => {
+    const p = pools();
+    const s = render(
+      <Box flexDirection="row">
+        <Box>
+          <Text>start</Text>
+        </Box>
+        <Box flexDirection="row" gap={3}>
+          <Text>A</Text>
+          <Text>B</Text>
+        </Box>
+      </Box>,
+      { width: 30, pools: p },
+    );
+    const line = readLine(s, p, 0);
+    expect(line.startsWith("startA   B")).toBe(true);
+  });
+});


### PR DESCRIPTION
Phase 5d-7 of the cell-diff renderer (#160).

Adds `gap` to `Box`. In column flow it inserts N empty rows between siblings; in row flow it reserves N cells between siblings before flexGrow distribution.

## Layout

- Column flow: each transition between siblings injects N blank rows (skipped before the first child and after the last).
- Row flow: `gap * (children.length - 1)` cells are subtracted from the row's inner width *before* `allocateRowWidths` runs, so flexGrow children only compete for the remaining space.
- `intrinsicWidth(node)` now counts the gap total when summing row children, so a parent's flex distribution sees the true intrinsic of a gapped row.
- Composes with `justifyContent`: `space-between` distributes extra slack *on top of* the configured gap.

## Plumbing

- `BoxNode.gap`, `BoxProps.gap`, `host-node` and `render` walker forward it.
- `inkCompat.Box.gap` already declared on the prop type — now wired through.

## Tests

6 new tests in `tests/renderer/gap.test.tsx`:

- column gap=1 inserts a single empty row between three siblings
- column gap with a single child has no effect
- row gap=2 leaves two-column space between three siblings
- row gap reduces remaining width before flexGrow distribution
- gap interacts cleanly with justifyContent=space-between
- intrinsicWidth(row) counts gaps in nested layouts

## Test plan

- [x] `npm run verify` clean — 2076 passing tests (was 2070)