### PR TITLE
fix(release): pass GITHUB_TOKEN to tauri-action so the draft release upload works

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,7 @@ jobs:
           && (!startsWith(matrix.target.os, 'macos-') || env.HAS_APPLE_CERT != 'true')
         uses: tauri-apps/tauri-action@v0
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
@@ -113,6 +114,7 @@ jobs:
         if: matrix.target.os == 'windows-latest' && env.HAS_WIN_CERT == 'true'
         uses: tauri-apps/tauri-action@v0
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
@@ -129,6 +131,7 @@ jobs:
         if: startsWith(matrix.target.os, 'macos-') && env.HAS_APPLE_CERT == 'true'
         uses: tauri-apps/tauri-action@v0
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}


### PR DESCRIPTION
## Summary
`v0.42.0-0` build got past compile + bundle (MSI included — the numeric prerelease tag fixed WiX) but died at `GITHUB_TOKEN is required` when `tauri-action` tried to create the draft release. The earlier codesign failure on `v0.42.0-desktop.0` masked this — the build never reached upload, so nobody noticed the token was missing.

`tauri-action@v0` reads `GITHUB_TOKEN` from env for the GitHub API call that creates the draft + uploads assets. Wires `secrets.GITHUB_TOKEN` into all three build-step variants (unsigned, Windows signed, macOS signed).

Windows shard from the failed run produced its full artifact set before the upload error:
- `Reasonix_0.42.0-0_x64_en-US.msi`
- `Reasonix_0.42.0-0_x64-setup.exe` (NSIS)
- `.sig` files for both

So bundling + minisign signing on the unsigned path already works end-to-end.

## Test plan
- [ ] After merge, tag `v0.42.0-1`; expect 4-shard matrix to succeed and produce a draft release on the Releases page