### PR TITLE
chore(release): 0.36.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,74 @@
 All notable changes to Reasonix. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.36.2] — 2026-05-09
+
+**Headline:** stability sweep on field-reported crashes and freezes —
+TUI no longer tears down on `/model` / `/sessions`, Esc and `/new`
+recover from a stuck plan checkpoint, the dashboard chat tab survives
+long streaming turns, plan-card spinners can't strand themselves on a
+missed end-event, and the model can't infer its identity from a
+foreign agent platform's data dir at the workspace root. New `/theme`
+picker for one-keystroke theme switching.
+
+**Fixes:**
+
+- fix(tui): a card-stream layout feedback loop (the `↑ earlier` hint
+  conditionally rendered as a sibling of the measured outer Box) tied
+  `outer.height` to `scrollRows`. Opening `/model` or `/sessions` —
+  which mounts a picker that shrinks the outer column by 10+ rows in
+  a single commit — could stack the cycle deep enough to trip React's
+  `MAX_NESTED_UPDATES = 50`, raising "Maximum update depth exceeded"
+  inside ink's `useBoxMetrics` and tearing down the TUI. The hint row
+  is now reserved unconditionally so its visibility no longer feeds
+  back into measurement. (#549)
+- fix(tui): `pauseGate.ask` ignored AbortSignal — when a tool was
+  awaiting the gate (e.g. `mark_step_complete` → `plan_checkpoint`)
+  and the user pressed Esc, the gate's promise stayed pending forever,
+  `busy` stayed true, the prompt stayed disabled, and `/new` was
+  silently dropped by `handleSubmit`'s `if (busy) return` guard. New
+  `pauseGate.cancelAll()` resolves every outstanding request with its
+  kind's safe-cancel verdict; Esc-during-busy and `/new` both flush
+  pending modals through it so the awaiting tool fn returns cleanly
+  and the user can recover. (#552)
+- fix(prompt): when the workspace root contained another agent
+  platform's config (`SOUL.md`, `skills/`, `memories/`, a foreign
+  `REASONIX.md`) the model would browse those files and claim a
+  layered architectural relationship — "the underlying runtime is
+  Hermes Agent" or similar. Top-of-prompt identity guard names the
+  failure mode: workspace files describe the user's project, never
+  what Reasonix is; identity questions are answered from the prompt,
+  not from `ls`. Plus a launch-time detector that warns when those
+  markers sit at the workspace root, suggesting `--dir <real-project>`.
+  (#555)
+- fix(dashboard): the embedded chat tab triggered Chrome's "Page not
+  responding" dialog during long sessions and concurrent jobs. Each
+  `assistant_delta` (~20/sec, more under fan-in) called setState
+  synchronously, re-rendering every historical `ChatMessage` with no
+  memoization — every delta re-ran `marked.parse` and `hljs.highlight`
+  on unchanged content. Memoized `ChatMessage` via `preact/compat`
+  `memo`, stabilised the per-row `streaming` prop so memo's shallow
+  compare actually bails out, and rAF-coalesced delta accumulation so
+  the streaming bubble re-renders at most once per frame regardless
+  of delta volume. (#560)
+- fix(loop): tool-card spinners occasionally kept spinning after the
+  underlying work had finished — the `running` flag was set
+  imperatively from paired events, and any exit path that forgot to
+  emit the closing event (storm-breaker, network drop, parent abort
+  propagating, hook block) left the card stuck. Replaced with a
+  finally-guaranteed `InflightSet` on the loop: tools are added at
+  dispatch entry and deleted in `finally` regardless of how the call
+  exits. UI tool cards consult the set via `useIsInflight(card.id)`
+  for the spinner, decoupling running-or-not from end-event delivery.
+  (#566)
+
+**Features:**
+
+- feat(ui): bare `/theme` opens a SingleSelect picker listing `auto`
+  + every registered theme; `/theme <name>` keeps its existing
+  persist-and-report behaviour. (#543, contributed by @J3y0r;
+  re-landed via #567 after rebasing onto current main)
+
 ## [0.36.1] — 2026-05-09
 
 **Fixes:**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reasonix",
-  "version": "0.36.1",
+  "version": "0.36.2",
   "description": "DeepSeek-native coding agent: cache-first loop, flash-first cost control, tool-call repair.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Stability sweep — TUI / dashboard / loop bugs from field reports plus
the new \`/theme\` picker.

## What's in 0.36.2

**Fixes:**

- **#549** — TUI tear-down on \`/model\` / \`/sessions\`: a card-stream
  layout feedback loop tied \`outer.height\` to \`scrollRows\`, which
  could trip React's \`MAX_NESTED_UPDATES\` when a picker mounted and
  shrank the column in one commit.
- **#552** — Stuck plan checkpoint: \`pauseGate.ask\` ignored
  AbortSignal, so Esc and \`/new\` couldn't cancel an awaiting tool fn.
  New \`pauseGate.cancelAll()\` flushed by both paths.
- **#555** — Identity contamination: workspace files (Hermes /
  persona platforms' \`SOUL.md\`, \`skills/\`, \`memories/\`, foreign
  \`REASONIX.md\`) could make the model claim a layered architectural
  relationship. Top-of-prompt identity guard + launch-time foreign-
  workspace warning.
- **#560** — Dashboard chat-tab freeze on long sessions: every
  \`assistant_delta\` re-rendered every historical message,
  re-running marked + hljs on unchanged content. Memoized
  \`ChatMessage\` + rAF-coalesced delta accumulation.
- **#566** — Stuck tool-card spinner: \`running\` flag was
  imperatively set from paired events; missed end-events left it
  spinning forever. Replaced with a finally-guaranteed \`InflightSet\`
  on the loop; UI derives the spinner via \`useIsInflight(card.id)\`.

**Features:**

- **#543 / #567** — \`/theme\` picker (contributed by @J3y0r): bare
  \`/theme\` opens a SingleSelect modal listing \`auto\` + every
  registered theme; \`/theme <name>\` keeps existing persist-and-report.

## Test plan

- [x] \`npm run verify\` passes — 2431 tests, lint clean, comment-policy gate clean
- [x] \`npm run build\` clean (CLI + dashboard bundle)
- [ ] Smoke: \`/theme\` and \`/model\` both open without "Maximum update depth exceeded"
- [ ] Smoke: Esc during a stuck plan_checkpoint clears state and re-enables prompt
- [ ] Smoke: long streaming reply on dashboard tab doesn't freeze