### PR TITLE
fix(tui): quantize CardStream window so boundary cards stop oscillating

### DIFF
--- a/src/cli/ui/layout/CardStream.tsx
+++ b/src/cli/ui/layout/CardStream.tsx
@@ -9,7 +9,50 @@ import { FG, TONE } from "../theme/tokens.js";
 
 /** Buffer of rows kept rendered on each side of the viewport so a single scroll
  * step doesn't reveal an unmeasured card. Larger = smoother but renders more. */
-const VISIBLE_BUFFER_ROWS = 30;
+export const VISIBLE_BUFFER_ROWS = 30;
+
+export type CardStreamItem<T> =
+  | { kind: "spacer"; rows: number; key: string }
+  | { kind: "card"; card: T };
+
+/** Decide which cards render live vs collapse into a spacer, given the cached
+ * heights and the current viewport position. Window is quantized to
+ * VISIBLE_BUFFER_ROWS buckets so a single-row scrollRows / outerHeight wiggle
+ * doesn't toggle a boundary card and re-trigger inner.height oscillation
+ * (root cause of issues #549 / #700). */
+export function computeCardStreamItems<T extends { id: string }>(
+  cards: readonly T[],
+  cardHeights: ReadonlyMap<string, number>,
+  scrollRows: number,
+  outerHeight: number,
+): CardStreamItem<T>[] {
+  const bucket = Math.floor(scrollRows / VISIBLE_BUFFER_ROWS) * VISIBLE_BUFFER_ROWS;
+  const winStart = Math.max(0, bucket - VISIBLE_BUFFER_ROWS);
+  const winEnd = bucket + outerHeight + VISIBLE_BUFFER_ROWS * 2;
+  const out: CardStreamItem<T>[] = [];
+  let cursor = 0;
+  let pendingSpacer = 0;
+  let spacerKey = 0;
+  for (const card of cards) {
+    const h = cardHeights.get(card.id);
+    const cardEnd = cursor + (h ?? 0);
+    const live = h === undefined || (cardEnd >= winStart && cursor <= winEnd);
+    if (live) {
+      if (pendingSpacer > 0) {
+        out.push({ kind: "spacer", rows: pendingSpacer, key: `sp-${spacerKey++}` });
+        pendingSpacer = 0;
+      }
+      out.push({ kind: "card", card });
+    } else {
+      pendingSpacer += h ?? 0;
+    }
+    cursor = cardEnd;
+  }
+  if (pendingSpacer > 0) {
+    out.push({ kind: "spacer", rows: pendingSpacer, key: `sp-${spacerKey}` });
+  }
+  return out;
+}
 
 /**
  * Row-precision virtual scroll with card-level virtualization.
@@ -55,39 +98,10 @@ export function CardStream({
     visible = cards.slice(0, -1);
   }
 
-  /** Compute which cards land inside the visible window + buffer. Cards with
-   * unknown heights are always kept live so they get measured on first paint. */
-  const items = useMemo(() => {
-    const winStart = Math.max(0, scrollRows - VISIBLE_BUFFER_ROWS);
-    const winEnd = scrollRows + outer.height + VISIBLE_BUFFER_ROWS;
-    const out: Array<{ kind: "spacer"; rows: number; key: string } | { kind: "card"; card: Card }> =
-      [];
-    let cursor = 0;
-    let pendingSpacer = 0;
-    let spacerKey = 0;
-    for (const card of visible) {
-      const h = cardHeights.get(card.id);
-      const cardEnd = cursor + (h ?? 0);
-      // Render live when:
-      //   1. height isn't cached yet (need to measure), OR
-      //   2. card range overlaps the visible window.
-      const live = h === undefined || (cardEnd >= winStart && cursor <= winEnd);
-      if (live) {
-        if (pendingSpacer > 0) {
-          out.push({ kind: "spacer", rows: pendingSpacer, key: `sp-${spacerKey++}` });
-          pendingSpacer = 0;
-        }
-        out.push({ kind: "card", card });
-      } else {
-        pendingSpacer += h ?? 0;
-      }
-      cursor = cardEnd;
-    }
-    if (pendingSpacer > 0) {
-      out.push({ kind: "spacer", rows: pendingSpacer, key: `sp-${spacerKey}` });
-    }
-    return out;
-  }, [visible, cardHeights, scrollRows, outer.height]);
+  const items = useMemo(
+    () => computeCardStreamItems(visible, cardHeights, scrollRows, outer.height),
+    [visible, cardHeights, scrollRows, outer.height],
+  );
 
   return (
     <>

--- a/tests/card-stream-items.test.ts
+++ b/tests/card-stream-items.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+  type CardStreamItem,
+  VISIBLE_BUFFER_ROWS,
+  computeCardStreamItems,
+} from "../src/cli/ui/layout/CardStream.js";
+
+type C = { id: string };
+
+function liveIds<T extends C>(items: CardStreamItem<T>[]): string[] {
+  return items
+    .filter((i): i is { kind: "card"; card: T } => i.kind === "card")
+    .map((i) => i.card.id);
+}
+
+describe("computeCardStreamItems", () => {
+  it("renders every card live when all fit inside outer+buffer", () => {
+    const cards: C[] = [{ id: "a" }, { id: "b" }, { id: "c" }];
+    const heights = new Map([
+      ["a", 10],
+      ["b", 10],
+      ["c", 10],
+    ]);
+    const out = computeCardStreamItems(cards, heights, 0, 40);
+    expect(liveIds(out)).toEqual(["a", "b", "c"]);
+  });
+
+  it("collapses far-above cards into a spacer when scrolled to the bottom", () => {
+    const cards: C[] = Array.from({ length: 20 }, (_, i) => ({ id: `c${i}` }));
+    const heights = new Map(cards.map((c) => [c.id, 10]));
+    const out = computeCardStreamItems(cards, heights, 180, 20);
+    const live = liveIds(out);
+    // bottom cards visible, top cards collapsed
+    expect(live).toContain("c19");
+    expect(live).not.toContain("c0");
+    expect(out.some((i) => i.kind === "spacer")).toBe(true);
+  });
+
+  it("keeps a card with no cached height live (so it can be measured)", () => {
+    const cards: C[] = [{ id: "a" }, { id: "new" }];
+    const heights = new Map([["a", 1000]]); // a is far below winStart
+    const out = computeCardStreamItems(cards, heights, 1500, 20);
+    expect(liveIds(out)).toContain("new");
+  });
+
+  // #700: in pinned mode, scrollRows tracks maxScroll = inner.height -
+  // outer.height. A boundary card can flip live↔spacer on every render as
+  // outer.height wiggles by a row or two, which changes inner.height by Δ,
+  // which changes maxScroll back, ad infinitum. Quantizing the window to
+  // VISIBLE_BUFFER_ROWS buckets means sub-bucket wiggles produce the SAME
+  // items array — the dep array still notices the change, but the result
+  // is referentially-different-but-equal so downstream metrics settle.
+  it("does not toggle which cards are live for sub-bucket scrollRows shifts", () => {
+    const cards: C[] = Array.from({ length: 30 }, (_, i) => ({ id: `c${i}` }));
+    const heights = new Map(cards.map((c) => [c.id, 10]));
+    const outerHeight = 20;
+    // Pick a bucket-aligned base so scrollRows..base+(BUCKET-1) all sit in
+    // the same bucket — that's the invariant the quantization guarantees.
+    const baseScroll = 9 * VISIBLE_BUFFER_ROWS;
+    const base = liveIds(computeCardStreamItems(cards, heights, baseScroll, outerHeight));
+    for (let delta = 1; delta < VISIBLE_BUFFER_ROWS; delta++) {
+      const wiggled = liveIds(
+        computeCardStreamItems(cards, heights, baseScroll + delta, outerHeight),
+      );
+      expect(wiggled, `scrollRows ${baseScroll}+${delta} changed live set`).toEqual(base);
+    }
+  });
+
+  it("does not toggle which cards are live for sub-bucket outerHeight shifts", () => {
+    const cards: C[] = Array.from({ length: 30 }, (_, i) => ({ id: `c${i}` }));
+    const heights = new Map(cards.map((c) => [c.id, 10]));
+    const scroll = 270;
+    const base = liveIds(computeCardStreamItems(cards, heights, scroll, 20));
+    for (const h of [21, 22, 25, 30, 40]) {
+      const wiggled = liveIds(computeCardStreamItems(cards, heights, scroll, h));
+      expect(wiggled, `outerHeight ${h} changed live set`).toEqual(base);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Second instance of the same setState-loop class that #549 fixed. CardStream's `items` useMemo depends on both `scrollRows` and `outer.height`. In pinned mode `scrollRows = maxScroll = inner.height − outer.height`, so when a sibling row toggles (`ToastRail` appearing, `ThinkingRow` flipping based on `busy/streaming`), `outer.height` shifts by ±1 → window slides → a card sitting on the live/spacer boundary flips → `inner.height` changes by Δ → `setMaxScroll` → `scrollRows` updates → useMemo recomputes → card flips back. With flash streaming compounding inside the same React batch, the chain reaches `MAX_NESTED_UPDATES = 50` and Ink throws inside `useBoxMetrics` (`use-box-metrics.js:51`).

#549 patched one specific cause (the "↑ earlier" hint changing `outer.height` based on `scrollRows`). #700 is the residual case where any sibling toggle does the same thing.

## Fix

Quantize the window position to `VISIBLE_BUFFER_ROWS` buckets. Sub-bucket `scrollRows` / `outer.height` wiggles now map to the same window, so the items array is referentially-stable across them. The boundary card doesn't move on its own anymore — only on real scrolls that cross a bucket.

Trade: a single bucket (30 rows) of "stickiness" at scroll boundaries. Imperceptible in practice — the existing pre-`#700` buffer was already 30 rows.

## Test plan

- [x] New `tests/card-stream-items.test.ts` covers the invariant: the live-card set is identical for every sub-bucket `scrollRows` delta (0..VISIBLE_BUFFER_ROWS−1) and for `outer.height` values in [20..40]
- [x] Full suite: 2689 / 2689 passing (was 2681, +5 new + 3 incidental from other branches)
- [x] Existing CardStream behaviors (live-by-default for unmeasured cards, spacer-when-scrolled-far) still pass

Closes #700
