### PR TITLE
fix(composer): keep the prompt cursor visible when the ticker suspends

### DIFF
--- a/src/cli/ui/PromptInput.tsx
+++ b/src/cli/ui/PromptInput.tsx
@@ -16,7 +16,7 @@ import {
 } from "./paste-sentinels.js";
 import { type Segment, buildViewport, stringCells } from "./prompt-viewport.js";
 import { FG, SURFACE, TONE } from "./theme/tokens.js";
-import { useSlowTick } from "./ticker.js";
+import { useCursorBlink } from "./ticker.js";
 
 /** Raw-stdin keystroke bus → multiline reducer; one logical line per Box row, viewport-clipped. */
 
@@ -165,7 +165,7 @@ export function PromptInput({
 
   const lines = value.length > 0 ? value.split("\n") : [""];
   const accentColor = disabled ? FG.faint : TONE.brand;
-  const cursorVisible = useSlowTick() % 2 === 0;
+  const cursorVisible = useCursorBlink();
   const { line: cursorLine, col: cursorCol } = lineAndColumn(value, cursor);
 
   const renderItems = collapseLinesForDisplay(lines, cursorLine);

--- a/src/cli/ui/ticker.tsx
+++ b/src/cli/ui/ticker.tsx
@@ -63,6 +63,19 @@ export function useSlowTick(): number {
   return useAnimation({ interval: SLOW_TICK_MS, isActive }).frame;
 }
 
+/**
+ * Cursor blink — 1Hz while the heartbeat is running; forced visible when
+ * the ticker is suspended. Without the active-guard the raw frame stays
+ * at whatever value it last reached (issue #728): a turn that lasts an
+ * odd number of seconds leaves the cursor stuck off, so the user can't
+ * tell where input lands.
+ */
+export function useCursorBlink(): boolean {
+  const isActive = useTickerActive();
+  const tick = useSlowTick();
+  return !isActive || tick % 2 === 0;
+}
+
 /** Seconds elapsed since mount. Re-renders at 1Hz via the slow tick. */
 export function useElapsedSeconds(): number {
   const [start] = useState(() => Date.now());

--- a/tests/cursor-blink.test.tsx
+++ b/tests/cursor-blink.test.tsx
@@ -1,0 +1,36 @@
+import { Text } from "ink";
+import { render } from "ink-testing-library";
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TickerProvider, useCursorBlink } from "../src/cli/ui/ticker.js";
+
+function Probe(): React.ReactElement {
+  return <Text>{useCursorBlink() ? "ON" : "OFF"}</Text>;
+}
+
+describe("useCursorBlink — issue #728", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "performance"] });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("stays visible when the ticker disables after an odd frame (issue #728)", async () => {
+    const { lastFrame, rerender, unmount } = render(
+      <TickerProvider disabled={false}>
+        <Probe />
+      </TickerProvider>,
+    );
+    await vi.advanceTimersByTimeAsync(1100);
+    rerender(
+      <TickerProvider disabled={true}>
+        <Probe />
+      </TickerProvider>,
+    );
+    const out = lastFrame() ?? "";
+    unmount();
+    expect(out).toContain("ON");
+  });
+});


### PR DESCRIPTION
## Summary

Reported in #728: after a single round of dialogue the blue cursor in
the composer disappears and the user can no longer tell where typed
characters will land. Regression from #672, which traded the
hardcoded `cursorVisible = true` for `useSlowTick() % 2 === 0`.

## Cause

The slow-tick frame is driven by Ink's shared animation timer, which
the TUI suspends whenever the conversation is idle:

```ts
const tickerSuspended = modalOpen || (!busy && !isStreaming);
```

When the timer pauses, Ink's `useAnimation` stops advancing but keeps
returning the last frame value. If a streaming turn ran for an odd
number of seconds, the frame freezes on 1 (or 3, 5, …), so
`frame % 2 === 0` evaluates to `false` and the cursor stays blanked
indefinitely. The user only sees the cursor on the empty-input first
mount (frame 0); every later idle state inherits whatever parity the
last active stretch landed on. Lines up exactly with the reporter's
screenshots — cursor present on first mount, gone after one turn.

## Fix

- Add `useCursorBlink()` in `src/cli/ui/ticker.tsx` that combines the
  slow tick with the ticker-active state: while suspended, force
  visible; while active, blink each second as designed.
- Replace the single inline expression in `src/cli/ui/PromptInput.tsx`.

Regression test in `tests/cursor-blink.test.tsx` mounts a probe inside
an active `TickerProvider`, advances fake timers past a slow tick so
the raw frame is odd, then rerenders with the provider suspended and
asserts the probe still reads `ON`. Verified to fail against the old
inline expression (reads `OFF`) and pass after the fix.

Closes #728

## Test plan

- [ ] On macOS / kitty, run `reasonix code`, exchange one round of
      dialogue with the agent, and confirm the blue block cursor
      remains visible in the composer afterwards.
- [ ] Repeat with several conversation lengths to cover both even and
      odd "last frame" parities.
- [ ] Confirm the cursor still blinks at 1Hz while the model is
      streaming (active heartbeat path unchanged).
