### PR TITLE
feat(desktop): surface memory store entries in the Memory tab

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -14,6 +14,7 @@ import type {
   ConfirmationChoice,
   IncomingEvent,
   McpSpecInfo,
+  MemoryEntryInfo,
   OutgoingCommand,
   PlanVerdict,
   RevisionVerdict,
@@ -189,6 +190,7 @@ type State = {
   skills: SkillInfo[];
   /** Files the agent has read this session — paths as the tool args provided them (typically relative to workspace). */
   inContextPaths: string[];
+  memory: MemoryEntryInfo[];
 };
 
 type DeltaBatchItem = {
@@ -483,6 +485,8 @@ function applyIncoming(state: State, ev: IncomingEvent): State {
       return { ...state, skills: ev.items };
     case "$ctx_breakdown":
       return { ...state, usage: { ...state.usage, reservedTokens: ev.reservedTokens } };
+    case "$memory":
+      return { ...state, memory: ev.entries };
     case "$balance":
       return {
         ...state,
@@ -787,6 +791,7 @@ function TabRuntime({
     mcpBridged: false,
     skills: [],
     inContextPaths: [],
+    memory: [],
   });
   const [draft, setDraft] = useState("");
   const [toast, setToast] = useState<string | null>(null);
@@ -1389,6 +1394,7 @@ function TabRuntime({
           mcpSpecs={state.mcpSpecs}
           mcpBridged={state.mcpBridged}
           inContextPaths={state.inContextPaths}
+          memory={state.memory}
         />
 
         <StatusBar

--- a/desktop/src/protocol.ts
+++ b/desktop/src/protocol.ts
@@ -155,6 +155,17 @@ export type CtxBreakdownEvent = {
   reservedTokens: number;
 };
 
+export type MemoryEntryInfo = {
+  name: string;
+  scope: "project" | "global";
+  description: string;
+};
+
+export type MemoryEvent = {
+  type: "$memory";
+  entries: MemoryEntryInfo[];
+};
+
 export type LoadedSegment =
   | { kind: "text"; text: string }
   | { kind: "reasoning"; text: string }
@@ -343,6 +354,7 @@ export type IncomingEvent = { tabId?: string } & (
   | McpSpecsEvent
   | SkillsEvent
   | CtxBreakdownEvent
+  | MemoryEvent
   | UserMessageEvent
   | ModelTurnStartedEvent
   | ModelDeltaEvent

--- a/desktop/src/ui/context-panel.tsx
+++ b/desktop/src/ui/context-panel.tsx
@@ -2,7 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { useEffect, useMemo, useState } from "react";
 import type { Settings, UsageStats } from "../App";
 import { I } from "../icons";
-import type { McpSpecInfo } from "../protocol";
+import type { McpSpecInfo, MemoryEntryInfo } from "../protocol";
 
 type Tab = "files" | "tools" | "memory" | "rules";
 
@@ -27,6 +27,7 @@ export function ContextPanel({
   mcpSpecs,
   mcpBridged,
   inContextPaths,
+  memory,
 }: {
   settings: Settings | null;
   usage: UsageStats;
@@ -34,6 +35,7 @@ export function ContextPanel({
   mcpSpecs: McpSpecInfo[];
   mcpBridged: boolean;
   inContextPaths: string[];
+  memory: MemoryEntryInfo[];
 }) {
   const [tab, setTab] = useState<Tab>("files");
   const reserved = usage.reservedTokens;
@@ -100,7 +102,7 @@ export function ContextPanel({
           <CtxFiles workspaceDir={workspaceDir} inContextPaths={inContextPaths} />
         )}
         {tab === "tools" && <CtxTools specs={mcpSpecs} bridged={mcpBridged} />}
-        {tab === "memory" && <CtxMemory />}
+        {tab === "memory" && <CtxMemory entries={memory} />}
         {tab === "rules" && <CtxRules settings={settings} />}
       </div>
     </aside>
@@ -318,14 +320,27 @@ function CtxTools({ specs, bridged }: { specs: McpSpecInfo[]; bridged: boolean }
   );
 }
 
-function CtxMemory() {
+function CtxMemory({ entries }: { entries: MemoryEntryInfo[] }) {
   return (
     <div className="ctx-block">
       <div className="h">
         <span>长期记忆</span>
-        <span className="right">—</span>
+        <span className="right">{entries.length === 0 ? "—" : `${entries.length} 项`}</span>
       </div>
-      <div className="ctx-empty">当前会话尚未记录长期记忆。</div>
+      {entries.length === 0 ? (
+        <div className="ctx-empty">当前会话尚未记录长期记忆。</div>
+      ) : (
+        <div className="mem">
+          {entries.map((m) => (
+            <div className="mem-row" key={`${m.scope}/${m.name}`}>
+              <span className="scope" data-s={m.scope}>
+                {m.scope === "project" ? "项目" : "全局"}
+              </span>
+              <span className="txt">{m.description || m.name}</span>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -58,6 +58,7 @@ import {
   patchSessionMeta,
   timestampSuffix,
 } from "../../memory/session.js";
+import { MemoryStore } from "../../memory/user.js";
 import { SkillStore } from "../../skills.js";
 import { countTokens } from "../../tokenizer.js";
 import type { ChoiceOption } from "../../tools/choice.js";
@@ -275,6 +276,17 @@ interface CtxBreakdownEvent {
   reservedTokens: number;
 }
 
+interface MemoryEntryInfo {
+  name: string;
+  scope: "project" | "global";
+  description: string;
+}
+
+interface MemoryEvent {
+  type: "$memory";
+  entries: MemoryEntryInfo[];
+}
+
 interface SkillInfo {
   name: string;
   description: string;
@@ -315,7 +327,8 @@ type EmittableEvent =
   | TabClosedEvent
   | McpSpecsEvent
   | SkillsEvent
-  | CtxBreakdownEvent;
+  | CtxBreakdownEvent
+  | MemoryEvent;
 
 function emit(ev: EmittableEvent, tabId?: string): void {
   const payload = tabId ? { ...ev, tabId } : ev;
@@ -456,6 +469,20 @@ function emitMcpSpecs(tab: Tab): void {
   const cfg = readConfig();
   const specs = (cfg.mcp ?? []).map(summarizeMcpSpec);
   emit({ type: "$mcp_specs", specs, bridged: false }, tab.id);
+}
+
+function emitMemory(tab: Tab): void {
+  try {
+    const store = new MemoryStore({ projectRoot: tab.rootDir });
+    const entries: MemoryEntryInfo[] = store.list().map((e) => ({
+      name: e.name,
+      scope: e.scope,
+      description: e.description,
+    }));
+    emit({ type: "$memory", entries }, tab.id);
+  } catch (err) {
+    emit({ type: "$error", message: `memory_get failed: ${(err as Error).message}` }, tab.id);
+  }
 }
 
 // reserved = system prompt + tool specs, constant for the tab's lifetime once
@@ -936,6 +963,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
   emitSettings(first);
   emitMcpSpecs(first);
   emitSkills(first);
+  emitMemory(first);
   emitCtxBreakdown(first);
   void emitBalance(first);
 
@@ -962,6 +990,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
           emitSettings(tab);
           emitMcpSpecs(tab);
           emitSkills(tab);
+          emitMemory(tab);
           emitCtxBreakdown(tab);
           void emitBalance(tab);
         } catch (err) {


### PR DESCRIPTION
## Summary

Wires the right-panel Memory tab to the actual memory store. The desktop command opens a `MemoryStore` per tab and emits the entries as a new `$memory` event on tab open. Each row shows the scope badge (项目 / 全局) and the entry's description, matching the v4 mockup.

## Refresh strategy

Tab-open only for v1. When the agent writes a new memory via `update_memory` mid-session, the panel reflects it on next tab open / workspace switch. Live refresh on a `update_memory` `tool.result` is a small follow-up if it proves annoying in practice.

## Test plan

- [x] `npx tsc --noEmit` clean in both `src/` and `desktop/`
- [ ] Manual: open the desktop client in a project with `.reasonix/memory/project/*.md`, switch to Memory tab, confirm the entries render with the project badge; check global memory works equivalently

Closes #754.
