### PR TITLE
refactor(mcp): move server summary out of UI types

### DIFF
--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -9,6 +9,7 @@ import { parseMcpSpec } from "../../mcp/spec.js";
 import { SseTransport } from "../../mcp/sse.js";
 import { type McpTransport, StdioTransport } from "../../mcp/stdio.js";
 import { StreamableHttpTransport } from "../../mcp/streamable-http.js";
+import { buildMcpServerSummary } from "../../mcp/summary.js";
 import {
   deleteSession,
   listSessionsForWorkspace,
@@ -278,14 +279,16 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
         );
         clients.push(mcp);
         successfulSpecs.push(raw);
-        mcpServers.push({
-          label,
-          spec: raw,
-          toolCount: bridge.registeredNames.length,
-          report,
-          host,
-          bridgeEnv: bridge.env,
-        });
+        mcpServers.push(
+          buildMcpServerSummary({
+            label,
+            spec: raw,
+            toolCount: bridge.registeredNames.length,
+            report,
+            host,
+            bridgeEnv: bridge.env,
+          }),
+        );
       } catch (err) {
         // Per-server failure is non-fatal: one broken server shouldn't
         // kill a chat that has working servers configured. Recover by

--- a/src/cli/ui/slash/types.ts
+++ b/src/cli/ui/slash/types.ts
@@ -1,8 +1,9 @@
 import type { EditMode } from "../../../config.js";
-import type { InspectionReport } from "../../../mcp/inspect.js";
-import type { BridgeEnv, McpClientHost } from "../../../mcp/registry.js";
+import type { McpServerSummary } from "../../../mcp/summary.js";
 import type { JobRegistry } from "../../../tools/jobs.js";
 import type { PlanStep } from "../../../tools/plan.js";
+
+export type { McpServerSummary } from "../../../mcp/summary.js";
 
 export interface SlashResult {
   /** Text to display back to the user as a system/info line. */
@@ -113,21 +114,6 @@ export interface SlashContext {
   stopDashboard?: () => Promise<void>;
   /** Snapshot the dashboard's URL when running, null otherwise. */
   getDashboardUrl?: () => string | null;
-}
-
-export interface McpServerSummary {
-  /** Short label shown in the `/mcp` output (server namespace or "anon"). */
-  label: string;
-  /** Original --mcp spec string. */
-  spec: string;
-  /** Count of tools bridged into the Reasonix registry from this server. */
-  toolCount: number;
-  /** Full inspection snapshot — used for the resources + prompts sections. */
-  report: InspectionReport;
-  /** Mutable client handle so `/mcp reconnect` can swap the underlying socket without re-bridging tools. */
-  host: McpClientHost;
-  /** Captured at first-bridge time so append-drift reconnects can register newly-added tools with the same options. */
-  bridgeEnv: BridgeEnv;
 }
 
 export interface SlashCommandSpec {

--- a/src/mcp/summary.ts
+++ b/src/mcp/summary.ts
@@ -1,0 +1,29 @@
+import type { InspectionReport } from "./inspect.js";
+import type { BridgeEnv, McpClientHost } from "./registry.js";
+
+export interface McpServerSummary {
+  label: string;
+  spec: string;
+  toolCount: number;
+  report: InspectionReport;
+  host: McpClientHost;
+  bridgeEnv: BridgeEnv;
+}
+
+export function buildMcpServerSummary(opts: {
+  label: string;
+  spec: string;
+  toolCount: number;
+  report: InspectionReport;
+  host: McpClientHost;
+  bridgeEnv: BridgeEnv;
+}): McpServerSummary {
+  return {
+    label: opts.label,
+    spec: opts.spec,
+    toolCount: opts.toolCount,
+    report: opts.report,
+    host: opts.host,
+    bridgeEnv: opts.bridgeEnv,
+  };
+}


### PR DESCRIPTION
## Summary

Moves McpServerSummary from src/cli/ui/slash/types.ts (UI layer) into src/mcp/summary.ts (MCP layer) where it logically belongs, and adds a buildMcpServerSummary() builder function.

Relates to #196 — this is the first boundary (relocation + builder only, zero behavior change).

## Changes

- **New** src/mcp/summary.ts: canonical McpServerSummary interface + buildMcpServerSummary() builder
- **Updated** src/cli/ui/slash/types.ts: imports and re-exports McpServerSummary from the MCP layer; removed the inline interface definition and its now-unused InspectionReport/BridgeEnv/McpClientHost imports
- **Updated** src/cli/commands/chat.tsx: uses buildMcpServerSummary() instead of inline object literal

## Design notes

- slash/types.ts needs both import type (for local SlashContext usage) and export type (re-export for existing consumers) — TypeScript doesn't make re-exported names available locally
- buildMcpServerSummary() is a plain field-copy builder, preserving exact behavior. It enables future field validation/defaults without touching call sites
- Field doc comments from the original interface intentionally dropped per CONTRIBUTING.md (no what comments)

## Verification

- npm run verify passes: build, lint (Biome), typecheck, all 2150 tests
- Diff: +43 / -25 lines (3 files)