### PR TITLE
fix(prompt): escalation contract names the actual session model

### DIFF
--- a/src/cli/commands/code.tsx
+++ b/src/cli/commands/code.tsx
@@ -209,6 +209,7 @@ export async function codeCommand(opts: CodeOptions = {}): Promise<void> {
       hasSemanticSearch: semantic.enabled,
       systemAppend: opts.systemAppend,
       systemAppendFile: systemAppendFileContents,
+      modelId: opts.model ?? "deepseek-v4-flash",
     }),
     transcript: opts.transcript,
     session,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4,13 +4,14 @@ import { t } from "../i18n/index.js";
 import { VERSION } from "../index.js";
 import { listSessions } from "../memory/session.js";
 import { applyMemoryStack } from "../memory/user.js";
-import { ESCALATION_CONTRACT } from "../prompt-fragments.js";
+import { escalationContract } from "../prompt-fragments.js";
 import { resolveContinueFlag, resolveDefaults } from "./resolve.js";
 import { markPhase } from "./startup-profile.js";
 
 markPhase("cli_module_loaded");
 
-const DEFAULT_SYSTEM = `You are Reasonix, a helpful DeepSeek-powered assistant. Be concise and accurate. Use tools when available.
+function defaultSystemPrompt(modelId: string): string {
+  return `You are Reasonix, a helpful DeepSeek-powered assistant. Be concise and accurate. Use tools when available.
 
 # Cite or shut up — non-negotiable
 
@@ -30,7 +31,8 @@ Your training data has a cutoff. When an answer's correctness depends on somethi
 
 The signal isn't a topic list — it's: "if I'm wrong about this, is it because reality moved on?". If yes, ground the answer in fresh evidence; if no (definitions, mechanisms, well-established APIs), answer from memory.
 
-${ESCALATION_CONTRACT}`;
+${escalationContract(modelId)}`;
+}
 
 /** Lenient: malformed → undefined (no cap) so a bad flag doesn't abort launch. */
 function parseBudgetFlag(raw: number | undefined): number | undefined {
@@ -73,7 +75,7 @@ program.action(async (opts: { continue?: boolean }) => {
   const { chatCommand } = await import("./commands/chat.js");
   await chatCommand({
     model: defaults.model,
-    system: applyMemoryStack(DEFAULT_SYSTEM, process.cwd()),
+    system: applyMemoryStack(defaultSystemPrompt(defaults.model), process.cwd()),
     session: continueOpts.session,
     mcp: defaults.mcp,
     forceResume: continueOpts.forceResume,
@@ -124,7 +126,7 @@ program
   .command("chat")
   .description(t("cli.chat"))
   .option("-m, --model <id>", t("ui.modelIdHint"))
-  .option("-s, --system <prompt>", t("ui.systemPromptHint"), DEFAULT_SYSTEM)
+  .option("-s, --system <prompt>", t("ui.systemPromptHint"))
   .option("--transcript <path>", t("ui.transcriptHint"))
   .option("--preset <name>", t("ui.presetHint"))
   .option("--budget <usd>", t("ui.budgetHint"), (v) => Number.parseFloat(v))
@@ -167,7 +169,7 @@ program
     const { chatCommand } = await import("./commands/chat.js");
     await chatCommand({
       model: defaults.model,
-      system: applyMemoryStack(opts.system, process.cwd()),
+      system: applyMemoryStack(opts.system ?? defaultSystemPrompt(defaults.model), process.cwd()),
       transcript: opts.transcript,
       budgetUsd: parseBudgetFlag(opts.budget),
       session: continueOpts.session,
@@ -185,7 +187,7 @@ program
   .command("run <task>")
   .description(t("cli.run"))
   .option("-m, --model <id>", t("ui.modelIdHint"))
-  .option("-s, --system <prompt>", t("ui.systemPromptHint"), DEFAULT_SYSTEM)
+  .option("-s, --system <prompt>", t("ui.systemPromptHint"))
   .option("--preset <name>", t("ui.presetHintShort"))
   .option("--budget <usd>", t("ui.budgetHintShort"), (v) => Number.parseFloat(v))
   .option("--transcript <path>", t("ui.transcriptHintShort"))
@@ -208,7 +210,7 @@ program
     await runCommand({
       task,
       model: defaults.model,
-      system: applyMemoryStack(opts.system, process.cwd()),
+      system: applyMemoryStack(opts.system ?? defaultSystemPrompt(defaults.model), process.cwd()),
       budgetUsd: parseBudgetFlag(opts.budget),
       transcript: opts.transcript,
       mcp: defaults.mcp,

--- a/src/code/prompt.ts
+++ b/src/code/prompt.ts
@@ -1,9 +1,16 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { applyMemoryStack } from "../memory/user.js";
-import { ESCALATION_CONTRACT, TUI_FORMATTING_RULES } from "../prompt-fragments.js";
+import { TUI_FORMATTING_RULES, escalationContract } from "../prompt-fragments.js";
 
-export const CODE_SYSTEM_PROMPT = `You are Reasonix Code, a coding assistant. You have filesystem tools (read_file, write_file, edit_file, multi_edit, list_directory, directory_tree, search_files, search_content, glob, get_file_info) rooted at the user's working directory, plus run_command / run_background for shell, plus \`todo_write\` for in-session multi-step tracking.
+const DEFAULT_CODE_MODEL = "deepseek-v4-flash";
+
+/** Built per-session against the resolved model id so the contract names the actual tier (#582). */
+export function codeSystemBase(modelId: string): string {
+  return CODE_SYSTEM_TEMPLATE.replace("__ESCALATION_CONTRACT__", escalationContract(modelId));
+}
+
+const CODE_SYSTEM_TEMPLATE = `You are Reasonix Code, a coding assistant. You have filesystem tools (read_file, write_file, edit_file, multi_edit, list_directory, directory_tree, search_files, search_content, glob, get_file_info) rooted at the user's working directory, plus run_command / run_background for shell, plus \`todo_write\` for in-session multi-step tracking.
 
 # Identity is fixed by this prompt — never inferred from the workspace
 
@@ -210,10 +217,13 @@ If you notice an obvious issue, MENTION it in one sentence and wait for the user
 - One short paragraph explaining *why*, then the blocks.
 - If you need to explore first (list / read / search), do it with tool calls before writing any prose — silence while exploring is fine.
 
-${ESCALATION_CONTRACT}
+__ESCALATION_CONTRACT__
 
 ${TUI_FORMATTING_RULES}
 `;
+
+/** Backward-compat — public-API const, frozen at the historical flash phrasing. Internal callers use codeSystemPrompt(rootDir, { modelId }) so the contract names the real tier (#582). */
+export const CODE_SYSTEM_PROMPT = codeSystemBase(DEFAULT_CODE_MODEL);
 
 /** Stack order (stable for cache prefix): base → REASONIX.md → global → project → .gitignore. */
 const SEMANTIC_SEARCH_ROUTING = `
@@ -238,12 +248,13 @@ export interface CodeSystemPromptOptions {
   /** UTF-8 file contents appended after the generated code system prompt.
    *  Preserves the default prompt — this is append-only, not a replacement. */
   systemAppendFile?: string;
+  /** Model the loop will run on — interpolated into the escalation contract so the model can name itself correctly when asked (#582). */
+  modelId?: string;
 }
 
 export function codeSystemPrompt(rootDir: string, opts: CodeSystemPromptOptions = {}): string {
-  const base = opts.hasSemanticSearch
-    ? `${CODE_SYSTEM_PROMPT}${SEMANTIC_SEARCH_ROUTING}`
-    : CODE_SYSTEM_PROMPT;
+  const codeBase = codeSystemBase(opts.modelId ?? DEFAULT_CODE_MODEL);
+  const base = opts.hasSemanticSearch ? `${codeBase}${SEMANTIC_SEARCH_ROUTING}` : codeBase;
   const withMemory = applyMemoryStack(base, rootDir);
   const gitignorePath = join(rootDir, ".gitignore");
   let result = withMemory;

--- a/src/prompt-fragments.ts
+++ b/src/prompt-fragments.ts
@@ -8,15 +8,24 @@ export const TUI_FORMATTING_RULES = `Formatting (rendered in a TUI with a real m
 - Do NOT draw decorative frames around content with \`┌──┐ │ └──┘\` characters. The renderer adds its own borders; extra ASCII art adds noise and shatters at narrow widths.
 - For flow charts and diagrams: a plain bullet list with \`→\` or \`↓\` between steps. Don't try to draw boxes-and-arrows in ASCII; it never survives word-wrap.`;
 
-export const ESCALATION_CONTRACT = `Cost-aware escalation (when you're running on deepseek-v4-flash):
+/** Pro is the top tier — escalation is a no-op for it; flash + others get the full ladder. */
+export function escalationContract(modelId: string): string {
+  if (modelId === "deepseek-v4-pro") {
+    return `Cost-aware escalation note: you are running on \`${modelId}\` — the escalation tier. There is no higher tier to escalate to, so the \`<<<NEEDS_PRO>>>\` marker is a no-op for you; deliver the strongest answer you can directly. If asked which model you are, answer \`${modelId}\`.`;
+  }
+  return `Cost-aware escalation (you are running on \`${modelId}\`):
 
-If a task CLEARLY exceeds what flash can do well — complex cross-file architecture refactors, subtle concurrency / security / correctness invariants you can't resolve with confidence, or a design trade-off you'd be guessing at — output the marker as the FIRST line of your response (nothing before it, not even whitespace on a separate line). This aborts the current call and retries this turn on deepseek-v4-pro, one shot.
+If a task CLEARLY exceeds what this tier can do well — complex cross-file architecture refactors, subtle concurrency / security / correctness invariants you can't resolve with confidence, or a design trade-off you'd be guessing at — output the marker as the FIRST line of your response (nothing before it, not even whitespace on a separate line). This aborts the current call and retries this turn on deepseek-v4-pro, one shot.
 
 Two accepted forms:
 - \`<<<NEEDS_PRO>>>\` — bare marker, no rationale.
 - \`<<<NEEDS_PRO: <one-sentence reason>>>>\` — preferred. The reason text appears in the user-visible warning ("⇧ flash requested escalation — <your reason>"), so they understand WHY a more expensive call is happening. Keep it under ~150 chars, no newlines, no nested \`>\` characters. Examples: \`<<<NEEDS_PRO: cross-file refactor across 6 modules with circular imports>>>\` or \`<<<NEEDS_PRO: subtle session-token race; flash would likely miss the locking invariant>>>\`.
 
-Do NOT emit any other content in the same response when you request escalation. Use this sparingly: normal tasks — reading files, small edits, clear bug fixes, straightforward feature additions — stay on flash. Request escalation ONLY when you would otherwise produce a guess or a visibly-mediocre answer. If in doubt, attempt the task on flash first; the system also escalates automatically if you hit 3+ repair / SEARCH-mismatch errors in a single turn (the user sees a typed breakdown).`;
+Do NOT emit any other content in the same response when you request escalation. Use this sparingly: normal tasks — reading files, small edits, clear bug fixes, straightforward feature additions — stay on this tier. Request escalation ONLY when you would otherwise produce a guess or a visibly-mediocre answer. If in doubt, attempt the task here first; the system also escalates automatically if you hit 3+ repair / SEARCH-mismatch errors in a single turn (the user sees a typed breakdown). If asked which model you are, answer \`${modelId}\`.`;
+}
+
+/** Backward-compat — pre-#582 callers (and the `CODE_SYSTEM_PROMPT` public-API const) keep the historical flash phrasing. */
+export const ESCALATION_CONTRACT = escalationContract("deepseek-v4-flash");
 
 export const NEGATIVE_CLAIM_RULE = `Negative claims ("X is missing", "Y isn't implemented", "there's no Z") are the #1 hallucination shape. They feel safe to write because no citation seems possible — but that's exactly why you must NOT write them on instinct.
 

--- a/src/tools/subagent.ts
+++ b/src/tools/subagent.ts
@@ -5,9 +5,9 @@ import { CacheFirstLoop } from "../loop.js";
 import { applyProjectMemory } from "../memory/project.js";
 import { ImmutablePrefix } from "../memory/runtime.js";
 import {
-  ESCALATION_CONTRACT,
   NEGATIVE_CLAIM_RULE,
   TUI_FORMATTING_RULES,
+  escalationContract,
 } from "../prompt-fragments.js";
 import { ToolRegistry } from "../tools.js";
 import { SUBAGENT_TYPE_NAMES, getSubagentType } from "./subagent-types.js";
@@ -83,7 +83,8 @@ export interface SubagentToolOptions {
   sink?: SubagentSink;
 }
 
-const DEFAULT_SUBAGENT_SYSTEM = `You are a Reasonix subagent. The parent agent spawned you to handle one focused subtask, then return.
+/** Memory-stable prefix — shared across spawns, cached. The model-dependent escalation contract is appended per spawn so a pro spawn doesn't get told it's running on flash (#582). */
+const SUBAGENT_BASE_SYSTEM = `You are a Reasonix subagent. The parent agent spawned you to handle one focused subtask, then return.
 
 Rules:
 - Stay on the task you were given. Do not expand scope.
@@ -93,9 +94,11 @@ Rules:
 
 ${NEGATIVE_CLAIM_RULE}
 
-${ESCALATION_CONTRACT}
-
 ${TUI_FORMATTING_RULES}`;
+
+function defaultSubagentSystem(modelId: string): string {
+  return `${SUBAGENT_BASE_SYSTEM}\n\n${escalationContract(modelId)}`;
+}
 
 const DEFAULT_MAX_RESULT_CHARS = 8000;
 const DEFAULT_MAX_ITERS = 16;
@@ -380,14 +383,15 @@ export function registerSubagentTool(
   parentRegistry: ToolRegistry,
   opts: SubagentToolOptions,
 ): ToolRegistry {
-  const baseSystem = opts.defaultSystem ?? DEFAULT_SUBAGENT_SYSTEM;
+  const baseSystem = opts.defaultSystem ?? SUBAGENT_BASE_SYSTEM;
   // Bake project memory into the default once — re-reading on every
   // spawn would (a) make the child prefix unstable when REASONIX.md
   // changes mid-session, defeating cache reuse across multiple
   // subagent calls, and (b) cost a stat() per call. The parent itself
   // also reads memory once at startup; matching that semantics keeps
-  // subagent and parent on the same page.
-  const defaultSystem = opts.projectRoot
+  // subagent and parent on the same page. The escalation contract is
+  // appended per-spawn against the spawn's resolved model id (#582).
+  const defaultSystemBase = opts.projectRoot
     ? applyProjectMemory(baseSystem, opts.projectRoot)
     : baseSystem;
   const defaultModel = opts.defaultModel ?? DEFAULT_SUBAGENT_MODEL;
@@ -451,14 +455,14 @@ export function registerSubagentTool(
         });
       }
       const typeSpec = getSubagentType(args.type);
-      const system =
-        typeof args.system === "string" && args.system.trim().length > 0
-          ? args.system.trim()
-          : (typeSpec?.system ?? defaultSystem);
       const model =
         typeof args.model === "string" && args.model.startsWith("deepseek-")
           ? args.model
           : defaultModel;
+      const system =
+        typeof args.system === "string" && args.system.trim().length > 0
+          ? args.system.trim()
+          : (typeSpec?.system ?? `${defaultSystemBase}\n\n${escalationContract(model)}`);
       const callerIters = clampMaxIters(args.max_iters);
       const result = await spawnSubagent({
         client: opts.client,

--- a/tests/code-prompt.test.ts
+++ b/tests/code-prompt.test.ts
@@ -89,6 +89,22 @@ describe("codeSystemPrompt", () => {
     });
   });
 
+  describe("modelId interpolation (#582)", () => {
+    it("defaults to flash when modelId is omitted (back-compat)", () => {
+      const out = codeSystemPrompt(root);
+      expect(out).toContain("`deepseek-v4-flash`");
+      expect(out).toContain("If asked which model you are, answer `deepseek-v4-flash`");
+    });
+
+    it("interpolates the supplied modelId into the escalation contract", () => {
+      const out = codeSystemPrompt(root, { modelId: "deepseek-v4-pro" });
+      expect(out).toContain("`deepseek-v4-pro`");
+      expect(out).toContain("escalation tier");
+      expect(out).toContain("If asked which model you are, answer `deepseek-v4-pro`");
+      expect(out).not.toMatch(/running on `?deepseek-v4-flash`?/);
+    });
+  });
+
   describe("system append", () => {
     it("does not add a User System Append section when neither option is provided", () => {
       const out = codeSystemPrompt(root);

--- a/tests/prompt-fragments.test.ts
+++ b/tests/prompt-fragments.test.ts
@@ -1,0 +1,36 @@
+/** escalationContract — model-aware contract so the system prompt names the actual tier (#582). */
+
+import { describe, expect, it } from "vitest";
+import { ESCALATION_CONTRACT, escalationContract } from "../src/prompt-fragments.js";
+
+describe("escalationContract (#582)", () => {
+  it("interpolates the actual model id for non-pro tiers", () => {
+    const out = escalationContract("deepseek-v4-flash");
+    expect(out).toContain("`deepseek-v4-flash`");
+    expect(out).toContain("If asked which model you are, answer `deepseek-v4-flash`");
+    expect(out).toContain("<<<NEEDS_PRO");
+  });
+
+  it("returns the no-escalation note for the pro tier instead of the full ladder", () => {
+    const out = escalationContract("deepseek-v4-pro");
+    expect(out).toContain("`deepseek-v4-pro`");
+    expect(out).toContain("escalation tier");
+    expect(out).toContain("If asked which model you are, answer `deepseek-v4-pro`");
+    expect(out).not.toContain("<<<NEEDS_PRO: <one-sentence reason>>>>");
+  });
+
+  it("never tells a pro session it is running on flash (regression for #582)", () => {
+    const out = escalationContract("deepseek-v4-pro");
+    expect(out).not.toMatch(/running on `?deepseek-v4-flash`?/);
+  });
+
+  it("backward-compat const matches the historical flash phrasing", () => {
+    expect(ESCALATION_CONTRACT).toBe(escalationContract("deepseek-v4-flash"));
+  });
+
+  it("treats unknown future tiers as non-pro (full contract, name themselves)", () => {
+    const out = escalationContract("deepseek-v5-experimental");
+    expect(out).toContain("`deepseek-v5-experimental`");
+    expect(out).toContain("<<<NEEDS_PRO");
+  });
+});


### PR DESCRIPTION
## What

Make the escalation-contract block in every system prompt name the model actually running this session, so a pro session no longer self-reports as flash.

## Why

Reported in #582. `ESCALATION_CONTRACT` was a module-level const with `deepseek-v4-flash` baked into the literal — interpolated into `DEFAULT_SYSTEM`, `CODE_SYSTEM_PROMPT`, and `DEFAULT_SUBAGENT_SYSTEM` at module load. `/model pro` only swaps the API request's `model` field, never the system prompt. So pro received "you are running on deepseek-v4-flash" and answered honestly when asked. Same for sessions launched on the `pro` preset from the start.

## How

- `escalationContract(modelId)` in `src/prompt-fragments.ts` — pro tier gets a short "you are the escalation tier; <<<NEEDS_PRO>>> is a no-op" note (no ladder, since pro can't escalate to itself). All other tiers get the full contract with the actual model id interpolated, plus an explicit "if asked which model you are, answer `<id>`" sentence.
- `DEFAULT_SYSTEM` (cli/index.ts) → `defaultSystemPrompt(modelId)`. The `--system` commander default is removed; the action handler builds with `defaults.model` when no override is passed.
- `CODE_SYSTEM_PROMPT` stays as a backward-compat const (still in the public API surface, frozen at the historical flash phrasing). New `codeSystemBase(modelId)` plus a `modelId?: string` field on `CodeSystemPromptOptions` — `src/cli/commands/code.tsx` threads `opts.model` in.
- `DEFAULT_SUBAGENT_SYSTEM` split into `SUBAGENT_BASE_SYSTEM` (memory-stable, cached across spawns) plus a per-spawn append of `escalationContract(model)` against the spawn's resolved model id.

Mid-session `/model pro` swaps still won't update the prefix (cache-first invariant by design — the prefix is frozen for the session). Issue scope was launch-time correctness, which this delivers.

## How to verify

- `npm run verify` (2452 tests pass).
- `tests/prompt-fragments.test.ts` covers the contract per tier (pro returns the no-escalation note; flash returns the full contract; backward-compat const matches `escalationContract("deepseek-v4-flash")`).
- `tests/code-prompt.test.ts` adds two cases: default (flash) phrasing and pro phrasing through `codeSystemPrompt(root, { modelId: "deepseek-v4-pro" })`.

## Checklist

- [x] `npm run verify` passes locally
- [x] No `Co-Authored-By: Claude` trailer
- [x] Public API surface (`CODE_SYSTEM_PROMPT`) preserved
- [x] No CHANGELOG.md edits