### PR TITLE
feat(subagent): expose max_iters on spawn_subagent tool schema

### DIFF
--- a/src/tools/subagent.ts
+++ b/src/tools/subagent.ts
@@ -90,6 +90,8 @@ ${TUI_FORMATTING_RULES}`;
 
 const DEFAULT_MAX_RESULT_CHARS = 8000;
 const DEFAULT_MAX_ITERS = 16;
+const MIN_MAX_ITERS = 1;
+const MAX_MAX_ITERS = 32;
 // Subagents default to flash — their work is read-and-synthesize
 // (explore, research), which doesn't need the 12× pro tier. Skill
 // frontmatter `model: deepseek-v4-pro` is the opt-in override for
@@ -380,10 +382,19 @@ export function registerSubagentTool(
           description:
             "Which DeepSeek model the subagent runs on. Default is 'deepseek-v4-flash' — cheap and fast, fine for explore/research-style subtasks. Override to 'deepseek-v4-pro' (~12× more expensive) when the subtask genuinely needs the stronger model: cross-file architecture, subtle bug hunts, anything where flash has empirically underperformed.",
         },
+        max_iters: {
+          type: "integer",
+          minimum: MIN_MAX_ITERS,
+          maximum: MAX_MAX_ITERS,
+          description: `Cap on the subagent's tool-call iterations. Default 16. Lower (e.g. 6-8) for narrow verify-style tasks; higher (e.g. 24) for broad exploration. Hard range: ${MIN_MAX_ITERS}-${MAX_MAX_ITERS}; out-of-range values are clamped to the nearest end.`,
+        },
       },
       required: ["task"],
     },
-    fn: async (args: { task?: unknown; system?: unknown; model?: unknown }, ctx) => {
+    fn: async (
+      args: { task?: unknown; system?: unknown; model?: unknown; max_iters?: unknown },
+      ctx,
+    ) => {
       const task = typeof args.task === "string" ? args.task.trim() : "";
       if (!task) {
         return JSON.stringify({
@@ -398,13 +409,14 @@ export function registerSubagentTool(
         typeof args.model === "string" && args.model.startsWith("deepseek-")
           ? args.model
           : defaultModel;
+      const callerIters = clampMaxIters(args.max_iters);
       const result = await spawnSubagent({
         client: opts.client,
         parentRegistry,
         system,
         task,
         model,
-        maxToolIters,
+        maxToolIters: callerIters ?? maxToolIters,
         maxResultChars,
         sink,
         parentSignal: ctx?.signal,
@@ -414,6 +426,15 @@ export function registerSubagentTool(
   });
 
   return parentRegistry;
+}
+
+/** Floats round down; non-finite / wrong-type yields undefined so caller falls back to its default. */
+function clampMaxIters(raw: unknown): number | undefined {
+  if (typeof raw !== "number" || !Number.isFinite(raw)) return undefined;
+  const n = Math.floor(raw);
+  if (n < MIN_MAX_ITERS) return MIN_MAX_ITERS;
+  if (n > MAX_MAX_ITERS) return MAX_MAX_ITERS;
+  return n;
 }
 
 /** Plan-mode state propagates — a subagent spawned under `/plan` MUST NOT escape it. */

--- a/tests/subagent.test.ts
+++ b/tests/subagent.test.ts
@@ -76,6 +76,19 @@ function makeClient(responses: FakeResponseShape[]) {
   });
 }
 
+function makeToolCallResponses(n: number): FakeResponseShape[] {
+  return Array.from({ length: n }, (_, i) => ({
+    content: "",
+    tool_calls: [
+      {
+        id: `call_${i + 1}`,
+        type: "function",
+        function: { name: "noop", arguments: JSON.stringify({ i: i + 1 }) },
+      },
+    ],
+  }));
+}
+
 function makeSink(): { sink: SubagentSink; events: SubagentEvent[] } {
   const events: SubagentEvent[] = [];
   const sink: SubagentSink = {
@@ -380,6 +393,58 @@ describe("registerSubagentTool", () => {
     const parsed = JSON.parse(out);
     expect(parsed.success).toBe(false);
     expect(fetchCalls).toBe(0);
+  });
+
+  it("exposes max_iters in the tool schema with min/max bounds", () => {
+    const parent = new ToolRegistry();
+    const client = makeClient([{ content: "ok" }]);
+    registerSubagentTool(parent, { client });
+    const spec = parent.specs().find((s) => s.function.name === "spawn_subagent");
+    const params = spec?.function.parameters as {
+      properties: { max_iters: { type: string; minimum: number; maximum: number } };
+    };
+    expect(params.properties.max_iters.type).toBe("integer");
+    expect(params.properties.max_iters.minimum).toBe(1);
+    expect(params.properties.max_iters.maximum).toBe(32);
+  });
+
+  it("caps the child loop at the caller-supplied max_iters", async () => {
+    const parent = new ToolRegistry();
+    parent.register({ name: "noop", readOnly: true, fn: () => "noop-result" });
+    const client = makeClient(makeToolCallResponses(50));
+    registerSubagentTool(parent, { client });
+    const out = await parent.dispatch(
+      "spawn_subagent",
+      JSON.stringify({ task: "loop forever", max_iters: 3 }),
+    );
+    const parsed = JSON.parse(out);
+    expect(parsed.tool_iters).toBe(3);
+  });
+
+  it("clamps max_iters above the maximum", async () => {
+    const parent = new ToolRegistry();
+    parent.register({ name: "noop", readOnly: true, fn: () => "noop-result" });
+    const client = makeClient(makeToolCallResponses(50));
+    registerSubagentTool(parent, { client });
+    const out = await parent.dispatch(
+      "spawn_subagent",
+      JSON.stringify({ task: "loop forever", max_iters: 9999 }),
+    );
+    const parsed = JSON.parse(out);
+    expect(parsed.tool_iters).toBe(32);
+  });
+
+  it("ignores non-numeric max_iters and falls back to the default", async () => {
+    const parent = new ToolRegistry();
+    parent.register({ name: "noop", readOnly: true, fn: () => "noop-result" });
+    const client = makeClient(makeToolCallResponses(50));
+    registerSubagentTool(parent, { client, maxToolIters: 4 });
+    const out = await parent.dispatch(
+      "spawn_subagent",
+      JSON.stringify({ task: "loop forever", max_iters: "lots" }),
+    );
+    const parsed = JSON.parse(out);
+    expect(parsed.tool_iters).toBe(4);
   });
 });
 


### PR DESCRIPTION
## Summary

- `SpawnSubagentOptions.maxToolIters` already existed internally but was unreachable from the public `spawn_subagent` schema, so every spawn paid the 16-iter default.
- Add an optional `max_iters` integer to the schema (range 1-32, clamped at the boundary). Floats round down; non-numeric / missing falls back to the registration-time default (still 16).
- Tool-call cap and clamp behavior covered by tests; verify-style skills can ask for 6-8, explore-style can ask for 24+.

## Test plan

- [x] Schema exposes `max_iters` with `minimum: 1` / `maximum: 32`.
- [x] Caller-supplied valid value is honored: child loop stops at exactly that many tool dispatches.
- [x] Out-of-range values (9999) are clamped to 32; non-numeric values fall back to the registration default.
- [x] `npm run verify` green (lint, typecheck, full suite, build).

Closes #318
Tracking: #316