### PR TITLE
refactor(ui): extract useLanguageReload from App.tsx

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -48,7 +48,7 @@ import {
 import { Eventizer } from "../../core/eventize.js";
 import { pauseGate } from "../../core/pause-gate.js";
 import { formatHookOutcomeMessage, runHooks } from "../../hooks.js";
-import { onLanguageChange, t, tObj } from "../../i18n/index.js";
+import { t, tObj } from "../../i18n/index.js";
 import { CacheFirstLoop, DeepSeekClient, ImmutablePrefix } from "../../index.js";
 import type { LoopEvent } from "../../loop.js";
 import {
@@ -123,6 +123,7 @@ import { useCodeMode } from "./hooks/useCodeMode.js";
 import { useEditGate } from "./hooks/useEditGate.js";
 import { useHookList } from "./hooks/useHookList.js";
 import { useInputRecall } from "./hooks/useInputRecall.js";
+import { useLanguageReload } from "./hooks/useLanguageReload.js";
 import { useLoopMode } from "./hooks/useLoopMode.js";
 import { usePresetMode } from "./hooks/usePresetMode.js";
 import { useQuit } from "./hooks/useQuit.js";
@@ -385,8 +386,7 @@ function AppInner({
   useEffect(() => {
     if (!isStreaming && liveExpand) setLiveExpand(false);
   }, [isStreaming, liveExpand]);
-  const [languageVersion, setLanguageVersion] = useState(0);
-  useEffect(() => onLanguageChange(() => setLanguageVersion((v) => v + 1)), []);
+  const languageVersion = useLanguageReload();
   useEffect(() => {
     markPhase("first_paint");
     dumpStartupProfile();

--- a/src/cli/ui/hooks/useLanguageReload.ts
+++ b/src/cli/ui/hooks/useLanguageReload.ts
@@ -1,0 +1,8 @@
+import { useEffect, useState } from "react";
+import { onLanguageChange } from "../../../i18n/index.js";
+
+export function useLanguageReload(): number {
+  const [version, setVersion] = useState(0);
+  useEffect(() => onLanguageChange(() => setVersion((v) => v + 1)), []);
+  return version;
+}


### PR DESCRIPTION
## Summary

Step 7/7 — final hook in #565 phase 1.

`useLanguageReload()` owns the `version` counter +
`onLanguageChange` subscription that forces consumers to
re-render after a runtime locale switch. App.tsx loses the
`onLanguageChange` import.

App.tsx LOC unchanged at 3695 (one new import line in, the
inline `useState` + `useEffect` pair out).

This wraps phase 1 of #565 — App.tsx 3782 → 3695, with seven
new hooks under `src/cli/ui/hooks/` carrying state that was
previously inline. Phase 2 (sub-component decomposition) and
phase 3 (slash-command registry) follow.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `biome check` clean
- [x] `vitest run` — 153 files / 2431 tests pass

Closes part of #565.
