### PR TITLE
feat(desktop): per-file status dots in the right-panel Files tree

### DIFF
--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -71,6 +71,57 @@ fn list_workspace_tree(root: String, max_depth: u32) -> Result<Vec<FileEntry>, S
     Ok(out)
 }
 
+#[derive(Serialize)]
+struct GitStatusEntry {
+    path: String,
+    kind: &'static str,
+}
+
+#[tauri::command]
+fn git_status(root: String) -> Result<Vec<GitStatusEntry>, String> {
+    use std::process::Command;
+    let root_path = Path::new(&root);
+    if !root_path.is_dir() {
+        return Err(format!("not a directory: {root}"));
+    }
+    let mut cmd = Command::new("git");
+    cmd.arg("status").arg("--porcelain").arg("-z").current_dir(root_path);
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+    let output = match cmd.output() {
+        Ok(o) => o,
+        Err(_) => return Ok(Vec::new()), // not a git repo / no git on PATH — silent
+    };
+    if !output.status.success() {
+        return Ok(Vec::new()); // not a git repo — silent
+    }
+    let mut out = Vec::new();
+    for rec in output.stdout.split(|&b| b == 0) {
+        if rec.len() < 4 {
+            continue;
+        }
+        // `git status --porcelain -z` format: `XY ` + path, where X / Y are
+        // index / worktree statuses. Map both to a coarse `kind`.
+        let x = rec[0];
+        let y = rec[1];
+        let kind = match (x, y) {
+            (b'?', b'?') => "untracked",
+            (b'A', _) | (_, b'A') => "added",
+            (b'D', _) | (_, b'D') => "deleted",
+            (b'M', _) | (_, b'M') => "modified",
+            (b'R', _) | (_, b'R') => "renamed",
+            _ => continue,
+        };
+        let path = String::from_utf8_lossy(&rec[3..]).into_owned();
+        out.push(GitStatusEntry { path, kind });
+    }
+    Ok(out)
+}
+
 #[tauri::command]
 fn open_in_editor(command: String, path: String, line: Option<u32>) -> Result<(), String> {
     use std::process::{Command, Stdio};
@@ -119,7 +170,8 @@ fn main() {
             rpc_spawn,
             rpc_send,
             open_in_editor,
-            list_workspace_tree
+            list_workspace_tree,
+            git_status
         ])
         .setup(|app| {
             if std::env::var("REASONIX_DEVTOOLS").is_ok() {

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -187,6 +187,8 @@ type State = {
   mcpSpecs: McpSpecInfo[];
   mcpBridged: boolean;
   skills: SkillInfo[];
+  /** Files the agent has read this session — paths as the tool args provided them (typically relative to workspace). */
+  inContextPaths: string[];
 };
 
 type DeltaBatchItem = {
@@ -338,6 +340,26 @@ function reduce(state: State, action: Action): State {
     case "mention_preview":
       return { ...state, mentionPreview: action.preview };
   }
+}
+
+const FILE_READING_TOOLS = new Set([
+  "read_file",
+  "list_directory",
+  "directory_tree",
+  "search_files",
+  "get_file_info",
+  "glob_files",
+]);
+
+function extractToolFilePath(name: string, args: string): string | null {
+  if (!FILE_READING_TOOLS.has(name)) return null;
+  try {
+    const parsed = JSON.parse(args) as { path?: unknown };
+    if (typeof parsed?.path === "string") return parsed.path;
+  } catch {
+    // malformed args — skip; tool will error on the real side anyway
+  }
+  return null;
 }
 
 function zeroUsage(): UsageStats {
@@ -522,6 +544,15 @@ function applyIncoming(state: State, ev: IncomingEvent): State {
         });
         return { kind: "assistant", turn: m.turn, segments, pending: false };
       });
+      const inContextPaths: string[] = [];
+      for (const m of loaded) {
+        if (m.kind !== "assistant") continue;
+        for (const s of m.segments) {
+          if (s.kind !== "tool") continue;
+          const p = extractToolFilePath(s.name, s.args);
+          if (p && !inContextPaths.includes(p)) inContextPaths.push(p);
+        }
+      }
       return {
         ...state,
         busy: false,
@@ -540,6 +571,7 @@ function applyIncoming(state: State, ev: IncomingEvent): State {
           cacheHitTokens: ev.carryover.cacheHitTokens,
           cacheMissTokens: ev.carryover.cacheMissTokens,
         },
+        inContextPaths,
       };
     }
     case "$error":
@@ -620,9 +652,15 @@ function applyIncoming(state: State, ev: IncomingEvent): State {
           };
         }),
       };
-    case "tool.intent":
+    case "tool.intent": {
+      const filePath = extractToolFilePath(ev.name, ev.args);
+      const inContextPaths =
+        filePath && !state.inContextPaths.includes(filePath)
+          ? [...state.inContextPaths, filePath]
+          : state.inContextPaths;
       return {
         ...state,
+        inContextPaths,
         messages: state.messages.map((m) => {
           if (m.kind !== "assistant" || m.turn !== ev.turn) return m;
           const idx = m.segments.findIndex((s) => s.kind === "tool" && s.callId === ev.callId);
@@ -649,6 +687,7 @@ function applyIncoming(state: State, ev: IncomingEvent): State {
           };
         }),
       };
+    }
     case "tool.result":
       return {
         ...state,
@@ -747,6 +786,7 @@ function TabRuntime({
     mcpSpecs: [],
     mcpBridged: false,
     skills: [],
+    inContextPaths: [],
   });
   const [draft, setDraft] = useState("");
   const [toast, setToast] = useState<string | null>(null);
@@ -1348,6 +1388,7 @@ function TabRuntime({
           workspaceDir={state.settings?.workspaceDir}
           mcpSpecs={state.mcpSpecs}
           mcpBridged={state.mcpBridged}
+          inContextPaths={state.inContextPaths}
         />
 
         <StatusBar

--- a/desktop/src/ui/context-panel.tsx
+++ b/desktop/src/ui/context-panel.tsx
@@ -13,6 +13,11 @@ type FileEntry = {
   name: string;
 };
 
+type GitStatusEntry = {
+  path: string;
+  kind: string;
+};
+
 const CONTEXT_MAX_TOKENS = 1_000_000;
 
 export function ContextPanel({
@@ -21,12 +26,14 @@ export function ContextPanel({
   workspaceDir,
   mcpSpecs,
   mcpBridged,
+  inContextPaths,
 }: {
   settings: Settings | null;
   usage: UsageStats;
   workspaceDir?: string;
   mcpSpecs: McpSpecInfo[];
   mcpBridged: boolean;
+  inContextPaths: string[];
 }) {
   const [tab, setTab] = useState<Tab>("files");
   const reserved = usage.reservedTokens;
@@ -89,7 +96,9 @@ export function ContextPanel({
           </div>
         </div>
 
-        {tab === "files" && <CtxFiles workspaceDir={workspaceDir} />}
+        {tab === "files" && (
+          <CtxFiles workspaceDir={workspaceDir} inContextPaths={inContextPaths} />
+        )}
         {tab === "tools" && <CtxTools specs={mcpSpecs} bridged={mcpBridged} />}
         {tab === "memory" && <CtxMemory />}
         {tab === "rules" && <CtxRules settings={settings} />}
@@ -98,16 +107,24 @@ export function ContextPanel({
   );
 }
 
-function CtxFiles({ workspaceDir }: { workspaceDir?: string }) {
+function CtxFiles({
+  workspaceDir,
+  inContextPaths,
+}: {
+  workspaceDir?: string;
+  inContextPaths: string[];
+}) {
   const [entries, setEntries] = useState<FileEntry[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [collapsed, setCollapsed] = useState<Set<string>>(() => new Set());
+  const [modified, setModified] = useState<Set<string>>(() => new Set());
 
   useEffect(() => {
     if (!workspaceDir) {
       setEntries(null);
       setError(null);
       setCollapsed(new Set());
+      setModified(new Set());
       return;
     }
     let cancelled = false;
@@ -125,6 +142,50 @@ function CtxFiles({ workspaceDir }: { workspaceDir?: string }) {
       cancelled = true;
     };
   }, [workspaceDir]);
+
+  // Poll git status every 5s. Silent if the workspace isn't a git repo —
+  // the Rust side returns an empty list rather than erroring.
+  useEffect(() => {
+    if (!workspaceDir) return;
+    let cancelled = false;
+    const refresh = () => {
+      invoke<GitStatusEntry[]>("git_status", { root: workspaceDir })
+        .then((rows) => {
+          if (cancelled) return;
+          setModified(new Set(rows.map((r) => r.path.replace(/\\/g, "/"))));
+        })
+        .catch(() => {
+          if (!cancelled) setModified(new Set());
+        });
+    };
+    refresh();
+    const t = setInterval(refresh, 5000);
+    return () => {
+      cancelled = true;
+      clearInterval(t);
+    };
+  }, [workspaceDir]);
+
+  const inContextSet = useMemo(() => {
+    return new Set(inContextPaths.map((p) => p.replace(/\\/g, "/")));
+  }, [inContextPaths]);
+
+  const relativize = (absPath: string): string => {
+    if (!workspaceDir) return absPath;
+    const root = workspaceDir.replace(/\\/g, "/");
+    const norm = absPath.replace(/\\/g, "/");
+    if (norm.startsWith(`${root}/`)) return norm.slice(root.length + 1);
+    if (norm === root) return "";
+    return norm;
+  };
+
+  const statusFor = (e: FileEntry): "m" | "c" | null => {
+    if (e.kind !== "file") return null;
+    const rel = relativize(e.path);
+    if (modified.has(rel)) return "m";
+    if (inContextSet.has(rel) || inContextSet.has(e.path.replace(/\\/g, "/"))) return "c";
+    return null;
+  };
 
   // depth-first traversal — each entry's parent is the nearest dir above it
   // at depth-1, which is what walk_dir on the Rust side guarantees.
@@ -199,6 +260,16 @@ function CtxFiles({ workspaceDir }: { workspaceDir?: string }) {
                 {n.name}
                 {n.kind === "dir" ? "/" : ""}
               </span>
+              {(() => {
+                const s = statusFor(n);
+                return s ? (
+                  <span
+                    className="dot"
+                    data-s={s}
+                    title={s === "m" ? "modified" : "in context"}
+                  />
+                ) : null;
+              })()}
             </div>
           ))
         )}


### PR DESCRIPTION
## Summary

Modified files (yellow dot) and in-context files (green dot) now render beside their tree row, matching the v4 mockup's `data-s="m"` / `data-s="c"` hooks (the CSS was already shipped in #750).

## Implementation

- **Modified**: new Tauri command `git_status(root)` runs `git status --porcelain -z` and parses index/worktree codes into coarse kinds (modified / added / deleted / renamed / untracked). The Files tab polls every 5s and on workspace switch. Outside a git repo or when `git` isn't on PATH, the command returns an empty list silently — no error spam.
- **In context**: the reducer scans `tool.intent` events for the known file-reading tools (`read_file`, `list_directory`, `directory_tree`, `search_files`, `get_file_info`, `glob_files`) and accumulates each `path` arg into `state.inContextPaths`. `$session_loaded` rebuilds the set from loaded tool segments so resumed sessions show their dots without re-reading anything.

## Test plan

- [x] `cargo check` clean
- [x] `npx tsc --noEmit` clean in `desktop/`
- [x] biome — no new warnings (pre-existing `useKeyWithClickEvents` only)
- [ ] Manual: open a git repo, edit a file, confirm yellow dot appears within ~5s; ask the agent to `read_file foo.ts`, confirm green dot appears on `foo.ts`; switch workspaces, confirm dots refresh for the new repo

Closes #756.
