### PR TITLE
fix(jobs): settle running state on exit + post-taskkill timeout (Node 24 Windows)

### DIFF
--- a/src/tools/jobs.ts
+++ b/src/tools/jobs.ts
@@ -249,12 +249,19 @@ export class JobRegistry {
       job.signalReady();
       job.signalClosed();
     });
-    child.on("close", (code) => {
+    // `exit` fires when the process is dead; `close` waits for stdio drain too.
+    // On Windows + Node ≥ 24, drained stdio can lag 5–10s behind taskkill /T /F,
+    // so we settle `running`/`closedPromise` on the earlier event. `close` is
+    // still wired for the no-exit fallback (spawn error before any process exists).
+    const settleClosed = (code: number | null) => {
+      if (!job.running && job.exitCode !== null) return;
       job.running = false;
       job.exitCode = code;
       job.signalReady();
       job.signalClosed();
-    });
+    };
+    child.on("exit", settleClosed);
+    child.on("close", settleClosed);
 
     const onAbort = () => this.stop(id, { graceMs: 100 });
     if (opts.signal?.aborted) {
@@ -380,6 +387,13 @@ export class JobRegistry {
       // before Node's `close` event fires under load (Windows taskkill
       // /T /F on a three-level tree can take ~1s to propagate).
       await Promise.race([job.closedPromise, new Promise<void>((res) => setTimeout(res, 5000))]);
+      // Node ≥ 24 on Windows sometimes never fires `close` after taskkill /T /F
+      // (the OS handle lingers even though the process is dead). We issued the
+      // kill; trust it and settle the record so callers don't see ghost-running.
+      if (job.running) {
+        job.running = false;
+        job.signalClosed();
+      }
     }
     return snapshot(job);
   }
@@ -426,6 +440,15 @@ export class JobRegistry {
     // non-zero after shutdown" looks like.
     const remaining = Math.max(800, deadlineMs - elapsed());
     await Promise.race([allClose, new Promise<void>((res) => setTimeout(res, remaining))]);
+    // Same Node ≥ 24 Windows fallback as `stop()`: settle any job whose `close`
+    // event never arrived after taskkill /T /F — the kill is synchronous, the
+    // notification isn't.
+    for (const job of runningJobs) {
+      if (job.running) {
+        job.running = false;
+        job.signalClosed();
+      }
+    }
   }
 
   /** Count of still-running jobs — drives the TUI status-bar indicator. */


### PR DESCRIPTION
## Summary

`JobRegistry.stop()` and `shutdown()` waited on the child's `close` event to confirm the process was dead, but on Node ≥ 24 + Windows that event often never fires after `taskkill /T /F` — libuv's stdio handle lingers even though the OS has already reaped the process. The 5s race timer would expire, `stop()` returned a snapshot with `running: true`, and downstream callers (including the three flaky `JobRegistry` tests that have been blocking `npm run verify`) saw a ghost-running process.

## Fix

- Settle the record on the `exit` event in addition to `close`. `exit` fires the moment the OS reaps the process, well before stdio drains.
- If neither event arrives by the SIGKILL deadline, mark the job dead anyway — we issued `taskkill /T /F`, the kill is synchronous, the notification just isn't.
- Same fallback path in `shutdown()` for the multi-job case.

## Test plan

- [x] `npx vitest run tests/jobs.test.ts` — 16/16 pass on Node 24.11.1 Windows (was 3/16 failing)
- [x] `npm run verify` — clean (was failing the pre-push hook on these same tests)
