### PR TITLE
fix(skills): hard-fail install + surface skills missing description

### DIFF
--- a/src/server/api/skills.ts
+++ b/src/server/api/skills.ts
@@ -15,7 +15,7 @@ import {
 } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
-import { SKILLS_DIRNAME, SKILL_FILE } from "../../skills.js";
+import { SKILLS_DIRNAME, SKILL_FILE, validateSkillFrontmatter } from "../../skills.js";
 import { readUsageLog } from "../../telemetry/usage.js";
 import type { DashboardContext } from "../context.js";
 import type { ApiResult } from "../router.js";
@@ -247,6 +247,10 @@ export async function handleSkills(
     const { body: contents } = parseBody(body);
     if (typeof contents !== "string") {
       return { status: 400, body: { error: "body (string) required" } };
+    }
+    const fm = validateSkillFrontmatter(contents);
+    if ("error" in fm) {
+      return { status: 400, body: { error: fm.error } };
     }
     const target = resolved ?? defaultSkillPath(dir, name);
     mkdirSync(dirname(target.path), { recursive: true });

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -44,6 +44,19 @@ export interface SkillStoreOptions {
   disableBuiltins?: boolean;
 }
 
+/** Reject skill files that would silently disappear from the prefix index — `description:` is what `applySkillsIndex` keys on. */
+export function validateSkillFrontmatter(raw: string): { ok: true } | { error: string } {
+  const { data } = parseFrontmatter(raw);
+  const desc = (data.description ?? "").trim();
+  if (!desc) {
+    return {
+      error:
+        'skill frontmatter is missing a non-empty "description:" line — without it the skill will not appear in the model\'s skills index',
+    };
+  }
+  return { ok: true };
+}
+
 function parseFrontmatter(raw: string): { data: Record<string, string>; body: string } {
   const lines = raw.split(/\r?\n/);
   if (lines[0] !== "---") return { data: {}, body: raw };
@@ -262,12 +275,17 @@ function skillIndexLine(s: Pick<Skill, "name" | "description" | "runAs">): strin
   return clipped ? `- ${s.name}${tag} — ${clipped}` : `- ${s.name}${tag}`;
 }
 
+const MISSING_DESCRIPTION_PLACEHOLDER =
+  '(no description — frontmatter is missing a "description:" line; tell the user to add one)';
+
 /** Bodies stay out — prefix must stay short + cacheable; bodies load on demand. */
 export function applySkillsIndex(basePrompt: string, opts: SkillStoreOptions = {}): string {
   const store = new SkillStore(opts);
-  const skills = store.list().filter((s) => s.description);
+  const skills = store.list();
   if (skills.length === 0) return basePrompt;
-  const lines = skills.map(skillIndexLine);
+  const lines = skills.map((s) =>
+    skillIndexLine(s.description ? s : { ...s, description: MISSING_DESCRIPTION_PLACEHOLDER }),
+  );
   const joined = lines.join("\n");
   const truncated =
     joined.length > SKILLS_INDEX_MAX_CHARS

--- a/tests/server-dashboard.test.ts
+++ b/tests/server-dashboard.test.ts
@@ -355,6 +355,48 @@ describe("dashboard server: endpoints", () => {
     }
   });
 
+  it("POST /api/skills rejects content missing a description frontmatter line (#583)", async () => {
+    const proj = mkdtempSync(join(tmpdir(), "reasonix-dash-skills-desc-"));
+    try {
+      const audited: Array<{ action: string }> = [];
+      const base = await boot({
+        getCurrentCwd: () => proj,
+        audit: (e) => audited.push({ action: e.action }),
+      });
+      const target = join(proj, ".reasonix", "skills", "silent-fail", "SKILL.md");
+
+      const noFrontmatter = await call(`${base}api/skills/project/silent-fail`, {
+        method: "POST",
+        token: TOKEN,
+        tokenInHeader: true,
+        body: { body: "# just a body, no frontmatter\n" },
+      });
+      expect(noFrontmatter.status).toBe(400);
+      expect(noFrontmatter.body.error).toMatch(/description/);
+
+      const blankDesc = await call(`${base}api/skills/project/silent-fail`, {
+        method: "POST",
+        token: TOKEN,
+        tokenInHeader: true,
+        body: { body: "---\nname: silent-fail\ndescription:   \n---\nbody\n" },
+      });
+      expect(blankDesc.status).toBe(400);
+      expect(existsSync(target)).toBe(false);
+
+      const ok = await call(`${base}api/skills/project/silent-fail`, {
+        method: "POST",
+        token: TOKEN,
+        tokenInHeader: true,
+        body: { body: "---\ndescription: does the thing\n---\nbody\n" },
+      });
+      expect(ok.status).toBe(200);
+      expect(existsSync(target)).toBe(true);
+      expect(audited.map((e) => e.action)).toEqual(["save-skill"]);
+    } finally {
+      rmSync(proj, { recursive: true, force: true });
+    }
+  });
+
   it("GET /api/permissions lists builtin always; project list when cwd is set", async () => {
     addProjectShellAllowed(PROJ, "npm run build", cfgPath);
     const base = await boot({ getCurrentCwd: () => PROJ, getEditMode: () => "review" });

--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -4,7 +4,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { SkillStore, applySkillsIndex } from "../src/skills.js";
+import { SkillStore, applySkillsIndex, validateSkillFrontmatter } from "../src/skills.js";
 
 const BASE = "You are a test assistant.";
 
@@ -240,12 +240,13 @@ describe("applySkillsIndex", () => {
     expect(out).toContain("- hello — global hello");
   });
 
-  it("omits skills with blank descriptions from the pinned index", () => {
+  it("surfaces skills with blank descriptions using a placeholder so the model can name + flag them (#583)", () => {
     writeSkillDir(projectRoot, "global", "has-desc", { description: "I have one" }, "body", home);
     writeSkillDir(projectRoot, "global", "no-desc", {}, "body", home);
     const out = applySkillsIndex(BASE, { homeDir: home, projectRoot, disableBuiltins: true });
-    expect(out).toContain("- has-desc —");
-    expect(out).not.toContain("- no-desc");
+    expect(out).toContain("- has-desc — I have one");
+    expect(out).toContain("- no-desc");
+    expect(out).toContain('"description:"');
   });
 
   it("is byte-stable across two calls with the same filesystem state", () => {
@@ -282,6 +283,28 @@ describe("applySkillsIndex", () => {
     // the model copied the marker verbatim and run_skill failed lookup.
     expect(out).not.toMatch(/- 🧬 lookup\b/);
     expect(out).not.toContain("- 🧬 fmt");
+  });
+});
+
+describe("validateSkillFrontmatter (#583 install gate)", () => {
+  it("accepts content with a non-empty description line", () => {
+    const result = validateSkillFrontmatter("---\ndescription: does a thing\n---\nbody\n");
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("rejects content with no frontmatter at all", () => {
+    const result = validateSkillFrontmatter("# just a body\n");
+    expect("error" in result && result.error).toMatch(/description/);
+  });
+
+  it("rejects frontmatter that omits description", () => {
+    const result = validateSkillFrontmatter("---\nname: foo\n---\nbody\n");
+    expect("error" in result && result.error).toMatch(/description/);
+  });
+
+  it("rejects frontmatter where description is whitespace-only", () => {
+    const result = validateSkillFrontmatter("---\ndescription:    \n---\nbody\n");
+    expect("error" in result && result.error).toMatch(/description/);
   });
 });
 


### PR DESCRIPTION
## What

Two-layer fix for the silent-skill-drop bug in #583:

1. **Hard-fail at install time.** `POST /api/skills/<scope>/<name>` parses the frontmatter via the new `validateSkillFrontmatter()` helper and returns 400 if `description:` is missing or whitespace-only — instead of writing a file the model will never list.
2. **Surface already-installed skills with bad frontmatter.** `applySkillsIndex` no longer filters out blank-description skills; it injects them with a placeholder line — `(no description — frontmatter is missing a "description:" line; tell the user to add one)` — so the model can name the skill in the index AND tell the user how to fix it.

## Why

Reported in #583. A skill missing `description:` worked in the install session (because `/skill <name>` calls `store.read` directly) and silently disappeared the next session (because the prefix was built via `applySkillsIndex` which dropped it). Install reported success, the file was on disk, the model said "not found, copy it again." Two layers of silent failure compounded.

The CLI scaffold tool already validates description (`src/tools/scaffold.ts:91-97`), so this PR mirrors that policy in the dashboard install path.

## How to verify

- `npm run verify` (2445 tests pass)
- New tests:
  - `validateSkillFrontmatter` accepts good frontmatter, rejects no-frontmatter / no-description / whitespace-only description.
  - `applySkillsIndex` now lists skills missing description with the placeholder text (replaces the prior "omits blank descriptions" assertion).
  - `POST /api/skills` integration test: 400 on missing/blank description, 200 + audit on valid content, file is not created on rejection.

## Checklist

- [x] `npm run verify` passes locally
- [x] No `Co-Authored-By: Claude` trailer
- [x] Comments follow CLAUDE.md
- [x] No CHANGELOG.md edits