### PR TITLE
feat(ui): live tokens/s on streaming reply + space pauses 5s undo (#334, #337)

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -433,6 +433,7 @@ function AppInner({
     undoBanner,
     recordEdit,
     armUndoBanner,
+    toggleUndoPause,
     codeUndo,
     codeHistory,
     codeShowEdit,
@@ -1254,7 +1255,7 @@ function AppInner({
         next === "yolo"
           ? "▸ edit mode: YOLO — edits AND shell commands auto-run. /undo still rolls back edits. Use carefully."
           : next === "auto"
-            ? "▸ edit mode: AUTO — edits apply immediately; press u within 5s to undo. Shell commands still ask."
+            ? "▸ edit mode: AUTO — edits apply immediately; press u within 5s to undo (space pauses the timer). Shell commands still ask."
             : "▸ edit mode: review — edits queue for /apply (or y) / /discard (or n)";
       log.pushInfo(message);
       return;
@@ -1285,6 +1286,28 @@ function AppInner({
     ) {
       const out = codeUndo([]);
       log.pushInfo(out);
+      return;
+    }
+    // Space toggles pause on the active undo countdown. Same gating as
+    // the `u` keybind so typing in the prompt isn't intercepted.
+    if (
+      codeMode &&
+      input.length === 0 &&
+      chKey === " " &&
+      undoBanner &&
+      !pendingShell &&
+      !pendingPlan &&
+      !pendingReviseEditor &&
+      !pendingSessionsPicker &&
+      !pendingMcpHub &&
+      !stagedInput &&
+      !pendingEditReview &&
+      !walkthroughActive &&
+      !pendingChoice &&
+      !stagedChoiceCustom &&
+      !pendingRevision
+    ) {
+      toggleUndoPause();
       return;
     }
     if (busy) return;

--- a/src/cli/ui/cards/StreamingCard.tsx
+++ b/src/cli/ui/cards/StreamingCard.tsx
@@ -2,6 +2,7 @@ import { Box, Text, useStdout } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React from "react";
 import { clipToCells, wrapToCells } from "../../../frame/width.js";
+import { countTokens } from "../../../tokenizer.js";
 import { useReserveRows } from "../layout/viewport-budget.js";
 import { Markdown } from "../markdown.js";
 import { Card } from "../primitives/Card.js";
@@ -10,9 +11,34 @@ import { PILL_MODEL, Pill, modelBadgeFor } from "../primitives/Pill.js";
 import { Spinner } from "../primitives/Spinner.js";
 import type { StreamingCard as StreamingCardData } from "../state/cards.js";
 import { FG, TONE, TONE_ACTIVE } from "../theme/tokens.js";
+import { useSlowTick } from "../ticker.js";
 
 /** Streaming preview tail length — bounded live region so chunks don't thrash whole-card layout. */
 const STREAMING_PREVIEW_LINES = 4;
+
+const MIN_ELAPSED_MS_FOR_RATE = 500;
+const MIN_TOKENS_FOR_RATE = 4;
+
+function formatTokenCount(n: number): string {
+  if (n >= 10000) return `${(n / 1000).toFixed(1)}k`;
+  if (n >= 1000) return `${(n / 1000).toFixed(2)}k`;
+  return String(n);
+}
+
+function tokenRate(
+  text: string,
+  startTs: number,
+  endTs: number,
+): { tokens: number; tps: number | null } {
+  const tokens = countTokens(text);
+  const elapsedMs = endTs - startTs;
+  if (elapsedMs < MIN_ELAPSED_MS_FOR_RATE || tokens < MIN_TOKENS_FOR_RATE) {
+    return { tokens, tps: null };
+  }
+  return { tokens, tps: Math.round((tokens * 1000) / elapsedMs) };
+}
+
+const PILL_RATE = { bg: "#11141a", fg: "#8b949e" } as const;
 
 export function StreamingCard({ card }: { card: StreamingCardData }): React.ReactElement {
   const { stdout } = useStdout();
@@ -21,6 +47,9 @@ export function StreamingCard({ card }: { card: StreamingCardData }): React.Reac
     min: STREAMING_PREVIEW_LINES + 1,
     max: STREAMING_PREVIEW_LINES + 2,
   });
+  // Re-render at 1Hz so the rate keeps updating even when chunks stall.
+  // Frozen once `card.done` is true — settled cards render via Static.
+  useSlowTick();
 
   const modelBadge = card.model ? modelBadgeFor(card.model) : null;
   const modelPill = modelBadge ? (
@@ -28,9 +57,24 @@ export function StreamingCard({ card }: { card: StreamingCardData }): React.Reac
   ) : null;
 
   if (card.done && !card.aborted) {
+    const { tokens, tps } = tokenRate(card.text, card.ts, card.endedAt ?? Date.now());
+    const ratePill =
+      tokens >= MIN_TOKENS_FOR_RATE && tps !== null ? (
+        <Pill label={`${formatTokenCount(tokens)} tok · ${tps} t/s`} {...PILL_RATE} bold={false} />
+      ) : null;
     return (
       <Card tone={TONE.ok}>
-        <CardHeader glyph="‹" tone={TONE.ok} title="reply" right={modelPill} />
+        <CardHeader
+          glyph="‹"
+          tone={TONE.ok}
+          title="reply"
+          right={
+            <>
+              {ratePill}
+              {modelPill}
+            </>
+          }
+        />
         <Markdown text={card.text} />
       </Card>
     );
@@ -45,6 +89,12 @@ export function StreamingCard({ card }: { card: StreamingCardData }): React.Reac
   const glyph = aborted ? "‹" : "◈";
   const headLabel = aborted ? "aborted" : "writing…";
 
+  const { tokens: liveTokens, tps: liveTps } = tokenRate(card.text, card.ts, Date.now());
+  const liveRatePill =
+    !aborted && liveTokens >= MIN_TOKENS_FOR_RATE && liveTps !== null ? (
+      <Pill label={`${liveTps} t/s`} {...PILL_RATE} bold={false} />
+    ) : null;
+
   return (
     <Card tone={headColor}>
       <CardHeader
@@ -53,6 +103,7 @@ export function StreamingCard({ card }: { card: StreamingCardData }): React.Reac
         title={headLabel}
         right={
           <>
+            {liveRatePill}
             {aborted ? null : <Spinner kind="braille" color={TONE_ACTIVE.brand} />}
             {modelPill}
           </>

--- a/src/cli/ui/layout/LiveRows.tsx
+++ b/src/cli/ui/layout/LiveRows.tsx
@@ -113,17 +113,20 @@ function ModePill({
 export function UndoBanner({
   banner,
 }: {
-  banner: { results: ApplyResult[]; expiresAt: number };
+  banner: { results: ApplyResult[]; expiresAt: number; pausedRemainingMs: number | null };
 }) {
   useTick();
   const totalMs = 5000;
-  const remainingMs = Math.max(0, banner.expiresAt - Date.now());
+  const paused = banner.pausedRemainingMs !== null;
+  const remainingMs = paused
+    ? (banner.pausedRemainingMs ?? 0)
+    : Math.max(0, banner.expiresAt - Date.now());
   const remainingSec = Math.ceil(remainingMs / 1000);
   const ok = banner.results.filter((r) => r.status === "applied" || r.status === "created").length;
   const total = banner.results.length;
-  const urgent = remainingSec <= 1;
+  const urgent = !paused && remainingSec <= 1;
   const pct = (remainingMs / totalMs) * 100;
-  const tone = urgent ? TONE.err : TONE.accent;
+  const tone = paused ? TONE.warn : urgent ? TONE.err : TONE.accent;
   return (
     <Box marginY={1} paddingX={1}>
       <Text backgroundColor={TONE.accent} color="black" bold>
@@ -133,11 +136,15 @@ export function UndoBanner({
       <Text backgroundColor={TONE.brand} color="black" bold>
         {" u "}
       </Text>
-      <Text color={FG.faint}>{" to undo  "}</Text>
+      <Text color={FG.faint}>{paused ? " to undo · " : " to undo · "}</Text>
+      <Text backgroundColor={paused ? TONE.warn : FG.faint} color="black" bold>
+        {" space "}
+      </Text>
+      <Text color={FG.faint}>{paused ? " to resume  " : " to pause  "}</Text>
       <CharBar pct={pct} width={20} color={tone} showLabel={false} />
       <Text color={FG.faint}>{"  "}</Text>
-      <Text color={tone} bold={urgent}>
-        {`${remainingSec}s`}
+      <Text color={tone} bold={urgent || paused}>
+        {paused ? `${remainingSec}s · paused` : `${remainingSec}s`}
       </Text>
     </Box>
   );

--- a/src/cli/ui/useEditHistory.ts
+++ b/src/cli/ui/useEditHistory.ts
@@ -16,6 +16,8 @@ import {
 export interface UndoBannerState {
   results: ApplyResult[];
   expiresAt: number;
+  /** Set when the user paused the countdown; banner stays up until they resume or hit `u`. */
+  pausedRemainingMs: number | null;
 }
 
 export interface UseEditHistoryResult {
@@ -30,6 +32,8 @@ export interface UseEditHistoryResult {
   ) => void;
   /** Replaces the dismiss timer so multiple edits in one turn don't prematurely expire the window. */
   armUndoBanner: (results: ApplyResult[]) => void;
+  /** Pause / resume the active undo countdown. No-ops if the banner is already settled. */
+  toggleUndoPause: () => void;
   codeUndo: (args?: readonly string[]) => string;
   codeHistory: () => string;
   codeShowEdit: (args?: readonly string[]) => string;
@@ -77,12 +81,32 @@ export function useEditHistory(codeMode: { rootDir: string } | undefined): UseEd
   );
 
   const armUndoBanner = useCallback<UseEditHistoryResult["armUndoBanner"]>((results) => {
-    setUndoBanner({ results, expiresAt: Date.now() + 5000 });
+    setUndoBanner({ results, expiresAt: Date.now() + 5000, pausedRemainingMs: null });
     if (undoTimeoutRef.current) clearTimeout(undoTimeoutRef.current);
     undoTimeoutRef.current = setTimeout(() => {
       setUndoBanner(null);
       undoTimeoutRef.current = null;
     }, 5000);
+  }, []);
+
+  const toggleUndoPause = useCallback<UseEditHistoryResult["toggleUndoPause"]>(() => {
+    setUndoBanner((prev) => {
+      if (!prev) return prev;
+      if (prev.pausedRemainingMs === null) {
+        const remaining = Math.max(0, prev.expiresAt - Date.now());
+        if (undoTimeoutRef.current) {
+          clearTimeout(undoTimeoutRef.current);
+          undoTimeoutRef.current = null;
+        }
+        return { ...prev, pausedRemainingMs: remaining };
+      }
+      const remaining = prev.pausedRemainingMs;
+      undoTimeoutRef.current = setTimeout(() => {
+        setUndoBanner(null);
+        undoTimeoutRef.current = null;
+      }, remaining);
+      return { ...prev, expiresAt: Date.now() + remaining, pausedRemainingMs: null };
+    });
   }, []);
 
   const codeUndo = useCallback<UseEditHistoryResult["codeUndo"]>(
@@ -266,6 +290,7 @@ export function useEditHistory(codeMode: { rootDir: string } | undefined): UseEd
     undoBanner,
     recordEdit,
     armUndoBanner,
+    toggleUndoPause,
     codeUndo,
     codeHistory,
     codeShowEdit,


### PR DESCRIPTION
Closes #334
Refs #337 (partial — `space` pause done; fold-toggle deferred to its own issue)

## Summary

Two small live-feedback fixes from @dacec354's recent triage.

### #334 — token/s on the streaming reply card

While the model writes, the card header now carries a `42 t/s` pill next to the spinner. After the reply settles, the pill flips to `1.2k tok · 42 t/s` so the throughput stays visible on scrollback.

- Computed via the bundled DeepSeek tokenizer; gated below 4 tokens / 500 ms so the first chunk doesn't print bogus 1000 t/s rates.
- Re-renders piggyback on the slow tick — rate keeps updating during chunk silence, then freezes once the card is settled (rendered via Static).

### #337 (partial) — `space` pauses the auto-mode undo countdown

The "press u within 5s to undo" banner now also accepts `space` to pause the timer indefinitely. While paused the bar freezes at the captured fraction, the badge swaps to `Ns · paused`, and pressing `space` again resumes from where it stopped.

The other half of #337 (shortcut to fold/unfold the last message) is left for a follow-up — it needs its own design pass on what "fold" means for streaming vs settled messages.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 164/164 test files pass
- [ ] Manual: `npm run chat`, watch the t/s pill update during a long reply
- [ ] Manual: trigger an auto-applied edit, press `space` during the 5s window, confirm the bar freezes; press `space` again, confirm it resumes