### PR TITLE
fix(loop): yield reasoning before content so transition chunks don't fragment

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -778,6 +778,18 @@ export class CacheFirstLoop {
             thinking: thinkingModeForModel(callModel),
             reasoningEffort: this.reasoningEffort,
           })) {
+            // DeepSeek transition chunks carry both reasoning_content and
+            // content; emit reasoning first so consumers can merge
+            // consecutive same-kind segments instead of fragmenting.
+            if (chunk.reasoningDelta) {
+              reasoningContent += chunk.reasoningDelta;
+              yield {
+                turn: this._turn,
+                role: "assistant_delta",
+                content: "",
+                reasoningDelta: chunk.reasoningDelta,
+              };
+            }
             if (chunk.contentDelta) {
               assistantContent += chunk.contentDelta;
               if (bufferForEscalation && !escalationBufFlushed) {
@@ -810,15 +822,6 @@ export class CacheFirstLoop {
                   content: chunk.contentDelta,
                 };
               }
-            }
-            if (chunk.reasoningDelta) {
-              reasoningContent += chunk.reasoningDelta;
-              yield {
-                turn: this._turn,
-                role: "assistant_delta",
-                content: "",
-                reasoningDelta: chunk.reasoningDelta,
-              };
             }
             if (chunk.toolCallDelta) {
               const d = chunk.toolCallDelta;

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -1887,6 +1887,49 @@ describe("CacheFirstLoop (streaming) — tool_call_delta emission", () => {
     expect(deltas[deltas.length - 1]!.chars).toBeGreaterThan(deltas[0]!.chars!);
   });
 
+  it("yields reasoning before content when a chunk carries both fields", async () => {
+    const client = new DeepSeekClient({
+      apiKey: "sk-test",
+      fetch: (async (_url: any, _init: any) => {
+        const frames = [
+          `data: ${JSON.stringify({ choices: [{ delta: { reasoning_content: "I" } }] })}\n\n`,
+          `data: ${JSON.stringify({ choices: [{ delta: { reasoning_content: "'m thinking", content: "Let" } }] })}\n\n`,
+          `data: ${JSON.stringify({ choices: [{ delta: { content: " me reply" } }] })}\n\n`,
+          `data: ${JSON.stringify({ choices: [{ finish_reason: "stop", delta: {} }], usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2, prompt_cache_hit_tokens: 0, prompt_cache_miss_tokens: 1 } })}\n\n`,
+          "data: [DONE]\n\n",
+        ];
+        const body = new ReadableStream({
+          start(ctrl) {
+            for (const f of frames) ctrl.enqueue(new TextEncoder().encode(f));
+            ctrl.close();
+          },
+        });
+        return new Response(body, {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        });
+      }) as unknown as typeof fetch,
+    });
+
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s" }),
+      stream: true,
+      maxToolIters: 1,
+      autoEscalate: false,
+    });
+
+    const channels: Array<"reasoning" | "content"> = [];
+    for await (const ev of loop.step("hi")) {
+      if (ev.role === "assistant_delta") {
+        channels.push(ev.reasoningDelta ? "reasoning" : "content");
+      }
+      if (ev.role === "done") break;
+    }
+
+    expect(channels).toEqual(["reasoning", "reasoning", "content", "content"]);
+  });
+
   it("does not emit a red error event when the API call is aborted mid-flight", async () => {
     // Reproduces the reported "error This operation was aborted" UX
     // bug: when App.tsx calls loop.abort() to switch to a queued


### PR DESCRIPTION
## Summary

DeepSeek's streaming response splits `delta.content` and `delta.reasoning_content` across chunks, but the chunk that straddles the thinking→output boundary carries *both* fields. The streaming branch in `src/loop.ts` handled `chunk.contentDelta` first and `chunk.reasoningDelta` second, so on a mixed chunk it yielded two `assistant_delta` events in the order `[content, reasoning]`. The desktop reducer (`appendTextSegment` in `desktop/src/App.tsx:437`) only merges *consecutive same-kind* segments, so one mixed chunk anywhere in the turn alternated the segment kind and split the rest of the turn into one tiny `ReasoningCard` + plain-text paragraph pair per delta — the fragmented "card / `Let` / card / `me verify the complete` / card / `:` / ..." pattern users reported.

Swapped the yield order in `src/loop.ts` so reasoning is emitted before content within a chunk iteration, matching the model's semantic ordering (reasoning happens first, then output). Same-kind runs now stay adjacent and `appendTextSegment` collapses them back to one reasoning segment + one content segment per turn.

## Changes

- `src/loop.ts` — within the streaming for-await loop, move the `chunk.reasoningDelta` branch above the `chunk.contentDelta` branch. The escalation buffer logic on the content branch is unchanged.
- `tests/loop.test.ts` — new streaming test in the existing `CacheFirstLoop (streaming)` describe block: builds an SSE body with a mixed `{reasoning_content, content}` chunk in the middle and asserts the `assistant_delta` yield order is `[reasoning, reasoning, content, content]`. Regresses the bug if the order ever flips back.

## Test plan

- `npm run verify` — passes (2858 tests).
- The new test fails against the pre-fix code (asserts `[reasoning, content, reasoning, content]`-style ordering would not equal the expected `[reasoning, reasoning, content, content]`).
