### PR TITLE
fix(jobs): close stop() race condition; drop useless \$ escapes

### DIFF
--- a/benchmarks/spike-tdd-kernel/tdd-eval.mjs
+++ b/benchmarks/spike-tdd-kernel/tdd-eval.mjs
@@ -45,7 +45,7 @@ const PROMPTS = [
   { id: "m3", level: "medium", task: "A function \`debounceAsync<T extends any[], R>(fn: (...args: T) => Promise<R>, ms: number): (...args: T) => Promise<R>\` in src/util/debounce.ts. Resolves only the latest call's promise; earlier callers reject with an AbortError-like." },
 
   // hard (2) — these touch domain types from the repo
-  { id: "h1", level: "hard", task: "A function \`extractTestId(file: string, fullName: string, source: string): { id: string, source: 'native' | 'annotation' }\` in src/repair/test-id.ts. If \`source\` contains a '// @reasonix-test-id: <slug>' comment within 3 lines above an it()/test() whose name matches \`fullName\`, return that slug with source='annotation'. Otherwise return \`\${file}::\${fullName}\` with source='native'." },
+  { id: "h1", level: "hard", task: "A function \`extractTestId(file: string, fullName: string, source: string): { id: string, source: 'native' | 'annotation' }\` in src/repair/test-id.ts. If \`source\` contains a '// @reasonix-test-id: <slug>' comment within 3 lines above an it()/test() whose name matches \`fullName\`, return that slug with source='annotation'. Otherwise return \`${file}::${fullName}\` with source='native'." },
   { id: "h2", level: "hard", task: "A function \`pairRedGreen(events: Array<{type:string, test_id?:string, status?:string, ts:number}>): Array<{ test_id: string, red_ts: number, green_ts: number }>\` in src/events/pair.ts. For each test_id, find the most recent fail→pass transition and return one entry per test_id. Ignore test_ids that never went green." },
 ];
 

--- a/src/tools/jobs.ts
+++ b/src/tools/jobs.ts
@@ -160,6 +160,8 @@ export class JobRegistry {
         child: null,
         readyPromise: Promise.resolve(),
         signalReady: () => {},
+        closedPromise: Promise.resolve(),
+        signalClosed: () => {},
       };
       this.jobs.set(id, job);
       return {
@@ -177,6 +179,10 @@ export class JobRegistry {
     const readyPromise = new Promise<void>((res) => {
       readyResolve = res;
     });
+    let closedResolve: () => void = () => {};
+    const closedPromise = new Promise<void>((res) => {
+      closedResolve = res;
+    });
     const job: InternalJob = {
       id,
       command: trimmed,
@@ -189,6 +195,8 @@ export class JobRegistry {
       child,
       readyPromise,
       signalReady: readyResolve,
+      closedPromise,
+      signalClosed: closedResolve,
     };
     this.jobs.set(id, job);
 
@@ -232,11 +240,13 @@ export class JobRegistry {
       job.running = false;
       job.spawnError = err.message;
       job.signalReady();
+      job.signalClosed();
     });
     child.on("close", (code) => {
       job.running = false;
       job.exitCode = code;
       job.signalReady();
+      job.signalClosed();
     });
 
     const onAbort = () => this.stop(id, { graceMs: 100 });
@@ -308,8 +318,10 @@ export class JobRegistry {
         /* already dead — fall through */
       }
     }
-    // Wait for the close event or graceMs, then SIGKILL.
-    await Promise.race([job.readyPromise, new Promise<void>((res) => setTimeout(res, graceMs))]);
+    // closedPromise (not readyPromise) — readyPromise can have fired at
+    // startup on a ready-signal regex match, which would short-circuit
+    // this race even though the process is still alive.
+    await Promise.race([job.closedPromise, new Promise<void>((res) => setTimeout(res, graceMs))]);
     if (job.running) {
       if (job.pid !== null) {
         killProcessTree(job.pid, "SIGKILL");
@@ -320,10 +332,10 @@ export class JobRegistry {
           /* ignore */
         }
       }
-      // Give the OS a moment to reap the tree so our exitCode field
-      // catches it before we return. Windows taskkill can take up to
-      // ~700ms to propagate on a three-level tree (npm → node → vite).
-      await new Promise<void>((res) => setTimeout(res, 800));
+      // Wait for the actual close handler — a fixed timer can return
+      // before Node's `close` event fires under load (Windows taskkill
+      // /T /F on a three-level tree can take ~1s to propagate).
+      await Promise.race([job.closedPromise, new Promise<void>((res) => setTimeout(res, 5000))]);
     }
     return snapshot(job);
   }
@@ -387,6 +399,9 @@ interface InternalJob extends JobRecord {
   readyPromise: Promise<void>;
   /** Fires readyPromise — called by ready-signal OR close/error handlers. */
   signalReady: () => void;
+  /** Resolves only on close/error — never on ready-signal. Used by stop() to wait for actual exit. */
+  closedPromise: Promise<void>;
+  signalClosed: () => void;
 }
 
 export interface JobReadResult {


### PR DESCRIPTION
Two small fixes that came up while validating the file-split PRs against CI:

## 1. `stop() kills a running job` was actually flaky, not just unlucky

`tests/jobs.test.ts` has been retried once on every CI run because of a "Windows scheduler hiccup." Reading the code, it's not a hiccup — `stop()` had two real timing races, both of which let the snapshot return `running: true` even when the test had just told us to stop the job:

1. **SIGKILL phase used a fixed 800ms timer**, then returned regardless of whether Node's `close` event had fired. On Windows, `taskkill /T /F` against a 3-level tree (npm → node → vite) routinely takes over a second to propagate.
2. **SIGTERM phase awaited `readyPromise`**, which is dual-purpose — it fires on either a startup ready-signal regex match OR child exit. If the job had already matched a ready signal at startup, `readyPromise` was already resolved, so the SIGTERM grace race short-circuited immediately and we'd jump to SIGKILL with zero pause.

Adds `closedPromise` — fires only on close/error, never on ready signal — and uses it for both the SIGTERM grace race and the post-SIGKILL wait, with a 5s ceiling on the latter so a wedged kernel can't hang us indefinitely.

After the fix, three full `npm test` runs back-to-back all green, no retries needed.

## 2. CodeQL error: useless `\$` escape in benchmark prompt

`benchmarks/spike-tdd-kernel/tdd-eval.mjs:48` had `\${file}::\${fullName}` inside a regular `"..."` literal. The backslashes were no-ops (JS quietly drops unrecognized escapes in regular strings) but tripped CodeQL's `js/useless-regexp-character-escape` rule. Identical resulting string, cleaner source.

## Acceptance

- [x] `npm run verify` green, three runs in a row
- [x] No public API change
- [x] Two atomic commits — review one or the other independently