### PR TITLE
fix(net): honor HTTPS_PROXY / HTTP_PROXY / ALL_PROXY for all fetch calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "reasonix",
       "version": "0.38.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "cli-highlight": "^2.1.11",
@@ -19,6 +20,7 @@
         "picomatch": "^4.0.4",
         "react": "^19.2.6",
         "string-width": "^7.2.0",
+        "undici": "^8.2.0",
         "zod": "^4.4.1"
       },
       "bin": {
@@ -6858,6 +6860,15 @@
       "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.2.0.tgz",
+      "integrity": "sha512-Z+4Hx9GE26Lh9Upwfnc8C7SsrpBPGaM/Gm6kMFtiG7c+5IvQKlXi/t+9x9DrrCh29cww5TSP9YdVaBcnLDs5fQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
     },
     "node_modules/undici-types": {
       "version": "6.21.0",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "picomatch": "^4.0.4",
     "react": "^19.2.6",
     "string-width": "^7.2.0",
+    "undici": "^8.2.0",
     "zod": "^4.4.1"
   },
   "devDependencies": {

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -16,6 +16,7 @@ import { t } from "../../i18n/index.js";
 import { indexExists } from "../../index/semantic/builder.js";
 import { checkOllamaStatus } from "../../index/semantic/ollama-launcher.js";
 import { listSessions } from "../../memory/session.js";
+import { detectProxyUrl } from "../../net/proxy.js";
 import { resolveDataPath } from "../../tokenizer.js";
 import { VERSION } from "../../version.js";
 
@@ -39,6 +40,7 @@ export async function runDoctorChecks(projectRoot: string): Promise<DoctorCheck[
   return Promise.all([
     checkApiKey(),
     checkConfig(),
+    checkProxy(),
     checkApiReach(),
     checkTokenizer(),
     checkSessions(),
@@ -46,6 +48,35 @@ export async function runDoctorChecks(projectRoot: string): Promise<DoctorCheck[
     checkOllama(projectRoot),
     checkProject(projectRoot),
   ]);
+}
+
+function checkProxy(): Check {
+  const url = detectProxyUrl();
+  if (!url) {
+    return {
+      id: "proxy",
+      label: "http proxy   ",
+      level: "ok",
+      detail: "no HTTPS_PROXY / HTTP_PROXY / ALL_PROXY set — direct connection",
+    };
+  }
+  let redacted = url;
+  try {
+    const u = new URL(url);
+    if (u.username || u.password) {
+      u.username = "***";
+      u.password = "";
+      redacted = u.toString();
+    }
+  } catch {
+    /* not a URL — leave raw */
+  }
+  return {
+    id: "proxy",
+    label: "http proxy   ",
+    level: "ok",
+    detail: `routing fetch through ${redacted}`,
+  };
 }
 
 const TTY = process.stdout.isTTY && process.env.TERM !== "dumb";

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4,9 +4,15 @@ import { t } from "../i18n/index.js";
 import { VERSION } from "../index.js";
 import { listSessions } from "../memory/session.js";
 import { applyMemoryStack } from "../memory/user.js";
+import { installProxyIfConfigured } from "../net/proxy.js";
 import { escalationContract } from "../prompt-fragments.js";
 import { resolveContinueFlag, resolveDefaults } from "./resolve.js";
 import { markPhase } from "./startup-profile.js";
+
+// HTTPS_PROXY / HTTP_PROXY only reach Node's fetch via undici's global
+// dispatcher; install before any client (DeepSeek, web tools, dashboard)
+// constructs a fetch closure. Issue #646.
+installProxyIfConfigured();
 
 markPhase("cli_module_loaded");
 

--- a/src/net/proxy.ts
+++ b/src/net/proxy.ts
@@ -1,0 +1,42 @@
+/** Node's built-in fetch ignores HTTPS_PROXY env vars — undici's ProxyAgent has to be wired in explicitly. */
+
+import { ProxyAgent, setGlobalDispatcher } from "undici";
+
+/** Env-var precedence matches curl: HTTPS_PROXY → HTTP_PROXY → ALL_PROXY, upper-case first then lower. */
+const PROXY_ENV_KEYS = [
+  "HTTPS_PROXY",
+  "https_proxy",
+  "HTTP_PROXY",
+  "http_proxy",
+  "ALL_PROXY",
+  "all_proxy",
+] as const;
+
+export function detectProxyUrl(env: NodeJS.ProcessEnv = process.env): string | null {
+  for (const key of PROXY_ENV_KEYS) {
+    const raw = env[key];
+    if (typeof raw !== "string") continue;
+    const trimmed = raw.trim();
+    if (trimmed) return trimmed;
+  }
+  return null;
+}
+
+let installed = false;
+
+/** Sets the undici global dispatcher to a ProxyAgent. Returns the proxy URL or null if no env var is set. Idempotent. */
+export function installProxyIfConfigured(
+  env: NodeJS.ProcessEnv = process.env,
+): { url: string; reinstalled: boolean } | null {
+  const url = detectProxyUrl(env);
+  if (!url) return null;
+  const reinstalled = installed;
+  setGlobalDispatcher(new ProxyAgent(url));
+  installed = true;
+  return { url, reinstalled };
+}
+
+/** Test-only escape hatch so the installed flag doesn't leak between vitest cases. */
+export function _resetForTests(): void {
+  installed = false;
+}

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { _resetForTests, detectProxyUrl, installProxyIfConfigured } from "../src/net/proxy.js";
+
+describe("detectProxyUrl (issue #646)", () => {
+  it("returns null when no proxy env var is set", () => {
+    expect(detectProxyUrl({})).toBeNull();
+  });
+
+  it("returns null when the proxy var is whitespace only", () => {
+    expect(detectProxyUrl({ HTTPS_PROXY: "   " })).toBeNull();
+  });
+
+  it("HTTPS_PROXY wins over HTTP_PROXY (curl-style precedence)", () => {
+    expect(
+      detectProxyUrl({
+        HTTPS_PROXY: "http://https.example:8080",
+        HTTP_PROXY: "http://http.example:8080",
+      }),
+    ).toBe("http://https.example:8080");
+  });
+
+  it("falls back to HTTP_PROXY when HTTPS_PROXY is absent", () => {
+    expect(detectProxyUrl({ HTTP_PROXY: "http://http.example:8080" })).toBe(
+      "http://http.example:8080",
+    );
+  });
+
+  it("falls back to ALL_PROXY last", () => {
+    expect(detectProxyUrl({ ALL_PROXY: "socks5://proxy.example:1080" })).toBe(
+      "socks5://proxy.example:1080",
+    );
+  });
+
+  it("upper-case wins over lower-case for the same family (HTTPS_PROXY beats https_proxy)", () => {
+    expect(
+      detectProxyUrl({
+        HTTPS_PROXY: "http://upper.example:8080",
+        https_proxy: "http://lower.example:8080",
+      }),
+    ).toBe("http://upper.example:8080");
+  });
+
+  it("uses lower-case https_proxy when upper-case isn't set", () => {
+    expect(detectProxyUrl({ https_proxy: "http://lower.example:8080" })).toBe(
+      "http://lower.example:8080",
+    );
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(detectProxyUrl({ HTTPS_PROXY: "  http://example:8080  " })).toBe("http://example:8080");
+  });
+});
+
+describe("installProxyIfConfigured", () => {
+  beforeEach(() => {
+    _resetForTests();
+  });
+  afterEach(() => {
+    _resetForTests();
+  });
+
+  it("returns null when no proxy is configured (no global dispatcher change)", () => {
+    expect(installProxyIfConfigured({})).toBeNull();
+  });
+
+  it("returns the detected url + reinstalled=false on the first install", () => {
+    const result = installProxyIfConfigured({ HTTPS_PROXY: "http://example:8080" });
+    expect(result).toEqual({ url: "http://example:8080", reinstalled: false });
+  });
+
+  it("returns reinstalled=true on subsequent installs (idempotent at the env-detect level)", () => {
+    installProxyIfConfigured({ HTTPS_PROXY: "http://first:8080" });
+    const second = installProxyIfConfigured({ HTTPS_PROXY: "http://second:8080" });
+    expect(second?.reinstalled).toBe(true);
+    expect(second?.url).toBe("http://second:8080");
+  });
+});


### PR DESCRIPTION
## Summary

Node's built-in `fetch` is undici under the hood, but undici **ignores** the standard `HTTPS_PROXY` / `HTTP_PROXY` env vars unless you explicitly install a `ProxyAgent` on its global dispatcher. We never did, so users behind a proxy were getting opaque connection failures from every network surface — DeepSeek API, web search, model list refresh, version check, dashboard reach — even with the env var set in their shell.

Changes:

- New `src/net/proxy.ts`:
  - `detectProxyUrl(env)` walks `HTTPS_PROXY → https_proxy → HTTP_PROXY → http_proxy → ALL_PROXY → all_proxy` and returns the first non-empty match. Matches curl precedence.
  - `installProxyIfConfigured(env)` installs an undici `ProxyAgent` as the global dispatcher when a proxy is detected. Idempotent.
- Wired at the top of `src/cli/index.ts` before any HTTP client is constructed, so every later fetch closure (DeepSeek client, web tools, doctor's reach check, dashboard) picks up the dispatcher.
- `/doctor` gets a `http proxy` row showing the active proxy URL (with credentials redacted) or "no HTTPS_PROXY / HTTP_PROXY / ALL_PROXY set — direct connection".
- `undici@8.2.0` added as a direct dep — already transitively present via Node, but explicit import requires it in the manifest.

Closes #646

## Test plan

- [x] `npm run verify` — 2581 passed (added 11), 2 skipped
- [x] `tests/proxy.test.ts` covers env-var precedence (HTTPS over HTTP, upper over lower, ALL_PROXY fallback, whitespace handling) and install idempotence
- [ ] Manual: set `HTTPS_PROXY=http://your-proxy:8080`, run `reasonix doctor`, verify the `http proxy` row shows the URL and `api reach` succeeds
