### PR TITLE
fix(release): split bundle step so unsigned builds skip codesign envs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,13 +83,49 @@ jobs:
         working-directory: desktop
         run: npm run bundle:node
 
-      - name: Build Tauri bundle
+      # tauri-action signs OS bundles whenever the corresponding env vars are
+      # defined — including when they're defined to the empty string, which is
+      # what `secrets.UNSET` evaluates to. Gate each signing block on its
+      # certificate being non-empty so unsigned prereleases don't trip
+      # `security import` / `signtool` on missing certs.
+      - name: Build Tauri bundle (unsigned)
+        if: >-
+          (matrix.target.os != 'windows-latest' || secrets.WINDOWS_CERTIFICATE == '')
+          && (!startsWith(matrix.target.os, 'macos-') || secrets.APPLE_CERTIFICATE == '')
+        uses: tauri-apps/tauri-action@v0
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        with:
+          projectPath: desktop
+          tagName: ${{ steps.tag.outputs.name }}
+          releaseName: Reasonix ${{ steps.tag.outputs.name }}
+          releaseDraft: true
+          prerelease: false
+          args: --target ${{ matrix.target.rust }}
+
+      - name: Build Tauri bundle (Windows, signed)
+        if: matrix.target.os == 'windows-latest' && secrets.WINDOWS_CERTIFICATE != ''
         uses: tauri-apps/tauri-action@v0
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
           WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
+        with:
+          projectPath: desktop
+          tagName: ${{ steps.tag.outputs.name }}
+          releaseName: Reasonix ${{ steps.tag.outputs.name }}
+          releaseDraft: true
+          prerelease: false
+          args: --target ${{ matrix.target.rust }}
+
+      - name: Build Tauri bundle (macOS, signed + notarized)
+        if: startsWith(matrix.target.os, 'macos-') && secrets.APPLE_CERTIFICATE != ''
+        uses: tauri-apps/tauri-action@v0
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}


### PR DESCRIPTION
## Summary
Releasing v0.42.0-desktop.0 surfaced two issues. This PR fixes the more critical one.

When an `APPLE_*` or `WINDOWS_CERTIFICATE` secret is unset, GitHub Actions fills the env var with an empty string. tauri-action treats "env defined" as "try to sign", so:
- macOS: `security: SecKeychainItemImport: One or more parameters passed to a function were not valid.`
- Windows: would fail the same way on `signtool` once we add an .exe signing path

Splits the single `Build Tauri bundle` step into three mutually exclusive variants gated on whether the certificate secret is actually non-empty:
- **unsigned** (Linux always; Windows/macOS when no cert) — runs today
- **Windows signed** — only when `secrets.WINDOWS_CERTIFICATE != ''`
- **macOS signed + notarized** — only when `secrets.APPLE_CERTIFICATE != ''`

Only the Tauri updater key (`TAURI_SIGNING_PRIVATE_KEY`) is configured today, so every matrix shard takes the unsigned path. Wiring stays in place for when CA / Developer ID certs land.

## The other v0.42.0-desktop.0 failure (Windows MSI)

Separately, the MSI bundler rejected `0.42.0-desktop.0`: `optional pre-release identifier in app version must be numeric-only`. Not fixed in this PR — handled by re-tagging as `v0.42.0-0` (numeric prerelease) once this merges.

## Test plan
- [x] YAML lint clean (`actionlint` not run locally; conditions hand-verified)
- [ ] Re-tag `v0.42.0-0` after merge and confirm all 4 matrix shards reach the unsigned-bundle step