### PR TITLE
feat(renderer): wire useApp().exit() to a mount onExit hook (#160)

### DIFF
--- a/src/renderer/reconciler/mount.ts
+++ b/src/renderer/reconciler/mount.ts
@@ -3,6 +3,7 @@ import { type DiffPools, diffFrames } from "../diff/diff-frames.js";
 import { type Cursor, type Frame, emptyFrame } from "../diff/frame.js";
 import { serializePatches } from "../diff/serialize.js";
 import { RendererBridgeContext } from "../ink-compat/renderer-bridge.js";
+import { AppContext } from "../ink-compat/use-app.js";
 import { ViewportContext } from "../ink-compat/viewport.js";
 import { KeystrokeContext, KeystrokeReader, type KeystrokeSource } from "../input/index.js";
 import { renderToScreen } from "../layout/layout.js";
@@ -17,6 +18,7 @@ export interface MountOptions {
   readonly write: (bytes: string) => void;
   readonly cursor?: () => Cursor;
   readonly stdin?: KeystrokeSource;
+  readonly onExit?: (error?: Error) => void;
 }
 
 export interface Handle {
@@ -85,11 +87,19 @@ export function mount(element: ReactNode, opts: MountOptions): Handle {
 
   const bridge = { emitStatic };
 
+  const appApi = {
+    exit: (error?: Error): void => {
+      if (destroyed) return;
+      queueMicrotask(() => opts.onExit?.(error));
+    },
+  };
+
   const wrap = (node: ReactNode): ReactNode => {
+    const withApp: ReactNode = createElement(AppContext.Provider, { value: appApi }, node);
     const withBridge: ReactNode = createElement(
       RendererBridgeContext.Provider,
       { value: bridge },
-      node,
+      withApp,
     );
     const withViewport: ReactNode = createElement(
       ViewportContext.Provider,

--- a/tests/renderer/use-app-mount.test.tsx
+++ b/tests/renderer/use-app-mount.test.tsx
@@ -1,0 +1,117 @@
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React, { useEffect } from "react";
+import { describe, expect, it } from "vitest";
+import { CharPool, HyperlinkPool, StylePool, inkCompat, mount } from "../../src/renderer/index.js";
+import { makeTestWriter } from "../../src/renderer/runtime/test-writer.js";
+
+function pools() {
+  return { char: new CharPool(), style: new StylePool(), hyperlink: new HyperlinkPool() };
+}
+
+function flush(): Promise<void> {
+  return new Promise((r) => setTimeout(r, 0));
+}
+
+describe("mount — useApp().exit() routes through onExit", () => {
+  it("exit() inside the tree triggers the onExit callback", async () => {
+    const w = makeTestWriter();
+    let exited = false;
+    function App() {
+      const { exit } = inkCompat.useApp();
+      useEffect(() => {
+        exit();
+      }, [exit]);
+      return <inkCompat.Text>x</inkCompat.Text>;
+    }
+    const handle = mount(<App />, {
+      viewportWidth: 5,
+      viewportHeight: 1,
+      pools: pools(),
+      write: w.write,
+      onExit: () => {
+        exited = true;
+      },
+    });
+    await flush();
+    await flush();
+    expect(exited).toBe(true);
+    handle.destroy();
+  });
+
+  it("exit(err) forwards the error to onExit", async () => {
+    const w = makeTestWriter();
+    let received: Error | undefined;
+    function App() {
+      const { exit } = inkCompat.useApp();
+      useEffect(() => {
+        exit(new Error("boom"));
+      }, [exit]);
+      return <inkCompat.Text>x</inkCompat.Text>;
+    }
+    const handle = mount(<App />, {
+      viewportWidth: 5,
+      viewportHeight: 1,
+      pools: pools(),
+      write: w.write,
+      onExit: (err) => {
+        received = err;
+      },
+    });
+    await flush();
+    await flush();
+    expect(received?.message).toBe("boom");
+    handle.destroy();
+  });
+
+  it("exit() after destroy is a no-op (no late onExit fire)", async () => {
+    const w = makeTestWriter();
+    let exitCalls = 0;
+    let trigger: () => void = () => {};
+    function App() {
+      const { exit } = inkCompat.useApp();
+      trigger = exit;
+      return <inkCompat.Text>x</inkCompat.Text>;
+    }
+    const handle = mount(<App />, {
+      viewportWidth: 5,
+      viewportHeight: 1,
+      pools: pools(),
+      write: w.write,
+      onExit: () => {
+        exitCalls++;
+      },
+    });
+    await flush();
+    handle.destroy();
+    trigger();
+    await flush();
+    await flush();
+    expect(exitCalls).toBe(0);
+  });
+
+  it("exit() runs deferred — never fires synchronously inside a render", async () => {
+    const w = makeTestWriter();
+    const seen: string[] = [];
+    function App() {
+      const { exit } = inkCompat.useApp();
+      seen.push("render");
+      useEffect(() => {
+        exit();
+        seen.push("after-exit");
+      }, [exit]);
+      return <inkCompat.Text>x</inkCompat.Text>;
+    }
+    mount(<App />, {
+      viewportWidth: 5,
+      viewportHeight: 1,
+      pools: pools(),
+      write: w.write,
+      onExit: () => {
+        seen.push("onExit");
+      },
+    });
+    await flush();
+    await flush();
+    expect(seen.indexOf("after-exit")).toBeLessThan(seen.indexOf("onExit"));
+  });
+});


### PR DESCRIPTION
Phase 5d-10 of the cell-diff renderer (#160).

Closes the last functional gap in the ink-compat hook surface. Previously `useApp()` returned a default `{exit: noop}` — components inside a mount tree could call `exit()` but nothing happened. The host had to read the user's intent some other way (a Promise resolved from a keystroke handler, etc.).

## Wiring

- `mount` gains an `onExit?: (error?: Error) => void` option.
- `mount` provides `AppContext.Provider` with a real `exit` fn that:
  - defers via `queueMicrotask` so it never fires synchronously inside a render or effect (would unmount mid-commit otherwise)
  - is a no-op after `destroy()`, so a stale closure can't fire onExit late

The host owns the actual teardown; `onExit` is just the signal.

## Tests

4 new tests in `tests/renderer/use-app-mount.test.tsx`:

- `exit()` inside a `useEffect` triggers `onExit`
- `exit(new Error("boom"))` forwards the error to `onExit`
- `exit()` after `destroy()` is a no-op (no late fire)
- `exit()` is deferred — `useEffect` body runs to completion before `onExit` fires

## Test plan

- [x] `npm run verify` clean — 2103 passing tests (was 2099)