### PR TITLE
fix(events): emit tool audit trail events (#260)

### DIFF
--- a/src/cli/commands/events.ts
+++ b/src/cli/commands/events.ts
@@ -80,6 +80,14 @@ function detailsFor(e: Event): string {
       return `${e.callId} reason=${e.reason}`;
     case "tool.result":
       return `${e.callId} ${e.ok ? "ok" : "err"} ${e.output.length}B${e.truncated ? " [trunc]" : ""}`;
+    case "tool.call":
+      return `${e.name} args=${truncate(JSON.stringify(e.args), 60)}`;
+    case "tool.confirm.allow":
+      return `${e.kind} ${quote(e.payload.command, 60)}`;
+    case "tool.confirm.deny":
+      return `${e.kind} ${quote(e.payload.command, 60)}${e.denyContext ? ` — ${truncate(e.denyContext, 40)}` : ""}`;
+    case "tool.confirm.always_allow":
+      return `${e.kind} ${quote(e.payload.command, 60)} prefix=${truncate(e.prefix, 30)}`;
     case "effect.file.touched":
       return `${e.mode} ${e.path} (${e.bytes}B)`;
     case "effect.memory.written":

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -809,6 +809,50 @@ function AppInner({
     return l;
   }, [model, system, harvest, branch, budgetUsd, session, tools, codeMode]);
 
+  useEffect(() => {
+    if (!session || !tools) return;
+    tools.setAuditListener((event) => {
+      const sink = eventSinkRef.current;
+      const eventizer = eventizerRef.current;
+      if (!sink || !eventizer) return;
+      sink.append(eventizer.emitToolCall(loop.currentTurn, event.name, event.args));
+    });
+    pauseGate.setAuditListener((event) => {
+      const sink = eventSinkRef.current;
+      const eventizer = eventizerRef.current;
+      if (!sink || !eventizer) return;
+      switch (event.type) {
+        case "tool.confirm.allow":
+          sink.append(eventizer.emitToolConfirmAllow(loop.currentTurn, event.kind, event.payload));
+          break;
+        case "tool.confirm.deny":
+          sink.append(
+            eventizer.emitToolConfirmDeny(
+              loop.currentTurn,
+              event.kind,
+              event.payload,
+              event.denyContext,
+            ),
+          );
+          break;
+        case "tool.confirm.always_allow":
+          sink.append(
+            eventizer.emitToolConfirmAlwaysAllow(
+              loop.currentTurn,
+              event.kind,
+              event.payload,
+              event.prefix,
+            ),
+          );
+          break;
+      }
+    });
+    return () => {
+      tools.setAuditListener(null);
+      pauseGate.setAuditListener(null);
+    };
+  }, [loop, session, tools]);
+
   // Keep the loop's hook list in sync after a `/hooks reload`. The
   // loop's field is intentionally mutable for exactly this case —
   // construction happens once, hook edits are picked up live.

--- a/src/core/event-redaction.ts
+++ b/src/core/event-redaction.ts
@@ -1,0 +1,21 @@
+const SECRET_KEY_RE =
+  /(secret|token|password|passphrase|api[-_]?key|authorization|cookie|credential|passwd|pwd)/i;
+
+export function redactEventValue<T>(value: T): T {
+  return redactUnknown(value, null) as T;
+}
+
+function redactUnknown(value: unknown, key: string | null): unknown {
+  if (Array.isArray(value)) return value.map((item) => redactUnknown(item, null));
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [childKey, childValue] of Object.entries(value)) {
+      out[childKey] = redactUnknown(childValue, childKey);
+    }
+    return out;
+  }
+  if (typeof value === "string") {
+    if ((key && SECRET_KEY_RE.test(key)) || /^Bearer\s+/i.test(value)) return "[redacted]";
+  }
+  return value;
+}

--- a/src/core/eventize.ts
+++ b/src/core/eventize.ts
@@ -1,5 +1,6 @@
 import type { LoopEvent } from "../loop.js";
 import type { ChatMessage, RawUsage, ToolCall } from "../types.js";
+import { redactEventValue } from "./event-redaction.js";
 import type {
   Event,
   ErrorEvent as KernelErrorEvent,
@@ -10,6 +11,10 @@ import type {
   SessionOpenedEvent,
   SlashInvokedEvent,
   StatusEvent,
+  ToolCallEvent,
+  ToolConfirmAllowEvent,
+  ToolConfirmAlwaysAllowEvent,
+  ToolConfirmDenyEvent,
   ToolDispatchedEvent,
   ToolIntentEvent,
   ToolResultEvent,
@@ -122,6 +127,66 @@ export class Eventizer {
       afterMessages: after,
       reason,
       replacementMessages,
+    };
+  }
+
+  emitToolCall(turn: number, name: string, args: Record<string, unknown>): ToolCallEvent {
+    return {
+      id: ++this.nextId,
+      ts: new Date().toISOString(),
+      turn,
+      type: "tool.call",
+      name,
+      args: redactEventValue(args),
+    };
+  }
+
+  emitToolConfirmAllow(
+    turn: number,
+    kind: "run_command" | "run_background",
+    payload: { command: string },
+  ): ToolConfirmAllowEvent {
+    return {
+      id: ++this.nextId,
+      ts: new Date().toISOString(),
+      turn,
+      type: "tool.confirm.allow",
+      kind,
+      payload: redactEventValue(payload),
+    };
+  }
+
+  emitToolConfirmDeny(
+    turn: number,
+    kind: "run_command" | "run_background",
+    payload: { command: string },
+    denyContext?: string,
+  ): ToolConfirmDenyEvent {
+    return {
+      id: ++this.nextId,
+      ts: new Date().toISOString(),
+      turn,
+      type: "tool.confirm.deny",
+      kind,
+      payload: redactEventValue(payload),
+      denyContext,
+    };
+  }
+
+  emitToolConfirmAlwaysAllow(
+    turn: number,
+    kind: "run_command" | "run_background",
+    payload: { command: string },
+    prefix: string,
+  ): ToolConfirmAlwaysAllowEvent {
+    return {
+      id: ++this.nextId,
+      ts: new Date().toISOString(),
+      turn,
+      type: "tool.confirm.always_allow",
+      kind,
+      payload: redactEventValue(payload),
+      prefix,
     };
   }
 

--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -76,6 +76,32 @@ export interface ToolResultEvent extends EventBase {
   durationMs: number;
 }
 
+export interface ToolCallEvent extends EventBase {
+  type: "tool.call";
+  name: string;
+  args: Record<string, unknown>;
+}
+
+export interface ToolConfirmAllowEvent extends EventBase {
+  type: "tool.confirm.allow";
+  kind: "run_command" | "run_background";
+  payload: { command: string };
+}
+
+export interface ToolConfirmDenyEvent extends EventBase {
+  type: "tool.confirm.deny";
+  kind: "run_command" | "run_background";
+  payload: { command: string };
+  denyContext?: string;
+}
+
+export interface ToolConfirmAlwaysAllowEvent extends EventBase {
+  type: "tool.confirm.always_allow";
+  kind: "run_command" | "run_background";
+  payload: { command: string };
+  prefix: string;
+}
+
 export interface FileTouchedEvent extends EventBase {
   type: "effect.file.touched";
   path: string;
@@ -197,6 +223,10 @@ export type Event =
   | ToolDispatchedEvent
   | ToolDeniedEvent
   | ToolResultEvent
+  | ToolCallEvent
+  | ToolConfirmAllowEvent
+  | ToolConfirmDenyEvent
+  | ToolConfirmAlwaysAllowEvent
   | FileTouchedEvent
   | MemoryWrittenEvent
   | PlanSubmittedEvent

--- a/src/core/pause-gate.ts
+++ b/src/core/pause-gate.ts
@@ -21,6 +21,25 @@ export type ChoiceVerdict =
   | { type: "text"; text: string }
   | { type: "cancel" };
 
+export type ToolConfirmationAuditEvent =
+  | {
+      type: "tool.confirm.allow";
+      kind: "run_command" | "run_background";
+      payload: { command: string };
+    }
+  | {
+      type: "tool.confirm.deny";
+      kind: "run_command" | "run_background";
+      payload: { command: string };
+      denyContext?: string;
+    }
+  | {
+      type: "tool.confirm.always_allow";
+      kind: "run_command" | "run_background";
+      payload: { command: string };
+      prefix: string;
+    };
+
 interface PauseResponseMap {
   run_command: ConfirmationChoice;
   run_background: ConfirmationChoice;
@@ -48,6 +67,7 @@ export type PauseRequest = {
 };
 
 type GateListener = (request: PauseRequest) => void;
+type AuditListener = (event: ToolConfirmationAuditEvent) => void;
 
 /** Named options for PauseGate.ask() — makes it obvious which field is kind vs payload. */
 export interface PauseAskOpts<K extends PauseKind = PauseKind> {
@@ -59,6 +79,7 @@ export class PauseGate {
   private _nextId = 0;
   private _pending = new Map<number, { resolve: (data: unknown) => void; request: PauseRequest }>();
   private _listeners: Set<GateListener> = new Set();
+  private _auditListener: AuditListener | null = null;
 
   /** Block until the user responds. Takes a named options object so the
    *  kind and payload fields don't get confused at the call site. */
@@ -88,7 +109,12 @@ export class PauseGate {
     const p = this._pending.get(id);
     if (!p) return;
     this._pending.delete(id);
+    this.emitAuditEvent(p.request, data);
     p.resolve(data);
+  }
+
+  setAuditListener(fn: AuditListener | null): void {
+    this._auditListener = fn;
   }
 
   /** Subscribe to new pause requests. Returns an unsubscribe function. */
@@ -103,6 +129,45 @@ export class PauseGate {
   get current(): PauseRequest | null {
     for (const [, p] of this._pending) return p.request;
     return null;
+  }
+
+  private emitAuditEvent(request: PauseRequest, data: unknown): void {
+    if (!this._auditListener) return;
+    if (request.kind !== "run_command" && request.kind !== "run_background") return;
+    if (!data || typeof data !== "object") return;
+    const choice = data as Partial<ConfirmationChoice>;
+    try {
+      switch (choice.type) {
+        case "run_once":
+          this._auditListener({
+            type: "tool.confirm.allow",
+            kind: request.kind,
+            payload: request.payload as { command: string },
+          });
+          break;
+        case "deny":
+          this._auditListener({
+            type: "tool.confirm.deny",
+            kind: request.kind,
+            payload: request.payload as { command: string },
+            denyContext: choice.denyContext,
+          });
+          break;
+        case "always_allow":
+          if (typeof choice.prefix !== "string") return;
+          this._auditListener({
+            type: "tool.confirm.always_allow",
+            kind: request.kind,
+            payload: request.payload as { command: string },
+            prefix: choice.prefix,
+          });
+          break;
+        default:
+          break;
+      }
+    } catch {
+      /* audit path must never break the gate */
+    }
   }
 }
 

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -208,6 +208,10 @@ export class CacheFirstLoop {
   private _foldedThisTurn = false;
   private context!: ContextManager;
 
+  get currentTurn(): number {
+    return this._turn;
+  }
+
   constructor(opts: CacheFirstLoopOptions) {
     this.client = opts.client;
     this.prefix = opts.prefix;

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -30,6 +30,13 @@ export interface ToolRegistryOptions {
   autoFlatten?: boolean;
 }
 
+export type ToolCallAuditEvent = {
+  name: string;
+  args: Record<string, unknown>;
+};
+
+export type ToolCallAuditListener = (event: ToolCallAuditEvent) => void;
+
 /** String return short-circuits dispatch; null/undefined falls through to the tool fn. */
 export type ToolInterceptor = (
   name: string,
@@ -41,6 +48,7 @@ export class ToolRegistry {
   private readonly _autoFlatten: boolean;
   private _planMode = false;
   private _interceptor: ToolInterceptor | null = null;
+  private _auditListener: ToolCallAuditListener | null = null;
 
   constructor(opts: ToolRegistryOptions = {}) {
     this._autoFlatten = opts.autoFlatten !== false;
@@ -59,6 +67,10 @@ export class ToolRegistry {
   /** At most one interceptor active; calling twice replaces. */
   setToolInterceptor(fn: ToolInterceptor | null): void {
     this._interceptor = fn;
+  }
+
+  setAuditListener(fn: ToolCallAuditListener | null): void {
+    this._auditListener = fn;
   }
 
   register<A, R>(def: ToolDefinition<A, R>): this {
@@ -172,6 +184,11 @@ export class ToolRegistry {
     }
 
     try {
+      try {
+        this._auditListener?.({ name, args });
+      } catch {
+        /* audit path must never break tool execution */
+      }
       const result = await tool.fn(args, {
         signal: opts.signal,
         confirmationGate: opts.confirmationGate,

--- a/tests/events-command.test.ts
+++ b/tests/events-command.test.ts
@@ -41,6 +41,11 @@ describe("eventsCommand", () => {
       ev(4, "tool.intent", { callId: "tc-1", name: "list_directory", args: '{"path":"src"}' }),
       ev(5, "tool.dispatched", { callId: "tc-1" }),
       ev(6, "tool.result", { callId: "tc-1", ok: true, output: "App.tsx\n", durationMs: 12 }),
+      ev(7, "tool.call", {
+        name: "run_command",
+        args: { command: "npm test", apiKey: "[redacted]" },
+      }),
+      ev(8, "tool.confirm.allow", { kind: "run_command", payload: { command: "npm test" } }),
     ]);
 
     const log = vi.spyOn(console, "log").mockImplementation(() => {});
@@ -55,6 +60,8 @@ describe("eventsCommand", () => {
     expect(out).toContain("prefix=abcd1234");
     expect(out).toContain("tc-1 list_directory");
     expect(out).toContain("tc-1 ok 8B"); // "App.tsx\n".length === 8
+    expect(out).toContain('run_command args={"command":"npm test","apiKey":"[redacted]"}');
+    expect(out).toContain('run_command "npm test"');
   });
 
   it("--type filters to one event variant", () => {

--- a/tests/pause-gate.test.ts
+++ b/tests/pause-gate.test.ts
@@ -131,4 +131,70 @@ describe("PauseGate", () => {
     await expect(p2).resolves.toEqual({ type: "deny" });
     expect(gate.current).toBeNull();
   });
+
+  it("emits audit events for run_once / deny / always_allow shell decisions", async () => {
+    const gate = new PauseGate();
+    const audit = vi.fn();
+    gate.setAuditListener(audit);
+    gate.on(() => {});
+
+    const allow = gate.ask({ kind: "run_command", payload: { command: "npm test" } });
+    gate.resolve(gate.current!.id, { type: "run_once" } as ConfirmationChoice);
+    await expect(allow).resolves.toEqual({ type: "run_once" });
+
+    const deny = gate.ask({ kind: "run_background", payload: { command: "npm run dev" } });
+    gate.resolve(gate.current!.id, {
+      type: "deny",
+      denyContext: "too risky",
+    } as ConfirmationChoice);
+    await expect(deny).resolves.toEqual({ type: "deny", denyContext: "too risky" });
+
+    const always = gate.ask({ kind: "run_command", payload: { command: "npm run lint" } });
+    gate.resolve(gate.current!.id, {
+      type: "always_allow",
+      prefix: "npm run",
+    } as ConfirmationChoice);
+    await expect(always).resolves.toEqual({ type: "always_allow", prefix: "npm run" });
+
+    expect(audit.mock.calls).toEqual([
+      [
+        {
+          type: "tool.confirm.allow",
+          kind: "run_command",
+          payload: { command: "npm test" },
+        },
+      ],
+      [
+        {
+          type: "tool.confirm.deny",
+          kind: "run_background",
+          payload: { command: "npm run dev" },
+          denyContext: "too risky",
+        },
+      ],
+      [
+        {
+          type: "tool.confirm.always_allow",
+          kind: "run_command",
+          payload: { command: "npm run lint" },
+          prefix: "npm run",
+        },
+      ],
+    ]);
+  });
+
+  it("does not emit audit events for non-tool pauses", async () => {
+    const gate = new PauseGate();
+    const audit = vi.fn();
+    gate.setAuditListener(audit);
+    gate.on(() => {});
+
+    const promise = gate.ask({
+      kind: "plan_proposed",
+      payload: { plan: "# Plan", steps: [], summary: "ship it" },
+    });
+    gate.resolve(gate.current!.id, { type: "approve" });
+    await expect(promise).resolves.toEqual({ type: "approve" });
+    expect(audit).not.toHaveBeenCalled();
+  });
 });

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -19,6 +19,30 @@ describe("ToolRegistry", () => {
     expect(result).toBe("5");
   });
 
+  it("emits tool.call audit events with parsed args", async () => {
+    const reg = new ToolRegistry();
+    const seen: Array<{ name: string; args: Record<string, unknown> }> = [];
+    reg.register({
+      name: "echo",
+      fn: (args: { msg: string; apiKey: string }) => args.msg,
+    });
+    reg.setAuditListener((event) => {
+      seen.push({
+        name: event.name,
+        args: JSON.parse(JSON.stringify(event.args)) as Record<string, unknown>,
+      });
+    });
+
+    await reg.dispatch("echo", '{"msg":"hi","apiKey":"secret-value"}');
+
+    expect(seen).toEqual([
+      {
+        name: "echo",
+        args: { msg: "hi", apiKey: "secret-value" },
+      },
+    ]);
+  });
+
   it("returns structured error for unknown tool", async () => {
     const reg = new ToolRegistry();
     const out = await reg.dispatch("nope", "{}");


### PR DESCRIPTION
## What

Emit structured audit events for tool calls and shell confirmation decisions, then teach `reasonix events` how to render them. This records `tool.call`, `tool.confirm.allow`, `tool.confirm.deny`, and `tool.confirm.always_allow` in the event stream with redacted arguments, without polluting test-fixture snapshots.

## Why

Closes #260. Today the append-only event log shows dispatch/result events but not the original tool args or the user's confirmation choice for shell tools, which makes replay/auditing incomplete.

## How to verify

- `npm run verify`
- `npx vitest run tests/tools.test.ts tests/pause-gate.test.ts tests/events-command.test.ts`
