### PR TITLE
fix(desktop): kill Node child on Tauri exit, add rpc_kill command

### DIFF
--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -2,7 +2,7 @@
 
 mod rpc;
 
-use rpc::{RpcState, rpc_send, rpc_spawn};
+use rpc::{RpcState, rpc_kill, rpc_send, rpc_spawn};
 use serde::Serialize;
 use std::path::Path;
 
@@ -169,6 +169,7 @@ fn main() {
         .invoke_handler(tauri::generate_handler![
             rpc_spawn,
             rpc_send,
+            rpc_kill,
             open_in_editor,
             list_workspace_tree,
             git_status
@@ -186,6 +187,16 @@ fn main() {
             let _ = app;
             Ok(())
         })
-        .run(tauri::generate_context!())
-        .expect("tauri run failed");
+        .build(tauri::generate_context!())
+        .expect("tauri build failed")
+        .run(|app, event| {
+            // Tauri 2 normally exits the process via Exit; managed-state drops
+            // don't always run. ExitRequested fires before that, so we kill the
+            // Node child here too — belt-and-braces vs the Drop on RpcHandle.
+            if let tauri::RunEvent::ExitRequested { .. } = event {
+                use tauri::Manager;
+                let state = app.state::<RpcState>();
+                let _ = rpc::rpc_kill(state);
+            }
+        });
 }

--- a/desktop/src-tauri/src/rpc.rs
+++ b/desktop/src-tauri/src/rpc.rs
@@ -3,7 +3,9 @@ use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
 use std::process::{ChildStdin, Command, Stdio};
 use std::sync::Arc;
+use std::sync::mpsc;
 use std::thread;
+use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow};
 use parking_lot::Mutex;
@@ -20,6 +22,10 @@ pub struct RpcState {
 
 struct RpcHandle {
     stdin: ChildStdin,
+    /// Held only so its drop disconnects the wait thread's recv, signalling
+    /// it to kill the child. Replaces the old fire-and-forget exit watcher
+    /// that left Node orphaned if Tauri exited while a tool call was in flight.
+    _kill_signal: mpsc::Sender<()>,
 }
 
 #[derive(Clone, Serialize)]
@@ -164,7 +170,8 @@ pub fn rpc_spawn(app: AppHandle, state: State<'_, RpcState>) -> Result<(), Strin
     let stdout = child.stdout.take().ok_or("no stdout")?;
     let stderr = child.stderr.take().ok_or("no stderr")?;
 
-    *guard = Some(RpcHandle { stdin });
+    let (kill_tx, kill_rx) = mpsc::channel::<()>();
+    *guard = Some(RpcHandle { stdin, _kill_signal: kill_tx });
     drop(guard);
 
     let app_for_stdout = app.clone();
@@ -183,12 +190,45 @@ pub fn rpc_spawn(app: AppHandle, state: State<'_, RpcState>) -> Result<(), Strin
         }
     });
 
+    // Wait thread: poll try_wait every 500 ms while watching the kill channel.
+    // Disconnected fires when RpcHandle drops (rpc_kill or Tauri exit) — the
+    // 500 ms cadence is a tradeoff between exit-detection latency and idle CPU.
     let app_for_exit = app.clone();
+    let inner_for_exit = state.inner.clone();
     thread::spawn(move || {
-        let code = child.wait().ok().and_then(|s| s.code());
-        let _ = app_for_exit.emit("rpc:exit", ExitEvent { code });
+        loop {
+            match kill_rx.recv_timeout(Duration::from_millis(500)) {
+                Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    let _ = child.kill();
+                    let code = child.wait().ok().and_then(|s| s.code());
+                    let _ = app_for_exit.emit("rpc:exit", ExitEvent { code });
+                    return;
+                }
+                Err(mpsc::RecvTimeoutError::Timeout) => match child.try_wait() {
+                    Ok(Some(status)) => {
+                        let _ = inner_for_exit.lock().take();
+                        let _ = app_for_exit.emit("rpc:exit", ExitEvent { code: status.code() });
+                        return;
+                    }
+                    Ok(None) => continue,
+                    Err(_) => {
+                        let _ = child.kill();
+                        let _ = inner_for_exit.lock().take();
+                        return;
+                    }
+                },
+            }
+        }
     });
 
+    Ok(())
+}
+
+/// Drop the spawned Node child cleanly. Used by Tauri-side teardown and by a
+/// future "restart RPC" UI affordance. Idempotent — no-op if nothing is running.
+#[tauri::command]
+pub fn rpc_kill(state: State<'_, RpcState>) -> Result<(), String> {
+    state.inner.lock().take();
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
The previous exit watcher in `rpc.rs` took the spawned `Child` by move and blocked on `child.wait()`, with no way to interrupt it from outside. `RpcHandle` only stored `stdin`, so the only thing keeping Node alive-or-not was the stdin pipe closing on parent exit — fine in the common case but leaks the child if Node is mid-tool-call when Tauri exits (e.g. a running `wait_for_job` or a native module that doesn't promptly process stdin EOF).

Replaces the watcher with a `recv_timeout` loop on a kill-signal mpsc:
- `RpcHandle` holds the `Sender`. Dropping the handle disconnects the channel.
- The wait thread sees `Disconnected` and calls `child.kill()` followed by `wait()` to reap.
- Natural exit (`try_wait` returns `Some`) is detected on the 500 ms tick and clears `RpcState`, so a future `rpc_spawn` isn't blocked by stale state.

Tauri 2's process exit doesn't always run managed-state drops, so `RunEvent::ExitRequested` also invokes `rpc_kill` explicitly — belt-and-braces.

`rpc_kill` is exposed as a `#[tauri::command]` for a future "restart RPC" UI button; not wired to a button in this PR.

## Test plan
- [x] `cargo build` clean
- [ ] manual: close Tauri window with Node mid-tool-call, confirm child terminates in Task Manager
- [ ] manual: invoke `rpc_kill` from devtools → Node exits → respawn works without an error