### PR TITLE
i18n(hooks/summary): localize hook outcome and force-summary text

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -4,6 +4,7 @@ import { spawn } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { t } from "./i18n/index.js";
 
 export type HookEvent = "PreToolUse" | "PostToolUse" | "UserPromptSubmit" | "Stop";
 
@@ -284,9 +285,15 @@ export function formatHookOutcomeMessage(outcome: HookOutcome): string {
     outcome.hook.command.length > 60
       ? `${outcome.hook.command.slice(0, 60)}…`
       : outcome.hook.command;
-  const truncTag = outcome.truncated ? " (output truncated at 256KB)" : "";
-  const head = `hook ${tag} \`${cmd}\` ${outcome.decision}${truncTag}`;
-  return detail ? `${head}: ${detail}` : head;
+  const truncTag = outcome.truncated ? t("hooks.truncated") : "";
+  const decision = t(`hooks.decision${capitalize(outcome.decision)}`);
+  return detail
+    ? t("hooks.headWithDetail", { tag, cmd, decision, truncTag, detail })
+    : t("hooks.head", { tag, cmd, decision, truncTag });
+}
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
 }
 
 export function decideOutcome(

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -321,6 +321,22 @@ export const EN: TranslationSchema = {
     selectFooter: "[↑↓] navigate · [Enter] confirm · [Esc] cancel",
     stepCounter: "Step {step}/{total} · ",
   },
+  hooks: {
+    head: "hook {tag} `{cmd}` {decision}{truncTag}",
+    headWithDetail: "hook {tag} `{cmd}` {decision}{truncTag}: {detail}",
+    truncated: " (output truncated at 256KB)",
+    decisionBlock: "block",
+    decisionWarn: "warn",
+    decisionTimeout: "timeout",
+    decisionError: "error",
+  },
+  summary: {
+    status: "summarizing what was gathered…",
+    hallucinatedFallback:
+      "(model emitted fake tool-call markup instead of a prose summary — try /retry with a narrower question, or /think to inspect R1's reasoning)",
+    failedAfterReason:
+      "{label} and the fallback summary call failed: {message}. Run /clear and retry with a narrower question, or raise --max-tool-iters.",
+  },
   loop: {
     budgetExhausted:
       "session budget exhausted — spent ${spent} ≥ cap ${cap}. Bump the cap with /budget <usd>, clear it with /budget off, or end the session.",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -124,6 +124,20 @@ export interface TranslationSchema {
       unsupported?: string;
     };
   };
+  hooks: {
+    head: string;
+    headWithDetail: string;
+    truncated: string;
+    decisionBlock: string;
+    decisionWarn: string;
+    decisionTimeout: string;
+    decisionError: string;
+  };
+  summary: {
+    status: string;
+    hallucinatedFallback: string;
+    failedAfterReason: string;
+  };
   loop: {
     budgetExhausted: string;
     budget80Pct: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -314,6 +314,22 @@ export const zhCN: TranslationSchema = {
     selectFooter: "[↑↓] 移动 · [Enter] 确认 · [Esc] 取消",
     stepCounter: "步骤 {step}/{total} · ",
   },
+  hooks: {
+    head: "钩子 {tag} `{cmd}` {decision}{truncTag}",
+    headWithDetail: "钩子 {tag} `{cmd}` {decision}{truncTag}：{detail}",
+    truncated: "（输出在 256KB 处截断）",
+    decisionBlock: "拦截",
+    decisionWarn: "告警",
+    decisionTimeout: "超时",
+    decisionError: "错误",
+  },
+  summary: {
+    status: "正在总结已收集的内容…",
+    hallucinatedFallback:
+      "（模型生成了伪造的工具调用标记而非纯文本总结 — 试试 /retry 换个更窄的问题，或 /think 查看 R1 的推理）",
+    failedAfterReason:
+      "{label}，且回退的总结调用也失败：{message}。请运行 /clear 后用更窄的问题重试，或提高 --max-tool-iters。",
+  },
   loop: {
     budgetExhausted:
       "会话预算已用完 — 已花费 ${spent} ≥ 上限 ${cap}。用 /budget <usd> 提高上限，/budget off 清除上限，或结束会话。",

--- a/src/loop/force-summary.ts
+++ b/src/loop/force-summary.ts
@@ -1,4 +1,5 @@
 import { type DeepSeekClient, Usage } from "../client.js";
+import { t } from "../i18n/index.js";
 import type { TurnStats } from "../telemetry/stats.js";
 import type { ChatMessage } from "../types.js";
 import { errorLabelFor, reasonPrefixFor } from "./errors.js";
@@ -24,7 +25,7 @@ export async function* forceSummaryAfterIterLimit(
 ): AsyncGenerator<LoopEvent> {
   try {
     // Status bridges the silence — summary call is non-streaming, 30-60s typical.
-    yield { turn: ctx.turn, role: "status", content: "summarizing what was gathered…" };
+    yield { turn: ctx.turn, role: "status", content: t("summary.status") };
     const messages = ctx.buildMessages();
     // Passing `tools: undefined` was supposed to force a text response,
     // but R1 can still hallucinate tool-call markup (e.g. DSML
@@ -50,9 +51,7 @@ export async function* forceSummaryAfterIterLimit(
     });
     const rawContent = resp.content?.trim() ?? "";
     const cleaned = stripHallucinatedToolMarkup(rawContent);
-    const summary =
-      cleaned ||
-      "(model emitted fake tool-call markup instead of a prose summary — try /retry with a narrower question, or /think to inspect R1's reasoning)";
+    const summary = cleaned || t("summary.hallucinatedFallback");
     const reasonPrefix = reasonPrefixFor(opts.reason, ctx.maxToolIters);
     const annotated = `${reasonPrefix}\n\n${summary}`;
     // Record under the actual model used (flash), so per-turn cost reflects reality.
@@ -72,7 +71,7 @@ export async function* forceSummaryAfterIterLimit(
       turn: ctx.turn,
       role: "error",
       content: "",
-      error: `${label} and the fallback summary call failed: ${(err as Error).message}. Run /clear and retry with a narrower question, or raise --max-tool-iters.`,
+      error: t("summary.failedAfterReason", { label, message: (err as Error).message }),
     };
     yield { turn: ctx.turn, role: "done", content: "" };
   }


### PR DESCRIPTION
## Why

Two small follow-on batches after #445.

**Hook outcomes** were hardcoded — \`hook \${tag} \\`\${cmd}\\` \${decision}\${truncTag}\`. A Chinese user with a failing PreToolUse hook saw \"hook PreToolUse/Bash \`npm test\` block (output truncated at 256KB)\" with all the structural words still in English.

**Force-summary** path had three user-visible strings: the \"summarizing…\" status, the hallucinated-markup fallback, and the post-failure error template.

## What

### \`hooks.*\` namespace
- \`head\` / \`headWithDetail\` — the two output shapes (with / without trailing detail)
- \`truncated\` — \" (output truncated at 256KB)\"
- \`decision{Block,Warn,Timeout,Error}\` — translated verbs

\`tag\` and \`cmd\` are identifiers, kept verbatim. The decision verb is looked up by \`outcome.decision\` (the typed enum) so the formatter input doesn't change.

### \`summary.*\` namespace
- \`status\` — \"summarizing what was gathered…\"
- \`hallucinatedFallback\` — the message when R1 emits fake tool-call markup
- \`failedAfterReason\` — the error template when even the fallback summary call fails

zh-CN translations included for all 10 keys.

## Test plan

- [x] Full suite 2301 pass (no test changes — the format strings flow through existing assertions)
- [x] tsc + biome clean

## Follow-ups

Still on the queue:
- \`src/cli/ui/App.tsx\` slash command outputs (~30 strings — biggest remaining chunk)