### PR TITLE
feat(tui): context-usage pill in the status row (#828)

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -395,6 +395,7 @@ export function App(props: AppProps): React.ReactElement {
       showSessionCost: cfg.showSessionCost !== false,
       showTurnCost: cfg.showTurnCost !== false,
       showCacheHit: cfg.showCacheHit !== false,
+      showCtxUsage: cfg.showCtxUsage !== false,
       showVersion: cfg.showVersion !== false,
       showFeedbackHint: cfg.showFeedbackHint !== false,
     };

--- a/src/cli/ui/layout/StatusRow.tsx
+++ b/src/cli/ui/layout/StatusRow.tsx
@@ -2,10 +2,13 @@ import { Box, Text, useStdout } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React from "react";
 import { t } from "../../../i18n/index.js";
+import { DEEPSEEK_CONTEXT_TOKENS, DEFAULT_CONTEXT_TOKENS } from "../../../telemetry/stats.js";
 import { VERSION } from "../../../version.js";
+import { formatTokens } from "../primitives.js";
 import { Countdown } from "../primitives/Countdown.js";
 import { useAgentState } from "../state/provider.js";
 import type { Mode, NetworkState, StatusBar } from "../state/state.js";
+import { GLYPH } from "../theme.js";
 import { FG, TONE, balanceColor, formatBalance, formatCost } from "../theme/tokens.js";
 
 export interface StatusBarConfig {
@@ -13,6 +16,7 @@ export interface StatusBarConfig {
   showSessionCost: boolean;
   showTurnCost: boolean;
   showCacheHit: boolean;
+  showCtxUsage: boolean;
   showVersion: boolean;
   showFeedbackHint: boolean;
 }
@@ -23,12 +27,16 @@ const WALLET_MIN_COLS = 90;
 const VERSION_MIN_COLS = 70;
 const FEEDBACK_HINT_MIN_COLS = 100;
 const PRESET_MIN_COLS = 60;
+const CTX_TOKENS_MIN_COLS = 90;
+const CTX_BAR_MIN_COLS = 110;
+const CTX_BAR_CELLS = 8;
 
 const DEFAULT_STATUS_BAR_CONFIG: StatusBarConfig = {
   showBalance: true,
   showSessionCost: true,
   showTurnCost: true,
   showCacheHit: true,
+  showCtxUsage: true,
   showVersion: true,
   showFeedbackHint: true,
 };
@@ -90,6 +98,15 @@ export function StatusRow({
             >{`${t("statusBar.cache")} ${Math.round(status.cacheHit * 100)}%`}</Text>
           </>
         )}
+        {statusBar.showCtxUsage && status.promptTokens !== undefined && status.promptTokens > 0 && (
+          <CtxUsagePill
+            tokens={status.promptTokens}
+            cap={
+              status.promptCap ?? DEEPSEEK_CONTEXT_TOKENS[session.model] ?? DEFAULT_CONTEXT_TOKENS
+            }
+            cols={cols}
+          />
+        )}
         {status.mcpLoading && status.mcpLoading.ready < status.mcpLoading.total && (
           <McpLoadingPill ready={status.mcpLoading.ready} total={status.mcpLoading.total} />
         )}
@@ -150,6 +167,47 @@ function shortModelLabel(model: string): string {
   if (model === "deepseek-v4-flash") return "flash";
   if (model === "deepseek-v4-pro") return "pro";
   return model.replace(/^deepseek-/, "");
+}
+
+function CtxUsagePill({
+  tokens,
+  cap,
+  cols,
+}: {
+  tokens: number;
+  cap: number;
+  cols: number;
+}): React.ReactElement {
+  const ratio = cap > 0 ? Math.min(1, tokens / cap) : 0;
+  const pct = Math.round(ratio * 100);
+  const color = ratio >= 0.8 ? TONE.err : ratio >= 0.5 ? TONE.warn : TONE.ok;
+  const showTokens = cols >= CTX_TOKENS_MIN_COLS;
+  const showBar = cols >= CTX_BAR_MIN_COLS;
+  const filled = Math.round(CTX_BAR_CELLS * ratio);
+  return (
+    <>
+      <Sep />
+      <Text color={FG.meta} wrap="truncate">{`${t("statusBar.ctx")} `}</Text>
+      {showBar && (
+        <>
+          <Text color={color} wrap="truncate">
+            {GLYPH.block.repeat(filled)}
+          </Text>
+          <Text color={FG.faint} wrap="truncate">
+            {GLYPH.shade1.repeat(CTX_BAR_CELLS - filled)}
+          </Text>
+          <Text wrap="truncate"> </Text>
+        </>
+      )}
+      <Text color={color} wrap="truncate">{`${pct}%`}</Text>
+      {showTokens && (
+        <Text
+          color={FG.faint}
+          wrap="truncate"
+        >{` · ${formatTokens(tokens)}/${formatTokens(cap)}`}</Text>
+      )}
+    </>
+  );
 }
 
 function McpLoadingPill({

--- a/src/cli/ui/state/reducer.ts
+++ b/src/cli/ui/state/reducer.ts
@@ -97,6 +97,8 @@ export function reduce(state: AgentState, event: AgentEvent): AgentState {
           cost: event.usage.cost,
           sessionCost,
           cacheHit: event.usage.cacheHit,
+          promptTokens: event.usage.prompt,
+          promptCap: event.promptCap ?? state.status.promptCap,
         },
       };
     }

--- a/src/cli/ui/state/state.ts
+++ b/src/cli/ui/state/state.ts
@@ -30,6 +30,10 @@ export interface StatusBar {
   balance?: number;
   balanceCurrency?: string;
   cacheHit: number;
+  /** Last-turn prompt tokens; drives the context-usage pill. */
+  promptTokens?: number;
+  /** Model context-window cap (denominator for the usage pill). */
+  promptCap?: number;
   countdownSeconds?: number;
   recording?: { sizeBytes: number; events: number; path: string };
   /** null → user is on a custom model that doesn't match any preset; pill falls back to the model id. */

--- a/src/config.ts
+++ b/src/config.ts
@@ -117,6 +117,7 @@ export interface ReasonixConfig {
     showSessionCost?: boolean;
     showTurnCost?: boolean;
     showCacheHit?: boolean;
+    showCtxUsage?: boolean;
     showVersion?: boolean;
     showFeedbackHint?: boolean;
   };

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -1088,6 +1088,7 @@ export const EN: TranslationSchema = {
     evt: " evt",
     editsLabel: "edits:",
     mcpLoading: "MCP",
+    ctx: "ctx",
   },
   editMode: {
     plan: "PLAN MODE",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -375,6 +375,8 @@ export interface TranslationSchema {
     editsLabel: string;
     /** Label for the MCP-handshake progress pill (rendered as `⌁ MCP n/m`). */
     mcpLoading: string;
+    /** Word used in the context-usage pill (rendered as `ctx 72% · 144K/200K`). */
+    ctx: string;
   };
   editMode: {
     plan: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -1034,6 +1034,7 @@ export const zhCN: TranslationSchema = {
     evt: " 事件",
     editsLabel: "编辑:",
     mcpLoading: "MCP",
+    ctx: "上下文",
   },
   editMode: {
     plan: "计划",

--- a/tests/ui-reducer.test.ts
+++ b/tests/ui-reducer.test.ts
@@ -165,6 +165,22 @@ describe("ui reducer", () => {
     expect(s.status.cacheHit).toBeCloseTo(0.92);
   });
 
+  it("turn.end records promptTokens and remembers promptCap across turns", () => {
+    const s = run([
+      {
+        type: "turn.end",
+        usage: { prompt: 12_000, reason: 0, output: 200, cacheHit: 0.5, cost: 0 },
+        promptCap: 1_000_000,
+      },
+      {
+        type: "turn.end",
+        usage: { prompt: 48_000, reason: 0, output: 200, cacheHit: 0.5, cost: 0 },
+      },
+    ]);
+    expect(s.status.promptTokens).toBe(48_000);
+    expect(s.status.promptCap).toBe(1_000_000);
+  });
+
   it("turn.end + session.update sets all display fields", () => {
     // Full flow: a turn completes (updates cost/sessionCost), then the
     // App dispatches balance + balanceCurrency via session.update.

--- a/tests/ui-status-row-balance.test.tsx
+++ b/tests/ui-status-row-balance.test.tsx
@@ -114,6 +114,7 @@ describe("StatusRow — statusBar config toggles", () => {
       showSessionCost: true,
       showTurnCost: true,
       showCacheHit: true,
+      showCtxUsage: true,
       showVersion: true,
       showFeedbackHint: true,
       ...config,
@@ -191,6 +192,29 @@ describe("StatusRow — statusBar config toggles", () => {
     );
     expect(text).toContain("⛁");
     expect(text).toContain("spent");
+  });
+
+  it("ctx pill renders pct + tokens once promptTokens is known", async () => {
+    const text = await renderStatusRowWithConfig(
+      { cost: 0, promptTokens: 720_000, promptCap: 1_000_000 } as any,
+      {},
+    );
+    expect(text).toContain("ctx");
+    expect(text).toContain("72%");
+    expect(text).toContain("703K/977K");
+  });
+
+  it("showCtxUsage=false hides ctx pill", async () => {
+    const text = await renderStatusRowWithConfig(
+      { cost: 0, promptTokens: 720_000, promptCap: 1_000_000 } as any,
+      { showCtxUsage: false },
+    );
+    expect(text).not.toContain("ctx ");
+  });
+
+  it("ctx pill hidden when promptTokens is unset", async () => {
+    const text = await renderStatusRowWithConfig({ cost: 0 } as any, {});
+    expect(text).not.toContain("ctx ");
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds a context-fill indicator to the bottom status row so it's obvious how close the current prompt is to the model's context window — same role claude-dashboard plays for Claude Code.
- Three responsive forms: `ctx 72%` → `ctx 72% · 144K/1M` (≥90 cols) → `ctx ████░░░░ 72% · 144K/1M` (≥110 cols). Tier-colored green / amber / red at 50% / 80% thresholds.
- Plumbed off the existing `turn.end` event (already carries `usage.prompt` + optional `promptCap`); falls back to `DEEPSEEK_CONTEXT_TOKENS[model]` → `DEFAULT_CONTEXT_TOKENS`. Opt-out via `statusBar.showCtxUsage` next to the other pill toggles.

## Test plan

- [x] `npx vitest run tests/ui-status-row-balance.test.tsx tests/ui-reducer.test.ts tests/comment-policy.test.ts` — 65/65 pass
- [x] `tsc --noEmit` clean
- [x] Lint clean (one pre-existing unrelated warning in `tests/plan-confirm.test.tsx`)

Closes #828