### PR TITLE
search: per-file cap + histogram fallback for search_content

### DIFF
--- a/src/tools/filesystem.ts
+++ b/src/tools/filesystem.ts
@@ -352,7 +352,7 @@ Prefer \`list_directory\` for a single-level view, \`search_files\` to find spec
     name: "search_content",
     parallelSafe: true,
     description:
-      "Recursively grep file CONTENTS for a substring or regex. This is the right tool for 'find all places that call X', 'where is Y referenced', 'what files contain Z'. Different from search_files (which matches FILE NAMES). Returns one match per line in 'path:line: text' format. Skips dependency / VCS / build directories (node_modules, .git, dist, build, .next, target, .venv) and binary files by default.",
+      "Recursively grep file CONTENTS for a substring or regex. This is the right tool for 'find all places that call X', 'where is Y referenced', 'what files contain Z'. Different from search_files (which matches FILE NAMES). Returns one match per line in 'path:line: text' format. Per-file hits are capped at 30 (a footer reports any extras); when the byte budget is mostly spent the remaining files switch to a 'rel: N matches' histogram so distribution stays visible instead of one popular file drowning the rest. Pass `summary_only:true` to skip line content entirely and get just the histogram. Skips dependency / VCS / build directories (node_modules, .git, dist, build, .next, target, .venv) and binary files by default.",
     readOnly: true,
     parameters: {
       type: "object",
@@ -384,6 +384,11 @@ Prefer \`list_directory\` for a single-level view, \`search_files\` to find spec
           description:
             "Lines of context to show around each match (both before and after). Default 0 (just the matching line). Capped at 20. Output uses ripgrep style: `:` after the line number on the matching line, `-` on context lines, `--` separating non-adjacent windows.",
         },
+        summary_only: {
+          type: "boolean",
+          description:
+            "When true, skip line content and return one 'rel: N matches' line per matching file. Use for 'where does this exist at all' questions before drilling in with a targeted read_file.",
+        },
       },
       required: ["pattern"],
     },
@@ -395,6 +400,7 @@ Prefer \`list_directory\` for a single-level view, \`search_files\` to find spec
         case_sensitive?: boolean;
         include_deps?: boolean;
         context?: number;
+        summary_only?: boolean;
       },
       toolCtx,
     ) =>

--- a/src/tools/fs/search.ts
+++ b/src/tools/fs/search.ts
@@ -67,6 +67,11 @@ export async function searchFiles(
   return matches.length === 0 ? "(no matches)" : matches.join("\n");
 }
 
+/** Per-file printed-hit cap; beyond this we emit a "N more matches in this file" footer. */
+const MAX_HITS_PER_FILE = 30;
+/** Once printed bytes pass this fraction of the byte budget, remaining files switch to histogram. */
+const SUMMARY_MODE_TRIGGER_RATIO = 0.8;
+
 export async function searchContent(
   ctx: SearchContext,
   startAbs: string,
@@ -75,6 +80,8 @@ export async function searchContent(
     case_sensitive?: boolean;
     include_deps?: boolean;
     context?: number;
+    /** Skip line content; return only "rel: N matches" per file. */
+    summary_only?: boolean;
     signal?: AbortSignal;
   },
 ): Promise<string> {
@@ -82,6 +89,7 @@ export async function searchContent(
   const caseSensitive = args.case_sensitive === true;
   const includeDeps = args.include_deps === true;
   const ctxLines = Math.max(0, Math.min(20, Math.floor(args.context ?? 0)));
+  const summaryOnly = args.summary_only === true;
   let re: RegExp | null = null;
   try {
     re = new RegExp(args.pattern, caseSensitive ? "" : "i");
@@ -93,6 +101,9 @@ export async function searchContent(
   let totalBytes = 0;
   let scanned = 0;
   let truncated = false;
+  let summaryMode = summaryOnly;
+  let summaryNoticeEmitted = false;
+  const fileHitCounts = new Map<string, number>();
 
   const pushLine = (out: string): boolean => {
     if (totalBytes + out.length + 1 > ctx.maxListBytes) {
@@ -103,6 +114,19 @@ export async function searchContent(
     matches.push(out);
     totalBytes += out.length + 1;
     return true;
+  };
+
+  const maybeEnterSummaryMode = (): void => {
+    if (summaryMode) return;
+    if (totalBytes <= SUMMARY_MODE_TRIGGER_RATIO * ctx.maxListBytes) return;
+    summaryMode = true;
+    if (!summaryNoticeEmitted) {
+      const pct = Math.round((totalBytes / ctx.maxListBytes) * 100);
+      pushLine(
+        `[switching to summary mode — byte budget at ${pct}%; remaining files will report match counts only]`,
+      );
+      summaryNoticeEmitted = true;
+    }
   };
 
   const walk = async (dir: string): Promise<void> => {
@@ -162,33 +186,55 @@ export async function searchContent(
       }
       scanned++;
       if (hits.length === 0) continue;
+      fileHitCounts.set(rel, hits.length);
+
+      if (summaryMode) {
+        if (!pushLine(`${rel}: ${hits.length} match${hits.length === 1 ? "" : "es"}`)) return;
+        continue;
+      }
+
+      const printable = Math.min(hits.length, MAX_HITS_PER_FILE);
+      const omittedFromFile = hits.length - printable;
+      const printableHits = hits.slice(0, printable);
+
       if (ctxLines === 0) {
-        for (const li of hits) {
+        for (const li of printableHits) {
           if (truncated) return;
           const line = lines[li]!;
           const display = line.length > 200 ? `${line.slice(0, 200)}…` : line;
           if (!pushLine(`${rel}:${li + 1}: ${display}`)) return;
         }
-        continue;
-      }
-      const hitSet = new Set(hits);
-      let prevWindowEnd = -2;
-      for (const li of hits) {
-        if (truncated) return;
-        const winStart = Math.max(0, li - ctxLines);
-        const winEnd = Math.min(lines.length - 1, li + ctxLines);
-        if (winStart > prevWindowEnd + 1 && prevWindowEnd >= 0) {
-          if (!pushLine("--")) return;
+      } else {
+        const hitSet = new Set(printableHits);
+        let prevWindowEnd = -2;
+        for (const li of printableHits) {
+          if (truncated) return;
+          const winStart = Math.max(0, li - ctxLines);
+          const winEnd = Math.min(lines.length - 1, li + ctxLines);
+          if (winStart > prevWindowEnd + 1 && prevWindowEnd >= 0) {
+            if (!pushLine("--")) return;
+          }
+          const realStart = winStart > prevWindowEnd + 1 ? winStart : prevWindowEnd + 1;
+          for (let i = realStart; i <= winEnd; i++) {
+            const line = lines[i]!;
+            const display = line.length > 200 ? `${line.slice(0, 200)}…` : line;
+            const sep = hitSet.has(i) ? ":" : "-";
+            if (!pushLine(`${rel}:${i + 1}${sep} ${display}`)) return;
+          }
+          prevWindowEnd = winEnd;
         }
-        const realStart = winStart > prevWindowEnd + 1 ? winStart : prevWindowEnd + 1;
-        for (let i = realStart; i <= winEnd; i++) {
-          const line = lines[i]!;
-          const display = line.length > 200 ? `${line.slice(0, 200)}…` : line;
-          const sep = hitSet.has(i) ? ":" : "-";
-          if (!pushLine(`${rel}:${i + 1}${sep} ${display}`)) return;
-        }
-        prevWindowEnd = winEnd;
       }
+
+      if (omittedFromFile > 0) {
+        if (
+          !pushLine(
+            `[${rel}: ${omittedFromFile} more match${omittedFromFile === 1 ? "" : "es"} in this file — re-grep with a tighter pattern or use read_file to see them]`,
+          )
+        )
+          return;
+      }
+
+      maybeEnterSummaryMode();
     }
   };
   await walk(startAbs);

--- a/tests/filesystem-tools.test.ts
+++ b/tests/filesystem-tools.test.ts
@@ -501,6 +501,71 @@ describe("filesystem tools (built-in, sandbox-enforced)", () => {
         expect(out).not.toContain("gamma.tsx:");
       });
     });
+
+    describe("per-file cap and histogram fallback", () => {
+      it("caps a single file's printed hits at 30 and footers the overflow", async () => {
+        const lines = Array.from({ length: 47 }, () => "TARGETSTRING here");
+        await fs.writeFile(join(root, "many.ts"), lines.join("\n"));
+        const out = await tools.dispatch(
+          "search_content",
+          JSON.stringify({ pattern: "TARGETSTRING", glob: "many.ts" }),
+        );
+        const hitLines = out.split("\n").filter((l) => /^many\.ts:\d+:/.test(l));
+        expect(hitLines).toHaveLength(30);
+        expect(out).toMatch(/\[many\.ts: 17 more matches in this file/);
+      });
+
+      it("does not emit the cap footer when hits fit under the cap", async () => {
+        const lines = Array.from({ length: 5 }, () => "TARGETSTRING here");
+        await fs.writeFile(join(root, "few.ts"), lines.join("\n"));
+        const out = await tools.dispatch(
+          "search_content",
+          JSON.stringify({ pattern: "TARGETSTRING", glob: "few.ts" }),
+        );
+        expect(out).not.toMatch(/more matches in this file/);
+      });
+
+      it("summary_only:true returns histogram with no line content", async () => {
+        await fs.writeFile(
+          join(root, "a.ts"),
+          ["MARK one", "noise", "MARK two", "MARK three"].join("\n"),
+        );
+        await fs.writeFile(join(root, "b.ts"), ["MARK only"].join("\n"));
+        const out = await tools.dispatch(
+          "search_content",
+          JSON.stringify({ pattern: "MARK", summary_only: true, glob: "*.ts" }),
+        );
+        expect(out).toContain("a.ts: 3 matches");
+        expect(out).toContain("b.ts: 1 match");
+        expect(out).not.toMatch(/MARK one/);
+        expect(out).not.toMatch(/MARK two/);
+      });
+
+      it("flips remaining files to summary mode once 80% of the byte budget is spent", async () => {
+        const tiny = new ToolRegistry();
+        registerFilesystemTools(tiny, { rootDir: root, maxListBytes: 4096 });
+        const dir = join(root, "histtest");
+        await fs.mkdir(dir, { recursive: true });
+        // Per-file output ≈ 8 hits × ~75 bytes ≈ 600 bytes. 5 files → 3000 bytes
+        // (~73%); 6 → ~88%, so the flip lands somewhere in the back half of
+        // the alphabetical walk.
+        const fileNames = "abcdefghij".split("");
+        const hitLine = `TARGET ${"y".repeat(50)}`;
+        for (const name of fileNames) {
+          const lines = Array.from({ length: 8 }, () => hitLine);
+          await fs.writeFile(join(dir, `${name}.ts`), lines.join("\n"));
+        }
+        const out = await tiny.dispatch(
+          "search_content",
+          JSON.stringify({ pattern: "TARGET", path: "histtest" }),
+        );
+        expect(out).toMatch(/switching to summary mode — byte budget at \d+%/);
+        const histogramLines = out
+          .split("\n")
+          .filter((l) => /^histtest\/[a-j]\.ts: \d+ match/.test(l));
+        expect(histogramLines.length).toBeGreaterThan(0);
+      });
+    });
   });
 
   describe("compileNameFilter", () => {


### PR DESCRIPTION
## Summary

`search_content` had one truncation knob — a byte budget on `ctx.maxListBytes`. A single popular symbol could match 200+ lines in one big file and consume the entire budget before the walk reached any other file. Callers saw a wall of `App.tsx:NNN: ...` lines and no hint that distribution was wider.

This PR adds three layers of distribution-preserving behavior:

1. **Per-file cap.** `MAX_HITS_PER_FILE = 30`; overflow is summarized with `[rel: N more matches in this file — re-grep with a tighter pattern or use read_file to see them]`.
2. **Histogram fallback.** Once printed bytes cross 80 % of the byte budget, remaining files switch to `rel: N matches` form. A one-line notice marks the flip.
3. **`summary_only: true` arg.** Skip line content entirely; return just the histogram. Cheap one-shot for "where does this exist at all" before drilling in with a targeted `read_file`.

The existing byte-budget cap stays as the safety net.

Closes #489

## Test plan

- [x] `tests/filesystem-tools.test.ts` — four new cases under a `per-file cap and histogram fallback` describe block: hits-cap + footer, no-footer when under cap, `summary_only` shape, and the 80 % flip-to-summary trigger.
- [x] `npm run verify` (full suite, 2295 tests).