### PR TITLE
fix(input): recognize PowerShell / modifyOtherKeys / Kitty Shift+Tab variants

### DIFF
--- a/src/cli/ui/key-normalize.ts
+++ b/src/cli/ui/key-normalize.ts
@@ -27,7 +27,13 @@ const CSI_TAIL_TO_FLAGS: ReadonlyArray<{ tail: string; flags: CsiKeyFlags }> = [
   // Forward-delete (the key labelled Delete on most keyboards).
   { tail: "[3~", flags: { delete: true } },
   // Shift+Tab — terminal sends `\x1b[Z` rather than tab-with-shift.
+  // `[1;2Z` is the modifier-encoded variant some Windows PowerShell
+  // hosts emit; `[27;2;9~` and `[9;2u` cover modifyOtherKeys / Kitty
+  // forms. Issue #373.
   { tail: "[Z", flags: { shift: true, tab: true } },
+  { tail: "[1;2Z", flags: { shift: true, tab: true } },
+  { tail: "[27;2;9~", flags: { shift: true, tab: true } },
+  { tail: "[9;2u", flags: { shift: true, tab: true } },
 ];
 
 function alreadyStructured(flags: CsiKeyFlags): boolean {

--- a/src/cli/ui/stdin-reader.ts
+++ b/src/cli/ui/stdin-reader.ts
@@ -62,17 +62,23 @@ const CSI_TAIL_MAP: ReadonlyArray<{ tail: string; ev: KeyEvent }> = [
   { tail: "6~", ev: { input: "", pageDown: true } },
   { tail: "3~", ev: { input: "", delete: true } },
   { tail: "Z", ev: { input: "", shift: true, tab: true } },
-  // modifyOtherKeys (xterm CSI > 4 ; 2 m) sequences for Enter with
-  // modifiers. Only fired when App.tsx has enabled the mode at
+  // Some Windows hosts (PowerShell 7.x conhost path) emit the
+  // modifier-encoded back-tab `\x1b[1;2Z` instead of bare `\x1b[Z`.
+  // Issue #373 — without this entry Shift+Tab is silently dropped.
+  { tail: "1;2Z", ev: { input: "", shift: true, tab: true } },
+  // modifyOtherKeys (xterm CSI > 4 ; 2 m) sequences for Enter / Tab
+  // with modifiers. Only fired when App.tsx has enabled the mode at
   // startup; otherwise Shift+Enter stays indistinguishable from Enter.
   // Modifier encoding: 2=shift, 3=alt, 4=alt+shift, 5=ctrl,
-  // 6=ctrl+shift, 7=ctrl+alt, 8=ctrl+alt+shift. Keycode 13 = Enter.
+  // 6=ctrl+shift, 7=ctrl+alt, 8=ctrl+alt+shift. Keycodes: 9=Tab, 13=Enter.
+  { tail: "27;2;9~", ev: { input: "", tab: true, shift: true } },
   { tail: "27;2;13~", ev: { input: "", return: true, shift: true } },
   { tail: "27;5;13~", ev: { input: "", return: true, ctrl: true } },
   { tail: "27;6;13~", ev: { input: "", return: true, ctrl: true, shift: true } },
   // Kitty keyboard protocol — same idea, different envelope:
   // `\x1b[<keycode>;<mod>u`. Some terminals (kitty, recent Windows
   // Terminal previews) prefer this shape. Harmless to map here too.
+  { tail: "9;2u", ev: { input: "", tab: true, shift: true } },
   { tail: "13;2u", ev: { input: "", return: true, shift: true } },
   { tail: "13;5u", ev: { input: "", return: true, ctrl: true } },
   { tail: "13;6u", ev: { input: "", return: true, ctrl: true, shift: true } },

--- a/tests/key-normalize.test.ts
+++ b/tests/key-normalize.test.ts
@@ -27,6 +27,16 @@ describe("recoverCsiTail — ESC-stripped fallbacks (Windows ConPTY)", () => {
   it("recovers Shift+Tab tail", () => {
     expect(recoverCsiTail("[Z")).toEqual({ shift: true, tab: true });
   });
+
+  it("recovers Shift+Tab from PowerShell-style `[1;2Z` (#373)", () => {
+    expect(recoverCsiTail("[1;2Z")).toEqual({ shift: true, tab: true });
+    expect(recoverCsiTail("\x1b[1;2Z")).toEqual({ shift: true, tab: true });
+  });
+
+  it("recovers Shift+Tab from modifyOtherKeys `[27;2;9~` and Kitty `[9;2u` (#373)", () => {
+    expect(recoverCsiTail("[27;2;9~")).toEqual({ shift: true, tab: true });
+    expect(recoverCsiTail("[9;2u")).toEqual({ shift: true, tab: true });
+  });
 });
 
 describe("recoverCsiTail — full CSI sequences (well-behaved terminals)", () => {

--- a/tests/stdin-reader.test.ts
+++ b/tests/stdin-reader.test.ts
@@ -43,6 +43,22 @@ describe("StdinReader — CSI sequences (well-behaved)", () => {
     expect(events).toEqual([{ input: "", shift: true, tab: true }]);
   });
 
+  it("parses Shift+Tab from modifier-encoded `\\x1b[1;2Z` (PowerShell variant, #373)", () => {
+    const { reader, events } = setup();
+    reader.feed("\x1b[1;2Z");
+    expect(events).toEqual([{ input: "", shift: true, tab: true }]);
+  });
+
+  it("parses Shift+Tab from modifyOtherKeys `\\x1b[27;2;9~` and Kitty `\\x1b[9;2u` (#373)", () => {
+    const { reader, events } = setup();
+    reader.feed("\x1b[27;2;9~");
+    reader.feed("\x1b[9;2u");
+    expect(events).toEqual([
+      { input: "", shift: true, tab: true },
+      { input: "", shift: true, tab: true },
+    ]);
+  });
+
   it("parses SS3 arrow forms (`\\x1bO<letter>`)", () => {
     const { reader, events } = setup();
     reader.feed("\x1bOA");


### PR DESCRIPTION
Closes #373.

## Why

Reasonix only recognized the bare xterm back-tab `\x1b[Z`. Windows reporters confirmed Shift+Tab does nothing on PowerShell 7.x — the edit-mode cycle silently drops because the input never matches `key.shift && key.tab`.

Three other Shift+Tab encodings are common in the wild and ALL are emitted by configurations Reasonix already enables:

| Encoding | Source |
|---|---|
| `\x1b[1;2Z` | xterm-style modifier-encoded back-tab — emitted by some PowerShell hosts |
| `\x1b[27;2;9~` | modifyOtherKeys level 2 (we enable via `\x1b[>4;2m` at startup) |
| `\x1b[9;2u` | Kitty keyboard protocol (Ink 7's optional handshake) |

## What changes

- **`src/cli/ui/stdin-reader.ts`** — `CSI_TAIL_MAP` gains `1;2Z`, `27;2;9~`, `9;2u` entries (all → `{ shift: true, tab: true }`).
- **`src/cli/ui/key-normalize.ts`** — `CSI_TAIL_TO_FLAGS` gains the same three forms so the Ink fallback path matches when `useInput` doesn't pre-structure them.

## Tests

- `tests/key-normalize.test.ts` — 2 new cases (PowerShell variant + modifyOtherKeys / Kitty forms).
- `tests/stdin-reader.test.ts` — 2 new cases (matching round-trip through the reader).

## Test plan

- [x] `npm run verify` — 133 files / 2145 passed / 1 skipped (was 2141, +4 new)
- [ ] Manual: PowerShell 7.x on Windows Terminal — Shift+Tab cycles edit modes
- [ ] Manual: PowerShell on conhost (legacy console host) — Shift+Tab cycles edit modes (best-effort; some hosts intercept)

If a terminal emits a form we still don't recognize, `/mode` continues to work as a typed fallback.