### PR TITLE
fix(session): persist new sessions opened via /session

### DIFF
--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -20,6 +20,7 @@ import { buildMcpServerSummary } from "../../mcp/summary.js";
 import { buildTransportFromSpec } from "../../mcp/transport-from-spec.js";
 import {
   deleteSession,
+  freshSessionName,
   listSessionsForWorkspace,
   renameSession,
   resolveSession,
@@ -451,7 +452,7 @@ function Root({
               return;
             }
             if (outcome.kind === "new") {
-              setActiveSession(undefined);
+              setActiveSession(freshSessionName(activeSession));
               setPickerOpen(false);
               return;
             }

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -57,6 +57,7 @@ import type { LoopEvent } from "../../loop.js";
 import {
   deleteSession,
   detectGitBranch,
+  freshSessionName,
   type listSessions,
   listSessionsForWorkspace,
   loadSessionMessages,
@@ -3824,7 +3825,7 @@ function AppInner({
                       if (outcome.kind === "new") {
                         setPendingSessionsPicker(false);
                         if (onSwitchSession) {
-                          onSwitchSession(undefined);
+                          onSwitchSession(freshSessionName(session));
                         } else {
                           log.pushInfo(
                             "▸ to start a fresh session, quit and run: reasonix chat (no --session flag)",

--- a/src/memory/session.ts
+++ b/src/memory/session.ts
@@ -75,6 +75,13 @@ export function timestampSuffix(): string {
   return new Date().toISOString().replace(/[^\d]/g, "").slice(0, 12);
 }
 
+/** Unique name for an in-app "new session" — strips a trailing 12/14-digit timestamp from the current name and re-stamps with seconds precision so back-to-back clicks don't collide. */
+export function freshSessionName(currentName: string | undefined): string {
+  const base = currentName ? currentName.replace(/-\d{12,14}$/, "") : "default";
+  const stamp = new Date().toISOString().replace(/[^\d]/g, "").slice(0, 14);
+  return `${base || "default"}-${stamp}`;
+}
+
 /** Names of `.jsonl` sessions starting with `prefix`, newest-first by filename. */
 export function findSessionsByPrefix(prefix: string): string[] {
   const dir = sessionsDir();

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -10,6 +10,7 @@ import {
   archiveSession,
   deleteSession,
   findSessionsByPrefix,
+  freshSessionName,
   listSessions,
   listSessionsForWorkspace,
   loadSessionMessages,
@@ -326,6 +327,28 @@ describe("session persistence", () => {
       const b = timestampSuffix();
       // In the unlikely event both fall on the same minute, they're equal
       expect(b.localeCompare(a)).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe("freshSessionName", () => {
+    it("defaults to a default-prefixed name when no current session", () => {
+      expect(freshSessionName(undefined)).toMatch(/^default-\d{14}$/);
+    });
+
+    it("preserves a non-timestamped base", () => {
+      expect(freshSessionName("foo")).toMatch(/^foo-\d{14}$/);
+    });
+
+    it("strips an existing 12-digit timestamp suffix before re-stamping", () => {
+      expect(freshSessionName("foo-202605120800")).toMatch(/^foo-\d{14}$/);
+    });
+
+    it("strips an existing 14-digit timestamp suffix before re-stamping", () => {
+      expect(freshSessionName("foo-20260512080000")).toMatch(/^foo-\d{14}$/);
+    });
+
+    it("keeps dashed bases intact (only the trailing timestamp is stripped)", () => {
+      expect(freshSessionName("my-app-bar")).toMatch(/^my-app-bar-\d{14}$/);
     });
   });
 


### PR DESCRIPTION
## Summary

`/session` → "new" (or picking "new" at launch) silently dropped every message of the new chat. The picker called `setActiveSession(undefined)`, which propagated `session: undefined` to `CacheFirstLoop`. `this.sessionName` became `null`, and every `appendSessionMessage()` call short-circuited on the `if (this.sessionName)` guard (`src/loop.ts:300`). Nothing landed on disk; the new session never showed back up in the picker.

Compare: `reasonix chat` at launch resolves to the string `"default"` (`src/cli/resolve.ts:72`), so the loop persists fine — the bug only surfaced through the new-session flow.

## Fix

- New helper `freshSessionName(currentName)` in `src/memory/session.ts` — strips a trailing 12/14-digit timestamp from the current name, re-stamps with seconds precision (`YYYYMMDDHHMMSS`), falls back to `default` when no base. Seconds precision prevents back-to-back-click name collisions that would otherwise re-load the previous "new" chat's messages.
- Both new-session call sites (`chat.tsx` launch picker, `App.tsx` `/session` picker) pass the generated name instead of `undefined`.

## Test plan

- [x] 5 new `freshSessionName` unit tests in `tests/session.test.ts`
- [x] `npx vitest run tests/session.test.ts` — 50/50 pass
- [x] `npm run verify` — clean

Closes #737
