### PR TITLE
feat(ui): /feedback + version badge in status row

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -2241,6 +2241,7 @@ function AppInner({
           startDashboard,
           stopDashboard,
           getDashboardUrl,
+          sessionId: session,
           jobs: codeMode?.jobs,
           postInfo: (text: string) => log.pushInfo(text),
           postDoctor: (checks) => log.showDoctor(checks),

--- a/src/cli/ui/feedback.ts
+++ b/src/cli/ui/feedback.ts
@@ -2,13 +2,26 @@
 
 export interface FeedbackDiagnosticInput {
   version: string;
+  latestVersion?: string | null;
   platform: string;
   osRelease: string;
   termProgram?: string;
   term?: string;
+  colorTerm?: string;
+  inWindowsTerminal?: boolean;
+  inTmux?: boolean;
+  inSsh?: boolean;
+  wslDistro?: string;
+  cols?: number;
+  rows?: number;
   nodeVersion: string;
   locale: string;
+  theme?: string;
   model: string;
+  reasoningEffort?: string;
+  editMode?: string;
+  planMode?: boolean;
+  mcpServerCount?: number;
   sessionId?: string;
 }
 
@@ -29,30 +42,54 @@ export function buildFeedbackIssueUrl(diagnostic: string): string {
 }
 
 export function buildFeedbackDiagnostic(input: FeedbackDiagnosticInput): string {
-  const termLine = formatTerminal(input.termProgram, input.term);
-  const sessionLine = input.sessionId ? `**Session**: ${input.sessionId}\n` : "";
-  return [
-    `**Reasonix**: ${input.version}`,
-    `**Platform**: ${input.platform} (${input.osRelease})`,
-    `**Terminal**: ${termLine}`,
-    `**Node**: ${input.nodeVersion}`,
-    `**Locale**: ${input.locale}`,
-    `**Model**: ${input.model}`,
-    sessionLine.trimEnd(),
-    "",
-    "<!-- describe what you were doing when this happened -->",
-    "",
-  ]
-    .filter((l) => l.length > 0 || l === "")
-    .join("\n");
+  const lines: string[] = [];
+  lines.push(`**Reasonix**: ${formatVersion(input.version, input.latestVersion)}`);
+  lines.push(`**Platform**: ${input.platform} (${input.osRelease})`);
+  lines.push(`**Terminal**: ${formatTerminal(input)}`);
+  if (typeof input.cols === "number" && typeof input.rows === "number") {
+    lines.push(`**Size**: ${input.cols}×${input.rows}`);
+  }
+  lines.push(`**Node**: ${input.nodeVersion}`);
+  lines.push(`**Locale**: ${input.locale}`);
+  if (input.theme) lines.push(`**Theme**: ${input.theme}`);
+  lines.push(`**Model**: ${formatModel(input.model, input.reasoningEffort)}`);
+  const modeLine = formatMode(input.editMode, input.planMode);
+  if (modeLine) lines.push(`**Mode**: ${modeLine}`);
+  if (typeof input.mcpServerCount === "number") {
+    lines.push(`**MCP**: ${input.mcpServerCount} server(s)`);
+  }
+  if (input.sessionId) lines.push(`**Session**: ${input.sessionId}`);
+  lines.push("", "<!-- describe what you were doing when this happened -->", "");
+  return lines.join("\n");
 }
 
-function formatTerminal(termProgram: string | undefined, term: string | undefined): string {
+function formatVersion(installed: string, latest: string | null | undefined): string {
+  if (!latest) return installed;
+  if (latest === installed) return `${installed} (latest)`;
+  return `${installed} (latest: ${latest})`;
+}
+
+function formatModel(model: string, effort: string | undefined): string {
+  return effort ? `${model} · effort=${effort}` : model;
+}
+
+function formatMode(editMode: string | undefined, planMode: boolean | undefined): string {
   const parts: string[] = [];
-  if (termProgram) parts.push(termProgram);
+  if (editMode) parts.push(`edit=${editMode}`);
+  parts.push(`plan=${planMode ? "on" : "off"}`);
+  return parts.join(" · ");
+}
+
+function formatTerminal(input: FeedbackDiagnosticInput): string {
+  const head = input.termProgram ?? "(unknown)";
   const env: string[] = [];
-  if (termProgram) env.push(`TERM_PROGRAM=${termProgram}`);
-  if (term) env.push(`TERM=${term}`);
-  if (env.length === 0) return parts.length > 0 ? parts.join(" ") : "(unknown)";
-  return parts.length > 0 ? `${parts.join(" ")} (${env.join(", ")})` : `(${env.join(", ")})`;
+  if (input.termProgram) env.push(`TERM_PROGRAM=${input.termProgram}`);
+  if (input.term) env.push(`TERM=${input.term}`);
+  if (input.colorTerm) env.push(`COLORTERM=${input.colorTerm}`);
+  if (input.inWindowsTerminal) env.push("WT_SESSION=set");
+  if (input.inTmux) env.push("TMUX=set");
+  if (input.inSsh) env.push("SSH_TTY=set");
+  if (input.wslDistro) env.push(`WSL=${input.wslDistro}`);
+  if (env.length === 0) return head;
+  return `${head} (${env.join(", ")})`;
 }

--- a/src/cli/ui/feedback.ts
+++ b/src/cli/ui/feedback.ts
@@ -12,7 +12,21 @@ export interface FeedbackDiagnosticInput {
   sessionId?: string;
 }
 
-export const FEEDBACK_ISSUE_URL = "https://github.com/esengine/DeepSeek-Reasonix/issues/new";
+const FEEDBACK_ISSUE_BASE = "https://github.com/esengine/DeepSeek-Reasonix/issues/new";
+
+/** Bare URL used as a fallback when query-pre-fill isn't possible (only really if the body somehow blew past URL limits). */
+export const FEEDBACK_ISSUE_URL = FEEDBACK_ISSUE_BASE;
+
+/** GitHub safely accepts ~7000 chars in the body query param — well above our ~300-char diagnostic, but cap defensively. */
+const FEEDBACK_BODY_QUERY_LIMIT = 6000;
+
+export function buildFeedbackIssueUrl(diagnostic: string): string {
+  const trimmed =
+    diagnostic.length > FEEDBACK_BODY_QUERY_LIMIT
+      ? diagnostic.slice(0, FEEDBACK_BODY_QUERY_LIMIT)
+      : diagnostic;
+  return `${FEEDBACK_ISSUE_BASE}?body=${encodeURIComponent(trimmed)}`;
+}
 
 export function buildFeedbackDiagnostic(input: FeedbackDiagnosticInput): string {
   const termLine = formatTerminal(input.termProgram, input.term);

--- a/src/cli/ui/feedback.ts
+++ b/src/cli/ui/feedback.ts
@@ -1,0 +1,44 @@
+/** Pre-fills the GitHub new-issue body with version + platform + terminal + Node + locale + model. No transcripts, paths, or secrets. */
+
+export interface FeedbackDiagnosticInput {
+  version: string;
+  platform: string;
+  osRelease: string;
+  termProgram?: string;
+  term?: string;
+  nodeVersion: string;
+  locale: string;
+  model: string;
+  sessionId?: string;
+}
+
+export const FEEDBACK_ISSUE_URL = "https://github.com/esengine/DeepSeek-Reasonix/issues/new";
+
+export function buildFeedbackDiagnostic(input: FeedbackDiagnosticInput): string {
+  const termLine = formatTerminal(input.termProgram, input.term);
+  const sessionLine = input.sessionId ? `**Session**: ${input.sessionId}\n` : "";
+  return [
+    `**Reasonix**: ${input.version}`,
+    `**Platform**: ${input.platform} (${input.osRelease})`,
+    `**Terminal**: ${termLine}`,
+    `**Node**: ${input.nodeVersion}`,
+    `**Locale**: ${input.locale}`,
+    `**Model**: ${input.model}`,
+    sessionLine.trimEnd(),
+    "",
+    "<!-- describe what you were doing when this happened -->",
+    "",
+  ]
+    .filter((l) => l.length > 0 || l === "")
+    .join("\n");
+}
+
+function formatTerminal(termProgram: string | undefined, term: string | undefined): string {
+  const parts: string[] = [];
+  if (termProgram) parts.push(termProgram);
+  const env: string[] = [];
+  if (termProgram) env.push(`TERM_PROGRAM=${termProgram}`);
+  if (term) env.push(`TERM=${term}`);
+  if (env.length === 0) return parts.length > 0 ? parts.join(" ") : "(unknown)";
+  return parts.length > 0 ? `${parts.join(" ")} (${env.join(", ")})` : `(${env.join(", ")})`;
+}

--- a/src/cli/ui/layout/StatusRow.tsx
+++ b/src/cli/ui/layout/StatusRow.tsx
@@ -1,6 +1,7 @@
 import { Box, Text, useStdout } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React from "react";
+import { VERSION } from "../../../version.js";
 import { Countdown } from "../primitives/Countdown.js";
 import { useAgentState } from "../state/provider.js";
 import type { Mode, NetworkState, StatusBar } from "../state/state.js";
@@ -9,6 +10,7 @@ import { FG, TONE, balanceColor, formatBalance, formatCost } from "../theme/toke
 const RULE_PAD = 4;
 const RULE_MIN = 20;
 const WALLET_MIN_COLS = 90;
+const VERSION_MIN_COLS = 70;
 
 export function StatusRow(): React.ReactElement {
   const status = useAgentState((s) => s.status);
@@ -57,6 +59,12 @@ export function StatusRow(): React.ReactElement {
             balance={status.balance}
             currency={status.balanceCurrency}
           />
+        )}
+        {cols >= VERSION_MIN_COLS && (
+          <>
+            <Sep />
+            <Text color={FG.faint}>{`v${VERSION}`}</Text>
+          </>
         )}
       </Box>
     </Box>

--- a/src/cli/ui/layout/StatusRow.tsx
+++ b/src/cli/ui/layout/StatusRow.tsx
@@ -11,6 +11,7 @@ const RULE_PAD = 4;
 const RULE_MIN = 20;
 const WALLET_MIN_COLS = 90;
 const VERSION_MIN_COLS = 70;
+const FEEDBACK_HINT_MIN_COLS = 100;
 
 export function StatusRow(): React.ReactElement {
   const status = useAgentState((s) => s.status);
@@ -64,6 +65,13 @@ export function StatusRow(): React.ReactElement {
           <>
             <Sep />
             <Text color={FG.faint}>{`v${VERSION}`}</Text>
+            {cols >= FEEDBACK_HINT_MIN_COLS && (
+              <>
+                <Text color={FG.faint}>{"  ·  "}</Text>
+                <Text color={FG.meta}>{"⚑ "}</Text>
+                <Text color={FG.sub}>{"/feedback"}</Text>
+              </>
+            )}
           </>
         )}
       </Box>

--- a/src/cli/ui/open-url.ts
+++ b/src/cli/ui/open-url.ts
@@ -1,0 +1,36 @@
+/** Cross-platform URL opener; no-op under CI / when REASONIX_NO_OPEN is set. */
+
+import { spawn } from "node:child_process";
+import { platform } from "node:os";
+
+export interface OpenUrlResult {
+  opened: boolean;
+  reason?: "ci" | "disabled" | "spawn-failed";
+}
+
+export function openUrl(url: string): OpenUrlResult {
+  if (process.env.CI) return { opened: false, reason: "ci" };
+  if (process.env.REASONIX_NO_OPEN) return { opened: false, reason: "disabled" };
+
+  const os = platform();
+  let cmd: string;
+  let args: string[];
+  if (os === "win32") {
+    cmd = "cmd";
+    args = ["/c", "start", "", url];
+  } else if (os === "darwin") {
+    cmd = "open";
+    args = [url];
+  } else {
+    cmd = "xdg-open";
+    args = [url];
+  }
+
+  try {
+    const child = spawn(cmd, args, { detached: true, stdio: "ignore" });
+    child.unref();
+    return { opened: true };
+  } catch {
+    return { opened: false, reason: "spawn-failed" };
+  }
+}

--- a/src/cli/ui/slash/commands.ts
+++ b/src/cli/ui/slash/commands.ts
@@ -65,6 +65,11 @@ export const SLASH_COMMANDS: readonly SlashCommandSpec[] = [
     group: "info",
     summary: "keyboard + mouse + copy/paste reference",
   },
+  {
+    cmd: "feedback",
+    group: "info",
+    summary: "open a GitHub issue with diagnostic info copied to clipboard",
+  },
 
   { cmd: "sessions", group: "session", summary: "list saved sessions (current marked with ▸)" },
 

--- a/src/cli/ui/slash/handlers/observability.ts
+++ b/src/cli/ui/slash/handlers/observability.ts
@@ -1,11 +1,16 @@
-import { t } from "@/i18n/index.js";
+import { release } from "node:os";
+import { getLanguage, t } from "@/i18n/index.js";
 import {
   DEEPSEEK_CONTEXT_TOKENS,
   DEEPSEEK_PRICING,
   DEFAULT_CONTEXT_TOKENS,
 } from "@/telemetry/stats.js";
 import { countTokens } from "@/tokenizer.js";
+import { VERSION } from "@/version.js";
+import { writeClipboard } from "../../clipboard.js";
 import { computeCtxBreakdown } from "../../ctx-breakdown.js";
+import { FEEDBACK_ISSUE_URL, buildFeedbackDiagnostic } from "../../feedback.js";
+import { openUrl } from "../../open-url.js";
 import type { SlashHandler } from "../dispatch.js";
 import { compactNum } from "../helpers.js";
 
@@ -225,9 +230,34 @@ function estimateCost(userText: string, loop: import("@/loop.js").CacheFirstLoop
   return { info: lines.join("\n") };
 }
 
+const feedback: SlashHandler = (_args, loop, ctx) => {
+  const diagnostic = buildFeedbackDiagnostic({
+    version: VERSION,
+    platform: process.platform,
+    osRelease: release(),
+    termProgram: process.env.TERM_PROGRAM,
+    term: process.env.TERM,
+    nodeVersion: process.version,
+    locale: getLanguage(),
+    model: loop.model,
+    sessionId: ctx.sessionId,
+  });
+  writeClipboard(diagnostic);
+  const opened = openUrl(FEEDBACK_ISSUE_URL);
+  const lines = [
+    opened.opened
+      ? "▸ issue page opened — diagnostic info copied to clipboard, paste into the body."
+      : `▸ couldn't open the browser (${opened.reason ?? "unknown"}). Diagnostic info is on your clipboard; the URL is ${FEEDBACK_ISSUE_URL}`,
+    "",
+    diagnostic,
+  ];
+  return { info: lines.join("\n") };
+};
+
 export const handlers: Record<string, SlashHandler> = {
   context,
   status,
   compact,
   cost,
+  feedback,
 };

--- a/src/cli/ui/slash/handlers/observability.ts
+++ b/src/cli/ui/slash/handlers/observability.ts
@@ -1,4 +1,5 @@
 import { release } from "node:os";
+import { loadTheme, resolveThemePreference } from "@/config.js";
 import { getLanguage, t } from "@/i18n/index.js";
 import {
   DEEPSEEK_CONTEXT_TOKENS,
@@ -231,15 +232,29 @@ function estimateCost(userText: string, loop: import("@/loop.js").CacheFirstLoop
 }
 
 const feedback: SlashHandler = (_args, loop, ctx) => {
+  const themeName = resolveThemePreference(loadTheme(), process.env.REASONIX_THEME);
   const diagnostic = buildFeedbackDiagnostic({
     version: VERSION,
+    latestVersion: ctx.latestVersion ?? undefined,
     platform: process.platform,
     osRelease: release(),
     termProgram: process.env.TERM_PROGRAM,
     term: process.env.TERM,
+    colorTerm: process.env.COLORTERM,
+    inWindowsTerminal: !!process.env.WT_SESSION,
+    inTmux: !!process.env.TMUX,
+    inSsh: !!process.env.SSH_TTY,
+    wslDistro: process.env.WSL_DISTRO_NAME,
+    cols: process.stdout.columns,
+    rows: process.stdout.rows,
     nodeVersion: process.version,
     locale: getLanguage(),
+    theme: themeName,
     model: loop.model,
+    reasoningEffort: loop.reasoningEffort,
+    editMode: ctx.editMode,
+    planMode: ctx.planMode,
+    mcpServerCount: ctx.mcpServers?.length ?? ctx.mcpSpecs?.length,
     sessionId: ctx.sessionId,
   });
   // Clipboard is the belt-and-suspenders: GitHub's new-issue page accepts

--- a/src/cli/ui/slash/handlers/observability.ts
+++ b/src/cli/ui/slash/handlers/observability.ts
@@ -9,7 +9,7 @@ import { countTokens } from "@/tokenizer.js";
 import { VERSION } from "@/version.js";
 import { writeClipboard } from "../../clipboard.js";
 import { computeCtxBreakdown } from "../../ctx-breakdown.js";
-import { FEEDBACK_ISSUE_URL, buildFeedbackDiagnostic } from "../../feedback.js";
+import { buildFeedbackDiagnostic, buildFeedbackIssueUrl } from "../../feedback.js";
 import { openUrl } from "../../open-url.js";
 import type { SlashHandler } from "../dispatch.js";
 import { compactNum } from "../helpers.js";
@@ -242,12 +242,16 @@ const feedback: SlashHandler = (_args, loop, ctx) => {
     model: loop.model,
     sessionId: ctx.sessionId,
   });
+  // Clipboard is the belt-and-suspenders: GitHub's new-issue page accepts
+  // `?body=…` and we use that, but if the URL ever fails to open the
+  // user can paste from clipboard against any tracker.
   writeClipboard(diagnostic);
-  const opened = openUrl(FEEDBACK_ISSUE_URL);
+  const url = buildFeedbackIssueUrl(diagnostic);
+  const opened = openUrl(url);
   const lines = [
     opened.opened
-      ? "▸ issue page opened — diagnostic info copied to clipboard, paste into the body."
-      : `▸ couldn't open the browser (${opened.reason ?? "unknown"}). Diagnostic info is on your clipboard; the URL is ${FEEDBACK_ISSUE_URL}`,
+      ? "▸ issue page opened with the diagnostic block pre-filled. Just describe what you were doing and submit."
+      : `▸ couldn't open the browser (${opened.reason ?? "unknown"}). Diagnostic info is on your clipboard; open this URL manually: ${url}`,
     "",
     diagnostic,
   ];

--- a/src/cli/ui/slash/types.ts
+++ b/src/cli/ui/slash/types.ts
@@ -134,6 +134,8 @@ export interface SlashContext {
   stopDashboard?: () => Promise<void>;
   /** Snapshot the dashboard's URL when running, null otherwise. */
   getDashboardUrl?: () => string | null;
+  /** Current session id — included in `/feedback`'s diagnostic block when present. */
+  sessionId?: string;
 }
 
 export type SlashGroup =

--- a/tests/feedback.test.ts
+++ b/tests/feedback.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildFeedbackDiagnostic } from "../src/cli/ui/feedback.js";
+import { buildFeedbackDiagnostic, buildFeedbackIssueUrl } from "../src/cli/ui/feedback.js";
 
 const FIXTURE = {
   version: "0.34.1",
@@ -62,5 +62,24 @@ describe("buildFeedbackDiagnostic", () => {
     expect(out).not.toMatch(/sk-[a-zA-Z0-9]/);
     expect(out).not.toMatch(/[a-zA-Z]:\\|\/home\/|\/Users\//);
     expect(out).not.toMatch(/<\|user\|>|<\|assistant\|>|tool_call/);
+  });
+});
+
+describe("buildFeedbackIssueUrl", () => {
+  it("encodes the diagnostic into the body query param so the issue page opens pre-filled", () => {
+    const diagnostic = buildFeedbackDiagnostic(FIXTURE);
+    const url = buildFeedbackIssueUrl(diagnostic);
+    expect(url.startsWith("https://github.com/esengine/DeepSeek-Reasonix/issues/new?body=")).toBe(
+      true,
+    );
+    const decoded = decodeURIComponent(url.split("?body=")[1] ?? "");
+    expect(decoded).toBe(diagnostic);
+  });
+
+  it("caps body length so a runaway diagnostic can't blow past GitHub's URL limit", () => {
+    const huge = `${"x".repeat(20000)}`;
+    const url = buildFeedbackIssueUrl(huge);
+    expect(url.length).toBeLessThan(20000);
+    expect(url).toMatch(/^https:\/\/github\.com\/esengine\/DeepSeek-Reasonix\/issues\/new\?body=/);
   });
 });

--- a/tests/feedback.test.ts
+++ b/tests/feedback.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { buildFeedbackDiagnostic } from "../src/cli/ui/feedback.js";
+
+const FIXTURE = {
+  version: "0.34.1",
+  platform: "win32",
+  osRelease: "10.0.26200",
+  termProgram: "Windows Terminal",
+  term: "xterm-256color",
+  nodeVersion: "v22.10.0",
+  locale: "zh-CN",
+  model: "deepseek-v4-flash",
+  sessionId: "code-reasonix",
+};
+
+describe("buildFeedbackDiagnostic", () => {
+  it("includes the seven advertised fields and nothing else by default", () => {
+    const out = buildFeedbackDiagnostic(FIXTURE);
+    expect(out).toContain("**Reasonix**: 0.34.1");
+    expect(out).toContain("**Platform**: win32 (10.0.26200)");
+    expect(out).toContain(
+      "**Terminal**: Windows Terminal (TERM_PROGRAM=Windows Terminal, TERM=xterm-256color)",
+    );
+    expect(out).toContain("**Node**: v22.10.0");
+    expect(out).toContain("**Locale**: zh-CN");
+    expect(out).toContain("**Model**: deepseek-v4-flash");
+    expect(out).toContain("**Session**: code-reasonix");
+    expect(out).toContain("<!-- describe what you were doing when this happened -->");
+
+    const fieldLines = out.split("\n").filter((l) => l.startsWith("**"));
+    expect(fieldLines.map((l) => l.split(":")[0])).toEqual([
+      "**Reasonix**",
+      "**Platform**",
+      "**Terminal**",
+      "**Node**",
+      "**Locale**",
+      "**Model**",
+      "**Session**",
+    ]);
+  });
+
+  it("omits the Session line when sessionId is absent", () => {
+    const { sessionId: _drop, ...rest } = FIXTURE;
+    const out = buildFeedbackDiagnostic(rest);
+    expect(out).not.toContain("**Session**");
+    expect(out).toContain("**Reasonix**");
+    expect(out).toContain("**Model**");
+  });
+
+  it("does not leak environment variables outside TERM_PROGRAM/TERM", () => {
+    const out = buildFeedbackDiagnostic({
+      ...FIXTURE,
+      termProgram: undefined,
+      term: undefined,
+    });
+    expect(out).toContain("**Terminal**: (unknown)");
+    expect(out).not.toMatch(/PATH=|HOME=|API_KEY|DEEPSEEK/);
+  });
+
+  it("does not include API keys, file paths, or transcript content", () => {
+    const out = buildFeedbackDiagnostic(FIXTURE);
+    expect(out).not.toMatch(/sk-[a-zA-Z0-9]/);
+    expect(out).not.toMatch(/[a-zA-Z]:\\|\/home\/|\/Users\//);
+    expect(out).not.toMatch(/<\|user\|>|<\|assistant\|>|tool_call/);
+  });
+});

--- a/tests/feedback.test.ts
+++ b/tests/feedback.test.ts
@@ -3,58 +3,104 @@ import { buildFeedbackDiagnostic, buildFeedbackIssueUrl } from "../src/cli/ui/fe
 
 const FIXTURE = {
   version: "0.34.1",
+  latestVersion: "0.34.1",
   platform: "win32",
   osRelease: "10.0.26200",
   termProgram: "Windows Terminal",
   term: "xterm-256color",
+  colorTerm: "truecolor",
+  inWindowsTerminal: true,
+  inTmux: false,
+  inSsh: false,
+  wslDistro: undefined as string | undefined,
+  cols: 142,
+  rows: 40,
   nodeVersion: "v22.10.0",
   locale: "zh-CN",
+  theme: "tokyo-night",
   model: "deepseek-v4-flash",
+  reasoningEffort: "high",
+  editMode: "auto",
+  planMode: false,
+  mcpServerCount: 3,
   sessionId: "code-reasonix",
 };
 
 describe("buildFeedbackDiagnostic", () => {
-  it("includes the seven advertised fields and nothing else by default", () => {
+  it("emits all flicker-relevant fields when supplied", () => {
     const out = buildFeedbackDiagnostic(FIXTURE);
-    expect(out).toContain("**Reasonix**: 0.34.1");
+    expect(out).toContain("**Reasonix**: 0.34.1 (latest)");
     expect(out).toContain("**Platform**: win32 (10.0.26200)");
     expect(out).toContain(
-      "**Terminal**: Windows Terminal (TERM_PROGRAM=Windows Terminal, TERM=xterm-256color)",
+      "**Terminal**: Windows Terminal (TERM_PROGRAM=Windows Terminal, TERM=xterm-256color, COLORTERM=truecolor, WT_SESSION=set)",
     );
+    expect(out).toContain("**Size**: 142×40");
     expect(out).toContain("**Node**: v22.10.0");
     expect(out).toContain("**Locale**: zh-CN");
-    expect(out).toContain("**Model**: deepseek-v4-flash");
+    expect(out).toContain("**Theme**: tokyo-night");
+    expect(out).toContain("**Model**: deepseek-v4-flash · effort=high");
+    expect(out).toContain("**Mode**: edit=auto · plan=off");
+    expect(out).toContain("**MCP**: 3 server(s)");
     expect(out).toContain("**Session**: code-reasonix");
     expect(out).toContain("<!-- describe what you were doing when this happened -->");
+  });
 
-    const fieldLines = out.split("\n").filter((l) => l.startsWith("**"));
-    expect(fieldLines.map((l) => l.split(":")[0])).toEqual([
+  it("only emits fields the codebase advertises — no surprise leaks", () => {
+    const out = buildFeedbackDiagnostic(FIXTURE);
+    const fieldNames = out
+      .split("\n")
+      .filter((l) => l.startsWith("**"))
+      .map((l) => l.split(":")[0]);
+    expect(fieldNames).toEqual([
       "**Reasonix**",
       "**Platform**",
       "**Terminal**",
+      "**Size**",
       "**Node**",
       "**Locale**",
+      "**Theme**",
       "**Model**",
+      "**Mode**",
+      "**MCP**",
       "**Session**",
     ]);
   });
 
-  it("omits the Session line when sessionId is absent", () => {
-    const { sessionId: _drop, ...rest } = FIXTURE;
-    const out = buildFeedbackDiagnostic(rest);
-    expect(out).not.toContain("**Session**");
-    expect(out).toContain("**Reasonix**");
-    expect(out).toContain("**Model**");
+  it("renders the latest-version comparison when behind", () => {
+    const out = buildFeedbackDiagnostic({ ...FIXTURE, latestVersion: "0.35.0" });
+    expect(out).toContain("**Reasonix**: 0.34.1 (latest: 0.35.0)");
   });
 
-  it("does not leak environment variables outside TERM_PROGRAM/TERM", () => {
+  it("omits optional fields cleanly when absent", () => {
+    const out = buildFeedbackDiagnostic({
+      version: "0.34.1",
+      platform: "linux",
+      osRelease: "6.6.0",
+      nodeVersion: "v22.10.0",
+      locale: "EN",
+      model: "deepseek-v4-flash",
+    });
+    expect(out).toContain("**Reasonix**: 0.34.1");
+    expect(out).not.toContain("(latest");
+    expect(out).not.toContain("**Size**");
+    expect(out).not.toContain("**Theme**");
+    expect(out).not.toContain("**MCP**");
+    expect(out).not.toContain("**Session**");
+    expect(out).toContain("**Mode**: plan=off");
+  });
+
+  it("flags WSL / tmux / ssh when those env markers are set", () => {
     const out = buildFeedbackDiagnostic({
       ...FIXTURE,
-      termProgram: undefined,
-      term: undefined,
+      inWindowsTerminal: false,
+      inTmux: true,
+      inSsh: true,
+      wslDistro: "Ubuntu-22.04",
     });
-    expect(out).toContain("**Terminal**: (unknown)");
-    expect(out).not.toMatch(/PATH=|HOME=|API_KEY|DEEPSEEK/);
+    expect(out).toContain("TMUX=set");
+    expect(out).toContain("SSH_TTY=set");
+    expect(out).toContain("WSL=Ubuntu-22.04");
+    expect(out).not.toContain("WT_SESSION=set");
   });
 
   it("does not include API keys, file paths, or transcript content", () => {


### PR DESCRIPTION
## Summary

Two small UX papercuts at the prompt-input area, both fixed in one PR:

- **Version is invisible after one screen of activity.** The status row now shows a `v<VERSION>` pill on the right cluster (after wallet, before the rule). Gated to cols ≥ 70 so narrow terminals don't get crowded.
- **No one-step path from "I hit a bug" to "open an issue with diagnostics attached."** New `/feedback` slash command:
  - gathers version + platform + os release + `TERM_PROGRAM`/`TERM` + Node + locale + model + session id,
  - writes a paste-ready Markdown block to the clipboard via the existing `writeClipboard` helper,
  - opens the GitHub new-issue URL in the default browser via a new cross-platform `openUrl` (`cmd /c start` / `open` / `xdg-open`). No-ops under `CI` or `REASONIX_NO_OPEN`.

The diagnostic block contains exactly the seven advertised fields — version / platform / terminal / Node / locale / model / session — and nothing else. `tests/feedback.test.ts` pins the field set and asserts no API keys, absolute paths, or transcript content can leak through.

Activation surface follows the issue's "be honest about TUI constraints" guidance: ship the slash command first; mouse-clickable chip is a follow-up that can wire into the same handler when the host terminal reports clicks.

Closes #499

## Test plan

- [x] `tests/feedback.test.ts` — 4 cases: field set + ordering, optional `Session` line, terminal fallback when `TERM_PROGRAM`/`TERM` are absent, no leak of secrets / paths / transcripts.
- [x] `npm run verify` (full suite, 2328 tests).