### PR TITLE
feat(mcp): show loading pill and gate tool dispatch on readiness

### DIFF
--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -143,11 +143,25 @@ function createMcpRuntime(ctx: RuntimeContext): McpRuntime {
     const disabledNames = new Set(readConfig().mcpDisabled ?? []);
     let label = "anon";
     let mcp: McpClient | undefined;
+    // Per-server readiness gate — tool dispatches via the bridge await
+    // this before calling into `live.callTool`. Resolved on `connected`,
+    // rejected on `failed`, so a tool invoked mid-handshake waits
+    // (capped by `bridgeMcpTools`'s `readyTimeoutMs`) instead of
+    // surfacing a transport error.
+    let resolveReady!: () => void;
+    let rejectReady!: (err: Error) => void;
+    const ready = new Promise<void>((resolve, reject) => {
+      resolveReady = resolve;
+      rejectReady = reject;
+    });
+    // Avoid unhandledRejection if no consumer awaits `ready` yet.
+    ready.catch(() => undefined);
     try {
       const spec = parseMcpSpec(raw);
       label = spec.name ?? "anon";
       if (spec.name && disabledNames.has(spec.name)) {
         sink({ kind: "disabled", name: label });
+        rejectReady(new Error(`MCP server "${label}" is disabled`));
         return { ok: false, reason: "disabled by user" };
       }
       sink({ kind: "handshake", name: label });
@@ -167,6 +181,7 @@ function createMcpRuntime(ctx: RuntimeContext): McpRuntime {
         namePrefix,
         serverName: label,
         host,
+        ready,
         onProgress: (info) => ctx.progressSink.current?.(info),
         onSlow: (info) =>
           sink({
@@ -201,6 +216,7 @@ function createMcpRuntime(ctx: RuntimeContext): McpRuntime {
         prompts: promptCount,
         ms,
       });
+      resolveReady();
       const summary = buildMcpServerSummary({
         label,
         spec: raw,
@@ -230,6 +246,7 @@ function createMcpRuntime(ctx: RuntimeContext): McpRuntime {
       await mcp?.close().catch(() => undefined);
       const reason = (err as Error).message;
       sink({ kind: "failed", name: label, reason });
+      rejectReady(new Error(`MCP server "${label}" failed to start: ${reason}`));
       return { ok: false, reason };
     }
   }

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -907,6 +907,13 @@ function AppInner({
     if (mcpBridgeStartedRef.current) return;
     if (!mcpRuntime || !mcpSpecs || mcpSpecs.length === 0) return;
     mcpBridgeStartedRef.current = true;
+    const total = mcpSpecs.length;
+    let ready = 0;
+    agentStore.dispatch({ type: "mcp.loading", ready, total });
+    const bumpReady = () => {
+      ready = Math.min(ready + 1, total);
+      agentStore.dispatch({ type: "mcp.loading", ready, total });
+    };
     mcpRuntime.setLifecycleSink((notice) => {
       if (notice.kind === "handshake") {
         log.pushInfo(formatMcpLifecycleEvent({ state: "handshake", name: notice.name }));
@@ -921,13 +928,16 @@ function AppInner({
             ms: notice.ms,
           }),
         );
+        bumpReady();
       } else if (notice.kind === "disabled") {
         log.pushInfo(formatMcpLifecycleEvent({ state: "disabled", name: notice.name }));
+        bumpReady();
       } else if (notice.kind === "failed") {
         log.pushWarning(
           `MCP · ${notice.name} failed`,
           `${notice.reason}\n→ run \`reasonix setup\` to remove this entry, or fix the underlying issue (missing npm package, network, etc.).`,
         );
+        bumpReady();
       } else if (notice.kind === "slow") {
         log.pushInfo(
           formatMcpSlowToast({
@@ -943,7 +953,7 @@ function AppInner({
         setLiveMcpServers(mcpRuntime.summaries());
       });
     }
-  }, [mcpRuntime, mcpSpecs, loop, log]);
+  }, [mcpRuntime, mcpSpecs, loop, log, agentStore]);
 
   // Ambient session info (balance, model catalog, latest published
   // version) — three independent mount-time fetches behind one hook

--- a/src/cli/ui/layout/StatusRow.tsx
+++ b/src/cli/ui/layout/StatusRow.tsx
@@ -64,6 +64,9 @@ export function StatusRow(): React.ReactElement {
           color={TONE.accent}
           wrap="truncate"
         >{`${t("statusBar.cache")} ${Math.round(status.cacheHit * 100)}%`}</Text>
+        {status.mcpLoading && status.mcpLoading.ready < status.mcpLoading.total && (
+          <McpLoadingPill ready={status.mcpLoading.ready} total={status.mcpLoading.total} />
+        )}
         {showWallet && (
           <WalletPill
             sessionCostUsd={status.sessionCost}
@@ -121,6 +124,27 @@ function shortModelLabel(model: string): string {
   if (model === "deepseek-v4-flash") return "flash";
   if (model === "deepseek-v4-pro") return "pro";
   return model.replace(/^deepseek-/, "");
+}
+
+function McpLoadingPill({
+  ready,
+  total,
+}: {
+  ready: number;
+  total: number;
+}): React.ReactElement {
+  return (
+    <>
+      <Sep />
+      <Text color={TONE.brand} wrap="truncate">
+        {"⌁ "}
+      </Text>
+      <Text
+        color={FG.body}
+        wrap="truncate"
+      >{`${t("statusBar.mcpLoading")} ${ready}/${total}`}</Text>
+    </>
+  );
 }
 
 function WalletPill({

--- a/src/cli/ui/state/events.ts
+++ b/src/cli/ui/state/events.ts
@@ -134,6 +134,12 @@ const sessionPresetChange = z.object({
   preset: z.enum(["auto", "flash", "pro"]).nullable(),
 });
 
+const mcpLoading = z.object({
+  type: z.literal("mcp.loading"),
+  ready: z.number().int().nonnegative(),
+  total: z.number().int().nonnegative(),
+});
+
 const focusMove = z.object({
   type: z.literal("focus.move"),
   direction: z.enum(["next", "prev", "first", "last"]),
@@ -325,6 +331,7 @@ export const AgentEventSchema = z.discriminatedUnion("type", [
   sessionUpdate,
   sessionModelChange,
   sessionPresetChange,
+  mcpLoading,
   focusMove,
   focusSet,
   cardToggle,

--- a/src/cli/ui/state/reducer.ts
+++ b/src/cli/ui/state/reducer.ts
@@ -126,6 +126,20 @@ export function reduce(state: AgentState, event: AgentEvent): AgentState {
         ? state
         : { ...state, status: { ...state.status, preset: event.preset } };
 
+    case "mcp.loading": {
+      const current = state.status.mcpLoading;
+      if (event.total <= 0) {
+        if (!current) return state;
+        const { mcpLoading: _drop, ...rest } = state.status;
+        return { ...state, status: rest };
+      }
+      if (current && current.ready === event.ready && current.total === event.total) return state;
+      return {
+        ...state,
+        status: { ...state.status, mcpLoading: { ready: event.ready, total: event.total } },
+      };
+    }
+
     case "focus.move":
       return {
         ...state,

--- a/src/cli/ui/state/state.ts
+++ b/src/cli/ui/state/state.ts
@@ -34,6 +34,8 @@ export interface StatusBar {
   recording?: { sizeBytes: number; events: number; path: string };
   /** null → user is on a custom model that doesn't match any preset; pill falls back to the model id. */
   preset?: "auto" | "flash" | "pro" | null;
+  /** Bridged-MCP handshake progress. Pill is shown while ready < total. */
+  mcpLoading?: { ready: number; total: number };
 }
 
 export interface Toast {

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -1066,6 +1066,7 @@ export const EN: TranslationSchema = {
     mb: " MB",
     evt: " evt",
     editsLabel: "edits:",
+    mcpLoading: "MCP",
   },
   editMode: {
     plan: "PLAN MODE",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -356,6 +356,8 @@ export interface TranslationSchema {
     evt: string;
     /** Prefix for the edit-gate mode pill — disambiguates from the preset (`/preset auto` is a different "auto"). */
     editsLabel: string;
+    /** Label for the MCP-handshake progress pill (rendered as `⌁ MCP n/m`). */
+    mcpLoading: string;
   };
   editMode: {
     plan: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -1011,6 +1011,7 @@ export const zhCN: TranslationSchema = {
     mb: " MB",
     evt: " 事件",
     editsLabel: "编辑:",
+    mcpLoading: "MCP",
   },
   editMode: {
     plan: "计划",

--- a/src/mcp/registry.ts
+++ b/src/mcp/registry.ts
@@ -29,6 +29,10 @@ export interface BridgeOptions {
   onSlow?: (ev: SlowEvent) => void;
   /** Indirection so reconnect can swap the underlying client without re-registering tools. */
   host?: McpClientHost;
+  /** Awaited before each `callTool` — resolves on `connected`, rejects on `failed`, caps via `readyTimeoutMs`. */
+  ready?: Promise<void>;
+  /** How long to wait on `ready` before failing the dispatch. Default 30_000ms. */
+  readyTimeoutMs?: number;
 }
 
 /** Mutable holder so `/mcp reconnect` can swap the underlying client without re-bridging tools. */
@@ -40,6 +44,9 @@ export const DEFAULT_MAX_RESULT_CHARS = 32_000;
 
 /** ~6% of DeepSeek V3 context. Char cap alone fails on CJK (~1 char/token). */
 export const DEFAULT_MAX_RESULT_TOKENS = 8_000;
+
+/** Default per-call wait before failing if the server is still handshaking. */
+export const DEFAULT_READY_TIMEOUT_MS = 30_000;
 
 export interface BridgeResult {
   registry: ToolRegistry;
@@ -57,6 +64,12 @@ export interface BridgeEnv {
   maxResultChars: number;
   tracker: LatencyTracker | null;
   onProgress?: BridgeOptions["onProgress"];
+  /** Optional readiness gate awaited before each `callTool` dispatch. */
+  ready?: Promise<void>;
+  /** Timeout for waiting on `ready` — milliseconds. Defaults to DEFAULT_READY_TIMEOUT_MS. */
+  readyTimeoutMs?: number;
+  /** Server name surfaced in timeout errors. Defaults to the prefix or "anon". */
+  serverName?: string;
 }
 
 /** Register one MCP tool's bridged closure into the registry. Returns the registered name (or "" if skipped). */
@@ -71,6 +84,14 @@ export function registerSingleMcpTool(
     description: mcpTool.description ?? "",
     parameters: mcpTool.inputSchema as JSONSchema,
     fn: async (args: Record<string, unknown>, ctx) => {
+      if (env.ready) {
+        await waitForReady(
+          env.ready,
+          env.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS,
+          env.serverName ?? (env.prefix.replace(/_$/, "") || "anon"),
+          ctx?.signal,
+        );
+      }
       const t0 = env.tracker ? Date.now() : 0;
       // Resolve client at call time via the host indirection so `/mcp reconnect`
       // can swap a fresh client in without re-bridging tools.
@@ -86,6 +107,61 @@ export function registerSingleMcpTool(
     },
   });
   return registeredName;
+}
+
+async function waitForReady(
+  ready: Promise<void>,
+  timeoutMs: number,
+  serverName: string,
+  signal: AbortSignal | undefined,
+): Promise<void> {
+  let settled = false;
+  let timer: NodeJS.Timeout | undefined;
+  let onAbort: (() => void) | undefined;
+  try {
+    await new Promise<void>((resolve, reject) => {
+      ready.then(
+        () => {
+          if (settled) return;
+          settled = true;
+          resolve();
+        },
+        (err) => {
+          if (settled) return;
+          settled = true;
+          reject(err instanceof Error ? err : new Error(String(err)));
+        },
+      );
+      if (timeoutMs > 0) {
+        timer = setTimeout(() => {
+          if (settled) return;
+          settled = true;
+          reject(
+            new Error(
+              `MCP server "${serverName}" still handshaking after ${timeoutMs}ms — try /mcp reconnect or check the server logs.`,
+            ),
+          );
+        }, timeoutMs);
+      }
+      if (signal) {
+        if (signal.aborted) {
+          if (settled) return;
+          settled = true;
+          reject(new Error("aborted"));
+          return;
+        }
+        onAbort = () => {
+          if (settled) return;
+          settled = true;
+          reject(new Error("aborted"));
+        };
+        signal.addEventListener("abort", onAbort, { once: true });
+      }
+    });
+  } finally {
+    if (timer) clearTimeout(timer);
+    if (signal && onAbort) signal.removeEventListener("abort", onAbort);
+  }
 }
 
 export async function bridgeMcpTools(
@@ -113,6 +189,9 @@ export async function bridgeMcpTools(
     maxResultChars,
     tracker,
     onProgress: opts.onProgress,
+    ready: opts.ready,
+    readyTimeoutMs: opts.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS,
+    serverName,
   };
   const listed = await client.listTools();
   for (const mcpTool of listed.tools) {

--- a/tests/mcp-registry-readiness.test.ts
+++ b/tests/mcp-registry-readiness.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { type BridgeEnv, type McpClientHost, registerSingleMcpTool } from "../src/mcp/registry.js";
+import type { CallToolResult, McpTool } from "../src/mcp/types.js";
+import { ToolRegistry } from "../src/tools.js";
+
+interface FakeClient {
+  callTool: (
+    name: string,
+    args?: Record<string, unknown>,
+    opts?: { signal?: AbortSignal },
+  ) => Promise<CallToolResult>;
+}
+
+function makeFakeHost(callImpl: FakeClient["callTool"]): McpClientHost {
+  const fake: FakeClient = { callTool: callImpl };
+  // The bridge only touches host.client.callTool — cast to satisfy the type.
+  return { client: fake as unknown as McpClientHost["client"] };
+}
+
+const TOOL: McpTool = {
+  name: "echo",
+  description: "echo input",
+  inputSchema: { type: "object", properties: { msg: { type: "string" } } },
+};
+
+describe("MCP bridge readiness gate", () => {
+  it("dispatch fired mid-handshake waits for the ready deferred and then resolves", async () => {
+    let resolveReady!: () => void;
+    const ready = new Promise<void>((r) => {
+      resolveReady = r;
+    });
+    let callsAttempted = 0;
+    const host = makeFakeHost(async () => {
+      callsAttempted += 1;
+      return {
+        content: [{ type: "text", text: "pong" }],
+      };
+    });
+    const registry = new ToolRegistry();
+    const env: BridgeEnv = {
+      registry,
+      host,
+      prefix: "demo_",
+      maxResultChars: 32_000,
+      tracker: null,
+      ready,
+      readyTimeoutMs: 5_000,
+      serverName: "demo",
+    };
+    const name = registerSingleMcpTool(TOOL, env);
+    expect(name).toBe("demo_echo");
+
+    const dispatched = registry.dispatch(name, JSON.stringify({ msg: "hi" }));
+
+    // Yield a few microtasks — the dispatch must still be awaiting `ready`
+    // since `callTool` hasn't been invoked yet.
+    await new Promise((r) => setTimeout(r, 30));
+    expect(callsAttempted).toBe(0);
+
+    resolveReady();
+    const out = await dispatched;
+    expect(out).toContain("pong");
+    expect(callsAttempted).toBe(1);
+  });
+
+  it("dispatch rejects with the failure reason when ready rejects", async () => {
+    const ready = Promise.reject(new Error('MCP server "demo" failed to start: ENOENT'));
+    // Avoid unhandledRejection warning before the bridge consumes it.
+    ready.catch(() => undefined);
+    const host = makeFakeHost(async () => {
+      throw new Error("callTool should not run for a failed server");
+    });
+    const registry = new ToolRegistry();
+    const env: BridgeEnv = {
+      registry,
+      host,
+      prefix: "demo_",
+      maxResultChars: 32_000,
+      tracker: null,
+      ready,
+      readyTimeoutMs: 5_000,
+      serverName: "demo",
+    };
+    const name = registerSingleMcpTool(TOOL, env);
+    const out = await registry.dispatch(name, JSON.stringify({ msg: "hi" }));
+    // ToolRegistry.dispatch returns a string envelope; the failure reason
+    // must surface to the model rather than the bare transport error.
+    expect(out).toContain("ENOENT");
+  });
+
+  it("dispatch surfaces a timeout error when ready never resolves within the budget", async () => {
+    const ready = new Promise<void>(() => {
+      // never settles
+    });
+    const host = makeFakeHost(async () => {
+      throw new Error("callTool should not run while still handshaking");
+    });
+    const registry = new ToolRegistry();
+    const env: BridgeEnv = {
+      registry,
+      host,
+      prefix: "demo_",
+      maxResultChars: 32_000,
+      tracker: null,
+      ready,
+      readyTimeoutMs: 60,
+      serverName: "demo",
+    };
+    const name = registerSingleMcpTool(TOOL, env);
+    const out = await registry.dispatch(name, JSON.stringify({ msg: "hi" }));
+    expect(out.toLowerCase()).toContain("handshaking");
+  });
+});


### PR DESCRIPTION
## Summary
Tool calls dispatched while an MCP server is still handshaking were surfacing transport errors because the bridge had no signal that the connection wasn't ready yet. This adds a per-server readiness gate that dispatches await (capped at 30s) before invoking `live.callTool`, plus a status-bar pill so the otherwise-invisible background load is legible to the user.

## Changes
- `src/cli/commands/chat.tsx`: track a per-server `ready` deferred in `createMcpRuntime`, resolve it on the `connected` lifecycle event, and reject it on `disabled` / `failed` so awaiting dispatches fail fast with a meaningful reason. Pass `ready` through to `bridgeMcpTools`.
- `src/mcp/registry.ts`: extend `BridgeOptions` / `BridgeEnv` with `ready`, `readyTimeoutMs`, and `serverName`. Add a `waitForReady` helper that races the readiness promise against the timeout and the call's `AbortSignal`, and await it at the top of every bridged `callTool` closure. Default timeout is `DEFAULT_READY_TIMEOUT_MS` (30_000ms).
- `src/cli/ui/App.tsx`: dispatch a `mcp.loading` event from the lifecycle sink — initialised at `{ ready: 0, total: specs.length }`, bumped on `connected` / `disabled` / `failed` so the pill clears once every server reaches a terminal state.
- `src/cli/ui/state/events.ts`, `src/cli/ui/state/reducer.ts`, `src/cli/ui/state/state.ts`: add the `mcp.loading` action, its zod schema, and an `mcpLoading?: { ready, total }` field on `StatusBar`. The reducer drops the field when `total <= 0` and short-circuits no-op updates.
- `src/cli/ui/layout/StatusRow.tsx`: render a `⌁ MCP n/m` pill (new `McpLoadingPill` component) only while `ready < total`.
- `src/i18n/EN.ts`, `src/i18n/zh-CN.ts`, `src/i18n/types.ts`: add the `statusBar.mcpLoading` translation key (`"MCP"` in both locales) with a JSDoc note describing the rendered format.

## Testing
- `npm test -- tests/mcp/registry-readiness.test.ts` — covers a `callTool` invoked mid-handshake resolving once the readiness deferred settles.

## Notes
- The 30s cap matches the value called out in the issue body and is exposed as `readyTimeoutMs` on `BridgeOptions` for callers that want to override it.
- `ready.catch(() => undefined)` is attached at construction so a server that fails before any tool is invoked doesn't trigger an unhandled rejection.
- The pill only renders while `ready < total`; once every server reaches `connected` / `disabled` / `failed` it disappears, so there's no separate teardown event to manage.

Closes #638