### PR TITLE
fix(ui): refresh model badge on dashboard preset change and /pro turns (#403)

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -1630,6 +1630,7 @@ function AppInner({
             autoEscalate: settings.autoEscalate,
             reasoningEffort: settings.reasoningEffort,
           });
+          agentStore.dispatch({ type: "session.model.change", model: settings.model });
           const canonical: "auto" | "flash" | "pro" =
             settings.model === "deepseek-v4-pro" ? "pro" : settings.autoEscalate ? "auto" : "flash";
           setPreset(canonical);
@@ -2262,7 +2263,7 @@ function AppInner({
 
       const flush = () => {
         if (!contentBuf.current && !reasoningBuf.current && !toolCallBuildBuf.current) return;
-        translator.flushBuffers(reasoningBuf.current, contentBuf.current);
+        translator.flushBuffers(reasoningBuf.current, contentBuf.current, loop.currentCallModel);
         streamRef.text += contentBuf.current;
         streamRef.reasoning += reasoningBuf.current;
         if (toolCallBuildBuf.current) {

--- a/src/cli/ui/hooks/useScrollback.ts
+++ b/src/cli/ui/hooks/useScrollback.ts
@@ -72,11 +72,11 @@ export interface Scrollback {
   ): void;
   endBranch(id: string, aborted?: boolean): void;
 
-  startReasoning(): string;
+  startReasoning(model?: string): string;
   appendReasoning(id: string, chunk: string): void;
   endReasoning(id: string, paragraphs: number, tokens: number, aborted?: boolean): void;
 
-  startStreaming(): string;
+  startStreaming(model?: string): string;
   appendStreaming(id: string, chunk: string): void;
   endStreaming(id: string, aborted?: boolean): void;
 
@@ -249,9 +249,9 @@ export function useScrollback(): Scrollback {
       endBranch(id, aborted) {
         dispatch({ type: "branch.end", id, aborted });
       },
-      startReasoning() {
+      startReasoning(model) {
         const id = nextId("r");
-        dispatch({ type: "reasoning.start", id });
+        dispatch({ type: "reasoning.start", id, ...(model ? { model } : {}) });
         return id;
       },
       appendReasoning(id, chunk) {
@@ -260,9 +260,9 @@ export function useScrollback(): Scrollback {
       endReasoning(id, paragraphs, tokens, aborted) {
         dispatch({ type: "reasoning.end", id, paragraphs, tokens, aborted });
       },
-      startStreaming() {
+      startStreaming(model) {
         const id = nextId("s");
-        dispatch({ type: "streaming.start", id });
+        dispatch({ type: "streaming.start", id, ...(model ? { model } : {}) });
         return id;
       },
       appendStreaming(id, chunk) {

--- a/src/cli/ui/state/TurnTranslator.ts
+++ b/src/cli/ui/state/TurnTranslator.ts
@@ -9,13 +9,13 @@ export class TurnTranslator {
 
   constructor(private readonly log: Scrollback) {}
 
-  flushBuffers(reasoningChunk: string, contentChunk: string): void {
+  flushBuffers(reasoningChunk: string, contentChunk: string, model?: string): void {
     if (reasoningChunk) {
-      if (!this.reasoningCardId) this.reasoningCardId = this.log.startReasoning();
+      if (!this.reasoningCardId) this.reasoningCardId = this.log.startReasoning(model);
       this.log.appendReasoning(this.reasoningCardId, reasoningChunk);
     }
     if (contentChunk) {
-      if (!this.streamingCardId) this.streamingCardId = this.log.startStreaming();
+      if (!this.streamingCardId) this.streamingCardId = this.log.startStreaming(model);
       this.log.appendStreaming(this.streamingCardId, contentChunk);
     }
   }

--- a/src/cli/ui/state/events.ts
+++ b/src/cli/ui/state/events.ts
@@ -20,6 +20,7 @@ const turnThinking = z.object({
 const reasoningStart = z.object({
   type: z.literal("reasoning.start"),
   id: cardId,
+  model: z.string().min(1).optional(),
 });
 
 const reasoningChunk = z.object({
@@ -39,6 +40,7 @@ const reasoningEnd = z.object({
 const streamingStart = z.object({
   type: z.literal("streaming.start"),
   id: cardId,
+  model: z.string().min(1).optional(),
 });
 
 const streamingChunk = z.object({

--- a/src/cli/ui/state/reducer.ts
+++ b/src/cli/ui/state/reducer.ts
@@ -25,7 +25,7 @@ export function reduce(state: AgentState, event: AgentEvent): AgentState {
       );
 
     case "reasoning.start":
-      return appendCard(state, makeReasoningCard(event.id, state.session.model));
+      return appendCard(state, makeReasoningCard(event.id, event.model ?? state.session.model));
 
     case "reasoning.chunk":
       return mutateCard(state, event.id, "reasoning", (c) => ({ ...c, text: c.text + event.text }));
@@ -41,7 +41,7 @@ export function reduce(state: AgentState, event: AgentEvent): AgentState {
       }));
 
     case "streaming.start":
-      return appendCard(state, makeStreamingCard(event.id, state.session.model));
+      return appendCard(state, makeStreamingCard(event.id, event.model ?? state.session.model));
 
     case "streaming.chunk":
       return mutateCard(state, event.id, "streaming", (c) => ({ ...c, text: c.text + event.text }));

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -397,6 +397,11 @@ export class CacheFirstLoop {
     return this._escalateThisTurn;
   }
 
+  /** UI surface — model id of the call about to run (or running) right now, including escalation. */
+  get currentCallModel(): string {
+    return this.modelForCurrentCall();
+  }
+
   private modelForCurrentCall(): string {
     return this._escalateThisTurn ? ESCALATION_MODEL : this.model;
   }

--- a/tests/turn-translator.test.ts
+++ b/tests/turn-translator.test.ts
@@ -82,6 +82,16 @@ describe("TurnTranslator", () => {
     ]);
   });
 
+  it("forwards an explicit model id into start{Reasoning,Streaming} so /pro turns get the right badge (#403)", () => {
+    const { log, calls } = makeMockLog();
+    const t = new TurnTranslator(log);
+    t.flushBuffers("first reasoning", "first stream", "deepseek-v4-pro");
+    const startReasoning = calls.find((c) => c.method === "startReasoning");
+    const startStreaming = calls.find((c) => c.method === "startStreaming");
+    expect(startReasoning?.args[0]).toBe("deepseek-v4-pro");
+    expect(startStreaming?.args[0]).toBe("deepseek-v4-pro");
+  });
+
   it("toolStart + toolEnd pair sends startTool then endTool with elapsedMs", () => {
     const { log, calls } = makeMockLog();
     const t = new TurnTranslator(log);

--- a/tests/ui-reducer.test.ts
+++ b/tests/ui-reducer.test.ts
@@ -53,6 +53,20 @@ describe("ui reducer", () => {
     expect(card.model).toBe("deepseek-chat");
   });
 
+  it("reasoning.start carrying an explicit model overrides the session snapshot (#403 /pro armed turn)", () => {
+    const s = run([{ type: "reasoning.start", id: "r1", model: "deepseek-v4-pro" }]);
+    const card = s.cards[0] as ReasoningCard;
+    expect(card.model).toBe("deepseek-v4-pro");
+    expect(s.session.model).toBe("deepseek-chat");
+  });
+
+  it("streaming.start carrying an explicit model overrides the session snapshot (#403 /pro armed turn)", () => {
+    const s = run([{ type: "streaming.start", id: "s1", model: "deepseek-v4-pro" }]);
+    const card = s.cards[0] as StreamingCard;
+    expect(card.model).toBe("deepseek-v4-pro");
+    expect(s.session.model).toBe("deepseek-chat");
+  });
+
   it("session.model.change updates the active model so the next card snapshots it (#372)", () => {
     const s = run([
       { type: "session.model.change", model: "deepseek-v4-pro" },


### PR DESCRIPTION
## Summary

Fixes #403. The model badge on reasoning/streaming cards went stale in two paths:

- **Dashboard preset change.** `applyPresetLive` reconfigured the loop but never dispatched `session.model.change`, so cards opened after the dashboard switch still carried the old model snapshot.
- **`/pro` armed turn.** The single-turn escalation flipped `loop.modelForCurrentCall()` to v4-pro, but `state.session.model` (which the reducer snapshots into the card) stayed on the base model — so the badge showed flash even though the call ran on pro.

## Fix

- `applyPresetLive` now dispatches `session.model.change` after `loop.configure(...)`, mirroring what the `/preset` slash handler already did.
- `reasoning.start` / `streaming.start` events accept an optional `model` field. The loop's new `currentCallModel` getter feeds it through `TurnTranslator.flushBuffers` so the badge tracks whichever model actually produced the output, even mid-turn under auto-escalation. Falls back to `state.session.model` when no override is supplied — older replay logs and tests keep working unchanged.

## Test plan

- [x] `npm run verify` (135 files, 2169 tests)
- [x] New reducer tests assert the explicit `model` override on `reasoning.start` / `streaming.start` doesn't bleed back into `state.session.model`.
- [x] New `TurnTranslator` test asserts the model id forwards into `start{Reasoning,Streaming}`.