### PR TITLE
refactor(mcp): deduplicate health badge helpers

### DIFF
--- a/src/cli/ui/McpBrowser.tsx
+++ b/src/cli/ui/McpBrowser.tsx
@@ -5,6 +5,7 @@ import { Box, Text } from "ink";
 import React, { useState } from "react";
 import { useKeystroke } from "./keystroke-context.js";
 import { toggleMcpDisabled } from "./mcp-disable.js";
+import { healthBadge } from "./mcp-health.js";
 import { type ApplyAppend, kickOffMcpReconnect } from "./mcp-reconnect-kickoff.js";
 import type { McpServerSummary } from "./slash/types.js";
 import { COLOR } from "./theme.js";
@@ -104,13 +105,6 @@ function ServerRow({ server, active }: { server: McpServerSummary; active: boole
       ) : null}
     </Box>
   );
-}
-
-function healthBadge(elapsedMs: number): { glyph: string; label: string; color: string } {
-  if (elapsedMs === 0) return { glyph: "✗", label: "no inspect data", color: COLOR.err };
-  if (elapsedMs < 500) return { glyph: "●", label: `healthy · ${elapsedMs}ms`, color: COLOR.ok };
-  if (elapsedMs < 3000) return { glyph: "◌", label: `slow · ${elapsedMs}ms`, color: COLOR.warn };
-  return { glyph: "✗", label: `very slow · ${elapsedMs}ms`, color: COLOR.err };
 }
 
 function capabilityList(s: McpServerSummary): string {

--- a/src/cli/ui/mcp-health.ts
+++ b/src/cli/ui/mcp-health.ts
@@ -1,0 +1,21 @@
+import { COLOR } from "./theme.js";
+
+export interface HealthBadge {
+  glyph: string;
+  label: string;
+  color: string;
+}
+
+export function healthBadge(elapsedMs: number): HealthBadge {
+  if (elapsedMs === 0) return { glyph: "✗", label: "no inspect data", color: COLOR.err };
+  if (elapsedMs < 500) return { glyph: "●", label: `healthy · ${elapsedMs}ms`, color: COLOR.ok };
+  if (elapsedMs < 3000) return { glyph: "◌", label: `slow · ${elapsedMs}ms`, color: COLOR.warn };
+  return { glyph: "✗", label: `very slow · ${elapsedMs}ms`, color: COLOR.err };
+}
+
+// Preserves original slash thresholds: 0 → "● healthy · 0ms" (no === 0 branch)
+export function slashHealthBadge(elapsedMs: number): string {
+  if (elapsedMs < 500) return `● healthy · ${elapsedMs}ms`;
+  if (elapsedMs < 3000) return `◌ slow · ${elapsedMs}ms`;
+  return `✗ very slow · ${elapsedMs}ms`;
+}

--- a/src/cli/ui/slash/handlers/mcp.ts
+++ b/src/cli/ui/slash/handlers/mcp.ts
@@ -2,6 +2,7 @@ import { t } from "../../../../i18n/index.js";
 import type { CacheFirstLoop } from "../../../../loop.js";
 import { applyMcpAppend } from "../../mcp-append.js";
 import { toggleMcpDisabled } from "../../mcp-disable.js";
+import { slashHealthBadge } from "../../mcp-health.js";
 import { kickOffMcpReconnect } from "../../mcp-reconnect-kickoff.js";
 import type { SlashHandler } from "../dispatch.js";
 import { appendSection } from "../helpers.js";
@@ -37,7 +38,7 @@ const mcp: SlashHandler = (args, loop, ctx) => {
       const { report } = s;
       const serverName = report.serverInfo.name || "(unknown)";
       const serverVer = report.serverInfo.version ? ` v${report.serverInfo.version}` : "";
-      const health = healthBadge(report.elapsedMs);
+      const health = slashHealthBadge(report.elapsedMs);
       lines.push(`${health}  [${s.label}] ${serverName}${serverVer}  —  ${s.spec}`);
       lines.push(t("handlers.mcp.toolsLabel", { count: s.toolCount }));
       appendSection(lines, "resources", report.resources);
@@ -71,12 +72,6 @@ const mcp: SlashHandler = (args, loop, ctx) => {
   lines.push(t("handlers.mcp.fallbackChange"));
   return { info: lines.join("\n") };
 };
-
-function healthBadge(elapsedMs: number): string {
-  if (elapsedMs < 500) return `● healthy · ${elapsedMs}ms`;
-  if (elapsedMs < 3000) return `◌ slow · ${elapsedMs}ms`;
-  return `✗ very slow · ${elapsedMs}ms`;
-}
 
 function toggleDisabled(
   action: "disable" | "enable",


### PR DESCRIPTION
Refs #196.

This pulls the MCP health badge formatting into a small CLI UI helper without changing the existing output.

The two call sites looked almost the same, but they are not quite interchangeable:

- `McpBrowser` keeps `elapsedMs === 0` as `no inspect data`
- `/mcp` text output keeps the old threshold behavior, so `0ms` still renders as healthy

So this keeps two helpers in `mcp-health.ts` instead of forcing both paths through one shared function. The `/mcp` line formatting is left alone as well, including the existing spacing around the label and em dash.

I kept this intentionally narrow: no runtime MCP changes, no threshold changes, no output wording changes, and no tests added for the small extraction since the behavior preservation is visible in the diff.

Verified locally with:

- `npm run verify`