### PR TITLE
fix(tui): wheel scroll on cloud/web terminals + drop render ghosting

### DIFF
--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -529,7 +529,12 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
       exitOnCtrlC: true,
       // patchConsole:false — winpty/MINTTY redraw-glitch source.
       patchConsole: false,
-      incrementalRendering: true,
+      // incrementalRendering:false — Ink's diff drifts when stringWidth
+      // misjudges CJK / emoji ZWJ width or when async terminal-event
+      // bytes interleave mid-render, leaving residual rows. Full-frame
+      // redraws cost more stdout bytes per flush but eliminate the
+      // ghost class.
+      incrementalRendering: false,
       // Default true — alt-screen is the only mode without scrollback-
       // reflow ghosting. `--no-alt-screen` opts back into scrollback mode
       // for users who need chat output preserved in shell history on exit.

--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -317,6 +317,14 @@ export interface ChatOptions {
    * in shell scrollback after exit.
    */
   altScreen?: boolean;
+  /**
+   * Enable DECSET 1007 (alternate-scroll) so the wheel scrolls chat on
+   * web/cloud/SSH terminals — terminal translates wheel events to ↑/↓
+   * key sequences in alt-screen, no full mouse tracking, native
+   * drag-select + right-click unaffected. Default true. Pass false
+   * (CLI: `--no-mouse`) to suppress entirely.
+   */
+  mouse?: boolean;
 }
 
 interface RootProps extends ChatOptions {
@@ -413,6 +421,7 @@ function Root({
         progressSink={progressSink}
         codeMode={appProps.codeMode}
         noDashboard={appProps.noDashboard}
+        mouse={appProps.mouse}
         onSwitchSession={setActiveSession}
       />
     </KeystrokeProvider>

--- a/src/cli/commands/code.tsx
+++ b/src/cli/commands/code.tsx
@@ -62,6 +62,8 @@ export interface CodeOptions {
   systemAppendFile?: string;
   /** Default true. Pass false (CLI: `--no-alt-screen`) to keep chat output in shell scrollback. */
   altScreen?: boolean;
+  /** Default true. Pass false (CLI: `--no-mouse`) to keep terminal-native drag-select unmodified. */
+  mouse?: boolean;
 }
 
 export async function codeCommand(opts: CodeOptions = {}): Promise<void> {
@@ -214,5 +216,6 @@ export async function codeCommand(opts: CodeOptions = {}): Promise<void> {
     forceNew: opts.forceNew,
     noDashboard: opts.noDashboard,
     altScreen: opts.altScreen,
+    mouse: opts.mouse,
   });
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -99,6 +99,7 @@ program
   .option("--budget <usd>", t("ui.budgetHint"), (v) => Number.parseFloat(v))
   .option("--no-dashboard", t("ui.noDashboard"))
   .option("--no-alt-screen", "keep chat output in shell scrollback (legacy mode, ghost-prone)")
+  .option("--no-mouse", "disable SGR mouse tracking (keeps drag-select 100% native)")
   .option("--system-append <prompt>", t("ui.systemAppendHint"))
   .option("--system-append-file <path>", t("ui.systemAppendFileHint"))
   .action(async (dir: string | undefined, opts) => {
@@ -115,6 +116,7 @@ program
       systemAppend: opts.systemAppend,
       systemAppendFile: opts.systemAppendFile,
       altScreen: opts.altScreen !== false,
+      mouse: opts.mouse !== false,
     });
   });
 
@@ -141,6 +143,7 @@ program
   .option("--no-config", t("ui.noConfigHint"))
   .option("--no-dashboard", t("ui.noDashboard"))
   .option("--no-alt-screen", "keep chat output in shell scrollback (legacy mode, ghost-prone)")
+  .option("--no-mouse", "disable SGR mouse tracking (keeps drag-select 100% native)")
   .action(async (opts) => {
     const defaults = resolveDefaults({
       model: opts.model,
@@ -174,6 +177,7 @@ program
       forceNew: !!opts.new,
       noDashboard: opts.dashboard === false,
       altScreen: opts.altScreen !== false,
+      mouse: opts.mouse !== false,
     });
   });
 

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -232,6 +232,14 @@ export interface AppProps {
   noDashboard?: boolean;
   /** Mid-chat session swap — Root remounts App with the new session via key. */
   onSwitchSession?: (name: string | undefined) => void;
+  /**
+   * Enable DECSET 1007 (alternate-scroll) so the wheel scrolls chat
+   * on web/cloud/SSH terminals — terminal translates wheel events to
+   * ↑/↓ key sequences in alt-screen, no full mouse tracking, native
+   * drag-select + right-click unaffected. Default true. Pass false
+   * (CLI: `--no-mouse`) to suppress entirely.
+   */
+  mouse?: boolean;
 }
 
 /**
@@ -324,6 +332,7 @@ function AppInner({
   codeMode,
   noDashboard,
   onSwitchSession,
+  mouse = true,
 }: AppProps) {
   markPhase("app_inner_start");
   const log = useScrollback();
@@ -383,36 +392,34 @@ function AppInner({
   // H genuinely nukes viewport AND scrollback, which is what `/clear`
   // means to a shell user.
   const { stdout } = useStdout();
-  // Terminal input modes we opt into at startup, all paired with
-  // disable-on-unmount so the user's shell doesn't inherit them:
+  // Bracketed paste + modifyOtherKeys + alternate-scroll. All three
+  // are opt-in per session and reset on unmount.
   //
-  //   • Bracketed paste (DECSET 2004) — terminal wraps pasted text
-  //     with \x1b[200~ … \x1b[201~ markers so a multi-chunk paste
-  //     can't be misread as keystrokes (the trailing \n in a paste
-  //     would otherwise fire submit).
-  //
-  //   • modifyOtherKeys level 2 (CSI > 4 ; 2 m) — terminal encodes
-  //     modifier-bearing keypresses (Shift+Enter, Ctrl+Enter, etc.)
-  //     as `\x1b[27;<mod>;<key>~` instead of the bare ASCII byte. Our
-  //     stdin-reader recognises `27;2;13~` as Shift+Enter and
-  //     `27;5;13~` as Ctrl+Enter. Terminals that don't understand the
-  //     SGR fall through silently — Shift+Enter just stays
-  //     indistinguishable from Enter, no regression.
-  //
-  // Mouse tracking is intentionally NOT enabled: terminals translate
-  // the wheel to ↑/↓ in the alt-screen buffer, App-level ↑/↓ scrolls
-  // chat, and Ctrl+P / Ctrl+N own the prompt's history + multi-line
-  // cursor moves. Skipping mouse mode keeps native drag-to-select +
-  // right-click paste working in every terminal.
+  //   • DECSET 2004 — bracketed paste markers so multi-chunk pastes
+  //     don't fire submit on the trailing \n.
+  //   • CSI > 4 ; 2 m — modifyOtherKeys level 2 so Shift+Enter /
+  //     Ctrl+Enter encode as `\x1b[27;<mod>;<key>~` instead of bare
+  //     CR; stdin-reader recognises them. Silent fallback otherwise.
+  //   • DECSET 1007 — alternate-scroll: in alt-screen the terminal
+  //     translates wheel events to ↑/↓ key sequences instead of
+  //     swallowing them. Lets us route wheel to chat-scroll without
+  //     enabling full mouse tracking, so terminal-native drag-select
+  //     and right-click stay 100% intact (no Shift modifier needed).
+  //     Supported by xterm/iTerm/Windows Terminal/Alacritty/Kitty and
+  //     xterm.js 4.x+ (covers code-server, VS Code web, modern cloud
+  //     shells). Pre-1007 terminals fall through silently — wheel is
+  //     dead but everything else works.
   useEffect(() => {
     if (!stdout || !stdout.isTTY) return;
     stdout.write("\u001b[?2004h");
     stdout.write("\u001b[>4;2m");
+    if (mouse) stdout.write("\u001b[?1007h");
     return () => {
+      if (mouse) stdout.write("\u001b[?1007l");
       stdout.write("\u001b[?2004l");
       stdout.write("\u001b[>4m");
     };
-  }, [stdout]);
+  }, [stdout, mouse]);
 
   // Subagent UI wiring: live activity row + sink ref the loop closure
   // captures. Must be declared BEFORE loop construction so the
@@ -1226,18 +1233,12 @@ function AppInner({
   // Esc handles "abort the current turn" separately; Ctrl+C is the universal "I'm done" key.
   const quitProcess = useQuit(transcriptRef);
 
-  // ↑/↓/PgUp/PgDn always scroll chat. The terminal translates the
-  // mouse wheel to ↑/↓ in alt-screen mode so the wheel scrolls chat
-  // for free without us enabling mouse tracking. Prompt history +
-  // multi-line cursor moves live on Ctrl+P / Ctrl+N (see
-  // multiline-keys.ts); leftover mouseScrollUp/Down events from a
-  // terminal that ignores DECRST 1000 still route correctly.
-  //
-  // Pickers (slash / @-mention / slash-arg / shell-confirm) own ↑/↓
-  // for their own list nav — when any of them is open we skip the
-  // arrow path here so the user doesn't see the chat scroll AND the
-  // picker selection move on the same keypress. PgUp/PgDn/End still
-  // scroll regardless because pickers don't claim those.
+  // ↑/↓/PgUp/PgDn always scroll chat; wheel arrives as ↑/↓ via
+  // DECSET 1007 alternate-scroll so it joins the same path. Pickers
+  // (slash / @-mention / slash-arg / shell-confirm) own ↑/↓ — when
+  // any of them is open we skip the arrow path so chat doesn't scroll
+  // alongside picker navigation; PgUp/PgDn/End still scroll. Prompt
+  // history + multi-line cursor moves live on Ctrl+P / Ctrl+N.
   useKeystroke((ev) => {
     const pickerOwnsArrows =
       (atState?.entries.length ?? 0) > 0 ||

--- a/src/cli/ui/multiline-keys.ts
+++ b/src/cli/ui/multiline-keys.ts
@@ -66,13 +66,10 @@ export function processMultilineKey(
     return cursor === value.length ? NOOP : { next: null, cursor: value.length, submit: false };
   }
 
-  // ↑/↓ are NOT consumed here — they belong to chat-scroll at the App
-  // level. Ctrl+P / Ctrl+N take over what ↑/↓ used to do here:
+  // ↑/↓ belong to chat-scroll at the App level. Ctrl+P / Ctrl+N take
+  // over what ↑/↓ used to do here:
   //   • multi-line buffer → cursor up/down within the buffer
   //   • single-line / empty → hand off to prompt history (readline parity)
-  // This pairing lets us drop xterm mouse tracking; the terminal's own
-  // wheel→↑/↓ translation in alt-screen mode then scrolls chat for free
-  // and native drag-select / right-click stay intact.
   if (key.ctrl && key.input === "p") {
     if (value.includes("\n")) {
       const moved = moveCursorUp(value, cursor);

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -80,12 +80,12 @@ export const EN: TranslationSchema = {
       sections: [
         {
           rows: [
-            { key: "drag", text: "select text directly — terminal-native, no modifier needed" },
+            { key: "drag", text: "select text — terminal-native, no modifier needed" },
             {
               key: "right-click",
               text: "your terminal's native menu (paste / copy on Windows Terminal etc.)",
             },
-            { key: "wheel", text: "scrolls chat history (terminal translates wheel to ↑/↓)" },
+            { key: "wheel", text: "scrolls chat history (works on web/cloud/SSH terminals too)" },
             {
               key: "↑ / ↓",
               text: "scroll chat · use Ctrl+P / Ctrl+N for prompt history + multi-line cursor",
@@ -103,10 +103,7 @@ export const EN: TranslationSchema = {
           rows: [
             { key: "Enter", text: "submit the prompt" },
             { key: "Shift+Enter", text: "insert a newline in the prompt" },
-            {
-              key: "↑ / ↓",
-              text: "scroll chat history (always — wheel maps to ↑/↓ via the terminal)",
-            },
+            { key: "↑ / ↓", text: "scroll chat history (mouse wheel routes here too)" },
             {
               key: "Ctrl+P / Ctrl+N",
               text: "previous / next prompt history · cursor up / down in a multi-line draft",
@@ -125,8 +122,8 @@ export const EN: TranslationSchema = {
         {
           title: "mouse",
           rows: [
-            { key: "wheel", text: "scrolls chat history (terminal translates to ↑/↓)" },
-            { key: "drag", text: "selects text natively — direct copy works" },
+            { key: "wheel", text: "scrolls chat history (works on web/cloud/SSH terminals too)" },
+            { key: "drag", text: "selects text natively — direct copy works, no modifier" },
             { key: "right-click", text: "terminal-native (paste menu on Windows Terminal etc.)" },
           ],
         },
@@ -155,7 +152,7 @@ export const EN: TranslationSchema = {
         },
       ],
       footer:
-        "Mouse tracking is OFF — drag-to-select, right-click, and the wheel all behave the way your terminal natively does. Wheel sends ↑/↓ which the app uses for chat scroll.",
+        "Wheel→↑/↓ via DECSET 1007 (alternate-scroll) — wheel scrolls chat on most terminals (web/cloud/SSH included) without disturbing native selection. Drag to select stays modifier-free. Pass --no-mouse to opt out.",
     },
     tipShownOnce: "shown once",
     modelOverride: "override the default model",

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -80,7 +80,7 @@ export const zhCN: TranslationSchema = {
               key: "右键",
               text: "终端原生菜单（Windows Terminal 等的复制 / 粘贴）",
             },
-            { key: "滚轮", text: "滚动聊天（终端把滚轮翻译成 ↑ / ↓）" },
+            { key: "滚轮", text: "滚动聊天记录（Web / 云端 / SSH 终端也能用）" },
             {
               key: "↑ / ↓",
               text: "滚动聊天 · 输入框历史 + 多行光标用 Ctrl+P / Ctrl+N",
@@ -98,7 +98,7 @@ export const zhCN: TranslationSchema = {
           rows: [
             { key: "Enter", text: "提交输入" },
             { key: "Shift+Enter", text: "在输入框中插入换行" },
-            { key: "↑ / ↓", text: "滚动聊天记录（始终 — 滚轮也通过终端映射到 ↑/↓）" },
+            { key: "↑ / ↓", text: "滚动聊天记录（鼠标滚轮也走这条路径）" },
             {
               key: "Ctrl+P / Ctrl+N",
               text: "上一条 / 下一条输入历史 · 多行草稿中按行移动光标",
@@ -117,8 +117,8 @@ export const zhCN: TranslationSchema = {
         {
           title: "鼠标",
           rows: [
-            { key: "滚轮", text: "滚动聊天记录（终端翻译为 ↑/↓）" },
-            { key: "拖动", text: "原生选中文本 — 直接复制" },
+            { key: "滚轮", text: "滚动聊天记录（Web / 云端 / SSH 终端也能用）" },
+            { key: "拖动", text: "原生选中文本 — 直接复制，不需要修饰键" },
             { key: "右键", text: "终端原生（Windows Terminal 等的粘贴菜单）" },
           ],
         },
@@ -147,7 +147,7 @@ export const zhCN: TranslationSchema = {
         },
       ],
       footer:
-        "鼠标追踪已关闭 — 拖动选中、右键、滚轮都按终端原生方式工作。滚轮发送 ↑/↓，应用用它来滚动聊天。",
+        "通过 DECSET 1007（alternate-scroll），终端把滚轮翻译成 ↑/↓ 发给应用 — 大多数终端（含 Web / 云端 / SSH）都能滚，且不影响终端原生选区。直接拖动选中文本无需 Shift。传入 --no-mouse 可关闭。",
     },
     tipShownOnce: "仅显示一次",
     modelOverride: "覆盖默认模型",


### PR DESCRIPTION
## Summary

Two related fixes for a class of complaint from users on remote / cloud / web terminals: chat won't scroll, and what does render leaves residual rows.

### 1. Wheel scroll on cloud terminals (`DECSET 1007`)

Old code relied on the implicit "terminal translates wheel→↑/↓ in alt-screen" behavior — but that's only on by default in xterm/iTerm/Windows Terminal/Alacritty/Kitty. Web/cloud/SSH terminals (xterm.js, code-server, GCP Cloud Shell, AWS CloudShell, mobile SSH apps, tmux without `mouse on`) ship with it off, so the wheel was a dead key — the most common "can't scroll" report.

We now explicitly request the behavior via **DECSET 1007 (alternate-scroll)** on mount, reset on unmount. The terminal turns wheel events into ↑/↓ keystrokes; existing chat-scroll handler picks them up. Native drag-to-select and right-click stay 100% intact — no Shift bypass needed (the alternative — full SGR mouse tracking — would have required Shift+drag, which is the worse trade-off).

`--no-mouse` opts out for the rare user who'd rather suppress the sequence entirely.

### 2. Drop render ghosting (`incrementalRendering: false`)

Ink's incremental render diffs against an internal "what's on screen" snapshot. The diff drifts when:
- `string-width` misjudges CJK / emoji ZWJ cell width
- async terminal-event bytes (DA replies, focus, mouse) interleave between Ink's cursor-positioning writes
- terminal resize races a flush

Stale rows survive the redraw → the residual "ghost" class users have been reporting on cloud/web terminals.

Full-frame redraws sidestep the snapshot. Cost is more stdout bytes per flush; at the 60Hz default, local terminals are unaffected. Sustained high-rate streaming on slow SSH can drop to 30Hz via the existing `REASONIX_FLUSH_MS=33` env var.

## Test plan

- [x] `npm run verify` passes (148 files / 2381 tests)
- [ ] Local terminal: wheel still scrolls chat; drag-to-select still copies natively without Shift
- [ ] Cloud terminal (code-server / Cloud Shell / mobile SSH): wheel now scrolls chat
- [ ] Verify no residual rows after mid-stream resize or after CJK / emoji-heavy assistant reply
- [ ] `--no-mouse` cleanly disables the new sequence