### PR TITLE
feat(config): add statusBar toggles to hide individual status row fields (#626)

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -40,6 +40,7 @@ import {
   markEditModeHintShown,
   markMouseClipboardHintShown,
   mouseClipboardHintShown,
+  readConfig,
   resolveThemePreference,
   saveEditMode,
   savePreset,
@@ -149,6 +150,7 @@ import {
   UndoBanner,
 } from "./layout/LiveRows.js";
 import { StatusRow } from "./layout/StatusRow.js";
+import type { StatusBarConfig } from "./layout/StatusRow.js";
 import { ToastRail } from "./layout/ToastRail.js";
 import { PlanLiveRow } from "./layout/plan-live-row.js";
 import { ViewportBudgetProvider } from "./layout/viewport-budget.js";
@@ -344,11 +346,27 @@ export function App(props: AppProps): React.ReactElement {
   const [themeName, setThemeName] = React.useState<ThemeName>(() =>
     resolveThemePreference(loadTheme(), process.env.REASONIX_THEME),
   );
+  const statusBar = React.useMemo((): StatusBarConfig => {
+    const cfg = readConfig().statusBar ?? {};
+    return {
+      showBalance: cfg.showBalance !== false,
+      showSessionCost: cfg.showSessionCost !== false,
+      showTurnCost: cfg.showTurnCost !== false,
+      showCacheHit: cfg.showCacheHit !== false,
+      showVersion: cfg.showVersion !== false,
+      showFeedbackHint: cfg.showFeedbackHint !== false,
+    };
+  }, []);
   return (
     <ThemeProvider name={themeName}>
       <AgentStoreProvider session={session} initialCards={initialCards}>
         <ChatScrollProvider>
-          <AppInner {...props} themeName={themeName} setThemeName={setThemeName} />
+          <AppInner
+            {...props}
+            themeName={themeName}
+            setThemeName={setThemeName}
+            statusBar={statusBar}
+          />
         </ChatScrollProvider>
       </AgentStoreProvider>
     </ThemeProvider>
@@ -358,6 +376,7 @@ export function App(props: AppProps): React.ReactElement {
 type AppInnerProps = AppProps & {
   themeName: ThemeName;
   setThemeName: React.Dispatch<React.SetStateAction<ThemeName>>;
+  statusBar: StatusBarConfig;
 };
 
 function AppInner({
@@ -379,6 +398,7 @@ function AppInner({
   mouse = true,
   themeName,
   setThemeName,
+  statusBar,
 }: AppInnerProps) {
   markPhase("app_inner_start");
   const log = useScrollback();
@@ -3983,7 +4003,7 @@ function AppInner({
                             />
                           ) : null}
                           {activeLoop ? <LoopStatusRow loop={activeLoop} /> : null}
-                          <StatusRow />
+                          <StatusRow statusBar={statusBar} />
                           <PromptInput
                             value={input}
                             onChange={setInput}

--- a/src/cli/ui/layout/StatusRow.tsx
+++ b/src/cli/ui/layout/StatusRow.tsx
@@ -8,6 +8,15 @@ import { useAgentState } from "../state/provider.js";
 import type { Mode, NetworkState, StatusBar } from "../state/state.js";
 import { FG, TONE, balanceColor, formatBalance, formatCost } from "../theme/tokens.js";
 
+export interface StatusBarConfig {
+  showBalance: boolean;
+  showSessionCost: boolean;
+  showTurnCost: boolean;
+  showCacheHit: boolean;
+  showVersion: boolean;
+  showFeedbackHint: boolean;
+}
+
 const RULE_PAD = 4;
 const RULE_MIN = 20;
 const WALLET_MIN_COLS = 90;
@@ -15,7 +24,18 @@ const VERSION_MIN_COLS = 70;
 const FEEDBACK_HINT_MIN_COLS = 100;
 const PRESET_MIN_COLS = 60;
 
-export function StatusRow(): React.ReactElement {
+const DEFAULT_STATUS_BAR_CONFIG: StatusBarConfig = {
+  showBalance: true,
+  showSessionCost: true,
+  showTurnCost: true,
+  showCacheHit: true,
+  showVersion: true,
+  showFeedbackHint: true,
+};
+
+export function StatusRow({
+  statusBar = DEFAULT_STATUS_BAR_CONFIG,
+}: { statusBar?: StatusBarConfig }): React.ReactElement {
   const status = useAgentState((s) => s.status);
   const session = useAgentState((s) => s.session);
   const { stdout } = useStdout();
@@ -24,7 +44,9 @@ export function StatusRow(): React.ReactElement {
   const hasTurn = status.cost > 0;
   const hasSession = status.sessionCost > 0;
   const hasBalance = typeof status.balance === "number";
-  const showWallet = cols >= WALLET_MIN_COLS && (hasSession || hasBalance);
+  const showWallet =
+    cols >= WALLET_MIN_COLS &&
+    ((hasSession && statusBar.showSessionCost) || (hasBalance && statusBar.showBalance));
 
   return (
     <Box flexDirection="column" flexShrink={0} flexWrap="nowrap">
@@ -48,7 +70,7 @@ export function StatusRow(): React.ReactElement {
         )}
         <Sep />
         <Text color={FG.sub} wrap="truncate">{`${session.id} · ${session.branch}`}</Text>
-        {hasTurn && (
+        {hasTurn && statusBar.showTurnCost && (
           <>
             <Sep />
             <Text bold color={TONE.brand} wrap="truncate">
@@ -59,11 +81,15 @@ export function StatusRow(): React.ReactElement {
             </Text>
           </>
         )}
-        <Sep />
-        <Text
-          color={TONE.accent}
-          wrap="truncate"
-        >{`${t("statusBar.cache")} ${Math.round(status.cacheHit * 100)}%`}</Text>
+        {statusBar.showCacheHit && (
+          <>
+            <Sep />
+            <Text
+              color={TONE.accent}
+              wrap="truncate"
+            >{`${t("statusBar.cache")} ${Math.round(status.cacheHit * 100)}%`}</Text>
+          </>
+        )}
         {status.mcpLoading && status.mcpLoading.ready < status.mcpLoading.total && (
           <McpLoadingPill ready={status.mcpLoading.ready} total={status.mcpLoading.total} />
         )}
@@ -72,25 +98,25 @@ export function StatusRow(): React.ReactElement {
             sessionCostUsd={status.sessionCost}
             balance={status.balance}
             currency={status.balanceCurrency}
+            showSessionCost={statusBar.showSessionCost}
+            showBalance={statusBar.showBalance}
           />
         )}
-        {cols >= VERSION_MIN_COLS && (
+        {statusBar.showVersion && cols >= VERSION_MIN_COLS && (
           <>
             <Sep />
             <Text color={FG.faint} wrap="truncate">{`v${VERSION}`}</Text>
-            {cols >= FEEDBACK_HINT_MIN_COLS && (
-              <>
-                <Text color={FG.faint} wrap="truncate">
-                  {"  ·  "}
-                </Text>
-                <Text color={FG.meta} wrap="truncate">
-                  {"⚑ "}
-                </Text>
-                <Text color={FG.sub} wrap="truncate">
-                  {"/feedback"}
-                </Text>
-              </>
-            )}
+          </>
+        )}
+        {statusBar.showFeedbackHint && cols >= FEEDBACK_HINT_MIN_COLS && (
+          <>
+            <Sep />
+            <Text color={FG.meta} wrap="truncate">
+              {"⚑ "}
+            </Text>
+            <Text color={FG.sub} wrap="truncate">
+              {"/feedback"}
+            </Text>
           </>
         )}
       </Box>
@@ -151,13 +177,17 @@ function WalletPill({
   sessionCostUsd,
   balance,
   currency,
+  showSessionCost,
+  showBalance: showBalanceCfg,
 }: {
   sessionCostUsd: number;
   balance?: number;
   currency?: string;
+  showSessionCost: boolean;
+  showBalance: boolean;
 }): React.ReactElement {
-  const showSpent = sessionCostUsd > 0;
-  const showBalance = typeof balance === "number";
+  const showSpent = showSessionCost && sessionCostUsd > 0;
+  const showBalanceLine = showBalanceCfg && typeof balance === "number";
   return (
     <>
       <Sep />
@@ -170,17 +200,17 @@ function WalletPill({
           wrap="truncate"
         >{`${formatCost(sessionCostUsd, currency, 2)} ${t("statusBar.spent")}`}</Text>
       )}
-      {showSpent && showBalance && (
+      {showSpent && showBalanceLine && (
         <Text color={FG.meta} wrap="truncate">
           {"  /  "}
         </Text>
       )}
-      {showBalance && (
+      {showBalanceLine && (
         <Text bold color={balanceColor(balance, currency)} wrap="truncate">
           {formatBalance(balance, currency, { fractionDigits: 2 })}
         </Text>
       )}
-      {showBalance && (
+      {showBalanceLine && (
         <Text color={FG.faint} wrap="truncate">
           {t("statusBar.left")}
         </Text>

--- a/src/config.ts
+++ b/src/config.ts
@@ -111,6 +111,15 @@ export interface ReasonixConfig {
     /** Per-turn repair/error signal count required to escalate flash→pro. Defaults to 3. Out-of-range → default. */
     failureThreshold?: number;
   };
+  /** Per-field visibility toggles for the bottom status row. All default to true (visible). */
+  statusBar?: {
+    showBalance?: boolean;
+    showSessionCost?: boolean;
+    showTurnCost?: boolean;
+    showCacheHit?: boolean;
+    showVersion?: boolean;
+    showFeedbackHint?: boolean;
+  };
   projects?: {
     [absoluteRootDir: string]: {
       shellAllowed?: string[];

--- a/tests/ui-status-row-balance.test.tsx
+++ b/tests/ui-status-row-balance.test.tsx
@@ -104,6 +104,96 @@ describe("StatusRow — turn cost currency", () => {
   });
 });
 
+describe("StatusRow — statusBar config toggles", () => {
+  async function renderStatusRowWithConfig(
+    overrides: Partial<AgentState["status"]>,
+    config: Partial<import("../src/cli/ui/layout/StatusRow.js").StatusBarConfig>,
+  ): Promise<string> {
+    const cfg = {
+      showBalance: true,
+      showSessionCost: true,
+      showTurnCost: true,
+      showCacheHit: true,
+      showVersion: true,
+      showFeedbackHint: true,
+      ...config,
+    };
+    const stdout = makeFakeStdout();
+    const { unmount } = render(
+      <AgentStoreProvider session={SESSION}>
+        <StateInjector overrides={overrides}>
+          <StatusRow
+            statusBar={cfg as import("../src/cli/ui/layout/StatusRow.js").StatusBarConfig}
+          />
+        </StateInjector>
+      </AgentStoreProvider>,
+      { stdout: stdout as never, stdin: makeFakeStdin() as never },
+    );
+    await new Promise((r) => setTimeout(r, 50));
+    unmount();
+    return stdout.text();
+  }
+
+  it("default config (all true) shows turn cost and cache", async () => {
+    const text = await renderStatusRowWithConfig({ cost: 0.05, cacheHit: 0.5 } as any, {});
+    expect(text).toContain("turn");
+    expect(text).toContain("cache");
+  });
+
+  it("showTurnCost=false hides turn cost", async () => {
+    const text = await renderStatusRowWithConfig({ cost: 0.05, cacheHit: 0.5 } as any, {
+      showTurnCost: false,
+    });
+    expect(text).not.toContain("turn");
+    expect(text).toContain("cache");
+  });
+
+  it("showCacheHit=false hides cache hit", async () => {
+    const text = await renderStatusRowWithConfig({ cost: 0.05, cacheHit: 0.5 } as any, {
+      showCacheHit: false,
+    });
+    expect(text).toContain("turn");
+    expect(text).not.toContain("cache");
+  });
+
+  it("showVersion=false hides version string", async () => {
+    const text = await renderStatusRowWithConfig({ cost: 0 } as any, { showVersion: false });
+    expect(text).not.toContain(`v${VERSION}`);
+  });
+
+  it("showFeedbackHint=false hides /feedback hint", async () => {
+    const text = await renderStatusRowWithConfig({ cost: 0 } as any, { showFeedbackHint: false });
+    expect(text).not.toContain("/feedback");
+  });
+
+  it("both showBalance and showSessionCost false drops wallet pill", async () => {
+    const text = await renderStatusRowWithConfig(
+      { cost: 0, sessionCost: 0.01, balance: 5 } as any,
+      { showBalance: false, showSessionCost: false },
+    );
+    expect(text).not.toContain("⛁");
+  });
+
+  it("showBalance=false still shows session cost in wallet", async () => {
+    const text = await renderStatusRowWithConfig(
+      { cost: 0, sessionCost: 0.01, balance: 5 } as any,
+      { showBalance: false, showSessionCost: true },
+    );
+    expect(text).toContain("⛁");
+    expect(text).toContain("spent");
+    expect(text).not.toContain("left");
+  });
+
+  it("default config (all true) shows balance and session cost in wallet", async () => {
+    const text = await renderStatusRowWithConfig(
+      { cost: 0, sessionCost: 0.01, balance: 10, balanceCurrency: "USD" } as any,
+      {},
+    );
+    expect(text).toContain("⛁");
+    expect(text).toContain("spent");
+  });
+});
+
 function makeSlashCommands(count: number): SlashCommandSpec[] {
   return Array.from({ length: count }, (_, i) => ({
     cmd: `cmd${i.toString().padStart(2, "0")}`,


### PR DESCRIPTION
## Summary

Adds per-field visibility toggles for the bottom status row, so users can hide noisy fields without a code fork.

- New `statusBar` config section in `ReasonixConfig` with 6 optional boolean flags (all default `true`)
- Each field gated independently:
  - `showTurnCost` — current turn cost
  - `showCacheHit` — prefix-cache hit %
  - `showBalance` / `showSessionCost` — wallet fields (wallet pill dropped entirely when both false)
  - `showVersion` — version string
  - `showFeedbackHint` — `/feedback` tip
- Config read once via `readConfig()` in `App`, passed as prop to `StatusRow`, with defaults for testability
- 8 new tests covering all toggle scenarios

## Usage

```json
{
  "statusBar": {
    "showBalance": false,
    "showVersion": false
  }
}
```

## Files

| File | Change |
|------|--------|
| `src/config.ts` | Add `statusBar` section to `ReasonixConfig` |
| `src/cli/ui/App.tsx` | Read config, define `StatusBarConfig` type, pass through `AppInner` |
| `src/cli/ui/layout/StatusRow.tsx` | Accept `statusBar` prop, gate each field |
| `tests/ui-status-row-balance.test.tsx` | 8 new tests for configuration toggles |

Closes #626