### PR TITLE
fix(skills,memory): handle BOM, folded lines, and quoted values in frontmatter

### DIFF
--- a/src/frontmatter.ts
+++ b/src/frontmatter.ts
@@ -1,6 +1,8 @@
 /** Tiny YAML-frontmatter parser shared by skills / memory loaders. Single source so BOM + folded + quoted handling stay consistent. */
 
 const KEY_RE = /^([a-zA-Z_][a-zA-Z0-9_-]*):\s*(.*)$/;
+/** Bracket-write guard — regex permits these as identifiers, but writing them would mutate Object.prototype. */
+const FORBIDDEN_KEYS = new Set(["__proto__", "constructor", "prototype"]);
 
 function stripQuotes(s: string): string {
   if (s.length < 2) return s;
@@ -18,7 +20,7 @@ export function parseFrontmatter(raw: string): { data: Record<string, string>; b
   if (lines[0] !== "---") return { data: {}, body: stripped };
   const end = lines.indexOf("---", 1);
   if (end < 0) return { data: {}, body: stripped };
-  const data: Record<string, string> = {};
+  const entries = new Map<string, string>();
   let currentKey: string | null = null;
   for (let i = 1; i < end; i++) {
     const line = lines[i] ?? "";
@@ -27,17 +29,19 @@ export function parseFrontmatter(raw: string): { data: Record<string, string>; b
       continue;
     }
     const m = line.match(KEY_RE);
-    if (m?.[1]) {
+    if (m?.[1] && !FORBIDDEN_KEYS.has(m[1])) {
       currentKey = m[1];
-      data[currentKey] = (m[2] ?? "").trim();
+      entries.set(currentKey, (m[2] ?? "").trim());
     } else if (currentKey) {
       const cont = line.trim();
-      const prev = data[currentKey] ?? "";
-      data[currentKey] = prev ? `${prev} ${cont}` : cont;
+      const prev = entries.get(currentKey) ?? "";
+      entries.set(currentKey, prev ? `${prev} ${cont}` : cont);
     }
   }
-  for (const k of Object.keys(data)) {
-    data[k] = stripQuotes(data[k] ?? "");
+  const data: Record<string, string> = Object.create(null);
+  for (const [k, v] of entries) {
+    if (FORBIDDEN_KEYS.has(k)) continue;
+    data[k] = stripQuotes(v);
   }
   return {
     data,

--- a/src/frontmatter.ts
+++ b/src/frontmatter.ts
@@ -1,0 +1,49 @@
+/** Tiny YAML-frontmatter parser shared by skills / memory loaders. Single source so BOM + folded + quoted handling stay consistent. */
+
+const KEY_RE = /^([a-zA-Z_][a-zA-Z0-9_-]*):\s*(.*)$/;
+
+function stripQuotes(s: string): string {
+  if (s.length < 2) return s;
+  const first = s[0];
+  const last = s[s.length - 1];
+  if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+    return s.slice(1, -1);
+  }
+  return s;
+}
+
+export function parseFrontmatter(raw: string): { data: Record<string, string>; body: string } {
+  const stripped = raw.charCodeAt(0) === 0xfeff ? raw.slice(1) : raw;
+  const lines = stripped.split(/\r?\n/);
+  if (lines[0] !== "---") return { data: {}, body: stripped };
+  const end = lines.indexOf("---", 1);
+  if (end < 0) return { data: {}, body: stripped };
+  const data: Record<string, string> = {};
+  let currentKey: string | null = null;
+  for (let i = 1; i < end; i++) {
+    const line = lines[i] ?? "";
+    if (line.trim() === "") {
+      currentKey = null;
+      continue;
+    }
+    const m = line.match(KEY_RE);
+    if (m?.[1]) {
+      currentKey = m[1];
+      data[currentKey] = (m[2] ?? "").trim();
+    } else if (currentKey) {
+      const cont = line.trim();
+      const prev = data[currentKey] ?? "";
+      data[currentKey] = prev ? `${prev} ${cont}` : cont;
+    }
+  }
+  for (const k of Object.keys(data)) {
+    data[k] = stripQuotes(data[k] ?? "");
+  }
+  return {
+    data,
+    body: lines
+      .slice(end + 1)
+      .join("\n")
+      .replace(/^\n+/, ""),
+  };
+}

--- a/src/memory/user.ts
+++ b/src/memory/user.ts
@@ -11,6 +11,7 @@ import {
 } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
+import { parseFrontmatter } from "../frontmatter.js";
 import { applySkillsIndex } from "../skills.js";
 import { applyProjectMemory, memoryEnabled } from "./project.js";
 
@@ -78,27 +79,6 @@ function scopeDir(opts: { homeDir: string; scope: MemoryScope; projectRoot?: str
 
 function ensureDir(p: string): void {
   if (!existsSync(p)) mkdirSync(p, { recursive: true });
-}
-
-function parseFrontmatter(raw: string): { data: Record<string, string>; body: string } {
-  const lines = raw.split(/\r?\n/);
-  if (lines[0] !== "---") return { data: {}, body: raw };
-  const end = lines.indexOf("---", 1);
-  if (end < 0) return { data: {}, body: raw };
-  const data: Record<string, string> = {};
-  for (let i = 1; i < end; i++) {
-    const line = lines[i];
-    if (!line) continue;
-    const m = line.match(/^([a-zA-Z_][a-zA-Z0-9_-]*):\s*(.*)$/);
-    if (m?.[1]) data[m[1]] = (m[2] ?? "").trim();
-  }
-  return {
-    data,
-    body: lines
-      .slice(end + 1)
-      .join("\n")
-      .replace(/^\n+/, ""),
-  };
 }
 
 function formatFrontmatter(e: WriteInput & { createdAt: string }): string {

--- a/src/server/api/skills.ts
+++ b/src/server/api/skills.ts
@@ -15,6 +15,7 @@ import {
 } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+import { parseFrontmatter } from "../../frontmatter.js";
 import { SKILLS_DIRNAME, SKILL_FILE, validateSkillFrontmatter } from "../../skills.js";
 import { readUsageLog } from "../../telemetry/usage.js";
 import type { DashboardContext } from "../context.js";
@@ -61,14 +62,8 @@ interface ResolvedSkillPath {
 }
 
 function parseFrontmatterDescription(raw: string): string | undefined {
-  const lines = raw.split(/\r?\n/);
-  if (lines[0] !== "---") return undefined;
-  for (let i = 1; i < lines.length; i++) {
-    if (lines[i] === "---") break;
-    const m = lines[i]!.match(/^description:\s*(.*)$/);
-    if (m) return m[1]!.trim();
-  }
-  return undefined;
+  const desc = parseFrontmatter(raw).data.description?.trim();
+  return desc ? desc : undefined;
 }
 
 function readSkillListEntry(

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -3,6 +3,7 @@
 import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
+import { parseFrontmatter } from "./frontmatter.js";
 import { NEGATIVE_CLAIM_RULE, TUI_FORMATTING_RULES } from "./prompt-fragments.js";
 
 export const SKILLS_DIRNAME = "skills";
@@ -55,27 +56,6 @@ export function validateSkillFrontmatter(raw: string): { ok: true } | { error: s
     };
   }
   return { ok: true };
-}
-
-function parseFrontmatter(raw: string): { data: Record<string, string>; body: string } {
-  const lines = raw.split(/\r?\n/);
-  if (lines[0] !== "---") return { data: {}, body: raw };
-  const end = lines.indexOf("---", 1);
-  if (end < 0) return { data: {}, body: raw };
-  const data: Record<string, string> = {};
-  for (let i = 1; i < end; i++) {
-    const line = lines[i];
-    if (!line) continue;
-    const m = line.match(/^([a-zA-Z_][a-zA-Z0-9_-]*):\s*(.*)$/);
-    if (m?.[1]) data[m[1]] = (m[2] ?? "").trim();
-  }
-  return {
-    data,
-    body: lines
-      .slice(end + 1)
-      .join("\n")
-      .replace(/^\n+/, ""),
-  };
 }
 
 function isValidSkillName(name: string): boolean {

--- a/tests/frontmatter.test.ts
+++ b/tests/frontmatter.test.ts
@@ -67,4 +67,16 @@ describe("parseFrontmatter", () => {
     const { data } = parseFrontmatter(raw);
     expect(data.description).toBe("one");
   });
+
+  it("drops keys that would mutate Object.prototype (__proto__, constructor, prototype)", () => {
+    const raw =
+      "---\n__proto__: polluted\nconstructor: nope\nprototype: also-nope\nname: ok\n---\n";
+    const probe = {} as Record<string, unknown>;
+    const before = probe.polluted;
+    const { data } = parseFrontmatter(raw);
+    expect(data.name).toBe("ok");
+    expect(data.__proto__).toBeUndefined();
+    expect(Object.getPrototypeOf(data)).toBeNull();
+    expect(probe.polluted).toBe(before);
+  });
 });

--- a/tests/frontmatter.test.ts
+++ b/tests/frontmatter.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { parseFrontmatter } from "../src/frontmatter.js";
+
+describe("parseFrontmatter", () => {
+  it("parses a basic single-line frontmatter", () => {
+    const { data, body } = parseFrontmatter("---\nname: foo\ndescription: bar\n---\nhello\n");
+    expect(data).toEqual({ name: "foo", description: "bar" });
+    expect(body).toBe("hello\n");
+  });
+
+  it("strips a UTF-8 BOM before the opening delimiter", () => {
+    const raw = "\uFEFF---\ndescription: with bom\n---\nbody\n";
+    const { data, body } = parseFrontmatter(raw);
+    expect(data.description).toBe("with bom");
+    expect(body).toBe("body\n");
+  });
+
+  it("folds indented continuation lines into the preceding key", () => {
+    const raw = "---\ndescription: first line\n  second line\n  third line\n---\nbody\n";
+    const { data } = parseFrontmatter(raw);
+    expect(data.description).toBe("first line second line third line");
+  });
+
+  it("folds continuations onto a key whose value started empty", () => {
+    const raw = "---\ndescription:\n  one\n  two\n---\nbody\n";
+    const { data } = parseFrontmatter(raw);
+    expect(data.description).toBe("one two");
+  });
+
+  it("strips wrapping double quotes from a value", () => {
+    const { data } = parseFrontmatter('---\ndescription: "quoted text"\n---\nb\n');
+    expect(data.description).toBe("quoted text");
+  });
+
+  it("strips wrapping single quotes from a value", () => {
+    const { data } = parseFrontmatter("---\ndescription: 'quoted text'\n---\nb\n");
+    expect(data.description).toBe("quoted text");
+  });
+
+  it("leaves mismatched or interior quotes alone", () => {
+    const { data } = parseFrontmatter('---\ndescription: "starts but no end\n---\nb\n');
+    expect(data.description).toBe('"starts but no end');
+  });
+
+  it("returns body unchanged when frontmatter delimiters are missing", () => {
+    const raw = "no frontmatter here\njust text\n";
+    const { data, body } = parseFrontmatter(raw);
+    expect(data).toEqual({});
+    expect(body).toBe(raw);
+  });
+
+  it("returns body unchanged when the closing delimiter is missing", () => {
+    const raw = "---\ndescription: never closed\nmore text\n";
+    const { data, body } = parseFrontmatter(raw);
+    expect(data).toEqual({});
+    expect(body).toBe(raw);
+  });
+
+  it("handles CRLF line endings", () => {
+    const raw = "---\r\nname: x\r\ndescription: y\r\n---\r\nbody\r\n";
+    const { data } = parseFrontmatter(raw);
+    expect(data).toEqual({ name: "x", description: "y" });
+  });
+
+  it("resets continuation scope across a blank line inside frontmatter", () => {
+    const raw = "---\ndescription: one\n\n  two\n---\nb\n";
+    const { data } = parseFrontmatter(raw);
+    expect(data.description).toBe("one");
+  });
+});


### PR DESCRIPTION
## Summary

The three local copies of the frontmatter parser (`src/skills.ts`, `src/memory/user.ts`, `src/server/api/skills.ts`) shared three defects:

1. **UTF-8 BOM not stripped** — `lines[0] !== "---"` failed for any file saved with a BOM, so the whole frontmatter block was treated as body.
2. **Folded / continuation lines dropped** — a wrapped `description:` like
   ```yaml
   description: first line
     second line
   ```
   kept only `first line` because the continuation didn't match the `key: value` regex.
3. **Quotes leaked into values** — `description: "text"` was stored as `"text"`, so the literal quotes showed up in the dashboard and the skills index.

Consolidates the three copies into one parser at `src/frontmatter.ts`:
- strips a leading `\uFEFF` before checking for the opening `---`
- folds indented non-key lines onto the preceding key with a single-space join, resetting scope on blank lines
- unwraps matching `"…"` / `'…'` after folding (so quoted multi-line values work too)

Three call sites now import the shared parser. `parseFrontmatterDescription` in the dashboard API is a two-line wrapper that picks `data.description`.

Closes #678

## Test plan

- [x] `tests/frontmatter.test.ts` — 11 cases covering BOM, folded onto inline value, folded onto empty value, double-quote strip, single-quote strip, mismatched-quote preservation, missing delimiters, CRLF endings, blank-line scope reset
- [x] `npx vitest run` — 2639 passed / 2 skipped
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
