### PR TITLE
feat(cli): --profile flag records a V8 CPU profile for perf bug reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ desktop/src-tauri/binaries/
 
 # Design mock-up reference (local, not part of repo)
 .design-ref/
+*.cpuprofile

--- a/scripts/perf/analyze-cpu-prof.mjs
+++ b/scripts/perf/analyze-cpu-prof.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+
+const path = process.argv[2];
+if (!path) {
+  console.error("usage: analyze-cpu-prof.mjs <file.cpuprofile>");
+  process.exit(2);
+}
+
+const prof = JSON.parse(readFileSync(path, "utf8"));
+const nodes = prof.nodes;
+const samples = prof.samples;
+const deltas = prof.timeDeltas;
+
+const byId = new Map();
+for (const n of nodes) byId.set(n.id, n);
+
+const selfMicros = new Map();
+for (let i = 0; i < samples.length; i++) {
+  const id = samples[i];
+  const dt = deltas[i];
+  selfMicros.set(id, (selfMicros.get(id) ?? 0) + dt);
+}
+
+const totalMicros = new Map();
+const childOf = new Map();
+for (const n of nodes) {
+  for (const c of n.children ?? []) {
+    childOf.set(c, n.id);
+  }
+}
+
+function ancestors(id) {
+  const out = [];
+  let cur = id;
+  while (cur !== undefined) {
+    out.push(cur);
+    cur = childOf.get(cur);
+  }
+  return out;
+}
+
+for (const [leaf, micros] of selfMicros) {
+  for (const a of ancestors(leaf)) {
+    totalMicros.set(a, (totalMicros.get(a) ?? 0) + micros);
+  }
+}
+
+const totalRun = [...deltas].reduce((a, b) => a + b, 0);
+
+const IDLE_FNS = new Set(["(idle)", "(program)", "(garbage collector)"]);
+let activeMicros = 0;
+for (const [id, micros] of selfMicros) {
+  const n = byId.get(id);
+  if (!IDLE_FNS.has(n.callFrame.functionName)) activeMicros += micros;
+}
+
+const rows = [...totalMicros.entries()]
+  .map(([id, total]) => {
+    const n = byId.get(id);
+    const cf = n.callFrame;
+    const file = (cf.url || "").replace(/^file:\/\/\//, "").replace(/.*[\\/]/, "");
+    const fn = cf.functionName || "(anonymous)";
+    const self = selfMicros.get(id) ?? 0;
+    return {
+      id,
+      fn,
+      file: file ? `${file}:${cf.lineNumber + 1}` : "(native)",
+      url: cf.url || "",
+      total,
+      self,
+    };
+  })
+  .filter(
+    (r) =>
+      !/node:internal|node_modules[\\/]tsx|node_modules[\\/]esbuild/.test(r.url) &&
+      !IDLE_FNS.has(r.fn),
+  )
+  .sort((a, b) => b.total - a.total);
+
+const fmt = (us) =>
+  `${(us / 1000).toFixed(1).padStart(7)} ms (${((us / Math.max(1, activeMicros)) * 100).toFixed(1).padStart(4)}% active / ${((us / totalRun) * 100).toFixed(1).padStart(4)}% wall)`;
+
+console.log(
+  `Total wall: ${(totalRun / 1000).toFixed(0)} ms across ${samples.length} samples · active CPU: ${(activeMicros / 1000).toFixed(0)} ms · idle: ${((totalRun - activeMicros) / 1000).toFixed(0)} ms\n`,
+);
+
+console.log("Top 30 by inclusive time (excludes node-internal):");
+console.log("─".repeat(120));
+for (const r of rows.slice(0, 30)) {
+  console.log(`  ${fmt(r.total)} self=${fmt(r.self)}  ${r.fn.padEnd(40)} @ ${r.file}`);
+}
+
+console.log("\nTop 20 by self time:");
+console.log("─".repeat(120));
+const bySelf = [...selfMicros.entries()]
+  .map(([id, self]) => {
+    const n = byId.get(id);
+    const cf = n.callFrame;
+    const file = (cf.url || "").replace(/^file:\/\/\//, "").replace(/.*[\\/]/, "");
+    return {
+      fn: cf.functionName || "(anonymous)",
+      file: file ? `${file}:${cf.lineNumber + 1}` : "(native)",
+      url: cf.url || "",
+      self,
+    };
+  })
+  .filter(
+    (r) =>
+      !IDLE_FNS.has(r.fn) &&
+      !/node:internal|node_modules[\\/]tsx|node_modules[\\/]esbuild/.test(r.url),
+  )
+  .sort((a, b) => b.self - a.self);
+for (const r of bySelf.slice(0, 20)) {
+  console.log(`  ${fmt(r.self)}  ${r.fn.padEnd(40)} @ ${r.file}`);
+}

--- a/scripts/perf/profile-tui-streaming.tsx
+++ b/scripts/perf/profile-tui-streaming.tsx
@@ -1,0 +1,133 @@
+/**
+ * Profiling harness for the TUI render path during streaming.
+ *
+ * Mounts CardStream against a fake stdout, dispatches a realistic event
+ * stream (50 turns × user / tool / streaming chunks / tool result), and
+ * lets Node's --cpu-prof flag dump a .cpuprofile next to the script.
+ *
+ * Run: node --cpu-prof --cpu-prof-dir=. --import tsx scripts/perf/profile-tui-streaming.tsx
+ */
+
+import { render } from "ink";
+import React from "react";
+import { CardStream } from "../../src/cli/ui/layout/CardStream.js";
+import { ChatScrollProvider } from "../../src/cli/ui/state/chat-scroll-provider.js";
+import { AgentStoreProvider, useAgentStore } from "../../src/cli/ui/state/provider.js";
+import type { SessionInfo } from "../../src/cli/ui/state/state.js";
+import { makeFakeStdin, makeFakeStdout } from "../../tests/helpers/ink-stdio.js";
+
+const SESSION: SessionInfo = {
+  id: "perf",
+  branch: "main",
+  workspace: "/tmp/perf",
+  model: "deepseek-v4-flash",
+};
+
+const TURNS = 50;
+const CHUNKS_PER_TURN = 30;
+const CHUNK_CHARS = 18;
+
+const SAMPLE_REPLY_FRAGMENTS = [
+  "Looking at the call site, the ",
+  "function returns a Promise<Result> ",
+  "where Result is the union of Success and Failure. ",
+  "The Failure branch carries a `code` and a human message; ",
+  "downstream callers should switch on the code, not ",
+  "the message text. There's a related discussion in ",
+  "the architecture doc — section 3.2 covers the error contract. ",
+  "Want me to add a test that pins the shape? ",
+];
+
+function fragmentAt(i: number): string {
+  return SAMPLE_REPLY_FRAGMENTS[i % SAMPLE_REPLY_FRAGMENTS.length]!.slice(0, CHUNK_CHARS);
+}
+
+const tick = (): Promise<void> => new Promise((r) => setImmediate(r));
+
+function Driver({ done }: { done: () => void }): React.ReactElement {
+  const store = useAgentStore();
+  React.useEffect(() => {
+    let aborted = false;
+    const run = async () => {
+      const dispatch = store.dispatch;
+      const start = performance.now();
+      let dispatches = 0;
+      for (let t = 0; t < TURNS && !aborted; t++) {
+        dispatch({ type: "user.submit", text: `turn ${t}: explore the renderer hot path` } as never);
+        dispatches++;
+        await tick();
+        dispatch({ type: "turn.start", turnId: `t-${t}` } as never);
+        dispatch({
+          type: "tool.start",
+          id: `tool-${t}-r`,
+          name: "read_file",
+          args: { path: `src/file-${t}.ts` },
+        } as never);
+        dispatches += 2;
+        await tick();
+        dispatch({
+          type: "tool.end",
+          id: `tool-${t}-r`,
+          output: "ok",
+          elapsedMs: 12,
+        } as never);
+        dispatches++;
+        await tick();
+        dispatch({ type: "streaming.start", id: `s-${t}` } as never);
+        dispatches++;
+        await tick();
+        for (let c = 0; c < CHUNKS_PER_TURN && !aborted; c++) {
+          dispatch({ type: "streaming.chunk", id: `s-${t}`, text: fragmentAt(c) } as never);
+          dispatches++;
+          await tick();
+        }
+        dispatch({ type: "streaming.end", id: `s-${t}` } as never);
+        dispatch({
+          type: "turn.end",
+          usage: { prompt: 1000 + t * 50, reason: 0, output: 500, cacheHit: 0.85, cost: 0.0008 },
+          promptCap: 1_000_000,
+        } as never);
+        dispatches += 2;
+        await tick();
+      }
+      const elapsedMs = performance.now() - start;
+      process.stdout.write(
+        `[perf] ${dispatches} dispatches over ${elapsedMs.toFixed(1)}ms · ${(dispatches / (elapsedMs / 1000)).toFixed(0)} ev/s · ${(elapsedMs / dispatches).toFixed(2)} ms/ev\n`,
+      );
+      setTimeout(done, 50);
+    };
+    void run();
+    return () => {
+      aborted = true;
+    };
+  }, [store]);
+  return React.createElement(CardStream, null);
+}
+
+async function main(): Promise<void> {
+  const stdout = makeFakeStdout();
+  await new Promise<void>((resolve) => {
+    const { unmount } = render(
+      React.createElement(
+        AgentStoreProvider,
+        { session: SESSION },
+        React.createElement(
+          ChatScrollProvider,
+          null,
+          React.createElement(Driver, { done: () => resolve() }),
+        ),
+      ),
+      { stdout: stdout as never, stdin: makeFakeStdin() as never },
+    );
+    // unmount happens after `done()` resolves the outer promise.
+    void unmount;
+  });
+}
+
+main().then(
+  () => process.exit(0),
+  (e) => {
+    console.error(e);
+    process.exit(1);
+  },
+);

--- a/scripts/perf/profile-tui-sync.tsx
+++ b/scripts/perf/profile-tui-sync.tsx
@@ -1,0 +1,88 @@
+/**
+ * Synchronous variant of the TUI streaming profile: drives all dispatches
+ * in a single tick to expose the React reconciler + reducer cost without
+ * Ink's frame throttle. CPU profile dumps next to the script.
+ */
+
+import { render } from "ink";
+import React from "react";
+import { CardStream } from "../../src/cli/ui/layout/CardStream.js";
+import { ChatScrollProvider } from "../../src/cli/ui/state/chat-scroll-provider.js";
+import { AgentStoreProvider, useAgentStore } from "../../src/cli/ui/state/provider.js";
+import type { SessionInfo } from "../../src/cli/ui/state/state.js";
+import { makeFakeStdin, makeFakeStdout } from "../../tests/helpers/ink-stdio.js";
+
+const SESSION: SessionInfo = {
+  id: "perf",
+  branch: "main",
+  workspace: "/tmp/perf",
+  model: "deepseek-v4-flash",
+};
+
+const TURNS = 50;
+const CHUNKS_PER_TURN = 30;
+const CHUNK = "function returns Promise<Result> ";
+
+function Driver({ done }: { done: () => void }): React.ReactElement {
+  const store = useAgentStore();
+  React.useEffect(() => {
+    const dispatch = store.dispatch;
+    const start = performance.now();
+    let n = 0;
+    for (let t = 0; t < TURNS; t++) {
+      dispatch({ type: "user.submit", text: `turn ${t}` } as never);
+      dispatch({ type: "turn.start", turnId: `t-${t}` } as never);
+      dispatch({
+        type: "tool.start",
+        id: `tool-${t}`,
+        name: "read_file",
+        args: { path: `f-${t}.ts` },
+      } as never);
+      dispatch({ type: "tool.end", id: `tool-${t}`, output: "ok", elapsedMs: 12 } as never);
+      dispatch({ type: "streaming.start", id: `s-${t}` } as never);
+      for (let c = 0; c < CHUNKS_PER_TURN; c++) {
+        dispatch({ type: "streaming.chunk", id: `s-${t}`, text: CHUNK } as never);
+      }
+      dispatch({ type: "streaming.end", id: `s-${t}` } as never);
+      dispatch({
+        type: "turn.end",
+        usage: { prompt: 1000, reason: 0, output: 500, cacheHit: 0.85, cost: 0.001 },
+        promptCap: 1_000_000,
+      } as never);
+      n += 6 + CHUNKS_PER_TURN + 1;
+    }
+    const ms = performance.now() - start;
+    process.stdout.write(
+      `[perf-sync] ${n} dispatches in ${ms.toFixed(1)}ms · ${(n / (ms / 1000)).toFixed(0)} ev/s · ${(ms / n).toFixed(3)} ms/ev\n`,
+    );
+    setTimeout(done, 200);
+  }, [store]);
+  return React.createElement(CardStream, null);
+}
+
+async function main(): Promise<void> {
+  const stdout = makeFakeStdout();
+  await new Promise<void>((resolve) => {
+    const { unmount } = render(
+      React.createElement(
+        AgentStoreProvider,
+        { session: SESSION },
+        React.createElement(
+          ChatScrollProvider,
+          null,
+          React.createElement(Driver, { done: () => resolve() }),
+        ),
+      ),
+      { stdout: stdout as never, stdin: makeFakeStdin() as never },
+    );
+    void unmount;
+  });
+}
+
+main().then(
+  () => process.exit(0),
+  (e) => {
+    console.error(e);
+    process.exit(1);
+  },
+);

--- a/src/cli/cpu-prof.ts
+++ b/src/cli/cpu-prof.ts
@@ -1,0 +1,63 @@
+import { writeFileSync } from "node:fs";
+import { Session } from "node:inspector/promises";
+import { resolve } from "node:path";
+
+let session: Session | null = null;
+let outPath: string | null = null;
+let installed = false;
+let stopping = false;
+
+function defaultOutPath(): string {
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-").replace("Z", "");
+  return resolve(process.cwd(), `reasonix-cpu-${stamp}.cpuprofile`);
+}
+
+export async function startCpuProfile(pathArg?: string | true): Promise<string> {
+  if (session) return outPath ?? defaultOutPath();
+  outPath = typeof pathArg === "string" ? resolve(pathArg) : defaultOutPath();
+  session = new Session();
+  session.connect();
+  await session.post("Profiler.enable");
+  await session.post("Profiler.start");
+  process.stderr.write(`▸ cpu profile recording — will save to ${outPath} on exit\n`);
+  return outPath;
+}
+
+async function stopAndSave(): Promise<void> {
+  if (!session || !outPath || stopping) return;
+  stopping = true;
+  const s = session;
+  const out = outPath;
+  session = null;
+  try {
+    const { profile } = (await s.post("Profiler.stop")) as { profile: unknown };
+    writeFileSync(out, JSON.stringify(profile));
+    process.stderr.write(`▸ cpu profile saved → ${out}\n`);
+  } catch (e) {
+    process.stderr.write(`▲ cpu profile save failed: ${(e as Error).message}\n`);
+  } finally {
+    try {
+      s.disconnect();
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+export function installCpuProfileExitHandler(): void {
+  if (installed) return;
+  installed = true;
+  const onSignal = (sig: NodeJS.Signals) => {
+    void (async () => {
+      await stopAndSave();
+      process.exit(sig === "SIGINT" ? 130 : 0);
+    })();
+  };
+  for (const sig of ["SIGINT", "SIGTERM", "SIGHUP"] as const) {
+    process.on(sig, onSignal);
+  }
+  // beforeExit fires when the loop is empty — gives us one chance to await.
+  process.on("beforeExit", () => {
+    void stopAndSave();
+  });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6,8 +6,15 @@ import { listSessions } from "../memory/session.js";
 import { applyMemoryStack } from "../memory/user.js";
 import { installProxyIfConfigured } from "../net/proxy.js";
 import { escalationContract } from "../prompt-fragments.js";
+import { installCpuProfileExitHandler, startCpuProfile } from "./cpu-prof.js";
 import { resolveBareCommandMode, resolveContinueFlag, resolveDefaults } from "./resolve.js";
 import { markPhase } from "./startup-profile.js";
+
+async function maybeStartCpuProfile(flag: unknown): Promise<void> {
+  if (flag === undefined || flag === false) return;
+  installCpuProfileExitHandler();
+  await startCpuProfile(typeof flag === "string" ? flag : undefined);
+}
 
 // HTTPS_PROXY / HTTP_PROXY only reach Node's fetch via undici's global
 // dispatcher; install before any client (DeepSeek, web tools, dashboard)
@@ -185,7 +192,12 @@ program
   .option("--no-mouse", "disable SGR mouse tracking (keeps drag-select 100% native)")
   .option("--system-append <prompt>", t("ui.systemAppendHint"))
   .option("--system-append-file <path>", t("ui.systemAppendFileHint"))
+  .option(
+    "--profile [path]",
+    "record a V8 CPU profile; saved on exit. Send the .cpuprofile back if you're reporting a perf bug.",
+  )
   .action(async (dir: string | undefined, opts) => {
+    await maybeStartCpuProfile(opts.profile);
     const { codeCommand } = await import("./commands/code.js");
     await codeCommand({
       dir,
@@ -237,7 +249,12 @@ program
   .option("--dashboard-port <port>", t("ui.dashboardPortHint"))
   .option("--no-alt-screen", "keep chat output in shell scrollback (legacy mode, ghost-prone)")
   .option("--no-mouse", "disable SGR mouse tracking (keeps drag-select 100% native)")
+  .option(
+    "--profile [path]",
+    "record a V8 CPU profile; saved on exit. Send the .cpuprofile back if you're reporting a perf bug.",
+  )
   .action(async (opts) => {
+    await maybeStartCpuProfile(opts.profile);
     const defaults = resolveDefaults({
       model: opts.model,
       mcp: opts.mcp as string[],


### PR DESCRIPTION
## Summary

- Adds `--profile [path]` to `reasonix code` and `reasonix chat`. Starts a V8 CPU profile on launch via `node:inspector/promises`, saves the `.cpuprofile` to the given path (or cwd with a timestamped default name) when the process exits. Stops on SIGINT/SIGTERM/SIGHUP and on natural exit via `beforeExit`.
- Bundles two reusable harnesses + an analyzer under `scripts/perf/`:
  - `profile-tui-streaming.tsx` — throttled, mimics real streaming via the actual reducer + CardStream
  - `profile-tui-sync.tsx` — synchronous, exposes raw reducer + single-commit cost
  - `analyze-cpu-prof.mjs` — top-N self/total with idle and node-internal frames excluded
- `.cpuprofile` added to `.gitignore`.

## Why

Profiling on my box (50 turns × 30 chunks against a fake stdout) showed **98.6% idle / ~461 ms active CPU over 37 s wall** — meaning the reducer + React reconciler + Ink commit path is not CPU-bound. The "卡" in #843-style reports almost certainly lives in the terminal emulator's ANSI parse or a code path my synthetic harness doesn't exercise. We need real `.cpuprofile`s from the user's actual session to tell which.

Usage:

```
reasonix code --profile
# … reproduce the lag …
# Ctrl+C
# ▸ cpu profile saved → /cwd/reasonix-cpu-2026-05-14T….cpuprofile
```

Drop the file into Chrome DevTools → Performance → Load profile, or pipe it through `scripts/perf/analyze-cpu-prof.mjs`.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `npx vitest run tests/` — 2857 passed / 3 skipped, 189 files clean
- [x] `npm run lint` clean (one pre-existing unrelated warning)
- [x] Manual smoke: `node:inspector/promises` start → Profiler.stop → writeFileSync produces a valid `.cpuprofile` on Linux. Windows raw-TTY signal delivery is a known wrinkle but Ink's `exitOnCtrlC` already routes Ctrl+C through keypress, not SIGINT — `beforeExit` covers that path.

Refs #843.
