### PR TITLE
feat(ui): boot splash with REASONIX logo + animated whale

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -86,6 +86,7 @@ import { webFetch } from "../../tools/web.js";
 import { openTranscriptFile } from "../../transcript/log.js";
 import { dumpStartupProfile, markPhase } from "../startup-profile.js";
 import { AtMentionSuggestions } from "./AtMentionSuggestions.js";
+import { BootSplash } from "./BootSplash.js";
 import { CheckpointPicker } from "./CheckpointPicker.js";
 import { ChoiceConfirm, type ChoiceConfirmChoice } from "./ChoiceConfirm.js";
 import { EditConfirm, type EditReviewChoice } from "./EditConfirm.js";
@@ -387,6 +388,13 @@ function AppInner({
     if (!isStreaming && liveExpand) setLiveExpand(false);
   }, [isStreaming, liveExpand]);
   const languageVersion = useLanguageReload();
+  // Splash holds for one full whale-spout cycle (~1.4s) so the brand
+  // mark always lands clean and heavy first-paint cost stays hidden.
+  const [bootReady, setBootReady] = useState(false);
+  useEffect(() => {
+    const t = setTimeout(() => setBootReady(true), 1400);
+    return () => clearTimeout(t);
+  }, []);
   useEffect(() => {
     markPhase("first_paint");
     dumpStartupProfile();
@@ -3263,6 +3271,8 @@ function AppInner({
   // Suspend cosmetic animations during modal interactions and idle so
   // a quiescent TUI is byte-stable.
   const tickerSuspended = modalOpen || (!busy && !isStreaming);
+
+  if (!bootReady) return <BootSplash />;
 
   return (
     <>

--- a/src/cli/ui/BootSplash.tsx
+++ b/src/cli/ui/BootSplash.tsx
@@ -1,0 +1,82 @@
+import { Box, Text } from "ink";
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React, { useEffect, useState } from "react";
+import { FG, TONE } from "./theme/tokens.js";
+
+const REASONIX_LOGO = [
+  "██████╗ ███████╗ █████╗ ███████╗ ██████╗ ███╗   ██╗██╗██╗  ██╗",
+  "██╔══██╗██╔════╝██╔══██╗██╔════╝██╔═══██╗████╗  ██║██║╚██╗██╔╝",
+  "██████╔╝█████╗  ███████║███████╗██║   ██║██╔██╗ ██║██║ ╚███╔╝ ",
+  "██╔══██╗██╔══╝  ██╔══██║╚════██║██║   ██║██║╚██╗██║██║ ██╔██╗ ",
+  "██║  ██║███████╗██║  ██║███████║╚██████╔╝██║ ╚████║██║██╔╝ ██╗",
+  "╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝╚══════╝ ╚═════╝ ╚═╝  ╚═══╝╚═╝╚═╝  ╚═╝",
+];
+
+const WHALE_LINES = [
+  "                _____:_____",
+  "          __.-''           ''-.__",
+  "       ,-'   ░░▒▒▒▒▒▒▒▒▒▒▒▒░░     '-.",
+  "     ,'   ░▒▒▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▒▒░     '\\",
+  "    /   ░▒▓▓▓▓◉▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▒░     '\\___",
+  "   |  ░▒▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▒░         '\\\\__",
+  "   |  ░▒▓▓▓▓▓▓ ‿‿‿ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▒░          \\\\__\\",
+  "   |  ░▒▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▒░          //__/",
+  "    \\   ░▒▒▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▒▒░         //",
+  "     '\\.   ░░▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░░       __,/'",
+  "        '-..___                 ___..-'",
+  "              '''---..........---'''",
+];
+
+const SPOUT_FRAMES: ReadonlyArray<readonly string[]> = [
+  ["                  ", "                  ", "                  "],
+  ["                  ", "                  ", "                 ."],
+  ["                  ", "                 .", "                 :"],
+  ["                 .", "                 :", "                 :"],
+  ["              .  '  .", "                 :", "                 :"],
+  ["              '  .  '", "                 '", "                 :"],
+  ["              .     .", "                  '", "                  "],
+];
+
+const WAVE_SOURCE = "~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^";
+const WAVE_WIDTH = 44;
+const FRAME_MS = 200;
+
+export function BootSplash(): React.ReactElement {
+  const [frame, setFrame] = useState(0);
+  useEffect(() => {
+    const t = setInterval(() => setFrame((f) => f + 1), FRAME_MS);
+    return () => clearInterval(t);
+  }, []);
+  const spout = SPOUT_FRAMES[frame % SPOUT_FRAMES.length] as readonly string[];
+  const waveOffset = frame % 4;
+  const wave = WAVE_SOURCE.slice(waveOffset, waveOffset + WAVE_WIDTH);
+  const dots = ".".repeat((frame % 4) + 1);
+  return (
+    <Box flexDirection="column" alignItems="center" marginY={1}>
+      <Box flexDirection="column" alignItems="flex-start" marginBottom={1}>
+        {REASONIX_LOGO.map((line) => (
+          <Text key={line} color={TONE.brand} bold>
+            {line}
+          </Text>
+        ))}
+      </Box>
+      <Box flexDirection="column" alignItems="flex-start">
+        {spout.map((line, i) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: fixed-length spout column, position is the identity
+          <Text key={i} color={TONE.accent}>
+            {line.length > 0 ? line : " "}
+          </Text>
+        ))}
+        {WHALE_LINES.map((line) => (
+          <Text key={line} color={TONE.brand} bold>
+            {line}
+          </Text>
+        ))}
+        <Text color={FG.faint}>{wave}</Text>
+      </Box>
+      <Box marginTop={1}>
+        <Text color={FG.meta}>{`loading${dots}`}</Text>
+      </Box>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a boot splash screen for `reasonix code` / `reasonix chat`.
On cold launch the alt-screen used to flash blank for a few
hundred ms before AppInner's first paint completed; users read
that as a freeze. The splash holds for one full whale-spout
cycle (~1.4s) so:

- The brand mark lands cleanly instead of raw mount state
  flashing through.
- AppInner's heavy first-paint cost (~150 hooks + several disk
  reads in `useState` initializers) hides under the splash.

## Splash content

- **REASONIX wordmark** — ANSI Shadow block letters, 6 rows,
  brand color (replaces the small inline `REASONIX × DeepSeek`
  text from the prior iteration)
- **Whale silhouette** — three-tone shaded (`░` outline / `▒`
  midtone / `▓` inner) with visible eye, mouth, and tail flukes
- **Spout animation** — 7-frame cycle at 200ms (idle → rising →
  peak with droplets → dispersing)
- **Wave** — `~^~^~` shifting one column per frame below the body
- **`loading...`** — cycling dots

## Wiring

`AppInner` adds a `bootReady` state and a one-shot
`setTimeout(setBootReady(true), 1400)`. Right before the
existing return, returns `<BootSplash />` until ready. All
hooks and effects (loop construction, MCP probe, useSessionInfo
fetches, etc.) run during the splash window so the post-splash
render is ready immediately.

Setup screen and SessionPicker bypass the splash — only AppInner
shows it, since that's where the heavy first-paint cost lives.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `biome check` clean
- [x] `vitest run` — 153 files / 2431 tests pass
- [ ] Manual: `npx reasonix code` — alt-screen comes up to splash
  immediately, holds ~1.4s with animated spout/wave, then swaps
  to the main UI. Verify the `█ ╗ ╔` block characters align in
  Windows Terminal + PowerShell.
