### PR TITLE
feat(desktop): wire up stubbed UI surfaces; functional MCP + Skills pages

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -6,6 +6,7 @@ import { type Update, check } from "@tauri-apps/plugin-updater";
 import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import { CommandPalette, Toast, buildCommands, useCommandPalette } from "./CommandPalette";
 import { I } from "./icons";
+import { getLang, setLang } from "./i18n";
 import { WorkspaceProvider } from "./Markdown";
 import type {
   CheckpointVerdict,
@@ -20,7 +21,7 @@ import type {
 import { Composer, type SlashCmd } from "./ui/composer";
 import { ContextPanel } from "./ui/context-panel";
 import { InterruptBar, useElapsed } from "./ui/live";
-import { SettingsModal } from "./ui/settings";
+import { type PageId as SettingsPageId, SettingsModal } from "./ui/settings";
 import { Sidebar } from "./ui/sidebar";
 import { Splash, shouldShowSplash } from "./ui/splash";
 import { StatusBar } from "./ui/statusbar";
@@ -52,7 +53,7 @@ export type AssistantSegment =
       durationMs?: number;
     };
 
-type ChatMessage =
+export type ChatMessage =
   | { kind: "user"; text: string; clientId: string; turn: number }
   | {
       kind: "assistant";
@@ -737,6 +738,11 @@ function TabRuntime({
   const composerRef = useRef<HTMLTextAreaElement>(null);
   const threadRef = useRef<HTMLDivElement>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [settingsPage, setSettingsPage] = useState<SettingsPageId>("general");
+  const openSettingsAt = useCallback((page: SettingsPageId = "general") => {
+    setSettingsPage(page);
+    setSettingsOpen(true);
+  }, []);
   const palette = useCommandPalette();
 
   useEffect(() => {
@@ -870,7 +876,8 @@ function TabRuntime({
         setWdOpen((v) => !v);
       } else if (mod && e.key === ",") {
         e.preventDefault();
-        setSettingsOpen((v) => !v);
+        if (settingsOpen) setSettingsOpen(false);
+        else openSettingsAt("general");
       } else if (e.key === "Escape" && state.busy) {
         const target = e.target as HTMLElement | null;
         if (target?.tagName === "INPUT" || target?.tagName === "TEXTAREA") return;
@@ -880,7 +887,7 @@ function TabRuntime({
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [state.busy, abort, newChat]);
+  }, [state.busy, abort, newChat, settingsOpen, openSettingsAt]);
 
   const commands = buildCommands({
     newChat: () => {
@@ -892,7 +899,7 @@ function TabRuntime({
       flashToast("已清空");
     },
     focusComposer: () => composerRef.current?.focus(),
-    openSettings: () => setSettingsOpen(true),
+    openSettings: () => openSettingsAt("general"),
     about: () => flashToast(`Reasonix · ${state.settings?.version ?? "dev"}`),
     abort,
     copyLast: () => {
@@ -962,12 +969,26 @@ function TabRuntime({
         }
       },
     },
-    { cmd: "/model", desc: "切换模型", run: () => setSettingsOpen(true), kb: "⌘M" },
+    { cmd: "/model", desc: "切换模型", run: () => openSettingsAt("models") },
     { cmd: "/theme", desc: "切换深浅主题", run: onToggleTheme },
     {
       cmd: "/currency",
       desc: "切换货币显示 (CNY / USD)",
       run: onToggleCurrency,
+    },
+    {
+      cmd: "/lang",
+      desc: "切换界面语言 (中 / 英)",
+      run: () => {
+        const next = getLang() === "zh-CN" ? "en" : "zh-CN";
+        setLang(next);
+        flashToast(next === "zh-CN" ? "已切换到中文" : "switched to English");
+      },
+    },
+    {
+      cmd: "/export",
+      desc: "复制本会话为 Markdown",
+      run: () => exportConversation(),
     },
   ];
 
@@ -1043,7 +1064,7 @@ function TabRuntime({
           onToggleSide={onToggleSide}
           onToggleCtx={onToggleCtx}
           onOpenCommands={() => palette.setOpen(true)}
-          onOpenSettings={() => setSettingsOpen(true)}
+          onOpenSettings={() => openSettingsAt("general")}
           onExport={exportConversation}
           onClear={() => dispatch({ t: "clear" })}
           hasMessages={state.messages.length > 0}
@@ -1070,7 +1091,8 @@ function TabRuntime({
           onNewChat={newChat}
           onLoadSession={(name) => sendRpc({ cmd: "session_load", name })}
           onDeleteSession={(name) => sendRpc({ cmd: "session_delete", name })}
-          onOpenSettings={() => setSettingsOpen(true)}
+          onOpenSettings={() => openSettingsAt("general")}
+          onOpenRules={() => openSettingsAt("rules")}
           onOpenCommands={() => palette.setOpen(true)}
         />
 
@@ -1296,6 +1318,7 @@ function TabRuntime({
           settings={state.settings}
           usage={state.usage}
           workspaceDir={state.settings?.workspaceDir}
+          messages={state.messages}
         />
 
         <StatusBar
@@ -1308,7 +1331,7 @@ function TabRuntime({
           theme={theme}
           onToggleTheme={onToggleTheme}
           onToggleCurrency={onToggleCurrency}
-          onOpenSettings={() => setSettingsOpen(true)}
+          onOpenSettings={() => openSettingsAt("general")}
         />
 
         <CommandPalette
@@ -1333,6 +1356,7 @@ function TabRuntime({
             balance={state.balance}
             usage={state.usage}
             currency={currency}
+            initialPage={settingsPage}
             onClose={() => setSettingsOpen(false)}
             onSave={saveSettings}
             onSaveApiKey={saveApiKey}

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -13,10 +13,12 @@ import type {
   ChoiceVerdict,
   ConfirmationChoice,
   IncomingEvent,
+  McpSpecInfo,
   OutgoingCommand,
   PlanVerdict,
   RevisionVerdict,
   SettingsPatch,
+  SkillInfo,
 } from "./protocol";
 import { Composer, type SlashCmd } from "./ui/composer";
 import { ContextPanel } from "./ui/context-panel";
@@ -180,6 +182,9 @@ type State = {
   balance: Balance | null;
   mentionResults: MentionResults | null;
   mentionPreview: MentionPreviewState | null;
+  mcpSpecs: McpSpecInfo[];
+  mcpBridged: boolean;
+  skills: SkillInfo[];
 };
 
 type DeltaBatchItem = {
@@ -447,6 +452,10 @@ function applyIncoming(state: State, ev: IncomingEvent): State {
       };
     case "$sessions":
       return { ...state, sessions: ev.items };
+    case "$mcp_specs":
+      return { ...state, mcpSpecs: ev.specs, mcpBridged: ev.bridged };
+    case "$skills":
+      return { ...state, skills: ev.items };
     case "$balance":
       return {
         ...state,
@@ -729,6 +738,9 @@ function TabRuntime({
     balance: null,
     mentionResults: null,
     mentionPreview: null,
+    mcpSpecs: [],
+    mcpBridged: false,
+    skills: [],
   });
   const [draft, setDraft] = useState("");
   const [toast, setToast] = useState<string | null>(null);
@@ -778,6 +790,14 @@ function TabRuntime({
   );
   const saveApiKey = useCallback(
     (key: string) => sendRpc({ cmd: "setup_save_key", key }),
+    [sendRpc],
+  );
+  const addMcpSpec = useCallback(
+    (spec: string) => sendRpc({ cmd: "mcp_specs_add", spec }),
+    [sendRpc],
+  );
+  const removeMcpSpec = useCallback(
+    (spec: string) => sendRpc({ cmd: "mcp_specs_remove", spec }),
     [sendRpc],
   );
   const newChat = useCallback(() => {
@@ -1357,10 +1377,15 @@ function TabRuntime({
             usage={state.usage}
             currency={currency}
             initialPage={settingsPage}
+            mcpSpecs={state.mcpSpecs}
+            mcpBridged={state.mcpBridged}
+            skills={state.skills}
             onClose={() => setSettingsOpen(false)}
             onSave={saveSettings}
             onSaveApiKey={saveApiKey}
             onPickWorkspace={pickWorkspace}
+            onAddMcpSpec={addMcpSpec}
+            onRemoveMcpSpec={removeMcpSpec}
           />
         ) : null}
 

--- a/desktop/src/protocol.ts
+++ b/desktop/src/protocol.ts
@@ -120,6 +120,36 @@ export type TabClosedEvent = {
   type: "$tab_closed";
 };
 
+export type McpSpecInfo = {
+  raw: string;
+  name: string | null;
+  transport: "stdio" | "sse" | "streamable-http";
+  summary: string;
+  parseError?: string;
+};
+
+export type McpSpecsEvent = {
+  type: "$mcp_specs";
+  specs: McpSpecInfo[];
+  bridged: boolean;
+};
+
+export type SkillScope = "project" | "global" | "builtin";
+
+export type SkillInfo = {
+  name: string;
+  description: string;
+  scope: SkillScope;
+  path: string;
+  runAs: "inline" | "subagent";
+  model?: string;
+};
+
+export type SkillsEvent = {
+  type: "$skills";
+  items: SkillInfo[];
+};
+
 export type LoadedSegment =
   | { kind: "text"; text: string }
   | { kind: "reasoning"; text: string }
@@ -305,6 +335,8 @@ export type IncomingEvent = { tabId?: string } & (
   | MentionPreviewEvent
   | TabOpenedEvent
   | TabClosedEvent
+  | McpSpecsEvent
+  | SkillsEvent
   | UserMessageEvent
   | ModelTurnStartedEvent
   | ModelDeltaEvent
@@ -336,4 +368,8 @@ export type OutgoingCommand = { tabId?: string } & (
   | { cmd: "mention_picked"; path: string }
   | { cmd: "tab_open"; workspaceDir?: string }
   | { cmd: "tab_close" }
+  | { cmd: "mcp_specs_get" }
+  | { cmd: "mcp_specs_add"; spec: string }
+  | { cmd: "mcp_specs_remove"; spec: string }
+  | { cmd: "skills_get" }
 );

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -2654,6 +2654,7 @@ button {
   display: flex;
   flex-direction: column;
   min-width: 0;
+  min-height: 0;
 }
 .settings-head {
   display: flex;

--- a/desktop/src/ui/context-panel.tsx
+++ b/desktop/src/ui/context-panel.tsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { I } from "../icons";
-import type { Settings, UsageStats } from "../App";
+import type { ChatMessage, Settings, UsageStats } from "../App";
 
 type Tab = "files" | "tools" | "memory" | "rules";
 
@@ -8,10 +8,12 @@ export function ContextPanel({
   settings,
   usage,
   workspaceDir,
+  messages,
 }: {
   settings: Settings | null;
   usage: UsageStats;
   workspaceDir?: string;
+  messages: ChatMessage[];
 }) {
   const [tab, setTab] = useState<Tab>("files");
   const used = usage.cacheMissTokens;
@@ -65,7 +67,7 @@ export function ContextPanel({
         </div>
 
         {tab === "files" && <CtxFiles workspaceDir={workspaceDir} />}
-        {tab === "tools" && <CtxTools />}
+        {tab === "tools" && <CtxTools messages={messages} />}
         {tab === "memory" && <CtxMemory />}
         {tab === "rules" && <CtxRules settings={settings} />}
       </div>
@@ -105,30 +107,48 @@ function CtxFiles({ workspaceDir }: { workspaceDir?: string }) {
   );
 }
 
-function CtxTools() {
+function CtxTools({ messages }: { messages: ChatMessage[] }) {
+  const entries = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const m of messages) {
+      if (m.kind !== "assistant") continue;
+      for (const s of m.segments) {
+        if (s.kind !== "tool") continue;
+        counts.set(s.name, (counts.get(s.name) ?? 0) + 1);
+      }
+    }
+    return [...counts.entries()].sort((a, b) => b[1] - a[1]);
+  }, [messages]);
   return (
     <div className="ctx-block">
       <div className="h">
-        <span>内置工具</span>
-        <span className="right">connected</span>
+        <span>本会话工具</span>
+        <span className="right">{entries.length}</span>
       </div>
-      {[
-        { id: "fs", name: "filesystem", tools: 12 },
-        { id: "shell", name: "shell", tools: 2 },
-        { id: "search", name: "search", tools: 4 },
-        { id: "edit", name: "edit", tools: 5 },
-      ].map((m) => (
-        <div className="mcp-row" key={m.id}>
-          <span className="ico">
-            <I.wrench size={12} />
-          </span>
-          <div className="body">
-            <div className="n">{m.name}</div>
-            <div className="m">{m.tools} tools · ready</div>
-          </div>
-          <span className="status" />
+      {entries.length === 0 ? (
+        <div
+          style={{
+            padding: "8px",
+            fontSize: 11.5,
+            color: "var(--muted)",
+            fontFamily: "IBM Plex Mono, monospace",
+          }}
+        >
+          本会话尚未调用工具。
         </div>
-      ))}
+      ) : (
+        entries.map(([name, n]) => (
+          <div className="mcp-row" key={name}>
+            <span className="ico">
+              <I.wrench size={12} />
+            </span>
+            <div className="body">
+              <div className="n">{name}</div>
+              <div className="m">{n} 次调用</div>
+            </div>
+          </div>
+        ))
+      )}
     </div>
   );
 }

--- a/desktop/src/ui/settings.tsx
+++ b/desktop/src/ui/settings.tsx
@@ -1,11 +1,13 @@
 import { useState, type ReactNode } from "react";
 import { I } from "../icons";
 import type { Balance, Settings as SettingsType, UsageStats } from "../App";
-import type { SettingsPatch } from "../protocol";
+import type { McpSpecInfo, SettingsPatch, SkillInfo } from "../protocol";
 
 export type PageId =
   | "general"
   | "models"
+  | "mcp"
+  | "skills"
   | "memory"
   | "rules"
   | "billing"
@@ -14,6 +16,8 @@ export type PageId =
 const SETTING_PAGES: { id: PageId; label: string; icon: keyof typeof I; desc: string }[] = [
   { id: "general", label: "通用", icon: "cog", desc: "外观、语言、行为" },
   { id: "models", label: "模型", icon: "brain", desc: "选择默认模型与采样参数" },
+  { id: "mcp", label: "MCP 服务器", icon: "wrench", desc: "管理 MCP 协议工具服务器" },
+  { id: "skills", label: "技能 / Skills", icon: "zap", desc: "为 / 命令绑定的可复用提示集" },
   { id: "memory", label: "记忆", icon: "bookmark", desc: "CLAUDE.md / AGENTS.md 注入说明" },
   { id: "rules", label: "审批规则", icon: "shield", desc: "自动批准、拒绝、需确认命令模式" },
   { id: "billing", label: "账户 & 计费", icon: "coin", desc: "账户余额、用量与发票" },
@@ -26,20 +30,30 @@ export function SettingsModal({
   usage,
   currency,
   initialPage,
+  mcpSpecs,
+  mcpBridged,
+  skills,
   onClose,
   onSave,
   onSaveApiKey,
   onPickWorkspace,
+  onAddMcpSpec,
+  onRemoveMcpSpec,
 }: {
   settings: SettingsType;
   balance: Balance | null;
   usage: UsageStats;
   currency: "CNY" | "USD";
   initialPage?: PageId;
+  mcpSpecs: McpSpecInfo[];
+  mcpBridged: boolean;
+  skills: SkillInfo[];
   onClose: () => void;
   onSave: (patch: SettingsPatch) => void;
   onSaveApiKey: (key: string) => void;
   onPickWorkspace: () => void;
+  onAddMcpSpec: (spec: string) => void;
+  onRemoveMcpSpec: (spec: string) => void;
 }) {
   const [page, setPage] = useState<PageId>(initialPage ?? "general");
   const current = SETTING_PAGES.find((p) => p.id === page) ?? SETTING_PAGES[0]!;
@@ -76,6 +90,15 @@ export function SettingsModal({
               <PageGeneral settings={settings} onSave={onSave} onPickWorkspace={onPickWorkspace} />
             )}
             {page === "models" && <PageModels settings={settings} onSave={onSave} />}
+            {page === "mcp" && (
+              <PageMCP
+                specs={mcpSpecs}
+                bridged={mcpBridged}
+                onAdd={onAddMcpSpec}
+                onRemove={onRemoveMcpSpec}
+              />
+            )}
+            {page === "skills" && <PageSkills skills={skills} />}
             {page === "memory" && <PageMemory />}
             {page === "rules" && <PageRules settings={settings} onSave={onSave} />}
             {page === "billing" && (
@@ -333,6 +356,175 @@ function PageModels({
           </div>
         ))}
       </div>
+    </section>
+  );
+}
+
+function PageMCP({
+  specs,
+  bridged,
+  onAdd,
+  onRemove,
+}: {
+  specs: McpSpecInfo[];
+  bridged: boolean;
+  onAdd: (spec: string) => void;
+  onRemove: (spec: string) => void;
+}) {
+  const [draft, setDraft] = useState("");
+  const submit = () => {
+    const v = draft.trim();
+    if (!v) return;
+    onAdd(v);
+    setDraft("");
+  };
+  return (
+    <>
+      <section className="section">
+        <div className="stitle">
+          已配置 · {specs.length}
+          {bridged ? (
+            <span style={{ color: "var(--accent)", marginLeft: 8, fontSize: 11 }}>
+              · 已桥接
+            </span>
+          ) : (
+            <span style={{ color: "var(--muted)", marginLeft: 8, fontSize: 11 }}>
+              · 当前桌面会话未桥接，重启 reasonix code (TUI) 后生效
+            </span>
+          )}
+        </div>
+        {specs.length === 0 ? (
+          <div
+            style={{
+              padding: 16,
+              background: "var(--card)",
+              border: "1px solid var(--border)",
+              borderRadius: 10,
+              fontSize: 12,
+              color: "var(--muted)",
+            }}
+          >
+            还没有配置 MCP 服务器。下面输入 spec 添加。
+          </div>
+        ) : (
+          specs.map((s) => (
+            <div className="scard" key={s.raw}>
+              <div className="top">
+                <span className="ico">
+                  <I.wrench size={14} />
+                </span>
+                <div>
+                  <div className="nm">{s.name ?? "(anonymous)"}</div>
+                  <div className="sub">{s.summary}</div>
+                </div>
+                <span className="grow" />
+                <button
+                  type="button"
+                  className="btn ghost"
+                  style={{ color: "var(--danger)" }}
+                  onClick={() => onRemove(s.raw)}
+                >
+                  移除
+                </button>
+              </div>
+              {s.parseError ? (
+                <div className="desc" style={{ color: "var(--danger)" }}>
+                  解析失败：{s.parseError}
+                </div>
+              ) : null}
+            </div>
+          ))
+        )}
+      </section>
+      <section className="section">
+        <div className="stitle">添加服务器</div>
+        <div className="setting-row">
+          <div className="l">
+            <div className="n">spec 字符串</div>
+            <div className="h">
+              格式：<code>name=command args</code> 或 <code>name=https://host/sse</code>
+            </div>
+          </div>
+          <div style={{ display: "flex", gap: 6 }}>
+            <input
+              className="field mono"
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              placeholder="github=npx -y @smithery/cli ..."
+              onKeyDown={(e) => {
+                if (e.key === "Enter") submit();
+              }}
+            />
+            <button
+              type="button"
+              className="btn primary"
+              disabled={!draft.trim()}
+              onClick={submit}
+            >
+              添加
+            </button>
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}
+
+function PageSkills({ skills }: { skills: SkillInfo[] }) {
+  return (
+    <section className="section">
+      <div className="stitle">已加载 · {skills.length} · 通过 / 命令调用</div>
+      {skills.length === 0 ? (
+        <div
+          style={{
+            padding: 16,
+            background: "var(--card)",
+            border: "1px solid var(--border)",
+            borderRadius: 10,
+            fontSize: 12,
+            color: "var(--muted)",
+          }}
+        >
+          没有可用技能。可在 ~/.reasonix/skills/ 或 项目根/.reasonix/skills/ 下创建 SKILL.md。
+        </div>
+      ) : (
+        skills.map((s) => (
+          <div className="scard" key={`${s.scope}:${s.name}`}>
+            <div className="top">
+              <span className="ico">
+                <I.zap size={14} />
+              </span>
+              <div>
+                <div className="nm">
+                  <span
+                    style={{
+                      fontFamily: "IBM Plex Mono, monospace",
+                      color: "var(--accent)",
+                    }}
+                  >
+                    /{s.name}
+                  </span>
+                </div>
+                <div className="sub">
+                  {s.scope} · {s.runAs}
+                  {s.model ? ` · ${s.model}` : ""}
+                </div>
+              </div>
+            </div>
+            <div className="desc">{s.description}</div>
+            <div
+              style={{
+                fontFamily: "IBM Plex Mono, monospace",
+                fontSize: 10.5,
+                color: "var(--muted-2)",
+                marginTop: 4,
+              }}
+            >
+              {s.path}
+            </div>
+          </div>
+        ))
+      )}
     </section>
   );
 }

--- a/desktop/src/ui/settings.tsx
+++ b/desktop/src/ui/settings.tsx
@@ -3,11 +3,9 @@ import { I } from "../icons";
 import type { Balance, Settings as SettingsType, UsageStats } from "../App";
 import type { SettingsPatch } from "../protocol";
 
-type PageId =
+export type PageId =
   | "general"
   | "models"
-  | "mcp"
-  | "skills"
   | "memory"
   | "rules"
   | "billing"
@@ -16,9 +14,7 @@ type PageId =
 const SETTING_PAGES: { id: PageId; label: string; icon: keyof typeof I; desc: string }[] = [
   { id: "general", label: "通用", icon: "cog", desc: "外观、语言、行为" },
   { id: "models", label: "模型", icon: "brain", desc: "选择默认模型与采样参数" },
-  { id: "mcp", label: "MCP 服务器", icon: "wrench", desc: "管理 MCP 协议工具服务器" },
-  { id: "skills", label: "技能 / Skills", icon: "zap", desc: "为 / 命令绑定的可复用提示集" },
-  { id: "memory", label: "记忆", icon: "bookmark", desc: "项目 / 用户 / 全局三层长期记忆" },
+  { id: "memory", label: "记忆", icon: "bookmark", desc: "CLAUDE.md / AGENTS.md 注入说明" },
   { id: "rules", label: "审批规则", icon: "shield", desc: "自动批准、拒绝、需确认命令模式" },
   { id: "billing", label: "账户 & 计费", icon: "coin", desc: "账户余额、用量与发票" },
   { id: "shortcuts", label: "快捷键", icon: "cpu", desc: "键盘快捷键总览" },
@@ -29,6 +25,7 @@ export function SettingsModal({
   balance,
   usage,
   currency,
+  initialPage,
   onClose,
   onSave,
   onSaveApiKey,
@@ -38,12 +35,13 @@ export function SettingsModal({
   balance: Balance | null;
   usage: UsageStats;
   currency: "CNY" | "USD";
+  initialPage?: PageId;
   onClose: () => void;
   onSave: (patch: SettingsPatch) => void;
   onSaveApiKey: (key: string) => void;
   onPickWorkspace: () => void;
 }) {
-  const [page, setPage] = useState<PageId>("general");
+  const [page, setPage] = useState<PageId>(initialPage ?? "general");
   const current = SETTING_PAGES.find((p) => p.id === page) ?? SETTING_PAGES[0]!;
   return (
     <div className="settings-mask" onClick={onClose}>
@@ -78,8 +76,6 @@ export function SettingsModal({
               <PageGeneral settings={settings} onSave={onSave} onPickWorkspace={onPickWorkspace} />
             )}
             {page === "models" && <PageModels settings={settings} onSave={onSave} />}
-            {page === "mcp" && <PageMCP />}
-            {page === "skills" && <PageSkills />}
             {page === "memory" && <PageMemory />}
             {page === "rules" && <PageRules settings={settings} onSave={onSave} />}
             {page === "billing" && (
@@ -336,46 +332,6 @@ function PageModels({
             </div>
           </div>
         ))}
-      </div>
-    </section>
-  );
-}
-
-function PageMCP() {
-  return (
-    <section className="section">
-      <div className="stitle">MCP 服务器</div>
-      <div
-        style={{
-          padding: 16,
-          background: "var(--card)",
-          border: "1px solid var(--border)",
-          borderRadius: 10,
-          fontSize: 12,
-          color: "var(--muted)",
-        }}
-      >
-        MCP 集成在路线图上。当前内核内置文件 / 搜索 / shell / edit 工具。
-      </div>
-    </section>
-  );
-}
-
-function PageSkills() {
-  return (
-    <section className="section">
-      <div className="stitle">技能</div>
-      <div
-        style={{
-          padding: 16,
-          background: "var(--card)",
-          border: "1px solid var(--border)",
-          borderRadius: 10,
-          fontSize: 12,
-          color: "var(--muted)",
-        }}
-      >
-        通过 / 命令调用自定义提示集。即将开放配置入口。
       </div>
     </section>
   );

--- a/desktop/src/ui/sidebar.tsx
+++ b/desktop/src/ui/sidebar.tsx
@@ -30,6 +30,7 @@ export function Sidebar({
   onLoadSession,
   onDeleteSession,
   onOpenSettings,
+  onOpenRules,
   onOpenCommands,
 }: {
   sessions: SessionInfo[];
@@ -38,6 +39,7 @@ export function Sidebar({
   onLoadSession: (name: string) => void;
   onDeleteSession: (name: string) => void;
   onOpenSettings: () => void;
+  onOpenRules: () => void;
   onOpenCommands: () => void;
 }) {
   const [query, setQuery] = useState("");
@@ -149,12 +151,11 @@ export function Sidebar({
       </div>
 
       <div className="side-foot">
-        <div className="row" onClick={onOpenSettings}>
+        <div className="row" onClick={onOpenRules}>
           <span className="ico">
             <I.shield size={13} />
           </span>
           <span>审批规则</span>
-          <span className="right">⌘,</span>
         </div>
         <div className="row" onClick={onOpenSettings}>
           <span className="ico">

--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -25,6 +25,7 @@ import {
   loadRecentWorkspaces,
   loadWorkspaceDir,
   pushRecentWorkspace,
+  readConfig,
   saveApiKey,
   saveBaseUrl,
   saveEditMode,
@@ -32,6 +33,7 @@ import {
   savePreset,
   saveReasoningEffort,
   saveWorkspaceDir,
+  writeConfig,
 } from "../../config.js";
 import { Eventizer } from "../../core/eventize.js";
 import type { Event as KernelEvent } from "../../core/events.js";
@@ -46,6 +48,7 @@ import {
 import { autoResolveVerdict } from "../../core/pause-policy.js";
 import { loadDotenv } from "../../env.js";
 import { CacheFirstLoop, DeepSeekClient, ImmutablePrefix } from "../../index.js";
+import { parseMcpSpec } from "../../mcp/spec.js";
 import {
   deleteSession,
   listSessionsForWorkspace,
@@ -54,6 +57,7 @@ import {
   patchSessionMeta,
   timestampSuffix,
 } from "../../memory/session.js";
+import { SkillStore } from "../../skills.js";
 import type { ChoiceOption } from "../../tools/choice.js";
 import type { ChatMessage } from "../../types.js";
 import { VERSION } from "../../version.js";
@@ -95,6 +99,10 @@ type InMessage = { tabId?: string } & (
   | { cmd: "mention_picked"; path: string }
   | { cmd: "tab_open"; workspaceDir?: string }
   | { cmd: "tab_close" }
+  | { cmd: "mcp_specs_get" }
+  | { cmd: "mcp_specs_add"; spec: string }
+  | { cmd: "mcp_specs_remove"; spec: string }
+  | { cmd: "skills_get" }
 );
 
 interface NeedsSetupEvent {
@@ -246,6 +254,34 @@ interface PlanClearedEvent {
   type: "$plan_cleared";
 }
 
+interface McpSpecInfo {
+  raw: string;
+  name: string | null;
+  transport: "stdio" | "sse" | "streamable-http";
+  summary: string;
+  parseError?: string;
+}
+
+interface McpSpecsEvent {
+  type: "$mcp_specs";
+  specs: McpSpecInfo[];
+  bridged: boolean;
+}
+
+interface SkillInfo {
+  name: string;
+  description: string;
+  scope: "project" | "global" | "builtin";
+  path: string;
+  runAs: "inline" | "subagent";
+  model?: string;
+}
+
+interface SkillsEvent {
+  type: "$skills";
+  items: SkillInfo[];
+}
+
 /** Direct fd write — bypasses Node's stream layer (and its piped-output
  *  block buffering) so every JSON line reaches Rust the moment it's
  *  produced, not whenever the next 8 KB flushes. */
@@ -269,7 +305,9 @@ type EmittableEvent =
   | MentionResultsEvent
   | MentionPreviewEvent
   | TabOpenedEvent
-  | TabClosedEvent;
+  | TabClosedEvent
+  | McpSpecsEvent
+  | SkillsEvent;
 
 function emit(ev: EmittableEvent, tabId?: string): void {
   const payload = tabId ? { ...ev, tabId } : ev;
@@ -373,6 +411,58 @@ function emitSessions(tab: Tab): void {
     emit({ type: "$sessions", items }, tab.id);
   } catch (err) {
     emit({ type: "$error", message: `session_list failed: ${(err as Error).message}` }, tab.id);
+  }
+}
+
+function summarizeMcpSpec(raw: string): McpSpecInfo {
+  try {
+    const parsed = parseMcpSpec(raw);
+    if (parsed.transport === "stdio") {
+      const argv = [parsed.command, ...parsed.args].join(" ");
+      return {
+        raw,
+        name: parsed.name,
+        transport: "stdio",
+        summary: `stdio · ${argv}`,
+      };
+    }
+    return {
+      raw,
+      name: parsed.name,
+      transport: parsed.transport,
+      summary: `${parsed.transport} · ${parsed.url}`,
+    };
+  } catch (err) {
+    return {
+      raw,
+      name: null,
+      transport: "stdio",
+      summary: raw,
+      parseError: (err as Error).message,
+    };
+  }
+}
+
+function emitMcpSpecs(tab: Tab): void {
+  const cfg = readConfig();
+  const specs = (cfg.mcp ?? []).map(summarizeMcpSpec);
+  emit({ type: "$mcp_specs", specs, bridged: false }, tab.id);
+}
+
+function emitSkills(tab: Tab): void {
+  try {
+    const store = new SkillStore({ projectRoot: tab.rootDir });
+    const items = store.list().map((s) => ({
+      name: s.name,
+      description: s.description,
+      scope: s.scope,
+      path: s.path,
+      runAs: s.runAs,
+      model: s.model,
+    }));
+    emit({ type: "$skills", items }, tab.id);
+  } catch (err) {
+    emit({ type: "$error", message: `skills_get failed: ${(err as Error).message}` }, tab.id);
   }
 }
 
@@ -658,6 +748,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
     if (tab.runtime) tab.runtime = buildRuntimeFor(tab);
     emitSessions(tab);
     emitSettings(tab);
+    emitSkills(tab);
   }
 
   function forgetGate(id: number): Tab | undefined {
@@ -820,6 +911,8 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
   else emit({ type: "$needs_setup", reason: "no_api_key" }, first.id);
   emitSessions(first);
   emitSettings(first);
+  emitMcpSpecs(first);
+  emitSkills(first);
   void emitBalance(first);
 
   const rl = createInterface({ input: stdin });
@@ -843,6 +936,8 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
           else emit({ type: "$needs_setup", reason: "no_api_key" }, tab.id);
           emitSessions(tab);
           emitSettings(tab);
+          emitMcpSpecs(tab);
+          emitSkills(tab);
           void emitBalance(tab);
         } catch (err) {
           emit({ type: "$error", message: `tab_open failed: ${(err as Error).message}` });
@@ -922,6 +1017,53 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
     }
     if (msg.cmd === "tab_close") {
       void closeTab(tab);
+      return;
+    }
+    if (msg.cmd === "mcp_specs_get") {
+      emitMcpSpecs(tab);
+      return;
+    }
+    if (msg.cmd === "mcp_specs_add") {
+      const spec = msg.spec.trim();
+      if (!spec) {
+        emit({ type: "$error", message: "mcp_specs_add: spec is empty" }, tab.id);
+        return;
+      }
+      try {
+        parseMcpSpec(spec);
+      } catch (err) {
+        emit({ type: "$error", message: `mcp_specs_add: ${(err as Error).message}` }, tab.id);
+        return;
+      }
+      try {
+        const cfg = readConfig();
+        const list = cfg.mcp ?? [];
+        if (!list.includes(spec)) {
+          cfg.mcp = [...list, spec];
+          writeConfig(cfg);
+        }
+        emitMcpSpecs(tab);
+      } catch (err) {
+        emit({ type: "$error", message: `mcp_specs_add: ${(err as Error).message}` }, tab.id);
+      }
+      return;
+    }
+    if (msg.cmd === "mcp_specs_remove") {
+      try {
+        const cfg = readConfig();
+        const list = cfg.mcp ?? [];
+        if (list.includes(msg.spec)) {
+          cfg.mcp = list.filter((s) => s !== msg.spec);
+          writeConfig(cfg);
+        }
+        emitMcpSpecs(tab);
+      } catch (err) {
+        emit({ type: "$error", message: `mcp_specs_remove: ${(err as Error).message}` }, tab.id);
+      }
+      return;
+    }
+    if (msg.cmd === "skills_get") {
+      emitSkills(tab);
       return;
     }
     if (msg.cmd === "session_list") {


### PR DESCRIPTION
## Summary

A polish pass over the Tauri desktop client. The unifying theme: surfaces that *rendered* without doing anything real, plus two genuinely missing pages the design mockup (and the CLI) calls for.

### Wired up
- **Context panel "工具" tab** was hardcoded mock data — fake MCP servers with made-up tool counts and "ready" dots. Now shows real per-session tool-call frequency from assistant message segments, with an empty state.
- **Sidebar footer 审批规则 row** previously called `onOpenSettings` — same handler as the next row. Now opens the modal directly on the rules tab via a new `initialPage` prop.
- **Composer slash commands** gained `/export` (copies the conversation as Markdown — reuses the existing `exportConversation`) and `/lang` (flips between en / zh-CN). Both icons were already in the `slashIcon` table; only the registrations were missing.
- **Settings entry points** (⌘,, command palette, title bar, status bar, sidebar) all route through a single `openSettingsAt(page)` helper, so each one lands on the right tab.

### New, wired-to-backend pages
- **`PageMCP`** — lists every spec in `config.mcp[]` with name + transport + summary, "移除" button, "添加" input. Add/remove validate via `parseMcpSpec` then persist through `readConfig`/`writeConfig`. The header surfaces that desktop sessions don't bridge MCP themselves yet; the `bridged` flag in the new `$mcp_specs` event will flip once the bridge lands and the caveat will disappear.
- **`PageSkills`** — one card per skill: `/name`, scope, `runAs`, model override, full description, file path. Read-only since skills are markdown files on disk. Loaded via `new SkillStore({ projectRoot: tab.rootDir })`, so it follows the active workspace.

### Backend bits (src/cli/commands/desktop.ts)

New RPC commands:
- `mcp_specs_get` / `mcp_specs_add { spec }` / `mcp_specs_remove { spec }`
- `skills_get`

New emitted events:
- `$mcp_specs { specs: McpSpecInfo[], bridged: boolean }`
- `$skills { items: SkillInfo[] }`

Both auto-emit on `$ready` and on `tab_open`. Skills re-emit on `switchWorkspace` since they're scoped to the project root.

## Test plan

- [ ] Open settings → sidebar shows MCP + Skills tabs again, body actually has data
- [ ] MCP page: add a spec (e.g. `name=npx -y @modelcontextprotocol/server-filesystem /tmp`), confirm it appears with the right name + summary; remove it; confirm it disappears
- [ ] Skills page: lists project + global + builtin skills with correct scope badge and description
- [ ] Switch workspace via WorkdirPop → Skills page list re-fetches against the new project root
- [ ] Context panel "工具" tab: shows real tool names + call counts after the agent runs a tool; empty state in a fresh chat
- [ ] Sidebar "审批规则" → opens settings on rules tab; "设置" → general tab
- [ ] Slash: `/export` copies markdown, `/lang` flips UI language with a toast
- [ ] `/model` opens settings on the models tab
- [ ] Bad spec ("not a real spec") returns an `$error` event, doesn't persist
