### PR TITLE
fix(composer): surface ^U clear on hint bar and i18n hint strings

### DIFF
--- a/src/cli/ui/PromptInput.tsx
+++ b/src/cli/ui/PromptInput.tsx
@@ -300,11 +300,11 @@ export function PromptInput({
   );
 }
 
-function HintRow(): React.ReactElement {
+export function HintRow(): React.ReactElement {
   const items: Array<{ key: string; tKey: string }> = [
     { key: "\u23ce", tKey: "composer.hintSend" },
     { key: "\u21e7\u23ce", tKey: "composer.hintNewline" },
-    { key: "\u2191\u2193", tKey: "composer.hintScroll" },
+    { key: "^U", tKey: "composer.hintClear" },
     { key: "^P/^N", tKey: "composer.hintHistory" },
     { key: "esc", tKey: "composer.hintAbort" },
     { key: "^C", tKey: "composer.hintQuit" },

--- a/src/cli/ui/layout/Composer.tsx
+++ b/src/cli/ui/layout/Composer.tsx
@@ -2,6 +2,7 @@ import { Box, Text } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React from "react";
 import { t } from "../../../i18n/index.js";
+import { HintRow } from "../PromptInput.js";
 import { useAgentState } from "../state/provider.js";
 import { useThemeTokens } from "../theme/context.js";
 import { StatusRow } from "./StatusRow.js";
@@ -25,10 +26,14 @@ export function Composer(): React.ReactElement {
         )}
       </Box>
       <Box height={1} />
-      <Text color={fg.faint}>
-        {"  "}
-        {composer.abortedHint ? t("composer.abortedHint") : t("composer.hint")}
-      </Text>
+      {composer.abortedHint ? (
+        <Text color={fg.faint}>
+          {"  "}
+          {t("composer.abortedHint")}
+        </Text>
+      ) : (
+        <HintRow />
+      )}
     </Box>
   );
 }

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -1030,6 +1030,7 @@ export const EN: TranslationSchema = {
     waitingForResponse: "\u2026waiting for response\u2026",
     hintSend: "send",
     hintNewline: "newline",
+    hintClear: "clear",
     hintScroll: "scroll",
     hintHistory: "history",
     hintAbort: "abort",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -355,6 +355,7 @@ export interface TranslationSchema {
     waitingForResponse: string;
     hintSend: string;
     hintNewline: string;
+    hintClear: string;
     hintScroll: string;
     hintHistory: string;
     hintAbort: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -977,6 +977,7 @@ export const zhCN: TranslationSchema = {
     waitingForResponse: "…等待响应…",
     hintSend: "发送",
     hintNewline: "换行",
+    hintClear: "清空",
     hintScroll: "滚动",
     hintHistory: "历史",
     hintAbort: "中止",

--- a/tests/composer-hint.test.tsx
+++ b/tests/composer-hint.test.tsx
@@ -1,0 +1,77 @@
+import { render } from "ink-testing-library";
+import React from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import { HintRow } from "../src/cli/ui/PromptInput.js";
+import { setLanguageRuntime, t } from "../src/i18n/index.js";
+
+describe("composer hint bar — issue #564", () => {
+  afterEach(() => {
+    setLanguageRuntime("EN");
+  });
+
+  describe("i18n keys", () => {
+    it("exposes composer.hintClear in EN", () => {
+      setLanguageRuntime("EN");
+      expect(t("composer.hintClear")).toBe("clear");
+    });
+
+    it("exposes composer.hintClear in zh-CN", () => {
+      setLanguageRuntime("zh-CN");
+      expect(t("composer.hintClear")).toBe("清空");
+    });
+
+    it("never leaks the literal key 'composer.hint' (was rendered raw before fix)", () => {
+      setLanguageRuntime("EN");
+      // t() falls through to returning the path when a key is missing —
+      // the proposed always-visible row must be assembled from real keys.
+      expect(t("composer.hintSend")).not.toBe("composer.hintSend");
+      expect(t("composer.hintNewline")).not.toBe("composer.hintNewline");
+      expect(t("composer.hintClear")).not.toBe("composer.hintClear");
+      expect(t("composer.hintHistory")).not.toBe("composer.hintHistory");
+      expect(t("composer.hintAbort")).not.toBe("composer.hintAbort");
+      expect(t("composer.hintQuit")).not.toBe("composer.hintQuit");
+    });
+  });
+
+  describe("HintRow rendering", () => {
+    it("surfaces ^U clear on the always-visible hint row in EN", () => {
+      setLanguageRuntime("EN");
+      const { lastFrame, unmount } = render(<HintRow />);
+      const out = lastFrame() ?? "";
+      unmount();
+      expect(out).toContain("^U");
+      expect(out).toContain("clear");
+    });
+
+    it("renders the proposed terse hint set in EN", () => {
+      setLanguageRuntime("EN");
+      const { lastFrame, unmount } = render(<HintRow />);
+      const out = lastFrame() ?? "";
+      unmount();
+      // ⏎ send · ⇧⏎ newline · ^U clear · ^P/^N history · esc abort · ^C quit
+      expect(out).toContain("send");
+      expect(out).toContain("newline");
+      expect(out).toContain("clear");
+      expect(out).toContain("^P/^N");
+      expect(out).toContain("history");
+      expect(out).toContain("esc");
+      expect(out).toContain("abort");
+      expect(out).toContain("^C");
+      expect(out).toContain("quit");
+    });
+
+    it("translates verbs in zh-CN (chord glyphs stay literal)", () => {
+      setLanguageRuntime("zh-CN");
+      const { lastFrame, unmount } = render(<HintRow />);
+      const out = lastFrame() ?? "";
+      unmount();
+      expect(out).toContain("^U");
+      expect(out).toContain("清空");
+      expect(out).toContain("发送");
+      expect(out).toContain("换行");
+      expect(out).toContain("历史");
+      expect(out).toContain("中止");
+      expect(out).toContain("退出");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes esengine/DeepSeek-Reasonix#564.

## Notes

- Branched from `upstream/main`.
- Implementation per the issue's acceptance criteria; tests added/updated.
