### PR TITLE
docs(changelog): add slash hook-order fix to 0.36.0 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,15 @@ endpoints with non-standard key prefixes accepted.
 
 **Fixes:**
 
+- fix(slash): hoist hooks above early returns. SlashSuggestions had
+  `useColor` / `useStdout` / `useState` before two early-return
+  branches and `useEffect` after, so when matches flipped between
+  non-empty and null/empty across renders React saw a different hook
+  count and threw "Rendered more hooks than during the previous
+  render", killing the entire TUI mid-session. Triggered by everyday
+  slash editing (typo → backspace → typing again). Hoisted the
+  effect + windowStart math above the returns. (#538)
+
 - fix(tui): wheel scroll on cloud / web / SSH terminals via DECSET
   1007. Old code relied on the implicit "terminal translates
   wheel→↑/↓ in alt-screen" behavior — only on by default in xterm /


### PR DESCRIPTION
## Summary

Rolling PR #538 (slash hook-order fix) into the 0.36.0 changelog entry. Tag was created locally but not yet `npm publish`'d, so we don't need to burn a 0.36.1 version on a known-broken release — instead, this PR amends the changelog and the v0.36.0 git tag will be moved forward to this commit so the published 0.36.0 includes the fix.

## Test plan

- [x] CHANGELOG-only diff
- [ ] After merge: move v0.36.0 tag forward, then `npm publish`