### PR TITLE
feat(acp): --yolo flag to bypass plan checkpoints

### DIFF
--- a/src/cli/commands/acp.ts
+++ b/src/cli/commands/acp.ts
@@ -40,6 +40,7 @@ export interface AcpOptions {
   dir?: string;
   budgetUsd?: number;
   transcript?: string;
+  yolo?: boolean;
 }
 
 interface Session {
@@ -124,7 +125,8 @@ export async function acpCommand(opts: AcpOptions): Promise<void> {
   }
 
   pauseGate.on((req) => {
-    const auto = autoResolveVerdict(req, loadEditMode());
+    const editMode = opts.yolo ? "yolo" : loadEditMode();
+    const auto = autoResolveVerdict(req, editMode);
     if (auto !== null) {
       pauseGate.resolve(req.id, auto);
       return;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -318,6 +318,10 @@ program
   .option("--preset <name>", t("ui.presetHintShort"))
   .option("--budget <usd>", t("ui.budgetHintShort"), (v) => Number.parseFloat(v))
   .option("--transcript <path>", t("ui.transcriptHint"))
+  .option(
+    "--yolo",
+    "auto-approve plan checkpoints for this invocation (equivalent to editMode=yolo without mutating config)",
+  )
   .action(async (opts) => {
     const defaults = resolveDefaults({
       model: opts.model,
@@ -331,6 +335,7 @@ program
       budgetUsd: parseBudgetFlag(opts.budget),
       dir: opts.dir,
       transcript: opts.transcript,
+      yolo: !!opts.yolo,
     });
   });
 

--- a/tests/acp-yolo.test.ts
+++ b/tests/acp-yolo.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { PauseGate } from "../src/core/pause-gate.js";
+import { autoResolveVerdict } from "../src/core/pause-policy.js";
+
+// Mirrors the listener body in src/cli/commands/acp.ts.
+function makeListener(opts: { yolo?: boolean }, configEditMode: "review" | "auto" | "yolo") {
+  return (gate: PauseGate, onBridge: (reqId: number) => void) => {
+    gate.on((req) => {
+      const editMode = opts.yolo ? "yolo" : configEditMode;
+      const auto = autoResolveVerdict(req, editMode);
+      if (auto !== null) {
+        gate.resolve(req.id, auto as never);
+        return;
+      }
+      onBridge(req.id);
+    });
+  };
+}
+
+describe("acp --yolo", () => {
+  it("auto-continues plan_checkpoint when opts.yolo is true even if config says review", async () => {
+    const gate = new PauseGate();
+    let bridged = false;
+    makeListener({ yolo: true }, "review")(gate, () => {
+      bridged = true;
+    });
+
+    const promise = gate.ask({
+      kind: "plan_checkpoint",
+      payload: { stepId: "s1", result: "done" },
+    });
+
+    await expect(promise).resolves.toEqual({ type: "continue" });
+    expect(bridged).toBe(false);
+  });
+
+  it("bridges plan_checkpoint to the client when opts.yolo is false and config is review", async () => {
+    const gate = new PauseGate();
+    let bridgedReqId: number | null = null;
+    makeListener({ yolo: false }, "review")(gate, (id) => {
+      bridgedReqId = id;
+      gate.resolve(id, { type: "continue" } as never);
+    });
+
+    await gate.ask({ kind: "plan_checkpoint", payload: { stepId: "s1", result: "done" } });
+    expect(bridgedReqId).not.toBeNull();
+  });
+
+  it("falls back to config editMode when opts.yolo is undefined", async () => {
+    const gate = new PauseGate();
+    let bridged = false;
+    makeListener({}, "auto")(gate, () => {
+      bridged = true;
+    });
+
+    const promise = gate.ask({
+      kind: "plan_checkpoint",
+      payload: { stepId: "s1", result: "done" },
+    });
+    await expect(promise).resolves.toEqual({ type: "continue" });
+    expect(bridged).toBe(false);
+  });
+
+  it("does NOT auto-resolve run_command requests even with --yolo (plan-checkpoint-only scope)", async () => {
+    const gate = new PauseGate();
+    let bridgedReqId: number | null = null;
+    makeListener({ yolo: true }, "review")(gate, (id) => {
+      bridgedReqId = id;
+      gate.resolve(id, { type: "run_once" } as never);
+    });
+
+    await gate.ask({ kind: "run_command", payload: { command: "rm -rf /" } });
+    expect(bridgedReqId).not.toBeNull();
+  });
+});


### PR DESCRIPTION
Closes part 2 of #765 (ack from @esengine: https://github.com/esengine/DeepSeek-Reasonix/issues/765#issuecomment-4439399331).

**Stacked on #766** — that PR adds `--transcript`. This PR shows both commits until #766 merges, after which I'll rebase and only the `--yolo` commit will remain.

## What

Per-invocation override of `editMode` for plan-checkpoint gates only. Headless ACP callers can skip plan modals without mutating `~/.reasonix/config.json`.

## How

Three lines in the `pauseGate.on` listener:

```ts
const editMode = opts.yolo ? "yolo" : loadEditMode();
const auto = autoResolveVerdict(req, editMode);
```

- `autoResolveVerdict` already routes `editMode = "yolo"` to `{type: "continue"}` for `plan_checkpoint` — see `src/core/pause-policy.ts:12-17`. Zero changes there.
- **Plan-checkpoint-only scope.** `run_command`, `edit_file`, and any future gates still bridge to the client via `session/request_permission`. The test asserts this explicitly.
- No env var, no global flag mode, no surface beyond the one option.

## Scope

| File | Lines | Why |
|---|---|---|
| `src/cli/commands/acp.ts` | +3 / -1 | `AcpOptions.yolo` field; editMode source switch in pauseGate listener |
| `src/cli/index.ts` | +5 | Register `--yolo` on `.command(\"acp\")`, forward to `acpCommand` |
| `tests/acp-yolo.test.ts` | +75 (new) | Unit-level: yolo overrides config, fallback to config when undefined, `run_command` still bridges even with `--yolo` |

## Review notes

I considered extracting a small `resolveEditMode(opts)` helper to avoid duplicating the inline expression between production code and the test. Skipped: one call site, and CONTRIBUTING.md (\"no abstractions before two call sites\"). The test replicates the 1-line decision inline.

## Verification

```sh
npm run verify     # lint + typecheck + 2,783 tests + build — green
node dist/cli/index.js acp --help   # shows --yolo with the scoped description
```

Refs: #765