### PR TITLE
feat(composer): Ctrl+X opens $EDITOR with the current input

### DIFF
--- a/src/cli/edit/external-editor.ts
+++ b/src/cli/edit/external-editor.ts
@@ -1,0 +1,80 @@
+/** Hands the composer buffer to $EDITOR / $VISUAL / $GIT_EDITOR and reads back what the user saved. */
+
+import { spawn } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export interface OpenEditorResult {
+  /** "ok" when the editor returned 0 and we read content back; "missing" when no editor env var is set; "failed" on spawn error or non-zero exit. */
+  kind: "ok" | "missing" | "failed";
+  /** Final buffer contents. On `missing` / `failed`, this is the original `initial` (caller restores composer state). */
+  content: string;
+  /** Human-readable detail — surface to the user on failed / missing. */
+  detail?: string;
+}
+
+/** $VISUAL beats $EDITOR per traditional Unix precedence; $GIT_EDITOR wins because users who set it are explicit about their tool of choice. */
+export function detectEditor(env: NodeJS.ProcessEnv = process.env): string | null {
+  for (const key of ["GIT_EDITOR", "VISUAL", "EDITOR"]) {
+    const raw = env[key];
+    if (typeof raw === "string" && raw.trim().length > 0) return raw.trim();
+  }
+  return null;
+}
+
+/** Writes `initial` to a temp file, spawns the editor on it, reads back on exit. Strips one trailing newline that most editors auto-append. */
+export async function openInExternalEditor(initial: string): Promise<OpenEditorResult> {
+  const editor = detectEditor();
+  if (!editor) {
+    return {
+      kind: "missing",
+      content: initial,
+      detail:
+        "no $EDITOR / $VISUAL / $GIT_EDITOR set — export one (e.g. `export EDITOR=nano`) and retry",
+    };
+  }
+  const dir = mkdtempSync(join(tmpdir(), "reasonix-compose-"));
+  const path = join(dir, "REASONIX_INPUT.md");
+  try {
+    writeFileSync(path, initial, "utf8");
+    await spawnEditor(editor, path);
+    const raw = readFileSync(path, "utf8");
+    return { kind: "ok", content: stripTrailingNewline(raw) };
+  } catch (err) {
+    return {
+      kind: "failed",
+      content: initial,
+      detail: (err as Error).message,
+    };
+  } finally {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      /* leftover temp file is harmless — OS cleans tmpdir periodically */
+    }
+  }
+}
+
+function spawnEditor(editor: string, path: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    // Use a shell so `editor` strings like `nvim --noplugin` or `code --wait`
+    // split correctly across platforms. `stdio: inherit` is what lets vim /
+    // nano take over the terminal — they need TTY input + output.
+    const child = spawn(`${editor} "${path}"`, {
+      shell: true,
+      stdio: "inherit",
+    });
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code === 0 || code === null) resolve();
+      else reject(new Error(`editor exited with code ${code}`));
+    });
+  });
+}
+
+function stripTrailingNewline(s: string): string {
+  if (s.endsWith("\r\n")) return s.slice(0, -2);
+  if (s.endsWith("\n")) return s.slice(0, -1);
+  return s;
+}

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -1,6 +1,6 @@
 import { type WriteStream, statSync } from "node:fs";
 import { resolve } from "node:path";
-import { Box, Text, useStdout } from "ink";
+import { Box, Text, useStdin, useStdout } from "ink";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   type JsonlEventSink,
@@ -84,6 +84,7 @@ import { registerSkillTools } from "../../tools/skills.js";
 import { formatSubagentResult, spawnSubagent } from "../../tools/subagent.js";
 import { webFetch } from "../../tools/web.js";
 import { openTranscriptFile } from "../../transcript/log.js";
+import { openInExternalEditor } from "../edit/external-editor.js";
 import { dumpStartupProfile, markPhase } from "../startup-profile.js";
 import { AtMentionSuggestions } from "./AtMentionSuggestions.js";
 import { BootSplash } from "./BootSplash.js";
@@ -624,6 +625,23 @@ function AppInner({
   // persist to disk — the session log already keeps the messages, and
   // cross-session bash-style recall would need per-project scoping.
   const { recallPrev, recallNext, pushHistory, resetCursor } = useInputRecall(setInput);
+  const { setRawMode, isRawModeSupported } = useStdin();
+  // Ctrl+X — hand the composer buffer to $EDITOR. Raw-mode flip lets the
+  // editor own line-buffered input; result replaces the composer value.
+  const handleOpenExternalEditor = useCallback(async () => {
+    if (!isRawModeSupported) {
+      log.pushWarning(t("composer.editorFailed"), t("composer.editorNoRawMode"));
+      return;
+    }
+    setRawMode(false);
+    try {
+      const result = await openInExternalEditor(input);
+      if (result.kind === "ok") setInput(result.content);
+      else if (result.detail) log.pushWarning(t("composer.editorFailed"), result.detail);
+    } finally {
+      setRawMode(true);
+    }
+  }, [input, isRawModeSupported, log, setRawMode]);
   // Disambiguates <Static> keys when a single turn yields multiple assistant_final events.
   const assistantIterCounter = useRef<number>(0);
   // Per-session @url fetch cache. Keyed by stripped URL; same URL
@@ -3776,6 +3794,7 @@ function AppInner({
                             disabled={busy}
                             onHistoryPrev={recallPrev}
                             onHistoryNext={recallNext}
+                            onOpenExternalEditor={handleOpenExternalEditor}
                           />
                         </Box>
                         <Box flexDirection="column" flexShrink={0} flexWrap="nowrap">

--- a/src/cli/ui/PromptInput.tsx
+++ b/src/cli/ui/PromptInput.tsx
@@ -35,6 +35,8 @@ export interface PromptInputProps {
   /** Ctrl+P / Ctrl+N hand off here when no in-buffer cursor move applies — parent walks history and swaps `value` via `onChange`. */
   onHistoryPrev?: () => void;
   onHistoryNext?: () => void;
+  /** Ctrl+X — parent spawns $EDITOR with the current buffer and re-injects on exit. */
+  onOpenExternalEditor?: () => void;
 }
 
 export function PromptInput({
@@ -45,6 +47,7 @@ export function PromptInput({
   placeholder,
   onHistoryPrev,
   onHistoryNext,
+  onOpenExternalEditor,
 }: PromptInputProps) {
   // Cap at 24 — collapseLinesForDisplay hides content past ~20 logical lines.
   // Quantize spec.max to 4-row buckets so per-keystroke line-count changes
@@ -141,6 +144,7 @@ export function PromptInput({
     }
     if (action.historyHandoff === "prev") onHistoryPrev?.();
     if (action.historyHandoff === "next") onHistoryNext?.();
+    if (action.openExternalEditor) onOpenExternalEditor?.();
   }, !disabled);
 
   // ── Render ──────────────────────────────────────────────────────

--- a/src/cli/ui/multiline-keys.ts
+++ b/src/cli/ui/multiline-keys.ts
@@ -32,6 +32,8 @@ export interface MultilineAction {
   historyHandoff?: "prev" | "next";
   /** Reducer is pure — hands raw paste to PromptInput which allocates a sentinel and inserts that. */
   pasteRequest?: { content: string };
+  /** Ctrl+X — hand the current buffer to $EDITOR; parent re-injects on exit. */
+  openExternalEditor?: boolean;
 }
 
 import { recoverCsiTail, stripCsiFragments } from "./key-normalize.js";
@@ -54,6 +56,13 @@ export function processMultilineKey(
   // Parent-owned keys: Tab (slash-complete), Esc (abort).
   if (key.tab || key.escape) {
     return NOOP;
+  }
+
+  // Ctrl+X — open $EDITOR with the current buffer (bash readline parity).
+  // Parent runs the spawn (filesystem + child process) and replaces the
+  // composer value with whatever the user saved.
+  if (key.ctrl && key.input === "x") {
+    return { ...NOOP, openExternalEditor: true };
   }
 
   // PageUp/PageDown jump to start/end of the WHOLE buffer — useful

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -1090,6 +1090,9 @@ export const EN: TranslationSchema = {
     hintAbort: "abort",
     hintQuit: "quit",
     abortedHint: "turn aborted by user \u00b7 esc again to clear \u00b7 \u23ce to ask a follow-up",
+    editorNoRawMode:
+      "external editor unavailable \u2014 stdin doesn't support raw-mode toggling on this terminal",
+    editorFailed: "external editor:",
   },
   shellConfirm: {
     title: "Shell command",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -379,6 +379,8 @@ export interface TranslationSchema {
     hintAbort: string;
     hintQuit: string;
     abortedHint: string;
+    editorNoRawMode: string;
+    editorFailed: string;
   };
   shellConfirm: {
     title: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -1035,6 +1035,8 @@ export const zhCN: TranslationSchema = {
     hintAbort: "中止",
     hintQuit: "退出",
     abortedHint: "用户已中止本轮 · 再按 Esc 清除 · ⏎ 继续提问",
+    editorNoRawMode: "外部编辑器不可用 — 当前终端不支持 raw-mode 切换",
+    editorFailed: "外部编辑器：",
   },
   shellConfirm: {
     title: "Shell 命令",

--- a/tests/external-editor.test.ts
+++ b/tests/external-editor.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { detectEditor } from "../src/cli/edit/external-editor.js";
+
+describe("detectEditor (issue #647)", () => {
+  it("returns null when no editor env var is set", () => {
+    expect(detectEditor({})).toBeNull();
+  });
+
+  it("GIT_EDITOR wins over VISUAL and EDITOR", () => {
+    expect(
+      detectEditor({
+        GIT_EDITOR: "git-pref",
+        VISUAL: "visual-pref",
+        EDITOR: "editor-pref",
+      }),
+    ).toBe("git-pref");
+  });
+
+  it("VISUAL wins over EDITOR when GIT_EDITOR is unset", () => {
+    expect(detectEditor({ VISUAL: "visual-pref", EDITOR: "editor-pref" })).toBe("visual-pref");
+  });
+
+  it("falls back to EDITOR last", () => {
+    expect(detectEditor({ EDITOR: "nano" })).toBe("nano");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(detectEditor({ EDITOR: "  nano --noplugin  " })).toBe("nano --noplugin");
+  });
+
+  it("treats an empty / whitespace-only var as unset", () => {
+    expect(detectEditor({ EDITOR: "   " })).toBeNull();
+    expect(detectEditor({ EDITOR: "" })).toBeNull();
+  });
+});

--- a/tests/multiline-keys.test.ts
+++ b/tests/multiline-keys.test.ts
@@ -515,3 +515,19 @@ describe("lineAndColumn", () => {
     expect(lineAndColumn("abc", 99)).toEqual({ line: 0, col: 3 });
   });
 });
+
+describe("processMultilineKey — Ctrl+X opens external editor (issue #647)", () => {
+  it("Ctrl+X returns openExternalEditor flag without mutating the buffer", () => {
+    const action = processMultilineKey("draft", 3, key({ ctrl: true, input: "x" }));
+    expect(action.openExternalEditor).toBe(true);
+    expect(action.next).toBeNull();
+    expect(action.cursor).toBeNull();
+    expect(action.submit).toBe(false);
+  });
+
+  it("plain 'x' (no ctrl) still inserts as a character", () => {
+    const action = processMultilineKey("a", 1, key({ input: "x" }));
+    expect(action.openExternalEditor).toBeUndefined();
+    expect(action.next).toBe("ax");
+  });
+});


### PR DESCRIPTION
Composes a long prompt in the user's preferred editor instead of typing it inside the TUI. Matches `opencode <C-x>e` and `codex <C-g>` — issue #647.

## Changes

- New `src/cli/edit/external-editor.ts` — resolves the editor via `GIT_EDITOR → VISUAL → EDITOR` (Unix precedence), writes the current buffer to a temp file, spawns the editor inheriting the TTY, reads back on exit, strips one trailing newline.
- `multiline-keys.ts` — new pure action flag `openExternalEditor: true` on `Ctrl+X`, so the reducer stays testable.
- `PromptInput.tsx` — new `onOpenExternalEditor` callback prop.
- `App.tsx` — wires the callback: flips raw-mode off around the spawn so the editor owns cooked line-buffered input, restores raw-mode on exit, and replaces the composer value with the result. Missing-editor and non-zero-exit cases surface as a warning card in the chat log.
- Spawn uses `shell: true` so `EDITOR="nvim --noplugin"` and `EDITOR="code --wait"` split correctly cross-platform (same shape as the existing `commit.ts` invocation).

Refs #647 — the picker-keymap half of that issue (Ctrl+N/P navigating the slash picker) is a separate change, coming next.

## Test plan

- [x] `npm run verify` — 2609 passed (added 8), 2 skipped
- [x] `tests/external-editor.test.ts` covers env-var precedence + trim + empty-string handling
- [x] `tests/multiline-keys.test.ts` covers Ctrl+X → action flag, plain `x` still inserts
- [ ] Manual: `export EDITOR=nano`, hit Ctrl+X in the composer, type, save+exit, verify input replaced