### PR TITLE
fix(markdown): row-group the table fallback layout (#340)

### DIFF
--- a/src/cli/ui/markdown.tsx
+++ b/src/cli/ui/markdown.tsx
@@ -328,31 +328,29 @@ function FallbackTable({
 }): React.ReactElement {
   return (
     <Box flexDirection="column">
-      {headerCells.map((h, ci) => {
-        const label = `${padToCells(h, labelPad - 2)}: `;
-        const values = bodyCells.map((r) => r[ci] ?? "");
-        return (
-          // biome-ignore lint/suspicious/noArrayIndexKey: header cells positional
-          <Box key={`fk-${ci}`} flexDirection="column">
-            {values.map((v, ri) => {
-              const lines = wrapToCells(v, valueCells);
-              return lines.map((line, li) => (
-                // biome-ignore lint/suspicious/noArrayIndexKey: fallback table lines are positional
-                <Box key={`fv-${ri}-${li}`}>
-                  {li === 0 ? (
-                    <Text bold color={FG.sub}>
-                      {label}
-                    </Text>
-                  ) : (
-                    <Text>{padToCells("", labelPad)}</Text>
-                  )}
-                  <Text color={FG.body}>{line}</Text>
-                </Box>
-              ));
-            })}
-          </Box>
-        );
-      })}
+      {bodyCells.map((row, ri) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: body rows positional
+        <Box key={`fr-${ri}`} flexDirection="column">
+          {ri > 0 ? <Text> </Text> : null}
+          {headerCells.map((h, ci) => {
+            const label = `${padToCells(h, labelPad - 2)}: `;
+            const lines = wrapToCells(row[ci] ?? "", valueCells);
+            return lines.map((line, li) => (
+              // biome-ignore lint/suspicious/noArrayIndexKey: fallback table lines are positional
+              <Box key={`fc-${ri}-${ci}-${li}`}>
+                {li === 0 ? (
+                  <Text bold color={FG.sub}>
+                    {label}
+                  </Text>
+                ) : (
+                  <Text>{padToCells("", labelPad)}</Text>
+                )}
+                <Text color={FG.body}>{line}</Text>
+              </Box>
+            ));
+          })}
+        </Box>
+      ))}
     </Box>
   );
 }

--- a/tests/markdown.test.ts
+++ b/tests/markdown.test.ts
@@ -82,6 +82,40 @@ describe("Markdown component", () => {
   });
 });
 
+describe("Markdown — issue #340 table fallback row grouping", () => {
+  it("renders fallback as row-grouped key/value pairs (column 1 row 1 before column 1 row 2)", async () => {
+    const { mount } = await import("../src/renderer/reconciler/mount.js");
+    const { CharPool } = await import("../src/renderer/pools/char-pool.js");
+    const { StylePool } = await import("../src/renderer/pools/style-pool.js");
+    const { HyperlinkPool } = await import("../src/renderer/pools/hyperlink-pool.js");
+    const md = [
+      "| Component | What | Manual TCs |",
+      "| - | - | - |",
+      "| Login form | Yup validation | AUTH-01 → AUTH-07 |",
+      "| Scheduler | Renders events | SCH-01 → SCH-15 |",
+    ].join("\n");
+    const chunks: string[] = [];
+    const handle = mount(React.createElement(Markdown, { text: md, width: 30 }), {
+      viewportWidth: 30,
+      viewportHeight: 30,
+      pools: { char: new CharPool(), style: new StylePool(), hyperlink: new HyperlinkPool() },
+      write: (s: string) => {
+        chunks.push(s);
+      },
+    });
+    await new Promise((r) => setTimeout(r, 100));
+    const visible = chunks
+      .join("")
+      .replace(new RegExp(`${String.fromCharCode(27)}\\[[0-9;?]*[a-zA-Z]`, "g"), "");
+    handle.destroy();
+    const tcIdx1 = visible.indexOf("AUTH-01");
+    const compIdx2 = visible.indexOf("Scheduler");
+    expect(tcIdx1).toBeGreaterThan(-1);
+    expect(compIdx2).toBeGreaterThan(-1);
+    expect(tcIdx1).toBeLessThan(compIdx2);
+  });
+});
+
 describe("Markdown — issue #330 file-ref over-match regression", () => {
   it("English abbreviations 'e.g' / 'i.e' are NOT treated as file refs", async () => {
     const { mount } = await import("../src/renderer/reconciler/mount.js");


### PR DESCRIPTION
Closes #340.

## Bug

When a markdown table is too wide for the viewport, \`FallbackTable\` flattens it into key/value lines. The previous implementation iterated headers first, then rows-within-each-header — so a 3×N table came out as:

\`\`\`
Component  : Login form
Component  : Scheduler
Component  : Appointment page
…  (all 9 components first)
What       : Yup validation fires
What       : Renders events
…  (all 9 What entries)
Manual TCs : AUTH-01 → AUTH-07
Manual TCs : SCH-01 → SCH-15
…
\`\`\`

The reader couldn't tell which value belonged to which row — the output read as a list grouped by column, not a table.

Reporter screenshot: <https://github.com/user-attachments/assets/c34f193b-9885-45d2-9d14-00c20f9a68d6>

## Fix

Swap the loop order in \`FallbackTable\`: iterate \`bodyCells\` (rows) first, and inside each row iterate \`headerCells\` (columns). Add a blank row separator between rows. Output now reads top-to-bottom as one logical row at a time:

\`\`\`
Component  : Login form
What       : Yup validation fires
Manual TCs : AUTH-01 → AUTH-07

Component  : Scheduler
What       : Renders events
Manual TCs : SCH-01 → SCH-15
\`\`\`

Pure rendering change — \`tableLayout()\` math is unchanged, no other layout math touches.

## Test plan

- [x] \`tests/markdown.test.ts\` mounts a 3×2 table at width=30 (forces fallback) and asserts that row 1's last value precedes row 2's first.
- [x] \`npm run verify\` green (lint + typecheck + 2413 tests + build).
- [ ] User #340 reporter to confirm rendering on Windows 11.