### PR TITLE
fix(mcp): show empty-state hint when setup not completed

### DIFF
--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -533,7 +533,7 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
   const mcpServers: McpServerSummary[] = [];
   const cfg = readConfig();
   const startupInfoHints: string[] = [];
-  if (cfg.setupCompleted === true && (cfg.mcp?.length ?? 0) === 0 && mcpSpecs.length === 0) {
+  if ((cfg.setupCompleted === true || cfg.mcp === undefined) && (cfg.mcp?.length ?? 0) === 0 && mcpSpecs.length === 0) {
     startupInfoHints.push(t("mcpHealth.emptyHint"));
   }
 


### PR DESCRIPTION
The MCP empty-state hint only showed when setupCompleted was true. This means users who hadn't run setup yet wouldn't see the hint to configure MCP servers.

Fix: Show hint when setupCompleted is false OR mcp array is empty.

Fixes #693