### PR TITLE
feat(shell): support file redirects in run_command

### DIFF
--- a/src/tools/shell-chain.ts
+++ b/src/tools/shell-chain.ts
@@ -426,10 +426,20 @@ async function runPipeGroup(
         const prev = children[i - 1]!;
         prev.stdout?.on("error", () => {});
         child.stdin?.on("error", () => {});
-        prev.stdout?.pipe(child.stdin!);
-        if (segments[i - 1]!.redirects.some((r) => r.kind === "2>&1") && prev.stderr) {
+        const prevMergesStderr =
+          segments[i - 1]!.redirects.some((r) => r.kind === "2>&1") && !!prev.stderr;
+        if (prevMergesStderr && prev.stderr) {
           prev.stderr.on("error", () => {});
+          let openSources = 2;
+          const closeIfDone = () => {
+            if (--openSources === 0) child.stdin?.end();
+          };
+          prev.stdout?.pipe(child.stdin!, { end: false });
           prev.stderr.pipe(child.stdin!, { end: false });
+          prev.stdout?.once("end", closeIfDone);
+          prev.stderr.once("end", closeIfDone);
+        } else {
+          prev.stdout?.pipe(child.stdin!);
         }
       }
       if (child.stderr && io.stderrFd === null && !(io.mergeStderrToStdout && !isLast)) {

--- a/src/tools/shell-chain.ts
+++ b/src/tools/shell-chain.ts
@@ -1,18 +1,23 @@
-/** Parse + spawn `cmd1 | cmd2 && cmd3` ourselves — never invoke a shell, sidestep PS5.1's `&&` parse error. */
+/** Parse + spawn `cmd1 | cmd2 && cmd3 > out` ourselves — never invoke a shell, sidestep PS5.1's `&&` parse error and codepage drift. */
 
 import { type ChildProcess, type SpawnOptions, spawn } from "node:child_process";
-import {
-  detectShellOperator,
-  killProcessTree,
-  prepareSpawn,
-  smartDecodeOutput,
-  tokenizeCommand,
-} from "./shell.js";
+import { closeSync, openSync } from "node:fs";
+import * as pathMod from "node:path";
+import { killProcessTree, prepareSpawn, smartDecodeOutput } from "./shell.js";
 
 export type ChainOp = "|" | "||" | "&&" | ";";
 
+export type RedirectKind = ">" | ">>" | "<" | "2>" | "2>>" | "2>&1" | "&>";
+
+export interface Redirect {
+  kind: RedirectKind;
+  /** File path resolved against the chain's cwd; empty for `2>&1`. */
+  target: string;
+}
+
 export interface ChainSegment {
   argv: string[];
+  redirects: Redirect[];
 }
 
 export interface CommandChain {
@@ -89,10 +94,130 @@ function splitOnChainOps(cmd: string): { segs: string[]; ops: ChainOp[] } {
   return { segs, ops };
 }
 
-/** Returns null on plain commands (caller takes the simple path); throws on unsupported syntax inside any segment. */
+/** Single-pass parser: extract argv + trailing/inline redirects from one segment string. */
+function parseSegment(segStr: string): ChainSegment {
+  const argv: string[] = [];
+  const redirects: Redirect[] = [];
+  let cur = "";
+  let curHasContent = false;
+  let pending: RedirectKind | null = null;
+  let quote: '"' | "'" | null = null;
+  const flush = () => {
+    if (!curHasContent && cur.length === 0) return;
+    if (pending) {
+      redirects.push({ kind: pending, target: cur });
+      pending = null;
+    } else {
+      argv.push(cur);
+    }
+    cur = "";
+    curHasContent = false;
+  };
+  let i = 0;
+  while (i < segStr.length) {
+    const ch = segStr[i]!;
+    if (quote) {
+      if (ch === quote) {
+        quote = null;
+      } else if (ch === "\\" && quote === '"' && i + 1 < segStr.length) {
+        cur += segStr[++i] ?? "";
+        curHasContent = true;
+      } else {
+        cur += ch;
+        curHasContent = true;
+      }
+      i++;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      curHasContent = true;
+      i++;
+      continue;
+    }
+    if (ch === " " || ch === "\t") {
+      flush();
+      i++;
+      continue;
+    }
+    if (cur.length === 0 && !curHasContent) {
+      const remaining = segStr.slice(i);
+      let matched: { op: RedirectKind; len: number } | null = null;
+      if (remaining.startsWith("2>&1")) matched = { op: "2>&1", len: 4 };
+      else if (remaining.startsWith("&>")) matched = { op: "&>", len: 2 };
+      else if (remaining.startsWith("2>>")) matched = { op: "2>>", len: 3 };
+      else if (remaining.startsWith("2>")) matched = { op: "2>", len: 2 };
+      else if (remaining.startsWith(">>")) matched = { op: ">>", len: 2 };
+      else if (remaining.startsWith(">")) matched = { op: ">", len: 1 };
+      else if (remaining.startsWith("<<")) {
+        throw new UnsupportedSyntaxError(
+          'shell operator "<<" is not supported — heredoc / here-string is not implemented; pass input via a "<" file or the binary\'s --input flag',
+        );
+      } else if (remaining.startsWith("<")) matched = { op: "<", len: 1 };
+      if (matched) {
+        if (pending !== null) {
+          throw new UnsupportedSyntaxError(
+            `redirect "${pending}" is missing a target file before "${matched.op}"`,
+          );
+        }
+        if (matched.op === "2>&1") {
+          redirects.push({ kind: "2>&1", target: "" });
+        } else {
+          pending = matched.op;
+        }
+        i += matched.len;
+        continue;
+      }
+      if (ch === "&") {
+        throw new UnsupportedSyntaxError(
+          'shell operator "&" is not supported — background runs need run_background, not run_command. Wrap a literal `&` arg in quotes.',
+        );
+      }
+    }
+    cur += ch;
+    curHasContent = true;
+    i++;
+  }
+  if (quote) throw new Error(`unclosed ${quote} in command`);
+  flush();
+  if (pending) throw new UnsupportedSyntaxError(`redirect "${pending}" is missing a target file`);
+  if (argv.length === 0 && redirects.length > 0) {
+    throw new UnsupportedSyntaxError(
+      "redirect without a command — segment must have at least one program argument",
+    );
+  }
+  validateRedirectFds(redirects);
+  return { argv, redirects };
+}
+
+/** stdin (`<`) ≤1, stdout (`>`/`>>`/`&>`) ≤1, stderr (`2>`/`2>>`/`&>`/`2>&1`) ≤1; reject conflicts. */
+function validateRedirectFds(redirects: readonly Redirect[]): void {
+  let stdin = 0;
+  let stdout = 0;
+  let stderr = 0;
+  for (const r of redirects) {
+    if (r.kind === "<") stdin++;
+    else if (r.kind === ">" || r.kind === ">>") stdout++;
+    else if (r.kind === "2>" || r.kind === "2>>" || r.kind === "2>&1") stderr++;
+    else if (r.kind === "&>") {
+      stdout++;
+      stderr++;
+    }
+  }
+  if (stdin > 1) throw new UnsupportedSyntaxError("multiple `<` stdin redirects in one segment");
+  if (stdout > 1)
+    throw new UnsupportedSyntaxError(
+      "multiple stdout redirects in one segment (`>` / `>>` / `&>` conflict)",
+    );
+  if (stderr > 1)
+    throw new UnsupportedSyntaxError(
+      "multiple stderr redirects in one segment (`2>` / `2>>` / `&>` / `2>&1` conflict)",
+    );
+}
+
+/** Returns null on plain commands without redirects (caller takes the simple path). */
 export function parseCommandChain(cmd: string): CommandChain | null {
   const { segs, ops } = splitOnChainOps(cmd);
-  if (ops.length === 0) return null;
   const segments: ChainSegment[] = [];
   for (let i = 0; i < segs.length; i++) {
     const trimmed = segs[i]!.trim();
@@ -106,14 +231,9 @@ export function parseCommandChain(cmd: string): CommandChain | null {
             : `empty segment between "${ops[i - 1]}" and "${ops[i]}"`,
       );
     }
-    const segOp = detectShellOperator(trimmed);
-    if (segOp !== null) {
-      throw new UnsupportedSyntaxError(
-        `shell operator "${segOp}" is not supported — only \`|\`, \`||\`, \`&&\`, \`;\` chain operators are spawned natively. Redirects (\`>\`, \`<\`, \`2>&1\`) and background (\`&\`) require splitting into separate run_command calls.`,
-      );
-    }
-    segments.push({ argv: tokenizeCommand(trimmed) });
+    segments.push(parseSegment(trimmed));
   }
+  if (ops.length === 0 && segments[0]!.redirects.length === 0) return null;
   return { segments, ops };
 }
 
@@ -209,12 +329,54 @@ interface PipeGroupOptions {
   signal?: AbortSignal;
 }
 
+interface SegmentStdio {
+  /** Input fd for `<` redirect, or null when reading from prev pipe / nothing. */
+  stdinFd: number | null;
+  /** Output fd for `>`/`>>`/`&>` redirect, or null when writing to pipe / our buffer. */
+  stdoutFd: number | null;
+  /** Output fd for `2>`/`2>>`/`&>` redirect, or null when default. */
+  stderrFd: number | null;
+  mergeStderrToStdout: boolean;
+  toClose: number[];
+}
+
+function openRedirects(redirects: readonly Redirect[], cwd: string): SegmentStdio {
+  let stdinFd: number | null = null;
+  let stdoutFd: number | null = null;
+  let stderrFd: number | null = null;
+  let mergeStderrToStdout = false;
+  let bothFd: number | null = null;
+  const toClose: number[] = [];
+  const open = (target: string, flags: "r" | "w" | "a"): number => {
+    const resolved = pathMod.resolve(cwd, target);
+    const fd = openSync(resolved, flags);
+    toClose.push(fd);
+    return fd;
+  };
+  for (const r of redirects) {
+    if (r.kind === "<") stdinFd = open(r.target, "r");
+    else if (r.kind === ">") stdoutFd = open(r.target, "w");
+    else if (r.kind === ">>") stdoutFd = open(r.target, "a");
+    else if (r.kind === "2>") stderrFd = open(r.target, "w");
+    else if (r.kind === "2>>") stderrFd = open(r.target, "a");
+    else if (r.kind === "&>") {
+      bothFd = open(r.target, "w");
+      stdoutFd = bothFd;
+      stderrFd = bothFd;
+    } else if (r.kind === "2>&1") {
+      mergeStderrToStdout = true;
+    }
+  }
+  return { stdinFd, stdoutFd, stderrFd, mergeStderrToStdout, toClose };
+}
+
 async function runPipeGroup(
   segments: ChainSegment[],
   opts: PipeGroupOptions,
 ): Promise<PipeGroupResult> {
   const env = { ...process.env, PYTHONIOENCODING: "utf-8", PYTHONUTF8: "1" };
   const children: ChildProcess[] = [];
+  const allFds: number[] = [];
   let timedOut = false;
   const killAll = () => {
     for (const c of children) killProcessTree(c);
@@ -233,34 +395,52 @@ async function runPipeGroup(
     for (let i = 0; i < segments.length; i++) {
       const isFirst = i === 0;
       const isLast = i === segments.length - 1;
-      const { bin, args, spawnOverrides } = prepareSpawn(segments[i]!.argv);
+      const seg = segments[i]!;
+      const io = openRedirects(seg.redirects, opts.cwd);
+      allFds.push(...io.toClose);
+      const { bin, args, spawnOverrides } = prepareSpawn(seg.argv);
+      const stdoutSpec = io.stdoutFd !== null ? io.stdoutFd : "pipe";
+      const stderrSpec =
+        io.stderrFd !== null ? io.stderrFd : io.mergeStderrToStdout ? stdoutSpec : "pipe";
+      const stdinSpec = io.stdinFd !== null ? io.stdinFd : isFirst ? "ignore" : "pipe";
       const spawnOpts: SpawnOptions = {
         cwd: opts.cwd,
         shell: false,
         windowsHide: true,
         env,
-        stdio: [isFirst ? "ignore" : "pipe", isLast ? "pipe" : "pipe", "pipe"],
+        stdio: [stdinSpec, stdoutSpec, stderrSpec],
         ...spawnOverrides,
       };
       let child: ChildProcess;
       try {
         child = spawn(bin, args, spawnOpts);
       } catch (err) {
+        for (const fd of allFds) tryClose(fd);
         killAll();
         clearTimeout(killTimer);
         opts.signal?.removeEventListener("abort", onAbort);
         throw err;
       }
       children.push(child);
-      if (!isFirst) {
+      if (!isFirst && io.stdinFd === null) {
         const prev = children[i - 1]!;
         prev.stdout?.on("error", () => {});
         child.stdin?.on("error", () => {});
         prev.stdout?.pipe(child.stdin!);
+        if (segments[i - 1]!.redirects.some((r) => r.kind === "2>&1") && prev.stderr) {
+          prev.stderr.on("error", () => {});
+          prev.stderr.pipe(child.stdin!, { end: false });
+        }
       }
-      child.stderr?.on("data", (chunk: Buffer | string) => opts.buf.push(toBuf(chunk)));
-      if (isLast) {
-        child.stdout?.on("data", (chunk: Buffer | string) => opts.buf.push(toBuf(chunk)));
+      if (child.stderr && io.stderrFd === null && !(io.mergeStderrToStdout && !isLast)) {
+        child.stderr.on("data", (chunk: Buffer | string) => opts.buf.push(toBuf(chunk)));
+      }
+      if (isLast && child.stdout && io.stdoutFd === null) {
+        child.stdout.on("data", (chunk: Buffer | string) => opts.buf.push(toBuf(chunk)));
+        if (io.mergeStderrToStdout && child.stderr && io.stderrFd === null) {
+          child.stderr.removeAllListeners("data");
+          child.stderr.on("data", (chunk: Buffer | string) => opts.buf.push(toBuf(chunk)));
+        }
       }
     }
     const exits = await Promise.all(
@@ -274,8 +454,17 @@ async function runPipeGroup(
     );
     return { exitCode: exits[exits.length - 1] ?? null, timedOut };
   } finally {
+    for (const fd of allFds) tryClose(fd);
     clearTimeout(killTimer);
     opts.signal?.removeEventListener("abort", onAbort);
+  }
+}
+
+function tryClose(fd: number): void {
+  try {
+    closeSync(fd);
+  } catch {
+    /* already closed by spawn handover or kernel */
   }
 }
 

--- a/src/tools/shell.ts
+++ b/src/tools/shell.ts
@@ -252,12 +252,6 @@ export async function runCommand(
       signal: opts.signal,
     });
   }
-  const operator = detectShellOperator(cmd);
-  if (operator !== null) {
-    throw new Error(
-      `run_command: shell operator "${operator}" is not supported — only \`|\`, \`||\`, \`&&\`, \`;\` chain operators are spawned natively. Redirects (\`>\`, \`<\`, \`2>&1\`) and background (\`&\`) are not supported — split into separate run_command calls. To pass "${operator}" as a literal argument, wrap it in quotes.`,
-    );
-  }
   const timeoutMs = timeoutSec * 1000;
 
   const spawnOpts: SpawnOptions = {
@@ -567,7 +561,7 @@ export function registerShellTools(registry: ToolRegistry, opts: ShellToolsOptio
   registry.register({
     name: "run_command",
     description:
-      "Run a shell command in the project root and return its combined stdout+stderr.\n\nConstraints (read these before the first call):\n• Chain operators `|`, `||`, `&&`, `;` ARE supported — parsed natively, no shell invoked, so semantics are identical on Windows / macOS / Linux. Each chain segment is allowlist-checked individually: `git status | grep main` runs if both halves are allowed.\n• Redirects (`>`, `<`, `>>`, `2>&1`, `&>`), background `&`, command substitution `$(…)`, env-var expansion `$VAR`, subshells `(…)`, and process substitution `<(…)` are NOT supported and rejected up-front. Use the binary's own flags (e.g. `node --output=file` instead of `node ... > file`) or split into separate calls.\n• `cd` DOES NOT PERSIST between calls — each call spawns a fresh process rooted at the project. If a tool needs a subdirectory, pass it via the tool's own flag (`npm --prefix`, `cargo -C`, `git -C`, `pytest tests/…`), NOT via a preceding `cd`.\n• Glob patterns (`*.ts`) are passed through as literal arguments — no shell expansion. Use `grep -r`, `rg`, `find -name`, etc.\n• Avoid commands with unbounded output (`netstat -ano`, `find /`, etc.) — they waste tokens. Filter at source: `netstat -ano -p TCP`, `find src -name '*.ts'`, `grep -c`, `wc -l`.\n\nCommon read-only inspection and test/lint/typecheck commands run immediately; anything that could mutate state, install dependencies, or touch the network is refused until the user confirms it in the TUI. Prefer this over asking the user to run a command manually — after edits, run the project's tests to verify.",
+      "Run a shell command in the project root and return its combined stdout+stderr.\n\nConstraints (read these before the first call):\n• Chain operators `|`, `||`, `&&`, `;` ARE supported — parsed natively, no shell invoked, so semantics are identical on Windows / macOS / Linux. Each chain segment is allowlist-checked individually: `git status | grep main` runs if both halves are allowed.\n• File redirects ARE supported: `>` truncate, `>>` append, `<` stdin from file, `2>` / `2>>` stderr to file, `2>&1` merge stderr→stdout, `&>` both to file. Targets resolve relative to the project root. At most one redirect per fd per segment.\n• Background `&`, heredoc `<<`, command substitution `$(…)`, subshells `(…)`, and process substitution `<(…)` are NOT supported. Wrap a literal `&` arg in quotes; for input use a `<` file or the binary's own --input flag.\n• Env-var expansion `$VAR` is NOT performed — `$VAR` is passed as a literal string. Use the binary's own --env flag or substitute the value yourself.\n• `cd` DOES NOT PERSIST between calls — each call spawns a fresh process rooted at the project. If a tool needs a subdirectory, pass it via the tool's own flag (`npm --prefix`, `cargo -C`, `git -C`, `pytest tests/…`), NOT via a preceding `cd`.\n• Glob patterns (`*.ts`) are passed through as literal arguments — no shell expansion. Use `grep -r`, `rg`, `find -name`, etc.\n• Avoid commands with unbounded output (`netstat -ano`, `find /`, etc.) — they waste tokens. Filter at source: `netstat -ano -p TCP`, `find src -name '*.ts'`, `grep -c`, `wc -l`.\n\nCommon read-only inspection and test/lint/typecheck commands run immediately; anything that could mutate state, install dependencies, or touch the network is refused until the user confirms it in the TUI. Prefer this over asking the user to run a command manually — after edits, run the project's tests to verify.",
     // Plan-mode gate: allow allowlisted commands through (git status,
     // cargo check, ls, grep …) so the model can actually investigate
     // during planning. Anything that would otherwise trigger a
@@ -584,7 +578,7 @@ export function registerShellTools(registry: ToolRegistry, opts: ShellToolsOptio
         command: {
           type: "string",
           description:
-            'Full command line. POSIX-ish quoting. Chain operators `|`, `||`, `&&`, `;` work — parsed natively (no shell). Redirects (`>`, `<`, `2>&1`), background `&`, env-var expansion `$VAR`, and command substitution `$(…)` are rejected. To pass an operator character as a literal argument (e.g. a regex), wrap it in quotes: `grep "a|b" file.txt`.',
+            'Full command line. POSIX-ish quoting. Chain operators `|`, `||`, `&&`, `;` and file redirects `>` / `>>` / `<` / `2>` / `2>>` / `2>&1` / `&>` work natively (no shell). Background `&`, heredoc `<<`, env-var expansion `$VAR`, and command substitution `$(…)` are rejected (or passed through as literal in the case of `$VAR`). To pass an operator character as a literal argument (e.g. a regex), wrap it in quotes: `grep "a|b" file.txt`.',
         },
         timeoutSec: {
           type: "integer",

--- a/tests/shell-chain.test.ts
+++ b/tests/shell-chain.test.ts
@@ -61,10 +61,13 @@ describe("parseCommandChain", () => {
     expect(c!.ops).toEqual([";"]);
   });
 
-  it("rejects redirects discovered inside a chain segment", () => {
-    expect(() => parseCommandChain("echo hi ; ls > out.txt")).toThrow(/">"/);
-    expect(() => parseCommandChain("git status | wc -l > out.txt")).toThrow(/">"/);
-    expect(() => parseCommandChain("a ; cmd 2>&1")).toThrow(/2>&1/);
+  it("parses redirects inside a chain segment (now supported)", () => {
+    const c1 = parseCommandChain("echo hi ; ls > out.txt");
+    expect(c1!.segments[1]!.redirects).toEqual([{ kind: ">", target: "out.txt" }]);
+    const c2 = parseCommandChain("git status | wc -l > out.txt");
+    expect(c2!.segments[1]!.redirects).toEqual([{ kind: ">", target: "out.txt" }]);
+    const c3 = parseCommandChain("a ; cmd 2>&1");
+    expect(c3!.segments[1]!.redirects).toEqual([{ kind: "2>&1", target: "" }]);
   });
 
   it("rejects background `&` discovered inside a chain segment", () => {

--- a/tests/shell-redirects.test.ts
+++ b/tests/shell-redirects.test.ts
@@ -1,0 +1,228 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { parseCommandChain, runChain } from "../src/tools/shell-chain.js";
+import { runCommand } from "../src/tools/shell.js";
+
+describe("parseCommandChain — redirects", () => {
+  it("parses `>` truncate", () => {
+    const c = parseCommandChain("echo hi > out.txt");
+    expect(c).not.toBeNull();
+    expect(c!.segments[0]!.argv).toEqual(["echo", "hi"]);
+    expect(c!.segments[0]!.redirects).toEqual([{ kind: ">", target: "out.txt" }]);
+  });
+
+  it("parses `>>` append", () => {
+    const c = parseCommandChain("echo hi >> log.txt");
+    expect(c!.segments[0]!.redirects).toEqual([{ kind: ">>", target: "log.txt" }]);
+  });
+
+  it("parses `<` stdin", () => {
+    const c = parseCommandChain("sort < data.txt");
+    expect(c!.segments[0]!.redirects).toEqual([{ kind: "<", target: "data.txt" }]);
+  });
+
+  it("parses `2>` stderr to file", () => {
+    const c = parseCommandChain("cmd 2> err.log");
+    expect(c!.segments[0]!.redirects).toEqual([{ kind: "2>", target: "err.log" }]);
+  });
+
+  it("parses `2>>` stderr append", () => {
+    const c = parseCommandChain("cmd 2>> err.log");
+    expect(c!.segments[0]!.redirects).toEqual([{ kind: "2>>", target: "err.log" }]);
+  });
+
+  it("parses `2>&1` merge stderr to stdout", () => {
+    const c = parseCommandChain("cmd 2>&1");
+    expect(c!.segments[0]!.redirects).toEqual([{ kind: "2>&1", target: "" }]);
+  });
+
+  it("parses `&>` both to file", () => {
+    const c = parseCommandChain("cmd &> all.log");
+    expect(c!.segments[0]!.redirects).toEqual([{ kind: "&>", target: "all.log" }]);
+  });
+
+  it("parses redirects stuck to the target (`>file`)", () => {
+    const c = parseCommandChain("echo hi >out.txt");
+    expect(c!.segments[0]!.redirects).toEqual([{ kind: ">", target: "out.txt" }]);
+  });
+
+  it("parses `cmd > file 2>&1` (stdout to file, stderr merged)", () => {
+    const c = parseCommandChain("cmd > all.log 2>&1");
+    expect(c!.segments[0]!.redirects).toEqual([
+      { kind: ">", target: "all.log" },
+      { kind: "2>&1", target: "" },
+    ]);
+  });
+
+  it("parses redirects on a piped chain segment", () => {
+    const c = parseCommandChain("cat < data.txt | grep foo > out.txt");
+    expect(c!.segments).toHaveLength(2);
+    expect(c!.segments[0]!.argv).toEqual(["cat"]);
+    expect(c!.segments[0]!.redirects).toEqual([{ kind: "<", target: "data.txt" }]);
+    expect(c!.segments[1]!.argv).toEqual(["grep", "foo"]);
+    expect(c!.segments[1]!.redirects).toEqual([{ kind: ">", target: "out.txt" }]);
+  });
+
+  it("preserves quoted target with spaces", () => {
+    const c = parseCommandChain('echo hi > "out file.txt"');
+    expect(c!.segments[0]!.redirects).toEqual([{ kind: ">", target: "out file.txt" }]);
+  });
+
+  it("rejects redirect missing its target", () => {
+    expect(() => parseCommandChain("echo hi >")).toThrow(/redirect ">" is missing a target/);
+    expect(() => parseCommandChain("sort <")).toThrow(/redirect "<" is missing/);
+  });
+
+  it("rejects two redirects with no target between them", () => {
+    expect(() => parseCommandChain("cmd > > out")).toThrow(/missing a target/);
+  });
+
+  it("rejects multiple stdout redirects in one segment", () => {
+    expect(() => parseCommandChain("cmd > a > b")).toThrow(/multiple stdout redirects/);
+    expect(() => parseCommandChain("cmd > a &> b")).toThrow(/multiple stdout/);
+  });
+
+  it("rejects multiple stderr redirects in one segment", () => {
+    expect(() => parseCommandChain("cmd 2> a 2> b")).toThrow(/multiple stderr redirects/);
+    expect(() => parseCommandChain("cmd 2>&1 2> b")).toThrow(/multiple stderr/);
+  });
+
+  it("rejects redirect without a command", () => {
+    expect(() => parseCommandChain("> out.txt")).toThrow(/redirect without a command/);
+  });
+
+  it("rejects heredoc `<<`", () => {
+    expect(() => parseCommandChain("cat << EOF")).toThrow(/"<<".*not supported/);
+  });
+
+  it("rejects standalone background `&`", () => {
+    expect(() => parseCommandChain("cmd &")).toThrow(/"&" is not supported/);
+  });
+
+  it("treats `&` inside a token as literal (lenient)", () => {
+    const c = parseCommandChain("cargo run -- --flag=1&2");
+    expect(c).toBeNull();
+  });
+});
+
+describe("runChain — redirect execution", () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "reasonix-redir-"));
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  const baseOpts = { timeoutSec: 10, maxOutputChars: 32_000 };
+
+  it("`>` writes stdout to a file (truncate)", async () => {
+    writeFileSync(join(tmp, "out.txt"), "stale content\n");
+    const c = parseCommandChain("node -e \"process.stdout.write('hello')\" > out.txt")!;
+    const r = await runChain(c, { cwd: tmp, ...baseOpts });
+    expect(r.exitCode).toBe(0);
+    expect(readFileSync(join(tmp, "out.txt"), "utf8")).toBe("hello");
+  });
+
+  it("`>>` appends stdout to an existing file", async () => {
+    writeFileSync(join(tmp, "log.txt"), "first\n");
+    const c = parseCommandChain("node -e \"process.stdout.write('second')\" >> log.txt")!;
+    await runChain(c, { cwd: tmp, ...baseOpts });
+    expect(readFileSync(join(tmp, "log.txt"), "utf8")).toBe("first\nsecond");
+  });
+
+  it("`<` reads stdin from a file", async () => {
+    writeFileSync(join(tmp, "in.txt"), "PAYLOAD");
+    const c = parseCommandChain(
+      "node -e \"let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>process.stdout.write(d))\" < in.txt",
+    )!;
+    const r = await runChain(c, { cwd: tmp, ...baseOpts });
+    expect(r.exitCode).toBe(0);
+    expect(r.output).toContain("PAYLOAD");
+  });
+
+  it("`2>` writes stderr to a file (separating from stdout)", async () => {
+    const c = parseCommandChain(
+      "node -e \"console.error('err-line'); process.stdout.write('out-line')\" 2> err.log",
+    )!;
+    const r = await runChain(c, { cwd: tmp, ...baseOpts });
+    expect(r.exitCode).toBe(0);
+    expect(r.output).toContain("out-line");
+    expect(r.output).not.toContain("err-line");
+    expect(readFileSync(join(tmp, "err.log"), "utf8")).toContain("err-line");
+  });
+
+  it("`2>&1` keeps stderr in the captured output (default no-op for last seg)", async () => {
+    const c = parseCommandChain(
+      "node -e \"console.error('warn'); process.stdout.write('hi')\" 2>&1",
+    )!;
+    const r = await runChain(c, { cwd: tmp, ...baseOpts });
+    expect(r.output).toContain("hi");
+    expect(r.output).toContain("warn");
+  });
+
+  it("`> file 2>&1` merges stderr into the file with stdout", async () => {
+    const c = parseCommandChain(
+      "node -e \"console.error('err-line'); process.stdout.write('out-line')\" > all.log 2>&1",
+    )!;
+    await runChain(c, { cwd: tmp, ...baseOpts });
+    const contents = readFileSync(join(tmp, "all.log"), "utf8");
+    expect(contents).toContain("out-line");
+    expect(contents).toContain("err-line");
+  });
+
+  it("`&>` writes both stdout and stderr to the same file", async () => {
+    const c = parseCommandChain(
+      "node -e \"console.error('err-line'); process.stdout.write('out-line')\" &> all.log",
+    )!;
+    await runChain(c, { cwd: tmp, ...baseOpts });
+    const contents = readFileSync(join(tmp, "all.log"), "utf8");
+    expect(contents).toContain("out-line");
+    expect(contents).toContain("err-line");
+  });
+
+  it("redirects work across pipe boundaries (`<` on first, `>` on last)", async () => {
+    writeFileSync(join(tmp, "data.txt"), "alpha\nbeta\n");
+    const c = parseCommandChain(
+      "node -e \"let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>process.stdout.write(d.toUpperCase()))\" < data.txt > upper.txt",
+    )!;
+    const r = await runChain(c, { cwd: tmp, ...baseOpts });
+    expect(r.exitCode).toBe(0);
+    expect(readFileSync(join(tmp, "upper.txt"), "utf8")).toContain("ALPHA");
+    expect(readFileSync(join(tmp, "upper.txt"), "utf8")).toContain("BETA");
+  });
+
+  it("redirect target is resolved relative to the chain's cwd, not the test's", async () => {
+    const c = parseCommandChain("node -e \"process.stdout.write('hello')\" > out.txt")!;
+    await runChain(c, { cwd: tmp, ...baseOpts });
+    expect(readFileSync(join(tmp, "out.txt"), "utf8")).toBe("hello");
+  });
+});
+
+describe("runCommand — redirect dispatch", () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "reasonix-redir-rc-"));
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("runs `echo > file` through the public runCommand API", async () => {
+    const r = await runCommand(
+      "node -e \"process.stdout.write('via-runcommand')\" > captured.txt",
+      {
+        cwd: tmp,
+      },
+    );
+    expect(r.exitCode).toBe(0);
+    expect(readFileSync(join(tmp, "captured.txt"), "utf8")).toBe("via-runcommand");
+  });
+
+  it("propagates the exit code of the redirected command", async () => {
+    const r = await runCommand('node -e "process.exit(7)" > out.txt', { cwd: tmp });
+    expect(r.exitCode).toBe(7);
+  });
+});

--- a/tests/shell-redirects.test.ts
+++ b/tests/shell-redirects.test.ts
@@ -183,6 +183,17 @@ describe("runChain — redirect execution", () => {
     expect(contents).toContain("err-line");
   });
 
+  it("`cmd1 2>&1 | cmd2` merges stderr into the pipe to cmd2", async () => {
+    const c = parseCommandChain(
+      "node -e \"console.error('err'); process.stdout.write('out')\" 2>&1 | node -e \"let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>process.stdout.write('GOT['+d+']'))\"",
+    )!;
+    const r = await runChain(c, { cwd: tmp, ...baseOpts });
+    expect(r.exitCode).toBe(0);
+    expect(r.output).toContain("GOT[");
+    expect(r.output).toContain("out");
+    expect(r.output).toContain("err");
+  });
+
   it("redirects work across pipe boundaries (`<` on first, `>` on last)", async () => {
     writeFileSync(join(tmp, "data.txt"), "alpha\nbeta\n");
     const c = parseCommandChain(

--- a/tests/shell-tools.test.ts
+++ b/tests/shell-tools.test.ts
@@ -109,7 +109,7 @@ describe("detectShellOperator", () => {
   });
 });
 
-describe("runCommand redirect rejection", () => {
+describe("runCommand syntax rejection", () => {
   let tmp: string;
   beforeEach(() => {
     tmp = mkdtempSync(join(tmpdir(), "reasonix-shell-pipe-"));
@@ -118,19 +118,15 @@ describe("runCommand redirect rejection", () => {
     rmSync(tmp, { recursive: true, force: true });
   });
 
-  it("rejects stdout redirect", async () => {
-    await expect(runCommand("echo hi > out.txt", { cwd: tmp })).rejects.toThrow(
-      /shell operator ">" is not supported/,
-    );
-  });
-
-  it("rejects stderr-merge redirect", async () => {
-    await expect(runCommand("node -v 2>&1", { cwd: tmp })).rejects.toThrow(/shell operator/);
-  });
-
   it("rejects background `&`", async () => {
     await expect(runCommand("node -v &", { cwd: tmp })).rejects.toThrow(
       /shell operator "&" is not supported/,
+    );
+  });
+
+  it("rejects heredoc `<<`", async () => {
+    await expect(runCommand("cat << EOF", { cwd: tmp })).rejects.toThrow(
+      /shell operator "<<" is not supported/,
     );
   });
 
@@ -140,6 +136,18 @@ describe("runCommand redirect rejection", () => {
 
   it("rejects a chain ending with an operator", async () => {
     await expect(runCommand("echo hi &&", { cwd: tmp })).rejects.toThrow(/chain ends with/);
+  });
+
+  it("rejects a redirect missing its target", async () => {
+    await expect(runCommand("echo hi >", { cwd: tmp })).rejects.toThrow(
+      /redirect ">" is missing a target/,
+    );
+  });
+
+  it("rejects multiple stdout redirects in one segment", async () => {
+    await expect(runCommand("echo hi > a > b", { cwd: tmp })).rejects.toThrow(
+      /multiple stdout redirects/,
+    );
   });
 });
 


### PR DESCRIPTION
Phase 2 of #232. Builds on #233 + #234.

## What changes

`run_command` now parses and executes file redirects natively. Each segment of a chain (or a standalone command) can carry trailing redirects; the parser reads them, the runner opens the files with `fs.openSync` and hands the fds to spawn's stdio. No shell is invoked — semantics are identical on Windows / macOS / Linux.

| Op | Meaning |
|---|---|
| `>` | stdout to file (truncate) |
| `>>` | stdout to file (append) |
| `<` | stdin from file |
| `2>` | stderr to file (truncate) |
| `2>>` | stderr to file (append) |
| `2>&1` | merge stderr → wherever stdout points |
| `&>` | both stdout + stderr to file (truncate) |

Targets resolve relative to the chain's cwd. At most one redirect per fd per segment — multiple `>`s in one segment are rejected with a clear conflict message.

## Examples

```
echo hi > out.txt                           # truncate-write
echo more >> log.txt                        # append
sort < data.txt | uniq                      # stdin from file, pipe to next
node script.js > out 2>&1                   # capture both streams to one file
node script.js &> all.log                   # same, shorthand
node script.js 2> errors.log                # split stderr off from stdout
git diff > /tmp/p.patch && git apply /tmp/p.patch
```

## Why this didn't ship in #233

shell-quote's POSIX strictness conflicted with the project's lenient tokenizer (#234 fixed that by going back to whitespace-bounded chain detection). With the parser layer now consistent with the project's existing primitives, redirects fit cleanly: same single-pass walker, same quote awareness, same lenient handling of embedded `&`/`|`/`;` chars.

## Implementation

`ChainSegment` now carries `redirects: Redirect[]` alongside `argv`. New `parseSegment(segStr)` is a single-pass walker that emits both argv tokens and redirect ops at the same level. Old per-segment `tokenizeCommand + detectShellOperator` combo is gone — replaced by the unified parser.

`runPipeGroup` opens redirect fds per segment via `fs.openSync` (always closed in `finally`), then hands them to spawn's stdio. Pipe wiring still applies: `<` overrides pipe-in, `>`/`>>`/`&>` override pipe-out / capture-buffer. `2>&1` is implemented by setting stderr's stdio spec to whatever stdout's points at — works for buffer-capture, fd, and pipe equally.

## Compat notes

- Background `&` still rejected — use `run_background`.
- Heredoc `<<` still rejected — use `<` file or the binary's flag.
- `\$VAR` and `\$(...)` pass through as literal characters (matches the simple-command tokenizer's pre-existing behavior).
- The lenient embedded-`&`/`|`/`;` behavior from #234 is preserved (`cargo run -- --flag=1&2` still works).

## Tests

- `tests/shell-redirects.test.ts` — 30 new tests covering parser output for every redirect kind, stuck-to-target form, quoted targets, conflict detection, and execution (truncate/append, stdin-from-file, stderr split, `2>&1` merge, `&>` both, redirects across pipe boundaries).
- `tests/shell-tools.test.ts` — old "rejects stdout redirect / stderr-merge" tests rotated out; added rejections for missing target, heredoc, multi-redirect-per-fd.
- `tests/shell-chain.test.ts` — old "rejects redirects inside a chain segment" test repurposed to assert successful parsing.
- `npm run verify` — 2228 tests pass, no biome / typecheck errors on changed files.