### PR TITLE
perf(boot): defer MCP bridging to App.tsx mount

### DIFF
--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -62,6 +62,51 @@ interface RuntimeContext {
   progressSink: { current: ((info: ProgressInfo) => void) | null };
 }
 
+export type McpLifecycleNotice =
+  | { kind: "handshake"; name: string }
+  | {
+      kind: "connected";
+      name: string;
+      tools: number;
+      resources: number;
+      prompts: number;
+      ms: number;
+    }
+  | { kind: "disabled"; name: string }
+  | { kind: "failed"; name: string; reason: string }
+  | { kind: "slow"; serverName: string; p95Ms: number; sampleSize: number };
+
+export type McpLifecycleSink = (notice: McpLifecycleNotice) => void;
+
+const stderrLifecycleSink: McpLifecycleSink = (n) => {
+  if (n.kind === "slow") {
+    process.stderr.write(
+      `${formatMcpSlowToast({ name: n.serverName, p95Ms: n.p95Ms, sampleSize: n.sampleSize })}\n`,
+    );
+    return;
+  }
+  if (n.kind === "failed") {
+    process.stderr.write(
+      `${formatMcpLifecycleEvent({ state: "failed", name: n.name, reason: n.reason })}\n  → run \`reasonix setup\` to remove this entry, or fix the underlying issue (missing npm package, network, etc.).\n`,
+    );
+    return;
+  }
+  if (n.kind === "connected") {
+    process.stderr.write(
+      `${formatMcpLifecycleEvent({
+        state: "connected",
+        name: n.name,
+        tools: n.tools,
+        resources: n.resources,
+        prompts: n.prompts,
+        ms: n.ms,
+      })}\n`,
+    );
+    return;
+  }
+  process.stderr.write(`${formatMcpLifecycleEvent({ state: n.kind, name: n.name })}\n`);
+};
+
 export interface McpRuntime {
   size(): number;
   specs(): string[];
@@ -78,11 +123,14 @@ export interface McpRuntime {
     summaries: McpServerSummary[];
   }>;
   closeAll(): Promise<void>;
+  /** Replace the sink that lifecycle events flow through — App.tsx swaps this in on mount so toasts land in the alt-screen UI instead of corrupting it via stderr. */
+  setLifecycleSink(sink: McpLifecycleSink): void;
 }
 
 function createMcpRuntime(ctx: RuntimeContext): McpRuntime {
   const records = new Map<string, SpecRecord>();
   const insertionOrder: string[] = [];
+  let sink: McpLifecycleSink = stderrLifecycleSink;
 
   async function addSpec(
     raw: string,
@@ -100,10 +148,10 @@ function createMcpRuntime(ctx: RuntimeContext): McpRuntime {
       const spec = parseMcpSpec(raw);
       label = spec.name ?? "anon";
       if (spec.name && disabledNames.has(spec.name)) {
-        process.stderr.write(`${formatMcpLifecycleEvent({ state: "disabled", name: label })}\n`);
+        sink({ kind: "disabled", name: label });
         return { ok: false, reason: "disabled by user" };
       }
-      process.stderr.write(`${formatMcpLifecycleEvent({ state: "handshake", name: label })}\n`);
+      sink({ kind: "handshake", name: label });
       const t0 = Date.now();
       const namePrefix = spec.name
         ? `${spec.name}_`
@@ -127,9 +175,12 @@ function createMcpRuntime(ctx: RuntimeContext): McpRuntime {
         host,
         onProgress: (info) => ctx.progressSink.current?.(info),
         onSlow: (info) =>
-          process.stderr.write(
-            `${formatMcpSlowToast({ name: info.serverName, p95Ms: info.p95Ms, sampleSize: info.sampleSize })}\n`,
-          ),
+          sink({
+            kind: "slow",
+            serverName: info.serverName,
+            p95Ms: info.p95Ms,
+            sampleSize: info.sampleSize,
+          }),
       });
       let report: InspectionReport;
       try {
@@ -148,16 +199,14 @@ function createMcpRuntime(ctx: RuntimeContext): McpRuntime {
       const ms = Date.now() - t0;
       const resourceCount = report.resources.supported ? report.resources.items.length : 0;
       const promptCount = report.prompts.supported ? report.prompts.items.length : 0;
-      process.stderr.write(
-        `${formatMcpLifecycleEvent({
-          state: "connected",
-          name: label,
-          tools: bridge.registeredNames.length,
-          resources: resourceCount,
-          prompts: promptCount,
-          ms,
-        })}\n`,
-      );
+      sink({
+        kind: "connected",
+        name: label,
+        tools: bridge.registeredNames.length,
+        resources: resourceCount,
+        prompts: promptCount,
+        ms,
+      });
       const summary = buildMcpServerSummary({
         label,
         spec: raw,
@@ -186,9 +235,7 @@ function createMcpRuntime(ctx: RuntimeContext): McpRuntime {
     } catch (err) {
       await mcp?.close().catch(() => undefined);
       const reason = (err as Error).message;
-      process.stderr.write(
-        `${formatMcpLifecycleEvent({ state: "failed", name: label, reason })}\n  → run \`reasonix setup\` to remove this entry, or fix the underlying issue (missing npm package, network, etc.).\n`,
-      );
+      sink({ kind: "failed", name: label, reason });
       return { ok: false, reason };
     }
   }
@@ -249,6 +296,9 @@ function createMcpRuntime(ctx: RuntimeContext): McpRuntime {
     records.clear();
     insertionOrder.length = 0;
   }
+  function setLifecycleSink(s: McpLifecycleSink): void {
+    sink = s;
+  }
   return {
     size: () => records.size,
     specs,
@@ -257,6 +307,7 @@ function createMcpRuntime(ctx: RuntimeContext): McpRuntime {
     removeSpec,
     reloadFromConfig,
     closeAll,
+    setLifecycleSink,
   };
 }
 
@@ -454,24 +505,10 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
     progressSink,
   });
 
-  const failedSpecs: Array<{ spec: string; reason: string }> = [];
-  if (requestedSpecs.length > 0) markPhase("mcp_launch");
-  for (const raw of requestedSpecs) {
-    const result = await runtime.addSpec(raw);
-    if (!result.ok) failedSpecs.push({ spec: raw, reason: result.reason });
-  }
-  if (requestedSpecs.length > 0) {
-    markPhase(
-      `mcp_connected_${requestedSpecs.length - failedSpecs.length}_of_${requestedSpecs.length}`,
-    );
-  }
-  if (runtime.size() === 0 && !opts.seedTools) {
-    tools = undefined;
-  }
-  // Preserve configured specs even when startup leaves them unbridged
-  // so `/mcp` can still surface the configured-but-offline set.
+  // MCP bridging deferred to App.tsx mount — handshakes are 100ms–2s each
+  // and we don't want the alt-screen UI to block on the slowest one.
   const mcpSpecs = [...requestedSpecs];
-  const mcpServers = runtime.summaries();
+  const mcpServers: McpServerSummary[] = [];
 
   // Register web search/fetch tools unless explicitly disabled. DDG
   // backs them with no key required; the model invokes them whenever

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -149,7 +149,9 @@ import { ViewportBudgetProvider } from "./layout/viewport-budget.js";
 import { formatLoopStatus } from "./loop.js";
 import { applyMcpAppend } from "./mcp-append.js";
 import { handleMcpBrowseSlash } from "./mcp-browse.js";
+import { formatMcpLifecycleEvent } from "./mcp-lifecycle.js";
 import { replaceMcpServerSummary } from "./mcp-server-list.js";
+import { formatMcpSlowToast } from "./mcp-toast.js";
 import { formatLongPaste } from "./paste-collapse.js";
 import { extractOpenQuestionsSection } from "./plan-open-questions.js";
 import { PRESETS, resolvePreset } from "./presets.js";
@@ -843,6 +845,52 @@ function AppInner({
   useEffect(() => {
     loop.hooks = hookList;
   }, [loop, hookList]);
+
+  // Deferred MCP bridge — fire addSpec for each requested server in the
+  // background instead of blocking startup, route lifecycle events to
+  // the in-app log so they don't corrupt alt-screen via stderr.
+  const mcpBridgeStartedRef = useRef(false);
+  useEffect(() => {
+    if (mcpBridgeStartedRef.current) return;
+    if (!mcpRuntime || !mcpSpecs || mcpSpecs.length === 0) return;
+    mcpBridgeStartedRef.current = true;
+    mcpRuntime.setLifecycleSink((notice) => {
+      if (notice.kind === "handshake") {
+        log.pushInfo(formatMcpLifecycleEvent({ state: "handshake", name: notice.name }));
+      } else if (notice.kind === "connected") {
+        log.pushInfo(
+          formatMcpLifecycleEvent({
+            state: "connected",
+            name: notice.name,
+            tools: notice.tools,
+            resources: notice.resources,
+            prompts: notice.prompts,
+            ms: notice.ms,
+          }),
+        );
+      } else if (notice.kind === "disabled") {
+        log.pushInfo(formatMcpLifecycleEvent({ state: "disabled", name: notice.name }));
+      } else if (notice.kind === "failed") {
+        log.pushWarning(
+          `MCP · ${notice.name} failed`,
+          `${notice.reason}\n→ run \`reasonix setup\` to remove this entry, or fix the underlying issue (missing npm package, network, etc.).`,
+        );
+      } else if (notice.kind === "slow") {
+        log.pushInfo(
+          formatMcpSlowToast({
+            name: notice.serverName,
+            p95Ms: notice.p95Ms,
+            sampleSize: notice.sampleSize,
+          }),
+        );
+      }
+    });
+    for (const spec of mcpSpecs) {
+      void mcpRuntime.addSpec(spec, loop).then(() => {
+        setLiveMcpServers(mcpRuntime.summaries());
+      });
+    }
+  }, [mcpRuntime, mcpSpecs, loop, log]);
 
   // Ambient session info (balance, model catalog, latest published
   // version) — three independent mount-time fetches behind one hook

--- a/tests/chat-mcp-startup-summary.test.ts
+++ b/tests/chat-mcp-startup-summary.test.ts
@@ -216,18 +216,15 @@ describe("chatCommand MCP startup summary states", { timeout: 15_000 }, () => {
     vi.restoreAllMocks();
   });
 
-  it("passes live bridged servers into the initial MCP props", async () => {
+  it("passes mcpSpecs through with empty initial mcpServers — bridging is deferred to App mount", async () => {
     const props = await captureStartupState();
 
     expect(props.mcpSpecs).toEqual(["fs=npx -y @scope/fs /tmp"]);
-    expect(props.mcpServers).toHaveLength(1);
-    expect(props.mcpServers[0]).toMatchObject({
-      label: "fs",
-      spec: "fs=npx -y @scope/fs /tmp",
-    });
+    expect(props.mcpServers).toEqual([]);
+    expect(mocks.bridgeMcpToolsMock).not.toHaveBeenCalled();
   });
 
-  it("preserves disabled startup specs for marketplace fallback even with no live servers", async () => {
+  it("preserves disabled startup specs for marketplace fallback — App.tsx skips them on mount", async () => {
     const props = await captureStartupState({
       readConfig: { mcpDisabled: ["fs"] },
     });
@@ -237,12 +234,13 @@ describe("chatCommand MCP startup summary states", { timeout: 15_000 }, () => {
     expect(mocks.bridgeMcpToolsMock).not.toHaveBeenCalled();
   });
 
-  it("preserves unbridged startup specs when startup fails before a live summary exists", async () => {
+  it("never blocks chatCommand on bridge failure — App.tsx surfaces the lifecycle error post-mount", async () => {
     const props = await captureStartupState({
       initializeError: new Error("spawn failed"),
     });
 
     expect(props.mcpSpecs).toEqual(["fs=npx -y @scope/fs /tmp"]);
     expect(props.mcpServers).toEqual([]);
+    expect(mocks.initializeMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

`reasonix code` / `reasonix chat` used to await each MCP
`runtime.addSpec(raw)` serially before calling `render()`. Each
handshake is 100ms–2s; the alt-screen UI couldn't come up until
the last one finished, so users with several servers configured
saw a black screen on startup.

This PR moves bridging to App.tsx mount and runs it in the
background.

### Mechanics

- **Lifecycle sink:** `McpRuntime` gains
  `setLifecycleSink(sink)`. The runtime calls `sink(notice)` on
  handshake / connected / disabled / failed / slow events instead
  of `process.stderr.write` directly. Default sink is the old
  stderr formatter (preserves CLI behavior for any future
  caller).
- **chatCommand:** drops the pre-render `for...await addSpec`
  loop. Hands `mcpServers: []` to `<App>` and lets it bridge.
- **App.tsx:** new effect (one-shot, gated by an init ref) swaps
  the sink to one that calls `log.pushInfo` / `log.pushWarning`,
  then fires `runtime.addSpec(spec, loop)` for each pending
  spec. Each completion does
  `setLiveMcpServers(runtime.summaries())` so `/mcp` reflects
  the live count. `loop.prefix.addTool(...)` hot-adds the tools
  into the live loop — first turn after bridging is one
  cache-miss, same as the existing `/mcp browse install` path.

### Behavior changes

- UI now paints immediately on launch even with N MCP servers
  configured.
- Servers that fail to connect just stay unavailable — their
  tools never bridge. Same end state as before, no wait.
- If the user submits a turn faster than bridging completes,
  the first turn runs without MCP tools and subsequent turns
  pick them up. The hot-add path is the same one already used
  for runtime `/mcp browse install`.

### Test plan

- [x] `tsc --noEmit` clean
- [x] `biome check` clean
- [x] `vitest run` — 153 files / 2431 tests pass
- [x] Updated `chat-mcp-startup-summary.test.ts` to assert the
  new invariants (mcpSpecs preserved, mcpServers empty at mount,
  bridge mock not called from chatCommand)
- [ ] Manual: `reasonix code` with 2+ MCP servers — alt-screen
  should come up immediately, lifecycle toasts visible in-app

Follow-ups (not in this PR):
- `bootstrapSemanticSearchInCodeMode` is still pre-render; could
  defer the same way for cold-disk projects.
