### PR TITLE
fix(release-mirror): default Gitee release body when GitHub body is empty

### DIFF
--- a/scripts/mirror-release-to-gitee.mjs
+++ b/scripts/mirror-release-to-gitee.mjs
@@ -17,7 +17,10 @@ const REPO = envOrDie("GITEE_REPO");
 const TAG = envOrDie("RELEASE_TAG");
 const ASSETS_DIR = envOrDie("ASSETS_DIR");
 const RELEASE_NAME = process.env.RELEASE_NAME ?? `Reasonix ${TAG}`;
-const RELEASE_BODY = process.env.RELEASE_BODY ?? `Mirror of GitHub Release ${TAG}.`;
+// Gitee rejects empty body with "发行版的描述不能为空"; treat unset / empty / whitespace alike.
+const RELEASE_BODY = process.env.RELEASE_BODY?.trim()
+  ? process.env.RELEASE_BODY
+  : `Mirror of GitHub Release ${TAG}. See https://github.com/esengine/DeepSeek-Reasonix/releases/tag/${TAG}`;
 const TARGET_BRANCH = process.env.GITEE_TARGET_BRANCH ?? "main";
 
 async function giteeFetch(p, init = {}) {


### PR DESCRIPTION
## Summary

Third bug uncovered while mirroring v0.42.0-3:

```
Error: Gitee POST /repos/reasonix/DeepSeek-Reasonix/releases → 400:
{"message":"验证失败：发行版的描述不能为空"}
```

Gitee rejects creating a release with an empty body. The previous default in the script kicked in only when `RELEASE_BODY` was unset — but the workflow always sets it from the GitHub release body, so when the maintainer publishes without notes, an empty string slips past `??`.

Now treats unset / empty / whitespace-only body as "no body" and substitutes a one-line pointer back to the GitHub release page.

R2 mirroring already works end-to-end with the corrected `R2_ACCOUNT_ID` secret + Object Read & Write permissions on the API token — confirmed in the previous run.

## Test plan

- [ ] Re-trigger `Release mirror` for `v0.42.0-3` after merge; verify Gitee creates the release with the fallback body and uploads all assets; summary shows ✓ for both targets.
