### PR TITLE
fix(wallet): pick the largest balance instead of balance_infos[0]

### DIFF
--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -11,6 +11,7 @@ import {
   parseAtQuery,
   rankPickerCandidates,
 } from "../../at-mentions.js";
+import { pickPrimaryBalance } from "../../client.js";
 import { codeSystemPrompt } from "../../code/prompt.js";
 import { buildCodeToolset } from "../../code/setup.js";
 import {
@@ -387,8 +388,9 @@ function emitSettings(tab: Tab): void {
 async function emitBalance(tab: Tab): Promise<void> {
   if (!tab.runtime) return;
   const bal = await tab.runtime.loop.client.getBalance().catch(() => null);
-  if (!bal || !bal.balance_infos.length) return;
-  const primary = bal.balance_infos[0]!;
+  if (!bal) return;
+  const primary = pickPrimaryBalance(bal.balance_infos);
+  if (!primary) return;
   emit(
     {
       type: "$balance",

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -3,7 +3,7 @@
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
-import { DeepSeekClient } from "../../client.js";
+import { DeepSeekClient, pickPrimaryBalance } from "../../client.js";
 import {
   defaultConfigPath,
   loadBaseUrl,
@@ -194,23 +194,20 @@ async function checkApiReach(): Promise<Check> {
         detail: "/user/balance returned null — auth failed or network blocked",
       };
     }
+    const summary = summarizeBalances(balance.balance_infos);
     if (!balance.is_available) {
-      const info = balance.balance_infos[0];
       return {
         id: "api-reach",
         label: "api reach    ",
         level: "warn",
-        detail: `account flagged not-available${info ? ` (${info.total_balance} ${info.currency})` : ""} — top up or check your dashboard`,
+        detail: `account flagged not-available${summary ? ` (${summary})` : ""} — top up or check your dashboard`,
       };
     }
-    const info = balance.balance_infos[0];
     return {
       id: "api-reach",
       label: "api reach    ",
       level: "ok",
-      detail: info
-        ? `/user/balance ok — ${info.total_balance} ${info.currency}`
-        : "/user/balance ok",
+      detail: summary ? `/user/balance ok — ${summary}` : "/user/balance ok",
     };
   } catch (err) {
     return {
@@ -220,6 +217,17 @@ async function checkApiReach(): Promise<Check> {
       detail: `${(err as Error).message}`,
     };
   }
+}
+
+function summarizeBalances(
+  infos: ReadonlyArray<{ currency: string; total_balance: string }>,
+): string {
+  if (infos.length === 0) return "";
+  const primary = pickPrimaryBalance(infos);
+  if (infos.length === 1 || !primary)
+    return primary ? `${primary.total_balance} ${primary.currency}` : "";
+  const rest = infos.filter((i) => i !== primary).map((i) => `${i.total_balance} ${i.currency}`);
+  return `${primary.total_balance} ${primary.currency} + ${rest.join(" + ")}`;
 }
 
 async function checkTokenizer(): Promise<Check> {

--- a/src/cli/ui/useSessionInfo.ts
+++ b/src/cli/ui/useSessionInfo.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import { pickPrimaryBalance } from "../../client.js";
 import type { CacheFirstLoop } from "../../loop.js";
 import { VERSION, compareVersions, getLatestVersion } from "../../version.js";
 
@@ -32,8 +33,9 @@ export function useSessionInfo(loop: CacheFirstLoop): UseSessionInfoResult {
     let cancelled = false;
     void (async () => {
       const bal = await loop.client.getBalance().catch(() => null);
-      if (cancelled || !bal || !bal.balance_infos.length) return;
-      const primary = bal.balance_infos[0]!;
+      if (cancelled || !bal) return;
+      const primary = pickPrimaryBalance(bal.balance_infos);
+      if (!primary) return;
       setBalance({ currency: primary.currency, total: Number(primary.total_balance) });
     })();
     return () => {
@@ -79,9 +81,9 @@ export function useSessionInfo(loop: CacheFirstLoop): UseSessionInfoResult {
   const refreshBalance = useCallback(() => {
     void (async () => {
       const bal = await loop.client.getBalance().catch(() => null);
-      if (bal?.balance_infos.length) {
-        const p = bal.balance_infos[0]!;
-        setBalance({ currency: p.currency, total: Number(p.total_balance) });
+      const primary = bal ? pickPrimaryBalance(bal.balance_infos) : null;
+      if (primary) {
+        setBalance({ currency: primary.currency, total: Number(primary.total_balance) });
       }
     })();
   }, [loop]);

--- a/src/client.ts
+++ b/src/client.ts
@@ -57,6 +57,16 @@ export interface UserBalance {
   balance_infos: BalanceInfo[];
 }
 
+/** Largest `total_balance` wins — the wallet the user actually paid for and expects to see ticking down. */
+export function pickPrimaryBalance(infos: ReadonlyArray<BalanceInfo>): BalanceInfo | null {
+  if (infos.length === 0) return null;
+  let best = infos[0]!;
+  for (let i = 1; i < infos.length; i++) {
+    if (Number(infos[i]!.total_balance) > Number(best.total_balance)) best = infos[i]!;
+  }
+  return best;
+}
+
 export interface ModelInfo {
   id: string;
   object: "model";

--- a/tests/pick-primary-balance.test.ts
+++ b/tests/pick-primary-balance.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { type BalanceInfo, pickPrimaryBalance } from "../src/client.js";
+
+describe("pickPrimaryBalance — issue #724", () => {
+  it("returns null for an empty list", () => {
+    expect(pickPrimaryBalance([])).toBeNull();
+  });
+
+  it("picks the only entry when there is just one wallet", () => {
+    const only: BalanceInfo = { currency: "CNY", total_balance: "0.47" };
+    expect(pickPrimaryBalance([only])).toBe(only);
+  });
+
+  it("picks the largest top-up wallet when USD + CNY both exist (issue #724 case)", () => {
+    const usd: BalanceInfo = { currency: "USD", total_balance: "4.99", topped_up_balance: "4.99" };
+    const cny: BalanceInfo = { currency: "CNY", total_balance: "0.47", topped_up_balance: "0.47" };
+    expect(pickPrimaryBalance([cny, usd])).toBe(usd);
+    expect(pickPrimaryBalance([usd, cny])).toBe(usd);
+  });
+
+  it("keeps CNY when USD has zero balance", () => {
+    const usd: BalanceInfo = { currency: "USD", total_balance: "0" };
+    const cny: BalanceInfo = { currency: "CNY", total_balance: "50" };
+    expect(pickPrimaryBalance([usd, cny])).toBe(cny);
+  });
+
+  it("breaks ties by keeping the first entry (stable)", () => {
+    const a: BalanceInfo = { currency: "USD", total_balance: "5" };
+    const b: BalanceInfo = { currency: "CNY", total_balance: "5" };
+    expect(pickPrimaryBalance([a, b])).toBe(a);
+  });
+});


### PR DESCRIPTION
## Summary

Reported in #724: when `/user/balance` returns both USD and CNY
entries (e.g. `USD 4.99` top-up + dust `CNY 0.47`), the TUI status
row, `doctor` check, desktop kernel and dashboard cockpit all rendered
just the first array entry — typically CNY in that order — so the
account looked almost empty even though the user has real USD funds.

Five call sites were doing `balance_infos[0]!`:

- `src/cli/ui/useSessionInfo.ts` (initial fetch + refresh)
- `src/cli/commands/desktop.ts` (Tauri kernel `$balance` event)
- `src/cli/commands/doctor.ts` (api-reach check, both branches)

## Fix

- Add `pickPrimaryBalance(infos)` in `src/client.ts` that walks the
  array and returns the entry with the largest `total_balance`. For
  single-wallet accounts the behaviour is unchanged; for multi-wallet
  accounts the wallet the user actually funded surfaces correctly.
- `doctor`'s api-reach check additionally enumerates every wallet when
  more than one is present, so the diagnostic now reads
  `/user/balance ok — 4.99 USD + 0.47 CNY` instead of hiding one half.
- The dashboard cockpit reads `stats.balance` which is built from
  `balanceRef.current` (the primary surfaced by `useSessionInfo`), so
  this fix propagates through the wire shape without separate plumbing.

Unit tests in `tests/pick-primary-balance.test.ts` cover the empty
case, single-entry passthrough, the issue-#724 USD+CNY case, the
zero-USD fallback, and the tie-break invariant.

Closes #724

## Test plan

- [ ] On an account with both USD + CNY balances, run `reasonix code`
      and confirm the status-row wallet pill shows the larger wallet
      (USD in the reporter's case).
- [ ] Run `reasonix doctor` on the same account and verify the
      api-reach detail enumerates both wallets joined by ` + `.
- [ ] On an account with a single wallet, confirm the display is
      unchanged.
- [ ] In the dashboard, confirm the cockpit wallet card matches the
      TUI's selection.
