### PR TITLE
fix(policy): yolo bypasses path_access too, parity with shell allowAll

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -48,7 +48,7 @@ import {
 } from "../../config.js";
 import { Eventizer } from "../../core/eventize.js";
 import { pauseGate } from "../../core/pause-gate.js";
-import { shouldAutoResolveCheckpoint } from "../../core/pause-policy.js";
+import { autoResolveVerdict, shouldAutoResolveCheckpoint } from "../../core/pause-policy.js";
 import { formatHookOutcomeMessage, runHooks } from "../../hooks.js";
 import { t, tObj } from "../../i18n/index.js";
 import { CacheFirstLoop, DeepSeekClient, ImmutablePrefix } from "../../index.js";
@@ -3329,6 +3329,11 @@ function AppInner({
           break;
         }
         case "path_access": {
+          const auto = autoResolveVerdict(request, editModeRef.current);
+          if (auto !== null) {
+            pauseGate.resolve(request.id, auto);
+            break;
+          }
           const p = payload as {
             path: string;
             intent: "read" | "write";

--- a/src/core/pause-policy.ts
+++ b/src/core/pause-policy.ts
@@ -13,5 +13,11 @@ export function autoResolveVerdict(req: PauseRequest, editMode: EditMode): unkno
   if (req.kind === "plan_checkpoint" && shouldAutoResolveCheckpoint(editMode)) {
     return { type: "continue" };
   }
+  // yolo mirrors shell.ts's allowAll bypass — outside-sandbox reads/writes pass
+  // through too. Stays "run_once" rather than "always_allow" so the YOLO session
+  // doesn't pollute the on-disk allowlist with every transient path it touched.
+  if (req.kind === "path_access" && editMode === "yolo") {
+    return { type: "run_once" };
+  }
   return null;
 }

--- a/tests/acp-yolo.test.ts
+++ b/tests/acp-yolo.test.ts
@@ -61,7 +61,7 @@ describe("acp --yolo", () => {
     expect(bridged).toBe(false);
   });
 
-  it("does NOT auto-resolve run_command requests even with --yolo (plan-checkpoint-only scope)", async () => {
+  it("does NOT auto-resolve run_command requests even with --yolo (shell.ts handles that via allowAll)", async () => {
     const gate = new PauseGate();
     let bridgedReqId: number | null = null;
     makeListener({ yolo: true }, "review")(gate, (id) => {
@@ -70,6 +70,48 @@ describe("acp --yolo", () => {
     });
 
     await gate.ask({ kind: "run_command", payload: { command: "rm -rf /" } });
+    expect(bridgedReqId).not.toBeNull();
+  });
+
+  it("auto-allows path_access (run_once) when yolo — mirrors shell.ts allowAll bypass", async () => {
+    const gate = new PauseGate();
+    let bridged = false;
+    makeListener({ yolo: true }, "review")(gate, () => {
+      bridged = true;
+    });
+
+    const promise = gate.ask({
+      kind: "path_access",
+      payload: {
+        path: "/tmp/foo",
+        intent: "read",
+        toolName: "read_file",
+        sandboxRoot: "/work",
+        allowPrefix: "/tmp",
+      },
+    });
+    await expect(promise).resolves.toEqual({ type: "run_once" });
+    expect(bridged).toBe(false);
+  });
+
+  it("bridges path_access to the client in auto mode (only yolo bypasses)", async () => {
+    const gate = new PauseGate();
+    let bridgedReqId: number | null = null;
+    makeListener({ yolo: false }, "auto")(gate, (id) => {
+      bridgedReqId = id;
+      gate.resolve(id, { type: "deny" } as never);
+    });
+
+    await gate.ask({
+      kind: "path_access",
+      payload: {
+        path: "/etc/passwd",
+        intent: "read",
+        toolName: "read_file",
+        sandboxRoot: "/work",
+        allowPrefix: "/etc",
+      },
+    });
     expect(bridgedReqId).not.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- YOLO mode auto-allowed shell tools via `setup.ts`'s `allowAll` getter but filesystem tools still hit the `path_access` gate. Outside-sandbox reads (`/tmp/foo`, etc.) paused the loop waiting for user approval even with YOLO on.
- `autoResolveVerdict` now returns `run_once` for `path_access` when `editMode === "yolo"`. `run_once` rather than `always_allow` so a transient YOLO session doesn't pollute the on-disk allowlist with every path it touched.
- CLI TUI's pause-gate listener now routes `path_access` through `autoResolveVerdict` too, so all three surfaces (CLI / ACP / desktop) converge on the shared policy.

## Test plan
- [x] `npx vitest run tests/acp-yolo.test.ts` — 6 passed (4 existing + 2 new)
- [x] new test: yolo + path_access auto-allows
- [x] new test: auto mode still bridges path_access to UI