### PR TITLE
feat(i18n): localize setup wizard, theme picker, plan editor, MCP hub, and more with zh-CN

### DIFF
--- a/src/cli/ui/DenyContextInput.tsx
+++ b/src/cli/ui/DenyContextInput.tsx
@@ -1,5 +1,6 @@
 import { Box, Text } from "ink";
 import React, { useState } from "react";
+import { t } from "../../i18n/index.js";
 import { useKeystroke } from "./keystroke-context.js";
 import { FG, TONE } from "./theme/tokens.js";
 
@@ -9,8 +10,7 @@ export interface DenyContextInputProps {
   onCancel: () => void;
 }
 
-const DEFAULT_DESCRIPTION =
-  "Tell the agent why you denied this. The next attempt will see your reason as additional context.";
+const DEFAULT_DESCRIPTION = t("denyContextInput.description");
 
 export function DenyContextInput({
   description = DEFAULT_DESCRIPTION,

--- a/src/cli/ui/McpHub.tsx
+++ b/src/cli/ui/McpHub.tsx
@@ -2,6 +2,7 @@
 
 import { Box, Text } from "ink";
 import React, { useState } from "react";
+import { t } from "../../i18n/index.js";
 import { McpBrowser } from "./McpBrowser.js";
 import { McpMarketplace } from "./McpMarketplace.js";
 import type { PickerBroadcastPorts } from "./dashboard/use-picker-broadcast.js";
@@ -54,10 +55,14 @@ export function McpHub({
           ◈ MCP
         </Text>
         <Text>{"  "}</Text>
-        <TabPill label="Live" count={liveServers.length} active={tab === "live"} />
+        <TabPill
+          label={t("handlers.mcp.liveTab")}
+          count={liveServers.length}
+          active={tab === "live"}
+        />
         <Text>{"  "}</Text>
-        <TabPill label="Marketplace" active={tab === "marketplace"} />
-        <Text dimColor>{"   tab to switch"}</Text>
+        <TabPill label={t("handlers.mcp.marketplaceTab")} active={tab === "marketplace"} />
+        <Text dimColor>{`   ${t("handlers.mcp.tabHint")}`}</Text>
       </Box>
       {tab === "live" ? (
         <McpBrowser

--- a/src/cli/ui/PlanReviseEditor.tsx
+++ b/src/cli/ui/PlanReviseEditor.tsx
@@ -1,6 +1,7 @@
 import { Box, Text } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React, { useState } from "react";
+import { t } from "../../i18n/index.js";
 import type { PlanStep } from "../../tools/plan.js";
 import { ApprovalCard } from "./cards/ApprovalCard.js";
 import { useKeystroke } from "./keystroke-context.js";
@@ -98,9 +99,9 @@ export function PlanReviseEditor({
     <ApprovalCard
       tone="accent"
       glyph="✎"
-      title="Revise plan"
-      metaRight={`${rows.length} steps`}
-      footerHint="↑↓ focus  ·  space toggle skip  ·  k/j move  ·  ⏎ accept  ·  esc cancel"
+      title={t("planFlow.reviseTitle")}
+      metaRight={t("planFlow.reviseSteps", { count: rows.length })}
+      footerHint={t("planFlow.reviseFooter")}
     >
       {rows.map((r, i) => (
         <ReviseRow key={r.step.id} row={r} index={i} focused={i === focus} />

--- a/src/cli/ui/Setup.tsx
+++ b/src/cli/ui/Setup.tsx
@@ -1,6 +1,7 @@
 import { Box, Text, useApp } from "ink";
 import React, { useState } from "react";
 import { defaultConfigPath, isPlausibleKey, redactKey, saveApiKey } from "../../config.js";
+import { t } from "../../i18n/index.js";
 import { MaskedInput } from "./MaskedInput.js";
 import { COLOR, GLYPH, GRADIENT } from "./theme.js";
 
@@ -20,14 +21,14 @@ export function Setup({ onReady }: SetupProps) {
       return;
     }
     if (!isPlausibleKey(trimmed)) {
-      setError("Key looks too short — paste the full token (16+ chars, no spaces).");
+      setError(t("wizard.apiKeyInvalid"));
       setValue("");
       return;
     }
     try {
       saveApiKey(trimmed);
     } catch (err) {
-      setError(`Could not save key: ${(err as Error).message}`);
+      setError(t("wizard.reviewSaveError", { message: (err as Error).message }));
       return;
     }
     onReady(trimmed);
@@ -40,21 +41,16 @@ export function Setup({ onReady }: SetupProps) {
           {GLYPH.brand}
         </Text>
         <Text>{"  "}</Text>
-        <Text bold>Welcome to </Text>
-        <Text bold color={GRADIENT[2]}>
-          REASONIX
-        </Text>
+        <Text bold>{t("wizard.welcomeTitle")}</Text>
       </Box>
       <Box marginTop={1}>
-        <Text color={COLOR.info}>Paste your DeepSeek API key to get started.</Text>
+        <Text color={COLOR.info}>{t("wizard.apiKeyPrompt")}</Text>
       </Box>
       <Box>
-        <Text dimColor>{"  sign up at · "}</Text>
-        <Text color={COLOR.primary}>https://platform.deepseek.com/api_keys</Text>
+        <Text dimColor>{`  ${t("wizard.apiKeyGetOne")}`}</Text>
       </Box>
       <Box>
-        <Text dimColor>{"  saved to "}</Text>
-        <Text dimColor>{defaultConfigPath()}</Text>
+        <Text dimColor>{t("wizard.apiKeySavedLocally", { path: defaultConfigPath() })}</Text>
       </Box>
       <Box marginTop={1}>
         <Text bold color={COLOR.brand}>
@@ -68,7 +64,7 @@ export function Setup({ onReady }: SetupProps) {
           onChange={setValue}
           onSubmit={handleSubmit}
           mask="•"
-          placeholder="sk-..."
+          placeholder={t("wizard.apiKeyPlaceholder")}
         />
       </Box>
       {error ? (
@@ -80,11 +76,11 @@ export function Setup({ onReady }: SetupProps) {
         </Box>
       ) : value ? (
         <Box marginTop={1}>
-          <Text dimColor>{`  preview · ${redactKey(value)}`}</Text>
+          <Text dimColor>{t("wizard.apiKeyPreview", { redacted: redactKey(value) })}</Text>
         </Box>
       ) : null}
       <Box marginTop={1}>
-        <Text dimColor>{"  /exit to abort"}</Text>
+        <Text dimColor>{t("wizard.exitHint")}</Text>
       </Box>
     </Box>
   );

--- a/src/cli/ui/SlashArgPicker.tsx
+++ b/src/cli/ui/SlashArgPicker.tsx
@@ -1,6 +1,7 @@
 import { Box, Text } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig.jsx = "react" needs React in value scope for JSX compilation
 import React from "react";
+import { t } from "../../i18n/index.js";
 import type { SlashCommandSpec } from "./slash.js";
 import { GLYPH, useColor } from "./theme.js";
 
@@ -68,8 +69,8 @@ export function SlashArgPicker({
           <Text color={color.warn} bold>
             {GLYPH.warn}
           </Text>
-          <Text color={color.warn}>{` no match for "${partial}"`}</Text>
-          <Text dimColor>{" — keep typing, or Backspace to edit"}</Text>
+          <Text color={color.warn}>{t("slashArgPicker.noMatch", { partial })}</Text>
+          <Text dimColor>{t("slashArgPicker.keepTyping")}</Text>
         </Box>
       </Box>
     );
@@ -85,13 +86,17 @@ export function SlashArgPicker({
   return (
     <Box flexDirection="column" paddingX={1} marginTop={1}>
       {headerRow}
-      {hiddenAbove > 0 ? <Text dimColor>{`   ↑ ${hiddenAbove} above`}</Text> : null}
+      {hiddenAbove > 0 ? (
+        <Text dimColor>{t("slashArgPicker.above", { hidden: hiddenAbove })}</Text>
+      ) : null}
       {shown.map((value, i) => (
         <ArgRow key={value} value={value} isSelected={windowStart + i === selectedIndex} />
       ))}
-      {hiddenBelow > 0 ? <Text dimColor>{`   ↓ ${hiddenBelow} below`}</Text> : null}
+      {hiddenBelow > 0 ? (
+        <Text dimColor>{t("slashArgPicker.below", { hidden: hiddenBelow })}</Text>
+      ) : null}
       <Box marginTop={0}>
-        <Text dimColor>{"  ↑↓ navigate · Tab / ⏎ pick · esc cancel"}</Text>
+        <Text dimColor>{t("slashArgPicker.footer")}</Text>
       </Box>
     </Box>
   );

--- a/src/cli/ui/ThemePicker.tsx
+++ b/src/cli/ui/ThemePicker.tsx
@@ -1,5 +1,6 @@
 import { Box, Text } from "ink";
 import React from "react";
+import { t } from "../../i18n/index.js";
 import { type SelectItem, SingleSelect } from "./Select.js";
 import { type ThemeName, listThemeNames } from "./theme/tokens.js";
 
@@ -25,13 +26,13 @@ export function ThemePicker({
 
   return (
     <Box flexDirection="column" marginY={1}>
-      <Text bold>Theme</Text>
+      <Text bold>{t("themePicker.header")}</Text>
       <SingleSelect
         items={items}
         initialValue={currentPreference}
         onSubmit={(value) => onChoose({ kind: "select", value })}
         onCancel={() => onChoose({ kind: "quit" })}
-        footer="↑↓ pick · ⏎ confirm · esc cancel"
+        footer={t("themePicker.footer")}
       />
     </Box>
   );
@@ -43,8 +44,8 @@ function describeTheme(
   activeTheme: ThemeName,
 ): string {
   const tags: string[] = [];
-  if (value === currentPreference) tags.push("current preference");
-  if (value === activeTheme) tags.push("active now");
-  if (value === "auto") tags.push("use REASONIX_THEME or default");
+  if (value === currentPreference) tags.push(t("themePicker.currentPref"));
+  if (value === activeTheme) tags.push(t("themePicker.activeNow"));
+  if (value === "auto") tags.push(t("themePicker.autoDesc"));
   return tags.join(" · ");
 }

--- a/src/cli/ui/Wizard.tsx
+++ b/src/cli/ui/Wizard.tsx
@@ -363,7 +363,7 @@ function ThemeStep({
         <Text color={theme.fg.meta}>{t("wizard.themeSampleHeading")}</Text>
         <Box marginTop={1}>
           <Text color={theme.tone.accent}>{"◆ "}</Text>
-          <Text color={theme.tone.accent}>Reasoning</Text>
+          <Text color={theme.tone.accent}>{t("wizard.themeSampleReasoning")}</Text>
         </Box>
         <Box>
           <Text color={theme.tone.info}>{"▣ "}</Text>

--- a/src/cli/ui/layout/CardStream.tsx
+++ b/src/cli/ui/layout/CardStream.tsx
@@ -1,5 +1,6 @@
 import { Box, type DOMElement, Text, useBoxMetrics } from "ink";
 import React, { useEffect, useMemo, useRef } from "react";
+import { t } from "../../../i18n/index.js";
 import { CardRenderer } from "../cards/CardRenderer.js";
 import type { Card } from "../state/cards.js";
 import { useChatScrollActions, useChatScrollState } from "../state/chat-scroll-provider.js";
@@ -144,7 +145,12 @@ function ScrollIndicator({
     return () => clearTimeout(id);
   }, [version]);
   const remaining = Math.max(0, maxScroll - scrollRows);
-  const text = ` ↑ ${scrollRows} / ${maxScroll} rows above${remaining > 0 ? ` — ${remaining} more` : ""} · PgUp / wheel / ↑`;
+  const above =
+    scrollRows === 1
+      ? t("cardStream.scrollAbove", { scroll: scrollRows, max: maxScroll })
+      : t("cardStream.scrollAbovePlural", { scroll: scrollRows, max: maxScroll });
+  const more = remaining > 0 ? t("cardStream.scrollMore", { remaining }) : "";
+  const text = `${above}${more}${t("cardStream.scrollPgUp")}`;
   return <Text color={hot ? TONE.accent : FG.faint}>{text}</Text>;
 }
 

--- a/src/cli/ui/mcp-health.ts
+++ b/src/cli/ui/mcp-health.ts
@@ -1,3 +1,4 @@
+import { t } from "../../i18n/index.js";
 import { COLOR } from "./theme.js";
 
 export interface HealthBadge {
@@ -7,15 +8,17 @@ export interface HealthBadge {
 }
 
 export function healthBadge(elapsedMs: number): HealthBadge {
-  if (elapsedMs === 0) return { glyph: "✗", label: "no inspect data", color: COLOR.err };
-  if (elapsedMs < 500) return { glyph: "●", label: `healthy · ${elapsedMs}ms`, color: COLOR.ok };
-  if (elapsedMs < 3000) return { glyph: "◌", label: `slow · ${elapsedMs}ms`, color: COLOR.warn };
-  return { glyph: "✗", label: `very slow · ${elapsedMs}ms`, color: COLOR.err };
+  if (elapsedMs === 0) return { glyph: "✗", label: t("mcpHealth.noData"), color: COLOR.err };
+  if (elapsedMs < 500)
+    return { glyph: "●", label: t("mcpHealth.healthy", { ms: elapsedMs }), color: COLOR.ok };
+  if (elapsedMs < 3000)
+    return { glyph: "◌", label: t("mcpHealth.slow", { ms: elapsedMs }), color: COLOR.warn };
+  return { glyph: "✗", label: t("mcpHealth.verySlow", { ms: elapsedMs }), color: COLOR.err };
 }
 
 // Preserves original slash thresholds: 0 → "● healthy · 0ms" (no === 0 branch)
 export function slashHealthBadge(elapsedMs: number): string {
-  if (elapsedMs < 500) return `● healthy · ${elapsedMs}ms`;
-  if (elapsedMs < 3000) return `◌ slow · ${elapsedMs}ms`;
-  return `✗ very slow · ${elapsedMs}ms`;
+  if (elapsedMs < 500) return t("mcpHealth.healthy", { ms: elapsedMs });
+  if (elapsedMs < 3000) return t("mcpHealth.slow", { ms: elapsedMs });
+  return t("mcpHealth.verySlow", { ms: elapsedMs });
 }

--- a/src/cli/ui/slash/dispatch.ts
+++ b/src/cli/ui/slash/dispatch.ts
@@ -1,3 +1,4 @@
+import { t } from "../../../i18n/index.js";
 import type { CacheFirstLoop } from "../../../loop.js";
 import { resolveSlashAlias } from "./commands.js";
 import { handlers as adminHandlers } from "./handlers/admin.js";
@@ -54,7 +55,7 @@ export function handleSlash(
   const suggestions = nearestCommands(cmd, Object.keys(HANDLERS));
   if (suggestions.length > 0) {
     const list = suggestions.map((name) => `/${name}`).join(", ");
-    return { unknown: true, info: `unknown command: /${cmd} — did you mean ${list}?` };
+    return { unknown: true, info: t("handlers.basic.unknownCommand", { cmd, list }) };
   }
-  return { unknown: true, info: `unknown command: /${cmd}  (try /help)` };
+  return { unknown: true, info: t("handlers.basic.unknownCommandShort", { cmd }) };
 }

--- a/src/cli/ui/slash/handlers/basic.ts
+++ b/src/cli/ui/slash/handlers/basic.ts
@@ -1,11 +1,6 @@
 import { t, tObj } from "@/i18n/index.js";
 import { formatDuration, formatLoopStatus, parseLoopCommand } from "../../loop.js";
-import {
-  SLASH_COMMANDS,
-  SLASH_GROUP_LABEL,
-  SLASH_GROUP_ORDER,
-  orderSlashCommandsByGroup,
-} from "../commands.js";
+import { SLASH_COMMANDS, SLASH_GROUP_ORDER, orderSlashCommandsByGroup } from "../commands.js";
 import type { SlashHandler } from "../dispatch.js";
 import type { SlashCommandSpec, SlashGroup } from "../types.js";
 
@@ -19,19 +14,11 @@ const resetLog: SlashHandler = (_args, loop) => {
   return { clear: true, info };
 };
 
-const GROUP_DETAIL: Record<SlashGroup, string> = {
-  setup: "model + cost",
-  info: "current state",
-  chat: "daily turn ops",
-  extend: "MCP, memory, skills",
-  session: "saved sessions",
-  code: "edits + plans (code mode)",
-  jobs: "background processes (code mode)",
-  advanced: "rare or set-and-forget",
-};
-
 function groupHeader(group: SlashGroup): string {
-  return `${SLASH_GROUP_LABEL[group]}  ·  ${GROUP_DETAIL[group]}`;
+  const cap = group.charAt(0).toUpperCase() + group.slice(1);
+  const label = t(`slashSuggestions.group${cap}`);
+  const detail = t(`slashSuggestions.groupDetail${cap}`);
+  return `${label}  ·  ${detail}`;
 }
 
 function renderRow(spec: SlashCommandSpec): string {

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -429,6 +429,16 @@ export const EN: TranslationSchema = {
     savedFooter: "[Enter] to exit",
     selectFooter: "[↑↓] navigate · [Enter] confirm · [Esc] cancel",
     stepCounter: "Step {step}/{total} · ",
+    exitHint: "/exit to abort",
+    apiKeyPlaceholder: "sk-...",
+    themeSampleReasoning: "Reasoning",
+  },
+  themePicker: {
+    header: "Theme",
+    footer: "↑↓ pick · ⏎ confirm · esc cancel",
+    currentPref: "current preference",
+    activeNow: "active now",
+    autoDesc: "use REASONIX_THEME or default",
   },
   planFlow: {
     approveCardTitle: "Approve plan",
@@ -493,6 +503,9 @@ export const EN: TranslationSchema = {
       counterDone: "{done}/{total} done ({pct}%) · {total} steps",
       counterDoneSingular: "{done}/{total} done ({pct}%) · {total} step",
     },
+    reviseTitle: "Revise plan",
+    reviseSteps: "{count} steps",
+    reviseFooter: "↑↓ focus  ·  space toggle skip  ·  k/j move  ·  ⏎ accept  ·  esc cancel",
   },
   app: {
     walkCancelledRemaining: "▸ walk cancelled — {count} block(s) still pending.",
@@ -668,6 +681,8 @@ export const EN: TranslationSchema = {
       loopStarted:
         '▸ loop started — re-submitting "{prompt}" every {duration}. Type anything (or /loop stop) to cancel.',
       keysNeedsTui: "/keys needs a TUI context (postKeys wired).",
+      unknownCommand: "unknown command: /{cmd} — did you mean {list}?",
+      unknownCommandShort: "unknown command: /{cmd}  (try /help)",
     },
     admin: {
       doctorNeedsTui: "/doctor needs a TUI context (postDoctor wired).",
@@ -972,6 +987,9 @@ export const EN: TranslationSchema = {
       unknownServer: 'unknown MCP server "{name}". Known: {list}.',
       noneList: "(none)",
       reconnectNoTui: "/mcp reconnect requires the interactive TUI (postInfo not wired).",
+      liveTab: "Live",
+      marketplaceTab: "Marketplace",
+      tabHint: "tab to switch",
     },
     init: {
       codeOnly:
@@ -1143,6 +1161,14 @@ export const EN: TranslationSchema = {
     groupCode: "CODE",
     groupJobs: "JOBS",
     groupAdvanced: "ADVANCED",
+    groupDetailSetup: "model + cost",
+    groupDetailInfo: "current state",
+    groupDetailChat: "daily turn ops",
+    groupDetailExtend: "MCP, memory, skills",
+    groupDetailSession: "saved sessions",
+    groupDetailCode: "edits + plans (code mode)",
+    groupDetailJobs: "background processes (code mode)",
+    groupDetailAdvanced: "rare or set-and-forget",
   },
   atMentions: {
     loading: "loading\u2026",
@@ -1304,5 +1330,28 @@ export const EN: TranslationSchema = {
     labelReasoning: "reasoning",
     yankedToast: "▸ copied {size} chars to clipboard (osc52)",
     yankedToastFile: "▸ copied {size} chars · file: {path}",
+  },
+  mcpHealth: {
+    noData: "no inspect data",
+    healthy: "healthy \u00b7 {ms}ms",
+    slow: "slow \u00b7 {ms}ms",
+    verySlow: "very slow \u00b7 {ms}ms",
+  },
+  denyContextInput: {
+    description:
+      "Tell the agent why you denied this. The next attempt will see your reason as additional context.",
+  },
+  cardStream: {
+    scrollAbove: " \u2191 {scroll} / {max} row above",
+    scrollAbovePlural: " \u2191 {scroll} / {max} rows above",
+    scrollMore: " \u2014 {remaining} more",
+    scrollPgUp: " \u00b7 PgUp / wheel / \u2191",
+  },
+  slashArgPicker: {
+    noMatch: 'no match for "{partial}"',
+    keepTyping: " \u2014 keep typing, or Backspace to edit",
+    above: "   \u2191 {hidden} above",
+    below: "   \u2193 {hidden} below",
+    footer: "  \u2191\u2193 navigate \u00b7 Tab / \u23ce pick \u00b7 esc cancel",
   },
 };

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -283,6 +283,16 @@ export interface TranslationSchema {
     savedFooter: string;
     selectFooter: string;
     stepCounter: string;
+    exitHint: string;
+    apiKeyPlaceholder: string;
+    themeSampleReasoning: string;
+  };
+  themePicker: {
+    header: string;
+    footer: string;
+    currentPref: string;
+    activeNow: string;
+    autoDesc: string;
   };
   planFlow: {
     approveCardTitle: string;
@@ -325,6 +335,9 @@ export interface TranslationSchema {
       counterDone: string;
       counterDoneSingular: string;
     };
+    reviseTitle: string;
+    reviseSteps: string;
+    reviseFooter: string;
   };
   statusBar: {
     turn: string;
@@ -442,6 +455,14 @@ export interface TranslationSchema {
     groupCode: string;
     groupJobs: string;
     groupAdvanced: string;
+    groupDetailSetup: string;
+    groupDetailInfo: string;
+    groupDetailChat: string;
+    groupDetailExtend: string;
+    groupDetailSession: string;
+    groupDetailCode: string;
+    groupDetailJobs: string;
+    groupDetailAdvanced: string;
   };
   atMentions: {
     loading: string;
@@ -595,5 +616,27 @@ export interface TranslationSchema {
     labelReasoning: string;
     yankedToast: string;
     yankedToastFile: string;
+  };
+  mcpHealth: {
+    noData: string;
+    healthy: string;
+    slow: string;
+    verySlow: string;
+  };
+  denyContextInput: {
+    description: string;
+  };
+  cardStream: {
+    scrollAbove: string;
+    scrollAbovePlural: string;
+    scrollMore: string;
+    scrollPgUp: string;
+  };
+  slashArgPicker: {
+    noMatch: string;
+    keepTyping: string;
+    above: string;
+    below: string;
+    footer: string;
   };
 }

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -417,6 +417,16 @@ export const zhCN: TranslationSchema = {
     savedFooter: "[Enter] 退出",
     selectFooter: "[↑↓] 移动 · [Enter] 确认 · [Esc] 取消",
     stepCounter: "步骤 {step}/{total} · ",
+    exitHint: "/exit 中止",
+    apiKeyPlaceholder: "sk-...",
+    themeSampleReasoning: "推理中",
+  },
+  themePicker: {
+    header: "主题",
+    footer: "↑↓ 选择 · ⏎ 确认 · Esc 取消",
+    currentPref: "当前偏好",
+    activeNow: "当前生效",
+    autoDesc: "使用 REASONIX_THEME 或默认主题",
   },
   planFlow: {
     approveCardTitle: "确认计划",
@@ -480,6 +490,9 @@ export const zhCN: TranslationSchema = {
       counterDone: "{done}/{total} 已完成（{pct}%） · 共 {total} 步",
       counterDoneSingular: "{done}/{total} 已完成（{pct}%） · 共 {total} 步",
     },
+    reviseTitle: "修改计划",
+    reviseSteps: "{count} 个步骤",
+    reviseFooter: "↑↓ 焦点  ·  空格切换跳过  ·  k/j 移动  ·  ⏎ 确认  ·  Esc 取消",
   },
   app: {
     walkCancelledRemaining: "▸ 浏览已取消 — 还有 {count} 个待处理编辑块。",
@@ -640,6 +653,8 @@ export const zhCN: TranslationSchema = {
       loopStarted:
         '▸ 循环已启动 — 每 {duration} 重新提交 "{prompt}"。输入任何内容（或 /loop stop）取消。',
       keysNeedsTui: "/keys 需要 TUI 上下文（postKeys 已连接）。",
+      unknownCommand: "未知命令：/{cmd} — 你是不是想用 {list}？",
+      unknownCommandShort: "未知命令：/{cmd}  （试试 /help）",
     },
     admin: {
       doctorNeedsTui: "/doctor 需要 TUI 上下文（postDoctor 已连接）。",
@@ -920,6 +935,9 @@ export const zhCN: TranslationSchema = {
       unknownServer: '未知 MCP 服务器 "{name}"。已知：{list}。',
       noneList: "（无）",
       reconnectNoTui: "/mcp reconnect 需要交互式 TUI（postInfo 未连接）。",
+      liveTab: "已连接",
+      marketplaceTab: "市场",
+      tabHint: "按 tab 切换",
     },
     init: {
       codeOnly:
@@ -1083,6 +1101,14 @@ export const zhCN: TranslationSchema = {
     groupCode: "代码",
     groupJobs: "任务",
     groupAdvanced: "高级",
+    groupDetailSetup: "模型 + 成本",
+    groupDetailInfo: "当前状态",
+    groupDetailChat: "日常聊天操作",
+    groupDetailExtend: "MCP, 记忆, 技能",
+    groupDetailSession: "已保存的会话",
+    groupDetailCode: "编辑 + 计划 (代码模式)",
+    groupDetailJobs: "后台进程 (代码模式)",
+    groupDetailAdvanced: "高级或一次性设置",
   },
   atMentions: {
     loading: "加载中…",
@@ -1240,5 +1266,27 @@ export const zhCN: TranslationSchema = {
     labelReasoning: "推理",
     yankedToast: "▸ 已复制 {size} 字符到剪贴板 (osc52)",
     yankedToastFile: "▸ 已复制 {size} 字符 · 文件：{path}",
+  },
+  mcpHealth: {
+    noData: "无检查数据",
+    healthy: "正常 \u00b7 {ms}ms",
+    slow: "缓慢 \u00b7 {ms}ms",
+    verySlow: "非常慢 \u00b7 {ms}ms",
+  },
+  denyContextInput: {
+    description: "告诉模型你为什么拒绝了。模型下次会看到你的理由作为额外的上下文。",
+  },
+  cardStream: {
+    scrollAbove: " \u2191 {scroll}/{max} 行",
+    scrollAbovePlural: " \u2191 {scroll}/{max} 行",
+    scrollMore: " \u2014 还有 {remaining} 行",
+    scrollPgUp: " \u00b7 PgUp/\u6eda\u8f6e/\u2191",
+  },
+  slashArgPicker: {
+    noMatch: '\u6ca1\u6709\u5339\u914d "{partial}"',
+    keepTyping: " \u2014 \u7ee7\u7eed\u8f93\u5165\uff0c\u6216 Backspace \u4fee\u6539",
+    above: "   \u2191 \u8fd8\u6709 {hidden} \u4e2a",
+    below: "   \u2193 \u8fd8\u6709 {hidden} \u4e2a",
+    footer: "  \u2191\u2193 \u5bfc\u822a \u00b7 Tab/\u23ce \u9009\u62e9 \u00b7 Esc \u53d6\u6d88",
   },
 };


### PR DESCRIPTION
汉化了一批之前遗漏的用户界面：

**组件（11 个）：**
- `Setup.tsx` — 首次运行 API key 配置界面所有提示文字改用 `t("wizard.*")`
- `ThemePicker.tsx` — 主题选择器标题/底部提示/偏好标签改用 `t("themePicker.*")`
- `PlanReviseEditor.tsx` — 计划修改编辑器的标题/步骤数/操作提示改用 `t("planFlow.revise*")`
- `Wizard.tsx` — 主题预览 "Reasoning" → `t("wizard.themeSampleReasoning")`
- `McpHub.tsx` — MCP 标签页名称和切换提示
- `slash/dispatch.ts` — 未知命令错误提示
- `slash/handlers/basic.ts` — 移除硬编码 `GROUP_DETAIL`，改用 `t("slashSuggestions.groupDetail*")`；清理未使用的 `SLASH_GROUP_LABEL` 导入
- `DenyContextInput.tsx` — 拒绝原因输入处提示
- `mcp-health.ts` — MCP 健康状态标签
- `CardStream.tsx` — 滚动行数提示（含单复数拆分）
- `SlashArgPicker.tsx` — 斜杠参数选择器全部提示

**新增 i18n key（6 个 namespace）：**
- `mcpHealth` / `denyContextInput` / `cardStream` / `slashArgPicker` — 新命名空间
- `handlers.basic` + `handlers.mcp` + `slashSuggestions.groupDetail*` — 扩展已有命名空间
- `wizard` + `themePicker` + `planFlow` — 补充之前 PR 遗漏的 key

`npm run verify` — 160 files, 2528 passed, lint/typecheck/build 全过。