### PR TITLE
feat(dashboard): server surface for /pro / /budget / /model / /loop (#429)

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -1686,6 +1686,20 @@ function AppInner({
         applyEffortLive: (effort) => {
           loop.configure({ reasoningEffort: effort });
         },
+        applyModelLive: (model) => {
+          loop.configure({ model });
+          agentStore.dispatch({ type: "session.model.change", model });
+        },
+        setProNextLive: (armed) => {
+          if (armed) loop.armProForNextTurn();
+          else loop.disarmPro();
+        },
+        setBudgetUsdLive: (usd) => {
+          loop.setBudget(usd);
+        },
+        getLoopRunStatus: () => getLoopStatus(),
+        startAutoLoop: (intervalMs, prompt) => startLoop(intervalMs, prompt),
+        stopAutoLoop: () => stopLoop(),
         // ---------- Chat bridge ----------
         getMessages: (): DashboardMessage[] =>
           cardsToDashboardMessages(agentStore.getState().cards),
@@ -1898,6 +1912,9 @@ function AppInner({
     pendingRevision,
     agentStore,
     mcpRuntime,
+    getLoopStatus,
+    startLoop,
+    stopLoop,
   ]);
 
   const stopDashboard = useCallback(async (): Promise<void> => {

--- a/src/server/api/loop.ts
+++ b/src/server/api/loop.ts
@@ -1,0 +1,74 @@
+import type { DashboardContext } from "../context.js";
+import type { ApiResult } from "../router.js";
+
+interface LoopStartBody {
+  intervalMs?: unknown;
+  prompt?: unknown;
+}
+
+function parseBody(raw: string): LoopStartBody {
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    return typeof parsed === "object" && parsed !== null ? (parsed as LoopStartBody) : {};
+  } catch {
+    return {};
+  }
+}
+
+const MIN_INTERVAL_MS = 5_000;
+const MAX_INTERVAL_MS = 6 * 60 * 60 * 1000;
+
+export async function handleLoop(
+  method: string,
+  rest: string[],
+  body: string,
+  ctx: DashboardContext,
+): Promise<ApiResult> {
+  if (method === "GET" && rest[0] === "status") {
+    if (!ctx.getLoopRunStatus) {
+      return { status: 503, body: { error: "auto-loop not available — attach to a chat session" } };
+    }
+    return { status: 200, body: { status: ctx.getLoopRunStatus() } };
+  }
+
+  if (method === "POST" && rest[0] === "start") {
+    if (!ctx.startAutoLoop) {
+      return { status: 503, body: { error: "auto-loop start not wired" } };
+    }
+    const { intervalMs, prompt } = parseBody(body);
+    if (typeof prompt !== "string" || !prompt.trim()) {
+      return { status: 400, body: { error: "prompt must be a non-empty string" } };
+    }
+    if (
+      typeof intervalMs !== "number" ||
+      !Number.isFinite(intervalMs) ||
+      intervalMs < MIN_INTERVAL_MS ||
+      intervalMs > MAX_INTERVAL_MS
+    ) {
+      return {
+        status: 400,
+        body: {
+          error: `intervalMs must be a number in [${MIN_INTERVAL_MS}, ${MAX_INTERVAL_MS}] (5s..6h)`,
+        },
+      };
+    }
+    ctx.startAutoLoop(intervalMs, prompt.trim());
+    ctx.audit?.({ ts: Date.now(), action: "auto-loop-start", payload: { intervalMs } });
+    return { status: 200, body: { started: true } };
+  }
+
+  if (method === "POST" && rest[0] === "stop") {
+    if (!ctx.stopAutoLoop) {
+      return { status: 503, body: { error: "auto-loop stop not wired" } };
+    }
+    ctx.stopAutoLoop();
+    ctx.audit?.({ ts: Date.now(), action: "auto-loop-stop" });
+    return { status: 200, body: { stopped: true } };
+  }
+
+  return {
+    status: 405,
+    body: { error: `method ${method} not supported on /api/loop/${rest[0] ?? ""}` },
+  };
+}

--- a/src/server/api/settings.ts
+++ b/src/server/api/settings.ts
@@ -13,6 +13,9 @@ interface SettingsBody {
   preset?: unknown;
   reasoningEffort?: unknown;
   search?: unknown;
+  model?: unknown;
+  proNext?: unknown;
+  budgetUsd?: unknown;
 }
 
 function parseBody(raw: string): SettingsBody {
@@ -39,6 +42,7 @@ export async function handleSettings(
 ): Promise<ApiResult> {
   if (method === "GET") {
     const cfg = readConfig(ctx.configPath);
+    const live = ctx.loop;
     return {
       status: 200,
       body: {
@@ -51,7 +55,9 @@ export async function handleSettings(
         search: cfg.search !== false,
         editMode: cfg.editMode ?? "review",
         session: cfg.session ?? null,
-        model: ctx.loop?.model ?? null,
+        model: live?.model ?? null,
+        proNext: live?.proArmed ?? false,
+        budgetUsd: live?.budgetUsd ?? null,
         // Hint to the SPA which fields require restart.
         appliesAt: {
           apiKey: "next-session",
@@ -59,6 +65,9 @@ export async function handleSettings(
           preset: "next-session",
           reasoningEffort: "next-turn",
           search: "next-session",
+          model: "next-turn",
+          proNext: "next-turn",
+          budgetUsd: "live",
         },
       },
     };
@@ -127,6 +136,43 @@ export async function handleSettings(
       cfg.search = fields.search;
       changed.push("search");
     }
+    let modelPendingLive: string | null = null;
+    let proNextPending: boolean | null = null;
+    let budgetPending: number | null | undefined;
+    if (fields.model !== undefined) {
+      if (typeof fields.model !== "string" || !fields.model.trim()) {
+        return { status: 400, body: { error: "model must be a non-empty string" } };
+      }
+      // Model is live-only (not in ReasonixConfig). Same as /model <id> slash — disk
+      // pickup goes through preset / startup flag, not direct cfg.model.
+      modelPendingLive = fields.model.trim();
+      changed.push("model");
+    }
+    if (fields.proNext !== undefined) {
+      if (typeof fields.proNext !== "boolean") {
+        return { status: 400, body: { error: "proNext must be a boolean" } };
+      }
+      // Not persisted: arming is per-turn ephemeral. Live-only side effect.
+      proNextPending = fields.proNext;
+      changed.push("proNext");
+    }
+    if (fields.budgetUsd !== undefined) {
+      if (fields.budgetUsd === null) {
+        budgetPending = null;
+      } else if (
+        typeof fields.budgetUsd === "number" &&
+        fields.budgetUsd > 0 &&
+        Number.isFinite(fields.budgetUsd)
+      ) {
+        budgetPending = fields.budgetUsd;
+      } else {
+        return {
+          status: 400,
+          body: { error: "budgetUsd must be null or a positive finite number" },
+        };
+      }
+      changed.push("budgetUsd");
+    }
 
     if (changed.length > 0) {
       writeConfig(cfg, ctx.configPath);
@@ -137,6 +183,9 @@ export async function handleSettings(
       if (langPending) setLanguage(langPending);
       if (presetPendingLive) ctx.applyPresetLive?.(presetPendingLive);
       if (effortPendingLive) ctx.applyEffortLive?.(effortPendingLive);
+      if (modelPendingLive) ctx.applyModelLive?.(modelPendingLive);
+      if (proNextPending !== null) ctx.setProNextLive?.(proNextPending);
+      if (budgetPending !== undefined) ctx.setBudgetUsdLive?.(budgetPending);
       ctx.audit?.({ ts: Date.now(), action: "set-settings", payload: { fields: changed } });
     }
     return { status: 200, body: { changed } };

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -37,6 +37,23 @@ export interface DashboardContext {
   applyPresetLive?: (name: string) => void;
   /** Side-channel to live loop — settings POST persists, this flips the running session. */
   applyEffortLive?: (effort: "high" | "max") => void;
+  /** Same model swap path /model <id> takes — live + persisted. */
+  applyModelLive?: (model: string) => void;
+  /** One-shot v4-pro arming for the next turn. `armed=false` cancels a pending arm. */
+  setProNextLive?: (armed: boolean) => void;
+  /** Session USD cap; null disables. Re-arms the 80% warning latch. */
+  setBudgetUsdLive?: (usd: number | null) => void;
+  /** Auto-resubmit timer status — same shape `useLoopMode` exposes to slash handlers. */
+  getLoopRunStatus?: () => {
+    prompt: string;
+    intervalMs: number;
+    iter: number;
+    nextFireMs: number;
+  } | null;
+  /** Start the auto-resubmit timer. Same path the `/loop` slash takes. */
+  startAutoLoop?: (intervalMs: number, prompt: string) => void;
+  /** Clear the auto-resubmit timer. */
+  stopAutoLoop?: () => void;
   /** Endpoints don't write the audit log themselves so tests can swap the implementation. */
   audit?: (entry: AuditEntry) => void;
 

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -4,6 +4,7 @@ import { handleFiles } from "./api/files.js";
 import { handleHealth } from "./api/health.js";
 import { handleHooks } from "./api/hooks.js";
 import { handleIndexConfig } from "./api/index-config.js";
+import { handleLoop } from "./api/loop.js";
 import { handleMcp } from "./api/mcp.js";
 import { handleMemory } from "./api/memory.js";
 import { handleMessages } from "./api/messages.js";
@@ -81,6 +82,8 @@ export async function handleApi(
         return await handleSlash(method, rest, body, ctx);
       case "files":
         return await handleFiles(method, rest, body, ctx);
+      case "loop":
+        return await handleLoop(method, rest, body, ctx);
       default:
         return { status: 404, body: { error: `no such endpoint: /${head}` } };
     }

--- a/tests/server-dashboard.test.ts
+++ b/tests/server-dashboard.test.ts
@@ -864,3 +864,159 @@ describe("dashboard server: modal mirroring (workspace / checkpoint / revision)"
     expect(r.status).toBe(503);
   });
 });
+
+describe("dashboard server: D-1 settings + auto-loop surface", () => {
+  let dir: string;
+  let cfgPath: string;
+  let usagePath: string;
+  let handle: DashboardServerHandle | null = null;
+  const TOKEN = "f".repeat(64);
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "reasonix-d1-"));
+    cfgPath = join(dir, "config.json");
+    usagePath = join(dir, "usage.jsonl");
+  });
+
+  afterEach(async () => {
+    await handle?.close();
+    if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  async function boot(extra: Partial<DashboardContext> = {}): Promise<string> {
+    handle = await startDashboardServer(
+      { mode: "attached", configPath: cfgPath, usageLogPath: usagePath, ...extra },
+      { token: TOKEN },
+    );
+    return handle.url.split("?")[0]!;
+  }
+
+  it("POST /api/settings routes proNext / budgetUsd / model to live callbacks", async () => {
+    const calls: Record<string, unknown[]> = {
+      proNext: [],
+      budgetUsd: [],
+      model: [],
+    };
+    const base = await boot({
+      setProNextLive: (v) => calls.proNext!.push(v),
+      setBudgetUsdLive: (v) => calls.budgetUsd!.push(v),
+      applyModelLive: (v) => calls.model!.push(v),
+    });
+    const r = await call(`${base}api/settings`, {
+      method: "POST",
+      token: TOKEN,
+      tokenInHeader: true,
+      body: { proNext: true, budgetUsd: 2.5, model: "deepseek-v4-pro" },
+    });
+    expect(r.status).toBe(200);
+    expect(r.body.changed).toEqual(expect.arrayContaining(["proNext", "budgetUsd", "model"]));
+    expect(calls.proNext).toEqual([true]);
+    expect(calls.budgetUsd).toEqual([2.5]);
+    expect(calls.model).toEqual(["deepseek-v4-pro"]);
+  });
+
+  it("POST /api/settings rejects non-positive budgetUsd", async () => {
+    const base = await boot({ setBudgetUsdLive: () => undefined });
+    const negative = await call(`${base}api/settings`, {
+      method: "POST",
+      token: TOKEN,
+      tokenInHeader: true,
+      body: { budgetUsd: -1 },
+    });
+    expect(negative.status).toBe(400);
+  });
+
+  it("POST /api/settings accepts null budgetUsd to clear the cap", async () => {
+    const budgetCalls: unknown[] = [];
+    const base = await boot({ setBudgetUsdLive: (v) => budgetCalls.push(v) });
+    const r = await call(`${base}api/settings`, {
+      method: "POST",
+      token: TOKEN,
+      tokenInHeader: true,
+      body: { budgetUsd: null },
+    });
+    expect(r.status).toBe(200);
+    expect(budgetCalls).toEqual([null]);
+  });
+
+  it("GET /api/loop/status returns null when nothing is running", async () => {
+    const base = await boot({ getLoopRunStatus: () => null });
+    const r = await call(`${base}api/loop/status`, { token: TOKEN });
+    expect(r.status).toBe(200);
+    expect(r.body.status).toBeNull();
+  });
+
+  it("GET /api/loop/status returns the live status snapshot", async () => {
+    const snap = { prompt: "ping", intervalMs: 30_000, iter: 3, nextFireMs: 12_000 };
+    const base = await boot({ getLoopRunStatus: () => snap });
+    const r = await call(`${base}api/loop/status`, { token: TOKEN });
+    expect(r.status).toBe(200);
+    expect(r.body.status).toEqual(snap);
+  });
+
+  it("POST /api/loop/start forwards intervalMs and prompt", async () => {
+    const calls: Array<[number, string]> = [];
+    const base = await boot({ startAutoLoop: (ms, p) => calls.push([ms, p]) });
+    const r = await call(`${base}api/loop/start`, {
+      method: "POST",
+      token: TOKEN,
+      tokenInHeader: true,
+      body: { intervalMs: 30_000, prompt: "check the deploy" },
+    });
+    expect(r.status).toBe(200);
+    expect(calls).toEqual([[30_000, "check the deploy"]]);
+  });
+
+  it("POST /api/loop/start rejects out-of-range interval and missing prompt", async () => {
+    const base = await boot({ startAutoLoop: () => undefined });
+    const tooFast = await call(`${base}api/loop/start`, {
+      method: "POST",
+      token: TOKEN,
+      tokenInHeader: true,
+      body: { intervalMs: 1_000, prompt: "x" },
+    });
+    expect(tooFast.status).toBe(400);
+    const noPrompt = await call(`${base}api/loop/start`, {
+      method: "POST",
+      token: TOKEN,
+      tokenInHeader: true,
+      body: { intervalMs: 30_000, prompt: "" },
+    });
+    expect(noPrompt.status).toBe(400);
+  });
+
+  it("POST /api/loop/stop calls the stop hook", async () => {
+    let stopped = 0;
+    const base = await boot({
+      stopAutoLoop: () => {
+        stopped++;
+      },
+    });
+    const r = await call(`${base}api/loop/stop`, {
+      method: "POST",
+      token: TOKEN,
+      tokenInHeader: true,
+    });
+    expect(r.status).toBe(200);
+    expect(stopped).toBe(1);
+  });
+
+  it("returns 503 when loop callbacks are not wired", async () => {
+    const base = await boot({});
+    const status = await call(`${base}api/loop/status`, { token: TOKEN });
+    expect(status.status).toBe(503);
+    const start = await call(`${base}api/loop/start`, {
+      method: "POST",
+      token: TOKEN,
+      tokenInHeader: true,
+      body: { intervalMs: 30_000, prompt: "x" },
+    });
+    expect(start.status).toBe(503);
+    const stop = await call(`${base}api/loop/stop`, {
+      method: "POST",
+      token: TOKEN,
+      tokenInHeader: true,
+    });
+    expect(stop.status).toBe(503);
+  });
+});


### PR DESCRIPTION
First stage of #428 (bucket-D of #369). Server-side plumbing so D-2..D-5 each ship a panel section against a stable surface — no per-PR server churn.

## Scope changed mid-flight

` /harvest` and ` /branch` were originally on the bucket-D list but have been removed from this PR — they are deletion-bound features and adding settings UI / web endpoints for them would only need to be torn out again. Tracking issues #428 / #430 updated to match.

## Summary

- ` GET /api/settings` exposes ` proNext` / ` budgetUsd` / ` model` from the live loop alongside the existing persisted fields. ` appliesAt` hint added so the SPA can show "next-turn" / "live" badges.
- ` POST /api/settings` validates and routes each new field to its matching ` ctx.*Live` callback. ` budgetUsd` accepts a positive finite number or ` null`.
- ` /api/loop/{status,start,stop}` (new ` src/server/api/loop.ts`) drives the auto-resubmit timer the same way the ` /loop` slash does. ` start` enforces the same ` 5s..6h` interval window the slash parser uses.
- ` DashboardContext` gets matching callbacks: ` applyModelLive`, ` setProNextLive`, ` setBudgetUsdLive`, ` getLoopRunStatus`, ` startAutoLoop`, ` stopAutoLoop`.
- ` App.tsx` wires each callback against existing live methods on ` CacheFirstLoop` (` setBudget`, ` armProForNextTurn`, ` configure`) and the ` useLoopMode` hook. No new state.

` /model` is live-only — matches the ` /model <id>` slash semantics which don't persist either.

## Test plan

- [x] ` npm run lint` clean
- [x] ` npm run typecheck` clean (root + dashboard)
- [x] ` npm test` — 2269 pass / 2 skipped (tests in ` server-dashboard.test.ts` covering each knob's happy path, validation, null clearing, and 503 when callbacks are unwired)
- [x] ` npm run build` clean

Closes #429