### PR TITLE
feat(i18n): add marketplace zh-CN overlay + fix remaining TUI gaps

### DIFF
--- a/src/cli/commands/mcp-browse.tsx
+++ b/src/cli/commands/mcp-browse.tsx
@@ -4,6 +4,7 @@ import { Box, Text, render, useApp, useInput } from "ink";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { readConfig, writeConfig } from "../../config.js";
 import { loadDotenv } from "../../env.js";
+import { loadOverlay } from "../../mcp/marketplace-overlay/loader.js";
 import {
   type RegistryHandle,
   loadMorePages,
@@ -157,6 +158,8 @@ function McpBrowseApp() {
     }
   });
 
+  const overlay = useMemo(() => loadOverlay("zh-CN"), []);
+
   const start = Math.max(
     0,
     Math.min(state.selected - Math.floor(VISIBLE_ROWS / 2), filtered.length - VISIBLE_ROWS),
@@ -199,9 +202,14 @@ function McpBrowseApp() {
       {selected ? (
         <Box marginTop={1} flexDirection="column">
           <Text bold color="white">
-            {selected.title}
+            {overlay?.[selected.name]?.title ?? selected.title}
+            {overlay?.[selected.name] ? (
+              <Text dimColor>{`  \u00b7  ${selected.title}`}</Text>
+            ) : null}
           </Text>
-          {selected.description ? <Text dimColor>{selected.description.slice(0, 160)}</Text> : null}
+          <Text dimColor>
+            {overlay?.[selected.name]?.description ?? selected.description?.slice(0, 160) ?? null}
+          </Text>
           {selected.install ? (
             <Text dimColor>
               {`spec: ${selected.install.runtime} ${selected.install.packageId ?? selected.install.url ?? "—"} · ${selected.install.transport}`}

--- a/src/cli/ui/BootSplash.tsx
+++ b/src/cli/ui/BootSplash.tsx
@@ -1,6 +1,7 @@
 import { Box, Text } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React, { useEffect, useState } from "react";
+import { t } from "../../i18n/index.js";
 import { FG, TONE } from "./theme/tokens.js";
 
 const REASONIX_LOGO = [
@@ -75,7 +76,7 @@ export function BootSplash(): React.ReactElement {
         <Text color={FG.faint}>{wave}</Text>
       </Box>
       <Box marginTop={1}>
-        <Text color={FG.meta}>{`loading${dots}`}</Text>
+        <Text color={FG.meta}>{`${t("common.loading")}${dots}`}</Text>
       </Box>
     </Box>
   );

--- a/src/cli/ui/McpMarketplace.tsx
+++ b/src/cli/ui/McpMarketplace.tsx
@@ -4,6 +4,7 @@ import { Box, Text } from "ink";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { readConfig, writeConfig } from "../../config.js";
 import { t } from "../../i18n/index.js";
+import { loadOverlay } from "../../mcp/marketplace-overlay/loader.js";
 import {
   type RegistryHandle,
   fetchSmitheryDetail,
@@ -345,6 +346,8 @@ export function McpMarketplace({ onClose, postInfo, reloadMcp, pickerPorts }: Mc
     }
   });
 
+  const overlay = useMemo(() => loadOverlay("zh-CN"), []);
+
   const start = Math.max(
     0,
     Math.min(state.selected - Math.floor(VISIBLE_ROWS / 2), filtered.length - VISIBLE_ROWS),
@@ -392,8 +395,15 @@ export function McpMarketplace({ onClose, postInfo, reloadMcp, pickerPorts }: Mc
       </Box>
       {selected ? (
         <Box marginTop={1} flexDirection="column">
-          <Text bold>{selected.title}</Text>
-          {selected.description ? <Text dimColor>{selected.description.slice(0, 200)}</Text> : null}
+          <Text bold>
+            {overlay?.[selected.name]?.title ?? selected.title}
+            {overlay?.[selected.name] ? (
+              <Text dimColor>{`  \u00b7  ${selected.title}`}</Text>
+            ) : null}
+          </Text>
+          <Text dimColor>
+            {overlay?.[selected.name]?.description ?? selected.description?.slice(0, 200) ?? null}
+          </Text>
           {selected.install ? (
             <Text dimColor>
               {t("mcpMarketplace.specLine", {

--- a/src/cli/ui/PlanStepList.tsx
+++ b/src/cli/ui/PlanStepList.tsx
@@ -81,8 +81,8 @@ function statusGlyph(status: StepStatus, isCur: boolean): StatusGlyph {
 }
 
 function riskLabel(risk: PlanStepRisk | undefined): { text: string; color: string } | null {
-  if (risk === "med") return { text: `${GLYPH.warn} med`, color: COLOR.warn };
-  if (risk === "high") return { text: `${GLYPH.warn} high`, color: COLOR.err };
+  if (risk === "med") return { text: `${GLYPH.warn}${t("planFlow.riskMed")}`, color: COLOR.warn };
+  if (risk === "high") return { text: `${GLYPH.warn}${t("planFlow.riskHigh")}`, color: COLOR.err };
   // low + undefined: omitted entirely (the default reading should be
   // "low risk" — surfacing it on every line buries the med/high ones).
   return null;

--- a/src/cli/ui/hooks/handle-stream-events.ts
+++ b/src/cli/ui/hooks/handle-stream-events.ts
@@ -1,4 +1,5 @@
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
+import { t } from "../../../i18n/index.js";
 import type { LoopEvent } from "../../../loop.js";
 import type { TurnTranslator } from "../state/TurnTranslator.js";
 import type { Scrollback } from "./useScrollback.js";
@@ -65,7 +66,7 @@ export function handleErrorEvent(ev: LoopEvent, ctx: ErrorContext): void {
   ctx.setToolProgress(null);
   ctx.toolStartedAtRef.current = null;
   ctx.translator.toolAbort(ev.error ?? ev.content);
-  ctx.log.pushError("tool error", ev.error ?? ev.content);
+  ctx.log.pushError(t("common.error"), ev.error ?? ev.content);
 }
 
 export interface WarningContext {
@@ -74,7 +75,7 @@ export interface WarningContext {
 }
 
 export function handleWarningEvent(ev: LoopEvent, ctx: WarningContext): void {
-  ctx.log.pushWarning("warning", ev.content);
+  ctx.log.pushWarning(t("common.warning"), ev.content);
   // Loop emits warnings starting with "⇧" whenever this turn is (or just
   // became) running on pro — flip the badge so the escalation shows.
   if (ev.content?.startsWith("⇧ ")) ctx.setTurnOnPro(true);

--- a/src/cli/ui/hooks/handle-tool-event.ts
+++ b/src/cli/ui/hooks/handle-tool-event.ts
@@ -1,5 +1,6 @@
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import { archivePlanState } from "../../../code/plan-store.js";
+import { t } from "../../../i18n/index.js";
 import type { LoopEvent } from "../../../loop.js";
 import type { ChoiceOption } from "../../../tools/choice.js";
 import type { PlanStep, StepCompletion } from "../../../tools/plan.js";
@@ -58,9 +59,7 @@ export function handleToolEvent(ev: LoopEvent, ctx: ToolEventContext): void {
         if (ctx.session && total > 0 && completed >= total) {
           const archive = archivePlanState(ctx.session);
           if (archive) {
-            ctx.log.pushInfo(
-              `▸ plan complete — all ${total} step${total === 1 ? "" : "s"} done · archived`,
-            );
+            ctx.log.pushInfo(t("planFlow.completeMsg", { total, s: total === 1 ? "" : "s" }));
           }
         }
       }

--- a/src/cli/ui/primitives.tsx
+++ b/src/cli/ui/primitives.tsx
@@ -1,6 +1,7 @@
 import { Text, useStdout } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React from "react";
+import { t } from "../../i18n/index.js";
 import { COLOR } from "./theme.js";
 
 /**
@@ -72,7 +73,7 @@ export function ContextCell({
         <Text color={COLOR.info} dimColor>
           {"▣ ctx "}
         </Text>
-        <Text dimColor>— (no turns yet)</Text>
+        <Text dimColor>{`\u2014 ${t("common.noTurns")}`}</Text>
       </Text>
     );
   }

--- a/src/cli/ui/useSubagent.ts
+++ b/src/cli/ui/useSubagent.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { t } from "../../i18n/index.js";
 import type { LoopEvent } from "../../loop.js";
 import { appendUsage } from "../../telemetry/usage.js";
 import type { SubagentEvent, SubagentSink } from "../../tools/subagent.js";
@@ -59,23 +60,28 @@ function summariseInner(ev: LoopEvent): SubagentInnerSummary | null {
     return {
       glyph: "▣",
       color: CARD.tool.color,
-      label: ev.toolName ?? "tool",
-      meta: "running",
+      label: ev.toolName ?? t("common.tool"),
+      meta: t("common.running"),
     };
   }
   if (ev.role === "tool") {
     return {
       glyph: "▣",
       color: CARD.tool.color,
-      label: ev.toolName ?? "tool",
-      meta: "done",
+      label: ev.toolName ?? t("common.tool"),
+      meta: t("common.done"),
     };
   }
   if (ev.role === "warning") {
-    return { glyph: "⚠", color: TONE.warn, label: "warning", meta: ev.content?.slice(0, 40) };
+    return {
+      glyph: "\u26a0",
+      color: TONE.warn,
+      label: t("common.warning"),
+      meta: ev.content?.slice(0, 40),
+    };
   }
   if (ev.role === "error") {
-    return { glyph: "✖", color: TONE.err, label: ev.error ?? "error" };
+    return { glyph: "\u2716", color: TONE.err, label: ev.error ?? t("common.error") };
   }
   return null;
 }

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -10,6 +10,9 @@ export const EN: TranslationSchema = {
     confirm: "Confirm",
     back: "Back",
     next: "Next",
+    tool: "tool",
+    running: "running",
+    noTurns: "(no turns yet)",
   },
   cli: {
     description: "DeepSeek-native agent framework — built for cache hits and cheap tokens.",
@@ -508,7 +511,11 @@ export const EN: TranslationSchema = {
     },
     reviseTitle: "Revise plan",
     reviseSteps: "{count} steps",
-    reviseFooter: "↑↓ focus  ·  space toggle skip  ·  k/j move  ·  ⏎ accept  ·  esc cancel",
+    reviseFooter:
+      "\u2191\u2193 focus  \u00b7  space toggle skip  \u00b7  k/j move  \u00b7  \u23ce accept  \u00b7  esc cancel",
+    riskMed: " med",
+    riskHigh: " high",
+    completeMsg: "\u25b8 plan complete \u2014 all {total} step{s} done \u00b7 archived",
   },
   app: {
     walkCancelledRemaining: "▸ walk cancelled — {count} block(s) still pending.",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -10,6 +10,9 @@ export interface TranslationSchema {
     confirm: string;
     back: string;
     next: string;
+    tool: string;
+    running: string;
+    noTurns: string;
   };
   cli: {
     description: string;
@@ -340,6 +343,9 @@ export interface TranslationSchema {
     reviseTitle: string;
     reviseSteps: string;
     reviseFooter: string;
+    riskMed: string;
+    riskHigh: string;
+    completeMsg: string;
   };
   statusBar: {
     turn: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -10,6 +10,9 @@ export const zhCN: TranslationSchema = {
     confirm: "确认",
     back: "返回",
     next: "下一步",
+    tool: "工具",
+    running: "运行中",
+    noTurns: "(暂无对话)",
   },
   cli: {
     description: "DeepSeek 原生智能体框架 — 专为缓存命中和低成本令牌构建。",
@@ -496,7 +499,12 @@ export const zhCN: TranslationSchema = {
     },
     reviseTitle: "修改计划",
     reviseSteps: "{count} 个步骤",
-    reviseFooter: "↑↓ 焦点  ·  空格切换跳过  ·  k/j 移动  ·  ⏎ 确认  ·  Esc 取消",
+    reviseFooter:
+      "\u2191\u2193 焦点  \u00b7  空格切换跳过  \u00b7  k/j 移动  \u00b7  \u23ce 确认  \u00b7  Esc 取消",
+    riskMed: " 中",
+    riskHigh: " 高",
+    completeMsg:
+      "\u25b8 \u8ba1\u5212\u5b8c\u6210 \u2014 \u5168\u90e8 {total} \u4e2a\u6b65\u9aa4\u5df2\u5b8c\u6210 \u00b7 \u5df2\u5f52\u6863",
   },
   app: {
     walkCancelledRemaining: "▸ 浏览已取消 — 还有 {count} 个待处理编辑块。",

--- a/src/mcp/marketplace-overlay/loader.ts
+++ b/src/mcp/marketplace-overlay/loader.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export interface OverlayEntry {
+  title: string;
+  description: string;
+}
+
+let cache: Record<string, OverlayEntry> | null = null;
+let cachedLang: string | null = null;
+
+export function loadOverlay(lang: string): Record<string, OverlayEntry> | null {
+  if (cachedLang === lang && cache) return cache;
+  try {
+    const dir = dirname(fileURLToPath(import.meta.url));
+    const raw = readFileSync(join(dir, `${lang}.json`), "utf8");
+    cache = JSON.parse(raw) as Record<string, OverlayEntry>;
+    cachedLang = lang;
+    return cache;
+  } catch {
+    return null;
+  }
+}

--- a/src/mcp/marketplace-overlay/zh-CN.json
+++ b/src/mcp/marketplace-overlay/zh-CN.json
@@ -1,0 +1,42 @@
+{
+  "filesystem": {
+    "title": "文件系统",
+    "description": "为代理授予对指定目录的读写权限，支持创建、读取、编辑和删除文件"
+  },
+  "fetch": {
+    "title": "网络请求",
+    "description": "从互联网获取网页内容，支持 HTML 抓取和 API 调用"
+  },
+  "git": {
+    "title": "Git 版本控制",
+    "description": "执行 Git 操作：查看日志、分支、差异，暂存和提交变更"
+  },
+  "sqlite": {
+    "title": "SQLite 数据库",
+    "description": "在本地 SQLite 数据库中执行 SQL 查询和管理表结构"
+  },
+  "postgres": {
+    "title": "PostgreSQL 数据库",
+    "description": "连接 PostgreSQL 数据库，执行 SQL 查询和管理表结构"
+  },
+  "github": {
+    "title": "GitHub API",
+    "description": "管理 GitHub 仓库、Issue、PR、分支和 Actions"
+  },
+  "slack": {
+    "title": "Slack 消息",
+    "description": "发送和读取 Slack 频道消息，管理频道和用户"
+  },
+  "brave-search": {
+    "title": "Brave 搜索",
+    "description": "通过 Brave Search API 进行网页和新闻搜索"
+  },
+  "memory": {
+    "title": "知识图谱记忆",
+    "description": "持久化存储和检索知识图谱实体的记忆系统"
+  },
+  "puppeteer": {
+    "title": "Puppeteer 浏览器",
+    "description": "通过 Puppeteer 控制的 Chromium 实例进行网页浏览、截图和交互"
+  }
+}

--- a/tests/subagent-reducer.test.ts
+++ b/tests/subagent-reducer.test.ts
@@ -63,7 +63,7 @@ describe("reduceSubagentInnerEvent", () => {
     expect(next[0]).toBe(a);
     expect(next[1]).not.toBe(b);
     expect(next[1]?.lastInner?.label).toBe("grep");
-    expect(next[1]?.lastInner?.meta).toBe("done");
+    expect(next[1]?.lastInner?.meta).toBe("Done");
   });
 
   it("returns prev by reference when progress repeats the same iter/elapsedMs", () => {

--- a/tests/ui-stream-events.test.ts
+++ b/tests/ui-stream-events.test.ts
@@ -72,6 +72,6 @@ describe("stream event handlers", () => {
     expect(toolProgress).toBeNull();
     expect(toolStartedAtRef.current).toBeNull();
     expect(translator.toolAbort).toHaveBeenCalledWith("Error: tool crashed");
-    expect(log.pushError).toHaveBeenCalledWith("tool error", "Error: tool crashed");
+    expect(log.pushError).toHaveBeenCalledWith("Error", "Error: tool crashed");
   });
 });


### PR DESCRIPTION
Two changes:

1. Marketplace localization overlay — adds zh-CN translations for the 10 most-installed MCP entries (filesystem, fetch, git, sqlite, postgres, github, slack, brave-search, memory, puppeteer). A thin loader reads the JSON on first use and caches in memory. Both rendering sites (McpMarketplace TUI modal and mcp-browse CLI) show the translated title with the original English name in dim text for searchability. Closes #695.

2. Remaining TUI i18n gaps — wraps the last few hardcoded English strings in BootSplash (loading), primitives (no-turns placeholder), PlanStepList (risk labels), handle-stream-events (toast titles), handle-tool-event (plan-complete banner), and useSubagent (activity labels). Most reuse existing common keys.

New i18n keys: common.tool, common.running, common.noTurns, planFlow.riskMed, planFlow.riskHigh, planFlow.completeMsg.