### PR TITLE
fix(renderer): stop input bar duplicating on Windows conhost resize (#249)

### DIFF
--- a/src/renderer/reconciler/mount.ts
+++ b/src/renderer/reconciler/mount.ts
@@ -46,7 +46,6 @@ const LEAVE_VIRTUAL = "\x1b[?1006l\x1b[?1002l\x1b[?1000l\x1b[?1049l";
 // DEC 2026 synchronized output — defers paint until ESU so half-arrived diffs don't flash.
 const BSU = "\x1b[?2026h";
 const ESU = "\x1b[?2026l";
-const ERASE_SCREEN = "\x1b[2J\x1b[H";
 
 export function mount(element: ReactNode, opts: MountOptions): Handle {
   const scrollMode: ScrollMode = opts.scroll ?? "scrollback";
@@ -60,13 +59,18 @@ export function mount(element: ReactNode, opts: MountOptions): Handle {
   let lastTotalRows = 0;
   let destroyed = false;
   let lastElement: ReactNode = element;
-  // Set by resize() so the clear is folded into the next commit's sync block.
-  let pendingClear = false;
+  // Set by resize(); -1 = none. \x1b[2J would scroll content into scrollback
+  // on Windows conhost, so we rewind + \x1b[J to fill in place instead.
+  let pendingClearRewind = -1;
 
   // Empty input is dropped — bare BSU+ESU can briefly flash on some terminals.
   const flushFrame = (out: string): void => {
-    const buffer = pendingClear ? ERASE_SCREEN + out : out;
-    pendingClear = false;
+    let buffer = out;
+    if (pendingClearRewind >= 0) {
+      const r = pendingClearRewind;
+      buffer = (r > 0 ? `\r\x1b[${r}A\x1b[J` : "\r\x1b[J") + buffer;
+      pendingClearRewind = -1;
+    }
     if (buffer.length === 0) return;
     opts.write(BSU + buffer + ESU);
   };
@@ -311,6 +315,10 @@ export function mount(element: ReactNode, opts: MountOptions): Handle {
       if (destroyed) return;
       // Same-dim events fire 2-3× per drag on most terminals; skip duplicates.
       if (width === viewportWidth && height === viewportHeight) return;
+      // Capture rewind distance before discarding frame state below.
+      if (frame.screen.height > 0 || reservedRows > 0) {
+        pendingClearRewind = Math.max(0, frame.cursor.y);
+      }
       viewportWidth = width;
       viewportHeight = height;
       frame = emptyFrame(width, height);
@@ -321,8 +329,6 @@ export function mount(element: ReactNode, opts: MountOptions): Handle {
       scrollOffset = 0;
       stickyBottom = true;
       lastTotalRows = 0;
-      // Folded into the next commit so clear+repaint is one atomic block.
-      pendingClear = true;
       reconciler.updateContainer(wrap(lastElement), container, null, () => {
         /* committed */
       });

--- a/tests/renderer/ink-compat/hooks.test.tsx
+++ b/tests/renderer/ink-compat/hooks.test.tsx
@@ -82,6 +82,27 @@ describe("useStdout — viewport from mount/resize", () => {
     expect(w.output()).toContain("cols=80");
     handle.destroy();
   });
+
+  // Regression for #249: \x1b[2J on Windows conhost scrolls content into
+  // scrollback rather than erasing, so a later grow-resize pulls duplicate
+  // input/toolbar rows back. resize() must clear in place via \x1b[J.
+  it("resize uses in-place clear, not \\x1b[2J", async () => {
+    const w = makeTestWriter();
+    const handle = mount(<Text>hello</Text>, {
+      viewportWidth: 40,
+      viewportHeight: 8,
+      pools: pools(),
+      write: w.write,
+    });
+    await flush();
+    w.flush();
+    handle.resize(60, 16);
+    await flush();
+    const out = w.output();
+    expect(out).not.toContain("\x1b[2J");
+    expect(out).toContain("\x1b[J");
+    handle.destroy();
+  });
 });
 
 describe("useApp — exit via context", () => {


### PR DESCRIPTION
## Summary
- `\x1b[2J` on Windows PowerShell 5.1's legacy conhost scrolls the visible viewport into scrollback rather than truly erasing it. The renderer's resize handler used this sequence via `pendingClear`, so each resize pushed the current input/toolbar into scrollback. A subsequent grow-resize then pulled those rows back into the viewport — the user saw stacked duplicate input bars.
- Replaced with the rewind-and-clear pattern (`\r\x1b[<N>A\x1b[J`) already used by `commitScrollback` / `emitStatic`. `\x1b[J` fills with spaces in place — no scrollback push on conhost. Platform-neutral, no Windows branch needed.
- Added a regression test asserting `handle.resize()` produces output containing `\x1b[J` and never `\x1b[2J`.

Closes #249.

## Test plan
- [x] Existing 294 renderer tests pass
- [x] New regression test: `tests/renderer/ink-compat/hooks.test.tsx` — "resize uses in-place clear, not \x1b[2J"
- [ ] Manual: resize Windows PowerShell 5.1 window with drag + Win+Right, confirm no duplicated input/toolbar