### PR TITLE
fix(subagent): raise iter cap 32 → 256 (validated against real API)

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -880,7 +880,6 @@ function AppInner({
             // attribute the run to a skill without extra bookkeeping.
             skillName: skill.name,
             maxToolIters: skill.maxToolIters,
-            itersSource: skill.maxToolIters !== undefined ? "frontmatter" : "default",
           });
           return formatSubagentResult(result);
         },

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -879,6 +879,8 @@ function AppInner({
             // Stamped onto every event so the TUI sink + usage log can
             // attribute the run to a skill without extra bookkeeping.
             skillName: skill.name,
+            maxToolIters: skill.maxToolIters,
+            itersSource: skill.maxToolIters !== undefined ? "frontmatter" : "default",
           });
           return formatSubagentResult(result);
         },

--- a/src/code/setup.ts
+++ b/src/code/setup.ts
@@ -83,6 +83,8 @@ export async function buildCodeToolset(opts: CodeToolsetOpts): Promise<CodeTools
         model: skill.model,
         allowedTools: skill.allowedTools,
         maxToolIters: skill.maxToolIters,
+        skillName: skill.name,
+        itersSource: skill.maxToolIters !== undefined ? "frontmatter" : "default",
       });
       return formatSubagentResult(result);
     },

--- a/src/code/setup.ts
+++ b/src/code/setup.ts
@@ -84,7 +84,6 @@ export async function buildCodeToolset(opts: CodeToolsetOpts): Promise<CodeTools
         allowedTools: skill.allowedTools,
         maxToolIters: skill.maxToolIters,
         skillName: skill.name,
-        itersSource: skill.maxToolIters !== undefined ? "frontmatter" : "default",
       });
       return formatSubagentResult(result);
     },

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -73,9 +73,9 @@ function parseAllowedTools(raw: string | undefined): readonly string[] | undefin
   return names.length > 0 ? Object.freeze(names) : undefined;
 }
 
-/** Match subagent's own bounds (src/tools/subagent.ts MIN_MAX_ITERS / MAX_MAX_ITERS). */
+/** Match subagent's own bounds (src/tools/subagent.ts MIN_MAX_ITERS / MAX_MAX_ITERS). Widened from 32 → 256 alongside the subagent cap as part of the iter-cap experiment. */
 const SKILL_MAX_ITERS_MIN = 1;
-const SKILL_MAX_ITERS_MAX = 32;
+const SKILL_MAX_ITERS_MAX = 256;
 
 function parseMaxToolIters(raw: string | undefined): number | undefined {
   if (raw === undefined) return undefined;
@@ -257,7 +257,7 @@ Tips:
 - Reference tools by name (run_command, edit_file, search_content, ...)
 - Add \`runAs: subagent\` to frontmatter to spawn an isolated subagent loop
 - Add \`allowed-tools: read_file, search_content\` to scope a subagent's tools
-- Add \`max-iters: 32\` to raise the subagent's tool-call budget (default 16, max 32)
+- Add \`max-iters: 64\` (or higher, up to 256) to raise the subagent's tool-call budget — default 16. Pick what the task actually needs; large values just delay the natural termination.
 `;
 }
 

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -73,7 +73,7 @@ function parseAllowedTools(raw: string | undefined): readonly string[] | undefin
   return names.length > 0 ? Object.freeze(names) : undefined;
 }
 
-/** Match subagent's own bounds (src/tools/subagent.ts MIN_MAX_ITERS / MAX_MAX_ITERS). Widened from 32 → 256 alongside the subagent cap as part of the iter-cap experiment. */
+/** Match subagent's own bounds (src/tools/subagent.ts MIN_MAX_ITERS / MAX_MAX_ITERS). */
 const SKILL_MAX_ITERS_MIN = 1;
 const SKILL_MAX_ITERS_MAX = 256;
 

--- a/src/tools/subagent.ts
+++ b/src/tools/subagent.ts
@@ -43,8 +43,6 @@ export interface SubagentSink {
   current: ((ev: SubagentEvent) => void) | null;
 }
 
-export type IterCapSource = "json-arg" | "type" | "frontmatter" | "default";
-
 export interface SpawnSubagentOptions {
   client: DeepSeekClient;
   parentRegistry: ToolRegistry;
@@ -59,9 +57,6 @@ export interface SpawnSubagentOptions {
   skillName?: string;
   /** Scopes the child registry to these literal tool names; NEVER_INHERITED still wins. Driven by skill `allowed-tools` frontmatter. */
   allowedTools?: readonly string[];
-  /** Experiment telemetry — see PR widening MAX_MAX_ITERS to 256. Optional; missing = "unknown". */
-  itersSource?: IterCapSource;
-  itersRaw?: number | null;
 }
 
 export interface SubagentResult {
@@ -108,7 +103,6 @@ function defaultSubagentSystem(modelId: string): string {
 const DEFAULT_MAX_RESULT_CHARS = 8000;
 const DEFAULT_MAX_ITERS = 16;
 const MIN_MAX_ITERS = 1;
-/** Widened from 32 to 256 as an experiment — see PR: collecting evidence on whether the model picks pathological values when given freedom, before deciding whether to remove the cap entirely. */
 const MAX_MAX_ITERS = 256;
 /** Iters-from-cap at which we start appending a remaining-budget hint to tool results. */
 const BUDGET_WARN_THRESHOLD = 3;
@@ -149,23 +143,6 @@ export function subagentBudgetHint(spawnCount: number, totalTokens: number): str
   return null;
 }
 
-/** Experiment-only stderr telemetry collecting evidence on what model picks for max_iters when the cap is wide. Single line per spawn — easy to grep, easy to delete once the data is in. */
-function emitIterCapTelemetry(info: {
-  skillName?: string;
-  model: string;
-  maxToolIters: number;
-  source?: IterCapSource;
-  raw?: number | null;
-}): void {
-  if (process.env.REASONIX_ITER_CAP_TELEMETRY === "off") return;
-  const skill = info.skillName ?? "anon";
-  const src = info.source ?? "unknown";
-  const raw = info.raw !== undefined && info.raw !== null ? ` raw=${info.raw}` : "";
-  process.stderr.write(
-    `[iter-cap-exp] skill=${skill} model=${info.model} source=${src} chosen=${info.maxToolIters}${raw}\n`,
-  );
-}
-
 /** Errors captured in the result shape, never thrown — caller decides how to surface. */
 export async function spawnSubagent(opts: SpawnSubagentOptions): Promise<SubagentResult> {
   const model = opts.model ?? DEFAULT_SUBAGENT_MODEL;
@@ -177,13 +154,6 @@ export async function spawnSubagent(opts: SpawnSubagentOptions): Promise<Subagen
   const startedAt = Date.now();
   const runId = nextRunId();
   const taskPreview = opts.task.length > 30 ? `${opts.task.slice(0, 30)}…` : opts.task;
-  emitIterCapTelemetry({
-    skillName,
-    model,
-    maxToolIters,
-    source: opts.itersSource,
-    raw: opts.itersRaw,
-  });
   sink?.current?.({
     kind: "start",
     runId,
@@ -516,14 +486,6 @@ export function registerSubagentTool(
           ? args.system.trim()
           : (typeSpec?.system ?? `${defaultSystemBase}\n\n${escalationContract(model)}`);
       const callerIters = clampMaxIters(args.max_iters);
-      const itersSource: IterCapSource =
-        callerIters !== undefined
-          ? "json-arg"
-          : typeSpec?.maxToolIters !== undefined
-            ? "type"
-            : opts.maxToolIters !== undefined
-              ? "frontmatter"
-              : "default";
       const result = await spawnSubagent({
         client: opts.client,
         parentRegistry,
@@ -534,8 +496,6 @@ export function registerSubagentTool(
         maxResultChars,
         sink,
         parentSignal: ctx?.signal,
-        itersSource,
-        itersRaw: typeof args.max_iters === "number" ? args.max_iters : null,
       });
       sessionSpawnCount++;
       sessionSpawnTokens += result.usage.totalTokens;

--- a/src/tools/subagent.ts
+++ b/src/tools/subagent.ts
@@ -43,6 +43,8 @@ export interface SubagentSink {
   current: ((ev: SubagentEvent) => void) | null;
 }
 
+export type IterCapSource = "json-arg" | "type" | "frontmatter" | "default";
+
 export interface SpawnSubagentOptions {
   client: DeepSeekClient;
   parentRegistry: ToolRegistry;
@@ -57,6 +59,9 @@ export interface SpawnSubagentOptions {
   skillName?: string;
   /** Scopes the child registry to these literal tool names; NEVER_INHERITED still wins. Driven by skill `allowed-tools` frontmatter. */
   allowedTools?: readonly string[];
+  /** Experiment telemetry — see PR widening MAX_MAX_ITERS to 256. Optional; missing = "unknown". */
+  itersSource?: IterCapSource;
+  itersRaw?: number | null;
 }
 
 export interface SubagentResult {
@@ -103,7 +108,8 @@ function defaultSubagentSystem(modelId: string): string {
 const DEFAULT_MAX_RESULT_CHARS = 8000;
 const DEFAULT_MAX_ITERS = 16;
 const MIN_MAX_ITERS = 1;
-const MAX_MAX_ITERS = 32;
+/** Widened from 32 to 256 as an experiment — see PR: collecting evidence on whether the model picks pathological values when given freedom, before deciding whether to remove the cap entirely. */
+const MAX_MAX_ITERS = 256;
 /** Iters-from-cap at which we start appending a remaining-budget hint to tool results. */
 const BUDGET_WARN_THRESHOLD = 3;
 
@@ -143,6 +149,23 @@ export function subagentBudgetHint(spawnCount: number, totalTokens: number): str
   return null;
 }
 
+/** Experiment-only stderr telemetry collecting evidence on what model picks for max_iters when the cap is wide. Single line per spawn — easy to grep, easy to delete once the data is in. */
+function emitIterCapTelemetry(info: {
+  skillName?: string;
+  model: string;
+  maxToolIters: number;
+  source?: IterCapSource;
+  raw?: number | null;
+}): void {
+  if (process.env.REASONIX_ITER_CAP_TELEMETRY === "off") return;
+  const skill = info.skillName ?? "anon";
+  const src = info.source ?? "unknown";
+  const raw = info.raw !== undefined && info.raw !== null ? ` raw=${info.raw}` : "";
+  process.stderr.write(
+    `[iter-cap-exp] skill=${skill} model=${info.model} source=${src} chosen=${info.maxToolIters}${raw}\n`,
+  );
+}
+
 /** Errors captured in the result shape, never thrown — caller decides how to surface. */
 export async function spawnSubagent(opts: SpawnSubagentOptions): Promise<SubagentResult> {
   const model = opts.model ?? DEFAULT_SUBAGENT_MODEL;
@@ -154,6 +177,13 @@ export async function spawnSubagent(opts: SpawnSubagentOptions): Promise<Subagen
   const startedAt = Date.now();
   const runId = nextRunId();
   const taskPreview = opts.task.length > 30 ? `${opts.task.slice(0, 30)}…` : opts.task;
+  emitIterCapTelemetry({
+    skillName,
+    model,
+    maxToolIters,
+    source: opts.itersSource,
+    raw: opts.itersRaw,
+  });
   sink?.current?.({
     kind: "start",
     runId,
@@ -449,7 +479,7 @@ export function registerSubagentTool(
           type: "integer",
           minimum: MIN_MAX_ITERS,
           maximum: MAX_MAX_ITERS,
-          description: `Cap on the subagent's tool-call iterations. Default 16 (or the type's default when 'type' is set). Hard range: ${MIN_MAX_ITERS}-${MAX_MAX_ITERS}; out-of-range values are clamped to the nearest end.`,
+          description: `Cap on the subagent's tool-call iterations. Default 16 (or the type's default when 'type' is set). Hard range: ${MIN_MAX_ITERS}-${MAX_MAX_ITERS}; out-of-range values are clamped to the nearest end. Pick what the task actually needs — flash spawns are cheap, but values much larger than the work warrants just delay the natural termination.`,
         },
         type: {
           type: "string",
@@ -486,6 +516,14 @@ export function registerSubagentTool(
           ? args.system.trim()
           : (typeSpec?.system ?? `${defaultSystemBase}\n\n${escalationContract(model)}`);
       const callerIters = clampMaxIters(args.max_iters);
+      const itersSource: IterCapSource =
+        callerIters !== undefined
+          ? "json-arg"
+          : typeSpec?.maxToolIters !== undefined
+            ? "type"
+            : opts.maxToolIters !== undefined
+              ? "frontmatter"
+              : "default";
       const result = await spawnSubagent({
         client: opts.client,
         parentRegistry,
@@ -496,6 +534,8 @@ export function registerSubagentTool(
         maxResultChars,
         sink,
         parentSignal: ctx?.signal,
+        itersSource,
+        itersRaw: typeof args.max_iters === "number" ? args.max_iters : null,
       });
       sessionSpawnCount++;
       sessionSpawnTokens += result.usage.totalTokens;

--- a/tests/setup-lang.ts
+++ b/tests/setup-lang.ts
@@ -1,3 +1,5 @@
 import { setLanguageRuntime } from "../src/i18n/index.js";
 
 setLanguageRuntime("EN");
+
+process.env.REASONIX_ITER_CAP_TELEMETRY = "off";

--- a/tests/setup-lang.ts
+++ b/tests/setup-lang.ts
@@ -1,5 +1,3 @@
 import { setLanguageRuntime } from "../src/i18n/index.js";
 
 setLanguageRuntime("EN");
-
-process.env.REASONIX_ITER_CAP_TELEMETRY = "off";

--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -411,17 +411,30 @@ describe("Skill frontmatter — runAs", () => {
     expect(store.read("big")?.maxToolIters).toBe(32);
   });
 
-  it("clamps max-iters above 32 to the upper bound", () => {
+  it("passes max-iters values up to 256 through unchanged", () => {
     writeSkillDir(
       home,
       "global",
-      "toobig",
-      { description: "...", runAs: "subagent", "max-iters": "100" },
+      "bigger",
+      { description: "...", runAs: "subagent", "max-iters": "128" },
       "body",
       home,
     );
     const store = new SkillStore({ homeDir: home, disableBuiltins: true });
-    expect(store.read("toobig")?.maxToolIters).toBe(32);
+    expect(store.read("bigger")?.maxToolIters).toBe(128);
+  });
+
+  it("clamps max-iters above 256 to the upper bound", () => {
+    writeSkillDir(
+      home,
+      "global",
+      "toobig",
+      { description: "...", runAs: "subagent", "max-iters": "9999" },
+      "body",
+      home,
+    );
+    const store = new SkillStore({ homeDir: home, disableBuiltins: true });
+    expect(store.read("toobig")?.maxToolIters).toBe(256);
   });
 
   it("clamps max-iters below 1 to the lower bound", () => {

--- a/tests/subagent.test.ts
+++ b/tests/subagent.test.ts
@@ -407,7 +407,7 @@ describe("registerSubagentTool", () => {
     };
     expect(params.properties.max_iters.type).toBe("integer");
     expect(params.properties.max_iters.minimum).toBe(1);
-    expect(params.properties.max_iters.maximum).toBe(32);
+    expect(params.properties.max_iters.maximum).toBe(256);
   });
 
   it("caps the child loop at the caller-supplied max_iters", async () => {
@@ -426,14 +426,14 @@ describe("registerSubagentTool", () => {
   it("clamps max_iters above the maximum", async () => {
     const parent = new ToolRegistry();
     parent.register({ name: "noop", readOnly: true, fn: () => "noop-result" });
-    const client = makeClient(makeToolCallResponses(50));
+    const client = makeClient(makeToolCallResponses(300));
     registerSubagentTool(parent, { client });
     const out = await parent.dispatch(
       "spawn_subagent",
       JSON.stringify({ task: "loop forever", max_iters: 9999 }),
     );
     const parsed = JSON.parse(out);
-    expect(parsed.tool_iters).toBe(32);
+    expect(parsed.tool_iters).toBe(256);
   });
 
   it("ignores non-numeric max_iters and falls back to the default", async () => {


### PR DESCRIPTION
## Background

Surfaced in #783 — bluedevil947's review-pro subagent ran out of
budget at 16 iters with the old [1, 32] cap. The frontmatter knob
shared the same ceiling as the model-picked JSON arg, so even a
skill author who wrote `max-iters: 64` got clamped to 32.

The blocker for raising the cap was an unproven worry: would the
model pick pathological values (1 or 9999) if given freedom? Easy
to find out — wide the cap, log what the model picks, run real
prompts against the live DeepSeek API.

## Validation run

Real `deepseek-v4-flash` (auto-escalating to pro on the harder
probe), `spawn_subagent` schema published with `min=1 max=256`:

| Prompt shape | `max_iters` model picked |
|---|---:|
| "trivially small lookup" | 3 |
| "read 5-10 files" | 30 |
| "30-40 calls thorough audit" | 80 |
| "exhaustively map everything, unbounded" | 256 (hit ceiling, as instructed) |

No 1, no 999, no random noise. The model picks values that track
the task description. The original cap at 32 was unsupported by
evidence.

## What ships

- `MAX_MAX_ITERS` 32 → 256 in `src/tools/subagent.ts`
- `SKILL_MAX_ITERS_MAX` 32 → 256 in `src/skills.ts`
- Auto-injected skill docs reworded (the old text read "max 32" as
  the natural ceiling)
- App.tsx skill subagentRunner now actually propagates
  `skill.maxToolIters` — it was being silently dropped in chat mode,
  a latent divergence from the `reasonix code` setup path. Surfaced
  while wiring this change; fix is one line, kept here rather than
  splitting.
- Test updates to match the new bounds (clamp at 256, 128 passes
  through unchanged).

## Tests

- `npm run typecheck` ✅
- `tests/subagent.test.ts` (38) ✅
- `tests/skills.test.ts` (40) ✅
- `tests/comment-policy.test.ts` (9) ✅
- Pre-push `npm run verify` — full suite (2842 passed) ✅

## What's NOT in this PR

- pause/resume (the structural answer to "what is iters actually
  for" — separate PR, this one keeps the cap in place as a safety
  net until that ships)
- Cap removal entirely — empirically tempting after this data, but
  without pause/resume an extreme pick could still hurt before
  natural termination catches it