### PR TITLE
fix: add actionable mcp inspect errors

### DIFF
--- a/src/cli/commands/mcp-inspect.ts
+++ b/src/cli/commands/mcp-inspect.ts
@@ -35,6 +35,32 @@ export async function mcpInspectCommand(opts: McpInspectOptions): Promise<void> 
   }
 }
 
+export function formatMcpInspectFailure(err: unknown): string {
+  const error = err instanceof Error ? err : new Error(String(err));
+  const message = error.message;
+  const code = (error as NodeJS.ErrnoException).code;
+
+  if (code === "ENOENT") {
+    const command = message.match(/^spawn\s+([^\s]+)\s+ENOENT$/)?.[1] ?? "the command";
+    return `${message} — try: install or verify \`${command}\`, then check the MCP spec's command spelling`;
+  }
+
+  if (code === "ECONNREFUSED") {
+    const target = message.match(/\b(https?:\/\/\S+|\d+\.\d+\.\d+\.\d+:\d+|localhost:\d+)\b/i)?.[1];
+    return `${message} — try: confirm ${target ?? "the MCP server"} is running and the host/port match the spec`;
+  }
+
+  if (/^MCP request initialize \(id=\d+\) timed out after \d+ms$/.test(message)) {
+    return `${message} — try: confirm the target speaks MCP and completes the handshake before the request timeout`;
+  }
+
+  if (/^(empty MCP spec|MCP spec ".*" has name but no command)/.test(message)) {
+    return `${message} — try: pass \`name=command args\` or an http(s):// URL`;
+  }
+
+  return message;
+}
+
 function formatReport(nsName: string, r: InspectionReport): string {
   const lines: string[] = [];
   lines.push(`MCP server [${nsName}]`);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -35,7 +35,7 @@ import { doctorCommand } from "./commands/doctor.js";
 import { eventsCommand } from "./commands/events.js";
 import { indexCommand } from "./commands/index.js";
 import { mcpBrowseCommand } from "./commands/mcp-browse.js";
-import { mcpInspectCommand } from "./commands/mcp-inspect.js";
+import { formatMcpInspectFailure, mcpInspectCommand } from "./commands/mcp-inspect.js";
 import { mcpInstallCommand, mcpListCommand, mcpSearchCommand } from "./commands/mcp.js";
 import { pruneSessionsCommand } from "./commands/prune-sessions.js";
 import { replayCommand } from "./commands/replay.js";
@@ -414,7 +414,7 @@ mcp
     try {
       await mcpInspectCommand({ spec, json: !!opts.json });
     } catch (err) {
-      process.stderr.write(`mcp inspect failed: ${(err as Error).message}\n`);
+      process.stderr.write(`mcp inspect failed: ${formatMcpInspectFailure(err)}\n`);
       process.exit(1);
     }
   });

--- a/tests/mcp-inspect.test.ts
+++ b/tests/mcp-inspect.test.ts
@@ -1,6 +1,7 @@
 /** inspectMcpServer — runs against the fake transport. */
 
 import { describe, expect, it } from "vitest";
+import { formatMcpInspectFailure } from "../src/cli/commands/mcp-inspect.js";
 import { McpClient } from "../src/mcp/client.js";
 import { inspectMcpServer } from "../src/mcp/inspect.js";
 import type { McpTransport } from "../src/mcp/stdio.js";
@@ -221,5 +222,43 @@ describe("McpClient: initialize records serverInfo + protocolVersion + instructi
     await client.initialize();
     expect(client.serverInstructions).toBeUndefined();
     await client.close();
+  });
+});
+
+describe("formatMcpInspectFailure", () => {
+  it("adds a command-install hint for ENOENT spawn errors", () => {
+    const err = Object.assign(new Error("spawn npx-typo ENOENT"), { code: "ENOENT" });
+    expect(formatMcpInspectFailure(err)).toBe(
+      "spawn npx-typo ENOENT — try: install or verify `npx-typo`, then check the MCP spec's command spelling",
+    );
+  });
+
+  it("adds a host/port hint for connection refused errors", () => {
+    const err = Object.assign(new Error("connect ECONNREFUSED 127.0.0.1:8787"), {
+      code: "ECONNREFUSED",
+    });
+    expect(formatMcpInspectFailure(err)).toBe(
+      "connect ECONNREFUSED 127.0.0.1:8787 — try: confirm 127.0.0.1:8787 is running and the host/port match the spec",
+    );
+  });
+
+  it("adds a handshake hint for initialize timeouts", () => {
+    const err = new Error("MCP request initialize (id=1) timed out after 60000ms");
+    expect(formatMcpInspectFailure(err)).toBe(
+      "MCP request initialize (id=1) timed out after 60000ms — try: confirm the target speaks MCP and completes the handshake before the request timeout",
+    );
+  });
+
+  it("adds a spec-shape hint for malformed specs", () => {
+    expect(formatMcpInspectFailure(new Error("empty MCP spec"))).toBe(
+      "empty MCP spec — try: pass `name=command args` or an http(s):// URL",
+    );
+    expect(formatMcpInspectFailure(new Error('MCP spec "fs=" has name but no command'))).toBe(
+      'MCP spec "fs=" has name but no command — try: pass `name=command args` or an http(s):// URL',
+    );
+  });
+
+  it("leaves unknown errors unchanged", () => {
+    expect(formatMcpInspectFailure(new Error("boom"))).toBe("boom");
   });
 });


### PR DESCRIPTION
## Summary
- add actionable recovery hints for common `reasonix mcp inspect` failures
- route inspect CLI errors through a formatter for ENOENT, ECONNREFUSED, handshake timeout, and malformed spec cases
- cover the new failure messaging with focused tests

## Testing
- `npm test -- mcp-inspect`
- `npm run build`

## Notes
- `npm run verify` is currently not green on this branch because the repo already has unrelated lint/typecheck failures and local uncommitted slash-command changes:
  - existing Biome warnings promoted during `npm run lint`
  - existing TypeScript errors in `src/cli/ui/slash/nearest.ts`
  - local unrelated worktree changes in `src/cli/ui/slash/*`
