### PR TITLE
feat(cards): migrate ToolCard (#160)

### DIFF
--- a/src/cli/ui/cards/ToolCard.tsx
+++ b/src/cli/ui/cards/ToolCard.tsx
@@ -2,15 +2,13 @@ import { Box, Text, useStdout } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React from "react";
 import { clipToCells } from "../../../frame/width.js";
-import { BarRow } from "../primitives/BarRow.js";
 import { Spinner } from "../primitives/Spinner.js";
 import type { ToolCard as ToolCardData } from "../state/cards.js";
-import { CARD, FG, TONE } from "../theme/tokens.js";
-import { CardHeader } from "./CardHeader.js";
+import { FG, TONE } from "../theme/tokens.js";
 
 const READ_TAIL = 2;
 const OTHER_TAIL = 5;
-const BODY_INDENT_CELLS = 7;
+const BODY_PAD = 2;
 
 /** Read-style tools dump file/list bodies — short tail is enough; the model already has the full text in context. */
 function tailLinesFor(name: string): number {
@@ -24,48 +22,58 @@ function tailLinesFor(name: string): number {
 export function ToolCard({ card }: { card: ToolCardData }): React.ReactElement {
   const { stdout } = useStdout();
   const cols = stdout?.columns ?? 80;
-  const lineCells = Math.max(20, cols - BODY_INDENT_CELLS - 1);
+  const lineCells = Math.max(20, cols - BODY_PAD - 4);
   const argsLabel = formatArgsSummary(card.args);
-  const meta = formatMeta(card);
   const allLines = card.output.length > 0 ? card.output.split("\n") : [];
   const tail = tailLinesFor(card.name);
   const truncated = allLines.length > tail;
   const visible = truncated ? allLines.slice(-tail) : allLines;
   const hidden = truncated ? allLines.length - visible.length : 0;
-  const errColor = card.exitCode && card.exitCode !== 0 ? CARD.error.color : FG.sub;
+  const status = toolStatus(card);
+  const headColor = headerColorFor(status);
+  const errColor = card.exitCode && card.exitCode !== 0 ? TONE.err : FG.sub;
   // Rejected calls show a single trailing badge — the verbose JSON error body
   // is already conveyed by the badge, so dropping the body keeps the card tight.
   const showBody = !card.rejected && visible.length > 0;
 
   return (
-    <Box flexDirection="column">
-      <CardHeader
-        tone="tool"
-        glyph="▣"
-        title={card.name}
-        subtitle={argsLabel || undefined}
-        meta={meta || undefined}
-        inline={
-          !card.done && !card.rejected ? (
-            <Spinner kind="braille" color={CARD.tool.color} bold />
-          ) : undefined
-        }
-        trailing={trailingBadge(card)}
-      />
+    <Box flexDirection="column" marginTop={1}>
+      <Box flexDirection="row" gap={1}>
+        <Text color={headColor}>{statusGlyph(status)}</Text>
+        <Text color={headColor} bold>
+          {card.name}
+        </Text>
+        {argsLabel ? <Text color={FG.faint}>{argsLabel}</Text> : null}
+        {card.retry ? (
+          <Text color={TONE.warn} bold>{`↻ ${card.retry.attempt}/${card.retry.max}`}</Text>
+        ) : null}
+        {card.rejected ? (
+          <Text color={TONE.err} bold>
+            rejected
+          </Text>
+        ) : null}
+        <Text color={FG.faint}>{metaTrail(card)}</Text>
+        {status === "running" ? (
+          <Box flexDirection="row">
+            <Spinner kind="braille" color={TONE.brand} bold />
+          </Box>
+        ) : null}
+      </Box>
       {showBody && (
         <>
-          <BarRow tone="tool" indent={0} />
-          {hidden > 0 && (
-            <BarRow tone="tool">
+          {hidden > 0 ? (
+            <Box paddingLeft={BODY_PAD}>
               <Text color={FG.faint}>
                 {`⋮ ${hidden} earlier line${hidden === 1 ? "" : "s"} (use /tool to read full)`}
               </Text>
-            </BarRow>
-          )}
+            </Box>
+          ) : null}
           {visible.map((line, i) => (
-            <BarRow key={`${card.id}:${hidden + i}`} tone="tool">
-              <Text color={errColor}>{clipToCells(line, lineCells)}</Text>
-            </BarRow>
+            <Box key={`${card.id}:${hidden + i}`} paddingLeft={BODY_PAD}>
+              <Text color={errColor} dimColor={!card.exitCode || card.exitCode === 0}>
+                {clipToCells(line, lineCells) || " "}
+              </Text>
+            </Box>
           ))}
         </>
       )}
@@ -73,18 +81,59 @@ export function ToolCard({ card }: { card: ToolCardData }): React.ReactElement {
   );
 }
 
-function trailingBadge(card: ToolCardData): React.ReactNode {
-  if (card.rejected) {
-    return (
-      <Text color={CARD.error.color} bold>
-        ✗ rejected
-      </Text>
-    );
+type ToolStatus = "running" | "ok" | "rejected" | "error" | "aborted";
+
+function toolStatus(card: ToolCardData): ToolStatus {
+  if (card.rejected) return "rejected";
+  if (card.aborted) return "aborted";
+  if (!card.done) return "running";
+  if (card.exitCode !== undefined && card.exitCode !== 0) return "error";
+  return "ok";
+}
+
+function statusGlyph(s: ToolStatus): string {
+  switch (s) {
+    case "running":
+      return "▢";
+    case "ok":
+      return "✓";
+    case "rejected":
+      return "✗";
+    case "error":
+      return "✖";
+    case "aborted":
+      return "⊘";
   }
-  if (card.retry) {
-    return <Text color={TONE.warn} bold>{`↻ retry ${card.retry.attempt}/${card.retry.max}`}</Text>;
+}
+
+function headerColorFor(s: ToolStatus): string {
+  switch (s) {
+    case "ok":
+      return TONE.ok;
+    case "rejected":
+    case "error":
+    case "aborted":
+      return TONE.err;
+    case "running":
+      return TONE.brand;
   }
-  return undefined;
+}
+
+function metaTrail(card: ToolCardData): string {
+  const parts: string[] = [];
+  const inputBytes = largestStringInputBytes(card.args);
+  if (inputBytes !== null) parts.push(`${formatBytes(inputBytes)} in`);
+  if (card.elapsedMs > 0) parts.push(`${(card.elapsedMs / 1000).toFixed(2)}s`);
+  if (
+    card.done &&
+    !card.rejected &&
+    !card.aborted &&
+    card.exitCode !== undefined &&
+    card.exitCode !== 0
+  ) {
+    parts.push(`exit ${card.exitCode}`);
+  }
+  return parts.length > 0 ? `· ${parts.join(" · ")}` : "";
 }
 
 function formatArgsSummary(args: unknown): string {
@@ -101,24 +150,6 @@ function formatArgsSummary(args: unknown): string {
     return keys.join(" ");
   }
   return "";
-}
-
-function formatMeta(card: ToolCardData): string {
-  const parts: string[] = [];
-  const inputBytes = largestStringInputBytes(card.args);
-  if (inputBytes !== null) parts.push(`${formatBytes(inputBytes)} in`);
-  if (card.elapsedMs > 0) parts.push(`${(card.elapsedMs / 1000).toFixed(2)}s`);
-  if (card.rejected) {
-    // Trailing badge carries the status; meta stays clean (no "exit N").
-  } else if (card.aborted) {
-    parts.push("aborted");
-  } else if (card.done) {
-    if (card.exitCode === 0) parts.push("exit 0");
-    else if (card.exitCode !== undefined) parts.push(`exit ${card.exitCode}`);
-  } else {
-    parts.push("running");
-  }
-  return parts.length > 0 ? `· ${parts.join(" · ")}` : "";
 }
 
 const INPUT_SIZE_THRESHOLD = 1024;


### PR DESCRIPTION
## Summary
ToolCard's turn in the visual sweep. Drops CardHeader / BarRow / CardBox; the header collapses to one row.

**Before**
```
▎ ▣ shell  · ls -la · ↻ retry 1/3 · 12 KB in · 0.34s · running
▎
▎ src/
▎ tests/
▎ ...
```

**After**
```
▢ shell  ls -la  ↻ 1/3  · 12 KB in · 0.34s  ⠋
  src/
  tests/
  ...
```

Status glyphs:
- `▢` running (with ⠋ braille spinner trailing)
- `✓` ok
- `✗` rejected
- `✖` error (exit ≠ 0)
- `⊘` aborted

Retry / rejected badges live inline in the header. Long output keeps the `⋮ N earlier lines (use /tool to read full)` elision. Exit-code ≠ 0 output renders in error red; OK output dims.

## Test plan
- [x] `npm run verify` — 2251 pass, typecheck clean
- [x] Manual: `chat` running a tool shows the new tight one-line header