### PR TITLE
fix(dashboard): resync canonical state on SSE reconnect

### DIFF
--- a/dashboard/src/panels/chat.ts
+++ b/dashboard/src/panels/chat.ts
@@ -185,8 +185,37 @@ export function ChatPanel() {
     };
   }, []);
 
+  // SSE reconnect drops missed deltas / finals / modals — server only
+  // snapshots `busy-change` on (re)connect. Pull /messages + /modal to
+  // recover canonical state, otherwise UI wedges on the last seen state (#521).
+  const refetchCanonicalState = useCallback(async () => {
+    try {
+      const data = await api<MessagesResponse>("/messages");
+      setMessages(data.messages ?? []);
+      setBusy(Boolean(data.busy));
+      setStreaming(null);
+      setActiveTool(null);
+    } catch {
+      /* keep current state — next event or next reconnect will retry */
+    }
+    try {
+      const m = await api<ModalEnvelope>("/modal");
+      setModal(m.modal ?? null);
+    } catch {
+      /* modal endpoint optional in standalone */
+    }
+  }, []);
+
   useEffect(() => {
     const es = new EventSource(`/api/events?token=${TOKEN}`);
+    let firstOpen = true;
+    es.onopen = () => {
+      if (firstOpen) {
+        firstOpen = false;
+        return;
+      }
+      void refetchCanonicalState();
+    };
     es.onmessage = (ev) => {
       let dash;
       try {
@@ -266,12 +295,13 @@ export function ChatPanel() {
     };
     es.onerror = () => {
       // Auto-reconnect by default; surface a brief banner on persistent
-      // failure but don't tear down — EventSource retries in the background.
+      // failure but don't tear down — EventSource retries in the
+      // background. The next `onopen` will resync canonical state.
       setError(t("chat.eventStreamError"));
       setTimeout(() => setError(null), 3000);
     };
     return () => es.close();
-  }, []);
+  }, [refetchCanonicalState]);
 
   const send = useCallback(async () => {
     const text = input.trim();


### PR DESCRIPTION
## Summary

The dashboard's `/api/events` SSE stream snapshots only `busy-change` on (re)connect — every `assistant_delta` / `assistant_final` / `tool` / `modal-up` event fired during a disconnect window is lost. EventSource auto-reconnects, but if the disconnect happened before the end-of-turn `busy-change(false)`, the UI is wedged on "busy" forever and the completed reply never appears. The user-visible symptom: page becomes unresponsive while the task runs and stays stale after it finishes; the only escape is reopening the dashboard URL (which fetches `/api/messages` on boot).

The disconnect itself has multiple triggers, all common:
- 25s ping miss when the Node event loop is blocked by heavy task work
- Browser background-tab throttling / aggressive proxy timeouts
- Network blips on cloud / SSH-tunneled deployments

## Fix

On every `onopen` after the first, refetch `/api/messages` + `/api/modal` to recover canonical state. Streaming and active-tool slots reset since they're transient — the next `assistant_delta` repopulates streaming, the next `tool_start` repopulates active-tool. First open is skipped because the boot effect already owns the initial canonical fetch.

This is a client-only change. Server-side ring-buffer / `Last-Event-ID` resume could layer on later if we want byte-perfect replay, but the resync alone fixes the documented wedge.

Closes #521

## Test plan

- [x] `npm run typecheck` passes
- [x] `npx vitest run tests/comment-policy.test.ts tests/server-dashboard.test.ts` — 73 tests pass
- [ ] Manual: open dashboard, kill the SSE connection (browser devtools → Network → set offline → online), confirm message list and busy state recover from canonical
- [ ] Manual: trigger a long task, observe that page stays in sync after the task completes (no wedge)
- [ ] Manual: confirm modal state survives a forced reconnect mid-modal