### PR TITLE
Mcp debug log malformed

### DIFF
--- a/src/mcp/README.md
+++ b/src/mcp/README.md
@@ -145,3 +145,7 @@ about it.
   process hasn't exited.
 - **Malformed lines**: dropped silently. Some servers emit non-JSON
   during startup; logging every dropped line would be noise.
+- **Debugging dropped lines**: set `REASONIX_DEBUG_MCP=1` to print each
+  dropped malformed line to stderr, prefixed with
+  `[mcp-stdio] dropped malformed line:`. Useful when an MCP server
+  ships truncated or corrupted frames and tool calls come back empty.

--- a/src/mcp/stdio.ts
+++ b/src/mcp/stdio.ts
@@ -141,6 +141,9 @@ export class StdioTransport implements McpTransport {
         // Malformed lines are dropped — some servers emit startup banners
         // before the JSON-RPC loop begins. We surface the noise to stderr
         // via the inherited stderr stream, not our event queue.
+        if (process.env.REASONIX_DEBUG_MCP === "1") {
+          process.stderr.write(`[mcp-stdio] dropped malformed line: ${line}\n`);
+        }
       }
     }
   }

--- a/tests/mcp-stdio-debug.test.ts
+++ b/tests/mcp-stdio-debug.test.ts
@@ -1,0 +1,63 @@
+/** REASONIX_DEBUG_MCP=1 surfaces dropped malformed lines on stderr; otherwise silent. */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { StdioTransport } from "../src/mcp/stdio.js";
+
+const GARBAGE_THEN_EXIT = "process.stdout.write('not-json-banner\\n'); process.exit(0)";
+
+describe("StdioTransport REASONIX_DEBUG_MCP", { timeout: 5_000 }, () => {
+  let writeSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    writeSpy.mockRestore();
+    vi.unstubAllEnvs();
+  });
+
+  it("logs the dropped line to stderr when REASONIX_DEBUG_MCP=1", async () => {
+    vi.stubEnv("REASONIX_DEBUG_MCP", "1");
+    const t = new StdioTransport({
+      command: "node",
+      args: ["-e", GARBAGE_THEN_EXIT],
+      shell: false,
+    });
+    await new Promise((r) => setTimeout(r, 250));
+    await t.close();
+
+    const stderrCalls = writeSpy.mock.calls.map((c) => String(c[0]));
+    expect(
+      stderrCalls.some((s) => s.includes("[mcp-stdio] dropped malformed line: not-json-banner")),
+    ).toBe(true);
+  });
+
+  it("stays silent when REASONIX_DEBUG_MCP is unset", async () => {
+    vi.stubEnv("REASONIX_DEBUG_MCP", "");
+    const t = new StdioTransport({
+      command: "node",
+      args: ["-e", GARBAGE_THEN_EXIT],
+      shell: false,
+    });
+    await new Promise((r) => setTimeout(r, 250));
+    await t.close();
+
+    const stderrCalls = writeSpy.mock.calls.map((c) => String(c[0]));
+    expect(stderrCalls.some((s) => s.includes("[mcp-stdio] dropped malformed line"))).toBe(false);
+  });
+
+  it("stays silent when REASONIX_DEBUG_MCP is set to something other than '1'", async () => {
+    vi.stubEnv("REASONIX_DEBUG_MCP", "true");
+    const t = new StdioTransport({
+      command: "node",
+      args: ["-e", GARBAGE_THEN_EXIT],
+      shell: false,
+    });
+    await new Promise((r) => setTimeout(r, 250));
+    await t.close();
+
+    const stderrCalls = writeSpy.mock.calls.map((c) => String(c[0]));
+    expect(stderrCalls.some((s) => s.includes("[mcp-stdio] dropped malformed line"))).toBe(false);
+  });
+});

--- a/tests/mcp-stdio-debug.test.ts
+++ b/tests/mcp-stdio-debug.test.ts
@@ -5,6 +5,15 @@ import { StdioTransport } from "../src/mcp/stdio.js";
 
 const GARBAGE_THEN_EXIT = "process.stdout.write('not-json-banner\\n'); process.exit(0)";
 
+/** Wait for child exit via messages(). Node delivers stdout `data` before
+ * `close`, so by the time the iterator returns the synchronous catch has
+ * routed every malformed line — no fixed-time sleep needed. */
+async function awaitChildExit(t: StdioTransport): Promise<void> {
+  for await (const _msg of t.messages()) {
+    // Test scripts never emit valid JSON-RPC, so the body never runs.
+  }
+}
+
 describe("StdioTransport REASONIX_DEBUG_MCP", { timeout: 5_000 }, () => {
   let writeSpy: ReturnType<typeof vi.spyOn>;
 
@@ -24,7 +33,7 @@ describe("StdioTransport REASONIX_DEBUG_MCP", { timeout: 5_000 }, () => {
       args: ["-e", GARBAGE_THEN_EXIT],
       shell: false,
     });
-    await new Promise((r) => setTimeout(r, 250));
+    await awaitChildExit(t);
     await t.close();
 
     const stderrCalls = writeSpy.mock.calls.map((c) => String(c[0]));
@@ -40,21 +49,35 @@ describe("StdioTransport REASONIX_DEBUG_MCP", { timeout: 5_000 }, () => {
       args: ["-e", GARBAGE_THEN_EXIT],
       shell: false,
     });
-    await new Promise((r) => setTimeout(r, 250));
+    await awaitChildExit(t);
     await t.close();
 
     const stderrCalls = writeSpy.mock.calls.map((c) => String(c[0]));
     expect(stderrCalls.some((s) => s.includes("[mcp-stdio] dropped malformed line"))).toBe(false);
   });
 
-  it("stays silent when REASONIX_DEBUG_MCP is set to something other than '1'", async () => {
+  it("stays silent when REASONIX_DEBUG_MCP is set to '0'", async () => {
+    vi.stubEnv("REASONIX_DEBUG_MCP", "0");
+    const t = new StdioTransport({
+      command: "node",
+      args: ["-e", GARBAGE_THEN_EXIT],
+      shell: false,
+    });
+    await awaitChildExit(t);
+    await t.close();
+
+    const stderrCalls = writeSpy.mock.calls.map((c) => String(c[0]));
+    expect(stderrCalls.some((s) => s.includes("[mcp-stdio] dropped malformed line"))).toBe(false);
+  });
+
+  it("stays silent when REASONIX_DEBUG_MCP is set to a truthy non-'1' value", async () => {
     vi.stubEnv("REASONIX_DEBUG_MCP", "true");
     const t = new StdioTransport({
       command: "node",
       args: ["-e", GARBAGE_THEN_EXIT],
       shell: false,
     });
-    await new Promise((r) => setTimeout(r, 250));
+    await awaitChildExit(t);
     await t.close();
 
     const stderrCalls = writeSpy.mock.calls.map((c) => String(c[0]));


### PR DESCRIPTION
## What

Gate a stderr trace behind `REASONIX_DEBUG_MCP=1` so the MCP stdio transport surfaces the actual bytes when it drops a malformed JSON-RPC line. Default behavior is unchanged — nothing is logged unless the var is set to exactly `"1"`. Documented in `src/mcp/README.md`.

## Why

`StdioTransport.onStdout` silently swallows anything that fails `JSON.parse`, which is correct for the common case (servers emit non-JSON startup banners) but hides real wire-level bugs. When a server ships truncated or corrupted frames, users see empty tool results with no clue why. An opt-in env var keeps the hot path quiet for everyone else and gives a developer one switch to flip when diagnosing an empty `callTool` response. Closes #630.

## How to verify

```
npm run verify
npx vitest run tests/mcp-stdio-debug.test.ts
```

The new test file covers four cases: env=`"1"` (logs), unset (silent), `"0"` (silent), `"true"` (silent). Tests wait on child exit via the `messages()` iterator instead of a fixed sleep — Node guarantees
stdout `data` fires before `close`, so once the iterator returns the synchronous catch has already run.

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time