### PR TITLE
fix(/cwd): re-bootstrap semantic_search on workspace swap

### DIFF
--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -297,6 +297,8 @@ export interface ChatOptions {
      * then falls back to non-tool updates only).
      */
     reregisterTools?: (rootDir: string) => void;
+    /** Async tail of `/cwd` — re-probe the new dir for a semantic index. */
+    reBootstrapSemantic?: (rootDir: string) => Promise<{ enabled: boolean }>;
   };
   /** Skip the session picker — assume "Resume" (backwards-compatible auto-continue). */
   forceResume?: boolean;

--- a/src/cli/commands/code.tsx
+++ b/src/cli/commands/code.tsx
@@ -109,6 +109,16 @@ export async function codeCommand(opts: CodeOptions = {}): Promise<void> {
     // per-project memory store; the global scope is shared across runs.
     registerMemoryTools(tools, { projectRoot: root });
   };
+  // Async tail to `registerRootedTools`. Kept separate because the FS /
+  // shell / memory re-registration above is sync and must happen before
+  // the next tool dispatch, while semantic-index probing reads disk and
+  // can race ahead in the background. On `/cwd`, App.tsx fires this
+  // after the sync swap and surfaces the result via postInfo.
+  const reBootstrapSemantic = async (root: string): Promise<{ enabled: boolean }> => {
+    const result = await bootstrapSemanticSearchInCodeMode(tools, root);
+    if (!result.enabled) tools.unregister("semantic_search");
+    return result;
+  };
   registerRootedTools(rootDir);
   // `submit_plan` is always in the spec list so the prefix cache stays
   // stable across plan-mode toggles (Pillar 1). The tool itself is a
@@ -135,7 +145,7 @@ export async function codeCommand(opts: CodeOptions = {}): Promise<void> {
   // happens via the explicit `reasonix index` command — never
   // by surprise on launch.
   markPhase("semantic_bootstrap_start");
-  const semantic = await bootstrapSemanticSearchInCodeMode(tools, rootDir);
+  const semantic = await reBootstrapSemantic(rootDir);
   markPhase(
     semantic.enabled ? "semantic_bootstrap_done_enabled" : "semantic_bootstrap_done_skipped",
   );
@@ -187,7 +197,12 @@ export async function codeCommand(opts: CodeOptions = {}): Promise<void> {
     transcript: opts.transcript,
     session,
     seedTools: tools,
-    codeMode: { rootDir, jobs, reregisterTools: registerRootedTools },
+    codeMode: {
+      rootDir,
+      jobs,
+      reregisterTools: registerRootedTools,
+      reBootstrapSemantic,
+    },
     mcp: readConfig().mcp,
     forceResume: opts.forceResume,
     forceNew: opts.forceNew,

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -205,6 +205,14 @@ export interface AppProps {
      * with file/shell tools still pointing at the original root.
      */
     reregisterTools?: (rootDir: string) => void;
+    /**
+     * Async tail of the `/cwd` swap — re-probes the new directory for a
+     * compatible semantic index, registers `semantic_search` against it
+     * if found, unregisters the stale binding otherwise. Kept separate
+     * from `reregisterTools` so the sync FS/shell/memory re-registration
+     * isn't blocked on disk I/O.
+     */
+    reBootstrapSemantic?: (rootDir: string) => Promise<{ enabled: boolean }>;
   };
   /**
    * When `true`, suppress the auto-launch of the embedded web dashboard
@@ -2234,6 +2242,23 @@ function AppInner({
                 setCurrentRootDir(resolved);
                 const fresh = loadHooks({ projectRoot: resolved });
                 setHookList(fresh);
+                const reBootstrap = codeMode.reBootstrapSemantic;
+                if (reBootstrap) {
+                  void reBootstrap(resolved).then(
+                    (r) => {
+                      log.pushInfo(
+                        r.enabled
+                          ? `▸ semantic_search re-pointed at ${resolved}`
+                          : `▸ semantic_search disabled (no compatible index in ${resolved})`,
+                      );
+                    },
+                    (err) => {
+                      log.pushInfo(
+                        `▸ semantic_search re-bootstrap failed: ${(err as Error).message}`,
+                      );
+                    },
+                  );
+                }
                 return { ok: true, info: `▸ workspace switched to ${resolved}` };
               }
             : undefined,

--- a/tests/slash.test.ts
+++ b/tests/slash.test.ts
@@ -461,6 +461,24 @@ describe("handleSlash", () => {
       });
       expect(calls).toEqual(["/x"]);
     });
+
+    it("the slash result returns immediately even when switchCwd kicks off async work", () => {
+      let resolved = false;
+      const r = handleSlash("cwd", ["/somewhere"], makeLoop(), {
+        switchCwd: () => {
+          // Real implementation fires `void reBootstrapSemantic(...)` in
+          // the background and returns sync. The slash dispatch must NOT
+          // wait on that — postInfo carries the eventual result.
+          queueMicrotask(() => {
+            resolved = true;
+          });
+          return { ok: true, info: "▸ workspace switched" };
+        },
+      });
+      expect(r.info).toBe("▸ workspace switched");
+      // The async work hasn't drained yet — the slash returned synchronously.
+      expect(resolved).toBe(false);
+    });
   });
 
   it("SLASH_COMMANDS registry contains every handler switch case", () => {


### PR DESCRIPTION
## Summary

The remaining tail of #459. When \`/cwd\` swaps the workspace root, FS / shell / memory tools were re-registered against the new path but \`semantic_search\` kept pointing at the OLD root. Queries either searched the previous project's index silently, or the tool stayed registered when the new directory had no index at all.

## Design

Split the semantic re-bootstrap from the sync \`reregisterTools\` callback:

- \`reregisterTools\` stays sync — FS/shell/memory registrations must land before the next tool dispatch.
- New \`reBootstrapSemantic(root) => Promise<{ enabled }>\` reads disk to probe index compatibility, registers \`semantic_search\` if found, unregisters it otherwise.

App.tsx fires the async tail with \`void ...then(postInfo)\` so the slash dispatch returns synchronously — matches the codebase's fire-and-forget pattern documented in \`slash/dispatch.ts\` (\"Synchronous return — async work fires-and-forgets via \`ctx.postInfo\` to keep input non-blocking\").

User sees:

\`\`\`
▸ workspace switched to /new/path
▸ semantic_search re-pointed at /new/path                     ← if compatible
▸ semantic_search disabled (no compatible index in /new/path) ← if not
\`\`\`

Launch path now goes through \`reBootstrapSemantic\` too so the unregister-on-skip case is exercised on every entry — single code path, harder to drift.

## Files

- \`src/cli/commands/code.tsx\` — split out \`reBootstrapSemantic\`, expose via \`codeMode\`
- \`src/cli/commands/chat.tsx\` — extend \`codeMode\` prop type
- \`src/cli/ui/App.tsx\` — extend \`codeMode\` prop type, fire async tail in \`switchCwd\`
- \`tests/slash.test.ts\` — assert the slash result returns sync even when async work is queued

## Test plan

- [x] \`npm run verify\` — 2259 pass / 2 skipped
- [x] tsc clean, biome clean

Closes #459 (its last remaining sub-item).