### PR TITLE
fix(ui): compress scroll-schedule comment to satisfy 3-line cap

### DIFF
--- a/src/cli/ui/hooks/useChatScroll.ts
+++ b/src/cli/ui/hooks/useChatScroll.ts
@@ -45,11 +45,7 @@ export function useChatScroll(): ChatScrollState {
     });
   }, []);
 
-  /** Leading-edge schedule: first call applies immediately so the user
-   * sees the wheel respond on the first tick (no 16 ms wait before any
-   * visual feedback). Further calls inside the COALESCE_MS window batch
-   * into pendingDelta and land in one trailing flush, so a fast scroll
-   * still produces only one re-render per window. */
+  /** Leading-edge: first tick flushes immediately, rest coalesce into one trailing flush. */
   const schedule = useCallback(
     (delta: number) => {
       if (flushTimer.current === null) {


### PR DESCRIPTION
## Summary

Hotfix for main. The squash merge of #571 landed with a 5-line block comment in `useChatScroll.ts` that violates `tests/comment-policy.test.ts` (cap is 3 lines). The branch had a fixup commit shrinking it to one line, but the auto-merge fired on the branch's first commit before the fixup was pushed — and only CodeQL (not the build) is a required check, so the squash merge proceeded with the failing build.

This PR brings main back to green.

## Note for branch protection

`build (node 22)` should probably be added to the required-status-checks list — that's how this slipped through.

## Test plan

- [ ] `npm run verify` passes locally (already confirmed: comment-policy test green).