### PR TITLE
feat(renderer): multi-line SimplePromptInput (#160)

### DIFF
--- a/src/cli/ui/prompt-input-v2.tsx
+++ b/src/cli/ui/prompt-input-v2.tsx
@@ -1,9 +1,10 @@
-/** Single-line prompt input for chat-v2 — useCursor + useKeystroke, no Ink. */
+/** Multi-line prompt input for chat-v2 — useCursor + useKeystroke, no Ink. */
 
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React from "react";
 import stringWidth from "string-width";
 import { inkCompat, useCursor, useKeystroke } from "../../renderer/index.js";
+import { lineAndColumn, processMultilineKey } from "./multiline-keys.js";
 
 const FG_BODY = "#c9d1d9";
 const FG_FAINT = "#6e7681";
@@ -14,6 +15,10 @@ export interface SimplePromptInputProps {
   readonly onChange: (next: string) => void;
   readonly onSubmit?: (value: string) => void;
   readonly onCancel?: () => void;
+  /** Fired when ↑ pushes past the top of an empty / boundary buffer. Parent walks history. */
+  readonly onHistoryPrev?: () => void;
+  /** Fired when ↓ pushes past the bottom of an empty / boundary buffer. */
+  readonly onHistoryNext?: () => void;
   /** Hint shown when value is empty. */
   readonly placeholder?: string;
   /** Leading marker before the input. Default `›`. */
@@ -22,14 +27,13 @@ export interface SimplePromptInputProps {
   readonly disabled?: boolean;
 }
 
-/** Cursor index is held internally — caller controls the value, but the
- *  caret position is a UI concern. Reset to value.length whenever the value
- *  is replaced from outside (longer or shorter than current cursor allows). */
 export function SimplePromptInput({
   value,
   onChange,
   onSubmit,
   onCancel,
+  onHistoryPrev,
+  onHistoryNext,
   placeholder,
   prefix = "›",
   disabled,
@@ -50,11 +54,15 @@ export function SimplePromptInput({
   const cursorRef = React.useRef(cursor);
   cursorRef.current = cursor;
 
-  const apply = (next: string, nextCursor: number): void => {
-    valueRef.current = next;
-    cursorRef.current = nextCursor;
-    setCursor(nextCursor);
-    onChange(next);
+  const apply = (nextValue: string | null, nextCursor: number | null): void => {
+    if (nextValue !== null && nextValue !== valueRef.current) {
+      valueRef.current = nextValue;
+      onChange(nextValue);
+    }
+    if (nextCursor !== null && nextCursor !== cursorRef.current) {
+      cursorRef.current = nextCursor;
+      setCursor(nextCursor);
+    }
   };
 
   useKeystroke((k) => {
@@ -67,76 +75,82 @@ export function SimplePromptInput({
       apply("", 0);
       return;
     }
-    if (k.return) {
-      onSubmit?.(valueRef.current);
+    const action = processMultilineKey(valueRef.current, cursorRef.current, {
+      input: k.input,
+      return: k.return,
+      shift: k.shift,
+      ctrl: k.ctrl,
+      meta: k.meta,
+      backspace: k.backspace,
+      delete: k.delete,
+      tab: k.tab,
+      upArrow: k.upArrow,
+      downArrow: k.downArrow,
+      leftArrow: k.leftArrow,
+      rightArrow: k.rightArrow,
+      escape: k.escape,
+      pageUp: k.pageUp,
+      pageDown: k.pageDown,
+      home: k.home,
+      end: k.end,
+    });
+    if (action.historyHandoff === "prev") {
+      onHistoryPrev?.();
       return;
     }
-    const v = valueRef.current;
-    const c = cursorRef.current;
-    if (k.backspace) {
-      if (c === 0) return;
-      apply(v.slice(0, c - 1) + v.slice(c), c - 1);
+    if (action.historyHandoff === "next") {
+      onHistoryNext?.();
       return;
     }
-    if (k.delete) {
-      if (c >= v.length) return;
-      apply(v.slice(0, c) + v.slice(c + 1), c);
+    if (action.pasteRequest) {
+      // Paste support is deferred to 5d-21f; for now insert the raw content.
+      const v = valueRef.current;
+      const c = cursorRef.current;
+      const merged = v.slice(0, c) + action.pasteRequest.content + v.slice(c);
+      apply(merged, c + action.pasteRequest.content.length);
       return;
     }
-    if (k.leftArrow) {
-      if (c === 0) return;
-      cursorRef.current = c - 1;
-      setCursor(c - 1);
+    if (action.submit) {
+      onSubmit?.(action.submitValue ?? valueRef.current);
       return;
     }
-    if (k.rightArrow) {
-      if (c >= v.length) return;
-      cursorRef.current = c + 1;
-      setCursor(c + 1);
-      return;
-    }
-    if (k.home || (k.ctrl && k.input === "a")) {
-      cursorRef.current = 0;
-      setCursor(0);
-      return;
-    }
-    if (k.end || (k.ctrl && k.input === "e")) {
-      cursorRef.current = v.length;
-      setCursor(v.length);
-      return;
-    }
-    if (k.ctrl && k.input === "u") {
-      // Bash convention: kill from cursor to start of line.
-      apply(v.slice(c), 0);
-      return;
-    }
-    if (k.ctrl && k.input === "k") {
-      apply(v.slice(0, c), c);
-      return;
-    }
-    if (k.ctrl || k.meta) return;
-    if (k.input.length > 0) {
-      apply(v.slice(0, c) + k.input + v.slice(c), c + k.input.length);
-    }
+    apply(action.next, action.cursor);
   });
 
-  const prefixCells = stringCells(prefix) + 1; // prefix + 1 space
-  const visualCol = prefixCells + stringCells(value.slice(0, cursor));
-  useCursor(disabled ? null : { col: visualCol, rowFromBottom: 0, visible: true });
+  // Cursor positioning: split logical lines and project the (line, col) onto
+  // the rendered rows. The prompt prefix sits on the FIRST logical line; the
+  // following lines are gutter-padded by spaces of the same width.
+  const lines = value.length === 0 ? [""] : value.split("\n");
+  const { line: cursorLine, col: cursorCol } = lineAndColumn(value, cursor);
+  const prefixCells = stringCells(prefix) + 1; // prefix + the gap=1 space
+  const lineText = lines[cursorLine] ?? "";
+  const cursorVisualCol = prefixCells + stringCells(lineText.slice(0, cursorCol));
+  const rowFromBottom = lines.length - 1 - cursorLine;
+  useCursor(disabled ? null : { col: cursorVisualCol, rowFromBottom, visible: true });
 
   const showPlaceholder = value.length === 0;
+  const gutter = " ".repeat(stringCells(prefix));
+
   return (
-    <inkCompat.Box flexDirection="row" gap={1}>
-      <inkCompat.Text color={TONE_BRAND} bold>
-        {prefix}
-      </inkCompat.Text>
-      {showPlaceholder ? (
-        <inkCompat.Text dimColor color={FG_FAINT}>
-          {placeholder ?? "type a message…"}
-        </inkCompat.Text>
-      ) : (
-        <inkCompat.Text color={FG_BODY}>{value}</inkCompat.Text>
-      )}
+    <inkCompat.Box flexDirection="column">
+      {lines.map((ln, idx) => (
+        <inkCompat.Box key={lineKey(ln, idx)} flexDirection="row" gap={1}>
+          {idx === 0 ? (
+            <inkCompat.Text color={TONE_BRAND} bold>
+              {prefix}
+            </inkCompat.Text>
+          ) : (
+            <inkCompat.Text color={FG_FAINT}>{gutter}</inkCompat.Text>
+          )}
+          {idx === 0 && showPlaceholder ? (
+            <inkCompat.Text dimColor color={FG_FAINT}>
+              {placeholder ?? "type a message…"}
+            </inkCompat.Text>
+          ) : (
+            <inkCompat.Text color={FG_BODY}>{ln.length > 0 ? ln : " "}</inkCompat.Text>
+          )}
+        </inkCompat.Box>
+      ))}
     </inkCompat.Box>
   );
 }
@@ -144,4 +158,8 @@ export function SimplePromptInput({
 function stringCells(s: string): number {
   if (s.length === 0) return 0;
   return stringWidth(s);
+}
+
+function lineKey(line: string, idx: number): string {
+  return `${idx}-${line.length}`;
 }

--- a/src/renderer/input/keystroke.ts
+++ b/src/renderer/input/keystroke.ts
@@ -125,6 +125,15 @@ function parseEscape(s: string, start: number): Consumed {
     return parseCsi(s, start);
   }
 
+  // Alt+Enter — terminals send \x1b\r (or \x1b\n on some). Surface as
+  // meta+return so multi-line reducers can distinguish it from a bare Enter.
+  if (next === "\r" || next === "\n") {
+    return {
+      key: { ...emptyKeystroke(), raw: `\x1b${next}`, meta: true, return: true },
+      length: 2,
+    };
+  }
+
   if (isPrintable(next)) {
     return {
       key: { ...emptyKeystroke(), raw: `\x1b${next}`, meta: true, input: next },

--- a/tests/renderer/prompt-input-v2.test.tsx
+++ b/tests/renderer/prompt-input-v2.test.tsx
@@ -170,18 +170,19 @@ describe("SimplePromptInput — cursor movement", () => {
     h.destroy();
   });
 
-  it("ctrl+u clears everything before the cursor", async () => {
+  it("ctrl+u clears the whole buffer", async () => {
+    // Reasonix convention (matches the live chat input): ctrl+u kills the
+    // entire buffer rather than only the part before the cursor — the
+    // ergonomic alternative for getting rid of a long paste.
     const h = harness();
     await flush();
     h.push("abcdef");
     await flush();
-    h.push("\x1b[D"); // cursor before 'f'
-    await flush();
-    h.push("\x1b[D"); // cursor before 'e'
+    h.push("\x1b[D");
     await flush();
     h.push("\x15"); // ctrl+u
     await flush();
-    expect(h.values.at(-1)).toBe("ef");
+    expect(h.values.at(-1)).toBe("");
     h.destroy();
   });
 
@@ -200,12 +201,13 @@ describe("SimplePromptInput — cursor movement", () => {
     h.destroy();
   });
 
-  it("delete removes the char under the cursor", async () => {
+  it("delete acts as backspace (Reasonix convention)", async () => {
+    // The live chat input collapses forward-delete onto backspace because
+    // some Windows terminals report Backspace without setting the
+    // backspace flag; v2 follows the same convention via processMultilineKey.
     const h = harness();
     await flush();
     h.push("abc");
-    await flush();
-    h.push("\x1b[D");
     await flush();
     h.push("\x1b[D");
     await flush();
@@ -213,6 +215,108 @@ describe("SimplePromptInput — cursor movement", () => {
     await flush();
     expect(h.values.at(-1)).toBe("ac");
     h.destroy();
+  });
+});
+
+describe("SimplePromptInput — multi-line", () => {
+  it("Alt+Enter inserts a newline", async () => {
+    const h = harness();
+    await flush();
+    h.push("foo");
+    await flush();
+    h.push("\x1b\r"); // Alt+Enter
+    await flush();
+    h.push("bar");
+    await flush();
+    expect(h.values.at(-1)).toBe("foo\nbar");
+    h.destroy();
+  });
+
+  it("Enter on a multi-line buffer still submits", async () => {
+    const h = harness();
+    await flush();
+    h.push("a");
+    await flush();
+    h.push("\x1b\r"); // Alt+Enter for newline
+    await flush();
+    h.push("b");
+    await flush();
+    h.push("\r"); // Enter — submit
+    await flush();
+    expect(h.submits).toEqual(["a\nb"]);
+    h.destroy();
+  });
+
+  it("up arrow moves cursor up one logical line", async () => {
+    const h = harness();
+    await flush();
+    h.push("first");
+    await flush();
+    h.push("\x1b\r");
+    await flush();
+    h.push("second");
+    await flush();
+    h.push("\x1b[A"); // up arrow
+    await flush();
+    h.push("X"); // should land on the first line
+    await flush();
+    // Cursor was at end of "second" (col 6); up keeps col but first line is
+    // "first" (len 5), so cursor clamps to 5 → "firstX\nsecond".
+    expect(h.values.at(-1)).toBe("firstX\nsecond");
+    h.destroy();
+  });
+
+  it("down arrow moves cursor down one logical line", async () => {
+    const h = harness();
+    await flush();
+    h.push("ab");
+    await flush();
+    h.push("\x1b\r");
+    await flush();
+    h.push("cd");
+    await flush();
+    h.push("\x1b[H"); // home → cursor 0
+    await flush();
+    h.push("\x1b[B"); // down → second line, col 0
+    await flush();
+    h.push("X");
+    await flush();
+    expect(h.values.at(-1)).toBe("ab\nXcd");
+    h.destroy();
+  });
+
+  it("backslash + Enter at end-of-buffer continues to a new line", async () => {
+    const h = harness();
+    await flush();
+    h.push("foo\\");
+    await flush();
+    h.push("\r");
+    await flush();
+    h.push("bar");
+    await flush();
+    expect(h.values.at(-1)).toBe("foo\nbar");
+    h.destroy();
+  });
+
+  it("up arrow on empty buffer fires onHistoryPrev", async () => {
+    const w = makeTestWriter();
+    const stdin = makeFakeStdin();
+    let prevs = 0;
+    const handle = mount(
+      <SimplePromptInput
+        value=""
+        onChange={() => {}}
+        onHistoryPrev={() => {
+          prevs++;
+        }}
+      />,
+      { viewportWidth: 40, viewportHeight: 4, pools: pools(), write: w.write, stdin },
+    );
+    await flush();
+    stdin.push("\x1b[A");
+    await flush();
+    expect(prevs).toBe(1);
+    handle.destroy();
   });
 });
 


### PR DESCRIPTION
## Summary
- `SimplePromptInput` now delegates to `processMultilineKey` from `src/cli/ui/multiline-keys.ts`, so chat-v2's input shares behavior with the live chat input: backslash line continuation, ↑/↓ traversal between logical lines, Ctrl+W word delete, Meta+B/F word jump, Alt+Enter for newline, Enter to submit, paste fallback (raw insert pending the proper sentinel pipeline in 5d-21f), `onHistoryPrev`/`onHistoryNext` hooks fired when ↑/↓ pushes past a buffer boundary.
- Each logical line renders as its own row; the cursor lands on the correct (line, col) via `useCursor`'s `rowFromBottom`.
- Keystroke parser learns Alt+Enter (`\x1b\r` and `\x1b\n` → `meta + return`) so the multi-line reducer can distinguish it from a bare Enter.
- 6 new tests cover Alt+Enter newline, Enter-still-submits, ↑/↓ navigation, backslash continuation, history-handoff on empty buffer.

## Why
Issue #160 — Phase 5d-21d. Builds on `useCursor` (#199) + `SimplePromptInput` (#200) + chat-v2 live input (#202). Reusing the existing `multiline-keys` reducer keeps semantics identical to the live chat input, so when 5d-23 flips `chat` → `chat-v2` users won't relearn anything.

## Test plan
- [x] `npm run verify` — 2204 tests pass (6 new), typecheck clean, lint warnings only (no errors)
- [x] Manual: `reasonix input-demo` and `reasonix chat-v2` both accept Alt+Enter for newline; ↑/↓ navigates rows; backslash continuation works
- [ ] Reviewer: confirm Alt+Enter parsing doesn't regress any keystroke decoder paths