### PR TITLE
fix(filesystem): search_files skips dependency/build dirs by default

### DIFF
--- a/src/tools/filesystem.ts
+++ b/src/tools/filesystem.ts
@@ -284,7 +284,7 @@ Prefer \`list_directory\` for a single-level view, \`search_files\` to find spec
   registry.register({
     name: "search_files",
     description:
-      "Find files whose NAME matches a substring or regex. Case-insensitive. Walks the directory recursively under the sandbox root. Returns one path per line.",
+      "Find files whose NAME matches a substring or regex. Case-insensitive. Walks the directory recursively under the sandbox root. Returns one path per line. Skips dependency / VCS / build directories (node_modules, .git, dist, build, .next, target, .venv) by default.",
     readOnly: true,
     parameters: {
       type: "object",
@@ -294,12 +294,18 @@ Prefer \`list_directory\` for a single-level view, \`search_files\` to find spec
           type: "string",
           description: "Substring (or regex) to match against filenames.",
         },
+        include_deps: {
+          type: "boolean",
+          description:
+            "When true, also walk node_modules / .git / dist / build / etc. Off by default — most filename searches are about the user's own code.",
+        },
       },
       required: ["pattern"],
     },
-    fn: async (args: { path?: string; pattern: string }) => {
+    fn: async (args: { path?: string; pattern: string; include_deps?: boolean }) => {
       const startAbs = safePath(args.path ?? ".");
       const needle = args.pattern.toLowerCase();
+      const includeDeps = args.include_deps === true;
       // Try as regex first (permits users who want patterns); fall
       // back to plain substring when it's not a valid regex. Flag `i`
       // so matching is case-insensitive regardless of path.
@@ -331,7 +337,10 @@ Prefer \`list_directory\` for a single-level view, \`search_files\` to find spec
             matches.push(rel);
             totalBytes += rel.length + 1;
           }
-          if (e.isDirectory()) await walk(full);
+          if (e.isDirectory()) {
+            if (!includeDeps && SKIP_DIR_NAMES.has(e.name)) continue;
+            await walk(full);
+          }
         }
       };
       await walk(startAbs);

--- a/tests/filesystem-tools.test.ts
+++ b/tests/filesystem-tools.test.ts
@@ -251,6 +251,29 @@ describe("filesystem tools (built-in, sandbox-enforced)", () => {
       expect(out).toContain("src/cli/ui/App.tsx");
       expect(out).not.toMatch(/src[\\]cli/);
     });
+
+    it("skips dependency/build/VCS dirs by default", async () => {
+      await fs.mkdir(join(root, "node_modules", "lib"), { recursive: true });
+      await fs.writeFile(join(root, "node_modules", "lib", "marker.ts"), "x");
+      await fs.mkdir(join(root, "dist"), { recursive: true });
+      await fs.writeFile(join(root, "dist", "marker.ts"), "x");
+      await fs.mkdir(join(root, "src"), { recursive: true });
+      await fs.writeFile(join(root, "src", "marker.ts"), "x");
+      const out = await tools.dispatch("search_files", JSON.stringify({ pattern: "marker" }));
+      expect(out).toContain("src/marker.ts");
+      expect(out).not.toContain("node_modules");
+      expect(out).not.toContain("dist/marker.ts");
+    });
+
+    it("walks dependency dirs when include_deps:true", async () => {
+      await fs.mkdir(join(root, "node_modules", "lib"), { recursive: true });
+      await fs.writeFile(join(root, "node_modules", "lib", "marker.ts"), "x");
+      const out = await tools.dispatch(
+        "search_files",
+        JSON.stringify({ pattern: "marker", include_deps: true }),
+      );
+      expect(out).toContain("node_modules/lib/marker.ts");
+    });
   });
 
   describe("search_content", () => {


### PR DESCRIPTION
## Summary

Aligns `search_files` with `search_content` and `directory_tree`: skip the existing `SKIP_DIR_NAMES` set (`node_modules`, `.git`, `dist`, `build`, `.next`, `target`, `.venv`) by default, accept `include_deps: true` to opt back into walking them.

Before this PR `search_files` was the only filesystem tool that walked dependency/build trees by default — surprising mismatch with its sister tools, slow on large projects.

## Test plan

- [x] Existing 60 filesystem tests still pass.
- [x] New regression: `search_files` skips `node_modules` / `dist` matches by default.
- [x] New regression: `search_files` reaches into `node_modules` when `include_deps: true`.

Closes #267