### PR TITLE
fix(ui): top bar cost + subagent end-cost follow wallet currency

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -394,10 +394,14 @@ function AppInner({
   }, [stdout]);
   // Subagent UI wiring: live activity row + sink ref the loop closure
   // captures. Must be declared BEFORE loop construction so the
-  // subagentRunner closure can read the ref.
+  // subagentRunner closure can read the ref. The wallet-currency thunk
+  // reads from a ref populated AFTER useSessionInfo loads balance, so the
+  // subagent-end cost suffix renders in the live wallet's symbol.
+  const walletCurrencyRef = useRef<string | undefined>(undefined);
   const { activity: subagentActivity, sinkRef: subagentSinkRef } = useSubagent({
     session,
     log,
+    getWalletCurrency: () => walletCurrencyRef.current,
   });
   // Transient "what's happening" text set by the loop during silent
   // phases (harvest round-trip, between-iteration R1 thinking, forced
@@ -887,6 +891,7 @@ function AppInner({
   const balanceRef = useRef<typeof balance>(null);
   useEffect(() => {
     balanceRef.current = balance;
+    walletCurrencyRef.current = balance?.currency;
     if (balance) {
       agentStore.dispatch({
         type: "session.update",

--- a/src/cli/ui/StatsPanel.tsx
+++ b/src/cli/ui/StatsPanel.tsx
@@ -6,6 +6,7 @@ import type { EditMode } from "../../config.js";
 import type { SessionSummary } from "../../telemetry/stats.js";
 import { Bar, ChromeRule } from "./primitives.js";
 import { COLOR, GRADIENT } from "./theme.js";
+import { formatBalance, formatCost } from "./theme/tokens.js";
 
 const COLD_START_TURNS = 3;
 
@@ -91,9 +92,9 @@ function ChromeRow({
   const cacheColor =
     summary.cacheHitRatio >= 0.7 ? COLOR.ok : summary.cacheHitRatio >= 0.4 ? COLOR.warn : COLOR.err;
   const balanceLabel = balance
-    ? `[w ${balance.currency === "USD" ? "$" : ""}${balance.total.toFixed(2)}${balance.currency !== "USD" ? ` ${balance.currency}` : ""}]`
+    ? `[${formatBalance(balance.total, balance.currency, { label: true })}]`
     : "";
-  const costLabel = `[$${summary.totalCostUsd.toFixed(4)}]`;
+  const costLabel = `[${formatCost(summary.totalCostUsd, balance?.currency)}]`;
   const cacheLabel = "[c ▰▰▰▰▰▰ 100%]";
   const updateLabel = updateAvailable ? `↑ ${updateAvailable}` : "";
 

--- a/src/cli/ui/useSubagent.ts
+++ b/src/cli/ui/useSubagent.ts
@@ -3,7 +3,7 @@ import type { LoopEvent } from "../../loop.js";
 import { appendUsage } from "../../telemetry/usage.js";
 import type { SubagentEvent, SubagentSink } from "../../tools/subagent.js";
 import type { Scrollback } from "./hooks/useScrollback.js";
-import { CARD, TONE } from "./theme/tokens.js";
+import { CARD, TONE, formatCost } from "./theme/tokens.js";
 
 function summariseInner(ev: LoopEvent): SubagentInnerSummary | null {
   if (ev.role === "tool_start") {
@@ -52,6 +52,8 @@ export interface SubagentActivity {
 export interface UseSubagentParams {
   session: string | undefined;
   log: Scrollback;
+  /** Read live wallet currency at end-event time so the cost suffix follows the wallet symbol. */
+  getWalletCurrency?: () => string | undefined;
 }
 
 export interface UseSubagentResult {
@@ -60,9 +62,19 @@ export interface UseSubagentResult {
   sinkRef: React.MutableRefObject<SubagentSink>;
 }
 
-export function useSubagent({ session, log }: UseSubagentParams): UseSubagentResult {
+export function useSubagent({
+  session,
+  log,
+  getWalletCurrency,
+}: UseSubagentParams): UseSubagentResult {
   const [activity, setActivity] = useState<SubagentActivity | null>(null);
   const sinkRef = useRef<SubagentSink>({ current: null });
+  // Subagent runs can outlive a balance refresh; the thunk lives in a ref so the
+  // sink callback (installed once at mount) always reads the latest wallet currency.
+  const getWalletCurrencyRef = useRef(getWalletCurrency);
+  useEffect(() => {
+    getWalletCurrencyRef.current = getWalletCurrency;
+  }, [getWalletCurrency]);
 
   useEffect(() => {
     sinkRef.current.current = (ev: SubagentEvent) => {
@@ -113,7 +125,9 @@ export function useSubagent({ session, log }: UseSubagentParams): UseSubagentRes
       const seconds = ((ev.elapsedMs ?? 0) / 1000).toFixed(1);
       // Inline cost: the one number most users look at. Saves a /stats round-trip.
       const costTail =
-        ev.costUsd !== undefined && ev.costUsd > 0 ? ` · $${ev.costUsd.toFixed(4)}` : "";
+        ev.costUsd !== undefined && ev.costUsd > 0
+          ? ` · ${formatCost(ev.costUsd, getWalletCurrencyRef.current?.())}`
+          : "";
       const summary = ev.error
         ? `⌬ subagent "${ev.task}" failed after ${seconds}s · ${ev.iter ?? 0} tool call(s) — ${ev.error}`
         : `⌬ subagent "${ev.task}" done in ${seconds}s · ${ev.iter ?? 0} tool call(s) · ${ev.turns ?? 0} turn(s)${costTail}`;

--- a/tests/ui-stats-panel-currency.test.tsx
+++ b/tests/ui-stats-panel-currency.test.tsx
@@ -1,0 +1,67 @@
+import { render } from "ink";
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { StatsPanel } from "../src/cli/ui/StatsPanel.js";
+import type { SessionSummary } from "../src/telemetry/stats.js";
+
+function makeFakeStdout() {
+  const chunks: string[] = [];
+  return {
+    columns: 120,
+    rows: 30,
+    isTTY: true,
+    write(chunk: string) {
+      chunks.push(chunk);
+      return true;
+    },
+    on() {},
+    off() {},
+    text(): string {
+      // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI SGR codes
+      return chunks.join("").replace(/\x1b\[[0-9;]*m/g, "");
+    },
+  };
+}
+
+const SUMMARY: SessionSummary = {
+  turns: 5,
+  totalCostUsd: 0.0308,
+  totalInputCostUsd: 0.01,
+  totalOutputCostUsd: 0.02,
+  claudeEquivalentUsd: 0.5,
+  savingsVsClaudePct: 0.94,
+  cacheHitRatio: 0.8,
+  lastPromptTokens: 1000,
+  lastTurnCostUsd: 0.0001,
+};
+
+function renderPanel(balance: { currency: string; total: number } | null): string {
+  const stdout = makeFakeStdout();
+  const { unmount } = render(React.createElement(StatsPanel, { summary: SUMMARY, balance }), {
+    stdout: stdout as any,
+    stdin: process.stdin as any,
+  });
+  unmount();
+  return stdout.text();
+}
+
+describe("StatsPanel — top-bar cost + balance follow wallet currency", () => {
+  it("USD wallet: cost shows $0.0308 and balance shows $0.91", () => {
+    const text = renderPanel({ currency: "USD", total: 0.91 });
+    expect(text).toContain("[$0.0308]");
+    expect(text).toContain("[w $0.91]");
+    expect(text).not.toContain("¥");
+  });
+
+  it("CNY wallet: USD cost is converted to ¥ and balance shows ¥6.55", () => {
+    const text = renderPanel({ currency: "CNY", total: 6.55 });
+    expect(text).toContain("[¥0.2218]");
+    expect(text).toContain("[w ¥6.55]");
+  });
+
+  it("no wallet: cost defaults to ¥ (matches pre-fix unconditional ¥)", () => {
+    const text = renderPanel(null);
+    expect(text).toContain("[¥0.2218]");
+    expect(text).not.toContain("[w ");
+  });
+});


### PR DESCRIPTION
## Summary

Closes the consistency gap left after #272: three live-render display sites still hardcoded `\$` and ignored wallet currency.

- **`StatsPanel.ChromeRow` cost label** `[\$0.0058]` → `[\$0.0058]` for USD wallet, `[¥0.0418]` for CNY wallet, `[¥0.0418]` when no wallet (default-CNY backward compat).
- **`StatsPanel.ChromeRow` balance label** — used to inline-format with manual `\${balance.total}` template; now routes through the `formatBalance` helper from #272 like the rest of the codebase.
- **`useSubagent` end-event summary** — ` · \$0.0123` cost suffix on the subagent-finished log row now follows the wallet symbol.

`useSubagent` takes a `getWalletCurrency: () => string | undefined` thunk rather than a snapshot value, because subagent runs can outlive a balance refresh — the thunk reads the live currency at end-event time. App.tsx forward-declares a `walletCurrencyRef` before the `useSubagent` call (it's installed before loop construction) and populates it when `useSessionInfo`'s balance arrives.

## Out of scope (intentional)

- **`ChromeBar.tsx`** — only referenced from tests + CHANGELOG, no live render path. Worth deleting in a separate cleanup.
- **`DiffApp.tsx`** — `reasonix diff` CLI compares two historical sessions; the `\$0.000123` six-decimal format is for engineers reading raw cost deltas. No live wallet context anyway.
- **`StatsPanel.BudgetRow`** — the `--budget` cap is user-set in USD by definition. Stays \$.
- **`SessionPicker.tsx`** — tracked separately in #312 (different file shape, threading wallet currency in there is a bigger lift).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `tests/ui-stats-panel-currency.test.tsx` (new, 3 tests) — USD / CNY / no-wallet variants
- [x] `tests/ui-status-row-balance.test.tsx`, `tests/ui-usage-card-balance.test.tsx`, `tests/ui-reducer.test.ts` — 49 pre-existing pass unchanged
- [x] biome organizeImports + format applied