### PR TITLE
fix(setup): MaskedInput + strip paste markers

### DIFF
--- a/src/cli/ui/MaskedInput.tsx
+++ b/src/cli/ui/MaskedInput.tsx
@@ -1,0 +1,69 @@
+import { Text, useInput } from "ink";
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React, { useRef } from "react";
+import { FG } from "./theme/tokens.js";
+
+export interface MaskedInputProps {
+  value: string;
+  onChange: (next: string) => void;
+  onSubmit: (final: string) => void;
+  mask?: string;
+  placeholder?: string;
+}
+
+/** Windows ConPTY splits bracketed-paste wrappers across stdin chunks; Ink's parser sees them as printable `[`, `2`, `0`, `0`, `~` and they leak into the buffer. Strip them at the input boundary and again at submit. */
+function stripPasteMarkers(s: string): string {
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: ESC (0x1b) is exactly what we're stripping — bracketed-paste wrappers and stray escape bytes leaked from Ink's parser.
+  return s.replace(/\u001b?\[20[01]~/g, "").replace(/\u001b/g, "");
+}
+
+export function MaskedInput({
+  value,
+  onChange,
+  onSubmit,
+  mask = "•",
+  placeholder = "",
+}: MaskedInputProps): React.ReactElement {
+  const valueRef = useRef(value);
+  valueRef.current = value;
+
+  useInput((input, key) => {
+    if (key.return) {
+      onSubmit(stripPasteMarkers(valueRef.current));
+      return;
+    }
+    if (key.backspace || key.delete) {
+      if (valueRef.current.length === 0) return;
+      const next = valueRef.current.slice(0, -1);
+      valueRef.current = next;
+      onChange(next);
+      return;
+    }
+    if (input && !key.ctrl && !key.meta && !key.escape) {
+      const cleaned = stripPasteMarkers(input);
+      if (cleaned.length === 0) return;
+      const next = stripPasteMarkers(valueRef.current + cleaned);
+      valueRef.current = next;
+      onChange(next);
+    }
+  });
+
+  if (value.length === 0) {
+    if (placeholder.length === 0) {
+      return <Text inverse> </Text>;
+    }
+    return (
+      <>
+        <Text inverse>{placeholder[0]}</Text>
+        <Text color={FG.faint}>{placeholder.slice(1)}</Text>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Text>{mask.repeat(value.length)}</Text>
+      <Text inverse> </Text>
+    </>
+  );
+}

--- a/src/cli/ui/Setup.tsx
+++ b/src/cli/ui/Setup.tsx
@@ -1,7 +1,7 @@
 import { Box, Text, useApp } from "ink";
-import TextInput from "ink-text-input";
 import React, { useState } from "react";
 import { defaultConfigPath, isPlausibleKey, redactKey, saveApiKey } from "../../config.js";
+import { MaskedInput } from "./MaskedInput.js";
 import { COLOR, GLYPH, GRADIENT } from "./theme.js";
 
 export interface SetupProps {
@@ -63,7 +63,7 @@ export function Setup({ onReady }: SetupProps) {
         <Text bold color={COLOR.primary}>
           {" › "}
         </Text>
-        <TextInput
+        <MaskedInput
           value={value}
           onChange={setValue}
           onSubmit={handleSubmit}


### PR DESCRIPTION
Two bugs in the Setup screen on Windows / cell-diff renderer:

1. **`ink-text-input` ANSI leak** — the third-party input bakes chalk-styled output into the text it returns. Our renderer strips the ESC byte but keeps the rest, so users saw literal `[7ms[27m[90mk-...[39m` in the input field. Replaced with `MaskedInput` that uses `<Text inverse>` / `<Text dimColor>` primitives — ANSI is emitted by the renderer's style pool.

2. **Bracketed-paste markers leak into value** — Windows ConPTY splits the wrappers (`\x1b[200~ … \x1b[201~`) across stdin chunks, so Ink's parser sees them as printable `[`, `2`, `0`, `0`, `~` and they enter the buffer. Strip them in MaskedInput at both the input boundary and at submit.

Also: fixes a stale-closure bug where a paste burst's keystrokes all read the initial empty `value`, so only the last char survived. A ref synced on every render lets each keystroke append onto the latest accumulated value.

## Test plan

- [x] `npm run chat` (with `.env` removed and `config.json` lacking apiKey) → Setup screen, paste a real `sk-...` key
- [x] Mask shows correct dot count
- [x] Submit accepts the key (no `[200~s…201~` garbage in `redactKey` preview)
- [x] `npx tsc --noEmit` ✅
- [x] `npx biome check` ✅ (only pre-existing warnings)