### PR TITLE
feat(slash): first-class command aliases (#332)

### DIFF
--- a/src/cli/ui/SlashSuggestions.tsx
+++ b/src/cli/ui/SlashSuggestions.tsx
@@ -86,6 +86,7 @@ function SuggestionRow({ spec, isSelected }: { spec: SlashCommandSpec; isSelecte
   const key = `slash.${spec.cmd}.description`;
   const translated = t(key);
   const summary = translated === key ? spec.summary : translated;
+  const aliasHint = spec.aliases?.length ? ` · /${spec.aliases.join(" /")}` : "";
   return (
     <Box>
       <Text color={isSelected ? COLOR.primary : COLOR.info} bold={isSelected}>
@@ -99,6 +100,7 @@ function SuggestionRow({ spec, isSelected }: { spec: SlashCommandSpec; isSelecte
       <Text color={isSelected ? COLOR.user : COLOR.info} dimColor={!isSelected}>
         {summary}
       </Text>
+      {aliasHint ? <Text dimColor>{aliasHint}</Text> : null}
     </Box>
   );
 }

--- a/src/cli/ui/slash/commands.ts
+++ b/src/cli/ui/slash/commands.ts
@@ -1,7 +1,7 @@
 import type { SlashArgContext, SlashCommandSpec } from "./types.js";
 
 export const SLASH_COMMANDS: readonly SlashCommandSpec[] = [
-  { cmd: "help", summary: "show the full command reference" },
+  { cmd: "help", summary: "show the full command reference", aliases: ["?"] },
   { cmd: "status", summary: "current model, flags, context, session" },
   {
     cmd: "preset",
@@ -52,6 +52,7 @@ export const SLASH_COMMANDS: readonly SlashCommandSpec[] = [
     argsHint: "<EN|zh-CN>",
     summary: "switch the runtime language",
     argCompleter: ["EN", "zh-CN"],
+    aliases: ["lang"],
   },
   { cmd: "mcp", summary: "list MCP servers + tools attached to this session" },
   {
@@ -147,13 +148,17 @@ export const SLASH_COMMANDS: readonly SlashCommandSpec[] = [
     summary: "show semantic_search status — built? Ollama installed? how to enable",
   },
   { cmd: "clear", summary: "clear visible scrollback only (log/context kept)" },
-  { cmd: "new", summary: "start a fresh conversation (clear context + scrollback)" },
+  {
+    cmd: "new",
+    summary: "start a fresh conversation (clear context + scrollback)",
+    aliases: ["reset"],
+  },
   {
     cmd: "loop",
     argsHint: "<5s..6h> <prompt>  ·  stop  ·  (no args = status)",
     summary: "auto-resubmit <prompt> every <interval> until you type something / Esc / /loop stop",
   },
-  { cmd: "exit", summary: "quit the TUI" },
+  { cmd: "exit", summary: "quit the TUI", aliases: ["quit", "q"] },
   // Code-mode only
   {
     cmd: "init",
@@ -253,8 +258,23 @@ export function suggestSlashCommands(prefix: string, codeMode = false): SlashCom
   const p = prefix.toLowerCase();
   return SLASH_COMMANDS.filter((c) => {
     if (c.contextual === "code" && !codeMode) return false;
-    return c.cmd.startsWith(p);
+    if (c.cmd.startsWith(p)) return true;
+    return c.aliases?.some((a) => a.startsWith(p)) ?? false;
   });
+}
+
+/** alias → canonical cmd map, derived from SLASH_COMMANDS at module init. */
+const ALIAS_TO_CMD: Readonly<Record<string, string>> = (() => {
+  const m: Record<string, string> = {};
+  for (const spec of SLASH_COMMANDS) {
+    if (!spec.aliases) continue;
+    for (const a of spec.aliases) m[a] = spec.cmd;
+  }
+  return m;
+})();
+
+export function resolveSlashAlias(name: string): string {
+  return ALIAS_TO_CMD[name] ?? name;
 }
 
 /** Picker fires only when arg tail has no internal whitespace; past that it's a usage hint. */
@@ -262,7 +282,7 @@ export function detectSlashArgContext(input: string, codeMode = false): SlashArg
   // `/cmd <rest>` — one space, rest captured up to end-of-buffer.
   const m = /^\/(\S+) ([\s\S]*)$/.exec(input);
   if (!m) return null;
-  const cmdName = m[1]!.toLowerCase();
+  const cmdName = resolveSlashAlias(m[1]!.toLowerCase());
   const tail = m[2] ?? "";
   const spec = SLASH_COMMANDS.find(
     (s) => s.cmd === cmdName && (s.contextual !== "code" || codeMode),

--- a/src/cli/ui/slash/dispatch.ts
+++ b/src/cli/ui/slash/dispatch.ts
@@ -1,4 +1,5 @@
 import type { CacheFirstLoop } from "../../../loop.js";
+import { resolveSlashAlias } from "./commands.js";
 import { handlers as adminHandlers } from "./handlers/admin.js";
 import { handlers as basicHandlers } from "./handlers/basic.js";
 import { handlers as dashboardHandlers } from "./handlers/dashboard.js";
@@ -45,7 +46,7 @@ export function handleSlash(
   loop: CacheFirstLoop,
   ctx: SlashContext = {},
 ): SlashResult {
-  const h = HANDLERS[cmd];
+  const h = HANDLERS[resolveSlashAlias(cmd)];
   if (h) return h(args, loop, ctx);
   return { unknown: true, info: `unknown command: /${cmd}  (try /help)` };
 }

--- a/src/cli/ui/slash/handlers/basic.ts
+++ b/src/cli/ui/slash/handlers/basic.ts
@@ -189,13 +189,10 @@ const loop: SlashHandler = (args, _loop, ctx) => {
 
 export const handlers: Record<string, SlashHandler> = {
   exit,
-  quit: exit,
   clear,
   new: resetLog,
-  reset: resetLog,
   keys,
   help,
-  "?": help,
   retry,
   loop,
 };

--- a/src/cli/ui/slash/handlers/language.ts
+++ b/src/cli/ui/slash/handlers/language.ts
@@ -25,5 +25,4 @@ export const handlers: Record<string, SlashHandler> = {
 
     return { info: t("slash.language.success") };
   },
-  lang: (args, loop, ctx) => handlers.language!(args, loop, ctx),
 };

--- a/src/cli/ui/slash/types.ts
+++ b/src/cli/ui/slash/types.ts
@@ -132,6 +132,8 @@ export interface SlashCommandSpec {
   argsHint?: string;
   /** First-arg picker source — file paths intentionally absent (use `@path` mentions instead). */
   argCompleter?: "models" | "mcp-resources" | "mcp-prompts" | readonly string[];
+  /** Alternate names — typing any of these resolves to `cmd` for dispatch / suggestion / arg-context. */
+  aliases?: readonly string[];
 }
 
 export interface SlashArgContext {

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -365,7 +365,7 @@ export const EN: TranslationSchema = {
         "  /clear                   clear displayed scrollback only (context kept — model still sees it)",
       helpLoop:
         "  /loop <interval> <prompt> auto-resubmit <prompt> every <interval> (5s..6h). /loop stop · type anything to cancel.",
-      helpExit: "  /exit                    quit",
+      helpExit: "  /exit                    quit (aliases: /quit, /q)",
       helpShellTitle: "Shell shortcut:",
       helpShell: "  !<cmd>                   run <cmd> in the sandbox root; output goes into",
       helpShellDetail:

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -345,7 +345,7 @@ export const zhCN: TranslationSchema = {
       helpClear: "  /clear                   仅清除显示的滚动回放（上下文保留 — 模型仍能看到）",
       helpLoop:
         "  /loop <interval> <prompt> 每 <interval> 自动重新提交 <prompt>（5秒..6小时）。/loop stop · 输入任何内容取消。",
-      helpExit: "  /exit                    退出",
+      helpExit: "  /exit                    退出（别名：/quit, /q）",
       helpShellTitle: "Shell 快捷方式：",
       helpShell: "  !<cmd>                   在沙箱根目录运行 <cmd>；输出进入对话",
       helpShellDetail: "                             以便模型在下一轮看到。无允许列表限制。",

--- a/src/server/api/slash.ts
+++ b/src/server/api/slash.ts
@@ -15,6 +15,7 @@ export async function handleSlash(
     summary: c.summary,
     argsHint: c.argsHint,
     contextual: c.contextual,
+    aliases: c.aliases,
   }));
   return { status: 200, body: { commands, codeMode } };
 }

--- a/tests/slash.test.ts
+++ b/tests/slash.test.ts
@@ -45,10 +45,25 @@ describe("parseSlash", () => {
 });
 
 describe("handleSlash", () => {
-  it("/exit requests exit", () => {
+  it("/exit requests exit (incl. /quit and /q aliases)", () => {
     const loop = makeLoop();
     expect(handleSlash("exit", [], loop).exit).toBe(true);
     expect(handleSlash("quit", [], loop).exit).toBe(true);
+    expect(handleSlash("q", [], loop).exit).toBe(true);
+  });
+
+  it("alias prefixes surface the canonical spec in suggestions", () => {
+    const matches = suggestSlashCommands("q");
+    expect(matches.map((s) => s.cmd)).toContain("exit");
+    expect(matches.find((s) => s.cmd === "exit")?.aliases).toEqual(["quit", "q"]);
+    expect(suggestSlashCommands("?").map((s) => s.cmd)).toContain("help");
+    expect(suggestSlashCommands("res").map((s) => s.cmd)).toContain("new");
+  });
+
+  it("detectSlashArgContext resolves an alias to its canonical spec", () => {
+    const ctx = detectSlashArgContext("/lang zh");
+    expect(ctx).not.toBeNull();
+    expect(ctx!.spec.cmd).toBe("language");
   });
 
   it("/clear requests history clear + surfaces an info line about what it does", () => {


### PR DESCRIPTION
Closes #332.

## Summary
- `SlashCommandSpec` gets an optional `aliases?: readonly string[]` field. `/exit` declares `["quit", "q"]`, `/help` → `["?"]`, `/new` → `["reset"]`, `/language` → `["lang"]`. One spec is the single source of truth — dispatch, autocomplete and arg-context all route through one `resolveSlashAlias()` map built from `SLASH_COMMANDS` at module init.
- Removes the ad-hoc per-handler alias mirrors that used to live in `handlers/basic.ts` (`quit: exit`, `"?": help`, `reset: resetLog`) and `handlers/language.ts` (`lang`). New aliases now only need a one-line edit to the spec — no follow-up work in handlers / dispatch / suggestion UI / dashboard.
- Suggestion rows display aliases dimly (`/exit  quit the TUI · /quit /q`) so they stay discoverable without doubling the list. `/api/slash` exposes the field for the dashboard.

## Test plan
- [x] `npx vitest run tests/slash.test.ts` — 134/134 pass; new tests cover `/q` dispatch, alias-prefix suggestion matching, and alias-driven `detectSlashArgContext` resolution.
- [x] `npm run verify` (full pre-push gate: build + lint + typecheck + 2415 tests) — green.
- [ ] Manual: launch TUI, type `/q` → `/exit (alias: q, quit)` row appears; Tab snaps to canonical `/exit`; bare `/q` + Enter exits.