### PR TITLE
feat(loop): append-only history fold at 50% of ctxMax

### DIFF
--- a/scripts/probe-long-session.mts
+++ b/scripts/probe-long-session.mts
@@ -1,0 +1,167 @@
+/**
+ * Long-session probe — drives CacheFirstLoop through 20 real turns
+ * with oversized tool results (each ~4k tokens, the size that USED to
+ * trigger the old turn-end auto-compaction every turn).
+ *
+ * Reports per-turn: prompt size, cache hit %, miss tokens, USD cost.
+ * Surfaces: cache trajectory, cost shape, anything degrading over time.
+ *
+ * Run: REASONIX_LOG_LEVEL=ERROR npx tsx scripts/probe-long-session.mts
+ */
+
+import { readFileSync } from "node:fs";
+import { DeepSeekClient } from "../src/client.js";
+import { CacheFirstLoop } from "../src/loop.js";
+import { ImmutablePrefix } from "../src/memory/runtime.js";
+import { DEEPSEEK_CONTEXT_TOKENS } from "../src/telemetry/stats.js";
+import { ToolRegistry } from "../src/tools.js";
+
+// Force a small ctx window so the 50% fold threshold trips in a few
+// turns instead of needing 200+ turns at the real 1M cap. Same model
+// id, real API call, just the local gauge is shrunk.
+DEEPSEEK_CONTEXT_TOKENS["deepseek-chat"] = 50_000;
+
+function loadDotenv(path: string) {
+  const txt = readFileSync(path, "utf8");
+  for (const line of txt.split(/\r?\n/)) {
+    const m = line.match(/^([A-Z_][A-Z0-9_]*)=(.*)$/);
+    if (m && !process.env[m[1]]) process.env[m[1]] = m[2];
+  }
+}
+loadDotenv("./.env.testbak");
+
+const PRICE_HIT_PER_M = 0.07;
+const PRICE_MISS_PER_M = 0.27;
+const PRICE_COMPLETION_PER_M = 1.1;
+
+const docLine = (i: number, sec: string) =>
+  `[${sec}#${i}] section ${sec} entry ${i}: requirement traces to constraint ${(i % 7) + 1}, status ${i % 3 === 0 ? "open" : "closed"}, owner team-${(i % 5) + 1}, last touched 2026-04-${(i % 28) + 1}.`;
+
+async function main() {
+  const reg = new ToolRegistry();
+  reg.register({
+    name: "read_doc",
+    description: "Read a section of a project document.",
+    parameters: {
+      type: "object",
+      properties: { section: { type: "string" } },
+      required: ["section"],
+    },
+    fn: async (args: Record<string, unknown>) => {
+      const sec = String(args.section ?? "default");
+      const lines = Array.from({ length: 65 }, (_, i) => docLine(i, sec));
+      return lines.join("\n");
+    },
+  });
+
+  const client = new DeepSeekClient();
+  const model = "deepseek-chat";
+  const loop = new CacheFirstLoop({
+    client,
+    prefix: new ImmutablePrefix({
+      system:
+        "You are a documentation triage agent. For each turn, call read_doc with the section the user asks about, then reply with one short sentence summarizing what you found.",
+      toolSpecs: reg.specs(),
+    }),
+    tools: reg,
+    stream: false,
+    model,
+    maxToolIters: 4,
+  });
+
+  let mutations = 0;
+  let folds = 0;
+  const origCompactInPlace = loop.log.compactInPlace.bind(loop.log);
+  loop.log.compactInPlace = (...args) => {
+    mutations++;
+    return origCompactInPlace(...args);
+  };
+
+  const sections = [
+    "auth",
+    "billing",
+    "telemetry",
+    "rate-limit",
+    "webhooks",
+    "search",
+    "indexing",
+    "permissions",
+    "audit",
+    "exports",
+    "imports",
+    "cdn",
+    "analytics",
+    "rbac",
+    "sso",
+    "scheduler",
+    "workflows",
+    "notifications",
+    "reports",
+    "api-v2",
+  ];
+
+  console.log("turn |  prompt  |   hit   |   miss  | hit% |  $/turn  |  $cum");
+  console.log("-----+----------+---------+---------+------+----------+--------");
+
+  let cumCost = 0;
+  let forceSummaryHit = false;
+
+  for (let i = 0; i < sections.length; i++) {
+    const t0 = Date.now();
+    let usage: {
+      promptTokens: number;
+      completionTokens: number;
+      promptCacheHitTokens: number;
+      promptCacheMissTokens: number;
+    } | null = null;
+    let warning = "";
+    for await (const ev of loop.step(`Read the "${sections[i]}" section.`)) {
+      if (ev.role === "assistant_final" && ev.stats?.usage) {
+        usage = ev.stats.usage as typeof usage;
+      }
+      if (ev.role === "warning" && ev.content) {
+        warning = ev.content;
+        if (/folded \d+ messages/.test(ev.content)) folds++;
+      }
+      if (ev.forcedSummary) forceSummaryHit = true;
+    }
+    const ms = Date.now() - t0;
+    if (!usage) {
+      console.log(
+        `${String(i).padStart(3)}  | (no usage)  -- ${warning ? `warning: ${warning}` : ""}`,
+      );
+      continue;
+    }
+    const total = usage.promptCacheHitTokens + usage.promptCacheMissTokens;
+    const ratio = total > 0 ? (usage.promptCacheHitTokens / total) * 100 : 0;
+    const cost =
+      (usage.promptCacheHitTokens * PRICE_HIT_PER_M +
+        usage.promptCacheMissTokens * PRICE_MISS_PER_M +
+        usage.completionTokens * PRICE_COMPLETION_PER_M) /
+      1_000_000;
+    cumCost += cost;
+    console.log(
+      `${String(i).padStart(3)}  | ${String(usage.promptTokens).padStart(7)} | ${String(usage.promptCacheHitTokens).padStart(7)} | ${String(usage.promptCacheMissTokens).padStart(7)} | ${ratio.toFixed(1).padStart(4)} | $${cost.toFixed(5)} | $${cumCost.toFixed(4)}  ${ms}ms${warning ? ` (${warning.slice(0, 60)}…)` : ""}`,
+    );
+    if (forceSummaryHit) {
+      console.log(
+        `\n>> force-summary triggered at turn ${i} (${ratio.toFixed(1)}% cache hit, ${usage.promptTokens} tokens)`,
+      );
+      break;
+    }
+  }
+
+  console.log(`\ntotal log.compactInPlace() calls: ${mutations} (expected: ${folds} folds)`);
+  console.log(`total cost across session: $${cumCost.toFixed(4)}`);
+
+  if (mutations !== folds) {
+    console.log(`FAIL: ${mutations} mutations but only ${folds} fold events — unexpected mutation`);
+    process.exit(1);
+  }
+  console.log(`\nVERDICT: ${folds} fold(s) fired, no other mutations.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -20,6 +20,16 @@ import {
   truncateForModelByTokens,
 } from "./mcp/registry.js";
 
+/** Auto-fold when a turn's response shows promptTokens above this fraction of ctxMax. */
+const HISTORY_FOLD_THRESHOLD = 0.5;
+/** Tail budget after fold, as a fraction of ctxMax. Sized to leave 25%+ headroom before next fold. */
+const HISTORY_FOLD_TAIL_FRACTION = 0.2;
+/** Skip the fold if the head wouldn't shrink the log by at least this fraction — avoids re-fold thrash. */
+const HISTORY_FOLD_MIN_SAVINGS_FRACTION = 0.3;
+/** Prepended to fold summary content so the model knows it's a synthesized recap, not its own past output. */
+const HISTORY_FOLD_MARKER =
+  "[CONVERSATION HISTORY SUMMARY — earlier turns folded for context efficiency]\n\n";
+
 const FAILURE_ESCALATION_THRESHOLD = 3;
 const ESCALATION_MODEL = "deepseek-v4-pro";
 /** Accepts `<<<NEEDS_PRO>>>` or `<<<NEEDS_PRO: reason>>>` (reason trimmed, may be empty). */
@@ -36,7 +46,7 @@ import {
   SessionStats,
   type TurnStats,
 } from "./telemetry/stats.js";
-import { countTokens, estimateRequestTokens } from "./tokenizer.js";
+import { countTokens, estimateConversationTokens, estimateRequestTokens } from "./tokenizer.js";
 import { ToolRegistry } from "./tools.js";
 import type { ChatMessage, ToolCall } from "./types.js";
 
@@ -169,6 +179,7 @@ export class CacheFirstLoop {
   private _turnFailureCount = 0;
   private _turnFailureTypes: Record<string, number> = {};
   private _turnSelfCorrected = false;
+  private _foldedThisTurn = false;
 
   constructor(opts: CacheFirstLoopOptions) {
     this.client = opts.client;
@@ -292,6 +303,101 @@ export class CacheFirstLoop {
       }
     }
     return { healedCount, tokensSaved, charsSaved };
+  }
+
+  /** Replace older turns with one summary message; keep tail within keepRecentTokens budget. */
+  async compactHistory(opts?: {
+    keepRecentTokens?: number;
+  }): Promise<{
+    folded: boolean;
+    beforeMessages: number;
+    afterMessages: number;
+    summaryChars: number;
+  }> {
+    const ctxMax = DEEPSEEK_CONTEXT_TOKENS[this.model] ?? DEFAULT_CONTEXT_TOKENS;
+    const tailBudget = opts?.keepRecentTokens ?? Math.floor(ctxMax * HISTORY_FOLD_TAIL_FRACTION);
+    const all = this.log.toMessages();
+    const noop = {
+      folded: false,
+      beforeMessages: all.length,
+      afterMessages: all.length,
+      summaryChars: 0,
+    };
+    if (all.length === 0) return noop;
+
+    const tokenCounts = all.map((m) => estimateConversationTokens([m]));
+    const totalTokens = tokenCounts.reduce((a, b) => a + b, 0);
+
+    // Walk backward from the end; the boundary is the latest user-role
+    // message such that everything from there to the end fits in
+    // tailBudget. Snapping to a user-msg boundary keeps tool_calls /
+    // tool-result pairs intact (they live within a single turn).
+    let cumTokens = 0;
+    let boundary = all.length;
+    for (let i = all.length - 1; i >= 0; i--) {
+      if (cumTokens + tokenCounts[i]! > tailBudget) break;
+      cumTokens += tokenCounts[i]!;
+      if (all[i]!.role === "user") boundary = i;
+    }
+    if (boundary <= 0) return noop;
+
+    const head = all.slice(0, boundary);
+    const tail = all.slice(boundary);
+    const headTokens = totalTokens - cumTokens;
+    if (headTokens < totalTokens * HISTORY_FOLD_MIN_SAVINGS_FRACTION) return noop;
+
+    const summary = await this.summarizeForFold(head);
+    if (!summary) return noop;
+
+    const summaryMsg: ChatMessage = {
+      role: "assistant",
+      content: HISTORY_FOLD_MARKER + summary,
+    };
+    const replacement = [summaryMsg, ...tail];
+    this.log.compactInPlace(replacement);
+    if (this.sessionName) {
+      try {
+        rewriteSession(this.sessionName, replacement);
+      } catch {
+        /* disk full / perms — in-memory fold still applies */
+      }
+    }
+    return {
+      folded: true,
+      beforeMessages: all.length,
+      afterMessages: replacement.length,
+      summaryChars: summary.length,
+    };
+  }
+
+  private async summarizeForFold(messagesToSummarize: ChatMessage[]): Promise<string> {
+    const summaryModel = "deepseek-v4-flash";
+    const systemPrompt =
+      "You compress conversation history for a coding agent. Output one prose recap that preserves: the user's overall goal, decisions and conclusions reached, files inspected or modified, important tool results still relevant to ongoing work, and any open todos. Skip turn-by-turn play-by-play. No tool calls, no markdown headings, no SEARCH/REPLACE blocks — plain prose only.";
+    const healed = healLoadedMessages(messagesToSummarize, DEFAULT_MAX_RESULT_CHARS).messages;
+    const messages: ChatMessage[] = [
+      { role: "system", content: systemPrompt },
+      ...healed,
+      {
+        role: "user",
+        content:
+          "Summarize the conversation above as plain prose. This summary replaces the original turns to free context — make it self-contained.",
+      },
+    ];
+    try {
+      const resp = await this.client.chat({
+        model: summaryModel,
+        messages,
+        signal: this._turnAbort.signal,
+        thinking: thinkingModeForModel(summaryModel),
+        reasoningEffort: "high",
+      });
+      this.stats.record(this._turn, summaryModel, resp.usage ?? new Usage());
+      const cleaned = stripHallucinatedToolMarkup((resp.content ?? "").trim());
+      return cleaned;
+    } catch {
+      return "";
+    }
   }
 
   appendAndPersist(message: ChatMessage): void {
@@ -538,6 +644,7 @@ export class CacheFirstLoop {
     this._turnFailureTypes = {};
     this._turnSelfCorrected = false;
     this._escalateThisTurn = false;
+    this._foldedThisTurn = false;
     let armedConsumed = false;
     if (this._proArmedForNextTurn) {
       this._escalateThisTurn = true;
@@ -1124,13 +1231,36 @@ export class CacheFirstLoop {
         return;
       }
 
-      // Token-budget guard. Over 80% of context, force-summarize and
-      // exit the turn — the next iter would only get worse. We used to
-      // try in-place compaction here, but mutating mid-history bytes
-      // invalidates DeepSeek's prompt cache from the mutation point on,
-      // turning a "save 50% of prompt size" win into a "lose 90% of
-      // cache discount" loss. See scripts/probe-cache.mjs.
+      // History fold — once we cross 50% of ctxMax, replace older turns
+      // with a single summary message and keep the recent K turns raw.
+      // One cache break at fold time, then per-turn cost drops back to
+      // the post-warmup baseline. Fires at most once per turn.
       const ctxMax = DEEPSEEK_CONTEXT_TOKENS[this.model] ?? DEFAULT_CONTEXT_TOKENS;
+      if (
+        usage &&
+        !this._foldedThisTurn &&
+        usage.promptTokens / ctxMax > HISTORY_FOLD_THRESHOLD &&
+        usage.promptTokens / ctxMax <= 0.8
+      ) {
+        this._foldedThisTurn = true;
+        const before = usage.promptTokens;
+        yield { turn: this._turn, role: "status", content: "compacting history…" };
+        const result = await this.compactHistory();
+        if (result.folded) {
+          yield {
+            turn: this._turn,
+            role: "warning",
+            content: `context ${before.toLocaleString()}/${ctxMax.toLocaleString()} (${Math.round(
+              (before / ctxMax) * 100,
+            )}%) — folded ${result.beforeMessages} messages → ${result.afterMessages} (summary ${result.summaryChars} chars). Continuing.`,
+          };
+        }
+      }
+
+      // Token-budget guard. Over 80% of context, force-summarize and
+      // exit the turn. Belt-and-braces: history fold above should keep us
+      // here only if the fold itself failed or the recent K turns alone
+      // already exceed 80%.
       if (usage && usage.promptTokens / ctxMax > 0.8) {
         const before = usage.promptTokens;
         yield {

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -580,6 +580,121 @@ describe("CacheFirstLoop (non-streaming)", () => {
     expect(summary!.content).toMatch(/context budget running low/);
   });
 
+  it("compactHistory replaces head with summary, keeps tail within token budget", async () => {
+    const responses: FakeResponseShape[] = [
+      { content: "User explored auth and billing modules; landed on session refactor plan." },
+    ];
+    const client = makeClient(responses);
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s" }),
+      stream: false,
+    });
+
+    // Seed 6 user/assistant pairs with chunky content so we can
+    // reason about token weight; each pair ≈ 20 tokens.
+    for (let i = 0; i < 6; i++) {
+      loop.log.append({
+        role: "user",
+        content: `question number ${i} with some words to weigh it`,
+      });
+      loop.log.append({ role: "assistant", content: `answer number ${i} with similar bulk` });
+    }
+    expect(loop.log.length).toBe(12);
+
+    // Budget of ~60 tokens fits ~3 trailing pairs.
+    const result = await loop.compactHistory({ keepRecentTokens: 60 });
+    expect(result.folded).toBe(true);
+    expect(result.beforeMessages).toBe(12);
+    expect(result.afterMessages).toBeLessThan(12);
+
+    const entries = loop.log.entries;
+    expect(entries[0]!.role).toBe("assistant");
+    expect(entries[0]!.content as string).toMatch(/HISTORY SUMMARY/);
+    expect(entries[1]!.role).toBe("user");
+    expect(entries[entries.length - 1]!.content).toMatch(/answer number 5/);
+  });
+
+  it("compactHistory no-ops when head wouldn't shrink log meaningfully", async () => {
+    const client = makeClient([{ content: "summary" }]);
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s" }),
+      stream: false,
+    });
+    loop.log.append({ role: "user", content: "q0" });
+    loop.log.append({ role: "assistant", content: "a0" });
+    loop.log.append({ role: "user", content: "q1" });
+    loop.log.append({ role: "assistant", content: "a1" });
+
+    // Budget large enough to cover everything → no fold needed.
+    const result = await loop.compactHistory({ keepRecentTokens: 10_000 });
+    expect(result.folded).toBe(false);
+    expect(loop.log.length).toBe(4);
+  });
+
+  it("auto-folds history when promptTokens crosses 50% of ctxMax", async () => {
+    const reg = new ToolRegistry();
+    reg.register({
+      name: "probe",
+      description: "no-op",
+      parameters: { type: "object", properties: {} },
+      fn: async () => "ok",
+    });
+    const responses: FakeResponseShape[] = [
+      // Iter 0: tool call with usage above 50% of 1M ctx.
+      {
+        content: "",
+        tool_calls: [{ id: "c1", type: "function", function: { name: "probe", arguments: "{}" } }],
+        usage: {
+          prompt_tokens: 600_000,
+          completion_tokens: 10,
+          total_tokens: 600_010,
+          prompt_cache_hit_tokens: 500_000,
+          prompt_cache_miss_tokens: 100_000,
+        },
+      },
+      // Summary call response (compactHistory).
+      { content: "Earlier turns explored topic X and decided Y." },
+      // Iter 1 (after fold): wrap-up.
+      { content: "done." },
+    ];
+    const client = makeClient(responses);
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s", toolSpecs: reg.specs() }),
+      tools: reg,
+      stream: false,
+      maxToolIters: 8,
+    });
+    // Seed 18 user/assistant turns with realistic per-message bulk so
+    // the fold's tail-token budget (20% of 1M = 200k) actually covers
+    // only the trailing turns, not all of them. Each pair ≈ 25k tokens.
+    const fillLines = (label: string, n: number) =>
+      Array.from(
+        { length: n },
+        (_, i) =>
+          `${label} line ${i}: lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`,
+      ).join("\n");
+    for (let i = 0; i < 18; i++) {
+      loop.log.append({ role: "user", content: `Q${i}\n${fillLines(`q${i}`, 800)}` });
+      loop.log.append({ role: "assistant", content: `A${i}\n${fillLines(`a${i}`, 800)}` });
+    }
+    const beforeMessages = loop.log.length;
+
+    const events: { role: string; content?: string }[] = [];
+    for await (const ev of loop.step("continue")) {
+      events.push({ role: ev.role, content: ev.content });
+    }
+
+    const foldWarn = events.find(
+      (e) => e.role === "warning" && /folded \d+ messages/.test(e.content ?? ""),
+    );
+    expect(foldWarn).toBeDefined();
+    expect(foldWarn!.content).toMatch(/folded \d+ messages/);
+    expect(loop.log.length).toBeLessThan(beforeMessages);
+  }, 30_000);
+
   it("pre-clips new tool results at dispatch so they never enter the log oversized", async () => {
     const reg = new ToolRegistry();
     // Tool returns ~50k chars of realistic-shape log text; the default


### PR DESCRIPTION
## Summary

Closes the long-session cliff that #238 left open. After #238 we shipped append-only — every turn appends, never mutates — which made cache hit ~98% for the lifetime of a session. But sessions still grew unbounded. Once promptTokens crossed 80% of ctxMax, the existing force-summary path fired every turn (\$0.07 each, only summary returned, no actual work) until the user typed `/clear` or `/compact`.

This PR adds the second half of #236: at 50% of ctxMax, automatically replace the older portion of the log with a single synthesized assistant summary, keep the trailing turns whose token weight fits in 20% of ctxMax. One cache break per fold; cache rebuilds in ~1 turn; conversation continues.

## Design

- Trigger: `usage.promptTokens / ctxMax > 0.5` after a turn's response (fires at most once per turn via `_foldedThisTurn` flag)
- Tail budget: 20% of ctxMax — leaves ~30% headroom before next fold
- Boundary: walk backward from end, snap to most recent user message that keeps the tail under budget — preserves tool_calls / tool-result pairs intact
- Min savings: skip fold if head < 30% of total tokens (avoids re-fold thrash on stable post-fold logs)
- Summary call: deepseek-v4-flash + high effort + no tools, ~\$0.07 each
- Marker: summary message starts with `[CONVERSATION HISTORY SUMMARY — earlier turns folded for context efficiency]` so the model knows it's a synthesized recap not its own past output
- 80% force-summary kept as belt-and-braces if fold fails or recent K turns alone exceed the cap

## Validation

20-turn live DeepSeek session with ctxMax pinned at 50k (`scripts/probe-long-session.mts`):

\`\`\`
turn |  prompt  |   hit   |   miss  | hit% |  $/turn  |  $cum
-----+----------+---------+---------+------+----------+--------
  9  |   25756 |   23296 |    2460 | 90.4 | $0.00234 | $0.0156
 10  |   13030 |     384 |   12646 |  2.9 | $0.00349 | $0.0191  (folded 42→19)
 11  |   15557 |   13056 |    2501 | 83.9 | $0.00164 | $0.0207
 ...
 16  |   13132 |     384 |   12748 |  2.9 | $0.00352 | $0.0326  (folded 43→19)
 17  |   15665 |   13184 |    2481 | 84.2 | $0.00165 | $0.0342

total mutations: 2 (= the 2 folds, nothing else)
total cost: \$0.0381 across 20 turns (vs \$0.0493 without fold — fold session is cheaper because prompt stays bounded)
\`\`\`

Cache rebuilds in 1 turn. Steady-state cycle: ~6 turns of growth → fold → repeat. No drift, no thrash.

## Test plan

- [x] `npm test` — 2230 pass (3 new tests for compactHistory + auto-trigger)
- [x] `npm run typecheck` — clean
- [x] Live 20-turn probe shows 2 folds, 0 unexpected mutations, cost trajectory matches design
- [ ] Manual smoke test in a real `reasonix chat` session past 50% to confirm the warning text + recovery feel right

## Follow-ups

- `/compact-history` slash command for manual invocation (current slash handlers are sync; needs minor refactor to support async)
- Tune `HISTORY_FOLD_TAIL_FRACTION` and `HISTORY_FOLD_MIN_SAVINGS_FRACTION` based on real-world session data once shipped

Closes #236.