### PR TITLE
refactor(mcp): hide host client reads from browse UI

### DIFF
--- a/src/cli/ui/mcp-browse.ts
+++ b/src/cli/ui/mcp-browse.ts
@@ -1,6 +1,5 @@
 /** `/resource` + `/prompt` handlers — async (round-trip to MCP server), so App.tsx calls directly instead of `handleSlash`. */
 
-import type { McpClient } from "../../mcp/client.js";
 import type {
   GetPromptResult,
   McpPromptMessage,
@@ -161,9 +160,8 @@ export async function handleMcpBrowseSlash(
       );
       return;
     }
-    const client: McpClient = server.host.client;
     try {
-      const result = await client.readResource(arg);
+      const result = await server.readResource(arg);
       log.pushInfo(formatResourceContents(arg, result));
     } catch (err) {
       log.pushWarning("readResource failed", (err as Error).message);
@@ -180,9 +178,8 @@ export async function handleMcpBrowseSlash(
     );
     return;
   }
-  const client: McpClient = server.host.client;
   try {
-    const result = await client.getPrompt(arg);
+    const result = await server.getPrompt(arg);
     log.pushInfo(formatPromptMessages(arg, result));
   } catch (err) {
     log.pushWarning("getPrompt failed", (err as Error).message);

--- a/src/mcp/summary.ts
+++ b/src/mcp/summary.ts
@@ -1,5 +1,6 @@
 import type { InspectionReport } from "./inspect.js";
 import type { BridgeEnv, McpClientHost } from "./registry.js";
+import type { GetPromptResult, ReadResourceResult } from "./types.js";
 
 export interface McpServerSummary {
   label: string;
@@ -8,6 +9,8 @@ export interface McpServerSummary {
   report: InspectionReport;
   host: McpClientHost;
   bridgeEnv: BridgeEnv;
+  readResource(uri: string): Promise<ReadResourceResult>;
+  getPrompt(name: string, args?: Record<string, string>): Promise<GetPromptResult>;
 }
 
 export function buildMcpServerSummary(opts: {
@@ -25,5 +28,13 @@ export function buildMcpServerSummary(opts: {
     report: opts.report,
     host: opts.host,
     bridgeEnv: opts.bridgeEnv,
+    readResource(uri) {
+      return opts.host.client.readResource(uri);
+    },
+    getPrompt(name, args) {
+      return args !== undefined
+        ? opts.host.client.getPrompt(name, args)
+        : opts.host.client.getPrompt(name);
+    },
   };
 }

--- a/tests/mcp-append.test.ts
+++ b/tests/mcp-append.test.ts
@@ -50,6 +50,12 @@ function summary(env: BridgeEnv, host: McpClientHost): McpServerSummary {
       prompts: { supported: false, reason: "" },
       elapsedMs: 50,
     },
+    readResource(uri) {
+      return host.client.readResource(uri);
+    },
+    getPrompt(name, args) {
+      return args !== undefined ? host.client.getPrompt(name, args) : host.client.getPrompt(name);
+    },
   };
 }
 

--- a/tests/mcp-browse.test.ts
+++ b/tests/mcp-browse.test.ts
@@ -56,10 +56,18 @@ function server(
   // Tests pass a stubbed `client` for convenience; wrap it in the host shape
   // the bridge expects.
   const { client, ...rest } = partial;
+  const host = rest.host ?? { client: client as never };
   return {
     spec: partial.spec ?? `fake://${partial.label}`,
     toolCount: partial.toolCount ?? 0,
-    host: rest.host ?? { client: client as never },
+    host,
+    bridgeEnv: partial.bridgeEnv ?? {
+      registry: {} as never,
+      host,
+      prefix: "",
+      maxResultChars: 32_000,
+      tracker: null,
+    },
     report: partial.report ?? {
       protocolVersion: "2024-11-05",
       serverInfo: { name: partial.label, version: "1.0" },
@@ -67,6 +75,12 @@ function server(
       tools: { supported: true, items: [] },
       resources: { supported: true, items: [] },
       prompts: { supported: true, items: [] },
+    },
+    readResource(uri) {
+      return host.client.readResource(uri);
+    },
+    getPrompt(name, args) {
+      return args !== undefined ? host.client.getPrompt(name, args) : host.client.getPrompt(name);
     },
     ...rest,
   };


### PR DESCRIPTION
## What

Moves `/resource` and `/prompt` browse calls off direct `server.host.client` access.

`McpServerSummary` now exposes `readResource()` and `getPrompt()`, and `buildMcpServerSummary()` wires those through to the underlying MCP client. The browse UI calls those summary methods instead of importing or reaching into `McpClient` directly.

Refs #196.

## Why

This keeps the UI side on the summary boundary instead of making it know about the host/client internals. It is a small seam for the MCP modularity work in #196, with no intended behavior change.

## How to verify

```sh
npm run verify
```

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time