### PR TITLE
chore(desktop): drop the fake traffic-light dots from the titlebar

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -1640,11 +1640,6 @@ function TitleBar({
   }, [menuOpen]);
   return (
     <header className="titlebar">
-      <div className="traffic">
-        <span className="dot r" />
-        <span className="dot y" />
-        <span className="dot g" />
-      </div>
       <div className="brand">
         <span className="mark" />
         <span>Reasonix</span>

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -183,29 +183,7 @@ button {
   font-size: 12px;
 }
 
-.traffic {
-  display: flex;
-  gap: 8px;
-  padding: 0 6px;
-}
-.traffic .dot {
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  background: var(--border-strong);
-}
-.traffic .dot.r {
-  background: oklch(65% 0.18 22);
-}
-.traffic .dot.y {
-  background: oklch(78% 0.14 75);
-}
-.traffic .dot.g {
-  background: oklch(68% 0.14 145);
-}
-
 .titlebar .brand {
-  margin-left: 14px;
   display: flex;
   align-items: center;
   gap: 8px;


### PR DESCRIPTION
## Summary

The three coloured dots (red / yellow / green) in the top-left of the desktop titlebar were pure decoration — no onClick handlers, no Tauri window-API wiring, just `<span>` elements styled to look like macOS traffic-light buttons. Users clicked them expecting close / minimize / maximize and got nothing.

Remove the markup, the `.traffic` / `.dot` CSS rules, and the now-redundant `margin-left: 14px` on `.brand` that was compensating for the removed block. Native window chrome already handles min / max / close on every platform we ship to.

## Files

- `desktop/src/App.tsx` — drop the `<div className="traffic">` block (5 lines)
- `desktop/src/styles.css` — drop `.traffic` + `.dot` rules + the brand margin compensation (22 lines)

## Test plan

- [x] `npx tsc --noEmit -p desktop`
- [ ] Manual: open desktop client, confirm titlebar no longer shows the fake dots; native window chrome (Windows / macOS / Linux) still works.