### PR TITLE
fix(settings): preserve lang in combined settings POST

### DIFF
--- a/src/server/api/settings.ts
+++ b/src/server/api/settings.ts
@@ -1,15 +1,7 @@
 /** apiKey is write-only on the wire; GET always returns a redacted form so dashboard screenshots don't leak credentials. */
 
-import {
-  isPlausibleKey,
-  readConfig,
-  redactKey,
-  saveApiKey,
-  saveEditMode,
-  saveReasoningEffort,
-  writeConfig,
-} from "../../config.js";
-import { getLanguage, getSupportedLanguages, setLanguage } from "../../i18n/index.js";
+import { isPlausibleKey, readConfig, redactKey, saveEditMode, writeConfig } from "../../config.js";
+import { getLanguage, getSupportedLanguages, setLanguageRuntime } from "../../i18n/index.js";
 import type { LanguageCode } from "../../i18n/types.js";
 import type { DashboardContext } from "../context.js";
 import type { ApiResult } from "../router.js";
@@ -76,6 +68,7 @@ export async function handleSettings(
     const fields = parseBody(body);
     const cfg = readConfig(ctx.configPath);
     const changed: string[] = [];
+    let cfgDirty = false;
 
     if (fields.lang !== undefined) {
       const raw = String(fields.lang);
@@ -86,37 +79,43 @@ export async function handleSettings(
       if (!langCode) {
         return { status: 400, body: { error: `lang must be one of: ${supported.join(", ")}` } };
       }
-      setLanguage(langCode);
+      cfg.lang = langCode;
+      setLanguageRuntime(langCode);
+      cfgDirty = true;
       changed.push("lang");
     }
+
     if (fields.apiKey !== undefined) {
       if (typeof fields.apiKey !== "string" || !isPlausibleKey(fields.apiKey)) {
         return { status: 400, body: { error: "apiKey must be a plausible sk- token" } };
       }
-      // saveApiKey reads + writes the entire file with chmod 600.
-      saveApiKey(fields.apiKey, ctx.configPath);
+      cfg.apiKey = fields.apiKey.trim();
+      cfgDirty = true;
       changed.push("apiKey");
     }
+
     if (fields.baseUrl !== undefined) {
       if (typeof fields.baseUrl !== "string" || !fields.baseUrl.trim()) {
         return { status: 400, body: { error: "baseUrl must be a non-empty string" } };
       }
       cfg.baseUrl = fields.baseUrl.trim();
-      writeConfig(cfg, ctx.configPath);
+      cfgDirty = true;
       changed.push("baseUrl");
     }
+
     if (fields.preset !== undefined) {
       if (typeof fields.preset !== "string" || !VALID_PRESETS.has(fields.preset)) {
         return { status: 400, body: { error: "preset must be auto | flash | pro" } };
       }
       cfg.preset = fields.preset as "auto" | "flash" | "pro" | "fast" | "smart" | "max";
-      writeConfig(cfg, ctx.configPath);
+      cfgDirty = true;
+      changed.push("preset");
       // Apply to the LIVE loop too so the user doesn't have to restart
       // their session to feel the change. The callback canonicalizes
       // legacy aliases via resolvePreset internally.
       ctx.applyPresetLive?.(fields.preset);
-      changed.push("preset");
     }
+
     if (fields.reasoningEffort !== undefined) {
       if (
         typeof fields.reasoningEffort !== "string" ||
@@ -124,17 +123,23 @@ export async function handleSettings(
       ) {
         return { status: 400, body: { error: "reasoningEffort must be high | max" } };
       }
-      saveReasoningEffort(fields.reasoningEffort as "high" | "max", ctx.configPath);
-      ctx.applyEffortLive?.(fields.reasoningEffort as "high" | "max");
+      cfg.reasoningEffort = fields.reasoningEffort as "high" | "max";
+      cfgDirty = true;
       changed.push("reasoningEffort");
+      ctx.applyEffortLive?.(fields.reasoningEffort as "high" | "max");
     }
+
     if (fields.search !== undefined) {
       if (typeof fields.search !== "boolean") {
         return { status: 400, body: { error: "search must be a boolean" } };
       }
       cfg.search = fields.search;
-      writeConfig(cfg, ctx.configPath);
+      cfgDirty = true;
       changed.push("search");
+    }
+
+    if (cfgDirty) {
+      writeConfig(cfg, ctx.configPath);
     }
 
     if (changed.length > 0) {

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -1,0 +1,170 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  type DashboardServerHandle,
+  startDashboardServer,
+} from "../src/server/index.js";
+
+const TOKEN = "f".repeat(64);
+
+async function api(
+  base: string,
+  path: string,
+  opts: { method?: string; body?: unknown } = {},
+): Promise<{ status: number; body: unknown }> {
+  const url = new URL(`${base}${path}`);
+  const method = opts.method ?? "GET";
+  const headers: Record<string, string> = {};
+  if (method === "GET") {
+    url.searchParams.set("token", TOKEN);
+  } else {
+    headers["X-Reasonix-Token"] = TOKEN;
+  }
+  if (opts.body !== undefined) headers["Content-Type"] = "application/json";
+  const res = await fetch(url.toString(), {
+    method,
+    headers,
+    body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+  });
+  const text = await res.text();
+  let parsed: unknown = null;
+  try {
+    parsed = text ? JSON.parse(text) : null;
+  } catch {
+    parsed = text;
+  }
+  return { status: res.status, body: parsed };
+}
+
+function readConfigFile(path: string): Record<string, unknown> {
+  try {
+    return JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+describe("settings API: combined POST persistence", () => {
+  let dir: string;
+  let cfgPath: string;
+  let usagePath: string;
+  let handle: DashboardServerHandle | null = null;
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "reasonix-settings-"));
+    cfgPath = join(dir, "config.json");
+    usagePath = join(dir, "usage.jsonl");
+    handle = await startDashboardServer(
+      {
+        mode: "standalone",
+        configPath: cfgPath,
+        usageLogPath: usagePath,
+      },
+      { token: TOKEN },
+    );
+  });
+
+  afterEach(async () => {
+    await handle?.close();
+    if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  function baseUrl(): string {
+    return handle!.url.split("?")[0]!;
+  }
+
+  function post(body: unknown) {
+    const u = new URL(`${baseUrl()}api/settings`);
+    const headers: Record<string, string> = {
+      "X-Reasonix-Token": TOKEN,
+      "Content-Type": "application/json",
+    };
+    return fetch(u.toString(), {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    }).then(async (r) => ({ status: r.status, body: await r.json().catch(() => null) as unknown }));
+  }
+
+  function get() {
+    const u = new URL(`${baseUrl()}api/settings`);
+    u.searchParams.set("token", TOKEN);
+    return fetch(u.toString()).then(async (r) => ({
+      status: r.status,
+      body: (await r.json().catch(() => null)) as unknown,
+    }));
+  }
+
+  it("lang-only POST persists language", async () => {
+    const r = await post({ lang: "zh-CN" });
+    expect(r.status).toBe(200);
+    expect((r.body as Record<string, unknown>).changed).toContain("lang");
+    expect(readConfigFile(cfgPath).lang).toBe("zh-CN");
+  });
+
+  it("lang + baseUrl persists both fields", async () => {
+    const r = await post({ lang: "EN", baseUrl: "https://new.example.com" });
+    expect(r.status).toBe(200);
+    const cfg = readConfigFile(cfgPath);
+    expect(cfg.lang).toBe("EN");
+    expect(cfg.baseUrl).toBe("https://new.example.com");
+  });
+
+  it("lang + preset persists both fields", async () => {
+    const r = await post({ lang: "zh-CN", preset: "pro" });
+    expect(r.status).toBe(200);
+    const cfg = readConfigFile(cfgPath);
+    expect(cfg.lang).toBe("zh-CN");
+    expect(cfg.preset).toBe("pro");
+  });
+
+  it("lang + search persists both fields", async () => {
+    const r = await post({ lang: "EN", search: false });
+    expect(r.status).toBe(200);
+    const cfg = readConfigFile(cfgPath);
+    expect(cfg.lang).toBe("EN");
+    expect(cfg.search).toBe(false);
+  });
+
+  it("lang + apiKey persists both fields", async () => {
+    const r = await post({ lang: "EN", apiKey: "sk-deadbeef1234567890abcdef" });
+    expect(r.status).toBe(200);
+    const cfg = readConfigFile(cfgPath);
+    expect(cfg.lang).toBe("EN");
+    expect(cfg.apiKey).toBe("sk-deadbeef1234567890abcdef");
+  });
+
+  it("setting baseUrl does not drop existing lang", async () => {
+    writeFileSync(cfgPath, JSON.stringify({ lang: "zh-CN" }), "utf8");
+    await handle!.close();
+    handle = await startDashboardServer(
+      { mode: "standalone", configPath: cfgPath, usageLogPath: usagePath },
+      { token: TOKEN },
+    );
+    const r = await post({ baseUrl: "https://new.example.com" });
+    expect(r.status).toBe(200);
+    const cfg = readConfigFile(cfgPath);
+    expect(cfg.lang).toBe("zh-CN");
+    expect(cfg.baseUrl).toBe("https://new.example.com");
+  });
+
+  it("rejects invalid lang", async () => {
+    const r = await post({ lang: "de" });
+    expect(r.status).toBe(400);
+    expect((r.body as Record<string, unknown>).error).toContain("lang must be one of");
+  });
+
+  it("rejects invalid preset", async () => {
+    const r = await post({ preset: "turbo" });
+    expect(r.status).toBe(400);
+    expect((r.body as Record<string, unknown>).error).toContain("preset must be");
+  });
+
+  it("rejects non-boolean search", async () => {
+    const r = await post({ search: "yes" });
+    expect(r.status).toBe(400);
+    expect((r.body as Record<string, unknown>).error).toContain("search must be a boolean");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #274.

This fixes a small settings API edge case where `lang` could be saved and then dropped by a later write from the same request.

`handleSettings` now updates one shared config object and writes it once at the end, so combined settings updates compose cleanly.

## What changed

- Persist config-backed settings through one shared `cfg` object.
- Keep runtime side effects for language, preset, and reasoning effort.
- Add focused settings API tests for combined POST persistence and validation.

## Notes

- No dashboard UI changes.
- No config format changes.
- `writeConfig()` remains the final persistence path, including the existing `0600` file mode behavior.

## Verification

Local verification was run before opening this PR.