### PR TITLE
fix: drain CodeQL warnings — polynomial redos + web.ts htmlToText

### DIFF
--- a/src/at-mentions.ts
+++ b/src/at-mentions.ts
@@ -315,8 +315,10 @@ export function expandAtMentions(
   for (const match of text.matchAll(AT_MENTION_PATTERN)) {
     const rawPath = match[1] ?? "";
     // Strip trailing dot (sentence terminator): `@foo.ts.` → `@foo.ts`.
-    // Keep internal dots intact.
-    const cleaned = rawPath.replace(/\.+$/, "");
+    // Keep internal dots intact. Manual loop instead of `/\.+$/` — the
+    // regex is O(n²) on dot-heavy non-matches per CodeQL js/polynomial-redos.
+    let cleaned = rawPath;
+    while (cleaned.endsWith(".")) cleaned = cleaned.slice(0, -1);
     if (!cleaned) continue;
     const token = `@${cleaned}`;
     if (seen.has(token)) continue;

--- a/src/client.ts
+++ b/src/client.ts
@@ -92,11 +92,10 @@ export class DeepSeekClient {
       );
     }
     this.apiKey = apiKey;
-    this.baseUrl = (
-      opts.baseUrl ??
-      process.env.DEEPSEEK_BASE_URL ??
-      "https://api.deepseek.com"
-    ).replace(/\/+$/, "");
+    let url = opts.baseUrl ?? process.env.DEEPSEEK_BASE_URL ?? "https://api.deepseek.com";
+    // Manual trim — `/\/+$/` is O(n²) on slash-heavy non-matches per CodeQL js/polynomial-redos.
+    while (url.endsWith("/")) url = url.slice(0, -1);
+    this.baseUrl = url;
     // 11 min. DeepSeek's load-balancer may keep a connection open for
     // up to 10 minutes while the request waits in queue (non-streaming
     // sends empty lines, streaming sends `:` SSE keep-alive comments —

--- a/src/repair/scavenge.ts
+++ b/src/repair/scavenge.ts
@@ -14,11 +14,20 @@ export interface ScavengeResult {
   notes: string[];
 }
 
+/** Bounds the regex input — DSML matchers are O(n²) on adversarial input per CodeQL js/polynomial-redos. */
+const MAX_SCAVENGE_INPUT = 100 * 1024;
+
 export function scavengeToolCalls(
   reasoningContent: string | null | undefined,
   opts: ScavengeOptions,
 ): ScavengeResult {
   if (!reasoningContent) return { calls: [], notes: [] };
+  if (reasoningContent.length > MAX_SCAVENGE_INPUT) {
+    return {
+      calls: [],
+      notes: [`scavenge skipped: reasoning_content too large (${reasoningContent.length} chars)`],
+    };
+  }
   const max = opts.maxCalls ?? 4;
   const notes: string[] = [];
   const out: ToolCall[] = [];

--- a/src/tools/web.ts
+++ b/src/tools/web.ts
@@ -182,15 +182,14 @@ async function readBodyCapped(resp: Response, maxBytes: number): Promise<string>
   return out;
 }
 
+/** Hard cap so the per-request HTML budget stays linear-time even on adversarial pages. */
+const MAX_HTML_INPUT = 5 * 1024 * 1024;
+
+const STRIP_BLOCK_TAGS = ["script", "style", "noscript", "nav", "footer", "aside", "svg"];
+
 export function htmlToText(html: string): string {
-  let s = html;
-  s = s.replace(/<script[\s\S]*?<\/script>/gi, "");
-  s = s.replace(/<style[\s\S]*?<\/style>/gi, "");
-  s = s.replace(/<noscript[\s\S]*?<\/noscript>/gi, "");
-  s = s.replace(/<nav[\s\S]*?<\/nav>/gi, "");
-  s = s.replace(/<footer[\s\S]*?<\/footer>/gi, "");
-  s = s.replace(/<aside[\s\S]*?<\/aside>/gi, "");
-  s = s.replace(/<svg[\s\S]*?<\/svg>/gi, "");
+  let s = html.length > MAX_HTML_INPUT ? html.slice(0, MAX_HTML_INPUT) : html;
+  for (const tag of STRIP_BLOCK_TAGS) s = stripTagBlock(s, tag);
   // Preserve paragraph breaks by turning common block tags into newlines.
   s = s.replace(/<\/?(p|div|br|h[1-6]|li|tr|section|article)\b[^>]*>/gi, "\n");
   s = s.replace(/<[^>]+>/g, "");
@@ -205,14 +204,66 @@ function stripHtml(s: string): string {
   return s.replace(/<[^>]+>/g, "");
 }
 
+/** Remove `<tag …>…</tag>` blocks via indexOf — the regex form `<tag[\s\S]*?</tag>` is O(n²) on adversarial input AND has well-known bypasses (`</tag >`, nested openings revealed after one pass). */
+function stripTagBlock(s: string, tag: string): string {
+  const lower = s.toLowerCase();
+  const openLead = `<${tag}`;
+  const closeLead = `</${tag}`;
+  let pos = 0;
+  let out = "";
+  while (pos < s.length) {
+    const openIdx = lower.indexOf(openLead, pos);
+    if (openIdx < 0) {
+      out += s.slice(pos);
+      break;
+    }
+    // Followed by `>`, `/`, or whitespace — otherwise it's a different tag (`<scriptfoo>`).
+    const after = s.charCodeAt(openIdx + openLead.length);
+    const isTagBoundary = after === 0x3e || after === 0x2f || after === 0x20 || after === 0x09;
+    if (!isTagBoundary) {
+      out += s.slice(pos, openIdx + 1);
+      pos = openIdx + 1;
+      continue;
+    }
+    const closeIdx = lower.indexOf(closeLead, openIdx + openLead.length);
+    if (closeIdx < 0) {
+      // No closer — drop the open tag and everything after, matching the original regex's "no match" behaviour at end of input.
+      out += s.slice(pos, openIdx);
+      break;
+    }
+    const closeEnd = s.indexOf(">", closeIdx + closeLead.length);
+    if (closeEnd < 0) {
+      out += s.slice(pos, openIdx);
+      break;
+    }
+    out += s.slice(pos, openIdx);
+    pos = closeEnd + 1;
+  }
+  return out;
+}
+
+const HTML_ENTITIES: Readonly<Record<string, string>> = {
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  apos: "'",
+  nbsp: " ",
+};
+
+/** Single-pass decode — the previous chained `replace`s decoded `&amp;lt;` into `<` because `&amp;` ran before `&lt;`. */
 function decodeHtmlEntities(s: string): string {
-  return s
-    .replace(/&nbsp;/g, " ")
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'");
+  return s.replace(/&(#\d+|#x[0-9a-fA-F]+|\w+);/g, (raw, name: string) => {
+    if (name.startsWith("#x") || name.startsWith("#X")) {
+      const code = Number.parseInt(name.slice(2), 16);
+      return Number.isFinite(code) ? String.fromCodePoint(code) : raw;
+    }
+    if (name.startsWith("#")) {
+      const code = Number.parseInt(name.slice(1), 10);
+      return Number.isFinite(code) ? String.fromCodePoint(code) : raw;
+    }
+    return HTML_ENTITIES[name.toLowerCase()] ?? raw;
+  });
 }
 
 function extractTitle(html: string): string | undefined {


### PR DESCRIPTION
Drains 8 of the 36 open CodeQL warnings, none of which were exploitable in our pipeline (inputs are model output / our own URL constants / web pages whose extracted text goes to the LLM). Several were also real correctness bugs the model would notice.

## Two commits

### 1. `fix(redos): close polynomial backtracking in 4 regexes`

| File | Pattern | Fix |
|---|---|---|
| `at-mentions.ts:319` | `/\.+$/` on path-like tokens | Loop `endsWith(".")` + `slice` |
| `client.ts:95` | `/\/+$/` on baseUrl | Loop `endsWith("/")` + `slice` |
| `scavenge.ts:67/75/86` | DSML `<X>[\s\S]*?</X>` matchers | 100 KB input cap + early-bail note |

### 2. `fix(web): drain CodeQL warnings on htmlToText`

`htmlToText` leaned on a chain of regex replacements that CodeQL flagged across six rules — `bad-tag-filter`, `incomplete-multi-character-sanitization`, `polynomial-redos` (×2), `double-escaping`.

Real correctness bugs visible in the bullet list:

- `<script[\s\S]*?</script>` missed `</script >` (whitespace before `>`) and could leave `<script` behind on the second pass when an outer match revealed a previously-hidden inner opening.
- Chained `decodeHtmlEntities` replacements ran `&amp;` before `&lt;`, so `&amp;lt;` decoded to `<` instead of literal `&lt;`.

Rewrites both with `indexOf`-based parsing:

- `stripTagBlock(s, tag)` — explicit tag-boundary check (avoids matching `<scriptfoo>`) and tolerant close matching
- `decodeHtmlEntities` — single regex pass with an entity map plus `&#nnn;` / `&#xHH;` numeric-entity handling
- 5 MB input cap on `htmlToText` so any residual quadratic patterns (e.g. the kept `<[^>]+>` strip) stay bounded

## Acceptance

- [x] `npm run verify` green (2328 pass + 1 pre-existing skip)
- [x] No public API change
- [x] 21 `tests/web-tools.test.ts` cases unchanged

## What's still open after this

- 13 `js/file-system-race` (TOCTOU patterns; mostly server/index/cli)
- 4 `js/indirect-command-line-injection` (process.env in shell tools — fundamental to running shells)
- 2 `js/http-to-file-access` (legitimate downloads in `version.ts` + benchmark)
- 1 `js/shell-command-constructed-from-input` (`withUtf8Codepage` — needs maintainer judgement, see #283 thread)
- A handful of one-offs

Most of the remainder are either accepted tradeoffs or need design decisions (e.g. whether to add an HTML parser dep, dismiss `withUtf8Codepage`).