### PR TITLE
fix(slash): hoist hooks above early returns — stops "Rendered more hooks" crash

### DIFF
--- a/src/cli/ui/SlashSuggestions.tsx
+++ b/src/cli/ui/SlashSuggestions.tsx
@@ -40,6 +40,23 @@ export function SlashSuggestions({
   const cols = stdout?.columns ?? 80;
   const [rememberedWindowStart, setRememberedWindowStart] = React.useState(0);
 
+  // All hooks must run on every render; the early-return branches below
+  // would otherwise change hook count between renders → "Rendered more
+  // hooks than during the previous render" crash when matches flips
+  // between null/empty and non-empty.
+  const maxRows = groupMode ? GROUP_MODE_MAX_ROWS : SEARCH_MODE_MAX_ROWS;
+  const safeMatches = matches ?? [];
+  const windowStart = computeWindowStart(
+    safeMatches,
+    maxRows,
+    selectedIndex,
+    rememberedWindowStart,
+    groupMode,
+  );
+  React.useEffect(() => {
+    setRememberedWindowStart(windowStart);
+  }, [windowStart]);
+
   if (matches === null) return null;
   if (matches.length === 0) {
     return (
@@ -53,18 +70,7 @@ export function SlashSuggestions({
       </Box>
     );
   }
-  const maxRows = groupMode ? GROUP_MODE_MAX_ROWS : SEARCH_MODE_MAX_ROWS;
   const total = matches.length;
-  const windowStart = computeWindowStart(
-    matches,
-    maxRows,
-    selectedIndex,
-    rememberedWindowStart,
-    groupMode,
-  );
-  React.useEffect(() => {
-    setRememberedWindowStart(windowStart);
-  }, [windowStart]);
   const items = buildVisibleItems(matches, windowStart, maxRows, groupMode);
   const shownCommands = items.filter((item) => item.kind === "command");
   const hiddenAbove = windowStart;

--- a/tests/ui-slash-suggestions.test.tsx
+++ b/tests/ui-slash-suggestions.test.tsx
@@ -173,4 +173,42 @@ describe("SlashSuggestions", () => {
       );
     expect(visibleBodyRows.length).toBeLessThanOrEqual(24);
   });
+
+  it("survives matches null → non-empty → null transitions without a hook-order crash", () => {
+    // Reproducer for the "Rendered more hooks than during the previous
+    // render" crash: useEffect used to live AFTER the early returns, so
+    // the hook count flipped between 3 and 4 across renders.
+    const commands = makeCommands(5);
+    const { rerender, unmount } = render(
+      React.createElement(SlashSuggestions, {
+        matches: commands,
+        selectedIndex: 0,
+        groupMode: true,
+      }),
+    );
+    expect(() => {
+      rerender(
+        React.createElement(SlashSuggestions, {
+          matches: null,
+          selectedIndex: 0,
+          groupMode: true,
+        }),
+      );
+      rerender(
+        React.createElement(SlashSuggestions, {
+          matches: [],
+          selectedIndex: 0,
+          groupMode: true,
+        }),
+      );
+      rerender(
+        React.createElement(SlashSuggestions, {
+          matches: commands,
+          selectedIndex: 1,
+          groupMode: true,
+        }),
+      );
+    }).not.toThrow();
+    unmount();
+  });
 });


### PR DESCRIPTION
## Summary

`SlashSuggestions` was crashing the entire TUI mid-session with `Error: Rendered more hooks than during the previous render.` from `react-reconciler` whenever the slash-popover state flipped between an active match list and an empty / null one.

Root cause is a Rules of Hooks violation: `useColor` / `useStdout` / `useState` ran first, then **two early-return branches** (`matches === null`, `matches.length === 0`) returned before `React.useEffect` was reached. So:

- Render with non-empty matches → 4 hooks
- Render with `matches === null` → 3 hooks (early return)
- Next render with non-empty matches → 4 hooks → React detects the mismatch and throws

The slash popover is the most-touched surface in the TUI; users hit this every session by typing `/`, then a typo, then editing back, then typing again.

## Fix

Hoist `windowStart` computation + the `useEffect` above the early returns. Compute against `matches ?? []` so the math is well-defined when `matches` is null (`windowStart` resolves to 0, the effect no-ops because state already equals 0). The early-return JSX branches stay unchanged below.

## Regression test

Rerenders the component through `non-empty → null → empty → non-empty` and asserts the React reconciler does not throw. Without the fix this throws on the second non-empty render.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npx vitest run tests/ui-slash-suggestions.test.tsx` — 9 pass (1 new regression test)
- [x] Pre-push verify: build + lint + typecheck + 2397 tests
- [ ] Manual: type `/`, type a non-matching prefix, backspace back to a matching one — TUI should stay alive