### PR TITLE
fix(desktop): bundled CLI loads on installed targets; drop CDN fonts

### DIFF
--- a/desktop/index.html
+++ b/desktop/index.html
@@ -4,12 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Reasonix</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Serif:wght@400;500&display=swap"
-      rel="stylesheet"
-    />
     <link rel="stylesheet" href="/src/styles.css" />
   </head>
   <body>

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -8,8 +8,9 @@
       "name": "reasonix-desktop",
       "version": "0.0.0",
       "dependencies": {
-        "@fontsource-variable/inter": "^5.1.0",
-        "@fontsource-variable/jetbrains-mono": "^5.1.0",
+        "@fontsource/ibm-plex-mono": "^5.2.7",
+        "@fontsource/ibm-plex-sans": "^5.2.8",
+        "@fontsource/ibm-plex-serif": "^5.2.7",
         "@tauri-apps/api": "^2.1.1",
         "@tauri-apps/plugin-dialog": "^2.7.1",
         "@tauri-apps/plugin-opener": "^2.0.0",
@@ -705,19 +706,28 @@
         "node": ">=12"
       }
     },
-    "node_modules/@fontsource-variable/inter": {
-      "version": "5.2.8",
-      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.2.8.tgz",
-      "integrity": "sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==",
+    "node_modules/@fontsource/ibm-plex-mono": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@fontsource/ibm-plex-mono/-/ibm-plex-mono-5.2.7.tgz",
+      "integrity": "sha512-MKAb8qV+CaiMQn2B0dIi1OV3565NYzp3WN5b4oT6LTkk+F0jR6j0ZN+5BKJiIhffDC3rtBULsYZE65+0018z9w==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
       }
     },
-    "node_modules/@fontsource-variable/jetbrains-mono": {
+    "node_modules/@fontsource/ibm-plex-sans": {
       "version": "5.2.8",
-      "resolved": "https://registry.npmjs.org/@fontsource-variable/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
-      "integrity": "sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q==",
+      "resolved": "https://registry.npmjs.org/@fontsource/ibm-plex-sans/-/ibm-plex-sans-5.2.8.tgz",
+      "integrity": "sha512-eztSXjDhPhcpxNIiGTgMebdLP9qS4rWkysuE1V7c+DjOR0qiezaiDaTwQE7bTnG5HxAY/8M43XKDvs3cYq6ZYQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/ibm-plex-serif": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@fontsource/ibm-plex-serif/-/ibm-plex-serif-5.2.7.tgz",
+      "integrity": "sha512-04owmc2OQQ/DAMjXjEMJc+7V4dBVmR01aIFOg4cuqS8pQ4HbvtlYs/u6+O0vCt21EMx5M/azIbgx43iKyisEOA==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -11,8 +11,9 @@
     "bundle:node": "node scripts/bundle-node.mjs"
   },
   "dependencies": {
-    "@fontsource-variable/inter": "^5.1.0",
-    "@fontsource-variable/jetbrains-mono": "^5.1.0",
+    "@fontsource/ibm-plex-mono": "^5.2.7",
+    "@fontsource/ibm-plex-sans": "^5.2.8",
+    "@fontsource/ibm-plex-serif": "^5.2.7",
     "@tauri-apps/api": "^2.1.1",
     "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-opener": "^2.0.0",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
 tauri-plugin-opener = "2"

--- a/desktop/src/main.tsx
+++ b/desktop/src/main.tsx
@@ -1,5 +1,12 @@
-import "@fontsource-variable/inter";
-import "@fontsource-variable/jetbrains-mono";
+import "@fontsource/ibm-plex-sans/400.css";
+import "@fontsource/ibm-plex-sans/500.css";
+import "@fontsource/ibm-plex-sans/600.css";
+import "@fontsource/ibm-plex-sans/700.css";
+import "@fontsource/ibm-plex-mono/400.css";
+import "@fontsource/ibm-plex-mono/500.css";
+import "@fontsource/ibm-plex-mono/600.css";
+import "@fontsource/ibm-plex-serif/400.css";
+import "@fontsource/ibm-plex-serif/500.css";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
 

--- a/scripts/copy-dashboard-vendor-css.mjs
+++ b/scripts/copy-dashboard-vendor-css.mjs
@@ -1,4 +1,4 @@
-import { copyFileSync, mkdirSync } from "node:fs";
+import { copyFileSync, mkdirSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 
 const targets = [
@@ -11,3 +11,10 @@ for (const [src, dst] of targets) {
   copyFileSync(resolve(src), resolve(dst));
   console.log(`copied ${src} → ${dst}`);
 }
+
+// Marks dist/cli/ as ESM so Node skips the CJS-then-ESM reparse warning when
+// the bundle is loaded outside its own npm install (e.g. desktop sidecar).
+const cliMarker = resolve("dist/cli/package.json");
+mkdirSync(dirname(cliMarker), { recursive: true });
+writeFileSync(cliMarker, `${JSON.stringify({ type: "module" }, null, 2)}\n`);
+console.log(`wrote ${cliMarker}`);

--- a/tests/bundle-smoke.test.ts
+++ b/tests/bundle-smoke.test.ts
@@ -45,18 +45,23 @@ describe("bundled dist — tokenizer path resolution", () => {
   );
 
   (cliExists ? it : it.skip)(
-    'dist/cli/* keeps `from "ink"` external so users get the real package',
+    "dist/cli/* inlines runtime deps so the desktop sidecar can run without node_modules",
     async () => {
       const { readdirSync, readFileSync } = await import("node:fs");
       const distDir = resolve("dist/cli");
       const jsFiles = readdirSync(distDir).filter((f) => f.endsWith(".js"));
-      const inkImporters = jsFiles.filter((f) =>
-        /from\s*"ink"/.test(readFileSync(resolve(distDir, f), "utf8")),
-      );
+      const leakedImports = jsFiles.flatMap((f) => {
+        const body = readFileSync(resolve(distDir, f), "utf8");
+        const hits: string[] = [];
+        for (const pkg of ["commander", "ink", "undici"]) {
+          if (new RegExp(`from\\s*["']${pkg}["']`).test(body)) hits.push(`${f}:${pkg}`);
+        }
+        return hits;
+      });
       expect(
-        inkImporters.length,
-        `expected at least one dist/cli/*.js to import "ink" (found ${jsFiles.length} JS files)`,
-      ).toBeGreaterThan(0);
+        leakedImports,
+        `dist/cli/*.js still imports runtime deps from node_modules: ${leakedImports.join(", ")}`,
+      ).toEqual([]);
     },
   );
 

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -18,7 +18,14 @@ export default defineConfig([
     sourcemap: true,
     target: "node22",
     outDir: "dist/cli",
-    banner: { js: "#!/usr/bin/env node" },
+    banner: {
+      js: "#!/usr/bin/env node\nimport { createRequire as __cr } from 'node:module'; if (typeof globalThis.require === 'undefined') { globalThis.require = __cr(import.meta.url); }",
+    },
+    platform: "node",
+    noExternal: [/.*/],
+    esbuildOptions(opts) {
+      opts.external = [...(opts.external ?? []), "react-devtools-core"];
+    },
   },
   {
     entry: { app: "dashboard/app.js" },


### PR DESCRIPTION
## Summary

Fixes the black screen on v0.42.0-2 and the CSP-blocked Google Fonts request. Two distinct bugs, both load-bearing.

### CLI sidecar wasn't self-contained
`tsup` was emitting `dist/cli/index.js` as ESM with `commander`, `ink`, `undici`, etc. left external. Fine for `npm i -g reasonix` (npm fetches the deps), but the desktop ships `dist/cli/` as a static resource with no `node_modules` next to it — the spawned Node died on the first `import` with `ERR_MODULE_NOT_FOUND`, the IPC channel never came up, and the UI rendered an empty `#0b0b0b` background → black screen.

- `noExternal: [/.*/]` plus `platform: "node"` inlines runtime deps.
- `react-devtools-core` is whitelisted as external — it's an optional peer dep that ink dynamically pulls only when devtools are enabled (which we never do), and forcing tsup to resolve it would fail since it's not installed.
- undici's dispatcher uses `require()` internally; in ESM output esbuild's shim throws on dynamic require. The banner now installs `createRequire(import.meta.url)` onto `globalThis.require` so the shim picks it up.
- `dist/cli/package.json` is written with `{"type":"module"}` so Node skips the CJS-first reparse warning when the bundle runs outside its own npm install.

### Fonts on a CDN the bundled CSP forbids
`desktop/index.html` pulled IBM Plex from `googleapis.com`, which the bundled CSP (`style-src 'self' 'unsafe-inline'; font-src 'self' data:`) blocks outright — and is also unreachable on mainland China networks. Switched to `@fontsource/ibm-plex-{sans,mono,serif}` so the woff2s are bundled into `dist/assets/` at build time. Identical typeface, zero runtime network. Also dropped `@fontsource-variable/inter` + `jetbrains-mono` — they'd been imported but never referenced by any CSS rule.

### Devtools feature
Enabled tauri's `devtools` feature. F12 is what surfaced both bugs and stays useful while the desktop is prerelease — revisit before stable.

## Test plan

- [x] CLI smoke test inverted: assert no `dist/cli/*.js` imports `commander | ink | undici` from node_modules (the three packages that broke v0.42.0-2).
- [x] `npm run verify` — 2837 tests pass.
- [x] Local release build (`tauri build` in `desktop/`) → installed `Reasonix_0.0.0_x64-setup.exe` → app loads, IBM Plex renders, no `Cannot find package 'commander'` in stderr, no Google Fonts CSP violation, no `MODULE_TYPELESS_PACKAGE_JSON` warning.
