### PR TITLE
feat(web): landing + download site, ported from the design mockup

### DIFF
--- a/download-site/README.md
+++ b/download-site/README.md
@@ -1,0 +1,64 @@
+# reasonix-web
+
+Static landing + download site for Reasonix. No build step — React 18 UMD + Babel
+standalone (in-browser JSX compile). Hosted on Cloudflare Pages.
+
+## Layout
+
+```
+index.html       — landing (/) — hero, install, three pillars, features, …
+download.html    — download page (/download) — smart-mirror probe + per-OS picks
+src/
+  *.jsx          — React components, loaded via <script type="text/babel">
+  styles.css     — full sheet, port of the design mockup
+  fonts.css      — system-font stack (no external font CDN; matters for CN)
+_headers         — Cloudflare Pages response headers
+_redirects       — pretty URL → static file mappings
+```
+
+## Run locally
+
+```
+cd download-site
+python3 -m http.server 4173
+# open http://127.0.0.1:4173
+```
+
+Babel standalone compiles the JSX on every load — fine for dev, fine for our
+traffic volume, but if the bundle ever needs to be fast on cold loads, this
+should be converted to a real Vite build emitting plain JS.
+
+## Updating the version
+
+Currently hardcoded in three places — keep them in sync per release:
+
+- `src/mirrors.jsx` → `const VERSION = "..."`
+- `src/download-page.jsx` → release notes + hero version label + AppImage chmod example
+- `src/nav.jsx` + `src/hero.jsx` + `src/footer.jsx` → display strings
+
+`grep -rn "0.42.0-3" src/` will find every site.
+
+## Cloudflare Pages deploy
+
+Two options:
+
+### Dashboard (one-time setup)
+
+1. Cloudflare dashboard → **Pages** → **Connect to Git**
+2. Pick this repo, branch `main`
+3. **Root directory**: `download-site`
+4. **Build command**: *(leave blank — static)*
+5. **Build output directory**: `download-site`
+6. Save & deploy. Auto-redeploys on push to `main`.
+
+### Wrangler (CI-driven, optional)
+
+A GitHub Action can deploy on every push using
+`cloudflare/pages-action@v1` + a `CLOUDFLARE_API_TOKEN` secret. Skipped here —
+add it once we want preview deploys per PR.
+
+### Custom domain
+
+In Pages → **Custom domains**, add e.g. `reasonix.dev` or
+`download.reasonix.dev`. Update `src/mirrors.jsx`'s `R2_BASE` if R2 also moves
+to a custom domain later.

--- a/download-site/_headers
+++ b/download-site/_headers
@@ -1,0 +1,11 @@
+/*
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: interest-cohort=()
+
+/src/*.jsx
+  Cache-Control: public, max-age=300, must-revalidate
+  Content-Type: text/babel; charset=utf-8
+
+/src/*.css
+  Cache-Control: public, max-age=86400, must-revalidate

--- a/download-site/_redirects
+++ b/download-site/_redirects
@@ -1,0 +1,2 @@
+/download    /download.html   200
+/install     /index.html#install   302

--- a/download-site/download.html
+++ b/download-site/download.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Download · DeepSeek-Reasonix</title>
+<meta name="description" content="Download Reasonix desktop — installers for macOS, Windows, Linux. Auto-routes to the fastest mirror." />
+<meta name="color-scheme" content="dark" />
+<link rel="stylesheet" href="src/fonts.css" />
+<link rel="stylesheet" href="src/styles.css" />
+</head>
+<body>
+  <div class="noise"></div>
+  <div id="root"></div>
+
+  <script crossorigin src="https://cdn.jsdelivr.net/npm/react@18.3.1/umd/react.production.min.js"></script>
+  <script crossorigin src="https://cdn.jsdelivr.net/npm/react-dom@18.3.1/umd/react-dom.production.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@babel/standalone@7.29.0/babel.min.js"></script>
+
+  <script type="text/babel" src="src/icons.jsx"></script>
+  <script type="text/babel" src="src/nav.jsx"></script>
+  <script type="text/babel" src="src/mirrors.jsx"></script>
+  <script type="text/babel" src="src/footer.jsx"></script>
+  <script type="text/babel" src="src/download-page.jsx"></script>
+</body>
+</html>

--- a/download-site/index.html
+++ b/download-site/index.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>DeepSeek-Reasonix · DeepSeek-native coding agent</title>
+<meta name="description" content="DeepSeek-native AI coding agent for your terminal. Engineered around prefix-cache stability." />
+<meta name="color-scheme" content="dark" />
+<link rel="stylesheet" href="src/fonts.css" />
+<link rel="stylesheet" href="src/styles.css" />
+</head>
+<body>
+  <div class="grid-bg"></div>
+  <div class="noise"></div>
+  <div id="root"></div>
+
+  <script crossorigin src="https://cdn.jsdelivr.net/npm/react@18.3.1/umd/react.production.min.js"></script>
+  <script crossorigin src="https://cdn.jsdelivr.net/npm/react-dom@18.3.1/umd/react-dom.production.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@babel/standalone@7.29.0/babel.min.js"></script>
+
+  <script type="text/babel" src="src/icons.jsx"></script>
+  <script type="text/babel" src="src/nav.jsx"></script>
+  <script type="text/babel" src="src/hero.jsx"></script>
+  <script type="text/babel" src="src/install.jsx"></script>
+  <script type="text/babel" src="src/agents.jsx"></script>
+  <script type="text/babel" src="src/features.jsx"></script>
+  <script type="text/babel" src="src/config.jsx"></script>
+  <script type="text/babel" src="src/community.jsx"></script>
+  <script type="text/babel" src="src/roadmap.jsx"></script>
+  <script type="text/babel" src="src/faq.jsx"></script>
+  <script type="text/babel" src="src/footer.jsx"></script>
+  <script type="text/babel" src="src/app.jsx"></script>
+</body>
+</html>

--- a/download-site/src/agents.jsx
+++ b/download-site/src/agents.jsx
@@ -1,0 +1,107 @@
+// Three Pillars — Cache-First Loop, R1 Thought Harvest, Tool-Call Repair
+// Replaces the previous "agents matrix" since Reasonix is one focused agent
+// engineered around three invariants.
+
+const PILLARS = [
+  {
+    id: 'cache',
+    name: 'Cache-First Loop',
+    cn: '字节稳定的运行循环',
+    badge: 'P1',
+    summary:
+      'DeepSeek 的 prefix-cache 从 prompt 第 0 字节开始指纹化。Reasonix 的循环是 append-only —— 不重排、不基于 marker 做压缩 —— 让缓存前缀在每一次工具调用后都保持稳定。',
+    metric: '94%',
+    metricLabel: 'cache hit · long sessions',
+    points: [
+      { n: '01', label: 'append-only',      desc: '消息、工具结果一律尾部追加，绝不修改历史' },
+      { n: '02', label: 'no marker',        desc: '不使用 cache_control 之类的标记触发器' },
+      { n: '03', label: 'stable order',     desc: '工具调用顺序与时间戳完全确定性' },
+      { n: '04', label: 'prefix-survive',   desc: '即使 dispatch 多次工具，前缀仍命中' },
+    ],
+  },
+  {
+    id: 'r1',
+    name: 'R1 Thought Harvest',
+    cn: '推理链回收',
+    badge: 'P2',
+    summary:
+      '当模型在 <think> 块里"想偏了"把工具调用写进了思考内容，Reasonix 会做一次扫掠（scavenge pass）把这些逃逸的 tool call 抓回来执行，不浪费推理 token。',
+    metric: '+38%',
+    metricLabel: 'tool dispatch recovered',
+    points: [
+      { n: '01', label: 'capture',  desc: '解析 <think> 块，识别其中的 tool-call 语法' },
+      { n: '02', label: 'replay',   desc: '把抓出的调用重新走 dispatch 通道' },
+      { n: '03', label: 'effort',   desc: '/effort 控制推理深度，便宜回合可降级' },
+      { n: '04', label: 'observe',  desc: '所有 harvest 操作落盘到 events 日志' },
+    ],
+  },
+  {
+    id: 'repair',
+    name: 'Tool-Call Repair',
+    cn: '工具调用自愈',
+    badge: 'P3',
+    summary:
+      '模型生成的工具参数偶尔会有 JSON 拼写错、引号不闭合、shape 不一致的情况。Reasonix 在送入 dispatch 之前先做一轮 schema-aware 的修复，把畸形参数补好再执行。',
+    metric: '< 0.3%',
+    metricLabel: 'tool failures after repair',
+    points: [
+      { n: '01', label: 'parse',    desc: 'JSON5 / 容错解析，识别常见畸形写法' },
+      { n: '02', label: 'reshape',  desc: '按 schema 重排字段名 · 修补默认值' },
+      { n: '03', label: 'retry',    desc: '修复失败时优雅回报 · 让模型自我纠正' },
+      { n: '04', label: 'log',      desc: '所有修复动作可在 reasonix replay 中回放' },
+    ],
+  },
+];
+
+function Agents() {
+  const [sel, setSel] = React.useState('cache');
+  const cur = PILLARS.find(a => a.id === sel) || PILLARS[0];
+
+  return (
+    <section className="section" id="agents">
+      <SecHead
+        num="02"
+        label="Three Pillars"
+        title="为什么是 <em>DeepSeek</em> 原生"
+        sub="Reasonix 只对接 DeepSeek，因为这套循环的不变量是按 DeepSeek 的 cache 机制设计的。同样的模型、同样的 API —— 改变的是循环的工程姿态。"
+      />
+
+      <div className="agents">
+        <div className="agent-list">
+          {PILLARS.map(a => (
+            <div key={a.id} className={'agent-item ' + (a.id === sel ? 'on' : '')} onClick={() => setSel(a.id)}>
+              <span className="dot"></span>
+              <div className="label">
+                {a.name}
+                <small>{a.cn}</small>
+              </div>
+              <span className="meta">{a.badge}</span>
+            </div>
+          ))}
+        </div>
+        <div className="agent-detail" key={cur.id}>
+          <div className="en">{cur.name}</div>
+          <h3>{cur.cn}</h3>
+          <p>{cur.summary}</p>
+
+          <div className="metric-bar">
+            <b>{cur.metric}</b>
+            <span>{cur.metricLabel}</span>
+          </div>
+
+          <div className="agent-flow">
+            {cur.points.map(s => (
+              <div key={s.n} className="step">
+                <b>{s.n}</b>
+                <em>{s.label}</em>
+                <span>— {s.desc}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+window.Agents = Agents;

--- a/download-site/src/app.jsx
+++ b/download-site/src/app.jsx
@@ -1,0 +1,45 @@
+// Landing-page entry
+
+function DlPromo() {
+  return (
+    <div style={{maxWidth:'1280px', margin:'0 auto', padding:'40px 40px 0'}} id="desktop-promo">
+      <div className="dl-promo">
+        <div>
+          <h3>或者 — <em>桌面端</em>，开箱即用。</h3>
+          <p>
+            原生 Tauri 客户端 · 自带 Node runtime · 共享 ~/.reasonix 配置。
+            多 tab 会话、实时 cost / cache / token 表盘。
+          </p>
+        </div>
+        <div className="dl-promo-actions">
+          <a className="btn btn-ghost btn-sm" href="download.html">
+            查看所有平台 →
+          </a>
+          <a className="btn btn-primary btn-sm" href="download.html">
+            智能镜像下载
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function App() {
+  return (
+    <>
+      <Nav/>
+      <Hero/>
+      <Install/>
+      <DlPromo/>
+      <Agents/>
+      <Features/>
+      <Config/>
+      <Community/>
+      <Roadmap/>
+      <Faq/>
+      <Footer/>
+    </>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App/>);

--- a/download-site/src/community.jsx
+++ b/download-site/src/community.jsx
@@ -1,0 +1,110 @@
+// Community — live GitHub stats + contributors from the API
+
+function useGithubStats() {
+  const [stats, setStats] = React.useState({ stars: null, forks: null, openIssues: null });
+  const [contributors, setContributors] = React.useState([]);
+  React.useEffect(() => {
+    let cancelled = false;
+    fetch("https://api.github.com/repos/esengine/DeepSeek-Reasonix")
+      .then(r => r.ok ? r.json() : null)
+      .then(j => {
+        if (cancelled || !j) return;
+        setStats({
+          stars: j.stargazers_count ?? null,
+          forks: j.forks_count ?? null,
+          openIssues: j.open_issues_count ?? null,
+        });
+      })
+      .catch(() => {});
+    fetch("https://api.github.com/repos/esengine/DeepSeek-Reasonix/contributors?per_page=24")
+      .then(r => r.ok ? r.json() : null)
+      .then(j => {
+        if (cancelled || !Array.isArray(j)) return;
+        setContributors(j);
+      })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, []);
+  return { stats, contributors };
+}
+
+function Community() {
+  const { stats, contributors } = useGithubStats();
+  return (
+    <section className="section" id="community">
+      <SecHead
+        num="06"
+        label="Community"
+        title="由 <em>社区</em>驱动，完全开源。"
+        sub="MIT 协议、公开 Roadmap、公开 Discussions。欢迎一起把推理型 Agent 的工程基线推得更高。"
+      />
+
+      <div className="community-grid">
+        <div className="star-card">
+          <div style={{display:"flex",alignItems:"center",gap:10,color:"var(--cream-mute)",fontFamily:"var(--mono)",fontSize:11,letterSpacing:"0.08em",textTransform:"uppercase"}}>
+            <Ic.Star size={12}/> Github Stats · live
+          </div>
+          <div className="star-row">
+            <b>{stats.stars != null ? stats.stars.toLocaleString() : "—"}</b>
+            <span className="delta">stars</span>
+            <span style={{marginLeft:"auto", fontFamily:"var(--mono)", fontSize:12, color:"var(--cream-mute)"}}>
+              {stats.forks != null && stats.openIssues != null
+                ? `· forks ${stats.forks} · open issues ${stats.openIssues}`
+                : "· loading…"}
+            </span>
+          </div>
+          <div style={{display:"flex", gap:10, marginTop:18, flexWrap:"wrap"}}>
+            <a className="btn btn-primary btn-sm" href="https://github.com/esengine/DeepSeek-Reasonix" target="_blank" rel="noreferrer">
+              <Ic.Star size={13}/> Star on GitHub
+            </a>
+            <a className="btn btn-ghost btn-sm" href="https://github.com/esengine/DeepSeek-Reasonix" target="_blank" rel="noreferrer">
+              <Ic.Github size={13}/> 阅读源码
+            </a>
+            <a className="btn btn-ghost btn-sm" href="https://github.com/esengine/DeepSeek-Reasonix/discussions" target="_blank" rel="noreferrer">
+              加入讨论
+            </a>
+          </div>
+        </div>
+
+        <div className="contrib-grid">
+          <h3>开源贡献者</h3>
+          <div className="sub">core · plugin · docs · translation</div>
+          <div className="contrib-wall">
+            {contributors.slice(0, 24).map((c) => (
+              <a
+                key={c.login}
+                href={c.html_url}
+                target="_blank"
+                rel="noreferrer"
+                className="contrib-avatar"
+                title={c.login}
+                style={{
+                  backgroundImage: c.avatar_url ? `url(${c.avatar_url})` : undefined,
+                  backgroundSize: "cover",
+                  color: "transparent",
+                }}
+              >{c.login.slice(0, 2).toUpperCase()}</a>
+            ))}
+            {contributors.length === 0 && (
+              <div className="contrib-avatar" style={{background:"transparent", border:"1px solid var(--rule-2)", color:"var(--cream-mute)", fontSize:11}}>loading…</div>
+            )}
+            {contributors.length > 0 && (
+              <a
+                href="https://github.com/esengine/DeepSeek-Reasonix/graphs/contributors"
+                target="_blank"
+                rel="noreferrer"
+                className="contrib-avatar"
+                style={{background:"transparent", border:"1px solid var(--rule-2)", color:"var(--cream-dim)"}}
+              >+more</a>
+            )}
+          </div>
+          <p style={{color:"var(--cream-mute)", fontSize:12.5, marginTop:18, marginBottom:0, lineHeight:1.6}}>
+            想成为下一个？阅读 <a href="https://github.com/esengine/DeepSeek-Reasonix/blob/main/CONTRIBUTING.md" target="_blank" rel="noreferrer" style={{color:"var(--accent)", textDecoration:"none"}}>CONTRIBUTING.md</a> 并领取一个 <span className="kbd">good first issue</span>。
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+window.Community = Community;

--- a/download-site/src/config.jsx
+++ b/download-site/src/config.jsx
@@ -1,0 +1,369 @@
+// Configuration explorer — MCP, Skills, Memory, Slash commands
+// Tabbed interface with code panels showing real Reasonix config
+
+const CONFIG_TABS = [
+  {
+    id: 'mcp',
+    label: 'MCP',
+    title: 'Model Context Protocol',
+    cn: '外部工具服务器',
+    desc: 'MCP 是 Reasonix 接入外部能力的一等公民通道，支持 stdio / SSE / Streamable HTTP 三种传输。每个 server 的工具会以前缀合并进统一的工具 registry，对模型透明。',
+    bullets: [
+      '一行命令挂载: --mcp \'name=cmd args\'',
+      '所有 MCP 工具沙箱权限与原生工具一致',
+      '/mcp 子命令查看已挂载服务器 · 健康状态 · 工具清单',
+      '失败重连 · 自动 reconnect with backoff',
+    ],
+    files: [
+      {
+        name: '~/.reasonix/config.json',
+        lang: 'json',
+        code: `{
+  "model": "deepseek-v4-flash",
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": { "GITHUB_TOKEN": "ghp_***" }
+    },
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/data"]
+    },
+    "postgres": {
+      "transport": "sse",
+      "url": "https://mcp.internal/pg/sse"
+    }
+  }
+}`,
+      },
+      {
+        name: 'or via CLI flag',
+        lang: 'bash',
+        code: `$ reasonix code \\
+    --mcp 'github=npx -y @modelcontextprotocol/server-github' \\
+    --mcp 'pg=https://mcp.internal/pg/sse'`,
+      },
+    ],
+  },
+  {
+    id: 'skills',
+    label: 'Skills',
+    title: 'Skills',
+    cn: '可复用的 Markdown 剧本',
+    desc: 'Skill 是一段带 frontmatter 的 Markdown，把"做某件事的方式"凝固成可调用单元。runAs: subagent 时会在隔离子 agent 里运行，allowed-tools 限制可用工具集。',
+    bullets: [
+      '项目级: <project>/.reasonix/skills/<name>.md',
+      '全局: ~/.reasonix/skills/<name>.md',
+      '/skill new <name> 生成脚手架',
+      'runAs: subagent 让 skill 跑在隔离的子循环里',
+    ],
+    files: [
+      {
+        name: '.reasonix/skills/review-pr.md',
+        lang: 'md',
+        code: `---
+description: 阅读当前分支 vs main 的 diff，输出 review 意见
+runAs: subagent
+allowed-tools: [run_command, read_file, grep_files]
+---
+你是一名严格的 code reviewer。请按以下步骤工作：
+
+1. 运行 \`git diff main..HEAD\` 获取变更
+2. 对每个被修改的文件，read_file 加载上下文
+3. 输出结构化 review：
+   - blockers (必须修复)
+   - suggestions (建议改进)
+   - nits (风格)
+4. 不要写文件 · 不要执行测试
+
+只关注本次 diff 涉及的代码，不要离题。`,
+      },
+      {
+        name: 'invoke',
+        lang: 'bash',
+        code: `# 在 TUI 中
+› /skill run review-pr
+
+# 或者直接当 tool 调用 —— 模型也能主动触发
+› 请帮我 review 当前分支`,
+      },
+    ],
+  },
+  {
+    id: 'memory',
+    label: 'Memory',
+    title: 'Memory',
+    cn: '项目级与全局记忆',
+    desc: 'Reasonix 把"应当记住"的内容拆成两层：仓库级的 reasonix.md（提交进 git，团队共享）与用户级的 ~/.reasonix/memory.md（个人偏好，不入库）。每次会话启动时自动注入到 prompt 头部。',
+    bullets: [
+      '<project>/reasonix.md · 项目约定 · git-tracked',
+      '~/.reasonix/memory.md · 用户偏好 · 私有',
+      '/memory edit 在 TUI 内直接编辑',
+      '注入位置位于 cache-stable 前缀 · 不影响命中',
+    ],
+    files: [
+      {
+        name: '<project>/reasonix.md',
+        lang: 'md',
+        code: `# reasonix.md
+# 这个文件会被 Reasonix 在每次会话启动时加载
+
+## 项目约定
+- 包管理器使用 pnpm，不要建议 npm install
+- 测试运行 \`pnpm test --filter=affected\`
+- TypeScript strict 模式，禁用 any
+- 提交信息遵循 Conventional Commits
+
+## 目录结构
+- src/   业务代码
+- packages/   monorepo 子包
+- tooling/   构建脚本，未经讨论不要改
+
+## 不要做
+- 不要自动 git commit · 等我手动确认
+- 不要修改 package.json 里的版本号`,
+      },
+      {
+        name: '~/.reasonix/memory.md',
+        lang: 'md',
+        code: `# 个人偏好
+
+- 中文回答 · 代码注释保持英文
+- 函数式风格优先 · 少用 class
+- 喜欢小步提交 · 一次只改一件事`,
+      },
+    ],
+  },
+  {
+    id: 'config',
+    label: 'Config',
+    title: 'Config',
+    cn: '全局与项目级配置',
+    desc: '一份 JSON 配置承载所有可调项。全局放 ~/.reasonix/config.json，每个项目可以再用 <project>/.reasonix/config.json 局部覆盖。',
+    bullets: [
+      '模型 · 推理深度 · 输出格式',
+      'MCP 服务器声明',
+      '主题 · 快捷键',
+      '项目级覆盖优先于全局',
+    ],
+    files: [
+      {
+        name: '~/.reasonix/config.json',
+        lang: 'json',
+        code: `{
+  "apiKey": "sk-***",
+  "model": "deepseek-v4-flash",
+  "preset": "balanced",
+  "effort": "medium",
+  "theme": "ember",
+  "autoApply": false,
+  "approval": {
+    "writeFiles": "ask",
+    "runCommand": "ask",
+    "webFetch": "allow"
+  },
+  "telemetry": false
+}`,
+      },
+      {
+        name: '<project>/.reasonix/config.json',
+        lang: 'json',
+        code: `{
+  "model": "deepseek-v4-pro",
+  "preset": "max",
+  "approval": { "writeFiles": "auto" },
+  "skills": ["review-pr", "release-notes"]
+}`,
+      },
+    ],
+  },
+  {
+    id: 'slash',
+    label: 'Slash',
+    title: 'Slash Commands',
+    cn: 'TUI 内的快捷指令',
+    desc: '在交互式 TUI 中以 / 开头的命令直接控制 session 行为。所有命令支持 "did you mean /…?" 模糊纠错。输入 /help 查看完整列表。',
+    bullets: [
+      '/pro · /preset · /effort   — 模型与推理深度切换',
+      '/plan · /apply · /discard  — 编辑审批门',
+      '/mcp · /skill · /memory    — 外部能力与剧本管理',
+      '/status · /stats · /replay — 会话状态与回放',
+    ],
+    files: [
+      {
+        name: 'common commands',
+        lang: 'shell',
+        code: `# 推理深度与模型
+› /pro                # 下一回合切到 V4-Pro
+› /preset max         # 整个 session 用 Pro
+› /effort high        # 强推理 (think harder)
+
+# 编辑审批
+› /plan               # 进入只读审计门
+› /apply              # 写入待提交的编辑
+› /discard            # 丢弃所有 pending 编辑
+
+# 能力管理
+› /mcp list           # 已挂载的 MCP server
+› /skill new fix-bug  # 新建 skill 脚手架
+› /memory edit        # 打开 reasonix.md
+
+# 会话与回放
+› /status             # 模型 · 缓存命中 · 成本
+› /stats              # token 与费用统计
+› /replay -1          # 回放上一次会话
+› /help               # 完整命令参考`,
+      },
+    ],
+  },
+];
+
+function syntaxHighlight(code, lang) {
+  const esc = (s) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+  // Build a single token list per line to avoid double-wrapping spans.
+  const lines = code.split('\n');
+  const out = lines.map((line) => {
+    if (lang === 'json') {
+      // Handle key, then string-value, then number/bool
+      // Tokenize by walking the line
+      let result = '';
+      let rest = line;
+      // simple loop: match key/value pairs
+      while (rest.length) {
+        let m;
+        if ((m = rest.match(/^(\s*)("(?:[^"\\]|\\.)*")(\s*:)/))) {
+          result += esc(m[1]) + '<span style="color:#7ec8ff">' + esc(m[2]) + '</span>' + esc(m[3]);
+          rest = rest.slice(m[0].length);
+        } else if ((m = rest.match(/^("(?:[^"\\]|\\.)*")/))) {
+          result += '<span style="color:#00e5a8">' + esc(m[1]) + '</span>';
+          rest = rest.slice(m[0].length);
+        } else if ((m = rest.match(/^(true|false|null)\b/))) {
+          result += '<span style="color:#ffb84d">' + esc(m[1]) + '</span>';
+          rest = rest.slice(m[0].length);
+        } else if ((m = rest.match(/^(-?\d+(?:\.\d+)?)/))) {
+          result += '<span style="color:#ffb84d">' + esc(m[1]) + '</span>';
+          rest = rest.slice(m[0].length);
+        } else {
+          result += esc(rest[0]);
+          rest = rest.slice(1);
+        }
+      }
+      return result;
+    }
+    if (lang === 'md') {
+      if (/^---$/.test(line)) return '<span style="color:#6b7593">' + esc(line) + '</span>';
+      if (/^#{1,3}\s/.test(line)) return '<span style="color:#7ec8ff">' + esc(line) + '</span>';
+      // frontmatter key (only when before --- ends)
+      let m = line.match(/^([a-zA-Z\-]+:)(.*)$/);
+      if (m) return '<span style="color:#ffb84d">' + esc(m[1]) + '</span>' + esc(m[2]);
+      if (/^- /.test(line)) return '<span style="color:#a3adc6">' + esc(line) + '</span>';
+      return esc(line);
+    }
+    if (lang === 'bash' || lang === 'shell') {
+      if (/^\s*#/.test(line)) return '<span style="color:#6b7593">' + esc(line) + '</span>';
+      // Walk tokens, escaping each chunk separately
+      let result = '';
+      let rest = line;
+      // leading prompt
+      let m = rest.match(/^(›\s|\$\s)/);
+      if (m) {
+        result += '<span style="color:#4d6bfe">' + esc(m[1]) + '</span>';
+        rest = rest.slice(m[0].length);
+      }
+      // tokenize the remainder by whitespace, coloring slash-commands and flags
+      const parts = rest.split(/(\s+)/);
+      for (const p of parts) {
+        if (/^\s+$/.test(p)) { result += esc(p); continue; }
+        if (/^\/[a-z][a-z\-]+$/i.test(p)) {
+          result += '<span style="color:#7c5cff">' + esc(p) + '</span>';
+        } else if (/^--?[a-z][a-zA-Z\-]+$/.test(p)) {
+          result += '<span style="color:#ffb84d">' + esc(p) + '</span>';
+        } else {
+          result += esc(p);
+        }
+      }
+      return result;
+    }
+    return esc(line);
+  });
+  return out.join('\n');
+}
+
+function CodePanel({ file }) {
+  const [copied, setCopied] = React.useState(false);
+  const copy = () => {
+    navigator.clipboard?.writeText(file.code).catch(()=>{});
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+  return (
+    <div className="code-panel">
+      <div className="code-panel-head">
+        <span className="code-file"><Ic.Terminal size={12}/> {file.name}</span>
+        <button className={'copy-btn ' + (copied?'copied':'')} onClick={copy} style={{marginLeft:'auto'}}>
+          {copied ? <Ic.Check/> : <Ic.Copy/>} {copied ? 'Copied' : 'Copy'}
+        </button>
+      </div>
+      <pre className="code-body" dangerouslySetInnerHTML={{ __html: syntaxHighlight(file.code, file.lang) }}/>
+    </div>
+  );
+}
+
+function Config() {
+  const [tab, setTab] = React.useState('mcp');
+  const cur = CONFIG_TABS.find(t => t.id === tab) || CONFIG_TABS[0];
+
+  return (
+    <section className="section" id="config">
+      <SecHead
+        num="04"
+        label="Configure"
+        title="扩展、记忆、配置 — <em>纯文本</em>就够了。"
+        sub="Reasonix 把可扩展性收敛到几个明确的目录与文件 —— 没有花哨的注册表，所有内容都是可读、可 diff、可入库的纯文本。"
+      />
+
+      <div className="config-grid">
+        <div className="config-side">
+          {CONFIG_TABS.map(t => (
+            <div key={t.id} className={'config-tab ' + (t.id === tab ? 'on' : '')} onClick={() => setTab(t.id)}>
+              <span className="config-tab-key">/{t.label.toLowerCase()}</span>
+              <div>
+                <div className="config-tab-title">{t.title}</div>
+                <div className="config-tab-cn">{t.cn}</div>
+              </div>
+              <Ic.Arrow size={13}/>
+            </div>
+          ))}
+          <div className="config-hint">
+            <Ic.Sparkle size={13}/>
+            <span>所有路径与命令均来自 <a href="https://github.com/esengine/DeepSeek-Reasonix" target="_blank" rel="noreferrer" style={{color:'var(--accent)', textDecoration:'none'}}>esengine/DeepSeek-Reasonix</a>。</span>
+          </div>
+        </div>
+
+        <div className="config-main" key={cur.id}>
+          <div className="config-main-head">
+            <h3>{cur.title}<span> · {cur.cn}</span></h3>
+            <p>{cur.desc}</p>
+          </div>
+
+          <ul className="config-bullets">
+            {cur.bullets.map((b, i) => (
+              <li key={i}>
+                <span className="bullet-dot"></span>
+                <span>{b}</span>
+              </li>
+            ))}
+          </ul>
+
+          <div className="config-files">
+            {cur.files.map((f, i) => <CodePanel key={i} file={f}/>)}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+window.Config = Config;

--- a/download-site/src/download-page.jsx
+++ b/download-site/src/download-page.jsx
@@ -1,0 +1,173 @@
+// Dedicated /download page — hero + smart mirror grid + platform notes
+
+function PlatformNotes({ os }) {
+  const NOTES = {
+    mac: {
+      title: 'macOS · Gatekeeper',
+      en: 'first-launch unquarantine',
+      desc: '安装包暂未代码签名，首次启动会被 Gatekeeper 拦下。任选其一：',
+      steps: [
+        { cmd: 'xattr -dr com.apple.quarantine /Applications/Reasonix.app', note: '终端一行解除隔离属性' },
+        { cmd: 'right-click → Open → 确认', note: '在 Finder 中右键打开，确认一次后续不再询问' },
+      ],
+    },
+    win: {
+      title: 'Windows · SmartScreen',
+      en: '"unknown publisher" warning',
+      desc: 'SmartScreen 会提示 "Unknown publisher"。需要：',
+      steps: [
+        { cmd: '更多信息 → 仍要运行', note: 'Click "More info" then "Run anyway" 即可' },
+        { cmd: 'Get-AuthenticodeSignature .\\Reasonix_setup.exe', note: '可在 PowerShell 中校验文件 hash' },
+      ],
+    },
+    linux: {
+      title: 'Linux · AppImage',
+      en: 'chmod +x · libfuse2',
+      desc: 'AppImage 需要执行权限，部分发行版还要补 libfuse2：',
+      steps: [
+        { cmd: 'chmod +x Reasonix_0.42.0-3_amd64.AppImage', note: '赋予可执行权限' },
+        { cmd: 'sudo apt install libfuse2 # debian/ubuntu', note: 'AppImage 运行时依赖' },
+      ],
+    },
+  };
+  const n = NOTES[os] || NOTES.mac;
+  return (
+    <div className="platform-note">
+      <div className="platform-note-head">
+        <span className="platform-note-en">{n.en}</span>
+        <h3>{n.title}</h3>
+      </div>
+      <p className="platform-note-desc">{n.desc}</p>
+      <div className="platform-steps">
+        {n.steps.map((s, i) => (
+          <div key={i} className="platform-step">
+            <div className="copy-block" style={{maxWidth:'none'}}>
+              <span className="cmd"><span className="tok-cmt">$ </span>{s.cmd}</span>
+            </div>
+            <p>{s.note}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function DownloadHero({ os, setOs }) {
+  return (
+    <section className="dl-hero">
+      <div className="hero-head">
+        <span>§00 · Download</span>
+        <span className="rule"></span>
+        <span className="v">Reasonix Desktop · 0.42.0-3</span>
+      </div>
+      <div className="dl-hero-grid">
+        <div>
+          <h1>
+            桌面端，<em>与 CLI 同根</em>。
+          </h1>
+          <p className="lede">
+            原生 <b>Tauri</b> 客户端 · 自带 Node runtime · 共享 <b>~/.reasonix</b> 配置与会话。
+            多 tab 并行，右侧栏列出当前会话读过和改过的文件，底部 cost / cache / token 实时表盘。
+          </p>
+          <p className="lede-foot">
+            <span style={{color:'var(--accent)'}}>※</span> 当前为预发布版本 · 安装包暂未代码签名 · 见下方平台提示
+          </p>
+        </div>
+        <div className="dl-hero-stats">
+          <div className="hero-stat"><b>2</b><span>Mirrors</span></div>
+          <div className="hero-stat"><b>3</b><span>Platforms</span></div>
+          <div className="hero-stat"><b>Auto</b><span>Probe</span></div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function CliAlt() {
+  return (
+    <section className="section" id="cli-alt">
+      <div className="sec-meta">
+        <span className="sec-num">§02</span>
+        <span>· CLI 替代方案</span>
+        <span className="rule"></span>
+      </div>
+      <div className="section-head">
+        <div className="section-head-text">
+          <h2 className="section-title">
+            <em>不想装桌面？</em>一行 CLI 就够。
+          </h2>
+        </div>
+        <p className="section-sub">
+          桌面端只是 CLI 的可视化伴侣。如果你日常就在终端里，直接 npx 拉起 reasonix code 即可，
+          缓存策略、工具协议、记忆路径完全一致。
+        </p>
+      </div>
+      <div className="copy-block" style={{maxWidth: 640}}>
+        <span className="cmd"><span className="tok-cmt">$ </span>cd /path/to/my-project &amp;&amp; npx reasonix code</span>
+      </div>
+      <a className="btn btn-ghost" href="index.html#install" style={{marginTop: 22}}>
+        查看完整安装指引 →
+      </a>
+    </section>
+  );
+}
+
+function DownloadPage() {
+  const [os, setOs] = React.useState(detectOS);
+
+  return (
+    <>
+      <Nav active="download"/>
+      <DownloadHero os={os} setOs={setOs}/>
+
+      <section className="section" id="mirror">
+        <div className="sec-meta">
+          <span className="sec-num">§01</span>
+          <span>· Smart Mirror · 自动测速</span>
+          <span className="rule"></span>
+        </div>
+        <div className="section-head">
+          <div className="section-head-text">
+            <h2 className="section-title">
+              两路并行 <em>探测</em>，自动择优。
+            </h2>
+          </div>
+          <p className="section-sub">
+            页面打开瞬间同时向 Cloudflare R2 与 GitHub Releases 发起 HEAD 请求，按 TTFB 排序，
+            把最快的链路标记为 Fastest 推给你。R2 是 CN 主路径（CF 边缘），GitHub 是国际兜底。
+          </p>
+        </div>
+        <MirrorGrid os={os} setOs={setOs}/>
+      </section>
+
+      <section className="section" id="platform">
+        <div className="sec-meta">
+          <span className="sec-num">§03</span>
+          <span>· 平台注意事项</span>
+          <span className="rule"></span>
+        </div>
+        <div className="platform-tabs">
+          {[
+            { id: 'mac', label: 'macOS' },
+            { id: 'win', label: 'Windows' },
+            { id: 'linux', label: 'Linux' },
+          ].map(p => (
+            <button
+              key={p.id}
+              className={'platform-tab ' + (os === p.id ? 'on' : '')}
+              onClick={() => setOs(p.id)}
+            >
+              {p.label}
+            </button>
+          ))}
+        </div>
+        <PlatformNotes os={os}/>
+      </section>
+
+      <CliAlt/>
+      <Footer/>
+    </>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<DownloadPage/>);

--- a/download-site/src/faq.jsx
+++ b/download-site/src/faq.jsx
@@ -1,0 +1,65 @@
+// FAQ — based on actual README "what Reasonix deliberately doesn't do" section
+
+const FAQS = [
+  {
+    q: '为什么只支持 DeepSeek？能不能换 Claude / GPT？',
+    a: '这不是限制，是设计。DeepSeek 的 prefix-cache 从 prompt 第 0 字节开始指纹化，Reasonix 的循环是围绕这个不变量构建的 —— 长会话能保持 ~94% 缓存命中。挂到 Anthropic 兼容端点能拿到便宜 token，但 cache_control 标记会失效；通用 backend (Aider / Cline / Continue) 的压缩模式则会破坏字节稳定性。Coupling to one backend is the feature。',
+  },
+  {
+    q: '需要付费吗？',
+    a: 'Reasonix 本身 MIT 开源，完全免费。但需要付费的 DeepSeek API Key。参考定价：V4-Flash $0.07/Mtok 未命中、$0.014/Mtok 命中，长会话下成本通常只到通用工具的 1/3。',
+  },
+  {
+    q: '需要 IDE 插件吗？',
+    a: '不会做。Reasonix 是 terminal-first。diff 留给 git diff，文件树留给 ls。桌面端是配套的可视化伴侣，不是 Cursor 替代品。',
+  },
+  {
+    q: '能在内网 / 私有部署的 DeepSeek 上跑吗？',
+    a: '可以。从 0.30 起接受非标准 key 前缀的自托管 DeepSeek 端点。把 baseUrl 改成你的内部地址即可，循环、缓存策略、工具协议都不变。',
+  },
+  {
+    q: 'CLI 和桌面端是什么关系？',
+    a: '完全同一份循环 / 协议 / ~/.reasonix 配置。桌面端 (Tauri) 自带 Node runtime，无需独立 npm install；多 tab 会话、右侧栏列出当前会话读过和改过的文件，底部显示 cost / cache / token 实时表盘。',
+  },
+  {
+    q: '怎么开发自己的 Skill？',
+    a: '没有远程注册表，直接写文件。在 TUI 内 /skill new my-skill 生成项目级模板，--global 写到 ~/.reasonix/skills 跨项目复用。Skill 是带 frontmatter (description, runAs, allowed-tools) 的 Markdown，runAs: subagent 会在隔离子循环里运行。',
+  },
+  {
+    q: '工具调用是否安全？',
+    a: '所有原生工具 (read_file / write_file / edit_file / run_command 等) 都沙箱化到启动目录，--dir 显式指定。SEARCH/REPLACE 编辑默认进 pending 队列，/apply 才落盘。/plan 进入只读审计门，未批准计划前不允许写入。',
+  },
+  {
+    q: '能切换工作目录吗？',
+    a: '不能在 session 中途切。memory 路径会与陈旧的根目录纠缠。退出后 reasonix code --dir <path> 重新启动即可。',
+  },
+];
+
+function Faq() {
+  const [open, setOpen] = React.useState(0);
+  return (
+    <section className="section" id="faq">
+      <SecHead
+        num="08"
+        label="FAQ"
+        title="高频<em>问题</em>。"
+        sub="仍有疑问？欢迎到 GitHub Discussions 提问。"
+      />
+
+      <div className="faq-list">
+        {FAQS.map((f, i) => (
+          <div key={i} className={'faq-item ' + (open === i ? 'open' : '')}>
+            <div className="faq-q" onClick={() => setOpen(open === i ? -1 : i)}>
+              <span className="idx">{String(i + 1).padStart(2, '0')}</span>
+              <span style={{flex:1}}>{f.q}</span>
+              <Ic.Chev className="chev"/>
+            </div>
+            <div className="faq-a">{f.a}</div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+window.Faq = Faq;

--- a/download-site/src/features.jsx
+++ b/download-site/src/features.jsx
@@ -1,0 +1,60 @@
+// Feature grid — editorial numbered tiles
+
+const FEATURES = [
+  {
+    title: '终端原生 TUI',
+    en: 'TypeScript + Ink TUI',
+    desc: '不是又一个 IDE 插件。diff 留给 git diff，文件树留给 ls —— 终端就是工作面板。',
+  },
+  {
+    title: 'V4 双档位',
+    en: 'Flash by default · /pro on demand',
+    desc: '默认 V4-Flash 跑日常迭代控成本，/pro 单回合切到 V4-Pro，/preset max 整个 session 走 Pro。',
+  },
+  {
+    title: 'MCP first-class',
+    en: 'stdio · SSE · Streamable HTTP',
+    desc: '一行 --mcp "name=cmd args" 接入外部服务器，工具以前缀合并进同一个 registry。',
+  },
+  {
+    title: '沙箱与计划门',
+    en: 'Sandbox + /plan gate',
+    desc: '所有原生工具沙箱化到启动目录；/plan 进入只读审计门，未批准前不允许写入。',
+  },
+  {
+    title: 'Skills 可编排',
+    en: 'Markdown skill scripts',
+    desc: '.reasonix/skills/<name>.md，frontmatter 支持 runAs: subagent + allowed-tools 隔离运行。',
+  },
+  {
+    title: 'Replay & Events',
+    en: 'reasonix replay / events / stats',
+    desc: '完整事件流落盘，可回放任意一次会话，可统计 token / cache / 成本，便于审计。',
+  },
+];
+
+function Features() {
+  return (
+    <section className="section" id="features">
+      <SecHead
+        num="03"
+        label="Features"
+        title="围绕 <em>DeepSeek API</em> 的工程姿态。"
+        sub="十几个工具一起构成一个看似简单的命令行 —— 但底下的每一层都在为缓存命中、成本和稳定性服务。"
+      />
+
+      <div className="feat-grid">
+        {FEATURES.map((f, i) => (
+          <div key={f.title} className="feat">
+            <div className="feat-num">F-{String(i + 1).padStart(2, '0')}</div>
+            <h3>{f.title}</h3>
+            <p>{f.desc}</p>
+            <span className="feat-en">{f.en}</span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+window.Features = Features;

--- a/download-site/src/fonts.css
+++ b/download-site/src/fonts.css
@@ -1,0 +1,12 @@
+/* System-font stack tuned to match the mockup's editorial look:
+   - sans: Geist → Inter → system fallback
+   - serif: Instrument Serif → Iowan/Charter/Hoefler system serifs
+   - mono: Geist Mono / JetBrains Mono → system mono
+   Loading actual woff2 from a third-party CDN is intentionally avoided —
+   external font hosts are blocked or slow on mainland China networks. */
+
+:root {
+  --sans:  "Geist", "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI Variable", "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;
+  --serif: "Instrument Serif", "Iowan Old Style", "Apple Garamond", "Hoefler Text", "Source Han Serif SC", Georgia, serif;
+  --mono:  "Geist Mono", "JetBrains Mono", ui-monospace, "SFMono-Regular", "Cascadia Mono", "Liberation Mono", Menlo, monospace;
+}

--- a/download-site/src/footer.jsx
+++ b/download-site/src/footer.jsx
@@ -1,0 +1,61 @@
+// Footer
+
+function Footer() {
+  return (
+    <footer className="footer">
+      <div className="footer-inner">
+        <div>
+          <a className="brand" href="#top" style={{textDecoration:'none', color:'inherit'}}>
+            <span className="brand-mark"></span>
+            <span className="brand-name">
+              <b>DeepSeek-Reasonix</b>
+            </span>
+          </a>
+          <p style={{color:'var(--cream-mute)', fontSize:13, marginTop:14, lineHeight:1.65, maxWidth:340}}>
+            DeepSeek-native AI coding agent for your terminal. Engineered around
+            prefix-cache stability — leave it running.
+          </p>
+          <div style={{display:'flex', gap:10, marginTop:18}}>
+            <a className="btn btn-ghost btn-sm" href="https://github.com/esengine/DeepSeek-Reasonix" target="_blank" rel="noreferrer" aria-label="GitHub"><Ic.Github size={14}/></a>
+            <a className="btn btn-ghost btn-sm" href="https://github.com/esengine/DeepSeek-Reasonix/discussions" target="_blank" rel="noreferrer">Discussions</a>
+          </div>
+        </div>
+        <div>
+          <h5>Product</h5>
+          <ul>
+            <li><a href="index.html#install">CLI 安装</a></li>
+            <li><a href="download.html">桌面端</a></li>
+            <li><a href="index.html#agents">三大支柱</a></li>
+            <li><a href="index.html#config">配置</a></li>
+          </ul>
+        </div>
+        <div>
+          <h5>Community</h5>
+          <ul>
+            <li><a href="https://github.com/esengine/DeepSeek-Reasonix" target="_blank" rel="noreferrer">GitHub</a></li>
+            <li><a href="https://github.com/esengine/DeepSeek-Reasonix/discussions" target="_blank" rel="noreferrer">Discussions</a></li>
+            <li><a href="https://github.com/esengine/DeepSeek-Reasonix/issues" target="_blank" rel="noreferrer">Issues</a></li>
+            <li><a href="https://github.com/esengine/DeepSeek-Reasonix/blob/main/CONTRIBUTING.md" target="_blank" rel="noreferrer">Contributing</a></li>
+          </ul>
+        </div>
+        <div>
+          <h5>Resources</h5>
+          <ul>
+            <li><a href="https://github.com/esengine/DeepSeek-Reasonix#readme" target="_blank" rel="noreferrer">README</a></li>
+            <li><a href="index.html#roadmap">Roadmap</a></li>
+            <li><a href="https://github.com/esengine/DeepSeek-Reasonix/blob/main/CHANGELOG.md" target="_blank" rel="noreferrer">Changelog</a></li>
+            <li><a href="https://platform.deepseek.com" target="_blank" rel="noreferrer">DeepSeek Platform</a></li>
+          </ul>
+        </div>
+      </div>
+      <div className="footer-bottom">
+        <span>© 2026 esengine · MIT License</span>
+        <span className="spacer"></span>
+        <span>Independent open-source project · 与 DeepSeek 官方无关</span>
+        <span style={{marginLeft:18}}>v0.42.0-3 · prerelease</span>
+      </div>
+    </footer>
+  );
+}
+
+window.Footer = Footer;

--- a/download-site/src/hero.jsx
+++ b/download-site/src/hero.jsx
@@ -1,0 +1,165 @@
+// Hero — animated terminal showing a real Reasonix coding session
+
+// Based on the actual reasonix code TUI: cache-first loop, SEARCH/REPLACE edits,
+// tool calls sandboxed to launch dir.
+const TERM_SCRIPT = [
+  { t: 'cmd', text: 'npx reasonix code' },
+  { t: 'out', text: '⏺ reasonix 0.42.0-3 · model: deepseek-v4-flash · workspace: ~/app', cls: 'term-info', delay: 280 },
+  { t: 'out', text: '⏺ cache: 94.2% hit · session: 18m23s · cost: $0.043', cls: 'term-dim', delay: 220 },
+  { t: 'blank' },
+  { t: 'cmd', text: 'fix the case-sensitivity bug in findByEmail' },
+  { t: 'out', text: '▸ tool<search_files>  → src/users.ts, src/users.test.ts', cls: 'term-dim', delay: 260 },
+  { t: 'out', text: '▸ tool<read_file>     → src/users.ts (412 chars)', cls: 'term-dim', delay: 220 },
+  { t: 'out', text: '▸ thinking …  reasoning on  · /effort high', cls: 'term-info', delay: 280 },
+  { t: 'out', text: 'src/users.ts', cls: 'term-warn', delay: 180 },
+  { t: 'out', text: '<<<<<<< SEARCH', cls: 'term-dim', delay: 80 },
+  { t: 'out', text: '  return users.find(u => u.email === email);', delay: 80 },
+  { t: 'out', text: '=======', cls: 'term-dim', delay: 80 },
+  { t: 'out', text: '  const needle = email.toLowerCase();', cls: 'term-ok', delay: 80 },
+  { t: 'out', text: '  return users.find(u => u.email.toLowerCase() === needle);', cls: 'term-ok', delay: 80 },
+  { t: 'out', text: '>>>>>>> REPLACE', cls: 'term-dim', delay: 80 },
+  { t: 'out', text: '▸ 1 pending edit · /apply to write · /discard to drop', cls: 'term-info', delay: 240 },
+  { t: 'blank' },
+  { t: 'cmd', text: '/apply' },
+  { t: 'out', text: '✓ wrote src/users.ts · 2 lines changed', cls: 'term-ok', delay: 200 },
+  { t: 'out', text: '✓ npm test users  · 14 passed · 0 failed (3.1s)', cls: 'term-ok', delay: 220 },
+];
+
+function Terminal() {
+  const [lines, setLines] = React.useState([]);
+  const [typing, setTyping] = React.useState('');
+  const stepRef = React.useRef(0);
+  const charRef = React.useRef(0);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    let timer;
+
+    const run = () => {
+      if (cancelled) return;
+      const i = stepRef.current;
+      if (i >= TERM_SCRIPT.length) {
+        timer = setTimeout(() => {
+          if (cancelled) return;
+          stepRef.current = 0;
+          charRef.current = 0;
+          setLines([]);
+          run();
+        }, 3600);
+        return;
+      }
+      const step = TERM_SCRIPT[i];
+      if (step.t === 'cmd') {
+        const text = step.text;
+        if (charRef.current < text.length) {
+          setTyping(text.slice(0, charRef.current + 1));
+          charRef.current += 1;
+          timer = setTimeout(run, 22 + Math.random() * 28);
+        } else {
+          setLines(prev => [...prev, { ...step, text }]);
+          setTyping('');
+          charRef.current = 0;
+          stepRef.current += 1;
+          timer = setTimeout(run, 380);
+        }
+      } else if (step.t === 'blank') {
+        setLines(prev => [...prev, step]);
+        stepRef.current += 1;
+        timer = setTimeout(run, 240);
+      } else {
+        setLines(prev => [...prev, step]);
+        stepRef.current += 1;
+        timer = setTimeout(run, step.delay || 180);
+      }
+    };
+
+    timer = setTimeout(run, 600);
+    return () => { cancelled = true; clearTimeout(timer); };
+  }, []);
+
+  return (
+    <div className="terminal" role="presentation" aria-hidden="true">
+      <div className="term-head">
+        <div className="term-dots"><i></i><i></i><i></i></div>
+        <span className="term-title">~/app  ·  reasonix code</span>
+        <div className="term-tabs">
+          <span className="term-tab on">session</span>
+          <span className="term-tab">events</span>
+          <span className="term-tab">+</span>
+        </div>
+      </div>
+      <div className="term-body">
+        {lines.map((l, i) => {
+          if (l.t === 'blank') return <div key={i} className="term-line">&nbsp;</div>;
+          if (l.t === 'cmd') {
+            return (
+              <div key={i} className="term-line">
+                <span className="term-prompt-user">›</span>
+                <span className="term-cmd">{l.text}</span>
+              </div>
+            );
+          }
+          return (
+            <div key={i} className={'term-line ' + (l.cls || '')}>{l.text}</div>
+          );
+        })}
+        {typing !== '' ? (
+          <div className="term-line">
+            <span className="term-prompt-user">›</span>
+            <span className="term-cmd">{typing}</span>
+            <span className="cursor"></span>
+          </div>
+        ) : (
+          lines.length > 0 && stepRef.current < TERM_SCRIPT.length && (
+            <div className="term-line"><span className="term-prompt-user">›</span><span className="cursor"></span></div>
+          )
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Hero() {
+  return (
+    <section className="hero" id="top">
+      <div className="hero-head">
+        <span>§00 · Reasonix</span>
+        <span className="rule"></span>
+        <span className="v">v0.42.0-3 · open source</span>
+      </div>
+      <div className="hero-grid">
+        <div>
+          <h1>
+            为终端而生的<br/>
+            <em>DeepSeek</em> 原生<br/>
+            编程 <em>Agent</em>。
+          </h1>
+          <p className="lede">
+            Reasonix 直接对接 <b>api.deepseek.com</b>，围绕 DeepSeek 的字节稳定 prefix-cache 设计了
+            append-only 的运行循环 —— 长会话能把缓存命中保持在 90%+，输入 token 成本降到 1/5。
+            终端优先，留它一直跑着。
+          </p>
+          <div className="hero-actions">
+            <a className="btn btn-primary" href="#install">
+              立即开始 →
+            </a>
+            <a className="btn btn-ghost" href="download.html">
+              下载桌面端
+            </a>
+          </div>
+          <div className="hero-stats">
+            <div className="hero-stat"><b>94<span style={{fontFamily:'var(--mono)',fontStyle:'normal',fontSize:18,marginLeft:2,color:'var(--cream-mute)'}}>%</span></b><span>Cache Hit</span></div>
+            <div className="hero-stat"><b>2.5<span style={{fontFamily:'var(--mono)',fontStyle:'normal',fontSize:18,marginLeft:2,color:'var(--cream-mute)'}}>×</span></b><span>Cost Down</span></div>
+            <div className="hero-stat"><b>2837</b><span>Tests</span></div>
+            <div className="hero-stat"><b>MIT</b><span>License</span></div>
+          </div>
+        </div>
+        <div style={{position:'relative'}}>
+          <Terminal/>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+window.Hero = Hero;

--- a/download-site/src/icons.jsx
+++ b/download-site/src/icons.jsx
@@ -1,0 +1,121 @@
+// SVG icon components, minimal stroke style
+
+const Ic = {
+  Github: (p) => (
+    <svg viewBox="0 0 24 24" width={p.size||16} height={p.size||16} fill="currentColor" {...p}>
+      <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2c-3.2.69-3.87-1.54-3.87-1.54-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.03 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.73-1.54-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.18 1.17.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.21-1.48 3.18-1.17 3.18-1.17.62 1.58.23 2.75.11 3.04.73.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14v3.17c0 .31.21.68.8.56C20.21 21.39 23.5 17.07 23.5 12 23.5 5.65 18.35.5 12 .5z"/>
+    </svg>
+  ),
+  Terminal: (p) => (
+    <svg viewBox="0 0 24 24" width={p.size||16} height={p.size||16} fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" {...p}>
+      <rect x="2.5" y="4" width="19" height="16" rx="2"/>
+      <path d="M6 9l3 3-3 3M12 15h6"/>
+    </svg>
+  ),
+  Download: (p) => (
+    <svg viewBox="0 0 24 24" width={p.size||16} height={p.size||16} fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" {...p}>
+      <path d="M12 3v13M6 11l6 6 6-6M4 21h16"/>
+    </svg>
+  ),
+  Copy: (p) => (
+    <svg viewBox="0 0 24 24" width={p.size||14} height={p.size||14} fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" {...p}>
+      <rect x="8" y="8" width="13" height="13" rx="2"/>
+      <path d="M16 8V5a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h3"/>
+    </svg>
+  ),
+  Check: (p) => (
+    <svg viewBox="0 0 24 24" width={p.size||14} height={p.size||14} fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...p}>
+      <path d="M20 6L9 17l-5-5"/>
+    </svg>
+  ),
+  Chev: (p) => (
+    <svg viewBox="0 0 24 24" width={p.size||16} height={p.size||16} fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" {...p}>
+      <path d="M6 9l6 6 6-6"/>
+    </svg>
+  ),
+  Arrow: (p) => (
+    <svg viewBox="0 0 24 24" width={p.size||14} height={p.size||14} fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" {...p}>
+      <path d="M5 12h14M13 5l7 7-7 7"/>
+    </svg>
+  ),
+  Bolt: (p) => (
+    <svg viewBox="0 0 24 24" width={p.size||18} height={p.size||18} fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinejoin="round" strokeLinecap="round" {...p}>
+      <path d="M13 2L4 14h7l-1 8 9-12h-7l1-8z"/>
+    </svg>
+  ),
+  Shield: (p) => (
+    <svg viewBox="0 0 24 24" width={p.size||18} height={p.size||18} fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinejoin="round" strokeLinecap="round" {...p}>
+      <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
+    </svg>
+  ),
+  Cube: (p) => (
+    <svg viewBox="0 0 24 24" width={p.size||18} height={p.size||18} fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinejoin="round" strokeLinecap="round" {...p}>
+      <path d="M12 2l9 5v10l-9 5-9-5V7l9-5zM3 7l9 5 9-5M12 12v10"/>
+    </svg>
+  ),
+  Plug: (p) => (
+    <svg viewBox="0 0 24 24" width={p.size||18} height={p.size||18} fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinejoin="round" strokeLinecap="round" {...p}>
+      <path d="M9 7V2M15 7V2M5 12h14v2a6 6 0 0 1-6 6h-2a6 6 0 0 1-6-6v-2zM12 20v2"/>
+    </svg>
+  ),
+  Brain: (p) => (
+    <svg viewBox="0 0 24 24" width={p.size||18} height={p.size||18} fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinejoin="round" strokeLinecap="round" {...p}>
+      <path d="M9 4a3 3 0 0 0-3 3v1a3 3 0 0 0-2 2.83V13a3 3 0 0 0 2 2.83V17a3 3 0 0 0 6 0V4a3 3 0 0 0-3 0zM15 4a3 3 0 0 1 3 3v1a3 3 0 0 1 2 2.83V13a3 3 0 0 1-2 2.83V17a3 3 0 0 1-6 0"/>
+    </svg>
+  ),
+  Plugin: (p) => (
+    <svg viewBox="0 0 24 24" width={p.size||18} height={p.size||18} fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinejoin="round" strokeLinecap="round" {...p}>
+      <path d="M14 7V3h-4v4H6v4a4 4 0 0 0 4 4h4a4 4 0 0 0 4-4V7h-4zM12 15v6"/>
+    </svg>
+  ),
+  Eye: (p) => (
+    <svg viewBox="0 0 24 24" width={p.size||18} height={p.size||18} fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinejoin="round" strokeLinecap="round" {...p}>
+      <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8S1 12 1 12z"/><circle cx="12" cy="12" r="3"/>
+    </svg>
+  ),
+  Gitee: (p) => (
+    <svg viewBox="0 0 24 24" width={p.size||16} height={p.size||16} fill="currentColor" {...p}>
+      <path d="M12 .5C5.65.5.5 5.65.5 12S5.65 23.5 12 23.5 23.5 18.35 23.5 12 18.35.5 12 .5zm5.91 9.62v1.45c0 .76-.62 1.38-1.38 1.38h-5.05v1.45h7.21c-.04 2.6-2.16 4.7-4.77 4.7H9.6a1.38 1.38 0 0 1-1.38-1.38v-5.05c0-2.62 2.13-4.75 4.75-4.75h4.94z"/>
+    </svg>
+  ),
+  Cloud: (p) => (
+    <svg viewBox="0 0 24 24" width={p.size||16} height={p.size||16} fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinejoin="round" strokeLinecap="round" {...p}>
+      <path d="M17.5 19a4.5 4.5 0 0 0 .25-9 6 6 0 0 0-11.5 1.5A4 4 0 0 0 6 19h11.5z"/>
+    </svg>
+  ),
+  Star: (p) => (
+    <svg viewBox="0 0 24 24" width={p.size||14} height={p.size||14} fill="currentColor" {...p}>
+      <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
+    </svg>
+  ),
+  Sparkle: (p) => (
+    <svg viewBox="0 0 24 24" width={p.size||16} height={p.size||16} fill="currentColor" {...p}>
+      <path d="M12 2l1.5 5.5L19 9l-5.5 1.5L12 16l-1.5-5.5L5 9l5.5-1.5L12 2zM19 14l.8 2.7L22 17.5l-2.2.8L19 21l-.8-2.7L16 17.5l2.2-.8L19 14z"/>
+    </svg>
+  ),
+};
+
+window.Ic = Ic;
+
+// Shared editorial section header
+function SecHead({ num, label, title, sub, actions }) {
+  return (
+    <>
+      <div className="sec-meta">
+        <span className="sec-num">§{num}</span>
+        <span>· {label}</span>
+        <span className="rule"></span>
+      </div>
+      <div className="section-head">
+        <div className="section-head-text">
+          <h2 className="section-title" dangerouslySetInnerHTML={{__html: title}}/>
+        </div>
+        <div style={{display:'flex', flexDirection:'column', gap:18, alignItems:'flex-end'}}>
+          {sub && <p className="section-sub">{sub}</p>}
+          {actions && <div className="section-head-actions">{actions}</div>}
+        </div>
+      </div>
+    </>
+  );
+}
+window.SecHead = SecHead;

--- a/download-site/src/install.jsx
+++ b/download-site/src/install.jsx
@@ -1,0 +1,94 @@
+// CLI install + verification
+
+function CopyCmd({ cmd }) {
+  const [copied, setCopied] = React.useState(false);
+  const copy = () => {
+    navigator.clipboard?.writeText(cmd).catch(()=>{});
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+  return (
+    <div className="copy-block">
+      <span className="cmd">
+        <span className="tok-cmt">$ </span>
+        {cmd}
+      </span>
+      <button className={'copy-btn ' + (copied?'copied':'')} onClick={copy}>
+        {copied ? <Ic.Check/> : <Ic.Copy/>}
+        {copied ? 'Copied' : 'Copy'}
+      </button>
+    </div>
+  );
+}
+
+const INSTALL_TABS = [
+  { id: 'npx',  label: 'npx (推荐)', cmd: 'npx reasonix code',                                        note: '无需全局安装，进入项目目录即用' },
+  { id: 'npm',  label: 'npm',        cmd: 'npm install -g reasonix && reasonix code',                  note: '需要 Node ≥ 22 (或 ≥ 20.10)' },
+  { id: 'pnpm', label: 'pnpm',       cmd: 'pnpm add -g reasonix && reasonix code',                     note: '全局安装速度更快' },
+  { id: 'src',  label: 'from source',cmd: 'git clone https://github.com/esengine/DeepSeek-Reasonix && cd DeepSeek-Reasonix && npm install && npm run dev code', note: '需要参与开发请走源码' },
+];
+
+function Install() {
+  const [tab, setTab] = React.useState('npx');
+  const active = INSTALL_TABS.find(t => t.id === tab) || INSTALL_TABS[0];
+
+  return (
+    <section className="section" id="install">
+      <SecHead
+        num="01"
+        label="Install"
+        title="<em>两步</em>运行，免全局安装。"
+        sub="Node ≥ 22，支持 macOS / Linux / Windows (PowerShell · Git Bash · Windows Terminal)。首次运行内置向导会引导你粘贴 DeepSeek API Key。"
+      />
+
+      <div className="tabs" role="tablist">
+        {INSTALL_TABS.map(t => (
+          <button key={t.id} className={tab === t.id ? 'on' : ''} onClick={() => setTab(t.id)}>
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      <CopyCmd cmd={active.cmd}/>
+      <p style={{color:'var(--cream-mute)', fontSize:12.5, marginTop:14, fontFamily:'var(--mono)', letterSpacing:'0.04em'}}>
+        // {active.note}
+      </p>
+
+      <div style={{display:'grid', gridTemplateColumns:'repeat(3, 1fr)', gap: 0, marginTop: 56, borderTop: '1px solid var(--rule)'}}>
+        <div className="card" style={{padding:'32px 28px 32px 0', borderRight:'1px solid var(--rule)'}}>
+          <div style={{fontFamily:'var(--mono)', fontSize:11, letterSpacing:'0.14em', color:'var(--cream-mute)', textTransform:'uppercase', marginBottom: 18}}>01 — API Key</div>
+          <h3 style={{fontFamily:'var(--serif)', fontStyle:'italic', fontWeight:400, fontSize:26, letterSpacing:'-0.005em', margin:'0 0 10px', color:'var(--cream)'}}>获取 DeepSeek API Key</h3>
+          <p style={{color:'var(--cream-dim)', fontSize:14.5, marginTop:6, marginBottom:14, lineHeight:1.6}}>
+            前往 <a href="https://platform.deepseek.com" target="_blank" rel="noreferrer" style={{color:'var(--accent)',textDecoration:'none', borderBottom:'1px solid var(--accent-line)'}}>DeepSeek 开放平台</a> 创建一个 Key，按量计费、命中缓存的 token 仅原价 1/5。
+          </p>
+          <p style={{color:'var(--cream-mute)', fontSize:11.5, marginTop:0, marginBottom:0, fontFamily:'var(--mono)', letterSpacing:'0.04em'}}>
+            $0.07 /Mtok in · $0.014 /Mtok cached
+          </p>
+        </div>
+        <div className="card" style={{padding:'32px 28px', borderRight:'1px solid var(--rule)'}}>
+          <div style={{fontFamily:'var(--mono)', fontSize:11, letterSpacing:'0.14em', color:'var(--cream-mute)', textTransform:'uppercase', marginBottom: 18}}>02 — Workspace</div>
+          <h3 style={{fontFamily:'var(--serif)', fontStyle:'italic', fontWeight:400, fontSize:26, letterSpacing:'-0.005em', margin:'0 0 14px', color:'var(--cream)'}}>进入项目目录</h3>
+          <div className="copy-block" style={{fontSize:13, maxWidth:'none'}}>
+            <span className="cmd"><span className="tok-cmt">$ </span>cd /path/to/my-project</span>
+          </div>
+          <p style={{color:'var(--cream-mute)', fontSize:11.5, marginTop:14, marginBottom:0, fontFamily:'var(--mono)', letterSpacing:'0.04em'}}>
+            // tools sandboxed to launch dir
+          </p>
+        </div>
+        <div className="card" style={{padding:'32px 0 32px 28px'}}>
+          <div style={{fontFamily:'var(--mono)', fontSize:11, letterSpacing:'0.14em', color:'var(--cream-mute)', textTransform:'uppercase', marginBottom: 18}}>03 — Run</div>
+          <h3 style={{fontFamily:'var(--serif)', fontStyle:'italic', fontWeight:400, fontSize:26, letterSpacing:'-0.005em', margin:'0 0 14px', color:'var(--cream)'}}>启动 TUI 会话</h3>
+          <div className="copy-block" style={{fontSize:13, maxWidth:'none'}}>
+            <span className="cmd"><span className="tok-cmt">$ </span>npx reasonix code</span>
+          </div>
+          <p style={{color:'var(--cream-mute)', fontSize:11.5, marginTop:14, marginBottom:0, fontFamily:'var(--mono)', letterSpacing:'0.04em'}}>
+            // 首次启动向导自动注入 Key
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+window.Install = Install;
+window.CopyCmd = CopyCmd;

--- a/download-site/src/mirrors.jsx
+++ b/download-site/src/mirrors.jsx
@@ -1,0 +1,210 @@
+// Smart mirror grid — probes R2 / GitHub Releases for fastest TTFB and offers
+// a per-platform installer link from whichever wins.
+
+const VERSION = "0.42.0-3";
+const GH_REPO = "esengine/DeepSeek-Reasonix";
+const R2_BASE = "https://pub-147fb53b9c1e4bbf891a257968619ea7.r2.dev";
+
+const MIRRORS = [
+  {
+    id: "r2",
+    name: "Cloudflare R2",
+    region: "GLOBAL · CF Edge",
+    icon: "Cloud",
+    base: `${R2_BASE}/v${VERSION}`,
+    probe: `${R2_BASE}/latest/latest.json`,
+  },
+  {
+    id: "github",
+    name: "GitHub Releases",
+    region: "GLOBAL · US",
+    icon: "Github",
+    base: `https://github.com/${GH_REPO}/releases/download/v${VERSION}`,
+    probe: `https://github.com/${GH_REPO}/releases/download/v${VERSION}/latest.json`,
+  },
+];
+
+const OS_OPTIONS = [
+  {
+    id: "mac",
+    label: "macOS",
+    file: `Reasonix_${VERSION}_universal.dmg`,
+    size: "53 MB",
+    note: "Universal — Apple Silicon + Intel",
+  },
+  {
+    id: "win",
+    label: "Windows",
+    file: `Reasonix_${VERSION}_x64-setup.exe`,
+    size: "30 MB",
+    note: "NSIS installer · x64",
+  },
+  {
+    id: "linux",
+    label: "Linux",
+    file: `Reasonix_${VERSION}_amd64.AppImage`,
+    size: "122 MB",
+    note: "AppImage · x86_64",
+  },
+];
+
+function MirrorIcon({ name }) {
+  const Icon = Ic[name];
+  return Icon ? <Icon size={16}/> : null;
+}
+
+function detectOS() {
+  if (typeof navigator === "undefined") return "mac";
+  const ua = navigator.userAgent || "";
+  if (/Mac/i.test(ua)) return "mac";
+  if (/Win/i.test(ua)) return "win";
+  if (/Linux/i.test(ua)) return "linux";
+  return "mac";
+}
+
+// HEAD-probe a small URL on each mirror and return TTFB in ms. Uses `no-cors`
+// so cross-origin probes still complete (we can't read the response but we
+// can time it). 5 s ceiling; failures return null.
+async function probeMirror(url) {
+  const t0 = performance.now();
+  try {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), 5000);
+    await fetch(url, { method: "GET", mode: "no-cors", cache: "no-store", signal: ctrl.signal });
+    clearTimeout(timer);
+    return Math.round(performance.now() - t0);
+  } catch {
+    return null;
+  }
+}
+
+function MirrorGrid({ os, setOs }) {
+  const [testing, setTesting] = React.useState(true);
+  const [results, setResults] = React.useState(() =>
+    MIRRORS.map(m => ({ id: m.id, lat: null, done: false, ok: false }))
+  );
+
+  const runTest = React.useCallback(() => {
+    setTesting(true);
+    setResults(MIRRORS.map(m => ({ id: m.id, lat: null, done: false, ok: false })));
+    let remaining = MIRRORS.length;
+    MIRRORS.forEach((m) => {
+      probeMirror(m.probe).then((lat) => {
+        setResults(prev => prev.map(r =>
+          r.id === m.id ? { id: m.id, lat, done: true, ok: lat != null } : r
+        ));
+        remaining -= 1;
+        if (remaining === 0) setTesting(false);
+      });
+    });
+  }, []);
+
+  React.useEffect(() => {
+    const t = setTimeout(runTest, 200);
+    return () => clearTimeout(t);
+  }, [runTest]);
+
+  const fastest = React.useMemo(() => {
+    const done = results.filter(r => r.done && r.ok && r.lat != null);
+    if (done.length === 0) return null;
+    return done.reduce((a, b) => (a.lat <= b.lat ? a : b)).id;
+  }, [results]);
+
+  const currentOs = OS_OPTIONS.find(o => o.id === os) || OS_OPTIONS[0];
+  const fastestMirror = MIRRORS.find(m => m.id === fastest);
+  const downloadUrl = fastestMirror ? `${fastestMirror.base}/${currentOs.file}` : null;
+
+  return (
+    <div>
+      <div className="dl-toolbar">
+        <div className="tabs">
+          {OS_OPTIONS.map(o => (
+            <button key={o.id} className={os === o.id ? "on" : ""} onClick={() => setOs(o.id)}>
+              {o.label}
+            </button>
+          ))}
+        </div>
+        <button
+          className="btn btn-ghost btn-sm"
+          onClick={runTest}
+          disabled={testing}
+          title="重新探测"
+          style={{ marginLeft: "auto" }}
+        >
+          <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" style={testing ? { animation: "spin 0.9s linear infinite" } : {}}>
+            <path d="M21 12a9 9 0 1 1-3-6.7L21 8M21 3v5h-5"/>
+          </svg>
+          {testing ? "探测中…" : "重新探测"}
+        </button>
+      </div>
+
+      <div className="mirrors">
+        {MIRRORS.map(m => {
+          const r = results.find(x => x.id === m.id);
+          const isFastest = m.id === fastest && r.done && r.ok;
+          const isTesting = !r.done;
+          const failed = r.done && !r.ok;
+          const url = `${m.base}/${currentOs.file}`;
+          return (
+            <div key={m.id} className={"mirror " + (isFastest ? "fastest " : "") + (isTesting ? "testing" : "")}>
+              <div className="mirror-head">
+                <span className="mirror-icon"><MirrorIcon name={m.icon}/></span>
+                <div>
+                  <div className="mirror-name">{m.name}</div>
+                  <div className="mirror-region">{m.region}</div>
+                </div>
+                <span className="mirror-badge">Fastest</span>
+              </div>
+              <div className="mirror-stats">
+                <div className="mirror-stat">
+                  <label>延迟 · TTFB</label>
+                  <b>
+                    {r.done ? (r.ok ? r.lat : "—") : "—"}
+                    <span className="unit">{r.done && r.ok ? "ms" : ""}</span>
+                  </b>
+                </div>
+                <div className="mirror-stat">
+                  <label>状态 · Status</label>
+                  <b>{isTesting ? "probing…" : failed ? "unreachable" : "online"}</b>
+                </div>
+              </div>
+              <a
+                href={url}
+                className={"btn btn-sm " + (isFastest ? "btn-primary" : "btn-ghost")}
+                style={{ marginTop: 18, width: "100%", justifyContent: "center", ...(failed ? { opacity: 0.5, pointerEvents: "none" } : {}) }}
+              >
+                从此镜像下载 →
+              </a>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="dl-summary">
+        <div className="info">
+          {testing ? (
+            <>正在探测最快镜像 <span style={{ color: "var(--cream-mute)" }}>· measuring TTFB</span></>
+          ) : fastestMirror ? (
+            <>
+              已为你选择 <b>{fastestMirror.name}</b>
+              <span style={{ color: "var(--cream-mute)" }}> · {currentOs.file} · {currentOs.size}</span>
+            </>
+          ) : "探测失败 · 请手动选择镜像"}
+        </div>
+        <a
+          href={downloadUrl || "#"}
+          className="btn btn-primary"
+          style={testing || !downloadUrl ? { opacity: 0.5, pointerEvents: "none" } : {}}
+        >
+          下载 {currentOs.label} 版本 →
+        </a>
+      </div>
+
+      <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+    </div>
+  );
+}
+
+window.MirrorGrid = MirrorGrid;
+window.detectOS = detectOS;
+window.REASONIX_VERSION = VERSION;

--- a/download-site/src/nav.jsx
+++ b/download-site/src/nav.jsx
@@ -1,0 +1,55 @@
+// Top nav — single bar shared between index and download pages
+
+function Nav({ active }) {
+  const [scrolled, setScrolled] = React.useState(false);
+  React.useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > 8);
+    window.addEventListener('scroll', onScroll);
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  const NAV_LINKS = [
+    { href: 'index.html#install',  label: '安装' },
+    { href: 'index.html#agents',   label: '原理' },
+    { href: 'index.html#features', label: '特性' },
+    { href: 'index.html#config',   label: '配置' },
+    { href: 'download.html',       label: '下载', key: 'download' },
+    { href: 'index.html#roadmap',  label: 'Roadmap' },
+    { href: 'index.html#faq',      label: 'FAQ' },
+  ];
+
+  return (
+    <nav className="nav" style={scrolled ? { borderBottomColor: 'var(--rule-2)' } : {}}>
+      <div className="nav-inner">
+        <a className="brand" href="index.html">
+          <span className="brand-mark"></span>
+          <span className="brand-name">
+            <b>Reasonix</b><span>DS · v0.42.0-3</span>
+          </span>
+        </a>
+        <div className="nav-links" role="navigation">
+          {NAV_LINKS.map(l => (
+            <a
+              key={l.label}
+              href={l.href}
+              className={l.key && active === l.key ? 'on' : ''}
+              style={l.key && active === l.key ? {color:'var(--accent)'} : {}}
+            >
+              {l.label}
+            </a>
+          ))}
+        </div>
+        <div className="nav-cta">
+          <a className="btn btn-ghost btn-sm" href="https://github.com/esengine/DeepSeek-Reasonix" target="_blank" rel="noreferrer">
+            <Ic.Github size={13}/> GitHub
+          </a>
+          <a className="btn btn-primary btn-sm" href="download.html">
+            下载桌面端 →
+          </a>
+        </div>
+      </div>
+    </nav>
+  );
+}
+
+window.Nav = Nav;

--- a/download-site/src/roadmap.jsx
+++ b/download-site/src/roadmap.jsx
@@ -1,0 +1,82 @@
+// Roadmap — based on real Reasonix release notes & wishlist discussion
+
+const ROADMAP = [
+  {
+    key: 'shipped',
+    title: '已发布',
+    state: 'done',
+    items: [
+      'Cache-First Loop · prefix 字节稳定',
+      'R1 Thought Harvest · 思考逃逸回收',
+      'Tool-Call Repair · 工具参数自愈',
+      'MCP first-class (stdio / SSE / HTTP)',
+      'Skills · Markdown frontmatter 剧本',
+      '原生 Tauri 桌面端 (prerelease)',
+    ],
+  },
+  {
+    key: 'v0.30.x',
+    title: '迭代中',
+    state: 'now',
+    items: [
+      '/skill new <name> 脚手架命令',
+      'setup-wizard 主题选择 + live preview',
+      '"did you mean /…?" 模糊纠错',
+      'install-source-aware reasonix update',
+      'zh-CN 覆盖扩展至卡片组件',
+    ],
+  },
+  {
+    key: 'next',
+    title: 'Roadmap',
+    state: 'plan',
+    items: [
+      'reasonix init · 项目脚手架 CLI',
+      '跨设备 context 同步',
+      'Plugin system (Claude .claude-plugin/ 兼容)',
+      'Repo map · 仓库语义索引',
+      'TUI 浅色主题',
+    ],
+  },
+  {
+    key: 'wishlist',
+    title: '社区许愿',
+    state: 'plan',
+    items: [
+      '多 agent 协作 · 持久 worker',
+      '跨 provider 编排 (codex + deepseek)',
+      'composer 语音输入',
+      '托管服务模式',
+      '更多语言 i18n 覆盖',
+    ],
+  },
+];
+
+function Roadmap() {
+  return (
+    <section className="section" id="roadmap">
+      <SecHead
+        num="07"
+        label="Roadmap"
+        title="<em>公开的</em>产品节奏。"
+        sub="所有里程碑同步在 GitHub Discussions 的 wishlist。issue 投票影响优先级，PR 决定速度。"
+      />
+
+      <div className="roadmap">
+        {ROADMAP.map(c => (
+          <div key={c.key} className={'rm-col ' + c.state}>
+            <header>
+              <span className="q">{c.key}</span>
+              <h4>{c.title}</h4>
+            </header>
+            <ul>
+              {c.items.map(i => <li key={i}>{i}</li>)}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+window.Roadmap = Roadmap;

--- a/download-site/src/styles.css
+++ b/download-site/src/styles.css
@@ -1,0 +1,1630 @@
+/* DeepSeek-Reasonix v2 — Editorial / Engineering Brief
+ * Direction: deep warm ink, cream foreground, single sodium accent.
+ * Type: Instrument Serif display · Geist body · Geist Mono.
+ * Principle: restraint, hairlines, generous whitespace, marginalia.
+ */
+
+:root {
+  /* Warm ink palette */
+  --ink:        #0c0b0a;
+  --ink-2:      #131110;
+  --ink-3:      #1a1714;
+  --cream:      #ece4d3;
+  --cream-2:    #d9cfb8;
+  --cream-dim:  #a09784;
+  --cream-mute: #6a6358;
+  --rule:       rgba(236, 228, 211, 0.10);
+  --rule-2:     rgba(236, 228, 211, 0.18);
+
+  /* Single accent — sodium ochre */
+  --accent:     #e87a3a;
+  --accent-2:   #d96b2c;
+  --accent-soft: rgba(232, 122, 58, 0.14);
+  --accent-line: rgba(232, 122, 58, 0.35);
+
+  /* Editorial accents */
+  --jade:       #6b8a6f;   /* used very sparingly for success */
+  --rust:       #b35538;
+
+  /* Type stack */
+  --serif:  "Instrument Serif", "Newsreader", ui-serif, Georgia, serif;
+  --sans:   "Geist", "Söhne", ui-sans-serif, system-ui, -apple-system, sans-serif;
+  --mono:   "Geist Mono", "JetBrains Mono", ui-monospace, Menlo, monospace;
+
+  --maxw: 1280px;
+  --gutter: 40px;
+}
+
+* { box-sizing: border-box; }
+*::selection { background: var(--accent); color: var(--ink); }
+
+html, body {
+  margin: 0; padding: 0;
+  background: var(--ink);
+  color: var(--cream);
+  font-family: var(--sans);
+  font-feature-settings: "ss01", "ss02", "cv11";
+  font-size: 16px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  scroll-behavior: smooth;
+}
+
+body {
+  overflow-x: hidden;
+  background:
+    radial-gradient(1400px 600px at 100% -100px, rgba(232,122,58,0.08), transparent 60%),
+    var(--ink);
+}
+
+/* Paper-grain (super subtle) */
+.grid-bg { display: none; }
+.noise {
+  position: fixed; inset: 0; z-index: 1; pointer-events: none;
+  opacity: 0.06;
+  mix-blend-mode: overlay;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2'/></filter><rect width='100%25' height='100%25' filter='url(%23n)' opacity='0.4'/></svg>");
+}
+
+/* ─── NAV ──────────────────────────────────────────────────── */
+.nav {
+  position: sticky; top: 0; z-index: 50;
+  background: rgba(12, 11, 10, 0.78);
+  backdrop-filter: blur(14px) saturate(140%);
+  border-bottom: 1px solid var(--rule);
+}
+.nav-inner {
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: 16px var(--gutter);
+  display: flex;
+  align-items: center;
+  gap: 32px;
+}
+.brand {
+  display: flex; align-items: baseline; gap: 10px;
+  text-decoration: none; color: inherit;
+}
+.brand-mark {
+  width: 22px; height: 22px;
+  border: 1px solid var(--cream-2);
+  border-radius: 50%;
+  position: relative;
+  flex-shrink: 0;
+  align-self: center;
+  background: radial-gradient(circle at 35% 35%, var(--accent) 0 26%, transparent 28%);
+}
+.brand-mark::after {
+  display: none;
+}
+.brand-name { display: flex; align-items: baseline; gap: 8px; }
+.brand-name b {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 19px;
+  letter-spacing: 0.005em;
+}
+.brand-name span {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--cream-mute);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.nav-links {
+  display: flex; gap: 24px;
+  margin-left: 28px;
+  font-family: var(--mono);
+}
+.nav-links a {
+  color: var(--cream-dim);
+  text-decoration: none;
+  font-size: 12px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  transition: color 0.18s;
+  position: relative;
+  padding: 4px 0;
+}
+.nav-links a::after {
+  content: "";
+  position: absolute;
+  left: 0; right: 100%; bottom: 0;
+  height: 1px; background: var(--accent);
+  transition: right 0.25s ease;
+}
+.nav-links a:hover { color: var(--cream); }
+.nav-links a:hover::after { right: 0; }
+
+.nav-cta {
+  margin-left: auto;
+  display: flex; gap: 10px; align-items: center;
+}
+
+/* ─── BUTTONS ──────────────────────────────────────────────── */
+.btn {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 11px 18px;
+  font-family: var(--sans);
+  font-size: 13.5px;
+  font-weight: 500;
+  letter-spacing: 0.005em;
+  cursor: pointer;
+  border: 1px solid transparent;
+  text-decoration: none;
+  transition: all 0.18s ease;
+  white-space: nowrap;
+  border-radius: 0;
+}
+.btn-primary {
+  background: var(--cream);
+  color: var(--ink);
+  border-color: var(--cream);
+}
+.btn-primary:hover {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--ink);
+}
+.btn-ghost {
+  background: transparent;
+  color: var(--cream);
+  border-color: var(--rule-2);
+}
+.btn-ghost:hover {
+  border-color: var(--cream-dim);
+  background: rgba(236, 228, 211, 0.03);
+}
+.btn-sm { padding: 7px 12px; font-size: 12.5px; }
+
+/* ─── LAYOUT ──────────────────────────────────────────────── */
+.section {
+  position: relative;
+  z-index: 2;
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: 120px var(--gutter) 64px;
+  border-top: 1px solid var(--rule);
+}
+.section:first-of-type { border-top: 0; }
+
+/* Section head: §01 · LABEL  +  big serif title  +  lead */
+.sec-meta {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--cream-mute);
+  margin-bottom: 36px;
+}
+.sec-num {
+  color: var(--accent);
+  font-weight: 500;
+}
+.sec-meta .rule {
+  flex: 1;
+  height: 1px;
+  background: var(--rule);
+  max-width: 240px;
+}
+
+.section-head {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 60px;
+  margin-bottom: 60px;
+  align-items: end;
+}
+@media (max-width: 900px) {
+  .section-head { grid-template-columns: 1fr; gap: 28px; }
+}
+.section-title {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: clamp(40px, 5.4vw, 72px);
+  line-height: 1.02;
+  letter-spacing: -0.015em;
+  color: var(--cream);
+  margin: 0;
+  text-wrap: balance;
+}
+.section-title em {
+  font-style: italic;
+  color: var(--accent);
+  font-feature-settings: "ss01";
+}
+.section-sub {
+  color: var(--cream-dim);
+  font-size: 15.5px;
+  line-height: 1.65;
+  text-wrap: pretty;
+  max-width: 460px;
+  justify-self: end;
+}
+@media (max-width: 900px) { .section-sub { justify-self: start; } }
+
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--cream-mute);
+}
+.eyebrow::before {
+  content: "—";
+  color: var(--accent);
+}
+
+/* ─── HERO ─────────────────────────────────────────────────── */
+.hero {
+  position: relative;
+  z-index: 2;
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: 80px var(--gutter) 100px;
+}
+
+.hero-head {
+  display: flex;
+  align-items: baseline;
+  gap: 20px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--cream-mute);
+  margin-bottom: 36px;
+}
+.hero-head .rule { flex: 1; height: 1px; background: var(--rule); max-width: 300px; }
+.hero-head .v { color: var(--accent); }
+
+.hero-grid {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 64px;
+  align-items: start;
+}
+@media (max-width: 980px) {
+  .hero-grid { grid-template-columns: 1fr; gap: 40px; }
+}
+
+.hero h1 {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: clamp(54px, 8.6vw, 124px);
+  line-height: 0.95;
+  letter-spacing: -0.02em;
+  margin: 0 0 28px;
+  color: var(--cream);
+  text-wrap: balance;
+}
+.hero h1 em {
+  font-style: italic;
+  color: var(--accent);
+}
+.hero h1 .accent {
+  font-style: italic;
+  color: var(--accent);
+}
+.hero .lede {
+  font-family: var(--sans);
+  font-size: 17.5px;
+  line-height: 1.55;
+  color: var(--cream-dim);
+  max-width: 560px;
+  text-wrap: pretty;
+  margin: 0 0 36px;
+}
+.hero .lede b {
+  color: var(--cream);
+  font-weight: 500;
+  font-family: var(--mono);
+  font-size: 0.92em;
+  letter-spacing: -0.01em;
+}
+
+.hero-actions {
+  display: flex; gap: 12px; flex-wrap: wrap;
+  margin-bottom: 56px;
+}
+
+/* Hero stats — engineering brief */
+.hero-stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0;
+  border-top: 1px solid var(--rule);
+  padding-top: 24px;
+  max-width: 600px;
+}
+.hero-stat {
+  padding-right: 16px;
+  border-right: 1px solid var(--rule);
+}
+.hero-stat:last-child { border-right: 0; }
+.hero-stat b {
+  display: block;
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 36px;
+  letter-spacing: -0.01em;
+  line-height: 1;
+  color: var(--cream);
+}
+.hero-stat span {
+  display: block;
+  margin-top: 8px;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--cream-mute);
+}
+
+/* Terminal — restrained */
+.terminal {
+  position: relative;
+  background: var(--ink-2);
+  border: 1px solid var(--rule-2);
+  font-family: var(--mono);
+  font-size: 12.5px;
+  line-height: 1.7;
+  border-radius: 0;
+  box-shadow: none;
+  overflow: hidden;
+}
+.terminal::before { display: none; }
+.term-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 11px 14px;
+  border-bottom: 1px solid var(--rule);
+  background: transparent;
+}
+.term-dots { display: flex; gap: 6px; }
+.term-dots i {
+  width: 9px; height: 9px;
+  border-radius: 50%;
+  background: var(--rule-2);
+}
+.term-dots i:nth-child(1) { background: rgba(232, 122, 58, 0.5); }
+.term-dots i:nth-child(2) { background: rgba(236, 228, 211, 0.25); }
+.term-dots i:nth-child(3) { background: rgba(236, 228, 211, 0.18); }
+.term-title {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--cream-mute);
+  letter-spacing: 0.04em;
+  margin-left: 6px;
+}
+.term-tabs {
+  margin-left: auto;
+  display: flex; gap: 4px;
+  font-size: 10px;
+  font-family: var(--mono);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.term-tab { padding: 3px 9px; color: var(--cream-mute); cursor: default; }
+.term-tab.on { color: var(--accent); }
+.term-body {
+  padding: 22px 22px 26px;
+  min-height: 320px;
+}
+.term-line { white-space: pre-wrap; color: var(--cream); }
+.term-prompt-user { color: var(--accent); margin-right: 10px; }
+.term-mute, .term-dim { color: var(--cream-mute); }
+.term-cmd { color: var(--cream); }
+.term-warn { color: #c98e4b; }
+.term-info { color: var(--cream-2); }
+.term-ok { color: var(--jade); }
+.cursor {
+  display: inline-block;
+  width: 8px; height: 14px;
+  background: var(--accent);
+  vertical-align: -2px;
+  margin-left: 2px;
+  animation: blink 1s steps(1) infinite;
+}
+@keyframes blink { 50% { opacity: 0; } }
+
+.spark { display: none; }
+
+/* ─── PILLARS / AGENTS ─────────────────────────────────────── */
+.agents {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: 56px;
+  margin-top: 8px;
+  align-items: start;
+}
+@media (max-width: 920px) { .agents { grid-template-columns: 1fr; gap: 24px; } }
+
+.agent-list {
+  display: flex; flex-direction: column;
+  border-top: 1px solid var(--rule);
+}
+.agent-item {
+  display: flex;
+  align-items: baseline;
+  gap: 16px;
+  padding: 22px 0;
+  cursor: pointer;
+  border: 0;
+  border-bottom: 1px solid var(--rule);
+  background: transparent;
+  transition: color 0.2s;
+  color: var(--cream-dim);
+}
+.agent-item:hover { background: transparent; color: var(--cream); }
+.agent-item.on { color: var(--cream); }
+.agent-item .dot { display: none; }
+.agent-item .meta {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--cream-mute);
+  letter-spacing: 0.04em;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+.agent-item.on .meta { color: var(--accent); }
+.agent-item .label {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 22px;
+  letter-spacing: -0.005em;
+  flex: 1;
+  line-height: 1.15;
+}
+.agent-item .label small {
+  display: block;
+  font-family: var(--mono);
+  font-style: normal;
+  font-weight: 400;
+  font-size: 10.5px;
+  color: var(--cream-mute);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-top: 6px;
+}
+
+.agent-detail {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  min-height: 0;
+}
+.agent-detail .en {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--accent);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.agent-detail h3 {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 44px;
+  letter-spacing: -0.015em;
+  line-height: 1.05;
+  margin: 10px 0 24px;
+  color: var(--cream);
+}
+.agent-detail > p {
+  font-size: 16px;
+  line-height: 1.65;
+  color: var(--cream-dim);
+  max-width: 560px;
+  margin: 0 0 32px;
+}
+
+.agent-detail .metric-bar {
+  display: flex;
+  align-items: baseline;
+  gap: 18px;
+  padding: 22px 0;
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 32px;
+}
+.agent-detail .metric-bar b {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 64px;
+  line-height: 1;
+  color: var(--accent);
+  letter-spacing: -0.02em;
+}
+.agent-detail .metric-bar span {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--cream-mute);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.agent-flow {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  font-family: var(--mono);
+  font-size: 13px;
+  line-height: 1.9;
+  color: var(--cream-dim);
+  border-radius: 0;
+}
+.agent-flow .step {
+  display: grid;
+  grid-template-columns: 36px 140px 1fr;
+  gap: 14px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--rule);
+  align-items: baseline;
+}
+.agent-flow .step:last-child { border-bottom: 0; }
+.agent-flow .step b {
+  color: var(--accent);
+  width: auto;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+}
+.agent-flow .step em {
+  color: var(--cream);
+  font-style: normal;
+  font-family: var(--mono);
+  letter-spacing: 0.04em;
+}
+.agent-flow .step span:last-child { color: var(--cream-dim); }
+
+/* ─── FEATURES — editorial 2-col ───────────────────────────── */
+.feat-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0;
+  margin-top: 8px;
+  border-top: 1px solid var(--rule);
+}
+@media (max-width: 880px) { .feat-grid { grid-template-columns: 1fr; } }
+.feat {
+  position: relative;
+  padding: 36px 28px 36px 0;
+  border-bottom: 1px solid var(--rule);
+  border-right: 1px solid var(--rule);
+  background: transparent;
+  border-radius: 0;
+  overflow: visible;
+}
+.feat:nth-child(3n) { border-right: 0; padding-right: 0; }
+@media (max-width: 880px) {
+  .feat { border-right: 0; padding-right: 0; }
+}
+.feat:nth-child(n+4) { padding-top: 36px; }
+.feat > * { margin-left: 28px; }
+.feat:nth-child(3n+1) > * { margin-left: 0; }
+@media (max-width: 880px) {
+  .feat > * { margin-left: 0; }
+}
+
+.feat-num {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  color: var(--cream-mute);
+  margin-bottom: 18px;
+}
+.feat-icon { display: none; }
+.feat h3 {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 26px;
+  letter-spacing: -0.005em;
+  line-height: 1.15;
+  margin: 0 0 10px;
+  color: var(--cream);
+}
+.feat p {
+  color: var(--cream-dim);
+  font-size: 14.5px;
+  line-height: 1.6;
+  margin: 0;
+}
+.feat-en {
+  display: block;
+  margin-top: 18px;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--cream-mute);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+/* ─── INSTALL ──────────────────────────────────────────────── */
+.tabs {
+  display: inline-flex;
+  border: 1px solid var(--rule-2);
+  padding: 0;
+  background: transparent;
+  border-radius: 0;
+  margin-bottom: 18px;
+}
+.tabs button {
+  background: transparent;
+  border: none;
+  padding: 10px 16px;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  color: var(--cream-mute);
+  cursor: pointer;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border-right: 1px solid var(--rule);
+  transition: color 0.18s;
+}
+.tabs button:last-child { border-right: 0; }
+.tabs button.on {
+  color: var(--ink);
+  background: var(--accent);
+}
+.tabs button:hover:not(.on) { color: var(--cream); }
+
+.copy-block {
+  display: flex;
+  align-items: stretch;
+  background: var(--ink-2);
+  border: 1px solid var(--rule-2);
+  border-radius: 0;
+  padding: 0;
+  font-family: var(--mono);
+  font-size: 14px;
+  max-width: 640px;
+}
+.copy-block .cmd {
+  flex: 1;
+  padding: 14px 18px;
+  color: var(--cream);
+}
+.copy-block .cmd .tok-cmt { color: var(--accent); }
+.copy-block .cmd .tok-fn { color: var(--cream-dim); }
+.copy-block .copy-btn {
+  background: transparent;
+  border: 0;
+  border-left: 1px solid var(--rule);
+  color: var(--cream-dim);
+  padding: 0 18px;
+  font-size: 11.5px;
+  cursor: pointer;
+  font-family: var(--mono);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  transition: all 0.18s;
+}
+.copy-block .copy-btn:hover {
+  color: var(--ink);
+  background: var(--cream);
+}
+.copy-block .copy-btn.copied {
+  color: var(--ink);
+  background: var(--jade);
+}
+
+/* Cards used in install — minimal editorial */
+.card {
+  background: transparent;
+  border: 0;
+  border-top: 1px solid var(--rule);
+  border-radius: 0;
+  padding: 28px 0 0;
+  transition: none;
+}
+.card:hover { border-color: var(--rule); }
+.glow-card { background: transparent; border: 1px solid var(--rule); border-radius: 0; padding: 24px; }
+.glow-card:hover { border-color: var(--rule-2); }
+
+/* ─── MIRRORS ──────────────────────────────────────────────── */
+.mirrors {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0;
+  margin-top: 16px;
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+}
+@media (max-width: 820px) { .mirrors { grid-template-columns: 1fr; } }
+
+.mirror {
+  position: relative;
+  background: transparent;
+  border: 0;
+  border-right: 1px solid var(--rule);
+  border-radius: 0;
+  padding: 32px 28px;
+  transition: background 0.25s;
+  overflow: hidden;
+}
+.mirror:last-child { border-right: 0; }
+.mirror.fastest {
+  background: rgba(232, 122, 58, 0.04);
+  box-shadow: none;
+}
+.mirror.testing { background: transparent; }
+.mirror-head {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+  margin-bottom: 26px;
+}
+.mirror-icon {
+  width: 26px; height: 26px;
+  display: grid; place-items: center;
+  background: transparent;
+  border: 1px solid var(--rule-2);
+  color: var(--cream-dim);
+  border-radius: 0;
+  flex-shrink: 0;
+  align-self: center;
+}
+.mirror-name {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 22px;
+  letter-spacing: -0.005em;
+  color: var(--cream);
+  line-height: 1.1;
+}
+.mirror-region {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--cream-mute);
+  letter-spacing: 0.1em;
+  margin-top: 4px;
+  text-transform: uppercase;
+}
+.mirror-badge {
+  margin-left: auto;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  padding: 4px 8px;
+  border-radius: 0;
+  background: var(--accent);
+  color: var(--ink);
+  text-transform: uppercase;
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+.mirror.fastest .mirror-badge { opacity: 1; }
+
+.mirror-stats {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0;
+  border-top: 1px solid var(--rule);
+}
+.mirror-stat {
+  background: transparent;
+  border: 0;
+  border-right: 1px solid var(--rule);
+  border-radius: 0;
+  padding: 16px 18px 16px 0;
+}
+.mirror-stat:last-child { border-right: 0; padding-right: 0; padding-left: 18px; }
+.mirror-stat label {
+  display: block;
+  font-family: var(--mono);
+  font-size: 9.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--cream-mute);
+  margin-bottom: 8px;
+}
+.mirror-stat b {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 30px;
+  letter-spacing: -0.01em;
+  line-height: 1;
+  color: var(--cream);
+}
+.mirror-stat .unit {
+  color: var(--cream-mute);
+  font-size: 12px;
+  margin-left: 4px;
+  font-family: var(--mono);
+  font-style: normal;
+}
+
+.mirror-bar {
+  margin-top: 16px;
+  height: 2px;
+  background: var(--rule);
+  border-radius: 0;
+  overflow: hidden;
+}
+.mirror-bar i {
+  display: block;
+  height: 100%;
+  background: var(--accent);
+  border-radius: 0;
+  transition: width 0.4s ease;
+  box-shadow: none;
+}
+.mirror.testing .mirror-bar i {
+  background: linear-gradient(90deg, transparent, var(--accent), transparent);
+  animation: scan 1.2s linear infinite;
+  width: 100% !important;
+}
+@keyframes scan {
+  0% { transform: translateX(-100%); }
+  100% { transform: translateX(100%); }
+}
+
+.dl-summary {
+  display: flex;
+  align-items: baseline;
+  gap: 24px;
+  margin-top: 32px;
+  padding: 22px 0 0;
+  border-top: 1px solid var(--rule);
+}
+.dl-summary .info {
+  flex: 1;
+  font-size: 14px;
+  color: var(--cream-dim);
+  font-family: var(--mono);
+  letter-spacing: 0.02em;
+}
+.dl-summary .info b {
+  color: var(--cream);
+  font-weight: 500;
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 18px;
+  letter-spacing: -0.005em;
+}
+
+/* ─── COMMUNITY ────────────────────────────────────────────── */
+.community-grid {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 56px;
+  margin-top: 8px;
+  align-items: start;
+}
+@media (max-width: 920px) { .community-grid { grid-template-columns: 1fr; gap: 28px; } }
+
+.star-card {
+  background: transparent;
+  border: 0;
+  border-top: 1px solid var(--rule);
+  border-radius: 0;
+  padding: 28px 0;
+  overflow: visible;
+}
+.star-card > div:first-child {
+  font-family: var(--mono);
+}
+.star-row {
+  display: flex;
+  align-items: baseline;
+  gap: 16px;
+  margin: 20px 0 24px;
+}
+.star-row b {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 80px;
+  letter-spacing: -0.025em;
+  line-height: 1;
+  color: var(--cream);
+}
+.star-row .delta {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--jade);
+  background: transparent;
+  border: 1px solid rgba(107, 138, 111, 0.3);
+  padding: 3px 8px;
+  border-radius: 0;
+  letter-spacing: 0.04em;
+}
+.star-chart {
+  height: 90px;
+  margin-top: 8px;
+}
+
+.contrib-grid {
+  background: transparent;
+  border: 0;
+  border-top: 1px solid var(--rule);
+  border-radius: 0;
+  padding: 28px 0;
+}
+.contrib-grid h3 {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 28px;
+  letter-spacing: -0.005em;
+  margin: 0 0 6px;
+  color: var(--cream);
+}
+.contrib-grid .sub {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--cream-mute);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.contrib-wall {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(36px, 1fr));
+  gap: 6px;
+  margin-top: 22px;
+}
+.contrib-avatar {
+  aspect-ratio: 1;
+  border-radius: 0;
+  display: grid; place-items: center;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  font-weight: 500;
+  color: var(--ink);
+  background: var(--cream-2);
+  border: 0;
+  transition: transform 0.2s;
+  letter-spacing: 0.02em;
+}
+.contrib-avatar:hover { transform: scale(1.1); z-index: 2; }
+
+/* ─── ROADMAP ──────────────────────────────────────────────── */
+.roadmap {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0;
+  margin-top: 8px;
+  border-top: 1px solid var(--rule);
+}
+@media (max-width: 900px) { .roadmap { grid-template-columns: 1fr 1fr; } }
+@media (max-width: 600px) { .roadmap { grid-template-columns: 1fr; } }
+.rm-col {
+  background: transparent;
+  border: 0;
+  border-right: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  border-radius: 0;
+  padding: 28px 24px 28px 0;
+  position: relative;
+}
+.rm-col:last-child { border-right: 0; }
+.rm-col header {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 18px;
+}
+.rm-col header .q {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 0;
+  background: transparent;
+  color: var(--cream-mute);
+}
+.rm-col header h4 {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 24px;
+  margin: 0;
+  letter-spacing: -0.005em;
+  color: var(--cream);
+  line-height: 1.1;
+}
+.rm-col.done header .q { color: var(--jade); }
+.rm-col.now header .q { color: var(--accent); }
+.rm-col ul { list-style: none; padding: 0; margin: 0; }
+.rm-col li {
+  display: flex;
+  gap: 12px;
+  padding: 8px 0;
+  font-size: 13.5px;
+  color: var(--cream-dim);
+  line-height: 1.5;
+  border-bottom: 1px solid var(--rule);
+}
+.rm-col li:last-child { border-bottom: 0; }
+.rm-col li::before {
+  content: "·";
+  font-family: var(--serif);
+  color: var(--cream-mute);
+  font-size: 18px;
+  line-height: 1;
+  width: auto; height: auto;
+  border: 0;
+  background: none !important;
+  flex-shrink: 0;
+  margin-top: -2px;
+}
+.rm-col.done li::before {
+  content: "✓";
+  font-size: 13px;
+  color: var(--jade);
+}
+.rm-col.now li::before {
+  content: "◐";
+  font-size: 13px;
+  color: var(--accent);
+}
+
+/* ─── FAQ ──────────────────────────────────────────────────── */
+.faq-list {
+  margin-top: 8px;
+  border-top: 1px solid var(--rule);
+}
+.faq-item {
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid var(--rule);
+  border-radius: 0;
+  overflow: hidden;
+  transition: none;
+}
+.faq-item.open { border-color: var(--rule); }
+.faq-q {
+  display: flex;
+  align-items: baseline;
+  gap: 20px;
+  padding: 26px 0;
+  cursor: pointer;
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 24px;
+  letter-spacing: -0.005em;
+  color: var(--cream);
+  line-height: 1.25;
+}
+.faq-q .idx {
+  font-family: var(--mono);
+  font-style: normal;
+  font-size: 11px;
+  color: var(--cream-mute);
+  letter-spacing: 0.1em;
+  flex-shrink: 0;
+  width: 32px;
+}
+.faq-q .chev {
+  margin-left: auto;
+  width: 16px; height: 16px;
+  transition: transform 0.25s;
+  color: var(--cream-mute);
+  flex-shrink: 0;
+  align-self: center;
+}
+.faq-item.open .chev { transform: rotate(180deg); color: var(--accent); }
+.faq-a {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.3s ease;
+  padding: 0 0 0 52px;
+  color: var(--cream-dim);
+  font-size: 15px;
+  line-height: 1.65;
+  font-family: var(--sans);
+  font-style: normal;
+}
+.faq-item.open .faq-a { max-height: 500px; padding: 0 0 26px 52px; }
+
+/* ─── CONFIG ───────────────────────────────────────────────── */
+.config-grid {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: 56px;
+  margin-top: 8px;
+  align-items: start;
+}
+@media (max-width: 920px) { .config-grid { grid-template-columns: 1fr; gap: 24px; } }
+
+.config-side {
+  position: sticky;
+  top: 96px;
+  display: flex; flex-direction: column;
+  border-top: 1px solid var(--rule);
+}
+@media (max-width: 920px) { .config-side { position: static; } }
+
+.config-tab {
+  display: flex;
+  align-items: baseline;
+  gap: 18px;
+  padding: 22px 0;
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid var(--rule);
+  border-radius: 0;
+  cursor: pointer;
+  transition: color 0.18s;
+  color: var(--cream-dim);
+}
+.config-tab:hover { color: var(--cream); border-color: var(--rule); }
+.config-tab.on {
+  color: var(--cream);
+  background: transparent;
+  border-color: var(--rule);
+  box-shadow: none;
+}
+.config-tab-key {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  color: var(--cream-mute);
+  flex-shrink: 0;
+  width: 60px;
+}
+.config-tab.on .config-tab-key {
+  background: transparent;
+  border: 0;
+  color: var(--accent);
+}
+.config-tab > div:nth-child(2) { flex: 1; }
+.config-tab-title {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 22px;
+  letter-spacing: -0.005em;
+  line-height: 1.1;
+}
+.config-tab-cn {
+  font-size: 12px;
+  color: var(--cream-mute);
+  margin-top: 4px;
+  font-family: var(--mono);
+  letter-spacing: 0.02em;
+}
+.config-tab svg { color: var(--cream-mute); transition: transform 0.2s, color 0.2s; align-self: center; }
+.config-tab.on svg { color: var(--accent); transform: translateX(4px); }
+
+.config-hint {
+  margin-top: 24px;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  font-size: 12px;
+  color: var(--cream-mute);
+  line-height: 1.6;
+  font-family: var(--mono);
+}
+.config-hint svg { color: var(--accent); flex-shrink: 0; margin-top: 2px; }
+
+.config-main {
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  padding: 0;
+}
+.config-main-head h3 {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 38px;
+  letter-spacing: -0.015em;
+  margin: 0 0 12px;
+  color: var(--cream);
+  line-height: 1.05;
+}
+.config-main-head h3 span {
+  color: var(--cream-mute);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 22px;
+  font-family: var(--serif);
+}
+.config-main-head p {
+  color: var(--cream-dim);
+  font-size: 15.5px;
+  line-height: 1.65;
+  margin: 0;
+  max-width: 640px;
+}
+
+.config-bullets {
+  list-style: none;
+  padding: 0;
+  margin: 28px 0 32px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0 28px;
+  border-top: 1px solid var(--rule);
+}
+@media (max-width: 720px) { .config-bullets { grid-template-columns: 1fr; } }
+.config-bullets li {
+  display: flex;
+  gap: 12px;
+  align-items: baseline;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--rule);
+  font-size: 13px;
+  color: var(--cream-dim);
+  font-family: var(--mono);
+  line-height: 1.55;
+  letter-spacing: -0.005em;
+}
+.bullet-dot {
+  width: 5px; height: 5px;
+  margin-top: 0;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: none;
+  flex-shrink: 0;
+  align-self: center;
+}
+
+.config-files {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  margin-top: 12px;
+}
+.code-panel {
+  background: var(--ink-2);
+  border: 1px solid var(--rule-2);
+  border-radius: 0;
+  overflow: hidden;
+}
+.code-panel-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 11px 14px;
+  background: transparent;
+  border-bottom: 1px solid var(--rule);
+}
+.code-file {
+  font-family: var(--mono);
+  font-size: 11.5px;
+  color: var(--cream-dim);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  letter-spacing: 0.02em;
+}
+.code-file svg { color: var(--cream-mute); }
+.code-panel .copy-btn {
+  background: transparent;
+  border: 0;
+  border-left: 1px solid var(--rule);
+  color: var(--cream-mute);
+  padding: 6px 12px;
+  border-radius: 0;
+  font-size: 10.5px;
+  cursor: pointer;
+  font-family: var(--mono);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: auto;
+  transition: all 0.18s;
+}
+.code-panel .copy-btn:hover {
+  color: var(--ink);
+  background: var(--cream);
+}
+.code-panel .copy-btn.copied {
+  color: var(--ink);
+  background: var(--jade);
+}
+.code-body {
+  margin: 0;
+  padding: 20px 22px;
+  font-family: var(--mono);
+  font-size: 12.5px;
+  line-height: 1.7;
+  color: var(--cream);
+  overflow-x: auto;
+  white-space: pre;
+}
+
+/* ─── FOOTER ───────────────────────────────────────────────── */
+.footer {
+  position: relative; z-index: 2;
+  border-top: 1px solid var(--rule);
+  margin-top: 0;
+  padding: 88px 0 36px;
+  background: transparent;
+}
+.footer-inner {
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: 0 var(--gutter);
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr 1fr;
+  gap: 48px;
+}
+@media (max-width: 760px) { .footer-inner { grid-template-columns: 1fr 1fr; } }
+.footer h5 {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--cream-mute);
+  margin: 0 0 18px;
+  font-weight: 400;
+}
+.footer ul { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 10px; }
+.footer a {
+  color: var(--cream-dim);
+  text-decoration: none;
+  font-size: 14px;
+  font-family: var(--sans);
+  transition: color 0.18s;
+}
+.footer a:hover { color: var(--accent); }
+.footer-bottom {
+  max-width: var(--maxw);
+  margin: 64px auto 0;
+  padding: 28px var(--gutter) 0;
+  border-top: 1px solid var(--rule);
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  font-size: 11px;
+  color: var(--cream-mute);
+  font-family: var(--mono);
+  letter-spacing: 0.06em;
+}
+.footer-bottom .spacer { flex: 1; }
+
+/* ─── UTILITY ──────────────────────────────────────────────── */
+.kbd {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  padding: 2px 6px;
+  border-radius: 0;
+  background: transparent;
+  border: 1px solid var(--rule-2);
+  color: var(--cream-dim);
+  letter-spacing: 0.04em;
+}
+
+.section-head-text { max-width: none; }
+.section-head-actions { display: flex; gap: 10px; align-items: center; }
+
+/* ─── DOWNLOAD PAGE ────────────────────────────────────────── */
+.dl-hero {
+  position: relative;
+  z-index: 2;
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: 80px var(--gutter) 80px;
+}
+.dl-hero-grid {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 60px;
+  align-items: end;
+}
+@media (max-width: 900px) {
+  .dl-hero-grid { grid-template-columns: 1fr; gap: 36px; }
+}
+.dl-hero h1 {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: clamp(48px, 6.8vw, 96px);
+  line-height: 0.98;
+  letter-spacing: -0.018em;
+  margin: 0 0 26px;
+  color: var(--cream);
+  text-wrap: balance;
+}
+.dl-hero h1 em {
+  font-style: italic;
+  color: var(--accent);
+}
+.dl-hero .lede {
+  font-size: 16.5px;
+  line-height: 1.6;
+  color: var(--cream-dim);
+  max-width: 600px;
+  margin: 0 0 16px;
+}
+.dl-hero .lede b {
+  color: var(--cream);
+  font-family: var(--mono);
+  font-weight: 500;
+  font-size: 0.92em;
+}
+.dl-hero .lede-foot {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--cream-mute);
+  letter-spacing: 0.02em;
+  margin: 0;
+}
+.dl-hero-stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  border-top: 1px solid var(--rule);
+  padding-top: 24px;
+  justify-self: end;
+  width: 100%;
+  max-width: 360px;
+}
+@media (max-width: 900px) { .dl-hero-stats { justify-self: start; max-width: 100%; } }
+.dl-hero-stats .hero-stat {
+  padding-right: 16px;
+  border-right: 1px solid var(--rule);
+}
+.dl-hero-stats .hero-stat:last-child { border-right: 0; }
+
+/* Toolbar above mirror grid */
+.dl-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+/* Platform tabs (above platform notes) */
+.platform-tabs {
+  display: flex;
+  gap: 0;
+  border: 1px solid var(--rule-2);
+  width: fit-content;
+  margin-bottom: 28px;
+}
+.platform-tab {
+  background: transparent;
+  border: 0;
+  border-right: 1px solid var(--rule);
+  padding: 12px 24px;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  color: var(--cream-dim);
+  cursor: pointer;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  transition: color 0.18s;
+}
+.platform-tab:last-child { border-right: 0; }
+.platform-tab.on {
+  background: var(--accent);
+  color: var(--ink);
+}
+.platform-tab:hover:not(.on) { color: var(--cream); }
+
+.platform-note {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: 56px;
+  align-items: start;
+  border-top: 1px solid var(--rule);
+  padding-top: 32px;
+}
+@media (max-width: 900px) { .platform-note { grid-template-columns: 1fr; gap: 24px; } }
+.platform-note-head h3 {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 32px;
+  letter-spacing: -0.015em;
+  margin: 0;
+  color: var(--cream);
+  line-height: 1.1;
+}
+.platform-note-en {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent);
+  display: block;
+  margin-bottom: 10px;
+}
+.platform-note-desc {
+  color: var(--cream-dim);
+  font-size: 15px;
+  line-height: 1.65;
+  margin: 0 0 24px;
+  max-width: 620px;
+}
+.platform-steps {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+.platform-step .copy-block {
+  font-size: 13px;
+}
+.platform-step p {
+  margin: 8px 0 0;
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--cream-mute);
+  letter-spacing: 0.02em;
+}
+
+/* Home page download promo strip */
+.dl-promo {
+  margin-top: 64px;
+  padding: 36px 36px 36px 40px;
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 24px;
+  align-items: center;
+  position: relative;
+}
+.dl-promo::before {
+  content: "→ DOWNLOAD";
+  position: absolute;
+  left: 0; top: -1px;
+  background: var(--accent);
+  color: var(--ink);
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.16em;
+  padding: 5px 12px;
+  font-weight: 500;
+}
+.dl-promo h3 {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 36px;
+  letter-spacing: -0.012em;
+  margin: 0 0 8px;
+  color: var(--cream);
+  line-height: 1.05;
+}
+.dl-promo h3 em { color: var(--accent); font-style: italic; }
+.dl-promo p {
+  color: var(--cream-dim);
+  font-size: 14.5px;
+  margin: 0;
+  max-width: 520px;
+  line-height: 1.55;
+}
+.dl-promo-actions {
+  display: flex;
+  gap: 10px;
+  flex-shrink: 0;
+}
+@media (max-width: 760px) {
+  .dl-promo { grid-template-columns: 1fr; }
+  .dl-promo-actions { flex-wrap: wrap; }
+}


### PR DESCRIPTION
## Summary

Adds `download-site/` — the static landing + smart-download page, ported from the design mockup with real Reasonix data substituted in. Two routes:

- **`/`** — editorial landing: hero (animated terminal replay of an actual `reasonix code` session), CLI install tabs (npx / npm / pnpm / source), three-pillar breakdown (Cache-First Loop, R1 Thought Harvest, Tool-Call Repair), feature grid, configuration explorer (MCP / Skills / Memory / Slash), community card with **live** GitHub stars + contributor wall fetched from api.github.com, roadmap, FAQ.
- **`/download`** — smart-mirror page. On load, races HEAD probes against R2 and GitHub Releases (TTFB, 5 s ceiling), tags the fastest as "Fastest", offers per-platform installer links for whichever wins. Platform tabs surface first-launch caveats (macOS Gatekeeper, Windows SmartScreen, Linux AppImage chmod + libfuse2).

## Substitutions from the mockup

| Mock value | Real value |
|---|---|
| Version `0.30.5` | `0.42.0-3` (mirrors / hero / footer / nav / AppImage chmod example / terminal replay) |
| Three mirrors {R2, Gitee, GitHub} | Two mirrors {R2, GitHub} — Gitee mirror was dropped upstream |
| Hardcoded 1665 tests | 2837 |
| Hardcoded 1128 stars + 24 fake contributor initials | Live `api.github.com` fetch (graceful fallback if rate-limited) |
| `新账号有免费额度` wording | Replaced — DeepSeek pulled that perk in 2026-05 |
| Mock `setTimeout` mirror probe | Real `fetch(..., {mode:"no-cors"})` HEAD probe with `performance.now()` timing + AbortController 5 s cap |

## Implementation notes

- No build step — React 18 UMD + Babel standalone (in-browser JSX). Fine at our traffic; if cold-load perf becomes a concern later, convert to a real Vite build emitting plain JS.
- React + Babel pinned to `cdn.jsdelivr.net` (jsDelivr has better mainland-CN access than unpkg).
- `src/fonts.css` is a **system-font stack** — no external font CDN. The mockup's Google Fonts `<link>` would degrade ugly on CN networks where this page matters most.
- `tweaks-panel.jsx` (dev-only design knob panel) is not copied; `app.jsx` simplified.
- `_headers` sets `text/babel` MIME for `.jsx`, plus basic security headers.
- `_redirects` maps `/download` → `/download.html` for clean URLs.

## Deploy

Cloudflare Pages, no build:

1. Pages → Connect to Git → pick this repo, branch `main`
2. Root directory: `download-site`
3. Build command: *(empty)*
4. Build output directory: `download-site`
5. Save & deploy. Auto-deploys on `main` push.

Custom domain (later): bind `reasonix.dev` or `download.reasonix.dev` in Pages → Custom domains.

## Test plan

- [ ] `python -m http.server 4173 -d download-site` locally; verify both pages render, Babel doesn't throw, mirror probe runs and picks the GH/R2 winner, install command tabs switch, FAQ expand/collapse, contributor wall populates from API.
- [ ] After Cloudflare Pages deploy, visit the published URL from a CN network if possible; verify the R2 probe wins by latency.
- [ ] On next release, bump the `0.42.0-3` references (grep finds them all).
