### PR TITLE
fix: Model was still doing things while pending to approve

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -33,6 +33,7 @@ import {
   saveEditMode,
 } from "../../config.js";
 import { Eventizer } from "../../core/eventize.js";
+import { pauseGate } from "../../core/pause-gate.js";
 import { type ResolvedHook, formatHookOutcomeMessage, loadHooks, runHooks } from "../../hooks.js";
 import { onLanguageChange } from "../../i18n/index.js";
 import { CacheFirstLoop, DeepSeekClient, ImmutablePrefix } from "../../index.js";
@@ -510,13 +511,8 @@ function AppInner({
   // project / Deny and we feed the result back as a synthetic user
   // message so the model sees what happened.
   const [pendingShell, setPendingShell] = useState<{
+    id: number;
     command: string;
-    /**
-     * Which tool surfaced the NeedsConfirmationError. Drives post-
-     * approval dispatch: `run_command` uses the synchronous runCommand
-     * (waits for exit); `run_background` spawns via JobRegistry and
-     * returns after a ready-signal / waitSec window.
-     */
     kind: "run_command" | "run_background";
   } | null>(null);
   // Plan text the model submitted via `submit_plan` while plan mode
@@ -542,6 +538,21 @@ function AppInner({
   const [stagedInput, setStagedInput] = useState<{
     plan: string;
     mode: "refine" | "approve" | "reject";
+  } | null>(null);
+  // Mid-execution pause from mark_step_complete — model finished a step
+  // and the loop waits for user to pick Continue / Revise / Stop.
+  const [pendingCheckpoint, setPendingCheckpoint] = useState<{
+    stepId: string;
+    title?: string;
+    completed: number;
+    total: number;
+  } | null>(null);
+  // Staged entry for the Revise feedback input at a checkpoint.
+  const [stagedCheckpointRevise, setStagedCheckpointRevise] = useState<{
+    stepId: string;
+    title?: string;
+    completed: number;
+    total: number;
   } | null>(null);
   // Plan revision proposal from `revise_plan`. Non-null mounts the
   // PlanReviseConfirm picker showing a step-level diff. Accept replaces
@@ -1759,7 +1770,7 @@ function AppInner({
         },
         resolveShellConfirm: (choice) => {
           const fn = handleShellConfirmRef.current;
-          if (fn) fn(choice).catch(() => undefined);
+          if (fn) Promise.resolve(fn(choice)).catch(() => undefined);
         },
         resolveChoiceConfirm: (choice) => {
           const fn = handleChoiceConfirmRef.current;
@@ -1787,8 +1798,24 @@ function AppInner({
             resolve({ choice, denyContext: undefined });
           }
         },
+        resolveCheckpointConfirm: (choice, text) => {
+          // Web's "revise" path sends feedback in one shot; we hand the
+          // current pending checkpoint to the submit handler directly,
+          // skipping the TUI's staged-input two-step. continue/stop fall
+          // through to the regular picker handler.
+          if (choice === "revise" && typeof text === "string") {
+            const snap = pendingCheckpoint;
+            setPendingCheckpoint(null);
+            if (!snap) return;
+            Promise.resolve(handleCheckpointReviseSubmitRef.current(text, snap)).catch(
+              () => undefined,
+            );
+            return;
+          }
+          Promise.resolve(handleCheckpointConfirmRef.current(choice)).catch(() => undefined);
+        },
         resolveReviseConfirm: (choice) => {
-          handleReviseConfirmRef.current(choice).catch(() => undefined);
+          Promise.resolve(handleReviseConfirmRef.current(choice)).catch(() => undefined);
         },
         // ---------- v0.14 mutation surface ----------
         reloadHooks: () => {
@@ -1819,6 +1846,7 @@ function AppInner({
     togglePlanMode,
     pendingShell,
     pendingChoice,
+    pendingCheckpoint,
     pendingEditReview,
     pendingRevision,
     agentStore,
@@ -2610,74 +2638,38 @@ function AppInner({
   });
 
   /**
-   * ShellConfirm callback. Three outcomes, all of them ending with a
-   * synthetic user message fed back into the loop so the model sees
-   * what happened next turn:
-   *   - deny → "I denied running X." and we move on.
-   *   - run_once / always_allow → run the command inside the sandbox
-   *     root, attach the formatted output as the user turn. In the
-   *     always_allow case we also persist the derived prefix to
-   *     config so next invocation auto-runs.
+   * ShellConfirm callback. Resolves the PauseGate so the
+   * blocked tool function can proceed. The tool handles running the
+   * command (or throwing on deny) — no synthetic user message needed.
    */
   const handleShellConfirm = useCallback(
-    async (choice: ShellConfirmChoice, denyContext?: string) => {
+    (choice: ShellConfirmChoice, denyContext?: string) => {
       const pending = pendingShell;
       if (!pending || !codeMode) return;
-      const { command: cmd, kind } = pending;
+      const { id, command: cmd, kind } = pending;
       setPendingShell(null);
 
-      let synthetic: string;
       if (choice === "deny") {
         const context = denyContext ? ` because: ${denyContext}` : "";
         log.pushInfo(`▸ denied: ${cmd}${context}`);
-        synthetic = `I denied running \`${cmd}\`${context}. Please continue without running it.`;
+        pauseGate.resolve(id, { type: "deny", denyContext });
+      } else if (choice === "always_allow") {
+        const prefix = derivePrefix(cmd);
+        log.pushInfo(`▸ always allowed "${prefix}" for ${currentRootDir}`);
+        pauseGate.resolve(id, { type: "always_allow", prefix });
       } else {
-        if (choice === "always_allow") {
-          const prefix = derivePrefix(cmd);
-          addProjectShellAllowed(currentRootDir, prefix);
-          log.pushInfo(`▸ always allowed "${prefix}" for ${currentRootDir}`);
-        }
         log.pushInfo(
           kind === "run_background" ? `▸ starting (background): ${cmd}` : `▸ running: ${cmd}`,
         );
-        if (kind === "run_background" && codeMode.jobs) {
-          // JobRegistry spawn keeps the process running after this handler
-          // resolves; the synthetic tells the model the job id for job_output
-          // / stop_job follow-ups.
-          try {
-            const res = await codeMode.jobs.start(cmd, { cwd: currentRootDir });
-            const preview = res.preview;
-            const header = res.stillRunning
-              ? `[job ${res.jobId} started · pid ${res.pid ?? "?"} · ${res.readyMatched ? "READY signal matched" : "running"}]`
-              : res.exitCode !== null
-                ? `[job ${res.jobId} exited during startup · exit ${res.exitCode}]`
-                : `[job ${res.jobId} failed to start]`;
-            const body = preview ? `${header}\n${preview}` : header;
-            log.pushInfo(body);
-            synthetic = `I approved the background spawn. ${header}\n\nStartup preview:\n\n${preview || "(no output yet)"}\n\nThe process is still running — use job_output to read newer logs, stop_job to halt it.`;
-          } catch (err) {
-            const msg = `$ ${cmd}\n[failed to start] ${(err as Error).message}`;
-            log.pushInfo(msg);
-            synthetic = `I approved the background spawn but it failed to start:\n\n${msg}`;
-          }
-        } else {
-          // Foreground (run_command) — synchronous; waits for exit.
-          let body: string;
-          try {
-            const res = await runCommand(cmd, { cwd: currentRootDir });
-            body = formatCommandResult(cmd, res);
-          } catch (err) {
-            body = `$ ${cmd}\n[failed to spawn] ${(err as Error).message}`;
-          }
-          log.pushInfo(body);
-          synthetic = `I ran the command you requested. Output:\n\n${body}`;
-        }
+        pauseGate.resolve(id, { type: "run_once" });
       }
-
-      await syntheticSubmit.submit(synthetic);
     },
-    [pendingShell, codeMode, currentRootDir, syntheticSubmit, log],
+    [pendingShell, codeMode, currentRootDir, log],
   );
+
+  /** Holds the PauseGate request id for the current modal so
+   *  handlePlanConfirm / handleCheckpointResponse / etc. can resolve it. */
+  const pendingGateIdRef = useRef<number | null>(null);
 
   // Drain the shell-confirm queue after the in-flight turn tears down.
   // React closure staleness means handleShellConfirm can't just await
@@ -2828,9 +2820,20 @@ function AppInner({
         }
       }
 
-      await syntheticSubmit.post({ marker, synthetic });
+      // Resolve the PauseGate so the blocked submit_plan tool function
+      // can return and the model sees the verdict without a synthetic message.
+      const gateId = pendingGateIdRef.current;
+      if (gateId !== null) {
+        if (staged.mode === "approve") {
+          pauseGate.resolve(gateId, { type: "approve" });
+        } else if (staged.mode === "reject") {
+          pauseGate.resolve(gateId, { type: "cancel" });
+        } else {
+          pauseGate.resolve(gateId, { type: "refine" });
+        }
+      }
     },
-    [stagedInput, togglePlanMode, syntheticSubmit, persistPlanState, agentStore],
+    [stagedInput, togglePlanMode, persistPlanState, agentStore],
   );
   // Ref-mirror so startDashboard's resolvePlanConfirm closure can call
   // the latest function — handleStagedInputSubmit's deps churn on every
@@ -2860,22 +2863,17 @@ function AppInner({
         setStagedChoiceCustom(snap);
         return;
       }
+      const gateId = pendingGateIdRef.current;
       if (choice.kind === "cancel") {
-        await syntheticSubmit.post({
-          marker: "▸ choice cancelled",
-          synthetic:
-            "The user cancelled the choice. Don't act on any of the options you presented. Ask what they actually want before doing anything else.",
-        });
+        if (gateId !== null) pauseGate.resolve(gateId, { type: "cancel" });
         return;
       }
       const picked = snap.options.find((o) => o.id === choice.optionId);
-      const label = picked ? `${picked.id} · ${picked.title}` : choice.optionId;
-      await syntheticSubmit.post({
-        marker: `▸ chose ${label}`,
-        synthetic: `The user picked option ${choice.optionId}${picked ? ` ("${picked.title}")` : ""}. Proceed with that branch. Do not re-ask the same question.`,
-      });
+      if (gateId !== null) {
+        pauseGate.resolve(gateId, { type: "pick", optionId: choice.optionId });
+      }
     },
-    [pendingChoice, syntheticSubmit],
+    [pendingChoice],
   );
 
   // Ref-wrap to keep ChoiceConfirm's React.memo from re-rendering on
@@ -2888,6 +2886,74 @@ function AppInner({
   useEffect(() => {
     handleShellConfirmRef.current = handleShellConfirm;
   }, [handleShellConfirm]);
+  // Listen for pause requests from tool functions (via PauseGate).
+  // Dispatches to the correct modal based on request.kind.
+  // Note: stable deps (none) — codeMode changes don't re-trigger,
+  // the listener checks nothing from closure except setState setters.
+  useEffect(() => {
+    return pauseGate.on((request) => {
+      const payload = request.payload as Record<string, unknown>;
+      pendingGateIdRef.current = request.id;
+
+      switch (request.kind) {
+        case "run_command":
+        case "run_background":
+          setPendingShell({
+            id: request.id,
+            command: (payload as { command: string }).command,
+            kind: request.kind,
+          });
+          break;
+        case "plan_proposed":
+          setPendingPlan((payload as { plan: string }).plan);
+          break;
+        case "plan_checkpoint": {
+          const p = payload as {
+            stepId: string;
+            title?: string;
+            result: string;
+            notes?: string;
+          };
+          // completed/total come from planStepsRef — don't have them via gate
+          const completed = completedStepIdsRef.current.size;
+          const total = planStepsRef.current?.length ?? 0;
+          setPendingCheckpoint({
+            stepId: p.stepId,
+            title: p.title,
+            completed,
+            total,
+          });
+          break;
+        }
+        case "plan_revision": {
+          const p = payload as {
+            reason: string;
+            remainingSteps: PlanStep[];
+            summary?: string;
+          };
+          setPendingRevision({
+            reason: p.reason,
+            remainingSteps: p.remainingSteps,
+            summary: p.summary,
+          });
+          break;
+        }
+        case "choice": {
+          const p = payload as {
+            question: string;
+            options: unknown[];
+            allowCustom: boolean;
+          };
+          setPendingChoice({
+            question: p.question,
+            options: p.options as ChoiceOption[],
+            allowCustom: p.allowCustom,
+          });
+          break;
+        }
+      }
+    });
+  }, []);
   // Ref-mirror of pendingPlan so the web's resolvePlanConfirm callback
   // (registered in startDashboard, frozen at boot) can read the live
   // body when the web resolves an approve/refine.
@@ -2903,21 +2969,109 @@ function AppInner({
     async (choice: ChoiceConfirmChoice) => handleChoiceConfirmRef.current(choice),
     [],
   );
-  /** Custom free-form answer submitted — ship it as a synthetic message. */
-  const handleChoiceCustomSubmit = useCallback(
-    async (answer: string) => {
-      setStagedChoiceCustom(null);
-      const trimmed = answer.trim();
-      const synthetic = trimmed
-        ? `The user answered with a custom reply (none of the pre-defined options fit):\n\n${trimmed}\n\nRead it carefully and proceed — don't snap back to the options you listed unless the user's reply clearly maps to one.`
-        : "The user pressed Enter without typing anything. Ask what they actually want.";
-      const marker = trimmed
-        ? `▸ custom answer — ${trimmed.length > 50 ? `${trimmed.slice(0, 50)}…` : trimmed}`
-        : "▸ custom answer — (blank)";
-      await syntheticSubmit.post({ marker, synthetic });
+
+  /**
+   * Checkpoint picker callback. Resolves the PauseGate so the blocked
+   * mark_step_complete tool function can return (or throw).
+   */
+  const handleCheckpointConfirm = useCallback(
+    (choice: "continue" | "revise" | "stop") => {
+      const snap = pendingCheckpoint;
+      if (!snap) return;
+      setPendingCheckpoint(null);
+      const gid = pendingGateIdRef.current;
+      if (choice === "revise") {
+        if (gid !== null) pauseGate.resolve(gid, { type: "revise" });
+        setStagedCheckpointRevise(snap);
+        return;
+      }
+      // Auto file-snapshot per plan step
+      if (codeMode && choice === "continue") {
+        const paths = touchedPaths();
+        if (paths.length > 0) {
+          try {
+            const cpName = snap.title ? `${snap.stepId} · ${snap.title}` : snap.stepId;
+            const meta = createCheckpoint({
+              rootDir: codeMode.rootDir,
+              name: cpName.slice(0, 60),
+              paths,
+              source: "auto-pre-restore",
+            });
+            log.pushInfo(
+              `⛁ checkpoint saved · ${meta.id} · ${meta.fileCount} file${meta.fileCount === 1 ? "" : "s"} · /restore ${meta.id} to roll back this step`,
+            );
+          } catch {
+            /* best-effort */
+          }
+        }
+      }
+      if (gid !== null) {
+        pauseGate.resolve(gid, {
+          type: choice === "continue" ? "continue" : "stop",
+        });
+      }
+      const label = snap.title ? `${snap.stepId} · ${snap.title}` : snap.stepId;
+      const counter = snap.total > 0 ? ` (${snap.completed}/${snap.total})` : "";
+      log.pushInfo(
+        choice === "continue"
+          ? `▸ continuing after ${label}${counter}`
+          : `▸ plan stopped at ${label}${counter}`,
+      );
     },
-    [syntheticSubmit],
+    [pendingCheckpoint, codeMode, touchedPaths, log],
   );
+
+  const handleCheckpointConfirmRef = useRef(handleCheckpointConfirm);
+  useEffect(() => {
+    handleCheckpointConfirmRef.current = handleCheckpointConfirm;
+  }, [handleCheckpointConfirm]);
+  const stableHandleCheckpointConfirm = useCallback(
+    (choice: "continue" | "revise" | "stop") => handleCheckpointConfirmRef.current(choice),
+    [],
+  );
+
+  /** Revise feedback submitted — resolves the gate with revise. */
+  const handleCheckpointReviseSubmit = useCallback(
+    async (feedback: string, snapOverride?: { stepId: string; title?: string }) => {
+      const snap = snapOverride;
+      setStagedCheckpointRevise(null);
+      if (!snap) return;
+      const label = snap.title ? `${snap.stepId} · ${snap.title}` : snap.stepId;
+      const trimmed = feedback.trim();
+      // User wants to revise — push the feedback via gate, model will
+      // call revise_plan on the next iteration.
+      const gid = pendingGateIdRef.current;
+      if (gid !== null) pauseGate.resolve(gid, { type: "revise" });
+      const marker = trimmed
+        ? `▸ revising after ${label} — ${trimmed.length > 50 ? `${trimmed.slice(0, 50)}…` : trimmed}`
+        : `▸ continuing after ${label}`;
+      log.pushInfo(marker);
+    },
+    [log],
+  );
+
+  const handleCheckpointReviseCancel = useCallback(() => {
+    const snap = stagedCheckpointRevise;
+    setStagedCheckpointRevise(null);
+    if (snap) setPendingCheckpoint(snap);
+  }, [stagedCheckpointRevise]);
+
+  // Ref-mirrors so the web's resolveXxx callbacks (registered in
+  // startDashboard, frozen at boot) keep calling the latest handler.
+  const handleCheckpointReviseSubmitRef = useRef(handleCheckpointReviseSubmit);
+  useEffect(() => {
+    handleCheckpointReviseSubmitRef.current = handleCheckpointReviseSubmit;
+  }, [handleCheckpointReviseSubmit]);
+
+  /** Custom free-form answer submitted — resolves the PauseGate with the typed text. */
+  const handleChoiceCustomSubmit = useCallback((answer: string) => {
+    setStagedChoiceCustom(null);
+    const trimmed = answer.trim();
+    const gateId = pendingGateIdRef.current;
+    if (gateId !== null) {
+      pauseGate.resolve(gateId, { type: "text", text: trimmed || "" });
+    }
+  }, []);
 
   /** Esc on the custom input — restore the choice picker. */
   const handleChoiceCustomCancel = useCallback(() => {
@@ -2932,16 +3086,13 @@ function AppInner({
    * proposal and tells the model to stick with the original plan.
    */
   const handleReviseConfirm = useCallback(
-    async (choice: ReviseChoice) => {
+    (choice: ReviseChoice) => {
       const snap = pendingRevision;
       if (!snap) return;
       setPendingRevision(null);
+      const gateId = pendingGateIdRef.current;
       if (choice === "reject") {
-        await syntheticSubmit.post({
-          marker: "▸ revision rejected",
-          synthetic:
-            "The user rejected the proposed plan revision. Don't apply it. Continue executing the original plan from the next pending step. If you genuinely cannot proceed without the change, stop and explain in plain text why.",
-        });
+        if (gateId !== null) pauseGate.resolve(gateId, { type: "rejected" });
         return;
       }
       // Accept: keep the done-step prefix from the existing plan, replace
@@ -2957,21 +3108,9 @@ function AppInner({
       }
       planStepsRef.current = merged;
       persistPlanState();
-      const removedCount = oldSteps.filter(
-        (s) => !completed.has(s.id) && !snap.remainingSteps.some((n) => n.id === s.id),
-      ).length;
-      const addedCount = snap.remainingSteps.filter(
-        (s) => !oldSteps.some((o) => o.id === s.id),
-      ).length;
-      const marker = `▸ revision accepted — −${removedCount} +${addedCount}: ${snap.reason}`;
-      const synthetic = `Revision accepted. The remaining plan is now:\n${snap.remainingSteps
-        .map((s, i) => `  ${i + 1}. ${s.id} · ${s.title} — ${s.action}`)
-        .join(
-          "\n",
-        )}\n\nContinue executing from the next pending step. Call mark_step_complete after each one as before.`;
-      await syntheticSubmit.post({ marker, synthetic });
+      if (gateId !== null) pauseGate.resolve(gateId, { type: "accepted" });
     },
-    [pendingRevision, syntheticSubmit, persistPlanState],
+    [pendingRevision, persistPlanState],
   );
 
   // Ref-wrap to keep PlanReviseConfirm's React.memo from re-rendering.

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -24,7 +24,6 @@ import {
 import {
   type EditMode,
   type PresetName,
-  addProjectShellAllowed,
   defaultConfigPath,
   editModeHintShown,
   loadEditMode,
@@ -73,6 +72,7 @@ import { AtMentionSuggestions } from "./AtMentionSuggestions.js";
 import { ChoiceConfirm, type ChoiceConfirmChoice } from "./ChoiceConfirm.js";
 import { EditConfirm, type EditReviewChoice } from "./EditConfirm.js";
 import { McpBrowser } from "./McpBrowser.js";
+import { PlanCheckpointConfirm } from "./PlanCheckpointConfirm.js";
 import { PlanConfirm, type PlanConfirmChoice } from "./PlanConfirm.js";
 import { PlanRefineInput } from "./PlanRefineInput.js";
 import { PlanReviseConfirm, type ReviseChoice } from "./PlanReviseConfirm.js";
@@ -97,7 +97,6 @@ import {
 import { handleToolEvent } from "./hooks/handle-tool-event.js";
 import { useAgentSession } from "./hooks/useAgentSession.js";
 import { useScrollback } from "./hooks/useScrollback.js";
-import { useSyntheticSubmit } from "./hooks/useSyntheticSubmit.js";
 import { useKeystroke } from "./keystroke-context.js";
 import { CardStream } from "./layout/CardStream.js";
 import {
@@ -2629,14 +2628,6 @@ function AppInner({
     return () => clearTimeout(timer);
   }, [activeLoop, stopLoop, log]);
 
-  const syntheticSubmit = useSyntheticSubmit({
-    log,
-    busy,
-    loop,
-    setQueuedSubmit,
-    handleSubmit,
-  });
-
   /**
    * ShellConfirm callback. Resolves the PauseGate so the
    * blocked tool function can proceed. The tool handles running the
@@ -2981,7 +2972,8 @@ function AppInner({
       setPendingCheckpoint(null);
       const gid = pendingGateIdRef.current;
       if (choice === "revise") {
-        if (gid !== null) pauseGate.resolve(gid, { type: "revise" });
+        // Don't resolve the gate yet — wait for the staged feedback input
+        // and let handleCheckpointReviseSubmit resolve with the feedback text.
         setStagedCheckpointRevise(snap);
         return;
       }
@@ -3030,18 +3022,21 @@ function AppInner({
     [],
   );
 
-  /** Revise feedback submitted — resolves the gate with revise. */
+  /** Revise feedback submitted — resolves the gate with feedback. */
   const handleCheckpointReviseSubmit = useCallback(
-    async (feedback: string, snapOverride?: { stepId: string; title?: string }) => {
+    (feedback: string, snapOverride?: { stepId: string; title?: string }) => {
       const snap = snapOverride;
       setStagedCheckpointRevise(null);
       if (!snap) return;
       const label = snap.title ? `${snap.stepId} · ${snap.title}` : snap.stepId;
       const trimmed = feedback.trim();
-      // User wants to revise — push the feedback via gate, model will
-      // call revise_plan on the next iteration.
       const gid = pendingGateIdRef.current;
-      if (gid !== null) pauseGate.resolve(gid, { type: "revise" });
+      if (gid !== null) {
+        pauseGate.resolve(
+          gid,
+          trimmed ? { type: "revise", feedback: trimmed } : { type: "revise" },
+        );
+      }
       const marker = trimmed
         ? `▸ revising after ${label} — ${trimmed.length > 50 ? `${trimmed.slice(0, 50)}…` : trimmed}`
         : `▸ continuing after ${label}`;
@@ -3139,6 +3134,8 @@ function AppInner({
           !!pendingChoice ||
           !!stagedChoiceCustom ||
           !!pendingRevision ||
+          !!stagedCheckpointRevise ||
+          !!pendingCheckpoint ||
           // Idle gate: when nothing is actively happening, suspend the
           // 8Hz/1Hz heartbeats. The cursor blink, gradient pulse, and
           // spinner glyphs are pure cosmetics — running them at idle
@@ -3220,7 +3217,9 @@ function AppInner({
                 !pendingEditReview &&
                 !pendingChoice &&
                 !stagedChoiceCustom &&
-                !pendingRevision ? (
+                !pendingRevision &&
+                !stagedCheckpointRevise &&
+                !pendingCheckpoint ? (
                   <UndoBanner banner={undoBanner} />
                 ) : null}
                 {/*
@@ -3269,6 +3268,12 @@ function AppInner({
                   onSubmit={handleChoiceCustomSubmit}
                   onCancel={handleChoiceCustomCancel}
                 />
+              ) : stagedCheckpointRevise ? (
+                <PlanRefineInput
+                  mode="checkpoint-revise"
+                  onSubmit={(text) => handleCheckpointReviseSubmit(text, stagedCheckpointRevise)}
+                  onCancel={handleCheckpointReviseCancel}
+                />
               ) : pendingChoice ? (
                 <ChoiceConfirm
                   question={pendingChoice.question}
@@ -3285,6 +3290,16 @@ function AppInner({
                   newRemaining={pendingRevision.remainingSteps}
                   summary={pendingRevision.summary}
                   onChoose={stableHandleReviseConfirm}
+                />
+              ) : pendingCheckpoint ? (
+                <PlanCheckpointConfirm
+                  stepId={pendingCheckpoint.stepId}
+                  title={pendingCheckpoint.title}
+                  completed={pendingCheckpoint.completed}
+                  total={pendingCheckpoint.total}
+                  steps={planStepsRef.current ?? undefined}
+                  completedStepIds={completedStepIdsRef.current}
+                  onChoose={stableHandleCheckpointConfirm}
                 />
               ) : pendingSessionsPicker ? (
                 <SessionPicker

--- a/src/cli/ui/PlanCheckpointConfirm.tsx
+++ b/src/cli/ui/PlanCheckpointConfirm.tsx
@@ -1,0 +1,96 @@
+/** Modal picker for `PlanCheckpointError`: continue / revise / stop. */
+
+import { Box } from "ink";
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React from "react";
+import type { PlanStep } from "../../tools/plan.js";
+import { PlanStepList, type StepStatus } from "./PlanStepList.js";
+import { SingleSelect } from "./Select.js";
+import { ApprovalCard } from "./cards/ApprovalCard.js";
+import { useReserveRows } from "./layout/viewport-budget.js";
+
+export type CheckpointChoice = "continue" | "revise" | "stop";
+
+export interface PlanCheckpointConfirmProps {
+  stepId: string;
+  title?: string;
+  completed: number;
+  total: number;
+  /** Full step list from the approved plan, when available. */
+  steps?: PlanStep[];
+  /** Set of stepIds the model has marked complete so far. */
+  completedStepIds?: Set<string>;
+  onChoose: (choice: CheckpointChoice) => void;
+}
+
+function PlanCheckpointConfirmInner({
+  stepId,
+  title,
+  completed,
+  total,
+  steps,
+  completedStepIds,
+  onChoose,
+}: PlanCheckpointConfirmProps) {
+  const stepRows = steps?.length ?? 0;
+  useReserveRows("modal", { min: 10, max: Math.max(14, stepRows + 12) });
+
+  const label = title ? `${stepId} · ${title}` : stepId;
+  const counter = total > 0 ? `${completed}/${total}` : "";
+  const isLast = total > 0 && completed >= total;
+  const statuses = buildStatusMap(steps, completedStepIds, stepId, isLast);
+  const subtitle = counter ? `${counter}  ·  ${label}` : label;
+  return (
+    <ApprovalCard tone="ok" glyph="⛁" title="Checkpoint — step done" metaRight={subtitle}>
+      {steps && steps.length > 0 ? (
+        <Box marginBottom={1} flexDirection="column">
+          <PlanStepList steps={steps} statuses={statuses} focusStepId={stepId} />
+        </Box>
+      ) : null}
+      <SingleSelect
+        initialValue={isLast ? "stop" : "continue"}
+        items={[
+          {
+            value: "continue",
+            label: "Continue — run the next step",
+            hint: "Model resumes with the next step.",
+          },
+          {
+            value: "revise",
+            label: "Revise — give feedback before the next step",
+            hint: "Stay paused, type guidance; model adjusts the remaining plan.",
+          },
+          {
+            value: "stop",
+            label: "Stop — end the plan here",
+            hint: "Model summarizes what was done and ends.",
+          },
+        ]}
+        onSubmit={(v) => onChoose(v as CheckpointChoice)}
+        onCancel={() => onChoose("stop")}
+      />
+    </ApprovalCard>
+  );
+}
+
+export const PlanCheckpointConfirm = React.memo(PlanCheckpointConfirmInner);
+
+/** Current step renders as "done" — flush order isn't guaranteed at picker time. */
+function buildStatusMap(
+  steps: PlanStep[] | undefined,
+  completedStepIds: Set<string> | undefined,
+  currentStepId: string,
+  isLast: boolean,
+): Map<string, StepStatus> {
+  const map = new Map<string, StepStatus>();
+  if (!steps) return map;
+  for (const step of steps) {
+    if (completedStepIds?.has(step.id) || step.id === currentStepId) {
+      map.set(step.id, "done");
+    } else {
+      map.set(step.id, "pending");
+    }
+  }
+  void isLast;
+  return map;
+}

--- a/src/cli/ui/Select.tsx
+++ b/src/cli/ui/Select.tsx
@@ -19,6 +19,8 @@ export interface SingleSelectProps<V extends string> {
   initialValue?: V;
   onSubmit: (value: V) => void;
   onCancel?: () => void;
+  /** Fired when Tab is pressed on the currently highlighted item. */
+  onTab?: (value: V) => void;
   /** Optional dim footer beneath the list. */
   footer?: string;
 }
@@ -27,6 +29,7 @@ export function SingleSelect<V extends string>({
   items,
   initialValue,
   onSubmit,
+  onTab,
   onCancel,
   footer,
 }: SingleSelectProps<V>) {
@@ -45,6 +48,9 @@ export function SingleSelect<V extends string>({
     } else if (ev.return) {
       const chosen = items[index];
       if (chosen && !chosen.disabled) onSubmit(chosen.value);
+    } else if (ev.tab) {
+      const chosen = items[index];
+      if (chosen && !chosen.disabled) onTab?.(chosen.value);
     } else if (ev.escape && onCancel) {
       onCancel();
     }

--- a/src/cli/ui/ShellConfirm.tsx
+++ b/src/cli/ui/ShellConfirm.tsx
@@ -35,7 +35,7 @@ export function ShellConfirm({ command, allowPrefix, kind, onChoose }: ShellConf
         glyph="✗"
         title="Deny — provide context"
         metaRight="optional"
-        footerHint="⏎ submit  ·  esc skip (deny without reason)"
+        footerHint="type context  ·  ⏎ submit with reason  ·  esc skip (deny without reason)"
       >
         <DenyContextInput
           onSubmit={(context) => onChoose("deny", context || undefined)}
@@ -51,7 +51,7 @@ export function ShellConfirm({ command, allowPrefix, kind, onChoose }: ShellConf
       glyph={isBackground ? "⏱" : "?"}
       title={isBackground ? "Background process" : "Shell command"}
       metaRight="awaiting"
-      footerHint="↑↓ pick  ·  ⏎ confirm  ·  esc cancel"
+      footerHint="↑↓ pick  ·  ⏎ confirm  ·  Tab add context  ·  esc cancel"
     >
       <Box marginBottom={1}>
         <Text color={FG.faint}>{subtitle}</Text>
@@ -80,12 +80,15 @@ export function ShellConfirm({ command, allowPrefix, kind, onChoose }: ShellConf
           {
             value: "deny",
             label: "deny",
-            hint: "skip; agent will pick an alternative",
+            hint: "press Tab to add context telling the model why",
           },
         ]}
         onSubmit={(v) => {
           if (v === "deny") setPhase("deny");
           else onChoose(v as ShellConfirmChoice);
+        }}
+        onTab={(v) => {
+          if (v === "deny") setPhase("deny");
         }}
         onCancel={() => onChoose("deny")}
       />

--- a/src/cli/ui/hooks/handle-tool-event.ts
+++ b/src/cli/ui/hooks/handle-tool-event.ts
@@ -16,7 +16,7 @@ export interface ToolEventContext {
   toolStartedAtRef: MutableRefObject<number | null>;
   toolHistoryRef: MutableRefObject<Array<{ toolName: string; text: string }>>;
   setPendingShell: Dispatch<
-    SetStateAction<{ command: string; kind: "run_command" | "run_background" } | null>
+    SetStateAction<{ id: number; command: string; kind: "run_command" | "run_background" } | null>
   >;
   setPendingPlan: Dispatch<SetStateAction<string | null>>;
   setPendingRevision: Dispatch<
@@ -50,122 +50,6 @@ export function handleToolEvent(ev: LoopEvent, ctx: ToolEventContext): void {
       toolName: ev.toolName ?? "?",
       text: ev.content,
     });
-  }
-
-  if (
-    ctx.codeModeOn &&
-    (ev.toolName === "run_command" || ev.toolName === "run_background") &&
-    ev.content.includes('"NeedsConfirmationError:') &&
-    ev.toolArgs
-  ) {
-    try {
-      const parsed = JSON.parse(ev.toolArgs) as { command?: unknown };
-      if (typeof parsed.command === "string" && parsed.command.trim()) {
-        ctx.setPendingShell({
-          command: parsed.command.trim(),
-          kind: ev.toolName as "run_command" | "run_background",
-        });
-      }
-    } catch {
-      /* malformed args — skip the prompt */
-    }
-  }
-
-  if (
-    ctx.codeModeOn &&
-    ev.toolName === "submit_plan" &&
-    ev.content.includes('"PlanProposedError:')
-  ) {
-    try {
-      const parsed = JSON.parse(ev.content) as {
-        plan?: unknown;
-        steps?: unknown;
-        summary?: unknown;
-      };
-      if (typeof parsed.plan === "string" && parsed.plan.trim()) {
-        const planText = parsed.plan.trim();
-        ctx.setPendingPlan(planText);
-        const steps = Array.isArray(parsed.steps) ? (parsed.steps as PlanStep[]) : null;
-        ctx.planStepsRef.current = steps;
-        ctx.completedStepIdsRef.current = new Set();
-        ctx.planBodyRef.current = planText;
-        ctx.planSummaryRef.current =
-          typeof parsed.summary === "string" && parsed.summary.trim()
-            ? parsed.summary.trim()
-            : null;
-        ctx.persistPlanState();
-        const summary =
-          typeof parsed.summary === "string" && parsed.summary.trim() ? parsed.summary.trim() : "";
-        const title = summary ? `Plan · ${summary}` : "Plan submitted";
-        ctx.log.showPlan({
-          title,
-          steps: (steps ?? []).map((s) => ({ id: s.id, title: s.title, status: "queued" })),
-          variant: "active",
-        });
-      }
-    } catch {
-      /* malformed payload — skip the picker */
-    }
-  }
-
-  if (ev.toolName === "revise_plan" && ev.content.includes('"PlanRevisionProposedError:')) {
-    try {
-      const parsed = JSON.parse(ev.content) as {
-        reason?: unknown;
-        remainingSteps?: unknown;
-        summary?: unknown;
-      };
-      const reason = typeof parsed.reason === "string" ? parsed.reason.trim() : "";
-      const remainingSteps = Array.isArray(parsed.remainingSteps)
-        ? (parsed.remainingSteps as PlanStep[]).filter(
-            (s) =>
-              s &&
-              typeof s.id === "string" &&
-              s.id.trim() &&
-              typeof s.title === "string" &&
-              s.title.trim() &&
-              typeof s.action === "string" &&
-              s.action.trim(),
-          )
-        : [];
-      if (reason && remainingSteps.length > 0) {
-        const summary =
-          typeof parsed.summary === "string" ? parsed.summary.trim() || undefined : undefined;
-        ctx.setPendingRevision({ reason, remainingSteps, summary });
-      }
-    } catch {
-      /* malformed payload — skip the picker */
-    }
-  }
-
-  if (ev.toolName === "ask_choice" && ev.content.includes('"ChoiceRequestedError:')) {
-    try {
-      const parsed = JSON.parse(ev.content) as {
-        question?: unknown;
-        options?: unknown;
-        allowCustom?: unknown;
-      };
-      const question = typeof parsed.question === "string" ? parsed.question.trim() : "";
-      const options = Array.isArray(parsed.options)
-        ? (parsed.options as ChoiceOption[]).filter(
-            (o) =>
-              o &&
-              typeof o.id === "string" &&
-              o.id.trim() &&
-              typeof o.title === "string" &&
-              o.title.trim(),
-          )
-        : [];
-      if (question && options.length >= 2) {
-        ctx.setPendingChoice({
-          question,
-          options,
-          allowCustom: parsed.allowCustom === true,
-        });
-      }
-    } catch {
-      /* malformed payload — skip the picker */
-    }
   }
 
   if (ev.toolName === "mark_step_complete") {

--- a/src/core/pause-gate.ts
+++ b/src/core/pause-gate.ts
@@ -9,7 +9,10 @@ export type ConfirmationChoice =
 
 export type PlanVerdict = { type: "approve" } | { type: "refine" } | { type: "cancel" };
 
-export type CheckpointVerdict = { type: "continue" } | { type: "revise" } | { type: "stop" };
+export type CheckpointVerdict =
+  | { type: "continue" }
+  | { type: "revise"; feedback?: string }
+  | { type: "stop" };
 
 export type RevisionVerdict = { type: "accepted" } | { type: "rejected" } | { type: "cancelled" };
 

--- a/src/core/pause-gate.ts
+++ b/src/core/pause-gate.ts
@@ -1,0 +1,107 @@
+/** Generic pause gate — bridges tool functions and the App's modals via Promises. */
+// Tools call gate.ask(kind, payload) and await the result; the App subscribes
+// with gate.on() to show the right modal, then calls gate.resolve() on user pick.
+
+export type ConfirmationChoice =
+  | { type: "deny"; denyContext?: string }
+  | { type: "run_once" }
+  | { type: "always_allow"; prefix: string };
+
+export type PlanVerdict = { type: "approve" } | { type: "refine" } | { type: "cancel" };
+
+export type CheckpointVerdict = { type: "continue" } | { type: "revise" } | { type: "stop" };
+
+export type RevisionVerdict = { type: "accepted" } | { type: "rejected" } | { type: "cancelled" };
+
+export type ChoiceVerdict =
+  | { type: "pick"; optionId: string }
+  | { type: "text"; text: string }
+  | { type: "cancel" };
+
+interface PauseResponseMap {
+  run_command: ConfirmationChoice;
+  run_background: ConfirmationChoice;
+  plan_proposed: PlanVerdict;
+  plan_checkpoint: CheckpointVerdict;
+  plan_revision: RevisionVerdict;
+  choice: ChoiceVerdict;
+}
+
+type PauseKind = keyof PauseResponseMap;
+
+interface PausePayloadMap {
+  run_command: { command: string };
+  run_background: { command: string };
+  plan_proposed: { plan: string; steps?: unknown[]; summary?: string };
+  plan_checkpoint: { stepId: string; title?: string; result: string; notes?: string };
+  plan_revision: { reason: string; remainingSteps: unknown[]; summary?: string };
+  choice: { question: string; options: unknown[]; allowCustom: boolean };
+}
+
+export type PauseRequest = {
+  id: number;
+  kind: PauseKind;
+  payload: unknown;
+};
+
+type GateListener = (request: PauseRequest) => void;
+
+/** Named options for PauseGate.ask() — makes it obvious which field is kind vs payload. */
+export interface PauseAskOpts<K extends PauseKind = PauseKind> {
+  kind: K;
+  payload: PausePayloadMap[K];
+}
+
+export class PauseGate {
+  private _nextId = 0;
+  private _pending = new Map<number, { resolve: (data: unknown) => void; request: PauseRequest }>();
+  private _listeners: Set<GateListener> = new Set();
+
+  /** Block until the user responds. Takes a named options object so the
+   *  kind and payload fields don't get confused at the call site. */
+  ask<K extends PauseKind>(opts: PauseAskOpts<K>): Promise<PauseResponseMap[K]> {
+    const { kind, payload } = opts;
+    if (this._listeners.size === 0) {
+      throw new Error(
+        `${kind}: no confirmation listener registered — cannot prompt the user. This tool can only be used inside an interactive Reasonix session.`,
+      );
+    }
+    return new Promise((resolve) => {
+      const id = this._nextId++;
+      const request: PauseRequest = { id, kind, payload };
+      this._pending.set(id, { resolve: resolve as (d: unknown) => void, request });
+      for (const fn of this._listeners) {
+        try {
+          fn(request);
+        } catch {
+          /* listener error shouldn't break the gate */
+        }
+      }
+    });
+  }
+
+  /** Resolve a pending request. Called by the App's modal callback. */
+  resolve(id: number, data: unknown): void {
+    const p = this._pending.get(id);
+    if (!p) return;
+    this._pending.delete(id);
+    p.resolve(data);
+  }
+
+  /** Subscribe to new pause requests. Returns an unsubscribe function. */
+  on(fn: GateListener): () => void {
+    this._listeners.add(fn);
+    return () => {
+      this._listeners.delete(fn);
+    };
+  }
+
+  /** Current pending request, if any (polling fallback). */
+  get current(): PauseRequest | null {
+    for (const [, p] of this._pending) return p.request;
+    return null;
+  }
+}
+
+/** Singleton shared between tools and the App. */
+export const pauseGate = new PauseGate();

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -5,6 +5,8 @@ import {
   aggregateBranchUsage,
   runBranches,
 } from "./consistency.js";
+import type { PauseGate } from "./core/pause-gate.js";
+import { pauseGate as defaultPauseGate } from "./core/pause-gate.js";
 import { type HarvestOptions, type TypedPlanState, emptyPlanState, harvest } from "./harvest.js";
 import {
   type HookOutcome,
@@ -119,6 +121,8 @@ export interface CacheFirstLoopOptions {
   hooks?: ResolvedHook[];
   /** `cwd` reported to hooks; `reasonix code` sets this to the sandbox root, not shell home. */
   hookCwd?: string;
+  /** PauseGate bridge — defaults to singleton, injectable for tests. */
+  confirmationGate?: PauseGate;
 }
 
 export interface ReconfigurableOptions {
@@ -160,6 +164,9 @@ export class CacheFirstLoop {
   hooks: ResolvedHook[];
   hookCwd: string;
 
+  /** PauseGate bridge — defaults to singleton, injectable for tests. */
+  readonly confirmationGate: PauseGate;
+
   /** Number of messages that were pre-loaded from the session file. */
   readonly resumedMessageCount: number;
 
@@ -187,6 +194,7 @@ export class CacheFirstLoop {
     this.maxToolIters = opts.maxToolIters ?? 64;
     this.hooks = opts.hooks ?? [];
     this.hookCwd = opts.hookCwd ?? process.cwd();
+    this.confirmationGate = opts.confirmationGate ?? defaultPauseGate;
 
     // Resolve branch config first (since it forces harvest on).
     if (typeof opts.branch === "number") {
@@ -1295,6 +1303,7 @@ export class CacheFirstLoop {
           result = await this.tools.dispatch(name, args, {
             signal,
             maxResultTokens: DEFAULT_MAX_RESULT_TOKENS,
+            confirmationGate: this.confirmationGate,
           });
 
           // PostToolUse hooks — block is meaningless after the fact, so

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,9 +1,12 @@
+import type { PauseGate } from "./core/pause-gate.js";
 import { truncateForModel, truncateForModelByTokens } from "./mcp/registry.js";
 import { analyzeSchema, flattenSchema, nestArguments } from "./repair/flatten.js";
 import type { JSONSchema, ToolSpec } from "./types.js";
 
 export interface ToolCallContext {
   signal?: AbortSignal;
+  /** Inject a mock PauseGate for tests. When absent, tools use the singleton. */
+  confirmationGate?: PauseGate;
 }
 
 export interface ToolDefinition<A = any, R = any> {
@@ -102,7 +105,13 @@ export class ToolRegistry {
   async dispatch(
     name: string,
     argumentsRaw: string | Record<string, unknown>,
-    opts: { signal?: AbortSignal; maxResultChars?: number; maxResultTokens?: number } = {},
+    opts: {
+      signal?: AbortSignal;
+      maxResultChars?: number;
+      maxResultTokens?: number;
+      /** Inject a mock PauseGate for tests. */
+      confirmationGate?: PauseGate;
+    } = {},
   ): Promise<string> {
     const tool = this._tools.get(name);
     if (!tool) {
@@ -158,7 +167,10 @@ export class ToolRegistry {
     }
 
     try {
-      const result = await tool.fn(args, { signal: opts.signal });
+      const result = await tool.fn(args, {
+        signal: opts.signal,
+        confirmationGate: opts.confirmationGate,
+      });
       const str = typeof result === "string" ? result : JSON.stringify(result);
       // Pre-clip at dispatch so a single fat result can't balloon the
       // log (and disk session file) on its way in. Healing at load time

--- a/src/tools/choice.ts
+++ b/src/tools/choice.ts
@@ -1,5 +1,6 @@
 /** Branching primitive separate from submit_plan; throws ChoiceRequestedError so the TUI can mount a picker and the model stops. */
 
+import { pauseGate } from "../core/pause-gate.js";
 import type { ToolRegistry } from "../tools.js";
 
 export interface ChoiceOption {
@@ -104,7 +105,7 @@ export function registerChoiceTool(
       },
       required: ["question", "options"],
     },
-    fn: async (args: { question: string; options: unknown; allowCustom?: boolean }) => {
+    fn: async (args: { question: string; options: unknown; allowCustom?: boolean }, ctx) => {
       const question = (args?.question ?? "").trim();
       if (!question) {
         throw new Error(
@@ -124,7 +125,14 @@ export function registerChoiceTool(
       }
       const allowCustom = args?.allowCustom === true;
       opts.onChoiceRequested?.(question, options);
-      throw new ChoiceRequestedError(question, options, allowCustom);
+      // Block until the user picks an option, types custom text, or cancels
+      const verdict = await (ctx?.confirmationGate ?? pauseGate).ask({
+        kind: "choice",
+        payload: { question, options, allowCustom },
+      });
+      if (verdict.type === "pick") return `user picked: ${verdict.optionId}`;
+      if (verdict.type === "text") return `user answered: ${verdict.text}`;
+      return "user cancelled the choice";
     },
   });
   return registry;

--- a/src/tools/plan-core.ts
+++ b/src/tools/plan-core.ts
@@ -1,3 +1,4 @@
+import { pauseGate } from "../core/pause-gate.js";
 import type { ToolRegistry } from "../tools.js";
 import { PlanProposedError, PlanRevisionProposedError } from "./plan-errors.js";
 import type { PlanStep, PlanStepRisk, StepCompletion } from "./plan-types.js";
@@ -94,7 +95,7 @@ function registerSubmitPlan(registry: ToolRegistry, opts: PlanToolOptions): void
       },
       required: ["plan"],
     },
-    fn: async (args: { plan: string; steps?: unknown; summary?: string }) => {
+    fn: async (args: { plan: string; steps?: unknown; summary?: string }, ctx) => {
       const plan = (args?.plan ?? "").trim();
       if (!plan) {
         throw new Error("submit_plan: empty plan — write a markdown plan and try again.");
@@ -103,7 +104,14 @@ function registerSubmitPlan(registry: ToolRegistry, opts: PlanToolOptions): void
       const summary =
         typeof args?.summary === "string" ? args.summary.trim() || undefined : undefined;
       opts.onPlanSubmitted?.(plan, steps);
-      throw new PlanProposedError(plan, steps, summary);
+      // Block until the user approves, refines, or cancels
+      const verdict = await (ctx?.confirmationGate ?? pauseGate).ask({
+        kind: "plan_proposed",
+        payload: { plan, steps, summary },
+      });
+      if (verdict.type === "approve") return "plan approved";
+      if (verdict.type === "refine") throw new Error("user requested refinement");
+      throw new Error("plan cancelled");
     },
   });
 }
@@ -138,7 +146,7 @@ function registerMarkStepComplete(registry: ToolRegistry, opts: PlanToolOptions)
       },
       required: ["stepId", "result"],
     },
-    fn: async (args: { stepId: string; title?: string; result: string; notes?: string }) => {
+    fn: async (args: { stepId: string; title?: string; result: string; notes?: string }, ctx) => {
       const stepId = (args?.stepId ?? "").trim();
       const result = (args?.result ?? "").trim();
       if (!stepId) {
@@ -155,7 +163,14 @@ function registerMarkStepComplete(registry: ToolRegistry, opts: PlanToolOptions)
       if (title) update.title = title;
       if (notes) update.notes = notes;
       opts.onStepCompleted?.(update);
-      return update;
+      // Block until the user continues, revises, or stops
+      const verdict = await (ctx?.confirmationGate ?? pauseGate).ask({
+        kind: "plan_checkpoint",
+        payload: { stepId, title, result, notes },
+      });
+      if (verdict.type === "continue") return JSON.stringify(update);
+      if (verdict.type === "revise") throw new Error("user requested revision at checkpoint");
+      throw new Error("user stopped at checkpoint");
     },
   });
 }
@@ -187,7 +202,7 @@ function registerRevisePlan(registry: ToolRegistry, opts: PlanToolOptions): void
       },
       required: ["reason", "remainingSteps"],
     },
-    fn: async (args: { reason: string; remainingSteps: unknown; summary?: string }) => {
+    fn: async (args: { reason: string; remainingSteps: unknown; summary?: string }, ctx) => {
       const reason = (args?.reason ?? "").trim();
       if (!reason) {
         throw new Error(
@@ -203,7 +218,14 @@ function registerRevisePlan(registry: ToolRegistry, opts: PlanToolOptions): void
       const summary =
         typeof args?.summary === "string" ? args.summary.trim() || undefined : undefined;
       opts.onPlanRevisionProposed?.(reason, remainingSteps, summary);
-      throw new PlanRevisionProposedError(reason, remainingSteps, summary);
+      // Block until the user accepts, rejects, or cancels the revision
+      const verdict = await (ctx?.confirmationGate ?? pauseGate).ask({
+        kind: "plan_revision",
+        payload: { reason, remainingSteps, summary },
+      });
+      if (verdict.type === "accepted") return "revision accepted";
+      if (verdict.type === "rejected") throw new Error("revision rejected");
+      throw new Error("revision cancelled");
     },
   });
 }

--- a/src/tools/plan-core.ts
+++ b/src/tools/plan-core.ts
@@ -169,7 +169,10 @@ function registerMarkStepComplete(registry: ToolRegistry, opts: PlanToolOptions)
         payload: { stepId, title, result, notes },
       });
       if (verdict.type === "continue") return JSON.stringify(update);
-      if (verdict.type === "revise") throw new Error("user requested revision at checkpoint");
+      if (verdict.type === "revise") {
+        if (verdict.feedback) return `revision requested: ${verdict.feedback}`;
+        throw new Error("user requested revision at checkpoint");
+      }
       throw new Error("user stopped at checkpoint");
     },
   });

--- a/src/tools/shell.ts
+++ b/src/tools/shell.ts
@@ -3,6 +3,8 @@
 import { type ChildProcess, type SpawnOptions, spawn, spawnSync } from "node:child_process";
 import { existsSync, statSync } from "node:fs";
 import * as pathMod from "node:path";
+import { addProjectShellAllowed } from "../config.js";
+import { pauseGate } from "../core/pause-gate.js";
 import type { ToolRegistry } from "../tools.js";
 import { JobRegistry } from "./jobs.js";
 import {
@@ -591,7 +593,17 @@ export function registerShellTools(registry: ToolRegistry, opts: ShellToolsOptio
       const cmd = args.command.trim();
       if (!cmd) throw new Error("run_command: empty command");
       if (!isAllowAll() && !isCommandAllowed(cmd, getExtraAllowed())) {
-        throw new NeedsConfirmationError(cmd);
+        const gate = ctx?.confirmationGate ?? pauseGate;
+        const choice = await gate.ask({ kind: "run_command", payload: { command: cmd } });
+        if (choice.type === "deny") {
+          throw new Error(
+            `user denied: ${cmd}${choice.denyContext ? ` — ${choice.denyContext}` : ""}`,
+          );
+        }
+        if (choice.type === "always_allow") {
+          addProjectShellAllowed(rootDir, choice.prefix);
+        }
+        // "run_once" — fall through and execute
       }
       const effectiveTimeout = Math.max(1, Math.min(600, args.timeoutSec ?? timeoutSec));
       const result = await runCommand(cmd, {
@@ -627,8 +639,18 @@ export function registerShellTools(registry: ToolRegistry, opts: ShellToolsOptio
     fn: async (args: { command: string; waitSec?: number }, ctx) => {
       const cmd = args.command.trim();
       if (!cmd) throw new Error("run_background: empty command");
-      if (!isAllowAll() && !isAllowed(cmd, getExtraAllowed())) {
-        throw new NeedsConfirmationError(cmd);
+      if (!isAllowAll() && !isCommandAllowed(cmd, getExtraAllowed())) {
+        const gate = ctx?.confirmationGate ?? pauseGate;
+        const choice = await gate.ask({ kind: "run_background", payload: { command: cmd } });
+        if (choice.type === "deny") {
+          throw new Error(
+            `user denied: ${cmd}${choice.denyContext ? ` — ${choice.denyContext}` : ""}`,
+          );
+        }
+        if (choice.type === "always_allow") {
+          addProjectShellAllowed(rootDir, choice.prefix);
+        }
+        // "run_once" — fall through and execute
       }
       const result = await jobs.start(cmd, {
         cwd: rootDir,

--- a/tests/choice.test.ts
+++ b/tests/choice.test.ts
@@ -1,8 +1,20 @@
 /** ask_choice — schema, sanitization, ChoiceRequestedError → tool_result protocol. */
 
 import { describe, expect, it } from "vitest";
+import { PauseGate } from "../src/core/pause-gate.js";
 import { ToolRegistry } from "../src/tools.js";
 import { ChoiceRequestedError, registerChoiceTool } from "../src/tools/choice.js";
+
+class AutoGate extends PauseGate {
+  private _choice: { type: string; optionId?: string; text?: string };
+  constructor(choice: { type: string; optionId?: string; text?: string }) {
+    super();
+    this._choice = choice;
+  }
+  override ask(_opts: { kind: string; payload?: unknown }): Promise<any> {
+    return Promise.resolve(this._choice);
+  }
+}
 
 describe("ChoiceRequestedError", () => {
   it("carries the question / options / allowCustom on the instance and in toToolResult()", () => {
@@ -40,12 +52,13 @@ describe("registerChoiceTool + ask_choice", () => {
     expect(reg.get("ask_choice")?.readOnly).toBe(true);
   });
 
-  it("throws ChoiceRequestedError and surfaces the full payload via toToolResult", async () => {
+  it("blocks on PauseGate and returns the user's pick", async () => {
     const reg = new ToolRegistry();
     const seen: Array<{ question: string; options: unknown }> = [];
     registerChoiceTool(reg, {
       onChoiceRequested: (q, o) => seen.push({ question: q, options: o }),
     });
+    const gate = new AutoGate({ type: "pick", optionId: "A" });
     const out = await reg.dispatch(
       "ask_choice",
       JSON.stringify({
@@ -56,15 +69,9 @@ describe("registerChoiceTool + ask_choice", () => {
         ],
         allowCustom: true,
       }),
+      { confirmationGate: gate },
     );
-    const parsed = JSON.parse(out);
-    expect(parsed.question).toBe("Pick a route.");
-    expect(parsed.options).toEqual([
-      { id: "A", title: "Deepen demo" },
-      { id: "B", title: "Start UE5", summary: "fresh engine" },
-    ]);
-    expect(parsed.allowCustom).toBe(true);
-    expect(parsed.error).toMatch(/^ChoiceRequestedError:/);
+    expect(out).toBe("user picked: A");
     expect(seen).toHaveLength(1);
     expect(seen[0]?.question).toBe("Pick a route.");
   });
@@ -72,6 +79,7 @@ describe("registerChoiceTool + ask_choice", () => {
   it("defaults allowCustom to false when not provided", async () => {
     const reg = new ToolRegistry();
     registerChoiceTool(reg);
+    const gate = new AutoGate({ type: "pick", optionId: "A" });
     const out = await reg.dispatch(
       "ask_choice",
       JSON.stringify({
@@ -81,14 +89,20 @@ describe("registerChoiceTool + ask_choice", () => {
           { id: "B", title: "two" },
         ],
       }),
+      { confirmationGate: gate },
     );
-    expect(JSON.parse(out).allowCustom).toBe(false);
+    // Tool works without error — allowCustom defaults to false
+    expect(out).toBe("user picked: A");
   });
 
   it("drops malformed option entries (DeepSeek sometimes misses fields)", async () => {
     const reg = new ToolRegistry();
-    registerChoiceTool(reg);
-    const out = await reg.dispatch(
+    const seen: Array<{ options: { id: string; title: string }[] }> = [];
+    registerChoiceTool(reg, {
+      onChoiceRequested: (_q, opts) => seen.push({ options: opts as any }),
+    });
+    const gate = new AutoGate({ type: "pick", optionId: "A" });
+    await reg.dispatch(
       "ask_choice",
       JSON.stringify({
         question: "Pick.",
@@ -101,9 +115,9 @@ describe("registerChoiceTool + ask_choice", () => {
           { id: "C", title: "also good" },
         ],
       }),
+      { confirmationGate: gate },
     );
-    const parsed = JSON.parse(out);
-    expect(parsed.options).toEqual([
+    expect(seen[0]?.options).toEqual([
       { id: "A", title: "good" },
       { id: "C", title: "also good" },
     ]);
@@ -111,8 +125,12 @@ describe("registerChoiceTool + ask_choice", () => {
 
   it("deduplicates options with the same id (first one wins)", async () => {
     const reg = new ToolRegistry();
-    registerChoiceTool(reg);
-    const out = await reg.dispatch(
+    const seen: Array<{ question: string; options: unknown }> = [];
+    registerChoiceTool(reg, {
+      onChoiceRequested: (q, o) => seen.push({ question: q, options: o }),
+    });
+    const gate = new AutoGate({ type: "pick", optionId: "A" });
+    await reg.dispatch(
       "ask_choice",
       JSON.stringify({
         question: "Pick.",
@@ -122,9 +140,9 @@ describe("registerChoiceTool + ask_choice", () => {
           { id: "B", title: "second" },
         ],
       }),
+      { confirmationGate: gate },
     );
-    const parsed = JSON.parse(out);
-    expect(parsed.options).toEqual([
+    expect(seen[0]?.options).toEqual([
       { id: "A", title: "first" },
       { id: "B", title: "second" },
     ]);
@@ -174,6 +192,7 @@ describe("registerChoiceTool + ask_choice", () => {
     const reg = new ToolRegistry();
     registerChoiceTool(reg);
     reg.setPlanMode(true);
+    const gate = new AutoGate({ type: "pick", optionId: "A" });
     const out = await reg.dispatch(
       "ask_choice",
       JSON.stringify({
@@ -183,10 +202,8 @@ describe("registerChoiceTool + ask_choice", () => {
           { id: "B", title: "b" },
         ],
       }),
+      { confirmationGate: gate },
     );
-    const parsed = JSON.parse(out);
-    // Plan mode doesn't block ask_choice — it's readOnly.
-    expect(parsed.error).toMatch(/^ChoiceRequestedError:/);
-    expect(parsed.options).toHaveLength(2);
+    expect(out).toBe("user picked: A");
   });
 });

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -2,6 +2,7 @@
 
 import { describe, expect, it, vi } from "vitest";
 import { DeepSeekClient } from "../src/client.js";
+import { type ConfirmationChoice, PauseGate } from "../src/core/pause-gate.js";
 import { CacheFirstLoop } from "../src/loop.js";
 import { ImmutablePrefix } from "../src/memory/runtime.js";
 import { ToolRegistry } from "../src/tools.js";
@@ -1043,6 +1044,169 @@ describe("CacheFirstLoop (streaming) — tool_call_delta emission", () => {
     // No "error" event leaked through.
     expect(events.find((e) => e.role === "error")).toBeUndefined();
     // Loop terminated cleanly so the TUI's busy state unsticks.
+    expect(events[events.length - 1]?.role).toBe("done");
+  });
+
+  it.skip("defers sibling tool calls when change_workspace pops the confirmation modal", async () => {
+    // This test is skipped — change_workspace was removed (fb1b306).
+    // The model emits TWO tool calls in one assistant message:
+    // change_workspace + write_file. The workspace switch needs user
+    // approval; the write must NOT execute against the OLD root before
+    // the user confirms (silent data loss). Both still get tool
+    // results — the deferred one with a clear "skipped" payload — so
+    // tool_call ↔ tool pairing stays valid for DeepSeek's next turn.
+    const { registerWorkspaceTool } = await import("../src/tools/workspace.js");
+
+    const client = makeClient([
+      {
+        content: "",
+        tool_calls: [
+          {
+            id: "call_1",
+            type: "function",
+            function: {
+              name: "change_workspace",
+              arguments: `{"path":"${process.cwd().replace(/\\/g, "/")}"}`,
+            },
+          },
+          {
+            id: "call_2",
+            type: "function",
+            function: {
+              name: "write_marker",
+              arguments: '{"value":"should-not-fire"}',
+            },
+          },
+        ],
+      },
+      { content: "ok" },
+    ]);
+
+    const tools = new ToolRegistry();
+    registerWorkspaceTool(tools);
+    let writeFired = false;
+    tools.register<{ value: string }, string>({
+      name: "write_marker",
+      parameters: { type: "object", properties: { value: { type: "string" } } },
+      fn: ({ value }) => {
+        writeFired = true;
+        return value;
+      },
+    });
+
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s", toolSpecs: tools.specs() }),
+      tools,
+      stream: false,
+    });
+
+    const toolResults: Array<{ name: string; content: string }> = [];
+    for await (const ev of loop.step("switch and write")) {
+      if (ev.role === "tool" && ev.toolName) {
+        toolResults.push({ name: ev.toolName, content: ev.content });
+      }
+    }
+
+    expect(writeFired).toBe(false);
+    expect(toolResults).toHaveLength(2);
+    expect(toolResults[0]?.name).toBe("change_workspace");
+    expect(toolResults[0]?.content).toContain("WorkspaceConfirmationError");
+    expect(toolResults[1]?.name).toBe("write_marker");
+    expect(toolResults[1]?.content).toContain("deferred");
+  });
+
+  it("blocks on confirmation gate without letting the model retry in the same turn", async () => {
+    // An auto-approving gate so the tool doesn't block forever in tests.
+    // In production, the singleton gate shows the ShellConfirm modal.
+    const gate = new PauseGate();
+    // Override ask to auto-approve without blocking.
+    const origAsk = gate.ask.bind(gate);
+    void origAsk;
+    gate.ask = (_opts: { kind: string; payload?: unknown }) => {
+      return Promise.resolve<ConfirmationChoice>({ type: "run_once" });
+    };
+
+    // A tool that uses the confirmation gate (like run_command does)
+    const reg = new ToolRegistry();
+    reg.register({
+      name: "run_command",
+      description: "run a command — needs confirmation",
+      parameters: {
+        type: "object",
+        properties: { command: { type: "string" } },
+        required: ["command"],
+      },
+      fn: async (_args: { command: string }, ctx) => {
+        // Simulate what shell.ts does: block on the gate
+        const realGate = ctx?.confirmationGate ?? gate;
+        const choice = await (realGate.ask({
+          kind: "run_command",
+          payload: { command: "echo ok" },
+        }) as Promise<ConfirmationChoice>);
+        if (choice.type === "deny") {
+          throw new Error("user denied: echo ok");
+        }
+        return "$ echo ok\n[exit 0]\nok";
+      },
+    });
+
+    // Response 1: model emits a run_command tool call
+    const toolCallResp: FakeResponseShape = {
+      content: "",
+      tool_calls: [
+        {
+          id: "call_1",
+          type: "function",
+          function: {
+            name: "run_command",
+            arguments: '{"command":"echo ok"}',
+          },
+        },
+      ],
+    };
+    // Response 2: model sees the tool output and responds naturally
+    const followUpResp: FakeResponseShape = {
+      content: "Command ran successfully — output was 'ok'.",
+      tool_calls: [],
+    };
+
+    const responses: FakeResponseShape[] = [toolCallResp, followUpResp];
+    const client = new DeepSeekClient({
+      apiKey: "sk-test",
+      fetch: fakeFetch(responses) as unknown as typeof fetch,
+    });
+
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s", toolSpecs: reg.specs() }),
+      tools: reg,
+      stream: false,
+      confirmationGate: gate,
+    });
+
+    const events: Array<{ role: string; content?: string }> = [];
+    for await (const ev of loop.step("run something")) {
+      events.push({ role: ev.role, content: ev.content });
+    }
+
+    // The tool result should be the normal command output — not a
+    // NeedsConfirmationError string
+    const toolEvents = events.filter((e) => e.role === "tool");
+    expect(toolEvents).toHaveLength(1);
+    expect(toolEvents[0]?.content).toContain("ok");
+    expect(toolEvents[0]?.content).not.toContain("NeedsConfirmationError");
+    expect(toolEvents[0]?.content).not.toContain("user denied");
+
+    // Two model calls: first generates the tool call, second responds to the
+    // output. The gate made the tool return real output synchronously — no
+    // error, no NeedsConfirmationError, no synthetic retry.
+    const finals = events.filter((e) => e.role === "assistant_final");
+    expect(finals).toHaveLength(2);
+    // Second call should be the natural follow-up, not a workaround
+    expect(finals[1]?.content).toMatch(/ran successfully/);
+
+    // Turn ends cleanly
     expect(events[events.length - 1]?.role).toBe("done");
   });
 

--- a/tests/pause-gate.test.ts
+++ b/tests/pause-gate.test.ts
@@ -1,0 +1,104 @@
+/** Tests for the PauseGate core — ask/resolve/on/current. */
+
+import { describe, expect, it, vi } from "vitest";
+import { type ConfirmationChoice, PauseGate } from "../src/core/pause-gate.js";
+
+describe("PauseGate", () => {
+  it("ask creates a pending request and notifies listeners", async () => {
+    const gate = new PauseGate();
+    const listener = vi.fn();
+    gate.on(listener);
+
+    const promise = gate.ask({ kind: "run_command", payload: { command: "echo hi" } });
+    expect(listener).toHaveBeenCalledTimes(1);
+    const req = listener.mock.calls[0]![0]! as { id: number; kind: string; payload: unknown };
+    expect(req.kind).toBe("run_command");
+    expect((req.payload as { command: string }).command).toBe("echo hi");
+    expect(gate.current).not.toBeNull();
+    expect(gate.current?.kind).toBe("run_command");
+
+    gate.resolve(req.id, { type: "run_once" } as ConfirmationChoice);
+    await expect(promise).resolves.toEqual({ type: "run_once" });
+    expect(gate.current).toBeNull();
+  });
+
+  it("resolve with unknown id is a no-op (does not throw)", () => {
+    const gate = new PauseGate();
+    expect(() => gate.resolve(999, { type: "cancel" })).not.toThrow();
+  });
+
+  it("on() returns an unsubscribe function", async () => {
+    const gate = new PauseGate();
+    const listener = vi.fn();
+    const unsub = gate.on(listener);
+    unsub();
+
+    // After unsubscribe, ask should throw (no listeners)
+    expect(() => gate.ask({ kind: "run_command", payload: { command: "test" } })).toThrow(
+      "no confirmation listener",
+    );
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("supports all pause kinds with their payload shapes", async () => {
+    const gate = new PauseGate();
+    const listener = vi.fn();
+    gate.on(listener);
+
+    const entries: Array<{ opts: { kind: string; payload: Record<string, unknown> } }> = [
+      { opts: { kind: "run_command", payload: { command: "x" } } },
+      { opts: { kind: "plan_proposed", payload: { plan: "#", steps: [], summary: "test" } } },
+      { opts: { kind: "plan_checkpoint", payload: { stepId: "s1", result: "done" } } },
+      { opts: { kind: "plan_revision", payload: { reason: "r", remainingSteps: [] } } },
+      { opts: { kind: "choice", payload: { question: "q", options: [], allowCustom: false } } },
+    ];
+
+    for (const { opts } of entries) {
+      const p = gate.ask(opts as any);
+      const req = listener.mock.lastCall?.[0] as { kind: string };
+      expect(req.kind).toBe(opts.kind);
+      gate.resolve(req.id, { type: "run_once" } as ConfirmationChoice);
+      await expect(p).resolves.toBeDefined();
+    }
+  });
+
+  it("listener errors do not break the gate", async () => {
+    const gate = new PauseGate();
+    gate.on(() => {
+      throw new Error("listener crash");
+    });
+    const listener2 = vi.fn();
+    gate.on(listener2);
+
+    const promise = gate.ask({ kind: "run_command", payload: { command: "crash" } });
+    // Second listener should still fire despite the first throwing
+    expect(listener2).toHaveBeenCalledTimes(1);
+    const req = listener2.mock.calls[0]![0]! as { id: number };
+    gate.resolve(req.id, { type: "run_once" } as ConfirmationChoice);
+    await expect(promise).resolves.toEqual({ type: "run_once" });
+  });
+
+  it("multiple pending requests queue independently", async () => {
+    const gate = new PauseGate();
+    const listener = vi.fn();
+    gate.on(listener);
+
+    const p1 = gate.ask({ kind: "run_command", payload: { command: "first" } });
+    const p2 = gate.ask({ kind: "run_command", payload: { command: "second" } });
+
+    // current should return the first one (FIFO by insertion order)
+    expect((gate.current?.payload as { command: string }).command).toBe("first");
+
+    const calls = listener.mock.calls;
+    const id1 = (calls[0]![0]! as { id: number }).id;
+    const id2 = (calls[1]![0]! as { id: number }).id;
+
+    // Resolve in reverse order — should still work independently
+    gate.resolve(id2, { type: "deny" } as ConfirmationChoice);
+    gate.resolve(id1, { type: "run_once" } as ConfirmationChoice);
+
+    await expect(p1).resolves.toEqual({ type: "run_once" });
+    await expect(p2).resolves.toEqual({ type: "deny" });
+    expect(gate.current).toBeNull();
+  });
+});

--- a/tests/pause-gate.test.ts
+++ b/tests/pause-gate.test.ts
@@ -78,6 +78,36 @@ describe("PauseGate", () => {
     await expect(promise).resolves.toEqual({ type: "run_once" });
   });
 
+  it("CheckpointVerdict carries feedback on revise", async () => {
+    const gate = new PauseGate();
+    gate.on(() => {});
+
+    const promise = gate.ask({
+      kind: "plan_checkpoint",
+      payload: { stepId: "step-1", result: "done" },
+    });
+    const req = gate.current!;
+    gate.resolve(req.id, { type: "revise", feedback: "rename to auth-tokens.ts instead" });
+    await expect(promise).resolves.toEqual({
+      type: "revise",
+      feedback: "rename to auth-tokens.ts instead",
+    });
+  });
+
+  it("CheckpointVerdict revise without feedback is accepted", async () => {
+    const gate = new PauseGate();
+    gate.on(() => {});
+
+    const promise = gate.ask({
+      kind: "plan_checkpoint",
+      payload: { stepId: "step-2", result: "added tests" },
+    });
+    const req = gate.current!;
+    // Bare revise — no feedback string
+    gate.resolve(req.id, { type: "revise" });
+    await expect(promise).resolves.toEqual({ type: "revise" });
+  });
+
   it("multiple pending requests queue independently", async () => {
     const gate = new PauseGate();
     const listener = vi.fn();

--- a/tests/plan.test.ts
+++ b/tests/plan.test.ts
@@ -434,6 +434,31 @@ describe("registerPlanTool + mark_step_complete", () => {
     );
     expect(JSON.parse(out).error).toMatch(/result is required/);
   });
+
+  it("surfaces revise feedback in the tool result when gate resolves with feedback", async () => {
+    const reg = new ToolRegistry();
+    registerPlanTool(reg);
+    const gate = new AutoGate({ type: "revise", feedback: "skip step 3 and add auth middleware" });
+    const out = await reg.dispatch(
+      "mark_step_complete",
+      JSON.stringify({ stepId: "step-2", result: "added tests" }),
+      { confirmationGate: gate },
+    );
+    // Not JSON — the tool returns a plain string when feedback is present
+    expect(out).toBe("revision requested: skip step 3 and add auth middleware");
+  });
+
+  it("throws user requested revision when revise has no feedback", async () => {
+    const reg = new ToolRegistry();
+    registerPlanTool(reg);
+    const gate = new AutoGate({ type: "revise" });
+    const out = await reg.dispatch(
+      "mark_step_complete",
+      JSON.stringify({ stepId: "step-3", result: "finished wiring" }),
+      { confirmationGate: gate },
+    );
+    expect(JSON.parse(out).error).toMatch(/user requested revision at checkpoint/);
+  });
 });
 
 describe("PlanRevisionProposedError", () => {

--- a/tests/plan.test.ts
+++ b/tests/plan.test.ts
@@ -1,12 +1,25 @@
 /** Plan Mode — read-only dispatch gate + submit_plan tool's PlanProposedError → tool_result protocol. */
 
 import { describe, expect, it } from "vitest";
+import { type ConfirmationChoice, PauseGate } from "../src/core/pause-gate.js";
 import { ToolRegistry } from "../src/tools.js";
 import {
   PlanProposedError,
   PlanRevisionProposedError,
   registerPlanTool,
 } from "../src/tools/plan.js";
+
+/** A PauseGate that auto-resolves with a pre-configured choice.  */
+class AutoGate extends PauseGate {
+  private _choice: ConfirmationChoice | { type: string };
+  constructor(choice: ConfirmationChoice | { type: string }) {
+    super();
+    this._choice = choice;
+  }
+  override ask(_opts: { kind: string; payload?: unknown }): Promise<any> {
+    return Promise.resolve(this._choice);
+  }
+}
 
 describe("ToolRegistry plan mode", () => {
   it("starts with plan mode off by default", () => {
@@ -149,15 +162,16 @@ describe("registerPlanTool + submit_plan", () => {
     expect(reg.get("submit_plan")?.readOnly).toBe(true);
   });
 
-  it("throws PlanProposedError when called with a plan (plan mode ON)", async () => {
+  it("blocks on PauseGate when called with a plan (plan mode ON)", async () => {
     const reg = new ToolRegistry();
     const submitted: string[] = [];
     registerPlanTool(reg, { onPlanSubmitted: (p) => submitted.push(p) });
     reg.setPlanMode(true);
-    const out = await reg.dispatch("submit_plan", JSON.stringify({ plan: "# Plan\n- A" }));
-    const parsed = JSON.parse(out);
-    expect(parsed.plan).toBe("# Plan\n- A");
-    expect(parsed.error).toMatch(/PlanProposedError/);
+    const gate = new AutoGate({ type: "approve" });
+    const out = await reg.dispatch("submit_plan", JSON.stringify({ plan: "# Plan\n- A" }), {
+      confirmationGate: gate,
+    });
+    expect(out).toBe("plan approved");
     expect(submitted).toEqual(["# Plan\n- A"]);
   });
 
@@ -166,10 +180,11 @@ describe("registerPlanTool + submit_plan", () => {
     const submitted: string[] = [];
     registerPlanTool(reg, { onPlanSubmitted: (p) => submitted.push(p) });
     // Plan mode intentionally NOT enabled.
-    const out = await reg.dispatch("submit_plan", JSON.stringify({ plan: "big refactor plan" }));
-    const parsed = JSON.parse(out);
-    expect(parsed.plan).toBe("big refactor plan");
-    expect(parsed.error).toMatch(/PlanProposedError/);
+    const gate = new AutoGate({ type: "approve" });
+    const out = await reg.dispatch("submit_plan", JSON.stringify({ plan: "big refactor plan" }), {
+      confirmationGate: gate,
+    });
+    expect(out).toBe("plan approved");
     expect(submitted).toEqual(["big refactor plan"]);
   });
 
@@ -187,32 +202,43 @@ describe("registerPlanTool + submit_plan", () => {
 
   it("trims surrounding whitespace from the plan", async () => {
     const reg = new ToolRegistry();
-    registerPlanTool(reg);
+    const submitted: Array<{ plan: string }> = [];
+    registerPlanTool(reg, { onPlanSubmitted: (p) => submitted.push({ plan: p }) });
     reg.setPlanMode(true);
-    const out = await reg.dispatch("submit_plan", JSON.stringify({ plan: "\n\n  trimmed  \n" }));
-    expect(JSON.parse(out).plan).toBe("trimmed");
+    const gate = new AutoGate({ type: "approve" });
+    await reg.dispatch("submit_plan", JSON.stringify({ plan: "\n\n  trimmed  \n" }), {
+      confirmationGate: gate,
+    });
+    expect(submitted[0]?.plan).toBe("trimmed");
   });
 
-  it("carries an optional summary through toToolResult", async () => {
+  it("carries an optional summary through to PauseGate", async () => {
     const reg = new ToolRegistry();
-    registerPlanTool(reg);
+    const submitted: string[] = [];
+    registerPlanTool(reg, { onPlanSubmitted: (p) => submitted.push(p) });
     reg.setPlanMode(true);
+    const gate = new AutoGate({ type: "approve" });
     const out = await reg.dispatch(
       "submit_plan",
       JSON.stringify({ plan: "# Plan", summary: "Refactor auth into signed tokens" }),
+      { confirmationGate: gate },
     );
-    expect(JSON.parse(out).summary).toBe("Refactor auth into signed tokens");
+    expect(out).toBe("plan approved");
+    expect(submitted).toEqual(["# Plan"]);
   });
 
   it("omits summary when blank / whitespace-only", async () => {
     const reg = new ToolRegistry();
-    registerPlanTool(reg);
+    const submitted: Array<{ plan: string; summary?: string }> = [];
+    registerPlanTool(reg, {
+      onPlanSubmitted: (p, _s, summary) => submitted.push({ plan: p, summary }),
+    });
     reg.setPlanMode(true);
-    const out = await reg.dispatch(
-      "submit_plan",
-      JSON.stringify({ plan: "# Plan", summary: "   " }),
-    );
-    expect(JSON.parse(out).summary).toBeUndefined();
+    const gate = new AutoGate({ type: "approve" });
+    await reg.dispatch("submit_plan", JSON.stringify({ plan: "# Plan", summary: "   " }), {
+      confirmationGate: gate,
+    });
+    expect(submitted[0]?.summary).toBeUndefined();
   });
 
   it("accepts an optional steps array and surfaces it in the tool result", async () => {
@@ -230,17 +256,20 @@ describe("registerPlanTool + submit_plan", () => {
         action: "Rewrite auth.test.ts to use the new module.",
       },
     ];
-    const out = await reg.dispatch("submit_plan", JSON.stringify({ plan: "# Plan", steps }));
-    const parsed = JSON.parse(out);
-    expect(parsed.steps).toEqual(steps);
+    const gate = new AutoGate({ type: "approve" });
+    await reg.dispatch("submit_plan", JSON.stringify({ plan: "# Plan", steps }), {
+      confirmationGate: gate,
+    });
     expect(submitted[0]?.steps).toEqual(steps);
   });
 
   it("drops malformed step entries and omits steps entirely when none remain", async () => {
     const reg = new ToolRegistry();
-    registerPlanTool(reg);
+    const submitted: Array<{ steps?: unknown }> = [];
+    registerPlanTool(reg, { onPlanSubmitted: (_p, steps) => submitted.push({ steps }) });
     reg.setPlanMode(true);
-    const out = await reg.dispatch(
+    const gate = new AutoGate({ type: "approve" });
+    await reg.dispatch(
       "submit_plan",
       JSON.stringify({
         plan: "# Plan",
@@ -252,16 +281,18 @@ describe("registerPlanTool + submit_plan", () => {
           null,
         ],
       }),
+      { confirmationGate: gate },
     );
-    const parsed = JSON.parse(out);
-    expect(parsed.steps).toBeUndefined();
+    expect(submitted[0]?.steps).toBeUndefined();
   });
 
   it("accepts and preserves valid risk levels on steps", async () => {
     const reg = new ToolRegistry();
-    registerPlanTool(reg);
+    const submitted: Array<{ steps?: unknown }> = [];
+    registerPlanTool(reg, { onPlanSubmitted: (_p, steps) => submitted.push({ steps }) });
     reg.setPlanMode(true);
-    const out = await reg.dispatch(
+    const gate = new AutoGate({ type: "approve" });
+    await reg.dispatch(
       "submit_plan",
       JSON.stringify({
         plan: "# Plan",
@@ -271,9 +302,9 @@ describe("registerPlanTool + submit_plan", () => {
           { id: "step-3", title: "risky", action: "prod migration", risk: "high" },
         ],
       }),
+      { confirmationGate: gate },
     );
-    const parsed = JSON.parse(out);
-    expect(parsed.steps).toEqual([
+    expect(submitted[0]?.steps).toEqual([
       { id: "step-1", title: "safe", action: "local edit", risk: "low" },
       { id: "step-2", title: "medium", action: "multi-file edit", risk: "med" },
       { id: "step-3", title: "risky", action: "prod migration", risk: "high" },
@@ -282,9 +313,11 @@ describe("registerPlanTool + submit_plan", () => {
 
   it("drops malformed risk values rather than letting them through", async () => {
     const reg = new ToolRegistry();
-    registerPlanTool(reg);
+    const submitted: Array<{ steps?: unknown }> = [];
+    registerPlanTool(reg, { onPlanSubmitted: (_p, steps) => submitted.push({ steps }) });
     reg.setPlanMode(true);
-    const out = await reg.dispatch(
+    const gate = new AutoGate({ type: "approve" });
+    await reg.dispatch(
       "submit_plan",
       JSON.stringify({
         plan: "# Plan",
@@ -294,12 +327,12 @@ describe("registerPlanTool + submit_plan", () => {
           { id: "step-3", title: "e", action: "f" },
         ],
       }),
+      { confirmationGate: gate },
     );
-    const parsed = JSON.parse(out);
     // "critical" and 3 are rejected → risk field omitted; step-3 had
     // no risk to begin with. All three steps survive (the step itself
     // was well-formed; only the bad risk got dropped).
-    expect(parsed.steps).toEqual([
+    expect(submitted[0]?.steps).toEqual([
       { id: "step-1", title: "a", action: "b" },
       { id: "step-2", title: "c", action: "d" },
       { id: "step-3", title: "e", action: "f" },
@@ -308,9 +341,11 @@ describe("registerPlanTool + submit_plan", () => {
 
   it("keeps only the well-formed steps when the array is mixed", async () => {
     const reg = new ToolRegistry();
-    registerPlanTool(reg);
+    const submitted: Array<{ steps?: unknown }> = [];
+    registerPlanTool(reg, { onPlanSubmitted: (_p, steps) => submitted.push({ steps }) });
     reg.setPlanMode(true);
-    const out = await reg.dispatch(
+    const gate = new AutoGate({ type: "approve" });
+    await reg.dispatch(
       "submit_plan",
       JSON.stringify({
         plan: "# Plan",
@@ -320,9 +355,9 @@ describe("registerPlanTool + submit_plan", () => {
           { id: "step-2", title: "also good", action: "do other thing" },
         ],
       }),
+      { confirmationGate: gate },
     );
-    const parsed = JSON.parse(out);
-    expect(parsed.steps).toEqual([
+    expect(submitted[0]?.steps).toEqual([
       { id: "step-1", title: "good", action: "do thing" },
       { id: "step-2", title: "also good", action: "do other thing" },
     ]);
@@ -337,10 +372,11 @@ describe("registerPlanTool + mark_step_complete", () => {
     expect(reg.get("mark_step_complete")?.readOnly).toBe(true);
   });
 
-  it("returns the step_completed payload and fires onStepCompleted", async () => {
+  it("blocks on PauseGate on step complete and returns step_completed payload on continue", async () => {
     const reg = new ToolRegistry();
     const seen: unknown[] = [];
     registerPlanTool(reg, { onStepCompleted: (u) => seen.push(u) });
+    const gate = new AutoGate({ type: "continue" });
     const out = await reg.dispatch(
       "mark_step_complete",
       JSON.stringify({
@@ -349,6 +385,7 @@ describe("registerPlanTool + mark_step_complete", () => {
         result: "Moved tokens into src/auth/tokens.ts.",
         notes: "Had to rename one export.",
       }),
+      { confirmationGate: gate },
     );
     const parsed = JSON.parse(out);
     expect(parsed.kind).toBe("step_completed");
@@ -356,6 +393,7 @@ describe("registerPlanTool + mark_step_complete", () => {
     expect(parsed.title).toBe("Refactor auth");
     expect(parsed.result).toBe("Moved tokens into src/auth/tokens.ts.");
     expect(parsed.notes).toBe("Had to rename one export.");
+    // No error wrapper — gate returns the structured payload directly
     expect(parsed.error).toBeUndefined();
     expect(seen).toHaveLength(1);
     expect((seen[0] as { stepId: string }).stepId).toBe("step-1");
@@ -364,9 +402,11 @@ describe("registerPlanTool + mark_step_complete", () => {
   it("omits optional fields when empty", async () => {
     const reg = new ToolRegistry();
     registerPlanTool(reg);
+    const gate = new AutoGate({ type: "continue" });
     const out = await reg.dispatch(
       "mark_step_complete",
       JSON.stringify({ stepId: "step-1", result: "done" }),
+      { confirmationGate: gate },
     );
     const parsed = JSON.parse(out);
     expect(parsed.title).toBeUndefined();
@@ -430,12 +470,13 @@ describe("registerPlanTool + revise_plan", () => {
     expect(reg.get("revise_plan")?.readOnly).toBe(true);
   });
 
-  it("throws PlanRevisionProposedError with the structured payload", async () => {
+  it("blocks on PauseGate when revising — returns accepted verdict", async () => {
     const reg = new ToolRegistry();
     const seen: Array<{ reason: string; steps: number }> = [];
     registerPlanTool(reg, {
       onPlanRevisionProposed: (reason, steps) => seen.push({ reason, steps: steps.length }),
     });
+    const gate = new AutoGate({ type: "accepted" });
     const out = await reg.dispatch(
       "revise_plan",
       JSON.stringify({
@@ -445,11 +486,9 @@ describe("registerPlanTool + revise_plan", () => {
           { id: "step-4", title: "tests", action: "update", risk: "med" },
         ],
       }),
+      { confirmationGate: gate },
     );
-    const parsed = JSON.parse(out);
-    expect(parsed.reason).toBe("User asked to skip step 3.");
-    expect(parsed.remainingSteps).toHaveLength(2);
-    expect(parsed.error).toMatch(/^PlanRevisionProposedError:/);
+    expect(out).toBe("revision accepted");
     expect(seen).toHaveLength(1);
     expect(seen[0]?.steps).toBe(2);
   });
@@ -497,8 +536,12 @@ describe("registerPlanTool + revise_plan", () => {
 
   it("preserves valid risk levels through revision", async () => {
     const reg = new ToolRegistry();
-    registerPlanTool(reg);
-    const out = await reg.dispatch(
+    const seen: Array<{ steps: Array<{ id: string; risk?: string }> }> = [];
+    registerPlanTool(reg, {
+      onPlanRevisionProposed: (_, steps) => seen.push({ steps }),
+    });
+    const gate = new AutoGate({ type: "accepted" });
+    await reg.dispatch(
       "revise_plan",
       JSON.stringify({
         reason: "tighten",
@@ -507,23 +550,28 @@ describe("registerPlanTool + revise_plan", () => {
           { id: "b", title: "t", action: "a", risk: "low" },
         ],
       }),
+      { confirmationGate: gate },
     );
-    const parsed = JSON.parse(out);
-    expect(parsed.remainingSteps[0].risk).toBe("high");
-    expect(parsed.remainingSteps[1].risk).toBe("low");
+    expect(seen[0]?.steps[0]?.risk).toBe("high");
+    expect(seen[0]?.steps[1]?.risk).toBe("low");
   });
 
   it("includes an optional summary when provided", async () => {
     const reg = new ToolRegistry();
-    registerPlanTool(reg);
-    const out = await reg.dispatch(
+    const seen: Array<{ summary?: string }> = [];
+    registerPlanTool(reg, {
+      onPlanRevisionProposed: (_, __, summary) => seen.push({ summary }),
+    });
+    const gate = new AutoGate({ type: "accepted" });
+    await reg.dispatch(
       "revise_plan",
       JSON.stringify({
         reason: "ok",
         remainingSteps: [{ id: "x", title: "y", action: "z" }],
         summary: "Refactor without migration",
       }),
+      { confirmationGate: gate },
     );
-    expect(JSON.parse(out).summary).toBe("Refactor without migration");
+    expect(seen[0]?.summary).toBe("Refactor without migration");
   });
 });

--- a/tests/shell-chain.test.ts
+++ b/tests/shell-chain.test.ts
@@ -254,10 +254,11 @@ describe("runCommand wired with chains", () => {
   it("refuses a chain when one segment is not allowlisted", async () => {
     const registry = new ToolRegistry();
     registerShellTools(registry, { rootDir: tmp });
+    // Non-allowlisted segment with no confirmation listener throws
     const out = await registry.dispatch(
       "run_command",
       JSON.stringify({ command: "git status | rm -rf dist" }),
     );
-    expect(out).toMatch(/NeedsConfirmationError/);
+    expect(out).toMatch(/no confirmation listener registered/);
   });
 });

--- a/tests/shell-tools.test.ts
+++ b/tests/shell-tools.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { type ConfirmationChoice, PauseGate } from "../src/core/pause-gate.js";
 import { ToolRegistry } from "../src/tools.js";
 import {
   NeedsConfirmationError,
@@ -17,6 +18,27 @@ import {
   smartDecodeOutput,
   tokenizeCommand,
 } from "../src/tools/shell.js";
+
+/** A PauseGate that auto-resolves with a pre-configured choice. */
+/** A PauseGate that records call args for assertions. */
+class SpyGate extends PauseGate {
+  lastCall: { kind: string; payload?: unknown } | null = null;
+  override ask(opts: { kind: string; payload?: unknown }): Promise<any> {
+    this.lastCall = opts;
+    return Promise.resolve({ type: "run_once" } as ConfirmationChoice);
+  }
+}
+
+class AutoGate extends PauseGate {
+  private _choice: ConfirmationChoice;
+  constructor(choice: ConfirmationChoice) {
+    super();
+    this._choice = choice;
+  }
+  override ask(_opts: { kind: string; payload?: unknown }): Promise<ConfirmationChoice> {
+    return Promise.resolve(this._choice);
+  }
+}
 
 describe("tokenizeCommand", () => {
   it("splits on whitespace", () => {
@@ -274,15 +296,34 @@ describe("registerShellTools — dispatch integration", () => {
     expect(out).toMatch(/\[exit 0\]/);
   });
 
-  it("refuses non-allowlisted commands with NeedsConfirmationError", async () => {
+  it("blocks non-allowlisted commands via confirmation gate, runs on approve", async () => {
     const registry = new ToolRegistry();
     registerShellTools(registry, { rootDir: tmp });
+    const gate = new AutoGate({ type: "run_once" });
     const out = await registry.dispatch(
       "run_command",
-      JSON.stringify({ command: "rm -rf node_modules" }),
+      JSON.stringify({ command: "node --version" }),
+      { confirmationGate: gate },
     );
-    expect(out).toMatch(/NeedsConfirmationError/);
-    expect(out).toMatch(/rm -rf node_modules/);
+    // The command should run (approve-auto) and return normal output
+    expect(out).toMatch(/\$ node --version/);
+    expect(out).toMatch(/\[exit 0\]/);
+    expect(out).not.toMatch(/NeedsConfirmationError/);
+    expect(out).not.toMatch(/user denied/);
+  });
+
+  it("passes the correct kind to the gate — regression check for argument swap", async () => {
+    const registry = new ToolRegistry();
+    registerShellTools(registry, { rootDir: tmp });
+    const spy = new SpyGate();
+    await registry.dispatch("run_command", JSON.stringify({ command: "npm i" }), {
+      confirmationGate: spy,
+    });
+    // The gate must receive kind="run_command" in the first argument,
+    // NOT the command string (old ConfirmationGate swapped these).
+    expect(spy.lastCall).not.toBeNull();
+    expect(spy.lastCall!.kind).toBe("run_command");
+    expect(spy.lastCall!.payload).toEqual({ command: "npm i" });
   });
 
   it("allowAll:true bypasses the allowlist entirely", async () => {
@@ -310,8 +351,13 @@ describe("registerShellTools — dispatch integration", () => {
     const list: string[] = [];
     registerShellTools(registry, { rootDir: tmp, extraAllowed: () => list });
 
-    const before = await registry.dispatch("run_command", JSON.stringify({ command: cmd }));
-    expect(before).toMatch(/NeedsConfirmationError/);
+    // Before: command is not in extraAllowed → gate blocks → auto-deny
+    const denyGate = new AutoGate({ type: "deny" });
+    const before = await registry.dispatch("run_command", JSON.stringify({ command: cmd }), {
+      confirmationGate: denyGate,
+    });
+    expect(before).toMatch(/user denied/);
+    expect(before).toMatch(/node -e/);
 
     // Simulate the TUI's "always allow" click — mutate the source the
     // getter reads. No re-registration; the live tool instance picks
@@ -319,7 +365,7 @@ describe("registerShellTools — dispatch integration", () => {
     list.push("node -e");
 
     const after = await registry.dispatch("run_command", JSON.stringify({ command: cmd }));
-    expect(after).not.toMatch(/NeedsConfirmationError/);
+    expect(after).not.toMatch(/user denied/);
     expect(after).toMatch(/\[exit 0\]/);
     expect(after).toContain("ok");
   });
@@ -337,17 +383,24 @@ describe("registerShellTools — dispatch integration", () => {
       allowAll: () => yoloOn,
     });
 
-    const beforeYolo = await registry.dispatch("run_command", JSON.stringify({ command: cmd }));
-    expect(beforeYolo).toMatch(/NeedsConfirmationError/);
+    const denyGate = new AutoGate({ type: "deny" });
+    const beforeYolo = await registry.dispatch("run_command", JSON.stringify({ command: cmd }), {
+      confirmationGate: denyGate,
+    });
+    expect(beforeYolo).toMatch(/user denied/);
+    expect(beforeYolo).toMatch(/node -e/);
 
     yoloOn = true;
     const duringYolo = await registry.dispatch("run_command", JSON.stringify({ command: cmd }));
-    expect(duringYolo).not.toMatch(/NeedsConfirmationError/);
+    expect(duringYolo).not.toMatch(/user denied/);
     expect(duringYolo).toMatch(/\[exit 0\]/);
 
     yoloOn = false;
-    const afterYolo = await registry.dispatch("run_command", JSON.stringify({ command: cmd }));
-    expect(afterYolo).toMatch(/NeedsConfirmationError/);
+    const afterYolo = await registry.dispatch("run_command", JSON.stringify({ command: cmd }), {
+      confirmationGate: denyGate,
+    });
+    expect(afterYolo).toMatch(/user denied/);
+    expect(afterYolo).toMatch(/node -e/);
   });
 });
 


### PR DESCRIPTION
## Discovery

The bug was first noticed during a session where the model called a non-allowlisted `run_command`. The tool threw `NeedsConfirmationError`, the TUI showed the ShellConfirm modal asking "Run once / Always allow / Deny" -- but while the user was still reading the modal, the model had already generated a follow-up response in the same turn ("Hmm, let me just write it directly instead... 1 2 3 ..."). The confirmation gate was effectively bypassed: the model answered the question before the user could approve or deny the command.

Later, the same pattern was observed during plan execution: when `mark_step_complete` fired its checkpoint modal (Continue / Revise / Stop), the model kept inferring in the background and produced unwanted output while the plan was paused for user review. The issue wasn't specific to shell commands -- it affected every tool that needed to pause for user input.

## Root cause

All five control-signal errors (`NeedsConfirmationError` in shell.ts, `PlanProposedError` / `PlanCheckpointError` / `PlanRevisionProposedError` in plan-errors.ts, `ChoiceRequestedError` in choice.ts) shared the same pattern: they were **thrown** from tool functions, caught by `ToolRegistry.dispatch()`, serialized to JSON, and appended to the message log as if they were normal tool results. The loop had no way to distinguish "this is a control signal, stop iterating" from a regular tool failure. It advanced to the next model call, and the model -- seeing the error text in its context -- naturally treated it as "that didn't work, try something else" and generated a workaround response.

The error messages literally said *"STOP calling tools now ... Wait for the next user message"* -- but that text was just a string inside a JSON tool result. At the architecture level, it had no effect on the loop's iteration logic.

## Fix

Replace all control-signal throws with a blocking pause gate. `PauseGate` is a generic Promise-based bridge that tool functions call to await user input synchronously (from the model's perspective). The App subscribes via `gate.on()` to show the correct modal, and calls `gate.resolve()` when the user picks.

```
shell.ts -> await gate.ask({ kind: "run_command", payload: { command } })
               |
  gate fires listener synchronously
               |
App.tsx -> pauseGate.on() -> shows ShellConfirm modal
User picks -> pauseGate.resolve(id, choice) -> promise resolves
               |
shell.ts -> runs command -> returns output -> dispatch() returns normally
loop -> continues same iteration -> model sees output inline
```

### Files changed

| File | What |
|---|---|
| `src/core/pause-gate.ts` | New -- `PauseGate` class with typed `ask({ kind, payload })`, `resolve(id, data)`, `on(fn)`, `current` |
| `src/tools/shell.ts` | `run_command`/`run_background` use `gate.ask()` instead of throwing `NeedsConfirmationError` |
| `src/tools/plan-core.ts` | `submit_plan`/`mark_step_complete`/`revise_plan` use `gate.ask()` instead of throwing `Plan*Error` |
| `src/tools/choice.ts` | `ask_choice` uses `gate.ask()` instead of throwing `ChoiceRequestedError` |
| `src/loop.ts` | Constructor accepts optional `PauseGate`, passes through to `dispatch()` |
| `src/tools.ts` | `ToolCallContext.confirmationGate` + `dispatch()` opts carry injectable `PauseGate` |
| `src/cli/ui/App.tsx` | Gate listener switches on `request.kind` to show correct modal; all modal callbacks call `gate.resolve()` |
| `src/cli/ui/hooks/handle-tool-event.ts` | Removed all error-string greps (NeedsConfirmationError, PlanProposedError, etc.) |
| `src/cli/ui/Select.tsx` | Added `onTab` prop for inline deny-context editor |
| `src/cli/ui/ShellConfirm.tsx` | Tab on "deny" opens context editor; updated footer hints |

## How to verify

```sh
npm test
npm run typecheck
npm run lint
```