### PR TITLE
fix(ui/shell-confirm): clamp long command preview so options stay visible

### DIFF
--- a/src/cli/ui/ShellConfirm.tsx
+++ b/src/cli/ui/ShellConfirm.tsx
@@ -6,8 +6,13 @@ import { t } from "../../i18n/index.js";
 import { DenyContextInput } from "./DenyContextInput.js";
 import { SingleSelect } from "./Select.js";
 import { ApprovalCard } from "./cards/ApprovalCard.js";
-import { useReserveRows } from "./layout/viewport-budget.js";
+import { useReserveRows, useTotalRows } from "./layout/viewport-budget.js";
 import { FG, TONE } from "./theme/tokens.js";
+
+/** Header + subtitle + info rows + 3-option select + separator + footer — empirically 18 rows. */
+const CHROME_ROWS = 18;
+/** Floor so the user can always see *something* of the command on tiny terminals. */
+const MIN_COMMAND_LINES = 3;
 
 export type ShellConfirmChoice = "run_once" | "always_allow" | "deny";
 
@@ -24,6 +29,13 @@ export interface ShellConfirmProps {
   /** run_background startup wait in seconds — surfaced as "wait 3s". */
   waitSec?: number;
   onChoose: (choice: ShellConfirmChoice, denyContext?: string) => void;
+}
+
+/** Keep the first `max` lines so the SingleSelect + footer stay on screen; `hidden` counts the dropped tail. */
+export function clampCommand(command: string, max: number): { preview: string; hidden: number } {
+  const lines = command.split("\n");
+  if (lines.length <= max) return { preview: command, hidden: 0 };
+  return { preview: lines.slice(0, max).join("\n"), hidden: lines.length - max };
 }
 
 /** ~/foo when path is under $HOME so the row doesn't blow past viewport width. */
@@ -47,6 +59,9 @@ export function ShellConfirm({
   onChoose,
 }: ShellConfirmProps) {
   useReserveRows("modal", { min: 8, max: 14 });
+  const totalRows = useTotalRows();
+  const maxCommandLines = Math.max(MIN_COMMAND_LINES, totalRows - CHROME_ROWS);
+  const { preview, hidden } = clampCommand(command, maxCommandLines);
 
   const isBackground = kind === "run_background";
   const subtitle = isBackground ? t("shellConfirm.bgSubtitle") : t("shellConfirm.subtitle");
@@ -81,13 +96,22 @@ export function ShellConfirm({
       <Box marginBottom={1}>
         <Text color={FG.faint}>{subtitle}</Text>
       </Box>
-      <Box marginBottom={1}>
-        <Text bold color={TONE.err}>
-          {"$ "}
-        </Text>
-        <Text bold color={FG.strong}>
-          {command}
-        </Text>
+      <Box marginBottom={1} flexDirection="column">
+        <Box>
+          <Text bold color={TONE.err}>
+            {"$ "}
+          </Text>
+          <Text bold color={FG.strong}>
+            {preview}
+          </Text>
+        </Box>
+        {hidden > 0 ? (
+          <Text color={FG.faint}>
+            {t(hidden === 1 ? "shellConfirm.previewMore" : "shellConfirm.previewMorePlural", {
+              n: hidden,
+            })}
+          </Text>
+        ) : null}
       </Box>
       <InfoRows cwd={cwd} timeoutSec={timeoutSec} waitSec={waitSec} kind={kind} />
       <SingleSelect

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -1120,6 +1120,8 @@ export const EN: TranslationSchema = {
     cwdLabel: "cwd",
     timeoutLabel: "timeout",
     waitLabel: "wait",
+    previewMore: "… {n} more line hidden — press esc, ask the model to split it",
+    previewMorePlural: "… {n} more lines hidden — press esc, ask the model to split it",
   },
   editConfirm: {
     footer:

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -407,6 +407,8 @@ export interface TranslationSchema {
     cwdLabel: string;
     timeoutLabel: string;
     waitLabel: string;
+    previewMore: string;
+    previewMorePlural: string;
   };
   editConfirm: {
     footer: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -1062,6 +1062,8 @@ export const zhCN: TranslationSchema = {
     cwdLabel: "工作目录",
     timeoutLabel: "超时",
     waitLabel: "等待",
+    previewMore: "… 还有 {n} 行未显示 — 按 esc 取消，让模型拆分后再试",
+    previewMorePlural: "… 还有 {n} 行未显示 — 按 esc 取消，让模型拆分后再试",
   },
   editConfirm: {
     footer:

--- a/tests/shell-confirm-render.test.tsx
+++ b/tests/shell-confirm-render.test.tsx
@@ -1,0 +1,53 @@
+import { render } from "ink-testing-library";
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { ShellConfirm, clampCommand } from "../src/cli/ui/ShellConfirm.js";
+
+describe("clampCommand", () => {
+  it("returns the original command when line count is within max", () => {
+    const cmd = "echo one\necho two\necho three";
+    expect(clampCommand(cmd, 5)).toEqual({ preview: cmd, hidden: 0 });
+  });
+
+  it("keeps exactly `max` lines and reports the dropped count", () => {
+    const cmd = ["a", "b", "c", "d", "e"].join("\n");
+    expect(clampCommand(cmd, 3)).toEqual({ preview: "a\nb\nc", hidden: 2 });
+  });
+
+  it("treats a single-line command as not clamped", () => {
+    expect(clampCommand("ls -la", 3)).toEqual({ preview: "ls -la", hidden: 0 });
+  });
+
+  it("is a no-op when max equals the line count exactly", () => {
+    const cmd = "a\nb\nc";
+    expect(clampCommand(cmd, 3)).toEqual({ preview: cmd, hidden: 0 });
+  });
+});
+
+describe("ShellConfirm — long-command rendering (issue #680)", () => {
+  it("renders the action options and footer even with a 50-line command", () => {
+    const command = Array.from({ length: 50 }, (_, i) => `echo line-${i + 1}`).join("\n");
+    const { lastFrame, unmount } = render(
+      <ShellConfirm command={command} allowPrefix="echo" onChoose={() => {}} />,
+    );
+    const out = lastFrame() ?? "";
+    unmount();
+    expect(out).toContain("allow once");
+    expect(out).toContain("allow always");
+    expect(out).toContain("deny");
+    expect(out).toContain("pick");
+    expect(out).toContain("confirm");
+    expect(out).toMatch(/more lines? hidden/);
+    expect(out).toContain("echo line-1");
+  });
+
+  it("does not show the hidden-lines hint for a short command", () => {
+    const { lastFrame, unmount } = render(
+      <ShellConfirm command="echo hello" allowPrefix="echo" onChoose={() => {}} />,
+    );
+    const out = lastFrame() ?? "";
+    unmount();
+    expect(out).toContain("echo hello");
+    expect(out).not.toMatch(/more lines? hidden/);
+  });
+});


### PR DESCRIPTION
## Summary

When the model proposes a long multi-line shell command, the `$ <command>` block in the `ShellConfirm` modal grows tall enough to push the `▸ allow once / allow always / deny` options — and the `↑↓ pick · ⏎ confirm · Tab add context · esc cancel` footer — past the visible viewport. The reporter's screenshot shows a ~30-line python heredoc occupying the entire screen with no action footer in sight.

This fix clamps the command preview based on the actual terminal height:

- `useTotalRows()` from the viewport budget reports terminal rows
- preview is capped at `max(3, totalRows - 18)` lines (18 = empirical chrome: header, subtitle, info rows, 3-option select, separator, footer)
- when clamped, a dim `… N more lines hidden — press esc, ask the model to split it` line replaces the rest, so the user knows there's more they're not seeing
- new pure `clampCommand` helper is exported for tests

i18n: added `previewMore` / `previewMorePlural` to `shellConfirm` for EN and zh-CN.

Closes #680

## Test plan

- [x] new `tests/shell-confirm-render.test.tsx` — 4 pure `clampCommand` cases + 2 render cases (50-line command shows options + hidden-lines hint; short command shows neither hint)
- [x] `npx vitest run` — 2653 passed / 2 skipped
- [x] `npm run lint` — clean (one unrelated pre-existing warning)
- [x] `npm run typecheck` — clean
