### PR TITLE
fix(dashboard): list flat-format skills

### DIFF
--- a/src/server/api/skills.ts
+++ b/src/server/api/skills.ts
@@ -10,6 +10,7 @@ import {
   readSync,
   readdirSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
@@ -52,6 +53,13 @@ interface SkillListEntry {
   mtime: number;
 }
 
+type SkillLayout = "folder" | "flat";
+
+interface ResolvedSkillPath {
+  path: string;
+  layout: SkillLayout;
+}
+
 function parseFrontmatterDescription(raw: string): string | undefined {
   const lines = raw.split(/\r?\n/);
   if (lines[0] !== "---") return undefined;
@@ -63,45 +71,86 @@ function parseFrontmatterDescription(raw: string): string | undefined {
   return undefined;
 }
 
+function readSkillListEntry(
+  skillPath: string,
+  name: string,
+  scope: "project" | "global",
+): SkillListEntry | null {
+  try {
+    // Open once and reuse the fd so size/mtime/content all bind to
+    // the same inode — closes the exists→stat→read TOCTOU races.
+    const fd = openSync(skillPath, "r");
+    let stat: ReturnType<typeof fstatSync>;
+    let raw: string;
+    try {
+      stat = fstatSync(fd);
+      if (!stat.isFile()) return null;
+      const buf = Buffer.alloc(stat.size);
+      let read = 0;
+      while (read < stat.size) {
+        const n = readSync(fd, buf, read, stat.size - read, read);
+        if (n <= 0) break;
+        read += n;
+      }
+      raw = buf.toString("utf8", 0, read);
+    } finally {
+      closeSync(fd);
+    }
+    const item: SkillListEntry = {
+      name,
+      scope,
+      path: skillPath,
+      size: stat.size,
+      mtime: stat.mtime.getTime(),
+    };
+    const desc = parseFrontmatterDescription(raw);
+    if (desc) item.description = desc;
+    return item;
+  } catch {
+    return null;
+  }
+}
+
+function resolveSkillPath(dir: string, name: string): ResolvedSkillPath | null {
+  const folderPath = join(dir, name, SKILL_FILE);
+  try {
+    if (statSync(folderPath).isFile()) return { path: folderPath, layout: "folder" };
+  } catch {
+    /* try flat layout below */
+  }
+  const flatPath = join(dir, `${name}.md`);
+  try {
+    if (statSync(flatPath).isFile()) return { path: flatPath, layout: "flat" };
+  } catch {
+    /* not found */
+  }
+  return null;
+}
+
+function defaultSkillPath(dir: string, name: string): ResolvedSkillPath {
+  return { path: join(dir, name, SKILL_FILE), layout: "folder" };
+}
+
 function listSkills(dir: string, scope: "project" | "global"): SkillListEntry[] {
   if (!existsSync(dir)) return [];
   const out: SkillListEntry[] = [];
   try {
-    for (const entry of readdirSync(dir)) {
-      if (!SAFE_NAME.test(entry)) continue;
-      const skillPath = join(dir, entry, SKILL_FILE);
-      try {
-        // Open once and reuse the fd so size/mtime/content all bind to
-        // the same inode — closes the exists→stat→read TOCTOU races.
-        const fd = openSync(skillPath, "r");
-        let stat: ReturnType<typeof fstatSync>;
-        let raw: string;
-        try {
-          stat = fstatSync(fd);
-          const buf = Buffer.alloc(stat.size);
-          let read = 0;
-          while (read < stat.size) {
-            const n = readSync(fd, buf, read, stat.size - read, read);
-            if (n <= 0) break;
-            read += n;
-          }
-          raw = buf.toString("utf8", 0, read);
-        } finally {
-          closeSync(fd);
-        }
-        const item: SkillListEntry = {
-          name: entry,
-          scope,
-          path: skillPath,
-          size: stat.size,
-          mtime: stat.mtime.getTime(),
-        };
-        const desc = parseFrontmatterDescription(raw);
-        if (desc) item.description = desc;
-        out.push(item);
-      } catch {
-        /* skip unreadable */
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      let name: string;
+      let skillPath: string;
+      if (entry.isDirectory()) {
+        name = entry.name;
+        if (!SAFE_NAME.test(name)) continue;
+        skillPath = join(dir, name, SKILL_FILE);
+      } else if (entry.isFile() && entry.name.endsWith(".md")) {
+        name = entry.name.slice(0, -3);
+        if (!SAFE_NAME.test(name)) continue;
+        skillPath = join(dir, entry.name);
+      } else {
+        continue;
       }
+      const item = readSkillListEntry(skillPath, name, scope);
+      if (item) out.push(item);
     }
   } catch {
     /* skip unreadable dir */
@@ -184,11 +233,14 @@ export async function handleSkills(
   } else {
     dir = globalSkillsDir();
   }
-  const skillPath = join(dir, name, SKILL_FILE);
+  const resolved = resolveSkillPath(dir, name);
 
   if (method === "GET") {
-    if (!existsSync(skillPath)) return { status: 404, body: { error: "skill not found" } };
-    return { status: 200, body: { path: skillPath, body: readFileSync(skillPath, "utf8") } };
+    if (!resolved) return { status: 404, body: { error: "skill not found" } };
+    return {
+      status: 200,
+      body: { path: resolved.path, body: readFileSync(resolved.path, "utf8") },
+    };
   }
 
   if (method === "POST") {
@@ -196,20 +248,24 @@ export async function handleSkills(
     if (typeof contents !== "string") {
       return { status: 400, body: { error: "body (string) required" } };
     }
-    mkdirSync(dirname(skillPath), { recursive: true });
-    writeFileSync(skillPath, contents, "utf8");
+    const target = resolved ?? defaultSkillPath(dir, name);
+    mkdirSync(dirname(target.path), { recursive: true });
+    writeFileSync(target.path, contents, "utf8");
     ctx.audit?.({
       ts: Date.now(),
       action: "save-skill",
-      payload: { scope, name, path: skillPath },
+      payload: { scope, name, path: target.path },
     });
-    return { status: 200, body: { saved: true, path: skillPath } };
+    return { status: 200, body: { saved: true, path: target.path } };
   }
 
   if (method === "DELETE") {
-    if (!existsSync(skillPath)) return { status: 404, body: { error: "skill not found" } };
-    // Drop the whole skill folder (it may carry assets next to SKILL.md).
-    rmSync(dirname(skillPath), { recursive: true, force: true });
+    if (!resolved) return { status: 404, body: { error: "skill not found" } };
+    // Folder-layout skills may carry assets next to SKILL.md; flat skills are single-file entries.
+    rmSync(resolved.layout === "folder" ? dirname(resolved.path) : resolved.path, {
+      recursive: true,
+      force: true,
+    });
     ctx.audit?.({ ts: Date.now(), action: "delete-skill", payload: { scope, name } });
     return { status: 200, body: { deleted: true } };
   }

--- a/tests/server-dashboard.test.ts
+++ b/tests/server-dashboard.test.ts
@@ -1,7 +1,7 @@
 /** Dashboard server — token/CSRF gates, endpoint shapes, permissions CRUD against a real http server. */
 
 import { existsSync, mkdtempSync, rmSync } from "node:fs";
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -289,6 +289,70 @@ describe("dashboard server: endpoints", () => {
     expect(r.body.total).toBe(1);
     expect(r.body.tools[0].name).toBe("echo");
     expect(r.body.tools[0].readOnly).toBe(true);
+  });
+
+  it("GET /api/skills lists and edits flat-format project skills (#586)", async () => {
+    const proj = mkdtempSync(join(tmpdir(), "reasonix-dash-skills-"));
+    try {
+      const skillsDir = join(proj, ".reasonix", "skills");
+      const folderDir = join(skillsDir, "folder-skill");
+      const flatPath = join(skillsDir, "flat-skill.md");
+      await mkdir(folderDir, { recursive: true });
+      await writeFile(
+        join(folderDir, "SKILL.md"),
+        "---\ndescription: Folder skill\n---\nfolder body\n",
+        "utf8",
+      );
+      await writeFile(flatPath, "---\ndescription: Flat skill\n---\nflat body\n", "utf8");
+      await writeFile(join(skillsDir, "notes.txt"), "not a skill\n", "utf8");
+
+      const audited: Array<{ action: string; payload?: unknown }> = [];
+      const base = await boot({
+        getCurrentCwd: () => proj,
+        audit: (e) => audited.push({ action: e.action, payload: e.payload }),
+      });
+
+      const list = await call(`${base}api/skills`, { token: TOKEN });
+      expect(list.status).toBe(200);
+      expect(list.body.project.map((s: { name: string }) => s.name)).toEqual([
+        "flat-skill",
+        "folder-skill",
+      ]);
+      const flat = list.body.project.find((s: { name: string }) => s.name === "flat-skill");
+      expect(flat).toMatchObject({
+        name: "flat-skill",
+        scope: "project",
+        description: "Flat skill",
+        path: flatPath,
+      });
+
+      const read = await call(`${base}api/skills/project/flat-skill`, { token: TOKEN });
+      expect(read.status).toBe(200);
+      expect(read.body.path).toBe(flatPath);
+      expect(read.body.body).toContain("flat body");
+
+      const updated = "---\ndescription: Flat skill updated\n---\nnew body\n";
+      const save = await call(`${base}api/skills/project/flat-skill`, {
+        method: "POST",
+        token: TOKEN,
+        tokenInHeader: true,
+        body: { body: updated },
+      });
+      expect(save.status).toBe(200);
+      expect(save.body.path).toBe(flatPath);
+      expect(await readFile(flatPath, "utf8")).toBe(updated);
+
+      const del = await call(`${base}api/skills/project/flat-skill`, {
+        method: "DELETE",
+        token: TOKEN,
+        tokenInHeader: true,
+      });
+      expect(del.status).toBe(200);
+      expect(existsSync(flatPath)).toBe(false);
+      expect(audited.map((e) => e.action)).toEqual(["save-skill", "delete-skill"]);
+    } finally {
+      rmSync(proj, { recursive: true, force: true });
+    }
   });
 
   it("GET /api/permissions lists builtin always; project list when cwd is set", async () => {


### PR DESCRIPTION
## What

Teach the dashboard skills API to recognize flat-format skill files (<name>.md) in addition to folder-format skills (<name>/SKILL.md). The same resolver is used for listing, reading, saving, and deleting skills so a flat skill shown in the dashboard can also be edited or removed without creating a duplicate folder-layout skill.

## Why

Fixes #586. The TUI skill loader already supports both layouts, but /api/skills only looked for <dir>/<name>/SKILL.md, so flat installed skills worked from /skill <name> while the dashboard silently omitted them.

## How to verify

- 
pm run verify
- 
pm run test -- tests/server-dashboard.test.ts
- 
px biome check src/server/api/skills.ts tests/server-dashboard.test.ts
- 
pm run typecheck

## Checklist

- [x] 
pm run verify passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No Co-Authored-By: Claude trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to CHANGELOG.md — release notes are maintainer-written at release time