### PR TITLE
fix(plan): show plan body in PlanConfirm modal (#336)

### DIFF
--- a/src/cli/ui/PlanConfirm.tsx
+++ b/src/cli/ui/PlanConfirm.tsx
@@ -8,7 +8,8 @@ import { PlanStepList } from "./PlanStepList.js";
 import { SingleSelect } from "./Select.js";
 import { ApprovalCard } from "./cards/ApprovalCard.js";
 import { useReserveRows } from "./layout/viewport-budget.js";
-import { CARD, TONE } from "./theme/tokens.js";
+import { MarkdownView } from "./markdown-view.js";
+import { CARD, FG, TONE } from "./theme/tokens.js";
 
 export type PlanConfirmChoice = "approve" | "refine" | "revise" | "cancel";
 
@@ -21,9 +22,19 @@ export interface PlanConfirmProps {
   projectRoot?: string;
 }
 
+const PLAN_BODY_PREVIEW_LINES = 24;
+
 function PlanConfirmInner({ plan, steps, onChoose }: PlanConfirmProps) {
   const stepRows = steps?.length ?? 0;
-  useReserveRows("modal", { min: 10, max: Math.max(16, stepRows + 14) });
+  const hasSteps = stepRows > 0;
+  const planLines = plan.split("\n");
+  const truncatedBody = planLines.length > PLAN_BODY_PREVIEW_LINES;
+  const previewBody = truncatedBody ? planLines.slice(0, PLAN_BODY_PREVIEW_LINES).join("\n") : plan;
+  const previewRows = truncatedBody
+    ? PLAN_BODY_PREVIEW_LINES
+    : Math.min(planLines.length, PLAN_BODY_PREVIEW_LINES);
+  const reservedFor = hasSteps ? stepRows : previewRows;
+  useReserveRows("modal", { min: 10, max: Math.max(16, reservedFor + 14) });
 
   const hasOpenQuestions =
     /^#{1,6}\s*(open[-\s]?questions?|risks?|unknowns?|assumptions?|unclear)/im.test(plan) ||
@@ -45,9 +56,20 @@ function PlanConfirmInner({ plan, steps, onChoose }: PlanConfirmProps) {
           </Text>
         </Box>
       ) : null}
-      {steps && steps.length > 0 ? (
+      {hasSteps ? (
         <Box marginBottom={1} flexDirection="column">
-          <PlanStepList steps={steps} />
+          <PlanStepList steps={steps!} />
+        </Box>
+      ) : plan.trim().length > 0 ? (
+        <Box marginBottom={1} flexDirection="column">
+          <MarkdownView text={previewBody} />
+          {truncatedBody ? (
+            <Text color={FG.faint}>
+              {`… ${planLines.length - PLAN_BODY_PREVIEW_LINES} more line${
+                planLines.length - PLAN_BODY_PREVIEW_LINES === 1 ? "" : "s"
+              } above in scrollback`}
+            </Text>
+          ) : null}
         </Box>
       ) : null}
       <SingleSelect

--- a/tests/plan-confirm.test.tsx
+++ b/tests/plan-confirm.test.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { PlanConfirm } from "../src/cli/ui/PlanConfirm.js";
+import { CharPool } from "../src/renderer/pools/char-pool.js";
+import { HyperlinkPool } from "../src/renderer/pools/hyperlink-pool.js";
+import { StylePool } from "../src/renderer/pools/style-pool.js";
+import { mount } from "../src/renderer/reconciler/mount.js";
+
+async function bytesFor(plan: string, steps?: { id: string; title: string }[]): Promise<string> {
+  const chunks: string[] = [];
+  const handle = mount(<PlanConfirm plan={plan} steps={steps as never} onChoose={() => {}} />, {
+    viewportWidth: 80,
+    viewportHeight: 30,
+    pools: { char: new CharPool(), style: new StylePool(), hyperlink: new HyperlinkPool() },
+    write: (s) => {
+      chunks.push(s);
+    },
+  });
+  await new Promise((r) => setTimeout(r, 100));
+  const out = chunks.join("");
+  handle.destroy();
+  return out;
+}
+
+describe("PlanConfirm — issue #336 plan body must be visible", () => {
+  it("renders the markdown body when no steps are supplied", async () => {
+    const plan = [
+      "## Summary",
+      "Refactor `web_search` to support multiple backends",
+      "",
+      "## Steps",
+      "1. add adapter interface",
+      "2. wire env-var dispatch",
+    ].join("\n");
+    const out = await bytesFor(plan);
+    expect(out).toContain("Refactor");
+    expect(out).toContain("adapter interface");
+    expect(out).toContain("Approve plan");
+  });
+
+  it("falls back to step list when steps are present", async () => {
+    const plan = "## Summary\nbackend swap";
+    const steps = [
+      { id: "s1", title: "step one" },
+      { id: "s2", title: "step two" },
+    ];
+    const out = await bytesFor(plan, steps);
+    expect(out).toContain("step one");
+    expect(out).toContain("step two");
+  });
+
+  it("truncates very long plans and surfaces the overflow hint", async () => {
+    const longPlan = Array.from({ length: 50 }, (_, i) => `line ${i + 1}`).join("\n");
+    const out = await bytesFor(longPlan);
+    expect(out).toContain("line 1");
+    expect(out).toMatch(/more line.*scrollback/);
+  });
+});


### PR DESCRIPTION
Closes #336.

## Bug

When the model called \`submit_plan\` with a markdown body but no structured \`steps\` array, the Approve plan modal rendered only the warning banner + the choice list. The plan content itself was hidden behind the collapsed \`submit_plan\` tool-call card in scrollback (e.g. \"2.1 KB in · Refactor \`web_search\` to sup…\"). Users couldn't see what they were approving without scrolling back manually.

Reporter screenshot: <https://github.com/user-attachments/assets/0dd4a7b7-3856-4023-beea-f517f45abd28>

## Fix

\`PlanConfirm\` now renders the markdown body via \`MarkdownView\` when no structured steps are supplied. Structured steps still take precedence when present — they are the canonical view. When the body exceeds the inline preview cap (24 lines), the modal shows the leading 24 + a \"… N more lines above in scrollback\" hint.

## Test plan

- [x] \`tests/plan-confirm.test.tsx\` covers the three branches: body-only renders the markdown; steps-present renders the step list; long body truncates with overflow hint.
- [x] \`npm run verify\` green (lint + typecheck + 2412 tests + build)
- [ ] User #336 reporter to confirm the plan content now shows up