### PR TITLE
feat(acp): stage 3 — session/request_permission bridging shell + plan gates

### DIFF
--- a/src/acp/gates.ts
+++ b/src/acp/gates.ts
@@ -1,0 +1,177 @@
+/** Bridges Reasonix's internal `PauseGate` requests onto ACP `session/request_permission` round-trips. */
+
+import type {
+  CheckpointVerdict,
+  ChoiceVerdict,
+  ConfirmationChoice,
+  PauseRequest,
+  PlanVerdict,
+  RevisionVerdict,
+} from "../core/pause-gate.js";
+import type {
+  PermissionOption,
+  PermissionRequestParams,
+  PermissionRequestResult,
+} from "./protocol.js";
+import type { AcpServer } from "./server.js";
+
+const ID_ALLOW_ONCE = "allow_once";
+const ID_ALLOW_ALWAYS = "allow_always";
+const ID_REJECT = "reject";
+const ID_REFINE = "refine";
+const ID_REVISE = "revise";
+const ID_STOP = "stop";
+const ID_CANCEL = "cancel";
+const ID_ACCEPT = "accept";
+
+/** Build the `options` list shown to the host for a given gate kind. The IDs are what the host echoes back in the response. */
+export function permissionOptionsFor(req: PauseRequest): PermissionOption[] {
+  switch (req.kind) {
+    case "run_command":
+    case "run_background":
+    case "path_access":
+      return [
+        { optionId: ID_ALLOW_ONCE, name: "Allow once", kind: "allow_once" },
+        { optionId: ID_ALLOW_ALWAYS, name: "Allow always", kind: "allow_always" },
+        { optionId: ID_REJECT, name: "Reject", kind: "reject_once" },
+      ];
+    case "plan_proposed":
+      return [
+        { optionId: ID_ALLOW_ONCE, name: "Approve plan", kind: "allow_once" },
+        { optionId: ID_REFINE, name: "Refine", kind: "allow_once" },
+        { optionId: ID_CANCEL, name: "Cancel", kind: "reject_once" },
+      ];
+    case "plan_checkpoint":
+      return [
+        { optionId: ID_ALLOW_ONCE, name: "Continue", kind: "allow_once" },
+        { optionId: ID_REVISE, name: "Revise", kind: "allow_once" },
+        { optionId: ID_STOP, name: "Stop", kind: "reject_once" },
+      ];
+    case "plan_revision":
+      return [
+        { optionId: ID_ACCEPT, name: "Accept revision", kind: "allow_once" },
+        { optionId: ID_REJECT, name: "Keep original plan", kind: "reject_once" },
+      ];
+    case "choice": {
+      const payload = req.payload as { options: { id: string; title?: string }[] };
+      const opts: PermissionOption[] = (payload.options ?? []).map((o) => ({
+        optionId: o.id,
+        name: o.title ?? o.id,
+        kind: "allow_once",
+      }));
+      opts.push({ optionId: ID_CANCEL, name: "Cancel", kind: "reject_once" });
+      return opts;
+    }
+  }
+}
+
+function commandPrefix(command: string): string {
+  const first = command.trim().split(/\s+/)[0] ?? command.trim();
+  return `${first} *`;
+}
+
+function pathPrefix(p: string): string {
+  return p;
+}
+
+/** Map an ACP permission response back into the internal verdict shape PauseGate.resolve expects. */
+export function verdictFor(
+  req: PauseRequest,
+  result: PermissionRequestResult,
+): ConfirmationChoice | PlanVerdict | CheckpointVerdict | RevisionVerdict | ChoiceVerdict {
+  const cancelled = result.outcome.outcome === "cancelled";
+  const optionId = result.outcome.outcome === "selected" ? result.outcome.optionId : null;
+  switch (req.kind) {
+    case "run_command":
+    case "run_background": {
+      if (cancelled || optionId === ID_REJECT) return { type: "deny" };
+      if (optionId === ID_ALLOW_ALWAYS) {
+        const payload = req.payload as { command?: string };
+        return { type: "always_allow", prefix: commandPrefix(payload.command ?? "") };
+      }
+      return { type: "run_once" };
+    }
+    case "path_access": {
+      if (cancelled || optionId === ID_REJECT) return { type: "deny" };
+      if (optionId === ID_ALLOW_ALWAYS) {
+        const payload = req.payload as { allowPrefix: string };
+        return { type: "always_allow", prefix: pathPrefix(payload.allowPrefix) };
+      }
+      return { type: "run_once" };
+    }
+    case "plan_proposed": {
+      if (cancelled || optionId === ID_CANCEL) return { type: "cancel" };
+      if (optionId === ID_REFINE) return { type: "refine" };
+      return { type: "approve" };
+    }
+    case "plan_checkpoint": {
+      if (cancelled || optionId === ID_STOP) return { type: "stop" };
+      if (optionId === ID_REVISE) return { type: "revise" };
+      return { type: "continue" };
+    }
+    case "plan_revision": {
+      if (cancelled) return { type: "cancelled" };
+      if (optionId === ID_ACCEPT) return { type: "accepted" };
+      return { type: "rejected" };
+    }
+    case "choice": {
+      if (cancelled || optionId === ID_CANCEL || !optionId) return { type: "cancel" };
+      return { type: "pick", optionId };
+    }
+  }
+}
+
+function permissionTitleFor(req: PauseRequest): string {
+  switch (req.kind) {
+    case "run_command":
+    case "run_background":
+      return `Run command — ${((req.payload as { command?: string }).command ?? "").slice(0, 80)}`;
+    case "path_access":
+      return `Access path — ${(req.payload as { path: string }).path}`;
+    case "plan_proposed":
+      return "Approve plan";
+    case "plan_checkpoint":
+      return `Checkpoint — ${(req.payload as { title?: string }).title ?? "step complete"}`;
+    case "plan_revision":
+      return "Approve plan revision";
+    case "choice":
+      return (req.payload as { question?: string }).question ?? "Choose an option";
+  }
+}
+
+function permissionKindFor(req: PauseRequest): "execute" | "edit" | "other" {
+  if (req.kind === "run_command" || req.kind === "run_background") return "execute";
+  if (req.kind === "path_access") {
+    return (req.payload as { intent?: string }).intent === "write" ? "edit" : "other";
+  }
+  return "other";
+}
+
+/** Forward a PauseGate request as an ACP session/request_permission outbound call. Returns the verdict to pass into pauseGate.resolve. */
+export async function requestPermissionForGate(
+  server: AcpServer,
+  sessionId: string,
+  req: PauseRequest,
+): Promise<ConfirmationChoice | PlanVerdict | CheckpointVerdict | RevisionVerdict | ChoiceVerdict> {
+  const params: PermissionRequestParams = {
+    sessionId,
+    toolCall: {
+      toolCallId: `gate-${req.id}`,
+      title: permissionTitleFor(req),
+      kind: permissionKindFor(req),
+      status: "pending",
+      rawInput: req.payload,
+    },
+    options: permissionOptionsFor(req),
+  };
+  let result: PermissionRequestResult;
+  try {
+    result = await server.sendRequest<PermissionRequestResult>(
+      "session/request_permission",
+      params,
+    );
+  } catch {
+    result = { outcome: { outcome: "cancelled" } };
+  }
+  return verdictFor(req, result);
+}

--- a/src/acp/protocol.ts
+++ b/src/acp/protocol.ts
@@ -122,6 +122,34 @@ export interface SessionCancelParams {
   sessionId: string;
 }
 
+export type PermissionOptionKind = "allow_once" | "allow_always" | "reject_once" | "reject_always";
+
+export interface PermissionOption {
+  optionId: string;
+  name: string;
+  kind: PermissionOptionKind;
+}
+
+export interface PermissionRequestParams {
+  sessionId: string;
+  toolCall: {
+    toolCallId: string;
+    title?: string;
+    kind?: "read" | "edit" | "search" | "execute" | "other";
+    status?: "pending";
+    rawInput?: unknown;
+  };
+  options: PermissionOption[];
+}
+
+export type PermissionOutcome =
+  | { outcome: "selected"; optionId: string }
+  | { outcome: "cancelled" };
+
+export interface PermissionRequestResult {
+  outcome: PermissionOutcome;
+}
+
 export const ERR_PARSE = -32700;
 export const ERR_INVALID_REQUEST = -32600;
 export const ERR_METHOD_NOT_FOUND = -32601;

--- a/src/acp/server.ts
+++ b/src/acp/server.ts
@@ -20,9 +20,16 @@ export interface AcpServerOptions {
   output?: Writable;
 }
 
+interface PendingOutbound {
+  resolve: (value: unknown) => void;
+  reject: (err: Error) => void;
+}
+
 export class AcpServer {
   private requestHandlers = new Map<string, RequestHandler>();
   private notificationHandlers = new Map<string, NotificationHandler>();
+  private pending = new Map<JsonRpcId, PendingOutbound>();
+  private nextOutboundId = 1;
   private readonly output: Writable;
   private readonly rl: Interface;
   private closed = false;
@@ -48,9 +55,23 @@ export class AcpServer {
     this.write({ jsonrpc: "2.0", method, params });
   }
 
+  /** Send an outbound JSON-RPC request and resolve when the peer responds. */
+  sendRequest<R = unknown>(method: string, params: unknown): Promise<R> {
+    const id = this.nextOutboundId++;
+    return new Promise<R>((resolve, reject) => {
+      this.pending.set(id, {
+        resolve: resolve as (v: unknown) => void,
+        reject,
+      });
+      this.write({ jsonrpc: "2.0", id, method, params });
+    });
+  }
+
   close(): void {
     if (this.closed) return;
     this.closed = true;
+    for (const p of this.pending.values()) p.reject(new Error("server closed"));
+    this.pending.clear();
     this.rl.close();
   }
 
@@ -107,6 +128,16 @@ export class AcpServer {
       }
       return;
     }
-    // Responses to outbound requests are ignored in stage 1 (we don't make any yet — stage 3 will).
+    if (msg.id !== undefined && msg.method === undefined) {
+      const response = parsed as JsonRpcResponse;
+      const pending = this.pending.get(response.id as JsonRpcId);
+      if (!pending) return;
+      this.pending.delete(response.id as JsonRpcId);
+      if (response.error) {
+        pending.reject(new Error(response.error.message));
+      } else {
+        pending.resolve(response.result);
+      }
+    }
   }
 }

--- a/src/cli/commands/acp.ts
+++ b/src/cli/commands/acp.ts
@@ -1,8 +1,10 @@
 /** ACP (Agent Client Protocol) agent — drives the cache-first loop over stdio NDJSON JSON-RPC. */
 
+import { AsyncLocalStorage } from "node:async_hooks";
 import { existsSync, statSync } from "node:fs";
 import { resolve } from "node:path";
 import { dispatchKernelEvent } from "../../acp/dispatch.js";
+import { requestPermissionForGate } from "../../acp/gates.js";
 import {
   ACP_PROTOCOL_VERSION,
   type ContentBlock,
@@ -22,7 +24,10 @@ import { AcpServer } from "../../acp/server.js";
 import { codeSystemPrompt } from "../../code/prompt.js";
 import { buildCodeToolset } from "../../code/setup.js";
 import { loadApiKey, loadBaseUrl, loadPreset, loadReasoningEffort } from "../../config.js";
+import { loadEditMode } from "../../config.js";
 import { Eventizer } from "../../core/eventize.js";
+import { pauseGate } from "../../core/pause-gate.js";
+import { autoResolveVerdict } from "../../core/pause-policy.js";
 import { loadDotenv } from "../../env.js";
 import { CacheFirstLoop, DeepSeekClient, ImmutablePrefix } from "../../index.js";
 import { timestampSuffix } from "../../memory/session.js";
@@ -102,7 +107,25 @@ export async function acpCommand(opts: AcpOptions): Promise<void> {
 
   const defaultDir = resolveDir(opts.dir, process.cwd());
   const sessions = new Map<string, Session>();
+  const sessionContext = new AsyncLocalStorage<string>();
   const server = new AcpServer();
+
+  pauseGate.on((req) => {
+    const auto = autoResolveVerdict(req, loadEditMode());
+    if (auto !== null) {
+      pauseGate.resolve(req.id, auto);
+      return;
+    }
+    const activeSessionId = sessionContext.getStore();
+    if (!activeSessionId || !sessions.has(activeSessionId)) {
+      pauseGate.cancel(req.id);
+      return;
+    }
+    void (async () => {
+      const verdict = await requestPermissionForGate(server, activeSessionId, req);
+      pauseGate.resolve(req.id, verdict);
+    })();
+  });
 
   server.onRequest<InitializeParams, InitializeResult>("initialize", (params) => {
     if (!params || typeof params !== "object") {
@@ -150,16 +173,18 @@ export async function acpCommand(opts: AcpOptions): Promise<void> {
     session.aborter = new AbortController();
     let stopReason: StopReason = "end_turn";
     try {
-      for await (const ev of session.loop.step(text)) {
-        if (session.aborter.signal.aborted) {
-          stopReason = "cancelled";
-          break;
+      await sessionContext.run(session.id, async () => {
+        for await (const ev of session.loop.step(text)) {
+          if (session.aborter?.signal.aborted) {
+            stopReason = "cancelled";
+            break;
+          }
+          for (const kev of session.eventizer.consume(ev, session.ctx)) {
+            dispatchKernelEvent(server, session.id, kev);
+            if (kev.type === "error") stopReason = "error";
+          }
         }
-        for (const kev of session.eventizer.consume(ev, session.ctx)) {
-          dispatchKernelEvent(server, session.id, kev);
-          if (kev.type === "error") stopReason = "error";
-        }
-      }
+      });
     } catch (err) {
       const message = (err as Error).message;
       server.sendNotification("session/update", {

--- a/tests/acp.test.ts
+++ b/tests/acp.test.ts
@@ -3,6 +3,7 @@
 import { PassThrough } from "node:stream";
 import { describe, expect, it } from "vitest";
 import { dispatchKernelEvent, toolKindFor } from "../src/acp/dispatch.js";
+import { permissionOptionsFor, requestPermissionForGate, verdictFor } from "../src/acp/gates.js";
 import {
   ACP_PROTOCOL_VERSION,
   type ContentBlock,
@@ -12,6 +13,7 @@ import {
 } from "../src/acp/protocol.js";
 import { AcpServer } from "../src/acp/server.js";
 import type { Event as KernelEvent } from "../src/core/events.js";
+import type { PauseRequest } from "../src/core/pause-gate.js";
 
 function makePair(): {
   server: AcpServer;
@@ -327,6 +329,193 @@ describe("ACP kernel-event dispatch", () => {
     expect(toolKindFor("run_command")).toBe("execute");
     expect(toolKindFor("run_background")).toBe("execute");
     expect(toolKindFor("totally_made_up_tool")).toBe("other");
+  });
+});
+
+describe("ACP outbound requests + gate bridge", () => {
+  it("sendRequest resolves with the peer's result when the matching id replies", async () => {
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const lines: string[] = [];
+    output.on("data", (chunk: Buffer) => {
+      for (const line of chunk.toString("utf8").split("\n")) {
+        if (line.trim()) lines.push(line.trim());
+      }
+    });
+    const server = new AcpServer({ input, output });
+    const promise = server.sendRequest<{ ok: number }>("ping", { x: 1 });
+    await wait(5);
+    const outboundId = JSON.parse(lines[0] ?? "{}").id;
+    input.write(`${JSON.stringify({ jsonrpc: "2.0", id: outboundId, result: { ok: 42 } })}\n`);
+    expect(await promise).toEqual({ ok: 42 });
+    server.close();
+  });
+
+  it("sendRequest rejects when the peer returns an error", async () => {
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const lines: string[] = [];
+    output.on("data", (chunk: Buffer) => {
+      for (const line of chunk.toString("utf8").split("\n")) {
+        if (line.trim()) lines.push(line.trim());
+      }
+    });
+    const server = new AcpServer({ input, output });
+    const promise = server.sendRequest("oops", {});
+    await wait(5);
+    const id = JSON.parse(lines[0] ?? "{}").id;
+    input.write(
+      `${JSON.stringify({
+        jsonrpc: "2.0",
+        id,
+        error: { code: -32000, message: "denied" },
+      })}\n`,
+    );
+    await expect(promise).rejects.toThrow("denied");
+    server.close();
+  });
+
+  it("close() rejects all in-flight outbound requests", async () => {
+    const input = new PassThrough();
+    const output = new PassThrough();
+    output.on("data", () => {});
+    const server = new AcpServer({ input, output });
+    const promise = server.sendRequest("never");
+    server.close();
+    await expect(promise).rejects.toThrow(/closed/);
+  });
+
+  describe("permissionOptionsFor", () => {
+    it("offers allow_once / allow_always / reject for shell commands", () => {
+      const req: PauseRequest = {
+        id: 1,
+        kind: "run_command",
+        payload: { command: "rm -rf /" },
+      };
+      const opts = permissionOptionsFor(req);
+      expect(opts.map((o) => o.kind)).toEqual(["allow_once", "allow_always", "reject_once"]);
+    });
+
+    it("offers approve / refine / cancel for plan_proposed", () => {
+      const req: PauseRequest = {
+        id: 2,
+        kind: "plan_proposed",
+        payload: { plan: "do the thing" },
+      };
+      const ids = permissionOptionsFor(req).map((o) => o.optionId);
+      expect(ids).toEqual(["allow_once", "refine", "cancel"]);
+    });
+
+    it("offers continue / revise / stop for plan_checkpoint", () => {
+      const req: PauseRequest = {
+        id: 3,
+        kind: "plan_checkpoint",
+        payload: { stepId: "s1", result: "done" },
+      };
+      const ids = permissionOptionsFor(req).map((o) => o.optionId);
+      expect(ids).toEqual(["allow_once", "revise", "stop"]);
+    });
+  });
+
+  describe("verdictFor", () => {
+    it("shell allow_once → run_once", () => {
+      const req: PauseRequest = {
+        id: 1,
+        kind: "run_command",
+        payload: { command: "ls -la /tmp" },
+      };
+      expect(verdictFor(req, { outcome: { outcome: "selected", optionId: "allow_once" } })).toEqual(
+        { type: "run_once" },
+      );
+    });
+
+    it("shell allow_always → always_allow with command-prefix glob", () => {
+      const req: PauseRequest = {
+        id: 1,
+        kind: "run_command",
+        payload: { command: "git status -sb" },
+      };
+      expect(
+        verdictFor(req, { outcome: { outcome: "selected", optionId: "allow_always" } }),
+      ).toEqual({ type: "always_allow", prefix: "git *" });
+    });
+
+    it("shell cancelled / reject → deny", () => {
+      const req: PauseRequest = {
+        id: 1,
+        kind: "run_command",
+        payload: { command: "rm -rf /" },
+      };
+      expect(verdictFor(req, { outcome: { outcome: "cancelled" } })).toEqual({ type: "deny" });
+      expect(verdictFor(req, { outcome: { outcome: "selected", optionId: "reject" } })).toEqual({
+        type: "deny",
+      });
+    });
+
+    it("plan checkpoint continue / revise / stop map cleanly", () => {
+      const req: PauseRequest = {
+        id: 1,
+        kind: "plan_checkpoint",
+        payload: { stepId: "s1", result: "" },
+      };
+      expect(verdictFor(req, { outcome: { outcome: "selected", optionId: "allow_once" } })).toEqual(
+        { type: "continue" },
+      );
+      expect(verdictFor(req, { outcome: { outcome: "selected", optionId: "revise" } })).toEqual({
+        type: "revise",
+      });
+      expect(verdictFor(req, { outcome: { outcome: "cancelled" } })).toEqual({ type: "stop" });
+    });
+
+    it("plan_revision accept / reject / cancel map cleanly", () => {
+      const req: PauseRequest = {
+        id: 1,
+        kind: "plan_revision",
+        payload: { reason: "", remainingSteps: [] },
+      };
+      expect(verdictFor(req, { outcome: { outcome: "selected", optionId: "accept" } })).toEqual({
+        type: "accepted",
+      });
+      expect(verdictFor(req, { outcome: { outcome: "selected", optionId: "reject" } })).toEqual({
+        type: "rejected",
+      });
+      expect(verdictFor(req, { outcome: { outcome: "cancelled" } })).toEqual({
+        type: "cancelled",
+      });
+    });
+  });
+
+  it("requestPermissionForGate round-trips via sendRequest and returns the mapped verdict", async () => {
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const lines: string[] = [];
+    output.on("data", (chunk: Buffer) => {
+      for (const line of chunk.toString("utf8").split("\n")) {
+        if (line.trim()) lines.push(line.trim());
+      }
+    });
+    const server = new AcpServer({ input, output });
+    const req: PauseRequest = {
+      id: 7,
+      kind: "run_command",
+      payload: { command: "pnpm test" },
+    };
+    const verdictPromise = requestPermissionForGate(server, "s1", req);
+    await wait(5);
+    const sent = JSON.parse(lines[0] ?? "{}");
+    expect(sent.method).toBe("session/request_permission");
+    expect(sent.params.sessionId).toBe("s1");
+    expect(sent.params.toolCall.kind).toBe("execute");
+    expect(sent.params.options.length).toBe(3);
+    input.write(
+      `${JSON.stringify({
+        jsonrpc: "2.0",
+        id: sent.id,
+        result: { outcome: { outcome: "selected", optionId: "allow_always" } },
+      })}\n`,
+    );
+    expect(await verdictPromise).toEqual({ type: "always_allow", prefix: "pnpm *" });
+    server.close();
   });
 });
 


### PR DESCRIPTION
## Summary

Final ACP slice tracked in #103, building on the stage-1 NDJSON foundation (#714) and the stage-2 tool-event mapping (#715).

Internal `PauseGate` requests — shell command confirmation, plan approval, plan checkpoints, plan revisions, and `choice` — now surface to the ACP host as outbound `session/request_permission` requests. The host's response is mapped back into the Reasonix verdict shape and resolved into the gate. A Zed / JetBrains / AionUI host can now drive a real Reasonix flow end-to-end, including the mobile-bridge use case @lin0kin sketched in #103 (Feishu/Telegram → AionUI → reasonix on a remote VPS, with shell-command authorization forwarded to the user's phone).

### Mechanics

**Outbound JSON-RPC** — `AcpServer` gains:
- `sendRequest(method, params): Promise<unknown>` with monotonic id tracking
- a new branch in `handleLine` that routes `{ id, result|error }` (no `method`) frames to the matching pending entry
- `close()` rejects all in-flight outbound calls with `Error("server closed")`

**Gate bridge** — `src/acp/gates.ts`:

| PauseGate kind | ACP options | Verdict mapping |
|---|---|---|
| `run_command` / `run_background` / `path_access` | `allow_once` / `allow_always` / `reject` | `run_once` / `always_allow (with prefix glob)` / `deny` |
| `plan_proposed` | `allow_once` / `refine` / `cancel` | `approve` / `refine` / `cancel` |
| `plan_checkpoint` | `allow_once` / `revise` / `stop` | `continue` / `revise` / `stop` |
| `plan_revision` | `accept` / `reject` | `accepted` / `rejected` (cancelled → `cancelled`) |
| `choice` | each option from payload + `cancel` | `pick (optionId)` / `cancel` |

`allow_always` for a shell command produces a `{firstWord} *` glob prefix so the same decision auto-resolves next time via the existing `pause-policy`. `allow_always` for `path_access` uses the request's `allowPrefix` field verbatim.

**Lifecycle** — `acpCommand` registers a global `pauseGate.on` listener that:
1. Runs the shared `autoResolveVerdict(req, editMode)` first (yolo/auto modes still bypass the host, matching desktop/TUI behavior)
2. If not auto-resolved, finds the active session via `AsyncLocalStorage` (set inside `sessionContext.run` around the loop iteration)
3. Forwards as `session/request_permission`, awaits the host response, and calls `pauseGate.resolve(req.id, verdict)`
4. Gates that fire outside any active session (initialization races) get cancelled cleanly via `pauseGate.cancel(req.id)`

### What's deferred

- `session/load` — capability advertised as `false`; we have the session-load primitive but haven't wired it through the ACP method yet
- `mcpServers` param on `session/new` — declared in the type but ignored; would need MCP-bridge plumbing
- Plan-progress `session/update` with `sessionUpdate: "plan"` entries — currently the host learns about plans via the per-gate `session/request_permission`; the dedicated plan update is a nice-to-have

### Test plan

- [x] `npm run verify` — 179 files, 2743 tests pass, biome clean
- [x] `tests/acp.test.ts` — 12 new tests for stage 3 covering:
  - `sendRequest` resolves with the peer's result; rejects with the peer's error message
  - `close()` rejects all in-flight outbound requests
  - `permissionOptionsFor` produces the right option list for shell / plan_proposed / plan_checkpoint
  - `verdictFor` maps shell `allow_once` → `run_once`, `allow_always` → `always_allow with command-prefix glob`, cancelled/reject → `deny`
  - `verdictFor` maps `plan_checkpoint` continue/revise/stop, `plan_revision` accept/reject/cancelled
  - `requestPermissionForGate` end-to-end round-trip via the live server: sends `session/request_permission`, gets a response, returns the mapped verdict

### Closing the umbrella

After this PR lands, the three core ACP capabilities are wired:
- ✅ stage 1 — initialize / session/new / session/prompt / session/cancel
- ✅ stage 2 — tool_call / tool_call_update for every internal tool
- ✅ stage 3 — session/request_permission for every gate

#103 should be closeable on merge. Filing the residual session/load + mcpServers items as separate issues if anyone hits them.

Refs #103
