### PR TITLE
feat(ui): add /theme picker (rebased from #543)

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -44,6 +44,7 @@ import {
   resolveThemePreference,
   saveEditMode,
   saveReasoningEffort,
+  saveTheme,
 } from "../../config.js";
 import { Eventizer } from "../../core/eventize.js";
 import { pauseGate } from "../../core/pause-gate.js";
@@ -101,6 +102,7 @@ import { SessionPicker } from "./SessionPicker.js";
 import { ShellConfirm, type ShellConfirmChoice, derivePrefix } from "./ShellConfirm.js";
 import { SlashArgPicker } from "./SlashArgPicker.js";
 import { SlashSuggestions } from "./SlashSuggestions.js";
+import { ThemePicker } from "./ThemePicker.js";
 import { WelcomeBanner } from "./WelcomeBanner.js";
 import { detectBangCommand, formatBangUserMessage } from "./bang.js";
 import type { PickerSnapshot, ViewerSnapshot } from "./dashboard/use-picker-broadcast.js";
@@ -153,7 +155,7 @@ import { hydrateCardsFromMessages } from "./state/hydrate.js";
 import { InflightProvider } from "./state/inflight-context.js";
 import { AgentStoreProvider, useAgentState, useAgentStore } from "./state/provider.js";
 import { ThemeProvider } from "./theme/context.js";
-import { FG } from "./theme/tokens.js";
+import { FG, type ThemeName } from "./theme/tokens.js";
 import { TickerProvider } from "./ticker.js";
 import { useCompletionPickers } from "./useCompletionPickers.js";
 import { useEditHistory } from "./useEditHistory.js";
@@ -310,15 +312,22 @@ export function App(props: AppProps): React.ReactElement {
     () => (props.session ? hydrateCardsFromMessages(loadSessionMessages(props.session)) : []),
     [props.session],
   );
-  const themeName = resolveThemePreference(loadTheme(), process.env.REASONIX_THEME);
+  const [themeName, setThemeName] = React.useState<ThemeName>(() =>
+    resolveThemePreference(loadTheme(), process.env.REASONIX_THEME),
+  );
   return (
     <ThemeProvider name={themeName}>
       <AgentStoreProvider session={session} initialCards={initialCards}>
-        <AppInner {...props} />
+        <AppInner {...props} themeName={themeName} setThemeName={setThemeName} />
       </AgentStoreProvider>
     </ThemeProvider>
   );
 }
+
+type AppInnerProps = AppProps & {
+  themeName: ThemeName;
+  setThemeName: React.Dispatch<React.SetStateAction<ThemeName>>;
+};
 
 function AppInner({
   model,
@@ -335,7 +344,9 @@ function AppInner({
   noDashboard,
   onSwitchSession,
   mouse = true,
-}: AppProps) {
+  themeName,
+  setThemeName,
+}: AppInnerProps) {
   markPhase("app_inner_start");
   const log = useScrollback();
   const agentStore = useAgentStore();
@@ -585,6 +596,8 @@ function AppInner({
   const [pendingMcpHub, setPendingMcpHub] = useState<{ tab: "live" | "marketplace" } | null>(null);
   /** True while the ModelPicker is open mid-chat (triggered by bare `/model`). */
   const [pendingModelPicker, setPendingModelPicker] = useState(false);
+  /** True while the ThemePicker is open mid-chat (triggered by bare `/theme`). */
+  const [pendingThemePicker, setPendingThemePicker] = useState(false);
   // Stashed plan + intent while the user types free-form feedback
   // (refinement or last instructions on approve). When the picker
   // returns "refine" or "approve", we defer the loop-resume and show
@@ -652,6 +665,7 @@ function AppInner({
     !!pendingCheckpointPicker ||
     !!pendingMcpHub ||
     pendingModelPicker ||
+    pendingThemePicker ||
     !!stagedInput ||
     !!pendingEditReview ||
     walkthroughActive ||
@@ -2338,6 +2352,11 @@ function AppInner({
           pushHistory(text);
           return;
         }
+        if (result.openThemePicker) {
+          setPendingThemePicker(true);
+          pushHistory(text);
+          return;
+        }
         if (result.openArgPickerFor) {
           pushHistory(text);
           setInput(`/${result.openArgPickerFor} `);
@@ -3607,6 +3626,22 @@ function AppInner({
                       if (outcome.kind === "quit") {
                         setPendingSessionsPicker(false);
                       }
+                    }}
+                  />
+                ) : pendingThemePicker ? (
+                  <ThemePicker
+                    currentPreference={loadTheme() ?? "auto"}
+                    activeTheme={themeName}
+                    onChoose={(outcome) => {
+                      setPendingThemePicker(false);
+                      if (outcome.kind === "quit") return;
+                      saveTheme(outcome.value);
+                      const active = resolveThemePreference(
+                        outcome.value,
+                        process.env.REASONIX_THEME,
+                      );
+                      setThemeName(active);
+                      log.pushInfo(`▸ theme saved: ${outcome.value}\n  active now: ${active}`);
                     }}
                   />
                 ) : pendingModelPicker ? (

--- a/src/cli/ui/ThemePicker.tsx
+++ b/src/cli/ui/ThemePicker.tsx
@@ -1,0 +1,50 @@
+import { Box, Text } from "ink";
+import React from "react";
+import { type SelectItem, SingleSelect } from "./Select.js";
+import { type ThemeName, listThemeNames } from "./theme/tokens.js";
+
+export type ThemeChoice = ThemeName | "auto";
+
+export type ThemePickerOutcome = { kind: "select"; value: ThemeChoice } | { kind: "quit" };
+
+export function ThemePicker({
+  currentPreference,
+  activeTheme,
+  onChoose,
+}: {
+  currentPreference: ThemeChoice;
+  activeTheme: ThemeName;
+  onChoose: (outcome: ThemePickerOutcome) => void;
+}) {
+  const choices: ThemeChoice[] = ["auto", ...listThemeNames()];
+  const items: SelectItem<ThemeChoice>[] = choices.map((value) => ({
+    value,
+    label: value,
+    hint: describeTheme(value, currentPreference, activeTheme),
+  }));
+
+  return (
+    <Box flexDirection="column" marginY={1}>
+      <Text bold>Theme</Text>
+      <SingleSelect
+        items={items}
+        initialValue={currentPreference}
+        onSubmit={(value) => onChoose({ kind: "select", value })}
+        onCancel={() => onChoose({ kind: "quit" })}
+        footer="↑↓ pick · ⏎ confirm · esc cancel"
+      />
+    </Box>
+  );
+}
+
+function describeTheme(
+  value: ThemeChoice,
+  currentPreference: ThemeChoice,
+  activeTheme: ThemeName,
+): string {
+  const tags: string[] = [];
+  if (value === currentPreference) tags.push("current preference");
+  if (value === activeTheme) tags.push("active now");
+  if (value === "auto") tags.push("use REASONIX_THEME or default");
+  return tags.join(" · ");
+}

--- a/src/cli/ui/slash/commands.ts
+++ b/src/cli/ui/slash/commands.ts
@@ -43,6 +43,22 @@ export const SLASH_COMMANDS: readonly SlashCommandSpec[] = [
     argCompleter: ["EN", "zh-CN"],
     aliases: ["lang"],
   },
+  {
+    cmd: "theme",
+    group: "setup",
+    argsHint: "[auto|default|dark|light|tokyo-night|github-dark|github-light|high-contrast]",
+    summary: "show or persist the terminal theme preference. Bare opens picker.",
+    argCompleter: [
+      "auto",
+      "default",
+      "dark",
+      "light",
+      "tokyo-night",
+      "github-dark",
+      "github-light",
+      "high-contrast",
+    ],
+  },
 
   { cmd: "status", group: "info", summary: "current model, flags, context, session" },
   {
@@ -244,21 +260,6 @@ export const SLASH_COMMANDS: readonly SlashCommandSpec[] = [
     summary:
       "session USD cap — warns at 80%, refuses next turn at 100%. Off by default. /budget alone shows status",
     argCompleter: ["off", "1", "5", "10", "20", "50"],
-  },
-  {
-    cmd: "theme",
-    group: "advanced",
-    argsHint: "[auto|default|dark|light|tokyo-night|github-dark|github-light]",
-    summary: "show or persist the terminal theme preference",
-    argCompleter: [
-      "auto",
-      "default",
-      "dark",
-      "light",
-      "tokyo-night",
-      "github-dark",
-      "github-light",
-    ],
   },
   {
     cmd: "search-engine",

--- a/src/cli/ui/slash/handlers/theme.ts
+++ b/src/cli/ui/slash/handlers/theme.ts
@@ -1,21 +1,8 @@
-import { loadTheme, resolveThemePreference, saveTheme } from "@/config.js";
+import { resolveThemePreference, saveTheme } from "@/config.js";
 import { type ThemeName, isThemeName, listThemeNames } from "../../theme/tokens.js";
 import type { SlashHandler } from "../dispatch.js";
 
 const themeChoices = ["auto", ...listThemeNames()] as const;
-
-function formatThemeStatus(): string {
-  const configured = loadTheme();
-  const active = resolveThemePreference(configured, process.env.REASONIX_THEME);
-  const source = configured && configured !== "auto" ? "config" : "env/default";
-
-  return [
-    `theme: ${active} (${source})`,
-    `configured: ${configured ?? "unset"}`,
-    `available: ${themeChoices.join(", ")}`,
-    "usage: /theme <name|auto>",
-  ].join("\n");
-}
 
 function isThemeChoice(value: string): value is ThemeName | "auto" {
   return value === "auto" || isThemeName(value);
@@ -23,7 +10,7 @@ function isThemeChoice(value: string): value is ThemeName | "auto" {
 
 const theme: SlashHandler = (args) => {
   const next = args[0];
-  if (!next) return { info: formatThemeStatus() };
+  if (!next) return { openThemePicker: true };
 
   if (!isThemeChoice(next)) {
     return { info: `unknown theme: ${next}\navailable: ${themeChoices.join(", ")}` };

--- a/src/cli/ui/slash/types.ts
+++ b/src/cli/ui/slash/types.ts
@@ -14,6 +14,8 @@ export interface SlashResult {
   openCheckpointPicker?: boolean;
   /** Open the ModelPicker modal — bare `/model` (no id) opens it. */
   openModelPicker?: boolean;
+  /** Open the ThemePicker modal — bare `/theme` opens it. */
+  openThemePicker?: boolean;
   /** Open the unified MCP hub — `/mcp` defaults to "live", `/mcp browse` to "marketplace". */
   openMcpHub?: { tab: "live" | "marketplace" };
   /** Open the arg-completer picker for this command (e.g. `/language` → language picker). */

--- a/tests/slash.test.ts
+++ b/tests/slash.test.ts
@@ -517,7 +517,7 @@ describe("handleSlash", () => {
     // Case-insensitive.
     expect(suggestSlashCommands("HE").map((s) => s.cmd)).toEqual(["help"]);
     // Empty prefix returns the full non-advanced release list, including code commands.
-    expect(suggestSlashCommands("", true)).toHaveLength(37);
+    expect(suggestSlashCommands("", true)).toHaveLength(38);
     expect(suggestSlashCommands("", true).map((s) => s.cmd)).toContain("logs");
     expect(suggestSlashCommands("", true).map((s) => s.cmd)).toContain("language");
     expect(suggestSlashCommands("lan").map((s) => s.cmd)).toContain("language");
@@ -1170,16 +1170,16 @@ describe("handleSlash", () => {
       rmSync(tempHome, { recursive: true, force: true });
     });
 
-    it("shows current theme status and available choices", () => {
+    it("opens the theme picker when no argument is given", () => {
       const r = handleSlash("theme", [], makeLoop());
-      expect(r.info).toMatch(/theme: github-dark/);
-      expect(r.info).toMatch(/configured: unset/);
-      expect(r.info).toMatch(/tokyo-night/);
+      expect(r.openThemePicker).toBe(true);
+      expect(r.info).toBeUndefined();
     });
 
     it("persists a registered theme", () => {
       const r = handleSlash("theme", ["tokyo-night"], makeLoop());
       expect(r.info).toMatch(/theme saved: tokyo-night/);
+      expect(r.openThemePicker).toBeUndefined();
       expect(loadTheme()).toBe("tokyo-night");
     });
 

--- a/tests/ui-slash-suggestions.test.tsx
+++ b/tests/ui-slash-suggestions.test.tsx
@@ -64,7 +64,7 @@ function hiddenAboveCount(frame: string): number {
 }
 
 describe("SlashSuggestions", () => {
-  it("renders the bare slash release command surface as 37 total commands", () => {
+  it("renders the bare slash release command surface as 38 total commands", () => {
     const matches = suggestSlashCommands("", true);
     const names = matches.map((spec) => spec.cmd);
     const { lastFrame, unmount } = render(
@@ -73,11 +73,11 @@ describe("SlashSuggestions", () => {
     const frame = lastFrame() ?? "";
     unmount();
 
-    expect(matches).toHaveLength(37);
+    expect(matches).toHaveLength(38);
     expect(names).toContain("language");
-    expect(countAdvancedCommands(true)).toBe(12);
-    expect(frame).toContain("37 commands");
-    expect(frame).toContain("+ 12 advanced");
+    expect(countAdvancedCommands(true)).toBe(11);
+    expect(frame).toContain("38 commands");
+    expect(frame).toContain("+ 11 advanced");
   });
 
   it("surfaces /language for typed language prefixes", () => {

--- a/tests/ui-theme-picker.test.tsx
+++ b/tests/ui-theme-picker.test.tsx
@@ -1,0 +1,46 @@
+import { render } from "ink";
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { ThemePicker } from "../src/cli/ui/ThemePicker.js";
+import { listThemeNames } from "../src/cli/ui/theme/tokens.js";
+import { makeFakeStdin, makeFakeStdout } from "./helpers/ink-stdio.js";
+
+function renderPicker(props: {
+  currentPreference: "auto" | ReturnType<typeof listThemeNames>[number];
+  activeTheme: ReturnType<typeof listThemeNames>[number];
+}): string {
+  const stdout = makeFakeStdout();
+  const { unmount } = render(
+    React.createElement(ThemePicker, {
+      currentPreference: props.currentPreference,
+      activeTheme: props.activeTheme,
+      onChoose: () => {},
+    }),
+    { stdout: stdout as never, stdin: makeFakeStdin() as never },
+  );
+  unmount();
+  return stdout.text();
+}
+
+describe("ThemePicker", () => {
+  it("lists auto and all registered themes", () => {
+    const text = renderPicker({ currentPreference: "auto", activeTheme: "github-dark" });
+    expect(text).toContain("auto");
+    for (const name of listThemeNames()) {
+      expect(text).toContain(name);
+    }
+  });
+
+  it("marks the current preference and active theme", () => {
+    const text = renderPicker({ currentPreference: "auto", activeTheme: "github-dark" });
+    expect(text).toMatch(/auto[\s\S]*current preference/);
+    expect(text).toMatch(/github-dark[\s\S]*active now/);
+  });
+
+  it("renders the keybind hint footer", () => {
+    const text = renderPicker({ currentPreference: "tokyo-night", activeTheme: "tokyo-night" });
+    expect(text).toContain("↑↓");
+    expect(text).toContain("⏎");
+    expect(text).toContain("esc");
+  });
+});


### PR DESCRIPTION
Re-land of @J3y0r's #543 on top of current main.

## Why a fresh PR

The original #543 branched from before #549 / #552 / #555 / #560 /
#566 landed; #566 in particular reformatted \`src/cli/ui/App.tsx\`
around a new \`<InflightProvider>\` wrap, which made GitHub flag #543
as DIRTY and produced a ~400-line conflict on local merge (mostly
indentation, but with the wrap interleaved). Rebasing onto current
main was simpler than resolving the merge in-place.

## What's in the PR

Same shape as #543:

- New \`ThemePicker\` modal (\`src/cli/ui/ThemePicker.tsx\`) — a
  \`SingleSelect\` listing \`auto\` + every registered theme, marking
  the current preference and the active theme.
- \`/theme\` slash handler now returns \`{ openThemePicker: true }\`
  on bare invocation; \`/theme <name>\` keeps its existing persist-
  and-report behaviour.
- \`/theme\` slash entry moved from the \`advanced\` group to \`setup\`
  and \`high-contrast\` added to the arg completer.
- App-level wiring: \`pendingThemePicker\` state, \`modalOpen\`
  inclusion, slash-result branch, and the picker render branch in
  the modal-conditional chain.

## Delta vs #543

- Rebased onto current main (post-#566), so the \`InflightProvider\`
  wrap is preserved.
- \`tests/ui-slash-suggestions.test.tsx\`: \`countAdvancedCommands(true)\`
  expectation updated 12 → 11 (the contributor caught the total going
  37 → 38 but missed the advanced count dropping by one when /theme
  moved out of advanced) and the matching \`"+ 12 advanced"\` string.

## Test plan

- [x] \`npm run verify\` passes (lint + typecheck + 2431 tests + comment-policy gate)
- [x] \`npm run build\` clean
- [ ] Smoke: \`/theme\` opens picker; arrow-key + Enter persists; \`/theme tokyo-night\` still works as a one-shot

Thanks @J3y0r for the contribution. Closing #543 in favour of this rebased version.