### PR TITLE
ci(release): mirror published releases to Gitee + R2

### DIFF
--- a/.github/workflows/release-mirror.yml
+++ b/.github/workflows/release-mirror.yml
@@ -1,0 +1,103 @@
+name: Release mirror
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to mirror (e.g. v0.42.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  mirror:
+    name: Mirror release assets
+    runs-on: ubuntu-latest
+    env:
+      HAS_GITEE: ${{ secrets.GITEE_TOKEN != '' }}
+      HAS_R2: ${{ secrets.R2_ACCESS_KEY_ID != '' && secrets.R2_SECRET_ACCESS_KEY != '' && secrets.R2_ACCOUNT_ID != '' && secrets.R2_BUCKET != '' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Resolve tag
+        id: tag
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "name=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download release assets from GitHub
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p assets
+          gh release download "${{ steps.tag.outputs.name }}" \
+            -R "${{ github.repository }}" \
+            -D assets
+
+      - name: Fetch release notes
+        id: notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BODY=$(gh release view "${{ steps.tag.outputs.name }}" \
+            -R "${{ github.repository }}" --json body --jq .body)
+          {
+            echo "body<<RELEASE_BODY_EOF"
+            echo "$BODY"
+            echo "RELEASE_BODY_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Mirror to Gitee
+        if: env.HAS_GITEE == 'true'
+        env:
+          GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
+          GITEE_REPO: reasonix/deep-seek-reasonix
+          RELEASE_TAG: ${{ steps.tag.outputs.name }}
+          RELEASE_BODY: ${{ steps.notes.outputs.body }}
+          ASSETS_DIR: assets
+        run: node scripts/mirror-release-to-gitee.mjs
+
+      - name: Configure AWS CLI for R2
+        if: env.HAS_R2 == 'true'
+        run: |
+          aws configure set aws_access_key_id "${{ secrets.R2_ACCESS_KEY_ID }}"
+          aws configure set aws_secret_access_key "${{ secrets.R2_SECRET_ACCESS_KEY }}"
+          aws configure set region auto
+
+      - name: Mirror to R2
+        if: env.HAS_R2 == 'true'
+        env:
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          TAG: ${{ steps.tag.outputs.name }}
+        run: |
+          ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+          aws s3 cp assets/ "s3://${R2_BUCKET}/${TAG}/" \
+            --recursive \
+            --endpoint-url "$ENDPOINT"
+          aws s3 cp assets/ "s3://${R2_BUCKET}/latest/" \
+            --recursive \
+            --endpoint-url "$ENDPOINT"
+
+      - name: Summary
+        run: |
+          {
+            echo "## Mirror result"
+            echo ""
+            echo "- Tag: \`${{ steps.tag.outputs.name }}\`"
+            echo "- Gitee: ${{ env.HAS_GITEE == 'true' && '✓ mirrored' || 'skipped (no GITEE_TOKEN)' }}"
+            echo "- R2:    ${{ env.HAS_R2 == 'true' && '✓ mirrored' || 'skipped (no R2 secrets)' }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/mirror-release-to-gitee.mjs
+++ b/scripts/mirror-release-to-gitee.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+// Pushes assets in $ASSETS_DIR to a Gitee Release matching $RELEASE_TAG, creating it if needed.
+
+import { readFile, readdir, stat } from "node:fs/promises";
+import path from "node:path";
+
+const GITEE_API = "https://gitee.com/api/v5";
+
+function envOrDie(name) {
+  const v = process.env[name];
+  if (!v) throw new Error(`missing env: ${name}`);
+  return v;
+}
+
+const TOKEN = envOrDie("GITEE_TOKEN");
+const REPO = envOrDie("GITEE_REPO");
+const TAG = envOrDie("RELEASE_TAG");
+const ASSETS_DIR = envOrDie("ASSETS_DIR");
+const RELEASE_NAME = process.env.RELEASE_NAME ?? `Reasonix ${TAG}`;
+const RELEASE_BODY = process.env.RELEASE_BODY ?? `Mirror of GitHub Release ${TAG}.`;
+const TARGET_BRANCH = process.env.GITEE_TARGET_BRANCH ?? "main";
+
+async function giteeFetch(p, init = {}) {
+  const res = await fetch(`${GITEE_API}${p}`, {
+    ...init,
+    headers: { ...(init.headers ?? {}), Authorization: `token ${TOKEN}` },
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Gitee ${init.method ?? "GET"} ${p} → ${res.status}: ${body}`);
+  }
+  return res;
+}
+
+async function getOrCreateRelease() {
+  const lookup = await fetch(
+    `${GITEE_API}/repos/${REPO}/releases/tags/${encodeURIComponent(TAG)}`,
+    { headers: { Authorization: `token ${TOKEN}` } },
+  );
+  if (lookup.status === 200) {
+    const data = await lookup.json();
+    console.log(`Gitee: release ${TAG} exists (id=${data.id}), reusing.`);
+    return data;
+  }
+  if (lookup.status !== 404) {
+    const body = await lookup.text().catch(() => "");
+    throw new Error(`Gitee lookup failed: ${lookup.status}: ${body}`);
+  }
+  const res = await giteeFetch(`/repos/${REPO}/releases`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      tag_name: TAG,
+      name: RELEASE_NAME,
+      body: RELEASE_BODY,
+      prerelease: false,
+      target_commitish: TARGET_BRANCH,
+    }),
+  });
+  const data = await res.json();
+  console.log(`Gitee: created release ${TAG} (id=${data.id}).`);
+  return data;
+}
+
+async function existingAssetNames(releaseId) {
+  const res = await fetch(`${GITEE_API}/repos/${REPO}/releases/${releaseId}`, {
+    headers: { Authorization: `token ${TOKEN}` },
+  });
+  if (!res.ok) return new Set();
+  const data = await res.json();
+  return new Set((data.assets ?? []).map((a) => a.name));
+}
+
+async function uploadAsset(releaseId, filePath) {
+  const filename = path.basename(filePath);
+  const buf = await readFile(filePath);
+  const form = new FormData();
+  form.append("file", new Blob([buf]), filename);
+  const res = await fetch(`${GITEE_API}/repos/${REPO}/releases/${releaseId}/attach_files`, {
+    method: "POST",
+    headers: { Authorization: `token ${TOKEN}` },
+    body: form,
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`upload ${filename} → ${res.status}: ${body}`);
+  }
+  console.log(`Gitee: uploaded ${filename} (${buf.byteLength} bytes)`);
+}
+
+const release = await getOrCreateRelease();
+const skip = await existingAssetNames(release.id);
+for (const name of await readdir(ASSETS_DIR)) {
+  const fp = path.join(ASSETS_DIR, name);
+  const st = await stat(fp);
+  if (!st.isFile()) continue;
+  if (skip.has(name)) {
+    console.log(`Gitee: skip ${name} (already present)`);
+    continue;
+  }
+  await uploadAsset(release.id, fp);
+}
+console.log("Gitee mirror complete.");


### PR DESCRIPTION
## Summary

New `release-mirror.yml` workflow fires on `release: published` (and is manually runnable). Downloads the GH release assets, then in two parallel steps:

- **Gitee**: creates / reuses a Release at the same tag on `reasonix/deep-seek-reasonix` and uploads each asset via the v5 API. Release notes are copied from the GH release body. Helper script lives at `scripts/mirror-release-to-gitee.mjs`.
- **R2**: `aws s3 cp --recursive --endpoint-url <R2>` to `<bucket>/<tag>/` and `<bucket>/latest/`.

Both mirror steps gate on their secrets being present, so the workflow no-ops cleanly until tokens are configured. The build pipeline (`release.yml`) is untouched — mirroring is downstream of GH publish.

## Required secrets

| Name | Used for |
|---|---|
| `GITEE_TOKEN` | Gitee Release create + asset upload |
| `R2_ACCOUNT_ID` | R2 endpoint host |
| `R2_ACCESS_KEY_ID` | R2 S3 auth |
| `R2_SECRET_ACCESS_KEY` | R2 S3 auth |
| `R2_BUCKET` | Target bucket name |

## Test plan

- [x] `node --check scripts/mirror-release-to-gitee.mjs` clean
- [x] `npm run lint` clean (only the pre-existing `plan-confirm.test.tsx` warning, unrelated)
- [ ] Add `GITEE_TOKEN`, run workflow manually with an existing tag, verify Release appears on Gitee with all assets
- [ ] Add R2 secrets, re-run, verify objects appear under `<tag>/` and `latest/`

Refs #802
