### PR TITLE
fix(fs): close 3 stat→read TOCTOU races (CodeQL js/file-system-race)

### DIFF
--- a/src/server/api/skills.ts
+++ b/src/server/api/skills.ts
@@ -1,12 +1,15 @@
 /** `/api/skills` — edits files only; loop reloads on /new or restart. `builtin` scope is read-only. */
 
 import {
+  closeSync,
   existsSync,
+  fstatSync,
   mkdirSync,
+  openSync,
   readFileSync,
+  readSync,
   readdirSync,
   rmSync,
-  statSync,
   writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
@@ -67,10 +70,25 @@ function listSkills(dir: string, scope: "project" | "global"): SkillListEntry[] 
     for (const entry of readdirSync(dir)) {
       if (!SAFE_NAME.test(entry)) continue;
       const skillPath = join(dir, entry, SKILL_FILE);
-      if (!existsSync(skillPath)) continue;
       try {
-        const stat = statSync(skillPath);
-        const raw = readFileSync(skillPath, "utf8");
+        // Open once and reuse the fd so size/mtime/content all bind to
+        // the same inode — closes the exists→stat→read TOCTOU races.
+        const fd = openSync(skillPath, "r");
+        let stat: ReturnType<typeof fstatSync>;
+        let raw: string;
+        try {
+          stat = fstatSync(fd);
+          const buf = Buffer.alloc(stat.size);
+          let read = 0;
+          while (read < stat.size) {
+            const n = readSync(fd, buf, read, stat.size - read, read);
+            if (n <= 0) break;
+            read += n;
+          }
+          raw = buf.toString("utf8", 0, read);
+        } finally {
+          closeSync(fd);
+        }
         const item: SkillListEntry = {
           name: entry,
           scope,

--- a/src/server/assets.ts
+++ b/src/server/assets.ts
@@ -1,4 +1,4 @@
-import { readFileSync, statSync } from "node:fs";
+import { closeSync, fstatSync, openSync, readFileSync, readSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -33,12 +33,26 @@ const ASSET_DIR = resolveAssetDir();
 const fileCache = new Map<string, { body: string; mtimeMs: number }>();
 
 function loadCachedFile(path: string): string {
-  const stat = statSync(path);
-  const cached = fileCache.get(path);
-  if (cached && cached.mtimeMs === stat.mtimeMs) return cached.body;
-  const body = readFileSync(path, "utf8");
-  fileCache.set(path, { body, mtimeMs: stat.mtimeMs });
-  return body;
+  // Open once and reuse the fd so the mtime check and the read bind to
+  // the same inode — closes the stat→read TOCTOU race.
+  const fd = openSync(path, "r");
+  try {
+    const stat = fstatSync(fd);
+    const cached = fileCache.get(path);
+    if (cached && cached.mtimeMs === stat.mtimeMs) return cached.body;
+    const buf = Buffer.alloc(stat.size);
+    let read = 0;
+    while (read < stat.size) {
+      const n = readSync(fd, buf, read, stat.size - read, read);
+      if (n <= 0) break;
+      read += n;
+    }
+    const body = buf.toString("utf8", 0, read);
+    fileCache.set(path, { body, mtimeMs: stat.mtimeMs });
+    return body;
+  } finally {
+    closeSync(fd);
+  }
 }
 
 function loadIndexTemplate(): string {

--- a/src/tools/filesystem.ts
+++ b/src/tools/filesystem.ts
@@ -124,11 +124,19 @@ When none of these is given AND the file is longer than ${DEFAULT_AUTO_PREVIEW_L
     },
     fn: async (args: { path: string; head?: number; tail?: number; range?: string }) => {
       const abs = safePath(args.path);
-      const stat = await fs.stat(abs);
-      if (stat.isDirectory()) {
-        throw new Error(`not a file: ${args.path} (it's a directory)`);
+      // Open once and reuse the fd so the directory check and the read
+      // bind to the same inode — closes the stat→read TOCTOU race.
+      const fh = await fs.open(abs, "r");
+      let raw: Buffer;
+      try {
+        const stat = await fh.stat();
+        if (stat.isDirectory()) {
+          throw new Error(`not a file: ${args.path} (it's a directory)`);
+        }
+        raw = await fh.readFile();
+      } finally {
+        await fh.close();
       }
-      const raw = await fs.readFile(abs);
       if (raw.length > maxReadBytes) {
         const headBytes = raw.slice(0, maxReadBytes).toString("utf8");
         return `${headBytes}\n\n[…truncated ${raw.length - maxReadBytes} bytes — file is ${raw.length} B, cap ${maxReadBytes} B. Retry with head/tail/range for targeted view.]`;


### PR DESCRIPTION
Drains 3 of the 12 `js/file-system-race` warnings. Same fix shape across all three: open once, use `fstat` + `read` against the same fd. The fd binding pins the inode for the lifetime of the operation, so a concurrent rename / replace / unlink during the call can't desync the size or mtime we just observed from the bytes we're about to read.

## What changes

| File | Before | After |
|---|---|---|
| `src/tools/filesystem.ts:127` (read_file body) | `fs.stat` → `fs.readFile` | `fs.open` + `fh.stat` + `fh.readFile` |
| `src/server/assets.ts:36` (asset cache) | `statSync` → `readFileSync` | `openSync` + `fstatSync` + chunked `readSync` |
| `src/server/api/skills.ts:72` (skill listing) | `existsSync` → `statSync` → `readFileSync` | `openSync` + `fstatSync` + `readSync`; drops the redundant `existsSync` precheck (which was a separate race in the same chain) |

## Acceptance

- [x] `npm run verify` green (2328 pass + 1 pre-existing skip)
- [x] No public API change
- [x] No behavioral change — same return shapes, same error semantics (missing-file still fails the operation; the surrounding try/catch in `listSkills` already handles it)

## What's still open

9 `js/file-system-race` warnings remain — these are `exists→write` or `read→write` patterns (`hash-memory.ts`, `edit-blocks.ts`, `usage.ts:103`, `chunker.ts`, `slash/handlers/semantic.ts`, `server/api/semantic.ts`). Different fix shape (`fs.open` with `ax` / `r+` flags or compare-and-swap); separate PR.