### PR TITLE
chore(release): 0.30.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,68 @@
 All notable changes to Reasonix. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.3] — 2026-05-07
+
+**Headline:** the chat scroll rewrite lands. Ink 5.2 → 7.0.2 / React
+18.3 → 19.2, the cell-diff renderer is retired, and `reasonix code` /
+`reasonix chat` default to alt-screen with row-precision virtual
+scroll. PgUp / PgDn / mouse wheel scroll history; an empty prompt + ↑
+also scrolls (Ctrl+P / Ctrl+N still recalls prompt history). When
+scrolled away from bottom, the prompt hides and a `📖 reading
+history — End / PgDn to return` hint appears. Resize-ghost dividers
+and `<Static>`-related scroll-yank artifacts are gone with the
+renderer that produced them. `--no-alt-screen` keeps the legacy
+in-shell-scrollback behavior.
+
+`web_search` gains a configurable backend — Mojeek stays the default,
+but `/web-search-engine searxng <url>` switches to a self-hosted
+SearXNG instance for users whose network blocks Mojeek. And the MCP
+filesystem sandbox now fails with an actionable
+`mkdir -p '<path>'` hint instead of a raw Node stack when the
+configured directory doesn't exist; the wizard offers to create it
+inline at config time.
+
+**Features:**
+
+- feat(ui): row-precision virtual scroll on Ink 7 + React 19.
+  `<Static>` retired (incompatible with alt-screen reflow);
+  `React.memo(CardRenderer)` plus reference-stable cards in the
+  reducer skip the reconciler on unchanged history. `useChatScroll`
+  drives an outer `overflow=hidden` clip + inner `marginTop=-N`
+  slide; `useBoxMetrics` reports inner / outer heights so bounds
+  clamp and auto-pin to bottom on new content. `App` owns
+  PgUp/PgDn/End/wheel; PromptInput hands off ↑/↓ on empty buffer
+  when pinned + idle. Ticker migrated to Ink 7's shared
+  `useAnimation`. (PR #380)
+- feat(web): configurable `web_search` backend with SearXNG support.
+  `/web-search-engine` shows / switches the active engine; URL is
+  persisted to `~/.reasonix/config.json`. Mojeek remains the default;
+  the original Mojeek path is preserved as `searchMojeek()`. Protocol
+  auto-normalizes (`localhost:8080` → `http://...`); an unreachable
+  SearXNG endpoint surfaces an install hint instead of a raw fetch
+  error. (PR #338)
+
+**Bug fixes:**
+
+- fix(mcp): preflight the filesystem sandbox directory before
+  spawning `@modelcontextprotocol/server-filesystem`. Missing
+  directories now throw `MCP filesystem sandbox '<path>' does not
+  exist — create it with: mkdir -p '<path>'` instead of a raw Node
+  stack from inside `npx`'s child. The init wizard adds an inline
+  `[Y] create it (mkdir -p) / [N] enter a different path` confirm
+  step when the user types a path that doesn't exist, so bad config
+  never reaches disk. Spawn-time path deliberately does not
+  auto-mkdir — by then the user may not remember writing the
+  config. (#362, PR #379)
+- fix(readme): website URLs corrected from `/reasonix/` to
+  `/DeepSeek-Reasonix/`. (PR #375)
+
+**Chores:**
+
+- chore(issue-template): bug template now asks for shell + terminal,
+  and the model-id examples track the current DeepSeek model
+  lineup. (PR #378)
+
 ## [0.30.2] — 2026-05-07
 
 **Headline:** five user-visible polish items from the @dacec354 triage

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reasonix",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reasonix",
-      "version": "0.30.2",
+      "version": "0.30.3",
       "license": "MIT",
       "dependencies": {
         "cli-highlight": "^2.1.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reasonix",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "description": "DeepSeek-native coding agent: cache-first loop, flash-first cost control, tool-call repair.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- **feat(ui): row-precision virtual scroll on Ink 7 + React 19** (#380) — Ink 5.2 → 7.0.2, React 18.3 → 19.2; cell-diff renderer retired; alt-screen by default; PgUp/PgDn/wheel/empty-↑ scroll history; `--no-alt-screen` keeps legacy mode.
- **feat(web): configurable `web_search` backend with SearXNG support** (#338) — `/web-search-engine` switches between Mojeek (default) and self-hosted SearXNG; URL persisted to `~/.reasonix/config.json`.
- **fix(mcp): filesystem sandbox preflight + wizard mkdir confirm** (#362, PR #379) — actionable `mkdir -p` hint instead of raw Node stack when sandbox dir is missing; wizard offers to create it inline.
- **fix(readme):** website URLs corrected from `/reasonix/` to `/DeepSeek-Reasonix/` (PR #375).
- **chore(issue-template):** ask for shell + terminal, refresh model-id examples (PR #378).

Today's freshly-filed bugs (#364 cache/expense reset on resume, #365 fish/bash terminal escape leak, #372 stale model badge after `/model`, #373 PowerShell Shift+Tab) all reproduce on 0.30.2 and are deferred to 0.30.4 — they don't block this release because the items shipping here are unrelated and already on `main`.

## Test plan

- [x] `npm run verify` — 133 files / 2132 passed / 1 skipped
- [ ] `bunx reasonix@0.30.3 code` boots into alt-screen, PgUp/wheel scroll, End re-pins
- [ ] `--no-alt-screen` still works for legacy in-shell scrollback
- [ ] `/web-search-engine searxng <url>` round-trips through config
- [ ] Stale config pointing at missing filesystem sandbox dir → actionable error, not Node stack