### PR TITLE
fix(ui): capture keystrokes while scrolled up in history

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -413,6 +413,7 @@ function AppInner({
   const isStreaming = useAgentState((s) => s.cards.some((c) => c.kind === "streaming" && !c.done));
   const activityLabel = useActivityLabel();
   const chatScroll = useChatScrollActions();
+  const pinned = useChatScrollState((s) => s.pinned);
   const [input, setInput] = useState("");
   const [busy, setBusy] = useState(false);
   const [slashUsage, setSlashUsage] = useState<Readonly<Record<string, number>>>(() =>
@@ -1359,6 +1360,28 @@ function AppInner({
     else if (!pickerOwnsArrows && ev.upArrow) chatScroll.scrollUp();
     else if (!pickerOwnsArrows && ev.downArrow) chatScroll.scrollDown();
   }, !modalOpen);
+
+  // When scrolled up (PromptInput unmounted), capture printable keys
+  // and backspace so the user can type blind and see their input when
+  // they scroll back down. Enter returns to bottom.
+  useKeystroke(
+    (ev) => {
+      if (ev.paste) return;
+      if (ev.return) {
+        chatScroll.jumpToBottom();
+        return;
+      }
+      if (ev.backspace) {
+        setInput(input.slice(0, -1));
+        return;
+      }
+      if (ev.input.length > 0 && ev.input >= " ") {
+        setInput(input + ev.input);
+        return;
+      }
+    },
+    !modalOpen && !pinned && !busy,
+  );
 
   // Esc during busy → forward to the loop as an abort signal. The loop
   // finishes the tool call in flight (we can't kill subprocess stdio


### PR DESCRIPTION
## What

When the user scrolls up to read chat history, `PromptInput` is unmounted and all keystrokes are silently dropped. This PR adds an App-level `useKeystroke` handler that captures printable characters, backspace, and Enter (returns to bottom) when `pinned=false`, so the user can type blind while reading history and see their input when they scroll back — Claude Code parity.

## Why

Reported by a user testing Reasonix for the first time. The current behavior (keystrokes silently lost) is confusing and breaks the flow of "read the agent output, start typing my next question, scroll back to see it."

## How

- Adds `const pinned = useChatScrollState((s) => s.pinned)` to `AppInner`
- Registers a new `useKeystroke` handler active when `!modalOpen && !pinned && !busy`
- Handler: printable chars → append to `input`, backspace → delete last char, Enter → `chatScroll.jumpToBottom()`
- Supports CJK IME input (multi-character `ev.input`)

## Test plan

- [x] `npm run verify` passes (same 2 pre-existing memory test failures as main)
- [x] Manual: scroll up → type letters, numbers, symbols, Chinese → scroll back → input preserved
- [x] Manual: scroll up → press Enter → returns to bottom, input visible