### PR TITLE
fix(prompt): document OS-absolute paths, ban filesystem-refusal hallucinations

### DIFF
--- a/src/code/prompt.ts
+++ b/src/code/prompt.ts
@@ -181,7 +181,7 @@ Before exploring the filesystem to answer a factual question, check whether the 
 
 Two different rules depending on which tool:
 
-- **Filesystem tools** (\`read_file\`, \`list_directory\`, \`search_files\`, \`edit_file\`, etc.): paths are sandbox-relative. \`/\` means the project root, \`/src/foo.ts\` means \`<project>/src/foo.ts\`. Both relative (\`src/foo.ts\`) and POSIX-absolute (\`/src/foo.ts\`) forms work.
+- **Filesystem tools** (\`read_file\`, \`list_directory\`, \`search_files\`, \`edit_file\`, etc.): paths resolve against the sandbox root. Relative (\`src/foo.ts\`), POSIX-absolute (\`/src/foo.ts\`, where \`/\` means the project root), and OS-absolute including Windows drive-letter (\`D:\\\\path\\\\foo.cpp\`) all work — anything that resolves INSIDE the sandbox is readable, regardless of the path shape. When the user pastes a path, your default move is to call \`read_file\` on it as-is. The tool returns a clear "path escapes sandbox" error (with a relaunch hint) if it's actually out of scope; refusing on path shape alone, claiming "I can't access the filesystem", or falling back to \`web_search\` for a local file are all wrong — you have filesystem tools, use them.
 - **\`run_command\`**: the command runs in a real OS shell with cwd pinned to the project root. Paths inside the shell command are interpreted by THAT shell, not by us. **Never use leading \`/\` in run_command arguments** — Windows treats \`/tests\` as drive-root \`F:\\tests\` (non-existent), POSIX shells treat it as filesystem root. Use plain relative paths (\`tests\`, \`./tests\`, \`src/loop.ts\`) instead.
 
 # When the user wants to switch project / working directory


### PR DESCRIPTION
## Summary

- A user pasted `D:\VS_project\...\GraspAnalysisCommand.cpp` (inside their workspace). Flash hallucinated "I cannot access the filesystem" and ran `web_search` for a private local cpp file instead of just calling `read_file`.
- The Path-conventions block in the code system prompt only documented `relative` and `POSIX-absolute` as accepted forms. Windows drive-letter shape was left to the model's imagination — which here defaulted to "refuse".
- `safePath` in `src/tools/filesystem.ts` already accepts any shape that resolves inside the sandbox, so this is purely a prompt clarification plus an explicit ban on the refusal patterns we observed:
  - shape-based refusals
  - "no filesystem access" claims
  - `web_search` fallback for a local file

## Test plan

- [x] `npm run verify` (pre-push gate) — 2616 passed, 2 skipped
- [ ] Spot-check next time a Windows user pastes `D:\...` for a file inside the workspace: model should `read_file` it, not refuse