### PR TITLE
feat(renderer): chat-v2 — submit history with ↑/↓ recall (#160)

### DIFF
--- a/src/cli/commands/chat-v2.tsx
+++ b/src/cli/commands/chat-v2.tsx
@@ -14,6 +14,7 @@ import type { Card } from "../ui/state/cards.js";
 import type { AgentEvent } from "../ui/state/events.js";
 import { AgentStoreProvider, useAgentState, useDispatch } from "../ui/state/provider.js";
 import type { SessionInfo } from "../ui/state/state.js";
+import { usePromptHistory } from "../ui/use-prompt-history.js";
 
 const BRAND = "#79c0ff";
 const FAINT = "#6e7681";
@@ -235,6 +236,7 @@ export function ChatV2Shell({
   const turnRef = useRef(0);
   const dispatchRef = useRef(dispatch);
   dispatchRef.current = dispatch;
+  const history = usePromptHistory();
 
   const replyBuilder = buildReplyOverride ?? buildReply;
 
@@ -265,8 +267,19 @@ export function ChatV2Shell({
     if (trimmed.length === 0) return;
     if (inProgress) return;
     dispatchRef.current({ type: "user.submit", text: trimmed });
+    history.recordSubmit(trimmed);
     setDraft("");
     playReply(trimmed);
+  };
+
+  const handleHistoryPrev = (): void => {
+    const recalled = history.recallPrev(draft);
+    if (recalled !== null) setDraft(recalled);
+  };
+
+  const handleHistoryNext = (): void => {
+    const recalled = history.recallNext();
+    if (recalled !== null) setDraft(recalled);
   };
 
   return (
@@ -284,6 +297,8 @@ export function ChatV2Shell({
           onChange={setDraft}
           onSubmit={handleSubmit}
           onCancel={onExit}
+          onHistoryPrev={handleHistoryPrev}
+          onHistoryNext={handleHistoryNext}
           disabled={inProgress}
           placeholder={inProgress ? "thinking…" : "type a message and hit enter…"}
         />

--- a/src/cli/ui/use-prompt-history.ts
+++ b/src/cli/ui/use-prompt-history.ts
@@ -1,0 +1,72 @@
+/** Submit-history walker for SimplePromptInput. ↑ recalls older entries, ↓ walks forward. */
+
+import { useRef } from "react";
+
+export interface PromptHistory {
+  /** Push the just-submitted text. Empty / duplicate-of-latest entries are ignored. */
+  recordSubmit(text: string): void;
+  /** Step back one entry. Saves currentValue as the restored draft on the
+   *  very first prev call so ↓-past-newest can restore it. Returns the
+   *  recalled string or null when there's nothing older. */
+  recallPrev(currentValue: string): string | null;
+  /** Step forward one entry. Returns the recalled string, the saved draft
+   *  when stepping past the newest entry, or null when not currently
+   *  recalling anything. */
+  recallNext(): string | null;
+  /** Drop the recall cursor + saved draft (e.g. on a new submit). */
+  reset(): void;
+}
+
+export function usePromptHistory(maxEntries = 100): PromptHistory {
+  // Refs throughout — recall walking shouldn't trigger re-renders. The
+  // parent's `onChange` from SimplePromptInput is what propagates the
+  // recalled value back into the controlled input.
+  const entriesRef = useRef<string[]>([]);
+  const indexRef = useRef<number | null>(null);
+  const draftRef = useRef<string>("");
+
+  return {
+    recordSubmit(text) {
+      if (text.length === 0) return;
+      const entries = entriesRef.current;
+      if (entries[entries.length - 1] === text) {
+        indexRef.current = null;
+        draftRef.current = "";
+        return;
+      }
+      entries.push(text);
+      if (entries.length > maxEntries) entries.splice(0, entries.length - maxEntries);
+      indexRef.current = null;
+      draftRef.current = "";
+    },
+    recallPrev(currentValue) {
+      const entries = entriesRef.current;
+      if (entries.length === 0) return null;
+      if (indexRef.current === null) {
+        draftRef.current = currentValue;
+        indexRef.current = entries.length - 1;
+        return entries[indexRef.current] ?? null;
+      }
+      if (indexRef.current === 0) return null;
+      indexRef.current -= 1;
+      return entries[indexRef.current] ?? null;
+    },
+    recallNext() {
+      const entries = entriesRef.current;
+      if (indexRef.current === null) return null;
+      if (indexRef.current >= entries.length - 1) {
+        // Past the newest → restore the saved draft and exit recall mode.
+        const draft = draftRef.current;
+        indexRef.current = null;
+        draftRef.current = "";
+        return draft;
+      }
+      indexRef.current += 1;
+      return entries[indexRef.current] ?? null;
+    },
+    reset() {
+      indexRef.current = null;
+      draftRef.current = "";
+    },
+  };
+}

--- a/tests/renderer/chat-v2.test.tsx
+++ b/tests/renderer/chat-v2.test.tsx
@@ -167,6 +167,42 @@ describe("chat-v2 shell — interactive submit", () => {
   });
 });
 
+describe("chat-v2 shell — history navigation", () => {
+  it("up arrow on the empty prompt recalls the most recent submission", async () => {
+    const w = makeTestWriter();
+    const stdin = makeFakeStdin();
+    const handle = mount(
+      <AgentStoreProvider session={DEMO_SESSION}>
+        <ChatV2Shell onExit={() => {}} buildReply={instantReply} />
+      </AgentStoreProvider>,
+      {
+        viewportWidth: 80,
+        viewportHeight: 24,
+        pools: pools(),
+        write: w.write,
+        stdin,
+      },
+    );
+    await flush();
+    stdin.push("alpha\r");
+    for (let i = 0; i < 30; i++) await flush();
+    stdin.push("beta\r");
+    for (let i = 0; i < 30; i++) await flush();
+    // Both submissions should be in history; ↑ recalls "beta", ↑ again recalls "alpha".
+    stdin.push("\x1b[A");
+    await flush();
+    stdin.push("\r");
+    for (let i = 0; i < 30; i++) await flush();
+    // The third submission should be "beta" (recalled). Easy assertion: a fourth
+    // user.submit lands the text "beta" again.
+    const out = w.output();
+    // beta appears at least twice in the rendered output (original submission + recall).
+    const occurrences = (out.match(/beta/g) ?? []).length;
+    expect(occurrences).toBeGreaterThanOrEqual(2);
+    handle.destroy();
+  });
+});
+
 describe("chat-v2 shell — exit", () => {
   it("Esc on the empty prompt invokes onExit", async () => {
     const w = makeTestWriter();

--- a/tests/renderer/use-prompt-history.test.tsx
+++ b/tests/renderer/use-prompt-history.test.tsx
@@ -1,0 +1,132 @@
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { type PromptHistory, usePromptHistory } from "../../src/cli/ui/use-prompt-history.js";
+import { CharPool, HyperlinkPool, StylePool, mount } from "../../src/renderer/index.js";
+import { makeTestWriter } from "../../src/renderer/runtime/test-writer.js";
+
+function pools() {
+  return { char: new CharPool(), style: new StylePool(), hyperlink: new HyperlinkPool() };
+}
+
+function flush(): Promise<void> {
+  return new Promise((r) => setTimeout(r, 0));
+}
+
+/** Mount a tiny probe that exposes the hook's API to the surrounding test. */
+async function buildHistory(): Promise<{ history: PromptHistory; destroy: () => void }> {
+  let captured: PromptHistory | null = null;
+  function Probe(): React.ReactElement | null {
+    captured = usePromptHistory(5);
+    return null;
+  }
+  const w = makeTestWriter();
+  const handle = mount(<Probe />, {
+    viewportWidth: 20,
+    viewportHeight: 4,
+    pools: pools(),
+    write: w.write,
+  });
+  await flush();
+  if (!captured) throw new Error("hook was never invoked");
+  return { history: captured, destroy: () => handle.destroy() };
+}
+
+describe("usePromptHistory — empty state", () => {
+  it("recallPrev on an empty store returns null", async () => {
+    const { history, destroy } = await buildHistory();
+    expect(history.recallPrev("draft")).toBeNull();
+    destroy();
+  });
+
+  it("recallNext when not recalling returns null", async () => {
+    const { history, destroy } = await buildHistory();
+    expect(history.recallNext()).toBeNull();
+    destroy();
+  });
+});
+
+describe("usePromptHistory — recording + recall", () => {
+  it("recordSubmit then recallPrev returns the most recent entry", async () => {
+    const { history, destroy } = await buildHistory();
+    history.recordSubmit("first");
+    history.recordSubmit("second");
+    expect(history.recallPrev("draft")).toBe("second");
+    destroy();
+  });
+
+  it("recallPrev twice walks back through history", async () => {
+    const { history, destroy } = await buildHistory();
+    history.recordSubmit("one");
+    history.recordSubmit("two");
+    history.recordSubmit("three");
+    expect(history.recallPrev("draft")).toBe("three");
+    expect(history.recallPrev("draft")).toBe("two");
+    expect(history.recallPrev("draft")).toBe("one");
+    expect(history.recallPrev("draft")).toBeNull();
+    destroy();
+  });
+
+  it("recallNext walks forward + restores the saved draft past the newest", async () => {
+    const { history, destroy } = await buildHistory();
+    history.recordSubmit("one");
+    history.recordSubmit("two");
+    expect(history.recallPrev("my draft")).toBe("two"); // saves draft
+    expect(history.recallPrev("ignored")).toBe("one");
+    expect(history.recallNext()).toBe("two");
+    expect(history.recallNext()).toBe("my draft"); // back to original draft
+    expect(history.recallNext()).toBeNull(); // not recalling anymore
+    destroy();
+  });
+
+  it("duplicate-of-latest submissions are coalesced", async () => {
+    const { history, destroy } = await buildHistory();
+    history.recordSubmit("hi");
+    history.recordSubmit("hi");
+    expect(history.recallPrev("d")).toBe("hi");
+    expect(history.recallPrev("d")).toBeNull();
+    destroy();
+  });
+
+  it("empty submissions are ignored", async () => {
+    const { history, destroy } = await buildHistory();
+    history.recordSubmit("");
+    expect(history.recallPrev("d")).toBeNull();
+    destroy();
+  });
+
+  it("entries past maxEntries are dropped from the front", async () => {
+    const { history, destroy } = await buildHistory();
+    // maxEntries=5 from the harness; push 7 distinct entries.
+    for (let i = 1; i <= 7; i++) history.recordSubmit(`m${i}`);
+    expect(history.recallPrev("d")).toBe("m7");
+    expect(history.recallPrev("d")).toBe("m6");
+    expect(history.recallPrev("d")).toBe("m5");
+    expect(history.recallPrev("d")).toBe("m4");
+    expect(history.recallPrev("d")).toBe("m3");
+    expect(history.recallPrev("d")).toBeNull(); // m1 + m2 evicted
+    destroy();
+  });
+});
+
+describe("usePromptHistory — reset", () => {
+  it("recordSubmit clears any in-progress recall", async () => {
+    const { history, destroy } = await buildHistory();
+    history.recordSubmit("a");
+    history.recordSubmit("b");
+    history.recallPrev("draft"); // index = 1, draft saved
+    history.recordSubmit("c"); // resets cursor
+    // After recordSubmit, recallPrev should start fresh from the newest entry.
+    expect(history.recallPrev("new draft")).toBe("c");
+    destroy();
+  });
+
+  it("explicit reset() clears recall state", async () => {
+    const { history, destroy } = await buildHistory();
+    history.recordSubmit("a");
+    history.recallPrev("draft");
+    history.reset();
+    expect(history.recallNext()).toBeNull();
+    destroy();
+  });
+});


### PR DESCRIPTION
## Summary
- New `usePromptHistory` hook (`src/cli/ui/use-prompt-history.ts`) — FIFO of submitted entries, capped (default 100). ↑ saves the current draft on the first call, then walks back; ↓ walks forward and restores the saved draft once it steps past the newest entry. Duplicate-of-latest submissions are coalesced.
- chat-v2 wires `recordSubmit` into its submit handler and `recallPrev` / `recallNext` into `SimplePromptInput`'s history hooks (already plumbed through `processMultilineKey`'s `historyHandoff`).
- 11 new tests: 10 unit-level on the hook + 1 integration on chat-v2 round-tripping a recall.

## Why
Issue #160 — Phase 5d-21e. Closes the "single-line / multi-line / history" trio of basic input behaviors that the live chat already has. With this in place, only paste handling (5d-21f) remains before chat-v2 reaches feature parity with the existing PromptInput.

## Test plan
- [x] `npm run verify` — 2215 tests pass (11 new), typecheck clean, lint warnings only (no errors)
- [x] Manual: `reasonix chat-v2` — submit a few messages, ↑ recalls each in reverse order, ↓ walks forward, ↓-past-newest restores the in-progress draft
- [ ] Reviewer: confirm draft-save semantics match expected behavior (saved on first ↑ in a given recall session, cleared on submit)