### PR TITLE
polish cards, composer cursor, shell modal info rows

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -511,6 +511,9 @@ function AppInner({
     id: number;
     command: string;
     kind: "run_command" | "run_background";
+    cwd?: string;
+    timeoutSec?: number;
+    waitSec?: number;
   } | null>(null);
   // Plan text the model submitted via `submit_plan` while plan mode
   // was active. Non-null renders PlanConfirm; user picks Approve /
@@ -3160,13 +3163,23 @@ function AppInner({
 
       switch (request.kind) {
         case "run_command":
-        case "run_background":
+        case "run_background": {
+          const p = payload as {
+            command: string;
+            cwd?: string;
+            timeoutSec?: number;
+            waitSec?: number;
+          };
           setPendingShell({
             id: request.id,
-            command: (payload as { command: string }).command,
+            command: p.command,
             kind: request.kind,
+            cwd: p.cwd,
+            timeoutSec: p.timeoutSec,
+            waitSec: p.waitSec,
           });
           break;
+        }
         case "plan_proposed": {
           const p = payload as { plan: string; steps?: PlanStep[]; summary?: string };
           setPendingPlan(p.plan);
@@ -3847,6 +3860,9 @@ function AppInner({
                     command={pendingShell.command}
                     allowPrefix={derivePrefix(pendingShell.command)}
                     kind={pendingShell.kind}
+                    cwd={pendingShell.cwd}
+                    timeoutSec={pendingShell.timeoutSec}
+                    waitSec={pendingShell.waitSec}
                     onChoose={handleShellConfirm}
                   />
                 ) : pendingEditReview ? (

--- a/src/cli/ui/PromptInput.tsx
+++ b/src/cli/ui/PromptInput.tsx
@@ -16,6 +16,7 @@ import {
 } from "./paste-sentinels.js";
 import { type Segment, buildViewport, stringCells } from "./prompt-viewport.js";
 import { FG, SURFACE, TONE } from "./theme/tokens.js";
+import { useSlowTick } from "./ticker.js";
 
 /** Raw-stdin keystroke bus → multiline reducer; one logical line per Box row, viewport-clipped. */
 
@@ -164,7 +165,7 @@ export function PromptInput({
 
   const lines = value.length > 0 ? value.split("\n") : [""];
   const accentColor = disabled ? FG.faint : TONE.brand;
-  const cursorVisible = true;
+  const cursorVisible = useSlowTick() % 2 === 0;
   const { line: cursorLine, col: cursorCol } = lineAndColumn(value, cursor);
 
   const renderItems = collapseLinesForDisplay(lines, cursorLine);

--- a/src/cli/ui/ShellConfirm.tsx
+++ b/src/cli/ui/ShellConfirm.tsx
@@ -1,4 +1,6 @@
+import { homedir } from "node:os";
 import { Box, Text } from "ink";
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React, { useState } from "react";
 import { t } from "../../i18n/index.js";
 import { DenyContextInput } from "./DenyContextInput.js";
@@ -15,10 +17,35 @@ export interface ShellConfirmProps {
   allowPrefix: string;
   /** `run_background` returns early; `run_command` blocks the TUI. */
   kind?: "run_command" | "run_background";
+  /** Working directory the command will run in — surfaced as an info row. */
+  cwd?: string;
+  /** run_command timeout in seconds — surfaced as "timeout 120s". */
+  timeoutSec?: number;
+  /** run_background startup wait in seconds — surfaced as "wait 3s". */
+  waitSec?: number;
   onChoose: (choice: ShellConfirmChoice, denyContext?: string) => void;
 }
 
-export function ShellConfirm({ command, allowPrefix, kind, onChoose }: ShellConfirmProps) {
+/** ~/foo when path is under $HOME so the row doesn't blow past viewport width. */
+function tildeify(path: string): string {
+  const home = homedir();
+  if (!home) return path;
+  const normalized = home.replace(/[\\/]+$/, "");
+  if (path === normalized) return "~";
+  if (path.startsWith(`${normalized}/`)) return `~/${path.slice(normalized.length + 1)}`;
+  if (path.startsWith(`${normalized}\\`)) return `~\\${path.slice(normalized.length + 1)}`;
+  return path;
+}
+
+export function ShellConfirm({
+  command,
+  allowPrefix,
+  kind,
+  cwd,
+  timeoutSec,
+  waitSec,
+  onChoose,
+}: ShellConfirmProps) {
   useReserveRows("modal", { min: 8, max: 14 });
 
   const isBackground = kind === "run_background";
@@ -62,6 +89,7 @@ export function ShellConfirm({ command, allowPrefix, kind, onChoose }: ShellConf
           {command}
         </Text>
       </Box>
+      <InfoRows cwd={cwd} timeoutSec={timeoutSec} waitSec={waitSec} kind={kind} />
       <SingleSelect
         initialValue="run_once"
         items={[
@@ -91,6 +119,38 @@ export function ShellConfirm({ command, allowPrefix, kind, onChoose }: ShellConf
         onCancel={() => onChoose("deny")}
       />
     </ApprovalCard>
+  );
+}
+
+function InfoRows({
+  cwd,
+  timeoutSec,
+  waitSec,
+  kind,
+}: {
+  cwd?: string;
+  timeoutSec?: number;
+  waitSec?: number;
+  kind?: "run_command" | "run_background";
+}): React.ReactElement | null {
+  const rows: Array<{ label: string; value: string }> = [];
+  if (cwd) rows.push({ label: t("shellConfirm.cwdLabel"), value: tildeify(cwd) });
+  if (kind === "run_background" && waitSec !== undefined && waitSec > 0) {
+    rows.push({ label: t("shellConfirm.waitLabel"), value: `${waitSec}s` });
+  } else if (kind !== "run_background" && timeoutSec !== undefined) {
+    rows.push({ label: t("shellConfirm.timeoutLabel"), value: `${timeoutSec}s` });
+  }
+  if (rows.length === 0) return null;
+  const labelWidth = Math.max(...rows.map((r) => r.label.length));
+  return (
+    <Box flexDirection="column" marginBottom={1}>
+      {rows.map((r) => (
+        <Box key={r.label} flexDirection="row" gap={1}>
+          <Text color={FG.faint}>{r.label.padEnd(labelWidth)}</Text>
+          <Text color={FG.body}>{r.value}</Text>
+        </Box>
+      ))}
+    </Box>
   );
 }
 

--- a/src/cli/ui/cards/ReasoningCard.tsx
+++ b/src/cli/ui/cards/ReasoningCard.tsx
@@ -11,10 +11,11 @@ import { Spinner } from "../primitives/Spinner.js";
 import type { ReasoningCard as ReasoningCardData } from "../state/cards.js";
 import { FG, TONE, TONE_ACTIVE } from "../theme/tokens.js";
 
-/** Streaming preview tail length — wide enough to feel responsive, small enough not to thrash on every chunk. Full body lives in the events log. */
-const STREAMING_PREVIEW_LINES = 4;
-/** Once settled, only the conclusion is actionable; the rest is in `/reasoning last`. */
+const STREAMING_PREVIEW_LINES = 3;
+const SETTLED_HEAD_LINES = 2;
 const SETTLED_TAIL_LINES = 2;
+/** Above this, head+tail noise > value — collapse to tail + scroll-past summary. */
+const XL_TOKEN_THRESHOLD = 800;
 
 export function ReasoningCard({
   card,
@@ -28,14 +29,17 @@ export function ReasoningCard({
   const lineCells = Math.max(20, cols - 4);
 
   const allLines = card.text.length > 0 ? card.text.split("\n") : [];
-  const showBody = expanded && (allLines.length > 0 || card.streaming);
+  const isEmpty = !card.streaming && !card.aborted && allLines.length === 0;
+  const showBody = expanded && (allLines.length > 0 || card.streaming || isEmpty);
   const tone = card.aborted ? TONE.err : card.streaming ? TONE_ACTIVE.accent : TONE.accent;
 
   return (
     <Card tone={tone}>
-      <ReasoningHeader card={card} />
+      <ReasoningHeader card={card} isEmpty={isEmpty} />
       {showBody &&
-        (card.streaming ? (
+        (isEmpty ? (
+          <EmptyHint />
+        ) : card.streaming ? (
           <StreamingPreview card={card} allLines={allLines} lineCells={lineCells} />
         ) : (
           <SettledPreview card={card} allLines={allLines} lineCells={lineCells} />
@@ -44,15 +48,28 @@ export function ReasoningCard({
   );
 }
 
-function ReasoningHeader({ card }: { card: ReasoningCardData }): React.ReactElement {
+function ReasoningHeader({
+  card,
+  isEmpty,
+}: {
+  card: ReasoningCardData;
+  isEmpty: boolean;
+}): React.ReactElement {
   const streamingActive = card.streaming && !card.aborted;
-  const headColor = card.aborted ? TONE.err : streamingActive ? TONE_ACTIVE.accent : TONE.accent;
+  const headColor = card.aborted
+    ? TONE.err
+    : streamingActive
+      ? TONE_ACTIVE.accent
+      : isEmpty
+        ? FG.faint
+        : TONE.accent;
   const glyph = streamingActive ? "◇" : "◆";
   const title = streamingActive
     ? t("cardTitles.reasoningEllipsis")
     : card.aborted
       ? t("cardTitles.reasoningAborted")
       : t("cardTitles.reasoning");
+  const pill = isEmpty ? PILL_SECTION.empty : PILL_SECTION.reason;
   const meta: MetaItem[] = [];
   const m = headerMeta(card);
   if (m) meta.push(m);
@@ -64,8 +81,8 @@ function ReasoningHeader({ card }: { card: ReasoningCardData }): React.ReactElem
       glyph={glyph}
       tone={headColor}
       title={title}
-      titleColor={PILL_SECTION.reason.fg}
-      titleBg={PILL_SECTION.reason.bg}
+      titleColor={pill.fg}
+      titleBg={pill.bg}
       meta={meta.length > 0 ? meta : undefined}
       right={
         <>
@@ -104,18 +121,61 @@ interface BodyProps {
 function StreamingPreview({ card, allLines, lineCells }: BodyProps): React.ReactElement {
   const visualLines = allLines.flatMap((l) => wrapToCells(l, lineCells));
   const visible = visualLines.slice(-STREAMING_PREVIEW_LINES);
-  return <BodyLines card={card} lines={visible} lineCells={lineCells} cursorOnLast />;
+  const hasOverflow = visualLines.length > visible.length;
+  return (
+    <>
+      {hasOverflow ? <Text color={FG.faint}>⋮</Text> : null}
+      <BodyLines
+        card={card}
+        lines={visible}
+        lineCells={lineCells}
+        anchor={!hasOverflow}
+        cursorOnLast
+      />
+    </>
+  );
 }
 
 function SettledPreview({ card, allLines, lineCells }: BodyProps): React.ReactElement {
   const visualLines = allLines.flatMap((l) => wrapToCells(l, lineCells));
-  const visible = visualLines.slice(-SETTLED_TAIL_LINES);
-  const droppedLines = Math.max(0, visualLines.length - visible.length);
+
+  if (card.tokens >= XL_TOKEN_THRESHOLD) {
+    const visible = visualLines.slice(-SETTLED_TAIL_LINES);
+    const droppedLines = Math.max(0, visualLines.length - visible.length);
+    return (
+      <>
+        {droppedLines > 0 ? <ScrollPastHint card={card} /> : null}
+        <BodyLines card={card} lines={visible} lineCells={lineCells} indexOffset={droppedLines} />
+      </>
+    );
+  }
+
+  const totalShown = SETTLED_HEAD_LINES + SETTLED_TAIL_LINES;
+  if (visualLines.length <= totalShown) {
+    return <BodyLines card={card} lines={visualLines} lineCells={lineCells} anchor />;
+  }
+  const headLines = visualLines.slice(0, SETTLED_HEAD_LINES);
+  const tailLines = visualLines.slice(-SETTLED_TAIL_LINES);
+  const droppedMid = visualLines.length - headLines.length - tailLines.length;
   return (
     <>
-      {droppedLines > 0 ? <ElisionHint droppedLines={droppedLines} card={card} /> : null}
-      <BodyLines card={card} lines={visible} lineCells={lineCells} indexOffset={droppedLines} />
+      <BodyLines card={card} lines={headLines} lineCells={lineCells} anchor />
+      <MidElisionHint droppedLines={droppedMid} />
+      <BodyLines
+        card={card}
+        lines={tailLines}
+        lineCells={lineCells}
+        indexOffset={headLines.length + droppedMid}
+      />
     </>
+  );
+}
+
+function EmptyHint(): React.ReactElement {
+  return (
+    <Text italic color={FG.faint}>
+      no thinking — direct answer
+    </Text>
   );
 }
 
@@ -125,6 +185,8 @@ interface BodyLinesProps {
   lineCells: number;
   cursorOnLast?: boolean;
   indexOffset?: number;
+  /** Render ↳ before the first line — only when this slice is the absolute body start. */
+  anchor?: boolean;
 }
 
 function BodyLines({
@@ -133,15 +195,20 @@ function BodyLines({
   lineCells,
   cursorOnLast = false,
   indexOffset = 0,
+  anchor = false,
 }: BodyLinesProps): React.ReactElement {
+  const tone = card.aborted ? TONE.err : card.streaming ? TONE_ACTIVE.accent : TONE.accent;
+  const innerCells = lineCells - (anchor ? 2 : 0);
   return (
     <>
       {lines.map((line, i) => {
         const isLast = i === lines.length - 1;
+        const isFirst = i === 0;
         return (
-          <Box key={`${card.id}:b:${indexOffset + i}`} flexDirection="row">
+          <Box key={`${card.id}:b:${indexOffset + i}`} flexDirection="row" gap={1}>
+            {anchor ? <Text color={tone}>{isFirst ? "↳" : " "}</Text> : null}
             <Text italic color={FG.meta}>
-              {clipToCells(line, lineCells)}
+              {clipToCells(line, innerCells)}
             </Text>
             {isLast && cursorOnLast && <CursorBlock />}
           </Box>
@@ -151,19 +218,15 @@ function BodyLines({
   );
 }
 
-function ElisionHint({
-  droppedLines,
-  card,
-}: {
-  droppedLines: number;
-  card: ReasoningCardData;
-}): React.ReactElement {
+function MidElisionHint({ droppedLines }: { droppedLines: number }): React.ReactElement {
+  return (
+    <Text color={FG.faint}>{`⋯ ${droppedLines} line${droppedLines === 1 ? "" : "s"} elided`}</Text>
+  );
+}
+
+function ScrollPastHint({ card }: { card: ReasoningCardData }): React.ReactElement {
   const parts: string[] = [];
-  if (card.paragraphs > 1) {
-    parts.push(`${card.paragraphs} ¶`);
-  } else {
-    parts.push(`${droppedLines} line${droppedLines === 1 ? "" : "s"}`);
-  }
-  if (card.tokens > 0) parts.push(`${card.tokens.toLocaleString()} tok`);
-  return <Text color={FG.faint}>{`⋯ ${parts.join(" · ")} above · /reasoning last`}</Text>;
+  if (card.paragraphs > 0) parts.push(`${card.paragraphs} ¶`);
+  if (card.tokens > 0) parts.push(`~${card.tokens.toLocaleString()} tok`);
+  return <Text color={FG.faint}>{`⋯ ${parts.join(" + ")} scrolled past · /reasoning last`}</Text>;
 }

--- a/src/cli/ui/cards/TaskCard.tsx
+++ b/src/cli/ui/cards/TaskCard.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { t } from "../../../i18n/index.js";
 import { Card } from "../primitives/Card.js";
 import { CardHeader } from "../primitives/CardHeader.js";
+import { PILL_PATH, PILL_SECTION, Pill } from "../primitives/Pill.js";
 import type { TaskCard as TaskCardData, TaskStep } from "../state/cards.js";
 import { useThemeTokens } from "../theme/context.js";
 
@@ -20,6 +21,12 @@ const TASK_GLYPH: Record<TaskCardData["status"], string> = {
   failed: "✗",
 };
 
+const TASK_PILL: Record<TaskCardData["status"], { bg: string; fg: string }> = {
+  running: PILL_SECTION.task,
+  done: PILL_SECTION.taskDone,
+  failed: PILL_SECTION.taskFailed,
+};
+
 export function TaskCard({ card }: { card: TaskCardData }): React.ReactElement {
   const { fg, tone } = useThemeTokens();
   const stepColor: Record<TaskStep["status"], string> = {
@@ -33,14 +40,17 @@ export function TaskCard({ card }: { card: TaskCardData }): React.ReactElement {
     done: tone.ok,
     failed: tone.err,
   };
+  const pill = TASK_PILL[card.status];
   const elapsed = `${(card.elapsedMs / 1000).toFixed(1)}s`;
   return (
     <Card tone={taskColor[card.status]}>
       <CardHeader
         glyph={TASK_GLYPH[card.status]}
         tone={taskColor[card.status]}
-        title={`${t("cardLabels.stepLabel")} ${card.index}/${card.total}`}
-        subtitle={card.title}
+        title={t("cardTitles.task")}
+        titleColor={pill.fg}
+        titleBg={pill.bg}
+        subtitle={`${card.index} / ${card.total}  ${card.title}`}
         meta={[elapsed, card.status]}
       />
       {card.steps.map((step) => (
@@ -49,7 +59,7 @@ export function TaskCard({ card }: { card: TaskCardData }): React.ReactElement {
           <Text bold color={fg.body}>
             {(step.toolName ?? t("cardLabels.stepLabel")).padEnd(7)}
           </Text>
-          <Text color={fg.sub}>{step.title}</Text>
+          <Pill label={step.title} {...PILL_PATH} bold={false} />
           {step.detail ? <Text color={fg.faint}>{step.detail}</Text> : null}
           {step.elapsedMs !== undefined ? (
             <Text color={fg.faint}>{`${(step.elapsedMs / 1000).toFixed(2)}s`}</Text>

--- a/src/cli/ui/cards/UserCard.tsx
+++ b/src/cli/ui/cards/UserCard.tsx
@@ -1,24 +1,29 @@
-import { Text } from "ink";
+import { Box, Text } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React from "react";
 import { t } from "../../../i18n/index.js";
 import { Card } from "../primitives/Card.js";
 import { CardHeader } from "../primitives/CardHeader.js";
+import { PILL_SECTION } from "../primitives/Pill.js";
 import type { UserCard as UserCardData } from "../state/cards.js";
-import { FG, TONE } from "../theme/tokens.js";
+import { CARD, FG } from "../theme/tokens.js";
 import { formatRelativeTime } from "./time.js";
 
 export function UserCard({ card }: { card: UserCardData }): React.ReactElement {
   return (
-    <Card tone={TONE.accent}>
+    <Card tone={CARD.user.color}>
       <CardHeader
-        glyph="›"
-        tone={TONE.accent}
+        glyph={CARD.user.glyph}
+        tone={CARD.user.color}
         title={t("cardTitles.you")}
-        titleColor={FG.sub}
+        titleColor={PILL_SECTION.user.fg}
+        titleBg={PILL_SECTION.user.bg}
         meta={[formatRelativeTime(card.ts)]}
       />
-      <Text>{card.text}</Text>
+      <Box flexDirection="row" gap={1}>
+        <Text color={FG.sub}>↳</Text>
+        <Text>{card.text}</Text>
+      </Box>
     </Card>
   );
 }

--- a/src/cli/ui/primitives/Pill.tsx
+++ b/src/cli/ui/primitives/Pill.tsx
@@ -26,7 +26,11 @@ export const PILL_SECTION = {
   taskFailed: { bg: "#2c1416", fg: "#ff8b81" },
   plan: { bg: "#2a1f3d", fg: "#d2a8ff" },
   user: { bg: "#11141a", fg: "#8b949e" },
+  empty: { bg: "#11141a", fg: "#6e7681" },
 } as const;
+
+/** Path pill — bg-elev tint for filenames / paths / shell targets inside tool rows. */
+export const PILL_PATH = { bg: "#11141a", fg: "#8b949e" } as const;
 
 /** Model pill — neutral bg, color signals model class. */
 export const PILL_MODEL = {

--- a/src/core/pause-gate.ts
+++ b/src/core/pause-gate.ts
@@ -55,8 +55,8 @@ interface PauseResponseMap {
 type PauseKind = keyof PauseResponseMap;
 
 interface PausePayloadMap {
-  run_command: { command: string };
-  run_background: { command: string };
+  run_command: { command: string; cwd?: string; timeoutSec?: number };
+  run_background: { command: string; cwd?: string; waitSec?: number };
   plan_proposed: { plan: string; steps?: unknown[]; summary?: string };
   plan_checkpoint: { stepId: string; title?: string; result: string; notes?: string };
   plan_revision: { reason: string; remainingSteps: unknown[]; summary?: string };

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -1113,6 +1113,9 @@ export const EN: TranslationSchema = {
     allowAlwaysDesc: "remember `{prefix}` for this project",
     deny: "deny",
     denyDesc: "press Tab to add context telling the model why",
+    cwdLabel: "cwd",
+    timeoutLabel: "timeout",
+    waitLabel: "wait",
   },
   editConfirm: {
     footer:

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -1290,6 +1290,7 @@ export const EN: TranslationSchema = {
     error: "error",
     doctor: "doctor",
     you: "you",
+    task: "task",
   },
   cardLabels: {
     prompt: "prompt",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -553,6 +553,7 @@ export interface TranslationSchema {
     error: string;
     doctor: string;
     you: string;
+    task: string;
   };
   cardLabels: {
     prompt: string;

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -400,6 +400,9 @@ export interface TranslationSchema {
     allowAlwaysDesc: string;
     deny: string;
     denyDesc: string;
+    cwdLabel: string;
+    timeoutLabel: string;
+    waitLabel: string;
   };
   editConfirm: {
     footer: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -1226,6 +1226,7 @@ export const zhCN: TranslationSchema = {
     error: "错误",
     doctor: "环境诊断",
     you: "你",
+    task: "任务",
   },
   cardLabels: {
     prompt: "提示",

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -1055,6 +1055,9 @@ export const zhCN: TranslationSchema = {
     allowAlwaysDesc: "记住 `{prefix}`，本项目内不再询问",
     deny: "拒绝",
     denyDesc: "按 Tab 添加说明，告诉模型原因",
+    cwdLabel: "工作目录",
+    timeoutLabel: "超时",
+    waitLabel: "等待",
   },
   editConfirm: {
     footer:

--- a/src/tools/shell.ts
+++ b/src/tools/shell.ts
@@ -112,9 +112,13 @@ export function registerShellTools(registry: ToolRegistry, opts: ShellToolsOptio
     fn: async (args: { command: string; timeoutSec?: number }, ctx) => {
       const cmd = args.command.trim();
       if (!cmd) throw new Error("run_command: empty command");
+      const effectiveTimeout = Math.max(1, Math.min(600, args.timeoutSec ?? timeoutSec));
       if (!isAllowAll() && !isCommandAllowed(cmd, getExtraAllowed())) {
         const gate = ctx?.confirmationGate ?? pauseGate;
-        const choice = await gate.ask({ kind: "run_command", payload: { command: cmd } });
+        const choice = await gate.ask({
+          kind: "run_command",
+          payload: { command: cmd, cwd: rootDir, timeoutSec: effectiveTimeout },
+        });
         if (choice.type === "deny") {
           throw new Error(
             `user denied: ${cmd}${choice.denyContext ? ` — ${choice.denyContext}` : ""}`,
@@ -125,7 +129,6 @@ export function registerShellTools(registry: ToolRegistry, opts: ShellToolsOptio
         }
         // "run_once" — fall through and execute
       }
-      const effectiveTimeout = Math.max(1, Math.min(600, args.timeoutSec ?? timeoutSec));
       const result = await runCommand(cmd, {
         cwd: rootDir,
         timeoutSec: effectiveTimeout,
@@ -161,7 +164,10 @@ export function registerShellTools(registry: ToolRegistry, opts: ShellToolsOptio
       if (!cmd) throw new Error("run_background: empty command");
       if (!isAllowAll() && !isCommandAllowed(cmd, getExtraAllowed())) {
         const gate = ctx?.confirmationGate ?? pauseGate;
-        const choice = await gate.ask({ kind: "run_background", payload: { command: cmd } });
+        const choice = await gate.ask({
+          kind: "run_background",
+          payload: { command: cmd, cwd: rootDir, waitSec: args.waitSec },
+        });
         if (choice.type === "deny") {
           throw new Error(
             `user denied: ${cmd}${choice.denyContext ? ` — ${choice.denyContext}` : ""}`,

--- a/tests/shell-tools.test.ts
+++ b/tests/shell-tools.test.ts
@@ -451,7 +451,7 @@ describe("registerShellTools — dispatch integration", () => {
     });
     expect(spy.lastCall).not.toBeNull();
     expect(spy.lastCall!.kind).toBe("run_command");
-    expect(spy.lastCall!.payload).toEqual({ command: "npm i" });
+    expect(spy.lastCall!.payload).toMatchObject({ command: "npm i", cwd: tmp });
   });
 
   it("allowAll:true bypasses the allowlist entirely", async () => {


### PR DESCRIPTION
## Summary

Design-audit pass against `docs/design/agent-tui-terminal.html`, split into three commits:

- **`feat(cards)`** — UserCard goes muted (◇ glyph, bg-elev pill, fg.sub ↳ anchor) since the user is the conversational anchor, not status. ReasoningCard tightens the four-tier render: streaming tail-3 + ⋮ overflow, settled-medium head+tail with mid `⋯ N lines elided`, XL (≥800 tok) drops the head and shows `⋯ N ¶ + ~T tok scrolled past`, empty reasoning surfaces a grayed `PILL_SECTION.empty` + "no thinking — direct answer" hint. Body anchor ↳ renders only when the absolute body start is visible. TaskCard gets a status-mapped section pill (task / taskDone / taskFailed) and step rows wrap targets in `PILL_PATH` chips.
- **`feat(composer)`** — block cursor blinks at 1Hz via `useSlowTick` (was hardcoded visible).
- **`feat(shell-confirm)`** — modal now shows `cwd ~/projects/reasonix` + `timeout 120s` (or `wait 3s` for backgrounds) below the `$ command` line. `PausePayloadMap.run_command` / `run_background` widened with optional `cwd` + `timeoutSec` / `waitSec`; `shell.ts` computes the effective timeout before `gate.ask` so the modal shows the same number the runtime will enforce.

## Test plan

- [x] `npm run verify` — 169 files, 2621 tests passing
- [x] `tests/shell-tools.test.ts` regression for run_command payload still passes after widening to `toMatchObject({ command, cwd })`
- [x] `tests/user-card-verbatim.test.tsx` still passes — the new ↳ anchor doesn't affect the verbatim text path
- [ ] Manual: stream a long reasoning (>800 tok) and confirm the XL tail-only render with the scroll-past hint
- [ ] Manual: trigger an empty `reasoning_content` (instruct-mode v4) and confirm the grayed pill + "no thinking" line
- [ ] Manual: gated shell command displays cwd + timeout rows correctly under both `run_command` and `run_background`