### PR TITLE
feat(renderer): chat-v2 — stripped-down App tree on cell-diff renderer (#160)

### DIFF
--- a/src/cli/commands/chat-v2.tsx
+++ b/src/cli/commands/chat-v2.tsx
@@ -1,0 +1,321 @@
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React, { useEffect, useRef, useState } from "react";
+import {
+  CharPool,
+  type Handle,
+  HyperlinkPool,
+  StylePool,
+  inkCompat,
+  mount,
+  useKeystroke,
+} from "../../renderer/index.js";
+import type { Card } from "../ui/state/cards.js";
+import type { AgentEvent } from "../ui/state/events.js";
+import { AgentStoreProvider, useAgentState, useDispatch } from "../ui/state/provider.js";
+import type { SessionInfo } from "../ui/state/state.js";
+
+const BRAND = "#79c0ff";
+const FAINT = "#6e7681";
+const META = "#8b949e";
+const ACCENT = "#d2a8ff";
+const OK = "#7ee787";
+const ERR = "#ff8b81";
+
+const SPINNER = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"] as const;
+const SPINNER_TICK_MS = 80;
+
+export const DEMO_SESSION: SessionInfo = {
+  id: "chat-v2-demo",
+  branch: "main",
+  workspace: "(demo)",
+  model: "deepseek-chat",
+};
+
+export interface ScriptStep {
+  readonly delayMs: number;
+  readonly event: AgentEvent;
+}
+
+/** Canned turn lifecycle. user → reasoning → streaming → tool → turn.end. Plays once. */
+export function buildScript(): ReadonlyArray<ScriptStep> {
+  const reasonId = "r-1";
+  const replyId = "s-1";
+  const toolId = "t-1";
+  const reasonChunks = [
+    "The user wants the streaming pipeline preview. ",
+    "I'll dispatch a few staged events through the real reducer ",
+    "and let the cell-diff renderer paint the cards.",
+  ];
+  const replyChunks = [
+    "Mounting through the cell-diff renderer.\n",
+    "Each card is dispatched through the real reducer ",
+    "and rendered without Ink — only the changed cells get patched on stdout.",
+  ];
+  return [
+    { delayMs: 200, event: { type: "user.submit", text: "show me the chat-v2 mount" } },
+    { delayMs: 200, event: { type: "turn.start", turnId: "turn-1" } },
+    { delayMs: 100, event: { type: "reasoning.start", id: reasonId } },
+    { delayMs: 200, event: { type: "reasoning.chunk", id: reasonId, text: reasonChunks[0]! } },
+    { delayMs: 200, event: { type: "reasoning.chunk", id: reasonId, text: reasonChunks[1]! } },
+    { delayMs: 200, event: { type: "reasoning.chunk", id: reasonId, text: reasonChunks[2]! } },
+    {
+      delayMs: 100,
+      event: { type: "reasoning.end", id: reasonId, paragraphs: 1, tokens: 42 },
+    },
+    {
+      delayMs: 100,
+      event: { type: "tool.start", id: toolId, name: "shell", args: { cmd: "ls" } },
+    },
+    { delayMs: 250, event: { type: "tool.chunk", id: toolId, text: "src/\nrenderer/\n" } },
+    {
+      delayMs: 250,
+      event: {
+        type: "tool.end",
+        id: toolId,
+        output: "src/\nrenderer/\n",
+        exitCode: 0,
+        elapsedMs: 230,
+      },
+    },
+    { delayMs: 100, event: { type: "streaming.start", id: replyId } },
+    { delayMs: 200, event: { type: "streaming.chunk", id: replyId, text: replyChunks[0]! } },
+    { delayMs: 200, event: { type: "streaming.chunk", id: replyId, text: replyChunks[1]! } },
+    { delayMs: 200, event: { type: "streaming.chunk", id: replyId, text: replyChunks[2]! } },
+    { delayMs: 100, event: { type: "streaming.end", id: replyId } },
+    {
+      delayMs: 200,
+      event: {
+        type: "turn.end",
+        usage: { prompt: 120, reason: 42, output: 36, cacheHit: 0.5, cost: 0.00034 },
+        elapsedMs: 1800,
+      },
+    },
+  ];
+}
+
+function Header({ inProgress, frame }: { inProgress: boolean; frame: number }): React.ReactElement {
+  const glyph = inProgress ? (SPINNER[frame % SPINNER.length] ?? "·") : "◈";
+  return (
+    <inkCompat.Box flexDirection="row" gap={1}>
+      <inkCompat.Text color={inProgress ? BRAND : ACCENT} bold>
+        {glyph}
+      </inkCompat.Text>
+      <inkCompat.Text color={BRAND} bold>
+        Reasonix
+      </inkCompat.Text>
+      <inkCompat.Text color={FAINT}>chat-v2 · cell-diff renderer · Esc to exit</inkCompat.Text>
+    </inkCompat.Box>
+  );
+}
+
+function previewLine(text: string, max = 72): string {
+  const flat = text.replace(/\s+/g, " ").trim();
+  if (flat.length <= max) return flat;
+  return `${flat.slice(0, max - 1)}…`;
+}
+
+function summarize(card: Card): { glyph: string; tone: string; head: string; body: string } {
+  switch (card.kind) {
+    case "user":
+      return { glyph: "›", tone: ACCENT, head: "you", body: previewLine(card.text) };
+    case "reasoning":
+      return {
+        glyph: card.streaming ? "◇" : "◆",
+        tone: META,
+        head: card.streaming ? "reasoning…" : `reasoning · ${card.tokens}t`,
+        body: previewLine(card.text),
+      };
+    case "streaming":
+      return {
+        glyph: card.done ? "‹" : "▸",
+        tone: card.done ? OK : BRAND,
+        head: card.done ? "reply" : "streaming…",
+        body: previewLine(card.text),
+      };
+    case "tool": {
+      const status = card.aborted
+        ? "aborted"
+        : card.rejected
+          ? "rejected"
+          : card.done
+            ? card.exitCode === 0 || card.exitCode === undefined
+              ? "ok"
+              : `exit ${card.exitCode}`
+            : "running";
+      const tone = card.done && !card.aborted && !card.rejected ? OK : BRAND;
+      return {
+        glyph: card.done ? "▣" : "▢",
+        tone,
+        head: `${card.name} · ${status}`,
+        body: previewLine(card.output) || "(no output)",
+      };
+    }
+    case "live":
+      return {
+        glyph: "·",
+        tone: META,
+        head: card.variant,
+        body: previewLine(card.text),
+      };
+    default:
+      return {
+        glyph: "·",
+        tone: META,
+        head: card.kind,
+        body: "",
+      };
+  }
+}
+
+function CardRow({ card }: { card: Card }): React.ReactElement {
+  const { glyph, tone, head, body } = summarize(card);
+  return (
+    <inkCompat.Box flexDirection="column">
+      <inkCompat.Box flexDirection="row" gap={1}>
+        <inkCompat.Text color={tone} bold>
+          {glyph}
+        </inkCompat.Text>
+        <inkCompat.Text color={tone}>{head}</inkCompat.Text>
+      </inkCompat.Box>
+      {body.length > 0 ? (
+        <inkCompat.Box flexDirection="row" paddingLeft={2}>
+          <inkCompat.Text>{body}</inkCompat.Text>
+        </inkCompat.Box>
+      ) : null}
+    </inkCompat.Box>
+  );
+}
+
+function TurnTrailer(): React.ReactElement | null {
+  const status = useAgentState((s) => s.status);
+  if (status.cost === 0 && status.sessionCost === 0) return null;
+  return (
+    <inkCompat.Box flexDirection="row" gap={2} marginTop={1}>
+      <inkCompat.Text color={FAINT}>
+        {`turn $${status.cost.toFixed(5)} · session $${status.sessionCost.toFixed(5)} · cache ${(status.cacheHit * 100).toFixed(0)}%`}
+      </inkCompat.Text>
+    </inkCompat.Box>
+  );
+}
+
+interface ShellProps {
+  readonly script: ReadonlyArray<ScriptStep>;
+  readonly onExit: () => void;
+}
+
+export function ChatV2Shell({ script, onExit }: ShellProps): React.ReactElement {
+  const cards = useAgentState((s) => s.cards);
+  const inProgress = useAgentState((s) => s.turnInProgress);
+  const dispatch = useDispatch();
+  const [frame, setFrame] = useState(0);
+  const [done, setDone] = useState(false);
+  const playedRef = useRef(false);
+
+  useKeystroke((k) => {
+    if (k.escape || (k.ctrl && k.input === "c")) onExit();
+  });
+
+  useEffect(() => {
+    if (playedRef.current) return;
+    playedRef.current = true;
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let i = 0;
+    const step = () => {
+      if (cancelled || i >= script.length) {
+        if (!cancelled) setDone(true);
+        return;
+      }
+      const cur = script[i]!;
+      timer = setTimeout(() => {
+        if (cancelled) return;
+        dispatch(cur.event);
+        i++;
+        step();
+      }, cur.delayMs);
+    };
+    step();
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [script, dispatch]);
+
+  useEffect(() => {
+    if (!inProgress) return;
+    const id = setInterval(() => setFrame((f) => f + 1), SPINNER_TICK_MS);
+    return () => clearInterval(id);
+  }, [inProgress]);
+
+  return (
+    <inkCompat.Box flexDirection="column">
+      <Header inProgress={inProgress} frame={frame} />
+      <inkCompat.Box flexDirection="column" marginTop={1} gap={1}>
+        {cards.map((c) => (
+          <CardRow key={c.id} card={c} />
+        ))}
+      </inkCompat.Box>
+      <TurnTrailer />
+      {done ? (
+        <inkCompat.Box marginTop={1}>
+          <inkCompat.Text color={FAINT}>— end of demo · press Esc to exit —</inkCompat.Text>
+        </inkCompat.Box>
+      ) : null}
+    </inkCompat.Box>
+  );
+}
+
+export interface ChatV2Options {
+  readonly stdout?: NodeJS.WriteStream;
+  readonly stdin?: NodeJS.ReadStream;
+  /** Override the canned playback (used by tests). */
+  readonly script?: ReadonlyArray<ScriptStep>;
+}
+
+export async function runChatV2(opts: ChatV2Options = {}): Promise<void> {
+  const stdout = opts.stdout ?? process.stdout;
+  const stdin = opts.stdin ?? process.stdin;
+
+  if (!stdin.isTTY || !stdout.isTTY) {
+    process.stderr.write("chat-v2 requires an interactive TTY.\n");
+    process.exit(1);
+  }
+
+  const pools = {
+    char: new CharPool(),
+    style: new StylePool(),
+    hyperlink: new HyperlinkPool(),
+  };
+
+  let resolveExit: () => void = () => {};
+  const exited = new Promise<void>((resolve) => {
+    resolveExit = resolve;
+  });
+
+  const script = opts.script ?? buildScript();
+
+  const handle: Handle = mount(
+    <AgentStoreProvider session={DEMO_SESSION}>
+      <ChatV2Shell script={script} onExit={() => resolveExit()} />
+    </AgentStoreProvider>,
+    {
+      viewportWidth: stdout.columns ?? 80,
+      viewportHeight: stdout.rows ?? 24,
+      pools,
+      write: (bytes) => stdout.write(bytes),
+      stdin,
+      onExit: () => resolveExit(),
+    },
+  );
+
+  const onResize = () => handle.resize(stdout.columns ?? 80, stdout.rows ?? 24);
+  stdout.on("resize", onResize);
+
+  try {
+    await exited;
+  } finally {
+    stdout.off("resize", onResize);
+    handle.destroy();
+    stdin.pause();
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -390,6 +390,14 @@ program
   });
 
 program
+  .command("chat-v2")
+  .description("experimental — chat App tree mounted on the cell-diff renderer (Esc to exit)")
+  .action(async () => {
+    const { runChatV2 } = await import("./commands/chat-v2.js");
+    await runChatV2();
+  });
+
+program
   .command("update")
   .description(t("cli.update"))
   .option("--dry-run", t("ui.dryRunHint"))

--- a/tests/renderer/chat-v2.test.tsx
+++ b/tests/renderer/chat-v2.test.tsx
@@ -1,0 +1,138 @@
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { ChatV2Shell, DEMO_SESSION, type ScriptStep } from "../../src/cli/commands/chat-v2.js";
+import { AgentStoreProvider } from "../../src/cli/ui/state/provider.js";
+import {
+  CharPool,
+  HyperlinkPool,
+  type KeystrokeSource,
+  StylePool,
+  mount,
+} from "../../src/renderer/index.js";
+import { makeTestWriter } from "../../src/renderer/runtime/test-writer.js";
+
+function pools() {
+  return { char: new CharPool(), style: new StylePool(), hyperlink: new HyperlinkPool() };
+}
+
+function flush(): Promise<void> {
+  return new Promise((r) => setTimeout(r, 0));
+}
+
+function makeFakeStdin(): KeystrokeSource & { push: (s: string) => void } {
+  let listener: ((c: string | Buffer) => void) | null = null;
+  return {
+    on(_e, cb) {
+      listener = cb;
+    },
+    off() {
+      listener = null;
+    },
+    setRawMode() {},
+    resume() {},
+    pause() {},
+    push(c: string) {
+      listener?.(c);
+    },
+  };
+}
+
+const FAST_SCRIPT: ReadonlyArray<ScriptStep> = [
+  { delayMs: 0, event: { type: "user.submit", text: "hello chat-v2" } },
+  { delayMs: 0, event: { type: "turn.start", turnId: "t-1" } },
+  { delayMs: 0, event: { type: "reasoning.start", id: "r-1" } },
+  { delayMs: 0, event: { type: "reasoning.chunk", id: "r-1", text: "thinking-line" } },
+  { delayMs: 0, event: { type: "reasoning.end", id: "r-1", paragraphs: 1, tokens: 7 } },
+  { delayMs: 0, event: { type: "streaming.start", id: "s-1" } },
+  { delayMs: 0, event: { type: "streaming.chunk", id: "s-1", text: "answer-line" } },
+  { delayMs: 0, event: { type: "streaming.end", id: "s-1" } },
+  {
+    delayMs: 0,
+    event: {
+      type: "turn.end",
+      usage: { prompt: 100, reason: 7, output: 11, cacheHit: 0.4, cost: 0.0001 },
+    },
+  },
+];
+
+describe("chat-v2 shell — initial paint", () => {
+  it("renders the header before the script plays", async () => {
+    const w = makeTestWriter();
+    const handle = mount(
+      <AgentStoreProvider session={DEMO_SESSION}>
+        <ChatV2Shell script={[]} onExit={() => {}} />
+      </AgentStoreProvider>,
+      {
+        viewportWidth: 80,
+        viewportHeight: 12,
+        pools: pools(),
+        write: w.write,
+        stdin: makeFakeStdin(),
+      },
+    );
+    await flush();
+    const out = w.output();
+    expect(out).toContain("Reasonix");
+    expect(out).toContain("chat-v2");
+    expect(out).toContain("Esc");
+    handle.destroy();
+  });
+});
+
+describe("chat-v2 shell — playback through the real reducer", () => {
+  it("dispatched events flow through useAgentState into rendered card rows", async () => {
+    const w = makeTestWriter();
+    const handle = mount(
+      <AgentStoreProvider session={DEMO_SESSION}>
+        <ChatV2Shell script={FAST_SCRIPT} onExit={() => {}} />
+      </AgentStoreProvider>,
+      {
+        viewportWidth: 80,
+        viewportHeight: 24,
+        pools: pools(),
+        write: w.write,
+        stdin: makeFakeStdin(),
+      },
+    );
+    // FAST_SCRIPT has zero-delay setTimeout chains; flush enough microtask
+    // ticks that the whole sequence drains.
+    for (let i = 0; i < 30; i++) await flush();
+    const out = w.output();
+    expect(out).toContain("hello chat-v2");
+    expect(out).toContain("thinking-line");
+    expect(out).toContain("answer-line");
+    expect(out).toContain("end of demo");
+    handle.destroy();
+  });
+});
+
+describe("chat-v2 shell — exit", () => {
+  it("Esc invokes onExit", async () => {
+    const w = makeTestWriter();
+    const stdin = makeFakeStdin();
+    let exited = false;
+    const handle = mount(
+      <AgentStoreProvider session={DEMO_SESSION}>
+        <ChatV2Shell
+          script={[]}
+          onExit={() => {
+            exited = true;
+          }}
+        />
+      </AgentStoreProvider>,
+      {
+        viewportWidth: 60,
+        viewportHeight: 8,
+        pools: pools(),
+        write: w.write,
+        stdin,
+      },
+    );
+    await flush();
+    stdin.push("\x1b");
+    await flush();
+    expect(exited).toBe(true);
+    handle.destroy();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `reasonix chat-v2` — a new subcommand that mounts the chat App tree through the cell-diff renderer's `mount()` instead of Ink's `render()`.
- The shell wraps `AgentStoreProvider` from `src/cli/ui/state/` and feeds it a canned turn-lifecycle script (user submit → reasoning → tool → streaming → turn.end). Cards are read via `useAgentState` and rendered through the inkCompat shim.
- No PromptInput yet; Esc / Ctrl+C exits. This is the proof-of-mount step — events → reducer → state → React tree → cell-diff renderer all wired end-to-end with one command.

## Why
Issue #160 — Phase 5d-19 of the cell-diff renderer rollout. The next steps (markdown pipeline, real PromptInput, long-response overflow) all depend on the chat App's React tree mounting through `mount()` rather than Ink. This PR establishes that seam without touching the live `chat` command.

## Test plan
- [x] `npm run verify` — 2140 tests pass (3 new in `tests/renderer/chat-v2.test.tsx`)
- [x] Manual: `reasonix chat-v2` plays the canned turn through to `end of demo · press Esc to exit`
- [ ] Reviewer: spot-check that exit + resize don't leave the terminal in a wedged state