### PR TITLE
Implement shared group order and labels for slash commands

### DIFF
--- a/src/cli/ui/SlashSuggestions.tsx
+++ b/src/cli/ui/SlashSuggestions.tsx
@@ -2,6 +2,7 @@ import { Box, Text, useStdout } from "ink";
 import React from "react";
 import { t } from "../../i18n/index.js";
 import type { SlashCommandSpec, SlashGroup } from "./slash.js";
+import { SLASH_GROUP_LABEL } from "./slash/commands.js";
 import { GLYPH, useColor } from "./theme.js";
 
 const GROUP_MODE_MAX_ROWS = 24;
@@ -17,17 +18,6 @@ export interface SlashSuggestionsProps {
   /** Count of hidden `advanced` commands; rendered as a footer hint when groupMode is true. */
   advancedHidden?: number;
 }
-
-const GROUP_LABEL: Record<SlashGroup, string> = {
-  chat: "CHAT",
-  setup: "SETUP",
-  info: "INFO",
-  session: "SESSION",
-  extend: "EXTEND",
-  code: "CODE",
-  jobs: "JOBS",
-  advanced: "ADVANCED",
-};
 
 export function SlashSuggestions({
   matches,
@@ -163,7 +153,7 @@ function GroupHeader({ group }: { group: SlashGroup }): React.ReactElement {
   return (
     <Box flexShrink={0} height={1} flexWrap="nowrap">
       <Text dimColor wrap="truncate">
-        {`  ${GROUP_LABEL[group]}`}
+        {`  ${SLASH_GROUP_LABEL[group]}`}
       </Text>
     </Box>
   );

--- a/src/cli/ui/slash.ts
+++ b/src/cli/ui/slash.ts
@@ -5,8 +5,11 @@
 // modules under ./slash/.
 export {
   SLASH_COMMANDS,
+  SLASH_GROUP_LABEL,
+  SLASH_GROUP_ORDER,
   countAdvancedCommands,
   detectSlashArgContext,
+  orderSlashCommandsByGroup,
   parseSlash,
   suggestSlashCommands,
 } from "./slash/commands.js";

--- a/src/cli/ui/slash/commands.ts
+++ b/src/cli/ui/slash/commands.ts
@@ -1,4 +1,44 @@
-import type { SlashArgContext, SlashCommandSpec } from "./types.js";
+import type { SlashArgContext, SlashCommandSpec, SlashGroup } from "./types.js";
+
+export const SLASH_GROUP_ORDER = [
+  "setup",
+  "info",
+  "chat",
+  "extend",
+  "session",
+  "code",
+  "jobs",
+  "advanced",
+] as const satisfies readonly SlashGroup[];
+
+export const SLASH_GROUP_LABEL: Record<SlashGroup, string> = {
+  setup: "SETUP",
+  info: "INFO",
+  chat: "CHAT",
+  extend: "EXTEND",
+  session: "SESSION",
+  code: "CODE",
+  jobs: "JOBS",
+  advanced: "ADVANCED",
+};
+
+const SLASH_GROUP_RANK = new Map<SlashGroup, number>(
+  SLASH_GROUP_ORDER.map((group, index) => [group, index]),
+);
+
+export function orderSlashCommandsByGroup<T extends Pick<SlashCommandSpec, "group">>(
+  commands: readonly T[],
+): T[] {
+  return commands
+    .map((command, index) => ({ command, index }))
+    .sort((a, b) => {
+      const groupDiff =
+        SLASH_GROUP_RANK.get(a.command.group)! - SLASH_GROUP_RANK.get(b.command.group)!;
+      if (groupDiff !== 0) return groupDiff;
+      return a.index - b.index;
+    })
+    .map((entry) => entry.command);
+}
 
 export const SLASH_COMMANDS: readonly SlashCommandSpec[] = [
   { cmd: "help", group: "chat", summary: "show the full command reference", aliases: ["?"] },
@@ -329,6 +369,7 @@ export function suggestSlashCommands(
     if (c.cmd.startsWith(p)) return true;
     return c.aliases?.some((a) => a.startsWith(p)) ?? false;
   });
+  if (p === "") return orderSlashCommandsByGroup(matches);
   if (!counts) return matches;
   const indexOf = new Map(matches.map((s, i) => [s.cmd, i]));
   return [...matches].sort((a, b) => {

--- a/src/cli/ui/slash/handlers/basic.ts
+++ b/src/cli/ui/slash/handlers/basic.ts
@@ -1,6 +1,11 @@
 import { t, tObj } from "@/i18n/index.js";
 import { formatDuration, formatLoopStatus, parseLoopCommand } from "../../loop.js";
-import { SLASH_COMMANDS } from "../commands.js";
+import {
+  SLASH_COMMANDS,
+  SLASH_GROUP_LABEL,
+  SLASH_GROUP_ORDER,
+  orderSlashCommandsByGroup,
+} from "../commands.js";
 import type { SlashHandler } from "../dispatch.js";
 import type { SlashCommandSpec, SlashGroup } from "../types.js";
 
@@ -14,27 +19,20 @@ const resetLog: SlashHandler = (_args, loop) => {
   return { clear: true, info };
 };
 
-const GROUP_ORDER: ReadonlyArray<SlashGroup> = [
-  "chat",
-  "setup",
-  "info",
-  "session",
-  "extend",
-  "code",
-  "jobs",
-  "advanced",
-];
-
-const GROUP_HEADER: Record<SlashGroup, string> = {
-  chat: "CHAT  ·  daily turn ops",
-  setup: "SETUP  ·  model + cost",
-  info: "INFO  ·  current state",
-  session: "SESSION  ·  saved sessions",
-  extend: "EXTEND  ·  MCP, memory, skills",
-  code: "CODE  ·  edits + plans (code mode)",
-  jobs: "JOBS  ·  background processes (code mode)",
-  advanced: "ADVANCED  ·  rare or set-and-forget",
+const GROUP_DETAIL: Record<SlashGroup, string> = {
+  setup: "model + cost",
+  info: "current state",
+  chat: "daily turn ops",
+  extend: "MCP, memory, skills",
+  session: "saved sessions",
+  code: "edits + plans (code mode)",
+  jobs: "background processes (code mode)",
+  advanced: "rare or set-and-forget",
 };
+
+function groupHeader(group: SlashGroup): string {
+  return `${SLASH_GROUP_LABEL[group]}  ·  ${GROUP_DETAIL[group]}`;
+}
 
 function renderRow(spec: SlashCommandSpec): string {
   const name = `/${spec.cmd}${spec.argsHint ? ` ${spec.argsHint}` : ""}`;
@@ -45,10 +43,15 @@ function renderRow(spec: SlashCommandSpec): string {
 
 const help: SlashHandler = () => {
   const lines: string[] = [t("handlers.basic.helpTitle"), ""];
-  for (const group of GROUP_ORDER) {
-    const rows = SLASH_COMMANDS.filter((c) => c.group === group);
+  const rowsByGroup = new Map<SlashGroup, SlashCommandSpec[]>();
+  for (const group of SLASH_GROUP_ORDER) rowsByGroup.set(group, []);
+  for (const command of orderSlashCommandsByGroup(SLASH_COMMANDS)) {
+    rowsByGroup.get(command.group)!.push(command);
+  }
+  for (const group of SLASH_GROUP_ORDER) {
+    const rows = rowsByGroup.get(group) ?? [];
     if (rows.length === 0) continue;
-    lines.push(`  ${GROUP_HEADER[group]}`);
+    lines.push(`  ${groupHeader(group)}`);
     for (const r of rows) lines.push(renderRow(r));
     lines.push("");
   }

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -221,6 +221,10 @@ export const EN: TranslationSchema = {
     },
     model: { description: "switch DeepSeek model id", argsHint: "<id>" },
     models: { description: "list available models fetched from DeepSeek /models" },
+    theme: {
+      description: "show or persist the terminal theme preference. Bare opens picker.",
+      argsHint: "[auto|default|dark|light|tokyo-night|github-dark|github-light|high-contrast]",
+    },
     language: {
       description: "switch the runtime language",
       argsHint: "<EN|zh-CN>",

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -216,6 +216,10 @@ export const zhCN: TranslationSchema = {
     },
     model: { description: "切换 DeepSeek 模型 ID", argsHint: "<id>" },
     models: { description: "列出从 DeepSeek /models 获取的可用模型" },
+    theme: {
+      description: "显示或持久化终端主题偏好。无参数时打开选择器。",
+      argsHint: "[auto|default|dark|light|tokyo-night|github-dark|github-light|high-contrast]",
+    },
     language: {
       description: "切换运行时语言",
       argsHint: "<en|zh-CN>",

--- a/tests/slash.test.ts
+++ b/tests/slash.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   SLASH_COMMANDS,
+  SLASH_GROUP_ORDER,
   detectSlashArgContext,
   handleSlash,
   parseSlash,
@@ -61,6 +62,17 @@ describe("handleSlash", () => {
     expect(suggestSlashCommands("res").map((s) => s.cmd)).toContain("new");
   });
 
+  it("bare-slash browsing follows the shared group order", () => {
+    const matches = suggestSlashCommands("");
+    const seenGroups = [...new Set(matches.map((spec) => spec.group))];
+    expect(seenGroups).toEqual(SLASH_GROUP_ORDER.filter((group) => group !== "advanced"));
+
+    const setupCommands = matches.filter((spec) => spec.group === "setup").map((spec) => spec.cmd);
+    expect(setupCommands).toEqual(
+      SLASH_COMMANDS.filter((spec) => spec.group === "setup").map((spec) => spec.cmd),
+    );
+  });
+
   it("detectSlashArgContext resolves an alias to its canonical spec", () => {
     const ctx = detectSlashArgContext("/lang zh");
     expect(ctx).not.toBeNull();
@@ -94,6 +106,15 @@ describe("handleSlash", () => {
     expect(r.info).toMatch(/\/status/);
     expect(r.info).toMatch(/\/preset/);
     expect(r.info).toMatch(/\/compact/);
+  });
+
+  it("/help groups commands in the shared order", () => {
+    const info = handleSlash("help", [], makeLoop()).info ?? "";
+    const groupHeaders = [
+      ...info.matchAll(/^ {2}(SETUP|INFO|CHAT|EXTEND|SESSION|CODE|JOBS|ADVANCED)\b/gm),
+    ].map((match) => match[1]);
+    expect(groupHeaders).toEqual(SLASH_GROUP_ORDER.map((group) => group.toUpperCase()));
+    expect(info.indexOf("  SETUP")).toBeLessThan(info.indexOf("  CHAT"));
   });
 
   it("/status reflects current loop config", () => {

--- a/tests/ui-slash-suggestions.test.tsx
+++ b/tests/ui-slash-suggestions.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import { SlashSuggestions } from "../src/cli/ui/SlashSuggestions.js";
 import {
   SLASH_COMMANDS,
+  SLASH_GROUP_ORDER,
   type SlashCommandSpec,
   countAdvancedCommands,
   suggestSlashCommands,
@@ -63,7 +64,26 @@ function hiddenAboveCount(frame: string): number {
   return match ? Number(match[1]) : 0;
 }
 
+function visibleGroupOrder(frame: string): string[] {
+  return frame
+    .split(/\r?\n/)
+    .map(
+      (line) => /^\s*(CHAT|SETUP|INFO|SESSION|EXTEND|CODE|JOBS|ADVANCED)\b/.exec(line)?.[1] ?? "",
+    )
+    .filter(Boolean);
+}
+
 describe("SlashSuggestions", () => {
+  it("renders visible bare-slash groups in the shared order", () => {
+    const frame = renderSuggestions(0);
+    const visibleGroups = visibleGroupOrder(frame);
+    expect(visibleGroups).toEqual(
+      SLASH_GROUP_ORDER.filter((group) => group !== "advanced")
+        .map((group) => group.toUpperCase())
+        .slice(0, visibleGroups.length),
+    );
+  });
+
   it("renders the bare slash release command surface as 38 total commands", () => {
     const matches = suggestSlashCommands("", true);
     const names = matches.map((spec) => spec.cmd);


### PR DESCRIPTION
<!-- Read CONTRIBUTING.md first if this is your first PR. -->

## What

This rebases the stale slash-grouping work onto current main and trims it to the maintainer-requested scope by centralizing slash command group order/labels, reusing that metadata for bare-slash browsing, /help, and slash suggestion headers, and adding missing i18n entries for /theme so its description and args hint are translated instead of falling back to English.

<!-- One paragraph: what does this change? -->

## Why

PR #524 had gone stale after #516 merged the overlapping slash suggestion UI/windowing work, and the maintainer asked for a smaller follow-up that keeps only the shared grouping/order plumbing. While rebuilding that reduced diff, /theme still lacked slash.theme.* translations, so localized slash output could show mixed-language fallback text.

<!-- Bug fix? Pre-existing issue? Linked discussion? -->

## How to verify

Run:

npx vitest run tests/slash.test.ts tests/slash-usage.test.ts tests/ui-slash-suggestions.test.tsx
npm run typecheck
npx biome check src/cli/ui/slash/commands.ts src/cli/ui/SlashSuggestions.tsx src/cli/ui/slash/handlers/basic.ts src/cli/ui/slash.ts tests/slash.test.ts tests/ui-slash-suggestions.test.tsx src/i18n/EN.ts src/i18n/zh-CN.ts

Expected results:

Bare / browsing groups commands in the shared order (SETUP → INFO → CHAT → EXTEND → SESSION → CODE → JOBS), /help uses the same grouping metadata, slash suggestion headers still render correctly, and /theme shows translated description/args-hint text instead of falling back to English in localized runtime output.

<!-- Steps the reviewer can run. `npm run verify` is assumed. -->

## Checklist

- [✅ ] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [✅ ] No `Co-Authored-By: Claude` trailer in commits
- [✅ ] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [✅ ] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time
