### PR TITLE
fix(tui): clear ongoing tool on errors

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -2650,7 +2650,13 @@ function AppInner({
               codeModeOn: !!codeMode,
             });
           } else if (ev.role === "error") {
-            handleErrorEvent(ev, { log });
+            handleErrorEvent(ev, {
+              log,
+              setOngoingTool,
+              setToolProgress,
+              toolStartedAtRef,
+              translator,
+            });
           } else if (ev.role === "warning") {
             handleWarningEvent(ev, { log, setTurnOnPro });
           }

--- a/src/cli/ui/hooks/handle-stream-events.ts
+++ b/src/cli/ui/hooks/handle-stream-events.ts
@@ -52,9 +52,19 @@ export function handleToolStart(ev: LoopEvent, ctx: ToolStartContext): void {
 
 export interface ErrorContext {
   log: Scrollback;
+  setOngoingTool: Dispatch<SetStateAction<{ name: string; args?: string } | null>>;
+  setToolProgress: Dispatch<
+    SetStateAction<{ progress: number; total?: number; message?: string } | null>
+  >;
+  toolStartedAtRef: MutableRefObject<number | null>;
+  translator: TurnTranslator;
 }
 
 export function handleErrorEvent(ev: LoopEvent, ctx: ErrorContext): void {
+  ctx.setOngoingTool(null);
+  ctx.setToolProgress(null);
+  ctx.toolStartedAtRef.current = null;
+  ctx.translator.toolAbort(ev.error ?? ev.content);
   ctx.log.pushError("tool error", ev.error ?? ev.content);
 }
 

--- a/src/cli/ui/state/TurnTranslator.ts
+++ b/src/cli/ui/state/TurnTranslator.ts
@@ -35,6 +35,17 @@ export class TurnTranslator {
     }
   }
 
+  toolAbort(output?: string): void {
+    if (this.toolCardId) {
+      this.log.endTool(this.toolCardId, {
+        output,
+        elapsedMs: Date.now() - this.toolStartedAt,
+        aborted: true,
+      });
+      this.toolCardId = null;
+    }
+  }
+
   toolRetry(attempt: number, max: number): void {
     if (this.toolCardId) this.log.retryTool(this.toolCardId, attempt, max);
   }

--- a/tests/turn-translator.test.ts
+++ b/tests/turn-translator.test.ts
@@ -27,8 +27,15 @@ function makeMockLog(): { log: Scrollback; calls: Call[] } {
     pushWarning: record("pushWarning", () => next("warn")),
     pushError: record("pushError", () => next("err")),
     pushInfo: record("pushInfo", () => next("info")),
+    pushTip: record("pushTip", () => next("tip")),
+    pushCtxPressureIfHigh: record("pushCtxPressureIfHigh", () => undefined),
     pushStepProgress: record("pushStepProgress", () => next("step")),
     pushPlanAnnounce: record("pushPlanAnnounce", () => next("plan")),
+    showDoctor: record("showDoctor", () => next("doctor")),
+    showUsageVerbose: record("showUsageVerbose", () => next("usage")),
+    showPlan: record("showPlan", () => next("plan")),
+    completePlanStep: record("completePlanStep", () => undefined),
+    showCtx: record("showCtx", () => next("ctx")),
     startReasoning: record("startReasoning", () => next("r")),
     appendReasoning: record("appendReasoning", () => undefined),
     endReasoning: record("endReasoning", () => undefined),
@@ -42,6 +49,7 @@ function makeMockLog(): { log: Scrollback; calls: Call[] } {
     thinking: record("thinking", () => next("think")),
     abortTurn: record("abortTurn", () => undefined),
     endTurn: record("endTurn", () => undefined),
+    reset: record("reset", () => undefined),
   };
   return { log, calls };
 }
@@ -111,6 +119,16 @@ describe("TurnTranslator", () => {
     const t = new TurnTranslator(log);
     t.toolEnd("stray output");
     expect(calls).toEqual([]);
+  });
+
+  it("toolAbort closes an open tool card as aborted", () => {
+    const { log, calls } = makeMockLog();
+    const t = new TurnTranslator(log);
+    t.toolStart("read_file", { path: "src/x.ts" });
+    t.toolAbort("Error: failed");
+    const endCall = calls.find((c) => c.method === "endTool");
+    expect(endCall?.args[0]).toBe("tool-1");
+    expect(endCall?.args[1]).toMatchObject({ output: "Error: failed", aborted: true });
   });
 
   it("reasoningDone derives paragraphs and tokens from accumulated text", () => {

--- a/tests/ui-stream-events.test.ts
+++ b/tests/ui-stream-events.test.ts
@@ -1,0 +1,77 @@
+import type { SetStateAction } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { handleErrorEvent, handleToolStart } from "../src/cli/ui/hooks/handle-stream-events.js";
+import type { Scrollback } from "../src/cli/ui/hooks/useScrollback.js";
+import type { TurnTranslator } from "../src/cli/ui/state/TurnTranslator.js";
+import type { LoopEvent } from "../src/loop.js";
+
+type OngoingTool = { name: string; args?: string } | null;
+type ToolProgress = { progress: number; total?: number; message?: string } | null;
+
+function applyState<T>(current: T, next: SetStateAction<T>): T {
+  return typeof next === "function" ? (next as (prev: T) => T)(current) : next;
+}
+
+describe("stream event handlers", () => {
+  it("clears the ongoing tool row when an error interrupts a tool", () => {
+    let ongoingTool: OngoingTool = null;
+    let toolProgress: ToolProgress = { progress: 1, message: "working" };
+    const toolStartedAtRef = { current: null as number | null };
+    const setOngoingTool = vi.fn((next: SetStateAction<OngoingTool>) => {
+      ongoingTool = applyState(ongoingTool, next);
+    });
+    const setToolProgress = vi.fn((next: SetStateAction<ToolProgress>) => {
+      toolProgress = applyState(toolProgress, next);
+    });
+    const translator = {
+      toolStart: vi.fn(),
+      toolAbort: vi.fn(),
+    } as unknown as TurnTranslator;
+    const log = {
+      pushError: vi.fn(() => "err-1"),
+    } as unknown as Scrollback;
+
+    handleToolStart(
+      {
+        turn: 1,
+        role: "tool_start",
+        content: "",
+        toolName: "read_file",
+        toolArgs: '{"path":"src/x.ts"}',
+      } satisfies LoopEvent,
+      {
+        setOngoingTool,
+        setToolProgress,
+        toolStartedAtRef,
+        translator,
+        codeModeOn: false,
+        recordRecentFile: vi.fn(),
+      },
+    );
+
+    expect(ongoingTool).toEqual({ name: "read_file", args: '{"path":"src/x.ts"}' });
+    expect(toolStartedAtRef.current).not.toBeNull();
+
+    handleErrorEvent(
+      {
+        turn: 1,
+        role: "error",
+        content: "",
+        error: "Error: tool crashed",
+      } satisfies LoopEvent,
+      {
+        log,
+        setOngoingTool,
+        setToolProgress,
+        toolStartedAtRef,
+        translator,
+      },
+    );
+
+    expect(ongoingTool).toBeNull();
+    expect(toolProgress).toBeNull();
+    expect(toolStartedAtRef.current).toBeNull();
+    expect(translator.toolAbort).toHaveBeenCalledWith("Error: tool crashed");
+    expect(log.pushError).toHaveBeenCalledWith("tool error", "Error: tool crashed");
+  });
+});


### PR DESCRIPTION
## What

Clear the live ongoing-tool state when the loop emits an error while a tool card is active. This adds a small `TurnTranslator.toolAbort()` helper so error handling can close the current tool card defensively without treating the whole turn as a user abort.

## Why

Fixes #535. If an error interrupts a tool after `tool_start`, the TUI could leave the loading marker / ongoing tool row visible because the error path only logged the error and did not clear the tool-running state.

## How to verify

- `npm run verify`
- `npm run test -- tests/ui-stream-events.test.ts tests/turn-translator.test.ts`
- `npx biome check src/cli/ui/hooks/handle-stream-events.ts src/cli/ui/App.tsx src/cli/ui/state/TurnTranslator.ts tests/ui-stream-events.test.ts tests/turn-translator.test.ts`
- `npm run typecheck`

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time