### PR TITLE
feat(ui): wallet pill on status row + tighter prompt hints

### DIFF
--- a/src/cli/ui/PromptInput.tsx
+++ b/src/cli/ui/PromptInput.tsx
@@ -163,7 +163,7 @@ export function PromptInput({
   // a just-cleared buffer and read as residual typed input on dim-poor terminals.
   const effectivePlaceholder = disabled
     ? (placeholder ?? "…waiting for response…")
-    : (placeholder ?? "type a message · slash for commands · at-sign for files");
+    : (placeholder ?? "ask anything  ·  slash for commands  ·  at-sign for files");
 
   const lines = value.length > 0 ? value.split("\n") : [""];
   const accentColor = disabled ? FG.faint : TONE.brand;
@@ -295,15 +295,35 @@ export function PromptInput({
       ) : null}
       {!disabled ? (
         <Box marginTop={1}>
-          <Text color={FG.faint}>
-            {"  ⏎ send  ·  shift/alt+⏎ newline  ·  ↑↓ history  ·  esc abort  ·  ctrl-c quit"}
-          </Text>
+          <HintRow />
         </Box>
       ) : (
         <Box marginTop={1}>
           <Text color={FG.faint}>{"  esc to stop"}</Text>
         </Box>
       )}
+    </Box>
+  );
+}
+
+function HintRow(): React.ReactElement {
+  const items: Array<{ key: string; sep: string }> = [
+    { key: "⏎", sep: "send" },
+    { key: "⇧⏎", sep: "newline" },
+    { key: "↑↓", sep: "history" },
+    { key: "esc", sep: "abort" },
+    { key: "^C", sep: "quit" },
+  ];
+  return (
+    <Box flexDirection="row">
+      <Text>{"  "}</Text>
+      {items.map((item, i) => (
+        <React.Fragment key={item.key}>
+          {i > 0 && <Text color={FG.faint}>{"  ·  "}</Text>}
+          <Text color={FG.meta}>{item.key}</Text>
+          <Text color={FG.faint}>{` ${item.sep}`}</Text>
+        </React.Fragment>
+      ))}
     </Box>
   );
 }

--- a/src/cli/ui/layout/StatusRow.tsx
+++ b/src/cli/ui/layout/StatusRow.tsx
@@ -4,10 +4,11 @@ import React from "react";
 import { Countdown } from "../primitives/Countdown.js";
 import { useAgentState } from "../state/provider.js";
 import type { Mode, NetworkState, StatusBar } from "../state/state.js";
-import { FG, TONE, formatCost } from "../theme/tokens.js";
+import { FG, TONE, balanceColor, formatBalance, formatCost } from "../theme/tokens.js";
 
 const RULE_PAD = 4;
 const RULE_MIN = 20;
+const WALLET_MIN_COLS = 90;
 
 export function StatusRow(): React.ReactElement {
   const status = useAgentState((s) => s.status);
@@ -16,6 +17,9 @@ export function StatusRow(): React.ReactElement {
   const cols = stdout?.columns ?? 80;
   const ruleWidth = Math.max(RULE_MIN, cols - RULE_PAD);
   const hasTurn = status.cost > 0;
+  const hasSession = status.sessionCost > 0;
+  const hasBalance = typeof status.balance === "number";
+  const showWallet = cols >= WALLET_MIN_COLS && (hasSession || hasBalance);
 
   return (
     <Box flexDirection="column">
@@ -47,8 +51,44 @@ export function StatusRow(): React.ReactElement {
         )}
         <Sep />
         <Text color={TONE.accent}>{`cache ${Math.round(status.cacheHit * 100)}%`}</Text>
+        {showWallet && (
+          <WalletPill
+            sessionCostUsd={status.sessionCost}
+            balance={status.balance}
+            currency={status.balanceCurrency}
+          />
+        )}
       </Box>
     </Box>
+  );
+}
+
+function WalletPill({
+  sessionCostUsd,
+  balance,
+  currency,
+}: {
+  sessionCostUsd: number;
+  balance?: number;
+  currency?: string;
+}): React.ReactElement {
+  const showSpent = sessionCostUsd > 0;
+  const showBalance = typeof balance === "number";
+  return (
+    <>
+      <Sep />
+      <Text color={FG.meta}>{"⛁ "}</Text>
+      {showSpent && (
+        <Text color={FG.body}>{`${formatCost(sessionCostUsd, currency, 2)} spent`}</Text>
+      )}
+      {showSpent && showBalance && <Text color={FG.meta}>{"  /  "}</Text>}
+      {showBalance && (
+        <Text bold color={balanceColor(balance, currency)}>
+          {formatBalance(balance, currency, { fractionDigits: 2 })}
+        </Text>
+      )}
+      {showBalance && <Text color={FG.faint}>{" left"}</Text>}
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary

Two UX gaps surfaced in conversation:

1. **Wallet not visible.** \`state.status.balance\` and \`state.status.sessionCost\` were already populated by the reducer (App.tsx:925-933 / 2569-2572) and \`balanceColor()\` with red/orange thresholds was already in tokens.ts:85 — but \`StatusRow.tsx\` only ever read \`status.cost\` (turn) and \`status.cacheHit\`. Pure plumbing gap. Users had to type \`/cost\` to see the running spend or remaining DeepSeek wallet.

2. **Prompt input felt utilitarian.** Hint footer was \`⏎ send · shift/alt+⏎ newline · ↑↓ history · esc abort · ctrl-c quit\` — verbose, jargon-heavy. Placeholder said \`type a message\`.

## Changes

### \`StatusRow.tsx\` — new \`WalletPill\` segment

Renders right of the cache pill:

\`\`\`
  ● auto · sess-abc · main   ·   ▸ ¥0.02 turn   ·   cache 87%   ·   ⛁ ¥1.20 spent  /  ¥45.32 left
\`\`\`

- Shown only when \`cols >= 90\` and at least one of \`sessionCost > 0\` / \`balance != null\` is true (so narrow sessions don't wrap)
- Spent: \`formatCost(sessionCostUsd, currency, 2)\` — converts USD-internal to display currency
- Balance: \`formatBalance(balance, currency, { fractionDigits: 2 })\` colored via \`balanceColor()\` (red <¥5, orange <¥20, brand otherwise)
- One or both pills can show; separator only renders when both are present

### \`PromptInput.tsx\` — friendlier copy + \`HintRow\`

- Placeholder: \`type a message · slash for commands · at-sign for files\` → \`ask anything · slash for commands · at-sign for files\`
- Hint footer extracted into \`HintRow\` component; keys (⏎ ⇧⏎ ↑↓ esc ^C) render in \`FG.meta\`, labels in \`FG.faint\` for keycap/label rhythm
- Symbols: \`shift/alt+⏎\` → \`⇧⏎\`, \`ctrl-c\` → \`^C\`

## Test plan

- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx vitest run tests/comment-policy.test.ts\` — 9/9 pass
- [ ] **Visual check needed.** I can't run the TUI from this environment to verify spacing on different terminal widths. Please pull and confirm: (a) wallet pill renders correctly when \`/cost\` was previously the only way to see the data, (b) narrow-terminal fallback (drop wallet at <90 cols) feels right, (c) hint row spacing reads cleanly with the new keycap styling.

The status state was already there — this PR is mostly about surfacing it. If you want different copy, formatting, or threshold colors, single-line edits in \`WalletPill\` / \`HintRow\` cover it.