### PR TITLE
feat(tools/web): attach actionable hints to web_search / web_fetch er…

### DIFF
--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -1234,7 +1234,14 @@ export const EN: TranslationSchema = {
     probeFailed: "probe failed \u2014 {message}",
   },
   webErrors: {
-    status: "web_search {status}",
+    status:
+      "web_search {status} \u2014 try: confirm the search engine is reachable and your query parses",
+    searchStatus429:
+      "web_search {status} \u2014 try: wait 10s before retrying, or rephrase the query (the engine is rate-limiting)",
+    searchStatus403:
+      "web_search {status} \u2014 try: confirm your network reaches the engine; switch with /search-engine if you're behind a proxy",
+    searchStatus5xx:
+      "web_search {status} \u2014 try: open the search URL in a browser; if it loads this is transient and a retry in 30s may help",
     mojeekBlocked: "web_search: Mojeek anti-bot page \u2014 rate-limited or blocked",
     mojeekNoResults:
       "web_search: 0 results but response doesn't look like a real empty page ({chars} chars, first 120: {preview})",
@@ -1244,7 +1251,16 @@ export const EN: TranslationSchema = {
       "web_search: Cannot reach SearXNG server at {endpoint}. Please install SearXNG (https://github.com/searxng/searxng) and start it (e.g. `docker run -d -p 8080:8080 searxng/searxng`), or switch to the default engine with /search-engine mojeek.",
     searxngNoResults:
       "web_search: 0 results but SearXNG response doesn't look like an empty results page ({chars} chars)",
-    fetchStatus: "web_fetch {status} for {url}",
+    fetchStatus:
+      "web_fetch {status} for {url} \u2014 try: confirm the URL resolves and returns an HTTP 2xx in a browser",
+    fetchStatus429:
+      "web_fetch {status} for {url} \u2014 try: wait 10s before retrying; the host is rate-limiting",
+    fetchStatus403:
+      "web_fetch {status} for {url} \u2014 try: confirm the URL is publicly accessible; some servers reject non-browser User-Agents",
+    fetchStatus5xx:
+      "web_fetch {status} for {url} \u2014 try: open the URL in a browser; if it loads this is transient and a retry in 30s may help",
+    fetchTimeout:
+      "web_fetch timed out after {ms}ms for {url} \u2014 try: a shorter or lighter URL, or skip pages known to be large",
     fetchTooLarge: "web_fetch refused: content-length {len} bytes exceeds {cap}-byte cap ({url})",
     fetchBodyTooLarge:
       "web_fetch refused: response body exceeded {cap}-byte cap ({seen} bytes seen)",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -515,6 +515,9 @@ export interface TranslationSchema {
   };
   webErrors: {
     status: string;
+    searchStatus429: string;
+    searchStatus403: string;
+    searchStatus5xx: string;
     mojeekBlocked: string;
     mojeekNoResults: string;
     invalidEndpoint: string;
@@ -522,6 +525,10 @@ export interface TranslationSchema {
     cannotReach: string;
     searxngNoResults: string;
     fetchStatus: string;
+    fetchStatus429: string;
+    fetchStatus403: string;
+    fetchStatus5xx: string;
+    fetchTimeout: string;
     fetchTooLarge: string;
     fetchBodyTooLarge: string;
     fetchInvalidUrl: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -1172,7 +1172,13 @@ export const zhCN: TranslationSchema = {
     probeFailed: "探测失败 — {message}",
   },
   webErrors: {
-    status: "web_search 状态码 {status}",
+    status: "web_search 状态码 {status} — 建议：确认搜索引擎可达，且查询能被解析",
+    searchStatus429:
+      "web_search 状态码 {status} — 建议：等待 10 秒再重试，或换种说法（引擎在限速）",
+    searchStatus403:
+      "web_search 状态码 {status} — 建议：确认网络能直达引擎；如在代理后请用 /search-engine 切换引擎",
+    searchStatus5xx:
+      "web_search 状态码 {status} — 建议：在浏览器打开搜索 URL；若能加载则属临时故障，等 30 秒重试即可",
     mojeekBlocked: "web_search: Mojeek 反爬页面 — 频率限制或被屏蔽",
     mojeekNoResults:
       "web_search: 返回 0 条结果但响应看起来不是正常空结果页（{chars} 字符，前 120 字符：{preview}）",
@@ -1182,7 +1188,14 @@ export const zhCN: TranslationSchema = {
       "web_search: 无法访问 SearXNG 服务器 {endpoint}。请安装 SearXNG（https://github.com/searxng/searxng）并启动（例如 `docker run -d -p 8080:8080 searxng/searxng`），或使用 /search-engine mojeek 切换到默认引擎。",
     searxngNoResults:
       "web_search: 返回 0 条结果但 SearXNG 响应看起来不是正常空结果页（{chars} 字符）",
-    fetchStatus: "web_fetch 状态码 {status}（{url}）",
+    fetchStatus: "web_fetch 状态码 {status}（{url}）— 建议：在浏览器打开该 URL，确认返回 HTTP 2xx",
+    fetchStatus429: "web_fetch 状态码 {status}（{url}）— 建议：等待 10 秒再重试；该主机正在限速",
+    fetchStatus403:
+      "web_fetch 状态码 {status}（{url}）— 建议：确认 URL 是公开可访问的；某些服务器拒绝非浏览器 User-Agent",
+    fetchStatus5xx:
+      "web_fetch 状态码 {status}（{url}）— 建议：在浏览器打开该 URL；若能加载则属临时故障，等 30 秒重试即可",
+    fetchTimeout:
+      "web_fetch 在 {ms}ms 后超时（{url}）— 建议：换更短/更轻量的 URL，或避开已知较大的页面",
     fetchTooLarge: "web_fetch 拒绝：content-length {len} 字节超过上限 {cap} 字节（{url}）",
     fetchBodyTooLarge: "web_fetch 拒绝：响应体超过 {cap} 字节上限（已接收 {seen} 字节）",
     fetchInvalidUrl: "web_fetch: URL 必须以 http:// 或 https:// 开头",

--- a/src/tools/web.ts
+++ b/src/tools/web.ts
@@ -8,6 +8,34 @@ import {
 import { t } from "../i18n/index.js";
 import type { ToolRegistry } from "../tools.js";
 
+/** Tool errors go back to the model verbatim, so we pick a status-specific
+ * key with an actionable hint instead of returning bare "web_search 429". */
+function searchStatusErrorKey(
+  status: number,
+):
+  | "webErrors.searchStatus429"
+  | "webErrors.searchStatus403"
+  | "webErrors.searchStatus5xx"
+  | "webErrors.status" {
+  if (status === 429) return "webErrors.searchStatus429";
+  if (status === 403) return "webErrors.searchStatus403";
+  if (status >= 500 && status <= 599) return "webErrors.searchStatus5xx";
+  return "webErrors.status";
+}
+
+function fetchStatusErrorKey(
+  status: number,
+):
+  | "webErrors.fetchStatus429"
+  | "webErrors.fetchStatus403"
+  | "webErrors.fetchStatus5xx"
+  | "webErrors.fetchStatus" {
+  if (status === 429) return "webErrors.fetchStatus429";
+  if (status === 403) return "webErrors.fetchStatus403";
+  if (status >= 500 && status <= 599) return "webErrors.fetchStatus5xx";
+  return "webErrors.fetchStatus";
+}
+
 export interface SearchResult {
   title: string;
   url: string;
@@ -72,7 +100,7 @@ async function searchMojeek(query: string, opts: WebSearchOptions = {}): Promise
     signal: opts.signal,
     redirect: "follow",
   });
-  if (!resp.ok) throw new Error(t("webErrors.status", { status: resp.status }));
+  if (!resp.ok) throw new Error(t(searchStatusErrorKey(resp.status), { status: resp.status }));
   const html = await resp.text();
   const results = parseMojeekResults(html).slice(0, topK);
   if (results.length === 0) {
@@ -127,7 +155,7 @@ async function searchSearxng(query: string, opts: WebSearchOptions = {}): Promis
     }
     throw err;
   }
-  if (!resp.ok) throw new Error(t("webErrors.status", { status: resp.status }));
+  if (!resp.ok) throw new Error(t(searchStatusErrorKey(resp.status), { status: resp.status }));
   const html = await resp.text();
   const results = parseSearxngHtmlResults(html).slice(0, topK);
   if (results.length === 0) {
@@ -236,11 +264,17 @@ export async function webFetch(url: string, opts: WebFetchOptions = {}): Promise
       signal: ctl.signal,
       redirect: "follow",
     });
+  } catch (err) {
+    // Our own timer's abort is a timeout; a caller-driven abort propagates as-is.
+    if ((err as { name?: string }).name === "AbortError" && !opts.signal?.aborted) {
+      throw new Error(t("webErrors.fetchTimeout", { ms: timeoutMs, url }));
+    }
+    throw err;
   } finally {
     clearTimeout(timer);
     opts.signal?.removeEventListener("abort", cancel);
   }
-  if (!resp.ok) throw new Error(t("webErrors.fetchStatus", { status: resp.status, url }));
+  if (!resp.ok) throw new Error(t(fetchStatusErrorKey(resp.status), { status: resp.status, url }));
   const contentType = resp.headers.get("content-type") ?? "";
   // Pre-check Content-Length when the server provides it. Cheaper to
   // refuse upfront than to start streaming a 1GB ISO.

--- a/tests/web-tools.test.ts
+++ b/tests/web-tools.test.ts
@@ -388,3 +388,63 @@ describe("webFetch", () => {
     }
   });
 });
+
+describe("actionable error hints", () => {
+  it("web_search 429 appends a wait/rephrase hint", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(
+      async () => new Response("blocked", { status: 429 }),
+    ) as unknown as typeof fetch;
+    try {
+      await expect(webSearch("q")).rejects.toThrow(/web_search 429 — try: wait 10s/);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("web_search 503 points the model at a 30s retry / browser check", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(
+      async () => new Response("down", { status: 503 }),
+    ) as unknown as typeof fetch;
+    try {
+      await expect(webSearch("q")).rejects.toThrow(/web_search 503 — try:.*retry in 30s/);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("web_fetch 403 suggests checking public access / User-Agent", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(
+      async () => new Response("forbidden", { status: 403 }),
+    ) as unknown as typeof fetch;
+    try {
+      await expect(webFetch("https://example.com/private")).rejects.toThrow(
+        /web_fetch 403 .* try:.*publicly accessible/,
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("web_fetch surfaces an actionable timeout when the internal timer fires", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async (_input: unknown, init?: { signal?: AbortSignal }) => {
+      return await new Promise<Response>((_, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          const err = new Error("aborted");
+          err.name = "AbortError";
+          reject(err);
+        });
+      });
+    }) as unknown as typeof fetch;
+    try {
+      await expect(webFetch("https://example.com/slow", { timeoutMs: 50 })).rejects.toThrow(
+        /web_fetch timed out after 50ms .* try: a shorter or lighter URL/,
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
Closes #16.

Tool errors round-trip to the model verbatim, so a bare 'web_search 429' prompts the model to retry the same call with the same args. Pick a status-specific i18n key with a hint clause for the four cases the model most commonly hits:

- 429 — wait 10s, or rephrase the query
- 403 — confirm public access / network reachability / User-Agent
- 5xx — try a browser; if it loads, retry in 30s
- other — confirm reachability and parseability (existing message, reused as the default)

Also surface the AbortController timeout as 'web_fetch timed out after {ms}ms' with a 'use a lighter URL' hint, instead of letting the raw AbortError bubble up. Caller-driven aborts still propagate as-is.

Both EN and zh-CN translations updated; the existing /web_search 429/ regex assertion is preserved as a prefix.

<!-- Read CONTRIBUTING.md first if this is your first PR. -->

## What

Pick a status-code-specific i18n key with an actionable hint when `web_search` or `web_fetch` hits a non-2xx response, instead of returning the bare status. Four buckets: `429`, `403`, `5xx`, and a generic catch-all that's still actionable. Also surface `AbortController` timeouts in `web_fetch` as `"web_fetch timed out after {ms}ms"` instead of letting the raw `AbortError` bubble up; caller-driven aborts (Esc) still propagate unchanged. EN + zh-CN translations and `TranslationSchema` updated in step. Closes #16.

## Why

Tool errors go back to the model verbatim — they're how the agent decides what to do next. A bare `web_search 429` reads as a transient failure, so the model retries with identical args and burns tokens. `web_search 429 — try: wait 10s before retrying, or rephrase the query` tells the model both that a same-args retry won't help and what to do instead. Same shape for 403 (check public access / UA), 5xx (open in a browser, retry in 30s), timeout (lighter URL).

## How to verify

```
npm run verify
npx vitest run tests/web-tools.test.ts
```

The new `actionable error hints` describe block adds four cases: search 429, search 503, fetch 403, fetch timeout — each asserts on the hint substring, not just the status. Existing assertions on `/web_search 429/` and `/web_fetch 404/` still match (the new messages start with the same prefix).

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time
