### PR TITLE
feat(cards): migrate PlanCard + TaskCard (#160)

### DIFF
--- a/src/cli/ui/cards/PlanCard.tsx
+++ b/src/cli/ui/cards/PlanCard.tsx
@@ -1,13 +1,11 @@
 import { Box, Text } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React from "react";
-import { BarRow } from "../primitives/BarRow.js";
 import type { PlanCard as PlanCardData, PlanStep } from "../state/cards.js";
 import { FG, TONE } from "../theme/tokens.js";
-import { CardHeader } from "./CardHeader.js";
 
 const STATUS_GLYPH: Record<PlanStep["status"], string> = {
-  queued: " ",
+  queued: "○",
   running: "▶",
   done: "✓",
   failed: "✗",
@@ -27,24 +25,29 @@ const STATUS_COLOR: Record<PlanStep["status"], string> = {
 export function PlanCard({ card }: { card: PlanCardData }): React.ReactElement {
   const doneCount = card.steps.filter((s) => s.status === "done").length;
   const variantTag =
-    card.variant === "resumed" ? " · resumed" : card.variant === "replay" ? " · ⏪ archive" : "";
-  const meta = `${variantTag}  · ${doneCount} of ${card.steps.length} done`;
+    card.variant === "resumed" ? "resumed · " : card.variant === "replay" ? "⏪ archive · " : "";
+  const progress = `${variantTag}${doneCount}/${card.steps.length} done`;
 
   return (
-    <Box flexDirection="column">
-      <CardHeader tone="plan" glyph="⊞" title={card.title} meta={meta} />
-      <BarRow tone="plan" indent={0} />
+    <Box flexDirection="column" marginTop={1}>
+      <Box flexDirection="row" gap={1}>
+        <Text color={TONE.accent}>⊞</Text>
+        <Text color={TONE.accent} bold>
+          {card.title}
+        </Text>
+        <Text color={FG.faint}>{`· ${progress}`}</Text>
+      </Box>
       {card.steps.map((step, i) => {
         const isActive = step.status === "running";
         const titleColor = isActive ? FG.strong : FG.sub;
         return (
-          <BarRow key={step.id} tone="plan">
-            <Text color={STATUS_COLOR[step.status]}>{`[${STATUS_GLYPH[step.status]}]`}</Text>
+          <Box key={step.id} paddingLeft={2} flexDirection="row" gap={1}>
+            <Text color={STATUS_COLOR[step.status]}>{STATUS_GLYPH[step.status]}</Text>
             <Text bold={isActive} color={titleColor}>
-              {` ${i + 1}. ${step.title}`}
+              {`${i + 1}. ${step.title}`}
             </Text>
-            {isActive && <Text color={TONE.brand}>{"      ←  in progress"}</Text>}
-          </BarRow>
+            {isActive ? <Text color={TONE.brand}>← in progress</Text> : null}
+          </Box>
         );
       })}
     </Box>

--- a/src/cli/ui/cards/TaskCard.tsx
+++ b/src/cli/ui/cards/TaskCard.tsx
@@ -1,10 +1,8 @@
 import { Box, Text } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React from "react";
-import { BarRow } from "../primitives/BarRow.js";
 import type { TaskCard as TaskCardData, TaskStep } from "../state/cards.js";
-import { CARD, FG, TONE } from "../theme/tokens.js";
-import { CardHeader } from "./CardHeader.js";
+import { FG, TONE } from "../theme/tokens.js";
 
 const STEP_GLYPH: Record<TaskStep["status"], string> = {
   queued: "○",
@@ -21,7 +19,7 @@ const STEP_COLOR: Record<TaskStep["status"], string> = {
 };
 
 const TASK_COLOR: Record<TaskCardData["status"], string> = {
-  running: CARD.task.color,
+  running: TONE.brand,
   done: TONE.ok,
   failed: TONE.err,
 };
@@ -34,33 +32,29 @@ const TASK_GLYPH: Record<TaskCardData["status"], string> = {
 
 export function TaskCard({ card }: { card: TaskCardData }): React.ReactElement {
   const elapsed = `${(card.elapsedMs / 1000).toFixed(1)}s`;
-  const showSteps = card.steps.length > 0;
   return (
-    <Box flexDirection="column">
-      <CardHeader
-        tone="task"
-        glyph={TASK_GLYPH[card.status]}
-        title={`Step ${card.index} of ${card.total} · ${card.title}`}
-        meta={`${elapsed} ·`}
-        trailing={<Text color={TASK_COLOR[card.status]}>{card.status}</Text>}
-        barColor={TASK_COLOR[card.status]}
-      />
-      {showSteps && (
-        <>
-          <BarRow tone="task" indent={0} />
-          {card.steps.map((step) => (
-            <BarRow key={step.id} tone="task">
-              <Text color={STEP_COLOR[step.status]}>{STEP_GLYPH[step.status]}</Text>
-              <Text bold color={FG.body}>{`  ${(step.toolName ?? "step").padEnd(7)} `}</Text>
-              <Text color={FG.sub}>{step.title}</Text>
-              {step.detail && <Text color={FG.faint}>{`  ${step.detail}`}</Text>}
-              {step.elapsedMs !== undefined && (
-                <Text color={FG.faint}>{`  ${(step.elapsedMs / 1000).toFixed(2)}s`}</Text>
-              )}
-            </BarRow>
-          ))}
-        </>
-      )}
+    <Box flexDirection="column" marginTop={1}>
+      <Box flexDirection="row" gap={1}>
+        <Text color={TASK_COLOR[card.status]}>{TASK_GLYPH[card.status]}</Text>
+        <Text color={TASK_COLOR[card.status]} bold>
+          {`step ${card.index}/${card.total}`}
+        </Text>
+        <Text color={FG.body}>{card.title}</Text>
+        <Text color={FG.faint}>{`· ${elapsed} · ${card.status}`}</Text>
+      </Box>
+      {card.steps.map((step) => (
+        <Box key={step.id} paddingLeft={2} flexDirection="row" gap={1}>
+          <Text color={STEP_COLOR[step.status]}>{STEP_GLYPH[step.status]}</Text>
+          <Text bold color={FG.body}>
+            {(step.toolName ?? "step").padEnd(7)}
+          </Text>
+          <Text color={FG.sub}>{step.title}</Text>
+          {step.detail ? <Text color={FG.faint}>{step.detail}</Text> : null}
+          {step.elapsedMs !== undefined ? (
+            <Text color={FG.faint}>{`${(step.elapsedMs / 1000).toFixed(2)}s`}</Text>
+          ) : null}
+        </Box>
+      ))}
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
PlanCard step list and TaskCard substep list lose CardBox chrome; both adopt the same flat header + indented body pattern.

**PlanCard before / after**
```
- ▎ ⊞ refactor cards · 2 of 5 done
- ▎ [✓] 1. drop CardBox
- ▎ [✓] 2. update UserCard
- ▎ [▶] 3. migrate ReasoningCard       ←  in progress
+ ⊞ refactor cards · 2/5 done
+   ✓ 1. drop CardBox
+   ✓ 2. update UserCard
+   ▶ 3. migrate ReasoningCard ← in progress
```

**TaskCard before / after**
```
- ▎ ▶ Step 2 of 5 · search and replace · 4.2s · running
- ▎ ▶  read    locate the type alias    0.18s
+ ▶ step 2/5 search and replace · 4.2s · running
+   ▶ read    locate the type alias 0.18s
```

## Test plan
- [x] `npm run verify` — 2251 pass
- [x] Manual: a `/plan` flow shows the new step list cleanly