### PR TITLE
chore(test): retry once on flaky tests

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,6 +16,9 @@ export default defineConfig({
     setupFiles: ["tests/setup-lang.ts"],
     environment: "node",
     globals: false,
+    // One retry absorbs Windows scheduler hiccups in jobs.test.ts / loop.test.ts /
+    // bundle-smoke (real spawns + tokenizer cold load). A real failure still re-fails.
+    retry: 1,
     coverage: {
       provider: "v8",
       reporter: ["text", "html", "json-summary"],


### PR DESCRIPTION
## Summary

`jobs.test.ts` / `loop.test.ts` / `bundle-smoke.test.ts` spawn real processes and cold-load the tokenizer. On Windows under load they intermittently miss their wall-clock budget and fail the local pre-push verify gate, even though re-running passes immediately.

`retry: 1` in `vitest.config.ts` absorbs the scheduler hiccup. A real failure still re-fails on the second run, so this doesn't mask bugs — only flake.

## Test plan

- [x] Local `npx vitest run` still passes (2325 / 1 skipped).
- Watching: pre-push verify on the next chore(release) commit should stop blowing up on the spawn-heavy tests.