### PR TITLE
feat(dashboard): pin port via --dashboard-port flag and config

### DIFF
--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -361,6 +361,8 @@ export interface ChatOptions {
    * URL is visible in the status bar.
    */
   noDashboard?: boolean;
+  /** Pin the dashboard to a fixed port. `undefined` keeps ephemeral assignment. */
+  dashboardPort?: number;
   /**
    * Render into the terminal's alternate screen buffer. Default true —
    * alt-screen avoids the scrollback-mode resize/wrap ghost class. Pass
@@ -472,6 +474,7 @@ function Root({
         progressSink={progressSink}
         codeMode={appProps.codeMode}
         noDashboard={appProps.noDashboard}
+        dashboardPort={appProps.dashboardPort}
         mouse={appProps.mouse}
         onSwitchSession={setActiveSession}
       />

--- a/src/cli/commands/code.tsx
+++ b/src/cli/commands/code.tsx
@@ -58,6 +58,8 @@ export interface CodeOptions {
   budgetUsd?: number;
   /** Suppress the auto-launched embedded web dashboard. */
   noDashboard?: boolean;
+  /** Pin the dashboard to a fixed port. `undefined` keeps ephemeral assignment. */
+  dashboardPort?: number;
   /** Inline string appended to the code system prompt after the generated base prompt. */
   systemAppend?: string;
   /** Path to a UTF-8 text file whose contents are appended to the code system prompt. */
@@ -228,6 +230,7 @@ export async function codeCommand(opts: CodeOptions = {}): Promise<void> {
     forceResume: opts.forceResume,
     forceNew: opts.forceNew,
     noDashboard: opts.noDashboard,
+    dashboardPort: opts.dashboardPort,
     altScreen: opts.altScreen,
     mouse: opts.mouse,
   });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -46,6 +46,32 @@ function parseBudgetFlag(raw: number | undefined): number | undefined {
   return raw;
 }
 
+/** Lenient port parser — bad value warns + falls back to ephemeral, same shape as parseBudgetFlag. */
+function parseDashboardPortFlag(raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isInteger(n) || n < 1 || n > 65535) {
+    process.stderr.write(`${t("ui.dashboardPortInvalid", { value: raw })}\n`);
+    return undefined;
+  }
+  return n;
+}
+
+function resolveDashboardPort(
+  flagValue: number | undefined,
+  noConfig: boolean,
+): number | undefined {
+  if (flagValue !== undefined) return flagValue;
+  if (noConfig) return undefined;
+  const fromCfg = readConfig().dashboard?.port;
+  return typeof fromCfg === "number" &&
+    Number.isInteger(fromCfg) &&
+    fromCfg >= 1 &&
+    fromCfg <= 65535
+    ? fromCfg
+    : undefined;
+}
+
 const program = new Command();
 program
   .name("reasonix")
@@ -100,6 +126,7 @@ program
   .option("--transcript <path>", t("ui.transcriptHint"))
   .option("--budget <usd>", t("ui.budgetHint"), (v) => Number.parseFloat(v))
   .option("--no-dashboard", t("ui.noDashboard"))
+  .option("--dashboard-port <port>", t("ui.dashboardPortHint"))
   .option("--no-alt-screen", "keep chat output in shell scrollback (legacy mode, ghost-prone)")
   .option("--no-mouse", "disable SGR mouse tracking (keeps drag-select 100% native)")
   .option("--system-append <prompt>", t("ui.systemAppendHint"))
@@ -115,6 +142,7 @@ program
       forceNew: !!opts.new,
       budgetUsd: parseBudgetFlag(opts.budget),
       noDashboard: opts.dashboard === false,
+      dashboardPort: resolveDashboardPort(parseDashboardPortFlag(opts.dashboardPort), false),
       systemAppend: opts.systemAppend,
       systemAppendFile: opts.systemAppendFile,
       altScreen: opts.altScreen !== false,
@@ -144,6 +172,7 @@ program
   .option("--mcp-prefix <str>", t("ui.mcpPrefixHint"))
   .option("--no-config", t("ui.noConfigHint"))
   .option("--no-dashboard", t("ui.noDashboard"))
+  .option("--dashboard-port <port>", t("ui.dashboardPortHint"))
   .option("--no-alt-screen", "keep chat output in shell scrollback (legacy mode, ghost-prone)")
   .option("--no-mouse", "disable SGR mouse tracking (keeps drag-select 100% native)")
   .action(async (opts) => {
@@ -178,6 +207,10 @@ program
       forceResume: continueOpts.forceResume,
       forceNew: !!opts.new,
       noDashboard: opts.dashboard === false,
+      dashboardPort: resolveDashboardPort(
+        parseDashboardPortFlag(opts.dashboardPort),
+        opts.config === false,
+      ),
       altScreen: opts.altScreen !== false,
       mouse: opts.mouse !== false,
     });

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -248,6 +248,8 @@ export interface AppProps {
    * who don't want a localhost listener.
    */
   noDashboard?: boolean;
+  /** Pin the dashboard to a fixed port. `undefined` keeps ephemeral assignment. */
+  dashboardPort?: number;
   /** Mid-chat session swap — Root remounts App with the new session via key. */
   onSwitchSession?: (name: string | undefined) => void;
   /**
@@ -365,6 +367,7 @@ function AppInner({
   progressSink,
   codeMode,
   noDashboard,
+  dashboardPort,
   onSwitchSession,
   mouse = true,
   themeName,
@@ -1647,240 +1650,247 @@ function AppInner({
     if (dashboardStartingRef.current) return dashboardStartingRef.current;
     const startup = (async () => {
       const { startDashboardServer } = await import("../../server/index.js");
-      const handle = await startDashboardServer({
-        mode: "attached",
-        configPath: defaultConfigPath(),
-        usageLogPath: defaultUsageLogPath(),
-        loop,
-        tools,
-        mcpServers: liveMcpServers,
-        getCurrentCwd: () => (codeMode ? currentRootDirRef.current : undefined),
-        getEditMode: () => (codeMode ? editModeRef.current : undefined),
-        getPlanMode: () => planModeRef.current,
-        getPendingEditCount: () => pendingEdits.current.length,
-        getLatestVersion: () => latestVersionRef.current,
-        getSessionName: () => session ?? null,
-        setEditMode: (m: EditMode) => {
-          setEditMode(m);
-          editModeRef.current = m;
-          saveEditMode(m);
-          return m;
-        },
-        setPlanMode: (on: boolean) => {
-          if (codeMode) togglePlanMode(on);
-        },
-        applyPresetLive: (name: string) => {
-          const settings = resolvePreset(name as PresetName);
-          loop.configure({
-            model: settings.model,
-            autoEscalate: settings.autoEscalate,
-            reasoningEffort: settings.reasoningEffort,
-          });
-          agentStore.dispatch({ type: "session.model.change", model: settings.model });
-          const canonical: "auto" | "flash" | "pro" =
-            settings.model === "deepseek-v4-pro" ? "pro" : settings.autoEscalate ? "auto" : "flash";
-          setPreset(canonical);
-        },
-        applyEffortLive: (effort) => {
-          loop.configure({ reasoningEffort: effort });
-        },
-        applyModelLive: (model) => {
-          loop.configure({ model });
-          agentStore.dispatch({ type: "session.model.change", model });
-        },
-        getModels: () => modelsRef.current,
-        setProNextLive: (armed) => {
-          if (armed) loop.armProForNextTurn();
-          else loop.disarmPro();
-        },
-        setBudgetUsdLive: (usd) => {
-          loop.setBudget(usd);
-        },
-        getLoopRunStatus: () => getLoopStatus(),
-        startAutoLoop: (intervalMs, prompt) => startLoop(intervalMs, prompt),
-        stopAutoLoop: () => stopLoop(),
-        // ---------- Chat bridge ----------
-        getMessages: (): DashboardMessage[] =>
-          cardsToDashboardMessages(agentStore.getState().cards),
-        subscribeEvents: (handler) => {
-          eventSubscribersRef.current.add(handler);
-          return () => {
-            eventSubscribersRef.current.delete(handler);
-          };
-        },
-        submitPrompt: (text: string): SubmitResult => {
-          if (busyRef.current) {
-            return { accepted: false, reason: "loop is busy with a turn" };
-          }
-          const fn = handleSubmitRef.current;
-          if (!fn) return { accepted: false, reason: "TUI not ready" };
-          // Fire-and-forget — handleSubmit drives the loop event stream
-          // which the web sees via SSE. We don't await it here because
-          // a turn can take minutes; the HTTP request would time out.
-          fn(text).catch(() => undefined);
-          return { accepted: true };
-        },
-        abortTurn: () => {
-          if (busyRef.current) loop.abort();
-        },
-        isBusy: () => busyRef.current,
-        getStats: () => {
-          // Pull from the loop's live aggregator (same source the TUI's
-          // StatsPanel reads). `balance` comes from useSessionInfo via a
-          // ref-mirror so this callback stays cheap.
-          const s = loop.stats.summary();
-          const ctxCap = DEEPSEEK_CONTEXT_TOKENS[loop.model] ?? DEFAULT_CONTEXT_TOKENS;
-          return {
-            turns: s.turns,
-            totalCostUsd: s.totalCostUsd,
-            lastTurnCostUsd: s.lastTurnCostUsd,
-            totalInputCostUsd: s.totalInputCostUsd,
-            totalOutputCostUsd: s.totalOutputCostUsd,
-            cacheHitRatio: s.cacheHitRatio,
-            lastPromptTokens: s.lastPromptTokens,
-            contextCapTokens: ctxCap,
-            // useSessionInfo's Balance is a flat { currency, total }; the
-            // dashboard wire shape is the richer DeepSeek BalanceInfo
-            // array (granted / topped_up split). Convert as a single-
-            // entry array so the SPA always reads `balance[0]` shape.
-            balance: balanceRef.current
-              ? [
-                  {
-                    currency: balanceRef.current.currency,
-                    total_balance: String(balanceRef.current.total),
-                  },
-                ]
-              : null,
-          };
-        },
-        // ---------- Modal mirroring ----------
-        getActiveModal: (): ActiveModal | null => {
-          // Probe the live state via refs in priority order — only one
-          // modal can be up at a time per App invariant.
-          const ps = pendingShell;
-          if (ps) {
-            return {
-              kind: "shell",
-              command: ps.command,
-              allowPrefix: derivePrefix(ps.command),
-              shellKind: ps.kind,
+      const handle = await startDashboardServer(
+        {
+          mode: "attached",
+          configPath: defaultConfigPath(),
+          usageLogPath: defaultUsageLogPath(),
+          loop,
+          tools,
+          mcpServers: liveMcpServers,
+          getCurrentCwd: () => (codeMode ? currentRootDirRef.current : undefined),
+          getEditMode: () => (codeMode ? editModeRef.current : undefined),
+          getPlanMode: () => planModeRef.current,
+          getPendingEditCount: () => pendingEdits.current.length,
+          getLatestVersion: () => latestVersionRef.current,
+          getSessionName: () => session ?? null,
+          setEditMode: (m: EditMode) => {
+            setEditMode(m);
+            editModeRef.current = m;
+            saveEditMode(m);
+            return m;
+          },
+          setPlanMode: (on: boolean) => {
+            if (codeMode) togglePlanMode(on);
+          },
+          applyPresetLive: (name: string) => {
+            const settings = resolvePreset(name as PresetName);
+            loop.configure({
+              model: settings.model,
+              autoEscalate: settings.autoEscalate,
+              reasoningEffort: settings.reasoningEffort,
+            });
+            agentStore.dispatch({ type: "session.model.change", model: settings.model });
+            const canonical: "auto" | "flash" | "pro" =
+              settings.model === "deepseek-v4-pro"
+                ? "pro"
+                : settings.autoEscalate
+                  ? "auto"
+                  : "flash";
+            setPreset(canonical);
+          },
+          applyEffortLive: (effort) => {
+            loop.configure({ reasoningEffort: effort });
+          },
+          applyModelLive: (model) => {
+            loop.configure({ model });
+            agentStore.dispatch({ type: "session.model.change", model });
+          },
+          getModels: () => modelsRef.current,
+          setProNextLive: (armed) => {
+            if (armed) loop.armProForNextTurn();
+            else loop.disarmPro();
+          },
+          setBudgetUsdLive: (usd) => {
+            loop.setBudget(usd);
+          },
+          getLoopRunStatus: () => getLoopStatus(),
+          startAutoLoop: (intervalMs, prompt) => startLoop(intervalMs, prompt),
+          stopAutoLoop: () => stopLoop(),
+          // ---------- Chat bridge ----------
+          getMessages: (): DashboardMessage[] =>
+            cardsToDashboardMessages(agentStore.getState().cards),
+          subscribeEvents: (handler) => {
+            eventSubscribersRef.current.add(handler);
+            return () => {
+              eventSubscribersRef.current.delete(handler);
             };
-          }
-          const pc = pendingChoice;
-          if (pc) {
-            return {
-              kind: "choice",
-              question: pc.question,
-              options: pc.options,
-              allowCustom: pc.allowCustom,
-            };
-          }
-          if (pendingPlanRef.current) {
-            return { kind: "plan", body: pendingPlanRef.current };
-          }
-          const er = pendingEditReview;
-          if (er) {
-            return {
-              kind: "edit-review",
-              path: er.path,
-              search: er.search ?? "",
-              replace: er.replace ?? "",
-              preview: (er.search || er.replace || "").split("\n").slice(0, 12).join("\n"),
-              total: pendingEdits.current.length,
-              remaining: pendingEdits.current.length,
-            };
-          }
-          if (pendingRevision) {
-            return {
-              kind: "revision",
-              reason: pendingRevision.reason,
-              remainingSteps: pendingRevision.remainingSteps.map((s) => ({
-                id: s.id,
-                title: s.title,
-                action: s.action,
-                ...(s.risk ? { risk: s.risk } : {}),
-              })),
-              ...(pendingRevision.summary ? { summary: pendingRevision.summary } : {}),
-            };
-          }
-          const picker = activePickerSnapshotRef.current;
-          if (picker) {
-            return { kind: "picker", ...picker };
-          }
-          const viewer = activeViewerSnapshotRef.current;
-          if (viewer) {
-            return { kind: "viewer", ...viewer };
-          }
-          return null;
-        },
-        resolveShellConfirm: (choice) => {
-          const fn = handleShellConfirmRef.current;
-          if (fn) Promise.resolve(fn(choice)).catch(() => undefined);
-        },
-        resolveChoiceConfirm: (choice) => {
-          const fn = handleChoiceConfirmRef.current;
-          if (fn) fn(choice).catch(() => undefined);
-        },
-        resolvePlanConfirm: (choice, text) => {
-          if (choice === "cancel") {
-            handlePlanConfirmRef.current("cancel").catch(() => undefined);
-            return;
-          }
-          const plan = pendingPlanRef.current ?? "";
-          // Bypass the picker → input two-step on web. The override
-          // form of handleStagedInputSubmit takes the plan + mode
-          // directly; behaviour matches the TUI's "user typed feedback +
-          // pressed Enter" path.
-          handleStagedInputSubmitRef
-            .current(text ?? "", { plan, mode: choice })
-            .catch(() => undefined);
-        },
-        resolveEditReview: (choice) => {
-          const resolve = editReviewResolveRef.current;
-          if (resolve) {
-            editReviewResolveRef.current = null;
-            setPendingEditReview(null);
-            resolve({ choice, denyContext: undefined });
-          }
-        },
-        resolveCheckpointConfirm: (choice, text) => {
-          // Web's "revise" path sends feedback in one shot; we hand the
-          // current pending checkpoint to the submit handler directly,
-          // skipping the TUI's staged-input two-step. continue/stop fall
-          // through to the regular picker handler.
-          if (choice === "revise" && typeof text === "string") {
-            const snap = pendingCheckpoint;
-            setPendingCheckpoint(null);
-            if (!snap) return;
-            Promise.resolve(handleCheckpointReviseSubmitRef.current(text, snap)).catch(
-              () => undefined,
-            );
-            return;
-          }
-          Promise.resolve(handleCheckpointConfirmRef.current(choice)).catch(() => undefined);
-        },
-        resolveReviseConfirm: (choice) => {
-          Promise.resolve(handleReviseConfirmRef.current(choice)).catch(() => undefined);
-        },
-        resolvePicker: (resolution) => {
-          const fn = activePickerResolverRef.current;
-          if (fn) Promise.resolve(fn(resolution)).catch(() => undefined);
-        },
-        resolveViewer: () => {
-          const fn = activeViewerResolverRef.current;
-          if (fn) Promise.resolve(fn()).catch(() => undefined);
-        },
-        // ---------- v0.14 mutation surface ----------
-        reloadHooks: () => reloadHooks(codeMode ? currentRootDirRef.current : undefined),
-        addToolToPrefix: (spec) => loop.prefix.addTool(spec),
-        reloadMcp: mcpRuntime
-          ? async () => {
-              const r = await mcpRuntime.reloadFromConfig(loop);
-              setLiveMcpServers(r.summaries);
-              return r.summaries.length;
+          },
+          submitPrompt: (text: string): SubmitResult => {
+            if (busyRef.current) {
+              return { accepted: false, reason: "loop is busy with a turn" };
             }
-          : undefined,
-      });
+            const fn = handleSubmitRef.current;
+            if (!fn) return { accepted: false, reason: "TUI not ready" };
+            // Fire-and-forget — handleSubmit drives the loop event stream
+            // which the web sees via SSE. We don't await it here because
+            // a turn can take minutes; the HTTP request would time out.
+            fn(text).catch(() => undefined);
+            return { accepted: true };
+          },
+          abortTurn: () => {
+            if (busyRef.current) loop.abort();
+          },
+          isBusy: () => busyRef.current,
+          getStats: () => {
+            // Pull from the loop's live aggregator (same source the TUI's
+            // StatsPanel reads). `balance` comes from useSessionInfo via a
+            // ref-mirror so this callback stays cheap.
+            const s = loop.stats.summary();
+            const ctxCap = DEEPSEEK_CONTEXT_TOKENS[loop.model] ?? DEFAULT_CONTEXT_TOKENS;
+            return {
+              turns: s.turns,
+              totalCostUsd: s.totalCostUsd,
+              lastTurnCostUsd: s.lastTurnCostUsd,
+              totalInputCostUsd: s.totalInputCostUsd,
+              totalOutputCostUsd: s.totalOutputCostUsd,
+              cacheHitRatio: s.cacheHitRatio,
+              lastPromptTokens: s.lastPromptTokens,
+              contextCapTokens: ctxCap,
+              // useSessionInfo's Balance is a flat { currency, total }; the
+              // dashboard wire shape is the richer DeepSeek BalanceInfo
+              // array (granted / topped_up split). Convert as a single-
+              // entry array so the SPA always reads `balance[0]` shape.
+              balance: balanceRef.current
+                ? [
+                    {
+                      currency: balanceRef.current.currency,
+                      total_balance: String(balanceRef.current.total),
+                    },
+                  ]
+                : null,
+            };
+          },
+          // ---------- Modal mirroring ----------
+          getActiveModal: (): ActiveModal | null => {
+            // Probe the live state via refs in priority order — only one
+            // modal can be up at a time per App invariant.
+            const ps = pendingShell;
+            if (ps) {
+              return {
+                kind: "shell",
+                command: ps.command,
+                allowPrefix: derivePrefix(ps.command),
+                shellKind: ps.kind,
+              };
+            }
+            const pc = pendingChoice;
+            if (pc) {
+              return {
+                kind: "choice",
+                question: pc.question,
+                options: pc.options,
+                allowCustom: pc.allowCustom,
+              };
+            }
+            if (pendingPlanRef.current) {
+              return { kind: "plan", body: pendingPlanRef.current };
+            }
+            const er = pendingEditReview;
+            if (er) {
+              return {
+                kind: "edit-review",
+                path: er.path,
+                search: er.search ?? "",
+                replace: er.replace ?? "",
+                preview: (er.search || er.replace || "").split("\n").slice(0, 12).join("\n"),
+                total: pendingEdits.current.length,
+                remaining: pendingEdits.current.length,
+              };
+            }
+            if (pendingRevision) {
+              return {
+                kind: "revision",
+                reason: pendingRevision.reason,
+                remainingSteps: pendingRevision.remainingSteps.map((s) => ({
+                  id: s.id,
+                  title: s.title,
+                  action: s.action,
+                  ...(s.risk ? { risk: s.risk } : {}),
+                })),
+                ...(pendingRevision.summary ? { summary: pendingRevision.summary } : {}),
+              };
+            }
+            const picker = activePickerSnapshotRef.current;
+            if (picker) {
+              return { kind: "picker", ...picker };
+            }
+            const viewer = activeViewerSnapshotRef.current;
+            if (viewer) {
+              return { kind: "viewer", ...viewer };
+            }
+            return null;
+          },
+          resolveShellConfirm: (choice) => {
+            const fn = handleShellConfirmRef.current;
+            if (fn) Promise.resolve(fn(choice)).catch(() => undefined);
+          },
+          resolveChoiceConfirm: (choice) => {
+            const fn = handleChoiceConfirmRef.current;
+            if (fn) fn(choice).catch(() => undefined);
+          },
+          resolvePlanConfirm: (choice, text) => {
+            if (choice === "cancel") {
+              handlePlanConfirmRef.current("cancel").catch(() => undefined);
+              return;
+            }
+            const plan = pendingPlanRef.current ?? "";
+            // Bypass the picker → input two-step on web. The override
+            // form of handleStagedInputSubmit takes the plan + mode
+            // directly; behaviour matches the TUI's "user typed feedback +
+            // pressed Enter" path.
+            handleStagedInputSubmitRef
+              .current(text ?? "", { plan, mode: choice })
+              .catch(() => undefined);
+          },
+          resolveEditReview: (choice) => {
+            const resolve = editReviewResolveRef.current;
+            if (resolve) {
+              editReviewResolveRef.current = null;
+              setPendingEditReview(null);
+              resolve({ choice, denyContext: undefined });
+            }
+          },
+          resolveCheckpointConfirm: (choice, text) => {
+            // Web's "revise" path sends feedback in one shot; we hand the
+            // current pending checkpoint to the submit handler directly,
+            // skipping the TUI's staged-input two-step. continue/stop fall
+            // through to the regular picker handler.
+            if (choice === "revise" && typeof text === "string") {
+              const snap = pendingCheckpoint;
+              setPendingCheckpoint(null);
+              if (!snap) return;
+              Promise.resolve(handleCheckpointReviseSubmitRef.current(text, snap)).catch(
+                () => undefined,
+              );
+              return;
+            }
+            Promise.resolve(handleCheckpointConfirmRef.current(choice)).catch(() => undefined);
+          },
+          resolveReviseConfirm: (choice) => {
+            Promise.resolve(handleReviseConfirmRef.current(choice)).catch(() => undefined);
+          },
+          resolvePicker: (resolution) => {
+            const fn = activePickerResolverRef.current;
+            if (fn) Promise.resolve(fn(resolution)).catch(() => undefined);
+          },
+          resolveViewer: () => {
+            const fn = activeViewerResolverRef.current;
+            if (fn) Promise.resolve(fn()).catch(() => undefined);
+          },
+          // ---------- v0.14 mutation surface ----------
+          reloadHooks: () => reloadHooks(codeMode ? currentRootDirRef.current : undefined),
+          addToolToPrefix: (spec) => loop.prefix.addTool(spec),
+          reloadMcp: mcpRuntime
+            ? async () => {
+                const r = await mcpRuntime.reloadFromConfig(loop);
+                setLiveMcpServers(r.summaries);
+                return r.summaries.length;
+              }
+            : undefined,
+        },
+        { port: dashboardPort },
+      );
       dashboardRef.current = handle;
       setDashboardUrlState(handle.url);
       return handle.url;
@@ -1914,6 +1924,7 @@ function AppInner({
     currentRootDirRef,
     reloadHooks,
     setPreset,
+    dashboardPort,
   ]);
 
   const stopDashboard = useCallback(async (): Promise<void> => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -95,6 +95,10 @@ export interface ReasonixConfig {
   webSearchEngine?: "mojeek" | "searxng";
   /** Base URL for SearXNG instance (default http://localhost:8080). */
   webSearchEndpoint?: string;
+  dashboard?: {
+    /** Pin the embedded dashboard to a fixed port — required for stable SSH tunnels. 0/absent → ephemeral. */
+    port?: number;
+  };
   projects?: {
     [absoluteRootDir: string]: {
       shellAllowed?: string[];

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -45,6 +45,10 @@ export const EN: TranslationSchema = {
     applied: "applied",
     rejected: "rejected",
     noDashboard: "Suppress the auto-launched embedded web dashboard.",
+    dashboardPortHint:
+      "Pin the dashboard to a fixed port (1–65535). Stable across restarts — required for SSH tunnels. Default: ephemeral.",
+    dashboardPortInvalid:
+      "▲ ignoring --dashboard-port={value} (must be an integer 1–65535) — falling back to ephemeral",
     dashboardAutoStartFailed:
       "▲ dashboard auto-start failed ({reason}) — try /dashboard, or pass --no-dashboard to silence",
     systemAppendHint:

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -45,6 +45,8 @@ export interface TranslationSchema {
     applied: string;
     rejected: string;
     noDashboard: string;
+    dashboardPortHint: string;
+    dashboardPortInvalid: string;
     dashboardAutoStartFailed: string;
     systemAppendHint: string;
     systemAppendFileHint: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -45,6 +45,10 @@ export const zhCN: TranslationSchema = {
     applied: "已应用",
     rejected: "已拒绝",
     noDashboard: "禁止自动启动嵌入式 Web 仪表板。",
+    dashboardPortHint:
+      "将仪表板绑定到固定端口 (1–65535)。重启后保持稳定 — SSH 隧道访问必需。默认为临时端口。",
+    dashboardPortInvalid:
+      "▲ 忽略 --dashboard-port={value} (必须为 1–65535 之间的整数) — 回退到临时端口",
     dashboardAutoStartFailed:
       "▲ 仪表板自动启动失败 ({reason}) — 尝试 /dashboard，或传递 --no-dashboard 以静默",
     systemAppendHint: "追加指令到代码系统提示词。不替换默认提示词 — 在其后添加。",

--- a/tests/dashboard-port-pin.test.ts
+++ b/tests/dashboard-port-pin.test.ts
@@ -1,0 +1,73 @@
+/** `startDashboardServer({ port })` — pinned port binds and rejects EADDRINUSE. */
+
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { type DashboardServerHandle, startDashboardServer } from "../src/server/index.js";
+
+const TOKEN = "test-token";
+
+function ctx(dir: string) {
+  return {
+    mode: "standalone" as const,
+    configPath: join(dir, "config.json"),
+    usageLogPath: join(dir, "usage.jsonl"),
+  };
+}
+
+/** Pick a likely-free port by binding a throwaway server with port 0 and reading what the OS gave us. */
+async function reserveEphemeralPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const probe = createServer();
+    probe.once("error", reject);
+    probe.listen(0, "127.0.0.1", () => {
+      const addr = probe.address();
+      if (!addr || typeof addr === "string") {
+        probe.close();
+        reject(new Error("no address"));
+        return;
+      }
+      const port = addr.port;
+      probe.close(() => resolve(port));
+    });
+  });
+}
+
+describe("startDashboardServer port pinning", () => {
+  let dir: string;
+  let handle: DashboardServerHandle | undefined;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "reasonix-dashport-"));
+  });
+
+  afterEach(async () => {
+    await handle?.close();
+    handle = undefined;
+    if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("binds to the requested port when opts.port is set", async () => {
+    const port = await reserveEphemeralPort();
+    handle = await startDashboardServer(ctx(dir), { token: TOKEN, port });
+    expect(handle.port).toBe(port);
+    expect(handle.url).toContain(`:${port}/`);
+  });
+
+  it("defaults to an ephemeral port when opts.port is absent", async () => {
+    handle = await startDashboardServer(ctx(dir), { token: TOKEN });
+    expect(handle.port).toBeGreaterThan(0);
+    expect(handle.port).toBeLessThan(65536);
+  });
+
+  it("rejects when the requested port is already bound (EADDRINUSE)", async () => {
+    const port = await reserveEphemeralPort();
+    handle = await startDashboardServer(ctx(dir), { token: TOKEN, port });
+
+    await expect(startDashboardServer(ctx(dir), { token: TOKEN, port })).rejects.toThrow(
+      /EADDRINUSE/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Add `--dashboard-port <port>` on `reasonix chat` and `reasonix code`, plus a `dashboard.port` config key.
- Resolution: flag > `config.dashboard.port` > ephemeral (current default).
- Out-of-range values (`<1`, `>65535`, non-integer) warn and fall back to ephemeral.
- Pinned-port `EADDRINUSE` surfaces through the existing dashboard auto-start failure toast — no silent fallback to a random port (would defeat the point of pinning for SSH tunnels).
- Host binding stays `127.0.0.1`; no `--dashboard-host` flag. SSH tunnel (`ssh -L 9876:127.0.0.1:9876 host`) is the supported remote workflow, and the dashboard is intentionally loopback-only in production.

## Test plan

- [x] `tests/dashboard-port-pin.test.ts` — pinned port binds at the requested value, ephemeral default still works, second bind on same port rejects with `EADDRINUSE`.
- [x] `npm run verify` green (2526 passed, 2 skipped).

Closes #624
