### PR TITLE
feat(renderer): chat-v2 — wire web / memory / ask_choice tools (#160)

### DIFF
--- a/src/cli/commands/chat-v2.tsx
+++ b/src/cli/commands/chat-v2.tsx
@@ -370,24 +370,47 @@ export interface ChatV2Options {
 const DEFAULT_SYSTEM =
   "You are Reasonix, a helpful DeepSeek-powered assistant. Be concise and accurate.";
 
+async function buildDefaultTools(): Promise<import("../../tools.js").ToolRegistry> {
+  const { ToolRegistry } = await import("../../tools.js");
+  const { searchEnabled } = await import("../../config.js");
+  const { registerWebTools } = await import("../../tools/web.js");
+  const { registerMemoryTools } = await import("../../tools/memory.js");
+  const { registerChoiceTool } = await import("../../tools/choice.js");
+  const tools = new ToolRegistry();
+  if (searchEnabled()) registerWebTools(tools);
+  registerMemoryTools(tools, {});
+  registerChoiceTool(tools);
+  return tools;
+}
+
 function makeRealRunTurn(model: string, system: string): RunTurn {
-  return async (userText, turn, dispatch) => {
-    // Lazy-load to keep the demo path import-light. The renderer module
-    // shouldn't pull in the full DeepSeek client unless an interactive turn
-    // is actually firing.
+  // The loop construction is per-turn so dependencies stay lazy; the same
+  // CacheFirstLoop instance is reused via closure to preserve cache state
+  // and the running session transcript across turns.
+  let loopPromise: Promise<{
+    loop: import("../../loop.js").CacheFirstLoop;
+  }> | null = null;
+
+  const setupLoop = async () => {
     const { DeepSeekClient, ImmutablePrefix, CacheFirstLoop } = await import("../../index.js");
-    const { makeLoopBridge } = await import("../ui/loop-bridge.js");
+    const tools = await buildDefaultTools();
     const client = new DeepSeekClient();
-    const prefix = new ImmutablePrefix({ system });
-    const loop = new CacheFirstLoop({ client, prefix, model });
+    const prefix = new ImmutablePrefix({ system, toolSpecs: tools.specs() });
+    const loop = new CacheFirstLoop({ client, prefix, model, tools });
+    return { loop };
+  };
+
+  return async (userText, turn, dispatch) => {
+    const { makeLoopBridge } = await import("../ui/loop-bridge.js");
     const bridge = makeLoopBridge(`turn-${turn}`);
+    if (!loopPromise) loopPromise = setupLoop();
+    const { loop } = await loopPromise;
     try {
       for await (const ev of loop.step(userText)) {
         for (const out of bridge.consume(ev)) dispatch(out);
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      // Synthesise an error LoopEvent so the bridge closes any open cards.
       for (const out of bridge.consume({ turn, role: "error", content: msg, error: msg })) {
         dispatch(out);
       }

--- a/tests/renderer/chat-v2.test.tsx
+++ b/tests/renderer/chat-v2.test.tsx
@@ -210,6 +210,74 @@ describe("chat-v2 shell — history navigation", () => {
   });
 });
 
+describe("chat-v2 shell — tool flow", () => {
+  it("a runTurn that emits tool events produces a tool card", async () => {
+    const w = makeTestWriter();
+    const stdin = makeFakeStdin();
+    const toolRunTurn = makeCannedRunTurn((userText, turn) => {
+      const reasonId = `r-${turn}`;
+      const replyId = `s-${turn}`;
+      const toolId = `t-${turn}`;
+      return [
+        { delayMs: 0, event: { type: "turn.start", turnId: `t-${turn}` } },
+        { delayMs: 0, event: { type: "reasoning.start", id: reasonId } },
+        {
+          delayMs: 0,
+          event: { type: "reasoning.chunk", id: reasonId, text: "I'll list the directory." },
+        },
+        { delayMs: 0, event: { type: "reasoning.end", id: reasonId, paragraphs: 1, tokens: 5 } },
+        {
+          delayMs: 0,
+          event: { type: "tool.start", id: toolId, name: "shell", args: { cmd: "ls" } },
+        },
+        {
+          delayMs: 0,
+          event: {
+            type: "tool.end",
+            id: toolId,
+            output: "src/\nrenderer/\n",
+            exitCode: 0,
+            elapsedMs: 12,
+          },
+        },
+        { delayMs: 0, event: { type: "streaming.start", id: replyId } },
+        {
+          delayMs: 0,
+          event: { type: "streaming.chunk", id: replyId, text: `Listed ${userText}.` },
+        },
+        { delayMs: 0, event: { type: "streaming.end", id: replyId } },
+        {
+          delayMs: 0,
+          event: {
+            type: "turn.end",
+            usage: { prompt: 10, reason: 5, output: 5, cacheHit: 0, cost: 0.0001 },
+          },
+        },
+      ];
+    });
+    const handle = mount(
+      <AgentStoreProvider session={DEMO_SESSION}>
+        <ChatV2Shell onExit={() => {}} runTurn={toolRunTurn} />
+      </AgentStoreProvider>,
+      {
+        viewportWidth: 80,
+        viewportHeight: 30,
+        pools: pools(),
+        write: w.write,
+        stdin,
+      },
+    );
+    await flush();
+    stdin.push("./somewhere\r");
+    for (let i = 0; i < 30; i++) await flush();
+    const out = w.output();
+    expect(out).toContain("shell");
+    expect(out).toContain("ok");
+    expect(out).toMatch(/Listed/);
+    handle.destroy();
+  });
+});
+
 describe("chat-v2 shell — long-conversation overflow", () => {
   it("settled cards from older turns appear in the byte stream as scrollback writes", async () => {
     const w = makeTestWriter();


### PR DESCRIPTION
## Summary
- The real-loop `runTurn` builds a `ToolRegistry` mirroring `chatCommand`: web search/fetch (when `searchEnabled()`), memory tools (remember / recall / forget), and `ask_choice`.
- The loop is constructed once per chat session and reused across turns so the cache state and running transcript carry over (instead of re-priming each turn).
- Tool events flow through the existing `makeLoopBridge` into `tool.start` / `tool.end` card pairs, so chat-v2 now shows real tool activity inline.
- 1 new integration test exercises the tool flow through a fake `runTurn` that emits `tool.start` + `tool.end` directly.

## Why
Issue #160 — Phase 5d-23b. With this, `reasonix chat-v2` (with `DEEPSEEK_API_KEY` set) is functionally a basic Reasonix chat with the model's full tool surface active for web research / memory / branching prompts. MCP / sessions / slash commands are still deferred to 5d-23c-e before the final flip in 5d-23f.

## Test plan
- [x] `npm run verify` — 2232 tests pass (1 new integration), typecheck clean, lint warnings only (no errors)
- [x] Manual: with `DEEPSEEK_API_KEY` set, a question that needs web search now produces a `web_search` tool card before the reply
- [ ] Reviewer: confirm the per-session loop construction matches the singleton lifetime of the existing `chat` command