### PR TITLE
tools: add top-level export outline to read_file auto-preview

### DIFF
--- a/src/tools/filesystem.ts
+++ b/src/tools/filesystem.ts
@@ -29,6 +29,50 @@ const DEFAULT_MAX_LIST_BYTES = 256 * 1024;
 const DEFAULT_AUTO_PREVIEW_LINES = 200;
 const AUTO_PREVIEW_HEAD_LINES = 80;
 const AUTO_PREVIEW_TAIL_LINES = 40;
+const OUTLINE_MAX_ENTRIES = 30;
+const OUTLINE_TAIL_KEEP = 5;
+
+type OutlineEntry = { line: number; kind: string; name: string };
+
+const TS_EXPORT_RE =
+  /^export\s+(?:default\s+)?(?:async\s+)?(function|class|const|let|var|interface|type|enum)\s+\*?\s*(\w+)/;
+
+function extractTsExportOutline(lines: readonly string[]): OutlineEntry[] {
+  const out: OutlineEntry[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (!line.startsWith("export ")) continue;
+    const m = TS_EXPORT_RE.exec(line);
+    if (!m) continue;
+    out.push({ line: i + 1, kind: m[1]!, name: m[2]! });
+  }
+  return out;
+}
+
+function formatOutline(entries: readonly OutlineEntry[]): string {
+  const total = entries.length;
+  if (total === 0) return "";
+  const lastEntry = entries[total - 1]!;
+  const width = String(lastEntry.line).length;
+  const fmt = (e: OutlineEntry) =>
+    `  L${String(e.line).padStart(width, " ")}  export ${e.kind} ${e.name}`;
+  const header = `[outline: ${total} top-level export${total === 1 ? "" : "s"}]`;
+  if (total <= OUTLINE_MAX_ENTRIES) {
+    return [header, ...entries.map(fmt)].join("\n");
+  }
+  const headCount = OUTLINE_MAX_ENTRIES - OUTLINE_TAIL_KEEP;
+  const headEntries = entries.slice(0, headCount);
+  const tailEntries = entries.slice(-OUTLINE_TAIL_KEEP);
+  const omitted = total - OUTLINE_MAX_ENTRIES;
+  const gapStart = headEntries[headEntries.length - 1]!.line;
+  const gapEnd = tailEntries[0]!.line;
+  return [
+    header,
+    ...headEntries.map(fmt),
+    `  [… ${omitted} more export${omitted === 1 ? "" : "s"} between L${gapStart} and L${gapEnd} …]`,
+    ...tailEntries.map(fmt),
+  ].join("\n");
+}
 
 /** Skipped unless `include_deps:true` — shared with the semantic indexer via DEFAULT_INDEX_EXCLUDES. */
 const SKIP_DIR_NAMES: ReadonlySet<string> = new Set(DEFAULT_INDEX_EXCLUDES.dirs);
@@ -110,7 +154,7 @@ export function registerFilesystemTools(
   - head: N  → first N lines (imports, public API, small configs)
   - tail: N  → last N lines (recently-added code, log tails)
   - range: "A-B"  → inclusive line range A..B, 1-indexed (e.g. "120-180" around an edit site)
-When none of these is given AND the file is longer than ${DEFAULT_AUTO_PREVIEW_LINES} lines, the tool auto-returns a head+tail preview with an "N lines omitted" marker rather than dumping everything. If you need the middle, re-call with a range. Prefer search_content to locate a symbol first, then read_file with a range around the hit — one scoped read beats three full-file reads.`,
+When none of these is given AND the file is longer than ${DEFAULT_AUTO_PREVIEW_LINES} lines, the tool auto-returns a head+tail preview with an "N lines omitted" marker, plus a top-level export outline (function / class / const / interface / type / enum names with line numbers, capped at ${OUTLINE_MAX_ENTRIES}) so you can pick a smart range without a follow-up grep. If you need the middle, re-call with a range. Prefer search_content to locate a symbol first only when the outline doesn't have what you want — one scoped read beats three full-file reads.`,
     readOnly: true,
     stormExempt: true,
     parameters: {
@@ -195,12 +239,17 @@ When none of these is given AND the file is longer than ${DEFAULT_AUTO_PREVIEW_L
       const head = lines.slice(0, AUTO_PREVIEW_HEAD_LINES).join("\n");
       const tail = lines.slice(totalLines - AUTO_PREVIEW_TAIL_LINES).join("\n");
       const omitted = totalLines - AUTO_PREVIEW_HEAD_LINES - AUTO_PREVIEW_TAIL_LINES;
-      return [
+      const outline = formatOutline(extractTsExportOutline(lines));
+      const parts: string[] = [
         `[auto-preview: head ${AUTO_PREVIEW_HEAD_LINES} + tail ${AUTO_PREVIEW_TAIL_LINES} of ${totalLines} lines]`,
         head,
+      ];
+      if (outline) parts.push("", outline);
+      parts.push(
         `\n[… ${omitted} lines omitted — call read_file again with range:"A-B" (1-indexed) or head / tail to get the middle]\n`,
         tail,
-      ].join("\n");
+      );
+      return parts.join("\n");
     },
   });
 

--- a/tests/filesystem-tools.test.ts
+++ b/tests/filesystem-tools.test.ts
@@ -93,6 +93,67 @@ describe("filesystem tools (built-in, sandbox-enforced)", () => {
       expect(out).not.toContain("line 200");
     });
 
+    it("auto-preview embeds a top-level export outline for TS-shaped files", async () => {
+      const filler = (n: number) => Array.from({ length: n }, () => "  // filler").join("\n");
+      const src = [
+        'import { foo } from "./foo";',
+        'import { bar } from "./bar";',
+        "",
+        "export interface AppProps {",
+        "  id: string;",
+        "}",
+        "",
+        filler(120),
+        "export function AppInner(props: AppProps) {",
+        "  return null;",
+        "}",
+        filler(80),
+        "export const handleSubmit = () => {};",
+        filler(38),
+        "export default AppInner;",
+      ].join("\n");
+      await fs.writeFile(join(root, "App.tsx"), src);
+      const out = await tools.dispatch("read_file", JSON.stringify({ path: "App.tsx" }));
+      expect(out).toMatch(/\[outline: 3 top-level exports\]/);
+      expect(out).toMatch(/L\s*4\s+export interface AppProps/);
+      expect(out).toMatch(/L128\s+export function AppInner/);
+      expect(out).toMatch(/L211\s+export const handleSubmit/);
+    });
+
+    it("auto-preview omits the outline when no top-level exports are present", async () => {
+      const src = Array.from({ length: 220 }, (_, i) => `line ${i + 1}`).join("\n");
+      await fs.writeFile(join(root, "plain.txt"), src);
+      const out = await tools.dispatch("read_file", JSON.stringify({ path: "plain.txt" }));
+      expect(out).toMatch(/auto-preview: /);
+      expect(out).not.toMatch(/\[outline:/);
+    });
+
+    it("auto-preview outline elides the middle when more than 30 exports", async () => {
+      // Spread the 35 exports out so head/tail slices don't mask the elision.
+      const lines: string[] = [];
+      const exportPositions: number[] = [];
+      for (let i = 0; i < 35; i++) {
+        for (let f = 0; f < 6; f++) lines.push(`// filler block ${i}-${f}`);
+        exportPositions.push(lines.length + 1);
+        lines.push(`export const sym${String(i + 1).padStart(2, "0")} = ${i + 1};`);
+      }
+      for (let i = 0; i < 60; i++) lines.push(`// trailer ${i}`);
+      await fs.writeFile(join(root, "many.ts"), lines.join("\n"));
+      const out = await tools.dispatch("read_file", JSON.stringify({ path: "many.ts" }));
+      const outlineMatch = /\[outline: 35 top-level exports\]([\s\S]*?)\n\n/.exec(out);
+      expect(outlineMatch).not.toBeNull();
+      const outlineBlock = outlineMatch![1]!;
+      expect(outlineBlock).toMatch(/export const sym01/);
+      expect(outlineBlock).toMatch(/export const sym25/);
+      expect(outlineBlock).not.toMatch(/export const sym26/);
+      expect(outlineBlock).not.toMatch(/export const sym30/);
+      expect(outlineBlock).toMatch(/export const sym31/);
+      expect(outlineBlock).toMatch(/export const sym35/);
+      const gapStart = exportPositions[24]!;
+      const gapEnd = exportPositions[30]!;
+      expect(outlineBlock).toContain(`[… 5 more exports between L${gapStart} and L${gapEnd} …]`);
+    });
+
     it("returns full content when file is at or below the auto-preview threshold", async () => {
       const out = await tools.dispatch("read_file", JSON.stringify({ path: "hello.txt" }));
       expect(out).toBe("line 1\nline 2\nline 3");


### PR DESCRIPTION
## Summary

When `read_file` auto-preview fires (file > 200 lines, no `head` / `tail` / `range` given), the head 80 + tail 40 slice doesn't cover the full export list of a real-shape file. Callers had to follow up with `search_content` to find "where is `function AppInner` defined" before picking a useful `range`.

This PR embeds a top-level export outline between the head slice and the omitted-marker — function / class / const / interface / type / enum names with their line numbers — so the caller can pick a range without a follow-up grep.

- Cap: 30 entries (first 25 + last 5 + an elide marker like `[… N more exports between Lx and Ly …]`).
- Skipped when the file has zero matching exports, so `.txt` / `.md` / `.json` aren't polluted with empty outlines.
- TS-leaning regex (`^export ...`); language-aware parsing is intentionally out of scope.

Closes #487

## Test plan

- [x] `tests/filesystem-tools.test.ts` — three new cases: outline present + line numbers correct, outline absent for export-less files, outline elision when > 30 exports.
- [x] `npm run verify` (full suite, 2294 tests).