### PR TITLE
perf(cli): startup-profile instrumentation (Stage 1 of #464)

### DIFF
--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -28,6 +28,7 @@ import { ToolRegistry } from "../../tools.js";
 import { registerChoiceTool } from "../../tools/choice.js";
 import { registerMemoryTools } from "../../tools/memory.js";
 import { registerWebTools } from "../../tools/web.js";
+import { markPhase } from "../startup-profile.js";
 import { App } from "../ui/App.js";
 import { SessionPicker } from "../ui/SessionPicker.js";
 import { Setup } from "../ui/Setup.js";
@@ -417,8 +418,10 @@ function Root({
 }
 
 export async function chatCommand(opts: ChatOptions): Promise<void> {
+  markPhase("chat_command_enter");
   loadDotenv();
   const initialKey = loadApiKey();
+  markPhase("config_loaded");
 
   const requestedSpecs = opts.mcp ?? [];
   // Shared progress sink: the bridge's onProgress callback writes
@@ -441,9 +444,15 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
   });
 
   const failedSpecs: Array<{ spec: string; reason: string }> = [];
+  if (requestedSpecs.length > 0) markPhase("mcp_launch");
   for (const raw of requestedSpecs) {
     const result = await runtime.addSpec(raw);
     if (!result.ok) failedSpecs.push({ spec: raw, reason: result.reason });
+  }
+  if (requestedSpecs.length > 0) {
+    markPhase(
+      `mcp_connected_${requestedSpecs.length - failedSpecs.length}_of_${requestedSpecs.length}`,
+    );
   }
   if (runtime.size() === 0 && !opts.seedTools) {
     tools = undefined;
@@ -492,6 +501,7 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
   const showPicker =
     !opts.session && !opts.forceResume && listSessionsForWorkspace(launchWorkspace).length > 0;
 
+  markPhase("ink_render_call");
   const { waitUntilExit } = render(
     <Root
       initialKey={initialKey}

--- a/src/cli/commands/code.tsx
+++ b/src/cli/commands/code.tsx
@@ -31,6 +31,7 @@ import { registerMemoryTools } from "../../tools/memory.js";
 import { registerPlanTool } from "../../tools/plan.js";
 import { registerShellTools } from "../../tools/shell.js";
 import { registerTodoTool } from "../../tools/todo.js";
+import { markPhase } from "../startup-profile.js";
 import { chatCommand } from "./chat.js";
 
 export interface CodeOptions {
@@ -63,6 +64,7 @@ export interface CodeOptions {
 }
 
 export async function codeCommand(opts: CodeOptions = {}): Promise<void> {
+  markPhase("code_command_enter");
   const { codeSystemPrompt } = await import("../../code/prompt.js");
   const rootDir = resolve(opts.dir ?? process.cwd());
   // Per-directory session so switching projects doesn't mix histories.
@@ -132,7 +134,11 @@ export async function codeCommand(opts: CodeOptions = {}): Promise<void> {
   // on-disk index already exists, skips entirely otherwise. Setup
   // happens via the explicit `reasonix index` command — never
   // by surprise on launch.
+  markPhase("semantic_bootstrap_start");
   const semantic = await bootstrapSemanticSearchInCodeMode(tools, rootDir);
+  markPhase(
+    semantic.enabled ? "semantic_bootstrap_done_enabled" : "semantic_bootstrap_done_skipped",
+  );
 
   process.stderr.write(
     `▸ reasonix code: rooted at ${rootDir}, session "${session ?? "(ephemeral)"}" · ${tools.size} native tool(s)${

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,3 +1,7 @@
+import { markPhase } from "./startup-profile.js";
+
+markPhase("cli_module_loaded");
+
 import { Command } from "commander";
 import { readConfig } from "../config.js";
 import { t } from "../i18n/index.js";

--- a/src/cli/startup-profile.ts
+++ b/src/cli/startup-profile.ts
@@ -1,0 +1,47 @@
+import { performance } from "node:perf_hooks";
+
+interface PhaseMark {
+  name: string;
+  t: number;
+}
+
+const marks: PhaseMark[] = [];
+let dumped = false;
+
+function envFlag(): boolean {
+  const v = process.env.REASONIX_PROFILE_STARTUP;
+  return v === "1" || v === "true" || v === "yes";
+}
+
+export function isStartupProfileEnabled(): boolean {
+  return envFlag();
+}
+
+export function markPhase(name: string): void {
+  if (!envFlag()) return;
+  marks.push({ name, t: performance.now() });
+}
+
+export function dumpStartupProfile(stream: NodeJS.WriteStream = process.stderr): void {
+  if (!envFlag() || dumped || marks.length === 0) return;
+  dumped = true;
+  const totalMs = marks[marks.length - 1]!.t;
+  const widest = String(Math.round(totalMs)).length;
+  const lines: string[] = ["[startup-profile]"];
+  let prev = 0;
+  for (const m of marks) {
+    const cum = Math.round(m.t).toString().padStart(widest);
+    const delta = Math.round(m.t - prev);
+    lines.push(`  ${cum}ms  ${m.name.padEnd(28)}  (+${delta})`);
+    prev = m.t;
+  }
+  lines.push(
+    `─── ${Math.round(totalMs)}ms total · last phase ${marks[marks.length - 1]!.name} · set REASONIX_PROFILE_STARTUP=0 to silence`,
+  );
+  stream.write(`${lines.join("\n")}\n`);
+}
+
+export function _resetForTests(): void {
+  marks.length = 0;
+  dumped = false;
+}

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -79,6 +79,7 @@ import { registerSkillTools } from "../../tools/skills.js";
 import { formatSubagentResult, spawnSubagent } from "../../tools/subagent.js";
 import { webFetch } from "../../tools/web.js";
 import { openTranscriptFile } from "../../transcript/log.js";
+import { dumpStartupProfile, markPhase } from "../startup-profile.js";
 import { AtMentionSuggestions } from "./AtMentionSuggestions.js";
 import { CheckpointPicker } from "./CheckpointPicker.js";
 import { ChoiceConfirm, type ChoiceConfirmChoice } from "./ChoiceConfirm.js";
@@ -325,6 +326,10 @@ function AppInner({
   }, [isStreaming, liveExpand]);
   const [languageVersion, setLanguageVersion] = useState(0);
   useEffect(() => onLanguageChange(() => setLanguageVersion((v) => v + 1)), []);
+  useEffect(() => {
+    markPhase("first_paint");
+    dumpStartupProfile();
+  }, []);
   // Live MCP server list: initialized from the boot-time prop, then
   // updated immutably when append-drift adds tools mid-session.
   const [liveMcpServers, setLiveMcpServers] = useState<McpServerSummary[]>(() => mcpServers ?? []);

--- a/tests/startup-profile.test.ts
+++ b/tests/startup-profile.test.ts
@@ -1,0 +1,101 @@
+import { Writable } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  _resetForTests,
+  dumpStartupProfile,
+  isStartupProfileEnabled,
+  markPhase,
+} from "../src/cli/startup-profile.js";
+
+function makeSink(): { stream: NodeJS.WriteStream; output: () => string } {
+  const chunks: Buffer[] = [];
+  const stream = new Writable({
+    write(chunk, _enc, cb) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      cb();
+    },
+  }) as unknown as NodeJS.WriteStream;
+  return { stream, output: () => Buffer.concat(chunks).toString("utf8") };
+}
+
+describe("startup-profile", () => {
+  const original = process.env.REASONIX_PROFILE_STARTUP;
+
+  beforeEach(() => {
+    _resetForTests();
+  });
+
+  afterEach(() => {
+    if (original === undefined) Reflect.deleteProperty(process.env, "REASONIX_PROFILE_STARTUP");
+    else process.env.REASONIX_PROFILE_STARTUP = original;
+    _resetForTests();
+  });
+
+  it("is disabled by default — markPhase + dumpStartupProfile are no-ops", () => {
+    Reflect.deleteProperty(process.env, "REASONIX_PROFILE_STARTUP");
+    expect(isStartupProfileEnabled()).toBe(false);
+    markPhase("a");
+    markPhase("b");
+    const sink = makeSink();
+    dumpStartupProfile(sink.stream);
+    expect(sink.output()).toBe("");
+  });
+
+  it("recognizes 1 / true / yes as enable values", () => {
+    for (const v of ["1", "true", "yes"]) {
+      process.env.REASONIX_PROFILE_STARTUP = v;
+      expect(isStartupProfileEnabled()).toBe(true);
+    }
+    process.env.REASONIX_PROFILE_STARTUP = "0";
+    expect(isStartupProfileEnabled()).toBe(false);
+  });
+
+  it("emits a formatted profile when enabled, with cumulative + delta per phase", () => {
+    process.env.REASONIX_PROFILE_STARTUP = "1";
+    markPhase("first");
+    markPhase("second");
+    markPhase("third");
+    const sink = makeSink();
+    dumpStartupProfile(sink.stream);
+    const out = sink.output();
+    expect(out).toContain("[startup-profile]");
+    expect(out).toContain("first");
+    expect(out).toContain("second");
+    expect(out).toContain("third");
+    expect(out).toMatch(/total/);
+    expect(out).toMatch(/last phase third/);
+  });
+
+  it("dumpStartupProfile is idempotent — second call is silent", () => {
+    process.env.REASONIX_PROFILE_STARTUP = "1";
+    markPhase("only");
+    const sink1 = makeSink();
+    dumpStartupProfile(sink1.stream);
+    const first = sink1.output();
+    expect(first.length).toBeGreaterThan(0);
+
+    const sink2 = makeSink();
+    dumpStartupProfile(sink2.stream);
+    expect(sink2.output()).toBe("");
+  });
+
+  it("emits nothing when enabled but no phases were marked", () => {
+    process.env.REASONIX_PROFILE_STARTUP = "1";
+    const sink = makeSink();
+    dumpStartupProfile(sink.stream);
+    expect(sink.output()).toBe("");
+  });
+
+  it("each line shows ms + phase name + (+delta) suffix", () => {
+    process.env.REASONIX_PROFILE_STARTUP = "1";
+    markPhase("alpha");
+    markPhase("beta");
+    const sink = makeSink();
+    dumpStartupProfile(sink.stream);
+    const lines = sink.output().split("\n");
+    const alphaLine = lines.find((l) => l.includes("alpha"));
+    const betaLine = lines.find((l) => l.includes("beta"));
+    expect(alphaLine).toMatch(/\d+ms\s+alpha\s+\(\+\d+\)/);
+    expect(betaLine).toMatch(/\d+ms\s+beta\s+\(\+\d+\)/);
+  });
+});


### PR DESCRIPTION
## Summary

Stage 1 of #464 — instrument the cold-start path so subsequent stages can target real bottlenecks instead of guessing. Zero cost when the env var is off.

## What it does

\`src/cli/startup-profile.ts\` exposes \`markPhase(name)\` and \`dumpStartupProfile()\`, both gated behind \`REASONIX_PROFILE_STARTUP=1\`. When unset, every call is a no-op (single env-var read). When enabled, marks accumulate and dump to stderr at first paint.

Marks land at:
- \`cli_module_loaded\` — first statement after the entry's transitive imports settle
- \`chat_command_enter\` / \`config_loaded\`
- \`mcp_launch\` / \`mcp_connected_M_of_N\` (only when MCP specs configured)
- \`code_command_enter\` (only on \`reasonix code\`)
- \`semantic_bootstrap_start\` / \`_done_(enabled|skipped)\`
- \`ink_render_call\` — just before \`render(<Root/>)\`
- \`first_paint\` — App's first \`useEffect\` after mount, also triggers the dump

Idempotent — second \`dumpStartupProfile\` call is silent.

## Baseline

Captured on Windows (this dev box), no MCP, semantic index already built:

\`\`\`
[startup-profile]
  436ms  cli_module_loaded             (+436)
    3ms  code_command_enter            (+3)
    2ms  semantic_bootstrap_start      (+2)
    2ms  semantic_bootstrap_done_enabled  (+2)
    3ms  chat_command_enter            (+2)
    0ms  config_loaded                 (+0)
    2ms  ink_render_call               (+1)
  316ms  first_paint                   (+316)
─── 764ms total
\`\`\`

**Read:** two real buckets.

| phase | ms | % |
|---|---:|---:|
| `cli_module_loaded` (Node startup + all transitive imports settling) | 436 | 57% |
| `first_paint` (Ink mount + React initial commit) | 316 | 41% |
| Everything else | ~12 | ~2% |

The semantic-index hypothesis from the issue does NOT hold for this config (only 2ms, because the index was already built). The MCP serial-setup hypothesis can't be tested without an actual multi-MCP config.

## What this informs

**Stage 2 candidates, in priority order:**
1. Lazy-load heavy synchronous imports — DeepSeek client SDK, Ink, dashboard server, embedding provider. The \`cli_module_loaded\` bucket is dominated by these resolving eagerly even when the user never uses them (\`reasonix index\` doesn't need Ink, \`reasonix code\` doesn't need the dashboard if `--no-dashboard`).
2. Re-measure against a real multi-MCP config (mine is bare). If serial \`addSpec\` shows up as a real bucket, parallelize.
3. \`first_paint\` 316ms is mostly Ink/React's first commit. Likely unavoidable without a UI redesign — defer.

**Stage 3 (CI budget gate)** stays deferred until Stage 2 trims have landed and we have stable numbers.

## Files

- \`src/cli/startup-profile.ts\` — new, ~50 lines
- \`src/cli/index.ts\` — first mark
- \`src/cli/commands/chat.tsx\` — chat / config / mcp marks
- \`src/cli/commands/code.tsx\` — code-command + semantic marks
- \`src/cli/ui/App.tsx\` — first_paint mark + auto-dump
- \`tests/startup-profile.test.ts\` — 6 cases (default-off, env-var values, formatting, idempotency, no-marks-empty, line shape)

## Test plan

- [x] \`npm run verify\` — 2258 pass, 2 skipped (pre-existing)
- [x] tsc clean, biome clean
- [x] Manual: \`REASONIX_PROFILE_STARTUP=1 reasonix code\` emits the profile; without the env var, no extra output

## Out of scope

- Trimming work itself — separate PRs once we have multi-platform / multi-config baselines
- Bundling / esbuild swap of the production CLI (orthogonal)
- Embedded dashboard server's startup path (separate codepath)