### PR TITLE
fix(tui): stop subagent delta storm from re-rendering live stack

### DIFF
--- a/src/cli/ui/cards/ToolCard.tsx
+++ b/src/cli/ui/cards/ToolCard.tsx
@@ -1,5 +1,4 @@
 import { Box, Text, useStdout } from "ink";
-// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React from "react";
 import { clipToCells } from "../../../frame/width.js";
 import { t } from "../../../i18n/index.js";
@@ -29,7 +28,10 @@ export function ToolCard({ card }: { card: ToolCardData }): React.ReactElement {
   const lineCells = Math.max(20, cols - 4);
   const argsLabel = formatArgsSummary(card.args);
 
-  const subagentMarkdown = unwrapSubagentMarkdown(card);
+  const subagentMarkdown = React.useMemo(
+    () => unwrapSubagentMarkdown(card.name, card.output),
+    [card.name, card.output],
+  );
 
   const allLines = card.output.length > 0 ? card.output.split("\n") : [];
   const tail = tailLinesFor(card.name);
@@ -94,11 +96,11 @@ export function ToolCard({ card }: { card: ToolCardData }): React.ReactElement {
   );
 }
 
-function unwrapSubagentMarkdown(card: ToolCardData): string | null {
-  if (card.name !== "spawn_subagent") return null;
-  if (card.output.length === 0) return null;
+function unwrapSubagentMarkdown(name: string, output: string): string | null {
+  if (name !== "spawn_subagent") return null;
+  if (output.length === 0) return null;
   try {
-    const parsed = JSON.parse(card.output) as unknown;
+    const parsed = JSON.parse(output) as unknown;
     if (!parsed || typeof parsed !== "object") return null;
     const obj = parsed as Record<string, unknown>;
     if (obj.success !== true) return null;

--- a/src/cli/ui/useSubagent.ts
+++ b/src/cli/ui/useSubagent.ts
@@ -5,6 +5,55 @@ import type { SubagentEvent, SubagentSink } from "../../tools/subagent.js";
 import type { Scrollback } from "./hooks/useScrollback.js";
 import { CARD, TONE, formatCost } from "./theme/tokens.js";
 
+/** Identity-preserving — returns prev unchanged when no row would change. */
+export function reduceSubagentInnerEvent(
+  prev: ReadonlyArray<SubagentActivity>,
+  ev: SubagentEvent,
+): ReadonlyArray<SubagentActivity> {
+  if (ev.kind === "inner") {
+    if (!ev.inner) return prev;
+    const summary = summariseInner(ev.inner);
+    if (!summary) return prev;
+    return mapMatchingRun(prev, ev.runId, (a) => ({ ...a, lastInner: summary }));
+  }
+  if (ev.kind === "progress") {
+    return mapMatchingRun(prev, ev.runId, (a) => {
+      const iter = ev.iter ?? a.iter;
+      const elapsedMs = ev.elapsedMs ?? a.elapsedMs;
+      if (iter === a.iter && elapsedMs === a.elapsedMs) return a;
+      return { ...a, iter, elapsedMs };
+    });
+  }
+  if (ev.kind === "phase") {
+    return mapMatchingRun(prev, ev.runId, (a) => {
+      const phase = ev.phase ?? a.phase;
+      if (phase === a.phase) return a;
+      return { ...a, phase };
+    });
+  }
+  return prev;
+}
+
+function mapMatchingRun(
+  prev: ReadonlyArray<SubagentActivity>,
+  runId: string,
+  fn: (a: SubagentActivity) => SubagentActivity,
+): ReadonlyArray<SubagentActivity> {
+  let idx = -1;
+  for (let i = 0; i < prev.length; i++) {
+    if (prev[i]!.runId === runId) {
+      idx = i;
+      break;
+    }
+  }
+  if (idx < 0) return prev;
+  const updated = fn(prev[idx]!);
+  if (updated === prev[idx]) return prev;
+  const next = prev.slice();
+  next[idx] = updated;
+  return next;
+}
+
 function summariseInner(ev: LoopEvent): SubagentInnerSummary | null {
   if (ev.role === "tool_start") {
     return {
@@ -127,27 +176,7 @@ export function useSubagent({
         }
         return;
       }
-      // progress / phase / inner — patch the matching row, ignore stragglers from runs we never saw `start` for.
-      setActivities((prev) =>
-        prev.map((a) => {
-          if (a.runId !== ev.runId) return a;
-          if (ev.kind === "progress") {
-            return {
-              ...a,
-              iter: ev.iter ?? a.iter,
-              elapsedMs: ev.elapsedMs ?? a.elapsedMs,
-            };
-          }
-          if (ev.kind === "phase") {
-            return { ...a, phase: ev.phase ?? a.phase };
-          }
-          if (ev.kind === "inner" && ev.inner) {
-            const summary = summariseInner(ev.inner);
-            return summary ? { ...a, lastInner: summary } : a;
-          }
-          return a;
-        }),
-      );
+      setActivities((prev) => reduceSubagentInnerEvent(prev, ev));
     };
     return () => {
       sinkRef.current.current = null;

--- a/tests/subagent-reducer.test.ts
+++ b/tests/subagent-reducer.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import { type SubagentActivity, reduceSubagentInnerEvent } from "../src/cli/ui/useSubagent.js";
+import type { LoopEvent } from "../src/loop/types.js";
+import type { SubagentEvent } from "../src/tools/subagent.js";
+
+const baseActivity: SubagentActivity = {
+  runId: "sub-1",
+  startedAt: 0,
+  task: "demo",
+  iter: 0,
+  elapsedMs: 0,
+  phase: "exploring",
+  lastInner: null,
+};
+
+function inner(
+  runId: string,
+  role: LoopEvent["role"],
+  extra: Partial<LoopEvent> = {},
+): SubagentEvent {
+  return {
+    kind: "inner",
+    runId,
+    task: "demo",
+    inner: { turn: 1, role, content: "", ...extra },
+  };
+}
+
+describe("reduceSubagentInnerEvent", () => {
+  it("returns prev by reference for assistant_delta inner events", () => {
+    const prev = [baseActivity];
+    const next = reduceSubagentInnerEvent(
+      prev,
+      inner("sub-1", "assistant_delta", { content: "hi" }),
+    );
+    expect(next).toBe(prev);
+  });
+
+  it("returns prev by reference for reasoning deltas (no role -> pseudo) and other non-summarisable roles", () => {
+    const prev = [baseActivity];
+    expect(reduceSubagentInnerEvent(prev, inner("sub-1", "tool_call_delta"))).toBe(prev);
+    expect(
+      reduceSubagentInnerEvent(prev, inner("sub-1", "assistant_final", { content: "ok" })),
+    ).toBe(prev);
+    expect(reduceSubagentInnerEvent(prev, inner("sub-1", "done"))).toBe(prev);
+  });
+
+  it("returns prev by reference for inner events from unknown runs", () => {
+    const prev = [baseActivity];
+    const next = reduceSubagentInnerEvent(
+      prev,
+      inner("sub-999", "tool_start", { toolName: "read" }),
+    );
+    expect(next).toBe(prev);
+  });
+
+  it("updates only the matching row when an inner event summarises", () => {
+    const a: SubagentActivity = { ...baseActivity, runId: "sub-1" };
+    const b: SubagentActivity = { ...baseActivity, runId: "sub-2" };
+    const prev = [a, b];
+    const next = reduceSubagentInnerEvent(prev, inner("sub-2", "tool", { toolName: "grep" }));
+    expect(next).not.toBe(prev);
+    expect(next[0]).toBe(a);
+    expect(next[1]).not.toBe(b);
+    expect(next[1]?.lastInner?.label).toBe("grep");
+    expect(next[1]?.lastInner?.meta).toBe("done");
+  });
+
+  it("returns prev by reference when progress repeats the same iter/elapsedMs", () => {
+    const prev = [{ ...baseActivity, iter: 3, elapsedMs: 1000 }];
+    const next = reduceSubagentInnerEvent(prev, {
+      kind: "progress",
+      runId: "sub-1",
+      task: "demo",
+      iter: 3,
+      elapsedMs: 1000,
+    });
+    expect(next).toBe(prev);
+  });
+
+  it("updates the row when progress advances iter or elapsedMs", () => {
+    const prev = [{ ...baseActivity, iter: 3, elapsedMs: 1000 }];
+    const next = reduceSubagentInnerEvent(prev, {
+      kind: "progress",
+      runId: "sub-1",
+      task: "demo",
+      iter: 4,
+      elapsedMs: 1500,
+    });
+    expect(next).not.toBe(prev);
+    expect(next[0]?.iter).toBe(4);
+    expect(next[0]?.elapsedMs).toBe(1500);
+  });
+
+  it("returns prev by reference when phase repeats", () => {
+    const prev = [{ ...baseActivity, phase: "summarising" as const }];
+    const next = reduceSubagentInnerEvent(prev, {
+      kind: "phase",
+      runId: "sub-1",
+      task: "demo",
+      phase: "summarising",
+    });
+    expect(next).toBe(prev);
+  });
+
+  it("updates the row on a phase transition", () => {
+    const prev = [{ ...baseActivity, phase: "exploring" as const }];
+    const next = reduceSubagentInnerEvent(prev, {
+      kind: "phase",
+      runId: "sub-1",
+      task: "demo",
+      phase: "summarising",
+    });
+    expect(next).not.toBe(prev);
+    expect(next[0]?.phase).toBe("summarising");
+  });
+
+  it("returns prev unchanged for start/end events (those branches are handled outside the reducer)", () => {
+    const prev = [baseActivity];
+    expect(reduceSubagentInnerEvent(prev, { kind: "start", runId: "sub-2", task: "x" })).toBe(prev);
+    expect(reduceSubagentInnerEvent(prev, { kind: "end", runId: "sub-1", task: "demo" })).toBe(
+      prev,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes #554.

The subagent sink mirrors every child `LoopEvent` (`assistant_delta` /
`reasoning_delta` / `tool_call_delta`) into `useSubagent`'s in-flight
branch. The old `prev.map((a) => …)` callback always returned a fresh
array reference even when `summariseInner` resolved to `null` for the
event, so React re-rendered `App.tsx` and the entire
`SubagentLiveStack` on every child-loop delta. With 3 parallel
subagents streaming, that's 90+ no-op re-renders/sec — each forcing a
Yoga layout pass on the live region. That's the family of main-thread
sync work the issue suspected.

The fix has two parts:

- **`useSubagent.ts`** — extract the in-flight branches into a pure
  reducer (`reduceSubagentInnerEvent`) that returns `prev` by
  reference when no row would actually change. React's identity check
  then short-circuits the re-render. The reducer is exported so the
  prev-by-reference invariant is regression-tested in
  `tests/subagent-reducer.test.ts`.
- **`cards/ToolCard.tsx`** — memoize `unwrapSubagentMarkdown` on
  `card.name` + `card.output`. `useIsInflight` subscribes the card to
  the inflight context, which ticks on every parent-side tool
  start/finish; without the memo we re-`JSON.parse` up to 8 KB per
  spawn_subagent ToolCard on every tick.

The architecture issue's "things to check" list:

- ✅ Sink fan-in **was** causing N×M re-renders — fixed.
- ✅ Synchronous JSON.parse on the result-handling path — found one
  on every render of every spawn_subagent ToolCard, now memoized.
- ❌ `SubAgentCard.tsx` itself — clean (already wrapped in
  `React.memo` via CardRenderer).
- ❌ Markdown / syntax-highlight path — only fires on terminal
  results (`StreamingCard` only mounts `<Markdown>` when
  `card.done && !card.aborted`); `marked.lexer` already memoized via
  `useMemo([text])`.

Out of scope (and consistent with the issue): no worker-threads, no
reduction of `maxResultChars`.

## Test plan

- [x] `npx vitest run` — 2483 pass / 2 skipped, no regressions
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] New `tests/subagent-reducer.test.ts` — 9 cases covering the
      identity-preservation invariant for assistant_delta /
      tool_call_delta / unknown-run / repeat-progress / repeat-phase
      events, plus the matching positive cases.