### PR TITLE
fix(plan): stabilize expanded approval modal layout

### DIFF
--- a/docs/CLI-REFERENCE.md
+++ b/docs/CLI-REFERENCE.md
@@ -109,7 +109,7 @@ Type `/` mid-chat to open the picker. Aliases shown in parentheses. Code-mode-on
 | `/show [id]` | Dump a stored edit diff |
 | `/commit "msg"` | `git add -A && git commit -m ...` |
 | `/mode <review\|auto\|yolo>` | Edit-gate mode. Shift+Tab cycles |
-| `/plan [on\|off]` | Toggle read-only plan mode |
+| `/plan [on\|off]` | Toggle read-only plan mode. Submitted plans initially show a compact summary; press `Ctrl+P` in the plan confirmation modal to expand/collapse full details |
 | `/checkpoint [name\|list\|forget]` | Snapshot every file the session has touched |
 | `/restore <name\|id>` | Roll back to a named checkpoint |
 | `/cwd <path>` (`/sandbox`) | Switch the workspace root mid-session |
@@ -147,7 +147,7 @@ Type `/` mid-chat to open the picker. Aliases shown in parentheses. Code-mode-on
 | `Enter` | Submit the prompt |
 | `Shift+Enter` | Insert a newline in the prompt |
 | `↑` / `↓` | Scroll chat history (mouse wheel routes here too) |
-| `Ctrl+P` / `Ctrl+N` | Previous / next prompt history · cursor up / down in a multi-line draft |
+| `Ctrl+P` / `Ctrl+N` | Previous / next prompt history · cursor up / down in a multi-line draft. In a submitted-plan confirmation modal, `Ctrl+P` expands/collapses full plan details |
 | `Ctrl+A` / `Ctrl+E` | Jump to start / end of the current line |
 | `Ctrl+W` | Delete the word before the cursor |
 | `Ctrl+U` | Clear the entire prompt buffer |
@@ -155,7 +155,7 @@ Type `/` mid-chat to open the picker. Aliases shown in parentheses. Code-mode-on
 | `Shift+Tab` | Edit-gate: toggle review ↔ AUTO mode |
 | `Esc` | Dismiss picker · abort the running model turn |
 | `Ctrl+C` | Abort the running model turn (NOT copy — see clipboard) |
-| `PgUp` / `PgDn` | Scroll chat history a page at a time |
+| `PgUp` / `PgDn` | Scroll chat history a page at a time. While plan details are expanded, scroll the bounded detail window |
 | `End` | Jump chat to the most recent line |
 
 ### Edit-gate (code mode)

--- a/src/cli/ui/PlanConfirm.tsx
+++ b/src/cli/ui/PlanConfirm.tsx
@@ -1,15 +1,15 @@
-/** Modal-style picker for `submit_plan`: accept / refine / cancel. */
-
-import { Box, Text } from "ink";
-import React from "react";
+import { Box, Text, useStdout } from "ink";
+import React, { useMemo, useState } from "react";
 import { t } from "../../i18n/index.js";
 import type { PlanStep } from "../../tools/plan.js";
 import { PlanStepList } from "./PlanStepList.js";
 import { SingleSelect } from "./Select.js";
 import { ApprovalCard } from "./cards/ApprovalCard.js";
-import { useReserveRows } from "./layout/viewport-budget.js";
+import { useKeystroke } from "./keystroke-context.js";
+import { useReserveRows, useTotalRows } from "./layout/viewport-budget.js";
 import { MarkdownView } from "./markdown-view.js";
 import { extractOpenQuestionsSection } from "./plan-open-questions.js";
+import type { KeyEvent } from "./stdin-reader.js";
 import { CARD, FG, TONE } from "./theme/tokens.js";
 
 export type PlanConfirmChoice = "approve" | "refine" | "revise" | "cancel";
@@ -17,27 +17,95 @@ export type PlanConfirmChoice = "approve" | "refine" | "revise" | "cancel";
 export interface PlanConfirmProps {
   plan: string;
   steps?: PlanStep[];
-  /** Optional human-friendly title from the model — surfaced in the header. */
   summary?: string;
   onChoose: (choice: PlanConfirmChoice) => void;
   projectRoot?: string;
 }
 
-const PLAN_BODY_PREVIEW_LINES = 24;
+const DEFAULT_DETAIL_LINES = 12;
+const MIN_DETAIL_LINES = 6;
+const EXPANDED_MODAL_OVERHEAD_ROWS = 12;
+const EXPANDED_DETAIL_CHROME_ROWS = 4;
 
-function PlanConfirmInner({ plan, steps, onChoose }: PlanConfirmProps) {
+function PlanConfirmInner({ plan, steps, summary, onChoose }: PlanConfirmProps) {
+  const { stdout } = useStdout();
+  const totalRows = useTotalRows();
+  const [expanded, setExpanded] = useState(false);
+  const [detailOffset, setDetailOffset] = useState(0);
   const stepRows = steps?.length ?? 0;
   const hasSteps = stepRows > 0;
   const openQuestions = extractOpenQuestionsSection(plan);
-  const planLines = plan.split("\n");
-  const truncatedBody = planLines.length > PLAN_BODY_PREVIEW_LINES;
-  const previewBody = truncatedBody ? planLines.slice(0, PLAN_BODY_PREVIEW_LINES).join("\n") : plan;
-  const previewRows = truncatedBody
-    ? PLAN_BODY_PREVIEW_LINES
-    : Math.min(planLines.length, PLAN_BODY_PREVIEW_LINES);
-  const reservedFor = hasSteps ? stepRows : previewRows;
-  const oqRows = openQuestions ? openQuestions.split("\n").length : 0;
-  useReserveRows("modal", { min: 10, max: Math.max(16, reservedFor + oqRows + 14) });
+  const planLines = useMemo(() => plan.split("\n"), [plan]);
+  const effectiveSummary = useMemo(
+    () => summarizePlan(plan, summary, steps),
+    [plan, summary, steps],
+  );
+
+  const oqRows = openQuestions ? Math.min(openQuestions.split("\n").length, 8) : 0;
+  const modalRows = useReserveRows("modal", {
+    min: 10,
+    max: expanded
+      ? Math.max(10, totalRows - EXPANDED_DETAIL_CHROME_ROWS)
+      : Math.max(16, Math.min(32, (hasSteps ? stepRows + 2 : 2) + oqRows + 14)),
+  });
+  const detailViewRows = expanded
+    ? Math.max(10, modalRows - EXPANDED_MODAL_OVERHEAD_ROWS)
+    : Math.max(
+        MIN_DETAIL_LINES,
+        Math.min(18, Math.floor(((stdout?.rows ?? 32) - 14) / 2) || DEFAULT_DETAIL_LINES),
+      );
+  const maxDetailOffset = Math.max(0, planLines.length - detailViewRows);
+  const clampedDetailOffset = Math.min(detailOffset, maxDetailOffset);
+  const rawSliceStart = clampedDetailOffset;
+  const rawSliceEnd = Math.min(planLines.length, rawSliceStart + detailViewRows);
+  const { displayStart, displayEnd } = (() => {
+    let start = rawSliceStart;
+    let end = rawSliceEnd;
+    while (start < end && planLines[start]?.trim() === "" && end < planLines.length) {
+      start += 1;
+      end += 1;
+    }
+    return { displayStart: start, displayEnd: end };
+  })();
+  const visiblePlanLines = planLines.slice(displayStart, displayEnd);
+  const detailOverflow = planLines.length > detailViewRows;
+  const showDetailScrollHint = expanded && plan.trim().length > 0 && detailOverflow;
+
+  const detailOwnsScrollKey = expanded && detailOverflow;
+  const isDetailScrollKey = (ev: KeyEvent) =>
+    detailOwnsScrollKey &&
+    !!(
+      ev.pageUp ||
+      ev.pageDown ||
+      ev.home ||
+      ev.end ||
+      ev.mouseScrollUp ||
+      ev.mouseScrollDown ||
+      ev.upArrow ||
+      ev.downArrow
+    );
+
+  useKeystroke((ev) => {
+    if (ev.paste) return;
+    if (ev.ctrl && ev.input === "p") {
+      setExpanded((v) => !v);
+      return;
+    }
+    if (!isDetailScrollKey(ev)) return;
+    if (ev.pageUp || ev.mouseScrollUp) {
+      setDetailOffset((n) => Math.max(0, n - detailViewRows));
+    } else if (ev.pageDown || ev.mouseScrollDown) {
+      setDetailOffset((n) => Math.min(maxDetailOffset, n + detailViewRows));
+    } else if (ev.home) {
+      setDetailOffset(0);
+    } else if (ev.end) {
+      setDetailOffset(maxDetailOffset);
+    } else if (ev.upArrow) {
+      setDetailOffset((n) => Math.max(0, n - 1));
+    } else if (ev.downArrow) {
+      setDetailOffset((n) => Math.min(maxDetailOffset, n + 1));
+    }
+  });
 
   const refineLabel = t("planFlow.picker.refine");
   const bannerTemplate = t("planFlow.openQuestionsBanner");
@@ -66,23 +134,35 @@ function PlanConfirmInner({ plan, steps, onChoose }: PlanConfirmProps) {
           </Box>
         </Box>
       ) : null}
-      {hasSteps ? (
+      {!expanded || plan.trim().length === 0 ? (
         <Box marginBottom={1} flexDirection="column">
-          <PlanStepList steps={steps!} />
-        </Box>
-      ) : plan.trim().length > 0 ? (
-        <Box marginBottom={1} flexDirection="column">
-          <MarkdownView text={previewBody} />
-          {truncatedBody ? (
-            <Text color={FG.faint}>
-              {t(
-                planLines.length - PLAN_BODY_PREVIEW_LINES === 1
-                  ? "planFlow.truncatedBodyMore"
-                  : "planFlow.truncatedBodyMorePlural",
-                { n: planLines.length - PLAN_BODY_PREVIEW_LINES },
-              )}
-            </Text>
+          {effectiveSummary ? (
+            <Text color={FG.body}>{effectiveSummary}</Text>
+          ) : (
+            <Text color={FG.faint}>{t("planFlow.noPlanSummary")}</Text>
+          )}
+          {!expanded && hasSteps ? (
+            <Box marginTop={1} flexDirection="column">
+              <PlanStepList steps={steps!} />
+            </Box>
           ) : null}
+          <Text color={FG.faint}>
+            {expanded ? t("planFlow.detailExpandedHint") : t("planFlow.detailCollapsedHint")}
+          </Text>
+        </Box>
+      ) : null}
+      {expanded && plan.trim().length > 0 ? (
+        <PlanDetailWindow
+          lines={visiblePlanLines}
+          overflow={detailOverflow}
+          start={displayStart + 1}
+          end={displayEnd}
+          total={planLines.length}
+        />
+      ) : null}
+      {showDetailScrollHint ? (
+        <Box marginBottom={1}>
+          <Text color={FG.faint}>{t("planFlow.detailScrollHint")}</Text>
         </Box>
       ) : null}
       <SingleSelect
@@ -111,10 +191,54 @@ function PlanConfirmInner({ plan, steps, onChoose }: PlanConfirmProps) {
         ]}
         onSubmit={(v) => onChoose(v as PlanConfirmChoice)}
         onCancel={() => onChoose("cancel")}
+        inlineHints
+        ignoreKey={isDetailScrollKey}
       />
     </ApprovalCard>
   );
 }
 
-/** Memoized — parent re-renders every tick; props only change on user action. */
+function PlanDetailWindow({
+  lines,
+  overflow,
+  start,
+  end,
+  total,
+}: {
+  lines: readonly string[];
+  overflow: boolean;
+  start: number;
+  end: number;
+  total: number;
+}): React.ReactElement {
+  return (
+    <Box flexDirection="column">
+      {overflow ? (
+        <Text color={FG.faint}>{t("planFlow.detailWindow", { start, end, total })}</Text>
+      ) : null}
+      {lines.map((line, i) => (
+        <Text key={`plan-detail-${start + i}`} wrap="truncate">
+          {line.length > 0 ? line : " "}
+        </Text>
+      ))}
+    </Box>
+  );
+}
+
+function summarizePlan(
+  plan: string,
+  summary: string | undefined,
+  steps: PlanStep[] | undefined,
+): string {
+  const trimmedSummary = summary?.trim();
+  if (trimmedSummary) return trimmedSummary;
+  const firstTextLine = plan
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => line.length > 0 && !/^#{1,6}\s*$/.test(line));
+  if (firstTextLine) return firstTextLine.replace(/^#{1,6}\s+/, "").slice(0, 160);
+  if (steps && steps.length > 0) return steps[0]?.title ?? "";
+  return "";
+}
+
 export const PlanConfirm = React.memo(PlanConfirmInner);

--- a/src/cli/ui/Select.tsx
+++ b/src/cli/ui/Select.tsx
@@ -3,12 +3,13 @@
 import { Box, Text } from "ink";
 import React, { useState } from "react";
 import { useKeystroke } from "./keystroke-context.js";
+import type { KeyEvent } from "./stdin-reader.js";
 import { type UiColor, useColor } from "./theme.js";
 
 export interface SelectItem<V extends string = string> {
   value: V;
   label: string;
-  /** Optional second row rendered dimmed. */
+  /** Optional descriptive text rendered dimmed. */
   hint?: string;
   /** Disabled rows render dimmed and are skipped on nav. */
   disabled?: boolean;
@@ -23,6 +24,10 @@ export interface SingleSelectProps<V extends string> {
   onTab?: (value: V) => void;
   /** Optional dim footer beneath the list. */
   footer?: string;
+  /** Render item hints on the same row as the label instead of a second row. */
+  inlineHints?: boolean;
+  /** Ignore matching keystrokes so an enclosing component can own them. */
+  ignoreKey?: (ev: KeyEvent) => boolean;
 }
 
 export function SingleSelect<V extends string>({
@@ -32,6 +37,8 @@ export function SingleSelect<V extends string>({
   onTab,
   onCancel,
   footer,
+  inlineHints = false,
+  ignoreKey,
 }: SingleSelectProps<V>) {
   const color = useColor();
   const initialIndex = Math.max(
@@ -41,7 +48,7 @@ export function SingleSelect<V extends string>({
   const [index, setIndex] = useState(initialIndex === -1 ? 0 : initialIndex);
 
   useKeystroke((ev) => {
-    if (ev.paste) return;
+    if (ev.paste || ignoreKey?.(ev)) return;
     if (ev.upArrow) {
       setIndex((i) => findNextEnabled(items, i, -1));
     } else if (ev.downArrow) {
@@ -66,6 +73,7 @@ export function SingleSelect<V extends string>({
           active={i === index}
           marker={i === index ? "▸" : " "}
           color={color}
+          inlineHint={inlineHints}
         />
       ))}
       {footer ? (
@@ -84,6 +92,10 @@ export interface MultiSelectProps<V extends string> {
   onCancel?: () => void;
   /** Footer hint under the list — e.g. "[Space] toggle · [Enter] confirm". */
   footer?: string;
+  /** Render item hints on the same row as the label instead of a second row. */
+  inlineHints?: boolean;
+  /** Ignore matching keystrokes so an enclosing component can own them. */
+  ignoreKey?: (ev: KeyEvent) => boolean;
 }
 
 export function MultiSelect<V extends string>({
@@ -92,6 +104,8 @@ export function MultiSelect<V extends string>({
   onSubmit,
   onCancel,
   footer,
+  inlineHints = false,
+  ignoreKey,
 }: MultiSelectProps<V>) {
   const color = useColor();
   const [index, setIndex] = useState(() => {
@@ -101,7 +115,7 @@ export function MultiSelect<V extends string>({
   const [selected, setSelected] = useState<Set<V>>(new Set(initialSelected));
 
   useKeystroke((ev) => {
-    if (ev.paste) return;
+    if (ev.paste || ignoreKey?.(ev)) return;
     if (ev.upArrow) {
       setIndex((i) => findNextEnabled(items, i, -1));
     } else if (ev.downArrow) {
@@ -135,6 +149,7 @@ export function MultiSelect<V extends string>({
             active={i === index}
             marker={`${i === index ? "▸" : " "} ${marker}`}
             color={color}
+            inlineHint={inlineHints}
           />
         );
       })}
@@ -152,18 +167,31 @@ function SelectRow<V extends string>({
   active,
   marker,
   color,
+  inlineHint = false,
 }: {
   item: SelectItem<V>;
   active: boolean;
   marker: string;
   color: UiColor;
+  inlineHint?: boolean;
 }) {
   const rowColor = item.disabled ? color.info : active ? color.primary : undefined;
+  const labelText = `${marker} ${item.label}`;
+  if (inlineHint) {
+    return (
+      <Box flexDirection="row" flexWrap="nowrap" minHeight={1}>
+        <Text color={rowColor} bold={active} dimColor={item.disabled} wrap="truncate">
+          {labelText}
+        </Text>
+        {item.hint ? <Text dimColor wrap="truncate">{`  ${item.hint}`}</Text> : null}
+      </Box>
+    );
+  }
   return (
     <Box flexDirection="column">
       <Box>
         <Text color={rowColor} bold={active} dimColor={item.disabled}>
-          {marker} {item.label}
+          {labelText}
         </Text>
       </Box>
       {item.hint ? (

--- a/src/cli/ui/cards/ApprovalCard.tsx
+++ b/src/cli/ui/cards/ApprovalCard.tsx
@@ -51,7 +51,7 @@ export function ApprovalCard({
   const ruleWidth = Math.max(MIN_SEPARATOR, cols - SEPARATOR_PAD);
 
   return (
-    <Box flexDirection="column" marginY={1}>
+    <Box flexDirection="column" marginY={1} flexShrink={0}>
       <Box flexDirection="row">
         <Text color={palette.color} backgroundColor={SURFACE.bgElev}>
           {" ▎ "}
@@ -68,13 +68,13 @@ export function ApprovalCard({
           </Text>
         )}
       </Box>
-      <Box flexDirection="column" paddingX={2} marginTop={1}>
+      <Box flexDirection="column" paddingX={2} marginTop={1} flexShrink={0}>
         {children}
       </Box>
-      <Box paddingX={2} marginTop={1}>
+      <Box paddingX={2} marginTop={1} flexShrink={0}>
         <Text color={FG.faint}>{"─".repeat(ruleWidth)}</Text>
       </Box>
-      <Box paddingX={2}>
+      <Box paddingX={2} flexShrink={0}>
         <Text color={FG.faint}>{effectiveFooter}</Text>
       </Box>
     </Box>

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -509,6 +509,12 @@ export const EN: TranslationSchema = {
       counterDone: "{done}/{total} done ({pct}%) · {total} steps",
       counterDoneSingular: "{done}/{total} done ({pct}%) · {total} step",
     },
+    noPlanSummary: "No plan body submitted yet.",
+    detailCollapsedHint: "Ctrl+P expands full plan details.",
+    detailExpandedHint: "Ctrl+P collapses details.",
+    detailHeader: "Plan details",
+    detailWindow: "showing lines {start}-{end} of {total}",
+    detailScrollHint: "PgUp/PgDn scroll details · Home/End jump",
     reviseTitle: "Revise plan",
     reviseSteps: "{count} steps",
     reviseFooter:

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -306,6 +306,12 @@ export interface TranslationSchema {
     openQuestionsHeader: string;
     truncatedBodyMore: string;
     truncatedBodyMorePlural: string;
+    noPlanSummary: string;
+    detailCollapsedHint: string;
+    detailExpandedHint: string;
+    detailHeader: string;
+    detailWindow: string;
+    detailScrollHint: string;
     picker: {
       accept: string;
       acceptHint: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -497,6 +497,12 @@ export const zhCN: TranslationSchema = {
       counterDone: "{done}/{total} 已完成（{pct}%） · 共 {total} 步",
       counterDoneSingular: "{done}/{total} 已完成（{pct}%） · 共 {total} 步",
     },
+    noPlanSummary: "尚未提交计划内容。",
+    detailCollapsedHint: "Ctrl+P 展开完整计划详情。",
+    detailExpandedHint: "Ctrl+P 收起详情。",
+    detailHeader: "计划详情",
+    detailWindow: "显示第 {start}-{end} 行，共 {total} 行",
+    detailScrollHint: "PgUp/PgDn 滚动详情 · Home/End 跳转",
     reviseTitle: "修改计划",
     reviseSteps: "{count} 个步骤",
     reviseFooter:

--- a/tests/plan-confirm.test.tsx
+++ b/tests/plan-confirm.test.tsx
@@ -1,6 +1,6 @@
 import { Box, Text } from "ink";
 import { render } from "ink-testing-library";
-import type React from "react";
+import React from "react";
 import { describe, expect, it } from "vitest";
 import { PlanConfirm } from "../src/cli/ui/PlanConfirm.js";
 import { ViewportBudgetProvider, useReserveRows } from "../src/cli/ui/layout/viewport-budget.js";

--- a/tests/plan-confirm.test.tsx
+++ b/tests/plan-confirm.test.tsx
@@ -1,7 +1,10 @@
+import { Box, Text } from "ink";
 import { render } from "ink-testing-library";
-import React from "react";
+import type React from "react";
 import { describe, expect, it } from "vitest";
 import { PlanConfirm } from "../src/cli/ui/PlanConfirm.js";
+import { ViewportBudgetProvider, useReserveRows } from "../src/cli/ui/layout/viewport-budget.js";
+import { makeFakeStdin, makeFakeStdout } from "./helpers/ink-stdio.js";
 
 function bytesFor(plan: string, steps?: { id: string; title: string }[]): string {
   const { lastFrame, unmount } = render(
@@ -12,8 +15,40 @@ function bytesFor(plan: string, steps?: { id: string; title: string }[]): string
   return out;
 }
 
+function ModalHost({ children }: { children: React.ReactNode }): React.ReactElement {
+  useReserveRows("stream", { min: 0, max: 12 });
+  return (
+    <Box flexDirection="row" height={30}>
+      <Box flexDirection="column" flexGrow={1}>
+        <Box flexDirection="column" flexGrow={1}>
+          <Text>top</Text>
+        </Box>
+        {children}
+      </Box>
+    </Box>
+  );
+}
+
+async function nextFrame(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function stripAnsi(text: string): string {
+  return text.replaceAll("", "").replace(/\[[0-9;]*m/g, "");
+}
+
+function blankLinesBetween(out: string, before: string, after: string): number {
+  const clean = stripAnsi(out);
+  const lines = clean.split("\n");
+  const start = lines.findIndex((line) => line.includes(before));
+  const end = lines.findIndex((line, i) => i > start && line.includes(after));
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return lines.slice(start + 1, end).filter((line) => line.trim().length === 0).length;
+}
+
 describe("PlanConfirm — issue #336 plan body must be visible", () => {
-  it("renders the markdown body when no steps are supplied", () => {
+  it("renders only a summary by default and expands body on Ctrl+P", async () => {
     const plan = [
       "## Summary",
       "Refactor `web_search` to support multiple backends",
@@ -22,10 +57,39 @@ describe("PlanConfirm — issue #336 plan body must be visible", () => {
       "1. add adapter interface",
       "2. wire env-var dispatch",
     ].join("\n");
-    const out = bytesFor(plan);
+    const { lastFrame, stdin, unmount } = render(
+      <PlanConfirm plan={plan} steps={[]} onChoose={() => {}} />,
+    );
+    expect(lastFrame() ?? "").toContain("Summary");
+    expect(lastFrame() ?? "").not.toContain("adapter interface");
+    stdin.write("\x10");
+    await nextFrame();
+    expect(lastFrame() ?? "").toContain("adapter interface");
+    stdin.write("\x10");
+    await nextFrame();
+    expect(lastFrame() ?? "").not.toContain("adapter interface");
+    unmount();
+  });
+
+  it("renders the markdown body when no steps are supplied after expand", async () => {
+    const plan = [
+      "## Summary",
+      "Refactor `web_search` to support multiple backends",
+      "",
+      "## Steps",
+      "1. add adapter interface",
+      "2. wire env-var dispatch",
+    ].join("\n");
+    const { lastFrame, stdin, unmount } = render(
+      <PlanConfirm plan={plan} steps={[]} onChoose={() => {}} />,
+    );
+    stdin.write("\x10");
+    await nextFrame();
+    const out = lastFrame() ?? "";
     expect(out).toContain("Refactor");
     expect(out).toContain("adapter interface");
     expect(out).toContain("Approve plan");
+    unmount();
   });
 
   it("falls back to step list when steps are present", () => {
@@ -39,11 +103,107 @@ describe("PlanConfirm — issue #336 plan body must be visible", () => {
     expect(out).toContain("step two");
   });
 
-  it("truncates very long plans and surfaces the overflow hint", () => {
+  it("bounds very long expanded plans and gives detail scrolling priority over the picker", async () => {
     const longPlan = Array.from({ length: 50 }, (_, i) => `line ${i + 1}`).join("\n");
-    const out = bytesFor(longPlan);
-    expect(out).toContain("line 1");
-    expect(out).toMatch(/more line.*scrollback/);
+    const choices: string[] = [];
+    const { lastFrame, stdin, unmount } = render(
+      <PlanConfirm plan={longPlan} steps={[]} onChoose={(choice) => choices.push(choice)} />,
+    );
+    expect(lastFrame() ?? "").toContain("line 1");
+    expect(lastFrame() ?? "").not.toContain("line 20");
+    stdin.write("\x10");
+    await nextFrame();
+    const expanded = lastFrame() ?? "";
+    expect(expanded).toContain("showing lines 1-");
+    expect(expanded).toContain("line 1");
+    expect(expanded).not.toContain("line 50");
+    stdin.write("\u001B[6~");
+    await nextFrame();
+    const scrolled = lastFrame() ?? "";
+    expect(scrolled).toContain("showing lines");
+    expect(scrolled).not.toContain("showing lines 1-");
+    stdin.write("\r");
+    await nextFrame();
+    expect(choices).toEqual(["approve"]);
+    unmount();
+  });
+
+  it("uses the allocated expanded detail height before any detail scroll", async () => {
+    const longPlan = Array.from({ length: 50 }, (_, i) => `line ${i + 1}`).join("\n");
+    const stdout = makeFakeStdout();
+    const { lastFrame, stdin, unmount } = render(
+      <PlanConfirm plan={longPlan} steps={[]} onChoose={() => {}} />,
+      { stdout: stdout as never, stdin: makeFakeStdin() as never },
+    );
+    stdin.write("\x10");
+    await nextFrame();
+    await nextFrame();
+    const expanded = lastFrame() ?? "";
+    expect(expanded).toContain("showing lines 1-24 of 50");
+    expect(expanded).toContain("line 24");
+    expect(expanded).not.toContain("line 25");
+    expect(
+      blankLinesBetween(expanded, "PgUp/PgDn scroll details · Home/End jump", "▸ accept"),
+    ).toBeLessThanOrEqual(1);
+    unmount();
+  });
+
+  it("keeps expanded action options tight after detail scrolling", async () => {
+    const longPlan = Array.from({ length: 50 }, (_, i) => `line ${i + 1}`).join("\n");
+    const { lastFrame, stdin, unmount } = render(
+      <PlanConfirm plan={longPlan} steps={[]} onChoose={() => {}} />,
+    );
+    stdin.write("\x10");
+    await nextFrame();
+    stdin.write("\u001B[6~");
+    await nextFrame();
+    const scrolled = lastFrame() ?? "";
+    expect(scrolled).toContain("showing lines");
+    expect(scrolled).not.toContain("showing lines 1-");
+    expect(
+      blankLinesBetween(scrolled, "PgUp/PgDn scroll details · Home/End jump", "▸ accept"),
+    ).toBeLessThanOrEqual(1);
+    unmount();
+  });
+
+  it("arrow keys scroll plan content, not options, when details are expanded", async () => {
+    const longPlan = Array.from({ length: 50 }, (_, i) => `line ${i + 1}`).join("\n");
+    const choices: string[] = [];
+    const { lastFrame, stdin, unmount } = render(
+      <PlanConfirm plan={longPlan} steps={[]} onChoose={(choice) => choices.push(choice)} />,
+    );
+    stdin.write("\x10");
+    await nextFrame();
+    const expanded = lastFrame() ?? "";
+    expect(expanded).toContain("showing lines 1-");
+    stdin.write("\u001B[B");
+    await nextFrame();
+    const scrolled = lastFrame() ?? "";
+    expect(scrolled).not.toContain("showing lines 1-");
+    expect(scrolled).toContain("showing lines");
+    stdin.write("\r");
+    await nextFrame();
+    expect(choices).toEqual(["approve"]);
+    unmount();
+  });
+
+  it("renders plan choice labels and descriptions on the same row", () => {
+    const out = bytesFor("## Summary\nbackend swap", []);
+    expect(out).toMatch(/accept\s+run it now, in order/);
+    expect(out).toMatch(/refine\s+give the agent more guidance, draft a new plan/);
+    expect(out).toMatch(/revise\s+edit the plan inline before running \(skip \/ reorder steps\)/);
+    expect(out).toMatch(/reject\s+discard, agent will retry from scratch/);
+  });
+
+  it("handles Ctrl+P safely when no plan body exists", async () => {
+    const { lastFrame, stdin, unmount } = render(
+      <PlanConfirm plan="" steps={[]} onChoose={() => {}} />,
+    );
+    expect(lastFrame() ?? "").toContain("No plan body submitted yet.");
+    stdin.write("\x10");
+    await nextFrame();
+    expect(lastFrame() ?? "").toContain("No plan body submitted yet.");
+    unmount();
   });
 
   it("surfaces the open-questions block even when steps are present (issue #477)", () => {
@@ -62,11 +222,63 @@ describe("PlanConfirm — issue #336 plan body must be visible", () => {
     expect(out).toContain("do thing");
   });
 
-  it("surfaces the open-questions block even when the body is past the truncation cap", () => {
-    const filler = Array.from({ length: 30 }, (_, i) => `body line ${i + 1}`).join("\n");
-    const plan = `## Summary\n${filler}\n\n## Risks\n- migration runs hot\n- breaking config`;
-    const out = bytesFor(plan);
-    expect(out).toContain("migration runs hot");
-    expect(out).toContain("breaking config");
+  it("does not jump when scrolling into a blank line at the top of the detail window", async () => {
+    const planLines = Array.from({ length: 241 }, (_, i) => `line ${i + 1}`);
+    planLines[96] = "detail preface";
+    planLines[97] = "";
+    planLines[98] = "status marker";
+    planLines[99] = "";
+    planLines[100] = "showing lines 97-126 of 241";
+    planLines[101] = "";
+    planLines[102] = "- route segment `[slug]` matches the file name";
+    planLines[103] = "- **`generateStaticParams()`** builds static article pages";
+    planLines[104] = "- **`generateMetadata()`** derives title and description";
+    const plan = planLines.join("\n");
+    const { lastFrame, stdin, unmount } = render(
+      <PlanConfirm plan={plan} steps={[]} onChoose={() => {}} />,
+    );
+    stdin.write("\x10");
+    await nextFrame();
+    for (let i = 0; i < 97; i++) stdin.write("[B");
+    await nextFrame();
+    const before = lastFrame() ?? "";
+    stdin.write("[B");
+    await nextFrame();
+    const after = lastFrame() ?? "";
+    const cleanBefore = stripAnsi(before);
+    const cleanAfter = stripAnsi(after);
+    expect(cleanBefore).toContain("showing lines 99-");
+    expect(cleanBefore).toContain("- route segment `[slug]` matches the file name");
+    expect(cleanAfter).toContain("showing lines 99-");
+    expect(cleanAfter).toContain("- route segment `[slug]` matches the file name");
+    expect(cleanAfter).toBe(cleanBefore);
+    unmount();
+  });
+
+  it("keeps the expanded detail header intact inside the app-style modal stack", async () => {
+    const planLines = Array.from({ length: 277 }, (_, i) => `line ${i + 1}`);
+    planLines[158] = "**`src/components/Pagination.tsx`**";
+    planLines[159] = "- 上一页 / 下一页按钮 of 277";
+    planLines[160] = "- 页码数字（显示前后各 2 页，中间用 ... 省略）";
+    planLines[161] = "- 禁用状态（第一页/最后一页）";
+    const plan = planLines.join("\n");
+    const { lastFrame, stdin, unmount } = render(
+      <ViewportBudgetProvider initialRows={30}>
+        <ModalHost>
+          <PlanConfirm plan={plan} steps={[]} onChoose={() => {}} />
+        </ModalHost>
+      </ViewportBudgetProvider>,
+    );
+    stdin.write("\x10");
+    await nextFrame();
+    for (let i = 0; i < 158; i++) stdin.write("[B");
+    await nextFrame();
+    const out = lastFrame() ?? "";
+    const clean = stripAnsi(out);
+    expect(
+      clean.split("\n").some((line) => line.trimStart().startsWith("showing lines 159-")),
+    ).toBe(true);
+    expect(out).toContain("- 上一页 / 下一页按钮 of 277");
+    unmount();
   });
 });

--- a/tests/user-card-verbatim.test.tsx
+++ b/tests/user-card-verbatim.test.tsx
@@ -1,5 +1,5 @@
 import { render } from "ink-testing-library";
-import type React from "react";
+import React from "react";
 import { describe, expect, it } from "vitest";
 import { UserCard } from "../src/cli/ui/cards/UserCard.js";
 import type { UserCard as UserCardData } from "../src/cli/ui/state/cards.js";

--- a/tests/user-card-verbatim.test.tsx
+++ b/tests/user-card-verbatim.test.tsx
@@ -1,6 +1,5 @@
 import { render } from "ink-testing-library";
-// biome-ignore lint/style/useImportType: needed in value scope for JSX
-import React from "react";
+import type React from "react";
 import { describe, expect, it } from "vitest";
 import { UserCard } from "../src/cli/ui/cards/UserCard.js";
 import type { UserCard as UserCardData } from "../src/cli/ui/state/cards.js";


### PR DESCRIPTION
<!-- Read CONTRIBUTING.md first if this is your first PR. -->

## What

This change stabilizes the expanded plan approval modal in the CLI/TUI. It keeps the approval card from being vertically compressed inside the app-style modal stack, tightens
  the expanded detail/options layout, and makes expanded-plan scrolling stable when the detail window encounters blank lines at the top of the viewport. It also documents the
  `Ctrl+P` summary/detail toggle in the CLI reference, updates the related i18n strings/types, and adds regression coverage for the clipping and scroll-jitter cases. A follow-up
  test fix restores runtime `React` imports in JSX-based Ink tests so the push-time verify suite passes.

<!-- One paragraph: what does this change? -->

## Why

The expanded `PlanConfirm` UI had two regressions: the detail header/content could be clipped in the real app layout, and the visible content could jump while scrolling long
  plans. Those issues made reviewing plans harder and caused confusing rendering in the approval flow. The test import fix was needed because the verify hook executes the
  JSX-based tests under Vitest, where those files still need `React` in value scope at runtime.

<!-- Bug fix? Pre-existing issue? Linked discussion? -->

## How to verify

 1. Run `npm run verify`.
  2. Run `npx vitest run tests/plan-confirm.test.tsx tests/user-card-verbatim.test.tsx`.
  3. Start the CLI UI and open a submitted plan in the approval modal.
  4. Press `Ctrl+P` to expand the plan body.
  5. Confirm the expanded detail header is fully visible, the scroll hint sits directly above the options list, and scrolling through long plans does not cause the visible content
   to jump when blank lines enter the top of the detail window.

<!-- Steps the reviewer can run. `npm run verify` is assumed. -->

## Checklist

- [✅ ] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [✅ ] No `Co-Authored-By: Claude` trailer in commits
- [✅ ] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [✅ ] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time
