### PR TITLE
feat(renderer): chat-v2 — slash commands (#160)

### DIFF
--- a/src/cli/commands/chat-v2.tsx
+++ b/src/cli/commands/chat-v2.tsx
@@ -8,11 +8,17 @@ import {
   inkCompat,
   mount,
 } from "../../renderer/index.js";
+import { isSlashInput, runSlash } from "../ui/chat-v2-slash.js";
 import { MarkdownView } from "../ui/markdown-view.js";
 import { SimplePromptInput } from "../ui/prompt-input-v2.js";
 import type { Card } from "../ui/state/cards.js";
 import type { AgentEvent } from "../ui/state/events.js";
-import { AgentStoreProvider, useAgentState, useDispatch } from "../ui/state/provider.js";
+import {
+  AgentStoreProvider,
+  useAgentState,
+  useAgentStore,
+  useDispatch,
+} from "../ui/state/provider.js";
 import type { SessionInfo } from "../ui/state/state.js";
 import { usePromptHistory } from "../ui/use-prompt-history.js";
 
@@ -267,6 +273,7 @@ export function ChatV2Shell({ onExit, runTurn = defaultRunTurn }: ShellProps): R
   const cards = useAgentState((s) => s.cards);
   const inProgress = useAgentState((s) => s.turnInProgress);
   const dispatch = useDispatch();
+  const store = useAgentStore();
   const [frame, setFrame] = useState(0);
   const [draft, setDraft] = useState("");
   const turnRef = useRef(0);
@@ -274,6 +281,8 @@ export function ChatV2Shell({ onExit, runTurn = defaultRunTurn }: ShellProps): R
   dispatchRef.current = dispatch;
   const runTurnRef = useRef(runTurn);
   runTurnRef.current = runTurn;
+  const onExitRef = useRef(onExit);
+  onExitRef.current = onExit;
   const history = usePromptHistory();
 
   useEffect(() => {
@@ -286,10 +295,18 @@ export function ChatV2Shell({ onExit, runTurn = defaultRunTurn }: ShellProps): R
     const trimmed = text.trim();
     if (trimmed.length === 0) return;
     if (inProgress) return;
-    const turn = ++turnRef.current;
-    dispatchRef.current({ type: "user.submit", text: trimmed });
     history.recordSubmit(trimmed);
     setDraft("");
+
+    if (isSlashInput(trimmed)) {
+      const outcome = runSlash(trimmed, { state: store.getState() });
+      for (const ev of outcome.events) dispatchRef.current(ev);
+      if (outcome.exit) onExitRef.current();
+      return;
+    }
+
+    const turn = ++turnRef.current;
+    dispatchRef.current({ type: "user.submit", text: trimmed });
     void runTurnRef.current(trimmed, turn, (ev) => dispatchRef.current(ev));
   };
 

--- a/src/cli/ui/chat-v2-slash.ts
+++ b/src/cli/ui/chat-v2-slash.ts
@@ -1,0 +1,141 @@
+/** Slash command handlers for chat-v2 — synthesise AgentEvents instead of running a turn. */
+
+import type { AgentEvent } from "./state/events.js";
+import type { AgentState } from "./state/state.js";
+
+export interface SlashContext {
+  readonly state: AgentState;
+}
+
+export interface SlashOutcome {
+  /** Events to dispatch in order. */
+  readonly events: ReadonlyArray<AgentEvent>;
+  /** When true, run the parent's `onExit` after dispatching. */
+  readonly exit?: boolean;
+  /** When true, do NOT run a model turn after this command. */
+  readonly handled: true;
+}
+
+export interface SlashCommand {
+  readonly name: string;
+  readonly summary: string;
+  readonly run: (raw: string, ctx: SlashContext) => SlashOutcome;
+}
+
+const HELP_TEXT = `## Available commands
+
+- \`/help\` — show this list
+- \`/clear\` — wipe the conversation cards
+- \`/cost\` — show session usage and cost
+- \`/new\` — clear and start a fresh turn count
+- \`/exit\` — leave chat-v2
+
+Tip: **Alt+Enter** inserts a newline; **↑/↓** walks history.
+`;
+
+const HELP: SlashCommand = {
+  name: "/help",
+  summary: "list available commands",
+  run: () => ({
+    events: [synthUser("/help"), ...synthReply("help", HELP_TEXT)],
+    handled: true,
+  }),
+};
+
+const CLEAR: SlashCommand = {
+  name: "/clear",
+  summary: "wipe the conversation",
+  run: () => ({
+    events: [{ type: "session.reset" }],
+    handled: true,
+  }),
+};
+
+const COST: SlashCommand = {
+  name: "/cost",
+  summary: "show session usage and cost",
+  run: (_raw, { state }) => {
+    const { cost, sessionCost, cacheHit } = state.status;
+    const body = [
+      "## Session cost",
+      "",
+      `- last turn: \`$${cost.toFixed(5)}\``,
+      `- session total: \`$${sessionCost.toFixed(5)}\``,
+      `- cache hit: \`${(cacheHit * 100).toFixed(0)}%\``,
+      "",
+    ].join("\n");
+    return {
+      events: [synthUser("/cost"), ...synthReply("cost", body)],
+      handled: true,
+    };
+  },
+};
+
+const NEW: SlashCommand = {
+  name: "/new",
+  summary: "clear cards and start a fresh turn",
+  run: () => ({
+    events: [{ type: "session.reset" }],
+    handled: true,
+  }),
+};
+
+const EXIT: SlashCommand = {
+  name: "/exit",
+  summary: "leave chat-v2",
+  run: () => ({
+    events: [],
+    exit: true,
+    handled: true,
+  }),
+};
+
+export const SLASH_COMMANDS: ReadonlyArray<SlashCommand> = [HELP, CLEAR, COST, NEW, EXIT];
+
+const COMMAND_MAP: ReadonlyMap<string, SlashCommand> = new Map(
+  SLASH_COMMANDS.map((c) => [c.name, c]),
+);
+
+export function isSlashInput(text: string): boolean {
+  return text.trimStart().startsWith("/");
+}
+
+export function runSlash(raw: string, ctx: SlashContext): SlashOutcome {
+  const trimmed = raw.trim();
+  const head = trimmed.split(/\s+/, 1)[0] ?? trimmed;
+  const cmd = COMMAND_MAP.get(head);
+  if (cmd) return cmd.run(trimmed, ctx);
+  return {
+    events: [
+      synthUser(trimmed),
+      {
+        type: "live.show",
+        id: `slash-err-${Date.now()}`,
+        ts: Date.now(),
+        variant: "sessionOp",
+        tone: "err",
+        text: `unknown command: ${head}. type /help for the list.`,
+      },
+    ],
+    handled: true,
+  };
+}
+
+function synthUser(text: string): AgentEvent {
+  return { type: "user.submit", text };
+}
+
+function synthReply(tag: string, text: string): ReadonlyArray<AgentEvent> {
+  const id = `slash-${tag}-${Date.now()}`;
+  const turnId = `slash-turn-${Date.now()}`;
+  return [
+    { type: "turn.start", turnId },
+    { type: "streaming.start", id },
+    { type: "streaming.chunk", id, text },
+    { type: "streaming.end", id },
+    {
+      type: "turn.end",
+      usage: { prompt: 0, reason: 0, output: 0, cacheHit: 0, cost: 0 },
+    },
+  ];
+}

--- a/tests/renderer/chat-v2-slash.test.ts
+++ b/tests/renderer/chat-v2-slash.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { isSlashInput, runSlash } from "../../src/cli/ui/chat-v2-slash.js";
+import type { AgentState } from "../../src/cli/ui/state/state.js";
+
+function blankState(): AgentState {
+  return {
+    lang: "en",
+    session: { id: "test", branch: "main", workspace: "(test)", model: "deepseek-chat" },
+    cards: [],
+    composer: { value: "", cursor: 0, picker: null, shell: false, abortedHint: false },
+    status: {
+      mode: "auto",
+      network: "online",
+      cost: 0.001,
+      sessionCost: 0.005,
+      cacheHit: 0.6,
+    },
+    focusedCardId: null,
+    toasts: [],
+    turnInProgress: false,
+  };
+}
+
+describe("isSlashInput", () => {
+  it("returns true for /foo and false for foo", () => {
+    expect(isSlashInput("/help")).toBe(true);
+    expect(isSlashInput("  /help")).toBe(true);
+    expect(isSlashInput("hello")).toBe(false);
+    expect(isSlashInput("")).toBe(false);
+  });
+});
+
+describe("runSlash — known commands", () => {
+  it("/help dispatches a synthetic user + reply with the command list", () => {
+    const out = runSlash("/help", { state: blankState() });
+    const userEv = out.events.find((e) => e.type === "user.submit");
+    expect(userEv && userEv.type === "user.submit" ? userEv.text : null).toBe("/help");
+    const chunkEvs = out.events.filter((e) => e.type === "streaming.chunk");
+    expect(chunkEvs.length).toBeGreaterThan(0);
+    const text = chunkEvs.map((e) => (e.type === "streaming.chunk" ? e.text : "")).join("");
+    expect(text).toContain("/help");
+    expect(text).toContain("/clear");
+    expect(text).toContain("/cost");
+    expect(out.exit).toBeFalsy();
+  });
+
+  it("/clear dispatches session.reset", () => {
+    const out = runSlash("/clear", { state: blankState() });
+    expect(out.events).toHaveLength(1);
+    expect(out.events[0]?.type).toBe("session.reset");
+  });
+
+  it("/cost shows the current usage in the reply text", () => {
+    const out = runSlash("/cost", { state: blankState() });
+    const text = out.events
+      .filter((e) => e.type === "streaming.chunk")
+      .map((e) => (e.type === "streaming.chunk" ? e.text : ""))
+      .join("");
+    expect(text).toContain("$0.00100");
+    expect(text).toContain("$0.00500");
+    expect(text).toContain("60%");
+  });
+
+  it("/exit returns exit:true with no dispatched events", () => {
+    const out = runSlash("/exit", { state: blankState() });
+    expect(out.exit).toBe(true);
+    expect(out.events).toHaveLength(0);
+  });
+
+  it("/new resets the session", () => {
+    const out = runSlash("/new", { state: blankState() });
+    expect(out.events.some((e) => e.type === "session.reset")).toBe(true);
+  });
+});
+
+describe("runSlash — unknown commands", () => {
+  it("dispatches an error live card", () => {
+    const out = runSlash("/banana", { state: blankState() });
+    const live = out.events.find((e) => e.type === "live.show");
+    if (live?.type !== "live.show") throw new Error("expected live.show");
+    expect(live.tone).toBe("err");
+    expect(live.text).toContain("/banana");
+  });
+});

--- a/tests/renderer/chat-v2.test.tsx
+++ b/tests/renderer/chat-v2.test.tsx
@@ -343,6 +343,88 @@ describe("chat-v2 shell — long-conversation overflow", () => {
   });
 });
 
+describe("chat-v2 shell — slash commands", () => {
+  it("/help renders the available commands inline without invoking runTurn", async () => {
+    const w = makeTestWriter();
+    const stdin = makeFakeStdin();
+    let runCount = 0;
+    const trackingRunTurn = makeCannedRunTurn((text, turn) => {
+      runCount++;
+      return instantReply(text, turn);
+    });
+    const handle = mount(
+      <AgentStoreProvider session={DEMO_SESSION}>
+        <ChatV2Shell onExit={() => {}} runTurn={trackingRunTurn} />
+      </AgentStoreProvider>,
+      {
+        viewportWidth: 80,
+        viewportHeight: 30,
+        pools: pools(),
+        write: w.write,
+        stdin,
+      },
+    );
+    await flush();
+    stdin.push("/help\r");
+    for (let i = 0; i < 30; i++) await flush();
+    expect(runCount).toBe(0);
+    const out = w.output();
+    expect(out).toContain("/help");
+    expect(out).toContain("/clear");
+    handle.destroy();
+  });
+
+  it("/exit invokes onExit", async () => {
+    const w = makeTestWriter();
+    const stdin = makeFakeStdin();
+    let exited = false;
+    const handle = mount(
+      <AgentStoreProvider session={DEMO_SESSION}>
+        <ChatV2Shell
+          onExit={() => {
+            exited = true;
+          }}
+          runTurn={instantRunTurn}
+        />
+      </AgentStoreProvider>,
+      {
+        viewportWidth: 60,
+        viewportHeight: 8,
+        pools: pools(),
+        write: w.write,
+        stdin,
+      },
+    );
+    await flush();
+    stdin.push("/exit\r");
+    await flush();
+    expect(exited).toBe(true);
+    handle.destroy();
+  });
+
+  it("unknown /command renders an error live card", async () => {
+    const w = makeTestWriter();
+    const stdin = makeFakeStdin();
+    const handle = mount(
+      <AgentStoreProvider session={DEMO_SESSION}>
+        <ChatV2Shell onExit={() => {}} runTurn={instantRunTurn} />
+      </AgentStoreProvider>,
+      {
+        viewportWidth: 80,
+        viewportHeight: 12,
+        pools: pools(),
+        write: w.write,
+        stdin,
+      },
+    );
+    await flush();
+    stdin.push("/banana\r");
+    for (let i = 0; i < 5; i++) await flush();
+    expect(w.output()).toMatch(/unknown command/);
+    handle.destroy();
+  });
+});
+
 describe("chat-v2 shell — exit", () => {
   it("Esc on the empty prompt invokes onExit", async () => {
     const w = makeTestWriter();


### PR DESCRIPTION
## Summary
- New pure handler module `src/cli/ui/chat-v2-slash.ts` with `/help`, `/clear`, `/cost`, `/new`, `/exit`. Each handler returns events to dispatch (synthetic user + canned reply, or a `session.reset`, or a `live.show` error) plus an optional exit flag.
- `ChatV2Shell.handleSubmit` detects a leading `/` and routes to the slash handler instead of running a turn.
- `/help` renders the command list as a regular streaming card so the markdown view picks up the formatting; `/cost` reads from agentStore state and shows current usage; `/clear` and `/new` both fire `session.reset`. Unknown commands surface as an `err` live card with the offending name.
- 10 new tests: 7 unit-level on the handler module + 3 integration through the chat-v2 shell (`/help` doesn't invoke runTurn, `/exit` triggers onExit, unknown commands render the error).

## Why
Issue #160 — Phase 5d-23d. Closes the `chat-v2` parity gap on slash commands at the basic-action level. Suggestion picker / arg picker / a richer command set are still deferred to later sub-stages before the final flip in 5d-23f.

## Test plan
- [x] `npm run verify` — 2243 tests pass (10 new), typecheck clean, lint warnings only (no errors)
- [x] Manual: `reasonix chat-v2`, type `/help`, command list renders; `/clear` empties cards; `/exit` exits cleanly
- [ ] Reviewer: confirm slash commands DON'T persist to the session transcript (they shouldn't — they're UI affordances, not user turns)