### PR TITLE
feat(renderer): inkCompat.render — Ink-shaped runtime over cell-diff (#160)

### DIFF
--- a/src/renderer/ink-compat/index.ts
+++ b/src/renderer/ink-compat/index.ts
@@ -7,3 +7,4 @@ export { type ColorName, bgCode, fgCode } from "./colors.js";
 export { type ViewportSize, ViewportContext, useStdout } from "./viewport.js";
 export { type AppApi, AppContext, useApp } from "./use-app.js";
 export { type InkInputHandler, type InkKey, type UseInputOptions, useInput } from "./use-input.js";
+export { type InkLikeInstance, type InkLikeRenderOptions, render } from "./render.js";

--- a/src/renderer/ink-compat/render.tsx
+++ b/src/renderer/ink-compat/render.tsx
@@ -1,0 +1,115 @@
+/** Ink-shaped render() that mounts a React tree on the cell-diff renderer. */
+
+import type { ReactNode } from "react";
+import { CharPool } from "../pools/char-pool.js";
+import { HyperlinkPool } from "../pools/hyperlink-pool.js";
+import { StylePool } from "../pools/style-pool.js";
+import { type Handle, mount } from "../reconciler/mount.js";
+
+export interface InkLikeRenderOptions {
+  readonly stdout?: NodeJS.WriteStream;
+  readonly stdin?: NodeJS.ReadStream;
+  readonly stderr?: NodeJS.WriteStream;
+  /** Default true. Listens for Ctrl+C on stdin and unmounts. */
+  readonly exitOnCtrlC?: boolean;
+  /** Ink had this; we don't patch console, so this option is accepted but ignored. */
+  readonly patchConsole?: boolean;
+}
+
+export interface InkLikeInstance {
+  rerender(element: ReactNode): void;
+  unmount(): void;
+  waitUntilExit(): Promise<void>;
+  cleanup(): void;
+  clear(): void;
+}
+
+export function render(element: ReactNode, opts: InkLikeRenderOptions = {}): InkLikeInstance {
+  const stdout = opts.stdout ?? process.stdout;
+  const stdin = opts.stdin ?? process.stdin;
+  const exitOnCtrlC = opts.exitOnCtrlC !== false;
+
+  const pools = {
+    char: new CharPool(),
+    style: new StylePool(),
+    hyperlink: new HyperlinkPool(),
+  };
+
+  let resolveExit: () => void = () => {};
+  let exitError: Error | undefined;
+  const exitPromise = new Promise<void>((resolve, reject) => {
+    resolveExit = () => {
+      if (exitError) reject(exitError);
+      else resolve();
+    };
+  });
+
+  let destroyed = false;
+  let handle: Handle | null = null;
+
+  const onResize = (): void => {
+    if (destroyed || !handle) return;
+    handle.resize(stdout.columns ?? 80, stdout.rows ?? 24);
+  };
+
+  const onCtrlCData = (chunk: Buffer | string): void => {
+    if (destroyed || !exitOnCtrlC) return;
+    const text = typeof chunk === "string" ? chunk : chunk.toString("utf8");
+    // Ctrl+C in raw mode is a literal \x03; outside raw mode the terminal turns
+    // it into SIGINT and we never see it here. Either path lands in unmount.
+    if (text.includes("\x03")) instance.unmount();
+  };
+
+  handle = mount(element, {
+    viewportWidth: stdout.columns ?? 80,
+    viewportHeight: stdout.rows ?? 24,
+    pools,
+    write: (bytes) => stdout.write(bytes),
+    stdin,
+    onExit: (err) => {
+      if (destroyed) return;
+      if (err) exitError = err;
+      // Tear down on app-driven exit (useApp().exit()).
+      instance.unmount();
+    },
+  });
+
+  stdout.on("resize", onResize);
+  stdin.on("data", onCtrlCData);
+
+  const sigintListener = (): void => {
+    if (!destroyed) instance.unmount();
+  };
+  if (exitOnCtrlC) process.on("SIGINT", sigintListener);
+
+  const instance: InkLikeInstance = {
+    rerender(next) {
+      if (destroyed || !handle) return;
+      handle.update(next);
+    },
+    unmount() {
+      if (destroyed) return;
+      destroyed = true;
+      stdout.off("resize", onResize);
+      stdin.off("data", onCtrlCData);
+      if (exitOnCtrlC) process.off("SIGINT", sigintListener);
+      handle?.destroy();
+      handle = null;
+      resolveExit();
+    },
+    waitUntilExit() {
+      return exitPromise;
+    },
+    cleanup() {
+      // Ink uses cleanup() to clear listeners without unmounting; for our renderer
+      // the listeners are bound to the handle's lifetime, so this is a no-op
+      // unless explicitly unmounting.
+    },
+    clear() {
+      if (destroyed) return;
+      stdout.write("\x1b[2J\x1b[H");
+    },
+  };
+
+  return instance;
+}

--- a/tests/renderer/ink-compat-render.test.tsx
+++ b/tests/renderer/ink-compat-render.test.tsx
@@ -1,0 +1,212 @@
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { Box, Text, render, useApp, useInput } from "../../src/renderer/ink-compat/index.js";
+
+interface FakeWriteStream {
+  columns: number;
+  rows: number;
+  isTTY: boolean;
+  write: (chunk: string) => boolean;
+  on: (event: "resize", cb: () => void) => void;
+  off: (event: "resize", cb: () => void) => void;
+  emit: (event: "resize") => void;
+  data: string[];
+}
+
+function makeFakeStdout(width = 60, height = 12): FakeWriteStream {
+  const listeners = new Set<() => void>();
+  const data: string[] = [];
+  return {
+    columns: width,
+    rows: height,
+    isTTY: true,
+    write(chunk) {
+      data.push(chunk);
+      return true;
+    },
+    on(_event, cb) {
+      listeners.add(cb);
+    },
+    off(_event, cb) {
+      listeners.delete(cb);
+    },
+    emit() {
+      for (const cb of listeners) cb();
+    },
+    data,
+  };
+}
+
+interface FakeStdin {
+  isTTY: boolean;
+  on: (event: "data", cb: (c: string | Buffer) => void) => void;
+  off: (event: "data", cb: (c: string | Buffer) => void) => void;
+  setRawMode: (raw: boolean) => void;
+  resume: () => void;
+  pause: () => void;
+  push: (s: string) => void;
+}
+
+function makeFakeStdin(): FakeStdin {
+  const listeners = new Set<(c: string | Buffer) => void>();
+  return {
+    isTTY: true,
+    on(_event, cb) {
+      listeners.add(cb);
+    },
+    off(_event, cb) {
+      listeners.delete(cb);
+    },
+    setRawMode() {},
+    resume() {},
+    pause() {},
+    push(s) {
+      for (const cb of listeners) cb(s);
+    },
+  };
+}
+
+function flush(): Promise<void> {
+  return new Promise((r) => setTimeout(r, 0));
+}
+
+describe("inkCompat.render — basic mount", () => {
+  it("renders a Box + Text tree", async () => {
+    const stdout = makeFakeStdout();
+    const stdin = makeFakeStdin();
+    const inst = render(
+      <Box flexDirection="column">
+        <Text>hello cell-diff</Text>
+      </Box>,
+      {
+        stdout: stdout as unknown as NodeJS.WriteStream,
+        stdin: stdin as unknown as NodeJS.ReadStream,
+      },
+    );
+    await flush();
+    const out = stdout.data.join("");
+    expect(out).toContain("hello cell-diff");
+    inst.unmount();
+    await inst.waitUntilExit();
+  });
+
+  it("waitUntilExit resolves only after unmount", async () => {
+    const stdout = makeFakeStdout();
+    const stdin = makeFakeStdin();
+    const inst = render(<Text>x</Text>, {
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+    });
+    let resolved = false;
+    const exit = inst.waitUntilExit().then(() => {
+      resolved = true;
+    });
+    await flush();
+    expect(resolved).toBe(false);
+    inst.unmount();
+    await exit;
+    expect(resolved).toBe(true);
+  });
+
+  it("rerender swaps the displayed text", async () => {
+    const stdout = makeFakeStdout();
+    const stdin = makeFakeStdin();
+    const inst = render(<Text>first</Text>, {
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+    });
+    await flush();
+    const before = stdout.data.length;
+    inst.rerender(<Text>second</Text>);
+    await flush();
+    const out = stdout.data.slice(before).join("");
+    expect(out).toContain("second");
+    inst.unmount();
+    await inst.waitUntilExit();
+  });
+});
+
+describe("inkCompat.render — Ctrl+C", () => {
+  it("Ctrl+C on stdin unmounts when exitOnCtrlC is on (default)", async () => {
+    const stdout = makeFakeStdout();
+    const stdin = makeFakeStdin();
+    const inst = render(<Text>busy</Text>, {
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+    });
+    await flush();
+    let resolved = false;
+    const exit = inst.waitUntilExit().then(() => {
+      resolved = true;
+    });
+    stdin.push("\x03");
+    await flush();
+    await exit;
+    expect(resolved).toBe(true);
+  });
+
+  it("exitOnCtrlC: false ignores Ctrl+C bytes", async () => {
+    const stdout = makeFakeStdout();
+    const stdin = makeFakeStdin();
+    const inst = render(<Text>busy</Text>, {
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      exitOnCtrlC: false,
+    });
+    await flush();
+    let resolved = false;
+    inst.waitUntilExit().then(() => {
+      resolved = true;
+    });
+    stdin.push("\x03");
+    await flush();
+    await flush();
+    expect(resolved).toBe(false);
+    inst.unmount();
+  });
+});
+
+describe("inkCompat.render — useApp().exit() integration", () => {
+  it("a child calling useApp().exit() drives waitUntilExit to completion", async () => {
+    const stdout = makeFakeStdout();
+    const stdin = makeFakeStdin();
+    function Bye(): React.ReactElement {
+      const { exit } = useApp();
+      React.useEffect(() => {
+        const id = setTimeout(() => exit(), 10);
+        return () => clearTimeout(id);
+      }, [exit]);
+      return <Text>about to exit</Text>;
+    }
+    const inst = render(<Bye />, {
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+    });
+    await inst.waitUntilExit();
+  });
+});
+
+describe("inkCompat.render — useInput is wired", () => {
+  it("typed bytes reach a useInput consumer inside the rendered tree", async () => {
+    const stdout = makeFakeStdout();
+    const stdin = makeFakeStdin();
+    let captured = "";
+    function Listener(): React.ReactElement {
+      useInput((input) => {
+        captured += input;
+      });
+      return <Text>x</Text>;
+    }
+    const inst = render(<Listener />, {
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+    });
+    await flush();
+    stdin.push("hi");
+    await flush();
+    expect(captured).toContain("h");
+    expect(captured).toContain("i");
+    inst.unmount();
+  });
+});


### PR DESCRIPTION
## Summary
- New `render(element, opts)` in `src/renderer/ink-compat/render.tsx` returns `{ rerender, unmount, waitUntilExit, cleanup, clear }` — the same Instance shape as Ink's `render`. Internally mounts through the cell-diff renderer's `mount()`.
- Wires resize, Ctrl+C handling (default-on, opt-out via `exitOnCtrlC: false`), and `useApp().exit()` integration so existing Ink-shaped apps drop in cleanly.
- 7 new tests: initial mount, `waitUntilExit` gating, `rerender`, Ctrl+C exit, `exitOnCtrlC: false`, `useApp().exit()`, `useInput` wiring.

## Why
Course correction for #160. The chat-v2 track was a parallel reimplementation of `chat`, which means duplicating thousands of lines of feature-rich UI (MCP, modal flows, dashboard, slash commands) before reaching parity. This PR is the foundation for an alternative path: a tsup alias that maps `ink` → `inkCompat` so the existing 3496-line `App.tsx` (and every UI file that imports from "ink") renders through the cell-diff renderer with **zero source changes**. The next PR wires the alias.

## Test plan
- [x] `npm run verify` — 2250 tests pass (7 new), typecheck clean, lint warnings only (no errors)
- [x] Manual: tests cover the Ink-shaped API surface (Box / Text / useApp / useInput / Ctrl+C / waitUntilExit)
- [ ] Reviewer: confirm the API shape matches Ink's `render` closely enough that existing call sites drop in