### PR TITLE
feat(tools): multi_edit — atomic batch SEARCH/REPLACE in one file

### DIFF
--- a/src/cli/ui/tool-summary.ts
+++ b/src/cli/ui/tool-summary.ts
@@ -118,6 +118,13 @@ function summarizeKnownTool(toolName: string, content: string): ToolSummary | nu
     const bytes = formatBytes(content.length);
     return { summary: `wrote ${lines} · ${bytes}`, isError: false };
   }
+  if (hasSuffix("multi_edit")) {
+    const m = content.match(/applied (\d+) edits? to (\S+)/);
+    if (m) {
+      return { summary: `${m[1]} edit${m[1] === "1" ? "" : "s"} · ${m[2]}`, isError: false };
+    }
+    return { summary: clip(firstNonEmptyLine(content), MAX_SUMMARY_CHARS), isError: false };
+  }
   if (hasSuffix("run_command") || hasSuffix("run_background")) {
     // Native shell tools prepend "exit 0:" / "exit N:" or the result
     // already mentions exit code. Try to surface it.

--- a/src/code/prompt.ts
+++ b/src/code/prompt.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { applyMemoryStack } from "../memory/user.js";
 import { ESCALATION_CONTRACT, TUI_FORMATTING_RULES } from "../prompt-fragments.js";
 
-export const CODE_SYSTEM_PROMPT = `You are Reasonix Code, a coding assistant. You have filesystem tools (read_file, write_file, edit_file, list_directory, directory_tree, search_files, search_content, get_file_info) rooted at the user's working directory, plus run_command / run_background for shell.
+export const CODE_SYSTEM_PROMPT = `You are Reasonix Code, a coding assistant. You have filesystem tools (read_file, write_file, edit_file, multi_edit, list_directory, directory_tree, search_files, search_content, get_file_info) rooted at the user's working directory, plus run_command / run_background for shell.
 
 # Cite or shut up — non-negotiable
 
@@ -54,7 +54,7 @@ Each option: short stable id (A/B/C), one-line title, optional summary. \`allowC
 # Plan mode (/plan)
 
 The user can ALSO enter "plan mode" via /plan, which is a stronger, explicit constraint:
-- Write tools (edit_file, write_file, create_directory, move_file) and non-allowlisted run_command calls are BOUNCED at dispatch — you'll get a tool result like "unavailable in plan mode". Don't retry them.
+- Write tools (edit_file, multi_edit, write_file, create_directory, move_file) and non-allowlisted run_command calls are BOUNCED at dispatch — you'll get a tool result like "unavailable in plan mode". Don't retry them.
 - Read tools (read_file, list_directory, search_files, directory_tree, get_file_info) and allowlisted read-only / test shell commands still work — use them to investigate.
 - You MUST call submit_plan before anything will execute. Approve exits plan mode; Refine stays in; Cancel exits without implementing.
 
@@ -123,6 +123,7 @@ Rules:
     >>>>>>> REPLACE
 - Do NOT use write_file to change existing files — the user reviews your edits as SEARCH/REPLACE. write_file is only for files you explicitly want to overwrite wholesale (rare).
 - Paths are relative to the working directory. Don't use absolute paths.
+- For multi-site changes in ONE file (rename, batched refactor), prefer \`multi_edit\` over N \`edit_file\` calls — it applies all edits atomically in a single call (any failure → no edits written) and saves a round-trip per edit.
 
 # Trust what you already know
 

--- a/src/tools/filesystem.ts
+++ b/src/tools/filesystem.ts
@@ -5,7 +5,7 @@ import * as pathMod from "node:path";
 import picomatch from "picomatch";
 import { DEFAULT_INDEX_EXCLUDES } from "../index/config.js";
 import type { ToolRegistry } from "../tools.js";
-import { applyEdit } from "./fs/edit.js";
+import { applyEdit, applyMultiEdit } from "./fs/edit.js";
 import { searchContent, searchFiles } from "./fs/search.js";
 
 export { lineDiff } from "./fs/edit.js";
@@ -466,6 +466,33 @@ Prefer \`list_directory\` for a single-level view, \`search_files\` to find spec
     },
     fn: async (args: { path: string; search: string; replace: string }) =>
       applyEdit(rootDir, safePath(args.path), args),
+  });
+
+  registry.register({
+    name: "multi_edit",
+    description:
+      "Apply N SEARCH/REPLACE edits to ONE file in a single atomic call. Edits run sequentially against an in-memory buffer (so a later edit can match text inserted by an earlier one), then the file is written once. If ANY edit fails (search not found, ambiguous match, empty search), NO edits are written — the file stays untouched. Same per-edit rules as edit_file: `search` is exact text (whitespace sensitive, no regex) and must be unique at the moment that edit applies. Use this for renames and other multi-site refactors instead of N edit_file round-trips.",
+    parameters: {
+      type: "object",
+      properties: {
+        path: { type: "string" },
+        edits: {
+          type: "array",
+          description: "Edits to apply in order. Length ≥ 1.",
+          items: {
+            type: "object",
+            properties: {
+              search: { type: "string", description: "Exact text to find (must be unique)." },
+              replace: { type: "string", description: "Text to substitute in place of `search`." },
+            },
+            required: ["search", "replace"],
+          },
+        },
+      },
+      required: ["path", "edits"],
+    },
+    fn: async (args: { path: string; edits: Array<{ search: string; replace: string }> }) =>
+      applyMultiEdit(rootDir, safePath(args.path), args.edits),
   });
 
   registry.register({

--- a/src/tools/fs/edit.ts
+++ b/src/tools/fs/edit.ts
@@ -37,6 +37,54 @@ export async function applyEdit(
   return `${header}\n${diff}`;
 }
 
+export async function applyMultiEdit(
+  rootDir: string,
+  abs: string,
+  edits: ReadonlyArray<{ search: string; replace: string }>,
+): Promise<string> {
+  if (edits.length === 0) {
+    throw new Error("multi_edit: edits must contain at least one entry");
+  }
+  const before = await fs.readFile(abs, "utf8");
+  const le = before.includes("\r\n") ? "\r\n" : "\n";
+  const rel = displayRel(rootDir, abs);
+
+  let buf = before;
+  const hunks: string[] = [];
+  let totalDelta = 0;
+
+  for (let i = 0; i < edits.length; i++) {
+    const e = edits[i]!;
+    if (e.search.length === 0) {
+      throw new Error(`multi_edit: edit #${i + 1} search cannot be empty (no edits applied)`);
+    }
+    const adaptedSearch = e.search.replace(/\r?\n/g, le);
+    const adaptedReplace = e.replace.replace(/\r?\n/g, le);
+    const firstIdx = buf.indexOf(adaptedSearch);
+    if (firstIdx < 0) {
+      throw new Error(
+        `multi_edit: edit #${i + 1} search text not found in ${rel} — no edits applied (multi_edit is atomic)`,
+      );
+    }
+    const nextIdx = buf.indexOf(adaptedSearch, firstIdx + 1);
+    if (nextIdx >= 0) {
+      throw new Error(
+        `multi_edit: edit #${i + 1} search text appears multiple times in ${rel} — include more context to disambiguate (no edits applied)`,
+      );
+    }
+    const startLine = buf.slice(0, firstIdx).split(/\r?\n/).length;
+    buf = buf.slice(0, firstIdx) + adaptedReplace + buf.slice(firstIdx + adaptedSearch.length);
+    hunks.push(renderEditDiff(adaptedSearch, adaptedReplace, startLine));
+    totalDelta += adaptedReplace.length - adaptedSearch.length;
+  }
+
+  await fs.writeFile(abs, buf, "utf8");
+  const sign = totalDelta >= 0 ? "+" : "";
+  const noun = edits.length === 1 ? "edit" : "edits";
+  const header = `multi_edit: applied ${edits.length} ${noun} to ${rel} (${sign}${totalDelta} chars)`;
+  return `${header}\n${hunks.join("\n")}`;
+}
+
 function renderEditDiff(search: string, replace: string, startLine: number): string {
   const a = search.split(/\r?\n/);
   const b = replace.split(/\r?\n/);

--- a/tests/filesystem-tools.test.ts
+++ b/tests/filesystem-tools.test.ts
@@ -736,15 +736,107 @@ describe("filesystem tools (built-in, sandbox-enforced)", () => {
   });
 
   describe("allowWriting=false (read-only mode)", () => {
-    it("skips registering write_file / edit_file / create_directory / move_file", async () => {
+    it("skips registering write_file / edit_file / multi_edit / create_directory / move_file", async () => {
       const ro = new ToolRegistry();
       registerFilesystemTools(ro, { rootDir: root, allowWriting: false });
       expect(ro.has("read_file")).toBe(true);
       expect(ro.has("list_directory")).toBe(true);
       expect(ro.has("write_file")).toBe(false);
       expect(ro.has("edit_file")).toBe(false);
+      expect(ro.has("multi_edit")).toBe(false);
       expect(ro.has("create_directory")).toBe(false);
       expect(ro.has("move_file")).toBe(false);
+    });
+  });
+
+  describe("multi_edit (atomic batch SEARCH/REPLACE)", () => {
+    it("applies multiple edits in one call", async () => {
+      await fs.writeFile(join(root, "a.txt"), "alpha\nbeta\ngamma\n");
+      const out = await tools.dispatch(
+        "multi_edit",
+        JSON.stringify({
+          path: "a.txt",
+          edits: [
+            { search: "alpha", replace: "ALPHA" },
+            { search: "gamma", replace: "GAMMA" },
+          ],
+        }),
+      );
+      expect(out).toMatch(/applied 2 edits/);
+      const disk = await fs.readFile(join(root, "a.txt"), "utf8");
+      expect(disk).toBe("ALPHA\nbeta\nGAMMA\n");
+    });
+
+    it("applies edits sequentially — edit 2 can match text inserted by edit 1", async () => {
+      await fs.writeFile(join(root, "a.txt"), "x\n");
+      const out = await tools.dispatch(
+        "multi_edit",
+        JSON.stringify({
+          path: "a.txt",
+          edits: [
+            { search: "x", replace: "x\nINSERTED" },
+            { search: "INSERTED", replace: "REPLACED" },
+          ],
+        }),
+      );
+      expect(out).toMatch(/applied 2 edits/);
+      const disk = await fs.readFile(join(root, "a.txt"), "utf8");
+      expect(disk).toBe("x\nREPLACED\n");
+    });
+
+    it("is atomic: a failing edit leaves the file untouched", async () => {
+      await fs.writeFile(join(root, "a.txt"), "alpha\nbeta\ngamma\n");
+      const out = await tools.dispatch(
+        "multi_edit",
+        JSON.stringify({
+          path: "a.txt",
+          edits: [
+            { search: "alpha", replace: "ALPHA" },
+            { search: "MISSING", replace: "x" },
+          ],
+        }),
+      );
+      expect(out).toMatch(/edit #2/);
+      expect(out).toMatch(/no edits applied/);
+      const disk = await fs.readFile(join(root, "a.txt"), "utf8");
+      expect(disk).toBe("alpha\nbeta\ngamma\n");
+    });
+
+    it("refuses an empty edits array", async () => {
+      await fs.writeFile(join(root, "a.txt"), "x");
+      const out = await tools.dispatch("multi_edit", JSON.stringify({ path: "a.txt", edits: [] }));
+      expect(out).toMatch(/at least one entry/);
+    });
+
+    it("refuses a duplicate match (same as edit_file)", async () => {
+      await fs.writeFile(join(root, "a.txt"), "cat cat\n");
+      const out = await tools.dispatch(
+        "multi_edit",
+        JSON.stringify({
+          path: "a.txt",
+          edits: [{ search: "cat", replace: "dog" }],
+        }),
+      );
+      expect(out).toMatch(/multiple times/);
+      const disk = await fs.readFile(join(root, "a.txt"), "utf8");
+      expect(disk).toBe("cat cat\n");
+    });
+
+    it("matches LF search against a CRLF file and preserves CRLF", async () => {
+      await fs.writeFile(join(root, "a.txt"), "one\r\ntwo\r\nthree\r\n");
+      const out = await tools.dispatch(
+        "multi_edit",
+        JSON.stringify({
+          path: "a.txt",
+          edits: [
+            { search: "one", replace: "ONE" },
+            { search: "three", replace: "THREE" },
+          ],
+        }),
+      );
+      expect(out).toMatch(/applied 2 edits/);
+      const disk = await fs.readFile(join(root, "a.txt"), "utf8");
+      expect(disk).toBe("ONE\r\ntwo\r\nTHREE\r\n");
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds `multi_edit`: applies N SEARCH/REPLACE edits to ONE file in a single atomic call. Sequential against an in-memory buffer, single write at the end. Any failure → file untouched.

Cuts the round-trip cost of multi-site refactors (rename a symbol across 8 occurrences in one file: 1 tool call instead of 8) and removes the half-applied-edit failure mode of looping `edit_file`.

## Design

- Per-edit rules match `edit_file`: exact whitespace-sensitive `search`, must be unique at the moment that edit applies. No regex.
- Edits run **in order**; edit N+1 can match text that edit N inserted (composable refactors).
- Atomic: empty `edits[]`, search not found, or ambiguous match → throws before the write, file is untouched.
- Read-only mode (`allowWriting:false`) skips registration alongside `edit_file` / `write_file` / `move_file` / `create_directory`.
- Plan-mode bouncing is automatic (no `readOnly:true` flag).

## Files

- `src/tools/fs/edit.ts` — `applyMultiEdit`, shares `renderEditDiff` / `lineDiff` with `applyEdit`.
- `src/tools/filesystem.ts` — register the tool next to `edit_file`.
- `src/cli/ui/tool-summary.ts` — surface "N edits · path" in the result chip.
- `src/code/prompt.ts` — list `multi_edit` in the tools intro + a one-line "prefer over N edit_file" nudge in the editing rules.
- `tests/filesystem-tools.test.ts` — 6 new cases (parity with `edit_file` plus atomic / sequential semantics) and read-only-mode assertion updated.

## Why not extend `edit_file` to take an array?

- Back-compat with skills, prompts, and snapshot tests that rely on the existing `{ path, search, replace }` shape.
- Keeps the cheap single-edit path obvious — model can still reach for `edit_file` when there's literally one site.

## Test plan

- [x] `npm run verify` — 2222 pass, 2 skipped (pre-existing)
- [x] 6 new test cases cover: multi-site, sequential composition, atomic-on-failure, empty array refusal, duplicate-match refusal, LF→CRLF preservation
- [x] tsc clean, biome clean (only pre-existing JSX-import-type warnings unchanged)

## Related

Tracks the LSP follow-up at #457 (separate bigger lift).