### PR TITLE
feat(renderer): preview — incremental text reveal on the streaming row (#160)

### DIFF
--- a/src/cli/commands/preview.tsx
+++ b/src/cli/commands/preview.tsx
@@ -25,7 +25,12 @@ interface HistoryEntry {
 
 const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"] as const;
 const SPINNER_TICK_MS = 80;
-const STREAM_DURATION_MS = 1500;
+const TOKEN_TICK_MS = 33;
+const CHARS_PER_TICK = 3;
+
+function buildResponse(userText: string): string {
+  return `you said: ${userText}. Streamed cell-by-cell — only the new chars get patched.`;
+}
 
 interface SlashCommand {
   readonly name: string;
@@ -106,11 +111,13 @@ function HintBar({ streaming }: { streaming: boolean }): React.ReactElement {
 
 interface StreamingProps {
   readonly userText: string;
+  readonly response: string;
   readonly frame: number;
+  readonly done: boolean;
 }
 
-function StreamingRow({ userText, frame }: StreamingProps): React.ReactElement {
-  const glyph = SPINNER_FRAMES[frame % SPINNER_FRAMES.length] ?? "·";
+function StreamingRow({ userText, response, frame, done }: StreamingProps): React.ReactElement {
+  const glyph = done ? "‹" : (SPINNER_FRAMES[frame % SPINNER_FRAMES.length] ?? "·");
   return (
     <inkCompat.Box flexDirection="column">
       <inkCompat.Box flexDirection="row" gap={1}>
@@ -118,8 +125,8 @@ function StreamingRow({ userText, frame }: StreamingProps): React.ReactElement {
         <inkCompat.Text>{userText}</inkCompat.Text>
       </inkCompat.Box>
       <inkCompat.Box flexDirection="row" gap={1}>
-        <inkCompat.Text color={BRAND}>{glyph}</inkCompat.Text>
-        <inkCompat.Text dimColor>thinking…</inkCompat.Text>
+        <inkCompat.Text color={done ? OK : BRAND}>{glyph}</inkCompat.Text>
+        <inkCompat.Text>{response.length > 0 ? response : "thinking…"}</inkCompat.Text>
       </inkCompat.Box>
     </inkCompat.Box>
   );
@@ -161,6 +168,8 @@ function trySlash(
 
 interface InflightState {
   readonly userText: string;
+  readonly fullResponse: string;
+  readonly revealed: number;
   readonly frame: number;
 }
 
@@ -179,26 +188,36 @@ export function PreviewShell({ onExit }: ShellProps): React.ReactElement {
   const streaming = inflight !== null;
   useEffect(() => {
     if (!streaming) return;
-    const tick = setInterval(() => {
+    const spin = setInterval(() => {
       const cur = inflightRef.current;
       if (!cur) return;
-      setInflight({ userText: cur.userText, frame: cur.frame + 1 });
+      setInflight({ ...cur, frame: cur.frame + 1 });
     }, SPINNER_TICK_MS);
-    const finish = setTimeout(() => {
+    const reveal = setInterval(() => {
       const cur = inflightRef.current;
       if (!cur) return;
-      const id = nextIdRef.current;
-      nextIdRef.current = id + 2;
-      setHistory((prev) => [
-        ...prev,
-        { id, role: "user", text: cur.userText },
-        { id: id + 1, role: "echo", text: `you said: ${cur.userText}` },
-      ]);
-      setInflight(null);
-    }, STREAM_DURATION_MS);
+      if (cur.revealed >= cur.fullResponse.length) {
+        clearInterval(reveal);
+        setTimeout(() => {
+          const fin = inflightRef.current;
+          if (!fin) return;
+          const id = nextIdRef.current;
+          nextIdRef.current = id + 2;
+          setHistory((prev) => [
+            ...prev,
+            { id, role: "user", text: fin.userText },
+            { id: id + 1, role: "echo", text: fin.fullResponse },
+          ]);
+          setInflight(null);
+        }, 200);
+        return;
+      }
+      const next = Math.min(cur.fullResponse.length, cur.revealed + CHARS_PER_TICK);
+      setInflight({ ...cur, revealed: next });
+    }, TOKEN_TICK_MS);
     return () => {
-      clearInterval(tick);
-      clearTimeout(finish);
+      clearInterval(spin);
+      clearInterval(reveal);
     };
   }, [streaming]);
 
@@ -232,7 +251,7 @@ export function PreviewShell({ onExit }: ShellProps): React.ReactElement {
         setDraft("");
         return;
       }
-      setInflight({ userText: text, frame: 0 });
+      setInflight({ userText: text, fullResponse: buildResponse(text), revealed: 0, frame: 0 });
       draftRef.current = "";
       setDraft("");
       return;
@@ -261,7 +280,12 @@ export function PreviewShell({ onExit }: ShellProps): React.ReactElement {
       </inkCompat.Box>
       {inflight ? (
         <inkCompat.Box marginTop={1}>
-          <StreamingRow userText={inflight.userText} frame={inflight.frame} />
+          <StreamingRow
+            userText={inflight.userText}
+            response={inflight.fullResponse.slice(0, inflight.revealed)}
+            frame={inflight.frame}
+            done={inflight.revealed >= inflight.fullResponse.length}
+          />
         </inkCompat.Box>
       ) : (
         <PromptLine value={draft} placeholder="say something…" />

--- a/tests/renderer/preview.test.tsx
+++ b/tests/renderer/preview.test.tsx
@@ -119,12 +119,12 @@ describe("preview shell — submit + streaming", () => {
     expect(mid).toContain("thinking");
     expect(mid).not.toContain("you said: hello");
 
-    await new Promise((r) => setTimeout(r, 1700));
+    await new Promise((r) => setTimeout(r, 2500));
     await flush();
     const out = w.output();
     expect(out).toContain("you said: hello");
     handle.destroy();
-  }, 5000);
+  }, 8000);
 
   it("input is paused while streaming — keystrokes during the stream are dropped", async () => {
     const w = makeTestWriter();
@@ -142,13 +142,13 @@ describe("preview shell — submit + streaming", () => {
     await flush();
     stdin.push("X");
     await flush();
-    await new Promise((r) => setTimeout(r, 1700));
+    await new Promise((r) => setTimeout(r, 2500));
     await flush();
     const after = w.output();
     expect(after).toContain("you said: first");
     expect(after).not.toContain("you said: firstX");
     handle.destroy();
-  }, 5000);
+  }, 8000);
 
   it("empty submit is a no-op (no streaming starts)", async () => {
     const w = makeTestWriter();


### PR DESCRIPTION
Phase 5d-15 of the cell-diff renderer (#160).

Closes the loop on the streaming-card use case. Phase 5d-14 added a fixed-time spinner; this PR makes the response text **grow in place** during the stream — the workload that breaks Ink and that this whole renderer was built to handle.

## Behavior

- Submit a non-slash message → enter streaming.
- Spinner ticks 80ms/frame in the live area.
- Response text reveals 3 chars per 33ms tick, growing in place.
- When fully revealed, 200ms pause, then user line + complete echo land in Static and prompt re-enables.

## Why this proves the renderer

Each reveal step is ~3 cell-writes on a single row of the live area. The diff layer:
- doesn't repaint the spinner glyph (frozen across reveals)
- doesn't repaint the user line above it
- doesn't repaint the hint bar below it
- doesn't repaint any of the static history

Only the 3 new chars on the current reveal column get patches. If Ink were rendering this, every reveal would re-emit the entire live region (header + history + streaming row + hint).

## Real LLM integration

When the actual DeepSeek API gets wired in (next phase), the state machine slots in cleanly: replace the `setInterval` that advances `revealed` with a token-arrival callback. `revealed` becomes `partialResponse.length`; `fullResponse` becomes the running buffer. No structural change to the render tree.

## Wrap behavior

Response is now ~80 chars on a 60-col viewport — wraps once during reveal, exercising the reveal-across-wrap case (adding chars at end of one row spills onto the next without re-emitting the wrapped chunk).

## Test plan

- [x] `npm run verify` clean — 2120 passing tests
- [ ] `node dist/cli/index.js preview` in PowerShell: type `hello`, watch text grow smoothly with the spinner ticking; no flicker on the user line / hint bar / surrounding chrome