### PR TITLE
fix(plan): pipe user feedback through refine / approve / cancel gate

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -2909,8 +2909,8 @@ function AppInner({
       }
       if (!staged) return;
       const trimmed = feedback.trim();
+      const tail = trimmed.length > 50 ? `${trimmed.slice(0, 50)}…` : trimmed;
 
-      let synthetic: string;
       let marker: string;
       if (staged.mode === "approve") {
         togglePlanMode(false);
@@ -2931,14 +2931,9 @@ function AppInner({
           });
           persistPlanState();
         }
-        if (trimmed) {
-          synthetic = `The plan above has been approved. Implement it now. You are out of plan mode — use edit_file / write_file / run_command as needed.\n\nUser's additional instructions / answers to your open questions:\n\n${trimmed}\n\nFactor these in before the first edit. Stick to the plan unless you discover a concrete reason to deviate; if you do, tell me and wait for a response.`;
-          marker = `▸ plan approved + instructions — ${trimmed.length > 50 ? `${trimmed.slice(0, 50)}…` : trimmed}`;
-        } else {
-          synthetic =
-            "The plan above has been approved. Implement it now. You are out of plan mode — use edit_file / write_file / run_command as needed. If the plan listed open questions and I didn't answer them, default to the safest interpretation and call them out in your first reply. Don't fabricate preferences — if a question is truly unanswerable without me, stop and ask.";
-          marker = "▸ plan approved — implementing";
-        }
+        marker = trimmed
+          ? `▸ plan approved + instructions — ${tail}`
+          : "▸ plan approved — implementing";
       } else if (staged.mode === "reject") {
         // Drop the structured plan state — the user said this path is wrong,
         // no point keeping it around for resume.
@@ -2949,36 +2944,25 @@ function AppInner({
         persistPlanState();
         togglePlanMode(false);
         agentStore.dispatch({ type: "plan.drop" });
-        if (trimmed) {
-          synthetic = `The plan was rejected. User's reason / what they actually want:\n\n${trimmed}\n\nDrop the proposed plan entirely. Use this guidance to understand what the user is after — ask follow-up questions if anything is still unclear, otherwise propose a different plan that addresses it.`;
-          marker = `▸ plan rejected — ${trimmed.length > 50 ? `${trimmed.slice(0, 50)}…` : trimmed}`;
-        } else {
-          synthetic =
-            "The plan was cancelled. Drop it entirely. Ask me what I actually want before proposing another plan or making any changes.";
-          marker = "▸ plan cancelled";
-        }
+        marker = trimmed ? `▸ plan rejected — ${tail}` : "▸ plan cancelled";
       } else {
-        // refine
-        if (trimmed) {
-          synthetic = `The plan needs refinement. User feedback / answers:\n\n${trimmed}\n\nStay in plan mode — address the feedback (explore more if needed), then submit an improved submit_plan call. Don't propose a near-identical plan unless you explain why the feedback doesn't apply.`;
-          marker = `▸ refining — ${trimmed.length > 50 ? `${trimmed.slice(0, 50)}…` : trimmed}`;
-        } else {
-          synthetic =
-            "The plan needs refinement. The user saw your open questions / risks block and chose not to answer specifics. Pick the safest default for each open question, call those defaults out explicitly in the new plan, and submit the refined submit_plan. Do not re-ask — the user already saw the questions.";
-          marker = "▸ refining — using safe defaults";
-        }
+        marker = trimmed ? `▸ refining — ${tail}` : "▸ refining — using safe defaults";
       }
+      log.pushInfo(marker);
 
       // Resolve the PauseGate so the blocked submit_plan tool function
-      // can return and the model sees the verdict without a synthetic message.
+      // returns. The user's typed feedback rides on the verdict so the
+      // model sees it as the tool result — without this, refine looked
+      // identical to "user requested refinement" with no payload (#533).
       const gateId = pendingGateIdRef.current;
       if (gateId !== null) {
+        const fb = trimmed || undefined;
         if (staged.mode === "approve") {
-          pauseGate.resolve(gateId, { type: "approve" });
+          pauseGate.resolve(gateId, { type: "approve", feedback: fb });
         } else if (staged.mode === "reject") {
-          pauseGate.resolve(gateId, { type: "cancel" });
+          pauseGate.resolve(gateId, { type: "cancel", feedback: fb });
         } else {
-          pauseGate.resolve(gateId, { type: "refine" });
+          pauseGate.resolve(gateId, { type: "refine", feedback: fb });
         }
       }
     },

--- a/src/core/pause-gate.ts
+++ b/src/core/pause-gate.ts
@@ -7,7 +7,10 @@ export type ConfirmationChoice =
   | { type: "run_once" }
   | { type: "always_allow"; prefix: string };
 
-export type PlanVerdict = { type: "approve" } | { type: "refine" } | { type: "cancel" };
+export type PlanVerdict =
+  | { type: "approve"; feedback?: string }
+  | { type: "refine"; feedback?: string }
+  | { type: "cancel"; feedback?: string };
 
 export type CheckpointVerdict =
   | { type: "continue" }

--- a/src/tools/plan-core.ts
+++ b/src/tools/plan-core.ts
@@ -109,9 +109,14 @@ function registerSubmitPlan(registry: ToolRegistry, opts: PlanToolOptions): void
         kind: "plan_proposed",
         payload: { plan, steps, summary },
       });
-      if (verdict.type === "approve") return "plan approved";
-      if (verdict.type === "refine") throw new Error("user requested refinement");
-      throw new Error("plan cancelled");
+      const fb = verdict.feedback?.trim();
+      if (verdict.type === "approve") {
+        return fb ? `plan approved. user's additional instructions: ${fb}` : "plan approved";
+      }
+      if (verdict.type === "refine") {
+        throw new Error(fb ? `user requested refinement: ${fb}` : "user requested refinement");
+      }
+      throw new Error(fb ? `plan cancelled: ${fb}` : "plan cancelled");
     },
   });
 }

--- a/tests/plan.test.ts
+++ b/tests/plan.test.ts
@@ -362,6 +362,48 @@ describe("registerPlanTool + submit_plan", () => {
       { id: "step-2", title: "also good", action: "do other thing" },
     ]);
   });
+
+  it("surfaces refine feedback in the tool error so the model sees what to fix (#533)", async () => {
+    const reg = new ToolRegistry();
+    registerPlanTool(reg);
+    const gate = new AutoGate({ type: "refine", feedback: "use sqlite, not postgres" });
+    const out = await reg.dispatch("submit_plan", JSON.stringify({ plan: "# Plan" }), {
+      confirmationGate: gate,
+    });
+    expect(JSON.parse(out).error).toMatch(/user requested refinement: use sqlite, not postgres/);
+  });
+
+  it("falls back to bare 'user requested refinement' when no feedback is supplied", async () => {
+    const reg = new ToolRegistry();
+    registerPlanTool(reg);
+    const gate = new AutoGate({ type: "refine" });
+    const out = await reg.dispatch("submit_plan", JSON.stringify({ plan: "# Plan" }), {
+      confirmationGate: gate,
+    });
+    expect(JSON.parse(out).error).toMatch(/user requested refinement$/);
+  });
+
+  it("surfaces approve feedback as additional instructions in the tool result", async () => {
+    const reg = new ToolRegistry();
+    registerPlanTool(reg);
+    const gate = new AutoGate({ type: "approve", feedback: "skip the migration step for now" });
+    const out = await reg.dispatch("submit_plan", JSON.stringify({ plan: "# Plan" }), {
+      confirmationGate: gate,
+    });
+    expect(out).toBe(
+      "plan approved. user's additional instructions: skip the migration step for now",
+    );
+  });
+
+  it("surfaces cancel feedback in the tool error so the model knows the why", async () => {
+    const reg = new ToolRegistry();
+    registerPlanTool(reg);
+    const gate = new AutoGate({ type: "cancel", feedback: "out of scope for this branch" });
+    const out = await reg.dispatch("submit_plan", JSON.stringify({ plan: "# Plan" }), {
+      confirmationGate: gate,
+    });
+    expect(JSON.parse(out).error).toMatch(/plan cancelled: out of scope for this branch/);
+  });
 });
 
 describe("registerPlanTool + mark_step_complete", () => {


### PR DESCRIPTION
## Summary

When the user picked **Refine** on `PlanConfirm` and typed their suggestion, the model never saw the text.

`handleStagedInputSubmit` built a rich `synthetic` string with the feedback embedded, but only resolved the `PauseGate` with `{ type: "refine" }` — no payload. `submit_plan` threw the bare `Error("user requested refinement")`, the model received that as the tool result with zero context, and proposed a near-identical plan, which fired `PlanConfirm` again. From the user's perspective the suggestion was silently dropped — exactly the report in #533.

The `PlanVerdict` union didn't even allow a `feedback` field, so the omission was structural. The `CheckpointVerdict` pattern (already shipping for revise-at-step) had the right shape — `submit_plan` just never adopted it.

## Fix

- `pause-gate.ts` — extend `PlanVerdict` so `refine` / `approve` / `cancel` can each carry optional `feedback`
- `plan-core.ts` — surface that feedback in the tool result string (`"user requested refinement: <text>"` / `"plan approved. user's additional instructions: <text>"` / `"plan cancelled: <text>"`)
- `App.tsx` — pass `feedback: trimmed || undefined` through `pauseGate.resolve()` for all three branches; drop the dead `synthetic` text that was being built and discarded; emit the existing `marker` via `pushInfo` so the user sees a chat-row confirmation right after they hit Enter

## Test coverage

Mirrors the existing `mark_step_complete` revise-feedback tests:
- refine + feedback → tool error includes the feedback text
- refine + no feedback → bare error message preserved
- approve + feedback → tool result includes "user's additional instructions"
- cancel + feedback → tool error includes the cancellation reason

Closes #533

## Test plan

- [x] `npm run typecheck` passes
- [x] `npx vitest run tests/plan.test.ts` — 42 pass (4 new)
- [ ] Manual: `/plan` → submit something → Refine → type a concrete instruction → confirm the next plan reflects it instead of being a copy
- [ ] Manual: confirm Approve + extra instructions still routes the user's text to the model