### PR TITLE
fix(web): rewrite htmlToText with a real HTML parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "commander": "^12.1.0",
         "eventsource-parser": "^3.0.0",
         "ignore": "^7.0.5",
+        "node-html-parser": "^7.1.0",
         "picomatch": "^4.0.4",
         "react": "^18.3.1",
         "react-reconciler": "^0.29.2",
@@ -2580,6 +2581,12 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
@@ -3084,6 +3091,34 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -3137,6 +3172,61 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -3171,6 +3261,18 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/environment": {
       "version": "1.1.0",
@@ -3716,6 +3818,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
       }
     },
     "node_modules/highlight.js": {
@@ -4337,6 +4448,16 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/node-html-parser": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-7.1.0.tgz",
+      "integrity": "sha512-iJo8b2uYGT40Y8BTyy5ufL6IVbN8rbm/1QK2xffXU/1a/v3AAa0d1YAoqBNYqaS4R/HajkWIpIfdE6KcyFh1AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "he": "1.2.0"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.38",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
@@ -4372,6 +4493,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/object-assign": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "commander": "^12.1.0",
     "eventsource-parser": "^3.0.0",
     "ignore": "^7.0.5",
+    "node-html-parser": "^7.1.0",
     "picomatch": "^4.0.4",
     "react": "^18.3.1",
     "react-reconciler": "^0.29.2",

--- a/src/tools/web.ts
+++ b/src/tools/web.ts
@@ -1,5 +1,6 @@
 /** web_search uses Mojeek (DDG returns anti-bot 202 to unauthenticated POSTs); web_fetch sniffs HTML to text. */
 
+import { parse as parseHtml } from "node-html-parser";
 import type { ToolRegistry } from "../tools.js";
 
 export interface SearchResult {
@@ -185,14 +186,36 @@ async function readBodyCapped(resp: Response, maxBytes: number): Promise<string>
 /** Hard cap so the per-request HTML budget stays linear-time even on adversarial pages. */
 const MAX_HTML_INPUT = 5 * 1024 * 1024;
 
-const STRIP_BLOCK_TAGS = ["script", "style", "noscript", "nav", "footer", "aside", "svg"];
+const STRIP_BLOCK_TAGS = "script, style, noscript, nav, footer, aside, svg";
+
+/** Block-level tags that should produce a paragraph break in the extracted text. */
+const BLOCK_BREAK_TAGS = new Set([
+  "p",
+  "div",
+  "br",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "li",
+  "tr",
+  "section",
+  "article",
+]);
 
 export function htmlToText(html: string): string {
-  let s = html.length > MAX_HTML_INPUT ? html.slice(0, MAX_HTML_INPUT) : html;
-  for (const tag of STRIP_BLOCK_TAGS) s = stripTagBlock(s, tag);
-  // Preserve paragraph breaks by turning common block tags into newlines.
-  s = s.replace(/<\/?(p|div|br|h[1-6]|li|tr|section|article)\b[^>]*>/gi, "\n");
-  s = s.replace(/<[^>]+>/g, "");
+  const input = html.length > MAX_HTML_INPUT ? html.slice(0, MAX_HTML_INPUT) : html;
+  // Real HTML parser — sidesteps the well-known regex anti-patterns
+  // (`<X[\s\S]*?</X>`, `<[^>]+>`) CodeQL flags as bad-tag-filter and
+  // incomplete-multi-character-sanitization.
+  const root = parseHtml(input);
+  for (const node of root.querySelectorAll(STRIP_BLOCK_TAGS)) node.remove();
+
+  const out: string[] = [];
+  walkExtract(root, out);
+  let s = out.join("");
   s = decodeHtmlEntities(s);
   s = s.replace(/[ \t]+/g, " ");
   s = s.replace(/\n[ \t]+/g, "\n");
@@ -200,46 +223,29 @@ export function htmlToText(html: string): string {
   return s.trim();
 }
 
-function stripHtml(s: string): string {
-  return s.replace(/<[^>]+>/g, "");
+interface WalkableNode {
+  nodeType: number;
+  rawText?: string;
+  text?: string;
+  rawTagName?: string;
+  childNodes: WalkableNode[];
 }
 
-/** Remove `<tag …>…</tag>` blocks via indexOf — the regex form `<tag[\s\S]*?</tag>` is O(n²) on adversarial input AND has well-known bypasses (`</tag >`, nested openings revealed after one pass). */
-function stripTagBlock(s: string, tag: string): string {
-  const lower = s.toLowerCase();
-  const openLead = `<${tag}`;
-  const closeLead = `</${tag}`;
-  let pos = 0;
-  let out = "";
-  while (pos < s.length) {
-    const openIdx = lower.indexOf(openLead, pos);
-    if (openIdx < 0) {
-      out += s.slice(pos);
-      break;
-    }
-    // Followed by `>`, `/`, or whitespace — otherwise it's a different tag (`<scriptfoo>`).
-    const after = s.charCodeAt(openIdx + openLead.length);
-    const isTagBoundary = after === 0x3e || after === 0x2f || after === 0x20 || after === 0x09;
-    if (!isTagBoundary) {
-      out += s.slice(pos, openIdx + 1);
-      pos = openIdx + 1;
-      continue;
-    }
-    const closeIdx = lower.indexOf(closeLead, openIdx + openLead.length);
-    if (closeIdx < 0) {
-      // No closer — drop the open tag and everything after, matching the original regex's "no match" behaviour at end of input.
-      out += s.slice(pos, openIdx);
-      break;
-    }
-    const closeEnd = s.indexOf(">", closeIdx + closeLead.length);
-    if (closeEnd < 0) {
-      out += s.slice(pos, openIdx);
-      break;
-    }
-    out += s.slice(pos, openIdx);
-    pos = closeEnd + 1;
+function walkExtract(node: WalkableNode, out: string[]): void {
+  // nodeType 3 = TEXT_NODE; 1 = ELEMENT_NODE per node-html-parser.
+  if (node.nodeType === 3) {
+    out.push(node.rawText ?? node.text ?? "");
+    return;
   }
-  return out;
+  const tag = node.rawTagName?.toLowerCase();
+  const isBreak = tag !== undefined && BLOCK_BREAK_TAGS.has(tag);
+  if (isBreak) out.push("\n");
+  for (const child of node.childNodes) walkExtract(child, out);
+  if (isBreak) out.push("\n");
+}
+
+function stripHtml(s: string): string {
+  return parseHtml(s).text;
 }
 
 const HTML_ENTITIES: Readonly<Record<string, string>> = {


### PR DESCRIPTION
Drains the 3 CodeQL warnings clustered on `htmlToText`'s chain-of-regex approach by switching to a real HTML parser.

## What was racing on what

| Rule | Pattern | Real-world bug |
|---|---|---|
| `js/incomplete-multi-character-sanitization` | `<tag[\s\S]*?</tag>` | misses `</tag >` (whitespace before `>`); re-exposes `<tag` after one pass on `<scr<tag>ipt>`-shaped input |
| `js/polynomial-redos` | same | catastrophic backtracking on adversarial input |
| `js/incomplete-multi-character-sanitization` | `<[^>]+>` | doesn't handle attribute values containing `>` (rare but legal) |

For the LLM-as-consumer pipeline these are theoretical (no XSS surface), but the underlying parser is genuinely flaky on the malformed HTML real sites ship.

## What changes

- Adds `node-html-parser` 7.x as a runtime dep (25 KB gzip, zero deps, no transitives — lighter than `parse5`; we don't need full HTML5 conformance, just the tree).
- `htmlToText` now `parseHtml`s the input, removes `script / style / noscript / nav / footer / aside / svg` blocks via `querySelectorAll(...).remove()`, then walks the surviving tree and emits text with `\n` breaks at the block-level tags we care about (`p`, `div`, `br`, `h1-6`, `li`, `tr`, `section`, `article`).
- `stripHtml` (used by `parseMojeekResults`) becomes `parseHtml(s).text`.
- `decodeHtmlEntities` stays — useful as a post-parser pass for any numeric entities the parser passes through verbatim in attribute contexts.
- 5 MB input cap retained.

## Acceptance

- [x] `npm run verify` green (2336 pass + 1 pre-existing skip)
- [x] No public API change — `htmlToText`, `parseMojeekResults`, `webFetch`, `webSearch` signatures unchanged
- [x] 21 `tests/web-tools.test.ts` cases pass unchanged

## What's still open after this

Down to 1 error + 7 warnings on CodeQL. Remainder are mostly design-level patterns: `process.env` propagation in shell tools (`indirect-command-line-injection` ×3), the `withUtf8Codepage` cmd.exe wrapper (the lone `error`), intentional file↔HTTP transfers (downloads / SSE upload), and one benchmark-script sanitization. Those need either inline ignore comments with explanations or maintainer-side dismissal — separate PR.