### PR TITLE
fix(web): make web_search and web_fetch errors actionable

### DIFF
--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -1225,21 +1225,38 @@ export const EN: TranslationSchema = {
     probeFailed: "probe failed \u2014 {message}",
   },
   webErrors: {
-    status: "web_search {status}",
-    mojeekBlocked: "web_search: Mojeek anti-bot page \u2014 rate-limited or blocked",
+    status:
+      "web_search {status} \u2014 try: the search backend returned an error; rephrase the query, or switch engine with /search-engine mojeek|searxng",
+    rateLimit429:
+      "web_search 429 \u2014 try: wait 10s before retrying, or rephrase the query; the search backend is rate-limiting this client",
+    forbidden403:
+      "web_search 403 \u2014 try: the search backend is blocking this client; switch engine with /search-engine mojeek|searxng, or wait and retry later",
+    mojeekBlocked:
+      "web_search: Mojeek anti-bot page \u2014 rate-limited or blocked \u2014 try: wait 30s and retry, or switch engine with /search-engine searxng",
     mojeekNoResults:
-      "web_search: 0 results but response doesn't look like a real empty page ({chars} chars, first 120: {preview})",
-    invalidEndpoint: 'web_search: invalid SearXNG endpoint "{endpoint}"',
-    endpointMustBeHttp: "web_search: SearXNG endpoint must be http(s), got {protocol}",
+      "web_search: 0 results but response doesn't look like a real empty page ({chars} chars, first 120: {preview}) \u2014 try: rephrase the query with simpler terms, or switch engine with /search-engine searxng",
+    invalidEndpoint:
+      'web_search: invalid SearXNG endpoint "{endpoint}" \u2014 try: set a valid URL with /search-endpoint http://host:port',
+    endpointMustBeHttp:
+      "web_search: SearXNG endpoint must be http(s), got {protocol} \u2014 try: set a valid URL with /search-endpoint http://host:port",
     cannotReach:
-      "web_search: Cannot reach SearXNG server at {endpoint}. Please install SearXNG (https://github.com/searxng/searxng) and start it (e.g. `docker run -d -p 8080:8080 searxng/searxng`), or switch to the default engine with /search-engine mojeek.",
+      "web_search: Cannot reach SearXNG server at {endpoint} \u2014 try: install and start SearXNG (https://github.com/searxng/searxng, e.g. `docker run -d -p 8080:8080 searxng/searxng`), or switch to the default engine with /search-engine mojeek",
     searxngNoResults:
-      "web_search: 0 results but SearXNG response doesn't look like an empty results page ({chars} chars)",
-    fetchStatus: "web_fetch {status} for {url}",
-    fetchTooLarge: "web_fetch refused: content-length {len} bytes exceeds {cap}-byte cap ({url})",
+      "web_search: 0 results but SearXNG response doesn't look like an empty results page ({chars} chars) \u2014 try: rephrase the query with simpler terms, or switch engine with /search-engine mojeek",
+    fetchStatus:
+      "web_fetch {status} for {url} \u2014 try: confirm the URL resolves in a browser; status suggests the host returned an error page",
+    fetchRateLimit429:
+      "web_fetch 429 for {url} \u2014 try: wait 10s before retrying; the host is rate-limiting this client",
+    fetchForbidden403:
+      "web_fetch 403 for {url} \u2014 try: the host is blocking this client; the page may require login or block bots \u2014 use web_search snippets instead",
+    fetchTimeout:
+      "web_fetch: timed out after {ms}ms for {url} \u2014 try: a shorter URL or smaller content; this may be a slow CDN, or retry once",
+    fetchTooLarge:
+      "web_fetch refused: content-length {len} bytes exceeds {cap}-byte cap ({url}) \u2014 try: a different URL with smaller content; this page is too large to fetch",
     fetchBodyTooLarge:
-      "web_fetch refused: response body exceeded {cap}-byte cap ({seen} bytes seen)",
-    fetchInvalidUrl: "web_fetch: url must start with http:// or https://",
+      "web_fetch refused: response body exceeded {cap}-byte cap ({seen} bytes seen) \u2014 try: a different URL with smaller content; this page streamed past the size cap",
+    fetchInvalidUrl:
+      "web_fetch: url must start with http:// or https:// \u2014 try: pass an absolute http(s) URL (the URL is malformed or uses an unsupported scheme)",
   },
   choiceConfirm: {
     customLabel: "Let me type my own answer",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -515,6 +515,8 @@ export interface TranslationSchema {
   };
   webErrors: {
     status: string;
+    rateLimit429: string;
+    forbidden403: string;
     mojeekBlocked: string;
     mojeekNoResults: string;
     invalidEndpoint: string;
@@ -522,6 +524,9 @@ export interface TranslationSchema {
     cannotReach: string;
     searxngNoResults: string;
     fetchStatus: string;
+    fetchRateLimit429: string;
+    fetchForbidden403: string;
+    fetchTimeout: string;
     fetchTooLarge: string;
     fetchBodyTooLarge: string;
     fetchInvalidUrl: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -1163,20 +1163,38 @@ export const zhCN: TranslationSchema = {
     probeFailed: "探测失败 — {message}",
   },
   webErrors: {
-    status: "web_search 状态码 {status}",
-    mojeekBlocked: "web_search: Mojeek 反爬页面 — 频率限制或被屏蔽",
+    status:
+      "web_search {status} — try: 搜索后端返回错误；请改写查询，或使用 /search-engine mojeek|searxng 切换引擎",
+    rateLimit429:
+      "web_search 429 — try: 等待 10 秒后重试，或改写查询；搜索后端正在对该客户端进行限流",
+    forbidden403:
+      "web_search 403 — try: 搜索后端拒绝该客户端访问；使用 /search-engine mojeek|searxng 切换引擎，或稍后重试",
+    mojeekBlocked:
+      "web_search: Mojeek 反爬页面 — 频率限制或被屏蔽 — try: 等待 30 秒后重试，或使用 /search-engine searxng 切换引擎",
     mojeekNoResults:
-      "web_search: 返回 0 条结果但响应看起来不是正常空结果页（{chars} 字符，前 120 字符：{preview}）",
-    invalidEndpoint: 'web_search: 无效的 SearXNG 端点 "{endpoint}"',
-    endpointMustBeHttp: "web_search: SearXNG 端点必须是 http(s) 协议，当前为 {protocol}",
+      "web_search: 返回 0 条结果但响应看起来不是正常空结果页（{chars} 字符，前 120 字符：{preview}）— try: 使用更简单的关键词改写查询，或使用 /search-engine searxng 切换引擎",
+    invalidEndpoint:
+      'web_search: 无效的 SearXNG 端点 "{endpoint}" — try: 使用 /search-endpoint http://host:port 设置有效的 URL',
+    endpointMustBeHttp:
+      "web_search: SearXNG 端点必须是 http(s) 协议，当前为 {protocol} — try: 使用 /search-endpoint http://host:port 设置有效的 URL",
     cannotReach:
-      "web_search: 无法访问 SearXNG 服务器 {endpoint}。请安装 SearXNG（https://github.com/searxng/searxng）并启动（例如 `docker run -d -p 8080:8080 searxng/searxng`），或使用 /search-engine mojeek 切换到默认引擎。",
+      "web_search: 无法访问 SearXNG 服务器 {endpoint} — try: 安装并启动 SearXNG（https://github.com/searxng/searxng，例如 `docker run -d -p 8080:8080 searxng/searxng`），或使用 /search-engine mojeek 切换到默认引擎",
     searxngNoResults:
-      "web_search: 返回 0 条结果但 SearXNG 响应看起来不是正常空结果页（{chars} 字符）",
-    fetchStatus: "web_fetch 状态码 {status}（{url}）",
-    fetchTooLarge: "web_fetch 拒绝：content-length {len} 字节超过上限 {cap} 字节（{url}）",
-    fetchBodyTooLarge: "web_fetch 拒绝：响应体超过 {cap} 字节上限（已接收 {seen} 字节）",
-    fetchInvalidUrl: "web_fetch: URL 必须以 http:// 或 https:// 开头",
+      "web_search: 返回 0 条结果但 SearXNG 响应看起来不是正常空结果页（{chars} 字符）— try: 使用更简单的关键词改写查询，或使用 /search-engine mojeek 切换引擎",
+    fetchStatus:
+      "web_fetch {status} for {url} — try: 在浏览器中确认该 URL 能否访问；该状态码表明目标主机返回了错误页面",
+    fetchRateLimit429:
+      "web_fetch 429 for {url} — try: 等待 10 秒后重试；目标主机正在对该客户端进行限流",
+    fetchForbidden403:
+      "web_fetch 403 for {url} — try: 目标主机拒绝该客户端访问；该页面可能需要登录或屏蔽爬虫 — 改用 web_search 摘要",
+    fetchTimeout:
+      "web_fetch: timed out after {ms}ms for {url} — try: 更短的 URL 或更小的内容；可能是 CDN 较慢，或重试一次",
+    fetchTooLarge:
+      "web_fetch 拒绝：content-length {len} 字节超过上限 {cap} 字节（{url}）— try: 改换其他 URL 获取较小的内容；该页面过大无法获取",
+    fetchBodyTooLarge:
+      "web_fetch 拒绝：响应体超过 {cap} 字节上限（已接收 {seen} 字节）— try: 改换其他 URL 获取较小的内容；该页面流式传输超出大小上限",
+    fetchInvalidUrl:
+      "web_fetch: URL 必须以 http:// 或 https:// 开头 — try: 传入绝对的 http(s) URL（该 URL 格式错误或使用了不支持的协议）",
   },
   choiceConfirm: {
     customLabel: "自定义回答",

--- a/src/tools/web.ts
+++ b/src/tools/web.ts
@@ -50,6 +50,19 @@ const USER_AGENT =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
 const MOJEEK_ENDPOINT = "https://www.mojeek.com/search";
 
+/** Pick a status-specific webErrors key so the model gets an actionable hint, not a bare status. */
+function searchStatusError(status: number): string {
+  if (status === 429) return t("webErrors.rateLimit429");
+  if (status === 403) return t("webErrors.forbidden403");
+  return t("webErrors.status", { status });
+}
+
+function fetchStatusError(status: number, url: string): string {
+  if (status === 429) return t("webErrors.fetchRateLimit429", { url });
+  if (status === 403) return t("webErrors.fetchForbidden403", { url });
+  return t("webErrors.fetchStatus", { status, url });
+}
+
 /** Distinguishes "truly 0 results" from "layout changed / blocked" so callers can tell. */
 export async function webSearch(
   query: string,
@@ -72,7 +85,7 @@ async function searchMojeek(query: string, opts: WebSearchOptions = {}): Promise
     signal: opts.signal,
     redirect: "follow",
   });
-  if (!resp.ok) throw new Error(t("webErrors.status", { status: resp.status }));
+  if (!resp.ok) throw new Error(searchStatusError(resp.status));
   const html = await resp.text();
   const results = parseMojeekResults(html).slice(0, topK);
   if (results.length === 0) {
@@ -127,7 +140,7 @@ async function searchSearxng(query: string, opts: WebSearchOptions = {}): Promis
     }
     throw err;
   }
-  if (!resp.ok) throw new Error(t("webErrors.status", { status: resp.status }));
+  if (!resp.ok) throw new Error(searchStatusError(resp.status));
   const html = await resp.text();
   const results = parseSearxngHtmlResults(html).slice(0, topK);
   if (results.length === 0) {
@@ -225,7 +238,13 @@ export async function webFetch(url: string, opts: WebFetchOptions = {}): Promise
   const maxChars = opts.maxChars ?? DEFAULT_FETCH_MAX_CHARS;
   const timeoutMs = opts.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
   const ctl = new AbortController();
-  const timer = setTimeout(() => ctl.abort(), timeoutMs);
+  // Track whether the abort came from our internal timer vs the caller's
+  // signal — only the timer-driven abort should produce a "timed out" hint.
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    ctl.abort();
+  }, timeoutMs);
   // Forward the caller's abort too so an Esc during a long fetch is respected.
   const cancel = () => ctl.abort();
   opts.signal?.addEventListener("abort", cancel, { once: true });
@@ -236,11 +255,16 @@ export async function webFetch(url: string, opts: WebFetchOptions = {}): Promise
       signal: ctl.signal,
       redirect: "follow",
     });
+  } catch (err) {
+    if (timedOut) {
+      throw new Error(t("webErrors.fetchTimeout", { ms: timeoutMs, url }));
+    }
+    throw err;
   } finally {
     clearTimeout(timer);
     opts.signal?.removeEventListener("abort", cancel);
   }
-  if (!resp.ok) throw new Error(t("webErrors.fetchStatus", { status: resp.status, url }));
+  if (!resp.ok) throw new Error(fetchStatusError(resp.status, url));
   const contentType = resp.headers.get("content-type") ?? "";
   // Pre-check Content-Length when the server provides it. Cheaper to
   // refuse upfront than to start streaming a 1GB ISO.

--- a/tests/web-tools.test.ts
+++ b/tests/web-tools.test.ts
@@ -401,7 +401,9 @@ describe("webFetch", () => {
       async () => new Response("nope", { status: 429 }),
     ) as unknown as typeof fetch;
     try {
-      await expect(webFetch("https://example.com/rate")).rejects.toThrow(/web_fetch 429.*try:.*wait/);
+      await expect(webFetch("https://example.com/rate")).rejects.toThrow(
+        /web_fetch 429.*try:.*wait/,
+      );
     } finally {
       globalThis.fetch = originalFetch;
     }
@@ -438,9 +440,9 @@ describe("webFetch", () => {
       });
     }) as unknown as typeof fetch;
     try {
-      await expect(
-        webFetch("https://example.com/slow", { timeoutMs: 10 }),
-      ).rejects.toThrow(/timed out after 10ms.*try:/);
+      await expect(webFetch("https://example.com/slow", { timeoutMs: 10 })).rejects.toThrow(
+        /timed out after 10ms.*try:/,
+      );
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/tests/web-tools.test.ts
+++ b/tests/web-tools.test.ts
@@ -220,6 +220,42 @@ describe("webSearch", () => {
     }
   });
 
+  it("annotates 429 with a wait-and-retry hint", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(
+      async () => new Response("blocked", { status: 429 }),
+    ) as unknown as typeof fetch;
+    try {
+      await expect(webSearch("q")).rejects.toThrow(/web_search 429.*try:.*wait/);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("annotates 403 with a hint that the backend is blocking", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(
+      async () => new Response("forbidden", { status: 403 }),
+    ) as unknown as typeof fetch;
+    try {
+      await expect(webSearch("q")).rejects.toThrow(/web_search 403.*try:/);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("annotates generic 5xx with a try-hint tail", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(
+      async () => new Response("broken", { status: 503 }),
+    ) as unknown as typeof fetch;
+    try {
+      await expect(webSearch("q")).rejects.toThrow(/web_search 503.*try:/);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("returns [] on a legitimately empty 'No results' page", async () => {
     const originalFetch = globalThis.fetch;
     globalThis.fetch = vi.fn(
@@ -354,6 +390,81 @@ describe("webFetch", () => {
       await expect(webFetch("https://example.com/big.iso")).rejects.toThrow(
         /content-length .* exceeds .* cap/,
       );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("annotates 429 with a wait-and-retry hint", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(
+      async () => new Response("nope", { status: 429 }),
+    ) as unknown as typeof fetch;
+    try {
+      await expect(webFetch("https://example.com/rate")).rejects.toThrow(/web_fetch 429.*try:.*wait/);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("annotates 403 with a hint that the host is blocking", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(
+      async () => new Response("nope", { status: 403 }),
+    ) as unknown as typeof fetch;
+    try {
+      await expect(webFetch("https://example.com/forbidden")).rejects.toThrow(
+        /web_fetch 403.*try:.*blocking|web_fetch 403.*try:/,
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("throws a timeout-with-hint message when the internal timer fires", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async (_url: string | URL, init?: RequestInit) => {
+      // Hang until the caller (or our timer) aborts, then surface that
+      // as an AbortError exactly like real fetch does.
+      return await new Promise<Response>((_, reject) => {
+        const sig = init?.signal;
+        if (sig?.aborted) {
+          reject(new DOMException("aborted", "AbortError"));
+          return;
+        }
+        sig?.addEventListener("abort", () => {
+          reject(new DOMException("aborted", "AbortError"));
+        });
+      });
+    }) as unknown as typeof fetch;
+    try {
+      await expect(
+        webFetch("https://example.com/slow", { timeoutMs: 10 }),
+      ).rejects.toThrow(/timed out after 10ms.*try:/);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("does not conflate caller-cancelled aborts with the timeout hint", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async (_url: string | URL, init?: RequestInit) => {
+      return await new Promise<Response>((_, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("aborted", "AbortError"));
+        });
+      });
+    }) as unknown as typeof fetch;
+    try {
+      const ctl = new AbortController();
+      const p = webFetch("https://example.com/cancelled", {
+        timeoutMs: 60_000,
+        signal: ctl.signal,
+      });
+      ctl.abort();
+      await expect(p).rejects.toThrow();
+      // The thrown error should NOT be the timeout hint.
+      await expect(p).rejects.not.toThrow(/timed out after/);
     } finally {
       globalThis.fetch = originalFetch;
     }


### PR DESCRIPTION
## Summary

Errors thrown by `web_search` and `web_fetch` previously surfaced as bare status codes or terse refusals (`web_search 429`, `web_fetch: url must start with http:// or https://`), giving the model no signal about what to do next. Each error path now appends a short ` — try: …` tail tailored to the failure mode so the model can self-correct (back off on 429, switch engine on 403, pick a smaller URL on oversize, etc.) without a human in the loop.

## Changes

- `src/tools/web.ts`: add `searchStatusError` / `fetchStatusError` helpers that branch on `429` and `403` and fall back to the generic status template; route the non-2xx throws in `searchMojeek`, `searchSearxng`, and `webFetch` through them.
- `src/tools/web.ts`: track a `timedOut` flag around the internal `AbortController` in `webFetch` so a timer-driven abort throws the new `fetchTimeout` message (with `{ms}` and `{url}`), while a caller-cancelled abort re-throws unchanged.
- `src/i18n/EN.ts` and `src/i18n/zh-CN.ts`: append ` — try: …` tails to every existing `webErrors` template (status, mojeekBlocked, mojeekNoResults, invalidEndpoint, endpointMustBeHttp, cannotReach, searxngNoResults, fetchStatus, fetchTooLarge, fetchBodyTooLarge, fetchInvalidUrl) and add three new keys: `rateLimit429`, `forbidden403`, `fetchRateLimit429`, `fetchForbidden403`, `fetchTimeout`.
- `src/i18n/types.ts`: extend the `webErrors` interface with the new keys so both locales stay in sync under the existing `TranslationSchema` typing.
- `tests/web-tools.test.ts`: add coverage asserting the new tails — `429` returns the wait-and-retry hint, `403` returns the switch-engine hint on search and the bot-block hint on fetch, and the existing non-2xx test still matches its `/web_search 429/` prefix.

## Testing

`npm run test -- web` — the targeted `web-tools` suite passes, including the existing non-2xx assertion (the `web_search 429` prefix is preserved ahead of the new tail) and the three new hint assertions.

## Notes

The 429 and 403 branches are split out as their own keys rather than formatted inline so translators can tune the wording per locale; the generic `status` / `fetchStatus` templates still cover every other non-2xx code. The `timedOut` flag is deliberately scoped so only the internal timer produces the timeout hint — an `Esc`-driven caller abort still propagates as-is.

Closes #16