### PR TITLE
fix(slash): use frequency-sorted list when picking by index on Enter

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -2100,7 +2100,7 @@ function AppInner({
       // input when they know what they want).
       if (text.startsWith("/") && !text.includes(" ")) {
         const typed = text.slice(1).toLowerCase();
-        const matches = suggestSlashCommands(typed, !!codeMode);
+        const matches = suggestSlashCommands(typed, !!codeMode, slashUsage);
         const exact = matches.find((m) => m.cmd === typed);
         if (!exact && matches.length > 0) {
           const chosen = matches[slashSelected] ?? matches[0];
@@ -2723,6 +2723,7 @@ function AppInner({
       planMode,
       session,
       slashSelected,
+      slashUsage,
       atState,
       atSelected,
       pickAtMention,


### PR DESCRIPTION
## Summary

The slash-suggestion picker displayed commands sorted by usage frequency (`slashUsage`), but the Enter-time substitution in `handleSubmit` recomputed the list **without** `slashUsage`, so it fell back to insertion order. The shared `slashSelected` index was then dereferenced against a differently-ordered list, picking a different command than the row the user had highlighted.

Fix: pass `slashUsage` to the second call so both lists agree, and add it to the `useCallback` dep array.

## Test plan

- [x] `npm test` — 2404 passing
- [x] Manual: type `/`, navigate, press Enter — selected row matches what runs