### PR TITLE
fix(markdown): emit OSC-8 hyperlinks so [text](url) is clickable in the TUI

### DIFF
--- a/src/cli/ui/markdown-view.tsx
+++ b/src/cli/ui/markdown-view.tsx
@@ -1,4 +1,4 @@
-import { Box, Text } from "ink";
+import { Box, Text, Transform } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React from "react";
 import { type InlineSpan, type MdLine, markdownToLines } from "./markdown-lines.js";
@@ -158,7 +158,7 @@ function SpanText({
       : strongColor
         ? FG_STRONG
         : FG_BODY;
-  return (
+  const inner = (
     <Text
       color={color}
       bold={!!(span.bold || ambientBold)}
@@ -170,4 +170,20 @@ function SpanText({
       {span.text}
     </Text>
   );
+  const target = linkTarget(span);
+  if (!target) return inner;
+  return (
+    <Transform transform={(text) => `\x1b]8;;${target}\x1b\\${text}\x1b]8;;\x1b\\`}>
+      {inner}
+    </Transform>
+  );
+}
+
+function linkTarget(span: InlineSpan): string | null {
+  if (span.link) return span.link;
+  if (span.fileRef) {
+    const { path, line } = span.fileRef;
+    return line ? `file://${path}:${line}` : `file://${path}`;
+  }
+  return null;
 }

--- a/src/cli/ui/markdown.tsx
+++ b/src/cli/ui/markdown.tsx
@@ -1,7 +1,7 @@
 /** Markdown → Ink. Parsing via marked; visual mapping mirrors dashboard/app.css `.md` rules. Code blocks pass through cli-highlight for ANSI syntax coloring. */
 
 import { highlight, supportsLanguage } from "cli-highlight";
-import { Box, Text, useStdout } from "ink";
+import { Box, Text, Transform, useStdout } from "ink";
 import { type Token, type Tokens, marked } from "marked";
 import React from "react";
 import stringWidth from "string-width";
@@ -375,11 +375,13 @@ function looksLikeFileRef(path: string, hasLine: boolean): boolean {
   return ext.length >= 2;
 }
 
-function osc8(label: string, _target: string, color: string): React.ReactElement {
+function osc8(children: React.ReactNode, target: string, color: string): React.ReactElement {
   return (
-    <Text color={color} underline>
-      {label}
-    </Text>
+    <Transform transform={(text) => `\x1b]8;;${target}\x1b\\${text}\x1b]8;;\x1b\\`}>
+      <Text color={color} underline>
+        {children}
+      </Text>
+    </Transform>
   );
 }
 
@@ -454,11 +456,7 @@ function InlineToken({ token }: { token: Token }): React.ReactElement {
       );
     case "link": {
       const l = token as Tokens.Link;
-      return (
-        <Text color={TONE.brand} underline>
-          <Inline tokens={l.tokens} />
-        </Text>
-      );
+      return osc8(<Inline tokens={l.tokens} />, l.href, TONE.brand);
     }
     case "image": {
       const im = token as Tokens.Image;

--- a/tests/markdown.test.ts
+++ b/tests/markdown.test.ts
@@ -102,6 +102,28 @@ describe("Markdown — issue #340 table fallback row grouping", () => {
   });
 });
 
+describe("Markdown — issue #723 link OSC-8 emission", () => {
+  function bytesFor(text: string): string {
+    const { lastFrame, unmount } = render(React.createElement(Markdown, { text }));
+    const out = lastFrame() ?? "";
+    unmount();
+    return out;
+  }
+
+  it("emits OSC-8 hyperlink wrapping [text](url) so terminals can click it", () => {
+    const out = bytesFor("see [点此查看](https://example.com/issues/1549) for details");
+    expect(out).toContain("\x1b]8;;https://example.com/issues/1549\x1b\\");
+    expect(out).toContain("\x1b]8;;\x1b\\");
+    expect(out).toContain("点此查看");
+  });
+
+  it("emits OSC-8 hyperlink for file refs (file://path:line)", () => {
+    const out = bytesFor("look at src/cli/ui/markdown.tsx:42 closely");
+    expect(out).toContain("\x1b]8;;file://src/cli/ui/markdown.tsx:42\x1b\\");
+    expect(out).toContain("\x1b]8;;\x1b\\");
+  });
+});
+
 describe("Markdown — issue #330 file-ref over-match regression", () => {
   it("English abbreviations 'e.g' / 'i.e' are NOT treated as file refs", () => {
     function bytesFor(text: string): string {


### PR DESCRIPTION
## Summary

Reported in #723: assistant replies containing `[text](url)` render as
blue underlined text but aren't actually clickable on hover. Modern
terminals (kitty, iTerm2, Windows Terminal, VSCode) honour OSC 8
hyperlinks — we just never emitted the escape.

The `osc8()` helper in `src/cli/ui/markdown.tsx` was named for the job
but ignored its `target` parameter (note the `_target` prefix). The
markdown parser at `markdown-lines.ts:170` already pre-threaded the
link href into every descendant span ready for this; the renderer was
the missing piece.

## Fix

- `osc8()` now wraps its child in `<Transform>` that emits
  `ESC ]8;; URL ESC \ ... ESC ]8;; ESC \` around the squashed text,
  matching the cell-renderer convention in `src/frame/ansi.ts:146`.
  Accepts `React.ReactNode` so a link with nested **bold** / *em* /
  `codespan` still composes correctly.
- The `case "link"` branch in `InlineToken` now routes through
  `osc8()` with `l.href` instead of a styled-but-inert `<Text>`.
- `SpanText` in `src/cli/ui/markdown-view.tsx` (PlanConfirm /
  PlanRefineInput) gets the same treatment — plan-modal links and
  file refs are now clickable too.
- Regression tests in `tests/markdown.test.ts` assert the OSC 8 open
  + close bytes appear in `lastFrame()` for both `[text](url)` and
  bare file refs (`path:line` → `file://path:line`).

OSC 8 is emitted unconditionally; terminals that don't support it
silently discard the sequence (xterm/VT spec behaviour).

Closes #723

## Test plan

- [ ] In a kitty / iTerm2 / Windows Terminal / VSCode terminal, ask
      the model to include a `[label](https://...)` link in a reply —
      hover and confirm the underlined text shows as a real hyperlink.
- [ ] Same for file refs that the model emits (e.g. `src/foo.ts:42`).
- [ ] Open `/plan` and verify any link/file ref in the plan-confirm
      modal is also clickable.
- [ ] In a non-supporting terminal (e.g. Apple Terminal), confirm the
      text still renders cleanly without showing raw escape bytes.
