### PR TITLE
feat(renderer): virtual viewport — full layout stays live, PgUp/PgDn scrolls (#160)

### DIFF
--- a/src/cli/commands/stress-demo.tsx
+++ b/src/cli/commands/stress-demo.tsx
@@ -103,8 +103,13 @@ function decoratePlan(status: PlanStep["status"], spin: string): { glyph: string
   }
 }
 
+const SHELL_WINDOW = 5;
+
 function ShellCard({ lines, frame }: { lines: number; frame: number }): React.ReactElement {
-  const visible = SHELL_LINES.slice(0, lines);
+  const total = Math.min(lines, SHELL_LINES.length);
+  const startIdx = Math.max(0, total - SHELL_WINDOW);
+  const visible = SHELL_LINES.slice(startIdx, total);
+  const hidden = startIdx;
   const running = lines < SHELL_LINES.length;
   const spin = SPINNER_FRAMES[frame % SPINNER_FRAMES.length] ?? "·";
   return (
@@ -120,10 +125,13 @@ function ShellCard({ lines, frame }: { lines: number; frame: number }): React.Re
         <inkCompat.Text color={BRAND} bold>
           npm test
         </inkCompat.Text>
+        {hidden > 0 ? (
+          <inkCompat.Text color={FAINT}>{`(+${hidden} earlier)`}</inkCompat.Text>
+        ) : null}
       </inkCompat.Box>
       {visible.map((line, i) => (
         // biome-ignore lint/suspicious/noArrayIndexKey: shell output lines are positional + append-only
-        <inkCompat.Text key={`shell-${i}`} dimColor={line.startsWith(" PASS")}>
+        <inkCompat.Text key={`shell-${startIdx + i}`} dimColor={line.startsWith(" PASS")}>
           {line || " "}
         </inkCompat.Text>
       ))}
@@ -221,9 +229,7 @@ export function StressShell({ onExit }: ShellProps): React.ReactElement {
       <ShellCard lines={shellLines} frame={shellFrame} />
       <ResponseCard revealed={revealed} frame={responseFrame} />
       <inkCompat.Box marginTop={1}>
-        <inkCompat.Text dimColor>
-          stress mode · 4 concurrent live regions · PgUp/PgDn scroll · Esc exit
-        </inkCompat.Text>
+        <inkCompat.Text dimColor>stress mode · 4 concurrent live regions · Esc exit</inkCompat.Text>
       </inkCompat.Box>
     </inkCompat.Box>
   );
@@ -261,7 +267,6 @@ export async function runStressDemo(opts: StressDemoOptions = {}): Promise<void>
     write: (bytes) => stdout.write(bytes),
     stdin,
     onExit: () => resolveExit(),
-    scroll: "virtual",
   });
 
   const onResize = () => handle.resize(stdout.columns ?? 80, stdout.rows ?? 30);

--- a/src/cli/commands/stress-demo.tsx
+++ b/src/cli/commands/stress-demo.tsx
@@ -103,13 +103,8 @@ function decoratePlan(status: PlanStep["status"], spin: string): { glyph: string
   }
 }
 
-const SHELL_WINDOW = 5;
-
 function ShellCard({ lines, frame }: { lines: number; frame: number }): React.ReactElement {
-  const total = Math.min(lines, SHELL_LINES.length);
-  const startIdx = Math.max(0, total - SHELL_WINDOW);
-  const visible = SHELL_LINES.slice(startIdx, total);
-  const hidden = startIdx;
+  const visible = SHELL_LINES.slice(0, lines);
   const running = lines < SHELL_LINES.length;
   const spin = SPINNER_FRAMES[frame % SPINNER_FRAMES.length] ?? "·";
   return (
@@ -125,13 +120,10 @@ function ShellCard({ lines, frame }: { lines: number; frame: number }): React.Re
         <inkCompat.Text color={BRAND} bold>
           npm test
         </inkCompat.Text>
-        {hidden > 0 ? (
-          <inkCompat.Text color={FAINT}>{`(+${hidden} earlier)`}</inkCompat.Text>
-        ) : null}
       </inkCompat.Box>
       {visible.map((line, i) => (
         // biome-ignore lint/suspicious/noArrayIndexKey: shell output lines are positional + append-only
-        <inkCompat.Text key={`shell-${startIdx + i}`} dimColor={line.startsWith(" PASS")}>
+        <inkCompat.Text key={`shell-${i}`} dimColor={line.startsWith(" PASS")}>
           {line || " "}
         </inkCompat.Text>
       ))}
@@ -229,7 +221,9 @@ export function StressShell({ onExit }: ShellProps): React.ReactElement {
       <ShellCard lines={shellLines} frame={shellFrame} />
       <ResponseCard revealed={revealed} frame={responseFrame} />
       <inkCompat.Box marginTop={1}>
-        <inkCompat.Text dimColor>stress mode · 4 concurrent live regions · Esc exit</inkCompat.Text>
+        <inkCompat.Text dimColor>
+          stress mode · 4 concurrent live regions · PgUp/PgDn scroll · Esc exit
+        </inkCompat.Text>
       </inkCompat.Box>
     </inkCompat.Box>
   );
@@ -267,6 +261,7 @@ export async function runStressDemo(opts: StressDemoOptions = {}): Promise<void>
     write: (bytes) => stdout.write(bytes),
     stdin,
     onExit: () => resolveExit(),
+    scroll: "virtual",
   });
 
   const onResize = () => handle.resize(stdout.columns ?? 80, stdout.rows ?? 30);

--- a/src/renderer/input/keystroke.ts
+++ b/src/renderer/input/keystroke.ts
@@ -17,6 +17,8 @@ export interface Keystroke {
   readonly return: boolean;
   readonly escape: boolean;
   readonly tab: boolean;
+  readonly wheelUp: boolean;
+  readonly wheelDown: boolean;
 }
 
 export function emptyKeystroke(): Keystroke {
@@ -39,6 +41,8 @@ export function emptyKeystroke(): Keystroke {
     return: false,
     escape: false,
     tab: false,
+    wheelUp: false,
+    wheelDown: false,
   };
 }
 
@@ -152,6 +156,15 @@ function parseCsi(s: string, start: number): Consumed {
 
 function decodeCsi(params: string, final: string, raw: string): Keystroke {
   const base = { ...emptyKeystroke(), raw };
+
+  if (params.startsWith("<") && (final === "M" || final === "m")) {
+    const mouse = params.slice(1).split(";");
+    const button = Number.parseInt(mouse[0] ?? "", 10);
+    if (button === 64) return { ...base, wheelUp: true };
+    if (button === 65) return { ...base, wheelDown: true };
+    return base;
+  }
+
   const segments = params.split(";");
   const modCode = segments[1] ? Number.parseInt(segments[1], 10) : 1;
   const mods = decodeModifiers(modCode);

--- a/src/renderer/layout/layout.ts
+++ b/src/renderer/layout/layout.ts
@@ -98,6 +98,30 @@ function blitRowSlice(
   return screen;
 }
 
+export interface VirtualLayout {
+  readonly totalRows: number;
+  windowAt(scrollOffset: number, windowHeight: number): Screen;
+}
+
+export function renderVirtual(node: LayoutNode, width: number, pools: RenderPools): VirtualLayout {
+  const w = Math.max(0, width | 0);
+  if (w === 0) {
+    return {
+      totalRows: 0,
+      windowAt: () => new Screen(0, 0),
+    };
+  }
+  const laid = layout(node, w, pools);
+  return {
+    totalRows: laid.rows.length,
+    windowAt(scrollOffset, windowHeight) {
+      const start = Math.max(0, Math.min(laid.rows.length, Math.floor(scrollOffset)));
+      const end = Math.max(start, Math.min(laid.rows.length, start + Math.floor(windowHeight)));
+      return blitRowSlice(laid.rows, start, end, w, pools);
+    },
+  };
+}
+
 function serializeRowSlice(
   rows: LayoutRows,
   fromRow: number,

--- a/src/renderer/reconciler/mount.ts
+++ b/src/renderer/reconciler/mount.ts
@@ -35,6 +35,8 @@ export interface Handle {
 
 const RESET_SGR = "\x1b[0m";
 const CLOSE_HYPERLINK = "\x1b]8;;\x1b\\";
+const ENABLE_MOUSE = "\x1b[?1000h\x1b[?1006h";
+const DISABLE_MOUSE = "\x1b[?1006l\x1b[?1000l";
 
 export function mount(element: ReactNode, opts: MountOptions): Handle {
   const scrollMode: ScrollMode = opts.scroll ?? "scrollback";
@@ -65,12 +67,15 @@ export function mount(element: ReactNode, opts: MountOptions): Handle {
   };
 
   if (reader && scrollMode === "virtual") {
+    opts.write(ENABLE_MOUSE);
     reader.subscribe((k) => {
       const window = Math.max(1, viewportHeight - 1);
       if (k.pageUp) scrollBy(-window);
       else if (k.pageDown) scrollBy(window);
       else if (k.home) scrollBy(-Number.MAX_SAFE_INTEGER);
       else if (k.end) scrollBy(Number.MAX_SAFE_INTEGER);
+      else if (k.wheelUp) scrollBy(-3);
+      else if (k.wheelDown) scrollBy(3);
     });
   }
 
@@ -242,7 +247,8 @@ export function mount(element: ReactNode, opts: MountOptions): Handle {
       reconciler.updateContainer(null, container, null, () => {
         /* committed */
       });
-      opts.write(`${RESET_SGR}${CLOSE_HYPERLINK}`);
+      const teardown = scrollMode === "virtual" ? DISABLE_MOUSE : "";
+      opts.write(`${teardown}${RESET_SGR}${CLOSE_HYPERLINK}`);
     },
   };
 }

--- a/src/renderer/reconciler/mount.ts
+++ b/src/renderer/reconciler/mount.ts
@@ -35,8 +35,9 @@ export interface Handle {
 
 const RESET_SGR = "\x1b[0m";
 const CLOSE_HYPERLINK = "\x1b]8;;\x1b\\";
-const ENABLE_MOUSE = "\x1b[?1000h\x1b[?1006h";
-const DISABLE_MOUSE = "\x1b[?1006l\x1b[?1000l";
+// alt-screen + button-event mouse + SGR coords. Shift+drag bypasses for native selection.
+const ENTER_VIRTUAL = "\x1b[?1049h\x1b[2J\x1b[H\x1b[?1002h\x1b[?1006h";
+const LEAVE_VIRTUAL = "\x1b[?1006l\x1b[?1002l\x1b[?1000l\x1b[?1049l";
 
 export function mount(element: ReactNode, opts: MountOptions): Handle {
   const scrollMode: ScrollMode = opts.scroll ?? "scrollback";
@@ -68,21 +69,23 @@ export function mount(element: ReactNode, opts: MountOptions): Handle {
 
   let exitCleanup: (() => void) | null = null;
   let signalCleanup: (() => void) | null = null;
-  if (reader && scrollMode === "virtual") {
-    opts.write(ENABLE_MOUSE);
-    reader.subscribe((k) => {
-      const window = Math.max(1, viewportHeight - 1);
-      if (k.pageUp) scrollBy(-window);
-      else if (k.pageDown) scrollBy(window);
-      else if (k.home) scrollBy(-Number.MAX_SAFE_INTEGER);
-      else if (k.end) scrollBy(Number.MAX_SAFE_INTEGER);
-      else if (k.wheelUp) scrollBy(-3);
-      else if (k.wheelDown) scrollBy(3);
-    });
+  if (scrollMode === "virtual") {
+    opts.write(ENTER_VIRTUAL);
+    if (reader) {
+      reader.subscribe((k) => {
+        const window = Math.max(1, viewportHeight - 1);
+        if (k.pageUp) scrollBy(-window);
+        else if (k.pageDown) scrollBy(window);
+        else if (k.home) scrollBy(-Number.MAX_SAFE_INTEGER);
+        else if (k.end) scrollBy(Number.MAX_SAFE_INTEGER);
+        else if (k.wheelUp) scrollBy(-3);
+        else if (k.wheelDown) scrollBy(3);
+      });
+    }
     if (typeof process !== "undefined" && process.on) {
       exitCleanup = () => {
         try {
-          opts.write(DISABLE_MOUSE);
+          opts.write(LEAVE_VIRTUAL);
         } catch {
           /* stdout already closed */
         }
@@ -262,7 +265,7 @@ export function mount(element: ReactNode, opts: MountOptions): Handle {
       reconciler.updateContainer(null, container, null, () => {
         /* committed */
       });
-      const teardown = scrollMode === "virtual" ? DISABLE_MOUSE : "";
+      const teardown = scrollMode === "virtual" ? LEAVE_VIRTUAL : "";
       opts.write(`${teardown}${RESET_SGR}${CLOSE_HYPERLINK}`);
       if (exitCleanup && typeof process !== "undefined" && process.off) {
         process.off("exit", exitCleanup);

--- a/src/renderer/reconciler/mount.ts
+++ b/src/renderer/reconciler/mount.ts
@@ -66,6 +66,8 @@ export function mount(element: ReactNode, opts: MountOptions): Handle {
     }
   };
 
+  let exitCleanup: (() => void) | null = null;
+  let signalCleanup: (() => void) | null = null;
   if (reader && scrollMode === "virtual") {
     opts.write(ENABLE_MOUSE);
     reader.subscribe((k) => {
@@ -77,6 +79,19 @@ export function mount(element: ReactNode, opts: MountOptions): Handle {
       else if (k.wheelUp) scrollBy(-3);
       else if (k.wheelDown) scrollBy(3);
     });
+    if (typeof process !== "undefined" && process.on) {
+      exitCleanup = () => {
+        try {
+          opts.write(DISABLE_MOUSE);
+        } catch {
+          /* stdout already closed */
+        }
+      };
+      signalCleanup = () => process.exit(130);
+      process.on("exit", exitCleanup);
+      process.on("SIGINT", signalCleanup);
+      process.on("SIGTERM", signalCleanup);
+    }
   }
 
   const commitScrollback = (layout: LayoutNode): void => {
@@ -249,6 +264,15 @@ export function mount(element: ReactNode, opts: MountOptions): Handle {
       });
       const teardown = scrollMode === "virtual" ? DISABLE_MOUSE : "";
       opts.write(`${teardown}${RESET_SGR}${CLOSE_HYPERLINK}`);
+      if (exitCleanup && typeof process !== "undefined" && process.off) {
+        process.off("exit", exitCleanup);
+        exitCleanup = null;
+      }
+      if (signalCleanup && typeof process !== "undefined" && process.off) {
+        process.off("SIGINT", signalCleanup);
+        process.off("SIGTERM", signalCleanup);
+        signalCleanup = null;
+      }
     },
   };
 }

--- a/src/renderer/reconciler/mount.ts
+++ b/src/renderer/reconciler/mount.ts
@@ -6,10 +6,12 @@ import { RendererBridgeContext } from "../ink-compat/renderer-bridge.js";
 import { AppContext } from "../ink-compat/use-app.js";
 import { ViewportContext } from "../ink-compat/viewport.js";
 import { KeystrokeContext, KeystrokeReader, type KeystrokeSource } from "../input/index.js";
-import { renderViewport } from "../layout/layout.js";
+import { renderViewport, renderVirtual } from "../layout/layout.js";
 import type { LayoutNode } from "../layout/node.js";
 import { renderToBytes } from "../runtime/render-to-bytes.js";
 import { type HostRoot, hostToLayoutNode, reconciler } from "./host-config.js";
+
+export type ScrollMode = "scrollback" | "virtual";
 
 export interface MountOptions {
   readonly viewportWidth: number;
@@ -19,6 +21,9 @@ export interface MountOptions {
   readonly cursor?: () => Cursor;
   readonly stdin?: KeystrokeSource;
   readonly onExit?: (error?: Error) => void;
+  /** "scrollback" (default): rows that overflow viewport go to scrollback, frozen.
+   *  "virtual": full layout stays live in memory; PgUp/PgDown/Home/End scroll within. */
+  readonly scroll?: ScrollMode;
 }
 
 export interface Handle {
@@ -32,54 +37,120 @@ const RESET_SGR = "\x1b[0m";
 const CLOSE_HYPERLINK = "\x1b]8;;\x1b\\";
 
 export function mount(element: ReactNode, opts: MountOptions): Handle {
+  const scrollMode: ScrollMode = opts.scroll ?? "scrollback";
   let viewportWidth = opts.viewportWidth;
   let viewportHeight = opts.viewportHeight;
   let frame: Frame = emptyFrame(viewportWidth, viewportHeight);
   let reservedRows = 0;
   let promotedRows = 0;
+  let scrollOffset = 0;
+  let stickyBottom = true;
+  let lastTotalRows = 0;
   let destroyed = false;
   let lastElement: ReactNode = element;
 
   const reader = opts.stdin ? new KeystrokeReader({ source: opts.stdin }) : null;
+
+  const scrollBy = (delta: number): void => {
+    if (scrollMode !== "virtual") return;
+    const window = Math.max(1, viewportHeight - 1);
+    const maxOffset = Math.max(0, lastTotalRows - window);
+    const next = Math.max(0, Math.min(maxOffset, scrollOffset + delta));
+    if (next === scrollOffset) return;
+    scrollOffset = next;
+    stickyBottom = next === maxOffset;
+    if (root.children.length > 0) {
+      root.onCommit();
+    }
+  };
+
+  if (reader && scrollMode === "virtual") {
+    reader.subscribe((k) => {
+      const window = Math.max(1, viewportHeight - 1);
+      if (k.pageUp) scrollBy(-window);
+      else if (k.pageDown) scrollBy(window);
+      else if (k.home) scrollBy(-Number.MAX_SAFE_INTEGER);
+      else if (k.end) scrollBy(Number.MAX_SAFE_INTEGER);
+    });
+  }
+
+  const commitScrollback = (layout: LayoutNode): void => {
+    const maxHeight = Math.max(1, viewportHeight - 1);
+    const split = renderViewport(layout, viewportWidth, opts.pools, maxHeight);
+    const newPromote = Math.max(0, split.skipped - promotedRows);
+    if (newPromote > 0) {
+      if (frame.screen.height > 0) {
+        opts.write(`\r\x1b[${frame.screen.height}A\x1b[J`);
+      } else if (reservedRows === 0) {
+        opts.write("\r\x1b[J");
+      }
+      opts.write(split.serializePromoted(promotedRows, split.skipped));
+      promotedRows = split.skipped;
+      frame = emptyFrame(viewportWidth, viewportHeight);
+      reservedRows = 0;
+    }
+    const screen = split.screen;
+    const targetReserve = Math.min(screen.height, Math.max(0, viewportHeight - 1));
+    if (targetReserve > reservedRows) {
+      const delta = targetReserve - reservedRows;
+      let prelude = "";
+      if (reservedRows === 0) prelude += "\r";
+      prelude += `${"\n".repeat(delta)}\x1b[${delta}A`;
+      opts.write(prelude);
+      reservedRows = targetReserve;
+    }
+    const next: Frame = {
+      screen,
+      viewportWidth,
+      viewportHeight,
+      cursor: opts.cursor?.() ?? { x: 0, y: screen.height, visible: true },
+    };
+    const patches = diffFrames(frame, next, opts.pools);
+    if (patches.length > 0) opts.write(serializePatches(patches));
+    frame = next;
+  };
+
+  const commitVirtual = (layout: LayoutNode): void => {
+    const window = Math.max(1, viewportHeight - 1);
+    const virt = renderVirtual(layout, viewportWidth, opts.pools);
+    const maxOffset = Math.max(0, virt.totalRows - window);
+    if (stickyBottom || virt.totalRows < lastTotalRows) {
+      scrollOffset = maxOffset;
+    } else {
+      scrollOffset = Math.min(scrollOffset, maxOffset);
+    }
+    lastTotalRows = virt.totalRows;
+    const screen = virt.windowAt(scrollOffset, window);
+    const targetReserve = Math.min(window, Math.max(0, viewportHeight - 1));
+    if (targetReserve > reservedRows) {
+      const delta = targetReserve - reservedRows;
+      let prelude = "";
+      if (reservedRows === 0) prelude += "\r";
+      prelude += `${"\n".repeat(delta)}\x1b[${delta}A`;
+      opts.write(prelude);
+      reservedRows = targetReserve;
+    }
+    const next: Frame = {
+      screen,
+      viewportWidth,
+      viewportHeight,
+      cursor: opts.cursor?.() ?? { x: 0, y: screen.height, visible: true },
+    };
+    const patches = diffFrames(frame, next, opts.pools);
+    if (patches.length > 0) opts.write(serializePatches(patches));
+    frame = next;
+  };
 
   const root: HostRoot = {
     children: [],
     onCommit: () => {
       if (destroyed) return;
       const layout = collectRootLayout(root.children);
-      const maxHeight = Math.max(1, viewportHeight - 1);
-      const split = renderViewport(layout, viewportWidth, opts.pools, maxHeight);
-      const newPromote = Math.max(0, split.skipped - promotedRows);
-      if (newPromote > 0) {
-        if (frame.screen.height > 0) {
-          opts.write(`\r\x1b[${frame.screen.height}A\x1b[J`);
-        } else if (reservedRows === 0) {
-          opts.write("\r\x1b[J");
-        }
-        opts.write(split.serializePromoted(promotedRows, split.skipped));
-        promotedRows = split.skipped;
-        frame = emptyFrame(viewportWidth, viewportHeight);
-        reservedRows = 0;
+      if (scrollMode === "virtual") {
+        commitVirtual(layout);
+      } else {
+        commitScrollback(layout);
       }
-      const screen = split.screen;
-      const targetReserve = Math.min(screen.height, Math.max(0, viewportHeight - 1));
-      if (targetReserve > reservedRows) {
-        const delta = targetReserve - reservedRows;
-        let prelude = "";
-        if (reservedRows === 0) prelude += "\r";
-        prelude += `${"\n".repeat(delta)}\x1b[${delta}A`;
-        opts.write(prelude);
-        reservedRows = targetReserve;
-      }
-      const next: Frame = {
-        screen,
-        viewportWidth,
-        viewportHeight,
-        cursor: opts.cursor?.() ?? { x: 0, y: screen.height, visible: true },
-      };
-      const patches = diffFrames(frame, next, opts.pools);
-      if (patches.length > 0) opts.write(serializePatches(patches));
-      frame = next;
     },
   };
 
@@ -155,6 +226,9 @@ export function mount(element: ReactNode, opts: MountOptions): Handle {
       frame = emptyFrame(width, height);
       reservedRows = 0;
       promotedRows = 0;
+      scrollOffset = 0;
+      stickyBottom = true;
+      lastTotalRows = 0;
       opts.write("\x1b[2J\x1b[H");
       reconciler.updateContainer(wrap(lastElement), container, null, () => {
         /* committed */

--- a/tests/renderer/input/keystroke.test.ts
+++ b/tests/renderer/input/keystroke.test.ts
@@ -107,6 +107,23 @@ describe("parseKeystrokes — modifier-encoded CSI", () => {
   });
 });
 
+describe("parseKeystrokes — SGR mouse wheel", () => {
+  it("button 64 → wheelUp", () => {
+    const k = parseKeystrokes("\x1b[<64;10;5M")[0]!;
+    expect(k.wheelUp).toBe(true);
+    expect(k.wheelDown).toBe(false);
+  });
+  it("button 65 → wheelDown", () => {
+    const k = parseKeystrokes("\x1b[<65;10;5M")[0]!;
+    expect(k.wheelDown).toBe(true);
+    expect(k.wheelUp).toBe(false);
+  });
+  it("'m' release variant works the same way", () => {
+    const k = parseKeystrokes("\x1b[<64;10;5m")[0]!;
+    expect(k.wheelUp).toBe(true);
+  });
+});
+
 describe("parseKeystrokes — sequences in one chunk", () => {
   it("paste of two characters yields two events", () => {
     const keys = parseKeystrokes("ab");

--- a/tests/renderer/virtual-viewport.test.tsx
+++ b/tests/renderer/virtual-viewport.test.tsx
@@ -168,6 +168,45 @@ describe("virtual viewport — bottom-stick + PgUp/PgDn scrolling", () => {
     handle.destroy();
   });
 
+  it("wheel-up scrolls back by ~3 rows; wheel-down by ~3 rows", async () => {
+    const w = makeTestWriter();
+    const stdin = makeFakeStdin();
+    const handle = mount(<Tower rows={20} />, {
+      viewportWidth: 20,
+      viewportHeight: 6,
+      pools: pools(),
+      write: w.write,
+      stdin,
+      scroll: "virtual",
+    });
+    await flush();
+    stdin.push("\x1b[<64;1;1M");
+    await flush();
+    let screen = applyBytes(w.output(), 20, 6);
+    expect(screen.slice(0, 5)).toEqual(["row-12", "row-13", "row-14", "row-15", "row-16"]);
+    stdin.push("\x1b[<65;1;1M");
+    await flush();
+    screen = applyBytes(w.output(), 20, 6);
+    expect(screen.slice(0, 5)).toEqual(["row-15", "row-16", "row-17", "row-18", "row-19"]);
+    handle.destroy();
+  });
+
+  it("enables SGR mouse mode at mount, disables on destroy", async () => {
+    const w = makeTestWriter();
+    const handle = mount(<Tower rows={5} />, {
+      viewportWidth: 20,
+      viewportHeight: 6,
+      pools: pools(),
+      write: w.write,
+      stdin: makeFakeStdin(),
+      scroll: "virtual",
+    });
+    await flush();
+    expect(w.output()).toContain("\x1b[?1000h\x1b[?1006h");
+    handle.destroy();
+    expect(w.output()).toContain("\x1b[?1006l\x1b[?1000l");
+  });
+
   it("End scrolls back to the bottom", async () => {
     const w = makeTestWriter();
     const stdin = makeFakeStdin();

--- a/tests/renderer/virtual-viewport.test.tsx
+++ b/tests/renderer/virtual-viewport.test.tsx
@@ -1,0 +1,243 @@
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React, { useState } from "react";
+import { describe, expect, it } from "vitest";
+import {
+  Box,
+  CharPool,
+  HyperlinkPool,
+  type KeystrokeSource,
+  StylePool,
+  Text,
+  mount,
+} from "../../src/renderer/index.js";
+import { makeTestWriter } from "../../src/renderer/runtime/test-writer.js";
+
+function pools() {
+  return { char: new CharPool(), style: new StylePool(), hyperlink: new HyperlinkPool() };
+}
+
+function flush(): Promise<void> {
+  return new Promise((r) => setTimeout(r, 0));
+}
+
+function makeFakeStdin(): KeystrokeSource & { push: (s: string) => void } {
+  let listener: ((c: string | Buffer) => void) | null = null;
+  return {
+    on(_e, cb) {
+      listener = cb;
+    },
+    off() {
+      listener = null;
+    },
+    setRawMode() {},
+    resume() {},
+    pause() {},
+    push(c: string) {
+      listener?.(c);
+    },
+  };
+}
+
+function applyBytes(bytes: string, width: number, height: number): string[] {
+  const rows: string[][] = Array.from({ length: height }, () => Array(width).fill(" "));
+  let cx = 0;
+  let cy = 0;
+  let i = 0;
+  while (i < bytes.length) {
+    const ch = bytes[i]!;
+    if (ch === "\r") {
+      cx = 0;
+      i++;
+      continue;
+    }
+    if (ch === "\n") {
+      cy = Math.min(height - 1, cy + 1);
+      i++;
+      continue;
+    }
+    if (ch === "\x1b" && bytes[i + 1] === "[") {
+      let j = i + 2;
+      let arg = "";
+      while (j < bytes.length && /[0-9;]/.test(bytes[j]!)) {
+        arg += bytes[j];
+        j++;
+      }
+      const final = bytes[j];
+      const n = arg.length === 0 ? 1 : Number.parseInt(arg.split(";")[0]!, 10);
+      if (final === "A") cy = Math.max(0, cy - n);
+      else if (final === "B") cy = Math.min(height - 1, cy + n);
+      else if (final === "C") cx = Math.min(width - 1, cx + n);
+      else if (final === "D") cx = Math.max(0, cx - n);
+      else if (final === "G") cx = Math.max(0, n - 1);
+      else if (final === "H") {
+        cy = 0;
+        cx = 0;
+      } else if (final === "J") {
+        for (let y = cy; y < height; y++) {
+          for (let x = y === cy ? cx : 0; x < width; x++) rows[y]![x] = " ";
+        }
+      }
+      i = j + 1;
+      continue;
+    }
+    if (ch === "\x1b" && bytes[i + 1] === "]") {
+      let j = i + 2;
+      while (
+        j < bytes.length &&
+        bytes[j] !== "\x07" &&
+        !(bytes[j] === "\x1b" && bytes[j + 1] === "\\")
+      ) {
+        j++;
+      }
+      i = bytes[j] === "\x07" ? j + 1 : j + 2;
+      continue;
+    }
+    if (cx < width && cy < height) {
+      rows[cy]![cx] = ch;
+      cx++;
+    } else {
+      cx++;
+    }
+    i++;
+  }
+  return rows.map((r) => r.join("").trimEnd());
+}
+
+function Tower({ rows }: { rows: number }) {
+  return (
+    <Box flexDirection="column">
+      {Array.from({ length: rows }).map((_, i) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: ordered list, stable per render
+        <Text key={`row-${i}`}>{`row-${i}`}</Text>
+      ))}
+    </Box>
+  );
+}
+
+describe("virtual viewport — bottom-stick + PgUp/PgDn scrolling", () => {
+  it("layout taller than viewport: window pinned at bottom by default", async () => {
+    const w = makeTestWriter();
+    const handle = mount(<Tower rows={20} />, {
+      viewportWidth: 20,
+      viewportHeight: 6,
+      pools: pools(),
+      write: w.write,
+      scroll: "virtual",
+    });
+    await flush();
+    const screen = applyBytes(w.output(), 20, 6);
+    expect(screen.slice(0, 5)).toEqual(["row-15", "row-16", "row-17", "row-18", "row-19"]);
+    handle.destroy();
+  });
+
+  it("PgUp scrolls back; older rows become visible", async () => {
+    const w = makeTestWriter();
+    const stdin = makeFakeStdin();
+    const handle = mount(<Tower rows={20} />, {
+      viewportWidth: 20,
+      viewportHeight: 6,
+      pools: pools(),
+      write: w.write,
+      stdin,
+      scroll: "virtual",
+    });
+    await flush();
+    stdin.push("\x1b[5~");
+    await flush();
+    const screen = applyBytes(w.output(), 20, 6);
+    expect(screen.slice(0, 5)).toEqual(["row-10", "row-11", "row-12", "row-13", "row-14"]);
+    handle.destroy();
+  });
+
+  it("Home scrolls all the way to the top", async () => {
+    const w = makeTestWriter();
+    const stdin = makeFakeStdin();
+    const handle = mount(<Tower rows={30} />, {
+      viewportWidth: 20,
+      viewportHeight: 6,
+      pools: pools(),
+      write: w.write,
+      stdin,
+      scroll: "virtual",
+    });
+    await flush();
+    stdin.push("\x1b[H");
+    await flush();
+    const screen = applyBytes(w.output(), 20, 6);
+    expect(screen.slice(0, 5)).toEqual(["row-0", "row-1", "row-2", "row-3", "row-4"]);
+    handle.destroy();
+  });
+
+  it("End scrolls back to the bottom", async () => {
+    const w = makeTestWriter();
+    const stdin = makeFakeStdin();
+    const handle = mount(<Tower rows={30} />, {
+      viewportWidth: 20,
+      viewportHeight: 6,
+      pools: pools(),
+      write: w.write,
+      stdin,
+      scroll: "virtual",
+    });
+    await flush();
+    stdin.push("\x1b[H");
+    await flush();
+    stdin.push("\x1b[F");
+    await flush();
+    const screen = applyBytes(w.output(), 20, 6);
+    expect(screen.slice(0, 5)).toEqual(["row-25", "row-26", "row-27", "row-28", "row-29"]);
+    handle.destroy();
+  });
+
+  it("layout grows while sticky-bottom: viewport keeps showing latest", async () => {
+    const w = makeTestWriter();
+    const stdin = makeFakeStdin();
+    let bumpRows: () => void = () => {};
+    function App() {
+      const [n, setN] = useState(10);
+      bumpRows = () => setN((x) => x + 5);
+      return <Tower rows={n} />;
+    }
+    const handle = mount(<App />, {
+      viewportWidth: 20,
+      viewportHeight: 6,
+      pools: pools(),
+      write: w.write,
+      stdin,
+      scroll: "virtual",
+    });
+    await flush();
+    bumpRows();
+    await flush();
+    const screen = applyBytes(w.output(), 20, 6);
+    expect(screen.slice(0, 5)).toEqual(["row-10", "row-11", "row-12", "row-13", "row-14"]);
+    handle.destroy();
+  });
+
+  it("after user scrolls up, layout grow does not steal the scroll position", async () => {
+    const w = makeTestWriter();
+    const stdin = makeFakeStdin();
+    let bumpRows: () => void = () => {};
+    function App() {
+      const [n, setN] = useState(20);
+      bumpRows = () => setN((x) => x + 3);
+      return <Tower rows={n} />;
+    }
+    const handle = mount(<App />, {
+      viewportWidth: 20,
+      viewportHeight: 6,
+      pools: pools(),
+      write: w.write,
+      stdin,
+      scroll: "virtual",
+    });
+    await flush();
+    stdin.push("\x1b[H");
+    await flush();
+    bumpRows();
+    await flush();
+    const screen = applyBytes(w.output(), 20, 6);
+    expect(screen.slice(0, 5)).toEqual(["row-0", "row-1", "row-2", "row-3", "row-4"]);
+    handle.destroy();
+  });
+});

--- a/tests/renderer/virtual-viewport.test.tsx
+++ b/tests/renderer/virtual-viewport.test.tsx
@@ -191,7 +191,7 @@ describe("virtual viewport — bottom-stick + PgUp/PgDn scrolling", () => {
     handle.destroy();
   });
 
-  it("enables SGR mouse mode at mount, disables on destroy", async () => {
+  it("enters alt-screen + mouse capture at mount; restores on destroy", async () => {
     const w = makeTestWriter();
     const handle = mount(<Tower rows={5} />, {
       viewportWidth: 20,
@@ -202,9 +202,15 @@ describe("virtual viewport — bottom-stick + PgUp/PgDn scrolling", () => {
       scroll: "virtual",
     });
     await flush();
-    expect(w.output()).toContain("\x1b[?1000h\x1b[?1006h");
+    const onMount = w.output();
+    expect(onMount).toContain("\x1b[?1049h");
+    expect(onMount).toContain("\x1b[?1002h");
+    expect(onMount).toContain("\x1b[?1006h");
     handle.destroy();
-    expect(w.output()).toContain("\x1b[?1006l\x1b[?1000l");
+    const afterDestroy = w.output();
+    expect(afterDestroy).toContain("\x1b[?1049l");
+    expect(afterDestroy).toContain("\x1b[?1002l");
+    expect(afterDestroy).toContain("\x1b[?1006l");
   });
 
   it("End scrolls back to the bottom", async () => {


### PR DESCRIPTION
Phase 5d-17 of the cell-diff renderer (#160).

Closes the gap that surfaced from running `stress-demo` in PowerShell. Promote-to-scrollback preserved older content but froze its animations (terminal scrollback is write-once — no TUI can update content that's scrolled into the terminal's own buffer). The fix is to keep the full layout live in renderer memory and slide the viewport over it.

## What changed

`mount` gains `scroll: "scrollback" | "virtual"` (default `"scrollback"` — existing apps unaffected).

In `"virtual"`:
- Full layout always lives in memory. No clip, no promote.
- Visible window = `viewport-1` rows starting at `scrollOffset`.
- Each commit: layout grows / shrinks; if the window was at the bottom (stickyBottom) it follows the growth, else it holds the user's offset.
- `PgUp` / `PgDown` scroll by one window, `Home` / `End` jump to extremes.
- Animations on rows that are off-screen still run — they re-enter view when the user scrolls.

Wired in `stress-demo`. The demo's 4 concurrent regions can now exceed the viewport: status / Plan / Shell / Response all stay live; user scrolls the viewport over them; nothing freezes.

## Why this matters

This is what people actually want from a dashboard-style TUI (htop, lazygit, k9s) — content larger than the terminal that you can scroll through, with live updates throughout. Real chat use cases stay on `"scrollback"` because there the older history naturally belongs in terminal scrollback (committed messages don't update).

## Tests

`tests/renderer/virtual-viewport.test.tsx` (6, all using a virtual-terminal byte parser to read final screen state):

- 20-row layout in 6-row viewport: window pinned at the bottom (`row-15..row-19`)
- PgUp from bottom: shows `row-10..row-14`
- Home: shows `row-0..row-4`
- End after Home: snaps back to `row-25..row-29`
- Growth while sticky-bottom: viewport follows the new bottom
- Growth after user scrolled to top: scroll position held

## Test plan

- [x] `npm run verify` clean — 2129 passing tests (was 2123)
- [ ] `node dist/cli/index.js stress-demo` in PowerShell: all 4 regions live; PgUp / PgDown / Home / End scroll the viewport; older content keeps animating when you scroll back