### PR TITLE
refactor(ui): extract HistoryTypingCapture so AppInner stops subscribing to pinned

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -307,6 +307,41 @@ function InputAreaWithHistoryHint({
 }
 
 /**
+ * Captures printable keys / backspace / Enter while history is unpinned so the
+ * user can type blind and see the buffer when they scroll back. Lives in its
+ * own leaf so AppInner doesn't subscribe to `pinned` — same trick as
+ * `InputAreaWithHistoryHint` above.
+ */
+function HistoryTypingCapture({
+  input,
+  setInput,
+  enabled,
+  onReturnToBottom,
+}: {
+  input: string;
+  setInput: (next: string) => void;
+  enabled: boolean;
+  onReturnToBottom: () => void;
+}): null {
+  const pinned = useChatScrollState((s) => s.pinned);
+  useKeystroke((ev) => {
+    if (ev.paste) return;
+    if (ev.return) {
+      onReturnToBottom();
+      return;
+    }
+    if (ev.backspace) {
+      setInput(input.slice(0, -1));
+      return;
+    }
+    if (ev.input.length > 0 && ev.input >= " ") {
+      setInput(input + ev.input);
+    }
+  }, enabled && !pinned);
+  return null;
+}
+
+/**
  * Single-line status pill rendered below the modeline whenever a /loop
  * is active. Re-renders every second so the countdown ticks.
  */
@@ -413,7 +448,6 @@ function AppInner({
   const isStreaming = useAgentState((s) => s.cards.some((c) => c.kind === "streaming" && !c.done));
   const activityLabel = useActivityLabel();
   const chatScroll = useChatScrollActions();
-  const pinned = useChatScrollState((s) => s.pinned);
   const [input, setInput] = useState("");
   const [busy, setBusy] = useState(false);
   const [slashUsage, setSlashUsage] = useState<Readonly<Record<string, number>>>(() =>
@@ -1360,28 +1394,6 @@ function AppInner({
     else if (!pickerOwnsArrows && ev.upArrow) chatScroll.scrollUp();
     else if (!pickerOwnsArrows && ev.downArrow) chatScroll.scrollDown();
   }, !modalOpen);
-
-  // When scrolled up (PromptInput unmounted), capture printable keys
-  // and backspace so the user can type blind and see their input when
-  // they scroll back down. Enter returns to bottom.
-  useKeystroke(
-    (ev) => {
-      if (ev.paste) return;
-      if (ev.return) {
-        chatScroll.jumpToBottom();
-        return;
-      }
-      if (ev.backspace) {
-        setInput(input.slice(0, -1));
-        return;
-      }
-      if (ev.input.length > 0 && ev.input >= " ") {
-        setInput(input + ev.input);
-        return;
-      }
-    },
-    !modalOpen && !pinned && !busy,
-  );
 
   // Esc during busy → forward to the loop as an abort signal. The loop
   // finishes the tool call in flight (we can't kill subprocess stdio
@@ -3625,6 +3637,12 @@ function AppInner({
 
   return (
     <>
+      <HistoryTypingCapture
+        input={input}
+        setInput={setInput}
+        enabled={!modalOpen && !busy}
+        onReturnToBottom={chatScroll.jumpToBottom}
+      />
       <TickerProvider disabled={tickerSuspended}>
         <ViewportBudgetProvider>
           <InflightProvider inflight={loop.inflight}>


### PR DESCRIPTION
## Summary

Follow-up to #760. That PR added a `useChatScrollState((s) => s.pinned)` subscription directly inside `AppInner`, which re-renders the whole subtree every time scroll state ticks (every wheel/arrow event).

Move the keystroke handler into a `HistoryTypingCapture` leaf that renders `null` and owns its own `pinned` read — same pattern `InputAreaWithHistoryHint` already uses. AppInner just passes `input` / `setInput` / `onReturnToBottom` / an `enabled` gate; the leaf decides when to register.

Behavior identical, AppInner is no longer re-rendered by scroll events.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] biome clean
- [ ] Manual: scroll up, type letters and Chinese, scroll back — input preserved; press Enter while scrolled up — returns to bottom (same as #760)
