### PR TITLE
fix(release-mirror): 3-min hard timeout per Gitee upload

### DIFF
--- a/scripts/mirror-release-to-gitee.mjs
+++ b/scripts/mirror-release-to-gitee.mjs
@@ -77,21 +77,32 @@ async function existingAssetNames(releaseId) {
   return new Set((data.assets ?? []).map((a) => a.name));
 }
 
+// Hard cap per upload — undici's default 5-min headersTimeout is too generous
+// when Gitee just hangs; bail fast so the rest of the batch isn't blocked.
+const UPLOAD_TIMEOUT_MS = 180_000;
+
 async function uploadAsset(releaseId, filePath) {
   const filename = path.basename(filePath);
   const buf = await readFile(filePath);
   const form = new FormData();
   form.append("file", new Blob([buf]), filename);
-  const res = await fetch(`${GITEE_API}/repos/${REPO}/releases/${releaseId}/attach_files`, {
-    method: "POST",
-    headers: { Authorization: `token ${TOKEN}` },
-    body: form,
-  });
-  if (!res.ok) {
-    const body = await res.text().catch(() => "");
-    throw new Error(`upload ${filename} → ${res.status}: ${body}`);
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(new Error(`timeout after ${UPLOAD_TIMEOUT_MS / 1000}s`)), UPLOAD_TIMEOUT_MS);
+  try {
+    const res = await fetch(`${GITEE_API}/repos/${REPO}/releases/${releaseId}/attach_files`, {
+      method: "POST",
+      headers: { Authorization: `token ${TOKEN}` },
+      body: form,
+      signal: ctrl.signal,
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      throw new Error(`upload ${filename} → ${res.status}: ${body}`);
+    }
+    console.log(`Gitee: uploaded ${filename} (${buf.byteLength} bytes)`);
+  } finally {
+    clearTimeout(timer);
   }
-  console.log(`Gitee: uploaded ${filename} (${buf.byteLength} bytes)`);
 }
 
 // Gitee caps individual release assets at 100MB on free accounts; uploading


### PR DESCRIPTION
## Summary

Fifth iteration on the mirror chase. Previous run was cancelled after 15+ minutes stuck on Gitee — only the first 3 small `.sig` files had been uploaded. Gitee accepted the connection then sat on the response, and undici's default 5-min headersTimeout wasn't aggressive enough to recycle the loop.

Adds an `AbortController` with a 3-min hard cap per file. A stalled upload now aborts in 3 min, hits the per-file `try/catch` from the previous fix, and the loop moves on. Files that genuinely take longer to transfer (none of ours should at < 90 MB) would be the cost.

## Test plan

- [ ] After merge, manually re-trigger `Release mirror` for `v0.42.0-3`. Expect Gitee to either complete all eligible files in < 3 min × n_files, or report per-file failures cleanly. Total step time should now have an upper bound around 14 files × 3 min = 42 min worst case (vs. previously unbounded).
