### PR TITLE
feat(loop): make flash→pro escalation threshold configurable

### DIFF
--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -333,6 +333,8 @@ export interface ChatOptions {
    * mid-session.
    */
   budgetUsd?: number;
+  /** Per-turn repair-signal count required to escalate flash→pro. Undefined → loop default (3). */
+  failureThreshold?: number;
   session?: string;
   /** Zero or more MCP server specs. Each: `"name=cmd args..."` or `"cmd args..."`. */
   mcp?: string[];
@@ -477,6 +479,7 @@ function Root({
         system={appProps.system}
         transcript={appProps.transcript}
         budgetUsd={appProps.budgetUsd}
+        failureThreshold={appProps.failureThreshold}
         session={activeSession}
         tools={tools}
         mcpSpecs={mcpSpecs}

--- a/src/cli/commands/code.tsx
+++ b/src/cli/commands/code.tsx
@@ -47,6 +47,8 @@ export interface CodeOptions {
    * via `/budget <usd>` slash command.
    */
   budgetUsd?: number;
+  /** Per-turn repair-signal count required to escalate flash→pro. Undefined → loop default (3). */
+  failureThreshold?: number;
   /** Suppress the auto-launched embedded web dashboard. */
   noDashboard?: boolean;
   /** Pin the dashboard to a fixed port. `undefined` keeps ephemeral assignment. */
@@ -127,6 +129,7 @@ export async function codeCommand(opts: CodeOptions = {}): Promise<void> {
   await chatCommand({
     model: opts.model ?? "deepseek-v4-flash",
     budgetUsd: opts.budgetUsd,
+    failureThreshold: opts.failureThreshold,
     system: codeSystemPrompt(rootDir, {
       hasSemanticSearch: semantic.enabled,
       systemAppend: opts.systemAppend,

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -28,6 +28,8 @@ export interface RunOptions {
   model: string;
   system: string;
   budgetUsd?: number;
+  /** Per-turn repair-signal count required to escalate flash→pro. Undefined → loop default (3). */
+  failureThreshold?: number;
   /** JSONL transcript path — lets `reasonix replay` / `diff` audit this run. */
   transcript?: string;
   /** Zero or more MCP server specs. Each: `"name=cmd args..."` or `"cmd args..."`. */
@@ -150,6 +152,7 @@ export async function runCommand(opts: RunOptions): Promise<void> {
     tools,
     model: opts.model,
     budgetUsd: opts.budgetUsd,
+    failureThreshold: opts.failureThreshold,
   });
   const prefixHash = prefix.fingerprint;
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -52,6 +52,35 @@ function parseBudgetFlag(raw: number | undefined): number | undefined {
   return raw;
 }
 
+/** Lenient: malformed → undefined so a bad flag falls back to config / default. */
+function parseEscalateAfterFlag(raw: number | undefined): number | undefined {
+  if (raw === undefined) return undefined;
+  if (!Number.isInteger(raw) || raw < 1 || raw > 20) {
+    process.stderr.write(
+      `▲ ignoring --escalate-after=${raw} (must be an integer in [1,20]) — using default\n`,
+    );
+    return undefined;
+  }
+  return raw;
+}
+
+function resolveFailureThreshold(
+  flagValue: number | undefined,
+  noConfig: boolean,
+): number | undefined {
+  if (flagValue !== undefined) return flagValue;
+  if (noConfig) return undefined;
+  const fromCfg = readConfig().escalation?.failureThreshold;
+  if (typeof fromCfg !== "number") return undefined;
+  if (!Number.isInteger(fromCfg) || fromCfg < 1 || fromCfg > 20) {
+    process.stderr.write(
+      `▲ ignoring escalation.failureThreshold=${fromCfg} from config (must be an integer in [1,20]) — using default\n`,
+    );
+    return undefined;
+  }
+  return fromCfg;
+}
+
 /** Lenient port parser — bad value warns + falls back to ephemeral, same shape as parseBudgetFlag. */
 function parseDashboardPortFlag(raw: string | undefined): number | undefined {
   if (raw === undefined) return undefined;
@@ -131,6 +160,11 @@ program
   .option("-n, --new", t("ui.newHint"))
   .option("--transcript <path>", t("ui.transcriptHint"))
   .option("--budget <usd>", t("ui.budgetHint"), (v) => Number.parseFloat(v))
+  .option(
+    "--escalate-after <n>",
+    "repair-signal count before flash→pro escalation (default 3)",
+    (v) => Number.parseInt(v, 10),
+  )
   .option("--no-dashboard", t("ui.noDashboard"))
   .option("--dashboard-port <port>", t("ui.dashboardPortHint"))
   .option("--no-alt-screen", "keep chat output in shell scrollback (legacy mode, ghost-prone)")
@@ -147,6 +181,7 @@ program
       forceResume: !!opts.resume,
       forceNew: !!opts.new,
       budgetUsd: parseBudgetFlag(opts.budget),
+      failureThreshold: resolveFailureThreshold(parseEscalateAfterFlag(opts.escalateAfter), false),
       noDashboard: opts.dashboard === false,
       dashboardPort: resolveDashboardPort(parseDashboardPortFlag(opts.dashboardPort), false),
       systemAppend: opts.systemAppend,
@@ -164,6 +199,11 @@ program
   .option("--transcript <path>", t("ui.transcriptHint"))
   .option("--preset <name>", t("ui.presetHint"))
   .option("--budget <usd>", t("ui.budgetHint"), (v) => Number.parseFloat(v))
+  .option(
+    "--escalate-after <n>",
+    "repair-signal count before flash→pro escalation (default 3)",
+    (v) => Number.parseInt(v, 10),
+  )
   .option("--session <name>", t("ui.sessionNameHint"))
   .option("--no-session", t("ui.ephemeralHint"))
   .option("-r, --resume", t("ui.resumeHint"))
@@ -207,6 +247,10 @@ program
       system: applyMemoryStack(opts.system ?? defaultSystemPrompt(defaults.model), process.cwd()),
       transcript: opts.transcript,
       budgetUsd: parseBudgetFlag(opts.budget),
+      failureThreshold: resolveFailureThreshold(
+        parseEscalateAfterFlag(opts.escalateAfter),
+        opts.config === false,
+      ),
       session: continueOpts.session,
       mcp: defaults.mcp,
       mcpPrefix: opts.mcpPrefix,
@@ -229,6 +273,11 @@ program
   .option("-s, --system <prompt>", t("ui.systemPromptHint"))
   .option("--preset <name>", t("ui.presetHintShort"))
   .option("--budget <usd>", t("ui.budgetHintShort"), (v) => Number.parseFloat(v))
+  .option(
+    "--escalate-after <n>",
+    "repair-signal count before flash→pro escalation (default 3)",
+    (v) => Number.parseInt(v, 10),
+  )
   .option("--transcript <path>", t("ui.transcriptHintShort"))
   .option(
     "--mcp <spec>",
@@ -251,6 +300,10 @@ program
       model: defaults.model,
       system: applyMemoryStack(opts.system ?? defaultSystemPrompt(defaults.model), process.cwd()),
       budgetUsd: parseBudgetFlag(opts.budget),
+      failureThreshold: resolveFailureThreshold(
+        parseEscalateAfterFlag(opts.escalateAfter),
+        opts.config === false,
+      ),
       transcript: opts.transcript,
       mcp: defaults.mcp,
       mcpPrefix: opts.mcpPrefix,

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -185,6 +185,8 @@ export interface AppProps {
   transcript?: string;
   /** Soft USD spend cap; undefined → no cap. See CacheFirstLoopOptions.budgetUsd. */
   budgetUsd?: number;
+  /** Per-turn repair-signal count required to escalate flash→pro. Undefined → loop default (3). */
+  failureThreshold?: number;
   session?: string;
   /**
    * Pre-populated tool registry (e.g. from bridgeMcpTools()). When present,
@@ -362,6 +364,7 @@ function AppInner({
   system,
   transcript,
   budgetUsd,
+  failureThreshold,
   session,
   tools,
   mcpSpecs,
@@ -829,6 +832,7 @@ function AppInner({
       tools,
       model,
       budgetUsd,
+      failureThreshold,
       session,
       hooks: hookList,
       hookCwd: currentRootDir,
@@ -839,7 +843,7 @@ function AppInner({
     });
     loopRef.current = l;
     return l;
-  }, [model, system, budgetUsd, session, tools, codeMode]);
+  }, [model, system, budgetUsd, failureThreshold, session, tools, codeMode]);
 
   useEffect(() => {
     if (!session || !tools) return;

--- a/src/config.ts
+++ b/src/config.ts
@@ -107,6 +107,10 @@ export interface ReasonixConfig {
     /** Pin the embedded dashboard to a fixed port — required for stable SSH tunnels. 0/absent → ephemeral. */
     port?: number;
   };
+  escalation?: {
+    /** Per-turn repair/error signal count required to escalate flash→pro. Defaults to 3. Out-of-range → default. */
+    failureThreshold?: number;
+  };
   projects?: {
     [absoluteRootDir: string]: {
       shellAllowed?: string[];

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -39,7 +39,7 @@ import {
   stripHallucinatedToolMarkup,
   thinkingModeForModel,
 } from "./loop/thinking.js";
-import { TurnFailureTracker } from "./loop/turn-failure-tracker.js";
+import { FAILURE_ESCALATION_THRESHOLD, TurnFailureTracker } from "./loop/turn-failure-tracker.js";
 import type { LoopEvent } from "./loop/types.js";
 import { AppendOnlyLog, type ImmutablePrefix, VolatileScratch } from "./memory/runtime.js";
 import {
@@ -86,6 +86,8 @@ export interface CacheFirstLoopOptions {
   autoEscalate?: boolean;
   /** Soft USD cap — warns at 80%, refuses next turn at 100%. Opt-in (default no cap). */
   budgetUsd?: number;
+  /** Per-turn repair/error signal count required to escalate flash→pro. Defaults to FAILURE_ESCALATION_THRESHOLD. Out-of-range values warn + fall back. */
+  failureThreshold?: number;
   session?: string;
   /** PreToolUse + PostToolUse only — UserPromptSubmit / Stop live at the App boundary. */
   hooks?: ResolvedHook[];
@@ -143,7 +145,7 @@ export class CacheFirstLoop {
 
   private _proArmedForNextTurn = false;
   private _escalateThisTurn = false;
-  private readonly _turnFailures = new TurnFailureTracker();
+  private readonly _turnFailures: TurnFailureTracker;
   private _turnSelfCorrected = false;
   private _foldedThisTurn = false;
   private _toolDispatchesThisStep = 0;
@@ -167,6 +169,9 @@ export class CacheFirstLoop {
     if (opts.autoEscalate !== undefined) this.autoEscalate = opts.autoEscalate;
     this.budgetUsd =
       typeof opts.budgetUsd === "number" && opts.budgetUsd > 0 ? opts.budgetUsd : null;
+    this._turnFailures = new TurnFailureTracker(
+      resolveFailureThreshold(opts.failureThreshold, FAILURE_ESCALATION_THRESHOLD),
+    );
     // Last-resort backstop — primary stop is the token-context guard inside step().
     this.maxToolIters = opts.maxToolIters ?? 64;
     this.hooks = opts.hooks ?? [];
@@ -1204,4 +1209,19 @@ function parsePositiveIntEnv(raw: string | undefined): number | undefined {
   if (!raw) return undefined;
   const n = Number.parseInt(raw, 10);
   return Number.isFinite(n) && n > 0 ? n : undefined;
+}
+
+/** Sane-range bounds for the flash→pro escalation threshold. */
+const FAILURE_THRESHOLD_MIN = 1;
+const FAILURE_THRESHOLD_MAX = 20;
+
+function resolveFailureThreshold(raw: number | undefined, fallback: number): number {
+  if (raw === undefined) return fallback;
+  if (!Number.isInteger(raw) || raw < FAILURE_THRESHOLD_MIN || raw > FAILURE_THRESHOLD_MAX) {
+    process.stderr.write(
+      `▲ ignoring escalation failureThreshold=${raw} (must be an integer in [${FAILURE_THRESHOLD_MIN},${FAILURE_THRESHOLD_MAX}]) — using default ${fallback}\n`,
+    );
+    return fallback;
+  }
+  return raw;
 }

--- a/src/loop/turn-failure-tracker.ts
+++ b/src/loop/turn-failure-tracker.ts
@@ -5,13 +5,18 @@ export const FAILURE_ESCALATION_THRESHOLD = 3;
 export class TurnFailureTracker {
   private count = 0;
   private types: Record<string, number> = {};
+  private readonly threshold: number;
+
+  constructor(threshold: number = FAILURE_ESCALATION_THRESHOLD) {
+    this.threshold = threshold;
+  }
 
   reset(): void {
     this.count = 0;
     this.types = {};
   }
 
-  /** True ONLY on the call where the count crosses FAILURE_ESCALATION_THRESHOLD. */
+  /** True ONLY on the call where the count crosses the configured threshold. */
   noteAndCrossedThreshold(resultJson: string, repair?: RepairReport): boolean {
     const before = this.count;
     const bump = (kind: string, by = 1): void => {
@@ -26,7 +31,7 @@ export class TurnFailureTracker {
       if (repair.truncationsFixed > 0) bump("truncated", repair.truncationsFixed);
       if (repair.stormsBroken > 0) bump("repeat-loop", repair.stormsBroken);
     }
-    return before < FAILURE_ESCALATION_THRESHOLD && this.count >= FAILURE_ESCALATION_THRESHOLD;
+    return before < this.threshold && this.count >= this.threshold;
   }
 
   formatBreakdown(): string {

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -1124,6 +1124,91 @@ describe("CacheFirstLoop - auto-escalation on tool failures", () => {
     expect(result.escalated).toBe(false);
     expect(loop.escalatedThisTurn).toBe(false);
   });
+
+  it("custom failureThreshold=5 does not escalate until 5th signal", () => {
+    const client = makeClient([{ content: "ok" }]);
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s" }),
+      stream: false,
+      failureThreshold: 5,
+    });
+    // First four signals should not escalate.
+    for (let i = 0; i < 4; i++) {
+      const result = signalToolFailure(loop, {
+        repair: { scavenged: 1, truncationsFixed: 0, stormsBroken: 0, notes: [] },
+      });
+      expect(result.escalated).toBe(false);
+    }
+    expect(loop.escalatedThisTurn).toBe(false);
+    // Fifth signal crosses the configured threshold.
+    const fifth = signalToolFailure(loop, {
+      repair: { scavenged: 1, truncationsFixed: 0, stormsBroken: 0, notes: [] },
+    });
+    expect(fifth.escalated).toBe(true);
+    expect(fifth.count).toBe(5);
+    expect(loop.escalatedThisTurn).toBe(true);
+  });
+
+  it("default failureThreshold preserves the 3-signal escalation behavior", () => {
+    const client = makeClient([{ content: "ok" }]);
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s" }),
+      stream: false,
+      // No failureThreshold passed — should use default of 3.
+    });
+    // Two signals: not crossed yet.
+    for (let i = 0; i < 2; i++) {
+      const result = signalToolFailure(loop, {
+        repair: { scavenged: 1, truncationsFixed: 0, stormsBroken: 0, notes: [] },
+      });
+      expect(result.escalated).toBe(false);
+    }
+    // Third crosses.
+    const third = signalToolFailure(loop, {
+      repair: { scavenged: 1, truncationsFixed: 0, stormsBroken: 0, notes: [] },
+    });
+    expect(third.escalated).toBe(true);
+    expect(third.count).toBe(3);
+  });
+
+  it("invalid failureThreshold values warn on stderr and fall back to default 3", () => {
+    const client = makeClient([{ content: "ok" }]);
+    const writes: string[] = [];
+    const original = process.stderr.write.bind(process.stderr);
+    // Capture stderr writes during construction so we can assert the warning.
+    (process.stderr as unknown as { write: (s: string) => boolean }).write = (s: string) => {
+      writes.push(String(s));
+      return true;
+    };
+    let loop: CacheFirstLoop;
+    try {
+      loop = new CacheFirstLoop({
+        client,
+        prefix: new ImmutablePrefix({ system: "s" }),
+        stream: false,
+        // Out-of-range value (>20) — must warn and fall back to default 3.
+        failureThreshold: 999,
+      });
+    } finally {
+      (process.stderr as unknown as { write: typeof original }).write = original;
+    }
+    expect(writes.some((w) => /failureThreshold=999/.test(w))).toBe(true);
+
+    // Behavior matches the default-3 threshold.
+    for (let i = 0; i < 2; i++) {
+      const result = signalToolFailure(loop, {
+        repair: { scavenged: 1, truncationsFixed: 0, stormsBroken: 0, notes: [] },
+      });
+      expect(result.escalated).toBe(false);
+    }
+    const third = signalToolFailure(loop, {
+      repair: { scavenged: 1, truncationsFixed: 0, stormsBroken: 0, notes: [] },
+    });
+    expect(third.escalated).toBe(true);
+    expect(third.count).toBe(3);
+  });
 });
 
 describe("CacheFirstLoop - retryLastUser edge cases", () => {


### PR DESCRIPTION
## Summary
The flash→pro escalation threshold has been hardcoded to 3 repair signals per turn, which trips too early on long subagent runs where transient tool failures are expected and recoverable on flash. This PR makes the threshold configurable through `escalation.failureThreshold` in `~/.reasonix/config.json` and a `--escalate-after <n>` flag on `chat` / `code` / `run`, while preserving the existing default of 3.

## Changes
- `src/loop/turn-failure-tracker.ts`: `TurnFailureTracker` now takes an optional threshold in its constructor (defaulting to the exported `FAILURE_ESCALATION_THRESHOLD = 3`) and compares against the instance value in `noteAndCrossedThreshold`.
- `src/loop.ts`: add `failureThreshold?: number` to `CacheFirstLoopOptions`, validate (integer in [1,20], else stderr warning + fall back to default), and pass the resolved value into the `TurnFailureTracker` constructor.
- `src/config.ts`: add the optional `escalation?: { failureThreshold?: number }` shape to `ReasonixConfig`.
- `src/cli/index.ts`: add `--escalate-after <n>` to the `chat`, `code`, and `run` subcommands; `parseEscalateAfterFlag` mirrors `parseBudgetFlag` (lenient — bad value warns + returns undefined), and `resolveFailureThreshold` picks flag > config > default, honouring `--no-config`.
- `src/cli/commands/chat.tsx`, `code.tsx`, `run.ts`, `src/cli/ui/App.tsx`: thread `failureThreshold` from CLI options through to the loop constructor; included in the `AppInner` memo deps.
- `tests/loop.test.ts`: cover threshold=5 (no escalation until the 5th signal), default behaviour (threshold=3 preserved), and invalid values falling back to 3 with a stderr warning.

## Testing
`npm test -- tests/loop.test.ts` — passes locally. The new cases exercise the tracker via the existing private-access helper used for the threshold=3 baseline.

## Notes
- Range bounds are [1,20] — generous enough for the long-subagent-run case (the issue suggests values around 5–10) without letting a typo disable escalation effectively forever.
- No persistence helper was added — `escalation.failureThreshold` is hand-edited in `~/.reasonix/config.json`, matching how `budget` is handled today.
- The warning channel is stderr for both the flag and the config-key fallback; happy to switch to the structured logger if you'd prefer.

Closes #628