### PR TITLE
fix(i18n): repair startup banner separator + consolidate template

### DIFF
--- a/src/cli/commands/code.tsx
+++ b/src/cli/commands/code.tsx
@@ -161,9 +161,12 @@ export async function codeCommand(opts: CodeOptions = {}): Promise<void> {
   );
 
   process.stderr.write(
-    `${t("startup.codeRooted")}${rootDir}${t("startup.session")}${session ?? t("startup.ephemeral")}" · ${tools.size}${t("startup.nativeTools")}${
-      semantic.enabled ? t("startup.semanticOn") : ""
-    }\n`,
+    `${t("startup.codeRooted", {
+      rootDir,
+      session: session ?? t("startup.ephemeral"),
+      tools: tools.size,
+      semantic: semantic.enabled ? t("startup.semanticOn") : "",
+    })}\n`,
   );
 
   const foreign = detectForeignAgentPlatform(rootDir);

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -1176,10 +1176,9 @@ export const EN: TranslationSchema = {
     turnLabel: "turn",
   },
   startup: {
-    codeRooted: "\u25b8 reasonix code: rooted at ",
-    session: 'session "',
+    codeRooted:
+      '\u25b8 reasonix code: rooted at {rootDir}, session "{session}" \u00b7 {tools} native tool(s){semantic}',
     ephemeral: "(ephemeral)",
-    nativeTools: " native tool(s)",
     semanticOn: " \u00b7 semantic_search on",
   },
   doctorErrors: {

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -481,9 +481,7 @@ export interface TranslationSchema {
   };
   startup: {
     codeRooted: string;
-    session: string;
     ephemeral: string;
-    nativeTools: string;
     semanticOn: string;
   };
   doctorErrors: {

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -1114,10 +1114,9 @@ export const zhCN: TranslationSchema = {
     turnLabel: "轮",
   },
   startup: {
-    codeRooted: "▸ reasonix code：根目录 ",
-    session: '会话 "',
+    codeRooted:
+      '▸ reasonix code：根目录 {rootDir}，会话 "{session}" · {tools} 个原生工具{semantic}',
     ephemeral: "（临时）",
-    nativeTools: " 个原生工具",
     semanticOn: " · 语义搜索已开启",
   },
   doctorErrors: {

--- a/tests/startup-banner-i18n.test.ts
+++ b/tests/startup-banner-i18n.test.ts
@@ -1,0 +1,47 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { getLanguage, setLanguageRuntime, t } from "../src/i18n/index.js";
+
+const originalLang = getLanguage();
+
+afterAll(() => {
+  setLanguageRuntime(originalLang);
+});
+
+describe("startup.codeRooted", () => {
+  it("renders the EN banner with comma + space between rootDir and session", () => {
+    setLanguageRuntime("EN");
+    const out = t("startup.codeRooted", {
+      rootDir: "/project",
+      session: "abc",
+      tools: 5,
+      semantic: t("startup.semanticOn"),
+    });
+    expect(out).toBe(
+      '\u25b8 reasonix code: rooted at /project, session "abc" \u00b7 5 native tool(s) \u00b7 semantic_search on',
+    );
+  });
+
+  it("omits the semantic suffix when no semantic engine is on", () => {
+    setLanguageRuntime("EN");
+    const out = t("startup.codeRooted", {
+      rootDir: "/project",
+      session: t("startup.ephemeral"),
+      tools: 0,
+      semantic: "",
+    });
+    expect(out).toBe(
+      '\u25b8 reasonix code: rooted at /project, session "(ephemeral)" \u00b7 0 native tool(s)',
+    );
+  });
+
+  it("renders the zh-CN banner with the CJK comma between rootDir and session", () => {
+    setLanguageRuntime("zh-CN");
+    const out = t("startup.codeRooted", {
+      rootDir: "/项目",
+      session: "abc",
+      tools: 5,
+      semantic: t("startup.semanticOn"),
+    });
+    expect(out).toBe('▸ reasonix code：根目录 /项目，会话 "abc" · 5 个原生工具 · 语义搜索已开启');
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #606. The startup banner was split across five `t()` calls
(`codeRooted` + `session` + `ephemeral` + `nativeTools` + `semanticOn`),
which dropped the `, ` between rootDir and session in both locales:

```
EN before:  ▸ reasonix code: rooted at /foo, session "abc" · 5 native tool(s)
EN after:   ▸ reasonix code: rooted at /foosession "abc" · 5 native tool(s)
zh-CN now:  ▸ reasonix code：根目录 /foo会话 "abc" · 5 个原生工具
```

Fold the four fixed segments into a single `codeRooted` template with
`{rootDir}` / `{session}` / `{tools}` / `{semantic}` placeholders so each
locale owns its full sentence — translators can reorder freely instead of
being constrained to the EN word order. `ephemeral` and `semanticOn` stay
as separate keys since they're conditionally substituted.

## Test plan

- [x] `npx vitest run` — 2486 pass, no regressions
- [x] `npm run typecheck` / `npm run lint` clean
- [x] New `tests/startup-banner-i18n.test.ts` locks both rendered banners
      (EN with semantic-on, EN with ephemeral session + no semantic,
      zh-CN full case) — fails if a future split reintroduces the
      missing-separator regression.