### PR TITLE
fix(dashboard): show the plan-checkpoint modal in the web UI (#832)

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -1219,6 +1219,23 @@ function AppInner({
     };
   }, [pendingRevision, broadcastDashboardEvent]);
 
+  useEffect(() => {
+    if (!pendingCheckpoint) return;
+    broadcastDashboardEvent({
+      kind: "modal-up",
+      modal: {
+        kind: "checkpoint",
+        stepId: pendingCheckpoint.stepId,
+        ...(pendingCheckpoint.title ? { title: pendingCheckpoint.title } : {}),
+        completed: pendingCheckpoint.completed,
+        total: pendingCheckpoint.total,
+      },
+    });
+    return () => {
+      broadcastDashboardEvent({ kind: "modal-down", modalKind: "checkpoint" });
+    };
+  }, [pendingCheckpoint, broadcastDashboardEvent]);
+
   // Three mutually-exclusive input-prefix pickers (slash name, @ file
   // mention, slash argument) — state + memos + commit callbacks live
   // in a dedicated hook so App.tsx only sees the small surface it
@@ -2003,6 +2020,15 @@ function AppInner({
                   ...(s.risk ? { risk: s.risk } : {}),
                 })),
                 ...(pendingRevision.summary ? { summary: pendingRevision.summary } : {}),
+              };
+            }
+            if (pendingCheckpoint) {
+              return {
+                kind: "checkpoint",
+                stepId: pendingCheckpoint.stepId,
+                ...(pendingCheckpoint.title ? { title: pendingCheckpoint.title } : {}),
+                completed: pendingCheckpoint.completed,
+                total: pendingCheckpoint.total,
               };
             }
             const picker = activePickerSnapshotRef.current;


### PR DESCRIPTION
## Summary

- Mirrors the plan-checkpoint pause to the dashboard the way plan / edit-review / revision modals already do. Adds the missing `useEffect` that broadcasts `modal-up` when `pendingCheckpoint` changes, and the missing branch in `getActiveModal` so a dashboard that connects mid-checkpoint replays the modal instead of starting blank.
- Everything else was already in place: `CheckpointModal` in the dashboard SPA, the `/api/modal/resolve` route accepting `kind: "checkpoint"`, and the `resolveCheckpointConfirm` resolver on App.tsx. The TUI was rendering the prompt because it reads `pendingCheckpoint` state directly; only the bridge to the web UI was missing.

## Test plan

- [x] `npx vitest run tests/` — 2857 passed / 3 skipped, 189 files clean
- [x] `tsc --noEmit` clean (typed against the existing `ActiveModal["checkpoint"]` variant)
- [x] Lint clean (one pre-existing unrelated warning)

Closes #832
