### PR TITLE
fix(preset): don't clobber persisted reasoningEffort on preset switch

### DIFF
--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -585,6 +585,7 @@ function mintSessionFor(rootDir: string): string {
 function buildRuntimeFor(tab: Tab): RuntimeState {
   const client = new DeepSeekClient({ baseUrl: loadBaseUrl() });
   const prefix = new ImmutablePrefix({ system: tab.system, toolSpecs: tab.toolset.tools.specs() });
+  const reasoningEffort = loadReasoningEffort();
   const loop = new CacheFirstLoop({
     client,
     prefix,
@@ -592,8 +593,8 @@ function buildRuntimeFor(tab: Tab): RuntimeState {
     model: tab.currentModel,
     budgetUsd: tab.budgetUsd,
     session: tab.currentSession,
+    reasoningEffort,
   });
-  const reasoningEffort = loadReasoningEffort();
   const eventizer = new Eventizer();
   const ctx = { model: tab.currentModel, prefixHash: prefix.fingerprint, reasoningEffort };
   return { loop, eventizer, ctx };
@@ -1270,7 +1271,6 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
           const resolved = resolvePreset(tab.currentPreset);
           tab.currentModel = resolved.model;
           savePreset(tab.currentPreset);
-          saveReasoningEffort(resolved.reasoningEffort);
           tab.system = codeSystemPrompt(tab.rootDir, {
             hasSemanticSearch: tab.toolset.semantic.enabled,
             modelId: tab.currentModel,

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -44,7 +44,6 @@ import {
   resolveThemePreference,
   saveEditMode,
   savePreset,
-  saveReasoningEffort,
   saveTheme,
 } from "../../config.js";
 import { Eventizer } from "../../core/eventize.js";
@@ -3971,7 +3970,6 @@ function AppInner({
                           preset: outcome.name,
                         });
                         try {
-                          saveReasoningEffort(p.reasoningEffort);
                           savePreset(outcome.name);
                         } catch {
                           /* disk full / perms — runtime change still took effect */

--- a/src/cli/ui/slash/handlers/model.ts
+++ b/src/cli/ui/slash/handlers/model.ts
@@ -1,4 +1,4 @@
-import { savePreset, saveReasoningEffort } from "@/config.js";
+import { savePreset } from "@/config.js";
 import { t } from "@/i18n/index.js";
 import { PRESETS } from "../../presets.js";
 import type { SlashHandler } from "../dispatch.js";
@@ -50,7 +50,6 @@ const preset: SlashHandler = (args, loop, ctx) => {
     ctx.dispatch?.({ type: "session.model.change", model: p.model });
     ctx.dispatch?.({ type: "session.preset.change", preset: presetName });
     try {
-      saveReasoningEffort(p.reasoningEffort);
       savePreset(presetName);
     } catch {
       /* disk full / perms — runtime change still took effect */

--- a/tests/preset-effort-isolation.test.ts
+++ b/tests/preset-effort-isolation.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import { handleSlash } from "../src/cli/ui/slash.js";
+import { DeepSeekClient } from "../src/client.js";
+import { savePreset, saveReasoningEffort } from "../src/config.js";
+import { CacheFirstLoop } from "../src/loop.js";
+import { ImmutablePrefix } from "../src/memory/runtime.js";
+
+vi.mock("../src/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/config.js")>();
+  return {
+    ...actual,
+    saveReasoningEffort: vi.fn(),
+    savePreset: vi.fn(),
+  };
+});
+
+function makeLoop() {
+  const client = new DeepSeekClient({
+    apiKey: "sk-test",
+    fetch: vi.fn() as unknown as typeof fetch,
+  });
+  return new CacheFirstLoop({
+    client,
+    prefix: new ImmutablePrefix({ system: "s" }),
+  });
+}
+
+describe("/preset apply — issue #770", () => {
+  it("does not write reasoningEffort to disk when switching preset", () => {
+    vi.mocked(saveReasoningEffort).mockClear();
+    vi.mocked(savePreset).mockClear();
+    for (const name of ["auto", "flash", "pro"] as const) {
+      handleSlash("preset", [name], makeLoop());
+    }
+    expect(saveReasoningEffort).not.toHaveBeenCalled();
+    expect(vi.mocked(savePreset).mock.calls.map((c) => c[0])).toEqual(["auto", "flash", "pro"]);
+  });
+
+  it("still flips the live loop's reasoningEffort when preset is applied", () => {
+    vi.mocked(saveReasoningEffort).mockClear();
+    vi.mocked(savePreset).mockClear();
+    const loop = makeLoop();
+    handleSlash("preset", ["pro"], loop);
+    expect(loop.model).toBe("deepseek-v4-pro");
+    expect(loop.reasoningEffort).toBe("max");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #770 — reasoning effort silently reverting to `max` after each update / preset interaction.

The update flow wasn't the cause. The real bug: every preset-apply path called `saveReasoningEffort(preset.reasoningEffort)` to disk, and all three canonical presets bundle `reasoningEffort: "max"`. So any click on a preset card in the desktop app, any `/preset` slash, or any ModelPicker outcome stamped `"max"` over whatever the user had stored — most often the user then re-opened the dashboard to set `"high"`, only to see it reset on the next preset interaction.

### Changes

| File | What |
|---|---|
| `src/cli/ui/slash/handlers/model.ts` | `apply()` no longer calls `saveReasoningEffort`. Live `loop.configure({ reasoningEffort })` stays so the preset's bundle still affects the current session. |
| `src/cli/ui/App.tsx` | ModelPicker outcome handler: same removal + drops the now-unused import. |
| `src/cli/commands/desktop.ts` | `settings_save` with `preset` field: same removal. Also: `buildRuntimeFor` was reading `loadReasoningEffort()` for `ctx` but never passing it to the `CacheFirstLoop` constructor, so the desktop runtime loop ignored the persisted value entirely — fixed by passing through. |

Persistence of `reasoningEffort` is now user-driven only (the dashboard effort dropdown remains the explicit source). Next-launch `loadReasoningEffort()` returns the stored choice instead of the silently-rewritten preset default.

### Test plan

- [x] `tests/preset-effort-isolation.test.ts` — mocks `saveReasoningEffort` / `savePreset` and asserts the slash handler calls `savePreset` but never `saveReasoningEffort`, while `loop.reasoningEffort` still flips to the preset's bundle value.
- [x] `npm run verify` green — 2,804 passed (was 2,795 before adding the new tests + the run.ts changes).
- [x] Existing `/preset auto/flash/pro` live-loop tests in `tests/slash.test.ts` still pass — the live effort apply is unchanged.

Closes #770.