### PR TITLE
fix(cli): flush profile before useQuit's process.exit so --profile actually writes

### DIFF
--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -20,6 +20,7 @@ import { ToolRegistry } from "../../tools.js";
 import { registerChoiceTool } from "../../tools/choice.js";
 import { registerMemoryTools } from "../../tools/memory.js";
 import { registerWebTools } from "../../tools/web.js";
+import { stopAndSaveCpuProfile } from "../cpu-prof.js";
 import { markPhase } from "../startup-profile.js";
 import { App } from "../ui/App.js";
 import { SessionPicker } from "../ui/SessionPicker.js";
@@ -184,7 +185,10 @@ function Root({
               return;
             }
             if (outcome.kind === "quit") {
-              process.exit(0);
+              void (async () => {
+                await stopAndSaveCpuProfile();
+                process.exit(0);
+              })();
             }
           }}
         />

--- a/src/cli/cpu-prof.ts
+++ b/src/cli/cpu-prof.ts
@@ -1,10 +1,11 @@
 import { writeFileSync } from "node:fs";
 import { Session } from "node:inspector/promises";
 import { resolve } from "node:path";
+import { gzipSync } from "node:zlib";
 
 let session: Session | null = null;
 let outPath: string | null = null;
-let installed = false;
+let signalHandlerInstalled = false;
 let stopping = false;
 
 function defaultOutPath(): string {
@@ -20,19 +21,26 @@ export async function startCpuProfile(pathArg?: string | true): Promise<string> 
   await session.post("Profiler.enable");
   await session.post("Profiler.start");
   process.stderr.write(`▸ cpu profile recording — will save to ${outPath} on exit\n`);
+  installSignalHandler();
   return outPath;
 }
 
-async function stopAndSave(): Promise<void> {
+export async function stopAndSaveCpuProfile(): Promise<void> {
   if (!session || !outPath || stopping) return;
   stopping = true;
   const s = session;
-  const out = outPath;
+  const baseOut = outPath;
   session = null;
   try {
     const { profile } = (await s.post("Profiler.stop")) as { profile: unknown };
-    writeFileSync(out, JSON.stringify(profile));
-    process.stderr.write(`▸ cpu profile saved → ${out}\n`);
+    const json = JSON.stringify(profile);
+    const gz = gzipSync(json);
+    const gzPath = `${baseOut}.gz`;
+    writeFileSync(gzPath, gz);
+    const mb = (gz.length / (1024 * 1024)).toFixed(2);
+    process.stderr.write(
+      `▸ cpu profile saved → ${gzPath} (${mb} MB gzipped)\n  drag into a GitHub issue comment, or:\n  gh issue comment <N> --repo esengine/DeepSeek-Reasonix -F "${gzPath}"\n`,
+    );
   } catch (e) {
     process.stderr.write(`▲ cpu profile save failed: ${(e as Error).message}\n`);
   } finally {
@@ -44,20 +52,15 @@ async function stopAndSave(): Promise<void> {
   }
 }
 
-export function installCpuProfileExitHandler(): void {
-  if (installed) return;
-  installed = true;
-  const onSignal = (sig: NodeJS.Signals) => {
-    void (async () => {
-      await stopAndSave();
-      process.exit(sig === "SIGINT" ? 130 : 0);
-    })();
-  };
+function installSignalHandler(): void {
+  if (signalHandlerInstalled) return;
+  signalHandlerInstalled = true;
   for (const sig of ["SIGINT", "SIGTERM", "SIGHUP"] as const) {
-    process.on(sig, onSignal);
+    process.on(sig, () => {
+      void (async () => {
+        await stopAndSaveCpuProfile();
+        process.exit(sig === "SIGINT" ? 130 : 0);
+      })();
+    });
   }
-  // beforeExit fires when the loop is empty — gives us one chance to await.
-  process.on("beforeExit", () => {
-    void stopAndSave();
-  });
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6,14 +6,14 @@ import { listSessions } from "../memory/session.js";
 import { applyMemoryStack } from "../memory/user.js";
 import { installProxyIfConfigured } from "../net/proxy.js";
 import { escalationContract } from "../prompt-fragments.js";
-import { installCpuProfileExitHandler, startCpuProfile } from "./cpu-prof.js";
+import { startCpuProfile, stopAndSaveCpuProfile } from "./cpu-prof.js";
 import { resolveBareCommandMode, resolveContinueFlag, resolveDefaults } from "./resolve.js";
 import { markPhase } from "./startup-profile.js";
 
-async function maybeStartCpuProfile(flag: unknown): Promise<void> {
-  if (flag === undefined || flag === false) return;
-  installCpuProfileExitHandler();
+async function maybeStartCpuProfile(flag: unknown): Promise<boolean> {
+  if (flag === undefined || flag === false) return false;
   await startCpuProfile(typeof flag === "string" ? flag : undefined);
+  return true;
 }
 
 // HTTPS_PROXY / HTTP_PROXY only reach Node's fetch via undici's global
@@ -197,25 +197,32 @@ program
     "record a V8 CPU profile; saved on exit. Send the .cpuprofile back if you're reporting a perf bug.",
   )
   .action(async (dir: string | undefined, opts) => {
-    await maybeStartCpuProfile(opts.profile);
-    const { codeCommand } = await import("./commands/code.js");
-    await codeCommand({
-      dir,
-      model: opts.model,
-      noSession: opts.session === false,
-      transcript: opts.transcript,
-      forceResume: !!opts.resume,
-      forceNew: !!opts.new,
-      budgetUsd: parseBudgetFlag(opts.budget),
-      failureThreshold: resolveFailureThreshold(parseEscalateAfterFlag(opts.escalateAfter), false),
-      noDashboard: opts.dashboard === false,
-      openDashboard: opts.openDashboard === true,
-      dashboardPort: resolveDashboardPort(parseDashboardPortFlag(opts.dashboardPort), false),
-      systemAppend: opts.systemAppend,
-      systemAppendFile: opts.systemAppendFile,
-      altScreen: opts.altScreen !== false,
-      mouse: opts.mouse !== false,
-    });
+    const profiling = await maybeStartCpuProfile(opts.profile);
+    try {
+      const { codeCommand } = await import("./commands/code.js");
+      await codeCommand({
+        dir,
+        model: opts.model,
+        noSession: opts.session === false,
+        transcript: opts.transcript,
+        forceResume: !!opts.resume,
+        forceNew: !!opts.new,
+        budgetUsd: parseBudgetFlag(opts.budget),
+        failureThreshold: resolveFailureThreshold(
+          parseEscalateAfterFlag(opts.escalateAfter),
+          false,
+        ),
+        noDashboard: opts.dashboard === false,
+        openDashboard: opts.openDashboard === true,
+        dashboardPort: resolveDashboardPort(parseDashboardPortFlag(opts.dashboardPort), false),
+        systemAppend: opts.systemAppend,
+        systemAppendFile: opts.systemAppendFile,
+        altScreen: opts.altScreen !== false,
+        mouse: opts.mouse !== false,
+      });
+    } finally {
+      if (profiling) await stopAndSaveCpuProfile();
+    }
   });
 
 program
@@ -254,54 +261,58 @@ program
     "record a V8 CPU profile; saved on exit. Send the .cpuprofile back if you're reporting a perf bug.",
   )
   .action(async (opts) => {
-    await maybeStartCpuProfile(opts.profile);
-    const defaults = resolveDefaults({
-      model: opts.model,
-      mcp: opts.mcp as string[],
-      session: opts.session,
-      preset: opts.preset,
-      noConfig: opts.config === false,
-    });
-    // `-c` is "newest-touched session" + auto-resume; `-r` is "this
-    // session's prior messages, even if you also passed --session".
-    // When both are set we prefer the explicit `--session` + `-r`
-    // (more specific input wins). `-c` only kicks in if `-r` wasn't.
-    const continueOpts = opts.resume
-      ? { session: defaults.session, forceResume: true }
-      : resolveContinueFlag(
-          opts.continue,
-          defaults.session,
-          () => listSessions()[0],
-          (msg) => process.stderr.write(`${msg}\n`),
-        );
-    const { chatCommand } = await import("./commands/chat.js");
-    const chatBase = opts.system ?? defaultSystemPrompt(defaults.model);
-    const chatCwd = process.cwd();
-    const chatRebuildSystem = () => applyMemoryStack(chatBase, chatCwd);
-    await chatCommand({
-      model: defaults.model,
-      system: chatRebuildSystem(),
-      rebuildSystem: chatRebuildSystem,
-      transcript: opts.transcript,
-      budgetUsd: parseBudgetFlag(opts.budget),
-      failureThreshold: resolveFailureThreshold(
-        parseEscalateAfterFlag(opts.escalateAfter),
-        opts.config === false,
-      ),
-      session: continueOpts.session,
-      mcp: defaults.mcp,
-      mcpPrefix: opts.mcpPrefix,
-      forceResume: continueOpts.forceResume,
-      forceNew: !!opts.new,
-      noDashboard: opts.dashboard === false,
-      openDashboard: opts.openDashboard === true,
-      dashboardPort: resolveDashboardPort(
-        parseDashboardPortFlag(opts.dashboardPort),
-        opts.config === false,
-      ),
-      altScreen: opts.altScreen !== false,
-      mouse: opts.mouse !== false,
-    });
+    const profiling = await maybeStartCpuProfile(opts.profile);
+    try {
+      const defaults = resolveDefaults({
+        model: opts.model,
+        mcp: opts.mcp as string[],
+        session: opts.session,
+        preset: opts.preset,
+        noConfig: opts.config === false,
+      });
+      // `-c` is "newest-touched session" + auto-resume; `-r` is "this
+      // session's prior messages, even if you also passed --session".
+      // When both are set we prefer the explicit `--session` + `-r`
+      // (more specific input wins). `-c` only kicks in if `-r` wasn't.
+      const continueOpts = opts.resume
+        ? { session: defaults.session, forceResume: true }
+        : resolveContinueFlag(
+            opts.continue,
+            defaults.session,
+            () => listSessions()[0],
+            (msg) => process.stderr.write(`${msg}\n`),
+          );
+      const { chatCommand } = await import("./commands/chat.js");
+      const chatBase = opts.system ?? defaultSystemPrompt(defaults.model);
+      const chatCwd = process.cwd();
+      const chatRebuildSystem = () => applyMemoryStack(chatBase, chatCwd);
+      await chatCommand({
+        model: defaults.model,
+        system: chatRebuildSystem(),
+        rebuildSystem: chatRebuildSystem,
+        transcript: opts.transcript,
+        budgetUsd: parseBudgetFlag(opts.budget),
+        failureThreshold: resolveFailureThreshold(
+          parseEscalateAfterFlag(opts.escalateAfter),
+          opts.config === false,
+        ),
+        session: continueOpts.session,
+        mcp: defaults.mcp,
+        mcpPrefix: opts.mcpPrefix,
+        forceResume: continueOpts.forceResume,
+        forceNew: !!opts.new,
+        noDashboard: opts.dashboard === false,
+        openDashboard: opts.openDashboard === true,
+        dashboardPort: resolveDashboardPort(
+          parseDashboardPortFlag(opts.dashboardPort),
+          opts.config === false,
+        ),
+        altScreen: opts.altScreen !== false,
+        mouse: opts.mouse !== false,
+      });
+    } finally {
+      if (profiling) await stopAndSaveCpuProfile();
+    }
   });
 
 program

--- a/src/cli/ui/hooks/useQuit.ts
+++ b/src/cli/ui/hooks/useQuit.ts
@@ -1,11 +1,15 @@
 import type { WriteStream } from "node:fs";
 import { type MutableRefObject, useCallback, useEffect } from "react";
+import { stopAndSaveCpuProfile } from "../../cpu-prof.js";
 
-/** Ctrl+C / SIGINT → flush transcript + `process.exit(0)`. We call `process.exit` directly rather than Ink's `exit()` because the singleton stdin reader keeps a `data` listener attached — `exit()` would unmount the React tree but leave the event loop alive and the terminal would hang. */
+/** Ctrl+C / SIGINT → flush transcript + (if profiling) save .cpuprofile, then `process.exit(0)`. We call `process.exit` directly rather than Ink's `exit()` because the singleton stdin reader keeps a `data` listener attached — `exit()` would unmount the React tree but leave the event loop alive and the terminal would hang. */
 export function useQuit(transcriptRef: MutableRefObject<WriteStream | null>): () => void {
   const quitProcess = useCallback(() => {
     transcriptRef.current?.end();
-    process.exit(0);
+    void (async () => {
+      await stopAndSaveCpuProfile();
+      process.exit(0);
+    })();
   }, [transcriptRef]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

PR #846 set up `--profile` but no `.cpuprofile` ever landed on Ctrl+C from `reasonix code`. The root cause was deeper than the commander-action try/finally I tried in the first pass:

The TUI's `useQuit` calls `process.exit(0)` **directly** (intentionally — the singleton stdin reader otherwise hangs the terminal, see `src/cli/ui/hooks/useQuit.ts`). That skips the whole await chain — `waitUntilExit()` never resolves, the action's `finally` never runs, V8's profile buffer is dropped on the floor.

## Fix

Hook the stop+save into the two TUI quit paths that call `process.exit` directly:

- `src/cli/ui/hooks/useQuit.ts` — the Ctrl+C / SIGINT path. Awaits `stopAndSaveCpuProfile()` before `process.exit(0)`.
- `src/cli/commands/chat.tsx:187` — session-picker quit. Same shape.

`stopAndSaveCpuProfile()` is a no-op when `--profile` isn't active, so the TUI's normal quit path stays unchanged.

Also picks up the gzip + drop-into-GitHub instructions from the earlier in-flight branch.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `npx vitest run tests/` — 2857 passed / 3 skipped
- [x] `npm run lint` clean
- [ ] Live: `reasonix code --profile`, Ctrl+C, file appears with the "saved → …" line

Refs #843.
