### PR TITLE
feat(subagent): built-in explore / verify types on spawn_subagent

### DIFF
--- a/src/tools/subagent-types.ts
+++ b/src/tools/subagent-types.ts
@@ -1,0 +1,57 @@
+/** Built-in subagent personas — system prompt + iter budget pairs picked via the `type` arg. Skills override at the run_skill level; this is the inline shortcut for parents that don't want to author one. */
+
+import { NEGATIVE_CLAIM_RULE, TUI_FORMATTING_RULES } from "../prompt-fragments.js";
+
+export type SubagentTypeName = "explore" | "verify";
+
+export interface SubagentTypeSpec {
+  system: string;
+  maxToolIters: number;
+}
+
+const EXPLORE_SYSTEM = `You are an exploration subagent. Wide-net read-only investigation; return one distilled answer.
+
+How to operate:
+- Read-only tools only (read_file, search_files, search_content, directory_tree, list_directory, get_file_info).
+- For "find all places that call / reference / use X" — use search_content (content grep), NOT search_files (which only matches names).
+- Cast a wide net first to map the territory, then read the 3-10 most relevant files in full. Stop as soon as you can answer.
+- The parent does not see your tool calls — over-exploration is pure waste.
+
+Final answer:
+- One paragraph or short bullets; lead with the conclusion.
+- Cite file:line ranges when they back the claim.
+- No follow-up offers, no "let me know if you need more" — the parent will ask again.
+
+${NEGATIVE_CLAIM_RULE}
+
+${TUI_FORMATTING_RULES}`;
+
+const VERIFY_SYSTEM = `You are a verify subagent. Narrow check — return YES / NO / INCONCLUSIVE with evidence. Do not expand scope.
+
+How to operate:
+- Read only what's needed to verify the specific claim. No exploration past the claim.
+- Use search_content / read_file to confirm the exact behavior, type, or call site in question.
+- Cap at 6-8 tool calls. If you can't verify in that, return INCONCLUSIVE plus what's missing.
+
+Final answer:
+- Lead with VERIFIED / NOT VERIFIED / INCONCLUSIVE.
+- Cite file:line for the evidence.
+- One paragraph or a few bullets. No follow-up offers.
+
+${NEGATIVE_CLAIM_RULE}
+
+${TUI_FORMATTING_RULES}`;
+
+const TYPES: Record<SubagentTypeName, SubagentTypeSpec> = {
+  explore: { system: EXPLORE_SYSTEM, maxToolIters: 20 },
+  verify: { system: VERIFY_SYSTEM, maxToolIters: 8 },
+};
+
+export const SUBAGENT_TYPE_NAMES: readonly SubagentTypeName[] = Object.freeze(
+  Object.keys(TYPES) as SubagentTypeName[],
+);
+
+export function getSubagentType(name: unknown): SubagentTypeSpec | undefined {
+  if (typeof name !== "string") return undefined;
+  return TYPES[name as SubagentTypeName];
+}

--- a/src/tools/subagent.ts
+++ b/src/tools/subagent.ts
@@ -10,6 +10,7 @@ import {
   TUI_FORMATTING_RULES,
 } from "../prompt-fragments.js";
 import { ToolRegistry } from "../tools.js";
+import { SUBAGENT_TYPE_NAMES, getSubagentType } from "./subagent-types.js";
 
 /** Side-channel — subagents run inside a tool-dispatch frame, can't go through parent's `LoopEvent` stream. */
 export interface SubagentEvent {
@@ -386,13 +387,25 @@ export function registerSubagentTool(
           type: "integer",
           minimum: MIN_MAX_ITERS,
           maximum: MAX_MAX_ITERS,
-          description: `Cap on the subagent's tool-call iterations. Default 16. Lower (e.g. 6-8) for narrow verify-style tasks; higher (e.g. 24) for broad exploration. Hard range: ${MIN_MAX_ITERS}-${MAX_MAX_ITERS}; out-of-range values are clamped to the nearest end.`,
+          description: `Cap on the subagent's tool-call iterations. Default 16 (or the type's default when 'type' is set). Hard range: ${MIN_MAX_ITERS}-${MAX_MAX_ITERS}; out-of-range values are clamped to the nearest end.`,
+        },
+        type: {
+          type: "string",
+          enum: [...SUBAGENT_TYPE_NAMES],
+          description:
+            "Optional persona shaping the system prompt and default iter budget. 'explore' = wide-net read-only investigation (20-iter budget, returns a distilled answer). 'verify' = narrow yes/no check with evidence (8-iter budget). Omit when supplying your own 'system' prompt or when the default generic persona fits. Caller-supplied 'system' / 'max_iters' override the type's defaults.",
         },
       },
       required: ["task"],
     },
     fn: async (
-      args: { task?: unknown; system?: unknown; model?: unknown; max_iters?: unknown },
+      args: {
+        task?: unknown;
+        system?: unknown;
+        model?: unknown;
+        max_iters?: unknown;
+        type?: unknown;
+      },
       ctx,
     ) => {
       const task = typeof args.task === "string" ? args.task.trim() : "";
@@ -401,10 +414,11 @@ export function registerSubagentTool(
           error: "spawn_subagent requires a non-empty 'task' argument.",
         });
       }
+      const typeSpec = getSubagentType(args.type);
       const system =
         typeof args.system === "string" && args.system.trim().length > 0
           ? args.system.trim()
-          : defaultSystem;
+          : (typeSpec?.system ?? defaultSystem);
       const model =
         typeof args.model === "string" && args.model.startsWith("deepseek-")
           ? args.model
@@ -416,7 +430,7 @@ export function registerSubagentTool(
         system,
         task,
         model,
-        maxToolIters: callerIters ?? maxToolIters,
+        maxToolIters: callerIters ?? typeSpec?.maxToolIters ?? maxToolIters,
         maxResultChars,
         sink,
         parentSignal: ctx?.signal,

--- a/tests/subagent.test.ts
+++ b/tests/subagent.test.ts
@@ -446,6 +446,98 @@ describe("registerSubagentTool", () => {
     const parsed = JSON.parse(out);
     expect(parsed.tool_iters).toBe(4);
   });
+
+  it("type=explore uses the explore persona and 20-iter budget", async () => {
+    const seenSystems: string[] = [];
+    const client = new DeepSeekClient({
+      apiKey: "sk-test",
+      fetch: vi.fn(async (_url: any, init: any) => {
+        const body = init?.body ? JSON.parse(init.body) : {};
+        const sys = (body.messages ?? []).find((m: any) => m.role === "system");
+        if (sys) seenSystems.push(sys.content);
+        return new Response(
+          JSON.stringify({
+            choices: [
+              { index: 0, message: { role: "assistant", content: "ok" }, finish_reason: "stop" },
+            ],
+            usage: { prompt_tokens: 10, completion_tokens: 1, total_tokens: 11 },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }) as any,
+    });
+    const parent = new ToolRegistry();
+    registerSubagentTool(parent, { client });
+    await parent.dispatch(
+      "spawn_subagent",
+      JSON.stringify({ task: "find all callers of foo()", type: "explore" }),
+    );
+    expect(seenSystems[0]).toMatch(/exploration subagent/);
+  });
+
+  it("type=verify caps the child loop at the verify budget (8)", async () => {
+    const parent = new ToolRegistry();
+    parent.register({ name: "noop", readOnly: true, fn: () => "noop-result" });
+    const client = makeClient(makeToolCallResponses(50));
+    registerSubagentTool(parent, { client });
+    const out = await parent.dispatch(
+      "spawn_subagent",
+      JSON.stringify({ task: "verify foo", type: "verify" }),
+    );
+    const parsed = JSON.parse(out);
+    expect(parsed.tool_iters).toBe(8);
+  });
+
+  it("explicit max_iters overrides the type's default budget", async () => {
+    const parent = new ToolRegistry();
+    parent.register({ name: "noop", readOnly: true, fn: () => "noop-result" });
+    const client = makeClient(makeToolCallResponses(50));
+    registerSubagentTool(parent, { client });
+    const out = await parent.dispatch(
+      "spawn_subagent",
+      JSON.stringify({ task: "verify foo", type: "verify", max_iters: 4 }),
+    );
+    const parsed = JSON.parse(out);
+    expect(parsed.tool_iters).toBe(4);
+  });
+
+  it("explicit system overrides the type's default prompt", async () => {
+    const seenSystems: string[] = [];
+    const client = new DeepSeekClient({
+      apiKey: "sk-test",
+      fetch: vi.fn(async (_url: any, init: any) => {
+        const body = init?.body ? JSON.parse(init.body) : {};
+        const sys = (body.messages ?? []).find((m: any) => m.role === "system");
+        if (sys) seenSystems.push(sys.content);
+        return new Response(
+          JSON.stringify({
+            choices: [
+              { index: 0, message: { role: "assistant", content: "ok" }, finish_reason: "stop" },
+            ],
+            usage: { prompt_tokens: 10, completion_tokens: 1, total_tokens: 11 },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }) as any,
+    });
+    const parent = new ToolRegistry();
+    registerSubagentTool(parent, { client });
+    await parent.dispatch(
+      "spawn_subagent",
+      JSON.stringify({ task: "go", type: "explore", system: "I am a custom prompt." }),
+    );
+    expect(seenSystems[0]).toBe("I am a custom prompt.");
+  });
+
+  it("omitted type leaves the default persona and budget unchanged", async () => {
+    const parent = new ToolRegistry();
+    parent.register({ name: "noop", readOnly: true, fn: () => "noop-result" });
+    const client = makeClient(makeToolCallResponses(50));
+    registerSubagentTool(parent, { client, maxToolIters: 5 });
+    const out = await parent.dispatch("spawn_subagent", JSON.stringify({ task: "loop please" }));
+    const parsed = JSON.parse(out);
+    expect(parsed.tool_iters).toBe(5);
+  });
 });
 
 describe("forkRegistryExcluding", () => {


### PR DESCRIPTION
## Summary

- Two task shapes repeat often enough to warrant first-class support without needing a skill: **explore** (wide-net read-only, 20-iter budget) and **verify** (narrow yes/no with evidence, 8-iter budget).
- New optional `type: "explore" | "verify"` field on the `spawn_subagent` schema. When set, the type supplies the system prompt and default iter budget.
- Caller's explicit `system` / `max_iters` (#318) override the type's defaults — caller wins.
- Prompts live in `src/tools/subagent-types.ts` so `subagent.ts` stays under the 500-line target.

## Test plan

- [x] `type: "explore"` injects the explore persona into the child system prompt.
- [x] `type: "verify"` caps the child loop at the verify budget (8).
- [x] `type` + explicit `max_iters` → caller's value wins (4 over 8).
- [x] `type` + explicit `system` → caller's prompt wins.
- [x] Omitted `type` → unchanged behavior (default persona, registration default budget).
- [x] `npm run verify` green (lint, typecheck, full suite, build).

Closes #319
Tracking: #316