### PR TITLE
fix(markdown): decode HTML entities in code blocks and inline code

### DIFF
--- a/src/cli/ui/html-entities.ts
+++ b/src/cli/ui/html-entities.ts
@@ -1,0 +1,43 @@
+/** Models sometimes emit HTML-escaped code (issue #657: `&quot;` instead of `"`). Terminals don't render entities, so decode at the markdown boundary. */
+
+const NAMED: Record<string, string> = {
+  quot: '"',
+  apos: "'",
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  nbsp: "\u00a0",
+};
+
+const ENTITY_RE = /&(?:#x([0-9A-Fa-f]+)|#(\d+)|([a-zA-Z]+));/g;
+
+/** Decode the entity shapes LLMs leak into code (`&quot;` / `&amp;` / `&#34;` / `&#x22;`). Unknown names are left as-is, since legitimate text may quote entities by name. */
+export function decodeHtmlEntities(text: string): string {
+  if (text.indexOf("&") === -1) return text;
+  return text.replace(
+    ENTITY_RE,
+    (match, hex: string | undefined, dec: string | undefined, name: string | undefined) => {
+      if (hex !== undefined) {
+        const code = Number.parseInt(hex, 16);
+        return Number.isFinite(code) && code > 0 ? safeFromCodePoint(code, match) : match;
+      }
+      if (dec !== undefined) {
+        const code = Number.parseInt(dec, 10);
+        return Number.isFinite(code) && code > 0 ? safeFromCodePoint(code, match) : match;
+      }
+      if (name !== undefined) {
+        const lower = name.toLowerCase();
+        return Object.hasOwn(NAMED, lower) ? NAMED[lower]! : match;
+      }
+      return match;
+    },
+  );
+}
+
+function safeFromCodePoint(code: number, fallback: string): string {
+  try {
+    return String.fromCodePoint(code);
+  } catch {
+    return fallback;
+  }
+}

--- a/src/cli/ui/markdown-lines.ts
+++ b/src/cli/ui/markdown-lines.ts
@@ -1,6 +1,7 @@
 /** Pure markdown → flat MdLine[]. Streaming-safe: marked.lexer tolerates partial input. */
 
 import { type Token, type Tokens, marked } from "marked";
+import { decodeHtmlEntities } from "./html-entities.js";
 
 export interface InlineStyle {
   bold?: boolean;
@@ -57,7 +58,11 @@ function emitBlock(tok: Token, out: MdLine[], depth: number): void {
     }
     case "code": {
       const c = tok as Tokens.Code;
-      out.push({ kind: "code", lang: (c.lang ?? "").split(/\s+/)[0] ?? "", text: c.text });
+      out.push({
+        kind: "code",
+        lang: (c.lang ?? "").split(/\s+/)[0] ?? "",
+        text: decodeHtmlEntities(c.text),
+      });
       return;
     }
     case "list": {
@@ -157,7 +162,7 @@ function walk(tokens: Token[], style: InlineStyle, out: InlineSpan[]): void {
         walk((tok as Tokens.Del).tokens, { ...style, strike: true }, out);
         break;
       case "codespan":
-        out.push({ text: (tok as Tokens.Codespan).text, code: true, ...style });
+        out.push({ text: decodeHtmlEntities((tok as Tokens.Codespan).text), code: true, ...style });
         break;
       case "link": {
         const l = tok as Tokens.Link;

--- a/src/cli/ui/markdown.tsx
+++ b/src/cli/ui/markdown.tsx
@@ -6,6 +6,7 @@ import { type Token, type Tokens, marked } from "marked";
 import React from "react";
 import stringWidth from "string-width";
 import { wrapToCells } from "../../frame/width.js";
+import { decodeHtmlEntities } from "./html-entities.js";
 import { FG, SURFACE, TONE } from "./theme/tokens.js";
 
 /** Left margin consumed by card outer marginLeft + body paddingLeft + safety. */
@@ -136,7 +137,7 @@ function ListItem({
 
 function CodeBlock({ token }: { token: Tokens.Code }): React.ReactElement {
   const lang = token.lang?.split(/\s+/)[0] ?? "";
-  const colored = highlightCode(token.text, lang);
+  const colored = highlightCode(decodeHtmlEntities(token.text), lang);
   const lines = colored.split("\n");
   return (
     <Box flexDirection="column">
@@ -442,7 +443,7 @@ function InlineToken({ token }: { token: Token }): React.ReactElement {
     case "codespan":
       return (
         <Text color={FG.strong} backgroundColor={SURFACE.bgElev}>
-          {` ${(token as Tokens.Codespan).text} `}
+          {` ${decodeHtmlEntities((token as Tokens.Codespan).text)} `}
         </Text>
       );
     case "del":
@@ -489,7 +490,7 @@ export function plainText(tokens: Token[] | undefined): string {
         out += plainText((t as { tokens?: Token[] }).tokens ?? []);
         break;
       case "codespan":
-        out += (t as Tokens.Codespan).text;
+        out += decodeHtmlEntities((t as Tokens.Codespan).text);
         break;
       case "br":
         out += "\n";

--- a/tests/html-entities.test.ts
+++ b/tests/html-entities.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { decodeHtmlEntities } from "../src/cli/ui/html-entities.js";
+
+describe("decodeHtmlEntities (issue #657)", () => {
+  it("passes through strings with no '&' fast-path", () => {
+    expect(decodeHtmlEntities('{ "apiKey": "value" }')).toBe('{ "apiKey": "value" }');
+  });
+
+  it("decodes the common five named entities models leak", () => {
+    expect(decodeHtmlEntities("&quot;apiKey&quot;: &quot;sk-...&quot;")).toBe('"apiKey": "sk-..."');
+    expect(decodeHtmlEntities("&apos;foo&apos;")).toBe("'foo'");
+    expect(decodeHtmlEntities("a &amp; b")).toBe("a & b");
+    expect(decodeHtmlEntities("&lt;div&gt;")).toBe("<div>");
+  });
+
+  it("decodes &nbsp; to NBSP (terminal renders it as a space cell)", () => {
+    expect(decodeHtmlEntities("a&nbsp;b")).toBe("a\u00a0b");
+  });
+
+  it('decodes decimal numeric entities (&#34; → ")', () => {
+    expect(decodeHtmlEntities("&#34;hello&#34;")).toBe('"hello"');
+    expect(decodeHtmlEntities("emoji &#128512;")).toBe("emoji 😀");
+  });
+
+  it('decodes hex numeric entities (&#x22; → ", &#x1F600; → 😀)', () => {
+    expect(decodeHtmlEntities("&#x22;k&#x22;")).toBe('"k"');
+    expect(decodeHtmlEntities("&#x1F600;")).toBe("😀");
+  });
+
+  it("leaves unknown named entities alone (don't corrupt prose that quotes entity names)", () => {
+    expect(decodeHtmlEntities("the &notreal; entity")).toBe("the &notreal; entity");
+  });
+
+  it("is case-insensitive on named entities (&QUOT; works)", () => {
+    expect(decodeHtmlEntities("&QUOT;mixed&Quot;")).toBe('"mixed"');
+  });
+
+  it("leaves malformed-looking '&' fragments alone", () => {
+    expect(decodeHtmlEntities("a & b")).toBe("a & b");
+    expect(decodeHtmlEntities("&;")).toBe("&;");
+    expect(decodeHtmlEntities("&#;")).toBe("&#;");
+  });
+
+  it("decodes the real-world JSON-with-quot pattern from issue #657", () => {
+    const input = [
+      "{",
+      "  &quot;apiKey&quot;: &quot;sk-deepseek&quot;,",
+      "  &quot;preset&quot;: &quot;auto&quot;,",
+      "  &quot;mcp&quot;: [",
+      "  ]",
+      "}",
+    ].join("\n");
+    const expected = [
+      "{",
+      '  "apiKey": "sk-deepseek",',
+      '  "preset": "auto",',
+      '  "mcp": [',
+      "  ]",
+      "}",
+    ].join("\n");
+    expect(decodeHtmlEntities(input)).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary

Reporter showed a JSON snippet rendered as `{ &quot;apiKey&quot;: &quot;...&quot; }` inside a code fence — the model emitted literal HTML entities instead of `"`. `marked` passes the entities through verbatim (its tokens carry raw text, not HTML-escaped output), and our renderer hands that to the terminal unchanged. Terminals don't render entities, so `&quot;` / `&amp;` / `&lt;` leak as visible artifacts.

This is a known LLM artifact: models sometimes HTML-escape inside code blocks — especially on JSON / HTML / XML output — because their training data had plenty of HTML-encoded code in web posts and docs. Claude Code and Cursor both decode entities at the rendering boundary; doing the same here.

## Scope

- New `src/cli/ui/html-entities.ts` with `decodeHtmlEntities()` — handles the five common named entities (`quot` / `apos` / `amp` / `lt` / `gt` / `nbsp`) plus numeric forms (`&#34;` / `&#x22;`). Unknown named entities pass through so prose that quotes entity names by name doesn't get corrupted. Fast-path early-return when no `&` is present so paragraph text pays nothing.
- Decode applied at **four sites**: `CodeBlock` text and `codespan` text in both `markdown.tsx` and `markdown-lines.ts`.
- Prose paragraph text is **left alone** — limiting scope to code keeps the edge case of "user genuinely wrote about `&amp;`" working in prose.

Closes #657

## Test plan

- [x] `npm run verify` — 2601 passed (added 9), 2 skipped
- [x] `tests/html-entities.test.ts` covers: no-`&` fast path, five named entities, `&nbsp;` → NBSP, decimal + hex numeric (incl. emoji codepoint), unknown-name pass-through, case-insensitivity, malformed `&` fragments left alone, and the literal real-world JSON pattern from the issue
- [ ] Manual: ask the model to emit a JSON code block and verify quotes render as `"` not `&quot;`
