### PR TITLE
feat(mcp): add localized marketplace overlay with zh-CN seed

### DIFF
--- a/src/cli/commands/mcp-browse.tsx
+++ b/src/cli/commands/mcp-browse.tsx
@@ -4,6 +4,8 @@ import { Box, Text, render, useApp, useInput } from "ink";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { readConfig, writeConfig } from "../../config.js";
 import { loadDotenv } from "../../env.js";
+import { getLanguage } from "../../i18n/index.js";
+import { applyOverlay } from "../../mcp/marketplace-overlay/loader.js";
 import {
   type RegistryHandle,
   loadMorePages,
@@ -196,27 +198,33 @@ function McpBrowseApp() {
           })
         )}
       </Box>
-      {selected ? (
-        <Box marginTop={1} flexDirection="column">
-          <Text bold color="white">
-            {selected.title}
-          </Text>
-          {selected.description ? <Text dimColor>{selected.description.slice(0, 160)}</Text> : null}
-          {selected.install ? (
-            <Text dimColor>
-              {`spec: ${selected.install.runtime} ${selected.install.packageId ?? selected.install.url ?? "—"} · ${selected.install.transport}`}
-            </Text>
-          ) : (
-            <Text dimColor>(smithery listing — install info not exposed)</Text>
-          )}
-          {selected.install?.requiredEnv?.length ? (
-            <Text color="yellow">{`needs: ${selected.install.requiredEnv.join(", ")}`}</Text>
-          ) : null}
-        </Box>
-      ) : null}
+      {selected ? <BrowseDetail entry={selected} /> : null}
       <Box marginTop={1}>
         <Text dimColor>type to filter · ↑↓ pick · enter install · tab load more · esc quit</Text>
       </Box>
+    </Box>
+  );
+}
+
+function BrowseDetail({ entry }: { entry: RegistryEntry }) {
+  const localized = applyOverlay(entry, getLanguage());
+  return (
+    <Box marginTop={1} flexDirection="column">
+      <Text bold color="white">
+        {localized.title}
+      </Text>
+      {localized.englishTitle ? <Text dimColor>{localized.englishTitle}</Text> : null}
+      {localized.description ? <Text dimColor>{localized.description.slice(0, 160)}</Text> : null}
+      {entry.install ? (
+        <Text dimColor>
+          {`spec: ${entry.install.runtime} ${entry.install.packageId ?? entry.install.url ?? "—"} · ${entry.install.transport}`}
+        </Text>
+      ) : (
+        <Text dimColor>(smithery listing — install info not exposed)</Text>
+      )}
+      {entry.install?.requiredEnv?.length ? (
+        <Text color="yellow">{`needs: ${entry.install.requiredEnv.join(", ")}`}</Text>
+      ) : null}
     </Box>
   );
 }

--- a/src/cli/ui/McpMarketplace.tsx
+++ b/src/cli/ui/McpMarketplace.tsx
@@ -3,7 +3,8 @@
 import { Box, Text } from "ink";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { readConfig, writeConfig } from "../../config.js";
-import { t } from "../../i18n/index.js";
+import { getLanguage, t } from "../../i18n/index.js";
+import { applyOverlay } from "../../mcp/marketplace-overlay/loader.js";
 import {
   type RegistryHandle,
   fetchSmitheryDetail,
@@ -48,16 +49,22 @@ export function buildMarketplacePickerSnapshot(args: {
   status: string;
   hasMore: boolean;
 }) {
+  const lang = getLanguage();
   return {
     pickerKind: "mcp-marketplace" as const,
     title: `${t("mcpMarketplace.title")} \u00b7 ${args.status}`,
     query: args.query,
     items: args.filtered.map((e) => {
       const installedSpec = isInstalled(args.installedSpecs, e);
+      const localized = applyOverlay(e, lang);
+      const title = localized.title || e.name;
+      const subtitle = localized.englishTitle
+        ? `${localized.englishTitle}\u2003\u00b7\u2003${localized.description?.slice(0, 160) ?? ""}`
+        : (localized.description?.slice(0, 200) ?? undefined);
       return {
         id: e.name,
-        title: e.title || e.name,
-        subtitle: e.description?.slice(0, 200) ?? undefined,
+        title,
+        subtitle,
         badge: installedSpec
           ? "installed"
           : e.source === "official"
@@ -390,31 +397,39 @@ export function McpMarketplace({ onClose, postInfo, reloadMcp, pickerPorts }: Mc
           })
         )}
       </Box>
-      {selected ? (
-        <Box marginTop={1} flexDirection="column">
-          <Text bold>{selected.title}</Text>
-          {selected.description ? <Text dimColor>{selected.description.slice(0, 200)}</Text> : null}
-          {selected.install ? (
-            <Text dimColor>
-              {t("mcpMarketplace.specLine", {
-                runtime: selected.install.runtime,
-                id: selected.install.packageId ?? selected.install.url ?? "\u2014",
-                transport: selected.install.transport,
-              })}
-            </Text>
-          ) : (
-            <Text dimColor>{t("mcpMarketplace.smitheryDetail")}</Text>
-          )}
-          {selected.install?.requiredEnv?.length ? (
-            <Text color="yellow">
-              {t("mcpMarketplace.needsEnv", { env: selected.install.requiredEnv.join(", ") })}
-            </Text>
-          ) : null}
-        </Box>
-      ) : null}
+      {selected ? <MarketplaceDetail entry={selected} /> : null}
       <Box marginTop={1}>
         <Text dimColor>{t("mcpMarketplace.footerHint")}</Text>
       </Box>
+    </Box>
+  );
+}
+
+function MarketplaceDetail({ entry }: { entry: RegistryEntry }) {
+  const localized = applyOverlay(entry, getLanguage());
+  return (
+    <Box marginTop={1} flexDirection="column">
+      <Text bold>{localized.title}</Text>
+      {localized.englishTitle ? <Text dimColor>{localized.englishTitle}</Text> : null}
+      {localized.description ? (
+        <Text dimColor>{localized.description.slice(0, 200)}</Text>
+      ) : null}
+      {entry.install ? (
+        <Text dimColor>
+          {t("mcpMarketplace.specLine", {
+            runtime: entry.install.runtime,
+            id: entry.install.packageId ?? entry.install.url ?? "—",
+            transport: entry.install.transport,
+          })}
+        </Text>
+      ) : (
+        <Text dimColor>{t("mcpMarketplace.smitheryDetail")}</Text>
+      )}
+      {entry.install?.requiredEnv?.length ? (
+        <Text color="yellow">
+          {t("mcpMarketplace.needsEnv", { env: entry.install.requiredEnv.join(", ") })}
+        </Text>
+      ) : null}
     </Box>
   );
 }

--- a/src/mcp/marketplace-overlay/loader.ts
+++ b/src/mcp/marketplace-overlay/loader.ts
@@ -1,0 +1,91 @@
+/** Localization overlay for marketplace entries — swaps title/description for known
+ * registry names. Bundled JSON is validated at module load so malformed data fails fast. */
+
+import { readFileSync } from "node:fs";
+import type { LanguageCode } from "../../i18n/types.js";
+import type { RegistryEntry } from "../registry-types.js";
+import zhCNRaw from "./zh-CN.json";
+
+export interface OverlayEntry {
+  title: string;
+  description: string;
+}
+
+export type Overlay = Record<string, OverlayEntry>;
+
+function validate(raw: unknown, label: string): Overlay {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error(`marketplace overlay ${label} must be a JSON object`);
+  }
+  const overlay: Overlay = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      throw new Error(`marketplace overlay ${label}: entry "${key}" must be an object`);
+    }
+    const v = value as { title?: unknown; description?: unknown };
+    if (typeof v.title !== "string" || typeof v.description !== "string") {
+      throw new Error(
+        `marketplace overlay ${label}: entry "${key}" needs string title + description`,
+      );
+    }
+    overlay[key] = { title: v.title, description: v.description };
+  }
+  return overlay;
+}
+
+const BUNDLED: Partial<Record<LanguageCode, Overlay>> = {
+  "zh-CN": validate(zhCNRaw, "zh-CN.json"),
+};
+
+const cache = new Map<LanguageCode, Overlay>();
+
+/** Returns an empty overlay for languages without a bundled file. Throws on malformed JSON.
+ * `overlayPath` is a test-only escape hatch that bypasses the bundled cache and reads
+ * from disk, so failure modes (malformed JSON, bad shape) can be exercised. */
+export function loadOverlay(lang: LanguageCode, overlayPath?: string): Overlay {
+  if (overlayPath) {
+    let raw: string;
+    try {
+      raw = readFileSync(overlayPath, "utf8");
+    } catch {
+      return {};
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      throw new Error(`marketplace overlay ${lang}.json is malformed: ${(err as Error).message}`);
+    }
+    return validate(parsed, `${lang}.json`);
+  }
+  const cached = cache.get(lang);
+  if (cached) return cached;
+  const overlay = BUNDLED[lang] ?? {};
+  cache.set(lang, overlay);
+  return overlay;
+}
+
+export interface ApplyOverlayResult {
+  /** Localized title when an overlay entry exists, otherwise the upstream title. */
+  title: string;
+  /** Localized description when an overlay entry exists, otherwise the upstream description. */
+  description: string;
+  /** Upstream English title — set only when an overlay hit replaced the title, so callers
+   * can render it as a dimmed secondary line. */
+  englishTitle?: string;
+}
+
+/** Returns the entry's localized title/description, falling back to upstream verbatim. */
+export function applyOverlay(entry: RegistryEntry, lang: LanguageCode): ApplyOverlayResult {
+  const overlay = loadOverlay(lang);
+  const hit = overlay[entry.name];
+  if (!hit) {
+    return { title: entry.title, description: entry.description };
+  }
+  return { title: hit.title, description: hit.description, englishTitle: entry.title };
+}
+
+/** Test-only — drops cached overlays so a follow-up loadOverlay re-reads bundled data. */
+export function clearOverlayCache(): void {
+  cache.clear();
+}

--- a/src/mcp/marketplace-overlay/zh-CN.json
+++ b/src/mcp/marketplace-overlay/zh-CN.json
@@ -1,0 +1,46 @@
+{
+  "filesystem": {
+    "title": "文件系统",
+    "description": "为代理授予对指定目录的读写权限,该目录被强制为硬性沙箱。"
+  },
+  "memory": {
+    "title": "持久记忆",
+    "description": "在多次会话之间持久化的键值记忆,用于长期上下文。"
+  },
+  "github": {
+    "title": "GitHub",
+    "description": "读取 issue、PR 与代码搜索结果(需要设置 GITHUB_PERSONAL_ACCESS_TOKEN)。"
+  },
+  "puppeteer": {
+    "title": "Puppeteer 浏览器自动化",
+    "description": "通过无头浏览器进行截屏、点击、输入等自动化操作(首次运行会下载 Chromium)。"
+  },
+  "everything": {
+    "title": "MCP 全功能示例服务器",
+    "description": "官方测试服务器,涵盖 MCP 的全部能力——用于调试本地配置。"
+  },
+  "fetch": {
+    "title": "网页抓取",
+    "description": "抓取并解析远程网页,将正文转换为 Markdown 供代理阅读。"
+  },
+  "git": {
+    "title": "Git 仓库",
+    "description": "在本地 Git 仓库上执行只读检查:diff、log、blame 与文件历史。"
+  },
+  "sqlite": {
+    "title": "SQLite 数据库",
+    "description": "对本地 SQLite 数据库进行只读 SQL 查询,适合分析与原型开发。"
+  },
+  "postgres": {
+    "title": "PostgreSQL 数据库",
+    "description": "对 PostgreSQL 数据库进行只读 SQL 查询并返回行结果。"
+  },
+  "slack": {
+    "title": "Slack",
+    "description": "读取频道与会话消息、发布消息(需要 Slack Bot Token)。"
+  },
+  "time": {
+    "title": "时间与时区",
+    "description": "返回当前时间、做时区换算,适合需要明确时间戳的代理。"
+  }
+}

--- a/tests/mcp-marketplace-overlay.test.ts
+++ b/tests/mcp-marketplace-overlay.test.ts
@@ -1,0 +1,72 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  applyOverlay,
+  clearOverlayCache,
+  loadOverlay,
+} from "../src/mcp/marketplace-overlay/loader.js";
+import type { RegistryEntry } from "../src/mcp/registry-types.js";
+
+const filesystemEntry: RegistryEntry = {
+  name: "filesystem",
+  title: "Filesystem",
+  description: "Grants the agent read/write inside a sandboxed directory.",
+  source: "local",
+  install: { runtime: "npm", packageId: "@modelcontextprotocol/server-filesystem", transport: "stdio" },
+};
+
+const unknownEntry: RegistryEntry = {
+  name: "io.example/zzz-unknown",
+  title: "Zzz Unknown",
+  description: "Not in any overlay.",
+  source: "official",
+};
+
+describe("marketplace overlay loader", () => {
+  afterEach(() => {
+    clearOverlayCache();
+  });
+
+  it("applies the overlay for a seeded entry under zh-CN", () => {
+    const result = applyOverlay(filesystemEntry, "zh-CN");
+    expect(result.title).toBe("文件系统");
+    expect(result.description).toContain("沙箱");
+    expect(result.englishTitle).toBe("Filesystem");
+  });
+
+  it("falls through to upstream when no overlay key matches", () => {
+    const result = applyOverlay(unknownEntry, "zh-CN");
+    expect(result.title).toBe("Zzz Unknown");
+    expect(result.description).toBe("Not in any overlay.");
+    expect(result.englishTitle).toBeUndefined();
+  });
+
+  it("falls through to upstream when language has no bundled overlay (EN)", () => {
+    const result = applyOverlay(filesystemEntry, "EN");
+    expect(result.title).toBe("Filesystem");
+    expect(result.description).toBe(filesystemEntry.description);
+    expect(result.englishTitle).toBeUndefined();
+  });
+
+  it("throws at load time when the JSON file is malformed", () => {
+    const dir = mkdtempSync(join(tmpdir(), "overlay-malformed-"));
+    const path = join(dir, "zh-CN.json");
+    writeFileSync(path, "{ not valid json");
+    expect(() => loadOverlay("zh-CN", path)).toThrow(/malformed/);
+  });
+
+  it("throws at load time when an entry is missing required fields", () => {
+    const dir = mkdtempSync(join(tmpdir(), "overlay-shape-"));
+    const path = join(dir, "zh-CN.json");
+    writeFileSync(path, JSON.stringify({ foo: { title: "x" } }));
+    expect(() => loadOverlay("zh-CN", path)).toThrow(/title \+ description/);
+  });
+
+  it("caches per language so repeated reads do not re-parse", () => {
+    const first = loadOverlay("zh-CN");
+    const second = loadOverlay("zh-CN");
+    expect(second).toBe(first);
+  });
+});


### PR DESCRIPTION
## Summary
Adds a community-maintained localization overlay so MCP marketplace rows can render locale-specific title/description while keeping the upstream English title visible as a secondary line. Ships a zh-CN seed for the most common registry entries (filesystem, fetch, git, sqlite, github, slack, …); non-seeded entries fall through to the upstream English text verbatim. Search and registry keys continue to use the canonical English `entry.name`, so nothing changes about install behavior or matching.

## Changes
- Add `src/mcp/marketplace-overlay/loader.ts` with `loadOverlay(lang)` (cached, validated at module load) and `applyOverlay(entry, lang)` returning `{ title, description, englishTitle? }`. Malformed overlay JSON throws with the offending file/key in the message.
- Add `src/mcp/marketplace-overlay/zh-CN.json` seeded with 11 high-traffic entries (`filesystem`, `memory`, `github`, `puppeteer`, `everything`, `fetch`, `git`, `sqlite`, `postgres`, `slack`, `time`), keyed by `entry.name`.
- Wire `src/cli/ui/McpMarketplace.tsx`: picker snapshot and the detail panel now go through `applyOverlay` using `getLanguage()`. When an overlay hit replaces the title, the upstream English title is rendered as a dimmed second line; the spec/needs lines are unchanged.
- Wire `src/cli/commands/mcp-browse.tsx` the same way — detail block extracted into a small `BrowseDetail` component that calls `applyOverlay`.
- Add `tests/mcp-marketplace-overlay.test.ts` covering: overlay hit returns localized fields + retains `englishTitle`, overlay miss falls through to upstream, and malformed JSON throws at load time.

## Testing
- `npm test -- mcp-marketplace-overlay` — passes locally.
- Type-check via the project's existing TS build passes; no other test files were touched.
- No manual TUI verification beyond unit coverage; the render-site changes are mechanical swaps of `selected.title`/`selected.description` for the overlay result.

## Notes
- Overlay keys are intentionally the registry `entry.name` (qualified id) rather than the catalog title, so the same key works across upstream registry shape changes.
- Only zh-CN is seeded here, matching the issue's seed-locale guidance. Adding another locale is a new JSON file plus one line in `BUNDLED` in `loader.ts`.
- The bundled JSON is imported directly (`import zhCNRaw from "./zh-CN.json"`) — relies on the existing `resolveJsonModule` setting. If a future build target strips JSON imports, the loader's `overlayPath` escape hatch can be promoted to the default path.

Closes #695