### PR TITLE
docs(architecture): parallel tool dispatch + env knobs (#325)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -43,6 +43,29 @@ timestamps each turn — cache hit rate in practice: <20%.
 **Metric.** `prompt_cache_hit_tokens / (hit + miss)` exposed per-turn and
 aggregated per-session. Visible in the TUI's top-bar cache cell.
 
+#### Parallel tool dispatch
+
+Each tool declares `parallelSafe?: boolean` (default `false`). The loop
+dispatcher groups consecutive parallel-safe calls into chunks and races
+them via `Promise.allSettled`; the first non-parallel-safe call ends the
+chunk and runs alone (serial barrier — read-after-write order
+preserved). Tool-result yields and history append still land in declared
+order regardless of which call settles first, so the model sees the
+same shape it would under a fully serial dispatch.
+
+| Env var | Default | Effect |
+|---|---|---|
+| `REASONIX_PARALLEL_MAX` | `3` (hard cap `16`) | Max chunk size. |
+| `REASONIX_TOOL_DISPATCH=serial` | unset | Forces serial dispatch — escape hatch. |
+
+Built-in opt-ins: read-only filesystem (`read_file`, `list_directory`,
+`directory_tree`, `search_files`, `search_content`, `get_file_info`),
+web (`web_search`, `web_fetch`), `recall_memory`, `semantic_search`,
+isolated child loops (`run_skill`, `spawn_subagent`), in-memory job
+queries (`job_output`, `list_jobs`). Mutating / side-effecting tools
+stay default. MCP-bridged tools default `false` — third-party tools
+opt in only when the server explicitly declares parallel safety.
+
 ### Pillar 2 — R1 Thought Harvesting *(opt-in)*
 
 **Problem.** R1 / V4-thinking emits extensive `reasoning_content`. DeepSeek's


### PR DESCRIPTION
PR 3 of #325. Closes the docs portion of the parallel-dispatch tracking issue.

## What

Documents the chunked-parallel dispatcher in `docs/ARCHITECTURE.md` under Pillar 1:

- The grouping rule (consecutive parallelSafe → chunk; unsafe → barrier).
- The two env knobs and their defaults: `REASONIX_PARALLEL_MAX=3` and `REASONIX_TOOL_DISPATCH=serial`.
- The list of built-in tools that opt in.

## What was deferred

The "observability event in events.jsonl" idea I floated in #325 is **deferred** — adding a new `tool.chunk.dispatched` event to the kernel is a heavier surface (schema, reducers, persistence) than is justified by the current need. The existing test suite already validates the timing, ordering, and barrier guarantees from the harness side; the parallelism is also visible to humans through the multi-row `SubagentLiveStack` UI when 2+ subagents fire at once.

If a real ops need surfaces (e.g. "I want to grep events.jsonl for chunks of size > 1"), it's a one-event addition and a separate PR.

## Test plan

- [x] `tests/comment-policy.test.ts` green
- [x] No code changes — docs only