### PR TITLE
fix(desktop): honor preset autoEscalate when building the loop

### DIFF
--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -597,6 +597,7 @@ function buildRuntimeFor(tab: Tab): RuntimeState {
   const client = new DeepSeekClient({ baseUrl: loadBaseUrl() });
   const prefix = new ImmutablePrefix({ system: tab.system, toolSpecs: tab.toolset.tools.specs() });
   const reasoningEffort = loadReasoningEffort();
+  const { autoEscalate } = resolvePreset(tab.currentPreset);
   const loop = new CacheFirstLoop({
     client,
     prefix,
@@ -605,6 +606,7 @@ function buildRuntimeFor(tab: Tab): RuntimeState {
     budgetUsd: tab.budgetUsd,
     session: tab.currentSession,
     reasoningEffort,
+    autoEscalate,
   });
   const eventizer = new Eventizer();
   const ctx = { model: tab.currentModel, prefixHash: prefix.fingerprint, reasoningEffort };


### PR DESCRIPTION
## Summary

- The desktop JSON-RPC entry (`src/cli/commands/desktop.ts`, the brain
  behind the Tauri client) built `CacheFirstLoop` without passing
  `autoEscalate`. The constructor defaults it to `true`, so the `flash`
  preset — advertised in the picker as *"cheapest · predictable"* —
  still let the loop escalate flash → pro on hard turns and bill users
  at pro rates.
- The TUI's `applyPresetLive` already wires `autoEscalate` from the
  resolved preset (`src/cli/ui/App.tsx:1858`). `buildRuntimeFor` now
  does the same — resolves the preset from `tab.currentPreset` and
  feeds `autoEscalate` into the loop.
- Covers both code paths that rebuild the runtime: initial `createTab`,
  and the `settings_save { preset }` branch which already does a nuclear
  rebuild after preset change.

## Test plan

- [x] `npm run typecheck`
- [x] `npx vitest run tests/presets.test.ts tests/preset-effort-isolation.test.ts tests/comment-policy.test.ts`
- [x] Full `npm run verify` via pre-push hook (2837 passed)
- [ ] Manual: open the desktop app, pick `flash` preset, trigger a tool-failure-heavy turn, confirm the model stays on `deepseek-v4-flash` instead of escalating