### PR TITLE
fix(i18n): add missing cardTitles.you key

### DIFF
--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -1222,6 +1222,7 @@ export const EN: TranslationSchema = {
     reasoningEllipsis: "reasoning\u2026",
     error: "error",
     doctor: "doctor",
+    you: "you",
   },
   cardLabels: {
     prompt: "prompt",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -520,6 +520,7 @@ export interface TranslationSchema {
     reasoningEllipsis: string;
     error: string;
     doctor: string;
+    you: string;
   };
   cardLabels: {
     prompt: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -1158,6 +1158,7 @@ export const zhCN: TranslationSchema = {
     reasoningEllipsis: "推理中…",
     error: "错误",
     doctor: "环境诊断",
+    you: "你",
   },
   cardLabels: {
     prompt: "提示",


### PR DESCRIPTION
## Summary
- `UserCard` rendered the literal string `cardTitles.you` because the key was used in `src/cli/ui/cards/UserCard.tsx:17` but never defined in `EN.ts`, `zh-CN.ts`, or the `TranslationSchema` type.
- Adds `you` to all three. EN: "you". zh-CN: "你".

## Test plan
- [x] `npm run verify` (build + lint + typecheck + tests) passes
- [ ] Run the TUI, send a message, confirm the user-message card title renders as `you` / `你` instead of `cardTitles.you`
