### PR TITLE
i18n(dashboard): translate the plan 'idle' status pill

### DIFF
--- a/dashboard/src/i18n/en.ts
+++ b/dashboard/src/i18n/en.ts
@@ -404,6 +404,7 @@ export const en = {
     filterPlaceholder: "filter plans",
     active: "active",
     done: "done",
+    idle: "idle",
     steps: "steps",
     pickHint: "Pick a plan on the left.",
     noTitle: "(no title)",

--- a/dashboard/src/i18n/zh-CN.ts
+++ b/dashboard/src/i18n/zh-CN.ts
@@ -404,6 +404,7 @@ export const zhCN = {
     filterPlaceholder: "筛选计划",
     active: "进行中",
     done: "已完成",
+    idle: "未开始",
     steps: "步骤",
     pickHint: "选择左侧的计划。",
     noTitle: "（无标题）",

--- a/dashboard/src/panels/plans.ts
+++ b/dashboard/src/panels/plans.ts
@@ -29,7 +29,7 @@ interface PlansData {
 function statusPill(p: ArchivedPlan) {
   if (p.completionRatio >= 1) return html`<span class="pill ok">${t("plans.done")}</span>`;
   if (p.completionRatio > 0) return html`<span class="pill info">${t("plans.active")}</span>`;
-  return html`<span class="pill">idle</span>`;
+  return html`<span class="pill">${t("plans.idle")}</span>`;
 }
 
 export function PlansPanel() {


### PR DESCRIPTION
## Why

Plans whose `completionRatio === 0` (submitted but no steps marked complete yet) rendered a hardcoded English `idle` pill in the dashboard — the surrounding `active` / `done` pills already went through `t()`. Spotted during the broader i18n audit.

## What

- `dashboard/src/panels/plans.ts` — route the third branch of `statusPill()` through `t("plans.idle")`
- `dashboard/src/i18n/en.ts` — add `idle: "idle"`
- `dashboard/src/i18n/zh-CN.ts` — add `idle: "未开始"`

3-line diff. Independent of #440 / #441 / #442.

## Test plan

- [x] tsc clean (project + dashboard)
- [x] biome clean on the touched files