### PR TITLE
fix(ux): fuzzy at-mention ranking + /cwd slash (#459 parts 1+2)

### DIFF
--- a/src/at-mentions.ts
+++ b/src/at-mentions.ts
@@ -274,15 +274,25 @@ export function rankPickerCandidates(
   for (const e of entries) {
     const lower = e.path.toLowerCase();
     const hit = lower.indexOf(needle);
-    if (hit < 0) continue;
-    const slash = lower.lastIndexOf("/");
-    const base = slash >= 0 ? lower.slice(slash + 1) : lower;
-    let score = 2;
-    if (base.startsWith(needle)) score = 0;
-    else if (lower.startsWith(needle)) score = 1;
+    if (hit >= 0) {
+      const slash = lower.lastIndexOf("/");
+      const base = slash >= 0 ? lower.slice(slash + 1) : lower;
+      let cls = 2;
+      if (base.startsWith(needle)) cls = 0;
+      else if (lower.startsWith(needle)) cls = 1;
+      scored.push({
+        path: e.path,
+        score: cls * 10_000 + Math.min(hit, 9999),
+        mtimeMs: e.mtimeMs,
+        recent: recent.has(e.path),
+      });
+      continue;
+    }
+    const fuzzy = fuzzySubseqScore(needle, lower);
+    if (fuzzy === null) continue;
     scored.push({
       path: e.path,
-      score: score * 10_000 + hit,
+      score: 30_000 + fuzzy,
       mtimeMs: e.mtimeMs,
       recent: recent.has(e.path),
     });
@@ -294,6 +304,29 @@ export function rankPickerCandidates(
     return b.mtimeMs - a.mtimeMs;
   });
   return scored.slice(0, limit).map((s) => s.path);
+}
+
+function fuzzySubseqScore(needle: string, target: string): number | null {
+  if (needle.length === 0) return 0;
+  const slashIdx = target.lastIndexOf("/");
+  const basenameStart = slashIdx >= 0 ? slashIdx + 1 : 0;
+  let qi = 0;
+  let lastMatchIdx = -2;
+  let consecutive = 0;
+  let basenameMatches = 0;
+  let totalGap = 0;
+  for (let ti = 0; ti < target.length && qi < needle.length; ti++) {
+    if (target[ti] !== needle[qi]) continue;
+    if (ti === lastMatchIdx + 1) consecutive++;
+    else if (lastMatchIdx >= 0) totalGap += ti - lastMatchIdx - 1;
+    if (ti >= basenameStart) basenameMatches++;
+    lastMatchIdx = ti;
+    qi++;
+  }
+  if (qi < needle.length) return null;
+  const quality = Math.max(0, totalGap - consecutive * 10 - basenameMatches * 5);
+  const lengthPenalty = Math.floor(target.length / 4);
+  return quality + lengthPenalty;
 }
 
 /** Word-boundary anchor rejects `@` embedded in emails / social handles; trailing `.` stripped before lookup. */

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -1,4 +1,5 @@
-import type { WriteStream } from "node:fs";
+import { type WriteStream, statSync } from "node:fs";
+import { resolve } from "node:path";
 import { Box, Text, useStdout } from "ink";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -405,9 +406,9 @@ function AppInner({
   // the workspace mid-session; the prop `codeMode.rootDir` stays as
   // the original launch root so it can't accidentally drift (it's
   // used purely for "is this a code-mode session?" checks now).
-  // Initial-only — no setter exists, so this is effectively a const captured
-  // at first mount. Kept as state for future `/cwd` mid-session retargeting.
-  const [currentRootDir] = useState<string>(() => codeMode?.rootDir ?? process.cwd());
+  const [currentRootDir, setCurrentRootDir] = useState<string>(
+    () => codeMode?.rootDir ?? process.cwd(),
+  );
   // Loaded user hooks (project + global settings.json). Stays mutable
   // so `/hooks reload` and `/cwd` can rescan disk without
   // reconstructing the loop. The loop holds a parallel reference for
@@ -2209,6 +2210,25 @@ function AppInner({
             setHookList(fresh);
             return fresh.length;
           },
+          switchCwd: codeMode?.reregisterTools
+            ? (newPath: string) => {
+                const resolved = resolve(newPath);
+                let stat: ReturnType<typeof statSync>;
+                try {
+                  stat = statSync(resolved);
+                } catch (err) {
+                  return { ok: false, info: `/cwd: ${(err as Error).message}` };
+                }
+                if (!stat.isDirectory()) {
+                  return { ok: false, info: `/cwd: ${resolved} is not a directory` };
+                }
+                codeMode.reregisterTools?.(resolved);
+                setCurrentRootDir(resolved);
+                const fresh = loadHooks({ projectRoot: resolved });
+                setHookList(fresh);
+                return { ok: true, info: `▸ workspace switched to ${resolved}` };
+              }
+            : undefined,
           reloadMcp: mcpRuntime
             ? async () => {
                 const r = await mcpRuntime.reloadFromConfig(loop);

--- a/src/cli/ui/slash/commands.ts
+++ b/src/cli/ui/slash/commands.ts
@@ -181,6 +181,15 @@ export const SLASH_COMMANDS: readonly SlashCommandSpec[] = [
     summary: "roll back files to a named checkpoint (see /checkpoint list)",
     contextual: "code",
   },
+  {
+    cmd: "cwd",
+    group: "code",
+    argsHint: "<path>",
+    summary:
+      "switch the workspace root mid-session — re-points fs / shell / memory tools, reloads project hooks, refreshes the at-mention walker",
+    contextual: "code",
+    aliases: ["sandbox"],
+  },
 
   {
     cmd: "jobs",

--- a/src/cli/ui/slash/handlers/edits.ts
+++ b/src/cli/ui/slash/handlers/edits.ts
@@ -240,6 +240,23 @@ const restore: SlashHandler = (args, _loop, ctx) => {
   return { info: lines.join("\n") };
 };
 
+const cwd: SlashHandler = (args, _loop, ctx) => {
+  if (!ctx.switchCwd) {
+    return { info: t("handlers.edits.cwdCodeOnly") };
+  }
+  const target = args.join(" ").trim();
+  if (!target) {
+    return {
+      info:
+        ctx.codeRoot != null
+          ? t("handlers.edits.cwdUsage", { current: ctx.codeRoot })
+          : t("handlers.edits.cwdUsageNoCurrent"),
+    };
+  }
+  const result = ctx.switchCwd(stripOuterQuotes(target));
+  return { info: result.info };
+};
+
 export const handlers: Record<string, SlashHandler> = {
   undo,
   history,
@@ -252,4 +269,5 @@ export const handlers: Record<string, SlashHandler> = {
   walk,
   checkpoint,
   restore,
+  cwd,
 };

--- a/src/cli/ui/slash/types.ts
+++ b/src/cli/ui/slash/types.ts
@@ -95,6 +95,8 @@ export interface SlashContext {
   setPlanMode?: (on: boolean) => void;
 
   reloadHooks?: () => number;
+  /** Switch the workspace root mid-session — re-targets filesystem/shell/memory tools, hooks, at-mention walker. Code mode only. */
+  switchCwd?: (newPath: string) => { ok: boolean; info: string };
   /** Diff config.mcp[] vs live bridges → add/close clients accordingly. Wired from chat.tsx mcpRuntime. */
   reloadMcp?: () => Promise<{
     added: string[];

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -554,6 +554,10 @@ export const EN: TranslationSchema = {
       restoreWrote: "  · wrote back {count} file{s}",
       restoreRemoved: "  · removed {count} file{s} (didn't exist at checkpoint time)",
       restoreSkipped: "  ✗ {count} file{s} skipped:",
+      cwdCodeOnly: "/cwd is only available inside `reasonix code`.",
+      cwdUsage:
+        "usage: /cwd <path>   (current root: {current}). Re-points filesystem / shell / memory tools to <path>.",
+      cwdUsageNoCurrent: "usage: /cwd <path>   re-points the workspace root to <path>.",
     },
     model: {
       modelHint: "try deepseek-v4-flash or deepseek-v4-pro — run /models to fetch the live list",

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -524,6 +524,10 @@ export const zhCN: TranslationSchema = {
       restoreWrote: "  · 写回了 {count} 个文件",
       restoreRemoved: "  · 移除了 {count} 个文件（检查点时不存在）",
       restoreSkipped: "  ✗ 跳过了 {count} 个文件：",
+      cwdCodeOnly: "/cwd 仅在 `reasonix code` 中可用。",
+      cwdUsage:
+        "用法：/cwd <path>   （当前根目录：{current}）。重新指向 filesystem / shell / memory 工具到 <path>。",
+      cwdUsageNoCurrent: "用法：/cwd <path>   将工作区根目录切换到 <path>。",
     },
     model: {
       modelHint: "尝试 deepseek-v4-flash 或 deepseek-v4-pro — 运行 /models 获取实时列表",

--- a/tests/at-mentions.test.ts
+++ b/tests/at-mentions.test.ts
@@ -311,6 +311,40 @@ describe("rankPickerCandidates", () => {
     expect(r[2]).toBe("b.ts");
   });
 
+  it("fuzzy-subsequence-matches when no substring hits — typed acronyms find the file", () => {
+    // `atmnt` isn't a substring of any path, but is a subsequence of
+    // `at-mentions`. Today's prefix-only ranker would drop it; fuzzy
+    // fallback should surface both at-mentions paths.
+    const r = rankPickerCandidates(files, "atmnt");
+    expect(r).toContain("src/at-mentions.ts");
+    expect(r).toContain("tests/at-mentions.test.ts");
+  });
+
+  it("substring hits still rank above fuzzy-subsequence hits", () => {
+    // `loop` is a substring of "src/loop.ts" (class 2) and
+    // "tests/loop.test.ts" (class 2). It's a subsequence of a few
+    // others (e.g. "src/cli/ui/PromptInput.tsx" has l-o-..-p? actually
+    // no `l` then `o` then `o` then `p` — "PromptInput" is P-r-o-m-p-t,
+    // no subsequence). Use a query that matches both substring and
+    // subsequence to verify substring wins:
+    //   `app` → substring hit on "src/cli/ui/App.tsx" (case-insensitive)
+    //         + subseq match on "src/at-mentions.ts" (a-..-p? no `p`).
+    // Simpler: just ensure all results for `loop` are substring hits
+    // (the only two such files), and nothing fuzzy snuck above.
+    const r = rankPickerCandidates(files, "loop");
+    expect(r[0]).toMatch(/loop/);
+    expect(r[1]).toMatch(/loop/);
+  });
+
+  it("clusters of consecutive subsequence chars rank above scattered ones", () => {
+    const candidates = [
+      "src/a/b/c/d/e/things.ts", // `thgs` scattered as subseq with gaps
+      "src/things.ts", // `thgs` as cleaner subseq, no path noise
+    ];
+    const r = rankPickerCandidates(candidates, "thgs");
+    expect(r[0]).toBe("src/things.ts");
+  });
+
   it("tie-breaks query matches by recently-used, then mtime", () => {
     const entries = [
       { path: "src/alpha.ts", mtimeMs: 100 },

--- a/tests/slash.test.ts
+++ b/tests/slash.test.ts
@@ -405,6 +405,64 @@ describe("handleSlash", () => {
     });
   });
 
+  describe("/cwd", () => {
+    it("registry exposes /cwd as a code-mode command with `sandbox` alias", () => {
+      const spec = SLASH_COMMANDS.find((c) => c.cmd === "cwd");
+      expect(spec).toBeDefined();
+      expect(spec?.contextual).toBe("code");
+      expect(spec?.aliases).toContain("sandbox");
+    });
+
+    it("returns code-only message when switchCwd is not provided", () => {
+      const r = handleSlash("cwd", ["./somewhere"], makeLoop());
+      expect(r.info).toMatch(/only available inside/);
+    });
+
+    it("shows usage when called without arguments", () => {
+      const r = handleSlash("cwd", [], makeLoop(), {
+        codeRoot: "/proj",
+        switchCwd: () => ({ ok: true, info: "" }),
+      });
+      expect(r.info).toMatch(/usage:/);
+      expect(r.info).toMatch(/\/proj/);
+    });
+
+    it("calls switchCwd and surfaces its info string", () => {
+      const calls: string[] = [];
+      const r = handleSlash("cwd", ["../sibling"], makeLoop(), {
+        switchCwd: (path) => {
+          calls.push(path);
+          return { ok: true, info: `▸ moved to ${path}` };
+        },
+      });
+      expect(calls).toEqual(["../sibling"]);
+      expect(r.info).toBe("▸ moved to ../sibling");
+    });
+
+    it("strips outer quotes from the path argument", () => {
+      const calls: string[] = [];
+      const r = handleSlash("cwd", ['"path with spaces"'], makeLoop(), {
+        switchCwd: (path) => {
+          calls.push(path);
+          return { ok: true, info: "ok" };
+        },
+      });
+      expect(calls).toEqual(["path with spaces"]);
+      expect(r.info).toBe("ok");
+    });
+
+    it("`sandbox` alias resolves to the same handler", () => {
+      const calls: string[] = [];
+      handleSlash("sandbox", ["/x"], makeLoop(), {
+        switchCwd: (p) => {
+          calls.push(p);
+          return { ok: true, info: "" };
+        },
+      });
+      expect(calls).toEqual(["/x"]);
+    });
+  });
+
   it("SLASH_COMMANDS registry contains every handler switch case", () => {
     // Spot-check a handful so the registry doesn't silently drift
     // from `handleSlash`. If a new case lands in handleSlash, it


### PR DESCRIPTION
## Summary

Lands two of three papercuts from #459; defers the third (startup perf) for profile-first work.

### Part 1 — `@`-mention picker rejected typo'd subsequences

Today the ranker rejects anything that isn't a literal substring of the path, so `@atmnt` returns nothing for `at-mentions.ts`. Adds a fuzzy-subsequence fallback that triggers only when the substring lookup misses. Substring hits still win the ranking (classes 0/1/2 cap at 29_999, subseq starts at 30_000). Fuzzy score rewards consecutive runs and basename-anchored matches; penalizes total path length.

The other two suspects flagged in the issue (walk-cap, cap-aware UI hint) were already in place at `useCompletionPickers.ts:102` (caps walks at 500) and `AtMentionSuggestions.tsx:55–77` (shows "↑ N above / ↓ N below"). The actual missing piece was just ranking.

### Part 2 — `/cwd` slash command

The plumbing was wired but no handler existed. `code.tsx` already exposes `reregisterTools` per `rootDir`, and `App.tsx` already commented "/cwd mutates this state to swap the workspace mid-session". Just had to connect the wires.

End-to-end:
- `SlashContext.switchCwd?: (newPath) => { ok, info }`
- App.tsx: stat + isDirectory check → `codeMode.reregisterTools(newPath)` → `setCurrentRootDir` → reload hooks
- `/cwd <path>` (alias `/sandbox`) registered in the `code` group, contextual to code mode
- Handler in `handlers/edits.ts`
- EN + zh-CN strings

### Part 3 (deferred)

Slow startup needs profiling before redesign — premature optimization without measurement is how regressions ship. Will open a follow-up issue with a "mark phases (import / config / MCP / semantic / first paint), defer post-mount" plan once we have numbers.

## Files

- `src/at-mentions.ts` — `fuzzySubseqScore` + ranker fallback
- `src/cli/ui/App.tsx` — `switchCwd` callback, `setCurrentRootDir` setter
- `src/cli/ui/slash/commands.ts` — register `/cwd` (+ `sandbox` alias)
- `src/cli/ui/slash/handlers/edits.ts` — `cwd` handler
- `src/cli/ui/slash/types.ts` — `SlashContext.switchCwd`
- `src/i18n/EN.ts` + `src/i18n/zh-CN.ts` — copy
- `tests/at-mentions.test.ts` — 3 fuzzy cases
- `tests/slash.test.ts` — 6 /cwd cases

## Test plan

- [x] `npm run verify` — 2252 pass / 2 skipped (pre-existing)
- [x] tsc clean, biome clean (only pre-existing JSX warnings)

## Out of scope (follow-ups)

- Semantic-index re-bootstrap on `/cwd` swap. The current `bootstrapSemanticSearchInCodeMode(tools, rootDir)` runs once at `code.tsx` startup; re-running it on cwd switch needs careful handling of the existing index registration.
- Startup-perf profiling — separate issue, separate PR.