### PR TITLE
fix(tui): wrap overflowing markdown tables

### DIFF
--- a/src/cli/ui/markdown.tsx
+++ b/src/cli/ui/markdown.tsx
@@ -1,29 +1,37 @@
 /** Markdown → Ink. Parsing via marked; visual mapping mirrors dashboard/app.css `.md` rules. Code blocks pass through cli-highlight for ANSI syntax coloring. */
 
 import { highlight, supportsLanguage } from "cli-highlight";
-import { Box, Text } from "ink";
+import { Box, Text, useStdout } from "ink";
 import { type Token, type Tokens, marked } from "marked";
 import React from "react";
 import stringWidth from "string-width";
+import { wrapToCells } from "../../frame/width.js";
 import { FG, SURFACE, TONE } from "./theme/tokens.js";
 
-/** Right-pad to `cells` visual columns — wide chars (CJK, emoji) count as 2. */
-function padToCells(text: string, cells: number): string {
-  const w = stringWidth(text);
-  if (w >= cells) return text;
-  return text + " ".repeat(cells - w);
+/** Left margin consumed by CardBox (marginLeft=2 + borderLeft=1) + body paddingLeft. */
+const BODY_LEFT_CELLS = 7;
+
+const MarkdownWidthCtx = React.createContext<number | undefined>(undefined);
+
+function useWidth(): number {
+  const ctx = React.useContext(MarkdownWidthCtx);
+  if (ctx !== undefined) return ctx;
+  return (useStdout()?.stdout?.columns ?? process.stdout.columns ?? 80) - BODY_LEFT_CELLS;
 }
 
 marked.setOptions({ gfm: true, breaks: false });
 
-export function Markdown({ text }: { text: string }): React.ReactElement {
+export function Markdown({ text, width }: { text: string; width?: number }): React.ReactElement {
   const tokens = React.useMemo(() => marked.lexer(text), [text]);
+  const ctxWidth = width !== undefined ? Math.max(1, width) : undefined;
   return (
-    <Box flexDirection="column" gap={1}>
-      {tokens.map((token, i) => (
-        <BlockToken key={`${i}-${token.type}`} token={token} />
-      ))}
-    </Box>
+    <MarkdownWidthCtx.Provider value={ctxWidth}>
+      <Box flexDirection="column" gap={1}>
+        {tokens.map((token, i) => (
+          <BlockToken key={`${i}-${token.type}`} token={token} />
+        ))}
+      </Box>
+    </MarkdownWidthCtx.Provider>
   );
 }
 
@@ -100,7 +108,7 @@ function ListItem({
   const marker = item.task ? (item.checked ? "✓" : "○") : ordered ? `${index}.` : "·";
   const markerColor = item.task ? (item.checked ? TONE.ok : FG.faint) : FG.meta;
   const dim = item.task && item.checked === true;
-  const indent = "  ".repeat(depth + 1);
+  const indent = " ".repeat(depth + 1);
   return (
     <Box>
       <Text color={markerColor}>{`${indent}${marker} `}</Text>
@@ -135,14 +143,14 @@ function CodeBlock({ token }: { token: Tokens.Code }): React.ReactElement {
     <Box flexDirection="column">
       {lang ? (
         <Box>
-          <Text color={FG.meta}>{`  ${lang}`}</Text>
+          <Text color={FG.meta}>{` ${lang}`}</Text>
         </Box>
       ) : null}
       <Box flexDirection="column">
         {lines.map((line, i) => (
           // biome-ignore lint/suspicious/noArrayIndexKey: code lines are positional and stable per render
           <Text key={`code-${i}`} backgroundColor={SURFACE.bgElev}>
-            {`  ${line}  `}
+            {` ${line} `}
           </Text>
         ))}
       </Box>
@@ -165,7 +173,7 @@ function Blockquote({ token }: { token: Tokens.Blockquote }): React.ReactElement
     <Box flexDirection="column">
       {(token.tokens ?? []).map((child, i) => (
         <Box key={`${i}-${child.type}`} flexDirection="row">
-          <Text color={TONE.brand}>{"  ▎  "}</Text>
+          <Text color={TONE.brand}>{" ▎ "}</Text>
           <Box flexDirection="column" flexGrow={1}>
             {child.type === "paragraph" ? (
               <Text italic color={FG.sub}>
@@ -181,54 +189,170 @@ function Blockquote({ token }: { token: Tokens.Blockquote }): React.ReactElement
   );
 }
 
-function HorizontalRule(): React.ReactElement {
-  return <Text color={FG.faint}>{"  ────────────────────────────────────"}</Text>;
+/** Right-pad to `cells` visual columns — wide chars (CJK, emoji) count as 2. */
+function padToCells(text: string, cells: number): string {
+  const w = stringWidth(text);
+  if (w >= cells) return text;
+  return text + " ".repeat(cells - w);
 }
 
-function Table({ token }: { token: Tokens.Table }): React.ReactElement {
-  const colCount = token.header.length;
-  const headerCells = token.header.map((c) => plainText(c.tokens));
-  const bodyCells = token.rows.map((row) => row.map((c) => plainText(c.tokens)));
-  const widths = new Array(colCount).fill(0);
+function HorizontalRule(): React.ReactElement {
+  const width = useWidth();
+  const rule = "─".repeat(Math.max(width, 1));
+  return <Text color={FG.faint}>{` ${rule}`}</Text>;
+}
+
+/** Pure function — no React deps. */
+export function tableLayout(
+  headerCells: string[],
+  bodyCells: string[][],
+  availableWidth: number,
+): ColumnarLayout | FallbackLayout {
+  const colCount = headerCells.length;
+  const GAP = " ";
+  const GAP_W = stringWidth(GAP);
+  const widths = new Array<number>(colCount).fill(0);
   for (let c = 0; c < colCount; c++) {
     widths[c] = Math.max(
       stringWidth(headerCells[c] ?? ""),
       ...bodyCells.map((r) => stringWidth(r[c] ?? "")),
     );
   }
-  const GAP = "  ";
-  const ruleRow = widths.map((w) => "─".repeat(w)).join(GAP);
+  const totalWidth = widths.reduce((s, w) => s + w, 0) + GAP_W * (colCount - 1);
+  if (totalWidth <= availableWidth) {
+    return { fallback: false, widths, colCount, gap: GAP };
+  }
+  // Fallback: key/value pairs, label column = widest header, value gets the rest.
+  const rawLabel = Math.max(...headerCells.map((h) => stringWidth(h))) + 2; // label + ": "
+  const labelPad = Math.min(rawLabel, availableWidth - 1);
+  const valueCells = availableWidth - labelPad;
+  return { fallback: true, labelPad, valueCells };
+}
+
+interface ColumnarLayout {
+  fallback: false;
+  widths: number[];
+  colCount: number;
+  gap: string;
+}
+interface FallbackLayout {
+  fallback: true;
+  labelPad: number;
+  valueCells: number;
+}
+
+function Table({ token }: { token: Tokens.Table }): React.ReactElement {
+  const width = useWidth();
+  const headerCells = token.header.map((c) => plainText(c.tokens));
+  const bodyCells = token.rows.map((row) => row.map((c) => plainText(c.tokens)));
+  const layout = tableLayout(headerCells, bodyCells, width);
+  if (!layout.fallback)
+    return (
+      <ColumnarTable
+        headerCells={headerCells}
+        bodyCells={bodyCells}
+        widths={layout.widths}
+        colCount={headerCells.length}
+        gap={layout.gap}
+      />
+    );
+  return (
+    <FallbackTable
+      headerCells={headerCells}
+      bodyCells={bodyCells}
+      labelPad={layout.labelPad}
+      valueCells={layout.valueCells}
+    />
+  );
+}
+
+function ColumnarTable({
+  headerCells,
+  bodyCells,
+  widths,
+  colCount,
+  gap,
+}: {
+  headerCells: string[];
+  bodyCells: string[][];
+  widths: number[];
+  colCount: number;
+  gap: string;
+}): React.ReactElement {
+  const ruleRow = widths.map((w) => "─".repeat(w)).join(gap);
   return (
     <Box flexDirection="column">
       <Box>
-        <Text>{"      "}</Text>
+        <Text> </Text>
         {headerCells.map((cell, i) => (
           // biome-ignore lint/suspicious/noArrayIndexKey: header cells positional
           <React.Fragment key={`h-${i}`}>
             <Text bold color={FG.sub}>
               {padToCells(cell, widths[i]!)}
             </Text>
-            {i < colCount - 1 ? <Text>{GAP}</Text> : null}
+            {i < colCount - 1 ? <Text>{gap}</Text> : null}
           </React.Fragment>
         ))}
       </Box>
       <Box>
-        <Text>{"      "}</Text>
+        <Text> </Text>
         <Text color={FG.faint}>{ruleRow}</Text>
       </Box>
       {bodyCells.map((row, ri) => (
         // biome-ignore lint/suspicious/noArrayIndexKey: body rows positional
         <Box key={`tr-${ri}`}>
-          <Text>{"      "}</Text>
+          <Text> </Text>
           {row.map((cell, i) => (
             // biome-ignore lint/suspicious/noArrayIndexKey: cells positional
             <React.Fragment key={`c-${ri}-${i}`}>
               <Text color={FG.body}>{padToCells(cell ?? "", widths[i]!)}</Text>
-              {i < colCount - 1 ? <Text>{GAP}</Text> : null}
+              {i < colCount - 1 ? <Text>{gap}</Text> : null}
             </React.Fragment>
           ))}
         </Box>
       ))}
+    </Box>
+  );
+}
+
+function FallbackTable({
+  headerCells,
+  bodyCells,
+  labelPad,
+  valueCells,
+}: {
+  headerCells: string[];
+  bodyCells: string[][];
+  labelPad: number;
+  valueCells: number;
+}): React.ReactElement {
+  return (
+    <Box flexDirection="column">
+      {headerCells.map((h, ci) => {
+        const label = `${padToCells(h, labelPad - 2)}: `;
+        const values = bodyCells.map((r) => r[ci] ?? "");
+        return (
+          // biome-ignore lint/suspicious/noArrayIndexKey: header cells positional
+          <Box key={`fk-${ci}`} flexDirection="column">
+            {values.map((v, ri) => {
+              const lines = wrapToCells(v, valueCells);
+              return lines.map((line, li) => (
+                // biome-ignore lint/suspicious/noArrayIndexKey: fallback table lines are positional
+                <Box key={`fv-${ri}-${li}`}>
+                  {li === 0 ? (
+                    <Text bold color={FG.sub}>
+                      {label}
+                    </Text>
+                  ) : (
+                    <Text>{padToCells("", labelPad)}</Text>
+                  )}
+                  <Text color={FG.body}>{line}</Text>
+                </Box>
+              ));
+            })}
+          </Box>
+        );
+      })}
     </Box>
   );
 }
@@ -347,7 +471,7 @@ function InlineToken({ token }: { token: Token }): React.ReactElement {
   }
 }
 
-function plainText(tokens: Token[] | undefined): string {
+export function plainText(tokens: Token[] | undefined): string {
   if (!tokens) return "";
   let out = "";
   for (const t of tokens) {

--- a/tests/markdown.test.ts
+++ b/tests/markdown.test.ts
@@ -1,6 +1,9 @@
+import { type Tokens, marked } from "marked";
 import React from "react";
+import stringWidth from "string-width";
 import { describe, expect, it } from "vitest";
-import { Markdown } from "../src/cli/ui/markdown.js";
+import { Markdown, plainText, tableLayout } from "../src/cli/ui/markdown.js";
+import { wrapToCells } from "../src/frame/width.js";
 
 /** Smoke tests — markdown parsing is delegated to `marked`; we only verify the component mounts and dispatches over the token kinds we care about. */
 
@@ -50,5 +53,161 @@ describe("Markdown component", () => {
     const text = "**unterminated bold and `unterminated code";
     const el = React.createElement(Markdown, { text });
     expect(el).toBeTruthy();
+  });
+
+  it("renders a wide GFM table with explicit body-width without throwing", () => {
+    const longCell = "a-very-long-cell-value-that-would-overflow-a-narrow-terminal-card";
+    const text = ["| header | value |", "| - | - |", `| key | ${longCell} |`].join("\n");
+    // body-width 40 — table overflows, triggers FallbackTable path
+    const el = React.createElement(Markdown, { text, width: 40 });
+    expect(el).toBeTruthy();
+  });
+
+  it("renders a narrow GFM table with explicit body-width (columnar path)", () => {
+    const text = ["| a | b |", "| - | - |", "| 1 | 2 |"].join("\n");
+    const el = React.createElement(Markdown, { text, width: 80 });
+    expect(el).toBeTruthy();
+  });
+
+  it("renders a multi-row wide table without throwing", () => {
+    const longCell = "x".repeat(120);
+    const text = [
+      "| name | description |",
+      "| - | - |",
+      `| item1 | ${longCell} |`,
+      "| item2 | shorter |",
+    ].join("\n");
+    const el = React.createElement(Markdown, { text, width: 60 });
+    expect(el).toBeTruthy();
+  });
+});
+
+// Table layout invariants: bounded width, no separator rows, content preservation.
+
+/** Parse a GFM table into header/body cells via the same pipeline as the component. */
+function parseTableCells(md: string): { headerCells: string[]; bodyCells: string[][] } {
+  const tokens = marked.lexer(md);
+  const table = tokens.find((t) => t.type === "table") as Tokens.Table | undefined;
+  if (!table) throw new Error("no table token found");
+  const headerCells = table.header.map((c) => plainText(c.tokens));
+  const bodyCells = table.rows.map((row) => row.map((c) => plainText(c.tokens)));
+  return { headerCells, bodyCells };
+}
+
+describe("tableLayout - fallback decision", () => {
+  it("chooses columnar layout when table fits the width", () => {
+    const { headerCells, bodyCells } = parseTableCells("| a | b |\n| - | - |\n| 1 | 2 |");
+    const result = tableLayout(headerCells, bodyCells, 80);
+    expect(result.fallback).toBe(false);
+    if (!result.fallback) {
+      expect(result.widths).toEqual([1, 1]);
+    }
+  });
+
+  it("chooses fallback layout when table overflows the width", () => {
+    const longVal = "a-very-long-cell-value-that-would-overflow-a-narrow-terminal-card";
+    const md = `| header | value |\n| - | - |\n| key | ${longVal} |`;
+    const { headerCells, bodyCells } = parseTableCells(md);
+    const result = tableLayout(headerCells, bodyCells, 30);
+    expect(result.fallback).toBe(true);
+    if (result.fallback) {
+      expect(result.labelPad).toBeGreaterThan(0);
+      expect(result.valueCells).toBeGreaterThan(0);
+      expect(result.labelPad + result.valueCells).toBeLessThanOrEqual(30);
+    }
+  });
+});
+
+describe("FallbackTable width invariants", () => {
+  it("every wrapped line fits within the valueCells budget", () => {
+    const longVal = "a-very-long-cell-value-that-would-overflow-a-narrow-terminal-card";
+    const md = `| header | value |\n| - | - |\n| key | ${longVal} |`;
+    const { headerCells, bodyCells } = parseTableCells(md);
+    const width = 30;
+    const layout = tableLayout(headerCells, bodyCells, width);
+    expect(layout.fallback).toBe(true);
+    if (!layout.fallback) return;
+
+    const { labelPad, valueCells } = layout;
+    for (const row of bodyCells) {
+      for (const cell of row) {
+        const lines = wrapToCells(cell, valueCells);
+        for (const line of lines) {
+          expect(
+            stringWidth(line),
+            `line exceeds valueCells=${valueCells}: "${line}"`,
+          ).toBeLessThanOrEqual(valueCells);
+        }
+      }
+    }
+    expect(labelPad + valueCells).toBeLessThanOrEqual(width);
+  });
+
+  it("fallback does not produce a separator row (box-dash line)", () => {
+    const longVal = "x".repeat(120);
+    const md = `| name | description |\n| - | - |\n| item1 | ${longVal} |`;
+    const { headerCells, bodyCells } = parseTableCells(md);
+    const layout = tableLayout(headerCells, bodyCells, 40);
+    expect(layout.fallback).toBe(true);
+    if (!layout.fallback) return;
+    const { valueCells } = layout;
+    for (const row of bodyCells) {
+      for (const cell of row) {
+        const lines = wrapToCells(cell, valueCells);
+        for (const line of lines) {
+          expect(line).not.toMatch(/^\u2500+$/);
+        }
+      }
+    }
+  });
+
+  it("content is preserved via wrapping, not truncated (no ellipsis)", () => {
+    const longVal = "abcdefghij";
+    const md = `| k | v |\n| - | - |\n| key | ${longVal} |`;
+    const { headerCells, bodyCells } = parseTableCells(md);
+    const layout = tableLayout(headerCells, bodyCells, 12);
+    expect(layout.fallback).toBe(true);
+    if (!layout.fallback) return;
+    const { valueCells } = layout;
+    const lines = wrapToCells(bodyCells[0]![1]!, valueCells);
+    const joined = lines.join("");
+    expect(joined).toBe(longVal);
+  });
+
+  it("wide table at narrow width: total visual width of every output row is at or below card width", () => {
+    const longVal = "this-is-a-moderately-long-value-that-should-wrap-onto-multiple-lines";
+    const md = `| label | data |\n| - | - |\n| key | ${longVal} |`;
+    const { headerCells, bodyCells } = parseTableCells(md);
+    const width = 36;
+    const layout = tableLayout(headerCells, bodyCells, width);
+    expect(layout.fallback).toBe(true);
+    if (!layout.fallback) return;
+
+    const { labelPad, valueCells } = layout;
+    for (const row of bodyCells) {
+      for (const cell of row) {
+        const lines = wrapToCells(cell, valueCells);
+        for (const line of lines) {
+          const rowWidth = labelPad + stringWidth(line);
+          expect(
+            rowWidth,
+            `row visual width ${rowWidth} exceeds card width ${width}`,
+          ).toBeLessThanOrEqual(width);
+        }
+      }
+    }
+  });
+
+  it("narrow width: labelPad + valueCells never exceeds available width", () => {
+    const md = "| name | value |\n| - | - |\n| k | v |";
+    const { headerCells, bodyCells } = parseTableCells(md);
+    for (let w = 5; w <= 20; w++) {
+      const layout = tableLayout(headerCells, bodyCells, w);
+      if (!layout.fallback) continue;
+      expect(
+        layout.labelPad + layout.valueCells,
+        `width=${w}: labelPad(${layout.labelPad}) + valueCells(${layout.valueCells}) > ${w}`,
+      ).toBeLessThanOrEqual(w);
+    }
   });
 });


### PR DESCRIPTION
## What

Makes TUI Markdown table rendering width-aware.

Tables still render in the existing columnar layout when they fit within the available body width. When a table would overflow, it falls back to wrapped key/value rows so content stays readable and bounded.

Closes #194.

## Why

Wide Markdown tables can exceed the TUI card/body width. When that happens, the terminal wraps the physical line outside Ink’s expected layout, which can break left-border alignment and produce oversized separator rows.

This keeps Markdown table support while preventing wide tables from breaking the terminal layout.

## How to verify

```sh
npm run verify
```

Added regression coverage for:

- columnar layout when a table fits
- fallback layout when a table overflows
- wrapped fallback values fitting within their value column
- content preservation via wrapping instead of truncation
- no separator row emitted in fallback mode
- total fallback row width staying within the available card/body width
- narrow-width fallback math preserving `labelPad + valueCells <= width`

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time
