### PR TITLE
refactor(ui): quiet chat-screen chrome

### DIFF
--- a/src/cli/ui/layout/LiveRows.tsx
+++ b/src/cli/ui/layout/LiveRows.tsx
@@ -1,4 +1,4 @@
-import { Box, Text, useStdout } from "ink";
+import { Box, Text } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React as a runtime value (classic transform)
 import React from "react";
 import type { ApplyResult } from "../../../code/edit-blocks.js";
@@ -80,17 +80,7 @@ export function ModeStatusBar({
 }
 
 function ModeBarFrame({ children }: { children: React.ReactNode }) {
-  const { stdout } = useStdout();
-  const cols = stdout?.columns ?? 80;
-  const ruleWidth = Math.max(20, cols - 2);
-  return (
-    <Box flexDirection="column">
-      <Box paddingX={1}>
-        <Text color={FG.faint}>{"╌".repeat(ruleWidth)}</Text>
-      </Box>
-      <Box paddingX={1}>{children}</Box>
-    </Box>
-  );
+  return <Box paddingX={1}>{children}</Box>;
 }
 
 function ModePill({

--- a/src/cli/ui/layout/StatusRow.tsx
+++ b/src/cli/ui/layout/StatusRow.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { Countdown } from "../primitives/Countdown.js";
 import { useAgentState } from "../state/provider.js";
 import type { Mode, NetworkState, StatusBar } from "../state/state.js";
-import { FG, TONE, balanceColor, formatBalance, formatCost } from "../theme/tokens.js";
+import { FG, TONE, formatCost } from "../theme/tokens.js";
 
 const RULE_PAD = 4;
 const RULE_MIN = 20;
@@ -42,19 +42,6 @@ export function StatusRow(): React.ReactElement {
             </Text>
             <Text bold color={FG.body}>
               {`${formatCost(status.cost, status.balanceCurrency)} turn`}
-            </Text>
-          </>
-        )}
-        <Sep />
-        <Text
-          color={FG.sub}
-        >{`${formatCost(status.sessionCost, status.balanceCurrency, 3)} session`}</Text>
-        {status.balance !== undefined && (
-          <>
-            <Sep />
-            <Text color={FG.faint}>{"wallet "}</Text>
-            <Text bold color={balanceColor(status.balance, status.balanceCurrency)}>
-              {formatBalance(status.balance, status.balanceCurrency)}
             </Text>
           </>
         )}

--- a/src/cli/ui/primitives/Card.tsx
+++ b/src/cli/ui/primitives/Card.tsx
@@ -1,7 +1,7 @@
 import { Box } from "ink";
 import React, { useContext } from "react";
 
-/** Settled cards (in scrollback) drop the border + paddingX so history reads as flat lines. */
+/** Settled cards (in scrollback) drop border + padding + margin so history collapses to flat lines. */
 export const ActiveCardContext = React.createContext(true);
 
 export interface CardProps {
@@ -23,11 +23,7 @@ const STRIPE_BORDER = {
 export function Card({ tone, children }: CardProps): React.ReactElement {
   const active = useContext(ActiveCardContext);
   if (!active) {
-    return (
-      <Box flexDirection="column" marginTop={1}>
-        {children}
-      </Box>
-    );
+    return <Box flexDirection="column">{children}</Box>;
   }
   return (
     <Box

--- a/src/cli/ui/primitives/CardHeader.tsx
+++ b/src/cli/ui/primitives/CardHeader.tsx
@@ -1,6 +1,7 @@
 import { Box, Text } from "ink";
-import React from "react";
+import React, { useContext } from "react";
 import { FG } from "../theme/tokens.js";
+import { ActiveCardContext } from "./Card.js";
 
 export type MetaItem = string | { text: string; color: string };
 
@@ -30,6 +31,9 @@ export function CardHeader({
   meta,
   right,
 }: CardHeaderProps): React.ReactElement {
+  const active = useContext(ActiveCardContext);
+  // Settled scrollback drops faint string meta + spinners; colored badges (rejected, retry) stay.
+  const visibleMeta = active ? meta : meta?.filter((item) => typeof item !== "string");
   return (
     <Box flexDirection="row" gap={1}>
       <Text color={tone}>{glyph}</Text>
@@ -43,7 +47,7 @@ export function CardHeader({
         </Text>
       )}
       {subtitle ? <Text color={FG.body}>{subtitle}</Text> : null}
-      {meta?.map((item, i) => {
+      {visibleMeta?.map((item, i) => {
         const isStr = typeof item === "string";
         const text = isStr ? item : item.text;
         const color = isStr ? FG.faint : item.color;
@@ -55,7 +59,7 @@ export function CardHeader({
           </React.Fragment>
         );
       })}
-      {right}
+      {active ? right : null}
     </Box>
   );
 }

--- a/tests/ui-status-row-balance.test.tsx
+++ b/tests/ui-status-row-balance.test.tsx
@@ -1,10 +1,7 @@
 /**
- * StatusRow wallet rendering - verifies the currency symbol matches the
- * balance currency, not hardcoded ¥.
- *
- * These tests import the REAL StatusRow component and render it through
- * Ink with a mock AgentStore.  They FAIL today because StatusRow:61
- * hardcodes ¥ and the state has no balanceCurrency field.
+ * StatusRow turn-cost rendering — wallet + session-cost segments live in
+ * StatsPanel / UsageCard now (covered by their own tests). This file only
+ * asserts the turn-cost + cache cells StatusRow still renders.
  */
 import { render } from "ink";
 import React, { useEffect } from "react";
@@ -21,7 +18,6 @@ const SESSION: SessionInfo = {
   model: "deepseek-chat",
 };
 
-/** Dispatches arbitrary events on mount into the store created by AgentStoreProvider. */
 function EventInjector({
   events,
   children,
@@ -37,7 +33,6 @@ function EventInjector({
   return React.createElement(React.Fragment, null, children);
 }
 
-/** Convenience: inject a single session.update with status overrides. */
 function StateInjector({
   overrides,
   children,
@@ -51,7 +46,6 @@ function StateInjector({
   });
 }
 
-/** Render <StatusRow /> through Ink with a fake stdout, return collected text. */
 async function renderStatusRow(overrides: Partial<AgentState["status"]>): Promise<string> {
   const stdout = makeFakeStdout();
   const { unmount } = render(
@@ -62,139 +56,47 @@ async function renderStatusRow(overrides: Partial<AgentState["status"]>): Promis
     </AgentStoreProvider>,
     { stdout: stdout as never, stdin: makeFakeStdin() as never },
   );
-  // Let the StateInjector effect fire and StatusRow re-render.
   await new Promise((r) => setTimeout(r, 50));
   unmount();
   return stdout.text();
 }
 
-// ---------------------------------------------------------------------------
-// tests
-// ---------------------------------------------------------------------------
-
-describe("StatusRow - wallet currency symbol", () => {
-  it("shows $ for USD balance", async () => {
-    const text = await renderStatusRow({ balance: 0.91, balanceCurrency: "USD" } as any);
-    expect(text).toContain("$0.91");
-  });
-
-  it("shows ¥ for CNY balance", async () => {
-    const text = await renderStatusRow({ balance: 6.55, balanceCurrency: "CNY" } as any);
-    expect(text).toContain("¥6.55");
-  });
-
-  it("shows no wallet when balance is undefined", async () => {
-    const text = await renderStatusRow({ balance: undefined } as any);
-    expect(text).not.toContain("wallet");
-  });
-
-  it("uses correct color for USD $0.91 (~¥6.55 -> warn, not err)", async () => {
-    // $0.91 * 7.2 = ¥6.55 -> warn range (yellow), not err (red).
-    // The err color is #ff8b81, warn is #f0b07d.
-    const text = await renderStatusRow({ balance: 0.91, balanceCurrency: "USD" } as any);
-    expect(text).toContain("$0.91");
-    // After the fix, the color should be warn (yellow) not err (red).
-    // For now, this test just confirms the symbol is correct.
-  });
-
-  // ---- Turn/session costs must follow wallet currency ----
-  // When the wallet is in USD, costs should show in USD ($).
-  // When the wallet is in CNY, costs should show in CNY (¥).
-  // When no wallet is loaded, default to CNY (DeepSeek native pricing).
-
-  it("USD wallet: turn/session costs show $, not ¥", async () => {
+describe("StatusRow — turn cost currency", () => {
+  it("USD wallet: turn cost shows $", async () => {
     const text = await renderStatusRow({
       cost: 0.0308,
-      sessionCost: 0.064,
       balance: 0.71,
       balanceCurrency: "USD",
     } as any);
-    // Cost in USD, no conversion: $0.0308 turn, $0.064 session
     expect(text).toContain("$0.0308 turn");
-    expect(text).toContain("$0.064 session");
-    expect(text).toContain("wallet $0.71");
+    expect(text).not.toContain(" session ");
+    expect(text).not.toContain("wallet ");
   });
 
-  it("CNY wallet: turn/session costs show ¥ (converted from USD)", async () => {
+  it("CNY wallet: turn cost shows ¥ (USD→CNY)", async () => {
     const text = await renderStatusRow({
       cost: 0.0308,
-      sessionCost: 0.064,
       balance: 6.55,
       balanceCurrency: "CNY",
     } as any);
-    // 0.0308 USD * 7.2 = 0.2218 CNY → "¥0.2218 turn"
     expect(text).toContain("¥0.2218 turn");
-    // 0.064 USD * 7.2 = 0.461 CNY → "¥0.461 session"
-    expect(text).toContain("¥0.461 session");
-    expect(text).toContain("wallet ¥6.55");
+    expect(text).not.toContain(" session ");
+    expect(text).not.toContain("wallet ");
   });
 
-  it("no wallet info: costs default to CNY (backward compat)", async () => {
-    const text = await renderStatusRow({
-      cost: 0.0308,
-      sessionCost: 0.064,
-      balance: undefined,
-    } as any);
-    // When balanceCurrency is undefined, fall back to CNY display.
+  it("no wallet info: turn cost defaults to ¥", async () => {
+    const text = await renderStatusRow({ cost: 0.0308, balance: undefined } as any);
     expect(text).toContain("¥0.2218 turn");
-    expect(text).toContain("¥0.461 session");
-    expect(text).not.toContain("wallet");
+    expect(text).not.toContain("wallet ");
   });
 
-  // ---- Full turn flow (pricing -> turn.end -> session.update -> display) ----
-
-  it("full USD flow: turn.end + session.update renders all $ symbols", async () => {
-    const stdout = makeFakeStdout();
-    const { unmount } = render(
-      <AgentStoreProvider session={SESSION}>
-        <EventInjector
-          events={[
-            {
-              type: "turn.end",
-              usage: { prompt: 1000, reason: 0, output: 200, cacheHit: 0.8, cost: 0.00015 },
-            },
-            { type: "session.update", patch: { balance: 0.71, balanceCurrency: "USD" } },
-          ]}
-        >
-          <StatusRow />
-        </EventInjector>
-      </AgentStoreProvider>,
-      { stdout: stdout as never, stdin: makeFakeStdin() as never },
-    );
-    await new Promise((r) => setTimeout(r, 50));
-    unmount();
-    const text = stdout.text();
-    expect(text).toContain("$0.0001 turn");
-    expect(text).toContain("$0.000 session");
-    expect(text).toContain("wallet $0.71");
+  it("turn cost hidden when zero", async () => {
+    const text = await renderStatusRow({ cost: 0 } as any);
+    expect(text).not.toContain("turn");
   });
 
-  it("full CNY flow: turn.end + session.update renders all ¥ symbols", async () => {
-    const stdout = makeFakeStdout();
-    const { unmount } = render(
-      <AgentStoreProvider session={SESSION}>
-        <EventInjector
-          events={[
-            {
-              type: "turn.end",
-              usage: { prompt: 1000, reason: 0, output: 200, cacheHit: 0.8, cost: 0.00015 },
-            },
-            { type: "session.update", patch: { balance: 6.55, balanceCurrency: "CNY" } },
-          ]}
-        >
-          <StatusRow />
-        </EventInjector>
-      </AgentStoreProvider>,
-      { stdout: stdout as never, stdin: makeFakeStdin() as never },
-    );
-    await new Promise((r) => setTimeout(r, 50));
-    unmount();
-    const text = stdout.text();
-    // 0.00015 USD * 7.2 = 0.0011 CNY → "¥0.0011 turn"
-    expect(text).toContain("¥0.0011 turn");
-    // 0.00015 USD * 7.2 = 0.001 CNY (3 fraction digits)
-    expect(text).toContain("¥0.001 session");
-    // Wallet in ¥
-    expect(text).toContain("wallet ¥6.55");
+  it("cache % always rendered", async () => {
+    const text = await renderStatusRow({ cost: 0, cacheHit: 0.873 } as any);
+    expect(text).toContain("cache 87%");
   });
 });


### PR DESCRIPTION
## Summary

Two community reports of "visual fatigue / scattered information" on the
chat surface. Diagnosis: two stacked rules at the bottom, a five-segment
status row carrying redundant cost data, and every card getting its own
margin-top blank line — so history scroll reads as fragments instead of
one block.

Four small cuts:

- `Card.tsx` — settled (scrollback) cards drop the `marginTop` the active
  card keeps. Active card still has breathing room; history collapses.
- `LiveRows.tsx` — `ModeStatusBar` drops its dashed `╌` rule. `StatusRow`'s
  solid `─` rule already does the chat/chrome separation.
- `StatusRow.tsx` — drop `session cost` + `wallet` segments (StatsPanel
  and UsageCard already surface them). Status row keeps `mode · sess ·
  branch · turn cost · cache%` only.
- `CardHeader.tsx` — settled cards filter faint string meta (`1.2KB`,
  `2.34s`, `exit 1` on OK rows) and drop the right slot so spinners
  don't linger in scrollback. Colored meta badges (`rejected`, `retry
  N/M`) still render — those carry signal worth keeping.

`tests/ui-status-row-balance.test.tsx` reduced to the cells StatusRow
now renders. Wallet/session currency coverage stays in
`ui-stats-panel-currency` and `ui-usage-card-balance`.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run tests/ui-*` — 69/69 pass
- [x] `npx vitest run tests/comment-policy.test.ts` — pass
- [x] `npx vitest run tests/tool-card-meta.test.ts tests/hydrate-cards.test.ts` — pass
- [ ] Manual TUI sweep: chat with several tool calls, settle them into
      scrollback, confirm reduced breathing room and meta dropout
- [ ] Manual TUI sweep: error / rejected / retry cards still legible
- [ ] Manual TUI sweep: bottom bar reads as one rule + mode line + status line