### PR TITLE
refactor(app): extract codeApply / codeDiscard into useCodeMode hook

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -14,7 +14,7 @@ import {
   snapshotBeforeEdits,
   toWholeFileEditBlock,
 } from "../../code/edit-blocks.js";
-import { clearPendingEdits, loadPendingEdits, savePendingEdits } from "../../code/pending-edits.js";
+import { clearPendingEdits, loadPendingEdits } from "../../code/pending-edits.js";
 import {
   clearPlanState,
   loadPlanState,
@@ -84,7 +84,7 @@ import { SlashArgPicker } from "./SlashArgPicker.js";
 import { SlashSuggestions } from "./SlashSuggestions.js";
 import { WelcomeBanner } from "./WelcomeBanner.js";
 import { detectBangCommand, formatBangUserMessage } from "./bang.js";
-import { formatEditResults, partitionEdits } from "./edit-history.js";
+import { formatEditResults } from "./edit-history.js";
 import { loopEventToDashboard } from "./effects/loop-to-dashboard.js";
 import { appendGlobalMemory, appendProjectMemory, detectHashMemory } from "./hash-memory.js";
 import { applySlashResult } from "./hooks/apply-slash-result.js";
@@ -96,6 +96,7 @@ import {
 } from "./hooks/handle-stream-events.js";
 import { handleToolEvent } from "./hooks/handle-tool-event.js";
 import { useAgentSession } from "./hooks/useAgentSession.js";
+import { useCodeMode } from "./hooks/useCodeMode.js";
 import { useInputRecall } from "./hooks/useInputRecall.js";
 import { useLoopMode } from "./hooks/useLoopMode.js";
 import { useQuit } from "./hooks/useQuit.js";
@@ -1423,72 +1424,14 @@ function AppInner({
     };
   }, [tools, codeMode, session, recordEdit, armUndoBanner, syncPendingCount, setEditMode]);
 
-  /**
-   * /apply callback — write pending edit blocks to disk, snapshot
-   * beforehand so /undo still works, report per-file results. With
-   * `indices` (1-based) only those blocks are applied; the rest stay
-   * pending so the user can iterate on them. Empty / undefined indices
-   * apply every pending block (the all-or-nothing original behavior).
-   */
-  const codeApply = useCallback(
-    (indices?: readonly number[]): string => {
-      if (!codeMode) return "not in code mode";
-      const blocks = pendingEdits.current;
-      if (blocks.length === 0) {
-        return "nothing pending — the model hasn't proposed edits since the last /apply or /discard.";
-      }
-      const useSubset = indices !== undefined && indices.length > 0;
-      const { selected, remaining } = useSubset
-        ? partitionEdits(blocks, indices)
-        : { selected: blocks, remaining: [] as EditBlock[] };
-      if (selected.length === 0) {
-        return "▸ no edits matched those indices — nothing applied. Use /apply with no args to commit them all.";
-      }
-      const snaps = snapshotBeforeEdits(selected, currentRootDir);
-      const results = applyEditBlocks(selected, currentRootDir);
-      const anyApplied = results.some((r) => r.status === "applied" || r.status === "created");
-      if (anyApplied) recordEdit("review-apply", selected, results, snaps);
-      pendingEdits.current = remaining;
-      if (remaining.length === 0) clearPendingEdits(session ?? null);
-      else savePendingEdits(session ?? null, remaining);
-      syncPendingCount();
-      const tail =
-        remaining.length > 0
-          ? `\n▸ ${remaining.length} edit block(s) still pending — /apply or /discard to clear them.`
-          : "";
-      return formatEditResults(results) + tail;
-    },
-    [codeMode, currentRootDir, session, syncPendingCount, recordEdit],
-  );
-
-  /**
-   * /discard callback — forget the pending edits without touching
-   * disk. With `indices` (1-based) only those blocks are dropped; the
-   * rest stay pending. Empty / undefined indices drop everything.
-   */
-  const codeDiscard = useCallback(
-    (indices?: readonly number[]): string => {
-      const blocks = pendingEdits.current;
-      if (blocks.length === 0) return "nothing pending to discard.";
-      const useSubset = indices !== undefined && indices.length > 0;
-      const { selected, remaining } = useSubset
-        ? partitionEdits(blocks, indices)
-        : { selected: blocks, remaining: [] as EditBlock[] };
-      if (selected.length === 0) {
-        return "▸ no edits matched those indices — nothing discarded.";
-      }
-      pendingEdits.current = remaining;
-      if (remaining.length === 0) clearPendingEdits(session ?? null);
-      else savePendingEdits(session ?? null, remaining);
-      syncPendingCount();
-      const tail =
-        remaining.length > 0
-          ? `  (${remaining.length} block(s) still pending)`
-          : ". Nothing was written to disk.";
-      return `▸ discarded ${selected.length} pending edit block(s)${tail}`;
-    },
-    [session, syncPendingCount],
-  );
+  const { codeApply, codeDiscard } = useCodeMode({
+    codeMode: !!codeMode,
+    pendingEdits,
+    currentRootDir,
+    session: session ?? null,
+    syncPendingCount,
+    recordEdit,
+  });
 
   const prefixHash = loop.prefix.fingerprint;
 

--- a/src/cli/ui/hooks/useCodeMode.ts
+++ b/src/cli/ui/hooks/useCodeMode.ts
@@ -1,0 +1,93 @@
+import { type MutableRefObject, useCallback } from "react";
+import {
+  type ApplyResult,
+  type EditBlock,
+  type EditSnapshot,
+  applyEditBlocks,
+  snapshotBeforeEdits,
+} from "../../../code/edit-blocks.js";
+import { clearPendingEdits, savePendingEdits } from "../../../code/pending-edits.js";
+import { formatEditResults, partitionEdits } from "../edit-history.js";
+
+export interface UseCodeModeResult {
+  /** /apply callback. Empty `indices` means "all"; specific 1-based indices apply only those. */
+  codeApply: (indices?: readonly number[]) => string;
+  /** /discard callback. Same indices semantics as codeApply. */
+  codeDiscard: (indices?: readonly number[]) => string;
+}
+
+export interface UseCodeModeOptions {
+  codeMode: boolean;
+  pendingEdits: MutableRefObject<EditBlock[]>;
+  currentRootDir: string;
+  session: string | null;
+  syncPendingCount: () => void;
+  recordEdit: (
+    source: string,
+    blocks: readonly EditBlock[],
+    results: readonly ApplyResult[],
+    snaps: readonly EditSnapshot[],
+  ) => void;
+}
+
+/** Slash-command callbacks for `/apply` and `/discard` over the pending-edits queue. Owns the partition / snapshot / save / sync sequence; AppInner just forwards the strings to its log. */
+export function useCodeMode(opts: UseCodeModeOptions): UseCodeModeResult {
+  const { codeMode, pendingEdits, currentRootDir, session, syncPendingCount, recordEdit } = opts;
+
+  const codeApply = useCallback(
+    (indices?: readonly number[]): string => {
+      if (!codeMode) return "not in code mode";
+      const blocks = pendingEdits.current;
+      if (blocks.length === 0) {
+        return "nothing pending — the model hasn't proposed edits since the last /apply or /discard.";
+      }
+      const useSubset = indices !== undefined && indices.length > 0;
+      const { selected, remaining } = useSubset
+        ? partitionEdits(blocks, indices)
+        : { selected: blocks, remaining: [] as EditBlock[] };
+      if (selected.length === 0) {
+        return "▸ no edits matched those indices — nothing applied. Use /apply with no args to commit them all.";
+      }
+      const snaps = snapshotBeforeEdits(selected, currentRootDir);
+      const results = applyEditBlocks(selected, currentRootDir);
+      const anyApplied = results.some((r) => r.status === "applied" || r.status === "created");
+      if (anyApplied) recordEdit("review-apply", selected, results, snaps);
+      pendingEdits.current = remaining;
+      if (remaining.length === 0) clearPendingEdits(session ?? null);
+      else savePendingEdits(session ?? null, remaining);
+      syncPendingCount();
+      const tail =
+        remaining.length > 0
+          ? `\n▸ ${remaining.length} edit block(s) still pending — /apply or /discard to clear them.`
+          : "";
+      return formatEditResults(results) + tail;
+    },
+    [codeMode, currentRootDir, session, syncPendingCount, recordEdit, pendingEdits],
+  );
+
+  const codeDiscard = useCallback(
+    (indices?: readonly number[]): string => {
+      const blocks = pendingEdits.current;
+      if (blocks.length === 0) return "nothing pending to discard.";
+      const useSubset = indices !== undefined && indices.length > 0;
+      const { selected, remaining } = useSubset
+        ? partitionEdits(blocks, indices)
+        : { selected: blocks, remaining: [] as EditBlock[] };
+      if (selected.length === 0) {
+        return "▸ no edits matched those indices — nothing discarded.";
+      }
+      pendingEdits.current = remaining;
+      if (remaining.length === 0) clearPendingEdits(session ?? null);
+      else savePendingEdits(session ?? null, remaining);
+      syncPendingCount();
+      const tail =
+        remaining.length > 0
+          ? `  (${remaining.length} block(s) still pending)`
+          : ". Nothing was written to disk.";
+      return `▸ discarded ${selected.length} pending edit block(s)${tail}`;
+    },
+    [session, syncPendingCount, pendingEdits],
+  );
+
+  return { codeApply, codeDiscard };
+}


### PR DESCRIPTION
First Phase-2 PR under #290 (start of the feature-cluster phase).

The `/apply` and `/discard` slash callbacks move into one hook (93 lines). The hook owns the partition / snapshot / save / sync sequence and returns thin string-builders that `AppInner` forwards to its log.

Drops `partitionEdits` (unused after extraction) and `savePendingEdits` (only used by the extracted callbacks) from `App.tsx`'s imports.

## Acceptance

- [x] `npm run verify` green (2328 pass + 1 pre-existing skip)
- [x] No public API change
- [x] App.tsx: 3361 → 3304 lines (-57)
- [x] No behavioral change — same semantics for both slashes, including the per-block index subset path