### PR TITLE
fix(release-mirror): skip Gitee uploads over 90 MB + isolate per-file errors

### DIFF
--- a/scripts/mirror-release-to-gitee.mjs
+++ b/scripts/mirror-release-to-gitee.mjs
@@ -94,8 +94,14 @@ async function uploadAsset(releaseId, filePath) {
   console.log(`Gitee: uploaded ${filename} (${buf.byteLength} bytes)`);
 }
 
+// Gitee caps individual release assets at 100MB on free accounts; uploading
+// over that hangs until undici's headersTimeout fires and the script crashes.
+const GITEE_ASSET_SIZE_LIMIT = 90 * 1024 * 1024;
+
 const release = await getOrCreateRelease();
 const skip = await existingAssetNames(release.id);
+const failed = [];
+const skipped = [];
 for (const name of await readdir(ASSETS_DIR)) {
   const fp = path.join(ASSETS_DIR, name);
   const st = await stat(fp);
@@ -104,6 +110,22 @@ for (const name of await readdir(ASSETS_DIR)) {
     console.log(`Gitee: skip ${name} (already present)`);
     continue;
   }
-  await uploadAsset(release.id, fp);
+  if (st.size > GITEE_ASSET_SIZE_LIMIT) {
+    const mb = (st.size / 1024 / 1024).toFixed(1);
+    console.log(`Gitee: skip ${name} (${mb} MB exceeds ${GITEE_ASSET_SIZE_LIMIT / 1024 / 1024} MB limit)`);
+    skipped.push(`${name} (${mb} MB)`);
+    continue;
+  }
+  try {
+    await uploadAsset(release.id, fp);
+  } catch (err) {
+    console.error(`Gitee: ${name} upload failed: ${err instanceof Error ? err.message : err}`);
+    failed.push(name);
+  }
+}
+if (skipped.length > 0) console.log(`Gitee: skipped (too large): ${skipped.join(", ")}`);
+if (failed.length > 0) {
+  console.error(`Gitee: ${failed.length} upload(s) failed: ${failed.join(", ")}`);
+  process.exit(1);
 }
 console.log("Gitee mirror complete.");


### PR DESCRIPTION
## Summary

Fourth bug on the v0.42.0-3 mirror chase. R2 finally went green last run; Gitee crashed mid-batch with `TypeError: fetch failed [cause]: HeadersTimeoutError` while uploading the 118 MB AppImage.

Two fixes:

- **Skip files over 90 MB on Gitee.** Gitee free accounts cap release assets at 100 MB per file. Our AppImage exceeds that and was hanging until undici's 5-min headers timeout. Now skipped with a clear log line — Linux users still get it from GitHub Release / R2.
- **Isolate per-file errors.** Wrap each upload in try/catch and continue to the next file; collect failures and exit non-zero at the end. One flaky upload no longer kills the whole batch.

## Test plan

- [ ] Re-trigger `Release mirror` for `v0.42.0-3` after merge; expect Gitee to upload all assets except `Reasonix_0.42.0-3_amd64.AppImage`, summary ✓.
- [ ] R2 still ✓ (already validated on previous run with corrected `R2_ACCOUNT_ID` + token permissions).
