### PR TITLE
chore(tools,loop): align readOnlyCheck warnings to process.stderr.write

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -197,7 +197,7 @@ export class CacheFirstLoop {
         } catch (err) {
           // Mirror tools.ts: surface buggy readOnlyCheck instead of silently
           // falling through to the static flag.
-          console.warn(`readOnlyCheck for ${name} threw: ${(err as Error).message}`);
+          process.stderr.write(`readOnlyCheck for ${name} threw: ${(err as Error).message}\n`);
         }
       }
       return def.readOnly !== true;

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -304,7 +304,7 @@ function isReadOnlyCall(tool: InternalTool, args: Record<string, unknown>): bool
     } catch (err) {
       // A buggy readOnlyCheck silently downgrades to "may mutate" — log it so
       // the bug doesn't hide behind plan-mode refusals or storm-breaker noise.
-      console.warn(`readOnlyCheck for ${tool.name} threw: ${(err as Error).message}`);
+      process.stderr.write(`readOnlyCheck for ${tool.name} threw: ${(err as Error).message}\n`);
       return false;
     }
   }

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -509,13 +509,16 @@ describe("ToolRegistry", () => {
         fn: () => "ok",
       });
       reg.setPlanMode(true);
-      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
       try {
         const out = await reg.dispatch("buggy_tool", "{}");
         expect(JSON.parse(out).error).toMatch(/unavailable in plan mode/);
-        expect(warnSpy).toHaveBeenCalledWith("readOnlyCheck for buggy_tool threw: check is buggy");
+        const writes = writeSpy.mock.calls.map((c) => String(c[0]));
+        expect(
+          writes.some((w) => w.includes("readOnlyCheck for buggy_tool threw: check is buggy")),
+        ).toBe(true);
       } finally {
-        warnSpy.mockRestore();
+        writeSpy.mockRestore();
       }
     });
 
@@ -527,12 +530,13 @@ describe("ToolRegistry", () => {
         fn: () => "ok",
       });
       reg.setPlanMode(true);
-      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
       try {
         await reg.dispatch("good_tool", "{}");
-        expect(warnSpy).not.toHaveBeenCalled();
+        const writes = writeSpy.mock.calls.map((c) => String(c[0]));
+        expect(writes.some((w) => w.includes("readOnlyCheck for"))).toBe(false);
       } finally {
-        warnSpy.mockRestore();
+        writeSpy.mockRestore();
       }
     });
   });


### PR DESCRIPTION
## Summary

Silent follow-up to #670 — converts the two `console.warn` calls added there to `process.stderr.write` so they match the rest of the project's diagnostic convention (`src/cli/commands/commit.ts`, the `[mcp-stdio]` trace from #669, etc.). No behavior change; both routes land on stderr.

Test was updated alongside — spies on `process.stderr.write` instead of `console.warn`, with the same assertion semantics.

## Test plan

- [x] `npm run verify` — 170 files / 2627 tests passing
- [x] `npx vitest run tests/tools.test.ts` — both buggy-check tests still cover the warn path