### PR TITLE
chore(release): 0.33.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,35 @@
 All notable changes to Reasonix. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.33.2] — 2026-05-09
+
+**Headline:** two bug fixes for #468 reported by @dacec354.
+
+**Bug fixes:**
+
+- fix(ui): ↑/↓ on an empty buffer recalls prompt history again. The
+  binding was unbound from arrows back in 9254d3a because Windows
+  Terminal + ConPTY can translate mouse-wheel events to ↑/↓
+  keystrokes (wheel-up was clobbering the prompt with a recalled
+  message); history moved to Ctrl+P / Ctrl+N. That was right for
+  legacy ConPTY but broke the universal CLI convention for
+  everyone else (bash / zsh / fish all bind ↑ to history). Restored
+  ↑/↓ on empty buffer = history; Ctrl+P / Ctrl+N stays as the
+  wheel-immune fallback. Dead `chatScrollHandoff` plumbing dropped.
+  (#475, closes part 1 of #468)
+
+- fix(doctor): tokenizer check now finds the file. The runtime
+  resolver in `tokenizer.ts` had three candidates including a
+  `createRequire("reasonix/package.json")` probe and worked
+  reliably; the doctor had its own copy of the path math that
+  walked `dist/cli/commands/doctor.js → ../../../data/`. After the
+  lazy-import refactor in #467 the doctor compiles to
+  `dist/cli/doctor-HASH.js` (one level shallower), so three `..`
+  walked above the package root and reported "tokenizer not
+  found" even when the npm tarball had it. Reuse the runtime
+  resolver so the two paths can never disagree. (#475, closes part
+  2 of #468)
+
 ## [0.33.1] — 2026-05-09
 
 **Headline:** the bottom status row now shows the wallet. Both

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reasonix",
-  "version": "0.33.1",
+  "version": "0.33.2",
   "description": "DeepSeek-native coding agent: cache-first loop, flash-first cost control, tool-call repair.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Release 0.33.2.

Bumps to 0.33.2 with a CHANGELOG entry covering #475 (closes #468).

## Headline

Two bug fixes from @dacec354's report on #468:

- **↑/↓ on empty buffer** recalls prompt history again (universal CLI convention). Ctrl+P / Ctrl+N stays as the wheel-immune fallback for legacy Windows ConPTY users.
- **`reasonix doctor`** finds the tokenizer instead of falsely reporting it missing. The runtime resolver was correct; the doctor had its own copy of the path math that broke after the lazy-import refactor in #467.

## PR

- **#475** — fix: ↑/↓ on empty buffer recall history; doctor finds tokenizer (closes #468)

## Test plan

- [x] CI green on #475 (141 files, 2259 pass)
- [ ] CI green on this release PR
- [ ] `npm publish` after merge