### PR TITLE
fix(tui): flush pending modals + cancel pauseGate on Esc and /new

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -1284,16 +1284,11 @@ function AppInner({
     if (key.escape && busy) {
       if (abortedThisTurn.current) return;
       abortedThisTurn.current = true;
-      // If an edit-review modal is up, resolve its promise first so the
-      // interceptor unblocks — otherwise the tool call hangs past the
-      // loop's abort and the next turn can't start. Esc during modal =
-      // "reject this edit" (safe default — nothing lands on disk).
-      const resolve = editReviewResolveRef.current;
-      if (resolve) {
-        editReviewResolveRef.current = null;
-        setPendingEditReview(null);
-        resolve({ choice: "reject" });
-      }
+      // Flush every pending modal + cancel the awaiting tool fn behind
+      // it. pauseGate.ask doesn't watch AbortSignal, so without this a
+      // plan_checkpoint / plan_proposed / choice / shell modal would
+      // strand its tool fn and busy would never clear.
+      resetPendingModals();
       // Esc during a busy turn also kills any active /loop — the user
       // is taking over. Loops persist past plain Esc when the system is
       // idle so a long-cadence loop doesn't die from random key noise.
@@ -2374,6 +2369,7 @@ function AppInner({
           stopLoop,
           quitProcess,
           pushHistory,
+          resetPendingModals,
           text,
         });
         if (outcome.kind === "resubmit") {
@@ -2809,6 +2805,28 @@ function AppInner({
   /** Holds the PauseGate request id for the current modal so
    *  handlePlanConfirm / handleCheckpointResponse / etc. can resolve it. */
   const pendingGateIdRef = useRef<number | null>(null);
+
+  /** Bail out of every pending modal + the awaiting tool fn behind it.
+   *  Called by Esc-during-busy and by /new — without this, a tool stuck
+   *  on `pauseGate.ask` ignores the AbortSignal and the turn never ends. */
+  const resetPendingModals = useCallback(() => {
+    const editResolve = editReviewResolveRef.current;
+    if (editResolve) {
+      editReviewResolveRef.current = null;
+      setPendingEditReview(null);
+      editResolve({ choice: "reject" });
+    }
+    setPendingShell(null);
+    setPendingPlan(null);
+    setPendingCheckpoint(null);
+    setPendingRevision(null);
+    setPendingChoice(null);
+    setStagedInput(null);
+    setStagedChoiceCustom(null);
+    setStagedCheckpointRevise(null);
+    pendingGateIdRef.current = null;
+    pauseGate.cancelAll();
+  }, []);
 
   // Drain the shell-confirm queue after the in-flight turn tears down.
   // React closure staleness means handleShellConfirm can't just await

--- a/src/cli/ui/hooks/apply-slash-result.ts
+++ b/src/cli/ui/hooks/apply-slash-result.ts
@@ -17,6 +17,8 @@ export interface ApplySlashResultContext {
   stopLoop: () => void;
   quitProcess: () => void;
   pushHistory: (text: string) => void;
+  /** Flush pending modals + cancel awaiting pauseGate requests on /new — without this a stuck plan_checkpoint survives the wipe. */
+  resetPendingModals?: () => void;
   /** The verbatim text the user typed; used for promptHistory bookkeeping. */
   text: string;
 }
@@ -32,6 +34,7 @@ export function applySlashResult(result: SlashResult, ctx: ApplySlashResultConte
     return { kind: "consumed" };
   }
   if (result.clear) {
+    ctx.resetPendingModals?.();
     // 2J + 3J + H: visible buffer + scrollback + cursor home.
     ctx.stdoutWrite("\x1b[2J\x1b[3J\x1b[H");
     ctx.log.reset();

--- a/src/core/pause-gate.ts
+++ b/src/core/pause-gate.ts
@@ -116,6 +116,17 @@ export class PauseGate {
     p.resolve(data);
   }
 
+  /** Safe-cancel every outstanding request — frees stranded tool fns on Esc / /new. */
+  cancelAll(): void {
+    const ids = [...this._pending.keys()];
+    for (const id of ids) {
+      const p = this._pending.get(id);
+      if (!p) continue;
+      this._pending.delete(id);
+      p.resolve(safeCancelVerdict(p.request.kind));
+    }
+  }
+
   setAuditListener(fn: AuditListener | null): void {
     this._auditListener = fn;
   }
@@ -171,6 +182,22 @@ export class PauseGate {
     } catch {
       /* audit path must never break the gate */
     }
+  }
+}
+
+function safeCancelVerdict(kind: PauseKind): unknown {
+  switch (kind) {
+    case "run_command":
+    case "run_background":
+      return { type: "deny" };
+    case "plan_proposed":
+      return { type: "cancel" };
+    case "plan_checkpoint":
+      return { type: "stop" };
+    case "plan_revision":
+      return { type: "cancelled" };
+    case "choice":
+      return { type: "cancel" };
   }
 }
 

--- a/tests/pause-gate.test.ts
+++ b/tests/pause-gate.test.ts
@@ -183,6 +183,36 @@ describe("PauseGate", () => {
     ]);
   });
 
+  it("cancelAll resolves every pending request with its kind's safe-cancel verdict", async () => {
+    const gate = new PauseGate();
+    gate.on(() => {});
+
+    const shell = gate.ask({ kind: "run_command", payload: { command: "rm -rf /" } });
+    const plan = gate.ask({ kind: "plan_proposed", payload: { plan: "#", steps: [] } });
+    const cp = gate.ask({ kind: "plan_checkpoint", payload: { stepId: "s1", result: "ok" } });
+    const rev = gate.ask({ kind: "plan_revision", payload: { reason: "r", remainingSteps: [] } });
+    const ch = gate.ask({
+      kind: "choice",
+      payload: { question: "q", options: [], allowCustom: false },
+    });
+
+    gate.cancelAll();
+
+    await expect(shell).resolves.toEqual({ type: "deny" });
+    await expect(plan).resolves.toEqual({ type: "cancel" });
+    await expect(cp).resolves.toEqual({ type: "stop" });
+    await expect(rev).resolves.toEqual({ type: "cancelled" });
+    await expect(ch).resolves.toEqual({ type: "cancel" });
+    expect(gate.current).toBeNull();
+  });
+
+  it("cancelAll on an empty gate is a no-op", () => {
+    const gate = new PauseGate();
+    gate.on(() => {});
+    expect(() => gate.cancelAll()).not.toThrow();
+    expect(gate.current).toBeNull();
+  });
+
   it("does not emit audit events for non-tool pauses", async () => {
     const gate = new PauseGate();
     const audit = vi.fn();


### PR DESCRIPTION
A user reported a stuck-task pattern: the plan card freezes at \`0/N
done\`, can't be dismissed, and \`/new\` doesn't clear it either.

## Reproducer

The model proposes a plan, the user approves, the model calls a tool
that goes through pauseGate (e.g. \`mark_step_complete\` →
\`plan_checkpoint\`). Either the modal mounts and the user closes the
terminal modal in some way that misses the resolve, or the modal mounts
but the user wants to bail out via Esc / \`/new\`.

## Root cause

\`PauseGate.ask()\` returns a Promise that ignores AbortSignal — it only
resolves when someone calls \`gate.resolve(id, verdict)\`. Three knock-on
problems:

1. **Esc during busy** runs \`loop.abort()\`, which aborts the turn's
   AbortController. The model fetch path bails on \`signal.aborted\`,
   but the \`await pauseGate.ask(...)\` inside a tool fn doesn't see
   the signal — the tool fn stays awaiting forever.
2. With the tool fn stuck, the loop's \`for-await\` stays awaiting,
   \`busy\` stays \`true\`, and \`<PromptInput disabled={busy}>\` stays
   disabled. The user can't type.
3. Even when the user does manage to type \`/new\`, \`handleSubmit\`'s
   \`if (busy) return\` (App.tsx:2066) silently drops it.

The plan card the user sees frozen at \`0/N done\` is the visible
manifestation of the awaiting tool fn behind it.

## Fix

- Add \`pauseGate.cancelAll()\` that resolves every outstanding request
  with its kind's safe-cancel verdict (\`run_command\` → \`deny\`,
  \`plan_proposed\` → \`cancel\`, \`plan_checkpoint\` → \`stop\`,
  \`plan_revision\` → \`cancelled\`, \`choice\` → \`cancel\`). Awaiting tool
  fns return or throw cleanly.
- Add a \`resetPendingModals\` helper in App.tsx that clears every
  \`setPending*\` modal state and calls \`pauseGate.cancelAll()\`.
- Wire it into:
  - **Esc-during-busy** — replaces the prior edit-review-only cleanup.
  - **\`/new\`** — \`apply-slash-result\`'s \`result.clear\` branch now
    calls it before \`log.reset()\`, so the wipe is atomic.

After the fix:
- Esc during a stuck plan_checkpoint flushes the gate → the tool's
  await returns with \`{type: "stop"}\` → \`mark_step_complete\` throws
  → the loop's \`signal.aborted\` check catches the next iter → busy
  clears → prompt re-enables.
- \`/new\` (issued after Esc, since it still respects the busy gate)
  now also flushes any modals/gate state that survived a partial
  cleanup.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npx vitest run\` — 2406 passed, 2 skipped (added 2 cancelAll
      tests in \`tests/pause-gate.test.ts\`)
- [ ] Smoke: start a plan, when the checkpoint modal mounts hit Esc —
      confirm modal closes, prompt re-enables, busy spinner stops
- [ ] Smoke: same scenario but type \`/new\` after Esc — confirm cards
      wipe and no plan card returns