### PR TITLE
fix(mcp): silence the race-leg derivative on initialize timeout

### DIFF
--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -235,8 +235,14 @@ export class McpClient {
       }
     });
     promise.catch(() => undefined);
+    // Swallow rejection on the race-leg derivative too — if `send` wins the race,
+    // a late-rejecting `promise.then(...)` would otherwise be orphaned (#742).
+    const promiseSettled = promise.then(
+      () => undefined,
+      () => undefined,
+    );
     try {
-      await Promise.race([this.transport.send(frame), promise.then(() => undefined)]);
+      await Promise.race([this.transport.send(frame), promiseSettled]);
     } catch (err) {
       const pending = this.pending.get(id);
       if (pending) clearTimeout(pending.timeout);

--- a/tests/mcp-client-timeout.test.ts
+++ b/tests/mcp-client-timeout.test.ts
@@ -115,4 +115,22 @@ describe("McpClient.request() timeout/no-crash", () => {
     await expect(client.initialize()).rejects.toThrow(/timed out/);
     await client.close();
   });
+
+  it("silent-server timeout does not emit unhandledRejection", async () => {
+    const transport = new SilentServerTransport();
+    const client = new McpClient({
+      transport,
+      requestTimeoutMs: shortTimeoutMs,
+    });
+    const handler = vi.fn();
+    process.on("unhandledRejection", handler);
+    try {
+      await expect(client.initialize()).rejects.toThrow(/timed out/);
+      await new Promise((r) => setTimeout(r, shortTimeoutMs + 100));
+      expect(handler).not.toHaveBeenCalled();
+    } finally {
+      process.off("unhandledRejection", handler);
+      await client.close();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

The CLI was crashing with an unhandled-rejection style error after an MCP server failed to respond to `initialize` within the 60s window:

```
Error: MCP request initialize (id=1) timed out after 60000ms
    at Timeout._onTimeout (.../dist/cli/index.js:6665:11)
```

## Root cause

`McpClient.request()` did:

```ts
await Promise.race([this.transport.send(frame), promise.then(() => undefined)]);
```

When `transport.send()` won the race, the derived `promise.then(() => undefined)` was left dangling. The original `promise` had a `.catch(() => undefined)` attached, but that does not extend to the separate `.then()` derivative — and Node 20's V8 doesn't reliably suppress unhandledRejection on inputs of an already-settled `Promise.race`. The pending request then timed out, rejected the derivative, and the process died mid-session.

## Fix

Use the two-arg form `promise.then(() => undefined, () => undefined)` so the derivative is always fulfilled regardless of how `promise` settles. The original rejection still reaches the caller via `await promise` further down (and ultimately the `try/catch` around `mcp.initialize()` in `createMcpRuntime`).

## Test plan

- [x] New regression test `silent-server timeout does not emit unhandledRejection` — uses a transport whose `send()` resolves immediately and whose server never responds (exactly the shape of the crash report). Attaches an `unhandledRejection` listener and asserts it isn't called.
- [x] All 6 cases in `tests/mcp-client-timeout.test.ts` pass.
- [x] `npm run verify` clean.

Closes #742
