### PR TITLE
chore: oosmetrics badges + weekly health-check workflow

### DIFF
--- a/.github/workflows/oosmetrics.yml
+++ b/.github/workflows/oosmetrics.yml
@@ -1,0 +1,17 @@
+name: oosmetrics Health Check
+
+on:
+  schedule:
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: oosmetrics/health-check-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@
   <a href="https://github.com/esengine/reasonix/discussions"><img src="https://img.shields.io/github/discussions/esengine/reasonix.svg?style=flat-square&color=58a6ff&labelColor=161b22&logo=github&logoColor=white" alt="Discussions"/></a>
 </p>
 
+<p align="center">
+  <a href="https://oosmetrics.com/repo/esengine/reasonix"><img src="https://api.oosmetrics.com/api/v1/badge/achievement/9e931d80-2050-4b10-902e-44970cc133ad.svg" alt="oosmetrics — Top 2 in Agents by velocity"/></a>
+  <a href="https://oosmetrics.com/repo/esengine/reasonix"><img src="https://api.oosmetrics.com/api/v1/badge/achievement/556d94b3-61b7-486b-baf2-888b9327deab.svg" alt="oosmetrics — Top 3 in LLMs by velocity"/></a>
+  <a href="https://oosmetrics.com/repo/esengine/reasonix"><img src="https://api.oosmetrics.com/api/v1/badge/achievement/0f457d4c-efca-4d15-ad2b-139691ff342c.svg" alt="oosmetrics — Top 3 in CLI by velocity"/></a>
+</p>
+
 <br/>
 
 <h3 align="center">A DeepSeek-native AI coding agent for your terminal.</h3>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -27,6 +27,12 @@
   <a href="https://github.com/esengine/reasonix/discussions"><img src="https://img.shields.io/github/discussions/esengine/reasonix.svg?style=flat-square&color=58a6ff&labelColor=161b22&logo=github&logoColor=white" alt="Discussions"/></a>
 </p>
 
+<p align="center">
+  <a href="https://oosmetrics.com/repo/esengine/reasonix"><img src="https://api.oosmetrics.com/api/v1/badge/achievement/9e931d80-2050-4b10-902e-44970cc133ad.svg" alt="oosmetrics — Agents 速度榜 Top 2"/></a>
+  <a href="https://oosmetrics.com/repo/esengine/reasonix"><img src="https://api.oosmetrics.com/api/v1/badge/achievement/556d94b3-61b7-486b-baf2-888b9327deab.svg" alt="oosmetrics — LLMs 速度榜 Top 3"/></a>
+  <a href="https://oosmetrics.com/repo/esengine/reasonix"><img src="https://api.oosmetrics.com/api/v1/badge/achievement/0f457d4c-efca-4d15-ad2b-139691ff342c.svg" alt="oosmetrics — CLI 速度榜 Top 3"/></a>
+</p>
+
 <br/>
 
 <h3 align="center">DeepSeek 原生的终端 AI 编程代理。</h3>


### PR DESCRIPTION
## Summary

We just landed in oosmetrics' weekly rankings (7-day velocity, as of 2026-05-12):

- **#2 in Agents**
- **#3 in LLMs**
- **#3 in CLI**

Three additions:

1. **README badges** — three achievement badges added as a second `<p align="center">` row under the existing build/license block, in both `README.md` and `README.zh-CN.md`. Each links back to `oosmetrics.com/repo/esengine/reasonix`.
2. **Health-check workflow** — `.github/workflows/oosmetrics.yml`, runs `oosmetrics/health-check-action@v1` weekly (Monday 09:00 UTC) plus `workflow_dispatch`. Opens an issue summarising rank changes and any new achievements. Uses only the default `GITHUB_TOKEN` with `issues: write` — no secret to configure.
3. No code changes; nothing in this PR affects runtime behaviour.

## Test plan

- [x] Both READMEs render the badge row in GitHub preview
- [x] Badge image URLs return SVG (`api.oosmetrics.com/api/v1/badge/achievement/<uuid>.svg`)
- [x] Workflow file passes YAML lint (no required schema beyond GitHub's parser)
- [ ] First scheduled run lands an issue next Monday — we'll see it then