### PR TITLE
fix(loop): /new reloads REASONIX.md without restart

### DIFF
--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -40,6 +40,8 @@ export type { McpLifecycleNotice, McpLifecycleSink, McpRuntime, ProgressInfo };
 export interface ChatOptions {
   model: string;
   system: string;
+  /** Re-runs the prompt builder on /new so REASONIX.md edits don't need a restart. Should produce the same string `system` was built from. */
+  rebuildSystem?: () => string;
   transcript?: string;
   /**
    * Soft USD cap on session spend. Undefined → no cap (default).
@@ -195,6 +197,7 @@ function Root({
         key={activeSession ?? "__new__"}
         model={appProps.model}
         system={appProps.system}
+        rebuildSystem={appProps.rebuildSystem}
         transcript={appProps.transcript}
         budgetUsd={appProps.budgetUsd}
         failureThreshold={appProps.failureThreshold}

--- a/src/cli/commands/code.tsx
+++ b/src/cli/commands/code.tsx
@@ -137,16 +137,19 @@ export async function codeCommand(opts: CodeOptions = {}): Promise<void> {
     }
   }
 
-  await chatCommand({
-    model: opts.model ?? "deepseek-v4-flash",
-    budgetUsd: opts.budgetUsd,
-    failureThreshold: opts.failureThreshold,
-    system: codeSystemPrompt(rootDir, {
+  const codeRebuildSystem = () =>
+    codeSystemPrompt(rootDir, {
       hasSemanticSearch: semantic.enabled,
       systemAppend: opts.systemAppend,
       systemAppendFile: systemAppendFileContents,
       modelId: opts.model ?? "deepseek-v4-flash",
-    }),
+    });
+  await chatCommand({
+    model: opts.model ?? "deepseek-v4-flash",
+    budgetUsd: opts.budgetUsd,
+    failureThreshold: opts.failureThreshold,
+    system: codeRebuildSystem(),
+    rebuildSystem: codeRebuildSystem,
     transcript: opts.transcript,
     session,
     seedTools: tools,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -134,9 +134,13 @@ program.action(async (opts: { continue?: boolean }) => {
     (msg) => process.stderr.write(`${msg}\n`),
   );
   const { chatCommand } = await import("./commands/chat.js");
+  const defaultBase = defaultSystemPrompt(defaults.model);
+  const defaultCwd = process.cwd();
+  const defaultRebuildSystem = () => applyMemoryStack(defaultBase, defaultCwd);
   await chatCommand({
     model: defaults.model,
-    system: applyMemoryStack(defaultSystemPrompt(defaults.model), process.cwd()),
+    system: defaultRebuildSystem(),
+    rebuildSystem: defaultRebuildSystem,
     session: continueOpts.session,
     mcp: defaults.mcp,
     forceResume: continueOpts.forceResume,
@@ -242,9 +246,13 @@ program
           (msg) => process.stderr.write(`${msg}\n`),
         );
     const { chatCommand } = await import("./commands/chat.js");
+    const chatBase = opts.system ?? defaultSystemPrompt(defaults.model);
+    const chatCwd = process.cwd();
+    const chatRebuildSystem = () => applyMemoryStack(chatBase, chatCwd);
     await chatCommand({
       model: defaults.model,
-      system: applyMemoryStack(opts.system ?? defaultSystemPrompt(defaults.model), process.cwd()),
+      system: chatRebuildSystem(),
+      rebuildSystem: chatRebuildSystem,
       transcript: opts.transcript,
       budgetUsd: parseBudgetFlag(opts.budget),
       failureThreshold: resolveFailureThreshold(

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -185,6 +185,8 @@ import { useSubagent } from "./useSubagent.js";
 export interface AppProps {
   model: string;
   system: string;
+  /** Re-runs the prompt builder on /new so REASONIX.md edits don't need a restart. Must produce the same shape as `system` was built from. */
+  rebuildSystem?: () => string;
   transcript?: string;
   /** Soft USD spend cap; undefined → no cap. See CacheFirstLoopOptions.budgetUsd. */
   budgetUsd?: number;
@@ -419,6 +421,7 @@ type AppInnerProps = AppProps & {
 function AppInner({
   model,
   system,
+  rebuildSystem,
   transcript,
   budgetUsd,
   failureThreshold,
@@ -899,10 +902,11 @@ function AppInner({
       // `/effort high` silently reverted to `max` on relaunch — the
       // loop's constructor default wins over persisted state.
       reasoningEffort: loadReasoningEffort(),
+      rebuildSystem,
     });
     loopRef.current = l;
     return l;
-  }, [model, system, budgetUsd, failureThreshold, session, tools, codeMode]);
+  }, [model, system, rebuildSystem, budgetUsd, failureThreshold, session, tools, codeMode]);
 
   useEffect(() => {
     if (!session || !tools) return;

--- a/src/cli/ui/slash/handlers/basic.ts
+++ b/src/cli/ui/slash/handlers/basic.ts
@@ -7,10 +7,11 @@ import type { SlashCommandSpec, SlashGroup } from "../types.js";
 const exit: SlashHandler = () => ({ exit: true });
 
 const resetLog: SlashHandler = (_args, loop) => {
-  const { dropped, archived } = loop.clearLog();
-  const info = archived
+  const { dropped, archived, systemRebuilt } = loop.clearLog();
+  const head = archived
     ? t("handlers.basic.newInfoArchived", { count: dropped, archived })
     : t("handlers.basic.newInfo", { count: dropped });
+  const info = systemRebuilt ? head + t("handlers.basic.newInfoSystemReloaded") : head;
   return { clear: true, info };
 };
 

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -651,6 +651,8 @@ export const EN: TranslationSchema = {
         "▸ new conversation — dropped {count} message(s) from context. Same session, fresh slate.",
       newInfoArchived:
         '▸ new conversation — dropped {count} message(s) from context. Prior transcript archived as "{archived}" (visible under Sessions).',
+      newInfoSystemReloaded:
+        " · REASONIX.md / project memory reloaded (next turn pays one cache miss)",
       helpTitle: "Commands:",
       helpShellTitle: "Shell shortcut:",
       helpShell: "  !<cmd>                   run <cmd> in the sandbox root; output goes into",

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -634,6 +634,7 @@ export const zhCN: TranslationSchema = {
       newInfo: "▸ 新对话 — 已从上下文中丢弃 {count} 条消息。同一会话，全新开始。",
       newInfoArchived:
         "▸ 新对话 — 已从上下文中丢弃 {count} 条消息。原对话已归档为「{archived}」，可在 Sessions 面板查看。",
+      newInfoSystemReloaded: " · REASONIX.md / 项目记忆已重新加载（下一轮一次性 cache miss）",
       helpTitle: "命令：",
       helpShellTitle: "Shell 快捷方式：",
       helpShell: "  !<cmd>                   在沙箱根目录运行 <cmd>；输出进入对话",

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -99,6 +99,8 @@ export interface CacheFirstLoopOptions {
   hookCwd?: string;
   /** PauseGate bridge — defaults to singleton, injectable for tests. */
   confirmationGate?: PauseGate;
+  /** Re-runs the prompt builder (applyMemoryStack / codeSystemPrompt) on /new so REASONIX.md edits take effect without a restart. Accepting a cache miss is the price. */
+  rebuildSystem?: () => string;
 }
 
 export interface ReconfigurableOptions {
@@ -139,6 +141,8 @@ export class CacheFirstLoop {
 
   /** Number of messages that were pre-loaded from the session file. */
   readonly resumedMessageCount: number;
+
+  private readonly _rebuildSystem: (() => string) | null;
 
   private _turn = 0;
   private _streamPreference: boolean;
@@ -186,6 +190,7 @@ export class CacheFirstLoop {
     this.hooks = opts.hooks ?? [];
     this.hookCwd = opts.hookCwd ?? process.cwd();
     this.confirmationGate = opts.confirmationGate ?? defaultPauseGate;
+    this._rebuildSystem = opts.rebuildSystem ?? null;
 
     this._streamPreference = opts.stream ?? true;
     this.stream = this._streamPreference;
@@ -309,8 +314,8 @@ export class CacheFirstLoop {
     }
   }
 
-  /** "New chat" — drops in-memory messages, archives the on-disk transcript so it survives in Sessions, keeps sessionName so the prefix cache stays warm. */
-  clearLog(): { dropped: number; archived: string | null } {
+  /** "New chat" — drops in-memory messages, archives the on-disk transcript so it survives in Sessions, keeps sessionName so the prefix cache stays warm. Re-runs the system-prompt builder if one was wired (issue #778: REASONIX.md edits otherwise need a restart). */
+  clearLog(): { dropped: number; archived: string | null; systemRebuilt: boolean } {
     const dropped = this.log.length;
     this.log.compactInPlace([]);
     let archived: string | null = null;
@@ -324,7 +329,15 @@ export class CacheFirstLoop {
     }
     this.scratch.reset();
     this._inflight.clear();
-    return { dropped, archived };
+    let systemRebuilt = false;
+    if (this._rebuildSystem) {
+      try {
+        systemRebuilt = this.prefix.replaceSystem(this._rebuildSystem());
+      } catch {
+        /* builder threw — keep prior system rather than crash /new */
+      }
+    }
+    return { dropped, archived, systemRebuilt };
   }
 
   configure(opts: ReconfigurableOptions): void {

--- a/src/memory/runtime.ts
+++ b/src/memory/runtime.ts
@@ -8,17 +8,26 @@ export interface ImmutablePrefixOptions {
 }
 
 export class ImmutablePrefix {
-  readonly system: string;
+  /** Stable across turns; rebuilt only on /new when REASONIX.md changed on disk. */
+  system: string;
   /** Each `addTool` costs one cache-miss turn — DeepSeek's prefix cache is keyed by full tool list. */
   private _toolSpecs: ToolSpec[];
   readonly fewShots: readonly ChatMessage[];
-  /** Invalidated only via `addTool`; bypassing it leaves cache stale → fingerprint diverges from sent prefix. */
+  /** Invalidated by addTool / removeTool / replaceSystem; bypassing any of those leaves cache stale → fingerprint diverges from sent prefix. */
   private _fingerprintCache: string | null = null;
 
   constructor(opts: ImmutablePrefixOptions) {
     this.system = opts.system;
     this._toolSpecs = [...(opts.toolSpecs ?? [])];
     this.fewShots = Object.freeze([...(opts.fewShots ?? [])]);
+  }
+
+  /** Replaces the system prompt; returns true iff the string actually changed. Caller must accept a cache miss on the next turn. */
+  replaceSystem(s: string): boolean {
+    if (this.system === s) return false;
+    this.system = s;
+    this._fingerprintCache = null;
+    return true;
   }
 
   get toolSpecs(): readonly ToolSpec[] {

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -1543,6 +1543,55 @@ describe("CacheFirstLoop - setBudget / clearLog / retryLastUser / proArm", () =>
     expect(dropped).toBe(0);
   });
 
+  it("clearLog rebuilds prefix.system when the rebuild closure returns a new string", () => {
+    const client = makeClient([{ content: "ok" }]);
+    let current = "system-v1";
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: current }),
+      stream: false,
+      rebuildSystem: () => current,
+    });
+    expect(loop.prefix.system).toBe("system-v1");
+    const fp1 = loop.prefix.fingerprint;
+
+    current = "system-v2";
+    const { systemRebuilt } = loop.clearLog();
+    expect(systemRebuilt).toBe(true);
+    expect(loop.prefix.system).toBe("system-v2");
+    expect(loop.prefix.fingerprint).not.toBe(fp1);
+  });
+
+  it("clearLog leaves prefix.system untouched when the rebuild closure returns the same string", () => {
+    const client = makeClient([{ content: "ok" }]);
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "stable" }),
+      stream: false,
+      rebuildSystem: () => "stable",
+    });
+    const fp1 = loop.prefix.fingerprint;
+    const { systemRebuilt } = loop.clearLog();
+    expect(systemRebuilt).toBe(false);
+    expect(loop.prefix.system).toBe("stable");
+    expect(loop.prefix.fingerprint).toBe(fp1);
+  });
+
+  it("clearLog swallows rebuild-closure exceptions and keeps the prior system", () => {
+    const client = makeClient([{ content: "ok" }]);
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "keep-me" }),
+      stream: false,
+      rebuildSystem: () => {
+        throw new Error("disk on fire");
+      },
+    });
+    const { systemRebuilt } = loop.clearLog();
+    expect(systemRebuilt).toBe(false);
+    expect(loop.prefix.system).toBe("keep-me");
+  });
+
   it("retryLastUser returns null when no user message exists", () => {
     const client = makeClient([{ content: "ok" }]);
     const loop = new CacheFirstLoop({


### PR DESCRIPTION
## Summary

- `/new` now re-runs the system-prompt builder so a fresh REASONIX.md is honored without a process restart. The current implementation locks `applyMemoryStack(...)` into `ImmutablePrefix.system` at startup (intentional — keeps the prefix-cache warm) and `clearLog()` never touches it, which is why the only workaround today is quitting Reasonix.
- New optional `rebuildSystem: () => string` on `CacheFirstLoopOptions`. `clearLog()` calls it after wiping the log, compares against `prefix.system`, and only invalidates the cache when the string actually changed (`ImmutablePrefix.replaceSystem` is a no-op on equality). Closures land at the `chat` / `code` entry points and point back at the same builder the initial system was created with.
- `/new` banner gets a " · REASONIX.md / project memory reloaded (next turn pays one cache miss)" suffix when a reload happened, so the cache miss isn't a silent surprise.

Refs #778 (bug 2 of 2 — the `/new` doesn't reload REASONIX.md part).

## Why a closure, not a string

The system prompt builder differs per entry point:
- `reasonix chat` / bare `reasonix` → `applyMemoryStack(opts.system ?? defaultSystemPrompt(model), cwd)`
- `reasonix code` → `codeSystemPrompt(rootDir, { hasSemanticSearch, systemAppend, ... })`

A closure captures the right args without the loop knowing which CLI it's serving. It also keeps the failure mode local — a builder throwing on `/new` just keeps the prior system instead of crashing the turn.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (one pre-existing warning in `tests/plan-confirm.test.tsx`, unrelated)
- [x] `npm run build` — ESM + DTS bundle clean
- [x] `npx vitest run tests/loop.test.ts` — 16/16 clearLog-relevant pass, including 3 new cases:
  - `clearLog rebuilds prefix.system when the rebuild closure returns a new string` — fingerprint changes
  - `clearLog leaves prefix.system untouched when the rebuild closure returns the same string` — fingerprint unchanged
  - `clearLog swallows rebuild-closure exceptions and keeps the prior system` — disk-read failure path
- [x] `npx vitest run tests/comment-policy.test.ts` — 9/9 pass
- [x] Full suite: 2810/2810 pass (+3 over `main`)

## Wire compatibility

`rebuildSystem` is optional everywhere. Callers that don't pass one (e.g. `runCommand`, ACP, subagent loops) get the old "system stays as-is on `/new`" behavior unchanged. The cache-key fingerprint logic already invalidated on tool add/remove; adding system-replace to that list closes the same hole.

## Non-goals

- Not re-reading global user memory / skills on `/new` (`applyMemoryStack` already does that — it's the same closure). If the user only changed `~/.reasonix/memory/` files, the same path covers it.
- Not making the rebuild automatic mid-turn. `/new` is the user's explicit "fresh slate" signal, which is the right moment to pay the cache miss.
