### PR TITLE
feat(desktop): @-mention UX — drag-drop, tree picker, file-index TTL

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -952,6 +952,61 @@ function TabRuntime({
     window.setTimeout(() => setToast(null), 1600);
   }, []);
 
+  // Drag-and-drop: dropping files/folders onto the window inserts them
+  // as @-mentions in the draft (relative to workspaceDir when inside it).
+  // Tauri's webview API gives us absolute paths; converting to relative
+  // matches what the file-picker dialog does in composer.attachFile.
+  useEffect(() => {
+    const ws = state.settings?.workspaceDir;
+    let unlisten: (() => void) | null = null;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const mod = await import("@tauri-apps/api/webview");
+        const webview = mod.getCurrentWebview();
+        const handle = await webview.onDragDropEvent((event) => {
+          if (event.payload.type === "enter") {
+            document.body.dataset.dragOver = "1";
+            return;
+          }
+          if (event.payload.type === "leave") {
+            delete document.body.dataset.dragOver;
+            return;
+          }
+          if (event.payload.type !== "drop") return;
+          delete document.body.dataset.dragOver;
+          const paths = event.payload.paths ?? [];
+          if (paths.length === 0) return;
+          const mentions = paths.map((p) => {
+            const norm = p.replace(/\\/g, "/");
+            if (ws) {
+              const wsNorm = ws.replace(/\\/g, "/").replace(/\/+$/, "");
+              if (norm === wsNorm || norm.startsWith(`${wsNorm}/`)) {
+                return norm.slice(wsNorm.length).replace(/^\/+/, "") || ".";
+              }
+            }
+            return norm;
+          });
+          setDraft((d) => {
+            const prefix = d.trim() ? `${d.replace(/\s+$/, "")} ` : "";
+            return `${prefix}${mentions.map((m) => `@${m}`).join(" ")} `;
+          });
+          for (const m of mentions) markMentionPicked(m);
+          composerRef.current?.focus();
+        });
+        if (cancelled) handle();
+        else unlisten = handle;
+      } catch (err) {
+        console.error("drag-drop listen failed", err);
+      }
+    })();
+    return () => {
+      cancelled = true;
+      unlisten?.();
+      delete document.body.dataset.dragOver;
+    };
+  }, [state.settings?.workspaceDir, markMentionPicked]);
+
   const send = useCallback(
     (override?: string) => {
       const text = (override ?? draft).trim();

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -27,6 +27,21 @@ body {
   text-rendering: optimizeLegibility;
 }
 
+body[data-drag-over="1"]::after {
+  content: "Drop to attach as @-mention";
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: oklch(20% 0.006 255 / 0.6);
+  color: var(--fg);
+  font-size: 14px;
+  font-weight: 500;
+  border: 2px dashed var(--accent);
+  z-index: 9999;
+  pointer-events: none;
+}
+
 /* ---------- THEME TOKENS ---------- */
 
 :root,

--- a/desktop/src/ui/composer.tsx
+++ b/desktop/src/ui/composer.tsx
@@ -269,6 +269,20 @@ export function Composer({
         dismiss();
         return;
       }
+      if (e.key === "Tab" && popup.kind === "at" && items.length > 0) {
+        // Tab on a directory enters it — replaces `@src` with `@src/`
+        // and re-queries so the popup shows that directory's children.
+        const it = items[activeIdx];
+        if (it && (it as MentionItem).kind === "dir") {
+          e.preventDefault();
+          const dirPath = (it as MentionItem).name.replace(/\/+$/, "");
+          const next = draft.replace(/[@][^\s]*$/, `@${dirPath}/`);
+          setDraft(next);
+          const nonce = ++nonceRef.current;
+          setPopup({ kind: "at", query: `${dirPath}/`, nonce });
+          return;
+        }
+      }
       if (e.key === "Enter") {
         if (items.length > 0) {
           e.preventDefault();

--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -564,6 +564,7 @@ interface Tab {
   aborter: AbortController | null;
   fileIndex: FileWithStats[] | null;
   fileIndexBuilding: Promise<FileWithStats[]> | null;
+  fileIndexBuiltAt: number;
   symbolIndex: SymbolEntry[] | null;
   symbolBuilding: Promise<SymbolEntry[]> | null;
   recentMentions: string[];
@@ -616,12 +617,17 @@ function buildRuntimeFor(tab: Tab): RuntimeState {
 const TS_EXPORT_RE =
   /^export\s+(?:default\s+)?(?:async\s+)?(function|class|const|let|var|interface|type|enum)\s+\*?\s*(\w+)/;
 
+/** TTL on the in-memory file index — without this, files deleted / renamed since the last @ popup still show up as candidates. 10s balances "fresh enough for typical edit-then-mention flows" against "don't re-scan 5000 files on every keystroke". */
+const FILE_INDEX_TTL_MS = 10_000;
+
 async function getFileIndexFor(tab: Tab): Promise<FileWithStats[]> {
-  if (tab.fileIndex) return tab.fileIndex;
+  const fresh = tab.fileIndex && Date.now() - tab.fileIndexBuiltAt < FILE_INDEX_TTL_MS;
+  if (fresh) return tab.fileIndex as FileWithStats[];
   if (tab.fileIndexBuilding) return tab.fileIndexBuilding;
   tab.fileIndexBuilding = listFilesWithStatsAsync(tab.rootDir, { maxResults: 5000 })
     .then((res) => {
       tab.fileIndex = res;
+      tab.fileIndexBuiltAt = Date.now();
       tab.fileIndexBuilding = null;
       return res;
     })
@@ -730,6 +736,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
       aborter: null,
       fileIndex: null,
       fileIndexBuilding: null,
+      fileIndexBuiltAt: 0,
       symbolIndex: null,
       symbolBuilding: null,
       recentMentions: [],
@@ -878,6 +885,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
     pushRecentWorkspace(target);
     tab.fileIndex = null;
     tab.fileIndexBuilding = null;
+    tab.fileIndexBuiltAt = 0;
     tab.symbolIndex = null;
     tab.symbolBuilding = null;
     tab.recentMentions.length = 0;
@@ -1325,7 +1333,11 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
       const nonce = msg.nonce;
       const query = msg.query;
       const parsed = parseAtQuery(query);
-      if (parsed.trailingSlash) {
+      // Empty query → list workspace root's top-level entries (tree
+      // style). Without this, bare `@` floods with all 5000 files; the
+      // TUI's @+Tab pattern already shows the tree top.
+      const treeWalk = parsed.trailingSlash || query.length === 0;
+      if (treeWalk) {
         void listDirectory(tab.rootDir, parsed.dir)
           .then((entries) => {
             const results = entries.map((e) => (e.isDir ? `${e.path}/` : e.path));


### PR DESCRIPTION
## Summary

Three coupled changes addressing the three asks in #816 (all in the desktop client's @-mention surface):

| # | Ask (from #816) | Fix |
|---|---|---|
| 1 | Drag-and-drop files / folders into the composer | `desktop/src/App.tsx`: subscribe to Tauri's `onDragDropEvent`, convert dropped paths to relative (when inside `workspaceDir`), append as `@path` mentions in the draft. Overlay shows "Drop to attach as @-mention" while the drag is over the window. |
| 2 | @ picker doesn't refresh when files are deleted/renamed | `src/cli/commands/desktop.ts`: 10s TTL on the in-memory file index — next `@` query past the window triggers a rebuild. |
| 3 | Bare `@` floods with all files; want tree-style like the TUI's `@+Tab` | Backend: empty query → list workspace root's top-level entries (same path as `@dir/` trailing-slash queries). Frontend: Tab on a directory item enters it (`@src` → Tab → `@src/`, re-queries to show that directory's children). Enter on a directory still picks the directory itself. |

## Files touched

- `src/cli/commands/desktop.ts` — file-index TTL + tree-walk default for empty query
- `desktop/src/ui/composer.tsx` — Tab-to-enter-directory in the @ popup
- `desktop/src/App.tsx` — drag-drop listener wiring + path normalisation
- `desktop/src/styles.css` — drag-over overlay

## Test plan

- [x] `npm run typecheck` (root + dashboard)
- [x] `npx tsc --noEmit -p desktop`
- [x] `tests/at-mentions.test.ts` (95), `tests/comment-policy.test.ts` (9)
- [x] Pre-push `npm run verify` (full suite)
- [ ] Manual on the desktop client:
  - drag a file from the workspace → appears as `@path` in draft
  - drag a file from outside the workspace → appears as absolute path
  - delete a file via the OS, type `@` → file no longer suggested (within 10s)
  - type `@` with no query → see workspace root's top level, not 5000 fuzzy matches
  - type `@src`, press Tab → popup switches to `src/` directory contents

Closes #816