### PR TITLE
feat(memory): user-defined memory types with priority + expires

### DIFF
--- a/src/cli/ui/slash/handlers/memory.ts
+++ b/src/cli/ui/slash/handlers/memory.ts
@@ -1,9 +1,33 @@
 import { basename } from "node:path";
 import { t } from "@/i18n/index.js";
 import { PROJECT_MEMORY_FILE, memoryEnabled, readProjectMemory } from "@/memory/project.js";
-import { type MemoryScope, MemoryStore } from "@/memory/user.js";
+import { type MemoryScope, MemoryStore, effectivePriority } from "@/memory/user.js";
 import type { SlashHandler } from "../dispatch.js";
 import { resolveMemoryTarget } from "../helpers.js";
+
+/** Parses optional flags out of a slash-arg list. Returns the type filter (`--type X` or `--type=X`) and the residue without those tokens. */
+function pickTypeFlag(args: string[]): { type: string | null; rest: string[] } {
+  const rest: string[] = [];
+  let type: string | null = null;
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i] ?? "";
+    if (a === "--type" || a === "-t") {
+      const next = args[i + 1];
+      if (next) {
+        type = next;
+        i++;
+      }
+      continue;
+    }
+    const eq = a.match(/^--type=(.+)$/);
+    if (eq) {
+      type = eq[1] ?? null;
+      continue;
+    }
+    rest.push(a);
+  }
+  return { type, rest };
+}
 
 const memory: SlashHandler = (args, _loop, ctx) => {
   if (!memoryEnabled()) {
@@ -13,19 +37,30 @@ const memory: SlashHandler = (args, _loop, ctx) => {
     return { info: t("handlers.memory.noRoot") };
   }
   const store = new MemoryStore({ projectRoot: ctx.codeRoot });
-  const sub = (args[0] ?? "").toLowerCase();
+  const { type: typeFilter, rest: filteredArgs } = pickTypeFlag(args);
+  const sub = (filteredArgs[0] ?? args[0] ?? "").toLowerCase();
 
   if (sub === "list" || sub === "ls") {
-    const entries = store.list();
+    const all = store.list();
+    const entries = typeFilter ? all.filter((e) => e.type === typeFilter) : all;
     if (entries.length === 0) {
-      return { info: t("handlers.memory.listEmpty") };
+      return {
+        info: typeFilter
+          ? `no memories with type='${typeFilter}'. (${all.length} total across all types)`
+          : t("handlers.memory.listEmpty"),
+      };
     }
-    const lines = [t("handlers.memory.listHeader", { count: entries.length })];
+    const header = typeFilter
+      ? `▸ memory entries — type=${typeFilter} (${entries.length}/${all.length})`
+      : t("handlers.memory.listHeader", { count: entries.length });
+    const lines = [header];
     for (const e of entries) {
+      const prio = effectivePriority(e);
+      const marker = prio === "high" ? "⚠ " : prio === "low" ? "· " : "  ";
       const tag = `${e.scope}/${e.type}`.padEnd(18);
       const name = e.name.padEnd(28);
       const desc = e.description.length > 70 ? `${e.description.slice(0, 69)}…` : e.description;
-      lines.push(`  ${tag}  ${name}  ${desc}`);
+      lines.push(`${marker}${tag}  ${name}  ${desc}`);
     }
     lines.push("");
     lines.push(t("handlers.memory.listFooter"));
@@ -83,16 +118,29 @@ const memory: SlashHandler = (args, _loop, ctx) => {
       };
     }
     const scope = rawScope as MemoryScope;
-    const entries = store.list().filter((e) => e.scope === scope);
+    const all = store.list();
+    const inScope = all.filter((e) => e.scope === scope);
+    const expiring =
+      scope === "project"
+        ? all.filter((e) => e.scope === "global" && e.expires === "project_end")
+        : [];
     let deleted = 0;
-    for (const e of entries) {
+    for (const e of inScope) {
       try {
         if (store.delete(scope, e.name)) deleted++;
       } catch {
         /* skip */
       }
     }
-    return { info: t("handlers.memory.cleared", { scope, count: deleted }) };
+    for (const e of expiring) {
+      try {
+        if (store.delete("global", e.name)) deleted++;
+      } catch {
+        /* skip */
+      }
+    }
+    const extra = expiring.length > 0 ? ` (+${expiring.length} global expires=project_end)` : "";
+    return { info: `${t("handlers.memory.cleared", { scope, count: deleted })}${extra}` };
   }
 
   const parts: string[] = [];

--- a/src/config.ts
+++ b/src/config.ts
@@ -120,6 +120,70 @@ export interface ReasonixConfig {
   };
   index?: IndexUserConfig;
   semantic?: SemanticEmbeddingUserConfig;
+  /** User-declared extensions to the built-in memory types (#709). Unknown types round-trip even without a declaration; declaring one lets you attach a default priority + lifecycle. */
+  memory?: {
+    customTypes?: CustomMemoryTypeConfig[];
+  };
+}
+
+export interface CustomMemoryTypeConfig {
+  name: string;
+  description?: string;
+  priority?: "low" | "medium" | "high";
+  expires?: "project_end";
+}
+
+export interface MemoryTypeRegistryEntry {
+  name: string;
+  builtin: boolean;
+  description?: string;
+  priority?: "low" | "medium" | "high";
+  expires?: "project_end";
+}
+
+const BUILTIN_TYPE_DOCS: Record<string, string> = {
+  user: "role / skills / preferences",
+  feedback: "corrections or confirmed approaches",
+  project: "facts / decisions about the current work",
+  reference: "pointers to external systems the user uses",
+};
+
+/** Resolve the merged registry of memory types — built-ins, overlaid by anything in `config.memory.customTypes`. */
+export function loadMemoryTypeRegistry(
+  cfg: ReasonixConfig = readConfig(),
+): MemoryTypeRegistryEntry[] {
+  const out: MemoryTypeRegistryEntry[] = [];
+  for (const name of ["user", "feedback", "project", "reference"]) {
+    out.push({ name, builtin: true, description: BUILTIN_TYPE_DOCS[name] });
+  }
+  const seen = new Set(out.map((e) => e.name));
+  for (const raw of cfg.memory?.customTypes ?? []) {
+    if (!raw || typeof raw.name !== "string") continue;
+    const name = raw.name.trim();
+    if (!name || !/^[a-zA-Z][a-zA-Z0-9_-]{0,31}$/.test(name)) continue;
+    if (seen.has(name)) continue;
+    seen.add(name);
+    const entry: MemoryTypeRegistryEntry = { name, builtin: false };
+    if (typeof raw.description === "string") entry.description = raw.description;
+    if (raw.priority === "low" || raw.priority === "medium" || raw.priority === "high") {
+      entry.priority = raw.priority;
+    }
+    if (raw.expires === "project_end") entry.expires = raw.expires;
+    out.push(entry);
+  }
+  return out;
+}
+
+export function memoryTypeDefaults(
+  typeName: string,
+  cfg: ReasonixConfig = readConfig(),
+): { priority?: "low" | "medium" | "high"; expires?: "project_end" } {
+  const found = loadMemoryTypeRegistry(cfg).find((e) => e.name === typeName);
+  if (!found) return {};
+  const out: { priority?: "low" | "medium" | "high"; expires?: "project_end" } = {};
+  if (found.priority) out.priority = found.priority;
+  if (found.expires) out.expires = found.expires;
+  return out;
 }
 
 const DEFAULT_OLLAMA_URL = "http://localhost:11434";

--- a/src/memory/user.ts
+++ b/src/memory/user.ts
@@ -11,6 +11,7 @@ import {
 } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
+import { type ReasonixConfig, memoryTypeDefaults } from "../config.js";
 import { parseFrontmatter } from "../frontmatter.js";
 import { applySkillsIndex } from "../skills.js";
 import { applyProjectMemory, memoryEnabled } from "./project.js";
@@ -20,8 +21,13 @@ export const MEMORY_INDEX_FILE = "MEMORY.md";
 /** Cap on the index file content loaded into the prefix, per scope. */
 export const MEMORY_INDEX_MAX_CHARS = 4000;
 
-export type MemoryType = "user" | "feedback" | "project" | "reference";
+export const BUILTIN_MEMORY_TYPES = ["user", "feedback", "project", "reference"] as const;
+export type BuiltinMemoryType = (typeof BUILTIN_MEMORY_TYPES)[number];
+/** Built-ins plus any string declared in `config.memory.customTypes`. Unknown values are accepted (round-tripped verbatim). */
+export type MemoryType = BuiltinMemoryType | (string & {});
 export type MemoryScope = "global" | "project";
+export type MemoryPriority = "low" | "medium" | "high";
+export type MemoryExpires = "project_end";
 
 export interface MemoryEntry {
   name: string;
@@ -31,6 +37,10 @@ export interface MemoryEntry {
   body: string;
   /** ISO date string (YYYY-MM-DD). */
   createdAt: string;
+  /** Explicit per-entry priority; absent → resolve from config default for `type`, else "medium". */
+  priority?: MemoryPriority;
+  /** Lifecycle hint. `project_end` → cleared by `/memory clear project`. */
+  expires?: MemoryExpires;
 }
 
 export interface MemoryStoreOptions {
@@ -46,6 +56,8 @@ export interface WriteInput {
   scope: MemoryScope;
   description: string;
   body: string;
+  priority?: MemoryPriority;
+  expires?: MemoryExpires;
 }
 
 const VALID_NAME = /^[a-zA-Z0-9_-][a-zA-Z0-9_.-]{1,38}[a-zA-Z0-9]$/;
@@ -82,16 +94,26 @@ function ensureDir(p: string): void {
 }
 
 function formatFrontmatter(e: WriteInput & { createdAt: string }): string {
-  return [
+  const lines = [
     "---",
     `name: ${e.name}`,
     `description: ${e.description.replace(/\n/g, " ")}`,
     `type: ${e.type}`,
     `scope: ${e.scope}`,
     `created: ${e.createdAt}`,
-    "---",
-    "",
-  ].join("\n");
+  ];
+  if (e.priority) lines.push(`priority: ${e.priority}`);
+  if (e.expires) lines.push(`expires: ${e.expires}`);
+  lines.push("---", "");
+  return lines.join("\n");
+}
+
+function coercePriority(v: unknown): MemoryPriority | undefined {
+  return v === "low" || v === "medium" || v === "high" ? v : undefined;
+}
+
+function coerceExpires(v: unknown): MemoryExpires | undefined {
+  return v === "project_end" ? v : undefined;
 }
 
 function todayIso(): string {
@@ -165,7 +187,7 @@ export class MemoryStore {
     }
     const raw = readFileSync(file, "utf8");
     const { data, body } = parseFrontmatter(raw);
-    return {
+    const entry: MemoryEntry = {
       name: data.name ?? name,
       type: (data.type as MemoryType) ?? "project",
       scope: (data.scope as MemoryScope) ?? scope,
@@ -173,6 +195,11 @@ export class MemoryStore {
       body: body.trim(),
       createdAt: data.created ?? "",
     };
+    const priority = coercePriority(data.priority);
+    if (priority) entry.priority = priority;
+    const expires = coerceExpires(data.expires);
+    if (expires) entry.expires = expires;
+    return entry;
   }
 
   /** Skips malformed files — index stays queryable even if one file is hand-edited into nonsense. */
@@ -218,6 +245,8 @@ export class MemoryStore {
       body,
       createdAt: todayIso(),
     };
+    if (input.priority) entry.priority = input.priority;
+    if (input.expires) entry.expires = input.expires;
     const dir = this.dir(input.scope);
     const file = join(dir, `${name}.md`);
     const content = `${formatFrontmatter(entry)}${body}\n`;
@@ -314,17 +343,46 @@ export function applyGlobalReasonixMemory(basePrompt: string, homeDir?: string):
   ].join("\n");
 }
 
+/** Effective priority: entry's own field wins, else the config default for its type, else undefined. */
+export function effectivePriority(
+  entry: MemoryEntry,
+  cfg?: ReasonixConfig,
+): MemoryPriority | undefined {
+  if (entry.priority) return entry.priority;
+  return memoryTypeDefaults(entry.type, cfg).priority;
+}
+
+function highPriorityBlock(entries: MemoryEntry[], cfg?: ReasonixConfig): string | null {
+  const high = entries.filter((e) => effectivePriority(e, cfg) === "high");
+  if (high.length === 0) return null;
+  const lines: string[] = [
+    "# HIGH PRIORITY constraints (must observe)",
+    "",
+    "These memories were declared `priority: high` (via config.memory.customTypes or the memory file itself). Treat them as hard rules — violations override any other guidance below.",
+    "",
+  ];
+  for (const e of high) {
+    const head = `!!! [${e.scope}/${e.type}/${e.name}] ${e.description || "(no description)"}`;
+    lines.push(head);
+    if (e.body) lines.push("", e.body);
+    lines.push("");
+  }
+  return lines.join("\n").trimEnd();
+}
+
 /** Empty index → omit the whole block (otherwise we'd add bytes to the prefix hash for nothing). */
 export function applyUserMemory(
   basePrompt: string,
-  opts: { homeDir?: string; projectRoot?: string } = {},
+  opts: { homeDir?: string; projectRoot?: string; cfg?: ReasonixConfig } = {},
 ): string {
   if (!memoryEnabled()) return basePrompt;
   const store = new MemoryStore(opts);
   const global = store.loadIndex("global");
   const project = store.hasProjectScope() ? store.loadIndex("project") : null;
-  if (!global && !project) return basePrompt;
+  const high = highPriorityBlock(store.list(), opts.cfg);
+  if (!global && !project && !high) return basePrompt;
   const parts: string[] = [basePrompt];
+  if (high) parts.push("", high);
   if (global) {
     parts.push(
       "",

--- a/src/tools/memory.ts
+++ b/src/tools/memory.ts
@@ -1,6 +1,9 @@
 /** Writes are eager but the prefix is NOT re-loaded mid-session — keeps prompt-cache stable. */
 
+import { loadMemoryTypeRegistry } from "../config.js";
 import {
+  type MemoryExpires,
+  type MemoryPriority,
   type MemoryScope,
   MemoryStore,
   type MemoryType,
@@ -22,6 +25,17 @@ export function registerMemoryTools(
   const store = new MemoryStore({ homeDir: opts.homeDir, projectRoot: opts.projectRoot });
   const hasProject = store.hasProjectScope();
 
+  const registry_types = loadMemoryTypeRegistry();
+  const customTypeNames = registry_types.filter((r) => !r.builtin).map((r) => r.name);
+  const typeDescParts = [
+    "'user' = role/skills/prefs; 'feedback' = corrections or confirmed approaches; 'project' = facts/decisions about the current work; 'reference' = pointers to external systems the user uses.",
+  ];
+  if (customTypeNames.length > 0) {
+    typeDescParts.push(
+      `Custom types declared in config: ${customTypeNames.join(", ")}. Any string is accepted; unknown types are stored verbatim and treated as 'reference' priority.`,
+    );
+  }
+
   registry.register({
     name: "remember",
     description:
@@ -31,9 +45,7 @@ export function registerMemoryTools(
       properties: {
         type: {
           type: "string",
-          enum: ["user", "feedback", "project", "reference"],
-          description:
-            "'user' = role/skills/prefs; 'feedback' = corrections or confirmed approaches; 'project' = facts/decisions about the current work; 'reference' = pointers to external systems the user uses.",
+          description: typeDescParts.join(" "),
         },
         scope: {
           type: "string",
@@ -55,6 +67,18 @@ export function registerMemoryTools(
           description:
             "Full memory body in markdown. For feedback/project types, structure as: rule/fact, then **Why:** line, then **How to apply:** line.",
         },
+        priority: {
+          type: "string",
+          enum: ["low", "medium", "high"],
+          description:
+            "Optional per-memory priority. `high` injects the entry into a `# HIGH PRIORITY constraints` block at the top of the system prompt — use sparingly, only for hard rules the model must never violate.",
+        },
+        expires: {
+          type: "string",
+          enum: ["project_end"],
+          description:
+            "Optional lifecycle hint. `project_end` causes `/memory clear project` to also remove this entry even when it's stored at global scope.",
+        },
       },
       required: ["type", "scope", "name", "description", "content"],
     },
@@ -64,6 +88,8 @@ export function registerMemoryTools(
       name: string;
       description: string;
       content: string;
+      priority?: MemoryPriority;
+      expires?: MemoryExpires;
     }) => {
       if (args.scope === "project" && !hasProject) {
         return JSON.stringify({
@@ -78,6 +104,8 @@ export function registerMemoryTools(
           scope: args.scope,
           description: args.description,
           body: args.content,
+          ...(args.priority ? { priority: args.priority } : {}),
+          ...(args.expires ? { expires: args.expires } : {}),
         });
         const key = sanitizeMemoryName(args.name);
         // The return text is load-bearing: it's the ONLY thing keeping

--- a/tests/memory-custom-types.test.ts
+++ b/tests/memory-custom-types.test.ts
@@ -1,0 +1,258 @@
+/** User-defined memory types — config-driven priority + expires (#709). */
+
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  type CustomMemoryTypeConfig,
+  type ReasonixConfig,
+  loadMemoryTypeRegistry,
+  memoryTypeDefaults,
+} from "../src/config.js";
+import { MemoryStore, applyUserMemory, effectivePriority } from "../src/memory/user.js";
+
+function cfgWith(types: CustomMemoryTypeConfig[]): ReasonixConfig {
+  return { memory: { customTypes: types } };
+}
+
+describe("custom memory types (#709)", () => {
+  let home: string;
+  let projectRoot: string;
+  const originalEnv = process.env.REASONIX_MEMORY;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "reasonix-memtype-home-"));
+    projectRoot = mkdtempSync(join(tmpdir(), "reasonix-memtype-proj-"));
+    // biome-ignore lint/performance/noDelete: avoid leaking "undefined" into env
+    delete process.env.REASONIX_MEMORY;
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(projectRoot, { recursive: true, force: true });
+    if (originalEnv === undefined) {
+      // biome-ignore lint/performance/noDelete: same
+      delete process.env.REASONIX_MEMORY;
+    } else {
+      process.env.REASONIX_MEMORY = originalEnv;
+    }
+  });
+
+  describe("loadMemoryTypeRegistry", () => {
+    it("returns the four built-ins when no config is provided", () => {
+      const reg = loadMemoryTypeRegistry({});
+      expect(reg.map((r) => r.name)).toEqual(["user", "feedback", "project", "reference"]);
+      expect(reg.every((r) => r.builtin)).toBe(true);
+    });
+
+    it("overlays validated custom types with defaults", () => {
+      const reg = loadMemoryTypeRegistry(
+        cfgWith([
+          { name: "security", priority: "high" },
+          { name: "design_system", priority: "medium" },
+          { name: "deploy_checklist", priority: "medium", expires: "project_end" },
+        ]),
+      );
+      const security = reg.find((r) => r.name === "security");
+      expect(security?.builtin).toBe(false);
+      expect(security?.priority).toBe("high");
+      expect(reg.find((r) => r.name === "deploy_checklist")?.expires).toBe("project_end");
+    });
+
+    it("rejects invalid type names and conflicting built-ins", () => {
+      const reg = loadMemoryTypeRegistry(
+        cfgWith([
+          { name: "../etc" } as CustomMemoryTypeConfig,
+          { name: "" } as CustomMemoryTypeConfig,
+          { name: "user", priority: "high" },
+        ]),
+      );
+      expect(reg.filter((r) => r.builtin).length).toBe(4);
+      expect(reg.find((r) => r.name === "user")?.builtin).toBe(true);
+      expect(reg.find((r) => r.name === "../etc")).toBeUndefined();
+    });
+  });
+
+  describe("MemoryStore round-trip with priority + expires", () => {
+    it("persists and reads priority + expires fields", () => {
+      const store = new MemoryStore({ homeDir: home, projectRoot });
+      store.write({
+        name: "no-secrets",
+        type: "security",
+        scope: "global",
+        description: "never hardcode credentials in source files",
+        body: "API keys live in env files only. Reject any diff that inlines a secret.",
+        priority: "high",
+      });
+      const file = store.pathFor("global", "no-secrets");
+      const raw = readFileSync(file, "utf8");
+      expect(raw).toContain("type: security");
+      expect(raw).toContain("priority: high");
+
+      const back = store.read("global", "no-secrets");
+      expect(back.type).toBe("security");
+      expect(back.priority).toBe("high");
+      expect(back.expires).toBeUndefined();
+    });
+
+    it("round-trips `expires: project_end`", () => {
+      const store = new MemoryStore({ homeDir: home, projectRoot });
+      store.write({
+        name: "release-freeze",
+        type: "deploy_checklist",
+        scope: "global",
+        description: "no merges until release branch cuts",
+        body: "Hold non-critical merges until 2026-05-15.",
+        expires: "project_end",
+      });
+      const back = store.read("global", "release-freeze");
+      expect(back.expires).toBe("project_end");
+    });
+  });
+
+  describe("effectivePriority", () => {
+    it("uses the entry's own priority when present", () => {
+      expect(
+        effectivePriority({
+          name: "x",
+          type: "reference",
+          scope: "global",
+          description: "",
+          body: "",
+          createdAt: "",
+          priority: "high",
+        }),
+      ).toBe("high");
+    });
+
+    it("falls back to config default for the type", () => {
+      const cfg = cfgWith([{ name: "security", priority: "high" }]);
+      expect(
+        effectivePriority(
+          {
+            name: "x",
+            type: "security",
+            scope: "global",
+            description: "",
+            body: "",
+            createdAt: "",
+          },
+          cfg,
+        ),
+      ).toBe("high");
+    });
+
+    it("returns undefined when neither the entry nor the type registers a priority", () => {
+      expect(
+        effectivePriority({
+          name: "x",
+          type: "reference",
+          scope: "global",
+          description: "",
+          body: "",
+          createdAt: "",
+        }),
+      ).toBeUndefined();
+    });
+  });
+
+  describe("memoryTypeDefaults", () => {
+    it("returns config-declared priority + expires for a known custom type", () => {
+      const cfg = cfgWith([
+        { name: "deploy_checklist", priority: "medium", expires: "project_end" },
+      ]);
+      expect(memoryTypeDefaults("deploy_checklist", cfg)).toEqual({
+        priority: "medium",
+        expires: "project_end",
+      });
+    });
+
+    it("returns empty defaults for built-ins (they have no priority by default)", () => {
+      expect(memoryTypeDefaults("project", {})).toEqual({});
+    });
+
+    it("returns empty defaults for entirely unknown types", () => {
+      expect(memoryTypeDefaults("something_unregistered", {})).toEqual({});
+    });
+  });
+
+  describe("applyUserMemory injects HIGH PRIORITY block", () => {
+    it("prepends a HIGH PRIORITY section when any entry resolves to priority: high", () => {
+      const store = new MemoryStore({ homeDir: home, projectRoot });
+      store.write({
+        name: "no-prod-writes",
+        type: "security",
+        scope: "global",
+        description: "never run write queries against prod DBs",
+        body: "All migrations go through the staging pipeline first.",
+        priority: "high",
+      });
+      store.write({
+        name: "naming-style",
+        type: "user",
+        scope: "global",
+        description: "use kebab-case for filenames",
+        body: "kebab-case throughout.",
+      });
+
+      const out = applyUserMemory("BASE", { homeDir: home, projectRoot });
+      expect(out).toContain("# HIGH PRIORITY constraints (must observe)");
+      expect(out).toContain("!!! [global/security/no-prod-writes]");
+      expect(out).toContain("never run write queries against prod DBs");
+      expect(out).toContain("# User memory — global");
+      // Regular naming-style entry is in the regular index, not the high-priority block:
+      const high = out.split("# User memory")[0] ?? "";
+      expect(high).not.toContain("naming-style");
+    });
+
+    it("does not produce a HIGH PRIORITY block when no entry is high-priority", () => {
+      const store = new MemoryStore({ homeDir: home, projectRoot });
+      store.write({
+        name: "naming-style",
+        type: "user",
+        scope: "global",
+        description: "use kebab-case for filenames",
+        body: "kebab-case throughout.",
+      });
+      const out = applyUserMemory("BASE", { homeDir: home, projectRoot });
+      expect(out).not.toContain("HIGH PRIORITY constraints");
+    });
+
+    it("treats config-driven priority for a custom type as high priority", () => {
+      const store = new MemoryStore({ homeDir: home, projectRoot });
+      store.write({
+        name: "modal-component",
+        type: "design_system",
+        scope: "global",
+        description: "all modals must use the shared Modal component",
+        body: "Use @ui/Modal — never roll your own.",
+      });
+
+      const cfg = cfgWith([{ name: "design_system", priority: "high" }]);
+      const out = applyUserMemory("BASE", { homeDir: home, projectRoot, cfg });
+      expect(out).toContain("# HIGH PRIORITY constraints (must observe)");
+      expect(out).toContain("!!! [global/design_system/modal-component]");
+    });
+  });
+
+  describe("unknown types fall through verbatim", () => {
+    it("accepts any string for `type` and preserves it on read", () => {
+      const store = new MemoryStore({ homeDir: home, projectRoot });
+      store.write({
+        name: "experimental",
+        type: "performance_budget",
+        scope: "global",
+        description: "p99 latency budget",
+        body: "p99 < 200ms.",
+      });
+      const back = store.read("global", "experimental");
+      expect(back.type).toBe("performance_budget");
+    });
+  });
+});
+
+it("exists", () => {
+  // top-level placeholder so `vitest --reporter=verbose` shows the file even if all describe blocks are skipped
+  expect(existsSync(__filename)).toBe(true);
+});


### PR DESCRIPTION
## Summary

Resolves the limitation called out in #709 — the four hardcoded memory types (`user` / `feedback` / `project` / `reference`) collapse qualitatively different categories into the same bucket. A team using Reasonix for non-trivial work ends up filing security rules, design-system conventions, deploy checklists, and external references under `reference`, and the model treats them all with the same weight.

This PR opens the type field to user-declared values and gives the model a real signal for which entries are load-bearing.

### What's new

**Config**
```yaml
# ~/.reasonix/config.json
{
  "memory": {
    "customTypes": [
      { "name": "security",         "priority": "high" },
      { "name": "design_system",    "priority": "medium" },
      { "name": "deploy_checklist", "priority": "medium", "expires": "project_end" }
    ]
  }
}
```

**`MemoryEntry` shape** — gains optional `priority: low | medium | high` and `expires: project_end`. Both round-trip through frontmatter; existing memory files parse unchanged.

**System prompt** — `applyUserMemory` collects entries whose effective priority is `high` (own field OR config default for their type) and prepends a `# HIGH PRIORITY constraints (must observe)` block with `!!! [scope/type/name]` headings. The regular memory index sits below as before, so the model can't miss a security constraint just because it ended up near the bottom of a 50-entry list.

**`/memory list --type X`** filters by type. Each row gets `⚠` for high-priority and `·` for low.

**`/memory clear project confirm`** additionally removes any global-scope entry tagged `expires: project_end` — useful for memories whose lifecycle is tied to the project's, even though they live at the global layer.

**`remember` tool** drops the hardcoded enum, surfaces the config-declared types in its description, and accepts `priority` / `expires` parameters.

### Backward compatibility

Zero. Empty config → behavior identical to before. Memory files without the new frontmatter keys parse exactly as before. The four built-in types still exist and stay first in the registry.

### Test plan

- [x] `npm run verify` — 178 files, 2706 tests pass
- [x] `tests/memory-custom-types.test.ts` — 16 new tests covering:
  - registry merge (built-ins + custom, rejects invalid names + builtin collisions)
  - `priority` / `expires` round-trip via frontmatter
  - `effectivePriority` falls back from entry → config default → undefined
  - `applyUserMemory` injects the HIGH PRIORITY block when (and only when) an entry resolves to high
  - config-driven priority on a custom type counts as high
  - unknown type strings are stored verbatim

Closes #709
