### PR TITLE
fix(code): bridge config key into env + lazy subagent client

### DIFF
--- a/src/cli/commands/code.tsx
+++ b/src/cli/commands/code.tsx
@@ -21,7 +21,8 @@
 import { readFileSync } from "node:fs";
 import { basename, resolve } from "node:path";
 import { buildCodeToolset } from "../../code/setup.js";
-import { readConfig } from "../../config.js";
+import { loadApiKey, readConfig } from "../../config.js";
+import { loadDotenv } from "../../env.js";
 import { t } from "../../i18n/index.js";
 import { detectForeignAgentPlatform } from "../../memory/project.js";
 import { sanitizeName } from "../../memory/session.js";
@@ -65,6 +66,16 @@ export interface CodeOptions {
 
 export async function codeCommand(opts: CodeOptions = {}): Promise<void> {
   markPhase("code_command_enter");
+  // Bridge .env + ~/.reasonix/config.json into process.env so buildCodeToolset's
+  // eager DeepSeekClient constructions (subagent client; semantic embedder) can
+  // pick up a key the user already configured via `reasonix setup`. chatCommand
+  // does the same dance — code.tsx wraps chatCommand but must also seed env
+  // before buildCodeToolset runs, which is BEFORE chatCommand.
+  loadDotenv();
+  const cfgKey = loadApiKey();
+  if (cfgKey && !process.env.DEEPSEEK_API_KEY) {
+    process.env.DEEPSEEK_API_KEY = cfgKey;
+  }
   const { codeSystemPrompt } = await import("../../code/prompt.js");
   const rootDir = resolve(opts.dir ?? process.cwd());
   // Per-directory session so switching projects doesn't mix histories.

--- a/src/code/setup.ts
+++ b/src/code/setup.ts
@@ -65,10 +65,15 @@ export async function buildCodeToolset(opts: CodeToolsetOpts): Promise<CodeTools
       webSearchEndpoint: webSearchEndpoint(),
     });
   }
-  const subagentClient = new DeepSeekClient({ baseUrl: loadBaseUrl() });
+  // Lazy: constructing DeepSeekClient throws when DEEPSEEK_API_KEY is unset,
+  // which would kill `reasonix code` before the setup wizard can prompt for
+  // one. Defer to first subagent dispatch — by then the user has either keyed
+  // in or we error per-call instead of at boot.
+  let subagentClient: DeepSeekClient | null = null;
   registerSkillTools(tools, {
     projectRoot: opts.rootDir,
     subagentRunner: async (skill, task, signal) => {
+      if (!subagentClient) subagentClient = new DeepSeekClient({ baseUrl: loadBaseUrl() });
       const result = await spawnSubagent({
         client: subagentClient,
         parentRegistry: tools,

--- a/tests/code-setup-lazy-subagent.test.ts
+++ b/tests/code-setup-lazy-subagent.test.ts
@@ -1,0 +1,33 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildCodeToolset } from "../src/code/setup.js";
+
+// #700-followup: buildCodeToolset used to eagerly construct a DeepSeekClient
+// for the subagent runner, which threw "DEEPSEEK_API_KEY is not set" before
+// the wizard could prompt. Now the client is constructed lazily on the first
+// subagent dispatch, so the toolset builds without a key.
+
+describe("buildCodeToolset", () => {
+  let savedKey: string | undefined;
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    savedKey = process.env.DEEPSEEK_API_KEY;
+    // biome-ignore lint/performance/noDelete: setting to "undefined" string would mask test
+    delete process.env.DEEPSEEK_API_KEY;
+    tmpRoot = mkdtempSync(join(tmpdir(), "reasonix-code-setup-"));
+  });
+
+  afterEach(async () => {
+    if (savedKey !== undefined) process.env.DEEPSEEK_API_KEY = savedKey;
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("builds without DEEPSEEK_API_KEY set", async () => {
+    const toolset = await buildCodeToolset({ rootDir: tmpRoot });
+    expect(toolset.tools.size).toBeGreaterThan(0);
+    await toolset.jobs.shutdown();
+  });
+});


### PR DESCRIPTION
## Summary

`reasonix code` (and `npx tsx src/cli/index.ts code` in dev) crashed at boot with `DEEPSEEK_API_KEY is not set` even when the user had a key saved in `~/.reasonix/config.json` via `reasonix setup`. Two bugs stacked:

1. **`code.tsx` never bridged config → env.** `chat.tsx`, `desktop.ts`, and `run.ts` all do `loadDotenv()` + `process.env.DEEPSEEK_API_KEY = loadApiKey()` at the top of their command. `code.tsx` skipped this entirely, relying on the shell env to already have it.

2. **Subagent client constructed eagerly.** `buildCodeToolset` in `src/code/setup.ts` builds a `DeepSeekClient` for the skill-subagent runner at boot. With no env key the constructor throws — before `chatCommand` (called later in `codeCommand`) can mount the wizard that would prompt for one. So even fixing (1) wouldn't recover the wizard path for a brand-new user.

## Fix

- `code.tsx`: call `loadDotenv()` + bridge `loadApiKey()` into env at the very top of `codeCommand`, mirroring `chatCommand`
- `setup.ts`: defer the subagent client to first dispatch (lazy `let subagentClient: DeepSeekClient | null = null`). Construction error now surfaces at the call site (user invokes a skill) instead of at boot, which preserves the wizard path

## Test plan

- [x] New `tests/code-setup-lazy-subagent.test.ts` deletes `DEEPSEEK_API_KEY` and asserts `buildCodeToolset` succeeds
- [x] Full suite: 2690 / 2690
- [x] Manually re-ran `npx tsx src/cli/index.ts code --help` — boots cleanly with no env key
