### PR TITLE
fix(shell): preserve Windows path backslashes inside quoted args

### DIFF
--- a/src/tools/shell-chain.ts
+++ b/src/tools/shell-chain.ts
@@ -3,7 +3,7 @@
 import { type ChildProcess, type SpawnOptions, spawn } from "node:child_process";
 import { closeSync, openSync } from "node:fs";
 import * as pathMod from "node:path";
-import { killProcessTree, prepareSpawn, smartDecodeOutput } from "./shell.js";
+import { isDqEscape, killProcessTree, prepareSpawn, smartDecodeOutput } from "./shell.js";
 
 export type ChainOp = "|" | "||" | "&&" | ";";
 
@@ -45,7 +45,7 @@ function splitOnChainOps(cmd: string): { segs: string[]; ops: ChainOp[] } {
     const ch = cmd[i]!;
     if (quote) {
       if (ch === quote) quote = null;
-      else if (ch === "\\" && quote === '"' && i + 1 < cmd.length) i++;
+      else if (quote === '"' && isDqEscape(ch, cmd[i + 1])) i++;
       i++;
       atTokenStart = false;
       continue;
@@ -119,7 +119,7 @@ function parseSegment(segStr: string): ChainSegment {
     if (quote) {
       if (ch === quote) {
         quote = null;
-      } else if (ch === "\\" && quote === '"' && i + 1 < segStr.length) {
+      } else if (quote === '"' && isDqEscape(ch, segStr[i + 1])) {
         cur += segStr[++i] ?? "";
         curHasContent = true;
       } else {

--- a/src/tools/shell.ts
+++ b/src/tools/shell.ts
@@ -120,6 +120,11 @@ export const BUILTIN_ALLOWLIST: ReadonlyArray<string> = [
   "mypy",
 ];
 
+/** Inside `"…"` only `\"` and `\\` are escapes — `\X` otherwise stays literal so Windows paths like `"C:\Users\foo\.bar"` survive tokenization. */
+export function isDqEscape(prev: string, next: string | undefined): boolean {
+  return prev === "\\" && (next === '"' || next === "\\");
+}
+
 /** No env / glob / backtick / `$(…)` expansion — prevents bypass of allowlist via concatenation. */
 export function tokenizeCommand(cmd: string): string[] {
   const out: string[] = [];
@@ -130,7 +135,7 @@ export function tokenizeCommand(cmd: string): string[] {
     if (quote) {
       if (ch === quote) {
         quote = null;
-      } else if (ch === "\\" && quote === '"' && i + 1 < cmd.length) {
+      } else if (quote === '"' && isDqEscape(ch, cmd[i + 1])) {
         cur += cmd[++i];
       } else {
         cur += ch;
@@ -174,7 +179,7 @@ export function detectShellOperator(cmd: string): string | null {
     if (quote) {
       if (ch === quote) {
         quote = null;
-      } else if (ch === "\\" && quote === '"' && i + 1 < cmd.length) {
+      } else if (quote === '"' && isDqEscape(ch, cmd[i + 1])) {
         cur += cmd[++i];
         curQuoted = true;
       } else {

--- a/tests/shell-tools.test.ts
+++ b/tests/shell-tools.test.ts
@@ -56,6 +56,17 @@ describe("tokenizeCommand", () => {
     expect(tokenizeCommand('echo "a \\"b\\" c"')).toEqual(["echo", 'a "b" c']);
   });
 
+  // Issue #265 — `\` was eaten as a generic escape inside `"..."`, so
+  // Windows path separators got dropped (`thron\.reasonix` → `thron.reasonix`).
+  // Only `\"` and `\\` are escapes now; everything else is literal.
+  it("preserves Windows path backslashes inside double quotes", () => {
+    expect(tokenizeCommand('dir /b "C:\\Users\\thron\\.reasonix"')).toEqual([
+      "dir",
+      "/b",
+      "C:\\Users\\thron\\.reasonix",
+    ]);
+  });
+
   it("rejects unclosed quotes", () => {
     expect(() => tokenizeCommand('grep "unclosed')).toThrow(/unclosed/);
     expect(() => tokenizeCommand("grep 'unclosed")).toThrow(/unclosed/);
@@ -701,6 +712,18 @@ describe("prepareSpawn", () => {
       isFile: (p) => hits.has(p),
     });
     expect(out.args[3]).toBe('chcp 65001 >nul & C:\\tools\\tool.CMD "a&b" "c|d"');
+  });
+
+  it("preserves Windows path backslashes through tokenize → prepareSpawn (issue #265)", () => {
+    const argv = tokenizeCommand('dir /b "C:\\Users\\thron\\.reasonix"');
+    const out = prepareSpawn(argv, {
+      platform: "win32",
+      env: { PATH: "C:\\nope", PATHEXT: ".EXE" },
+      pathDelimiter: ";",
+      isFile: () => false,
+    });
+    expect(out.bin).toBe("cmd.exe");
+    expect(out.args[3]).toBe("chcp 65001 >nul & dir /b C:\\Users\\thron\\.reasonix");
   });
 
   it("routes bare unresolved Windows commands through cmd.exe (builtins)", () => {


### PR DESCRIPTION
## Summary

- `tokenizeCommand` was treating any `\X` inside `"…"` as a generic escape and dropping the backslash, so `dir /b "C:\Users\foo\.bar"` ran against `C:\Users\foo.bar` (issue #265).
- Restrict the escape rule to `\"` and `\` only — every other `\X` stays literal so Windows path separators survive tokenization.
- Same bug existed in `detectShellOperator`, `splitOnChainOps`, and `parseSegment`. Extracted a single `isDqEscape` helper so all four sites share the rule.

## Test plan

- [x] Existing tokenizer / chain / spawn tests still pass (87/87 in `tests/shell-tools.test.ts`).
- [x] New regression: `tokenizeCommand('dir /b "C:\Users\thron\.reasonix"')` → `["dir","/b","C:\Users\thron\.reasonix"]`.
- [x] New regression: full pipe through `prepareSpawn({ platform: "win32" })` produces `cmd.exe /d /s /c chcp 65001 >/dev/null & dir /b C:\Users\thron\.reasonix`.

Closes #265