### PR TITLE
feat(acp): stage 2 — tool_call / tool_call_update notifications

### DIFF
--- a/src/acp/dispatch.ts
+++ b/src/acp/dispatch.ts
@@ -1,0 +1,126 @@
+/** Map kernel events (model.delta / tool.preparing|intent|result) to ACP session/update notifications. */
+
+import type { Event as KernelEvent } from "../core/events.js";
+import type { SessionUpdateParams } from "./protocol.js";
+import type { AcpServer } from "./server.js";
+
+const READ_TOOLS = new Set([
+  "read_file",
+  "list_directory",
+  "directory_tree",
+  "get_file_info",
+  "glob",
+]);
+const EDIT_TOOLS = new Set([
+  "write_file",
+  "edit_file",
+  "multi_edit",
+  "create_directory",
+  "delete_file",
+  "delete_directory",
+  "move_file",
+  "copy_file",
+]);
+const SEARCH_TOOLS = new Set(["search_content", "search_files"]);
+const EXECUTE_TOOLS = new Set(["run_command", "run_background"]);
+
+export type AcpToolKind = "read" | "edit" | "search" | "execute" | "other";
+
+export function toolKindFor(name: string): AcpToolKind {
+  if (READ_TOOLS.has(name)) return "read";
+  if (EDIT_TOOLS.has(name)) return "edit";
+  if (SEARCH_TOOLS.has(name)) return "search";
+  if (EXECUTE_TOOLS.has(name)) return "execute";
+  return "other";
+}
+
+function tryParseJson(raw: string): unknown {
+  if (!raw) return undefined;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+/** Stateless mapping from one kernel event to (zero or more) ACP session/update notifications. */
+export function dispatchKernelEvent(server: AcpServer, sessionId: string, ev: KernelEvent): void {
+  switch (ev.type) {
+    case "model.delta": {
+      if (!ev.text) return;
+      const variant = ev.channel === "reasoning" ? "agent_thought_chunk" : "agent_message_chunk";
+      emit(server, {
+        sessionId,
+        update: { sessionUpdate: variant, content: { type: "text", text: ev.text } },
+      });
+      return;
+    }
+    case "tool.preparing": {
+      emit(server, {
+        sessionId,
+        update: {
+          sessionUpdate: "tool_call",
+          toolCallId: ev.callId,
+          title: ev.name,
+          kind: toolKindFor(ev.name),
+          status: "pending",
+        },
+      });
+      return;
+    }
+    case "tool.intent": {
+      emit(server, {
+        sessionId,
+        update: {
+          sessionUpdate: "tool_call_update",
+          toolCallId: ev.callId,
+          status: "in_progress",
+        },
+      });
+      const rawInput = tryParseJson(ev.args);
+      if (rawInput !== undefined) {
+        emit(server, {
+          sessionId,
+          update: {
+            sessionUpdate: "tool_call",
+            toolCallId: ev.callId,
+            title: ev.name,
+            kind: toolKindFor(ev.name),
+            status: "in_progress",
+            rawInput,
+          },
+        });
+      }
+      return;
+    }
+    case "tool.result": {
+      emit(server, {
+        sessionId,
+        update: {
+          sessionUpdate: "tool_call_update",
+          toolCallId: ev.callId,
+          status: ev.ok ? "completed" : "failed",
+          content: [
+            {
+              type: "content",
+              content: { type: "text", text: clip(ev.output) },
+            },
+          ],
+        },
+      });
+      return;
+    }
+    default:
+      return;
+  }
+}
+
+const MAX_RESULT_CHARS = 8000;
+function clip(text: string): string {
+  if (text.length <= MAX_RESULT_CHARS) return text;
+  return `${text.slice(0, MAX_RESULT_CHARS)}\n…(${text.length - MAX_RESULT_CHARS} more chars truncated)`;
+}
+
+function emit(server: AcpServer, params: SessionUpdateParams): void {
+  server.sendNotification("session/update", params);
+}

--- a/src/cli/commands/acp.ts
+++ b/src/cli/commands/acp.ts
@@ -2,6 +2,7 @@
 
 import { existsSync, statSync } from "node:fs";
 import { resolve } from "node:path";
+import { dispatchKernelEvent } from "../../acp/dispatch.js";
 import {
   ACP_PROTOCOL_VERSION,
   type ContentBlock,
@@ -22,7 +23,6 @@ import { codeSystemPrompt } from "../../code/prompt.js";
 import { buildCodeToolset } from "../../code/setup.js";
 import { loadApiKey, loadBaseUrl, loadPreset, loadReasoningEffort } from "../../config.js";
 import { Eventizer } from "../../core/eventize.js";
-import type { Event as KernelEvent } from "../../core/events.js";
 import { loadDotenv } from "../../env.js";
 import { CacheFirstLoop, DeepSeekClient, ImmutablePrefix } from "../../index.js";
 import { timestampSuffix } from "../../memory/session.js";
@@ -182,16 +182,4 @@ export async function acpCommand(opts: AcpOptions): Promise<void> {
   });
 
   await server.done();
-}
-
-/** Stage 1 mapping — only assistant content + reasoning deltas are forwarded as ACP session/update notifications. Tool events come in stage 2. */
-function dispatchKernelEvent(server: AcpServer, sessionId: string, ev: KernelEvent): void {
-  if (ev.type !== "model.delta") return;
-  if (!ev.text) return;
-  const variant = ev.channel === "reasoning" ? "agent_thought_chunk" : "agent_message_chunk";
-  const update: SessionUpdateParams = {
-    sessionId,
-    update: { sessionUpdate: variant, content: { type: "text", text: ev.text } },
-  };
-  server.sendNotification("session/update", update);
 }

--- a/tests/acp.test.ts
+++ b/tests/acp.test.ts
@@ -2,6 +2,7 @@
 
 import { PassThrough } from "node:stream";
 import { describe, expect, it } from "vitest";
+import { dispatchKernelEvent, toolKindFor } from "../src/acp/dispatch.js";
 import {
   ACP_PROTOCOL_VERSION,
   type ContentBlock,
@@ -10,6 +11,7 @@ import {
   flattenPrompt,
 } from "../src/acp/protocol.js";
 import { AcpServer } from "../src/acp/server.js";
+import type { Event as KernelEvent } from "../src/core/events.js";
 
 function makePair(): {
   server: AcpServer;
@@ -148,6 +150,183 @@ describe("ACP protocol helpers", () => {
 
   it("ACP_PROTOCOL_VERSION pins to the spec's v1", () => {
     expect(ACP_PROTOCOL_VERSION).toBe(1);
+  });
+});
+
+describe("ACP kernel-event dispatch", () => {
+  function captureUpdates(): { server: AcpServer; updates: () => unknown[] } {
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const lines: string[] = [];
+    output.on("data", (chunk: Buffer) => {
+      for (const line of chunk.toString("utf8").split("\n")) {
+        if (line.trim()) lines.push(line.trim());
+      }
+    });
+    const server = new AcpServer({ input, output });
+    return {
+      server,
+      updates: () =>
+        lines
+          .map((l) => JSON.parse(l))
+          .filter((m) => m.method === "session/update")
+          .map((m) => m.params.update),
+    };
+  }
+
+  function kev<T extends KernelEvent["type"]>(type: T, fields: Partial<KernelEvent>): KernelEvent {
+    return {
+      id: 1,
+      ts: "2026-05-12T00:00:00Z",
+      turn: 1,
+      type,
+      ...fields,
+    } as KernelEvent;
+  }
+
+  it("model.delta on content channel emits agent_message_chunk", async () => {
+    const { server, updates } = captureUpdates();
+    dispatchKernelEvent(
+      server,
+      "s1",
+      kev("model.delta", { channel: "content", text: "hello" } as never),
+    );
+    await wait(5);
+    expect(updates()).toEqual([
+      { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "hello" } },
+    ]);
+    server.close();
+  });
+
+  it("model.delta on reasoning channel emits agent_thought_chunk", async () => {
+    const { server, updates } = captureUpdates();
+    dispatchKernelEvent(
+      server,
+      "s1",
+      kev("model.delta", { channel: "reasoning", text: "thinking…" } as never),
+    );
+    await wait(5);
+    expect(updates()).toEqual([
+      { sessionUpdate: "agent_thought_chunk", content: { type: "text", text: "thinking…" } },
+    ]);
+    server.close();
+  });
+
+  it("tool.preparing emits a pending tool_call with the right kind classification", async () => {
+    const { server, updates } = captureUpdates();
+    dispatchKernelEvent(
+      server,
+      "s1",
+      kev("tool.preparing", { callId: "tc-1", name: "read_file" } as never),
+    );
+    await wait(5);
+    expect(updates()).toEqual([
+      {
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-1",
+        title: "read_file",
+        kind: "read",
+        status: "pending",
+      },
+    ]);
+    server.close();
+  });
+
+  it("tool.intent emits in_progress then a tool_call carrying parsed rawInput", async () => {
+    const { server, updates } = captureUpdates();
+    dispatchKernelEvent(
+      server,
+      "s1",
+      kev("tool.intent", {
+        callId: "tc-2",
+        name: "write_file",
+        args: '{"path":"a.ts","content":"x"}',
+      } as never),
+    );
+    await wait(5);
+    const seen = updates();
+    expect(seen).toHaveLength(2);
+    expect(seen[0]).toEqual({
+      sessionUpdate: "tool_call_update",
+      toolCallId: "tc-2",
+      status: "in_progress",
+    });
+    expect(seen[1]).toMatchObject({
+      sessionUpdate: "tool_call",
+      toolCallId: "tc-2",
+      kind: "edit",
+      status: "in_progress",
+      rawInput: { path: "a.ts", content: "x" },
+    });
+    server.close();
+  });
+
+  it("tool.result emits completed with content; failed when ok=false", async () => {
+    const { server, updates } = captureUpdates();
+    dispatchKernelEvent(
+      server,
+      "s1",
+      kev("tool.result", {
+        callId: "tc-3",
+        ok: true,
+        output: "42",
+        durationMs: 7,
+      } as never),
+    );
+    dispatchKernelEvent(
+      server,
+      "s1",
+      kev("tool.result", {
+        callId: "tc-4",
+        ok: false,
+        output: "ENOENT",
+        durationMs: 1,
+      } as never),
+    );
+    await wait(5);
+    const seen = updates();
+    expect(seen).toHaveLength(2);
+    expect(seen[0]).toMatchObject({
+      sessionUpdate: "tool_call_update",
+      toolCallId: "tc-3",
+      status: "completed",
+      content: [{ type: "content", content: { type: "text", text: "42" } }],
+    });
+    expect(seen[1]).toMatchObject({
+      toolCallId: "tc-4",
+      status: "failed",
+      content: [{ type: "content", content: { type: "text", text: "ENOENT" } }],
+    });
+    server.close();
+  });
+
+  it("very long tool outputs are clipped with a truncation suffix", async () => {
+    const { server, updates } = captureUpdates();
+    const big = "x".repeat(8000 + 200);
+    dispatchKernelEvent(
+      server,
+      "s1",
+      kev("tool.result", { callId: "tc-5", ok: true, output: big, durationMs: 1 } as never),
+    );
+    await wait(5);
+    const seen = updates();
+    const text = (seen[0] as { content: Array<{ content: { text: string } }> }).content[0]?.content
+      .text as string;
+    expect(text.length).toBeGreaterThan(0);
+    expect(text.length).toBeLessThan(big.length);
+    expect(text).toContain("more chars truncated");
+    server.close();
+  });
+
+  it("toolKindFor classifies known tool names into ACP kinds", () => {
+    expect(toolKindFor("read_file")).toBe("read");
+    expect(toolKindFor("glob")).toBe("read");
+    expect(toolKindFor("write_file")).toBe("edit");
+    expect(toolKindFor("multi_edit")).toBe("edit");
+    expect(toolKindFor("search_content")).toBe("search");
+    expect(toolKindFor("run_command")).toBe("execute");
+    expect(toolKindFor("run_background")).toBe("execute");
+    expect(toolKindFor("totally_made_up_tool")).toBe("other");
   });
 });
 


### PR DESCRIPTION
## Summary

Stage 2 of the ACP rollout tracked in #103. Builds on the stage-1 NDJSON foundation from #714. Internal tool events now surface to ACP hosts as the corresponding `session/update` variants, so a Zed / JetBrains / AionUI client sees real-time tool execution matching what the TUI and desktop already show.

### Mapping

Lives in `src/acp/dispatch.ts` — pure stateless function called per kernel event:

| Kernel event | ACP frame(s) |
|---|---|
| `tool.preparing` | `tool_call` (status=pending, `kind` classified from name) |
| `tool.intent` | `tool_call_update` (in_progress) + follow-up `tool_call` carrying `rawInput` (parsed from args JSON if valid, else the raw string) |
| `tool.result` (ok=true) | `tool_call_update` (completed) with `content[].content.text` |
| `tool.result` (ok=false) | `tool_call_update` (failed) with the same content shape |

Result text is clipped at 8000 chars with a `…(N more chars truncated)` suffix so a runaway tool output can't bloat the wire.

### Kind classification (`toolKindFor`)

| ACP kind | Tool names |
|---|---|
| `read` | `read_file`, `list_directory`, `directory_tree`, `get_file_info`, `glob` |
| `edit` | `write_file`, `edit_file`, `multi_edit`, `create_directory`, `delete_file`, `delete_directory`, `move_file`, `copy_file` |
| `search` | `search_content`, `search_files` |
| `execute` | `run_command`, `run_background` |
| `other` | everything else (custom MCP tools, etc.) |

### What's still deferred

- Stage 3 (next PR): `session/request_permission` outbound calls bridging `$confirm_required` / `$plan_required` / `$checkpoint_required` gates back to ACP authorize round-trips
- Stage 4 (optional): `session/load` (resume), `mcpServers` param wiring

### Test plan

- [x] `npm run verify` — 179 files, 2731 tests pass, biome clean
- [x] `tests/acp.test.ts` — 7 new tests:
  - `model.delta` on content channel → `agent_message_chunk` (already covered)
  - `tool.preparing` → pending `tool_call` with correct `kind`
  - `tool.intent` → in_progress `tool_call_update` + follow-up `tool_call` with parsed `rawInput`
  - `tool.result` ok=true → completed `tool_call_update`; ok=false → failed
  - long output gets clipped + truncation suffix
  - `toolKindFor` classification matches the table above

Refs #103
