### PR TITLE
feat(i18n): localize MCP lifecycle, slow toast, and external editor messages with zh-CN

### DIFF
--- a/src/cli/edit/external-editor.ts
+++ b/src/cli/edit/external-editor.ts
@@ -4,6 +4,7 @@ import { spawn } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { t } from "../../i18n/index.js";
 
 export interface OpenEditorResult {
   /** "ok" when the editor returned 0 and we read content back; "missing" when no editor env var is set; "failed" on spawn error or non-zero exit. */
@@ -30,8 +31,7 @@ export async function openInExternalEditor(initial: string): Promise<OpenEditorR
     return {
       kind: "missing",
       content: initial,
-      detail:
-        "no $EDITOR / $VISUAL / $GIT_EDITOR set — export one (e.g. `export EDITOR=nano`) and retry",
+      detail: t("composer.editorMissing"),
     };
   }
   const dir = mkdtempSync(join(tmpdir(), "reasonix-compose-"));
@@ -45,7 +45,7 @@ export async function openInExternalEditor(initial: string): Promise<OpenEditorR
     return {
       kind: "failed",
       content: initial,
-      detail: (err as Error).message,
+      detail: t("composer.editorExited", { code: (err as Error).message }),
     };
   } finally {
     try {
@@ -68,7 +68,7 @@ function spawnEditor(editor: string, path: string): Promise<void> {
     child.on("error", reject);
     child.on("exit", (code) => {
       if (code === 0 || code === null) resolve();
-      else reject(new Error(`editor exited with code ${code}`));
+      else reject(new Error(String(code)));
     });
   });
 }

--- a/src/cli/ui/mcp-lifecycle.ts
+++ b/src/cli/ui/mcp-lifecycle.ts
@@ -1,5 +1,7 @@
 /** Formats one-liner MCP lifecycle events per `docs/design/agent-tui-terminal.html` §37. */
 
+import { t } from "../../i18n/index.js";
+
 export type McpLifecycleEvent =
   | { state: "handshake"; name: string }
   | {
@@ -14,12 +16,12 @@ export type McpLifecycleEvent =
   | { state: "disabled"; name: string }
   | { state: "reconnect"; name: string };
 
-const STATE: Record<McpLifecycleEvent["state"], { glyph: string; label: string }> = {
-  handshake: { glyph: "↻", label: "handshake…" },
-  connected: { glyph: "✓", label: "connected" },
-  failed: { glyph: "✖", label: "failed" },
-  disabled: { glyph: "○", label: "disabled" },
-  reconnect: { glyph: "↻", label: "reconnect…" },
+const STATE: Record<McpLifecycleEvent["state"], { glyph: string; label: () => string }> = {
+  handshake: { glyph: "↻", label: () => t("mcpLifecycle.handshake") },
+  connected: { glyph: "✓", label: () => t("mcpLifecycle.connected") },
+  failed: { glyph: "✖", label: () => t("mcpLifecycle.failed") },
+  disabled: { glyph: "○", label: () => t("mcpLifecycle.disabled") },
+  reconnect: { glyph: "↻", label: () => t("mcpLifecycle.reconnect") },
 };
 
 const NAME_COL = 22;
@@ -29,15 +31,15 @@ export function formatMcpLifecycleEvent(ev: McpLifecycleEvent): string {
   const { glyph, label } = STATE[ev.state];
   const namePart = `MCP · ${ev.name}`;
   const namePad = " ".repeat(Math.max(1, NAME_COL - namePart.length));
-  const stateField = `${glyph} ${label}`.padEnd(STATE_COL);
+  const stateField = `${glyph} ${label()}`.padEnd(STATE_COL);
   return `⌘ ${namePart}${namePad}${stateField}${describeDetail(ev)}`;
 }
 
 function describeDetail(ev: McpLifecycleEvent): string {
-  if (ev.state === "handshake") return "initialise → tools/list → resources/list";
+  if (ev.state === "handshake") return t("mcpLifecycle.initDetail");
   if (ev.state === "failed") return ev.reason;
-  if (ev.state === "disabled") return `via /mcp disable ${ev.name}`;
-  if (ev.state === "reconnect") return "tearing down · re-handshake · listing tools";
+  if (ev.state === "disabled") return t("mcpLifecycle.disabledDetail", { name: ev.name });
+  if (ev.state === "reconnect") return t("mcpLifecycle.reconnectDetail");
   const parts: string[] = [`${ev.tools} tools`];
   if (ev.resources && ev.resources > 0) parts.push(`${ev.resources} resources`);
   if (ev.prompts && ev.prompts > 0) parts.push(`${ev.prompts} prompts`);

--- a/src/cli/ui/mcp-toast.ts
+++ b/src/cli/ui/mcp-toast.ts
@@ -1,12 +1,14 @@
 /** One-line warn toast emitted when an MCP server's p95 crosses the slow threshold (design §32). */
 
+import { t } from "../../i18n/index.js";
+
 export interface McpSlowToast {
   name: string;
   p95Ms: number;
   sampleSize: number;
 }
 
-export function formatMcpSlowToast(t: McpSlowToast): string {
-  const seconds = (t.p95Ms / 1000).toFixed(1);
-  return `⚠ MCP \`${t.name}\` slow · ${seconds}s p95 over the last ${t.sampleSize} calls`;
+export function formatMcpSlowToast(tst: McpSlowToast): string {
+  const seconds = (tst.p95Ms / 1000).toFixed(1);
+  return t("mcpHealth.slowToast", { name: tst.name, seconds, sampleSize: tst.sampleSize });
 }

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -1094,6 +1094,9 @@ export const EN: TranslationSchema = {
     editorNoRawMode:
       "external editor unavailable \u2014 stdin doesn't support raw-mode toggling on this terminal",
     editorFailed: "external editor:",
+    editorMissing:
+      "no $EDITOR / $VISUAL / $GIT_EDITOR set \u2014 export one (e.g. `export EDITOR=nano`) and retry",
+    editorExited: "editor exited with code {code}",
   },
   shellConfirm: {
     title: "Shell command",
@@ -1378,6 +1381,7 @@ export const EN: TranslationSchema = {
     healthy: "healthy \u00b7 {ms}ms",
     slow: "slow \u00b7 {ms}ms",
     verySlow: "very slow \u00b7 {ms}ms",
+    slowToast: "\u26a0 MCP `{name}` slow \u00b7 {seconds}s p95 over the last {sampleSize} calls",
   },
   denyContextInput: {
     description:
@@ -1436,6 +1440,16 @@ export const EN: TranslationSchema = {
     empty: "No MCP servers attached. Run `reasonix setup` to pick some, or launch with --mcp.",
     serverCount: "{count} server{s}",
     footer: "\u2191\u2193 pick \u00b7 [r] reconnect \u00b7 [d] disable \u00b7 esc quit",
+  },
+  mcpLifecycle: {
+    handshake: "handshake\u2026",
+    connected: "connected",
+    failed: "failed",
+    disabled: "disabled",
+    reconnect: "reconnect\u2026",
+    initDetail: "initialise \u2192 tools/list \u2192 resources/list",
+    reconnectDetail: "tearing down \u00b7 re-handshake \u00b7 listing tools",
+    disabledDetail: "via /mcp disable {name}",
   },
   checkpointPicker: {
     title: "restore a checkpoint \u2014 {workspace}",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -383,6 +383,8 @@ export interface TranslationSchema {
     abortedHint: string;
     editorNoRawMode: string;
     editorFailed: string;
+    editorMissing: string;
+    editorExited: string;
   };
   shellConfirm: {
     title: string;
@@ -639,6 +641,7 @@ export interface TranslationSchema {
     healthy: string;
     slow: string;
     verySlow: string;
+    slowToast: string;
   };
   denyContextInput: {
     description: string;
@@ -694,6 +697,16 @@ export interface TranslationSchema {
     empty: string;
     serverCount: string;
     footer: string;
+  };
+  mcpLifecycle: {
+    handshake: string;
+    connected: string;
+    failed: string;
+    disabled: string;
+    reconnect: string;
+    initDetail: string;
+    reconnectDetail: string;
+    disabledDetail: string;
   };
   checkpointPicker: {
     title: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -1038,6 +1038,9 @@ export const zhCN: TranslationSchema = {
     abortedHint: "用户已中止本轮 · 再按 Esc 清除 · ⏎ 继续提问",
     editorNoRawMode: "外部编辑器不可用 — 当前终端不支持 raw-mode 切换",
     editorFailed: "外部编辑器：",
+    editorMissing:
+      "未设置 $EDITOR / $VISUAL / $GIT_EDITOR — 请导出环境变量（例如 `export EDITOR=nano`）后重试",
+    editorExited: "编辑器异常退出，返回码 {code}",
   },
   shellConfirm: {
     title: "Shell 命令",
@@ -1314,6 +1317,7 @@ export const zhCN: TranslationSchema = {
     healthy: "正常 \u00b7 {ms}ms",
     slow: "缓慢 \u00b7 {ms}ms",
     verySlow: "非常慢 \u00b7 {ms}ms",
+    slowToast: "\u26a0 MCP `{name}` 响应缓慢 \u00b7 P95 {seconds}s \u00b7 最近 {sampleSize} 次调用",
   },
   denyContextInput: {
     description: "告诉模型你为什么拒绝了。模型下次会看到你的理由作为额外的上下文。",
@@ -1369,6 +1373,16 @@ export const zhCN: TranslationSchema = {
     empty: "没有挂载 MCP 服务器。运行 `reasonix setup` 选择一些，或使用 --mcp 启动。",
     serverCount: "{count} 个服务器",
     footer: "↑↓ 选择 · [r] 重连 · [d] 禁用 · Esc 退出",
+  },
+  mcpLifecycle: {
+    handshake: "握手中…",
+    connected: "已连接",
+    failed: "失败",
+    disabled: "已禁用",
+    reconnect: "重连中…",
+    initDetail: "初始化 → tools/list → resources/list",
+    reconnectDetail: "断开旧连接 · 重新握手 · 列出工具",
+    disabledDetail: "通过 /mcp disable {name}",
   },
   checkpointPicker: {
     title: "恢复检查点 \u2014 {workspace}",


### PR DESCRIPTION
Localizes previously hardcoded English strings in three files that were missed during the initial i18n pass:

**`mcp-lifecycle.ts`** — MCP connection state labels (handshake/connected/failed/disabled/reconnect) and detail text now route through `t()`. The `STATE` constant uses arrow functions to defer `t()` calls to runtime.

**`mcp-toast.ts`** — MCP slow-server warning toast now uses `t()` via `mcpHealth.slowToast`.

**`external-editor.ts`** — Editor-not-configured and editor-exit-error messages now use `t()` via `composer.editorMissing` / `composer.editorExited`. `spawnEditor` passes numeric exit codes instead of English sentences.

New i18n keys: `mcpLifecycle` namespace (8 keys), `mcpHealth.slowToast`, `composer.editorMissing`, `composer.editorExited`.

## Test plan
- [x] `npm run verify`