### PR TITLE
docs(readme): canonical install + subcommand cheatsheet (#408)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,20 @@ npx reasonix code   # paste a DeepSeek API key on first run; persists after
 
 Requires Node ≥ 22. Tested on macOS · Linux · Windows (PowerShell · Git Bash · Windows Terminal). Get a [DeepSeek API key →](https://platform.deepseek.com/api_keys) · `reasonix code --help` for flags.
 
+`npx` is the recommended path — no global install, always picks up the latest version. If you'll use Reasonix daily and want `reasonix` on your `PATH`, run `reasonix update` once and it'll do the `npm install -g` for you.
+
+### Subcommand cheatsheet
+
+| Command | When to use |
+|---|---|
+| `reasonix code [dir]` | Coding agent rooted at a project. **Start here.** |
+| `reasonix chat` | Plain chat — no filesystem tools, just a conversation with persisted history. |
+| `reasonix run "task"` | One-shot, streams the answer to stdout. Good for shell pipes. |
+| `reasonix doctor` | Environment health check (Node version, API key, MCP wiring). |
+| `reasonix update` | Upgrade Reasonix itself. |
+
+Other subcommands (`replay` · `diff` · `events` · `stats` · `index` · `mcp` · `prune-sessions`) are listed in `reasonix --help` and on the [CLI reference](https://esengine.github.io/DeepSeek-Reasonix/#cli).
+
 **Working in a different folder:** Reasonix scopes filesystem tools to the launch directory. To work elsewhere, pass `--dir`:
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -52,6 +52,20 @@ npx reasonix code   # 首次运行粘贴 DeepSeek API Key，之后会记住
 
 要求 Node ≥ 22。已在 macOS · Linux · Windows（PowerShell · Git Bash · Windows Terminal）测过。[去拿 DeepSeek API Key →](https://platform.deepseek.com/api_keys) · 完整 flag 看 `reasonix code --help`。
 
+`npx` 是推荐路径 —— 不用全局安装，每次都拿到最新版本。如果你天天用、想把 `reasonix` 装到 `PATH` 上，跑一次 `reasonix update` 就行，它会替你跑 `npm install -g`。
+
+### 子命令速查
+
+| 命令 | 适用场景 |
+|---|---|
+| `reasonix code [dir]` | 锁在某个项目根目录的编码 agent。**先用这个。** |
+| `reasonix chat` | 纯聊天 —— 不挂文件系统工具，只是带历史的对话。 |
+| `reasonix run "task"` | 一次性，把答案直接流到 stdout。适合 shell 管道。 |
+| `reasonix doctor` | 环境体检（Node 版本、API Key、MCP 接线）。 |
+| `reasonix update` | 升级 Reasonix 本身。 |
+
+其他子命令（`replay` · `diff` · `events` · `stats` · `index` · `mcp` · `prune-sessions`）见 `reasonix --help` 和 [CLI 参考](https://esengine.github.io/DeepSeek-Reasonix/#cli)。
+
 **在其他目录工作：** Reasonix 把文件系统工具作用域绑定在启动目录。要在别的目录工作，传 `--dir`：
 
 ```bash

--- a/docs/index.html
+++ b/docs/index.html
@@ -403,7 +403,7 @@ npx reasonix diff \
         </div>
       </section>
 
-      <section class="cli">
+      <section id="cli" class="cli">
         <div class="container">
           <h2 class="section-title" data-i18n="cli.title">CLI at a glance</h2>
           <pre class="code"><code>npx reasonix code [path]                 <span class="hash"># <span data-i18n="cli.code">coding mode scoped to path</span></span>


### PR DESCRIPTION
## Summary

Fixes #408. The first scroll of the README left two questions unanswered: *do I `npx` or `npm install -g`?* and *out of `code` / `chat` / `run` / etc., which subcommand do I actually want?*

## Changes

- README.md + README.zh-CN.md: name `npx` as the recommended path and point users at `reasonix update` for the global install. Add a 5-row subcommand cheatsheet (`code` / `chat` / `run` / doctor` / `update`); defer the long tail to `--help` and the website CLI panel.
- docs/index.html: add `id="cli"` to the CLI section so the README anchor link resolves.

## Test plan

- [x] `npm run verify` — 136 files, 2241 tests pass.
- [x] Visually checked both READMEs render the table correctly.