### PR TITLE
chore(tsconfig): add @/* path alias for src; migrate slash handlers

### DIFF
--- a/src/cli/ui/slash/handlers/admin.ts
+++ b/src/cli/ui/slash/handlers/admin.ts
@@ -4,10 +4,10 @@ import {
   type ResolvedHook,
   globalSettingsPath,
   projectSettingsPath,
-} from "../../../../hooks.js";
-import { t } from "../../../../i18n/index.js";
-import { aggregateUsage, defaultUsageLogPath, readUsageLog } from "../../../../telemetry/usage.js";
-import { VERSION, compareVersions, isNpxInstall } from "../../../../version.js";
+} from "@/hooks.js";
+import { t } from "@/i18n/index.js";
+import { aggregateUsage, defaultUsageLogPath, readUsageLog } from "@/telemetry/usage.js";
+import { VERSION, compareVersions, isNpxInstall } from "@/version.js";
 import { runDoctorChecks } from "../../../commands/doctor.js";
 import { renderDashboard } from "../../../commands/stats.js";
 import type { SlashHandler } from "../dispatch.js";

--- a/src/cli/ui/slash/handlers/basic.ts
+++ b/src/cli/ui/slash/handlers/basic.ts
@@ -1,4 +1,4 @@
-import { t } from "../../../../i18n/index.js";
+import { t } from "@/i18n/index.js";
 import { formatDuration, formatLoopStatus, parseLoopCommand } from "../../loop.js";
 import type { SlashHandler } from "../dispatch.js";
 

--- a/src/cli/ui/slash/handlers/dashboard.ts
+++ b/src/cli/ui/slash/handlers/dashboard.ts
@@ -1,4 +1,4 @@
-import { t } from "../../../../i18n/index.js";
+import { t } from "@/i18n/index.js";
 import type { SlashHandler } from "../dispatch.js";
 
 const dashboard: SlashHandler = (args, _loop, ctx) => {

--- a/src/cli/ui/slash/handlers/edits.ts
+++ b/src/cli/ui/slash/handlers/edits.ts
@@ -5,9 +5,9 @@ import {
   fmtAgo,
   listCheckpoints,
   restoreCheckpoint,
-} from "../../../../code/checkpoints.js";
-import type { EditMode } from "../../../../config.js";
-import { t } from "../../../../i18n/index.js";
+} from "@/code/checkpoints.js";
+import type { EditMode } from "@/config.js";
+import { t } from "@/i18n/index.js";
 import { parseEditIndices } from "../../edit-history.js";
 import type { SlashHandler } from "../dispatch.js";
 import { runGitCommit, stripOuterQuotes } from "../helpers.js";

--- a/src/cli/ui/slash/handlers/init.ts
+++ b/src/cli/ui/slash/handlers/init.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import * as pathMod from "node:path";
-import { t } from "../../../../i18n/index.js";
+import { t } from "@/i18n/index.js";
 import type { SlashHandler } from "../dispatch.js";
 
 const INIT_PROMPT = [

--- a/src/cli/ui/slash/handlers/jobs.ts
+++ b/src/cli/ui/slash/handlers/jobs.ts
@@ -1,5 +1,5 @@
-import { t } from "../../../../i18n/index.js";
-import type { JobRecord } from "../../../../tools/jobs.js";
+import { t } from "@/i18n/index.js";
+import type { JobRecord } from "@/tools/jobs.js";
 import type { SlashHandler } from "../dispatch.js";
 
 function statusIcon(r: JobRecord): string {

--- a/src/cli/ui/slash/handlers/language.ts
+++ b/src/cli/ui/slash/handlers/language.ts
@@ -1,10 +1,5 @@
-import {
-  getSupportedLanguages,
-  notifyLanguageChange,
-  setLanguage,
-  t,
-} from "../../../../i18n/index.js";
-import type { LanguageCode } from "../../../../i18n/types.js";
+import { getSupportedLanguages, notifyLanguageChange, setLanguage, t } from "@/i18n/index.js";
+import type { LanguageCode } from "@/i18n/types.js";
 import type { SlashHandler } from "../dispatch.js";
 
 export const handlers: Record<string, SlashHandler> = {

--- a/src/cli/ui/slash/handlers/mcp.ts
+++ b/src/cli/ui/slash/handlers/mcp.ts
@@ -1,5 +1,5 @@
-import { t } from "../../../../i18n/index.js";
-import type { CacheFirstLoop } from "../../../../loop.js";
+import { t } from "@/i18n/index.js";
+import type { CacheFirstLoop } from "@/loop.js";
 import { applyMcpAppend } from "../../mcp-append.js";
 import { toggleMcpDisabled } from "../../mcp-disable.js";
 import { slashHealthBadge } from "../../mcp-health.js";

--- a/src/cli/ui/slash/handlers/memory.ts
+++ b/src/cli/ui/slash/handlers/memory.ts
@@ -1,10 +1,6 @@
-import { t } from "../../../../i18n/index.js";
-import {
-  PROJECT_MEMORY_FILE,
-  memoryEnabled,
-  readProjectMemory,
-} from "../../../../memory/project.js";
-import { type MemoryScope, MemoryStore } from "../../../../memory/user.js";
+import { t } from "@/i18n/index.js";
+import { PROJECT_MEMORY_FILE, memoryEnabled, readProjectMemory } from "@/memory/project.js";
+import { type MemoryScope, MemoryStore } from "@/memory/user.js";
 import type { SlashHandler } from "../dispatch.js";
 import { resolveMemoryTarget } from "../helpers.js";
 

--- a/src/cli/ui/slash/handlers/model.ts
+++ b/src/cli/ui/slash/handlers/model.ts
@@ -1,5 +1,5 @@
-import { saveReasoningEffort } from "../../../../config.js";
-import { t } from "../../../../i18n/index.js";
+import { saveReasoningEffort } from "@/config.js";
+import { t } from "@/i18n/index.js";
 import { PRESETS } from "../../presets.js";
 import type { SlashHandler } from "../dispatch.js";
 

--- a/src/cli/ui/slash/handlers/observability.ts
+++ b/src/cli/ui/slash/handlers/observability.ts
@@ -1,10 +1,10 @@
-import { t } from "../../../../i18n/index.js";
+import { t } from "@/i18n/index.js";
 import {
   DEEPSEEK_CONTEXT_TOKENS,
   DEEPSEEK_PRICING,
   DEFAULT_CONTEXT_TOKENS,
-} from "../../../../telemetry/stats.js";
-import { countTokens } from "../../../../tokenizer.js";
+} from "@/telemetry/stats.js";
+import { countTokens } from "@/tokenizer.js";
 import { computeCtxBreakdown } from "../../ctx-breakdown.js";
 import type { SlashHandler } from "../dispatch.js";
 import { compactNum, formatToolList } from "../helpers.js";
@@ -208,7 +208,7 @@ const cost: SlashHandler = (args, loop, ctx) => {
   return {};
 };
 
-function estimateCost(userText: string, loop: import("../../../../loop.js").CacheFirstLoop) {
+function estimateCost(userText: string, loop: import("@/loop.js").CacheFirstLoop) {
   const pricing = DEEPSEEK_PRICING[loop.model];
   if (!pricing) {
     return { info: t("handlers.observability.costNoPricing", { model: loop.model }) };

--- a/src/cli/ui/slash/handlers/permissions.ts
+++ b/src/cli/ui/slash/handlers/permissions.ts
@@ -3,9 +3,9 @@ import {
   clearProjectShellAllowed,
   loadProjectShellAllowed,
   removeProjectShellAllowed,
-} from "../../../../config.js";
-import { t } from "../../../../i18n/index.js";
-import { BUILTIN_ALLOWLIST } from "../../../../tools/shell.js";
+} from "@/config.js";
+import { t } from "@/i18n/index.js";
+import { BUILTIN_ALLOWLIST } from "@/tools/shell.js";
 import type { SlashHandler } from "../dispatch.js";
 
 const permissions: SlashHandler = (args, _loop, ctx) => {

--- a/src/cli/ui/slash/handlers/plans.ts
+++ b/src/cli/ui/slash/handlers/plans.ts
@@ -1,6 +1,6 @@
 import { basename } from "node:path";
-import { listPlanArchives, loadPlanState, relativeTime } from "../../../../code/plan-store.js";
-import { t } from "../../../../i18n/index.js";
+import { listPlanArchives, loadPlanState, relativeTime } from "@/code/plan-store.js";
+import { t } from "@/i18n/index.js";
 import type { SlashHandler } from "../dispatch.js";
 
 const plans: SlashHandler = (_args, loop) => {

--- a/src/cli/ui/slash/handlers/semantic.ts
+++ b/src/cli/ui/slash/handlers/semantic.ts
@@ -2,9 +2,9 @@
 
 import { promises as fs } from "node:fs";
 import path from "node:path";
-import { probeOllama } from "../../../../index/semantic/embedding.js";
-import { t } from "../../../../index/semantic/i18n.js";
-import { findOllamaBinary } from "../../../../index/semantic/ollama-launcher.js";
+import { probeOllama } from "@/index/semantic/embedding.js";
+import { t } from "@/index/semantic/i18n.js";
+import { findOllamaBinary } from "@/index/semantic/ollama-launcher.js";
 import type { SlashHandler } from "../dispatch.js";
 
 const semantic: SlashHandler = (_args, _loop, ctx) => {

--- a/src/cli/ui/slash/handlers/sessions.ts
+++ b/src/cli/ui/slash/handlers/sessions.ts
@@ -1,5 +1,5 @@
-import { t } from "../../../../i18n/index.js";
-import { deleteSession, listSessions, renameSession } from "../../../../memory/session.js";
+import { t } from "@/i18n/index.js";
+import { deleteSession, listSessions, renameSession } from "@/memory/session.js";
 import type { SlashHandler } from "../dispatch.js";
 
 const sessions: SlashHandler = () => ({ openSessionsPicker: true });

--- a/src/cli/ui/slash/handlers/skill.ts
+++ b/src/cli/ui/slash/handlers/skill.ts
@@ -1,5 +1,5 @@
-import { t } from "../../../../i18n/index.js";
-import { SkillStore } from "../../../../skills.js";
+import { t } from "@/i18n/index.js";
+import { SkillStore } from "@/skills.js";
 import type { SlashHandler } from "../dispatch.js";
 
 const skill: SlashHandler = (args, _loop, ctx) => {

--- a/src/tools/jobs.ts
+++ b/src/tools/jobs.ts
@@ -160,6 +160,8 @@ export class JobRegistry {
         child: null,
         readyPromise: Promise.resolve(),
         signalReady: () => {},
+        closedPromise: Promise.resolve(),
+        signalClosed: () => {},
       };
       this.jobs.set(id, job);
       return {
@@ -177,6 +179,10 @@ export class JobRegistry {
     const readyPromise = new Promise<void>((res) => {
       readyResolve = res;
     });
+    let closedResolve: () => void = () => {};
+    const closedPromise = new Promise<void>((res) => {
+      closedResolve = res;
+    });
     const job: InternalJob = {
       id,
       command: trimmed,
@@ -189,6 +195,8 @@ export class JobRegistry {
       child,
       readyPromise,
       signalReady: readyResolve,
+      closedPromise,
+      signalClosed: closedResolve,
     };
     this.jobs.set(id, job);
 
@@ -232,11 +240,13 @@ export class JobRegistry {
       job.running = false;
       job.spawnError = err.message;
       job.signalReady();
+      job.signalClosed();
     });
     child.on("close", (code) => {
       job.running = false;
       job.exitCode = code;
       job.signalReady();
+      job.signalClosed();
     });
 
     const onAbort = () => this.stop(id, { graceMs: 100 });
@@ -308,8 +318,10 @@ export class JobRegistry {
         /* already dead — fall through */
       }
     }
-    // Wait for the close event or graceMs, then SIGKILL.
-    await Promise.race([job.readyPromise, new Promise<void>((res) => setTimeout(res, graceMs))]);
+    // closedPromise (not readyPromise) — readyPromise can have fired at
+    // startup on a ready-signal regex match, which would short-circuit
+    // this race even though the process is still alive.
+    await Promise.race([job.closedPromise, new Promise<void>((res) => setTimeout(res, graceMs))]);
     if (job.running) {
       if (job.pid !== null) {
         killProcessTree(job.pid, "SIGKILL");
@@ -320,10 +332,10 @@ export class JobRegistry {
           /* ignore */
         }
       }
-      // Give the OS a moment to reap the tree so our exitCode field
-      // catches it before we return. Windows taskkill can take up to
-      // ~700ms to propagate on a three-level tree (npm → node → vite).
-      await new Promise<void>((res) => setTimeout(res, 800));
+      // Wait for the actual close handler — a fixed timer can return
+      // before Node's `close` event fires under load (Windows taskkill
+      // /T /F on a three-level tree can take ~1s to propagate).
+      await Promise.race([job.closedPromise, new Promise<void>((res) => setTimeout(res, 5000))]);
     }
     return snapshot(job);
   }
@@ -387,6 +399,9 @@ interface InternalJob extends JobRecord {
   readyPromise: Promise<void>;
   /** Fires readyPromise — called by ready-signal OR close/error handlers. */
   signalReady: () => void;
+  /** Resolves only on close/error — never on ready-signal. Used by stop() to wait for actual exit. */
+  closedPromise: Promise<void>;
+  signalClosed: () => void;
 }
 
 export interface JobReadResult {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,10 @@
     "sourceMap": true,
     "outDir": "dist",
     "rootDir": "src",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
     "types": ["node"]
   },
   "include": ["src/**/*"],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,7 +9,10 @@ const inkCompatPath = resolve(here, "src/renderer/ink-compat/index.ts");
 
 export default defineConfig({
   resolve: {
-    alias: { ink: inkCompatPath },
+    alias: {
+      ink: inkCompatPath,
+      "@": resolve(here, "src"),
+    },
   },
   test: {
     include: ["tests/**/*.test.ts", "tests/**/*.test.tsx"],


### PR DESCRIPTION
**Note**: this branch cherry-picks the `jobs.stop()` race fix from #288 so the local pre-push hook can run the test suite without the existing flake. After #288 merges first, that commit naturally drops on rebase. Review the second commit (`chore(tsconfig)…`) for the actual content of this PR.

---

## Why

The 16 files under `src/cli/ui/slash/handlers/` sit four levels deep in the tree, so every reference to a top-level module reads like `../../../../i18n/index.js`. The depth carries no meaning — it just makes file moves and review diffs noisy.

## What

- Adds `paths: { "@/*": ["src/*"] }` + `baseUrl: "."` to `tsconfig.json`
- Mirrors `@` → `src/` in `vitest.config.ts` (esbuild via tsup picks up tsconfig paths transparently — no tsup config change needed)
- Migrates the four-level-deep imports in the 16 handler files: `../../../../i18n/index.js` → `@/i18n/index.js`, etc.

Three-level imports (siblings within `cli/` resolving to `@/cli/...`) are intentionally left alone — the relative form reads more naturally when the target is a neighbour, and migrating them would touch ~30 more files for marginal gain. A follow-up can address that later if it's worth the churn.

## Acceptance

- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean (verified `dist/cli/index.js` contains zero `@/` strings, alias fully resolved at bundle time)
- [x] `npm run test` — 2325 pass + 1 pre-existing skip
- [x] No public API change