### PR TITLE
fix: ↑/↓ on empty buffer recall history; doctor finds tokenizer (#468)

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -2,7 +2,7 @@
 
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { join, resolve } from "node:path";
 import { DeepSeekClient } from "../../client.js";
 import { defaultConfigPath, readConfig, resolveSemanticEmbeddingConfig } from "../../config.js";
 import { loadDotenv } from "../../env.js";
@@ -10,6 +10,7 @@ import { loadHooks } from "../../hooks.js";
 import { indexExists } from "../../index/semantic/builder.js";
 import { checkOllamaStatus } from "../../index/semantic/ollama-launcher.js";
 import { listSessions } from "../../memory/session.js";
+import { resolveDataPath } from "../../tokenizer.js";
 import { VERSION } from "../../version.js";
 
 export type DoctorLevel = "ok" | "warn" | "fail";
@@ -169,32 +170,20 @@ async function checkApiReach(): Promise<Check> {
 }
 
 async function checkTokenizer(): Promise<Check> {
-  // The tokenizer file is the gzipped vocab shipped under data/. We
-  // resolve relative to the package's dist/ rather than process.cwd()
-  // — the same logic the runtime uses when loading on first count.
-  const candidates = [
-    join(
-      dirname(new URL(import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1")),
-      "..",
-      "..",
-      "..",
-      "data",
-      "deepseek-tokenizer.json.gz",
-    ),
-    join(process.cwd(), "data", "deepseek-tokenizer.json.gz"),
-  ];
-  for (const p of candidates) {
-    if (existsSync(p)) {
-      try {
-        const stat = statSync(p);
-        return {
-          label: "tokenizer    ",
-          level: "ok",
-          detail: `${p} (${fmtBytes(stat.size)})`,
-        };
-      } catch {
-        /* try next */
-      }
+  // Reuse the runtime's resolver so the doctor never disagrees with what
+  // the tokenizer actually loads — three candidates including a global
+  // npm install probe via createRequire.
+  const path = resolveDataPath();
+  if (existsSync(path)) {
+    try {
+      const stat = statSync(path);
+      return {
+        label: "tokenizer    ",
+        level: "ok",
+        detail: `${path} (${fmtBytes(stat.size)})`,
+      };
+    } catch {
+      /* fall through to warn */
     }
   }
   return {

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -1195,16 +1195,14 @@ function AppInner({
   // Esc handles "abort the current turn" separately; Ctrl+C is the universal "I'm done" key.
   const quitProcess = useQuit(transcriptRef);
 
-  // PgUp / PgDn always scroll chat history; ↑/↓-on-empty-buffer also
-  // routes here via PromptInput's chatScrollHandoff. WT translates wheel
-  // events to ↑/↓ in raw mode, so this is what makes wheel-scroll work.
+  // PgUp / PgDn always scroll chat history. ↑/↓ also reaches here when
+  // PromptInput can't act on it: while busy (disabled) or once chat is
+  // unpinned (user already scrolling). When pinned + idle, PromptInput
+  // owns arrows — empty buffer recalls history, otherwise cursor motion.
   useKeystroke((ev) => {
     if (ev.pageUp) chatScroll.scrollUp();
     else if (ev.pageDown) chatScroll.scrollDown();
     else if (ev.end) chatScroll.jumpToBottom();
-    // Wheel-translated ↑/↓ has nowhere to go when PromptInput can't
-    // process it: in reading mode (unmounted) or while busy (disabled).
-    // When pinned + idle, PromptInput owns arrows for cursor / handoff.
     else if ((!chatScroll.pinned || busy) && ev.upArrow) chatScroll.scrollUp();
     else if ((!chatScroll.pinned || busy) && ev.downArrow) chatScroll.scrollDown();
   }, !modalOpen);
@@ -3687,8 +3685,6 @@ function AppInner({
                     disabled={busy}
                     onHistoryPrev={recallPrev}
                     onHistoryNext={recallNext}
-                    onChatScrollUp={chatScroll.scrollUp}
-                    onChatScrollDown={chatScroll.scrollDown}
                   />
                   {slashMatches !== null ? (
                     <SlashSuggestions

--- a/src/cli/ui/PromptInput.tsx
+++ b/src/cli/ui/PromptInput.tsx
@@ -32,12 +32,9 @@ export interface PromptInputProps {
   onSubmit: (v: string) => void;
   disabled?: boolean;
   placeholder?: string;
-  /** Ctrl+P / Ctrl+N — parent walks its prompt history and swaps `value` via `onChange`. */
+  /** ↑/↓ on an empty buffer or Ctrl+P / Ctrl+N — parent walks history and swaps `value` via `onChange`. */
   onHistoryPrev?: () => void;
   onHistoryNext?: () => void;
-  /** ↑/↓ on an empty buffer — parent scrolls chat history. */
-  onChatScrollUp?: () => void;
-  onChatScrollDown?: () => void;
 }
 
 export function PromptInput({
@@ -48,8 +45,6 @@ export function PromptInput({
   placeholder,
   onHistoryPrev,
   onHistoryNext,
-  onChatScrollUp,
-  onChatScrollDown,
 }: PromptInputProps) {
   // Cap at 24 — collapseLinesForDisplay hides content past ~20 logical lines.
   // Quantize spec.max to 4-row buckets so per-keystroke line-count changes
@@ -146,8 +141,6 @@ export function PromptInput({
     }
     if (action.historyHandoff === "prev") onHistoryPrev?.();
     if (action.historyHandoff === "next") onHistoryNext?.();
-    if (action.chatScrollHandoff === "up") onChatScrollUp?.();
-    if (action.chatScrollHandoff === "down") onChatScrollDown?.();
   }, !disabled);
 
   // ── Render ──────────────────────────────────────────────────────

--- a/src/cli/ui/multiline-keys.ts
+++ b/src/cli/ui/multiline-keys.ts
@@ -28,10 +28,8 @@ export interface MultilineAction {
   /** When `true`, fire `onSubmit(submitValue ?? value)`. */
   submit: boolean;
   submitValue?: string;
-  /** Set on Ctrl+P / Ctrl+N — parent handles prompt-history recall. */
+  /** Set on ↑/↓ at a buffer boundary or Ctrl+P / Ctrl+N — parent recalls prompt history. */
   historyHandoff?: "prev" | "next";
-  /** Set when ↑/↓ fires on an empty buffer — parent scrolls the chat history. */
-  chatScrollHandoff?: "up" | "down";
   /** Reducer is pure — hands raw paste to PromptInput which allocates a sentinel and inserts that. */
   pasteRequest?: { content: string };
 }
@@ -70,11 +68,11 @@ export function processMultilineKey(
     return cursor === value.length ? NOOP : { next: null, cursor: value.length, submit: false };
   }
 
-  // Prompt-history recall is on Ctrl+P / Ctrl+N (bash readline
-  // convention). ↑/↓ on an empty buffer scrolls chat history because
-  // Windows Terminal + ConPTY translates mouse wheel events to ↑/↓ in
-  // raw mode — the only way to make wheel-up scroll chat is to map ↑
-  // to chat-scroll. Ctrl+P/N is wheel-immune.
+  // ↑/↓ on an empty buffer recalls prompt history (universal CLI
+  // convention — bash, zsh, fish all do this). Ctrl+P / Ctrl+N is the
+  // wheel-immune fallback for Windows ConPTY users whose terminal
+  // translates mouse-wheel events to arrow keys; bind it on every
+  // platform so the muscle memory works the same everywhere.
   if (key.ctrl && key.input === "p") {
     return { ...NOOP, historyHandoff: "prev" };
   }
@@ -82,8 +80,6 @@ export function processMultilineKey(
     return { ...NOOP, historyHandoff: "next" };
   }
 
-  // Cursor motion. Empty single-line buffer + ↑/↓ is now a no-op
-  // (used to recall history; see Ctrl+P/N comment above).
   if (key.leftArrow) {
     return { next: null, cursor: Math.max(0, cursor - 1), submit: false };
   }
@@ -91,12 +87,12 @@ export function processMultilineKey(
     return { next: null, cursor: Math.min(value.length, cursor + 1), submit: false };
   }
   if (key.upArrow) {
-    if (value.length === 0) return { ...NOOP, chatScrollHandoff: "up" };
+    if (value.length === 0) return { ...NOOP, historyHandoff: "prev" };
     const moved = moveCursorUp(value, cursor);
     return moved === cursor ? NOOP : { next: null, cursor: moved, submit: false };
   }
   if (key.downArrow) {
-    if (value.length === 0) return { ...NOOP, chatScrollHandoff: "down" };
+    if (value.length === 0) return { ...NOOP, historyHandoff: "next" };
     const moved = moveCursorDown(value, cursor);
     return moved === cursor ? NOOP : { next: null, cursor: moved, submit: false };
   }

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -77,7 +77,7 @@ function buildByteToChar(): string[] {
 let cached: LoadedTokenizer | null = null;
 
 /** Two ../data candidates needed: dist/index.js AND dist/cli/index.js resolve to different roots. */
-function resolveDataPath(): string {
+export function resolveDataPath(): string {
   if (process.env.REASONIX_TOKENIZER_PATH) return process.env.REASONIX_TOKENIZER_PATH;
   const candidates: string[] = [];
   try {

--- a/tests/multiline-keys.test.ts
+++ b/tests/multiline-keys.test.ts
@@ -148,21 +148,16 @@ describe("processMultilineKey — cursor motion", () => {
     expect(processMultilineKey("abc", 3, key({ rightArrow: true })).cursor).toBe(3);
   });
 
-  it("↑/↓ on a single-line non-empty buffer is a NOOP (no history recall)", () => {
-    // 0.7.10: history recall moved to Ctrl+P/N because mouse wheel
-    // on Windows ConPTY translates to ↑/↓ events, indistinguishable
-    // from keyboard. Wheel scrolling was clobbering the prompt with
-    // recalled history. Now ↑/↓ does nothing on a single-line
-    // buffer; users press Ctrl+P / Ctrl+N for history.
+  it("↑/↓ on a single-line non-empty buffer is a NOOP", () => {
     const up = processMultilineKey("hello", 3, key({ upArrow: true }));
     expect(up).toEqual({ next: null, cursor: null, submit: false });
     const down = processMultilineKey("hello", 3, key({ downArrow: true }));
     expect(down).toEqual({ next: null, cursor: null, submit: false });
   });
 
-  it("↑/↓ on an empty buffer hands off to chat scroll (wheel-routed)", () => {
-    expect(processMultilineKey("", 0, key({ upArrow: true })).chatScrollHandoff).toBe("up");
-    expect(processMultilineKey("", 0, key({ downArrow: true })).chatScrollHandoff).toBe("down");
+  it("↑/↓ on an empty buffer hands off to history recall (universal CLI convention)", () => {
+    expect(processMultilineKey("", 0, key({ upArrow: true })).historyHandoff).toBe("prev");
+    expect(processMultilineKey("", 0, key({ downArrow: true })).historyHandoff).toBe("next");
   });
 
   it("Ctrl+P / Ctrl+N hand off to history recall (bash readline binding)", () => {
@@ -197,13 +192,13 @@ describe("processMultilineKey — cursor motion", () => {
     expect(result).toEqual({ next: null, cursor: null, submit: false });
   });
 
-  it("raw `\\x1b[A` escape sequence is rewritten into upArrow (chat-scroll handoff on empty buffer)", () => {
+  it("raw `\\x1b[A` escape sequence is rewritten into upArrow (history handoff on empty buffer)", () => {
     const result = processMultilineKey("", 0, { input: "\x1b[A" });
-    expect(result.chatScrollHandoff).toBe("up");
+    expect(result.historyHandoff).toBe("prev");
   });
 
   it("raw `\\x1b[B` becomes downArrow; `\\x1b[C` rightArrow; `\\x1b[D` leftArrow", () => {
-    expect(processMultilineKey("", 0, { input: "\x1b[B" }).chatScrollHandoff).toBe("down");
+    expect(processMultilineKey("", 0, { input: "\x1b[B" }).historyHandoff).toBe("next");
     expect(processMultilineKey("abc", 0, { input: "\x1b[C" }).cursor).toBe(1);
     expect(processMultilineKey("abc", 2, { input: "\x1b[D" }).cursor).toBe(1);
   });
@@ -216,8 +211,8 @@ describe("processMultilineKey — cursor motion", () => {
     // newline boundary.
     expect(processMultilineKey("ab\ncd", 2, { input: "[C" }).cursor).toBe(3);
     expect(processMultilineKey("ab\ncd", 3, { input: "[D" }).cursor).toBe(2);
-    expect(processMultilineKey("", 0, { input: "[A" }).chatScrollHandoff).toBe("up");
-    expect(processMultilineKey("", 0, { input: "[B" }).chatScrollHandoff).toBe("down");
+    expect(processMultilineKey("", 0, { input: "[A" }).historyHandoff).toBe("prev");
+    expect(processMultilineKey("", 0, { input: "[B" }).historyHandoff).toBe("next");
   });
 
   it("↑ moves cursor to the previous line, preserving column when possible", () => {


### PR DESCRIPTION
## Summary

Two bugs in #468.

### 1. ↑/↓ on an empty buffer used to scroll chat instead of recalling history

9254d3a moved history off ↑/↓ onto Ctrl+P / Ctrl+N because Windows Terminal + ConPTY can translate mouse-wheel events to ↑/↓ keystrokes — wheel-up was clobbering the prompt with a recalled message. b07b86e then bound empty-buffer ↑/↓ to chat-scroll.

That was the right call for users hitting the ConPTY-arrow case. But it broke the universal CLI muscle memory for everyone else (bash / zsh / fish all bind ↑ to history). Linux / macOS / modern Windows Terminal users don't have the wheel-translation problem to begin with — they just lost a binding they expect.

@dacec354 hit this on Konsole / fish / arch.

**Fix:** restore ↑/↓ on empty buffer = history. Keep Ctrl+P / Ctrl+N as the wheel-immune fallback (binding is unconditional, all platforms).

The App-level keystroke handler still routes ↑/↓ to chat-scroll once the chat is unpinned (App.tsx:1198), so on platforms with wheel-as-arrow the FIRST wheel-up from a pinned position will recall a prompt — but every subsequent wheel event keeps scrolling because the chat is now unpinned. ⌃P/N is one keystroke away if the muscle memory is sticky.

Dead `chatScrollHandoff` plumbing dropped (action field, two PromptInput props, the App.tsx wiring).

### 2. \`doctor\` reported "tokenizer not found" when it was installed

@dacec354's doctor output:
\`\`\`
⚠  tokenizer      data/deepseek-tokenizer.json.gz not found — token counts will fall back to char heuristics
\`\`\`

The tokenizer ships in the npm tarball under \`data/\` (it's in package.json:\`files\`). The runtime resolver in tokenizer.ts has three candidates including a \`createRequire("reasonix/package.json")\` probe — that finds it reliably.

The doctor had its OWN inline resolver that walked \`dist/cli/commands/doctor.js → ../../../data/\`. After the lazy-import refactor in #467 the doctor compiles to \`dist/cli/doctor-HASH.js\` (one level shallower), so \`../../../data/\` walks ABOVE the package root and reports missing. Three \`..\` should have been two.

**Fix:** export \`resolveDataPath\` from tokenizer.ts and reuse it in the doctor. Two paths can never disagree about where the tokenizer is.

## Test plan

- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx vitest run\` — 141 files, 2259 pass / 2 skip
- [x] Updated 5 existing test cases that asserted the old chat-scroll handoff behavior
- [ ] Visual check: wheel-scroll on Konsole / iTerm / kitty (should always work without surprise — wheel events bypass arrow keys natively); wheel-scroll on legacy ConPTY (first wheel-up may recall history, then unpinned-mode kicks in)

Closes #468