### PR TITLE
feat(dashboard): editable model picker in settings (#432)

### DIFF
--- a/dashboard/src/i18n/en.ts
+++ b/dashboard/src/i18n/en.ts
@@ -77,6 +77,7 @@ export const en = {
     budgetRefusing: "cap exhausted — next turn refused until bumped or cleared",
     sectionRuntime: "Runtime",
     activeModel: "active model",
+    modelPricingLine: "${hit} hit · ${miss} miss · ${out} out  per 1M tok",
     editMode: "edit mode",
     editModeNote: "switch from the Chat tab header",
     sectionLanguage: "Language",

--- a/dashboard/src/i18n/zh-CN.ts
+++ b/dashboard/src/i18n/zh-CN.ts
@@ -77,6 +77,7 @@ export const zhCN = {
     budgetRefusing: "已超出上限 — 提高或清除后才会继续",
     sectionRuntime: "运行时",
     activeModel: "当前模型",
+    modelPricingLine: "${hit} 命中 · ${miss} 未命中 · ${out} 输出  / 100 万 tok",
     editMode: "编辑模式",
     editModeNote: "在对话标签页头部切换",
     sectionLanguage: "语言",

--- a/dashboard/src/panels/settings.ts
+++ b/dashboard/src/panels/settings.ts
@@ -28,6 +28,70 @@ function fmtUsd2(n: number): string {
   return `$${n.toFixed(n < 1 ? 4 : 2)}`;
 }
 
+interface ModelPriceEntry {
+  inputCacheHit: number;
+  inputCacheMiss: number;
+  output: number;
+}
+
+interface ModelCatalog {
+  models: string[] | null;
+  current: string | null;
+  pricing: Record<string, ModelPriceEntry>;
+}
+
+function formatPricing(p: ModelPriceEntry | undefined): string | null {
+  if (!p) return null;
+  return t("settings.modelPricingLine", {
+    hit: p.inputCacheHit.toFixed(3),
+    miss: p.inputCacheMiss.toFixed(3),
+    out: p.output.toFixed(3),
+  });
+}
+
+function ModelRow({
+  current,
+  catalog,
+  saving,
+  onPick,
+}: {
+  current: string;
+  catalog: ModelCatalog | null;
+  saving: boolean;
+  onPick: (model: string) => void;
+}) {
+  const list = catalog?.models ?? null;
+  const ready = list && list.length > 0;
+  if (!ready) {
+    // Fallback: catalog hasn't loaded (or API failed). Read-only — same as before D-4.
+    return html`<code class="mono">${current ?? "—"}</code>`;
+  }
+  // Ensure the live model is selectable even if the catalog hasn't reported it
+  // yet (preset overrides, custom IDs).
+  const options = list.includes(current) ? list : [current, ...list];
+  const price = catalog?.pricing[current];
+  return html`
+    <span style="display:inline-flex;flex-direction:column;gap:4px">
+      <select
+        value=${current}
+        onChange=${(e: Event) => {
+          const next = (e.target as HTMLSelectElement).value;
+          if (next && next !== current) onPick(next);
+        }}
+        disabled=${saving}
+        style="font-family:var(--font-mono);min-width:200px"
+      >
+        ${options.map((m) => html`<option key=${m} value=${m}>${m}</option>`)}
+      </select>
+      ${
+        price
+          ? html`<span style="color:var(--fg-3);font-size:11px;font-family:var(--font-mono)">${formatPricing(price)}</span>`
+          : null
+      }
+    </span>
+  `;
+}
+
 function BudgetGauge({ state }: { state: BudgetState }) {
   if (state.kind === "off") return null;
   const tone = budgetTone(state);
@@ -188,6 +252,7 @@ export function SettingsPanel() {
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState<string | null>(null);
   const [draft, setDraft] = useState<Partial<SettingsData>>({});
+  const [catalog, setCatalog] = useState<ModelCatalog | null>(null);
 
   const load = useCallback(async () => {
     try {
@@ -201,6 +266,11 @@ export function SettingsPanel() {
   useEffect(() => {
     load();
   }, [load]);
+  useEffect(() => {
+    api<ModelCatalog>("/models")
+      .then(setCatalog)
+      .catch(() => undefined);
+  }, []);
 
   const save = useCallback(
     async (fields: Partial<SettingsData>) => {
@@ -384,7 +454,13 @@ export function SettingsPanel() {
       <div class="card">
         ${fieldRow(
           t("settings.activeModel"),
-          html`<code class="mono">${v.model ?? "—"}</code>`,
+          html`<${ModelRow}
+            current=${v.model ?? "—"}
+            catalog=${catalog}
+            saving=${saving}
+            onPick=${(m: string) => save({ model: m })}
+          />`,
+          t("settings.appliesNextTurn"),
         )}
         ${fieldRow(
           t("settings.editMode"),

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -910,6 +910,10 @@ function AppInner({
   // balance. useSessionInfo refreshes balance every few minutes; we
   // forward to the dashboard without re-minting startDashboard.
   const balanceRef = useRef<typeof balance>(null);
+  const modelsRef = useRef<string[] | null>(null);
+  useEffect(() => {
+    modelsRef.current = models;
+  }, [models]);
   useEffect(() => {
     balanceRef.current = balance;
     walletCurrencyRef.current = balance?.currency;
@@ -1690,6 +1694,7 @@ function AppInner({
           loop.configure({ model });
           agentStore.dispatch({ type: "session.model.change", model });
         },
+        getModels: () => modelsRef.current,
         setProNextLive: (armed) => {
           if (armed) loop.armProForNextTurn();
           else loop.disarmPro();

--- a/src/server/api/models.ts
+++ b/src/server/api/models.ts
@@ -1,0 +1,22 @@
+import { DEEPSEEK_PRICING } from "../../telemetry/stats.js";
+import type { DashboardContext } from "../context.js";
+import type { ApiResult } from "../router.js";
+
+export async function handleModels(
+  method: string,
+  _rest: string[],
+  _body: string,
+  ctx: DashboardContext,
+): Promise<ApiResult> {
+  if (method !== "GET") return { status: 405, body: { error: "GET only" } };
+  const models = ctx.getModels?.() ?? null;
+  return {
+    status: 200,
+    body: {
+      models,
+      current: ctx.loop?.model ?? null,
+      /** USD per 1M tokens — same table the cost gauge uses. */
+      pricing: DEEPSEEK_PRICING,
+    },
+  };
+}

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -39,6 +39,8 @@ export interface DashboardContext {
   applyEffortLive?: (effort: "high" | "max") => void;
   /** Same model swap path /model <id> takes — live + persisted. */
   applyModelLive?: (model: string) => void;
+  /** Cached model catalog. Null = in flight / failed; `[]` = API answered empty. */
+  getModels?: () => string[] | null;
   /** One-shot v4-pro arming for the next turn. `armed=false` cancels a pending arm. */
   setProNextLive?: (armed: boolean) => void;
   /** Session USD cap; null disables. Re-arms the 80% warning latch. */

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -9,6 +9,7 @@ import { handleMcp } from "./api/mcp.js";
 import { handleMemory } from "./api/memory.js";
 import { handleMessages } from "./api/messages.js";
 import { handleModal } from "./api/modal.js";
+import { handleModels } from "./api/models.js";
 import { handleOverview } from "./api/overview.js";
 import { handlePermissions } from "./api/permissions.js";
 import { handlePlans } from "./api/plans.js";
@@ -84,6 +85,8 @@ export async function handleApi(
         return await handleFiles(method, rest, body, ctx);
       case "loop":
         return await handleLoop(method, rest, body, ctx);
+      case "models":
+        return await handleModels(method, rest, body, ctx);
       default:
         return { status: 404, body: { error: `no such endpoint: /${head}` } };
     }

--- a/tests/server-dashboard.test.ts
+++ b/tests/server-dashboard.test.ts
@@ -1001,6 +1001,23 @@ describe("dashboard server: D-1 settings + auto-loop surface", () => {
     expect(stopped).toBe(1);
   });
 
+  it("GET /api/models returns the cached catalog + pricing + current model", async () => {
+    const base = await boot({ getModels: () => ["deepseek-v4-flash", "deepseek-v4-pro"] });
+    const r = await call(`${base}api/models`, { token: TOKEN });
+    expect(r.status).toBe(200);
+    expect(r.body.models).toEqual(["deepseek-v4-flash", "deepseek-v4-pro"]);
+    expect(r.body.pricing["deepseek-v4-flash"]).toBeDefined();
+    expect(r.body.pricing["deepseek-v4-flash"].output).toBeGreaterThan(0);
+  });
+
+  it("GET /api/models returns null catalog when getModels is not wired", async () => {
+    const base = await boot({});
+    const r = await call(`${base}api/models`, { token: TOKEN });
+    expect(r.status).toBe(200);
+    expect(r.body.models).toBeNull();
+    expect(r.body.pricing).toBeDefined();
+  });
+
   it("returns 503 when loop callbacks are not wired", async () => {
     const base = await boot({});
     const status = await call(`${base}api/loop/status`, { token: TOKEN });


### PR DESCRIPTION
Fourth stage of #428. Replaces the read-only active-model code line with a ` <select>` driven by ` /api/models`, plus an inline pricing line.

Stacked on #436 (D-3). Auto-retargets to ` main` once the D-1..D-3 chain merges.

## Summary

- New ` GET /api/models` — returns ` { models: string[] | null, current, pricing: DEEPSEEK_PRICING }`. Serving the pricing table from the server keeps it the single source of truth (same one the cost gauge already reads) instead of duplicating it on the SPA.
- ` DashboardContext.getModels` callback; ` App.tsx` ref-mirrors ` useSessionInfo`'s catalog so the dashboard server (whose closures are frozen at boot time) sees fresh model lists without re-mint.
- ` SettingsPanel` ` ModelRow` component:
  - Graceful fallback to the existing read-only display when the catalog is ` null` / ` []` (in-flight or network failure) — the dashboard never *worsens* relative to before D-4.
  - Live model is always selectable even if the catalog hasn't echoed it yet (preset overrides, custom ` --model` flag).
  - Inline pricing line: ` $0.028 hit · $0.139 miss · $0.278 out  per 1M tok`.
- Save flows through the existing D-1 ` applyModelLive` path — same as ` /model <id>` slash; no new mutation surface.

## Test plan

- [x] ` npm run lint` clean
- [x] ` npm run typecheck` clean (root + dashboard)
- [x] ` npm test` — 2283 pass / 2 skipped (2 new tests in ` server-dashboard.test.ts`: catalog round-trip with pricing, ` null` fallback when ` getModels` is unwired)
- [x] ` npm run build` clean

Closes #432