### PR TITLE
fix(filesystem): slash-normalize tool output paths

### DIFF
--- a/src/tools/filesystem.ts
+++ b/src/tools/filesystem.ts
@@ -30,6 +30,10 @@ const SKIP_DIR_NAMES: ReadonlySet<string> = new Set(DEFAULT_INDEX_EXCLUDES.dirs)
 /** First line of binary defense; NUL-byte sniff is the second (catches mislabeled `.txt`). */
 const BINARY_EXTENSIONS: ReadonlySet<string> = new Set(DEFAULT_INDEX_EXCLUDES.exts);
 
+export function displayRel(rootDir: string, full: string): string {
+  return pathMod.relative(rootDir, full).replaceAll("\\", "/");
+}
+
 function isLikelyBinaryByName(name: string): boolean {
   const dot = name.lastIndexOf(".");
   if (dot < 0) return false;
@@ -319,7 +323,7 @@ Prefer \`list_directory\` for a single-level view, \`search_files\` to find spec
           const lower = e.name.toLowerCase();
           const hit = re ? re.test(e.name) : lower.includes(needle);
           if (hit) {
-            const rel = pathMod.relative(rootDir, full);
+            const rel = displayRel(rootDir, full);
             if (totalBytes + rel.length + 1 > maxListBytes) {
               matches.push("[… search truncated — refine pattern …]");
               return;
@@ -436,7 +440,7 @@ Prefer \`list_directory\` for a single-level view, \`search_files\` to find spec
           const firstNul = raw.indexOf(0);
           if (firstNul !== -1 && firstNul < 8 * 1024) continue;
           const text = raw.toString("utf8");
-          const rel = pathMod.relative(rootDir, full);
+          const rel = displayRel(rootDir, full);
           const lines = text.split(/\r?\n/);
           for (let li = 0; li < lines.length; li++) {
             const line = lines[li]!;
@@ -510,7 +514,7 @@ Prefer \`list_directory\` for a single-level view, \`search_files\` to find spec
       const abs = safePath(args.path);
       await fs.mkdir(pathMod.dirname(abs), { recursive: true });
       await fs.writeFile(abs, args.content, "utf8");
-      return `wrote ${args.content.length} chars to ${pathMod.relative(rootDir, abs)}`;
+      return `wrote ${args.content.length} chars to ${displayRel(rootDir, abs)}`;
     },
   });
 
@@ -538,18 +542,18 @@ Prefer \`list_directory\` for a single-level view, \`search_files\` to find spec
       const adaptedReplace = args.replace.replace(/\r?\n/g, le);
       const firstIdx = before.indexOf(adaptedSearch);
       if (firstIdx < 0) {
-        throw new Error(`edit_file: search text not found in ${pathMod.relative(rootDir, abs)}`);
+        throw new Error(`edit_file: search text not found in ${displayRel(rootDir, abs)}`);
       }
       const nextIdx = before.indexOf(adaptedSearch, firstIdx + 1);
       if (nextIdx >= 0) {
         throw new Error(
-          `edit_file: search text appears multiple times in ${pathMod.relative(rootDir, abs)} — include more context to disambiguate`,
+          `edit_file: search text appears multiple times in ${displayRel(rootDir, abs)} — include more context to disambiguate`,
         );
       }
       const after =
         before.slice(0, firstIdx) + adaptedReplace + before.slice(firstIdx + adaptedSearch.length);
       await fs.writeFile(abs, after, "utf8");
-      const rel = pathMod.relative(rootDir, abs);
+      const rel = displayRel(rootDir, abs);
       const header = `edited ${rel} (${adaptedSearch.length}→${adaptedReplace.length} chars)`;
       const startLine = before.slice(0, firstIdx).split(/\r?\n/).length;
       const diff = renderEditDiff(adaptedSearch, adaptedReplace, startLine);
@@ -568,7 +572,7 @@ Prefer \`list_directory\` for a single-level view, \`search_files\` to find spec
     fn: async (args: { path: string }) => {
       const abs = safePath(args.path);
       await fs.mkdir(abs, { recursive: true });
-      return `created ${pathMod.relative(rootDir, abs)}/`;
+      return `created ${displayRel(rootDir, abs)}/`;
     },
   });
 
@@ -588,7 +592,7 @@ Prefer \`list_directory\` for a single-level view, \`search_files\` to find spec
       const dst = safePath(args.destination);
       await fs.mkdir(pathMod.dirname(dst), { recursive: true });
       await fs.rename(src, dst);
-      return `moved ${pathMod.relative(rootDir, src)} → ${pathMod.relative(rootDir, dst)}`;
+      return `moved ${displayRel(rootDir, src)} → ${displayRel(rootDir, dst)}`;
     },
   });
 

--- a/tests/filesystem-tools.test.ts
+++ b/tests/filesystem-tools.test.ts
@@ -5,6 +5,7 @@ import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ToolRegistry } from "../src/tools.js";
 import { lineDiff, registerFilesystemTools } from "../src/tools/filesystem.js";
+import { displayRel } from "../src/tools/filesystem.js";
 
 describe("filesystem tools (built-in, sandbox-enforced)", () => {
   let root: string;
@@ -242,6 +243,14 @@ describe("filesystem tools (built-in, sandbox-enforced)", () => {
       expect(out).not.toMatch(/escapes sandbox/);
       expect(out).toContain("util.ts");
     });
+
+    it("returns slash-normalized paths (no backslashes)", async () => {
+      await fs.mkdir(join(root, "src", "cli", "ui"), { recursive: true });
+      await fs.writeFile(join(root, "src", "cli", "ui", "App.tsx"), "// app\n");
+      const out = await tools.dispatch("search_files", JSON.stringify({ pattern: "App" }));
+      expect(out).toContain("src/cli/ui/App.tsx");
+      expect(out).not.toMatch(/src[\\]cli/);
+    });
   });
 
   describe("search_content", () => {
@@ -251,8 +260,8 @@ describe("filesystem tools (built-in, sandbox-enforced)", () => {
         "search_content",
         JSON.stringify({ pattern: "export const x" }),
       );
-      // Format: path:line: text
-      expect(out).toMatch(/src[\\/]index\.ts:1: export const x = 1;/);
+      // Format: path:line: text (always slash-normalized)
+      expect(out).toMatch(/src\/index\.ts:1: export const x = 1;/);
     });
 
     it("matches across multiple files and reports each line", async () => {
@@ -342,6 +351,17 @@ describe("filesystem tools (built-in, sandbox-enforced)", () => {
       );
       expect(out).toMatch(/no matches/);
     });
+
+    it("returns slash-normalized path prefixes (no backslashes)", async () => {
+      await fs.mkdir(join(root, "src", "cli", "ui"), { recursive: true });
+      await fs.writeFile(join(root, "src", "cli", "ui", "App.tsx"), "UNIQUE_MARKER_42\n");
+      const out = await tools.dispatch(
+        "search_content",
+        JSON.stringify({ pattern: "UNIQUE_MARKER_42" }),
+      );
+      expect(out).toMatch(/src\/cli\/ui\/App\.tsx:1:/);
+      expect(out).not.toMatch(/src[\\]cli/);
+    });
   });
 
   describe("get_file_info", () => {
@@ -374,6 +394,16 @@ describe("filesystem tools (built-in, sandbox-enforced)", () => {
       await tools.dispatch("write_file", JSON.stringify({ path: "a/b/c/deep.txt", content: "x" }));
       const disk = await fs.readFile(join(root, "a", "b", "c", "deep.txt"), "utf8");
       expect(disk).toBe("x");
+    });
+
+    it("returns slash-normalized path in output", async () => {
+      await fs.mkdir(join(root, "src", "cli"), { recursive: true });
+      const out = await tools.dispatch(
+        "write_file",
+        JSON.stringify({ path: "src/cli/new.ts", content: "export {}" }),
+      );
+      expect(out).toContain("src/cli/new.ts");
+      expect(out).not.toMatch(/src[\\]cli/);
     });
 
     it("rejects writes outside the sandbox", async () => {
@@ -608,5 +638,23 @@ describe("lineDiff — LCS line-level diff used by edit_file", () => {
     expect(d[0]!.line).toContain("prestigePointsGainElement");
     // The rest are pure additions.
     expect(d.slice(1).every((o) => o.op === "+")).toBe(true);
+  });
+});
+
+describe("displayRel — slash-normalized relative paths", () => {
+  it("normalizes backslashes to forward slashes", () => {
+    const root = "C:\\root";
+    const full = "C:\\root\\src\\cli\\ui\\App.tsx";
+    const result = displayRel(root, full);
+    expect(result).not.toContain("\\");
+    expect(result).toContain("/");
+  });
+
+  it("returns forward-slash paths on POSIX systems", () => {
+    const root = "/tmp/test-root";
+    const full = "/tmp/test-root/src/foo.ts";
+    const result = displayRel(root, full);
+    expect(result).toBe("src/foo.ts");
+    expect(result).not.toContain("\\");
   });
 });


### PR DESCRIPTION
## Summary

Fixes #269.

Filesystem tools were returning platform-native relative paths in their output. On Windows that can produce paths like `src\tools\filesystem.ts`, which are easy for the model to copy into a later JSON tool call incorrectly because backslashes can become JSON escapes.

This PR normalizes relative paths in filesystem tool output to forward slashes.

## What changed

- Add a small `displayRel()` helper for slash-normalized relative output paths.
- Use it for filesystem tool output paths from search/edit/write/create/move flows.
- Add regression coverage for search output and helper behavior.

## What did not change

- Sandbox path resolution is unchanged.
- Search matching and traversal behavior are unchanged.
- Shell parsing is unchanged.
- Dependency/build-dir skipping is unchanged.

## Verification

Local verification was run before opening this PR.