### PR TITLE
fix(loop): derive tool-card running state from finally-guarded inflight set

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -150,6 +150,7 @@ import { type McpServerSummary, handleSlash, parseSlash, suggestSlashCommands } 
 import { TurnTranslator } from "./state/TurnTranslator.js";
 import { cardsToDashboardMessages } from "./state/cards-to-messages.js";
 import { hydrateCardsFromMessages } from "./state/hydrate.js";
+import { InflightProvider } from "./state/inflight-context.js";
 import { AgentStoreProvider, useAgentState, useAgentStore } from "./state/provider.js";
 import { ThemeProvider } from "./theme/context.js";
 import { FG } from "./theme/tokens.js";
@@ -3359,419 +3360,421 @@ function AppInner({
     <>
       <TickerProvider disabled={tickerSuspended}>
         <ViewportBudgetProvider>
-          <Box flexDirection="row" height={stdout?.rows ?? 24}>
-            <Box flexDirection="column" flexGrow={1}>
+          <InflightProvider inflight={loop.inflight}>
+            <Box flexDirection="row" height={stdout?.rows ?? 24}>
               <Box flexDirection="column" flexGrow={1}>
-                <LiveExpandContext.Provider value={liveExpand}>
-                  <CardStream
-                    suppressLive={modalOpen}
-                    scrollRows={chatScroll.scrollRows}
-                    onMaxScrollChange={chatScroll.setMaxScroll}
-                  />
-                </LiveExpandContext.Provider>
-                {/*
+                <Box flexDirection="column" flexGrow={1}>
+                  <LiveExpandContext.Provider value={liveExpand}>
+                    <CardStream
+                      suppressLive={modalOpen}
+                      scrollRows={chatScroll.scrollRows}
+                      onMaxScrollChange={chatScroll.setMaxScroll}
+                    />
+                  </LiveExpandContext.Provider>
+                  {/*
           Welcome card on the empty state. Visible only when nothing
           has happened yet (no past events, nothing in flight, no
           modal up). Removes the "what do I type?" friction without
           surviving past the first turn.
         */}
-                {!hasConversation && !busy && !isStreaming ? (
-                  <WelcomeBanner
-                    inCodeMode={!!codeMode}
-                    workspaceRoot={codeMode ? currentRootDir : undefined}
-                    dashboardUrl={dashboardUrl}
-                    languageVersion={languageVersion}
-                  />
-                ) : null}
-                {/*
+                  {!hasConversation && !busy && !isStreaming ? (
+                    <WelcomeBanner
+                      inCodeMode={!!codeMode}
+                      workspaceRoot={codeMode ? currentRootDir : undefined}
+                      dashboardUrl={dashboardUrl}
+                      languageVersion={languageVersion}
+                    />
+                  ) : null}
+                  {/*
           Live rows are hidden while the ShellConfirm modal is up — the
           model's concurrent "please confirm" stream is noise the user
           doesn't need, and the picker shouldn't fight it for visual
           attention. They come back naturally once the user chooses and
           the next turn begins.
         */}
-                {!PLAIN_UI &&
-                !pendingShell &&
-                !pendingPlan &&
-                !pendingReviseEditor &&
-                !pendingSessionsPicker &&
-                !pendingCheckpointPicker &&
-                !pendingMcpHub &&
-                !stagedInput &&
-                !pendingEditReview &&
-                ongoingTool ? (
-                  <OngoingToolRow tool={ongoingTool} progress={toolProgress} />
-                ) : null}
-                {!PLAIN_UI &&
-                !pendingShell &&
-                !pendingPlan &&
-                !pendingReviseEditor &&
-                !pendingSessionsPicker &&
-                !pendingCheckpointPicker &&
-                !pendingMcpHub &&
-                !stagedInput &&
-                !pendingEditReview &&
-                subagentActivities.length > 0 ? (
-                  <SubagentLiveStack activities={subagentActivities} max={3} />
-                ) : null}
-                {!PLAIN_UI &&
-                !pendingShell &&
-                !pendingPlan &&
-                !pendingReviseEditor &&
-                !pendingSessionsPicker &&
-                !pendingCheckpointPicker &&
-                !pendingMcpHub &&
-                !stagedInput &&
-                !pendingEditReview &&
-                !ongoingTool &&
-                statusLine ? (
-                  <ThinkingRow text={statusLine} />
-                ) : null}
-                {!PLAIN_UI &&
-                undoBanner &&
-                !pendingShell &&
-                !pendingPlan &&
-                !pendingReviseEditor &&
-                !pendingSessionsPicker &&
-                !pendingCheckpointPicker &&
-                !pendingMcpHub &&
-                !stagedInput &&
-                !pendingEditReview &&
-                !pendingChoice &&
-                !stagedChoiceCustom &&
-                !pendingRevision &&
-                !stagedCheckpointRevise &&
-                !pendingCheckpoint ? (
-                  <UndoBanner banner={undoBanner} />
-                ) : null}
-                {/* Activity row when no targeted indicator is visible — phase label from useActivityLabel. */}
-                {!PLAIN_UI &&
-                !pendingShell &&
-                !pendingPlan &&
-                !pendingReviseEditor &&
-                !pendingSessionsPicker &&
-                !pendingCheckpointPicker &&
-                !pendingMcpHub &&
-                !stagedInput &&
-                !pendingEditReview &&
-                busy &&
-                !isStreaming &&
-                !ongoingTool &&
-                !statusLine ? (
-                  <ThinkingRow text={activityLabel} />
-                ) : null}
-                {!PLAIN_UI &&
-                !pendingShell &&
-                !pendingPlan &&
-                !pendingReviseEditor &&
-                !pendingSessionsPicker &&
-                !pendingCheckpointPicker &&
-                !pendingMcpHub &&
-                !stagedInput &&
-                !pendingEditReview ? (
-                  <PlanLiveRow />
-                ) : null}
-                <ToastRail />
-              </Box>
-              {stagedInput ? (
-                <PlanRefineInput
-                  mode={stagedInput.mode}
-                  questions={stagedInput.questions}
-                  onSubmit={handleStagedInputSubmit}
-                  onCancel={handleStagedInputCancel}
-                />
-              ) : stagedChoiceCustom ? (
-                <PlanRefineInput
-                  mode="choice-custom"
-                  onSubmit={handleChoiceCustomSubmit}
-                  onCancel={handleChoiceCustomCancel}
-                />
-              ) : stagedCheckpointRevise ? (
-                <PlanRefineInput
-                  mode="checkpoint-revise"
-                  onSubmit={(text) => handleCheckpointReviseSubmit(text, stagedCheckpointRevise)}
-                  onCancel={handleCheckpointReviseCancel}
-                />
-              ) : pendingChoice ? (
-                <ChoiceConfirm
-                  question={pendingChoice.question}
-                  options={pendingChoice.options}
-                  allowCustom={pendingChoice.allowCustom}
-                  onChoose={stableHandleChoiceConfirm}
-                />
-              ) : pendingRevision ? (
-                <PlanReviseConfirm
-                  reason={pendingRevision.reason}
-                  oldRemaining={(planStepsRef.current ?? []).filter(
-                    (s) => !completedStepIdsRef.current.has(s.id),
-                  )}
-                  newRemaining={pendingRevision.remainingSteps}
-                  summary={pendingRevision.summary}
-                  onChoose={stableHandleReviseConfirm}
-                />
-              ) : pendingCheckpoint ? (
-                <PlanCheckpointConfirm
-                  stepId={pendingCheckpoint.stepId}
-                  title={pendingCheckpoint.title}
-                  completed={pendingCheckpoint.completed}
-                  total={pendingCheckpoint.total}
-                  steps={planStepsRef.current ?? undefined}
-                  completedStepIds={completedStepIdsRef.current}
-                  onChoose={stableHandleCheckpointConfirm}
-                />
-              ) : pendingCheckpointPicker ? (
-                <CheckpointPicker
-                  checkpoints={checkpointPickerList}
-                  workspace={currentRootDir}
-                  pickerPorts={pickerPorts}
-                  onChoose={(outcome) => {
-                    if (outcome.kind === "quit") {
-                      setPendingCheckpointPicker(false);
-                      return;
-                    }
-                    if (outcome.kind === "restore") {
-                      const target = checkpointPickerList.find((c) => c.id === outcome.id);
-                      setPendingCheckpointPicker(false);
-                      if (!target) return;
-                      const result = restoreCheckpoint(currentRootDir, target.id);
-                      const lines = [
-                        `▸ restored "${target.name}" (${target.id.slice(0, 7)}, ${fmtAgo(target.createdAt)})`,
-                      ];
-                      if (result.restored.length > 0) {
-                        lines.push(
-                          `  wrote ${result.restored.length} file${result.restored.length === 1 ? "" : "s"}`,
-                        );
-                      }
-                      if (result.removed.length > 0) {
-                        lines.push(
-                          `  removed ${result.removed.length} file${result.removed.length === 1 ? "" : "s"}`,
-                        );
-                      }
-                      if (result.skipped.length > 0) {
-                        lines.push(
-                          `  skipped ${result.skipped.length} file${result.skipped.length === 1 ? "" : "s"}`,
-                        );
-                      }
-                      log.pushInfo(lines.join("\n"));
-                      return;
-                    }
-                    if (outcome.kind === "delete") {
-                      const target = checkpointPickerList.find((c) => c.id === outcome.id);
-                      if (!target) return;
-                      deleteCheckpoint(currentRootDir, target.id);
-                      setCheckpointPickerList([...listCheckpoints(currentRootDir)].reverse());
-                    }
-                  }}
-                />
-              ) : pendingSessionsPicker ? (
-                <SessionPicker
-                  sessions={sessionsPickerList}
-                  workspace={currentRootDir}
-                  walletCurrency={walletCurrencyRef.current}
-                  pickerPorts={pickerPorts}
-                  onChoose={(outcome) => {
-                    if (outcome.kind === "open") {
-                      setPendingSessionsPicker(false);
-                      if (onSwitchSession) {
-                        onSwitchSession(outcome.name);
-                      } else {
-                        log.pushInfo(
-                          `▸ to switch to "${outcome.name}", quit and run: reasonix chat --session ${outcome.name}`,
-                        );
-                      }
-                      return;
-                    }
-                    if (outcome.kind === "new") {
-                      setPendingSessionsPicker(false);
-                      if (onSwitchSession) {
-                        onSwitchSession(undefined);
-                      } else {
-                        log.pushInfo(
-                          "▸ to start a fresh session, quit and run: reasonix chat (no --session flag)",
-                        );
-                      }
-                      return;
-                    }
-                    if (outcome.kind === "delete") {
-                      deleteSession(outcome.name);
-                      setSessionsPickerList(listSessionsForWorkspace(currentRootDir));
-                      return;
-                    }
-                    if (outcome.kind === "rename") {
-                      renameSession(outcome.name, outcome.newName);
-                      setSessionsPickerList(listSessionsForWorkspace(currentRootDir));
-                      return;
-                    }
-                    if (outcome.kind === "quit") {
-                      setPendingSessionsPicker(false);
-                    }
-                  }}
-                />
-              ) : pendingModelPicker ? (
-                <ModelPicker
-                  models={models}
-                  current={loop.model}
-                  currentEffort={loop.reasoningEffort}
-                  currentAutoEscalate={loop.autoEscalate}
-                  onRefresh={refreshModels}
-                  onChoose={(outcome) => {
-                    setPendingModelPicker(false);
-                    if (outcome.kind === "select") {
-                      loop.configure({ model: outcome.id });
-                      agentStore.dispatch({ type: "session.model.change", model: outcome.id });
-                      log.pushInfo(`▸ model: ${outcome.id}`);
-                      return;
-                    }
-                    if (outcome.kind === "preset") {
-                      const p = PRESETS[outcome.name];
-                      loop.configure({
-                        model: p.model,
-                        autoEscalate: p.autoEscalate,
-                        reasoningEffort: p.reasoningEffort,
-                      });
-                      agentStore.dispatch({ type: "session.model.change", model: p.model });
-                      try {
-                        saveReasoningEffort(p.reasoningEffort);
-                      } catch {
-                        /* disk full / perms — runtime change still took effect */
-                      }
-                      log.pushInfo(`▸ preset: ${outcome.name} · ${p.model}`);
-                    }
-                  }}
-                />
-              ) : pendingMcpHub ? (
-                <McpHub
-                  initialTab={pendingMcpHub.tab}
-                  liveServers={liveMcpServers}
-                  configPath={defaultConfigPath()}
-                  pickerPorts={pickerPorts}
-                  onClose={() => setPendingMcpHub(null)}
-                  postInfo={(text) => log.pushInfo(text)}
-                  applyAppend={(target, addedTools) => {
-                    const updated = applyMcpAppend(loop, target, addedTools);
-                    setLiveMcpServers((prev) => replaceMcpServerSummary(prev, target, updated));
-                    return updated;
-                  }}
-                  reloadMcp={
-                    mcpRuntime
-                      ? async () => {
-                          const r = await mcpRuntime.reloadFromConfig(loop);
-                          setLiveMcpServers(r.summaries);
-                          return r;
-                        }
-                      : undefined
-                  }
-                />
-              ) : pendingPlan ? (
-                <PlanConfirm
-                  plan={pendingPlan}
-                  steps={planStepsRef.current ?? undefined}
-                  summary={planSummaryRef.current ?? undefined}
-                  onChoose={stableHandlePlanConfirm}
-                  projectRoot={currentRootDir}
-                />
-              ) : pendingReviseEditor ? (
-                <PlanReviseEditor
-                  steps={planStepsRef.current ?? []}
-                  completedStepIds={completedStepIdsRef.current}
-                  onAccept={(revised, skippedIds) => {
-                    planStepsRef.current = revised;
-                    for (const id of skippedIds) completedStepIdsRef.current.add(id);
-                    persistPlanState();
-                    const planText = pendingReviseEditor;
-                    setPendingReviseEditor(null);
-                    setPendingPlan(planText);
-                  }}
-                  onCancel={() => {
-                    const planText = pendingReviseEditor;
-                    setPendingReviseEditor(null);
-                    setPendingPlan(planText);
-                  }}
-                />
-              ) : pendingShell ? (
-                <ShellConfirm
-                  command={pendingShell.command}
-                  allowPrefix={derivePrefix(pendingShell.command)}
-                  kind={pendingShell.kind}
-                  onChoose={handleShellConfirm}
-                />
-              ) : pendingEditReview ? (
-                <EditConfirm
-                  block={pendingEditReview}
-                  onChoose={(choice, denyContext) => {
-                    const resolve = editReviewResolveRef.current;
-                    if (resolve) {
-                      editReviewResolveRef.current = null;
-                      resolve({ choice, denyContext });
-                    }
-                  }}
-                />
-              ) : walkthroughActive && pendingEdits.current.length > 0 ? (
-                <EditConfirm
-                  // pendingTick re-keys the modal so each apply/discard
-                  // forces a remount with the NEW first block. Without it,
-                  // EditConfirm's internal scroll state would persist
-                  // across blocks, which is the wrong UX.
-                  key={`walk-${pendingTick}`}
-                  block={pendingEdits.current[0]!}
-                  onChoose={handleWalkChoice}
-                />
-              ) : !chatScroll.pinned ? (
-                <Text color={FG.faint}>
-                  {" 📖 reading history — End / PgDn to return · ↓ to advance one line"}
-                </Text>
-              ) : (
-                <Box flexDirection="column" flexShrink={0} flexWrap="nowrap">
-                  <Box flexDirection="column" flexShrink={0} flexWrap="nowrap">
-                    {codeMode ? (
-                      <ModeStatusBar
-                        editMode={editMode}
-                        pendingCount={pendingCount}
-                        flash={modeFlash}
-                        planMode={planMode}
-                        undoArmed={!!undoBanner || hasUndoable()}
-                        jobs={codeMode.jobs}
-                      />
-                    ) : null}
-                    {activeLoop ? <LoopStatusRow loop={activeLoop} /> : null}
-                    <StatusRow />
-                    <PromptInput
-                      value={input}
-                      onChange={setInput}
-                      onSubmit={handleSubmit}
-                      disabled={busy}
-                      onHistoryPrev={recallPrev}
-                      onHistoryNext={recallNext}
-                    />
-                  </Box>
-                  <Box flexDirection="column" flexShrink={0} flexWrap="nowrap">
-                    {slashMatches !== null ? (
-                      <SlashSuggestions
-                        key={`slash-suggestions:${slashGroupMode ? "group" : "search"}`}
-                        matches={slashMatches}
-                        selectedIndex={slashSelected}
-                        groupMode={slashGroupMode}
-                        advancedHidden={slashAdvancedHidden}
-                      />
-                    ) : null}
-                    {atState !== null ? (
-                      <AtMentionSuggestions state={atState} selectedIndex={atSelected} />
-                    ) : null}
-                  </Box>
-                  {slashArgContext ? (
-                    <SlashArgPicker
-                      matches={slashArgMatches}
-                      selectedIndex={slashArgSelected}
-                      spec={slashArgContext.spec}
-                      kind={slashArgContext.kind}
-                      partial={slashArgContext.partial}
-                    />
+                  {!PLAIN_UI &&
+                  !pendingShell &&
+                  !pendingPlan &&
+                  !pendingReviseEditor &&
+                  !pendingSessionsPicker &&
+                  !pendingCheckpointPicker &&
+                  !pendingMcpHub &&
+                  !stagedInput &&
+                  !pendingEditReview &&
+                  ongoingTool ? (
+                    <OngoingToolRow tool={ongoingTool} progress={toolProgress} />
                   ) : null}
-                  {/* CtxFooter retired — UsageCard auto-emits per turn covers the same data */}
+                  {!PLAIN_UI &&
+                  !pendingShell &&
+                  !pendingPlan &&
+                  !pendingReviseEditor &&
+                  !pendingSessionsPicker &&
+                  !pendingCheckpointPicker &&
+                  !pendingMcpHub &&
+                  !stagedInput &&
+                  !pendingEditReview &&
+                  subagentActivities.length > 0 ? (
+                    <SubagentLiveStack activities={subagentActivities} max={3} />
+                  ) : null}
+                  {!PLAIN_UI &&
+                  !pendingShell &&
+                  !pendingPlan &&
+                  !pendingReviseEditor &&
+                  !pendingSessionsPicker &&
+                  !pendingCheckpointPicker &&
+                  !pendingMcpHub &&
+                  !stagedInput &&
+                  !pendingEditReview &&
+                  !ongoingTool &&
+                  statusLine ? (
+                    <ThinkingRow text={statusLine} />
+                  ) : null}
+                  {!PLAIN_UI &&
+                  undoBanner &&
+                  !pendingShell &&
+                  !pendingPlan &&
+                  !pendingReviseEditor &&
+                  !pendingSessionsPicker &&
+                  !pendingCheckpointPicker &&
+                  !pendingMcpHub &&
+                  !stagedInput &&
+                  !pendingEditReview &&
+                  !pendingChoice &&
+                  !stagedChoiceCustom &&
+                  !pendingRevision &&
+                  !stagedCheckpointRevise &&
+                  !pendingCheckpoint ? (
+                    <UndoBanner banner={undoBanner} />
+                  ) : null}
+                  {/* Activity row when no targeted indicator is visible — phase label from useActivityLabel. */}
+                  {!PLAIN_UI &&
+                  !pendingShell &&
+                  !pendingPlan &&
+                  !pendingReviseEditor &&
+                  !pendingSessionsPicker &&
+                  !pendingCheckpointPicker &&
+                  !pendingMcpHub &&
+                  !stagedInput &&
+                  !pendingEditReview &&
+                  busy &&
+                  !isStreaming &&
+                  !ongoingTool &&
+                  !statusLine ? (
+                    <ThinkingRow text={activityLabel} />
+                  ) : null}
+                  {!PLAIN_UI &&
+                  !pendingShell &&
+                  !pendingPlan &&
+                  !pendingReviseEditor &&
+                  !pendingSessionsPicker &&
+                  !pendingCheckpointPicker &&
+                  !pendingMcpHub &&
+                  !stagedInput &&
+                  !pendingEditReview ? (
+                    <PlanLiveRow />
+                  ) : null}
+                  <ToastRail />
                 </Box>
-              )}
+                {stagedInput ? (
+                  <PlanRefineInput
+                    mode={stagedInput.mode}
+                    questions={stagedInput.questions}
+                    onSubmit={handleStagedInputSubmit}
+                    onCancel={handleStagedInputCancel}
+                  />
+                ) : stagedChoiceCustom ? (
+                  <PlanRefineInput
+                    mode="choice-custom"
+                    onSubmit={handleChoiceCustomSubmit}
+                    onCancel={handleChoiceCustomCancel}
+                  />
+                ) : stagedCheckpointRevise ? (
+                  <PlanRefineInput
+                    mode="checkpoint-revise"
+                    onSubmit={(text) => handleCheckpointReviseSubmit(text, stagedCheckpointRevise)}
+                    onCancel={handleCheckpointReviseCancel}
+                  />
+                ) : pendingChoice ? (
+                  <ChoiceConfirm
+                    question={pendingChoice.question}
+                    options={pendingChoice.options}
+                    allowCustom={pendingChoice.allowCustom}
+                    onChoose={stableHandleChoiceConfirm}
+                  />
+                ) : pendingRevision ? (
+                  <PlanReviseConfirm
+                    reason={pendingRevision.reason}
+                    oldRemaining={(planStepsRef.current ?? []).filter(
+                      (s) => !completedStepIdsRef.current.has(s.id),
+                    )}
+                    newRemaining={pendingRevision.remainingSteps}
+                    summary={pendingRevision.summary}
+                    onChoose={stableHandleReviseConfirm}
+                  />
+                ) : pendingCheckpoint ? (
+                  <PlanCheckpointConfirm
+                    stepId={pendingCheckpoint.stepId}
+                    title={pendingCheckpoint.title}
+                    completed={pendingCheckpoint.completed}
+                    total={pendingCheckpoint.total}
+                    steps={planStepsRef.current ?? undefined}
+                    completedStepIds={completedStepIdsRef.current}
+                    onChoose={stableHandleCheckpointConfirm}
+                  />
+                ) : pendingCheckpointPicker ? (
+                  <CheckpointPicker
+                    checkpoints={checkpointPickerList}
+                    workspace={currentRootDir}
+                    pickerPorts={pickerPorts}
+                    onChoose={(outcome) => {
+                      if (outcome.kind === "quit") {
+                        setPendingCheckpointPicker(false);
+                        return;
+                      }
+                      if (outcome.kind === "restore") {
+                        const target = checkpointPickerList.find((c) => c.id === outcome.id);
+                        setPendingCheckpointPicker(false);
+                        if (!target) return;
+                        const result = restoreCheckpoint(currentRootDir, target.id);
+                        const lines = [
+                          `▸ restored "${target.name}" (${target.id.slice(0, 7)}, ${fmtAgo(target.createdAt)})`,
+                        ];
+                        if (result.restored.length > 0) {
+                          lines.push(
+                            `  wrote ${result.restored.length} file${result.restored.length === 1 ? "" : "s"}`,
+                          );
+                        }
+                        if (result.removed.length > 0) {
+                          lines.push(
+                            `  removed ${result.removed.length} file${result.removed.length === 1 ? "" : "s"}`,
+                          );
+                        }
+                        if (result.skipped.length > 0) {
+                          lines.push(
+                            `  skipped ${result.skipped.length} file${result.skipped.length === 1 ? "" : "s"}`,
+                          );
+                        }
+                        log.pushInfo(lines.join("\n"));
+                        return;
+                      }
+                      if (outcome.kind === "delete") {
+                        const target = checkpointPickerList.find((c) => c.id === outcome.id);
+                        if (!target) return;
+                        deleteCheckpoint(currentRootDir, target.id);
+                        setCheckpointPickerList([...listCheckpoints(currentRootDir)].reverse());
+                      }
+                    }}
+                  />
+                ) : pendingSessionsPicker ? (
+                  <SessionPicker
+                    sessions={sessionsPickerList}
+                    workspace={currentRootDir}
+                    walletCurrency={walletCurrencyRef.current}
+                    pickerPorts={pickerPorts}
+                    onChoose={(outcome) => {
+                      if (outcome.kind === "open") {
+                        setPendingSessionsPicker(false);
+                        if (onSwitchSession) {
+                          onSwitchSession(outcome.name);
+                        } else {
+                          log.pushInfo(
+                            `▸ to switch to "${outcome.name}", quit and run: reasonix chat --session ${outcome.name}`,
+                          );
+                        }
+                        return;
+                      }
+                      if (outcome.kind === "new") {
+                        setPendingSessionsPicker(false);
+                        if (onSwitchSession) {
+                          onSwitchSession(undefined);
+                        } else {
+                          log.pushInfo(
+                            "▸ to start a fresh session, quit and run: reasonix chat (no --session flag)",
+                          );
+                        }
+                        return;
+                      }
+                      if (outcome.kind === "delete") {
+                        deleteSession(outcome.name);
+                        setSessionsPickerList(listSessionsForWorkspace(currentRootDir));
+                        return;
+                      }
+                      if (outcome.kind === "rename") {
+                        renameSession(outcome.name, outcome.newName);
+                        setSessionsPickerList(listSessionsForWorkspace(currentRootDir));
+                        return;
+                      }
+                      if (outcome.kind === "quit") {
+                        setPendingSessionsPicker(false);
+                      }
+                    }}
+                  />
+                ) : pendingModelPicker ? (
+                  <ModelPicker
+                    models={models}
+                    current={loop.model}
+                    currentEffort={loop.reasoningEffort}
+                    currentAutoEscalate={loop.autoEscalate}
+                    onRefresh={refreshModels}
+                    onChoose={(outcome) => {
+                      setPendingModelPicker(false);
+                      if (outcome.kind === "select") {
+                        loop.configure({ model: outcome.id });
+                        agentStore.dispatch({ type: "session.model.change", model: outcome.id });
+                        log.pushInfo(`▸ model: ${outcome.id}`);
+                        return;
+                      }
+                      if (outcome.kind === "preset") {
+                        const p = PRESETS[outcome.name];
+                        loop.configure({
+                          model: p.model,
+                          autoEscalate: p.autoEscalate,
+                          reasoningEffort: p.reasoningEffort,
+                        });
+                        agentStore.dispatch({ type: "session.model.change", model: p.model });
+                        try {
+                          saveReasoningEffort(p.reasoningEffort);
+                        } catch {
+                          /* disk full / perms — runtime change still took effect */
+                        }
+                        log.pushInfo(`▸ preset: ${outcome.name} · ${p.model}`);
+                      }
+                    }}
+                  />
+                ) : pendingMcpHub ? (
+                  <McpHub
+                    initialTab={pendingMcpHub.tab}
+                    liveServers={liveMcpServers}
+                    configPath={defaultConfigPath()}
+                    pickerPorts={pickerPorts}
+                    onClose={() => setPendingMcpHub(null)}
+                    postInfo={(text) => log.pushInfo(text)}
+                    applyAppend={(target, addedTools) => {
+                      const updated = applyMcpAppend(loop, target, addedTools);
+                      setLiveMcpServers((prev) => replaceMcpServerSummary(prev, target, updated));
+                      return updated;
+                    }}
+                    reloadMcp={
+                      mcpRuntime
+                        ? async () => {
+                            const r = await mcpRuntime.reloadFromConfig(loop);
+                            setLiveMcpServers(r.summaries);
+                            return r;
+                          }
+                        : undefined
+                    }
+                  />
+                ) : pendingPlan ? (
+                  <PlanConfirm
+                    plan={pendingPlan}
+                    steps={planStepsRef.current ?? undefined}
+                    summary={planSummaryRef.current ?? undefined}
+                    onChoose={stableHandlePlanConfirm}
+                    projectRoot={currentRootDir}
+                  />
+                ) : pendingReviseEditor ? (
+                  <PlanReviseEditor
+                    steps={planStepsRef.current ?? []}
+                    completedStepIds={completedStepIdsRef.current}
+                    onAccept={(revised, skippedIds) => {
+                      planStepsRef.current = revised;
+                      for (const id of skippedIds) completedStepIdsRef.current.add(id);
+                      persistPlanState();
+                      const planText = pendingReviseEditor;
+                      setPendingReviseEditor(null);
+                      setPendingPlan(planText);
+                    }}
+                    onCancel={() => {
+                      const planText = pendingReviseEditor;
+                      setPendingReviseEditor(null);
+                      setPendingPlan(planText);
+                    }}
+                  />
+                ) : pendingShell ? (
+                  <ShellConfirm
+                    command={pendingShell.command}
+                    allowPrefix={derivePrefix(pendingShell.command)}
+                    kind={pendingShell.kind}
+                    onChoose={handleShellConfirm}
+                  />
+                ) : pendingEditReview ? (
+                  <EditConfirm
+                    block={pendingEditReview}
+                    onChoose={(choice, denyContext) => {
+                      const resolve = editReviewResolveRef.current;
+                      if (resolve) {
+                        editReviewResolveRef.current = null;
+                        resolve({ choice, denyContext });
+                      }
+                    }}
+                  />
+                ) : walkthroughActive && pendingEdits.current.length > 0 ? (
+                  <EditConfirm
+                    // pendingTick re-keys the modal so each apply/discard
+                    // forces a remount with the NEW first block. Without it,
+                    // EditConfirm's internal scroll state would persist
+                    // across blocks, which is the wrong UX.
+                    key={`walk-${pendingTick}`}
+                    block={pendingEdits.current[0]!}
+                    onChoose={handleWalkChoice}
+                  />
+                ) : !chatScroll.pinned ? (
+                  <Text color={FG.faint}>
+                    {" 📖 reading history — End / PgDn to return · ↓ to advance one line"}
+                  </Text>
+                ) : (
+                  <Box flexDirection="column" flexShrink={0} flexWrap="nowrap">
+                    <Box flexDirection="column" flexShrink={0} flexWrap="nowrap">
+                      {codeMode ? (
+                        <ModeStatusBar
+                          editMode={editMode}
+                          pendingCount={pendingCount}
+                          flash={modeFlash}
+                          planMode={planMode}
+                          undoArmed={!!undoBanner || hasUndoable()}
+                          jobs={codeMode.jobs}
+                        />
+                      ) : null}
+                      {activeLoop ? <LoopStatusRow loop={activeLoop} /> : null}
+                      <StatusRow />
+                      <PromptInput
+                        value={input}
+                        onChange={setInput}
+                        onSubmit={handleSubmit}
+                        disabled={busy}
+                        onHistoryPrev={recallPrev}
+                        onHistoryNext={recallNext}
+                      />
+                    </Box>
+                    <Box flexDirection="column" flexShrink={0} flexWrap="nowrap">
+                      {slashMatches !== null ? (
+                        <SlashSuggestions
+                          key={`slash-suggestions:${slashGroupMode ? "group" : "search"}`}
+                          matches={slashMatches}
+                          selectedIndex={slashSelected}
+                          groupMode={slashGroupMode}
+                          advancedHidden={slashAdvancedHidden}
+                        />
+                      ) : null}
+                      {atState !== null ? (
+                        <AtMentionSuggestions state={atState} selectedIndex={atSelected} />
+                      ) : null}
+                    </Box>
+                    {slashArgContext ? (
+                      <SlashArgPicker
+                        matches={slashArgMatches}
+                        selectedIndex={slashArgSelected}
+                        spec={slashArgContext.spec}
+                        kind={slashArgContext.kind}
+                        partial={slashArgContext.partial}
+                      />
+                    ) : null}
+                    {/* CtxFooter retired — UsageCard auto-emits per turn covers the same data */}
+                  </Box>
+                )}
+              </Box>
             </Box>
-          </Box>
+          </InflightProvider>
         </ViewportBudgetProvider>
       </TickerProvider>
     </>

--- a/src/cli/ui/cards/ToolCard.tsx
+++ b/src/cli/ui/cards/ToolCard.tsx
@@ -8,6 +8,7 @@ import { Card } from "../primitives/Card.js";
 import { CardHeader, type MetaItem } from "../primitives/CardHeader.js";
 import { Spinner } from "../primitives/Spinner.js";
 import type { ToolCard as ToolCardData } from "../state/cards.js";
+import { useIsInflight } from "../state/inflight-context.js";
 import { FG, TONE, TONE_ACTIVE } from "../theme/tokens.js";
 
 const READ_TAIL = 2;
@@ -35,7 +36,8 @@ export function ToolCard({ card }: { card: ToolCardData }): React.ReactElement {
   const truncated = allLines.length > tail;
   const visible = truncated ? allLines.slice(-tail) : allLines;
   const hidden = truncated ? allLines.length - visible.length : 0;
-  const status = toolStatus(card);
+  const isInflight = useIsInflight(card.id);
+  const status = toolStatus(card, isInflight);
   const headColor = headerColorFor(status);
   const errColor = card.exitCode && card.exitCode !== 0 ? TONE.err : FG.sub;
   // Rejected calls show a single trailing badge — the verbose JSON error body
@@ -109,10 +111,13 @@ function unwrapSubagentMarkdown(card: ToolCardData): string | null {
 
 type ToolStatus = "running" | "ok" | "rejected" | "error" | "aborted";
 
-function toolStatus(card: ToolCardData): ToolStatus {
+function toolStatus(card: ToolCardData, isInflight: boolean): ToolStatus {
+  // Running is derived from the loop's inflight set so a missed `tool` event
+  // can't strand the spinner forever — finally in runOneToolCall guarantees
+  // the id leaves the set on every exit path.
+  if (isInflight) return "running";
   if (card.rejected) return "rejected";
   if (card.aborted) return "aborted";
-  if (!card.done) return "running";
   if (card.exitCode !== undefined && card.exitCode !== 0) return "error";
   return "ok";
 }

--- a/src/cli/ui/hooks/handle-stream-events.ts
+++ b/src/cli/ui/hooks/handle-stream-events.ts
@@ -27,7 +27,7 @@ export function handleToolStart(ev: LoopEvent, ctx: ToolStartContext): void {
   ctx.setOngoingTool({ name: ev.toolName ?? "?", args: ev.toolArgs });
   ctx.setToolProgress(null);
   ctx.toolStartedAtRef.current = Date.now();
-  ctx.translator.toolStart(ev.toolName ?? "?", parseJsonOrRaw(ev.toolArgs));
+  ctx.translator.toolStart(ev.toolName ?? "?", parseJsonOrRaw(ev.toolArgs), ev.callId);
   // Feed the `@` picker's recency LRU from any path-shaped field in the
   // tool args. Picker surfaces these next time `@` is typed, even if mtime
   // is stale.

--- a/src/cli/ui/hooks/useScrollback.ts
+++ b/src/cli/ui/hooks/useScrollback.ts
@@ -74,7 +74,8 @@ export interface Scrollback {
   appendStreaming(id: string, chunk: string): void;
   endStreaming(id: string, aborted?: boolean): void;
 
-  startTool(name: string, args: unknown): string;
+  /** `presetId` overrides the auto-generated card id — pass the loop's callId so the inflight set's key matches the card's id. */
+  startTool(name: string, args: unknown, presetId?: string): string;
   appendToolOutput(id: string, chunk: string): void;
   endTool(
     id: string,
@@ -270,8 +271,8 @@ export function useScrollback(): Scrollback {
       endStreaming(id, aborted) {
         dispatch({ type: "streaming.end", id, aborted });
       },
-      startTool(name, args) {
-        const id = nextId("tool");
+      startTool(name, args, presetId) {
+        const id = presetId ?? nextId("tool");
         dispatch({ type: "tool.start", id, name, args });
         return id;
       },

--- a/src/cli/ui/state/TurnTranslator.ts
+++ b/src/cli/ui/state/TurnTranslator.ts
@@ -20,9 +20,11 @@ export class TurnTranslator {
     }
   }
 
-  toolStart(name: string, args: unknown): void {
+  toolStart(name: string, args: unknown, callId?: string): void {
     this.toolStartedAt = Date.now();
-    this.toolCardId = this.log.startTool(name, args);
+    // callId from the loop event is the inflight-set key — using it as
+    // the card id lets the UI derive `running` from `loop.inflight.has(card.id)`.
+    this.toolCardId = this.log.startTool(name, args, callId);
   }
 
   toolEnd(output: string): void {

--- a/src/cli/ui/state/inflight-context.tsx
+++ b/src/cli/ui/state/inflight-context.tsx
@@ -1,0 +1,27 @@
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React, { createContext, useContext, useSyncExternalStore } from "react";
+import type { InflightSet } from "../../../core/inflight.js";
+
+const Ctx = createContext<InflightSet | null>(null);
+
+export function InflightProvider({
+  inflight,
+  children,
+}: {
+  inflight: InflightSet;
+  children: React.ReactNode;
+}): React.ReactElement {
+  return <Ctx.Provider value={inflight}>{children}</Ctx.Provider>;
+}
+
+/** True iff the loop currently has `id` in its inflight set. Re-renders on every set mutation; React bails on unchanged boolean snapshot. */
+export function useIsInflight(id: string): boolean {
+  const inflight = useContext(Ctx);
+  return useSyncExternalStore(
+    (cb) => (inflight ? inflight.subscribe(cb) : noop),
+    () => (inflight ? inflight.has(id) : false),
+    () => false,
+  );
+}
+
+const noop = () => {};

--- a/src/core/inflight.ts
+++ b/src/core/inflight.ts
@@ -1,0 +1,52 @@
+/** Authoritative running-id set — cards derive `running` from `has(id)` instead of trusting end-event delivery. Loop adds on dispatch entry, deletes in `finally` so every exit path cleans up. */
+
+export type InflightSubscriber = () => void;
+
+export class InflightSet {
+  private readonly _set = new Set<string>();
+  private readonly _listeners = new Set<InflightSubscriber>();
+
+  add(id: string): void {
+    if (this._set.has(id)) return;
+    this._set.add(id);
+    this._notify();
+  }
+
+  delete(id: string): void {
+    if (this._set.delete(id)) this._notify();
+  }
+
+  has(id: string): boolean {
+    return this._set.has(id);
+  }
+
+  /** Snapshot for diagnostics / tests; live view, do not mutate. */
+  get size(): number {
+    return this._set.size;
+  }
+
+  /** Subscribe to add/delete; returns the unsubscribe function. */
+  subscribe(fn: InflightSubscriber): () => void {
+    this._listeners.add(fn);
+    return () => {
+      this._listeners.delete(fn);
+    };
+  }
+
+  /** Drop everything — only use at session reset. Notifies once. */
+  clear(): void {
+    if (this._set.size === 0) return;
+    this._set.clear();
+    this._notify();
+  }
+
+  private _notify(): void {
+    for (const fn of this._listeners) {
+      try {
+        fn();
+      } catch {
+        /* listener errors must not break the gate */
+      }
+    }
+  }
+}

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -10,6 +10,7 @@ import {
 } from "./mcp/registry.js";
 
 import { ContextManager } from "./context-manager.js";
+import { InflightSet } from "./core/inflight.js";
 import { t } from "./i18n/index.js";
 import { formatLoopError, is5xxError, probeDeepSeekReachable } from "./loop/errors.js";
 import {
@@ -134,6 +135,8 @@ export class CacheFirstLoop {
   private _streamPreference: boolean;
   /** Threaded through HTTP + every tool dispatch so Esc cancels in-flight work, not after. */
   private _turnAbort: AbortController = new AbortController();
+  /** Authoritative running-id set — UI cards consult this instead of trusting end-event delivery. Insert at dispatch entry, delete in finally. */
+  private readonly _inflight = new InflightSet();
 
   private _proArmedForNextTurn = false;
   private _escalateThisTurn = false;
@@ -141,6 +144,11 @@ export class CacheFirstLoop {
   private _turnSelfCorrected = false;
   private _foldedThisTurn = false;
   private context!: ContextManager;
+
+  /** Subscribe API so UI hooks can derive `running` from finally-guaranteed insertions. */
+  get inflight(): InflightSet {
+    return this._inflight;
+  }
 
   get currentTurn(): number {
     return this._turn;
@@ -300,6 +308,7 @@ export class CacheFirstLoop {
       }
     }
     this.scratch.reset();
+    this._inflight.clear();
     return { dropped };
   }
 
@@ -360,48 +369,67 @@ export class CacheFirstLoop {
     const name = call.function?.name ?? "";
     const args = call.function?.arguments ?? "{}";
     const parsedArgs = safeParseToolArgs(args);
+    this._inflight.add(this.inflightIdFor(call));
+    try {
+      const preReport = await runHooks({
+        hooks: this.hooks,
+        payload: {
+          event: "PreToolUse",
+          cwd: this.hookCwd,
+          toolName: name,
+          toolArgs: parsedArgs,
+        },
+      });
+      const preWarnings = [...hookWarnings(preReport.outcomes, this._turn)];
 
-    const preReport = await runHooks({
-      hooks: this.hooks,
-      payload: {
-        event: "PreToolUse",
-        cwd: this.hookCwd,
-        toolName: name,
-        toolArgs: parsedArgs,
-      },
-    });
-    const preWarnings = [...hookWarnings(preReport.outcomes, this._turn)];
+      if (preReport.blocked) {
+        const blocking = preReport.outcomes[preReport.outcomes.length - 1];
+        const reason = (
+          blocking?.stderr ||
+          blocking?.stdout ||
+          "blocked by PreToolUse hook"
+        ).trim();
+        return {
+          preWarnings,
+          postWarnings: [],
+          result: `[hook block] ${blocking?.hook.command ?? "<unknown>"}\n${reason}`,
+        };
+      }
 
-    if (preReport.blocked) {
-      const blocking = preReport.outcomes[preReport.outcomes.length - 1];
-      const reason = (blocking?.stderr || blocking?.stdout || "blocked by PreToolUse hook").trim();
-      return {
-        preWarnings,
-        postWarnings: [],
-        result: `[hook block] ${blocking?.hook.command ?? "<unknown>"}\n${reason}`,
-      };
+      const result = await this.tools.dispatch(name, args, {
+        signal,
+        maxResultTokens: DEFAULT_MAX_RESULT_TOKENS,
+        confirmationGate: this.confirmationGate,
+      });
+
+      const postReport = await runHooks({
+        hooks: this.hooks,
+        payload: {
+          event: "PostToolUse",
+          cwd: this.hookCwd,
+          toolName: name,
+          toolArgs: parsedArgs,
+          toolResult: result,
+        },
+      });
+      const postWarnings = [...hookWarnings(postReport.outcomes, this._turn)];
+
+      return { preWarnings, postWarnings, result };
+    } finally {
+      this._inflight.delete(this.inflightIdFor(call));
     }
-
-    const result = await this.tools.dispatch(name, args, {
-      signal,
-      maxResultTokens: DEFAULT_MAX_RESULT_TOKENS,
-      confirmationGate: this.confirmationGate,
-    });
-
-    const postReport = await runHooks({
-      hooks: this.hooks,
-      payload: {
-        event: "PostToolUse",
-        cwd: this.hookCwd,
-        toolName: name,
-        toolArgs: parsedArgs,
-        toolResult: result,
-      },
-    });
-    const postWarnings = [...hookWarnings(postReport.outcomes, this._turn)];
-
-    return { preWarnings, postWarnings, result };
   }
+
+  /** Stable per-call id used as the inflight key AND threaded into tool_start / tool events so the UI matches them up. */
+  private inflightIdFor(call: ToolCall): string {
+    if (call.id) return call.id;
+    const fallback = (call as { _inflightFallback?: string })._inflightFallback;
+    if (fallback) return fallback;
+    const generated = `inflight-${++this._inflightCounter}`;
+    (call as { _inflightFallback?: string })._inflightFallback = generated;
+    return generated;
+  }
+  private _inflightCounter = 0;
 
   private buildMessages(pendingUser: string | null): ChatMessage[] {
     // DeepSeek 400s on either unpaired tool_calls or stray tool entries — heal before sending.
@@ -1043,14 +1071,19 @@ export class CacheFirstLoop {
         // tool_start announces every call in the chunk BEFORE any
         // dispatch awaits — TUI shows live indicators for each, and the
         // gap between assistant_final and the first tool_result yield is
-        // never silent.
+        // never silent. Pre-add to the inflight set so the spinner is
+        // already correct on the very first card render — runOneToolCall's
+        // own add is then idempotent and its finally is the cleanup contract.
         for (const call of chunk) {
+          const callId = this.inflightIdFor(call);
+          this._inflight.add(callId);
           yield {
             turn: this._turn,
             role: "tool_start",
             content: "",
             toolName: call.function?.name ?? "",
             toolArgs: call.function?.arguments ?? "{}",
+            callId,
           };
         }
 
@@ -1105,6 +1138,7 @@ export class CacheFirstLoop {
             content: result,
             toolName: name,
             toolArgs: args,
+            callId: this.inflightIdFor(call),
           };
         }
       }

--- a/src/loop/types.ts
+++ b/src/loop/types.ts
@@ -29,6 +29,8 @@ export interface LoopEvent {
   toolCallIndex?: number;
   /** Count of tool calls whose args have parsed as valid JSON (UI progress, not dispatch gate). */
   toolCallReadyCount?: number;
+  /** Stable id for tool_start / tool pairs — also the inflight-set key. UI uses this as the card id so it can derive `running` from `loop.inflight.has(callId)` instead of trusting end-event delivery. */
+  callId?: string;
   stats?: TurnStats;
   repair?: RepairReport;
   error?: string;

--- a/tests/inflight.test.ts
+++ b/tests/inflight.test.ts
@@ -1,0 +1,150 @@
+/** InflightSet — finally-driven cleanup contract. */
+
+import { describe, expect, it, vi } from "vitest";
+import { InflightSet } from "../src/core/inflight.js";
+
+describe("InflightSet", () => {
+  it("add / has / delete round-trips", () => {
+    const s = new InflightSet();
+    expect(s.has("a")).toBe(false);
+    s.add("a");
+    expect(s.has("a")).toBe(true);
+    expect(s.size).toBe(1);
+    s.delete("a");
+    expect(s.has("a")).toBe(false);
+    expect(s.size).toBe(0);
+  });
+
+  it("add is idempotent — re-adding the same id is a no-op + does not re-notify", () => {
+    const s = new InflightSet();
+    const sub = vi.fn();
+    s.subscribe(sub);
+    s.add("a");
+    s.add("a");
+    s.add("a");
+    expect(sub).toHaveBeenCalledTimes(1);
+  });
+
+  it("delete on a missing id does not notify", () => {
+    const s = new InflightSet();
+    const sub = vi.fn();
+    s.subscribe(sub);
+    s.delete("never-added");
+    expect(sub).not.toHaveBeenCalled();
+  });
+
+  it("subscribe fires on add and on delete", () => {
+    const s = new InflightSet();
+    const sub = vi.fn();
+    s.subscribe(sub);
+    s.add("a");
+    s.add("b");
+    s.delete("a");
+    expect(sub).toHaveBeenCalledTimes(3);
+  });
+
+  it("subscribe returns an unsubscribe function", () => {
+    const s = new InflightSet();
+    const sub = vi.fn();
+    const unsub = s.subscribe(sub);
+    s.add("a");
+    expect(sub).toHaveBeenCalledTimes(1);
+    unsub();
+    s.add("b");
+    expect(sub).toHaveBeenCalledTimes(1);
+  });
+
+  it("listener errors do not propagate or break further notifications", () => {
+    const s = new InflightSet();
+    s.subscribe(() => {
+      throw new Error("boom");
+    });
+    const ok = vi.fn();
+    s.subscribe(ok);
+    expect(() => s.add("a")).not.toThrow();
+    expect(ok).toHaveBeenCalledTimes(1);
+  });
+
+  it("clear empties the set and notifies once", () => {
+    const s = new InflightSet();
+    s.add("a");
+    s.add("b");
+    const sub = vi.fn();
+    s.subscribe(sub);
+    s.clear();
+    expect(s.size).toBe(0);
+    expect(s.has("a")).toBe(false);
+    expect(s.has("b")).toBe(false);
+    expect(sub).toHaveBeenCalledTimes(1);
+  });
+
+  it("clear on an empty set is a no-op + does not notify", () => {
+    const s = new InflightSet();
+    const sub = vi.fn();
+    s.subscribe(sub);
+    s.clear();
+    expect(sub).not.toHaveBeenCalled();
+  });
+
+  it("models the finally contract — id is removed even when work throws", async () => {
+    const s = new InflightSet();
+    const work = async () => {
+      s.add("job-1");
+      try {
+        throw new Error("simulated tool failure");
+      } finally {
+        s.delete("job-1");
+      }
+    };
+    await expect(work()).rejects.toThrow("simulated tool failure");
+    // The whole point of the refactor: regardless of how the work exits,
+    // the inflight bit is gone, so the spinner stops.
+    expect(s.has("job-1")).toBe(false);
+    expect(s.size).toBe(0);
+  });
+
+  it("models the finally contract — id is removed when work is aborted mid-flight", async () => {
+    const s = new InflightSet();
+    const ctl = new AbortController();
+    const work = async (signal: AbortSignal) => {
+      s.add("abortable");
+      try {
+        // Simulated tool that hangs until the signal fires.
+        await new Promise<void>((resolve, reject) => {
+          if (signal.aborted) {
+            reject(new Error("aborted before await"));
+            return;
+          }
+          signal.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+        });
+      } finally {
+        s.delete("abortable");
+      }
+    };
+    const promise = work(ctl.signal);
+    expect(s.has("abortable")).toBe(true);
+    ctl.abort();
+    await expect(promise).rejects.toThrow();
+    expect(s.has("abortable")).toBe(false);
+  });
+
+  it("parallel adds with concurrent settle — every id leaves the set on completion", async () => {
+    const s = new InflightSet();
+    const work = async (id: string, ms: number, fail: boolean) => {
+      s.add(id);
+      try {
+        await new Promise((r) => setTimeout(r, ms));
+        if (fail) throw new Error(`${id} failed`);
+      } finally {
+        s.delete(id);
+      }
+    };
+    const settled = await Promise.allSettled([
+      work("a", 5, false),
+      work("b", 1, true),
+      work("c", 3, false),
+    ]);
+    expect(settled.map((r) => r.status)).toEqual(["fulfilled", "rejected", "fulfilled"]);
+    expect(s.size).toBe(0);
+  });
+});

--- a/tests/loop-inflight.test.ts
+++ b/tests/loop-inflight.test.ts
@@ -1,0 +1,149 @@
+/** CacheFirstLoop.inflight — finally-driven cleanup around runOneToolCall. */
+
+import { describe, expect, it, vi } from "vitest";
+import { DeepSeekClient } from "../src/client.js";
+import { CacheFirstLoop, type LoopEvent } from "../src/loop.js";
+import { ImmutablePrefix } from "../src/memory/runtime.js";
+import { ToolRegistry } from "../src/tools.js";
+import type { ChatMessage } from "../src/types.js";
+
+interface FakeResponseShape {
+  content?: string;
+  tool_calls?: Array<{
+    id: string;
+    type?: "function";
+    function: { name: string; arguments: string };
+  }>;
+}
+
+function fakeFetch(responses: FakeResponseShape[]): typeof fetch {
+  let i = 0;
+  return vi.fn(async (_url: unknown, init: { body?: string } | undefined) => {
+    const body = init?.body ? JSON.parse(init.body) : {};
+    const resp = responses[i++] ?? responses[responses.length - 1]!;
+    return new Response(
+      JSON.stringify({
+        _echo_messages: body.messages as ChatMessage[],
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: "assistant",
+              content: resp.content ?? "",
+              tool_calls: resp.tool_calls,
+            },
+            finish_reason: resp.tool_calls ? "tool_calls" : "stop",
+          },
+        ],
+        usage: {
+          prompt_tokens: 100,
+          completion_tokens: 20,
+          total_tokens: 120,
+          prompt_cache_hit_tokens: 0,
+          prompt_cache_miss_tokens: 100,
+        },
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  }) as unknown as typeof fetch;
+}
+
+function makeClient(responses: FakeResponseShape[]) {
+  return new DeepSeekClient({ apiKey: "sk-test", fetch: fakeFetch(responses) });
+}
+
+async function drain(loop: CacheFirstLoop, prompt: string): Promise<LoopEvent[]> {
+  const out: LoopEvent[] = [];
+  for await (const ev of loop.step(prompt)) out.push(ev);
+  return out;
+}
+
+describe("CacheFirstLoop.inflight", () => {
+  it("starts empty and exposes the InflightSet via getter", () => {
+    const loop = new CacheFirstLoop({
+      client: makeClient([{ content: "x" }]),
+      prefix: new ImmutablePrefix({ system: "s" }),
+    });
+    expect(loop.inflight.size).toBe(0);
+    expect(loop.inflight.has("anything")).toBe(false);
+  });
+
+  it("tool_start event carries a callId that matches the inflight key", async () => {
+    const tools = new ToolRegistry();
+    tools.register({
+      name: "echo",
+      description: "test tool",
+      readOnly: true,
+      parameters: { type: "object", properties: {} },
+      fn: async () => "ok",
+    });
+    const loop = new CacheFirstLoop({
+      client: makeClient([
+        {
+          tool_calls: [
+            {
+              id: "call_abc",
+              type: "function",
+              function: { name: "echo", arguments: "{}" },
+            },
+          ],
+        },
+        { content: "all done" },
+      ]),
+      prefix: new ImmutablePrefix({ system: "s" }),
+      tools,
+      stream: false,
+    });
+    const events = await drain(loop, "go");
+    const start = events.find((e) => e.role === "tool_start");
+    expect(start).toBeDefined();
+    expect(start?.callId).toBe("call_abc");
+    // Set is drained after the turn completes — every dispatch's finally fired.
+    expect(loop.inflight.size).toBe(0);
+  });
+
+  it("inflight is empty after a tool throws — finally still removes the id", async () => {
+    const tools = new ToolRegistry();
+    tools.register({
+      name: "boom",
+      description: "always fails",
+      readOnly: true,
+      parameters: { type: "object", properties: {} },
+      fn: async () => {
+        throw new Error("simulated tool failure");
+      },
+    });
+    const loop = new CacheFirstLoop({
+      client: makeClient([
+        {
+          tool_calls: [
+            {
+              id: "call_boom",
+              type: "function",
+              function: { name: "boom", arguments: "{}" },
+            },
+          ],
+        },
+        { content: "recovered" },
+      ]),
+      prefix: new ImmutablePrefix({ system: "s" }),
+      tools,
+      stream: false,
+    });
+    await drain(loop, "go");
+    expect(loop.inflight.size).toBe(0);
+    expect(loop.inflight.has("call_boom")).toBe(false);
+  });
+
+  it("clearLog drains the inflight set so /new can't strand a stale callId", () => {
+    const loop = new CacheFirstLoop({
+      client: makeClient([{ content: "x" }]),
+      prefix: new ImmutablePrefix({ system: "s" }),
+    });
+    loop.inflight.add("call-1");
+    loop.inflight.add("call-2");
+    expect(loop.inflight.size).toBe(2);
+    loop.clearLog();
+    expect(loop.inflight.size).toBe(0);
+  });
+});

--- a/tests/turn-translator.test.ts
+++ b/tests/turn-translator.test.ts
@@ -107,7 +107,7 @@ describe("TurnTranslator", () => {
     t.toolEnd("ok 250 lines");
     const startCall = calls.find((c) => c.method === "startTool");
     const endCall = calls.find((c) => c.method === "endTool");
-    expect(startCall?.args).toEqual(["read_file", { path: "src/x.ts" }]);
+    expect(startCall?.args).toEqual(["read_file", { path: "src/x.ts" }, undefined]);
     expect(endCall?.args[0]).toBe("tool-1");
     const endInfo = endCall?.args[1] as { output: string; elapsedMs: number };
     expect(endInfo.output).toBe("ok 250 lines");


### PR DESCRIPTION
Tool-card spinners occasionally kept spinning after the underlying work
had finished. Self-reported on dogfooding; preventive fix per #557.

## Why this happens

\`status\` was set imperatively from paired events: \`tool_start\` flips
the card to running, \`tool\` flips it to done. Every dispatch exit path
has to remember to emit the closing event — and there are a lot of
them: normal return, thrown error caught upstream, parent abort
propagating into a running child, storm-breaker truncation, network
drop. Miss one and the spinner stays running forever.

## Fix — derive, don't accumulate

Make \`running\` a derived view of an authoritative inflight set on the
loop, not an event-driven flag.

- **\`InflightSet\` (\`src/core/inflight.ts\`)** — add / delete / has /
  subscribe with notify-on-mutation. Only one contract: insertions
  paired with \`finally\`-guarded deletions. The language guarantees
  \`finally\` on every exit path, so there's no closing event to forget.
- **\`CacheFirstLoop\`** holds one (\`loop.inflight\`). \`runOneToolCall\`
  adds the call's id at function entry and deletes it in \`finally\`;
  the chunk loop pre-adds before yielding \`tool_start\` so the very
  first card render already reflects the running state. \`clearLog\`
  drains the set on \`/new\`.
- **\`LoopEvent.tool_start\` / \`tool\`** carry a new \`callId\` — same
  id used as the inflight key. \`TurnTranslator\` threads it into
  \`Scrollback.startTool\`, which uses it as the card id, so the card's
  id and the inflight key match.
- **\`InflightProvider\` + \`useIsInflight\` hook** expose the set as a
  React context backed by \`useSyncExternalStore\`. \`ToolCard\`'s
  \`toolStatus\` consults the hook for \"running\"; \`card.done\` is no
  longer the spinner discriminator — only the terminal flavor (ok /
  rejected / aborted / error).

The whole class of \"we forgot to emit the end event on path X\"
disappears: there's no end event to forget.

## Tests

- \`tests/inflight.test.ts\` (11 cases) — InflightSet contract:
  idempotent add, notify-only-on-change, listener errors don't break
  the gate, clear, finally-on-throw, finally-on-abort, parallel
  allSettled.
- \`tests/loop-inflight.test.ts\` (4 cases) — \`runOneToolCall\`
  \`finally\` clears the set on success and on tool throw;
  \`tool_start\` carries \`callId\` matching the inflight key;
  \`clearLog\` drains.

Type-check + dashboard build clean. Full suite: 2428 passed, 2 skipped
(was 2413, +15 new tests).

## Out of scope (follow-ups)

Per the issue, both mentioned but punted to keep this PR tight:

- **Subagent runId** in the same inflight set. Subagent end-event
  delivery has its own try-block in \`spawnSubagent\`; tightening that
  is a separate change.
- **Streaming / reasoning** running flags. Tied to the model-API call
  path, not tool dispatch — different leak surface.

Both are tracked in #557's checklist and can land incrementally now
that the InflightSet primitive exists.

Closes #557