### PR TITLE
fix(renderer): use CHA absolute for column moves in cell-diff (#346)

### DIFF
--- a/src/renderer/diff/diff-frames.ts
+++ b/src/renderer/diff/diff-frames.ts
@@ -91,7 +91,7 @@ function moveTo(
   }
 
   if (cursor.x !== targetX) {
-    out.push({ type: "cursorMove", dx: targetX - cursor.x, dy: 0 });
+    out.push({ type: "cursorTo", col: targetX });
     cursor.x = targetX;
   }
 }

--- a/tests/renderer/diff/diff-frames.test.ts
+++ b/tests/renderer/diff/diff-frames.test.ts
@@ -69,7 +69,7 @@ describe("diffFrames — empty diff", () => {
 });
 
 describe("diffFrames — single-cell change", () => {
-  it("emits cursorMove + stdout for one changed cell", () => {
+  it("positions cursor + writes stdout for one changed cell", () => {
     const p = pools();
     withPools(p, () => {
       const a = frame(5, 2);
@@ -77,10 +77,12 @@ describe("diffFrames — single-cell change", () => {
       const out = diffFrames(a, b, p);
       const stdout = out.filter((pp): pp is Patch & { type: "stdout" } => pp.type === "stdout");
       expect(stdout.map((p) => p.content)).toEqual(["x"]);
-      const cursorMoves = out.filter(
-        (pp): pp is Patch & { type: "cursorMove" } => pp.type === "cursorMove",
+      // Column targeting goes through CHA absolute (cursorTo) — relative CUF would
+      // accumulate drift across frames if any earlier write miscounted cell width.
+      const cursorTos = out.filter(
+        (pp): pp is Patch & { type: "cursorTo" } => pp.type === "cursorTo",
       );
-      expect(cursorMoves.some((m) => m.dx > 0 || m.dy > 0)).toBe(true);
+      expect(cursorTos.map((c) => c.col)).toContain(2);
     });
   });
 
@@ -94,10 +96,33 @@ describe("diffFrames — single-cell change", () => {
         s.writeCell(2, 0, cell(p, "c"));
       });
       const out = diffFrames(a, b, p);
-      const cursorMoves = out.filter((pp) => pp.type === "cursorMove");
-      // First write needs at most one cursor move; subsequent writes ride on
+      const positioningPatches = out.filter(
+        (pp) => pp.type === "cursorMove" || pp.type === "cursorTo",
+      );
+      // First write needs at most one position; subsequent writes ride on
       // the terminal's natural cursor advance, so no extra moves between.
-      expect(cursorMoves.length).toBeLessThanOrEqual(1);
+      expect(positioningPatches.length).toBeLessThanOrEqual(1);
+    });
+  });
+});
+
+describe("diffFrames — cursor positioning hardening (claude-code/issues/14208)", () => {
+  it("never emits relative CUF/CUB (column dx) for cell positioning — CHA only", () => {
+    const p = pools();
+    withPools(p, () => {
+      const a = frame(20, 5, (s) => {
+        for (const [x, ch] of "hello".split("").entries()) s.writeCell(x + 2, 1, cell(p, ch));
+        for (const [x, ch] of "world".split("").entries()) s.writeCell(x + 7, 3, cell(p, ch));
+      });
+      const b = frame(20, 5, (s) => {
+        for (const [x, ch] of "HELLO".split("").entries()) s.writeCell(x + 2, 1, cell(p, ch));
+        for (const [x, ch] of "WORLD".split("").entries()) s.writeCell(x + 7, 3, cell(p, ch));
+      });
+      const out = diffFrames(a, b, p);
+      const horizMoves = out.filter(
+        (pp): pp is Patch & { type: "cursorMove" } => pp.type === "cursorMove" && pp.dx !== 0,
+      );
+      expect(horizMoves).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
Hardens the cell-diff renderer against per-cell width miscounts. Closes #346 (defensive fix — couldn't reproduce locally on cmd / PowerShell / Windows Terminal, but the captured byte stream + Anthropic's own [claude-code#14208](https://github.com/anthropics/claude-code/issues/14208) post-mortem point to the same root cause).

## Summary
- `moveTo()` X-axis branch now emits `cursorTo` (CHA, `\x1b[N+1G` — absolute column) instead of `cursorMove(dx, 0)` (CUF/CUB — relative). Y-axis stays on CUU/CUD since we don't track absolute terminal rows.
- Relative column moves accumulate drift across frames whenever an earlier write miscounts cell width — `▸` (U+25B8) rendered 2-cell on fonts with East Asian fallback, ambiguous-width chars on terminals that font-detect width, OSC8 hyperlinks parsed as visible chars, etc. The next CUF lands at the wrong column, ghost rows leak into adjacent hint lines, and the modal "shifts" as users navigate (the symptom in #346's screenshots).
- CHA targets the absolute column regardless of where the terminal thinks the cursor is — immune to the desync chain. Same fix Anthropic applied to Claude Code per their issue #14208 post-mortem.

## Test plan
- [x] `npx vitest run tests/renderer/diff/diff-frames.test.ts` — 16/16 pass; new regression test `never emits relative CUF/CUB (column dx) for cell positioning — CHA only` locks in the invariant.
- [x] `npm run verify` (build + lint + typecheck + 2414 tests + 1 skipped) — green.
- [ ] Manual: I can't reproduce the original artifact on cmd.exe / PowerShell / Windows Terminal, so this is a defensive fix. Would appreciate if @dududarochadev could re-test on the next release.