### PR TITLE
feat(build): tsup alias 'ink' → inkCompat — chat now runs on cell-diff (#160)

### DIFF
--- a/tests/bundle-smoke.test.ts
+++ b/tests/bundle-smoke.test.ts
@@ -44,6 +44,24 @@ describe("bundled dist — tokenizer path resolution", () => {
     },
   );
 
+  (cliExists ? it : it.skip)(
+    'dist/cli/index.js bundle has zero `from "ink"` imports — alias is live',
+    async () => {
+      const { readFileSync, readdirSync } = await import("node:fs");
+      const dir = resolve("dist/cli");
+      const files = readdirSync(dir).filter((f) => f.endsWith(".js"));
+      const offenders: string[] = [];
+      for (const f of files) {
+        const text = readFileSync(resolve(dir, f), "utf8");
+        // The CLI is bundled with `ink → inkCompat` aliased; any literal
+        // `from "ink"` left in the output means the alias failed and the
+        // package is still external.
+        if (/from\s*"ink"/.test(text)) offenders.push(f);
+      }
+      expect(offenders).toEqual([]);
+    },
+  );
+
   (cliExists ? it : it.skip)("dist/cli/index.js loads tokenizer before the first API fetch", () => {
     // Spawn the CLI pointed at a bogus local address that fails fetch
     // fast. In step(), preflight's estimateRequestTokens runs BEFORE

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,4 +1,13 @@
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "tsup";
+
+const here = fileURLToPath(new URL(".", import.meta.url));
+// Resolve "ink" imports inside the CLI bundle to our cell-diff renderer's
+// shim. The real "ink" package never makes it into dist/cli; everything that
+// imports Box / Text / Static / useApp / useInput / useStdout / render flows
+// through src/renderer/ink-compat. Library + dashboard bundles are unchanged.
+const inkCompatPath = resolve(here, "src/renderer/ink-compat/index.ts");
 
 export default defineConfig([
   {
@@ -19,6 +28,13 @@ export default defineConfig([
     target: "node22",
     outDir: "dist/cli",
     banner: { js: "#!/usr/bin/env node" },
+    // Force the CLI bundle to inline "ink" so the alias actually fires.
+    // Without noExternal, tsup keeps "ink" as a literal external import and
+    // node would resolve it to the real package at runtime.
+    noExternal: ["ink"],
+    esbuildOptions(options) {
+      options.alias = { ...(options.alias ?? {}), ink: inkCompatPath };
+    },
   },
   {
     entry: { app: "dashboard/app.js" },


### PR DESCRIPTION
## Summary
- Adds an esbuild alias on the CLI bundle that resolves every `import … from \"ink\"` to `src/renderer/ink-compat`. Combined with `noExternal: [\"ink\"]` the bundle inlines the shim instead of leaving `\"ink\"` as a runtime external.
- The 3496-line `App.tsx` and every UI file that imports `Box / Text / Static / useApp / useInput / useStdout / render` now flow through the cell-diff renderer with **zero source changes**.
- Library + dashboard bundles are unchanged.
- `bundle-smoke` gains an assertion that no `from \"ink\"` literal survives in `dist/cli/` — a future regression that breaks the alias fails CI.
- Doctor command runs end-to-end through the aliased path; help / version / non-interactive subcommands work.

## Why
Issue #160 — Phase 5d-23f. Course correction from the parallel chat-v2 rebuild track. Instead of duplicating thousands of lines of feature-rich UI to reach parity, this PR routes the entire existing `chat` command through the cell-diff renderer in one step. Every modal flow / slash command / dashboard / MCP / hook / session feature is preserved without touching App.tsx.

Tests still resolve the real \"ink\" package (vitest doesn't go through tsup), so unit tests stay on the existing path; the bundle test is the production-correctness check.

## Test plan
- [x] `npm run verify` — 2251 tests pass (1 new bundle-smoke assertion), typecheck clean, lint warnings only (no errors)
- [x] Manual: `node dist/cli/index.js doctor` runs cleanly; `--help` / `version` work; `dist/cli/index.js` contains zero `from \"ink\"` literals
- [ ] Reviewer: interactive `node dist/cli/index.js chat` smoke — confirm the chat surface renders, accepts input, exits cleanly. Layout edge cases (Yoga vs our flex) are the most likely break-points.