### PR TITLE
perf(desktop): memoize message list so historical messages skip re-renders (#844)

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -1028,6 +1028,18 @@ function TabRuntime({
     },
     [sendRpc],
   );
+  const onApproveConfirm = useCallback(
+    (id: number) => resolveConfirm(id, { type: "run_once" }),
+    [resolveConfirm],
+  );
+  const onRejectConfirm = useCallback(
+    (id: number) => resolveConfirm(id, { type: "deny" }),
+    [resolveConfirm],
+  );
+  const onAlwaysAllowConfirm = useCallback(
+    (id: number, prefix: string) => resolveConfirm(id, { type: "always_allow", prefix }),
+    [resolveConfirm],
+  );
   const resolvePathAccess = useCallback(
     (id: number, response: ConfirmationChoice) => {
       sendRpc({ cmd: "confirm_response", id, response });
@@ -1394,11 +1406,9 @@ function TabRuntime({
                           segments={m.segments}
                           pending={m.pending}
                           model={state.model}
-                          onApproveConfirm={(id) => resolveConfirm(id, { type: "run_once" })}
-                          onRejectConfirm={(id) => resolveConfirm(id, { type: "deny" })}
-                          onAlwaysAllowConfirm={(id, prefix) =>
-                            resolveConfirm(id, { type: "always_allow", prefix })
-                          }
+                          onApproveConfirm={onApproveConfirm}
+                          onRejectConfirm={onRejectConfirm}
+                          onAlwaysAllowConfirm={onAlwaysAllowConfirm}
                           pendingConfirms={state.pendingConfirms}
                         />
                       );

--- a/desktop/src/Markdown.tsx
+++ b/desktop/src/Markdown.tsx
@@ -6,6 +6,7 @@ import {
   cloneElement,
   createContext,
   isValidElement,
+  memo,
   type ReactNode,
   useContext,
   useState,
@@ -133,7 +134,7 @@ function withFilePills(children: ReactNode): ReactNode {
   });
 }
 
-export function Markdown({ source }: { source: string }) {
+export const Markdown = memo(function Markdown({ source }: { source: string }) {
   return (
     <div className="markdown">
       <ReactMarkdown
@@ -158,7 +159,7 @@ export function Markdown({ source }: { source: string }) {
       </ReactMarkdown>
     </div>
   );
-}
+});
 
 function SafeLink({ href, children }: { href?: string; children: ReactNode }) {
   const ctx = useContext(WorkspaceContext);

--- a/desktop/src/ui/cards.tsx
+++ b/desktop/src/ui/cards.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from "react";
+import { memo, useState, type ReactNode } from "react";
 import { I } from "../icons";
 import { Markdown } from "../Markdown";
 
@@ -672,10 +672,10 @@ export function Checkpoint({
 
 // ---- Plain text block (assistant content via markdown) ----
 
-export function AssistantText({ text }: { text: string }) {
+export const AssistantText = memo(function AssistantText({ text }: { text: string }) {
   return (
     <div className="msg-text">
       <Markdown source={text} />
     </div>
   );
-}
+});

--- a/desktop/src/ui/thread.tsx
+++ b/desktop/src/ui/thread.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { memo, type ReactNode } from "react";
 import { I } from "../icons";
 import type { AssistantSegment, ActivePlan, PendingPlan, PendingCheckpoint, PendingRevision, PendingConfirm, PendingChoice } from "../App";
 import { AssistantText, PlanCardView, ReasoningCard, ShellCard, ToolCard, type PlanItem } from "./cards";
@@ -13,7 +13,7 @@ export function TurnDivider({ label }: { label: string }) {
   );
 }
 
-export function UserMsg({ text, time }: { text: string; time?: string }) {
+export const UserMsg = memo(function UserMsg({ text, time }: { text: string; time?: string }) {
   return (
     <div className="msg user">
       <div className="avatar">YOU</div>
@@ -26,9 +26,9 @@ export function UserMsg({ text, time }: { text: string; time?: string }) {
       </div>
     </div>
   );
-}
+});
 
-export function AssistantMsg({
+export const AssistantMsg = memo(function AssistantMsg({
   segments,
   pending,
   model,
@@ -119,7 +119,7 @@ export function AssistantMsg({
       </div>
     </div>
   );
-}
+});
 
 function extractCommand(args: string): string | undefined {
   if (!args) return undefined;


### PR DESCRIPTION
## Summary

- Wraps `UserMsg` / `AssistantMsg` / `AssistantText` / `Markdown` (desktop) in `React.memo`. The desktop message list maps `state.messages` inline, so every streaming chunk previously re-ran `<ReactMarkdown>` + `remark-gfm` for every historical message — at 50+ turns and 60 tok/s that's ~3000 redundant markdown parses per second on text that hadn't changed.
- Hoists the three approval callbacks (`onApproveConfirm` / `onRejectConfirm` / `onAlwaysAllowConfirm`) out of the JSX call site and into stable `useCallback` refs. They were minted inline on every render, so the new memo's shallow compare would never have bitten without this.

## What this does NOT touch

The TUI (`src/cli/ui/cards/CardRenderer.tsx:26`) and the dashboard (`dashboard/src/components/chat-internals.ts:308`) already wrap their per-message components in memo — the comment on the dashboard one calls out this exact problem and the fix that landed for it. No changes there. If a separate scaling-with-length bottleneck shows up on those two surfaces, it gets its own issue.

## Test plan

- [x] `npx vitest run tests/` — 2857 passed / 3 skipped, 189 files clean
- [x] `tsc --noEmit` clean for root and desktop projects
- [x] `npm run lint` clean (one pre-existing unrelated warning)

Closes #844
Refs #843
