### PR TITLE
fix(shell): demote destructive flags on allowlisted commands

### DIFF
--- a/src/tools/shell.ts
+++ b/src/tools/shell.ts
@@ -210,8 +210,20 @@ const RISKY_ARGS: Readonly<Record<string, ReadonlyArray<string>>> = {
   "git diff": ["--output", "--ext-diff"],
   "git log": ["--output"],
   "git show": ["--output"],
-  // `-exec*` / `-ok*` are RCE; `-delete` and `-fprint*` write to arbitrary paths.
-  find: ["-delete", "-exec", "-execdir", "-ok", "-okdir", "-fprint", "-fprintf", "-fls"],
+  // `-exec*` / `-ok*` are RCE; `-delete` and `-fprint*` / `-fls` write to arbitrary paths.
+  find: [
+    "-delete",
+    "-exec",
+    "-execdir",
+    "-ok",
+    "-okdir",
+    "-fprint",
+    "-fprint0",
+    "-fprintf",
+    "-fls",
+  ],
+  // `-o FILE` writes the tree to an arbitrary path.
+  tree: ["-o"],
   // Auto-fix mutates source files.
   "npx eslint": ["--fix", "--fix-dry-run"],
   "npx biome check": ["--write", "--apply", "--apply-unsafe"],

--- a/src/tools/shell.ts
+++ b/src/tools/shell.ts
@@ -201,13 +201,59 @@ export function detectShellOperator(cmd: string): string | null {
   return check();
 }
 
-/** Match on space-normalized leading tokens — `git   status  -s` matches the `git status` prefix. */
+/** Per-prefix demotion: an otherwise-allowlisted match falls back to the confirm gate when one of these tokens appears in the tail. Issue #257: `git branch -D` skipped review. Each token also matches its `--flag=value` form. */
+const RISKY_ARGS: Readonly<Record<string, ReadonlyArray<string>>> = {
+  // Branch / remote mutation
+  "git branch": ["-d", "-D", "--delete", "-m", "-M", "--move", "-c", "-C", "--copy", "--force"],
+  "git remote": ["add", "remove", "rm", "rename", "set-url", "set-head", "prune"],
+  // `--output` writes to an arbitrary path; `--ext-diff` invokes user-config'd external programs.
+  "git diff": ["--output", "--ext-diff"],
+  "git log": ["--output"],
+  "git show": ["--output"],
+  // `-exec*` / `-ok*` are RCE; `-delete` and `-fprint*` write to arbitrary paths.
+  find: ["-delete", "-exec", "-execdir", "-ok", "-okdir", "-fprint", "-fprintf", "-fls"],
+  // Auto-fix mutates source files.
+  "npx eslint": ["--fix", "--fix-dry-run"],
+  "npx biome check": ["--write", "--apply", "--apply-unsafe"],
+  ruff: ["--fix", "--unsafe-fixes", "format"],
+};
+
+function tailHasRisky(tail: readonly string[], risky: readonly string[]): boolean {
+  for (const a of tail) {
+    for (const r of risky) {
+      if (a === r) return true;
+      if (a.startsWith(`${r}=`)) return true;
+    }
+  }
+  return false;
+}
+
+/** Allowlist match on leading argv tokens; demoted by `RISKY_ARGS` when a destructive flag appears in the tail. */
 export function isAllowed(cmd: string, extra: readonly string[] = []): boolean {
-  const normalized = cmd.trim().replace(/\s+/g, " ");
+  let argv: string[];
+  try {
+    argv = tokenizeCommand(cmd);
+  } catch {
+    return false;
+  }
+  if (argv.length === 0) return false;
+
   const allowlist = [...BUILTIN_ALLOWLIST, ...extra];
   for (const prefix of allowlist) {
-    if (normalized === prefix) return true;
-    if (normalized.startsWith(`${prefix} `)) return true;
+    const prefixTokens = prefix.split(" ");
+    if (argv.length < prefixTokens.length) continue;
+    let match = true;
+    for (let i = 0; i < prefixTokens.length; i++) {
+      if (argv[i] !== prefixTokens[i]) {
+        match = false;
+        break;
+      }
+    }
+    if (!match) continue;
+
+    const risky = RISKY_ARGS[prefix];
+    if (risky && tailHasRisky(argv.slice(prefixTokens.length), risky)) return false;
+    return true;
   }
   return false;
 }

--- a/tests/shell-tools.test.ts
+++ b/tests/shell-tools.test.ts
@@ -201,6 +201,70 @@ describe("isAllowed", () => {
     expect(isAllowed("my-lint src/")).toBe(false);
     expect(isAllowed("my-lint src/", ["my-lint"])).toBe(true);
   });
+
+  // Issue #257 — allowlisted prefixes used to let destructive flags through
+  // because the match only looked at the leading tokens. Demotion rules
+  // bounce these specific risky tail tokens back to the confirm gate.
+  describe("risky-arg demotion", () => {
+    it("demotes destructive git-branch flags", () => {
+      expect(isAllowed("git branch")).toBe(true);
+      expect(isAllowed("git branch -v")).toBe(true);
+      expect(isAllowed("git branch --list")).toBe(true);
+      expect(isAllowed("git branch -d feature/foo")).toBe(false);
+      expect(isAllowed("git branch -D feature/foo")).toBe(false);
+      expect(isAllowed("git branch --delete feature/foo")).toBe(false);
+      expect(isAllowed("git branch -m old new")).toBe(false);
+      expect(isAllowed("git branch -M old new")).toBe(false);
+      expect(isAllowed("git branch -c old new")).toBe(false);
+      expect(isAllowed("git branch -C old new")).toBe(false);
+      expect(isAllowed("git branch --force foo origin/main")).toBe(false);
+    });
+
+    it("demotes mutating git-remote subcommands", () => {
+      expect(isAllowed("git remote")).toBe(true);
+      expect(isAllowed("git remote -v")).toBe(true);
+      expect(isAllowed("git remote show origin")).toBe(true);
+      expect(isAllowed("git remote add upstream https://example.com/x.git")).toBe(false);
+      expect(isAllowed("git remote remove origin")).toBe(false);
+      expect(isAllowed("git remote rm origin")).toBe(false);
+      expect(isAllowed("git remote set-url origin https://example.com/x.git")).toBe(false);
+      expect(isAllowed("git remote prune origin")).toBe(false);
+    });
+
+    it("demotes write-anywhere / external-program git flags", () => {
+      expect(isAllowed("git diff main")).toBe(true);
+      expect(isAllowed("git diff --output foo.patch main")).toBe(false);
+      expect(isAllowed("git diff --output=foo.patch main")).toBe(false);
+      expect(isAllowed("git diff --ext-diff main")).toBe(false);
+      expect(isAllowed("git log --output=log.txt")).toBe(false);
+      expect(isAllowed("git show --output=show.txt HEAD")).toBe(false);
+    });
+
+    it("demotes destructive find actions", () => {
+      expect(isAllowed("find . -name '*.ts'")).toBe(true);
+      expect(isAllowed("find src -type f")).toBe(true);
+      expect(isAllowed("find . -delete")).toBe(false);
+      expect(isAllowed("find . -name '*.tmp' -delete")).toBe(false);
+      expect(isAllowed("find . -exec rm {} ;")).toBe(false);
+      expect(isAllowed("find . -execdir rm {} ;")).toBe(false);
+      expect(isAllowed("find . -fprint /tmp/x")).toBe(false);
+      expect(isAllowed("find . -fprintf /tmp/x %p")).toBe(false);
+    });
+
+    it("demotes auto-fix flags on linters / formatters", () => {
+      expect(isAllowed("npx eslint src")).toBe(true);
+      expect(isAllowed("npx eslint --fix src")).toBe(false);
+      expect(isAllowed("npx eslint --fix-dry-run src")).toBe(false);
+      expect(isAllowed("npx biome check src")).toBe(true);
+      expect(isAllowed("npx biome check --write src")).toBe(false);
+      expect(isAllowed("npx biome check --apply src")).toBe(false);
+      expect(isAllowed("npx biome check --apply-unsafe src")).toBe(false);
+      expect(isAllowed("ruff check src")).toBe(true);
+      expect(isAllowed("ruff check --fix src")).toBe(false);
+      expect(isAllowed("ruff check --unsafe-fixes src")).toBe(false);
+      expect(isAllowed("ruff format src")).toBe(false);
+    });
+  });
 });
 
 describe("runCommand", () => {

--- a/tests/shell-tools.test.ts
+++ b/tests/shell-tools.test.ts
@@ -248,7 +248,16 @@ describe("isAllowed", () => {
       expect(isAllowed("find . -exec rm {} ;")).toBe(false);
       expect(isAllowed("find . -execdir rm {} ;")).toBe(false);
       expect(isAllowed("find . -fprint /tmp/x")).toBe(false);
+      expect(isAllowed("find . -fprint0 /tmp/x")).toBe(false);
       expect(isAllowed("find . -fprintf /tmp/x %p")).toBe(false);
+    });
+
+    it("demotes tree -o (write-anywhere)", () => {
+      expect(isAllowed("tree")).toBe(true);
+      expect(isAllowed("tree src")).toBe(true);
+      expect(isAllowed("tree -L 2")).toBe(true);
+      expect(isAllowed("tree -o /tmp/x")).toBe(false);
+      expect(isAllowed("tree -o=/tmp/x")).toBe(false);
     });
 
     it("demotes auto-fix flags on linters / formatters", () => {


### PR DESCRIPTION
## Summary
- Closes #257 — `git branch -D` (and similar destructive flags on otherwise-allowlisted commands) skipped review mode because the allowlist match looked at the leading tokens only.
- Adds a per-prefix `RISKY_ARGS` table in `src/tools/shell.ts`. When an allowlisted prefix matches but a tail token is in that prefix's risky list, the call falls back to the confirm gate. Read-only forms (`git branch`, `git branch -v`, `find -name '*.ts'`, `npx eslint src`, …) stay on the fast path.
- Audited the rest of `BUILTIN_ALLOWLIST` for the same class of bypass while in there. New rules cover: `git branch`, `git remote`, `git diff/log/show` (`--output`, `--ext-diff`), `find` (`-delete`, `-exec*`, `-ok*`, `-fprint*`), `npx eslint --fix`, `npx biome check --write/--apply*`, `ruff --fix/--unsafe-fixes/format`.
- Both `--flag value` and `--flag=value` forms are caught, so `git diff --output=x.patch` and `git diff --output x.patch` both demote.
- Chain commands (`a && b`, `a | b`) inherit automatically — `chainAllowed` already calls `isAllowed` per segment.
- `npm test` / `pytest` / `cargo test` etc. are intentionally not gated further: the contract of these allowlist entries is "run user code", and no flag-level filter would meaningfully constrain that.

## Test plan
- [x] `npm run verify` (build + lint + typecheck + 2260 tests, all pass)
- [x] New `risky-arg demotion` describe block in `tests/shell-tools.test.ts` — 5 groups covering each `RISKY_ARGS` prefix with happy + sad paths, including the `--flag=value` form
- [x] Manual repro of the original bug fixed: `git branch -D feature/foo` now hits the confirm gate instead of executing immediately