### PR TITLE
fix(shell): preserve lenient tokenization in chain segments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "picomatch": "^4.0.4",
         "react": "^18.3.1",
         "react-reconciler": "^0.29.2",
-        "shell-quote": "^1.8.3",
         "string-width": "^7.2.0",
         "yoga-layout": "^3.2.1",
         "zod": "^4.4.1"
@@ -30,7 +29,6 @@
         "@types/picomatch": "^4.0.3",
         "@types/react": "^18.3.12",
         "@types/react-reconciler": "^0.28.9",
-        "@types/shell-quote": "^1.7.5",
         "esbuild": "^0.21.5",
         "highlight.js": "^11.10.0",
         "htm": "^3.1.1",
@@ -1109,13 +1107,6 @@
       "peerDependencies": {
         "@types/react": "*"
       }
-    },
-    "node_modules/@types/shell-quote": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/@types/shell-quote/-/shell-quote-1.7.5.tgz",
-      "integrity": "sha512-+UE8GAGRPbJVQDdxi16dgadcBfQ+KG2vgZhV1+3A1XmHbmwcdwhCUwIdy+d3pAGrbvgRoVSjeI9vOWyq376Yzw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@vitest/expect": {
       "version": "2.1.9",
@@ -2560,18 +2551,6 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
-      }
-    },
-    "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "picomatch": "^4.0.4",
     "react": "^18.3.1",
     "react-reconciler": "^0.29.2",
-    "shell-quote": "^1.8.3",
     "string-width": "^7.2.0",
     "yoga-layout": "^3.2.1",
     "zod": "^4.4.1"
@@ -84,7 +83,6 @@
     "@types/picomatch": "^4.0.3",
     "@types/react": "^18.3.12",
     "@types/react-reconciler": "^0.28.9",
-    "@types/shell-quote": "^1.7.5",
     "esbuild": "^0.21.5",
     "highlight.js": "^11.10.0",
     "htm": "^3.1.1",

--- a/src/tools/shell-chain.ts
+++ b/src/tools/shell-chain.ts
@@ -1,8 +1,13 @@
 /** Parse + spawn `cmd1 | cmd2 && cmd3` ourselves — never invoke a shell, sidestep PS5.1's `&&` parse error. */
 
 import { type ChildProcess, type SpawnOptions, spawn } from "node:child_process";
-import { parse as shellParse } from "shell-quote";
-import { killProcessTree, prepareSpawn, smartDecodeOutput } from "./shell.js";
+import {
+  detectShellOperator,
+  killProcessTree,
+  prepareSpawn,
+  smartDecodeOutput,
+  tokenizeCommand,
+} from "./shell.js";
 
 export type ChainOp = "|" | "||" | "&&" | ";";
 
@@ -16,8 +21,6 @@ export interface CommandChain {
   ops: ChainOp[];
 }
 
-const CHAIN_OPS = new Set<string>(["|", "||", "&&", ";"]);
-
 export class UnsupportedSyntaxError extends Error {
   constructor(detail: string) {
     super(`run_command: ${detail}`);
@@ -25,55 +28,92 @@ export class UnsupportedSyntaxError extends Error {
   }
 }
 
-/** Returns null on plain commands (caller takes the simple path); throws on unsupported syntax. */
-export function parseCommandChain(cmd: string): CommandChain | null {
-  // shell-quote calls env() with name="" for `$(...)` — defer that to the `(` op handler.
-  const tokens = shellParse(cmd, (name: string) =>
-    name === "" ? "$" : { op: "$VAR" as const, name },
-  );
-  const segments: ChainSegment[] = [];
+/** Whitespace-bounded splitter — chain ops only count when they begin a token, so `--flag=1&2` stays literal. */
+function splitOnChainOps(cmd: string): { segs: string[]; ops: ChainOp[] } {
+  const segs: string[] = [];
   const ops: ChainOp[] = [];
-  let cur: string[] = [];
-  let sawChainOp = false;
-  for (const t of tokens) {
-    if (typeof t === "string") {
-      cur.push(t);
+  let segStart = 0;
+  let i = 0;
+  let quote: '"' | "'" | null = null;
+  let atTokenStart = true;
+  while (i < cmd.length) {
+    const ch = cmd[i]!;
+    if (quote) {
+      if (ch === quote) quote = null;
+      else if (ch === "\\" && quote === '"' && i + 1 < cmd.length) i++;
+      i++;
+      atTokenStart = false;
       continue;
     }
-    if ("comment" in t) continue;
-    const op = (t as { op: string }).op;
-    if (CHAIN_OPS.has(op)) {
-      sawChainOp = true;
-      if (cur.length === 0) throw new UnsupportedSyntaxError(`empty segment before "${op}"`);
-      segments.push({ argv: cur });
-      ops.push(op as ChainOp);
-      cur = [];
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      i++;
+      atTokenStart = false;
       continue;
     }
-    if (op === "glob") {
-      cur.push((t as { pattern: string }).pattern);
+    if (ch === " " || ch === "\t") {
+      i++;
+      atTokenStart = true;
       continue;
     }
-    if (op === "$VAR") {
-      const name = (t as { name: string }).name;
+    if (atTokenStart) {
+      let op: ChainOp | null = null;
+      let opLen = 0;
+      const next = cmd[i + 1];
+      if (ch === "|" && next === "|") {
+        op = "||";
+        opLen = 2;
+      } else if (ch === "&" && next === "&") {
+        op = "&&";
+        opLen = 2;
+      } else if (ch === "|") {
+        op = "|";
+        opLen = 1;
+      } else if (ch === ";") {
+        op = ";";
+        opLen = 1;
+      }
+      if (op !== null) {
+        segs.push(cmd.slice(segStart, i));
+        ops.push(op);
+        i += opLen;
+        segStart = i;
+        atTokenStart = true;
+        continue;
+      }
+    }
+    i++;
+    atTokenStart = false;
+  }
+  segs.push(cmd.slice(segStart));
+  return { segs, ops };
+}
+
+/** Returns null on plain commands (caller takes the simple path); throws on unsupported syntax inside any segment. */
+export function parseCommandChain(cmd: string): CommandChain | null {
+  const { segs, ops } = splitOnChainOps(cmd);
+  if (ops.length === 0) return null;
+  const segments: ChainSegment[] = [];
+  for (let i = 0; i < segs.length; i++) {
+    const trimmed = segs[i]!.trim();
+    if (trimmed.length === 0) {
+      const op = i === 0 ? ops[0]! : ops[i - 1]!;
       throw new UnsupportedSyntaxError(
-        `\$${name} expansion is not supported — pass values as literals, or use the binary's own --env flag`,
+        i === 0
+          ? `empty segment before "${op}"`
+          : i === segs.length - 1
+            ? `chain ends with "${op}"`
+            : `empty segment between "${ops[i - 1]}" and "${ops[i]}"`,
       );
     }
-    if (op === "(" || op === ")") {
+    const segOp = detectShellOperator(trimmed);
+    if (segOp !== null) {
       throw new UnsupportedSyntaxError(
-        "command substitution / subshells are not supported — split into separate calls",
+        `shell operator "${segOp}" is not supported — only \`|\`, \`||\`, \`&&\`, \`;\` chain operators are spawned natively. Redirects (\`>\`, \`<\`, \`2>&1\`) and background (\`&\`) require splitting into separate run_command calls.`,
       );
     }
-    throw new UnsupportedSyntaxError(
-      `shell operator "${op}" is not supported — only \`|\`, \`||\`, \`&&\`, \`;\` chain operators work; redirects (\`>\`, \`<\`, \`2>&1\`) are rejected`,
-    );
+    segments.push({ argv: tokenizeCommand(trimmed) });
   }
-  if (!sawChainOp) return null;
-  if (cur.length === 0) {
-    throw new UnsupportedSyntaxError(`chain ends with "${ops[ops.length - 1]}"`);
-  }
-  segments.push({ argv: cur });
   return { segments, ops };
 }
 

--- a/tests/shell-chain.test.ts
+++ b/tests/shell-chain.test.ts
@@ -33,17 +33,9 @@ describe("parseCommandChain", () => {
     expect(c!.ops).toEqual(["&&", "||", ";"]);
   });
 
-  it("handles `|` without surrounding spaces (`a|b`)", () => {
-    const c = parseCommandChain("git status|grep main");
-    expect(c!.segments.map((s) => s.argv)).toEqual([
-      ["git", "status"],
-      ["grep", "main"],
-    ]);
-  });
-
   it("preserves quoted operators as literal arguments", () => {
-    const c = parseCommandChain('grep "a|b" file');
-    expect(c).toBeNull();
+    expect(parseCommandChain('grep "a|b" file')).toBeNull();
+    expect(parseCommandChain("grep 'a|b' file")).toBeNull();
   });
 
   it("passes globs through as literal patterns (no shell expansion)", () => {
@@ -51,30 +43,50 @@ describe("parseCommandChain", () => {
     expect(c!.segments[0]!.argv).toEqual(["ls", "*.ts"]);
   });
 
-  it("rejects redirects", () => {
-    expect(() => parseCommandChain("echo hi > out.txt")).toThrow(UnsupportedSyntaxError);
-    expect(() => parseCommandChain("sort < in.txt")).toThrow(/<.*not supported/);
-    expect(() => parseCommandChain("cmd 2>&1")).toThrow(/not supported/);
+  it("does NOT split on chain chars embedded inside larger tokens", () => {
+    // `--flag=1&2` is one POSIX token; the `&` is a literal byte. Tokens
+    // containing `&` / `|` / `;` chars but not at the start are passed
+    // through untouched, matching the lenient single-command tokenizer.
+    expect(parseCommandChain("cargo run -- --flag=1&2")).toBeNull();
+    expect(parseCommandChain("grep a|b file")).toBeNull();
+    expect(parseCommandChain("echo a;b")).toBeNull();
   });
 
-  it("rejects background `&`", () => {
-    expect(() => parseCommandChain("long_task &")).toThrow(/"&" is not supported/);
+  it("allows embedded chain chars inside chain segments", () => {
+    const c = parseCommandChain("git status ; cargo run -- --flag=1&2");
+    expect(c!.segments.map((s) => s.argv)).toEqual([
+      ["git", "status"],
+      ["cargo", "run", "--", "--flag=1&2"],
+    ]);
+    expect(c!.ops).toEqual([";"]);
   });
 
-  it("rejects env-var expansion", () => {
-    expect(() => parseCommandChain("echo $HOME")).toThrow(/\$HOME expansion/);
+  it("rejects redirects discovered inside a chain segment", () => {
+    expect(() => parseCommandChain("echo hi ; ls > out.txt")).toThrow(/">"/);
+    expect(() => parseCommandChain("git status | wc -l > out.txt")).toThrow(/">"/);
+    expect(() => parseCommandChain("a ; cmd 2>&1")).toThrow(/2>&1/);
   });
 
-  it("rejects command substitution", () => {
-    expect(() => parseCommandChain("echo $(date)")).toThrow(/command substitution/);
+  it("rejects background `&` discovered inside a chain segment", () => {
+    expect(() => parseCommandChain("git status ; long &")).toThrow(/"&" is not supported/);
   });
 
   it("rejects empty leading segments", () => {
     expect(() => parseCommandChain("; echo hi")).toThrow(/empty segment/);
+    expect(() => parseCommandChain("|| cat")).toThrow(/empty segment/);
   });
 
   it("rejects a chain ending with an operator", () => {
     expect(() => parseCommandChain("echo hi &&")).toThrow(/chain ends with/);
+    expect(() => parseCommandChain("echo hi ;")).toThrow(/chain ends with/);
+  });
+
+  it("rejects empty middle segments", () => {
+    expect(() => parseCommandChain("a ; ; b")).toThrow(/empty segment/);
+  });
+
+  it("rejects unclosed quotes inside a chain segment", () => {
+    expect(() => parseCommandChain('git status ; echo "open')).toThrow(/unclosed/);
   });
 });
 
@@ -104,7 +116,7 @@ describe("isCommandAllowed", () => {
 
   it("returns false for unsupported syntax (rather than throwing)", () => {
     expect(isCommandAllowed("echo hi > out.txt")).toBe(false);
-    expect(isCommandAllowed("echo $(date)")).toBe(false);
+    expect(isCommandAllowed("echo hi &")).toBe(false);
   });
 });
 

--- a/tests/shell-tools.test.ts
+++ b/tests/shell-tools.test.ts
@@ -134,16 +134,6 @@ describe("runCommand redirect rejection", () => {
     );
   });
 
-  it("rejects `$VAR` env-var expansion", async () => {
-    await expect(runCommand("echo $HOME", { cwd: tmp })).rejects.toThrow(
-      /\$HOME expansion is not supported/,
-    );
-  });
-
-  it("rejects command substitution `$(…)`", async () => {
-    await expect(runCommand("echo $(date)", { cwd: tmp })).rejects.toThrow(/command substitution/);
-  });
-
   it("rejects an empty leading segment", async () => {
     await expect(runCommand("; echo hi", { cwd: tmp })).rejects.toThrow(/empty segment before/);
   });


### PR DESCRIPTION
Follow-up to #233. Fixes the regression flagged in the PR description.

## Problem

#233 used `shell-quote` for chain segmentation. shell-quote follows POSIX strictly, so it tokenizes `cargo run -- --flag=1&2` as three tokens with `&` flagged as a background operator and rejects the call. Pre-#233, `tokenizeCommand` (lenient by design) treated `--flag=1&2` as one literal argv.

That leniency is a deliberate, long-standing choice in this codebase — see the existing `detectShellOperator` test that documents it explicitly. shell-quote pulls in the opposite direction; mixing the two means fighting one with the other.

## Fix

Drop `shell-quote` entirely. Replace the chain splitter with `splitOnChainOps` (~50 lines): a whitespace-bounded walker that mirrors `detectShellOperator`'s convention — a chain operator only counts when it begins a whitespace-separated token. Each segment then runs through the existing `tokenizeCommand` (lenient) and `detectShellOperator` (rejects `>`, `<`, `&`, `2>&1`, `&>`).

This way the chain layer is consistent with the rest of `src/tools/shell.ts`: same primitives, same lenient philosophy, same UX for model output that isn't perfectly POSIX.

## What recovers

```
cargo run -- --flag=1&2                      # runs (was rejected post-#233)
git status ; cargo run -- --flag=1&2         # chain runs, second segment keeps &
grep a|b file                                # runs as one segment with regex `a|b`
echo a;b                                     # runs as `echo a;b` (no chain)
```

## What changes

- `git status|grep main` (no spaces around `|`) is no longer treated as a chain. It was a shell-quote-only side effect — never worked pre-#233. Aligns the chain detector with `detectShellOperator`.
- `$VAR` and `$(…)` are no longer rejected. They pass through as literal argv (since we don't invoke a shell). Same as the existing single-command tokenizer's behavior. Models see `$HOME` in echo's output and learn.

## Why not "keep shell-quote + post-process"

The post-process layer would need to walk the original string, find each operator's position, check whether it's at a whitespace boundary, and re-glue tokens that aren't. That's ~30 lines of fight-the-library code on top of the library, with more edge cases than just doing the splitting ourselves. The hand-rolled `splitOnChainOps` is the same complexity tier as the existing `tokenizeCommand` (also hand-rolled) and consistent with the project's lenient philosophy.

## Tests

- New parser tests: `does NOT split on chain chars embedded inside larger tokens`, `allows embedded chain chars inside chain segments`, `rejects redirects/background discovered inside a chain segment`, `rejects empty middle segments`, `rejects unclosed quotes inside a chain segment`.
- Removed: shell-quote-only `$VAR` and `$(…)` rejection tests.
- 105 shell-related tests pass; 2197 total.