### PR TITLE
feat(renderer): markdown pipeline — marked → MdLine[] → inkCompat (#160)

### DIFF
--- a/src/cli/commands/chat-v2.tsx
+++ b/src/cli/commands/chat-v2.tsx
@@ -9,6 +9,7 @@ import {
   mount,
   useKeystroke,
 } from "../../renderer/index.js";
+import { MarkdownView } from "../ui/markdown-view.js";
 import type { Card } from "../ui/state/cards.js";
 import type { AgentEvent } from "../ui/state/events.js";
 import { AgentStoreProvider, useAgentState, useDispatch } from "../ui/state/provider.js";
@@ -19,7 +20,6 @@ const FAINT = "#6e7681";
 const META = "#8b949e";
 const ACCENT = "#d2a8ff";
 const OK = "#7ee787";
-const ERR = "#ff8b81";
 
 const SPINNER = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"] as const;
 const SPINNER_TICK_MS = 80;
@@ -47,9 +47,13 @@ export function buildScript(): ReadonlyArray<ScriptStep> {
     "and let the cell-diff renderer paint the cards.",
   ];
   const replyChunks = [
-    "Mounting through the cell-diff renderer.\n",
-    "Each card is dispatched through the real reducer ",
-    "and rendered without Ink — only the changed cells get patched on stdout.",
+    "## Mount path\n\n",
+    "Each card is dispatched through the real reducer and rendered ",
+    "**without Ink** — only the changed cells get patched on stdout.\n\n",
+    "Key bits:\n\n",
+    "- `mount()` from `src/renderer/index.ts:19`\n",
+    "- markdown via `markdownToLines()`\n",
+    "- spans wrapped in `inkCompat.Text`\n",
   ];
   return [
     { delayMs: 200, event: { type: "user.submit", text: "show me the chat-v2 mount" } },
@@ -114,23 +118,27 @@ function previewLine(text: string, max = 72): string {
   return `${flat.slice(0, max - 1)}…`;
 }
 
-function summarize(card: Card): { glyph: string; tone: string; head: string; body: string } {
+interface CardHeader {
+  readonly glyph: string;
+  readonly tone: string;
+  readonly head: string;
+}
+
+function headerFor(card: Card): CardHeader {
   switch (card.kind) {
     case "user":
-      return { glyph: "›", tone: ACCENT, head: "you", body: previewLine(card.text) };
+      return { glyph: "›", tone: ACCENT, head: "you" };
     case "reasoning":
       return {
         glyph: card.streaming ? "◇" : "◆",
         tone: META,
         head: card.streaming ? "reasoning…" : `reasoning · ${card.tokens}t`,
-        body: previewLine(card.text),
       };
     case "streaming":
       return {
         glyph: card.done ? "‹" : "▸",
         tone: card.done ? OK : BRAND,
         head: card.done ? "reply" : "streaming…",
-        body: previewLine(card.text),
       };
     case "tool": {
       const status = card.aborted
@@ -143,32 +151,36 @@ function summarize(card: Card): { glyph: string; tone: string; head: string; bod
               : `exit ${card.exitCode}`
             : "running";
       const tone = card.done && !card.aborted && !card.rejected ? OK : BRAND;
-      return {
-        glyph: card.done ? "▣" : "▢",
-        tone,
-        head: `${card.name} · ${status}`,
-        body: previewLine(card.output) || "(no output)",
-      };
+      return { glyph: card.done ? "▣" : "▢", tone, head: `${card.name} · ${status}` };
     }
     case "live":
-      return {
-        glyph: "·",
-        tone: META,
-        head: card.variant,
-        body: previewLine(card.text),
-      };
+      return { glyph: "·", tone: META, head: card.variant };
     default:
-      return {
-        glyph: "·",
-        tone: META,
-        head: card.kind,
-        body: "",
-      };
+      return { glyph: "·", tone: META, head: card.kind };
+  }
+}
+
+function CardBody({ card }: { card: Card }): React.ReactElement | null {
+  switch (card.kind) {
+    case "user":
+      return <inkCompat.Text>{previewLine(card.text)}</inkCompat.Text>;
+    case "reasoning":
+    case "streaming":
+      return card.text.length > 0 ? <MarkdownView text={card.text} /> : null;
+    case "tool":
+      return (
+        <inkCompat.Text color={FAINT}>{previewLine(card.output) || "(no output)"}</inkCompat.Text>
+      );
+    case "live":
+      return <inkCompat.Text>{previewLine(card.text)}</inkCompat.Text>;
+    default:
+      return null;
   }
 }
 
 function CardRow({ card }: { card: Card }): React.ReactElement {
-  const { glyph, tone, head, body } = summarize(card);
+  const { glyph, tone, head } = headerFor(card);
+  const body = <CardBody card={card} />;
   return (
     <inkCompat.Box flexDirection="column">
       <inkCompat.Box flexDirection="row" gap={1}>
@@ -177,9 +189,9 @@ function CardRow({ card }: { card: Card }): React.ReactElement {
         </inkCompat.Text>
         <inkCompat.Text color={tone}>{head}</inkCompat.Text>
       </inkCompat.Box>
-      {body.length > 0 ? (
-        <inkCompat.Box flexDirection="row" paddingLeft={2}>
-          <inkCompat.Text>{body}</inkCompat.Text>
+      {body ? (
+        <inkCompat.Box flexDirection="column" paddingLeft={2}>
+          {body}
         </inkCompat.Box>
       ) : null}
     </inkCompat.Box>

--- a/src/cli/ui/markdown-lines.ts
+++ b/src/cli/ui/markdown-lines.ts
@@ -1,0 +1,268 @@
+/** Pure markdown → flat MdLine[]. Streaming-safe: marked.lexer tolerates partial input. */
+
+import { type Token, type Tokens, marked } from "marked";
+
+export interface InlineStyle {
+  bold?: boolean;
+  italic?: boolean;
+  strike?: boolean;
+  code?: boolean;
+  link?: string;
+  fileRef?: { path: string; line?: number; lineEnd?: number };
+}
+
+export interface InlineSpan extends InlineStyle {
+  text: string;
+}
+
+export type MdLine =
+  | { kind: "blank" }
+  | { kind: "hr" }
+  | { kind: "heading"; level: number; spans: InlineSpan[] }
+  | { kind: "paragraph"; spans: InlineSpan[] }
+  | {
+      kind: "list";
+      ordered: boolean;
+      index: number;
+      depth: number;
+      task?: "todo" | "done";
+      spans: InlineSpan[];
+    }
+  | { kind: "code"; lang: string; text: string }
+  | { kind: "blockquote"; spans: InlineSpan[] };
+
+const FILE_REF_RE = /\b([A-Za-z0-9_./@\-]+\.[A-Za-z0-9]{1,6})(?::(\d+)(?:-(\d+))?)?\b/g;
+
+marked.use({ gfm: true, breaks: false });
+
+export function markdownToLines(text: string): MdLine[] {
+  if (text.length === 0) return [];
+  const tokens = marked.lexer(text);
+  const out: MdLine[] = [];
+  for (const tok of tokens) emitBlock(tok, out, 0);
+  return out;
+}
+
+function emitBlock(tok: Token, out: MdLine[], depth: number): void {
+  switch (tok.type) {
+    case "heading": {
+      const h = tok as Tokens.Heading;
+      out.push({ kind: "heading", level: h.depth, spans: inline(h.tokens ?? []) });
+      return;
+    }
+    case "paragraph": {
+      const p = tok as Tokens.Paragraph;
+      out.push({ kind: "paragraph", spans: inline(p.tokens ?? []) });
+      return;
+    }
+    case "code": {
+      const c = tok as Tokens.Code;
+      out.push({ kind: "code", lang: (c.lang ?? "").split(/\s+/)[0] ?? "", text: c.text });
+      return;
+    }
+    case "list": {
+      const l = tok as Tokens.List;
+      const startIndex = Number(l.start) || 1;
+      l.items.forEach((item, i) => emitListItem(item, out, l.ordered, startIndex + i, depth));
+      return;
+    }
+    case "hr":
+      out.push({ kind: "hr" });
+      return;
+    case "blockquote": {
+      const bq = tok as Tokens.Blockquote;
+      for (const child of bq.tokens ?? []) {
+        if (child.type === "paragraph") {
+          out.push({ kind: "blockquote", spans: inline((child as Tokens.Paragraph).tokens ?? []) });
+        } else if (child.type === "space") {
+          // skip
+        } else {
+          // For nested non-paragraph blocks (lists, code), fall back to a flat blockquote span.
+          const flat = plainTokens(child);
+          if (flat.length > 0) out.push({ kind: "blockquote", spans: [{ text: flat }] });
+        }
+      }
+      return;
+    }
+    case "space":
+      out.push({ kind: "blank" });
+      return;
+    case "html": {
+      const h = tok as Tokens.HTML;
+      out.push({ kind: "paragraph", spans: [{ text: h.text }] });
+      return;
+    }
+    default: {
+      // Unknown / table / def — render the raw text as a paragraph fallback.
+      const raw = (tok as { raw?: string }).raw ?? "";
+      if (raw.trim().length > 0) out.push({ kind: "paragraph", spans: [{ text: raw }] });
+    }
+  }
+}
+
+function emitListItem(
+  item: Tokens.ListItem,
+  out: MdLine[],
+  ordered: boolean,
+  index: number,
+  depth: number,
+): void {
+  const task = item.task ? (item.checked ? "done" : "todo") : undefined;
+  const head: MdLine = {
+    kind: "list",
+    ordered,
+    index,
+    depth,
+    spans: [],
+    ...(task ? { task } : {}),
+  };
+  out.push(head);
+  for (const tok of item.tokens) {
+    if (tok.type === "text") {
+      const t = tok as Tokens.Text;
+      const spans = t.tokens ? inline(t.tokens) : inlineFromText(t.text);
+      head.spans.push(...spans);
+    } else if (tok.type === "list") {
+      const sub = tok as Tokens.List;
+      const subStart = Number(sub.start) || 1;
+      sub.items.forEach((s, i) => emitListItem(s, out, sub.ordered, subStart + i, depth + 1));
+    } else {
+      emitBlock(tok, out, depth);
+    }
+  }
+}
+
+function inline(tokens: Token[]): InlineSpan[] {
+  const out: InlineSpan[] = [];
+  walk(tokens, {}, out);
+  return mergeAdjacent(out);
+}
+
+function walk(tokens: Token[], style: InlineStyle, out: InlineSpan[]): void {
+  for (const tok of tokens) {
+    switch (tok.type) {
+      case "text": {
+        const t = tok as Tokens.Text;
+        if (t.tokens && t.tokens.length > 0) walk(t.tokens, style, out);
+        else pushTextSpans(t.text, style, out);
+        break;
+      }
+      case "strong":
+        walk((tok as Tokens.Strong).tokens, { ...style, bold: true }, out);
+        break;
+      case "em":
+        walk((tok as Tokens.Em).tokens, { ...style, italic: true }, out);
+        break;
+      case "del":
+        walk((tok as Tokens.Del).tokens, { ...style, strike: true }, out);
+        break;
+      case "codespan":
+        out.push({ text: (tok as Tokens.Codespan).text, code: true, ...style });
+        break;
+      case "link": {
+        const l = tok as Tokens.Link;
+        // A link's children are still subject to ancestor styles; emit each
+        // descendant span with the link href so OSC8 can wrap it later.
+        const before = out.length;
+        walk(l.tokens, style, out);
+        for (let i = before; i < out.length; i++) {
+          const span = out[i]!;
+          if (!span.link) span.link = l.href;
+        }
+        break;
+      }
+      case "image": {
+        const im = tok as Tokens.Image;
+        out.push({ text: `[image: ${im.text || im.href}]`, ...style });
+        break;
+      }
+      case "br":
+        out.push({ text: "\n", ...style });
+        break;
+      case "escape":
+        pushTextSpans((tok as Tokens.Escape).text, style, out);
+        break;
+      case "html":
+        pushTextSpans((tok as Tokens.HTML).text, style, out);
+        break;
+      default:
+        pushTextSpans((tok as { raw?: string }).raw ?? "", style, out);
+    }
+  }
+}
+
+function pushTextSpans(text: string, style: InlineStyle, out: InlineSpan[]): void {
+  if (text.length === 0) return;
+  // Split out file refs so the renderer can OSC8-link them.
+  let cursor = 0;
+  for (const m of text.matchAll(FILE_REF_RE)) {
+    const start = m.index ?? 0;
+    const end = start + m[0].length;
+    if (start > cursor) out.push({ text: text.slice(cursor, start), ...style });
+    const path = m[1]!;
+    const ln = m[2] ? Number(m[2]) : undefined;
+    const lnEnd = m[3] ? Number(m[3]) : undefined;
+    out.push({
+      text: m[0],
+      ...style,
+      fileRef: {
+        path,
+        ...(ln !== undefined ? { line: ln } : {}),
+        ...(lnEnd !== undefined ? { lineEnd: lnEnd } : {}),
+      },
+    });
+    cursor = end;
+  }
+  if (cursor < text.length) out.push({ text: text.slice(cursor), ...style });
+}
+
+function inlineFromText(text: string): InlineSpan[] {
+  const out: InlineSpan[] = [];
+  pushTextSpans(text, {}, out);
+  return out;
+}
+
+function mergeAdjacent(spans: InlineSpan[]): InlineSpan[] {
+  if (spans.length < 2) return spans;
+  const out: InlineSpan[] = [];
+  for (const s of spans) {
+    const last = out[out.length - 1];
+    if (last && stylesEqual(last, s)) {
+      out[out.length - 1] = { ...last, text: last.text + s.text };
+    } else {
+      out.push(s);
+    }
+  }
+  return out;
+}
+
+function stylesEqual(a: InlineSpan, b: InlineSpan): boolean {
+  return (
+    !!a.bold === !!b.bold &&
+    !!a.italic === !!b.italic &&
+    !!a.strike === !!b.strike &&
+    !!a.code === !!b.code &&
+    a.link === b.link &&
+    fileRefEqual(a.fileRef, b.fileRef)
+  );
+}
+
+function fileRefEqual(a: InlineSpan["fileRef"], b: InlineSpan["fileRef"]): boolean {
+  if (!a && !b) return true;
+  if (!a || !b) return false;
+  return a.path === b.path && a.line === b.line && a.lineEnd === b.lineEnd;
+}
+
+function plainTokens(tok: Token): string {
+  if ("raw" in tok && typeof (tok as { raw?: string }).raw === "string") {
+    return (tok as { raw: string }).raw.trim();
+  }
+  return "";
+}
+
+/** Extract just the visible characters from a span list — handy for tests / previews. */
+export function spansText(spans: ReadonlyArray<InlineSpan>): string {
+  let s = "";
+  for (const span of spans) s += span.text;
+  return s;
+}

--- a/src/cli/ui/markdown-view.tsx
+++ b/src/cli/ui/markdown-view.tsx
@@ -1,0 +1,175 @@
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React from "react";
+import { inkCompat } from "../../renderer/index.js";
+import { type InlineSpan, type MdLine, markdownToLines } from "./markdown-lines.js";
+
+const FG_BODY = "#c9d1d9";
+const FG_FAINT = "#6e7681";
+const FG_STRONG = "#f0f6fc";
+const FG_META = "#8b949e";
+const TONE_BRAND = "#79c0ff";
+const TONE_OK = "#7ee787";
+const TONE_WARN = "#f0b07d";
+const SURFACE_ELEV = "#161b22";
+
+export function MarkdownView({ text }: { text: string }): React.ReactElement {
+  const lines = React.useMemo(() => markdownToLines(text), [text]);
+  return <MarkdownLines lines={lines} />;
+}
+
+export function MarkdownLines({
+  lines,
+}: {
+  lines: ReadonlyArray<MdLine>;
+}): React.ReactElement {
+  return (
+    <inkCompat.Box flexDirection="column">
+      {lines.map((line, i) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: lines are positional + stable per render
+        <LineRow key={`md-${i}-${line.kind}`} line={line} />
+      ))}
+    </inkCompat.Box>
+  );
+}
+
+function LineRow({ line }: { line: MdLine }): React.ReactElement | null {
+  switch (line.kind) {
+    case "blank":
+      return <inkCompat.Text> </inkCompat.Text>;
+    case "hr":
+      return <inkCompat.Text color={FG_FAINT}>──────</inkCompat.Text>;
+    case "heading":
+      return (
+        <inkCompat.Box>
+          <inkCompat.Text bold color={FG_STRONG}>
+            {`${"#".repeat(line.level)} `}
+          </inkCompat.Text>
+          <Spans spans={line.spans} bold strongColor />
+        </inkCompat.Box>
+      );
+    case "paragraph":
+      return (
+        <inkCompat.Box>
+          <Spans spans={line.spans} />
+        </inkCompat.Box>
+      );
+    case "list": {
+      const indent = " ".repeat(line.depth * 2);
+      const marker =
+        line.task === "done"
+          ? "✓"
+          : line.task === "todo"
+            ? "○"
+            : line.ordered
+              ? `${line.index}.`
+              : "·";
+      const markerColor =
+        line.task === "done" ? TONE_OK : line.task === "todo" ? FG_FAINT : FG_META;
+      return (
+        <inkCompat.Box>
+          <inkCompat.Text color={markerColor}>{`${indent}${marker} `}</inkCompat.Text>
+          <Spans spans={line.spans} dim={line.task === "done"} strike={line.task === "done"} />
+        </inkCompat.Box>
+      );
+    }
+    case "code":
+      return <CodeBlock lang={line.lang} text={line.text} />;
+    case "blockquote":
+      return (
+        <inkCompat.Box>
+          <inkCompat.Text color={TONE_BRAND}>{"▎ "}</inkCompat.Text>
+          <Spans spans={line.spans} italic />
+        </inkCompat.Box>
+      );
+  }
+}
+
+function spanKey(span: InlineSpan, i: number): string {
+  return `${i}-${span.text.length}-${span.bold ? "b" : ""}${span.italic ? "i" : ""}${span.code ? "c" : ""}${span.strike ? "s" : ""}${span.link ? "l" : ""}`;
+}
+
+function CodeBlock({ lang, text }: { lang: string; text: string }): React.ReactElement {
+  const lines = text.split("\n");
+  return (
+    <inkCompat.Box flexDirection="column">
+      {lang.length > 0 ? <inkCompat.Text color={FG_META}>{` ${lang}`}</inkCompat.Text> : null}
+      {lines.map((ln, i) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: code lines are positional + stable per render
+        <inkCompat.Text key={`code-${i}`} backgroundColor={SURFACE_ELEV}>
+          {` ${ln} `}
+        </inkCompat.Text>
+      ))}
+    </inkCompat.Box>
+  );
+}
+
+interface SpansProps {
+  readonly spans: ReadonlyArray<InlineSpan>;
+  readonly bold?: boolean;
+  readonly italic?: boolean;
+  readonly dim?: boolean;
+  readonly strike?: boolean;
+  readonly strongColor?: boolean;
+}
+
+function Spans({ spans, bold, italic, dim, strike, strongColor }: SpansProps): React.ReactElement {
+  if (spans.length === 0) return <inkCompat.Text> </inkCompat.Text>;
+  return (
+    <>
+      {spans.map((span, i) => (
+        <SpanText
+          key={spanKey(span, i)}
+          span={span}
+          ambientBold={bold}
+          ambientItalic={italic}
+          ambientDim={dim}
+          ambientStrike={strike}
+          strongColor={strongColor}
+        />
+      ))}
+    </>
+  );
+}
+
+function SpanText({
+  span,
+  ambientBold,
+  ambientItalic,
+  ambientDim,
+  ambientStrike,
+  strongColor,
+}: {
+  span: InlineSpan;
+  ambientBold?: boolean;
+  ambientItalic?: boolean;
+  ambientDim?: boolean;
+  ambientStrike?: boolean;
+  strongColor?: boolean;
+}): React.ReactElement {
+  if (span.code) {
+    return (
+      <inkCompat.Text color={FG_STRONG} backgroundColor={SURFACE_ELEV}>
+        {` ${span.text} `}
+      </inkCompat.Text>
+    );
+  }
+  const color = span.fileRef
+    ? TONE_BRAND
+    : span.link
+      ? TONE_BRAND
+      : strongColor
+        ? FG_STRONG
+        : FG_BODY;
+  return (
+    <inkCompat.Text
+      color={color}
+      bold={!!(span.bold || ambientBold)}
+      italic={!!(span.italic || ambientItalic)}
+      dimColor={!!ambientDim}
+      strikethrough={!!(span.strike || ambientStrike)}
+      underline={!!(span.link || span.fileRef)}
+    >
+      {span.text}
+    </inkCompat.Text>
+  );
+}

--- a/tests/renderer/markdown-lines.test.ts
+++ b/tests/renderer/markdown-lines.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import { type MdLine, markdownToLines, spansText } from "../../src/cli/ui/markdown-lines.js";
+
+describe("markdownToLines — basic blocks", () => {
+  it("returns an empty array for empty input", () => {
+    expect(markdownToLines("")).toEqual([]);
+  });
+
+  it("parses a level-1 heading", () => {
+    const lines = markdownToLines("# Title");
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatchObject({ kind: "heading", level: 1 });
+    if (lines[0]?.kind === "heading") expect(spansText(lines[0].spans)).toBe("Title");
+  });
+
+  it("parses a paragraph with emphasis + bold + inline code", () => {
+    const lines = markdownToLines("Hello **bold** and *italic* and `code`.");
+    expect(lines).toHaveLength(1);
+    expect(lines[0]?.kind).toBe("paragraph");
+    if (lines[0]?.kind === "paragraph") {
+      const spans = lines[0].spans;
+      expect(spans.find((s) => s.bold)?.text).toBe("bold");
+      expect(spans.find((s) => s.italic)?.text).toBe("italic");
+      expect(spans.find((s) => s.code)?.text).toBe("code");
+    }
+  });
+
+  it("parses a fenced code block with a language", () => {
+    const lines = markdownToLines("```ts\nconst x = 1;\n```");
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatchObject({ kind: "code", lang: "ts", text: "const x = 1;" });
+  });
+
+  it("parses an unordered list — one MdLine per item", () => {
+    const lines = markdownToLines("- a\n- b\n- c");
+    const list = lines.filter((l) => l.kind === "list") as Extract<MdLine, { kind: "list" }>[];
+    expect(list).toHaveLength(3);
+    expect(list[0]).toMatchObject({ ordered: false, index: 1, depth: 0 });
+    expect(spansText(list[0]!.spans)).toBe("a");
+    expect(list[2]?.index).toBe(3);
+  });
+
+  it("parses an ordered list, preserves start index", () => {
+    const lines = markdownToLines("3. third\n4. fourth");
+    const list = lines.filter((l) => l.kind === "list") as Extract<MdLine, { kind: "list" }>[];
+    expect(list[0]).toMatchObject({ ordered: true, index: 3 });
+    expect(list[1]?.index).toBe(4);
+  });
+
+  it("parses a task list with checked / unchecked markers", () => {
+    const lines = markdownToLines("- [x] done\n- [ ] todo");
+    const list = lines.filter((l) => l.kind === "list") as Extract<MdLine, { kind: "list" }>[];
+    expect(list[0]?.task).toBe("done");
+    expect(list[1]?.task).toBe("todo");
+  });
+
+  it("parses nested lists with depth", () => {
+    const md = "- outer\n  - inner";
+    const lines = markdownToLines(md);
+    const list = lines.filter((l) => l.kind === "list") as Extract<MdLine, { kind: "list" }>[];
+    expect(list).toHaveLength(2);
+    expect(list[0]?.depth).toBe(0);
+    expect(list[1]?.depth).toBe(1);
+  });
+
+  it("parses a horizontal rule", () => {
+    const lines = markdownToLines("---");
+    expect(lines.some((l) => l.kind === "hr")).toBe(true);
+  });
+
+  it("parses a blockquote", () => {
+    const lines = markdownToLines("> quoted text");
+    const bq = lines.find((l) => l.kind === "blockquote");
+    expect(bq).toBeDefined();
+    if (bq?.kind === "blockquote") expect(spansText(bq.spans)).toContain("quoted text");
+  });
+});
+
+describe("markdownToLines — inline detail", () => {
+  it("merges adjacent same-style spans", () => {
+    const lines = markdownToLines("hello world");
+    if (lines[0]?.kind === "paragraph") {
+      expect(lines[0].spans).toHaveLength(1);
+      expect(lines[0].spans[0]?.text).toBe("hello world");
+    } else {
+      throw new Error("expected paragraph");
+    }
+  });
+
+  it("link tokens carry href on each child span", () => {
+    const lines = markdownToLines("see [docs](https://example.com) here");
+    if (lines[0]?.kind !== "paragraph") throw new Error("expected paragraph");
+    const linked = lines[0].spans.find((s) => s.link);
+    expect(linked?.text).toBe("docs");
+    expect(linked?.link).toBe("https://example.com");
+  });
+
+  it("strikethrough spans carry strike=true", () => {
+    const lines = markdownToLines("a ~~b~~ c");
+    if (lines[0]?.kind !== "paragraph") throw new Error("expected paragraph");
+    const struck = lines[0].spans.find((s) => s.strike);
+    expect(struck?.text).toBe("b");
+  });
+
+  it("file refs in paragraph text carry path/line metadata", () => {
+    const lines = markdownToLines("look at src/foo.ts:42 for the bug");
+    if (lines[0]?.kind !== "paragraph") throw new Error("expected paragraph");
+    const ref = lines[0].spans.find((s) => s.fileRef);
+    expect(ref?.fileRef?.path).toBe("src/foo.ts");
+    expect(ref?.fileRef?.line).toBe(42);
+  });
+
+  it("file ref ranges keep the end line", () => {
+    const lines = markdownToLines("see lib/x.ts:10-20");
+    if (lines[0]?.kind !== "paragraph") throw new Error("expected paragraph");
+    const ref = lines[0].spans.find((s) => s.fileRef);
+    expect(ref?.fileRef?.line).toBe(10);
+    expect(ref?.fileRef?.lineEnd).toBe(20);
+  });
+});
+
+describe("markdownToLines — streaming-friendliness", () => {
+  it("partial text without a closing backtick still parses", () => {
+    const lines = markdownToLines("partial `code");
+    expect(lines.length).toBeGreaterThan(0);
+    expect(lines[0]?.kind).toBe("paragraph");
+  });
+
+  it("empty heading marker before content arrives is tolerated", () => {
+    const lines = markdownToLines("# ");
+    expect(lines.length).toBeGreaterThanOrEqual(0);
+  });
+
+  it("multiple blocks separated by blank lines emit blank between them", () => {
+    const lines = markdownToLines("# a\n\nbody");
+    const kinds = lines.map((l) => l.kind);
+    expect(kinds).toContain("heading");
+    expect(kinds).toContain("paragraph");
+  });
+});

--- a/tests/renderer/markdown-view.test.tsx
+++ b/tests/renderer/markdown-view.test.tsx
@@ -1,0 +1,88 @@
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { MarkdownView } from "../../src/cli/ui/markdown-view.js";
+import { CharPool, HyperlinkPool, StylePool, mount } from "../../src/renderer/index.js";
+import { makeTestWriter } from "../../src/renderer/runtime/test-writer.js";
+
+function pools() {
+  return { char: new CharPool(), style: new StylePool(), hyperlink: new HyperlinkPool() };
+}
+
+function flush(): Promise<void> {
+  return new Promise((r) => setTimeout(r, 0));
+}
+
+async function render(text: string, width = 60, height = 20): Promise<string> {
+  const w = makeTestWriter();
+  const handle = mount(<MarkdownView text={text} />, {
+    viewportWidth: width,
+    viewportHeight: height,
+    pools: pools(),
+    write: w.write,
+  });
+  await flush();
+  const out = w.output();
+  handle.destroy();
+  return out;
+}
+
+describe("MarkdownView — through cell-diff renderer", () => {
+  it("renders a heading + paragraph", async () => {
+    const out = await render("# Title\n\nbody text");
+    expect(out).toContain("Title");
+    expect(out).toContain("body text");
+  });
+
+  it("renders ordered + unordered list markers", async () => {
+    const out = await render("- alpha\n- beta\n\n1. first\n2. second");
+    expect(out).toContain("alpha");
+    expect(out).toContain("beta");
+    expect(out).toContain("first");
+    expect(out).toContain("second");
+    expect(out).toMatch(/[·•]/);
+    expect(out).toContain("1.");
+  });
+
+  it("task list shows checked / unchecked glyphs", async () => {
+    const out = await render("- [x] done item\n- [ ] todo item");
+    expect(out).toContain("done item");
+    expect(out).toContain("todo item");
+    expect(out).toContain("✓");
+    expect(out).toContain("○");
+  });
+
+  it("renders a fenced code block with the lang label", async () => {
+    const out = await render("```ts\nconst x = 1;\n```");
+    expect(out).toContain("const x = 1;");
+    expect(out).toContain("ts");
+  });
+
+  it("inline bold + italic + code emit SGR codes", async () => {
+    const out = await render("plain **bold** *italic* `code`");
+    expect(out).toContain("bold");
+    expect(out).toContain("italic");
+    expect(out).toContain("code");
+    expect(out).toContain("\x1b[1m");
+    expect(out).toContain("\x1b[3m");
+  });
+
+  it("file refs render with hyperlink underline", async () => {
+    const out = await render("see src/foo.ts:42");
+    expect(out).toContain("src/foo.ts:42");
+    expect(out).toContain("\x1b[4m");
+  });
+
+  it("blockquote renders with the leading bar glyph", async () => {
+    const out = await render("> a quoted line");
+    expect(out).toContain("a quoted line");
+    expect(out).toContain("▎");
+  });
+
+  it("horizontal rule renders as a row of em-dashes", async () => {
+    const out = await render("before\n\n---\n\nafter");
+    expect(out).toContain("before");
+    expect(out).toContain("after");
+    expect(out).toContain("─");
+  });
+});


### PR DESCRIPTION
## Summary
- New pure parser `markdownToLines(text): MdLine[]` in `src/cli/ui/markdown-lines.ts`. Walks marked tokens into a flat line tree (heading/paragraph/list/code/blockquote/hr/blank) with inline spans carrying bold/italic/code/strike + link/fileRef metadata. No React imports, streaming-safe.
- New cell-diff renderer view `MarkdownView` in `src/cli/ui/markdown-view.tsx` — consumes the line tree through `inkCompat.{Box,Text}`, decorates fileRefs and links with underline, applies dim+strike to completed task items, etc.
- `chat-v2` reasoning + streaming card bodies now render full markdown instead of a single flattened `previewLine`.
- 26 new tests (18 parser + 8 view) covering paragraph/heading/list/code/blockquote/hr/inline styles/file refs/streaming-friendliness.

## Why
Issue #160 — Phase 5d-20 of the cell-diff renderer rollout. Before chat-v2 can stand in for the live chat App, streamed assistant replies need real markdown rendering. The existing `markdown.tsx` is bound to ink primitives and ships syntax highlighting via cli-highlight (ANSI inline codes). Splitting parse from render lets the cell-diff path consume the same parser without inheriting the Ink-only renderer or the ANSI-encoded code-block path.

## Test plan
- [x] `npm run verify` — 2176 tests pass, typecheck clean, lint warnings only (no errors)
- [x] Manual: `reasonix chat-v2` plays the canned script with markdown reply rendered as headings + list + bold + inline code + file refs
- [ ] Reviewer: spot-check that streaming partial input (e.g. unfinished code fence) doesn't crash the parser between chunks