### PR TITLE
feat(tools): parallelSafe annotation on ToolDefinition (#325)

### DIFF
--- a/src/index/semantic/tool.ts
+++ b/src/index/semantic/tool.ts
@@ -25,6 +25,7 @@ export async function registerSemanticSearchTool(
     description:
       "FIRST CHOICE for descriptive queries. Use this BEFORE search_content (grep) when the user describes WHAT code does ('where do we handle X', 'which file owns Y', 'how does Z work', 'find the logic that …'). Returns ranked snippets ordered by semantic relevance — finds the right file even when your description shares no words with the code. Falls back to search_content / search_files only for: exact identifiers, regex patterns, or counting occurrences of a known token. If your first instinct is grep on a paraphrased question, you are wrong — try semantic_search first.",
     readOnly: true,
+    parallelSafe: true,
     parameters: {
       type: "object",
       properties: {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -17,6 +17,8 @@ export interface ToolDefinition<A = any, R = any> {
   readOnly?: boolean;
   /** Per-args check; takes precedence over `readOnly`. e.g. `run_command` + allowlisted argv. */
   readOnlyCheck?: (args: A) => boolean;
+  /** Safe to dispatch concurrently with other parallel-safe calls in the same turn. Default false — opt-in only. */
+  parallelSafe?: boolean;
   fn: (args: A, ctx?: ToolCallContext) => R | Promise<R>;
 }
 
@@ -106,6 +108,11 @@ export class ToolRegistry {
   /** True if a registered tool's schema was flattened for the model. */
   wasFlattened(name: string): boolean {
     return Boolean(this._tools.get(name)?.flatSchema);
+  }
+
+  /** Unknown / unannotated tools default to false — third-party MCP tools must opt in. */
+  isParallelSafe(name: string): boolean {
+    return this._tools.get(name)?.parallelSafe === true;
   }
 
   specs(): ToolSpec[] {

--- a/src/tools/filesystem.ts
+++ b/src/tools/filesystem.ts
@@ -102,6 +102,7 @@ export function registerFilesystemTools(
 
   registry.register({
     name: "read_file",
+    parallelSafe: true,
     description: `Read a file under the sandbox root. To save context, PREFER to scope the read instead of pulling the whole file:
   - head: N  → first N lines (imports, public API, small configs)
   - tail: N  → last N lines (recently-added code, log tails)
@@ -201,6 +202,7 @@ When none of these is given AND the file is longer than ${DEFAULT_AUTO_PREVIEW_L
 
   registry.register({
     name: "list_directory",
+    parallelSafe: true,
     description:
       "List entries in a directory under the sandbox root. Returns one line per entry, marking directories with a trailing slash. Not recursive — use directory_tree for that.",
     readOnly: true,
@@ -223,6 +225,7 @@ When none of these is given AND the file is longer than ${DEFAULT_AUTO_PREVIEW_L
 
   registry.register({
     name: "directory_tree",
+    parallelSafe: true,
     description: `Recursively list entries in a directory. Shows indented tree structure with directories marked '/'. Budget-aware by default:
   - maxDepth defaults to 2 (root + one level). A depth-4 tree on a real repo blew ~5K tokens in one call. If you truly need deeper, pass maxDepth:N explicitly.
   - Skips ${[...SKIP_DIR_NAMES].sort().join(", ")} unless include_deps:true. Traversing into node_modules / .git / dist is almost always token-waste.
@@ -312,6 +315,7 @@ Prefer \`list_directory\` for a single-level view, \`search_files\` to find spec
 
   registry.register({
     name: "search_files",
+    parallelSafe: true,
     description:
       "Find files whose NAME matches a substring or regex. Case-insensitive. Walks the directory recursively under the sandbox root. Returns one path per line. Skips dependency / VCS / build directories (node_modules, .git, dist, build, .next, target, .venv) by default.",
     readOnly: true,
@@ -341,6 +345,7 @@ Prefer \`list_directory\` for a single-level view, \`search_files\` to find spec
 
   registry.register({
     name: "search_content",
+    parallelSafe: true,
     description:
       "Recursively grep file CONTENTS for a substring or regex. This is the right tool for 'find all places that call X', 'where is Y referenced', 'what files contain Z'. Different from search_files (which matches FILE NAMES). Returns one match per line in 'path:line: text' format. Skips dependency / VCS / build directories (node_modules, .git, dist, build, .next, target, .venv) and binary files by default.",
     readOnly: true,
@@ -394,6 +399,7 @@ Prefer \`list_directory\` for a single-level view, \`search_files\` to find spec
 
   registry.register({
     name: "get_file_info",
+    parallelSafe: true,
     description:
       "Stat a path under the sandbox root. Returns type (file|directory|symlink), size in bytes, mtime in ISO-8601.",
     readOnly: true,

--- a/src/tools/memory.ts
+++ b/src/tools/memory.ts
@@ -132,6 +132,7 @@ export function registerMemoryTools(
     description:
       "Read the full body of a memory file when its MEMORY.md one-liner (already in the system prompt) isn't enough detail. Most of the time the index suffices — only call this when the user's question genuinely requires the full context.",
     readOnly: true,
+    parallelSafe: true,
     parameters: {
       type: "object",
       properties: {

--- a/src/tools/shell.ts
+++ b/src/tools/shell.ts
@@ -186,6 +186,7 @@ export function registerShellTools(registry: ToolRegistry, opts: ShellToolsOptio
     description:
       "Read the latest output of a background job started with `run_background`. By default returns the tail of the buffer (last 80 lines). Pass `since` (the `byteLength` from a previous call) to stream only new content incrementally. Tells you whether the job is still running, so you can stop polling when it's done.",
     readOnly: true,
+    parallelSafe: true,
     parameters: {
       type: "object",
       properties: {
@@ -235,6 +236,7 @@ export function registerShellTools(registry: ToolRegistry, opts: ShellToolsOptio
     description:
       "List every background job started this session — running and exited — with id, command, pid, status. Use when you've lost track of which job_id corresponds to which process, or to see what's still alive.",
     readOnly: true,
+    parallelSafe: true,
     parameters: { type: "object", properties: {} },
     fn: async () => {
       const all = jobs.list();

--- a/src/tools/skills.ts
+++ b/src/tools/skills.ts
@@ -32,6 +32,7 @@ export function registerSkillTools(
     description:
       "Invoke a playbook from the Skills index pinned in the system prompt. Each entry is a self-contained instruction block. Pass `name` as the BARE skill identifier (e.g. 'explore'), NOT the `[🧬 subagent]` tag that appears after it in the index. Entries tagged `[🧬 subagent]` spawn an isolated subagent — only the final distilled answer comes back, the model's tool calls + reasoning during the run never enter your context. Plain skills are inlined: the body becomes a tool result you read and follow. For subagent skills, supply 'arguments' describing the concrete task — they'll be the only context the subagent has.",
     readOnly: true,
+    parallelSafe: true,
     parameters: {
       type: "object",
       properties: {

--- a/src/tools/subagent.ts
+++ b/src/tools/subagent.ts
@@ -362,6 +362,7 @@ export function registerSubagentTool(
 
   parentRegistry.register({
     name: SUBAGENT_TOOL_NAME,
+    parallelSafe: true,
     description:
       "Spawn an isolated subagent to handle a self-contained subtask in a fresh context, returning only its final answer. Use for: deep codebase exploration that would flood the main context, multi-step research where you only need the conclusion, or any focused subtask whose intermediate reasoning the user does not need to see. The subagent inherits all your tools (filesystem, shell, web, MCP, etc.) but runs in its own isolated message log — its tool calls and reasoning never enter your context. Only the final assistant message comes back as this tool's result. Keep tasks focused; the subagent has a stricter iter budget than you do.",
     parameters: {

--- a/src/tools/web.ts
+++ b/src/tools/web.ts
@@ -294,6 +294,7 @@ export function registerWebTools(registry: ToolRegistry, opts: WebToolsOptions =
     description:
       "Search the public web. Returns ranked results with title, url, and snippet. Call this when the answer's correctness depends on current state — anything that changes over time (events, prices, releases, status of a thing in the real world). Composing such answers from training memory invents stale numbers; search first, then ground the answer in the results. For evergreen / definitional questions you don't need this.",
     readOnly: true,
+    parallelSafe: true,
     parameters: {
       type: "object",
       properties: {
@@ -319,6 +320,7 @@ export function registerWebTools(registry: ToolRegistry, opts: WebToolsOptions =
     description:
       "Download a URL and return its visible text content (HTML pages get scripts/styles/nav stripped). Truncated at the tool-result cap. Use after web_search when a snippet isn't enough.",
     readOnly: true,
+    parallelSafe: true,
     parameters: {
       type: "object",
       properties: {

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -291,4 +291,23 @@ describe("ToolRegistry", () => {
       expect(JSON.parse(out).error).toMatch(/interceptor failed — boom/);
     });
   });
+
+  describe("isParallelSafe", () => {
+    it("returns true when the tool opts in", () => {
+      const reg = new ToolRegistry();
+      reg.register({ name: "read_thing", parallelSafe: true, fn: () => "ok" });
+      expect(reg.isParallelSafe("read_thing")).toBe(true);
+    });
+
+    it("defaults to false on unannotated tools", () => {
+      const reg = new ToolRegistry();
+      reg.register({ name: "do_thing", fn: () => "ok" });
+      expect(reg.isParallelSafe("do_thing")).toBe(false);
+    });
+
+    it("returns false for unknown tools", () => {
+      const reg = new ToolRegistry();
+      expect(reg.isParallelSafe("nope")).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
Plumbing PR for #325 (chunked parallel tool dispatch).

## What

- `ToolDefinition.parallelSafe?: boolean` — opt-in flag, default `false`
- `ToolRegistry.isParallelSafe(name)` — registry lookup; unknown / unannotated → `false`
- Annotate built-in tools that are safe to run concurrently with peers:
  - **Read-only filesystem**: `read_file`, `list_directory`, `directory_tree`, `search_files`, `search_content`, `get_file_info`
  - **Web**: `web_search`, `web_fetch`
  - **Memory recall**: `recall_memory`
  - **Semantic**: `semantic_search`
  - **Isolated child loops**: `run_skill`, `spawn_subagent`
  - **In-memory job queries**: `job_output`, `list_jobs`

## Out of scope

- No dispatcher change. Loop still serial. Behavior delta = 0.
- Mutating tools (write_file, edit_file, shell, plan-state writers, memory writers, ask_choice) stay default `false`.
- MCP-bridged tools default `false`. They opt in only when an MCP server explicitly declares parallel safety — third-party tools whose semantics we can't see should never auto-batch.

## Why default-deny

A bug in a `parallelSafe: true` flag on a stateful tool causes silent races across the entire dispatch batch. The cost of one mis-annotated read tool running serial is wall-clock latency. The cost of one mis-annotated write tool running parallel is corrupted state. Asymmetric — bias toward serial.

## Test plan

- [x] `tests/tools.test.ts` covers the three states: opted-in, unannotated, unknown
- [x] Existing 21 tools tests still pass
- [x] `comment-policy.test.ts` still green
- [x] `npx tsc --noEmit` clean

PR 2 (dispatcher chunking + multi-subagent UI) follows.