### PR TITLE
fix(tty): drain pending feature-detection replies on exit

### DIFF
--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -31,6 +31,7 @@ import { registerWebTools } from "../../tools/web.js";
 import { App } from "../ui/App.js";
 import { SessionPicker } from "../ui/SessionPicker.js";
 import { Setup } from "../ui/Setup.js";
+import { drainTtyResponses } from "../ui/drain-tty.js";
 import { KeystrokeProvider } from "../ui/keystroke-context.js";
 import { formatMcpLifecycleEvent } from "../ui/mcp-lifecycle.js";
 import { formatMcpSlowToast } from "../ui/mcp-toast.js";
@@ -520,5 +521,8 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
     await waitUntilExit();
   } finally {
     await runtime.closeAll();
+    // Eat any pending terminal-feature-detection responses (#365) so the
+    // parent shell doesn't print them as junk after exit.
+    await drainTtyResponses();
   }
 }

--- a/src/cli/ui/drain-tty.ts
+++ b/src/cli/ui/drain-tty.ts
@@ -1,0 +1,39 @@
+/** stdin-queue drain on exit — eats stuck terminal-feature-detection responses (#365). */
+
+import process from "node:process";
+
+/** Eats stuck OSC/CPR/DA replies on exit so fish/bash don't print them as input (#365). */
+export async function drainTtyResponses(timeoutMs = 50): Promise<void> {
+  const stdin = process.stdin;
+  if (!stdin.isTTY && typeof (stdin as { setRawMode?: unknown }).setRawMode !== "function") {
+    return;
+  }
+  let raised = false;
+  try {
+    stdin.setRawMode(true);
+    raised = true;
+  } catch {
+    return;
+  }
+  stdin.resume();
+
+  await new Promise<void>((resolve) => {
+    const onData = (_chunk: Buffer | string): void => {
+      // Discard — anything pending here is a terminal-feature reply.
+    };
+    stdin.on("data", onData);
+    const timer = setTimeout(() => {
+      stdin.off("data", onData);
+      stdin.pause();
+      if (raised) {
+        try {
+          stdin.setRawMode(false);
+        } catch {
+          /* stdin may already be closed; ignore */
+        }
+      }
+      resolve();
+    }, timeoutMs);
+    timer.unref();
+  });
+}

--- a/tests/drain-tty.test.ts
+++ b/tests/drain-tty.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { drainTtyResponses } from "../src/cli/ui/drain-tty.js";
+
+describe("drainTtyResponses (#365)", () => {
+  it("returns immediately on non-TTY stdin without throwing", async () => {
+    const start = Date.now();
+    await drainTtyResponses(50);
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeLessThan(40);
+  });
+
+  it("respects the timeout when raw mode IS available (caps total wait)", async () => {
+    const fakeStdin = makeFakeRawStdin();
+    const orig = process.stdin;
+    Object.defineProperty(process, "stdin", { value: fakeStdin, configurable: true });
+    try {
+      const start = Date.now();
+      await drainTtyResponses(30);
+      const elapsed = Date.now() - start;
+      expect(elapsed).toBeGreaterThanOrEqual(25);
+      expect(elapsed).toBeLessThan(150);
+      expect(fakeStdin.rawModeOn).toBe(false);
+    } finally {
+      Object.defineProperty(process, "stdin", { value: orig, configurable: true });
+    }
+  });
+
+  it("discards bytes the terminal pushed during the drain window", async () => {
+    const fakeStdin = makeFakeRawStdin();
+    const orig = process.stdin;
+    Object.defineProperty(process, "stdin", { value: fakeStdin, configurable: true });
+    try {
+      const drainPromise = drainTtyResponses(40);
+      setTimeout(() => fakeStdin.push(Buffer.from("\x1b]11;rgb:1111/2222/3333\x1b\\")), 5);
+      setTimeout(() => fakeStdin.push(Buffer.from("\x1b[33;1R\x1b[?62;1;4c")), 15);
+      await drainPromise;
+      // No assertion on what was discarded — the drain just has to not blow up
+      // when a terminal-response burst arrives mid-window.
+      expect(fakeStdin.rawModeOn).toBe(false);
+    } finally {
+      Object.defineProperty(process, "stdin", { value: orig, configurable: true });
+    }
+  });
+});
+
+function makeFakeRawStdin(): {
+  isTTY: true;
+  rawModeOn: boolean;
+  setRawMode: (on: boolean) => void;
+  resume: () => void;
+  pause: () => void;
+  on: (ev: string, fn: (chunk: Buffer | string) => void) => void;
+  off: (ev: string, fn: (chunk: Buffer | string) => void) => void;
+  push: (chunk: Buffer) => void;
+} {
+  const listeners: Array<(c: Buffer | string) => void> = [];
+  return {
+    isTTY: true,
+    rawModeOn: false,
+    setRawMode(on: boolean): void {
+      this.rawModeOn = on;
+    },
+    resume(): void {},
+    pause(): void {},
+    on(ev: string, fn: (c: Buffer | string) => void): void {
+      if (ev === "data") listeners.push(fn);
+    },
+    off(ev: string, fn: (c: Buffer | string) => void): void {
+      if (ev === "data") {
+        const i = listeners.indexOf(fn);
+        if (i >= 0) listeners.splice(i, 1);
+      }
+    },
+    push(chunk: Buffer): void {
+      for (const fn of [...listeners]) fn(chunk);
+    },
+  };
+}


### PR DESCRIPTION
Closes #365.

## Why

Reporter saw `^[]11;rgb:...^[\^[[33;1R^[[?62;1;4c` printed by fish / bash right after `exit`. Those bytes are **responses**, not queries:

- `\x1b]11;rgb:...\x1b\` — OSC 11 reply (terminal background color)
- `\x1b[33;1R` — CPR reply (cursor position)
- `\x1b[?62;1;4c` — DA1 reply (primary device attributes)

So *something* sent the matching queries (`\x1b]11;?\x1b\`, `\x1b[6n`, `\x1b[c`) into the tty during the session. I scanned the v0.30.2 dist bundle for the raw query bytes — zero hits. The source is the runtime (bun does some tty feature detection on startup) or a transitive dep doing color-scheme detection. Either way, the responses sat in stdin's queue until reasonix exited; the parent shell then read them and rendered the bytes as if the user typed them.

## What changes

- **`src/cli/ui/drain-tty.ts`** — new `drainTtyResponses(timeoutMs = 50)` helper. Sets raw mode, reads-and-discards anything pending for `timeoutMs`, restores cooked. No-op when stdin isn't a TTY or raw mode isn't available.

- **`src/cli/commands/chat.tsx`** — `await drainTtyResponses()` in the exit finally block, after `runtime.closeAll()`.

Two-layer mitigation:
- **Upstream** (already in 0.30.3): alt-screen default wraps the session in `\x1b[?1049h` / `\x1b[?1049l`, which flushes the input queue on most terminals.
- **Program-side** (this PR): drain regardless of which terminal the user is in, so we don't depend on any specific terminal's DECSET 1049 behavior.

The drain runs even with `--no-alt-screen`, so legacy in-shell scrollback users get the fix too.

## Tests

`tests/drain-tty.test.ts` — 3 cases: returns immediately on non-TTY stdin; respects the timeout cap when raw mode is available; doesn't blow up when a terminal-response burst arrives mid-window.

## Test plan

- [x] `npm run verify` — 135 files / 2155 passed / 1 skipped (was 2152, +3 new)
- [ ] Manual on Arch + fish (the original reproducer environment): `bunx reasonix@<this PR> code` → exit → no escape junk in fish prompt
- [ ] Manual: `--no-alt-screen` mode → still gets the drain → no junk
- [ ] Manual: starting reasonix from a piped / non-TTY stdin (CI smoke) — drain no-ops cleanly