### PR TITLE
fix(tui): avoid retokenizing streaming replies per chunk

### DIFF
--- a/src/cli/ui/ModelPicker.tsx
+++ b/src/cli/ui/ModelPicker.tsx
@@ -1,5 +1,4 @@
 import { Box, Text, useStdout } from "ink";
-// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React, { useState } from "react";
 import { useKeystroke } from "./keystroke-context.js";
 import { PRESETS, PRESET_DESCRIPTIONS } from "./presets.js";

--- a/src/cli/ui/PromptInput.tsx
+++ b/src/cli/ui/PromptInput.tsx
@@ -1,5 +1,4 @@
 import { Box, Text, useStdout } from "ink";
-// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React as a runtime value (classic transform compiles JSX to React.createElement)
 import React, { useRef, useState } from "react";
 import { t } from "../../i18n/index.js";
 import { useKeystroke } from "./keystroke-context.js";

--- a/src/cli/ui/cards/StreamingCard.tsx
+++ b/src/cli/ui/cards/StreamingCard.tsx
@@ -1,5 +1,4 @@
 import { Box, Text, useStdout } from "ink";
-// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React, { useContext } from "react";
 import { clipToCells, wrapToCells } from "../../../frame/width.js";
 import { t } from "../../../i18n/index.js";
@@ -22,6 +21,19 @@ const EXPANDED_MAX_LINES = 60;
 
 const MIN_ELAPSED_MS_FOR_RATE = 500;
 const MIN_TOKENS_FOR_RATE = 4;
+const LIVE_TOKEN_CALIBRATION_CHARS = 500;
+const ESTIMATED_CHARS_PER_TOKEN = 4;
+
+export interface LiveTokenCalibration {
+  cardId: string;
+  chars: number;
+  tokens: number;
+}
+
+interface TokenRate {
+  tokens: number;
+  tps: number | null;
+}
 
 function formatTokenCount(n: number): string {
   if (n >= 10000) return `${(n / 1000).toFixed(1)}k`;
@@ -29,17 +41,55 @@ function formatTokenCount(n: number): string {
   return String(n);
 }
 
-function tokenRate(
-  text: string,
-  startTs: number,
-  endTs: number,
-): { tokens: number; tps: number | null } {
-  const tokens = countTokens(text);
+function rateFromTokens(tokens: number, startTs: number, endTs: number): TokenRate {
   const elapsedMs = endTs - startTs;
   if (elapsedMs < MIN_ELAPSED_MS_FOR_RATE || tokens < MIN_TOKENS_FOR_RATE) {
     return { tokens, tps: null };
   }
   return { tokens, tps: Math.round((tokens * 1000) / elapsedMs) };
+}
+
+function tokenRate(text: string, startTs: number, endTs: number): TokenRate {
+  return rateFromTokens(countTokens(text), startTs, endTs);
+}
+
+export function estimateLiveTokenCount(
+  text: string,
+  cardId: string,
+  calibration: LiveTokenCalibration | null,
+  countFn: (value: string) => number = countTokens,
+): { tokens: number; calibration: LiveTokenCalibration; exact: boolean } {
+  const chars = text.length;
+  const shouldCalibrate =
+    chars > 0 &&
+    (!calibration ||
+      calibration.cardId !== cardId ||
+      chars < calibration.chars ||
+      (calibration.chars === 0 && chars > 0) ||
+      chars - calibration.chars >= LIVE_TOKEN_CALIBRATION_CHARS);
+
+  if (shouldCalibrate) {
+    const tokens = countFn(text);
+    return { tokens, calibration: { cardId, chars, tokens }, exact: true };
+  }
+
+  const base = calibration?.cardId === cardId && chars >= calibration.chars ? calibration : null;
+  const baseChars = base?.chars ?? 0;
+  const baseTokens = base?.tokens ?? 0;
+  const estimatedDelta = Math.ceil(Math.max(0, chars - baseChars) / ESTIMATED_CHARS_PER_TOKEN);
+  return {
+    tokens: baseTokens + estimatedDelta,
+    calibration: base ?? { cardId, chars: 0, tokens: 0 },
+    exact: false,
+  };
+}
+
+function useLiveTokenRate(card: StreamingCardData, enabled: boolean): TokenRate {
+  const calibrationRef = React.useRef<LiveTokenCalibration | null>(null);
+  if (!enabled) return { tokens: 0, tps: null };
+  const estimate = estimateLiveTokenCount(card.text, card.id, calibrationRef.current);
+  calibrationRef.current = estimate.calibration;
+  return rateFromTokens(estimate.tokens, card.ts, Date.now());
 }
 
 const PILL_RATE = { bg: "#11141a", fg: "#8b949e" } as const;
@@ -56,6 +106,7 @@ export function StreamingCard({ card }: { card: StreamingCardData }): React.Reac
   // Re-render at 1Hz so the rate keeps updating even when chunks stall.
   // Frozen once `card.done` is true — settled cards render via Static.
   useSlowTick();
+  const liveRate = useLiveTokenRate(card, !card.done && !card.aborted);
 
   const modelBadge = card.model ? modelBadgeFor(card.model) : null;
   const modelPill = modelBadge ? (
@@ -97,10 +148,9 @@ export function StreamingCard({ card }: { card: StreamingCardData }): React.Reac
   const glyph = aborted ? "‹" : "◈";
   const headLabel = aborted ? t("cardLabels.aborted") : t("cardLabels.writing");
 
-  const { tokens: liveTokens, tps: liveTps } = tokenRate(card.text, card.ts, Date.now());
   const liveRatePill =
-    !aborted && liveTokens >= MIN_TOKENS_FOR_RATE && liveTps !== null ? (
-      <Pill label={`${liveTps} t/s`} {...PILL_RATE} bold={false} />
+    !aborted && liveRate.tokens >= MIN_TOKENS_FOR_RATE && liveRate.tps !== null ? (
+      <Pill label={`${liveRate.tps} t/s`} {...PILL_RATE} bold={false} />
     ) : null;
   const expandPill = !aborted ? (
     <Pill label={expanded ? "expanded ⌃o" : "preview ⌃o"} {...PILL_RATE} bold={false} />

--- a/src/cli/ui/layout/CardStream.tsx
+++ b/src/cli/ui/layout/CardStream.tsx
@@ -1,5 +1,4 @@
 import { Box, type DOMElement, Text, useBoxMetrics } from "ink";
-// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React, { useEffect, useMemo, useRef } from "react";
 import { CardRenderer } from "../cards/CardRenderer.js";
 import type { Card } from "../state/cards.js";

--- a/src/cli/ui/state/chat-scroll-provider.tsx
+++ b/src/cli/ui/state/chat-scroll-provider.tsx
@@ -1,4 +1,3 @@
-// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React from "react";
 import {
   type ChatScrollState,

--- a/tests/streaming-card-token-rate.test.ts
+++ b/tests/streaming-card-token-rate.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+  type LiveTokenCalibration,
+  estimateLiveTokenCount,
+} from "../src/cli/ui/cards/StreamingCard.js";
+
+function counter() {
+  const calls: string[] = [];
+  return {
+    calls,
+    count: (value: string) => {
+      calls.push(value);
+      return value.length * 2;
+    },
+  };
+}
+
+describe("estimateLiveTokenCount", () => {
+  it("calibrates exactly for the first non-empty streaming text", () => {
+    const tokenizer = counter();
+    const result = estimateLiveTokenCount("hello", "card-1", null, tokenizer.count);
+
+    expect(result.exact).toBe(true);
+    expect(result.tokens).toBe(10);
+    expect(result.calibration).toEqual({ cardId: "card-1", chars: 5, tokens: 10 });
+    expect(tokenizer.calls).toEqual(["hello"]);
+  });
+
+  it("estimates small live growth without re-tokenizing the whole text", () => {
+    const tokenizer = counter();
+    const first = estimateLiveTokenCount("hello", "card-1", null, tokenizer.count);
+    const grown = estimateLiveTokenCount(
+      `hello${"x".repeat(120)}`,
+      "card-1",
+      first.calibration,
+      tokenizer.count,
+    );
+
+    expect(grown.exact).toBe(false);
+    expect(grown.tokens).toBe(40);
+    expect(grown.calibration).toBe(first.calibration);
+    expect(tokenizer.calls).toHaveLength(1);
+  });
+
+  it("re-calibrates once text grows by the live threshold", () => {
+    const tokenizer = counter();
+    const first = estimateLiveTokenCount("hello", "card-1", null, tokenizer.count);
+    const grown = estimateLiveTokenCount(
+      `hello${"x".repeat(500)}`,
+      "card-1",
+      first.calibration,
+      tokenizer.count,
+    );
+
+    expect(grown.exact).toBe(true);
+    expect(grown.tokens).toBe(1010);
+    expect(grown.calibration).toEqual({ cardId: "card-1", chars: 505, tokens: 1010 });
+    expect(tokenizer.calls).toHaveLength(2);
+  });
+
+  it("resets calibration for a new card id", () => {
+    const tokenizer = counter();
+    const previous: LiveTokenCalibration = { cardId: "card-1", chars: 200, tokens: 80 };
+    const result = estimateLiveTokenCount("new text", "card-2", previous, tokenizer.count);
+
+    expect(result.exact).toBe(true);
+    expect(result.calibration.cardId).toBe("card-2");
+    expect(tokenizer.calls).toEqual(["new text"]);
+  });
+
+  it("keeps tokenizer calls bucketed across many streaming chunks", () => {
+    const tokenizer = counter();
+    let calibration: LiveTokenCalibration | null = null;
+
+    for (let chunk = 1; chunk <= 100; chunk++) {
+      const result = estimateLiveTokenCount(
+        "x".repeat(chunk * 100),
+        "card-1",
+        calibration,
+        tokenizer.count,
+      );
+      calibration = result.calibration;
+    }
+
+    expect(tokenizer.calls.length).toBeLessThanOrEqual(20);
+    expect(tokenizer.calls.length).toBeGreaterThan(1);
+    expect(tokenizer.calls.at(-1)).toHaveLength(9600);
+  });
+});


### PR DESCRIPTION
## What
Reduces live StreamingCard token-rate work by calibrating exact token counts only at length buckets during streaming, while keeping the settled done-card token count exact. Also removes obsolete Biome suppression comments that now fail the current lint gate.

## Why
Fixes #562. The live reply card previously called countTokens on the full accumulated assistant text on each render/chunk, which can add avoidable BPE work for long streaming responses.

## How to verify
- npm run verify

## Checklist

- [x] npm run verify passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No Co-Authored-By: Claude trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to CHANGELOG.md — release notes are maintainer-written at release time