### PR TITLE
feat(tools,loop): warn when readOnlyCheck throws instead of swallowin…

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -194,8 +194,10 @@ export class CacheFirstLoop {
         }
         try {
           if (def.readOnlyCheck(args as never)) return false;
-        } catch {
-          /* ignore — fall through */
+        } catch (err) {
+          // Mirror tools.ts: surface buggy readOnlyCheck instead of silently
+          // falling through to the static flag.
+          console.warn(`readOnlyCheck for ${name} threw: ${(err as Error).message}`);
         }
       }
       return def.readOnly !== true;

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -301,7 +301,10 @@ function isReadOnlyCall(tool: InternalTool, args: Record<string, unknown>): bool
   if (tool.readOnlyCheck) {
     try {
       return Boolean(tool.readOnlyCheck(args as never));
-    } catch {
+    } catch (err) {
+      // A buggy readOnlyCheck silently downgrades to "may mutate" — log it so
+      // the bug doesn't hide behind plan-mode refusals or storm-breaker noise.
+      console.warn(`readOnlyCheck for ${tool.name} threw: ${(err as Error).message}`);
       return false;
     }
   }

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { ToolRegistry } from "../src/tools.js";
 
 describe("ToolRegistry", () => {
@@ -495,6 +495,45 @@ describe("ToolRegistry", () => {
       const out = await reg.dispatch("edit_file", "{}"); // first time for edit_file
       const parsed = JSON.parse(out);
       expect(parsed.consecutiveMalformed).toBeUndefined();
+    });
+  });
+
+  describe("isReadOnlyCall — buggy readOnlyCheck", () => {
+    it("warns when readOnlyCheck throws and treats the call as not read-only", async () => {
+      const reg = new ToolRegistry();
+      reg.register({
+        name: "buggy_tool",
+        readOnlyCheck: () => {
+          throw new Error("check is buggy");
+        },
+        fn: () => "ok",
+      });
+      reg.setPlanMode(true);
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const out = await reg.dispatch("buggy_tool", "{}");
+        expect(JSON.parse(out).error).toMatch(/unavailable in plan mode/);
+        expect(warnSpy).toHaveBeenCalledWith("readOnlyCheck for buggy_tool threw: check is buggy");
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it("stays silent when readOnlyCheck succeeds", async () => {
+      const reg = new ToolRegistry();
+      reg.register({
+        name: "good_tool",
+        readOnlyCheck: () => true,
+        fn: () => "ok",
+      });
+      reg.setPlanMode(true);
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        await reg.dispatch("good_tool", "{}");
+        expect(warnSpy).not.toHaveBeenCalled();
+      } finally {
+        warnSpy.mockRestore();
+      }
     });
   });
 });


### PR DESCRIPTION
Closes #629.

Two catch blocks treat a throwing readOnlyCheck as 'not read-only' and move on:

- src/tools.ts isReadOnlyCall — used by plan-mode refusal
- src/loop.ts isMutating — used by the storm-breaker window

If the check itself has a bug, nobody sees it; the tool just silently behaves as if it were mutating. Log the exception on console.warn at each catch so the bug surfaces during development without changing default-on-throw semantics.

<!-- Read CONTRIBUTING.md first if this is your first PR. -->

## What

Replace two silent `catch {}` blocks with `console.warn(...)` calls that surface buggy `readOnlyCheck` functions. Default-on-throw semantics are unchanged — `tools.ts isReadOnlyCall` still returns `false`, `loop.ts isMutating` still falls through to the static `readOnly` flag — but the bug in the check is no longer invisible. Closes #629.

## Why

`readOnlyCheck` lets a tool decide read-only-ness per-call (e.g. `run_command` is read-only iff its argv hits an allowlist). If that function throws because of a bug in the check itself, the tool silently behaves as if it might mutate: plan-mode quietly refuses it, or the storm-breaker reclassifies the call. Nobody sees the underlying exception. A bare `console.warn` is the minimum that surfaces it without dragging in a logging framework or changing observable behavior.

## How to verify

```
npm run verify
npx vitest run tests/tools.test.ts
```

The new test "warns when readOnlyCheck throws and treats the call as not read-only" registers a tool with a throwing `readOnlyCheck`, enables plan mode, dispatches it, and asserts both the plan-mode refusal AND the exact warn message string.

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time

