### PR TITLE
fix(ui): drop dead toolHistoryRef leak (#465)

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -670,14 +670,6 @@ function AppInner({
   // synced in a useEffect once handleSubmit is defined.
   const handleSubmitRef = useRef<((raw: string) => Promise<void>) | null>(null);
   const busyRef = useRef<boolean>(false);
-  // Full untruncated tool results, in arrival order. ToolCard clips
-  // output at 400 chars for display; `/tool N` reads from this ref to
-  // show the real thing. Not persisted — a
-  // resumed session replays the log (which has the same content in
-  // `tool` messages) but we don't repopulate this ref on resume
-  // because the user wouldn't expect `/tool` to reach back across
-  // process boundaries.
-  const toolHistoryRef = useRef<Array<{ toolName: string; text: string }>>([]);
   // Embedded dashboard server handle. Set when /dashboard boots; null
   // otherwise. Mutations to this ref happen inside the start/stop
   // callbacks; the slash handler uses getDashboardUrl() to surface
@@ -2184,7 +2176,6 @@ function AppInner({
           codeShowEdit: codeMode ? codeShowEdit : undefined,
           codeRoot: codeMode ? currentRootDir : undefined,
           pendingEditCount: codeMode ? pendingEdits.current.length : undefined,
-          toolHistory: () => toolHistoryRef.current,
           memoryRoot: currentRootDir,
           planMode,
           setPlanMode: codeMode ? togglePlanMode : undefined,
@@ -2597,7 +2588,6 @@ function AppInner({
               setOngoingTool,
               setToolProgress,
               toolStartedAtRef,
-              toolHistoryRef,
               setPendingShell,
               setPendingPlan,
               setPendingRevision,

--- a/src/cli/ui/hooks/handle-tool-event.ts
+++ b/src/cli/ui/hooks/handle-tool-event.ts
@@ -14,7 +14,6 @@ export interface ToolEventContext {
     SetStateAction<{ progress: number; total?: number; message?: string } | null>
   >;
   toolStartedAtRef: MutableRefObject<number | null>;
-  toolHistoryRef: MutableRefObject<Array<{ toolName: string; text: string }>>;
   setPendingShell: Dispatch<
     SetStateAction<{ id: number; command: string; kind: "run_command" | "run_background" } | null>
   >;
@@ -41,16 +40,7 @@ export function handleToolEvent(ev: LoopEvent, ctx: ToolEventContext): void {
   ctx.setToolProgress(null);
   ctx.translator.toolEnd(ev.content);
 
-  // mark_step_complete gets its own pretty scrollback row below — suppress
-  // the raw tool row here so we don't show the same JSON blob twice.
-  const isStepProgressTool = ev.toolName === "mark_step_complete";
   ctx.toolStartedAtRef.current = null;
-  if (!isStepProgressTool) {
-    ctx.toolHistoryRef.current.push({
-      toolName: ev.toolName ?? "?",
-      text: ev.content,
-    });
-  }
 
   if (ev.toolName === "mark_step_complete") {
     try {

--- a/src/cli/ui/slash/helpers.ts
+++ b/src/cli/ui/slash/helpers.ts
@@ -52,33 +52,6 @@ export function appendSection(
   lines.push(`  ${label.trim()}    ${names.length}  [${head}${more}]`);
 }
 
-export function formatToolList(history: Array<{ toolName: string; text: string }>): string {
-  const total = history.length;
-  const header = `Tool calls in this session (${total}, most recent first):`;
-  // Show the 10 most recent. Older ones are rarely what the user
-  // wants — and the help footer tells them how to reach any entry
-  // by index if they do.
-  const shown = Math.min(total, 10);
-  const lines: string[] = [header];
-  for (let i = 0; i < shown; i++) {
-    const entry = history[total - 1 - i];
-    if (!entry) continue;
-    const idx = i + 1; // 1-based from most recent
-    const flat = entry.text.replace(/\s+/g, " ").trim();
-    const preview = flat.length > 80 ? `${flat.slice(0, 80)}…` : flat;
-    const name = entry.toolName.length > 24 ? `${entry.toolName.slice(0, 23)}…` : entry.toolName;
-    lines.push(
-      `  #${String(idx).padStart(2)}  ${name.padEnd(24)}  ${String(entry.text.length).padStart(6)} chars  ${preview}`,
-    );
-  }
-  if (total > shown) {
-    lines.push(`  … (${total - shown} earlier, reach with /tool N)`);
-  }
-  lines.push("");
-  lines.push("View full output: /tool N   (N=1 → most recent)");
-  return lines.join("\n");
-}
-
 /** Binary-K to match DeepSeek docs; do NOT reuse for non-token counts. */
 export function compactNum(n: number): string {
   if (n < 1024) return String(n);

--- a/src/cli/ui/slash/types.ts
+++ b/src/cli/ui/slash/types.ts
@@ -62,7 +62,6 @@ export interface SlashContext {
   codeShowEdit?: (args: readonly string[]) => string;
   codeRoot?: string;
   pendingEditCount?: number;
-  toolHistory?: () => Array<{ toolName: string; text: string }>;
   mcpServers?: McpServerSummary[];
   /** Absent → tests context; `/memory` MUST reply "root unknown" rather than silently reading wrong dir. */
   memoryRoot?: string;


### PR DESCRIPTION
## Summary

`/tool` slash command was removed in #453, but its supporting infrastructure stayed behind:

- `toolHistoryRef` in `App.tsx` — `useRef<Array<{toolName, text}>>([])` pushed on every tool end
- `handleToolEvent` plumbing — pushed `ev.content` (full tool result) on every dispatch
- `formatToolList` exporter in slash/helpers
- `toolHistory: () => …` callback wired through SlashContext

Nothing ever read it. Every Read / Grep / Bash output was retained for the full session lifetime in dead memory.

#465 reports `FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory` after ~2.6h on v0.31.0 (heap topped 4GB). This leak matches that failure mode: a single large Bash output is enough to be measurable; in a multi-hour session with hundreds of tool calls the retention compounds.

## What changed

- 48 lines deleted across 4 files
- `state.cards[].output` (the source of truth that drives scrollback rendering) is untouched — UX unchanged
- Loop / transcript / context-manager unchanged

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 141 files, 2259 pass / 2 skip
- [ ] Long-session smoke (>1h) to confirm heap stays flat — needs follow-up RSS instrumentation

Closes #465