### PR TITLE
chore(issue-template): add shell/terminal fields, update model examples

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -17,7 +17,9 @@ Steps or minimal code that reproduces it.
 - Reasonix version:
 - Node version:
 - OS:
-- DeepSeek model (e.g. `deepseek-chat`, `deepseek-reasoner`):
+- Shell (bash, zsh, fish, PowerShell, etc.):
+- Terminal emulator (kitty, WezTerm, Windows Terminal, etc.):
+- DeepSeek model (e.g. `deepseek-v4-flash`, `deepseek-v4-pro`):
 
 **Logs / transcript**
 If using the CLI, attach the relevant chunk of `--transcript`.


### PR DESCRIPTION
 ## What 
  
 Add `shell` and `terminal` fields to bug report template. Update model examples from `deepseek-chat`/`deepseek-reasoner` to `deepseek-v4-flash`/`deepseek-v4-pro`. 
  
 ## Why 
  
 Closes #377. Shell and terminal matter for TUI bugs (rendering, key handling differ across them). Model names were outdated. 

