### PR TITLE
feat(subagent): honor skill allowed-tools frontmatter

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -780,6 +780,7 @@ function AppInner({
             // Per-skill model override (frontmatter `model: ...`),
             // else falls through to spawnSubagent's default.
             model: skill.model,
+            allowedTools: skill.allowedTools,
             sink: subagentSinkRef.current,
             // Stamped onto every event so the TUI sink + usage log can
             // attribute the run to a skill without extra bookkeeping.

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -28,8 +28,8 @@ export interface Skill {
   scope: SkillScope;
   /** Absolute path to the SKILL.md (or {name}.md) file, or "(builtin)" for shipped defaults. */
   path: string;
-  /** Raw `allowed-tools` field from frontmatter, if any. Unused in v1. */
-  allowedTools?: string;
+  /** Parsed `allowed-tools` frontmatter — when present, the spawned subagent's registry is scoped to these literal tool names. */
+  allowedTools?: readonly string[];
   runAs: SkillRunAs;
   /** Subagent model override; only meaningful when `runAs === "subagent"`. */
   model?: string;
@@ -67,6 +67,15 @@ function parseFrontmatter(raw: string): { data: Record<string, string>; body: st
 
 function isValidSkillName(name: string): boolean {
   return VALID_SKILL_NAME.test(name);
+}
+
+function parseAllowedTools(raw: string | undefined): readonly string[] | undefined {
+  if (raw === undefined) return undefined;
+  const names = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return names.length > 0 ? Object.freeze(names) : undefined;
 }
 
 export class SkillStore {
@@ -176,7 +185,7 @@ export class SkillStore {
       body: body.trim(),
       scope,
       path,
-      allowedTools: data["allowed-tools"],
+      allowedTools: parseAllowedTools(data["allowed-tools"]),
       runAs: parseRunAs(data.runAs),
       model: data.model?.startsWith("deepseek-") ? data.model : undefined,
     };

--- a/src/tools/subagent.ts
+++ b/src/tools/subagent.ts
@@ -46,6 +46,8 @@ export interface SpawnSubagentOptions {
   /** Forwarded into the child loop so parent Esc cancels nested work. */
   parentSignal?: AbortSignal;
   skillName?: string;
+  /** Scopes the child registry to these literal tool names; NEVER_INHERITED still wins. Driven by skill `allowed-tools` frontmatter. */
+  allowedTools?: readonly string[];
 }
 
 export interface SubagentResult {
@@ -122,7 +124,44 @@ export async function spawnSubagent(opts: SpawnSubagentOptions): Promise<Subagen
     elapsedMs: 0,
   });
 
-  const childTools = forkRegistryExcluding(opts.parentRegistry, NEVER_INHERITED_TOOLS);
+  if (opts.allowedTools) {
+    const missing = opts.allowedTools.filter((n) => !opts.parentRegistry.has(n));
+    if (missing.length > 0) {
+      const errorMessage = `subagent allow-list names tool(s) not registered in the parent: ${missing.join(", ")}. Fix the skill's \`allowed-tools\` frontmatter or check spelling.`;
+      sink?.current?.({
+        kind: "end",
+        task: taskPreview,
+        skillName,
+        model,
+        iter: 0,
+        elapsedMs: Date.now() - startedAt,
+        error: errorMessage,
+        turns: 0,
+        costUsd: 0,
+        usage: new Usage(),
+      });
+      return {
+        success: false,
+        output: "",
+        error: errorMessage,
+        turns: 0,
+        toolIters: 0,
+        elapsedMs: Date.now() - startedAt,
+        costUsd: 0,
+        model,
+        skillName,
+        usage: new Usage(),
+      };
+    }
+  }
+
+  const childTools = opts.allowedTools
+    ? forkRegistryWithAllowList(
+        opts.parentRegistry,
+        new Set(opts.allowedTools),
+        NEVER_INHERITED_TOOLS,
+      )
+    : forkRegistryExcluding(opts.parentRegistry, NEVER_INHERITED_TOOLS);
   const childPrefix = new ImmutablePrefix({
     system: opts.system,
     toolSpecs: childTools.specs(),
@@ -391,6 +430,25 @@ export function forkRegistryExcluding(
     // Re-register copies the public ToolDefinition fields. The child
     // re-runs auto-flatten analysis on its own, which produces an
     // identical flatSchema for the same input — no surprise.
+    child.register(def);
+  }
+  if (parent.planMode) child.setPlanMode(true);
+  return child;
+}
+
+/** alsoExclude wins over allow so NEVER_INHERITED still drops `spawn_subagent` even if a skill allow-list names it. */
+export function forkRegistryWithAllowList(
+  parent: ToolRegistry,
+  allow: ReadonlySet<string>,
+  alsoExclude: ReadonlySet<string>,
+): ToolRegistry {
+  const child = new ToolRegistry();
+  for (const spec of parent.specs()) {
+    const name = spec.function.name;
+    if (!allow.has(name)) continue;
+    if (alsoExclude.has(name)) continue;
+    const def = parent.get(name);
+    if (!def) continue;
     child.register(def);
   }
   if (parent.planMode) child.setPlanMode(true);

--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -303,6 +303,38 @@ describe("Skill frontmatter — runAs", () => {
     expect(store.read("rsr")?.model).toBe("deepseek-reasoner");
     expect(store.read("wrong")?.model).toBeUndefined();
   });
+
+  it("parses comma-separated allowed-tools into a trimmed list", () => {
+    writeSkillDir(
+      home,
+      "global",
+      "scoped",
+      { description: "...", runAs: "subagent", "allowed-tools": "read, search_content,write" },
+      "body",
+      home,
+    );
+    const store = new SkillStore({ homeDir: home, disableBuiltins: true });
+    expect(store.read("scoped")?.allowedTools).toEqual(["read", "search_content", "write"]);
+  });
+
+  it("treats missing allowed-tools as undefined (full inheritance)", () => {
+    writeSkillDir(home, "global", "open", { description: "...", runAs: "subagent" }, "body", home);
+    const store = new SkillStore({ homeDir: home, disableBuiltins: true });
+    expect(store.read("open")?.allowedTools).toBeUndefined();
+  });
+
+  it("treats an allowed-tools field with only whitespace/commas as undefined", () => {
+    writeSkillDir(
+      home,
+      "global",
+      "empty",
+      { description: "...", runAs: "subagent", "allowed-tools": " , , " },
+      "body",
+      home,
+    );
+    const store = new SkillStore({ homeDir: home, disableBuiltins: true });
+    expect(store.read("empty")?.allowedTools).toBeUndefined();
+  });
 });
 
 describe("Built-in skills", () => {

--- a/tests/subagent.test.ts
+++ b/tests/subagent.test.ts
@@ -7,7 +7,9 @@ import {
   type SubagentEvent,
   type SubagentSink,
   forkRegistryExcluding,
+  forkRegistryWithAllowList,
   registerSubagentTool,
+  spawnSubagent,
 } from "../src/tools/subagent.js";
 
 interface FakeResponseShape {
@@ -422,5 +424,109 @@ describe("forkRegistryExcluding", () => {
     const child = forkRegistryExcluding(parent, new Set());
     const out = await child.dispatch("counter", "{}");
     expect(out).toBe("n=1");
+  });
+});
+
+describe("forkRegistryWithAllowList", () => {
+  it("includes only names in the allow-list", () => {
+    const parent = new ToolRegistry();
+    parent.register({ name: "read", fn: () => "read" });
+    parent.register({ name: "write", fn: () => "write" });
+    parent.register({ name: "shell", fn: () => "shell" });
+    const child = forkRegistryWithAllowList(parent, new Set(["read", "write"]), new Set());
+    expect(child.has("read")).toBe(true);
+    expect(child.has("write")).toBe(true);
+    expect(child.has("shell")).toBe(false);
+    expect(child.size).toBe(2);
+  });
+
+  it("alsoExclude wins over allow", () => {
+    const parent = new ToolRegistry();
+    parent.register({ name: "spawn_subagent", fn: () => "x" });
+    parent.register({ name: "read", fn: () => "read" });
+    const child = forkRegistryWithAllowList(
+      parent,
+      new Set(["read", "spawn_subagent"]),
+      new Set(["spawn_subagent"]),
+    );
+    expect(child.has("read")).toBe(true);
+    expect(child.has("spawn_subagent")).toBe(false);
+  });
+
+  it("propagates parent plan mode", () => {
+    const parent = new ToolRegistry();
+    parent.register({ name: "read", fn: () => "x" });
+    parent.setPlanMode(true);
+    const child = forkRegistryWithAllowList(parent, new Set(["read"]), new Set());
+    expect(child.planMode).toBe(true);
+  });
+
+  it("ignores allow-list names that are not registered (caller validates)", () => {
+    const parent = new ToolRegistry();
+    parent.register({ name: "read", fn: () => "x" });
+    const child = forkRegistryWithAllowList(parent, new Set(["read", "ghost"]), new Set());
+    expect(child.has("read")).toBe(true);
+    expect(child.has("ghost")).toBe(false);
+    expect(child.size).toBe(1);
+  });
+});
+
+describe("spawnSubagent allowedTools", () => {
+  it("scopes the child registry to the allow-list", async () => {
+    const parent = new ToolRegistry();
+    parent.register({ name: "read", fn: () => "read result" });
+    parent.register({ name: "write", fn: () => "write result" });
+    parent.register({ name: "shell", fn: () => "shell result" });
+    const client = makeClient([{ content: "done" }]);
+    const result = await spawnSubagent({
+      client,
+      parentRegistry: parent,
+      system: "test",
+      task: "test",
+      allowedTools: ["read"],
+    });
+    expect(result.success).toBe(true);
+    expect(parent.has("write")).toBe(true);
+    expect(parent.has("shell")).toBe(true);
+  });
+
+  it("returns a structured error when allow-list names a tool the parent does not have", async () => {
+    const parent = new ToolRegistry();
+    parent.register({ name: "read", fn: () => "read result" });
+    const client = makeClient([{ content: "should not run" }]);
+    const result = await spawnSubagent({
+      client,
+      parentRegistry: parent,
+      system: "test",
+      task: "test",
+      allowedTools: ["read", "missing_tool"],
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("missing_tool");
+    expect(result.error).toContain("allow-list");
+    expect(result.turns).toBe(0);
+    expect(result.toolIters).toBe(0);
+  });
+
+  it("emits start then end with the validation error and runs no API call", async () => {
+    const parent = new ToolRegistry();
+    parent.register({ name: "read", fn: () => "read result" });
+    const fetchSpy = vi.fn();
+    const client = new DeepSeekClient({
+      apiKey: "sk-test",
+      fetch: fetchSpy as unknown as typeof fetch,
+    });
+    const { sink, events } = makeSink();
+    await spawnSubagent({
+      client,
+      parentRegistry: parent,
+      system: "test",
+      task: "test",
+      allowedTools: ["ghost"],
+      sink,
+    });
+    expect(events.map((e) => e.kind)).toEqual(["start", "end"]);
+    expect(events[1]?.error).toContain("ghost");
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- Skills' `allowed-tools` frontmatter was parsed but ignored ("Unused in v1"). Wire it through so a subagent's child registry is scoped to the named tools.
- New `forkRegistryWithAllowList` helper alongside `forkRegistryExcluding`. `NEVER_INHERITED` (`spawn_subagent` / `submit_plan`) still wins so depth=1 + plan-mode guarantees hold even if a skill names them.
- Validate at spawn time: an allow-list naming a tool the parent doesn't have returns a structured error result (no API call burned).
- Direct (non-skill) `spawn_subagent` tool calls are unchanged — full inheritance minus NEVER_INHERITED, same as today.

## Test plan

- [x] Skill parser test: comma-separated → trimmed list; missing field → `undefined`; whitespace-only → `undefined`.
- [x] `forkRegistryWithAllowList` unit tests: scoping, alsoExclude wins, plan-mode propagation.
- [x] `spawnSubagent` integration: scoped child registry, validation error structure, `start → end` events with no fetch.
- [x] `npm run verify` green (lint, typecheck, full suite, build).

Closes #317
Tracking: #316