### PR TITLE
refactor(app): extract quitProcess into useQuit hook

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -97,6 +97,7 @@ import {
 import { handleToolEvent } from "./hooks/handle-tool-event.js";
 import { useAgentSession } from "./hooks/useAgentSession.js";
 import { useInputRecall } from "./hooks/useInputRecall.js";
+import { useQuit } from "./hooks/useQuit.js";
 import { useScrollback } from "./hooks/useScrollback.js";
 import { useTranscriptWriter } from "./hooks/useTranscriptWriter.js";
 import { useKeystroke } from "./keystroke-context.js";
@@ -1113,25 +1114,8 @@ function AppInner({
     }
   }, [session, loop, codeMode, syncPendingCount, log]);
 
-  // Ctrl+C exits, period. SIGINT (cooked-mode terminals + Node's
-  // Windows console handler) and \x03 byte (raw-mode stdin) both
-  // converge on `quitProcess`. We call `process.exit` directly rather
-  // than Ink's `exit()` because the singleton stdin-reader keeps a
-  // `data` listener attached — `exit()` would unmount the React tree
-  // but the event loop would stay alive and the terminal would hang.
-  // Esc handles "abort the current turn" separately; Ctrl+C is the
-  // universal "I'm done" key, no banner, no double-press dance.
-  const quitProcess = useCallback(() => {
-    transcriptRef.current?.end();
-    process.exit(0);
-  }, []);
-
-  useEffect(() => {
-    process.on("SIGINT", quitProcess);
-    return () => {
-      process.off("SIGINT", quitProcess);
-    };
-  }, [quitProcess]);
+  // Esc handles "abort the current turn" separately; Ctrl+C is the universal "I'm done" key.
+  const quitProcess = useQuit(transcriptRef);
 
   // Esc during busy → forward to the loop as an abort signal. The loop
   // finishes the tool call in flight (we can't kill subprocess stdio

--- a/src/cli/ui/hooks/useQuit.ts
+++ b/src/cli/ui/hooks/useQuit.ts
@@ -1,0 +1,19 @@
+import type { WriteStream } from "node:fs";
+import { type MutableRefObject, useCallback, useEffect } from "react";
+
+/** Ctrl+C / SIGINT → flush transcript + `process.exit(0)`. We call `process.exit` directly rather than Ink's `exit()` because the singleton stdin reader keeps a `data` listener attached — `exit()` would unmount the React tree but leave the event loop alive and the terminal would hang. */
+export function useQuit(transcriptRef: MutableRefObject<WriteStream | null>): () => void {
+  const quitProcess = useCallback(() => {
+    transcriptRef.current?.end();
+    process.exit(0);
+  }, [transcriptRef]);
+
+  useEffect(() => {
+    process.on("SIGINT", quitProcess);
+    return () => {
+      process.off("SIGINT", quitProcess);
+    };
+  }, [quitProcess]);
+
+  return quitProcess;
+}


### PR DESCRIPTION
Second Phase-1 PR under #290.

The Ctrl+C / SIGINT exit handler now lives in `src/cli/ui/hooks/useQuit.ts` (19 lines). The hook returns the `quitProcess` callback and registers / deregisters the SIGINT listener on its own. `AppInner` just calls `useQuit(transcriptRef)` and forwards the returned function.

The "why `process.exit` rather than Ink's `exit()`" rationale moves with the code into the hook's docstring — that's the only place future callers need to read it.

## Acceptance

- [x] `npm run verify` green (2328 pass + 1 pre-existing skip)
- [x] No public API change
- [x] App.tsx: 3499 → 3483 lines
- [x] No behavioral change — same callback shape, same listener lifecycle, same exit semantics