### PR TITLE
fix(shell): route 2>/dev/null and 2>/dev/null to the OS null device

### DIFF
--- a/src/tools/shell-chain.ts
+++ b/src/tools/shell-chain.ts
@@ -2,6 +2,7 @@
 
 import { type ChildProcess, type SpawnOptions, spawn } from "node:child_process";
 import { closeSync, openSync } from "node:fs";
+import { devNull } from "node:os";
 import * as pathMod from "node:path";
 import { isDqEscape, killProcessTree, prepareSpawn, smartDecodeOutput } from "./shell.js";
 
@@ -352,6 +353,14 @@ interface SegmentStdio {
   toClose: number[];
 }
 
+/** Models reach for `2>nul` (Windows) and `2>/dev/null` (POSIX) interchangeably; without this the parser materializes a real `<cwd>/nul` file. */
+function isNullDeviceAlias(target: string): boolean {
+  const lower = target.toLowerCase();
+  if (lower === "/dev/null") return true;
+  if (process.platform === "win32" && lower === "nul") return true;
+  return false;
+}
+
 function openRedirects(redirects: readonly Redirect[], cwd: string): SegmentStdio {
   let stdinFd: number | null = null;
   let stdoutFd: number | null = null;
@@ -360,7 +369,7 @@ function openRedirects(redirects: readonly Redirect[], cwd: string): SegmentStdi
   let bothFd: number | null = null;
   const toClose: number[] = [];
   const open = (target: string, flags: "r" | "w" | "a"): number => {
-    const resolved = pathMod.resolve(cwd, target);
+    const resolved = isNullDeviceAlias(target) ? devNull : pathMod.resolve(cwd, target);
     const fd = openSync(resolved, flags);
     toClose.push(fd);
     return fd;

--- a/tests/shell-redirects.test.ts
+++ b/tests/shell-redirects.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -236,4 +236,71 @@ describe("runCommand — redirect dispatch", () => {
     const r = await runCommand('node -e "process.exit(7)" > out.txt', { cwd: tmp });
     expect(r.exitCode).toBe(7);
   });
+});
+
+describe("runChain — null-device redirects", () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "reasonix-null-dev-"));
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  const baseOpts = { timeoutSec: 10, maxOutputChars: 32_000 };
+
+  it("`2> /dev/null` discards stderr without creating a `/dev/null` file in cwd", async () => {
+    const c = parseCommandChain(
+      "node -e \"console.error('noisy'); process.stdout.write('quiet')\" 2> /dev/null",
+    )!;
+    const r = await runChain(c, { cwd: tmp, ...baseOpts });
+    expect(r.exitCode).toBe(0);
+    expect(r.output).toContain("quiet");
+    expect(r.output).not.toContain("noisy");
+    expect(existsSync(join(tmp, "dev"))).toBe(false);
+    expect(existsSync(join(tmp, "/dev/null"))).toBe(false);
+  });
+
+  it("`> /dev/null` discards stdout without creating a file in cwd", async () => {
+    const c = parseCommandChain("node -e \"process.stdout.write('vanish')\" > /dev/null")!;
+    const r = await runChain(c, { cwd: tmp, ...baseOpts });
+    expect(r.exitCode).toBe(0);
+    expect(r.output).not.toContain("vanish");
+    expect(existsSync(join(tmp, "dev"))).toBe(false);
+  });
+
+  it.skipIf(process.platform !== "win32")(
+    "`2>nul` (Windows) discards stderr without leaving a `nul` file behind",
+    async () => {
+      const c = parseCommandChain(
+        "node -e \"console.error('boom'); process.stdout.write('ok')\" 2>nul",
+      )!;
+      const r = await runChain(c, { cwd: tmp, ...baseOpts });
+      expect(r.exitCode).toBe(0);
+      expect(r.output).toContain("ok");
+      expect(r.output).not.toContain("boom");
+      expect(existsSync(join(tmp, "nul"))).toBe(false);
+    },
+  );
+
+  it.skipIf(process.platform !== "win32")(
+    "uppercase `2>NUL` also routes to the null device",
+    async () => {
+      const c = parseCommandChain("node -e \"console.error('x')\" 2>NUL")!;
+      const r = await runChain(c, { cwd: tmp, ...baseOpts });
+      expect(r.exitCode).toBe(0);
+      expect(existsSync(join(tmp, "NUL"))).toBe(false);
+      expect(existsSync(join(tmp, "nul"))).toBe(false);
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "`nul` is a regular filename on POSIX (no aliasing)",
+    async () => {
+      const c = parseCommandChain("node -e \"process.stdout.write('p')\" > nul")!;
+      await runChain(c, { cwd: tmp, ...baseOpts });
+      expect(existsSync(join(tmp, "nul"))).toBe(true);
+      expect(readFileSync(join(tmp, "nul"), "utf8")).toBe("p");
+    },
+  );
 });


### PR DESCRIPTION
## Summary

Users (mostly on Windows) noticed a stray `nul` file appearing at
the project root after the agent ran shell commands. The file
typically contained `File Not Found\n` — cmd.exe's `dir` stderr
message captured into it.

The root cause is in `src/tools/shell-chain.ts` — the native redirect
parser called `pathMod.resolve(cwd, target)` for every redirect target,
so:

- `something 2>nul` (Windows habit) opened a real file at `<cwd>/nul`
- `something 2>/dev/null` (POSIX habit, what the model is told to use
  in the bash environment) opened `<cwd>/dev/null`

There is no real shell in the loop — the tool tokenizes argv and
opens redirect targets via `openSync` directly, which is why neither
the cmd.exe `NUL` device nor the bash `/dev/null` translation kicked
in.

This PR adds an `isNullDeviceAlias` check that routes case-insensitive
`/dev/null` (any platform) and `nul` (Windows only — it's a legitimate
filename on POSIX) to `os.devNull`.

## Test plan

- [x] `npm run typecheck`
- [x] `npx vitest run tests/shell-redirects.test.ts` (5 new cases:
  `2> /dev/null`, `> /dev/null`, `2>nul`, `2>NUL`, POSIX-`nul`-stays-a-file)
- [x] `npx vitest run tests/shell-chain.test.ts tests/shell-tools.test.ts tests/comment-policy.test.ts` (133 passed)
- [x] Pre-push `npm run verify` (full suite)
- [ ] Manual: confirm `nul` no longer appears after the agent runs
  commands in a Windows project root