### PR TITLE
Stop dashboard from pushing localStorage lang back to server

### DIFF
--- a/dashboard/src/lib/i18n.ts
+++ b/dashboard/src/lib/i18n.ts
@@ -16,7 +16,6 @@ const TO_BACKEND = new Map(LANG_REGISTRY);
 const FROM_BACKEND = new Map(LANG_REGISTRY.map(([d, b]) => [b, d]));
 
 const STORAGE_KEY = "rx.lang";
-const EXPLICIT_KEY = "rx.langExplicit";
 const listeners: Listener[] = [];
 let currentLang: DashboardLang = loadFromStorage() ?? "en";
 
@@ -30,22 +29,6 @@ function loadFromStorage(): DashboardLang | null {
   return null;
 }
 
-function isExplicit(): boolean {
-  try {
-    return localStorage.getItem(EXPLICIT_KEY) === "1";
-  } catch {
-    return false;
-  }
-}
-
-function markExplicit(): void {
-  try {
-    localStorage.setItem(EXPLICIT_KEY, "1");
-  } catch {
-    /* ignore */
-  }
-}
-
 function toBackendLang(lang: DashboardLang): string {
   return TO_BACKEND.get(lang) ?? lang;
 }
@@ -54,23 +37,12 @@ function fromBackendLang(raw: string): DashboardLang {
   return (FROM_BACKEND.get(raw) as DashboardLang) ?? "en";
 }
 
-/** Fetch lang from backend on startup. */
+/** Adopt server lang on startup; localStorage is render-cache only, never pushed back. */
 export async function initLangFromServer(): Promise<void> {
   try {
-    const stored = loadFromStorage();
     const res = await api<{ lang?: string }>("/settings");
     const serverLang = res.lang ? fromBackendLang(res.lang) : null;
-
-    if (!serverLang || stored === serverLang) return;
-
-    if (isExplicit() && stored) {
-      // User explicitly chose a language — push to server.
-      api("/settings", { method: "POST", body: { lang: toBackendLang(stored) } })
-        .catch((err) => console.error("[reasonix dashboard] lang sync:", err));
-      return;
-    }
-
-    // No explicit choice yet (first visit or cleared storage) — adopt server value.
+    if (!serverLang || serverLang === currentLang) return;
     currentLang = serverLang;
     try {
       localStorage.setItem(STORAGE_KEY, serverLang);
@@ -79,7 +51,7 @@ export async function initLangFromServer(): Promise<void> {
     }
     for (const cb of listeners) cb();
   } catch {
-    /* offline — keep localStorage value */
+    /* offline — keep last-known value rendering */
   }
 }
 
@@ -90,7 +62,6 @@ export function getLang(): DashboardLang {
 export function setLang(lang: DashboardLang): void {
   if (!SUPPORTED.has(lang)) return;
   currentLang = lang;
-  markExplicit();
   try {
     localStorage.setItem(STORAGE_KEY, lang);
   } catch {


### PR DESCRIPTION
## Summary

User report: language picked in CLI keeps reverting to English between
launches even though the dashboard tab is closed in the browser.

## Root cause

`dashboard/src/lib/i18n.ts` had a one-way sync rule in
`initLangFromServer()`: when localStorage's lang differed from the
server config, AND localStorage was tagged as \"explicit\" (meaning the
user once picked it via the dashboard panel), the dashboard POSTed
localStorage's value back to the server — silently overwriting any
CLI-side `/language` change.

Reproduction:

1. User picks zh-CN once in the dashboard panel → localStorage gets
   `rx.langExplicit=1`, `rx.lang=en` (or whatever)
2. User runs `/language zh-CN` in the CLI → server config is now zh-CN
3. User reopens any browser tab pointing at the dashboard (including
   tabs auto-restored on browser launch) → `initLangFromServer()` runs
   → POSTs the stale localStorage value back → server flips → CLI's
   choice is gone on next launch

The dashboard process never \"opened\" interactively — the user only
needed to have a tab from a previous session that the browser restored.

## Fix

Server config is the single source of truth. localStorage stays as a
render-cache to avoid a first-paint flicker, but is never pushed back.

Removes `EXPLICIT_KEY` / `isExplicit` / `markExplicit` entirely. The
\"adopt server value\" branch is now the only path. The stale
`rx.langExplicit` key in existing users' localStorage is harmless dead
data.

`setLang(lang)` (user explicitly picks in dashboard panel) still POSTs
to the server — that's the right path for dashboard-originated changes.

## Test plan

- [x] `npm run verify` — build + lint + typecheck + 2291 tests pass
- [x] Verified `dashboard/dist/app.js` rebuild contains no references
      to `rx.langExplicit` / `markExplicit` / `isExplicit`
- [ ] Manual: set CLI lang to zh-CN, leave dashboard tab open in
      browser, restart CLI → lang stays zh-CN
- [ ] Manual: change lang from dashboard panel → CLI picks it up on
      next launch (existing flow still works)