### PR TITLE
fix(mcp): prevent unhandled rejection during hung send timeout

### DIFF
--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -234,9 +234,12 @@ export class McpClient {
         signal.addEventListener("abort", abortHandler, { once: true });
       }
     });
+    promise.catch(() => undefined);
     try {
-      await this.transport.send(frame);
+      await Promise.race([this.transport.send(frame), promise.then(() => undefined)]);
     } catch (err) {
+      const pending = this.pending.get(id);
+      if (pending) clearTimeout(pending.timeout);
       this.pending.delete(id);
       if (abortHandler && signal) signal.removeEventListener("abort", abortHandler);
       throw err;

--- a/tests/mcp-client-timeout.test.ts
+++ b/tests/mcp-client-timeout.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from "vitest";
+import { McpClient } from "../src/mcp/client.js";
+import type { McpTransport } from "../src/mcp/stdio.js";
+import type { JsonRpcMessage } from "../src/mcp/types.js";
+
+abstract class StubTransport implements McpTransport {
+  protected closed = false;
+  protected readonly queue: JsonRpcMessage[] = [];
+  protected readonly waiters: Array<(m: JsonRpcMessage | null) => void> = [];
+
+  abstract send(msg: JsonRpcMessage): Promise<void>;
+
+  async *messages(): AsyncIterableIterator<JsonRpcMessage> {
+    while (true) {
+      if (this.queue.length > 0) {
+        yield this.queue.shift()!;
+        continue;
+      }
+      if (this.closed) return;
+      const next = await new Promise<JsonRpcMessage | null>((resolve) => {
+        this.waiters.push(resolve);
+      });
+      if (next === null) return;
+      yield next;
+    }
+  }
+
+  async close(): Promise<void> {
+    this.closed = true;
+    while (this.waiters.length > 0) this.waiters.shift()!(null);
+  }
+}
+
+class HangingSendTransport extends StubTransport {
+  async send(_msg: JsonRpcMessage): Promise<void> {
+    return new Promise(() => {});
+  }
+}
+
+class RejectingSendTransport extends StubTransport {
+  async send(_msg: JsonRpcMessage): Promise<void> {
+    throw new Error("transport send failed");
+  }
+}
+
+class SilentServerTransport extends StubTransport {
+  async send(_msg: JsonRpcMessage): Promise<void> {}
+}
+
+describe("McpClient.request() timeout/no-crash", () => {
+  const shortTimeoutMs = 50;
+
+  it("hung send still rejects with timeout", async () => {
+    const transport = new HangingSendTransport();
+    const client = new McpClient({
+      transport,
+      requestTimeoutMs: shortTimeoutMs,
+    });
+    await expect(client.initialize()).rejects.toThrow(/timed out/);
+    await client.close();
+  });
+
+  it("hung-send timeout does not emit unhandledRejection", async () => {
+    const transport = new HangingSendTransport();
+    const client = new McpClient({
+      transport,
+      requestTimeoutMs: shortTimeoutMs,
+    });
+    const handler = vi.fn();
+    process.on("unhandledRejection", handler);
+    try {
+      await expect(client.initialize()).rejects.toThrow(/timed out/);
+      await new Promise((r) => setTimeout(r, shortTimeoutMs + 50));
+      expect(handler).not.toHaveBeenCalled();
+    } finally {
+      process.off("unhandledRejection", handler);
+      await client.close();
+    }
+  });
+
+  it("rejecting send rejects with the send error, not timeout", async () => {
+    const transport = new RejectingSendTransport();
+    const client = new McpClient({
+      transport,
+      requestTimeoutMs: 60_000,
+    });
+    await expect(client.initialize()).rejects.toThrow("transport send failed");
+    await client.close();
+  });
+
+  it("rejecting send clears the armed timeout (no late orphan rejection)", async () => {
+    const transport = new RejectingSendTransport();
+    const client = new McpClient({
+      transport,
+      requestTimeoutMs: shortTimeoutMs,
+    });
+    const handler = vi.fn();
+    process.on("unhandledRejection", handler);
+    try {
+      await expect(client.initialize()).rejects.toThrow("transport send failed");
+      await new Promise((r) => setTimeout(r, shortTimeoutMs + 100));
+      expect(handler).not.toHaveBeenCalled();
+    } finally {
+      process.off("unhandledRejection", handler);
+      await client.close();
+    }
+  });
+
+  it("normal silent-server timeout still works", async () => {
+    const transport = new SilentServerTransport();
+    const client = new McpClient({
+      transport,
+      requestTimeoutMs: shortTimeoutMs,
+    });
+    await expect(client.initialize()).rejects.toThrow(/timed out/);
+    await client.close();
+  });
+});


### PR DESCRIPTION
## What

Fixes an MCP request timeout race when `transport.send()` hangs or fails.

`McpClient.request()` previously awaited `transport.send(frame)` before observing the response/timeout promise. If `send()` hung past `requestTimeoutMs`, the timeout could reject that promise while nothing was awaiting it yet.

This observes the response promise immediately, races `send()` against the response/timeout path, and clears the armed timeout if `send()` itself rejects.

Closes #239.

## Why

MCP startup failures should reject cleanly and let the caller continue handling the failure. A hung or broken send path should not crash the process through an orphaned timeout rejection.

## How to verify

```sh
npm run verify
```

Added regression coverage for:

- hung `send()` timing out cleanly
- no `unhandledRejection` after hung-send timeout
- rejecting `send()` returning the send error
- no late orphan timeout rejection after send failure
- normal silent-server timeout behavior

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time