### PR TITLE
fix(stdin): decode generic modifyOtherKeys / Kitty CSI envelopes

### DIFF
--- a/src/cli/ui/stdin-reader.ts
+++ b/src/cli/ui/stdin-reader.ts
@@ -121,6 +121,42 @@ function lookupCsi(tail: string): KeyEvent | null {
   return null;
 }
 
+/** modifyOtherKeys / Kitty: reconstruct the keystroke from `<codepoint>` + `<mod>`. */
+function decodeModifiedKey(cp: number, mod: number): KeyEvent | null {
+  if (mod < 1 || mod > 8) return null;
+  const bits = mod - 1;
+  const shift = (bits & 1) !== 0;
+  const alt = (bits & 2) !== 0;
+  const ctrl = (bits & 4) !== 0;
+  if (cp >= 0x20 && cp <= 0x7e && !ctrl && !alt) {
+    const ev: KeyEvent = { input: String.fromCharCode(cp) };
+    if (shift) ev.shift = true;
+    return ev;
+  }
+  if (cp >= 0x20 && cp <= 0x7e && alt && !ctrl) {
+    const ev: KeyEvent = { input: String.fromCharCode(cp), meta: true };
+    if (shift) ev.shift = true;
+    return ev;
+  }
+  if (cp >= 0x41 && cp <= 0x7a && ctrl && !alt) {
+    const ev: KeyEvent = { input: String.fromCharCode(cp).toLowerCase(), ctrl: true };
+    if (shift) ev.shift = true;
+    return ev;
+  }
+  return null;
+}
+
+/** Generic modifyOtherKeys / Kitty envelope — picks up the keys lookupCsi misses (`@`, `_`, `[`, `\`, `]`, `^` under `>4;2m`). */
+function tryDecodeGenericCsi(seq: string): KeyEvent | null {
+  let m = /^27;(\d+);(\d+)~$/.exec(seq);
+  if (m) return decodeModifiedKey(Number.parseInt(m[2]!, 10), Number.parseInt(m[1]!, 10));
+  m = /^(\d+);(\d+)u$/.exec(seq);
+  if (m) return decodeModifiedKey(Number.parseInt(m[1]!, 10), Number.parseInt(m[2]!, 10));
+  m = /^(\d+)u$/.exec(seq);
+  if (m) return decodeModifiedKey(Number.parseInt(m[1]!, 10), 1);
+  return null;
+}
+
 /** Heuristic paste-burst detector — wraps raw multi-line chunks when the terminal didn't (#522). */
 export function looksLikeUnbracketedPaste(chunk: string): boolean {
   if (chunk.length < 2) return false;
@@ -498,7 +534,15 @@ export class StdinReader {
       }
     }
     const ev = lookupCsi(seq);
-    if (ev) this.dispatch(ev);
+    if (ev) {
+      this.dispatch(ev);
+      return;
+    }
+    const generic = tryDecodeGenericCsi(seq);
+    if (generic) {
+      this.dispatch(generic);
+      return;
+    }
     // Unknown CSI → drop. Do NOT insert raw bytes as text.
   }
 }

--- a/tests/stdin-reader.test.ts
+++ b/tests/stdin-reader.test.ts
@@ -74,6 +74,42 @@ describe("StdinReader — CSI sequences (well-behaved)", () => {
     reader.feed("\x1b[42m"); // SGR — irrelevant to us, skip
     expect(events).toEqual([]);
   });
+
+  it("recovers `@` / `_` / `[` / `\\` / `]` / `^` from modifyOtherKeys CSI 27 (ghostty, issue #683)", () => {
+    const { reader, events } = setup();
+    // xterm modifyOtherKeys=2 re-encodes these because Ctrl+them yields control bytes.
+    reader.feed("\x1b[27;2;64~"); // Shift+2 = @
+    reader.feed("\x1b[27;2;95~"); // Shift+- = _
+    reader.feed("\x1b[27;1;91~"); // [
+    reader.feed("\x1b[27;1;92~"); // \
+    reader.feed("\x1b[27;1;93~"); // ]
+    reader.feed("\x1b[27;2;94~"); // Shift+6 = ^
+    expect(events).toEqual([
+      { input: "@", shift: true },
+      { input: "_", shift: true },
+      { input: "[" },
+      { input: "\\" },
+      { input: "]" },
+      { input: "^", shift: true },
+    ]);
+  });
+
+  it("recovers `@` / `_` from Kitty `<cp>;<mod>u` and bare `<cp>u`", () => {
+    const { reader, events } = setup();
+    reader.feed("\x1b[64;2u"); // Shift+@ via Kitty
+    reader.feed("\x1b[95u"); // _ without modifier
+    expect(events).toEqual([{ input: "@", shift: true }, { input: "_" }]);
+  });
+
+  it("decodes Alt+letter and Ctrl+letter from modifyOtherKeys", () => {
+    const { reader, events } = setup();
+    reader.feed("\x1b[27;3;97~"); // Alt+a
+    reader.feed("\x1b[27;5;65~"); // Ctrl+A (uppercase code in envelope)
+    expect(events).toEqual([
+      { input: "a", meta: true },
+      { input: "a", ctrl: true },
+    ]);
+  });
 });
 
 describe("StdinReader — CSI sequences (Windows ConPTY ESC-stripped)", () => {


### PR DESCRIPTION
## Summary

Under Ubuntu's ghostty, typing `@` and `_` produces nothing in Reasonix while working everywhere else, including other CLIs on the same terminal. Root cause:

`useTerminalSetup` writes `\x1b[>4;2m` (xterm modifyOtherKeys=2) at startup. In that mode, xterm-compatible terminals re-encode any printable key whose Ctrl variant would clash with a control byte — `@` (^@=NUL), `[` (^[=ESC), `\`, `]`, `^`, `_` — as `\x1b[27;<mod>;<cp>~`. `dispatchCsi` only consulted `CSI_TAIL_MAP`, which has hardcoded entries for Tab/Enter modifier variants but not arbitrary printables. `lookupCsi("27;2;64~")` returned null, and the parser dropped the sequence on purpose ("Unknown CSI → drop. Do NOT insert raw bytes as text.").

Adds a generic decoder that handles both wire shapes:
- xterm modifyOtherKeys (formatOtherKeys=0): `\x1b[27;<mod>;<cp>~`
- Kitty keyboard protocol: `\x1b[<cp>;<mod>u` or `\x1b[<cp>u`

`decodeModifiedKey` reconstructs printable input, Alt-prefixed input, and Ctrl-letter, mirroring the existing single-byte paths. The new path runs **after** `lookupCsi`, so the hardcoded Tab / Enter / Shift+Tab / Ctrl+Enter entries still win — no behavior change for already-handled keys.

Closes #683

## Test plan

- [x] new test cases under `tests/stdin-reader.test.ts`:
  - `@` / `_` / `[` / `\` / `]` / `^` via `\x1b[27;<mod>;<cp>~`
  - `@` / `_` via Kitty `\x1b[<cp>;<mod>u` and bare `\x1b[<cp>u`
  - Alt+letter and Ctrl+letter via modifyOtherKeys
- [x] `npx vitest run` — 2657 passed / 2 skipped
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
