### PR TITLE
refactor(loop): extract escalation marker + summary-reason helpers

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -22,15 +22,14 @@ import {
   truncateForModelByTokens,
 } from "./mcp/registry.js";
 
-const FAILURE_ESCALATION_THRESHOLD = 3;
-const ESCALATION_MODEL = "deepseek-v4-pro";
-/** Accepts `<<<NEEDS_PRO>>>` or `<<<NEEDS_PRO: reason>>>` (reason trimmed, may be empty). */
-const NEEDS_PRO_MARKER_PREFIX = "<<<NEEDS_PRO";
-const NEEDS_PRO_MARKER_RE = /^<<<NEEDS_PRO(?::\s*([^>]*))?>>>/;
-/** Buffer cap before flushing — must fit `<<<NEEDS_PRO: reason>>>` without premature flush. */
-const NEEDS_PRO_BUFFER_CHARS = 256;
 import { ContextManager } from "./context-manager.js";
-import { formatLoopError } from "./loop/errors.js";
+import { errorLabelFor, formatLoopError, reasonPrefixFor } from "./loop/errors.js";
+import {
+  NEEDS_PRO_BUFFER_CHARS,
+  isEscalationRequest,
+  looksLikePartialEscalationMarker,
+  parseEscalationMarker,
+} from "./loop/escalation.js";
 import {
   fixToolCallPairing,
   healLoadedMessages,
@@ -55,6 +54,9 @@ import { SessionStats, type TurnStats } from "./telemetry/stats.js";
 import { countTokens } from "./tokenizer.js";
 import { ToolRegistry } from "./tools.js";
 import type { ChatMessage, ToolCall } from "./types.js";
+
+const FAILURE_ESCALATION_THRESHOLD = 3;
+const ESCALATION_MODEL = "deepseek-v4-pro";
 
 export {
   fixToolCallPairing,
@@ -431,33 +433,6 @@ export class CacheFirstLoop {
 
   private modelForCurrentCall(): string {
     return this._escalateThisTurn ? ESCALATION_MODEL : this.model;
-  }
-
-  /** Anchored to lead — mid-text matches are normal content (user asking about the marker). */
-  private parseEscalationMarker(content: string): { matched: boolean; reason?: string } {
-    const m = NEEDS_PRO_MARKER_RE.exec(content.trimStart());
-    if (!m) return { matched: false };
-    const reason = m[1]?.trim();
-    return { matched: true, reason: reason || undefined };
-  }
-
-  /** Convenience boolean — same gate the streaming path used to call. */
-  private isEscalationRequest(content: string): boolean {
-    return this.parseEscalationMarker(content).matched;
-  }
-
-  /** Drives streaming flush — while plausibly partial, keep accumulating; else flush. */
-  private looksLikePartialEscalationMarker(buf: string): boolean {
-    const t = buf.trimStart();
-    if (t.length === 0) return true;
-    if (t.length <= NEEDS_PRO_MARKER_PREFIX.length) {
-      return NEEDS_PRO_MARKER_PREFIX.startsWith(t);
-    }
-    if (!t.startsWith(NEEDS_PRO_MARKER_PREFIX)) return false;
-    const rest = t.slice(NEEDS_PRO_MARKER_PREFIX.length);
-    // Only `>` (close) or `:` (reason) are valid after the prefix.
-    if (rest[0] !== ">" && rest[0] !== ":") return false;
-    return true;
   }
 
   /** Returns true ONLY on the tipping call — caller surfaces a one-shot warning. */
@@ -862,7 +837,7 @@ export class CacheFirstLoop {
                 // Early exit: marker matches — break and let the
                 // post-call retry path take over. No delta was yielded
                 // so the user sees nothing flicker.
-                if (this.isEscalationRequest(escalationBuf)) {
+                if (isEscalationRequest(escalationBuf)) {
                   break;
                 }
                 // Flush once we have enough content to rule out the
@@ -870,7 +845,7 @@ export class CacheFirstLoop {
                 // the look-ahead window).
                 if (
                   escalationBuf.length >= NEEDS_PRO_BUFFER_CHARS ||
-                  !this.looksLikePartialEscalationMarker(escalationBuf)
+                  !looksLikePartialEscalationMarker(escalationBuf)
                 ) {
                   escalationBufFlushed = true;
                   yield {
@@ -942,7 +917,7 @@ export class CacheFirstLoop {
           // buffer ISN'T the marker, flush it as the final delta so
           // the user sees it. Marker-match is handled post-call.
           if (bufferForEscalation && !escalationBufFlushed && escalationBuf.length > 0) {
-            if (!this.isEscalationRequest(escalationBuf)) {
+            if (!isEscalationRequest(escalationBuf)) {
               yield {
                 turn: this._turn,
                 role: "assistant_delta",
@@ -1008,9 +983,9 @@ export class CacheFirstLoop {
       if (
         this.autoEscalate &&
         this.modelForCurrentCall() !== ESCALATION_MODEL &&
-        this.isEscalationRequest(assistantContent)
+        isEscalationRequest(assistantContent)
       ) {
-        const { reason } = this.parseEscalationMarker(assistantContent);
+        const { reason } = parseEscalationMarker(assistantContent);
         this._escalateThisTurn = true;
         const reasonSuffix = reason ? ` — ${reason}` : "";
         yield {
@@ -1427,30 +1402,6 @@ function* hookWarnings(outcomes: HookOutcome[], turn: number): Generator<LoopEve
     if (o.decision === "pass") continue;
     yield { turn, role: "warning", content: formatHookOutcomeMessage(o) };
   }
-}
-
-function reasonPrefixFor(
-  reason: "budget" | "aborted" | "context-guard" | "stuck",
-  iterCap: number,
-): string {
-  if (reason === "aborted") return "[aborted by user (Esc) — summarizing what I found so far]";
-  if (reason === "context-guard") {
-    return "[context budget running low — summarizing before the next call would overflow]";
-  }
-  if (reason === "stuck") {
-    return "[stuck on a repeated tool call — explaining what was tried and what's blocking progress]";
-  }
-  return `[tool-call budget (${iterCap}) reached — forcing summary from what I found]`;
-}
-
-function errorLabelFor(
-  reason: "budget" | "aborted" | "context-guard" | "stuck",
-  iterCap: number,
-): string {
-  if (reason === "aborted") return "aborted by user";
-  if (reason === "context-guard") return "context-guard triggered (prompt > 80% of window)";
-  if (reason === "stuck") return "stuck (repeated tool call suppressed by storm-breaker)";
-  return `tool-call budget (${iterCap}) reached`;
 }
 
 function summarizeBranch(chosen: BranchSample, samples: BranchSample[]): BranchSummary {

--- a/src/loop/errors.ts
+++ b/src/loop/errors.ts
@@ -30,6 +30,30 @@ export function formatLoopError(err: Error): string {
   return msg;
 }
 
+export function reasonPrefixFor(
+  reason: "budget" | "aborted" | "context-guard" | "stuck",
+  iterCap: number,
+): string {
+  if (reason === "aborted") return "[aborted by user (Esc) — summarizing what I found so far]";
+  if (reason === "context-guard") {
+    return "[context budget running low — summarizing before the next call would overflow]";
+  }
+  if (reason === "stuck") {
+    return "[stuck on a repeated tool call — explaining what was tried and what's blocking progress]";
+  }
+  return `[tool-call budget (${iterCap}) reached — forcing summary from what I found]`;
+}
+
+export function errorLabelFor(
+  reason: "budget" | "aborted" | "context-guard" | "stuck",
+  iterCap: number,
+): string {
+  if (reason === "aborted") return "aborted by user";
+  if (reason === "context-guard") return "context-guard triggered (prompt > 80% of window)";
+  if (reason === "stuck") return "stuck (repeated tool call suppressed by storm-breaker)";
+  return `tool-call budget (${iterCap}) reached`;
+}
+
 function extractDeepSeekErrorMessage(body: string): string {
   const trimmed = body.trim();
   if (!trimmed) return "(no message)";

--- a/src/loop/escalation.ts
+++ b/src/loop/escalation.ts
@@ -1,0 +1,31 @@
+/** Accepts `<<<NEEDS_PRO>>>` or `<<<NEEDS_PRO: reason>>>` (reason trimmed, may be empty). */
+const NEEDS_PRO_MARKER_PREFIX = "<<<NEEDS_PRO";
+const NEEDS_PRO_MARKER_RE = /^<<<NEEDS_PRO(?::\s*([^>]*))?>>>/;
+/** Buffer cap before flushing — must fit `<<<NEEDS_PRO: reason>>>` without premature flush. */
+export const NEEDS_PRO_BUFFER_CHARS = 256;
+
+/** Anchored to lead — mid-text matches are normal content (user asking about the marker). */
+export function parseEscalationMarker(content: string): { matched: boolean; reason?: string } {
+  const m = NEEDS_PRO_MARKER_RE.exec(content.trimStart());
+  if (!m) return { matched: false };
+  const reason = m[1]?.trim();
+  return { matched: true, reason: reason || undefined };
+}
+
+/** Convenience boolean — same gate the streaming path used to call. */
+export function isEscalationRequest(content: string): boolean {
+  return parseEscalationMarker(content).matched;
+}
+
+/** Drives streaming flush — while plausibly partial, keep accumulating; else flush. */
+export function looksLikePartialEscalationMarker(buf: string): boolean {
+  const t = buf.trimStart();
+  if (t.length === 0) return true;
+  if (t.length <= NEEDS_PRO_MARKER_PREFIX.length) {
+    return NEEDS_PRO_MARKER_PREFIX.startsWith(t);
+  }
+  if (!t.startsWith(NEEDS_PRO_MARKER_PREFIX)) return false;
+  const rest = t.slice(NEEDS_PRO_MARKER_PREFIX.length);
+  if (rest[0] !== ">" && rest[0] !== ":") return false;
+  return true;
+}


### PR DESCRIPTION
First PR under #307. Six functions and three constants in `loop.ts` never touched `this` — they had no business living inside `CacheFirstLoop`.

## What moved

- new `src/loop/escalation.ts` — `parseEscalationMarker`, `isEscalationRequest`, `looksLikePartialEscalationMarker`, plus `NEEDS_PRO_MARKER_PREFIX` / `NEEDS_PRO_MARKER_RE` / `NEEDS_PRO_BUFFER_CHARS`. Three former private methods on the class become free functions; the streaming chunk consumer + post-call retry path call them directly now.
- `src/loop/errors.ts` gains `reasonPrefixFor` + `errorLabelFor` next to `formatLoopError`. Same `"budget" | "aborted" | "context-guard" | "stuck"` reason union, single owner.

## Diff summary

- 3 files changed, +70 / -64
- `src/loop.ts`: 1463 → 1414 lines (-49)
- `src/loop/errors.ts`: +25 lines
- new `src/loop/escalation.ts`: 31 lines

## Acceptance (#307)

- [x] No public API change — moved names were `private` methods or file-local
- [x] No semantic diff — `npm run verify` green (2336 pass / 1 skip)
- [x] `loop.ts` line count drops monotonically — 1463 → 1414
- [ ] `loop.ts` ≤ 500 — not yet, follow-up PRs continue under #307

## What's next under #307

The remaining bulk is the 765-line `step()` body. Subsequent PRs will tackle the seams listed in #307 (pre-flight gate, iter-budget warning, hook reporting, etc.). This PR was the lowest-risk piece: pure functions that just lived in the wrong file.