### PR TITLE
fix(ui): leading-edge scroll + chunkier wheel/page step

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -1250,8 +1250,8 @@ function AppInner({
       (slashMatches?.length ?? 0) > 0 ||
       (slashArgMatches?.length ?? 0) > 0 ||
       pendingShell != null;
-    if (ev.pageUp || ev.mouseScrollUp) chatScroll.scrollUp();
-    else if (ev.pageDown || ev.mouseScrollDown) chatScroll.scrollDown();
+    if (ev.pageUp || ev.mouseScrollUp) chatScroll.scrollPageUp();
+    else if (ev.pageDown || ev.mouseScrollDown) chatScroll.scrollPageDown();
     else if (ev.end) chatScroll.jumpToBottom();
     else if (!pickerOwnsArrows && ev.upArrow) chatScroll.scrollUp();
     else if (!pickerOwnsArrows && ev.downArrow) chatScroll.scrollDown();

--- a/src/cli/ui/hooks/useChatScroll.ts
+++ b/src/cli/ui/hooks/useChatScroll.ts
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
-/** Rows advanced per PgUp / PgDn / arrow / wheel — small for smooth feel. */
-export const SCROLL_PAGE_ROWS = 3;
+/** Arrow-key step: small for fine-grained navigation. */
+export const SCROLL_ARROW_ROWS = 3;
+/** Wheel / PgUp / PgDn step: chunkier so each tick covers meaningful ground. */
+export const SCROLL_PAGE_ROWS = 8;
 const COALESCE_MS = 16;
 
 export interface ChatScrollState {
@@ -9,8 +11,12 @@ export interface ChatScrollState {
   scrollRows: number;
   /** True when the user is following the bottom (auto-advances on new content). */
   pinned: boolean;
+  /** Arrow-key step — fine-grained. */
   scrollUp: () => void;
   scrollDown: () => void;
+  /** PgUp / PgDn / wheel step — chunkier. */
+  scrollPageUp: () => void;
+  scrollPageDown: () => void;
   /** Jump straight to the latest content and resume auto-follow (End key). */
   jumpToBottom: () => void;
   /** CardStream calls this once it has measured inner/outer Box heights. */
@@ -27,8 +33,7 @@ export function useChatScroll(): ChatScrollState {
   const pendingDelta = useRef(0);
   const flushTimer = useRef<NodeJS.Timeout | null>(null);
 
-  const flush = useCallback(() => {
-    flushTimer.current = null;
+  const applyDelta = useCallback(() => {
     const d = pendingDelta.current;
     pendingDelta.current = 0;
     if (d === 0) return;
@@ -40,13 +45,25 @@ export function useChatScroll(): ChatScrollState {
     });
   }, []);
 
+  /** Leading-edge schedule: first call applies immediately so the user
+   * sees the wheel respond on the first tick (no 16 ms wait before any
+   * visual feedback). Further calls inside the COALESCE_MS window batch
+   * into pendingDelta and land in one trailing flush, so a fast scroll
+   * still produces only one re-render per window. */
   const schedule = useCallback(
     (delta: number) => {
-      pendingDelta.current += delta;
-      if (flushTimer.current !== null) return;
-      flushTimer.current = setTimeout(flush, COALESCE_MS);
+      if (flushTimer.current === null) {
+        pendingDelta.current = delta;
+        applyDelta(); // leading-edge flush — instant feedback
+        flushTimer.current = setTimeout(() => {
+          flushTimer.current = null;
+          if (pendingDelta.current !== 0) applyDelta();
+        }, COALESCE_MS);
+      } else {
+        pendingDelta.current += delta;
+      }
     },
-    [flush],
+    [applyDelta],
   );
 
   useEffect(() => {
@@ -66,8 +83,10 @@ export function useChatScroll(): ChatScrollState {
     if (scrollRows > maxScroll) setScrollRows(maxScroll);
   }, [scrollRows, maxScroll]);
 
-  const scrollUp = useCallback(() => schedule(-SCROLL_PAGE_ROWS), [schedule]);
-  const scrollDown = useCallback(() => schedule(SCROLL_PAGE_ROWS), [schedule]);
+  const scrollUp = useCallback(() => schedule(-SCROLL_ARROW_ROWS), [schedule]);
+  const scrollDown = useCallback(() => schedule(SCROLL_ARROW_ROWS), [schedule]);
+  const scrollPageUp = useCallback(() => schedule(-SCROLL_PAGE_ROWS), [schedule]);
+  const scrollPageDown = useCallback(() => schedule(SCROLL_PAGE_ROWS), [schedule]);
 
   const jumpToBottom = useCallback(() => {
     pendingDelta.current = 0;
@@ -83,5 +102,14 @@ export function useChatScroll(): ChatScrollState {
     setMaxScrollState(rows);
   }, []);
 
-  return { scrollRows, pinned, scrollUp, scrollDown, jumpToBottom, setMaxScroll };
+  return {
+    scrollRows,
+    pinned,
+    scrollUp,
+    scrollDown,
+    scrollPageUp,
+    scrollPageDown,
+    jumpToBottom,
+    setMaxScroll,
+  };
 }


### PR DESCRIPTION
## Summary

Wheel-up felt laggy because every tick paid a 16 ms wait before any visual feedback. `schedule()` was trailing-edge: the first call started a `setTimeout`, the actual `setScrollRows` didn't run until the timer fired. Layered on Ink reconcile + Yoga layout, a single tick cost 30-50 ms before the frame moved.

**Two changes:**

1. **Leading-edge `schedule()`.** First call applies the delta immediately so the user sees the wheel respond on the first tick. The 16 ms window still opens — subsequent calls inside it accumulate into `pendingDelta` and land in one trailing flush. Fast scrolls still produce only one re-render per window; the user just no longer waits for the first.
2. **Split arrow step from page/wheel step.** `SCROLL_ARROW_ROWS` stays at 3 (fine-grained ↑/↓). New `SCROLL_PAGE_ROWS = 8` covers PgUp/PgDn and the wheel-via-DECSET-1007 path. Each wheel tick now travels roughly a third of a typical viewport instead of three lines.

## Test plan

- [ ] `npm run verify` passes locally.
- [ ] Wheel-up in `reasonix code` moves the chat history immediately on the first tick.
- [ ] Holding ↑ still scrolls smoothly (one row at a time, no stutter).
- [ ] PgUp / PgDn travel ~8 rows per press.
- [ ] `End` still jumps to bottom and re-pins.