### PR TITLE
feat(mcp): per-server env config via mcpEnv key

### DIFF
--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -2,6 +2,7 @@ import { render } from "ink";
 import React, { useState } from "react";
 import {
   loadApiKey,
+  mcpEnvFor,
   readConfig,
   searchEnabled,
   webSearchEndpoint,
@@ -14,10 +15,8 @@ import { type InspectionReport, inspectMcpServer } from "../../mcp/inspect.js";
 import { preflightStdioSpec } from "../../mcp/preflight.js";
 import { type McpClientHost, bridgeMcpTools } from "../../mcp/registry.js";
 import { parseMcpSpec } from "../../mcp/spec.js";
-import { SseTransport } from "../../mcp/sse.js";
-import { type McpTransport, StdioTransport } from "../../mcp/stdio.js";
-import { StreamableHttpTransport } from "../../mcp/streamable-http.js";
 import { buildMcpServerSummary } from "../../mcp/summary.js";
+import { buildTransportFromSpec } from "../../mcp/transport-from-spec.js";
 import {
   deleteSession,
   listSessionsForWorkspace,
@@ -159,12 +158,7 @@ function createMcpRuntime(ctx: RuntimeContext): McpRuntime {
           ? (ctx.getMcpPrefix() as string)
           : "";
       if (spec.transport === "stdio") preflightStdioSpec(spec);
-      const transport: McpTransport =
-        spec.transport === "sse"
-          ? new SseTransport({ url: spec.url })
-          : spec.transport === "streamable-http"
-            ? new StreamableHttpTransport({ url: spec.url })
-            : new StdioTransport({ command: spec.command, args: spec.args });
+      const transport = buildTransportFromSpec(spec, { env: mcpEnvFor(spec.name, readConfig()) });
       mcp = new McpClient({ transport });
       await mcp.initialize();
       const host: McpClientHost = { client: mcp };

--- a/src/cli/commands/mcp-inspect.ts
+++ b/src/cli/commands/mcp-inspect.ts
@@ -1,11 +1,10 @@
+import { mcpEnvFor, readConfig } from "../../config.js";
 import { McpClient } from "../../mcp/client.js";
 import { inspectMcpServer } from "../../mcp/inspect.js";
 import type { InspectionReport } from "../../mcp/inspect.js";
 import { preflightStdioSpec } from "../../mcp/preflight.js";
 import { parseMcpSpec } from "../../mcp/spec.js";
-import { SseTransport } from "../../mcp/sse.js";
-import { type McpTransport, StdioTransport } from "../../mcp/stdio.js";
-import { StreamableHttpTransport } from "../../mcp/streamable-http.js";
+import { buildTransportFromSpec } from "../../mcp/transport-from-spec.js";
 
 export interface McpInspectOptions {
   /** The raw --mcp spec string (e.g. `fs=npx -y @modelcontextprotocol/server-filesystem .`). */
@@ -17,12 +16,7 @@ export interface McpInspectOptions {
 export async function mcpInspectCommand(opts: McpInspectOptions): Promise<void> {
   const spec = parseMcpSpec(opts.spec);
   if (spec.transport === "stdio") preflightStdioSpec(spec);
-  const transport: McpTransport =
-    spec.transport === "sse"
-      ? new SseTransport({ url: spec.url })
-      : spec.transport === "streamable-http"
-        ? new StreamableHttpTransport({ url: spec.url })
-        : new StdioTransport({ command: spec.command, args: spec.args });
+  const transport = buildTransportFromSpec(spec, { env: mcpEnvFor(spec.name, readConfig()) });
   const client = new McpClient({ transport });
   try {
     await client.initialize();

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -1,4 +1,4 @@
-import { readConfig, writeConfig } from "../../config.js";
+import { defaultConfigPath, readConfig, writeConfig } from "../../config.js";
 import { MCP_CATALOG, mcpCommandFor } from "../../mcp/catalog.js";
 import {
   type FetchProgress,
@@ -303,13 +303,22 @@ export async function mcpInstallCommand(name: string, opts: McpInstallOptions = 
 
   console.log(`Installed: ${entry.name}`);
   console.log(`  spec:    ${spec}`);
+  const installedName = parseInstalledName(spec);
   if (entry.install.requiredEnv?.length) {
+    console.log(`  needs:   ${entry.install.requiredEnv.join(", ")}`);
+    console.log("           Either export these before launching, or add them to config:");
+    console.log(`             mcpEnv.${installedName ?? entry.name} = { ... }`);
     console.log(
-      `  needs:   ${entry.install.requiredEnv.join(", ")}  (set these in your env before next chat)`,
+      `           (edit ${defaultConfigPath()} — values merge over process.env at spawn)`,
     );
   }
   console.log("");
   console.log(
     "Use it:  reasonix chat   (or `reasonix code`) — the server will be bridged automatically.",
   );
+}
+
+function parseInstalledName(spec: string): string | null {
+  const match = /^([a-zA-Z_][a-zA-Z0-9_-]*)=/.exec(spec);
+  return match ? match[1]! : null;
 }

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -6,6 +6,7 @@ import {
   isPlausibleKey,
   loadApiKey,
   loadBaseUrl,
+  mcpEnvFor,
   readConfig,
   saveApiKey,
 } from "../../config.js";
@@ -15,9 +16,7 @@ import { McpClient } from "../../mcp/client.js";
 import { preflightStdioSpec } from "../../mcp/preflight.js";
 import { bridgeMcpTools } from "../../mcp/registry.js";
 import { parseMcpSpec } from "../../mcp/spec.js";
-import { SseTransport } from "../../mcp/sse.js";
-import { type McpTransport, StdioTransport } from "../../mcp/stdio.js";
-import { StreamableHttpTransport } from "../../mcp/streamable-http.js";
+import { buildTransportFromSpec } from "../../mcp/transport-from-spec.js";
 import { appendUsage } from "../../telemetry/usage.js";
 import { ToolRegistry } from "../../tools.js";
 import { openTranscriptFile, recordFromLoopEvent, writeRecord } from "../../transcript/log.js";
@@ -102,12 +101,9 @@ export async function runCommand(opts: RunOptions): Promise<void> {
             ? opts.mcpPrefix
             : "";
         if (spec.transport === "stdio") preflightStdioSpec(spec);
-        const transport: McpTransport =
-          spec.transport === "sse"
-            ? new SseTransport({ url: spec.url })
-            : spec.transport === "streamable-http"
-              ? new StreamableHttpTransport({ url: spec.url })
-              : new StdioTransport({ command: spec.command, args: spec.args });
+        const transport = buildTransportFromSpec(spec, {
+          env: mcpEnvFor(spec.name, readConfig()),
+        });
         mcp = new McpClient({ transport });
         await mcp.initialize();
         const bridge = await bridgeMcpTools(mcp, {

--- a/src/cli/ui/mcp-reconnect-kickoff.ts
+++ b/src/cli/ui/mcp-reconnect-kickoff.ts
@@ -1,6 +1,8 @@
 /** Shared async-fire-and-forget reconnect trigger — called by both `/mcp reconnect` and the McpBrowser `r` keybind. */
 
+import { mcpEnvFor, readConfig } from "../../config.js";
 import { reconnectMcpServer } from "../../mcp/reconnect.js";
+import { parseMcpSpec } from "../../mcp/spec.js";
 import type { McpTool } from "../../mcp/types.js";
 import { formatMcpLifecycleEvent } from "./mcp-lifecycle.js";
 import type { McpServerSummary } from "./slash/types.js";
@@ -23,11 +25,19 @@ export function kickOffMcpReconnect(
   let liveTarget = target;
   void (async () => {
     try {
+      const env = (() => {
+        try {
+          return mcpEnvFor(parseMcpSpec(liveTarget.spec).name, readConfig());
+        } catch {
+          return undefined;
+        }
+      })();
       const result = await reconnectMcpServer({
         host: liveTarget.host,
         spec: liveTarget.spec,
         beforeTools,
         accept,
+        env,
       });
       if (result.ok) {
         if (result.kind === "append" && applyAppend) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -88,6 +88,8 @@ export interface ReasonixConfig {
   mcp?: string[];
   /** Names of servers in `mcp` to skip on bridge — see `/mcp disable <name>`. */
   mcpDisabled?: string[];
+  /** Env overlay per MCP server name (matches the `name=` prefix of the spec). Stdio transports merge this over process.env; SSE/HTTP ignore it. */
+  mcpEnv?: Record<string, Record<string, string>>;
   session?: string | null;
   setupCompleted?: boolean;
   search?: boolean;
@@ -140,6 +142,21 @@ export function writeConfig(cfg: ReasonixConfig, path: string = defaultConfigPat
 /** Resolve the language from config file. */
 export function loadLanguage(path: string = defaultConfigPath()): LanguageCode | undefined {
   return readConfig(path).lang;
+}
+
+export function mcpEnvFor(
+  serverName: string | null | undefined,
+  cfg: ReasonixConfig,
+): Record<string, string> | undefined {
+  if (!serverName) return undefined;
+  const entry = cfg.mcpEnv?.[serverName];
+  if (!entry) return undefined;
+  // Coerce to string and drop empty values — JSON config could be sloppy.
+  const filtered: Record<string, string> = {};
+  for (const [k, v] of Object.entries(entry)) {
+    if (typeof v === "string" && v.length > 0) filtered[k] = v;
+  }
+  return Object.keys(filtered).length > 0 ? filtered : undefined;
 }
 
 /** Persist the language so it survives a relaunch. */

--- a/src/mcp/reconnect.ts
+++ b/src/mcp/reconnect.ts
@@ -4,9 +4,7 @@ import { McpClient } from "./client.js";
 import { classifyToolListDrift } from "./drift.js";
 import type { McpClientHost } from "./registry.js";
 import { type McpSpec, parseMcpSpec } from "./spec.js";
-import { SseTransport } from "./sse.js";
-import { type McpTransport, StdioTransport } from "./stdio.js";
-import { StreamableHttpTransport } from "./streamable-http.js";
+import { buildTransportFromSpec } from "./transport-from-spec.js";
 import type { McpTool } from "./types.js";
 
 export interface ReconnectArgs {
@@ -18,6 +16,8 @@ export interface ReconnectArgs {
   beforeTools: readonly McpTool[];
   /** Drift kinds the caller is willing to accept. Default: ["identity"]. */
   accept?: ReadonlyArray<"identity" | "append">;
+  /** Stdio env overlay — same lookup that produced the live client's env. */
+  env?: Record<string, string>;
 }
 
 export type ReconnectResult =
@@ -56,12 +56,7 @@ export async function reconnectMcpServer(args: ReconnectArgs): Promise<Reconnect
       ms: Date.now() - t0,
     };
   }
-  const transport: McpTransport =
-    parsed.transport === "sse"
-      ? new SseTransport({ url: parsed.url })
-      : parsed.transport === "streamable-http"
-        ? new StreamableHttpTransport({ url: parsed.url })
-        : new StdioTransport({ command: parsed.command, args: parsed.args });
+  const transport = buildTransportFromSpec(parsed, { env: args.env });
   const next = new McpClient({ transport });
   try {
     await next.initialize();

--- a/src/mcp/transport-from-spec.ts
+++ b/src/mcp/transport-from-spec.ts
@@ -1,0 +1,18 @@
+import type { McpSpec } from "./spec.js";
+import { SseTransport } from "./sse.js";
+import { type McpTransport, StdioTransport } from "./stdio.js";
+import { StreamableHttpTransport } from "./streamable-http.js";
+
+export interface BuildTransportOptions {
+  /** Stdio-only env overlay — merged over process.env. SSE/Streamable-HTTP ignore it. */
+  env?: Record<string, string>;
+}
+
+export function buildTransportFromSpec(
+  spec: McpSpec,
+  opts: BuildTransportOptions = {},
+): McpTransport {
+  if (spec.transport === "sse") return new SseTransport({ url: spec.url });
+  if (spec.transport === "streamable-http") return new StreamableHttpTransport({ url: spec.url });
+  return new StdioTransport({ command: spec.command, args: spec.args, env: opts.env });
+}

--- a/tests/mcp-env-config.test.ts
+++ b/tests/mcp-env-config.test.ts
@@ -1,0 +1,97 @@
+/** `mcpEnvFor` lookup + `buildTransportFromSpec` transport selection — issue #376 plumbing. */
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { type ReasonixConfig, mcpEnvFor } from "../src/config.js";
+import { parseMcpSpec } from "../src/mcp/spec.js";
+import { SseTransport } from "../src/mcp/sse.js";
+import { StdioTransport } from "../src/mcp/stdio.js";
+import { StreamableHttpTransport } from "../src/mcp/streamable-http.js";
+import { buildTransportFromSpec } from "../src/mcp/transport-from-spec.js";
+
+describe("mcpEnvFor", () => {
+  it("returns the env map for a configured server name", () => {
+    const cfg: ReasonixConfig = {
+      mcpEnv: { github: { GITHUB_PERSONAL_ACCESS_TOKEN: "ghp_abc" } },
+    };
+    expect(mcpEnvFor("github", cfg)).toEqual({ GITHUB_PERSONAL_ACCESS_TOKEN: "ghp_abc" });
+  });
+
+  it("returns undefined when the server name is null (anonymous spec)", () => {
+    const cfg: ReasonixConfig = {
+      mcpEnv: { github: { GITHUB_PERSONAL_ACCESS_TOKEN: "ghp_abc" } },
+    };
+    expect(mcpEnvFor(null, cfg)).toBeUndefined();
+    expect(mcpEnvFor(undefined, cfg)).toBeUndefined();
+  });
+
+  it("returns undefined when no entry exists for the name", () => {
+    const cfg: ReasonixConfig = {
+      mcpEnv: { github: { GITHUB_PERSONAL_ACCESS_TOKEN: "ghp_abc" } },
+    };
+    expect(mcpEnvFor("filesystem", cfg)).toBeUndefined();
+  });
+
+  it("returns undefined when the config has no mcpEnv at all", () => {
+    expect(mcpEnvFor("github", {})).toBeUndefined();
+  });
+
+  it("drops empty-string values so blanks in config don't blank out process.env", () => {
+    const cfg: ReasonixConfig = {
+      mcpEnv: { github: { TOKEN: "real", LEFT_EMPTY: "" } },
+    };
+    expect(mcpEnvFor("github", cfg)).toEqual({ TOKEN: "real" });
+  });
+
+  it("returns undefined when every value is empty (no real overlay to apply)", () => {
+    const cfg: ReasonixConfig = { mcpEnv: { github: { A: "", B: "" } } };
+    expect(mcpEnvFor("github", cfg)).toBeUndefined();
+  });
+});
+
+describe("buildTransportFromSpec", () => {
+  it("returns an SseTransport for `http://…` specs", () => {
+    const spec = parseMcpSpec("svc=http://localhost:1234/sse");
+    expect(buildTransportFromSpec(spec)).toBeInstanceOf(SseTransport);
+  });
+
+  it("returns a StreamableHttpTransport for `streamable+http://…` specs", () => {
+    const spec = parseMcpSpec("svc=streamable+http://localhost:1234/mcp");
+    expect(buildTransportFromSpec(spec)).toBeInstanceOf(StreamableHttpTransport);
+  });
+
+  it("returns a StdioTransport for a bare command spec", () => {
+    const spec = parseMcpSpec("svc=node -v");
+    const transport = buildTransportFromSpec(spec, { env: { FOO: "bar" } });
+    expect(transport).toBeInstanceOf(StdioTransport);
+    void transport.close();
+  });
+
+  it("propagates the env overlay to the spawned child (end-to-end)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "reasonix-mcp-env-"));
+    const scriptPath = join(dir, "emit-env.cjs");
+    writeFileSync(
+      scriptPath,
+      'process.stdout.write(JSON.stringify({jsonrpc:"2.0",method:"x",params:{token:process.env.REASONIX_MCP_TEST_TOKEN||""}})+"\\n");',
+      "utf8",
+    );
+    const transport = new StdioTransport({
+      command: process.execPath,
+      args: [scriptPath],
+      env: { REASONIX_MCP_TEST_TOKEN: "from-config-overlay" },
+      shell: false,
+    });
+    try {
+      const iter = transport.messages();
+      const next = await iter.next();
+      expect(next.done).toBe(false);
+      const msg = next.value as { params?: { token?: string } };
+      expect(msg.params?.token).toBe("from-config-overlay");
+    } finally {
+      await transport.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 10_000);
+});


### PR DESCRIPTION
## Summary

- `ReasonixConfig.mcpEnv: Record<serverName, Record<envName, string>>` — per-server env overlay, keyed off the `name=` prefix in the `--mcp` spec.
- `StdioTransport` receives the entry merged over `process.env` at spawn; SSE / streamable-HTTP ignore it (no child process).
- Empty-string values are dropped so a blank in config doesn't accidentally blank out a real env var on the user's shell.
- Same lookup is piped into `/mcp reconnect` so a respawn after token rotation picks up the new value.
- `reasonix mcp install` now prints the `mcpEnv.<name>` shape next to its "needs:" line — users learn the key without grepping docs.

Out of scope (separate follow-ups, as noted on the issue):
- (3) Prompting for required env values during `mcp install`.
- (4) Auth-error toast that points the user at `mcpEnv`.

## Refactor

The four call sites that built a transport from a parsed spec (`chat.tsx`, `run.ts`, `mcp-inspect.ts`, `reconnect.ts`) all had the same ternary. Collapsed into `buildTransportFromSpec(spec, { env })` in `src/mcp/transport-from-spec.ts` so future transports land in a single place.

## Test plan

- [x] `tests/mcp-env-config.test.ts` — 10 cases:
  - `mcpEnvFor` lookup: hit, miss, null/undefined name, empty values dropped, all-empty → undefined.
  - `buildTransportFromSpec`: returns SSE / Streamable HTTP / Stdio for the right spec shapes.
  - End-to-end: env overlay reaches the spawned child (subprocess emits a JSON-RPC notification whose param mirrors `process.env.REASONIX_MCP_TEST_TOKEN`).
- [x] `npm run verify` green (163 files, 2546 passed, 2 skipped).

Closes #376
