### PR TITLE
feat(loop): inject remaining-iter budget hint into parent tool results

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -56,6 +56,8 @@ import { ToolRegistry } from "./tools.js";
 import type { ChatMessage, ToolCall } from "./types.js";
 
 const ESCALATION_MODEL = "deepseek-v4-pro";
+/** Iters-from-cap at which the parent loop starts injecting a remaining-budget tail into tool results. Subagent uses 3 against a 16-cap; parent's default 64-cap means this fires only at iter ≥ 60. */
+const PARENT_BUDGET_WARN_THRESHOLD = 5;
 
 export {
   fixToolCallPairing,
@@ -144,6 +146,7 @@ export class CacheFirstLoop {
   private readonly _turnFailures = new TurnFailureTracker();
   private _turnSelfCorrected = false;
   private _foldedThisTurn = false;
+  private _toolDispatchesThisStep = 0;
   private context!: ContextManager;
 
   /** Subscribe API so UI hooks can derive `running` from finally-guaranteed insertions. */
@@ -209,6 +212,21 @@ export class CacheFirstLoop {
       stormThreshold: parsePositiveIntEnv(process.env.REASONIX_STORM_THRESHOLD),
       stormWindow: parsePositiveIntEnv(process.env.REASONIX_STORM_WINDOW),
     });
+
+    // Inject a remaining-iter hint into tool results when closing in on the per-turn cap. Subagent's child registry pre-installs its own augmenter before constructing the child loop — preserve it instead of clobbering.
+    if (!this.tools.hasResultAugmenter) {
+      this.tools.setResultAugmenter((_name, _args, result) => {
+        this._toolDispatchesThisStep++;
+        const remaining = this.maxToolIters - this._toolDispatchesThisStep;
+        if (remaining <= 0) {
+          return `${result}\n\n[budget: 0 of ${this.maxToolIters} tool calls left this turn — finalize NOW; the next iter forces a summary]`;
+        }
+        if (remaining <= PARENT_BUDGET_WARN_THRESHOLD) {
+          return `${result}\n\n[budget: ${remaining} of ${this.maxToolIters} tool calls left this turn — wrap up soon]`;
+        }
+        return result;
+      });
+    }
 
     // Heal-on-load: oversized tool results would 400 the next call before the user types.
     this.sessionName = opts.session ?? null;
@@ -517,6 +535,7 @@ export class CacheFirstLoop {
     this._turnSelfCorrected = false;
     this._escalateThisTurn = false;
     this._foldedThisTurn = false;
+    this._toolDispatchesThisStep = 0;
     let armedConsumed = false;
     if (this._proArmedForNextTurn) {
       this._escalateThisTurn = true;

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -90,6 +90,11 @@ export class ToolRegistry {
     this._resultAugmenter = fn;
   }
 
+  /** True when an augmenter is already wired — lets late-installing callers skip clobbering an earlier one. */
+  get hasResultAugmenter(): boolean {
+    return this._resultAugmenter !== null;
+  }
+
   register<A, R>(def: ToolDefinition<A, R>): this {
     if (!def.name) throw new Error("tool requires a name");
     const internal: InternalTool = { ...(def as ToolDefinition) };

--- a/src/tools/shell.ts
+++ b/src/tools/shell.ts
@@ -219,6 +219,8 @@ export function registerShellTools(registry: ToolRegistry, opts: ShellToolsOptio
     description:
       "Block until a background job exits or produces new output, bounded by `timeoutMs`. Use this instead of polling `job_output` with identical args when you're intentionally waiting for state to change. Returns JSON with `exited`, `exitCode`, and `latestOutput`.",
     readOnly: true,
+    parallelSafe: true,
+    stormExempt: true,
     parameters: {
       type: "object",
       properties: {

--- a/tests/loop-budget-augmenter.test.ts
+++ b/tests/loop-budget-augmenter.test.ts
@@ -1,0 +1,177 @@
+/** Parent-loop budget augmenter — injects a remaining-iter tail into tool results when closing in on the per-turn cap, and leaves a pre-installed augmenter alone (subagent's child-loop case). */
+
+import { describe, expect, it, vi } from "vitest";
+import { DeepSeekClient } from "../src/client.js";
+import { CacheFirstLoop } from "../src/loop.js";
+import { ImmutablePrefix } from "../src/memory/runtime.js";
+import { ToolRegistry } from "../src/tools.js";
+
+interface FakeResponseShape {
+  content?: string;
+  tool_calls?: any[];
+  usage?: Record<string, number>;
+}
+
+function fakeFetch(responses: FakeResponseShape[]): typeof fetch {
+  let i = 0;
+  return vi.fn(async (_url: any, _init: any) => {
+    const resp = responses[i++] ?? responses[responses.length - 1]!;
+    return new Response(
+      JSON.stringify({
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: "assistant",
+              content: resp.content ?? "",
+              tool_calls: resp.tool_calls ?? undefined,
+            },
+            finish_reason: resp.tool_calls ? "tool_calls" : "stop",
+          },
+        ],
+        usage: resp.usage ?? {
+          prompt_tokens: 100,
+          completion_tokens: 20,
+          total_tokens: 120,
+          prompt_cache_hit_tokens: 0,
+          prompt_cache_miss_tokens: 100,
+        },
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  }) as unknown as typeof fetch;
+}
+
+function makeClient(responses: FakeResponseShape[]) {
+  return new DeepSeekClient({ apiKey: "sk-test", fetch: fakeFetch(responses) });
+}
+
+function probeRegistry(): ToolRegistry {
+  const reg = new ToolRegistry();
+  reg.register({
+    name: "probe",
+    description: "no-op probe",
+    parameters: { type: "object", properties: {} },
+    fn: async () => "raw-probe-result",
+  });
+  return reg;
+}
+
+function callProbe(): FakeResponseShape {
+  return {
+    content: "",
+    tool_calls: [{ id: "c", type: "function", function: { name: "probe", arguments: "{}" } }],
+  };
+}
+
+describe("parent-loop budget augmenter", () => {
+  it("does not inject a budget tail when iters remaining > threshold", async () => {
+    const tools = probeRegistry();
+    const client = makeClient([callProbe(), { content: "done" }]);
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s", toolSpecs: tools.specs() }),
+      tools,
+      stream: false,
+      maxToolIters: 64,
+    });
+
+    const toolContents: string[] = [];
+    for await (const ev of loop.step("go")) {
+      if (ev.role === "tool") toolContents.push(ev.content);
+    }
+    expect(toolContents).toHaveLength(1);
+    expect(toolContents[0]).toBe("raw-probe-result");
+    expect(toolContents[0]).not.toMatch(/\[budget:/);
+  });
+
+  it("injects a remaining-iter tail when iters remaining is at or below threshold", async () => {
+    const tools = probeRegistry();
+    const client = makeClient([callProbe(), { content: "done" }]);
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s", toolSpecs: tools.specs() }),
+      tools,
+      stream: false,
+      maxToolIters: 5,
+    });
+
+    const toolContents: string[] = [];
+    for await (const ev of loop.step("go")) {
+      if (ev.role === "tool") toolContents.push(ev.content);
+    }
+    expect(toolContents).toHaveLength(1);
+    expect(toolContents[0]).toMatch(/^raw-probe-result/);
+    expect(toolContents[0]).toMatch(/\[budget: 4 of 5 tool calls left this turn — wrap up soon\]/);
+  });
+
+  it("injects the strong stop-now tail when iters remaining is 0 (cap reached)", async () => {
+    const tools = probeRegistry();
+    const client = makeClient([callProbe(), callProbe(), { content: "done" }]);
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s", toolSpecs: tools.specs() }),
+      tools,
+      stream: false,
+      maxToolIters: 2,
+    });
+
+    const toolContents: string[] = [];
+    for await (const ev of loop.step("go")) {
+      if (ev.role === "tool") toolContents.push(ev.content);
+    }
+    expect(toolContents).toHaveLength(2);
+    expect(toolContents[0]).toMatch(/\[budget: 1 of 2 tool calls left this turn — wrap up soon\]/);
+    expect(toolContents[1]).toMatch(/\[budget: 0 of 2 tool calls left this turn — finalize NOW/);
+  });
+
+  it("resets the per-turn dispatch counter at step entry so consecutive turns don't accumulate", async () => {
+    const tools = probeRegistry();
+    const client = makeClient([
+      callProbe(),
+      { content: "turn-1-done" },
+      callProbe(),
+      { content: "turn-2-done" },
+    ]);
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s", toolSpecs: tools.specs() }),
+      tools,
+      stream: false,
+      maxToolIters: 5,
+    });
+
+    const turn1Tools: string[] = [];
+    for await (const ev of loop.step("go")) {
+      if (ev.role === "tool") turn1Tools.push(ev.content);
+    }
+    const turn2Tools: string[] = [];
+    for await (const ev of loop.step("again")) {
+      if (ev.role === "tool") turn2Tools.push(ev.content);
+    }
+    expect(turn1Tools[0]).toMatch(/\[budget: 4 of 5 tool calls left/);
+    expect(turn2Tools[0]).toMatch(/\[budget: 4 of 5 tool calls left/);
+  });
+
+  it("preserves a pre-installed augmenter — constructor must not clobber subagent's child-registry augmenter", async () => {
+    const tools = probeRegistry();
+    tools.setResultAugmenter((_n, _a, result) => `${result}\n\n[child-augmenter-marker]`);
+    expect(tools.hasResultAugmenter).toBe(true);
+
+    const client = makeClient([callProbe(), { content: "done" }]);
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s", toolSpecs: tools.specs() }),
+      tools,
+      stream: false,
+      maxToolIters: 1,
+    });
+
+    const toolContents: string[] = [];
+    for await (const ev of loop.step("go")) {
+      if (ev.role === "tool") toolContents.push(ev.content);
+    }
+    expect(toolContents[0]).toMatch(/\[child-augmenter-marker\]/);
+    expect(toolContents[0]).not.toMatch(/\[budget:/);
+  });
+});

--- a/tests/shell-tools.test.ts
+++ b/tests/shell-tools.test.ts
@@ -377,6 +377,13 @@ describe("registerShellTools — dispatch integration", () => {
     expect(registry.has("list_jobs")).toBe(true);
   });
 
+  it("flags wait_for_job as parallelSafe + stormExempt — concurrent waits on different jobs are safe and polling-loop is the intended pattern", () => {
+    const registry = new ToolRegistry();
+    registerShellTools(registry, { rootDir: tmp });
+    expect(registry.isParallelSafe("wait_for_job")).toBe(true);
+    expect(registry.get("wait_for_job")?.stormExempt).toBe(true);
+  });
+
   it("wait_for_job returns structured state when a job emits new output", async () => {
     const registry = new ToolRegistry();
     const jobs = new (await import("../src/tools/jobs.js")).JobRegistry();


### PR DESCRIPTION
## Summary

Follow-up audit on #610. The subagent loop has used a
`setResultAugmenter`-driven budget tail since 0.36 — when within
`BUDGET_WARN_THRESHOLD` of the per-spawn cap, every tool result picks
up `[budget: K of N tool calls left — wrap up soon]`, and at 0 left a
stronger `finalize NOW` form. The parent `CacheFirstLoop` exposed the
same `setResultAugmenter` hook on the registry but never wired a
consumer, so the model running in the main session had **zero
runtime visibility into its iter budget**. The user-facing 70%
warning fires to the TUI, not to the model — when it hits iter 60 of
64 it still has no signal it's about to be force-summarized.

Wire an analogous augmenter on the parent loop (threshold `5`,
slightly wider than subagent's `3` since the parent's default 64-cap
is 4× larger) and reset the per-step counter at step entry so
consecutive turns don't accumulate. The constructor checks
`ToolRegistry.hasResultAugmenter` first so subagent's pre-installed
child-registry augmenter (`subagent.ts:210`) survives — clobbering it
would re-apply the parent's wider threshold to subagent runs.

Also fix `wait_for_job`: it was missing both `parallelSafe` and
`stormExempt`. Concurrent waits on different jobs are safe, and
polling-loop is the intended use pattern — the storm breaker
shouldn't trip on it. (The broader stormExempt expansion the audit
session proposed isn't included; some of those tools — search /
grep / web — are genuinely repeat-storm-vulnerable and should keep
the breaker engaged.)

## Test plan

- [x] `tests/loop-budget-augmenter.test.ts` (new, 5 cases) —
      threshold-respect, off-threshold non-injection, 0-left strong
      form, per-turn counter reset, pre-installed augmenter
      preservation
- [x] `tests/shell-tools.test.ts` (+1 case) — flag invariants for
      `wait_for_job`
- [x] `npx vitest run` — 2492 pass / 2 skipped, no regressions
- [x] `npm run typecheck` / `npm run lint` clean