### PR TITLE
fix(stats): persist cache totals + lastPromptTokens across resume

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -2412,9 +2412,15 @@ function AppInner({
               const cost = (m.totalCostUsd ?? 0) + (ev.stats?.cost ?? 0);
               const turn = (m.turnCount ?? 0) + 1;
               const currency = walletCurrencyRef.current;
+              const u = ev.stats?.usage;
+              const cacheHitTokens = (m.cacheHitTokens ?? 0) + (u?.promptCacheHitTokens ?? 0);
+              const cacheMissTokens = (m.cacheMissTokens ?? 0) + (u?.promptCacheMissTokens ?? 0);
               patchSessionMeta(session, {
                 totalCostUsd: cost,
                 turnCount: turn,
+                cacheHitTokens,
+                cacheMissTokens,
+                ...(u?.promptTokens ? { lastPromptTokens: u.promptTokens } : {}),
                 ...(currency ? { balanceCurrency: currency } : {}),
               });
             }

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -252,6 +252,9 @@ export class CacheFirstLoop {
         this.stats.seedCarryover({
           totalCostUsd: meta.totalCostUsd,
           turnCount: meta.turnCount,
+          cacheHitTokens: meta.cacheHitTokens,
+          cacheMissTokens: meta.cacheMissTokens,
+          lastPromptTokens: meta.lastPromptTokens,
         });
       }
       if (healedCount > 0) {

--- a/src/memory/session.ts
+++ b/src/memory/session.ts
@@ -50,6 +50,11 @@ export interface SessionMeta {
   workspace?: string;
   /** Wallet currency at last save — used to format `totalCostUsd` in the picker without re-fetching balance. */
   balanceCurrency?: string;
+  /** Cumulative cache hit / miss tokens across the session — survives resume so /status cache% isn't 0 on a fresh boot. */
+  cacheHitTokens?: number;
+  cacheMissTokens?: number;
+  /** Last turn's promptTokens — lets /status render the context bar before the next turn fires. */
+  lastPromptTokens?: number;
 }
 
 export function sessionsDir(): string {

--- a/src/telemetry/stats.ts
+++ b/src/telemetry/stats.ts
@@ -100,14 +100,33 @@ export class SessionStats {
   private _carryoverCost = 0;
   /** Turn count from prior runs of a resumed session. */
   private _carryoverTurns = 0;
+  private _carryoverCacheHit = 0;
+  private _carryoverCacheMiss = 0;
+  /** Last turn's promptTokens before exit — surfaced via summary() until the next live turn lands. */
+  private _carryoverLastPromptTokens = 0;
 
   /** Seed totals from a resumed session's persisted meta — only call once at construction. */
-  seedCarryover(opts: { totalCostUsd?: number; turnCount?: number }): void {
+  seedCarryover(opts: {
+    totalCostUsd?: number;
+    turnCount?: number;
+    cacheHitTokens?: number;
+    cacheMissTokens?: number;
+    lastPromptTokens?: number;
+  }): void {
     if (typeof opts.totalCostUsd === "number" && opts.totalCostUsd > 0) {
       this._carryoverCost = opts.totalCostUsd;
     }
     if (typeof opts.turnCount === "number" && opts.turnCount > 0) {
       this._carryoverTurns = opts.turnCount;
+    }
+    if (typeof opts.cacheHitTokens === "number" && opts.cacheHitTokens > 0) {
+      this._carryoverCacheHit = opts.cacheHitTokens;
+    }
+    if (typeof opts.cacheMissTokens === "number" && opts.cacheMissTokens > 0) {
+      this._carryoverCacheMiss = opts.cacheMissTokens;
+    }
+    if (typeof opts.lastPromptTokens === "number" && opts.lastPromptTokens > 0) {
+      this._carryoverLastPromptTokens = opts.lastPromptTokens;
     }
   }
 
@@ -146,8 +165,8 @@ export class SessionStats {
   }
 
   get aggregateCacheHitRatio(): number {
-    let hit = 0;
-    let miss = 0;
+    let hit = this._carryoverCacheHit;
+    let miss = this._carryoverCacheMiss;
     for (const t of this.turns) {
       hit += t.usage.promptCacheHitTokens;
       miss += t.usage.promptCacheMissTokens;
@@ -166,7 +185,7 @@ export class SessionStats {
       claudeEquivalentUsd: round(this.totalClaudeEquivalent, 6),
       savingsVsClaudePct: round(this.savingsVsClaude * 100, 2),
       cacheHitRatio: round(this.aggregateCacheHitRatio, 4),
-      lastPromptTokens: last?.usage.promptTokens ?? 0,
+      lastPromptTokens: last?.usage.promptTokens ?? this._carryoverLastPromptTokens,
       lastTurnCostUsd: round(last?.cost ?? 0, 6),
     };
   }

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -382,4 +382,27 @@ describe("session persistence", () => {
       expect(loop.stats.summary().turns).toBe(0);
     });
   });
+
+  describe("issue #364 — resume seeds cache + lastPromptTokens from session meta", () => {
+    it("CacheFirstLoop on resume preloads cache totals + last prompt tokens", () => {
+      appendSessionMessage("c364", { role: "user", content: "hi" });
+      appendSessionMessage("c364", { role: "assistant", content: "hello" });
+      patchSessionMeta("c364", {
+        cacheHitTokens: 366976,
+        cacheMissTokens: 109,
+        lastPromptTokens: 367085,
+      });
+
+      const client = new DeepSeekClient({ apiKey: "sk-test" });
+      const loop = new CacheFirstLoop({
+        client,
+        prefix: new ImmutablePrefix({ system: "test" }),
+        session: "c364",
+      });
+
+      const summary = loop.stats.summary();
+      expect(summary.cacheHitRatio).toBeCloseTo(366976 / (366976 + 109), 4);
+      expect(summary.lastPromptTokens).toBe(367085);
+    });
+  });
 });

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -190,3 +190,41 @@ describe("SessionStats — issue #333 resume cost carryover", () => {
     expect(s.totalCost).toBe(live);
   });
 });
+
+describe("SessionStats — issue #364 resume cache + context carryover", () => {
+  it("aggregateCacheHitRatio includes carryover so /status isn't 0% on a fresh resume", () => {
+    const s = new SessionStats();
+    s.seedCarryover({ cacheHitTokens: 366976, cacheMissTokens: 109 });
+    // No live turns yet — ratio must come from the carryover alone.
+    expect(s.aggregateCacheHitRatio).toBeCloseTo(366976 / (366976 + 109), 4);
+    expect(s.summary().cacheHitRatio).toBeCloseTo(366976 / (366976 + 109), 4);
+  });
+
+  it("aggregateCacheHitRatio sums carryover + live turns", () => {
+    const s = new SessionStats();
+    s.seedCarryover({ cacheHitTokens: 1000, cacheMissTokens: 0 });
+    s.record(1, "deepseek-chat", new Usage(2000, 100, 0, 0, 2000));
+    // 1000 hit (carryover) + 0 hit (live) over 1000 + 2000 = 1/3.
+    expect(s.aggregateCacheHitRatio).toBeCloseTo(1000 / 3000, 4);
+  });
+
+  it("summary.lastPromptTokens falls back to carryover before any live turn", () => {
+    const s = new SessionStats();
+    s.seedCarryover({ lastPromptTokens: 367085 });
+    expect(s.summary().lastPromptTokens).toBe(367085);
+  });
+
+  it("live turn overrides carryover lastPromptTokens", () => {
+    const s = new SessionStats();
+    s.seedCarryover({ lastPromptTokens: 100 });
+    s.record(1, "deepseek-chat", new Usage(500, 50, 0, 400, 100));
+    expect(s.summary().lastPromptTokens).toBe(500);
+  });
+
+  it("seedCarryover ignores zero / negative cache + context fields", () => {
+    const s = new SessionStats();
+    s.seedCarryover({ cacheHitTokens: 0, cacheMissTokens: -5, lastPromptTokens: 0 });
+    expect(s.aggregateCacheHitRatio).toBe(0);
+    expect(s.summary().lastPromptTokens).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #364.

## Why

`SessionMeta` only carried `totalCostUsd` and `turnCount`. On every resume `/status` showed:

- **0 context** — `summary.lastPromptTokens` came from `turns[0]?.usage`, and `turns` is empty before the first live turn fires.
- **0% cache hit** — `aggregateCacheHitRatio` summed `turns[]` only, so it was undefined / 0 immediately after resume.

The next API call still hit the cached prefix and answered correctly (the user's transcript shows 366,976 / 367,085 cache hits on turn 1), but the status panel claimed "no context" until that call landed.

## What changes

**`src/memory/session.ts`** — extend `SessionMeta`:

```ts
cacheHitTokens?: number;
cacheMissTokens?: number;
lastPromptTokens?: number;
```

**`src/telemetry/stats.ts`** — `seedCarryover` accepts the three new fields. `aggregateCacheHitRatio` now seeds `hit` / `miss` from carryover before summing live turns. `summary().lastPromptTokens` falls back to the carryover when no live turn exists yet.

**`src/loop.ts`** — `seedCarryover` call on resume passes the new fields.

**`src/cli/ui/App.tsx`** — `patchSessionMeta` after `assistant_final` now writes:

```ts
cacheHitTokens: (m.cacheHitTokens ?? 0) + u.promptCacheHitTokens,
cacheMissTokens: (m.cacheMissTokens ?? 0) + u.promptCacheMissTokens,
lastPromptTokens: u.promptTokens, // only when truthy
```

## Tests

- `tests/telemetry.test.ts` — 5 new cases: ratio with carryover-only, ratio with carryover + live, lastPromptTokens fallback + override, seedCarryover ignores zero/negative.
- `tests/session.test.ts` — new case: `CacheFirstLoop` resume preloads cache + lastPromptTokens through the meta → stats path.

## Test plan

- [x] `npm run verify` — 133 files / 2138 passed / 1 skipped (was 2132, +6 new)
- [ ] Manual: chat one turn → exit → resume → `/status` shows the prior context bar and a non-zero cache hit %, not the previous 0/0 state