### PR TITLE
i18n(loop): localize 14 user-facing yields in step()

### DIFF
--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -322,14 +322,37 @@ export const EN: TranslationSchema = {
     stepCounter: "Step {step}/{total} · ",
   },
   loop: {
-    budgetWarning: "▲ session budget reached 80% ($${used} / $${cap})",
-    budgetRefusal:
-      "▲ session budget reached 100% ($${used} / $${cap}) — turn refused. Bump or clear via /budget.",
-    contextWarning: "▲ context window pressure: {ratio}% ({tokens} / {cap})",
-    escalationWarning: "⇧ flash requested escalation — {reason}",
-    toolFailure: "▸ tool {name} failed: {reason}",
-    interrupted: "▸ turn interrupted by user.",
-    loopStopped: "▸ loop stopped (after {count} iter{s}).",
+    budgetExhausted:
+      "session budget exhausted — spent ${spent} ≥ cap ${cap}. Bump the cap with /budget <usd>, clear it with /budget off, or end the session.",
+    budget80Pct: "▲ budget 80% used — ${spent} of ${cap}. Next turn or two likely trips the cap.",
+    proArmed: "⇧ /pro armed — this turn runs on deepseek-v4-pro (one-shot · disarms after turn)",
+    abortedAtIter:
+      "aborted at iter {iter}/{cap} — stopped without producing a summary (press ↑ + Enter or /retry to resume)",
+    toolUploadStatus: "tool result uploaded · model thinking before next response…",
+    toolBudgetWarning:
+      "{iter}/{cap} tool calls used — approaching budget. Press Esc to force a summary now.",
+    preflightFoldStatus: "preflight: context near full, attempting fold…",
+    preflightFolded:
+      "preflight: request ~{estimate}/{ctxMax} tokens ({pct}%) — folded {beforeMessages} messages → {afterMessages} (summary {summaryChars} chars). Sending.",
+    preflightNoFold:
+      "preflight: request ~{estimate}/{ctxMax} tokens ({pct}%) and nothing left to fold — DeepSeek will likely 400. Run /clear or /new to start fresh.",
+    flashEscalation: "⇧ flash requested escalation — retrying this turn on {model}{reasonSuffix}",
+    harvestStatus: "extracting plan state from reasoning…",
+    autoEscalation:
+      "⇧ auto-escalating to {model} for the rest of this turn — flash hit {breakdown}. Next turn falls back to {fallback} unless /pro is armed.",
+    repeatToolCallWarning:
+      "Caught a repeated tool call — let the model see the issue and retry with a different approach.",
+    stormStuck:
+      "Stopped a stuck retry loop — the model kept calling the same tool with identical args after a self-correction nudge. Try /retry, rephrase, or rule out the underlying blocker.",
+    stormSuppressed: "Suppressed {count} repeated tool call(s) — same name + args fired 3+ times.",
+    compactingHistoryStatus: "compacting history{aggressiveTag}…",
+    aggressiveTag: " (aggressive)",
+    foldedHistory:
+      "context {before}/{ctxMax} ({pct}%) — folded {beforeMessages} messages → {afterMessages} (summary {summaryChars} chars). Continuing.",
+    aggressivelyFoldedHistory:
+      "context {before}/{ctxMax} ({pct}%) — aggressively folded {beforeMessages} messages → {afterMessages} (summary {summaryChars} chars). Continuing.",
+    forcingSummary:
+      "context {before}/{ctxMax} ({pct}%) — forcing summary from what was gathered. Run /compact, /clear, or /new to reset.",
   },
   errors: {
     contextOverflow:

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -125,13 +125,26 @@ export interface TranslationSchema {
     };
   };
   loop: {
-    budgetWarning: string;
-    budgetRefusal: string;
-    contextWarning: string;
-    escalationWarning: string;
-    toolFailure: string;
-    interrupted: string;
-    loopStopped: string;
+    budgetExhausted: string;
+    budget80Pct: string;
+    proArmed: string;
+    abortedAtIter: string;
+    toolUploadStatus: string;
+    toolBudgetWarning: string;
+    preflightFoldStatus: string;
+    preflightFolded: string;
+    preflightNoFold: string;
+    flashEscalation: string;
+    harvestStatus: string;
+    autoEscalation: string;
+    repeatToolCallWarning: string;
+    stormStuck: string;
+    stormSuppressed: string;
+    compactingHistoryStatus: string;
+    aggressiveTag: string;
+    foldedHistory: string;
+    aggressivelyFoldedHistory: string;
+    forcingSummary: string;
   };
   errors: {
     contextOverflow: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -315,13 +315,35 @@ export const zhCN: TranslationSchema = {
     stepCounter: "步骤 {step}/{total} · ",
   },
   loop: {
-    budgetWarning: "▲ 会话预算达到 80% ($${used} / $${cap})",
-    budgetRefusal: "▲ 会话预算达到 100% ($${used} / $${cap}) — 拒绝执行。通过 /budget 提高或清除。",
-    contextWarning: "▲ 上下文窗口压力：{ratio}% ({tokens} / {cap})",
-    escalationWarning: "⇧ flash 请求升级 — {reason}",
-    toolFailure: "▸ 工具 {name} 失败：{reason}",
-    interrupted: "▸ 用户中断了执行。",
-    loopStopped: "▸ 循环停止（在执行 {count} 次之后）。",
+    budgetExhausted:
+      "会话预算已用完 — 已花费 ${spent} ≥ 上限 ${cap}。用 /budget <usd> 提高上限，/budget off 清除上限，或结束会话。",
+    budget80Pct: "▲ 预算已用 80% — ${spent} / ${cap}。下一两轮可能就触顶。",
+    proArmed: "⇧ /pro 已装备 — 本轮使用 deepseek-v4-pro（一次性 · 本轮后自动解除）",
+    abortedAtIter:
+      "在第 {iter}/{cap} 次工具调用处中断 — 未生成总结即停止（按 ↑ + Enter 或 /retry 恢复）",
+    toolUploadStatus: "工具结果已上传 · 模型在生成下一条响应前思考中…",
+    toolBudgetWarning: "已用 {iter}/{cap} 次工具调用 — 接近上限。按 Esc 立即强制总结。",
+    preflightFoldStatus: "预检：上下文接近上限，尝试折叠…",
+    preflightFolded:
+      "预检：请求约 {estimate}/{ctxMax} tokens（{pct}%）— 已折叠 {beforeMessages} 条消息 → {afterMessages}（总结 {summaryChars} 字）。发送中。",
+    preflightNoFold:
+      "预检：请求约 {estimate}/{ctxMax} tokens（{pct}%）且没有可折叠的内容 — DeepSeek 大概率会返回 400。请运行 /clear 或 /new 重新开始。",
+    flashEscalation: "⇧ flash 请求升级 — 本轮改用 {model}{reasonSuffix}",
+    harvestStatus: "正在从推理过程提取计划状态…",
+    autoEscalation:
+      "⇧ 本轮剩余调用自动升级到 {model} — flash 命中 {breakdown}。下一轮回退到 {fallback}，除非已装备 /pro。",
+    repeatToolCallWarning: "拦截到重复工具调用 — 让模型察觉问题并换种方式重试。",
+    stormStuck:
+      "已停止卡死的重试循环 — 模型在自纠提示后仍以相同参数重复调用同一工具。请尝试 /retry、换种说法，或排查底层阻塞。",
+    stormSuppressed: "已抑制 {count} 次重复工具调用 — 同一名称 + 参数触发 3 次以上。",
+    compactingHistoryStatus: "正在压缩历史{aggressiveTag}…",
+    aggressiveTag: "（激进）",
+    foldedHistory:
+      "上下文 {before}/{ctxMax}（{pct}%）— 已折叠 {beforeMessages} 条消息 → {afterMessages}（总结 {summaryChars} 字）。继续。",
+    aggressivelyFoldedHistory:
+      "上下文 {before}/{ctxMax}（{pct}%）— 已激进折叠 {beforeMessages} 条消息 → {afterMessages}（总结 {summaryChars} 字）。继续。",
+    forcingSummary:
+      "上下文 {before}/{ctxMax}（{pct}%）— 基于已收集到的内容强制总结。请运行 /compact、/clear 或 /new 重置。",
   },
   errors: {
     contextOverflow:

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -17,6 +17,7 @@ import {
 } from "./mcp/registry.js";
 
 import { ContextManager } from "./context-manager.js";
+import { t } from "./i18n/index.js";
 import { summarizeBranch } from "./loop/branch.js";
 import { formatLoopError, is5xxError, probeDeepSeekReachable } from "./loop/errors.js";
 import {
@@ -513,7 +514,10 @@ export class CacheFirstLoop {
           turn: this._turn,
           role: "error",
           content: "",
-          error: `session budget exhausted — spent $${spent.toFixed(4)} ≥ cap $${this.budgetUsd.toFixed(2)}. Bump the cap with /budget <usd>, clear it with /budget off, or end the session.`,
+          error: t("loop.budgetExhausted", {
+            spent: spent.toFixed(4),
+            cap: this.budgetUsd.toFixed(2),
+          }),
         };
         return;
       }
@@ -522,7 +526,10 @@ export class CacheFirstLoop {
         yield {
           turn: this._turn,
           role: "warning",
-          content: `▲ budget 80% used — $${spent.toFixed(4)} of $${this.budgetUsd.toFixed(2)}. Next turn or two likely trips the cap.`,
+          content: t("loop.budget80Pct", {
+            spent: spent.toFixed(4),
+            cap: this.budgetUsd.toFixed(2),
+          }),
         };
       }
     }
@@ -567,7 +574,7 @@ export class CacheFirstLoop {
       yield {
         turn: this._turn,
         role: "warning",
-        content: "⇧ /pro armed — this turn runs on deepseek-v4-pro (one-shot · disarms after turn)",
+        content: t("loop.proArmed"),
       };
     }
     let pendingUser: string | null = userInput;
@@ -596,7 +603,7 @@ export class CacheFirstLoop {
         yield {
           turn: this._turn,
           role: "warning",
-          content: `aborted at iter ${iter}/${this.maxToolIters} — stopped without producing a summary (press ↑ + Enter or /retry to resume)`,
+          content: t("loop.abortedAtIter", { iter, cap: this.maxToolIters }),
         };
         const stoppedMsg =
           "[aborted by user (Esc) — no summary produced. Ask again or /retry when ready; prior tool output is still in the log.]";
@@ -642,7 +649,7 @@ export class CacheFirstLoop {
         yield {
           turn: this._turn,
           role: "status",
-          content: "tool result uploaded · model thinking before next response…",
+          content: t("loop.toolUploadStatus"),
         };
       }
       if (!warnedForIterBudget && iter >= warnAt) {
@@ -650,7 +657,7 @@ export class CacheFirstLoop {
         yield {
           turn: this._turn,
           role: "warning",
-          content: `${iter}/${this.maxToolIters} tool calls used — approaching budget. Press Esc to force a summary now.`,
+          content: t("loop.toolBudgetWarning", { iter, cap: this.maxToolIters }),
         };
       }
       let messages = this.buildMessages(pendingUser);
@@ -668,16 +675,21 @@ export class CacheFirstLoop {
           yield {
             turn: this._turn,
             role: "status",
-            content: "preflight: context near full, attempting fold…",
+            content: t("loop.preflightFoldStatus"),
           };
           const result = await this.context.fold(this.model);
           if (result.folded) {
             yield {
               turn: this._turn,
               role: "warning",
-              content: `preflight: request ~${estimate.toLocaleString()}/${ctxMax.toLocaleString()} tokens (${Math.round(
-                (estimate / ctxMax) * 100,
-              )}%) — folded ${result.beforeMessages} messages → ${result.afterMessages} (summary ${result.summaryChars} chars). Sending.`,
+              content: t("loop.preflightFolded", {
+                estimate: estimate.toLocaleString(),
+                ctxMax: ctxMax.toLocaleString(),
+                pct: Math.round((estimate / ctxMax) * 100),
+                beforeMessages: result.beforeMessages,
+                afterMessages: result.afterMessages,
+                summaryChars: result.summaryChars,
+              }),
             };
             // Rebuild with the folded log so we send the smaller payload.
             messages = this.buildMessages(pendingUser);
@@ -685,9 +697,11 @@ export class CacheFirstLoop {
             yield {
               turn: this._turn,
               role: "warning",
-              content: `preflight: request ~${estimate.toLocaleString()}/${ctxMax.toLocaleString()} tokens (${Math.round(
-                (estimate / ctxMax) * 100,
-              )}%) and nothing left to fold — DeepSeek will likely 400. Run /clear or /new to start fresh.`,
+              content: t("loop.preflightNoFold", {
+                estimate: estimate.toLocaleString(),
+                ctxMax: ctxMax.toLocaleString(),
+                pct: Math.round((estimate / ctxMax) * 100),
+              }),
             };
           }
         }
@@ -983,7 +997,7 @@ export class CacheFirstLoop {
         yield {
           turn: this._turn,
           role: "warning",
-          content: `⇧ flash requested escalation — retrying this turn on ${ESCALATION_MODEL}${reasonSuffix}`,
+          content: t("loop.flashEscalation", { model: ESCALATION_MODEL, reasonSuffix }),
         };
         // Reset per-iter state. We don't record stats for the rejected
         // flash call (cost is small — a ~20-token lead-in that we broke
@@ -1028,7 +1042,7 @@ export class CacheFirstLoop {
         yield {
           turn: this._turn,
           role: "status",
-          content: "extracting plan state from reasoning…",
+          content: t("loop.harvestStatus"),
         };
       }
       const planState = preHarvestedPlanState
@@ -1070,7 +1084,11 @@ export class CacheFirstLoop {
         yield {
           turn: this._turn,
           role: "warning",
-          content: `⇧ auto-escalating to ${ESCALATION_MODEL} for the rest of this turn — flash hit ${this._turnFailures.formatBreakdown()}. Next turn falls back to ${this.model} unless /pro is armed.`,
+          content: t("loop.autoEscalation", {
+            model: ESCALATION_MODEL,
+            breakdown: this._turnFailures.formatBreakdown(),
+            fallback: this.model,
+          }),
         };
       }
 
@@ -1103,8 +1121,7 @@ export class CacheFirstLoop {
         yield {
           turn: this._turn,
           role: "warning",
-          content:
-            "Caught a repeated tool call — let the model see the issue and retry with a different approach.",
+          content: t("loop.repeatToolCallWarning"),
         };
         continue;
       }
@@ -1112,8 +1129,8 @@ export class CacheFirstLoop {
       if (report.stormsBroken > 0) {
         const noteTail = report.notes.length ? ` — ${report.notes[report.notes.length - 1]}` : "";
         const phrase = allSuppressed
-          ? "Stopped a stuck retry loop — the model kept calling the same tool with identical args after a self-correction nudge. Try /retry, rephrase, or rule out the underlying blocker."
-          : `Suppressed ${report.stormsBroken} repeated tool call(s) — same name + args fired 3+ times.`;
+          ? t("loop.stormStuck")
+          : t("loop.stormSuppressed", { count: report.stormsBroken });
         yield {
           turn: this._turn,
           role: "warning",
@@ -1137,20 +1154,28 @@ export class CacheFirstLoop {
         this._foldedThisTurn = true;
         const before = decision.promptTokens;
         const ctxMax = decision.ctxMax;
-        const aggressiveTag = decision.aggressive ? " (aggressive)" : "";
+        const aggressiveTag = decision.aggressive ? t("loop.aggressiveTag") : "";
         yield {
           turn: this._turn,
           role: "status",
-          content: `compacting history${aggressiveTag}…`,
+          content: t("loop.compactingHistoryStatus", { aggressiveTag }),
         };
         const result = await this.compactHistory({ keepRecentTokens: decision.tailBudget });
         if (result.folded) {
           yield {
             turn: this._turn,
             role: "warning",
-            content: `context ${before.toLocaleString()}/${ctxMax.toLocaleString()} (${Math.round(
-              (before / ctxMax) * 100,
-            )}%) — ${decision.aggressive ? "aggressively folded" : "folded"} ${result.beforeMessages} messages → ${result.afterMessages} (summary ${result.summaryChars} chars). Continuing.`,
+            content: t(
+              decision.aggressive ? "loop.aggressivelyFoldedHistory" : "loop.foldedHistory",
+              {
+                before: before.toLocaleString(),
+                ctxMax: ctxMax.toLocaleString(),
+                pct: Math.round((before / ctxMax) * 100),
+                beforeMessages: result.beforeMessages,
+                afterMessages: result.afterMessages,
+                summaryChars: result.summaryChars,
+              },
+            ),
           };
         }
       } else if (decision.kind === "exit-with-summary") {
@@ -1159,9 +1184,11 @@ export class CacheFirstLoop {
         yield {
           turn: this._turn,
           role: "warning",
-          content: `context ${before.toLocaleString()}/${ctxMax.toLocaleString()} (${Math.round(
-            (before / ctxMax) * 100,
-          )}%) — forcing summary from what was gathered. Run /compact, /clear, or /new to reset.`,
+          content: t("loop.forcingSummary", {
+            before: before.toLocaleString(),
+            ctxMax: ctxMax.toLocaleString(),
+            pct: Math.round((before / ctxMax) * 100),
+          }),
         };
         this.context.trimTrailingToolCalls();
         yield* forceSummaryAfterIterLimit(this.summaryContext(), { reason: "context-guard" });
@@ -1245,7 +1272,11 @@ export class CacheFirstLoop {
             yield {
               turn: this._turn,
               role: "warning",
-              content: `⇧ auto-escalating to ${ESCALATION_MODEL} for the rest of this turn — flash hit ${this._turnFailures.formatBreakdown()}. Next turn falls back to ${this.model} unless /pro is armed.`,
+              content: t("loop.autoEscalation", {
+                model: ESCALATION_MODEL,
+                breakdown: this._turnFailures.formatBreakdown(),
+                fallback: this.model,
+              }),
             };
           }
 


### PR DESCRIPTION
## Why

Yields like \"session budget exhausted\", \"aborted at iter X/Y\", \"preflight: request ~X/Y tokens\", and the post-turn fold / forcing-summary status lines were all hardcoded English in \`src/loop.ts\`. A Chinese user only sees their own typed text in zh-CN — every guardrail message from the loop reverts to English.

The \`loop.*\` i18n namespace had 7 keys defined but **never wired** anywhere — placeholders from a previous i18n attempt that drifted away from the actual call sites. Confirmed with grep: zero callers across \`src/\` and \`tests/\`.

## What

20 new keys covering every user-facing yield in \`step()\`:

| Category | Keys |
|---|---|
| Budget | \`budgetExhausted\`, \`budget80Pct\` |
| Pro arm | \`proArmed\` |
| Iter limit | \`abortedAtIter\`, \`toolBudgetWarning\` |
| Preflight | \`preflightFoldStatus\`, \`preflightFolded\`, \`preflightNoFold\` |
| Escalation | \`flashEscalation\`, \`autoEscalation\` |
| Storm | \`stormStuck\`, \`stormSuppressed\`, \`repeatToolCallWarning\` |
| Compaction | \`compactingHistoryStatus\`, \`aggressiveTag\`, \`foldedHistory\`, \`aggressivelyFoldedHistory\` |
| Status | \`toolUploadStatus\`, \`harvestStatus\`, \`forcingSummary\` |

Plus zh-CN translations for all 20.

The dead keys (\`budgetWarning\`, \`budgetRefusal\`, \`contextWarning\`, \`escalationWarning\`, \`toolFailure\`, \`interrupted\`, \`loopStopped\`) are removed as part of the cleanup. They had zero callers — removing them frees the names without a deprecation period.

## Test plan

- [x] Existing 2301 tests pass — vitest \`setupFiles\` pins runtime to EN, so the English text in assertions still matches
- [x] tsc + biome clean
- [x] No new tests added — these are status-line outputs without dedicated assertions; the i18n flip is structurally identical to #444 which already has dedicated zh-CN runtime-switch tests

## Follow-ups (separate PRs)

- \`src/loop/hook-events.ts\` (\`hookWarnings\` text)
- \`src/loop/branch.ts\`, \`src/loop/messages.ts\`, \`src/loop/force-summary.ts\`
- \`src/cli/ui/App.tsx\` slash command output strings