### PR TITLE
fix(tui): rescue unbracketed pastes so multi-line content stops firing N submits

### DIFF
--- a/src/cli/ui/stdin-reader.ts
+++ b/src/cli/ui/stdin-reader.ts
@@ -121,6 +121,32 @@ function lookupCsi(tail: string): KeyEvent | null {
   return null;
 }
 
+/** Heuristic paste-burst detector — wraps raw multi-line chunks when the terminal didn't (#522). */
+export function looksLikeUnbracketedPaste(chunk: string): boolean {
+  if (chunk.length < 2) return false;
+  if (chunk.includes(PASTE_START) || chunk.includes(PASTE_START_BARE)) return false;
+  if (chunk.includes(PASTE_END) || chunk.includes(PASTE_END_BARE)) return false;
+  // ESC anywhere = real keypress / control sequence, not a paste burst.
+  if (chunk.includes("\x1b")) return false;
+  // \r\n is one terminal-converted Enter, not two breaks — fold first.
+  const norm = chunk.replace(/\r\n/g, "\n");
+  if (norm === "\r" || norm === "\n") return false;
+  let breaks = 0;
+  let firstBreakIdx = -1;
+  for (let i = 0; i < norm.length; i++) {
+    const c = norm[i];
+    if (c === "\r" || c === "\n") {
+      if (firstBreakIdx < 0) firstBreakIdx = i;
+      breaks++;
+    }
+  }
+  if (breaks >= 2) return true;
+  // 1 break with non-empty text on BOTH sides — paste burst. ("abc\r"
+  // alone stays as type-then-Enter so a fast typist still submits.)
+  if (breaks === 1) return firstBreakIdx > 0 && firstBreakIdx < norm.length - 1;
+  return false;
+}
+
 export class StdinReader {
   private subscribers = new Set<Subscriber>();
   private state: "idle" | "esc" | "csi" | "ss3" | "paste" = "idle";
@@ -226,8 +252,15 @@ export class StdinReader {
     }, ESC_TIMEOUT_MS);
   }
 
-  private handleChunk(chunk: string): void {
+  private handleChunk(rawChunk: string): void {
     this.cancelEscTimer();
+    // Paste rescue when DECSET 2004 markers don't arrive (multiplexers
+    // strip them, some Windows pipes too) — otherwise each \r in a
+    // multi-line paste fires Enter and the loop submits N prompts (#522).
+    const chunk =
+      this.state === "idle" && looksLikeUnbracketedPaste(rawChunk)
+        ? PASTE_START + rawChunk + PASTE_END
+        : rawChunk;
     let i = 0;
     while (i < chunk.length) {
       // ── paste accumulator ──

--- a/tests/stdin-reader.test.ts
+++ b/tests/stdin-reader.test.ts
@@ -175,8 +175,11 @@ describe("StdinReader — single-byte keys", () => {
 
   it("printable run breaks at a CSI / control byte", () => {
     const { reader, events } = setup();
-    reader.feed("ab\rcd");
-    expect(events).toEqual([{ input: "ab" }, { input: "", return: true }, { input: "cd" }]);
+    // \t splits the printable run cleanly. \r / \n now route through the
+    // heuristic paste rescue when surrounded by text (#522), so they
+    // don't exercise the printable-coalescer split path anymore.
+    reader.feed("ab\tcd");
+    expect(events).toEqual([{ input: "ab" }, { input: "", tab: true }, { input: "cd" }]);
   });
 });
 
@@ -218,6 +221,75 @@ describe("StdinReader — bracketed paste", () => {
     const { reader, events } = setup();
     reader.feed("ab[Ccd");
     expect(events).toEqual([{ input: "ab" }, { input: "", rightArrow: true }, { input: "cd" }]);
+  });
+});
+
+describe("StdinReader — heuristic paste rescue (#522)", () => {
+  it("treats a multi-line chunk without paste markers as a single paste event", () => {
+    // Multiplexers / web-SSH gateways strip DECSET 2004 brackets; raw
+    // multi-line content used to fire one Enter per \r and submit N times.
+    const { reader, events } = setup();
+    reader.feed("first line\rsecond line\rthird line");
+    expect(events).toEqual([{ input: "first line\rsecond line\rthird line", paste: true }]);
+  });
+
+  it("treats a single-break chunk with text on both sides as a paste", () => {
+    const { reader, events } = setup();
+    reader.feed("hello\rworld");
+    expect(events).toEqual([{ input: "hello\rworld", paste: true }]);
+  });
+
+  it("leaves a bare Enter alone (\\r submits as before)", () => {
+    const { reader, events } = setup();
+    reader.feed("\r");
+    expect(events).toEqual([{ input: "", return: true }]);
+  });
+
+  it("leaves a bare CRLF alone (\\r\\n is one terminal-converted Enter, not paste)", () => {
+    const { reader, events } = setup();
+    reader.feed("\r\n");
+    // \r → return; \n → ctrl+j. Neither flagged as paste.
+    expect(events).toEqual([
+      { input: "", return: true },
+      { input: "j", ctrl: true },
+    ]);
+  });
+
+  it("leaves typed-then-Enter alone (`abc\\r` is not flagged as paste)", () => {
+    const { reader, events } = setup();
+    reader.feed("abc\r");
+    expect(events).toEqual([{ input: "abc" }, { input: "", return: true }]);
+  });
+
+  it("leaves Enter-then-typed alone (`\\rabc` is not flagged as paste)", () => {
+    const { reader, events } = setup();
+    reader.feed("\rabc");
+    expect(events).toEqual([{ input: "", return: true }, { input: "abc" }]);
+  });
+
+  it("does not interfere when the chunk already contains a real bracketed paste", () => {
+    const { reader, events } = setup();
+    reader.feed("\x1b[200~one\ntwo\x1b[201~");
+    expect(events).toEqual([{ input: "one\ntwo", paste: true }]);
+  });
+
+  it("does not wrap chunks containing ESC (could be an arrow / control sequence)", () => {
+    const { reader, events } = setup();
+    // Text + arrow sequence — historically would interleave; never a paste.
+    reader.feed("a\x1b[Ab\x1b[A");
+    expect(events).toEqual([
+      { input: "a" },
+      { input: "", upArrow: true },
+      { input: "b" },
+      { input: "", upArrow: true },
+    ]);
+  });
+
+  it("normalizes \\r\\n line endings inside the heuristic so Windows pastes still get one event", () => {
+    const { reader, events } = setup();
+    reader.feed("first\r\nsecond\r\nthird");
+    // Whole chunk wrapped → paste accumulator delivers verbatim
+    expect(events).toEqual([{ input: "first\r\nsecond\r\nthird", paste: true }]);
   });
 });
 


### PR DESCRIPTION
## Summary

Pasting multi-line text was triggering one agent call per line — the partial buffer got submitted on each `\r` in the paste blob (video on the issue).

Bracketed-paste markers (DECSET 2004) don't arrive on every host. Multiplexers strip them, some web-SSH gateways drop them, certain Windows pipes never forward them. When they're missing, paste content arrives as raw bytes; each `\r` gets dispatched as an Enter event; `PromptInput` submits the partial buffer; the loop fires a fresh agent call per line.

## Fix — heuristic rescue at the parser entry point

`StdinReader.handleChunk` now wraps a chunk in synthetic `\x1b[200~ … \x1b[201~` markers before processing when **all** of these are true:

- state is `idle` (not mid-paste, mid-CSI, mid-ESC)
- chunk has 2+ line breaks, **OR** a single break with non-empty text on both sides
- chunk contains no ESC bytes (would indicate a real key sequence)
- chunk has no existing paste markers (don't double-wrap)

Routes through the existing paste accumulator → one paste event with the whole blob → `PromptInput.registerPaste` inserts it as a sentinel chip. No submit fires.

## Tradeoff is intentional

The detector errs toward paste:
- false-positive paste → user re-presses Enter (annoyance)
- false-negative paste → N agent calls on a single paste (burns money + spams the loop)

Bare `\r` and `\r\n` stay as typed-Enter (terminal-converted CRLF is one keystroke). `abc\r` stays as type-then-Enter so a fast typist's batched chunk still submits on its trailing Enter.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npx vitest run tests/stdin-reader.test.ts tests/comment-policy.test.ts` — 45 pass (9 new heuristic-rescue tests)
- [x] Pre-existing `printable run breaks at a CSI / control byte` test updated to use `\t` since `\r`/`\n` between text now route through the rescue
- [ ] Manual: paste a multi-line snippet from clipboard inside Windows Terminal / iTerm / Konsole / Cursor terminal — should land as a single `[paste #N · M lines]` chip, no extra submits

Closes #522