### PR TITLE
fix(ui): render user-message cards verbatim, not through Markdown

### DIFF
--- a/src/cli/ui/cards/UserCard.tsx
+++ b/src/cli/ui/cards/UserCard.tsx
@@ -1,7 +1,7 @@
+import { Text } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React from "react";
 import { t } from "../../../i18n/index.js";
-import { Markdown } from "../markdown.js";
 import { Card } from "../primitives/Card.js";
 import { CardHeader } from "../primitives/CardHeader.js";
 import type { UserCard as UserCardData } from "../state/cards.js";
@@ -18,7 +18,7 @@ export function UserCard({ card }: { card: UserCardData }): React.ReactElement {
         titleColor={FG.sub}
         meta={[formatRelativeTime(card.ts)]}
       />
-      <Markdown text={card.text} />
+      <Text>{card.text}</Text>
     </Card>
   );
 }

--- a/tests/user-card-verbatim.test.tsx
+++ b/tests/user-card-verbatim.test.tsx
@@ -1,0 +1,43 @@
+import { render } from "ink-testing-library";
+// biome-ignore lint/style/useImportType: needed in value scope for JSX
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { UserCard } from "../src/cli/ui/cards/UserCard.js";
+import type { UserCard as UserCardData } from "../src/cli/ui/state/cards.js";
+
+function userCard(text: string): UserCardData {
+  return { kind: "user", id: "u1", ts: Date.now(), text };
+}
+
+describe("UserCard renders verbatim (issue #655)", () => {
+  it("preserves literal asterisks instead of treating them as bold/italic", () => {
+    const { lastFrame } = render(<UserCard card={userCard("hit **error** in src/foo.ts")} />);
+    expect(lastFrame()).toContain("**error**");
+    expect(lastFrame()).toContain("src/foo.ts");
+  });
+
+  it("preserves a leading '#' instead of rendering it as a heading", () => {
+    const { lastFrame } = render(<UserCard card={userCard("# why does this fail")} />);
+    expect(lastFrame()).toContain("# why does this fail");
+  });
+
+  it("preserves bracket-link syntax verbatim (no link rewrite, no hidden url)", () => {
+    const { lastFrame } = render(
+      <UserCard card={userCard("see [docs](https://example.com/doc)")} />,
+    );
+    expect(lastFrame()).toContain("[docs](https://example.com/doc)");
+  });
+
+  it("preserves inline backticks", () => {
+    const { lastFrame } = render(<UserCard card={userCard("call `web_search()`")} />);
+    expect(lastFrame()).toContain("`web_search()`");
+  });
+
+  it("preserves four-space-indented blocks (markdown's code-block trigger)", () => {
+    const { lastFrame } = render(
+      <UserCard card={userCard("error trace:\n    at foo (bar.js:10:5)")} />,
+    );
+    const out = lastFrame();
+    expect(out).toContain("    at foo (bar.js:10:5)");
+  });
+});


### PR DESCRIPTION
## Summary

`UserCard` was rendering every user message through `<Markdown>`. So pasting code, stack traces, or any text with `*` / `#` / `[]()` / backticks / 4-space indent caused the displayed user card to silently reinterpret the markdown punctuation — the model still saw the full verbatim text, but the user's visible round-trip (what I sent vs. what I see in history) was wrong.

Examples that broke:
- `**error**` → bold (asterisks vanish)
- `# why does this fail` → H1 (the `#` vanishes)
- `[docs](https://example.com)` → underlined "docs", URL hidden
- `` `web_search()` `` → inline-code styling
- 4-space-indented stack traces → re-styled as a code block

Fix: render the user-message card as a plain `<Text>` instead. Assistant turns keep Markdown — that's where formatted output belongs.

Closes #655

## Test plan

- [x] `npm run verify` — 2592 passed (added 5), 2 skipped
- [x] `tests/user-card-verbatim.test.tsx` pins five cases: asterisks, leading `#`, link syntax, inline backticks, 4-space indent — all preserved verbatim
- [ ] Manual: paste a stack trace into the composer, send, eyeball that the history card shows it literally
