### PR TITLE
test(jobs): per-test 15s timeout for Windows kill paths

### DIFF
--- a/tests/jobs.test.ts
+++ b/tests/jobs.test.ts
@@ -129,7 +129,7 @@ describe("JobRegistry", () => {
     expect(tailed?.output).not.toContain("line0\n");
   });
 
-  it("stop() kills a running job", async () => {
+  it("stop() kills a running job", { timeout: 15000 }, async () => {
     const cmd = `node -e "setTimeout(()=>{}, 10000)"`;
     const res = await registry.start(cmd, { cwd, waitSec: 0.2 });
     expect(res.stillRunning).toBe(true);
@@ -161,7 +161,7 @@ describe("JobRegistry", () => {
     expect(r2?.exitCode).toBe(0);
   });
 
-  it("runningCount() reflects live state", async () => {
+  it("runningCount() reflects live state", { timeout: 15000 }, async () => {
     expect(registry.runningCount()).toBe(0);
     const a = await registry.start(`node -e "setTimeout(()=>{}, 10000)"`, { cwd, waitSec: 0.2 });
     expect(registry.runningCount()).toBe(1);
@@ -220,7 +220,7 @@ describe("JobRegistry", () => {
     expect(waited?.latestOutput).toBe("");
   });
 
-  it("shutdown() kills all running jobs", async () => {
+  it("shutdown() kills all running jobs", { timeout: 15000 }, async () => {
     await registry.start(`node -e "setTimeout(()=>{}, 10000)"`, { cwd, waitSec: 0.2 });
     await registry.start(`node -e "setTimeout(()=>{}, 10000)"`, { cwd, waitSec: 0.2 });
     expect(registry.runningCount()).toBe(2);


### PR DESCRIPTION
## Summary

- Three `JobRegistry` tests (`stop()`, `runningCount()`, `shutdown()`) were flaking on Windows with `Test timed out in 5000ms` even though the kill paths themselves were working.
- Root cause: `stop()`'s internal SIGKILL race waits up to 5s for `close` to fire after `taskkill /T /F`, which legitimately can take that long on Windows. Vitest's 5s default test timeout killed the test before `stop()` could return.
- Fix: bump those three tests to a 15s per-test budget. Healthy runs still complete in 1–3s; the wider window only matters when taskkill propagation is slow.

## Test plan

- [x] `npx vitest run tests/jobs.test.ts` — 16/16 pass, slowest is ~3s
- [x] `npm run verify` — clean
