### PR TITLE
feat(read_file): multi-language outline (Python, Go, Rust, Markdown)

### DIFF
--- a/src/tools/filesystem.ts
+++ b/src/tools/filesystem.ts
@@ -9,6 +9,7 @@ import { DEFAULT_INDEX_EXCLUDES } from "../index/config.js";
 import type { ToolCallContext, ToolRegistry } from "../tools.js";
 import { applyEdit, applyMultiEdit } from "./fs/edit.js";
 import { globFiles } from "./fs/glob.js";
+import { extractOutline, formatOutline } from "./fs/outline.js";
 import { searchContent, searchFiles } from "./fs/search.js";
 
 export { lineDiff } from "./fs/edit.js";
@@ -32,49 +33,6 @@ const DEFAULT_AUTO_PREVIEW_LINES = 200;
 const AUTO_PREVIEW_HEAD_LINES = 80;
 const AUTO_PREVIEW_TAIL_LINES = 40;
 const OUTLINE_MAX_ENTRIES = 30;
-const OUTLINE_TAIL_KEEP = 5;
-
-type OutlineEntry = { line: number; kind: string; name: string };
-
-const TS_EXPORT_RE =
-  /^export\s+(?:default\s+)?(?:async\s+)?(function|class|const|let|var|interface|type|enum)\s+\*?\s*(\w+)/;
-
-function extractTsExportOutline(lines: readonly string[]): OutlineEntry[] {
-  const out: OutlineEntry[] = [];
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i]!;
-    if (!line.startsWith("export ")) continue;
-    const m = TS_EXPORT_RE.exec(line);
-    if (!m) continue;
-    out.push({ line: i + 1, kind: m[1]!, name: m[2]! });
-  }
-  return out;
-}
-
-function formatOutline(entries: readonly OutlineEntry[]): string {
-  const total = entries.length;
-  if (total === 0) return "";
-  const lastEntry = entries[total - 1]!;
-  const width = String(lastEntry.line).length;
-  const fmt = (e: OutlineEntry) =>
-    `  L${String(e.line).padStart(width, " ")}  export ${e.kind} ${e.name}`;
-  const header = `[outline: ${total} top-level export${total === 1 ? "" : "s"}]`;
-  if (total <= OUTLINE_MAX_ENTRIES) {
-    return [header, ...entries.map(fmt)].join("\n");
-  }
-  const headCount = OUTLINE_MAX_ENTRIES - OUTLINE_TAIL_KEEP;
-  const headEntries = entries.slice(0, headCount);
-  const tailEntries = entries.slice(-OUTLINE_TAIL_KEEP);
-  const omitted = total - OUTLINE_MAX_ENTRIES;
-  const gapStart = headEntries[headEntries.length - 1]!.line;
-  const gapEnd = tailEntries[0]!.line;
-  return [
-    header,
-    ...headEntries.map(fmt),
-    `  [… ${omitted} more export${omitted === 1 ? "" : "s"} between L${gapStart} and L${gapEnd} …]`,
-    ...tailEntries.map(fmt),
-  ].join("\n");
-}
 
 /** Skipped unless `include_deps:true` — shared with the semantic indexer via DEFAULT_INDEX_EXCLUDES. */
 const SKIP_DIR_NAMES: ReadonlySet<string> = new Set(DEFAULT_INDEX_EXCLUDES.dirs);
@@ -221,7 +179,7 @@ export function registerFilesystemTools(
   - head: N  → first N lines (imports, public API, small configs)
   - tail: N  → last N lines (recently-added code, log tails)
   - range: "A-B"  → inclusive line range A..B, 1-indexed (e.g. "120-180" around an edit site)
-When none of these is given AND the file is longer than ${DEFAULT_AUTO_PREVIEW_LINES} lines, the tool auto-returns a head+tail preview with an "N lines omitted" marker, plus a top-level export outline (function / class / const / interface / type / enum names with line numbers, capped at ${OUTLINE_MAX_ENTRIES}) so you can pick a smart range without a follow-up grep. If you need the middle, re-call with a range. Prefer search_content to locate a symbol first only when the outline doesn't have what you want — one scoped read beats three full-file reads.`,
+When none of these is given AND the file is longer than ${DEFAULT_AUTO_PREVIEW_LINES} lines, the tool auto-returns a head+tail preview with an "N lines omitted" marker, plus a top-level symbol outline (TS/JS exports, Python def/class, Go func/type, Rust fn/struct/impl/trait, Markdown headings, with line numbers, capped at ${OUTLINE_MAX_ENTRIES}) so you can pick a smart range without a follow-up grep. If you need the middle, re-call with a range. Prefer search_content to locate a symbol first only when the outline doesn't have what you want — one scoped read beats three full-file reads.`,
     readOnly: true,
     stormExempt: true,
     parameters: {
@@ -309,7 +267,7 @@ When none of these is given AND the file is longer than ${DEFAULT_AUTO_PREVIEW_L
       const head = lines.slice(0, AUTO_PREVIEW_HEAD_LINES).join("\n");
       const tail = lines.slice(totalLines - AUTO_PREVIEW_TAIL_LINES).join("\n");
       const omitted = totalLines - AUTO_PREVIEW_HEAD_LINES - AUTO_PREVIEW_TAIL_LINES;
-      const outline = formatOutline(extractTsExportOutline(lines));
+      const outline = formatOutline(extractOutline(abs, lines));
       const parts: string[] = [
         `[auto-preview: head ${AUTO_PREVIEW_HEAD_LINES} + tail ${AUTO_PREVIEW_TAIL_LINES} of ${totalLines} lines]`,
         head,

--- a/src/tools/fs/outline.ts
+++ b/src/tools/fs/outline.ts
@@ -1,0 +1,156 @@
+/** Per-language top-level symbol outline for read_file preview. Regex-anchored at column 0 — nested decls intentionally skipped. */
+
+import * as pathMod from "node:path";
+
+export type OutlineEntry = { line: number; text: string };
+
+const OUTLINE_MAX_ENTRIES = 30;
+const OUTLINE_TAIL_KEEP = 5;
+
+const TS_EXPORT_RE =
+  /^export\s+(?:default\s+)?(?:async\s+)?(function|class|const|let|var|interface|type|enum)\s+\*?\s*(\w+)/;
+
+const PY_DECL_RE = /^(?:async\s+)?(def|class)\s+(\w+)/;
+
+const GO_DECL_RE = /^(func|type|var|const)\s+(?:\([^)]+\)\s+)?(\w+)/;
+
+const RUST_DECL_RE =
+  /^(?:pub(?:\([^)]+\))?\s+)?(?:async\s+)?(?:unsafe\s+)?(fn|struct|enum|trait|mod|type|const|static|union)\s+(\w+)/;
+
+const RUST_IMPL_RE = /^(?:unsafe\s+)?impl(?:\s*<[^>]+>)?\s+(?:[^{]+\s+for\s+)?(\w+)/;
+
+const MD_HEADING_RE = /^(#{1,6})\s+(.+?)\s*$/;
+
+const MD_FENCE_RE = /^```/;
+
+type Lang = "ts" | "py" | "go" | "rust" | "md";
+
+const EXT_TO_LANG: Record<string, Lang> = {
+  ".ts": "ts",
+  ".tsx": "ts",
+  ".mts": "ts",
+  ".cts": "ts",
+  ".js": "ts",
+  ".jsx": "ts",
+  ".mjs": "ts",
+  ".cjs": "ts",
+  ".py": "py",
+  ".pyi": "py",
+  ".go": "go",
+  ".rs": "rust",
+  ".md": "md",
+  ".markdown": "md",
+  ".mdx": "md",
+};
+
+export function extractOutline(filename: string, lines: readonly string[]): OutlineEntry[] {
+  const ext = pathMod.extname(filename).toLowerCase();
+  const lang = EXT_TO_LANG[ext];
+  if (!lang) return [];
+  switch (lang) {
+    case "ts":
+      return extractTs(lines);
+    case "py":
+      return extractPython(lines);
+    case "go":
+      return extractGo(lines);
+    case "rust":
+      return extractRust(lines);
+    case "md":
+      return extractMarkdown(lines);
+  }
+}
+
+function extractTs(lines: readonly string[]): OutlineEntry[] {
+  const out: OutlineEntry[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (!line.startsWith("export ")) continue;
+    const m = TS_EXPORT_RE.exec(line);
+    if (!m) continue;
+    out.push({ line: i + 1, text: `export ${m[1]} ${m[2]}` });
+  }
+  return out;
+}
+
+function extractPython(lines: readonly string[]): OutlineEntry[] {
+  const out: OutlineEntry[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (line.startsWith(" ") || line.startsWith("\t")) continue;
+    const m = PY_DECL_RE.exec(line);
+    if (!m) continue;
+    out.push({ line: i + 1, text: `${m[1]} ${m[2]}` });
+  }
+  return out;
+}
+
+function extractGo(lines: readonly string[]): OutlineEntry[] {
+  const out: OutlineEntry[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (line.startsWith(" ") || line.startsWith("\t")) continue;
+    const m = GO_DECL_RE.exec(line);
+    if (!m) continue;
+    out.push({ line: i + 1, text: `${m[1]} ${m[2]}` });
+  }
+  return out;
+}
+
+function extractRust(lines: readonly string[]): OutlineEntry[] {
+  const out: OutlineEntry[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (line.startsWith(" ") || line.startsWith("\t")) continue;
+    const implMatch = RUST_IMPL_RE.exec(line);
+    if (implMatch) {
+      out.push({ line: i + 1, text: `impl ${implMatch[1]}` });
+      continue;
+    }
+    const m = RUST_DECL_RE.exec(line);
+    if (!m) continue;
+    out.push({ line: i + 1, text: `${m[1]} ${m[2]}` });
+  }
+  return out;
+}
+
+function extractMarkdown(lines: readonly string[]): OutlineEntry[] {
+  const out: OutlineEntry[] = [];
+  let inFence = false;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (MD_FENCE_RE.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+    const m = MD_HEADING_RE.exec(line);
+    if (!m) continue;
+    out.push({ line: i + 1, text: `${m[1]} ${m[2]}` });
+  }
+  return out;
+}
+
+export function formatOutline(entries: readonly OutlineEntry[]): string {
+  const total = entries.length;
+  if (total === 0) return "";
+  const lastEntry = entries[total - 1]!;
+  const width = String(lastEntry.line).length;
+  const fmt = (e: OutlineEntry) => `  L${String(e.line).padStart(width, " ")}  ${e.text}`;
+  const header = `[outline: ${total} symbol${total === 1 ? "" : "s"}]`;
+  if (total <= OUTLINE_MAX_ENTRIES) {
+    return [header, ...entries.map(fmt)].join("\n");
+  }
+  const headCount = OUTLINE_MAX_ENTRIES - OUTLINE_TAIL_KEEP;
+  const headEntries = entries.slice(0, headCount);
+  const tailEntries = entries.slice(-OUTLINE_TAIL_KEEP);
+  const omitted = total - OUTLINE_MAX_ENTRIES;
+  const gapStart = headEntries[headEntries.length - 1]!.line;
+  const gapEnd = tailEntries[0]!.line;
+  return [
+    header,
+    ...headEntries.map(fmt),
+    `  [… ${omitted} more symbol${omitted === 1 ? "" : "s"} between L${gapStart} and L${gapEnd} …]`,
+    ...tailEntries.map(fmt),
+  ].join("\n");
+}

--- a/tests/filesystem-tools.test.ts
+++ b/tests/filesystem-tools.test.ts
@@ -114,7 +114,7 @@ describe("filesystem tools (built-in, sandbox-enforced)", () => {
       ].join("\n");
       await fs.writeFile(join(root, "App.tsx"), src);
       const out = await tools.dispatch("read_file", JSON.stringify({ path: "App.tsx" }));
-      expect(out).toMatch(/\[outline: 3 top-level exports\]/);
+      expect(out).toMatch(/\[outline: 3 symbols\]/);
       expect(out).toMatch(/L\s*4\s+export interface AppProps/);
       expect(out).toMatch(/L128\s+export function AppInner/);
       expect(out).toMatch(/L211\s+export const handleSubmit/);
@@ -140,7 +140,7 @@ describe("filesystem tools (built-in, sandbox-enforced)", () => {
       for (let i = 0; i < 60; i++) lines.push(`// trailer ${i}`);
       await fs.writeFile(join(root, "many.ts"), lines.join("\n"));
       const out = await tools.dispatch("read_file", JSON.stringify({ path: "many.ts" }));
-      const outlineMatch = /\[outline: 35 top-level exports\]([\s\S]*?)\n\n/.exec(out);
+      const outlineMatch = /\[outline: 35 symbols\]([\s\S]*?)\n\n/.exec(out);
       expect(outlineMatch).not.toBeNull();
       const outlineBlock = outlineMatch![1]!;
       expect(outlineBlock).toMatch(/export const sym01/);
@@ -151,7 +151,7 @@ describe("filesystem tools (built-in, sandbox-enforced)", () => {
       expect(outlineBlock).toMatch(/export const sym35/);
       const gapStart = exportPositions[24]!;
       const gapEnd = exportPositions[30]!;
-      expect(outlineBlock).toContain(`[… 5 more exports between L${gapStart} and L${gapEnd} …]`);
+      expect(outlineBlock).toContain(`[… 5 more symbols between L${gapStart} and L${gapEnd} …]`);
     });
 
     it("returns full content when file is at or below the auto-preview threshold", async () => {

--- a/tests/outline.test.ts
+++ b/tests/outline.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from "vitest";
+import { extractOutline, formatOutline } from "../src/tools/fs/outline.js";
+
+function lines(src: string): string[] {
+  return src.split(/\r?\n/);
+}
+
+describe("extractOutline", () => {
+  describe("TypeScript / JavaScript", () => {
+    it("captures top-level exports with kind + name", () => {
+      const src = lines(
+        [
+          "export function alpha() {}",
+          "export class Beta {}",
+          "export const gamma = 1;",
+          "export interface Delta {}",
+          "export type Epsilon = string;",
+          "export enum Zeta { A }",
+        ].join("\n"),
+      );
+      const out = extractOutline("foo.ts", src);
+      expect(out.map((e) => e.text)).toEqual([
+        "export function alpha",
+        "export class Beta",
+        "export const gamma",
+        "export interface Delta",
+        "export type Epsilon",
+        "export enum Zeta",
+      ]);
+    });
+
+    it("ignores indented (non-top-level) exports", () => {
+      const src = lines(
+        [
+          "class Outer {",
+          "  export function inner() {} // syntactically invalid but worth covering",
+          "}",
+        ].join("\n"),
+      );
+      expect(extractOutline("foo.ts", src)).toEqual([]);
+    });
+
+    it("handles tsx/jsx/mjs/cjs/mts/cts extensions", () => {
+      const src = lines("export const x = 1;");
+      for (const name of ["a.tsx", "a.jsx", "a.mjs", "a.cjs", "a.mts", "a.cts", "a.js"]) {
+        const out = extractOutline(name, src);
+        expect(out, name).toHaveLength(1);
+        expect(out[0]!.text).toBe("export const x");
+      }
+    });
+  });
+
+  describe("Python", () => {
+    it("captures top-level def and class", () => {
+      const src = lines(
+        [
+          "def foo():",
+          "    pass",
+          "",
+          "class Bar:",
+          "    def method(self):",
+          "        pass",
+          "",
+          "async def baz():",
+          "    pass",
+        ].join("\n"),
+      );
+      const out = extractOutline("a.py", src);
+      expect(out).toEqual([
+        { line: 1, text: "def foo" },
+        { line: 4, text: "class Bar" },
+        { line: 8, text: "def baz" },
+      ]);
+    });
+
+    it("skips indented methods inside a class", () => {
+      const src = lines("class Foo:\n    def method(self):\n        pass");
+      const out = extractOutline("a.py", src);
+      expect(out).toEqual([{ line: 1, text: "class Foo" }]);
+    });
+  });
+
+  describe("Go", () => {
+    it("captures top-level func/type/var/const", () => {
+      const src = lines(
+        [
+          "package main",
+          "",
+          "func Foo() {}",
+          "type Bar struct {}",
+          "var Baz = 1",
+          "const Qux = 2",
+          "",
+          "func (r *Bar) Method() {}",
+        ].join("\n"),
+      );
+      const out = extractOutline("a.go", src);
+      expect(out.map((e) => e.text)).toEqual([
+        "func Foo",
+        "type Bar",
+        "var Baz",
+        "const Qux",
+        "func Method",
+      ]);
+    });
+  });
+
+  describe("Rust", () => {
+    it("captures top-level fn, struct, enum, trait, mod, type, const, static", () => {
+      const src = lines(
+        [
+          "pub fn foo() {}",
+          "fn bar() {}",
+          "struct Baz;",
+          "pub struct Qux { x: i32 }",
+          "enum Variant { A, B }",
+          "trait MyTrait {}",
+          "mod nested {}",
+          "type Alias = u32;",
+          "const C: u32 = 1;",
+          "static S: u32 = 2;",
+          "pub async unsafe fn raw() {}",
+        ].join("\n"),
+      );
+      const out = extractOutline("a.rs", src);
+      expect(out.map((e) => e.text)).toEqual([
+        "fn foo",
+        "fn bar",
+        "struct Baz",
+        "struct Qux",
+        "enum Variant",
+        "trait MyTrait",
+        "mod nested",
+        "type Alias",
+        "const C",
+        "static S",
+        "fn raw",
+      ]);
+    });
+
+    it("captures impl blocks with their target type", () => {
+      const src = lines(
+        [
+          "impl Foo {",
+          "  pub fn new() -> Self {}",
+          "}",
+          "impl<T> Bar<T> {}",
+          "impl Display for Foo {}",
+        ].join("\n"),
+      );
+      const out = extractOutline("a.rs", src);
+      expect(out.map((e) => e.text)).toEqual(["impl Foo", "impl Bar", "impl Foo"]);
+    });
+  });
+
+  describe("Markdown", () => {
+    it("captures headings at all levels", () => {
+      const src = lines(["# Top", "", "## Sub", "", "### Sub-sub", "", "#### Deeper"].join("\n"));
+      const out = extractOutline("a.md", src);
+      expect(out).toEqual([
+        { line: 1, text: "# Top" },
+        { line: 3, text: "## Sub" },
+        { line: 5, text: "### Sub-sub" },
+        { line: 7, text: "#### Deeper" },
+      ]);
+    });
+
+    it("skips headings inside fenced code blocks", () => {
+      const src = lines(
+        ["# Real heading", "", "```", "# Not a heading", "```", "", "## Also real"].join("\n"),
+      );
+      const out = extractOutline("a.md", src);
+      expect(out).toEqual([
+        { line: 1, text: "# Real heading" },
+        { line: 7, text: "## Also real" },
+      ]);
+    });
+  });
+
+  describe("unknown extensions", () => {
+    it("returns empty outline for unsupported file types", () => {
+      const src = lines("function not_recognized() {}");
+      expect(extractOutline("a.txt", src)).toEqual([]);
+      expect(extractOutline("a.yml", src)).toEqual([]);
+      expect(extractOutline("Makefile", src)).toEqual([]);
+    });
+  });
+});
+
+describe("formatOutline", () => {
+  it("returns empty string for empty entries", () => {
+    expect(formatOutline([])).toBe("");
+  });
+
+  it("formats single-entry outline without elision", () => {
+    const result = formatOutline([{ line: 5, text: "def foo" }]);
+    expect(result).toBe("[outline: 1 symbol]\n  L5  def foo");
+  });
+
+  it("singularises header for one entry, pluralises otherwise", () => {
+    expect(formatOutline([{ line: 1, text: "a" }])).toMatch(/^\[outline: 1 symbol\]/);
+    expect(
+      formatOutline([
+        { line: 1, text: "a" },
+        { line: 2, text: "b" },
+      ]),
+    ).toMatch(/^\[outline: 2 symbols\]/);
+  });
+
+  it("right-pads line numbers to the widest entry", () => {
+    const result = formatOutline([
+      { line: 5, text: "a" },
+      { line: 123, text: "b" },
+    ]);
+    // 'L  5' aligned under 'L123' — pad is to 3-wide.
+    expect(result).toContain("L  5  a");
+    expect(result).toContain("L123  b");
+  });
+
+  it("elides middle entries when over the 30-entry cap", () => {
+    const entries = Array.from({ length: 35 }, (_, i) => ({
+      line: i + 1,
+      text: `sym${i + 1}`,
+    }));
+    const result = formatOutline(entries);
+    expect(result).toMatch(/^\[outline: 35 symbols\]/);
+    expect(result).toContain("sym1");
+    expect(result).toContain("sym25");
+    expect(result).not.toContain("sym26");
+    expect(result).not.toContain("sym30");
+    expect(result).toContain("sym31");
+    expect(result).toContain("sym35");
+    expect(result).toContain("[… 5 more symbols between L25 and L31 …]");
+  });
+});


### PR DESCRIPTION
## Summary

The `read_file` auto-preview's symbol outline was TS-only. Any non-TS file longer than 200 lines fell into the preview path with no navigation map — just head 80 + tail 40 and an opaque "N lines omitted" marker. The model had no anchor for a follow-up `range:` read, so for Python / Go / Rust / Markdown files the "scope your read" workflow silently broke past the threshold and the model either guessed or full-read.

This PR adds per-language regex extractors dispatched on extension:

- **TS/JS/TSX/MJS/CJS** — existing top-level export logic (parity preserved)
- **Python** — top-level `def` / `class`, indent-sensitive so methods inside a class are skipped
- **Go** — top-level `func` / `type` / `var` / `const`; methods captured by name
- **Rust** — `fn` / `struct` / `enum` / `trait` / `impl` / `mod` / `type` / `const` / `static`; `impl` block target type extracted including `impl<T>` and `impl Trait for X`
- **Markdown** — headings at all levels, fenced code blocks ignored

Outline module lives in `src/tools/fs/outline.ts`. Header wording changes from `[outline: N top-level exports]` to `[outline: N symbols]` so it fits all languages; elision text follows. TS per-entry shape is unchanged (`export function foo`, etc).

## Why regex, not tree-sitter

Considered tree-sitter for AST-grade precision but the published WASM parsers run 5–50MB each — too much install weight for a "show me the top-level symbols" feature that regex covers ~95% of cases on. Tree-sitter stays a viable upgrade path if the regex extractors start hitting precision limits in real use.

## Test plan

- [x] `tests/outline.test.ts` — 16 cases covering all five languages plus `formatOutline` boundary behaviour (empty, single, plural header, line-number padding, 30-entry elision)
- [x] `tests/filesystem-tools.test.ts` updated for the new "N symbols" wording; existing TS outline coverage unchanged otherwise
- [x] `npm run verify` green (2795 passed, 2 skipped)