### PR TITLE
fix(healing): stamp fallback id on bare tool_calls to prevent DeepSeek 400

### DIFF
--- a/src/loop/healing.ts
+++ b/src/loop/healing.ts
@@ -1,6 +1,13 @@
-import type { ChatMessage } from "../types.js";
+import type { ChatMessage, ToolCall } from "../types.js";
 import { shrinkOversizedToolResults, shrinkOversizedToolResultsByTokens } from "./shrink.js";
 import { isThinkingModeModel } from "./thinking.js";
+
+let _stampSeq = 0;
+
+/** DeepSeek 400s on tool_calls missing `id`. Give bare calls a fallback. */
+function stampMissingIds(calls: ToolCall[]): ToolCall[] {
+  return calls.map((c) => (c.id ? c : { ...c, id: `z-ext-${Date.now()}-${_stampSeq++}` }));
+}
 
 /** Drops both unpaired assistant.tool_calls and stray tool messages — DeepSeek 400s on either. */
 export function fixToolCallPairing(messages: ChatMessage[]): {
@@ -14,9 +21,11 @@ export function fixToolCallPairing(messages: ChatMessage[]): {
   for (let i = 0; i < messages.length; i++) {
     const msg = messages[i]!;
     if (msg.role === "assistant" && Array.isArray(msg.tool_calls) && msg.tool_calls.length > 0) {
+      // Stamp missing ids before validation — DeepSeek rejects tool_calls without id.
+      const calls = stampMissingIds(msg.tool_calls);
       const needed = new Set<string>();
-      for (const call of msg.tool_calls) {
-        if (call?.id) needed.add(call.id);
+      for (const call of calls) {
+        if (call.id) needed.add(call.id);
       }
       const candidates: ChatMessage[] = [];
       let j = i + 1;
@@ -30,7 +39,7 @@ export function fixToolCallPairing(messages: ChatMessage[]): {
         j++;
       }
       if (needed.size === 0) {
-        out.push(msg);
+        out.push({ ...msg, tool_calls: calls });
         for (const r of candidates) out.push(r);
         i = j - 1;
       } else {


### PR DESCRIPTION
# [Bug] DeepSeek 400 Error: Missing `id` field in tool_calls during sessions

##  **What happened**
DeepSeek returns a **400 Bad Request** error after long sessions:  
`"failed to deserialize the json body into the target type: messages[n]: missing field id"`

In `src/types.ts`, `ToolCall.id` is defined as optional (`id?: string`), but the DeepSeek API strictly requires this field to be present.

##  **Expected**
Sessions should not error out due to missing `tool_call.id`. The application should ensure every tool call sent to the API contains a valid ID.

##  **Reproduction**
1. **Run a long coding session:** 50+ turns with multiple tool calls.
2. **Trigger context compaction:** Let the conversation grow large enough to trigger the `/compact` logic.
3. **Next request:** Wait for the next model interaction → the 400 error appears.

##  **Environment**
- **Reasonix Version:** 0.39.1
- **Node Version:** 24.14.1
- **OS:** Windows 11
- **Shell:** PowerShell
- **Terminal App:** Windows Terminal
- **DeepSeek Model:** deepseek-v4-flash

##  **Logs / Transcript**
- **Symptoms:** Error is displayed in the TUI status bar.
- **Persistence:** The error persists even across `/compact` commands.

## **Root Cause**
Located in `src/types.ts:24`:  
`ToolCall.id` is currently typed as `id?: string` (optional). During certain serialization paths or after context compaction, some `tool_call` entries are generated or restored without an `id` field. DeepSeek's JSON deserializer rejects these incomplete objects.

## **Fix Applied in PR**
Modified `src/loop/healing.ts`:
- Added a new function `stampMissingIds()`.
- This function scans for any `ToolCall` missing an `id` and assigns a fallback ID in the format:  
  `z-ext-{timestamp}-{sequence}`  
  This occurs immediately before the payload is sent to the API.


**Since the bug is hard to reproduce consistently, I'm not sure if this fix is effective. Please let me know what you think.**

---

<img width="1448" height="75" alt="Image" src="https://github.com/user-attachments/assets/0547ea96-2f17-4475-a6aa-016799f082a2" />

---

<img width="1818" height="1013" alt="Image" src="https://github.com/user-attachments/assets/cb6cf9af-997c-46ee-aa2d-2c8387ac000f" />

---
<img width="918" height="1101" alt="image" src="https://github.com/user-attachments/assets/64a19b3c-b69d-4cec-a3be-d2c6ed951a82" />
