### PR TITLE
i18n(loop/errors): localize DeepSeek error messages

### DIFF
--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -331,6 +331,38 @@ export const EN: TranslationSchema = {
     interrupted: "▸ turn interrupted by user.",
     loopStopped: "▸ loop stopped (after {count} iter{s}).",
   },
+  errors: {
+    contextOverflow:
+      "Context overflow (DeepSeek 400): session history is {requested}, past the model's prompt limit (V4: 1M tokens; legacy chat/reasoner: 131k). Usually a single tool result grew too big. Reasonix caps new tool results at 8k tokens and auto-heals oversized history on session load — a restart often clears it. If it still overflows, run /forget (delete the session) or /clear (drop the displayed history) to start fresh.",
+    contextOverflowTooMany: "too many tokens",
+    auth401:
+      "Authentication failed (DeepSeek 401): {inner}. Your API key is rejected. Fix with `reasonix setup` or `export DEEPSEEK_API_KEY=sk-...`. Get one at https://platform.deepseek.com/api_keys.",
+    balance402:
+      "Out of balance (DeepSeek 402): {inner}. Top up at https://platform.deepseek.com/top_up — the panel header shows your balance once it's non-zero.",
+    badparam422: "Invalid parameter (DeepSeek 422): {inner}",
+    badrequest400: "Bad request (DeepSeek 400): {inner}",
+    deepseek5xxHead:
+      "DeepSeek service unavailable ({status}) — this is a DeepSeek-side problem, not Reasonix. Already retried 4× with backoff.",
+    deepseek5xxReachable:
+      " DeepSeek's main API answered our health check, but /chat/completions is failing — partial outage on their side.",
+    deepseek5xxUnreachable:
+      " DeepSeek API is unreachable from your network — could be a wider DS outage or a local network issue.",
+    deepseek5xxActionNetwork:
+      " Try: (1) check your network, (2) wait 30s and retry, (3) status page: https://status.deepseek.com.",
+    deepseek5xxActionRetry:
+      " Try: (1) wait 30s and retry, (2) /preset to switch model, (3) status page: https://status.deepseek.com.",
+    innerNoMessage: "(no message)",
+    reasonAborted: "[aborted by user (Esc) — summarizing what I found so far]",
+    reasonContextGuard:
+      "[context budget running low — summarizing before the next call would overflow]",
+    reasonStuck:
+      "[stuck on a repeated tool call — explaining what was tried and what's blocking progress]",
+    reasonBudget: "[tool-call budget ({iterCap}) reached — forcing summary from what I found]",
+    labelAborted: "aborted by user",
+    labelContextGuard: "context-guard triggered (prompt > 80% of window)",
+    labelStuck: "stuck (repeated tool call suppressed by storm-breaker)",
+    labelBudget: "tool-call budget ({iterCap}) reached",
+  },
   handlers: {
     basic: {
       clearInfo:

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -133,6 +133,28 @@ export interface TranslationSchema {
     interrupted: string;
     loopStopped: string;
   };
+  errors: {
+    contextOverflow: string;
+    contextOverflowTooMany: string;
+    auth401: string;
+    balance402: string;
+    badparam422: string;
+    badrequest400: string;
+    deepseek5xxHead: string;
+    deepseek5xxReachable: string;
+    deepseek5xxUnreachable: string;
+    deepseek5xxActionNetwork: string;
+    deepseek5xxActionRetry: string;
+    innerNoMessage: string;
+    reasonAborted: string;
+    reasonContextGuard: string;
+    reasonStuck: string;
+    reasonBudget: string;
+    labelAborted: string;
+    labelContextGuard: string;
+    labelStuck: string;
+    labelBudget: string;
+  };
   handlers: {
     [group: string]: {
       [key: string]: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -323,6 +323,36 @@ export const zhCN: TranslationSchema = {
     interrupted: "▸ 用户中断了执行。",
     loopStopped: "▸ 循环停止（在执行 {count} 次之后）。",
   },
+  errors: {
+    contextOverflow:
+      "上下文溢出（DeepSeek 400）：会话历史已达 {requested}，超出模型 prompt 上限（V4：1M tokens；旧版 chat/reasoner：131k）。通常是单个工具结果太大。Reasonix 默认将新工具结果限制在 8k tokens，并在会话加载时自动修复超大历史 — 重启常能清掉。如果仍然溢出，运行 /forget（删除会话）或 /clear（丢弃显示中的历史）从头开始。",
+    contextOverflowTooMany: "tokens 数量过多",
+    auth401:
+      "认证失败（DeepSeek 401）：{inner}。你的 API key 被拒绝。运行 `reasonix setup` 或 `export DEEPSEEK_API_KEY=sk-...` 修复。在 https://platform.deepseek.com/api_keys 获取 key。",
+    balance402:
+      "余额不足（DeepSeek 402）：{inner}。在 https://platform.deepseek.com/top_up 充值 — 余额非零时面板顶栏会显示。",
+    badparam422: "参数错误（DeepSeek 422）：{inner}",
+    badrequest400: "请求错误（DeepSeek 400）：{inner}",
+    deepseek5xxHead:
+      "DeepSeek 服务不可用（{status}） — 这是 DeepSeek 服务端问题，不是 Reasonix 故障。已按指数退避重试 4 次。",
+    deepseek5xxReachable:
+      " DeepSeek 主 API 健康检查通过，但 /chat/completions 在挂 — 他们那边部分服务异常。",
+    deepseek5xxUnreachable:
+      " 无法从你的网络访问 DeepSeek API — 可能是 DS 整体故障，也可能是本地网络问题。",
+    deepseek5xxActionNetwork:
+      " 建议：(1) 检查网络，(2) 等 30 秒后重试，(3) 查看状态页 https://status.deepseek.com。",
+    deepseek5xxActionRetry:
+      " 建议：(1) 等 30 秒后重试，(2) 用 /preset 切换模型，(3) 查看状态页 https://status.deepseek.com。",
+    innerNoMessage: "（无错误信息）",
+    reasonAborted: "[用户已中断（Esc） — 正在总结到目前为止的发现]",
+    reasonContextGuard: "[上下文额度即将耗尽 — 在下一次调用溢出之前先总结]",
+    reasonStuck: "[卡在重复的工具调用上 — 说明已尝试的方法以及阻塞点]",
+    reasonBudget: "[工具调用配额（{iterCap}）已用尽 — 基于已发现的内容强制总结]",
+    labelAborted: "用户中断",
+    labelContextGuard: "触发上下文保护（prompt > 80% 窗口）",
+    labelStuck: "卡死（重复工具调用被反风暴机制抑制）",
+    labelBudget: "工具调用配额（{iterCap}）已用尽",
+  },
   handlers: {
     basic: {
       clearInfo:

--- a/src/loop/errors.ts
+++ b/src/loop/errors.ts
@@ -1,4 +1,5 @@
 import type { DeepSeekClient } from "../client.js";
+import { t } from "../i18n/index.js";
 
 export interface DeepSeekProbeResult {
   reachable: boolean;
@@ -10,8 +11,8 @@ export function formatLoopError(err: Error, probe?: DeepSeekProbeResult): string
     const reqMatch = msg.match(/requested\s+(\d+)\s+tokens/);
     const requested = reqMatch
       ? `${Number(reqMatch[1]).toLocaleString()} tokens`
-      : "too many tokens";
-    return `Context overflow (DeepSeek 400): session history is ${requested}, past the model's prompt limit (V4: 1M tokens; legacy chat/reasoner: 131k). Usually a single tool result grew too big. Reasonix caps new tool results at 8k tokens and auto-heals oversized history on session load — a restart often clears it. If it still overflows, run /forget (delete the session) or /clear (drop the displayed history) to start fresh.`;
+      : t("errors.contextOverflowTooMany");
+    return t("errors.contextOverflow", { requested });
   }
 
   const m = /^DeepSeek (\d{3}):\s*([\s\S]*)$/.exec(msg);
@@ -20,21 +21,11 @@ export function formatLoopError(err: Error, probe?: DeepSeekProbeResult): string
   const body = m[2] ?? "";
   const inner = extractDeepSeekErrorMessage(body);
 
-  if (status === "401") {
-    return `Authentication failed (DeepSeek 401): ${inner}. Your API key is rejected. Fix with \`reasonix setup\` or \`export DEEPSEEK_API_KEY=sk-...\`. Get one at https://platform.deepseek.com/api_keys.`;
-  }
-  if (status === "402") {
-    return `Out of balance (DeepSeek 402): ${inner}. Top up at https://platform.deepseek.com/top_up — the panel header shows your balance once it's non-zero.`;
-  }
-  if (status === "422") {
-    return `Invalid parameter (DeepSeek 422): ${inner}`;
-  }
-  if (status === "400") {
-    return `Bad request (DeepSeek 400): ${inner}`;
-  }
-  if (is5xxStatus(status)) {
-    return formatDeepSeek5xx(status, probe);
-  }
+  if (status === "401") return t("errors.auth401", { inner });
+  if (status === "402") return t("errors.balance402", { inner });
+  if (status === "422") return t("errors.badparam422", { inner });
+  if (status === "400") return t("errors.badrequest400", { inner });
+  if (is5xxStatus(status)) return formatDeepSeek5xx(status, probe);
   return msg;
 }
 
@@ -57,17 +48,17 @@ function is5xxStatus(status: string): boolean {
 }
 
 function formatDeepSeek5xx(status: string, probe?: DeepSeekProbeResult): string {
-  const head = `DeepSeek service unavailable (${status}) — this is a DeepSeek-side problem, not Reasonix. Already retried 4× with backoff.`;
+  const head = t("errors.deepseek5xxHead", { status });
   const probeNote =
     probe === undefined
       ? ""
       : probe.reachable
-        ? " DeepSeek's main API answered our health check, but /chat/completions is failing — partial outage on their side."
-        : " DeepSeek API is unreachable from your network — could be a wider DS outage or a local network issue.";
+        ? t("errors.deepseek5xxReachable")
+        : t("errors.deepseek5xxUnreachable");
   const action =
     probe?.reachable === false
-      ? " Try: (1) check your network, (2) wait 30s and retry, (3) status page: https://status.deepseek.com."
-      : " Try: (1) wait 30s and retry, (2) /preset to switch model, (3) status page: https://status.deepseek.com.";
+      ? t("errors.deepseek5xxActionNetwork")
+      : t("errors.deepseek5xxActionRetry");
   return `${head}${probeNote}${action}`;
 }
 
@@ -75,29 +66,25 @@ export function reasonPrefixFor(
   reason: "budget" | "aborted" | "context-guard" | "stuck",
   iterCap: number,
 ): string {
-  if (reason === "aborted") return "[aborted by user (Esc) — summarizing what I found so far]";
-  if (reason === "context-guard") {
-    return "[context budget running low — summarizing before the next call would overflow]";
-  }
-  if (reason === "stuck") {
-    return "[stuck on a repeated tool call — explaining what was tried and what's blocking progress]";
-  }
-  return `[tool-call budget (${iterCap}) reached — forcing summary from what I found]`;
+  if (reason === "aborted") return t("errors.reasonAborted");
+  if (reason === "context-guard") return t("errors.reasonContextGuard");
+  if (reason === "stuck") return t("errors.reasonStuck");
+  return t("errors.reasonBudget", { iterCap });
 }
 
 export function errorLabelFor(
   reason: "budget" | "aborted" | "context-guard" | "stuck",
   iterCap: number,
 ): string {
-  if (reason === "aborted") return "aborted by user";
-  if (reason === "context-guard") return "context-guard triggered (prompt > 80% of window)";
-  if (reason === "stuck") return "stuck (repeated tool call suppressed by storm-breaker)";
-  return `tool-call budget (${iterCap}) reached`;
+  if (reason === "aborted") return t("errors.labelAborted");
+  if (reason === "context-guard") return t("errors.labelContextGuard");
+  if (reason === "stuck") return t("errors.labelStuck");
+  return t("errors.labelBudget", { iterCap });
 }
 
 function extractDeepSeekErrorMessage(body: string): string {
   const trimmed = body.trim();
-  if (!trimmed) return "(no message)";
+  if (!trimmed) return t("errors.innerNoMessage");
   try {
     const parsed = JSON.parse(trimmed);
     if (parsed && typeof parsed === "object") {

--- a/tests/loop-error.test.ts
+++ b/tests/loop-error.test.ts
@@ -1,6 +1,7 @@
 /** Loop error decorator — context-overflow gets a user hint; everything else passes through. */
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { setLanguageRuntime } from "../src/i18n/index.js";
 import { formatLoopError, healLoadedMessages, stripHallucinatedToolMarkup } from "../src/loop.js";
 import type { ChatMessage } from "../src/types.js";
 
@@ -115,6 +116,31 @@ describe("formatLoopError", () => {
   it("tolerates an empty body on a 5xx — still produces the outage notice", () => {
     const out = formatLoopError(new Error("DeepSeek 500: "));
     expect(out).toMatch(/service unavailable \(500\)/);
+  });
+});
+
+describe("formatLoopError — zh-CN runtime switch", () => {
+  afterEach(() => {
+    setLanguageRuntime("EN");
+  });
+
+  it("503 outage notice translates when language is zh-CN", () => {
+    setLanguageRuntime("zh-CN");
+    const out = formatLoopError(new Error("DeepSeek 503: "));
+    expect(out).toContain("服务不可用");
+    expect(out).toContain("503");
+    expect(out).toContain("DeepSeek 服务端问题");
+    expect(out).toContain("status.deepseek.com");
+  });
+
+  it("401 auth error translates when language is zh-CN, preserves the inner DS message", () => {
+    setLanguageRuntime("zh-CN");
+    const out = formatLoopError(
+      new Error('DeepSeek 401: {"error":{"message":"Authentication Fails"}}'),
+    );
+    expect(out).toContain("认证失败");
+    expect(out).toContain("Authentication Fails");
+    expect(out).toContain("reasonix setup");
   });
 });
 


### PR DESCRIPTION
## Why

`formatLoopError`, `reasonPrefixFor`, and `errorLabelFor` were all hardcoded English. A Chinese user hitting a 503 / 401 / context-overflow saw raw English in the chat — same class of UX gap as #440, just on the i18n axis.

This includes the new 5xx outage notice from #440 (now in main).

## What

New \`errors.*\` i18n namespace covering:
- context overflow (with V4 / legacy limit mention)
- 401 auth / 402 balance / 422 param / 400 bad request
- 5xx head + reachable / unreachable / two action variants
- reason prefix and label for budget / aborted / context-guard / stuck
- (no message) fallback for empty error bodies

zh-CN translations for all 20 keys. The user-visible \`{inner}\` server message (e.g. \"Authentication Fails\") is preserved verbatim — translating DS's own response would be wrong.

## Test plan

- [x] 26 existing EN cases still pass (vitest setupFiles pins runtime to EN)
- [x] 2 new cases flip to zh-CN and confirm runtime translation works
- [x] full suite green
- [x] tsc + biome clean

## Note

Replaces #441 (closed). Original branch was stacked on the now-merged \`fix/loop-deepseek-5xx-friendly\`; new branch is rebased onto main.