### PR TITLE
perf(tui): lower streaming flush from 30Hz to 20Hz default

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -237,17 +237,17 @@ export interface AppProps {
 /**
  * Throttle interval in ms. We flush streaming deltas at most this often to
  * avoid re-rendering the whole UI on every single token from DeepSeek.
- * 33ms ≈ 30Hz, matches the cadence users feel as smooth in modern terminals
- * (Windows Terminal, WezTerm, iTerm2, Alacritty, Ghostty). Override via
- * `REASONIX_FLUSH_MS` if you're on a fragile terminal (winpty/MINTTY) that
- * leaves repaint artifacts at higher refresh rates — bumping back to 100
- * trades smoothness for stability.
+ * 50ms ≈ 20Hz — still visually smooth (Windows Terminal, WezTerm, iTerm2,
+ * Alacritty, Ghostty all comfortable here) and leaves the terminal
+ * enough stdout slack to repaint native drag-select highlights without
+ * fighting our streaming writes. Bump higher via `REASONIX_FLUSH_MS`
+ * for fragile terminals (winpty/MINTTY); drop to 33 for max smoothness.
  */
 const FLUSH_INTERVAL_MS = (() => {
   const raw = process.env.REASONIX_FLUSH_MS;
-  if (!raw) return 33;
+  if (!raw) return 50;
   const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed < 16 || parsed > 1000) return 33;
+  if (!Number.isFinite(parsed) || parsed < 16 || parsed > 1000) return 50;
   return Math.round(parsed);
 })();
 


### PR DESCRIPTION
## Summary

We write to stdout at the streaming flush rate, and the terminal has to interleave those writes with its own native drag-select highlight repaints. At 30Hz (33ms) the terminal can't keep up — selection feedback visibly lags during model output.

Now that mouse mode is off (#514) and users actually use drag-to-select again, this is the load-bearing perf knob for the "feels janky" complaints.

## Change

`FLUSH_INTERVAL_MS` default 33 → 50. Still feels smooth on every modern terminal we test on (Windows Terminal, WezTerm, iTerm2, Alacritty, Ghostty), and cuts the write rate by 33% — leaving the terminal's repaint pipeline enough budget to keep selection highlights snappy.

The `REASONIX_FLUSH_MS` env var still overrides; anyone who wants the old 30Hz back: `export REASONIX_FLUSH_MS=33`.

## Test plan

- [x] full suite — 2364 passed
- [x] typecheck + lint clean
- [ ] manual: drag-select a chunk of streaming output, confirm highlight stays under the cursor

Related: #514