### PR TITLE
feat(ui): surface --dir / pinned workspace for first-time users

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,14 @@ npx reasonix code   # paste a DeepSeek API key on first run; persists after
 
 Requires Node ≥ 22. Tested on macOS · Linux · Windows (PowerShell · Git Bash · Windows Terminal). Get a [DeepSeek API key →](https://platform.deepseek.com/api_keys) · `reasonix code --help` for flags.
 
+**Working in a different folder:** Reasonix scopes filesystem tools to the launch directory. To work elsewhere, pass `--dir`:
+
+```bash
+npx reasonix code --dir /path/to/project   # or use a relative path
+```
+
+Mid-session switching isn't supported by design (the message log + memory paths get tangled with stale roots). Quit and relaunch with a new `--dir` to retarget. `/status` always shows the current pinned workspace.
+
 <br/>
 
 ## What makes Reasonix different

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -52,6 +52,14 @@ npx reasonix code   # 首次运行粘贴 DeepSeek API Key，之后会记住
 
 要求 Node ≥ 22。已在 macOS · Linux · Windows（PowerShell · Git Bash · Windows Terminal）测过。[去拿 DeepSeek API Key →](https://platform.deepseek.com/api_keys) · 完整 flag 看 `reasonix code --help`。
 
+**在其他目录工作：** Reasonix 把文件系统工具作用域绑定在启动目录。要在别的目录工作，传 `--dir`：
+
+```bash
+npx reasonix code --dir /path/to/project   # 也可以用相对路径
+```
+
+中途切换工作区是有意不支持的（消息日志和 memory 路径会和旧的根目录混在一起，状态错乱）。退出后用新的 `--dir` 重新启动来切换。`/status` 始终显示当前锁定的工作区。
+
 <br/>
 
 ## Reasonix 的不同之处

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -3103,6 +3103,7 @@ function AppInner({
                 {!hasConversation && !busy && !isStreaming ? (
                   <WelcomeBanner
                     inCodeMode={!!codeMode}
+                    workspaceRoot={codeMode ? currentRootDir : undefined}
                     dashboardUrl={dashboardUrl}
                     languageVersion={languageVersion}
                   />

--- a/src/cli/ui/WelcomeBanner.tsx
+++ b/src/cli/ui/WelcomeBanner.tsx
@@ -9,6 +9,8 @@ import { FG, TONE } from "./theme/tokens.js";
 export interface WelcomeBannerProps {
   /** True when running `reasonix code`. Surfaces code-mode hints. */
   inCodeMode?: boolean;
+  /** Pinned workspace root — only meaningful in code mode. Surfaced so first-time users see they can pass --dir at next launch. */
+  workspaceRoot?: string;
   /** Live URL of the embedded dashboard, or null when it isn't running. */
   dashboardUrl?: string | null;
   /** Bumped on language change; forces re-render so t() picks up new locale. */
@@ -19,6 +21,7 @@ const HINTS = ["/help", "/init", "/memory", "/cost"] as const;
 
 export function WelcomeBanner({
   inCodeMode,
+  workspaceRoot,
   dashboardUrl,
 }: WelcomeBannerProps): React.ReactElement {
   const tagline = inCodeMode ? t("ui.taglineCode") : t("ui.taglineChat");
@@ -65,6 +68,15 @@ export function WelcomeBanner({
           </Text>
         ))}
       </Box>
+
+      {inCodeMode && workspaceRoot ? (
+        <Box marginTop={1} flexDirection="row" gap={1}>
+          <Text color={TONE.brand}>{"▸ workspace"}</Text>
+          <Text color={FG.faint}>{"·"}</Text>
+          <Text color={FG.body}>{workspaceRoot}</Text>
+          <Text color={FG.faint}>{"  (relaunch with --dir <path> to switch)"}</Text>
+        </Box>
+      ) : null}
 
       {dashboardUrl ? (
         <Box marginTop={1} flexDirection="row" gap={1}>

--- a/src/cli/ui/slash/handlers/observability.ts
+++ b/src/cli/ui/slash/handlers/observability.ts
@@ -132,6 +132,9 @@ const status: SlashHandler = (_args, loop, ctx) => {
           : "";
   const dashUrl = ctx.getDashboardUrl?.();
   const dashLine = dashUrl ? t("handlers.observability.statusDash", { url: dashUrl }) : "";
+  const workspaceLine = ctx.codeRoot
+    ? t("handlers.observability.statusWorkspace", { path: ctx.codeRoot })
+    : "";
   const lines = [
     t("handlers.observability.statusModel", { model: loop.model }),
     t("handlers.observability.statusFlags", {
@@ -145,6 +148,7 @@ const status: SlashHandler = (_args, loop, ctx) => {
     mcpLine,
     sessionLine,
   ];
+  if (workspaceLine) lines.push(workspaceLine);
   if (budgetLine) lines.push(budgetLine);
   if (pendingLine) lines.push(pendingLine);
   if (planLine) lines.push(planLine);

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -710,6 +710,8 @@ export const EN: TranslationSchema = {
       statusBudget: "  budget  ${spent} / ${cap} ({pct}%){tag}",
       statusSession: '  session "{name}" · {count} messages in log (resumed {resumed})',
       statusSessionEphemeral: "  session (ephemeral — no persistence)",
+      statusWorkspace:
+        "  workspace {path} · pinned at launch (relaunch with --dir <path> to switch)",
       statusMcp: "  mcp     {servers} server(s), {tools} tool(s) in registry",
       statusEdits: "  edits   {count} pending (/apply to commit, /discard to drop)",
       statusPlan: "  plan    ON — writes gated (submit_plan + approval)",

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -653,6 +653,7 @@ export const zhCN: TranslationSchema = {
       statusBudget: "  预算    ${spent} / ${cap}（{pct}%）{tag}",
       statusSession: '  会话    "{name}" · 日志中 {count} 条消息（恢复了 {resumed} 条）',
       statusSessionEphemeral: "  会话    （临时 — 无持久化）",
+      statusWorkspace: "  工作区  {path} · 启动时锁定（用 --dir <path> 重新启动以切换）",
       statusMcp: "  MCP     {servers} 个服务器，注册表中 {tools} 个工具",
       statusEdits: "  编辑    {count} 个待处理（/apply 提交，/discard 丢弃）",
       statusPlan: "  计划    开启 — 写入受限（submit_plan + 审批）",

--- a/src/tools/filesystem.ts
+++ b/src/tools/filesystem.ts
@@ -95,7 +95,9 @@ export function registerFilesystemTools(
     // Use relative() to catch any `..` segments that escape.
     const rel = pathMod.relative(normRoot, resolved);
     if (rel.startsWith("..") || pathMod.isAbsolute(rel)) {
-      throw new Error(`path escapes sandbox root (${normRoot}): ${raw}`);
+      throw new Error(
+        `path escapes sandbox root (${normRoot}): ${raw} — workspace is pinned at launch; quit and relaunch with \`reasonix code --dir <path>\` to work in a different folder`,
+      );
     }
     return resolved;
   };


### PR DESCRIPTION
Closes #370.

## Why

Beginners hit the default cwd-scoped behavior and conclude Reasonix can't read folders other than where they launched it. `reasonix code --dir <path>` exists today and works fine — it's just invisible until you `--help`. (The issue body suggested `/cwd` exists; it doesn't, and the agent's system prompt explicitly says mid-session retargeting was removed because the message log + memory paths get tangled with a stale root.)

So this is purely an onboarding fix — no new capability, no `/cwd` slash.

## Surfaces added

1. **WelcomeBanner** — shows a workspace line in code mode on the empty state:
   ```
   ▸ workspace · /path/to/repo  (relaunch with --dir <path> to switch)
   ```

2. **`/status`** — adds a workspace line:
   ```
   workspace /path/to/repo · pinned at launch (relaunch with --dir <path> to switch)
   ```

3. **Filesystem sandbox-escape error** — was a raw `path escapes sandbox root (X): Y`; now points the user at the right fix:
   > path escapes sandbox root (X): Y — workspace is pinned at launch; quit and relaunch with `reasonix code --dir <path>` to work in a different folder

4. **README + README.zh-CN** — Getting Started subsection explaining `--dir` and why mid-session switching isn't a thing.

## Tests

No new test file — all four surfaces are static text additions. Existing tests cover the unchanged code paths:
- `tests/filesystem-tools.test.ts` — still asserts `/escapes sandbox/` (matches the new message prefix).
- `tests/slash.test.ts` — unaffected (workspace line only appears in `/status` when `ctx.codeRoot` is set).

## Test plan

- [x] `npm run verify` — 134 files / 2152 passed / 1 skipped
- [ ] Manual: `reasonix code` empty-state shows the workspace banner line
- [ ] Manual: `/status` shows the workspace line in code mode
- [ ] Manual: ask the model to read a path outside rootDir → tool error mentions `reasonix code --dir`