### PR TITLE
增加模型在第一次会话会根据 memory.md 命中对应规则

### DIFF
--- a/src/tools/memory.ts
+++ b/src/tools/memory.ts
@@ -60,7 +60,26 @@ export function registerMemoryTools(
         },
         description: {
           type: "string",
-          description: "One-line summary shown in MEMORY.md (under ~150 chars).",
+          description:
+            "One-line summary shown in MEMORY.md index (capped ~110-130 chars) — this is ALL the model sees when deciding if the memory is relevant.\n" +
+            "\n" +
+            "MUST include trigger keywords — words the user would SAY or the model would THINK when this memory should activate.\n" +
+            "Rule: if a word never appears in a user message, it's a topic name, not a trigger keyword.\n" +
+            "\n" +
+            "Format: trigger:<word1/word2/word3> | <specific action to take>\n" +
+            "\n" +
+            "GOOD — trigger keywords are user-language, action is concrete:\n" +
+            "  trigger:deploy/release/ship | Blue-green deploy, 10% traffic first\n" +
+            "  trigger:write-tests/add-tests/run-tests | Mock external services, never connect real databases\n" +
+            "  trigger:reply/tone/how-to-answer | Keep replies direct, skip greetings and filler\n" +
+            "\n" +
+            "BAD — with reason:\n" +
+            "  Deployment rules           — pure concept name, no trigger keywords, no action\n" +
+            "  Be careful with tests      — vague advice, no trigger scenario, no action\n" +
+            "  FORMAT CORRECT, CONTENT WRONG:\n" +
+            "    trigger:project/code/work | Follow best practices\n" +
+            "      — trigger words match EVERY message (too broad),\n" +
+            "        action is empty filler, says nothing concrete",
         },
         content: {
           type: "string",


### PR DESCRIPTION
**解决 memory.md 索引命中问题**


本次提示词是通过模型写的，质量或许存在问题，希望作者能提供更好的解决方案。


# 问题

  目前现象是在 Reasonix ，首次会话时无法对指令进行遵守，常常无视直接执行，在 v4-flash 下会经常发生，而 v4-pro因为模型质量比较好会遵守执行，但还是有小部分概率忽略规则执行。

  **触发现象**
- 在当前会话让它保存相应的内容到目录中，开启新的会话时，会直接忽略我在 global/MEMORY 中写入的规则，执行搜索在读取，而不是直接加载。
- 使用 GitNexus 明确告诉 FTS 在 Win11 环境下有问题不要调用，但是模型还是会先进行调用

排查发现在 memory.ts 进对索引的描述只有 简短的一句 ‘One-line summary shown in MEMORY.md (under ~150 chars).’ 这就很有可能 v4-flash 即使读取了，也会再首次会话开始时直接忽略，需要再次提醒。


# 解决方案
 
**调整提示词，增加命中关键词，提供可供参考的示例，让模型自己完善 memory.md 索引**
```
One-line summary shown in MEMORY.md index (capped ~110-130 chars) — this is ALL the model sees when deciding if the memory is relevant.

MUST include trigger keywords — words the user would SAY or the model would THINK when this memory should activate.
Rule: if a word never appears in a user message, it's a topic name, not a trigger keyword.

Format: trigger:<word1/word2/word3> | <specific action to take>

GOOD — trigger keywords are user-language, action is concrete:
  trigger:deploy/release/ship | Blue-green deploy, 10% traffic first
  trigger:write-tests/add-tests/run-tests | Mock external services, never connect real databases
  trigger:reply/tone/how-to-answer | Keep replies direct, skip greetings and filler

BAD — with reason:
  Deployment rules           — pure concept name, no trigger keywords, no action
  Be careful with tests      — vague advice, no trigger scenario, no action
  FORMAT CORRECT, CONTENT WRONG:
    trigger:project/code/work | Follow best practices
      — trigger words match EVERY message (too broad),
        action is empty filler, says nothing concrete

```


# 效果

**修改前**
- memory.md
<img width="954" height="166" alt="image" src="https://github.com/user-attachments/assets/22993bef-ab72-47e6-b670-f79341255892" />


<img width="596" height="336" alt="image" src="https://github.com/user-attachments/assets/c339eafa-c17f-4b2f-9d6a-2524a04ef7fe" />

-----

**修改后**

- memory.md
<img width="1419" height="156" alt="image" src="https://github.com/user-attachments/assets/3ad78060-b75f-4b68-91f5-ac0fea65e5ca" />


<img width="1339" height="255" alt="image" src="https://github.com/user-attachments/assets/57342809-125c-47b3-aa8e-c74894059871" />


