### PR TITLE
fix(config): loadEditMode preserves yolo instead of demoting it to review

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -295,7 +295,8 @@ export function clearProjectShellAllowed(
 /** Unknown values fall back to "review" so hand-edited bad config gets the safe default. */
 export function loadEditMode(path: string = defaultConfigPath()): EditMode {
   const v = readConfig(path).editMode;
-  return v === "auto" ? "auto" : "review";
+  if (v === "auto" || v === "yolo") return v;
+  return "review";
 }
 
 /** Persist the edit mode so `/mode auto` survives a relaunch. */

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -305,6 +305,12 @@ describe("config", () => {
     expect(readConfig(path).editMode).toBe("auto");
   });
 
+  it("saveEditMode + loadEditMode round-trip 'yolo' (issue #644)", () => {
+    saveEditMode("yolo", path);
+    expect(loadEditMode(path)).toBe("yolo");
+    expect(readConfig(path).editMode).toBe("yolo");
+  });
+
   it("loadEditMode coerces unknown values back to 'review'", () => {
     writeConfig({ editMode: "garbage" as any }, path);
     expect(loadEditMode(path)).toBe("review");


### PR DESCRIPTION
## Summary

`EditMode` is `"review" | "auto" | "yolo"`, but `loadEditMode` (`src/config.ts:296-299`) used a ternary that only recognized `"auto"` and dropped everything else — including `"yolo"` — back to `"review"`. `/mode yolo` writes the right value to disk via `saveEditMode`, but the very next read silently downgrades it.

Downstream effect: `src/cli/commands/code.tsx:111` registers the shell tool with `allowAll: () => loadEditMode() === "yolo"`. Because that getter never returned `"yolo"`, the shell tool always fell through to the pauseGate, and the user saw the approval modal even though they thought they were "in yolo". `useEditGate.ts:38` is bitten the same way on every relaunch.

Closes #644

## Test plan

- [x] `npm run verify` — 2570 passed, 2 skipped
- [x] New round-trip test in `tests/config.test.ts`: `saveEditMode("yolo")` → `loadEditMode()` returns `"yolo"`
- [x] Existing tests still pass (default → review, "garbage" → review, round-trip "auto")

## Out of scope

The issue title also asks for "limit [the confirms] to dangerous operations" — i.e. yolo should still gate `sudo`, `rm -rf /`, `mkfs`, `curl | sh`, etc. That's a design change rather than a bug fix and warrants its own discussion + pattern list. I'll file a follow-up issue rather than slip a denylist into this PR.
