### PR TITLE
feat(ui): ctrl-o expands the live streaming card to full tail (#335, #337)

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -104,6 +104,7 @@ import { useScrollback } from "./hooks/useScrollback.js";
 import { useTranscriptWriter } from "./hooks/useTranscriptWriter.js";
 import { useKeystroke } from "./keystroke-context.js";
 import { CardStream } from "./layout/CardStream.js";
+import { LiveExpandContext } from "./layout/LiveExpandContext.js";
 import {
   ModeStatusBar,
   OngoingToolRow,
@@ -299,6 +300,12 @@ function AppInner({
   const isStreaming = useAgentState((s) => s.cards.some((c) => c.kind === "streaming" && !c.done));
   const [input, setInput] = useState("");
   const [busy, setBusy] = useState(false);
+  // ctrl-o toggles full-tail view on the live streaming card.
+  // Auto-resets at the end of every turn so the next reply starts collapsed.
+  const [liveExpand, setLiveExpand] = useState(false);
+  useEffect(() => {
+    if (!isStreaming && liveExpand) setLiveExpand(false);
+  }, [isStreaming, liveExpand]);
   const [languageVersion, setLanguageVersion] = useState(0);
   useEffect(() => onLanguageChange(() => setLanguageVersion((v) => v + 1)), []);
   // Live MCP server list: initialized from the boot-time prop, then
@@ -1308,6 +1315,28 @@ function AppInner({
       !pendingRevision
     ) {
       toggleUndoPause();
+      return;
+    }
+    // Ctrl-O toggles full-tail view on the live streaming reply so a long
+    // plan / todo can be read while it's still being written. Resets at
+    // turn end so each new reply starts collapsed.
+    if (
+      key.ctrl &&
+      key.input === "o" &&
+      isStreaming &&
+      !pendingShell &&
+      !pendingPlan &&
+      !pendingReviseEditor &&
+      !pendingSessionsPicker &&
+      !pendingMcpHub &&
+      !stagedInput &&
+      !pendingEditReview &&
+      !walkthroughActive &&
+      !pendingChoice &&
+      !stagedChoiceCustom &&
+      !pendingRevision
+    ) {
+      setLiveExpand((v) => !v);
       return;
     }
     if (busy) return;
@@ -3079,7 +3108,9 @@ function AppInner({
           <Box flexDirection="row">
             <Box flexDirection="column" flexGrow={1}>
               <Box flexDirection="column">
-                <CardStream suppressLive={modalOpen} />
+                <LiveExpandContext.Provider value={liveExpand}>
+                  <CardStream suppressLive={modalOpen} />
+                </LiveExpandContext.Provider>
                 {/*
           Welcome card on the empty state. Visible only when nothing
           has happened yet (no past events, nothing in flight, no

--- a/src/cli/ui/cards/StreamingCard.tsx
+++ b/src/cli/ui/cards/StreamingCard.tsx
@@ -1,8 +1,9 @@
 import { Box, Text, useStdout } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
-import React from "react";
+import React, { useContext } from "react";
 import { clipToCells, wrapToCells } from "../../../frame/width.js";
 import { countTokens } from "../../../tokenizer.js";
+import { LiveExpandContext } from "../layout/LiveExpandContext.js";
 import { useReserveRows } from "../layout/viewport-budget.js";
 import { Markdown } from "../markdown.js";
 import { Card } from "../primitives/Card.js";
@@ -15,6 +16,8 @@ import { useSlowTick } from "../ticker.js";
 
 /** Streaming preview tail length — bounded live region so chunks don't thrash whole-card layout. */
 const STREAMING_PREVIEW_LINES = 4;
+/** Expanded mode shows up to this many lines so the card can't swallow the whole viewport. */
+const EXPANDED_MAX_LINES = 60;
 
 const MIN_ELAPSED_MS_FOR_RATE = 500;
 const MIN_TOKENS_FOR_RATE = 4;
@@ -43,9 +46,11 @@ const PILL_RATE = { bg: "#11141a", fg: "#8b949e" } as const;
 export function StreamingCard({ card }: { card: StreamingCardData }): React.ReactElement {
   const { stdout } = useStdout();
   const cols = stdout?.columns ?? 80;
+  const expanded = useContext(LiveExpandContext);
+  const reserveCap = expanded ? EXPANDED_MAX_LINES + 2 : STREAMING_PREVIEW_LINES + 2;
   useReserveRows("stream", {
     min: STREAMING_PREVIEW_LINES + 1,
-    max: STREAMING_PREVIEW_LINES + 2,
+    max: reserveCap,
   });
   // Re-render at 1Hz so the rate keeps updating even when chunks stall.
   // Frozen once `card.done` is true — settled cards render via Static.
@@ -83,7 +88,9 @@ export function StreamingCard({ card }: { card: StreamingCardData }): React.Reac
   const lineCells = Math.max(20, cols - 4);
   const allLines = card.text.length > 0 ? card.text.split("\n") : [""];
   const visualLines = allLines.flatMap((l) => wrapToCells(l, lineCells));
-  const visible = visualLines.slice(-STREAMING_PREVIEW_LINES);
+  const cap = expanded ? EXPANDED_MAX_LINES : STREAMING_PREVIEW_LINES;
+  const visible = visualLines.slice(-cap);
+  const droppedAbove = Math.max(0, visualLines.length - visible.length);
   const aborted = !!card.aborted;
   const headColor = aborted ? TONE.err : TONE_ACTIVE.brand;
   const glyph = aborted ? "‹" : "◈";
@@ -94,6 +101,9 @@ export function StreamingCard({ card }: { card: StreamingCardData }): React.Reac
     !aborted && liveTokens >= MIN_TOKENS_FOR_RATE && liveTps !== null ? (
       <Pill label={`${liveTps} t/s`} {...PILL_RATE} bold={false} />
     ) : null;
+  const expandPill = !aborted ? (
+    <Pill label={expanded ? "expanded ⌃o" : "preview ⌃o"} {...PILL_RATE} bold={false} />
+  ) : null;
 
   return (
     <Card tone={headColor}>
@@ -104,13 +114,19 @@ export function StreamingCard({ card }: { card: StreamingCardData }): React.Reac
         right={
           <>
             {liveRatePill}
+            {expandPill}
             {aborted ? null : <Spinner kind="braille" color={TONE_ACTIVE.brand} />}
             {modelPill}
           </>
         }
       />
+      {expanded && droppedAbove > 0 ? (
+        <Text
+          color={FG.faint}
+        >{`⋯ ${droppedAbove} earlier line${droppedAbove === 1 ? "" : "s"} above`}</Text>
+      ) : null}
       {visible.map((line, i) => (
-        <Box key={`${card.id}:${allLines.length - visible.length + i}`} flexDirection="row">
+        <Box key={`${card.id}:${visualLines.length - visible.length + i}`} flexDirection="row">
           <Text color={aborted ? FG.meta : FG.body}>{clipToCells(line, lineCells)}</Text>
         </Box>
       ))}

--- a/src/cli/ui/layout/LiveExpandContext.ts
+++ b/src/cli/ui/layout/LiveExpandContext.ts
@@ -1,0 +1,4 @@
+import { createContext } from "react";
+
+/** ctrl-o toggles this; live streaming card swaps 4-line tail for full-tail view. */
+export const LiveExpandContext = createContext<boolean>(false);


### PR DESCRIPTION
Closes #335
Closes #337

## Summary

@dacec354 raised two related asks:

- **#335** — can't read the plan / todo list while the model is writing it; the streaming card only shows the last 4 lines.
- **#337 (second half)** — wants a shortcut to fold the last message.

Single keystroke covers both: **`ctrl-o` toggles "expanded" mode on the live streaming card**.

- Expanded shows up to 60 visual lines (capped so it can't swallow the viewport) plus a `⋯ N earlier lines above` hint when it overflows.
- Collapses back to the 4-line preview.
- Auto-resets to collapsed at the end of every turn so each new reply starts compact.
- A `expanded ⌃o` / `preview ⌃o` pill in the card header advertises the keybind.

The fold-toggle half of #337 is solved by the same mechanism (you can fold long content back to 4 lines while it's still live). Settled cards live in Ink's `<Static>` which already wrote the bytes to terminal scrollback — no take-backs there. The pre-existing `space` pause for the undo banner (PR #356) was the first half of #337; together they close it.

The first half of #337 (`space` pauses 5s undo) shipped in PR #356. This PR closes both #335 and #337 by addressing the remaining ask.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 165/165 test files, 2425 tests pass
- [ ] Manual: long reply, press `ctrl-o`, confirm tail expands and pill flips; press again to collapse