### PR TITLE
fix(scroll): coalesce pinned-mode shrinks to stop double-Esc flicker

### DIFF
--- a/src/cli/ui/state/chat-scroll-store.ts
+++ b/src/cli/ui/state/chat-scroll-store.ts
@@ -49,6 +49,12 @@ export function createChatScrollStore(): ChatScrollStore {
   const listeners = new Set<ScrollListener>();
   let pendingDelta = 0;
   let flushTimer: NodeJS.Timeout | null = null;
+  // Trailing-edge coalesce target for pinned-mode shrinks (issue #653).
+  // While a burst of card-collapse re-measurements arrives, we hold the latest
+  // target here and apply it once on a microtask flush, so subscribers see one
+  // settled transition instead of N oscillating snaps.
+  let pendingMaxShrink: number | null = null;
+  let shrinkTimer: NodeJS.Timeout | null = null;
 
   function set(next: Partial<ChatScrollState>): void {
     const merged = { ...state, ...next };
@@ -91,6 +97,18 @@ export function createChatScrollStore(): ChatScrollStore {
     }
   }
 
+  function flushShrink(): void {
+    if (shrinkTimer !== null) {
+      clearTimeout(shrinkTimer);
+      shrinkTimer = null;
+    }
+    const target = pendingMaxShrink;
+    pendingMaxShrink = null;
+    if (target === null) return;
+    const nextScrollRows = state.pinned ? target : Math.min(state.scrollRows, target);
+    set({ maxScroll: target, scrollRows: nextScrollRows });
+  }
+
   return {
     getState() {
       return state;
@@ -111,10 +129,34 @@ export function createChatScrollStore(): ChatScrollStore {
         clearTimeout(flushTimer);
         flushTimer = null;
       }
+      // Drop any deferred shrink so an explicit jump isn't undone by a stale target.
+      pendingMaxShrink = null;
+      if (shrinkTimer !== null) {
+        clearTimeout(shrinkTimer);
+        shrinkTimer = null;
+      }
       set({ pinned: true });
     },
     setMaxScroll(rows: number) {
       const m = rows < 0 ? 0 : rows;
+      // Coalesce shrinks while pinned (issue #653): a burst of card-teardown
+      // re-measurements during an Esc-abort would otherwise snap scrollRows N
+      // times, producing a visible flicker. Grows still apply immediately so
+      // normal streaming output keeps the viewport pinned without latency.
+      const currentMax = pendingMaxShrink ?? state.maxScroll;
+      if (state.pinned && m < currentMax) {
+        pendingMaxShrink = m;
+        if (shrinkTimer === null) {
+          shrinkTimer = setTimeout(() => {
+            shrinkTimer = null;
+            flushShrink();
+          }, COALESCE_MS);
+        }
+        return;
+      }
+      // Non-shrink path: flush any deferred shrink first so its trailing state
+      // doesn't clobber the value we're about to set.
+      if (pendingMaxShrink !== null) flushShrink();
       // Pinned-mode invariant: scrollRows tracks maxScroll exactly.
       const nextScrollRows = state.pinned ? m : Math.min(state.scrollRows, m);
       set({ maxScroll: m, scrollRows: nextScrollRows });

--- a/tests/modal-scroll-reset.test.ts
+++ b/tests/modal-scroll-reset.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createChatScrollStore } from "../src/cli/ui/state/chat-scroll-store.js";
 import { PauseGate } from "../src/core/pause-gate.js";
 
@@ -40,6 +40,126 @@ describe("chatScroll jumpToBottom (issue #642)", () => {
       void gate.ask({ kind, payload: payloadFor(kind) } as Parameters<typeof gate.ask>[0]);
       expect(store.getState().pinned).toBe(true);
       gate.cancelAll();
+    }
+  });
+});
+
+describe("chatScroll setMaxScroll coalescing (issue #653)", () => {
+  it("coalesces a burst of pinned-mode shrinks into a single trailing transition", async () => {
+    vi.useFakeTimers();
+    try {
+      const store = createChatScrollStore();
+      // Fill past one screen so maxScroll > 0; pinned stays true.
+      store.setMaxScroll(500);
+      expect(store.getState().pinned).toBe(true);
+      expect(store.getState().scrollRows).toBe(500);
+
+      const seen: Array<{ scrollRows: number; maxScroll: number }> = [];
+      store.subscribe(() => {
+        const s = store.getState();
+        seen.push({ scrollRows: s.scrollRows, maxScroll: s.maxScroll });
+      });
+
+      // Simulate N parallel subagent-card collapses re-measuring maxScroll in
+      // rapid succession during an Esc abort. Without coalescing, each call
+      // would snap scrollRows and bounce the viewport.
+      store.setMaxScroll(440);
+      store.setMaxScroll(380);
+      store.setMaxScroll(310);
+      store.setMaxScroll(260);
+      store.setMaxScroll(200);
+
+      // No subscriber notifications yet — shrinks are deferred.
+      expect(seen).toEqual([]);
+      // State still reflects the pre-burst values until the trailing flush.
+      expect(store.getState().scrollRows).toBe(500);
+      expect(store.getState().maxScroll).toBe(500);
+
+      await vi.advanceTimersByTimeAsync(32);
+
+      // Exactly one settled transition lands at the final target.
+      expect(seen).toEqual([{ scrollRows: 200, maxScroll: 200 }]);
+      expect(store.getState().pinned).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("applies grows immediately so streaming output stays pinned without latency", () => {
+    const store = createChatScrollStore();
+    store.setMaxScroll(50);
+    expect(store.getState().scrollRows).toBe(50);
+    store.setMaxScroll(120);
+    expect(store.getState().scrollRows).toBe(120);
+    store.setMaxScroll(300);
+    expect(store.getState().scrollRows).toBe(300);
+  });
+
+  it("does not coalesce when not pinned — shrinks apply immediately so scrollRows clamps", () => {
+    const store = createChatScrollStore();
+    store.setMaxScroll(500);
+    store.scrollPageUp();
+    store.scrollPageUp();
+    expect(store.getState().pinned).toBe(false);
+    const beforeRows = store.getState().scrollRows;
+
+    store.setMaxScroll(200);
+    expect(store.getState().maxScroll).toBe(200);
+    expect(store.getState().scrollRows).toBe(Math.min(beforeRows, 200));
+  });
+
+  it("a follow-up grow during a coalesced shrink flushes the shrink first", async () => {
+    vi.useFakeTimers();
+    try {
+      const store = createChatScrollStore();
+      store.setMaxScroll(500);
+
+      store.setMaxScroll(300);
+      // Deferred — state still 500.
+      expect(store.getState().maxScroll).toBe(500);
+
+      store.setMaxScroll(600);
+      // Grow forced an immediate flush; final value is the grow target.
+      expect(store.getState().maxScroll).toBe(600);
+      expect(store.getState().scrollRows).toBe(600);
+      expect(store.getState().pinned).toBe(true);
+
+      // Allow any leftover timer to fire — must not regress the state.
+      await vi.advanceTimersByTimeAsync(32);
+      expect(store.getState().maxScroll).toBe(600);
+      expect(store.getState().scrollRows).toBe(600);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("jumpToBottom cancels a pending shrink so the explicit pin wins", async () => {
+    vi.useFakeTimers();
+    try {
+      const store = createChatScrollStore();
+      store.setMaxScroll(500);
+      store.scrollPageUp();
+      store.scrollPageUp();
+      expect(store.getState().pinned).toBe(false);
+      // Re-pin (this also clears any prior delta flush).
+      store.jumpToBottom();
+      expect(store.getState().pinned).toBe(true);
+
+      // Now grow then queue a shrink.
+      store.setMaxScroll(500);
+      expect(store.getState().scrollRows).toBe(500);
+      store.setMaxScroll(200);
+      // Deferred.
+      expect(store.getState().maxScroll).toBe(500);
+
+      store.jumpToBottom();
+      await vi.advanceTimersByTimeAsync(32);
+
+      // The deferred shrink was dropped; state is still at 500 from the grow.
+      expect(store.getState().maxScroll).toBe(500);
+      expect(store.getState().pinned).toBe(true);
+    } finally {
+      vi.useRealTimers();
     }
   });
 });


### PR DESCRIPTION
## Summary
Double-Esc aborting a multi-subagent run past one screen would flicker and bounce the scroll position: each card teardown re-measured and called `setMaxScroll` synchronously, snapping `scrollRows` N times in pinned mode. This change coalesces those shrinks behind the same `COALESCE_MS` trailing-edge timer the delta path already uses, so a burst of re-measurements collapses into one settled transition.

## Changes
- `src/cli/ui/state/chat-scroll-store.ts`: add `pendingMaxShrink` / `shrinkTimer` and a `flushShrink()` helper; in `setMaxScroll`, defer pinned-mode shrinks to a trailing `setTimeout(COALESCE_MS)` flush while keeping grows immediate; flush any pending shrink before applying a non-shrink update so its trailing state can't clobber a fresh value; clear the pending shrink in `jumpToBottom` so an explicit pin isn't undone by a stale target.
- `tests/modal-scroll-reset.test.ts`: add a `setMaxScroll coalescing (issue #653)` suite covering the burst-of-shrinks case (one trailing transition at the final target), grows applying immediately, the unpinned path still clamping `scrollRows` synchronously, a grow flushing a pending shrink, and `jumpToBottom` dropping a pending shrink.

## Testing
`npm run test -- tests/modal-scroll-reset.test.ts` — the new coalescing suite passes alongside the existing `jumpToBottom` (issue #642) tests. The burst test uses `vi.useFakeTimers()` and advances 32ms to assert exactly one subscriber notification at the final target.

## Notes
The fix piggybacks on the existing `COALESCE_MS` window rather than introducing a separate knob, to keep the timing model in the store consistent. Grows are intentionally left synchronous so streaming output stays pinned without added latency; only pinned-mode shrinks are deferred.

Closes #653