### PR TITLE
feat(skills): max-iters frontmatter raises subagent tool budget

### DIFF
--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -340,6 +340,7 @@ description: <span data-i18n="sk.fm.desc">Review git log for security red flags.
 runAs: inline                  <span class="hash"># <span data-i18n="sk.fm.runas">inline | subagent</span></span>
 allowed-tools: bash,read       <span class="hash"># <span data-i18n="sk.fm.tools">subagent tool allowlist</span></span>
 model: deepseek-chat           <span class="hash"># <span data-i18n="sk.fm.model">subagent model override</span></span>
+max-iters: 32                  <span class="hash"># <span data-i18n="sk.fm.iters">subagent tool-call budget (default 16, max 32)</span></span>
 ---
 
 ## <span data-i18n="sk.body.task">Task</span>
@@ -373,6 +374,12 @@ model: deepseek-chat           <span class="hash"># <span data-i18n="sk.fm.model
                 <code>model</code>
                 <span data-i18n="sk.fm.f.model">
                   Subagent only. Must start with <code>deepseek-</code>; ignored otherwise.
+                </span>
+              </li>
+              <li>
+                <code>max-iters</code>
+                <span data-i18n="sk.fm.f.iters">
+                  Subagent only. Tool-call budget for the spawned loop. Default 16, clamped to [1, 32]. Raise when a skill empirically runs out before finishing.
                 </span>
               </li>
             </ul>

--- a/src/code/setup.ts
+++ b/src/code/setup.ts
@@ -82,6 +82,7 @@ export async function buildCodeToolset(opts: CodeToolsetOpts): Promise<CodeTools
         task,
         model: skill.model,
         allowedTools: skill.allowedTools,
+        maxToolIters: skill.maxToolIters,
       });
       return formatSubagentResult(result);
     },

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -34,6 +34,8 @@ export interface Skill {
   runAs: SkillRunAs;
   /** Subagent model override; only meaningful when `runAs === "subagent"`. */
   model?: string;
+  /** Subagent tool-call budget; only meaningful when `runAs === "subagent"`. Clamped to [1, 32]. */
+  maxToolIters?: number;
 }
 
 export interface SkillStoreOptions {
@@ -69,6 +71,17 @@ function parseAllowedTools(raw: string | undefined): readonly string[] | undefin
     .map((s) => s.trim())
     .filter(Boolean);
   return names.length > 0 ? Object.freeze(names) : undefined;
+}
+
+/** Match subagent's own bounds (src/tools/subagent.ts MIN_MAX_ITERS / MAX_MAX_ITERS). */
+const SKILL_MAX_ITERS_MIN = 1;
+const SKILL_MAX_ITERS_MAX = 32;
+
+function parseMaxToolIters(raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined;
+  const n = Number.parseInt(raw.trim(), 10);
+  if (!Number.isFinite(n)) return undefined;
+  return Math.min(SKILL_MAX_ITERS_MAX, Math.max(SKILL_MAX_ITERS_MIN, n));
 }
 
 export class SkillStore {
@@ -219,6 +232,7 @@ export class SkillStore {
       allowedTools: parseAllowedTools(data["allowed-tools"]),
       runAs: parseRunAs(data.runAs),
       model: data.model?.startsWith("deepseek-") ? data.model : undefined,
+      maxToolIters: parseMaxToolIters(data["max-iters"]),
     };
   }
 }
@@ -243,6 +257,7 @@ Tips:
 - Reference tools by name (run_command, edit_file, search_content, ...)
 - Add \`runAs: subagent\` to frontmatter to spawn an isolated subagent loop
 - Add \`allowed-tools: read_file, search_content\` to scope a subagent's tools
+- Add \`max-iters: 32\` to raise the subagent's tool-call budget (default 16, max 32)
 `;
 }
 

--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -397,6 +397,58 @@ describe("Skill frontmatter — runAs", () => {
     const store = new SkillStore({ homeDir: home, disableBuiltins: true });
     expect(store.read("empty")?.allowedTools).toBeUndefined();
   });
+
+  it("parses max-iters and passes it through as maxToolIters", () => {
+    writeSkillDir(
+      home,
+      "global",
+      "big",
+      { description: "...", runAs: "subagent", "max-iters": "32" },
+      "body",
+      home,
+    );
+    const store = new SkillStore({ homeDir: home, disableBuiltins: true });
+    expect(store.read("big")?.maxToolIters).toBe(32);
+  });
+
+  it("clamps max-iters above 32 to the upper bound", () => {
+    writeSkillDir(
+      home,
+      "global",
+      "toobig",
+      { description: "...", runAs: "subagent", "max-iters": "100" },
+      "body",
+      home,
+    );
+    const store = new SkillStore({ homeDir: home, disableBuiltins: true });
+    expect(store.read("toobig")?.maxToolIters).toBe(32);
+  });
+
+  it("clamps max-iters below 1 to the lower bound", () => {
+    writeSkillDir(
+      home,
+      "global",
+      "toosmall",
+      { description: "...", runAs: "subagent", "max-iters": "0" },
+      "body",
+      home,
+    );
+    const store = new SkillStore({ homeDir: home, disableBuiltins: true });
+    expect(store.read("toosmall")?.maxToolIters).toBe(1);
+  });
+
+  it("ignores max-iters that isn't a number", () => {
+    writeSkillDir(
+      home,
+      "global",
+      "junk",
+      { description: "...", runAs: "subagent", "max-iters": "many" },
+      "body",
+      home,
+    );
+    const store = new SkillStore({ homeDir: home, disableBuiltins: true });
+    expect(store.read("junk")?.maxToolIters).toBeUndefined();
+  });
 });
 
 describe("Built-in skills", () => {


### PR DESCRIPTION
## Summary
Skills with `runAs: subagent` were hard-capped at the spawn default of 16 tool calls. Big review / exploration playbooks bailed early with `Tool budget exhausted at 16 calls`. The `setup.ts` run_skill bridge wasn't passing `maxToolIters` through; `Skill` didn't even carry that field.

Adds `max-iters` to the parsed frontmatter, clamped to [1, 32] to match the `spawn_subagent` JSON-schema bounds. Plumbed through to `spawnSubagent`. Documented in `docs/configuration.html` and the `/skill new` stub.

```yaml
---
name: review-pro
runAs: subagent
model: deepseek-v4-pro
max-iters: 32        # ← new, raises from default 16
---
```

Invalid / out-of-range values fall back safely:
- junk text → `undefined` (skill uses default 16)
- `>32` → `32`
- `<1` → `1`

Closes #783

## Test plan
- [x] `npx vitest run tests/skills.test.ts` — 39 passed (35 existing + 4 new)
- [x] new tests cover: parse + clamp upper + clamp lower + ignore junk
- [x] `npx tsc --noEmit` clean