### PR TITLE
fix(dashboard): wire up filter chips + mark static indicators

### DIFF
--- a/dashboard/app.css
+++ b/dashboard/app.css
@@ -812,6 +812,9 @@ main { padding: 32px 40px 60px 32px; min-width: 0; }
 }
 .chip-f:hover { background: var(--bg-hover); color: var(--fg-1); }
 .chip-f.active { color: var(--c-brand); border-color: var(--c-brand); background: rgba(121,192,255,.08); }
+.chip-f.static { cursor: default; }
+.chip-f.static:hover { background: var(--bg-elev); color: var(--fg-2); }
+.chip-f.static.active:hover { color: var(--c-brand); background: rgba(121,192,255,.08); }
 .chip-f .ct { color: var(--fg-4); font-size: 10px; }
 .chip-f.active .ct { color: var(--c-brand); }
 .chip-f .x { color: var(--fg-4); padding: 0 2px; }

--- a/dashboard/src/panels/chat.ts
+++ b/dashboard/src/panels/chat.ts
@@ -559,7 +559,7 @@ export function ChatPanel() {
     <div class="chat-shell">
       <div style="display:flex;align-items:center;gap:12px;margin-bottom:10px">
         <div class="chips" style="padding:0">
-          <span class="chip-f active">${MODE === "attached" ? t("chat.modeMirror") : t("chat.modeView")}</span>
+          <span class="chip-f static active">${MODE === "attached" ? t("chat.modeMirror") : t("chat.modeView")}</span>
         </div>
         <div class="header-pickers" style="margin-left:auto">
           ${

--- a/dashboard/src/panels/hooks.ts
+++ b/dashboard/src/panels/hooks.ts
@@ -68,6 +68,7 @@ export function HooksPanel() {
   const [drafts, setDrafts] = useState<Record<string, string>>({});
   const [busy, setBusy] = useState(false);
   const [info, setInfo] = useState<string | null>(null);
+  const [eventFilter, setEventFilter] = useState<string>("all");
 
   const load = useCallback(async () => {
     try {
@@ -129,19 +130,31 @@ export function HooksPanel() {
     data.events.length > 0
       ? data.events
       : Array.from(new Set(matrixRows.flatMap((r) => Object.keys(r.cells))));
+  const visibleRows =
+    eventFilter === "all"
+      ? matrixRows
+      : matrixRows.filter((r) => r.cells[eventFilter]?.on);
   const gridCols = `220px repeat(${Math.max(events.length, 1)}, minmax(0, 1fr))`;
 
   return html`
     <div style="display:flex;flex-direction:column;gap:6px">
       <div class="chips">
-        <span class="chip-f active">${t("hooks.resolved")} <span class="ct">${data.resolved.length}</span></span>
-        ${data.events.map((ev) => html`<span class="chip-f">${ev}</span>`)}
+        <span
+          class=${`chip-f ${eventFilter === "all" ? "active" : ""}`}
+          onClick=${() => setEventFilter("all")}
+        >${t("hooks.resolved")} <span class="ct">${data.resolved.length}</span></span>
+        ${data.events.map(
+          (ev) => html`<span
+            class=${`chip-f ${eventFilter === ev ? "active" : ""}`}
+            onClick=${() => setEventFilter(ev)}
+          >${ev}</span>`,
+        )}
       </div>
       ${info ? html`<div><span class="pill ok">${info}</span></div>` : null}
       ${error ? html`<div class="card accent-err">${error}</div>` : null}
 
       ${sectionH3(t("hooks.eventMatrix"), t("hooks.matrixSub", { scripts: matrixRows.length, s: matrixRows.length === 1 ? "" : "s", events: events.length }))}${
-        matrixRows.length === 0
+        visibleRows.length === 0
           ? html`<div class="card" style="color:var(--fg-3)">
               ${t("hooks.noHooks")}
             </div>`
@@ -152,7 +165,7 @@ export function HooksPanel() {
                   <div>${t("hooks.colScript")}</div>
                   ${events.map((ev) => html`<div>${ev}</div>`)}
                 </div>
-                ${matrixRows.map(
+                ${visibleRows.map(
                   (r) => html`
                     <div class="row" style=${`grid-template-columns:${gridCols}`}>
                       <div class="cell" title=${r.command}>

--- a/dashboard/src/panels/permissions.ts
+++ b/dashboard/src/panels/permissions.ts
@@ -122,8 +122,8 @@ export function PermissionsPanel() {
       }
 
       <div class="chips">
-        <span class="chip-f active">${t("permissions.project")} <span class="ct">${p.project.length}</span></span>
-        <span class="chip-f">${t("permissions.builtin")} <span class="ct">${p.builtin.length}</span></span>
+        <span class="chip-f static active">${t("permissions.project")} <span class="ct">${p.project.length}</span></span>
+        <span class="chip-f static">${t("permissions.builtin")} <span class="ct">${p.builtin.length}</span></span>
       </div>
 
       ${

--- a/dashboard/src/panels/plans.ts
+++ b/dashboard/src/panels/plans.ts
@@ -37,6 +37,7 @@ export function PlansPanel() {
   const { data, error, loading } = usePoll<PlansData>("/plans", 8000);
   const [openIdx, setOpenIdx] = useState<number | null>(null);
   const [filter, setFilter] = useState("");
+  const [statusFilter, setStatusFilter] = useState<"all" | "active" | "done">("all");
 
   if (loading && !data)
     return html`<div class="card" style="color:var(--fg-3)">${t("plans.loading")}</div>`;
@@ -48,13 +49,19 @@ export function PlansPanel() {
       ${t("plans.noPlans")}
     </div>`;
 
+  const statusFiltered =
+    statusFilter === "all"
+      ? plans
+      : statusFilter === "active"
+        ? plans.filter((p) => p.completionRatio > 0 && p.completionRatio < 1)
+        : plans.filter((p) => p.completionRatio >= 1);
   const filtered = filter.trim()
-    ? plans.filter(
+    ? statusFiltered.filter(
         (p) =>
           p.session.toLowerCase().includes(filter.toLowerCase()) ||
           (p.summary ?? "").toLowerCase().includes(filter.toLowerCase()),
       )
-    : plans;
+    : statusFiltered;
 
   const open = openIdx !== null ? plans[openIdx] : null;
 
@@ -71,12 +78,21 @@ export function PlansPanel() {
           />
         </div>
         <div class="chips" style="padding:0 12px 8px">
-          <span class="chip-f active">${t("common.all")} <span class="ct">${plans.length}</span></span>
-          <span class="chip-f">
+          <span
+            class=${`chip-f ${statusFilter === "all" ? "active" : ""}`}
+            onClick=${() => setStatusFilter("all")}
+          >${t("common.all")} <span class="ct">${plans.length}</span></span>
+          <span
+            class=${`chip-f ${statusFilter === "active" ? "active" : ""}`}
+            onClick=${() => setStatusFilter("active")}
+          >
             ${t("plans.active")}
             <span class="ct">${plans.filter((p) => p.completionRatio > 0 && p.completionRatio < 1).length}</span>
           </span>
-          <span class="chip-f">
+          <span
+            class=${`chip-f ${statusFilter === "done" ? "active" : ""}`}
+            onClick=${() => setStatusFilter("done")}
+          >
             ${t("plans.done")} <span class="ct">${plans.filter((p) => p.completionRatio >= 1).length}</span>
           </span>
         </div>

--- a/dashboard/src/panels/semantic.ts
+++ b/dashboard/src/panels/semantic.ts
@@ -179,13 +179,13 @@ export function SemanticPanel() {
     <div style="display:grid;grid-template-columns:minmax(0,1fr) 280px;gap:14px;align-items:start">
       <div style="display:flex;flex-direction:column;gap:10px;min-width:0">
         <div class="chips">
-          <span class=${`chip-f ${idx?.exists ? "active" : ""}`}>
+          <span class=${`chip-f static ${idx?.exists ? "active" : ""}`}>
             ${idx?.exists ? t("semantic.indexBuilt") : t("semantic.noIndex")}
           </span>
           ${
             ready
-              ? html`<span class="chip-f" style="border-color:var(--c-ok);color:var(--c-ok)">${t("semantic.ready")}</span>`
-              : html`<span class="chip-f" style="border-color:var(--c-warn);color:var(--c-warn)">${t("semantic.setupNeeded")}</span>`
+              ? html`<span class="chip-f static" style="border-color:var(--c-ok);color:var(--c-ok)">${t("semantic.ready")}</span>`
+              : html`<span class="chip-f static" style="border-color:var(--c-warn);color:var(--c-warn)">${t("semantic.setupNeeded")}</span>`
           }
         </div>
         ${info ? html`<div><span class="pill info">${info}</span></div>` : null}
@@ -730,7 +730,7 @@ function ChipFormRow({
       <div style="display:flex;flex-wrap:wrap;gap:4px">
         ${value.map(
           (e) => html`
-            <span class="chip-f">
+            <span class="chip-f static">
               <span>${e}</span>
               <span class="x" style="cursor:pointer" onClick=${() => remove(e)} title="remove">×</span>
             </span>

--- a/dashboard/src/panels/sessions.ts
+++ b/dashboard/src/panels/sessions.ts
@@ -68,7 +68,7 @@ export function SessionsPanel() {
           />
         </div>
         <div class="chips" style="padding:0 12px 8px">
-          <span class="chip-f active">${t("common.all")} <span class="ct">${sessions.length}</span></span>
+          <span class="chip-f static active">${t("common.all")} <span class="ct">${sessions.length}</span></span>
         </div>
         <div class="ssl-rows">
           ${filtered.map(

--- a/dashboard/src/panels/skills.ts
+++ b/dashboard/src/panels/skills.ts
@@ -29,6 +29,7 @@ export function SkillsPanel() {
   const [newName, setNewName] = useState("");
   const [newScope, setNewScope] = useState<"global" | "project">("global");
   const [filter, setFilter] = useState("");
+  const [scopeFilter, setScopeFilter] = useState<"all" | Scope>("all");
 
   const load = useCallback(async () => {
     try {
@@ -120,13 +121,15 @@ export function SkillsPanel() {
     ...data.global.map((s) => ({ scope: "global" as Scope, ...s })),
     ...data.builtin.map((s) => ({ scope: "builtin" as Scope, ...s })),
   ];
+  const scopeFiltered =
+    scopeFilter === "all" ? allWith : allWith.filter((s) => s.scope === scopeFilter);
   const filtered = filter.trim()
-    ? allWith.filter(
+    ? scopeFiltered.filter(
         (s) =>
           s.name.toLowerCase().includes(filter.toLowerCase()) ||
           (s.description ?? "").toLowerCase().includes(filter.toLowerCase()),
       )
-    : allWith;
+    : scopeFiltered;
 
   return html`
     <div class="sessions-grid">
@@ -141,10 +144,22 @@ export function SkillsPanel() {
           />
         </div>
         <div class="chips" style="padding:0 12px 8px">
-          <span class="chip-f active">${t("common.all")} <span class="ct">${allWith.length}</span></span>
-          <span class="chip-f">${t("skills.project")} <span class="ct">${data.project.length}</span></span>
-          <span class="chip-f">${t("skills.global")} <span class="ct">${data.global.length}</span></span>
-          <span class="chip-f">${t("skills.builtin")} <span class="ct">${data.builtin.length}</span></span>
+          <span
+            class=${`chip-f ${scopeFilter === "all" ? "active" : ""}`}
+            onClick=${() => setScopeFilter("all")}
+          >${t("common.all")} <span class="ct">${allWith.length}</span></span>
+          <span
+            class=${`chip-f ${scopeFilter === "project" ? "active" : ""}`}
+            onClick=${() => setScopeFilter("project")}
+          >${t("skills.project")} <span class="ct">${data.project.length}</span></span>
+          <span
+            class=${`chip-f ${scopeFilter === "global" ? "active" : ""}`}
+            onClick=${() => setScopeFilter("global")}
+          >${t("skills.global")} <span class="ct">${data.global.length}</span></span>
+          <span
+            class=${`chip-f ${scopeFilter === "builtin" ? "active" : ""}`}
+            onClick=${() => setScopeFilter("builtin")}
+          >${t("skills.builtin")} <span class="ct">${data.builtin.length}</span></span>
         </div>
 
         <div style="padding:0 12px 8px;display:flex;gap:6px;flex-wrap:wrap">

--- a/dashboard/src/panels/tools.ts
+++ b/dashboard/src/panels/tools.ts
@@ -37,8 +37,8 @@ export function ToolsPanel() {
   return html`
     <div style="display:flex;flex-direction:column;gap:14px">
       <div class="chips">
-        <span class="chip-f active">${t("common.all")} <span class="ct">${d.total}</span></span>
-        ${d.planMode ? html`<span class="chip-f" style="border-color:var(--c-warn);color:var(--c-warn)">${t("tools.planMode")}</span>` : null}
+        <span class="chip-f static active">${t("common.all")} <span class="ct">${d.total}</span></span>
+        ${d.planMode ? html`<span class="chip-f static" style="border-color:var(--c-warn);color:var(--c-warn)">${t("tools.planMode")}</span>` : null}
       </div>
 
       ${

--- a/dashboard/src/panels/usage.ts
+++ b/dashboard/src/panels/usage.ts
@@ -174,8 +174,8 @@ export function UsagePanel() {
   return html`
     <div style="display:flex;flex-direction:column;gap:6px">
       <div class="chips">
-        <span class="chip-f active">${t("usage.records", { count: u.recordCount.toLocaleString() })}</span>
-        <span class="chip-f">${u.logSize}</span>
+        <span class="chip-f static active">${t("usage.records", { count: u.recordCount.toLocaleString() })}</span>
+        <span class="chip-f static">${u.logSize}</span>
       </div>
 
       ${


### PR DESCRIPTION
The `.chip-f` class has `cursor:pointer` and a hover style, so every chip on the dashboard looked clickable. In the **skills**, **plans**, and **hooks** panels the chips were laid out as filter buttons (one hardcoded \"active\") but had no `onClick` handlers — clicks did nothing. Other panels reused `chip-f` for non-interactive count indicators, which had the same misleading hover affordance.

Reported by user: \"skill hook 等上面页签点击无法切换\".

## Real filters wired

- **skills**: All / Project / Global / Builtin filters the list by scope (composes with the text filter).
- **plans**: All / Active / Done filters by completion status (composes with the text filter).
- **hooks**: Resolved + each event filters the matrix to rows whose hooks fire on the selected event. Matrix columns still show all events; the row filter is purely additive.

## Static indicators marked

New CSS modifier `chip-f.static` disables `cursor:pointer` and the hover lift without duplicating the chip styling. Applied to:

- **sessions**: \"All N\" count chip
- **permissions**: Project / Builtin counts (both sections render in full below regardless)
- **usage**: records count + log size
- **tools**: total count + plan-mode flag
- **chat**: mirror/view mode label
- **semantic**: index status indicator + ready/setup-needed status
- **semantic** (config tag chips with × remove buttons): the chip body itself is now non-interactive; only the × is clickable

## Test plan

- [x] `npx tsc --noEmit -p dashboard/tsconfig.json` clean
- [x] `npm run build` produces dashboard bundle without warnings
- [ ] Manual: open each panel, verify clicking each filter chip in skills / plans / hooks switches the visible rows; verify static chips no longer hover-lift