### PR TITLE
feat(tools/web): bucket 5xx separately with a transient-retry hint

### DIFF
--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -1247,6 +1247,8 @@ export const EN: TranslationSchema = {
       "web_search 429 \u2014 try: wait 10s before retrying, or rephrase the query; the search backend is rate-limiting this client",
     forbidden403:
       "web_search 403 \u2014 try: the search backend is blocking this client; switch engine with /search-engine mojeek|searxng, or wait and retry later",
+    serverError5xx:
+      "web_search {status} \u2014 try: open the search URL in a browser; if it loads this is transient and a retry in 30s may help",
     mojeekBlocked:
       "web_search: Mojeek anti-bot page \u2014 rate-limited or blocked \u2014 try: wait 30s and retry, or switch engine with /search-engine searxng",
     mojeekNoResults:
@@ -1265,6 +1267,8 @@ export const EN: TranslationSchema = {
       "web_fetch 429 for {url} \u2014 try: wait 10s before retrying; the host is rate-limiting this client",
     fetchForbidden403:
       "web_fetch 403 for {url} \u2014 try: the host is blocking this client; the page may require login or block bots \u2014 use web_search snippets instead",
+    fetchServerError5xx:
+      "web_fetch {status} for {url} \u2014 try: open the URL in a browser; if it loads this is transient and a retry in 30s may help",
     fetchTimeout:
       "web_fetch: timed out after {ms}ms for {url} \u2014 try: a shorter URL or smaller content; this may be a slow CDN, or retry once",
     fetchTooLarge:

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -524,6 +524,7 @@ export interface TranslationSchema {
     status: string;
     rateLimit429: string;
     forbidden403: string;
+    serverError5xx: string;
     mojeekBlocked: string;
     mojeekNoResults: string;
     invalidEndpoint: string;
@@ -533,6 +534,7 @@ export interface TranslationSchema {
     fetchStatus: string;
     fetchRateLimit429: string;
     fetchForbidden403: string;
+    fetchServerError5xx: string;
     fetchTimeout: string;
     fetchTooLarge: string;
     fetchBodyTooLarge: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -1184,6 +1184,8 @@ export const zhCN: TranslationSchema = {
       "web_search 429 — try: 等待 10 秒后重试，或改写查询；搜索后端正在对该客户端进行限流",
     forbidden403:
       "web_search 403 — try: 搜索后端拒绝该客户端访问；使用 /search-engine mojeek|searxng 切换引擎，或稍后重试",
+    serverError5xx:
+      "web_search {status} — try: 在浏览器中打开搜索 URL；若能加载则属临时故障，等 30 秒重试即可",
     mojeekBlocked:
       "web_search: Mojeek 反爬页面 — 频率限制或被屏蔽 — try: 等待 30 秒后重试，或使用 /search-engine searxng 切换引擎",
     mojeekNoResults:
@@ -1202,6 +1204,8 @@ export const zhCN: TranslationSchema = {
       "web_fetch 429 for {url} — try: 等待 10 秒后重试；目标主机正在对该客户端进行限流",
     fetchForbidden403:
       "web_fetch 403 for {url} — try: 目标主机拒绝该客户端访问；该页面可能需要登录或屏蔽爬虫 — 改用 web_search 摘要",
+    fetchServerError5xx:
+      "web_fetch {status} for {url} — try: 在浏览器中打开该 URL；若能加载则属临时故障，等 30 秒重试即可",
     fetchTimeout:
       "web_fetch: timed out after {ms}ms for {url} — try: 更短的 URL 或更小的内容；可能是 CDN 较慢，或重试一次",
     fetchTooLarge:

--- a/src/tools/web.ts
+++ b/src/tools/web.ts
@@ -54,12 +54,14 @@ const MOJEEK_ENDPOINT = "https://www.mojeek.com/search";
 function searchStatusError(status: number): string {
   if (status === 429) return t("webErrors.rateLimit429");
   if (status === 403) return t("webErrors.forbidden403");
+  if (status >= 500 && status <= 599) return t("webErrors.serverError5xx", { status });
   return t("webErrors.status", { status });
 }
 
 function fetchStatusError(status: number, url: string): string {
   if (status === 429) return t("webErrors.fetchRateLimit429", { url });
   if (status === 403) return t("webErrors.fetchForbidden403", { url });
+  if (status >= 500 && status <= 599) return t("webErrors.fetchServerError5xx", { status, url });
   return t("webErrors.fetchStatus", { status, url });
 }
 

--- a/tests/web-tools.test.ts
+++ b/tests/web-tools.test.ts
@@ -244,13 +244,13 @@ describe("webSearch", () => {
     }
   });
 
-  it("annotates generic 5xx with a try-hint tail", async () => {
+  it("annotates 5xx with a transient-retry hint", async () => {
     const originalFetch = globalThis.fetch;
     globalThis.fetch = vi.fn(
       async () => new Response("broken", { status: 503 }),
     ) as unknown as typeof fetch;
     try {
-      await expect(webSearch("q")).rejects.toThrow(/web_search 503.*try:/);
+      await expect(webSearch("q")).rejects.toThrow(/web_search 503.*try:.*retry in 30s/);
     } finally {
       globalThis.fetch = originalFetch;
     }
@@ -417,6 +417,20 @@ describe("webFetch", () => {
     try {
       await expect(webFetch("https://example.com/forbidden")).rejects.toThrow(
         /web_fetch 403.*try:.*blocking|web_fetch 403.*try:/,
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("annotates 5xx with a transient-retry hint", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(
+      async () => new Response("upstream broken", { status: 502 }),
+    ) as unknown as typeof fetch;
+    try {
+      await expect(webFetch("https://example.com/gateway")).rejects.toThrow(
+        /web_fetch 502.*try:.*retry in 30s/,
       );
     } finally {
       globalThis.fetch = originalFetch;


### PR DESCRIPTION
## Summary

Extends the actionable-error work from #632 with a dedicated 5xx bucket. Before this, generic 5xx fell through to the catch-all `webErrors.status` / `webErrors.fetchStatus` message — which advises rephrasing the query or switching engines, neither of which helps when the upstream server is just temporarily broken.

After:

- `web_search 503 — try: open the search URL in a browser; if it loads this is transient and a retry in 30s may help`
- `web_fetch 502 for {url} — try: open the URL in a browser; if it loads this is transient and a retry in 30s may help`

`searchStatusError` / `fetchStatusError` get one extra branch each (`status >= 500 && status <= 599`); EN + zh-CN + `TranslationSchema` updated in step.

Credit to @MyPrototypeWhat — #671 surfaced this gap (their PR added a 5xx bucket alongside a parallel re-do of #632's 429/403 work). #671 is closed as superseded, but the 5xx insight + the 503 test case land here.

## Test plan

- [x] `npm run verify` — 170 files / 2628 tests passing
- [x] Existing `webSearch` 503 test tightened from `/web_search 503.*try:/` to assert on the new `retry in 30s` substring
- [x] New parallel `webFetch` 502 test in the same shape