### PR TITLE
chore(desktop): surface theme toggle in settings, deduplicate settings entry point

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -8,6 +8,7 @@ import { CommandPalette, Toast, buildCommands, useCommandPalette } from "./Comma
 import { WorkspaceProvider } from "./Markdown";
 import { getLang, setLang, t, useLang } from "./i18n";
 import { I } from "./icons";
+import { THEME, type Theme } from "./theme";
 import type {
   CheckpointVerdict,
   ChoiceVerdict,
@@ -807,7 +808,8 @@ interface TabRuntimeProps {
   onNewTab: () => void;
   onCloseTab: () => void;
   canCloseTab: boolean;
-  theme: "dark" | "light";
+  theme: Theme;
+  onSetTheme: (theme: Theme) => void;
   onToggleTheme: () => void;
   sideCollapsed: boolean;
   ctxCollapsed: boolean;
@@ -832,6 +834,7 @@ function TabRuntime({
   onCloseTab,
   canCloseTab,
   theme,
+  onSetTheme,
   onToggleTheme,
   sideCollapsed,
   ctxCollapsed,
@@ -1605,6 +1608,8 @@ function TabRuntime({
             balance={state.balance}
             usage={state.usage}
             currency={currency}
+            theme={theme}
+            onSetTheme={onSetTheme}
             initialPage={settingsPage}
             mcpSpecs={state.mcpSpecs}
             mcpBridged={state.mcpBridged}
@@ -2133,9 +2138,9 @@ export function App() {
     const v = localStorage.getItem("reasonix.currency");
     return v === "USD" ? "USD" : "CNY";
   });
-  const [theme, setTheme] = useState<"dark" | "light">(() => {
+  const [theme, setTheme] = useState<Theme>(() => {
     const v = localStorage.getItem("reasonix.theme");
-    return v === "light" ? "light" : "dark";
+    return v === THEME.LIGHT ? THEME.LIGHT : THEME.DARK;
   });
   const [sideCollapsed, setSideCollapsed] = useState(false);
   const [ctxCollapsed, setCtxCollapsed] = useState(false);
@@ -2378,7 +2383,9 @@ export function App() {
   }, [openTab, closeTab, activeTabId, tabs]);
 
   const onToggleTheme = useCallback(() => {
-    setTheme((t) => (t === "dark" ? "light" : "dark"));
+    setTheme((currentTheme) =>
+      currentTheme === THEME.DARK ? THEME.LIGHT : THEME.DARK,
+    );
   }, []);
 
   const onToggleCurrency = useCallback(() => {
@@ -2407,6 +2414,7 @@ export function App() {
           onCloseTab={() => closeTab(t.id)}
           canCloseTab={tabs.length > 1}
           theme={theme}
+          onSetTheme={setTheme}
           onToggleTheme={onToggleTheme}
           sideCollapsed={sideCollapsed}
           ctxCollapsed={ctxCollapsed}

--- a/desktop/src/i18n/en.ts
+++ b/desktop/src/i18n/en.ts
@@ -136,6 +136,7 @@ export const en = {
     pageShortcutsLabel: "Shortcuts",
     pageShortcutsDesc: "Keyboard shortcuts overview",
     // section headers
+    appearanceSection: "Appearance",
     workspaceSection: "Workspace",
     behaviorSection: "Behavior",
     apiSection: "DeepSeek API",

--- a/desktop/src/i18n/zh-CN.ts
+++ b/desktop/src/i18n/zh-CN.ts
@@ -133,6 +133,7 @@ export const zhCN: typeof en = {
     pageBillingDesc: "账户余额、用量与发票",
     pageShortcutsLabel: "快捷键",
     pageShortcutsDesc: "键盘快捷键总览",
+    appearanceSection: "外观",
     workspaceSection: "工作区",
     behaviorSection: "行为",
     apiSection: "DeepSeek API",

--- a/desktop/src/icons.tsx
+++ b/desktop/src/icons.tsx
@@ -58,7 +58,7 @@ export const I = {
   moon: (p: IconProps) => (<Ic {...p}><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8Z" /></Ic>),
   panel_l: (p: IconProps) => (<Ic {...p}><rect x="3" y="4" width="18" height="16" rx="2" /><path d="M9 4v16" /></Ic>),
   panel_r: (p: IconProps) => (<Ic {...p}><rect x="3" y="4" width="18" height="16" rx="2" /><path d="M15 4v16" /></Ic>),
-  cog: (p: IconProps) => (<Ic {...p}><circle cx="12" cy="12" r="3" /><path d="M12 2v3M12 19v3M4.2 4.2l2.1 2.1M17.7 17.7l2.1 2.1M2 12h3M19 12h3M4.2 19.8l2.1-2.1M17.7 6.3l2.1-2.1" /></Ic>),
+  cog: (p: IconProps) => (<Ic {...p}><path d="M12 3.6 19.2 7.8v8.4L12 20.4 4.8 16.2V7.8Z" /><circle cx="12" cy="12" r="3.7" /></Ic>),
   stop: (p: IconProps) => (<Ic {...p}><rect x="6" y="6" width="12" height="12" rx="2" /></Ic>),
   play: (p: IconProps) => (<Ic {...p}><path d="M7 5v14l12-7Z" /></Ic>),
   more: (p: IconProps) => (<Ic {...p}><circle cx="6" cy="12" r="1.6" fill="currentColor" /><circle cx="12" cy="12" r="1.6" fill="currentColor" /><circle cx="18" cy="12" r="1.6" fill="currentColor" /></Ic>),

--- a/desktop/src/main.tsx
+++ b/desktop/src/main.tsx
@@ -9,9 +9,10 @@ import "@fontsource/ibm-plex-serif/400.css";
 import "@fontsource/ibm-plex-serif/500.css";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
+import { isTheme } from "./theme";
 
 const stored = localStorage.getItem("reasonix.theme");
-if (stored === "light" || stored === "dark") {
+if (isTheme(stored)) {
   document.documentElement.dataset.theme = stored;
 }
 

--- a/desktop/src/theme.ts
+++ b/desktop/src/theme.ts
@@ -1,0 +1,10 @@
+export const THEME = {
+  DARK: "dark",
+  LIGHT: "light",
+} as const;
+
+export type Theme = (typeof THEME)[keyof typeof THEME];
+
+export function isTheme(value: unknown): value is Theme {
+  return value === THEME.DARK || value === THEME.LIGHT;
+}

--- a/desktop/src/ui/settings.tsx
+++ b/desktop/src/ui/settings.tsx
@@ -3,6 +3,7 @@ import type { Balance, Settings as SettingsType, UsageStats } from "../App";
 import { t } from "../i18n";
 import { I } from "../icons";
 import type { McpSpecInfo, SettingsPatch, SkillInfo } from "../protocol";
+import { THEME, type Theme } from "../theme";
 
 export type PageId =
   | "general"
@@ -30,6 +31,8 @@ export function SettingsModal({
   balance,
   usage,
   currency,
+  theme,
+  onSetTheme,
   initialPage,
   mcpSpecs,
   mcpBridged,
@@ -45,6 +48,8 @@ export function SettingsModal({
   balance: Balance | null;
   usage: UsageStats;
   currency: "CNY" | "USD";
+  theme: Theme;
+  onSetTheme: (theme: Theme) => void;
   initialPage?: PageId;
   mcpSpecs: McpSpecInfo[];
   mcpBridged: boolean;
@@ -96,7 +101,13 @@ export function SettingsModal({
           </div>
           <div className="settings-body">
             {page === "general" && (
-              <PageGeneral settings={settings} onSave={onSave} onPickWorkspace={onPickWorkspace} />
+              <PageGeneral
+                settings={settings}
+                theme={theme}
+                onSetTheme={onSetTheme}
+                onSave={onSave}
+                onPickWorkspace={onPickWorkspace}
+              />
             )}
             {page === "models" && <PageModels settings={settings} onSave={onSave} />}
             {page === "mcp" && (
@@ -131,16 +142,46 @@ export function SettingsModal({
 
 function PageGeneral({
   settings,
+  theme,
+  onSetTheme,
   onSave,
   onPickWorkspace,
 }: {
   settings: SettingsType;
+  theme: Theme;
+  onSetTheme: (theme: Theme) => void;
   onSave: (patch: SettingsPatch) => void;
   onPickWorkspace: () => void;
 }) {
   const [editorDraft, setEditorDraft] = useState(settings.editor ?? "");
   return (
     <>
+      <section className="section">
+        <div className="stitle">{t("settings.appearanceSection")}</div>
+        <div className="setting-row">
+          <div className="l">
+            <div className="n">{t("settings.theme")}</div>
+            <div className="h">{t("settings.themeHint")}</div>
+          </div>
+          <div className="seg-ctrl">
+            <button
+              type="button"
+              data-on={theme === THEME.DARK}
+              onClick={() => onSetTheme(THEME.DARK)}
+            >
+              {t("settings.themeDark")}
+            </button>
+            <button
+              type="button"
+              data-on={theme === THEME.LIGHT}
+              onClick={() => onSetTheme(THEME.LIGHT)}
+            >
+              {t("settings.themeLight")}
+            </button>
+          </div>
+        </div>
+      </section>
+
       <section className="section">
         <div className="stitle">{t("settings.workspaceSection")}</div>
         <div className="setting-row">

--- a/desktop/src/ui/statusbar.tsx
+++ b/desktop/src/ui/statusbar.tsx
@@ -1,6 +1,7 @@
 import { I } from "../icons";
 import { t } from "../i18n";
 import type { Balance, Settings, UsageStats } from "../App";
+import { THEME, type Theme } from "../theme";
 
 function formatMoney(amount: number, currency: "CNY" | "USD"): string {
   const symbol = currency === "CNY" ? "¥" : "$";
@@ -31,7 +32,7 @@ export function StatusBar({
   busy: boolean;
   ready: boolean;
   currency: "CNY" | "USD";
-  theme: "dark" | "light";
+  theme: Theme;
   onToggleTheme: () => void;
   onToggleCurrency: () => void;
   onOpenSettings: () => void;
@@ -101,11 +102,8 @@ export function StatusBar({
         <span className="v ok">{balanceLabel}</span>
       </span>
       <span className="seg" title="切换主题" onClick={onToggleTheme}>
-        {theme === "dark" ? <I.moon size={11} /> : <I.sun size={11} />}
-        <span className="v">{theme === "dark" ? "深色" : "浅色"}</span>
-      </span>
-      <span className="seg" title="设置 (⌘,)" onClick={onOpenSettings}>
-        <I.cog size={11} />
+        {theme === THEME.DARK ? <I.moon size={11} /> : <I.sun size={11} />}
+        <span className="v">{theme === THEME.DARK ? "深色" : "浅色"}</span>
       </span>
     </footer>
   );


### PR DESCRIPTION
…s entry point

## What

Add a missing "Appearance" section with dark/light theme toggle to the General settings page, remove the redundant settings gear icon from the status bar, and extract theme constants into a shared `theme.ts` module. Also redesign the settings icon — the old gear shape was visually indistinguishable from the sun icon, replaced with a distinct hexagonal outline.

## Why

1. The General settings page had no appearance controls — users could only switch theme via the status bar. 
2. The status bar's settings gear was a duplicate entry point (settings is already accessible under the approval rules section). 3. The settings icon itself was ambiguous next to the theme sun/moon icons.

## How to verify

1. Open settings → General — confirm the "外观" section appears with dark/light toggle
2. Toggle theme via settings — confirm it applies immediately and persists across reload
3. Check the status bar — confirm the settings gear icon is removed, theme toggle still works
4. Visually confirm the new settings icon (hexagonal) is distinct from the sun icon

<img width="2048" height="1384" alt="image" src="https://github.com/user-attachments/assets/95de754f-e6ea-4eb3-8196-4d7370ad0569" />

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time
EOF
)"

