### PR TITLE
fix(dashboard): use semver compare for up-to-date check

### DIFF
--- a/dashboard/src/lib/version.ts
+++ b/dashboard/src/lib/version.ts
@@ -1,0 +1,15 @@
+/** Pre-release with same core sorts BELOW the bare version — matches npm `latest` dist-tag semantics. */
+export function compareVersions(a: string, b: string): number {
+  const [aCore = "0", aPre = ""] = a.split("-", 2);
+  const [bCore = "0", bPre = ""] = b.split("-", 2);
+  const aParts = aCore.split(".").map((p) => Number.parseInt(p, 10) || 0);
+  const bParts = bCore.split(".").map((p) => Number.parseInt(p, 10) || 0);
+  for (let i = 0; i < 3; i++) {
+    const diff = (aParts[i] ?? 0) - (bParts[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  if (!aPre && !bPre) return 0;
+  if (!aPre) return 1;
+  if (!bPre) return -1;
+  return aPre < bPre ? -1 : aPre > bPre ? 1 : 0;
+}

--- a/dashboard/src/panels/overview.ts
+++ b/dashboard/src/panels/overview.ts
@@ -2,6 +2,7 @@ import { budgetTone, deriveBudgetState } from "../lib/budget.js";
 import { fmtCompactNum, fmtCost, fmtNum, fmtRelativeTime, fmtUsd } from "../lib/format.js";
 import { html } from "../lib/html.js";
 import { usePoll } from "../lib/use-poll.js";
+import { compareVersions } from "../lib/version.js";
 import { t, useLang } from "../i18n/index.js";
 
 interface CockpitKpi {
@@ -280,7 +281,8 @@ export function OverviewPanel() {
     recentPlans: null,
     toolActivity: null,
   };
-  const upToDate = o.latestVersion ? o.latestVersion === o.version : null;
+  const upToDate =
+    o.latestVersion && o.version ? compareVersions(o.version, o.latestVersion) >= 0 : null;
   const versionDelta =
     upToDate === null ? t("overview.checking") : upToDate ? t("overview.latest") : `latest: ${o.latestVersion}`;
   const versionTone: "up" | "down" | "flat" = upToDate === false ? "down" : "flat";

--- a/dashboard/src/panels/system.ts
+++ b/dashboard/src/panels/system.ts
@@ -1,6 +1,7 @@
 import { fmtBytes, fmtNum } from "../lib/format.js";
 import { html } from "../lib/html.js";
 import { usePoll } from "../lib/use-poll.js";
+import { compareVersions } from "../lib/version.js";
 import { t, useLang } from "../i18n/index.js";
 
 interface HealthData {
@@ -22,7 +23,7 @@ export function SystemPanel() {
   if (error) return html`<div class="card accent-err">${t("common.loadingFailed", { name: "health", error: error.message })}</div>`;
   if (!data) return null;
   const h = data;
-  const upToDate = h.latestVersion ? h.latestVersion === h.version : null;
+  const upToDate = h.latestVersion ? compareVersions(h.version, h.latestVersion) >= 0 : null;
 
   return html`
     <div style="display:flex;flex-direction:column;gap:14px">

--- a/src/cli/ui/feedback.ts
+++ b/src/cli/ui/feedback.ts
@@ -1,5 +1,7 @@
 /** Pre-fills the GitHub new-issue body with version + platform + terminal + Node + locale + model. No transcripts, paths, or secrets. */
 
+import { compareVersions } from "../../version.js";
+
 export interface FeedbackDiagnosticInput {
   version: string;
   latestVersion?: string | null;
@@ -65,7 +67,9 @@ export function buildFeedbackDiagnostic(input: FeedbackDiagnosticInput): string 
 
 function formatVersion(installed: string, latest: string | null | undefined): string {
   if (!latest) return installed;
-  if (latest === installed) return `${installed} (latest)`;
+  const cmp = compareVersions(installed, latest);
+  if (cmp === 0) return `${installed} (latest)`;
+  if (cmp > 0) return installed;
   return `${installed} (latest: ${latest})`;
 }
 

--- a/tests/dashboard-version.test.ts
+++ b/tests/dashboard-version.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { compareVersions } from "../dashboard/src/lib/version.js";
+
+describe("dashboard compareVersions", () => {
+  it("treats installed > cached-latest as up-to-date (issue #510)", () => {
+    expect(compareVersions("0.35.0", "0.31.0")).toBeGreaterThan(0);
+  });
+
+  it("returns 0 for equal versions", () => {
+    expect(compareVersions("0.35.0", "0.35.0")).toBe(0);
+  });
+
+  it("returns negative when installed < latest", () => {
+    expect(compareVersions("0.34.0", "0.35.0")).toBeLessThan(0);
+  });
+
+  it("treats pre-release as lower than the bare version", () => {
+    expect(compareVersions("0.35.0-rc.1", "0.35.0")).toBeLessThan(0);
+    expect(compareVersions("0.35.0", "0.35.0-rc.1")).toBeGreaterThan(0);
+  });
+
+  it("orders mismatched part counts numerically", () => {
+    expect(compareVersions("1", "1.0.0")).toBe(0);
+    expect(compareVersions("1.2.0", "1.2.1")).toBeLessThan(0);
+  });
+});

--- a/tests/feedback.test.ts
+++ b/tests/feedback.test.ts
@@ -71,6 +71,17 @@ describe("buildFeedbackDiagnostic", () => {
     expect(out).toContain("**Reasonix**: 0.34.1 (latest: 0.35.0)");
   });
 
+  it("does not flag installed > cached-latest as out-of-date (issue #510)", () => {
+    const out = buildFeedbackDiagnostic({
+      ...FIXTURE,
+      version: "0.35.0",
+      latestVersion: "0.31.0",
+    });
+    expect(out).toContain("**Reasonix**: 0.35.0");
+    expect(out).not.toContain("(latest: 0.31.0)");
+    expect(out).not.toContain("(latest)");
+  });
+
   it("omits optional fields cleanly when absent", () => {
     const out = buildFeedbackDiagnostic({
       version: "0.34.1",


### PR DESCRIPTION
## Summary

Three places — the dashboard health card, the overview cockpit, and the `/feedback` diagnostic body — decided "up to date" via `latest === installed` string equality. That fires false-positive "needs update" / `(latest: 0.31.0)` pills whenever the cached `latest` is older than the installed version. Common case: we just published 0.35.0 but the user's 24h cache still holds 0.31.0 from a prior fetch — the pill says "needs update" while pointing at a version older than what they're already running (#510).

Switched all three sites to `compareVersions(installed, latest) >= 0`. The CLI side (`useSessionInfo`, `/update` slash) already used the right comparator; this brings the dashboard + feedback in line.

## Changes

- `dashboard/src/lib/version.ts` (new) — bundle-local copy of `compareVersions`. Same algorithm as `src/version.ts`; the dashboard is a separate browser bundle that doesn't import from `src/`.
- `dashboard/src/panels/system.ts` — health card uses semver compare.
- `dashboard/src/panels/overview.ts` — cockpit uses semver compare.
- `src/cli/ui/feedback.ts` — `(latest)` only when truly equal; behind shows `(latest: X)`; ahead (dev build) shows just the installed version with no annotation.

## Test plan

- [x] `npx vitest run --reporter=dot tests/` — 2360 passed, 2 skipped
- [x] new tests cover the issue's exact scenario (installed 0.35.0, cached latest 0.31.0)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (only pre-existing React-import warnings)

Closes #510