### PR TITLE
feat(cards): migrate ReasoningCard + StreamingCard (#160)

### DIFF
--- a/src/cli/ui/cards/ErrorCard.tsx
+++ b/src/cli/ui/cards/ErrorCard.tsx
@@ -1,53 +1,56 @@
 import { Box, Text } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React from "react";
-import { BarRow } from "../primitives/BarRow.js";
 import type { ErrorCard as ErrorCardData } from "../state/cards.js";
-import { CARD, FG } from "../theme/tokens.js";
-import { CardHeader } from "./CardHeader.js";
+import { FG, TONE } from "../theme/tokens.js";
 
 const STACK_TAIL = 5;
 
 export function ErrorCard({ card }: { card: ErrorCardData }): React.ReactElement {
-  const meta =
+  const retryNote =
     card.retries !== undefined && card.retries > 0
       ? `· ${card.retries} retr${card.retries === 1 ? "y" : "ies"}`
-      : undefined;
+      : null;
   const stackLines = card.stack ? card.stack.split("\n") : [];
   const stackTrunc = stackLines.length > STACK_TAIL;
   const stackVisible = stackTrunc ? stackLines.slice(-STACK_TAIL) : stackLines;
   const stackHidden = stackTrunc ? stackLines.length - stackVisible.length : 0;
   const hasStack = stackVisible.length > 0;
+  const messageLines = card.message.split("\n");
 
   return (
-    <Box flexDirection="column">
-      <CardHeader tone="error" glyph="✖" title="Error" subtitle={card.title} meta={meta} />
-      <BarRow tone="error" indent={0} />
-      {card.message.split("\n").map((line, i) => (
-        <BarRow key={`${card.id}:msg:${i}`} tone="error">
-          <Text color={CARD.error.color}>{line}</Text>
-        </BarRow>
+    <Box flexDirection="column" marginTop={1}>
+      <Box flexDirection="row" gap={1}>
+        <Text color={TONE.err}>✖</Text>
+        <Text color={TONE.err} bold>
+          {card.title || "error"}
+        </Text>
+        {retryNote ? <Text color={FG.faint}>{retryNote}</Text> : null}
+      </Box>
+      {messageLines.map((line, i) => (
+        <Box key={`${card.id}:msg:${i}`} paddingLeft={2}>
+          <Text color={TONE.err}>{line || " "}</Text>
+        </Box>
       ))}
-      {hasStack && (
+      {hasStack ? (
         <>
-          <BarRow tone="error" indent={0} />
-          <BarRow tone="error">
-            <Text color={FG.meta}>{"stack trace"}</Text>
-          </BarRow>
-          {stackHidden > 0 && (
-            <BarRow tone="error">
+          <Box paddingLeft={2} marginTop={1}>
+            <Text color={FG.meta}>stack trace</Text>
+          </Box>
+          {stackHidden > 0 ? (
+            <Box paddingLeft={2}>
               <Text color={FG.faint}>
                 {`⋮ ${stackHidden} earlier stack line${stackHidden === 1 ? "" : "s"} hidden`}
               </Text>
-            </BarRow>
-          )}
+            </Box>
+          ) : null}
           {stackVisible.map((line, i) => (
-            <BarRow key={`${card.id}:stk:${stackHidden + i}`} tone="error">
-              <Text color={FG.meta}>{line}</Text>
-            </BarRow>
+            <Box key={`${card.id}:stk:${stackHidden + i}`} paddingLeft={2}>
+              <Text color={FG.meta}>{line || " "}</Text>
+            </Box>
           ))}
         </>
-      )}
+      ) : null}
     </Box>
   );
 }

--- a/src/cli/ui/cards/ReasoningCard.tsx
+++ b/src/cli/ui/cards/ReasoningCard.tsx
@@ -3,18 +3,15 @@ import { Box, Text, useStdout } from "ink";
 import React from "react";
 import { clipToCells, wrapToCells } from "../../../frame/width.js";
 import { CursorBlock } from "../primitives/BarRow.js";
-import { CardBox } from "../primitives/CardBox.js";
-import { PILL_MODEL, PILL_SECTION, Pill, modelBadgeFor } from "../primitives/Pill.js";
 import { Spinner } from "../primitives/Spinner.js";
 import type { ReasoningCard as ReasoningCardData } from "../state/cards.js";
-import { CARD, FG } from "../theme/tokens.js";
+import { FG, TONE } from "../theme/tokens.js";
 
-/** Streaming live region stays at this many rows so Ink's eraseLines can't miscount enough to flicker. Full body lands in scrollback once the card settles. */
+/** Streaming preview tail length — wide enough to feel responsive, small enough not to thrash on every chunk. Full body lives in the events log. */
 const STREAMING_PREVIEW_LINES = 4;
-/** Settled reasoning collapses to tail-only — once the model is done thinking, the conclusion is the actionable signal; the rest is in the events log via `/reasoning last`. */
+/** Once settled, only the conclusion is actionable; the rest is in `/reasoning last`. */
 const SETTLED_TAIL_LINES = 2;
-const HEADER_PAD = 1;
-const BODY_PAD = 4;
+const BODY_PAD = 2;
 
 export function ReasoningCard({
   card,
@@ -29,56 +26,44 @@ export function ReasoningCard({
 
   const allLines = card.text.length > 0 ? card.text.split("\n") : [];
   const showBody = expanded && (allLines.length > 0 || card.streaming);
-  const barColor = card.streaming ? CARD.reasoning.color : FG.faint;
 
   return (
-    <CardBox color={barColor}>
+    <Box flexDirection="column" marginTop={1}>
       <ReasoningHeader card={card} />
-      {showBody && (
-        <>
-          <Box height={1} />
-          {card.streaming ? (
-            <StreamingPreview card={card} allLines={allLines} lineCells={lineCells} />
-          ) : (
-            <SettledPreview card={card} allLines={allLines} lineCells={lineCells} />
-          )}
-        </>
-      )}
-    </CardBox>
+      {showBody &&
+        (card.streaming ? (
+          <StreamingPreview card={card} allLines={allLines} lineCells={lineCells} />
+        ) : (
+          <SettledPreview card={card} allLines={allLines} lineCells={lineCells} />
+        ))}
+    </Box>
   );
 }
 
 function ReasoningHeader({ card }: { card: ReasoningCardData }): React.ReactElement {
-  const badge = modelBadgeFor(card.model);
-  const mdl = PILL_MODEL[badge.kind];
-  const sec = PILL_SECTION.reason;
+  const streamingActive = card.streaming && !card.aborted;
+  const headColor = card.aborted ? TONE.err : streamingActive ? TONE.accent : TONE.accent;
+  const glyph = streamingActive ? "◇" : "◆";
   const meta = headerMeta(card);
   const duration = headerDuration(card);
   return (
-    <Box paddingLeft={HEADER_PAD} flexDirection="row">
-      <Pill label="REASONING" bg={sec.bg} fg={sec.fg} />
-      <Text>{"  "}</Text>
-      <Pill label={badge.label} bg={mdl.bg} fg={mdl.fg} />
-      {meta && (
-        <>
-          <Text>{"  "}</Text>
-          <Text color={FG.faint}>{meta}</Text>
-        </>
-      )}
-      <Box flexGrow={1} />
-      {card.streaming && !card.aborted && (
-        <>
-          <Spinner kind="braille" color={CARD.reasoning.color} />
-          <Text color={CARD.reasoning.color}>{" thinking…"}</Text>
-        </>
-      )}
-      {duration && <Text color={FG.faint}>{duration}</Text>}
+    <Box flexDirection="row" gap={1}>
+      <Text color={headColor}>{glyph}</Text>
+      <Text color={headColor} bold>
+        {streamingActive ? "reasoning…" : card.aborted ? "reasoning (aborted)" : "reasoning"}
+      </Text>
+      {meta ? <Text color={FG.faint}>{`· ${meta}`}</Text> : null}
+      {duration ? <Text color={FG.faint}>{`· ${duration}`}</Text> : null}
+      {streamingActive ? (
+        <Box flexDirection="row">
+          <Spinner kind="braille" color={TONE.accent} />
+        </Box>
+      ) : null}
     </Box>
   );
 }
 
 function headerMeta(card: ReasoningCardData): string {
-  if (card.aborted) return "aborted";
   if (card.streaming) {
     return card.tokens > 0 ? `${card.tokens.toLocaleString()} tok` : "";
   }
@@ -112,7 +97,7 @@ function SettledPreview({ card, allLines, lineCells }: BodyProps): React.ReactEl
   const droppedLines = Math.max(0, visualLines.length - visible.length);
   return (
     <>
-      {droppedLines > 0 && <ElisionHint droppedLines={droppedLines} card={card} />}
+      {droppedLines > 0 ? <ElisionHint droppedLines={droppedLines} card={card} /> : null}
       <BodyLines card={card} lines={visible} lineCells={lineCells} indexOffset={droppedLines} />
     </>
   );

--- a/src/cli/ui/cards/StreamingCard.tsx
+++ b/src/cli/ui/cards/StreamingCard.tsx
@@ -4,21 +4,17 @@ import React from "react";
 import { clipToCells, wrapToCells } from "../../../frame/width.js";
 import { useReserveRows } from "../layout/viewport-budget.js";
 import { Markdown } from "../markdown.js";
-import { CardBox } from "../primitives/CardBox.js";
-import { PILL_MODEL, PILL_SECTION, Pill, modelBadgeFor } from "../primitives/Pill.js";
 import { Spinner } from "../primitives/Spinner.js";
 import type { StreamingCard as StreamingCardData } from "../state/cards.js";
-import { CARD, FG, TONE } from "../theme/tokens.js";
+import { FG, TONE } from "../theme/tokens.js";
 
-const HEADER_PAD = 1;
-const BODY_PAD = 4;
-/** Streaming live region stays at this many rows so Ink's eraseLines can't miscount enough to flicker. Full body lands in scrollback once the card settles. */
+const BODY_PAD = 2;
+/** Streaming preview tail length — bounded live region so chunks don't thrash whole-card layout. */
 const STREAMING_PREVIEW_LINES = 4;
 
 export function StreamingCard({ card }: { card: StreamingCardData }): React.ReactElement {
   const { stdout } = useStdout();
   const cols = stdout?.columns ?? 80;
-  // Claim before the done-state branch — hook order must stay stable across the done flip.
   useReserveRows("stream", {
     min: STREAMING_PREVIEW_LINES + 1,
     max: STREAMING_PREVIEW_LINES + 2,
@@ -26,59 +22,56 @@ export function StreamingCard({ card }: { card: StreamingCardData }): React.Reac
 
   if (card.done && !card.aborted) {
     return (
-      <CardBox color={CARD.streaming.color}>
+      <Box flexDirection="column" marginTop={1}>
+        <Box flexDirection="row" gap={1}>
+          <Text color={TONE.ok}>‹</Text>
+          <Text color={TONE.ok} bold>
+            reply
+          </Text>
+        </Box>
         <Box paddingLeft={BODY_PAD} flexDirection="column">
           <Markdown text={card.text} />
         </Box>
-      </CardBox>
+      </Box>
     );
   }
+
   const lineCells = Math.max(20, cols - BODY_PAD - 4);
   const allLines = card.text.length > 0 ? card.text.split("\n") : [""];
   const visualLines = allLines.flatMap((l) => wrapToCells(l, lineCells));
   const visible = visualLines.slice(-STREAMING_PREVIEW_LINES);
+  const aborted = !!card.aborted;
+  const headColor = aborted ? TONE.err : TONE.brand;
+  const glyph = aborted ? "‹" : "▸";
+  const headLabel = aborted ? "aborted" : "writing…";
 
   return (
-    <CardBox color={card.aborted ? FG.faint : CARD.streaming.color}>
-      {!card.aborted && <StreamingHeader card={card} />}
-      {card.aborted && (
-        <Box paddingLeft={HEADER_PAD} flexDirection="row">
-          <Text color={FG.faint} bold>
-            — aborted —
-          </Text>
-          <Text color={TONE.warn}>{"   stopped"}</Text>
-        </Box>
-      )}
+    <Box flexDirection="column" marginTop={1}>
+      <Box flexDirection="row" gap={1}>
+        <Text color={headColor}>{glyph}</Text>
+        <Text color={headColor} bold>
+          {headLabel}
+        </Text>
+        {aborted ? null : (
+          <Box flexDirection="row">
+            <Spinner kind="braille" color={TONE.brand} />
+          </Box>
+        )}
+      </Box>
       {visible.map((line, i) => (
         <Box
           key={`${card.id}:${allLines.length - visible.length + i}`}
           paddingLeft={BODY_PAD}
           flexDirection="row"
         >
-          <Text color={card.aborted ? FG.meta : FG.body}>{clipToCells(line, lineCells)}</Text>
+          <Text color={aborted ? FG.meta : FG.body}>{clipToCells(line, lineCells)}</Text>
         </Box>
       ))}
-      {card.aborted && (
+      {aborted ? (
         <Box paddingLeft={BODY_PAD}>
-          <Text color={FG.faint}>{"[truncated by esc]"}</Text>
+          <Text color={FG.faint}>[truncated by esc]</Text>
         </Box>
-      )}
-    </CardBox>
-  );
-}
-
-function StreamingHeader({ card }: { card: StreamingCardData }): React.ReactElement {
-  const badge = modelBadgeFor(card.model);
-  const mdl = PILL_MODEL[badge.kind];
-  const sec = PILL_SECTION.output;
-  return (
-    <Box paddingLeft={HEADER_PAD} flexDirection="row">
-      <Pill label="OUTPUT" bg={sec.bg} fg={sec.fg} />
-      <Text>{"  "}</Text>
-      <Pill label={badge.label} bg={mdl.bg} fg={mdl.fg} />
-      <Box flexGrow={1} />
-      <Spinner kind="braille" color={CARD.streaming.color} />
-      <Text color={CARD.streaming.color}>{" writing…"}</Text>
+      ) : null}
     </Box>
   );
 }

--- a/src/cli/ui/cards/WarnCard.tsx
+++ b/src/cli/ui/cards/WarnCard.tsx
@@ -1,31 +1,25 @@
 import { Box, Text } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React from "react";
-import { BarRow } from "../primitives/BarRow.js";
 import type { WarnCard as WarnCardData } from "../state/cards.js";
-import { FG } from "../theme/tokens.js";
-import { CardHeader } from "./CardHeader.js";
+import { FG, TONE } from "../theme/tokens.js";
 
 export function WarnCard({ card }: { card: WarnCardData }): React.ReactElement {
-  const showBody = card.message.length > 0;
+  const messageLines = card.message.length > 0 ? card.message.split("\n") : [];
   return (
-    <Box flexDirection="column">
-      <CardHeader
-        tone="warn"
-        glyph="⚠"
-        title={card.title}
-        meta={card.detail ? `· ${card.detail}` : undefined}
-      />
-      {showBody && (
-        <>
-          <BarRow tone="warn" indent={0} />
-          {card.message.split("\n").map((line, i) => (
-            <BarRow key={`${card.id}:${i}`} tone="warn">
-              <Text color={FG.body}>{line}</Text>
-            </BarRow>
-          ))}
-        </>
-      )}
+    <Box flexDirection="column" marginTop={1}>
+      <Box flexDirection="row" gap={1}>
+        <Text color={TONE.warn}>⚠</Text>
+        <Text color={TONE.warn} bold>
+          {card.title}
+        </Text>
+        {card.detail ? <Text color={FG.faint}>{`· ${card.detail}`}</Text> : null}
+      </Box>
+      {messageLines.map((line, i) => (
+        <Box key={`${card.id}:${i}`} paddingLeft={2}>
+          <Text color={FG.body}>{line || " "}</Text>
+        </Box>
+      ))}
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
The two cards every assistant turn renders. Drops `CardBox` + `Pill` chrome; adopts the card-demo glyph + bold-title pattern.

**ReasoningCard**
- Streaming: `◇ reasoning… · 234 tok ⠋` + italic preview tail (4 lines)
- Settled:   `◆ reasoning · 234 tok · 3¶ · 2.1s` + tail (2 lines) + `⋯ N lines · M tok above · /reasoning last`
- Aborted:   `◇ reasoning (aborted)` in red

**StreamingCard**
- Streaming: `▸ writing… ⠋` + clipped preview tail (4 lines)
- Done:      `‹ reply` + full markdown body indented 2
- Aborted:   `‹ aborted` (red) + clipped tail + `[truncated by esc]`

Spinner stays during streaming — liveness signal is real UX value, the cell-diff renderer ticks it cheaply (single cell update per frame).

## Test plan
- [x] `npm run verify` — 2251 pass, typecheck clean
- [x] Manual: `chat`, ask a question — see ◇/◆ reasoning header transitions cleanly to ▸/‹ reply
- [ ] Reviewer: confirm the Pills (REASONING / OUTPUT / model badge) being gone is the desired direction; if you want a model-name hint, easy to add as a faint trailing meta