### PR TITLE
i18n(slash): localize 4 lagging slash handlers

### DIFF
--- a/src/cli/ui/slash/handlers/mcp.ts
+++ b/src/cli/ui/slash/handlers/mcp.ts
@@ -85,17 +85,15 @@ function toggleDisabled(
 ): { info: string } {
   const name = rawName?.trim();
   if (!name) {
-    return {
-      info: `usage: /mcp ${action} <name>  ·  pick a name shown in /mcp (anonymous servers can't be named-toggled).`,
-    };
+    return { info: t("handlers.mcp.usageDisableEnable", { action }) };
   }
   const known = new Set<string>([
     ...ctx.servers.map((s) => s.label),
     ...ctx.specs.map((spec) => parseLabelFromSpec(spec)).filter((n): n is string => n !== null),
   ]);
   if (!known.has(name)) {
-    const list = [...known].sort().join(", ") || "(none)";
-    return { info: `unknown MCP server "${name}". Known: ${list}.` };
+    const list = [...known].sort().join(", ") || t("handlers.mcp.noneList");
+    return { info: t("handlers.mcp.unknownServer", { name, list }) };
   }
   return { info: toggleMcpDisabled(action, name) };
 }
@@ -113,20 +111,19 @@ function triggerReconnect(
 ): { info: string } {
   const name = rawName?.trim();
   if (!name) {
-    return {
-      info: "usage: /mcp reconnect <name>  ·  pick a name shown in /mcp.",
-    };
+    return { info: t("handlers.mcp.usageReconnect") };
   }
   const target = servers.find((s) => s.label === name);
   if (!target) {
-    const list = servers
-      .map((s) => s.label)
-      .sort()
-      .join(", ");
-    return { info: `unknown MCP server "${name}". Known: ${list || "(none)"}.` };
+    const list =
+      servers
+        .map((s) => s.label)
+        .sort()
+        .join(", ") || t("handlers.mcp.noneList");
+    return { info: t("handlers.mcp.unknownServer", { name, list }) };
   }
   if (!postInfo) {
-    return { info: "/mcp reconnect requires the interactive TUI (postInfo not wired)." };
+    return { info: t("handlers.mcp.reconnectNoTui") };
   }
   // Append-drift accepted automatically: server added new tools, we register them
   // and call addTool on the prefix (cache miss only on the appended chunks per the

--- a/src/cli/ui/slash/handlers/plans.ts
+++ b/src/cli/ui/slash/handlers/plans.ts
@@ -40,10 +40,16 @@ const plans: SlashHandler = (_args, loop) => {
     const when = relativeTime(a.completedAt);
     const total = a.steps.length;
     const done = a.completedStepIds.length;
-    const completion = done >= total ? "complete" : `${done}/${total}`;
+    const completion = done >= total ? t("handlers.plans.completionComplete") : `${done}/${total}`;
     const label = a.summary ?? a.path.split(/[\\/]/).pop() ?? a.path;
     lines.push(
-      `  ✓ ${when.padEnd(10)}  ${total} step${total === 1 ? "" : "s"} · ${completion}  ${label}`,
+      t("handlers.plans.archivedRow", {
+        when: when.padEnd(10),
+        total,
+        s: total === 1 ? "" : "s",
+        completion,
+        label,
+      }),
     );
   }
   return { info: lines.join("\n") };
@@ -83,9 +89,7 @@ const replay: SlashHandler = (args, loop) => {
 
 const stop: SlashHandler = (_args, loop) => {
   loop.abort();
-  return {
-    info: "▸ plan stopped — model aborted; type a follow-up to continue or start a new task.",
-  };
+  return { info: t("handlers.plans.stopAborted") };
 };
 
 export const handlers: Record<string, SlashHandler> = {

--- a/src/cli/ui/slash/handlers/semantic.ts
+++ b/src/cli/ui/slash/handlers/semantic.ts
@@ -2,6 +2,7 @@
 
 import { promises as fs } from "node:fs";
 import path from "node:path";
+import { t as tMain } from "@/i18n/index.js";
 import { probeOllama } from "@/index/semantic/embedding.js";
 import { t } from "@/index/semantic/i18n.js";
 import { findOllamaBinary } from "@/index/semantic/ollama-launcher.js";
@@ -10,9 +11,7 @@ import type { SlashHandler } from "../dispatch.js";
 const semantic: SlashHandler = (_args, _loop, ctx) => {
   const root = ctx.codeRoot;
   if (!root) {
-    return {
-      info: "/semantic is only available inside `reasonix code` (needs a project root).",
-    };
+    return { info: tMain("handlers.semantic.codeOnly") };
   }
   // Fire-and-forget: probes (file stat, optional Ollama HTTP) take
   // ~50–200ms which is too long to block the prompt. Same pattern
@@ -23,7 +22,7 @@ const semantic: SlashHandler = (_args, _loop, ctx) => {
     const status = await renderSemanticStatus(root);
     ctx.postInfo?.(status);
   })();
-  return { info: "▸ checking semantic_search status…" };
+  return { info: tMain("handlers.semantic.checking") };
 };
 
 export async function renderSemanticStatus(rootDir: string): Promise<string> {

--- a/src/cli/ui/slash/handlers/web-search-engine.ts
+++ b/src/cli/ui/slash/handlers/web-search-engine.ts
@@ -1,4 +1,5 @@
 import { readConfig, webSearchEndpoint, webSearchEngine, writeConfig } from "../../../../config.js";
+import { t } from "../../../../i18n/index.js";
 import type { SlashHandler } from "../dispatch.js";
 
 export const handlers: Record<string, SlashHandler> = {
@@ -7,18 +8,18 @@ export const handlers: Record<string, SlashHandler> = {
     if (!engine || (engine !== "mojeek" && engine !== "searxng")) {
       return {
         info: [
-          `Current web search engine: ${webSearchEngine()}`,
-          `SearXNG endpoint: ${webSearchEndpoint()}`,
+          t("handlers.webSearchEngine.currentEngine", { engine: webSearchEngine() }),
+          t("handlers.webSearchEngine.endpoint", { url: webSearchEndpoint() }),
           "",
-          "Usage:",
-          "  /search-engine mojeek            use Mojeek (default, no external deps)",
-          "  /search-engine searxng            use SearXNG at default endpoint",
-          "  /search-engine searxng <url>      use SearXNG at custom endpoint",
+          t("handlers.webSearchEngine.usageHeader"),
+          t("handlers.webSearchEngine.usageMojeek"),
+          t("handlers.webSearchEngine.usageSearxng"),
+          t("handlers.webSearchEngine.usageSearxngUrl"),
           "",
-          "Alias: /se",
+          t("handlers.webSearchEngine.alias"),
           "",
-          "SearXNG is a self-hosted metasearch engine (https://github.com/searxng/searxng).",
-          "Install it with:  docker run -d -p 8080:8080 searxng/searxng",
+          t("handlers.webSearchEngine.searxngInfo"),
+          t("handlers.webSearchEngine.searxngInstall"),
         ].join("\n"),
       };
     }
@@ -31,13 +32,17 @@ export const handlers: Record<string, SlashHandler> = {
     }
     writeConfig(cfg);
 
-    ctx.postInfo?.(
-      `Switched web search engine to "${engine}". ${engine === "searxng" ? `Make sure SearXNG is running at ${webSearchEndpoint()}.` : ""}`,
-    );
+    const note =
+      engine === "searxng"
+        ? t("handlers.webSearchEngine.switchedSearxngNote", { endpoint: webSearchEndpoint() })
+        : "";
+    ctx.postInfo?.(t("handlers.webSearchEngine.switched", { engine, note }));
 
-    return {
-      info: `✓ Web search engine set to "${engine}"${engine === "searxng" ? ` (${webSearchEndpoint()})` : ""}. Next assistant turn will pick up the change.`,
-    };
+    const detail =
+      engine === "searxng"
+        ? t("handlers.webSearchEngine.confirmedDetail", { endpoint: webSearchEndpoint() })
+        : "";
+    return { info: t("handlers.webSearchEngine.confirmed", { engine, detail }) };
   },
   se: (args, loop, ctx) => handlers["search-engine"]!(args, loop, ctx),
 };

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -880,6 +880,10 @@ export const EN: TranslationSchema = {
         "no archived plans yet for this session — `/replay` lights up once a plan completes (auto-archives when every step is done).",
       replayInvalidIndex:
         "invalid index — `/replay` takes 1..{max} (newest = 1). Use `/plans` to see the list.",
+      archivedRow: "  ✓ {when}  {total} step{s} · {completion}  {label}",
+      completionComplete: "complete",
+      stopAborted:
+        "▸ plan stopped — model aborted; type a follow-up to continue or start a new task.",
     },
     jobs: {
       codeOnly: "/jobs is only available inside `reasonix code`.",
@@ -951,6 +955,12 @@ export const EN: TranslationSchema = {
       fallbackServers: "MCP servers ({count}):",
       fallbackTools: "Tools in registry ({count}):",
       fallbackChange: "To change this set, exit and run `reasonix setup`.",
+      usageDisableEnable:
+        "usage: /mcp {action} <name>  ·  pick a name shown in /mcp (anonymous servers can't be named-toggled).",
+      usageReconnect: "usage: /mcp reconnect <name>  ·  pick a name shown in /mcp.",
+      unknownServer: 'unknown MCP server "{name}". Known: {list}.',
+      noneList: "(none)",
+      reconnectNoTui: "/mcp reconnect requires the interactive TUI (postInfo not wired).",
     },
     init: {
       codeOnly:
@@ -960,6 +970,27 @@ export const EN: TranslationSchema = {
       existsEdit: "  Or edit it by hand — it's just markdown. The current file is",
       existsPinned: "  pinned into the system prompt every launch as-is.",
       info: "▸ /init — model will scan the project and synthesize REASONIX.md.\n  The result lands as a pending edit; review with /apply or /walk.",
+    },
+    semantic: {
+      codeOnly: "/semantic is only available inside `reasonix code` (needs a project root).",
+      checking: "▸ checking semantic_search status…",
+    },
+    webSearchEngine: {
+      currentEngine: "Current web search engine: {engine}",
+      endpoint: "SearXNG endpoint: {url}",
+      usageHeader: "Usage:",
+      usageMojeek: "  /search-engine mojeek            use Mojeek (default, no external deps)",
+      usageSearxng: "  /search-engine searxng            use SearXNG at default endpoint",
+      usageSearxngUrl: "  /search-engine searxng <url>      use SearXNG at custom endpoint",
+      alias: "Alias: /se",
+      searxngInfo:
+        "SearXNG is a self-hosted metasearch engine (https://github.com/searxng/searxng).",
+      searxngInstall: "Install it with:  docker run -d -p 8080:8080 searxng/searxng",
+      switched: 'Switched web search engine to "{engine}".{note}',
+      switchedSearxngNote: " Make sure SearXNG is running at {endpoint}.",
+      confirmed:
+        '✓ Web search engine set to "{engine}"{detail}. Next assistant turn will pick up the change.',
+      confirmedDetail: " ({endpoint})",
     },
     skill: {
       listEmpty: "no skills found. Reasonix reads skills from:",

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -814,6 +814,9 @@ export const zhCN: TranslationSchema = {
         "此会话尚无归档计划 — `/replay` 在计划完成后启用（每个步骤完成时自动归档）。",
       replayInvalidIndex:
         "无效索引 — `/replay` 接受 1..{max}（最新 = 1）。使用 `/plans` 查看列表。",
+      archivedRow: "  ✓ {when}  {total}步 · {completion}  {label}",
+      completionComplete: "已完成",
+      stopAborted: "▸ 计划已停止 — 模型已中止；输入后续内容继续，或开始新任务。",
     },
     jobs: {
       codeOnly: "/jobs 仅在 `reasonix code` 中可用。",
@@ -882,6 +885,12 @@ export const zhCN: TranslationSchema = {
       fallbackServers: "MCP 服务器（{count}）：",
       fallbackTools: "注册表中的工具（{count}）：",
       fallbackChange: "要更改此设置，请退出并运行 `reasonix setup`。",
+      usageDisableEnable:
+        "用法：/mcp {action} <name>  ·  从 /mcp 列表中挑一个名字（匿名服务器无法按名切换）。",
+      usageReconnect: "用法：/mcp reconnect <name>  ·  从 /mcp 列表中挑一个名字。",
+      unknownServer: '未知 MCP 服务器 "{name}"。已知：{list}。',
+      noneList: "（无）",
+      reconnectNoTui: "/mcp reconnect 需要交互式 TUI（postInfo 未连接）。",
     },
     init: {
       codeOnly:
@@ -891,6 +900,25 @@ export const zhCN: TranslationSchema = {
       existsEdit: "  或手动编辑 — 它只是 markdown。当前文件已",
       existsPinned: "  固定到每次启动的系统提示词中。",
       info: "▸ /init — 模型将扫描项目并合成 REASONIX.md。\n  结果将作为待处理的编辑；使用 /apply 或 /walk 审查。",
+    },
+    semantic: {
+      codeOnly: "/semantic 仅在 `reasonix code` 中可用（需要项目根目录）。",
+      checking: "▸ 正在检查 semantic_search 状态…",
+    },
+    webSearchEngine: {
+      currentEngine: "当前网页搜索引擎：{engine}",
+      endpoint: "SearXNG 端点：{url}",
+      usageHeader: "用法：",
+      usageMojeek: "  /search-engine mojeek            使用 Mojeek（默认，无外部依赖）",
+      usageSearxng: "  /search-engine searxng            使用 SearXNG 默认端点",
+      usageSearxngUrl: "  /search-engine searxng <url>      使用 SearXNG 自定义端点",
+      alias: "别名：/se",
+      searxngInfo: "SearXNG 是一个自托管的元搜索引擎（https://github.com/searxng/searxng）。",
+      searxngInstall: "安装命令：  docker run -d -p 8080:8080 searxng/searxng",
+      switched: '已切换网页搜索引擎为 "{engine}"。{note}',
+      switchedSearxngNote: " 请确保 SearXNG 在 {endpoint} 运行。",
+      confirmed: '✓ 网页搜索引擎已设为 "{engine}"{detail}。下一轮模型调用将生效。',
+      confirmedDetail: "（{endpoint}）",
     },
     skill: {
       listEmpty: "未找到技能。Reasonix 从以下位置读取技能：",


### PR DESCRIPTION
## Why

Most handler files were already 80%+ i18n'd from prior work, but four files had drift / gaps. Quick survey of \`grep -c 't(\"' src/cli/ui/slash/handlers/*.ts\` flagged the laggers; this PR closes them.

## What

| File | Gap | Fix |
|---|---|---|
| \`web-search-engine.ts\` | **0** t() calls — entire help text + switch confirmation hardcoded | Whole new \`handlers.webSearchEngine\` namespace (~12 keys) |
| \`mcp.ts\` | 5 hardcoded usage / unknown-server / \"(none)\" / reconnect-not-wired strings | Added under \`handlers.mcp\` |
| \`plans.ts\` | Archive row template (\`✓ {when} {N} steps · …\`), \"complete\" verb, /stop abort line | Added under \`handlers.plans\` |
| \`semantic.ts\` | Code-mode-only refusal + \"checking…\" status | Added under \`handlers.semantic\` |

zh-CN translations included for all ~22 new keys.

### Note on \`semantic.ts\`

This file already uses \`t\` from \`@/index/semantic/i18n.js\` for its rich status renderer (slashHeader, slashEnabled, etc.). The new two strings need the **main** \`@/i18n/index\` instead, so I aliased it as \`tMain\` rather than rename the existing \`t\`. Two t() instances side-by-side looks odd but the alternative would have been a 50-line rename.

## Test plan

- [x] Full suite 2301 pass — vitest \`setupFiles\` pins runtime to EN
- [x] tsc + biome clean
- [x] No new tests added — these are status-line outputs without dedicated assertions

## Status of the i18n sweep

After this lands, the surface that was *flagged in the original audit* is fully covered:
1. ✅ \`src/loop/errors.ts\` (#444)
2. ✅ \`src/loop.ts\` yields (#445)
3. ✅ \`src/loop/hook-events.ts\` + \`src/loop/force-summary.ts\` (#446)
4. ✅ \`src/cli/ui/App.tsx\` slash output (#447)
5. ✅ \`src/cli/ui/slash/handlers/*\` (this PR)
6. ✅ Wizard first-launch language picker (#442)
7. ✅ Dashboard plan idle pill (#443)

Plus the 5xx friendly error UX from the original red-apple bug report (#440).

Anything still hardcoded after this is incidental (small-bite next-time fixes), not the systemic class of \"Chinese user sees raw English.\"