### PR TITLE
feat(slash): autocomplete skill names in /skill arg picker

### DIFF
--- a/src/cli/ui/slash/commands.ts
+++ b/src/cli/ui/slash/commands.ts
@@ -175,6 +175,7 @@ export const SLASH_COMMANDS: readonly SlashCommandSpec[] = [
     group: "extend",
     argsHint: "[list|show <name>|new <name>|<name> [args]]",
     summary: "list / run / scaffold user skills (<project>/.reasonix/skills + ~/.reasonix/skills)",
+    argCompleter: "skills",
   },
 
   {

--- a/src/cli/ui/slash/types.ts
+++ b/src/cli/ui/slash/types.ts
@@ -165,7 +165,7 @@ export interface SlashCommandSpec {
   /** If the command takes args, hint text shown after the name. */
   argsHint?: string;
   /** First-arg picker source — file paths intentionally absent (use `@path` mentions instead). */
-  argCompleter?: "models" | "mcp-resources" | "mcp-prompts" | readonly string[];
+  argCompleter?: "models" | "mcp-resources" | "mcp-prompts" | "skills" | readonly string[];
   /** Alternate names — typing any of these resolves to `cmd` for dispatch / suggestion / arg-context. */
   aliases?: readonly string[];
 }

--- a/src/cli/ui/useCompletionPickers.ts
+++ b/src/cli/ui/useCompletionPickers.ts
@@ -9,6 +9,7 @@ import {
   rankPickerCandidates,
   walkFilesStream,
 } from "../../at-mentions.js";
+import { SkillStore } from "../../skills.js";
 import {
   type McpServerSummary,
   type SlashArgContext,
@@ -228,8 +229,18 @@ export function useCompletionPickers({
       if (!partial) return names.slice(0, 40);
       return names.filter((n) => n.toLowerCase().includes(needle)).slice(0, 40);
     }
+    if (completer === "skills") {
+      const store = new SkillStore({ projectRoot: codeMode?.rootDir });
+      const names = store
+        .list()
+        .filter((s) => s.scope !== "builtin")
+        .map((s) => s.name);
+      if (partial && names.some((n) => n.toLowerCase() === needle)) return null;
+      if (!partial) return names.slice(0, 40);
+      return names.filter((n) => n.toLowerCase().includes(needle)).slice(0, 40);
+    }
     return null;
-  }, [slashArgContext, models, mcpServers]);
+  }, [slashArgContext, models, mcpServers, codeMode]);
   useEffect(() => {
     setSlashArgSelected((prev) => {
       if (!slashArgMatches || slashArgMatches.length === 0) return 0;


### PR DESCRIPTION
Add `argCompleter: "skills"` to the `/skill\ command so users see a picker with available user-defined skills (project + global scope) when typing `/skill ` — excludes built-in skills to reduce noise.

## Changes

- **`src/cli/ui/slash/types.ts`** — Add `"skills"\ to the `argCompleter` type union in `SlashCommandSpec`
- **`src/cli/ui/slash/commands.ts`** — Register `argCompleter: "skills"` on the skill command spec
- **`src/cli/ui/useCompletionPickers.ts`** — Add `SkillStore`-based resolver that lists project + global skills (filters out `builtin` scope)

## Testing

- Typecheck: ✅ `tsc --noEmit`
- Build: ✅ `tsup`
- All existing tests pass (GPG-related failures in `server-dashboard.test.ts` are pre-existing)

<img width="3120" height="868" alt="image" src="https://github.com/user-attachments/assets/c0cb4f50-2adf-43ad-b703-c91e20bd5c0e" />
