### PR TITLE
feat(status): surface preset in status bar; pin model on manual pick

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -42,6 +42,7 @@ import {
   mouseClipboardHintShown,
   resolveThemePreference,
   saveEditMode,
+  savePreset,
   saveReasoningEffort,
   saveTheme,
 } from "../../config.js";
@@ -877,6 +878,23 @@ function AppInner({
   useEffect(() => {
     loop.hooks = hookList;
   }, [loop, hookList]);
+
+  // Seed status.preset from initial loop state so the StatusRow preset pill
+  // renders correctly on first paint — usePresetMode's React-state mirror
+  // doesn't propagate to the agent store, so without this dispatch the pill
+  // would show the bare model id instead of the resolved preset.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: mount-only seed
+  useEffect(() => {
+    const canonical: "auto" | "flash" | "pro" | null =
+      loop.model === "deepseek-v4-pro"
+        ? "pro"
+        : loop.model === "deepseek-v4-flash"
+          ? loop.autoEscalate
+            ? "auto"
+            : "flash"
+          : null;
+    agentStore.dispatch({ type: "session.preset.change", preset: canonical });
+  }, []);
 
   // Deferred MCP bridge — fire addSpec for each requested server in the
   // background instead of blocking startup, route lifecycle events to
@@ -1756,6 +1774,12 @@ function AppInner({
                   ? "auto"
                   : "flash";
             setPreset(canonical);
+            agentStore.dispatch({ type: "session.preset.change", preset: canonical });
+            try {
+              savePreset(canonical);
+            } catch {
+              /* disk full / perms — runtime change still took effect */
+            }
           },
           applyEffortLive: (effort) => {
             loop.configure({ reasoningEffort: effort });
@@ -3721,8 +3745,28 @@ function AppInner({
                     onChoose={(outcome) => {
                       setPendingModelPicker(false);
                       if (outcome.kind === "select") {
-                        loop.configure({ model: outcome.id });
+                        // Manual model pick = explicit pin: turn off auto-escalate
+                        // so flash doesn't get bumped, persist inferred preset.
+                        loop.configure({ model: outcome.id, autoEscalate: false });
                         agentStore.dispatch({ type: "session.model.change", model: outcome.id });
+                        const inferred =
+                          outcome.id === "deepseek-v4-pro"
+                            ? "pro"
+                            : outcome.id === "deepseek-v4-flash"
+                              ? "flash"
+                              : null;
+                        setPreset(inferred ?? "flash");
+                        agentStore.dispatch({
+                          type: "session.preset.change",
+                          preset: inferred,
+                        });
+                        if (inferred) {
+                          try {
+                            savePreset(inferred);
+                          } catch {
+                            /* disk full / perms — runtime change still took effect */
+                          }
+                        }
                         log.pushInfo(`▸ model: ${outcome.id}`);
                         return;
                       }
@@ -3734,8 +3778,14 @@ function AppInner({
                           reasoningEffort: p.reasoningEffort,
                         });
                         agentStore.dispatch({ type: "session.model.change", model: p.model });
+                        setPreset(outcome.name);
+                        agentStore.dispatch({
+                          type: "session.preset.change",
+                          preset: outcome.name,
+                        });
                         try {
                           saveReasoningEffort(p.reasoningEffort);
+                          savePreset(outcome.name);
                         } catch {
                           /* disk full / perms — runtime change still took effect */
                         }

--- a/src/cli/ui/layout/StatusRow.tsx
+++ b/src/cli/ui/layout/StatusRow.tsx
@@ -13,6 +13,7 @@ const RULE_MIN = 20;
 const WALLET_MIN_COLS = 90;
 const VERSION_MIN_COLS = 70;
 const FEEDBACK_HINT_MIN_COLS = 100;
+const PRESET_MIN_COLS = 60;
 
 export function StatusRow(): React.ReactElement {
   const status = useAgentState((s) => s.status);
@@ -41,6 +42,9 @@ export function StatusRow(): React.ReactElement {
           <CountdownRow mode={status.mode} secondsLeft={status.countdownSeconds} />
         ) : (
           <ModePill mode={status.mode} network={status.network} detail={status.networkDetail} />
+        )}
+        {cols >= PRESET_MIN_COLS && status.preset !== undefined && (
+          <PresetPill preset={status.preset} model={session.model} />
         )}
         <Sep />
         <Text color={FG.sub} wrap="truncate">{`${session.id} · ${session.branch}`}</Text>
@@ -89,6 +93,34 @@ export function StatusRow(): React.ReactElement {
       </Box>
     </Box>
   );
+}
+
+function PresetPill({
+  preset,
+  model,
+}: {
+  preset: "auto" | "flash" | "pro" | null;
+  model: string;
+}): React.ReactElement {
+  const label = preset ?? shortModelLabel(model);
+  const color = preset === "pro" ? TONE.accent : preset === "flash" ? TONE.brand : FG.sub;
+  return (
+    <>
+      <Sep />
+      <Text color={FG.meta} wrap="truncate">
+        {"▴ "}
+      </Text>
+      <Text color={color} wrap="truncate">
+        {label}
+      </Text>
+    </>
+  );
+}
+
+function shortModelLabel(model: string): string {
+  if (model === "deepseek-v4-flash") return "flash";
+  if (model === "deepseek-v4-pro") return "pro";
+  return model.replace(/^deepseek-/, "");
 }
 
 function WalletPill({
@@ -142,6 +174,7 @@ function ModePill({
   network: NetworkState;
   detail?: string;
 }): React.ReactElement {
+  const modeLabel = `${t("statusBar.editsLabel")}${mode}`;
   if (network === "online") {
     const pill = modeGlyph(mode);
     return (
@@ -149,7 +182,7 @@ function ModePill({
         <Text color={pill.color} wrap="truncate">
           {pill.glyph}
         </Text>
-        <Text color={FG.sub} wrap="truncate">{` ${mode}`}</Text>
+        <Text color={FG.sub} wrap="truncate">{` ${modeLabel}`}</Text>
       </Box>
     );
   }
@@ -161,7 +194,10 @@ function ModePill({
         <Text color={dot.color} wrap="truncate">
           {dot.glyph}
         </Text>
-        <Text color={dot.color} wrap="truncate">{` ${mode} · ${t("statusBar.slow")}${tail}`}</Text>
+        <Text
+          color={dot.color}
+          wrap="truncate"
+        >{` ${modeLabel} · ${t("statusBar.slow")}${tail}`}</Text>
       </Box>
     );
   }
@@ -202,7 +238,9 @@ function CountdownRow({
       <Text color={pill.color} wrap="truncate">
         {pill.glyph}
       </Text>
-      <Text color={FG.sub} wrap="truncate">{` ${mode}   ·   `}</Text>
+      <Text color={FG.sub} wrap="truncate">
+        {` ${t("statusBar.editsLabel")}${mode}   ·   `}
+      </Text>
       <Text color={TONE.warn} wrap="truncate">
         {t("statusBar.approvingIn")}
       </Text>

--- a/src/cli/ui/slash/handlers/model.ts
+++ b/src/cli/ui/slash/handlers/model.ts
@@ -1,7 +1,13 @@
-import { saveReasoningEffort } from "@/config.js";
+import { savePreset, saveReasoningEffort } from "@/config.js";
 import { t } from "@/i18n/index.js";
 import { PRESETS } from "../../presets.js";
 import type { SlashHandler } from "../dispatch.js";
+
+function inferPresetFromModel(id: string): "auto" | "flash" | "pro" | null {
+  if (id === "deepseek-v4-pro") return "pro";
+  if (id === "deepseek-v4-flash") return "flash";
+  return null;
+}
 
 const model: SlashHandler = (args, loop, ctx) => {
   const id = args[0];
@@ -9,8 +15,19 @@ const model: SlashHandler = (args, loop, ctx) => {
   if (!id) {
     return { openModelPicker: true };
   }
-  loop.configure({ model: id });
+  // Manual model pick = explicit pin: disable auto-escalate so flash doesn't
+  // get bumped, and persist the inferred preset so a relaunch keeps the choice.
+  loop.configure({ model: id, autoEscalate: false });
   ctx.dispatch?.({ type: "session.model.change", model: id });
+  const inferred = inferPresetFromModel(id);
+  ctx.dispatch?.({ type: "session.preset.change", preset: inferred });
+  if (inferred) {
+    try {
+      savePreset(inferred);
+    } catch {
+      /* disk full / perms — runtime change still took effect */
+    }
+  }
   if (known && known.length > 0 && !known.includes(id)) {
     return {
       info: t("handlers.model.modelNotInCatalog", { id, list: known.join(", ") }),
@@ -21,32 +38,34 @@ const model: SlashHandler = (args, loop, ctx) => {
 
 const preset: SlashHandler = (args, loop, ctx) => {
   const name = (args[0] ?? "").toLowerCase();
-  const applyAndPersist = (effort: "high" | "max") => {
-    try {
-      saveReasoningEffort(effort);
-    } catch {
-      /* disk full / perms — runtime change still took effect */
-    }
-  };
-  const apply = (p: (typeof PRESETS)[keyof typeof PRESETS]) => {
+  const apply = (
+    presetName: "auto" | "flash" | "pro",
+    p: (typeof PRESETS)[keyof typeof PRESETS],
+  ) => {
     loop.configure({
       model: p.model,
       autoEscalate: p.autoEscalate,
       reasoningEffort: p.reasoningEffort,
     });
     ctx.dispatch?.({ type: "session.model.change", model: p.model });
-    applyAndPersist(p.reasoningEffort);
+    ctx.dispatch?.({ type: "session.preset.change", preset: presetName });
+    try {
+      saveReasoningEffort(p.reasoningEffort);
+      savePreset(presetName);
+    } catch {
+      /* disk full / perms — runtime change still took effect */
+    }
   };
   if (name === "auto") {
-    apply(PRESETS.auto);
+    apply("auto", PRESETS.auto);
     return { info: t("handlers.model.presetAuto") };
   }
   if (name === "flash") {
-    apply(PRESETS.flash);
+    apply("flash", PRESETS.flash);
     return { info: t("handlers.model.presetFlash") };
   }
   if (name === "pro") {
-    apply(PRESETS.pro);
+    apply("pro", PRESETS.pro);
     return { info: t("handlers.model.presetPro") };
   }
   if (name === "") {

--- a/src/cli/ui/state/events.ts
+++ b/src/cli/ui/state/events.ts
@@ -129,6 +129,11 @@ const sessionModelChange = z.object({
   model: z.string().min(1),
 });
 
+const sessionPresetChange = z.object({
+  type: z.literal("session.preset.change"),
+  preset: z.enum(["auto", "flash", "pro"]).nullable(),
+});
+
 const focusMove = z.object({
   type: z.literal("focus.move"),
   direction: z.enum(["next", "prev", "first", "last"]),
@@ -319,6 +324,7 @@ export const AgentEventSchema = z.discriminatedUnion("type", [
   languageChange,
   sessionUpdate,
   sessionModelChange,
+  sessionPresetChange,
   focusMove,
   focusSet,
   cardToggle,

--- a/src/cli/ui/state/reducer.ts
+++ b/src/cli/ui/state/reducer.ts
@@ -121,6 +121,11 @@ export function reduce(state: AgentState, event: AgentEvent): AgentState {
         ? state
         : { ...state, session: { ...state.session, model: event.model } };
 
+    case "session.preset.change":
+      return state.status.preset === event.preset
+        ? state
+        : { ...state, status: { ...state.status, preset: event.preset } };
+
     case "focus.move":
       return {
         ...state,

--- a/src/cli/ui/state/state.ts
+++ b/src/cli/ui/state/state.ts
@@ -32,6 +32,8 @@ export interface StatusBar {
   cacheHit: number;
   countdownSeconds?: number;
   recording?: { sizeBytes: number; events: number; path: string };
+  /** null → user is on a custom model that doesn't match any preset; pill falls back to the model id. */
+  preset?: "auto" | "flash" | "pro" | null;
 }
 
 export interface Toast {

--- a/src/config.ts
+++ b/src/config.ts
@@ -353,6 +353,13 @@ export function saveReasoningEffort(
   writeConfig(cfg, path);
 }
 
+/** Persist preset so `/preset pro` (or `/model deepseek-v4-pro`) sticks across relaunches. */
+export function savePreset(preset: PresetName, path: string = defaultConfigPath()): void {
+  const cfg = readConfig(path);
+  cfg.preset = preset;
+  writeConfig(cfg, path);
+}
+
 export function loadIndexUserConfig(path: string = defaultConfigPath()): IndexUserConfig {
   return readConfig(path).index ?? {};
 }

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -1065,6 +1065,7 @@ export const EN: TranslationSchema = {
     recordingGlyph: "\u25CFREC",
     mb: " MB",
     evt: " evt",
+    editsLabel: "edits:",
   },
   editMode: {
     plan: "PLAN MODE",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -354,6 +354,8 @@ export interface TranslationSchema {
     recordingGlyph: string;
     mb: string;
     evt: string;
+    /** Prefix for the edit-gate mode pill — disambiguates from the preset (`/preset auto` is a different "auto"). */
+    editsLabel: string;
   };
   editMode: {
     plan: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -1010,6 +1010,7 @@ export const zhCN: TranslationSchema = {
     recordingGlyph: "●REC",
     mb: " MB",
     evt: " 事件",
+    editsLabel: "编辑:",
   },
   editMode: {
     plan: "计划",


### PR DESCRIPTION
## Summary

Two adjacent UX failures, one fix. Users couldn't tell what was actually controlling the model:

1. **The `auto` on screen wasn't the preset.** StatusRow's `● auto` is the edit-gate mode (`auto`/`ask`/`plan`/`edit`); LiveRows shows the same as a `[AUTO]` pill above the input. Both got read as "the preset." Running `/preset pro` left both unchanged because the preset wasn't rendered anywhere — `usePresetMode`'s React-state mirror was never wired to the agent store, and the `/preset` slash handler didn't `setPreset` / `dispatch` at all.
2. **`/model <id>` didn't pin.** It only touched `loop.model`, leaving `autoEscalate` whatever the active preset had set. From the default `auto` preset, `/model deepseek-v4-flash` still let flash escalate to pro on hard turns. And no path wrote `cfg.preset`, so relaunch reverted silently to whatever the wizard had picked.

## Changes

- **StatusRow** (`src/cli/ui/layout/StatusRow.tsx`)
  - Edit-gate mode label gets an `edits:` prefix (new i18n key `statusBar.editsLabel`, `EN`/`zh-CN`).
  - New `▴ <preset>` pill after the mode pill. Falls back to a short model name when on a non-preset model.
  - Hidden under 60 cols (same pattern as `WALLET_MIN_COLS`).
- **Agent state**
  - `StatusBar.preset?: "auto"|"flash"|"pro"|null` (`state.ts`).
  - New `session.preset.change` event (`events.ts`), reducer entry (`reducer.ts`).
  - Mount-only `useEffect` in `App.tsx` that seeds the initial value from `loop.model + loop.autoEscalate` so the first paint is right.
- **Slash handlers** (`src/cli/ui/slash/handlers/model.ts`)
  - `/preset auto|flash|pro`: dispatches the preset change AND persists via the new `savePreset()`.
  - `/model <id>`: turns off `autoEscalate` (manual pick is an explicit pin), dispatches the inferred preset (`pro`/`flash`/`null`), and persists when the model maps to a known preset.
- **Model picker outcomes** (`src/cli/ui/App.tsx`): `kind:"select"` and `kind:"preset"` get the same dispatch + persist treatment; dashboard's `applyPresetLive` too.
- **Config** (`src/config.ts`): new `savePreset()`, mirrors `saveReasoningEffort`.

## After

Switching to pro via `/preset` or `/model` shows `▴ pro` in the status bar, sticks across the session (no silent escalate-back), and survives relaunch. The two visible `auto`s now read clearly as `● edits:auto · ▴ auto` so the user can see they're separate things.

## Test plan

- [x] `npm run verify` (pre-push gate) — 2621 passed / 2 skipped
- [x] `npm run lint` — clean (only the pre-existing `user-card-verbatim` suppression warning)
- [ ] Manual: open code mode, `/preset pro` → status bar shows `▴ pro`. `/model deepseek-v4-flash` → status bar shows `▴ flash`, exit + relaunch → still flash.