### PR TITLE
fix(web): poll /overview every 2.5s in Changes page chat

### DIFF
--- a/dashboard/src/panels/changes.ts
+++ b/dashboard/src/panels/changes.ts
@@ -1283,18 +1283,22 @@ function ChatPane(props: ChatPaneProps) {
 
   useEffect(() => {
     let cancelled = false;
-    (async () => {
+    const tick = async () => {
       try {
         const data = await api<OverviewResponse>("/overview");
-        if (!cancelled) {
-          setStats(data.stats ?? null);
-          setModel(data.model ?? null);
-        }
+        if (cancelled) return;
+        setStats(data.stats ?? null);
+        setModel(data.model ?? null);
       } catch {
         /* swallow */
       }
-    })();
-    return () => { cancelled = true; };
+    };
+    tick();
+    const t = setInterval(tick, 2500);
+    return () => {
+      cancelled = true;
+      clearInterval(t);
+    };
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
fix(web): poll /overview every 2.5s in Changes page chat
- Align with ChatPanel behavior — the stats bar now refreshes
- periodically instead of only fetching once at mount.

<!-- Read CONTRIBUTING.md first if this is your first PR. -->


## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time
