### PR TITLE
feat(desktop): cmdk palette restyle, splash intro, workdir popover

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -22,7 +22,9 @@ import { ContextPanel } from "./ui/context-panel";
 import { InterruptBar, useElapsed } from "./ui/live";
 import { SettingsModal } from "./ui/settings";
 import { Sidebar } from "./ui/sidebar";
+import { Splash, shouldShowSplash } from "./ui/splash";
 import { StatusBar } from "./ui/statusbar";
+import { WorkdirPop } from "./ui/workdir-pop";
 import {
   ActivePlanTaskCard,
   AssistantMsg,
@@ -729,6 +731,9 @@ function TabRuntime({
   });
   const [draft, setDraft] = useState("");
   const [toast, setToast] = useState<string | null>(null);
+  const [splashOn, setSplashOn] = useState<boolean>(() => shouldShowSplash());
+  const [wdOpen, setWdOpen] = useState(false);
+  const [wdAnchor, setWdAnchor] = useState<{ top: number; left: number } | undefined>(undefined);
   const composerRef = useRef<HTMLTextAreaElement>(null);
   const threadRef = useRef<HTMLDivElement>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -859,6 +864,10 @@ function TabRuntime({
       } else if (mod && (e.key === "n" || e.key === "N")) {
         e.preventDefault();
         newChat();
+      } else if (mod && (e.key === "o" || e.key === "O")) {
+        e.preventDefault();
+        setWdAnchor(undefined);
+        setWdOpen((v) => !v);
       } else if (mod && e.key === ",") {
         e.preventDefault();
         setSettingsOpen((v) => !v);
@@ -1083,7 +1092,10 @@ function TabRuntime({
                 onAbort={abort}
                 onNewChat={newChat}
                 onExport={exportConversation}
-                onPickWorkspace={pickWorkspace}
+                onOpenWorkdir={(anchor) => {
+                  setWdAnchor(anchor);
+                  setWdOpen(true);
+                }}
               />
               {state.settings?.editMode === "yolo" ? (
                 <div className="mode-banner">
@@ -1305,6 +1317,16 @@ function TabRuntime({
           commands={commands}
         />
 
+        <WorkdirPop
+          open={wdOpen}
+          onClose={() => setWdOpen(false)}
+          recent={state.settings?.recentWorkspaces ?? []}
+          current={state.settings?.workspaceDir}
+          anchor={wdAnchor}
+          onPick={(path) => saveSettings({ workspaceDir: path })}
+          onBrowse={pickWorkspace}
+        />
+
         {settingsOpen && state.settings ? (
           <SettingsModal
             settings={state.settings}
@@ -1319,6 +1341,8 @@ function TabRuntime({
         ) : null}
 
         <Toast message={toast} />
+
+        {splashOn ? <Splash onDone={() => setSplashOn(false)} /> : null}
       </div>
     </WorkspaceProvider>
   );
@@ -1546,7 +1570,7 @@ function MainHead({
   onAbort,
   onNewChat,
   onExport,
-  onPickWorkspace,
+  onOpenWorkdir,
 }: {
   session: string;
   model?: string;
@@ -1556,7 +1580,7 @@ function MainHead({
   onAbort: () => void;
   onNewChat: () => void;
   onExport: () => void;
-  onPickWorkspace: () => void;
+  onOpenWorkdir: (anchor: { top: number; left: number }) => void;
 }) {
   const wsLabel = workspaceDir ? workspaceDir.split(/[\\/]/).pop() || "workspace" : "未选择工作区";
   return (
@@ -1573,7 +1597,11 @@ function MainHead({
         </h1>
         <div className="sub">
           <span
-            onClick={onPickWorkspace}
+            className="ws-crumb"
+            onClick={(e) => {
+              const r = (e.currentTarget as HTMLElement).getBoundingClientRect();
+              onOpenWorkdir({ top: r.bottom + 6, left: r.left });
+            }}
             style={{ cursor: "pointer" }}
             title={workspaceDir ?? "点击选择工作区"}
           >

--- a/desktop/src/CommandPalette.tsx
+++ b/desktop/src/CommandPalette.tsx
@@ -1,14 +1,13 @@
 import {
   ClipboardCopy,
-  CornerDownLeft,
   Download,
   FilePlus,
   FocusIcon,
   FolderOpen,
   Info,
   Plus,
+  Search,
   Settings,
-  Sparkles,
   SquareX,
   StopCircle,
   Trash2,
@@ -16,12 +15,15 @@ import {
 import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { t, useLang } from "./i18n";
 
+export type CommandGroup = "nav" | "action" | "workspace" | "settings";
+
 export type Command = {
   id: string;
   label: string;
   hint?: string;
   icon: ReactNode;
   shortcut?: string[];
+  group: CommandGroup;
   run: () => void;
 };
 
@@ -64,17 +66,19 @@ export function buildCommands(handlers: CommandHandlers): Command[] {
   const list: Command[] = [
     {
       id: "new-chat",
+      group: "nav",
       label: t("palette.newChat"),
       hint: t("palette.newChatHint"),
-      icon: <FilePlus size={14} />,
+      icon: <FilePlus size={13} />,
       shortcut: ["⌘", "N"],
       run: handlers.newChat,
     },
     {
       id: "new-tab",
+      group: "nav",
       label: t("palette.newTab"),
       hint: t("palette.newTabHint"),
-      icon: <Plus size={14} />,
+      icon: <Plus size={13} />,
       shortcut: ["⌘", "T"],
       run: handlers.newTab,
     },
@@ -82,19 +86,29 @@ export function buildCommands(handlers: CommandHandlers): Command[] {
   if (handlers.canCloseTab) {
     list.push({
       id: "close-tab",
+      group: "nav",
       label: t("palette.closeTab"),
       hint: t("palette.closeTabHint"),
-      icon: <SquareX size={14} />,
+      icon: <SquareX size={13} />,
       shortcut: ["⌘", "W"],
       run: handlers.closeTab,
     });
   }
+  list.push({
+    id: "focus-composer",
+    group: "nav",
+    label: t("palette.focusComposer"),
+    icon: <FocusIcon size={13} />,
+    shortcut: ["⌘", "L"],
+    run: handlers.focusComposer,
+  });
   if (handlers.busy) {
     list.push({
       id: "abort",
+      group: "action",
       label: t("palette.abort"),
       hint: t("palette.abortHint"),
-      icon: <StopCircle size={14} />,
+      icon: <StopCircle size={13} />,
       shortcut: ["esc"],
       run: handlers.abort,
     });
@@ -102,54 +116,64 @@ export function buildCommands(handlers: CommandHandlers): Command[] {
   if (handlers.hasMessages) {
     list.push({
       id: "copy-last",
+      group: "action",
       label: t("palette.copyLast"),
       hint: t("palette.copyLastHint"),
-      icon: <ClipboardCopy size={14} />,
+      icon: <ClipboardCopy size={13} />,
       run: handlers.copyLast,
     });
     list.push({
       id: "export-md",
+      group: "action",
       label: t("palette.exportMd"),
       hint: t("palette.exportMdHint"),
-      icon: <Download size={14} />,
+      icon: <Download size={13} />,
       run: handlers.exportMarkdown,
     });
     list.push({
       id: "clear-chat",
+      group: "action",
       label: t("palette.clearChat"),
       hint: t("palette.clearChatHint"),
-      icon: <Trash2 size={14} />,
+      icon: <Trash2 size={13} />,
       run: handlers.clearChat,
     });
   }
   list.push({
-    id: "focus-composer",
-    label: t("palette.focusComposer"),
-    icon: <FocusIcon size={14} />,
-    shortcut: ["⌘", "L"],
-    run: handlers.focusComposer,
-  });
-  list.push({
     id: "pick-workspace",
+    group: "workspace",
     label: t("palette.pickWorkspace"),
     hint: t("palette.pickWorkspaceHint"),
-    icon: <FolderOpen size={14} />,
+    icon: <FolderOpen size={13} />,
     run: handlers.pickWorkspace,
   });
   list.push({
     id: "settings",
+    group: "settings",
     label: t("palette.settings"),
     hint: t("palette.settingsHint"),
-    icon: <Settings size={14} />,
+    icon: <Settings size={13} />,
     run: handlers.openSettings,
   });
   list.push({
     id: "about",
+    group: "settings",
     label: t("palette.about"),
-    icon: <Info size={14} />,
+    icon: <Info size={13} />,
     run: handlers.about,
   });
   return list;
+}
+
+const GROUP_ORDER: CommandGroup[] = ["nav", "action", "workspace", "settings"];
+
+function groupLabel(g: CommandGroup): string {
+  switch (g) {
+    case "nav": return t("palette.groupNav");
+    case "action": return t("palette.groupAction");
+    case "workspace": return t("palette.groupWorkspace");
+    case "settings": return t("palette.groupSettings");
+  }
 }
 
 export function CommandPalette({
@@ -192,6 +216,18 @@ export function CommandPalette({
     el?.scrollIntoView({ block: "nearest" });
   }, [active]);
 
+  const grouped = useMemo(() => {
+    const byGroup = new Map<CommandGroup, Command[]>();
+    for (const c of filtered) {
+      const arr = byGroup.get(c.group) ?? [];
+      arr.push(c);
+      byGroup.set(c.group, arr);
+    }
+    return GROUP_ORDER
+      .map((g) => ({ group: g, items: byGroup.get(g) ?? [] }))
+      .filter((s) => s.items.length > 0);
+  }, [filtered]);
+
   if (!open) return null;
 
   const run = (cmd: Command) => {
@@ -200,13 +236,12 @@ export function CommandPalette({
   };
 
   return (
-    <div className="palette-overlay" onMouseDown={onClose}>
-      <div className="palette" onMouseDown={(e) => e.stopPropagation()}>
-        <div className="palette-head">
-          <Sparkles size={14} className="palette-glyph" />
+    <div className="cmdk-mask" onMouseDown={onClose}>
+      <div className="cmdk" onMouseDown={(e) => e.stopPropagation()}>
+        <div className="cmdk-head">
+          <Search size={14} />
           <input
             ref={inputRef}
-            className="palette-input"
             placeholder={t("palette.searchPlaceholder")}
             value={query}
             onChange={(e) => setQuery(e.target.value)}
@@ -224,52 +259,57 @@ export function CommandPalette({
               }
             }}
           />
-          <span className="kbd">esc</span>
+          <span className="hint">
+            <kbd>esc</kbd>
+          </span>
         </div>
-        <div className="palette-list" ref={listRef}>
-          {filtered.length === 0 && <div className="palette-empty">{t("palette.empty")}</div>}
-          {filtered.map((c, i) => (
-            <button
-              type="button"
-              key={c.id}
-              data-idx={i}
-              className={`palette-item ${i === active ? "active" : ""}`}
-              onMouseEnter={() => setActive(i)}
-              onClick={() => run(c)}
-            >
-              <span className="palette-item-icon">{c.icon}</span>
-              <span className="palette-item-label">
-                <span>{c.label}</span>
-                {c.hint && <span className="palette-item-hint">{c.hint}</span>}
-              </span>
-              {c.shortcut && (
-                <span className="palette-item-kbd">
-                  {c.shortcut.map((k) => (
-                    <span key={k} className="kbd">
-                      {k}
-                    </span>
-                  ))}
-                </span>
-              )}
-              {i === active && !c.shortcut && (
-                <CornerDownLeft size={12} className="palette-item-enter" />
-              )}
-            </button>
+        <div className="cmdk-body" ref={listRef}>
+          {filtered.length === 0 ? (
+            <div className="cmdk-empty">{t("palette.empty")}</div>
+          ) : null}
+          {grouped.map((section) => (
+            <div className="cmdk-group" key={section.group}>
+              <div className="cmdk-gh">{groupLabel(section.group)}</div>
+              {section.items.map((c) => {
+                const i = filtered.indexOf(c);
+                return (
+                  <div
+                    key={c.id}
+                    data-idx={i}
+                    className="cmdk-row"
+                    data-active={i === active}
+                    onMouseEnter={() => setActive(i)}
+                    onClick={() => run(c)}
+                  >
+                    <span className="ic">{c.icon}</span>
+                    <span className="l">{c.label}</span>
+                    <span className="g">{groupLabel(c.group)}</span>
+                    {c.shortcut ? (
+                      <span className="kb">{c.shortcut.join("")}</span>
+                    ) : (
+                      <span className="kb-empty" />
+                    )}
+                  </div>
+                );
+              })}
+            </div>
           ))}
         </div>
-        <div className="palette-foot">
-          <span className="kbd-group">
-            <span className="kbd">↑</span>
-            <span className="kbd">↓</span>
+        <div className="cmdk-foot">
+          <span>
+            <kbd>↑↓</kbd>
             {t("palette.footMove")}
           </span>
-          <span className="kbd-group">
-            <span className="kbd">↵</span>
+          <span>
+            <kbd>⏎</kbd>
             {t("palette.footRun")}
           </span>
-          <span className="kbd-group">
-            <span className="kbd">esc</span>
+          <span>
+            <kbd>esc</kbd>
             {t("palette.footClose")}
+          </span>
+          <span style={{ marginLeft: "auto", color: "var(--muted)" }}>
+            {filtered.length} {t("palette.countSuffix")}
           </span>
         </div>
       </div>

--- a/desktop/src/i18n/en.ts
+++ b/desktop/src/i18n/en.ts
@@ -25,6 +25,17 @@ export const en = {
     settings: "Settings",
     settingsHint: "Model, budget, theme…",
     about: "About Reasonix",
+    groupNav: "Navigate",
+    groupAction: "Action",
+    groupWorkspace: "Workspace",
+    groupSettings: "Settings",
+    countSuffix: "items",
+  },
+  workdir: {
+    title: "Switch workspace",
+    searchPlaceholder: "Search recent paths…",
+    empty: "No recent workspaces",
+    browse: "Browse local…",
   },
   sidebar: {
     newChat: "New chat",

--- a/desktop/src/i18n/zh-CN.ts
+++ b/desktop/src/i18n/zh-CN.ts
@@ -27,6 +27,17 @@ export const zhCN: typeof en = {
     settings: "设置",
     settingsHint: "模型、预算、主题…",
     about: "关于 Reasonix",
+    groupNav: "导航",
+    groupAction: "动作",
+    groupWorkspace: "目录",
+    groupSettings: "设置",
+    countSuffix: "项",
+  },
+  workdir: {
+    title: "切换工作目录",
+    searchPlaceholder: "搜索最近路径…",
+    empty: "暂无最近工作目录",
+    browse: "浏览本地…",
   },
   sidebar: {
     newChat: "新建会话",

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -4126,13 +4126,12 @@ button {
    ============================================================ */
 .toast {
   position: fixed;
-  bottom: 56px;
-  left: 50%;
-  transform: translateX(-50%);
+  right: 20px;
+  bottom: 48px;
   background: var(--card);
   border: 1px solid var(--border-strong);
   color: var(--fg);
-  padding: 8px 14px;
+  padding: 7px 12px;
   border-radius: 999px;
   font-family: "IBM Plex Mono", monospace;
   font-size: 11.5px;
@@ -4143,6 +4142,490 @@ button {
   white-space: nowrap;
 }
 @keyframes toast-rise {
-  from { opacity: 0; transform: translate(-50%, 8px); }
-  to   { opacity: 1; transform: translate(-50%, 0); }
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: none; }
+}
+
+/* ============================================================
+   Cmd+K — command palette
+   ============================================================ */
+.cmdk-mask {
+  position: fixed;
+  inset: 0;
+  background: oklch(0% 0 0 / 0.5);
+  backdrop-filter: blur(6px);
+  z-index: 150;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 12vh;
+  animation: fade-in 0.18s ease-out;
+}
+[data-theme="light"] .cmdk-mask { background: oklch(0% 0 0 / 0.2); }
+.cmdk {
+  width: min(640px, 92vw);
+  max-height: 70vh;
+  background: var(--bg);
+  border: 1px solid var(--border-strong);
+  border-radius: 12px;
+  box-shadow: var(--shadow-lg);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  animation: rise 0.2s ease-out;
+}
+.cmdk-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+  color: var(--muted);
+}
+.cmdk-head input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  font-size: 14px;
+  color: var(--fg);
+  font-family: inherit;
+}
+.cmdk-head .hint kbd {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 10px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  padding: 1px 5px;
+  border-radius: 4px;
+}
+.cmdk-body {
+  overflow-y: auto;
+  padding: 4px 0;
+}
+.cmdk-group { padding: 4px 0; }
+.cmdk-gh {
+  padding: 6px 14px 2px;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+.cmdk-row {
+  display: grid;
+  grid-template-columns: 22px 1fr auto auto;
+  gap: 10px;
+  align-items: center;
+  padding: 7px 14px;
+  font-size: 13px;
+  cursor: pointer;
+  color: var(--fg-2);
+}
+.cmdk-row[data-active="true"] {
+  background: var(--accent-soft);
+  color: var(--fg);
+}
+.cmdk-row[data-active="true"] .ic { color: var(--accent); }
+.cmdk-row .ic {
+  color: var(--muted);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.cmdk-row .l {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cmdk-row .g {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 10px;
+  color: var(--muted);
+}
+.cmdk-row .kb {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 10px;
+  color: var(--muted-2);
+  background: var(--panel);
+  border: 1px solid var(--border);
+  padding: 1px 5px;
+  border-radius: 4px;
+}
+.cmdk-row .kb-empty { display: inline-block; width: 1px; }
+.cmdk-empty {
+  padding: 24px;
+  text-align: center;
+  color: var(--muted);
+  font-size: 12px;
+}
+.cmdk-foot {
+  display: flex;
+  gap: 12px;
+  padding: 7px 14px;
+  border-top: 1px solid var(--border);
+  background: var(--bg-2);
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 10.5px;
+  color: var(--muted-2);
+  align-items: center;
+}
+.cmdk-foot kbd {
+  background: var(--card);
+  border: 1px solid var(--border);
+  padding: 0 4px;
+  border-radius: 3px;
+  margin-right: 4px;
+}
+
+/* ============================================================
+   Workspace switcher popover
+   ============================================================ */
+.wd-mask {
+  position: fixed;
+  inset: 0;
+  z-index: 140;
+}
+.wd-pop {
+  position: fixed;
+  width: 360px;
+  max-width: calc(100vw - 24px);
+  background: var(--bg);
+  border: 1px solid var(--border-strong);
+  border-radius: 10px;
+  box-shadow: var(--shadow-lg);
+  overflow: hidden;
+  animation: rise 0.16s ease-out;
+}
+.wd-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+  font-size: 12px;
+  color: var(--fg-2);
+}
+.wd-search {
+  width: 100%;
+  padding: 8px 12px;
+  border: none;
+  border-bottom: 1px solid var(--border);
+  background: transparent;
+  outline: none;
+  font-size: 12.5px;
+  color: var(--fg);
+  font-family: inherit;
+}
+.wd-list {
+  max-height: 280px;
+  overflow-y: auto;
+  padding: 4px 0;
+}
+.wd-row {
+  display: grid;
+  grid-template-columns: 20px 1fr auto;
+  gap: 8px;
+  align-items: center;
+  padding: 7px 12px;
+  cursor: pointer;
+}
+.wd-row:hover { background: var(--bg-2); }
+.wd-row .ic { color: var(--muted); display: inline-flex; }
+.wd-row .b { min-width: 0; }
+.wd-row .b .p {
+  font-size: 12.5px;
+  font-family: "IBM Plex Mono", monospace;
+  color: var(--fg);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.wd-row .b .br {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 10.5px;
+  color: var(--muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-top: 1px;
+}
+.wd-row .pin { color: var(--accent); }
+.wd-foot {
+  display: flex;
+  gap: 6px;
+  padding: 8px 10px;
+  border-top: 1px solid var(--border);
+  background: var(--bg-2);
+}
+.wd-foot .btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 10px;
+  border-radius: 6px;
+  font-size: 11.5px;
+  font-family: "IBM Plex Mono", monospace;
+  color: var(--fg-2);
+  border: 1px solid var(--border);
+  background: var(--card);
+  cursor: pointer;
+}
+.wd-foot .btn:hover {
+  background: var(--panel);
+  color: var(--fg);
+}
+.wd-foot .btn.ghost {
+  background: transparent;
+  border-color: var(--border);
+}
+.main-head .sub .ws-crumb:hover {
+  color: var(--accent);
+}
+
+/* ============================================================
+   Splash — opening intro (sub-sea drift, "Reasonix" reveal)
+   ============================================================ */
+.splash {
+  position: fixed;
+  inset: 0;
+  z-index: 300;
+  background: oklch(8% 0.012 250);
+  overflow: hidden;
+  transition: opacity 0.7s ease;
+}
+.splash[data-fade="true"] { opacity: 0; pointer-events: none; }
+.splash-vignette {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    ellipse at 50% 38%,
+    oklch(22% 0.05 250) 0%,
+    oklch(11% 0.015 250) 45%,
+    oklch(6% 0.008 250) 100%
+  );
+}
+.splash-grain {
+  position: absolute;
+  inset: 0;
+  opacity: 0.18;
+  mix-blend-mode: overlay;
+  pointer-events: none;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='160' height='160'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/></filter><rect width='100%' height='100%' filter='url(%23n)' opacity='0.6'/></svg>");
+}
+
+.splash-plankton { position: absolute; inset: 0; }
+.splash .pk {
+  position: absolute;
+  border-radius: 50%;
+  background: oklch(85% 0.10 220);
+  box-shadow: 0 0 6px oklch(80% 0.14 220 / 0.9), 0 0 14px oklch(75% 0.12 220 / 0.6);
+  opacity: 0;
+  animation: pk-rise var(--dur) ease-in-out infinite;
+}
+.splash[data-stage="0"] .pk { opacity: 0; animation: none; }
+@keyframes pk-rise {
+  0%   { opacity: 0; transform: translateY(0) translateX(0) scale(0.6); }
+  12%  { opacity: var(--o); transform: translateY(-8vh) translateX(calc(var(--drift) * 0.2)) scale(1); }
+  50%  { opacity: var(--o); transform: translateY(-35vh) translateX(calc(var(--drift) * 0.6)) scale(1.05); }
+  88%  { opacity: calc(var(--o) * 0.6); }
+  100% { opacity: 0; transform: translateY(-78vh) translateX(var(--drift)) scale(0.85); }
+}
+
+.splash-rays {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  mix-blend-mode: screen;
+}
+.splash .ray {
+  position: absolute;
+  top: -10%;
+  height: 110%;
+  background: linear-gradient(180deg, oklch(85% 0.10 220 / var(--o)) 0%, oklch(70% 0.12 230 / 0) 80%);
+  transform: rotate(var(--rot));
+  filter: blur(14px);
+  animation: ray-flicker 6s ease-in-out infinite;
+  transform-origin: top center;
+}
+@keyframes ray-flicker {
+  0%, 100% { opacity: 0.5; transform: rotate(var(--rot)) translateX(0); }
+  50%      { opacity: 1;   transform: rotate(calc(var(--rot) + 2deg)) translateX(-6px); }
+}
+
+.splash-bokeh {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  filter: blur(2px);
+}
+.splash .bk {
+  position: absolute;
+  border-radius: 50%;
+  opacity: 0;
+  animation: bk-drift var(--dur) ease-in-out infinite;
+}
+.splash[data-stage="0"] .bk { opacity: 0; animation: none; }
+@keyframes bk-drift {
+  0%   { opacity: 0; transform: translate(0, 0) scale(0.7); }
+  20%  { opacity: var(--o); }
+  50%  { transform: translate(calc(var(--drift) * 0.6), -40px) scale(1.1); }
+  80%  { opacity: var(--o); }
+  100% { opacity: 0; transform: translate(var(--drift), -120px) scale(0.85); }
+}
+
+.splash-schools { position: absolute; inset: 0; pointer-events: none; }
+.splash .school {
+  position: absolute;
+  opacity: 0;
+  animation: school-swim var(--dur) ease-in-out infinite;
+}
+.splash[data-stage="0"] .school { opacity: 0; animation: none; }
+@keyframes school-swim {
+  0%   { opacity: 0; transform: translate(-15vw, 0) rotate(-2deg); }
+  15%  { opacity: 0.55; }
+  50%  { transform: translate(0, -4vh) rotate(2deg); }
+  85%  { opacity: 0.55; }
+  100% { opacity: 0; transform: translate(20vw, 2vh) rotate(-2deg); }
+}
+.splash .sd {
+  position: absolute;
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: oklch(85% 0.10 220);
+  box-shadow: 0 0 4px oklch(80% 0.14 220 / 0.8);
+  animation: sd-flick 1.4s ease-in-out infinite;
+}
+@keyframes sd-flick {
+  0%, 100% { opacity: 0.7; }
+  50%      { opacity: 1; transform: translate(1px, -1px); }
+}
+
+.splash-bubbles {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 100%;
+  pointer-events: none;
+}
+.splash .bb {
+  position: absolute;
+  bottom: -20px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, oklch(98% 0.02 220 / 0.7), oklch(80% 0.10 220 / 0.05));
+  border: 1px solid oklch(90% 0.06 220 / 0.4);
+  opacity: 0;
+  animation: bb-rise var(--dur) ease-in infinite;
+}
+.splash[data-stage="0"] .bb { animation: none; }
+@keyframes bb-rise {
+  0%   { opacity: 0; transform: translate(0, 0) scale(0.6); }
+  10%  { opacity: 0.7; }
+  50%  { transform: translate(calc(var(--sway) * 0.5), -50vh) scale(1); }
+  90%  { opacity: 0.7; }
+  100% { opacity: 0; transform: translate(var(--sway), -100vh) scale(1.2); }
+}
+
+.splash-whale {
+  position: absolute;
+  left: -10%;
+  right: -10%;
+  top: 58%;
+  width: 120%;
+  height: 22vh;
+  opacity: 0;
+  transform: translateX(-8%);
+  filter: blur(0.5px);
+}
+.splash[data-stage="2"] .splash-whale,
+.splash[data-stage="3"] .splash-whale,
+.splash[data-stage="4"] .splash-whale {
+  opacity: 1;
+  animation: glide 7s ease-in-out forwards;
+}
+@keyframes glide {
+  from { transform: translateX(-12%) translateY(8px); }
+  to   { transform: translateX(8%) translateY(-4px); }
+}
+
+.splash-stage {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 18px;
+}
+.splash-line {
+  width: 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, oklch(70% 0.12 230 / 0.7), transparent);
+  transition: width 0.9s cubic-bezier(.2,.7,.1,1);
+}
+.splash[data-stage="2"] .splash-line,
+.splash[data-stage="3"] .splash-line,
+.splash[data-stage="4"] .splash-line { width: 360px; }
+
+.splash-wordmark {
+  margin: 0;
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 300;
+  font-size: clamp(48px, 7.5vw, 92px);
+  letter-spacing: -0.025em;
+  color: oklch(96% 0.015 230);
+  position: relative;
+}
+.splash-wordmark .rsx {
+  display: inline-block;
+  background: linear-gradient(180deg, oklch(98% 0.02 230), oklch(82% 0.10 230));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  clip-path: inset(0 100% 0 0);
+  transition: clip-path 1.15s cubic-bezier(.2,.7,.1,1);
+}
+.splash[data-stage="3"] .splash-wordmark .rsx,
+.splash[data-stage="4"] .splash-wordmark .rsx { clip-path: inset(0 0 0 0); }
+.splash-wordmark::after {
+  content: "";
+  position: absolute;
+  top: 8%;
+  bottom: 8%;
+  width: 2px;
+  background: oklch(85% 0.16 230);
+  box-shadow: 0 0 18px oklch(80% 0.18 230);
+  left: 0%;
+  opacity: 0;
+  transition: left 1.15s cubic-bezier(.2,.7,.1,1), opacity 0.3s ease;
+}
+.splash[data-stage="2"] .splash-wordmark::after { opacity: 1; left: 0%; }
+.splash[data-stage="3"] .splash-wordmark::after { opacity: 1; left: 100%; }
+.splash[data-stage="4"] .splash-wordmark::after { opacity: 0; left: 100%; }
+
+.splash-tag {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.32em;
+  color: oklch(72% 0.04 230);
+  opacity: 0;
+  transform: translateY(4px);
+  transition: opacity 0.6s ease 0.3s, transform 0.6s ease 0.3s;
+}
+.splash-tag .dot {
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: oklch(70% 0.10 230);
+}
+.splash[data-stage="3"] .splash-tag,
+.splash[data-stage="4"] .splash-tag {
+  opacity: 1;
+  transform: translateY(0);
 }

--- a/desktop/src/ui/splash.tsx
+++ b/desktop/src/ui/splash.tsx
@@ -1,0 +1,251 @@
+import { useEffect, useRef, useState } from "react";
+
+const SPLASH_FLAG = "reasonix.splash.shown";
+
+export function shouldShowSplash(): boolean {
+  try {
+    return sessionStorage.getItem(SPLASH_FLAG) !== "1";
+  } catch {
+    return true;
+  }
+}
+
+function markSplashShown() {
+  try {
+    sessionStorage.setItem(SPLASH_FLAG, "1");
+  } catch {
+    /* sessionStorage unavailable */
+  }
+}
+
+type Layers = {
+  plankton: { x: number; y: number; r: number; d: number; dur: number; drift: number; o: number }[];
+  bokeh: { x: number; y: number; r: number; d: number; dur: number; drift: number; o: number; hue: number }[];
+  bubbles: { x: number; r: number; d: number; dur: number; sway: number }[];
+  rays: { x: number; rot: number; d: number; w: number; o: number }[];
+  schools: { cx: number; cy: number; d: number; dur: number; dots: { ox: number; oy: number; d: number }[] }[];
+};
+
+function makeLayers(): Layers {
+  const rand = (a: number, b: number) => a + Math.random() * (b - a);
+  return {
+    plankton: Array.from({ length: 90 }, () => ({
+      x: rand(0, 100),
+      y: rand(0, 100),
+      r: rand(0.5, 1.6),
+      d: rand(0, 5),
+      dur: rand(7, 14),
+      drift: rand(-30, 30),
+      o: rand(0.25, 0.7),
+    })),
+    bokeh: Array.from({ length: 14 }, () => ({
+      x: rand(0, 100),
+      y: rand(20, 90),
+      r: rand(6, 18),
+      d: rand(0, 4),
+      dur: rand(12, 22),
+      drift: rand(-40, 40),
+      o: rand(0.05, 0.18),
+      hue: rand(210, 245),
+    })),
+    bubbles: Array.from({ length: 18 }, () => ({
+      x: rand(0, 100),
+      r: rand(2, 6),
+      d: rand(0, 6),
+      dur: rand(5, 9),
+      sway: rand(20, 60),
+    })),
+    rays: Array.from({ length: 5 }, (_, i) => ({
+      x: 10 + i * 20 + rand(-4, 4),
+      rot: rand(-6, 6),
+      d: rand(0, 2),
+      w: rand(40, 90),
+      o: rand(0.05, 0.12),
+    })),
+    schools: Array.from({ length: 3 }, (_, i) => ({
+      cx: 20 + i * 30,
+      cy: 35 + rand(-10, 10),
+      d: i * 0.7,
+      dur: rand(14, 20),
+      dots: Array.from({ length: 12 }, () => ({
+        ox: rand(-4, 4),
+        oy: rand(-2, 2),
+        d: rand(0, 1.5),
+      })),
+    })),
+  };
+}
+
+export function Splash({ onDone }: { onDone: () => void }) {
+  const [stage, setStage] = useState(0);
+  const layersRef = useRef<Layers | null>(null);
+  if (!layersRef.current) layersRef.current = makeLayers();
+  const L = layersRef.current;
+
+  useEffect(() => {
+    const seq = [120, 380, 600, 1500, 700];
+    let acc = 0;
+    const timers = seq.map((d, i) => {
+      acc += d;
+      return window.setTimeout(() => {
+        if (i === seq.length - 1) {
+          markSplashShown();
+          onDone();
+        } else {
+          setStage(i + 1);
+        }
+      }, acc);
+    });
+    return () => {
+      for (const t of timers) window.clearTimeout(t);
+    };
+  }, [onDone]);
+
+  useEffect(() => {
+    const skip = (e: KeyboardEvent) => {
+      if (e.key !== "Escape" && e.key !== "Enter" && e.key !== " ") return;
+      markSplashShown();
+      onDone();
+    };
+    window.addEventListener("keydown", skip);
+    return () => window.removeEventListener("keydown", skip);
+  }, [onDone]);
+
+  const skipClick = () => {
+    markSplashShown();
+    onDone();
+  };
+
+  return (
+    <div className="splash" data-stage={stage} data-fade={stage >= 4} onClick={skipClick}>
+      <div className="splash-vignette" />
+      <div className="splash-grain" />
+
+      <div className="splash-rays">
+        {L.rays.map((r, i) => (
+          <span
+            key={i}
+            className="ray"
+            style={{
+              left: `${r.x}%`,
+              width: `${r.w}px`,
+              ["--rot" as never]: `${r.rot}deg`,
+              ["--o" as never]: r.o,
+              animationDelay: `${r.d}s`,
+            }}
+          />
+        ))}
+      </div>
+
+      <div className="splash-bokeh">
+        {L.bokeh.map((b, i) => (
+          <span
+            key={i}
+            className="bk"
+            style={{
+              left: `${b.x}%`,
+              bottom: `${b.y}%`,
+              width: `${b.r}px`,
+              height: `${b.r}px`,
+              background: `radial-gradient(circle, oklch(82% 0.14 ${b.hue} / 0.9), oklch(60% 0.10 ${b.hue} / 0))`,
+              ["--o" as never]: b.o,
+              ["--dur" as never]: `${b.dur}s`,
+              ["--drift" as never]: `${b.drift}px`,
+              animationDelay: `${b.d}s`,
+            }}
+          />
+        ))}
+      </div>
+
+      <div className="splash-schools">
+        {L.schools.map((s, i) => (
+          <div
+            key={i}
+            className="school"
+            style={{
+              left: `${s.cx}%`,
+              top: `${s.cy}%`,
+              ["--dur" as never]: `${s.dur}s`,
+              animationDelay: `${s.d}s`,
+            }}
+          >
+            {s.dots.map((d, j) => (
+              <span
+                key={j}
+                className="sd"
+                style={{
+                  left: `${d.ox * 4}px`,
+                  top: `${d.oy * 4}px`,
+                  animationDelay: `${d.d}s`,
+                }}
+              />
+            ))}
+          </div>
+        ))}
+      </div>
+
+      <div className="splash-plankton">
+        {L.plankton.map((p, i) => (
+          <span
+            key={i}
+            className="pk"
+            style={{
+              left: `${p.x}%`,
+              bottom: `${-(p.y / 2)}%`,
+              width: `${p.r}px`,
+              height: `${p.r}px`,
+              ["--o" as never]: p.o,
+              ["--dur" as never]: `${p.dur}s`,
+              ["--drift" as never]: `${p.drift}px`,
+              animationDelay: `${p.d}s`,
+            }}
+          />
+        ))}
+      </div>
+
+      <div className="splash-bubbles">
+        {L.bubbles.map((b, i) => (
+          <span
+            key={i}
+            className="bb"
+            style={{
+              left: `${b.x}%`,
+              width: `${b.r}px`,
+              height: `${b.r}px`,
+              ["--dur" as never]: `${b.dur}s`,
+              ["--sway" as never]: `${b.sway}px`,
+              animationDelay: `${b.d}s`,
+            }}
+          />
+        ))}
+      </div>
+
+      <svg className="splash-whale" viewBox="0 0 1200 200" preserveAspectRatio="none">
+        <defs>
+          <linearGradient id="whaleSil" x1="0" y1="0" x2="1" y2="0">
+            <stop offset="0%" stopColor="oklch(78% 0.12 240)" stopOpacity="0" />
+            <stop offset="40%" stopColor="oklch(78% 0.12 240)" stopOpacity="0.18" />
+            <stop offset="70%" stopColor="oklch(78% 0.12 240)" stopOpacity="0.10" />
+            <stop offset="100%" stopColor="oklch(78% 0.12 240)" stopOpacity="0" />
+          </linearGradient>
+        </defs>
+        <path
+          d="M 60 120 C 200 70, 420 60, 680 95 C 820 115, 920 130, 1010 122 C 1040 118, 1075 92, 1095 70 C 1095 95, 1080 122, 1055 138 C 990 155, 820 168, 660 158 C 420 142, 220 152, 60 138 Z"
+          fill="url(#whaleSil)"
+        />
+      </svg>
+
+      <div className="splash-stage">
+        <div className="splash-line" />
+        <h1 className="splash-wordmark">
+          <span className="rsx">Reasonix</span>
+        </h1>
+        <div className="splash-tag">
+          <span className="dot" />
+          <span>DEEPSEEK&nbsp;·&nbsp;AGENTS</span>
+          <span className="dot" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/ui/workdir-pop.tsx
+++ b/desktop/src/ui/workdir-pop.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { I } from "../icons";
+import { t, useLang } from "../i18n";
+
+type Anchor = { top: number; left: number };
+
+export function WorkdirPop({
+  open,
+  onClose,
+  recent,
+  current,
+  anchor,
+  onPick,
+  onBrowse,
+}: {
+  open: boolean;
+  onClose: () => void;
+  recent: string[];
+  current?: string;
+  anchor?: Anchor;
+  onPick: (path: string) => void;
+  onBrowse: () => void;
+}) {
+  useLang();
+  const [query, setQuery] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setQuery("");
+    const id = window.setTimeout(() => inputRef.current?.focus(), 40);
+    return () => window.clearTimeout(id);
+  }, [open]);
+
+  const items = useMemo(() => {
+    const list = recent.length > 0 ? recent : current ? [current] : [];
+    const q = query.trim().toLowerCase();
+    if (!q) return list;
+    return list.filter((p) => p.toLowerCase().includes(q));
+  }, [recent, current, query]);
+
+  if (!open) return null;
+
+  const top = anchor?.top ?? 56;
+  const left = anchor?.left ?? 240;
+
+  return (
+    <div className="wd-mask" onMouseDown={onClose}>
+      <div
+        className="wd-pop"
+        style={{ top, left }}
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        <div className="wd-head">
+          <I.folder size={12} />
+          <span>{t("workdir.title")}</span>
+          <span
+            style={{
+              marginLeft: "auto",
+              fontFamily: "IBM Plex Mono, monospace",
+              fontSize: 10,
+              color: "var(--muted)",
+            }}
+          >
+            ⌘O
+          </span>
+        </div>
+        <input
+          ref={inputRef}
+          className="wd-search"
+          placeholder={t("workdir.searchPlaceholder")}
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Escape") {
+              e.preventDefault();
+              onClose();
+            } else if (e.key === "Enter" && items[0]) {
+              e.preventDefault();
+              onPick(items[0]);
+              onClose();
+            }
+          }}
+        />
+        <div className="wd-list">
+          {items.length === 0 ? (
+            <div
+              style={{
+                padding: "16px 12px",
+                fontSize: 11.5,
+                color: "var(--muted)",
+                fontFamily: "IBM Plex Mono, monospace",
+              }}
+            >
+              {t("workdir.empty")}
+            </div>
+          ) : null}
+          {items.map((p) => {
+            const isCurrent = p === current;
+            const name = p.split(/[\\/]/).filter(Boolean).pop() ?? p;
+            return (
+              <div
+                key={p}
+                className="wd-row"
+                onClick={() => {
+                  if (!isCurrent) onPick(p);
+                  onClose();
+                }}
+                title={p}
+              >
+                <span className="ic">
+                  <I.folder size={12} />
+                </span>
+                <div className="b">
+                  <div className="p">{name}</div>
+                  <div className="br">{p}</div>
+                </div>
+                {isCurrent ? (
+                  <span className="pin">
+                    <I.check size={11} />
+                  </span>
+                ) : null}
+              </div>
+            );
+          })}
+        </div>
+        <div className="wd-foot">
+          <button
+            type="button"
+            className="btn ghost"
+            onClick={() => {
+              onBrowse();
+              onClose();
+            }}
+          >
+            <I.plus size={11} /> {t("workdir.browse")}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Bring back the Cmd+K palette styling under `.cmdk-*` (the card-based UI rebuild dropped the old `.palette-*` rules, so the palette was rendering unstyled). New version is grouped — 导航 / 动作 / 目录 / 设置 — with a Search head icon and an item-count in the footer.
- Add the opening **Splash** intro: plankton + caustic rays + a whale silhouette glide, then a wipe-reveal of the Reasonix wordmark. Runs ~3.3 s on first launch per session, skippable by click / Esc / Enter / Space. `sessionStorage`-gated so Vite HMR reloads don't re-trigger it.
- Add the **workspace switcher popover**: click the workspace breadcrumb in the main head (or press Cmd+O) → lists `Settings.recentWorkspaces`, search field, current path checkmarked, falls back to the existing native dir picker via a "browse local…" button.
- Move the transient `flashToast` from bottom-center to bottom-right so it stops landing on top of the Review / Auto / YOLO switch at the bottom of the composer.

## Test plan

- [ ] Cold launch the Tauri desktop client → splash plays, then dismisses; subsequent Vite HMR reloads don't replay it
- [ ] Press Esc / Enter / Space / click during splash → dismisses immediately
- [ ] Cmd+K → palette opens, grouped sections render with correct shortcuts and item count footer
- [ ] Cmd+O → workdir popover opens; clicking the workspace breadcrumb opens it anchored under the breadcrumb
- [ ] Picking a recent workspace switches `workspaceDir`; "browse local…" still opens the native picker
- [ ] Switch model / edit mode → flashToast appears bottom-right, no longer obscures the mode switch
- [ ] Toggle between zh-CN and en — palette group labels and workdir popover strings localize
