### PR TITLE
fix(ui): reset chat scroll to bottom when a confirm modal mounts

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -3034,11 +3034,14 @@ function AppInner({
   }, [handleShellConfirm]);
   // Listen for pause requests from tool functions (via PauseGate).
   // Dispatches to the correct modal based on request.kind.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: setters + editModeRef are stable; the listener installs once per mount and reads only refs/setters from closure
+  // biome-ignore lint/correctness/useExhaustiveDependencies: setters, editModeRef, and chatScroll (store handle) are stable; the listener installs once per mount and reads only refs/setters from closure
   useEffect(() => {
     return pauseGate.on((request) => {
       const payload = request.payload as Record<string, unknown>;
       pendingGateIdRef.current = request.id;
+      // Modal pickers reserve viewport rows from the bottom; if the chat is
+      // scrolled up, the picker mounts off-screen and the user can't see it.
+      chatScroll.jumpToBottom();
 
       switch (request.kind) {
         case "run_command":

--- a/tests/modal-scroll-reset.test.ts
+++ b/tests/modal-scroll-reset.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { createChatScrollStore } from "../src/cli/ui/state/chat-scroll-store.js";
+import { PauseGate } from "../src/core/pause-gate.js";
+
+describe("chatScroll jumpToBottom (issue #642)", () => {
+  it("flips pinned back on and snaps scrollRows on the next setMaxScroll", () => {
+    const store = createChatScrollStore();
+    store.setMaxScroll(100);
+    store.scrollPageUp();
+    store.scrollPageUp();
+    expect(store.getState().pinned).toBe(false);
+    expect(store.getState().scrollRows).toBeLessThan(100);
+
+    store.jumpToBottom();
+    expect(store.getState().pinned).toBe(true);
+
+    store.setMaxScroll(120);
+    expect(store.getState().scrollRows).toBe(120);
+  });
+
+  it("a pauseGate listener that calls jumpToBottom reseats the viewport on every modal kind", () => {
+    const store = createChatScrollStore();
+    const gate = new PauseGate();
+    gate.on(() => {
+      store.jumpToBottom();
+    });
+
+    const kinds = [
+      "run_command",
+      "plan_proposed",
+      "plan_checkpoint",
+      "plan_revision",
+      "choice",
+    ] as const;
+    for (const kind of kinds) {
+      store.setMaxScroll(50);
+      store.scrollPageUp();
+      expect(store.getState().pinned).toBe(false);
+
+      void gate.ask({ kind, payload: payloadFor(kind) } as Parameters<typeof gate.ask>[0]);
+      expect(store.getState().pinned).toBe(true);
+      gate.cancelAll();
+    }
+  });
+});
+
+function payloadFor(kind: string): unknown {
+  switch (kind) {
+    case "run_command":
+    case "run_background":
+      return { command: "ls" };
+    case "plan_proposed":
+      return { plan: "do thing" };
+    case "plan_checkpoint":
+      return { stepId: "s1", result: "ok" };
+    case "plan_revision":
+      return { reason: "r", remainingSteps: [] };
+    case "choice":
+      return { question: "?", options: [], allowCustom: false };
+    default:
+      return {};
+  }
+}


### PR DESCRIPTION
## Summary

When the user has scrolled up in the chat and a confirm modal arrives — `run_command`, `run_background`, `plan_proposed`, `plan_checkpoint`, `plan_revision`, or `choice` — the modal mounts at the bottom of the chat area, which is off-screen. The picker captures arrow keys, so scroll-down inputs no longer move the viewport either, and the user is visually stuck.

`src/cli/ui/App.tsx`'s `pauseGate.on(...)` listener now calls `chatScroll.jumpToBottom()` once before the kind switch. That flips `pinned: true`; the modal's `useReserveRows` shrinks the chat area, which triggers `setMaxScroll`, which under the pinned-mode invariant snaps `scrollRows` to the new bottom. Single line; covers all five modal kinds.

Closes #642

## Test plan

- [x] `npm run verify` — 2562 passed, 2 skipped
- [x] New test `tests/modal-scroll-reset.test.ts`:
  - Primitive: after `scrollPageUp` then `jumpToBottom`, the next `setMaxScroll` snaps `scrollRows` to the max.
  - Integration: a pauseGate listener wired to `jumpToBottom` reseats the viewport on every modal kind.
- [ ] Manual repro on Win Terminal: scroll up, trigger a shell-needing command, confirm the picker becomes visible.
