### PR TITLE
fix(tools): short-circuit a 2nd consecutive identical malformed call

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -61,6 +61,8 @@ export class ToolRegistry {
   private _interceptor: ToolInterceptor | null = null;
   private _auditListener: ToolCallAuditListener | null = null;
   private _resultAugmenter: ToolResultAugmenter | null = null;
+  /** Per-tool fingerprint of the last call that failed schema validation. Cleared by any successful validation for that tool. */
+  private readonly _lastMalformed = new Map<string, string>();
 
   constructor(opts: ToolRegistryOptions = {}) {
     this._autoFlatten = opts.autoFlatten !== false;
@@ -161,6 +163,7 @@ export class ToolRegistry {
     if (!tool) {
       return JSON.stringify({ error: `unknown tool: ${name}` });
     }
+    const fingerprint = fingerprintArgs(argumentsRaw);
     let args: Record<string, unknown>;
     try {
       args =
@@ -170,9 +173,11 @@ export class ToolRegistry {
             : {}
           : (argumentsRaw ?? {});
     } catch (err) {
-      return JSON.stringify({
-        error: `invalid tool arguments JSON: ${(err as Error).message}`,
-      });
+      return this._noteMalformed(
+        name,
+        fingerprint,
+        `invalid tool arguments JSON: ${(err as Error).message}`,
+      );
     }
 
     // Re-nest dot-notation args back to the original shape, but only when
@@ -186,10 +191,14 @@ export class ToolRegistry {
 
     const missing = tool.parameters ? missingRequiredParam(tool.parameters, args) : null;
     if (missing) {
-      return JSON.stringify({
-        error: `${name}: missing required parameter "${missing}". Retry with all required parameters filled.`,
-      });
+      return this._noteMalformed(
+        name,
+        fingerprint,
+        `missing required parameter "${missing}". Retry with all required parameters filled.`,
+      );
     }
+    // Validation passed — this tool's malformed-args streak is broken.
+    this._lastMalformed.delete(name);
 
     // Plan-mode enforcement — runs AFTER arg parsing so a tool with a
     // runtime `readOnlyCheck` can inspect the actual args (e.g.
@@ -273,6 +282,19 @@ export class ToolRegistry {
     }
     return finalResult;
   }
+
+  /** Records the failed call's fingerprint; on the 2nd consecutive identical malformed call to the same tool, returns a sharper error that tells the model to stop retrying. */
+  private _noteMalformed(name: string, fingerprint: string, detail: string): string {
+    const prev = this._lastMalformed.get(name);
+    this._lastMalformed.set(name, fingerprint);
+    if (prev === fingerprint) {
+      return JSON.stringify({
+        error: `${name}: same call just failed validation (${detail}) — DO NOT retry with identical args. Either fix the call (read the schema in the tool spec) or pick a different tool.`,
+        consecutiveMalformed: true,
+      });
+    }
+    return JSON.stringify({ error: `${name}: ${detail}` });
+  }
 }
 
 function isReadOnlyCall(tool: InternalTool, args: Record<string, unknown>): boolean {
@@ -291,6 +313,16 @@ function hasDotKey(obj: Record<string, unknown>): boolean {
     if (k.includes(".")) return true;
   }
   return false;
+}
+
+/** Stable per-call key for the malformed-args storm guard. String args compare as-is; objects round-trip through JSON so key order is stable. */
+function fingerprintArgs(argumentsRaw: string | Record<string, unknown>): string {
+  if (typeof argumentsRaw === "string") return argumentsRaw;
+  try {
+    return JSON.stringify(argumentsRaw);
+  } catch {
+    return "";
+  }
 }
 
 /** If the schema declares required params, return the first one that's missing. */

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -403,4 +403,98 @@ describe("ToolRegistry", () => {
       expect(out).toBe("wrote /foo");
     });
   });
+
+  describe("malformed-args storm guard (issue #651)", () => {
+    function readFileReg(): ToolRegistry {
+      const reg = new ToolRegistry();
+      reg.register({
+        name: "read_file",
+        parameters: {
+          type: "object",
+          properties: { path: { type: "string" } },
+          required: ["path"],
+        },
+        fn: ({ path }: { path: string }) => `read ${path}`,
+      });
+      return reg;
+    }
+
+    it("first malformed call returns the normal missing-param error", async () => {
+      const reg = readFileReg();
+      const out = await reg.dispatch("read_file", "{}");
+      const parsed = JSON.parse(out);
+      expect(parsed.error).toMatch(/missing required parameter "path"/);
+      expect(parsed.consecutiveMalformed).toBeUndefined();
+    });
+
+    it("2nd consecutive identical malformed call short-circuits with a sharper error", async () => {
+      const reg = readFileReg();
+      await reg.dispatch("read_file", "{}");
+      const out = await reg.dispatch("read_file", "{}");
+      const parsed = JSON.parse(out);
+      expect(parsed.consecutiveMalformed).toBe(true);
+      expect(parsed.error).toMatch(/DO NOT retry with identical args/);
+    });
+
+    it("a successful call between two malformed ones clears the streak", async () => {
+      const reg = readFileReg();
+      await reg.dispatch("read_file", "{}"); // 1st malformed
+      await reg.dispatch("read_file", '{"path": "ok.txt"}'); // success — clears
+      const out = await reg.dispatch("read_file", "{}"); // 1st-again, NOT 2nd-consecutive
+      const parsed = JSON.parse(out);
+      expect(parsed.consecutiveMalformed).toBeUndefined();
+    });
+
+    it("different malformed args to the same tool do not trip the guard", async () => {
+      const reg = new ToolRegistry();
+      reg.register({
+        name: "edit",
+        parameters: {
+          type: "object",
+          properties: { path: { type: "string" }, body: { type: "string" } },
+          required: ["path", "body"],
+        },
+        fn: () => "edited",
+      });
+      await reg.dispatch("edit", '{"path": "x"}'); // missing body
+      const out = await reg.dispatch("edit", '{"body": "y"}'); // missing path — different shape
+      const parsed = JSON.parse(out);
+      expect(parsed.consecutiveMalformed).toBeUndefined();
+    });
+
+    it("invalid JSON, identical twice, also short-circuits", async () => {
+      const reg = readFileReg();
+      await reg.dispatch("read_file", "{not json");
+      const out = await reg.dispatch("read_file", "{not json");
+      const parsed = JSON.parse(out);
+      expect(parsed.consecutiveMalformed).toBe(true);
+      expect(parsed.error).toMatch(/invalid tool arguments JSON/);
+    });
+
+    it("per-tool tracking — malformed read_file does not affect a separate edit_file tool", async () => {
+      const reg = new ToolRegistry();
+      reg.register({
+        name: "read_file",
+        parameters: {
+          type: "object",
+          properties: { path: { type: "string" } },
+          required: ["path"],
+        },
+        fn: () => "r",
+      });
+      reg.register({
+        name: "edit_file",
+        parameters: {
+          type: "object",
+          properties: { path: { type: "string" } },
+          required: ["path"],
+        },
+        fn: () => "e",
+      });
+      await reg.dispatch("read_file", "{}");
+      const out = await reg.dispatch("edit_file", "{}"); // first time for edit_file
+      const parsed = JSON.parse(out);
+      expect(parsed.consecutiveMalformed).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Caught in a real review session: model called `read_file({})` (missing required `path`), got back the standard "missing required parameter" error, and the very next turn issued the **exact same call** — same empty args, same tool. Same error came back. After the second rejection it gave up tool-calling entirely and dumped to summary. `StormBreaker` (6-call window, threshold 3) never tripped on this — it watches all tools together, not per-tool malformed-args repeats.

`ToolRegistry` now tracks the per-tool fingerprint of the last call that failed schema validation (JSON parse error or missing required param). On the **2nd consecutive identical malformed call** to the same tool, the result switches to a sharper error — `"same call just failed validation — DO NOT retry with identical args. Either fix the call (read the schema in the tool spec) or pick a different tool"` — plus `consecutiveMalformed: true` so future callers can spot it programmatically.

Streak clearing:
- Any **successful** validation for that tool clears its streak.
- Tracking is **per-tool** — a malformed `read_file` doesn't affect a fresh `edit_file` call.
- A successful call between two identical malformed ones counts as a fresh start, not the 2nd-in-a-row.

Closes #651

## Test plan

- [x] `npm run verify` — 2576 passed (added 6), 2 skipped
- [x] New `tests/tools.test.ts` block "malformed-args storm guard (issue #651)":
  - First malformed → normal error (no `consecutiveMalformed`)
  - Second identical → sharper error with `consecutiveMalformed: true`
  - Different malformed shape (missing `body` then missing `path`) → not tripped
  - Successful call in between → resets the streak
  - Invalid JSON identical twice → also short-circuits
  - Per-tool isolation — a streak on `read_file` doesn't poison `edit_file`
