### PR TITLE
feat(loop): auto-escalate flash→pro on consecutive read-only tool calls

### DIFF
--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -597,6 +597,8 @@ export const EN: TranslationSchema = {
     harvestStatus: "extracting plan state from reasoning…",
     autoEscalation:
       "⇧ auto-escalating to {model} for the rest of this turn — flash hit {breakdown}. Next turn falls back to {fallback} unless /pro is armed.",
+    readOnlyLoopEscalation:
+      "⇧ auto-escalating to {model} — flash made {n} consecutive read-only calls without producing an edit or final answer. Next turn falls back to {fallback} unless /pro is armed.",
     repeatToolCallWarning:
       "Caught a repeated tool call — let the model see the issue and retry with a different approach.",
     stormStuck:

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -211,6 +211,7 @@ export interface TranslationSchema {
     flashEscalation: string;
     harvestStatus: string;
     autoEscalation: string;
+    readOnlyLoopEscalation: string;
     repeatToolCallWarning: string;
     stormStuck: string;
     stormSuppressed: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -584,6 +584,8 @@ export const zhCN: TranslationSchema = {
     harvestStatus: "正在从推理过程提取计划状态…",
     autoEscalation:
       "⇧ 本轮剩余调用自动升级到 {model} — flash 命中 {breakdown}。下一轮回退到 {fallback}，除非已装备 /pro。",
+    readOnlyLoopEscalation:
+      "⇧ 自动升级到 {model} — flash 连续 {n} 次只读调用，未产出修改或最终答案。下一轮回退到 {fallback}，除非已装备 /pro。",
     repeatToolCallWarning: "拦截到重复工具调用 — 让模型察觉问题并换种方式重试。",
     stormStuck:
       "已停止卡死的重试循环 — 模型在自纠提示后仍以相同参数重复调用同一工具。请尝试 /retry、换种说法，或排查底层阻塞。",

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -29,6 +29,10 @@ import {
 import { hookWarnings, safeParseToolArgs } from "./loop/hook-events.js";
 import { buildAssistantMessage, buildSyntheticAssistantMessage } from "./loop/messages.js";
 import {
+  READONLY_LOOP_ESCALATION_THRESHOLD,
+  ReadOnlyLoopTracker,
+} from "./loop/read-only-loop-tracker.js";
+import {
   looksLikeCompleteJson,
   shrinkOversizedToolCallArgsByTokens,
   shrinkOversizedToolResults,
@@ -146,6 +150,7 @@ export class CacheFirstLoop {
   private _proArmedForNextTurn = false;
   private _escalateThisTurn = false;
   private readonly _turnFailures: TurnFailureTracker;
+  private readonly _readOnlyLoop: ReadOnlyLoopTracker;
   private _turnSelfCorrected = false;
   private _foldedThisTurn = false;
   private _toolDispatchesThisStep = 0;
@@ -172,6 +177,10 @@ export class CacheFirstLoop {
     this._turnFailures = new TurnFailureTracker(
       resolveFailureThreshold(opts.failureThreshold, FAILURE_ESCALATION_THRESHOLD),
     );
+    this._readOnlyLoop = new ReadOnlyLoopTracker(
+      parsePositiveIntEnv(process.env.REASONIX_READONLY_LOOP_THRESHOLD) ??
+        READONLY_LOOP_ESCALATION_THRESHOLD,
+    );
     // Last-resort backstop — primary stop is the token-context guard inside step().
     this.maxToolIters = opts.maxToolIters ?? 64;
     this.hooks = opts.hooks ?? [];
@@ -184,29 +193,6 @@ export class CacheFirstLoop {
     const allowedNames = new Set([...this.prefix.toolSpecs.map((s) => s.function.name)]);
     // Storm breaker clears its window on mutating calls so read → edit → verify isn't a storm.
     const registry = this.tools;
-    const isMutating = (call: ToolCall): boolean => {
-      const name = call.function?.name;
-      if (!name) return false;
-      const def = registry.get(name);
-      if (!def) return false;
-      if (def.readOnlyCheck) {
-        let args: Record<string, unknown> = {};
-        try {
-          args = JSON.parse(call.function?.arguments ?? "{}") ?? {};
-        } catch {
-          // Malformed args → fall through to the static flag below; the
-          // dynamic check would've thrown anyway.
-        }
-        try {
-          if (def.readOnlyCheck(args as never)) return false;
-        } catch (err) {
-          // Mirror tools.ts: surface buggy readOnlyCheck instead of silently
-          // falling through to the static flag.
-          process.stderr.write(`readOnlyCheck for ${name} threw: ${(err as Error).message}\n`);
-        }
-      }
-      return def.readOnly !== true;
-    };
     const isStormExempt = (call: ToolCall): boolean => {
       const name = call.function?.name;
       if (!name) return false;
@@ -214,7 +200,7 @@ export class CacheFirstLoop {
     };
     this.repair = new ToolCallRepair({
       allowedToolNames: allowedNames,
-      isMutating,
+      isMutating: (call) => this.isMutating(call),
       isStormExempt,
       stormThreshold: parsePositiveIntEnv(process.env.REASONIX_STORM_THRESHOLD),
       stormWindow: parsePositiveIntEnv(process.env.REASONIX_STORM_WINDOW),
@@ -391,6 +377,40 @@ export class CacheFirstLoop {
     return true;
   }
 
+  /** Returns true ONLY on the call where the read-only streak crosses the threshold (#681). */
+  private noteReadOnlyToolCall(call: ToolCall): boolean {
+    const isReadOnly = !this.isMutating(call);
+    if (!this._readOnlyLoop.noteAndCrossedThreshold(isReadOnly)) return false;
+    if (this._escalateThisTurn || !this.autoEscalate) return false;
+    this._escalateThisTurn = true;
+    return true;
+  }
+
+  /** A call counts as mutating when its definition reports `readOnly !== true` and any dynamic `readOnlyCheck` doesn't override that for these args. */
+  private isMutating(call: ToolCall): boolean {
+    const name = call.function?.name;
+    if (!name) return false;
+    const def = this.tools.get(name);
+    if (!def) return false;
+    if (def.readOnlyCheck) {
+      let args: Record<string, unknown> = {};
+      try {
+        args = JSON.parse(call.function?.arguments ?? "{}") ?? {};
+      } catch {
+        // Malformed args → fall through to the static flag below; the
+        // dynamic check would've thrown anyway.
+      }
+      try {
+        if (def.readOnlyCheck(args as never)) return false;
+      } catch (err) {
+        // Mirror tools.ts: surface buggy readOnlyCheck instead of silently
+        // falling through to the static flag.
+        process.stderr.write(`readOnlyCheck for ${name} threw: ${(err as Error).message}\n`);
+      }
+    }
+    return def.readOnly !== true;
+  }
+
   private async runOneToolCall(
     call: ToolCall,
     signal: AbortSignal,
@@ -540,6 +560,7 @@ export class CacheFirstLoop {
     // armed intent is one-shot — next turn starts fresh on flash
     // unless the user re-arms or mid-turn escalation triggers).
     this._turnFailures.reset();
+    this._readOnlyLoop.reset();
     this._turnSelfCorrected = false;
     this._escalateThisTurn = false;
     this._foldedThisTurn = false;
@@ -1157,6 +1178,17 @@ export class CacheFirstLoop {
               content: t("loop.autoEscalation", {
                 model: ESCALATION_MODEL,
                 breakdown: this._turnFailures.formatBreakdown(),
+                fallback: this.model,
+              }),
+            };
+          }
+          if (this.noteReadOnlyToolCall(call)) {
+            yield {
+              turn: this._turn,
+              role: "warning",
+              content: t("loop.readOnlyLoopEscalation", {
+                model: ESCALATION_MODEL,
+                n: this._readOnlyLoop.currentStreak,
                 fallback: this.model,
               }),
             };

--- a/src/loop/read-only-loop-tracker.ts
+++ b/src/loop/read-only-loop-tracker.ts
@@ -1,0 +1,31 @@
+/** Default streak length before the loop force-escalates flash→pro on consecutive read-only tool calls (#681). */
+export const READONLY_LOOP_ESCALATION_THRESHOLD = 8;
+
+/** Streak of consecutive read-only tool calls within a step; mutating call resets. Crossing the threshold lets the loop escalate flash→pro before the user pays for many more reads. */
+export class ReadOnlyLoopTracker {
+  private streak = 0;
+  private readonly threshold: number;
+
+  constructor(threshold: number = READONLY_LOOP_ESCALATION_THRESHOLD) {
+    this.threshold = Math.max(1, threshold);
+  }
+
+  reset(): void {
+    this.streak = 0;
+  }
+
+  /** True ONLY on the call where the streak crosses the configured threshold. */
+  noteAndCrossedThreshold(isReadOnly: boolean): boolean {
+    if (!isReadOnly) {
+      this.streak = 0;
+      return false;
+    }
+    const before = this.streak;
+    this.streak += 1;
+    return before < this.threshold && this.streak >= this.threshold;
+  }
+
+  get currentStreak(): number {
+    return this.streak;
+  }
+}

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -981,6 +981,136 @@ describe("CacheFirstLoop - auto-escalation on tool failures", () => {
     expect(warnings.some((w) => /escalat/i.test(w))).toBe(false);
   });
 
+  // ── Read-only loop escalation (#681) ──────────────────────────────
+
+  it("auto-escalates when 8 consecutive read-only calls fire without a write (#681)", async () => {
+    const tools = new ToolRegistry();
+    tools.register({
+      name: "peek",
+      description: "read-only fake",
+      parameters: { type: "object", properties: { n: { type: "integer" } }, required: [] },
+      readOnly: true,
+      fn: ({ n }: { n?: number }) => JSON.stringify({ saw: n ?? 0 }),
+    });
+    const call = (id: string, n: number) => ({
+      content: "",
+      tool_calls: [
+        {
+          id,
+          type: "function" as const,
+          function: { name: "peek", arguments: JSON.stringify({ n }) },
+        },
+      ],
+    });
+    // 8 read-only calls + a final text response so step() terminates.
+    const client = makeClient([
+      ...Array.from({ length: 8 }, (_, i) => call(`c${i}`, i)),
+      { content: "done after reads" },
+    ]);
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s", toolSpecs: tools.specs() }),
+      tools,
+      stream: false,
+    });
+
+    const warnings: string[] = [];
+    for await (const ev of loop.step("read everything")) {
+      if (ev.role === "warning") warnings.push(ev.content);
+    }
+
+    expect(loop.escalatedThisTurn).toBe(true);
+    expect(warnings.some((w) => /consecutive read-only/i.test(w))).toBe(true);
+  });
+
+  it("a mutating call mid-streak resets the read-only counter (#681)", async () => {
+    const tools = new ToolRegistry();
+    tools.register({
+      name: "peek",
+      description: "read-only fake",
+      parameters: { type: "object", properties: { n: { type: "integer" } }, required: [] },
+      readOnly: true,
+      fn: ({ n }: { n?: number }) => JSON.stringify({ saw: n ?? 0 }),
+    });
+    tools.register({
+      name: "poke",
+      description: "mutating fake",
+      parameters: { type: "object", properties: {}, required: [] },
+      fn: () => JSON.stringify({ ok: true }),
+    });
+    const peek = (id: string, n: number) => ({
+      content: "",
+      tool_calls: [
+        {
+          id,
+          type: "function" as const,
+          function: { name: "peek", arguments: JSON.stringify({ n }) },
+        },
+      ],
+    });
+    const poke = (id: string) => ({
+      content: "",
+      tool_calls: [{ id, type: "function" as const, function: { name: "poke", arguments: "{}" } }],
+    });
+    // 7 reads, one mutating call (resets), 7 more reads — never crosses 8 in a row.
+    const client = makeClient([
+      ...Array.from({ length: 7 }, (_, i) => peek(`r${i}`, i)),
+      poke("m"),
+      ...Array.from({ length: 7 }, (_, i) => peek(`r${i + 100}`, i + 100)),
+      { content: "done" },
+    ]);
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s", toolSpecs: tools.specs() }),
+      tools,
+      stream: false,
+    });
+
+    for await (const _ev of loop.step("mix it up")) {
+      // drain
+    }
+
+    expect(loop.escalatedThisTurn).toBe(false);
+  });
+
+  it("read-only loop does not escalate when autoEscalate=false (#681)", async () => {
+    const tools = new ToolRegistry();
+    tools.register({
+      name: "peek",
+      description: "read-only fake",
+      parameters: { type: "object", properties: { n: { type: "integer" } }, required: [] },
+      readOnly: true,
+      fn: ({ n }: { n?: number }) => JSON.stringify({ saw: n ?? 0 }),
+    });
+    const call = (id: string, n: number) => ({
+      content: "",
+      tool_calls: [
+        {
+          id,
+          type: "function" as const,
+          function: { name: "peek", arguments: JSON.stringify({ n }) },
+        },
+      ],
+    });
+    const client = makeClient([
+      ...Array.from({ length: 8 }, (_, i) => call(`c${i}`, i)),
+      { content: "done" },
+    ]);
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s", toolSpecs: tools.specs() }),
+      tools,
+      stream: false,
+      autoEscalate: false,
+    });
+
+    for await (const _ev of loop.step("read everything")) {
+      // drain
+    }
+
+    expect(loop.escalatedThisTurn).toBe(false);
+  });
+
   it("autoEscalate=false prevents auto-escalation despite accumulated failures", async () => {
     const tools = new ToolRegistry();
     tools.register({


### PR DESCRIPTION
## Summary

The flash→pro escalation today fires only on "repair signals" (SEARCH-mismatch / scavenged / truncated / repeat-loop). A model stuck reading file after file without ever writing or answering never trips that trigger — every read returns cleanly, so from the harness's view the turn looks healthy while the bill climbs. #681 hit this exact shape: 34 tool calls / 142 log messages, top-5 all `read_file`, ¥3.41 spent on flash before the user aborted.

## Fix

New `ReadOnlyLoopTracker` (`src/loop/read-only-loop-tracker.ts`) with default threshold `8`, env-tunable via `REASONIX_READONLY_LOOP_THRESHOLD`. After each tool result is appended in `step()`, the call goes through `noteReadOnlyToolCall(call)`:

- `isReadOnly` (computed via the existing `isMutating` predicate, hoisted to a private method on the class) bumps the streak.
- Any mutating call resets it.
- Crossing the threshold sets `_escalateThisTurn = true` and yields a new `loop.readOnlyLoopEscalation` warning — same contract as the existing failure-signal escalation.
- `autoEscalate=false` still blocks; the user keeps that lever.

The `isMutating` lambda inside the constructor is now `this.isMutating(call)`; the `ToolCallRepair` wiring forwards through the method. No behavioural change to repair / storm-breaker.

## Threshold choice

`8` is conservative on purpose — bursty read-heavy tasks ("read these 5 files then edit one") still finish on flash. Only genuinely unproductive loops (the #681 shape) cross.

## Test plan

- [x] `npx vitest run tests/loop.test.ts` — 73/73 pass (1 pre-existing skip), 3 new tests under "Read-only loop escalation (#681)"
- [x] `npm run verify` — clean (verified by pre-push hook)
- [x] Existing failure-signal escalation tests still pass (no regression in the storm/repair path)

Closes #681.
