### PR TITLE
feat(dashboard): viewer modal kind for /replay (#421)

### DIFF
--- a/dashboard/app.css
+++ b/dashboard/app.css
@@ -2122,6 +2122,52 @@ input:focus, textarea:focus, select:focus { border-color: var(--c-brand); }
   font-size: 13px;
 }
 
+.modal-viewer-steps {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.modal-viewer-step {
+  display: grid;
+  grid-template-columns: 18px 1fr;
+  gap: 6px;
+  padding: 4px 8px;
+  border-radius: var(--r-sm, 4px);
+  background: var(--bg-elev-2);
+  align-items: baseline;
+}
+
+.modal-viewer-step-mark {
+  text-align: center;
+  font-weight: 600;
+  color: var(--fg-2);
+}
+
+.modal-viewer-step-done .modal-viewer-step-mark {
+  color: #86efac;
+}
+
+.modal-viewer-step-title {
+  color: var(--fg-1);
+  font-size: 13px;
+}
+
+.modal-viewer-step-done .modal-viewer-step-title {
+  color: var(--fg-2);
+}
+
+.modal-viewer-body {
+  margin-top: 4px;
+  font-size: 13px;
+  color: var(--fg-1);
+  max-height: 360px;
+  overflow-y: auto;
+}
+
 /* Side-by-side diff for the edit-review modal — left is "before" (red
  * tint), right is "after" (green tint), context rows render unchanged.
  * Lines hljs-highlight per the file's language. */

--- a/dashboard/src/components/chat-internals.ts
+++ b/dashboard/src/components/chat-internals.ts
@@ -133,6 +133,20 @@ export interface PickerModalSpec {
   hint?: string;
 }
 
+export interface ViewerStep {
+  id: string;
+  title: string;
+  status: "done" | "queued";
+}
+
+export interface ViewerModalSpec {
+  viewerKind: string;
+  title: string;
+  body?: string;
+  steps?: ViewerStep[];
+  meta?: string;
+}
+
 interface DiffEntry {
   kind: "context" | "ins" | "del";
   text: string;
@@ -813,6 +827,49 @@ export function PickerModal({
               </div>
             `
       }
+    <//>
+  `;
+}
+
+export function ViewerModal({
+  modal,
+  onResolve,
+}: {
+  modal: ViewerModalSpec;
+  onResolve: OnResolve;
+}) {
+  useLang();
+  return html`
+    <${ModalCard}
+      accent="#67e8f9"
+      icon="◇"
+      title=${modal.title}
+      subtitle=${modal.meta}
+    >
+      ${
+        modal.steps && modal.steps.length > 0
+          ? html`
+            <ol class="modal-viewer-steps">
+              ${modal.steps.map(
+                (s: ViewerStep) => html`
+                  <li key=${s.id} class=${`modal-viewer-step modal-viewer-step-${s.status}`}>
+                    <span class="modal-viewer-step-mark">${s.status === "done" ? "✓" : "·"}</span>
+                    <span class="modal-viewer-step-title">${s.title}</span>
+                  </li>
+                `,
+              )}
+            </ol>
+          `
+          : null
+      }
+      ${
+        modal.body
+          ? html`<div class="md modal-viewer-body" dangerouslySetInnerHTML=${{ __html: marked.parse(modal.body) }}></div>`
+          : null
+      }
+      <div class="modal-actions">
+        <button onClick=${() => onResolve("viewer", { action: "close" })}>${t("modal.viewerClose")}</button>
+      </div>
     <//>
   `;
 }

--- a/dashboard/src/i18n/en.ts
+++ b/dashboard/src/i18n/en.ts
@@ -516,5 +516,6 @@ export const en = {
     pickerRename: "Rename…",
     pickerNew: "New…",
     pickerNewPlaceholder: "Name (leave blank for default)",
+    viewerClose: "Close",
   },
 };

--- a/dashboard/src/i18n/zh-CN.ts
+++ b/dashboard/src/i18n/zh-CN.ts
@@ -516,5 +516,6 @@ export const zhCN = {
     pickerRename: "重命名…",
     pickerNew: "新建…",
     pickerNewPlaceholder: "名称（留空使用默认）",
+    viewerClose: "关闭",
   },
 };

--- a/dashboard/src/panels/chat.ts
+++ b/dashboard/src/panels/chat.ts
@@ -10,6 +10,7 @@ import {
   PlanModal,
   RevisionModal,
   ShellModal,
+  ViewerModal,
   WorkspaceModal,
   parseToolArgs,
 } from "../components/chat-internals.js";
@@ -687,7 +688,9 @@ export function ChatPanel() {
                         ? html`<${RevisionModal} modal=${modal} onResolve=${resolveModal} />`
                         : modal.kind === "picker"
                           ? html`<${PickerModal} modal=${modal} onResolve=${resolveModal} />`
-                          : null
+                          : modal.kind === "viewer"
+                            ? html`<${ViewerModal} modal=${modal} onResolve=${resolveModal} />`
+                            : null
           : null
       }
 

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -94,7 +94,8 @@ import { SlashArgPicker } from "./SlashArgPicker.js";
 import { SlashSuggestions } from "./SlashSuggestions.js";
 import { WelcomeBanner } from "./WelcomeBanner.js";
 import { detectBangCommand, formatBangUserMessage } from "./bang.js";
-import type { PickerSnapshot } from "./dashboard/use-picker-broadcast.js";
+import type { PickerSnapshot, ViewerSnapshot } from "./dashboard/use-picker-broadcast.js";
+import { useViewerBroadcast } from "./dashboard/use-picker-broadcast.js";
 import { formatEditResults } from "./edit-history.js";
 import { loopEventToDashboard } from "./effects/loop-to-dashboard.js";
 import { appendGlobalMemory, appendProjectMemory, detectHashMemory } from "./hash-memory.js";
@@ -681,6 +682,10 @@ function AppInner({
   /** Only one picker mounts at a time; snapshot feeds `getActiveModal` for late SSE clients. */
   const activePickerResolverRef = useRef<((res: PickerResolution) => void) | null>(null);
   const activePickerSnapshotRef = useRef<PickerSnapshot | null>(null);
+  /** Active read-only viewer (e.g. /replay plan archive). Same late-SSE concern, simpler resolver (close only). */
+  const activeViewerResolverRef = useRef<(() => void) | null>(null);
+  const activeViewerSnapshotRef = useRef<ViewerSnapshot | null>(null);
+  const [pendingReplayViewer, setPendingReplayViewer] = useState<ViewerSnapshot | null>(null);
   // Structured steps captured from the most recent `submit_plan` call.
   // Populated only when the model supplied `steps`; used by the
   // `mark_step_complete` handler to look up the step title and compute
@@ -937,6 +942,20 @@ function AppInner({
       snapshotRef: activePickerSnapshotRef,
     }),
     [broadcastDashboardEvent],
+  );
+  const viewerPorts = useMemo(
+    () => ({
+      broadcast: broadcastDashboardEvent,
+      resolverRef: activeViewerResolverRef,
+      snapshotRef: activeViewerSnapshotRef,
+    }),
+    [broadcastDashboardEvent],
+  );
+  useViewerBroadcast(
+    !!pendingReplayViewer,
+    pendingReplayViewer ?? { viewerKind: "replay-plan", title: "" },
+    () => setPendingReplayViewer(null),
+    viewerPorts,
   );
 
   // Broadcast busy-state changes so the web Chat tab can disable its
@@ -1775,6 +1794,10 @@ function AppInner({
           if (picker) {
             return { kind: "picker", ...picker };
           }
+          const viewer = activeViewerSnapshotRef.current;
+          if (viewer) {
+            return { kind: "viewer", ...viewer };
+          }
           return null;
         },
         resolveShellConfirm: (choice) => {
@@ -1829,6 +1852,10 @@ function AppInner({
         resolvePicker: (resolution) => {
           const fn = activePickerResolverRef.current;
           if (fn) Promise.resolve(fn(resolution)).catch(() => undefined);
+        },
+        resolveViewer: () => {
+          const fn = activeViewerResolverRef.current;
+          if (fn) Promise.resolve(fn()).catch(() => undefined);
         },
         // ---------- v0.14 mutation surface ----------
         reloadHooks: () => {
@@ -2214,6 +2241,22 @@ function AppInner({
           pushHistory(text);
           setInput(`/${result.openArgPickerFor} `);
           return;
+        }
+        if (result.replayPlan) {
+          const rp = result.replayPlan;
+          const titleSuffix = rp.summary ? ` — ${rp.summary}` : "";
+          const done = new Set(rp.completedStepIds);
+          setPendingReplayViewer({
+            viewerKind: "replay-plan",
+            title: `Replay #${rp.index}/${rp.total} · ${rp.relativeTime}${titleSuffix}`,
+            body: rp.body,
+            steps: rp.steps.map((s) => ({
+              id: s.id,
+              title: s.title,
+              status: done.has(s.id) ? "done" : "queued",
+            })),
+            meta: rp.archiveBasename,
+          });
         }
         const outcome = applySlashResult(result, {
           log,

--- a/src/cli/ui/dashboard/use-picker-broadcast.ts
+++ b/src/cli/ui/dashboard/use-picker-broadcast.ts
@@ -17,6 +17,46 @@ export interface PickerSnapshot {
   hint?: string;
 }
 
+export interface ViewerSnapshot {
+  viewerKind: string;
+  title: string;
+  body?: string;
+  steps?: Array<{ id: string; title: string; status: "done" | "queued" }>;
+  meta?: string;
+}
+
+export interface ViewerBroadcastPorts {
+  broadcast: (ev: DashboardEvent) => void;
+  resolverRef: MutableRefObject<(() => void) | null>;
+  snapshotRef: MutableRefObject<ViewerSnapshot | null>;
+}
+
+/** Read-only sibling of `usePickerBroadcast` — viewer modals carry no selection so only `close` flows back. */
+export function useViewerBroadcast(
+  active: boolean,
+  snapshot: ViewerSnapshot,
+  onClose: () => void,
+  ports: ViewerBroadcastPorts,
+): void {
+  const { broadcast, resolverRef, snapshotRef } = ports;
+
+  useEffect(() => {
+    if (!active) return;
+    return () => {
+      broadcast({ kind: "modal-down", modalKind: "viewer" });
+      if (resolverRef.current) resolverRef.current = null;
+      if (snapshotRef.current) snapshotRef.current = null;
+    };
+  }, [active, broadcast, resolverRef, snapshotRef]);
+
+  useEffect(() => {
+    if (!active) return;
+    snapshotRef.current = snapshot;
+    resolverRef.current = onClose;
+    broadcast({ kind: "modal-up", modal: { kind: "viewer", ...snapshot } });
+  }, [active, snapshot, onClose, broadcast, resolverRef, snapshotRef]);
+}
+
 export interface PickerBroadcastPorts {
   broadcast: (ev: DashboardEvent) => void;
   resolverRef: MutableRefObject<((res: PickerResolution) => void) | null>;

--- a/src/server/api/modal.ts
+++ b/src/server/api/modal.ts
@@ -164,6 +164,16 @@ export async function handleModal(
       ctx.resolvePicker(resolution);
       return { status: 200, body: { resolved: true } };
     }
+    if (kind === "viewer") {
+      if (!ctx.resolveViewer) {
+        return { status: 503, body: { error: "viewer modal resolution not wired" } };
+      }
+      if (parsed.action !== "close") {
+        return { status: 400, body: { error: "viewer action must be close" } };
+      }
+      ctx.resolveViewer({ action: "close" });
+      return { status: 200, body: { resolved: true } };
+    }
     return { status: 400, body: { error: `unknown modal kind: ${String(kind)}` } };
   }
 

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -59,6 +59,8 @@ export interface DashboardContext {
   resolveReviseConfirm?: (choice: "accept" | "reject") => void;
   /** Active picker (sessions / checkpoints / mcp marketplace / …) resolves into the live TUI component via a runtime ref. */
   resolvePicker?: (resolution: PickerResolution) => void;
+  /** Active read-only viewer (replay-plan / …) — only `close` is meaningful since the viewer carries no selection state. */
+  resolveViewer?: (resolution: { action: "close" }) => void;
 
   reloadHooks?: () => number;
   reloadMcp?: () => Promise<number>;
@@ -179,6 +181,17 @@ export type ActiveModal =
       actions: PickerAction[];
       hasMore?: boolean;
       hint?: string;
+    }
+  | {
+      kind: "viewer";
+      /** Discriminator for the underlying viewer (replay-plan / …). */
+      viewerKind: string;
+      title: string;
+      /** Markdown / plain text body. */
+      body?: string;
+      /** Structured plan steps when viewerKind === "replay-plan". */
+      steps?: Array<{ id: string; title: string; status: "done" | "queued" }>;
+      meta?: string;
     };
 
 /** One row of the conversation as the SPA renders it. */

--- a/tests/server-dashboard.test.ts
+++ b/tests/server-dashboard.test.ts
@@ -826,4 +826,41 @@ describe("dashboard server: modal mirroring (workspace / checkpoint / revision)"
     });
     expect(r.status).toBe(503);
   });
+
+  it("POST /api/modal/resolve dispatches viewer close", async () => {
+    const calls: unknown[] = [];
+    const base = await boot({ resolveViewer: (r) => calls.push(r) });
+    const r = await call(`${base}api/modal/resolve`, {
+      method: "POST",
+      token: TOKEN,
+      tokenInHeader: true,
+      body: { kind: "viewer", action: "close" },
+    });
+    expect(r.status).toBe(200);
+    expect(calls).toEqual([{ action: "close" }]);
+  });
+
+  it("POST /api/modal/resolve rejects viewer actions other than close", async () => {
+    const calls: unknown[] = [];
+    const base = await boot({ resolveViewer: (r) => calls.push(r) });
+    const r = await call(`${base}api/modal/resolve`, {
+      method: "POST",
+      token: TOKEN,
+      tokenInHeader: true,
+      body: { kind: "viewer", action: "next" },
+    });
+    expect(r.status).toBe(400);
+    expect(calls).toEqual([]);
+  });
+
+  it("POST /api/modal/resolve returns 503 when viewer resolver is not wired", async () => {
+    const base = await boot({});
+    const r = await call(`${base}api/modal/resolve`, {
+      method: "POST",
+      token: TOKEN,
+      tokenInHeader: true,
+      body: { kind: "viewer", action: "close" },
+    });
+    expect(r.status).toBe(503);
+  });
 });


### PR DESCRIPTION
Final stage of #416. ` /replay [N]` now broadcasts a read-only viewer modal to the web dashboard so the plan archive (summary + structured steps + markdown body) is visible alongside the existing TUI scrollback card.

Stacked on #426 (C-4). Auto-retargets to ` main` once the C-1..C-4 chain merges.

## Summary

- New ` viewer` member on the ` ActiveModal` discriminated union — sibling to ` picker`, but read-only: only ` close` flows back through ` /api/modal/resolve`. Splitting them keeps the picker schema clean rather than carrying empty ` actions: []` on every viewer payload.
- ` useViewerBroadcast` helper lives alongside ` usePickerBroadcast` in ` src/cli/ui/dashboard/use-picker-broadcast.ts`.
- ` App.tsx` intercepts ` result.replayPlan`, packages a snapshot (title with ` #idx/total · relative time`, structured steps with ` done` / ` queued` status, markdown body, archive basename as ` meta`), and feeds it to the hook. The existing ` log.showPlan` call is unchanged so the TUI scrollback card still renders.
- SPA ` ViewerModal` renders the steps as a list (✓ for done, · for queued) plus the markdown body and a single Close button.
- Server tests cover the dispatcher: close happy path, rejection of non-close actions, 503 when the resolver is not wired.

## Wraps up bucket-C of #369

All five originally TUI-only surfaces — ` /resume`, ` /restore`, ` /mcp browse` and the read-only ` /replay` viewer — are now drivable from the web with no TUI keyboard required. (` /walk` already piggybacked on the existing ` edit-review` modal.)

Buckets A / B / D / E from #369 (rendering / structured output / settings UI / terminal-only) are still pending separate tracking issues.

## Test plan

- [x] ` npm run lint` clean
- [x] ` npm run typecheck` clean (root + dashboard)
- [x] ` npm test` — 2260 pass / 2 skipped (3 new viewer dispatcher tests in ` server-dashboard.test.ts`)
- [x] ` npm run build` clean

## Closes

- #421