### PR TITLE
Fix the command line rendering anomaly issue in cli, add /language command to the command list

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -3716,38 +3716,43 @@ function AppInner({
                   {" 📖 reading history — End / PgDn to return · ↓ to advance one line"}
                 </Text>
               ) : (
-                <>
-                  {codeMode ? (
-                    <ModeStatusBar
-                      editMode={editMode}
-                      pendingCount={pendingCount}
-                      flash={modeFlash}
-                      planMode={planMode}
-                      undoArmed={!!undoBanner || hasUndoable()}
-                      jobs={codeMode.jobs}
+                <Box flexDirection="column" flexShrink={0} flexWrap="nowrap">
+                  <Box flexDirection="column" flexShrink={0} flexWrap="nowrap">
+                    {codeMode ? (
+                      <ModeStatusBar
+                        editMode={editMode}
+                        pendingCount={pendingCount}
+                        flash={modeFlash}
+                        planMode={planMode}
+                        undoArmed={!!undoBanner || hasUndoable()}
+                        jobs={codeMode.jobs}
+                      />
+                    ) : null}
+                    {activeLoop ? <LoopStatusRow loop={activeLoop} /> : null}
+                    <StatusRow />
+                    <PromptInput
+                      value={input}
+                      onChange={setInput}
+                      onSubmit={handleSubmit}
+                      disabled={busy}
+                      onHistoryPrev={recallPrev}
+                      onHistoryNext={recallNext}
                     />
-                  ) : null}
-                  {activeLoop ? <LoopStatusRow loop={activeLoop} /> : null}
-                  <StatusRow />
-                  <PromptInput
-                    value={input}
-                    onChange={setInput}
-                    onSubmit={handleSubmit}
-                    disabled={busy}
-                    onHistoryPrev={recallPrev}
-                    onHistoryNext={recallNext}
-                  />
-                  {slashMatches !== null ? (
-                    <SlashSuggestions
-                      matches={slashMatches}
-                      selectedIndex={slashSelected}
-                      groupMode={slashGroupMode}
-                      advancedHidden={slashAdvancedHidden}
-                    />
-                  ) : null}
-                  {atState !== null ? (
-                    <AtMentionSuggestions state={atState} selectedIndex={atSelected} />
-                  ) : null}
+                  </Box>
+                  <Box flexDirection="column" flexShrink={0} flexWrap="nowrap">
+                    {slashMatches !== null ? (
+                      <SlashSuggestions
+                        key={`slash-suggestions:${slashGroupMode ? "group" : "search"}`}
+                        matches={slashMatches}
+                        selectedIndex={slashSelected}
+                        groupMode={slashGroupMode}
+                        advancedHidden={slashAdvancedHidden}
+                      />
+                    ) : null}
+                    {atState !== null ? (
+                      <AtMentionSuggestions state={atState} selectedIndex={atSelected} />
+                    ) : null}
+                  </Box>
                   {slashArgContext ? (
                     <SlashArgPicker
                       matches={slashArgMatches}
@@ -3758,7 +3763,7 @@ function AppInner({
                     />
                   ) : null}
                   {/* CtxFooter retired — UsageCard auto-emits per turn covers the same data */}
-                </>
+                </Box>
               )}
             </Box>
           </Box>

--- a/src/cli/ui/SlashSuggestions.tsx
+++ b/src/cli/ui/SlashSuggestions.tsx
@@ -1,9 +1,13 @@
-import { Box, Text } from "ink";
-// biome-ignore lint/style/useImportType: tsconfig.jsx = "react" needs React in value scope for JSX compilation
+import { Box, Text, useStdout } from "ink";
 import React from "react";
 import { t } from "../../i18n/index.js";
 import type { SlashCommandSpec, SlashGroup } from "./slash.js";
 import { GLYPH, useColor } from "./theme.js";
+
+const GROUP_MODE_MAX_ROWS = 24;
+const SEARCH_MODE_MAX_ROWS = 8;
+const COMMAND_NAME_CELLS = 14;
+const ARGS_CELLS = 14;
 
 export interface SlashSuggestionsProps {
   matches: SlashCommandSpec[] | null;
@@ -32,6 +36,9 @@ export function SlashSuggestions({
   advancedHidden,
 }: SlashSuggestionsProps): React.ReactElement | null {
   const color = useColor();
+  const { stdout } = useStdout();
+  const cols = stdout?.columns ?? 80;
+  const [rememberedWindowStart, setRememberedWindowStart] = React.useState(0);
 
   if (matches === null) return null;
   if (matches.length === 0) {
@@ -46,17 +53,24 @@ export function SlashSuggestions({
       </Box>
     );
   }
-  const MAX = groupMode ? 24 : 8;
+  const maxRows = groupMode ? GROUP_MODE_MAX_ROWS : SEARCH_MODE_MAX_ROWS;
   const total = matches.length;
-  const windowStart =
-    total <= MAX ? 0 : Math.max(0, Math.min(selectedIndex - Math.floor(MAX / 2), total - MAX));
-  const shown = matches.slice(windowStart, windowStart + MAX);
+  const windowStart = computeWindowStart(
+    matches,
+    maxRows,
+    selectedIndex,
+    rememberedWindowStart,
+    groupMode,
+  );
+  React.useEffect(() => {
+    setRememberedWindowStart(windowStart);
+  }, [windowStart]);
+  const items = buildVisibleItems(matches, windowStart, maxRows, groupMode);
+  const shownCommands = items.filter((item) => item.kind === "command");
   const hiddenAbove = windowStart;
-  const hiddenBelow = total - windowStart - shown.length;
-  let lastGroup: SlashGroup | null = null;
-  if (windowStart > 0) lastGroup = matches[windowStart - 1]?.group ?? null;
+  const hiddenBelow = total - windowStart - shownCommands.length;
   return (
-    <Box flexDirection="column" paddingX={1} marginTop={1}>
+    <Box flexDirection="column" paddingX={1} marginTop={1} flexShrink={0} flexWrap="nowrap">
       <Box>
         <Text color={color.accent} bold>
           {"/ "}
@@ -64,19 +78,17 @@ export function SlashSuggestions({
         <Text dimColor>{`${total} command${total === 1 ? "" : "s"}`}</Text>
         {hiddenAbove > 0 ? <Text dimColor>{`   ↑ ${hiddenAbove} above`}</Text> : null}
       </Box>
-      {shown.map((spec, i) => {
-        const idx = windowStart + i;
-        const showHeader = groupMode && spec.group !== lastGroup;
-        lastGroup = spec.group;
+      {items.map((item) => {
+        if (item.kind === "group") {
+          return <GroupHeader key={`group:${item.group}:${item.beforeIndex}`} group={item.group} />;
+        }
         return (
-          <React.Fragment key={spec.cmd}>
-            {showHeader ? (
-              <Box marginTop={idx === 0 ? 0 : 1}>
-                <Text dimColor>{`  ${GROUP_LABEL[spec.group]}`}</Text>
-              </Box>
-            ) : null}
-            <SuggestionRow spec={spec} isSelected={idx === selectedIndex} />
-          </React.Fragment>
+          <SuggestionRow
+            key={`cmd:${item.spec.group}:${item.spec.cmd}`}
+            spec={item.spec}
+            isSelected={item.index === selectedIndex}
+            columns={cols}
+          />
         );
       })}
       {hiddenBelow > 0 ? <Text dimColor>{`   ↓ ${hiddenBelow} below`}</Text> : null}
@@ -92,7 +104,74 @@ export function SlashSuggestions({
   );
 }
 
-function SuggestionRow({ spec, isSelected }: { spec: SlashCommandSpec; isSelected: boolean }) {
+export function computeWindowStart(
+  matches: readonly SlashCommandSpec[],
+  maxRows: number,
+  selectedIndex: number,
+  currentWindowStart: number,
+  groupMode = false,
+): number {
+  if (matches.length <= 0) return 0;
+  const maxWindowStart = Math.max(0, matches.length - 1);
+  let start = Math.max(0, Math.min(currentWindowStart, maxWindowStart));
+  const clampedSelectedIndex = Math.max(0, Math.min(selectedIndex, matches.length - 1));
+  if (clampedSelectedIndex < start) start = clampedSelectedIndex;
+  while (start < clampedSelectedIndex) {
+    const visibleCommandIndexes = buildVisibleItems(matches, start, maxRows, groupMode)
+      .filter((item) => item.kind === "command")
+      .map((item) => item.index);
+    if (visibleCommandIndexes.includes(clampedSelectedIndex)) break;
+    start += 1;
+  }
+  return Math.min(start, maxWindowStart);
+}
+
+type VisibleSuggestionItem =
+  | { kind: "group"; group: SlashGroup; beforeIndex: number }
+  | { kind: "command"; spec: SlashCommandSpec; index: number };
+
+export function buildVisibleItems(
+  matches: readonly SlashCommandSpec[],
+  windowStart: number,
+  maxRows: number,
+  groupMode = false,
+): VisibleSuggestionItem[] {
+  const out: VisibleSuggestionItem[] = [];
+  for (let idx = windowStart; idx < matches.length && out.length < maxRows; idx += 1) {
+    const spec = matches[idx]!;
+    if (groupMode && shouldShowGroupHeader(matches, idx)) {
+      if (out.length >= maxRows) break;
+      out.push({ kind: "group", group: spec.group, beforeIndex: idx });
+    }
+    if (out.length >= maxRows) break;
+    out.push({ kind: "command", spec, index: idx });
+  }
+  return out;
+}
+
+function shouldShowGroupHeader(matches: readonly SlashCommandSpec[], idx: number): boolean {
+  return idx === 0 || matches[idx]?.group !== matches[idx - 1]?.group;
+}
+
+function GroupHeader({ group }: { group: SlashGroup }): React.ReactElement {
+  return (
+    <Box flexShrink={0} height={1} flexWrap="nowrap">
+      <Text dimColor wrap="truncate">
+        {`  ${GROUP_LABEL[group]}`}
+      </Text>
+    </Box>
+  );
+}
+
+function SuggestionRow({
+  spec,
+  isSelected,
+  columns,
+}: {
+  spec: SlashCommandSpec;
+  isSelected: boolean;
+  columns: number;
+}) {
   const color = useColor();
   const name = `/${spec.cmd}`;
   const argsSuffix = spec.argsHint ? spec.argsHint : "";
@@ -100,20 +179,35 @@ function SuggestionRow({ spec, isSelected }: { spec: SlashCommandSpec; isSelecte
   const translated = t(key);
   const summary = translated === key ? spec.summary : translated;
   const aliasHint = spec.aliases?.length ? ` · /${spec.aliases.join(" /")}` : "";
+  const reservedCells = 2 + COMMAND_NAME_CELLS + ARGS_CELLS + 2 + 2;
+  const summaryBudget = Math.max(8, columns - reservedCells);
+  const summaryText = truncateCells(`${summary}${aliasHint}`, summaryBudget);
   return (
-    <Box>
-      <Text color={isSelected ? color.primary : color.info} bold={isSelected}>
+    <Box flexDirection="row" flexWrap="nowrap" flexShrink={0} height={1} minHeight={1}>
+      <Text color={isSelected ? color.primary : color.info} bold={isSelected} wrap="truncate">
         {isSelected ? `${GLYPH.cur} ` : "  "}
       </Text>
-      <Text color={color.accent} bold={isSelected}>
-        {name.padEnd(14)}
+      <Text color={color.accent} bold={isSelected} wrap="truncate">
+        {padOrTrim(name, COMMAND_NAME_CELLS)}
       </Text>
-      <Text dimColor>{argsSuffix.padEnd(14)}</Text>
-      <Text>{"  "}</Text>
-      <Text color={isSelected ? color.user : color.info} dimColor={!isSelected}>
-        {summary}
+      <Text dimColor wrap="truncate">
+        {padOrTrim(argsSuffix, ARGS_CELLS)}
       </Text>
-      {aliasHint ? <Text dimColor>{aliasHint}</Text> : null}
+      <Text wrap="truncate">{"  "}</Text>
+      <Text color={isSelected ? color.user : color.info} dimColor={!isSelected} wrap="truncate">
+        {summaryText}
+      </Text>
     </Box>
   );
+}
+
+function padOrTrim(value: string, cells: number): string {
+  const trimmed = truncateCells(value, cells);
+  return trimmed.padEnd(cells);
+}
+
+function truncateCells(value: string, maxCells: number): string {
+  if (value.length <= maxCells) return value;
+  if (maxCells <= 1) return value.slice(0, Math.max(0, maxCells));
+  return `${value.slice(0, maxCells - 1)}…`;
 }

--- a/src/cli/ui/layout/StatusRow.tsx
+++ b/src/cli/ui/layout/StatusRow.tsx
@@ -25,13 +25,15 @@ export function StatusRow(): React.ReactElement {
   const showWallet = cols >= WALLET_MIN_COLS && (hasSession || hasBalance);
 
   return (
-    <Box flexDirection="column">
-      <Box>
+    <Box flexDirection="column" flexShrink={0} flexWrap="nowrap">
+      <Box height={1} flexWrap="nowrap">
         <Text>{"  "}</Text>
-        <Text color={FG.faint}>{"─".repeat(ruleWidth)}</Text>
+        <Text color={FG.faint} wrap="truncate">
+          {"─".repeat(ruleWidth)}
+        </Text>
       </Box>
-      <Box flexDirection="row">
-        <Text>{"  "}</Text>
+      <Box flexDirection="row" height={1} minHeight={1} flexWrap="nowrap" flexShrink={0}>
+        <Text wrap="truncate">{"  "}</Text>
         {status.recording ? (
           <RecordingPill rec={status.recording} />
         ) : status.countdownSeconds !== undefined ? (
@@ -40,20 +42,23 @@ export function StatusRow(): React.ReactElement {
           <ModePill mode={status.mode} network={status.network} detail={status.networkDetail} />
         )}
         <Sep />
-        <Text color={FG.sub}>{`${session.id} · ${session.branch}`}</Text>
+        <Text color={FG.sub} wrap="truncate">{`${session.id} · ${session.branch}`}</Text>
         {hasTurn && (
           <>
             <Sep />
-            <Text bold color={TONE.brand}>
+            <Text bold color={TONE.brand} wrap="truncate">
               {"▸ "}
             </Text>
-            <Text bold color={FG.body}>
+            <Text bold color={FG.body} wrap="truncate">
               {`${formatCost(status.cost, status.balanceCurrency)} turn`}
             </Text>
           </>
         )}
         <Sep />
-        <Text color={TONE.accent}>{`cache ${Math.round(status.cacheHit * 100)}%`}</Text>
+        <Text
+          color={TONE.accent}
+          wrap="truncate"
+        >{`cache ${Math.round(status.cacheHit * 100)}%`}</Text>
         {showWallet && (
           <WalletPill
             sessionCostUsd={status.sessionCost}
@@ -64,12 +69,18 @@ export function StatusRow(): React.ReactElement {
         {cols >= VERSION_MIN_COLS && (
           <>
             <Sep />
-            <Text color={FG.faint}>{`v${VERSION}`}</Text>
+            <Text color={FG.faint} wrap="truncate">{`v${VERSION}`}</Text>
             {cols >= FEEDBACK_HINT_MIN_COLS && (
               <>
-                <Text color={FG.faint}>{"  ·  "}</Text>
-                <Text color={FG.meta}>{"⚑ "}</Text>
-                <Text color={FG.sub}>{"/feedback"}</Text>
+                <Text color={FG.faint} wrap="truncate">
+                  {"  ·  "}
+                </Text>
+                <Text color={FG.meta} wrap="truncate">
+                  {"⚑ "}
+                </Text>
+                <Text color={FG.sub} wrap="truncate">
+                  {"/feedback"}
+                </Text>
               </>
             )}
           </>
@@ -93,17 +104,30 @@ function WalletPill({
   return (
     <>
       <Sep />
-      <Text color={FG.meta}>{"⛁ "}</Text>
+      <Text color={FG.meta} wrap="truncate">
+        {"⛁ "}
+      </Text>
       {showSpent && (
-        <Text color={FG.body}>{`${formatCost(sessionCostUsd, currency, 2)} spent`}</Text>
+        <Text
+          color={FG.body}
+          wrap="truncate"
+        >{`${formatCost(sessionCostUsd, currency, 2)} spent`}</Text>
       )}
-      {showSpent && showBalance && <Text color={FG.meta}>{"  /  "}</Text>}
+      {showSpent && showBalance && (
+        <Text color={FG.meta} wrap="truncate">
+          {"  /  "}
+        </Text>
+      )}
       {showBalance && (
-        <Text bold color={balanceColor(balance, currency)}>
+        <Text bold color={balanceColor(balance, currency)} wrap="truncate">
           {formatBalance(balance, currency, { fractionDigits: 2 })}
         </Text>
       )}
-      {showBalance && <Text color={FG.faint}>{" left"}</Text>}
+      {showBalance && (
+        <Text color={FG.faint} wrap="truncate">
+          {" left"}
+        </Text>
+      )}
     </>
   );
 }
@@ -120,9 +144,11 @@ function ModePill({
   if (network === "online") {
     const pill = modeGlyph(mode);
     return (
-      <Box flexDirection="row">
-        <Text color={pill.color}>{pill.glyph}</Text>
-        <Text color={FG.sub}>{` ${mode}`}</Text>
+      <Box flexDirection="row" height={1} flexWrap="nowrap">
+        <Text color={pill.color} wrap="truncate">
+          {pill.glyph}
+        </Text>
+        <Text color={FG.sub} wrap="truncate">{` ${mode}`}</Text>
       </Box>
     );
   }
@@ -130,25 +156,33 @@ function ModePill({
   if (network === "slow") {
     const tail = detail ? ` · ${detail}` : "";
     return (
-      <Box flexDirection="row">
-        <Text color={dot.color}>{dot.glyph}</Text>
-        <Text color={dot.color}>{` ${mode} · slow${tail}`}</Text>
+      <Box flexDirection="row" height={1} flexWrap="nowrap">
+        <Text color={dot.color} wrap="truncate">
+          {dot.glyph}
+        </Text>
+        <Text color={dot.color} wrap="truncate">{` ${mode} · slow${tail}`}</Text>
       </Box>
     );
   }
   if (network === "disconnected") {
     const tail = detail ? ` · ${detail}` : "";
     return (
-      <Box flexDirection="row">
-        <Text color={dot.color}>{dot.glyph}</Text>
-        <Text color={dot.color}>{` disconnect${tail}`}</Text>
+      <Box flexDirection="row" height={1} flexWrap="nowrap">
+        <Text color={dot.color} wrap="truncate">
+          {dot.glyph}
+        </Text>
+        <Text color={dot.color} wrap="truncate">{` disconnect${tail}`}</Text>
       </Box>
     );
   }
   return (
-    <Box flexDirection="row">
-      <Text color={dot.color}>{dot.glyph}</Text>
-      <Text color={dot.color}>{" reconnecting…"}</Text>
+    <Box flexDirection="row" height={1} flexWrap="nowrap">
+      <Text color={dot.color} wrap="truncate">
+        {dot.glyph}
+      </Text>
+      <Text color={dot.color} wrap="truncate">
+        {" reconnecting…"}
+      </Text>
     </Box>
   );
 }
@@ -163,12 +197,18 @@ function CountdownRow({
   const pill = modeGlyph(mode);
   const endsAt = Date.now() + secondsLeft * 1000;
   return (
-    <Box flexDirection="row">
-      <Text color={pill.color}>{pill.glyph}</Text>
-      <Text color={FG.sub}>{` ${mode}   ·   `}</Text>
-      <Text color={TONE.warn}>{"approving in "}</Text>
+    <Box flexDirection="row" height={1} flexWrap="nowrap">
+      <Text color={pill.color} wrap="truncate">
+        {pill.glyph}
+      </Text>
+      <Text color={FG.sub} wrap="truncate">{` ${mode}   ·   `}</Text>
+      <Text color={TONE.warn} wrap="truncate">
+        {"approving in "}
+      </Text>
       <Countdown endsAt={endsAt} />
-      <Text color={TONE.warn}>{"s · esc to interrupt"}</Text>
+      <Text color={TONE.warn} wrap="truncate">
+        {"s · esc to interrupt"}
+      </Text>
     </Box>
   );
 }
@@ -176,17 +216,21 @@ function CountdownRow({
 function RecordingPill({ rec }: { rec: NonNullable<StatusBar["recording"]> }): React.ReactElement {
   const sizeMb = (rec.sizeBytes / (1024 * 1024)).toFixed(1);
   return (
-    <Box flexDirection="row">
-      <Text bold color={TONE.err}>
+    <Box flexDirection="row" height={1} flexWrap="nowrap">
+      <Text bold color={TONE.err} wrap="truncate">
         {"●REC"}
       </Text>
-      <Text color={TONE.err}>{` ${sizeMb} MB · ${rec.events} evt`}</Text>
+      <Text color={TONE.err} wrap="truncate">{` ${sizeMb} MB · ${rec.events} evt`}</Text>
     </Box>
   );
 }
 
 function Sep(): React.ReactElement {
-  return <Text color={FG.meta}>{"   ·   "}</Text>;
+  return (
+    <Text color={FG.meta} wrap="truncate">
+      {"   ·   "}
+    </Text>
+  );
 }
 
 function modeGlyph(mode: Mode): { glyph: string; color: string } {

--- a/src/cli/ui/slash/commands.ts
+++ b/src/cli/ui/slash/commands.ts
@@ -35,6 +35,14 @@ export const SLASH_COMMANDS: readonly SlashCommandSpec[] = [
     summary: "switch DeepSeek model id. Bare opens picker.",
     argCompleter: "models",
   },
+  {
+    cmd: "language",
+    group: "setup",
+    argsHint: "<EN|zh-CN>",
+    summary: "switch the runtime language",
+    argCompleter: ["EN", "zh-CN"],
+    aliases: ["lang"],
+  },
 
   { cmd: "status", group: "info", summary: "current model, flags, context, session" },
   {
@@ -238,14 +246,6 @@ export const SLASH_COMMANDS: readonly SlashCommandSpec[] = [
     argCompleter: ["off", "1", "5", "10", "20", "50"],
   },
   {
-    cmd: "language",
-    group: "advanced",
-    argsHint: "<EN|zh-CN>",
-    summary: "switch the runtime language",
-    argCompleter: ["EN", "zh-CN"],
-    aliases: ["lang"],
-  },
-  {
     cmd: "theme",
     group: "advanced",
     argsHint: "[auto|default|dark|light|tokyo-night|github-dark|github-light]",
@@ -321,9 +321,10 @@ export function suggestSlashCommands(
 ): SlashCommandSpec[] {
   const p = prefix.toLowerCase();
   const matches = SLASH_COMMANDS.filter((c) => {
+    // Empty prefix = browsing the menu — show the full release command surface except
+    // advanced rows, which remain collapsed behind the footer hint.
+    if (p === "") return c.group !== "advanced";
     if (c.contextual === "code" && !codeMode) return false;
-    // Empty prefix = browsing the menu — advanced stays hidden until a letter is typed.
-    if (p === "" && c.group === "advanced") return false;
     if (c.cmd.startsWith(p)) return true;
     return c.aliases?.some((a) => a.startsWith(p)) ?? false;
   });

--- a/tests/slash.test.ts
+++ b/tests/slash.test.ts
@@ -493,6 +493,7 @@ describe("handleSlash", () => {
       "status",
       "preset",
       "model",
+      "language",
       "theme",
       "mcp",
       "memory",
@@ -515,8 +516,11 @@ describe("handleSlash", () => {
     expect(suggestSlashCommands("h").map((s) => s.cmd)).toEqual(["help", "hooks"]);
     // Case-insensitive.
     expect(suggestSlashCommands("HE").map((s) => s.cmd)).toEqual(["help"]);
-    // Empty prefix returns the curated non-advanced list.
-    expect(suggestSlashCommands("").length).toBeGreaterThan(5);
+    // Empty prefix returns the full non-advanced release list, including code commands.
+    expect(suggestSlashCommands("", true)).toHaveLength(37);
+    expect(suggestSlashCommands("", true).map((s) => s.cmd)).toContain("logs");
+    expect(suggestSlashCommands("", true).map((s) => s.cmd)).toContain("language");
+    expect(suggestSlashCommands("lan").map((s) => s.cmd)).toContain("language");
   });
 
   describe("/update", () => {
@@ -561,16 +565,15 @@ describe("handleSlash", () => {
     });
   });
 
-  it("suggestSlashCommands hides code-mode-only entries when codeMode=false", () => {
+  it("suggestSlashCommands shows code-mode entries in bare slash browse mode", () => {
     const names = suggestSlashCommands("", false).map((s) => s.cmd);
-    expect(names).not.toContain("apply");
-    expect(names).not.toContain("undo");
-  });
-
-  it("suggestSlashCommands shows code-mode-only entries when codeMode=true", () => {
-    const names = suggestSlashCommands("", true).map((s) => s.cmd);
     expect(names).toContain("apply");
     expect(names).toContain("undo");
+  });
+
+  it("suggestSlashCommands keeps code-mode gating for typed prefixes", () => {
+    expect(suggestSlashCommands("ap", false).map((s) => s.cmd)).not.toContain("apply");
+    expect(suggestSlashCommands("ap", true).map((s) => s.cmd)).toContain("apply");
   });
 
   it("/mcp opens the browser modal when servers are attached", () => {

--- a/tests/ui-slash-suggestions.test.tsx
+++ b/tests/ui-slash-suggestions.test.tsx
@@ -1,0 +1,176 @@
+import { render } from "ink-testing-library";
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { SlashSuggestions } from "../src/cli/ui/SlashSuggestions.js";
+import {
+  SLASH_COMMANDS,
+  type SlashCommandSpec,
+  countAdvancedCommands,
+  suggestSlashCommands,
+} from "../src/cli/ui/slash.js";
+
+function makeCommands(count: number): SlashCommandSpec[] {
+  const groups = ["chat", "setup", "info", "session", "extend", "code", "jobs"] as const;
+  return Array.from({ length: count }, (_, i) => ({
+    cmd: `cmd${i.toString().padStart(2, "0")}`,
+    summary: `summary ${i}`,
+    group: groups[Math.floor(i / 5) % groups.length],
+  }));
+}
+
+function suggestionElement(
+  matches: SlashCommandSpec[],
+  selectedIndex: number,
+  advancedHidden = 0,
+): React.ReactElement {
+  return React.createElement(SlashSuggestions, {
+    matches,
+    selectedIndex,
+    groupMode: true,
+    advancedHidden,
+  });
+}
+
+function renderSuggestions(selectedIndex: number): string {
+  const { lastFrame, unmount } = render(
+    suggestionElement(suggestSlashCommands("", true), selectedIndex, countAdvancedCommands(true)),
+  );
+  const frame = lastFrame() ?? "";
+  unmount();
+  return frame;
+}
+
+function visibleCommandOrder(
+  frame: string,
+  commands: readonly SlashCommandSpec[] = SLASH_COMMANDS,
+): string[] {
+  const names = new Set(commands.map((spec) => `/${spec.cmd}`));
+  return frame
+    .split(/\r?\n/)
+    .map((line) => /^\s*(?:▸\s*)?(\/\w+)\b/.exec(line)?.[1] ?? "")
+    .filter((token) => names.has(token));
+}
+
+function firstVisibleCommand(
+  frame: string,
+  commands: readonly SlashCommandSpec[] = SLASH_COMMANDS,
+): string | undefined {
+  return visibleCommandOrder(frame, commands)[0];
+}
+
+function hiddenAboveCount(frame: string): number {
+  const match = /↑ (\d+) above/.exec(frame);
+  return match ? Number(match[1]) : 0;
+}
+
+describe("SlashSuggestions", () => {
+  it("renders the bare slash release command surface as 37 total commands", () => {
+    const matches = suggestSlashCommands("", true);
+    const names = matches.map((spec) => spec.cmd);
+    const { lastFrame, unmount } = render(
+      suggestionElement(matches, 0, countAdvancedCommands(true)),
+    );
+    const frame = lastFrame() ?? "";
+    unmount();
+
+    expect(matches).toHaveLength(37);
+    expect(names).toContain("language");
+    expect(countAdvancedCommands(true)).toBe(12);
+    expect(frame).toContain("37 commands");
+    expect(frame).toContain("+ 12 advanced");
+  });
+
+  it("surfaces /language for typed language prefixes", () => {
+    expect(suggestSlashCommands("lan").map((spec) => spec.cmd)).toContain("language");
+  });
+
+  it("keeps the command order stable while the selected row moves in grouped browse mode", () => {
+    const first = visibleCommandOrder(renderSuggestions(0));
+    const middle = visibleCommandOrder(renderSuggestions(10));
+    const last = visibleCommandOrder(renderSuggestions(18));
+
+    expect(first).toEqual(middle);
+    expect(middle).toEqual(last);
+    const matches = suggestSlashCommands("", true);
+    expect(first).toEqual(matches.slice(0, first.length).map((spec) => `/${spec.cmd}`));
+  });
+
+  it("scrolls through every command in grouped browse mode when the list is taller than the window", () => {
+    const commands = makeCommands(30);
+    const { lastFrame, rerender, unmount } = render(suggestionElement(commands, 0));
+
+    rerender(suggestionElement(commands, commands.length - 1));
+    const frame = lastFrame() ?? "";
+    unmount();
+
+    expect(visibleCommandOrder(frame, commands)).toContain("/cmd29");
+    expect(hiddenAboveCount(frame)).toBe(10);
+  });
+
+  it("only advances the grouped window when selection crosses a visible boundary", () => {
+    const commands = makeCommands(30);
+    const { lastFrame, rerender, unmount } = render(suggestionElement(commands, 0));
+    const firstAtStart = firstVisibleCommand(lastFrame() ?? "", commands);
+
+    for (let selected = 1; selected < 20; selected += 1) {
+      rerender(suggestionElement(commands, selected));
+      expect(firstVisibleCommand(lastFrame() ?? "", commands)).toBe(firstAtStart);
+    }
+
+    rerender(suggestionElement(commands, 20));
+    expect(firstVisibleCommand(lastFrame() ?? "", commands)).toBe("/cmd01");
+
+    rerender(suggestionElement(commands, 21));
+    expect(firstVisibleCommand(lastFrame() ?? "", commands)).toBe("/cmd02");
+    unmount();
+  });
+
+  it("renders each visible command as one row instead of wrapping selected text into extra blocks", () => {
+    const frame = renderSuggestions(7);
+    const visibleRows = frame.split(/\r?\n/).filter((line) => /^\s*(?:▸\s*)?\/\w+\b/.test(line));
+    const visibleCommands = visibleCommandOrder(frame);
+
+    expect(visibleRows).toHaveLength(visibleCommands.length);
+    expect(visibleRows.some((line) => line.includes("show the full command reference"))).toBe(true);
+  });
+
+  it("keeps bottom-window command rows paired with their own descriptions", () => {
+    const commands = makeCommands(30).map((spec, i) => ({
+      ...spec,
+      summary: `description-for-${spec.cmd}-unique-${i}`,
+    }));
+    const { lastFrame, rerender, unmount } = render(suggestionElement(commands, 0));
+
+    rerender(suggestionElement(commands, commands.length - 1));
+    const frame = lastFrame() ?? "";
+    unmount();
+
+    const commandRows = frame.split(/\r?\n/).filter((line) => /^\s*(?:▸\s*)?\/\w+\b/.test(line));
+    expect(commandRows).toContainEqual(expect.stringContaining("/cmd29"));
+    expect(commandRows.find((line) => line.includes("/cmd29"))).toContain(
+      "description-for-cmd29-unique-29",
+    );
+    expect(commandRows.find((line) => line.includes("/cmd29"))).not.toContain(
+      "description-for-cmd23-unique-23",
+    );
+  });
+
+  it("counts group headers inside the fixed visible row budget", () => {
+    const commands = makeCommands(30);
+    const frame =
+      render(
+        React.createElement(SlashSuggestions, {
+          matches: commands,
+          selectedIndex: commands.length - 1,
+          groupMode: true,
+        }),
+      ).lastFrame() ?? "";
+
+    const visibleBodyRows = frame
+      .split(/\r?\n/)
+      .filter((line) =>
+        /^(\s*(?:CHAT|SETUP|INFO|SESSION|EXTEND|CODE|JOBS)|\s*(?:▸\s*)?\/\w+\b)/.test(line),
+      );
+    expect(visibleBodyRows.length).toBeLessThanOrEqual(24);
+  });
+});

--- a/tests/ui-status-row-balance.test.tsx
+++ b/tests/ui-status-row-balance.test.tsx
@@ -6,13 +6,15 @@
 import { render } from "ink";
 import React, { useEffect } from "react";
 import { describe, expect, it } from "vitest";
+import { SlashSuggestions } from "../src/cli/ui/SlashSuggestions.js";
 import { StatusRow } from "../src/cli/ui/layout/StatusRow.js";
+import type { SlashCommandSpec } from "../src/cli/ui/slash.js";
 import { AgentStoreProvider, useAgentStore } from "../src/cli/ui/state/provider.js";
 import type { AgentState, SessionInfo } from "../src/cli/ui/state/state.js";
 import { makeFakeStdin, makeFakeStdout } from "./helpers/ink-stdio.js";
 
 const SESSION: SessionInfo = {
-  id: "test-session",
+  id: "default",
   branch: "main",
   workspace: "/tmp/repo",
   model: "deepseek-chat",
@@ -98,5 +100,61 @@ describe("StatusRow — turn cost currency", () => {
   it("cache % always rendered", async () => {
     const text = await renderStatusRow({ cost: 0, cacheHit: 0.873 } as any);
     expect(text).toContain("cache 87%");
+  });
+});
+
+function makeSlashCommands(count: number): SlashCommandSpec[] {
+  return Array.from({ length: count }, (_, i) => ({
+    cmd: `cmd${i.toString().padStart(2, "0")}`,
+    summary: `summary ${i}`,
+    group: i < 5 ? "setup" : "info",
+  }));
+}
+
+async function renderStatusWithSuggestions(): Promise<string> {
+  const stdout = makeFakeStdout();
+  const { unmount } = render(
+    <AgentStoreProvider session={SESSION}>
+      <StateInjector
+        overrides={{
+          mode: "auto",
+          cacheHit: 0,
+          balance: 8.08,
+          balanceCurrency: "CNY",
+        }}
+      >
+        <BoxLikeComposer />
+      </StateInjector>
+    </AgentStoreProvider>,
+    { stdout: stdout as never, stdin: makeFakeStdin() as never },
+  );
+  await new Promise((r) => setTimeout(r, 50));
+  unmount();
+  return stdout.text();
+}
+
+function BoxLikeComposer(): React.ReactElement {
+  return (
+    <React.Fragment>
+      <StatusRow />
+      <SlashSuggestions matches={makeSlashCommands(12)} selectedIndex={7} groupMode />
+    </React.Fragment>
+  );
+}
+
+describe("StatusRow + SlashSuggestions composition", () => {
+  it("keeps the status line independent from slash suggestion headers", async () => {
+    const text = await renderStatusWithSuggestions();
+    const lines = text.split(/\r?\n/);
+    const statusLine = lines.find((line) => line.includes("cache 0%"));
+
+    expect(statusLine).toBeDefined();
+    expect(statusLine).toContain("auto");
+    expect(statusLine).toContain("default · main");
+    expect(statusLine).toContain("v0.35.0");
+    expect(statusLine).toContain("/feedback");
+    expect(statusLine).not.toContain("SETUP");
+    expect(statusLine).not.toContain("commands");
+    expect(lines.some((line) => /^\s*SETUP\s*$/.test(line))).toBe(true);
   });
 });


### PR DESCRIPTION
<!-- Read CONTRIBUTING.md first if this is your first PR. -->

## What

This change stabilizes slash command suggestion rendering in the CLI/TUI, restores the full visible command list, and adds [/language](vscode-webview://02ns4aqc7ag1h1eqjrpa41vef6412injvqb7snd8ems0t1q4mve2/src/cli/ui/slash/commands.ts:39) as a normal visible command. It updates [SlashSuggestions](vscode-webview://02ns4aqc7ag1h1eqjrpa41vef6412injvqb7snd8ems0t1q4mve2/src/cli/ui/SlashSuggestions.tsx) to use stable windowing, fixed single-line command rows, stable row keys, and consistent group-header budgeting; updates status/input layout in [App.tsx](vscode-webview://02ns4aqc7ag1h1eqjrpa41vef6412injvqb7snd8ems0t1q4mve2/src/cli/ui/App.tsx) and [StatusRow.tsx](vscode-webview://02ns4aqc7ag1h1eqjrpa41vef6412injvqb7snd8ems0t1q4mve2/src/cli/ui/layout/StatusRow.tsx) to prevent prompt/status content from being overwritten by suggestions; and updates command tests so bare [/](vscode-webview://02ns4aqc7ag1h1eqjrpa41vef6412injvqb7snd8ems0t1q4mve2/src/cli/ui/SlashSuggestions.tsx) now shows 37 commands plus 12 advanced.

<!-- One paragraph: what does this change? -->

## Why

This fixes several pre-existing TUI rendering issues where moving the selected slash command could cause the command list to jump, reorder, split a command into multiple visual blocks, or leave stale descriptions at the bottom of the list. It also fixes an incorrect filtering condition that reduced the bare slash command list from the expected release behavior, and makes [/language](vscode-webview://02ns4aqc7ag1h1eqjrpa41vef6412injvqb7snd8ems0t1q4mve2/src/cli/ui/slash/commands.ts:39) discoverable directly from the command list instead of being hidden in advanced commands. The status row fix prevents the prompt/status line, such as the mode/session/cache/version/selected-command row, from being visually merged with suggestion headers.

<!-- Bug fix? Pre-existing issue? Linked discussion? -->

## How to verify

Run [npx vitest run tests/slash.test.ts tests/ui-slash-suggestions.test.tsx tests/ui-status-row-balance.test.tsx](vscode-webview://02ns4aqc7ag1h1eqjrpa41vef6412injvqb7snd8ems0t1q4mve2/index.html?id=9a19e26e-d25a-42cb-b76b-19dd8938ecbb&parentId=1&origin=ae8d1964-58bb-45b3-90bd-54fb004d76b2&swVersion=5&extensionId=RooVeterinaryInc.roo-cline&platform=electron&vscode-resource-base-authority=vscode-resource.vscode-cdn.net&parentOrigin=vscode-file%3A%2F%2Fvscode-app&remoteAuthority=ssh-remote%2B192.168.169.139&purpose=webviewView) and confirm all tests pass.
Run [npm run typecheck](vscode-webview://02ns4aqc7ag1h1eqjrpa41vef6412injvqb7snd8ems0t1q4mve2/index.html?id=9a19e26e-d25a-42cb-b76b-19dd8938ecbb&parentId=1&origin=ae8d1964-58bb-45b3-90bd-54fb004d76b2&swVersion=5&extensionId=RooVeterinaryInc.roo-cline&platform=electron&vscode-resource-base-authority=vscode-resource.vscode-cdn.net&parentOrigin=vscode-file%3A%2F%2Fvscode-app&remoteAuthority=ssh-remote%2B192.168.169.139&purpose=webviewView) and confirm TypeScript checks pass.
Run [npx biome check src/cli/ui/slash/commands.ts src/cli/ui/slash/dispatch.ts src/cli/ui/slash/handlers/language.ts src/cli/ui/SlashSuggestions.tsx src/cli/ui/App.tsx src/cli/ui/layout/StatusRow.tsx tests/slash.test.ts tests/ui-slash-suggestions.test.tsx tests/ui-status-row-balance.test.tsx](vscode-webview://02ns4aqc7ag1h1eqjrpa41vef6412injvqb7snd8ems0t1q4mve2/biome.json) and confirm formatting/lint checks pass.
Start the CLI/TUI from the current build and open bare [/](vscode-webview://02ns4aqc7ag1h1eqjrpa41vef6412injvqb7snd8ems0t1q4mve2/src/cli/ui/SlashSuggestions.tsx); confirm it shows 37 commands, + 12 advanced, includes [/language](vscode-webview://02ns4aqc7ag1h1eqjrpa41vef6412injvqb7snd8ems0t1q4mve2/src/cli/ui/slash/commands.ts:39), scrolls through the full list without jumping/reordering, keeps each command on one line, and does not corrupt the status/input row.

<!-- Steps the reviewer can run. `npm run verify` is assumed. -->

## Checklist

- [ ✅] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [ ✅] No `Co-Authored-By: Claude` trailer in commits
- [ ✅] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [ ✅] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time
