### PR TITLE
feat(loop): aggressive fold tier between 70% and 80% of ctxMax

### DIFF
--- a/src/context-manager.ts
+++ b/src/context-manager.ts
@@ -16,8 +16,12 @@ import type { ChatMessage } from "./types.js";
 
 /** Auto-fold when a turn's response shows promptTokens above this fraction of ctxMax. */
 export const HISTORY_FOLD_THRESHOLD = 0.5;
-/** Tail budget after fold, as a fraction of ctxMax. */
+/** Tail budget after a normal fold, as a fraction of ctxMax. */
 export const HISTORY_FOLD_TAIL_FRACTION = 0.2;
+/** Above this fraction the normal fold's tail budget didn't buy enough headroom — fold harder. */
+export const HISTORY_FOLD_AGGRESSIVE_THRESHOLD = 0.7;
+/** Tail budget after an aggressive fold — half the normal one, sacrifices recent context for headroom. */
+export const HISTORY_FOLD_AGGRESSIVE_TAIL_FRACTION = 0.1;
 /** Skip the fold if the head wouldn't shrink the log by at least this fraction. */
 export const HISTORY_FOLD_MIN_SAVINGS_FRACTION = 0.3;
 /** Above this fraction we exit the turn with a summary instead of folding (defense in depth). */
@@ -44,6 +48,10 @@ export interface PostUsageDecision {
   promptTokens: number;
   ctxMax: number;
   ratio: number;
+  /** Token budget for the recent tail when kind === "fold"; smaller in the aggressive band. */
+  tailBudget?: number;
+  /** True when this fold is in the 70-85% band — used in user-facing messaging. */
+  aggressive?: boolean;
 }
 
 export interface PreflightDecision {
@@ -71,13 +79,28 @@ export class ContextManager {
     const ctxMax = DEEPSEEK_CONTEXT_TOKENS[model] ?? DEFAULT_CONTEXT_TOKENS;
     if (!usage) return { kind: "none", promptTokens: 0, ctxMax, ratio: 0 };
     const ratio = usage.promptTokens / ctxMax;
+    const base = { promptTokens: usage.promptTokens, ctxMax, ratio };
     if (ratio > FORCE_SUMMARY_THRESHOLD) {
-      return { kind: "exit-with-summary", promptTokens: usage.promptTokens, ctxMax, ratio };
+      return { kind: "exit-with-summary", ...base };
     }
-    if (ratio > HISTORY_FOLD_THRESHOLD && !alreadyFoldedThisTurn) {
-      return { kind: "fold", promptTokens: usage.promptTokens, ctxMax, ratio };
+    if (alreadyFoldedThisTurn) return { kind: "none", ...base };
+    if (ratio > HISTORY_FOLD_AGGRESSIVE_THRESHOLD) {
+      return {
+        kind: "fold",
+        ...base,
+        tailBudget: Math.floor(ctxMax * HISTORY_FOLD_AGGRESSIVE_TAIL_FRACTION),
+        aggressive: true,
+      };
     }
-    return { kind: "none", promptTokens: usage.promptTokens, ctxMax, ratio };
+    if (ratio > HISTORY_FOLD_THRESHOLD) {
+      return {
+        kind: "fold",
+        ...base,
+        tailBudget: Math.floor(ctxMax * HISTORY_FOLD_TAIL_FRACTION),
+        aggressive: false,
+      };
+    }
+    return { kind: "none", ...base };
   }
 
   /** Local-side preflight before sending a request — catches oversized payloads early. */

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -1125,15 +1125,20 @@ export class CacheFirstLoop {
         this._foldedThisTurn = true;
         const before = decision.promptTokens;
         const ctxMax = decision.ctxMax;
-        yield { turn: this._turn, role: "status", content: "compacting history…" };
-        const result = await this.compactHistory();
+        const aggressiveTag = decision.aggressive ? " (aggressive)" : "";
+        yield {
+          turn: this._turn,
+          role: "status",
+          content: `compacting history${aggressiveTag}…`,
+        };
+        const result = await this.compactHistory({ keepRecentTokens: decision.tailBudget });
         if (result.folded) {
           yield {
             turn: this._turn,
             role: "warning",
             content: `context ${before.toLocaleString()}/${ctxMax.toLocaleString()} (${Math.round(
               (before / ctxMax) * 100,
-            )}%) — folded ${result.beforeMessages} messages → ${result.afterMessages} (summary ${result.summaryChars} chars). Continuing.`,
+            )}%) — ${decision.aggressive ? "aggressively folded" : "folded"} ${result.beforeMessages} messages → ${result.afterMessages} (summary ${result.summaryChars} chars). Continuing.`,
           };
         }
       } else if (decision.kind === "exit-with-summary") {

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -697,6 +697,67 @@ describe("CacheFirstLoop (non-streaming)", () => {
     expect(loop.log.length).toBeLessThan(beforeMessages);
   }, 30_000);
 
+  it("uses the aggressive fold tier when promptTokens crosses 70% of ctxMax", async () => {
+    const reg = new ToolRegistry();
+    reg.register({
+      name: "probe",
+      description: "no-op",
+      parameters: { type: "object", properties: {} },
+      fn: async () => "ok",
+    });
+    const responses: FakeResponseShape[] = [
+      // Iter 0: usage at 75% of 1M ctx — squarely in the aggressive band.
+      {
+        content: "",
+        tool_calls: [{ id: "c1", type: "function", function: { name: "probe", arguments: "{}" } }],
+        usage: {
+          prompt_tokens: 750_000,
+          completion_tokens: 10,
+          total_tokens: 750_010,
+          prompt_cache_hit_tokens: 600_000,
+          prompt_cache_miss_tokens: 150_000,
+        },
+      },
+      // Summary call (compactHistory).
+      { content: "Earlier turns covered topic X." },
+      // Iter 1 wrap-up.
+      { content: "done." },
+    ];
+    const client = makeClient(responses);
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s", toolSpecs: reg.specs() }),
+      tools: reg,
+      stream: false,
+      maxToolIters: 8,
+    });
+    const fillLines = (label: string, n: number) =>
+      Array.from(
+        { length: n },
+        (_, i) =>
+          `${label} line ${i}: lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`,
+      ).join("\n");
+    for (let i = 0; i < 18; i++) {
+      loop.log.append({ role: "user", content: `Q${i}\n${fillLines(`q${i}`, 400)}` });
+      loop.log.append({ role: "assistant", content: `A${i}\n${fillLines(`a${i}`, 400)}` });
+    }
+
+    const events: { role: string; content?: string }[] = [];
+    for await (const ev of loop.step("continue")) {
+      events.push({ role: ev.role, content: ev.content });
+    }
+
+    // The warning should call out the aggressive tier explicitly.
+    const foldWarn = events.find(
+      (e) => e.role === "warning" && /aggressively folded/.test(e.content ?? ""),
+    );
+    expect(foldWarn).toBeDefined();
+    // And the status line should advertise it too, so users know why
+    // recent context got trimmed harder than usual.
+    const status = events.find((e) => e.role === "status" && /aggressive/.test(e.content ?? ""));
+    expect(status).toBeDefined();
+  }, 30_000);
+
   it("pre-clips new tool results at dispatch so they never enter the log oversized", async () => {
     const reg = new ToolRegistry();
     // Tool returns ~50k chars of realistic-shape log text; the default


### PR DESCRIPTION
## Summary

PR-D from the #244 plan. Closes the gap between the normal-fold threshold (50%) and the force-summary cliff (80%).

When a turn returns in the 70-85% band, the recent K turns alone are already big enough that a normal fold (tail = 20% of ctxMax) wouldn't buy meaningful headroom — the fold's `MIN_SAVINGS_FRACTION` guard would silently no-op and the next turn would push us straight into force-summary territory. The aggressive tier shrinks the tail to 10% of ctxMax instead, sacrificing some recent context for a real reset.

## Decision matrix

\`\`\`
ratio > 0.8  → exit-with-summary
ratio > 0.7  → fold (tail = 10% ctxMax)  [aggressive]
ratio > 0.5  → fold (tail = 20% ctxMax)  [normal]
else         → none
\`\`\`

Both bands respect the per-turn `_foldedThisTurn` flag so neither tier re-fires within a single turn.

## User-visible

- **Status line** when aggressive tier fires: `compacting history (aggressive)…`
- **Warning text** after the fold: `... — aggressively folded N messages → M ...`

Normal-band fold output is unchanged.

## Implementation

- `PostUsageDecision` now carries `tailBudget` and `aggressive` fields when `kind === \"fold\"`. `loop.ts` passes `tailBudget` straight through to `compactHistory({ keepRecentTokens })` (the option already existed since #241).
- `decideAfterUsage` hoists the `alreadyFoldedThisTurn` short-circuit above the band checks — cleaner than threading it into each branch.
- Two new constants: `HISTORY_FOLD_AGGRESSIVE_THRESHOLD = 0.7`, `HISTORY_FOLD_AGGRESSIVE_TAIL_FRACTION = 0.1`.

## Test plan

- [x] `npm test` — 2243 pass (+1 new test for the aggressive band)
- [x] `npm run typecheck` — clean
- [x] New test asserts both the `\"aggressively folded\"` warning and the `aggressive` status line fire when usage crosses 70%
- [ ] Skipped live probe (env credentials no longer present locally); the unit test covers the dispatch path end-to-end and the fold mechanics are unchanged from #241

## Follow-ups (separate work)

- Model-aware threshold tuning — the current fractions are uniform across context sizes. Worth revisiting once we have real usage data on summary-call cost vs cache-rebuild trade-offs at different ctxMax tiers.
- #243 non-foot-gun cleanup (`/setup`, `/init` → CLI, etc.) — independent of context management.

Closes the architectural plan in #244.