### PR TITLE
docs(site): bilingual config guide, README restructure, SEO + perf cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
   &nbsp;·&nbsp;
   <a href="https://esengine.github.io/DeepSeek-Reasonix/">Website</a>
   &nbsp;·&nbsp;
+  <a href="https://esengine.github.io/DeepSeek-Reasonix/configuration.html">Guide</a>
+  &nbsp;·&nbsp;
   <a href="./docs/ARCHITECTURE.md">Architecture</a>
   &nbsp;·&nbsp;
   <a href="./benchmarks/">Benchmarks</a>
@@ -46,49 +48,6 @@
 
 <br/>
 
-## Web search
-
-Reasonix includes `web_search` and `web_fetch` tools. By default it uses **Mojeek** (no setup required). You can switch to a **self-hosted SearXNG** instance — a metasearch engine that aggregates whatever upstream engines your instance is configured for.
-
-### Switching engines (persists to disk)
-
-The `/search-engine` slash command (alias `/se`) writes your choice to `~/.reasonix/config.json` immediately — it survives restarts:
-
-```
-/search-engine mojeek              # default, no external deps
-/search-engine searxng             # SearXNG at http://localhost:8080
-/search-engine searxng http://192.168.1.100:8888  # custom endpoint
-```
-
-Equivalent `~/.reasonix/config.json`:
-
-```json
-{
-  "webSearchEngine": "searxng",
-  "webSearchEndpoint": "http://localhost:8080"
-}
-```
-
-The tool picks up the change on the next call — no restart needed.
-
-### Starting SearXNG
-
-```sh
-podman run -d --replace --name searxng -p 8080:8080 docker.io/searxng/searxng
-# or: docker run -d -p 8080:8080 searxng/searxng
-```
-
-Verify it's running:
-
-```sh
-curl http://localhost:8080/search?q=test
-# → HTML search results page
-```
-
-> **Note:** The endpoint must include the protocol (`http://`). `localhost:8080` alone will fail — the tool will show a clear error telling you to install SearXNG if the server is unreachable.
-
-<br/>
-
 ## Install
 
 ```bash
@@ -96,55 +55,68 @@ cd my-project
 npx reasonix code   # paste a DeepSeek API key on first run; persists after
 ```
 
-Requires Node ≥ 22. Tested on macOS · Linux · Windows (PowerShell · Git Bash · Windows Terminal). Get a [DeepSeek API key →](https://platform.deepseek.com/api_keys) · `reasonix code --help` for flags.
+Requires Node ≥ 22. Works on macOS · Linux · Windows (PowerShell · Git Bash · Windows Terminal). Grab a [DeepSeek API key →](https://platform.deepseek.com/api_keys) · `reasonix code --help` for flags.
 
-`npx` is the recommended path — no global install, always picks up the latest version. If you'll use Reasonix daily and want `reasonix` on your `PATH`, run `reasonix update` once and it'll do the `npm install -g` for you.
+`npx` is the recommended path — no global install, always latest. If you use Reasonix daily and want it on `PATH`, run `reasonix update` once.
 
-### Subcommand cheatsheet
-
-| Command | When to use |
+| Command | When |
 |---|---|
-| `reasonix code [dir]` | Coding agent rooted at a project. **Start here.** |
-| `reasonix chat` | Plain chat — no filesystem tools, just a conversation with persisted history. |
-| `reasonix run "task"` | One-shot, streams the answer to stdout. Good for shell pipes. |
-| `reasonix doctor` | Environment health check (Node version, API key, MCP wiring). |
+| `reasonix code [dir]` | The coding agent. **Start here.** |
+| `reasonix chat` | Plain chat — no filesystem or shell tools. |
+| `reasonix run "task"` | One-shot, streams to stdout. Good for pipes. |
+| `reasonix doctor` | Health check: Node, API key, MCP wiring. |
 | `reasonix update` | Upgrade Reasonix itself. |
 
-Other subcommands (`replay` · `diff` · `events` · `stats` · `index` · `mcp` · `prune-sessions`) are listed in `reasonix --help` and on the [CLI reference](https://esengine.github.io/DeepSeek-Reasonix/#cli).
+Other subcommands (`replay` · `diff` · `events` · `stats` · `index` · `mcp` · `prune-sessions`) are in `reasonix --help` and the [CLI reference](https://esengine.github.io/DeepSeek-Reasonix/#cli).
 
-#### When to pick `chat` over `code`
+<details>
+<summary><strong>Working in another folder · chat vs. code · author a skill</strong></summary>
 
-`code` is the default — it's the only mode that can read, write, or edit files, run shell commands, or apply SEARCH/REPLACE blocks. `chat` strips all of that down to a plain conversation; reach for it when you want a thinking-partner shell without granting filesystem or shell access.
+**Working in a different folder.** Reasonix scopes filesystem tools to the launch directory; pass `--dir` to retarget. Mid-session switching isn't supported by design (memory paths would tangle with stale roots) — quit and relaunch.
 
-| What you get | `reasonix code` | `reasonix chat` |
+```bash
+npx reasonix code --dir /path/to/project
+```
+
+**Picking `chat` vs `code`.** `code` is the default and the only mode with filesystem / shell tools and SEARCH/REPLACE review. `chat` is the lighter, tools-off shell — reach for it when you want a thinking partner with MCP attached but no disk access.
+
+| What you get | `code` | `chat` |
 |---|---|---|
-| Native filesystem tools (read · write · `edit_file`) | ✓ | — |
-| SEARCH/REPLACE edit blocks → `/apply` review | ✓ | — |
-| Shell tool (with confirm gate, `/mode yolo` to skip) | ✓ | — |
-| Plan mode · `submit_plan` · `/todo` · `/skill new` · `/mcp add` scaffolding | ✓ | — |
-| Memory tools (`remember` / `recall_memory`) | project + global | global only |
-| Web search · `ask_choice` · MCP servers from config | ✓ | ✓ |
-| Coding-focused system prompt (SEARCH/REPLACE, repo etiquette) | ✓ | generic |
-| Session scope | per-directory (`code-<basename>`) | shared default |
+| Filesystem tools + `edit_file` | ✓ | — |
+| SEARCH/REPLACE → `/apply` review | ✓ | — |
+| Shell tool (gated) | ✓ | — |
+| Plan mode · `/todo` · `/skill new` · `/mcp add` | ✓ | — |
+| Memory (`remember` / `recall_memory`) | project + global | global only |
+| MCP servers from config · web search · `ask_choice` | ✓ | ✓ |
+| Coding system prompt | ✓ | generic |
+| Session scope | per-directory | shared default |
 
-`chat` still picks up MCP servers from `~/.reasonix/config.json`, so if all you want is a chat shell with one or two MCP integrations, it's the lighter entrypoint. Otherwise `code` is what every screenshot, benchmark, and slash-command example in the docs assumes.
-
-**Working in a different folder:** Reasonix scopes filesystem tools to the launch directory. To work elsewhere, pass `--dir`:
+**Author your first skill.** No remote registry — write them directly. Edit the file (`description:` frontmatter + body), then `/skill list`. Add `runAs: subagent` to spawn an isolated subagent loop instead of inlining the body.
 
 ```bash
-npx reasonix code --dir /path/to/project   # or use a relative path
+/skill new my-skill              # <project>/.reasonix/skills/my-skill.md
+/skill new my-skill --global     # ~/.reasonix/skills for cross-project use
 ```
 
-Mid-session switching isn't supported by design (the message log + memory paths get tangled with stale roots). Quit and relaunch with a new `--dir` to retarget. `/status` always shows the current pinned workspace.
+</details>
 
-**Author your first skill:** Skills are markdown playbooks the model can invoke (`/skill <name>`). There's no remote registry yet — you author them directly:
+<br/>
 
-```bash
-/skill new my-skill          # scaffolds <project>/.reasonix/skills/my-skill.md
-/skill new my-skill --global # or under ~/.reasonix/skills for cross-project use
-```
+## Configuration
 
-Edit the file (`description:` frontmatter + body), then `/skill list` to see it. Add `runAs: subagent` to the frontmatter to spawn an isolated subagent loop instead of inlining the body.
+One JSON file at `~/.reasonix/config.json` plus per-project overrides under `<project>/.reasonix/`. The full bilingual reference — every key, every slash command, the on-disk shape of skills/memory/hooks — lives at:
+
+> 📘 **[Configuration Guide](https://esengine.github.io/DeepSeek-Reasonix/configuration.html)** · [中文](https://esengine.github.io/DeepSeek-Reasonix/configuration.html?lang=zh)
+
+| Topic | Quick read |
+|---|---|
+| [MCP servers](https://esengine.github.io/DeepSeek-Reasonix/configuration.html#mcp) | stdio · SSE · Streamable HTTP. One spec format works for both `config.json` and `--mcp`. |
+| [Skills](https://esengine.github.io/DeepSeek-Reasonix/configuration.html#skills) | Markdown playbooks the model can invoke. `inline` or `subagent` mode. |
+| [Memory](https://esengine.github.io/DeepSeek-Reasonix/configuration.html#memory) | User-private knowledge pinned into the prefix. `user` / `feedback` / `project` / `reference` types. |
+| [Hooks](https://esengine.github.io/DeepSeek-Reasonix/configuration.html#hooks) | Shell commands on lifecycle events. `PreToolUse` (gating) · `PostToolUse` · `UserPromptSubmit` · `Stop`. |
+| [Permissions](https://esengine.github.io/DeepSeek-Reasonix/configuration.html#permissions) | Per-workspace shell allowlist. Exact-prefix match. |
+| [Web search](https://esengine.github.io/DeepSeek-Reasonix/configuration.html#search) | Mojeek by default; switch to self-hosted SearXNG with `/search-engine`. |
+| [Semantic index](https://esengine.github.io/DeepSeek-Reasonix/configuration.html#index) | `reasonix index` — local Ollama or any OpenAI-compatible embedding endpoint. |
 
 <br/>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,6 +9,8 @@
   &nbsp;·&nbsp;
   <a href="https://esengine.github.io/DeepSeek-Reasonix/">官方网站</a>
   &nbsp;·&nbsp;
+  <a href="https://esengine.github.io/DeepSeek-Reasonix/configuration.html?lang=zh">配置指南</a>
+  &nbsp;·&nbsp;
   <a href="./docs/ARCHITECTURE.md">架构文档</a>
   &nbsp;·&nbsp;
   <a href="./benchmarks/">基准测试</a>
@@ -50,55 +52,68 @@ cd my-project
 npx reasonix code   # 首次运行粘贴 DeepSeek API Key，之后会记住
 ```
 
-要求 Node ≥ 22。已在 macOS · Linux · Windows（PowerShell · Git Bash · Windows Terminal）测过。[去拿 DeepSeek API Key →](https://platform.deepseek.com/api_keys) · 完整 flag 看 `reasonix code --help`。
+要求 Node ≥ 22。在 macOS · Linux · Windows（PowerShell · Git Bash · Windows Terminal）都跑得顺。[去拿 DeepSeek API Key →](https://platform.deepseek.com/api_keys) · 完整 flag 看 `reasonix code --help`。
 
-`npx` 是推荐路径 —— 不用全局安装，每次都拿到最新版本。如果你天天用、想把 `reasonix` 装到 `PATH` 上，跑一次 `reasonix update` 就行，它会替你跑 `npm install -g`。
+`npx` 是推荐路径 —— 不用全局安装，每次都拿最新版。如果你天天用、想把 `reasonix` 装到 `PATH`，跑一次 `reasonix update`。
 
-### 子命令速查
-
-| 命令 | 适用场景 |
+| 命令 | 何时用 |
 |---|---|
-| `reasonix code [dir]` | 锁在某个项目根目录的编码 agent。**先用这个。** |
-| `reasonix chat` | 纯聊天 —— 不挂文件系统工具，只是带历史的对话。 |
-| `reasonix run "task"` | 一次性，把答案直接流到 stdout。适合 shell 管道。 |
-| `reasonix doctor` | 环境体检（Node 版本、API Key、MCP 接线）。 |
+| `reasonix code [dir]` | 编码 agent。**先用这个。** |
+| `reasonix chat` | 纯聊天 —— 不挂文件系统 / shell 工具。 |
+| `reasonix run "task"` | 一次性，结果流到 stdout。适合 shell 管道。 |
+| `reasonix doctor` | 体检：Node 版本、API Key、MCP 接线。 |
 | `reasonix update` | 升级 Reasonix 本身。 |
 
-其他子命令（`replay` · `diff` · `events` · `stats` · `index` · `mcp` · `prune-sessions`）见 `reasonix --help` 和 [CLI 参考](https://esengine.github.io/DeepSeek-Reasonix/#cli)。
+其他子命令（`replay` · `diff` · `events` · `stats` · `index` · `mcp` · `prune-sessions`）在 `reasonix --help` 和 [CLI 参考](https://esengine.github.io/DeepSeek-Reasonix/#cli)。
 
-#### 什么时候用 `chat` 而不是 `code`
+<details>
+<summary><strong>切换工作区 · chat vs. code · 写第一个 Skill</strong></summary>
 
-`code` 是默认入口 —— 只有它能读写、编辑文件、跑 shell 命令、解析 SEARCH/REPLACE 块。`chat` 把这些全砍掉，只剩一个纯对话外壳；当你只想找模型对一对思路、又不想授予文件系统或 shell 权限时用它。
+**切换工作区。** Reasonix 把文件系统工具作用域绑定在启动目录，传 `--dir` 可以指别处。中途切换是有意不支持的（消息日志和 memory 路径会和旧根目录混在一起）—— 退出再启动。
 
-| 你拿到什么 | `reasonix code` | `reasonix chat` |
+```bash
+npx reasonix code --dir /path/to/project
+```
+
+**`chat` 还是 `code`？** `code` 是默认入口、唯一带文件系统 / shell 工具和 SEARCH/REPLACE 审阅的模式。`chat` 是更轻量的纯对话壳——想要一个挂着 MCP 但没有磁盘权限的“思路助手”时用它。
+
+| 你拿到什么 | `code` | `chat` |
 |---|---|---|
-| 原生文件系统工具（read · write · `edit_file`） | ✓ | — |
-| SEARCH/REPLACE 编辑块 → `/apply` 审核 | ✓ | — |
-| Shell 工具（带 confirm gate，`/mode yolo` 跳过） | ✓ | — |
-| Plan 模式 · `submit_plan` · `/todo` · `/skill new` · `/mcp add` 脚手架 | ✓ | — |
-| 记忆工具（`remember` / `recall_memory`） | 项目 + 全局 | 仅全局 |
-| Web 搜索 · `ask_choice` · 从配置加载的 MCP 服务 | ✓ | ✓ |
-| 编码导向系统提示词（SEARCH/REPLACE、仓库礼仪） | ✓ | 通用 |
-| Session 作用域 | 按目录（`code-<basename>`） | 共享默认 |
+| 文件系统工具 + `edit_file` | ✓ | — |
+| SEARCH/REPLACE → `/apply` 审阅 | ✓ | — |
+| Shell 工具（带 gate） | ✓ | — |
+| Plan 模式 · `/todo` · `/skill new` · `/mcp add` | ✓ | — |
+| Memory（`remember` / `recall_memory`） | 项目 + 全局 | 仅全局 |
+| 配置里的 MCP · web 搜索 · `ask_choice` | ✓ | ✓ |
+| 编码导向系统提示词 | ✓ | 通用 |
+| Session 作用域 | 按目录 | 共享默认 |
 
-`chat` 同样会从 `~/.reasonix/config.json` 读取 MCP 服务器，所以如果你只是想要一个聊天外壳挂一两个 MCP 集成，它是更轻量的入口。其他场景下，文档里所有截图、基准测试、slash 命令例子默认都是 `code`。
-
-**在其他目录工作：** Reasonix 把文件系统工具作用域绑定在启动目录。要在别的目录工作，传 `--dir`：
+**写第一个 Skill。** 暂无在线市场——自己写。编辑文件（`description:` frontmatter + 正文），然后 `/skill list` 就能看到。frontmatter 加 `runAs: subagent` 会以隔离 subagent 跑，而不是把正文内联进父 prompt。
 
 ```bash
-npx reasonix code --dir /path/to/project   # 也可以用相对路径
+/skill new my-skill              # <project>/.reasonix/skills/my-skill.md
+/skill new my-skill --global     # ~/.reasonix/skills，跨项目共用
 ```
 
-中途切换工作区是有意不支持的（消息日志和 memory 路径会和旧的根目录混在一起，状态错乱）。退出后用新的 `--dir` 重新启动来切换。`/status` 始终显示当前锁定的工作区。
+</details>
 
-**写第一个 Skill：** Skills 是模型可以调用的 markdown 剧本（`/skill <name>`）。暂无在线市场 —— 自己写：
+<br/>
 
-```bash
-/skill new my-skill          # 在 <project>/.reasonix/skills/my-skill.md 生成模板
-/skill new my-skill --global # 或者放到 ~/.reasonix/skills，跨项目共用
-```
+## 配置
 
-编辑文件（`description:` frontmatter + 正文），然后 `/skill list` 就能看到。frontmatter 里加 `runAs: subagent` 会以独立 subagent 跑，而不是把正文内联进父 prompt。
+一个全局 JSON 文件 `~/.reasonix/config.json`，加上项目级 `<project>/.reasonix/` 下的覆盖。完整的双语参考 —— 每一个 key、每一条斜杠命令、skills / memory / hooks 在磁盘上的形状 —— 都在这里：
+
+> 📘 **[配置指南](https://esengine.github.io/DeepSeek-Reasonix/configuration.html?lang=zh)** · [English](https://esengine.github.io/DeepSeek-Reasonix/configuration.html)
+
+| 主题 | 速读 |
+|---|---|
+| [MCP 服务器](https://esengine.github.io/DeepSeek-Reasonix/configuration.html?lang=zh#mcp) | stdio · SSE · Streamable HTTP。`config.json` 和 `--mcp` 共用同一种 spec 格式。 |
+| [Skills](https://esengine.github.io/DeepSeek-Reasonix/configuration.html?lang=zh#skills) | 模型可以调用的 markdown 剧本。`inline` 或 `subagent` 两种模式。 |
+| [Memory](https://esengine.github.io/DeepSeek-Reasonix/configuration.html?lang=zh#memory) | 用户私有的知识，钉进前缀。`user` / `feedback` / `project` / `reference` 四类。 |
+| [Hooks](https://esengine.github.io/DeepSeek-Reasonix/configuration.html?lang=zh#hooks) | 生命周期事件触发的 shell 命令。`PreToolUse`（拦截）· `PostToolUse` · `UserPromptSubmit` · `Stop`。 |
+| [权限](https://esengine.github.io/DeepSeek-Reasonix/configuration.html?lang=zh#permissions) | 按工作区的 shell 白名单，精确前缀匹配。 |
+| [Web 搜索](https://esengine.github.io/DeepSeek-Reasonix/configuration.html?lang=zh#search) | 默认 Mojeek；用 `/search-engine` 可切到自托管的 SearXNG。 |
+| [语义索引](https://esengine.github.io/DeepSeek-Reasonix/configuration.html?lang=zh#index) | `reasonix index` —— 本地 Ollama，或任何 OpenAI 兼容的 embedding 接口。 |
 
 <br/>
 

--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -1,0 +1,687 @@
+<!doctype html>
+<html lang="en" data-lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Configuration Guide — Reasonix · MCP, Skills, Memory, Hooks</title>
+    <meta
+      name="description"
+      content="Bilingual configuration guide for Reasonix — MCP servers, skills, memory, hooks, permissions, web search, and the full ~/.reasonix/config.json reference."
+    />
+    <meta
+      name="keywords"
+      content="Reasonix configuration, MCP setup, Model Context Protocol config, Claude Code skills, AI agent memory, lifecycle hooks, DeepSeek CLI, reasonix.config.json"
+    />
+    <meta name="author" content="esengine" />
+    <meta name="theme-color" content="#0b0f17" />
+    <meta name="robots" content="index, follow, max-image-preview:large" />
+
+    <link
+      rel="canonical"
+      href="https://esengine.github.io/DeepSeek-Reasonix/configuration.html"
+    />
+    <link
+      rel="alternate"
+      hreflang="en"
+      href="https://esengine.github.io/DeepSeek-Reasonix/configuration.html?lang=en"
+    />
+    <link
+      rel="alternate"
+      hreflang="zh-CN"
+      href="https://esengine.github.io/DeepSeek-Reasonix/configuration.html?lang=zh"
+    />
+    <link
+      rel="alternate"
+      hreflang="x-default"
+      href="https://esengine.github.io/DeepSeek-Reasonix/configuration.html"
+    />
+
+    <meta property="og:type" content="article" />
+    <meta property="og:site_name" content="Reasonix" />
+    <meta property="og:title" content="Reasonix Configuration Guide" />
+    <meta
+      property="og:description"
+      content="MCP, skills, memory, hooks, permissions — every key, every slash command, the on-disk shape."
+    />
+    <meta
+      property="og:url"
+      content="https://esengine.github.io/DeepSeek-Reasonix/configuration.html"
+    />
+    <meta
+      property="og:image"
+      content="https://raw.githubusercontent.com/esengine/reasonix/main/docs/assets/hero-terminal.svg"
+    />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:locale:alternate" content="zh_CN" />
+
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Reasonix Configuration Guide" />
+    <meta
+      name="twitter:description"
+      content="MCP, skills, memory, hooks, permissions — every key, every slash command."
+    />
+
+    <link rel="icon" type="image/svg+xml" href="favicon.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&family=Noto+Sans+SC:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="stylesheet" href="guide.css" />
+
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "TechArticle",
+        "headline": "Reasonix Configuration Guide",
+        "description": "MCP servers, skills, memory, hooks, permissions, web search, and the full ~/.reasonix/config.json reference.",
+        "url": "https://esengine.github.io/DeepSeek-Reasonix/configuration.html",
+        "inLanguage": ["en", "zh-CN"],
+        "author": {
+          "@type": "Organization",
+          "name": "esengine",
+          "url": "https://github.com/esengine"
+        },
+        "isPartOf": {
+          "@type": "WebSite",
+          "name": "Reasonix",
+          "url": "https://esengine.github.io/DeepSeek-Reasonix/"
+        },
+        "about": {
+          "@type": "SoftwareApplication",
+          "name": "Reasonix"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "Reasonix",
+            "item": "https://esengine.github.io/DeepSeek-Reasonix/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "Configuration Guide",
+            "item": "https://esengine.github.io/DeepSeek-Reasonix/configuration.html"
+          }
+        ]
+      }
+    </script>
+  </head>
+
+  <body>
+    <div class="bg-grid" aria-hidden="true"></div>
+    <div class="bg-glow" aria-hidden="true"></div>
+    <div class="bg-horizon" aria-hidden="true"></div>
+
+    <header class="nav">
+      <a class="nav-brand" href="index.html" aria-label="Reasonix">
+        <span class="brand-mark" aria-hidden="true">
+          <span class="diamond"></span>
+          <span class="diamond inner"></span>
+        </span>
+        <span class="brand-name">Reasonix</span>
+      </a>
+
+      <nav class="nav-links">
+        <a href="index.html#why" data-i18n="nav.why">Why</a>
+        <a href="index.html#features" data-i18n="nav.features">Features</a>
+        <a href="index.html#quickstart" data-i18n="nav.quickstart">Quick start</a>
+        <a href="configuration.html" data-i18n="nav.guide" class="active">Guide</a>
+        <a
+          href="https://github.com/esengine/reasonix"
+          target="_blank"
+          rel="noopener"
+          data-i18n="nav.github"
+          >GitHub</a
+        >
+      </nav>
+
+      <div class="nav-actions">
+        <div class="lang-switch" role="group" aria-label="Language">
+          <button data-lang-btn="en" type="button" aria-pressed="true">EN</button>
+          <button data-lang-btn="zh" type="button" aria-pressed="false">中文</button>
+        </div>
+      </div>
+    </header>
+
+    <main class="guide-main" id="top">
+      <section class="guide-hero">
+        <div class="container">
+          <div class="badge" data-i18n="guide.badge">Configuration · MCP · Skills · Memory</div>
+          <h1 class="guide-title">
+            <span class="grad-text" data-i18n="guide.title.line1">Configure Reasonix</span>
+            <br />
+            <span data-i18n="guide.title.line2">in five minutes</span>
+          </h1>
+          <p class="guide-sub" data-i18n="guide.sub">
+            One JSON file at <code>~/.reasonix/config.json</code> + per-project overrides
+            under <code>.reasonix/</code>. This page documents every key, every slash
+            command, and the on-disk shape of skills, memory, and hooks.
+          </p>
+        </div>
+      </section>
+
+      <div class="guide-shell container">
+        <aside class="guide-toc" aria-label="On this page">
+          <h4 data-i18n="guide.toc.title">On this page</h4>
+          <ul>
+            <li><a href="#config-json" data-i18n="guide.toc.config">config.json</a></li>
+            <li><a href="#mcp" data-i18n="guide.toc.mcp">MCP servers</a></li>
+            <li><a href="#skills" data-i18n="guide.toc.skills">Skills</a></li>
+            <li><a href="#memory" data-i18n="guide.toc.memory">Memory</a></li>
+            <li><a href="#hooks" data-i18n="guide.toc.hooks">Hooks</a></li>
+            <li><a href="#permissions" data-i18n="guide.toc.perms">Permissions</a></li>
+            <li><a href="#search" data-i18n="guide.toc.search">Web search</a></li>
+            <li><a href="#index" data-i18n="guide.toc.index">Semantic index</a></li>
+          </ul>
+        </aside>
+
+        <article class="guide-body">
+          <section id="config-json">
+            <h2 data-i18n="cfg.title">The config.json file</h2>
+            <p data-i18n="cfg.body1">
+              Reasonix reads a single global config from <code>~/.reasonix/config.json</code>
+              (Windows: <code>%USERPROFILE%\.reasonix\config.json</code>). The file is created
+              automatically on first run; you can hand-edit it any time. The CLI flag
+              <code>--no-config</code> bypasses it, useful in CI.
+            </p>
+            <p data-i18n="cfg.body2">
+              Per-project overrides live under <code>&lt;project&gt;/.reasonix/</code> —
+              skills, memory, settings.json (hooks). Project scope wins over global on name
+              collision.
+            </p>
+            <h3 data-i18n="cfg.shape">Top-level keys</h3>
+            <pre class="code"><code>{
+  "apiKey": "sk-...",
+  "baseUrl": "https://api.deepseek.com",
+  "lang": "en",                       <span class="hash"># <span data-i18n="cfg.k.lang">UI language: en | zh</span></span>
+  "preset": "auto",                   <span class="hash"># <span data-i18n="cfg.k.preset">auto | flash | pro</span></span>
+  "editMode": "review",               <span class="hash"># <span data-i18n="cfg.k.editmode">review | auto | yolo</span></span>
+  "reasoningEffort": "high",          <span class="hash"># <span data-i18n="cfg.k.effort">high | max</span></span>
+  "theme": "auto",                    <span class="hash"># <span data-i18n="cfg.k.theme">light | dark | auto</span></span>
+  "search": false,                    <span class="hash"># <span data-i18n="cfg.k.search">enable web_search/web_fetch tools</span></span>
+  "webSearchEngine": "mojeek",        <span class="hash"># <span data-i18n="cfg.k.engine">mojeek | searxng</span></span>
+  "webSearchEndpoint": "http://localhost:8080",
+  "mcp": [],                          <span class="hash"># <span data-i18n="cfg.k.mcp">MCP server specs</span></span>
+  "mcpDisabled": [],                  <span class="hash"># <span data-i18n="cfg.k.mcpoff">names skipped at startup</span></span>
+  "projects": {                       <span class="hash"># <span data-i18n="cfg.k.projects">per-workspace overrides</span></span>
+    "/abs/path": {
+      "shellAllowed": ["npm", "git status"]
+    }
+  },
+  "semantic": { ... },                <span class="hash"># <span data-i18n="cfg.k.semantic">embedding provider for `reasonix index`</span></span>
+  "session": null
+}</code></pre>
+            <div class="callout">
+              <div class="callout-tag" data-i18n="cfg.callout.tag">Trust dial</div>
+              <p data-i18n="cfg.callout.body">
+                <code>editMode</code> is the single trust dial for an entire session.
+                <code>review</code> queues edits + gates shell. <code>auto</code> applies
+                edits + still gates shell. <code>yolo</code> skips both gates — only use
+                inside a sandbox.
+              </p>
+            </div>
+          </section>
+
+          <section id="mcp">
+            <h2 data-i18n="mcp.title">MCP servers</h2>
+            <p data-i18n="mcp.body1">
+              Reasonix speaks the Model Context Protocol natively. Every entry in
+              <code>config.mcp</code> is a single string — the same format the
+              <code>--mcp</code> CLI flag accepts — so one parser handles both. Three
+              transports are supported.
+            </p>
+            <h3 data-i18n="mcp.h.stdio">Stdio (subprocess)</h3>
+            <pre class="code"><code>{
+  "mcp": [
+    "fs=npx -y @modelcontextprotocol/server-filesystem /tmp",
+    "git=uvx mcp-server-git --repository ."
+  ]
+}</code></pre>
+            <p data-i18n="mcp.body.stdio">
+              Format: <code>name=command arg1 arg2</code>. The <code>name=</code> prefix
+              namespaces every tool the server exposes. Args use shell-style splitting;
+              quote any with spaces.
+            </p>
+
+            <h3 data-i18n="mcp.h.sse">SSE (HTTP)</h3>
+            <pre class="code"><code>{
+  "mcp": [
+    "remote=https://example.com/mcp/sse",
+    "https://other.example.com/mcp"
+  ]
+}</code></pre>
+            <p data-i18n="mcp.body.sse">
+              Plain <code>http://</code> / <code>https://</code> URLs use HTTP+SSE for
+              back-compat. Anonymous (no <code>name=</code>) entries work but can't be
+              toggled by name later.
+            </p>
+
+            <h3 data-i18n="mcp.h.streamable">Streamable HTTP (2025-03 spec)</h3>
+            <pre class="code"><code>{
+  "mcp": [
+    "edge=streamable+https://edge.example.com/mcp"
+  ]
+}</code></pre>
+            <p data-i18n="mcp.body.streamable">
+              Opt in with the <code>streamable+</code> URL prefix.
+            </p>
+
+            <h3 data-i18n="mcp.h.cli">CLI flags &amp; slash commands</h3>
+            <pre class="code"><code>npx reasonix code --mcp "fs=npx -y @mcp/server-filesystem /tmp"
+npx reasonix mcp inspect "git=uvx mcp-server-git"
+npx reasonix mcp list</code></pre>
+            <table class="cmd-table">
+              <thead>
+                <tr>
+                  <th data-i18n="th.cmd">Command</th>
+                  <th data-i18n="th.what">What it does</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>/mcp</code></td>
+                  <td data-i18n="mcp.cmd.hub">Open the interactive MCP hub.</td>
+                </tr>
+                <tr>
+                  <td><code>/mcp disable &lt;name&gt;</code></td>
+                  <td data-i18n="mcp.cmd.disable">
+                    Persist to <code>mcpDisabled</code>; effective on next launch.
+                  </td>
+                </tr>
+                <tr>
+                  <td><code>/mcp enable &lt;name&gt;</code></td>
+                  <td data-i18n="mcp.cmd.enable">Re-enable a disabled server.</td>
+                </tr>
+                <tr>
+                  <td><code>/mcp reconnect &lt;name&gt;</code></td>
+                  <td data-i18n="mcp.cmd.recon">
+                    Reconnect a live server and pick up newly-registered tools.
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+
+          <section id="skills">
+            <h2 data-i18n="sk.title">Skills</h2>
+            <p data-i18n="sk.body1">
+              A skill is a markdown playbook the model can invoke (<code>/skill &lt;name&gt;</code>).
+              Names + descriptions are pinned in the prompt; bodies load on demand. Project
+              skills override global ones with the same name.
+            </p>
+            <h3 data-i18n="sk.h.layout">Layout</h3>
+            <pre class="code"><code>~/.reasonix/skills/<span class="hash">           # global</span>
+  audit-logs.md
+  refactor-react/
+    SKILL.md
+
+&lt;project&gt;/.reasonix/skills/<span class="hash">    # project (overrides global)</span>
+  release-notes.md</code></pre>
+            <p data-i18n="sk.body.layout">
+              Two equivalent shapes: a flat <code>&lt;name&gt;.md</code>, or a
+              <code>&lt;name&gt;/SKILL.md</code> folder when you want to colocate
+              attachments.
+            </p>
+
+            <h3 data-i18n="sk.h.fm">Frontmatter</h3>
+            <pre class="code"><code>---
+name: audit-logs
+description: <span data-i18n="sk.fm.desc">Review git log for security red flags.</span>
+runAs: inline                  <span class="hash"># <span data-i18n="sk.fm.runas">inline | subagent</span></span>
+allowed-tools: bash,read       <span class="hash"># <span data-i18n="sk.fm.tools">subagent tool allowlist</span></span>
+model: deepseek-chat           <span class="hash"># <span data-i18n="sk.fm.model">subagent model override</span></span>
+---
+
+## <span data-i18n="sk.body.task">Task</span>
+
+1. <span data-i18n="sk.body.s1">Fetch the last 20 commits.</span>
+2. <span data-i18n="sk.body.s2">Flag commits whose message mentions password / secret / token.</span>
+3. <span data-i18n="sk.body.s3">Report findings.</span></code></pre>
+            <ul class="kv-list">
+              <li>
+                <code>name</code>
+                <span data-i18n="sk.fm.f.name">1–64 chars: alnum, <code>_</code>, <code>-</code>, interior <code>.</code>. Defaults to filename stem.</span>
+              </li>
+              <li>
+                <code>description</code>
+                <span data-i18n="sk.fm.f.desc">One line. Shown in <code>/skill list</code>.</span>
+              </li>
+              <li>
+                <code>runAs</code>
+                <span data-i18n="sk.fm.f.runas">
+                  <code>inline</code> (default): body enters parent log. <code>subagent</code>:
+                  isolated child loop, only the final answer returns.
+                </span>
+              </li>
+              <li>
+                <code>allowed-tools</code>
+                <span data-i18n="sk.fm.f.tools">
+                  Comma-separated literal tool names. Subagent only — scopes the child's tool registry.
+                </span>
+              </li>
+              <li>
+                <code>model</code>
+                <span data-i18n="sk.fm.f.model">
+                  Subagent only. Must start with <code>deepseek-</code>; ignored otherwise.
+                </span>
+              </li>
+            </ul>
+
+            <h3 data-i18n="sk.h.cmds">Slash commands</h3>
+            <table class="cmd-table">
+              <tbody>
+                <tr>
+                  <td><code>/skill list</code></td>
+                  <td data-i18n="sk.cmd.list">List every skill, scope-tagged.</td>
+                </tr>
+                <tr>
+                  <td><code>/skill new &lt;name&gt;</code></td>
+                  <td data-i18n="sk.cmd.new">
+                    Scaffold a stub at project scope. Add <code>--global</code> for
+                    <code>~/.reasonix/skills</code>.
+                  </td>
+                </tr>
+                <tr>
+                  <td><code>/skill show &lt;name&gt;</code></td>
+                  <td data-i18n="sk.cmd.show">Print the full body.</td>
+                </tr>
+                <tr>
+                  <td><code>/skill &lt;name&gt; [args]</code></td>
+                  <td data-i18n="sk.cmd.run">
+                    Run it. Args are appended to the body as a single string.
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+
+          <section id="memory">
+            <h2 data-i18n="mem.title">Memory</h2>
+            <p data-i18n="mem.body1">
+              Memory is user-private knowledge pinned into the immutable prefix — so the
+              agent reads it on every turn without re-priming. Two scopes: <em>global</em>
+              (cross-project facts about you) and <em>project</em> (per-workspace context).
+              Distinct from a committable <code>REASONIX.md</code>, which lives in the repo.
+            </p>
+
+            <h3 data-i18n="mem.h.layout">Layout</h3>
+            <pre class="code"><code>~/.reasonix/memory/
+  global/
+    MEMORY.md                      <span class="hash"># <span data-i18n="mem.idx">index — pinned into the prefix</span></span>
+    user_role.md
+    feedback_terse_comments.md
+  &lt;project-hash&gt;/                  <span class="hash"># <span data-i18n="mem.proj">sha1(absRoot)[0..16]</span></span>
+    MEMORY.md
+    project_release_freeze.md</code></pre>
+
+            <h3 data-i18n="mem.h.entry">Entry shape</h3>
+            <pre class="code"><code>---
+name: user_role
+description: <span data-i18n="mem.f.desc">User is a senior backend engineer; new to React.</span>
+type: user                       <span class="hash"># <span data-i18n="mem.f.type">user | feedback | project | reference</span></span>
+scope: global
+created: 2026-05-09
+---
+
+<span data-i18n="mem.f.body">Body — the actual remembered fact, in plain markdown.</span></code></pre>
+            <p data-i18n="mem.body.types">
+              <strong>Types:</strong> <code>user</code> (who they are),
+              <code>feedback</code> (corrections / preferences),
+              <code>project</code> (initiative / deadline / motivation),
+              <code>reference</code> (where to look in external systems).
+            </p>
+
+            <h3 data-i18n="mem.h.cmds">Slash commands</h3>
+            <table class="cmd-table">
+              <tbody>
+                <tr>
+                  <td><code>/memory list</code></td>
+                  <td data-i18n="mem.cmd.list">List all entries, both scopes.</td>
+                </tr>
+                <tr>
+                  <td><code>/memory show &lt;name&gt;</code></td>
+                  <td data-i18n="mem.cmd.show">Display body. Scope is auto-resolved.</td>
+                </tr>
+                <tr>
+                  <td><code>/memory forget &lt;name&gt;</code></td>
+                  <td data-i18n="mem.cmd.forget">Delete one entry.</td>
+                </tr>
+                <tr>
+                  <td><code>/memory clear &lt;scope&gt; confirm</code></td>
+                  <td data-i18n="mem.cmd.clear">
+                    Wipe an entire scope. <code>confirm</code> is mandatory.
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <p data-i18n="mem.body.write">
+              <strong>Writing memories:</strong> say it in chat ("remember I prefer
+              Vitest over Jest"). The model invokes the <code>scaffold_memory</code> tool,
+              which proposes a file and waits for your <code>/apply</code>.
+            </p>
+          </section>
+
+          <section id="hooks">
+            <h2 data-i18n="hk.title">Hooks</h2>
+            <p data-i18n="hk.body1">
+              Hooks are shell commands the harness fires on lifecycle events. Configured
+              in <code>settings.json</code>, not <code>config.json</code>. Project scope
+              first, then global.
+            </p>
+            <h3 data-i18n="hk.h.where">Where to put them</h3>
+            <pre class="code"><code>&lt;project&gt;/.reasonix/settings.json   <span class="hash"># <span data-i18n="hk.path.proj">project scope</span></span>
+~/.reasonix/settings.json           <span class="hash"># <span data-i18n="hk.path.glob">global scope</span></span></code></pre>
+
+            <h3 data-i18n="hk.h.shape">Shape</h3>
+            <pre class="code"><code>{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "command": "node scripts/audit.js",
+        "match": "^(write|edit_file|bash)$",
+        "description": "<span data-i18n="hk.ex.audit">Audit risky tool calls before they run</span>",
+        "timeout": 5000
+      }
+    ],
+    "PostToolUse": [
+      { "command": "echo done >> /tmp/reasonix.log" }
+    ],
+    "UserPromptSubmit": [],
+    "Stop": []
+  }
+}</code></pre>
+
+            <h3 data-i18n="hk.h.events">Events</h3>
+            <ul class="kv-list">
+              <li>
+                <code>PreToolUse</code>
+                <span data-i18n="hk.ev.pre">
+                  Before a tool runs. <strong>Gating:</strong> exit 2 blocks; exit 0
+                  passes. 5 s default timeout.
+                </span>
+              </li>
+              <li>
+                <code>PostToolUse</code>
+                <span data-i18n="hk.ev.post">
+                  After a tool runs. Non-gating; warn-only on non-zero. 30 s default.
+                </span>
+              </li>
+              <li>
+                <code>UserPromptSubmit</code>
+                <span data-i18n="hk.ev.usr">
+                  Before user input is processed. <strong>Gating</strong> (exit 2 blocks
+                  the message).
+                </span>
+              </li>
+              <li>
+                <code>Stop</code>
+                <span data-i18n="hk.ev.stop">On <code>/quit</code> or session exit. Non-gating.</span>
+              </li>
+            </ul>
+
+            <h3 data-i18n="hk.h.payload">Stdin payload</h3>
+            <p data-i18n="hk.body.payload">
+              Each hook receives a JSON object on stdin describing the event:
+            </p>
+            <pre class="code"><code>{
+  "event": "PreToolUse",
+  "cwd": "/workspace",
+  "toolName": "bash",
+  "toolArgs": { "command": "rm -rf /" },
+  "turn": 3
+}</code></pre>
+          </section>
+
+          <section id="permissions">
+            <h2 data-i18n="perm.title">Permissions</h2>
+            <p data-i18n="perm.body1">
+              Shell commands are gated per-workspace. The first time the agent runs a
+              command, you get an interactive <em>allow once / allow always / deny</em>
+              prompt; "allow always" persists the exact prefix to <code>config.json</code>
+              under that project.
+            </p>
+            <pre class="code"><code>{
+  "projects": {
+    "/abs/path/to/repo": {
+      "shellAllowed": [
+        "npm test",
+        "git status",
+        "ls"
+      ]
+    }
+  }
+}</code></pre>
+            <p data-i18n="perm.body.exact">
+              <strong>Exact match after trim.</strong> <code>git</code> alone does
+              <em>not</em> cover <code>git push origin main</code>; list each prefix you
+              actually want green-lit.
+            </p>
+            <table class="cmd-table">
+              <tbody>
+                <tr>
+                  <td><code>/permissions list</code></td>
+                  <td data-i18n="perm.cmd.list">Show this project's allowlist.</td>
+                </tr>
+                <tr>
+                  <td><code>/permissions add &lt;prefix&gt;</code></td>
+                  <td data-i18n="perm.cmd.add">Add a shell prefix.</td>
+                </tr>
+                <tr>
+                  <td><code>/permissions rm &lt;prefix|index&gt;</code></td>
+                  <td data-i18n="perm.cmd.rm">Remove by name or list index.</td>
+                </tr>
+                <tr>
+                  <td><code>/permissions clear confirm</code></td>
+                  <td data-i18n="perm.cmd.clear">Wipe everything. <code>confirm</code> is mandatory.</td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+
+          <section id="search">
+            <h2 data-i18n="ws.title">Web search</h2>
+            <p data-i18n="ws.body1">
+              <code>web_search</code> + <code>web_fetch</code> ship in the box. Default
+              backend is <strong>Mojeek</strong> (no setup); switch to a self-hosted
+              <strong>SearXNG</strong> when you want full control over upstream engines.
+            </p>
+            <pre class="code"><code>/search-engine mojeek
+/search-engine searxng                       <span class="hash"># http://localhost:8080</span>
+/search-engine searxng http://192.168.1.5:8888</code></pre>
+            <p data-i18n="ws.body.json">Equivalent <code>config.json</code>:</p>
+            <pre class="code"><code>{
+  "webSearchEngine": "searxng",
+  "webSearchEndpoint": "http://localhost:8080"
+}</code></pre>
+            <p data-i18n="ws.body.start">Start a local SearXNG:</p>
+            <pre class="code"><code>podman run -d --replace --name searxng -p 8080:8080 docker.io/searxng/searxng</code></pre>
+          </section>
+
+          <section id="index">
+            <h2 data-i18n="ix.title">Semantic index</h2>
+            <p data-i18n="ix.body1">
+              <code>reasonix index</code> builds an embedding index the agent can query.
+              Pick an embedding provider:
+            </p>
+            <pre class="code"><code>{
+  "semantic": {
+    "provider": "ollama",
+    "ollama": {
+      "baseUrl": "http://localhost:11434",
+      "model": "nomic-embed-text"
+    },
+    "openaiCompat": {
+      "baseUrl": "https://api.example.com/v1",
+      "apiKey": "...",
+      "model": "text-embedding-3-small"
+    }
+  }
+}</code></pre>
+            <p data-i18n="ix.body.swap">
+              Switch by changing <code>provider</code>. Local Ollama is free and
+              air-gapped; OpenAI-compat lets you point at any hosted embedding API.
+            </p>
+          </section>
+
+          <section class="guide-cta">
+            <h2 data-i18n="cta.title">Still stuck?</h2>
+            <p data-i18n="cta.sub">
+              Open a discussion or drop into <code>good first issue</code>. Every avatar
+              on the contributors wall started somewhere.
+            </p>
+            <div class="hero-ctas">
+              <a
+                class="cta primary"
+                href="https://github.com/esengine/reasonix/discussions"
+                target="_blank"
+                rel="noopener"
+                data-i18n="cta.disc"
+                >Discussions →</a
+              >
+              <a
+                class="cta ghost"
+                href="https://github.com/esengine/reasonix/blob/main/docs/ARCHITECTURE.md"
+                target="_blank"
+                rel="noopener"
+                data-i18n="cta.arch"
+                >Architecture deep dive</a
+              >
+            </div>
+          </section>
+        </article>
+      </div>
+    </main>
+
+    <footer class="foot">
+      <div class="container foot-inner">
+        <div>
+          <a href="index.html" class="nav-brand">
+            <span class="brand-mark small" aria-hidden="true">
+              <span class="diamond"></span>
+              <span class="diamond inner"></span>
+            </span>
+            <span class="brand-name">Reasonix</span>
+          </a>
+          <p class="foot-tag" data-i18n="foot.tag">DeepSeek does deep, deeply.</p>
+        </div>
+      </div>
+      <div class="foot-bottom">
+        <span data-i18n="foot.copyright">© 2026 Reasonix · MIT License</span>
+      </div>
+    </footer>
+
+    <script src="i18n.js"></script>
+    <script src="guide-i18n.js"></script>
+    <script src="motion.js"></script>
+  </body>
+</html>

--- a/docs/guide-i18n.js
+++ b/docs/guide-i18n.js
@@ -1,0 +1,392 @@
+/* Configuration-guide translations + scrollspy. Layered on top of i18n.js. */
+
+(function () {
+  "use strict";
+
+  var R = window.Reasonix;
+  if (!R) return;
+
+  var en = {
+    "nav.guide": "Guide",
+
+    "guide.badge": "Configuration · MCP · Skills · Memory",
+    "guide.title.line1": "Configure Reasonix",
+    "guide.title.line2": "in five minutes",
+    "guide.sub":
+      "One JSON file at <code>~/.reasonix/config.json</code> + per-project overrides under <code>.reasonix/</code>. This page documents every key, every slash command, and the on-disk shape of skills, memory, and hooks.",
+
+    "guide.toc.title": "On this page",
+    "guide.toc.config": "config.json",
+    "guide.toc.mcp": "MCP servers",
+    "guide.toc.skills": "Skills",
+    "guide.toc.memory": "Memory",
+    "guide.toc.hooks": "Hooks",
+    "guide.toc.perms": "Permissions",
+    "guide.toc.search": "Web search",
+    "guide.toc.index": "Semantic index",
+
+    "th.cmd": "Command",
+    "th.what": "What it does",
+
+    "cfg.title": "The config.json file",
+    "cfg.body1":
+      "Reasonix reads a single global config from <code>~/.reasonix/config.json</code> (Windows: <code>%USERPROFILE%\\.reasonix\\config.json</code>). The file is created automatically on first run; you can hand-edit it any time. The CLI flag <code>--no-config</code> bypasses it, useful in CI.",
+    "cfg.body2":
+      "Per-project overrides live under <code>&lt;project&gt;/.reasonix/</code> — skills, memory, settings.json (hooks). Project scope wins over global on name collision.",
+    "cfg.shape": "Top-level keys",
+    "cfg.k.lang": "UI language: en | zh",
+    "cfg.k.preset": "auto | flash | pro",
+    "cfg.k.editmode": "review | auto | yolo",
+    "cfg.k.effort": "high | max",
+    "cfg.k.theme": "light | dark | auto",
+    "cfg.k.search": "enable web_search/web_fetch tools",
+    "cfg.k.engine": "mojeek | searxng",
+    "cfg.k.mcp": "MCP server specs",
+    "cfg.k.mcpoff": "names skipped at startup",
+    "cfg.k.projects": "per-workspace overrides",
+    "cfg.k.semantic": "embedding provider for `reasonix index`",
+    "cfg.callout.tag": "Trust dial",
+    "cfg.callout.body":
+      "<code>editMode</code> is the single trust dial for an entire session. <code>review</code> queues edits + gates shell. <code>auto</code> applies edits + still gates shell. <code>yolo</code> skips both gates — only use inside a sandbox.",
+
+    "mcp.title": "MCP servers",
+    "mcp.body1":
+      "Reasonix speaks the Model Context Protocol natively. Every entry in <code>config.mcp</code> is a single string — the same format the <code>--mcp</code> CLI flag accepts — so one parser handles both. Three transports are supported.",
+    "mcp.h.stdio": "Stdio (subprocess)",
+    "mcp.body.stdio":
+      "Format: <code>name=command arg1 arg2</code>. The <code>name=</code> prefix namespaces every tool the server exposes. Args use shell-style splitting; quote any with spaces.",
+    "mcp.h.sse": "SSE (HTTP)",
+    "mcp.body.sse":
+      "Plain <code>http://</code> / <code>https://</code> URLs use HTTP+SSE for back-compat. Anonymous (no <code>name=</code>) entries work but can't be toggled by name later.",
+    "mcp.h.streamable": "Streamable HTTP (2025-03 spec)",
+    "mcp.body.streamable": "Opt in with the <code>streamable+</code> URL prefix.",
+    "mcp.h.cli": "CLI flags &amp; slash commands",
+    "mcp.cmd.hub": "Open the interactive MCP hub.",
+    "mcp.cmd.disable":
+      "Persist to <code>mcpDisabled</code>; effective on next launch.",
+    "mcp.cmd.enable": "Re-enable a disabled server.",
+    "mcp.cmd.recon": "Reconnect a live server and pick up newly-registered tools.",
+
+    "sk.title": "Skills",
+    "sk.body1":
+      "A skill is a markdown playbook the model can invoke (<code>/skill &lt;name&gt;</code>). Names + descriptions are pinned in the prompt; bodies load on demand. Project skills override global ones with the same name.",
+    "sk.h.layout": "Layout",
+    "sk.body.layout":
+      "Two equivalent shapes: a flat <code>&lt;name&gt;.md</code>, or a <code>&lt;name&gt;/SKILL.md</code> folder when you want to colocate attachments.",
+    "sk.h.fm": "Frontmatter",
+    "sk.fm.desc": "Review git log for security red flags.",
+    "sk.fm.runas": "inline | subagent",
+    "sk.fm.tools": "subagent tool allowlist",
+    "sk.fm.model": "subagent model override",
+    "sk.body.task": "Task",
+    "sk.body.s1": "Fetch the last 20 commits.",
+    "sk.body.s2":
+      "Flag commits whose message mentions password / secret / token.",
+    "sk.body.s3": "Report findings.",
+    "sk.fm.f.name":
+      "1–64 chars: alnum, <code>_</code>, <code>-</code>, interior <code>.</code>. Defaults to filename stem.",
+    "sk.fm.f.desc": "One line. Shown in <code>/skill list</code>.",
+    "sk.fm.f.runas":
+      "<code>inline</code> (default): body enters parent log. <code>subagent</code>: isolated child loop, only the final answer returns.",
+    "sk.fm.f.tools":
+      "Comma-separated literal tool names. Subagent only — scopes the child's tool registry.",
+    "sk.fm.f.model":
+      "Subagent only. Must start with <code>deepseek-</code>; ignored otherwise.",
+    "sk.h.cmds": "Slash commands",
+    "sk.cmd.list": "List every skill, scope-tagged.",
+    "sk.cmd.new":
+      "Scaffold a stub at project scope. Add <code>--global</code> for <code>~/.reasonix/skills</code>.",
+    "sk.cmd.show": "Print the full body.",
+    "sk.cmd.run": "Run it. Args are appended to the body as a single string.",
+
+    "mem.title": "Memory",
+    "mem.body1":
+      "Memory is user-private knowledge pinned into the immutable prefix — so the agent reads it on every turn without re-priming. Two scopes: <em>global</em> (cross-project facts about you) and <em>project</em> (per-workspace context). Distinct from a committable <code>REASONIX.md</code>, which lives in the repo.",
+    "mem.h.layout": "Layout",
+    "mem.idx": "index — pinned into the prefix",
+    "mem.proj": "sha1(absRoot)[0..16]",
+    "mem.h.entry": "Entry shape",
+    "mem.f.desc": "User is a senior backend engineer; new to React.",
+    "mem.f.type": "user | feedback | project | reference",
+    "mem.f.body": "Body — the actual remembered fact, in plain markdown.",
+    "mem.body.types":
+      "<strong>Types:</strong> <code>user</code> (who they are), <code>feedback</code> (corrections / preferences), <code>project</code> (initiative / deadline / motivation), <code>reference</code> (where to look in external systems).",
+    "mem.h.cmds": "Slash commands",
+    "mem.cmd.list": "List all entries, both scopes.",
+    "mem.cmd.show": "Display body. Scope is auto-resolved.",
+    "mem.cmd.forget": "Delete one entry.",
+    "mem.cmd.clear":
+      "Wipe an entire scope. <code>confirm</code> is mandatory.",
+    "mem.body.write":
+      "<strong>Writing memories:</strong> say it in chat (\"remember I prefer Vitest over Jest\"). The model invokes the <code>scaffold_memory</code> tool, which proposes a file and waits for your <code>/apply</code>.",
+
+    "hk.title": "Hooks",
+    "hk.body1":
+      "Hooks are shell commands the harness fires on lifecycle events. Configured in <code>settings.json</code>, not <code>config.json</code>. Project scope first, then global.",
+    "hk.h.where": "Where to put them",
+    "hk.path.proj": "project scope",
+    "hk.path.glob": "global scope",
+    "hk.h.shape": "Shape",
+    "hk.ex.audit": "Audit risky tool calls before they run",
+    "hk.h.events": "Events",
+    "hk.ev.pre":
+      "Before a tool runs. <strong>Gating:</strong> exit 2 blocks; exit 0 passes. 5 s default timeout.",
+    "hk.ev.post":
+      "After a tool runs. Non-gating; warn-only on non-zero. 30 s default.",
+    "hk.ev.usr":
+      "Before user input is processed. <strong>Gating</strong> (exit 2 blocks the message).",
+    "hk.ev.stop":
+      "On <code>/quit</code> or session exit. Non-gating.",
+    "hk.h.payload": "Stdin payload",
+    "hk.body.payload":
+      "Each hook receives a JSON object on stdin describing the event:",
+
+    "perm.title": "Permissions",
+    "perm.body1":
+      "Shell commands are gated per-workspace. The first time the agent runs a command, you get an interactive <em>allow once / allow always / deny</em> prompt; \"allow always\" persists the exact prefix to <code>config.json</code> under that project.",
+    "perm.body.exact":
+      "<strong>Exact match after trim.</strong> <code>git</code> alone does <em>not</em> cover <code>git push origin main</code>; list each prefix you actually want green-lit.",
+    "perm.cmd.list": "Show this project's allowlist.",
+    "perm.cmd.add": "Add a shell prefix.",
+    "perm.cmd.rm": "Remove by name or list index.",
+    "perm.cmd.clear":
+      "Wipe everything. <code>confirm</code> is mandatory.",
+
+    "ws.title": "Web search",
+    "ws.body1":
+      "<code>web_search</code> + <code>web_fetch</code> ship in the box. Default backend is <strong>Mojeek</strong> (no setup); switch to a self-hosted <strong>SearXNG</strong> when you want full control over upstream engines.",
+    "ws.body.json": "Equivalent <code>config.json</code>:",
+    "ws.body.start": "Start a local SearXNG:",
+
+    "ix.title": "Semantic index",
+    "ix.body1":
+      "<code>reasonix index</code> builds an embedding index the agent can query. Pick an embedding provider:",
+    "ix.body.swap":
+      "Switch by changing <code>provider</code>. Local Ollama is free and air-gapped; OpenAI-compat lets you point at any hosted embedding API.",
+
+    "cta.title": "Still stuck?",
+    "cta.sub":
+      "Open a discussion or drop into <code>good first issue</code>. Every avatar on the contributors wall started somewhere.",
+    "cta.disc": "Discussions →",
+    "cta.arch": "Architecture deep dive",
+  };
+
+  var zh = {
+    "nav.guide": "配置指南",
+
+    "guide.badge": "配置 · MCP · Skills · Memory",
+    "guide.title.line1": "五分钟",
+    "guide.title.line2": "配置完 Reasonix",
+    "guide.sub":
+      "一个全局 JSON 文件 <code>~/.reasonix/config.json</code>，加上项目级 <code>.reasonix/</code> 下的覆盖。这一页把每个 key、每条斜杠命令、以及 skills / memory / hooks 在磁盘上的形状全部讲清楚。",
+
+    "guide.toc.title": "本页目录",
+    "guide.toc.config": "config.json",
+    "guide.toc.mcp": "MCP 服务器",
+    "guide.toc.skills": "Skills",
+    "guide.toc.memory": "Memory",
+    "guide.toc.hooks": "Hooks",
+    "guide.toc.perms": "权限",
+    "guide.toc.search": "Web 搜索",
+    "guide.toc.index": "语义索引",
+
+    "th.cmd": "命令",
+    "th.what": "作用",
+
+    "cfg.title": "config.json 配置文件",
+    "cfg.body1":
+      "Reasonix 只从 <code>~/.reasonix/config.json</code> 读取全局配置（Windows：<code>%USERPROFILE%\\.reasonix\\config.json</code>）。首次运行会自动创建，之后随便手改。CLI 加 <code>--no-config</code> 即可跳过，CI 友好。",
+    "cfg.body2":
+      "项目级覆盖放在 <code>&lt;project&gt;/.reasonix/</code> 下——skills、memory、settings.json（hooks）都遵守这个目录。同名时项目级覆盖全局。",
+    "cfg.shape": "顶层 key",
+    "cfg.k.lang": "界面语言：en | zh",
+    "cfg.k.preset": "auto | flash | pro",
+    "cfg.k.editmode": "review | auto | yolo",
+    "cfg.k.effort": "high | max",
+    "cfg.k.theme": "light | dark | auto",
+    "cfg.k.search": "启用 web_search / web_fetch 工具",
+    "cfg.k.engine": "mojeek | searxng",
+    "cfg.k.mcp": "MCP 服务器列表",
+    "cfg.k.mcpoff": "启动时跳过的服务器名",
+    "cfg.k.projects": "按工作区的覆盖配置",
+    "cfg.k.semantic": "`reasonix index` 用的 embedding 提供方",
+    "cfg.callout.tag": "信任挡位",
+    "cfg.callout.body":
+      "<code>editMode</code> 是整个会话的唯一一档信任旋钮。<code>review</code> 队列改动 + 拦截 shell；<code>auto</code> 直接落盘 + 继续拦截 shell；<code>yolo</code> 两个都不拦——只在沙箱里用。",
+
+    "mcp.title": "MCP 服务器",
+    "mcp.body1":
+      "Reasonix 原生支持 Model Context Protocol。<code>config.mcp</code> 里每条都是一个字符串——和 <code>--mcp</code> CLI flag 用同一个 parser。支持三种传输。",
+    "mcp.h.stdio": "Stdio（子进程）",
+    "mcp.body.stdio":
+      "格式：<code>name=command arg1 arg2</code>。<code>name=</code> 前缀会给该服务器暴露的所有工具加命名空间。args 走 shell 风格的分词，含空格的部分要加引号。",
+    "mcp.h.sse": "SSE（HTTP）",
+    "mcp.body.sse":
+      "纯 <code>http://</code> / <code>https://</code> URL 走 HTTP+SSE，向后兼容。匿名条目（不带 <code>name=</code>）能用，但之后没法按名字开关。",
+    "mcp.h.streamable": "Streamable HTTP（2025-03 规范）",
+    "mcp.body.streamable":
+      "用 <code>streamable+</code> 前缀显式开启。",
+    "mcp.h.cli": "CLI flag 与斜杠命令",
+    "mcp.cmd.hub": "打开交互式 MCP 中心。",
+    "mcp.cmd.disable":
+      "写到 <code>mcpDisabled</code>；下次启动生效。",
+    "mcp.cmd.enable": "重新启用一个被禁用的服务器。",
+    "mcp.cmd.recon":
+      "重连一个在线服务器，并增量注册新工具。",
+
+    "sk.title": "Skills",
+    "sk.body1":
+      "Skill 是 markdown 写的剧本，模型可以调用（<code>/skill &lt;name&gt;</code>）。名称+描述会钉进 prompt，body 按需加载。同名时项目级覆盖全局。",
+    "sk.h.layout": "目录布局",
+    "sk.body.layout":
+      "两种等价的形式：扁平的 <code>&lt;name&gt;.md</code>，或者 <code>&lt;name&gt;/SKILL.md</code> 文件夹（需要附带资源时用后者）。",
+    "sk.h.fm": "Frontmatter",
+    "sk.fm.desc": "审查 git log，看看有没有安全相关的危险信号。",
+    "sk.fm.runas": "inline | subagent",
+    "sk.fm.tools": "subagent 的工具白名单",
+    "sk.fm.model": "subagent 的模型覆盖",
+    "sk.body.task": "任务",
+    "sk.body.s1": "拉最近 20 个 commit。",
+    "sk.body.s2":
+      "标记 commit message 里出现 password / secret / token 的提交。",
+    "sk.body.s3": "汇总结果。",
+    "sk.fm.f.name":
+      "1–64 字符：alnum、<code>_</code>、<code>-</code>，中间允许 <code>.</code>。默认取文件名 stem。",
+    "sk.fm.f.desc":
+      "一行。在 <code>/skill list</code> 里展示。",
+    "sk.fm.f.runas":
+      "<code>inline</code>（默认）：body 进父循环的日志。<code>subagent</code>：起一个隔离子循环，只回传最终结果。",
+    "sk.fm.f.tools":
+      "逗号分隔的工具字面名。仅 subagent 生效——给子循环的 tool registry 圈定范围。",
+    "sk.fm.f.model":
+      "仅 subagent 生效。必须以 <code>deepseek-</code> 开头，否则忽略。",
+    "sk.h.cmds": "斜杠命令",
+    "sk.cmd.list": "按 scope 列出全部 skill。",
+    "sk.cmd.new":
+      "在项目 scope 下生成 stub。加 <code>--global</code> 可写到 <code>~/.reasonix/skills</code>。",
+    "sk.cmd.show": "打印完整 body。",
+    "sk.cmd.run":
+      "运行它。后续 args 会作为单一字符串拼到 body 之后。",
+
+    "mem.title": "Memory",
+    "mem.body1":
+      "Memory 是用户私有的知识，钉进不可变前缀——所以 agent 每回合都自动读到，不用再重新 prime。两个 scope：<em>global</em>（关于你的、跨项目事实）与 <em>project</em>（按工作区的上下文）。和提交进仓库的 <code>REASONIX.md</code> 不是一回事。",
+    "mem.h.layout": "目录布局",
+    "mem.idx": "索引——会被钉进前缀",
+    "mem.proj": "sha1(absRoot)[0..16]",
+    "mem.h.entry": "条目格式",
+    "mem.f.desc": "用户是资深后端，第一次接触 React。",
+    "mem.f.type":
+      "user | feedback | project | reference",
+    "mem.f.body": "正文——真正要记的事实，纯 markdown。",
+    "mem.body.types":
+      "<strong>四种类型：</strong><code>user</code>（用户是谁）、<code>feedback</code>（修正/偏好）、<code>project</code>（计划/截止/动机）、<code>reference</code>（外部系统该去哪里查）。",
+    "mem.h.cmds": "斜杠命令",
+    "mem.cmd.list": "列出两个 scope 的全部条目。",
+    "mem.cmd.show": "展示 body。scope 自动解析。",
+    "mem.cmd.forget": "删一条。",
+    "mem.cmd.clear":
+      "清空整个 scope。必须显式加 <code>confirm</code>。",
+    "mem.body.write":
+      "<strong>怎么写入：</strong>直接在对话里说（“记一下我用 Vitest，不用 Jest”）。模型会调用 <code>scaffold_memory</code> 工具起草一条文件，等你 <code>/apply</code> 落盘。",
+
+    "hk.title": "Hooks",
+    "hk.body1":
+      "Hooks 是 harness 在生命周期事件上触发的 shell 命令。配置写在 <code>settings.json</code>，不是 <code>config.json</code>。先项目级，再全局。",
+    "hk.h.where": "放在哪里",
+    "hk.path.proj": "项目 scope",
+    "hk.path.glob": "全局 scope",
+    "hk.h.shape": "Schema",
+    "hk.ex.audit":
+      "在风险工具调用执行前先审计一下",
+    "hk.h.events": "事件",
+    "hk.ev.pre":
+      "工具执行前。<strong>会拦截：</strong>exit 2 阻断；exit 0 通过。默认 5 秒超时。",
+    "hk.ev.post":
+      "工具执行后。不拦截；非零仅 warn。默认 30 秒。",
+    "hk.ev.usr":
+      "用户输入处理前。<strong>会拦截</strong>（exit 2 把这条消息阻断）。",
+    "hk.ev.stop":
+      "<code>/quit</code> 或会话退出时触发。不拦截。",
+    "hk.h.payload": "Stdin 负载",
+    "hk.body.payload":
+      "每个 hook 在 stdin 上收到一段 JSON，描述事件：",
+
+    "perm.title": "权限",
+    "perm.body1":
+      "Shell 命令按工作区拦截。Agent 第一次跑某条命令时弹交互式 <em>本次允许 / 永久允许 / 拒绝</em>；选“永久允许”就把这条精确前缀写进 <code>config.json</code> 的对应项目下。",
+    "perm.body.exact":
+      "<strong>trim 后做精确匹配。</strong>光列 <code>git</code> 并<em>不</em>覆盖 <code>git push origin main</code>——你想放行的每个前缀都得单独列。",
+    "perm.cmd.list": "查看本项目的白名单。",
+    "perm.cmd.add": "新增一条 shell 前缀。",
+    "perm.cmd.rm": "按名字或下标删除。",
+    "perm.cmd.clear":
+      "全清。必须显式加 <code>confirm</code>。",
+
+    "ws.title": "Web 搜索",
+    "ws.body1":
+      "<code>web_search</code> + <code>web_fetch</code> 开箱即用。默认走 <strong>Mojeek</strong>（无需配置）；想完全控制上游引擎就切到自托管 <strong>SearXNG</strong>。",
+    "ws.body.json": "等价的 <code>config.json</code>：",
+    "ws.body.start": "本机起一个 SearXNG：",
+
+    "ix.title": "语义索引",
+    "ix.body1":
+      "<code>reasonix index</code> 会构建一份 embedding 索引供 agent 查询。挑一个 embedding 提供方：",
+    "ix.body.swap":
+      "切换只需要改 <code>provider</code>。本地 Ollama 免费且离线；OpenAI-compat 可以指向任何兼容的 embedding API。",
+
+    "cta.title": "还有疑问？",
+    "cta.sub":
+      "去开个 discussion，或者从 <code>good first issue</code> 入坑——贡献者墙上每一张头像都是这么开始的。",
+    "cta.disc": "讨论区 →",
+    "cta.arch": "架构深度文档",
+  };
+
+  var DICT = { en: en, zh: zh };
+
+  function applyGuide(lang) {
+    var dict = DICT[lang] || DICT.en;
+    document.querySelectorAll("[data-i18n]").forEach(function (el) {
+      var key = el.getAttribute("data-i18n");
+      if (dict[key] !== undefined) el.innerHTML = dict[key];
+    });
+  }
+
+  // Re-apply on first load and every language change.
+  applyGuide(R.lang());
+  R.onLangChange(applyGuide);
+
+  // Scrollspy — highlight the current section's TOC entry.
+  var sections = Array.prototype.slice.call(
+    document.querySelectorAll(".guide-body section[id]"),
+  );
+  var tocLinks = Array.prototype.slice.call(
+    document.querySelectorAll(".guide-toc a"),
+  );
+  if (sections.length && tocLinks.length && "IntersectionObserver" in window) {
+    var byId = {};
+    tocLinks.forEach(function (a) {
+      var href = a.getAttribute("href") || "";
+      var id = href.replace(/^#/, "");
+      if (id) byId[id] = a;
+    });
+    var io = new IntersectionObserver(
+      function (entries) {
+        entries.forEach(function (e) {
+          var link = byId[e.target.id];
+          if (!link) return;
+          if (e.isIntersecting) {
+            tocLinks.forEach(function (l) {
+              l.classList.remove("is-active");
+            });
+            link.classList.add("is-active");
+          }
+        });
+      },
+      { rootMargin: "-30% 0px -60% 0px", threshold: 0 },
+    );
+    sections.forEach(function (s) {
+      io.observe(s);
+    });
+  }
+})();

--- a/docs/guide.css
+++ b/docs/guide.css
@@ -1,0 +1,247 @@
+/* Reasonix configuration guide — layout extensions over styles.css. */
+
+.guide-main {
+  padding-bottom: 80px;
+}
+
+.guide-hero {
+  padding: 32px 0 48px;
+}
+.guide-hero .badge {
+  margin-bottom: 18px;
+}
+.guide-title {
+  font-size: clamp(32px, 4.4vw, 52px);
+  line-height: 1.05;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  margin: 0 0 20px;
+}
+.guide-sub {
+  font-size: 17px;
+  color: var(--fg-2);
+  max-width: 780px;
+  margin: 0;
+}
+
+.guide-shell {
+  display: grid;
+  grid-template-columns: 220px minmax(0, 1fr);
+  gap: 56px;
+  align-items: start;
+}
+
+.guide-toc {
+  position: sticky;
+  top: 24px;
+  align-self: start;
+  border-left: 1px solid var(--border);
+  padding: 4px 0 4px 18px;
+}
+.guide-toc h4 {
+  font-size: 11.5px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+  margin: 0 0 14px;
+  font-weight: 700;
+}
+.guide-toc ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.guide-toc a {
+  display: block;
+  font-size: 14px;
+  color: var(--fg-2);
+  padding: 5px 0;
+  transition: color 0.15s ease;
+}
+.guide-toc a:hover {
+  color: var(--fg);
+}
+.guide-toc a.is-active {
+  color: var(--accent-2);
+}
+
+.guide-body section {
+  padding: 28px 0 12px;
+  border-bottom: 1px solid var(--border);
+}
+.guide-body section:last-child {
+  border-bottom: 0;
+}
+.guide-body h2 {
+  font-size: 28px;
+  font-weight: 800;
+  letter-spacing: -0.015em;
+  margin: 0 0 16px;
+  scroll-margin-top: 24px;
+}
+.guide-body h3 {
+  font-size: 16px;
+  font-weight: 700;
+  margin: 24px 0 10px;
+  color: var(--fg);
+  letter-spacing: 0.005em;
+}
+.guide-body p {
+  color: var(--fg-2);
+  font-size: 15.5px;
+  margin: 0 0 14px;
+}
+.guide-body p strong {
+  color: var(--fg);
+  font-weight: 600;
+}
+
+/* Slim two-column reference table (slash commands, frontmatter fields). */
+.cmd-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 8px 0 16px;
+  font-size: 14.5px;
+}
+.cmd-table th,
+.cmd-table td {
+  text-align: left;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+.cmd-table th {
+  background: rgba(20, 26, 46, 0.4);
+  color: var(--fg-2);
+  font-weight: 600;
+  font-size: 12px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.cmd-table tbody tr:last-child td {
+  border-bottom: 0;
+}
+.cmd-table td:first-child {
+  white-space: nowrap;
+  width: 1%;
+}
+.cmd-table td code {
+  font-size: 13px;
+}
+.cmd-table td:last-child {
+  color: var(--fg-2);
+}
+
+/* Definition-style list — `field` then description. */
+.kv-list {
+  list-style: none;
+  margin: 0 0 16px;
+  padding: 0;
+  display: grid;
+  gap: 6px;
+}
+.kv-list li {
+  display: grid;
+  grid-template-columns: 160px 1fr;
+  gap: 16px;
+  padding: 8px 0;
+  border-bottom: 1px solid rgba(30, 36, 54, 0.5);
+  font-size: 14.5px;
+  color: var(--fg-2);
+}
+.kv-list li:last-child {
+  border-bottom: 0;
+}
+.kv-list li > code {
+  font-size: 13px;
+  align-self: start;
+}
+
+/* Inline note block — gradient-edged callout that breaks up dense reference. */
+.callout {
+  position: relative;
+  background: linear-gradient(
+    135deg,
+    rgba(94, 234, 212, 0.06),
+    rgba(196, 181, 253, 0.06)
+  );
+  border: 1px solid rgba(165, 180, 252, 0.25);
+  border-left-width: 3px;
+  border-left-color: var(--grad-3);
+  border-radius: var(--radius-sm);
+  padding: 16px 18px;
+  margin: 18px 0 8px;
+}
+.callout-tag {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent-2);
+  margin-bottom: 6px;
+}
+.callout p {
+  margin: 0;
+  color: var(--fg);
+  font-size: 14.5px;
+}
+
+.guide-cta {
+  text-align: center;
+  padding: 48px 0 8px !important;
+  border-bottom: 0 !important;
+}
+.guide-cta h2 {
+  text-align: center;
+  margin-bottom: 8px;
+}
+.guide-cta p {
+  text-align: center;
+  margin: 0 auto 20px;
+  max-width: 520px;
+}
+.guide-cta .hero-ctas {
+  justify-content: center;
+}
+
+.nav-links a.active {
+  color: var(--fg);
+  position: relative;
+}
+.nav-links a.active::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -6px;
+  height: 2px;
+  border-radius: 2px;
+  background: linear-gradient(90deg, var(--grad-1), var(--grad-5));
+}
+
+@media (max-width: 960px) {
+  .guide-shell {
+    grid-template-columns: 1fr;
+    gap: 24px;
+  }
+  .guide-toc {
+    position: static;
+    border-left: 0;
+    border-top: 1px solid var(--border);
+    border-bottom: 1px solid var(--border);
+    padding: 14px 0;
+  }
+  .guide-toc ul {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 8px 16px;
+  }
+  .kv-list li {
+    grid-template-columns: 1fr;
+    gap: 4px;
+  }
+}

--- a/docs/i18n.js
+++ b/docs/i18n.js
@@ -14,10 +14,12 @@
       "nav.why": "Why",
       "nav.features": "Features",
       "nav.quickstart": "Quick start",
+      "nav.guide": "Guide",
       "nav.community": "Community",
       "nav.github": "GitHub",
 
-      "hero.badge": "v{version} · DeepSeek · cache-first · MIT",
+      "hero.status": "live · v{version}",
+      "hero.badge": "DeepSeek · cache-first · MIT",
       "hero.title.line1": "DeepSeek-native",
       "hero.title.line2": "AI coding agent in your terminal",
       "hero.sub":
@@ -26,12 +28,12 @@
       "hero.copy.done": "Copied",
       "hero.cta.start": "Get started →",
       "hero.cta.star": "Star on GitHub",
-      "hero.stat.cache.num": "Cache-engineered",
-      "hero.stat.cache": "Byte-stable prefix loop",
-      "hero.stat.lic.num": "Open source",
-      "hero.stat.lic": "MIT, community-developed",
-      "hero.stat.tui.num": "Terminal-native",
-      "hero.stat.tui": "Plus embedded dashboard",
+
+      "metric.hit": "Cache hit, single day",
+      "metric.tokens": "Input tokens served",
+      "metric.cost": "Cost vs. no-cache",
+      "metric.lic": "Open, community-built",
+      "metric.src": "Source: real-world cache case study (2026-05-01) →",
 
       "term.user":
         "users.ts findByEmail is case-sensitive — login fails for users with uppercase emails",
@@ -115,12 +117,29 @@
       "feat.events.body":
         "<code>events.jsonl</code> sidecar with reducers and a <code>reasonix events</code> CLI. Build dashboards, audits, or your own analytics.",
 
-      "bench.title": "Verify the cache claim yourself",
-      "bench.sub":
-        "We don't ship benchmark numbers in marketing copy — they move with model pricing and harness changes, so they live with the harness instead of the README. Reproduce on your own machine:",
-      "bench.repro.note":
-        "Each committed JSONL transcript carries per-turn <code>usage</code>, <code>cost</code>, and <code>prefixHash</code>. Reasonix's prefix hash stays byte-stable across every model call — that's the whole game.",
-      "bench.link": "Read the τ-bench-lite harness →",
+      "conf.title": "Configure in five minutes",
+      "conf.sub":
+        "One JSON file at <code>~/.reasonix/config.json</code>, plus per-project overrides under <code>.reasonix/</code>. Point. Click. Wire in your stack.",
+      "conf.read": "Read →",
+      "conf.mcp.title": "MCP servers",
+      "conf.mcp.body":
+        "stdio · SSE · Streamable HTTP. One spec format for both <code>config.json</code> and <code>--mcp</code>.",
+      "conf.sk.title": "Skills",
+      "conf.sk.body":
+        "Markdown playbooks the model invokes. Inline or sub-agent. Project overrides global.",
+      "conf.mem.title": "Memory",
+      "conf.mem.body":
+        "User-private knowledge pinned into the prefix. Global + project scopes. Four typed shapes.",
+      "conf.hk.title": "Hooks",
+      "conf.hk.body":
+        "Shell commands on lifecycle events. Pre/post tool, prompt submit, stop. Exit-2 to block.",
+      "conf.perm.title": "Permissions",
+      "conf.perm.body":
+        "Per-workspace shell allowlist. Exact-prefix match. Interactive \"always allow\" persists.",
+      "conf.ws.title": "Web search",
+      "conf.ws.body":
+        "Mojeek by default, no setup. Switch to self-hosted SearXNG with <code>/search-engine</code>.",
+      "conf.cta": "Open the configuration guide →",
 
       "cli.title": "CLI at a glance",
       "cli.code": "coding mode scoped to path",
@@ -175,10 +194,12 @@
       "nav.why": "为什么",
       "nav.features": "特性",
       "nav.quickstart": "快速上手",
+      "nav.guide": "配置指南",
       "nav.community": "社区",
       "nav.github": "GitHub",
 
-      "hero.badge": "v{version} · DeepSeek · 缓存优先 · MIT",
+      "hero.status": "运行中 · v{version}",
+      "hero.badge": "DeepSeek · 缓存优先 · MIT",
       "hero.title.line1": "DeepSeek 原生",
       "hero.title.line2": "终端里的 AI 编程代理",
       "hero.sub":
@@ -187,12 +208,12 @@
       "hero.copy.done": "已复制",
       "hero.cta.start": "开始使用 →",
       "hero.cta.star": "在 GitHub 加星",
-      "hero.stat.cache.num": "缓存工程化",
-      "hero.stat.cache": "字节稳定的前缀循环",
-      "hero.stat.lic.num": "开源",
-      "hero.stat.lic": "MIT 协议，社区共建",
-      "hero.stat.tui.num": "终端原生",
-      "hero.stat.tui": "外加内嵌仪表盘",
+
+      "metric.hit": "单日缓存命中率",
+      "metric.tokens": "单日输入 token",
+      "metric.cost": "对比无缓存成本",
+      "metric.lic": "开源 · 社区共建",
+      "metric.src": "数据来源：2026-05-01 真实用户缓存命中案例 →",
 
       "term.user":
         "users.ts 里 findByEmail 对大小写敏感导致登录失败，帮我改",
@@ -276,12 +297,29 @@
       "feat.events.body":
         "<code>events.jsonl</code> 旁路日志，附带 reducer 和 <code>reasonix events</code> CLI。自己搭仪表盘、审计、分析都行。",
 
-      "bench.title": "缓存命中自己也能验证",
-      "bench.sub":
-        "营销文案里我们不放具体 benchmark 数字——这些数会随模型定价和测试集变化，所以归在 harness 里，不进 README。在自己机器上复现：",
-      "bench.repro.note":
-        "提交进仓库的每个 JSONL transcript 都带逐轮 <code>usage</code>、<code>cost</code> 和 <code>prefixHash</code>。Reasonix 的前缀哈希在每次模型调用中都字节稳定——这就是全部把戏。",
-      "bench.link": "查看 τ-bench-lite harness →",
+      "conf.title": "五分钟配置完",
+      "conf.sub":
+        "一个全局 JSON <code>~/.reasonix/config.json</code>，加上项目级 <code>.reasonix/</code> 下的覆盖。点几下，把你的工具链接进来。",
+      "conf.read": "阅读 →",
+      "conf.mcp.title": "MCP 服务器",
+      "conf.mcp.body":
+        "stdio · SSE · Streamable HTTP。<code>config.json</code> 和 <code>--mcp</code> 共用同一种 spec 格式。",
+      "conf.sk.title": "Skills",
+      "conf.sk.body":
+        "模型可调用的 markdown 剧本。Inline 或 subagent。同名时项目级覆盖全局。",
+      "conf.mem.title": "Memory",
+      "conf.mem.body":
+        "用户私有的知识，钉进前缀。全局 + 项目两个 scope，四种结构化类型。",
+      "conf.hk.title": "Hooks",
+      "conf.hk.body":
+        "生命周期事件触发的 shell 命令。pre/post 工具、prompt 提交、退出。exit 2 即拦截。",
+      "conf.perm.title": "权限",
+      "conf.perm.body":
+        "按工作区的 shell 白名单。精确前缀匹配。交互式“永久允许”会持久化。",
+      "conf.ws.title": "Web 搜索",
+      "conf.ws.body":
+        "默认 Mojeek，零配置。要完全控制就用 <code>/search-engine</code> 切自托管 SearXNG。",
+      "conf.cta": "打开配置指南 →",
 
       "cli.title": "CLI 速览",
       "cli.code": "针对指定路径的编程模式",

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,22 +3,63 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Reasonix — DeepSeek-native AI coding agent</title>
+    <title>Reasonix — DeepSeek-native AI coding agent for your terminal</title>
     <meta
       name="description"
-      content="Open-source AI coding agent for your terminal, engineered around DeepSeek's prefix-cache so token costs stay low across long sessions. MCP first-class · plan mode · custom cell-diff renderer."
+      content="Open-source AI coding agent for your terminal, engineered around DeepSeek's prefix-cache so token costs stay low across long sessions. MCP first-class · plan mode · custom cell-diff renderer · MIT licensed."
     />
+    <meta
+      name="keywords"
+      content="DeepSeek, AI coding agent, terminal AI, prefix cache, MCP, Model Context Protocol, open source coding assistant, CLI agent, TUI, R1 reasoning, cache-first loop, Claude Code alternative, Cursor alternative, Aider alternative"
+    />
+    <meta name="author" content="esengine" />
     <meta name="theme-color" content="#0b0f17" />
+    <meta name="robots" content="index, follow, max-image-preview:large" />
+    <meta name="color-scheme" content="dark light" />
 
+    <link rel="canonical" href="https://esengine.github.io/DeepSeek-Reasonix/" />
+    <link
+      rel="alternate"
+      hreflang="en"
+      href="https://esengine.github.io/DeepSeek-Reasonix/?lang=en"
+    />
+    <link
+      rel="alternate"
+      hreflang="zh-CN"
+      href="https://esengine.github.io/DeepSeek-Reasonix/?lang=zh"
+    />
+    <link
+      rel="alternate"
+      hreflang="x-default"
+      href="https://esengine.github.io/DeepSeek-Reasonix/"
+    />
+
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Reasonix" />
     <meta property="og:title" content="Reasonix — DeepSeek-native AI coding agent" />
     <meta
       property="og:description"
       content="Open-source AI coding agent for your terminal. Engineered around DeepSeek's prefix-cache. MCP first-class · plan mode · embedded dashboard · MIT."
     />
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://esengine.github.io/reasonix/" />
-    <meta property="og:image" content="https://raw.githubusercontent.com/esengine/reasonix/main/docs/logo.svg" />
+    <meta property="og:url" content="https://esengine.github.io/DeepSeek-Reasonix/" />
+    <meta
+      property="og:image"
+      content="https://raw.githubusercontent.com/esengine/reasonix/main/docs/assets/hero-terminal.svg"
+    />
+    <meta property="og:image:alt" content="Reasonix — terminal showing a SEARCH/REPLACE edit proposal" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:locale:alternate" content="zh_CN" />
+
     <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Reasonix — DeepSeek-native AI coding agent" />
+    <meta
+      name="twitter:description"
+      content="Open-source AI coding agent for your terminal. Engineered around DeepSeek's prefix-cache."
+    />
+    <meta
+      name="twitter:image"
+      content="https://raw.githubusercontent.com/esengine/reasonix/main/docs/assets/hero-terminal.svg"
+    />
 
     <link rel="icon" type="image/svg+xml" href="favicon.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -28,11 +69,54 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="styles.css" />
+
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Reasonix",
+        "alternateName": ["DeepSeek-Reasonix", "reasonix"],
+        "description": "Open-source AI coding agent for your terminal, engineered around DeepSeek's prefix-cache so token costs stay low across long sessions.",
+        "applicationCategory": "DeveloperApplication",
+        "operatingSystem": "macOS, Linux, Windows",
+        "softwareRequirements": "Node.js >= 22",
+        "url": "https://esengine.github.io/DeepSeek-Reasonix/",
+        "downloadUrl": "https://www.npmjs.com/package/reasonix",
+        "license": "https://opensource.org/licenses/MIT",
+        "codeRepository": "https://github.com/esengine/reasonix",
+        "programmingLanguage": "TypeScript",
+        "author": {
+          "@type": "Organization",
+          "name": "esengine",
+          "url": "https://github.com/esengine"
+        },
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        "name": "Reasonix",
+        "url": "https://esengine.github.io/DeepSeek-Reasonix/",
+        "inLanguage": ["en", "zh-CN"],
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "https://github.com/esengine/reasonix/search?q={search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
   </head>
 
   <body>
     <div class="bg-grid" aria-hidden="true"></div>
     <div class="bg-glow" aria-hidden="true"></div>
+    <div class="bg-horizon" aria-hidden="true"></div>
 
     <header class="nav">
       <a class="nav-brand" href="#top" aria-label="Reasonix">
@@ -47,6 +131,7 @@
         <a href="#why" data-i18n="nav.why">Why</a>
         <a href="#features" data-i18n="nav.features">Features</a>
         <a href="#quickstart" data-i18n="nav.quickstart">Quick start</a>
+        <a href="configuration.html" data-i18n="nav.guide">Guide</a>
         <a href="#community" data-i18n="nav.community">Community</a>
         <a
           href="https://github.com/esengine/reasonix"
@@ -67,8 +152,43 @@
 
     <main id="top">
       <section class="hero">
+        <!-- Orbital decoration: three concentric rings + dots, lazily rotating. -->
+        <div class="hero-orbit" aria-hidden="true">
+          <svg viewBox="-200 -200 400 400" xmlns="http://www.w3.org/2000/svg">
+            <defs>
+              <linearGradient id="orbStroke" x1="0" y1="0" x2="1" y2="1">
+                <stop offset="0%" stop-color="#5eead4" stop-opacity="0.6" />
+                <stop offset="50%" stop-color="#a5b4fc" stop-opacity="0.35" />
+                <stop offset="100%" stop-color="#f0abfc" stop-opacity="0.5" />
+              </linearGradient>
+              <radialGradient id="orbCore" cx="50%" cy="50%" r="50%">
+                <stop offset="0%" stop-color="#c4b5fd" stop-opacity="0.85" />
+                <stop offset="100%" stop-color="#5eead4" stop-opacity="0.0" />
+              </radialGradient>
+            </defs>
+            <g class="orb-rings">
+              <circle r="170" fill="none" stroke="url(#orbStroke)" stroke-width="1" stroke-dasharray="2 6" opacity="0.6" />
+              <circle r="120" fill="none" stroke="url(#orbStroke)" stroke-width="1" opacity="0.5" />
+              <circle r="80" fill="none" stroke="url(#orbStroke)" stroke-width="1" stroke-dasharray="1 4" opacity="0.5" />
+            </g>
+            <circle r="60" fill="url(#orbCore)" />
+            <g class="orb-dots">
+              <circle cx="170" cy="0" r="3" fill="#5eead4" />
+              <circle cx="0" cy="-120" r="2.5" fill="#a5b4fc" />
+              <circle cx="-80" cy="0" r="2" fill="#f0abfc" />
+            </g>
+          </svg>
+        </div>
+
         <div class="hero-inner">
-          <div class="badge" data-i18n="hero.badge">v{version} · DeepSeek · cache-first · MIT</div>
+          <div class="hero-pills">
+            <span class="status-pill">
+              <span class="status-dot"></span>
+              <span data-i18n="hero.status">live · v{version}</span>
+            </span>
+            <span class="badge" data-i18n="hero.badge">DeepSeek · cache-first · MIT</span>
+          </div>
+
           <h1 class="hero-title">
             <span class="grad-text" data-i18n="hero.title.line1">DeepSeek-native</span>
             <br />
@@ -101,21 +221,6 @@
               >Star on GitHub</a
             >
           </div>
-
-          <div class="hero-stats">
-            <div class="stat">
-              <div class="stat-num grad-text" data-i18n="hero.stat.cache.num">Cache-engineered</div>
-              <div class="stat-label" data-i18n="hero.stat.cache">Byte-stable prefix loop</div>
-            </div>
-            <div class="stat">
-              <div class="stat-num grad-text" data-i18n="hero.stat.lic.num">Open source</div>
-              <div class="stat-label" data-i18n="hero.stat.lic">MIT, community-developed</div>
-            </div>
-            <div class="stat">
-              <div class="stat-num grad-text" data-i18n="hero.stat.tui.num">Terminal-native</div>
-              <div class="stat-label" data-i18n="hero.stat.tui">Plus embedded dashboard</div>
-            </div>
-          </div>
         </div>
 
         <div class="hero-terminal" aria-hidden="true">
@@ -127,6 +232,49 @@
           <div class="term-body" id="term-body" data-anim-root></div>
         </div>
       </section>
+
+      <!-- Metric strip: real numbers from the 2026-05-01 case study. Counts up
+           when scrolled into view. The data-target value is the truth; the
+           rendered text starts at zero and ticks. -->
+      <section class="metrics" aria-label="Real-world cache hit metrics">
+        <div class="container metrics-row">
+          <div class="metric">
+            <div class="metric-num">
+              <span class="counter" data-target="99.82" data-suffix="%" data-decimals="2">0</span>
+            </div>
+            <div class="metric-label" data-i18n="metric.hit">Cache hit, single day</div>
+          </div>
+          <div class="metric-divider" aria-hidden="true"></div>
+          <div class="metric">
+            <div class="metric-num">
+              <span class="counter" data-target="435" data-suffix="M" data-decimals="0">0</span>
+            </div>
+            <div class="metric-label" data-i18n="metric.tokens">Input tokens served</div>
+          </div>
+          <div class="metric-divider" aria-hidden="true"></div>
+          <div class="metric">
+            <div class="metric-num">
+              <span class="counter" data-target="5" data-prefix="~" data-suffix="×" data-decimals="0">0</span>
+            </div>
+            <div class="metric-label" data-i18n="metric.cost">Cost vs. no-cache</div>
+          </div>
+          <div class="metric-divider" aria-hidden="true"></div>
+          <div class="metric">
+            <div class="metric-num metric-static">MIT</div>
+            <div class="metric-label" data-i18n="metric.lic">Open, community-built</div>
+          </div>
+        </div>
+        <p class="metrics-foot">
+          <a
+            href="https://github.com/esengine/reasonix/tree/main/benchmarks/real-world-cache"
+            target="_blank"
+            rel="noopener"
+            data-i18n="metric.src"
+            >Source: real-world cache case study (2026-05-01) →</a
+          >
+        </p>
+      </section>
+
 
       <section id="why" class="why">
         <div class="container">
@@ -370,36 +518,76 @@ npx reasonix code</code></pre>
         </div>
       </section>
 
-      <section class="bench">
+      <section id="configure" class="configure">
         <div class="container">
-          <h2 class="section-title" data-i18n="bench.title">Verify the cache claim yourself</h2>
-          <p class="section-sub" data-i18n="bench.sub">
-            We don't ship benchmark numbers in marketing copy — they move with model
-            pricing and harness changes, so they live with the harness instead of the
-            README. Reproduce on your own machine:
+          <h2 class="section-title" data-i18n="conf.title">Configure in five minutes</h2>
+          <p class="section-sub" data-i18n="conf.sub">
+            One JSON file at <code>~/.reasonix/config.json</code>, plus per-project
+            overrides under <code>.reasonix/</code>. Point. Click. Wire in your stack.
           </p>
 
-          <pre class="code"><code>git clone https://github.com/esengine/reasonix.git &amp;&amp; cd reasonix &amp;&amp; npm install
-npx reasonix replay benchmarks/tau-bench/transcripts/t01_address_happy.reasonix.r1.jsonl
-npx reasonix diff \
-  benchmarks/tau-bench/transcripts/t01_address_happy.baseline.r1.jsonl \
-  benchmarks/tau-bench/transcripts/t01_address_happy.reasonix.r1.jsonl</code></pre>
+          <div class="conf-grid">
+            <a class="conf-card" href="configuration.html#mcp">
+              <div class="conf-icon">⌥</div>
+              <h3 data-i18n="conf.mcp.title">MCP servers</h3>
+              <p data-i18n="conf.mcp.body">
+                stdio · SSE · Streamable HTTP. One spec format for both
+                <code>config.json</code> and <code>--mcp</code>.
+              </p>
+              <span class="conf-link" data-i18n="conf.read">Read →</span>
+            </a>
+            <a class="conf-card" href="configuration.html#skills">
+              <div class="conf-icon">◇</div>
+              <h3 data-i18n="conf.sk.title">Skills</h3>
+              <p data-i18n="conf.sk.body">
+                Markdown playbooks the model invokes. Inline or sub-agent. Project
+                overrides global.
+              </p>
+              <span class="conf-link" data-i18n="conf.read">Read →</span>
+            </a>
+            <a class="conf-card" href="configuration.html#memory">
+              <div class="conf-icon">∞</div>
+              <h3 data-i18n="conf.mem.title">Memory</h3>
+              <p data-i18n="conf.mem.body">
+                User-private knowledge pinned into the prefix. Global + project
+                scopes. Four typed shapes.
+              </p>
+              <span class="conf-link" data-i18n="conf.read">Read →</span>
+            </a>
+            <a class="conf-card" href="configuration.html#hooks">
+              <div class="conf-icon">⚙</div>
+              <h3 data-i18n="conf.hk.title">Hooks</h3>
+              <p data-i18n="conf.hk.body">
+                Shell commands on lifecycle events. Pre/post tool, prompt submit,
+                stop. Exit-2 to block.
+              </p>
+              <span class="conf-link" data-i18n="conf.read">Read →</span>
+            </a>
+            <a class="conf-card" href="configuration.html#permissions">
+              <div class="conf-icon">⊟</div>
+              <h3 data-i18n="conf.perm.title">Permissions</h3>
+              <p data-i18n="conf.perm.body">
+                Per-workspace shell allowlist. Exact-prefix match. Interactive
+                "always allow" persists.
+              </p>
+              <span class="conf-link" data-i18n="conf.read">Read →</span>
+            </a>
+            <a class="conf-card" href="configuration.html#search">
+              <div class="conf-icon">⌘</div>
+              <h3 data-i18n="conf.ws.title">Web search</h3>
+              <p data-i18n="conf.ws.body">
+                Mojeek by default, no setup. Switch to self-hosted SearXNG with
+                <code>/search-engine</code>.
+              </p>
+              <span class="conf-link" data-i18n="conf.read">Read →</span>
+            </a>
+          </div>
 
-          <p data-i18n="bench.repro.note">
-            Each committed JSONL transcript carries per-turn <code>usage</code>,
-            <code>cost</code>, and <code>prefixHash</code>. Reasonix's prefix hash stays
-            byte-stable across every model call — that's the whole game.
-          </p>
-          <p>
-            <a
-              class="cta ghost"
-              href="https://github.com/esengine/reasonix/tree/main/benchmarks"
-              target="_blank"
-              rel="noopener"
-              data-i18n="bench.link"
-              >Read the τ-bench-lite harness →</a
-            >
-          </p>
+          <div class="conf-cta">
+            <a class="cta primary" href="configuration.html" data-i18n="conf.cta">
+              Open the configuration guide →
+            </a>
+          </div>
         </div>
       </section>
 
@@ -604,5 +792,6 @@ npx reasonix prune-sessions              <span class="hash"># <span data-i18n="c
 
     <script src="i18n.js"></script>
     <script src="term-anim.js"></script>
+    <script src="motion.js"></script>
   </body>
 </html>

--- a/docs/motion.js
+++ b/docs/motion.js
@@ -1,0 +1,76 @@
+/* Counter count-up — fires once when a `.counter` enters the viewport.
+ *
+ * That's it. No spotlight, no tilt, no scroll reveal, no stagger, no
+ * parallax. Static layout does the heavy lifting; this file exists only
+ * because metric numbers count up from zero, and that's a one-shot
+ * effect that stops as soon as the counter reaches its target. */
+
+(function () {
+  "use strict";
+
+  var prefersReduced =
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  function format(n, decimals, prefix, suffix) {
+    var s = n.toFixed(decimals);
+    var parts = s.split(".");
+    parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+    return (prefix || "") + parts.join(".") + (suffix || "");
+  }
+
+  function fill(el) {
+    var target = parseFloat(el.getAttribute("data-target") || "0");
+    var decimals = parseInt(el.getAttribute("data-decimals") || "0", 10);
+    var prefix = el.getAttribute("data-prefix") || "";
+    var suffix = el.getAttribute("data-suffix") || "";
+    el.textContent = format(target, decimals, prefix, suffix);
+  }
+
+  function animate(el) {
+    var target = parseFloat(el.getAttribute("data-target") || "0");
+    var decimals = parseInt(el.getAttribute("data-decimals") || "0", 10);
+    var prefix = el.getAttribute("data-prefix") || "";
+    var suffix = el.getAttribute("data-suffix") || "";
+    var dur = 1400;
+    var t0 = 0;
+    function step(t) {
+      if (!t0) t0 = t;
+      var p = Math.min(1, (t - t0) / dur);
+      var eased = 1 - Math.pow(1 - p, 3);
+      el.textContent = format(target * eased, decimals, prefix, suffix);
+      if (p < 1) window.requestAnimationFrame(step);
+      else fill(el);
+    }
+    window.requestAnimationFrame(step);
+  }
+
+  function init() {
+    var nodes = document.querySelectorAll(".counter");
+    if (!nodes.length) return;
+
+    if (prefersReduced || !("IntersectionObserver" in window)) {
+      nodes.forEach(fill);
+      return;
+    }
+
+    var io = new IntersectionObserver(
+      function (entries) {
+        entries.forEach(function (e) {
+          if (e.isIntersecting) {
+            animate(e.target);
+            io.unobserve(e.target);
+          }
+        });
+      },
+      { threshold: 0.4 },
+    );
+    nodes.forEach(function (n) { io.observe(n); });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://esengine.github.io/DeepSeek-Reasonix/sitemap.xml

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset
+  xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+  xmlns:xhtml="http://www.w3.org/1999/xhtml"
+>
+  <url>
+    <loc>https://esengine.github.io/DeepSeek-Reasonix/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://esengine.github.io/DeepSeek-Reasonix/?lang=en" />
+    <xhtml:link rel="alternate" hreflang="zh-CN" href="https://esengine.github.io/DeepSeek-Reasonix/?lang=zh" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://esengine.github.io/DeepSeek-Reasonix/" />
+  </url>
+  <url>
+    <loc>https://esengine.github.io/DeepSeek-Reasonix/configuration.html</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://esengine.github.io/DeepSeek-Reasonix/configuration.html?lang=en" />
+    <xhtml:link rel="alternate" hreflang="zh-CN" href="https://esengine.github.io/DeepSeek-Reasonix/configuration.html?lang=zh" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://esengine.github.io/DeepSeek-Reasonix/configuration.html" />
+  </url>
+</urlset>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -108,29 +108,94 @@ kbd {
   padding: 0 24px;
 }
 
-/* Background */
+/* ── Background system ────────────────────────────────────────────────
+ * Three layers, all fixed and pointer-events:none:
+ *   .bg-grid   — faint grid lattice, masked to fade at the viewport edges
+ *   .bg-glow   — two static, very-soft color blobs (no drift, no scale —
+ *                that's what made the page feel chaotic). Cursor parallax
+ *                on `--gx` / `--gy` still nudges them by a few percent.
+ *   .bg-noise  — SVG fractal turbulence at ~4% opacity. Gives the dark
+ *                surface a film-grain texture, which is what reads as
+ *                "premium" and stops gradients looking flat.
+ * ────────────────────────────────────────────────────────────────────── */
+/* Dot grid — single radial-gradient tile vs. two stacked linear-gradients
+ * for the line version. Reads more premium and is cheaper to paint. */
 .bg-grid {
   position: fixed;
   inset: 0;
-  background-image:
-    linear-gradient(rgba(165, 180, 252, 0.04) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(165, 180, 252, 0.04) 1px, transparent 1px);
-  background-size: 56px 56px;
-  mask-image: radial-gradient(circle at center, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 0) 70%);
+  background-image: radial-gradient(
+    circle,
+    rgba(165, 180, 252, 0.10) 1px,
+    transparent 1.4px
+  );
+  background-size: 28px 28px;
+  -webkit-mask-image: radial-gradient(
+    ellipse 70% 60% at 50% 25%,
+    rgba(0, 0, 0, 0.95) 0%,
+    rgba(0, 0, 0, 0) 80%
+  );
+          mask-image: radial-gradient(
+    ellipse 70% 60% at 50% 25%,
+    rgba(0, 0, 0, 0.95) 0%,
+    rgba(0, 0, 0, 0) 80%
+  );
   pointer-events: none;
   z-index: 0;
 }
 
+/* Three static color blobs anchored at top-left, top-right, and bottom
+ * center. Bottom blob gives the page floor a hint of horizon depth and
+ * keeps the lower viewport from looking flat. Zero animation. */
 .bg-glow {
   position: fixed;
   inset: 0;
   pointer-events: none;
   z-index: 0;
   background:
-    radial-gradient(800px circle at 20% 10%, rgba(94, 234, 212, 0.10), transparent 50%),
-    radial-gradient(700px circle at 90% 30%, rgba(196, 181, 253, 0.10), transparent 55%),
-    radial-gradient(600px circle at 50% 100%, rgba(240, 171, 252, 0.07), transparent 50%);
+    radial-gradient(
+      ellipse 55vmax 42vmax at 12% 16%,
+      rgba(94, 234, 212, 0.13),
+      transparent 60%
+    ),
+    radial-gradient(
+      ellipse 50vmax 40vmax at 88% 20%,
+      rgba(196, 181, 253, 0.11),
+      transparent 62%
+    ),
+    radial-gradient(
+      ellipse 90vmax 30vmax at 50% 110%,
+      rgba(165, 180, 252, 0.09),
+      transparent 70%
+    );
 }
+
+/* Faint horizon hairline — a single fixed gradient line that sits roughly
+ * at the hero / metrics seam. Adds a subtle depth break without animation. */
+.bg-horizon {
+  position: fixed;
+  left: 0;
+  right: 0;
+  top: 64vh;
+  height: 1px;
+  pointer-events: none;
+  z-index: 0;
+  background: linear-gradient(
+    90deg,
+    transparent 0,
+    rgba(165, 180, 252, 0.18) 35%,
+    rgba(196, 181, 253, 0.18) 65%,
+    transparent 100%
+  );
+  opacity: 0.6;
+}
+
+/* The fractal-noise overlay was removed — even static, a fullscreen
+ * fixed layer adds a compositing pass on every scroll/resize. The dot
+ * grid + horizon hairline + glow blobs already give enough texture. */
+
+/* The conic-gradient + blur + rotate effect was removed: animating a blur
+ * on a >100% surface repaints the entire viewport every frame. The
+ * orbital SVG already provides motion under the hero. */
 
 main,
 .nav,
@@ -265,6 +330,7 @@ main,
 
 /* Hero */
 .hero {
+  position: relative;
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 64px;
@@ -274,8 +340,80 @@ main,
   align-items: center;
 }
 
+/* Orbital SVG: lives behind the hero text column, slowly rotates the rings,
+ * counter-rotates the dot ring so it feels alive but never busy. */
+.hero-orbit {
+  position: absolute;
+  top: 50%;
+  left: -120px;
+  width: 620px;
+  height: 620px;
+  transform: translate3d(0, -50%, 0);
+  pointer-events: none;
+  z-index: 0;
+  opacity: 0.55;
+  mask-image: radial-gradient(circle, #000 35%, transparent 75%);
+}
+.hero-orbit svg {
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+}
+/* Orbital SVG is now a static decoration. The composition reads as
+ * "system diagram" without needing motion — and the page no longer
+ * pays a continuous repaint cost for it. */
+.hero-orbit .orb-rings,
+.hero-orbit .orb-dots {
+  transform-origin: 0 0;
+}
+.hero-inner,
+.hero-terminal {
+  position: relative;
+  z-index: 1;
+}
+
 .hero-inner {
   min-width: 0;
+}
+
+.hero-pills {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 24px;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  color: #c5fce8;
+  background: rgba(94, 234, 212, 0.08);
+  border: 1px solid rgba(94, 234, 212, 0.32);
+  padding: 5px 12px;
+  border-radius: 999px;
+}
+.status-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #34d399;
+  box-shadow: 0 0 0 0 rgba(52, 211, 153, 0.7);
+  animation: status-pulse 1.8s ease-out infinite;
+}
+@keyframes status-pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(52, 211, 153, 0.55);
+  }
+  70% {
+    box-shadow: 0 0 0 10px rgba(52, 211, 153, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(52, 211, 153, 0);
+  }
 }
 
 .badge {
@@ -290,7 +428,6 @@ main,
   border: 1px solid rgba(165, 180, 252, 0.25);
   padding: 5px 12px;
   border-radius: 999px;
-  margin-bottom: 24px;
 }
 
 .hero-title {
@@ -301,13 +438,15 @@ main,
   margin: 0 0 24px;
 }
 
-.grad-text {
+/* Static gradient text — no shimmer animation. `background-position`
+ * animation forces a paint per frame for every clipped-text element. */
+.grad-text,
+.grad-text-anim {
   background: linear-gradient(
     90deg,
     var(--grad-1) 0%,
-    var(--grad-2) 25%,
-    var(--grad-4) 60%,
-    var(--grad-6) 90%
+    var(--grad-3) 50%,
+    var(--grad-6) 100%
   );
   -webkit-background-clip: text;
   background-clip: text;
@@ -409,27 +548,98 @@ main,
   color: #fff;
 }
 
-.hero-stats {
+/* ── Metrics strip ─────────────────────────────────────────────────────
+ * Lives directly under the hero. Counters animate from 0 → target the
+ * first time the strip enters the viewport (motion.js). On dark gradient
+ * panel, with subtle vertical dividers between cells. */
+.metrics {
+  position: relative;
+  margin: 0 auto 80px;
+  max-width: var(--maxw);
+  padding: 0 32px;
+  z-index: 1;
+}
+.metrics-row {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 24px;
-  max-width: 520px;
+  grid-template-columns: 1fr auto 1fr auto 1fr auto 1fr;
+  align-items: center;
+  gap: 0;
+  /* No backdrop-filter — fullscreen-ish blurred backdrop forced a re-blur
+   * of underlying pixels every scroll frame. Plain solid panel reads
+   * almost identical at this opacity over the dark background. */
+  background: linear-gradient(
+    180deg,
+    rgba(20, 26, 46, 0.85),
+    rgba(13, 17, 28, 0.85)
+  );
+  border: 1px solid rgba(165, 180, 252, 0.18);
+  border-radius: 16px;
+  padding: 28px 32px;
+  box-shadow:
+    0 30px 80px rgba(0, 0, 0, 0.45),
+    inset 0 1px 0 rgba(255, 255, 255, 0.04);
 }
-.stat-num {
+.metric {
+  text-align: center;
+  min-width: 0;
+}
+.metric-num {
   font-family: var(--font-mono);
-  font-size: 18px;
+  font-size: clamp(28px, 3.4vw, 42px);
   font-weight: 700;
-  letter-spacing: -0.01em;
-  margin-bottom: 4px;
+  letter-spacing: -0.02em;
+  line-height: 1;
+  margin-bottom: 8px;
+  background: linear-gradient(
+    135deg,
+    var(--grad-1),
+    var(--grad-3) 50%,
+    var(--grad-6)
+  );
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
 }
-.stat-label {
+.metric-num.metric-static {
+  letter-spacing: 0.02em;
+}
+.metric-label {
   font-size: 12.5px;
   color: var(--fg-3);
-  line-height: 1.4;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
+.metric-divider {
+  width: 1px;
+  height: 56px;
+  background: linear-gradient(
+    180deg,
+    transparent,
+    rgba(165, 180, 252, 0.35) 50%,
+    transparent
+  );
+}
+.metrics-foot {
+  text-align: center;
+  margin: 14px 0 0;
+  font-size: 13px;
+  color: var(--fg-3);
+}
+.metrics-foot a {
+  color: var(--fg-3);
+  border-bottom: 1px dashed rgba(165, 180, 252, 0.3);
+}
+.metrics-foot a:hover {
+  color: var(--fg);
+  border-bottom-color: var(--accent-2);
+}
+
+/* The marquee was removed — a continuous translate at 48 s still costs a
+ * frame each, and the same information is conveyed by the feature grid. */
 
 /* Hero terminal mock */
 .hero-terminal {
+  position: relative;
   background: var(--term-bg);
   border: 1px solid var(--border-strong);
   border-radius: var(--radius);
@@ -440,6 +650,26 @@ main,
   font-family: var(--font-mono);
   font-size: 13px;
   line-height: 1.55;
+}
+.hero-terminal::after {
+  content: "";
+  position: absolute;
+  inset: -1px;
+  border-radius: inherit;
+  padding: 1px;
+  pointer-events: none;
+  background: linear-gradient(
+    135deg,
+    rgba(94, 234, 212, 0.35),
+    rgba(196, 181, 253, 0.25) 50%,
+    rgba(240, 171, 252, 0.2)
+  );
+  -webkit-mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+          mask-composite: exclude;
+  opacity: 0.6;
 }
 
 .term-bar {
@@ -983,66 +1213,122 @@ main,
   font-size: 14.5px;
 }
 
-/* Benchmarks */
-.bench {
+/* Configuration teaser — six cards linking into the dedicated guide.
+ * Card border uses a subtle gradient stroke; hover lifts + brightens.
+ */
+.configure {
   padding: 80px 0;
-  background: linear-gradient(
-    180deg,
-    transparent,
-    rgba(20, 26, 46, 0.4) 50%,
-    transparent
-  );
 }
-
-.bench-table-wrap {
-  max-width: 880px;
-  margin: 0 auto 32px;
-  overflow-x: auto;
+.conf-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  max-width: 1100px;
+  margin: 0 auto;
 }
-
-.bench-table {
-  width: 100%;
-  border-collapse: collapse;
+.conf-card {
+  position: relative;
+  display: block;
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: var(--radius);
+  padding: 24px 26px;
+  text-decoration: none;
+  color: inherit;
+  transition:
+    transform 0.2s ease,
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
   overflow: hidden;
 }
-.bench-table th,
-.bench-table td {
-  text-align: left;
-  padding: 14px 18px;
-  border-bottom: 1px solid var(--border);
+.conf-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 1px;
+  background: linear-gradient(
+    135deg,
+    rgba(94, 234, 212, 0.0),
+    rgba(196, 181, 253, 0.0)
+  );
+  -webkit-mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+          mask-composite: exclude;
+  pointer-events: none;
+  transition: background 0.25s ease;
+}
+.conf-card:hover {
+  transform: translateY(-3px);
+  border-color: rgba(165, 180, 252, 0.35);
+  box-shadow: 0 14px 32px rgba(8, 11, 18, 0.5);
+}
+.conf-card:hover::before {
+  background: linear-gradient(
+    135deg,
+    rgba(94, 234, 212, 0.55),
+    rgba(196, 181, 253, 0.55) 50%,
+    rgba(240, 171, 252, 0.5)
+  );
+}
+.conf-icon {
+  font-family: var(--font-mono);
+  font-size: 22px;
+  font-weight: 700;
+  width: 40px;
+  height: 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(
+    135deg,
+    rgba(94, 234, 212, 0.18),
+    rgba(196, 181, 253, 0.18)
+  );
+  border: 1px solid rgba(165, 180, 252, 0.3);
+  border-radius: 10px;
+  color: var(--accent-2);
+  margin-bottom: 16px;
+}
+.conf-card h3 {
+  font-size: 17px;
+  font-weight: 700;
+  margin: 0 0 8px;
+  color: var(--fg);
+}
+.conf-card p {
+  margin: 0 0 14px;
+  color: var(--fg-2);
   font-size: 14.5px;
+  line-height: 1.6;
 }
-.bench-table th {
-  background: rgba(20, 26, 46, 0.6);
-  color: var(--fg-2);
-  font-weight: 600;
-  font-size: 12.5px;
+.conf-link {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: var(--accent-2);
   text-transform: uppercase;
-  letter-spacing: 0.05em;
 }
-.bench-table tbody tr:last-child td {
-  border-bottom: 0;
-}
-.bench-table td.hi {
-  color: var(--grad-1);
-  font-weight: 600;
-}
-
-.bench p {
+.conf-cta {
   text-align: center;
-  color: var(--fg-2);
-  max-width: 720px;
-  margin: 0 auto 16px;
+  margin-top: 36px;
 }
 
-.bench .code {
-  max-width: 880px;
-  margin: 0 auto 24px;
+@media (max-width: 960px) {
+  .conf-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+@media (max-width: 640px) {
+  .conf-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
+/* Benchmarks */
 /* CLI */
 .cli {
   padding: 80px 0;
@@ -1143,11 +1429,113 @@ main,
   font-size: 13px;
 }
 
+/* ── Static affordances only ──────────────────────────────────────────
+ * No spotlight, no tilt, no scroll reveal, no stagger, no shimmer, no
+ * traveling beam, no hero-stat hover pulse. Just CSS hover hints and
+ * static decorations. The page should run with zero JS animation cost
+ * outside the one-shot counter and the term-anim demo. */
+
+/* Cards — plain, scoped hover. Border accent + small lift. */
+.why-card,
+.feat,
+.conf-card {
+  transition: border-color 0.2s ease, transform 0.2s ease, background 0.2s ease;
+}
+.why-card:hover,
+.feat:hover,
+.conf-card:hover {
+  border-color: rgba(165, 180, 252, 0.35);
+  transform: translateY(-2px);
+  background: rgba(20, 26, 46, 0.6);
+}
+
+/* Brand mark hover halo — single tiny element. */
+.nav-brand:hover .brand-mark {
+  filter: drop-shadow(0 0 8px rgba(196, 181, 253, 0.45));
+}
+
+/* Faint static scanlines on the hero terminal — pure paint at first
+ * paint only (no animation). */
+.hero-terminal::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: repeating-linear-gradient(
+    180deg,
+    rgba(165, 180, 252, 0.025) 0,
+    rgba(165, 180, 252, 0.025) 1px,
+    transparent 1px,
+    transparent 3px
+  );
+  opacity: 0.4;
+  z-index: 1;
+}
+
+/* Static section divider — gradient hairline at the top of each major
+ * section. No traveling pulse, no animation. */
+.why,
+.configure,
+.features,
+.cli,
+.community,
+.cta-band,
+.metrics {
+  position: relative;
+}
+.why::before,
+.configure::before,
+.features::before,
+.cli::before,
+.community::before,
+.cta-band::before,
+.metrics::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 12%;
+  right: 12%;
+  height: 1px;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(165, 180, 252, 0.16) 25%,
+    rgba(196, 181, 253, 0.16) 75%,
+    transparent
+  );
+  pointer-events: none;
+}
+
+/* Static section-title accent — small fixed-width gradient bar under H2. */
+.section-title {
+  position: relative;
+}
+.section-title::after {
+  content: "";
+  display: block;
+  margin: 14px auto 0;
+  width: 56px;
+  height: 2px;
+  border-radius: 2px;
+  background: linear-gradient(90deg, var(--grad-1), var(--grad-5), var(--grad-7));
+}
+
 /* Responsive */
 @media (max-width: 960px) {
   .hero {
     grid-template-columns: 1fr;
     gap: 40px;
+  }
+  .hero-orbit {
+    display: none;
+  }
+  .metrics-row {
+    grid-template-columns: 1fr 1fr;
+    row-gap: 24px;
+    padding: 24px 20px;
+  }
+  .metric-divider {
+    display: none;
   }
   .why-grid,
   .feat-grid {
@@ -1196,7 +1584,8 @@ main,
   }
 }
 
-/* Reduced motion */
+/* Reduced motion — kill drift / shimmer / reveal animations,
+ * but keep `data-reveal` content visible (otherwise the page stays blank). */
 @media (prefers-reduced-motion: reduce) {
   .diamond,
   *,
@@ -1207,5 +1596,9 @@ main,
   }
   html {
     scroll-behavior: auto;
+  }
+  [data-reveal] {
+    opacity: 1 !important;
+    transform: none !important;
   }
 }


### PR DESCRIPTION
## Summary

- **New configuration guide** (`docs/configuration.html`) — bilingual reference for MCP, skills, memory, hooks, permissions, web search, and the semantic index. Scrollspy TOC. Linked from the landing page nav and from both READMEs.
- **Landing page rewrite** — hero gets a real-metric strip with one-shot count-up (99.82% / 435M / 5×) sourced from the 2026-05-01 case study, an orbital SVG decoration, a status pill, and a "Configure in five minutes" teaser block linking into the guide.
- **README restructure** — Configuration moves into prime real estate; chat-vs-code / working-folder / first-skill collapse into a `<details>`; standalone Web Search section drops (covered by the guide). Same surgery in `README.zh-CN.md`.
- **SEO** — fixed `og:url` (was pointing at the wrong repo path), added `<link rel=canonical>`, hreflang `en` / `zh-CN` / `x-default`, JSON-LD `SoftwareApplication` + `WebSite` on landing, `TechArticle` + `BreadcrumbList` on guide, full Twitter card metadata. Adds `docs/robots.txt` and `docs/sitemap.xml`.
- **Performance** — stripped scroll-reveal, card spotlight + 3D tilt, capability marquee, `backdrop-filter`, fractal-noise overlay, `content-visibility`, gradient-text shimmer, and section-beam animations after they made the page feel laggy. Background is now fully static (dot grid + three glow blobs + horizon hairline). Only one-shot animation left is the metric count-up; brand mark, status dot, and terminal caret keep their tiny scoped pulses.

## Test plan

- [ ] Open `docs/index.html` locally — hero + metrics + guide teaser render; no jank on scroll.
- [ ] Open `docs/configuration.html` — TOC scrollspy works, EN/中文 toggle persists across pages.
- [ ] Verify `?lang=zh` works on both pages.
- [ ] View source — JSON-LD blocks parse as valid (paste into https://validator.schema.org/).
- [ ] Hit `docs/robots.txt` and `docs/sitemap.xml` directly to confirm they serve.
- [ ] README + `README.zh-CN.md` render correctly on GitHub (Configuration section, `<details>` block).