### PR TITLE
feat(shell): support `|`, `&&`, `||`, `;` chain operators in run_command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reasonix",
-  "version": "0.24.1",
+  "version": "0.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reasonix",
-      "version": "0.24.1",
+      "version": "0.25.0",
       "license": "MIT",
       "dependencies": {
         "cli-highlight": "^2.1.11",
@@ -16,6 +16,7 @@
         "picomatch": "^4.0.4",
         "react": "^18.3.1",
         "react-reconciler": "^0.29.2",
+        "shell-quote": "^1.8.3",
         "string-width": "^7.2.0",
         "yoga-layout": "^3.2.1",
         "zod": "^4.4.1"
@@ -29,6 +30,7 @@
         "@types/picomatch": "^4.0.3",
         "@types/react": "^18.3.12",
         "@types/react-reconciler": "^0.28.9",
+        "@types/shell-quote": "^1.7.5",
         "esbuild": "^0.21.5",
         "highlight.js": "^11.10.0",
         "htm": "^3.1.1",
@@ -1107,6 +1109,13 @@
       "peerDependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/shell-quote": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@types/shell-quote/-/shell-quote-1.7.5.tgz",
+      "integrity": "sha512-+UE8GAGRPbJVQDdxi16dgadcBfQ+KG2vgZhV1+3A1XmHbmwcdwhCUwIdy+d3pAGrbvgRoVSjeI9vOWyq376Yzw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vitest/expect": {
       "version": "2.1.9",
@@ -2551,6 +2560,18 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "picomatch": "^4.0.4",
     "react": "^18.3.1",
     "react-reconciler": "^0.29.2",
+    "shell-quote": "^1.8.3",
     "string-width": "^7.2.0",
     "yoga-layout": "^3.2.1",
     "zod": "^4.4.1"
@@ -83,6 +84,7 @@
     "@types/picomatch": "^4.0.3",
     "@types/react": "^18.3.12",
     "@types/react-reconciler": "^0.28.9",
+    "@types/shell-quote": "^1.7.5",
     "esbuild": "^0.21.5",
     "highlight.js": "^11.10.0",
     "htm": "^3.1.1",

--- a/src/tools/shell-chain.ts
+++ b/src/tools/shell-chain.ts
@@ -1,0 +1,264 @@
+/** Parse + spawn `cmd1 | cmd2 && cmd3` ourselves — never invoke a shell, sidestep PS5.1's `&&` parse error. */
+
+import { type ChildProcess, type SpawnOptions, spawn } from "node:child_process";
+import { parse as shellParse } from "shell-quote";
+import { killProcessTree, prepareSpawn, smartDecodeOutput } from "./shell.js";
+
+export type ChainOp = "|" | "||" | "&&" | ";";
+
+export interface ChainSegment {
+  argv: string[];
+}
+
+export interface CommandChain {
+  segments: ChainSegment[];
+  /** length === segments.length - 1 */
+  ops: ChainOp[];
+}
+
+const CHAIN_OPS = new Set<string>(["|", "||", "&&", ";"]);
+
+export class UnsupportedSyntaxError extends Error {
+  constructor(detail: string) {
+    super(`run_command: ${detail}`);
+    this.name = "UnsupportedSyntaxError";
+  }
+}
+
+/** Returns null on plain commands (caller takes the simple path); throws on unsupported syntax. */
+export function parseCommandChain(cmd: string): CommandChain | null {
+  // shell-quote calls env() with name="" for `$(...)` — defer that to the `(` op handler.
+  const tokens = shellParse(cmd, (name: string) =>
+    name === "" ? "$" : { op: "$VAR" as const, name },
+  );
+  const segments: ChainSegment[] = [];
+  const ops: ChainOp[] = [];
+  let cur: string[] = [];
+  let sawChainOp = false;
+  for (const t of tokens) {
+    if (typeof t === "string") {
+      cur.push(t);
+      continue;
+    }
+    if ("comment" in t) continue;
+    const op = (t as { op: string }).op;
+    if (CHAIN_OPS.has(op)) {
+      sawChainOp = true;
+      if (cur.length === 0) throw new UnsupportedSyntaxError(`empty segment before "${op}"`);
+      segments.push({ argv: cur });
+      ops.push(op as ChainOp);
+      cur = [];
+      continue;
+    }
+    if (op === "glob") {
+      cur.push((t as { pattern: string }).pattern);
+      continue;
+    }
+    if (op === "$VAR") {
+      const name = (t as { name: string }).name;
+      throw new UnsupportedSyntaxError(
+        `\$${name} expansion is not supported — pass values as literals, or use the binary's own --env flag`,
+      );
+    }
+    if (op === "(" || op === ")") {
+      throw new UnsupportedSyntaxError(
+        "command substitution / subshells are not supported — split into separate calls",
+      );
+    }
+    throw new UnsupportedSyntaxError(
+      `shell operator "${op}" is not supported — only \`|\`, \`||\`, \`&&\`, \`;\` chain operators work; redirects (\`>\`, \`<\`, \`2>&1\`) are rejected`,
+    );
+  }
+  if (!sawChainOp) return null;
+  if (cur.length === 0) {
+    throw new UnsupportedSyntaxError(`chain ends with "${ops[ops.length - 1]}"`);
+  }
+  segments.push({ argv: cur });
+  return { segments, ops };
+}
+
+/** Each segment must individually clear the allowlist for the chain to auto-run. */
+export function chainAllowed(
+  chain: CommandChain,
+  isAllowed: (segmentCmd: string) => boolean,
+): boolean {
+  for (const seg of chain.segments) {
+    if (!isAllowed(seg.argv.join(" "))) return false;
+  }
+  return true;
+}
+
+export interface ChainResult {
+  exitCode: number | null;
+  output: string;
+  timedOut: boolean;
+}
+
+interface ChainGroup {
+  segments: ChainSegment[];
+  /** Op connecting the PREVIOUS group to THIS one (`||`, `&&`, `;`); null on the first group. */
+  opBefore: Exclude<ChainOp, "|"> | null;
+}
+
+/** Pipe groups are runs of segments joined by `|`; sequential ops (`||`, `&&`, `;`) split them. */
+function groupChain(chain: CommandChain): ChainGroup[] {
+  const groups: ChainGroup[] = [{ segments: [chain.segments[0]!], opBefore: null }];
+  for (let i = 0; i < chain.ops.length; i++) {
+    const op = chain.ops[i]!;
+    const next = chain.segments[i + 1]!;
+    if (op === "|") {
+      groups[groups.length - 1]!.segments.push(next);
+    } else {
+      groups.push({ segments: [next], opBefore: op });
+    }
+  }
+  return groups;
+}
+
+export interface RunChainOptions {
+  cwd: string;
+  timeoutSec: number;
+  maxOutputChars: number;
+  signal?: AbortSignal;
+}
+
+export async function runChain(chain: CommandChain, opts: RunChainOptions): Promise<ChainResult> {
+  const groups = groupChain(chain);
+  const buf = new OutputBuffer(opts.maxOutputChars * 2 * 4);
+  const deadline = Date.now() + opts.timeoutSec * 1000;
+  let lastExit: number | null = 0;
+  let timedOut = false;
+  for (const group of groups) {
+    if (group.opBefore === "&&" && lastExit !== 0) continue;
+    if (group.opBefore === "||" && lastExit === 0) continue;
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
+      timedOut = true;
+      break;
+    }
+    const result = await runPipeGroup(group.segments, {
+      cwd: opts.cwd,
+      timeoutMs: remainingMs,
+      buf,
+      signal: opts.signal,
+    });
+    lastExit = result.exitCode;
+    if (result.timedOut) {
+      timedOut = true;
+      break;
+    }
+    if (opts.signal?.aborted) break;
+  }
+  const output = buf.toString();
+  const truncated =
+    output.length > opts.maxOutputChars
+      ? `${output.slice(0, opts.maxOutputChars)}\n\n[… truncated ${output.length - opts.maxOutputChars} chars …]`
+      : output;
+  return { exitCode: lastExit, output: truncated, timedOut };
+}
+
+interface PipeGroupResult {
+  exitCode: number | null;
+  timedOut: boolean;
+}
+
+interface PipeGroupOptions {
+  cwd: string;
+  timeoutMs: number;
+  buf: OutputBuffer;
+  signal?: AbortSignal;
+}
+
+async function runPipeGroup(
+  segments: ChainSegment[],
+  opts: PipeGroupOptions,
+): Promise<PipeGroupResult> {
+  const env = { ...process.env, PYTHONIOENCODING: "utf-8", PYTHONUTF8: "1" };
+  const children: ChildProcess[] = [];
+  let timedOut = false;
+  const killAll = () => {
+    for (const c of children) killProcessTree(c);
+  };
+  const killTimer = setTimeout(() => {
+    timedOut = true;
+    killAll();
+  }, opts.timeoutMs);
+  const onAbort = () => killAll();
+  if (opts.signal?.aborted) {
+    onAbort();
+  } else {
+    opts.signal?.addEventListener("abort", onAbort, { once: true });
+  }
+  try {
+    for (let i = 0; i < segments.length; i++) {
+      const isFirst = i === 0;
+      const isLast = i === segments.length - 1;
+      const { bin, args, spawnOverrides } = prepareSpawn(segments[i]!.argv);
+      const spawnOpts: SpawnOptions = {
+        cwd: opts.cwd,
+        shell: false,
+        windowsHide: true,
+        env,
+        stdio: [isFirst ? "ignore" : "pipe", isLast ? "pipe" : "pipe", "pipe"],
+        ...spawnOverrides,
+      };
+      let child: ChildProcess;
+      try {
+        child = spawn(bin, args, spawnOpts);
+      } catch (err) {
+        killAll();
+        clearTimeout(killTimer);
+        opts.signal?.removeEventListener("abort", onAbort);
+        throw err;
+      }
+      children.push(child);
+      if (!isFirst) {
+        const prev = children[i - 1]!;
+        prev.stdout?.on("error", () => {});
+        child.stdin?.on("error", () => {});
+        prev.stdout?.pipe(child.stdin!);
+      }
+      child.stderr?.on("data", (chunk: Buffer | string) => opts.buf.push(toBuf(chunk)));
+      if (isLast) {
+        child.stdout?.on("data", (chunk: Buffer | string) => opts.buf.push(toBuf(chunk)));
+      }
+    }
+    const exits = await Promise.all(
+      children.map(
+        (c) =>
+          new Promise<number | null>((resolve) => {
+            c.once("error", () => resolve(null));
+            c.once("close", (code) => resolve(code));
+          }),
+      ),
+    );
+    return { exitCode: exits[exits.length - 1] ?? null, timedOut };
+  } finally {
+    clearTimeout(killTimer);
+    opts.signal?.removeEventListener("abort", onAbort);
+  }
+}
+
+function toBuf(chunk: Buffer | string): Buffer {
+  return typeof chunk === "string" ? Buffer.from(chunk) : chunk;
+}
+
+class OutputBuffer {
+  private chunks: Buffer[] = [];
+  private bytes = 0;
+  constructor(private readonly cap: number) {}
+  push(b: Buffer): void {
+    if (this.bytes >= this.cap) return;
+    const remaining = this.cap - this.bytes;
+    if (b.length > remaining) {
+      this.chunks.push(b.subarray(0, remaining));
+      this.bytes = this.cap;
+    } else {
+      this.chunks.push(b);
+      this.bytes += b.length;
+    }
+  }
+  toString(): string {
+    return smartDecodeOutput(Buffer.concat(this.chunks));
+  }
+}

--- a/src/tools/shell.ts
+++ b/src/tools/shell.ts
@@ -5,9 +5,16 @@ import { existsSync, statSync } from "node:fs";
 import * as pathMod from "node:path";
 import type { ToolRegistry } from "../tools.js";
 import { JobRegistry } from "./jobs.js";
+import {
+  type CommandChain,
+  UnsupportedSyntaxError,
+  chainAllowed,
+  parseCommandChain,
+  runChain,
+} from "./shell-chain.js";
 
 /** Kill child + descendants. Windows: taskkill /T /F. Unix: SIGKILL the process group when detached, else fall back to SIGKILL on the leader. */
-function killProcessTree(child: ChildProcess): void {
+export function killProcessTree(child: ChildProcess): void {
   if (!child.pid || child.killed) return;
   if (process.platform === "win32") {
     try {
@@ -203,6 +210,18 @@ export function isAllowed(cmd: string, extra: readonly string[] = []): boolean {
   return false;
 }
 
+/** For chain commands, every segment must individually clear the allowlist. */
+export function isCommandAllowed(cmd: string, extra: readonly string[] = []): boolean {
+  let chain: CommandChain | null;
+  try {
+    chain = parseCommandChain(cmd);
+  } catch {
+    return false;
+  }
+  if (chain === null) return isAllowed(cmd, extra);
+  return chainAllowed(chain, (seg) => isAllowed(seg, extra));
+}
+
 export interface RunCommandResult {
   exitCode: number | null;
   /** Combined stdout+stderr, truncated to `maxOutputChars` with a marker. */
@@ -220,16 +239,26 @@ export async function runCommand(
     signal?: AbortSignal;
   },
 ): Promise<RunCommandResult> {
+  const timeoutSec = opts.timeoutSec ?? DEFAULT_TIMEOUT_SEC;
+  const maxChars = opts.maxOutputChars ?? DEFAULT_MAX_OUTPUT_CHARS;
   const argv = tokenizeCommand(cmd);
   if (argv.length === 0) throw new Error("run_command: empty command");
+  const chain = parseCommandChain(cmd);
+  if (chain !== null) {
+    return await runChain(chain, {
+      cwd: opts.cwd,
+      timeoutSec,
+      maxOutputChars: maxChars,
+      signal: opts.signal,
+    });
+  }
   const operator = detectShellOperator(cmd);
   if (operator !== null) {
     throw new Error(
-      `run_command: shell operator "${operator}" is not supported — this tool spawns one process, no shell expansion. Split into separate run_command calls and combine the output in your reasoning (e.g. instead of \`grep foo *.ts | wc -l\`, call \`grep -c foo *.ts\` or two separate commands). To pass "${operator}" as a literal argument, wrap it in quotes.`,
+      `run_command: shell operator "${operator}" is not supported — only \`|\`, \`||\`, \`&&\`, \`;\` chain operators are spawned natively. Redirects (\`>\`, \`<\`, \`2>&1\`) and background (\`&\`) are not supported — split into separate run_command calls. To pass "${operator}" as a literal argument, wrap it in quotes.`,
     );
   }
-  const timeoutMs = (opts.timeoutSec ?? DEFAULT_TIMEOUT_SEC) * 1000;
-  const maxChars = opts.maxOutputChars ?? DEFAULT_MAX_OUTPUT_CHARS;
+  const timeoutMs = timeoutSec * 1000;
 
   const spawnOpts: SpawnOptions = {
     cwd: opts.cwd,
@@ -538,7 +567,7 @@ export function registerShellTools(registry: ToolRegistry, opts: ShellToolsOptio
   registry.register({
     name: "run_command",
     description:
-      "Run a shell command in the project root and return its combined stdout+stderr.\n\nConstraints (read these before the first call):\n• ONE process per call, NO shell expansion. `&&`, `||`, `|`, `;`, `>`, `<`, `2>&1` are all rejected up-front — split into separate calls and combine results in reasoning. Example: instead of `grep foo *.ts | wc -l`, use `grep -c foo *.ts`; instead of `cd sub && npm test`, use `npm test --prefix sub` (or whatever --cwd flag the binary accepts).\n• `cd` DOES NOT PERSIST between calls — each call spawns a fresh process rooted at the project. If a tool needs a subdirectory, pass it via the tool's own flag (`npm --prefix`, `cargo -C`, `git -C`, `pytest tests/…`), NOT via a preceding `cd`.\n• Avoid commands with unbounded output (`netstat -ano`, `find /`, etc.) — they waste tokens. Filter at source: `netstat -ano -p TCP`, `find src -name '*.ts'`, `grep -c`, `wc -l`.\n\nCommon read-only inspection and test/lint/typecheck commands run immediately; anything that could mutate state, install dependencies, or touch the network is refused until the user confirms it in the TUI. Prefer this over asking the user to run a command manually — after edits, run the project's tests to verify.",
+      "Run a shell command in the project root and return its combined stdout+stderr.\n\nConstraints (read these before the first call):\n• Chain operators `|`, `||`, `&&`, `;` ARE supported — parsed natively, no shell invoked, so semantics are identical on Windows / macOS / Linux. Each chain segment is allowlist-checked individually: `git status | grep main` runs if both halves are allowed.\n• Redirects (`>`, `<`, `>>`, `2>&1`, `&>`), background `&`, command substitution `$(…)`, env-var expansion `$VAR`, subshells `(…)`, and process substitution `<(…)` are NOT supported and rejected up-front. Use the binary's own flags (e.g. `node --output=file` instead of `node ... > file`) or split into separate calls.\n• `cd` DOES NOT PERSIST between calls — each call spawns a fresh process rooted at the project. If a tool needs a subdirectory, pass it via the tool's own flag (`npm --prefix`, `cargo -C`, `git -C`, `pytest tests/…`), NOT via a preceding `cd`.\n• Glob patterns (`*.ts`) are passed through as literal arguments — no shell expansion. Use `grep -r`, `rg`, `find -name`, etc.\n• Avoid commands with unbounded output (`netstat -ano`, `find /`, etc.) — they waste tokens. Filter at source: `netstat -ano -p TCP`, `find src -name '*.ts'`, `grep -c`, `wc -l`.\n\nCommon read-only inspection and test/lint/typecheck commands run immediately; anything that could mutate state, install dependencies, or touch the network is refused until the user confirms it in the TUI. Prefer this over asking the user to run a command manually — after edits, run the project's tests to verify.",
     // Plan-mode gate: allow allowlisted commands through (git status,
     // cargo check, ls, grep …) so the model can actually investigate
     // during planning. Anything that would otherwise trigger a
@@ -547,7 +576,7 @@ export function registerShellTools(registry: ToolRegistry, opts: ShellToolsOptio
       if (isAllowAll()) return true;
       const cmd = typeof args?.command === "string" ? args.command.trim() : "";
       if (!cmd) return false;
-      return isAllowed(cmd, getExtraAllowed());
+      return isCommandAllowed(cmd, getExtraAllowed());
     },
     parameters: {
       type: "object",
@@ -555,7 +584,7 @@ export function registerShellTools(registry: ToolRegistry, opts: ShellToolsOptio
         command: {
           type: "string",
           description:
-            'Full command line. Tokenized with POSIX-ish quoting; no shell expansion. Pipes (`|`), redirects (`>`, `<`, `2>`), and `&&`/`||` chaining are rejected with an error — split into separate calls instead. To pass an operator character as a literal argument (e.g. a regex), wrap it in quotes: `grep "a|b" file.txt`.',
+            'Full command line. POSIX-ish quoting. Chain operators `|`, `||`, `&&`, `;` work — parsed natively (no shell). Redirects (`>`, `<`, `2>&1`), background `&`, env-var expansion `$VAR`, and command substitution `$(…)` are rejected. To pass an operator character as a literal argument (e.g. a regex), wrap it in quotes: `grep "a|b" file.txt`.',
         },
         timeoutSec: {
           type: "integer",
@@ -567,7 +596,7 @@ export function registerShellTools(registry: ToolRegistry, opts: ShellToolsOptio
     fn: async (args: { command: string; timeoutSec?: number }, ctx) => {
       const cmd = args.command.trim();
       if (!cmd) throw new Error("run_command: empty command");
-      if (!isAllowAll() && !isAllowed(cmd, getExtraAllowed())) {
+      if (!isAllowAll() && !isCommandAllowed(cmd, getExtraAllowed())) {
         throw new NeedsConfirmationError(cmd);
       }
       const effectiveTimeout = Math.max(1, Math.min(600, args.timeoutSec ?? timeoutSec));

--- a/tests/shell-chain.test.ts
+++ b/tests/shell-chain.test.ts
@@ -1,0 +1,248 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ToolRegistry } from "../src/tools.js";
+import {
+  UnsupportedSyntaxError,
+  chainAllowed,
+  parseCommandChain,
+  runChain,
+} from "../src/tools/shell-chain.js";
+import { isAllowed, isCommandAllowed, registerShellTools, runCommand } from "../src/tools/shell.js";
+
+describe("parseCommandChain", () => {
+  it("returns null on a plain single command", () => {
+    expect(parseCommandChain("git status")).toBeNull();
+    expect(parseCommandChain("node --version")).toBeNull();
+  });
+
+  it("splits on `|`", () => {
+    const c = parseCommandChain("git status | grep main");
+    expect(c).not.toBeNull();
+    expect(c!.segments.map((s) => s.argv)).toEqual([
+      ["git", "status"],
+      ["grep", "main"],
+    ]);
+    expect(c!.ops).toEqual(["|"]);
+  });
+
+  it("splits on `&&`, `||`, `;`", () => {
+    const c = parseCommandChain("a && b || c ; d");
+    expect(c!.segments.map((s) => s.argv.join(" "))).toEqual(["a", "b", "c", "d"]);
+    expect(c!.ops).toEqual(["&&", "||", ";"]);
+  });
+
+  it("handles `|` without surrounding spaces (`a|b`)", () => {
+    const c = parseCommandChain("git status|grep main");
+    expect(c!.segments.map((s) => s.argv)).toEqual([
+      ["git", "status"],
+      ["grep", "main"],
+    ]);
+  });
+
+  it("preserves quoted operators as literal arguments", () => {
+    const c = parseCommandChain('grep "a|b" file');
+    expect(c).toBeNull();
+  });
+
+  it("passes globs through as literal patterns (no shell expansion)", () => {
+    const c = parseCommandChain("ls *.ts | grep test");
+    expect(c!.segments[0]!.argv).toEqual(["ls", "*.ts"]);
+  });
+
+  it("rejects redirects", () => {
+    expect(() => parseCommandChain("echo hi > out.txt")).toThrow(UnsupportedSyntaxError);
+    expect(() => parseCommandChain("sort < in.txt")).toThrow(/<.*not supported/);
+    expect(() => parseCommandChain("cmd 2>&1")).toThrow(/not supported/);
+  });
+
+  it("rejects background `&`", () => {
+    expect(() => parseCommandChain("long_task &")).toThrow(/"&" is not supported/);
+  });
+
+  it("rejects env-var expansion", () => {
+    expect(() => parseCommandChain("echo $HOME")).toThrow(/\$HOME expansion/);
+  });
+
+  it("rejects command substitution", () => {
+    expect(() => parseCommandChain("echo $(date)")).toThrow(/command substitution/);
+  });
+
+  it("rejects empty leading segments", () => {
+    expect(() => parseCommandChain("; echo hi")).toThrow(/empty segment/);
+  });
+
+  it("rejects a chain ending with an operator", () => {
+    expect(() => parseCommandChain("echo hi &&")).toThrow(/chain ends with/);
+  });
+});
+
+describe("chainAllowed", () => {
+  it("requires every segment to clear the allowlist", () => {
+    const c = parseCommandChain("git status | grep foo")!;
+    expect(chainAllowed(c, (seg) => isAllowed(seg))).toBe(true);
+  });
+
+  it("rejects when any segment fails the allowlist", () => {
+    const c = parseCommandChain("git status | rm -rf dist")!;
+    expect(chainAllowed(c, (seg) => isAllowed(seg))).toBe(false);
+  });
+});
+
+describe("isCommandAllowed", () => {
+  it("delegates to isAllowed for plain commands", () => {
+    expect(isCommandAllowed("git status")).toBe(true);
+    expect(isCommandAllowed("rm -rf /")).toBe(false);
+  });
+
+  it("treats every chain segment independently", () => {
+    expect(isCommandAllowed("git status | grep main")).toBe(true);
+    expect(isCommandAllowed("git status && cargo check")).toBe(true);
+    expect(isCommandAllowed("git status | npm install")).toBe(false);
+  });
+
+  it("returns false for unsupported syntax (rather than throwing)", () => {
+    expect(isCommandAllowed("echo hi > out.txt")).toBe(false);
+    expect(isCommandAllowed("echo $(date)")).toBe(false);
+  });
+});
+
+describe("runChain integration", () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "reasonix-chain-"));
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  const opts = (over: Partial<Parameters<typeof runChain>[1]> = {}) => ({
+    cwd: tmp,
+    timeoutSec: 10,
+    maxOutputChars: 32_000,
+    ...over,
+  });
+
+  it("pipes stdout of one segment into stdin of the next", async () => {
+    const chain = parseCommandChain(
+      "node -e \"process.stdout.write('alpha\\nbeta\\n')\" | node -e \"let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>process.stdout.write(d.toUpperCase()))\"",
+    )!;
+    const r = await runChain(chain, opts());
+    expect(r.exitCode).toBe(0);
+    expect(r.output).toContain("ALPHA");
+    expect(r.output).toContain("BETA");
+  });
+
+  it("`&&` short-circuits when the left side fails", async () => {
+    const chain = parseCommandChain(
+      'node -e "process.exit(2)" && node -e "process.stdout.write(\'should-not-run\')"',
+    )!;
+    const r = await runChain(chain, opts());
+    expect(r.exitCode).toBe(2);
+    expect(r.output).not.toContain("should-not-run");
+  });
+
+  it("`&&` runs the right side when the left succeeds", async () => {
+    const chain = parseCommandChain(
+      'node -e "process.exit(0)" && node -e "process.stdout.write(\'ran\')"',
+    )!;
+    const r = await runChain(chain, opts());
+    expect(r.exitCode).toBe(0);
+    expect(r.output).toContain("ran");
+  });
+
+  it("`||` runs the right side when the left fails", async () => {
+    const chain = parseCommandChain(
+      'node -e "process.exit(1)" || node -e "process.stdout.write(\'fallback\')"',
+    )!;
+    const r = await runChain(chain, opts());
+    expect(r.exitCode).toBe(0);
+    expect(r.output).toContain("fallback");
+  });
+
+  it("`||` skips the right side when the left succeeds", async () => {
+    const chain = parseCommandChain(
+      "node -e \"process.stdout.write('ok')\" || node -e \"process.stdout.write('SKIPPED')\"",
+    )!;
+    const r = await runChain(chain, opts());
+    expect(r.exitCode).toBe(0);
+    expect(r.output).toContain("ok");
+    expect(r.output).not.toContain("SKIPPED");
+  });
+
+  it("`;` runs both sides regardless of exit code", async () => {
+    const chain = parseCommandChain(
+      'node -e "process.exit(7); 0" ; node -e "process.stdout.write(\'after\')"',
+    )!;
+    const r = await runChain(chain, opts());
+    expect(r.exitCode).toBe(0);
+    expect(r.output).toContain("after");
+  });
+
+  it("propagates the LAST executed group's exit code", async () => {
+    const chain = parseCommandChain('node -e "process.exit(0)" ; node -e "process.exit(5)"')!;
+    const r = await runChain(chain, opts());
+    expect(r.exitCode).toBe(5);
+  });
+
+  it("merges stderr from earlier pipe segments into the output", async () => {
+    const chain = parseCommandChain(
+      "node -e \"console.error('warn-from-1'); process.stdout.write('hello')\" | node -e \"let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>process.stdout.write(d))\"",
+    )!;
+    const r = await runChain(chain, opts());
+    expect(r.output).toContain("warn-from-1");
+    expect(r.output).toContain("hello");
+  });
+
+  it("times out a chain whose total runtime exceeds the budget", async () => {
+    const chain = parseCommandChain(
+      'node -e "setTimeout(()=>{},5000)" ; node -e "setTimeout(()=>{},5000)"',
+    )!;
+    const r = await runChain(chain, opts({ timeoutSec: 0.2 as unknown as number }));
+    expect(r.timedOut).toBe(true);
+  });
+});
+
+describe("runCommand wired with chains", () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "reasonix-chain-rc-"));
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("runs a pipe through the public runCommand API", async () => {
+    const r = await runCommand(
+      "node -e \"process.stdout.write('hi\\n')\" | node -e \"let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>process.stdout.write(d))\"",
+      { cwd: tmp, timeoutSec: 10 },
+    );
+    expect(r.exitCode).toBe(0);
+    expect(r.output).toContain("hi");
+  });
+
+  it("dispatches a chain through the registered tool when both segments are allowlisted", async () => {
+    const registry = new ToolRegistry();
+    registerShellTools(registry, { rootDir: tmp, extraAllowed: ["node"] });
+    const out = await registry.dispatch(
+      "run_command",
+      JSON.stringify({
+        command:
+          "node -e \"process.stdout.write('hi')\" && node -e \"process.stdout.write(' there')\"",
+      }),
+    );
+    expect(out).toMatch(/\[exit 0\]/);
+    expect(out).toContain("hi there");
+  });
+
+  it("refuses a chain when one segment is not allowlisted", async () => {
+    const registry = new ToolRegistry();
+    registerShellTools(registry, { rootDir: tmp });
+    const out = await registry.dispatch(
+      "run_command",
+      JSON.stringify({ command: "git status | rm -rf dist" }),
+    );
+    expect(out).toMatch(/NeedsConfirmationError/);
+  });
+});

--- a/tests/shell-tools.test.ts
+++ b/tests/shell-tools.test.ts
@@ -109,7 +109,7 @@ describe("detectShellOperator", () => {
   });
 });
 
-describe("runCommand pipe/redirect rejection", () => {
+describe("runCommand redirect rejection", () => {
   let tmp: string;
   beforeEach(() => {
     tmp = mkdtempSync(join(tmpdir(), "reasonix-shell-pipe-"));
@@ -118,26 +118,38 @@ describe("runCommand pipe/redirect rejection", () => {
     rmSync(tmp, { recursive: true, force: true });
   });
 
-  it("rejects a pipe command with a helpful error", async () => {
-    await expect(runCommand("echo hi | cat", { cwd: tmp })).rejects.toThrow(
-      /shell operator "\|" is not supported/,
-    );
-  });
-
-  it("rejects a redirect command with a helpful error", async () => {
+  it("rejects stdout redirect", async () => {
     await expect(runCommand("echo hi > out.txt", { cwd: tmp })).rejects.toThrow(
       /shell operator ">" is not supported/,
     );
   });
 
-  it("error message points the model at splitting the call", async () => {
-    try {
-      await runCommand("a && b", { cwd: tmp });
-    } catch (err) {
-      expect((err as Error).message).toMatch(/Split into separate run_command calls/i);
-      return;
-    }
-    throw new Error("expected runCommand to reject");
+  it("rejects stderr-merge redirect", async () => {
+    await expect(runCommand("node -v 2>&1", { cwd: tmp })).rejects.toThrow(/shell operator/);
+  });
+
+  it("rejects background `&`", async () => {
+    await expect(runCommand("node -v &", { cwd: tmp })).rejects.toThrow(
+      /shell operator "&" is not supported/,
+    );
+  });
+
+  it("rejects `$VAR` env-var expansion", async () => {
+    await expect(runCommand("echo $HOME", { cwd: tmp })).rejects.toThrow(
+      /\$HOME expansion is not supported/,
+    );
+  });
+
+  it("rejects command substitution `$(…)`", async () => {
+    await expect(runCommand("echo $(date)", { cwd: tmp })).rejects.toThrow(/command substitution/);
+  });
+
+  it("rejects an empty leading segment", async () => {
+    await expect(runCommand("; echo hi", { cwd: tmp })).rejects.toThrow(/empty segment before/);
+  });
+
+  it("rejects a chain ending with an operator", async () => {
+    await expect(runCommand("echo hi &&", { cwd: tmp })).rejects.toThrow(/chain ends with/);
   });
 });
 


### PR DESCRIPTION
Closes #232. Addresses discussion #231.

## What changes

`run_command` now supports the four most common chain operators: `|`, `&&`, `||`, `;`. Each segment is parsed via [`shell-quote`](https://www.npmjs.com/package/shell-quote) and spawned as a separate process — no system shell is ever invoked.

```
git status | grep main           # pipe — wired stdout→stdin
node -v && cargo check           # AND — short-circuit on non-zero
node -v || echo "node missing"   # OR — short-circuit on zero
mkdir tmp ; ls tmp               # sequence — always continue
```

## Why not just `shell: true`

The four shells we'd hand the string to disagree on the basics:

| Operator | bash/zsh | PowerShell 5.1 | PowerShell 7+ | cmd.exe |
|---|---|---|---|---|
| `\|` | bytes | objects, not bytes | objects | bytes |
| `&&` `\|\|` | yes | **parse error** | yes | yes |
| `;` | yes | yes | yes | no |
| `2>&1` | merge | wraps stderr as ErrorRecord | same | merge |

PowerShell 5.1 (the default on Windows 10/11) literally parse-errors on `&&`, so a shell-passthrough path would break `node -v && npm test` for every Windows user. Parsing ourselves and spawning each segment sidesteps the whole zoo — semantics are identical on every OS.

## Granular allowlist (the bit @wviana asked for)

Each segment is allowlist-checked **independently**: `git status | grep main` auto-runs because both halves are individually allowed. Previously the whole string was checked as one prefix and never matched.

```ts
isCommandAllowed("git status | grep main")  // → true
isCommandAllowed("git status | rm -rf dist") // → false (rm not allowed)
```

## Out of scope (rejected with a clear error)

- **Redirects** (`>`, `<`, `2>&1`, `&>`) — Phase 2 will implement these as stream piping, still no shell.
- **Background `&`** — doesn't fit `run_command`'s synchronous model; use `run_background`.
- **Env-var expansion `\$VAR`** — pass values literally or use the binary's own flags.
- **Command substitution `\$(…)`** and subshells `(…)` — split into separate calls.
- **Glob expansion `*.ts`** — passed through as a literal argument; tools like `grep -r` / `rg` / `find` already glob themselves.

## Compatibility note

The strict POSIX parser disagrees with the previous lenient tokenizer in one edge case: an unquoted `&` mid-token (`cargo run -- --flag=1&2`) used to pass through as a single argv. It now rejects with `"&" is not supported`. The fix is to quote: `cargo run -- "--flag=1&2"`. This is the POSIX-correct form and matches what every real shell would do.

## Test plan

- [x] 29 new tests in `tests/shell-chain.test.ts` covering parser, allowlist, pipe wiring, `&&`/`||` short-circuit, `;` sequence, exit-code propagation, stderr merge, timeouts, dispatch integration.
- [x] Existing 7 rejection tests in `tests/shell-tools.test.ts` updated to reflect chain ops being supported and redirects / `&` / `\$VAR` / `\$(...)` / empty-segment / trailing-op being rejected.
- [x] `npm run verify` — 2198 tests pass, no biome / typecheck errors on changed files.