### PR TITLE
fix(ui): /model + /preset update active model so the next card pill is fresh

### DIFF
--- a/src/cli/ui/slash/handlers/model.ts
+++ b/src/cli/ui/slash/handlers/model.ts
@@ -11,6 +11,7 @@ const model: SlashHandler = (args, loop, ctx) => {
     return { info: t("handlers.model.modelUsage", { hint }) };
   }
   loop.configure({ model: id });
+  ctx.dispatch?.({ type: "session.model.change", model: id });
   if (known && known.length > 0 && !known.includes(id)) {
     return {
       info: t("handlers.model.modelNotInCatalog", { id, list: known.join(", ") }),
@@ -53,7 +54,7 @@ const harvest: SlashHandler = (args, loop) => {
   return { info: t("handlers.model.harvestOff") };
 };
 
-const preset: SlashHandler = (args, loop) => {
+const preset: SlashHandler = (args, loop, ctx) => {
   const name = (args[0] ?? "").toLowerCase();
   const applyAndPersist = (effort: "high" | "max") => {
     try {
@@ -62,8 +63,7 @@ const preset: SlashHandler = (args, loop) => {
       /* disk full / perms — runtime change still took effect */
     }
   };
-  if (name === "auto") {
-    const p = PRESETS.auto;
+  const apply = (p: (typeof PRESETS)[keyof typeof PRESETS]) => {
     loop.configure({
       model: p.model,
       autoEscalate: p.autoEscalate,
@@ -71,31 +71,19 @@ const preset: SlashHandler = (args, loop) => {
       harvest: p.harvest,
       branch: p.branch,
     });
+    ctx.dispatch?.({ type: "session.model.change", model: p.model });
     applyAndPersist(p.reasoningEffort);
+  };
+  if (name === "auto") {
+    apply(PRESETS.auto);
     return { info: t("handlers.model.presetAuto") };
   }
   if (name === "flash") {
-    const p = PRESETS.flash;
-    loop.configure({
-      model: p.model,
-      autoEscalate: p.autoEscalate,
-      reasoningEffort: p.reasoningEffort,
-      harvest: p.harvest,
-      branch: p.branch,
-    });
-    applyAndPersist(p.reasoningEffort);
+    apply(PRESETS.flash);
     return { info: t("handlers.model.presetFlash") };
   }
   if (name === "pro") {
-    const p = PRESETS.pro;
-    loop.configure({
-      model: p.model,
-      autoEscalate: p.autoEscalate,
-      reasoningEffort: p.reasoningEffort,
-      harvest: p.harvest,
-      branch: p.branch,
-    });
-    applyAndPersist(p.reasoningEffort);
+    apply(PRESETS.pro);
     return { info: t("handlers.model.presetPro") };
   }
   return { info: t("handlers.model.presetUsage") };

--- a/src/cli/ui/state/events.ts
+++ b/src/cli/ui/state/events.ts
@@ -122,6 +122,11 @@ const sessionUpdate = z.object({
   }),
 });
 
+const sessionModelChange = z.object({
+  type: z.literal("session.model.change"),
+  model: z.string().min(1),
+});
+
 const focusMove = z.object({
   type: z.literal("focus.move"),
   direction: z.enum(["next", "prev", "first", "last"]),
@@ -318,6 +323,7 @@ export const AgentEventSchema = z.discriminatedUnion("type", [
   networkChange,
   languageChange,
   sessionUpdate,
+  sessionModelChange,
   focusMove,
   focusSet,
   cardToggle,

--- a/src/cli/ui/state/reducer.ts
+++ b/src/cli/ui/state/reducer.ts
@@ -116,6 +116,11 @@ export function reduce(state: AgentState, event: AgentEvent): AgentState {
     case "session.update":
       return { ...state, status: { ...state.status, ...event.patch } };
 
+    case "session.model.change":
+      return state.session.model === event.model
+        ? state
+        : { ...state, session: { ...state.session, model: event.model } };
+
     case "focus.move":
       return {
         ...state,

--- a/tests/ui-reducer.test.ts
+++ b/tests/ui-reducer.test.ts
@@ -53,6 +53,32 @@ describe("ui reducer", () => {
     expect(card.model).toBe("deepseek-chat");
   });
 
+  it("session.model.change updates the active model so the next card snapshots it (#372)", () => {
+    const s = run([
+      { type: "session.model.change", model: "deepseek-v4-pro" },
+      { type: "streaming.start", id: "s1" },
+    ]);
+    const card = s.cards[0] as StreamingCard;
+    expect(card.model).toBe("deepseek-v4-pro");
+    expect(s.session.model).toBe("deepseek-v4-pro");
+  });
+
+  it("session.model.change is a no-op when the model id is unchanged (referential identity preserved)", () => {
+    const before = run([{ type: "user.submit", text: "x" }]);
+    const after = reduce(before, { type: "session.model.change", model: "deepseek-chat" });
+    expect(after).toBe(before);
+  });
+
+  it("session.model.change does not relabel a card that was opened on the prior model", () => {
+    const s = run([
+      { type: "streaming.start", id: "s1" },
+      { type: "streaming.chunk", id: "s1", text: "answer on flash" },
+      { type: "session.model.change", model: "deepseek-v4-pro" },
+    ]);
+    const card = s.cards[0] as StreamingCard;
+    expect(card.model).toBe("deepseek-chat");
+  });
+
   it("streams response chunks into a single streaming card", () => {
     const s = run([
       { type: "streaming.start", id: "s1" },


### PR DESCRIPTION
Closes #372.

## Why

`state.session.model` is set once in `initialState()` and never mutated. `/model <id>`, `/preset {auto,flash,pro}` only route through `loop.configure({ model })` — they never feed the agent store. So the next `streaming.start` / `reasoning.start` / "thinking · X" card snapshots the **launch-time** model id, regardless of which model actually answered the turn.

Repro:
1. Start session on flash (or default).
2. `/model deepseek-v4-pro`.
3. Send a new message.
4. Streaming card pill still reads `flash`.

## What changes

- **`src/cli/ui/state/events.ts`** — new typed event:

  ```ts
  const sessionModelChange = z.object({
    type: z.literal("session.model.change"),
    model: z.string().min(1),
  });
  ```

- **`src/cli/ui/state/reducer.ts`** — handles `session.model.change`. Returns the same state when the id is unchanged so React.memo'd consumers don't re-render needlessly.

- **`src/cli/ui/slash/handlers/model.ts`** — `/model` and `/preset {auto,flash,pro}` dispatch the event after `loop.configure(...)`. `ctx.dispatch` is already plumbed via `agentStore.dispatch` in App.tsx (existing wire — used by other handlers).

Cards already opened keep their captured model — that snapshot at `streaming.start` / `reasoning.start` is intentional so mid-turn auto-escalation doesn't relabel completed reasoning. Fresh cards opened after the switch render the new id.

## Tests

`tests/ui-reducer.test.ts` — 3 new cases:

- `session.model.change` updates `state.session.model` and the next streaming card snapshots it
- no-op (referential identity) when id unchanged
- existing card opened on the prior model is NOT relabeled (preserves the existing snapshot guarantee)

## Test plan

- [x] `npm run verify` — 133 files / 2141 passed / 1 skipped (was 2138, +3 new)
- [ ] Manual: chat `/model deepseek-v4-pro` → send a message → next assistant card pill reads `pro`
- [ ] Manual: `/preset flash` → `/preset pro` → next card pill matches the active preset
- [ ] Manual: pre-existing assistant card from before the switch still shows the model that produced it (no retroactive relabel)