### PR TITLE
docs: render CLI reference and architecture pages in-site

### DIFF
--- a/docs/arch-i18n.js
+++ b/docs/arch-i18n.js
@@ -1,0 +1,294 @@
+/* Architecture page translations + scrollspy. Layered on top of i18n.js. */
+
+(function () {
+  "use strict";
+
+  var R = window.Reasonix;
+  if (!R) return;
+
+  var en = {
+    "arch.badge": "Cache · Repair · Cost · Modules",
+    "arch.title.line1": "Reasonix Architecture",
+    "arch.title.line2": "how it works under the hood",
+    "arch.sub":
+      "Reasonix is <strong>opinionated, not general</strong>. Every abstraction is justified by a DeepSeek-specific behavior or economic property. The product north star: a coding agent that stays cheap enough to leave on.",
+
+    "arch.toc.title": "On this page",
+    "arch.toc.philosophy": "Design philosophy",
+    "arch.toc.pillar1": "Pillar 1 — Cache",
+    "arch.toc.pillar2": "Pillar 2 — Repair",
+    "arch.toc.pillar3": "Pillar 3 — Cost",
+    "arch.toc.modules": "Module layout",
+    "arch.toc.evolution": "Design evolution",
+    "arch.toc.nongoals": "Non-goals",
+
+    "th.var": "Env var",
+    "th.default": "Default",
+    "th.effect": "Effect",
+    "th.preset": "Preset",
+    "th.model": "Model",
+    "th.effort": "Effort",
+    "th.cost": "Cost",
+
+    "ph.title": "Design philosophy",
+    "ph.body1":
+      "Reasonix is <strong>opinionated, not general</strong>. Every abstraction is justified by a DeepSeek-specific behavior or economic property. If it's generic, we don't ship it.",
+    "ph.body2":
+      "The product north star: <strong>coding agent that stays cheap enough to leave on</strong>. A tool that quietly burns $200/month on a background project is one nobody uses. Every subsystem below is answerable to that goal.",
+
+    "p1.title": "Pillar 1 — Cache-First Loop",
+    "p1.problem":
+      "<strong>Problem.</strong> DeepSeek bills cached input at ~10% of the miss rate. Automatic prefix caching activates only when the <em>exact</em> byte prefix of the previous request matches. Most agent loops reorder, rewrite, or inject fresh timestamps each turn — cache hit rate in practice: &lt;20%.",
+    "p1.solution":
+      "<strong>Solution.</strong> Partition the context into three regions:",
+    "p1.inv.title": "Invariants:",
+    "p1.inv1": "Prefix is computed once per session, hashed, and pinned.",
+    "p1.inv2": "Log entries are serialized in append order; no rewrites.",
+    "p1.inv3":
+      "Scratch is distilled via Pillar 2 before any information from it is folded into the log.",
+    "p1.metric":
+      "<strong>Metric.</strong> <code>prompt_cache_hit_tokens / (hit + miss)</code> exposed per-turn and aggregated per-session. Visible in the TUI's top-bar cache cell.",
+    "p1.h.parallel": "Parallel tool dispatch",
+    "p1.parallel.body":
+      "Each tool declares <code>parallelSafe?: boolean</code> (default <code>false</code>). The loop dispatcher groups consecutive parallel-safe calls into chunks and races them via <code>Promise.allSettled</code>; the first non-parallel-safe call ends the chunk and runs alone (serial barrier — read-after-write order preserved). Tool-result yields and history append still land in declared order regardless of which call settles first, so the model sees the same shape it would under a fully serial dispatch.",
+    "p1.parallel.optins":
+      "Built-in opt-ins: read-only filesystem (<code>read_file</code>, <code>list_directory</code>, <code>directory_tree</code>, <code>search_files</code>, <code>search_content</code>, <code>get_file_info</code>), web (<code>web_search</code>, <code>web_fetch</code>), <code>recall_memory</code>, <code>semantic_search</code>, isolated child loops (<code>run_skill</code>, <code>spawn_subagent</code>), in-memory job queries (<code>job_output</code>, <code>list_jobs</code>). Mutating / side-effecting tools stay default. MCP-bridged tools default <code>false</code> — third-party tools opt in only when the server explicitly declares parallel safety.",
+
+    "p2.title": "Pillar 2 — Tool-Call Repair",
+    "p2.problem": "<strong>Problem.</strong> Empirical DeepSeek failure modes:",
+    "p2.fm1":
+      "Tool-call JSON emitted inside <code>&lt;think&gt;</code>, missing from the final message.",
+    "p2.fm2":
+      "Arguments dropped when schema has &gt;10 params or deeply nested objects.",
+    "p2.fm3": "Same tool called repeatedly with identical args (call-storm).",
+    "p2.fm4":
+      "Truncated JSON due to <code>max_tokens</code> hit mid-structure.",
+    "p2.solution": "<strong>Solution.</strong> Four passes:",
+    "p2.pass1":
+      "<strong><code>flatten</code></strong> — schemas with &gt;10 leaf params or depth &gt;2 are auto-detected on <code>ToolRegistry.register()</code> and presented to the model in dot-notation form. <code>dispatch()</code> re-nests the args before calling the user's <code>fn</code>.",
+    "p2.pass2":
+      "<strong><code>scavenge</code></strong> — regex + JSON parser sweeps <code>reasoning_content</code> for any tool call the model forgot to emit in <code>tool_calls</code>.",
+    "p2.pass3":
+      "<strong><code>truncation</code></strong> — detect unbalanced JSON and repair by closing braces or requesting a continuation completion.",
+    "p2.pass4":
+      "<strong><code>storm</code></strong> — identical <code>(tool, args)</code> tuple within a sliding window → suppress the call, inject a reflection turn.",
+
+    "p3.title": "Pillar 3 — Cost Control (v0.6)",
+    "p3.problem":
+      "<strong>Problem.</strong> Coding agents that default to the frontier model (v4-pro, ~12× flash cost) and accumulate full tool results in context are $150–$250/month for active users. Most turns don't need frontier reasoning; most sessions re-pay for tool results that were only useful once.",
+    "p3.solution":
+      "<strong>Solution.</strong> Four complementary mechanisms, none of which require manual tuning in the common case:",
+    "p3.h.tiers": "4.1 Tiered defaults (flash-first)",
+    "p3.tiers.body":
+      "The three presets trade <strong>model tier</strong> and <strong>reasoning effort</strong>:",
+    "p3.tiers.aux":
+      "All auxiliary calls — <code>forceSummaryAfterIterLimit</code>, subagent spawns, truncation repair retries — hard-code <code>v4-flash + effort=high</code> regardless of the user's preset. There's no reason to pay pro rates for paraphrasing tool results or for an <code>explore</code> subagent's grep chain.",
+    "p3.h.compact": "4.2 Turn-end auto-compaction",
+    "p3.compact.body":
+      "Every tool result in the log exceeding <code>TURN_END_RESULT_CAP_TOKENS</code> (3000) is shrunk to that cap when a turn ends. The model had the full text for the turn that read it; subsequent turns see a compact summary and can re-read if needed. One extra <code>read_file</code> call is vastly cheaper than dragging 12 KB through every future prompt.",
+    "p3.compact.proactive":
+      "A proactive 40% context-ratio threshold runs the same shrink pre-emptively inside long multi-iter turns before the 80% emergency threshold fires.",
+    "p3.h.pro": "4.3 /pro single-turn arming",
+    "p3.pro.body":
+      "Users who predict a hard task type <code>/pro</code>; the <strong>next</strong> turn runs on <code>v4-pro</code>, then auto-disarms. No preset churn, no forgotten revert. Armed state is visible as a yellow <code>⇧ pro armed</code> pill in the header.",
+    "p3.h.escalation": "4.4 Failure-signal auto-escalation",
+    "p3.esc.body":
+      "The loop counts visible "flash is struggling" events per turn:",
+    "p3.esc.e1":
+      "<code>edit_file</code> / <code>write_file</code> SEARCH-not-found errors",
+    "p3.esc.e2":
+      "ToolCallRepair fires (scavenge / truncation-fix / storm-break)",
+    "p3.esc.threshold":
+      "Once the count hits <code>FAILURE_ESCALATION_THRESHOLD</code> (3), the <strong>remainder of the current turn</strong> runs on <code>v4-pro</code>. Announced via a yellow warning row — no silent cost surprises. Counter + escalation flag reset at every turn start.",
+    "p3.esc.pill":
+      "Header shows a red <code>⇧ pro escalated</code> pill while the turn is on pro.",
+    "p3.h.transparency": "Cost transparency",
+    "p3.trans.body":
+      "Per-turn and session cost are colored in the StatsPanel:",
+    "p3.trans.turn":
+      "<code>turn $0.003</code> — green &lt;$0.05, yellow $0.05–0.20, red ≥$0.20",
+    "p3.trans.session": "<code>session $0.12</code> — same scale ×10",
+
+    "mod.title": "Module layout",
+    "mod.note":
+      "Files kept small by design: the largest module under <code>cli/ui/</code> is 2K lines (App.tsx), every handler under <code>slash/handlers/</code> is ≤200 lines, every hook under <code>cli/ui/</code> is ≤310 lines. Adding a new slash command means editing one handler file and one registry line.",
+
+    "evo.title": "Design evolution",
+
+    "ng.title": "Explicit non-goals",
+    "ng.item1":
+      "Multi-agent orchestration as a first-class concept (subagents are a cost-reduction mechanism, not a coordination primitive).",
+    "ng.item2": "RAG / vector retrieval.",
+    "ng.item3":
+      "Support for non-DeepSeek backends (an OpenAI-compatible shim would work today via <code>--model</code> override, but is not tested).",
+    "ng.item4": "Web UI / SaaS.",
+    "ng.item5":
+      "Automatic cost escalation without user-visible announcement. Every pro-tier model call is surfaced; silent escalation was considered and rejected.",
+  };
+
+  var zh = {
+    "arch.badge": "缓存 · 修复 · 成本 · 模块",
+    "arch.title.line1": "Reasonix 架构",
+    "arch.title.line2": "底层原理详解",
+    "arch.sub":
+      "Reasonix <strong>有明确取舍，不追求通用</strong>。每一个抽象都有对应的 DeepSeek 特有行为或经济特性作为依据。产品北极星：一个便宜到可以一直挂着跑的编程 Agent。",
+
+    "arch.toc.title": "本页目录",
+    "arch.toc.philosophy": "设计哲学",
+    "arch.toc.pillar1": "支柱一 — 缓存优先循环",
+    "arch.toc.pillar2": "支柱二 — 工具调用修复",
+    "arch.toc.pillar3": "支柱三 — 成本控制",
+    "arch.toc.modules": "模块布局",
+    "arch.toc.evolution": "设计演进",
+    "arch.toc.nongoals": "明确不做的事",
+
+    "th.var": "环境变量",
+    "th.default": "默认值",
+    "th.effect": "效果",
+    "th.preset": "预设",
+    "th.model": "模型",
+    "th.effort": "推理力度",
+    "th.cost": "费用",
+
+    "ph.title": "设计哲学",
+    "ph.body1":
+      "Reasonix <strong>有明确取舍，不追求通用</strong>。每一个抽象都有对应的 DeepSeek 特有行为或经济特性作为依据。不通用的，就不加进来。",
+    "ph.body2":
+      "产品北极星：<strong>便宜到可以一直挂着跑的编程 Agent</strong>。一个在后台项目上悄悄烧掉 $200/月的工具没人会用。以下每一个子系统都要对这个目标负责。",
+
+    "p1.title": "支柱一 — 缓存优先循环",
+    "p1.problem":
+      "<strong>问题。</strong>DeepSeek 对命中缓存的输入 token 只收约 10% 的费用。自动前缀缓存只在<em>字节级完全匹配</em>上一次请求的前缀时才激活。大多数 agent 循环每轮都会重排、改写或注入新时间戳——实际缓存命中率：&lt;20%。",
+    "p1.solution":
+      "<strong>解决方案。</strong>把上下文分成三个区域：",
+    "p1.inv.title": "不变量：",
+    "p1.inv1": "前缀在每个 session 开始时计算一次，哈希后钉住。",
+    "p1.inv2": "日志条目按追加顺序序列化，不允许改写。",
+    "p1.inv3":
+      "Scratch 中的信息先经过支柱二蒸馏，再折叠进日志。",
+    "p1.metric":
+      "<strong>指标。</strong><code>prompt_cache_hit_tokens / (hit + miss)</code> 每轮暴露并按 session 聚合，显示在 TUI 顶栏的缓存格。",
+    "p1.h.parallel": "并行工具调度",
+    "p1.parallel.body":
+      "每个工具声明 <code>parallelSafe?: boolean</code>（默认 <code>false</code>）。循环调度器把连续的可并行调用打成一批，通过 <code>Promise.allSettled</code> 并发执行；第一个不可并行的调用截断当前批次并单独串行执行（串行屏障——保证读后写顺序）。工具结果 yield 和历史追加仍按声明顺序落入，模型看到的形状与完全串行一致。",
+    "p1.parallel.optins":
+      "内置并行安全工具：只读文件系统（<code>read_file</code>、<code>list_directory</code>、<code>directory_tree</code>、<code>search_files</code>、<code>search_content</code>、<code>get_file_info</code>）、Web（<code>web_search</code>、<code>web_fetch</code>）、<code>recall_memory</code>、<code>semantic_search</code>、隔离子循环（<code>run_skill</code>、<code>spawn_subagent</code>）、内存中任务查询（<code>job_output</code>、<code>list_jobs</code>）。有副作用的工具保持默认 false。MCP 桥接工具默认 false——第三方工具只有服务端明确声明并行安全时才可选入。",
+
+    "p2.title": "支柱二 — 工具调用修复",
+    "p2.problem": "<strong>问题。</strong>DeepSeek 实测失败模式：",
+    "p2.fm1":
+      "工具调用 JSON 被包在 <code>&lt;think&gt;</code> 里，没有出现在 final message。",
+    "p2.fm2":
+      "schema 有 &gt;10 个参数或深层嵌套时参数被丢弃。",
+    "p2.fm3": "用相同参数重复调用同一工具（调用风暴）。",
+    "p2.fm4":
+      "因 <code>max_tokens</code> 在 JSON 结构中间截断导致 JSON 不完整。",
+    "p2.solution": "<strong>解决方案。</strong>四个修复 pass：",
+    "p2.pass1":
+      "<strong><code>flatten</code></strong> — 超过 10 个叶节点参数或嵌套深度 &gt;2 的 schema 在 <code>ToolRegistry.register()</code> 时自动检测，以点记法平铺展示给模型。<code>dispatch()</code> 在调用用户 <code>fn</code> 前重新嵌套参数。",
+    "p2.pass2":
+      "<strong><code>scavenge</code></strong> — 用正则 + JSON 解析器扫描 <code>reasoning_content</code>，捞回模型忘记放进 <code>tool_calls</code> 的工具调用。",
+    "p2.pass3":
+      "<strong><code>truncation</code></strong> — 检测不平衡 JSON，通过补全括号或请求续写来修复。",
+    "p2.pass4":
+      "<strong><code>storm</code></strong> — 滑动窗口内出现相同 <code>(tool, args)</code> 元组时压制该调用并注入反思轮。",
+
+    "p3.title": "支柱三 — 成本控制（v0.6）",
+    "p3.problem":
+      "<strong>问题。</strong>默认使用旗舰模型（v4-pro，约 12× flash 成本）并在上下文中积累完整工具结果的编程 agent，活跃用户每月 $150–$250。大多数轮次不需要旗舰推理；大多数 session 都在重复支付只用了一次的工具结果。",
+    "p3.solution":
+      "<strong>解决方案。</strong>四个互补机制，常规场景下无需手动调整：",
+    "p3.h.tiers": "4.1 分层默认（flash 优先）",
+    "p3.tiers.body":
+      "三个预设在<strong>模型层级</strong>和<strong>推理力度</strong>之间做权衡：",
+    "p3.tiers.aux":
+      "所有辅助调用——<code>forceSummaryAfterIterLimit</code>、subagent 派生、截断修复重试——无论用户预设如何，均硬编码为 <code>v4-flash + effort=high</code>。没有理由以 pro 价格来"把工具结果改写成散文"或跑 <code>explore</code> subagent 的 grep 链。",
+    "p3.h.compact": "4.2 轮末自动压缩",
+    "p3.compact.body":
+      "每轮结束时，日志中超过 <code>TURN_END_RESULT_CAP_TOKENS</code>（3000）的工具结果会被压缩到该上限。读它的那一轮模型拿到了完整文本；后续轮次看到的是紧凑摘要，需要时可以重新读取。多一次 <code>read_file</code> 调用远比每次 prompt 都拖 12 KB 便宜。",
+    "p3.compact.proactive":
+      "当上下文占比达到 40% 时会主动提前触发相同压缩，而不是等到 80% 的紧急阈值才处理。",
+    "p3.h.pro": "4.3 /pro 单轮唤醒",
+    "p3.pro.body":
+      "预判当前任务较难时输入 <code>/pro</code>；<strong>下一轮</strong>在 <code>v4-pro</code> 上运行，随后自动解除。无需反复切预设，不会忘记还原。标头会显示黄色 <code>⇧ pro armed</code> 标签。",
+    "p3.h.escalation": "4.4 失败信号自动升级",
+    "p3.esc.body":
+      "循环统计每轮的"flash 在挣扎"事件：",
+    "p3.esc.e1":
+      "<code>edit_file</code> / <code>write_file</code> 的 SEARCH-not-found 错误",
+    "p3.esc.e2":
+      "ToolCallRepair 触发（scavenge / truncation-fix / storm-break）",
+    "p3.esc.threshold":
+      "计数达到 <code>FAILURE_ESCALATION_THRESHOLD</code>（3）后，<strong>当前轮的剩余部分</strong>切换到 <code>v4-pro</code>，并通过黄色警告行通知用户——不会有静默涨费。计数器和升级标志在每轮开始时重置。",
+    "p3.esc.pill":
+      "该轮在 pro 上运行时，标头显示红色 <code>⇧ pro escalated</code> 标签。",
+    "p3.h.transparency": "成本透明度",
+    "p3.trans.body":
+      "StatsPanel 中按颜色显示每轮和 session 成本：",
+    "p3.trans.turn":
+      "<code>turn $0.003</code> — 绿色 &lt;$0.05，黄色 $0.05–0.20，红色 ≥$0.20",
+    "p3.trans.session": "<code>session $0.12</code> — 同比例 ×10",
+
+    "mod.title": "模块布局",
+    "mod.note":
+      "文件故意保持精简：<code>cli/ui/</code> 下最大的模块是 2K 行（App.tsx），<code>slash/handlers/</code> 下每个 handler ≤200 行，<code>cli/ui/</code> 下每个 hook ≤310 行。新增斜杠命令只需改一个 handler 文件和一行注册。",
+
+    "evo.title": "设计演进",
+
+    "ng.title": "明确不做的事",
+    "ng.item1":
+      "把多 agent 编排作为一等概念（subagent 是成本削减机制，不是协调原语）。",
+    "ng.item2": "RAG / 向量检索。",
+    "ng.item3":
+      "支持非 DeepSeek 后端（通过 <code>--model</code> 覆盖使用 OpenAI 兼容 shim 今天能跑，但不做测试保障）。",
+    "ng.item4": "Web UI / SaaS。",
+    "ng.item5":
+      "不经用户可见通知的自动成本升级。每一次 pro 级模型调用都会明示；静默升级方案讨论过，被否决。",
+  };
+
+  var DICT = { en: en, zh: zh };
+
+  function applyArch(lang) {
+    var dict = DICT[lang] || DICT.en;
+    document.querySelectorAll("[data-i18n]").forEach(function (el) {
+      var key = el.getAttribute("data-i18n");
+      if (dict[key] !== undefined) el.innerHTML = dict[key];
+    });
+  }
+
+  applyArch(R.lang());
+  R.onLangChange(applyArch);
+
+  var sections = Array.prototype.slice.call(
+    document.querySelectorAll(".guide-body section[id]"),
+  );
+  var tocLinks = Array.prototype.slice.call(
+    document.querySelectorAll(".guide-toc a"),
+  );
+  if (sections.length && tocLinks.length && "IntersectionObserver" in window) {
+    var byId = {};
+    tocLinks.forEach(function (a) {
+      var href = a.getAttribute("href") || "";
+      var id = href.replace(/^#/, "");
+      if (id) byId[id] = a;
+    });
+    var io = new IntersectionObserver(
+      function (entries) {
+        entries.forEach(function (e) {
+          var link = byId[e.target.id];
+          if (!link) return;
+          if (e.isIntersecting) {
+            tocLinks.forEach(function (l) {
+              l.classList.remove("is-active");
+            });
+            link.classList.add("is-active");
+          }
+        });
+      },
+      { rootMargin: "-30% 0px -60% 0px", threshold: 0 },
+    );
+    sections.forEach(function (s) {
+      io.observe(s);
+    });
+  }
+})();

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -1,0 +1,572 @@
+<!doctype html>
+<html lang="en" data-lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Architecture — Reasonix · Cache-First Loop, Tool-Call Repair, Cost Control</title>
+    <meta
+      name="description"
+      content="Reasonix architecture deep dive — cache-first loop, tool-call repair pipeline, cost control, and module layout."
+    />
+    <meta
+      name="keywords"
+      content="Reasonix architecture, cache-first loop, tool-call repair, DeepSeek cost control, prefix caching, agent architecture"
+    />
+    <meta name="author" content="esengine" />
+    <meta name="theme-color" content="#0b0f17" />
+    <meta name="robots" content="index, follow, max-image-preview:large" />
+
+    <link
+      rel="canonical"
+      href="https://esengine.github.io/DeepSeek-Reasonix/architecture.html"
+    />
+    <link
+      rel="alternate"
+      hreflang="en"
+      href="https://esengine.github.io/DeepSeek-Reasonix/architecture.html?lang=en"
+    />
+    <link
+      rel="alternate"
+      hreflang="zh-CN"
+      href="https://esengine.github.io/DeepSeek-Reasonix/architecture.html?lang=zh"
+    />
+    <link
+      rel="alternate"
+      hreflang="x-default"
+      href="https://esengine.github.io/DeepSeek-Reasonix/architecture.html"
+    />
+
+    <meta property="og:type" content="article" />
+    <meta property="og:site_name" content="Reasonix" />
+    <meta property="og:title" content="Reasonix Architecture" />
+    <meta
+      property="og:description"
+      content="Cache-first loop, tool-call repair, cost control, and module layout — the full architecture deep dive."
+    />
+    <meta
+      property="og:url"
+      content="https://esengine.github.io/DeepSeek-Reasonix/architecture.html"
+    />
+    <meta
+      property="og:image"
+      content="https://raw.githubusercontent.com/esengine/reasonix/main/docs/assets/hero-terminal.svg"
+    />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:locale:alternate" content="zh_CN" />
+
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Reasonix Architecture" />
+    <meta
+      name="twitter:description"
+      content="Cache-first loop, tool-call repair, cost control, and module layout."
+    />
+
+    <link rel="icon" type="image/svg+xml" href="favicon.svg" />
+    <link rel="stylesheet" href="src/fonts.css" />
+    <link rel="stylesheet" href="src/styles.css" />
+    <link rel="stylesheet" href="guide.css" />
+
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "TechArticle",
+        "headline": "Reasonix Architecture",
+        "description": "Cache-first loop, tool-call repair pipeline, cost control, and module layout.",
+        "url": "https://esengine.github.io/DeepSeek-Reasonix/architecture.html",
+        "inLanguage": ["en", "zh-CN"],
+        "author": {
+          "@type": "Organization",
+          "name": "esengine",
+          "url": "https://github.com/esengine"
+        },
+        "isPartOf": {
+          "@type": "WebSite",
+          "name": "Reasonix",
+          "url": "https://esengine.github.io/DeepSeek-Reasonix/"
+        },
+        "about": {
+          "@type": "SoftwareApplication",
+          "name": "Reasonix"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "Reasonix",
+            "item": "https://esengine.github.io/DeepSeek-Reasonix/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "Architecture",
+            "item": "https://esengine.github.io/DeepSeek-Reasonix/architecture.html"
+          }
+        ]
+      }
+    </script>
+  </head>
+
+  <body>
+    <div class="grid-bg"></div>
+    <div class="noise"></div>
+
+    <nav class="nav">
+      <div class="nav-inner">
+        <a class="brand" href="index.html">
+          <span class="brand-mark"></span>
+          <span class="brand-name">
+            <b>Reasonix</b><span>DS · v0.42.0-3</span>
+          </span>
+        </a>
+        <div class="nav-links" role="navigation">
+          <a href="index.html#install">Install</a>
+          <a href="index.html#agents">Pillars</a>
+          <a href="index.html#features">Features</a>
+          <a href="index.html#config">Config</a>
+          <a href="configuration.html">Guide</a>
+          <a href="download.html">Download</a>
+          <a href="index.html#roadmap">Roadmap</a>
+          <a href="index.html#faq">FAQ</a>
+        </div>
+        <div class="nav-cta">
+          <div class="lang-switch" role="group" aria-label="Language">
+            <button data-lang-btn="en" type="button" aria-pressed="true">EN</button>
+            <button data-lang-btn="zh" type="button" aria-pressed="false">中文</button>
+          </div>
+          <a class="btn btn-ghost btn-sm" href="https://github.com/esengine/DeepSeek-Reasonix" target="_blank" rel="noopener">GitHub</a>
+          <a class="btn btn-primary btn-sm" href="download.html">Download →</a>
+        </div>
+      </div>
+    </nav>
+
+    <main class="guide-main" id="top">
+      <section class="guide-hero">
+        <div class="container">
+          <div class="badge" data-i18n="arch.badge">Cache · Repair · Cost · Modules</div>
+          <h1 class="guide-title">
+            <span class="grad-text" data-i18n="arch.title.line1">Reasonix Architecture</span>
+            <br />
+            <span data-i18n="arch.title.line2">how it works under the hood</span>
+          </h1>
+          <p class="guide-sub" data-i18n="arch.sub">
+            Reasonix is <strong>opinionated, not general</strong>. Every abstraction is
+            justified by a DeepSeek-specific behavior or economic property. The product
+            north star: a coding agent that stays cheap enough to leave on.
+          </p>
+        </div>
+      </section>
+
+      <div class="guide-shell container">
+        <aside class="guide-toc" aria-label="On this page">
+          <h4 data-i18n="arch.toc.title">On this page</h4>
+          <ul>
+            <li><a href="#philosophy" data-i18n="arch.toc.philosophy">Design philosophy</a></li>
+            <li><a href="#pillar1" data-i18n="arch.toc.pillar1">Pillar 1 — Cache</a></li>
+            <li><a href="#pillar2" data-i18n="arch.toc.pillar2">Pillar 2 — Repair</a></li>
+            <li><a href="#pillar3" data-i18n="arch.toc.pillar3">Pillar 3 — Cost</a></li>
+            <li><a href="#modules" data-i18n="arch.toc.modules">Module layout</a></li>
+            <li><a href="#evolution" data-i18n="arch.toc.evolution">Design evolution</a></li>
+            <li><a href="#nongoals" data-i18n="arch.toc.nongoals">Non-goals</a></li>
+          </ul>
+        </aside>
+
+        <article class="guide-body">
+          <section id="philosophy">
+            <h2 data-i18n="ph.title">Design philosophy</h2>
+            <p data-i18n="ph.body1">
+              Reasonix is <strong>opinionated, not general</strong>. Every abstraction is
+              justified by a DeepSeek-specific behavior or economic property. If it's
+              generic, we don't ship it.
+            </p>
+            <p data-i18n="ph.body2">
+              The product north star: <strong>coding agent that stays cheap enough to leave
+              on</strong>. A tool that quietly burns $200/month on a background project is
+              one nobody uses. Every subsystem below is answerable to that goal.
+            </p>
+          </section>
+
+          <section id="pillar1">
+            <h2 data-i18n="p1.title">Pillar 1 — Cache-First Loop</h2>
+            <p data-i18n="p1.problem">
+              <strong>Problem.</strong> DeepSeek bills cached input at ~10% of the miss
+              rate. Automatic prefix caching activates only when the <em>exact</em> byte
+              prefix of the previous request matches. Most agent loops reorder, rewrite, or
+              inject fresh timestamps each turn — cache hit rate in practice: &lt;20%.
+            </p>
+            <p data-i18n="p1.solution">
+              <strong>Solution.</strong> Partition the context into three regions:
+            </p>
+            <pre class="code"><code>┌─────────────────────────────────────────┐
+│ IMMUTABLE PREFIX                        │ ← fixed for session
+│   system + tool_specs + few_shots        │   cache hit candidate
+├─────────────────────────────────────────┤
+│ APPEND-ONLY LOG                         │ ← grows monotonically
+│   [assistant₁][tool₁][assistant₂]...    │   preserves prefix of prior turns
+├─────────────────────────────────────────┤
+│ VOLATILE SCRATCH                        │ ← reset each turn
+│   R1 thought, transient plan state      │   never sent upstream
+└─────────────────────────────────────────┘</code></pre>
+            <p data-i18n="p1.inv.title"><strong>Invariants:</strong></p>
+            <ol>
+              <li data-i18n="p1.inv1">Prefix is computed once per session, hashed, and pinned.</li>
+              <li data-i18n="p1.inv2">Log entries are serialized in append order; no rewrites.</li>
+              <li data-i18n="p1.inv3">
+                Scratch is distilled via Pillar 2 before any information from it is folded
+                into the log.
+              </li>
+            </ol>
+            <p data-i18n="p1.metric">
+              <strong>Metric.</strong> <code>prompt_cache_hit_tokens / (hit + miss)</code>
+              exposed per-turn and aggregated per-session. Visible in the TUI's top-bar
+              cache cell.
+            </p>
+
+            <h3 data-i18n="p1.h.parallel">Parallel tool dispatch</h3>
+            <p data-i18n="p1.parallel.body">
+              Each tool declares <code>parallelSafe?: boolean</code> (default
+              <code>false</code>). The loop dispatcher groups consecutive parallel-safe
+              calls into chunks and races them via <code>Promise.allSettled</code>; the
+              first non-parallel-safe call ends the chunk and runs alone (serial barrier —
+              read-after-write order preserved). Tool-result yields and history append still
+              land in declared order regardless of which call settles first, so the model
+              sees the same shape it would under a fully serial dispatch.
+            </p>
+            <table class="cmd-table">
+              <thead>
+                <tr>
+                  <th data-i18n="th.var">Env var</th>
+                  <th data-i18n="th.default">Default</th>
+                  <th data-i18n="th.effect">Effect</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>REASONIX_PARALLEL_MAX</code></td>
+                  <td><code>3</code> (hard cap <code>16</code>)</td>
+                  <td>Max chunk size.</td>
+                </tr>
+                <tr>
+                  <td><code>REASONIX_TOOL_DISPATCH=serial</code></td>
+                  <td>unset</td>
+                  <td>Forces serial dispatch — escape hatch.</td>
+                </tr>
+              </tbody>
+            </table>
+            <p data-i18n="p1.parallel.optins">
+              Built-in opt-ins: read-only filesystem (<code>read_file</code>,
+              <code>list_directory</code>, <code>directory_tree</code>,
+              <code>search_files</code>, <code>search_content</code>,
+              <code>get_file_info</code>), web (<code>web_search</code>,
+              <code>web_fetch</code>), <code>recall_memory</code>,
+              <code>semantic_search</code>, isolated child loops (<code>run_skill</code>,
+              <code>spawn_subagent</code>), in-memory job queries (<code>job_output</code>,
+              <code>list_jobs</code>). Mutating / side-effecting tools stay default.
+              MCP-bridged tools default <code>false</code> — third-party tools opt in only
+              when the server explicitly declares parallel safety.
+            </p>
+          </section>
+
+          <section id="pillar2">
+            <h2 data-i18n="p2.title">Pillar 2 — Tool-Call Repair</h2>
+            <p data-i18n="p2.problem">
+              <strong>Problem.</strong> Empirical DeepSeek failure modes:
+            </p>
+            <ul>
+              <li data-i18n="p2.fm1">Tool-call JSON emitted inside <code>&lt;think&gt;</code>, missing from the final message.</li>
+              <li data-i18n="p2.fm2">Arguments dropped when schema has &gt;10 params or deeply nested objects.</li>
+              <li data-i18n="p2.fm3">Same tool called repeatedly with identical args (call-storm).</li>
+              <li data-i18n="p2.fm4">Truncated JSON due to <code>max_tokens</code> hit mid-structure.</li>
+            </ul>
+            <p data-i18n="p2.solution"><strong>Solution.</strong> Four passes:</p>
+            <ol>
+              <li data-i18n="p2.pass1">
+                <strong><code>flatten</code></strong> — schemas with &gt;10 leaf params or
+                depth &gt;2 are auto-detected on <code>ToolRegistry.register()</code> and
+                presented to the model in dot-notation form. <code>dispatch()</code>
+                re-nests the args before calling the user's <code>fn</code>.
+              </li>
+              <li data-i18n="p2.pass2">
+                <strong><code>scavenge</code></strong> — regex + JSON parser sweeps
+                <code>reasoning_content</code> for any tool call the model forgot to emit
+                in <code>tool_calls</code>.
+              </li>
+              <li data-i18n="p2.pass3">
+                <strong><code>truncation</code></strong> — detect unbalanced JSON and
+                repair by closing braces or requesting a continuation completion.
+              </li>
+              <li data-i18n="p2.pass4">
+                <strong><code>storm</code></strong> — identical <code>(tool, args)</code>
+                tuple within a sliding window → suppress the call, inject a reflection turn.
+              </li>
+            </ol>
+          </section>
+
+          <section id="pillar3">
+            <h2 data-i18n="p3.title">Pillar 3 — Cost Control (v0.6)</h2>
+            <p data-i18n="p3.problem">
+              <strong>Problem.</strong> Coding agents that default to the frontier model
+              (v4-pro, ~12× flash cost) and accumulate full tool results in context are
+              $150–$250/month for active users. Most turns don't need frontier reasoning;
+              most sessions re-pay for tool results that were only useful once.
+            </p>
+            <p data-i18n="p3.solution">
+              <strong>Solution.</strong> Four complementary mechanisms, none of which
+              require manual tuning in the common case:
+            </p>
+
+            <h3 data-i18n="p3.h.tiers">4.1 Tiered defaults (flash-first)</h3>
+            <p data-i18n="p3.tiers.body">
+              The three presets trade <strong>model tier</strong> and <strong>reasoning
+              effort</strong>:
+            </p>
+            <table class="cmd-table">
+              <thead>
+                <tr>
+                  <th data-i18n="th.preset">Preset</th>
+                  <th data-i18n="th.model">Model</th>
+                  <th data-i18n="th.effort">Effort</th>
+                  <th data-i18n="th.cost">Cost</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>flash</code></td>
+                  <td><code>v4-flash</code></td>
+                  <td><code>max</code></td>
+                  <td>1×</td>
+                </tr>
+                <tr>
+                  <td><code>auto</code> (default)</td>
+                  <td><code>v4-flash</code> → <code>v4-pro</code> on hard turns</td>
+                  <td><code>max</code></td>
+                  <td>1–3×</td>
+                </tr>
+                <tr>
+                  <td><code>pro</code></td>
+                  <td><code>v4-pro</code></td>
+                  <td><code>max</code></td>
+                  <td>~12×</td>
+                </tr>
+              </tbody>
+            </table>
+            <p data-i18n="p3.tiers.aux">
+              All auxiliary calls — <code>forceSummaryAfterIterLimit</code>, subagent
+              spawns, truncation repair retries — hard-code <code>v4-flash +
+              effort=high</code> regardless of the user's preset. There's no reason to pay
+              pro rates for paraphrasing tool results or for an <code>explore</code>
+              subagent's grep chain.
+            </p>
+
+            <h3 data-i18n="p3.h.compact">4.2 Turn-end auto-compaction</h3>
+            <p data-i18n="p3.compact.body">
+              Every tool result in the log exceeding
+              <code>TURN_END_RESULT_CAP_TOKENS</code> (3000) is shrunk to that cap when a
+              turn ends. The model had the full text for the turn that read it; subsequent
+              turns see a compact summary and can re-read if needed. One extra
+              <code>read_file</code> call is vastly cheaper than dragging 12 KB through
+              every future prompt.
+            </p>
+            <p data-i18n="p3.compact.proactive">
+              A proactive 40% context-ratio threshold runs the same shrink pre-emptively
+              inside long multi-iter turns before the 80% emergency threshold fires.
+            </p>
+
+            <h3 data-i18n="p3.h.pro">4.3 /pro single-turn arming</h3>
+            <p data-i18n="p3.pro.body">
+              Users who predict a hard task type <code>/pro</code>; the <strong>next</strong>
+              turn runs on <code>v4-pro</code>, then auto-disarms. No preset churn, no
+              forgotten revert. Armed state is visible as a yellow <code>⇧ pro armed</code>
+              pill in the header.
+            </p>
+
+            <h3 data-i18n="p3.h.escalation">4.4 Failure-signal auto-escalation</h3>
+            <p data-i18n="p3.esc.body">
+              The loop counts visible "flash is struggling" events per turn:
+            </p>
+            <ul>
+              <li data-i18n="p3.esc.e1"><code>edit_file</code> / <code>write_file</code> SEARCH-not-found errors</li>
+              <li data-i18n="p3.esc.e2">ToolCallRepair fires (scavenge / truncation-fix / storm-break)</li>
+            </ul>
+            <p data-i18n="p3.esc.threshold">
+              Once the count hits <code>FAILURE_ESCALATION_THRESHOLD</code> (3), the
+              <strong>remainder of the current turn</strong> runs on <code>v4-pro</code>.
+              Announced via a yellow warning row — no silent cost surprises. Counter +
+              escalation flag reset at every turn start.
+            </p>
+            <p data-i18n="p3.esc.pill">
+              Header shows a red <code>⇧ pro escalated</code> pill while the turn is on pro.
+            </p>
+
+            <h3 data-i18n="p3.h.transparency">Cost transparency</h3>
+            <p data-i18n="p3.trans.body">
+              Per-turn and session cost are colored in the StatsPanel:
+            </p>
+            <ul>
+              <li data-i18n="p3.trans.turn"><code>turn $0.003</code> — green &lt;$0.05, yellow $0.05–0.20, red ≥$0.20</li>
+              <li data-i18n="p3.trans.session"><code>session $0.12</code> — same scale ×10</li>
+            </ul>
+          </section>
+
+          <section id="modules">
+            <h2 data-i18n="mod.title">Module layout</h2>
+            <pre class="code"><code>src/
+├── client.ts               <span class="hash"># DeepSeek client (fetch + SSE)</span>
+├── loop.ts                 <span class="hash"># Pillar 1 + 3 — CacheFirstLoop</span>
+├── repair/                 <span class="hash"># Pillar 2 pipeline</span>
+│   ├── index.ts
+│   ├── scavenge.ts
+│   ├── flatten.ts
+│   ├── truncation.ts
+│   └── storm.ts
+├── prompt-fragments.ts     <span class="hash"># TUI_FORMATTING_RULES, NEGATIVE_CLAIM_RULE</span>
+├── code/prompt.ts          <span class="hash"># reasonix code main system prompt</span>
+├── tools/                  <span class="hash"># Tool implementations</span>
+│   ├── filesystem.ts       <span class="hash"># read / list / search / edit / write</span>
+│   ├── shell.ts            <span class="hash"># run_command + run_background (JobRegistry)</span>
+│   ├── jobs.ts             <span class="hash"># background-process registry</span>
+│   ├── memory.ts           <span class="hash"># remember / forget / list user memories</span>
+│   ├── skills.ts           <span class="hash"># list + invoke SKILL.md playbooks</span>
+│   ├── subagent.ts         <span class="hash"># spawn_subagent — flash+high by default</span>
+│   ├── plan.ts             <span class="hash"># submit_plan (review gate)</span>
+│   └── web.ts              <span class="hash"># web_search, web_fetch (multi-engine)</span>
+├── mcp/                    <span class="hash"># MCP client + bridge (stdio + SSE)</span>
+├── memory.ts               <span class="hash"># ImmutablePrefix / AppendOnlyLog / VolatileScratch</span>
+├── project-memory.ts       <span class="hash"># REASONIX.md loader</span>
+├── user-memory.ts          <span class="hash"># ~/.reasonix/memory/ store (project + global)</span>
+├── skills.ts               <span class="hash"># built-in explore + research skills</span>
+├── session.ts              <span class="hash"># JSONL session persistence</span>
+├── telemetry.ts            <span class="hash"># cost + cache-hit accounting + SessionSummary</span>
+├── tokenizer.ts            <span class="hash"># DeepSeek V3 tokenizer (ported)</span>
+├── usage.ts                <span class="hash"># ~/.reasonix/usage.jsonl roll-up</span>
+├── types.ts                <span class="hash"># ChatMessage, ToolCall, ToolSpec</span>
+├── index.ts                <span class="hash"># library barrel</span>
+└── cli/
+    ├── index.ts            <span class="hash"># commander entry</span>
+    ├── resolve.ts          <span class="hash"># config + CLI flag precedence</span>
+    ├── commands/           <span class="hash"># chat, code, run, stats, sessions, ...</span>
+    └── ui/
+        ├── App.tsx                  <span class="hash"># root Ink component (~1984 LOC)</span>
+        ├── LiveRows.tsx             <span class="hash"># spinner rows</span>
+        ├── EventLog.tsx             <span class="hash"># historical row rendering</span>
+        ├── StatsPanel.tsx           <span class="hash"># top bar + cost badges</span>
+        ├── PromptInput.tsx          <span class="hash"># cursor-aware multi-line input</span>
+        ├── PlanConfirm.tsx          <span class="hash"># submit_plan review modal</span>
+        ├── ShellConfirm.tsx         <span class="hash"># run_command approval modal</span>
+        ├── EditConfirm.tsx          <span class="hash"># per-edit review modal</span>
+        ├── markdown.tsx             <span class="hash"># Ink-native markdown renderer</span>
+        ├── edit-history.ts          <span class="hash"># EditHistoryEntry + formatters</span>
+        ├── useEditHistory.ts        <span class="hash"># /undo, /history, /show state machine</span>
+        ├── useCompletionPickers.ts  <span class="hash"># slash, @, slash-arg pickers</span>
+        ├── useSessionInfo.ts        <span class="hash"># balance + models + updates fetch</span>
+        ├── useSubagent.ts           <span class="hash"># subagent sink wiring</span>
+        └── slash/                   <span class="hash"># /-command implementation</span>
+            ├── types.ts
+            ├── commands.ts
+            ├── helpers.ts
+            ├── dispatch.ts
+            └── handlers/</code></pre>
+            <p data-i18n="mod.note">
+              Files kept small by design: the largest module under <code>cli/ui/</code> is
+              2K lines (App.tsx), every handler under <code>slash/handlers/</code> is
+              ≤200 lines, every hook under <code>cli/ui/</code> is ≤310 lines. Adding a
+              new slash command means editing one handler file and one registry line.
+            </p>
+          </section>
+
+          <section id="evolution">
+            <h2 data-i18n="evo.title">Design evolution</h2>
+            <ul>
+              <li><strong>v0.0.x</strong> — Pillar 1 end-to-end, repair pipeline complete, Ink TUI scaffold.</li>
+              <li><strong>v0.1</strong> — τ-bench numbers published, streaming polish, transcript replay.</li>
+              <li><strong>v0.3</strong> — MCP client (stdio + SSE), session persistence.</li>
+              <li><strong>v0.4.x</strong> — <code>reasonix code</code> with SEARCH/REPLACE edits, review/auto gate, background jobs, hooks.</li>
+              <li><strong>v0.5.x</strong> — V4 model support, skills, memory, subagents, actionable error messages.</li>
+              <li>
+                <strong>v0.6</strong> —
+                <ul>
+                  <li><strong>Cost control</strong> (flash-first defaults, auto-compaction, <code>/pro</code> one-shot, failure-triggered escalation, cost badges).</li>
+                  <li><code>deepseek-chat</code> / <code>deepseek-reasoner</code> scheduled for deprecation — all user-facing surfaces updated to <code>v4-flash</code> / <code>v4-pro</code>.</li>
+                  <li>Shared prompt fragments (<code>TUI_FORMATTING_RULES</code>, <code>NEGATIVE_CLAIM_RULE</code>).</li>
+                  <li>UI refactor: App.tsx split into 6 hooks/components, slash.ts split into 13 per-topic modules.</li>
+                </ul>
+              </li>
+              <li><strong>v0.31</strong> <em>(current)</em> — <code>branch</code> + <code>harvest</code> features removed entirely (the parallel-sample selector and Pillar 2 plan-state extractor); both rarely paid for themselves and bloated the slash surface.</li>
+            </ul>
+          </section>
+
+          <section id="nongoals">
+            <h2 data-i18n="ng.title">Explicit non-goals</h2>
+            <ul>
+              <li data-i18n="ng.item1">Multi-agent orchestration as a first-class concept (subagents are a cost-reduction mechanism, not a coordination primitive).</li>
+              <li data-i18n="ng.item2">RAG / vector retrieval.</li>
+              <li data-i18n="ng.item3">Support for non-DeepSeek backends (an OpenAI-compatible shim would work today via <code>--model</code> override, but is not tested).</li>
+              <li data-i18n="ng.item4">Web UI / SaaS.</li>
+              <li data-i18n="ng.item5">Automatic cost escalation without user-visible announcement. Every pro-tier model call is surfaced; silent escalation was considered and rejected.</li>
+            </ul>
+          </section>
+        </article>
+      </div>
+    </main>
+
+    <footer class="footer">
+      <div class="footer-inner">
+        <div>
+          <a class="brand" href="index.html" style="text-decoration:none; color:inherit">
+            <span class="brand-mark"></span>
+            <span class="brand-name"><b>DeepSeek-Reasonix</b></span>
+          </a>
+          <p style="color:var(--cream-mute); font-size:13px; margin-top:14px; line-height:1.65; max-width:340px">
+            DeepSeek-native AI coding agent for your terminal. Engineered around prefix-cache stability — leave it running.
+          </p>
+          <div style="display:flex; gap:10px; margin-top:18px">
+            <a class="btn btn-ghost btn-sm" href="https://github.com/esengine/DeepSeek-Reasonix" target="_blank" rel="noopener" aria-label="GitHub">GitHub</a>
+            <a class="btn btn-ghost btn-sm" href="https://github.com/esengine/DeepSeek-Reasonix/discussions" target="_blank" rel="noopener">Discussions</a>
+          </div>
+        </div>
+        <div>
+          <h5>Product</h5>
+          <ul>
+            <li><a href="index.html#install">CLI</a></li>
+            <li><a href="download.html">Desktop</a></li>
+            <li><a href="index.html#agents">Pillars</a></li>
+            <li><a href="index.html#config">Config</a></li>
+          </ul>
+        </div>
+        <div>
+          <h5>Community</h5>
+          <ul>
+            <li><a href="https://github.com/esengine/DeepSeek-Reasonix" target="_blank" rel="noopener">GitHub</a></li>
+            <li><a href="https://github.com/esengine/DeepSeek-Reasonix/discussions" target="_blank" rel="noopener">Discussions</a></li>
+            <li><a href="https://github.com/esengine/DeepSeek-Reasonix/issues" target="_blank" rel="noopener">Issues</a></li>
+            <li><a href="https://github.com/esengine/DeepSeek-Reasonix/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener">Contributing</a></li>
+          </ul>
+        </div>
+        <div>
+          <h5>Resources</h5>
+          <ul>
+            <li><a href="https://github.com/esengine/DeepSeek-Reasonix#readme" target="_blank" rel="noopener">README</a></li>
+            <li><a href="index.html#roadmap">Roadmap</a></li>
+            <li><a href="https://github.com/esengine/DeepSeek-Reasonix/blob/main/CHANGELOG.md" target="_blank" rel="noopener">Changelog</a></li>
+            <li><a href="https://platform.deepseek.com" target="_blank" rel="noopener">DeepSeek Platform</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>© 2026 esengine · MIT License</span>
+        <span class="spacer"></span>
+        <span>Independent open-source project · not affiliated with DeepSeek</span>
+        <span style="margin-left:18px">v0.42.0-3 · prerelease</span>
+      </div>
+    </footer>
+
+    <script src="i18n.js"></script>
+    <script src="arch-i18n.js"></script>
+    <script src="motion.js"></script>
+  </body>
+</html>

--- a/docs/cli-ref-i18n.js
+++ b/docs/cli-ref-i18n.js
@@ -1,0 +1,170 @@
+/* CLI-reference page translations + scrollspy. Layered on top of i18n.js. */
+
+(function () {
+  "use strict";
+
+  var R = window.Reasonix;
+  if (!R) return;
+
+  var en = {
+    "cli.badge": "Shell · Slash Commands · Keyboard · Mouse",
+    "cli.title.line1": "CLI Reference",
+    "cli.title.line2": "every command, key, and flag",
+    "cli.sub":
+      "Every shell subcommand, every TUI slash command, every keybinding. The in-app <code>/help</code> and <code>/keys</code> panels are the live source of truth — this page is the printable companion.",
+
+    "cli.toc.title": "On this page",
+    "cli.toc.shell": "Shell subcommands",
+    "cli.toc.slash": "Slash commands",
+    "cli.toc.keyboard": "Keyboard",
+    "cli.toc.mouse": "Mouse",
+    "cli.toc.copypaste": "Copy / paste",
+
+    "th.cmd": "Command",
+    "th.what": "What it does",
+    "th.key": "Key",
+    "th.action": "Action",
+
+    "sh.title": "Shell subcommands",
+    "sh.body":
+      "Run <code>reasonix --help</code> (or any subcommand with <code>--help</code>) for the full flag list. Headline subcommands:",
+    "sh.flags.title": "Notable runtime flags (chat / code)",
+
+    "sl.title": "Slash commands",
+    "sl.body":
+      "Type <code>/</code> mid-chat to open the picker. Aliases shown in parentheses. Code-mode-only commands marked <strong>(code)</strong>.",
+    "sl.h.chatops": "Chat ops",
+    "sl.h.setup": "Setup",
+    "sl.h.info": "Info",
+    "sl.h.extend": "Extend",
+    "sl.h.session": "Session",
+    "sl.h.code": "Code mode",
+    "sl.h.jobs": "Jobs (code mode)",
+    "sl.h.advanced": "Advanced",
+
+    "kb.title": "Keyboard",
+    "kb.h.editgate": "Edit-gate (code mode)",
+
+    "ms.title": "Mouse",
+    "ms.body":
+      "Reasonix sets DECSET 1007 (alternate-scroll) only — wheel events translate to ↑/↓ keypresses for the app, but native click/drag selection is left untouched. Pass <code>--no-mouse</code> to opt out entirely.",
+
+    "cp.title": "Copy / paste",
+    "cp.body":
+      "The default path is <strong>terminal-native</strong>. Drag to select, then use your terminal's normal copy keys:",
+    "cp.h.drag": "When drag-select doesn't work",
+    "cp.body.drag":
+      "In SSH / mosh / tmux, the alt-screen buffer prevents the terminal from extending the selection past the visible viewport — there is no scrollback above the alt-screen to drag into. Two fixes:",
+    "cp.fix1":
+      "<strong><code>/copy</code></strong> — open vim/tmux-style copy mode in-app. Snapshots the current chat to a navigable buffer; <code>y</code> yanks to clipboard via OSC 52 (with a temp-file fallback for terminals that don't support it).",
+    "cp.fix2":
+      "<strong><code>--no-alt-screen</code></strong> — render to shell scrollback instead. Drag-select then works terminal-natively (the chat content is real lines in the scrollback above your cursor). Trade-off: redraw can ghost on resize.",
+    "cp.h.copymode": "<code>/copy</code> — copy mode keys",
+    "cp.body.osc":
+      "<code>y</code> with no active selection yanks just the current line. The yank goes through OSC 52 first (works through SSH, mosh, tmux with <code>set -g set-clipboard on</code>); content larger than 75 KB falls back to a temp file whose path is printed on exit.",
+  };
+
+  var zh = {
+    "cli.badge": "Shell · 斜杠命令 · 快捷键 · 鼠标",
+    "cli.title.line1": "CLI 参考",
+    "cli.title.line2": "所有命令、快捷键和 flag",
+    "cli.sub":
+      "所有 shell 子命令、所有 TUI 斜杠命令、所有快捷键一览。应用内 <code>/help</code> 与 <code>/keys</code> 面板是权威来源——本页是可检索的离线副本。",
+
+    "cli.toc.title": "本页目录",
+    "cli.toc.shell": "Shell 子命令",
+    "cli.toc.slash": "斜杠命令",
+    "cli.toc.keyboard": "快捷键",
+    "cli.toc.mouse": "鼠标",
+    "cli.toc.copypaste": "复制 / 粘贴",
+
+    "th.cmd": "命令",
+    "th.what": "作用",
+    "th.key": "按键",
+    "th.action": "效果",
+
+    "sh.title": "Shell 子命令",
+    "sh.body":
+      "任意子命令加 <code>--help</code> 可查完整 flag 列表。主要子命令：",
+    "sh.flags.title": "常用运行时 flag（chat / code）",
+
+    "sl.title": "斜杠命令",
+    "sl.body":
+      "输入 <code>/</code> 在聊天中打开选择器。括号内为别名。仅 code 模式可用的命令标注 <strong>（code）</strong>。",
+    "sl.h.chatops": "聊天操作",
+    "sl.h.setup": "设置",
+    "sl.h.info": "信息",
+    "sl.h.extend": "扩展",
+    "sl.h.session": "会话",
+    "sl.h.code": "Code 模式",
+    "sl.h.jobs": "后台任务（code 模式）",
+    "sl.h.advanced": "高级",
+
+    "kb.title": "快捷键",
+    "kb.h.editgate": "编辑门控（code 模式）",
+
+    "ms.title": "鼠标",
+    "ms.body":
+      "Reasonix 只设置 DECSET 1007（alternate-scroll）——滚轮事件转为 ↑/↓ 按键传给应用，原生点击/拖拽选择不受影响。加 <code>--no-mouse</code> 可完全关闭。",
+
+    "cp.title": "复制 / 粘贴",
+    "cp.body":
+      "默认走<strong>终端原生</strong>路径。拖拽选中文本，再用终端本身的复制快捷键：",
+    "cp.h.drag": "拖拽选择不生效时",
+    "cp.body.drag":
+      "SSH / mosh / tmux 下，alt-screen 缓冲区会阻止终端把选区延伸到可视视口以外——alt-screen 上方根本没有 scrollback 可拖入。两种解决方式：",
+    "cp.fix1":
+      "<strong><code>/copy</code></strong> — 在应用内打开 vim/tmux 风格的复制模式，把当前聊天快照到可导航的缓冲区；<code>y</code> 通过 OSC 52 复制到剪贴板（不支持 OSC 52 的终端会退到临时文件）。",
+    "cp.fix2":
+      "<strong><code>--no-alt-screen</code></strong> — 改为渲染到 shell scrollback。拖拽选择恢复终端原生（聊天内容就是光标上方的真实行）。代价：窗口大小改变时可能出现重绘残影。",
+    "cp.h.copymode": "<code>/copy</code> — 复制模式快捷键",
+    "cp.body.osc":
+      "没有活动选区时按 <code>y</code> 只复制当前行。复制先走 OSC 52（通过 SSH、mosh、开了 <code>set -g set-clipboard on</code> 的 tmux 均可用）；超过 75 KB 的内容退到临时文件，路径在退出时打印。",
+  };
+
+  var DICT = { en: en, zh: zh };
+
+  function applyCli(lang) {
+    var dict = DICT[lang] || DICT.en;
+    document.querySelectorAll("[data-i18n]").forEach(function (el) {
+      var key = el.getAttribute("data-i18n");
+      if (dict[key] !== undefined) el.innerHTML = dict[key];
+    });
+  }
+
+  applyCli(R.lang());
+  R.onLangChange(applyCli);
+
+  var sections = Array.prototype.slice.call(
+    document.querySelectorAll(".guide-body section[id]"),
+  );
+  var tocLinks = Array.prototype.slice.call(
+    document.querySelectorAll(".guide-toc a"),
+  );
+  if (sections.length && tocLinks.length && "IntersectionObserver" in window) {
+    var byId = {};
+    tocLinks.forEach(function (a) {
+      var href = a.getAttribute("href") || "";
+      var id = href.replace(/^#/, "");
+      if (id) byId[id] = a;
+    });
+    var io = new IntersectionObserver(
+      function (entries) {
+        entries.forEach(function (e) {
+          var link = byId[e.target.id];
+          if (!link) return;
+          if (e.isIntersecting) {
+            tocLinks.forEach(function (l) {
+              l.classList.remove("is-active");
+            });
+            link.classList.add("is-active");
+          }
+        });
+      },
+      { rootMargin: "-30% 0px -60% 0px", threshold: 0 },
+    );
+    sections.forEach(function (s) {
+      io.observe(s);
+    });
+  }
+})();

--- a/docs/cli-reference.html
+++ b/docs/cli-reference.html
@@ -1,0 +1,854 @@
+<!doctype html>
+<html lang="en" data-lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>CLI Reference — Reasonix · Shell, Slash Commands, Keyboard, Mouse</title>
+    <meta
+      name="description"
+      content="Complete CLI reference for Reasonix — every shell subcommand, every TUI slash command, every keybinding, and mouse / copy-paste guide."
+    />
+    <meta
+      name="keywords"
+      content="Reasonix CLI, reasonix commands, slash commands, keyboard shortcuts, DeepSeek CLI reference, reasonix code, reasonix chat"
+    />
+    <meta name="author" content="esengine" />
+    <meta name="theme-color" content="#0b0f17" />
+    <meta name="robots" content="index, follow, max-image-preview:large" />
+
+    <link
+      rel="canonical"
+      href="https://esengine.github.io/DeepSeek-Reasonix/cli-reference.html"
+    />
+    <link
+      rel="alternate"
+      hreflang="en"
+      href="https://esengine.github.io/DeepSeek-Reasonix/cli-reference.html?lang=en"
+    />
+    <link
+      rel="alternate"
+      hreflang="zh-CN"
+      href="https://esengine.github.io/DeepSeek-Reasonix/cli-reference.html?lang=zh"
+    />
+    <link
+      rel="alternate"
+      hreflang="x-default"
+      href="https://esengine.github.io/DeepSeek-Reasonix/cli-reference.html"
+    />
+
+    <meta property="og:type" content="article" />
+    <meta property="og:site_name" content="Reasonix" />
+    <meta property="og:title" content="Reasonix CLI Reference" />
+    <meta
+      property="og:description"
+      content="Every shell subcommand, every slash command, every keybinding — the printable companion to /help and /keys."
+    />
+    <meta
+      property="og:url"
+      content="https://esengine.github.io/DeepSeek-Reasonix/cli-reference.html"
+    />
+    <meta
+      property="og:image"
+      content="https://raw.githubusercontent.com/esengine/reasonix/main/docs/assets/hero-terminal.svg"
+    />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:locale:alternate" content="zh_CN" />
+
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Reasonix CLI Reference" />
+    <meta
+      name="twitter:description"
+      content="Every shell subcommand, every slash command, every keybinding."
+    />
+
+    <link rel="icon" type="image/svg+xml" href="favicon.svg" />
+    <link rel="stylesheet" href="src/fonts.css" />
+    <link rel="stylesheet" href="src/styles.css" />
+    <link rel="stylesheet" href="guide.css" />
+
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "TechArticle",
+        "headline": "Reasonix CLI Reference",
+        "description": "Every shell subcommand, every TUI slash command, every keybinding, and mouse / copy-paste guide.",
+        "url": "https://esengine.github.io/DeepSeek-Reasonix/cli-reference.html",
+        "inLanguage": ["en", "zh-CN"],
+        "author": {
+          "@type": "Organization",
+          "name": "esengine",
+          "url": "https://github.com/esengine"
+        },
+        "isPartOf": {
+          "@type": "WebSite",
+          "name": "Reasonix",
+          "url": "https://esengine.github.io/DeepSeek-Reasonix/"
+        },
+        "about": {
+          "@type": "SoftwareApplication",
+          "name": "Reasonix"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "Reasonix",
+            "item": "https://esengine.github.io/DeepSeek-Reasonix/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "CLI Reference",
+            "item": "https://esengine.github.io/DeepSeek-Reasonix/cli-reference.html"
+          }
+        ]
+      }
+    </script>
+  </head>
+
+  <body>
+    <div class="grid-bg"></div>
+    <div class="noise"></div>
+
+    <nav class="nav">
+      <div class="nav-inner">
+        <a class="brand" href="index.html">
+          <span class="brand-mark"></span>
+          <span class="brand-name">
+            <b>Reasonix</b><span>DS · v0.42.0-3</span>
+          </span>
+        </a>
+        <div class="nav-links" role="navigation">
+          <a href="index.html#install">Install</a>
+          <a href="index.html#agents">Pillars</a>
+          <a href="index.html#features">Features</a>
+          <a href="index.html#config">Config</a>
+          <a href="configuration.html">Guide</a>
+          <a href="download.html">Download</a>
+          <a href="index.html#roadmap">Roadmap</a>
+          <a href="index.html#faq">FAQ</a>
+        </div>
+        <div class="nav-cta">
+          <div class="lang-switch" role="group" aria-label="Language">
+            <button data-lang-btn="en" type="button" aria-pressed="true">EN</button>
+            <button data-lang-btn="zh" type="button" aria-pressed="false">中文</button>
+          </div>
+          <a class="btn btn-ghost btn-sm" href="https://github.com/esengine/DeepSeek-Reasonix" target="_blank" rel="noopener">GitHub</a>
+          <a class="btn btn-primary btn-sm" href="download.html">Download →</a>
+        </div>
+      </div>
+    </nav>
+
+    <main class="guide-main" id="top">
+      <section class="guide-hero">
+        <div class="container">
+          <div class="badge" data-i18n="cli.badge">Shell · Slash Commands · Keyboard · Mouse</div>
+          <h1 class="guide-title">
+            <span class="grad-text" data-i18n="cli.title.line1">CLI Reference</span>
+            <br />
+            <span data-i18n="cli.title.line2">every command, key, and flag</span>
+          </h1>
+          <p class="guide-sub" data-i18n="cli.sub">
+            Every shell subcommand, every TUI slash command, every keybinding. The in-app
+            <code>/help</code> and <code>/keys</code> panels are the live source of truth — this
+            page is the printable companion.
+          </p>
+        </div>
+      </section>
+
+      <div class="guide-shell container">
+        <aside class="guide-toc" aria-label="On this page">
+          <h4 data-i18n="cli.toc.title">On this page</h4>
+          <ul>
+            <li><a href="#shell" data-i18n="cli.toc.shell">Shell subcommands</a></li>
+            <li><a href="#slash" data-i18n="cli.toc.slash">Slash commands</a></li>
+            <li><a href="#keyboard" data-i18n="cli.toc.keyboard">Keyboard</a></li>
+            <li><a href="#mouse" data-i18n="cli.toc.mouse">Mouse</a></li>
+            <li><a href="#copypaste" data-i18n="cli.toc.copypaste">Copy / paste</a></li>
+          </ul>
+        </aside>
+
+        <article class="guide-body">
+          <section id="shell">
+            <h2 data-i18n="sh.title">Shell subcommands</h2>
+            <p data-i18n="sh.body">
+              Run <code>reasonix --help</code> (or any subcommand with <code>--help</code>) for the
+              full flag list. Headline subcommands:
+            </p>
+            <table class="cmd-table">
+              <thead>
+                <tr>
+                  <th data-i18n="th.cmd">Command</th>
+                  <th data-i18n="th.what">What it does</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>reasonix code [dir]</code></td>
+                  <td>Code-mode TUI — file edits, plan mode, edit-gate, project-scoped sessions</td>
+                </tr>
+                <tr>
+                  <td><code>reasonix chat</code></td>
+                  <td>Chat-only TUI — no filesystem access, no code mode</td>
+                </tr>
+                <tr>
+                  <td><code>reasonix run &lt;task&gt;</code></td>
+                  <td>Headless run — read prompt, execute, exit (CI-friendly)</td>
+                </tr>
+                <tr>
+                  <td><code>reasonix setup</code></td>
+                  <td>Interactive first-run config (API key, language, theme)</td>
+                </tr>
+                <tr>
+                  <td><code>reasonix sessions [name]</code></td>
+                  <td>List or open a saved session</td>
+                </tr>
+                <tr>
+                  <td><code>reasonix prune-sessions</code></td>
+                  <td>Drop sessions older than <code>--days N</code></td>
+                </tr>
+                <tr>
+                  <td><code>reasonix replay &lt;transcript&gt;</code></td>
+                  <td>Re-render a JSONL transcript without calling the model</td>
+                </tr>
+                <tr>
+                  <td><code>reasonix diff &lt;a&gt; &lt;b&gt;</code></td>
+                  <td>Compare two transcripts (cost / cache / tokens)</td>
+                </tr>
+                <tr>
+                  <td><code>reasonix events &lt;name&gt;</code></td>
+                  <td>Tail the event log for a session</td>
+                </tr>
+                <tr>
+                  <td><code>reasonix stats [transcript]</code></td>
+                  <td>One-shot cost / cache breakdown</td>
+                </tr>
+                <tr>
+                  <td><code>reasonix doctor</code></td>
+                  <td>Health check — API reach, config, hooks, project</td>
+                </tr>
+                <tr>
+                  <td><code>reasonix commit</code></td>
+                  <td><code>git add -A &amp;&amp; git commit</code> with an LLM-written message</td>
+                </tr>
+                <tr>
+                  <td><code>reasonix mcp &lt;list|search|install|inspect|browse&gt;</code></td>
+                  <td>MCP server management</td>
+                </tr>
+                <tr>
+                  <td><code>reasonix index</code></td>
+                  <td>Build the local semantic index (Ollama or OpenAI-compatible embeddings)</td>
+                </tr>
+                <tr>
+                  <td><code>reasonix version</code> / <code>reasonix update</code></td>
+                  <td>Version info + upgrade hint</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <h3 data-i18n="sh.flags.title">Notable runtime flags (chat / code)</h3>
+            <table class="cmd-table">
+              <thead>
+                <tr>
+                  <th>Flag</th>
+                  <th data-i18n="th.what">What it does</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>--no-session</code></td>
+                  <td>Ephemeral run — nothing is persisted</td>
+                </tr>
+                <tr>
+                  <td><code>--session &lt;name&gt;</code></td>
+                  <td>Resume / pin to a named session</td>
+                </tr>
+                <tr>
+                  <td><code>--continue</code></td>
+                  <td>Resume the most recent session for this workspace</td>
+                </tr>
+                <tr>
+                  <td><code>--new</code></td>
+                  <td>Force a fresh session even if one exists</td>
+                </tr>
+                <tr>
+                  <td><code>--budget &lt;usd&gt;</code></td>
+                  <td>Per-session USD cap — warns at 80%, refuses next turn at 100%</td>
+                </tr>
+                <tr>
+                  <td><code>--preset &lt;auto|flash|pro&gt;</code></td>
+                  <td>Model bundle (auto-escalation, locked flash, locked pro)</td>
+                </tr>
+                <tr>
+                  <td><code>--mcp &lt;spec&gt;</code></td>
+                  <td>Attach an MCP server for this run (repeatable)</td>
+                </tr>
+                <tr>
+                  <td><code>--no-config</code></td>
+                  <td>Ignore <code>~/.reasonix/config.json</code> for this run</td>
+                </tr>
+                <tr>
+                  <td><code>--no-dashboard</code></td>
+                  <td>Don't auto-start the embedded web dashboard</td>
+                </tr>
+                <tr>
+                  <td><code>--no-alt-screen</code></td>
+                  <td>Render to scrollback instead of the alt-screen buffer (preserves chat in shell history; legacy mode, can ghost on resize)</td>
+                </tr>
+                <tr>
+                  <td><code>--no-mouse</code></td>
+                  <td>Disable DECSET 1007 (alternate-scroll); wheel reverts to native terminal scroll</td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+
+          <section id="slash">
+            <h2 data-i18n="sl.title">Slash commands</h2>
+            <p data-i18n="sl.body">
+              Type <code>/</code> mid-chat to open the picker. Aliases shown in parentheses.
+              Code-mode-only commands marked <strong>(code)</strong>.
+            </p>
+
+            <h3 data-i18n="sl.h.chatops">Chat ops</h3>
+            <table class="cmd-table">
+              <thead>
+                <tr>
+                  <th data-i18n="th.cmd">Command</th>
+                  <th data-i18n="th.what">What it does</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>/help</code> (<code>/?</code>)</td>
+                  <td>Show the full command reference inline</td>
+                </tr>
+                <tr>
+                  <td><code>/new</code> (<code>/reset</code>, <code>/clear</code>)</td>
+                  <td>Start a fresh conversation (clear context + scrollback)</td>
+                </tr>
+                <tr>
+                  <td><code>/retry</code></td>
+                  <td>Truncate and resend your last message — fresh sample</td>
+                </tr>
+                <tr>
+                  <td><code>/compact</code></td>
+                  <td>Fold older turns into a summary (cache-safe). Auto-fires at 50% ctx; this is the manual trigger</td>
+                </tr>
+                <tr>
+                  <td><code>/stop</code></td>
+                  <td>Abort the current model turn (typed alternative to Esc)</td>
+                </tr>
+                <tr>
+                  <td><code>/copy</code></td>
+                  <td>Open vim/tmux-style copy mode — <code>j</code>/<code>k</code> navigate, <code>v</code> select, <code>y</code> yank to clipboard. The right answer for SSH / mosh / tmux where drag-select can't extend past the viewport</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <h3 data-i18n="sl.h.setup">Setup</h3>
+            <table class="cmd-table">
+              <tbody>
+                <tr>
+                  <td><code>/preset &lt;auto|flash|pro&gt;</code></td>
+                  <td>Switch model bundle. Bare opens picker</td>
+                </tr>
+                <tr>
+                  <td><code>/model &lt;id&gt;</code></td>
+                  <td>Switch DeepSeek model id. Bare opens picker</td>
+                </tr>
+                <tr>
+                  <td><code>/language &lt;EN|zh-CN&gt;</code> (<code>/lang</code>)</td>
+                  <td>Switch the runtime language</td>
+                </tr>
+                <tr>
+                  <td><code>/theme &lt;name&gt;</code></td>
+                  <td>Show or persist terminal theme. Bare opens picker</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <h3 data-i18n="sl.h.info">Info</h3>
+            <table class="cmd-table">
+              <tbody>
+                <tr>
+                  <td><code>/status</code></td>
+                  <td>Current model, flags, context, session</td>
+                </tr>
+                <tr>
+                  <td><code>/cost [text]</code></td>
+                  <td>Bare → last turn's spend; with text → estimate cost of sending it next</td>
+                </tr>
+                <tr>
+                  <td><code>/context</code></td>
+                  <td>Context-window breakdown (system / tools / log / input)</td>
+                </tr>
+                <tr>
+                  <td><code>/stats</code></td>
+                  <td>Cross-session cost dashboard (today / week / month / all-time)</td>
+                </tr>
+                <tr>
+                  <td><code>/doctor</code></td>
+                  <td>Health check (api / config / api-reach / index / hooks / project)</td>
+                </tr>
+                <tr>
+                  <td><code>/keys</code></td>
+                  <td>Keyboard + mouse + copy/paste reference</td>
+                </tr>
+                <tr>
+                  <td><code>/feedback</code></td>
+                  <td>Open a GitHub issue with diagnostic info copied to clipboard</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <h3 data-i18n="sl.h.extend">Extend</h3>
+            <table class="cmd-table">
+              <tbody>
+                <tr>
+                  <td><code>/mcp</code></td>
+                  <td>Open the MCP hub (live + marketplace tabs)</td>
+                </tr>
+                <tr>
+                  <td><code>/resource [uri]</code></td>
+                  <td>Browse / read MCP resources</td>
+                </tr>
+                <tr>
+                  <td><code>/prompt [name]</code></td>
+                  <td>Browse / fetch MCP prompts</td>
+                </tr>
+                <tr>
+                  <td><code>/memory [list|show|forget|clear]</code></td>
+                  <td>Manage pinned memory (REASONIX.md + <code>~/.reasonix/memory</code>)</td>
+                </tr>
+                <tr>
+                  <td><code>/skill [list|show|new|&lt;name&gt;]</code></td>
+                  <td>List / run / scaffold user skills</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <h3 data-i18n="sl.h.session">Session</h3>
+            <table class="cmd-table">
+              <tbody>
+                <tr>
+                  <td><code>/sessions</code></td>
+                  <td>List saved sessions (current marked with ▸)</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <h3 data-i18n="sl.h.code">Code mode</h3>
+            <table class="cmd-table">
+              <tbody>
+                <tr>
+                  <td><code>/init [force]</code></td>
+                  <td>Scan project, synthesize a baseline <code>REASONIX.md</code></td>
+                </tr>
+                <tr>
+                  <td><code>/apply [N|N,M|N-M]</code></td>
+                  <td>Commit pending edit blocks to disk (subset selection supported)</td>
+                </tr>
+                <tr>
+                  <td><code>/discard [N|N,M|N-M]</code></td>
+                  <td>Drop pending edits without writing</td>
+                </tr>
+                <tr>
+                  <td><code>/walk</code></td>
+                  <td>Step through pending edits one block at a time (git-add-p style)</td>
+                </tr>
+                <tr>
+                  <td><code>/undo</code></td>
+                  <td>Roll back the last applied edit batch</td>
+                </tr>
+                <tr>
+                  <td><code>/history</code></td>
+                  <td>List every edit batch this session</td>
+                </tr>
+                <tr>
+                  <td><code>/show [id]</code></td>
+                  <td>Dump a stored edit diff</td>
+                </tr>
+                <tr>
+                  <td><code>/commit "msg"</code></td>
+                  <td><code>git add -A &amp;&amp; git commit -m ...</code></td>
+                </tr>
+                <tr>
+                  <td><code>/mode &lt;review|auto|yolo&gt;</code></td>
+                  <td>Edit-gate mode. Shift+Tab cycles</td>
+                </tr>
+                <tr>
+                  <td><code>/plan [on|off]</code></td>
+                  <td>Toggle read-only plan mode. Submitted plans initially show a compact summary; press <code>Ctrl+P</code> in the plan confirmation modal to expand/collapse full details</td>
+                </tr>
+                <tr>
+                  <td><code>/checkpoint [name|list|forget]</code></td>
+                  <td>Snapshot every file the session has touched</td>
+                </tr>
+                <tr>
+                  <td><code>/restore &lt;name|id&gt;</code></td>
+                  <td>Roll back to a named checkpoint</td>
+                </tr>
+                <tr>
+                  <td><code>/cwd &lt;path&gt;</code> (<code>/sandbox</code>)</td>
+                  <td>Switch the workspace root mid-session</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <h3 data-i18n="sl.h.jobs">Jobs (code mode)</h3>
+            <table class="cmd-table">
+              <tbody>
+                <tr>
+                  <td><code>/jobs</code></td>
+                  <td>List background jobs</td>
+                </tr>
+                <tr>
+                  <td><code>/kill &lt;id&gt;</code></td>
+                  <td>Stop a background job (SIGTERM → SIGKILL)</td>
+                </tr>
+                <tr>
+                  <td><code>/logs &lt;id&gt; [lines]</code></td>
+                  <td>Tail a job's output (default 80 lines)</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <h3 data-i18n="sl.h.advanced">Advanced</h3>
+            <table class="cmd-table">
+              <tbody>
+                <tr>
+                  <td><code>/pro [off]</code></td>
+                  <td>Arm v4-pro for the NEXT turn only</td>
+                </tr>
+                <tr>
+                  <td><code>/budget [usd|off]</code></td>
+                  <td>Session USD cap</td>
+                </tr>
+                <tr>
+                  <td><code>/search-engine &lt;mojeek|searxng&gt;</code> (<code>/se</code>)</td>
+                  <td>Switch web search backend</td>
+                </tr>
+                <tr>
+                  <td><code>/hooks [reload]</code></td>
+                  <td>List / reload hooks</td>
+                </tr>
+                <tr>
+                  <td><code>/permissions [list|add|remove|clear]</code></td>
+                  <td>Edit shell allowlist</td>
+                </tr>
+                <tr>
+                  <td><code>/dashboard [stop]</code></td>
+                  <td>Launch / stop the embedded web dashboard</td>
+                </tr>
+                <tr>
+                  <td><code>/loop &lt;interval&gt; &lt;prompt&gt;</code></td>
+                  <td>Auto-resubmit a prompt every interval</td>
+                </tr>
+                <tr>
+                  <td><code>/plans</code></td>
+                  <td>List active + archived plans</td>
+                </tr>
+                <tr>
+                  <td><code>/replay [N]</code></td>
+                  <td>Load an archived plan as a read-only Time Travel snapshot</td>
+                </tr>
+                <tr>
+                  <td><code>/update</code></td>
+                  <td>Show current vs latest version</td>
+                </tr>
+                <tr>
+                  <td><code>/exit</code> (<code>/quit</code>, <code>/q</code>)</td>
+                  <td>Quit the TUI</td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+
+          <section id="keyboard">
+            <h2 data-i18n="kb.title">Keyboard</h2>
+            <table class="cmd-table">
+              <thead>
+                <tr>
+                  <th data-i18n="th.key">Key</th>
+                  <th data-i18n="th.what">What it does</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>Enter</code></td>
+                  <td>Submit the prompt</td>
+                </tr>
+                <tr>
+                  <td><code>Shift+Enter</code></td>
+                  <td>Insert a newline in the prompt</td>
+                </tr>
+                <tr>
+                  <td><code>↑</code> / <code>↓</code></td>
+                  <td>Scroll chat history (mouse wheel routes here too)</td>
+                </tr>
+                <tr>
+                  <td><code>Ctrl+P</code> / <code>Ctrl+N</code></td>
+                  <td>Previous / next prompt history · cursor up / down in a multi-line draft. In a submitted-plan confirmation modal, <code>Ctrl+P</code> expands/collapses full plan details</td>
+                </tr>
+                <tr>
+                  <td><code>Ctrl+A</code> / <code>Ctrl+E</code></td>
+                  <td>Jump to start / end of the current line</td>
+                </tr>
+                <tr>
+                  <td><code>Ctrl+W</code></td>
+                  <td>Delete the word before the cursor</td>
+                </tr>
+                <tr>
+                  <td><code>Ctrl+U</code></td>
+                  <td>Clear the entire prompt buffer</td>
+                </tr>
+                <tr>
+                  <td><code>Tab</code></td>
+                  <td>Complete @-mention · drill folder · accept slash command</td>
+                </tr>
+                <tr>
+                  <td><code>Shift+Tab</code></td>
+                  <td>Edit-gate: toggle review ↔ AUTO mode</td>
+                </tr>
+                <tr>
+                  <td><code>Esc</code></td>
+                  <td>Dismiss picker · abort the running model turn</td>
+                </tr>
+                <tr>
+                  <td><code>Ctrl+C</code></td>
+                  <td>Abort the running model turn (NOT copy — see clipboard)</td>
+                </tr>
+                <tr>
+                  <td><code>PgUp</code> / <code>PgDn</code></td>
+                  <td>Scroll chat history a page at a time. While plan details are expanded, scroll the bounded detail window</td>
+                </tr>
+                <tr>
+                  <td><code>End</code></td>
+                  <td>Jump chat to the most recent line</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <h3 data-i18n="kb.h.editgate">Edit-gate (code mode)</h3>
+            <table class="cmd-table">
+              <thead>
+                <tr>
+                  <th data-i18n="th.key">Key</th>
+                  <th data-i18n="th.what">What it does</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>y</code> / <code>n</code></td>
+                  <td>Accept / drop pending edits in the review modal</td>
+                </tr>
+                <tr>
+                  <td><code>Shift+Tab</code></td>
+                  <td>Toggle review ↔ AUTO (persisted across sessions)</td>
+                </tr>
+                <tr>
+                  <td><code>u</code></td>
+                  <td>Undo the last auto-applied batch (within the 5s banner)</td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+
+          <section id="mouse">
+            <h2 data-i18n="ms.title">Mouse</h2>
+            <table class="cmd-table">
+              <thead>
+                <tr>
+                  <th data-i18n="th.action">Action</th>
+                  <th data-i18n="th.what">What it does</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Wheel</td>
+                  <td>Scrolls chat history (works on web / cloud / SSH terminals too)</td>
+                </tr>
+                <tr>
+                  <td>Drag</td>
+                  <td>Selects text natively — no modifier needed</td>
+                </tr>
+                <tr>
+                  <td>Right-click</td>
+                  <td>Terminal-native (e.g. paste menu on Windows Terminal)</td>
+                </tr>
+              </tbody>
+            </table>
+            <p data-i18n="ms.body">
+              Reasonix sets DECSET 1007 (alternate-scroll) only — wheel events translate to
+              ↑/↓ keypresses for the app, but native click/drag selection is left untouched.
+              Pass <code>--no-mouse</code> to opt out entirely.
+            </p>
+          </section>
+
+          <section id="copypaste">
+            <h2 data-i18n="cp.title">Copy / paste</h2>
+            <p data-i18n="cp.body">
+              The default path is <strong>terminal-native</strong>. Drag to select, then use
+              your terminal's normal copy keys:
+            </p>
+            <table class="cmd-table">
+              <thead>
+                <tr>
+                  <th data-i18n="th.action">Action</th>
+                  <th>How</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Select text</td>
+                  <td>Drag — terminal-native (no modifier)</td>
+                </tr>
+                <tr>
+                  <td>Copy</td>
+                  <td><code>Ctrl+Shift+C</code> (Win / Linux) · <code>Cmd+C</code> (macOS) — or auto-copy-on-select if your terminal does it</td>
+                </tr>
+                <tr>
+                  <td>Paste</td>
+                  <td><code>Ctrl+V</code> or <code>Ctrl+Shift+V</code> (Win / Linux) · <code>Cmd+V</code> (macOS)</td>
+                </tr>
+                <tr>
+                  <td>Multi-line paste</td>
+                  <td>Bracketed paste — pastes stay one block, no auto-submit on intermediate newlines</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <h3 data-i18n="cp.h.drag">When drag-select doesn't work</h3>
+            <p data-i18n="cp.body.drag">
+              In SSH / mosh / tmux, the alt-screen buffer prevents the terminal from extending
+              the selection past the visible viewport — there is no scrollback above the
+              alt-screen to drag into. Two fixes:
+            </p>
+            <ol>
+              <li data-i18n="cp.fix1">
+                <strong><code>/copy</code></strong> — open vim/tmux-style copy mode in-app.
+                Snapshots the current chat to a navigable buffer; <code>y</code> yanks to
+                clipboard via OSC 52 (with a temp-file fallback for terminals that don't
+                support it).
+              </li>
+              <li data-i18n="cp.fix2">
+                <strong><code>--no-alt-screen</code></strong> — render to shell scrollback
+                instead. Drag-select then works terminal-natively (the chat content is real
+                lines in the scrollback above your cursor). Trade-off: redraw can ghost on
+                resize.
+              </li>
+            </ol>
+
+            <h3 data-i18n="cp.h.copymode"><code>/copy</code> — copy mode keys</h3>
+            <table class="cmd-table">
+              <thead>
+                <tr>
+                  <th data-i18n="th.key">Key</th>
+                  <th data-i18n="th.what">What it does</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>j</code> / <code>↓</code></td>
+                  <td>Cursor down one line</td>
+                </tr>
+                <tr>
+                  <td><code>k</code> / <code>↑</code></td>
+                  <td>Cursor up one line</td>
+                </tr>
+                <tr>
+                  <td><code>PgUp</code> / <code>PgDn</code></td>
+                  <td>Page up / down</td>
+                </tr>
+                <tr>
+                  <td><code>g</code> / <code>G</code></td>
+                  <td>Jump to top / bottom</td>
+                </tr>
+                <tr>
+                  <td><code>v</code></td>
+                  <td>Start (or cancel) selection at the cursor</td>
+                </tr>
+                <tr>
+                  <td><code>y</code> / <code>Enter</code></td>
+                  <td>Yank selection to clipboard, exit</td>
+                </tr>
+                <tr>
+                  <td><code>q</code> / <code>Esc</code></td>
+                  <td>Quit without yanking</td>
+                </tr>
+              </tbody>
+            </table>
+            <p data-i18n="cp.body.osc">
+              <code>y</code> with no active selection yanks just the current line. The yank
+              goes through OSC 52 first (works through SSH, mosh, tmux with
+              <code>set -g set-clipboard on</code>); content larger than 75 KB falls back to
+              a temp file whose path is printed on exit.
+            </p>
+          </section>
+        </article>
+      </div>
+    </main>
+
+    <footer class="footer">
+      <div class="footer-inner">
+        <div>
+          <a class="brand" href="index.html" style="text-decoration:none; color:inherit">
+            <span class="brand-mark"></span>
+            <span class="brand-name"><b>DeepSeek-Reasonix</b></span>
+          </a>
+          <p style="color:var(--cream-mute); font-size:13px; margin-top:14px; line-height:1.65; max-width:340px">
+            DeepSeek-native AI coding agent for your terminal. Engineered around prefix-cache stability — leave it running.
+          </p>
+          <div style="display:flex; gap:10px; margin-top:18px">
+            <a class="btn btn-ghost btn-sm" href="https://github.com/esengine/DeepSeek-Reasonix" target="_blank" rel="noopener" aria-label="GitHub">GitHub</a>
+            <a class="btn btn-ghost btn-sm" href="https://github.com/esengine/DeepSeek-Reasonix/discussions" target="_blank" rel="noopener">Discussions</a>
+          </div>
+        </div>
+        <div>
+          <h5>Product</h5>
+          <ul>
+            <li><a href="index.html#install">CLI</a></li>
+            <li><a href="download.html">Desktop</a></li>
+            <li><a href="index.html#agents">Pillars</a></li>
+            <li><a href="index.html#config">Config</a></li>
+          </ul>
+        </div>
+        <div>
+          <h5>Community</h5>
+          <ul>
+            <li><a href="https://github.com/esengine/DeepSeek-Reasonix" target="_blank" rel="noopener">GitHub</a></li>
+            <li><a href="https://github.com/esengine/DeepSeek-Reasonix/discussions" target="_blank" rel="noopener">Discussions</a></li>
+            <li><a href="https://github.com/esengine/DeepSeek-Reasonix/issues" target="_blank" rel="noopener">Issues</a></li>
+            <li><a href="https://github.com/esengine/DeepSeek-Reasonix/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener">Contributing</a></li>
+          </ul>
+        </div>
+        <div>
+          <h5>Resources</h5>
+          <ul>
+            <li><a href="https://github.com/esengine/DeepSeek-Reasonix#readme" target="_blank" rel="noopener">README</a></li>
+            <li><a href="index.html#roadmap">Roadmap</a></li>
+            <li><a href="https://github.com/esengine/DeepSeek-Reasonix/blob/main/CHANGELOG.md" target="_blank" rel="noopener">Changelog</a></li>
+            <li><a href="https://platform.deepseek.com" target="_blank" rel="noopener">DeepSeek Platform</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>© 2026 esengine · MIT License</span>
+        <span class="spacer"></span>
+        <span>Independent open-source project · not affiliated with DeepSeek</span>
+        <span style="margin-left:18px">v0.42.0-3 · prerelease</span>
+      </div>
+    </footer>
+
+    <script src="i18n.js"></script>
+    <script src="cli-ref-i18n.js"></script>
+    <script src="motion.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
Issue #623 asked for CLI Reference and Architecture to render in-site rather than bouncing readers to GitHub blobs, which dropped them out of the docs theme and skipped the zh-CN layer. This PR adds `docs/cli-reference.html` and `docs/architecture.html` as first-class pages modelled on `docs/configuration.html`, each with its own i18n sidecar, and repoints the two CTA links in `configuration.html` at the new pages.

## Changes
- Add `docs/cli-reference.html` — hand-ported from `docs/CLI-REFERENCE.md`, reuses the configuration page's head/nav/`guide-main`/`guide-shell`/footer shell and script trio.
- Add `docs/architecture.html` — hand-ported from `docs/ARCHITECTURE.md`, same shell, with sections for the three pillars, module layout, design evolution, and non-goals.
- Add `docs/cli-ref-i18n.js` — IIFE matching `guide-i18n.js`, supplies EN and zh-CN strings for every `data-i18n` key on the CLI reference page.
- Add `docs/arch-i18n.js` — same pattern, EN + zh-CN for the architecture page (badge, TOC, pillar copy, table headers, non-goals).
- Update `docs/configuration.html` lines 652 and 660 — swap the two `github.com/.../blob/...` hrefs for `architecture.html` and `cli-reference.html`.

## Testing
Ran `npm run verify` from the repo root; passes. No build step is involved for the docs site — the new pages are static HTML loaded with the existing `i18n.js` + per-page sidecar pattern, so behaviour was sanity-checked by following the same structure as `configuration.html`.

## Notes
- The zh-CN copy on the two new pages is a best-effort hand translation of the source Markdown. Maintainers familiar with the existing zh-CN tone may want to polish phrasing in a follow-up; the i18n keys are stable so edits are localized to `cli-ref-i18n.js` / `arch-i18n.js`.
- The source Markdown files (`docs/CLI-REFERENCE.md`, `docs/ARCHITECTURE.md`) are left in place so external links and the repo-level reading path still work; only the in-docs CTAs were repointed.
- `footer.jsx` referenced in `index.html` has no matching GitHub blob links for these two docs, so no edits were needed there.

Closes #623