### PR TITLE
refactor: make MCP append summary updates immutable

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -288,6 +288,9 @@ function AppInner({
   const [busy, setBusy] = useState(false);
   const [languageVersion, setLanguageVersion] = useState(0);
   useEffect(() => onLanguageChange(() => setLanguageVersion((v) => v + 1)), []);
+  // Live MCP server list: initialized from the boot-time prop, then
+  // updated immutably when append-drift adds tools mid-session.
+  const [liveMcpServers, setLiveMcpServers] = useState<McpServerSummary[]>(() => mcpServers ?? []);
   // Tracks whether the current turn has been aborted via Esc, so the
   // Esc handler only fires once per turn (repeated presses would yield
   // stacked warning events).
@@ -994,7 +997,7 @@ function AppInner({
     codeMode,
     rootDir: currentRootDir,
     models,
-    mcpServers,
+    mcpServers: liveMcpServers,
   });
 
   // Wire the shared progressSink so the bridge's onProgress → us.
@@ -1621,7 +1624,7 @@ function AppInner({
         usageLogPath: defaultUsageLogPath(),
         loop,
         tools,
-        mcpServers,
+        mcpServers: liveMcpServers,
         getCurrentCwd: () => (codeMode ? currentRootDirRef.current : undefined),
         getEditMode: () => (codeMode ? editModeRef.current : undefined),
         getPlanMode: () => planModeRef.current,
@@ -1813,7 +1816,7 @@ function AppInner({
   }, [
     loop,
     tools,
-    mcpServers,
+    liveMcpServers,
     codeMode,
     session,
     togglePlanMode,
@@ -2076,7 +2079,7 @@ function AppInner({
         const arg = mcpBrowseMatch[2]?.trim() ?? "";
         promptHistory.current.push(text);
         log.pushUser(text);
-        await handleMcpBrowseSlash(kind, arg, mcpServers ?? [], log);
+        await handleMcpBrowseSlash(kind, arg, liveMcpServers, log);
         return;
       }
 
@@ -2084,7 +2087,7 @@ function AppInner({
       if (slash) {
         const result = handleSlash(slash.cmd, slash.args, loop, {
           mcpSpecs,
-          mcpServers,
+          mcpServers: liveMcpServers,
           codeUndo: codeMode ? codeUndo : undefined,
           codeApply: codeMode ? codeApply : undefined,
           codeDiscard: codeMode ? codeDiscard : undefined,
@@ -2508,7 +2511,7 @@ function AppInner({
       loop,
       latestVersion,
       mcpSpecs,
-      mcpServers,
+      liveMcpServers,
       models,
       planMode,
       session,
@@ -3191,11 +3194,22 @@ function AppInner({
                 />
               ) : pendingMcpBrowser ? (
                 <McpBrowser
-                  servers={mcpServers ?? []}
+                  servers={liveMcpServers}
                   configPath={defaultConfigPath()}
                   onClose={() => setPendingMcpBrowser(false)}
                   postInfo={(text) => log.pushInfo(text)}
-                  applyAppend={(target, addedTools) => applyMcpAppend(loop, target, addedTools)}
+                  applyAppend={(target, addedTools) => {
+                    const updated = applyMcpAppend(loop, target, addedTools);
+                    setLiveMcpServers((prev) =>
+                      prev.map((server) =>
+                        server === target ||
+                        (server.label === target.label && server.spec === target.spec)
+                          ? updated
+                          : server,
+                      ),
+                    );
+                    return updated;
+                  }}
                 />
               ) : pendingPlan ? (
                 <PlanConfirm

--- a/src/cli/ui/mcp-append.ts
+++ b/src/cli/ui/mcp-append.ts
@@ -1,4 +1,4 @@
-/** Applies an MCP append-drift mid-session: registers each new tool in the loop's registry + prefix, and updates the summary's report. */
+/** Applies an MCP append-drift mid-session: registers each new tool in the loop's registry + prefix, and returns an updated summary. Immutable — does not mutate the input `target`. */
 
 import type { CacheFirstLoop } from "../../loop.js";
 import { registerSingleMcpTool } from "../../mcp/registry.js";
@@ -10,7 +10,7 @@ export function applyMcpAppend(
   loop: CacheFirstLoop,
   target: McpServerSummary,
   addedTools: McpTool[],
-): void {
+): McpServerSummary {
   const accepted: McpTool[] = [];
   for (const mcpTool of addedTools) {
     if (!mcpTool.name) continue;
@@ -27,14 +27,18 @@ export function applyMcpAppend(
     loop.prefix.addTool(spec);
     accepted.push(mcpTool);
   }
-  if (accepted.length === 0) return;
-  // Refresh the summary's snapshot so `/mcp` and the browser modal show the
-  // new shape on their next render.
-  if (target.report.tools.supported) {
-    const merged = [...target.report.tools.items, ...accepted];
-    // biome-ignore lint/suspicious/noExplicitAny: report is a typed snapshot we mutate in place; deeper refactor isn't worth it here
-    (target.report.tools as any).items = merged;
-    // biome-ignore lint/suspicious/noExplicitAny: same — toolCount mirrors items.length post-append
-    (target as any).toolCount = merged.length;
-  }
+  if (accepted.length === 0 || !target.report.tools.supported) return target;
+
+  const merged = [...target.report.tools.items, ...accepted];
+  return {
+    ...target,
+    toolCount: merged.length,
+    report: {
+      ...target.report,
+      tools: {
+        supported: true as const,
+        items: merged,
+      },
+    },
+  };
 }

--- a/src/cli/ui/mcp-reconnect-kickoff.ts
+++ b/src/cli/ui/mcp-reconnect-kickoff.ts
@@ -5,8 +5,8 @@ import type { McpTool } from "../../mcp/types.js";
 import { formatMcpLifecycleEvent } from "./mcp-lifecycle.js";
 import type { McpServerSummary } from "./slash/types.js";
 
-/** Applies append-drift mid-session: registers each new MCP tool in the registry + prefix. */
-export type ApplyAppend = (target: McpServerSummary, addedTools: McpTool[]) => void;
+/** Applies append-drift mid-session: registers each new MCP tool in the registry + prefix. Returns the updated summary. */
+export type ApplyAppend = (target: McpServerSummary, addedTools: McpTool[]) => McpServerSummary;
 
 /** Kicks off async reconnect; returns the start-line, schedules result via postInfo. */
 export function kickOffMcpReconnect(
@@ -18,17 +18,20 @@ export function kickOffMcpReconnect(
   // Only opt into "append" when the caller wired an applyAppend handler;
   // otherwise the reconnect refuses append-drift with a "restart" message.
   const accept = applyAppend ? (["identity", "append"] as const) : (["identity"] as const);
+  // Use a mutable local so the async closure can update it after applyAppend
+  // without reassigning the function parameter (linter: noParameterAssign).
+  let liveTarget = target;
   void (async () => {
     try {
       const result = await reconnectMcpServer({
-        host: target.host,
-        spec: target.spec,
+        host: liveTarget.host,
+        spec: liveTarget.spec,
         beforeTools,
         accept,
       });
       if (result.ok) {
         if (result.kind === "append" && applyAppend) {
-          applyAppend(target, result.addedTools);
+          liveTarget = applyAppend(liveTarget, result.addedTools);
         }
         postInfo(
           formatMcpLifecycleEvent({

--- a/tests/mcp-append.test.ts
+++ b/tests/mcp-append.test.ts
@@ -98,16 +98,25 @@ describe("applyMcpAppend", () => {
     expect(prefix.fingerprint).not.toBe(before);
   });
 
-  it("updates the summary's tool count + report.tools.items", () => {
+  it("returns a new summary with updated tool count + items, leaving the original unchanged", () => {
     const { loop } = makeLoop();
     const { env, host } = makeFakeMcp();
     env.registry = loop.tools;
     const target = summary(env, host);
+    const origItems = target.report.tools.supported ? target.report.tools.items : [];
 
-    applyMcpAppend(loop, target, [newTool]);
-    expect(target.toolCount).toBe(1);
-    if (!target.report.tools.supported) throw new Error("unreachable");
-    expect(target.report.tools.items.map((t) => t.name)).toContain("delete_file");
+    const result = applyMcpAppend(loop, target, [newTool]);
+
+    // Original object is not mutated
+    expect(target.toolCount).toBe(0);
+    if (target.report.tools.supported) {
+      expect(target.report.tools.items).toBe(origItems);
+    }
+    // Returned object is a new reference with updated data
+    expect(result).not.toBe(target);
+    expect(result.toolCount).toBe(1);
+    if (!result.report.tools.supported) throw new Error("unreachable");
+    expect(result.report.tools.items.map((t) => t.name)).toContain("delete_file");
   });
 
   it("skips MCP tools without a name (defensive)", () => {
@@ -116,8 +125,35 @@ describe("applyMcpAppend", () => {
     env.registry = loop.tools;
     const target = summary(env, host);
 
-    applyMcpAppend(loop, target, [{ name: "", inputSchema: { type: "object" } } as McpTool]);
+    const result = applyMcpAppend(loop, target, [
+      { name: "", inputSchema: { type: "object" } } as McpTool,
+    ]);
+    // Nothing accepted — returns the same reference, no side effects
+    expect(result).toBe(target);
     expect(loop.tools.size).toBe(0);
     expect(target.toolCount).toBe(0);
+  });
+
+  it("propagates the updated summary into the owning server list via the state-updater pattern", () => {
+    const { loop } = makeLoop();
+    const { env, host } = makeFakeMcp();
+    env.registry = loop.tools;
+    const server = summary(env, host);
+    const servers = [server];
+
+    const updated = applyMcpAppend(loop, server, [newTool]);
+
+    // Simulate the setLiveMcpServers updater from App.tsx
+    const next = servers.map((s) =>
+      s === server || (s.label === server.label && s.spec === server.spec) ? updated : s,
+    );
+
+    // The owning list now points at the new summary
+    expect(next).toHaveLength(1);
+    expect(next[0]).toBe(updated);
+    expect(next[0].toolCount).toBe(1);
+    // The original list and server are untouched
+    expect(servers[0]).toBe(server);
+    expect(servers[0].toolCount).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

This is a small MCP cleanup PR under the direction discussed in #196.

It changes `applyMcpAppend()` so it no longer mutates the provided `McpServerSummary` in place. Instead, it returns a new summary with updated `report.tools.items` and `toolCount` when append-drift accepts new tools.

## Changes

- Make `applyMcpAppend()` return `McpServerSummary` instead of `void`.
- Preserve the existing tool registration and prefix update behavior.
- Update reconnect kickoff wiring to capture the returned summary.
- Store MCP server summaries in App-local state so append-drift replaces the matching summary immutably.
- Add tests proving:
  - appended tools are registered under the MCP prefix
  - prefix fingerprint changes after append
  - the original summary is not mutated
  - invalid tools still no-op
  - the owning server list update pattern points at the returned summary

## Notes

- No MCP protocol behavior changes intended.
- No unrelated TUI redesign.
- No `CHANGELOG.md` changes.

Refs #196