### PR TITLE
fix(dashboard): swallow third-party-origin errors in the global overlay

### DIFF
--- a/dashboard/src/lib/bus-filter.ts
+++ b/dashboard/src/lib/bus-filter.ts
@@ -1,0 +1,13 @@
+/** Browser extensions (userscripts, ad blockers) inject scripts that throw into our window. Their errors land in the global handlers as if they were ours — see #818. Filter them by origin. */
+const THIRD_PARTY_ORIGIN_PREFIXES = [
+  "chrome-extension://",
+  "moz-extension://",
+  "safari-web-extension://",
+  "safari-extension://",
+  "ms-browser-extension://",
+];
+
+export function isThirdPartyError(error: unknown, filename?: string): boolean {
+  const hay = `${filename ?? ""}\n${(error as { stack?: string } | null)?.stack ?? ""}`;
+  return THIRD_PARTY_ORIGIN_PREFIXES.some((prefix) => hay.includes(prefix));
+}

--- a/dashboard/src/lib/bus.ts
+++ b/dashboard/src/lib/bus.ts
@@ -1,6 +1,7 @@
 import htm from "htm";
 import { h } from "preact";
 import { useEffect, useState } from "preact/hooks";
+import { isThirdPartyError } from "./bus-filter.js";
 
 const html = htm.bind(h);
 
@@ -29,10 +30,12 @@ export function reportAppError(error: unknown, source: string, info?: string): v
 
 window.addEventListener("error", (ev) => {
   if (!ev.error) return;
+  if (isThirdPartyError(ev.error, ev.filename)) return;
   reportAppError(ev.error, "window", ev.message);
 });
 
 window.addEventListener("unhandledrejection", (ev) => {
+  if (isThirdPartyError(ev.reason)) return;
   reportAppError(ev.reason, "promise");
 });
 

--- a/tests/dashboard-bus-filter.test.ts
+++ b/tests/dashboard-bus-filter.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { isThirdPartyError } from "../dashboard/src/lib/bus-filter.js";
+
+describe("isThirdPartyError", () => {
+  it("flags errors with a chrome-extension:// frame in the stack (real #818 case)", () => {
+    const err = new Error("require is not defined");
+    err.stack = [
+      "ReferenceError: require is not defined",
+      "    at Proxy.<anonymous> (chrome-extension://iikmkjmpaadaobahmlepeloendndfphd/userscript.html?name=adblock-ublock-x:8:14)",
+      "    at At (<anonymous>:10:89)",
+    ].join("\n");
+    expect(isThirdPartyError(err)).toBe(true);
+  });
+
+  it("flags errors whose filename argument points at a browser extension", () => {
+    const err = new Error("something");
+    expect(isThirdPartyError(err, "chrome-extension://abc/userscript.js")).toBe(true);
+    expect(isThirdPartyError(err, "moz-extension://abc/script.js")).toBe(true);
+    expect(isThirdPartyError(err, "safari-web-extension://abc/script.js")).toBe(true);
+  });
+
+  it("does not flag dashboard-origin errors", () => {
+    const err = new Error("real bug");
+    err.stack = [
+      "Error: real bug",
+      "    at chat.ts (http://localhost:5174/src/panels/chat.ts:123:4)",
+      "    at preact.module.js (http://localhost:5174/node_modules/preact/dist/preact.module.js:99:1)",
+    ].join("\n");
+    expect(isThirdPartyError(err)).toBe(false);
+  });
+
+  it("does not crash on non-Error values (rejection with string / null)", () => {
+    expect(isThirdPartyError("plain string")).toBe(false);
+    expect(isThirdPartyError(null)).toBe(false);
+    expect(isThirdPartyError(undefined)).toBe(false);
+    expect(isThirdPartyError({ no: "stack" })).toBe(false);
+  });
+
+  it("flags rejections (Promise.reject(error)) when the reason's stack mentions an extension", () => {
+    const reason = new Error("rejected from a userscript");
+    reason.stack =
+      "Error: rejected from a userscript\n    at chrome-extension://iikmkjmpaadaobahmlepeloendndfphd/content.js:9:1303";
+    expect(isThirdPartyError(reason)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

The dashboard's `window.addEventListener("error", ...)` and `unhandledrejection` handlers forwarded everything to the error overlay, including errors thrown by user-installed browser extensions / userscripts that have nothing to do with the dashboard. #818 is exactly that: an ad-blocker userscript threw `require is not defined` and the overlay prompted the reporter to file an issue against us.

Fix: skip reporting when the error's stack or the `ErrorEvent.filename` points at a browser-extension origin (`chrome-extension://`, `moz-extension://`, `safari-web-extension://`, `safari-extension://`, `ms-browser-extension://`). The error still hits `console.error` via the browser default; we just don't treat it as ours.

## Implementation note

Extracted the filter into `dashboard/src/lib/bus-filter.ts` (no side-effects) so it can be unit-tested under the project's node-env vitest config without pulling in jsdom. `bus.ts` imports it.

## Test plan

- [x] `npm run typecheck`
- [x] `tests/dashboard-bus-filter.test.ts` (5 cases — chrome-extension stack, three browser-extension filename schemes, dashboard-origin negative, non-Error rejection, rejection-from-extension)
- [x] `tests/comment-policy.test.ts`
- [x] Pre-push `npm run verify`

Closes #818