### PR TITLE
fix(mcp): classify network, TLS, and HTTP errors in inspect failures

### DIFF
--- a/src/cli/commands/mcp-inspect.ts
+++ b/src/cli/commands/mcp-inspect.ts
@@ -46,6 +46,34 @@ export function formatMcpInspectFailure(err: unknown): string {
     return `${message} — try: confirm ${target ?? "the MCP server"} is running and the host/port match the spec`;
   }
 
+  if (code === "ENOTFOUND" || code === "EAI_AGAIN") {
+    return `${message} — try: confirm the hostname is spelled correctly and DNS resolution is working (check your network/VPN)`;
+  }
+
+  if (code === "ECONNRESET") {
+    return `${message} — try: retry the request; if it keeps happening, check the server's logs for crashes or rate limits`;
+  }
+
+  if (code === "ETIMEDOUT") {
+    return `${message} — try: confirm the host is reachable and no firewall/proxy is blocking the port`;
+  }
+
+  if (
+    code === "CERT_HAS_EXPIRED" ||
+    code === "DEPTH_ZERO_SELF_SIGNED_CERT" ||
+    code === "UNABLE_TO_VERIFY_LEAF_SIGNATURE" ||
+    code === "SELF_SIGNED_CERT_IN_CHAIN"
+  ) {
+    return `${message} — try: renew or trust the server's TLS certificate, or point the spec at an endpoint with a valid cert`;
+  }
+
+  // HTTP non-2xx from SSE / Streamable HTTP transports. Match the three
+  // exact shapes those transports emit and surface an auth/endpoint hint.
+  const httpStatus = matchTransportHttpStatus(message);
+  if (httpStatus !== null) {
+    return `${message}${hintForHttpStatus(httpStatus)}`;
+  }
+
   if (/^MCP request initialize \(id=\d+\) timed out after \d+ms$/.test(message)) {
     return `${message} — try: confirm the target speaks MCP and completes the handshake before the request timeout`;
   }
@@ -55,6 +83,33 @@ export function formatMcpInspectFailure(err: unknown): string {
   }
 
   return message;
+}
+
+function matchTransportHttpStatus(message: string): number | null {
+  // src/mcp/sse.ts: `SSE handshake <url> → <status> <statusText>`
+  // src/mcp/sse.ts: `MCP SSE POST <url> failed: <status> <statusText>`
+  // src/mcp/streamable-http.ts: `MCP Streamable HTTP POST <url> → <status> <statusText>...`
+  const m =
+    message.match(/^SSE handshake \S+ → (\d{3})\b/) ??
+    message.match(/^MCP SSE POST \S+ failed: (\d{3})\b/) ??
+    message.match(/^MCP Streamable HTTP POST \S+ → (\d{3})\b/);
+  return m ? Number(m[1]) : null;
+}
+
+function hintForHttpStatus(status: number): string {
+  if (status === 401) {
+    return " — try: check the spec's auth header (e.g. `Authorization: Bearer …`) or confirm the token isn't expired";
+  }
+  if (status === 403) {
+    return " — try: confirm the credentials have permission to reach this MCP endpoint";
+  }
+  if (status === 404) {
+    return " — try: confirm the endpoint path in the spec matches what the server actually exposes";
+  }
+  if (status >= 500 && status <= 599) {
+    return " — try: retry shortly; if the failure persists, check the MCP server's logs";
+  }
+  return "";
 }
 
 function formatReport(nsName: string, r: InspectionReport): string {

--- a/tests/mcp-inspect.test.ts
+++ b/tests/mcp-inspect.test.ts
@@ -258,6 +258,85 @@ describe("formatMcpInspectFailure", () => {
     );
   });
 
+  it("adds a DNS hint for ENOTFOUND / EAI_AGAIN", () => {
+    const enotfound = Object.assign(new Error("getaddrinfo ENOTFOUND mcp.bogus.example"), {
+      code: "ENOTFOUND",
+    });
+    expect(formatMcpInspectFailure(enotfound)).toBe(
+      "getaddrinfo ENOTFOUND mcp.bogus.example — try: confirm the hostname is spelled correctly and DNS resolution is working (check your network/VPN)",
+    );
+    const eaiAgain = Object.assign(new Error("getaddrinfo EAI_AGAIN mcp.example.com"), {
+      code: "EAI_AGAIN",
+    });
+    expect(formatMcpInspectFailure(eaiAgain)).toBe(
+      "getaddrinfo EAI_AGAIN mcp.example.com — try: confirm the hostname is spelled correctly and DNS resolution is working (check your network/VPN)",
+    );
+  });
+
+  it("adds a connection-reset and timeout hint for ECONNRESET / ETIMEDOUT", () => {
+    const reset = Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" });
+    expect(formatMcpInspectFailure(reset)).toBe(
+      "read ECONNRESET — try: retry the request; if it keeps happening, check the server's logs for crashes or rate limits",
+    );
+    const timedOut = Object.assign(new Error("connect ETIMEDOUT 10.0.0.1:8443"), {
+      code: "ETIMEDOUT",
+    });
+    expect(formatMcpInspectFailure(timedOut)).toBe(
+      "connect ETIMEDOUT 10.0.0.1:8443 — try: confirm the host is reachable and no firewall/proxy is blocking the port",
+    );
+  });
+
+  it("adds a TLS hint for cert-validation failures", () => {
+    const expired = Object.assign(new Error("certificate has expired"), {
+      code: "CERT_HAS_EXPIRED",
+    });
+    expect(formatMcpInspectFailure(expired)).toBe(
+      "certificate has expired — try: renew or trust the server's TLS certificate, or point the spec at an endpoint with a valid cert",
+    );
+    const selfSigned = Object.assign(new Error("self signed certificate"), {
+      code: "DEPTH_ZERO_SELF_SIGNED_CERT",
+    });
+    expect(formatMcpInspectFailure(selfSigned)).toBe(
+      "self signed certificate — try: renew or trust the server's TLS certificate, or point the spec at an endpoint with a valid cert",
+    );
+  });
+
+  it("adds an auth hint for 401 from SSE handshake / POST and Streamable HTTP POST", () => {
+    const handshake = new Error("SSE handshake https://mcp.example.com/sse → 401 Unauthorized");
+    expect(formatMcpInspectFailure(handshake)).toBe(
+      "SSE handshake https://mcp.example.com/sse → 401 Unauthorized — try: check the spec's auth header (e.g. `Authorization: Bearer …`) or confirm the token isn't expired",
+    );
+    const ssePost = new Error("MCP SSE POST https://mcp.example.com/msg failed: 401 Unauthorized");
+    expect(formatMcpInspectFailure(ssePost)).toBe(
+      "MCP SSE POST https://mcp.example.com/msg failed: 401 Unauthorized — try: check the spec's auth header (e.g. `Authorization: Bearer …`) or confirm the token isn't expired",
+    );
+    const streamable = new Error(
+      "MCP Streamable HTTP POST https://mcp.example.com/mcp → 401 Unauthorized",
+    );
+    expect(formatMcpInspectFailure(streamable)).toBe(
+      "MCP Streamable HTTP POST https://mcp.example.com/mcp → 401 Unauthorized — try: check the spec's auth header (e.g. `Authorization: Bearer …`) or confirm the token isn't expired",
+    );
+  });
+
+  it("adds endpoint / permission / server hints for 403, 404, and 5xx", () => {
+    const forbidden = new Error(
+      "MCP Streamable HTTP POST https://mcp.example.com/mcp → 403 Forbidden",
+    );
+    expect(formatMcpInspectFailure(forbidden)).toBe(
+      "MCP Streamable HTTP POST https://mcp.example.com/mcp → 403 Forbidden — try: confirm the credentials have permission to reach this MCP endpoint",
+    );
+    const notFound = new Error("SSE handshake https://mcp.example.com/sse → 404 Not Found");
+    expect(formatMcpInspectFailure(notFound)).toBe(
+      "SSE handshake https://mcp.example.com/sse → 404 Not Found — try: confirm the endpoint path in the spec matches what the server actually exposes",
+    );
+    const bad = new Error(
+      "MCP Streamable HTTP POST https://mcp.example.com/mcp → 503 Service Unavailable",
+    );
+    expect(formatMcpInspectFailure(bad)).toBe(
+      "MCP Streamable HTTP POST https://mcp.example.com/mcp → 503 Service Unavailable — try: retry shortly; if the failure persists, check the MCP server's logs",
+    );
+  });
+
   it("leaves unknown errors unchanged", () => {
     expect(formatMcpInspectFailure(new Error("boom"))).toBe("boom");
   });


### PR DESCRIPTION
## Summary
Extends `formatMcpInspectFailure` to cover the long tail of failure modes the maintainer flagged as still missing: DNS/network errors, TLS cert validation errors, and HTTP non-2xx responses from the SSE and Streamable-HTTP transports. Each new branch turns a raw Node error code or bare status line into a targeted ` — try: …` hint so users have a next step instead of a stack-trace fragment. Protocol-version mismatch is intentionally left out per the maintainer's note that it depends on tightening `client.initialize()` first.

## Changes
- `src/cli/commands/mcp-inspect.ts`: add classifier branches for `ENOTFOUND`/`EAI_AGAIN` (DNS), `ECONNRESET` (transient), `ETIMEDOUT` (firewall/reachability), and the TLS code family (`CERT_HAS_EXPIRED`, `DEPTH_ZERO_SELF_SIGNED_CERT`, `UNABLE_TO_VERIFY_LEAF_SIGNATURE`, `SELF_SIGNED_CERT_IN_CHAIN`).
- `src/cli/commands/mcp-inspect.ts`: add `matchTransportHttpStatus` + `hintForHttpStatus` helpers that match the three exact message shapes emitted by `src/mcp/sse.ts` and `src/mcp/streamable-http.ts` and map 401/403/404/5xx to auth, permission, endpoint-path, and server-side hints respectively.
- `tests/mcp-inspect.test.ts`: add five tests covering DNS, reset/timeout, TLS, 401 across all three transport message shapes, and 403/404/5xx.

## Testing
`npm test -- tests/mcp-inspect.test.ts` — passes.

## Notes
- The HTTP-status branch is anchored to the literal message shapes in `src/mcp/sse.ts` and `src/mcp/streamable-http.ts`. If those strings drift, the regex falls through to the existing unchanged tail rather than misclassifying — same safe default as today, but worth knowing if those transports get reworded.
- Protocol-version mismatch is deliberately not handled here; per the earlier comment that needs `client.initialize()` tightened first and is better as a separate change.

Closes #101