### PR TITLE
perf(cli): lazy-import dashboard server + App profile marks

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -63,7 +63,7 @@ import type {
   PickerResolution,
   SubmitResult,
 } from "../../server/context.js";
-import { type DashboardServerHandle, startDashboardServer } from "../../server/index.js";
+import type { DashboardServerHandle } from "../../server/index.js";
 import { loadSlashUsage, recordSlashUse } from "../../slash-usage.js";
 import {
   DEEPSEEK_CONTEXT_TOKENS,
@@ -275,6 +275,7 @@ interface StreamingState {
 }
 
 export function App(props: AppProps): React.ReactElement {
+  markPhase("app_render_start");
   const session = useAgentSession({
     sessionId: props.session,
     model: props.model,
@@ -306,6 +307,7 @@ function AppInner({
   noDashboard,
   onSwitchSession,
 }: AppProps) {
+  markPhase("app_inner_start");
   const log = useScrollback();
   const agentStore = useAgentStore();
   const hasConversation = useAgentState((s) =>
@@ -1643,6 +1645,7 @@ function AppInner({
     if (dashboardRef.current) return dashboardRef.current.url;
     if (dashboardStartingRef.current) return dashboardStartingRef.current;
     const startup = (async () => {
+      const { startDashboardServer } = await import("../../server/index.js");
       const handle = await startDashboardServer({
         mode: "attached",
         configPath: defaultConfigPath(),


### PR DESCRIPTION
## Summary

Tail-end of Stage 2 trims for #464. Two changes:

1. **Lazy-import the dashboard server.** \`startDashboardServer\` (which transitively pulls ~4200 LOC of HTTP server / static asset code) was eagerly imported into App.tsx. Move to dynamic \`await import()\` inside the existing async \`startup()\` IIFE — same async shape, no behavioural change.
2. **Two strategic marks** in App.tsx: \`app_render_start\` (top of \`App\`) and \`app_inner_start\` (top of \`AppInner\`). Zero cost when \`REASONIX_PROFILE_STARTUP\` is off; clarifies the \`first_paint\` delta in the dump.

## Findings from the deeper dive (worth recording)

I instrumented the suspected disk-hitting \`useState\` initializers (\`loadHooks\`, \`loadSlashUsage\`, \`loadEditMode\`, \`loadSessionMessages + hydrate\`) and confirmed they're each **sub-ms**. Deferring them to post-mount \`useEffect\` would buy nothing measurable. Diagnostic marks reverted to keep the dump readable.

The real cost in the App-render-to-first-paint window (~280–300ms) is React reconciliation + Ink's terminal commit + the first \`useEffect\` flushing. Trimming further requires reducing initial render complexity (smaller component tree, fewer providers), not deferring side work.

## Phase breakdown after this PR (Windows, no MCP, semantic on)

\`\`\`
   85ms  cli_module_loaded
  354ms  code_command_enter         ← dynamic import of code/chat/App + transitive deps
    2ms  semantic_bootstrap_*       ← already-built index
    3ms  chat_command_enter
    1ms  ink_render_call
   36ms  app_render_start
    3ms  app_inner_start
  287ms  first_paint                ← React reconcile + Ink commit
─── 770ms total
\`\`\`

## What this leaves on the table

- The 354ms in \`code_command_enter\` is the dynamic-import cost for code.tsx + chat.tsx + App.tsx + their UI subtree. Trimming requires \`React.lazy\` on modal-only components (CheckpointPicker, McpHub, ModelPicker, etc.) — Ink compatibility is uncertain and worth a separate investigation.
- The 287ms \`first_paint\` is mostly React+Ink rendering the initial tree. Could be trimmed by lifting providers out of the initial mount path.

## Stage 3 (CI budget gate) — deferred

Numbers are platform-dependent (Windows here is slower than Linux; CI machines vary). A hard ms threshold would be fragile. The profile harness from #466 is the durable artifact: any contributor can run \`REASONIX_PROFILE_STARTUP=1 reasonix code\` to get the same dump and check their changes don't bloat the buckets.

If we want a CI gate later, the right shape is "warn on regression vs main baseline ± 30%" run on a fixed CI runner — separate ticket if needed.

## Test plan

- [x] \`npm run verify\` — 2258 pass / 2 skipped
- [x] tsc clean, biome clean
- [x] Manual: \`reasonix code --no-dashboard\` and \`reasonix code\` (with auto-start) both work normally; profile dump includes the new marks