### PR TITLE
fix(cli): route bare project launches to code mode

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6,7 +6,7 @@ import { listSessions } from "../memory/session.js";
 import { applyMemoryStack } from "../memory/user.js";
 import { installProxyIfConfigured } from "../net/proxy.js";
 import { escalationContract } from "../prompt-fragments.js";
-import { resolveContinueFlag, resolveDefaults } from "./resolve.js";
+import { resolveBareCommandMode, resolveContinueFlag, resolveDefaults } from "./resolve.js";
 import { markPhase } from "./startup-profile.js";
 
 // HTTPS_PROXY / HTTP_PROXY only reach Node's fetch via undici's global
@@ -121,9 +121,16 @@ program
 // `chat` / `setup` / `--mcp` — just type `reasonix`.
 program.action(async (opts: { continue?: boolean }) => {
   const cfg = readConfig();
-  if (!cfg.setupCompleted) {
+  const cwd = process.cwd();
+  const mode = resolveBareCommandMode(cwd, cfg);
+  if (mode === "setup") {
     const { setupCommand } = await import("./commands/setup.js");
     await setupCommand({ forceKeyStep: true });
+    return;
+  }
+  if (mode === "code") {
+    const { codeCommand } = await import("./commands/code.js");
+    await codeCommand({ dir: cwd });
     return;
   }
   const defaults = resolveDefaults({});
@@ -133,10 +140,12 @@ program.action(async (opts: { continue?: boolean }) => {
     () => listSessions()[0],
     (msg) => process.stderr.write(`${msg}\n`),
   );
+  process.stderr.write(
+    "ℹ chat mode (no filesystem tools). Run `reasonix code` to work on files in this folder.\n",
+  );
   const { chatCommand } = await import("./commands/chat.js");
   const defaultBase = defaultSystemPrompt(defaults.model);
-  const defaultCwd = process.cwd();
-  const defaultRebuildSystem = () => applyMemoryStack(defaultBase, defaultCwd);
+  const defaultRebuildSystem = () => applyMemoryStack(defaultBase, cwd);
   await chatCommand({
     model: defaults.model,
     system: defaultRebuildSystem(),

--- a/src/cli/resolve.ts
+++ b/src/cli/resolve.ts
@@ -1,5 +1,7 @@
 /** Precedence: per-setting flag > --preset > config.preset > "auto" defaults. */
 
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
 import { type PresetName, type ReasonixConfig, readConfig } from "../config.js";
 import { resolvePreset } from "./ui/presets.js";
 
@@ -85,4 +87,30 @@ export function resolveContinueFlag(
     return { session: fallbackSession, forceResume: false };
   }
   return { session: latest.name, forceResume: true };
+}
+
+const PROJECT_MARKERS = [
+  ".git",
+  "package.json",
+  "pyproject.toml",
+  "Cargo.toml",
+  "go.mod",
+  "pom.xml",
+  "build.gradle",
+  "CMakeLists.txt",
+];
+
+export function looksLikeProjectDir(cwd: string, recentWorkspaces: string[] = []): boolean {
+  const root = resolve(cwd);
+  if (recentWorkspaces.some((workspace) => resolve(workspace) === root)) return true;
+
+  return PROJECT_MARKERS.some((marker) => existsSync(resolve(root, marker)));
+}
+
+export function resolveBareCommandMode(
+  cwd: string,
+  cfg: Pick<ReasonixConfig, "setupCompleted" | "recentWorkspaces">,
+): "setup" | "code" | "chat" {
+  if (!cfg.setupCompleted) return "setup";
+  return looksLikeProjectDir(cwd, cfg.recentWorkspaces) ? "code" : "chat";
 }

--- a/tests/cli-bare-routing.test.ts
+++ b/tests/cli-bare-routing.test.ts
@@ -1,0 +1,118 @@
+/** Bare `reasonix` routing — project-like cwd should launch code mode, explicit `chat` must stay chat. */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { writeConfig } from "../src/config.js";
+
+const codeCommand = vi.fn(async () => {});
+const chatCommand = vi.fn(async () => {});
+const setupCommand = vi.fn(async () => {});
+
+vi.mock("../src/cli/commands/code.js", () => ({ codeCommand }));
+vi.mock("../src/cli/commands/chat.js", () => ({ chatCommand }));
+vi.mock("../src/cli/commands/setup.js", () => ({ setupCommand }));
+
+async function importCli(argv: string[]) {
+  vi.resetModules();
+  process.argv = ["node", "src/cli/index.ts", ...argv];
+  await import("../src/cli/index.ts");
+}
+
+describe("bare CLI routing", () => {
+  let home: string;
+  let cwd: string;
+  const origHome = process.env.HOME;
+  const origUserProfile = process.env.USERPROFILE;
+  const origArgv = process.argv;
+  const origCwd = process.cwd();
+  let stderr: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "reasonix-cli-home-"));
+    cwd = mkdtempSync(join(tmpdir(), "reasonix-cli-cwd-"));
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+    process.chdir(cwd);
+    codeCommand.mockClear();
+    chatCommand.mockClear();
+    setupCommand.mockClear();
+    stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stderr.mockRestore();
+    process.chdir(origCwd);
+    process.argv = origArgv;
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+    if (origHome === undefined) {
+      // biome-ignore lint/performance/noDelete: env restoration needs absence, not "undefined"
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = origHome;
+    }
+    if (origUserProfile === undefined) {
+      // biome-ignore lint/performance/noDelete: env restoration needs absence, not "undefined"
+      delete process.env.USERPROFILE;
+    } else {
+      process.env.USERPROFILE = origUserProfile;
+    }
+  });
+
+  it("routes bare reasonix in a .git directory to code mode rooted at cwd", async () => {
+    writeConfig({ setupCompleted: true }, join(home, ".reasonix", "config.json"));
+    mkdirSync(join(cwd, ".git"));
+
+    await importCli([]);
+
+    await vi.waitFor(() => expect(codeCommand).toHaveBeenCalledWith({ dir: cwd }));
+    expect(chatCommand).not.toHaveBeenCalled();
+  });
+
+  it("routes bare reasonix in a non-project directory to chat mode and prints the filesystem hint", async () => {
+    writeConfig({ setupCompleted: true }, join(home, ".reasonix", "config.json"));
+
+    await importCli([]);
+
+    await vi.waitFor(() => expect(chatCommand).toHaveBeenCalled());
+    expect(codeCommand).not.toHaveBeenCalled();
+    expect(stderr.mock.calls.map((call) => String(call[0])).join("")).toContain(
+      "chat mode (no filesystem tools). Run `reasonix code` to work on files in this folder.",
+    );
+  });
+
+  it("routes bare reasonix in a recent workspace to code mode", async () => {
+    writeConfig(
+      { setupCompleted: true, recentWorkspaces: [cwd] },
+      join(home, ".reasonix", "config.json"),
+    );
+
+    await importCli([]);
+
+    await vi.waitFor(() => expect(codeCommand).toHaveBeenCalledWith({ dir: cwd }));
+    expect(chatCommand).not.toHaveBeenCalled();
+  });
+
+  it("keeps explicit reasonix chat in chat mode even inside a project", async () => {
+    writeConfig({ setupCompleted: true }, join(home, ".reasonix", "config.json"));
+    writeFileSync(join(cwd, "package.json"), "{}\n", "utf8");
+
+    await importCli(["chat"]);
+
+    await vi.waitFor(() => expect(chatCommand).toHaveBeenCalled());
+    expect(codeCommand).not.toHaveBeenCalled();
+  });
+
+  it("keeps first-run bare reasonix on the setup wizard", async () => {
+    writeConfig({ setupCompleted: false }, join(home, ".reasonix", "config.json"));
+    mkdirSync(join(cwd, ".git"));
+
+    await importCli([]);
+
+    await vi.waitFor(() => expect(setupCommand).toHaveBeenCalledWith({ forceKeyStep: true }));
+    expect(codeCommand).not.toHaveBeenCalled();
+    expect(chatCommand).not.toHaveBeenCalled();
+  });
+});

--- a/tests/plan-confirm.test.tsx
+++ b/tests/plan-confirm.test.tsx
@@ -1,6 +1,6 @@
 import { Box, Text } from "ink";
 import { render } from "ink-testing-library";
-import React from "react";
+import type React from "react";
 import stripAnsi from "strip-ansi";
 import { describe, expect, it } from "vitest";
 import { PlanConfirm } from "../src/cli/ui/PlanConfirm.js";

--- a/tests/plan-confirm.test.tsx
+++ b/tests/plan-confirm.test.tsx
@@ -1,6 +1,6 @@
 import { Box, Text } from "ink";
 import { render } from "ink-testing-library";
-import type React from "react";
+import React from "react";
 import stripAnsi from "strip-ansi";
 import { describe, expect, it } from "vitest";
 import { PlanConfirm } from "../src/cli/ui/PlanConfirm.js";


### PR DESCRIPTION

## What

<!-- One paragraph: what does this change? -->
Detect project-like working directories for bare reasonix invocations so filesystem tools are rooted at cwd, while preserving explicit chat and first-run setup behavior.

## Why

<!-- Bug fix? Pre-existing issue? Linked discussion? -->
https://github.com/esengine/DeepSeek-Reasonix/issues/694

## How to verify

<!-- Steps the reviewer can run. `npm run verify` is assumed. -->

## Checklist

- [y ] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [y ] No `Co-Authored-By: Claude` trailer in commits
- [y ] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [y ] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time
