### PR TITLE
fix(filesystem): search_content.glob accepts real glob patterns

### DIFF
--- a/src/tools/filesystem.ts
+++ b/src/tools/filesystem.ts
@@ -2,6 +2,7 @@
 
 import { promises as fs } from "node:fs";
 import * as pathMod from "node:path";
+import picomatch from "picomatch";
 import { DEFAULT_INDEX_EXCLUDES } from "../index/config.js";
 import type { ToolRegistry } from "../tools.js";
 
@@ -32,6 +33,22 @@ const BINARY_EXTENSIONS: ReadonlySet<string> = new Set(DEFAULT_INDEX_EXCLUDES.ex
 
 export function displayRel(rootDir: string, full: string): string {
   return pathMod.relative(rootDir, full).replaceAll("\\", "/");
+}
+
+const GLOB_METACHARS = /[*?{[]/;
+
+/** Glob via picomatch when metachars present, else case-insensitive substring — keeps `.ts` / `test` callers working. Slash in pattern → match rel-path; otherwise basename. */
+export function compileNameFilter(
+  filter: string | null | undefined,
+): ((name: string, rel: string) => boolean) | null {
+  if (!filter) return null;
+  if (!GLOB_METACHARS.test(filter)) {
+    const needle = filter.toLowerCase();
+    return (name) => name.toLowerCase().includes(needle);
+  }
+  const matchPath = filter.includes("/");
+  const isMatch = picomatch(filter, { dot: true, nocase: true });
+  return matchPath ? (_n, rel) => isMatch(rel) : (name) => isMatch(name);
 }
 
 function isLikelyBinaryByName(name: string): boolean {
@@ -367,7 +384,7 @@ Prefer \`list_directory\` for a single-level view, \`search_files\` to find spec
         glob: {
           type: "string",
           description:
-            "Optional file-name suffix or substring filter. Examples: '.ts' (only TypeScript), 'test' (any file with 'test' in the name). Reduces noise when you know the file shape.",
+            "Optional filename filter. Real glob when the value contains `*`, `?`, `{`, or `[` — e.g. '*.ts', '**/*.tsx', 'src/**/*.{ts,tsx}'. Plain substring otherwise — e.g. '.ts' (suffix), 'test' (anywhere in the name). Patterns containing `/` match against the path relative to the search root; otherwise just the basename.",
         },
         case_sensitive: {
           type: "boolean",
@@ -391,7 +408,7 @@ Prefer \`list_directory\` for a single-level view, \`search_files\` to find spec
       const startAbs = safePath(args.path ?? ".");
       const caseSensitive = args.case_sensitive === true;
       const includeDeps = args.include_deps === true;
-      const nameFilter = typeof args.glob === "string" ? args.glob.toLowerCase() : null;
+      const nameMatch = compileNameFilter(typeof args.glob === "string" ? args.glob : null);
       // Try the pattern as a regex first (lets the model say `\bdispatch\(`
       // for a word-bounded match); fall back to literal substring on
       // invalid regex. No `g` flag — we test once per line, so global
@@ -424,9 +441,9 @@ Prefer \`list_directory\` for a single-level view, \`search_files\` to find spec
             continue;
           }
           if (!e.isFile()) continue;
-          if (nameFilter && !e.name.toLowerCase().includes(nameFilter)) continue;
-          if (isLikelyBinaryByName(e.name)) continue;
           const full = pathMod.join(dir, e.name);
+          if (nameMatch && !nameMatch(e.name, displayRel(rootDir, full))) continue;
+          if (isLikelyBinaryByName(e.name)) continue;
           let stat: import("node:fs").Stats;
           try {
             stat = await fs.stat(full);

--- a/tests/filesystem-tools.test.ts
+++ b/tests/filesystem-tools.test.ts
@@ -5,7 +5,7 @@ import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ToolRegistry } from "../src/tools.js";
 import { lineDiff, registerFilesystemTools } from "../src/tools/filesystem.js";
-import { displayRel } from "../src/tools/filesystem.js";
+import { compileNameFilter, displayRel } from "../src/tools/filesystem.js";
 
 describe("filesystem tools (built-in, sandbox-enforced)", () => {
   let root: string;
@@ -384,6 +384,95 @@ describe("filesystem tools (built-in, sandbox-enforced)", () => {
       );
       expect(out).toMatch(/src\/cli\/ui\/App\.tsx:1:/);
       expect(out).not.toMatch(/src[\\]cli/);
+    });
+
+    describe("glob filter", () => {
+      beforeEach(async () => {
+        await fs.mkdir(join(root, "src", "ui"), { recursive: true });
+        await fs.writeFile(join(root, "src", "alpha.ts"), "TARGETSTRING\n");
+        await fs.writeFile(join(root, "src", "beta.tsx"), "TARGETSTRING\n");
+        await fs.writeFile(join(root, "src", "ui", "gamma.tsx"), "TARGETSTRING\n");
+        await fs.writeFile(join(root, "notes.md"), "TARGETSTRING\n");
+      });
+
+      it("real glob: '*.ts' matches only .ts (not .tsx)", async () => {
+        const out = await tools.dispatch(
+          "search_content",
+          JSON.stringify({ pattern: "TARGETSTRING", glob: "*.ts" }),
+        );
+        expect(out).toContain("src/alpha.ts:");
+        expect(out).not.toContain("beta.tsx");
+        expect(out).not.toContain("gamma.tsx");
+        expect(out).not.toContain("notes.md");
+      });
+
+      it("real glob: '**/*.tsx' matches across subdirs", async () => {
+        const out = await tools.dispatch(
+          "search_content",
+          JSON.stringify({ pattern: "TARGETSTRING", glob: "**/*.tsx" }),
+        );
+        expect(out).toContain("src/beta.tsx:");
+        expect(out).toContain("src/ui/gamma.tsx:");
+        expect(out).not.toContain("alpha.ts:");
+        expect(out).not.toContain("notes.md");
+      });
+
+      it("real glob: brace expansion '*.{ts,tsx}'", async () => {
+        const out = await tools.dispatch(
+          "search_content",
+          JSON.stringify({ pattern: "TARGETSTRING", glob: "*.{ts,tsx}" }),
+        );
+        expect(out).toContain("src/alpha.ts:");
+        expect(out).toContain("src/beta.tsx:");
+        expect(out).not.toContain("notes.md");
+      });
+
+      it("substring fallback: '.ts' still works (matches .ts and .tsx)", async () => {
+        const out = await tools.dispatch(
+          "search_content",
+          JSON.stringify({ pattern: "TARGETSTRING", glob: ".ts" }),
+        );
+        expect(out).toContain("src/alpha.ts:");
+        expect(out).toContain("src/beta.tsx:");
+        expect(out).not.toContain("notes.md");
+      });
+
+      it("substring fallback: 'beta' matches by basename substring", async () => {
+        const out = await tools.dispatch(
+          "search_content",
+          JSON.stringify({ pattern: "TARGETSTRING", glob: "beta" }),
+        );
+        expect(out).toContain("src/beta.tsx:");
+        expect(out).not.toContain("alpha.ts:");
+        expect(out).not.toContain("gamma.tsx:");
+      });
+    });
+  });
+
+  describe("compileNameFilter", () => {
+    it("returns null for empty / undefined input", () => {
+      expect(compileNameFilter(null)).toBeNull();
+      expect(compileNameFilter(undefined)).toBeNull();
+      expect(compileNameFilter("")).toBeNull();
+    });
+
+    it("substring path for plain strings (case-insensitive)", () => {
+      const m = compileNameFilter(".TS")!;
+      expect(m("Foo.ts", "src/Foo.ts")).toBe(true);
+      expect(m("Foo.tsx", "src/Foo.tsx")).toBe(true);
+      expect(m("Foo.md", "src/Foo.md")).toBe(false);
+    });
+
+    it("real glob path for patterns with metachars; basename match", () => {
+      const m = compileNameFilter("*.ts")!;
+      expect(m("alpha.ts", "src/alpha.ts")).toBe(true);
+      expect(m("alpha.tsx", "src/alpha.tsx")).toBe(false);
+    });
+
+    it("rel-path match when pattern contains '/'", () => {
+      const m = compileNameFilter("src/**/*.tsx")!;
+      expect(m("App.tsx", "src/cli/App.tsx")).toBe(true);
+      expect(m("App.tsx", "tests/App.tsx")).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary

`search_content.glob` was a `name.toLowerCase().includes(...)` substring filter — `*.ts` matched the literal three-char filename instead of TypeScript files. Param name advertised glob, behavior didn't.

Now real glob via `picomatch` when the value contains `*`, `?`, `{`, or `[`; case-insensitive substring otherwise so existing `.ts` / `test` callers keep working. Patterns containing `/` match against the rel-path (enables `src/**/*.tsx`), basename otherwise.

Schema description updated to spell out both modes.

## Test plan

- [x] Existing 65 filesystem tests still pass.
- [x] New: `*.ts` matches `.ts` only, not `.tsx`.
- [x] New: `**/*.tsx` matches across subdirs.
- [x] New: brace expansion `*.{ts,tsx}` works.
- [x] New: substring fallback `.ts` matches both `.ts` and `.tsx` (back-compat).
- [x] New: substring fallback `beta` matches by basename substring.
- [x] New: 4 unit tests on `compileNameFilter` pinning the helper directly.

Closes #273