### PR TITLE
fix(at-mention): allow CJK and other Unicode letters in @-mention paths

### DIFF
--- a/src/at-mentions.ts
+++ b/src/at-mentions.ts
@@ -357,8 +357,8 @@ export function parseAtQuery(query: string): ParsedAtQuery {
   };
 }
 
-/** Trailing-token only, anchored at end-of-input — distinct from `AT_MENTION_PATTERN` which scans all. */
-export const AT_PICKER_PREFIX = /(?:^|\s)@([a-zA-Z0-9_./\\-]*)$/;
+/** Trailing-token only, anchored at end-of-input — distinct from `AT_MENTION_PATTERN` which scans all. `\p{L}\p{N}` for CJK and other non-ASCII filenames. */
+export const AT_PICKER_PREFIX = /(?:^|\s)@([\p{L}\p{N}_./\\-]*)$/u;
 
 export function detectAtPicker(input: string): { query: string; atOffset: number } | null {
   const m = AT_PICKER_PREFIX.exec(input);
@@ -475,7 +475,7 @@ function fuzzySubseqScore(needle: string, target: string): number | null {
 }
 
 /** Word-boundary anchor rejects `@` embedded in emails / social handles; trailing `.` stripped before lookup. */
-export const AT_MENTION_PATTERN = /(?<=^|\s)@([a-zA-Z0-9_./\\-]+)/g;
+export const AT_MENTION_PATTERN = /(?<=^|\s)@([\p{L}\p{N}_./\\-]+)/gu;
 
 export interface AtMentionExpansion {
   /** The raw `@path` token as it appeared in the text. */

--- a/tests/at-mentions.test.ts
+++ b/tests/at-mentions.test.ts
@@ -43,6 +43,12 @@ describe("AT_MENTION_PATTERN", () => {
     expect(m2).toHaveLength(0);
   });
 
+  it("matches CJK-named paths (issue #749)", () => {
+    const text = "see @docs/中文/readme.md";
+    const matches = [...text.matchAll(AT_MENTION_PATTERN)].map((m) => m[1]);
+    expect(matches).toEqual(["docs/中文/readme.md"]);
+  });
+
   it("matches multiple @paths in one string", () => {
     const m = [..."compare @a.ts and @b.ts".matchAll(AT_MENTION_PATTERN)];
     expect(m).toHaveLength(2);
@@ -217,6 +223,26 @@ describe("detectAtPicker", () => {
     expect(r).not.toBeNull();
     expect(r!.query).toBe("sr");
     expect(r!.atOffset).toBe(0);
+  });
+
+  it("captures CJK characters in the path (issue #749)", () => {
+    const r = detectAtPicker("look at @中文");
+    expect(r).not.toBeNull();
+    expect(r!.query).toBe("中文");
+    expect(r!.atOffset).toBe(8);
+  });
+
+  it("captures CJK folder with trailing slash so Tab can drill in (issue #749)", () => {
+    const r = detectAtPicker("@中文/");
+    expect(r).not.toBeNull();
+    expect(r!.query).toBe("中文/");
+    expect(r!.atOffset).toBe(0);
+  });
+
+  it("captures a child path under a CJK folder (issue #749)", () => {
+    const r = detectAtPicker("@中文/sub.ts");
+    expect(r).not.toBeNull();
+    expect(r!.query).toBe("中文/sub.ts");
   });
 });
 


### PR DESCRIPTION
## Summary

`@`-mention picker fell off the moment a path contained any non-ASCII character. The prefix regex was ASCII-only:

```
/(?:^|\s)@([a-zA-Z0-9_./\-]*)$/
```

So `@中文/` failed the `$` anchor on the first non-ASCII byte, `detectAtPicker` returned `null`, the picker disappeared, and Tab had nothing to drill into.

## Fix

Swap the char class to `[\p{L}\p{N}_./\-]` with the `u` flag, both in `AT_PICKER_PREFIX` (live picker) and `AT_MENTION_PATTERN` (post-submit expander). Adds four regression tests covering CJK in three positions: just after `@`, trailing-slash drill-in, and a child path inside a CJK folder; plus a mention-pattern test for the expansion side.

## Test plan

- [x] `npx vitest run tests/at-mentions.test.ts` — 95/95 pass
- [x] `npx tsc --noEmit` clean
- [ ] Manual: in a workspace with a `中文/` folder, type `@中文`, see the picker, press Tab → the prompt becomes `@中文/` and the picker now lists files inside

Closes #749.
