### PR TITLE
fix(desktop): replace MCP "loading" copy with "configured"

### DIFF
--- a/desktop/src/ui/context-panel.tsx
+++ b/desktop/src/ui/context-panel.tsx
@@ -202,14 +202,19 @@ function CtxTools({ specs, bridged }: { specs: McpSpecInfo[]; bridged: boolean }
       <div className="h">
         <span>MCP 服务器</span>
         <span className="right">
-          {specs.length === 0 ? "—" : `${specs.length} ${bridged ? "ready" : "loading"}`}
+          {specs.length === 0 ? "—" : `${specs.length} ${bridged ? "ready" : "configured"}`}
         </span>
       </div>
       {specs.length === 0 ? (
         <div className="ctx-empty">未配置 MCP 服务器</div>
       ) : (
         specs.map((s) => {
-          const ok = bridged && !s.parseError;
+          const ok = !s.parseError;
+          const suffix = s.parseError
+            ? ` · ${s.parseError}`
+            : bridged
+              ? " · ready"
+              : " · configured";
           return (
             <div className="mcp-row" key={s.raw}>
               <span className="ico">
@@ -219,7 +224,7 @@ function CtxTools({ specs, bridged }: { specs: McpSpecInfo[]; bridged: boolean }
                 <div className="n">{s.name ?? s.summary}</div>
                 <div className="m">
                   {s.transport}
-                  {s.parseError ? ` · ${s.parseError}` : bridged ? " · ready" : " · loading"}
+                  {suffix}
                 </div>
               </div>
               <span className="status" data-s={ok ? "ok" : "off"} />


### PR DESCRIPTION
## Summary

The desktop runtime doesn't actually bridge MCP yet — `$mcp_specs` is emitted with `bridged: false` indefinitely, so the Tools tab was painting every server as perpetually "loading". Show "configured" instead — that's the truthful state until desktop-side MCP bridging lands. The `bridged: true` branch still maps to "ready" with no further UI change.

Part of #744. Real per-server status needs `createMcpRuntime` from `chat.tsx` extracted to a shared module and wired into `desktop.ts:buildRuntimeFor` — separate scope.
