### PR TITLE
fix(tui): drop xterm mouse tracking — restore native copy/paste, rebind keys

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -1232,10 +1232,23 @@ function AppInner({
   // multi-line cursor moves live on Ctrl+P / Ctrl+N (see
   // multiline-keys.ts); leftover mouseScrollUp/Down events from a
   // terminal that ignores DECRST 1000 still route correctly.
+  //
+  // Pickers (slash / @-mention / slash-arg / shell-confirm) own ↑/↓
+  // for their own list nav — when any of them is open we skip the
+  // arrow path here so the user doesn't see the chat scroll AND the
+  // picker selection move on the same keypress. PgUp/PgDn/End still
+  // scroll regardless because pickers don't claim those.
   useKeystroke((ev) => {
-    if (ev.pageUp || ev.mouseScrollUp || ev.upArrow) chatScroll.scrollUp();
-    else if (ev.pageDown || ev.mouseScrollDown || ev.downArrow) chatScroll.scrollDown();
+    const pickerOwnsArrows =
+      (atState?.entries.length ?? 0) > 0 ||
+      (slashMatches?.length ?? 0) > 0 ||
+      (slashArgMatches?.length ?? 0) > 0 ||
+      pendingShell != null;
+    if (ev.pageUp || ev.mouseScrollUp) chatScroll.scrollUp();
+    else if (ev.pageDown || ev.mouseScrollDown) chatScroll.scrollDown();
     else if (ev.end) chatScroll.jumpToBottom();
+    else if (!pickerOwnsArrows && ev.upArrow) chatScroll.scrollUp();
+    else if (!pickerOwnsArrows && ev.downArrow) chatScroll.scrollDown();
   }, !modalOpen);
 
   // Esc during busy → forward to the loop as an abort signal. The loop

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -670,9 +670,9 @@ function AppInner({
   // so we abort the in-flight turn and let the effect below fire the
   // submit once busy clears.
   const [queuedSubmit, setQueuedSubmit] = useState<string | null>(null);
-  // ↑/↓ recall over a turn-local prompt history. We don't persist to
-  // disk — the session log already keeps the messages, and cross-
-  // session bash-style recall would need per-project scoping.
+  // Ctrl+P/Ctrl+N recall over a turn-local prompt history. We don't
+  // persist to disk — the session log already keeps the messages, and
+  // cross-session bash-style recall would need per-project scoping.
   const { recallPrev, recallNext, pushHistory, resetCursor } = useInputRecall(setInput);
   // Disambiguates <Static> keys when a single turn yields multiple assistant_final events.
   const assistantIterCounter = useRef<number>(0);
@@ -1244,9 +1244,10 @@ function AppInner({
   // gets an answer instead of a hard stop. Only listens while busy so
   // we don't accidentally hijack Esc in other contexts.
   //
-  // Also handles ↑/↓ shell-style history while idle. We don't use
-  // ink-text-input's (absent) history support; parent-level useInput
-  // is simpler and lets us own the cursor semantics.
+  // Prompt history (Ctrl+P/Ctrl+N) is handed off from PromptInput via
+  // recallPrev/recallNext below — parent-level useInput is simpler
+  // than ink-text-input's (absent) history support and lets us own
+  // the cursor semantics.
   useKeystroke((ev) => {
     // PromptInput consumes its own keystrokes via useKeystroke too,
     // so events fan out to both this handler and PromptInput's. The

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -399,20 +399,16 @@ function AppInner({
   //     SGR fall through silently — Shift+Enter just stays
   //     indistinguishable from Enter, no regression.
   //
-  //   • SGR mouse tracking (DECSET 1006 + 1000) — terminal reports
-  //     wheel + button presses as `\x1b[<btn;col;row;M` instead of
-  //     translating the wheel to ↑/↓ key sequences. Lets the chat
-  //     scroll-handler route `mouseScrollUp/Down` independently of
-  //     PromptInput's arrow-key bindings (history / cursor). Cost:
-  //     terminal-native drag-to-select needs a modifier (Shift on
-  //     Windows Terminal / Alacritty / WezTerm, Option on iTerm2).
+  // Mouse tracking is intentionally NOT enabled: terminals translate
+  // the wheel to ↑/↓ in the alt-screen buffer, App-level ↑/↓ scrolls
+  // chat, and Ctrl+P / Ctrl+N own the prompt's history + multi-line
+  // cursor moves. Skipping mouse mode keeps native drag-to-select +
+  // right-click paste working in every terminal.
   useEffect(() => {
     if (!stdout || !stdout.isTTY) return;
     stdout.write("\u001b[?2004h");
     stdout.write("\u001b[>4;2m");
-    stdout.write("\u001b[?1006h\u001b[?1000h");
     return () => {
-      stdout.write("\u001b[?1000l\u001b[?1006l");
       stdout.write("\u001b[?2004l");
       stdout.write("\u001b[>4m");
     };
@@ -1230,19 +1226,16 @@ function AppInner({
   // Esc handles "abort the current turn" separately; Ctrl+C is the universal "I'm done" key.
   const quitProcess = useQuit(transcriptRef);
 
-  // PgUp / PgDn always scroll chat history. ↑/↓ also reaches here when
-  // PromptInput can't act on it: while busy (disabled) or once chat is
-  // unpinned (user already scrolling). When pinned + idle, PromptInput
-  // owns arrows — empty buffer recalls history, otherwise cursor motion.
-  // Mouse wheel routes through mouseScrollUp/Down (SGR mouse mode) and
-  // bypasses the arrow-key path entirely so the wheel always scrolls
-  // scrollback regardless of buffer state.
+  // ↑/↓/PgUp/PgDn always scroll chat. The terminal translates the
+  // mouse wheel to ↑/↓ in alt-screen mode so the wheel scrolls chat
+  // for free without us enabling mouse tracking. Prompt history +
+  // multi-line cursor moves live on Ctrl+P / Ctrl+N (see
+  // multiline-keys.ts); leftover mouseScrollUp/Down events from a
+  // terminal that ignores DECRST 1000 still route correctly.
   useKeystroke((ev) => {
-    if (ev.pageUp || ev.mouseScrollUp) chatScroll.scrollUp();
-    else if (ev.pageDown || ev.mouseScrollDown) chatScroll.scrollDown();
+    if (ev.pageUp || ev.mouseScrollUp || ev.upArrow) chatScroll.scrollUp();
+    else if (ev.pageDown || ev.mouseScrollDown || ev.downArrow) chatScroll.scrollDown();
     else if (ev.end) chatScroll.jumpToBottom();
-    else if ((!chatScroll.pinned || busy) && ev.upArrow) chatScroll.scrollUp();
-    else if ((!chatScroll.pinned || busy) && ev.downArrow) chatScroll.scrollDown();
   }, !modalOpen);
 
   // Esc during busy → forward to the loop as an abort signal. The loop
@@ -1498,14 +1491,11 @@ function AppInner({
       }
     }
 
-    // History recall (↑/↓) used to live here guarded by `input.length
-    // === 0`. It now runs inside PromptInput — the child detects
-    // when a buffer-edge arrow key has nowhere left to go (empty
-    // buffer, or cursor at first/last line of a multi-line draft)
-    // and calls back into `recallPrev` / `recallNext` below. That
-    // lets users escape into history from a multi-line draft by
-    // pressing ↑ at the first line without first emptying the
-    // buffer.
+    // Prompt history is now Ctrl+P / Ctrl+N (PromptInput → multiline
+    // keys → historyHandoff → recallPrev / recallNext below). ↑/↓ are
+    // reserved for chat scroll — without that move, native drag-select
+    // and right-click paste don't work on most terminals because we'd
+    // have to keep xterm mouse tracking on to grab the wheel.
   });
 
   // Edit-gate interceptor. Reroutes `edit_file` / `write_file` tool

--- a/src/cli/ui/PromptInput.tsx
+++ b/src/cli/ui/PromptInput.tsx
@@ -32,7 +32,7 @@ export interface PromptInputProps {
   onSubmit: (v: string) => void;
   disabled?: boolean;
   placeholder?: string;
-  /** ↑/↓ on an empty buffer or Ctrl+P / Ctrl+N — parent walks history and swaps `value` via `onChange`. */
+  /** Ctrl+P / Ctrl+N hand off here when no in-buffer cursor move applies — parent walks history and swaps `value` via `onChange`. */
   onHistoryPrev?: () => void;
   onHistoryNext?: () => void;
 }
@@ -303,7 +303,8 @@ function HintRow(): React.ReactElement {
   const items: Array<{ key: string; sep: string }> = [
     { key: "⏎", sep: "send" },
     { key: "⇧⏎", sep: "newline" },
-    { key: "↑↓", sep: "history" },
+    { key: "↑↓", sep: "scroll" },
+    { key: "^P/^N", sep: "history" },
     { key: "esc", sep: "abort" },
     { key: "^C", sep: "quit" },
   ];

--- a/src/cli/ui/hooks/useInputRecall.ts
+++ b/src/cli/ui/hooks/useInputRecall.ts
@@ -8,7 +8,7 @@ export interface UseInputRecallResult {
   resetCursor: () => void;
 }
 
-/** Bash-style ↑/↓ recall over a turn-local prompt history. Cursor is `useRef` so toggles don't re-render. */
+/** Bash-style Ctrl+P/Ctrl+N recall over a turn-local prompt history. Cursor is `useRef` so toggles don't re-render. */
 export function useInputRecall(setInput: (s: string) => void): UseInputRecallResult {
   const promptHistory = useRef<string[]>([]);
   const historyCursor = useRef<number>(-1);

--- a/src/cli/ui/layout/Composer.tsx
+++ b/src/cli/ui/layout/Composer.tsx
@@ -6,7 +6,8 @@ import { useThemeTokens } from "../theme/context.js";
 import { StatusRow } from "./StatusRow.js";
 
 const PLACEHOLDER = "type a message · / for commands · @ to attach a file";
-const HINT = "⏎ send  ·  shift/alt+⏎ newline  ·  ↑↓ history  ·  esc abort  ·  ctrl-c quit";
+const HINT =
+  "⏎ send  ·  shift/alt+⏎ newline  ·  ↑↓ scroll  ·  ^P/^N history  ·  esc abort  ·  ctrl-c quit";
 const ABORTED_HINT = "turn aborted by user · esc again to clear · ⏎ to ask a follow-up";
 
 export function Composer(): React.ReactElement {

--- a/src/cli/ui/multiline-keys.ts
+++ b/src/cli/ui/multiline-keys.ts
@@ -28,7 +28,7 @@ export interface MultilineAction {
   /** When `true`, fire `onSubmit(submitValue ?? value)`. */
   submit: boolean;
   submitValue?: string;
-  /** Set on ↑/↓ at a buffer boundary or Ctrl+P / Ctrl+N — parent recalls prompt history. */
+  /** Set on Ctrl+P / Ctrl+N when no in-buffer cursor move applies — parent recalls prompt history. */
   historyHandoff?: "prev" | "next";
   /** Reducer is pure — hands raw paste to PromptInput which allocates a sentinel and inserts that. */
   pasteRequest?: { content: string };

--- a/src/cli/ui/multiline-keys.ts
+++ b/src/cli/ui/multiline-keys.ts
@@ -1,4 +1,4 @@
-/** Pure keystroke→action reducer; arrow keys at buffer boundary defer to the parent for history recall. */
+/** Pure keystroke→action reducer; ↑/↓ NOOP (chat-scroll), Ctrl+P/N do per-line cursor + history. */
 
 export interface MultilineKey {
   input: string;
@@ -56,11 +56,9 @@ export function processMultilineKey(
     return NOOP;
   }
 
-  // Buffer-wide navigation. Per-line motion (↑/↓ / Ctrl+A / Ctrl+E)
-  // is already covered; PageUp/PageDown are the missing "jump to
-  // top / bottom of the WHOLE buffer" pair, useful after pasting a
-  // 500-line blob where ↑×500 is absurd. Repurposed from the
-  // previous NOOP behavior (PageUp/Down had no binding).
+  // PageUp/PageDown jump to start/end of the WHOLE buffer — useful
+  // after pasting a 500-line blob. Per-line motion lives on Ctrl+P /
+  // Ctrl+N now (↑/↓ are owned by chat scroll at the App level).
   if (key.pageUp) {
     return cursor === 0 ? NOOP : { next: null, cursor: 0, submit: false };
   }
@@ -68,15 +66,25 @@ export function processMultilineKey(
     return cursor === value.length ? NOOP : { next: null, cursor: value.length, submit: false };
   }
 
-  // ↑/↓ on an empty buffer recalls prompt history (universal CLI
-  // convention — bash, zsh, fish all do this). Ctrl+P / Ctrl+N is the
-  // wheel-immune fallback for Windows ConPTY users whose terminal
-  // translates mouse-wheel events to arrow keys; bind it on every
-  // platform so the muscle memory works the same everywhere.
+  // ↑/↓ are NOT consumed here — they belong to chat-scroll at the App
+  // level. Ctrl+P / Ctrl+N take over what ↑/↓ used to do here:
+  //   • multi-line buffer → cursor up/down within the buffer
+  //   • single-line / empty → hand off to prompt history (readline parity)
+  // This pairing lets us drop xterm mouse tracking; the terminal's own
+  // wheel→↑/↓ translation in alt-screen mode then scrolls chat for free
+  // and native drag-select / right-click stay intact.
   if (key.ctrl && key.input === "p") {
+    if (value.includes("\n")) {
+      const moved = moveCursorUp(value, cursor);
+      if (moved !== cursor) return { next: null, cursor: moved, submit: false };
+    }
     return { ...NOOP, historyHandoff: "prev" };
   }
   if (key.ctrl && key.input === "n") {
+    if (value.includes("\n")) {
+      const moved = moveCursorDown(value, cursor);
+      if (moved !== cursor) return { next: null, cursor: moved, submit: false };
+    }
     return { ...NOOP, historyHandoff: "next" };
   }
 
@@ -86,15 +94,8 @@ export function processMultilineKey(
   if (key.rightArrow) {
     return { next: null, cursor: Math.min(value.length, cursor + 1), submit: false };
   }
-  if (key.upArrow) {
-    if (value.length === 0) return { ...NOOP, historyHandoff: "prev" };
-    const moved = moveCursorUp(value, cursor);
-    return moved === cursor ? NOOP : { next: null, cursor: moved, submit: false };
-  }
-  if (key.downArrow) {
-    if (value.length === 0) return { ...NOOP, historyHandoff: "next" };
-    const moved = moveCursorDown(value, cursor);
-    return moved === cursor ? NOOP : { next: null, cursor: moved, submit: false };
+  if (key.upArrow || key.downArrow) {
+    return NOOP;
   }
 
   // Emacs-style line jumps. Home/End come through our own stdin reader

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -80,14 +80,15 @@ export const EN: TranslationSchema = {
       sections: [
         {
           rows: [
-            { key: "wheel", text: "scrolls the chat history above" },
+            { key: "drag", text: "select text directly — terminal-native, no modifier needed" },
             {
               key: "right-click",
-              text: "captured by the app — use Ctrl+V (Win/Linux) or Cmd+V (macOS) to paste",
+              text: "your terminal's native menu (paste / copy on Windows Terminal etc.)",
             },
+            { key: "wheel", text: "scrolls chat history (terminal translates wheel to ↑/↓)" },
             {
-              key: "Shift + drag",
-              text: "selects text natively (Option on iTerm2, Shift on Win Term / Alacritty / WezTerm)",
+              key: "↑ / ↓",
+              text: "scroll chat · use Ctrl+P / Ctrl+N for prompt history + multi-line cursor",
             },
           ],
         },
@@ -102,7 +103,14 @@ export const EN: TranslationSchema = {
           rows: [
             { key: "Enter", text: "submit the prompt" },
             { key: "Shift+Enter", text: "insert a newline in the prompt" },
-            { key: "Ctrl+P / Ctrl+N", text: "recall previous / next prompt from history" },
+            {
+              key: "↑ / ↓",
+              text: "scroll chat history (always — wheel maps to ↑/↓ via the terminal)",
+            },
+            {
+              key: "Ctrl+P / Ctrl+N",
+              text: "previous / next prompt history · cursor up / down in a multi-line draft",
+            },
             { key: "Ctrl+A / Ctrl+E", text: "jump to start / end of the current line" },
             { key: "Ctrl+W", text: "delete the word before the cursor" },
             { key: "Ctrl+U", text: "clear the entire prompt buffer" },
@@ -110,10 +118,6 @@ export const EN: TranslationSchema = {
             { key: "Shift+Tab", text: "edit-gate: toggle review ↔ AUTO mode" },
             { key: "Esc", text: "dismiss picker · abort the running model turn" },
             { key: "Ctrl+C", text: "abort the running model turn (NOT copy — see clipboard)" },
-            {
-              key: "↑ / ↓",
-              text: "scroll chat history (PromptInput cursor when buffer non-empty)",
-            },
             { key: "PgUp / PgDn", text: "scroll chat history a page at a time" },
             { key: "End", text: "jump chat to the most recent line" },
           ],
@@ -121,18 +125,18 @@ export const EN: TranslationSchema = {
         {
           title: "mouse",
           rows: [
-            { key: "wheel", text: "scrolls the chat history" },
-            { key: "right-click", text: "captured by the app — use Ctrl+V / Cmd+V to paste" },
-            { key: "left-click", text: "captured (no action yet — reserved for future use)" },
+            { key: "wheel", text: "scrolls chat history (terminal translates to ↑/↓)" },
+            { key: "drag", text: "selects text natively — direct copy works" },
+            { key: "right-click", text: "terminal-native (paste menu on Windows Terminal etc.)" },
           ],
         },
         {
           title: "copy / paste",
           rows: [
-            { key: "select text", text: "hold Shift while dragging (Option on iTerm2)" },
+            { key: "select text", text: "drag to select — terminal-native (no modifier needed)" },
             {
               key: "copy",
-              text: "Ctrl+Shift+C (Win/Linux) · Cmd+C (macOS) — terminal-native after selection",
+              text: "Ctrl+Shift+C (Win/Linux) · Cmd+C (macOS) — or auto-copy-on-select if your terminal does it",
             },
             { key: "paste", text: "Ctrl+V or Ctrl+Shift+V (Win/Linux) · Cmd+V (macOS)" },
             {
@@ -151,7 +155,7 @@ export const EN: TranslationSchema = {
         },
       ],
       footer:
-        "Mouse tracking is on so the wheel scrolls chat instead of moving the cursor — that's why right-click no longer does the terminal's native paste.",
+        "Mouse tracking is OFF — drag-to-select, right-click, and the wheel all behave the way your terminal natively does. Wheel sends ↑/↓ which the app uses for chat scroll.",
     },
     tipShownOnce: "shown once",
     modelOverride: "override the default model",

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -75,14 +75,15 @@ export const zhCN: TranslationSchema = {
       sections: [
         {
           rows: [
-            { key: "滚轮", text: "滚动上方的聊天记录" },
+            { key: "拖动", text: "直接选中文本 — 终端原生，不需要按 Shift" },
             {
               key: "右键",
-              text: "已被应用接管 — 用 Ctrl+V（Win/Linux）或 Cmd+V（macOS）粘贴",
+              text: "终端原生菜单（Windows Terminal 等的复制 / 粘贴）",
             },
+            { key: "滚轮", text: "滚动聊天（终端把滚轮翻译成 ↑ / ↓）" },
             {
-              key: "Shift + 拖动",
-              text: "原生选中文本（iTerm2 用 Option，Win Term / Alacritty / WezTerm 用 Shift）",
+              key: "↑ / ↓",
+              text: "滚动聊天 · 输入框历史 + 多行光标用 Ctrl+P / Ctrl+N",
             },
           ],
         },
@@ -97,7 +98,11 @@ export const zhCN: TranslationSchema = {
           rows: [
             { key: "Enter", text: "提交输入" },
             { key: "Shift+Enter", text: "在输入框中插入换行" },
-            { key: "Ctrl+P / Ctrl+N", text: "调出上一条 / 下一条历史提示" },
+            { key: "↑ / ↓", text: "滚动聊天记录（始终 — 滚轮也通过终端映射到 ↑/↓）" },
+            {
+              key: "Ctrl+P / Ctrl+N",
+              text: "上一条 / 下一条输入历史 · 多行草稿中按行移动光标",
+            },
             { key: "Ctrl+A / Ctrl+E", text: "跳到当前行的开头 / 结尾" },
             { key: "Ctrl+W", text: "删除光标前的一个词" },
             { key: "Ctrl+U", text: "清空整个输入缓冲区" },
@@ -105,7 +110,6 @@ export const zhCN: TranslationSchema = {
             { key: "Shift+Tab", text: "编辑门控：切换 预览 ↔ 自动 模式" },
             { key: "Esc", text: "关闭弹出选择器 · 中止当前模型回合" },
             { key: "Ctrl+C", text: "中止当前模型回合（不是复制 — 见剪贴板段）" },
-            { key: "↑ / ↓", text: "滚动聊天记录（缓冲区非空时为光标移动）" },
             { key: "PgUp / PgDn", text: "整页滚动聊天记录" },
             { key: "End", text: "跳到聊天的最新一行" },
           ],
@@ -113,18 +117,18 @@ export const zhCN: TranslationSchema = {
         {
           title: "鼠标",
           rows: [
-            { key: "滚轮", text: "滚动聊天记录" },
-            { key: "右键", text: "被应用接管 — 用 Ctrl+V / Cmd+V 粘贴" },
-            { key: "左键", text: "被接管（暂无动作 — 预留给后续功能）" },
+            { key: "滚轮", text: "滚动聊天记录（终端翻译为 ↑/↓）" },
+            { key: "拖动", text: "原生选中文本 — 直接复制" },
+            { key: "右键", text: "终端原生（Windows Terminal 等的粘贴菜单）" },
           ],
         },
         {
           title: "复制 / 粘贴",
           rows: [
-            { key: "选中文字", text: "拖动时按住 Shift（iTerm2 用 Option）" },
+            { key: "选中文字", text: "直接拖动 — 终端原生（不需要任何修饰键）" },
             {
               key: "复制",
-              text: "Ctrl+Shift+C（Win/Linux）· Cmd+C（macOS）— 选中后由终端原生处理",
+              text: "Ctrl+Shift+C（Win/Linux）· Cmd+C（macOS）— 或选中即复制（看终端设置）",
             },
             { key: "粘贴", text: "Ctrl+V 或 Ctrl+Shift+V（Win/Linux）· Cmd+V（macOS）" },
             {
@@ -143,7 +147,7 @@ export const zhCN: TranslationSchema = {
         },
       ],
       footer:
-        "鼠标追踪已开启，滚轮用来滚动聊天而不是移动光标 — 这也是右键不再触发终端原生粘贴的原因。",
+        "鼠标追踪已关闭 — 拖动选中、右键、滚轮都按终端原生方式工作。滚轮发送 ↑/↓，应用用它来滚动聊天。",
     },
     tipShownOnce: "仅显示一次",
     modelOverride: "覆盖默认模型",

--- a/tests/multiline-keys.test.ts
+++ b/tests/multiline-keys.test.ts
@@ -148,19 +148,23 @@ describe("processMultilineKey — cursor motion", () => {
     expect(processMultilineKey("abc", 3, key({ rightArrow: true })).cursor).toBe(3);
   });
 
-  it("↑/↓ on a single-line non-empty buffer is a NOOP", () => {
-    const up = processMultilineKey("hello", 3, key({ upArrow: true }));
-    expect(up).toEqual({ next: null, cursor: null, submit: false });
-    const down = processMultilineKey("hello", 3, key({ downArrow: true }));
-    expect(down).toEqual({ next: null, cursor: null, submit: false });
+  it("↑/↓ are NOOP — reserved for chat scroll at the App level", () => {
+    expect(processMultilineKey("hello", 3, key({ upArrow: true }))).toEqual({
+      next: null,
+      cursor: null,
+      submit: false,
+    });
+    expect(processMultilineKey("hello", 3, key({ downArrow: true }))).toEqual({
+      next: null,
+      cursor: null,
+      submit: false,
+    });
+    expect(processMultilineKey("", 0, key({ upArrow: true })).historyHandoff).toBeUndefined();
+    expect(processMultilineKey("", 0, key({ downArrow: true })).historyHandoff).toBeUndefined();
+    expect(processMultilineKey("hello\nworld", 9, key({ upArrow: true })).cursor).toBeNull();
   });
 
-  it("↑/↓ on an empty buffer hands off to history recall (universal CLI convention)", () => {
-    expect(processMultilineKey("", 0, key({ upArrow: true })).historyHandoff).toBe("prev");
-    expect(processMultilineKey("", 0, key({ downArrow: true })).historyHandoff).toBe("next");
-  });
-
-  it("Ctrl+P / Ctrl+N hand off to history recall (bash readline binding)", () => {
+  it("Ctrl+P / Ctrl+N on single-line / empty buffer hand off to history recall", () => {
     expect(processMultilineKey("", 0, key({ ctrl: true, input: "p" }))).toEqual({
       next: null,
       cursor: null,
@@ -173,37 +177,75 @@ describe("processMultilineKey — cursor motion", () => {
       submit: false,
       historyHandoff: "next",
     });
-    // Also from a non-empty buffer — Ctrl+P/N is unambiguous, no
-    // need for buffer-state gating like the old ↑/↓ binding.
     expect(processMultilineKey("hello", 3, key({ ctrl: true, input: "p" })).historyHandoff).toBe(
       "prev",
     );
+    expect(processMultilineKey("hello", 3, key({ ctrl: true, input: "n" })).historyHandoff).toBe(
+      "next",
+    );
   });
 
-  it("↑ at line 0 of a multi-line buffer is a NOOP (no auto history handoff)", () => {
+  it("Ctrl+P moves cursor to the previous line in a multi-line buffer (readline parity)", () => {
+    //  line 0: "hello" (cols 0-5)
+    //  line 1: "world" (cols 0-5)
+    //  cursor at col 3 on line 1 = index 9
+    const v = "hello\nworld";
+    const up = processMultilineKey(v, 9, key({ ctrl: true, input: "p" }));
+    expect(up.cursor).toBe(3);
+    expect(up.historyHandoff).toBeUndefined();
+  });
+
+  it("Ctrl+P clamps column when the previous line is shorter", () => {
+    const v = "hi\nworld";
+    const up = processMultilineKey(v, 7, key({ ctrl: true, input: "p" }));
+    expect(up.cursor).toBe(2);
+  });
+
+  it("Ctrl+N moves cursor to the next line, preserving column", () => {
+    const v = "hello\nworld";
+    const down = processMultilineKey(v, 2, key({ ctrl: true, input: "n" }));
+    expect(down.cursor).toBe(8);
+  });
+
+  it("Ctrl+N clamps column when the next line is shorter", () => {
+    const v = "world\nhi";
+    const down = processMultilineKey(v, 4, key({ ctrl: true, input: "n" }));
+    expect(down.cursor).toBe(8);
+  });
+
+  it("Ctrl+P at line 0 of a multi-line buffer falls back to history (no cursor move available)", () => {
     const v = "first\nsecond";
-    const result = processMultilineKey(v, 3, key({ upArrow: true }));
-    expect(result).toEqual({ next: null, cursor: null, submit: false });
+    const up = processMultilineKey(v, 3, key({ ctrl: true, input: "p" }));
+    expect(up.historyHandoff).toBe("prev");
+    expect(up.cursor).toBeNull();
   });
 
-  it("↓ at last line is a NOOP", () => {
+  it("Ctrl+N at last line of a multi-line buffer falls back to history", () => {
     const v = "first\nsecond";
-    const result = processMultilineKey(v, 8, key({ downArrow: true }));
-    expect(result).toEqual({ next: null, cursor: null, submit: false });
+    const down = processMultilineKey(v, 8, key({ ctrl: true, input: "n" }));
+    expect(down.historyHandoff).toBe("next");
+    expect(down.cursor).toBeNull();
   });
 
-  it("raw `\\x1b[A` escape sequence is rewritten into upArrow (history handoff on empty buffer)", () => {
-    const result = processMultilineKey("", 0, { input: "\x1b[A" });
-    expect(result.historyHandoff).toBe("prev");
+  it("raw `\\x1b[A` / `\\x1b[B` escape sequences are NOOP (chat-scroll handled at App level)", () => {
+    expect(processMultilineKey("", 0, { input: "\x1b[A" })).toEqual({
+      next: null,
+      cursor: null,
+      submit: false,
+    });
+    expect(processMultilineKey("", 0, { input: "\x1b[B" })).toEqual({
+      next: null,
+      cursor: null,
+      submit: false,
+    });
   });
 
-  it("raw `\\x1b[B` becomes downArrow; `\\x1b[C` rightArrow; `\\x1b[D` leftArrow", () => {
-    expect(processMultilineKey("", 0, { input: "\x1b[B" }).historyHandoff).toBe("next");
+  it("raw `\\x1b[C` rightArrow / `\\x1b[D` leftArrow still move the cursor", () => {
     expect(processMultilineKey("abc", 0, { input: "\x1b[C" }).cursor).toBe(1);
     expect(processMultilineKey("abc", 2, { input: "\x1b[D" }).cursor).toBe(1);
   });
 
-  it("ESC-stripped arrow fallbacks (`[C`, `[D`, `[A`, `[B`) — Windows ConPTY case", () => {
+  it("ESC-stripped arrow fallbacks (`[C`, `[D`) — Windows ConPTY case", () => {
     // PowerShell + ConPTY consumes the leading \x1b and routes the
     // remaining `[C` through useInput as plain text. Without the
     // ESC-less fallback, pressing right-arrow at end of a line would
@@ -211,42 +253,6 @@ describe("processMultilineKey — cursor motion", () => {
     // newline boundary.
     expect(processMultilineKey("ab\ncd", 2, { input: "[C" }).cursor).toBe(3);
     expect(processMultilineKey("ab\ncd", 3, { input: "[D" }).cursor).toBe(2);
-    expect(processMultilineKey("", 0, { input: "[A" }).historyHandoff).toBe("prev");
-    expect(processMultilineKey("", 0, { input: "[B" }).historyHandoff).toBe("next");
-  });
-
-  it("↑ moves cursor to the previous line, preserving column when possible", () => {
-    //  line 0: "hello" (cols 0-5)
-    //  line 1: "world" (cols 0-5)
-    //  cursor at col 3 on line 1 = index 5 (for "\n") + 3 + 1 = 9
-    const v = "hello\nworld";
-    const up = processMultilineKey(v, 9, key({ upArrow: true }));
-    // target: line 0 col 3 → index 3
-    expect(up.cursor).toBe(3);
-  });
-
-  it("↑ clamps column when the previous line is shorter", () => {
-    const v = "hi\nworld";
-    // cursor at line 1 col 4 = index 3 + 4 = 7
-    const up = processMultilineKey(v, 7, key({ upArrow: true }));
-    // target: line 0 col min(4, 2) = 2 → index 2
-    expect(up.cursor).toBe(2);
-  });
-
-  it("↓ moves cursor to the next line, preserving column", () => {
-    const v = "hello\nworld";
-    // cursor at line 0 col 2 = index 2
-    const down = processMultilineKey(v, 2, key({ downArrow: true }));
-    // target: line 1 col 2 → index 6 + 2 = 8
-    expect(down.cursor).toBe(8);
-  });
-
-  it("↓ clamps column when the next line is shorter", () => {
-    const v = "world\nhi";
-    // cursor at line 0 col 4 = index 4
-    const down = processMultilineKey(v, 4, key({ downArrow: true }));
-    // target: line 1 col min(4, 2) = 2 → index 6 + 2 = 8
-    expect(down.cursor).toBe(8);
   });
 
   it("Ctrl+A jumps to start of current line, Ctrl+E to end", () => {


### PR DESCRIPTION
## Summary

Multiple users reported they can't copy text and can't scroll. Both trace to the same root: we enabled DECSET 1000 + 1006 mouse tracking so the wheel could route through `mouseScrollUp/Down`. The side effect — every terminal we know about then refuses to start a native drag-select on click, blocks right-click, and on ConPTY / multiplexer setups can drop the wheel events entirely (so neither path scrolls).

## Fix — architecture flip

- **Don't enable mouse tracking.** Bracketed paste + modifyOtherKeys stay.
- **↑/↓ at the App level always scroll chat** (no buffer-state gating). Terminals translate the wheel to ↑/↓ in alt-screen mode, so the wheel still scrolls chat — for free, in every terminal.
- **Ctrl+P / Ctrl+N take over what ↑/↓ used to do in `PromptInput`**: cursor up/down inside a multi-line draft, falling back to prompt history when no cursor move is available (readline parity).
- **Pickers still own ↑/↓** while open (slash-suggestion, @-mention, slash-arg, shell-confirm). Chat-scroll handler skips ↑/↓ when any picker is active so the user doesn't see the picker selection move AND the chat scroll on the same keypress.
- `/keys` + `tipMouseClipboard` rewritten to reflect the new bindings; the prompt hint row now reads `↑↓ scroll · ^P/^N history`. The old "hold Shift to drag-select" workaround is gone — drag works directly now.

## Cost

Power users who liked the wheel-scroll-while-typing affordance have to switch to PgUp/PgDn or empty their prompt. Worth it given how many users hit the copy-paste wall.

## Test plan

- [x] full suite — 2364 passed, 2 skipped
- [x] typecheck + lint clean
- [x] tests for new ↑/↓ NOOP semantics + Ctrl+P/N readline-style cursor + history fallback
- [ ] manual: open `/foo` slash menu, press ↑/↓ — only picker selection moves
- [ ] manual: drag-select chat text, terminal-native copy works