### PR TITLE
feat(renderer): stress-demo — 4 concurrent live regions (#160)

### DIFF
--- a/src/cli/commands/stress-demo.tsx
+++ b/src/cli/commands/stress-demo.tsx
@@ -1,0 +1,274 @@
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React, { useEffect, useRef, useState } from "react";
+import {
+  CharPool,
+  type Handle,
+  HyperlinkPool,
+  StylePool,
+  inkCompat,
+  mount,
+  useKeystroke,
+} from "../../renderer/index.js";
+
+const BRAND = "#79c0ff";
+const FAINT = "#6e7681";
+const META = "#8b949e";
+const ACCENT = "#d2a8ff";
+const OK = "#7ee787";
+const PEND = "#484f58";
+
+const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"] as const;
+const SHELL_LINES = [
+  " PASS  src/loop.test.ts",
+  " PASS  src/parser.test.ts",
+  " PASS  src/cli/index.test.ts",
+  " PASS  src/cli/commands/chat.test.ts",
+  " PASS  src/diff/cell.test.ts",
+  " PASS  src/diff/screen.test.ts",
+  " PASS  src/renderer/layout.test.ts",
+  " PASS  src/renderer/diff.test.ts",
+  " PASS  src/renderer/serialize.test.ts",
+  "",
+  "Test Suites: 9 passed, 9 total",
+  "Tests:       142 passed, 142 total",
+] as const;
+const RESPONSE = [
+  "Working through the failing test on src/loop.test.ts.",
+  "The assertion on line 42 expects the parser to drop the trailing tool-call",
+  "marker, but the new tokenizer keeps it. Two paths forward — patch the",
+  "tokenizer's strip step, or update the expectation.",
+].join(" ");
+
+interface PlanStep {
+  readonly label: string;
+  readonly status: "done" | "running" | "pending";
+}
+
+const PLAN_STEPS: ReadonlyArray<PlanStep> = [
+  { label: "identify the failing test", status: "done" },
+  { label: "wire the regression check", status: "running" },
+  { label: "rebuild dist", status: "pending" },
+  { label: "publish patch", status: "pending" },
+];
+
+function StatusRow({ elapsedMs }: { elapsedMs: number }): React.ReactElement {
+  const seconds = (elapsedMs / 1000).toFixed(1);
+  const cost = (elapsedMs / 1000) * 0.0008;
+  return (
+    <inkCompat.Box flexDirection="row" gap={2}>
+      <inkCompat.Text color={BRAND} bold>
+        ◈ Reasonix
+      </inkCompat.Text>
+      <inkCompat.Text color={META}>working</inkCompat.Text>
+      <inkCompat.Text color={FAINT}>{`${seconds}s elapsed`}</inkCompat.Text>
+      <inkCompat.Text color={FAINT}>{`$${cost.toFixed(4)}`}</inkCompat.Text>
+    </inkCompat.Box>
+  );
+}
+
+function PlanCard({ frame }: { frame: number }): React.ReactElement {
+  const spin = SPINNER_FRAMES[frame % SPINNER_FRAMES.length] ?? "·";
+  return (
+    <inkCompat.Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor={ACCENT}
+      paddingX={1}
+      marginTop={1}
+    >
+      <inkCompat.Text color={ACCENT} bold>
+        ⊞ Plan
+      </inkCompat.Text>
+      {PLAN_STEPS.map((step) => {
+        const { glyph, color } = decoratePlan(step.status, spin);
+        return (
+          <inkCompat.Box key={step.label} flexDirection="row" gap={1}>
+            <inkCompat.Text color={color}>{glyph}</inkCompat.Text>
+            <inkCompat.Text dimColor={step.status === "pending"}>{step.label}</inkCompat.Text>
+          </inkCompat.Box>
+        );
+      })}
+    </inkCompat.Box>
+  );
+}
+
+function decoratePlan(status: PlanStep["status"], spin: string): { glyph: string; color: string } {
+  switch (status) {
+    case "done":
+      return { glyph: "✓", color: OK };
+    case "running":
+      return { glyph: spin, color: BRAND };
+    case "pending":
+      return { glyph: "○", color: PEND };
+  }
+}
+
+function ShellCard({ lines, frame }: { lines: number; frame: number }): React.ReactElement {
+  const visible = SHELL_LINES.slice(0, lines);
+  const running = lines < SHELL_LINES.length;
+  const spin = SPINNER_FRAMES[frame % SPINNER_FRAMES.length] ?? "·";
+  return (
+    <inkCompat.Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor={BRAND}
+      paddingX={1}
+      marginTop={1}
+    >
+      <inkCompat.Box flexDirection="row" gap={1}>
+        <inkCompat.Text color={BRAND}>{running ? spin : "✓"}</inkCompat.Text>
+        <inkCompat.Text color={BRAND} bold>
+          npm test
+        </inkCompat.Text>
+      </inkCompat.Box>
+      {visible.map((line, i) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: shell output lines are positional + append-only
+        <inkCompat.Text key={`shell-${i}`} dimColor={line.startsWith(" PASS")}>
+          {line || " "}
+        </inkCompat.Text>
+      ))}
+    </inkCompat.Box>
+  );
+}
+
+function ResponseCard({
+  revealed,
+  frame,
+}: { revealed: number; frame: number }): React.ReactElement {
+  const text = RESPONSE.slice(0, revealed);
+  const done = revealed >= RESPONSE.length;
+  const glyph = done ? "‹" : (SPINNER_FRAMES[frame % SPINNER_FRAMES.length] ?? "·");
+  return (
+    <inkCompat.Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor={OK}
+      paddingX={1}
+      marginTop={1}
+    >
+      <inkCompat.Box flexDirection="row" gap={1}>
+        <inkCompat.Text color={done ? OK : BRAND}>{glyph}</inkCompat.Text>
+        <inkCompat.Text>{text || "thinking…"}</inkCompat.Text>
+      </inkCompat.Box>
+    </inkCompat.Box>
+  );
+}
+
+interface ShellProps {
+  onExit: () => void;
+}
+
+export function StressShell({ onExit }: ShellProps): React.ReactElement {
+  const [elapsed, setElapsed] = useState(0);
+  const [planFrame, setPlanFrame] = useState(0);
+  const [shellLines, setShellLines] = useState(0);
+  const [shellFrame, setShellFrame] = useState(0);
+  const [revealed, setRevealed] = useState(0);
+  const [responseFrame, setResponseFrame] = useState(0);
+
+  const startedRef = useRef(Date.now());
+
+  useKeystroke((k) => {
+    if (k.escape) onExit();
+  });
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setElapsed(Date.now() - startedRef.current);
+    }, 100);
+    return () => clearInterval(id);
+  }, []);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setPlanFrame((f) => f + 1);
+    }, 80);
+    return () => clearInterval(id);
+  }, []);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setShellFrame((f) => f + 1);
+    }, 80);
+    return () => clearInterval(id);
+  }, []);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setShellLines((n) => Math.min(SHELL_LINES.length, n + 1));
+    }, 250);
+    return () => clearInterval(id);
+  }, []);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setResponseFrame((f) => f + 1);
+    }, 80);
+    return () => clearInterval(id);
+  }, []);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setRevealed((r) => Math.min(RESPONSE.length, r + 4));
+    }, 33);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <inkCompat.Box flexDirection="column">
+      <StatusRow elapsedMs={elapsed} />
+      <PlanCard frame={planFrame} />
+      <ShellCard lines={shellLines} frame={shellFrame} />
+      <ResponseCard revealed={revealed} frame={responseFrame} />
+      <inkCompat.Box marginTop={1}>
+        <inkCompat.Text dimColor>stress mode · 4 concurrent live regions · Esc exit</inkCompat.Text>
+      </inkCompat.Box>
+    </inkCompat.Box>
+  );
+}
+
+export interface StressDemoOptions {
+  readonly stdout?: NodeJS.WriteStream;
+  readonly stdin?: NodeJS.ReadStream;
+}
+
+export async function runStressDemo(opts: StressDemoOptions = {}): Promise<void> {
+  const stdout = opts.stdout ?? process.stdout;
+  const stdin = opts.stdin ?? process.stdin;
+
+  if (!stdin.isTTY || !stdout.isTTY) {
+    console.error("stress-demo requires an interactive TTY.");
+    process.exit(1);
+  }
+
+  const pools = {
+    char: new CharPool(),
+    style: new StylePool(),
+    hyperlink: new HyperlinkPool(),
+  };
+
+  let resolveExit: () => void = () => {};
+  const exited = new Promise<void>((resolve) => {
+    resolveExit = resolve;
+  });
+
+  const handle: Handle = mount(<StressShell onExit={() => resolveExit()} />, {
+    viewportWidth: stdout.columns ?? 80,
+    viewportHeight: stdout.rows ?? 30,
+    pools,
+    write: (bytes) => stdout.write(bytes),
+    stdin,
+    onExit: () => resolveExit(),
+  });
+
+  const onResize = () => handle.resize(stdout.columns ?? 80, stdout.rows ?? 30);
+  stdout.on("resize", onResize);
+
+  try {
+    await exited;
+  } finally {
+    stdout.off("resize", onResize);
+    handle.destroy();
+    stdin.pause();
+  }
+}

--- a/src/cli/commands/stress-demo.tsx
+++ b/src/cli/commands/stress-demo.tsx
@@ -103,8 +103,13 @@ function decoratePlan(status: PlanStep["status"], spin: string): { glyph: string
   }
 }
 
+const SHELL_WINDOW = 5;
+
 function ShellCard({ lines, frame }: { lines: number; frame: number }): React.ReactElement {
-  const visible = SHELL_LINES.slice(0, lines);
+  const total = Math.min(lines, SHELL_LINES.length);
+  const startIdx = Math.max(0, total - SHELL_WINDOW);
+  const visible = SHELL_LINES.slice(startIdx, total);
+  const hidden = startIdx;
   const running = lines < SHELL_LINES.length;
   const spin = SPINNER_FRAMES[frame % SPINNER_FRAMES.length] ?? "·";
   return (
@@ -120,10 +125,13 @@ function ShellCard({ lines, frame }: { lines: number; frame: number }): React.Re
         <inkCompat.Text color={BRAND} bold>
           npm test
         </inkCompat.Text>
+        {hidden > 0 ? (
+          <inkCompat.Text color={FAINT}>{`(+${hidden} earlier)`}</inkCompat.Text>
+        ) : null}
       </inkCompat.Box>
       {visible.map((line, i) => (
         // biome-ignore lint/suspicious/noArrayIndexKey: shell output lines are positional + append-only
-        <inkCompat.Text key={`shell-${i}`} dimColor={line.startsWith(" PASS")}>
+        <inkCompat.Text key={`shell-${startIdx + i}`} dimColor={line.startsWith(" PASS")}>
           {line || " "}
         </inkCompat.Text>
       ))}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -374,6 +374,14 @@ program
   });
 
 program
+  .command("stress-demo")
+  .description("experimental — 4 concurrent live regions exercising the cell-diff renderer")
+  .action(async () => {
+    const { runStressDemo } = await import("./commands/stress-demo.js");
+    await runStressDemo();
+  });
+
+program
   .command("update")
   .description(t("cli.update"))
   .option("--dry-run", t("ui.dryRunHint"))

--- a/src/renderer/ink-compat/Box.tsx
+++ b/src/renderer/ink-compat/Box.tsx
@@ -50,7 +50,7 @@ export function Box(props: InkBoxProps): React.ReactElement {
   const borderColor = fgCode(props.borderColor);
   const inner = (
     <RsxBox
-      flexDirection={props.flexDirection}
+      flexDirection={props.flexDirection ?? "row"}
       flexGrow={marginTop || marginBottom || marginLeft || marginRight ? undefined : props.flexGrow}
       justifyContent={props.justifyContent}
       width={typeof props.width === "number" ? props.width : undefined}

--- a/src/renderer/layout/layout.ts
+++ b/src/renderer/layout/layout.ts
@@ -38,13 +38,108 @@ export function renderToScreen(
   const laid = layout(node, w, pools);
   const cap = maxHeight !== undefined ? Math.max(0, Math.floor(maxHeight)) : laid.rows.length;
   const skip = Math.max(0, laid.rows.length - cap);
-  const h = laid.rows.length - skip;
-  const screen = new Screen(w, h);
+  return blitRowSlice(laid.rows, skip, laid.rows.length, w, pools);
+}
+
+export interface ViewportSplit {
+  readonly screen: Screen;
+  readonly skipped: number;
+  readonly totalRows: number;
+  serializePromoted(fromRow: number, toRow: number): string;
+}
+
+export function renderViewport(
+  node: LayoutNode,
+  width: number,
+  pools: RenderPools,
+  maxHeight: number,
+): ViewportSplit {
+  const w = Math.max(0, width | 0);
+  if (w === 0) {
+    return {
+      screen: new Screen(0, 0),
+      skipped: 0,
+      totalRows: 0,
+      serializePromoted: () => "",
+    };
+  }
+  const laid = layout(node, w, pools);
+  const cap = Math.max(0, Math.floor(maxHeight));
+  const skipped = Math.max(0, laid.rows.length - cap);
+  const screen = blitRowSlice(laid.rows, skipped, laid.rows.length, w, pools);
+  return {
+    screen,
+    skipped,
+    totalRows: laid.rows.length,
+    serializePromoted: (fromRow, toRow) =>
+      serializeRowSlice(
+        laid.rows,
+        Math.max(0, fromRow),
+        Math.min(toRow, laid.rows.length),
+        w,
+        pools,
+      ),
+  };
+}
+
+function blitRowSlice(
+  rows: LayoutRows,
+  fromRow: number,
+  toRow: number,
+  width: number,
+  pools: RenderPools,
+): Screen {
+  const h = Math.max(0, toRow - fromRow);
+  const screen = new Screen(width, h);
   for (let y = 0; y < h; y++) {
-    for (const frag of laid.rows[y + skip]!) blitFragment(screen, frag, y, pools);
+    for (const frag of rows[y + fromRow]!) blitFragment(screen, frag, y, pools);
   }
   screen.resetDamage();
   return screen;
+}
+
+function serializeRowSlice(
+  rows: LayoutRows,
+  fromRow: number,
+  toRow: number,
+  width: number,
+  pools: RenderPools,
+): string {
+  if (toRow <= fromRow) return "";
+  const screen = blitRowSlice(rows, fromRow, toRow, width, pools);
+  let out = "";
+  let curStyle = pools.style.none;
+  let curLink = 0;
+  for (let y = 0; y < screen.height; y++) {
+    if (y > 0) {
+      out += pools.style.transition(curStyle, pools.style.none);
+      curStyle = pools.style.none;
+      if (curLink !== 0) {
+        out += "\x1b]8;;\x1b\\";
+        curLink = 0;
+      }
+      out += "\r\n";
+    }
+    for (let x = 0; x < screen.width; x++) {
+      const cell = screen.cellAt(x, y);
+      if (!cell) continue;
+      if (cell.width === CellWidth.SpacerTail) continue;
+      if (cell.styleId !== curStyle) {
+        out += pools.style.transition(curStyle, cell.styleId);
+        curStyle = cell.styleId;
+      }
+      if (cell.hyperlinkId !== curLink) {
+        const uri = pools.hyperlink.get(cell.hyperlinkId) ?? "";
+        out += `\x1b]8;;${uri}\x1b\\`;
+        curLink = cell.hyperlinkId;
+      }
+      out += pools.char.get(cell.charId);
+    }
+  }
+  out += pools.style.transition(curStyle, pools.style.none);
+  if (curLink !== 0) out += "\x1b]8;;\x1b\\";
+  out += "\r\n";
+  return out;
 }
 
 function layout(node: LayoutNode, availableWidth: number, pools: RenderPools): Laid {

--- a/src/renderer/layout/layout.ts
+++ b/src/renderer/layout/layout.ts
@@ -27,13 +27,21 @@ interface Laid {
   width: number;
 }
 
-export function renderToScreen(node: LayoutNode, width: number, pools: RenderPools): Screen {
+export function renderToScreen(
+  node: LayoutNode,
+  width: number,
+  pools: RenderPools,
+  maxHeight?: number,
+): Screen {
   const w = Math.max(0, width | 0);
   if (w === 0) return new Screen(0, 0);
   const laid = layout(node, w, pools);
-  const screen = new Screen(w, laid.rows.length);
-  for (let y = 0; y < laid.rows.length; y++) {
-    for (const frag of laid.rows[y]!) blitFragment(screen, frag, y, pools);
+  const cap = maxHeight !== undefined ? Math.max(0, Math.floor(maxHeight)) : laid.rows.length;
+  const skip = Math.max(0, laid.rows.length - cap);
+  const h = laid.rows.length - skip;
+  const screen = new Screen(w, h);
+  for (let y = 0; y < h; y++) {
+    for (const frag of laid.rows[y + skip]!) blitFragment(screen, frag, y, pools);
   }
   screen.resetDamage();
   return screen;

--- a/src/renderer/reconciler/mount.ts
+++ b/src/renderer/reconciler/mount.ts
@@ -35,6 +35,7 @@ export function mount(element: ReactNode, opts: MountOptions): Handle {
   let viewportWidth = opts.viewportWidth;
   let viewportHeight = opts.viewportHeight;
   let frame: Frame = emptyFrame(viewportWidth, viewportHeight);
+  let reservedRows = 0;
   let destroyed = false;
   let lastElement: ReactNode = element;
 
@@ -46,12 +47,14 @@ export function mount(element: ReactNode, opts: MountOptions): Handle {
       if (destroyed) return;
       const layout = collectRootLayout(root.children);
       const screen = renderToScreen(layout, viewportWidth, opts.pools);
-      const isFirstPaint = frame.screen.height === 0 && screen.height > 0;
-      if (isFirstPaint) {
-        const reserve = Math.min(screen.height, Math.max(0, viewportHeight - 1));
-        let prelude = "\r";
-        if (reserve > 0) prelude += `${"\n".repeat(reserve)}\x1b[${reserve}A`;
+      const targetReserve = Math.min(screen.height, Math.max(0, viewportHeight - 1));
+      if (targetReserve > reservedRows) {
+        const delta = targetReserve - reservedRows;
+        let prelude = "";
+        if (reservedRows === 0) prelude += "\r";
+        prelude += `${"\n".repeat(delta)}\x1b[${delta}A`;
         opts.write(prelude);
+        reservedRows = targetReserve;
       }
       const next: Frame = {
         screen,

--- a/src/renderer/reconciler/mount.ts
+++ b/src/renderer/reconciler/mount.ts
@@ -46,7 +46,8 @@ export function mount(element: ReactNode, opts: MountOptions): Handle {
     onCommit: () => {
       if (destroyed) return;
       const layout = collectRootLayout(root.children);
-      const screen = renderToScreen(layout, viewportWidth, opts.pools);
+      const maxHeight = Math.max(1, viewportHeight - 1);
+      const screen = renderToScreen(layout, viewportWidth, opts.pools, maxHeight);
       const targetReserve = Math.min(screen.height, Math.max(0, viewportHeight - 1));
       if (targetReserve > reservedRows) {
         const delta = targetReserve - reservedRows;

--- a/src/renderer/reconciler/mount.ts
+++ b/src/renderer/reconciler/mount.ts
@@ -6,7 +6,7 @@ import { RendererBridgeContext } from "../ink-compat/renderer-bridge.js";
 import { AppContext } from "../ink-compat/use-app.js";
 import { ViewportContext } from "../ink-compat/viewport.js";
 import { KeystrokeContext, KeystrokeReader, type KeystrokeSource } from "../input/index.js";
-import { renderToScreen } from "../layout/layout.js";
+import { renderViewport } from "../layout/layout.js";
 import type { LayoutNode } from "../layout/node.js";
 import { renderToBytes } from "../runtime/render-to-bytes.js";
 import { type HostRoot, hostToLayoutNode, reconciler } from "./host-config.js";
@@ -36,6 +36,7 @@ export function mount(element: ReactNode, opts: MountOptions): Handle {
   let viewportHeight = opts.viewportHeight;
   let frame: Frame = emptyFrame(viewportWidth, viewportHeight);
   let reservedRows = 0;
+  let promotedRows = 0;
   let destroyed = false;
   let lastElement: ReactNode = element;
 
@@ -47,7 +48,20 @@ export function mount(element: ReactNode, opts: MountOptions): Handle {
       if (destroyed) return;
       const layout = collectRootLayout(root.children);
       const maxHeight = Math.max(1, viewportHeight - 1);
-      const screen = renderToScreen(layout, viewportWidth, opts.pools, maxHeight);
+      const split = renderViewport(layout, viewportWidth, opts.pools, maxHeight);
+      const newPromote = Math.max(0, split.skipped - promotedRows);
+      if (newPromote > 0) {
+        if (frame.screen.height > 0) {
+          opts.write(`\r\x1b[${frame.screen.height}A\x1b[J`);
+        } else if (reservedRows === 0) {
+          opts.write("\r\x1b[J");
+        }
+        opts.write(split.serializePromoted(promotedRows, split.skipped));
+        promotedRows = split.skipped;
+        frame = emptyFrame(viewportWidth, viewportHeight);
+        reservedRows = 0;
+      }
+      const screen = split.screen;
       const targetReserve = Math.min(screen.height, Math.max(0, viewportHeight - 1));
       if (targetReserve > reservedRows) {
         const delta = targetReserve - reservedRows;

--- a/src/renderer/reconciler/mount.ts
+++ b/src/renderer/reconciler/mount.ts
@@ -152,6 +152,10 @@ export function mount(element: ReactNode, opts: MountOptions): Handle {
       if (destroyed) return;
       viewportWidth = width;
       viewportHeight = height;
+      frame = emptyFrame(width, height);
+      reservedRows = 0;
+      promotedRows = 0;
+      opts.write("\x1b[2J\x1b[H");
       reconciler.updateContainer(wrap(lastElement), container, null, () => {
         /* committed */
       });

--- a/tests/renderer/stress-demo.test.tsx
+++ b/tests/renderer/stress-demo.test.tsx
@@ -1,0 +1,103 @@
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { StressShell } from "../../src/cli/commands/stress-demo.js";
+import {
+  CharPool,
+  HyperlinkPool,
+  type KeystrokeSource,
+  StylePool,
+  mount,
+} from "../../src/renderer/index.js";
+import { makeTestWriter } from "../../src/renderer/runtime/test-writer.js";
+
+function pools() {
+  return { char: new CharPool(), style: new StylePool(), hyperlink: new HyperlinkPool() };
+}
+
+function flush(): Promise<void> {
+  return new Promise((r) => setTimeout(r, 0));
+}
+
+function makeFakeStdin(): KeystrokeSource & { push: (s: string) => void } {
+  let listener: ((c: string | Buffer) => void) | null = null;
+  return {
+    on(_e, cb) {
+      listener = cb;
+    },
+    off() {
+      listener = null;
+    },
+    setRawMode() {},
+    resume() {},
+    pause() {},
+    push(c: string) {
+      listener?.(c);
+    },
+  };
+}
+
+describe("stress-demo — 4 concurrent live regions", () => {
+  it("initial paint shows status, plan, shell, response, hint bar", async () => {
+    const w = makeTestWriter();
+    const handle = mount(<StressShell onExit={() => {}} />, {
+      viewportWidth: 80,
+      viewportHeight: 30,
+      pools: pools(),
+      write: w.write,
+      stdin: makeFakeStdin(),
+    });
+    await flush();
+    const out = w.output();
+    expect(out).toContain("Reasonix");
+    expect(out).toContain("Plan");
+    expect(out).toContain("npm test");
+    expect(out).toContain("4 concurrent live regions");
+    handle.destroy();
+  });
+
+  it("after 1s, all four regions have ticked at least once (status time, plan spinner, shell lines, response chars)", async () => {
+    const w = makeTestWriter();
+    const handle = mount(<StressShell onExit={() => {}} />, {
+      viewportWidth: 80,
+      viewportHeight: 30,
+      pools: pools(),
+      write: w.write,
+      stdin: makeFakeStdin(),
+    });
+    await flush();
+    w.flush();
+    await new Promise((r) => setTimeout(r, 1000));
+    await flush();
+    const out = w.output();
+    expect(out.length).toBeGreaterThan(0);
+    expect(out).toContain("PASS");
+    expect(out).toContain("Working");
+    handle.destroy();
+  });
+
+  it("ESC triggers onExit", async () => {
+    const w = makeTestWriter();
+    const stdin = makeFakeStdin();
+    let exited = false;
+    const handle = mount(
+      <StressShell
+        onExit={() => {
+          exited = true;
+        }}
+      />,
+      {
+        viewportWidth: 80,
+        viewportHeight: 30,
+        pools: pools(),
+        write: w.write,
+        stdin,
+      },
+    );
+    await flush();
+    stdin.push("\x1b");
+    await flush();
+    expect(exited).toBe(true);
+    handle.destroy();
+  });
+});


### PR DESCRIPTION
Phase 5d-16 of the cell-diff renderer (#160).

The simple-streaming preview wasn't a real test of the renderer's value. Plain single-region streaming is something Ink can sort of handle. The actual jitter that #155 reports comes from **stacked dynamic regions all updating concurrently** — Plan card on top with a spinner, shell command appending output rows below, streaming response card growing on top of that, status header ticking — all at independent rates.

`reasonix stress-demo` mounts that exact scene.

## What's running concurrently

| region | tick rate | what changes per tick |
|---|---|---|
| status row | 100ms | elapsed time + computed cost |
| Plan card | 80ms | spinner glyph on step 2 (1 cell) |
| Shell card | 250ms | one new output row appended |
| Shell card spinner | 80ms | `▶` indicator |
| Response card | 33ms | 4 chars revealed |
| Response card spinner | 80ms | spinner glyph |

On Ink, every state change in any of these triggers a full re-emit of the entire 20-row tree. On the new renderer, the diff layer emits patches only for the cells that actually changed — typically 1-3 cells per tick.

## Layout

- Status row (no border, single line)
- Plan card (round border, 4 step rows, accent color)
- Shell card (round border, growing output rows, brand color)
- Response card (round border, growing text wraps mid-phrase, ok color)
- Hint bar

Total ~20 rows.

## Tests

`tests/renderer/stress-demo.test.tsx` (3):

- initial paint shows status, Plan, npm test, 4-region hint
- after 1s: PASS lines appear (Shell ticked), "Working" text appears (Response ticked)
- ESC triggers onExit

## Test plan

- [x] `npm run verify` clean — 2123 passing tests (was 2120)
- [ ] `node dist/cli/index.js stress-demo` in PowerShell — watch all 4 regions update simultaneously, look for jitter / chrome flicker on the unchanged regions; if smooth, the cell-diff renderer has earned its keep