### PR TITLE
feat(acp): --mcp + --mcp-prefix for headless callers

### DIFF
--- a/src/cli/commands/acp.ts
+++ b/src/cli/commands/acp.ts
@@ -23,16 +23,30 @@ import {
 import { AcpServer } from "../../acp/server.js";
 import { codeSystemPrompt } from "../../code/prompt.js";
 import { buildCodeToolset } from "../../code/setup.js";
-import { loadApiKey, loadBaseUrl, loadPreset, loadReasoningEffort } from "../../config.js";
+import {
+  loadApiKey,
+  loadBaseUrl,
+  loadPreset,
+  loadReasoningEffort,
+  mcpEnvFor,
+  readConfig,
+} from "../../config.js";
 import { loadEditMode } from "../../config.js";
 import { Eventizer } from "../../core/eventize.js";
 import { pauseGate } from "../../core/pause-gate.js";
 import { autoResolveVerdict } from "../../core/pause-policy.js";
 import { loadDotenv } from "../../env.js";
 import { CacheFirstLoop, DeepSeekClient, ImmutablePrefix } from "../../index.js";
+import { McpClient } from "../../mcp/client.js";
+import { preflightStdioSpec } from "../../mcp/preflight.js";
+import { bridgeMcpTools } from "../../mcp/registry.js";
+import { parseMcpSpec } from "../../mcp/spec.js";
+import { buildTransportFromSpec } from "../../mcp/transport-from-spec.js";
 import { timestampSuffix } from "../../memory/session.js";
 import { openTranscriptFile, recordFromLoopEvent, writeRecord } from "../../transcript/log.js";
 import { VERSION } from "../../version.js";
+import { formatMcpLifecycleEvent } from "../ui/mcp-lifecycle.js";
+import { formatMcpSlowToast } from "../ui/mcp-toast.js";
 import { canonicalPresetName, resolvePreset } from "../ui/presets.js";
 
 export interface AcpOptions {
@@ -41,6 +55,10 @@ export interface AcpOptions {
   budgetUsd?: number;
   transcript?: string;
   yolo?: boolean;
+  /** Zero or more MCP server specs. Each: `"name=cmd args..."` or `"cmd args..."`. */
+  mcpSpecs?: string[];
+  /** Global prefix — only honored when a single anonymous server is given. */
+  mcpPrefix?: string;
 }
 
 interface Session {
@@ -48,10 +66,76 @@ interface Session {
   rootDir: string;
   model: string;
   toolset: Awaited<ReturnType<typeof buildCodeToolset>>;
+  mcpClients: McpClient[];
   loop: CacheFirstLoop;
   eventizer: Eventizer;
   ctx: { model: string; prefixHash: string; reasoningEffort: "high" | "max" };
   aborter: AbortController | null;
+}
+
+function resolveMcpPrefix(
+  specName: string | null | undefined,
+  specCount: number,
+  globalPrefix: string | undefined,
+): string {
+  if (specName) return `${specName}_`;
+  if (specCount === 1 && globalPrefix) return globalPrefix;
+  return "";
+}
+
+// Mirrors run.ts:81-142.
+export async function loadMcpServers(
+  tools: import("../../tools.js").ToolRegistry,
+  specs: string[],
+  globalPrefix: string | undefined,
+): Promise<McpClient[]> {
+  const clients: McpClient[] = [];
+  if (specs.length === 0) return clients;
+  const cfg = readConfig();
+  const disabledNames = new Set(cfg.mcpDisabled ?? []);
+  for (const raw of specs) {
+    let label = "anon";
+    let mcp: McpClient | undefined;
+    try {
+      const spec = parseMcpSpec(raw);
+      label = spec.name ?? "anon";
+      if (spec.name && disabledNames.has(spec.name)) {
+        process.stderr.write(`${formatMcpLifecycleEvent({ state: "disabled", name: label })}\n`);
+        continue;
+      }
+      process.stderr.write(`${formatMcpLifecycleEvent({ state: "handshake", name: label })}\n`);
+      const t0 = Date.now();
+      const prefix = resolveMcpPrefix(spec.name, specs.length, globalPrefix);
+      if (spec.transport === "stdio") preflightStdioSpec(spec);
+      const transport = buildTransportFromSpec(spec, { env: mcpEnvFor(spec.name, cfg) });
+      mcp = new McpClient({ transport });
+      await mcp.initialize();
+      const bridge = await bridgeMcpTools(mcp, {
+        registry: tools,
+        namePrefix: prefix,
+        serverName: label,
+        onSlow: (info) =>
+          process.stderr.write(
+            `${formatMcpSlowToast({ name: info.serverName, p95Ms: info.p95Ms, sampleSize: info.sampleSize })}\n`,
+          ),
+      });
+      process.stderr.write(
+        `${formatMcpLifecycleEvent({
+          state: "connected",
+          name: label,
+          tools: bridge.registeredNames.length,
+          ms: Date.now() - t0,
+        })}\n`,
+      );
+      clients.push(mcp);
+    } catch (err) {
+      await mcp?.close().catch(() => undefined);
+      process.stderr.write(
+        `${formatMcpLifecycleEvent({ state: "failed", name: label, reason: (err as Error).message })}\n  → run \`reasonix setup\` to remove broken entries from your saved config.\n`,
+      );
+    }
+  }
+  return clients;
 }
 
 function resolveDir(raw: string | undefined, fallback: string): string {
@@ -67,11 +151,15 @@ async function buildSession(opts: {
   rootDir: string;
   modelOverride?: string;
   budgetUsd?: number;
+  mcpSpecs?: string[];
+  mcpPrefix?: string;
 }): Promise<Session> {
   const preset = canonicalPresetName(loadPreset());
   const resolved = resolvePreset(preset);
   const model = opts.modelOverride || resolved.model;
   const toolset = await buildCodeToolset({ rootDir: opts.rootDir });
+  // Bridge MCP tools BEFORE building the prefix so their specs make it into the cache key.
+  const mcpClients = await loadMcpServers(toolset.tools, opts.mcpSpecs ?? [], opts.mcpPrefix);
   const system = codeSystemPrompt(opts.rootDir, {
     hasSemanticSearch: toolset.semantic.enabled,
     modelId: model,
@@ -91,6 +179,7 @@ async function buildSession(opts: {
     rootDir: opts.rootDir,
     model,
     toolset,
+    mcpClients,
     loop,
     eventizer: new Eventizer(),
     ctx: {
@@ -164,6 +253,8 @@ export async function acpCommand(opts: AcpOptions): Promise<void> {
       rootDir,
       modelOverride: opts.model,
       budgetUsd: opts.budgetUsd,
+      mcpSpecs: opts.mcpSpecs,
+      mcpPrefix: opts.mcpPrefix,
     });
     sessions.set(session.id, session);
     return { sessionId: session.id };
@@ -235,5 +326,13 @@ export async function acpCommand(opts: AcpOptions): Promise<void> {
     await server.done();
   } finally {
     transcriptStream?.end();
+    // Tear down MCP children so spawned servers don't outlive the agent.
+    const closes: Promise<unknown>[] = [];
+    for (const session of sessions.values()) {
+      for (const mcp of session.mcpClients) {
+        closes.push(mcp.close().catch(() => undefined));
+      }
+    }
+    await Promise.all(closes);
   }
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -322,10 +322,17 @@ program
     "--yolo",
     "auto-approve plan checkpoints for this invocation (equivalent to editMode=yolo without mutating config)",
   )
+  .option(
+    "--mcp <spec>",
+    t("ui.mcpSpecHintShort"),
+    (value: string, previous: string[] = []) => [...previous, value],
+    [] as string[],
+  )
+  .option("--mcp-prefix <str>", t("ui.mcpPrefixHintShort"))
   .action(async (opts) => {
     const defaults = resolveDefaults({
       model: opts.model,
-      mcp: [],
+      mcp: opts.mcp as string[],
       preset: opts.preset,
       noConfig: false,
     });
@@ -336,6 +343,8 @@ program
       dir: opts.dir,
       transcript: opts.transcript,
       yolo: !!opts.yolo,
+      mcpSpecs: defaults.mcp,
+      mcpPrefix: opts.mcpPrefix,
     });
   });
 

--- a/tests/acp-mcp.test.ts
+++ b/tests/acp-mcp.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const initializeMock = vi.fn(async () => undefined);
+  const closeMock = vi.fn(async () => undefined);
+  const bridgeMock = vi.fn(async (_client: unknown, opts: { namePrefix?: string }) => ({
+    registeredNames: [`${opts.namePrefix ?? ""}echo`],
+  }));
+  const preflightMock = vi.fn(() => undefined);
+  const readConfigMock = vi.fn(() => ({ mcpDisabled: [] as string[] }));
+
+  class FakeMcpClient {
+    async initialize() {
+      return initializeMock();
+    }
+    async close() {
+      return closeMock();
+    }
+  }
+  class FakeTransport {}
+  return {
+    initializeMock,
+    closeMock,
+    bridgeMock,
+    preflightMock,
+    readConfigMock,
+    FakeMcpClient,
+    FakeTransport,
+  };
+});
+
+vi.mock("../src/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/config.js")>();
+  return {
+    ...actual,
+    readConfig: mocks.readConfigMock,
+    mcpEnvFor: () => ({}),
+  };
+});
+
+vi.mock("../src/mcp/client.js", () => ({
+  McpClient: mocks.FakeMcpClient,
+}));
+
+vi.mock("../src/mcp/registry.js", () => ({
+  bridgeMcpTools: mocks.bridgeMock,
+}));
+
+vi.mock("../src/mcp/preflight.js", () => ({
+  preflightStdioSpec: mocks.preflightMock,
+}));
+
+vi.mock("../src/mcp/transport-from-spec.js", () => ({
+  buildTransportFromSpec: () => new mocks.FakeTransport(),
+}));
+
+describe("acp --mcp loader", () => {
+  afterEach(() => {
+    mocks.initializeMock.mockReset();
+    mocks.closeMock.mockReset();
+    mocks.bridgeMock.mockReset();
+    mocks.preflightMock.mockReset();
+    mocks.readConfigMock.mockReset();
+    mocks.readConfigMock.mockReturnValue({ mcpDisabled: [] });
+    mocks.initializeMock.mockImplementation(async () => undefined);
+    mocks.bridgeMock.mockImplementation(async (_c: unknown, opts: { namePrefix?: string }) => ({
+      registeredNames: [`${opts.namePrefix ?? ""}echo`],
+    }));
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  });
+
+  async function callLoader(specs: string[], prefix?: string) {
+    vi.resetModules();
+    const { loadMcpServers } = await import("../src/cli/commands/acp.js");
+    const { ToolRegistry } = await import("../src/tools.js");
+    const tools = new ToolRegistry();
+    const clients = await loadMcpServers(tools, specs, prefix);
+    return { clients, tools };
+  }
+
+  it("bridges every spec with its name as the tool prefix", async () => {
+    const { clients } = await callLoader(["fs=cmd1 a", "db=cmd2 b"]);
+    expect(clients).toHaveLength(2);
+    expect(mocks.initializeMock).toHaveBeenCalledTimes(2);
+    expect(mocks.bridgeMock).toHaveBeenCalledTimes(2);
+    const prefixes = mocks.bridgeMock.mock.calls.map(
+      ([, opts]) => (opts as { namePrefix: string }).namePrefix,
+    );
+    expect(prefixes).toEqual(["fs_", "db_"]);
+  });
+
+  it("honors --mcp-prefix only for a single anonymous spec", async () => {
+    const { clients } = await callLoader(["cmd1 a"], "pp_");
+    expect(clients).toHaveLength(1);
+    const opts = mocks.bridgeMock.mock.calls[0]?.[1] as { namePrefix: string };
+    expect(opts.namePrefix).toBe("pp_");
+  });
+
+  it("ignores --mcp-prefix when multiple specs are passed", async () => {
+    await callLoader(["a=cmd1", "cmd2"], "pp_");
+    const calls = mocks.bridgeMock.mock.calls.map(
+      ([, opts]) => (opts as { namePrefix: string }).namePrefix,
+    );
+    // Named spec uses its own prefix; anonymous one falls back to "" because multi-spec disables the global prefix.
+    expect(calls).toEqual(["a_", ""]);
+  });
+
+  it("skips servers listed in config.mcpDisabled", async () => {
+    mocks.readConfigMock.mockReturnValue({ mcpDisabled: ["fs"] });
+    const { clients } = await callLoader(["fs=cmd1", "db=cmd2"]);
+    expect(clients).toHaveLength(1);
+    expect(mocks.initializeMock).toHaveBeenCalledTimes(1);
+    const opts = mocks.bridgeMock.mock.calls[0]?.[1] as { serverName: string };
+    expect(opts.serverName).toBe("db");
+  });
+
+  it("is non-fatal on initialize failure (logs + continues)", async () => {
+    mocks.initializeMock
+      .mockImplementationOnce(async () => {
+        throw new Error("spawn ENOENT");
+      })
+      .mockImplementationOnce(async () => undefined);
+    const { clients } = await callLoader(["bad=cmd1", "good=cmd2"]);
+    expect(clients).toHaveLength(1);
+    expect(mocks.closeMock).toHaveBeenCalledTimes(1); // bad client closed after failure
+  });
+
+  it("is non-fatal on malformed spec (parse error)", async () => {
+    const { clients } = await callLoader(["fs=", "good=cmd2"]);
+    expect(clients).toHaveLength(1);
+    const opts = mocks.bridgeMock.mock.calls[0]?.[1] as { serverName: string };
+    expect(opts.serverName).toBe("good");
+  });
+
+  it("returns [] when no specs are passed (no work done)", async () => {
+    const { clients } = await callLoader([]);
+    expect(clients).toEqual([]);
+    expect(mocks.bridgeMock).not.toHaveBeenCalled();
+    expect(mocks.initializeMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `--mcp <spec>` (repeatable) and `--mcp-prefix <str>` to `reasonix acp`, lifting the spec/transport/bridge logic from `run.ts:81-142` into a shared `loadMcpServers` helper.
- MCP tools are bridged into the toolset registry **before** `ImmutablePrefix` is built, so they end up in the cache key alongside Reasonix's native tools.
- Spawned MCP children are disposed when the ACP stdin closes — no leaked stdio pipes when the headless caller exits.
- Same failure semantics as `run` / `chat`: a broken side-concern server logs to stderr and the session keeps going.

## Why
`reasonix acp` is the entrypoint headless ACP clients use to drive Reasonix. Without this flag, an embedder that wants domain-specific tools (Paperclip's `reasonix-local` adapter, custom MCP servers, etc.) has to mutate the user's saved config — which is unsafe for a process-per-task invocation. Mirrors what's already accepted on `run` / `chat`.

Closes #779.

## Test plan
- [x] `tests/acp-mcp.test.ts` — 7 cases: multi-spec parsing, single-anon `--mcp-prefix` honored, multi-spec prefix dropped, `mcpDisabled` skipped, initialize failure non-fatal (client closed), malformed-spec non-fatal, empty array no-op.
- [x] `node dist/cli/index.js acp --help` shows `--mcp` and `--mcp-prefix`.
- [x] `npm run verify` green (186 test files, 2814 tests, 0 failures).

## Lineage
Third in a small stack of upstream-able pieces of headless-ACP plumbing:
- #766 `--transcript <path>` (merged)
- #767 `--yolo` (merged)
- this PR — `--mcp` + `--mcp-prefix`