### PR TITLE
fix: issue #330 — markdown osc8 garbage + cell-diff shrink-row leak

### DIFF
--- a/src/cli/ui/markdown.tsx
+++ b/src/cli/ui/markdown.tsx
@@ -370,12 +370,17 @@ function Inline({ tokens }: { tokens: Token[] }): React.ReactElement {
 const FILE_REF_RE = /\b([A-Za-z0-9_./@\-]+\.[A-Za-z0-9]{1,6})(?::(\d+)(?:-(\d+))?)?\b/g;
 const MENTION_RE = /(?<![A-Za-z0-9_])@([A-Za-z0-9_./\-]+\.[A-Za-z0-9]{1,6})/g;
 
-function osc8(label: string, target: string, color: string): React.ReactElement {
-  const open = `\x1b]8;;${target}\x07`;
-  const close = "\x1b]8;;\x07";
+function looksLikeFileRef(path: string, hasLine: boolean): boolean {
+  if (hasLine) return true;
+  if (path.includes("/")) return true;
+  const ext = path.split(".").pop() ?? "";
+  return ext.length >= 2;
+}
+
+function osc8(label: string, _target: string, color: string): React.ReactElement {
   return (
     <Text color={color} underline>
-      {`${open}${label}${close}`}
+      {label}
     </Text>
   );
 }
@@ -402,6 +407,7 @@ function renderInlineText(raw: string): React.ReactElement {
     if (hits.some((h) => start < h.end && end > h.start)) continue;
     const path = m[1]!;
     const line = m[2];
+    if (!looksLikeFileRef(path, line !== undefined)) continue;
     const target = line ? `file://${path}:${line}` : `file://${path}`;
     hits.push({ start, end, node: osc8(m[0], target, TONE.brand) });
   }

--- a/src/renderer/diff/diff-frames.ts
+++ b/src/renderer/diff/diff-frames.ts
@@ -38,6 +38,8 @@ export function diffFrames(prev: Frame, next: Frame, pools: DiffPools): Patch[] 
     return undefined;
   });
 
+  appendTrailClears(out, cursor, prev, next);
+
   if (next.cursor.x !== cursor.x || next.cursor.y !== cursor.y) {
     moveTo(out, cursor, next.cursor.x, next.cursor.y, next.viewportWidth);
   }
@@ -157,4 +159,31 @@ function transitionHyperlink(
 function resetTrailingState(out: Patch[], cursor: CursorState, pools: DiffPools): void {
   transitionStyle(out, cursor, pools.style.none, pools);
   transitionHyperlink(out, cursor, 0, pools);
+}
+
+/** Per-row trail clear when prev had content past next's last visible cell — defends shrinking rows against terminal-state desync. */
+function appendTrailClears(out: Patch[], cursor: CursorState, prev: Frame, next: Frame): void {
+  const w = Math.min(prev.screen.width, next.viewportWidth);
+  const h = Math.max(prev.screen.height, next.screen.height);
+  for (let y = 0; y < h; y++) {
+    let lastNextCol = -1;
+    for (let x = next.screen.width - 1; x >= 0; x--) {
+      const c = next.screen.cellAt(x, y);
+      if (c && c.charId !== 0) {
+        lastNextCol = x;
+        break;
+      }
+    }
+    let prevHasTrail = false;
+    for (let x = lastNextCol + 1; x < w; x++) {
+      const c = prev.screen.cellAt(x, y);
+      if (c && c.charId !== 0) {
+        prevHasTrail = true;
+        break;
+      }
+    }
+    if (!prevHasTrail) continue;
+    moveTo(out, cursor, Math.max(0, lastNextCol + 1), y, next.viewportWidth);
+    out.push({ type: "clearToEOL" });
+  }
 }

--- a/src/renderer/diff/patch.ts
+++ b/src/renderer/diff/patch.ts
@@ -7,6 +7,7 @@ export type Patch =
   | { readonly type: "styleStr"; readonly str: string }
   | { readonly type: "hyperlink"; readonly uri: string }
   | { readonly type: "clear"; readonly count: number }
+  | { readonly type: "clearToEOL" }
   | { readonly type: "clearTerminal" };
 
 export type Diff = ReadonlyArray<Patch>;

--- a/src/renderer/diff/serialize.ts
+++ b/src/renderer/diff/serialize.ts
@@ -30,6 +30,8 @@ function serializeOne(patch: Patch): string {
       return `${ESC}]8;;${patch.uri}${ST}`;
     case "clear":
       return clearLines(patch.count);
+    case "clearToEOL":
+      return `${CSI}K`;
     case "clearTerminal":
       return `${CSI}2J${CSI}H`;
   }

--- a/src/renderer/ink-compat/Text.tsx
+++ b/src/renderer/ink-compat/Text.tsx
@@ -15,6 +15,8 @@ export interface InkTextProps {
   readonly strikethrough?: boolean;
   readonly inverse?: boolean;
   readonly wrap?: "wrap" | "truncate" | "truncate-start" | "truncate-middle" | "truncate-end";
+  /** OSC 8 hyperlink target — emitted as proper escape bytes, never inlined into cell content. */
+  readonly hyperlink?: string;
 }
 
 const SGR = {
@@ -38,5 +40,9 @@ export function Text(props: InkTextProps): React.ReactElement {
   if (props.underline) codes.push(SGR.underline);
   if (props.inverse) codes.push(SGR.inverse);
   if (props.strikethrough) codes.push(SGR.strikethrough);
-  return <RsxText style={codes.length > 0 ? codes : undefined}>{props.children}</RsxText>;
+  return (
+    <RsxText style={codes.length > 0 ? codes : undefined} hyperlink={props.hyperlink}>
+      {props.children}
+    </RsxText>
+  );
 }

--- a/tests/markdown.test.ts
+++ b/tests/markdown.test.ts
@@ -82,6 +82,36 @@ describe("Markdown component", () => {
   });
 });
 
+describe("Markdown — issue #330 file-ref over-match regression", () => {
+  it("English abbreviations 'e.g' / 'i.e' are NOT treated as file refs", async () => {
+    const { mount } = await import("../src/renderer/reconciler/mount.js");
+    const { CharPool } = await import("../src/renderer/pools/char-pool.js");
+    const { StylePool } = await import("../src/renderer/pools/style-pool.js");
+    const { HyperlinkPool } = await import("../src/renderer/pools/hyperlink-pool.js");
+    async function bytesFor(text: string): Promise<string> {
+      const chunks: string[] = [];
+      const handle = mount(React.createElement(Markdown, { text }), {
+        viewportWidth: 80,
+        viewportHeight: 10,
+        pools: { char: new CharPool(), style: new StylePool(), hyperlink: new HyperlinkPool() },
+        write: (s: string) => {
+          chunks.push(s);
+        },
+      });
+      await new Promise((r) => setTimeout(r, 100));
+      const out = chunks.join("");
+      handle.destroy();
+      return out;
+    }
+    for (const sample of ["use e.g. like this", "i.e. like that", "(e.g. Google)"]) {
+      const out = await bytesFor(sample);
+      expect(out.includes("]8;;")).toBe(false);
+      expect(out.includes("file://e.g")).toBe(false);
+      expect(out.includes("file://i.e")).toBe(false);
+    }
+  });
+});
+
 // Table layout invariants: bounded width, no separator rows, content preservation.
 
 /** Parse a GFM table into header/body cells via the same pipeline as the component. */

--- a/tests/renderer/diff/diff-frames.test.ts
+++ b/tests/renderer/diff/diff-frames.test.ts
@@ -276,6 +276,39 @@ describe("emptyFrame", () => {
   });
 });
 
+describe("diffFrames — issue #330 row-shrink trail clear", () => {
+  it("emits clearToEOL when prev row had content past next's last visible cell", () => {
+    const p = pools();
+    withPools(p, () => {
+      const a = frame(40, 1, (s) => {
+        const text = "  run this command, ask again next time";
+        for (let x = 0; x < text.length; x++) s.writeCell(x, 0, cell(p, text[x]!));
+      });
+      const b = frame(40, 1, (s) => {
+        const text = "  allow always";
+        for (let x = 0; x < text.length; x++) s.writeCell(x, 0, cell(p, text[x]!));
+      });
+      const out = diffFrames(a, b, p);
+      const trail = out.filter((pp) => pp.type === "clearToEOL");
+      expect(trail).toHaveLength(1);
+    });
+  });
+
+  it("does NOT emit clearToEOL when next row reaches the same width as prev", () => {
+    const p = pools();
+    withPools(p, () => {
+      const a = frame(10, 1, (s) => {
+        for (const [x, ch] of "abcdefghij".split("").entries()) s.writeCell(x, 0, cell(p, ch));
+      });
+      const b = frame(10, 1, (s) => {
+        for (const [x, ch] of "ABCDEFGHIJ".split("").entries()) s.writeCell(x, 0, cell(p, ch));
+      });
+      const out = diffFrames(a, b, p);
+      expect(out.filter((pp) => pp.type === "clearToEOL")).toHaveLength(0);
+    });
+  });
+});
+
 // Silence the unused-EMPTY_CELL import lint by referencing it.
 // eslint-disable-next-line
 void EMPTY_CELL;


### PR DESCRIPTION
Closes #330.

Two coupled bugs surfaced in the user's archlinux + bunx report:

## 1. Markdown linkifier emitted OSC 8 escape body as plain visible chars

\`src/cli/ui/markdown.tsx\`:

- \`FILE_REF_RE\` extension class was \`{1,6}\` — \`e.g\`, \`i.e\`, \`a.m\` all qualified as file paths.
- \`osc8()\` baked OSC 8 escape bytes (\`\x1b]8;;...\x07\`) into Text content. The cell-diff renderer's \`wrapLine\` strips zero-width chars (ESC, BEL) but keeps the printable body, so terminals received the bytes \`use ]8;;file://e.ge.g]8;;. like this\`. cmd.exe rendered the garbage verbatim; OSC 8-aware terminals also got no working link, just no garbage either.

User-confirmed reproduction: cmd.exe shows the garbled string for \`e.g.\` and any file ref like \`src/tools/web.ts:42\`.

## 2. Cell-diff renderer left stale chars in shrunk rows

The first bug fed terminal-state desync: stray bytes nudged the terminal cursor or scrollback off the renderer's prev model. Subsequent diffs skipped cells they thought were already correct, so the option-list modal rendered \`allow always\` + leftover \`mand, ask again next time\` on rows that originally held a longer hint.

Even after fixing #1, the diff is structurally fragile — any future ANSI-emitting bug would resurface the same class of corruption.

## Fix

**Markdown** (\`src/cli/ui/markdown.tsx\`):
- Tighten \`FILE_REF_RE\` post-match via \`looksLikeFileRef\`: require any of (a) path-shape (contains \`/\`), (b) \`:line\` suffix, (c) extension >= 2 chars. Preserves \`src/foo.ts\`, \`package.json\`, \`util.c:42\`. Drops bare \`util.c\` (acceptable — rare in prose vs. \`e.g.\`).
- Drop the OSC 8 escape emission from \`osc8()\` entirely. Keep color + underline so file refs stand out, but do not emit hyperlink bytes. Real OSC 8 support requires per-span hyperlink propagation through \`hostToLayoutNode\`'s nested-Text flattening — separate refactor.
- Plumb a \`hyperlink\` prop on ink-compat Text so the future per-span fix has a landing pad.

**Renderer** (\`src/renderer/diff/\`):
- New \`clearToEOL\` patch type → serializes to \`\x1b[K\`.
- After \`diffEach\`, sweep rows: when next's row ends earlier than prev's content extent, emit \`clearToEOL\` past the last visible cell. Bounded — at most one \`clearToEOL\` per row that shrank.

## Tests

- \`tests/markdown.test.ts\` — mounts Markdown through the reconciler, asserts the byte stream never contains \`]8;;\` for \`e.g.\` / \`i.e.\` / \`(e.g. Google)\` samples.
- \`tests/renderer/diff/diff-frames.test.ts\` — two cases: shrunk row emits one \`clearToEOL\`; same-width swap emits none.

## Test plan

- [x] \`npm run verify\` green (lint + typecheck + 2404 tests + build)
- [x] cmd.exe reproduction prompt verified locally to no longer show \`]8;;file://\` garbage
- [ ] User #330 reporter to confirm on archlinux + bunx