### PR TITLE
fix(dashboard): memoise chat feed + rails to kill input-typing lag

### DIFF
--- a/dashboard/src/panels/chat.ts
+++ b/dashboard/src/panels/chat.ts
@@ -1,3 +1,4 @@
+import { memo } from "preact/compat";
 import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 import {
   ChatMessage,
@@ -535,18 +536,6 @@ export function ChatPanel() {
     }, 0);
   }, [messages, streaming]);
 
-  const allMessages = streaming
-    ? [
-        ...messages,
-        {
-          id: streaming.id,
-          role: "assistant",
-          text: streaming.text,
-          reasoning: streaming.reasoning,
-        },
-      ]
-    : messages;
-
   const resolveModal = useCallback<OnResolve>(async (kind, choice, text) => {
     try {
       await api("/modal/resolve", {
@@ -756,23 +745,7 @@ export function ChatPanel() {
 
       <div class="chat-body">
         <div class="chat-main">
-          <div class="chat-feed" ref=${feedRef}>
-            ${
-              allMessages.length === 0
-                ? html`<div class="chat-empty">
-                    ${t("chat.noConversation")}
-                  </div>`
-                : allMessages.map(
-                    (m) => html`
-                      <${ChatMessage}
-                        key=${m.id}
-                        msg=${m}
-                        streaming=${Boolean(streaming && streaming.id === m.id)}
-                      />
-                    `,
-                  )
-            }
-          </div>
+          <${ChatFeed} messages=${messages} streaming=${streaming} innerRef=${feedRef} />
 
           <div class="chat-input-area" style="position:relative">
             ${
@@ -843,13 +816,52 @@ export function ChatPanel() {
   `;
 }
 
+interface ChatFeedProps {
+  messages: ChatMsg[];
+  streaming: StreamingState | null;
+  innerRef: { current: HTMLDivElement | null };
+}
+
+/** Memoised so keystrokes in ChatPanel don't re-walk the message list. */
+const ChatFeed = memo(function ChatFeed({ messages, streaming, innerRef }: ChatFeedProps) {
+  useLang();
+  const allMessages = streaming
+    ? [
+        ...messages,
+        {
+          id: streaming.id,
+          role: "assistant" as const,
+          text: streaming.text,
+          reasoning: streaming.reasoning,
+        },
+      ]
+    : messages;
+  return html`
+    <div class="chat-feed" ref=${innerRef}>
+      ${
+        allMessages.length === 0
+          ? html`<div class="chat-empty">${t("chat.noConversation")}</div>`
+          : allMessages.map(
+              (m) => html`
+                <${ChatMessage}
+                  key=${m.id}
+                  msg=${m}
+                  streaming=${Boolean(streaming && streaming.id === m.id)}
+                />
+              `,
+            )
+      }
+    </div>
+  `;
+});
+
 interface SideRailProps {
   stats: ChatStats | null;
   budgetUsd: number | null;
   activePlan: RailPlan | null;
 }
 
-function SideRail({ stats, budgetUsd, activePlan }: SideRailProps) {
+const SideRail = memo(function SideRail({ stats, budgetUsd, activePlan }: SideRailProps) {
   useLang();
   if (!stats && !activePlan) return html`<aside class="chat-rail"></aside>`;
   const cachePct = stats ? stats.cacheHitRatio * 100 : 0;
@@ -894,7 +906,7 @@ function SideRail({ stats, budgetUsd, activePlan }: SideRailProps) {
       }
     </aside>
   `;
-}
+});
 
 function ActivePlanCard({ plan }: { plan: RailPlan }) {
   useLang();
@@ -1023,7 +1035,7 @@ interface ChatStatusBarProps {
   model: string | null;
 }
 
-function ChatStatusBar({ stats, model }: ChatStatusBarProps) {
+const ChatStatusBar = memo(function ChatStatusBar({ stats, model }: ChatStatusBarProps) {
   useLang();
   if (!stats) {
     return html`
@@ -1077,4 +1089,4 @@ function ChatStatusBar({ stats, model }: ChatStatusBarProps) {
       }
     </div>
   `;
-}
+});


### PR DESCRIPTION
## Summary

Typing in the dashboard composer feels laggy on long sessions (#721).
Every keystroke commits to `input` state, so ChatPanel re-renders and
Preact walks its entire vnode tree on each frame — the message list,
the side rail, and the status bar.

`ChatMessage` was already memoised in #560 so historical bubbles
short-circuit individually, but Preact still has to `.map()` over every
message, evaluate the per-row `Boolean(streaming && streaming.id === m.id)`
discriminator, and diff each element. On a session with 100+ messages,
the per-keystroke work is enough to drop frames.

## Fix

- Lift the message list into a `<ChatFeed>` sub-component and wrap it
  in `memo`. While the user types, `messages` and `streaming` refs are
  stable, so memo bails the whole feed out — keystrokes no longer
  touch the feed.
- Wrap `SideRail` and `ChatStatusBar` in `memo` for the same reason —
  /overview poll churn and input edits won't repaint progress bars or
  the statusbar between actual state changes.

Closes #721

## Test plan

- [ ] Open dashboard with a long-running session (50+ messages), type
      in the composer, confirm typing is responsive.
- [ ] Verify auto-scroll on new message still works (`feedRef` passed
      through `innerRef`).
- [ ] Confirm streaming bubble still updates in real time (memo
      re-renders when `streaming` ref changes per rAF flush).
- [ ] `/overview` poll keeps refreshing status bar / side rail values
      every 2.5s.
- [ ] Language switch still updates feed empty-state text.
