### PR TITLE
fix(loop): friendly DeepSeek 5xx error with reachability probe

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -18,7 +18,7 @@ import {
 
 import { ContextManager } from "./context-manager.js";
 import { summarizeBranch } from "./loop/branch.js";
-import { formatLoopError } from "./loop/errors.js";
+import { formatLoopError, is5xxError, probeDeepSeekReachable } from "./loop/errors.js";
 import {
   NEEDS_PRO_BUFFER_CHARS,
   isEscalationRequest,
@@ -953,11 +953,12 @@ export class CacheFirstLoop {
           this._turnAbort = new AbortController();
           return;
         }
+        const probe = is5xxError(err) ? await probeDeepSeekReachable(this.client) : undefined;
         yield {
           turn: this._turn,
           role: "error",
           content: "",
-          error: formatLoopError(err as Error),
+          error: formatLoopError(err as Error, probe),
         };
         return;
       }

--- a/src/loop/errors.ts
+++ b/src/loop/errors.ts
@@ -1,5 +1,10 @@
-/** Single text-layer DeepSeek-error formatter — 429/5xx never reach here (retry.ts swallows). */
-export function formatLoopError(err: Error): string {
+import type { DeepSeekClient } from "../client.js";
+
+export interface DeepSeekProbeResult {
+  reachable: boolean;
+}
+
+export function formatLoopError(err: Error, probe?: DeepSeekProbeResult): string {
   const msg = err.message ?? "";
   if (msg.includes("maximum context length")) {
     const reqMatch = msg.match(/requested\s+(\d+)\s+tokens/);
@@ -27,7 +32,43 @@ export function formatLoopError(err: Error): string {
   if (status === "400") {
     return `Bad request (DeepSeek 400): ${inner}`;
   }
+  if (is5xxStatus(status)) {
+    return formatDeepSeek5xx(status, probe);
+  }
   return msg;
+}
+
+export function is5xxError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const m = /^DeepSeek (5\d{2}):/.exec(err.message ?? "");
+  return m !== null;
+}
+
+export async function probeDeepSeekReachable(
+  client: DeepSeekClient,
+  timeoutMs = 1500,
+): Promise<DeepSeekProbeResult> {
+  const balance = await client.getBalance({ signal: AbortSignal.timeout(timeoutMs) });
+  return { reachable: balance !== null };
+}
+
+function is5xxStatus(status: string): boolean {
+  return status === "500" || status === "502" || status === "503" || status === "504";
+}
+
+function formatDeepSeek5xx(status: string, probe?: DeepSeekProbeResult): string {
+  const head = `DeepSeek service unavailable (${status}) — this is a DeepSeek-side problem, not Reasonix. Already retried 4× with backoff.`;
+  const probeNote =
+    probe === undefined
+      ? ""
+      : probe.reachable
+        ? " DeepSeek's main API answered our health check, but /chat/completions is failing — partial outage on their side."
+        : " DeepSeek API is unreachable from your network — could be a wider DS outage or a local network issue.";
+  const action =
+    probe?.reachable === false
+      ? " Try: (1) check your network, (2) wait 30s and retry, (3) status page: https://status.deepseek.com."
+      : " Try: (1) wait 30s and retry, (2) /preset to switch model, (3) status page: https://status.deepseek.com.";
+  return `${head}${probeNote}${action}`;
 }
 
 export function reasonPrefixFor(

--- a/tests/loop-error.test.ts
+++ b/tests/loop-error.test.ts
@@ -77,11 +77,44 @@ describe("formatLoopError", () => {
     expect(out).toMatch(/131k/);
   });
 
-  it("tolerates an empty or malformed JSON body on the error payload", () => {
-    const raw = new Error("DeepSeek 500: ");
+  it("503 with no probe → DS-side outage notice + retry hint, no probe-specific line", () => {
+    const raw = new Error('DeepSeek 503: {"error":{"message":"Service unavailable"}}');
     const out = formatLoopError(raw);
-    // 500 isn't in the remapped set, so it passes through as-is
-    expect(out).toBe("DeepSeek 500: ");
+    expect(out).toMatch(/service unavailable \(503\)/);
+    expect(out).toMatch(/DeepSeek-side problem, not Reasonix/);
+    expect(out).toMatch(/Already retried 4×/);
+    expect(out).toMatch(/status\.deepseek\.com/);
+    expect(out).not.toMatch(/main API answered/);
+    expect(out).not.toMatch(/unreachable from your network/);
+  });
+
+  it("503 with reachable probe → tells user DS chat endpoint is sick but main API is up", () => {
+    const raw = new Error("DeepSeek 503: ");
+    const out = formatLoopError(raw, { reachable: true });
+    expect(out).toMatch(/main API answered our health check/);
+    expect(out).toMatch(/partial outage on their side/);
+    expect(out).not.toMatch(/check your network/);
+  });
+
+  it("503 with unreachable probe → tells user DS or their network is down, network-first hint", () => {
+    const raw = new Error("DeepSeek 503: ");
+    const out = formatLoopError(raw, { reachable: false });
+    expect(out).toMatch(/unreachable from your network/);
+    expect(out).toMatch(/check your network/);
+    expect(out).not.toMatch(/main API answered/);
+  });
+
+  it("500/502/504 also remap to the DS-side outage notice", () => {
+    for (const status of [500, 502, 504]) {
+      const out = formatLoopError(new Error(`DeepSeek ${status}: `));
+      expect(out).toMatch(new RegExp(`service unavailable \\(${status}\\)`));
+      expect(out).toMatch(/DeepSeek-side problem/);
+    }
+  });
+
+  it("tolerates an empty body on a 5xx — still produces the outage notice", () => {
+    const out = formatLoopError(new Error("DeepSeek 500: "));
+    expect(out).toMatch(/service unavailable \(500\)/);
   });
 });
 

--- a/tests/loop-error.test.ts
+++ b/tests/loop-error.test.ts
@@ -83,7 +83,7 @@ describe("formatLoopError", () => {
     expect(out).toMatch(/service unavailable \(503\)/);
     expect(out).toMatch(/DeepSeek-side problem, not Reasonix/);
     expect(out).toMatch(/Already retried 4×/);
-    expect(out).toMatch(/status\.deepseek\.com/);
+    expect(out).toContain("status.deepseek.com");
     expect(out).not.toMatch(/main API answered/);
     expect(out).not.toMatch(/unreachable from your network/);
   });


### PR DESCRIPTION
## Why

Raw `DeepSeek 503: <body>` was bubbling straight to the UI on every DS-side outage. Users couldn't tell if Reasonix had crashed or DeepSeek's service was struggling — and DS 5xx is common in evening/Asia hours, so this hit real users (red-apple feedback this week).

The file header in `src/loop/errors.ts` even lied about it:

```ts
/** Single text-layer DeepSeek-error formatter — 429/5xx never reach here (retry.ts swallows). */
```

But `retry.ts:50` returns the last response when retries are exhausted — it doesn't swallow. So 5xx **did** reach `formatLoopError` and just fell through to the passthrough branch with no friendly message.

## What

`formatLoopError(err, probe?)` now takes an optional reachability probe. The catch handler in `loop.ts:step()` detects 5xx via `is5xxError()`, fires a 1.5s `/user/balance` probe, and passes the result through. Three message shapes:

- **no probe** → "DeepSeek service unavailable (503) — DeepSeek-side problem, not Reasonix. Already retried 4×. Try wait 30s / /preset / status page."
- **reachable** → adds "main API answered our health check, but /chat/completions is failing — partial outage on their side."
- **unreachable** → adds "DeepSeek API is unreachable from your network — could be DS outage or local network. Check your network."

All three name DeepSeek explicitly and link `https://status.deepseek.com` so users know where to look.

The lying header comment is gone.

## Test plan

- [x] 26 cases in `tests/loop-error.test.ts` (was 22) — three probe states × three 5xx codes + 503 with/without probe
- [x] `tsc --noEmit` clean
- [x] biome lint clean
- [x] full suite (2296 passing, one MCP startup flake unrelated to this change, passes on rerun)