### PR TITLE
feat(acp): stage 1 — reasonix acp entrypoint, NDJSON framing, prompt round-trip

### DIFF
--- a/src/acp/protocol.ts
+++ b/src/acp/protocol.ts
@@ -1,0 +1,139 @@
+/** Wire types for the Agent Client Protocol — https://agentclientprotocol.com */
+
+export const ACP_PROTOCOL_VERSION = 1;
+
+export type JsonRpcId = string | number;
+
+export interface JsonRpcRequest<P = unknown> {
+  jsonrpc: "2.0";
+  id: JsonRpcId;
+  method: string;
+  params?: P;
+}
+
+export interface JsonRpcNotification<P = unknown> {
+  jsonrpc: "2.0";
+  method: string;
+  params?: P;
+}
+
+export interface JsonRpcError {
+  code: number;
+  message: string;
+  data?: unknown;
+}
+
+export interface JsonRpcResponse<R = unknown> {
+  jsonrpc: "2.0";
+  id: JsonRpcId | null;
+  result?: R;
+  error?: JsonRpcError;
+}
+
+export interface InitializeParams {
+  protocolVersion: number;
+  clientCapabilities?: {
+    fs?: { readTextFile?: boolean; writeTextFile?: boolean };
+    terminal?: boolean;
+  };
+  clientInfo?: { name: string; title?: string; version?: string };
+}
+
+export interface InitializeResult {
+  protocolVersion: number;
+  agentCapabilities: {
+    loadSession?: boolean;
+    promptCapabilities?: { image?: boolean; audio?: boolean; embeddedContext?: boolean };
+    mcpCapabilities?: { http?: boolean; sse?: boolean };
+  };
+  agentInfo: { name: string; title?: string; version: string };
+  authMethods: never[];
+}
+
+export interface SessionNewParams {
+  cwd?: string;
+  mcpServers?: Array<{
+    name: string;
+    command?: string;
+    args?: string[];
+    env?: Record<string, string>;
+  }>;
+}
+
+export interface SessionNewResult {
+  sessionId: string;
+}
+
+export type ContentBlock =
+  | { type: "text"; text: string }
+  | { type: "resource"; resource: { uri: string; mimeType?: string; text?: string } }
+  | { type: "image"; mimeType: string; data: string }
+  | { type: "audio"; mimeType: string; data: string };
+
+export interface SessionPromptParams {
+  sessionId: string;
+  prompt: ContentBlock[];
+}
+
+export type StopReason = "end_turn" | "tool_use_complete" | "cancelled" | "error";
+
+export interface SessionPromptResult {
+  stopReason: StopReason;
+}
+
+export type SessionUpdate =
+  | {
+      sessionUpdate: "agent_message_chunk";
+      content: { type: "text"; text: string };
+    }
+  | {
+      sessionUpdate: "agent_thought_chunk";
+      content: { type: "text"; text: string };
+    }
+  | {
+      sessionUpdate: "tool_call";
+      toolCallId: string;
+      title?: string;
+      kind?: "read" | "edit" | "search" | "execute" | "other";
+      status?: "pending" | "in_progress" | "completed" | "failed";
+      rawInput?: unknown;
+    }
+  | {
+      sessionUpdate: "tool_call_update";
+      toolCallId: string;
+      status?: "pending" | "in_progress" | "completed" | "failed";
+      content?: Array<{ type: "content"; content: { type: "text"; text: string } }>;
+    }
+  | {
+      sessionUpdate: "plan";
+      entries: Array<{
+        content: string;
+        priority: "high" | "medium" | "low";
+        status: "pending" | "in_progress" | "completed";
+      }>;
+    };
+
+export interface SessionUpdateParams {
+  sessionId: string;
+  update: SessionUpdate;
+}
+
+export interface SessionCancelParams {
+  sessionId: string;
+}
+
+export const ERR_PARSE = -32700;
+export const ERR_INVALID_REQUEST = -32600;
+export const ERR_METHOD_NOT_FOUND = -32601;
+export const ERR_INVALID_PARAMS = -32602;
+export const ERR_INTERNAL = -32603;
+
+/** Extract the user prompt text out of ACP content blocks. Resource blocks contribute their inline `text` if present. */
+export function flattenPrompt(blocks: ContentBlock[]): string {
+  const parts: string[] = [];
+  for (const b of blocks) {
+    if (b.type === "text") parts.push(b.text);
+    else if (b.type === "resource" && b.resource.text) parts.push(b.resource.text);
+  }
+  return parts.join("\n\n").trim();
+}

--- a/src/acp/server.ts
+++ b/src/acp/server.ts
@@ -1,0 +1,112 @@
+/** NDJSON JSON-RPC 2.0 server — per the ACP transport spec, one JSON object per line, no embedded newlines. */
+
+import { type Interface, createInterface } from "node:readline";
+import type { Readable, Writable } from "node:stream";
+import {
+  ERR_INTERNAL,
+  ERR_METHOD_NOT_FOUND,
+  ERR_PARSE,
+  type JsonRpcId,
+  type JsonRpcNotification,
+  type JsonRpcRequest,
+  type JsonRpcResponse,
+} from "./protocol.js";
+
+export type RequestHandler<P = unknown, R = unknown> = (params: P) => Promise<R> | R;
+export type NotificationHandler<P = unknown> = (params: P) => Promise<void> | void;
+
+export interface AcpServerOptions {
+  input?: Readable;
+  output?: Writable;
+}
+
+export class AcpServer {
+  private requestHandlers = new Map<string, RequestHandler>();
+  private notificationHandlers = new Map<string, NotificationHandler>();
+  private readonly output: Writable;
+  private readonly rl: Interface;
+  private closed = false;
+
+  constructor(opts: AcpServerOptions = {}) {
+    this.output = opts.output ?? process.stdout;
+    const input = opts.input ?? process.stdin;
+    this.rl = createInterface({ input });
+    this.rl.on("line", (line) => {
+      void this.handleLine(line);
+    });
+  }
+
+  onRequest<P, R>(method: string, handler: RequestHandler<P, R>): void {
+    this.requestHandlers.set(method, handler as RequestHandler);
+  }
+
+  onNotification<P>(method: string, handler: NotificationHandler<P>): void {
+    this.notificationHandlers.set(method, handler as NotificationHandler);
+  }
+
+  sendNotification(method: string, params: unknown): void {
+    this.write({ jsonrpc: "2.0", method, params });
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.rl.close();
+  }
+
+  /** Wait for the input stream to end. */
+  done(): Promise<void> {
+    return new Promise((resolve) => this.rl.once("close", () => resolve()));
+  }
+
+  private write(msg: JsonRpcRequest | JsonRpcNotification | JsonRpcResponse): void {
+    this.output.write(`${JSON.stringify(msg)}\n`);
+  }
+
+  private writeError(id: JsonRpcId | null, code: number, message: string): void {
+    this.write({ jsonrpc: "2.0", id, error: { code, message } });
+  }
+
+  private async handleLine(raw: string): Promise<void> {
+    const line = raw.trim();
+    if (!line) return;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      this.writeError(null, ERR_PARSE, "parse error");
+      return;
+    }
+    if (!parsed || typeof parsed !== "object") {
+      this.writeError(null, ERR_PARSE, "expected JSON object");
+      return;
+    }
+    const msg = parsed as Partial<JsonRpcRequest>;
+    if (typeof msg.method === "string" && msg.id !== undefined) {
+      const id = msg.id as JsonRpcId;
+      const handler = this.requestHandlers.get(msg.method);
+      if (!handler) {
+        this.writeError(id, ERR_METHOD_NOT_FOUND, `method not found: ${msg.method}`);
+        return;
+      }
+      try {
+        const result = await handler(msg.params);
+        this.write({ jsonrpc: "2.0", id, result });
+      } catch (err) {
+        this.writeError(id, ERR_INTERNAL, (err as Error).message);
+      }
+      return;
+    }
+    if (typeof msg.method === "string" && msg.id === undefined) {
+      const handler = this.notificationHandlers.get(msg.method);
+      if (!handler) return;
+      try {
+        await handler(msg.params);
+      } catch {
+        // notifications can't be replied to — log channel would help, but stderr would pollute the wire
+      }
+      return;
+    }
+    // Responses to outbound requests are ignored in stage 1 (we don't make any yet — stage 3 will).
+  }
+}

--- a/src/cli/commands/acp.ts
+++ b/src/cli/commands/acp.ts
@@ -1,0 +1,197 @@
+/** ACP (Agent Client Protocol) agent — drives the cache-first loop over stdio NDJSON JSON-RPC. */
+
+import { existsSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  ACP_PROTOCOL_VERSION,
+  type ContentBlock,
+  ERR_INVALID_PARAMS,
+  type InitializeParams,
+  type InitializeResult,
+  type SessionCancelParams,
+  type SessionNewParams,
+  type SessionNewResult,
+  type SessionPromptParams,
+  type SessionPromptResult,
+  type SessionUpdateParams,
+  type StopReason,
+  flattenPrompt,
+} from "../../acp/protocol.js";
+import { AcpServer } from "../../acp/server.js";
+import { codeSystemPrompt } from "../../code/prompt.js";
+import { buildCodeToolset } from "../../code/setup.js";
+import { loadApiKey, loadBaseUrl, loadPreset, loadReasoningEffort } from "../../config.js";
+import { Eventizer } from "../../core/eventize.js";
+import type { Event as KernelEvent } from "../../core/events.js";
+import { loadDotenv } from "../../env.js";
+import { CacheFirstLoop, DeepSeekClient, ImmutablePrefix } from "../../index.js";
+import { timestampSuffix } from "../../memory/session.js";
+import { VERSION } from "../../version.js";
+import { canonicalPresetName, resolvePreset } from "../ui/presets.js";
+
+export interface AcpOptions {
+  model?: string;
+  dir?: string;
+  budgetUsd?: number;
+}
+
+interface Session {
+  id: string;
+  rootDir: string;
+  model: string;
+  toolset: Awaited<ReturnType<typeof buildCodeToolset>>;
+  loop: CacheFirstLoop;
+  eventizer: Eventizer;
+  ctx: { model: string; prefixHash: string; reasoningEffort: "high" | "max" };
+  aborter: AbortController | null;
+}
+
+function resolveDir(raw: string | undefined, fallback: string): string {
+  if (!raw) return fallback;
+  const abs = resolve(raw);
+  if (!existsSync(abs) || !statSync(abs).isDirectory()) {
+    throw new Error(`workspace directory not found: ${abs}`);
+  }
+  return abs;
+}
+
+async function buildSession(opts: {
+  rootDir: string;
+  modelOverride?: string;
+  budgetUsd?: number;
+}): Promise<Session> {
+  const preset = canonicalPresetName(loadPreset());
+  const resolved = resolvePreset(preset);
+  const model = opts.modelOverride || resolved.model;
+  const toolset = await buildCodeToolset({ rootDir: opts.rootDir });
+  const system = codeSystemPrompt(opts.rootDir, {
+    hasSemanticSearch: toolset.semantic.enabled,
+    modelId: model,
+  });
+  const client = new DeepSeekClient({ baseUrl: loadBaseUrl() });
+  const prefix = new ImmutablePrefix({ system, toolSpecs: toolset.tools.specs() });
+  const loop = new CacheFirstLoop({
+    client,
+    prefix,
+    tools: toolset.tools,
+    model,
+    budgetUsd: opts.budgetUsd,
+    session: `acp-${timestampSuffix()}`,
+  });
+  return {
+    id: `sess_${timestampSuffix()}-${Math.random().toString(36).slice(2, 8)}`,
+    rootDir: opts.rootDir,
+    model,
+    toolset,
+    loop,
+    eventizer: new Eventizer(),
+    ctx: {
+      model,
+      prefixHash: prefix.fingerprint,
+      reasoningEffort: loadReasoningEffort(),
+    },
+    aborter: null,
+  };
+}
+
+export async function acpCommand(opts: AcpOptions): Promise<void> {
+  loadDotenv();
+  if (loadApiKey()) {
+    process.env.DEEPSEEK_API_KEY = loadApiKey();
+  }
+
+  const defaultDir = resolveDir(opts.dir, process.cwd());
+  const sessions = new Map<string, Session>();
+  const server = new AcpServer();
+
+  server.onRequest<InitializeParams, InitializeResult>("initialize", (params) => {
+    if (!params || typeof params !== "object") {
+      throw Object.assign(new Error("initialize: missing params"), { code: ERR_INVALID_PARAMS });
+    }
+    return {
+      protocolVersion: ACP_PROTOCOL_VERSION,
+      agentCapabilities: {
+        loadSession: false,
+        promptCapabilities: { image: false, audio: false, embeddedContext: true },
+        mcpCapabilities: { http: false, sse: false },
+      },
+      agentInfo: { name: "reasonix", title: "Reasonix", version: VERSION },
+      authMethods: [],
+    };
+  });
+
+  server.onRequest<SessionNewParams, SessionNewResult>("session/new", async (params) => {
+    const rootDir = resolveDir(params?.cwd, defaultDir);
+    const session = await buildSession({
+      rootDir,
+      modelOverride: opts.model,
+      budgetUsd: opts.budgetUsd,
+    });
+    sessions.set(session.id, session);
+    return { sessionId: session.id };
+  });
+
+  server.onRequest<SessionPromptParams, SessionPromptResult>("session/prompt", async (params) => {
+    if (!params?.sessionId) {
+      throw Object.assign(new Error("session/prompt: missing sessionId"), {
+        code: ERR_INVALID_PARAMS,
+      });
+    }
+    const session = sessions.get(params.sessionId);
+    if (!session) {
+      throw Object.assign(new Error(`session/prompt: unknown session ${params.sessionId}`), {
+        code: ERR_INVALID_PARAMS,
+      });
+    }
+    const text = flattenPrompt(params.prompt as ContentBlock[]);
+    if (!text) {
+      throw Object.assign(new Error("session/prompt: empty prompt"), { code: ERR_INVALID_PARAMS });
+    }
+    session.aborter = new AbortController();
+    let stopReason: StopReason = "end_turn";
+    try {
+      for await (const ev of session.loop.step(text)) {
+        if (session.aborter.signal.aborted) {
+          stopReason = "cancelled";
+          break;
+        }
+        for (const kev of session.eventizer.consume(ev, session.ctx)) {
+          dispatchKernelEvent(server, session.id, kev);
+          if (kev.type === "error") stopReason = "error";
+        }
+      }
+    } catch (err) {
+      const message = (err as Error).message;
+      server.sendNotification("session/update", {
+        sessionId: session.id,
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: `\n\n[error] ${message}` },
+        },
+      } satisfies SessionUpdateParams);
+      stopReason = "error";
+    } finally {
+      session.aborter = null;
+    }
+    return { stopReason };
+  });
+
+  server.onNotification<SessionCancelParams>("session/cancel", (params) => {
+    const session = params?.sessionId ? sessions.get(params.sessionId) : undefined;
+    session?.aborter?.abort();
+  });
+
+  await server.done();
+}
+
+/** Stage 1 mapping — only assistant content + reasoning deltas are forwarded as ACP session/update notifications. Tool events come in stage 2. */
+function dispatchKernelEvent(server: AcpServer, sessionId: string, ev: KernelEvent): void {
+  if (ev.type !== "model.delta") return;
+  if (!ev.text) return;
+  const variant = ev.channel === "reasoning" ? "agent_thought_chunk" : "agent_message_chunk";
+  const update: SessionUpdateParams = {
+    sessionId,
+    update: { sessionUpdate: variant, content: { type: "text", text: ev.text } },
+  };
+  server.sendNotification("session/update", update);
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -311,6 +311,28 @@ program
   });
 
 program
+  .command("acp")
+  .description("run reasonix as an Agent Client Protocol (ACP) agent on stdio NDJSON JSON-RPC")
+  .option("-m, --model <id>", t("ui.modelIdHint"))
+  .option("--dir <path>", "root directory for filesystem tools (default: cwd)")
+  .option("--preset <name>", t("ui.presetHintShort"))
+  .option("--budget <usd>", t("ui.budgetHintShort"), (v) => Number.parseFloat(v))
+  .action(async (opts) => {
+    const defaults = resolveDefaults({
+      model: opts.model,
+      mcp: [],
+      preset: opts.preset,
+      noConfig: false,
+    });
+    const { acpCommand } = await import("./commands/acp.js");
+    await acpCommand({
+      model: defaults.model,
+      budgetUsd: parseBudgetFlag(opts.budget),
+      dir: opts.dir,
+    });
+  });
+
+program
   .command("desktop")
   .description("headless JSON-RPC chat for the desktop client (internal)")
   .option("-m, --model <id>", t("ui.modelIdHint"))

--- a/tests/acp.test.ts
+++ b/tests/acp.test.ts
@@ -1,0 +1,183 @@
+/** ACP (Agent Client Protocol) server — NDJSON framing + JSON-RPC method dispatch. */
+
+import { PassThrough } from "node:stream";
+import { describe, expect, it } from "vitest";
+import {
+  ACP_PROTOCOL_VERSION,
+  type ContentBlock,
+  ERR_METHOD_NOT_FOUND,
+  ERR_PARSE,
+  flattenPrompt,
+} from "../src/acp/protocol.js";
+import { AcpServer } from "../src/acp/server.js";
+
+function makePair(): {
+  server: AcpServer;
+  send: (msg: unknown) => void;
+  reads: () => string[];
+} {
+  const input = new PassThrough();
+  const output = new PassThrough();
+  const collected: string[] = [];
+  output.on("data", (chunk: Buffer) => {
+    for (const line of chunk.toString("utf8").split("\n")) {
+      const trimmed = line.trim();
+      if (trimmed) collected.push(trimmed);
+    }
+  });
+  const server = new AcpServer({ input, output });
+  return {
+    server,
+    send: (msg) => input.write(`${JSON.stringify(msg)}\n`),
+    reads: () => collected.slice(),
+  };
+}
+
+function wait(ms = 10): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("AcpServer — NDJSON framing", () => {
+  it("dispatches a request to a registered handler and writes a JSON-RPC response", async () => {
+    const { server, send, reads } = makePair();
+    server.onRequest<{ x: number }, { y: number }>("math/double", (p) => ({ y: p.x * 2 }));
+    send({ jsonrpc: "2.0", id: 1, method: "math/double", params: { x: 21 } });
+    await wait();
+    expect(reads()).toEqual([JSON.stringify({ jsonrpc: "2.0", id: 1, result: { y: 42 } })]);
+    server.close();
+  });
+
+  it("rejects unknown methods with -32601 method not found", async () => {
+    const { server, send, reads } = makePair();
+    send({ jsonrpc: "2.0", id: 2, method: "nope" });
+    await wait();
+    const reply = JSON.parse(reads()[0] ?? "{}");
+    expect(reply.error?.code).toBe(ERR_METHOD_NOT_FOUND);
+    expect(reply.id).toBe(2);
+    server.close();
+  });
+
+  it("returns a parse-error response for malformed JSON", async () => {
+    const { server, reads } = makePair();
+    // bypass JSON.stringify — emit raw garbage
+    (server as unknown as { handleLine: (l: string) => Promise<void> }).handleLine = AcpServer
+      .prototype["handleLine" as keyof AcpServer] as never;
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const collected: string[] = [];
+    output.on("data", (chunk: Buffer) => {
+      for (const line of chunk.toString("utf8").split("\n")) {
+        if (line.trim()) collected.push(line.trim());
+      }
+    });
+    const s = new AcpServer({ input, output });
+    input.write("not json\n");
+    await wait();
+    expect(JSON.parse(collected[0] ?? "{}").error?.code).toBe(ERR_PARSE);
+    s.close();
+    server.close();
+    expect(reads()).toEqual([]);
+  });
+
+  it("does not respond to notifications", async () => {
+    const { server, send, reads } = makePair();
+    let seen: unknown = null;
+    server.onNotification<{ tag: string }>("ping", (p) => {
+      seen = p;
+    });
+    send({ jsonrpc: "2.0", method: "ping", params: { tag: "v1" } });
+    await wait();
+    expect(seen).toEqual({ tag: "v1" });
+    expect(reads()).toEqual([]);
+    server.close();
+  });
+
+  it("emits a notification verbatim on sendNotification", async () => {
+    const { server, reads } = makePair();
+    server.sendNotification("session/update", {
+      sessionId: "s1",
+      update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "hi" } },
+    });
+    // small wait to let the stream flush
+    await wait(5);
+    const parsed = JSON.parse(reads()[0] ?? "{}");
+    expect(parsed.method).toBe("session/update");
+    expect(parsed.params.update.content.text).toBe("hi");
+    expect(parsed.id).toBeUndefined();
+    server.close();
+  });
+
+  it("returns a -32603 internal error when a handler throws", async () => {
+    const { server, send, reads } = makePair();
+    server.onRequest("oops", () => {
+      throw new Error("kaboom");
+    });
+    send({ jsonrpc: "2.0", id: 9, method: "oops" });
+    await wait();
+    const reply = JSON.parse(reads()[0] ?? "{}");
+    expect(reply.error?.message).toBe("kaboom");
+    expect(reply.id).toBe(9);
+    server.close();
+  });
+});
+
+describe("ACP protocol helpers", () => {
+  it("flattenPrompt concatenates text and resource-with-inline-text blocks", () => {
+    const blocks: ContentBlock[] = [
+      { type: "text", text: "analyze this" },
+      {
+        type: "resource",
+        resource: { uri: "file:///x.py", mimeType: "text/x-python", text: "print('hi')" },
+      },
+      { type: "text", text: "thanks" },
+    ];
+    expect(flattenPrompt(blocks)).toBe("analyze this\n\nprint('hi')\n\nthanks");
+  });
+
+  it("flattenPrompt ignores image / audio / resource-without-text blocks", () => {
+    const blocks: ContentBlock[] = [
+      { type: "image", mimeType: "image/png", data: "AAAA" },
+      {
+        type: "resource",
+        resource: { uri: "file:///x.bin", mimeType: "application/octet-stream" },
+      },
+      { type: "text", text: "only this survives" },
+    ];
+    expect(flattenPrompt(blocks)).toBe("only this survives");
+  });
+
+  it("ACP_PROTOCOL_VERSION pins to the spec's v1", () => {
+    expect(ACP_PROTOCOL_VERSION).toBe(1);
+  });
+});
+
+describe("ACP initialize handshake (end-to-end via the server)", () => {
+  it("implements initialize → returns protocolVersion + agentCapabilities + agentInfo", async () => {
+    const { server, send, reads } = makePair();
+    // The CLI command wires the initialize handler; mirror its shape here for an isolated test
+    // so the wire contract is covered without spinning up the loop.
+    server.onRequest("initialize", () => ({
+      protocolVersion: ACP_PROTOCOL_VERSION,
+      agentCapabilities: {
+        loadSession: false,
+        promptCapabilities: { image: false, audio: false, embeddedContext: true },
+        mcpCapabilities: { http: false, sse: false },
+      },
+      agentInfo: { name: "reasonix", title: "Reasonix", version: "0.0.0-test" },
+      authMethods: [],
+    }));
+    send({
+      jsonrpc: "2.0",
+      id: 0,
+      method: "initialize",
+      params: { protocolVersion: 1, clientCapabilities: { fs: { readTextFile: true } } },
+    });
+    await wait();
+    const reply = JSON.parse(reads()[0] ?? "{}");
+    expect(reply.id).toBe(0);
+    expect(reply.result.protocolVersion).toBe(1);
+    expect(reply.result.agentInfo.name).toBe("reasonix");
+    expect(reply.result.authMethods).toEqual([]);
+    server.close();
+  });
+});


### PR DESCRIPTION
## Summary

First slice of the ACP (Agent Client Protocol) support tracked in #103. Spawns reasonix as an ACP agent on stdio NDJSON JSON-RPC 2.0; the cache-first loop and prefix hashing are untouched — only the IO layer changes. Cache stability across an ACP session and a TUI session is preserved.

```
$ reasonix acp --dir /path/to/workspace
{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":1,...}}
{"jsonrpc":"2.0","id":0,"result":{"protocolVersion":1,"agentCapabilities":{...},"agentInfo":{"name":"reasonix",...}}}
{"jsonrpc":"2.0","id":1,"method":"session/new"}
{"jsonrpc":"2.0","id":1,"result":{"sessionId":"sess_..."}}
{"jsonrpc":"2.0","id":2,"method":"session/prompt","params":{"sessionId":"sess_...","prompt":[{"type":"text","text":"hi"}]}}
{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"sess_...","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"..."}}}}
...
{"jsonrpc":"2.0","id":2,"result":{"stopReason":"end_turn"}}
```

### What stage 1 covers

- `reasonix acp` subcommand with `--dir` / `--model` / `--preset` / `--budget`
- `src/acp/` — JSON-RPC types + NDJSON `AcpServer` (one object per line, no embedded newlines, per the transport spec)
- `initialize` handshake with capability negotiation
- `session/new` — builds a per-session `CacheFirstLoop` with its own toolset rooted at cwd (or the cwd from the request)
- `session/prompt` — drives one turn, streaming `agent_message_chunk` and `agent_thought_chunk` via `session/update` notifications; returns `{ stopReason: end_turn | cancelled | error }` on completion
- `session/cancel` — notification aborts the in-flight turn cleanly, leaving the session reusable for the next prompt

### What's deferred (tracked in #103)

| Stage | Scope |
|---|---|
| 2 | `tool_call` / `tool_call_update` notifications mapped from `tool.preparing` / `tool.intent` / `tool.result` |
| 3 | `session/request_permission` outbound calls bridging `$confirm_required` / `$plan_required` / `$checkpoint_required` gates back to ACP `authorize` round-trips |
| 4 (optional) | `session/load`, MCP server forwarding via `mcpServers` param |

### Test plan

- [x] `npm run verify` — 179 files, 2724 tests pass + biome clean
- [x] `tests/acp.test.ts` — 10 tests covering:
  - request → response dispatch with NDJSON framing
  - unknown method → `-32601 method not found`
  - malformed line → `-32700 parse error`
  - notifications never produce a response
  - `sendNotification` writes a well-formed frame
  - handler throw → `-32603 internal error` with the error message
  - `flattenPrompt` concatenates text + inline-resource text, ignores image/audio/empty-resource blocks
  - `initialize` round-trip with capabilities

### Verification by hand

```bash
echo -e '{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":1}}\n{"jsonrpc":"2.0","id":1,"method":"session/new"}' | node ./bin/reasonix.js acp --dir .
```

Refs #103
