### PR TITLE
fix(desktop): drop stale literals from preset, plan badge, tool card

### DIFF
--- a/desktop/src/ui/cards.tsx
+++ b/desktop/src/ui/cards.tsx
@@ -64,8 +64,17 @@ export type PlanItem = {
   note?: string;
 };
 
+function derivePlanBadge(items: PlanItem[]): { cls: "run" | "ok" | "warn" | "err"; label: string } {
+  if (items.some((x) => x.status === "failed")) return { cls: "err", label: "失败" };
+  if (items.some((x) => x.status === "blocked")) return { cls: "warn", label: "阻塞" };
+  if (items.some((x) => x.status === "active")) return { cls: "run", label: "运行中" };
+  if (items.length > 0 && items.every((x) => x.status === "done")) return { cls: "ok", label: "已完成" };
+  return { cls: "run", label: "待开始" };
+}
+
 export function PlanCardView({ items, title = "计划" }: { items: PlanItem[]; title?: string }) {
   const done = items.filter((x) => x.status === "done").length;
+  const badge = derivePlanBadge(items);
   return (
     <Card
       tone="accent"
@@ -77,7 +86,7 @@ export function PlanCardView({ items, title = "计划" }: { items: PlanItem[]; t
           <span>
             {done}/{items.length}
           </span>
-          <span className="pill-tag run">运行中</span>
+          <span className={`pill-tag ${badge.cls}`}>{badge.label}</span>
         </>
       }
     >

--- a/desktop/src/ui/live.tsx
+++ b/desktop/src/ui/live.tsx
@@ -144,11 +144,6 @@ export function ToolRunningCard({
         <span className="pill-tag run">running</span>
         <span className="timer">{fmtElapsed(elapsedMs)}</span>
       </div>
-      <div className="body">
-        <div className="skel-line w-90" />
-        <div className="skel-line w-70" />
-        <div className="skel-line w-60" />
-      </div>
       {logLines && logLines.length > 0 ? (
         <div className="live-log">
           {logLines.map((ln, i) => (
@@ -161,7 +156,13 @@ export function ToolRunningCard({
             </div>
           ))}
         </div>
-      ) : null}
+      ) : (
+        <div className="body">
+          <div className="skel-line w-90" />
+          <div className="skel-line w-70" />
+          <div className="skel-line w-60" />
+        </div>
+      )}
     </div>
   );
 }

--- a/desktop/src/ui/settings.tsx
+++ b/desktop/src/ui/settings.tsx
@@ -295,8 +295,6 @@ function PageModels({
       desc: "自动从 flash 起步，遇复杂任务升级到 pro，兼顾速度与质量。",
       ctx: "—",
       out: "—",
-      speed: "—",
-      bench: "动态",
     },
     {
       id: "flash" as const,
@@ -305,8 +303,6 @@ function PageModels({
       desc: "通用对话模型，速度快、长上下文、价格友好。",
       ctx: "1M",
       out: "8K",
-      speed: "180 t/s",
-      bench: "MMLU 88.5",
     },
     {
       id: "pro" as const,
@@ -315,8 +311,6 @@ function PageModels({
       desc: "深度推理模型，先生成可解释的思考链，再给最终答案。",
       ctx: "1M",
       out: "32K",
-      speed: "84 t/s",
-      bench: "AIME 79.8",
     },
   ];
   return (
@@ -343,14 +337,6 @@ function PageModels({
               <div>
                 <span className="k">输出 </span>
                 <span className="v">{m.out}</span>
-              </div>
-              <div>
-                <span className="k">速度 </span>
-                <span className="v">{m.speed}</span>
-              </div>
-              <div>
-                <span className="k">基准 </span>
-                <span className="v">{m.bench}</span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary

Three small desktop UI surfaces showed values that looked dynamic but were actually frozen at build time or hardcoded:

1. **Model preset cards** (`src/ui/settings.tsx`) — the `speed` (`180 t/s` / `84 t/s`) and `bench` (`MMLU 88.5` / `AIME 79.8`) rows were build-time literals sitting right next to the contractual `ctx` / `out` caps, so users read all four as authoritative model metadata. Dropped both rows; `ctx` + `out` stay because those *are* contract.
2. **PlanCardView badge** (`src/ui/cards.tsx`) — the "运行中" pill rendered unconditionally, so a plan with every step `done` still flashed "running". Extracted `derivePlanBadge` to fold items into err / warn / run / ok / run for failed / blocked / active / all-done / todo respectively, reusing the existing `.pill-tag` color variants in `styles.css`.
3. **ToolRunningCard skeleton** (`src/ui/live.tsx`) — three `skel-line` placeholders rendered above the real `live-log` when both existed, so the user saw a fake gradient stack glued on top of actual streaming output. Moved skeleton into the else branch so it only shows when there is nothing real yet.

## Why now

While auditing the desktop UI for residual fake/stub displays, these three were the only items that ship visibly to every user (model settings page on first launch, plan card during any plan run, tool card during any tool call). There are also several orphan card components in `extra-cards.tsx` (`UsageFull`, `DoctorCard`, `MemoryGroups`, etc.) that have visual designs but no parent renderer — those are a separate, larger wire-up effort and aren't part of this PR.

## Test plan

- [x] `npm run verify` — 2,795 tests pass, lint + typecheck + build green
- [x] `cd desktop && npm run build` — desktop bundle builds clean
- [x] Preset cards now render 2 spec rows (ctx, out) instead of 4
- [x] Plan badge flips to "已完成 / ok" when every step is done; stays "运行中" only with an active step
- [x] Tool card skeleton hidden as soon as the first log line arrives