### PR TITLE
feat(renderer): SimplePromptInput — single-line input (#160)

### DIFF
--- a/src/cli/commands/input-demo.tsx
+++ b/src/cli/commands/input-demo.tsx
@@ -1,0 +1,132 @@
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React, { useState } from "react";
+import {
+  CharPool,
+  type Handle,
+  HyperlinkPool,
+  StylePool,
+  inkCompat,
+  mount,
+} from "../../renderer/index.js";
+import { SimplePromptInput } from "../ui/prompt-input-v2.js";
+
+const BRAND = "#79c0ff";
+const FAINT = "#6e7681";
+const ACCENT = "#d2a8ff";
+const OK = "#7ee787";
+
+interface Submission {
+  readonly id: number;
+  readonly text: string;
+}
+
+function Header(): React.ReactElement {
+  return (
+    <inkCompat.Box flexDirection="row" gap={1}>
+      <inkCompat.Text color={BRAND} bold>
+        ◈ Reasonix
+      </inkCompat.Text>
+      <inkCompat.Text color={FAINT}>
+        input-demo · cell-diff renderer · Esc Esc to exit
+      </inkCompat.Text>
+    </inkCompat.Box>
+  );
+}
+
+function HistoryRow({ entry }: { entry: Submission }): React.ReactElement {
+  return (
+    <inkCompat.Box flexDirection="row" gap={1}>
+      <inkCompat.Text color={ACCENT}>›</inkCompat.Text>
+      <inkCompat.Text color={OK}>#{entry.id}</inkCompat.Text>
+      <inkCompat.Text>{entry.text}</inkCompat.Text>
+    </inkCompat.Box>
+  );
+}
+
+interface ShellProps {
+  readonly onExit: () => void;
+}
+
+export function InputDemoShell({ onExit }: ShellProps): React.ReactElement {
+  const [history, setHistory] = useState<ReadonlyArray<Submission>>([]);
+  const [draft, setDraft] = useState("");
+  const nextIdRef = React.useRef(1);
+
+  return (
+    <inkCompat.Box flexDirection="column">
+      <Header />
+      <inkCompat.Box flexDirection="column" marginTop={1}>
+        <inkCompat.Static items={history}>
+          {(entry) => <HistoryRow key={entry.id} entry={entry} />}
+        </inkCompat.Static>
+      </inkCompat.Box>
+      <inkCompat.Box marginTop={1}>
+        <SimplePromptInput
+          value={draft}
+          onChange={setDraft}
+          onSubmit={(value) => {
+            const trimmed = value.trim();
+            if (trimmed.length === 0) return;
+            const id = nextIdRef.current;
+            nextIdRef.current = id + 1;
+            setHistory((prev) => [...prev, { id, text: trimmed }]);
+            setDraft("");
+          }}
+          onCancel={onExit}
+          placeholder="type a message and hit enter…"
+        />
+      </inkCompat.Box>
+      <inkCompat.Box marginTop={1}>
+        <inkCompat.Text dimColor>
+          Enter submit · Esc clear / exit when empty · ←→ move · ⌘a/⌘e jump · ⌘u/⌘k kill
+        </inkCompat.Text>
+      </inkCompat.Box>
+    </inkCompat.Box>
+  );
+}
+
+export interface InputDemoOptions {
+  readonly stdout?: NodeJS.WriteStream;
+  readonly stdin?: NodeJS.ReadStream;
+}
+
+export async function runInputDemo(opts: InputDemoOptions = {}): Promise<void> {
+  const stdout = opts.stdout ?? process.stdout;
+  const stdin = opts.stdin ?? process.stdin;
+
+  if (!stdin.isTTY || !stdout.isTTY) {
+    process.stderr.write("input-demo requires an interactive TTY.\n");
+    process.exit(1);
+  }
+
+  const pools = {
+    char: new CharPool(),
+    style: new StylePool(),
+    hyperlink: new HyperlinkPool(),
+  };
+
+  let resolveExit: () => void = () => {};
+  const exited = new Promise<void>((resolve) => {
+    resolveExit = resolve;
+  });
+
+  const handle: Handle = mount(<InputDemoShell onExit={() => resolveExit()} />, {
+    viewportWidth: stdout.columns ?? 80,
+    viewportHeight: stdout.rows ?? 24,
+    pools,
+    write: (bytes) => stdout.write(bytes),
+    stdin,
+    onExit: () => resolveExit(),
+  });
+
+  const onResize = () => handle.resize(stdout.columns ?? 80, stdout.rows ?? 24);
+  stdout.on("resize", onResize);
+
+  try {
+    await exited;
+  } finally {
+    stdout.off("resize", onResize);
+    handle.destroy();
+    stdin.pause();
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -398,6 +398,14 @@ program
   });
 
 program
+  .command("input-demo")
+  .description("experimental — single-line PromptInput on the cell-diff renderer")
+  .action(async () => {
+    const { runInputDemo } = await import("./commands/input-demo.js");
+    await runInputDemo();
+  });
+
+program
   .command("update")
   .description(t("cli.update"))
   .option("--dry-run", t("ui.dryRunHint"))

--- a/src/cli/ui/prompt-input-v2.tsx
+++ b/src/cli/ui/prompt-input-v2.tsx
@@ -1,0 +1,147 @@
+/** Single-line prompt input for chat-v2 — useCursor + useKeystroke, no Ink. */
+
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React from "react";
+import stringWidth from "string-width";
+import { inkCompat, useCursor, useKeystroke } from "../../renderer/index.js";
+
+const FG_BODY = "#c9d1d9";
+const FG_FAINT = "#6e7681";
+const TONE_BRAND = "#79c0ff";
+
+export interface SimplePromptInputProps {
+  readonly value: string;
+  readonly onChange: (next: string) => void;
+  readonly onSubmit?: (value: string) => void;
+  readonly onCancel?: () => void;
+  /** Hint shown when value is empty. */
+  readonly placeholder?: string;
+  /** Leading marker before the input. Default `›`. */
+  readonly prefix?: string;
+  /** Disable input; cursor still renders. */
+  readonly disabled?: boolean;
+}
+
+/** Cursor index is held internally — caller controls the value, but the
+ *  caret position is a UI concern. Reset to value.length whenever the value
+ *  is replaced from outside (longer or shorter than current cursor allows). */
+export function SimplePromptInput({
+  value,
+  onChange,
+  onSubmit,
+  onCancel,
+  placeholder,
+  prefix = "›",
+  disabled,
+}: SimplePromptInputProps): React.ReactElement {
+  const [cursor, setCursor] = React.useState(value.length);
+
+  // External value replacement: clamp / reset cursor.
+  const lastValueRef = React.useRef(value);
+  if (value !== lastValueRef.current) {
+    lastValueRef.current = value;
+    if (cursor > value.length) setCursor(value.length);
+  }
+
+  // Multiple keystrokes can flush in one stdin chunk before React commits;
+  // hold the latest value/cursor in refs so the handler reads them fresh.
+  const valueRef = React.useRef(value);
+  valueRef.current = value;
+  const cursorRef = React.useRef(cursor);
+  cursorRef.current = cursor;
+
+  const apply = (next: string, nextCursor: number): void => {
+    valueRef.current = next;
+    cursorRef.current = nextCursor;
+    setCursor(nextCursor);
+    onChange(next);
+  };
+
+  useKeystroke((k) => {
+    if (disabled) return;
+    if (k.escape) {
+      if (valueRef.current.length === 0) {
+        onCancel?.();
+        return;
+      }
+      apply("", 0);
+      return;
+    }
+    if (k.return) {
+      onSubmit?.(valueRef.current);
+      return;
+    }
+    const v = valueRef.current;
+    const c = cursorRef.current;
+    if (k.backspace) {
+      if (c === 0) return;
+      apply(v.slice(0, c - 1) + v.slice(c), c - 1);
+      return;
+    }
+    if (k.delete) {
+      if (c >= v.length) return;
+      apply(v.slice(0, c) + v.slice(c + 1), c);
+      return;
+    }
+    if (k.leftArrow) {
+      if (c === 0) return;
+      cursorRef.current = c - 1;
+      setCursor(c - 1);
+      return;
+    }
+    if (k.rightArrow) {
+      if (c >= v.length) return;
+      cursorRef.current = c + 1;
+      setCursor(c + 1);
+      return;
+    }
+    if (k.home || (k.ctrl && k.input === "a")) {
+      cursorRef.current = 0;
+      setCursor(0);
+      return;
+    }
+    if (k.end || (k.ctrl && k.input === "e")) {
+      cursorRef.current = v.length;
+      setCursor(v.length);
+      return;
+    }
+    if (k.ctrl && k.input === "u") {
+      // Bash convention: kill from cursor to start of line.
+      apply(v.slice(c), 0);
+      return;
+    }
+    if (k.ctrl && k.input === "k") {
+      apply(v.slice(0, c), c);
+      return;
+    }
+    if (k.ctrl || k.meta) return;
+    if (k.input.length > 0) {
+      apply(v.slice(0, c) + k.input + v.slice(c), c + k.input.length);
+    }
+  });
+
+  const prefixCells = stringCells(prefix) + 1; // prefix + 1 space
+  const visualCol = prefixCells + stringCells(value.slice(0, cursor));
+  useCursor(disabled ? null : { col: visualCol, rowFromBottom: 0, visible: true });
+
+  const showPlaceholder = value.length === 0;
+  return (
+    <inkCompat.Box flexDirection="row" gap={1}>
+      <inkCompat.Text color={TONE_BRAND} bold>
+        {prefix}
+      </inkCompat.Text>
+      {showPlaceholder ? (
+        <inkCompat.Text dimColor color={FG_FAINT}>
+          {placeholder ?? "type a message…"}
+        </inkCompat.Text>
+      ) : (
+        <inkCompat.Text color={FG_BODY}>{value}</inkCompat.Text>
+      )}
+    </inkCompat.Box>
+  );
+}
+
+function stringCells(s: string): number {
+  if (s.length === 0) return 0;
+  return stringWidth(s);
+}

--- a/tests/renderer/prompt-input-v2.test.tsx
+++ b/tests/renderer/prompt-input-v2.test.tsx
@@ -1,0 +1,262 @@
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React, { useState } from "react";
+import { describe, expect, it } from "vitest";
+import { SimplePromptInput } from "../../src/cli/ui/prompt-input-v2.js";
+import {
+  CharPool,
+  HyperlinkPool,
+  type KeystrokeSource,
+  StylePool,
+  mount,
+} from "../../src/renderer/index.js";
+import { makeTestWriter } from "../../src/renderer/runtime/test-writer.js";
+
+function pools() {
+  return { char: new CharPool(), style: new StylePool(), hyperlink: new HyperlinkPool() };
+}
+
+function flush(): Promise<void> {
+  return new Promise((r) => setTimeout(r, 0));
+}
+
+function makeFakeStdin(): KeystrokeSource & { push: (s: string) => void } {
+  let listener: ((c: string | Buffer) => void) | null = null;
+  return {
+    on(_e, cb) {
+      listener = cb;
+    },
+    off() {
+      listener = null;
+    },
+    setRawMode() {},
+    resume() {},
+    pause() {},
+    push(c: string) {
+      listener?.(c);
+    },
+  };
+}
+
+interface Harness {
+  values: string[];
+  submits: string[];
+  cancels: number;
+  push: (s: string) => void;
+  destroy: () => void;
+  output: () => string;
+}
+
+function harness(initial = ""): Harness {
+  const w = makeTestWriter();
+  const stdin = makeFakeStdin();
+  const values: string[] = [initial];
+  const submits: string[] = [];
+  let cancels = 0;
+  function App(): React.ReactElement {
+    const [v, setV] = useState(initial);
+    return (
+      <SimplePromptInput
+        value={v}
+        onChange={(next) => {
+          values.push(next);
+          setV(next);
+        }}
+        onSubmit={(next) => {
+          submits.push(next);
+        }}
+        onCancel={() => {
+          cancels++;
+        }}
+      />
+    );
+  }
+  const handle = mount(<App />, {
+    viewportWidth: 60,
+    viewportHeight: 6,
+    pools: pools(),
+    write: w.write,
+    stdin,
+  });
+  return {
+    values,
+    submits,
+    get cancels() {
+      return cancels;
+    },
+    push: (s) => stdin.push(s),
+    destroy: () => handle.destroy(),
+    output: () => w.output(),
+  };
+}
+
+describe("SimplePromptInput — typing", () => {
+  it("printable keys append to the value", async () => {
+    const h = harness();
+    await flush();
+    h.push("h");
+    await flush();
+    h.push("i");
+    await flush();
+    expect(h.values.at(-1)).toBe("hi");
+    h.destroy();
+  });
+
+  it("backspace removes the last char", async () => {
+    const h = harness();
+    await flush();
+    h.push("abc");
+    await flush();
+    h.push("\x7f");
+    await flush();
+    expect(h.values.at(-1)).toBe("ab");
+    h.destroy();
+  });
+
+  it("enter calls onSubmit with the current value", async () => {
+    const h = harness();
+    await flush();
+    h.push("hello\r");
+    await flush();
+    expect(h.submits).toEqual(["hello"]);
+    h.destroy();
+  });
+
+  it("escape on a non-empty value clears it", async () => {
+    const h = harness();
+    await flush();
+    h.push("text");
+    await flush();
+    h.push("\x1b");
+    await flush();
+    expect(h.values.at(-1)).toBe("");
+    expect(h.cancels).toBe(0);
+    h.destroy();
+  });
+
+  it("escape on empty value invokes onCancel", async () => {
+    const h = harness();
+    await flush();
+    h.push("\x1b");
+    await flush();
+    expect(h.cancels).toBe(1);
+    h.destroy();
+  });
+});
+
+describe("SimplePromptInput — cursor movement", () => {
+  it("left arrow + insert puts a char in the middle", async () => {
+    const h = harness();
+    await flush();
+    h.push("abc");
+    await flush();
+    h.push("\x1b[D");
+    await flush();
+    h.push("X");
+    await flush();
+    expect(h.values.at(-1)).toBe("abXc");
+    h.destroy();
+  });
+
+  it("home moves cursor to start; typing prepends", async () => {
+    const h = harness();
+    await flush();
+    h.push("abc");
+    await flush();
+    h.push("\x1b[H");
+    await flush();
+    h.push("Z");
+    await flush();
+    expect(h.values.at(-1)).toBe("Zabc");
+    h.destroy();
+  });
+
+  it("ctrl+u clears everything before the cursor", async () => {
+    const h = harness();
+    await flush();
+    h.push("abcdef");
+    await flush();
+    h.push("\x1b[D"); // cursor before 'f'
+    await flush();
+    h.push("\x1b[D"); // cursor before 'e'
+    await flush();
+    h.push("\x15"); // ctrl+u
+    await flush();
+    expect(h.values.at(-1)).toBe("ef");
+    h.destroy();
+  });
+
+  it("ctrl+k clears everything from cursor to end", async () => {
+    const h = harness();
+    await flush();
+    h.push("abcdef");
+    await flush();
+    h.push("\x1b[D");
+    await flush();
+    h.push("\x1b[D");
+    await flush();
+    h.push("\x0b"); // ctrl+k
+    await flush();
+    expect(h.values.at(-1)).toBe("abcd");
+    h.destroy();
+  });
+
+  it("delete removes the char under the cursor", async () => {
+    const h = harness();
+    await flush();
+    h.push("abc");
+    await flush();
+    h.push("\x1b[D");
+    await flush();
+    h.push("\x1b[D");
+    await flush();
+    h.push("\x1b[3~"); // delete (forward)
+    await flush();
+    expect(h.values.at(-1)).toBe("ac");
+    h.destroy();
+  });
+});
+
+describe("SimplePromptInput — render", () => {
+  it("placeholder shows when empty", async () => {
+    const w = makeTestWriter();
+    const stdin = makeFakeStdin();
+    const handle = mount(
+      <SimplePromptInput
+        value=""
+        onChange={() => {}}
+        onSubmit={() => {}}
+        placeholder="say something…"
+      />,
+      { viewportWidth: 50, viewportHeight: 4, pools: pools(), write: w.write, stdin },
+    );
+    await flush();
+    expect(w.output()).toContain("say something");
+    handle.destroy();
+  });
+
+  it("typed chars appear in the output bytes", async () => {
+    const h = harness();
+    await flush();
+    h.push("abc");
+    await flush();
+    const out = h.output();
+    // Cell-diff renderer emits one char at a time with cursor moves between
+    // them, so just verify each char shows up somewhere in the byte stream.
+    expect(out).toMatch(/a/);
+    expect(out).toMatch(/b/);
+    expect(out).toMatch(/c/);
+    h.destroy();
+  });
+
+  it("backspace re-emits cursor positioning", async () => {
+    const h = harness();
+    await flush();
+    h.push("hi");
+    await flush();
+    h.push("\x7f");
+    await flush();
+    // Just verify that backspace produced *some* output (cursor move + clear).
+    expect(h.values.at(-1)).toBe("h");
+    h.destroy();
+  });
+});


### PR DESCRIPTION
## Summary
- New `SimplePromptInput` (`src/cli/ui/prompt-input-v2.tsx`) — single-line text input built on `useCursor` + `useKeystroke`. Caller controls value (`onChange`); component owns caret position. Supported keys: printable chars, backspace, delete, enter, ←→, home/end, ctrl+a/e (jump), ctrl+u/k (kill), escape (clear when non-empty → fire `onCancel` when empty).
- New `reasonix input-demo` command exercising the input standalone — submitted entries land in a Static history list above the prompt.
- 13 new tests covering typing, backspace, enter/escape, cursor movement, ctrl-u/k, delete, placeholder rendering.

## Why
Issue #160 — Phase 5d-21b. Builds on top of `useCursor` (#199): the renderer now has both a way to publish caret position AND a working input component that uses it. Foundation for chat-v2's live-input mode (5d-21c).

## Test plan
- [x] `npm run verify` — 2195 tests pass (13 new), typecheck clean, lint warnings only (no errors)
- [x] Manual: `reasonix input-demo` — typing renders, caret tracks, ctrl+u/k kill correctly, esc-on-empty exits
- [ ] Reviewer: confirm the keystroke set matches expected single-line shell semantics