### PR TITLE
fix(settings): preserve fields when settings POST writes more than one

### DIFF
--- a/src/server/api/settings.ts
+++ b/src/server/api/settings.ts
@@ -1,14 +1,6 @@
 /** apiKey is write-only on the wire; GET always returns a redacted form so dashboard screenshots don't leak credentials. */
 
-import {
-  isPlausibleKey,
-  readConfig,
-  redactKey,
-  saveApiKey,
-  saveEditMode,
-  saveReasoningEffort,
-  writeConfig,
-} from "../../config.js";
+import { isPlausibleKey, readConfig, redactKey, saveEditMode, writeConfig } from "../../config.js";
 import { getLanguage, getSupportedLanguages, setLanguage } from "../../i18n/index.js";
 import type { LanguageCode } from "../../i18n/types.js";
 import type { DashboardContext } from "../context.js";
@@ -74,8 +66,13 @@ export async function handleSettings(
 
   if (method === "POST") {
     const fields = parseBody(body);
+    // Single read up top, all field updates accumulate, single writeConfig at the end —
+    // a per-field write would clobber earlier per-field writes from the same POST.
     const cfg = readConfig(ctx.configPath);
     const changed: string[] = [];
+    let langPending: LanguageCode | null = null;
+    let presetPendingLive: string | null = null;
+    let effortPendingLive: "high" | "max" | null = null;
 
     if (fields.lang !== undefined) {
       const raw = String(fields.lang);
@@ -86,15 +83,15 @@ export async function handleSettings(
       if (!langCode) {
         return { status: 400, body: { error: `lang must be one of: ${supported.join(", ")}` } };
       }
-      setLanguage(langCode);
+      cfg.lang = langCode;
+      langPending = langCode;
       changed.push("lang");
     }
     if (fields.apiKey !== undefined) {
       if (typeof fields.apiKey !== "string" || !isPlausibleKey(fields.apiKey)) {
         return { status: 400, body: { error: "apiKey must be a plausible sk- token" } };
       }
-      // saveApiKey reads + writes the entire file with chmod 600.
-      saveApiKey(fields.apiKey, ctx.configPath);
+      cfg.apiKey = fields.apiKey.trim();
       changed.push("apiKey");
     }
     if (fields.baseUrl !== undefined) {
@@ -102,7 +99,6 @@ export async function handleSettings(
         return { status: 400, body: { error: "baseUrl must be a non-empty string" } };
       }
       cfg.baseUrl = fields.baseUrl.trim();
-      writeConfig(cfg, ctx.configPath);
       changed.push("baseUrl");
     }
     if (fields.preset !== undefined) {
@@ -110,11 +106,7 @@ export async function handleSettings(
         return { status: 400, body: { error: "preset must be auto | flash | pro" } };
       }
       cfg.preset = fields.preset as "auto" | "flash" | "pro" | "fast" | "smart" | "max";
-      writeConfig(cfg, ctx.configPath);
-      // Apply to the LIVE loop too so the user doesn't have to restart
-      // their session to feel the change. The callback canonicalizes
-      // legacy aliases via resolvePreset internally.
-      ctx.applyPresetLive?.(fields.preset);
+      presetPendingLive = fields.preset;
       changed.push("preset");
     }
     if (fields.reasoningEffort !== undefined) {
@@ -124,8 +116,8 @@ export async function handleSettings(
       ) {
         return { status: 400, body: { error: "reasoningEffort must be high | max" } };
       }
-      saveReasoningEffort(fields.reasoningEffort as "high" | "max", ctx.configPath);
-      ctx.applyEffortLive?.(fields.reasoningEffort as "high" | "max");
+      cfg.reasoningEffort = fields.reasoningEffort as "high" | "max";
+      effortPendingLive = fields.reasoningEffort as "high" | "max";
       changed.push("reasoningEffort");
     }
     if (fields.search !== undefined) {
@@ -133,11 +125,18 @@ export async function handleSettings(
         return { status: 400, body: { error: "search must be a boolean" } };
       }
       cfg.search = fields.search;
-      writeConfig(cfg, ctx.configPath);
       changed.push("search");
     }
 
     if (changed.length > 0) {
+      writeConfig(cfg, ctx.configPath);
+      // Runtime side-effects fire after the disk write succeeds —
+      // prevents an i18n change from being visible while the on-disk
+      // value still reflects the old setting (and vice-versa for
+      // preset / reasoningEffort).
+      if (langPending) setLanguage(langPending);
+      if (presetPendingLive) ctx.applyPresetLive?.(presetPendingLive);
+      if (effortPendingLive) ctx.applyEffortLive?.(effortPendingLive);
       ctx.audit?.({ ts: Date.now(), action: "set-settings", payload: { fields: changed } });
     }
     return { status: 200, body: { changed } };

--- a/tests/settings-api.test.ts
+++ b/tests/settings-api.test.ts
@@ -1,0 +1,122 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { handleSettings } from "../src/server/api/settings.js";
+import type { DashboardContext } from "../src/server/context.js";
+
+function makeCtx(configPath: string): DashboardContext {
+  return {
+    configPath,
+    usageLogPath: join(configPath, "..", "usage.json"),
+    mode: "standalone",
+  };
+}
+
+function readCfg(path: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+}
+
+describe("settings API — combined POST persistence (#274)", () => {
+  let dir: string;
+  let configPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "reasonix-settings-"));
+    configPath = join(dir, "config.json");
+    writeFileSync(configPath, JSON.stringify({ lang: "ZH", baseUrl: "https://orig" }), "utf8");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("preserves lang when posted alongside baseUrl", async () => {
+    const res = await handleSettings(
+      "POST",
+      [],
+      JSON.stringify({ lang: "EN", baseUrl: "https://example.com" }),
+      makeCtx(configPath),
+    );
+    expect(res.status).toBe(200);
+    const cfg = readCfg(configPath);
+    expect(cfg.lang).toBe("EN");
+    expect(cfg.baseUrl).toBe("https://example.com");
+  });
+
+  it("preserves all fields in a multi-field POST", async () => {
+    const res = await handleSettings(
+      "POST",
+      [],
+      JSON.stringify({
+        lang: "EN",
+        baseUrl: "https://example.com",
+        preset: "pro",
+        reasoningEffort: "high",
+        search: false,
+      }),
+      makeCtx(configPath),
+    );
+    expect(res.status).toBe(200);
+    const cfg = readCfg(configPath);
+    expect(cfg.lang).toBe("EN");
+    expect(cfg.baseUrl).toBe("https://example.com");
+    expect(cfg.preset).toBe("pro");
+    expect(cfg.reasoningEffort).toBe("high");
+    expect(cfg.search).toBe(false);
+  });
+
+  it("does not write to disk when no fields are provided", async () => {
+    const before = readFileSync(configPath, "utf8");
+    const res = await handleSettings("POST", [], JSON.stringify({}), makeCtx(configPath));
+    expect(res.status).toBe(200);
+    expect((res.body as { changed: string[] }).changed).toEqual([]);
+    expect(readFileSync(configPath, "utf8")).toBe(before);
+  });
+
+  it("rejects an invalid lang without writing other fields", async () => {
+    const res = await handleSettings(
+      "POST",
+      [],
+      JSON.stringify({ lang: "XX", baseUrl: "https://changed" }),
+      makeCtx(configPath),
+    );
+    expect(res.status).toBe(400);
+    const cfg = readCfg(configPath);
+    expect(cfg.lang).toBe("ZH");
+    expect(cfg.baseUrl).toBe("https://orig");
+  });
+
+  it("persists apiKey alongside other fields without losing them", async () => {
+    const res = await handleSettings(
+      "POST",
+      [],
+      JSON.stringify({ apiKey: "sk-1234567890abcdef", lang: "EN" }),
+      makeCtx(configPath),
+    );
+    expect(res.status).toBe(200);
+    const cfg = readCfg(configPath);
+    expect(cfg.apiKey).toBe("sk-1234567890abcdef");
+    expect(cfg.lang).toBe("EN");
+  });
+
+  it("fires applyPresetLive only after the disk write succeeds", async () => {
+    const calls: string[] = [];
+    const ctx: DashboardContext = {
+      ...makeCtx(configPath),
+      applyPresetLive: (n) => calls.push(`preset:${n}`),
+      applyEffortLive: (e) => calls.push(`effort:${e}`),
+    };
+    const res = await handleSettings(
+      "POST",
+      [],
+      JSON.stringify({ preset: "flash", reasoningEffort: "high" }),
+      ctx,
+    );
+    expect(res.status).toBe(200);
+    expect(calls).toEqual(["preset:flash", "effort:high"]);
+    const cfg = readCfg(configPath);
+    expect(cfg.preset).toBe("flash");
+    expect(cfg.reasoningEffort).toBe("high");
+  });
+});


### PR DESCRIPTION
## Summary

`handleSettings` read `cfg` once up front, then each field branch either called a self-contained helper (`setLanguage` / `saveApiKey` / `saveReasoningEffort`, each doing its own read+write) or mutated the local snapshot and called `writeConfig(cfg)`. A combined POST like `{ lang, baseUrl }` would write `lang` via the helper, then immediately clobber it with the stale snapshot in the `writeConfig` branch.

Now: single read up front, all field updates accumulate into one `cfg`, single `writeConfig` at the end. Runtime side-effects (`setLanguage`, `applyPresetLive`, `applyEffortLive`) fire after the disk write succeeds so disk + runtime state can't diverge mid-request.

## Test plan

- [x] Existing 44 dashboard server tests still pass.
- [x] New `tests/settings-api.test.ts` (6 cases):
  - lang + baseUrl → both persist
  - all five persisted fields in one POST → all persist
  - empty POST → no disk write
  - invalid lang rejected → unrelated fields unchanged
  - apiKey + lang → both persist (the case the bug originally hit)
  - applyPresetLive / applyEffortLive fire after disk write succeeds

Closes #274