### PR TITLE
feat(subagent): include partial_summary in paused result (#838)

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -19,7 +19,11 @@ import {
   looksLikePartialEscalationMarker,
   parseEscalationMarker,
 } from "./loop/escalation.js";
-import { type ForceSummaryContext, forceSummaryAfterIterLimit } from "./loop/force-summary.js";
+import {
+  type ForceSummaryContext,
+  forceSummaryAfterIterLimit,
+  summarizePartialProgress,
+} from "./loop/force-summary.js";
 import {
   fixToolCallPairing,
   healLoadedMessages,
@@ -1228,12 +1232,14 @@ export class CacheFirstLoop {
     // SOMETHING. Subagents → emit `paused`, leaving session messages
     // intact so the parent can resume by passing the session name back.
     if (this.onIterBudgetExhausted === "pause") {
+      const partial = await summarizePartialProgress(this.summaryContext());
       yield {
         turn: this._turn,
         role: "paused",
         content: "",
         sessionName: this.sessionName ?? undefined,
         pausedAtIter: this.maxToolIters,
+        partialSummary: partial?.summary,
       };
       yield { turn: this._turn, role: "done", content: "" };
       return;

--- a/src/loop/force-summary.ts
+++ b/src/loop/force-summary.ts
@@ -7,6 +7,9 @@ import { buildAssistantMessage } from "./messages.js";
 import { stripHallucinatedToolMarkup, thinkingModeForModel } from "./thinking.js";
 import type { LoopEvent } from "./types.js";
 
+const PAUSE_SUMMARY_MODEL = "deepseek-v4-flash";
+const PAUSE_SUMMARY_EFFORT: "high" | "max" = "high";
+
 export type ForceSummaryReason = "budget" | "aborted" | "context-guard" | "stuck";
 
 export interface ForceSummaryContext {
@@ -74,5 +77,32 @@ export async function* forceSummaryAfterIterLimit(
       error: t("summary.failedAfterReason", { label, message: (err as Error).message }),
     };
     yield { turn: ctx.turn, role: "done", content: "" };
+  }
+}
+
+/** One-shot no-tools summary of progress / remaining / blockers; does not persist, so the resumed child stays clean. Returns null on empty/failed responses — pause still works without it. */
+export async function summarizePartialProgress(
+  ctx: ForceSummaryContext,
+): Promise<{ summary: string; stats: TurnStats } | null> {
+  try {
+    const messages = ctx.buildMessages();
+    messages.push({
+      role: "user",
+      content:
+        "You're being paused at a checkpoint, not stopped. In 3-6 sentences of plain prose, tell the parent agent: (1) what you accomplished so far, (2) what's still left, (3) any blockers or open questions. Be concrete — mention specific files / functions / tool results — so the parent can decide whether to resume you or take over. Do NOT emit any tool calls, function-call markup, DSML invocations, or SEARCH/REPLACE edit blocks — they will be silently discarded. Just plain text.",
+    });
+    const resp = await ctx.client.chat({
+      model: PAUSE_SUMMARY_MODEL,
+      messages,
+      signal: ctx.signal,
+      thinking: thinkingModeForModel(PAUSE_SUMMARY_MODEL),
+      reasoningEffort: PAUSE_SUMMARY_EFFORT,
+    });
+    const cleaned = stripHallucinatedToolMarkup(resp.content?.trim() ?? "");
+    if (!cleaned) return null;
+    const stats = ctx.recordStats(PAUSE_SUMMARY_MODEL, resp.usage ?? new Usage());
+    return { summary: cleaned, stats };
+  } catch {
+    return null;
   }
 }

--- a/src/loop/types.ts
+++ b/src/loop/types.ts
@@ -42,4 +42,6 @@ export interface LoopEvent {
   sessionName?: string;
   /** Set on `role === "paused"` — iter count consumed before pausing. */
   pausedAtIter?: number;
+  /** Set on `role === "paused"` — one-shot no-tools summary of progress / remaining / blockers, for the parent's resume decision. */
+  partialSummary?: string;
 }

--- a/src/tools/subagent.ts
+++ b/src/tools/subagent.ts
@@ -78,6 +78,8 @@ export interface SubagentResult {
   paused?: boolean;
   /** Session name the caller passes back as `resume_session` to continue. Set whenever `paused` is true. */
   pausedSession?: string;
+  /** Subagent's own report of progress / remaining / blockers at the pause checkpoint — only set when paused. */
+  partialSummary?: string;
 }
 
 export interface SubagentToolOptions {
@@ -270,6 +272,7 @@ export async function spawnSubagent(opts: SpawnSubagentOptions): Promise<Subagen
   let toolIter = 0;
   let summarisingEmitted = false;
   let paused = false;
+  let partialSummary: string | undefined;
   // Resume: tell the model the budget refreshed — without this it reads prior "finalize NOW" hints as still in force and refuses to keep calling tools.
   const taskForLoop = opts.resumeSession
     ? `[Resume: your tool-call budget has been refreshed with ${maxToolIters} new calls. Earlier "wrap up" / "finalize NOW" budget hints in this conversation referred to the previous window — they no longer apply. Continue the work you were given.]\n\n${opts.task}`
@@ -319,6 +322,7 @@ export async function spawnSubagent(opts: SpawnSubagentOptions): Promise<Subagen
       }
       if (ev.role === "paused") {
         paused = true;
+        if (ev.partialSummary) partialSummary = ev.partialSummary;
       }
     }
   } catch (err) {
@@ -379,6 +383,7 @@ export async function spawnSubagent(opts: SpawnSubagentOptions): Promise<Subagen
     usage,
     paused: paused || undefined,
     pausedSession: paused ? sessionName : undefined,
+    partialSummary: paused ? partialSummary : undefined,
   };
 }
 
@@ -404,7 +409,8 @@ export function formatSubagentResult(r: SubagentResult): string {
       tool_iters: r.toolIters,
       elapsed_ms: r.elapsedMs,
       cost_usd: r.costUsd,
-      note: `Subagent reached its pause-every interval (${r.toolIters} tool calls) without producing a final answer. To continue from where it left off, call spawn_subagent again with resume_session="${r.pausedSession}" (the task arg becomes a continuation nudge — e.g. "finish what you started"). To accept the partial work, ignore this and proceed with what you already know.`,
+      partial_summary: r.partialSummary,
+      note: `Subagent reached its pause-every interval (${r.toolIters} tool calls) without producing a final answer. Read partial_summary above to see what was done / left / blocked, then decide: resume by calling spawn_subagent again with resume_session="${r.pausedSession}" (the task arg becomes a continuation nudge — e.g. "finish what you started"), or accept the partial work and proceed with what you already know.`,
     });
   }
   if (!r.success) {

--- a/tests/subagent.test.ts
+++ b/tests/subagent.test.ts
@@ -424,6 +424,43 @@ describe("registerSubagentTool", () => {
     expect(typeof parsed.resume_session).toBe("string");
   });
 
+  it("paused result carries partial_summary so the parent can decide informed", async () => {
+    const parent = new ToolRegistry();
+    parent.register({ name: "noop", readOnly: true, fn: () => "noop-result" });
+    const responses: FakeResponseShape[] = [
+      ...makeToolCallResponses(2),
+      {
+        content:
+          "Read 2 files, mapped the auth flow; still need to wire the refresh-token path; blocked on the token-store interface choice.",
+      },
+    ];
+    const client = makeClient(responses);
+    registerSubagentTool(parent, { client });
+    const out = await parent.dispatch(
+      "spawn_subagent",
+      JSON.stringify({ task: "trace the auth flow", max_iters: 2 }),
+    );
+    const parsed = JSON.parse(out);
+    expect(parsed.paused).toBe(true);
+    expect(parsed.partial_summary).toMatch(/Read 2 files/);
+    expect(parsed.partial_summary).toMatch(/blocked/);
+  });
+
+  it("paused result still works when the summary call returns empty content", async () => {
+    const parent = new ToolRegistry();
+    parent.register({ name: "noop", readOnly: true, fn: () => "noop-result" });
+    const responses: FakeResponseShape[] = [...makeToolCallResponses(2), { content: "" }];
+    const client = makeClient(responses);
+    registerSubagentTool(parent, { client });
+    const out = await parent.dispatch(
+      "spawn_subagent",
+      JSON.stringify({ task: "loop forever", max_iters: 2 }),
+    );
+    const parsed = JSON.parse(out);
+    expect(parsed.paused).toBe(true);
+    expect(parsed.partial_summary).toBeUndefined();
+  });
+
   it("passes large max_iters values through without clamping", async () => {
     const parent = new ToolRegistry();
     parent.register({ name: "noop", readOnly: true, fn: () => "noop-result" });
@@ -546,9 +583,9 @@ describe("registerSubagentTool", () => {
 
   it("appends a remaining-budget hint to tool results within 3 iters of the cap", async () => {
     // Drive 5 tool calls. The augmenter appends a hint starting at iter 2
-    // (remaining=3). With pause-on-budget the loop ends at iter 4 without
-    // a sixth model call, so the model only sees results 1-4 (the 5th
-    // result lands in the session but isn't sent because the loop paused).
+    // (remaining=3). After iter 5 the loop pauses; the partial-summary call
+    // (one extra no-tools fetch) then sees all 5 results in the session —
+    // including the iter-5 "0 of 5 left — finalize NOW" form.
     const responses = makeToolCallResponses(5);
     const innerFetch = fakeFetch(responses);
     const seenToolResults: string[] = [];
@@ -567,14 +604,15 @@ describe("registerSubagentTool", () => {
     parent.register({ name: "noop", readOnly: true, fn: () => "noop-result" });
     registerSubagentTool(parent, { client, maxToolIters: 5 });
     await parent.dispatch("spawn_subagent", JSON.stringify({ task: "go" }));
-    expect(seenToolResults.length).toBeGreaterThanOrEqual(4);
+    expect(seenToolResults.length).toBeGreaterThanOrEqual(5);
     const unique = Array.from(new Set(seenToolResults));
-    expect(unique).toHaveLength(4);
+    expect(unique).toHaveLength(5);
     expect(unique[0]).not.toMatch(/budget:/);
     expect(unique[0]).toBe("noop-result");
     expect(unique[1]).toMatch(/\[budget: 3 of 5 tool calls left/);
     expect(unique[2]).toMatch(/\[budget: 2 of 5 tool calls left/);
     expect(unique[3]).toMatch(/\[budget: 1 of 5 tool call left/);
+    expect(unique[4]).toMatch(/\[budget: 0 of 5 tool calls left — finalize NOW/);
   });
 });
 


### PR DESCRIPTION
## Summary

- Closes the `partial_summary` gap in subagent `paused` results — the parent agent now sees a 3–6 sentence progress / remaining / blockers note alongside the resume token, instead of only the opaque iter count.
- Mechanism: one no-tools `summarizePartialProgress` call (pinned to `deepseek-v4-flash` + `effort: high`, matching the existing forced-summary path) fires before the `paused` event yields. Output is attached to the event as `partialSummary` → surfaces in subagent JSON as `partial_summary`.
- Not persisted to session messages, so the resumed child picks up clean state. Failure of the summary call is non-fatal — pause still works, parent just gets the old opaque shape back.

## Test plan

- [x] `partial_summary` lands in the paused JSON when the summary call returns content
- [x] `partial_summary` is omitted (not empty-string) when the summary call returns empty
- [x] Existing budget-hint test updated to expect 5 unique tool results (iter 5's `0 of 5 left` hint now reaches a model call — the summary call — instead of being silently dropped)
- [x] `npx vitest run tests/` — 2857 passed / 3 skipped, 189 files clean
- [x] `tsc --noEmit` clean
- [x] Comment policy clean

Closes #838

Refs #783 (the orchestrator-workflow report that drove this).
