### PR TITLE
fix(ci): use /pattern/i form in issue-labeler config

### DIFF
--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -1,25 +1,25 @@
 bug:
-  - '(?i)\b(crash|crashed|crashes|panic|panicked|stack trace|stacktrace|traceback)\b'
-  - '(?i)\b(broken|doesn''?t work|not working|stopped working|regression)\b'
-  - '(?i)\b(throws? (an? )?error|uncaught|unhandled)\b'
+  - '/\b(crash|crashed|crashes|panic|panicked|stack trace|stacktrace|traceback)\b/i'
+  - '/\b(broken|doesn''?t work|not working|stopped working|regression)\b/i'
+  - '/\b(throws? (an? )?error|uncaught|unhandled)\b/i'
 
 enhancement:
-  - '(?i)\b(feature request|would (be nice|like|love)|please add|please support)\b'
-  - '(?i)\b(add (a |the )?(flag|option|config|setting|switch)|allow (configuring|disabling|enabling))\b'
-  - '(?i)\b(can (we|you|reasonix) (add|support)|proposal|propose adding)\b'
+  - '/\b(feature request|would (be nice|like|love)|please add|please support)\b/i'
+  - '/\b(add (a |the )?(flag|option|config|setting|switch)|allow (configuring|disabling|enabling))\b/i'
+  - '/\b(can (we|you|reasonix) (add|support)|proposal|propose adding)\b/i'
 
 documentation:
-  - '(?i)\b(docs?\b|documentation|readme|getting started|tutorial|wiki|man page)\b'
-  - '(?i)\b(missing (docs?|documentation)|undocumented)\b'
+  - '/\b(docs?\b|documentation|readme|getting started|tutorial|wiki|man page)\b/i'
+  - '/\b(missing (docs?|documentation)|undocumented)\b/i'
 
 question:
-  - '(?i)\b(how (do|to|can) (i|we|you)|is it possible|is there a way|why does|why is)\b'
-  - '(?i)\b(question:|q:)\s'
+  - '/\b(how (do|to|can) (i|we|you)|is it possible|is there a way|why does|why is)\b/i'
+  - '/\b(question:|q:)\s/i'
 
 dashboard:
-  - '(?i)\b(dashboard|/dashboard|web UI|web companion|browser)\b'
-  - '(?i)\blocalhost:|127\.0\.0\.1'
+  - '/\b(dashboard|\/dashboard|web UI|web companion|browser)\b/i'
+  - '/\blocalhost:|127\.0\.0\.1/i'
 
 rendering:
-  - '(?i)\b(flicker|flickering|render artifact|redraw|repaint|ghost row|ghosting|screen tear)\b'
-  - '(?i)\b(TUI (glitch|artifact|garbled)|terminal (glitch|garbled|broken display))\b'
+  - '/\b(flicker|flickering|render artifact|redraw|repaint|ghost row|ghosting|screen tear)\b/i'
+  - '/\b(TUI (glitch|artifact|garbled)|terminal (glitch|garbled|broken display))\b/i'


### PR DESCRIPTION
## Summary

`github/issue-labeler@v3.4` compiles each pattern with `new RegExp(str)`, which is ECMAScript regex — it doesn't understand the PCRE `(?i)` inline case-insensitive flag and throws `Invalid regular expression: ... Invalid group` on the first pattern. The label job then dies before tagging anything (failed run on issue #635: [25649833795](https://github.com/esengine/DeepSeek-Reasonix/actions/runs/25649833795)).

Switching every entry from `'(?i)pattern'` to `'/pattern/i'` — the slash-delimited literal form `github/issue-labeler` parses for flag support. Behavior unchanged; the YAML just speaks JS regex now.

## Test plan

- [x] Local validation: all 14 patterns compile via `new RegExp(...)` with the `i` flag retained
- [x] Realistic fixture sweep: 17/17 expected matches across bug / enhancement / docs / question / dashboard / rendering labels
- [ ] Re-run failed action against issue #635 once merged to confirm
