### PR TITLE
refactor(app): extract writeTranscript into useTranscriptWriter hook

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -67,7 +67,7 @@ import { formatCommandResult, runCommand } from "../../tools/shell.js";
 import { registerSkillTools } from "../../tools/skills.js";
 import { formatSubagentResult, spawnSubagent } from "../../tools/subagent.js";
 import { webFetch } from "../../tools/web.js";
-import { openTranscriptFile, recordFromLoopEvent, writeRecord } from "../../transcript/log.js";
+import { openTranscriptFile } from "../../transcript/log.js";
 import { AtMentionSuggestions } from "./AtMentionSuggestions.js";
 import { ChoiceConfirm, type ChoiceConfirmChoice } from "./ChoiceConfirm.js";
 import { EditConfirm, type EditReviewChoice } from "./EditConfirm.js";
@@ -97,6 +97,7 @@ import {
 import { handleToolEvent } from "./hooks/handle-tool-event.js";
 import { useAgentSession } from "./hooks/useAgentSession.js";
 import { useScrollback } from "./hooks/useScrollback.js";
+import { useTranscriptWriter } from "./hooks/useTranscriptWriter.js";
 import { useKeystroke } from "./keystroke-context.js";
 import { CardStream } from "./layout/CardStream.js";
 import {
@@ -1548,14 +1549,7 @@ function AppInner({
 
   const prefixHash = loop.prefix.fingerprint;
 
-  const writeTranscript = useCallback(
-    (ev: LoopEvent) => {
-      const stream = transcriptRef.current;
-      if (!stream) return;
-      writeRecord(stream, recordFromLoopEvent(ev, { model, prefixHash }));
-    },
-    [model, prefixHash],
-  );
+  const writeTranscript = useTranscriptWriter(transcriptRef, model, prefixHash);
 
   /**
    * Toggle plan mode on the local state AND on the ToolRegistry. The

--- a/src/cli/ui/hooks/useTranscriptWriter.ts
+++ b/src/cli/ui/hooks/useTranscriptWriter.ts
@@ -1,0 +1,20 @@
+import type { WriteStream } from "node:fs";
+import { type MutableRefObject, useCallback } from "react";
+import type { LoopEvent } from "../../../loop.js";
+import { recordFromLoopEvent, writeRecord } from "../../../transcript/log.js";
+
+/** Returns a `LoopEvent` writer that no-ops when no transcript was opened. Wraps `recordFromLoopEvent` + `writeRecord` so callers don't carry the model/prefix metadata. */
+export function useTranscriptWriter(
+  transcriptRef: MutableRefObject<WriteStream | null>,
+  model: string,
+  prefixHash: string,
+): (ev: LoopEvent) => void {
+  return useCallback(
+    (ev: LoopEvent) => {
+      const stream = transcriptRef.current;
+      if (!stream) return;
+      writeRecord(stream, recordFromLoopEvent(ev, { model, prefixHash }));
+    },
+    [transcriptRef, model, prefixHash],
+  );
+}


### PR DESCRIPTION
Third Phase-1 PR under #290.

The transcript writer becomes its own hook (20 lines) — takes the transcript ref + the model/prefix metadata it needs to stamp on each record, returns the `LoopEvent` writer that `AppInner` forwards into stream subscribers and slash handlers.

Drops `recordFromLoopEvent` + `writeRecord` from `App.tsx`'s import block since the hook now owns those.

## Acceptance

- [x] `npm run verify` green (2328 pass + 1 pre-existing skip)
- [x] No public API change
- [x] App.tsx: 3499 → 3493 lines
- [x] No behavioral change — same callback signature, same dep array