### PR TITLE
feat(tools): glob, search_content -C context, cross-file multi_edit

### DIFF
--- a/src/code/prompt.ts
+++ b/src/code/prompt.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { applyMemoryStack } from "../memory/user.js";
 import { ESCALATION_CONTRACT, TUI_FORMATTING_RULES } from "../prompt-fragments.js";
 
-export const CODE_SYSTEM_PROMPT = `You are Reasonix Code, a coding assistant. You have filesystem tools (read_file, write_file, edit_file, multi_edit, list_directory, directory_tree, search_files, search_content, get_file_info) rooted at the user's working directory, plus run_command / run_background for shell, plus \`todo_write\` for in-session multi-step tracking.
+export const CODE_SYSTEM_PROMPT = `You are Reasonix Code, a coding assistant. You have filesystem tools (read_file, write_file, edit_file, multi_edit, list_directory, directory_tree, search_files, search_content, glob, get_file_info) rooted at the user's working directory, plus run_command / run_background for shell, plus \`todo_write\` for in-session multi-step tracking.
 
 # Cite or shut up — non-negotiable
 
@@ -136,7 +136,7 @@ Rules:
     >>>>>>> REPLACE
 - Do NOT use write_file to change existing files — the user reviews your edits as SEARCH/REPLACE. write_file is only for files you explicitly want to overwrite wholesale (rare).
 - Paths are relative to the working directory. Don't use absolute paths.
-- For multi-site changes in ONE file (rename, batched refactor), prefer \`multi_edit\` over N \`edit_file\` calls — it applies all edits atomically in a single call (any failure → no edits written) and saves a round-trip per edit.
+- For multi-site changes — same file or across files — prefer \`multi_edit\` over N \`edit_file\` calls. Shape: \`{ edits: [{ path, search, replace }, ...] }\`. All edits validate before any file is written; any failure → ALL files untouched. Per-file edits run in array order, so a later edit can match text inserted by an earlier one.
 
 # Trust what you already know
 
@@ -146,7 +146,7 @@ Before exploring the filesystem to answer a factual question, check whether the 
 
 - Skip dependency, build, and VCS directories unless the user explicitly asks. The pinned .gitignore block (if any, below) is your authoritative denylist.
 - Prefer \`search_files\` over \`list_directory\` when you know roughly what you're looking for — it saves context and avoids enumerating huge trees. Note: \`search_files\` matches file NAMES; for searching file CONTENTS use \`search_content\`.
-- Available exploration tools: \`read_file\`, \`list_directory\`, \`directory_tree\`, \`search_files\` (filename match), \`search_content\` (content grep — use for "where is X called", "find all references to Y"), \`get_file_info\`. Don't call \`grep\` or other tools that aren't in this list — they don't exist as functions.
+- Available exploration tools: \`read_file\`, \`list_directory\`, \`directory_tree\`, \`search_files\` (filename match), \`glob\` (mtime-sorted glob — use for "what changed lately", "all *.ts under src/"), \`search_content\` (content grep — use for "where is X called", "find all references to Y"; pass \`context:N\` for grep -C N around hits), \`get_file_info\`. Don't call \`grep\` or other tools that aren't in this list — they don't exist as functions.
 
 # Path conventions
 

--- a/src/tools/filesystem.ts
+++ b/src/tools/filesystem.ts
@@ -6,6 +6,7 @@ import picomatch from "picomatch";
 import { DEFAULT_INDEX_EXCLUDES } from "../index/config.js";
 import type { ToolRegistry } from "../tools.js";
 import { applyEdit, applyMultiEdit } from "./fs/edit.js";
+import { globFiles } from "./fs/glob.js";
 import { searchContent, searchFiles } from "./fs/search.js";
 
 export { lineDiff } from "./fs/edit.js";
@@ -378,6 +379,11 @@ Prefer \`list_directory\` for a single-level view, \`search_files\` to find spec
           description:
             "When true, also search inside node_modules / .git / dist / build / etc. Off by default — most exploration questions are about the user's own code.",
         },
+        context: {
+          type: "integer",
+          description:
+            "Lines of context to show around each match (both before and after). Default 0 (just the matching line). Capped at 20. Output uses ripgrep style: `:` after the line number on the matching line, `-` on context lines, `--` separating non-adjacent windows.",
+        },
       },
       required: ["pattern"],
     },
@@ -388,6 +394,7 @@ Prefer \`list_directory\` for a single-level view, \`search_files\` to find spec
         glob?: string;
         case_sensitive?: boolean;
         include_deps?: boolean;
+        context?: number;
       },
       toolCtx,
     ) =>
@@ -402,6 +409,58 @@ Prefer \`list_directory\` for a single-level view, \`search_files\` to find spec
         safePath(args.path ?? "."),
         { ...args, signal: toolCtx?.signal },
       ),
+  });
+
+  registry.register({
+    name: "glob",
+    parallelSafe: true,
+    description:
+      "List files matching a glob pattern, sorted by mtime (most-recently-modified first) by default. Use this for 'what changed lately', 'find all *.test.ts', 'all configs under src/'. Glob syntax matches the cross-tool standard: `*` (any chars in one segment), `**` (any segments), `?` (one char), `{a,b}` (alternation). Pattern matches against the path RELATIVE to the search root (e.g. 'src/**/*.ts' from project root). Skips node_modules / .git / dist / build / etc by default. Default limit 200; raise via `limit` (max 1000). Different from `search_files` (substring on basename) and `search_content` (matches inside file contents).",
+    readOnly: true,
+    parameters: {
+      type: "object",
+      properties: {
+        pattern: {
+          type: "string",
+          description: "Glob pattern, e.g. 'src/**/*.ts', '**/*.{md,mdx}', 'tests/*.test.ts'.",
+        },
+        path: {
+          type: "string",
+          description:
+            "Base directory to walk (default: sandbox root). The pattern matches relative to this path.",
+        },
+        sort_by: {
+          type: "string",
+          enum: ["mtime", "name"],
+          description:
+            "Sort order. 'mtime' (default) shows most-recently-modified first — useful for 'what did I change today'. 'name' is alphabetical.",
+        },
+        include_deps: {
+          type: "boolean",
+          description:
+            "When true, also walk node_modules / .git / dist / build / etc. Off by default.",
+        },
+        limit: {
+          type: "integer",
+          description: "Cap on returned matches. Default 200; clamped to [1, 1000].",
+        },
+      },
+      required: ["pattern"],
+    },
+    fn: async (
+      args: {
+        pattern: string;
+        path?: string;
+        sort_by?: "mtime" | "name";
+        include_deps?: boolean;
+        limit?: number;
+      },
+      toolCtx,
+    ) =>
+      globFiles({ rootDir, skipDirNames: SKIP_DIR_NAMES }, safePath(args.path ?? "."), {
+        ...args,
+        signal: toolCtx?.signal,
+      }),
   });
 
   registry.register({
@@ -471,28 +530,40 @@ Prefer \`list_directory\` for a single-level view, \`search_files\` to find spec
   registry.register({
     name: "multi_edit",
     description:
-      "Apply N SEARCH/REPLACE edits to ONE file in a single atomic call. Edits run sequentially against an in-memory buffer (so a later edit can match text inserted by an earlier one), then the file is written once. If ANY edit fails (search not found, ambiguous match, empty search), NO edits are written — the file stays untouched. Same per-edit rules as edit_file: `search` is exact text (whitespace sensitive, no regex) and must be unique at the moment that edit applies. Use this for renames and other multi-site refactors instead of N edit_file round-trips.",
+      "Apply N SEARCH/REPLACE edits across ONE OR MORE files in a single atomic call. Edits run sequentially in array order; for edits that touch the same file, a later edit can match text inserted by an earlier one. If ANY edit fails (search not found, ambiguous match, empty search, file unreadable), NO files are written — atomic at the validation layer. Same per-edit rules as edit_file: `search` is exact text (whitespace sensitive, no regex) and must be unique in its target file at the moment that edit applies. Use this for renames spanning multiple files, cross-file refactors, or any batch where you'd otherwise loop edit_file.",
     parameters: {
       type: "object",
       properties: {
-        path: { type: "string" },
         edits: {
           type: "array",
-          description: "Edits to apply in order. Length ≥ 1.",
+          description: "Edits to apply in order. Length ≥ 1. Each edit names its own target file.",
           items: {
             type: "object",
             properties: {
-              search: { type: "string", description: "Exact text to find (must be unique)." },
+              path: {
+                type: "string",
+                description: "File the edit targets (sandbox-relative or absolute).",
+              },
+              search: {
+                type: "string",
+                description: "Exact text to find (must be unique in the file).",
+              },
               replace: { type: "string", description: "Text to substitute in place of `search`." },
             },
-            required: ["search", "replace"],
+            required: ["path", "search", "replace"],
           },
         },
       },
-      required: ["path", "edits"],
+      required: ["edits"],
     },
-    fn: async (args: { path: string; edits: Array<{ search: string; replace: string }> }) =>
-      applyMultiEdit(rootDir, safePath(args.path), args.edits),
+    fn: async (args: { edits: Array<{ path: string; search: string; replace: string }> }) => {
+      const resolved = (args.edits ?? []).map((e) => ({
+        abs: safePath(e?.path),
+        search: e?.search,
+        replace: e?.replace,
+      }));
+      return applyMultiEdit(rootDir, resolved);
+    },
   });
 
   registry.register({

--- a/src/tools/fs/edit.ts
+++ b/src/tools/fs/edit.ts
@@ -37,52 +37,102 @@ export async function applyEdit(
   return `${header}\n${diff}`;
 }
 
+export interface MultiEditEntry {
+  abs: string;
+  search: string;
+  replace: string;
+}
+
 export async function applyMultiEdit(
   rootDir: string,
-  abs: string,
-  edits: ReadonlyArray<{ search: string; replace: string }>,
+  edits: ReadonlyArray<MultiEditEntry>,
 ): Promise<string> {
   if (edits.length === 0) {
     throw new Error("multi_edit: edits must contain at least one entry");
   }
-  const before = await fs.readFile(abs, "utf8");
-  const le = before.includes("\r\n") ? "\r\n" : "\n";
-  const rel = displayRel(rootDir, abs);
-
-  let buf = before;
-  const hunks: string[] = [];
-  let totalDelta = 0;
+  type FileState = {
+    buf: string;
+    le: string;
+    hunks: string[];
+    deltaChars: number;
+    touched: number;
+  };
+  const filesByPath = new Map<string, FileState>();
 
   for (let i = 0; i < edits.length; i++) {
     const e = edits[i]!;
-    if (e.search.length === 0) {
-      throw new Error(`multi_edit: edit #${i + 1} search cannot be empty (no edits applied)`);
+    if (typeof e.abs !== "string" || e.abs.length === 0) {
+      throw new Error(`multi_edit: edit #${i + 1} requires a string \`path\` (no edits applied)`);
     }
-    const adaptedSearch = e.search.replace(/\r?\n/g, le);
-    const adaptedReplace = e.replace.replace(/\r?\n/g, le);
-    const firstIdx = buf.indexOf(adaptedSearch);
+    if (typeof e.search !== "string") {
+      throw new Error(`multi_edit: edit #${i + 1} requires a string \`search\` (no edits applied)`);
+    }
+    if (typeof e.replace !== "string") {
+      throw new Error(
+        `multi_edit: edit #${i + 1} requires a string \`replace\` (no edits applied)`,
+      );
+    }
+    const rel = displayRel(rootDir, e.abs);
+    if (e.search.length === 0) {
+      throw new Error(
+        `multi_edit: edit #${i + 1} (${rel}) search cannot be empty (no edits applied)`,
+      );
+    }
+    let state = filesByPath.get(e.abs);
+    if (!state) {
+      let before: string;
+      try {
+        before = await fs.readFile(e.abs, "utf8");
+      } catch (err) {
+        throw new Error(
+          `multi_edit: edit #${i + 1} cannot read ${rel}: ${(err as Error).message} (no edits applied)`,
+        );
+      }
+      const le = before.includes("\r\n") ? "\r\n" : "\n";
+      state = { buf: before, le, hunks: [], deltaChars: 0, touched: 0 };
+      filesByPath.set(e.abs, state);
+    }
+    const adaptedSearch = e.search.replace(/\r?\n/g, state.le);
+    const adaptedReplace = e.replace.replace(/\r?\n/g, state.le);
+    const firstIdx = state.buf.indexOf(adaptedSearch);
     if (firstIdx < 0) {
       throw new Error(
         `multi_edit: edit #${i + 1} search text not found in ${rel} — no edits applied (multi_edit is atomic)`,
       );
     }
-    const nextIdx = buf.indexOf(adaptedSearch, firstIdx + 1);
+    const nextIdx = state.buf.indexOf(adaptedSearch, firstIdx + 1);
     if (nextIdx >= 0) {
       throw new Error(
         `multi_edit: edit #${i + 1} search text appears multiple times in ${rel} — include more context to disambiguate (no edits applied)`,
       );
     }
-    const startLine = buf.slice(0, firstIdx).split(/\r?\n/).length;
-    buf = buf.slice(0, firstIdx) + adaptedReplace + buf.slice(firstIdx + adaptedSearch.length);
-    hunks.push(renderEditDiff(adaptedSearch, adaptedReplace, startLine));
-    totalDelta += adaptedReplace.length - adaptedSearch.length;
+    const startLine = state.buf.slice(0, firstIdx).split(/\r?\n/).length;
+    state.buf =
+      state.buf.slice(0, firstIdx) +
+      adaptedReplace +
+      state.buf.slice(firstIdx + adaptedSearch.length);
+    state.hunks.push(`# ${rel}\n${renderEditDiff(adaptedSearch, adaptedReplace, startLine)}`);
+    state.deltaChars += adaptedReplace.length - adaptedSearch.length;
+    state.touched++;
   }
 
-  await fs.writeFile(abs, buf, "utf8");
+  for (const [abs, state] of filesByPath) {
+    await fs.writeFile(abs, state.buf, "utf8");
+  }
+
+  const fileCount = filesByPath.size;
+  const editCount = edits.length;
+  let totalDelta = 0;
+  const allHunks: string[] = [];
+  for (const state of filesByPath.values()) {
+    totalDelta += state.deltaChars;
+    allHunks.push(...state.hunks);
+  }
   const sign = totalDelta >= 0 ? "+" : "";
-  const noun = edits.length === 1 ? "edit" : "edits";
-  const header = `multi_edit: applied ${edits.length} ${noun} to ${rel} (${sign}${totalDelta} chars)`;
-  return `${header}\n${hunks.join("\n")}`;
+  const editNoun = editCount === 1 ? "edit" : "edits";
+  const fileNoun = fileCount === 1 ? "file" : "files";
+  const header = `multi_edit: applied ${editCount} ${editNoun} across ${fileCount} ${fileNoun} (${sign}${totalDelta} chars)`;
+  return `${header}\n${allHunks.join("\n")}`;
 }
 
 function renderEditDiff(search: string, replace: string, startLine: number): string {

--- a/src/tools/fs/glob.ts
+++ b/src/tools/fs/glob.ts
@@ -1,0 +1,82 @@
+import { promises as fs } from "node:fs";
+import * as pathMod from "node:path";
+import picomatch from "picomatch";
+
+export interface GlobContext {
+  rootDir: string;
+  skipDirNames: ReadonlySet<string>;
+}
+
+function displayRel(rootDir: string, full: string): string {
+  return pathMod.relative(rootDir, full).replaceAll("\\", "/");
+}
+
+export async function globFiles(
+  ctx: GlobContext,
+  startAbs: string,
+  args: {
+    pattern: string;
+    sort_by?: "mtime" | "name";
+    include_deps?: boolean;
+    limit?: number;
+    signal?: AbortSignal;
+  },
+): Promise<string> {
+  if (args.signal?.aborted) {
+    throw new DOMException("glob aborted by user", "AbortError");
+  }
+  const includeDeps = args.include_deps === true;
+  const sortBy = args.sort_by ?? "mtime";
+  const limit = Math.max(1, Math.min(1000, Math.floor(args.limit ?? 200)));
+  const isMatch = picomatch(args.pattern, { dot: true, nocase: true });
+
+  const hits: { rel: string; mtimeMs: number }[] = [];
+
+  const walk = async (dir: string): Promise<void> => {
+    if (args.signal?.aborted) {
+      throw new DOMException("glob aborted by user", "AbortError");
+    }
+    let entries: import("node:fs").Dirent[];
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      const full = pathMod.join(dir, e.name);
+      if (e.isDirectory()) {
+        if (!includeDeps && ctx.skipDirNames.has(e.name)) continue;
+        await walk(full);
+        continue;
+      }
+      if (!e.isFile() && !e.isSymbolicLink()) continue;
+      const rel = displayRel(ctx.rootDir, full);
+      if (!isMatch(rel)) continue;
+      let mtimeMs = 0;
+      if (sortBy === "mtime") {
+        try {
+          const st = await fs.stat(full);
+          mtimeMs = st.mtimeMs;
+        } catch {
+          continue;
+        }
+      }
+      hits.push({ rel, mtimeMs });
+    }
+  };
+  await walk(startAbs);
+
+  if (hits.length === 0) return "(no matches)";
+  if (sortBy === "mtime") hits.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  else hits.sort((a, b) => a.rel.localeCompare(b.rel));
+
+  const truncated = hits.length > limit;
+  const shown = hits.slice(0, limit);
+  const lines = shown.map((h) => h.rel);
+  if (truncated) {
+    lines.push(
+      `[… ${hits.length - limit} more matches — refine pattern or raise limit (max 1000) …]`,
+    );
+  }
+  return lines.join("\n");
+}

--- a/src/tools/fs/search.ts
+++ b/src/tools/fs/search.ts
@@ -74,16 +74,14 @@ export async function searchContent(
     pattern: string;
     case_sensitive?: boolean;
     include_deps?: boolean;
+    context?: number;
     signal?: AbortSignal;
   },
 ): Promise<string> {
   throwIfAborted(args.signal);
   const caseSensitive = args.case_sensitive === true;
   const includeDeps = args.include_deps === true;
-  // Try the pattern as a regex first (lets the model say `\bdispatch\(`
-  // for a word-bounded match); fall back to literal substring on
-  // invalid regex. No `g` flag — we test once per line, so global
-  // statefulness (lastIndex tracking) would just be noise.
+  const ctxLines = Math.max(0, Math.min(20, Math.floor(args.context ?? 0)));
   let re: RegExp | null = null;
   try {
     re = new RegExp(args.pattern, caseSensitive ? "" : "i");
@@ -95,6 +93,17 @@ export async function searchContent(
   let totalBytes = 0;
   let scanned = 0;
   let truncated = false;
+
+  const pushLine = (out: string): boolean => {
+    if (totalBytes + out.length + 1 > ctx.maxListBytes) {
+      matches.push(`[… truncated at ${ctx.maxListBytes} bytes — refine pattern or path …]`);
+      truncated = true;
+      return false;
+    }
+    matches.push(out);
+    totalBytes += out.length + 1;
+    return true;
+  };
 
   const walk = async (dir: string): Promise<void> => {
     if (truncated) return;
@@ -117,8 +126,6 @@ export async function searchContent(
       const full = pathMod.join(dir, e.name);
       if (ctx.nameMatch && !ctx.nameMatch(e.name, displayRel(ctx.rootDir, full))) continue;
       if (ctx.isBinaryByName(e.name)) continue;
-      // Open once and reuse the fd so the size check and read bind to the
-      // same inode — avoids the stat→readFile TOCTOU race CodeQL flags.
       let fh: import("node:fs/promises").FileHandle;
       try {
         fh = await fs.open(full, "r");
@@ -129,9 +136,6 @@ export async function searchContent(
       try {
         throwIfAborted(args.signal);
         const st = await fh.stat();
-        // Per-file size cap so a 50MB log doesn't dominate the search.
-        // Anything legitimately interesting fits in 2 MB; bigger files
-        // are usually data dumps or generated bundles.
         if (st.size > 2 * 1024 * 1024) {
           await fh.close();
           continue;
@@ -143,30 +147,48 @@ export async function searchContent(
       }
       await fh.close();
       throwIfAborted(args.signal);
-      // Content-based binary sniff: NUL byte in the first 8KB. Catches
-      // binaries with .json or .txt extensions (yes, this happens).
       const firstNul = raw.indexOf(0);
       if (firstNul !== -1 && firstNul < 8 * 1024) continue;
       const text = raw.toString("utf8");
       const rel = displayRel(ctx.rootDir, full);
       const lines = text.split(/\r?\n/);
+      const hits: number[] = [];
       for (let li = 0; li < lines.length; li++) {
         throwIfAborted(args.signal);
         const line = lines[li]!;
         const lineForCheck = caseSensitive ? line : line.toLowerCase();
         const hit = re ? re.test(line) : lineForCheck.includes(needle);
-        if (!hit) continue;
-        const display = line.length > 200 ? `${line.slice(0, 200)}…` : line;
-        const out = `${rel}:${li + 1}: ${display}`;
-        if (totalBytes + out.length + 1 > ctx.maxListBytes) {
-          matches.push(`[… truncated at ${ctx.maxListBytes} bytes — refine pattern or path …]`);
-          truncated = true;
-          return;
-        }
-        matches.push(out);
-        totalBytes += out.length + 1;
+        if (hit) hits.push(li);
       }
       scanned++;
+      if (hits.length === 0) continue;
+      if (ctxLines === 0) {
+        for (const li of hits) {
+          if (truncated) return;
+          const line = lines[li]!;
+          const display = line.length > 200 ? `${line.slice(0, 200)}…` : line;
+          if (!pushLine(`${rel}:${li + 1}: ${display}`)) return;
+        }
+        continue;
+      }
+      const hitSet = new Set(hits);
+      let prevWindowEnd = -2;
+      for (const li of hits) {
+        if (truncated) return;
+        const winStart = Math.max(0, li - ctxLines);
+        const winEnd = Math.min(lines.length - 1, li + ctxLines);
+        if (winStart > prevWindowEnd + 1 && prevWindowEnd >= 0) {
+          if (!pushLine("--")) return;
+        }
+        const realStart = winStart > prevWindowEnd + 1 ? winStart : prevWindowEnd + 1;
+        for (let i = realStart; i <= winEnd; i++) {
+          const line = lines[i]!;
+          const display = line.length > 200 ? `${line.slice(0, 200)}…` : line;
+          const sep = hitSet.has(i) ? ":" : "-";
+          if (!pushLine(`${rel}:${i + 1}${sep} ${display}`)) return;
+        }
+        prevWindowEnd = winEnd;
+      }
     }
   };
   await walk(startAbs);

--- a/tests/filesystem-tools.test.ts
+++ b/tests/filesystem-tools.test.ts
@@ -741,6 +741,7 @@ describe("filesystem tools (built-in, sandbox-enforced)", () => {
       registerFilesystemTools(ro, { rootDir: root, allowWriting: false });
       expect(ro.has("read_file")).toBe(true);
       expect(ro.has("list_directory")).toBe(true);
+      expect(ro.has("glob")).toBe(true);
       expect(ro.has("write_file")).toBe(false);
       expect(ro.has("edit_file")).toBe(false);
       expect(ro.has("multi_edit")).toBe(false);
@@ -749,72 +750,86 @@ describe("filesystem tools (built-in, sandbox-enforced)", () => {
     });
   });
 
-  describe("multi_edit (atomic batch SEARCH/REPLACE)", () => {
-    it("applies multiple edits in one call", async () => {
+  describe("multi_edit (atomic batch SEARCH/REPLACE, single-file and cross-file)", () => {
+    it("applies multiple edits to one file in one call", async () => {
       await fs.writeFile(join(root, "a.txt"), "alpha\nbeta\ngamma\n");
       const out = await tools.dispatch(
         "multi_edit",
         JSON.stringify({
-          path: "a.txt",
           edits: [
-            { search: "alpha", replace: "ALPHA" },
-            { search: "gamma", replace: "GAMMA" },
+            { path: "a.txt", search: "alpha", replace: "ALPHA" },
+            { path: "a.txt", search: "gamma", replace: "GAMMA" },
           ],
         }),
       );
-      expect(out).toMatch(/applied 2 edits/);
+      expect(out).toMatch(/applied 2 edits across 1 file/);
       const disk = await fs.readFile(join(root, "a.txt"), "utf8");
       expect(disk).toBe("ALPHA\nbeta\nGAMMA\n");
     });
 
-    it("applies edits sequentially — edit 2 can match text inserted by edit 1", async () => {
+    it("applies edits sequentially per file — edit 2 can match text inserted by edit 1", async () => {
       await fs.writeFile(join(root, "a.txt"), "x\n");
       const out = await tools.dispatch(
         "multi_edit",
         JSON.stringify({
-          path: "a.txt",
           edits: [
-            { search: "x", replace: "x\nINSERTED" },
-            { search: "INSERTED", replace: "REPLACED" },
+            { path: "a.txt", search: "x", replace: "x\nINSERTED" },
+            { path: "a.txt", search: "INSERTED", replace: "REPLACED" },
           ],
         }),
       );
-      expect(out).toMatch(/applied 2 edits/);
+      expect(out).toMatch(/applied 2 edits across 1 file/);
       const disk = await fs.readFile(join(root, "a.txt"), "utf8");
       expect(disk).toBe("x\nREPLACED\n");
     });
 
-    it("is atomic: a failing edit leaves the file untouched", async () => {
-      await fs.writeFile(join(root, "a.txt"), "alpha\nbeta\ngamma\n");
+    it("applies edits across multiple files in one atomic call", async () => {
+      await fs.writeFile(join(root, "a.txt"), "alpha\n");
+      await fs.writeFile(join(root, "b.txt"), "bravo\n");
       const out = await tools.dispatch(
         "multi_edit",
         JSON.stringify({
-          path: "a.txt",
           edits: [
-            { search: "alpha", replace: "ALPHA" },
-            { search: "MISSING", replace: "x" },
+            { path: "a.txt", search: "alpha", replace: "ALPHA" },
+            { path: "b.txt", search: "bravo", replace: "BRAVO" },
+          ],
+        }),
+      );
+      expect(out).toMatch(/applied 2 edits across 2 files/);
+      expect(await fs.readFile(join(root, "a.txt"), "utf8")).toBe("ALPHA\n");
+      expect(await fs.readFile(join(root, "b.txt"), "utf8")).toBe("BRAVO\n");
+    });
+
+    it("is atomic across files: a single failure leaves ALL files untouched", async () => {
+      await fs.writeFile(join(root, "a.txt"), "alpha\n");
+      await fs.writeFile(join(root, "b.txt"), "bravo\n");
+      const out = await tools.dispatch(
+        "multi_edit",
+        JSON.stringify({
+          edits: [
+            { path: "a.txt", search: "alpha", replace: "ALPHA" },
+            { path: "b.txt", search: "MISSING", replace: "x" },
           ],
         }),
       );
       expect(out).toMatch(/edit #2/);
       expect(out).toMatch(/no edits applied/);
-      const disk = await fs.readFile(join(root, "a.txt"), "utf8");
-      expect(disk).toBe("alpha\nbeta\ngamma\n");
+      expect(await fs.readFile(join(root, "a.txt"), "utf8")).toBe("alpha\n");
+      expect(await fs.readFile(join(root, "b.txt"), "utf8")).toBe("bravo\n");
     });
 
     it("refuses an empty edits array", async () => {
       await fs.writeFile(join(root, "a.txt"), "x");
-      const out = await tools.dispatch("multi_edit", JSON.stringify({ path: "a.txt", edits: [] }));
+      const out = await tools.dispatch("multi_edit", JSON.stringify({ edits: [] }));
       expect(out).toMatch(/at least one entry/);
     });
 
-    it("refuses a duplicate match (same as edit_file)", async () => {
+    it("refuses a duplicate match (same rules as edit_file)", async () => {
       await fs.writeFile(join(root, "a.txt"), "cat cat\n");
       const out = await tools.dispatch(
         "multi_edit",
         JSON.stringify({
-          path: "a.txt",
-          edits: [{ search: "cat", replace: "dog" }],
+          edits: [{ path: "a.txt", search: "cat", replace: "dog" }],
         }),
       );
       expect(out).toMatch(/multiple times/);
@@ -827,16 +842,147 @@ describe("filesystem tools (built-in, sandbox-enforced)", () => {
       const out = await tools.dispatch(
         "multi_edit",
         JSON.stringify({
-          path: "a.txt",
           edits: [
-            { search: "one", replace: "ONE" },
-            { search: "three", replace: "THREE" },
+            { path: "a.txt", search: "one", replace: "ONE" },
+            { path: "a.txt", search: "three", replace: "THREE" },
           ],
         }),
       );
       expect(out).toMatch(/applied 2 edits/);
       const disk = await fs.readFile(join(root, "a.txt"), "utf8");
       expect(disk).toBe("ONE\r\ntwo\r\nTHREE\r\n");
+    });
+
+    it("refuses when an edit references a non-existent file (atomic — no other files written)", async () => {
+      await fs.writeFile(join(root, "a.txt"), "alpha\n");
+      const out = await tools.dispatch(
+        "multi_edit",
+        JSON.stringify({
+          edits: [
+            { path: "a.txt", search: "alpha", replace: "ALPHA" },
+            { path: "missing.txt", search: "anything", replace: "x" },
+          ],
+        }),
+      );
+      expect(out).toMatch(/cannot read/i);
+      expect(await fs.readFile(join(root, "a.txt"), "utf8")).toBe("alpha\n");
+    });
+  });
+
+  describe("glob — mtime-sorted file listing", () => {
+    it("returns matching files (default mtime desc)", async () => {
+      const fileA = join(root, "a.ts");
+      const fileB = join(root, "b.ts");
+      await fs.writeFile(fileA, "// a");
+      await fs.writeFile(fileB, "// b");
+      const past = new Date(Date.now() - 60_000);
+      await fs.utimes(fileA, past, past);
+      const out = await tools.dispatch("glob", JSON.stringify({ pattern: "*.ts" }));
+      const lines = out.split("\n").filter((l) => l.trim());
+      expect(lines).toContain("a.ts");
+      expect(lines).toContain("b.ts");
+      expect(lines.indexOf("b.ts")).toBeLessThan(lines.indexOf("a.ts"));
+    });
+
+    it("supports ** for recursive walks", async () => {
+      const out = await tools.dispatch("glob", JSON.stringify({ pattern: "src/**/*.ts" }));
+      expect(out).toContain("src/index.ts");
+      expect(out).toContain("src/util.ts");
+    });
+
+    it("name sort is alphabetical", async () => {
+      await fs.writeFile(join(root, "z.ts"), "z");
+      await fs.writeFile(join(root, "a.ts"), "a");
+      const out = await tools.dispatch(
+        "glob",
+        JSON.stringify({ pattern: "*.ts", sort_by: "name" }),
+      );
+      const lines = out.split("\n").filter((l) => l.trim());
+      expect(lines.indexOf("a.ts")).toBeLessThan(lines.indexOf("z.ts"));
+    });
+
+    it("skips node_modules / .git by default", async () => {
+      await fs.mkdir(join(root, "node_modules"), { recursive: true });
+      await fs.writeFile(join(root, "node_modules", "lib.ts"), "x");
+      const out = await tools.dispatch("glob", JSON.stringify({ pattern: "**/*.ts" }));
+      expect(out).not.toContain("node_modules/lib.ts");
+    });
+
+    it("returns (no matches) when nothing matches", async () => {
+      const out = await tools.dispatch("glob", JSON.stringify({ pattern: "**/*.nope-extension" }));
+      expect(out).toMatch(/no matches/);
+    });
+
+    it("respects `limit` and reports overflow", async () => {
+      for (let i = 0; i < 5; i++) {
+        await fs.writeFile(join(root, `f${i}.tmp`), String(i));
+      }
+      const out = await tools.dispatch("glob", JSON.stringify({ pattern: "*.tmp", limit: 2 }));
+      const lines = out.split("\n").filter((l) => l.trim());
+      expect(lines.length).toBe(3);
+      expect(lines[lines.length - 1]).toMatch(/3 more matches/);
+    });
+  });
+
+  describe("search_content — context lines (-A/-B/-C semantics)", () => {
+    it("returns just the hit when context is omitted (default 0)", async () => {
+      await fs.writeFile(
+        join(root, "ctx.txt"),
+        ["one", "two", "TARGET", "four", "five"].join("\n"),
+      );
+      const out = await tools.dispatch(
+        "search_content",
+        JSON.stringify({ pattern: "TARGET", glob: "ctx.txt" }),
+      );
+      expect(out).toContain("ctx.txt:3: TARGET");
+      expect(out).not.toContain("ctx.txt:2");
+      expect(out).not.toContain("ctx.txt:4");
+    });
+
+    it("includes N lines before and after with `context:N`", async () => {
+      await fs.writeFile(
+        join(root, "ctx.txt"),
+        ["one", "two", "TARGET", "four", "five"].join("\n"),
+      );
+      const out = await tools.dispatch(
+        "search_content",
+        JSON.stringify({ pattern: "TARGET", glob: "ctx.txt", context: 1 }),
+      );
+      expect(out).toContain("ctx.txt:2- two");
+      expect(out).toContain("ctx.txt:3: TARGET");
+      expect(out).toContain("ctx.txt:4- four");
+      expect(out).not.toContain("ctx.txt:1-");
+      expect(out).not.toContain("ctx.txt:5-");
+    });
+
+    it("merges overlapping windows for adjacent hits and uses -- between non-adjacent windows", async () => {
+      await fs.writeFile(
+        join(root, "ctx.txt"),
+        ["zero", "HIT", "two", "three", "four", "HIT", "six", "seven"].join("\n"),
+      );
+      const out = await tools.dispatch(
+        "search_content",
+        JSON.stringify({ pattern: "HIT", glob: "ctx.txt", context: 1 }),
+      );
+      expect(out.match(/ctx\.txt:2: HIT/g)?.length).toBe(1);
+      expect(out.match(/ctx\.txt:6: HIT/g)?.length).toBe(1);
+      expect(out).toContain("--");
+    });
+
+    it("clamps `context` at 20", async () => {
+      await fs.writeFile(
+        join(root, "ctx.txt"),
+        Array.from({ length: 100 }, (_, i) => (i === 49 ? "TARGET" : `line ${i + 1}`)).join("\n"),
+      );
+      const out = await tools.dispatch(
+        "search_content",
+        JSON.stringify({ pattern: "TARGET", glob: "ctx.txt", context: 999 }),
+      );
+      expect(out).toContain("ctx.txt:50: TARGET");
+      expect(out).toContain("ctx.txt:30- line 30");
+      expect(out).toContain("ctx.txt:70- line 70");
+      expect(out).not.toMatch(/ctx\.txt:29-\s/);
+      expect(out).not.toMatch(/ctx\.txt:71-\s/);
     });
   });
 });


### PR DESCRIPTION
## Summary

Three filesystem-toolbelt polishes bundled together. Each fixes a sharp edge the model hits often; together they take the toolbelt from "works" to "fluent."

### 1. `glob` — new tool

Mtime-sorted file walk with picomatch glob syntax (`**/`, `*.{ts,tsx}`, etc.). Defaults to `sort: "mtime"` (most-recently-modified first) so "what did I touch lately" works without arguments. `sort: "name"` for deterministic listings. Skips deps by default, capped at 200 (1000 max) with overflow notice.

Distinct from existing tools:
- `search_files` — substring on basename
- `search_content` — greps file bodies
- `directory_tree` — full tree view, structural

### 2. `search_content` context lines

New `context: N` param, semantics match `grep -C N`. Output uses ripgrep convention: `:` after line number on hits, `-` on context lines, `--` between non-adjacent windows. Adjacent windows merge automatically. Capped at 20 each side to keep `maxListBytes` honest.

Why: today the model has to read whole files just to see what's around a grep hit. Now one call gives the hit + neighborhood.

### 3. `multi_edit` — cross-file

Schema change: from `{ path, edits: [{ search, replace }, ...] }` to `{ edits: [{ path, search, replace }, ...] }`.

- Reads each touched file once.
- Applies edits in array order against in-memory buffers (a later edit can still match text inserted by an earlier edit on the same file).
- Validates every edit before writing anything. Any failure → zero writes (atomic at the validation layer; sequential disk writes after that).
- Header now reports `applied N edits across M files`.

This is a hard schema break for `multi_edit`. It shipped unreleased six hours ago — no downstream consumers to migrate.

## Files

- `src/tools/fs/glob.ts` — new
- `src/tools/fs/search.ts` — context windowing
- `src/tools/fs/edit.ts` — `applyMultiEdit` reshape
- `src/tools/filesystem.ts` — `glob` registration, `multi_edit` new schema, `search_content` `context` param
- `src/code/prompt.ts` — tool intro updated, multi_edit usage rewrite, exploration paragraph mentions `glob` + `context:N`
- `tests/filesystem-tools.test.ts` — 17 new cases (glob: 6, context: 4, multi_edit cross-file: 7)

## Test plan

- [x] `npm run verify` — 2243 pass / 2 skipped (pre-existing)
- [x] tsc clean, biome clean (only pre-existing JSX import-type warnings unchanged)
- [x] Manual sanity: glob `**/*.ts` returns expected mtime-desc order; `search_content … context:2` produces ripgrep-style output

## Out of scope

- `multi_edit` doesn't go through the review-mode interceptor today (interceptor only checks `edit_file` / `write_file`). This was true before this PR too. Tracking separately.
- LSP-style symbol nav still in #457.