### PR TITLE
docs(changelog): add WelcomeBanner overlay fix to 0.37.0 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,14 @@ as flash when asked.
   the resolved session model through. The public `CODE_SYSTEM_PROMPT`
   const is preserved for backward compat. (#582, #592)
 
+- fix(ui): pressing `/` on the empty home screen left the bordered
+  WelcomeBanner mounted while `SlashSuggestions` rendered below — both
+  occupied the same flex column so the frame buffer interleaved them
+  and the welcome card border drew through the menu rows. The empty-
+  state guard now also requires `slashMatches === null`, so the
+  welcome card yields the moment the menu opens and returns when it
+  closes. (#594)
+
 - fix(ui): wheel-up felt laggy because `schedule()` was trailing-edge —
   every tick paid a 16 ms timer before any visual feedback, and on
   top of Ink reconcile + Yoga layout a single tick cost 30-50 ms


### PR DESCRIPTION
## Summary

Adds a CHANGELOG bullet for the WelcomeBanner / SlashSuggestions overlay fix (#594) under the existing 0.37.0 entry.

## Why

#594 landed after the `chore(release): 0.37.0` commit (#593), but the version is still unpublished — package.json says 0.37.0, no v0.37.0 tag exists, npm latest is still 0.36.2. Same precedent as #539 → 0.36.0: roll the late fix into the as-yet-unreleased entry rather than cutting a 0.37.1 immediately after.

After this merges, tag v0.37.0 lands here and `npm publish` ships the bundle including the WelcomeBanner fix.

## Test plan

- [x] CHANGELOG-only change, no code edits
- [x] verify pre-push hook: build + lint + typecheck + test all pass
