### PR TITLE
chore(ci): add issue triage workflows (similarity + auto-label)

### DIFF
--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -1,0 +1,25 @@
+bug:
+  - '(?i)\b(crash|crashed|crashes|panic|panicked|stack trace|stacktrace|traceback)\b'
+  - '(?i)\b(broken|doesn''?t work|not working|stopped working|regression)\b'
+  - '(?i)\b(throws? (an? )?error|uncaught|unhandled)\b'
+
+enhancement:
+  - '(?i)\b(feature request|would (be nice|like|love)|please add|please support)\b'
+  - '(?i)\b(add (a |the )?(flag|option|config|setting|switch)|allow (configuring|disabling|enabling))\b'
+  - '(?i)\b(can (we|you|reasonix) (add|support)|proposal|propose adding)\b'
+
+documentation:
+  - '(?i)\b(docs?\b|documentation|readme|getting started|tutorial|wiki|man page)\b'
+  - '(?i)\b(missing (docs?|documentation)|undocumented)\b'
+
+question:
+  - '(?i)\b(how (do|to|can) (i|we|you)|is it possible|is there a way|why does|why is)\b'
+  - '(?i)\b(question:|q:)\s'
+
+dashboard:
+  - '(?i)\b(dashboard|/dashboard|web UI|web companion|browser)\b'
+  - '(?i)\blocalhost:|127\.0\.0\.1'
+
+rendering:
+  - '(?i)\b(flicker|flickering|render artifact|redraw|repaint|ghost row|ghosting|screen tear)\b'
+  - '(?i)\b(TUI (glitch|artifact|garbled)|terminal (glitch|garbled|broken display))\b'

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,0 +1,22 @@
+name: Issue auto-label
+
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: github/issue-labeler@v3.4
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/issue-labeler.yml
+          enable-versioned-regex: 0
+          include-title: 1
+          include-body: 1
+          sync-labels: 0

--- a/.github/workflows/issue-similarity.yml
+++ b/.github/workflows/issue-similarity.yml
@@ -1,0 +1,20 @@
+name: Issue similarity check
+
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  issues: write
+
+jobs:
+  similarity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions-cool/issues-similarity-analysis@v1
+        with:
+          filter-threshold: 0.7
+          title-excludes: ""
+          comment-title: "### Possibly related issues"
+          comment-body: "- #${number} · ${title}"
+          show-footer: false


### PR DESCRIPTION
## Summary

Two GitHub Actions to cut down on duplicate-issue triage workload:

- **`.github/workflows/issue-similarity.yml`** — runs [`actions-cool/issues-similarity-analysis`](https://github.com/actions-cool/issues-similarity-analysis) on every new / edited issue and posts a comment listing the top related issues (similarity ≥ 0.7). Would have surfaced #633 → #624 / #625 automatically.
- **`.github/workflows/issue-labeler.yml`** + **`.github/issue-labeler.yml`** — runs [`github/issue-labeler`](https://github.com/github/issue-labeler) to apply area / kind labels by regex on title + body. Covered today: `bug`, `enhancement`, `documentation`, `question`, `dashboard`, `rendering`.

Both use the default `GITHUB_TOKEN`, no secrets to provision.

## Out of scope

- Judgment-call labels (`good first issue`, `rfc`, `tracking`, `duplicate`, `wontfix`, `invalid`, `help wanted`, `off-topic`, `blocked-upstream`) — those stay maintainer-driven.
- AI-driven semantic dup detection — keyword similarity catches most cases; revisit if we keep seeing semantic-but-different-words dups slip through.

## Test plan

- [x] YAML syntax check on all three files (`js-yaml`)
- [ ] After merge: watch the next 3-5 incoming issues for similarity comment / label accuracy; tune thresholds + regexes if noisy
