### PR TITLE
fix(dashboard): kill chat-tab freeze under long sessions / concurrent jobs

### DIFF
--- a/dashboard/src/components/chat-internals.ts
+++ b/dashboard/src/components/chat-internals.ts
@@ -1,4 +1,5 @@
 import { marked } from "marked";
+import { memo } from "preact/compat";
 import { useState } from "preact/hooks";
 import { html } from "../lib/html.js";
 import { t, useLang } from "../i18n/index.js";
@@ -300,7 +301,11 @@ export function ToolCard({ msg }: ToolCardProps) {
   `;
 }
 
-export function ChatMessage({ msg, streaming }: ChatMessageProps) {
+// memo() short-circuits re-renders when shallow props are unchanged.
+// Historical messages keep stable msg references across deltas, so the
+// O(N) marked.parse + hljs work that used to fire per assistant_delta
+// now only runs on truly new messages and the live streaming bubble.
+export const ChatMessage = memo(function ChatMessage({ msg, streaming }: ChatMessageProps) {
   const role = msg.role;
   const glyph = ROLE_GLYPH[role as ChatRole] ?? "·";
   if (role === "tool") {
@@ -321,7 +326,7 @@ export function ChatMessage({ msg, streaming }: ChatMessageProps) {
       </div>
     </div>
   `;
-}
+});
 
 //
 // Each component renders a card matching the TUI's ModalCard accent

--- a/dashboard/src/panels/chat.ts
+++ b/dashboard/src/panels/chat.ts
@@ -185,6 +185,26 @@ export function ChatPanel() {
     };
   }, []);
 
+  // rAF-coalesce assistant_delta events. A streaming turn fires ~20
+  // deltas/sec — committing each to React state forces a parent
+  // re-render per delta, which used to thrash the chat feed. Now the
+  // accumulated text lives in a ref and we flush at most once per
+  // frame, capping the streaming-bubble re-render rate at the display
+  // refresh rate. assistant_final cancels the pending flush.
+  const streamBufRef = useRef<StreamingState | null>(null);
+  const streamRafRef = useRef<number | null>(null);
+  const flushStreaming = useCallback(() => {
+    streamRafRef.current = null;
+    if (streamBufRef.current) setStreaming(streamBufRef.current);
+  }, []);
+  const cancelStreamingRaf = useCallback(() => {
+    if (streamRafRef.current !== null) {
+      cancelAnimationFrame(streamRafRef.current);
+      streamRafRef.current = null;
+    }
+    streamBufRef.current = null;
+  }, []);
+
   // SSE reconnect drops missed deltas / finals / modals — server only
   // snapshots `busy-change` on (re)connect. Pull /messages + /modal to
   // recover canonical state, otherwise UI wedges on the last seen state (#521).
@@ -193,6 +213,7 @@ export function ChatPanel() {
       const data = await api<MessagesResponse>("/messages");
       setMessages(data.messages ?? []);
       setBusy(Boolean(data.busy));
+      cancelStreamingRaf();
       setStreaming(null);
       setActiveTool(null);
     } catch {
@@ -204,7 +225,7 @@ export function ChatPanel() {
     } catch {
       /* modal endpoint optional in standalone */
     }
-  }, []);
+  }, [cancelStreamingRaf]);
 
   useEffect(() => {
     const es = new EventSource(`/api/events?token=${TOKEN}`);
@@ -233,14 +254,20 @@ export function ChatPanel() {
         return;
       }
       if (dash.kind === "assistant_delta") {
-        setStreaming((cur) => {
-          const text = (cur?.text ?? "") + (dash.contentDelta ?? "");
-          const reasoning = (cur?.reasoning ?? "") + (dash.reasoningDelta ?? "");
-          return { id: dash.id, text, reasoning };
-        });
+        const cur = streamBufRef.current;
+        const baseId = cur?.id === dash.id ? cur : null;
+        streamBufRef.current = {
+          id: dash.id,
+          text: (baseId?.text ?? "") + (dash.contentDelta ?? ""),
+          reasoning: (baseId?.reasoning ?? "") + (dash.reasoningDelta ?? ""),
+        };
+        if (streamRafRef.current === null) {
+          streamRafRef.current = requestAnimationFrame(flushStreaming);
+        }
         return;
       }
       if (dash.kind === "assistant_final") {
+        cancelStreamingRaf();
         setStreaming(null);
         setMessages((prev) => [
           ...prev,
@@ -300,8 +327,11 @@ export function ChatPanel() {
       setError(t("chat.eventStreamError"));
       setTimeout(() => setError(null), 3000);
     };
-    return () => es.close();
-  }, [refetchCanonicalState]);
+    return () => {
+      es.close();
+      cancelStreamingRaf();
+    };
+  }, [refetchCanonicalState, cancelStreamingRaf]);
 
   const send = useCallback(async () => {
     const text = input.trim();
@@ -737,7 +767,7 @@ export function ChatPanel() {
                       <${ChatMessage}
                         key=${m.id}
                         msg=${m}
-                        streaming=${streaming && streaming.id === m.id}
+                        streaming=${Boolean(streaming && streaming.id === m.id)}
                       />
                     `,
                   )


### PR DESCRIPTION
A user reported the embedded dashboard's chat tab triggering Chrome's
\"Page not responding\" dialog during long active sessions, especially
with concurrent jobs streaming at the same time. Profiled the chat
feed's hot path on a synthetic long session.

## Root cause — two cooperating bugs

1. **Per-delta re-render of every historical message.**
   Every \`assistant_delta\` event called \`setStreaming\` synchronously.
   The model streams ~20 deltas/sec; concurrent jobs add more events
   on top. Each setState re-rendered \`ChatPanel\`, which \`.map\`'d
   over every historical \`ChatMessage\` with **no memoization**. So
   each delta re-ran \`marked.parse\` per message, plus
   \`hljs.highlight\` on every \`ToolCard\` — on UNCHANGED content.
   Long session = N messages grows monotonically = main thread starves.
2. **Memo-defeating prop instability across streaming transitions.**
   The per-row streaming prop was passed as
   \`streaming && streaming.id === m.id\` — that produces \`null\` when
   no turn is streaming and \`false\` when one is streaming but not
   this message. Memo's shallow compare treats \`null !== false\` as a
   change, so even after memoizing, every historical row would
   re-render the moment a turn started or stopped.

## Fix (\`dashboard/src/\`, +46 / −11)

- **Memoize \`ChatMessage\`** via \`memo\` from \`preact/compat\`. Historical
  messages keep stable \`msg\` references across deltas → bail out.
- **Cast the per-row streaming prop to a boolean** so historical rows
  see a stable \`false\` across the streaming-on/off transition.
- **rAF-coalesce \`assistant_delta\`** in \`chat.ts\`. Accumulated text
  lives in a ref and we flush at most once per animation frame —
  capping the streaming-bubble re-render rate at the display refresh
  rate regardless of delta volume. \`assistant_final\` + SSE reconnect
  + unmount each cancel the pending flush so the buffer can't leak
  across turns.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run build\` (dashboard bundle compiles)
- [x] \`npx vitest run\` — 2406 passed, 2 skipped (no test churn)
- [ ] Smoke: open a long session in Chrome, ask the model for a 8k+
      char response, verify no \"Page not responding\" prompt during
      streaming
- [ ] Smoke: with 3+ concurrent \`run_background\` jobs running, leave
      the dashboard tab open for several minutes — confirm no freeze

Closes #551