### PR TITLE
fix(embed): tolerate providers that drop inputs from a batch response

### DIFF
--- a/src/index/semantic/embedding.ts
+++ b/src/index/semantic/embedding.ts
@@ -133,7 +133,13 @@ async function embedOpenAICompat(
   opts: Extract<EmbedOptions, { provider: "openai-compat" }>,
 ): Promise<Float32Array> {
   const vectors = await requestOpenAICompatEmbeddings(text, opts);
-  return vectors[0] ?? new Float32Array(0);
+  const v = vectors[0];
+  if (!v) {
+    throw new EmbeddingError(
+      `Embedding provider returned no vector for the input (model ${opts.model})`,
+    );
+  }
+  return v;
 }
 
 async function embedAllOpenAICompat(
@@ -146,6 +152,16 @@ async function embedAllOpenAICompat(
   if (texts.length === 0) return [];
   if (opts.signal?.aborted) throw new EmbeddingError("embedding aborted");
   const vectors = await requestOpenAICompatEmbeddings([...texts], opts);
+  for (let i = 0; i < vectors.length; i++) {
+    if (vectors[i] === null) {
+      opts.onError?.(
+        i,
+        new EmbeddingError(
+          `provider dropped input ${i} from the batch (model ${opts.model} returned no embedding for it)`,
+        ),
+      );
+    }
+  }
   opts.onProgress?.(texts.length, texts.length);
   return vectors;
 }
@@ -153,7 +169,7 @@ async function embedAllOpenAICompat(
 async function requestOpenAICompatEmbeddings(
   input: string | string[],
   opts: Extract<EmbedOptions, { provider: "openai-compat" }>,
-): Promise<Float32Array[]> {
+): Promise<Array<Float32Array | null>> {
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const { controller, cleanup } = composeAbort(opts.signal, timeoutMs, "embedding timeout");
   const url = opts.baseUrl.trim();
@@ -231,11 +247,7 @@ async function requestOpenAICompatEmbeddings(
     }
     out[index] = toFloat32Array(row.embedding, `data[${index}].embedding`);
   }
-  for (let i = 0; i < out.length; i++) {
-    if (!out[i])
-      throw new EmbeddingError(`OpenAI-compatible response missing embedding at index ${i}`);
-  }
-  return out as Float32Array[];
+  return out;
 }
 
 function toFloat32Array(values: unknown[], label: string): Float32Array {

--- a/tests/semantic-embed-tolerant.test.ts
+++ b/tests/semantic-embed-tolerant.test.ts
@@ -87,6 +87,62 @@ describe("embedAll fault tolerance", () => {
     expect(errors).toEqual([]);
   });
 
+  it("returns null + onError for inputs the provider silently drops from a batch (issue #727)", async () => {
+    globalThis.fetch = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          data: [
+            { index: 0, embedding: [0.1, 0, 0] },
+            { index: 1, embedding: [0.2, 0, 0] },
+            { index: 2, embedding: [0.3, 0, 0] },
+            { index: 3, embedding: [0.4, 0, 0] },
+            { index: 4, embedding: [0.5, 0, 0] },
+            { index: 5, embedding: [0.6, 0, 0] },
+            { index: 6, embedding: [0.7, 0, 0] },
+            { index: 7, embedding: [0.8, 0, 0] },
+            { index: 9, embedding: [0.9, 0, 0] },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as unknown as typeof globalThis.fetch;
+    const errors: number[] = [];
+    const out = await embedAll(
+      Array.from({ length: 10 }, (_, i) => `chunk ${i}`),
+      {
+        provider: "openai-compat",
+        baseUrl: "https://api.siliconflow.cn/v1/embeddings",
+        apiKey: "sk-test12345678901234567890",
+        model: "Qwen/Qwen3-VL-Embedding-8B",
+        onError: (i) => errors.push(i),
+      },
+    );
+    expect(out).toHaveLength(10);
+    expect(out[8]).toBeNull();
+    expect(errors).toEqual([8]);
+    for (let i = 0; i < 10; i++) {
+      if (i !== 8) expect(out[i]).toBeInstanceOf(Float32Array);
+    }
+  });
+
+  it("single-text embed still throws when the provider returns nothing", async () => {
+    globalThis.fetch = vi.fn(async () => {
+      return new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof globalThis.fetch;
+    const { embed } = await import("../src/index/semantic/embedding.js");
+    await expect(
+      embed("some text", {
+        provider: "openai-compat",
+        baseUrl: "https://api.example.com/v1",
+        apiKey: "sk-test12345678901234567890",
+        model: "Qwen/Qwen3-VL-Embedding-8B",
+      }),
+    ).rejects.toBeInstanceOf(EmbeddingError);
+  });
+
   it("treats openai-compatible aborts as aborts", async () => {
     globalThis.fetch = vi.fn(async (_input, init) => {
       const signal = init?.signal;


### PR DESCRIPTION
## Summary

Reported in #727: SiliconFlow's `Qwen/Qwen3-VL-Embedding-8B` sometimes
returns fewer entries in `data[]` than the request had inputs. The
user hit it at chunk 8 of 72 and the whole index pass aborted with
`OpenAI-compatible response missing embedding at index 8`, throwing
away 71 already-embedded chunks. The pure-text sibling
`Qwen/Qwen3-Embedding-8B` does not exhibit this.

The OpenAI-compat client treated a partial response as a hard error:

```ts
for (let i = 0; i < out.length; i++) {
  if (!out[i]) throw new EmbeddingError(`... missing embedding at index ${i}`);
}
```

That's right for strict providers but wrong against ones that silently
drop inputs. `embedAll`'s public contract already returns
`Array<Float32Array | null>` and the index builder already handles
`null` slots via `onError` + skip-and-continue.

## Fix

- `requestOpenAICompatEmbeddings` now returns
  `Array<Float32Array | null>` instead of throwing on partial
  responses. Other validation (invalid index, non-array embedding,
  HTTP errors) still throws.
- `embedAllOpenAICompat` routes each `null` slot through
  `opts.onError`, so the builder prints
  `! skipped path:start-end: provider dropped input N from the batch`
  for the dropped chunks and keeps going.
- `embedOpenAICompat` (single-text path) keeps the strict throw — if
  the provider refuses a single input there is nothing else to return.

Regression tests in `tests/semantic-embed-tolerant.test.ts` cover
both the SiliconFlow VL case (partial batch → partial result + per-
slot `onError`) and the single-text refusal (still throws).

Closes #727

## Test plan

- [ ] Run `reasonix index` against a repo with embedding model set to
      `Qwen/Qwen3-VL-Embedding-8B` and confirm the build completes,
      with per-chunk skip warnings for the dropped inputs.
- [ ] Run `reasonix index` against the same repo with
      `Qwen/Qwen3-Embedding-8B` and confirm no warnings (no inputs
      dropped, behaviour unchanged).
- [ ] Verify a single-text embed against a provider that returns
      empty `data[]` still surfaces a clear error rather than a
      zero-length vector.
