### PR TITLE
feat(loop): chunked parallel tool dispatch + multi-subagent UI (#325)

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -107,7 +107,7 @@ import { CardStream } from "./layout/CardStream.js";
 import {
   ModeStatusBar,
   OngoingToolRow,
-  SubagentRow,
+  SubagentLiveStack,
   ThinkingRow,
   UndoBanner,
 } from "./layout/LiveRows.js";
@@ -398,7 +398,7 @@ function AppInner({
   // reads from a ref populated AFTER useSessionInfo loads balance, so the
   // subagent-end cost suffix renders in the live wallet's symbol.
   const walletCurrencyRef = useRef<string | undefined>(undefined);
-  const { activity: subagentActivity, sinkRef: subagentSinkRef } = useSubagent({
+  const { activities: subagentActivities, sinkRef: subagentSinkRef } = useSubagent({
     session,
     log,
     getWalletCurrency: () => walletCurrencyRef.current,
@@ -3076,8 +3076,8 @@ function AppInner({
                 !pendingMcpHub &&
                 !stagedInput &&
                 !pendingEditReview &&
-                subagentActivity ? (
-                  <SubagentRow activity={subagentActivity} />
+                subagentActivities.length > 0 ? (
+                  <SubagentLiveStack activities={subagentActivities} max={3} />
                 ) : null}
                 {!PLAIN_UI &&
                 !pendingShell &&

--- a/src/cli/ui/layout/LiveRows.tsx
+++ b/src/cli/ui/layout/LiveRows.tsx
@@ -11,6 +11,7 @@ import { PILL_MODEL, PILL_SECTION, Pill, modelBadgeFor } from "../primitives/Pil
 import { Spinner } from "../primitives/Spinner.js";
 import { CARD, FG, TONE } from "../theme/tokens.js";
 import { useElapsedSeconds, useSlowTick, useTick } from "../ticker.js";
+import type { SubagentActivity } from "../useSubagent.js";
 
 export const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
@@ -159,20 +160,8 @@ function subagentTitle(skillName: string | undefined, task: string): string {
   return `Sub-agent · ${short || "anonymous"}`;
 }
 
-/** Live block for a running subagent — Card-styled, fixed row count for flicker-safety. */
-export function SubagentRow({
-  activity,
-}: {
-  activity: {
-    task: string;
-    iter: number;
-    elapsedMs: number;
-    skillName?: string;
-    model?: string;
-    phase?: "exploring" | "summarising";
-    lastInner: { glyph: string; color: string; label: string; meta?: string } | null;
-  };
-}) {
+/** Live block for a single in-flight subagent — rich layout, used when only one is running. */
+export function SubagentRow({ activity }: { activity: SubagentActivity }) {
   useTick();
   const seconds = (activity.elapsedMs / 1000).toFixed(1);
   const phase = subagentPhaseLabel(activity.phase, activity.iter, activity.elapsedMs);
@@ -219,6 +208,78 @@ export function SubagentRow({
         {phase}
       </Text>
     </Card>
+  );
+}
+
+/** 1 → rich; 2-max → compact rows; >max → compact + "+N more" fold. */
+export function SubagentLiveStack({
+  activities,
+  max = 3,
+}: {
+  activities: ReadonlyArray<SubagentActivity>;
+  max?: number;
+}) {
+  const tick = useTick();
+  if (activities.length === 0) return null;
+  if (activities.length === 1) return <SubagentRow activity={activities[0]!} />;
+  const visible = activities.slice(0, max);
+  const overflow = activities.length - visible.length;
+  const summarising = activities.filter((a) => a.phase === "summarising").length;
+  const metaParts = [`${activities.length} running`];
+  if (summarising > 0) metaParts.push(`${summarising} summarising`);
+  return (
+    <Card tone={CARD.subagent.color}>
+      <CardHeader
+        glyph="⌬"
+        tone={CARD.subagent.color}
+        title="subagents"
+        titleColor={PILL_SECTION.plan.fg}
+        titleBg={PILL_SECTION.plan.bg}
+        subtitle={metaParts.join(" · ")}
+        right={<Spinner kind="braille" color={CARD.subagent.color} />}
+      />
+      {visible.map((a, i) => (
+        <CompactSubagentLine key={a.runId} activity={a} tick={tick} index={i} />
+      ))}
+      {overflow > 0 ? <Text color={FG.faint}>{`  +${overflow} more running…`}</Text> : null}
+    </Card>
+  );
+}
+
+function CompactSubagentLine({
+  activity,
+  tick,
+  index,
+}: {
+  activity: SubagentActivity;
+  tick: number;
+  index: number;
+}) {
+  const summarising = activity.phase === "summarising";
+  const spinnerFrame = SPINNER_FRAMES[(tick + index) % SPINNER_FRAMES.length] ?? "·";
+  const glyph = summarising ? "▶" : spinnerFrame;
+  const glyphColor = summarising ? TONE.brand : CARD.subagent.color;
+  const seconds = (activity.elapsedMs / 1000).toFixed(1).padStart(5);
+  const title = activity.skillName ?? truncate(activity.task, 28);
+  const titlePadded = title.padEnd(28);
+  const last = activity.lastInner;
+  return (
+    <Box flexDirection="row">
+      <Text color={glyphColor} bold>
+        {`  ${glyph} `}
+      </Text>
+      <Text color={FG.body}>{titlePadded}</Text>
+      <Text color={FG.faint}>{`  iter ${String(activity.iter).padStart(2)} · ${seconds}s · `}</Text>
+      {last ? (
+        <>
+          <Text color={last.color}>{`${last.glyph} `}</Text>
+          <Text color={FG.body}>{truncate(last.label, 18)}</Text>
+          {last.meta ? <Text color={FG.faint}>{`  ${last.meta}`}</Text> : null}
+        </>
+      ) : (
+        <Text color={FG.faint}>queued…</Text>
+      )}
+    </Box>
   );
 }
 

--- a/src/cli/ui/useSubagent.ts
+++ b/src/cli/ui/useSubagent.ts
@@ -40,6 +40,10 @@ export interface SubagentInnerSummary {
 }
 
 export interface SubagentActivity {
+  /** Stable per-spawn id; key for parallel-row rendering. */
+  runId: string;
+  /** Wall-clock start so the stack stays in launch order even when events arrive interleaved. */
+  startedAt: number;
   task: string;
   iter: number;
   elapsedMs: number;
@@ -57,8 +61,8 @@ export interface UseSubagentParams {
 }
 
 export interface UseSubagentResult {
-  /** Live state for an in-flight subagent, null when none is running. */
-  activity: SubagentActivity | null;
+  /** In-flight runs, oldest first. Empty when none active. */
+  activities: ReadonlyArray<SubagentActivity>;
   sinkRef: React.MutableRefObject<SubagentSink>;
 }
 
@@ -67,7 +71,7 @@ export function useSubagent({
   log,
   getWalletCurrency,
 }: UseSubagentParams): UseSubagentResult {
-  const [activity, setActivity] = useState<SubagentActivity | null>(null);
+  const [activities, setActivities] = useState<ReadonlyArray<SubagentActivity>>([]);
   const sinkRef = useRef<SubagentSink>({ current: null });
   // Subagent runs can outlive a balance refresh; the thunk lives in a ref so the
   // sink callback (installed once at mount) always reads the latest wallet currency.
@@ -79,81 +83,76 @@ export function useSubagent({
   useEffect(() => {
     sinkRef.current.current = (ev: SubagentEvent) => {
       if (ev.kind === "start") {
-        setActivity({
-          task: ev.task,
-          iter: ev.iter ?? 0,
-          elapsedMs: ev.elapsedMs ?? 0,
-          skillName: ev.skillName,
-          model: ev.model,
-          phase: "exploring",
-          lastInner: null,
-        });
-        return;
-      }
-      if (ev.kind === "progress") {
-        setActivity((prev) =>
-          prev
-            ? {
-                ...prev,
-                iter: ev.iter ?? prev.iter,
-                elapsedMs: ev.elapsedMs ?? prev.elapsedMs,
-              }
-            : {
-                task: ev.task,
-                iter: ev.iter ?? 0,
-                elapsedMs: ev.elapsedMs ?? 0,
-                skillName: ev.skillName,
-                model: ev.model,
-                phase: "exploring",
-                lastInner: null,
-              },
-        );
-        return;
-      }
-      if (ev.kind === "phase") {
-        setActivity((prev) => (prev ? { ...prev, phase: ev.phase } : prev));
-        return;
-      }
-      if (ev.kind === "inner" && ev.inner) {
-        const summary = summariseInner(ev.inner);
-        if (!summary) return;
-        setActivity((prev) => (prev ? { ...prev, lastInner: summary } : prev));
-        return;
-      }
-      // end
-      setActivity(null);
-      const seconds = ((ev.elapsedMs ?? 0) / 1000).toFixed(1);
-      // Inline cost: the one number most users look at. Saves a /stats round-trip.
-      const costTail =
-        ev.costUsd !== undefined && ev.costUsd > 0
-          ? ` · ${formatCost(ev.costUsd, getWalletCurrencyRef.current?.())}`
-          : "";
-      const summary = ev.error
-        ? `⌬ subagent "${ev.task}" failed after ${seconds}s · ${ev.iter ?? 0} tool call(s) — ${ev.error}`
-        : `⌬ subagent "${ev.task}" done in ${seconds}s · ${ev.iter ?? 0} tool call(s) · ${ev.turns ?? 0} turn(s)${costTail}`;
-      log.pushInfo(summary);
-      // Persist a subagent summary row to ~/.reasonix/usage.jsonl so
-      // `/stats` and `reasonix stats` surface it. Skipped on error —
-      // we only record what actually cost money and did work.
-      if (!ev.error && ev.usage && ev.model) {
-        appendUsage({
-          session: session ?? null,
-          model: ev.model,
-          usage: ev.usage,
-          kind: "subagent",
-          subagent: {
+        setActivities((prev) => {
+          if (prev.some((a) => a.runId === ev.runId)) return prev;
+          const next: SubagentActivity = {
+            runId: ev.runId,
+            startedAt: Date.now() - (ev.elapsedMs ?? 0),
+            task: ev.task,
+            iter: ev.iter ?? 0,
+            elapsedMs: ev.elapsedMs ?? 0,
             skillName: ev.skillName,
-            taskPreview: ev.task.slice(0, 60),
-            toolIters: ev.iter ?? 0,
-            durationMs: ev.elapsedMs ?? 0,
-          },
+            model: ev.model,
+            phase: "exploring",
+            lastInner: null,
+          };
+          return [...prev, next];
         });
+        return;
       }
+      if (ev.kind === "end") {
+        setActivities((prev) => prev.filter((a) => a.runId !== ev.runId));
+        const seconds = ((ev.elapsedMs ?? 0) / 1000).toFixed(1);
+        const costTail =
+          ev.costUsd !== undefined && ev.costUsd > 0
+            ? ` · ${formatCost(ev.costUsd, getWalletCurrencyRef.current?.())}`
+            : "";
+        const summary = ev.error
+          ? `⌬ subagent "${ev.task}" failed after ${seconds}s · ${ev.iter ?? 0} tool call(s) — ${ev.error}`
+          : `⌬ subagent "${ev.task}" done in ${seconds}s · ${ev.iter ?? 0} tool call(s) · ${ev.turns ?? 0} turn(s)${costTail}`;
+        log.pushInfo(summary);
+        if (!ev.error && ev.usage && ev.model) {
+          appendUsage({
+            session: session ?? null,
+            model: ev.model,
+            usage: ev.usage,
+            kind: "subagent",
+            subagent: {
+              skillName: ev.skillName,
+              taskPreview: ev.task.slice(0, 60),
+              toolIters: ev.iter ?? 0,
+              durationMs: ev.elapsedMs ?? 0,
+            },
+          });
+        }
+        return;
+      }
+      // progress / phase / inner — patch the matching row, ignore stragglers from runs we never saw `start` for.
+      setActivities((prev) =>
+        prev.map((a) => {
+          if (a.runId !== ev.runId) return a;
+          if (ev.kind === "progress") {
+            return {
+              ...a,
+              iter: ev.iter ?? a.iter,
+              elapsedMs: ev.elapsedMs ?? a.elapsedMs,
+            };
+          }
+          if (ev.kind === "phase") {
+            return { ...a, phase: ev.phase ?? a.phase };
+          }
+          if (ev.kind === "inner" && ev.inner) {
+            const summary = summariseInner(ev.inner);
+            return summary ? { ...a, lastInner: summary } : a;
+          }
+          return a;
+        }),
+      );
     };
     return () => {
       sinkRef.current.current = null;
     };
   }, [session, log]);
 
-  return { activity, sinkRef };
+  return { activities, sinkRef };
 }

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -386,6 +386,56 @@ export class CacheFirstLoop {
     return true;
   }
 
+  private async runOneToolCall(
+    call: ToolCall,
+    signal: AbortSignal,
+  ): Promise<{ preWarnings: LoopEvent[]; postWarnings: LoopEvent[]; result: string }> {
+    const name = call.function?.name ?? "";
+    const args = call.function?.arguments ?? "{}";
+    const parsedArgs = safeParseToolArgs(args);
+
+    const preReport = await runHooks({
+      hooks: this.hooks,
+      payload: {
+        event: "PreToolUse",
+        cwd: this.hookCwd,
+        toolName: name,
+        toolArgs: parsedArgs,
+      },
+    });
+    const preWarnings = [...hookWarnings(preReport.outcomes, this._turn)];
+
+    if (preReport.blocked) {
+      const blocking = preReport.outcomes[preReport.outcomes.length - 1];
+      const reason = (blocking?.stderr || blocking?.stdout || "blocked by PreToolUse hook").trim();
+      return {
+        preWarnings,
+        postWarnings: [],
+        result: `[hook block] ${blocking?.hook.command ?? "<unknown>"}\n${reason}`,
+      };
+    }
+
+    const result = await this.tools.dispatch(name, args, {
+      signal,
+      maxResultTokens: DEFAULT_MAX_RESULT_TOKENS,
+      confirmationGate: this.confirmationGate,
+    });
+
+    const postReport = await runHooks({
+      hooks: this.hooks,
+      payload: {
+        event: "PostToolUse",
+        cwd: this.hookCwd,
+        toolName: name,
+        toolArgs: parsedArgs,
+        toolResult: result,
+      },
+    });
+    const postWarnings = [...hookWarnings(postReport.outcomes, this._turn)];
+
+    return { preWarnings, postWarnings, result };
+  }
+
   private buildMessages(pendingUser: string | null): ChatMessage[] {
     // DeepSeek 400s on either unpaired tool_calls or stray tool entries — heal before sending.
     const healed = healLoadedMessages(this.log.toMessages(), DEFAULT_MAX_RESULT_CHARS);
@@ -1089,94 +1139,95 @@ export class CacheFirstLoop {
         return;
       }
 
-      for (const call of repairedCalls) {
-        const name = call.function?.name ?? "";
-        const args = call.function?.arguments ?? "{}";
-        // Announce the tool BEFORE awaiting it so the TUI can render a
-        // "running…" indicator. Without this, the window between
-        // assistant_final and the tool-result yield is silent from the
-        // UI's perspective — which makes long tool calls feel like the
-        // app has hung.
-        yield {
-          turn: this._turn,
-          role: "tool_start",
-          content: "",
-          toolName: name,
-          toolArgs: args,
-        };
+      const dispatchSerial =
+        (process.env.REASONIX_TOOL_DISPATCH ?? "auto").toLowerCase() === "serial";
+      const parallelMaxParsed = Number.parseInt(process.env.REASONIX_PARALLEL_MAX ?? "", 10);
+      const parallelMax =
+        Number.isFinite(parallelMaxParsed) && parallelMaxParsed >= 1
+          ? Math.min(parallelMaxParsed, 16)
+          : 3;
 
-        // PreToolUse hooks. A `block` decision (exit 2) skips dispatch
-        // and surfaces the hook's stderr as the tool result so the model
-        // sees a structured refusal instead of a silent omission. Non-
-        // block non-zero outcomes are warnings: the loop continues, the
-        // UI gets a yellow row.
-        const parsedArgs = safeParseToolArgs(args);
-        const preReport = await runHooks({
-          hooks: this.hooks,
-          payload: {
-            event: "PreToolUse",
-            cwd: this.hookCwd,
-            toolName: name,
-            toolArgs: parsedArgs,
-          },
-        });
-        for (const w of hookWarnings(preReport.outcomes, this._turn)) yield w;
-
-        let result: string;
-        if (preReport.blocked) {
-          const blocking = preReport.outcomes[preReport.outcomes.length - 1];
-          const reason = (
-            blocking?.stderr ||
-            blocking?.stdout ||
-            "blocked by PreToolUse hook"
-          ).trim();
-          result = `[hook block] ${blocking?.hook.command ?? "<unknown>"}\n${reason}`;
-        } else {
-          result = await this.tools.dispatch(name, args, {
-            signal,
-            maxResultTokens: DEFAULT_MAX_RESULT_TOKENS,
-            confirmationGate: this.confirmationGate,
-          });
-
-          // PostToolUse hooks — block is meaningless after the fact, so
-          // every non-pass outcome is a warning. Hooks here are the
-          // natural place for "after every edit, run the formatter."
-          const postReport = await runHooks({
-            hooks: this.hooks,
-            payload: {
-              event: "PostToolUse",
-              cwd: this.hookCwd,
-              toolName: name,
-              toolArgs: parsedArgs,
-              toolResult: result,
-            },
-          });
-          for (const w of hookWarnings(postReport.outcomes, this._turn)) yield w;
+      let callIdx = 0;
+      while (callIdx < repairedCalls.length) {
+        // Group consecutive parallel-safe calls; an unsafe call breaks
+        // the chunk and runs alone (serial barrier).
+        const chunk: ToolCall[] = [];
+        if (!dispatchSerial) {
+          while (
+            callIdx < repairedCalls.length &&
+            chunk.length < parallelMax &&
+            this.tools.isParallelSafe(repairedCalls[callIdx]?.function?.name ?? "")
+          ) {
+            chunk.push(repairedCalls[callIdx++]!);
+          }
+        }
+        if (chunk.length === 0) {
+          chunk.push(repairedCalls[callIdx++]!);
         }
 
-        this.appendAndPersist({
-          role: "tool",
-          tool_call_id: call.id ?? "",
-          name,
-          content: result,
-        });
-        // Cost-aware escalation: check for "flash is struggling" shapes
-        // (SEARCH-not-found, etc). If threshold hits here, surface a
-        // one-time warning so the user knows the next call upgraded.
-        if (this.noteToolFailureSignal(result)) {
+        // tool_start announces every call in the chunk BEFORE any
+        // dispatch awaits — TUI shows live indicators for each, and the
+        // gap between assistant_final and the first tool_result yield is
+        // never silent.
+        for (const call of chunk) {
           yield {
             turn: this._turn,
-            role: "warning",
-            content: `⇧ auto-escalating to ${ESCALATION_MODEL} for the rest of this turn — flash hit ${this._turnFailures.formatBreakdown()}. Next turn falls back to ${this.model} unless /pro is armed.`,
+            role: "tool_start",
+            content: "",
+            toolName: call.function?.name ?? "",
+            toolArgs: call.function?.arguments ?? "{}",
           };
         }
-        yield {
-          turn: this._turn,
-          role: "tool",
-          content: result,
-          toolName: name,
-          toolArgs: args,
-        };
+
+        // Race the chunk; collect outcomes in declared order so history
+        // append + tool yields are deterministic regardless of which
+        // call settles first.
+        const settled = await Promise.allSettled(chunk.map((c) => this.runOneToolCall(c, signal)));
+
+        for (let k = 0; k < chunk.length; k++) {
+          const call = chunk[k]!;
+          const name = call.function?.name ?? "";
+          const args = call.function?.arguments ?? "{}";
+          const s = settled[k]!;
+
+          let result: string;
+          let preWarnings: LoopEvent[] = [];
+          let postWarnings: LoopEvent[] = [];
+          if (s.status === "fulfilled") {
+            preWarnings = s.value.preWarnings;
+            postWarnings = s.value.postWarnings;
+            result = s.value.result;
+          } else {
+            const err = s.reason instanceof Error ? s.reason : new Error(String(s.reason));
+            result = JSON.stringify({ error: `${err.name}: ${err.message}` });
+          }
+
+          for (const w of preWarnings) yield w;
+          for (const w of postWarnings) yield w;
+
+          this.appendAndPersist({
+            role: "tool",
+            tool_call_id: call.id ?? "",
+            name,
+            content: result,
+          });
+
+          if (this.noteToolFailureSignal(result)) {
+            yield {
+              turn: this._turn,
+              role: "warning",
+              content: `⇧ auto-escalating to ${ESCALATION_MODEL} for the rest of this turn — flash hit ${this._turnFailures.formatBreakdown()}. Next turn falls back to ${this.model} unless /pro is armed.`,
+            };
+          }
+
+          yield {
+            turn: this._turn,
+            role: "tool",
+            content: result,
+            toolName: name,
+            toolArgs: args,
+          };
+        }
       }
     }
 

--- a/src/tools/subagent.ts
+++ b/src/tools/subagent.ts
@@ -15,6 +15,8 @@ import { SUBAGENT_TYPE_NAMES, getSubagentType } from "./subagent-types.js";
 /** Side-channel — subagents run inside a tool-dispatch frame, can't go through parent's `LoopEvent` stream. */
 export interface SubagentEvent {
   kind: "start" | "progress" | "end" | "inner" | "phase";
+  /** Stable per-spawn id; lets the UI key parallel runs apart instead of overwriting one shared row. */
+  runId: string;
   task: string;
   skillName?: string;
   model?: string;
@@ -29,6 +31,12 @@ export interface SubagentEvent {
   inner?: import("../loop.js").LoopEvent;
   /** When kind === "phase": coarse status verb for the activity row. */
   phase?: "exploring" | "summarising";
+}
+
+let runIdCounter = 0;
+function nextRunId(): string {
+  runIdCounter++;
+  return `sub-${runIdCounter.toString(36)}`;
 }
 
 export interface SubagentSink {
@@ -117,9 +125,11 @@ export async function spawnSubagent(opts: SpawnSubagentOptions): Promise<Subagen
   const skillName = opts.skillName;
 
   const startedAt = Date.now();
+  const runId = nextRunId();
   const taskPreview = opts.task.length > 30 ? `${opts.task.slice(0, 30)}…` : opts.task;
   sink?.current?.({
     kind: "start",
+    runId,
     task: taskPreview,
     skillName,
     model,
@@ -133,6 +143,7 @@ export async function spawnSubagent(opts: SpawnSubagentOptions): Promise<Subagen
       const errorMessage = `subagent allow-list names tool(s) not registered in the parent: ${missing.join(", ")}. Fix the skill's \`allowed-tools\` frontmatter or check spelling.`;
       sink?.current?.({
         kind: "end",
+        runId,
         task: taskPreview,
         skillName,
         model,
@@ -212,7 +223,7 @@ export async function spawnSubagent(opts: SpawnSubagentOptions): Promise<Subagen
   let summarisingEmitted = false;
   try {
     for await (const ev of childLoop.step(opts.task)) {
-      sink?.current?.({ kind: "inner", task: taskPreview, skillName, model, inner: ev });
+      sink?.current?.({ kind: "inner", runId, task: taskPreview, skillName, model, inner: ev });
 
       if (ev.role === "tool") {
         toolIter++;
@@ -220,6 +231,7 @@ export async function spawnSubagent(opts: SpawnSubagentOptions): Promise<Subagen
         summarisingEmitted = false;
         sink?.current?.({
           kind: "progress",
+          runId,
           task: taskPreview,
           skillName,
           model,
@@ -233,6 +245,7 @@ export async function spawnSubagent(opts: SpawnSubagentOptions): Promise<Subagen
         summarisingEmitted = true;
         sink?.current?.({
           kind: "phase",
+          runId,
           task: taskPreview,
           skillName,
           model,
@@ -281,6 +294,7 @@ export async function spawnSubagent(opts: SpawnSubagentOptions): Promise<Subagen
 
   sink?.current?.({
     kind: "end",
+    runId,
     task: taskPreview,
     skillName,
     model,

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -1425,4 +1425,211 @@ describe("CacheFirstLoop (streaming) — tool_call_delta emission", () => {
       expect(turn2Warns).toBe(1);
     });
   });
+
+  describe("parallel tool dispatch", () => {
+    function makeMultiToolResponse(calls: Array<{ name: string; args: string }>) {
+      return {
+        content: "",
+        tool_calls: calls.map((c, i) => ({
+          id: `call_${i}`,
+          type: "function",
+          function: { name: c.name, arguments: c.args },
+        })),
+      };
+    }
+
+    it("runs consecutive parallelSafe calls concurrently", async () => {
+      const client = makeClient([
+        makeMultiToolResponse([
+          { name: "slow_read", args: '{"k":1}' },
+          { name: "slow_read", args: '{"k":2}' },
+          { name: "slow_read", args: '{"k":3}' },
+        ]),
+        { content: "ok" },
+      ]);
+      const tools = new ToolRegistry();
+      tools.register({
+        name: "slow_read",
+        parallelSafe: true,
+        fn: async (args: { k: number }) => {
+          await new Promise((r) => setTimeout(r, 80));
+          return String(args.k);
+        },
+      });
+      const loop = new CacheFirstLoop({
+        client,
+        prefix: new ImmutablePrefix({ system: "s", toolSpecs: tools.specs() }),
+        tools,
+        stream: false,
+      });
+
+      const t0 = Date.now();
+      for await (const _ of loop.step("go")) {
+        // drain
+      }
+      const elapsed = Date.now() - t0;
+
+      expect(elapsed).toBeLessThan(220);
+    });
+
+    it("unsafe call splits the chunk into serial barriers", async () => {
+      const client = makeClient([
+        makeMultiToolResponse([
+          { name: "slow_read", args: '{"k":1}' },
+          { name: "slow_write", args: '{"k":2}' },
+          { name: "slow_read", args: '{"k":3}' },
+        ]),
+        { content: "ok" },
+      ]);
+      const tools = new ToolRegistry();
+      tools.register({
+        name: "slow_read",
+        parallelSafe: true,
+        fn: async () => {
+          await new Promise((r) => setTimeout(r, 80));
+          return "r";
+        },
+      });
+      tools.register({
+        name: "slow_write",
+        fn: async () => {
+          await new Promise((r) => setTimeout(r, 80));
+          return "w";
+        },
+      });
+      const loop = new CacheFirstLoop({
+        client,
+        prefix: new ImmutablePrefix({ system: "s", toolSpecs: tools.specs() }),
+        tools,
+        stream: false,
+      });
+
+      const t0 = Date.now();
+      for await (const _ of loop.step("go")) {
+        // drain
+      }
+      const elapsed = Date.now() - t0;
+
+      expect(elapsed).toBeGreaterThan(220);
+    });
+
+    it("tool yields land in declared order even when later calls finish first", async () => {
+      const client = makeClient([
+        makeMultiToolResponse([
+          { name: "delayed", args: '{"id":"a","ms":120}' },
+          { name: "delayed", args: '{"id":"b","ms":20}' },
+          { name: "delayed", args: '{"id":"c","ms":60}' },
+        ]),
+        { content: "ok" },
+      ]);
+      const tools = new ToolRegistry();
+      tools.register({
+        name: "delayed",
+        parallelSafe: true,
+        fn: async (args: { id: string; ms: number }) => {
+          await new Promise((r) => setTimeout(r, args.ms));
+          return args.id;
+        },
+      });
+      const loop = new CacheFirstLoop({
+        client,
+        prefix: new ImmutablePrefix({ system: "s", toolSpecs: tools.specs() }),
+        tools,
+        stream: false,
+      });
+
+      const order: string[] = [];
+      for await (const ev of loop.step("go")) {
+        if (ev.role === "tool") order.push(ev.content);
+      }
+      expect(order).toEqual(["a", "b", "c"]);
+    });
+
+    it("REASONIX_TOOL_DISPATCH=serial forces serial dispatch", async () => {
+      const prev = process.env.REASONIX_TOOL_DISPATCH;
+      process.env.REASONIX_TOOL_DISPATCH = "serial";
+      try {
+        const client = makeClient([
+          makeMultiToolResponse([
+            { name: "slow_read", args: '{"k":1}' },
+            { name: "slow_read", args: '{"k":2}' },
+          ]),
+          { content: "ok" },
+        ]);
+        const tools = new ToolRegistry();
+        tools.register({
+          name: "slow_read",
+          parallelSafe: true,
+          fn: async () => {
+            await new Promise((r) => setTimeout(r, 80));
+            return "x";
+          },
+        });
+        const loop = new CacheFirstLoop({
+          client,
+          prefix: new ImmutablePrefix({ system: "s", toolSpecs: tools.specs() }),
+          tools,
+          stream: false,
+        });
+
+        const t0 = Date.now();
+        for await (const _ of loop.step("go")) {
+          // drain
+        }
+        const elapsed = Date.now() - t0;
+
+        expect(elapsed).toBeGreaterThan(150);
+      } finally {
+        if (prev === undefined) {
+          // biome-ignore lint/performance/noDelete: env restore must remove the key, not stringify "undefined"
+          delete process.env.REASONIX_TOOL_DISPATCH;
+        } else process.env.REASONIX_TOOL_DISPATCH = prev;
+      }
+    });
+
+    it("REASONIX_PARALLEL_MAX caps the chunk size", async () => {
+      const prev = process.env.REASONIX_PARALLEL_MAX;
+      process.env.REASONIX_PARALLEL_MAX = "2";
+      try {
+        const client = makeClient([
+          makeMultiToolResponse([
+            { name: "slow_read", args: '{"k":1}' },
+            { name: "slow_read", args: '{"k":2}' },
+            { name: "slow_read", args: '{"k":3}' },
+            { name: "slow_read", args: '{"k":4}' },
+          ]),
+          { content: "ok" },
+        ]);
+        const tools = new ToolRegistry();
+        tools.register({
+          name: "slow_read",
+          parallelSafe: true,
+          fn: async () => {
+            await new Promise((r) => setTimeout(r, 80));
+            return "x";
+          },
+        });
+        const loop = new CacheFirstLoop({
+          client,
+          prefix: new ImmutablePrefix({ system: "s", toolSpecs: tools.specs() }),
+          tools,
+          stream: false,
+        });
+
+        const t0 = Date.now();
+        for await (const _ of loop.step("go")) {
+          // drain
+        }
+        const elapsed = Date.now() - t0;
+
+        expect(elapsed).toBeGreaterThan(150);
+        expect(elapsed).toBeLessThan(280);
+      } finally {
+        if (prev === undefined) {
+          // biome-ignore lint/performance/noDelete: env restore must remove the key, not stringify "undefined"
+          delete process.env.REASONIX_PARALLEL_MAX;
+        } else process.env.REASONIX_PARALLEL_MAX = prev;
+      }
+    });
+  });
 });


### PR DESCRIPTION
PR 2 of #325. Closes the user-visible side of the parallel-dispatch plan.

## What

Replace the serial \`for...of + await\` tool dispatch with chunked parallel scheduling:

- Consecutive \`parallelSafe\` calls form a chunk and race together via \`Promise.allSettled\`.
- The first non-\`parallelSafe\` call ends the chunk and runs alone (serial barrier — read-after-write semantics preserved).
- Tool yields and history append run in **declared order** regardless of which call settles first. The model and the UI both see the same shape they would under serial dispatch.

## Knobs

| Env var | Default | Effect |
|---|---|---|
| \`REASONIX_PARALLEL_MAX\` | \`3\` (hard cap \`16\`) | Max chunk size. Overflow falls back to a fresh chunk for the next batch. |
| \`REASONIX_TOOL_DISPATCH=serial\` | unset (auto) | Forces serial dispatch — escape hatch when something behaves unexpectedly. |

## UI

The previously single-active \`SubagentRow\` becomes \`SubagentLiveStack\`:

- 1 active → rich card (unchanged from before)
- 2..\`max\` active → compact rows with per-row spinner + iter + tool last-step
- \`> max\` → compact rows + "+N more running…" fold

\`SubagentEvent\` now carries a stable \`runId\` per spawn so \`useSubagent\` can key parallel runs apart instead of overwriting one shared row.

## Tests

\`tests/loop.test.ts\` adds a \`parallel tool dispatch\` describe block covering the four guarantees:

1. **Parallel timing** — three 80ms parallel-safe calls finish in well under 220ms (would be 240ms+ serial).
2. **Serial barrier** — read → write → read takes 220ms+ (no batching across the unsafe call).
3. **Declared-order yields** — when the second call (20ms) finishes before the first (120ms), tool yields still land in 1, 2, 3 order.
4. **Env knobs** — \`REASONIX_TOOL_DISPATCH=serial\` and \`REASONIX_PARALLEL_MAX=2\` both observe the expected timing.

Plus the existing 35 loop tests still pass — declared-order property is the cross-test guarantee.

## Out of scope

- No PR 3 yet (observability events on \`events.jsonl\` + docs).

## Test plan

- [x] \`npx vitest run\` — 2401 passing
- [x] \`npx tsc --noEmit\` clean
- [x] \`tests/comment-policy.test.ts\` green
- [ ] Manual: spawn 3 \`run_skill explore\` calls in one turn, observe \`SubagentLiveStack\` in the TUI showing 3 concurrent rows