### PR TITLE
fix(loop): /new archives prior transcript instead of destroying it

### DIFF
--- a/src/cli/ui/slash/handlers/basic.ts
+++ b/src/cli/ui/slash/handlers/basic.ts
@@ -7,11 +7,11 @@ import type { SlashCommandSpec, SlashGroup } from "../types.js";
 const exit: SlashHandler = () => ({ exit: true });
 
 const resetLog: SlashHandler = (_args, loop) => {
-  const { dropped } = loop.clearLog();
-  return {
-    clear: true,
-    info: t("handlers.basic.newInfo", { count: dropped }),
-  };
+  const { dropped, archived } = loop.clearLog();
+  const info = archived
+    ? t("handlers.basic.newInfoArchived", { count: dropped, archived })
+    : t("handlers.basic.newInfo", { count: dropped });
+  return { clear: true, info };
 };
 
 const GROUP_ORDER: ReadonlyArray<SlashGroup> = [

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -592,6 +592,8 @@ export const EN: TranslationSchema = {
     basic: {
       newInfo:
         "▸ new conversation — dropped {count} message(s) from context. Same session, fresh slate.",
+      newInfoArchived:
+        '▸ new conversation — dropped {count} message(s) from context. Prior transcript archived as "{archived}" (visible under Sessions).',
       helpTitle: "Commands:",
       helpShellTitle: "Shell shortcut:",
       helpShell: "  !<cmd>                   run <cmd> in the sandbox root; output goes into",

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -575,6 +575,8 @@ export const zhCN: TranslationSchema = {
   handlers: {
     basic: {
       newInfo: "▸ 新对话 — 已从上下文中丢弃 {count} 条消息。同一会话，全新开始。",
+      newInfoArchived:
+        "▸ 新对话 — 已从上下文中丢弃 {count} 条消息。原对话已归档为「{archived}」，可在 Sessions 面板查看。",
       helpTitle: "命令：",
       helpShellTitle: "Shell 快捷方式：",
       helpShell: "  !<cmd>                   在沙箱根目录运行 <cmd>；输出进入对话",

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -44,6 +44,7 @@ import type { LoopEvent } from "./loop/types.js";
 import { AppendOnlyLog, type ImmutablePrefix, VolatileScratch } from "./memory/runtime.js";
 import {
   appendSessionMessage,
+  archiveSession,
   loadSessionMessages,
   loadSessionMeta,
   rewriteSession,
@@ -296,20 +297,22 @@ export class CacheFirstLoop {
     }
   }
 
-  /** "New chat" — drops messages but keeps session + immutable prefix (cache-first invariant). */
-  clearLog(): { dropped: number } {
+  /** "New chat" — drops in-memory messages, archives the on-disk transcript so it survives in Sessions, keeps sessionName so the prefix cache stays warm. */
+  clearLog(): { dropped: number; archived: string | null } {
     const dropped = this.log.length;
     this.log.compactInPlace([]);
+    let archived: string | null = null;
     if (this.sessionName) {
       try {
-        rewriteSession(this.sessionName, []);
+        archived = archiveSession(this.sessionName);
+        if (archived === null) rewriteSession(this.sessionName, []);
       } catch {
         /* disk issue shouldn't block the in-memory clear */
       }
     }
     this.scratch.reset();
     this._inflight.clear();
-    return { dropped };
+    return { dropped, archived };
   }
 
   configure(opts: ReconfigurableOptions): void {

--- a/src/memory/session.ts
+++ b/src/memory/session.ts
@@ -291,6 +291,22 @@ export function rewriteSession(name: string, messages: ChatMessage[]): void {
   }
 }
 
+/** Rotate the live jsonl + sidecars to `<name>__archive_<ts>` so /new doesn't destroy history. Returns the archive name, or null if there was nothing to archive. */
+export function archiveSession(name: string): string | null {
+  const path = sessionPath(name);
+  if (!existsSync(path)) return null;
+  try {
+    if (statSync(path).size === 0) return null;
+  } catch {
+    return null;
+  }
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const target = `${name}__archive_${timestampSuffix()}${attempt > 0 ? `_${attempt}` : ""}`;
+    if (renameSession(name, target)) return target;
+  }
+  return null;
+}
+
 function countLines(path: string): number {
   try {
     const raw = readFileSync(path, "utf8");

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -7,6 +7,7 @@ import { CacheFirstLoop } from "../src/loop.js";
 import { ImmutablePrefix } from "../src/memory/runtime.js";
 import {
   appendSessionMessage,
+  archiveSession,
   deleteSession,
   findSessionsByPrefix,
   listSessions,
@@ -187,6 +188,102 @@ describe("session persistence", () => {
     expect(existsSync(sessionPath("yesterday"))).toBe(true);
     expect(pruneStaleSessions(1)).toEqual(["yesterday"]);
     expect(existsSync(sessionPath("yesterday"))).toBe(false);
+  });
+
+  describe("archiveSession", () => {
+    it("returns null when the session file does not exist", () => {
+      expect(archiveSession("ghost")).toBeNull();
+    });
+
+    it("returns null when the session file is empty", () => {
+      appendSessionMessage("empty", { role: "user", content: "x" });
+      writeFileSync(sessionPath("empty"), "");
+      expect(archiveSession("empty")).toBeNull();
+      expect(existsSync(sessionPath("empty"))).toBe(true);
+    });
+
+    it("renames jsonl + sidecars to a timestamped archive name", () => {
+      appendSessionMessage("live", { role: "user", content: "hi" });
+      const events = sessionPath("live").replace(/\.jsonl$/, ".events.jsonl");
+      const meta = sessionPath("live").replace(/\.jsonl$/, ".meta.json");
+      writeFileSync(events, '{"id":1}\n');
+      writeFileSync(meta, "{}");
+
+      const archived = archiveSession("live");
+      expect(archived).toMatch(/^live__archive_\d{12}/);
+      expect(existsSync(sessionPath("live"))).toBe(false);
+      expect(existsSync(sessionPath(archived!))).toBe(true);
+      expect(existsSync(events)).toBe(false);
+      expect(existsSync(meta)).toBe(false);
+      expect(existsSync(sessionPath(archived!).replace(/\.jsonl$/, ".events.jsonl"))).toBe(true);
+      expect(existsSync(sessionPath(archived!).replace(/\.jsonl$/, ".meta.json"))).toBe(true);
+      expect(loadSessionMessages(archived!)).toEqual([{ role: "user", content: "hi" }]);
+    });
+
+    it("disambiguates when called twice in the same minute", () => {
+      appendSessionMessage("rapid", { role: "user", content: "first" });
+      const a = archiveSession("rapid");
+      appendSessionMessage("rapid", { role: "user", content: "second" });
+      const b = archiveSession("rapid");
+      expect(a).not.toBeNull();
+      expect(b).not.toBeNull();
+      expect(a).not.toBe(b);
+      expect(loadSessionMessages(a!)).toEqual([{ role: "user", content: "first" }]);
+      expect(loadSessionMessages(b!)).toEqual([{ role: "user", content: "second" }]);
+    });
+
+    it("archive name is excluded from the resume-by-prefix lookup", () => {
+      appendSessionMessage("proj", { role: "user", content: "x" });
+      const archived = archiveSession("proj");
+      expect(archived).not.toBeNull();
+      expect(findSessionsByPrefix("proj-")).toEqual([]);
+    });
+
+    it("archive shows up in listSessions", () => {
+      appendSessionMessage("show", { role: "user", content: "x" });
+      const archived = archiveSession("show");
+      const names = listSessions().map((s) => s.name);
+      expect(names).toContain(archived);
+    });
+  });
+
+  describe("clearLog archive integration", () => {
+    it("CacheFirstLoop.clearLog archives the live transcript and starts an empty file", () => {
+      const client = new DeepSeekClient({
+        apiKey: "sk-test",
+        fetch: (async () => new Response()) as any,
+      });
+      const loop = new CacheFirstLoop({
+        client,
+        prefix: new ImmutablePrefix({ system: "s" }),
+        stream: false,
+        session: "clear-archive",
+      });
+      loop.appendAndPersist({ role: "user", content: "first turn" });
+      loop.appendAndPersist({ role: "assistant", content: "reply" });
+
+      const { dropped, archived } = loop.clearLog();
+      expect(dropped).toBe(2);
+      expect(archived).toMatch(/^clear-archive__archive_\d{12}/);
+      expect(loadSessionMessages(archived!)).toHaveLength(2);
+      expect(loadSessionMessages("clear-archive")).toEqual([]);
+      expect(loop.log.length).toBe(0);
+    });
+
+    it("clearLog returns archived: null when the session has nothing on disk", () => {
+      const client = new DeepSeekClient({
+        apiKey: "sk-test",
+        fetch: (async () => new Response()) as any,
+      });
+      const loop = new CacheFirstLoop({
+        client,
+        prefix: new ImmutablePrefix({ system: "s" }),
+        stream: false,
+        session: "clear-empty",
+      });
+      const { archived } = loop.clearLog();
+      expect(archived).toBeNull();
+    });
   });
 
   it("sessionsDir exists after first append", () => {


### PR DESCRIPTION
## What

`/new` now archives the live transcript to `<name>__archive_<timestamp>` instead of truncating the session jsonl in place, so the prior conversation survives in the dashboard's Sessions tab.

## Why

Reported in #587. `clearLog()` was overwriting `~/.reasonix/sessions/code-<project>.jsonl` with `[]`, so multiple `/new`s in a single project still produced exactly one Sessions row — every prior turn destroyed without warning, no archive, no undo.

## How

- `archiveSession(name)` in `src/memory/session.ts` rotates the live `.jsonl` plus sidecars (`.events.jsonl`, `.meta.json`, `.pending.json`, `.plan.json`) to `<name>__archive_<ts>` via the existing `renameSession` helper. Returns `null` when there's nothing on disk to archive.
- The `__archive_` infix sits outside the `${name}-` resume-prefix matcher in `findSessionsByPrefix`, so archives show up in `listSessions()` (and the Sessions tab) but don't get auto-resumed on next launch.
- `clearLog()` in `src/loop.ts` calls `archiveSession` first; falls back to `rewriteSession([])` only if the rename is impossible (e.g. timestamp collision after 5 retries). `sessionName` is unchanged so the cache-first prefix invariant holds.
- Slash handler surfaces the archive name in the `▸ new conversation` info line so users see where their transcript went.

## How to verify

- `npm run verify`
- New tests in `tests/session.test.ts`:
  - `archiveSession` returns `null` for missing/empty files; renames jsonl + sidecars; disambiguates on rapid double-call; archive is excluded from prefix lookup; archive shows up in `listSessions`.
  - `clearLog` archives the on-disk transcript and starts an empty file; returns `archived: null` when there's nothing on disk.

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + 2440 tests)
- [x] No `Co-Authored-By: Claude` trailer
- [x] Comments follow CLAUDE.md (no module-essay headers, no incident history)
- [x] No CHANGELOG.md edits