### PR TITLE
fix(ui): SessionPicker honors wallet currency instead of hardcoded ¥ (#312)

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -2382,7 +2382,12 @@ function AppInner({
               const m = loadSessionMeta(session);
               const cost = (m.totalCostUsd ?? 0) + (ev.stats?.cost ?? 0);
               const turn = (m.turnCount ?? 0) + 1;
-              patchSessionMeta(session, { totalCostUsd: cost, turnCount: turn });
+              const currency = walletCurrencyRef.current;
+              patchSessionMeta(session, {
+                totalCostUsd: cost,
+                turnCount: turn,
+                ...(currency ? { balanceCurrency: currency } : {}),
+              });
             }
           } else if (ev.role === "tool_start") {
             handleToolStart(ev, {
@@ -3228,6 +3233,7 @@ function AppInner({
                 <SessionPicker
                   sessions={sessionsPickerList}
                   workspace={currentRootDir}
+                  walletCurrency={walletCurrencyRef.current}
                   onChoose={(outcome) => {
                     if (outcome.kind === "open") {
                       setPendingSessionsPicker(false);

--- a/src/cli/ui/SessionPicker.tsx
+++ b/src/cli/ui/SessionPicker.tsx
@@ -3,7 +3,7 @@ import { Box, Text, useStdout } from "ink";
 import React, { useState } from "react";
 import type { SessionInfo } from "../../memory/session.js";
 import { useKeystroke } from "./keystroke-context.js";
-import { FG, TONE, USD_TO_CNY } from "./theme/tokens.js";
+import { FG, TONE, formatCost } from "./theme/tokens.js";
 
 export type SessionPickerOutcome =
   | { kind: "open"; name: string }
@@ -16,6 +16,8 @@ export interface SessionPickerProps {
   sessions: ReadonlyArray<SessionInfo>;
   workspace: string;
   onChoose: (outcome: SessionPickerOutcome) => void;
+  /** Live wallet currency from App.tsx; falls back to each session's stored `meta.balanceCurrency` per row. */
+  walletCurrency?: string;
 }
 
 const PAGE_MARGIN = 6;
@@ -24,6 +26,7 @@ export function SessionPicker({
   sessions,
   workspace,
   onChoose,
+  walletCurrency,
 }: SessionPickerProps): React.ReactElement {
   const [focus, setFocus] = useState(0);
   const [renaming, setRenaming] = useState<{ from: string; buf: string } | null>(null);
@@ -101,7 +104,14 @@ export function SessionPicker({
           <Text color={FG.faint}>{" to start a new one"}</Text>
         </Box>
       ) : (
-        shown.map((s, i) => <SessionRow key={s.name} info={s} focused={start + i === focus} />)
+        shown.map((s, i) => (
+          <SessionRow
+            key={s.name}
+            info={s}
+            focused={start + i === focus}
+            walletCurrency={walletCurrency}
+          />
+        ))
       )}
       {hiddenBelow > 0 ? (
         <Box>
@@ -135,15 +145,19 @@ export function SessionPicker({
 function SessionRow({
   info,
   focused,
-}: { info: SessionInfo; focused: boolean }): React.ReactElement {
+  walletCurrency,
+}: {
+  info: SessionInfo;
+  focused: boolean;
+  walletCurrency?: string;
+}): React.ReactElement {
   const branch = info.meta.branch ?? "main";
   const summary =
     info.meta.summary ?? `${info.messageCount} message${info.messageCount === 1 ? "" : "s"}`;
   const turns = info.meta.turnCount ?? Math.ceil(info.messageCount / 2);
-  const costCny =
-    info.meta.totalCostUsd !== undefined
-      ? `¥${(info.meta.totalCostUsd * USD_TO_CNY).toFixed(2)}`
-      : "";
+  const currency = walletCurrency ?? info.meta.balanceCurrency;
+  const costLabel =
+    info.meta.totalCostUsd !== undefined ? formatCost(info.meta.totalCostUsd, currency, 2) : "";
   const time = relativeTime(info.mtime);
   return (
     <Box>
@@ -156,7 +170,7 @@ function SessionRow({
       <Box flexGrow={1} />
       <Text color={FG.faint}>{`${time.padStart(11)}   `}</Text>
       <Text color={FG.faint}>{`${turns} turns`}</Text>
-      {costCny ? <Text color={FG.faint}>{` · ${costCny}`}</Text> : null}
+      {costLabel ? <Text color={FG.faint}>{` · ${costLabel}`}</Text> : null}
     </Box>
   );
 }

--- a/src/memory/session.ts
+++ b/src/memory/session.ts
@@ -48,6 +48,8 @@ export interface SessionMeta {
   turnCount?: number;
   /** Absolute path of the workspace root the session was created/used in. */
   workspace?: string;
+  /** Wallet currency at last save — used to format `totalCostUsd` in the picker without re-fetching balance. */
+  balanceCurrency?: string;
 }
 
 export function sessionsDir(): string {

--- a/tests/ui-session-picker-currency.test.tsx
+++ b/tests/ui-session-picker-currency.test.tsx
@@ -1,0 +1,83 @@
+import { render } from "ink";
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { SessionPicker } from "../src/cli/ui/SessionPicker.js";
+import type { SessionInfo } from "../src/memory/session.js";
+
+function makeFakeStdout() {
+  const chunks: string[] = [];
+  return {
+    columns: 120,
+    rows: 30,
+    isTTY: true,
+    write(chunk: string) {
+      chunks.push(chunk);
+      return true;
+    },
+    on() {},
+    off() {},
+    text(): string {
+      // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI SGR codes
+      return chunks.join("").replace(/\x1b\[[0-9;]*m/g, "");
+    },
+  };
+}
+
+function makeSession(currencyHint?: string): SessionInfo {
+  return {
+    name: "demo",
+    path: "/tmp/demo.jsonl",
+    size: 100,
+    messageCount: 4,
+    mtime: new Date("2026-05-06T00:00:00Z"),
+    meta: {
+      branch: "main",
+      summary: "demo session",
+      totalCostUsd: 0.05,
+      turnCount: 2,
+      workspace: "/repo",
+      ...(currencyHint ? { balanceCurrency: currencyHint } : {}),
+    },
+  };
+}
+
+function renderPicker(sessions: SessionInfo[], walletCurrency: string | undefined): string {
+  const stdout = makeFakeStdout();
+  const { unmount } = render(
+    React.createElement(SessionPicker, {
+      sessions,
+      workspace: "/repo",
+      walletCurrency,
+      onChoose: () => {},
+    }),
+    { stdout: stdout as any, stdin: process.stdin as any },
+  );
+  unmount();
+  return stdout.text();
+}
+
+describe("SessionPicker — cost column follows wallet currency, not hardcoded ¥", () => {
+  it("USD wallet prop: $0.05 (not ¥)", () => {
+    const text = renderPicker([makeSession()], "USD");
+    expect(text).toContain("$0.05");
+    expect(text).not.toContain("¥");
+  });
+
+  it("CNY wallet prop: ¥0.36 (USD * 7.2)", () => {
+    const text = renderPicker([makeSession()], "CNY");
+    expect(text).toContain("¥0.36");
+    expect(text).not.toContain("$0.05");
+  });
+
+  it("no wallet prop: per-row meta.balanceCurrency wins", () => {
+    const text = renderPicker([makeSession("USD")], undefined);
+    expect(text).toContain("$0.05");
+    expect(text).not.toContain("¥");
+  });
+
+  it("neither prop nor meta: falls back to ¥ (unchanged from pre-fix)", () => {
+    const text = renderPicker([makeSession()], undefined);
+    expect(text).toContain("¥0.36");
+    expect(text).not.toContain("$0.05");
+  });
+});


### PR DESCRIPTION
Closes #312

## Summary

Same bug shape as the StatusRow / UsageCard / StatsPanel set fixed under #272 — SessionPicker still hardcoded `¥` and ran USD → CNY itself, so USD-wallet users saw `¥X.XX` in the session list picker.

The wallet currency in this codebase isn't persisted in config — it comes from a live balance fetch. The pre-mount picker (`chat.tsx`) doesn't have that yet. So the fix has two layers:

- **Stored fallback:** `SessionMeta` gains `balanceCurrency?: string`. Every turn's cost-save in `App.tsx` writes it alongside `totalCostUsd`. Rows fall back to their own stored currency when no live prop is in scope.
- **Live prop:** `SessionPicker` accepts `walletCurrency`. The in-app picker (`/sessions`) gets `walletCurrencyRef.current`. Prop wins over per-row stored value.

Cost rendering routes through the shared `formatCost(usd, currency, digits)` helper instead of the inline `¥${...}`.

## Test plan

- [x] `tests/ui-session-picker-currency.test.tsx` — 4 cases: USD prop, CNY prop, no-prop + USD meta, no-prop + no meta (legacy default ¥)
- [x] `npx vitest run` — 165/165 test files, 2423 tests pass