### PR TITLE
fix(ui): suppress live card redraw while picker modal is open

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -2994,6 +2994,21 @@ function AppInner({
     [],
   );
 
+  const modalOpen =
+    !!pendingShell ||
+    !!pendingPlan ||
+    !!pendingReviseEditor ||
+    !!pendingSessionsPicker ||
+    !!pendingMcpHub ||
+    !!stagedInput ||
+    !!pendingEditReview ||
+    walkthroughActive ||
+    !!pendingChoice ||
+    !!stagedChoiceCustom ||
+    !!pendingRevision ||
+    !!stagedCheckpointRevise ||
+    !!pendingCheckpoint;
+
   return (
     <>
       <TickerProvider
@@ -3027,7 +3042,7 @@ function AppInner({
           <Box flexDirection="row">
             <Box flexDirection="column" flexGrow={1}>
               <Box flexDirection="column">
-                <CardStream />
+                <CardStream suppressLive={modalOpen} />
                 {/*
           Welcome card on the empty state. Visible only when nothing
           has happened yet (no past events, nothing in flight, no

--- a/src/cli/ui/layout/CardStream.tsx
+++ b/src/cli/ui/layout/CardStream.tsx
@@ -20,13 +20,28 @@ function isSettled(card: Card): boolean {
   }
 }
 
-export function CardStream(): React.ReactElement {
-  const cards = useAgentState((s) => s.cards);
+export function splitCardStream(
+  cards: readonly Card[],
+  suppressLive = false,
+): { committed: Card[]; live: Card[] } {
   const lastIdx = cards.length - 1;
   const lastCard = lastIdx >= 0 ? (cards[lastIdx] as Card) : null;
   const lastIsLive = !!lastCard && !isSettled(lastCard);
+  if (suppressLive && lastIsLive) {
+    return { committed: cards.slice(0, lastIdx), live: [] };
+  }
   const committed: Card[] = lastIsLive ? cards.slice(0, lastIdx) : cards.slice();
   const live: Card[] = lastIsLive && lastCard ? [lastCard] : [];
+  return { committed, live };
+}
+
+export function CardStream({
+  suppressLive = false,
+}: {
+  suppressLive?: boolean;
+}): React.ReactElement {
+  const cards = useAgentState((s) => s.cards);
+  const { committed, live } = splitCardStream(cards, suppressLive);
   // Static items are emitted via bridge.emitStatic, which renders them in an
   // off-tree React reconciler — context from the live tree does NOT propagate.
   // The ActiveCardContext.Provider must therefore live inside the children

--- a/tests/card-stream.test.ts
+++ b/tests/card-stream.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { splitCardStream } from "../src/cli/ui/layout/CardStream.js";
+import type { Card, ToolCard, UserCard } from "../src/cli/ui/state/cards.js";
+
+function userCard(id: string): UserCard {
+  return { id, ts: 0, kind: "user", text: `user ${id}` };
+}
+
+function liveToolCard(id: string): ToolCard {
+  return {
+    id,
+    ts: 0,
+    kind: "tool",
+    name: "submit_plan",
+    args: {},
+    output: "",
+    done: false,
+    elapsedMs: 0,
+  };
+}
+
+describe("splitCardStream", () => {
+  it("keeps the last unsettled card live by default", () => {
+    const cards: Card[] = [userCard("u1"), liveToolCard("t1")];
+    const result = splitCardStream(cards);
+    expect(result.committed.map((c) => c.id)).toEqual(["u1"]);
+    expect(result.live.map((c) => c.id)).toEqual(["t1"]);
+  });
+
+  it("suppresses the last unsettled card while a modal owns the screen", () => {
+    const cards: Card[] = [userCard("u1"), liveToolCard("t1")];
+    const result = splitCardStream(cards, true);
+    expect(result.committed.map((c) => c.id)).toEqual(["u1"]);
+    expect(result.live).toEqual([]);
+  });
+
+  it("does not drop settled cards when suppression is enabled", () => {
+    const settled: ToolCard = { ...liveToolCard("t1"), done: true };
+    const cards: Card[] = [userCard("u1"), settled];
+    const result = splitCardStream(cards, true);
+    expect(result.committed.map((c) => c.id)).toEqual(["u1", "t1"]);
+    expect(result.live).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

Hide the unsettled live card while a modal owns the screen, so the picker is the only live surface repainting during arrow-key navigation.

This adds a small `CardStream` split helper, suppresses the live card when a modal is open, and covers that behavior with `tests/card-stream.test.ts`.

## Why

In the `submit_plan` flow, the tool card above the picker stays live while the pause gate is waiting for input. Moving through the picker can repaint both the modal and that blocked live card, which can leave a stale duplicated row behind in the TUI.

Fixes #352.

## How to verify

- `npm run verify`
- `npm run chat`
- Let the agent call `submit_plan`
- Move up and down through the approval choices and confirm old rows do not remain painted

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time
