### PR TITLE
fix(desktop): wire path_access gate and scope right-panel to this session

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -35,6 +35,7 @@ import {
   CheckpointApprovalCard,
   ChoiceApprovalCard,
   ConfirmApprovalCard,
+  PathAccessApprovalCard,
   PlanApprovalCard,
   PlanBanner,
   RevisionApprovalCard,
@@ -71,6 +72,15 @@ export type PendingConfirm = {
   id: number;
   kind: "run_command" | "run_background";
   command: string;
+};
+
+export type PendingPathAccess = {
+  id: number;
+  path: string;
+  intent: "read" | "write";
+  toolName: string;
+  sandboxRoot: string;
+  allowPrefix: string;
 };
 
 export type PendingChoice = {
@@ -174,6 +184,7 @@ type State = {
   currentSession?: string;
   messages: ChatMessage[];
   pendingConfirms: PendingConfirm[];
+  pendingPathAccess: PendingPathAccess[];
   pendingChoices: PendingChoice[];
   pendingPlans: PendingPlan[];
   pendingCheckpoints: PendingCheckpoint[];
@@ -188,9 +199,15 @@ type State = {
   mcpSpecs: McpSpecInfo[];
   mcpBridged: boolean;
   skills: SkillInfo[];
-  /** Files the agent has read this session — paths as the tool args provided them (typically relative to workspace). */
-  inContextPaths: string[];
+  /** Files the agent has read or modified this session — paths as the tool args provided them. */
+  sessionFiles: SessionFile[];
   memory: MemoryEntryInfo[];
+};
+
+export type SessionFile = {
+  path: string;
+  /** "c": pulled into context (read_file). "m": modified by the agent (edit_file / write_file / multi_edit). */
+  status: "c" | "m";
 };
 
 type DeltaBatchItem = {
@@ -206,6 +223,7 @@ type Action =
   | { t: "rpc_exit"; code: number | null }
   | { t: "clear" }
   | { t: "resolve_confirm"; id: number }
+  | { t: "resolve_path_access"; id: number }
   | { t: "resolve_choice"; id: number }
   | { t: "resolve_plan"; id: number; verdict: PlanVerdict }
   | { t: "resolve_checkpoint"; id: number; verdict: CheckpointVerdict }
@@ -277,17 +295,24 @@ function reduce(state: State, action: Action): State {
         currentSession: undefined,
         messages: [],
         pendingConfirms: [],
+        pendingPathAccess: [],
         pendingChoices: [],
         pendingPlans: [],
         pendingCheckpoints: [],
         pendingRevisions: [],
         activePlan: null,
         usage: zeroUsage(),
+        sessionFiles: [],
       };
     case "resolve_confirm":
       return {
         ...state,
         pendingConfirms: state.pendingConfirms.filter((c) => c.id !== action.id),
+      };
+    case "resolve_path_access":
+      return {
+        ...state,
+        pendingPathAccess: state.pendingPathAccess.filter((p) => p.id !== action.id),
       };
     case "resolve_choice":
       return {
@@ -344,24 +369,56 @@ function reduce(state: State, action: Action): State {
   }
 }
 
-const FILE_READING_TOOLS = new Set([
-  "read_file",
-  "list_directory",
-  "directory_tree",
-  "search_files",
-  "get_file_info",
-  "glob_files",
-]);
+const READING_TOOLS = new Set(["read_file"]);
+const MODIFYING_TOOLS = new Set(["edit_file", "write_file"]);
 
-function extractToolFilePath(name: string, args: string): string | null {
-  if (!FILE_READING_TOOLS.has(name)) return null;
+function extractToolFiles(name: string, args: string): SessionFile[] {
   try {
-    const parsed = JSON.parse(args) as { path?: unknown };
-    if (typeof parsed?.path === "string") return parsed.path;
+    const parsed = JSON.parse(args) as { path?: unknown; edits?: unknown };
+    if (READING_TOOLS.has(name) && typeof parsed?.path === "string") {
+      return [{ path: parsed.path, status: "c" }];
+    }
+    if (MODIFYING_TOOLS.has(name) && typeof parsed?.path === "string") {
+      return [{ path: parsed.path, status: "m" }];
+    }
+    if (name === "multi_edit" && Array.isArray(parsed?.edits)) {
+      const out: SessionFile[] = [];
+      const seen = new Set<string>();
+      for (const e of parsed.edits as Array<{ path?: unknown }>) {
+        if (typeof e?.path === "string" && !seen.has(e.path)) {
+          seen.add(e.path);
+          out.push({ path: e.path, status: "m" });
+        }
+      }
+      return out;
+    }
   } catch {
     // malformed args — skip; tool will error on the real side anyway
   }
-  return null;
+  return [];
+}
+
+function mergeSessionFiles(existing: SessionFile[], adds: SessionFile[]): SessionFile[] {
+  if (adds.length === 0) return existing;
+  const next = [...existing];
+  const indexByPath = new Map<string, number>();
+  next.forEach((f, i) => indexByPath.set(f.path, i));
+  let changed = false;
+  for (const add of adds) {
+    const idx = indexByPath.get(add.path);
+    if (idx === undefined) {
+      indexByPath.set(add.path, next.length);
+      next.push(add);
+      changed = true;
+      continue;
+    }
+    const prev = next[idx];
+    if (!prev || prev.status === "m") continue; // never downgrade m → c
+    if (prev.status === add.status) continue;
+    next[idx] = add;
+    changed = true;
+  }
+  return changed ? next : existing;
 }
 
 function zeroUsage(): UsageStats {
@@ -403,6 +460,21 @@ function applyIncoming(state: State, ev: IncomingEvent): State {
         pendingConfirms: [
           ...state.pendingConfirms,
           { id: ev.id, kind: ev.kind, command: ev.command },
+        ],
+      };
+    case "$path_access_required":
+      return {
+        ...state,
+        pendingPathAccess: [
+          ...state.pendingPathAccess,
+          {
+            id: ev.id,
+            path: ev.path,
+            intent: ev.intent,
+            toolName: ev.toolName,
+            sandboxRoot: ev.sandboxRoot,
+            allowPrefix: ev.allowPrefix,
+          },
         ],
       };
     case "$choice_required":
@@ -504,12 +576,14 @@ function applyIncoming(state: State, ev: IncomingEvent): State {
         busy: wsChanged ? false : state.busy,
         messages: wsChanged ? [] : state.messages,
         pendingConfirms: wsChanged ? [] : state.pendingConfirms,
+        pendingPathAccess: wsChanged ? [] : state.pendingPathAccess,
         pendingChoices: wsChanged ? [] : state.pendingChoices,
         pendingPlans: wsChanged ? [] : state.pendingPlans,
         pendingCheckpoints: wsChanged ? [] : state.pendingCheckpoints,
         pendingRevisions: wsChanged ? [] : state.pendingRevisions,
         activePlan: wsChanged ? null : state.activePlan,
         usage: wsChanged ? zeroUsage() : state.usage,
+        sessionFiles: wsChanged ? [] : state.sessionFiles,
         settings: {
           reasoningEffort: ev.reasoningEffort,
           editMode: ev.editMode,
@@ -548,13 +622,14 @@ function applyIncoming(state: State, ev: IncomingEvent): State {
         });
         return { kind: "assistant", turn: m.turn, segments, pending: false };
       });
-      const inContextPaths: string[] = [];
+      let sessionFiles: SessionFile[] = [];
       for (const m of loaded) {
         if (m.kind !== "assistant") continue;
         for (const s of m.segments) {
           if (s.kind !== "tool") continue;
-          const p = extractToolFilePath(s.name, s.args);
-          if (p && !inContextPaths.includes(p)) inContextPaths.push(p);
+          // For replayed sessions we don't have tool.result ok-status here, but
+          // segments only survive into history if the call completed. Trust it.
+          sessionFiles = mergeSessionFiles(sessionFiles, extractToolFiles(s.name, s.args));
         }
       }
       return {
@@ -563,6 +638,7 @@ function applyIncoming(state: State, ev: IncomingEvent): State {
         currentSession: sessionName,
         messages: loaded,
         pendingConfirms: [],
+        pendingPathAccess: [],
         pendingChoices: [],
         pendingPlans: [],
         pendingCheckpoints: [],
@@ -575,7 +651,7 @@ function applyIncoming(state: State, ev: IncomingEvent): State {
           cacheHitTokens: ev.carryover.cacheHitTokens,
           cacheMissTokens: ev.carryover.cacheMissTokens,
         },
-        inContextPaths,
+        sessionFiles,
       };
     }
     case "$error":
@@ -657,14 +733,10 @@ function applyIncoming(state: State, ev: IncomingEvent): State {
         }),
       };
     case "tool.intent": {
-      const filePath = extractToolFilePath(ev.name, ev.args);
-      const inContextPaths =
-        filePath && !state.inContextPaths.includes(filePath)
-          ? [...state.inContextPaths, filePath]
-          : state.inContextPaths;
+      const adds = extractToolFiles(ev.name, ev.args);
       return {
         ...state,
-        inContextPaths,
+        sessionFiles: mergeSessionFiles(state.sessionFiles, adds),
         messages: state.messages.map((m) => {
           if (m.kind !== "assistant" || m.turn !== ev.turn) return m;
           const idx = m.segments.findIndex((s) => s.kind === "tool" && s.callId === ev.callId);
@@ -776,6 +848,7 @@ function TabRuntime({
     busy: false,
     messages: [],
     pendingConfirms: [],
+    pendingPathAccess: [],
     pendingChoices: [],
     pendingPlans: [],
     pendingCheckpoints: [],
@@ -790,7 +863,7 @@ function TabRuntime({
     mcpSpecs: [],
     mcpBridged: false,
     skills: [],
-    inContextPaths: [],
+    sessionFiles: [],
     memory: [],
   });
   const [draft, setDraft] = useState("");
@@ -897,6 +970,13 @@ function TabRuntime({
     (id: number, response: ConfirmationChoice) => {
       sendRpc({ cmd: "confirm_response", id, response });
       dispatch({ t: "resolve_confirm", id });
+    },
+    [sendRpc],
+  );
+  const resolvePathAccess = useCallback(
+    (id: number, response: ConfirmationChoice) => {
+      sendRpc({ cmd: "confirm_response", id, response });
+      dispatch({ t: "resolve_path_access", id });
     },
     [sendRpc],
   );
@@ -1329,6 +1409,17 @@ function TabRuntime({
                       onDeny={() => resolveConfirm(c.id, { type: "deny" })}
                     />
                   ))}
+                  {state.pendingPathAccess.map((p) => (
+                    <PathAccessApprovalCard
+                      key={`pa-${p.id}`}
+                      p={p}
+                      onAllow={() => resolvePathAccess(p.id, { type: "run_once" })}
+                      onAlwaysAllow={(prefix) =>
+                        resolvePathAccess(p.id, { type: "always_allow", prefix })
+                      }
+                      onDeny={() => resolvePathAccess(p.id, { type: "deny" })}
+                    />
+                  ))}
                   {state.pendingChoices.map((c) => (
                     <ChoiceApprovalCard
                       key={`ch-${c.id}`}
@@ -1390,10 +1481,9 @@ function TabRuntime({
         <ContextPanel
           settings={state.settings}
           usage={state.usage}
-          workspaceDir={state.settings?.workspaceDir}
           mcpSpecs={state.mcpSpecs}
           mcpBridged={state.mcpBridged}
-          inContextPaths={state.inContextPaths}
+          sessionFiles={state.sessionFiles}
           memory={state.memory}
         />
 

--- a/desktop/src/protocol.ts
+++ b/desktop/src/protocol.ts
@@ -1,6 +1,16 @@
 export type ReadyEvent = { type: "$ready" };
 export type ProtocolErrorEvent = { type: "$error"; message: string };
 export type TurnCompleteEvent = { type: "$turn_complete" };
+export type PathAccessRequiredEvent = {
+  type: "$path_access_required";
+  id: number;
+  path: string;
+  intent: "read" | "write";
+  toolName: string;
+  sandboxRoot: string;
+  allowPrefix: string;
+};
+
 export type ConfirmRequiredEvent = {
   type: "$confirm_required";
   id: number;
@@ -341,6 +351,7 @@ export type IncomingEvent = { tabId?: string } & (
   | ProtocolErrorEvent
   | TurnCompleteEvent
   | ConfirmRequiredEvent
+  | PathAccessRequiredEvent
   | ChoiceRequiredEvent
   | PlanRequiredEvent
   | SessionsEvent

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -1930,15 +1930,6 @@ button {
 .tree .node[data-kind="file"] {
   cursor: default;
 }
-.tree .node .caret {
-  width: 10px;
-  height: 10px;
-  color: var(--muted-2);
-  flex-shrink: 0;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
 .tree .node .ico {
   color: var(--muted-2);
   flex-shrink: 0;
@@ -2278,7 +2269,7 @@ button {
 
 /* ---- streaming caret ---- */
 
-.caret {
+.stream-caret {
   display: inline-block;
   width: 6px;
   height: 14px;
@@ -2286,9 +2277,9 @@ button {
   vertical-align: text-bottom;
   margin-left: 1px;
   border-radius: 1px;
-  animation: caret 1s steps(2) infinite;
+  animation: stream-caret 1s steps(2) infinite;
 }
-@keyframes caret {
+@keyframes stream-caret {
   50% {
     opacity: 0;
   }

--- a/desktop/src/ui/context-panel.tsx
+++ b/desktop/src/ui/context-panel.tsx
@@ -1,40 +1,25 @@
-import { invoke } from "@tauri-apps/api/core";
-import { useEffect, useMemo, useState } from "react";
-import type { Settings, UsageStats } from "../App";
+import { useMemo, useState } from "react";
+import type { SessionFile, Settings, UsageStats } from "../App";
 import { I } from "../icons";
 import type { McpSpecInfo, MemoryEntryInfo } from "../protocol";
 
 type Tab = "files" | "tools" | "memory" | "rules";
-
-type FileEntry = {
-  path: string;
-  depth: number;
-  kind: "dir" | "file";
-  name: string;
-};
-
-type GitStatusEntry = {
-  path: string;
-  kind: string;
-};
 
 const CONTEXT_MAX_TOKENS = 1_000_000;
 
 export function ContextPanel({
   settings,
   usage,
-  workspaceDir,
   mcpSpecs,
   mcpBridged,
-  inContextPaths,
+  sessionFiles,
   memory,
 }: {
   settings: Settings | null;
   usage: UsageStats;
-  workspaceDir?: string;
   mcpSpecs: McpSpecInfo[];
   mcpBridged: boolean;
-  inContextPaths: string[];
+  sessionFiles: SessionFile[];
   memory: MemoryEntryInfo[];
 }) {
   const [tab, setTab] = useState<Tab>("files");
@@ -98,9 +83,7 @@ export function ContextPanel({
           </div>
         </div>
 
-        {tab === "files" && (
-          <CtxFiles workspaceDir={workspaceDir} inContextPaths={inContextPaths} />
-        )}
+        {tab === "files" && <CtxFiles files={sessionFiles} />}
         {tab === "tools" && <CtxTools specs={mcpSpecs} bridged={mcpBridged} />}
         {tab === "memory" && <CtxMemory entries={memory} />}
         {tab === "rules" && <CtxRules settings={settings} />}
@@ -109,171 +92,80 @@ export function ContextPanel({
   );
 }
 
-function CtxFiles({
-  workspaceDir,
-  inContextPaths,
-}: {
-  workspaceDir?: string;
-  inContextPaths: string[];
-}) {
-  const [entries, setEntries] = useState<FileEntry[] | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [collapsed, setCollapsed] = useState<Set<string>>(() => new Set());
-  const [modified, setModified] = useState<Set<string>>(() => new Set());
+type TreeNode =
+  | { kind: "dir"; depth: number; name: string; key: string }
+  | { kind: "file"; depth: number; name: string; key: string; status: "c" | "m" };
 
-  useEffect(() => {
-    if (!workspaceDir) {
-      setEntries(null);
-      setError(null);
-      setCollapsed(new Set());
-      setModified(new Set());
-      return;
+function buildSessionTree(files: SessionFile[]): TreeNode[] {
+  const sorted = [...files].sort((a, b) =>
+    a.path.replace(/\\/g, "/").localeCompare(b.path.replace(/\\/g, "/")),
+  );
+  const out: TreeNode[] = [];
+  const seenDirs = new Set<string>();
+  for (const f of sorted) {
+    const parts = f.path.replace(/\\/g, "/").split("/").filter(Boolean);
+    if (parts.length === 0) continue;
+    let prefix = "";
+    for (let i = 0; i < parts.length - 1; i++) {
+      const seg = parts[i] ?? "";
+      prefix = prefix ? `${prefix}/${seg}` : seg;
+      if (!seenDirs.has(prefix)) {
+        seenDirs.add(prefix);
+        out.push({ kind: "dir", depth: i, name: seg, key: `d:${prefix}` });
+      }
     }
-    let cancelled = false;
-    setEntries(null);
-    setError(null);
-    setCollapsed(new Set());
-    invoke<FileEntry[]>("list_workspace_tree", { root: workspaceDir, maxDepth: 2 })
-      .then((rows) => {
-        if (!cancelled) setEntries(rows);
-      })
-      .catch((err: unknown) => {
-        if (!cancelled) setError(String((err as { message?: string })?.message ?? err));
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [workspaceDir]);
-
-  // Poll git status every 5s. Silent if the workspace isn't a git repo —
-  // the Rust side returns an empty list rather than erroring.
-  useEffect(() => {
-    if (!workspaceDir) return;
-    let cancelled = false;
-    const refresh = () => {
-      invoke<GitStatusEntry[]>("git_status", { root: workspaceDir })
-        .then((rows) => {
-          if (cancelled) return;
-          setModified(new Set(rows.map((r) => r.path.replace(/\\/g, "/"))));
-        })
-        .catch(() => {
-          if (!cancelled) setModified(new Set());
-        });
-    };
-    refresh();
-    const t = setInterval(refresh, 5000);
-    return () => {
-      cancelled = true;
-      clearInterval(t);
-    };
-  }, [workspaceDir]);
-
-  const inContextSet = useMemo(() => {
-    return new Set(inContextPaths.map((p) => p.replace(/\\/g, "/")));
-  }, [inContextPaths]);
-
-  const relativize = (absPath: string): string => {
-    if (!workspaceDir) return absPath;
-    const root = workspaceDir.replace(/\\/g, "/");
-    const norm = absPath.replace(/\\/g, "/");
-    if (norm.startsWith(`${root}/`)) return norm.slice(root.length + 1);
-    if (norm === root) return "";
-    return norm;
-  };
-
-  const statusFor = (e: FileEntry): "m" | "c" | null => {
-    if (e.kind !== "file") return null;
-    const rel = relativize(e.path);
-    if (modified.has(rel)) return "m";
-    if (inContextSet.has(rel) || inContextSet.has(e.path.replace(/\\/g, "/"))) return "c";
-    return null;
-  };
-
-  // depth-first traversal — each entry's parent is the nearest dir above it
-  // at depth-1, which is what walk_dir on the Rust side guarantees.
-  const parentByPath = useMemo(() => {
-    const map = new Map<string, string | null>();
-    if (!entries) return map;
-    const stack: string[] = [];
-    for (const e of entries) {
-      while (stack.length > e.depth) stack.pop();
-      map.set(e.path, e.depth === 0 ? null : (stack[e.depth - 1] ?? null));
-      if (e.kind === "dir") stack[e.depth] = e.path;
-    }
-    return map;
-  }, [entries]);
-
-  const isVisible = (path: string): boolean => {
-    const parent = parentByPath.get(path);
-    if (!parent) return true;
-    if (collapsed.has(parent)) return false;
-    return isVisible(parent);
-  };
-
-  const toggle = (path: string) =>
-    setCollapsed((prev) => {
-      const next = new Set(prev);
-      if (next.has(path)) next.delete(path);
-      else next.add(path);
-      return next;
+    const leaf = parts[parts.length - 1] ?? "";
+    out.push({
+      kind: "file",
+      depth: parts.length - 1,
+      name: leaf,
+      key: `f:${f.path}`,
+      status: f.status,
     });
+  }
+  return out;
+}
 
-  const fileCount = entries?.filter((e) => e.kind === "file").length ?? 0;
-  const visible = entries?.filter((e) => isVisible(e.path)) ?? [];
-
+function CtxFiles({ files }: { files: SessionFile[] }) {
+  const tree = useMemo(() => buildSessionTree(files), [files]);
   return (
     <div className="ctx-block">
       <div className="h">
-        <span>当前工作区</span>
-        <span className="right">{entries ? `${fileCount} files` : "—"}</span>
+        <span>上下文中的文件</span>
+        <span className="right">{files.length === 0 ? "—" : `${files.length} files`}</span>
       </div>
       <div className="tree">
-        {!workspaceDir ? (
-          <div className="ctx-empty">未选择工作区</div>
-        ) : error ? (
-          <div className="ctx-empty">读取失败：{error}</div>
-        ) : entries === null ? (
-          <div className="ctx-empty">加载中…</div>
-        ) : entries.length === 0 ? (
-          <div className="ctx-empty">空目录</div>
+        {files.length === 0 ? (
+          <div className="ctx-empty">本会话尚未读取或修改文件。</div>
         ) : (
-          visible.map((n) => (
-            <div
-              className="node"
-              key={n.path}
-              data-d={n.depth}
-              data-kind={n.kind}
-              title={n.path}
-              onClick={n.kind === "dir" ? () => toggle(n.path) : undefined}
-            >
-              <span className="caret">
-                {n.kind === "dir" ? (
-                  collapsed.has(n.path) ? (
-                    <I.chevR size={10} />
-                  ) : (
-                    <I.chev size={10} />
-                  )
-                ) : null}
-              </span>
-              <span className="ico">
-                {n.kind === "dir" ? <I.folder size={12} /> : <I.file size={12} />}
-              </span>
-              <span className="nm">
-                {n.name}
-                {n.kind === "dir" ? "/" : ""}
-              </span>
-              {(() => {
-                const s = statusFor(n);
-                return s ? (
-                  <span
-                    className="dot"
-                    data-s={s}
-                    title={s === "m" ? "modified" : "in context"}
-                  />
-                ) : null;
-              })()}
-            </div>
-          ))
+          tree.map((n) =>
+            n.kind === "dir" ? (
+              <div className="node" key={n.key} data-d={n.depth} data-kind="dir">
+                <span className="ico">
+                  <I.folder size={12} />
+                </span>
+                <span className="nm">{n.name}/</span>
+              </div>
+            ) : (
+              <div
+                className="node"
+                key={n.key}
+                data-d={n.depth}
+                data-kind="file"
+                title={n.name}
+              >
+                <span className="ico">
+                  <I.file size={12} />
+                </span>
+                <span className="nm">{n.name}</span>
+                <span
+                  className="dot"
+                  data-s={n.status}
+                  title={n.status === "m" ? "modified" : "in context"}
+                />
+              </div>
+            ),
+          )
         )}
       </div>
     </div>

--- a/desktop/src/ui/live.tsx
+++ b/desktop/src/ui/live.tsx
@@ -63,7 +63,7 @@ export function LiveReasoning({ lines }: { lines: string[] }) {
       {lines.map((line, i) => (
         <div key={i}>
           {line}
-          {i === lines.length - 1 ? <span className="caret" /> : null}
+          {i === lines.length - 1 ? <span className="stream-caret" /> : null}
         </div>
       ))}
     </div>

--- a/desktop/src/ui/thread.tsx
+++ b/desktop/src/ui/thread.tsx
@@ -351,6 +351,50 @@ export function ConfirmApprovalCard({
   );
 }
 
+export function PathAccessApprovalCard({
+  p,
+  onAllow,
+  onAlwaysAllow,
+  onDeny,
+}: {
+  p: {
+    id: number;
+    path: string;
+    intent: "read" | "write";
+    toolName: string;
+    sandboxRoot: string;
+    allowPrefix: string;
+  };
+  onAllow: () => void;
+  onAlwaysAllow: (prefix: string) => void;
+  onDeny: () => void;
+}) {
+  const intentText = p.intent === "write" ? "写入" : "读取";
+  return (
+    <ApprovalCard
+      kind="path access"
+      tone="warn"
+      title={`${intentText}沙盒外的路径`}
+      sub={p.path}
+      preview={
+        <>
+          <div>{p.toolName} → {p.path}</div>
+          <div style={{ color: "var(--muted)", marginTop: 4 }}>
+            workspace: {p.sandboxRoot}
+          </div>
+        </>
+      }
+      meta={`risk · 中 · ${p.intent}`}
+      primaryLabel={intentText === "写入" ? "允许写入" : "允许读取"}
+      secondaryLabel="拒绝"
+      tertiaryLabel={`始终允许 ${p.allowPrefix}`}
+      onPrimary={onAllow}
+      onSecondary={onDeny}
+      onTertiary={() => onAlwaysAllow(p.allowPrefix)}
+    />
+  );
+}
+
 export function ChoiceApprovalCard({
   c,
   onPick,

--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -212,6 +212,16 @@ interface ConfirmRequiredEvent {
   command: string;
 }
 
+interface PathAccessRequiredEvent {
+  type: "$path_access_required";
+  id: number;
+  path: string;
+  intent: "read" | "write";
+  toolName: string;
+  sandboxRoot: string;
+  allowPrefix: string;
+}
+
 interface ChoiceRequiredEvent {
   type: "$choice_required";
   id: number;
@@ -316,6 +326,7 @@ type EmittableEvent =
   | { type: "$error"; message: string }
   | { type: "$turn_complete" }
   | ConfirmRequiredEvent
+  | PathAccessRequiredEvent
   | ChoiceRequiredEvent
   | PlanRequiredEvent
   | CheckpointRequiredEvent
@@ -942,6 +953,28 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
       const payload = req.payload as { command?: string };
       emit(
         { type: "$confirm_required", id: req.id, kind: req.kind, command: payload.command ?? "" },
+        tabId,
+      );
+      return;
+    }
+    if (req.kind === "path_access") {
+      const payload = req.payload as {
+        path: string;
+        intent: "read" | "write";
+        toolName: string;
+        sandboxRoot: string;
+        allowPrefix: string;
+      };
+      emit(
+        {
+          type: "$path_access_required",
+          id: req.id,
+          path: payload.path,
+          intent: payload.intent,
+          toolName: payload.toolName,
+          sandboxRoot: payload.sandboxRoot,
+          allowPrefix: payload.allowPrefix,
+        },
         tabId,
       );
       return;


### PR DESCRIPTION
## Summary
Two desktop-side gaps from the same field report (model tried to `get_file_info /tmp/big_buck_bunny_1080p.mov` on a Windows workspace; tool call stuck on `RUNNING` indefinitely).

- **path_access gate wiring.** `pauseGate.on` in `desktop.ts` handled run_command, run_background, choice, and plan_* requests but had no case for path_access. Any outside-sandbox read parked the tool call with no UI surface. Now emits `$path_access_required` and renders a `PathAccessApprovalCard` (allow once / always allow prefix / deny). Response reuses the existing `confirm_response` command since both gates return a `ConfirmationChoice`.
- **Right-panel Files tab scope.** The tab was dumping the entire workspace tree (up to 800 entries) overlaid with `git status` dots and polling every 5 s. The mockup intent was a curated "files in context" view — only files the agent has touched this session, status `c` for reads and `m` for writes. Rewrote `CtxFiles` to consume a session-tracked list directly; tree falls out from the small flat list via parent-dir grouping. Status `m` never downgrades back to `c`. Dropped the `list_workspace_tree` / `git_status` invokes (the Rust commands stay in place but go unused for now).

Companion to #786 — that PR makes YOLO bypass `path_access` automatically. This PR is what users in `review` / `auto` modes need so the gate doesn't hang.

## Test plan
- [x] `npx tsc --noEmit` clean in both repo root and `desktop/`
- [x] `vite build` clean
- [ ] manual: outside-sandbox read in review mode pops the approval card; allow / deny / always-allow each round-trip
- [ ] manual: read a workspace file → green dot in right panel; edit it → turns yellow; new chat → list clears