### PR TITLE
subagent: tell the child its iter budget, warn near the cap

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -47,12 +47,20 @@ export type ToolInterceptor = (
   args: Record<string, unknown>,
 ) => string | null | undefined | Promise<string | null | undefined>;
 
+/** Final-stage post-processor — runs on every dispatch return (success and error paths) so callers can append context like a remaining-budget hint. Whatever it returns becomes the dispatch result. */
+export type ToolResultAugmenter = (
+  name: string,
+  args: Record<string, unknown>,
+  result: string,
+) => string;
+
 export class ToolRegistry {
   private readonly _tools = new Map<string, InternalTool>();
   private readonly _autoFlatten: boolean;
   private _planMode = false;
   private _interceptor: ToolInterceptor | null = null;
   private _auditListener: ToolCallAuditListener | null = null;
+  private _resultAugmenter: ToolResultAugmenter | null = null;
 
   constructor(opts: ToolRegistryOptions = {}) {
     this._autoFlatten = opts.autoFlatten !== false;
@@ -75,6 +83,11 @@ export class ToolRegistry {
 
   setAuditListener(fn: ToolCallAuditListener | null): void {
     this._auditListener = fn;
+  }
+
+  /** Final-stage post-processor; replaces previous augmenter when called twice. Pass null to clear. */
+  setResultAugmenter(fn: ToolResultAugmenter | null): void {
+    this._resultAugmenter = fn;
   }
 
   register<A, R>(def: ToolDefinition<A, R>): this {
@@ -192,6 +205,7 @@ export class ToolRegistry {
       }
     }
 
+    let finalResult: string;
     try {
       try {
         this._auditListener?.({ name, args });
@@ -219,7 +233,7 @@ export class ToolRegistry {
       if (opts.maxResultChars !== undefined) {
         clipped = truncateForModel(clipped, opts.maxResultChars);
       }
-      return clipped;
+      finalResult = clipped;
     } catch (err) {
       const e = err as Error & { toToolResult?: () => unknown };
       // Errors may opt into a richer tool-result shape by implementing
@@ -229,15 +243,23 @@ export class ToolRegistry {
       // but keeping payloads structured is cleaner for UI parsing).
       if (typeof e.toToolResult === "function") {
         try {
-          return JSON.stringify(e.toToolResult());
+          finalResult = JSON.stringify(e.toToolResult());
         } catch {
-          /* fall through to the default shape */
+          finalResult = JSON.stringify({ error: `${e.name}: ${e.message}` });
         }
+      } else {
+        finalResult = JSON.stringify({ error: `${e.name}: ${e.message}` });
       }
-      return JSON.stringify({
-        error: `${e.name}: ${e.message}`,
-      });
     }
+
+    if (this._resultAugmenter) {
+      try {
+        return this._resultAugmenter(name, args, finalResult);
+      } catch {
+        /* augmenter must never break the tool result */
+      }
+    }
+    return finalResult;
   }
 }
 

--- a/src/tools/subagent.ts
+++ b/src/tools/subagent.ts
@@ -101,6 +101,12 @@ const DEFAULT_MAX_RESULT_CHARS = 8000;
 const DEFAULT_MAX_ITERS = 16;
 const MIN_MAX_ITERS = 1;
 const MAX_MAX_ITERS = 32;
+/** Iters-from-cap at which we start appending a remaining-budget hint to tool results. */
+const BUDGET_WARN_THRESHOLD = 3;
+
+function budgetParagraph(maxToolIters: number): string {
+  return `Tool budget: you have ${maxToolIters} tool call${maxToolIters === 1 ? "" : "s"} for this task. The cap is enforced from outside — the call after #${maxToolIters} is refused. Pace yourself: if you can't fully resolve the task within the budget, stop early and return what you have plus what's missing, rather than burning the budget on one branch.`;
+}
 // Subagents default to flash — their work is read-and-synthesize
 // (explore, research), which doesn't need the 12× pro tier. Skill
 // frontmatter `model: deepseek-v4-pro` is the opt-in override for
@@ -176,8 +182,23 @@ export async function spawnSubagent(opts: SpawnSubagentOptions): Promise<Subagen
         NEVER_INHERITED_TOOLS,
       )
     : forkRegistryExcluding(opts.parentRegistry, NEVER_INHERITED_TOOLS);
+  // Budget telemetry: count dispatches and append a remaining-iters hint
+  // when the child is within BUDGET_WARN_THRESHOLD of the cap, so the
+  // model can choose to wrap up rather than open another rabbit hole.
+  let dispatchCount = 0;
+  childTools.setResultAugmenter((_name, _args, result) => {
+    dispatchCount++;
+    const remaining = maxToolIters - dispatchCount;
+    if (remaining <= 0) {
+      return `${result}\n\n[budget: 0 of ${maxToolIters} tool calls left — finalize NOW; the next tool call will be refused]`;
+    }
+    if (remaining <= BUDGET_WARN_THRESHOLD) {
+      return `${result}\n\n[budget: ${remaining} of ${maxToolIters} tool call${remaining === 1 ? "" : "s"} left — wrap up soon]`;
+    }
+    return result;
+  });
   const childPrefix = new ImmutablePrefix({
-    system: opts.system,
+    system: `${opts.system}\n\n${budgetParagraph(maxToolIters)}`,
     toolSpecs: childTools.specs(),
   });
   const childLoop = new CacheFirstLoop({

--- a/tests/subagent.test.ts
+++ b/tests/subagent.test.ts
@@ -288,7 +288,8 @@ describe("registerSubagentTool", () => {
       "spawn_subagent",
       JSON.stringify({ task: "go", system: "You are a custom subagent." }),
     );
-    expect(seenSystems[0]).toBe("You are a custom subagent.");
+    expect(seenSystems[0]).toContain("You are a custom subagent.");
+    expect(seenSystems[0]).toMatch(/Tool budget: you have \d+ tool calls/);
   });
 
   it("falls back to the default model when the model arg is invalid", async () => {
@@ -526,7 +527,8 @@ describe("registerSubagentTool", () => {
       "spawn_subagent",
       JSON.stringify({ task: "go", type: "explore", system: "I am a custom prompt." }),
     );
-    expect(seenSystems[0]).toBe("I am a custom prompt.");
+    expect(seenSystems[0]).toContain("I am a custom prompt.");
+    expect(seenSystems[0]).toMatch(/Tool budget: you have 20 tool calls/);
   });
 
   it("omitted type leaves the default persona and budget unchanged", async () => {
@@ -537,6 +539,40 @@ describe("registerSubagentTool", () => {
     const out = await parent.dispatch("spawn_subagent", JSON.stringify({ task: "loop please" }));
     const parsed = JSON.parse(out);
     expect(parsed.tool_iters).toBe(5);
+  });
+
+  it("appends a remaining-budget hint to tool results within 3 iters of the cap", async () => {
+    // Drive 5 tool calls then a stop. The augmenter should append a hint
+    // starting at iter 2 (remaining=3) through iter 5 (remaining=0).
+    const responses = [...makeToolCallResponses(5), { content: "done" }];
+    const innerFetch = fakeFetch(responses);
+    const seenToolResults: string[] = [];
+    const fetchSpy = vi.fn(async (url: any, init: any) => {
+      const body = init?.body ? JSON.parse(init.body) : {};
+      for (const m of body.messages ?? []) {
+        if (m.role === "tool") seenToolResults.push(m.content);
+      }
+      return innerFetch(url, init);
+    });
+    const client = new DeepSeekClient({
+      apiKey: "sk-test",
+      fetch: fetchSpy as any,
+    });
+    const parent = new ToolRegistry();
+    parent.register({ name: "noop", readOnly: true, fn: () => "noop-result" });
+    registerSubagentTool(parent, { client, maxToolIters: 5 });
+    await parent.dispatch("spawn_subagent", JSON.stringify({ task: "go" }));
+    expect(seenToolResults.length).toBeGreaterThanOrEqual(5);
+    // Each tool result is sent on every subsequent turn — dedupe by
+    // taking the first occurrence of each unique result.
+    const unique = Array.from(new Set(seenToolResults));
+    expect(unique).toHaveLength(5);
+    expect(unique[0]).not.toMatch(/budget:/);
+    expect(unique[0]).toBe("noop-result");
+    expect(unique[1]).toMatch(/\[budget: 3 of 5 tool calls left/);
+    expect(unique[2]).toMatch(/\[budget: 2 of 5 tool calls left/);
+    expect(unique[3]).toMatch(/\[budget: 1 of 5 tool call left/);
+    expect(unique[4]).toMatch(/\[budget: 0 of 5 tool calls left — finalize NOW/);
   });
 });
 


### PR DESCRIPTION
## Summary

Subagents had no visibility into their own tool-iter budget. The parent's `maxToolIters` capped the loop from outside, but the child neither knew the cap nor its current iteration — so an `explore` run could burn all 20 iters mapping the territory, hit the cap mid-thought, and emit a partial summary the parent had to re-dispatch.

This PR closes the gap with prompt + telemetry:

1. **System-prompt budget line** — `spawnSubagent` appends a one-paragraph "Tool budget: you have N tool calls" notice with the resolved cap baked in, applied uniformly to default, typed (`explore` / `verify`), and caller-supplied system prompts.
2. **Run-time countdown via `setResultAugmenter`** — a new final-stage post-hook on `ToolRegistry.dispatch()`. `spawnSubagent` installs one that counts dispatches and appends `[budget: K of N tool calls left — wrap up soon]` once the child is within 3 iters of the cap, escalating to `[budget: 0 left — finalize NOW]` on the last call.

Static prompt sets the expectation; dynamic countdown forces reckoning when the budget is actually tight.

Closes #488

## Test plan

- [x] `tests/subagent.test.ts` — new case drives 5 tool calls under a `maxToolIters: 5` budget and asserts the augmented tool-result content at each iteration (no warning on iter 1, then `3 / 2 / 1 / 0 left` on iters 2–5).
- [x] Existing custom-system-prompt tests updated from `.toBe` to `.toContain` + a regex match for the budget line.
- [x] `npm run verify` (full suite, 2292 tests).