### PR TITLE
docs(issues): split off display/rendering template (#412)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,6 +4,10 @@ about: Something is broken
 labels: bug
 ---
 
+> **Screen flicker, garbled output, leftover artifacts, cursor jumping?**
+> Use the **Display / rendering issue** template instead — it asks for the
+> terminal-specific info we need to diagnose those.
+
 **What happened**
 A clear and concise description.
 
@@ -14,12 +18,13 @@ What you expected to happen.
 Steps or minimal code that reproduces it.
 
 **Environment**
-- Reasonix version:
-- Node version:
-- OS:
-- Shell (bash, zsh, fish, PowerShell, etc.):
-- Terminal emulator (kitty, WezTerm, Windows Terminal, etc.):
+- Reasonix version (`reasonix --version`):
+- Node version (`node --version`):
+- OS (Windows 11 / macOS 14 / Ubuntu 24.04 / …):
+- Shell (bash, zsh, fish, PowerShell 7, PowerShell 5.1, cmd, …):
+- Terminal app (Windows Terminal, iTerm2, Alacritty, kitty, WezTerm, **VSCode integrated**, **Cursor integrated**, Hyper, …):
 - DeepSeek model (e.g. `deepseek-v4-flash`, `deepseek-v4-pro`):
 
 **Logs / transcript**
-If using the CLI, attach the relevant chunk of `--transcript`.
+If using the CLI, attach the relevant chunk of `--transcript`, or run
+`reasonix doctor` and paste the output.

--- a/.github/ISSUE_TEMPLATE/display_issue.md
+++ b/.github/ISSUE_TEMPLATE/display_issue.md
@@ -1,0 +1,109 @@
+---
+name: Display / rendering issue
+about: Screen flicker, garbled output, leftover artifacts, cursor jumping
+labels: bug, rendering
+---
+
+> Display problems almost always come from the **terminal emulator**, not
+> the shell. Please fill the terminal section carefully — `bash vs PowerShell`
+> tells us very little; `VSCode integrated terminal vs Windows Terminal`
+> tells us everything.
+
+**Symptom** (tick all that apply)
+- [ ] Whole screen flickers / flashes during streaming response
+- [ ] Lines tear or only half-redraw
+- [ ] Stale output left behind after a frame updates
+- [ ] Cursor jumps to wrong column or vanishes
+- [ ] Mojibake / wrong-width characters (e.g. `□`, half-width emoji)
+- [ ] Other (describe below)
+
+**When it happens**
+- [ ] During assistant streaming (token-by-token output)
+- [ ] When tool cards expand / collapse
+- [ ] During scroll-up / scrollback
+- [ ] On terminal resize
+- [ ] On launch / on quit
+- [ ] Other (describe below)
+
+**Terminal — the important part**
+
+Where exactly are you running `reasonix`?
+
+- [ ] **VSCode** integrated terminal — VSCode version: `?`
+- [ ] **Cursor** integrated terminal — Cursor version: `?`
+- [ ] **Windows Terminal** — version: `?`
+- [ ] **cmd.exe** (legacy console host)
+- [ ] **PowerShell ISE** (note: ISE doesn't support ANSI — most things will look broken)
+- [ ] **iTerm2** / **Terminal.app** / **Alacritty** / **kitty** / **WezTerm** / **Hyper**
+- [ ] tmux / screen / mosh — and inside which outer terminal? `?`
+- [ ] Other:
+
+> 💡 **How to find your VSCode / Cursor version**
+> `Help → About` (Windows/Linux) or `Code → About Visual Studio Code` (macOS).
+> Paste the whole panel — version + commit + Electron + xterm.js if shown.
+
+**Diagnostic dump — copy/paste output**
+
+Run **one** of the snippets below in the same terminal where you saw the
+issue, and paste the output here:
+
+<details><summary>PowerShell (Windows)</summary>
+
+```powershell
+reasonix --version; node --version
+$PSVersionTable.PSVersion.ToString()
+[System.Environment]::OSVersion.VersionString
+"TERM=$env:TERM"
+"TERM_PROGRAM=$env:TERM_PROGRAM"
+"TERM_PROGRAM_VERSION=$env:TERM_PROGRAM_VERSION"
+"COLORTERM=$env:COLORTERM"
+"WT_SESSION=$env:WT_SESSION"
+"VSCODE_INJECTION=$env:VSCODE_INJECTION"
+"WSL_DISTRO_NAME=$env:WSL_DISTRO_NAME"
+```
+
+</details>
+
+<details><summary>bash / zsh (macOS / Linux / WSL / Git Bash)</summary>
+
+```bash
+reasonix --version; node --version
+uname -a
+echo "TERM=$TERM"
+echo "TERM_PROGRAM=$TERM_PROGRAM"
+echo "TERM_PROGRAM_VERSION=$TERM_PROGRAM_VERSION"
+echo "COLORTERM=$COLORTERM"
+echo "WT_SESSION=$WT_SESSION"
+echo "VSCODE_INJECTION=$VSCODE_INJECTION"
+echo "WSL_DISTRO_NAME=$WSL_DISTRO_NAME"
+```
+
+</details>
+
+```
+<paste output here>
+```
+
+**VSCode / Cursor users only — terminal settings**
+
+Open Settings (`Ctrl+,`), search `terminal.integrated.gpuAcceleration`,
+report current value: `auto` / `on` / `canvas` / `off` — `?`
+
+Already tried any of:
+- [ ] Switching `gpuAcceleration` to a different value
+- [ ] Detaching the terminal (drag tab into its own window)
+- [ ] Running the same command in a non-VSCode terminal — did it still flicker? `yes / no`
+
+**Reproduction**
+
+Steps that reliably trigger it (commands run, files edited, was a tool
+streaming a long response, was the window being resized, …):
+
+1.
+2.
+3.
+
+**Screen recording (strongly preferred)**
+
+A 5–10s GIF or MP4 is worth 1000 words for rendering bugs. Drop it in
+this comment box — GitHub uploads attachments inline.


### PR DESCRIPTION
## Summary

- New **Display / rendering issue** template (`display_issue.md`) to collect terminal-host info we actually need to triage flicker / repaint / cursor-jump reports — host + version, `TERM_PROGRAM` / `VSCODE_INJECTION` / `WT_SESSION` env vars, `terminal.integrated.gpuAcceleration`, plus a 5–10s recording.
- Ships copy-paste PowerShell + bash diagnostic snippets so reporters do not need to know how to introspect their own terminal.
- Bug template gets a one-line redirect at the top + tightens the Environment section (calls out VSCode/Cursor integrated terminal explicitly, links `reasonix --version` / `node --version` / `reasonix doctor` inline).

Tracking issue #412 has the root-cause writeup and links back here.

## Test plan

- [x] Pre-push verify passes (`npm run build && lint && typecheck && 2237 tests`)
- [ ] After merge, confirm GitHub renders both templates in the "New issue" picker
- [ ] Confirm the deep-link `?template=display_issue.md` from #412 lands on the new form