### PR TITLE
feat(desktop): add reserved-tokens bucket to the context meter

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -126,6 +126,8 @@ export type UsageStats = {
   cacheMissTokens: number;
   lastCallCacheHit: number | null;
   lastCallCacheMiss: number | null;
+  /** System prompt + tool specs — constant for the session, sent on tab open. */
+  reservedTokens: number;
 };
 
 export type SessionInfo = {
@@ -347,6 +349,7 @@ function zeroUsage(): UsageStats {
     cacheMissTokens: 0,
     lastCallCacheHit: null,
     lastCallCacheMiss: null,
+    reservedTokens: 0,
   };
 }
 
@@ -456,6 +459,8 @@ function applyIncoming(state: State, ev: IncomingEvent): State {
       return { ...state, mcpSpecs: ev.specs, mcpBridged: ev.bridged };
     case "$skills":
       return { ...state, skills: ev.items };
+    case "$ctx_breakdown":
+      return { ...state, usage: { ...state.usage, reservedTokens: ev.reservedTokens } };
     case "$balance":
       return {
         ...state,
@@ -583,6 +588,7 @@ function applyIncoming(state: State, ev: IncomingEvent): State {
         cacheMissTokens: state.usage.cacheMissTokens + callMiss,
         lastCallCacheHit: hasCall ? callHit : state.usage.lastCallCacheHit,
         lastCallCacheMiss: hasCall ? callMiss : state.usage.lastCallCacheMiss,
+        reservedTokens: state.usage.reservedTokens,
       };
       return {
         ...state,

--- a/desktop/src/protocol.ts
+++ b/desktop/src/protocol.ts
@@ -150,6 +150,11 @@ export type SkillsEvent = {
   items: SkillInfo[];
 };
 
+export type CtxBreakdownEvent = {
+  type: "$ctx_breakdown";
+  reservedTokens: number;
+};
+
 export type LoadedSegment =
   | { kind: "text"; text: string }
   | { kind: "reasoning"; text: string }
@@ -337,6 +342,7 @@ export type IncomingEvent = { tabId?: string } & (
   | TabClosedEvent
   | McpSpecsEvent
   | SkillsEvent
+  | CtxBreakdownEvent
   | UserMessageEvent
   | ModelTurnStartedEvent
   | ModelDeltaEvent

--- a/desktop/src/ui/context-panel.tsx
+++ b/desktop/src/ui/context-panel.tsx
@@ -29,11 +29,16 @@ export function ContextPanel({
   mcpBridged: boolean;
 }) {
   const [tab, setTab] = useState<Tab>("files");
-  const used = usage.cacheMissTokens;
-  const cached = usage.cacheHitTokens;
+  const reserved = usage.reservedTokens;
+  // After a warm cache turn the API counts the reserved prefix inside cacheHit;
+  // subtract to keep the bar segments visually disjoint. Cold cache shows the
+  // reserved portion in cacheMiss instead, so do the same for `used`.
+  const cached = Math.max(0, usage.cacheHitTokens - reserved);
+  const used = Math.max(0, usage.cacheMissTokens - Math.max(0, reserved - usage.cacheHitTokens));
+  const reservedPct = Math.min(100, (reserved / CONTEXT_MAX_TOKENS) * 100);
   const usedPct = Math.min(100, (used / CONTEXT_MAX_TOKENS) * 100);
   const cachedPct = Math.min(100, (cached / CONTEXT_MAX_TOKENS) * 100);
-  const free = Math.max(0, CONTEXT_MAX_TOKENS - used - cached);
+  const free = Math.max(0, CONTEXT_MAX_TOKENS - reserved - used - cached);
   return (
     <aside className="ctx">
       <div className="ctx-tabs">
@@ -56,21 +61,27 @@ export function ContextPanel({
           <div className="h">
             <span>上下文 · tokens</span>
             <span className="right">
-              {(used + cached).toLocaleString()} / {CONTEXT_MAX_TOKENS.toLocaleString()}
+              {(reserved + used + cached).toLocaleString()} /{" "}
+              {CONTEXT_MAX_TOKENS.toLocaleString()}
             </span>
           </div>
           <div className="meter">
-            <span className="used" style={{ width: `${usedPct}%` }} />
+            <span className="rsvd" style={{ width: `${reservedPct}%` }} />
             <span className="cached" style={{ width: `${cachedPct}%` }} />
+            <span className="used" style={{ width: `${usedPct}%` }} />
           </div>
           <div className="legend">
             <span className="l">
-              <span className="sw u" />
-              已用 <span className="v">{used.toLocaleString()}</span>
+              <span className="sw r" />
+              保留 <span className="v">{reserved.toLocaleString()}</span>
             </span>
             <span className="l">
               <span className="sw c" />
               缓存 <span className="v">{cached.toLocaleString()}</span>
+            </span>
+            <span className="l">
+              <span className="sw u" />
+              已用 <span className="v">{used.toLocaleString()}</span>
             </span>
             <span className="l">
               余 <span className="v">{free.toLocaleString()}</span>

--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -59,6 +59,7 @@ import {
   timestampSuffix,
 } from "../../memory/session.js";
 import { SkillStore } from "../../skills.js";
+import { countTokens } from "../../tokenizer.js";
 import type { ChoiceOption } from "../../tools/choice.js";
 import type { ChatMessage } from "../../types.js";
 import { VERSION } from "../../version.js";
@@ -269,6 +270,11 @@ interface McpSpecsEvent {
   bridged: boolean;
 }
 
+interface CtxBreakdownEvent {
+  type: "$ctx_breakdown";
+  reservedTokens: number;
+}
+
 interface SkillInfo {
   name: string;
   description: string;
@@ -308,7 +314,8 @@ type EmittableEvent =
   | TabOpenedEvent
   | TabClosedEvent
   | McpSpecsEvent
-  | SkillsEvent;
+  | SkillsEvent
+  | CtxBreakdownEvent;
 
 function emit(ev: EmittableEvent, tabId?: string): void {
   const payload = tabId ? { ...ev, tabId } : ev;
@@ -449,6 +456,20 @@ function emitMcpSpecs(tab: Tab): void {
   const cfg = readConfig();
   const specs = (cfg.mcp ?? []).map(summarizeMcpSpec);
   emit({ type: "$mcp_specs", specs, bridged: false }, tab.id);
+}
+
+// reserved = system prompt + tool specs, constant for the tab's lifetime once
+// the loop is built. The growing log portion is already covered by the
+// per-turn cache hit/miss numbers in `model.final`.
+function emitCtxBreakdown(tab: Tab): void {
+  if (!tab.runtime) return;
+  try {
+    const sys = countTokens(tab.runtime.loop.prefix.system);
+    const tools = countTokens(JSON.stringify(tab.runtime.loop.prefix.toolSpecs));
+    emit({ type: "$ctx_breakdown", reservedTokens: sys + tools }, tab.id);
+  } catch {
+    // tokenizer warmup can throw on first call before the data file loads
+  }
 }
 
 function emitSkills(tab: Tab): void {
@@ -915,6 +936,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
   emitSettings(first);
   emitMcpSpecs(first);
   emitSkills(first);
+  emitCtxBreakdown(first);
   void emitBalance(first);
 
   const rl = createInterface({ input: stdin });
@@ -940,6 +962,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
           emitSettings(tab);
           emitMcpSpecs(tab);
           emitSkills(tab);
+          emitCtxBreakdown(tab);
           void emitBalance(tab);
         } catch (err) {
           emit({ type: "$error", message: `tab_open failed: ${(err as Error).message}` });


### PR DESCRIPTION
## Summary

System prompt + tool specs are constant per tab. Compute their token count via `countTokens` at tab open, emit a new `$ctx_breakdown` event (`{ reservedTokens }`), and render the band on the right-panel meter alongside `cached` / `used` / `free`.

## Cache accounting

Cache-hit / miss numbers from the API include the reserved prefix once the cache warms up. The visual subtracts `reserved` from those buckets to keep the segments disjoint:

- Warm cache: `cached -= reserved`
- Cold cache (reserved landed in `cacheMiss` rather than `cacheHit`): `used -= max(0, reserved - cacheHit)`

Off by at most one turn of arithmetic, but doesn't visually double-count.

## Test plan

- [x] `npx tsc --noEmit` clean in both `src/` and `desktop/`
- [ ] Manual: open a desktop tab, confirm the `保留` band appears with non-zero width before any turn is sent; send a turn and confirm `已用` grows without `保留` shrinking; subsequent turns warm the cache so `缓存` grows in place of `已用`

Closes #755.
