### PR TITLE
fix(mcp): preflight filesystem sandbox dir + offer mkdir in wizard (#362)

### DIFF
--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -11,6 +11,7 @@ import { loadDotenv } from "../../env.js";
 import type { CacheFirstLoop } from "../../loop.js";
 import { McpClient } from "../../mcp/client.js";
 import { type InspectionReport, inspectMcpServer } from "../../mcp/inspect.js";
+import { preflightStdioSpec } from "../../mcp/preflight.js";
 import { type McpClientHost, bridgeMcpTools } from "../../mcp/registry.js";
 import { parseMcpSpec } from "../../mcp/spec.js";
 import { SseTransport } from "../../mcp/sse.js";
@@ -107,6 +108,7 @@ function createMcpRuntime(ctx: RuntimeContext): McpRuntime {
         : ctx.getRequestedCount() === 1 && ctx.getMcpPrefix()
           ? (ctx.getMcpPrefix() as string)
           : "";
+      if (spec.transport === "stdio") preflightStdioSpec(spec);
       const transport: McpTransport =
         spec.transport === "sse"
           ? new SseTransport({ url: spec.url })

--- a/src/cli/commands/mcp-inspect.ts
+++ b/src/cli/commands/mcp-inspect.ts
@@ -1,6 +1,7 @@
 import { McpClient } from "../../mcp/client.js";
 import { inspectMcpServer } from "../../mcp/inspect.js";
 import type { InspectionReport } from "../../mcp/inspect.js";
+import { preflightStdioSpec } from "../../mcp/preflight.js";
 import { parseMcpSpec } from "../../mcp/spec.js";
 import { SseTransport } from "../../mcp/sse.js";
 import { type McpTransport, StdioTransport } from "../../mcp/stdio.js";
@@ -15,6 +16,7 @@ export interface McpInspectOptions {
 
 export async function mcpInspectCommand(opts: McpInspectOptions): Promise<void> {
   const spec = parseMcpSpec(opts.spec);
+  if (spec.transport === "stdio") preflightStdioSpec(spec);
   const transport: McpTransport =
     spec.transport === "sse"
       ? new SseTransport({ url: spec.url })

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -11,6 +11,7 @@ import {
 import { loadDotenv } from "../../env.js";
 import { CacheFirstLoop, DeepSeekClient, ImmutablePrefix } from "../../index.js";
 import { McpClient } from "../../mcp/client.js";
+import { preflightStdioSpec } from "../../mcp/preflight.js";
 import { bridgeMcpTools } from "../../mcp/registry.js";
 import { parseMcpSpec } from "../../mcp/spec.js";
 import { SseTransport } from "../../mcp/sse.js";
@@ -103,6 +104,7 @@ export async function runCommand(opts: RunOptions): Promise<void> {
           : requestedSpecs.length === 1 && opts.mcpPrefix
             ? opts.mcpPrefix
             : "";
+        if (spec.transport === "stdio") preflightStdioSpec(spec);
         const transport: McpTransport =
           spec.transport === "sse"
             ? new SseTransport({ url: spec.url })

--- a/src/cli/ui/Wizard.tsx
+++ b/src/cli/ui/Wizard.tsx
@@ -11,6 +11,7 @@
  * `--branch`, etc. can be picked here in a few arrow-key presses.
  */
 
+import { mkdirSync, statSync } from "node:fs";
 import { Box, Text, useApp, useInput } from "ink";
 import TextInput from "ink-text-input";
 // biome-ignore lint/style/useImportType: JSX (jsx: "react") needs React as a value at runtime
@@ -287,6 +288,49 @@ function McpArgsStep({
   onError: (e: string | null) => void;
 }) {
   const [value, setValue] = useState("");
+  const [pendingCreate, setPendingCreate] = useState<string | null>(null);
+
+  useInput((input, key) => {
+    if (!pendingCreate) return;
+    const ch = input.toLowerCase();
+    if (ch === "y" || key.return) {
+      try {
+        mkdirSync(pendingCreate, { recursive: true });
+        const created = pendingCreate;
+        setPendingCreate(null);
+        setValue("");
+        onError(null);
+        onSubmit(created);
+      } catch (e) {
+        onError(`Couldn't create ${pendingCreate}: ${(e as Error).message}`);
+        setPendingCreate(null);
+      }
+    } else if (ch === "n" || key.escape) {
+      setPendingCreate(null);
+      onError(null);
+    }
+  });
+
+  if (pendingCreate) {
+    return (
+      <StepFrame title={`Configure ${entry.name}`} step={2} total={3}>
+        <Box flexDirection="column">
+          <Text>
+            Directory <Text bold>{pendingCreate}</Text> doesn't exist.
+          </Text>
+          <Box marginTop={1}>
+            <Text dimColor>[Y/Enter] create it (mkdir -p) · [N/Esc] enter a different path</Text>
+          </Box>
+          {error ? (
+            <Box marginTop={1}>
+              <Text color="red">{error}</Text>
+            </Box>
+          ) : null}
+        </Box>
+      </StepFrame>
+    );
+  }
+
   return (
     <StepFrame title={`Configure ${entry.name}`} step={2} total={3}>
       <Box flexDirection="column">
@@ -314,6 +358,17 @@ function McpArgsStep({
                 onError(`${entry.name} needs a value — got an empty string.`);
                 return;
               }
+              if (entry.name === "filesystem") {
+                const check = checkFilesystemPath(trimmed);
+                if (check.kind === "missing") {
+                  setPendingCreate(trimmed);
+                  return;
+                }
+                if (check.kind === "not-a-dir") {
+                  onError(`${trimmed} exists but is not a directory.`);
+                  return;
+                }
+              }
               onSubmit(trimmed);
               setValue("");
             }}
@@ -328,6 +383,14 @@ function McpArgsStep({
       </Box>
     </StepFrame>
   );
+}
+
+function checkFilesystemPath(p: string): { kind: "ok" | "missing" | "not-a-dir" } {
+  try {
+    return { kind: statSync(p).isDirectory() ? "ok" : "not-a-dir" };
+  } catch {
+    return { kind: "missing" };
+  }
 }
 
 function ReviewConfirm({ onConfirm }: { onConfirm: () => void }) {

--- a/src/mcp/preflight.ts
+++ b/src/mcp/preflight.ts
@@ -1,0 +1,23 @@
+import { type Stats, statSync } from "node:fs";
+import type { StdioMcpSpec } from "./spec.js";
+
+const FILESYSTEM_PKG = "@modelcontextprotocol/server-filesystem";
+
+export function preflightStdioSpec(spec: StdioMcpSpec): void {
+  const pkgIndex = spec.args.indexOf(FILESYSTEM_PKG);
+  if (pkgIndex < 0) return;
+  const positional = spec.args.slice(pkgIndex + 1).filter((a) => !a.startsWith("-"));
+  for (const dir of positional) {
+    let stat: Stats;
+    try {
+      stat = statSync(dir);
+    } catch {
+      throw new Error(
+        `MCP filesystem sandbox '${dir}' does not exist — create it with: mkdir -p '${dir}'`,
+      );
+    }
+    if (!stat.isDirectory()) {
+      throw new Error(`MCP filesystem sandbox '${dir}' exists but is not a directory`);
+    }
+  }
+}

--- a/tests/mcp-preflight.test.ts
+++ b/tests/mcp-preflight.test.ts
@@ -1,0 +1,62 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { preflightStdioSpec } from "../src/mcp/preflight.js";
+import type { StdioMcpSpec } from "../src/mcp/spec.js";
+
+function stdio(args: string[]): StdioMcpSpec {
+  return { transport: "stdio", name: "fs", command: "npx", args };
+}
+
+describe("preflightStdioSpec — filesystem MCP", () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "reasonix-preflight-"));
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("no-ops on non-filesystem servers (no package match in args)", () => {
+    expect(() =>
+      preflightStdioSpec(stdio(["-y", "@modelcontextprotocol/server-memory"])),
+    ).not.toThrow();
+  });
+
+  it("passes when the sandbox dir exists", () => {
+    expect(() =>
+      preflightStdioSpec(stdio(["-y", "@modelcontextprotocol/server-filesystem", tmp])),
+    ).not.toThrow();
+  });
+
+  it("throws an actionable error when the dir is missing", () => {
+    const missing = join(tmp, "does-not-exist");
+    expect(() =>
+      preflightStdioSpec(stdio(["-y", "@modelcontextprotocol/server-filesystem", missing])),
+    ).toThrow(/does not exist — create it with: mkdir -p/);
+  });
+
+  it("throws when the sandbox path is a file, not a directory", () => {
+    const file = join(tmp, "not-a-dir");
+    writeFileSync(file, "");
+    expect(() =>
+      preflightStdioSpec(stdio(["-y", "@modelcontextprotocol/server-filesystem", file])),
+    ).toThrow(/exists but is not a directory/);
+  });
+
+  it("checks every positional dir, fails on the first missing one", () => {
+    const missing = join(tmp, "missing");
+    expect(() =>
+      preflightStdioSpec(stdio(["-y", "@modelcontextprotocol/server-filesystem", tmp, missing])),
+    ).toThrow(new RegExp(`'${missing.replace(/\\/g, "\\\\")}' does not exist`));
+  });
+
+  it("ignores flag-shaped args after the package id", () => {
+    expect(() =>
+      preflightStdioSpec(
+        stdio(["-y", "@modelcontextprotocol/server-filesystem", "--verbose", tmp]),
+      ),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
Closes #362.

## Why

The official `@modelcontextprotocol/server-filesystem` refuses to start when its sandbox directory doesn't exist and prints a raw Node stack trace from inside `npx`'s child:

```
Error accessing directory /tmp/reasonix-sandbox: ENOENT: no such file or directory, stat '/tmp/reasonix-sandbox'
    at async Object.stat (node:internal/fs/promises:1680:18)
    at async file:///home/dacec/.npm/_npx/.../server-filesystem/dist/index.js:43:23
```

The user has no idea what to do, and we're partly responsible: our wizard suggests `/tmp/reasonix-sandbox` as a placeholder, then saves whatever the user types into `~/.reasonix/config.json` without checking it.

## What changes

Two-layer fix.

**1. Wizard input-time validation** (`src/cli/ui/Wizard.tsx`)

When the filesystem MCP server's directory arg is submitted:
- exists & dir → accept as before
- exists but not a dir → red error, stay on input
- missing → switch to a confirm step: `[Y/Enter] create it (mkdir -p)` / `[N/Esc] enter a different path`

**2. Spawn-time fallback** (`src/mcp/preflight.ts` + 3 call sites)

`preflightStdioSpec(spec)` runs right before `new StdioTransport(...)` in `chat.tsx`, `run.ts`, and `mcp-inspect.ts`. If a stdio spec contains `@modelcontextprotocol/server-filesystem`, every positional path arg is `stat`ed; missing → throws

```
MCP filesystem sandbox '/tmp/reasonix-sandbox' does not exist — create it with: mkdir -p '/tmp/reasonix-sandbox'
```

The existing per-call-site catch already surfaces this as a `failed` MCP lifecycle event, so users see the actionable message in the same place they currently see the raw stack.

The spawn-time path deliberately does **not** auto-mkdir: at that point the user might be running with a stale config they don't remember writing, and silently creating directories on their behalf is too magic. The wizard is the right place to ask before creating.

## Tests

`tests/mcp-preflight.test.ts` — 6 cases:
- non-filesystem servers: no-op
- existing dir: no throw
- missing dir: actionable error
- path-is-a-file: distinct error
- multi-dir spec, one missing: throws on the missing one
- flag-shaped tokens after the package id: ignored

## Test plan

- [x] `npx vitest run tests/mcp-preflight.test.ts` — 6/6 pass
- [x] `npx vitest run` — full suite 2430 pass / 5 skipped
- [x] `tsc --noEmit` clean
- [x] `biome check` clean on touched files
- [ ] Manual: `bunx reasonix code` with a stale config pointing at a missing dir → actionable error instead of raw Node stack
- [ ] Manual: `reasonix init` → pick filesystem → enter a missing path → Y creates it, N returns to input