### PR TITLE
fix(settings): normalize search default to disk on first GET

### DIFF
--- a/src/server/api/settings.ts
+++ b/src/server/api/settings.ts
@@ -42,6 +42,10 @@ export async function handleSettings(
 ): Promise<ApiResult> {
   if (method === "GET") {
     const cfg = readConfig(ctx.configPath);
+    if (cfg.search === undefined) {
+      cfg.search = true;
+      writeConfig(cfg, ctx.configPath);
+    }
     const live = ctx.loop;
     return {
       status: 200,

--- a/tests/settings-api.test.ts
+++ b/tests/settings-api.test.ts
@@ -100,6 +100,24 @@ describe("settings API — combined POST persistence (#274)", () => {
     expect(cfg.lang).toBe("EN");
   });
 
+  it("GET persists search=true when the field is missing (issue #778)", async () => {
+    writeFileSync(configPath, JSON.stringify({ lang: "EN" }), "utf8");
+    expect(readCfg(configPath).search).toBeUndefined();
+    const res = await handleSettings("GET", [], "", makeCtx(configPath));
+    expect(res.status).toBe(200);
+    expect((res.body as { search: boolean }).search).toBe(true);
+    expect(readCfg(configPath).search).toBe(true);
+  });
+
+  it("GET does not rewrite the file when search is already explicit", async () => {
+    writeFileSync(configPath, JSON.stringify({ lang: "EN", search: false }), "utf8");
+    const before = readFileSync(configPath, "utf8");
+    const res = await handleSettings("GET", [], "", makeCtx(configPath));
+    expect(res.status).toBe(200);
+    expect((res.body as { search: boolean }).search).toBe(false);
+    expect(readFileSync(configPath, "utf8")).toBe(before);
+  });
+
   it("fires applyPresetLive only after the disk write succeeds", async () => {
     const calls: string[] = [];
     const ctx: DashboardContext = {


### PR DESCRIPTION
## Summary

Best hypothesis on issue #778 bug 1: the dashboard's search toggle is a one-way trap when `~/.reasonix/config.json` has no `"search"` field. GET resolves the value via `cfg.search !== false` (runtime default: on), so the button renders ON even though nothing's persisted. A user who reads the config first, sees no `search` entry, opens the dashboard expecting OFF, and clicks "to enable it" actually does `undefined → false` — exactly what the reporter saw (`"search": false` in config after clicking).

Fix: GET persists the resolved default on first read when the field is missing. From then on, on-disk state always matches the toggle, and a click does what the user thinks it does. Idempotent on configs that already have an explicit `search`.

Refs #778 (bug 1 of 2 — bug 2 landed in #781).

## Why GET, not POST

The reporter's symptom is "I opened the dashboard, clicked once, config still wrong." If we normalize only on POST, we still hit the trap on the first click. Normalizing on GET means the dashboard never displays an ambiguous state — by the time the user sees a button, the config already reflects what the runtime would resolve to. The cost is one extra `writeConfig` per fresh-install dashboard open, which happens at most once per machine.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (the one pre-existing warning in `tests/plan-confirm.test.tsx` is unrelated)
- [x] `npx vitest run tests/settings-api.test.ts` — 8/8 pass, including 2 new cases:
  - `GET persists search=true when the field is missing` — config goes from `{}` to `{search: true}` on the first read
  - `GET does not rewrite the file when search is already explicit` — byte-for-byte unchanged
- [x] Full suite: 2819/2819 pass

## Caveat

This is speculative — the reporter hasn't replied to my repro questions on #778 yet. If their actual sequence is different (e.g. `"search": false` was already explicit on disk before the click), the bug is elsewhere and I'll dig further. Even in that case, this PR is a strict improvement: the on-disk shape always matches the dashboard's view, which is the property that should hold regardless.
