### PR TITLE
feat(cards): unify all card layouts via CardLayout + ProgressBar (#160)

### DIFF
--- a/src/cli/ui/cards/ApprovalCard.tsx
+++ b/src/cli/ui/cards/ApprovalCard.tsx
@@ -1,7 +1,12 @@
 import { Box, Text, useStdout } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React from "react";
-import { CARD, type CardTone, FG, SURFACE } from "../theme/tokens.js";
+import { CARD, type CardTone, FG } from "../theme/tokens.js";
+import { CardLayout } from "./CardLayout.js";
+
+/** Generic confirmation-modal wrapper used by Plan / Edit / Choice / Shell /
+ *  Checkpoint / Revise pickers. Looks like a regular card on top with a
+ *  horizontal rule + footer hint underneath; children fill the body. */
 
 const SEPARATOR_PAD = 6;
 const MIN_SEPARATOR = 20;
@@ -15,7 +20,8 @@ export interface ApprovalCardProps {
   glyph?: string;
   title: string;
   metaRight?: string;
-  /** Override metaRight color — defaults to FG.faint. Use the tone color to match design's status indicator (e.g. "awaiting" in accent for plan-confirm). */
+  /** Override metaRight color — defaults to FG.faint. Use the tone color to
+   *  match design's status indicator (e.g. "awaiting" in accent for plan-confirm). */
   metaRightColor?: string;
   children?: React.ReactNode;
   footerHint?: string;
@@ -49,34 +55,15 @@ export function ApprovalCard({
   const { stdout } = useStdout();
   const cols = stdout?.columns ?? 80;
   const ruleWidth = Math.max(MIN_SEPARATOR, cols - SEPARATOR_PAD);
+  const meta = metaRight ? <Text color={metaRightColor ?? FG.faint}>{metaRight}</Text> : undefined;
 
   return (
-    <Box flexDirection="column" marginY={1}>
-      <Box flexDirection="row">
-        <Text color={palette.color} backgroundColor={SURFACE.bgElev}>
-          {" ▎ "}
-        </Text>
-        <Text bold color={palette.color} backgroundColor={SURFACE.bgElev}>
-          {`${headerGlyph}  `}
-        </Text>
-        <Text bold color={FG.strong} backgroundColor={SURFACE.bgElev}>
-          {` ${title} `}
-        </Text>
-        {metaRight !== undefined && (
-          <Text color={metaRightColor ?? FG.faint} backgroundColor={SURFACE.bgElev}>
-            {`  ${metaRight} `}
-          </Text>
-        )}
-      </Box>
-      <Box flexDirection="column" paddingX={2} marginTop={1}>
-        {children}
-      </Box>
-      <Box paddingX={2} marginTop={1}>
+    <CardLayout glyph={headerGlyph} tone={palette.color} title={title} meta={meta}>
+      {children}
+      <Box marginTop={1}>
         <Text color={FG.faint}>{"─".repeat(ruleWidth)}</Text>
       </Box>
-      <Box paddingX={2}>
-        <Text color={FG.faint}>{footerHint}</Text>
-      </Box>
-    </Box>
+      <Text color={FG.faint}>{footerHint}</Text>
+    </CardLayout>
   );
 }

--- a/src/cli/ui/cards/BranchCard.tsx
+++ b/src/cli/ui/cards/BranchCard.tsx
@@ -1,40 +1,30 @@
-import { Text } from "ink";
-import { Box } from "ink";
+import { Box, Text } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React from "react";
-import { BarRow } from "../primitives/BarRow.js";
 import type { BranchCard as BranchCardData } from "../state/cards.js";
-import { CARD, FG, TONE } from "../theme/tokens.js";
-import { CardHeader } from "./CardHeader.js";
-
-const BAR_CELLS = 28;
+import { FG, TONE } from "../theme/tokens.js";
+import { CardLayout } from "./CardLayout.js";
+import { ProgressBar } from "./ProgressBar.js";
 
 export function BranchCard({ card }: { card: BranchCardData }): React.ReactElement {
   const ratio = card.total > 0 ? card.completed / card.total : 0;
-  const filled = Math.max(0, Math.min(BAR_CELLS, Math.round(ratio * BAR_CELLS)));
-  const tone = card.done ? TONE.ok : CARD.streaming.color;
+  const tone = card.done ? TONE.ok : TONE.brand;
   return (
-    <Box flexDirection="column">
-      <CardHeader
-        tone="streaming"
-        glyph="⎇"
-        title={card.done ? "Branching done" : "Branching"}
-        meta={`· ${card.completed} of ${card.total} samples`}
-        barColor={tone}
-      />
-      <BarRow tone="streaming" indent={0} />
-      <BarRow tone="streaming">
-        <Text color={tone}>{"█".repeat(filled)}</Text>
-        <Text color={FG.faint}>{"░".repeat(BAR_CELLS - filled)}</Text>
-        <Text color={FG.faint}>{`  ${(ratio * 100).toFixed(0)}%`}</Text>
-      </BarRow>
-      {!card.done && card.completed > 0 && (
-        <BarRow tone="streaming">
-          <Text color={FG.faint}>
-            {`latest: #${card.latestIndex} · T=${card.latestTemperature.toFixed(2)} · ${card.latestUncertainties} unc`}
-          </Text>
-        </BarRow>
-      )}
-    </Box>
+    <CardLayout
+      glyph="⎇"
+      tone={tone}
+      title={card.done ? "branching done" : "branching"}
+      meta={`${card.completed}/${card.total} samples`}
+    >
+      <Box flexDirection="row" gap={1}>
+        <ProgressBar ratio={ratio} color={tone} />
+        <Text color={FG.faint}>{`${(ratio * 100).toFixed(0)}%`}</Text>
+      </Box>
+      {!card.done && card.completed > 0 ? (
+        <Text color={FG.faint}>
+          {`latest: #${card.latestIndex} · T=${card.latestTemperature.toFixed(2)} · ${card.latestUncertainties} unc`}
+        </Text>
+      ) : null}
+    </CardLayout>
   );
 }

--- a/src/cli/ui/cards/CardLayout.tsx
+++ b/src/cli/ui/cards/CardLayout.tsx
@@ -1,0 +1,60 @@
+/** Shared layout for the chat card stack. Header row + indented body. */
+
+import { Box, Text } from "ink";
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React, { type ReactNode } from "react";
+import { FG } from "../theme/tokens.js";
+
+export interface CardLayoutProps {
+  /** Leading glyph (◆ ▸ ✓ ⊞ ± ⌬ etc.). */
+  readonly glyph: string;
+  /** Color used for both glyph and bold title. */
+  readonly tone: string;
+  /** Bold word right of the glyph — names the card kind. */
+  readonly title: string;
+  /** Optional faint inline meta — string is rendered in FG.faint with a leading `·`; pass a node for custom styling. */
+  readonly meta?: ReactNode;
+  /** Trailing inline element (spinner, badge, etc). Sits at the right of the header row. */
+  readonly trailing?: ReactNode;
+  /** Body content. Rendered with paddingLeft=2 below the header. */
+  readonly children?: ReactNode;
+}
+
+/** marginTop=1 separates cards in the stack; paddingLeft=2 keeps body indented from the glyph column. */
+const BODY_PAD = 2;
+
+export function CardLayout({
+  glyph,
+  tone,
+  title,
+  meta,
+  trailing,
+  children,
+}: CardLayoutProps): React.ReactElement {
+  return (
+    <Box flexDirection="column" marginTop={1}>
+      <Box flexDirection="row" gap={1}>
+        <Text color={tone}>{glyph}</Text>
+        <Text color={tone} bold>
+          {title}
+        </Text>
+        {renderMeta(meta)}
+        {trailing}
+      </Box>
+      {children ? (
+        <Box flexDirection="column" paddingLeft={BODY_PAD}>
+          {children}
+        </Box>
+      ) : null}
+    </Box>
+  );
+}
+
+function renderMeta(meta: ReactNode): ReactNode {
+  if (meta == null) return null;
+  if (typeof meta === "string") {
+    if (meta.length === 0) return null;
+    return <Text color={FG.faint}>{meta.startsWith("·") ? meta : `· ${meta}`}</Text>;
+  }
+  return meta;
+}

--- a/src/cli/ui/cards/CtxCard.tsx
+++ b/src/cli/ui/cards/CtxCard.tsx
@@ -1,23 +1,33 @@
 import { Box, Text } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React from "react";
-import { BarRow } from "../primitives/BarRow.js";
 import type { CtxCard as CtxCardData } from "../state/cards.js";
 import { FG, TONE } from "../theme/tokens.js";
-import { CardHeader } from "./CardHeader.js";
+import { CardLayout } from "./CardLayout.js";
+import { ProgressBar } from "./ProgressBar.js";
 
 const BAR_CELLS = 32;
 
-function row(label: string, tokens: number, ratio: number, color: string): React.ReactElement {
-  const filled = Math.max(0, Math.min(BAR_CELLS, Math.round(ratio * BAR_CELLS)));
+function Row({
+  label,
+  tokens,
+  ratio,
+  color,
+}: {
+  label: string;
+  tokens: number;
+  ratio: number;
+  color: string;
+}): React.ReactElement {
   return (
-    <BarRow tone="usage">
+    <Box flexDirection="row" gap={1}>
       <Text color={FG.sub}>{label.padEnd(8)}</Text>
-      <Text color={color}>{"█".repeat(filled)}</Text>
-      <Text color={FG.faint}>{"░".repeat(BAR_CELLS - filled)}</Text>
-      <Text bold color={FG.body}>{`  ${tokens.toLocaleString()}`}</Text>
-      <Text color={FG.faint}>{`  ${(ratio * 100).toFixed(1)}%`}</Text>
-    </BarRow>
+      <ProgressBar ratio={ratio} color={color} cells={BAR_CELLS} />
+      <Text bold color={FG.body}>
+        {tokens.toLocaleString()}
+      </Text>
+      <Text color={FG.faint}>{`${(ratio * 100).toFixed(1)}%`}</Text>
+    </Box>
   );
 }
 
@@ -25,32 +35,42 @@ export function CtxCard({ card }: { card: CtxCardData }): React.ReactElement {
   const cap = Math.max(1, card.ctxMax);
   const used = card.systemTokens + card.toolsTokens + card.logTokens + card.inputTokens;
   const usedPct = (used / cap) * 100;
-  const meta = `· ${used.toLocaleString()} / ${cap.toLocaleString()} (${usedPct.toFixed(1)}%)`;
+  const meta = `${used.toLocaleString()} / ${cap.toLocaleString()} (${usedPct.toFixed(1)}%)`;
 
   return (
-    <Box flexDirection="column">
-      <CardHeader tone="usage" glyph="⌘" title="Context window" meta={meta} />
-      <BarRow tone="usage" indent={0} />
-      {row("system", card.systemTokens, card.systemTokens / cap, TONE.brand)}
-      {row("tools", card.toolsTokens, card.toolsTokens / cap, TONE.warn)}
-      {row("log", card.logTokens, card.logTokens / cap, TONE.ok)}
-      {row("input", card.inputTokens, card.inputTokens / cap, TONE.accent)}
-      {card.topTools.length > 0 && (
-        <>
-          <BarRow tone="usage" indent={0} />
-          <BarRow tone="usage">
-            <Text color={FG.faint}>
-              {`top tools (${card.toolsCount} total · ${card.logMessages} log msgs):`}
-            </Text>
-          </BarRow>
+    <CardLayout glyph="⌘" tone={TONE.brand} title="context window" meta={meta}>
+      <Row
+        label="system"
+        tokens={card.systemTokens}
+        ratio={card.systemTokens / cap}
+        color={TONE.brand}
+      />
+      <Row
+        label="tools"
+        tokens={card.toolsTokens}
+        ratio={card.toolsTokens / cap}
+        color={TONE.warn}
+      />
+      <Row label="log" tokens={card.logTokens} ratio={card.logTokens / cap} color={TONE.ok} />
+      <Row
+        label="input"
+        tokens={card.inputTokens}
+        ratio={card.inputTokens / cap}
+        color={TONE.accent}
+      />
+      {card.topTools.length > 0 ? (
+        <Box flexDirection="column" marginTop={1}>
+          <Text color={FG.faint}>
+            {`top tools (${card.toolsCount} total · ${card.logMessages} log msgs):`}
+          </Text>
           {card.topTools.slice(0, 5).map((t) => (
-            <BarRow key={`${t.turn}-${t.name}`} tone="usage">
-              <Text color={FG.sub}>{`  ${t.name}`}</Text>
-              <Text color={FG.faint}>{`  · turn ${t.turn} · ${t.tokens.toLocaleString()}`}</Text>
-            </BarRow>
+            <Box key={`${t.turn}-${t.name}`} flexDirection="row" gap={1}>
+              <Text color={FG.sub}>{t.name}</Text>
+              <Text color={FG.faint}>{`· turn ${t.turn} · ${t.tokens.toLocaleString()}`}</Text>
+            </Box>
           ))}
-        </>
-      )}
-    </Box>
+        </Box>
+      ) : null}
+    </CardLayout>
   );
 }

--- a/src/cli/ui/cards/DiffCard.tsx
+++ b/src/cli/ui/cards/DiffCard.tsx
@@ -1,10 +1,9 @@
 import { Box, Text } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React from "react";
-import { BarRow } from "../primitives/BarRow.js";
 import type { DiffCard as DiffCardData } from "../state/cards.js";
 import { FG, TONE } from "../theme/tokens.js";
-import { CardHeader } from "./CardHeader.js";
+import { CardLayout } from "./CardLayout.js";
 
 const LINE_COLOR = {
   ctx: FG.sub,
@@ -14,46 +13,39 @@ const LINE_COLOR = {
 } as const;
 
 export function DiffCard({ card }: { card: DiffCardData }): React.ReactElement {
-  const meta = (
+  const stats = (
     <>
       <Text color={TONE.ok}>{`+${card.stats.add}`}</Text>
-      <Text color={FG.faint}>{" / "}</Text>
+      <Text color={FG.faint}>/</Text>
       <Text color={TONE.err}>{`-${card.stats.del}`}</Text>
     </>
   );
   const showFooter = card.hunks.length > 0;
   return (
-    <Box flexDirection="column">
-      <CardHeader tone="diff" glyph="±" title="Edit" subtitle={card.file} trailing={meta} />
-      {card.hunks.map((hunk) => (
-        <Box key={`${card.id}:${hunk.header}`} flexDirection="column">
-          <BarRow tone="diff" indent={0} />
-          <BarRow tone="diff">
-            <Text italic color={FG.faint}>
-              {hunk.header}
-            </Text>
-          </BarRow>
+    <CardLayout glyph="±" tone={TONE.ok} title={card.file} trailing={stats}>
+      {card.hunks.map((hunk, hi) => (
+        <Box key={`${card.id}:${hunk.header}`} flexDirection="column" marginTop={hi > 0 ? 1 : 0}>
+          <Text italic color={FG.faint}>
+            {hunk.header}
+          </Text>
           {hunk.lines.map((line, li) => (
-            <BarRow key={`${card.id}:${hunk.header}:${li}`} tone="diff">
-              <Text color={LINE_COLOR[line.kind]}>{line.text}</Text>
-            </BarRow>
+            <Text key={`${card.id}:${hunk.header}:${li}`} color={LINE_COLOR[line.kind]}>
+              {line.text || " "}
+            </Text>
           ))}
         </Box>
       ))}
-      {showFooter && (
-        <>
-          <BarRow tone="diff" indent={0} />
-          <BarRow tone="diff">
-            <Text bold color={TONE.ok}>
-              {"[a] apply"}
-            </Text>
-            <Text color={FG.sub}>{"   [s] skip   "}</Text>
-            <Text bold color={TONE.err}>
-              {"[r] reject"}
-            </Text>
-          </BarRow>
-        </>
-      )}
-    </Box>
+      {showFooter ? (
+        <Box flexDirection="row" gap={1} marginTop={1}>
+          <Text bold color={TONE.ok}>
+            [a] apply
+          </Text>
+          <Text color={FG.sub}>[s] skip</Text>
+          <Text bold color={TONE.err}>
+            [r] reject
+          </Text>
+        </Box>
+      ) : null}
+    </CardLayout>
   );
 }

--- a/src/cli/ui/cards/DoctorCard.tsx
+++ b/src/cli/ui/cards/DoctorCard.tsx
@@ -1,10 +1,9 @@
 import { Box, Text } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React from "react";
-import { BarRow } from "../primitives/BarRow.js";
 import type { DoctorCard as DoctorCardData, DoctorCheckEntry } from "../state/cards.js";
-import { CARD, FG, TONE } from "../theme/tokens.js";
-import { CardHeader } from "./CardHeader.js";
+import { FG, TONE } from "../theme/tokens.js";
+import { CardLayout } from "./CardLayout.js";
 
 const LEVEL_COLOR: Record<DoctorCheckEntry["level"], string> = {
   ok: TONE.ok,
@@ -30,19 +29,20 @@ export function DoctorCard({ card }: { card: DoctorCardData }): React.ReactEleme
   const fail = card.checks.filter((c) => c.level === "fail").length;
   const summary = `${card.checks.length} checks · ${ok} passed${warn > 0 ? ` · ${warn} warn` : ""}${fail > 0 ? ` · ${fail} fail` : ""}`;
   const labelWidth = card.checks.reduce((m, c) => Math.max(m, c.label.length), 0);
+  const headerTone = fail > 0 ? TONE.err : warn > 0 ? TONE.warn : TONE.ok;
 
   return (
-    <Box flexDirection="column">
-      <CardHeader tone="tool" glyph="⚕" title="Doctor" meta={summary} barColor={CARD.tool.color} />
-      <BarRow tone="tool" indent={0} />
+    <CardLayout glyph="⚕" tone={headerTone} title="doctor" meta={summary}>
       {card.checks.map((c) => (
-        <BarRow key={c.label} tone="tool">
+        <Box key={c.label} flexDirection="row" gap={1}>
           <Text color={LEVEL_COLOR[c.level]}>{LEVEL_GLYPH[c.level]}</Text>
-          <Text bold color={FG.body}>{`  ${c.label.padEnd(labelWidth + 1)}`}</Text>
+          <Text bold color={FG.body}>
+            {c.label.padEnd(labelWidth)}
+          </Text>
           <Text color={FG.sub}>{c.detail}</Text>
-          <Text color={LEVEL_COLOR[c.level]}>{`    ${LEVEL_TAG[c.level]}`}</Text>
-        </BarRow>
+          <Text color={LEVEL_COLOR[c.level]}>{LEVEL_TAG[c.level]}</Text>
+        </Box>
       ))}
-    </Box>
+    </CardLayout>
   );
 }

--- a/src/cli/ui/cards/ErrorCard.tsx
+++ b/src/cli/ui/cards/ErrorCard.tsx
@@ -3,14 +3,15 @@ import { Box, Text } from "ink";
 import React from "react";
 import type { ErrorCard as ErrorCardData } from "../state/cards.js";
 import { FG, TONE } from "../theme/tokens.js";
+import { CardLayout } from "./CardLayout.js";
 
 const STACK_TAIL = 5;
 
 export function ErrorCard({ card }: { card: ErrorCardData }): React.ReactElement {
   const retryNote =
     card.retries !== undefined && card.retries > 0
-      ? `· ${card.retries} retr${card.retries === 1 ? "y" : "ies"}`
-      : null;
+      ? `${card.retries} retr${card.retries === 1 ? "y" : "ies"}`
+      : undefined;
   const stackLines = card.stack ? card.stack.split("\n") : [];
   const stackTrunc = stackLines.length > STACK_TAIL;
   const stackVisible = stackTrunc ? stackLines.slice(-STACK_TAIL) : stackLines;
@@ -19,38 +20,29 @@ export function ErrorCard({ card }: { card: ErrorCardData }): React.ReactElement
   const messageLines = card.message.split("\n");
 
   return (
-    <Box flexDirection="column" marginTop={1}>
-      <Box flexDirection="row" gap={1}>
-        <Text color={TONE.err}>✖</Text>
-        <Text color={TONE.err} bold>
-          {card.title || "error"}
-        </Text>
-        {retryNote ? <Text color={FG.faint}>{retryNote}</Text> : null}
-      </Box>
+    <CardLayout glyph="✖" tone={TONE.err} title={card.title || "error"} meta={retryNote}>
       {messageLines.map((line, i) => (
-        <Box key={`${card.id}:msg:${i}`} paddingLeft={2}>
-          <Text color={TONE.err}>{line || " "}</Text>
-        </Box>
+        <Text key={`${card.id}:msg:${i}`} color={TONE.err}>
+          {line || " "}
+        </Text>
       ))}
       {hasStack ? (
         <>
-          <Box paddingLeft={2} marginTop={1}>
+          <Box marginTop={1}>
             <Text color={FG.meta}>stack trace</Text>
           </Box>
           {stackHidden > 0 ? (
-            <Box paddingLeft={2}>
-              <Text color={FG.faint}>
-                {`⋮ ${stackHidden} earlier stack line${stackHidden === 1 ? "" : "s"} hidden`}
-              </Text>
-            </Box>
+            <Text color={FG.faint}>
+              {`⋮ ${stackHidden} earlier stack line${stackHidden === 1 ? "" : "s"} hidden`}
+            </Text>
           ) : null}
           {stackVisible.map((line, i) => (
-            <Box key={`${card.id}:stk:${stackHidden + i}`} paddingLeft={2}>
-              <Text color={FG.meta}>{line || " "}</Text>
-            </Box>
+            <Text key={`${card.id}:stk:${stackHidden + i}`} color={FG.meta}>
+              {line || " "}
+            </Text>
           ))}
         </>
       ) : null}
-    </Box>
+    </CardLayout>
   );
 }

--- a/src/cli/ui/cards/LiveCard.tsx
+++ b/src/cli/ui/cards/LiveCard.tsx
@@ -5,6 +5,11 @@ import { Spinner } from "../primitives/Spinner.js";
 import type { LiveCard as LiveCardData } from "../state/cards.js";
 import { FG, TONE } from "../theme/tokens.js";
 
+/** LiveCard is a single transient row — used for thinking / undo / aborted /
+ *  retry hints. It deliberately does NOT use CardLayout: no marginTop spacer,
+ *  no body, no bold-title pattern. The signal is "something is happening
+ *  right now"; full card chrome would be too heavy. */
+
 const TONE_TO_COLOR = {
   ok: TONE.ok,
   warn: TONE.warn,
@@ -31,8 +36,7 @@ export function LiveCard({ card }: { card: LiveCardData }): React.ReactElement {
   const color = TONE_TO_COLOR[card.tone];
   const glyph = VARIANT_GLYPH[card.variant];
   return (
-    <Box flexDirection="row">
-      <Text>{"  "}</Text>
+    <Box flexDirection="row" gap={1}>
       {card.variant === "thinking" ? (
         <Spinner kind="circle" color={color} bold />
       ) : (
@@ -40,8 +44,8 @@ export function LiveCard({ card }: { card: LiveCardData }): React.ReactElement {
           {glyph}
         </Text>
       )}
-      <Text color={FG.body}>{` ${card.text}`}</Text>
-      {card.meta !== undefined && <Text color={FG.faint}>{`   ${card.meta}`}</Text>}
+      <Text color={FG.body}>{card.text}</Text>
+      {card.meta !== undefined ? <Text color={FG.faint}>{card.meta}</Text> : null}
     </Box>
   );
 }

--- a/src/cli/ui/cards/MemoryCard.tsx
+++ b/src/cli/ui/cards/MemoryCard.tsx
@@ -1,10 +1,9 @@
 import { Box, Text } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React from "react";
-import { BarRow } from "../primitives/BarRow.js";
 import type { MemoryCard as MemoryCardData, MemoryEntry } from "../state/cards.js";
 import { FG, TONE } from "../theme/tokens.js";
-import { CardHeader } from "./CardHeader.js";
+import { CardLayout } from "./CardLayout.js";
 
 const CATEGORY_ORDER: ReadonlyArray<MemoryEntry["category"]> = [
   "user",
@@ -42,42 +41,27 @@ export function MemoryCard({ card }: { card: MemoryCardData }): React.ReactEleme
   const tokens =
     card.tokens > 1024 ? `~${(card.tokens / 1024).toFixed(1)}K tok` : `~${card.tokens} tok`;
   return (
-    <Box flexDirection="column">
-      <CardHeader
-        tone="memory"
-        glyph="⌑"
-        title="Context"
-        subtitle={`·  ${summary}`}
-        meta={tokens}
-        titleColor={FG.sub}
-      />
-      {CATEGORY_ORDER.filter((c) => counts[c] > 0).map((category) => {
+    <CardLayout glyph="⌑" tone={FG.meta} title="memory" meta={`${summary} · ${tokens}`}>
+      {CATEGORY_ORDER.filter((c) => counts[c] > 0).map((category, ci) => {
         const all = card.entries.filter((e) => e.category === category);
         const shown = all.slice(0, 5);
         const remaining = all.length - shown.length;
         return (
-          <Box key={category} flexDirection="column">
-            <BarRow tone="memory" indent={0} />
-            <BarRow tone="memory">
-              <Text color={FG.faint}>
-                {CATEGORY_LABEL[category]} ({counts[category]})
-              </Text>
-            </BarRow>
+          <Box key={category} flexDirection="column" marginTop={ci > 0 ? 1 : 0}>
+            <Text color={FG.faint}>
+              {CATEGORY_LABEL[category]} ({counts[category]})
+            </Text>
             {shown.map((entry) => (
-              <BarRow key={`${category}:${entry.summary}`} tone="memory">
-                <Text color={CATEGORY_GLYPH_COLOR[category]}>{CATEGORY_GLYPH[category]} </Text>
+              <Box key={`${category}:${entry.summary}`} flexDirection="row" gap={1}>
+                <Text color={CATEGORY_GLYPH_COLOR[category]}>{CATEGORY_GLYPH[category]}</Text>
                 <Text color={FG.sub}>{entry.summary}</Text>
-              </BarRow>
+              </Box>
             ))}
-            {remaining > 0 && (
-              <BarRow tone="memory">
-                <Text color={FG.faint}>{`⋮ +${remaining} more`}</Text>
-              </BarRow>
-            )}
+            {remaining > 0 ? <Text color={FG.faint}>{`⋮ +${remaining} more`}</Text> : null}
           </Box>
         );
       })}
-    </Box>
+    </CardLayout>
   );
 }
 

--- a/src/cli/ui/cards/PlanCard.tsx
+++ b/src/cli/ui/cards/PlanCard.tsx
@@ -3,6 +3,7 @@ import { Box, Text } from "ink";
 import React from "react";
 import type { PlanCard as PlanCardData, PlanStep } from "../state/cards.js";
 import { FG, TONE } from "../theme/tokens.js";
+import { CardLayout } from "./CardLayout.js";
 
 const STATUS_GLYPH: Record<PlanStep["status"], string> = {
   queued: "○",
@@ -29,19 +30,12 @@ export function PlanCard({ card }: { card: PlanCardData }): React.ReactElement {
   const progress = `${variantTag}${doneCount}/${card.steps.length} done`;
 
   return (
-    <Box flexDirection="column" marginTop={1}>
-      <Box flexDirection="row" gap={1}>
-        <Text color={TONE.accent}>⊞</Text>
-        <Text color={TONE.accent} bold>
-          {card.title}
-        </Text>
-        <Text color={FG.faint}>{`· ${progress}`}</Text>
-      </Box>
+    <CardLayout glyph="⊞" tone={TONE.accent} title={card.title} meta={progress}>
       {card.steps.map((step, i) => {
         const isActive = step.status === "running";
         const titleColor = isActive ? FG.strong : FG.sub;
         return (
-          <Box key={step.id} paddingLeft={2} flexDirection="row" gap={1}>
+          <Box key={step.id} flexDirection="row" gap={1}>
             <Text color={STATUS_COLOR[step.status]}>{STATUS_GLYPH[step.status]}</Text>
             <Text bold={isActive} color={titleColor}>
               {`${i + 1}. ${step.title}`}
@@ -50,6 +44,6 @@ export function PlanCard({ card }: { card: PlanCardData }): React.ReactElement {
           </Box>
         );
       })}
-    </Box>
+    </CardLayout>
   );
 }

--- a/src/cli/ui/cards/ProgressBar.tsx
+++ b/src/cli/ui/cards/ProgressBar.tsx
@@ -1,0 +1,27 @@
+/** Block-character progress bar used by usage / context / branch cards. */
+
+import { Text } from "ink";
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React from "react";
+import { FG } from "../theme/tokens.js";
+
+export interface ProgressBarProps {
+  /** 0..1 fill ratio. Out-of-range values are clamped. */
+  readonly ratio: number;
+  /** Filled-cell color. */
+  readonly color: string;
+  /** Total cells the bar spans. Default 28. */
+  readonly cells?: number;
+}
+
+export function ProgressBar({ ratio, color, cells = 28 }: ProgressBarProps): React.ReactElement {
+  const clamped = Math.max(0, Math.min(1, ratio));
+  const filled = Math.max(0, Math.min(cells, Math.round(clamped * cells)));
+  const empty = cells - filled;
+  return (
+    <>
+      <Text color={color}>{"█".repeat(filled)}</Text>
+      <Text color={FG.faint}>{"░".repeat(empty)}</Text>
+    </>
+  );
+}

--- a/src/cli/ui/cards/ReasoningCard.tsx
+++ b/src/cli/ui/cards/ReasoningCard.tsx
@@ -6,12 +6,10 @@ import { CursorBlock } from "../primitives/BarRow.js";
 import { Spinner } from "../primitives/Spinner.js";
 import type { ReasoningCard as ReasoningCardData } from "../state/cards.js";
 import { FG, TONE } from "../theme/tokens.js";
+import { CardLayout } from "./CardLayout.js";
 
-/** Streaming preview tail length — wide enough to feel responsive, small enough not to thrash on every chunk. Full body lives in the events log. */
 const STREAMING_PREVIEW_LINES = 4;
-/** Once settled, only the conclusion is actionable; the rest is in `/reasoning last`. */
 const SETTLED_TAIL_LINES = 2;
-const BODY_PAD = 2;
 
 export function ReasoningCard({
   card,
@@ -22,115 +20,77 @@ export function ReasoningCard({
 }): React.ReactElement {
   const { stdout } = useStdout();
   const cols = stdout?.columns ?? 80;
-  const lineCells = Math.max(20, cols - BODY_PAD - 4);
-
+  const lineCells = Math.max(20, cols - 6);
   const allLines = card.text.length > 0 ? card.text.split("\n") : [];
   const showBody = expanded && (allLines.length > 0 || card.streaming);
-
-  return (
-    <Box flexDirection="column" marginTop={1}>
-      <ReasoningHeader card={card} />
-      {showBody &&
-        (card.streaming ? (
-          <StreamingPreview card={card} allLines={allLines} lineCells={lineCells} />
-        ) : (
-          <SettledPreview card={card} allLines={allLines} lineCells={lineCells} />
-        ))}
-    </Box>
-  );
-}
-
-function ReasoningHeader({ card }: { card: ReasoningCardData }): React.ReactElement {
   const streamingActive = card.streaming && !card.aborted;
-  const headColor = card.aborted ? TONE.err : streamingActive ? TONE.accent : TONE.accent;
+  const tone = card.aborted ? TONE.err : TONE.accent;
   const glyph = streamingActive ? "◇" : "◆";
-  const meta = headerMeta(card);
-  const duration = headerDuration(card);
+  const title = streamingActive ? "reasoning…" : card.aborted ? "reasoning (aborted)" : "reasoning";
+
   return (
-    <Box flexDirection="row" gap={1}>
-      <Text color={headColor}>{glyph}</Text>
-      <Text color={headColor} bold>
-        {streamingActive ? "reasoning…" : card.aborted ? "reasoning (aborted)" : "reasoning"}
-      </Text>
-      {meta ? <Text color={FG.faint}>{`· ${meta}`}</Text> : null}
-      {duration ? <Text color={FG.faint}>{`· ${duration}`}</Text> : null}
-      {streamingActive ? (
-        <Box flexDirection="row">
-          <Spinner kind="braille" color={TONE.accent} />
-        </Box>
-      ) : null}
-    </Box>
+    <CardLayout
+      glyph={glyph}
+      tone={tone}
+      title={title}
+      meta={headerMeta(card, streamingActive)}
+      trailing={streamingActive ? <Spinner kind="braille" color={TONE.accent} /> : undefined}
+    >
+      {showBody
+        ? streamingActive
+          ? renderStreamingTail(card, allLines, lineCells)
+          : renderSettledTail(card, allLines, lineCells)
+        : null}
+    </CardLayout>
   );
 }
 
-function headerMeta(card: ReasoningCardData): string {
-  if (card.streaming) {
-    return card.tokens > 0 ? `${card.tokens.toLocaleString()} tok` : "";
-  }
+function headerMeta(card: ReasoningCardData, streaming: boolean): string {
   const parts: string[] = [];
   if (card.tokens > 0) parts.push(`${card.tokens.toLocaleString()} tok`);
-  if (card.paragraphs > 0) parts.push(`${card.paragraphs} ¶`);
+  if (!streaming && card.paragraphs > 0) parts.push(`${card.paragraphs} ¶`);
+  if (!streaming && card.endedAt) {
+    parts.push(`${Math.max(0, (card.endedAt - card.ts) / 1000).toFixed(1)}s`);
+  }
   return parts.join(" · ");
 }
 
-function headerDuration(card: ReasoningCardData): string {
-  if (card.streaming || !card.endedAt) return "";
-  const seconds = Math.max(0, (card.endedAt - card.ts) / 1000);
-  return `${seconds.toFixed(1)}s`;
-}
-
-interface BodyProps {
-  card: ReasoningCardData;
-  allLines: string[];
-  lineCells: number;
-}
-
-function StreamingPreview({ card, allLines, lineCells }: BodyProps): React.ReactElement {
+function renderStreamingTail(
+  card: ReasoningCardData,
+  allLines: ReadonlyArray<string>,
+  lineCells: number,
+): React.ReactNode {
   const visualLines = allLines.flatMap((l) => wrapToCells(l, lineCells));
   const visible = visualLines.slice(-STREAMING_PREVIEW_LINES);
-  return <BodyLines card={card} lines={visible} lineCells={lineCells} cursorOnLast />;
+  return visible.map((line, i) => {
+    const isLast = i === visible.length - 1;
+    return (
+      <Box key={`${card.id}:s:${i}`} flexDirection="row">
+        <Text italic color={FG.meta}>
+          {clipToCells(line, lineCells)}
+        </Text>
+        {isLast ? <CursorBlock /> : null}
+      </Box>
+    );
+  });
 }
 
-function SettledPreview({ card, allLines, lineCells }: BodyProps): React.ReactElement {
+function renderSettledTail(
+  card: ReasoningCardData,
+  allLines: ReadonlyArray<string>,
+  lineCells: number,
+): React.ReactNode {
   const visualLines = allLines.flatMap((l) => wrapToCells(l, lineCells));
   const visible = visualLines.slice(-SETTLED_TAIL_LINES);
-  const droppedLines = Math.max(0, visualLines.length - visible.length);
+  const dropped = Math.max(0, visualLines.length - visible.length);
   return (
     <>
-      {droppedLines > 0 ? <ElisionHint droppedLines={droppedLines} card={card} /> : null}
-      <BodyLines card={card} lines={visible} lineCells={lineCells} indexOffset={droppedLines} />
-    </>
-  );
-}
-
-interface BodyLinesProps {
-  card: ReasoningCardData;
-  lines: string[];
-  lineCells: number;
-  cursorOnLast?: boolean;
-  indexOffset?: number;
-}
-
-function BodyLines({
-  card,
-  lines,
-  lineCells,
-  cursorOnLast = false,
-  indexOffset = 0,
-}: BodyLinesProps): React.ReactElement {
-  return (
-    <>
-      {lines.map((line, i) => {
-        const isLast = i === lines.length - 1;
-        return (
-          <Box key={`${card.id}:b:${indexOffset + i}`} paddingLeft={BODY_PAD} flexDirection="row">
-            <Text italic color={FG.meta}>
-              {clipToCells(line, lineCells)}
-            </Text>
-            {isLast && cursorOnLast && <CursorBlock />}
-          </Box>
-        );
-      })}
+      {dropped > 0 ? <ElisionHint droppedLines={dropped} card={card} /> : null}
+      {visible.map((line, i) => (
+        <Text key={`${card.id}:t:${dropped + i}`} italic color={FG.meta}>
+          {clipToCells(line, lineCells)}
+        </Text>
+      ))}
     </>
   );
 }
@@ -143,15 +103,8 @@ function ElisionHint({
   card: ReasoningCardData;
 }): React.ReactElement {
   const parts: string[] = [];
-  if (card.paragraphs > 1) {
-    parts.push(`${card.paragraphs} ¶`);
-  } else {
-    parts.push(`${droppedLines} line${droppedLines === 1 ? "" : "s"}`);
-  }
+  if (card.paragraphs > 1) parts.push(`${card.paragraphs} ¶`);
+  else parts.push(`${droppedLines} line${droppedLines === 1 ? "" : "s"}`);
   if (card.tokens > 0) parts.push(`${card.tokens.toLocaleString()} tok`);
-  return (
-    <Box paddingLeft={BODY_PAD}>
-      <Text color={FG.faint}>{`⋯ ${parts.join(" · ")} above · /reasoning last`}</Text>
-    </Box>
-  );
+  return <Text color={FG.faint}>{`⋯ ${parts.join(" · ")} above · /reasoning last`}</Text>;
 }

--- a/src/cli/ui/cards/SearchCard.tsx
+++ b/src/cli/ui/cards/SearchCard.tsx
@@ -1,10 +1,9 @@
 import { Box, Text } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React from "react";
-import { BarRow } from "../primitives/BarRow.js";
 import type { SearchCard as SearchCardData, SearchHit } from "../state/cards.js";
-import { FG } from "../theme/tokens.js";
-import { CardHeader } from "./CardHeader.js";
+import { FG, TONE } from "../theme/tokens.js";
+import { CardLayout } from "./CardLayout.js";
 
 export function SearchCard({ card }: { card: SearchCardData }): React.ReactElement {
   const fileCount = new Set(card.hits.map((h) => h.file)).size;
@@ -13,34 +12,28 @@ export function SearchCard({ card }: { card: SearchCardData }): React.ReactEleme
   } · ${(card.elapsedMs / 1000).toFixed(2)}s`;
 
   return (
-    <Box flexDirection="column">
-      <CardHeader tone="search" glyph="⊙" title="Search" subtitle={`"${card.query}"`} meta={meta} />
-      {card.hits.length > 0 && (
+    <CardLayout glyph="⊙" tone={TONE.info} title={`"${card.query}"`} meta={meta}>
+      {card.hits.length === 0 ? null : (
         <>
-          <BarRow tone="search" indent={0} />
-          {groupByFile(card.hits.slice(0, 10)).map(([file, hits]) => (
-            <Box key={file} flexDirection="column">
-              <BarRow tone="search">
-                <Text bold color={FG.strong}>
-                  {file}
-                </Text>
-              </BarRow>
+          {groupByFile(card.hits.slice(0, 10)).map(([file, hits], gi) => (
+            <Box key={file} flexDirection="column" marginTop={gi > 0 ? 1 : 0}>
+              <Text bold color={FG.strong}>
+                {file}
+              </Text>
               {hits.map((h, i) => (
-                <BarRow key={`${file}:${h.line}:${i}`} tone="search">
+                <Box key={`${file}:${h.line}:${i}`} flexDirection="row">
                   <Text color={FG.faint}>{`${h.line.toString().padStart(4)} │ `}</Text>
                   <HighlightedLine text={h.preview} start={h.matchStart} end={h.matchEnd} />
-                </BarRow>
+                </Box>
               ))}
             </Box>
           ))}
-          {card.hits.length > 10 && (
-            <BarRow tone="search">
-              <Text color={FG.faint}>{`⋮ +${card.hits.length - 10} more hits`}</Text>
-            </BarRow>
-          )}
+          {card.hits.length > 10 ? (
+            <Text color={FG.faint}>{`⋮ +${card.hits.length - 10} more hits`}</Text>
+          ) : null}
         </>
       )}
-    </Box>
+    </CardLayout>
   );
 }
 

--- a/src/cli/ui/cards/StreamingCard.tsx
+++ b/src/cli/ui/cards/StreamingCard.tsx
@@ -1,4 +1,4 @@
-import { Box, Text, useStdout } from "ink";
+import { Text, useStdout } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React from "react";
 import { clipToCells, wrapToCells } from "../../../frame/width.js";
@@ -7,9 +7,8 @@ import { Markdown } from "../markdown.js";
 import { Spinner } from "../primitives/Spinner.js";
 import type { StreamingCard as StreamingCardData } from "../state/cards.js";
 import { FG, TONE } from "../theme/tokens.js";
+import { CardLayout } from "./CardLayout.js";
 
-const BODY_PAD = 2;
-/** Streaming preview tail length — bounded live region so chunks don't thrash whole-card layout. */
 const STREAMING_PREVIEW_LINES = 4;
 
 export function StreamingCard({ card }: { card: StreamingCardData }): React.ReactElement {
@@ -22,56 +21,34 @@ export function StreamingCard({ card }: { card: StreamingCardData }): React.Reac
 
   if (card.done && !card.aborted) {
     return (
-      <Box flexDirection="column" marginTop={1}>
-        <Box flexDirection="row" gap={1}>
-          <Text color={TONE.ok}>‹</Text>
-          <Text color={TONE.ok} bold>
-            reply
-          </Text>
-        </Box>
-        <Box paddingLeft={BODY_PAD} flexDirection="column">
-          <Markdown text={card.text} />
-        </Box>
-      </Box>
+      <CardLayout glyph="‹" tone={TONE.ok} title="reply">
+        <Markdown text={card.text} />
+      </CardLayout>
     );
   }
 
-  const lineCells = Math.max(20, cols - BODY_PAD - 4);
+  const lineCells = Math.max(20, cols - 6);
   const allLines = card.text.length > 0 ? card.text.split("\n") : [""];
   const visualLines = allLines.flatMap((l) => wrapToCells(l, lineCells));
   const visible = visualLines.slice(-STREAMING_PREVIEW_LINES);
   const aborted = !!card.aborted;
-  const headColor = aborted ? TONE.err : TONE.brand;
-  const glyph = aborted ? "‹" : "▸";
-  const headLabel = aborted ? "aborted" : "writing…";
 
   return (
-    <Box flexDirection="column" marginTop={1}>
-      <Box flexDirection="row" gap={1}>
-        <Text color={headColor}>{glyph}</Text>
-        <Text color={headColor} bold>
-          {headLabel}
-        </Text>
-        {aborted ? null : (
-          <Box flexDirection="row">
-            <Spinner kind="braille" color={TONE.brand} />
-          </Box>
-        )}
-      </Box>
+    <CardLayout
+      glyph={aborted ? "‹" : "▸"}
+      tone={aborted ? TONE.err : TONE.brand}
+      title={aborted ? "aborted" : "writing…"}
+      trailing={aborted ? undefined : <Spinner kind="braille" color={TONE.brand} />}
+    >
       {visible.map((line, i) => (
-        <Box
+        <Text
           key={`${card.id}:${allLines.length - visible.length + i}`}
-          paddingLeft={BODY_PAD}
-          flexDirection="row"
+          color={aborted ? FG.meta : FG.body}
         >
-          <Text color={aborted ? FG.meta : FG.body}>{clipToCells(line, lineCells)}</Text>
-        </Box>
+          {clipToCells(line, lineCells) || " "}
+        </Text>
       ))}
-      {aborted ? (
-        <Box paddingLeft={BODY_PAD}>
-          <Text color={FG.faint}>[truncated by esc]</Text>
-        </Box>
-      ) : null}
-    </Box>
+      {aborted ? <Text color={FG.faint}>[truncated by esc]</Text> : null}
+    </CardLayout>
   );
 }

--- a/src/cli/ui/cards/SubAgentCard.tsx
+++ b/src/cli/ui/cards/SubAgentCard.tsx
@@ -1,10 +1,9 @@
 import { Box, Text } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React from "react";
-import { BarRow } from "../primitives/BarRow.js";
 import type { Card, SubAgentCard as SubAgentCardData } from "../state/cards.js";
-import { CARD, FG, TONE } from "../theme/tokens.js";
-import { CardHeader } from "./CardHeader.js";
+import { FG, TONE } from "../theme/tokens.js";
+import { CardLayout } from "./CardLayout.js";
 
 const STATUS_COLOR: Record<SubAgentCardData["status"], string> = {
   running: TONE.violet,
@@ -14,39 +13,34 @@ const STATUS_COLOR: Record<SubAgentCardData["status"], string> = {
 
 export function SubAgentCard({ card }: { card: SubAgentCardData }): React.ReactElement {
   return (
-    <Box flexDirection="column">
-      <CardHeader
-        tone="subagent"
-        glyph="⌬"
-        title={`Sub-agent · ${card.name}`}
-        trailing={<Text color={STATUS_COLOR[card.status]}>{card.status}</Text>}
-      />
-      <BarRow tone="subagent" indent={0} />
-      <BarRow tone="subagent">
-        <Text color={FG.faint}>{"Task   "}</Text>
+    <CardLayout
+      glyph="⌬"
+      tone={TONE.violet}
+      title={`subagent · ${card.name}`}
+      trailing={<Text color={STATUS_COLOR[card.status]}>{card.status}</Text>}
+    >
+      <Box flexDirection="row" gap={1}>
+        <Text color={FG.faint}>task</Text>
         <Text color={FG.sub}>{card.task}</Text>
-      </BarRow>
-      {card.tools && card.tools.length > 0 && (
-        <BarRow tone="subagent">
-          <Text color={FG.faint}>{"Tools  "}</Text>
+      </Box>
+      {card.tools && card.tools.length > 0 ? (
+        <Box flexDirection="row" gap={1}>
+          <Text color={FG.faint}>tools</Text>
           <Text color={FG.sub}>{card.tools.join(", ")}</Text>
-        </BarRow>
-      )}
-      {card.children.length > 0 && (
-        <>
-          <BarRow tone="subagent" indent={0} />
-          <BarRow tone="subagent">
-            <Text color={FG.meta}>{"sub-agent stream"}</Text>
-          </BarRow>
+        </Box>
+      ) : null}
+      {card.children.length > 0 ? (
+        <Box flexDirection="column" marginTop={1}>
+          <Text color={FG.meta}>sub-agent stream</Text>
           {card.children.map((child) => (
-            <BarRow key={child.id} tone="subagent">
-              <Text color={CARD.subagent.color}>{"▎  "}</Text>
+            <Box key={child.id} flexDirection="row" gap={1}>
+              <Text color={TONE.violet}>▎</Text>
               <ChildSummary card={child} />
-            </BarRow>
+            </Box>
           ))}
-        </>
-      )}
-    </Box>
+        </Box>
+      ) : null}
+    </CardLayout>
   );
 }
 
@@ -55,28 +49,28 @@ function ChildSummary({ card }: { card: Card }): React.ReactElement {
     case "reasoning":
       return (
         <>
-          <Text color={CARD.reasoning.color}>{"◆ "}</Text>
+          <Text color={TONE.accent}>◆</Text>
           <Text italic color={FG.meta}>
-            {`Reasoning · ${card.paragraphs} paragraph${card.paragraphs === 1 ? "" : "s"}`}
+            {`reasoning · ${card.paragraphs} paragraph${card.paragraphs === 1 ? "" : "s"}`}
           </Text>
         </>
       );
     case "tool":
       return (
         <>
-          <Text color={CARD.tool.color}>{"▣ "}</Text>
+          <Text color={TONE.brand}>▣</Text>
           <Text bold color={FG.body}>
             {card.name}
           </Text>
-          {card.elapsedMs > 0 && (
-            <Text color={FG.faint}>{`   ${(card.elapsedMs / 1000).toFixed(2)}s`}</Text>
-          )}
+          {card.elapsedMs > 0 ? (
+            <Text color={FG.faint}>{`${(card.elapsedMs / 1000).toFixed(2)}s`}</Text>
+          ) : null}
         </>
       );
     case "streaming":
       return (
         <>
-          <Text color={CARD.streaming.color}>{"▶ "}</Text>
+          <Text color={TONE.brand}>▶</Text>
           <Text color={card.done ? FG.sub : TONE.brand}>
             {card.done ? "response" : "streaming response …"}
           </Text>
@@ -85,18 +79,18 @@ function ChildSummary({ card }: { card: Card }): React.ReactElement {
     case "diff":
       return (
         <>
-          <Text color={CARD.diff.color}>{"± "}</Text>
+          <Text color={TONE.ok}>±</Text>
           <Text color={FG.sub}>{card.file}</Text>
         </>
       );
     case "error":
       return (
         <>
-          <Text color={CARD.error.color}>{"✖ "}</Text>
+          <Text color={TONE.err}>✖</Text>
           <Text color={FG.sub}>{card.title}</Text>
         </>
       );
     default:
-      return <Text color={FG.faint}>{`· ${card.kind}`}</Text>;
+      return <Text color={FG.faint}>{card.kind}</Text>;
   }
 }

--- a/src/cli/ui/cards/TaskCard.tsx
+++ b/src/cli/ui/cards/TaskCard.tsx
@@ -3,6 +3,7 @@ import { Box, Text } from "ink";
 import React from "react";
 import type { TaskCard as TaskCardData, TaskStep } from "../state/cards.js";
 import { FG, TONE } from "../theme/tokens.js";
+import { CardLayout } from "./CardLayout.js";
 
 const STEP_GLYPH: Record<TaskStep["status"], string> = {
   queued: "○",
@@ -32,18 +33,21 @@ const TASK_GLYPH: Record<TaskCardData["status"], string> = {
 
 export function TaskCard({ card }: { card: TaskCardData }): React.ReactElement {
   const elapsed = `${(card.elapsedMs / 1000).toFixed(1)}s`;
+  const meta = (
+    <>
+      <Text color={FG.body}>{card.title}</Text>
+      <Text color={FG.faint}>{`· ${elapsed} · ${card.status}`}</Text>
+    </>
+  );
   return (
-    <Box flexDirection="column" marginTop={1}>
-      <Box flexDirection="row" gap={1}>
-        <Text color={TASK_COLOR[card.status]}>{TASK_GLYPH[card.status]}</Text>
-        <Text color={TASK_COLOR[card.status]} bold>
-          {`step ${card.index}/${card.total}`}
-        </Text>
-        <Text color={FG.body}>{card.title}</Text>
-        <Text color={FG.faint}>{`· ${elapsed} · ${card.status}`}</Text>
-      </Box>
+    <CardLayout
+      glyph={TASK_GLYPH[card.status]}
+      tone={TASK_COLOR[card.status]}
+      title={`step ${card.index}/${card.total}`}
+      meta={meta}
+    >
       {card.steps.map((step) => (
-        <Box key={step.id} paddingLeft={2} flexDirection="row" gap={1}>
+        <Box key={step.id} flexDirection="row" gap={1}>
           <Text color={STEP_COLOR[step.status]}>{STEP_GLYPH[step.status]}</Text>
           <Text bold color={FG.body}>
             {(step.toolName ?? "step").padEnd(7)}
@@ -55,6 +59,6 @@ export function TaskCard({ card }: { card: TaskCardData }): React.ReactElement {
           ) : null}
         </Box>
       ))}
-    </Box>
+    </CardLayout>
   );
 }

--- a/src/cli/ui/cards/ToolCard.tsx
+++ b/src/cli/ui/cards/ToolCard.tsx
@@ -1,14 +1,14 @@
-import { Box, Text, useStdout } from "ink";
+import { Text, useStdout } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React from "react";
 import { clipToCells } from "../../../frame/width.js";
 import { Spinner } from "../primitives/Spinner.js";
 import type { ToolCard as ToolCardData } from "../state/cards.js";
 import { FG, TONE } from "../theme/tokens.js";
+import { CardLayout } from "./CardLayout.js";
 
 const READ_TAIL = 2;
 const OTHER_TAIL = 5;
-const BODY_PAD = 2;
 
 /** Read-style tools dump file/list bodies — short tail is enough; the model already has the full text in context. */
 function tailLinesFor(name: string): number {
@@ -22,7 +22,7 @@ function tailLinesFor(name: string): number {
 export function ToolCard({ card }: { card: ToolCardData }): React.ReactElement {
   const { stdout } = useStdout();
   const cols = stdout?.columns ?? 80;
-  const lineCells = Math.max(20, cols - BODY_PAD - 4);
+  const lineCells = Math.max(20, cols - 6);
   const argsLabel = formatArgsSummary(card.args);
   const allLines = card.output.length > 0 ? card.output.split("\n") : [];
   const tail = tailLinesFor(card.name);
@@ -30,54 +30,56 @@ export function ToolCard({ card }: { card: ToolCardData }): React.ReactElement {
   const visible = truncated ? allLines.slice(-tail) : allLines;
   const hidden = truncated ? allLines.length - visible.length : 0;
   const status = toolStatus(card);
-  const headColor = headerColorFor(status);
+  const tone = headerColorFor(status);
   const errColor = card.exitCode && card.exitCode !== 0 ? TONE.err : FG.sub;
   // Rejected calls show a single trailing badge — the verbose JSON error body
   // is already conveyed by the badge, so dropping the body keeps the card tight.
   const showBody = !card.rejected && visible.length > 0;
 
-  return (
-    <Box flexDirection="column" marginTop={1}>
-      <Box flexDirection="row" gap={1}>
-        <Text color={headColor}>{statusGlyph(status)}</Text>
-        <Text color={headColor} bold>
-          {card.name}
+  const meta = (
+    <>
+      {argsLabel ? <Text color={FG.faint}>{argsLabel}</Text> : null}
+      {card.retry ? (
+        <Text color={TONE.warn} bold>{`↻ ${card.retry.attempt}/${card.retry.max}`}</Text>
+      ) : null}
+      {card.rejected ? (
+        <Text color={TONE.err} bold>
+          rejected
         </Text>
-        {argsLabel ? <Text color={FG.faint}>{argsLabel}</Text> : null}
-        {card.retry ? (
-          <Text color={TONE.warn} bold>{`↻ ${card.retry.attempt}/${card.retry.max}`}</Text>
-        ) : null}
-        {card.rejected ? (
-          <Text color={TONE.err} bold>
-            rejected
-          </Text>
-        ) : null}
-        <Text color={FG.faint}>{metaTrail(card)}</Text>
-        {status === "running" ? (
-          <Box flexDirection="row">
-            <Spinner kind="braille" color={TONE.brand} bold />
-          </Box>
-        ) : null}
-      </Box>
-      {showBody && (
+      ) : null}
+      <Text color={FG.faint}>{metaTrail(card)}</Text>
+    </>
+  );
+
+  return (
+    <CardLayout
+      glyph={statusGlyph(status)}
+      tone={tone}
+      title={card.name}
+      meta={meta}
+      trailing={
+        status === "running" ? <Spinner kind="braille" color={TONE.brand} bold /> : undefined
+      }
+    >
+      {showBody ? (
         <>
           {hidden > 0 ? (
-            <Box paddingLeft={BODY_PAD}>
-              <Text color={FG.faint}>
-                {`⋮ ${hidden} earlier line${hidden === 1 ? "" : "s"} (use /tool to read full)`}
-              </Text>
-            </Box>
+            <Text color={FG.faint}>
+              {`⋮ ${hidden} earlier line${hidden === 1 ? "" : "s"} (use /tool to read full)`}
+            </Text>
           ) : null}
           {visible.map((line, i) => (
-            <Box key={`${card.id}:${hidden + i}`} paddingLeft={BODY_PAD}>
-              <Text color={errColor} dimColor={!card.exitCode || card.exitCode === 0}>
-                {clipToCells(line, lineCells) || " "}
-              </Text>
-            </Box>
+            <Text
+              key={`${card.id}:${hidden + i}`}
+              color={errColor}
+              dimColor={!card.exitCode || card.exitCode === 0}
+            >
+              {clipToCells(line, lineCells) || " "}
+            </Text>
           ))}
         </>
-      )}
-    </Box>
+      ) : null}
+    </CardLayout>
   );
 }
 

--- a/src/cli/ui/cards/UsageCard.tsx
+++ b/src/cli/ui/cards/UsageCard.tsx
@@ -1,10 +1,10 @@
 import { Box, Text } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React from "react";
-import { BarRow } from "../primitives/BarRow.js";
 import type { UsageCard as UsageCardData } from "../state/cards.js";
 import { FG, TONE, formatCNY } from "../theme/tokens.js";
-import { CardHeader } from "./CardHeader.js";
+import { CardLayout } from "./CardLayout.js";
+import { ProgressBar } from "./ProgressBar.js";
 
 const BAR_CELLS = 30;
 
@@ -14,14 +14,28 @@ function compactNum(n: number): string {
   return String(n);
 }
 
-function bar(ratio: number, color: string): React.ReactElement {
-  const filled = Math.max(0, Math.min(BAR_CELLS, Math.round(ratio * BAR_CELLS)));
-  const empty = BAR_CELLS - filled;
+function Row({
+  label,
+  ratio,
+  color,
+  tokens,
+  trail,
+}: {
+  label: string;
+  ratio: number;
+  color: string;
+  tokens: number;
+  trail?: string;
+}): React.ReactElement {
   return (
-    <>
-      <Text color={color}>{"█".repeat(filled)}</Text>
-      <Text color={FG.faint}>{"░".repeat(empty)}</Text>
-    </>
+    <Box flexDirection="row" gap={1}>
+      <Text color={FG.sub}>{label.padEnd(8)}</Text>
+      <ProgressBar ratio={ratio} color={color} cells={BAR_CELLS} />
+      <Text bold color={FG.body}>
+        {tokens.toLocaleString()}
+      </Text>
+      {trail ? <Text color={FG.faint}>{trail}</Text> : null}
+    </Box>
   );
 }
 
@@ -32,67 +46,59 @@ export function UsageCard({ card }: { card: UsageCardData }): React.ReactElement
   const reasonRatio = card.tokens.reason / cap;
   const outputRatio = card.tokens.output / cap;
   const elapsed = card.elapsedMs !== undefined ? ` · ${(card.elapsedMs / 1000).toFixed(1)}s` : "";
-  const meta = `${formatCNY(card.cost)}${elapsed}`;
+  const meta = `turn ${card.turn} · ${formatCNY(card.cost)}${elapsed}`;
 
   return (
-    <Box flexDirection="column">
-      <CardHeader tone="usage" glyph="Σ" title="Usage" subtitle={`turn ${card.turn}`} meta={meta} />
-      <BarRow tone="usage" indent={0} />
-      <BarRow tone="usage">
-        <Text color={FG.sub}>{"prompt    "}</Text>
-        {bar(promptRatio, TONE.brand)}
-        <Text bold color={FG.body}>{`  ${card.tokens.prompt.toLocaleString()}`}</Text>
-        <Text color={FG.faint}>{` / 1M · ${(promptRatio * 100).toFixed(1)}%`}</Text>
-      </BarRow>
-      <BarRow tone="usage">
-        <Text color={FG.sub}>{"reason    "}</Text>
-        {bar(reasonRatio, TONE.accent)}
-        <Text bold color={FG.body}>{`  ${card.tokens.reason.toLocaleString()}`}</Text>
-      </BarRow>
-      <BarRow tone="usage">
-        <Text color={FG.sub}>{"output    "}</Text>
-        {bar(outputRatio, TONE.brand)}
-        <Text bold color={FG.body}>{`  ${card.tokens.output.toLocaleString()}`}</Text>
-      </BarRow>
-      <BarRow tone="usage" indent={0} />
-      <BarRow tone="usage">
-        <Text color={FG.sub}>{"cache hit "}</Text>
-        {bar(card.cacheHit, TONE.ok)}
-        <Text bold color={TONE.ok}>{`  ${(card.cacheHit * 100).toFixed(1)}%`}</Text>
-      </BarRow>
-      <BarRow tone="usage" indent={0} />
-      <BarRow tone="usage">
-        <Text color={FG.faint}>{"session "}</Text>
+    <CardLayout glyph="Σ" tone={TONE.brand} title="usage" meta={meta}>
+      <Row
+        label="prompt"
+        ratio={promptRatio}
+        color={TONE.brand}
+        tokens={card.tokens.prompt}
+        trail={`/ 1M · ${(promptRatio * 100).toFixed(1)}%`}
+      />
+      <Row label="reason" ratio={reasonRatio} color={TONE.accent} tokens={card.tokens.reason} />
+      <Row label="output" ratio={outputRatio} color={TONE.brand} tokens={card.tokens.output} />
+      <Box marginTop={1}>
+        <Row
+          label="cache"
+          ratio={card.cacheHit}
+          color={TONE.ok}
+          tokens={Math.round(card.cacheHit * 100)}
+          trail="%"
+        />
+      </Box>
+      <Box flexDirection="row" gap={1} marginTop={1}>
+        <Text color={FG.faint}>session</Text>
         <Text bold color={FG.body}>{`⛁ ${formatCNY(card.sessionCost, 3)}`}</Text>
-        {card.balance !== undefined && (
+        {card.balance !== undefined ? (
           <>
-            <Text color={FG.meta}>{"  ·  "}</Text>
-            <Text color={FG.faint}>{"balance "}</Text>
+            <Text color={FG.faint}>· balance</Text>
             <Text bold color={TONE.brand}>{`¥${card.balance.toFixed(2)}`}</Text>
           </>
-        )}
-      </BarRow>
-    </Box>
+        ) : null}
+      </Box>
+    </CardLayout>
   );
 }
 
 function CompactUsageRow({ card }: { card: UsageCardData }): React.ReactElement {
-  const elapsed = card.elapsedMs !== undefined ? `  ·  ${(card.elapsedMs / 1000).toFixed(1)}s` : "";
+  const elapsed = card.elapsedMs !== undefined ? ` · ${(card.elapsedMs / 1000).toFixed(1)}s` : "";
   return (
-    <Box>
-      <Text color={FG.faint}>{`  Σ  turn ${card.turn}  ·  `}</Text>
-      <Text
-        color={FG.meta}
-      >{`${compactNum(card.tokens.prompt)} prompt · ${compactNum(card.tokens.output)} out`}</Text>
-      <Text color={FG.faint}>{"  ·  cache "}</Text>
+    <Box flexDirection="row" gap={1}>
+      <Text color={FG.faint}>{`Σ turn ${card.turn}`}</Text>
+      <Text color={FG.meta}>
+        {`${compactNum(card.tokens.prompt)} prompt · ${compactNum(card.tokens.output)} out`}
+      </Text>
+      <Text color={FG.faint}>· cache</Text>
       <Text color={TONE.ok}>{`${(card.cacheHit * 100).toFixed(0)}%`}</Text>
-      <Text color={FG.faint}>{`  ·  ${formatCNY(card.cost)}${elapsed}`}</Text>
-      {card.balance !== undefined && (
+      <Text color={FG.faint}>{`· ${formatCNY(card.cost)}${elapsed}`}</Text>
+      {card.balance !== undefined ? (
         <>
-          <Text color={FG.faint}>{"  ·  "}</Text>
+          <Text color={FG.faint}>·</Text>
           <Text color={TONE.brand}>{`¥${card.balance.toFixed(2)}`}</Text>
         </>
-      )}
+      ) : null}
     </Box>
   );
 }

--- a/src/cli/ui/cards/UserCard.tsx
+++ b/src/cli/ui/cards/UserCard.tsx
@@ -1,24 +1,15 @@
-import { Box, Text } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React from "react";
 import { Markdown } from "../markdown.js";
 import type { UserCard as UserCardData } from "../state/cards.js";
-import { FG, TONE } from "../theme/tokens.js";
+import { TONE } from "../theme/tokens.js";
+import { CardLayout } from "./CardLayout.js";
 import { formatRelativeTime } from "./time.js";
 
 export function UserCard({ card }: { card: UserCardData }): React.ReactElement {
   return (
-    <Box flexDirection="column" marginTop={1}>
-      <Box flexDirection="row" gap={1}>
-        <Text color={TONE.accent}>›</Text>
-        <Text bold color={FG.sub}>
-          you
-        </Text>
-        <Text color={FG.faint}>{`· ${formatRelativeTime(card.ts)}`}</Text>
-      </Box>
-      <Box paddingLeft={2} flexDirection="column">
-        <Markdown text={card.text} />
-      </Box>
-    </Box>
+    <CardLayout glyph="›" tone={TONE.accent} title="you" meta={formatRelativeTime(card.ts)}>
+      <Markdown text={card.text} />
+    </CardLayout>
   );
 }

--- a/src/cli/ui/cards/WarnCard.tsx
+++ b/src/cli/ui/cards/WarnCard.tsx
@@ -1,25 +1,19 @@
-import { Box, Text } from "ink";
+import { Text } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React from "react";
 import type { WarnCard as WarnCardData } from "../state/cards.js";
 import { FG, TONE } from "../theme/tokens.js";
+import { CardLayout } from "./CardLayout.js";
 
 export function WarnCard({ card }: { card: WarnCardData }): React.ReactElement {
   const messageLines = card.message.length > 0 ? card.message.split("\n") : [];
   return (
-    <Box flexDirection="column" marginTop={1}>
-      <Box flexDirection="row" gap={1}>
-        <Text color={TONE.warn}>⚠</Text>
-        <Text color={TONE.warn} bold>
-          {card.title}
-        </Text>
-        {card.detail ? <Text color={FG.faint}>{`· ${card.detail}`}</Text> : null}
-      </Box>
+    <CardLayout glyph="⚠" tone={TONE.warn} title={card.title} meta={card.detail}>
       {messageLines.map((line, i) => (
-        <Box key={`${card.id}:${i}`} paddingLeft={2}>
-          <Text color={FG.body}>{line || " "}</Text>
-        </Box>
+        <Text key={`${card.id}:${i}`} color={FG.body}>
+          {line || " "}
+        </Text>
       ))}
-    </Box>
+    </CardLayout>
   );
 }

--- a/tests/renderer/card-layout.test.tsx
+++ b/tests/renderer/card-layout.test.tsx
@@ -1,0 +1,109 @@
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { CardLayout } from "../../src/cli/ui/cards/CardLayout.js";
+import { ProgressBar } from "../../src/cli/ui/cards/ProgressBar.js";
+import { CharPool, HyperlinkPool, StylePool, mount } from "../../src/renderer/index.js";
+import { Box, Text } from "../../src/renderer/ink-compat/index.js";
+import { makeTestWriter } from "../../src/renderer/runtime/test-writer.js";
+
+function pools() {
+  return { char: new CharPool(), style: new StylePool(), hyperlink: new HyperlinkPool() };
+}
+
+function flush(): Promise<void> {
+  return new Promise((r) => setTimeout(r, 0));
+}
+
+async function render(node: React.ReactElement, height = 8): Promise<string> {
+  const w = makeTestWriter();
+  const handle = mount(node, {
+    viewportWidth: 80,
+    viewportHeight: height,
+    pools: pools(),
+    write: w.write,
+  });
+  await flush();
+  const out = w.output();
+  handle.destroy();
+  return out;
+}
+
+describe("CardLayout", () => {
+  it("renders glyph + bold title", async () => {
+    const out = await render(<CardLayout glyph="◆" tone="#79c0ff" title="reasoning" />);
+    expect(out).toContain("◆");
+    expect(out).toContain("reasoning");
+  });
+
+  it("string meta gets a leading `·` and faint color", async () => {
+    const out = await render(<CardLayout glyph="▶" tone="#79c0ff" title="step 1" meta="2.1s" />);
+    expect(out).toMatch(/2\.1s/);
+    expect(out).toMatch(/·/);
+  });
+
+  it("body is indented under the header", async () => {
+    const out = await render(
+      <CardLayout glyph="‹" tone="#7ee787" title="reply">
+        <Text>indented body</Text>
+      </CardLayout>,
+    );
+    expect(out).toContain("indented body");
+    expect(out).toContain("reply");
+  });
+
+  it("trailing slot renders inline at the right of the header", async () => {
+    const out = await render(
+      <CardLayout glyph="▢" tone="#79c0ff" title="shell" trailing={<Text>WORKING</Text>} />,
+    );
+    expect(out).toContain("WORKING");
+  });
+});
+
+describe("ProgressBar", () => {
+  it("draws a 0% bar as all empty", async () => {
+    const out = await render(
+      <Box>
+        <ProgressBar ratio={0} color="#79c0ff" cells={10} />
+      </Box>,
+    );
+    // 10 empty cells; no filled blocks should be present.
+    expect(out).toContain("░");
+    expect(out).not.toContain("█");
+  });
+
+  it("draws a 100% bar as all filled", async () => {
+    const out = await render(
+      <Box>
+        <ProgressBar ratio={1} color="#79c0ff" cells={10} />
+      </Box>,
+    );
+    expect(out).toContain("█");
+    expect(out).not.toContain("░");
+  });
+
+  it("draws a half bar as half filled / half empty", async () => {
+    const out = await render(
+      <Box>
+        <ProgressBar ratio={0.5} color="#79c0ff" cells={10} />
+      </Box>,
+    );
+    expect(out).toContain("█");
+    expect(out).toContain("░");
+  });
+
+  it("clamps out-of-range ratios", async () => {
+    const negative = await render(
+      <Box>
+        <ProgressBar ratio={-0.5} color="#79c0ff" cells={4} />
+      </Box>,
+    );
+    const huge = await render(
+      <Box>
+        <ProgressBar ratio={2} color="#79c0ff" cells={4} />
+      </Box>,
+    );
+    expect(negative).not.toContain("█");
+    expect(huge).not.toContain("░");
+  });
+});


### PR DESCRIPTION
## Summary
Course-correction PR. Instead of one card-per-PR migration drift, this lifts the repeated pattern into shared primitives so future cards stay coherent and any layout fix lands in one place.

### New primitives
- **`CardLayout`** (`src/cli/ui/cards/CardLayout.tsx`): glyph + bold title + faint meta header row, optional trailing slot (spinners / status badges), body rendered with `paddingLeft={2}`. `marginTop={1}` separates cards in the stack.
- **`ProgressBar`** (`src/cli/ui/cards/ProgressBar.tsx`): the `█░` bar pattern that was hand-rolled in BranchCard / CtxCard / UsageCard, now ratio-clamped and centralized.

### All 18 cards now route through these
Refactored where already card-demo-style (User / Error / Warn / Reasoning / Streaming / Tool / Plan / Task) and migrated where still Ink-era (Branch / Ctx / Diff / Doctor / Memory / Search / SubAgent / Usage / Approval).

`LiveCard` stays a single transient row by design — full card chrome is too heavy for a "thinking…" hint.

`ApprovalCard` (used by Plan / Edit / Choice / Shell / Checkpoint / Revise modals) is now built on `CardLayout` too, with the horizontal-rule + footer-hint convention preserved.

### Why this matters
Before: 18 cards, each rolling its own `<Box marginTop>` + header `<Box flexDirection="row">` + body indent. Tiny inconsistencies (`paddingLeft 2` vs 4, `gap 1` vs implicit space, marginTop on / off) scattered across files. Adding a new card meant reading three existing ones to figure out the convention.

After: import `CardLayout`, pass `glyph` + `tone` + `title` + `meta`, render body as children. Done. New cards take 10 lines.

### Followup (next PR)
Delete `CardBox`, `BarRow`, `CardHeader`, `Pill`, `glyphs.ts` — none are referenced any more. Tests still pass against the new layout.

## Test plan
- [x] `npm run verify` — 2259 tests pass (8 new for the primitives), typecheck clean, lint clean
- [x] Manual: `chat`, `card-demo`, plan-confirm flows all render through the new primitive
- [ ] Reviewer: pick any card, swap `import { CardLayout }` for inlined Box/Text — diff shows exactly what the primitive saved