### PR TITLE
fix(i18n): point session banners + overflow error at /new and /sessions

### DIFF
--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -56,9 +56,8 @@ export const EN: TranslationSchema = {
     systemAppendFileHint:
       "Append file contents to the code system prompt. Does NOT replace the default prompt. UTF-8, relative to cwd or absolute.",
     resumedSession:
-      '▸ resumed session "{name}" with {count} prior messages · /forget to start over · /sessions to list',
-    newSession:
-      '▸ session "{name}" (new) — auto-saved as you chat · /forget to delete · /sessions to list',
+      '▸ resumed session "{name}" with {count} prior messages · /new to start fresh · /sessions to manage',
+    newSession: '▸ session "{name}" (new) — auto-saved as you chat · /sessions to rename or delete',
     ephemeralSession: "▸ ephemeral chat (no session persistence) — drop --no-session to enable",
     restoredEdits:
       "▸ restored {count} pending edit block(s) from an interrupted prior run — /apply to commit or /discard to drop.",
@@ -598,7 +597,7 @@ export const EN: TranslationSchema = {
   },
   errors: {
     contextOverflow:
-      "Context overflow (DeepSeek 400): session history is {requested}, past the model's prompt limit (V4: 1M tokens; legacy chat/reasoner: 131k). Usually a single tool result grew too big. Reasonix caps new tool results at 8k tokens and auto-heals oversized history on session load — a restart often clears it. If it still overflows, run /forget (delete the session) or /clear (drop the displayed history) to start fresh.",
+      "Context overflow (DeepSeek 400): session history is {requested}, past the model's prompt limit (V4: 1M tokens; legacy chat/reasoner: 131k). Usually a single tool result grew too big. Reasonix caps new tool results at 8k tokens and auto-heals oversized history on session load — a restart often clears it. If it still overflows, run /new to start fresh, or open /sessions and press [d] to delete this session.",
     contextOverflowTooMany: "too many tokens",
     auth401:
       "Authentication failed (DeepSeek 401): {inner}. Your API key is rejected. Fix with `reasonix setup` or `export DEEPSEEK_API_KEY=sk-...`. Get one at https://platform.deepseek.com/api_keys.",

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -55,8 +55,8 @@ export const zhCN: TranslationSchema = {
     systemAppendFileHint:
       "追加文件内容到代码系统提示词。不替换默认提示词。UTF-8，相对于 cwd 或绝对路径。",
     resumedSession:
-      '▸ 已恢复会话 "{name}"，包含 {count} 条历史消息 · /forget 重新开始 · /sessions 列出',
-    newSession: '▸ 会话 "{name}" (新) — 随聊随存 · /forget 删除 · /sessions 列出',
+      '▸ 已恢复会话 "{name}"，包含 {count} 条历史消息 · /new 重新开始 · /sessions 管理',
+    newSession: '▸ 会话 "{name}" (新) — 随聊随存 · /sessions 重命名或删除',
     ephemeralSession: "▸ 临时聊天 (不保存会话) — 去掉 --no-session 以启用保存",
     restoredEdits:
       "▸ 从中断的运行中恢复了 {count} 个待处理的编辑块 — /apply 提交或 /discard 放弃。",
@@ -582,7 +582,7 @@ export const zhCN: TranslationSchema = {
   },
   errors: {
     contextOverflow:
-      "上下文溢出（DeepSeek 400）：会话历史已达 {requested}，超出模型 prompt 上限（V4：1M tokens；旧版 chat/reasoner：131k）。通常是单个工具结果太大。Reasonix 默认将新工具结果限制在 8k tokens，并在会话加载时自动修复超大历史 — 重启常能清掉。如果仍然溢出，运行 /forget（删除会话）或 /clear（丢弃显示中的历史）从头开始。",
+      "上下文溢出（DeepSeek 400）：会话历史已达 {requested}，超出模型 prompt 上限（V4：1M tokens；旧版 chat/reasoner：131k）。通常是单个工具结果太大。Reasonix 默认将新工具结果限制在 8k tokens，并在会话加载时自动修复超大历史 — 重启常能清掉。如果仍然溢出，运行 /new 重新开始，或打开 /sessions 选中后按 [d] 删除该会话。",
     contextOverflowTooMany: "tokens 数量过多",
     auth401:
       "认证失败（DeepSeek 401）：{inner}。你的 API key 被拒绝。运行 `reasonix setup` 或 `export DEEPSEEK_API_KEY=sk-...` 修复。在 https://platform.deepseek.com/api_keys 获取 key。",

--- a/src/memory/session.ts
+++ b/src/memory/session.ts
@@ -278,7 +278,7 @@ export function deleteSession(name: string): boolean {
   }
 }
 
-/** Non-atomic truncate+write window is acceptable — concurrent crash here = `/forget`. */
+/** Non-atomic truncate+write window is acceptable — a concurrent crash leaves the session file empty, same end state as the user deleting it. */
 export function rewriteSession(name: string, messages: ChatMessage[]): void {
   const path = sessionPath(name);
   mkdirSync(dirname(path), { recursive: true });

--- a/tests/loop-error.test.ts
+++ b/tests/loop-error.test.ts
@@ -14,7 +14,7 @@ describe("formatLoopError", () => {
     );
     const out = formatLoopError(raw);
     expect(out).toMatch(/Context overflow/);
-    expect(out).toMatch(/\/forget/);
+    expect(out).toMatch(/\/sessions/);
     expect(out).toMatch(/929,452 tokens/); // pretty-printed from the raw JSON
   });
 


### PR DESCRIPTION
## Summary

The top-level `/forget` slash command was removed in the slash-surface refactor that cut 11 commands, but the resumed-session banner, new-session banner, and the DeepSeek 400 context-overflow error message still tell users to type it. Repoint those three strings (× EN + zh-CN) at the paths that actually survived:

- `/new` — start a fresh conversation
- `/sessions` — open the picker, `[d]` deletes the row

Also straightens out the only code comment that referenced the dead command.

Sub-commands that still own the word `forget` (`/memory forget <name>`, `/checkpoint forget <id>`) are untouched — they still work and stay in the help text.

Closes #697

## Test plan

- [x] `tests/loop-error.test.ts` — updated the overflow-error assertion from `/forget` to `/sessions` so it tracks the new copy
- [x] `grep -rE "/forget" src docs` returns no hits
- [x] `npx vitest run` — 2681 passed / 2 skipped
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
