### PR TITLE
refactor(ui): extract useWorkspaceRoot from App.tsx

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -128,6 +128,7 @@ import { useScrollback } from "./hooks/useScrollback.js";
 import { useTerminalSetup } from "./hooks/useTerminalSetup.js";
 import { useToolProgressDisplay } from "./hooks/useToolProgressDisplay.js";
 import { useTranscriptWriter } from "./hooks/useTranscriptWriter.js";
+import { useWorkspaceRoot } from "./hooks/useWorkspaceRoot.js";
 import { useKeystroke } from "./keystroke-context.js";
 import { CardStream } from "./layout/CardStream.js";
 import { LiveExpandContext } from "./layout/LiveExpandContext.js";
@@ -424,15 +425,8 @@ function AppInner({
     log,
     getWalletCurrency: () => walletCurrencyRef.current,
   });
-  // Live working directory for every rootDir-dependent surface:
-  // hook cwd, memory root, project shell allowlist root, `@file`
-  // mention root, `applyEditBlocks` base, run_command cwd, project-
-  // settings hook loader. `/cwd <path>` mutates this state to swap
-  // the workspace mid-session; the prop `codeMode.rootDir` stays as
-  // the original launch root so it can't accidentally drift (it's
-  // used purely for "is this a code-mode session?" checks now).
-  const [currentRootDir, setCurrentRootDir] = useState<string>(
-    () => codeMode?.rootDir ?? process.cwd(),
+  const { currentRootDir, setCurrentRootDir, currentRootDirRef } = useWorkspaceRoot(
+    codeMode?.rootDir,
   );
   // Loaded user hooks (project + global settings.json). Stays mutable
   // so `/hooks reload` and `/cwd` can rescan disk without
@@ -476,7 +470,6 @@ function AppInner({
   // captured once at startDashboard time; without ref-mirrors the
   // returned values would freeze at boot. Same pattern as editModeRef.
   const planModeRef = useRef<boolean>(false);
-  const currentRootDirRef = useRef<string>("");
   const latestVersionRef = useRef<string | null>(null);
   // Current per-edit confirmation prompt (review mode, tool-call path).
   // Non-null → EditConfirm modal renders, interceptor is suspended on
@@ -879,9 +872,6 @@ function AppInner({
   useEffect(() => {
     planModeRef.current = planMode;
   }, [planMode]);
-  useEffect(() => {
-    currentRootDirRef.current = currentRootDir;
-  }, [currentRootDir]);
 
   useEffect(() => {
     latestVersionRef.current = latestVersion ?? null;
@@ -1882,6 +1872,7 @@ function AppInner({
     pendingEdits,
     editModeRef,
     setEditMode,
+    currentRootDirRef,
   ]);
 
   const stopDashboard = useCallback(async (): Promise<void> => {
@@ -2670,6 +2661,7 @@ function AppInner({
       setEditMode,
       pendingEdits,
       syncPendingCount,
+      setCurrentRootDir,
       setOngoingTool,
       setToolProgress,
       setStatusLine,

--- a/src/cli/ui/hooks/useWorkspaceRoot.ts
+++ b/src/cli/ui/hooks/useWorkspaceRoot.ts
@@ -1,0 +1,25 @@
+import {
+  type Dispatch,
+  type MutableRefObject,
+  type SetStateAction,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+export interface WorkspaceRoot {
+  /** Live working directory — every rootDir-dependent surface (hook cwd, memory root, shell allowlist root, `@file` mention root, applyEditBlocks base, run_command cwd) reads this. */
+  currentRootDir: string;
+  setCurrentRootDir: Dispatch<SetStateAction<string>>;
+  /** Mirror for closures captured at boot (dashboard server, tool interceptor) — without it those reads freeze on the launch root after `/cwd`. */
+  currentRootDirRef: MutableRefObject<string>;
+}
+
+export function useWorkspaceRoot(launchRoot: string | undefined): WorkspaceRoot {
+  const [currentRootDir, setCurrentRootDir] = useState<string>(() => launchRoot ?? process.cwd());
+  const currentRootDirRef = useRef<string>(currentRootDir);
+  useEffect(() => {
+    currentRootDirRef.current = currentRootDir;
+  }, [currentRootDir]);
+  return { currentRootDir, setCurrentRootDir, currentRootDirRef };
+}


### PR DESCRIPTION
## Summary

Step 4/7 of #565 phase 1.

`useWorkspaceRoot(launchRoot)` owns:
- `currentRootDir` state (defaults to `launchRoot ?? process.cwd()`)
- `setCurrentRootDir` setter (the `/cwd` swap calls this)
- `currentRootDirRef` mirror + the effect that keeps it fresh

App.tsx loses one `useState`, one `useRef`, and one mirror
`useEffect`, and the long inline narrative explaining which
surfaces read `currentRootDir`.

The `/cwd` slash handler still composes the swap orchestration
(re-register native tools + reload hooks + re-bootstrap
semantic) — only state + ref ownership moves into the hook.

3723 → 3715 lines.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `biome check` clean (deps arrays updated for the destructured ref + setter)
- [x] `vitest run` — 153 files / 2431 tests pass

Closes part of #565.
