### PR TITLE
fix(stats): carry session cost / turn count across resume (#333)

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -48,7 +48,12 @@ import {
 import { TurnFailureTracker } from "./loop/turn-failure-tracker.js";
 import type { BranchSummary, LoopEvent } from "./loop/types.js";
 import { AppendOnlyLog, type ImmutablePrefix, VolatileScratch } from "./memory/runtime.js";
-import { appendSessionMessage, loadSessionMessages, rewriteSession } from "./memory/session.js";
+import {
+  appendSessionMessage,
+  loadSessionMessages,
+  loadSessionMeta,
+  rewriteSession,
+} from "./memory/session.js";
 import { type RepairReport, ToolCallRepair } from "./repair/index.js";
 import { SessionStats, type TurnStats } from "./telemetry/stats.js";
 import { countTokens } from "./tokenizer.js";
@@ -240,6 +245,15 @@ export class CacheFirstLoop {
       const tokensSaved = shrunk.tokensSaved;
       for (const msg of messages) this.log.append(msg);
       this.resumedMessageCount = messages.length;
+      // Carry forward cumulative cost / turn count so the TUI's session
+      // total continues across resumes; otherwise each restart resets to $0.
+      if (messages.length > 0) {
+        const meta = loadSessionMeta(this.sessionName);
+        this.stats.seedCarryover({
+          totalCostUsd: meta.totalCostUsd,
+          turnCount: meta.turnCount,
+        });
+      }
       if (healedCount > 0) {
         // Persist healed log so the same break isn't re-noticed every restart.
         try {

--- a/src/telemetry/stats.ts
+++ b/src/telemetry/stats.ts
@@ -96,6 +96,20 @@ export interface SessionSummary {
 
 export class SessionStats {
   readonly turns: TurnStats[] = [];
+  /** Cost from prior runs of a resumed session, restored from session meta. */
+  private _carryoverCost = 0;
+  /** Turn count from prior runs of a resumed session. */
+  private _carryoverTurns = 0;
+
+  /** Seed totals from a resumed session's persisted meta — only call once at construction. */
+  seedCarryover(opts: { totalCostUsd?: number; turnCount?: number }): void {
+    if (typeof opts.totalCostUsd === "number" && opts.totalCostUsd > 0) {
+      this._carryoverCost = opts.totalCostUsd;
+    }
+    if (typeof opts.turnCount === "number" && opts.turnCount > 0) {
+      this._carryoverTurns = opts.turnCount;
+    }
+  }
 
   record(turn: number, model: string, usage: Usage): TurnStats {
     const cost = costUsd(model, usage);
@@ -111,7 +125,7 @@ export class SessionStats {
   }
 
   get totalCost(): number {
-    return this.turns.reduce((sum, t) => sum + t.cost, 0);
+    return this._carryoverCost + this.turns.reduce((sum, t) => sum + t.cost, 0);
   }
 
   get totalClaudeEquivalent(): number {
@@ -145,7 +159,7 @@ export class SessionStats {
   summary(): SessionSummary {
     const last = this.turns[this.turns.length - 1];
     return {
-      turns: this.turns.length,
+      turns: this.turns.length + this._carryoverTurns,
       totalCostUsd: round(this.totalCost, 6),
       totalInputCostUsd: round(this.totalInputCost, 6),
       totalOutputCostUsd: round(this.totalOutputCost, 6),

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -351,4 +351,35 @@ describe("session persistence", () => {
       expect(findSessionsByPrefix("project")).toEqual(["project", "project-20260430T143200"]);
     });
   });
+
+  describe("issue #333 — resume seeds cost carryover from session meta", () => {
+    it("CacheFirstLoop on resume preloads totalCostUsd / turnCount into stats", () => {
+      appendSessionMessage("c333", { role: "user", content: "hi" });
+      appendSessionMessage("c333", { role: "assistant", content: "hello" });
+      patchSessionMeta("c333", { totalCostUsd: 0.0123, turnCount: 5 });
+
+      const client = new DeepSeekClient({ apiKey: "sk-test" });
+      const loop = new CacheFirstLoop({
+        client,
+        prefix: new ImmutablePrefix({ system: "test" }),
+        session: "c333",
+      });
+
+      expect(loop.stats.totalCost).toBe(0.0123);
+      const summary = loop.stats.summary();
+      expect(summary.totalCostUsd).toBe(0.0123);
+      expect(summary.turns).toBe(5);
+    });
+
+    it("fresh session (no meta) leaves carryover at zero", () => {
+      const client = new DeepSeekClient({ apiKey: "sk-test" });
+      const loop = new CacheFirstLoop({
+        client,
+        prefix: new ImmutablePrefix({ system: "test" }),
+        session: "fresh-c333",
+      });
+      expect(loop.stats.totalCost).toBe(0);
+      expect(loop.stats.summary().turns).toBe(0);
+    });
+  });
 });

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -162,3 +162,31 @@ describe("cacheSavingsUsd", () => {
     expect(proSave).toBeGreaterThan(flashSave);
   });
 });
+
+describe("SessionStats — issue #333 resume cost carryover", () => {
+  it("totalCost includes seeded carryover plus live turns", () => {
+    const s = new SessionStats();
+    s.seedCarryover({ totalCostUsd: 0.05, turnCount: 3 });
+    s.record(4, "deepseek-chat", new Usage(1000, 100, 0, 800, 200));
+    expect(s.totalCost).toBeGreaterThan(0.05);
+    expect(s.summary().totalCostUsd).toBeGreaterThan(0.05);
+    expect(s.summary().turns).toBe(4);
+  });
+
+  it("seedCarryover ignores undefined / zero / negative inputs", () => {
+    const s = new SessionStats();
+    s.seedCarryover({ totalCostUsd: 0, turnCount: 0 });
+    s.seedCarryover({ totalCostUsd: -1 });
+    expect(s.totalCost).toBe(0);
+    expect(s.summary().turns).toBe(0);
+  });
+
+  it("zero carryover keeps totalCost equal to live-turn sum (regression: no double-count for fresh sessions)", () => {
+    const s = new SessionStats();
+    s.record(1, "deepseek-chat", new Usage(1000, 100, 0, 800, 200));
+    const live = s.totalCost;
+    expect(live).toBeGreaterThan(0);
+    s.seedCarryover({});
+    expect(s.totalCost).toBe(live);
+  });
+});


### PR DESCRIPTION
Closes #333.

## Bug

The TUI's \`\$X session\` figure reset to \`\$0\` on every resume even though the disk-side session meta still held the cumulative \`totalCostUsd\` from prior runs.

Reproduction (from issue): \`hello\` → exit → resume → expense accumulator displays 0 instead of the prior session total.

## Root cause

The persistence path was already correct. \`App.tsx\` writes \`{ totalCostUsd, turnCount }\` into the session meta after every turn. The bug was purely on the read-back: \`SessionStats\` was constructed empty on every loop start, and \`summary().totalCostUsd\` only summed the live \`turns[]\` array — which is empty until the user takes a new turn.

## Fix

- \`SessionStats\` gains a one-shot \`seedCarryover({ totalCostUsd, turnCount })\` hook. Cost goes into a private \`_carryoverCost\` added to the \`totalCost\` getter; turn count goes into \`summary().turns\`. The live \`turns[]\` array stays untouched — it intentionally holds only this run's per-turn records.
- \`CacheFirstLoop\` calls \`loadSessionMeta()\` after loading prior messages and seeds the carryover when the session has any prior content. Fresh sessions remain at zero — the \`messages.length > 0\` guard plus the \`> 0\` checks inside \`seedCarryover\` make undefined / zero / negative input fields no-ops.

## Tests

- \`tests/telemetry.test.ts\` — carryover math: seeded value plus live turn produces correct total; ignored on undefined / zero / negative; fresh session sees no double-count.
- \`tests/session.test.ts\` — end-to-end loop wiring: a session file with persisted meta produces a loop whose \`stats.totalCost\` and \`stats.summary().turns\` reflect the carryover.

## Test plan

- [x] \`npm run verify\` green (lint + typecheck + 2409 tests + build)
- [ ] User #333 reporter to confirm: hello → exit → resume now keeps the cost figure