### PR TITLE
fix(release-mirror): handle Gitee returning 200+null on missing tag

### DIFF
--- a/scripts/mirror-release-to-gitee.mjs
+++ b/scripts/mirror-release-to-gitee.mjs
@@ -38,11 +38,14 @@ async function getOrCreateRelease() {
     { headers: { Authorization: `token ${TOKEN}` } },
   );
   if (lookup.status === 200) {
-    const data = await lookup.json();
-    console.log(`Gitee: release ${TAG} exists (id=${data.id}), reusing.`);
-    return data;
-  }
-  if (lookup.status !== 404) {
+    // Gitee returns 200 + literal `null` body when the tag has no release yet,
+    // not 404 like a sane API would. Fall through to create in that case.
+    const data = await lookup.json().catch(() => null);
+    if (data && data.id) {
+      console.log(`Gitee: release ${TAG} exists (id=${data.id}), reusing.`);
+      return data;
+    }
+  } else if (lookup.status !== 404) {
     const body = await lookup.text().catch(() => "");
     throw new Error(`Gitee lookup failed: ${lookup.status}: ${body}`);
   }


### PR DESCRIPTION
## Summary

Second bug from the v0.42.0-3 mirror attempt: Gitee's `GET /repos/{owner}/{repo}/releases/tags/{tag}` returns **200 OK + JSON body `null`** when the tag has no release attached, instead of `404`. The script read `.id` off `null` and crashed before reaching the create branch.

Now the script treats a 200-with-null (or any 200 without `.id`) as "no release exists" and falls through to the POST /releases create path.

## Test plan

- [ ] After merge, manually re-trigger `Release mirror` with `tag=v0.42.0-3`, verify Gitee step now creates the release and uploads assets, ✓ in summary.

