### PR TITLE
chore(release): sync desktop version from tag, set minimum CSP

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,9 @@ jobs:
       - name: Install root deps
         run: npm ci
 
+      - name: Sync desktop version from tag
+        run: node scripts/sync-desktop-version.mjs "${{ steps.tag.outputs.name }}"
+
       - name: Build CLI bundle (dist/)
         run: npm run build
 

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -24,7 +24,7 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; img-src 'self' data: asset: https://asset.localhost; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' ipc: http://ipc.localhost"
     }
   },
   "bundle": {

--- a/scripts/sync-desktop-version.mjs
+++ b/scripts/sync-desktop-version.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const explicit = process.argv[2];
+const tag = explicit ?? process.env.GITHUB_REF_NAME ?? process.env.TAG;
+
+if (!tag) {
+  console.error("usage: sync-desktop-version.mjs <version>  (or set GITHUB_REF_NAME / TAG)");
+  process.exit(1);
+}
+
+const version = tag.replace(/^v/, "");
+if (!/^\d+\.\d+\.\d+(-[\w.-]+)?(\+[\w.-]+)?$/.test(version)) {
+  console.error(`refusing to write non-SemVer version: ${version}`);
+  process.exit(1);
+}
+
+const tauriConfPath = join(repoRoot, "desktop/src-tauri/tauri.conf.json");
+const cargoTomlPath = join(repoRoot, "desktop/src-tauri/Cargo.toml");
+const desktopPkgPath = join(repoRoot, "desktop/package.json");
+
+const tauriConf = JSON.parse(readFileSync(tauriConfPath, "utf8"));
+tauriConf.version = version;
+writeFileSync(tauriConfPath, `${JSON.stringify(tauriConf, null, 2)}\n`);
+
+const cargoToml = readFileSync(cargoTomlPath, "utf8");
+const nextCargo = cargoToml.replace(
+  /^version = ".*"$/m,
+  `version = "${version}"`,
+);
+if (nextCargo === cargoToml) {
+  console.error(`Cargo.toml: no version line matched`);
+  process.exit(1);
+}
+writeFileSync(cargoTomlPath, nextCargo);
+
+const desktopPkg = JSON.parse(readFileSync(desktopPkgPath, "utf8"));
+desktopPkg.version = version;
+writeFileSync(desktopPkgPath, `${JSON.stringify(desktopPkg, null, 2)}\n`);
+
+console.log(`Synced desktop version → ${version}`);
+console.log(`  ${tauriConfPath}`);
+console.log(`  ${cargoTomlPath}`);
+console.log(`  ${desktopPkgPath}`);


### PR DESCRIPTION
## Summary
Two prerequisites for the desktop's first prerelease bundle.

- `Cargo.toml`, `tauri.conf.json`, and `desktop/package.json` were all stuck at `0.0.0`. `tauri-action` doesn't auto-rewrite them from the tag, so artifact filenames would come out as `Reasonix_0.0.0_x64-setup.exe` and the updater's version compare would be broken. New `scripts/sync-desktop-version.mjs` reads the tag (or `GITHUB_REF_NAME` / `TAG` env var) and writes the SemVer to all three files. Wired into `release.yml` between `npm ci` and the CLI build step.
- CSP was `null`. Switched to a minimum self-only policy with escapes for inline styles, fonts, and Tauri IPC origins (`ipc:` + `http://ipc.localhost`). Only applied to the bundled build; dev server unaffected.

The updater pubkey was already committed on a previous pass. Code-signing certs (Windows EV, macOS Developer ID) are a later step — first prerelease can ship unsigned with the usual SmartScreen / Gatekeeper warnings.

## Test plan
- [x] `node scripts/sync-desktop-version.mjs v0.42.0-test.0` writes the expected fields, smoke-tested locally
- [x] SemVer guard rejects malformed inputs
- [ ] manual: cut `v0.42.0-desktop.0` tag and confirm artifacts come out named `Reasonix_0.42.0-desktop.0_*` across the four platform matrix shards