### PR TITLE
fix(desktop): refresh the memory panel mid-turn after remember / forget

### DIFF
--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -845,6 +845,12 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
       try {
         for await (const ev of rt.loop.step(text)) {
           for (const kev of rt.eventizer.consume(ev, rt.ctx)) emit(kev, tab.id);
+          // Memory tools mutate disk state behind the loop's back — the UI
+          // panel won't know until we re-emit. Without this the right-hand
+          // panel only updates on tab reopen.
+          if (ev.role === "tool" && (ev.toolName === "remember" || ev.toolName === "forget")) {
+            emitMemory(tab);
+          }
           if (tab.aborter?.signal.aborted) break;
         }
       } catch (err) {


### PR DESCRIPTION
## Summary

The right-hand memory panel only received an \`\$memory\` event on tab open (\`tab_open\` → \`emitMemory(tab)\`). When the agent invoked \`remember\` or \`forget\` mid-turn the file was written to disk but the panel kept showing the prior list until the user reopened the tab.

Fix: in the turn loop's \`for await (const ev of rt.loop.step(...))\`, watch for \`ev.role === "tool"\` with \`toolName ∈ {remember, forget}\` and re-emit \`\$memory\` right then. Same shape as \`emitSessions\` / \`emitBalance\` already use on turn-complete; firing on the tool boundary just means the UI updates the moment the entry is written, not after the model finishes speaking.

## Test plan

- [x] \`npm run typecheck\`
- [x] \`tests/memory.test.ts\` (11)
- [x] Pre-push \`npm run verify\` (full suite)
- [ ] Manual: in the desktop client, ask the agent to remember something; confirm the memory panel populates without reopening the tab.