### PR TITLE
perf(ui): coalesce chat-scroll events into one render per frame

### DIFF
--- a/src/cli/ui/hooks/useChatScroll.ts
+++ b/src/cli/ui/hooks/useChatScroll.ts
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 /** Rows advanced per PgUp / PgDn / arrow / wheel — small for smooth feel. */
 export const SCROLL_PAGE_ROWS = 3;
+const COALESCE_MS = 16;
 
 export interface ChatScrollState {
   /** How many rows of content are above the visible viewport. */
@@ -21,6 +22,41 @@ export function useChatScroll(): ChatScrollState {
   const [scrollRows, setScrollRows] = useState(0);
   const [pinned, setPinned] = useState(true);
   const [maxScroll, setMaxScrollState] = useState(0);
+  const maxScrollRef = useRef(0);
+
+  const pendingDelta = useRef(0);
+  const flushTimer = useRef<NodeJS.Timeout | null>(null);
+
+  const flush = useCallback(() => {
+    flushTimer.current = null;
+    const d = pendingDelta.current;
+    pendingDelta.current = 0;
+    if (d === 0) return;
+    if (d < 0) setPinned(false);
+    setScrollRows((o) => {
+      const next = Math.max(0, Math.min(maxScrollRef.current, o + d));
+      if (next >= maxScrollRef.current) setPinned(true);
+      return next;
+    });
+  }, []);
+
+  const schedule = useCallback(
+    (delta: number) => {
+      pendingDelta.current += delta;
+      if (flushTimer.current !== null) return;
+      flushTimer.current = setTimeout(flush, COALESCE_MS);
+    },
+    [flush],
+  );
+
+  useEffect(() => {
+    return () => {
+      if (flushTimer.current !== null) {
+        clearTimeout(flushTimer.current);
+        flushTimer.current = null;
+      }
+    };
+  }, []);
 
   useEffect(() => {
     if (pinned) setScrollRows(maxScroll);
@@ -30,22 +66,22 @@ export function useChatScroll(): ChatScrollState {
     if (scrollRows > maxScroll) setScrollRows(maxScroll);
   }, [scrollRows, maxScroll]);
 
-  const scrollUp = useCallback(() => {
-    setPinned(false);
-    setScrollRows((o) => Math.max(0, o - SCROLL_PAGE_ROWS));
+  const scrollUp = useCallback(() => schedule(-SCROLL_PAGE_ROWS), [schedule]);
+  const scrollDown = useCallback(() => schedule(SCROLL_PAGE_ROWS), [schedule]);
+
+  const jumpToBottom = useCallback(() => {
+    pendingDelta.current = 0;
+    if (flushTimer.current !== null) {
+      clearTimeout(flushTimer.current);
+      flushTimer.current = null;
+    }
+    setPinned(true);
   }, []);
 
-  const scrollDown = useCallback(() => {
-    setScrollRows((o) => {
-      const next = Math.min(maxScroll, o + SCROLL_PAGE_ROWS);
-      if (next >= maxScroll) setPinned(true);
-      return next;
-    });
-  }, [maxScroll]);
-
-  const jumpToBottom = useCallback(() => setPinned(true), []);
-
-  const setMaxScroll = useCallback((rows: number) => setMaxScrollState(rows), []);
+  const setMaxScroll = useCallback((rows: number) => {
+    maxScrollRef.current = rows;
+    setMaxScrollState(rows);
+  }, []);
 
   return { scrollRows, pinned, scrollUp, scrollDown, jumpToBottom, setMaxScroll };
 }


### PR DESCRIPTION
## Why

Reported in #482: scrolling feels laggy in long sessions, gets worse the
more cards are in history.

Root cause is in `useChatScroll`: every PgUp / PgDn / arrow / wheel tick
calls `setScrollRows` synchronously. A single mouse-wheel gesture on
Windows fires 10–30 events, so each gesture triggers 10–30 full Yoga
layout passes over the entire `CardStream` subtree. Layout cost scales
linearly with card count — that's why the lag worsens with history
length.

## What

Coalesce scroll deltas into a ref (`pendingDelta`) and flush once per
~16ms. One scroll burst → one `setScrollRows` → one layout pass,
regardless of event volume. `pinned` flips inside the same flush so it
batches with `scrollRows` in React 19.

`jumpToBottom` (End key) cancels any pending delta + clears the timer
so it stays instant.

Public API of the hook is unchanged; `App.tsx` and `CardStream.tsx`
require no edits.

## Scope / non-goals

This is the cheap win. The deeper fix — pre-rendering cards to a row
buffer so Yoga isn't on the scroll/streaming hot path at all — is a
follow-up that I'll open as a tracking issue. That one also covers the
streaming-redraw lag in the same issue.

## Test plan

- [x] `npm run verify` — all 142 files / 2291 tests green, comment-policy
      clean, tsc clean
- [ ] manual: hold PgUp/PgDn + spin mouse wheel in a session with 50+
      cards; verify no missed events and no audible lag
- [ ] manual: End still snaps to bottom instantly while a scroll burst
      is in flight

Closes #482