### PR TITLE
fix(prompt): inline short single-line pastes verbatim (#397)

### DIFF
--- a/src/cli/ui/PromptInput.tsx
+++ b/src/cli/ui/PromptInput.tsx
@@ -19,6 +19,13 @@ import { FG, SURFACE, TONE } from "./theme/tokens.js";
 
 /** Raw-stdin keystroke bus → multiline reducer; one logical line per Box row, viewport-clipped. */
 
+/** Pastes shorter than this AND single-line render verbatim; longer ones become a `[paste #N · …]` sentinel chip (#397). */
+export const INLINE_PASTE_THRESHOLD = 200;
+
+export function shouldInlinePaste(content: string): boolean {
+  return !content.includes("\n") && content.length <= INLINE_PASTE_THRESHOLD;
+}
+
 export interface PromptInputProps {
   value: string;
   onChange: (v: string) => void;
@@ -74,15 +81,19 @@ export function PromptInput({
   const registerPaste = (content: string) => {
     const v = lastLocalValueRef.current;
     const c = cursorRef.current;
-    const id = nextPasteIdRef.current % PASTE_SENTINEL_RANGE;
-    nextPasteIdRef.current = id + 1;
-    pastesRef.current.set(id, makePasteEntry(id, content));
-    const sentinel = encodePasteSentinel(id);
-    const next = v.slice(0, c) + sentinel + v.slice(c);
+    const insertion = shouldInlinePaste(content)
+      ? content
+      : (() => {
+          const id = nextPasteIdRef.current % PASTE_SENTINEL_RANGE;
+          nextPasteIdRef.current = id + 1;
+          pastesRef.current.set(id, makePasteEntry(id, content));
+          return encodePasteSentinel(id);
+        })();
+    const next = v.slice(0, c) + insertion + v.slice(c);
     lastLocalValueRef.current = next;
-    cursorRef.current = c + 1;
+    cursorRef.current = c + insertion.length;
     onChange(next);
-    setCursor(c + 1);
+    setCursor(c + insertion.length);
   };
 
   useKeystroke((ev) => {

--- a/tests/paste-collapse.test.ts
+++ b/tests/paste-collapse.test.ts
@@ -1,10 +1,35 @@
 import { describe, expect, it } from "vitest";
+import { INLINE_PASTE_THRESHOLD, shouldInlinePaste } from "../src/cli/ui/PromptInput.js";
 import {
   DEFAULT_PASTE_CHAR_THRESHOLD,
   DEFAULT_PASTE_HEAD_LINES,
   DEFAULT_PASTE_LINE_THRESHOLD,
   formatLongPaste,
 } from "../src/cli/ui/paste-collapse.js";
+
+describe("shouldInlinePaste — short single-line pastes render verbatim (#397)", () => {
+  it("a single word inlines", () => {
+    expect(shouldInlinePaste("hello")).toBe(true);
+  });
+
+  it("a number inlines", () => {
+    expect(shouldInlinePaste("42")).toBe(true);
+  });
+
+  it("a sentence-length string still inlines", () => {
+    expect(shouldInlinePaste("the quick brown fox jumps over the lazy dog")).toBe(true);
+  });
+
+  it("anything containing a newline becomes a sentinel chip", () => {
+    expect(shouldInlinePaste("line1\nline2")).toBe(false);
+    expect(shouldInlinePaste("hi\n")).toBe(false);
+  });
+
+  it("a single-line paste past the threshold becomes a sentinel chip", () => {
+    expect(shouldInlinePaste("x".repeat(INLINE_PASTE_THRESHOLD))).toBe(true);
+    expect(shouldInlinePaste("x".repeat(INLINE_PASTE_THRESHOLD + 1))).toBe(false);
+  });
+});
 
 describe("formatLongPaste", () => {
   it("passes through short input verbatim", () => {


### PR DESCRIPTION
## Summary

Fixes #397. Bracketed-paste content was always converted to a `[paste #N · …]` sentinel chip — even pasting a single word or a number left a chip in the buffer. The composer is hostile to the common one-shot case of copying an identifier or URL out of another window and dropping it mid-sentence.

## Fix

In `PromptInput.registerPaste`, route content through `shouldInlinePaste(content)`:

- No newline **and** length ≤ `INLINE_PASTE_THRESHOLD` (200) → insert verbatim text at the cursor.
- Anything longer or containing a newline → keep the existing sentinel-chip path.

Display-only — the model still receives the full paste text via `expandPasteSentinels` (sentinel pastes) or directly (inline pastes).

## Test plan

- [x] `npm run verify` — 135 files, 2171 passed
- [x] New `tests/paste-collapse.test.ts` block covers the boundary: word/number/sentence stay inline, anything multi-line or past 200 chars routes to a sentinel chip.