### PR TITLE
fix(mcp): close client on startup failure

### DIFF
--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -210,6 +210,7 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
     if (!tools) tools = new ToolRegistry();
     for (const raw of requestedSpecs) {
       let label = "anon";
+      let mcp: McpClient | undefined;
       try {
         const spec = parseMcpSpec(raw);
         label = spec.name ?? "anon";
@@ -230,7 +231,7 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
             : spec.transport === "streamable-http"
               ? new StreamableHttpTransport({ url: spec.url })
               : new StdioTransport({ command: spec.command, args: spec.args });
-        const mcp = new McpClient({ transport });
+        mcp = new McpClient({ transport });
         await mcp.initialize();
         // Host indirection lets `/mcp reconnect` swap the underlying client
         // without re-bridging the registered tools (closures resolve via
@@ -294,6 +295,7 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
         // kill a chat that has working servers configured. Recover by
         // recording the failure and continuing; user fixes via `reasonix
         // setup` without losing their other servers.
+        await mcp?.close().catch(() => undefined);
         const reason = (err as Error).message;
         failedSpecs.push({ spec: raw, reason });
         process.stderr.write(

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -88,6 +88,7 @@ export async function runCommand(opts: RunOptions): Promise<void> {
     tools = new ToolRegistry();
     for (const raw of requestedSpecs) {
       let label = "anon";
+      let mcp: McpClient | undefined;
       try {
         const spec = parseMcpSpec(raw);
         label = spec.name ?? "anon";
@@ -108,7 +109,7 @@ export async function runCommand(opts: RunOptions): Promise<void> {
             : spec.transport === "streamable-http"
               ? new StreamableHttpTransport({ url: spec.url })
               : new StdioTransport({ command: spec.command, args: spec.args });
-        const mcp = new McpClient({ transport });
+        mcp = new McpClient({ transport });
         await mcp.initialize();
         const bridge = await bridgeMcpTools(mcp, {
           registry: tools,
@@ -134,6 +135,7 @@ export async function runCommand(opts: RunOptions): Promise<void> {
         // one-shot `run` invocation with a broken MCP server otherwise
         // fails the whole run over a side-concern tool the task might
         // not even touch.
+        await mcp?.close().catch(() => undefined);
         process.stderr.write(
           `${formatMcpLifecycleEvent({ state: "failed", name: label, reason: (err as Error).message })}\n  → run \`reasonix setup\` to remove broken entries from your saved config.\n`,
         );

--- a/src/mcp/stdio.ts
+++ b/src/mcp/stdio.ts
@@ -115,7 +115,13 @@ export class StdioTransport implements McpTransport {
       /* already ended */
     }
     if (this.child.exitCode === null && !this.child.killed) {
-      this.child.kill("SIGTERM");
+      // child.kill("SIGTERM") throws EINVAL on Windows; plain kill()
+      // can also throw on failed spawns. Swallow both.
+      try {
+        this.child.kill(process.platform === "win32" ? undefined : "SIGTERM");
+      } catch {
+        /* already exited or unsignallable */
+      }
     }
   }
 

--- a/tests/mcp-stdio-close.test.ts
+++ b/tests/mcp-stdio-close.test.ts
@@ -1,0 +1,67 @@
+/** StdioTransport.close() must swallow child.kill() errors (e.g. EINVAL on Windows). */
+
+import type { ChildProcess } from "node:child_process";
+import { describe, expect, it } from "vitest";
+import { StdioTransport } from "../src/mcp/stdio.js";
+
+describe("StdioTransport.close()", () => {
+  it("swallows kill() EINVAL without throwing", async () => {
+    const t = new StdioTransport({
+      command: "node",
+      args: ["-e", "process.exit(0)"],
+      shell: false,
+    });
+    // Let child exit so .kill() hits a reaped/zombie-like state.
+    await new Promise((r) => setTimeout(r, 200));
+    await expect(t.close()).resolves.toBeUndefined();
+  });
+
+  it("does not throw on failed spawn", async () => {
+    const t = new StdioTransport({
+      command: "nonexistent_command_that_does_not_exist_12345",
+      shell: false,
+    });
+    const iter = t.messages();
+    const msg = await iter[Symbol.asyncIterator]().next();
+    expect(msg.value?.error?.code).toBe(-32000);
+    await expect(t.close()).resolves.toBeUndefined();
+  });
+
+  it("is idempotent — second close() is a no-op", async () => {
+    const t = new StdioTransport({
+      command: "node",
+      args: ["-e", "setTimeout(() => {}, 5000)"],
+      shell: false,
+    });
+    await t.close();
+    await expect(t.close()).resolves.toBeUndefined();
+  });
+
+  it("swallows kill() EINVAL via monkey-patch", async () => {
+    const t = new StdioTransport({
+      command: "node",
+      args: ["-e", "setTimeout(() => {}, 5000)"],
+      shell: false,
+    });
+    const child = (t as unknown as { child: ChildProcess }).child;
+    const originalKill = child.kill.bind(child);
+    let killCalled = false;
+    // Force EINVAL to verify the catch path works.
+    child.kill = (signal?: NodeJS.Signals | number) => {
+      killCalled = true;
+      if (signal === "SIGTERM") {
+        const err = new Error("kill EINVAL");
+        (err as NodeJS.ErrnoException).code = "EINVAL";
+        throw err;
+      }
+      return originalKill(signal);
+    };
+    await expect(t.close()).resolves.toBeUndefined();
+    expect(killCalled).toBe(true);
+    try {
+      if (!child.killed) child.kill();
+    } catch {
+      /* already dead */
+    }
+  });
+});


### PR DESCRIPTION
## What

Closes a partially-created MCP client when server startup fails in `chat`, `run`, or `code`.

`code` goes through the same chat startup flow after registering its native tools, so this cleanup gap applies there as well.

This also makes stdio transport cleanup best-effort for Windows and failed-startup paths.

Closes #215.

## Why

MCP startup failures are intentionally non-fatal: Reasonix should report the broken server and keep going when it can. But if the client had already been constructed before startup failed, it was not yet in the normal cleanup list.

That left a small gap where the child process/read loop could stay alive after the server had already been marked failed.

## How to verify

```sh
npm run verify
```

Added regression coverage for `StdioTransport.close()` handling:

- fast child exit
- failed spawn
- idempotent close
- thrown process-shutdown errors

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time
