### PR TITLE
fix(permissions): match Windows project keys case-insensitively (#402)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -115,12 +115,27 @@ export function saveApiKey(key: string, path: string = defaultConfigPath()): voi
   writeConfig(cfg, path);
 }
 
+/** Windows: case-insensitive — NTFS treats `F:\Foo` and `f:\foo` as one directory (#402). */
+function findProjectKey(cfg: ReasonixConfig, rootDir: string): string | undefined {
+  const projects = cfg.projects;
+  if (!projects) return undefined;
+  if (Object.hasOwn(projects, rootDir)) return rootDir;
+  if (process.platform !== "win32") return undefined;
+  const lower = rootDir.toLowerCase();
+  for (const k of Object.keys(projects)) {
+    if (k.toLowerCase() === lower) return k;
+  }
+  return undefined;
+}
+
 export function loadProjectShellAllowed(
   rootDir: string,
   path: string = defaultConfigPath(),
 ): string[] {
   const cfg = readConfig(path);
-  return cfg.projects?.[rootDir]?.shellAllowed ?? [];
+  const key = findProjectKey(cfg, rootDir);
+  if (key === undefined) return [];
+  return cfg.projects?.[key]?.shellAllowed ?? [];
 }
 
 export function addProjectShellAllowed(
@@ -132,10 +147,11 @@ export function addProjectShellAllowed(
   if (!trimmed) return;
   const cfg = readConfig(path);
   if (!cfg.projects) cfg.projects = {};
-  if (!cfg.projects[rootDir]) cfg.projects[rootDir] = {};
-  const existing = cfg.projects[rootDir].shellAllowed ?? [];
+  const key = findProjectKey(cfg, rootDir) ?? rootDir;
+  if (!cfg.projects[key]) cfg.projects[key] = {};
+  const existing = cfg.projects[key].shellAllowed ?? [];
   if (existing.includes(trimmed)) return;
-  cfg.projects[rootDir].shellAllowed = [...existing, trimmed];
+  cfg.projects[key].shellAllowed = [...existing, trimmed];
   writeConfig(cfg, path);
 }
 
@@ -148,12 +164,14 @@ export function removeProjectShellAllowed(
   const trimmed = prefix.trim();
   if (!trimmed) return false;
   const cfg = readConfig(path);
-  const existing = cfg.projects?.[rootDir]?.shellAllowed ?? [];
+  const key = findProjectKey(cfg, rootDir);
+  if (key === undefined) return false;
+  const existing = cfg.projects?.[key]?.shellAllowed ?? [];
   if (!existing.includes(trimmed)) return false;
   const next = existing.filter((p) => p !== trimmed);
   if (!cfg.projects) cfg.projects = {};
-  if (!cfg.projects[rootDir]) cfg.projects[rootDir] = {};
-  cfg.projects[rootDir].shellAllowed = next;
+  if (!cfg.projects[key]) cfg.projects[key] = {};
+  cfg.projects[key].shellAllowed = next;
   writeConfig(cfg, path);
   return true;
 }
@@ -163,11 +181,13 @@ export function clearProjectShellAllowed(
   path: string = defaultConfigPath(),
 ): number {
   const cfg = readConfig(path);
-  const existing = cfg.projects?.[rootDir]?.shellAllowed ?? [];
+  const key = findProjectKey(cfg, rootDir);
+  if (key === undefined) return 0;
+  const existing = cfg.projects?.[key]?.shellAllowed ?? [];
   if (existing.length === 0) return 0;
   if (!cfg.projects) cfg.projects = {};
-  if (!cfg.projects[rootDir]) cfg.projects[rootDir] = {};
-  cfg.projects[rootDir].shellAllowed = [];
+  if (!cfg.projects[key]) cfg.projects[key] = {};
+  cfg.projects[key].shellAllowed = [];
   writeConfig(cfg, path);
   return existing.length;
 }

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -215,6 +215,32 @@ describe("config", () => {
     expect(clearProjectShellAllowed("/empty", path)).toBe(0);
   });
 
+  it.runIf(process.platform === "win32")(
+    "matches project keys case-insensitively on Windows so cross-shell rootDir casing doesn't lose entries (#402)",
+    () => {
+      addProjectShellAllowed("F:\\Reasonix", "gh", path);
+      expect(loadProjectShellAllowed("f:\\reasonix", path)).toContain("gh");
+      expect(loadProjectShellAllowed("F:\\REASONIX", path)).toContain("gh");
+      // Mutations through any-cased rootDir consolidate onto the original key.
+      addProjectShellAllowed("f:\\reasonix", "deploy", path);
+      expect(loadProjectShellAllowed("F:\\Reasonix", path)).toEqual(["gh", "deploy"]);
+      expect(Object.keys(readConfig(path).projects ?? {})).toEqual(["F:\\Reasonix"]);
+      expect(removeProjectShellAllowed("f:\\REASONIX", "gh", path)).toBe(true);
+      expect(loadProjectShellAllowed("F:\\Reasonix", path)).toEqual(["deploy"]);
+      expect(clearProjectShellAllowed("F:\\REASONIX", path)).toBe(1);
+      expect(loadProjectShellAllowed("F:\\Reasonix", path)).toEqual([]);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "keeps project key matching case-sensitive on non-Windows platforms",
+    () => {
+      addProjectShellAllowed("/home/foo/repo", "gh", path);
+      expect(loadProjectShellAllowed("/home/foo/repo", path)).toContain("gh");
+      expect(loadProjectShellAllowed("/home/FOO/repo", path)).toEqual([]);
+    },
+  );
+
   it("loadEditMode defaults to 'review' when unset", () => {
     expect(loadEditMode(path)).toBe("review");
   });


### PR DESCRIPTION
## Summary

Fixes #402. After clicking "always allow" on a `run_command` confirmation, the next invocation of the same command was still prompting on Windows.

`projects[]` in `~/.reasonix/config.json` is keyed by the absolute `rootDir`. On Windows, NTFS is case-preserving but case-insensitive — `F:\Reasonix` and `f:\reasonix` point at the same directory, but `path.resolve()` does not normalize case, so a session whose `process.cwd()` returns one casing writes the entry, and a later session whose `process.cwd()` returns the other casing (PowerShell vs MINGW/bash, or even relaunching from a different cwd-aware shell) gets `[]` from `cfg.projects?.[rootDir]?.shellAllowed` and re-prompts.

## Fix

Introduce `findProjectKey(cfg, rootDir)` — exact match first, then a case-insensitive scan on `win32` only. Wire it into `loadProjectShellAllowed`, `addProjectShellAllowed`, `removeProjectShellAllowed`, `clearProjectShellAllowed` so any-cased `rootDir` reuses (and mutates) the existing key instead of forking a duplicate entry. Linux/macOS path matching stays case-sensitive — Linux paths really are.

## Test plan

- [x] `npm run verify` — 135 files, 2167 passed
- [x] New `tests/config.test.ts` covers Windows case-insensitive lookups across all four mutators (`it.runIf(process.platform === "win32")`) plus a non-Windows assertion that case-sensitivity is preserved.