### PR TITLE
feat(subagent): pause/resume + drop iter cap

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -101,6 +101,8 @@ export interface CacheFirstLoopOptions {
   confirmationGate?: PauseGate;
   /** Re-runs the prompt builder (applyMemoryStack / codeSystemPrompt) on /new so REASONIX.md edits take effect without a restart. Accepting a cache miss is the price. */
   rebuildSystem?: () => string;
+  /** What to do when the per-step iter budget is exhausted. "summarize" (default) fires a no-tools call so the user sees an answer — right for top-level chat. "pause" yields a `paused` event leaving the session intact — right for subagents whose parent can decide to resume or accept partial state. */
+  onIterBudgetExhausted?: "summarize" | "pause";
 }
 
 export interface ReconfigurableOptions {
@@ -132,6 +134,7 @@ export class CacheFirstLoop {
   /** One-shot 80% warning latch — cleared by setBudget so a bump re-arms at the new boundary. */
   private _budgetWarned = false;
   sessionName: string | null;
+  readonly onIterBudgetExhausted: "summarize" | "pause";
 
   hooks: ResolvedHook[];
   hookCwd: string;
@@ -187,6 +190,7 @@ export class CacheFirstLoop {
     );
     // Last-resort backstop — primary stop is the token-context guard inside step().
     this.maxToolIters = opts.maxToolIters ?? 64;
+    this.onIterBudgetExhausted = opts.onIterBudgetExhausted ?? "summarize";
     this.hooks = opts.hooks ?? [];
     this.hookCwd = opts.hookCwd ?? process.cwd();
     this.confirmationGate = opts.confirmationGate ?? defaultPauseGate;
@@ -1219,11 +1223,21 @@ export class CacheFirstLoop {
       }
     }
 
-    // We exhausted the tool-call budget while the model still wanted to
-    // call more tools. Rather than stopping silently (which leaves the
-    // user staring at a blank prompt), force one final no-tools call so
-    // the model must produce a text summary from everything it has
-    // already seen.
+    // Iter budget exhausted while the model still wanted more tools.
+    // Top-level chat → force a no-tools summary call so the user sees
+    // SOMETHING. Subagents → emit `paused`, leaving session messages
+    // intact so the parent can resume by passing the session name back.
+    if (this.onIterBudgetExhausted === "pause") {
+      yield {
+        turn: this._turn,
+        role: "paused",
+        content: "",
+        sessionName: this.sessionName ?? undefined,
+        pausedAtIter: this.maxToolIters,
+      };
+      yield { turn: this._turn, role: "done", content: "" };
+      return;
+    }
     yield* forceSummaryAfterIterLimit(this.summaryContext(), { reason: "budget" });
   }
 

--- a/src/loop/types.ts
+++ b/src/loop/types.ts
@@ -12,6 +12,8 @@ export type EventRole =
   | "done"
   | "error"
   | "warning"
+  /** Loop reached its pause interval; state is on disk under `sessionName`, caller may resume. */
+  | "paused"
   /** Transient indicator for silent phases; UI clears on next primary event. */
   | "status";
 
@@ -36,4 +38,8 @@ export interface LoopEvent {
   error?: string;
   /** Display-only — code-mode applier MUST skip SEARCH/REPLACE in forced-summary text. */
   forcedSummary?: boolean;
+  /** Set on `role === "paused"` — the session name caller passes back as `resume_session` to continue. */
+  sessionName?: string;
+  /** Set on `role === "paused"` — iter count consumed before pausing. */
+  pausedAtIter?: number;
 }

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -73,15 +73,12 @@ function parseAllowedTools(raw: string | undefined): readonly string[] | undefin
   return names.length > 0 ? Object.freeze(names) : undefined;
 }
 
-/** Match subagent's own bounds (src/tools/subagent.ts MIN_MAX_ITERS / MAX_MAX_ITERS). */
-const SKILL_MAX_ITERS_MIN = 1;
-const SKILL_MAX_ITERS_MAX = 256;
-
+/** `max-iters` is checkpoint cadence, not a budget — work continues across pauses via resume_session. No upper bound; values below 1 fall back to the subagent default. */
 function parseMaxToolIters(raw: string | undefined): number | undefined {
   if (raw === undefined) return undefined;
   const n = Number.parseInt(raw.trim(), 10);
-  if (!Number.isFinite(n)) return undefined;
-  return Math.min(SKILL_MAX_ITERS_MAX, Math.max(SKILL_MAX_ITERS_MIN, n));
+  if (!Number.isFinite(n) || n < 1) return undefined;
+  return n;
 }
 
 export class SkillStore {
@@ -257,7 +254,7 @@ Tips:
 - Reference tools by name (run_command, edit_file, search_content, ...)
 - Add \`runAs: subagent\` to frontmatter to spawn an isolated subagent loop
 - Add \`allowed-tools: read_file, search_content\` to scope a subagent's tools
-- Add \`max-iters: 64\` (or higher, up to 256) to raise the subagent's tool-call budget — default 16. Pick what the task actually needs; large values just delay the natural termination.
+- Add \`max-iters: N\` to change the subagent's pause cadence (default 16). This isn't a budget — the parent resumes on pause, so N is how often the parent gets a checkpoint, not how much total work the subagent gets.
 `;
 }
 

--- a/src/tools/subagent.ts
+++ b/src/tools/subagent.ts
@@ -4,6 +4,7 @@ import { type DeepSeekClient, Usage } from "../client.js";
 import { CacheFirstLoop } from "../loop.js";
 import { applyProjectMemory } from "../memory/project.js";
 import { ImmutablePrefix } from "../memory/runtime.js";
+import { timestampSuffix } from "../memory/session.js";
 import {
   NEGATIVE_CLAIM_RULE,
   TUI_FORMATTING_RULES,
@@ -57,6 +58,8 @@ export interface SpawnSubagentOptions {
   skillName?: string;
   /** Scopes the child registry to these literal tool names; NEVER_INHERITED still wins. Driven by skill `allowed-tools` frontmatter. */
   allowedTools?: readonly string[];
+  /** Reuse an earlier pausedSession instead of starting fresh. The child loop loads the prior messages from disk and continues; `task` is treated as a continuation nudge. */
+  resumeSession?: string;
 }
 
 export interface SubagentResult {
@@ -71,6 +74,10 @@ export interface SubagentResult {
   skillName?: string;
   /** Zero-filled when no API calls landed so consumers always see a valid shape. */
   usage: Usage;
+  /** True when the child hit its pause-every interval without producing a final answer. */
+  paused?: boolean;
+  /** Session name the caller passes back as `resume_session` to continue. Set whenever `paused` is true. */
+  pausedSession?: string;
 }
 
 export interface SubagentToolOptions {
@@ -101,9 +108,8 @@ function defaultSubagentSystem(modelId: string): string {
 }
 
 const DEFAULT_MAX_RESULT_CHARS = 8000;
-const DEFAULT_MAX_ITERS = 16;
-const MIN_MAX_ITERS = 1;
-const MAX_MAX_ITERS = 256;
+/** How many tool calls a subagent runs before yielding `paused` back to its parent. Not a budget — work continues via `resume_session`; this is checkpoint cadence. */
+const DEFAULT_PAUSE_EVERY = 16;
 /** Iters-from-cap at which we start appending a remaining-budget hint to tool results. */
 const BUDGET_WARN_THRESHOLD = 3;
 
@@ -146,13 +152,14 @@ export function subagentBudgetHint(spawnCount: number, totalTokens: number): str
 /** Errors captured in the result shape, never thrown — caller decides how to surface. */
 export async function spawnSubagent(opts: SpawnSubagentOptions): Promise<SubagentResult> {
   const model = opts.model ?? DEFAULT_SUBAGENT_MODEL;
-  const maxToolIters = opts.maxToolIters ?? DEFAULT_MAX_ITERS;
+  const maxToolIters = opts.maxToolIters ?? DEFAULT_PAUSE_EVERY;
   const maxResultChars = opts.maxResultChars ?? DEFAULT_MAX_RESULT_CHARS;
   const sink = opts.sink;
   const skillName = opts.skillName;
+  const runId = nextRunId();
+  const sessionName = opts.resumeSession ?? `subagent-${runId}-${timestampSuffix()}`;
 
   const startedAt = Date.now();
-  const runId = nextRunId();
   const taskPreview = opts.task.length > 30 ? `${opts.task.slice(0, 30)}…` : opts.task;
   sink?.current?.({
     kind: "start",
@@ -233,10 +240,9 @@ export async function spawnSubagent(opts: SpawnSubagentOptions): Promise<Subagen
     reasoningEffort: DEFAULT_SUBAGENT_EFFORT,
     maxToolIters,
     hooks: [],
-    // Streaming on so the parent UI can flip the "summarising" phase the
-    // moment the model starts emitting the final answer (first assistant_delta
-    // after the last tool result, before assistant_final lands).
     stream: true,
+    session: sessionName,
+    onIterBudgetExhausted: "pause",
   });
 
   // Wire parent-abort → child-abort. Two pitfalls we have to handle:
@@ -263,8 +269,13 @@ export async function spawnSubagent(opts: SpawnSubagentOptions): Promise<Subagen
   let errorMessage: string | undefined;
   let toolIter = 0;
   let summarisingEmitted = false;
+  let paused = false;
+  // Resume: tell the model the budget refreshed — without this it reads prior "finalize NOW" hints as still in force and refuses to keep calling tools.
+  const taskForLoop = opts.resumeSession
+    ? `[Resume: your tool-call budget has been refreshed with ${maxToolIters} new calls. Earlier "wrap up" / "finalize NOW" budget hints in this conversation referred to the previous window — they no longer apply. Continue the work you were given.]\n\n${opts.task}`
+    : opts.task;
   try {
-    for await (const ev of childLoop.step(opts.task)) {
+    for await (const ev of childLoop.step(taskForLoop)) {
       sink?.current?.({ kind: "inner", runId, task: taskPreview, skillName, model, inner: ev });
 
       if (ev.role === "tool") {
@@ -306,6 +317,9 @@ export async function spawnSubagent(opts: SpawnSubagentOptions): Promise<Subagen
       if (ev.role === "error") {
         errorMessage = ev.error ?? "subagent error";
       }
+      if (ev.role === "paused") {
+        paused = true;
+      }
     }
   } catch (err) {
     errorMessage = (err as Error).message;
@@ -318,7 +332,10 @@ export async function spawnSubagent(opts: SpawnSubagentOptions): Promise<Subagen
   // still counts as a failure: no answer came back, the parent has
   // nothing to render. Synthesize an error so `success: false` and the
   // UI surfaces the abort instead of returning empty output.
-  if (!errorMessage && !final) {
+  //
+  // Pause is NOT failure — the session is intact on disk, the parent
+  // resumes by passing sessionName back. Don't synthesize an error.
+  if (!errorMessage && !final && !paused) {
     errorMessage = opts.parentSignal?.aborted
       ? "subagent aborted before producing an answer"
       : "subagent ended without producing an answer";
@@ -360,6 +377,8 @@ export async function spawnSubagent(opts: SpawnSubagentOptions): Promise<Subagen
     model,
     skillName,
     usage,
+    paused: paused || undefined,
+    pausedSession: paused ? sessionName : undefined,
   };
 }
 
@@ -377,6 +396,17 @@ function aggregateChildUsage(loop: CacheFirstLoop): Usage {
 }
 
 export function formatSubagentResult(r: SubagentResult): string {
+  if (r.paused) {
+    return JSON.stringify({
+      success: false,
+      paused: true,
+      resume_session: r.pausedSession,
+      tool_iters: r.toolIters,
+      elapsed_ms: r.elapsedMs,
+      cost_usd: r.costUsd,
+      note: `Subagent reached its pause-every interval (${r.toolIters} tool calls) without producing a final answer. To continue from where it left off, call spawn_subagent again with resume_session="${r.pausedSession}" (the task arg becomes a continuation nudge — e.g. "finish what you started"). To accept the partial work, ignore this and proceed with what you already know.`,
+    });
+  }
   if (!r.success) {
     return JSON.stringify({
       success: false,
@@ -413,7 +443,7 @@ export function registerSubagentTool(
     ? applyProjectMemory(baseSystem, opts.projectRoot)
     : baseSystem;
   const defaultModel = opts.defaultModel ?? DEFAULT_SUBAGENT_MODEL;
-  const maxToolIters = opts.maxToolIters ?? DEFAULT_MAX_ITERS;
+  const maxToolIters = opts.maxToolIters ?? DEFAULT_PAUSE_EVERY;
   const maxResultChars = opts.maxResultChars ?? DEFAULT_MAX_RESULT_CHARS;
   const sink = opts.sink;
   // Per-session counters survive across spawn calls because registerSubagentTool
@@ -425,19 +455,19 @@ export function registerSubagentTool(
     name: SUBAGENT_TOOL_NAME,
     parallelSafe: true,
     description:
-      "Spawn an isolated subagent to handle a self-contained subtask in a fresh context, returning only its final answer. **Prefer direct tools.** Spawn primarily for parallel fan-out (2+ independent investigations issued in one tool batch) or when the work would otherwise need >10 file reads/searches whose trail you don't need to keep. Single greps, 1-3 file cross-references, and 'keep my context clean for one question' are NOT good reasons to spawn — direct tools are cheaper and let you reference the evidence later. Each spawn pays a fresh prefix-cache miss plus a full child loop. The subagent inherits your tools but runs in its own isolated message log; only the final assistant message comes back. Keep tasks focused; the subagent has a stricter iter budget than you do.",
+      "Spawn an isolated subagent to handle a self-contained subtask in a fresh context, returning only its final answer. **Prefer direct tools.** Spawn primarily for parallel fan-out (2+ independent investigations issued in one tool batch) or when the work would otherwise need >10 file reads/searches whose trail you don't need to keep. Single greps, 1-3 file cross-references, and 'keep my context clean for one question' are NOT good reasons to spawn — direct tools are cheaper and let you reference the evidence later. Each fresh spawn pays a prefix-cache miss plus a full child loop. The subagent inherits your tools but runs in its own isolated message log; only the final assistant message comes back. **Pause/resume**: subagents yield back to you every `max_iters` tool calls. A paused result returns `{ paused: true, resume_session: \"...\" }` — you can either accept the partial state, or call spawn_subagent again with `resume_session` set to continue where it left off (cheap: the prior prefix is cached). Tasks expected to run much longer than 16 tool calls don't need a huge `max_iters` — just resume.",
     parameters: {
       type: "object",
       properties: {
         task: {
           type: "string",
           description:
-            "The subtask the subagent should perform. Be specific and self-contained — the subagent has none of your conversation context, only what you write here.",
+            'The subtask the subagent should perform. Be specific and self-contained — the subagent has none of your conversation context, only what you write here. When resuming via `resume_session`, this becomes a continuation nudge (e.g. "finish what you started" or a delta instruction).',
         },
         system: {
           type: "string",
           description:
-            "Optional override for the subagent's system prompt. The default tells it to stay focused and return a concise answer; override only when the subtask needs a specialized persona.",
+            "Optional override for the subagent's system prompt. The default tells it to stay focused and return a concise answer; override only when the subtask needs a specialized persona. Ignored on resume — the prior session keeps its original system prompt for cache stability.",
         },
         model: {
           type: "string",
@@ -447,9 +477,13 @@ export function registerSubagentTool(
         },
         max_iters: {
           type: "integer",
-          minimum: MIN_MAX_ITERS,
-          maximum: MAX_MAX_ITERS,
-          description: `Cap on the subagent's tool-call iterations. Default 16 (or the type's default when 'type' is set). Hard range: ${MIN_MAX_ITERS}-${MAX_MAX_ITERS}; out-of-range values are clamped to the nearest end. Pick what the task actually needs — flash spawns are cheap, but values much larger than the work warrants just delay the natural termination.`,
+          description:
+            "How many tool calls the subagent runs before pausing back to you for a checkpoint. Default 16. This is checkpoint cadence, not a budget — work continues across pauses via `resume_session`. Pick what feels natural for the granularity of decisions you want to make: small (4-8) when you want frequent control, larger (32-64) when the subagent should mostly run autonomously.",
+        },
+        resume_session: {
+          type: "string",
+          description:
+            "Provide the `resume_session` value returned by a previous paused spawn to continue that subagent. When set, prior messages are loaded from disk and the original system prompt is reused (cache-friendly). `task` becomes a continuation nudge.",
         },
         type: {
           type: "string",
@@ -467,6 +501,7 @@ export function registerSubagentTool(
         model?: unknown;
         max_iters?: unknown;
         type?: unknown;
+        resume_session?: unknown;
       },
       ctx,
     ) => {
@@ -485,7 +520,11 @@ export function registerSubagentTool(
         typeof args.system === "string" && args.system.trim().length > 0
           ? args.system.trim()
           : (typeSpec?.system ?? `${defaultSystemBase}\n\n${escalationContract(model)}`);
-      const callerIters = clampMaxIters(args.max_iters);
+      const callerIters = parseMaxIters(args.max_iters);
+      const resumeSession =
+        typeof args.resume_session === "string" && args.resume_session.trim().length > 0
+          ? args.resume_session.trim()
+          : undefined;
       const result = await spawnSubagent({
         client: opts.client,
         parentRegistry,
@@ -496,6 +535,7 @@ export function registerSubagentTool(
         maxResultChars,
         sink,
         parentSignal: ctx?.signal,
+        resumeSession,
       });
       sessionSpawnCount++;
       sessionSpawnTokens += result.usage.totalTokens;
@@ -508,13 +548,11 @@ export function registerSubagentTool(
   return parentRegistry;
 }
 
-/** Floats round down; non-finite / wrong-type yields undefined so caller falls back to its default. */
-function clampMaxIters(raw: unknown): number | undefined {
+/** Floats round down; non-finite / wrong-type / non-positive yields undefined so caller falls back to its default. No upper clamp — the value is a pause cadence, work continues via resume_session. */
+function parseMaxIters(raw: unknown): number | undefined {
   if (typeof raw !== "number" || !Number.isFinite(raw)) return undefined;
   const n = Math.floor(raw);
-  if (n < MIN_MAX_ITERS) return MIN_MAX_ITERS;
-  if (n > MAX_MAX_ITERS) return MAX_MAX_ITERS;
-  return n;
+  return n >= 1 ? n : undefined;
 }
 
 /** Plan-mode state propagates — a subagent spawned under `/plan` MUST NOT escape it. */

--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -411,33 +411,20 @@ describe("Skill frontmatter — runAs", () => {
     expect(store.read("big")?.maxToolIters).toBe(32);
   });
 
-  it("passes max-iters values up to 256 through unchanged", () => {
+  it("passes large max-iters values through unchanged (no upper clamp)", () => {
     writeSkillDir(
       home,
       "global",
       "bigger",
-      { description: "...", runAs: "subagent", "max-iters": "128" },
-      "body",
-      home,
-    );
-    const store = new SkillStore({ homeDir: home, disableBuiltins: true });
-    expect(store.read("bigger")?.maxToolIters).toBe(128);
-  });
-
-  it("clamps max-iters above 256 to the upper bound", () => {
-    writeSkillDir(
-      home,
-      "global",
-      "toobig",
       { description: "...", runAs: "subagent", "max-iters": "9999" },
       "body",
       home,
     );
     const store = new SkillStore({ homeDir: home, disableBuiltins: true });
-    expect(store.read("toobig")?.maxToolIters).toBe(256);
+    expect(store.read("bigger")?.maxToolIters).toBe(9999);
   });
 
-  it("clamps max-iters below 1 to the lower bound", () => {
+  it("ignores max-iters below 1 (falls back to subagent default)", () => {
     writeSkillDir(
       home,
       "global",
@@ -447,7 +434,7 @@ describe("Skill frontmatter — runAs", () => {
       home,
     );
     const store = new SkillStore({ homeDir: home, disableBuiltins: true });
-    expect(store.read("toosmall")?.maxToolIters).toBe(1);
+    expect(store.read("toosmall")?.maxToolIters).toBeUndefined();
   });
 
   it("ignores max-iters that isn't a number", () => {

--- a/tests/subagent.test.ts
+++ b/tests/subagent.test.ts
@@ -397,20 +397,19 @@ describe("registerSubagentTool", () => {
     expect(fetchCalls).toBe(0);
   });
 
-  it("exposes max_iters in the tool schema with min/max bounds", () => {
+  it("exposes max_iters in the tool schema without an upper bound (checkpoint cadence, not budget)", () => {
     const parent = new ToolRegistry();
     const client = makeClient([{ content: "ok" }]);
     registerSubagentTool(parent, { client });
     const spec = parent.specs().find((s) => s.function.name === "spawn_subagent");
     const params = spec?.function.parameters as {
-      properties: { max_iters: { type: string; minimum: number; maximum: number } };
+      properties: { max_iters: { type: string; minimum?: number; maximum?: number } };
     };
     expect(params.properties.max_iters.type).toBe("integer");
-    expect(params.properties.max_iters.minimum).toBe(1);
-    expect(params.properties.max_iters.maximum).toBe(256);
+    expect(params.properties.max_iters.maximum).toBeUndefined();
   });
 
-  it("caps the child loop at the caller-supplied max_iters", async () => {
+  it("paces the child loop at the caller-supplied max_iters (pauses on reaching it)", async () => {
     const parent = new ToolRegistry();
     parent.register({ name: "noop", readOnly: true, fn: () => "noop-result" });
     const client = makeClient(makeToolCallResponses(50));
@@ -421,19 +420,22 @@ describe("registerSubagentTool", () => {
     );
     const parsed = JSON.parse(out);
     expect(parsed.tool_iters).toBe(3);
+    expect(parsed.paused).toBe(true);
+    expect(typeof parsed.resume_session).toBe("string");
   });
 
-  it("clamps max_iters above the maximum", async () => {
+  it("passes large max_iters values through without clamping", async () => {
     const parent = new ToolRegistry();
     parent.register({ name: "noop", readOnly: true, fn: () => "noop-result" });
-    const client = makeClient(makeToolCallResponses(300));
+    const client = makeClient(makeToolCallResponses(60));
     registerSubagentTool(parent, { client });
     const out = await parent.dispatch(
       "spawn_subagent",
-      JSON.stringify({ task: "loop forever", max_iters: 9999 }),
+      JSON.stringify({ task: "loop forever", max_iters: 50 }),
     );
     const parsed = JSON.parse(out);
-    expect(parsed.tool_iters).toBe(256);
+    expect(parsed.tool_iters).toBe(50);
+    expect(parsed.paused).toBe(true);
   });
 
   it("ignores non-numeric max_iters and falls back to the default", async () => {
@@ -543,9 +545,11 @@ describe("registerSubagentTool", () => {
   });
 
   it("appends a remaining-budget hint to tool results within 3 iters of the cap", async () => {
-    // Drive 5 tool calls then a stop. The augmenter should append a hint
-    // starting at iter 2 (remaining=3) through iter 5 (remaining=0).
-    const responses = [...makeToolCallResponses(5), { content: "done" }];
+    // Drive 5 tool calls. The augmenter appends a hint starting at iter 2
+    // (remaining=3). With pause-on-budget the loop ends at iter 4 without
+    // a sixth model call, so the model only sees results 1-4 (the 5th
+    // result lands in the session but isn't sent because the loop paused).
+    const responses = makeToolCallResponses(5);
     const innerFetch = fakeFetch(responses);
     const seenToolResults: string[] = [];
     const fetchSpy = vi.fn(async (url: any, init: any) => {
@@ -563,17 +567,14 @@ describe("registerSubagentTool", () => {
     parent.register({ name: "noop", readOnly: true, fn: () => "noop-result" });
     registerSubagentTool(parent, { client, maxToolIters: 5 });
     await parent.dispatch("spawn_subagent", JSON.stringify({ task: "go" }));
-    expect(seenToolResults.length).toBeGreaterThanOrEqual(5);
-    // Each tool result is sent on every subsequent turn — dedupe by
-    // taking the first occurrence of each unique result.
+    expect(seenToolResults.length).toBeGreaterThanOrEqual(4);
     const unique = Array.from(new Set(seenToolResults));
-    expect(unique).toHaveLength(5);
+    expect(unique).toHaveLength(4);
     expect(unique[0]).not.toMatch(/budget:/);
     expect(unique[0]).toBe("noop-result");
     expect(unique[1]).toMatch(/\[budget: 3 of 5 tool calls left/);
     expect(unique[2]).toMatch(/\[budget: 2 of 5 tool calls left/);
     expect(unique[3]).toMatch(/\[budget: 1 of 5 tool call left/);
-    expect(unique[4]).toMatch(/\[budget: 0 of 5 tool calls left — finalize NOW/);
   });
 });
 


### PR DESCRIPTION
## What

Subagents now pause on hitting their per-window iter count instead of being forced to summarize. The parent receives `{paused: true, resume_session: "..."}` and decides: accept partial state, or call `spawn_subagent` again with `resume_session` set to continue. Total work bounded by the parent's own budget + natural termination, not by an arbitrary upstream number.

PR #822 widened the cap 32 → 256 as a measurement step. The real-API probes there showed the model picks sensible values across task sizes — `tiny → 3`, `medium → 30`, `large → 80`, `unbounded → 256`. The cap was theater. This PR finishes the job by deleting it and replacing it with a mechanism that scales with whatever the work actually needs.

Closes #783

## Architecture

Pause uses the existing session-persistence layer:

- Child loop runs with a minted `session: subagent-<runId>-<ts>` so every message goes to disk as it would for a normal session.
- When the per-window iter count is reached, loop emits a new `paused` LoopEvent role carrying the session name instead of calling `forceSummaryAfterIterLimit`.
- Parent resumes by calling `spawn_subagent` with `resume_session: "..."`; the child loop loads the prior messages from disk and continues with the SAME system + tool prefix (cache stays byte-stable, hot prefix).

The pause/resume control flow follows the same shape as Anthropic's server-tool `pause_turn` mechanism, adapted for our client-side loop.

## Validated against real API

Real DeepSeek API. Phase 1 spawns with `max_iters=2`:

\`\`\`
[phase 1 subagent result] {
  success: false,
  paused: true,
  resume_session: 'subagent-sub-1-202605140827',
  tool_iters: 2,
  note: 'Subagent reached its pause-every interval (2 tool calls)…
         call spawn_subagent again with resume_session="..." to
         continue.'
}
\`\`\`

Phase 2 (new parent loop) resumes with that token:

\`\`\`
[phase 2 subagent result] {
  success: true,
  paused: undefined,
  tool_iters: 8,
  output_preview: 'All 10 topics have been read…'
}
\`\`\`

Total work across the two windows: 2 + 8 = 10 tool calls, exactly what the original task needed. The parent didn't think about iters — just resumed once.

## Knobs removed

| Constant | Was | Now |
|---|---|---|
| `DEFAULT_MAX_ITERS` (subagent) | 16 | replaced by `DEFAULT_PAUSE_EVERY = 16` (same value, different concept) |
| `MIN_MAX_ITERS` | 1 | gone (values below 1 still fall back) |
| `MAX_MAX_ITERS` | 256 (from #822) | gone (no upper clamp) |
| `SKILL_MAX_ITERS_MIN/MAX` | 1 / 256 | gone (frontmatter parses freely) |
| `clampMaxIters` | clamped to [1,256] | `parseMaxIters` (just int parsing, no clamp) |
| JSON schema `max_iters.minimum/maximum` | 1 / 256 | omitted |

## Surfaces that didn't change

- `forceSummaryAfterIterLimit` still fires for top-level chat (the user is staring at a screen and needs an answer). Only subagents switch to pause.
- 70% warning + 3-iter end-of-window hint still useful — they cue the model to produce a coherent partial before pausing.
- `budgetUsd` and the stuck-state escalation are untouched.

## One quirk worth knowing

On resume, the prior session has "finalize NOW" budget hints baked into earlier tool results. Without an explicit cue the model reads them as still in force and refuses to keep calling tools (tested this, it really does). So `spawnSubagent` prepends a one-line resume nudge to the user task: "your budget refreshed, earlier 'finalize NOW' hints no longer apply, continue."

## Tests

- typecheck ✓
- subagent.test.ts (38) ✓ — dropped clamp assertions, added pause assertions
- skills.test.ts (39) ✓ — same
- loop.test.ts (77) ✓
- comment-policy.test.ts (9) ✓
- Pre-push npm run verify on the way up (full suite)
- Real API end-to-end ✓ (smoke script above)