### PR TITLE
C:/Program Files/Git/keys reference command + first-run mouse/clipboard tip

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -38,6 +38,8 @@ import {
   loadReasoningEffort,
   loadTheme,
   markEditModeHintShown,
+  markMouseClipboardHintShown,
+  mouseClipboardHintShown,
   resolveThemePreference,
   saveEditMode,
   saveReasoningEffort,
@@ -1204,11 +1206,20 @@ function AppInner({
     if (codeMode && !editModeHintShown()) {
       const tip = tObj<{
         topic: string;
-        rows: ReadonlyArray<{ key: string; text: string }>;
+        sections: ReadonlyArray<{ rows: ReadonlyArray<{ key: string; text: string }> }>;
         footer: string;
       }>("ui.tipEditBindings");
-      log.pushTip({ topic: tip.topic, rows: tip.rows, footer: tip.footer });
+      log.pushTip({ topic: tip.topic, sections: tip.sections, footer: tip.footer });
       markEditModeHintShown();
+    }
+    if (!mouseClipboardHintShown()) {
+      const tip = tObj<{
+        topic: string;
+        sections: ReadonlyArray<{ rows: ReadonlyArray<{ key: string; text: string }> }>;
+        footer: string;
+      }>("ui.tipMouseClipboard");
+      log.pushTip({ topic: tip.topic, sections: tip.sections, footer: tip.footer });
+      markMouseClipboardHintShown();
     }
   }, [session, loop, codeMode, syncPendingCount, log]);
 
@@ -2231,6 +2242,13 @@ function AppInner({
           postInfo: (text: string) => log.pushInfo(text),
           postDoctor: (checks) => log.showDoctor(checks),
           postUsage: (args) => log.showUsageVerbose(args),
+          postKeys: (args) =>
+            log.pushTip({
+              topic: args.topic,
+              sections: args.sections,
+              footer: args.footer,
+              oneTime: false,
+            }),
           dispatch: agentStore.dispatch,
           reloadHooks: () => {
             const fresh = loadHooks({ projectRoot: codeMode ? currentRootDir : undefined });

--- a/src/cli/ui/cards/TipCard.tsx
+++ b/src/cli/ui/cards/TipCard.tsx
@@ -3,13 +3,16 @@ import { Box, Text } from "ink";
 import React from "react";
 import stringWidth from "string-width";
 import { t } from "../../../i18n/index.js";
-import type { TipCard as TipCardData } from "../state/cards.js";
+import type { TipCard as TipCardData, TipRow as TipRowData } from "../state/cards.js";
 import { FG, TONE } from "../theme/tokens.js";
 
 const KEY_GUTTER = 4;
 
 export function TipCard({ card }: { card: TipCardData }): React.ReactElement {
-  const keyWidth = card.rows.reduce((max, r) => Math.max(max, stringWidth(r.key)), 0);
+  const keyWidth = card.sections.reduce(
+    (max, sec) => sec.rows.reduce((m, r) => Math.max(m, stringWidth(r.key)), max),
+    0,
+  );
   return (
     <Box flexDirection="column" paddingLeft={2} marginY={1}>
       <Box flexDirection="row" justifyContent="space-between">
@@ -23,13 +26,23 @@ export function TipCard({ card }: { card: TipCardData }): React.ReactElement {
         </Box>
         {card.oneTime ? <Text color={FG.faint}>{t("ui.tipShownOnce")}</Text> : null}
       </Box>
-      {card.rows.length > 0 ? (
-        <Box flexDirection="column" marginTop={1}>
-          {card.rows.map((row) => (
-            <TipRow key={row.key} keyText={row.key} text={row.text} keyWidth={keyWidth} />
+      {card.sections.map((section, i) => (
+        <Box key={section.title ?? `section-${i}`} flexDirection="column" marginTop={1}>
+          {section.title ? (
+            <Box marginBottom={0}>
+              <Text color={FG.sub}>{section.title}</Text>
+            </Box>
+          ) : null}
+          {section.rows.map((row) => (
+            <TipRowRender
+              key={row.key}
+              row={row}
+              keyWidth={keyWidth}
+              indent={section.title ? 2 : 0}
+            />
           ))}
         </Box>
-      ) : null}
+      ))}
       {card.footer ? (
         <Box marginTop={1}>
           <Text color={FG.faint}>{card.footer}</Text>
@@ -39,21 +52,23 @@ export function TipCard({ card }: { card: TipCardData }): React.ReactElement {
   );
 }
 
-function TipRow({
-  keyText,
-  text,
+function TipRowRender({
+  row,
   keyWidth,
+  indent,
 }: {
-  keyText: string;
-  text: string;
+  row: TipRowData;
   keyWidth: number;
+  indent: number;
 }) {
-  const pad = " ".repeat(Math.max(0, keyWidth - stringWidth(keyText) + KEY_GUTTER));
+  const pad = " ".repeat(Math.max(0, keyWidth - stringWidth(row.key) + KEY_GUTTER));
+  const lead = indent > 0 ? " ".repeat(indent) : "";
   return (
     <Box flexDirection="row">
-      <Text color={TONE.accent}>{keyText}</Text>
+      {lead ? <Text>{lead}</Text> : null}
+      <Text color={TONE.accent}>{row.key}</Text>
       <Text>{pad}</Text>
-      <Text color={FG.body}>{text}</Text>
+      <Text color={FG.body}>{row.text}</Text>
     </Box>
   );
 }

--- a/src/cli/ui/hooks/useScrollback.ts
+++ b/src/cli/ui/hooks/useScrollback.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import type { DoctorCheckEntry, PlanStep, TipRow } from "../state/cards.js";
+import type { DoctorCheckEntry, PlanStep, TipSection } from "../state/cards.js";
 import { useDispatch } from "../state/provider.js";
 
 let seq = 0;
@@ -25,7 +25,7 @@ export interface Scrollback {
   /** Structured onboarding-tip card — replaces multi-line TIP strings stuffed into pushInfo. */
   pushTip(args: {
     topic: string;
-    rows: ReadonlyArray<TipRow>;
+    sections: ReadonlyArray<TipSection>;
     footer?: string;
     oneTime?: boolean;
   }): string;
@@ -146,14 +146,17 @@ export function useScrollback(): Scrollback {
         });
         return id;
       },
-      pushTip({ topic, rows, footer, oneTime = true }) {
+      pushTip({ topic, sections, footer, oneTime = true }) {
         const id = nextId("tip");
         dispatch({
           type: "tip.show",
           id,
           ts: Date.now(),
           topic,
-          rows: rows.map((r) => ({ key: r.key, text: r.text })),
+          sections: sections.map((s) => ({
+            title: s.title,
+            rows: s.rows.map((r) => ({ key: r.key, text: r.text })),
+          })),
           footer,
           oneTime,
         });

--- a/src/cli/ui/slash/commands.ts
+++ b/src/cli/ui/slash/commands.ts
@@ -60,6 +60,11 @@ export const SLASH_COMMANDS: readonly SlashCommandSpec[] = [
     group: "info",
     summary: "health check (api / config / api-reach / index / hooks / project)",
   },
+  {
+    cmd: "keys",
+    group: "info",
+    summary: "keyboard + mouse + copy/paste reference",
+  },
 
   { cmd: "sessions", group: "session", summary: "list saved sessions (current marked with ▸)" },
 

--- a/src/cli/ui/slash/handlers/basic.ts
+++ b/src/cli/ui/slash/handlers/basic.ts
@@ -1,4 +1,4 @@
-import { t } from "@/i18n/index.js";
+import { t, tObj } from "@/i18n/index.js";
 import { formatDuration, formatLoopStatus, parseLoopCommand } from "../../loop.js";
 import { SLASH_COMMANDS } from "../commands.js";
 import type { SlashHandler } from "../dispatch.js";
@@ -129,10 +129,25 @@ const loop: SlashHandler = (args, _loop, ctx) => {
   };
 };
 
+const keys: SlashHandler = (_args, _loop, ctx) => {
+  if (!ctx.postKeys) return { info: t("handlers.basic.keysNeedsTui") };
+  const ref = tObj<{
+    topic: string;
+    sections: ReadonlyArray<{
+      title?: string;
+      rows: ReadonlyArray<{ key: string; text: string }>;
+    }>;
+    footer: string;
+  }>("ui.keysReference");
+  ctx.postKeys({ topic: ref.topic, sections: ref.sections, footer: ref.footer });
+  return {};
+};
+
 export const handlers: Record<string, SlashHandler> = {
   exit,
   new: resetLog,
   help,
   retry,
   loop,
+  keys,
 };

--- a/src/cli/ui/slash/types.ts
+++ b/src/cli/ui/slash/types.ts
@@ -90,6 +90,15 @@ export interface SlashContext {
     balanceCurrency?: string;
     elapsedMs?: number;
   }) => void;
+  /** Push the keyboard + mouse + copy/paste reference TipCard (multi-section). Used by `/keys`. */
+  postKeys?: (args: {
+    topic: string;
+    sections: ReadonlyArray<{
+      title?: string;
+      rows: ReadonlyArray<{ key: string; text: string }>;
+    }>;
+    footer?: string;
+  }) => void;
   dispatch?: (event: import("../state/events.js").AgentEvent) => void;
   setPlanMode?: (on: boolean) => void;
 

--- a/src/cli/ui/state/cards-to-messages.ts
+++ b/src/cli/ui/state/cards-to-messages.ts
@@ -53,7 +53,11 @@ export function cardsToDashboardMessages(cards: ReadonlyArray<Card>): DashboardM
         out.push({ id: card.id, role: "info", text: card.text });
         break;
       case "tip": {
-        const body = card.rows.map((r) => `${r.key}\t${r.text}`).join("\n");
+        const sectionTexts = card.sections.map((sec) => {
+          const body = sec.rows.map((r) => `${r.key}\t${r.text}`).join("\n");
+          return sec.title ? `[${sec.title}]\n${body}` : body;
+        });
+        const body = sectionTexts.join("\n\n");
         const text = card.footer
           ? `${card.topic}\n${body}\n${card.footer}`
           : `${card.topic}\n${body}`;

--- a/src/cli/ui/state/cards.ts
+++ b/src/cli/ui/state/cards.ts
@@ -197,10 +197,16 @@ export interface TipRow {
   readonly text: string;
 }
 
+export interface TipSection {
+  /** Subsection heading (rendered above its rows). Omit for single-section tips. */
+  readonly title?: string;
+  readonly rows: ReadonlyArray<TipRow>;
+}
+
 export interface TipCard extends CardBase {
   readonly kind: "tip";
   readonly topic: string;
-  readonly rows: ReadonlyArray<TipRow>;
+  readonly sections: ReadonlyArray<TipSection>;
   readonly footer?: string;
   readonly oneTime: boolean;
 }

--- a/src/cli/ui/state/events.ts
+++ b/src/cli/ui/state/events.ts
@@ -288,7 +288,12 @@ const tipShow = z.object({
   id: cardId,
   ts: ts,
   topic: z.string(),
-  rows: z.array(z.object({ key: z.string(), text: z.string() })),
+  sections: z.array(
+    z.object({
+      title: z.string().optional(),
+      rows: z.array(z.object({ key: z.string(), text: z.string() })),
+    }),
+  ),
   footer: z.string().optional(),
   oneTime: z.boolean(),
 });

--- a/src/cli/ui/state/reducer.ts
+++ b/src/cli/ui/state/reducer.ts
@@ -179,7 +179,7 @@ export function reduce(state: AgentState, event: AgentEvent): AgentState {
         id: event.id,
         ts: event.ts,
         topic: event.topic,
-        rows: event.rows,
+        sections: event.sections,
         footer: event.footer,
         oneTime: event.oneTime,
       });

--- a/src/config.ts
+++ b/src/config.ts
@@ -81,6 +81,7 @@ export interface ReasonixConfig {
   preset?: PresetName;
   editMode?: EditMode;
   editModeHintShown?: boolean;
+  mouseClipboardHintShown?: boolean;
   reasoningEffort?: ReasoningEffort;
   theme?: ThemeName | "auto";
   /** Stored as `--mcp`-format strings so one parser handles both flag and config. */
@@ -271,6 +272,11 @@ export function editModeHintShown(path: string = defaultConfigPath()): boolean {
   return readConfig(path).editModeHintShown === true;
 }
 
+/** True when the mouse-tracking + clipboard tip has been shown. */
+export function mouseClipboardHintShown(path: string = defaultConfigPath()): boolean {
+  return readConfig(path).mouseClipboardHintShown === true;
+}
+
 /** Unknown / missing fall back to "max" so hand-edited bad config can't silently override the default. */
 export function loadReasoningEffort(path: string = defaultConfigPath()): ReasoningEffort {
   const v = readConfig(path).reasoningEffort;
@@ -393,6 +399,14 @@ export function markEditModeHintShown(path: string = defaultConfigPath()): void 
   const cfg = readConfig(path);
   if (cfg.editModeHintShown === true) return;
   cfg.editModeHintShown = true;
+  writeConfig(cfg, path);
+}
+
+/** Mark the mouse + clipboard tip as shown. */
+export function markMouseClipboardHintShown(path: string = defaultConfigPath()): void {
+  const cfg = readConfig(path);
+  if (cfg.mouseClipboardHintShown === true) return;
+  cfg.mouseClipboardHintShown = true;
   writeConfig(cfg, path);
 }
 

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -61,12 +61,97 @@ export const EN: TranslationSchema = {
     resumedPlan: "Resumed plan · {when}{summary}",
     tipEditBindings: {
       topic: "edit-gate keybindings",
-      rows: [
-        { key: "y / n", text: "accept or drop pending edits" },
-        { key: "Shift+Tab", text: "switch review ↔ AUTO (persisted; AUTO applies instantly)" },
-        { key: "u", text: "undo the last auto-applied batch (within the 5s banner)" },
+      sections: [
+        {
+          rows: [
+            { key: "y / n", text: "accept or drop pending edits" },
+            {
+              key: "Shift+Tab",
+              text: "switch review ↔ AUTO (persisted; AUTO applies instantly)",
+            },
+            { key: "u", text: "undo the last auto-applied batch (within the 5s banner)" },
+          ],
+        },
       ],
       footer: "Current mode shown in the bottom status bar · /keys for the full reference",
+    },
+    tipMouseClipboard: {
+      topic: "mouse + clipboard",
+      sections: [
+        {
+          rows: [
+            { key: "wheel", text: "scrolls the chat history above" },
+            {
+              key: "right-click",
+              text: "captured by the app — use Ctrl+V (Win/Linux) or Cmd+V (macOS) to paste",
+            },
+            {
+              key: "Shift + drag",
+              text: "selects text natively (Option on iTerm2, Shift on Win Term / Alacritty / WezTerm)",
+            },
+          ],
+        },
+      ],
+      footer: "Run /keys for the full keyboard + mouse reference",
+    },
+    keysReference: {
+      topic: "Reasonix keys + mouse reference",
+      sections: [
+        {
+          title: "keyboard",
+          rows: [
+            { key: "Enter", text: "submit the prompt" },
+            { key: "Shift+Enter", text: "insert a newline in the prompt" },
+            { key: "Ctrl+P / Ctrl+N", text: "recall previous / next prompt from history" },
+            { key: "Ctrl+A / Ctrl+E", text: "jump to start / end of the current line" },
+            { key: "Ctrl+W", text: "delete the word before the cursor" },
+            { key: "Ctrl+U", text: "clear the entire prompt buffer" },
+            { key: "Tab", text: "complete @-mention · drill folder · accept slash command" },
+            { key: "Shift+Tab", text: "edit-gate: toggle review ↔ AUTO mode" },
+            { key: "Esc", text: "dismiss picker · abort the running model turn" },
+            { key: "Ctrl+C", text: "abort the running model turn (NOT copy — see clipboard)" },
+            {
+              key: "↑ / ↓",
+              text: "scroll chat history (PromptInput cursor when buffer non-empty)",
+            },
+            { key: "PgUp / PgDn", text: "scroll chat history a page at a time" },
+            { key: "End", text: "jump chat to the most recent line" },
+          ],
+        },
+        {
+          title: "mouse",
+          rows: [
+            { key: "wheel", text: "scrolls the chat history" },
+            { key: "right-click", text: "captured by the app — use Ctrl+V / Cmd+V to paste" },
+            { key: "left-click", text: "captured (no action yet — reserved for future use)" },
+          ],
+        },
+        {
+          title: "copy / paste",
+          rows: [
+            { key: "select text", text: "hold Shift while dragging (Option on iTerm2)" },
+            {
+              key: "copy",
+              text: "Ctrl+Shift+C (Win/Linux) · Cmd+C (macOS) — terminal-native after selection",
+            },
+            { key: "paste", text: "Ctrl+V or Ctrl+Shift+V (Win/Linux) · Cmd+V (macOS)" },
+            {
+              key: "bracketed paste",
+              text: "multi-line pastes stay one block — no auto-submit on intermediate newlines",
+            },
+          ],
+        },
+        {
+          title: "edit-gate (code mode)",
+          rows: [
+            { key: "y / n", text: "accept or drop pending edits in the review modal" },
+            { key: "Shift+Tab", text: "toggle review ↔ AUTO (persisted across sessions)" },
+            { key: "u", text: "undo the last auto-applied batch (within the 5s banner)" },
+          ],
+        },
+      ],
+      footer:
+        "Mouse tracking is on so the wheel scrolls chat instead of moving the cursor — that's why right-click no longer does the terminal's native paste.",
     },
     tipShownOnce: "shown once",
     modelOverride: "override the default model",
@@ -198,7 +283,7 @@ export const EN: TranslationSchema = {
         "shrink oversized tool results AND tool-call args (edit_file search/replace) in the log; cap in tokens, default 4000",
       argsHint: "[tokens]",
     },
-    keys: { description: "show all keyboard shortcuts and prompt prefixes" },
+    keys: { description: "keyboard + mouse + copy/paste reference" },
     plans: { description: "list this session's active + archived plans, newest first" },
     replay: {
       description: "load an archived plan as a read-only Time Travel snapshot (default: newest)",
@@ -478,6 +563,7 @@ export const EN: TranslationSchema = {
         "no active loop. Start one with `/loop <interval> <prompt>` (e.g. /loop 30s npm test).\nCancels on: /loop stop · Esc · /clear /new · any user-typed prompt.",
       loopStarted:
         '▸ loop started — re-submitting "{prompt}" every {duration}. Type anything (or /loop stop) to cancel.',
+      keysNeedsTui: "/keys needs a TUI context (postKeys wired).",
     },
     admin: {
       doctorNeedsTui: "/doctor needs a TUI context (postDoctor wired).",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -55,7 +55,26 @@ export interface TranslationSchema {
     resumedPlan: string;
     tipEditBindings: {
       topic: string;
-      rows: ReadonlyArray<{ key: string; text: string }>;
+      sections: ReadonlyArray<{
+        title?: string;
+        rows: ReadonlyArray<{ key: string; text: string }>;
+      }>;
+      footer: string;
+    };
+    tipMouseClipboard: {
+      topic: string;
+      sections: ReadonlyArray<{
+        title?: string;
+        rows: ReadonlyArray<{ key: string; text: string }>;
+      }>;
+      footer: string;
+    };
+    keysReference: {
+      topic: string;
+      sections: ReadonlyArray<{
+        title: string;
+        rows: ReadonlyArray<{ key: string; text: string }>;
+      }>;
       footer: string;
     };
     tipShownOnce: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -59,12 +59,91 @@ export const zhCN: TranslationSchema = {
     resumedPlan: "已恢复计划 · {when}{summary}",
     tipEditBindings: {
       topic: "编辑门控快捷键",
-      rows: [
-        { key: "y / n", text: "接受或放弃待处理的编辑" },
-        { key: "Shift+Tab", text: "切换 预览 ↔ 自动（持久化；自动模式立即应用）" },
-        { key: "u", text: "撤销上次自动应用的批处理（5 秒横幅内）" },
+      sections: [
+        {
+          rows: [
+            { key: "y / n", text: "接受或放弃待处理的编辑" },
+            { key: "Shift+Tab", text: "切换 预览 ↔ 自动（持久化；自动模式立即应用）" },
+            { key: "u", text: "撤销上次自动应用的批处理（5 秒横幅内）" },
+          ],
+        },
       ],
       footer: "当前模式显示在底部状态栏 · /keys 查看完整快捷键参考",
+    },
+    tipMouseClipboard: {
+      topic: "鼠标 + 剪贴板",
+      sections: [
+        {
+          rows: [
+            { key: "滚轮", text: "滚动上方的聊天记录" },
+            {
+              key: "右键",
+              text: "已被应用接管 — 用 Ctrl+V（Win/Linux）或 Cmd+V（macOS）粘贴",
+            },
+            {
+              key: "Shift + 拖动",
+              text: "原生选中文本（iTerm2 用 Option，Win Term / Alacritty / WezTerm 用 Shift）",
+            },
+          ],
+        },
+      ],
+      footer: "运行 /keys 查看完整键盘 + 鼠标参考",
+    },
+    keysReference: {
+      topic: "Reasonix 键盘 + 鼠标参考",
+      sections: [
+        {
+          title: "键盘",
+          rows: [
+            { key: "Enter", text: "提交输入" },
+            { key: "Shift+Enter", text: "在输入框中插入换行" },
+            { key: "Ctrl+P / Ctrl+N", text: "调出上一条 / 下一条历史提示" },
+            { key: "Ctrl+A / Ctrl+E", text: "跳到当前行的开头 / 结尾" },
+            { key: "Ctrl+W", text: "删除光标前的一个词" },
+            { key: "Ctrl+U", text: "清空整个输入缓冲区" },
+            { key: "Tab", text: "补全 @-mention · 进入文件夹 · 接受 slash 命令" },
+            { key: "Shift+Tab", text: "编辑门控：切换 预览 ↔ 自动 模式" },
+            { key: "Esc", text: "关闭弹出选择器 · 中止当前模型回合" },
+            { key: "Ctrl+C", text: "中止当前模型回合（不是复制 — 见剪贴板段）" },
+            { key: "↑ / ↓", text: "滚动聊天记录（缓冲区非空时为光标移动）" },
+            { key: "PgUp / PgDn", text: "整页滚动聊天记录" },
+            { key: "End", text: "跳到聊天的最新一行" },
+          ],
+        },
+        {
+          title: "鼠标",
+          rows: [
+            { key: "滚轮", text: "滚动聊天记录" },
+            { key: "右键", text: "被应用接管 — 用 Ctrl+V / Cmd+V 粘贴" },
+            { key: "左键", text: "被接管（暂无动作 — 预留给后续功能）" },
+          ],
+        },
+        {
+          title: "复制 / 粘贴",
+          rows: [
+            { key: "选中文字", text: "拖动时按住 Shift（iTerm2 用 Option）" },
+            {
+              key: "复制",
+              text: "Ctrl+Shift+C（Win/Linux）· Cmd+C（macOS）— 选中后由终端原生处理",
+            },
+            { key: "粘贴", text: "Ctrl+V 或 Ctrl+Shift+V（Win/Linux）· Cmd+V（macOS）" },
+            {
+              key: "bracketed paste",
+              text: "多行粘贴整体进入 — 中间换行不会触发提交",
+            },
+          ],
+        },
+        {
+          title: "编辑门控（仅 code 模式）",
+          rows: [
+            { key: "y / n", text: "在预览模态中接受或放弃待处理的编辑" },
+            { key: "Shift+Tab", text: "切换 预览 ↔ 自动（持久化）" },
+            { key: "u", text: "撤销上次自动应用的批处理（5 秒横幅内）" },
+          ],
+        },
+      ],
+      footer:
+        "鼠标追踪已开启，滚轮用来滚动聊天而不是移动光标 — 这也是右键不再触发终端原生粘贴的原因。",
     },
     tipShownOnce: "仅显示一次",
     modelOverride: "覆盖默认模型",
@@ -193,7 +272,7 @@ export const zhCN: TranslationSchema = {
       description: "缩小日志中过大的工具结果和工具调用参数；上限为 tokens，默认 4000",
       argsHint: "[tokens]",
     },
-    keys: { description: "显示所有键盘快捷键和提示前缀" },
+    keys: { description: "键盘 + 鼠标 + 复制粘贴参考" },
     plans: { description: "列出此会话的活跃 + 归档计划（最新在前）" },
     replay: {
       description: "加载归档计划为只读的时间旅行快照（默认：最新）",
@@ -456,6 +535,7 @@ export const zhCN: TranslationSchema = {
         "没有活动的循环。使用 `/loop <interval> <prompt>` 启动一个（例如 /loop 30s npm test）。\n取消方式：/loop stop · Esc · /clear /new · 任何用户输入的提示。",
       loopStarted:
         '▸ 循环已启动 — 每 {duration} 重新提交 "{prompt}"。输入任何内容（或 /loop stop）取消。',
+      keysNeedsTui: "/keys 需要 TUI 上下文（postKeys 已连接）。",
     },
     admin: {
       doctorNeedsTui: "/doctor 需要 TUI 上下文（postDoctor 已连接）。",


### PR DESCRIPTION
## Summary

Two layers around the new structured TipCard (#480):

**1. `/keys` — make the slash command real.**

`/keys` was already referenced in the edit-gate tip's footer (\"Run /keys
anytime for the full list\") but no handler existed; typing `/keys` hit
the unknown-command branch. Add the spec under the `info` group, a
handler that pushes a multi-section TipCard with the full reference,
and a `postKeys` callback on `SlashContext` wired to `log.pushTip`.

The reference is sectioned: keyboard / mouse / copy-paste / edit-gate.
Each section has its own subtitle and aligned key column, footer
explains why right-click no longer pastes natively.

**2. First-run mouse + clipboard tip.**

PR #479 enabled SGR mouse tracking so the wheel scrolls chat — but as
a side effect the terminal stops doing its native right-click-paste.
Without explanation users think the prompt is broken.

Add a one-time tip mirroring the edit-gate pattern: pushed on first
launch, suppressed thereafter via a `mouseClipboardHintShown` config
flag.

```
ⓘ  mouse + clipboard                                    shown once

   wheel          scrolls the chat history above
   right-click    captured by the app — use Ctrl+V (Win/Linux) or Cmd+V (macOS) to paste
   Shift + drag   selects text natively (Option on iTerm2, Shift on Win Term / Alacritty / WezTerm)

   Run /keys for the full keyboard + mouse reference
```

## Architecture changes

- `TipCard` now supports multiple sections (single-section tips just
  have one un-titled section). The previously-shipped `tipEditBindings`
  is re-wrapped in a single section; behavior unchanged.
- `Scrollback.pushTip()` API switched from `rows` to `sections`.
- `SlashContext.postKeys` callback added (mirrors `postDoctor` /
  `postUsage`).
- New config helpers `mouseClipboardHintShown()` /
  `markMouseClipboardHintShown()` next to the existing edit-gate pair.

## i18n

- `keysReference` (4 sections, ~25 rows) + `tipMouseClipboard` (1
  section, 3 rows) added to `types.ts` / `EN.ts` / `zh-CN.ts`.
- `handlers.basic.keysNeedsTui` for the non-TUI fallback.
- `slash.keys.description` already existed but its summary was outdated
  (\"show all keyboard shortcuts and prompt prefixes\") — refreshed in
  both languages to match the broader scope.

## Test plan

- [x] `npm run verify` — build + lint + typecheck + 2291 tests pass
- [ ] Manual: fresh launch shows BOTH the edit-gate tip and the new
      mouse/clipboard tip on first run; subsequent launches show
      neither
- [ ] Manual: typing `/keys` renders the full reference, no \"shown
      once\" badge
- [ ] Manual: zh-CN locale renders all sections with correct CJK
      column widths