### PR TITLE
fix(tui): break scrollRows ↔ outer.height feedback that crashed CardStream

### DIFF
--- a/src/cli/ui/layout/CardStream.tsx
+++ b/src/cli/ui/layout/CardStream.tsx
@@ -8,11 +8,7 @@ import { FG } from "../theme/tokens.js";
 
 /**
  * Row-precision virtual scroll: outer Box clips with overflow="hidden",
- * inner Box holds all cards and slides up via negative marginTop. Yoga
- * computes inner height from card layout; useBoxMetrics reports it back
- * so App can clamp scroll bounds. New cards arriving while the user is
- * scrolled up sit below the visible window — bytes outside outer bounds
- * aren't written, so terminal text selection survives streaming activity.
+ * inner Box holds all cards and slides up via negative marginTop.
  */
 export function CardStream({
   scrollRows,
@@ -24,9 +20,6 @@ export function CardStream({
   suppressLive?: boolean;
 }): React.ReactElement {
   const cards = useAgentState((s) => s.cards);
-  // useBoxMetrics types its ref as RefObject<DOMElement> (non-null); the
-  // null! assertion satisfies the signature — Ink populates the ref on
-  // mount before the metrics hook reads it.
   const outerRef = useRef<DOMElement>(null!);
   const innerRef = useRef<DOMElement>(null!);
   const outer = useBoxMetrics(outerRef);
@@ -44,7 +37,10 @@ export function CardStream({
 
   return (
     <>
-      {scrollRows > 0 ? <Text color={FG.faint}>{" ↑ earlier — PgUp / wheel / ↑"}</Text> : null}
+      {/* Always reserve the row — making it conditional ties outer.height to scrollRows and closes a setState loop with pinned mode. */}
+      <Box height={1} flexShrink={0}>
+        {scrollRows > 0 ? <Text color={FG.faint}>{" ↑ earlier — PgUp / wheel / ↑"}</Text> : null}
+      </Box>
       <Box ref={outerRef} flexDirection="column" flexGrow={1} overflow="hidden">
         <Box ref={innerRef} flexDirection="column" marginTop={-scrollRows} flexShrink={0}>
           {visible.map((card) => (


### PR DESCRIPTION
A user reported the TUI crashing with `Maximum update depth exceeded`,
thrown from inside ink's `useBoxMetrics` (`use-box-metrics.js:51`,
called from `emitLayoutListeners` → `resetAfterCommit`).

## Reproducer

User says it triggers intermittently when invoking `/model` or
`/sessions`. Both commands mount a picker as a flex sibling of
`CardStream`'s column, so `outer.height` drops by however many rows the
picker claims — often 10+. That layout shock is what pushes the latent
loop below past React's nesting cap.

## Root cause

`CardStream` measures the outer Box via `useBoxMetrics`, computes
`maxScroll = inner.height - outer.height`, and pushes it up to
`useChatScroll`. In pinned mode, `useChatScroll` writes that value back
as `scrollRows`. The component then uses `scrollRows` for **two**
things:

1. `marginTop={-scrollRows}` on the inner Box — intended.
2. The `↑ earlier` hint, conditionally rendered as a **sibling of the
   measured outer Box** when `scrollRows > 0` — accidental feedback.

Toggling the hint shifts `outer.height` by one row, so the loop is:

```
scrollRows > 0 → hint visible → outer.height shrinks
              → maxScroll grows → pinned writes scrollRows = maxScroll
              → hint stays / re-evaluates
```

Each cycle is a few renders. Steady-state it converges. But when
`/model` or `/sessions` mounts and `outer.height` jumps from full
viewport to a few rows in a single commit, the cascade of pinned
writes + measurement updates + the hint flip stacks deep enough to
trip React's `MAX_NESTED_UPDATES = 50` from inside the
`useBoxMetrics` post-commit `setMetrics`.

## Fix

Reserve the hint row unconditionally with `<Box height={1}>`, with the
text content still gated on `scrollRows > 0`. `outer.height` is now
independent of `scrollRows`, so the loop is broken at its source — the
modal-mount layout shock no longer feeds back into hint visibility.

The trade is one row of permanent reservation at the top of the chat
viewport. Worth it.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 2404 passed, 2 skipped
- [ ] Smoke: open `/model` and `/sessions` repeatedly with a long chat
      history scrolled to the bottom — confirm no crash
- [ ] Smoke: stream a long reply, scroll up/down with PgUp/PgDn/wheel,
      confirm hint shows when scrolled and the reserved row is empty
      when at bottom