### PR TITLE
fix(ui): hide WelcomeBanner when slash menu is open

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -3339,7 +3339,7 @@ function AppInner({
           modal up). Removes the "what do I type?" friction without
           surviving past the first turn.
         */}
-                  {!hasConversation && !busy && !isStreaming ? (
+                  {!hasConversation && !busy && !isStreaming && slashMatches === null ? (
                     <WelcomeBanner
                       inCodeMode={!!codeMode}
                       workspaceRoot={codeMode ? currentRootDir : undefined}


### PR DESCRIPTION
## Summary

Pressing `/` from the empty home screen left the bordered welcome card mounted while the slash-suggestions panel rendered below. Both occupied the same flex column, so the frame buffer interleaved them — the welcome card border (`│ REASONIX × 🐋 DeepSeek │`) drew through the slash menu rows, producing a visibly garbled overlay.

The empty-state guard at `App.tsx:3342` checked `!hasConversation && !busy && !isStreaming` but never accounted for the slash menu. Adding `&& slashMatches === null` makes the welcome card yield to the menu the moment one is opened.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — only pre-existing biome-ignore warnings on other files
- [x] `npm run verify` — 2452 tests pass
- [ ] Manual: launch fresh `reasonix code`, press `/` on the empty screen, confirm the welcome card disappears and only the slash menu shows. Press Esc, confirm the welcome card returns.
