### PR TITLE
feat(renderer): reasonix preview — minimal chat shell (#160)

### DIFF
--- a/src/cli/commands/preview.tsx
+++ b/src/cli/commands/preview.tsx
@@ -1,0 +1,177 @@
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React, { useRef, useState } from "react";
+import {
+  CharPool,
+  type Handle,
+  HyperlinkPool,
+  StylePool,
+  inkCompat,
+  mount,
+  useKeystroke,
+} from "../../renderer/index.js";
+
+const BRAND = "#79c0ff";
+const FAINT = "#6e7681";
+const ACCENT = "#d2a8ff";
+const OK = "#7ee787";
+
+interface HistoryEntry {
+  readonly id: number;
+  readonly role: "user" | "echo";
+  readonly text: string;
+}
+
+function Header(): React.ReactElement {
+  return (
+    <inkCompat.Box flexDirection="row" gap={1}>
+      <inkCompat.Text color={BRAND} bold>
+        ◈ Reasonix
+      </inkCompat.Text>
+      <inkCompat.Text color={FAINT}>preview · cell-diff renderer</inkCompat.Text>
+    </inkCompat.Box>
+  );
+}
+
+function HistoryRow({ entry }: { entry: HistoryEntry }): React.ReactElement {
+  const tone = entry.role === "user" ? ACCENT : OK;
+  const glyph = entry.role === "user" ? "›" : "‹";
+  return (
+    <inkCompat.Box flexDirection="row" gap={1}>
+      <inkCompat.Text color={tone}>{glyph}</inkCompat.Text>
+      <inkCompat.Text>{entry.text}</inkCompat.Text>
+    </inkCompat.Box>
+  );
+}
+
+interface PromptLineProps {
+  readonly value: string;
+  readonly placeholder: string;
+}
+
+function PromptLine({ value, placeholder }: PromptLineProps): React.ReactElement {
+  const showPlaceholder = value.length === 0;
+  return (
+    <inkCompat.Box flexDirection="row" gap={1} marginTop={1}>
+      <inkCompat.Text color={BRAND} bold>
+        ›
+      </inkCompat.Text>
+      {showPlaceholder ? (
+        <inkCompat.Text dimColor>{placeholder}</inkCompat.Text>
+      ) : (
+        <inkCompat.Text>{value}</inkCompat.Text>
+      )}
+      <inkCompat.Text color={FAINT}>▏</inkCompat.Text>
+    </inkCompat.Box>
+  );
+}
+
+function HintBar(): React.ReactElement {
+  return (
+    <inkCompat.Box marginTop={1}>
+      <inkCompat.Text dimColor>Enter submit · Esc exit</inkCompat.Text>
+    </inkCompat.Box>
+  );
+}
+
+interface ShellProps {
+  onExit: () => void;
+}
+
+export function PreviewShell({ onExit }: ShellProps): React.ReactElement {
+  const [history, setHistory] = useState<ReadonlyArray<HistoryEntry>>([]);
+  const [draft, setDraft] = useState("");
+  const draftRef = useRef("");
+  const nextIdRef = useRef(0);
+
+  useKeystroke((k) => {
+    if (k.escape) {
+      onExit();
+      return;
+    }
+    if (k.return) {
+      const text = draftRef.current.trim();
+      if (text.length === 0) return;
+      const id = nextIdRef.current;
+      nextIdRef.current = id + 2;
+      setHistory((prev) => [
+        ...prev,
+        { id, role: "user", text },
+        { id: id + 1, role: "echo", text: `you said: ${text}` },
+      ]);
+      draftRef.current = "";
+      setDraft("");
+      return;
+    }
+    if (k.backspace) {
+      const next = draftRef.current.slice(0, -1);
+      draftRef.current = next;
+      setDraft(next);
+      return;
+    }
+    if (k.ctrl || k.meta) return;
+    if (k.input && k.input.length > 0) {
+      const next = draftRef.current + k.input;
+      draftRef.current = next;
+      setDraft(next);
+    }
+  });
+
+  return (
+    <inkCompat.Box flexDirection="column">
+      <Header />
+      <inkCompat.Box flexDirection="column" marginTop={1}>
+        <inkCompat.Static items={history}>
+          {(entry) => <HistoryRow key={entry.id} entry={entry} />}
+        </inkCompat.Static>
+      </inkCompat.Box>
+      <PromptLine value={draft} placeholder="say something…" />
+      <HintBar />
+    </inkCompat.Box>
+  );
+}
+
+export interface PreviewOptions {
+  readonly stdout?: NodeJS.WriteStream;
+  readonly stdin?: NodeJS.ReadStream;
+}
+
+export async function runPreview(opts: PreviewOptions = {}): Promise<void> {
+  const stdout = opts.stdout ?? process.stdout;
+  const stdin = opts.stdin ?? process.stdin;
+
+  if (!stdin.isTTY || !stdout.isTTY) {
+    console.error("preview requires an interactive TTY.");
+    process.exit(1);
+  }
+
+  const pools = {
+    char: new CharPool(),
+    style: new StylePool(),
+    hyperlink: new HyperlinkPool(),
+  };
+
+  let resolveExit: () => void = () => {};
+  const exited = new Promise<void>((resolve) => {
+    resolveExit = resolve;
+  });
+
+  const handle: Handle = mount(<PreviewShell onExit={() => resolveExit()} />, {
+    viewportWidth: stdout.columns ?? 80,
+    viewportHeight: stdout.rows ?? 24,
+    pools,
+    write: (bytes) => stdout.write(bytes),
+    stdin,
+    onExit: () => resolveExit(),
+  });
+
+  const onResize = () => handle.resize(stdout.columns ?? 80, stdout.rows ?? 24);
+  stdout.on("resize", onResize);
+
+  try {
+    await exited;
+  } finally {
+    stdout.off("resize", onResize);
+    handle.destroy();
+    stdin.pause();
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -366,6 +366,14 @@ program
   });
 
 program
+  .command("preview")
+  .description("experimental — minimal chat shell on the cell-diff renderer (echo mode)")
+  .action(async () => {
+    const { runPreview } = await import("./commands/preview.js");
+    await runPreview();
+  });
+
+program
   .command("update")
   .description(t("cli.update"))
   .option("--dry-run", t("ui.dryRunHint"))

--- a/tests/renderer/preview.test.tsx
+++ b/tests/renderer/preview.test.tsx
@@ -1,0 +1,193 @@
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { PreviewShell } from "../../src/cli/commands/preview.js";
+import {
+  CharPool,
+  HyperlinkPool,
+  type KeystrokeSource,
+  StylePool,
+  mount,
+} from "../../src/renderer/index.js";
+import { makeTestWriter } from "../../src/renderer/runtime/test-writer.js";
+
+function pools() {
+  return { char: new CharPool(), style: new StylePool(), hyperlink: new HyperlinkPool() };
+}
+
+function flush(): Promise<void> {
+  return new Promise((r) => setTimeout(r, 0));
+}
+
+function makeFakeStdin(): KeystrokeSource & { push: (s: string) => void } {
+  let listener: ((c: string | Buffer) => void) | null = null;
+  return {
+    on(_e, cb) {
+      listener = cb;
+    },
+    off() {
+      listener = null;
+    },
+    setRawMode() {},
+    resume() {},
+    pause() {},
+    push(c: string) {
+      listener?.(c);
+    },
+  };
+}
+
+describe("preview shell — initial paint", () => {
+  it("shows the header and the placeholder prompt", async () => {
+    const w = makeTestWriter();
+    const handle = mount(<PreviewShell onExit={() => {}} />, {
+      viewportWidth: 60,
+      viewportHeight: 8,
+      pools: pools(),
+      write: w.write,
+      stdin: makeFakeStdin(),
+    });
+    await flush();
+    const out = w.output();
+    expect(out).toContain("Reasonix");
+    expect(out).toContain("preview");
+    expect(out).toContain("say something");
+    expect(out).toContain("Enter submit");
+    handle.destroy();
+  });
+});
+
+describe("preview shell — typing", () => {
+  it("printable keys append to the draft, replacing the placeholder", async () => {
+    const w = makeTestWriter();
+    const stdin = makeFakeStdin();
+    const handle = mount(<PreviewShell onExit={() => {}} />, {
+      viewportWidth: 60,
+      viewportHeight: 8,
+      pools: pools(),
+      write: w.write,
+      stdin,
+    });
+    await flush();
+    w.flush();
+    stdin.push("h");
+    stdin.push("i");
+    await flush();
+    const out = w.output();
+    expect(out).toContain("h");
+    expect(out).toContain("i");
+    handle.destroy();
+  });
+
+  it("backspace removes the last character", async () => {
+    const w = makeTestWriter();
+    const stdin = makeFakeStdin();
+    const handle = mount(<PreviewShell onExit={() => {}} />, {
+      viewportWidth: 60,
+      viewportHeight: 8,
+      pools: pools(),
+      write: w.write,
+      stdin,
+    });
+    await flush();
+    stdin.push("abc");
+    await flush();
+    w.flush();
+    stdin.push("\x7f");
+    await flush();
+    expect(w.output().length).toBeGreaterThan(0);
+    handle.destroy();
+  });
+});
+
+describe("preview shell — submit + history", () => {
+  it("Enter pushes the draft into history and clears the prompt", async () => {
+    const w = makeTestWriter();
+    const stdin = makeFakeStdin();
+    const handle = mount(<PreviewShell onExit={() => {}} />, {
+      viewportWidth: 60,
+      viewportHeight: 10,
+      pools: pools(),
+      write: w.write,
+      stdin,
+    });
+    await flush();
+    stdin.push("hello");
+    await flush();
+    stdin.push("\r");
+    await flush();
+    await flush();
+    const out = w.output();
+    expect(out).toContain("hello");
+    expect(out).toContain("you said: hello");
+    handle.destroy();
+  });
+
+  it("two consecutive submits stack into history", async () => {
+    const w = makeTestWriter();
+    const stdin = makeFakeStdin();
+    const handle = mount(<PreviewShell onExit={() => {}} />, {
+      viewportWidth: 60,
+      viewportHeight: 12,
+      pools: pools(),
+      write: w.write,
+      stdin,
+    });
+    await flush();
+    stdin.push("one\r");
+    await flush();
+    await flush();
+    stdin.push("two\r");
+    await flush();
+    await flush();
+    const out = w.output();
+    expect(out).toContain("you said: one");
+    expect(out).toContain("you said: two");
+    handle.destroy();
+  });
+
+  it("empty submit (Enter on blank prompt) is a no-op", async () => {
+    const w = makeTestWriter();
+    const stdin = makeFakeStdin();
+    const handle = mount(<PreviewShell onExit={() => {}} />, {
+      viewportWidth: 60,
+      viewportHeight: 8,
+      pools: pools(),
+      write: w.write,
+      stdin,
+    });
+    await flush();
+    w.flush();
+    stdin.push("\r");
+    await flush();
+    expect(w.output()).not.toContain("you said:");
+    handle.destroy();
+  });
+});
+
+describe("preview shell — exit", () => {
+  it("Esc triggers onExit", async () => {
+    const w = makeTestWriter();
+    const stdin = makeFakeStdin();
+    let exited = false;
+    const handle = mount(
+      <PreviewShell
+        onExit={() => {
+          exited = true;
+        }}
+      />,
+      {
+        viewportWidth: 60,
+        viewportHeight: 8,
+        pools: pools(),
+        write: w.write,
+        stdin,
+      },
+    );
+    await flush();
+    stdin.push("\x1b");
+    await flush();
+    expect(exited).toBe(true);
+    handle.destroy();
+  });
+});


### PR DESCRIPTION
Phase 5d-12 of the cell-diff renderer (#160).

First user-facing surface that runs **entirely** on the new pipeline. `reasonix preview` mounts a minimal chat shell — header, scrollback history (via `Static`), single-line input, Enter submit, Esc exit. Echo mode for now (no model call).

This is the migration target. Subsequent PRs grow this shell toward feature parity with the live `chat`:
- model badge / status row
- streaming card
- tool result rows
- slash-commands and the `/help` overlay
- multi-line input with cursor

Once the preview catches up, the existing Ink-based App becomes the legacy backend and `chat` switches over.

## What this composes

Everything 5d-2..5d-11 added, in one component:
- `useKeystroke` — printable keys, Backspace, Enter, Esc
- `useApp().exit` (via `mount.onExit`)
- `Static` for scrollback (history rows never re-diff)
- `gap`, `marginTop`, hex colors, `dimColor`
- `useState`-driven draft state

State held in refs because a single `stdin.push("abc\r")` fires four keystrokes synchronously inside one event tick. Closure-captured state would read pre-update values; the ref read sees the latest characters before the `\r` commits.

## Tests

7 in `tests/renderer/preview.test.tsx`:

- initial paint shows header + placeholder + hint bar
- printable keys append to the draft
- Backspace removes the last character
- Enter submits and pushes both the user line and the echo line into history
- two consecutive submits stack into history (regression test for the closure bug)
- empty submit (Enter on blank prompt) is a no-op
- Esc triggers `onExit`

## Test plan

- [x] `npm run verify` clean — 2114 passing tests (was 2107)
- [ ] `node dist/cli/index.js preview` in Windows Terminal: typing renders, Enter submits, history scrolls correctly across 10+ lines, Esc exits cleanly