### PR TITLE
Structured TipCard variant for onboarding hints

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -45,7 +45,7 @@ import {
 import { Eventizer } from "../../core/eventize.js";
 import { pauseGate } from "../../core/pause-gate.js";
 import { type ResolvedHook, formatHookOutcomeMessage, loadHooks, runHooks } from "../../hooks.js";
-import { onLanguageChange, t } from "../../i18n/index.js";
+import { onLanguageChange, t, tObj } from "../../i18n/index.js";
 import { CacheFirstLoop, DeepSeekClient, ImmutablePrefix } from "../../index.js";
 import type { LoopEvent } from "../../loop.js";
 import {
@@ -1202,7 +1202,12 @@ function AppInner({
     // per install; the config flag suppresses re-display on every
     // relaunch. Skips chat mode — those shortcuts don't apply there.
     if (codeMode && !editModeHintShown()) {
-      log.pushInfo(t("ui.tipEditBindings"));
+      const tip = tObj<{
+        topic: string;
+        rows: ReadonlyArray<{ key: string; text: string }>;
+        footer: string;
+      }>("ui.tipEditBindings");
+      log.pushTip({ topic: tip.topic, rows: tip.rows, footer: tip.footer });
       markEditModeHintShown();
     }
   }, [session, loop, codeMode, syncPendingCount, log]);

--- a/src/cli/ui/cards/CardRenderer.tsx
+++ b/src/cli/ui/cards/CardRenderer.tsx
@@ -14,6 +14,7 @@ import { SearchCard } from "./SearchCard.js";
 import { StreamingCard } from "./StreamingCard.js";
 import { SubAgentCard } from "./SubAgentCard.js";
 import { TaskCard } from "./TaskCard.js";
+import { TipCard } from "./TipCard.js";
 import { ToolCard } from "./ToolCard.js";
 import { UsageCard } from "./UsageCard.js";
 import { UserCard } from "./UserCard.js";
@@ -58,6 +59,8 @@ function renderCard(card: Card): React.ReactElement {
       return <SearchCard card={card} />;
     case "live":
       return <LiveCard card={card} />;
+    case "tip":
+      return <TipCard card={card} />;
     case "ctx":
       return <CtxCard card={card} />;
     case "doctor":

--- a/src/cli/ui/cards/TipCard.tsx
+++ b/src/cli/ui/cards/TipCard.tsx
@@ -1,0 +1,59 @@
+import { Box, Text } from "ink";
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React from "react";
+import stringWidth from "string-width";
+import { t } from "../../../i18n/index.js";
+import type { TipCard as TipCardData } from "../state/cards.js";
+import { FG, TONE } from "../theme/tokens.js";
+
+const KEY_GUTTER = 4;
+
+export function TipCard({ card }: { card: TipCardData }): React.ReactElement {
+  const keyWidth = card.rows.reduce((max, r) => Math.max(max, stringWidth(r.key)), 0);
+  return (
+    <Box flexDirection="column" paddingLeft={2} marginY={1}>
+      <Box flexDirection="row" justifyContent="space-between">
+        <Box flexDirection="row" gap={1}>
+          <Text color={TONE.accent} bold>
+            ⓘ
+          </Text>
+          <Text color={FG.body} bold>
+            {card.topic}
+          </Text>
+        </Box>
+        {card.oneTime ? <Text color={FG.faint}>{t("ui.tipShownOnce")}</Text> : null}
+      </Box>
+      {card.rows.length > 0 ? (
+        <Box flexDirection="column" marginTop={1}>
+          {card.rows.map((row) => (
+            <TipRow key={row.key} keyText={row.key} text={row.text} keyWidth={keyWidth} />
+          ))}
+        </Box>
+      ) : null}
+      {card.footer ? (
+        <Box marginTop={1}>
+          <Text color={FG.faint}>{card.footer}</Text>
+        </Box>
+      ) : null}
+    </Box>
+  );
+}
+
+function TipRow({
+  keyText,
+  text,
+  keyWidth,
+}: {
+  keyText: string;
+  text: string;
+  keyWidth: number;
+}) {
+  const pad = " ".repeat(Math.max(0, keyWidth - stringWidth(keyText) + KEY_GUTTER));
+  return (
+    <Box flexDirection="row">
+      <Text color={TONE.accent}>{keyText}</Text>
+      <Text>{pad}</Text>
+      <Text color={FG.body}>{text}</Text>
+    </Box>
+  );
+}

--- a/src/cli/ui/hooks/useScrollback.ts
+++ b/src/cli/ui/hooks/useScrollback.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import type { DoctorCheckEntry, PlanStep } from "../state/cards.js";
+import type { DoctorCheckEntry, PlanStep, TipRow } from "../state/cards.js";
 import { useDispatch } from "../state/provider.js";
 
 let seq = 0;
@@ -22,6 +22,13 @@ export interface Scrollback {
     text: string,
     tone?: "info" | "ok" | "warn" | "err" | "ghost" | "brand" | "accent",
   ): string;
+  /** Structured onboarding-tip card — replaces multi-line TIP strings stuffed into pushInfo. */
+  pushTip(args: {
+    topic: string;
+    rows: ReadonlyArray<TipRow>;
+    footer?: string;
+    oneTime?: boolean;
+  }): string;
   /** Emits a `ctxPressure` live card when usedTokens crosses 80% (warn) or 95% (err) of ctxMax. */
   pushCtxPressureIfHigh(usedTokens: number, ctxMax: number): void;
   pushStepProgress(stepIndex: number, total: number, title: string, elapsedMs?: number): string;
@@ -136,6 +143,19 @@ export function useScrollback(): Scrollback {
           variant: "stepProgress",
           tone,
           text,
+        });
+        return id;
+      },
+      pushTip({ topic, rows, footer, oneTime = true }) {
+        const id = nextId("tip");
+        dispatch({
+          type: "tip.show",
+          id,
+          ts: Date.now(),
+          topic,
+          rows: rows.map((r) => ({ key: r.key, text: r.text })),
+          footer,
+          oneTime,
         });
         return id;
       },

--- a/src/cli/ui/state/cards-to-messages.ts
+++ b/src/cli/ui/state/cards-to-messages.ts
@@ -52,6 +52,14 @@ export function cardsToDashboardMessages(cards: ReadonlyArray<Card>): DashboardM
       case "ctx":
         out.push({ id: card.id, role: "info", text: card.text });
         break;
+      case "tip": {
+        const body = card.rows.map((r) => `${r.key}\t${r.text}`).join("\n");
+        const text = card.footer
+          ? `${card.topic}\n${body}\n${card.footer}`
+          : `${card.topic}\n${body}`;
+        out.push({ id: card.id, role: "info", text });
+        break;
+      }
       case "plan": {
         const done = card.steps.filter((s) => s.status === "done").length;
         const tag =

--- a/src/cli/ui/state/cards.ts
+++ b/src/cli/ui/state/cards.ts
@@ -192,6 +192,19 @@ export interface CtxCard extends CardBase {
   readonly topTools: ReadonlyArray<{ name: string; tokens: number; turn: number }>;
 }
 
+export interface TipRow {
+  readonly key: string;
+  readonly text: string;
+}
+
+export interface TipCard extends CardBase {
+  readonly kind: "tip";
+  readonly topic: string;
+  readonly rows: ReadonlyArray<TipRow>;
+  readonly footer?: string;
+  readonly oneTime: boolean;
+}
+
 export type Card =
   | UserCard
   | ReasoningCard
@@ -208,7 +221,8 @@ export type Card =
   | SearchCard
   | LiveCard
   | CtxCard
-  | DoctorCard;
+  | DoctorCard
+  | TipCard;
 
 export interface DoctorCheckEntry {
   readonly label: string;

--- a/src/cli/ui/state/events.ts
+++ b/src/cli/ui/state/events.ts
@@ -283,6 +283,16 @@ const liveShow = z.object({
   meta: z.string().optional(),
 });
 
+const tipShow = z.object({
+  type: z.literal("tip.show"),
+  id: cardId,
+  ts: ts,
+  topic: z.string(),
+  rows: z.array(z.object({ key: z.string(), text: z.string() })),
+  footer: z.string().optional(),
+  oneTime: z.boolean(),
+});
+
 export const AgentEventSchema = z.discriminatedUnion("type", [
   userSubmit,
   turnStart,
@@ -315,6 +325,7 @@ export const AgentEventSchema = z.discriminatedUnion("type", [
   toastShow,
   toastHide,
   liveShow,
+  tipShow,
   sessionReset,
   planShow,
   planStepComplete,

--- a/src/cli/ui/state/reducer.ts
+++ b/src/cli/ui/state/reducer.ts
@@ -173,6 +173,17 @@ export function reduce(state: AgentState, event: AgentEvent): AgentState {
         meta: event.meta,
       });
 
+    case "tip.show":
+      return appendCard(state, {
+        kind: "tip",
+        id: event.id,
+        ts: event.ts,
+        topic: event.topic,
+        rows: event.rows,
+        footer: event.footer,
+        oneTime: event.oneTime,
+      });
+
     case "session.reset":
       return { ...state, cards: [], focusedCardId: null, toasts: [] };
 

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -59,8 +59,16 @@ export const EN: TranslationSchema = {
     restoredEdits:
       "▸ restored {count} pending edit block(s) from an interrupted prior run — /apply to commit or /discard to drop.",
     resumedPlan: "Resumed plan · {when}{summary}",
-    tipEditBindings:
-      "▸ TIP: edit-gate keybindings\n    y / n       accept or drop pending edits\n    Shift+Tab   switch review ↔ AUTO (persisted; AUTO applies instantly)\n    u           undo the last auto-applied batch (within the 5s banner)\n  Current mode is shown in the bottom status bar. Run /keys anytime for the full list.\n  (This tip shows once — suppressed after.)",
+    tipEditBindings: {
+      topic: "edit-gate keybindings",
+      rows: [
+        { key: "y / n", text: "accept or drop pending edits" },
+        { key: "Shift+Tab", text: "switch review ↔ AUTO (persisted; AUTO applies instantly)" },
+        { key: "u", text: "undo the last auto-applied batch (within the 5s banner)" },
+      ],
+      footer: "Current mode shown in the bottom status bar · /keys for the full reference",
+    },
+    tipShownOnce: "shown once",
     modelOverride: "override the default model",
     noSession: "disable session persistence for this run",
     resumeHint: "force-resume the named session (even if idle)",

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -56,6 +56,24 @@ export function getSupportedLanguages(): LanguageCode[] {
   return Object.keys(translations) as LanguageCode[];
 }
 
+/** Returns a structured (non-string) translation entry — for tables / row objects passed to TipCard etc. */
+export function tObj<T>(path: string): T {
+  const parts = path.split(".");
+  let val: unknown = translations[currentLang] || translations.EN;
+  for (const part of parts) {
+    val = (val as Record<string, unknown> | undefined)?.[part];
+    if (val === undefined) break;
+  }
+  if (val === undefined && currentLang !== "EN") {
+    val = translations.EN;
+    for (const part of parts) {
+      val = (val as Record<string, unknown> | undefined)?.[part];
+      if (val === undefined) break;
+    }
+  }
+  return val as T;
+}
+
 /** Simple t() — nested keys (e.g. "common.error") + param replacement (e.g. "{code}"). */
 export function t(path: string, params?: Record<string, string | number>): string {
   const parts = path.split(".");

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -53,7 +53,12 @@ export interface TranslationSchema {
     ephemeralSession: string;
     restoredEdits: string;
     resumedPlan: string;
-    tipEditBindings: string;
+    tipEditBindings: {
+      topic: string;
+      rows: ReadonlyArray<{ key: string; text: string }>;
+      footer: string;
+    };
+    tipShownOnce: string;
     modelOverride: string;
     noSession: string;
     resumeHint: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -57,8 +57,16 @@ export const zhCN: TranslationSchema = {
     restoredEdits:
       "▸ 从中断的运行中恢复了 {count} 个待处理的编辑块 — /apply 提交或 /discard 放弃。",
     resumedPlan: "已恢复计划 · {when}{summary}",
-    tipEditBindings:
-      "▸ 提示：编辑门控快捷键\n    y / n       接受或放弃待处理的编辑\n    Shift+Tab   切换 预览 ↔ 自动 (持久化；自动模式立即应用)\n    u           撤消上次自动应用的批处理 (在 5 秒横幅内)\n  当前模式显示在底部状态栏。随时运行 /keys 查看完整列表。\n  (此提示仅显示一次 — 之后将隐藏。)",
+    tipEditBindings: {
+      topic: "编辑门控快捷键",
+      rows: [
+        { key: "y / n", text: "接受或放弃待处理的编辑" },
+        { key: "Shift+Tab", text: "切换 预览 ↔ 自动（持久化；自动模式立即应用）" },
+        { key: "u", text: "撤销上次自动应用的批处理（5 秒横幅内）" },
+      ],
+      footer: "当前模式显示在底部状态栏 · /keys 查看完整快捷键参考",
+    },
+    tipShownOnce: "仅显示一次",
     modelOverride: "覆盖默认模型",
     noSession: "禁用本次运行的会话持久化",
     resumeHint: "强制恢复指定会话（即使空闲）",


### PR DESCRIPTION
## Summary

Reported regression: the edit-gate tip looks ugly. Root cause is that
`pushInfo()` reuses the `stepProgress` LiveCard variant for what's
actually structured educational content — the renderer is a single-row
`[glyph] [text]` layout, so multi-line tip bodies get jammed into one
`<Text>` blob with hand-spaced columns that wrap badly on narrow
terminals.

Replace the borrowed surface with a dedicated `TipCard` kind so future
tips (mouse / clipboard, etc.) share a consistent, readable shape.

## What changes

**Visual (before → after)**

```
before:
  ✓ ▸ TIP: edit-gate keybindings
    y / n       accept or drop pending edits
    Shift+Tab   switch review ↔ AUTO (persisted; AUTO applies instantly)
    u           undo the last auto-applied batch (within the 5s banner)
  Current mode is shown in the bottom status bar. Run /keys anytime for the full list.
  (This tip shows once — suppressed after.)

after:
  ⓘ  edit-gate keybindings                                    shown once

     y / n        accept or drop pending edits
     Shift+Tab    switch review ↔ AUTO (persisted; AUTO applies instantly)
     u            undo the last auto-applied batch (within the 5s banner)

     Current mode shown in the bottom status bar · /keys for the full reference
```

- single `ⓘ` glyph (accent), no duplicated `▸ TIP:` prefix
- topic + `shown once` badge in a justified header row
- each row is its own `<Text>` with column alignment driven by
  `string-width` (works for CJK widths)
- footer separated by a blank row, dim color
- no border — tips are scrollback content, not modal

**Architecture**

- `TipCard` interface alongside the other kinds in `state/cards.ts`
- new `tip.show` event in `state/events.ts` (zod-validated like the rest)
- reducer case dispatches to `appendCard`
- `CardRenderer` branch renders `<TipCard>` from a new `cards/TipCard.tsx`
- `Scrollback.pushTip({ topic, rows, footer, oneTime })` alongside `pushInfo`
- `cards-to-messages.ts` flattens the tip back to text for the dashboard
  transcript export

**i18n**

- `tipEditBindings` becomes `{ topic, rows, footer }` in `types.ts` /
  `EN.ts` / `zh-CN.ts` — alignment is no longer faked with manual spaces
  in the localized string
- new `tipShownOnce` micro-string for the badge
- new helper `tObj<T>(path)` in `i18n/index.ts` for non-string entries;
  the existing `t()` is unchanged

## Test plan

- [x] `npm run verify` — build + lint + typecheck + 2291 tests pass
- [ ] Manual: launch `reasonix code` in a fresh workspace → first run
      shows the tip in the new layout
- [ ] Manual: zh-CN locale → CJK columns stay aligned (string-width
      drives padding, not space count)
- [ ] Manual: relaunch → tip suppressed (`editModeHintShown` flag)