### PR TITLE
feat(tui): phase-aware label for the busy-fallback activity row

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -116,6 +116,7 @@ import {
   handleWarningEvent,
 } from "./hooks/handle-stream-events.js";
 import { handleToolEvent } from "./hooks/handle-tool-event.js";
+import { useActivityLabel } from "./hooks/useActivityPhase.js";
 import { useAgentSession } from "./hooks/useAgentSession.js";
 import { useChatScroll } from "./hooks/useChatScroll.js";
 import { useCodeMode } from "./hooks/useCodeMode.js";
@@ -341,6 +342,7 @@ function AppInner({
     s.cards.some((c) => c.kind === "user" || c.kind === "streaming"),
   );
   const isStreaming = useAgentState((s) => s.cards.some((c) => c.kind === "streaming" && !c.done));
+  const activityLabel = useActivityLabel();
   const chatScroll = useChatScroll();
   const [input, setInput] = useState("");
   const [busy, setBusy] = useState(false);
@@ -3423,14 +3425,7 @@ function AppInner({
                 !pendingCheckpoint ? (
                   <UndoBanner banner={undoBanner} />
                 ) : null}
-                {/*
-          Belt-and-suspenders fallback: if we're busy but NONE of the
-          specific indicators (streaming, ongoingTool, statusLine) is
-          visible, something is still happening — show a generic
-          "processing…" so the user never stares at a silent ticker
-          without a label. Catches micro-gaps between events that the
-          targeted status lines don't cover.
-        */}
+                {/* Activity row when no targeted indicator is visible — phase label from useActivityLabel. */}
                 {!PLAIN_UI &&
                 !pendingShell &&
                 !pendingPlan &&
@@ -3444,7 +3439,7 @@ function AppInner({
                 !isStreaming &&
                 !ongoingTool &&
                 !statusLine ? (
-                  <ThinkingRow text="processing…" />
+                  <ThinkingRow text={activityLabel} />
                 ) : null}
                 {!PLAIN_UI &&
                 !pendingShell &&

--- a/src/cli/ui/hooks/useActivityPhase.ts
+++ b/src/cli/ui/hooks/useActivityPhase.ts
@@ -1,0 +1,13 @@
+import type { Card } from "../state/cards.js";
+import { useAgentState } from "../state/provider.js";
+
+export function deriveActivityLabel(cards: ReadonlyArray<Card>): string {
+  if (cards.some((c) => c.kind === "reasoning" && c.streaming)) return "thinking…";
+  const last = cards[cards.length - 1];
+  if (!last || last.kind === "user") return "waiting for model…";
+  return "processing…";
+}
+
+export function useActivityLabel(): string {
+  return useAgentState((s) => deriveActivityLabel(s.cards));
+}

--- a/tests/activity-phase.test.ts
+++ b/tests/activity-phase.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { deriveActivityLabel } from "../src/cli/ui/hooks/useActivityPhase.js";
+import type { Card } from "../src/cli/ui/state/cards.js";
+
+function user(id: string): Card {
+  return { id, ts: 0, kind: "user", text: "" };
+}
+function reasoning(id: string, streaming: boolean): Card {
+  return { id, ts: 0, kind: "reasoning", text: "", paragraphs: 0, tokens: 0, streaming };
+}
+function tool(id: string, done: boolean): Card {
+  return { id, ts: 0, kind: "tool", name: "read_file", args: {}, output: "", done, elapsedMs: 0 };
+}
+function streaming(id: string, done: boolean): Card {
+  return { id, ts: 0, kind: "streaming", text: "", done };
+}
+
+describe("deriveActivityLabel", () => {
+  it("returns 'waiting for model…' when only the user card exists", () => {
+    expect(deriveActivityLabel([user("u1")])).toBe("waiting for model…");
+  });
+
+  it("returns 'waiting for model…' when card list is empty", () => {
+    expect(deriveActivityLabel([])).toBe("waiting for model…");
+  });
+
+  it("returns 'thinking…' while a reasoning card is streaming", () => {
+    expect(deriveActivityLabel([user("u1"), reasoning("r1", true)])).toBe("thinking…");
+  });
+
+  it("returns 'processing…' once reasoning has settled but no follow-up card exists yet", () => {
+    expect(deriveActivityLabel([user("u1"), reasoning("r1", false)])).toBe("processing…");
+  });
+
+  it("returns 'processing…' between a finished tool and the next event", () => {
+    expect(deriveActivityLabel([user("u1"), tool("t1", true)])).toBe("processing…");
+  });
+
+  it("prefers 'thinking…' even when a settled reasoning card sits later in the list", () => {
+    expect(deriveActivityLabel([user("u1"), reasoning("r1", true), reasoning("r2", false)])).toBe(
+      "thinking…",
+    );
+  });
+
+  it("returns 'processing…' when the last card is a streaming content card", () => {
+    expect(deriveActivityLabel([user("u1"), streaming("s1", false)])).toBe("processing…");
+  });
+});


### PR DESCRIPTION
## What

Stage 1 of the #367 visibility fix. Replaces the generic `processing…` label on the fallback `ThinkingRow` with a phase-aware label derived from the current card stream:

| State | Label |
|---|---|
| A reasoning card is streaming | `thinking…` |
| Last card is the user message (no model output yet) | `waiting for model…` |
| Anything else | `processing…` (preserves prior behavior) |

New `useActivityLabel()` hook in `src/cli/ui/hooks/useActivityPhase.ts` — pure `deriveActivityLabel(cards)` derivation behind a `useAgentState` selector that returns a primitive string (so React's `useSyncExternalStore` doesn't re-render on every tick).

## Why

[#367](https://github.com/esengine/DeepSeek-Reasonix/issues/367) — users reported they "can't tell what Reasonix is doing while waiting." The `App.tsx:3434` fallback already covered the "is anything happening" gap with `processing…`, but the label was the same regardless of phase, so during reasoning streaming, between tool calls, or while waiting for the first byte, the user saw the same word. Phase-specific labels close the complaint without restructuring `LiveRows`, scrollback, or cards.

Plan for Stages 2 (recent-tools trail) and 3 (sticky reasoning preview) is in [the issue comment](https://github.com/esengine/DeepSeek-Reasonix/issues/367#issuecomment-4412938937) — deferred until we see whether Stage 1 alone is enough.

## How to verify

- `npm run verify` — 150 files / 2404 tests (7 new tests in `tests/activity-phase.test.ts`)
- Manual: launch `reasonix code`, send a prompt, watch the live row above PromptInput cycle through `waiting for model…` → `thinking…` (during reasoning) → tool spinner → `processing…` between events

## Checklist

- [x] `npm run verify` passes locally
- [x] No `Co-Authored-By: Claude` trailer
- [x] Comments follow CONTRIBUTING.md
- [x] No edits to `CHANGELOG.md`

Refs #367
