### PR TITLE
refactor(slash): drop /setup — handler did nothing useful

### DIFF
--- a/src/cli/ui/slash/commands.ts
+++ b/src/cli/ui/slash/commands.ts
@@ -143,7 +143,6 @@ export const SLASH_COMMANDS: readonly SlashCommandSpec[] = [
     summary: "delete sessions idle ≥N days (default 90) — frees disk on long-time installs",
     argsHint: "[days]",
   },
-  { cmd: "setup", summary: "reminds you to exit and run `reasonix setup`" },
   {
     cmd: "semantic",
     summary: "show semantic_search status — built? Ollama installed? how to enable",

--- a/src/cli/ui/slash/handlers/basic.ts
+++ b/src/cli/ui/slash/handlers/basic.ts
@@ -77,7 +77,6 @@ const help: SlashHandler = () => ({
     t("handlers.basic.helpMcp"),
     t("handlers.basic.helpResource"),
     t("handlers.basic.helpPrompt"),
-    t("handlers.basic.helpSetup"),
     t("handlers.basic.helpCompact"),
     t("handlers.basic.helpThink"),
     t("handlers.basic.helpTool"),
@@ -147,10 +146,6 @@ const help: SlashHandler = () => ({
   ].join("\n"),
 });
 
-const setup: SlashHandler = () => ({
-  info: t("handlers.basic.setupInfo"),
-});
-
 const retry: SlashHandler = (_args, loop) => {
   const prev = loop.retryLastUser();
   if (!prev) {
@@ -201,7 +196,6 @@ export const handlers: Record<string, SlashHandler> = {
   keys,
   help,
   "?": help,
-  setup,
   retry,
   loop,
 };

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -309,7 +309,6 @@ export const EN: TranslationSchema = {
         "  /resource [uri]          browse + read MCP resources (no arg → list URIs; <uri> → fetch)",
       helpPrompt:
         "  /prompt [name]           browse + fetch MCP prompts (no arg → list names; <name> → render)",
-      helpSetup: "  /setup                   (exit + reconfigure) → run `reasonix setup`",
       helpCompact:
         "  /compact                 fold older turns into a summary (cache-safe; auto-fires at 50% ctx)",
       helpThink:
@@ -452,8 +451,6 @@ export const EN: TranslationSchema = {
         "  /resource [uri]        browse & read resources exposed by your MCP servers",
       keysMcpPrompt: "  /prompt [name]         browse & fetch prompts exposed by your MCP servers",
       keysUseful: "Useful slashes: /help · /context · /stats · /compact · /new · /exit",
-      setupInfo:
-        "To reconfigure (preset, MCP servers, API key), exit this chat and run `reasonix setup`. Changes take effect on next launch.",
       retryNone: "nothing to retry — no prior user message in this session's log.",
       retryInfo: '▸ retrying: "{preview}"',
       loopTuiOnly: "/loop is only available in the interactive TUI (not in run/replay).",

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -300,7 +300,6 @@ export const zhCN: TranslationSchema = {
         "  /resource [uri]          浏览 + 读取 MCP 资源（无参数 → 列出 URI；<uri> → 获取）",
       helpPrompt:
         "  /prompt [name]           浏览 + 获取 MCP 提示（无参数 → 列出名称；<name> → 渲染）",
-      helpSetup: "  /setup                   （退出 + 重新配置）→ 运行 `reasonix setup`",
       helpCompact: "  /compact                 折叠旧轮次为摘要（cache-safe，50% 自动触发）",
       helpThink: "  /think                   转储最近一轮的完整 R1 推理（仅推理模型）",
       helpTool: "  /tool [N]                列出工具调用（或转储第 N 个的完整输出，1=最近）",
@@ -414,8 +413,6 @@ export const zhCN: TranslationSchema = {
       keysMcpResource: "  /resource [uri]        浏览并读取 MCP 服务器暴露的资源",
       keysMcpPrompt: "  /prompt [name]         浏览并获取 MCP 服务器暴露的提示",
       keysUseful: "常用斜杠命令：/help · /context · /stats · /compact · /new · /exit",
-      setupInfo:
-        "要重新配置（预设、MCP 服务器、API 密钥），请退出此聊天并运行 `reasonix setup`。更改在下次启动时生效。",
       retryNone: "没有可重试的内容 — 此会话日志中没有先前的用户消息。",
       retryInfo: '▸ 重试中："{preview}"',
       loopTuiOnly: "/loop 仅在交互式 TUI 中可用（不在 run/replay 中）。",

--- a/tests/slash.test.ts
+++ b/tests/slash.test.ts
@@ -246,12 +246,6 @@ describe("handleSlash", () => {
     expect(r.info).toMatch(/kb.example.com/);
   });
 
-  it("/setup prints instructions to exit and run reasonix setup", () => {
-    const r = handleSlash("setup", [], makeLoop());
-    expect(r.info).toMatch(/reasonix setup/);
-    expect(r.exit).toBeUndefined(); // /setup doesn't auto-exit — user presses /exit
-  });
-
   it("/compact returns synchronously with a 'folding…' status and fires fold async", async () => {
     const loop = makeLoop();
     let posted = "";
@@ -320,10 +314,9 @@ describe("handleSlash", () => {
     expect(r.info).toMatch(/\/forget/);
   });
 
-  it("/help mentions /mcp and /setup", () => {
+  it("/help mentions /mcp", () => {
     const r = handleSlash("help", [], makeLoop());
     expect(r.info).toMatch(/\/mcp/);
-    expect(r.info).toMatch(/\/setup/);
   });
 
   it("/undo outside code mode says it's not available", () => {


### PR DESCRIPTION
## Summary

Part of the #243 slash command inventory cleanup.

`/setup`'s handler was 3 lines that just printed a static "exit and run \`reasonix setup\`" reminder. It didn't launch anything, didn't change any state — it was a slash-shaped pointer to a CLI subcommand. Cheap to remove, and a small win on `/help` discoverability noise.

The actual `reasonix setup` CLI subcommand is unchanged.

## What changed

- Deleted `setup` handler from `src/cli/ui/slash/handlers/basic.ts`
- Removed from the `SLASH_COMMANDS` registry in `src/cli/ui/slash/commands.ts`
- Removed `helpSetup` and `setupInfo` strings from EN + zh-CN i18n
- Updated tests: dropped the `/setup` standalone test, updated `/help mentions /setup` → `/help mentions /mcp` (since the line was checking the help text rendered correctly)

Net diff: +1 / -21.

## Tests

- [x] `npm test` — 2254 pass (was 2255; -1 from the deleted /setup standalone test)
- [x] `npm run typecheck` — clean

## Out of scope (separate PRs)

The #243 RFC also proposed merging `/semantic` into `/doctor` — left for a follow-up because `/semantic` actually surfaces index detail (chunks, files counts) that `/doctor` doesn't currently show. Naive merge would lose info; doing it right means enriching `/doctor`.

Same for moving `/init`, `/prune-sessions`, `/dashboard` to CLI subcommands — each is its own design conversation.

Tracking #243.