### PR TITLE
Enhance slash command functionality and add language switching

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -214,7 +214,12 @@ src/
 Files kept small by design: the largest module under `cli/ui/` is 2K
 lines (App.tsx), every handler under `slash/handlers/` is ≤200 lines,
 every hook under `cli/ui/` is ≤310 lines. Adding a new slash command
-means editing one handler file and one registry line.
+means editing one handler file and one registry line. Declare its internal
+functional domain in the registry's `group` field; help and slash browsing
+are grouped by the centralized `SLASH_GROUP_ORDER` (`SETUP`, `INFO`,
+`CHAT`, `EXTEND`, `SESSION`, then code/jobs/advanced, with `UNKNOWN` last for
+unrecognized groups), so each category header appears once and commands keep
+their registry order within the category.
 
 ## Design evolution
 

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -3716,38 +3716,43 @@ function AppInner({
                   {" 📖 reading history — End / PgDn to return · ↓ to advance one line"}
                 </Text>
               ) : (
-                <>
-                  {codeMode ? (
-                    <ModeStatusBar
-                      editMode={editMode}
-                      pendingCount={pendingCount}
-                      flash={modeFlash}
-                      planMode={planMode}
-                      undoArmed={!!undoBanner || hasUndoable()}
-                      jobs={codeMode.jobs}
+                <Box flexDirection="column" flexShrink={0} flexWrap="nowrap">
+                  <Box flexDirection="column" flexShrink={0} flexWrap="nowrap">
+                    {codeMode ? (
+                      <ModeStatusBar
+                        editMode={editMode}
+                        pendingCount={pendingCount}
+                        flash={modeFlash}
+                        planMode={planMode}
+                        undoArmed={!!undoBanner || hasUndoable()}
+                        jobs={codeMode.jobs}
+                      />
+                    ) : null}
+                    {activeLoop ? <LoopStatusRow loop={activeLoop} /> : null}
+                    <StatusRow />
+                    <PromptInput
+                      value={input}
+                      onChange={setInput}
+                      onSubmit={handleSubmit}
+                      disabled={busy}
+                      onHistoryPrev={recallPrev}
+                      onHistoryNext={recallNext}
                     />
-                  ) : null}
-                  {activeLoop ? <LoopStatusRow loop={activeLoop} /> : null}
-                  <StatusRow />
-                  <PromptInput
-                    value={input}
-                    onChange={setInput}
-                    onSubmit={handleSubmit}
-                    disabled={busy}
-                    onHistoryPrev={recallPrev}
-                    onHistoryNext={recallNext}
-                  />
-                  {slashMatches !== null ? (
-                    <SlashSuggestions
-                      matches={slashMatches}
-                      selectedIndex={slashSelected}
-                      groupMode={slashGroupMode}
-                      advancedHidden={slashAdvancedHidden}
-                    />
-                  ) : null}
-                  {atState !== null ? (
-                    <AtMentionSuggestions state={atState} selectedIndex={atSelected} />
-                  ) : null}
+                  </Box>
+                  <Box flexDirection="column" flexShrink={0} flexWrap="nowrap">
+                    {slashMatches !== null ? (
+                      <SlashSuggestions
+                        key={`slash-suggestions:${slashGroupMode ? "group" : "search"}`}
+                        matches={slashMatches}
+                        selectedIndex={slashSelected}
+                        groupMode={slashGroupMode}
+                        advancedHidden={slashAdvancedHidden}
+                      />
+                    ) : null}
+                    {atState !== null ? (
+                      <AtMentionSuggestions state={atState} selectedIndex={atSelected} />
+                    ) : null}
+                  </Box>
                   {slashArgContext ? (
                     <SlashArgPicker
                       matches={slashArgMatches}
@@ -3758,7 +3763,7 @@ function AppInner({
                     />
                   ) : null}
                   {/* CtxFooter retired — UsageCard auto-emits per turn covers the same data */}
-                </>
+                </Box>
               )}
             </Box>
           </Box>

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -145,7 +145,13 @@ import { replaceMcpServerSummary } from "./mcp-server-list.js";
 import { formatLongPaste } from "./paste-collapse.js";
 import { extractOpenQuestionsSection } from "./plan-open-questions.js";
 import { PRESETS, resolvePreset } from "./presets.js";
-import { type McpServerSummary, handleSlash, parseSlash, suggestSlashCommands } from "./slash.js";
+import {
+  type McpServerSummary,
+  handleSlash,
+  orderSlashCommandsByGroup,
+  parseSlash,
+  suggestSlashCommands,
+} from "./slash.js";
 import { TurnTranslator } from "./state/TurnTranslator.js";
 import { cardsToDashboardMessages } from "./state/cards-to-messages.js";
 import { hydrateCardsFromMessages } from "./state/hydrate.js";
@@ -2097,7 +2103,7 @@ function AppInner({
       // input when they know what they want).
       if (text.startsWith("/") && !text.includes(" ")) {
         const typed = text.slice(1).toLowerCase();
-        const matches = suggestSlashCommands(typed, !!codeMode);
+        const matches = orderSlashCommandsByGroup(suggestSlashCommands(typed, !!codeMode));
         const exact = matches.find((m) => m.cmd === typed);
         if (!exact && matches.length > 0) {
           const chosen = matches[slashSelected] ?? matches[0];

--- a/src/cli/ui/SlashSuggestions.tsx
+++ b/src/cli/ui/SlashSuggestions.tsx
@@ -1,9 +1,13 @@
-import { Box, Text } from "ink";
-// biome-ignore lint/style/useImportType: tsconfig.jsx = "react" needs React in value scope for JSX compilation
+import { Box, Text, useStdout } from "ink";
 import React from "react";
 import { t } from "../../i18n/index.js";
 import type { SlashCommandSpec, SlashGroup } from "./slash.js";
 import { GLYPH, useColor } from "./theme.js";
+
+const GROUP_MODE_MAX_ROWS = 24;
+const SEARCH_MODE_MAX_ROWS = 8;
+const COMMAND_NAME_CELLS = 14;
+const ARGS_CELLS = 14;
 
 export interface SlashSuggestionsProps {
   matches: SlashCommandSpec[] | null;
@@ -32,6 +36,9 @@ export function SlashSuggestions({
   advancedHidden,
 }: SlashSuggestionsProps): React.ReactElement | null {
   const color = useColor();
+  const { stdout } = useStdout();
+  const cols = stdout?.columns ?? 80;
+  const [rememberedWindowStart, setRememberedWindowStart] = React.useState(0);
 
   if (matches === null) return null;
   if (matches.length === 0) {
@@ -46,17 +53,24 @@ export function SlashSuggestions({
       </Box>
     );
   }
-  const MAX = groupMode ? 24 : 8;
+  const maxRows = groupMode ? GROUP_MODE_MAX_ROWS : SEARCH_MODE_MAX_ROWS;
   const total = matches.length;
-  const windowStart =
-    total <= MAX ? 0 : Math.max(0, Math.min(selectedIndex - Math.floor(MAX / 2), total - MAX));
-  const shown = matches.slice(windowStart, windowStart + MAX);
+  const windowStart = computeWindowStart(
+    matches,
+    maxRows,
+    selectedIndex,
+    rememberedWindowStart,
+    groupMode,
+  );
+  React.useEffect(() => {
+    setRememberedWindowStart(windowStart);
+  }, [windowStart]);
+  const items = buildVisibleItems(matches, windowStart, maxRows, groupMode);
+  const shownCommands = items.filter((item) => item.kind === "command");
   const hiddenAbove = windowStart;
-  const hiddenBelow = total - windowStart - shown.length;
-  let lastGroup: SlashGroup | null = null;
-  if (windowStart > 0) lastGroup = matches[windowStart - 1]?.group ?? null;
+  const hiddenBelow = total - windowStart - shownCommands.length;
   return (
-    <Box flexDirection="column" paddingX={1} marginTop={1}>
+    <Box flexDirection="column" paddingX={1} marginTop={1} flexShrink={0} flexWrap="nowrap">
       <Box>
         <Text color={color.accent} bold>
           {"/ "}
@@ -64,19 +78,17 @@ export function SlashSuggestions({
         <Text dimColor>{`${total} command${total === 1 ? "" : "s"}`}</Text>
         {hiddenAbove > 0 ? <Text dimColor>{`   ↑ ${hiddenAbove} above`}</Text> : null}
       </Box>
-      {shown.map((spec, i) => {
-        const idx = windowStart + i;
-        const showHeader = groupMode && spec.group !== lastGroup;
-        lastGroup = spec.group;
+      {items.map((item) => {
+        if (item.kind === "group") {
+          return <GroupHeader key={`group:${item.group}:${item.beforeIndex}`} group={item.group} />;
+        }
         return (
-          <React.Fragment key={spec.cmd}>
-            {showHeader ? (
-              <Box marginTop={idx === 0 ? 0 : 1}>
-                <Text dimColor>{`  ${GROUP_LABEL[spec.group]}`}</Text>
-              </Box>
-            ) : null}
-            <SuggestionRow spec={spec} isSelected={idx === selectedIndex} />
-          </React.Fragment>
+          <SuggestionRow
+            key={`cmd:${item.spec.group}:${item.spec.cmd}`}
+            spec={item.spec}
+            isSelected={item.index === selectedIndex}
+            columns={cols}
+          />
         );
       })}
       {hiddenBelow > 0 ? <Text dimColor>{`   ↓ ${hiddenBelow} below`}</Text> : null}
@@ -92,7 +104,74 @@ export function SlashSuggestions({
   );
 }
 
-function SuggestionRow({ spec, isSelected }: { spec: SlashCommandSpec; isSelected: boolean }) {
+export function computeWindowStart(
+  matches: readonly SlashCommandSpec[],
+  maxRows: number,
+  selectedIndex: number,
+  currentWindowStart: number,
+  groupMode = false,
+): number {
+  if (matches.length <= 0) return 0;
+  const maxWindowStart = Math.max(0, matches.length - 1);
+  let start = Math.max(0, Math.min(currentWindowStart, maxWindowStart));
+  const clampedSelectedIndex = Math.max(0, Math.min(selectedIndex, matches.length - 1));
+  if (clampedSelectedIndex < start) start = clampedSelectedIndex;
+  while (start < clampedSelectedIndex) {
+    const visibleCommandIndexes = buildVisibleItems(matches, start, maxRows, groupMode)
+      .filter((item) => item.kind === "command")
+      .map((item) => item.index);
+    if (visibleCommandIndexes.includes(clampedSelectedIndex)) break;
+    start += 1;
+  }
+  return Math.min(start, maxWindowStart);
+}
+
+type VisibleSuggestionItem =
+  | { kind: "group"; group: SlashGroup; beforeIndex: number }
+  | { kind: "command"; spec: SlashCommandSpec; index: number };
+
+export function buildVisibleItems(
+  matches: readonly SlashCommandSpec[],
+  windowStart: number,
+  maxRows: number,
+  groupMode = false,
+): VisibleSuggestionItem[] {
+  const out: VisibleSuggestionItem[] = [];
+  for (let idx = windowStart; idx < matches.length && out.length < maxRows; idx += 1) {
+    const spec = matches[idx]!;
+    if (groupMode && shouldShowGroupHeader(matches, idx)) {
+      if (out.length >= maxRows) break;
+      out.push({ kind: "group", group: spec.group, beforeIndex: idx });
+    }
+    if (out.length >= maxRows) break;
+    out.push({ kind: "command", spec, index: idx });
+  }
+  return out;
+}
+
+function shouldShowGroupHeader(matches: readonly SlashCommandSpec[], idx: number): boolean {
+  return idx === 0 || matches[idx]?.group !== matches[idx - 1]?.group;
+}
+
+function GroupHeader({ group }: { group: SlashGroup }): React.ReactElement {
+  return (
+    <Box flexShrink={0} height={1} flexWrap="nowrap">
+      <Text dimColor wrap="truncate">
+        {`  ${GROUP_LABEL[group]}`}
+      </Text>
+    </Box>
+  );
+}
+
+function SuggestionRow({
+  spec,
+  isSelected,
+  columns,
+}: {
+  spec: SlashCommandSpec;
+  isSelected: boolean;
+  columns: number;
+}) {
   const color = useColor();
   const name = `/${spec.cmd}`;
   const argsSuffix = spec.argsHint ? spec.argsHint : "";
@@ -100,20 +179,35 @@ function SuggestionRow({ spec, isSelected }: { spec: SlashCommandSpec; isSelecte
   const translated = t(key);
   const summary = translated === key ? spec.summary : translated;
   const aliasHint = spec.aliases?.length ? ` · /${spec.aliases.join(" /")}` : "";
+  const reservedCells = 2 + COMMAND_NAME_CELLS + ARGS_CELLS + 2 + 2;
+  const summaryBudget = Math.max(8, columns - reservedCells);
+  const summaryText = truncateCells(`${summary}${aliasHint}`, summaryBudget);
   return (
-    <Box>
-      <Text color={isSelected ? color.primary : color.info} bold={isSelected}>
+    <Box flexDirection="row" flexWrap="nowrap" flexShrink={0} height={1} minHeight={1}>
+      <Text color={isSelected ? color.primary : color.info} bold={isSelected} wrap="truncate">
         {isSelected ? `${GLYPH.cur} ` : "  "}
       </Text>
-      <Text color={color.accent} bold={isSelected}>
-        {name.padEnd(14)}
+      <Text color={color.accent} bold={isSelected} wrap="truncate">
+        {padOrTrim(name, COMMAND_NAME_CELLS)}
       </Text>
-      <Text dimColor>{argsSuffix.padEnd(14)}</Text>
-      <Text>{"  "}</Text>
-      <Text color={isSelected ? color.user : color.info} dimColor={!isSelected}>
-        {summary}
+      <Text dimColor wrap="truncate">
+        {padOrTrim(argsSuffix, ARGS_CELLS)}
       </Text>
-      {aliasHint ? <Text dimColor>{aliasHint}</Text> : null}
+      <Text wrap="truncate">{"  "}</Text>
+      <Text color={isSelected ? color.user : color.info} dimColor={!isSelected} wrap="truncate">
+        {summaryText}
+      </Text>
     </Box>
   );
+}
+
+function padOrTrim(value: string, cells: number): string {
+  const trimmed = truncateCells(value, cells);
+  return trimmed.padEnd(cells);
+}
+
+function truncateCells(value: string, maxCells: number): string {
+  if (value.length <= maxCells) return value;
+  if (maxCells <= 1) return value.slice(0, Math.max(0, maxCells));
+  return `${value.slice(0, maxCells - 1)}…`;
 }

--- a/src/cli/ui/SlashSuggestions.tsx
+++ b/src/cli/ui/SlashSuggestions.tsx
@@ -1,6 +1,7 @@
 import { Box, Text, useStdout } from "ink";
 import React from "react";
 import { t } from "../../i18n/index.js";
+import { SLASH_GROUP_LABEL, getSlashCommandGroup, orderSlashCommandsByGroup } from "./slash.js";
 import type { SlashCommandSpec, SlashGroup } from "./slash.js";
 import { GLYPH, useColor } from "./theme.js";
 
@@ -17,17 +18,6 @@ export interface SlashSuggestionsProps {
   /** Count of hidden `advanced` commands; rendered as a footer hint when groupMode is true. */
   advancedHidden?: number;
 }
-
-const GROUP_LABEL: Record<SlashGroup, string> = {
-  chat: "CHAT",
-  setup: "SETUP",
-  info: "INFO",
-  session: "SESSION",
-  extend: "EXTEND",
-  code: "CODE",
-  jobs: "JOBS",
-  advanced: "ADVANCED",
-};
 
 export function SlashSuggestions({
   matches,
@@ -53,19 +43,21 @@ export function SlashSuggestions({
       </Box>
     );
   }
+  const orderedMatches = React.useMemo(() => orderSlashCommandsByGroup(matches), [matches]);
+  const orderedSelectedIndex = Math.max(0, Math.min(selectedIndex, orderedMatches.length - 1));
   const maxRows = groupMode ? GROUP_MODE_MAX_ROWS : SEARCH_MODE_MAX_ROWS;
-  const total = matches.length;
+  const total = orderedMatches.length;
   const windowStart = computeWindowStart(
-    matches,
+    orderedMatches,
     maxRows,
-    selectedIndex,
+    orderedSelectedIndex,
     rememberedWindowStart,
     groupMode,
   );
   React.useEffect(() => {
     setRememberedWindowStart(windowStart);
   }, [windowStart]);
-  const items = buildVisibleItems(matches, windowStart, maxRows, groupMode);
+  const items = buildVisibleItems(orderedMatches, windowStart, maxRows, groupMode);
   const shownCommands = items.filter((item) => item.kind === "command");
   const hiddenAbove = windowStart;
   const hiddenBelow = total - windowStart - shownCommands.length;
@@ -86,7 +78,7 @@ export function SlashSuggestions({
           <SuggestionRow
             key={`cmd:${item.spec.group}:${item.spec.cmd}`}
             spec={item.spec}
-            isSelected={item.index === selectedIndex}
+            isSelected={item.index === orderedSelectedIndex}
             columns={cols}
           />
         );
@@ -141,7 +133,7 @@ export function buildVisibleItems(
     const spec = matches[idx]!;
     if (groupMode && shouldShowGroupHeader(matches, idx)) {
       if (out.length >= maxRows) break;
-      out.push({ kind: "group", group: spec.group, beforeIndex: idx });
+      out.push({ kind: "group", group: getSlashCommandGroup(spec), beforeIndex: idx });
     }
     if (out.length >= maxRows) break;
     out.push({ kind: "command", spec, index: idx });
@@ -150,14 +142,18 @@ export function buildVisibleItems(
 }
 
 function shouldShowGroupHeader(matches: readonly SlashCommandSpec[], idx: number): boolean {
-  return idx === 0 || matches[idx]?.group !== matches[idx - 1]?.group;
+  if (idx === 0) return true;
+  const current = matches[idx];
+  const previous = matches[idx - 1];
+  if (!current || !previous) return true;
+  return getSlashCommandGroup(current) !== getSlashCommandGroup(previous);
 }
 
 function GroupHeader({ group }: { group: SlashGroup }): React.ReactElement {
   return (
     <Box flexShrink={0} height={1} flexWrap="nowrap">
       <Text dimColor wrap="truncate">
-        {`  ${GROUP_LABEL[group]}`}
+        {`  ${SLASH_GROUP_LABEL[group]}`}
       </Text>
     </Box>
   );

--- a/src/cli/ui/layout/StatusRow.tsx
+++ b/src/cli/ui/layout/StatusRow.tsx
@@ -25,13 +25,15 @@ export function StatusRow(): React.ReactElement {
   const showWallet = cols >= WALLET_MIN_COLS && (hasSession || hasBalance);
 
   return (
-    <Box flexDirection="column">
-      <Box>
+    <Box flexDirection="column" flexShrink={0} flexWrap="nowrap">
+      <Box height={1} flexWrap="nowrap">
         <Text>{"  "}</Text>
-        <Text color={FG.faint}>{"─".repeat(ruleWidth)}</Text>
+        <Text color={FG.faint} wrap="truncate">
+          {"─".repeat(ruleWidth)}
+        </Text>
       </Box>
-      <Box flexDirection="row">
-        <Text>{"  "}</Text>
+      <Box flexDirection="row" height={1} minHeight={1} flexWrap="nowrap" flexShrink={0}>
+        <Text wrap="truncate">{"  "}</Text>
         {status.recording ? (
           <RecordingPill rec={status.recording} />
         ) : status.countdownSeconds !== undefined ? (
@@ -40,20 +42,23 @@ export function StatusRow(): React.ReactElement {
           <ModePill mode={status.mode} network={status.network} detail={status.networkDetail} />
         )}
         <Sep />
-        <Text color={FG.sub}>{`${session.id} · ${session.branch}`}</Text>
+        <Text color={FG.sub} wrap="truncate">{`${session.id} · ${session.branch}`}</Text>
         {hasTurn && (
           <>
             <Sep />
-            <Text bold color={TONE.brand}>
+            <Text bold color={TONE.brand} wrap="truncate">
               {"▸ "}
             </Text>
-            <Text bold color={FG.body}>
+            <Text bold color={FG.body} wrap="truncate">
               {`${formatCost(status.cost, status.balanceCurrency)} turn`}
             </Text>
           </>
         )}
         <Sep />
-        <Text color={TONE.accent}>{`cache ${Math.round(status.cacheHit * 100)}%`}</Text>
+        <Text
+          color={TONE.accent}
+          wrap="truncate"
+        >{`cache ${Math.round(status.cacheHit * 100)}%`}</Text>
         {showWallet && (
           <WalletPill
             sessionCostUsd={status.sessionCost}
@@ -64,12 +69,18 @@ export function StatusRow(): React.ReactElement {
         {cols >= VERSION_MIN_COLS && (
           <>
             <Sep />
-            <Text color={FG.faint}>{`v${VERSION}`}</Text>
+            <Text color={FG.faint} wrap="truncate">{`v${VERSION}`}</Text>
             {cols >= FEEDBACK_HINT_MIN_COLS && (
               <>
-                <Text color={FG.faint}>{"  ·  "}</Text>
-                <Text color={FG.meta}>{"⚑ "}</Text>
-                <Text color={FG.sub}>{"/feedback"}</Text>
+                <Text color={FG.faint} wrap="truncate">
+                  {"  ·  "}
+                </Text>
+                <Text color={FG.meta} wrap="truncate">
+                  {"⚑ "}
+                </Text>
+                <Text color={FG.sub} wrap="truncate">
+                  {"/feedback"}
+                </Text>
               </>
             )}
           </>
@@ -93,17 +104,30 @@ function WalletPill({
   return (
     <>
       <Sep />
-      <Text color={FG.meta}>{"⛁ "}</Text>
+      <Text color={FG.meta} wrap="truncate">
+        {"⛁ "}
+      </Text>
       {showSpent && (
-        <Text color={FG.body}>{`${formatCost(sessionCostUsd, currency, 2)} spent`}</Text>
+        <Text
+          color={FG.body}
+          wrap="truncate"
+        >{`${formatCost(sessionCostUsd, currency, 2)} spent`}</Text>
       )}
-      {showSpent && showBalance && <Text color={FG.meta}>{"  /  "}</Text>}
+      {showSpent && showBalance && (
+        <Text color={FG.meta} wrap="truncate">
+          {"  /  "}
+        </Text>
+      )}
       {showBalance && (
-        <Text bold color={balanceColor(balance, currency)}>
+        <Text bold color={balanceColor(balance, currency)} wrap="truncate">
           {formatBalance(balance, currency, { fractionDigits: 2 })}
         </Text>
       )}
-      {showBalance && <Text color={FG.faint}>{" left"}</Text>}
+      {showBalance && (
+        <Text color={FG.faint} wrap="truncate">
+          {" left"}
+        </Text>
+      )}
     </>
   );
 }
@@ -120,9 +144,11 @@ function ModePill({
   if (network === "online") {
     const pill = modeGlyph(mode);
     return (
-      <Box flexDirection="row">
-        <Text color={pill.color}>{pill.glyph}</Text>
-        <Text color={FG.sub}>{` ${mode}`}</Text>
+      <Box flexDirection="row" height={1} flexWrap="nowrap">
+        <Text color={pill.color} wrap="truncate">
+          {pill.glyph}
+        </Text>
+        <Text color={FG.sub} wrap="truncate">{` ${mode}`}</Text>
       </Box>
     );
   }
@@ -130,25 +156,33 @@ function ModePill({
   if (network === "slow") {
     const tail = detail ? ` · ${detail}` : "";
     return (
-      <Box flexDirection="row">
-        <Text color={dot.color}>{dot.glyph}</Text>
-        <Text color={dot.color}>{` ${mode} · slow${tail}`}</Text>
+      <Box flexDirection="row" height={1} flexWrap="nowrap">
+        <Text color={dot.color} wrap="truncate">
+          {dot.glyph}
+        </Text>
+        <Text color={dot.color} wrap="truncate">{` ${mode} · slow${tail}`}</Text>
       </Box>
     );
   }
   if (network === "disconnected") {
     const tail = detail ? ` · ${detail}` : "";
     return (
-      <Box flexDirection="row">
-        <Text color={dot.color}>{dot.glyph}</Text>
-        <Text color={dot.color}>{` disconnect${tail}`}</Text>
+      <Box flexDirection="row" height={1} flexWrap="nowrap">
+        <Text color={dot.color} wrap="truncate">
+          {dot.glyph}
+        </Text>
+        <Text color={dot.color} wrap="truncate">{` disconnect${tail}`}</Text>
       </Box>
     );
   }
   return (
-    <Box flexDirection="row">
-      <Text color={dot.color}>{dot.glyph}</Text>
-      <Text color={dot.color}>{" reconnecting…"}</Text>
+    <Box flexDirection="row" height={1} flexWrap="nowrap">
+      <Text color={dot.color} wrap="truncate">
+        {dot.glyph}
+      </Text>
+      <Text color={dot.color} wrap="truncate">
+        {" reconnecting…"}
+      </Text>
     </Box>
   );
 }
@@ -163,12 +197,18 @@ function CountdownRow({
   const pill = modeGlyph(mode);
   const endsAt = Date.now() + secondsLeft * 1000;
   return (
-    <Box flexDirection="row">
-      <Text color={pill.color}>{pill.glyph}</Text>
-      <Text color={FG.sub}>{` ${mode}   ·   `}</Text>
-      <Text color={TONE.warn}>{"approving in "}</Text>
+    <Box flexDirection="row" height={1} flexWrap="nowrap">
+      <Text color={pill.color} wrap="truncate">
+        {pill.glyph}
+      </Text>
+      <Text color={FG.sub} wrap="truncate">{` ${mode}   ·   `}</Text>
+      <Text color={TONE.warn} wrap="truncate">
+        {"approving in "}
+      </Text>
       <Countdown endsAt={endsAt} />
-      <Text color={TONE.warn}>{"s · esc to interrupt"}</Text>
+      <Text color={TONE.warn} wrap="truncate">
+        {"s · esc to interrupt"}
+      </Text>
     </Box>
   );
 }
@@ -176,17 +216,21 @@ function CountdownRow({
 function RecordingPill({ rec }: { rec: NonNullable<StatusBar["recording"]> }): React.ReactElement {
   const sizeMb = (rec.sizeBytes / (1024 * 1024)).toFixed(1);
   return (
-    <Box flexDirection="row">
-      <Text bold color={TONE.err}>
+    <Box flexDirection="row" height={1} flexWrap="nowrap">
+      <Text bold color={TONE.err} wrap="truncate">
         {"●REC"}
       </Text>
-      <Text color={TONE.err}>{` ${sizeMb} MB · ${rec.events} evt`}</Text>
+      <Text color={TONE.err} wrap="truncate">{` ${sizeMb} MB · ${rec.events} evt`}</Text>
     </Box>
   );
 }
 
 function Sep(): React.ReactElement {
-  return <Text color={FG.meta}>{"   ·   "}</Text>;
+  return (
+    <Text color={FG.meta} wrap="truncate">
+      {"   ·   "}
+    </Text>
+  );
 }
 
 function modeGlyph(mode: Mode): { glyph: string; color: string } {

--- a/src/cli/ui/slash.ts
+++ b/src/cli/ui/slash.ts
@@ -5,8 +5,12 @@
 // modules under ./slash/.
 export {
   SLASH_COMMANDS,
+  SLASH_GROUP_LABEL,
+  SLASH_GROUP_ORDER,
   countAdvancedCommands,
   detectSlashArgContext,
+  getSlashCommandGroup,
+  orderSlashCommandsByGroup,
   parseSlash,
   suggestSlashCommands,
 } from "./slash/commands.js";

--- a/src/cli/ui/slash/commands.ts
+++ b/src/cli/ui/slash/commands.ts
@@ -35,6 +35,14 @@ export const SLASH_COMMANDS: readonly SlashCommandSpec[] = [
     summary: "switch DeepSeek model id. Bare opens picker.",
     argCompleter: "models",
   },
+  {
+    cmd: "language",
+    group: "setup",
+    argsHint: "<EN|zh-CN>",
+    summary: "switch the runtime language",
+    argCompleter: ["EN", "zh-CN"],
+    aliases: ["lang"],
+  },
 
   { cmd: "status", group: "info", summary: "current model, flags, context, session" },
   {
@@ -238,14 +246,6 @@ export const SLASH_COMMANDS: readonly SlashCommandSpec[] = [
     argCompleter: ["off", "1", "5", "10", "20", "50"],
   },
   {
-    cmd: "language",
-    group: "advanced",
-    argsHint: "<EN|zh-CN>",
-    summary: "switch the runtime language",
-    argCompleter: ["EN", "zh-CN"],
-    aliases: ["lang"],
-  },
-  {
     cmd: "theme",
     group: "advanced",
     argsHint: "[auto|default|dark|light|tokyo-night|github-dark|github-light]",
@@ -321,9 +321,10 @@ export function suggestSlashCommands(
 ): SlashCommandSpec[] {
   const p = prefix.toLowerCase();
   const matches = SLASH_COMMANDS.filter((c) => {
+    // Empty prefix = browsing the menu — show the full release command surface except
+    // advanced rows, which remain collapsed behind the footer hint.
+    if (p === "") return c.group !== "advanced";
     if (c.contextual === "code" && !codeMode) return false;
-    // Empty prefix = browsing the menu — advanced stays hidden until a letter is typed.
-    if (p === "" && c.group === "advanced") return false;
     if (c.cmd.startsWith(p)) return true;
     return c.aliases?.some((a) => a.startsWith(p)) ?? false;
   });

--- a/src/cli/ui/slash/commands.ts
+++ b/src/cli/ui/slash/commands.ts
@@ -1,4 +1,55 @@
-import type { SlashArgContext, SlashCommandSpec } from "./types.js";
+import type { SlashArgContext, SlashCommandSpec, SlashGroup } from "./types.js";
+
+export const SLASH_GROUP_ORDER = [
+  "setup",
+  "info",
+  "chat",
+  "extend",
+  "session",
+  "code",
+  "jobs",
+  "advanced",
+  "unknown",
+] as const satisfies readonly SlashGroup[];
+
+export const SLASH_GROUP_LABEL: Record<SlashGroup, string> = {
+  setup: "SETUP",
+  info: "INFO",
+  chat: "CHAT",
+  extend: "EXTEND",
+  session: "SESSION",
+  code: "CODE",
+  jobs: "JOBS",
+  advanced: "ADVANCED",
+  unknown: "UNKNOWN",
+};
+
+const SLASH_GROUP_RANK = new Map<SlashGroup, number>(
+  SLASH_GROUP_ORDER.map((group, index) => [group, index]),
+);
+
+export function getSlashCommandGroup(spec: Pick<SlashCommandSpec, "group">): SlashGroup {
+  const group = spec.group;
+  if (typeof group === "string" && SLASH_GROUP_RANK.has(group as SlashGroup)) {
+    return group as SlashGroup;
+  }
+  return "unknown";
+}
+
+export function orderSlashCommandsByGroup<T extends Pick<SlashCommandSpec, "group">>(
+  commands: readonly T[],
+): T[] {
+  return commands
+    .map((command, index) => ({ command, index, group: getSlashCommandGroup(command) }))
+    .sort((a, b) => {
+      const groupDiff =
+        (SLASH_GROUP_RANK.get(a.group) ?? Number.POSITIVE_INFINITY) -
+        (SLASH_GROUP_RANK.get(b.group) ?? Number.POSITIVE_INFINITY);
+      if (groupDiff !== 0) return groupDiff;
+      return a.index - b.index;
+    })
+    .map((entry) => entry.command);
+}
 
 export const SLASH_COMMANDS: readonly SlashCommandSpec[] = [
   { cmd: "help", group: "chat", summary: "show the full command reference", aliases: ["?"] },
@@ -22,6 +73,14 @@ export const SLASH_COMMANDS: readonly SlashCommandSpec[] = [
   },
 
   {
+    cmd: "language",
+    group: "setup",
+    argsHint: "<EN|zh-CN>",
+    summary: "switch the runtime language",
+    argCompleter: ["EN", "zh-CN"],
+    aliases: ["lang"],
+  },
+  {
     cmd: "preset",
     group: "setup",
     argsHint: "<auto|flash|pro>",
@@ -34,14 +93,6 @@ export const SLASH_COMMANDS: readonly SlashCommandSpec[] = [
     argsHint: "<id>",
     summary: "switch DeepSeek model id. Bare opens picker.",
     argCompleter: "models",
-  },
-  {
-    cmd: "language",
-    group: "setup",
-    argsHint: "<EN|zh-CN>",
-    summary: "switch the runtime language",
-    argCompleter: ["EN", "zh-CN"],
-    aliases: ["lang"],
   },
 
   { cmd: "status", group: "info", summary: "current model, flags, context, session" },
@@ -323,23 +374,24 @@ export function suggestSlashCommands(
   const matches = SLASH_COMMANDS.filter((c) => {
     // Empty prefix = browsing the menu — show the full release command surface except
     // advanced rows, which remain collapsed behind the footer hint.
-    if (p === "") return c.group !== "advanced";
+    if (p === "") return getSlashCommandGroup(c) !== "advanced";
     if (c.contextual === "code" && !codeMode) return false;
     if (c.cmd.startsWith(p)) return true;
     return c.aliases?.some((a) => a.startsWith(p)) ?? false;
   });
+  if (p === "") return orderSlashCommandsByGroup(matches);
   if (!counts) return matches;
   const indexOf = new Map(matches.map((s, i) => [s.cmd, i]));
   return [...matches].sort((a, b) => {
-    const diff = (counts[b.cmd] ?? 0) - (counts[a.cmd] ?? 0);
-    if (diff !== 0) return diff;
+    const countDiff = (counts[b.cmd] ?? 0) - (counts[a.cmd] ?? 0);
+    if (countDiff !== 0) return countDiff;
     return (indexOf.get(a.cmd) ?? 0) - (indexOf.get(b.cmd) ?? 0);
   });
 }
 
 export function countAdvancedCommands(codeMode: boolean): number {
   return SLASH_COMMANDS.filter(
-    (c) => c.group === "advanced" && (c.contextual !== "code" || codeMode),
+    (c) => getSlashCommandGroup(c) === "advanced" && (c.contextual !== "code" || codeMode),
   ).length;
 }
 

--- a/src/cli/ui/slash/handlers/basic.ts
+++ b/src/cli/ui/slash/handlers/basic.ts
@@ -1,6 +1,12 @@
 import { t, tObj } from "@/i18n/index.js";
 import { formatDuration, formatLoopStatus, parseLoopCommand } from "../../loop.js";
-import { SLASH_COMMANDS } from "../commands.js";
+import {
+  SLASH_COMMANDS,
+  SLASH_GROUP_LABEL,
+  SLASH_GROUP_ORDER,
+  getSlashCommandGroup,
+  orderSlashCommandsByGroup,
+} from "../commands.js";
 import type { SlashHandler } from "../dispatch.js";
 import type { SlashCommandSpec, SlashGroup } from "../types.js";
 
@@ -14,27 +20,21 @@ const resetLog: SlashHandler = (_args, loop) => {
   };
 };
 
-const GROUP_ORDER: ReadonlyArray<SlashGroup> = [
-  "chat",
-  "setup",
-  "info",
-  "session",
-  "extend",
-  "code",
-  "jobs",
-  "advanced",
-];
-
-const GROUP_HEADER: Record<SlashGroup, string> = {
-  chat: "CHAT  ·  daily turn ops",
-  setup: "SETUP  ·  model + cost",
-  info: "INFO  ·  current state",
-  session: "SESSION  ·  saved sessions",
-  extend: "EXTEND  ·  MCP, memory, skills",
-  code: "CODE  ·  edits + plans (code mode)",
-  jobs: "JOBS  ·  background processes (code mode)",
-  advanced: "ADVANCED  ·  rare or set-and-forget",
+const GROUP_DETAIL: Record<SlashGroup, string> = {
+  setup: "model + cost",
+  info: "current state",
+  chat: "daily turn ops",
+  extend: "MCP, memory, skills",
+  session: "saved sessions",
+  code: "edits + plans (code mode)",
+  jobs: "background processes (code mode)",
+  advanced: "rare or set-and-forget",
+  unknown: "uncategorized commands",
 };
+
+function groupHeader(group: SlashGroup): string {
+  return `${SLASH_GROUP_LABEL[group]}  ·  ${GROUP_DETAIL[group]}`;
+}
 
 function renderRow(spec: SlashCommandSpec): string {
   const name = `/${spec.cmd}${spec.argsHint ? ` ${spec.argsHint}` : ""}`;
@@ -45,10 +45,16 @@ function renderRow(spec: SlashCommandSpec): string {
 
 const help: SlashHandler = () => {
   const lines: string[] = [t("handlers.basic.helpTitle"), ""];
-  for (const group of GROUP_ORDER) {
-    const rows = SLASH_COMMANDS.filter((c) => c.group === group);
+  const rowsByGroup = new Map<SlashGroup, SlashCommandSpec[]>();
+  for (const group of SLASH_GROUP_ORDER) rowsByGroup.set(group, []);
+  for (const command of orderSlashCommandsByGroup(SLASH_COMMANDS)) {
+    const group = getSlashCommandGroup(command);
+    rowsByGroup.get(group)!.push(command);
+  }
+  for (const group of SLASH_GROUP_ORDER) {
+    const rows = rowsByGroup.get(group) ?? [];
     if (rows.length === 0) continue;
-    lines.push(`  ${GROUP_HEADER[group]}`);
+    lines.push(`  ${groupHeader(group)}`);
     for (const r of rows) lines.push(renderRow(r));
     lines.push("");
   }

--- a/src/cli/ui/slash/types.ts
+++ b/src/cli/ui/slash/types.ts
@@ -139,20 +139,21 @@ export interface SlashContext {
 }
 
 export type SlashGroup =
-  | "chat"
   | "setup"
   | "info"
-  | "session"
+  | "chat"
   | "extend"
+  | "session"
   | "code"
   | "jobs"
-  | "advanced";
+  | "advanced"
+  | "unknown";
 
 export interface SlashCommandSpec {
   cmd: string;
   summary: string;
   contextual?: "code";
-  /** Visual category in the suggestions palette + /help. `advanced` collapses by default. */
+  /** Internal functional domain for suggestions + /help. `advanced` collapses by default; unrecognized values fall back to `unknown`. */
   group: SlashGroup;
   /** If the command takes args, hint text shown after the name. */
   argsHint?: string;

--- a/src/cli/ui/useCompletionPickers.ts
+++ b/src/cli/ui/useCompletionPickers.ts
@@ -15,6 +15,7 @@ import {
   type SlashCommandSpec,
   countAdvancedCommands,
   detectSlashArgContext,
+  orderSlashCommandsByGroup,
   suggestSlashCommands,
 } from "./slash.js";
 
@@ -93,7 +94,7 @@ export function useCompletionPickers({
   const [slashSelected, setSlashSelected] = useState(0);
   const slashMatches = useMemo(() => {
     if (!input.startsWith("/") || input.includes(" ")) return null;
-    return suggestSlashCommands(input.slice(1), !!codeMode, slashUsage);
+    return orderSlashCommandsByGroup(suggestSlashCommands(input.slice(1), !!codeMode, slashUsage));
   }, [input, codeMode, slashUsage]);
   const slashGroupMode = input === "/";
   const slashAdvancedHidden = useMemo(

--- a/tests/slash-usage.test.ts
+++ b/tests/slash-usage.test.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "no
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { suggestSlashCommands } from "../src/cli/ui/slash.js";
+import { SLASH_GROUP_ORDER, suggestSlashCommands } from "../src/cli/ui/slash.js";
 import { loadSlashUsage, recordSlashUse, slashUsagePath } from "../src/slash-usage.js";
 
 let dir: string;
@@ -85,5 +85,13 @@ describe("suggestSlashCommands frequency sort", () => {
   it("ignores counts for commands outside the filter set", () => {
     const sorted = suggestSlashCommands("h", false, { status: 9999 }).map((s) => s.cmd);
     expect(sorted).toEqual(["help", "hooks"]);
+  });
+  it("keeps bare browse suggestions grouped even when counts are passed", () => {
+    const groups = suggestSlashCommands("", true, { help: 9999, compact: 9998 }).map(
+      (s) => s.group,
+    );
+    const groupRanks = groups.map((group) => SLASH_GROUP_ORDER.indexOf(group));
+    expect(groupRanks).toEqual([...groupRanks].sort((a, b) => a - b));
+    expect(groups.slice(0, 3)).toEqual(["setup", "setup", "setup"]);
   });
 });

--- a/tests/slash.test.ts
+++ b/tests/slash.test.ts
@@ -493,6 +493,7 @@ describe("handleSlash", () => {
       "status",
       "preset",
       "model",
+      "language",
       "theme",
       "mcp",
       "memory",
@@ -515,8 +516,11 @@ describe("handleSlash", () => {
     expect(suggestSlashCommands("h").map((s) => s.cmd)).toEqual(["help", "hooks"]);
     // Case-insensitive.
     expect(suggestSlashCommands("HE").map((s) => s.cmd)).toEqual(["help"]);
-    // Empty prefix returns the curated non-advanced list.
-    expect(suggestSlashCommands("").length).toBeGreaterThan(5);
+    // Empty prefix returns the full non-advanced release list, including code commands.
+    expect(suggestSlashCommands("", true)).toHaveLength(37);
+    expect(suggestSlashCommands("", true).map((s) => s.cmd)).toContain("logs");
+    expect(suggestSlashCommands("", true).map((s) => s.cmd)).toContain("language");
+    expect(suggestSlashCommands("lan").map((s) => s.cmd)).toContain("language");
   });
 
   describe("/update", () => {
@@ -561,16 +565,15 @@ describe("handleSlash", () => {
     });
   });
 
-  it("suggestSlashCommands hides code-mode-only entries when codeMode=false", () => {
+  it("suggestSlashCommands shows code-mode entries in bare slash browse mode", () => {
     const names = suggestSlashCommands("", false).map((s) => s.cmd);
-    expect(names).not.toContain("apply");
-    expect(names).not.toContain("undo");
-  });
-
-  it("suggestSlashCommands shows code-mode-only entries when codeMode=true", () => {
-    const names = suggestSlashCommands("", true).map((s) => s.cmd);
     expect(names).toContain("apply");
     expect(names).toContain("undo");
+  });
+
+  it("suggestSlashCommands keeps code-mode gating for typed prefixes", () => {
+    expect(suggestSlashCommands("ap", false).map((s) => s.cmd)).not.toContain("apply");
+    expect(suggestSlashCommands("ap", true).map((s) => s.cmd)).toContain("apply");
   });
 
   it("/mcp opens the browser modal when servers are attached", () => {

--- a/tests/slash.test.ts
+++ b/tests/slash.test.ts
@@ -4,8 +4,10 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   SLASH_COMMANDS,
+  SLASH_GROUP_ORDER,
   detectSlashArgContext,
   handleSlash,
+  orderSlashCommandsByGroup,
   parseSlash,
   suggestSlashCommands,
 } from "../src/cli/ui/slash.js";
@@ -521,6 +523,43 @@ describe("handleSlash", () => {
     expect(suggestSlashCommands("", true).map((s) => s.cmd)).toContain("logs");
     expect(suggestSlashCommands("", true).map((s) => s.cmd)).toContain("language");
     expect(suggestSlashCommands("lan").map((s) => s.cmd)).toContain("language");
+  });
+
+  it("orders slash suggestions by fixed internal functional domains", () => {
+    const groups = suggestSlashCommands("", true).map((s) => s.group);
+    const groupRanks = groups.map((group) => SLASH_GROUP_ORDER.indexOf(group));
+    expect(groupRanks).toEqual([...groupRanks].sort((a, b) => a - b));
+    expect(groups.slice(0, 3)).toEqual(["setup", "setup", "setup"]);
+  });
+
+  it("keeps same-domain command order stable after grouping", () => {
+    const codeCommands = suggestSlashCommands("", true)
+      .filter((s) => s.group === "code")
+      .map((s) => s.cmd);
+    expect(codeCommands).toEqual([
+      "init",
+      "apply",
+      "discard",
+      "walk",
+      "undo",
+      "history",
+      "show",
+      "commit",
+      "mode",
+      "plan",
+      "checkpoint",
+      "restore",
+      "cwd",
+    ]);
+  });
+
+  it("falls back unrecognized slash command domains to UNKNOWN at the end", () => {
+    const ordered = orderSlashCommandsByGroup([
+      { cmd: "known", summary: "known", group: "chat" },
+      { cmd: "mystery", summary: "mystery", group: "mystery" as never },
+      { cmd: "setup", summary: "setup", group: "setup" },
+    ]).map((s) => s.cmd);
+    expect(ordered).toEqual(["setup", "known", "mystery"]);
   });
 
   describe("/update", () => {

--- a/tests/ui-slash-suggestions.test.tsx
+++ b/tests/ui-slash-suggestions.test.tsx
@@ -1,0 +1,176 @@
+import { render } from "ink-testing-library";
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { SlashSuggestions } from "../src/cli/ui/SlashSuggestions.js";
+import {
+  SLASH_COMMANDS,
+  type SlashCommandSpec,
+  countAdvancedCommands,
+  suggestSlashCommands,
+} from "../src/cli/ui/slash.js";
+
+function makeCommands(count: number): SlashCommandSpec[] {
+  const groups = ["chat", "setup", "info", "session", "extend", "code", "jobs"] as const;
+  return Array.from({ length: count }, (_, i) => ({
+    cmd: `cmd${i.toString().padStart(2, "0")}`,
+    summary: `summary ${i}`,
+    group: groups[Math.floor(i / 5) % groups.length],
+  }));
+}
+
+function suggestionElement(
+  matches: SlashCommandSpec[],
+  selectedIndex: number,
+  advancedHidden = 0,
+): React.ReactElement {
+  return React.createElement(SlashSuggestions, {
+    matches,
+    selectedIndex,
+    groupMode: true,
+    advancedHidden,
+  });
+}
+
+function renderSuggestions(selectedIndex: number): string {
+  const { lastFrame, unmount } = render(
+    suggestionElement(suggestSlashCommands("", true), selectedIndex, countAdvancedCommands(true)),
+  );
+  const frame = lastFrame() ?? "";
+  unmount();
+  return frame;
+}
+
+function visibleCommandOrder(
+  frame: string,
+  commands: readonly SlashCommandSpec[] = SLASH_COMMANDS,
+): string[] {
+  const names = new Set(commands.map((spec) => `/${spec.cmd}`));
+  return frame
+    .split(/\r?\n/)
+    .map((line) => /^\s*(?:▸\s*)?(\/\w+)\b/.exec(line)?.[1] ?? "")
+    .filter((token) => names.has(token));
+}
+
+function firstVisibleCommand(
+  frame: string,
+  commands: readonly SlashCommandSpec[] = SLASH_COMMANDS,
+): string | undefined {
+  return visibleCommandOrder(frame, commands)[0];
+}
+
+function hiddenAboveCount(frame: string): number {
+  const match = /↑ (\d+) above/.exec(frame);
+  return match ? Number(match[1]) : 0;
+}
+
+describe("SlashSuggestions", () => {
+  it("renders the bare slash release command surface as 37 total commands", () => {
+    const matches = suggestSlashCommands("", true);
+    const names = matches.map((spec) => spec.cmd);
+    const { lastFrame, unmount } = render(
+      suggestionElement(matches, 0, countAdvancedCommands(true)),
+    );
+    const frame = lastFrame() ?? "";
+    unmount();
+
+    expect(matches).toHaveLength(37);
+    expect(names).toContain("language");
+    expect(countAdvancedCommands(true)).toBe(12);
+    expect(frame).toContain("37 commands");
+    expect(frame).toContain("+ 12 advanced");
+  });
+
+  it("surfaces /language for typed language prefixes", () => {
+    expect(suggestSlashCommands("lan").map((spec) => spec.cmd)).toContain("language");
+  });
+
+  it("keeps the command order stable while the selected row moves in grouped browse mode", () => {
+    const first = visibleCommandOrder(renderSuggestions(0));
+    const middle = visibleCommandOrder(renderSuggestions(10));
+    const last = visibleCommandOrder(renderSuggestions(18));
+
+    expect(first).toEqual(middle);
+    expect(middle).toEqual(last);
+    const matches = suggestSlashCommands("", true);
+    expect(first).toEqual(matches.slice(0, first.length).map((spec) => `/${spec.cmd}`));
+  });
+
+  it("scrolls through every command in grouped browse mode when the list is taller than the window", () => {
+    const commands = makeCommands(30);
+    const { lastFrame, rerender, unmount } = render(suggestionElement(commands, 0));
+
+    rerender(suggestionElement(commands, commands.length - 1));
+    const frame = lastFrame() ?? "";
+    unmount();
+
+    expect(visibleCommandOrder(frame, commands)).toContain("/cmd29");
+    expect(hiddenAboveCount(frame)).toBe(10);
+  });
+
+  it("only advances the grouped window when selection crosses a visible boundary", () => {
+    const commands = makeCommands(30);
+    const { lastFrame, rerender, unmount } = render(suggestionElement(commands, 0));
+    const firstAtStart = firstVisibleCommand(lastFrame() ?? "", commands);
+
+    for (let selected = 1; selected < 20; selected += 1) {
+      rerender(suggestionElement(commands, selected));
+      expect(firstVisibleCommand(lastFrame() ?? "", commands)).toBe(firstAtStart);
+    }
+
+    rerender(suggestionElement(commands, 20));
+    expect(firstVisibleCommand(lastFrame() ?? "", commands)).toBe("/cmd01");
+
+    rerender(suggestionElement(commands, 21));
+    expect(firstVisibleCommand(lastFrame() ?? "", commands)).toBe("/cmd02");
+    unmount();
+  });
+
+  it("renders each visible command as one row instead of wrapping selected text into extra blocks", () => {
+    const frame = renderSuggestions(7);
+    const visibleRows = frame.split(/\r?\n/).filter((line) => /^\s*(?:▸\s*)?\/\w+\b/.test(line));
+    const visibleCommands = visibleCommandOrder(frame);
+
+    expect(visibleRows).toHaveLength(visibleCommands.length);
+    expect(visibleRows.some((line) => line.includes("show the full command reference"))).toBe(true);
+  });
+
+  it("keeps bottom-window command rows paired with their own descriptions", () => {
+    const commands = makeCommands(30).map((spec, i) => ({
+      ...spec,
+      summary: `description-for-${spec.cmd}-unique-${i}`,
+    }));
+    const { lastFrame, rerender, unmount } = render(suggestionElement(commands, 0));
+
+    rerender(suggestionElement(commands, commands.length - 1));
+    const frame = lastFrame() ?? "";
+    unmount();
+
+    const commandRows = frame.split(/\r?\n/).filter((line) => /^\s*(?:▸\s*)?\/\w+\b/.test(line));
+    expect(commandRows).toContainEqual(expect.stringContaining("/cmd29"));
+    expect(commandRows.find((line) => line.includes("/cmd29"))).toContain(
+      "description-for-cmd29-unique-29",
+    );
+    expect(commandRows.find((line) => line.includes("/cmd29"))).not.toContain(
+      "description-for-cmd23-unique-23",
+    );
+  });
+
+  it("counts group headers inside the fixed visible row budget", () => {
+    const commands = makeCommands(30);
+    const frame =
+      render(
+        React.createElement(SlashSuggestions, {
+          matches: commands,
+          selectedIndex: commands.length - 1,
+          groupMode: true,
+        }),
+      ).lastFrame() ?? "";
+
+    const visibleBodyRows = frame
+      .split(/\r?\n/)
+      .filter((line) =>
+        /^(\s*(?:CHAT|SETUP|INFO|SESSION|EXTEND|CODE|JOBS)|\s*(?:▸\s*)?\/\w+\b)/.test(line),
+      );
+    expect(visibleBodyRows.length).toBeLessThanOrEqual(24);
+  });
+});

--- a/tests/ui-slash-suggestions.test.tsx
+++ b/tests/ui-slash-suggestions.test.tsx
@@ -6,11 +6,12 @@ import {
   SLASH_COMMANDS,
   type SlashCommandSpec,
   countAdvancedCommands,
+  orderSlashCommandsByGroup,
   suggestSlashCommands,
 } from "../src/cli/ui/slash.js";
 
 function makeCommands(count: number): SlashCommandSpec[] {
-  const groups = ["chat", "setup", "info", "session", "extend", "code", "jobs"] as const;
+  const groups = ["setup", "info", "chat", "extend", "session", "code", "jobs"] as const;
   return Array.from({ length: count }, (_, i) => ({
     cmd: `cmd${i.toString().padStart(2, "0")}`,
     summary: `summary ${i}`,
@@ -63,6 +64,34 @@ function hiddenAboveCount(frame: string): number {
   return match ? Number(match[1]) : 0;
 }
 
+function headerCount(frame: string, header: string): number {
+  return frame.split(/\r?\n/).filter((line) => line.trim() === header).length;
+}
+
+function visibleBodyRows(frame: string): string[] {
+  return frame
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .map((line) => {
+      if (/^(SETUP|INFO|CHAT|EXTEND|SESSION|CODE|JOBS|ADVANCED|UNKNOWN)$/.test(line)) return line;
+      return /^(?:▸\s*)?(\/\w+)\b/.exec(line)?.[1] ?? "";
+    })
+    .filter(Boolean);
+}
+
+function rowIndex(rows: readonly string[], token: string): number {
+  const index = rows.findIndex((line) => line.startsWith(token));
+  expect(index).toBeGreaterThanOrEqual(0);
+  return index;
+}
+
+function selectedCommand(frame: string): string | undefined {
+  return frame
+    .split(/\r?\n/)
+    .map((line) => /^\s*▸\s*(\/\w+)\b/.exec(line)?.[1])
+    .find((token): token is string => Boolean(token));
+}
+
 describe("SlashSuggestions", () => {
   it("renders the bare slash release command surface as 37 total commands", () => {
     const matches = suggestSlashCommands("", true);
@@ -84,15 +113,86 @@ describe("SlashSuggestions", () => {
     expect(suggestSlashCommands("lan").map((spec) => spec.cmd)).toContain("language");
   });
 
-  it("keeps the command order stable while the selected row moves in grouped browse mode", () => {
+  it("groups bare slash suggestions under one header per category", () => {
+    const frame = renderSuggestions(0);
+    const rows = visibleBodyRows(frame);
+    const setup = rowIndex(rows, "SETUP");
+    const language = rowIndex(rows, "/language");
+    const preset = rowIndex(rows, "/preset");
+    const model = rowIndex(rows, "/model");
+    const info = rowIndex(rows, "INFO");
+    const status = rowIndex(rows, "/status");
+
+    expect(headerCount(frame, "SETUP")).toBe(1);
+    expect(headerCount(frame, "INFO")).toBe(1);
+    expect(rows.filter((row) => row === "SETUP" || row === "INFO")).toEqual(["SETUP", "INFO"]);
+    expect(rows.slice(setup, info)).toEqual(["SETUP", "/language", "/preset", "/model"]);
+    expect([language, preset, model]).toEqual([setup + 1, setup + 2, setup + 3]);
+    expect(status).toBe(info + 1);
+  });
+
+  it("maps selectedIndex to grouped command rows without counting group headers", () => {
+    expect(selectedCommand(renderSuggestions(0))).toBe("/language");
+    expect(selectedCommand(renderSuggestions(1))).toBe("/preset");
+    expect(selectedCommand(renderSuggestions(2))).toBe("/model");
+    expect(selectedCommand(renderSuggestions(3))).toBe("/status");
+
+    const rows = visibleBodyRows(renderSuggestions(1));
+    expect(rows.slice(0, 5)).toEqual(["SETUP", "/language", "/preset", "/model", "INFO"]);
+    expect(selectedCommand(renderSuggestions(1))).not.toBe("SETUP");
+    expect(selectedCommand(renderSuggestions(3))).not.toBe("INFO");
+  });
+
+  it("moves from the first grouped command to the second grouped command on the next index", () => {
+    const { lastFrame, rerender, unmount } = render(
+      suggestionElement(suggestSlashCommands("", true), 0, countAdvancedCommands(true)),
+    );
+    expect(selectedCommand(lastFrame() ?? "")).toBe("/language");
+
+    rerender(suggestionElement(suggestSlashCommands("", true), 1, countAdvancedCommands(true)));
+    expect(selectedCommand(lastFrame() ?? "")).toBe("/preset");
+    unmount();
+  });
+
+  it("keeps filtered slash suggestions grouped even with usage counts", () => {
+    const matches = suggestSlashCommands("c", true, { compact: 100, cost: 90, checkpoint: 80 });
+    const { lastFrame, unmount } = render(
+      React.createElement(SlashSuggestions, {
+        matches,
+        selectedIndex: 0,
+        groupMode: true,
+      }),
+    );
+    const frame = lastFrame() ?? "";
+    const rows = visibleBodyRows(frame);
+    unmount();
+
+    expect(headerCount(frame, "INFO")).toBe(1);
+    expect(headerCount(frame, "CHAT")).toBe(1);
+    expect(headerCount(frame, "CODE")).toBe(1);
+    expect(rows).toEqual([
+      "INFO",
+      "/cost",
+      "/context",
+      "CHAT",
+      "/compact",
+      "/new",
+      "CODE",
+      "/checkpoint",
+      "/commit",
+      "/cwd",
+    ]);
+  });
+
+  it("keeps the grouped command order stable while the selected row moves in grouped browse mode", () => {
     const first = visibleCommandOrder(renderSuggestions(0));
     const middle = visibleCommandOrder(renderSuggestions(10));
     const last = visibleCommandOrder(renderSuggestions(18));
 
     expect(first).toEqual(middle);
     expect(middle).toEqual(last);
-    const matches = suggestSlashCommands("", true);
-    expect(first).toEqual(matches.slice(0, first.length).map((spec) => `/${spec.cmd}`));
+    const groupedMatches = orderSlashCommandsByGroup(suggestSlashCommands("", true));
+    expect(first).toEqual(groupedMatches.slice(0, first.length).map((spec) => `/${spec.cmd}`));
   });
 
   it("scrolls through every command in grouped browse mode when the list is taller than the window", () => {
@@ -169,7 +269,7 @@ describe("SlashSuggestions", () => {
     const visibleBodyRows = frame
       .split(/\r?\n/)
       .filter((line) =>
-        /^(\s*(?:CHAT|SETUP|INFO|SESSION|EXTEND|CODE|JOBS)|\s*(?:▸\s*)?\/\w+\b)/.test(line),
+        /^(\s*(?:SETUP|INFO|CHAT|EXTEND|SESSION|CODE|JOBS|UNKNOWN)|\s*(?:▸\s*)?\/\w+\b)/.test(line),
       );
     expect(visibleBodyRows.length).toBeLessThanOrEqual(24);
   });

--- a/tests/ui-status-row-balance.test.tsx
+++ b/tests/ui-status-row-balance.test.tsx
@@ -6,13 +6,15 @@
 import { render } from "ink";
 import React, { useEffect } from "react";
 import { describe, expect, it } from "vitest";
+import { SlashSuggestions } from "../src/cli/ui/SlashSuggestions.js";
 import { StatusRow } from "../src/cli/ui/layout/StatusRow.js";
+import type { SlashCommandSpec } from "../src/cli/ui/slash.js";
 import { AgentStoreProvider, useAgentStore } from "../src/cli/ui/state/provider.js";
 import type { AgentState, SessionInfo } from "../src/cli/ui/state/state.js";
 import { makeFakeStdin, makeFakeStdout } from "./helpers/ink-stdio.js";
 
 const SESSION: SessionInfo = {
-  id: "test-session",
+  id: "default",
   branch: "main",
   workspace: "/tmp/repo",
   model: "deepseek-chat",
@@ -98,5 +100,61 @@ describe("StatusRow — turn cost currency", () => {
   it("cache % always rendered", async () => {
     const text = await renderStatusRow({ cost: 0, cacheHit: 0.873 } as any);
     expect(text).toContain("cache 87%");
+  });
+});
+
+function makeSlashCommands(count: number): SlashCommandSpec[] {
+  return Array.from({ length: count }, (_, i) => ({
+    cmd: `cmd${i.toString().padStart(2, "0")}`,
+    summary: `summary ${i}`,
+    group: i < 5 ? "setup" : "info",
+  }));
+}
+
+async function renderStatusWithSuggestions(): Promise<string> {
+  const stdout = makeFakeStdout();
+  const { unmount } = render(
+    <AgentStoreProvider session={SESSION}>
+      <StateInjector
+        overrides={{
+          mode: "auto",
+          cacheHit: 0,
+          balance: 8.08,
+          balanceCurrency: "CNY",
+        }}
+      >
+        <BoxLikeComposer />
+      </StateInjector>
+    </AgentStoreProvider>,
+    { stdout: stdout as never, stdin: makeFakeStdin() as never },
+  );
+  await new Promise((r) => setTimeout(r, 50));
+  unmount();
+  return stdout.text();
+}
+
+function BoxLikeComposer(): React.ReactElement {
+  return (
+    <React.Fragment>
+      <StatusRow />
+      <SlashSuggestions matches={makeSlashCommands(12)} selectedIndex={7} groupMode />
+    </React.Fragment>
+  );
+}
+
+describe("StatusRow + SlashSuggestions composition", () => {
+  it("keeps the status line independent from slash suggestion headers", async () => {
+    const text = await renderStatusWithSuggestions();
+    const lines = text.split(/\r?\n/);
+    const statusLine = lines.find((line) => line.includes("cache 0%"));
+
+    expect(statusLine).toBeDefined();
+    expect(statusLine).toContain("auto");
+    expect(statusLine).toContain("default · main");
+    expect(statusLine).toContain("v0.35.0");
+    expect(statusLine).toContain("/feedback");
+    expect(statusLine).not.toContain("SETUP");
+    expect(statusLine).not.toContain("commands");
+    expect(lines.some((line) => /^\s*SETUP\s*$/.test(line))).toBe(true);
   });
 });


### PR DESCRIPTION
<!-- Read CONTRIBUTING.md first if this is your first PR. -->

## What

This change fixes slash command suggestion ordering and selection behavior by separating data-level suggestion ranking from UI-level grouped rendering. Empty slash command browsing is now ordered by fixed internal functional domains, while non-empty filtered suggestions can still use frequency ranking. The slash suggestion UI groups commands under stable domain headers and keeps keyboard selection aligned with the rendered command order.

<!-- One paragraph: what does this change? -->

## Why

The slash command menu could previously show repeated category headers such as SETUP/INFO/SETUP instead of grouping commands together. A follow-up fix introduced conflicts between fixed domain ordering and frequency-based suggestion sorting, causing test failures. The UI also mixed original match indexes with regrouped render order, which made keyboard navigation jump from the first command to a later command instead of moving one item at a time.

<!-- Bug fix? Pre-existing issue? Linked discussion? -->

## How to verify

Run:

npm test -- tests/slash.test.ts tests/slash-usage.test.ts tests/ui-slash-suggestions.test.tsx
npm run typecheck
npx biome check src/cli/ui/slash/commands.ts src/cli/ui/SlashSuggestions.tsx src/cli/ui/useCompletionPickers.ts src/cli/ui/App.tsx tests/slash-usage.test.ts tests/ui-slash-suggestions.test.tsx

Expected results:

Slash command suggestions are grouped by fixed internal domains for empty browsing.
Category headers appear once per group.
/language, /preset, and /model appear together under SETUP.
Frequency sorting still works for non-empty filtered suggestions.
Keyboard selection moves sequentially through commands without jumping over grouped items.

<!-- Steps the reviewer can run. `npm run verify` is assumed. -->

## Checklist

- [ ✅] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [ ✅] No `Co-Authored-By: Claude` trailer in commits
- [ ✅] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [ ✅] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time
