### PR TITLE
feat(desktop): expand/collapse dirs in the right-panel Files tree

### DIFF
--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -1927,6 +1927,18 @@ button {
 .tree .node[data-d="2"] {
   padding-left: 32px;
 }
+.tree .node[data-kind="file"] {
+  cursor: default;
+}
+.tree .node .caret {
+  width: 10px;
+  height: 10px;
+  color: var(--muted-2);
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
 .tree .node .ico {
   color: var(--muted-2);
   flex-shrink: 0;

--- a/desktop/src/ui/context-panel.tsx
+++ b/desktop/src/ui/context-panel.tsx
@@ -1,5 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { Settings, UsageStats } from "../App";
 import { I } from "../icons";
 import type { McpSpecInfo } from "../protocol";
@@ -90,16 +90,19 @@ export function ContextPanel({
 function CtxFiles({ workspaceDir }: { workspaceDir?: string }) {
   const [entries, setEntries] = useState<FileEntry[] | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [collapsed, setCollapsed] = useState<Set<string>>(() => new Set());
 
   useEffect(() => {
     if (!workspaceDir) {
       setEntries(null);
       setError(null);
+      setCollapsed(new Set());
       return;
     }
     let cancelled = false;
     setEntries(null);
     setError(null);
+    setCollapsed(new Set());
     invoke<FileEntry[]>("list_workspace_tree", { root: workspaceDir, maxDepth: 2 })
       .then((rows) => {
         if (!cancelled) setEntries(rows);
@@ -112,7 +115,37 @@ function CtxFiles({ workspaceDir }: { workspaceDir?: string }) {
     };
   }, [workspaceDir]);
 
+  // depth-first traversal — each entry's parent is the nearest dir above it
+  // at depth-1, which is what walk_dir on the Rust side guarantees.
+  const parentByPath = useMemo(() => {
+    const map = new Map<string, string | null>();
+    if (!entries) return map;
+    const stack: string[] = [];
+    for (const e of entries) {
+      while (stack.length > e.depth) stack.pop();
+      map.set(e.path, e.depth === 0 ? null : (stack[e.depth - 1] ?? null));
+      if (e.kind === "dir") stack[e.depth] = e.path;
+    }
+    return map;
+  }, [entries]);
+
+  const isVisible = (path: string): boolean => {
+    const parent = parentByPath.get(path);
+    if (!parent) return true;
+    if (collapsed.has(parent)) return false;
+    return isVisible(parent);
+  };
+
+  const toggle = (path: string) =>
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      return next;
+    });
+
   const fileCount = entries?.filter((e) => e.kind === "file").length ?? 0;
+  const visible = entries?.filter((e) => isVisible(e.path)) ?? [];
 
   return (
     <div className="ctx-block">
@@ -130,8 +163,24 @@ function CtxFiles({ workspaceDir }: { workspaceDir?: string }) {
         ) : entries.length === 0 ? (
           <div className="ctx-empty">空目录</div>
         ) : (
-          entries.map((n) => (
-            <div className="node" key={n.path} data-d={n.depth} title={n.path}>
+          visible.map((n) => (
+            <div
+              className="node"
+              key={n.path}
+              data-d={n.depth}
+              data-kind={n.kind}
+              title={n.path}
+              onClick={n.kind === "dir" ? () => toggle(n.path) : undefined}
+            >
+              <span className="caret">
+                {n.kind === "dir" ? (
+                  collapsed.has(n.path) ? (
+                    <I.chevR size={10} />
+                  ) : (
+                    <I.chev size={10} />
+                  )
+                ) : null}
+              </span>
               <span className="ico">
                 {n.kind === "dir" ? <I.folder size={12} /> : <I.file size={12} />}
               </span>


### PR DESCRIPTION
## Summary

Click a directory in the right-panel Files tree to fold/unfold its children. Builds on #750.

- Tracks a `collapsed: Set<string>` of dir paths. Each entry walks up its parent chain (reconstructed from the flat depth-first list returned by `list_workspace_tree`) to decide visibility.
- File rows lose their pointer cursor — they aren't interactive.
- New `.caret` slot uses `I.chev` / `I.chevR` for the expand affordance.
- Dirs default to expanded; collapsing is opt-in. State resets on workspace switch.

## Out of scope

- Lazy deeper fetch (beyond depth 2) — the Rust command supports it, the UI doesn't drive it yet.
- Modified / in-context status dots — still need a git-status feed.

Part of #744.
