### PR TITLE
feat(subagent): default-off delegation policy + per-session budget feedback

### DIFF
--- a/src/code/prompt.ts
+++ b/src/code/prompt.ts
@@ -97,15 +97,18 @@ Two built-ins ship by default:
 - **explore** \`[🧬 subagent]\` — read-only investigation across the codebase. Use when the user says things like "find all places that...", "how does X work across the project", "survey the code for Y". Pass \`arguments\` describing the concrete question.
 - **research** \`[🧬 subagent]\` — combines web search + code reading. Use for "is X supported by lib Y", "what's the canonical way to Z", "compare our impl to the spec".
 
-When to delegate (call \`run_skill\` with a subagent skill):
-- The task would otherwise need >5 file reads or searches.
-- You only need the conclusion, not the exploration trail.
-- The work is self-contained (you can describe it in one paragraph).
+**Default: don't delegate.** Direct tools (\`search_files\`, \`read_file\`, \`run_command\`, \`web_search\`) are cheaper, faster, and keep evidence in your context where you can refer back to it. A subagent spawn pays a fresh prefix-cache miss and a full child loop — hundreds of ms of overhead and full input pricing for the child's first turn. For most questions the spawn costs more than it saves.
 
-When NOT to delegate:
-- Direct, narrow questions answerable in 1-2 tool calls — just do them.
-- Anything where you need to track intermediate results yourself (planning, multi-step edits).
-- Anything that requires user interaction (subagents can't submit plans or ask you for clarification).
+Spawn ONLY in these two cases:
+1. **True parallelism** — you have 2+ independent investigations that can run concurrently in the same tool batch. The wall-time win is real and only achievable via fan-out.
+2. **Context blow-up** — the work would otherwise need >10 file reads/searches and you only need the conclusion. Keeping the trail out of your context is the actual saving.
+
+Anti-patterns — do NOT spawn for any of these:
+- single grep / single file read → call the tool directly
+- 1-3 file cross-reference → read them directly
+- "to keep my context clean for one question" → not enough saving to justify the spawn
+- anything that needs user interaction (subagents can't submit plans or ask for clarification)
+- anything where you need to track intermediate results yourself (planning, multi-step edits)
 
 Always pass a clear, self-contained \`arguments\` — that text is the **only** context the subagent gets.
 

--- a/src/tools/subagent.ts
+++ b/src/tools/subagent.ts
@@ -125,6 +125,24 @@ const SUBAGENT_TOOL_NAME = "spawn_subagent";
 /** spawn_subagent excluded → depth=1 hard cap; submit_plan excluded → no picker mid-parent-turn. */
 const NEVER_INHERITED_TOOLS = new Set<string>([SUBAGENT_TOOL_NAME, "submit_plan"]);
 
+/** Per-session spawn count past which the soft hint fires on every subsequent return. */
+const SOFT_HINT_AFTER_SPAWNS = 1;
+/** Per-session count past which the strong hint fires (asks the model to justify the next spawn). */
+const STRONG_HINT_AFTER_SPAWNS = 4;
+/** Per-session cumulative subagent token total past which the strong hint also fires. */
+const STRONG_HINT_TOKEN_THRESHOLD = 50_000;
+
+/** null → first spawn of the session, no hint. Pure for testability. */
+export function subagentBudgetHint(spawnCount: number, totalTokens: number): string | null {
+  if (spawnCount > STRONG_HINT_AFTER_SPAWNS || totalTokens >= STRONG_HINT_TOKEN_THRESHOLD) {
+    return `[budget: this session has now spawned ${spawnCount} subagents totalling ${totalTokens} tokens. Each spawn pays a fresh prefix-cache miss plus a full child loop — confirm the next spawn is genuinely needed (parallel fan-out or >10-read context blow-up) before calling spawn_subagent again. If you can answer with direct tools, do that instead.]`;
+  }
+  if (spawnCount > SOFT_HINT_AFTER_SPAWNS) {
+    return `[note: this session has spawned ${spawnCount} subagents totalling ${totalTokens} tokens; confirm this one is worth it.]`;
+  }
+  return null;
+}
+
 /** Errors captured in the result shape, never thrown — caller decides how to surface. */
 export async function spawnSubagent(opts: SpawnSubagentOptions): Promise<SubagentResult> {
   const model = opts.model ?? DEFAULT_SUBAGENT_MODEL;
@@ -398,12 +416,16 @@ export function registerSubagentTool(
   const maxToolIters = opts.maxToolIters ?? DEFAULT_MAX_ITERS;
   const maxResultChars = opts.maxResultChars ?? DEFAULT_MAX_RESULT_CHARS;
   const sink = opts.sink;
+  // Per-session counters survive across spawn calls because registerSubagentTool
+  // runs once per parent registry — closure scope is the session scope.
+  let sessionSpawnCount = 0;
+  let sessionSpawnTokens = 0;
 
   parentRegistry.register({
     name: SUBAGENT_TOOL_NAME,
     parallelSafe: true,
     description:
-      "Spawn an isolated subagent to handle a self-contained subtask in a fresh context, returning only its final answer. Use for: deep codebase exploration that would flood the main context, multi-step research where you only need the conclusion, or any focused subtask whose intermediate reasoning the user does not need to see. The subagent inherits all your tools (filesystem, shell, web, MCP, etc.) but runs in its own isolated message log — its tool calls and reasoning never enter your context. Only the final assistant message comes back as this tool's result. Keep tasks focused; the subagent has a stricter iter budget than you do.",
+      "Spawn an isolated subagent to handle a self-contained subtask in a fresh context, returning only its final answer. **Prefer direct tools.** Spawn primarily for parallel fan-out (2+ independent investigations issued in one tool batch) or when the work would otherwise need >10 file reads/searches whose trail you don't need to keep. Single greps, 1-3 file cross-references, and 'keep my context clean for one question' are NOT good reasons to spawn — direct tools are cheaper and let you reference the evidence later. Each spawn pays a fresh prefix-cache miss plus a full child loop. The subagent inherits your tools but runs in its own isolated message log; only the final assistant message comes back. Keep tasks focused; the subagent has a stricter iter budget than you do.",
     parameters: {
       type: "object",
       properties: {
@@ -475,7 +497,11 @@ export function registerSubagentTool(
         sink,
         parentSignal: ctx?.signal,
       });
-      return formatSubagentResult(result);
+      sessionSpawnCount++;
+      sessionSpawnTokens += result.usage.totalTokens;
+      const formatted = formatSubagentResult(result);
+      const hint = subagentBudgetHint(sessionSpawnCount, sessionSpawnTokens);
+      return hint ? `${formatted}\n${hint}` : formatted;
     },
   });
 

--- a/tests/subagent.test.ts
+++ b/tests/subagent.test.ts
@@ -10,6 +10,7 @@ import {
   forkRegistryWithAllowList,
   registerSubagentTool,
   spawnSubagent,
+  subagentBudgetHint,
 } from "../src/tools/subagent.js";
 
 interface FakeResponseShape {
@@ -573,6 +574,49 @@ describe("registerSubagentTool", () => {
     expect(unique[2]).toMatch(/\[budget: 2 of 5 tool calls left/);
     expect(unique[3]).toMatch(/\[budget: 1 of 5 tool call left/);
     expect(unique[4]).toMatch(/\[budget: 0 of 5 tool calls left — finalize NOW/);
+  });
+});
+
+describe("subagentBudgetHint", () => {
+  it("stays silent on the first spawn of a session", () => {
+    expect(subagentBudgetHint(1, 120)).toBeNull();
+  });
+
+  it("emits the soft note from the second spawn through the fourth", () => {
+    expect(subagentBudgetHint(2, 240)).toMatch(/\[note: this session has spawned 2 subagents/);
+    expect(subagentBudgetHint(4, 480)).toMatch(/\[note: this session has spawned 4 subagents/);
+  });
+
+  it("escalates to the strong budget hint past five spawns", () => {
+    const out = subagentBudgetHint(5, 600);
+    expect(out).toMatch(/\[budget: this session has now spawned 5 subagents/);
+    expect(out).toMatch(/parallel fan-out or >10-read context blow-up/);
+  });
+
+  it("escalates to the strong hint when cumulative tokens cross 50k even at low spawn count", () => {
+    const out = subagentBudgetHint(2, 60_000);
+    expect(out).toMatch(
+      /\[budget: this session has now spawned 2 subagents totalling 60000 tokens/,
+    );
+  });
+});
+
+describe("registerSubagentTool — per-session budget feedback", () => {
+  it("appends nothing on the first spawn, the soft note on the second, and the strong hint on the fifth", async () => {
+    const parent = new ToolRegistry();
+    const client = makeClient([{ content: "answer" }]);
+    registerSubagentTool(parent, { client });
+
+    const outs: string[] = [];
+    for (let i = 0; i < 5; i++) {
+      outs.push(await parent.dispatch("spawn_subagent", JSON.stringify({ task: `q${i}` })));
+    }
+
+    expect(outs[0]).not.toMatch(/\[(note|budget):/);
+    expect(outs[1]).toMatch(/\[note: this session has spawned 2 subagents/);
+    expect(outs[2]).toMatch(/\[note: this session has spawned 3 subagents/);
+    expect(outs[3]).toMatch(/\[note: this session has spawned 4 subagents/);
+    expect(outs[4]).toMatch(/\[budget: this session has now spawned 5 subagents/);
   });
 });
 


### PR DESCRIPTION
## Summary

Implements layers 1+2 of #553 — tightens the subagent delegation policy from "encouraged with thresholds" to "default off, narrow exceptions".

Closes #553. Surfaces back into #415 once one of the affected users confirms the storm pattern goes away.

## Layer 1 — prompt + tool description rewrite

`src/code/prompt.ts` and `src/tools/subagent.ts`:

- Lead with **"default: don't delegate"** instead of a "when to delegate" menu.
- Spell out the two cases where a spawn pays for itself: parallel fan-out (2+ batched investigations) or context blow-up (>10 reads whose trail you don't need).
- Name the anti-patterns explicitly: single grep, 1-3 file cross-reference, "keep my context clean for one question".
- Mirror the same flip on the `spawn_subagent` tool's description so model fine-tuning that ignores the prompt section still sees it on the tool itself.

The framing change is the cheapest lever and ships first.

## Layer 2 — per-session budget feedback

`src/tools/subagent.ts`:

- Closure-scoped counters in `registerSubagentTool` track per-session spawn count + cumulative subagent tokens. The closure scope IS the session scope because `registerSubagentTool` runs once per parent registry.
- New exported `subagentBudgetHint(spawnCount, totalTokens)` helper, pure for testability.
- After each spawn the JSON tool result gets an appended hint:
  - 1st spawn → no hint
  - 2nd-5th spawn → soft `[note: ...]`
  - 5+ spawns OR cumulative ≥ 50k tokens → strong `[budget: ...]` asking the model to justify the next spawn against the two valid use cases
- Same shape as the existing per-child iter budget hint (`subagent.ts:189`), so the model already knows how to read this format.

## Layer 3 — deferred

Per the issue spec, the single-call refusal gate (`subagent.singleCallPolicy`) is held back until we see whether 1+2 already moves the pattern in #415. Easier to add the hard gate later than to roll one back.

## Test plan

- [x] 5 new tests in `tests/subagent.test.ts`: 4 covering `subagentBudgetHint` thresholds (silent first, soft note 2-4, strong hint at 5, strong hint at 50k tokens with low count), 1 integration covering the actual `parent.dispatch` loop and verifying hint placement on each result
- [x] `npm run verify` — 2457 tests pass, lint + typecheck + build all green
- [ ] Manual: drive a multi-spawn task in `reasonix code`, confirm the soft note fires from spawn 2 and the strong hint kicks in past spawn 5 / 50k tokens
- [ ] Field signal: watch #415 for whether reporters see the storm pattern go away after upgrade
