### PR TITLE
Add QQ Channel Support to Chat and Code Sessions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react": "^19.2.6",
         "string-width": "^7.2.0",
         "undici": "^8.2.0",
+        "ws": "^8.20.1",
         "zod": "^4.4.1"
       },
       "bin": {
@@ -32,6 +33,7 @@
         "@types/node": "^22.9.0",
         "@types/picomatch": "^4.0.3",
         "@types/react": "^19.2.14",
+        "@types/ws": "^8.18.1",
         "@vitest/coverage-v8": "^2.1.5",
         "esbuild": "^0.21.5",
         "highlight.js": "^11.10.0",
@@ -2218,6 +2220,16 @@
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmmirror.com/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@vitest/coverage-v8": {
@@ -6877,9 +6889,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmmirror.com/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "react": "^19.2.6",
     "string-width": "^7.2.0",
     "undici": "^8.2.0",
+    "ws": "^8.20.1",
     "zod": "^4.4.1"
   },
   "devDependencies": {
@@ -88,6 +89,7 @@
     "@types/node": "^22.9.0",
     "@types/picomatch": "^4.0.3",
     "@types/react": "^19.2.14",
+    "@types/ws": "^8.18.1",
     "@vitest/coverage-v8": "^2.1.5",
     "esbuild": "^0.21.5",
     "highlight.js": "^11.10.0",

--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -16,6 +16,7 @@ import {
   renameSession,
   resolveSession,
 } from "../../memory/session.js";
+import { QQChannel } from "../../qq/channel.js";
 import { ToolRegistry } from "../../tools.js";
 import { registerChoiceTool } from "../../tools/choice.js";
 import { registerMemoryTools } from "../../tools/memory.js";
@@ -128,6 +129,12 @@ interface RootProps extends ChatOptions {
   mcpRuntime: McpRuntime;
   /** One-time startup info rows shown after App mounts. */
   startupInfoHints: string[];
+  /** Pre-created QQ channel (started before TUI mounts). */
+  qqChannel?: QQChannel;
+  /** App fills this ref on mount so QQ messages flow into the TUI input queue. */
+  qqSubmitRef: { current: ((text: string) => void) | null };
+  /** App fills this ref on mount so QQ errors appear in the TUI log. */
+  qqErrorRef: { current: ((msg: string) => void) | null };
 }
 
 function Root({
@@ -221,6 +228,9 @@ function Root({
         openDashboard={appProps.openDashboard}
         dashboardPort={appProps.dashboardPort}
         mouse={appProps.mouse}
+        qqChannel={appProps.qqChannel}
+        qqSubmitRef={appProps.qqSubmitRef}
+        qqErrorRef={appProps.qqErrorRef}
         onSwitchSession={setActiveSession}
       />
     </KeystrokeProvider>
@@ -303,6 +313,29 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
     !opts.session && !opts.forceResume && listSessionsForWorkspace(launchWorkspace).length > 0;
 
   markPhase("ink_render_call");
+
+  // Create QQ channel before the TUI mounts so connection setup stays
+  // outside React lifecycle timing and the WebSocket handshake remains
+  // deterministic.
+  const qqSubmitRef: { current: ((text: string) => void) | null } = { current: null };
+  const qqErrorRef: { current: ((msg: string) => void) | null } = { current: null };
+  const qqRequested = cfg.qq?.enabled === true;
+  let qqChannel: QQChannel | undefined;
+  if (qqRequested) {
+    const channel = new QQChannel({
+      onSubmitMessage: (text) => qqSubmitRef.current?.(text),
+      onError: (msg) => qqErrorRef.current?.(msg),
+    });
+    process.stderr.write("Connecting QQ bot...\n");
+    try {
+      await channel.start();
+      qqChannel = channel;
+      process.stderr.write("QQ bot connected\n");
+    } catch (err) {
+      process.stderr.write(`QQ bot failed: ${(err as Error).message}\n`);
+    }
+  }
+
   const { waitUntilExit } = render(
     <Root
       initialKey={initialKey}
@@ -315,6 +348,9 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
       showPicker={showPicker}
       {...opts}
       session={resolvedSession}
+      qqChannel={qqChannel}
+      qqSubmitRef={qqSubmitRef}
+      qqErrorRef={qqErrorRef}
     />,
     {
       exitOnCtrlC: true,
@@ -336,6 +372,7 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
     await waitUntilExit();
   } finally {
     await runtime.closeAll();
+    qqChannel?.stop();
     // Eat any pending terminal-feature-detection responses (#365) so the
     // parent shell doesn't print them as junk after exit.
     await drainTtyResponses();

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -1,5 +1,5 @@
 import { type WriteStream, statSync } from "node:fs";
-import { basename, resolve } from "node:path";
+import { resolve } from "node:path";
 import { Box, Text, useStdin, useStdout } from "ink";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -63,8 +63,9 @@ import {
   loadSessionMeta,
   patchSessionMeta,
   renameSession,
-  sanitizeName,
 } from "../../memory/session.js";
+import type { QQChannel } from "../../qq/channel.js";
+import { useQQChannel } from "../../qq/use-qq-channel.js";
 import type {
   ActiveModal,
   DashboardEvent,
@@ -108,7 +109,7 @@ import { SessionPicker } from "./SessionPicker.js";
 import { ShellConfirm, type ShellConfirmChoice, derivePrefix } from "./ShellConfirm.js";
 import { SlashArgPicker } from "./SlashArgPicker.js";
 import { SlashSuggestions } from "./SlashSuggestions.js";
-import { ThemePicker } from "./ThemePicker.js";
+import { type ThemeChoice, ThemePicker } from "./ThemePicker.js";
 import { WelcomeBanner } from "./WelcomeBanner.js";
 import { detectBangCommand, formatBangUserMessage } from "./bang.js";
 import { CopyMode } from "./copy-mode/CopyMode.js";
@@ -177,6 +178,7 @@ import { hydrateCardsFromMessages } from "./state/hydrate.js";
 import { InflightProvider } from "./state/inflight-context.js";
 import { AgentStoreProvider, useAgentState, useAgentStore } from "./state/provider.js";
 import { ThemeProvider } from "./theme/context.js";
+import { listThemeNames } from "./theme/tokens.js";
 import { FG, type ThemeName } from "./theme/tokens.js";
 import { TickerProvider } from "./ticker.js";
 import { useCompletionPickers } from "./useCompletionPickers.js";
@@ -190,15 +192,15 @@ export interface AppProps {
   /** Re-runs the prompt builder on /new so REASONIX.md edits don't need a restart. Must produce the same shape as `system` was built from. */
   rebuildSystem?: () => string;
   transcript?: string;
-  /** Soft USD spend cap; undefined → no cap. See CacheFirstLoopOptions.budgetUsd. */
+  /** Soft USD spend cap; undefined 闂?no cap. See CacheFirstLoopOptions.budgetUsd. */
   budgetUsd?: number;
-  /** Per-turn repair-signal count required to escalate flash→pro. Undefined → loop default (3). */
+  /** Per-turn repair-signal count required to escalate flash闂傚倸鍊搁崐鎼佸磹閹间礁纾归柟闂寸绾惧綊鏌熼梻瀵割槮缁炬儳缍婇弻鐔兼⒒鐎靛壊妲紒鐐劤缂嶅﹪寮婚悢鍏尖拻閻庨潧澹婂Σ顔剧磼閻愵剙鍔ょ紓宥咃躬瀵鏁愭径濠勵吅闂佹寧绻傞幉娑㈠箻缂佹鍘辨繝鐢靛Т閸婂綊宕戦妷鈺傜厸閻忕偠顕ф慨鍌溾偓娈垮枟閹告娊骞冨▎寰濆湱鈧綆浜欐竟鏇㈡⒑閸涘﹦缂氶柛搴㈠▕閹矂宕卞☉娆戝幈濡炪倖鍔戦崐鏇㈠几閹达附鐓曟繛鍡楃箳缁犳彃菐閸パ嶈含妞ゃ垺绋戦埥澶婎潨閸℃鐤傜紓鍌欒兌閾忓酣宕㈤崗鍏兼珷濞寸姴顑嗛崕澶嬨亜韫囨挾澧曠紒鐘虫皑閹茬顭ㄩ崼鐔蜂簵婵犻潧鍊搁幉锟犳偂濞戙垺鍊堕柣鎰絻閳锋棃鏌嶉挊澶樻█闁哄苯绉归幐濠冨緞濡儵鏋呴柣搴ゎ潐濞测晝鎹㈠┑瀣畺婵炲棙鍨熼崑鎾绘偨閸涘﹥鐝抽梺瑙勭叀缁犳牕顫忔繝姘＜婵炲棙鍩堝Σ顕€姊虹涵鍜佸殝缂佺粯绻堥獮鍐倻閽樺）銊ф喐鎼达紕鏆﹂柛娆忣槹閸欏繑淇婇悙棰濆殭濞存粓绠栭幃妤€鈻撻崹顔界亪濡炪値鍘鹃崗妯侯嚕椤愶箑绠涢柡澶嬪閵囨繃绻涙潏鍓у埌闁圭⒈鍋勯锝夊箮閼恒儮鎷绘繛杈剧到閹诧繝宕悙鐢电＜妞ゆ棁鍋愭晶锕傛煙椤旀儳浠遍柡浣稿暣瀹曟帒顫濇鏍ㄐ? Undefined 闂?loop default (3). */
   failureThreshold?: number;
   session?: string;
   /**
    * Pre-populated tool registry (e.g. from bridgeMcpTools()). When present,
    * its specs are folded into the ImmutablePrefix so the model sees them,
-   * and its dispatch is used for tool calls — MCP tools become first-class.
+   * and its dispatch is used for tool calls 闂?MCP tools become first-class.
    */
   tools?: ToolRegistry;
   /** Raw `--mcp` / config-derived spec strings, for `/mcp` slash display. */
@@ -219,7 +221,7 @@ export interface AppProps {
    * Shared ref the MCP bridge's onProgress callback writes through.
    * We attach our updater to `progressSink.current` on mount so any
    * `notifications/progress` frame from any bridged tool flows into
-   * the UI. `null` allowed — chat mode without MCP leaves it unset.
+   * the UI. `null` allowed 闂?chat mode without MCP leaves it unset.
    */
   progressSink?: {
     current:
@@ -236,28 +238,26 @@ export interface AppProps {
     rootDir: string;
     jobs?: import("../../tools/jobs.js").JobRegistry;
     /**
-     * `/cwd <path>` callback — re-registers every rootDir-dependent
+     * `/cwd <path>` callback 闂?re-registers every rootDir-dependent
      * native tool against the new path. Optional: when omitted the
      * slash command degrades to updating hook cwd / memory root only,
      * with file/shell tools still pointing at the original root.
      */
     reregisterTools?: (rootDir: string) => void;
     /**
-     * Async tail of the `/cwd` swap — re-probes the new directory for a
+     * Async tail of the `/cwd` swap 闂?re-probes the new directory for a
      * compatible semantic index, registers `semantic_search` against it
      * if found, unregisters the stale binding otherwise. Kept separate
      * from `reregisterTools` so the sync FS/shell/memory re-registration
      * isn't blocked on disk I/O.
      */
     reBootstrapSemantic?: (rootDir: string) => Promise<{ enabled: boolean }>;
-    /** Notify the launcher that the workspace root just changed — lets the rebuildSystem closure see the new dir on the next /cwd. */
-    onRootChange?: (newRoot: string) => void;
   };
   /**
    * When `true`, suppress the auto-launch of the embedded web dashboard
    * server on TUI mount. Default behavior is to boot the dashboard so
    * the URL shows in the status bar (clickable in OSC-8-aware
-   * terminals) — most users had no idea `/dashboard` even existed.
+   * terminals) 闂?most users had no idea `/dashboard` even existed.
    * `--no-dashboard` is the CLI flag that flips this on for CI / users
    * who don't want a localhost listener.
    */
@@ -266,22 +266,28 @@ export interface AppProps {
   openDashboard?: boolean;
   /** Pin the dashboard to a fixed port. `undefined` keeps ephemeral assignment. */
   dashboardPort?: number;
-  /** Mid-chat session swap — Root remounts App with the new session via key. */
+  /** Mid-chat session swap 闂?Root remounts App with the new session via key. */
   onSwitchSession?: (name: string | undefined) => void;
   /**
    * Enable DECSET 1007 (alternate-scroll) so the wheel scrolls chat
-   * on web/cloud/SSH terminals — terminal translates wheel events to
-   * ↑/↓ key sequences in alt-screen, no full mouse tracking, native
+   * on web/cloud/SSH terminals 闂?terminal translates wheel events to
+   * 闂?闂?key sequences in alt-screen, no full mouse tracking, native
    * drag-select + right-click unaffected. Default true. Pass false
    * (CLI: `--no-mouse`) to suppress entirely.
    */
   mouse?: boolean;
   /** One-time startup info rows injected by chatCommand. */
   startupInfoHints?: string[];
+  /** Pre-created QQ channel (started before TUI mounts). */
+  qqChannel?: QQChannel;
+  /** Ref filled by App on mount so QQ messages flow into the TUI input queue. */
+  qqSubmitRef?: { current: ((text: string) => void) | null };
+  /** Ref filled by App on mount so QQ errors appear in the TUI log. */
+  qqErrorRef?: { current: ((msg: string) => void) | null };
 }
 
 /**
- * Throttle interval in ms. 50ms ≈ 20Hz — slow enough that cursor-up
+ * Throttle interval in ms. 50ms 闂?20Hz 闂?slow enough that cursor-up
  * repaints on winpty/MINTTY/ConEmu/tmux don't leave half-drawn frames,
  * fast enough that streaming text still reads as continuous. Override
  * via `REASONIX_FLUSH_MS` if you want 60Hz on a terminal you trust.
@@ -297,7 +303,7 @@ const FLUSH_INTERVAL_MS = (() => {
 /**
  * Renders either the input area (pinned) or the "reading history" hint
  * (scrolled up). Reads `pinned` from the chat-scroll store directly so
- * AppInner doesn't subscribe — toggling pinned only re-renders this leaf.
+ * AppInner doesn't subscribe 闂?toggling pinned only re-renders this leaf.
  */
 function InputAreaWithHistoryHint({
   inputArea,
@@ -306,7 +312,9 @@ function InputAreaWithHistoryHint({
   if (!pinned) {
     return (
       <Text color={FG.faint}>
-        {" 📖 reading history — End / PgDn to return · ↓ to advance one line"}
+        {
+          " 濠电姷鏁告慨鐑藉极閸涘﹥鍙忛柣鎴ｆ閺嬩線鏌涘☉姗堟敾闁告瑥绻橀弻锝夊箣濠垫劖缍楅梺閫炲苯澧柛濠傛健楠炴劖绻濋崘顏嗗骄闂佸啿鎼鍥╃矓椤旈敮鍋撶憴鍕８闁告梹鍨甸锝夊醇閺囩偟顓洪梺缁樼懃閹虫劙鐛姀銈嗏拻闁稿本鐟︾粊鐗堛亜椤愩埄妲搁柣锝呭槻铻ｉ悶娑掑墲閻忓啫鈹戦悙鏉戠仸缁炬澘绉归、鏇熺鐎ｎ偆鍘梺鍓插亝缁诲啴宕戦鍡樺枑闁绘鐗嗙粭姘舵煕鐎ｎ偄濮夐柍褜鍓涢幊鎾寸珶婵犲洤绐楅柡宥庡幖缁€鍫澝归悡搴ｆ憼闁抽攱鍨堕幈銊╂偡閻楀牊鎮欓梺閫炲苯鍘甸柛濠冪箓閻ｇ兘寮剁拠鐐瀹曘劑顢橀崶椋庣暤闁哄本鐩鎾Ω閵壯傚摋闂備礁鎲￠崝蹇涘磻閹剧繝绻嗛柣鎰典簻閳ь剚鐗犲畷婵嬫晝閳ь剟鈥﹂崸妤€鐒垫い鎺戝€荤壕鍏笺亜閺冨倸甯舵い锝呯－缁?reading history 闂?End / PgDn to return 闂?闂?to advance one line"
+        }
       </Text>
     );
   }
@@ -316,7 +324,7 @@ function InputAreaWithHistoryHint({
 /**
  * Captures printable keys / backspace / Enter while history is unpinned so the
  * user can type blind and see the buffer when they scroll back. Lives in its
- * own leaf so AppInner doesn't subscribe to `pinned` — same trick as
+ * own leaf so AppInner doesn't subscribe to `pinned` 闂?same trick as
  * `InputAreaWithHistoryHint` above.
  */
 function HistoryTypingCapture({
@@ -332,10 +340,7 @@ function HistoryTypingCapture({
 }): null {
   const pinned = useChatScrollState((s) => s.pinned);
   useKeystroke((ev) => {
-    if (ev.paste) {
-      setInput(input + ev.input);
-      return;
-    }
+    if (ev.paste) return;
     if (ev.return) {
       onReturnToBottom();
       return;
@@ -368,7 +373,7 @@ function LoopStatusRow({
   const nextFireMs = Math.max(0, loop.nextFireAt - Date.now());
   return (
     <Box>
-      <Text color="cyan">{`▸ ${formatLoopStatus(loop.prompt, nextFireMs, loop.iter)} · /loop stop or type to cancel`}</Text>
+      <Text color="cyan">{`闂?${formatLoopStatus(loop.prompt, nextFireMs, loop.iter)} 闂?/loop stop or type to cancel`}</Text>
     </Box>
   );
 }
@@ -448,6 +453,9 @@ function AppInner({
   onSwitchSession,
   mouse = true,
   startupInfoHints,
+  qqChannel,
+  qqSubmitRef,
+  qqErrorRef,
   themeName,
   setThemeName,
   statusBar,
@@ -526,7 +534,7 @@ function AppInner({
   const { hookList, reloadHooks } = useHookList(codeMode?.rootDir);
   // Session-scoped edit history + undo banner + /undo, /history, /show
   // handlers. Kept in a custom hook so App.tsx only sees the small API
-  // it needs — append an edit, arm the banner, answer the slash
+  // it needs 闂?append an edit, arm the banner, answer the slash
   // callbacks, seal the turn entry, check whether anything's undoable.
   const {
     undoBanner,
@@ -559,12 +567,12 @@ function AppInner({
   const planModeRef = useRef<boolean>(false);
   const latestVersionRef = useRef<string | null>(null);
   // Current per-edit confirmation prompt (review mode, tool-call path).
-  // Non-null → EditConfirm modal renders, interceptor is suspended on
+  // Non-null 闂?EditConfirm modal renders, interceptor is suspended on
   // `editReviewResolveRef.current`, other live rows hide. User picks a
-  // choice → handleEditReviewChoose resolves the promise, interceptor
+  // choice 闂?handleEditReviewChoose resolves the promise, interceptor
   // resumes and returns the tool result the model will see.
   const [pendingEditReview, setPendingEditReview] = useState<EditBlock | null>(null);
-  // /walk active flag — when true the App walks pendingEdits one block
+  // /walk active flag 闂?when true the App walks pendingEdits one block
   // at a time through EditConfirm. Distinct from `pendingEditReview`,
   // which is the AUTO-mode tool-call interceptor. Walkthrough is
   // user-initiated against the QUEUED pending list, not mid-stream.
@@ -615,7 +623,7 @@ function AppInner({
   /** True while the CheckpointPicker is open mid-chat (triggered by bare `/restore`). */
   const [pendingCheckpointPicker, setPendingCheckpointPicker] = useState(false);
   const [checkpointPickerList, setCheckpointPickerList] = useState<CheckpointMeta[]>([]);
-  /** Opens the unified McpHub modal — null when closed. `tab` selects the initial tab. */
+  /** Opens the unified McpHub modal 闂?null when closed. `tab` selects the initial tab. */
   const [pendingMcpHub, setPendingMcpHub] = useState<{ tab: "live" | "marketplace" } | null>(null);
   /** True while the ModelPicker is open mid-chat (triggered by bare `/model`). */
   const [pendingModelPicker, setPendingModelPicker] = useState(false);
@@ -625,7 +633,7 @@ function AppInner({
   // Stashed plan + intent while the user types free-form feedback
   // (refinement or last instructions on approve). When the picker
   // returns "refine" or "approve", we defer the loop-resume and show
-  // PlanRefineInput. User types + Enter → we ship it; Esc → restore
+  // PlanRefineInput. User types + Enter 闂?we ship it; Esc 闂?restore
   // pendingPlan and re-show the picker. Letting Approve also take
   // input closes the "model left open questions, user had no place
   // to answer them" hole.
@@ -635,7 +643,7 @@ function AppInner({
     /** Open-questions / risks block extracted from the plan; surfaced in PlanRefineInput on refine. */
     questions?: string;
   } | null>(null);
-  // Mid-execution pause from mark_step_complete — model finished a step
+  // Mid-execution pause from mark_step_complete 闂?model finished a step
   // and the loop waits for user to pick Continue / Revise / Stop.
   const [pendingCheckpoint, setPendingCheckpoint] = useState<{
     stepId: string;
@@ -663,7 +671,7 @@ function AppInner({
   // user picks an option (synthetic "user picked <id>"), types a
   // custom answer (synthetic "user answered: <text>"), or cancels.
   // Kept separate from pendingPlan because a branch question is
-  // orthogonal to plan state — it can fire in chat mode or mid-plan
+  // orthogonal to plan state 闂?it can fire in chat mode or mid-plan
   // when the model genuinely needs a decision.
   const [pendingChoice, setPendingChoice] = useState<{
     question: string;
@@ -671,7 +679,7 @@ function AppInner({
     allowCustom: boolean;
   } | null>(null);
   // Staged entry for the "Let me type my own answer" path. Same
-  // two-step pattern as stagedInput for plan approvals — user picks
+  // two-step pattern as stagedInput for plan approvals 闂?user picks
   // "custom", we stash the question context, show a free-form input,
   // and Esc restores the picker.
   const [stagedChoiceCustom, setStagedChoiceCustom] = useState<{
@@ -679,7 +687,7 @@ function AppInner({
     options: ChoiceOption[];
     allowCustom: boolean;
   } | null>(null);
-  // Truthy when any pending modal owns the screen — gates global
+  // Truthy when any pending modal owns the screen 闂?gates global
   // hotkeys (chat-scroll, etc.) so they don't fire behind a picker.
   const modalOpen =
     !!pendingShell ||
@@ -699,9 +707,9 @@ function AppInner({
     !!pendingRevision ||
     !!stagedCheckpointRevise ||
     !!pendingCheckpoint;
-  // Plan-mode indicator — displayed in the StatsPanel, mirrored onto
+  // Plan-mode indicator 闂?displayed in the StatsPanel, mirrored onto
   // the ToolRegistry so dispatch enforces read-only. Toggled via the
-  // `/plan` slash and PlanConfirm picker. Ephemeral — not persisted
+  // `/plan` slash and PlanConfirm picker. Ephemeral 闂?not persisted
   // across launches (you explicitly opt in per session).
   const [planMode, setPlanMode] = useState<boolean>(false);
   // Text waiting to be submitted AFTER the current turn finishes.
@@ -712,11 +720,11 @@ function AppInner({
   // submit once busy clears.
   const [queuedSubmit, setQueuedSubmit] = useState<string | null>(null);
   // Ctrl+P/Ctrl+N recall over a turn-local prompt history. We don't
-  // persist to disk — the session log already keeps the messages, and
+  // persist to disk 闂?the session log already keeps the messages, and
   // cross-session bash-style recall would need per-project scoping.
   const { recallPrev, recallNext, pushHistory, resetCursor } = useInputRecall(setInput);
   const { setRawMode, isRawModeSupported } = useStdin();
-  // Ctrl+X — hand the composer buffer to $EDITOR. Raw-mode flip lets the
+  // Ctrl+X 闂?hand the composer buffer to $EDITOR. Raw-mode flip lets the
   // editor own line-buffered input; result replaces the composer value.
   const handleOpenExternalEditor = useCallback(async () => {
     if (!isRawModeSupported) {
@@ -735,8 +743,7 @@ function AppInner({
   // Disambiguates <Static> keys when a single turn yields multiple assistant_final events.
   const assistantIterCounter = useRef<number>(0);
   // Per-session @url fetch cache. Keyed by stripped URL; same URL
-  // referenced twice in one session fetches once. Not persisted —
-  // we deliberately re-fetch on session resume since the page may
+  // referenced twice in one session fetches once. Not persisted 闂?  // we deliberately re-fetch on session resume since the page may
   // have changed. Shape mirrors AtUrlExpansion + an optional `body`
   // so the trailing block can be reconstructed from cache alone.
   const atUrlCache = useRef<Map<string, AtUrlExpansion & { body?: string }>>(new Map());
@@ -746,6 +753,7 @@ function AppInner({
   // synced in a useEffect once handleSubmit is defined.
   const handleSubmitRef = useRef<((raw: string) => Promise<void>) | null>(null);
   const busyRef = useRef<boolean>(false);
+  const submittingRef = useRef<boolean>(false);
   // Embedded dashboard server handle. Set when /dashboard boots; null
   // otherwise. Mutations to this ref happen inside the start/stop
   // callbacks; the slash handler uses getDashboardUrl() to surface
@@ -755,7 +763,7 @@ function AppInner({
   // the auto-start useEffect re-fires (because `startDashboard`'s
   // useCallback deps change mid-mount) the early `if (dashboardRef.current)
   // return` check sees null because the first call hasn't returned from
-  // its `await startDashboardServer()` yet — so we'd start two listeners
+  // its `await startDashboardServer()` yet 闂?so we'd start two listeners
   // on two ports, leak the first handle, and make the chrome pill flicker
   // between two URLs. Hold the in-flight Promise here and reuse it.
   const dashboardStartingRef = useRef<Promise<string> | null>(null);
@@ -775,7 +783,7 @@ function AppInner({
   // Populated only when the model supplied `steps`; used by the
   // `mark_step_complete` handler to look up the step title and compute
   // the `N/M` counter. Reset on every new plan submission so a
-  // revised plan starts fresh — old completions don't spill over.
+  // revised plan starts fresh 闂?old completions don't spill over.
   const planStepsRef = useRef<PlanStep[] | null>(null);
   const completedStepIdsRef = useRef<Set<string>>(new Set());
   // Markdown body + human-friendly summary captured from submit_plan.
@@ -787,7 +795,7 @@ function AppInner({
   const planSummaryRef = useRef<string | null>(null);
   // Wall-clock when the latest tool_start fired. Cleared when the
   // matching `tool` event arrives (or at turn end). Tools are
-  // dispatched serially in the loop, so a single ref is enough — no
+  // dispatched serially in the loop, so a single ref is enough 闂?no
   // need for a per-toolName map.
   const toolStartedAtRef = useRef<number | null>(null);
   // Persist the active plan state (steps + completedStepIds) to disk
@@ -829,11 +837,11 @@ function AppInner({
       startedAt: new Date().toISOString(),
     });
   }
-  // Kernel event log sidecar — opens iff the session has a name (skip
+  // Kernel event log sidecar 闂?opens iff the session has a name (skip
   // ephemeral sessions). Sink + Eventizer share lifetime with App; the
   // for-await consumer below pipes every LoopEvent through them so a
   // typed Event log accumulates at `~/.reasonix/sessions/<name>.events.jsonl`.
-  // Old transcript path is unchanged — this is a parallel artifact, not
+  // Old transcript path is unchanged 闂?this is a parallel artifact, not
   // a replacement. Future replay / projection consumers read from here.
   const eventSinkRef = useRef<JsonlEventSink | null>(null);
   const eventizerRef = useRef<Eventizer | null>(null);
@@ -850,14 +858,14 @@ function AppInner({
   }, []);
 
   const loopRef = useRef<CacheFirstLoop | null>(null);
-  // hookList + currentRootDir intentionally NOT in deps — they seed
+  // hookList + currentRootDir intentionally NOT in deps 闂?they seed
   // the loop on first construction (loopRef guards a single
   // instantiation), and later edits flow in through the mutable
   // `loop.hooks = hookList` / `loop.hookCwd = currentRootDir` effects
   // below. Putting them in deps would tear down the loop on every
   // reload, wiping the append-only log mid-session.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: hookList — see comment above
-  // biome-ignore lint/correctness/useExhaustiveDependencies: currentRootDir — see comment above
+  // biome-ignore lint/correctness/useExhaustiveDependencies: hookList 闂?see comment above
+  // biome-ignore lint/correctness/useExhaustiveDependencies: currentRootDir 闂?see comment above
   const loop = useMemo(() => {
     if (loopRef.current) return loopRef.current;
     const client = new DeepSeekClient({ baseUrl: loadBaseUrl() });
@@ -867,7 +875,7 @@ function AppInner({
     // path covers both code mode and chat mode.
     //
     // The closure captures `tools` (parent registry), `client`, and
-    // the subagent sink ref by lexical scope — `spawnSubagent` reads
+    // the subagent sink ref by lexical scope 闂?`spawnSubagent` reads
     // them per invocation, so a sink handler attached after this
     // registration still receives events.
     if (tools && !tools.has("run_skill")) {
@@ -911,7 +919,7 @@ function AppInner({
       hooks: hookList,
       hookCwd: currentRootDir,
       // Restore the user's last-chosen effort cap. Without this a
-      // `/effort high` silently reverted to `max` on relaunch — the
+      // `/effort high` silently reverted to `max` on relaunch 闂?the
       // loop's constructor default wins over persisted state.
       reasoningEffort: loadReasoningEffort(),
       rebuildSystem,
@@ -965,14 +973,13 @@ function AppInner({
   }, [loop, session, tools]);
 
   // Keep the loop's hook list in sync after a `/hooks reload`. The
-  // loop's field is intentionally mutable for exactly this case —
-  // construction happens once, hook edits are picked up live.
+  // loop's field is intentionally mutable for exactly this case 闂?  // construction happens once, hook edits are picked up live.
   useEffect(() => {
     loop.hooks = hookList;
   }, [loop, hookList]);
 
   // Seed status.preset from initial loop state so the StatusRow preset pill
-  // renders correctly on first paint — usePresetMode's React-state mirror
+  // renders correctly on first paint 闂?usePresetMode's React-state mirror
   // doesn't propagate to the agent store, so without this dispatch the pill
   // would show the bare model id instead of the resolved preset.
   // biome-ignore lint/correctness/useExhaustiveDependencies: mount-only seed
@@ -988,7 +995,7 @@ function AppInner({
     agentStore.dispatch({ type: "session.preset.change", preset: canonical });
   }, []);
 
-  // Deferred MCP bridge — fire addSpec for each requested server in the
+  // Deferred MCP bridge 闂?fire addSpec for each requested server in the
   // background instead of blocking startup, route lifecycle events to
   // the in-app log so they don't corrupt alt-screen via stderr.
   const mcpBridgeStartedRef = useRef(false);
@@ -1023,8 +1030,8 @@ function AppInner({
         bumpReady();
       } else if (notice.kind === "failed") {
         log.pushWarning(
-          `MCP · ${notice.name} failed`,
-          `${notice.reason}\n→ run \`reasonix setup\` to remove this entry, or fix the underlying issue (missing npm package, network, etc.).`,
+          `MCP 闂?${notice.name} failed`,
+          `${notice.reason}\n闂?run \`reasonix setup\` to remove this entry, or fix the underlying issue (missing npm package, network, etc.).`,
         );
         bumpReady();
       } else if (notice.kind === "slow") {
@@ -1045,7 +1052,7 @@ function AppInner({
   }, [mcpRuntime, mcpSpecs, loop, log, agentStore]);
 
   // Ambient session info (balance, model catalog, latest published
-  // version) — three independent mount-time fetches behind one hook
+  // version) 闂?three independent mount-time fetches behind one hook
   // so the refresh callbacks can be wired into handleSubmit's finally
   // (balance) and the slash context (/models, /update).
   const { balance, models, latestVersion, refreshBalance, refreshModels, refreshLatestVersion } =
@@ -1131,11 +1138,11 @@ function AppInner({
   // Each pending* state is the source of truth on the TUI side. These
   // effects fan it out to web subscribers as `modal-up` events; the
   // useEffect cleanup fires `modal-down` when the modal closes (the
-  // user picked from EITHER surface — once a pending state goes null
+  // user picked from EITHER surface 闂?once a pending state goes null
   // the cleanup runs and both clients see it disappear).
   //
-  // The shell + choice + plan paths are straightforward state→event.
-  // edit-review is different — its source of truth is `editReviewResolveRef`
+  // The shell + choice + plan paths are straightforward state闂傚倸鍊搁崐鎼佸磹閹间礁纾归柟闂寸绾惧綊鏌熼梻瀵割槮缁炬儳缍婇弻鐔兼⒒鐎靛壊妲紒鐐劤缂嶅﹪寮婚悢鍏尖拻閻庨潧澹婂Σ顔剧磼閻愵剙鍔ょ紓宥咃躬瀵鏁愭径濠勵吅闂佹寧绻傞幉娑㈠箻缂佹鍘辨繝鐢靛Т閸婂綊宕戦妷鈺傜厸閻忕偠顕ф慨鍌溾偓娈垮枟閹告娊骞冨▎寰濆湱鈧綆浜欐竟鏇㈡⒑閸涘﹦缂氶柛搴㈠▕閹矂宕卞☉娆戝幈濡炪倖鍔戦崐鏇㈠几閹达附鐓曟繛鍡楃箳缁犳彃菐閸パ嶈含妞ゃ垺绋戦埥澶婎潨閸℃鐤傜紓鍌欒兌閾忓酣宕㈤崗鍏兼珷濞寸姴顑嗛崕澶嬨亜韫囨挾澧曠紒鐘虫皑閹茬顭ㄩ崼鐔蜂簵婵犻潧鍊搁幉锟犳偂濞戙垺鍊堕柣鎰絻閳锋棃鏌嶉挊澶樻█闁哄苯绉归幐濠冨緞濡儵鏋呴柣搴ゎ潐濞测晝鎹㈠┑瀣畺婵炲棙鍨熼崑鎾绘偨閸涘﹥鐝抽梺瑙勭叀缁犳牕顫忔繝姘＜婵炲棙鍩堝Σ顕€姊虹涵鍜佸殝缂佺粯绻堥獮鍐倻閽樺）銊ф喐鎼达紕鏆﹂柛娆忣槹閸欏繑淇婇悙棰濆殭濞存粓绠栭幃妤€鈻撻崹顔界仌濡炪倖娉﹂崶鑸垫櫍婵犻潧鍊婚…鍫ユ煁閸ャ劊浜滈柟鎷屾硾瀵攱銇勯幒鎴濐仾闁抽攱甯掗湁闁挎繂娲ら崝瀣煕閵堝倸浜鹃梺璇插椤旀牠宕伴弽顓熷亯濠靛倻顭堢粻姘扁偓鍏夊亾闁告洦鍓欐禍顖涚節?
+  // edit-review is different 闂?its source of truth is `editReviewResolveRef`
   // (a promise the dispatch interceptor is awaiting), wired via a
   // separate `pendingEditReview` state that we already broadcast here.
 
@@ -1180,7 +1187,7 @@ function AppInner({
 
   useEffect(() => {
     if (!pendingEditReview) return;
-    // Trim the preview — older clients only render this string; newer
+    // Trim the preview 闂?older clients only render this string; newer
     // clients use `search`/`replace` directly to render a side-by-side
     // diff with syntax highlighting (full content, no line cap).
     const previewLines = (pendingEditReview.search || pendingEditReview.replace || "")
@@ -1243,7 +1250,7 @@ function AppInner({
   }, [pendingCheckpoint, broadcastDashboardEvent]);
 
   // Three mutually-exclusive input-prefix pickers (slash name, @ file
-  // mention, slash argument) — state + memos + commit callbacks live
+  // mention, slash argument) 闂?state + memos + commit callbacks live
   // in a dedicated hook so App.tsx only sees the small surface it
   // actually consumes in useInput / handleSubmit / render. Declared
   // after useSessionInfo because the slash-arg picker reads the model
@@ -1263,7 +1270,6 @@ function AppInner({
     slashArgMatches,
     slashArgSelected,
     setSlashArgSelected,
-    slashArgPathCandidates,
     pickSlashArg,
   } = useCompletionPickers({
     input,
@@ -1277,7 +1283,7 @@ function AppInner({
 
   // Ctrl+P / Ctrl+N from PromptInput route here. When any input-prefix
   // picker is open (slash / @ / slash-arg), the keys navigate that picker
-  // — consistent with ↑/↓. Otherwise they walk prompt history (issue #647).
+  // 闂?consistent with 闂?闂? Otherwise they walk prompt history (issue #647).
   const handleHistoryPrev = useCallback(() => {
     if (atState && atState.entries.length > 0) {
       setAtSelected((i) => Math.max(0, i - 1));
@@ -1358,7 +1364,7 @@ function AppInner({
     // structured state to pick back up.
     // Guard: skip restoration when the session has zero prior messages
     // (truly fresh). A stale plan file from a prior wipe that wasn't
-    // cleaned up is not a real plan to resume — it's a sidecar orphan.
+    // cleaned up is not a real plan to resume 闂?it's a sidecar orphan.
     if (session && loop.resumedMessageCount > 0) {
       const restoredPlan = loadPlanState(session);
       if (restoredPlan && restoredPlan.steps.length > 0) {
@@ -1368,7 +1374,7 @@ function AppInner({
         planSummaryRef.current = restoredPlan.summary ?? null;
         const when = relativeTime(restoredPlan.updatedAt);
         const done = new Set(restoredPlan.completedStepIds);
-        const summary = restoredPlan.summary ? ` — ${restoredPlan.summary}` : "";
+        const summary = restoredPlan.summary ? ` 闂?${restoredPlan.summary}` : "";
         log.showPlan({
           title: t("ui.resumedPlan", { when, summary }),
           steps: restoredPlan.steps.map((s) => ({
@@ -1384,7 +1390,7 @@ function AppInner({
     // wouldn't otherwise discover Shift+Tab (it's in /keys and the
     // bottom status bar, but both require looking). Shown exactly once
     // per install; the config flag suppresses re-display on every
-    // relaunch. Skips chat mode — those shortcuts don't apply there.
+    // relaunch. Skips chat mode 闂?those shortcuts don't apply there.
     if (codeMode && !editModeHintShown()) {
       const tip = tObj<{
         topic: string;
@@ -1408,9 +1414,9 @@ function AppInner({
   // Esc handles "abort the current turn" separately; Ctrl+C is the universal "I'm done" key.
   const quitProcess = useQuit(transcriptRef);
 
-  // ↑/↓/PgUp/PgDn always scroll chat; wheel arrives as ↑/↓ via
+  // 闂?闂?PgUp/PgDn always scroll chat; wheel arrives as 闂?闂?via
   // DECSET 1007 alternate-scroll so it joins the same path. Pickers
-  // (slash / @-mention / slash-arg / shell-confirm) own ↑/↓ — when
+  // (slash / @-mention / slash-arg / shell-confirm) own 闂?闂?闂?when
   // any of them is open we skip the arrow path so chat doesn't scroll
   // alongside picker navigation; PgUp/PgDn/End still scroll. Prompt
   // history + multi-line cursor moves live on Ctrl+P / Ctrl+N.
@@ -1428,14 +1434,14 @@ function AppInner({
     else if (!pickerOwnsArrows && ev.downArrow) chatScroll.scrollDown();
   }, !modalOpen);
 
-  // Esc during busy → forward to the loop as an abort signal. The loop
+  // Esc during busy 闂?forward to the loop as an abort signal. The loop
   // finishes the tool call in flight (we can't kill subprocess stdio
   // mid-write), then diverts to its no-tools summary path so the user
   // gets an answer instead of a hard stop. Only listens while busy so
   // we don't accidentally hijack Esc in other contexts.
   //
   // Prompt history (Ctrl+P/Ctrl+N) is handed off from PromptInput via
-  // recallPrev/recallNext below — parent-level useInput is simpler
+  // recallPrev/recallNext below 闂?parent-level useInput is simpler
   // than ink-text-input's (absent) history support and lets us own
   // the cursor semantics.
   useKeystroke((ev) => {
@@ -1455,15 +1461,6 @@ function AppInner({
       quitProcess();
       return;
     }
-    // Typeahead queue management: Esc recalls for editing.
-    if (queuedSubmit !== null && busy) {
-      if (key.escape) {
-        setInput(queuedSubmit);
-        setQueuedSubmit(null);
-        loop.steer(null);
-        return;
-      }
-    }
     if (key.escape && busy) {
       if (abortedThisTurn.current) return;
       abortedThisTurn.current = true;
@@ -1472,7 +1469,7 @@ function AppInner({
       // plan_checkpoint / plan_proposed / choice / shell modal would
       // strand its tool fn and busy would never clear.
       resetPendingModals();
-      // Esc during a busy turn also kills any active /loop — the user
+      // Esc during a busy turn also kills any active /loop 闂?the user
       // is taking over. Loops persist past plain Esc when the system is
       // idle so a long-cadence loop doesn't die from random key noise.
       if (isLoopActive()) stopLoop();
@@ -1488,13 +1485,13 @@ function AppInner({
     }
     // Esc dismisses any composer-level picker (slash / @ / slash-arg)
     // by clearing the prefix that triggered it. Picker footers advertise
-    // "esc cancel" — this binds it.
+    // "esc cancel" 闂?this binds it.
     if (key.escape && !busy && (slashMatches || atState || slashArgContext)) {
       setInput("");
       return;
     }
     // Esc inside a /walk session exits the walk WITHOUT applying or
-    // discarding the current block — remaining edits stay queued so
+    // discarding the current block 闂?remaining edits stay queued so
     // the user can resume via /walk or commit via /apply later.
     if (key.escape && walkthroughActive) {
       setWalkthroughActive(false);
@@ -1506,8 +1503,8 @@ function AppInner({
       );
       return;
     }
-    // Edit-mode cycle: Shift+Tab flips review ↔ auto. Available any
-    // time a modal isn't up — including mid-turn — so the user can
+    // Edit-mode cycle: Shift+Tab flips review 闂?auto. Available any
+    // time a modal isn't up 闂?including mid-turn 闂?so the user can
     // switch gears without abandoning the in-flight request. Prefer
     // this to typing `/mode <x>`; one keystroke, no command parsing.
     if (
@@ -1528,7 +1525,7 @@ function AppInner({
       !stagedChoiceCustom &&
       !pendingRevision
     ) {
-      // Three-stop cycle: review → auto → yolo → review. yolo also
+      // Three-stop cycle: review 闂?auto 闂?yolo 闂?review. yolo also
       // disables shell confirmations so true zero-prompt iteration takes two Shift+Tabs from default.
       const cur = editModeRef.current;
       const next: EditMode = cur === "review" ? "auto" : cur === "auto" ? "yolo" : "review";
@@ -1564,7 +1561,7 @@ function AppInner({
       !stagedChoiceCustom &&
       !pendingRevision &&
       // Fire when EITHER the banner is up OR there's any non-undone
-      // history entry — the keybind is useful long after the 5-second
+      // history entry 闂?the keybind is useful long after the 5-second
       // banner expires, which users rightly want.
       (undoBanner || hasUndoable())
     ) {
@@ -1622,12 +1619,12 @@ function AppInner({
     }
     if (busy) return;
     // ShellConfirm owns the full keyboard while it's showing. If we
-    // kept handling ↑/↓ / Tab here they'd race with its SingleSelect
-    // — the picker would move AND history recall would fire into the
+    // kept handling 闂?闂?/ Tab here they'd race with its SingleSelect
+    // 闂?the picker would move AND history recall would fire into the
     // (hidden) prompt buffer. Bail early.
     if (pendingShell || pendingPath) return;
 
-    // @-mention picker takes the same priority tier as slash. ↑/↓ walk
+    // @-mention picker takes the same priority tier as slash. 闂?闂?walk
     // the list; Tab on a folder drills into it, Tab on a file commits.
     // Enter is caught in handleSubmit. Right arrow stays cursor-move
     // (would otherwise fight PromptInput's multiline cursor). Must come
@@ -1649,11 +1646,10 @@ function AppInner({
       }
     }
 
-    // Slash-argument picker. Fires inside `/<cmd> <partial>` — either
-    // a path picker (for /cwd), enum picker (for /preset, /model,
+    // Slash-argument picker. Fires inside `/<cmd> <partial>` 闂?either
+    // a file picker (for /edit), enum picker (for /preset, /model,
     // /plan, /branch, /harvest), or hint-only row. Navigation + Tab
-    // substitute the highlighted value at the arg's offset. For path
-    // completers, directories drill (trailing `/`), files commit.
+    // substitute the highlighted value at the arg's offset.
     if (slashArgMatches && slashArgMatches.length > 0) {
       if (key.upArrow) {
         setSlashArgSelected((i) => Math.max(0, i - 1));
@@ -1665,18 +1661,14 @@ function AppInner({
       }
       if (key.tab) {
         const sel = slashArgMatches[slashArgSelected] ?? slashArgMatches[0];
-        if (sel) {
-          const candidate =
-            slashArgPathCandidates?.[slashArgSelected] ?? slashArgPathCandidates?.[0];
-          pickSlashArg(sel, candidate?.isDir);
-        }
+        if (sel) pickSlashArg(sel);
         return;
       }
     }
 
     // Slash-suggestion mode takes priority over history recall.
-    // When the user is typing a `/…` prefix and there are matches,
-    // ↑/↓ walk the suggestion list and Tab snaps the input to the
+    // When the user is typing a `/闂傚倸鍊搁崐鎼佸磹閹间礁纾归柟闂寸绾惧綊鏌熼梻瀵割槮缁炬儳缍婇弻鐔兼⒒鐎靛壊妲紒鐐劤缂嶅﹪寮婚悢鍏尖拻閻庨潧澹婂Σ顔剧磼閻愵剙鍔ょ紓宥咃躬瀵鏁愭径濠勵吅闂佹寧绻傞幉娑㈠箻缂佹鍘遍梺闈涚墕閹冲酣顢旈銏＄厸閻忕偛澧藉ú瀛樸亜閵忊剝绀嬮柡浣瑰姍瀹曞崬鈻庡Ο鎭嶆氨绱撻崒娆掑厡闁稿鎹囧畷鏇㈠箮鐟欙絺鍋撻敃鍌涘€婚柦妯侯槼閹芥洟姊洪崫鍕窛闁哥姵鎸剧划缁樸偅閸愨晝鍘介梺閫涘嵆濞佳勬櫠椤栫偞鐓熸繝闈涙处閳锋帞绱掓潏銊ユ诞闁诡喗鐟╅、妤呭焵椤掑嫬绀夐柕鍫濇缁犲墽鐥銏╂缂佲檧鍋撻柣搴㈩問閸犳盯顢氳閸┿儲寰勬繛銏㈠枛閺屻劎鈧綆鍋呭鎴︽⒒閸屾瑨鍏岀痪顓炵埣瀹曟粌鈹戠€ｃ劉鍋撻崘顓犵杸闁哄啫鍋嗗ù鍕⒒娓氬洤澧紒澶屾暬閸?prefix and there are matches,
+    // 闂?闂?walk the suggestion list and Tab snaps the input to the
     // highlighted command. Enter is handled in `handleSubmit` so
     // TextInput's onSubmit still fires cleanly.
     if (slashMatches && slashMatches.length > 0) {
@@ -1695,9 +1687,9 @@ function AppInner({
       }
     }
 
-    // Prompt history is now Ctrl+P / Ctrl+N (PromptInput → multiline
-    // keys → historyHandoff → recallPrev / recallNext below). ↑/↓ are
-    // reserved for chat scroll — without that move, native drag-select
+    // Prompt history is now Ctrl+P / Ctrl+N (PromptInput 闂?multiline
+    // keys 闂?historyHandoff 闂?recallPrev / recallNext below). 闂?闂?are
+    // reserved for chat scroll 闂?without that move, native drag-select
     // and right-click paste don't work on most terminals because we'd
     // have to keep xterm mouse tracking on to grab the wheel.
   });
@@ -1706,14 +1698,14 @@ function AppInner({
   // calls through the review queue (in `review` mode) or the auto-apply
   // snapshot/banner path (in `auto` mode) so the model's tool usage
   // respects the same gate as its text-form SEARCH/REPLACE output.
-  // Without this, edit_file bypasses `/apply` entirely — which was the
+  // Without this, edit_file bypasses `/apply` entirely 闂?which was the
   // bug that made the preview flow feel absent pre-0.5.24.
   //
   // `editModeRef` is read inside the closure so mode cycles don't need
   // to reinstall the hook. Cleanup clears the slot on unmount so a
   // follow-up App instance (tests, HMR) starts with a fresh registry.
   //
-  // biome-ignore lint/correctness/useExhaustiveDependencies: session / setEditMode / syncPendingCount are intentional closure captures — their updaters are stable and we don't want to tear down and rebuild the interceptor on unrelated state churn
+  // biome-ignore lint/correctness/useExhaustiveDependencies: session / setEditMode / syncPendingCount are intentional closure captures 闂?their updaters are stable and we don't want to tear down and rebuild the interceptor on unrelated state churn
   useEffect(() => {
     if (!tools || !codeMode) return;
     tools.setToolInterceptor(async (name, args) => {
@@ -1730,8 +1722,7 @@ function AppInner({
       if (!relPath) return null;
 
       // Read root via ref so a workspace swap (which runs reregisterTools
-      // for read_file/run_command) is also visible to this interceptor —
-      // otherwise edit_file writes to the OLD root while read_file looks in
+      // for read_file/run_command) is also visible to this interceptor 闂?      // otherwise edit_file writes to the OLD root while read_file looks in
       // the NEW one, producing ENOENT on the next read of a just-edited file.
       const rootForEdit = currentRootDirRef.current;
       let block: EditBlock;
@@ -1743,7 +1734,7 @@ function AppInner({
       } else {
         // write_file: capture the current content (if any) as SEARCH so
         // the queued block is a literal whole-file overwrite. For new
-        // files SEARCH stays empty — applyEditBlock's create-new sentinel.
+        // files SEARCH stays empty 闂?applyEditBlock's create-new sentinel.
         const content = typeof args.content === "string" ? args.content : "";
         block = toWholeFileEditBlock(relPath, content, rootForEdit);
       }
@@ -1755,7 +1746,7 @@ function AppInner({
       //
       // Does NOT push an info row to scrollback: the returned string
       // becomes the tool result AND the loop yields a `tool` event right
-      // after — ToolCard renders that with the same text. Pushing here
+      // after 闂?ToolCard renders that with the same text. Pushing here
       // would produce "result shown twice".
       const applyNow = (): string => {
         const snaps = snapshotBeforeEdits([block], rootForEdit);
@@ -1768,7 +1759,7 @@ function AppInner({
         return formatEditResults(results);
       };
 
-      // yolo behaves like auto for edit application — the only extra
+      // yolo behaves like auto for edit application 闂?the only extra
       // power yolo adds is bypassing shell confirmations (handled in
       // shell.ts via the allowAll getter).
       if (editModeRef.current === "auto" || editModeRef.current === "yolo") return applyNow();
@@ -1776,7 +1767,7 @@ function AppInner({
       // review mode, tool-call path: suspend the interceptor on the
       // per-edit modal unless the user has already hit "apply-rest-of-
       // turn" earlier in the same turn. Text-form SEARCH/REPLACE blocks
-      // in assistant_final still queue for end-of-turn preview — they
+      // in assistant_final still queue for end-of-turn preview 闂?they
       // land all at once with no mid-stream opportunity to prompt.
       if (turnEditPolicyRef.current === "apply-all") return applyNow();
 
@@ -1792,7 +1783,7 @@ function AppInner({
       if (choice === "reject") {
         const context = denyContext ? ` because: ${denyContext}` : "";
         log.pushInfo(t("app.rejectedEdit", { path: block.path, context }));
-        return `User rejected this edit to ${block.path}${context}. Don't retry the same SEARCH/REPLACE — either try a different approach or ask the user what they want instead.`;
+        return `User rejected this edit to ${block.path}${context}. Don't retry the same SEARCH/REPLACE 闂?either try a different approach or ask the user what they want instead.`;
       }
       if (choice === "apply-rest-of-turn") {
         turnEditPolicyRef.current = "apply-all";
@@ -1860,16 +1851,16 @@ function AppInner({
       return "/walk is only available inside `reasonix code`.";
     }
     if (pendingEdits.current.length === 0) {
-      return "nothing pending — nothing to walk through.";
+      return "nothing pending 闂?nothing to walk through.";
     }
     setWalkthroughActive(true);
-    return `▸ walking ${pendingEdits.current.length} edit block(s) — y apply · n reject · a apply rest · A flip to AUTO · Esc cancels (keeps remaining queued).`;
+    return `闂?walking ${pendingEdits.current.length} edit block(s) 闂?y apply 闂?n reject 闂?a apply rest 闂?A flip to AUTO 闂?Esc cancels (keeps remaining queued).`;
   }, [codeMode, pendingEdits]);
 
   // Embedded dashboard server lifecycle. Boot is async (server has to
   // bind a port + read static assets); the slash handler kicks this
   // off and reads the URL out of `dashboardRef` once the promise
-  // resolves. Tear-down is also async but cheap — close drains
+  // resolves. Tear-down is also async but cheap 闂?close drains
   // in-flight requests within a 1s grace window.
   const startDashboard = useCallback(async (): Promise<string> => {
     if (dashboardRef.current) return dashboardRef.current.url;
@@ -1918,7 +1909,7 @@ function AppInner({
             try {
               savePreset(canonical);
             } catch {
-              /* disk full / perms — runtime change still took effect */
+              /* disk full / perms 闂?runtime change still took effect */
             }
           },
           applyEffortLive: (effort) => {
@@ -1954,7 +1945,7 @@ function AppInner({
             }
             const fn = handleSubmitRef.current;
             if (!fn) return { accepted: false, reason: "TUI not ready" };
-            // Fire-and-forget — handleSubmit drives the loop event stream
+            // Fire-and-forget 闂?handleSubmit drives the loop event stream
             // which the web sees via SSE. We don't await it here because
             // a turn can take minutes; the HTTP request would time out.
             fn(text).catch(() => undefined);
@@ -1995,7 +1986,7 @@ function AppInner({
           },
           // ---------- Modal mirroring ----------
           getActiveModal: (): ActiveModal | null => {
-            // Probe the live state via refs in priority order — only one
+            // Probe the live state via refs in priority order 闂?only one
             // modal can be up at a time per App invariant.
             const ps = pendingShell;
             if (ps) {
@@ -2076,7 +2067,7 @@ function AppInner({
               return;
             }
             const plan = pendingPlanRef.current ?? "";
-            // Bypass the picker → input two-step on web. The override
+            // Bypass the picker 闂?input two-step on web. The override
             // form of handleStagedInputSubmit takes the plan + mode
             // directly; behaviour matches the TUI's "user typed feedback +
             // pressed Enter" path.
@@ -2176,7 +2167,7 @@ function AppInner({
     try {
       await h.close();
     } catch {
-      /* swallow — server going down is best-effort */
+      /* swallow 闂?server going down is best-effort */
     }
     log.pushInfo(t("app.dashboardStopped"));
   }, [log]);
@@ -2195,8 +2186,7 @@ function AppInner({
   // opted out with --no-dashboard. The whole point is discoverability:
   // most users had no idea /dashboard existed, so the URL needs to be
   // visible from the first render. startDashboard updates the React
-  // state itself, so we just fire-and-forget. Failures stay silent —
-  // a missing dashboard never blocks the TUI.
+  // state itself, so we just fire-and-forget. Failures stay silent 闂?  // a missing dashboard never blocks the TUI.
   useEffect(() => {
     if (noDashboard) return;
     if (dashboardRef.current) return;
@@ -2208,7 +2198,7 @@ function AppInner({
         // Auto-start failure surfaces as a visible warn row. The URL
         // itself is shown on the welcome card (when the server is up),
         // so silence here would leave the user with no way to know the
-        // web UI is unreachable — port already in use, permission
+        // web UI is unreachable 闂?port already in use, permission
         // denied, etc. Don't block the TUI; everything else keeps working.
         const reason = err instanceof Error ? err.message : String(err);
         log.pushInfo(t("ui.dashboardAutoStartFailed", { reason }));
@@ -2230,7 +2220,7 @@ function AppInner({
   /**
    * onChoose for the walkthrough EditConfirm. Each pick mutates
    * pendingEdits via the existing codeApply/codeDiscard helpers, which
-   * also bump pendingTick → the modal re-renders with the next block.
+   * also bump pendingTick 闂?the modal re-renders with the next block.
    * When no blocks remain, the modal unmounts.
    */
   const handleWalkChoice = useCallback(
@@ -2248,7 +2238,7 @@ function AppInner({
         return;
       } else if (choice === "flip-to-auto") {
         // Flip the gate first, then apply the current block, then exit
-        // the walk. Remaining blocks stay pending — the user can keep
+        // the walk. Remaining blocks stay pending 闂?the user can keep
         // walking via /walk again or commit them with /apply.
         setEditMode("auto");
         saveEditMode("auto");
@@ -2266,10 +2256,121 @@ function AppInner({
     [codeApply, codeDiscard, log, pendingEdits, setEditMode],
   );
 
+  const pendingGateIdRef = useRef<number | null>(null);
+  const handleShellConfirmRef = useRef<
+    (choice: "run_once" | "always_allow" | "deny", denyContext?: string) => void
+  >(() => undefined);
+  const handlePathConfirmRef = useRef<
+    (choice: "run_once" | "always_allow" | "deny", denyContext?: string) => void
+  >(() => undefined);
+  const handlePlanCancelRef = useRef<() => void | Promise<void>>(() => undefined);
+  const handlePlanFeedbackRef = useRef<
+    (
+      feedback: string,
+      override: { plan: string; mode: "refine" | "approve" | "reject" },
+    ) => void | Promise<void>
+  >(() => undefined);
+  const handleCheckpointConfirmRef = useRef<(choice: "continue" | "revise" | "stop") => void>(
+    () => undefined,
+  );
+  const handleCheckpointReviseSubmitRef = useRef<
+    (feedback: string, snap: { stepId: string; title?: string }) => void
+  >(() => undefined);
+  const handleReviseConfirmRef = useRef<(choice: ReviseChoice | "cancel") => void | Promise<void>>(
+    () => undefined,
+  );
+  const handleChoiceResolveRef = useRef<
+    (
+      resolution:
+        | { type: "pick"; optionId: string }
+        | { type: "text"; text: string }
+        | { type: "cancel" },
+    ) => void
+  >(() => undefined);
+
+  const handleQQModelPick = useCallback(
+    (target: string): string => {
+      if (target === "auto" || target === "flash" || target === "pro") {
+        const preset = PRESETS[target];
+        loop.configure({
+          model: preset.model,
+          autoEscalate: preset.autoEscalate,
+          reasoningEffort: preset.reasoningEffort,
+        });
+        agentStore.dispatch({ type: "session.model.change", model: preset.model });
+        setPreset(target);
+        agentStore.dispatch({ type: "session.preset.change", preset: target });
+        try {
+          savePreset(target);
+        } catch {}
+        return `preset: ${target} / ${preset.model}`;
+      }
+
+      loop.configure({ model: target, autoEscalate: false });
+      agentStore.dispatch({ type: "session.model.change", model: target });
+      const inferred =
+        target === "deepseek-v4-pro" ? "pro" : target === "deepseek-v4-flash" ? "flash" : null;
+      setPreset(inferred ?? "flash");
+      agentStore.dispatch({ type: "session.preset.change", preset: inferred });
+      if (inferred) {
+        try {
+          savePreset(inferred);
+        } catch {}
+      }
+      return `model: ${target}`;
+    },
+    [agentStore, loop, setPreset],
+  );
+
+  const handleQQThemePick = useCallback(
+    (target: ThemeChoice): string => {
+      saveTheme(target);
+      const active = resolveThemePreference(target, process.env.REASONIX_THEME);
+      setThemeName(active);
+      return `theme saved: ${target}\nactive now: ${active}`;
+    },
+    [setThemeName],
+  );
+
+  const qq = useQQChannel({
+    codeMode: !!codeMode,
+    initialChannel: qqChannel,
+    log,
+    isRawModeSupported,
+    setRawMode,
+    setQueuedSubmit,
+    qqSubmitRef,
+    qqErrorRef,
+    sessionName: session,
+    currentRootDir,
+    pendingGateIdRef,
+    completedStepIdsRef,
+    planStepsRef,
+    onCreateSession: onSwitchSession ? (name) => onSwitchSession(name) : undefined,
+    onSelectSession: onSwitchSession ? (name) => onSwitchSession(name) : undefined,
+    onModelPick: handleQQModelPick,
+    onThemePick: handleQQThemePick,
+    onShellConfirmRef: handleShellConfirmRef,
+    onPathConfirmRef: handlePathConfirmRef,
+    onPlanCancelRef: handlePlanCancelRef,
+    onPlanFeedbackRef: handlePlanFeedbackRef,
+    onCheckpointConfirmRef: handleCheckpointConfirmRef,
+    onCheckpointReviseRef: handleCheckpointReviseSubmitRef,
+    onPlanRevisionRef: handleReviseConfirmRef,
+    onChoiceResolveRef: handleChoiceResolveRef,
+  });
+
   const handleSubmit = useCallback(
     async (raw: string) => {
-      let text = raw.trim();
-      if (!text) return;
+      const incoming = qq.parseSubmit(raw);
+      if (!incoming) return;
+      let { text, fromQQ } = incoming;
+      if (incoming.handled) {
+        return;
+      }
+      if (busy || submittingRef.current) {
+        return;
+      }
       // Cancel-on-user-input: any user-typed submit cancels an active
       // /loop, regardless of busy state. Loop-fired submits set the
       // firing flag so the timer's own re-submit doesn't self-cancel.
@@ -2277,19 +2378,8 @@ function AppInner({
         stopLoop();
       }
       clearFiringFlag();
-      if (busy) {
-        // Typeahead: append to queued message (merged on submit).
-        // Also write to loop.steer() so the message gets injected
-        // at the next iteration boundary without aborting the turn.
-        setInput("");
-        const merged = queuedSubmit ? `${queuedSubmit}\n${text}` : text;
-        setQueuedSubmit(merged);
-        loop.steer(merged);
-        return;
-      }
-
       // @-mention picker intercept. Enter on either a file or a folder
-      // commits the path INTO the buffer (with trailing space) — the
+      // commits the path INTO the buffer (with trailing space) 闂?the
       // user almost always types more after a mention. The trailing
       // space dismisses the picker, so the next Enter submits normally.
       // Folders inline as a directory listing at submit time.
@@ -2301,23 +2391,13 @@ function AppInner({
         }
       }
 
-      // Slash-argument picker intercept — same shape as @-picker. For
+      // Slash-argument picker intercept 闂?same shape as @-picker. For
       // file pickers (/edit) we splice + trailing space so the user
       // keeps typing the instruction. For enum pickers (/preset,
-      // /model, /plan, …) we splice without trailing space; those
+      // /model, /plan, 闂? we splice without trailing space; those
       // commands take no further args, so the user presses Enter a
       // second time to run.
-      //
-      // When the partial ends with `/` (browse mode, e.g. after Tab-
-      // completing a directory in `/cwd`), the user has already landed
-      // on the path they want — skip the picker and let Enter submit
-      // the command directly.
-      if (
-        slashArgMatches &&
-        slashArgMatches.length > 0 &&
-        slashArgContext &&
-        !slashArgContext.partial.endsWith("/")
-      ) {
+      if (slashArgMatches && slashArgMatches.length > 0 && slashArgContext) {
         const sel = slashArgMatches[slashArgSelected] ?? slashArgMatches[0];
         if (sel) {
           pickSlashArg(sel);
@@ -2327,7 +2407,7 @@ function AppInner({
 
       // Slash auto-complete on Enter. When the user typed a prefix
       // (e.g. "/he") and the suggestion list is visible, substitute
-      // the highlighted match so Enter runs it — same effect as Tab
+      // the highlighted match so Enter runs it 闂?same effect as Tab
       // + Enter, one keystroke less. Skip substitution if the user
       // already typed a full, exact command name (respect verbatim
       // input when they know what they want).
@@ -2345,7 +2425,7 @@ function AppInner({
       resetCursor();
 
       // Y/N fast-path when edits are pending. One keystroke is all it
-      // takes to commit or drop — matches the muscle memory of `git
+      // takes to commit or drop 闂?matches the muscle memory of `git
       // add -p` / most prompts. Deliberately scoped: only when there
       // ARE pending edits, so "y" as a normal message still works
       // when nothing's waiting.
@@ -2355,7 +2435,7 @@ function AppInner({
         return;
       }
 
-      // Hash mode — `#note` (project) and `#g note` (global) append to
+      // Hash mode 闂?`#note` (project) and `#g note` (global) append to
       // a REASONIX.md so future sessions pin the note in the immutable
       // prefix. No model round-trip. `\#literal` escape falls through to
       // normal submission with the backslash stripped so the model sees
@@ -2379,13 +2459,12 @@ function AppInner({
       }
       if (hashParse?.kind === "escape") {
         // Replace the working buffer with the de-escaped form. We don't
-        // recurse into handleSubmit to avoid the "still busy" race —
-        // just rewrite `text` and let the rest of the pipeline (bang /
+        // recurse into handleSubmit to avoid the "still busy" race 闂?        // just rewrite `text` and let the rest of the pipeline (bang /
         // slash / model) see the literal prompt.
         text = hashParse.text;
       }
 
-      // Bash mode — `!cmd` runs a shell command in the sandbox root
+      // Bash mode 闂?`!cmd` runs a shell command in the sandbox root
       // immediately (no allowlist gate: user-typed = explicit consent),
       // surfaces the formatted output in the Historical log, and
       // persists a user-role message so the next model turn sees what
@@ -2416,7 +2495,7 @@ function AppInner({
         return;
       }
 
-      // `/btw <question>` — one-shot side question. Same async-not-fit-
+      // `/btw <question>` 闂?one-shot side question. Same async-not-fit-
       // handleSlash shape as MCP browse: intercept here, call the client
       // directly with a fresh message list, never append to `loop.messages`
       // so the side exchange leaves the conversation context untouched.
@@ -2452,7 +2531,7 @@ function AppInner({
         return;
       }
 
-      // MCP resource / prompt browsers — async calls that don't fit the
+      // MCP resource / prompt browsers 闂?async calls that don't fit the
       // synchronous handleSlash shape, so we intercept the exact command
       // forms here. The slash-command registry still lists them (for
       // /help + argument-level picker completion), but this branch is
@@ -2478,7 +2557,6 @@ function AppInner({
         }
         setSlashUsage(recordSlashUse(slash.cmd));
         const result = handleSlash(slash.cmd, slash.args, loop, {
-          configPath: defaultConfigPath(),
           mcpSpecs,
           mcpServers: liveMcpServers,
           codeUndo: codeMode ? codeUndo : undefined,
@@ -2519,9 +2597,14 @@ function AppInner({
           startDashboard,
           stopDashboard,
           getDashboardUrl,
+          qq: {
+            connect: qq.connect,
+            disconnect: qq.disconnect,
+            status: qq.status,
+          },
           sessionId: session,
           jobs: codeMode?.jobs,
-          postInfo: (text: string) => log.pushInfo(text),
+          postInfo: fromQQ ? qq.sendInfo : log.pushInfo,
           postDoctor: (checks) => log.showDoctor(checks),
           postUsage: (args) => log.showUsageVerbose(args),
           postKeys: (args) =>
@@ -2571,37 +2654,24 @@ function AppInner({
                 codeMode.reregisterTools?.(resolved);
                 setCurrentRootDir(resolved);
                 reloadHooks(resolved);
-                codeMode.onRootChange?.(resolved);
-                // Mirror code.tsx's launch-time formula so the session label tracks the workspace basename.
-                const newSessionName = `code-${sanitizeName(basename(resolved))}`;
-                loop.switchWorkspace({ sessionName: newSessionName });
-                agentStore.dispatch({
-                  type: "session.workspace.change",
-                  id: newSessionName,
-                  workspace: resolved,
-                });
                 const reBootstrap = codeMode.reBootstrapSemantic;
                 if (reBootstrap) {
                   void reBootstrap(resolved).then(
                     (r) => {
                       log.pushInfo(
                         r.enabled
-                          ? `▸ semantic_search re-pointed at ${resolved}`
-                          : `▸ semantic_search disabled (no compatible index in ${resolved})`,
+                          ? `闂?semantic_search re-pointed at ${resolved}`
+                          : `闂?semantic_search disabled (no compatible index in ${resolved})`,
                       );
                     },
                     (err) => {
                       log.pushInfo(
-                        `▸ semantic_search re-bootstrap failed: ${(err as Error).message}`,
+                        `闂?semantic_search re-bootstrap failed: ${(err as Error).message}`,
                       );
                     },
                   );
                 }
-                return {
-                  ok: true,
-                  info: `▸ workspace switched to ${resolved} · session: ${newSessionName}`,
-                  clear: true,
-                };
+                return { ok: true, info: `闂?workspace switched to ${resolved}` };
               }
             : undefined,
           reloadMcp: mcpRuntime
@@ -2616,8 +2686,23 @@ function AppInner({
           models,
           refreshModels,
         });
+        if (
+          fromQQ &&
+          qq.handleRemoteSlashResult({
+            result,
+            codeMode: !!codeMode,
+            sessions: listSessionsForWorkspace(currentRootDir),
+            checkpoints: codeMode ? [...listCheckpoints(currentRootDir)].reverse() : [],
+            models,
+            restoreCodeOnlyMessage: t("app.restoreCodeOnly"),
+          })
+        ) {
+          pushHistory(text);
+          return;
+        }
         if (result.openSessionsPicker) {
-          setSessionsPickerList(listSessionsForWorkspace(currentRootDir));
+          const sessions = listSessionsForWorkspace(currentRootDir);
+          setSessionsPickerList(sessions);
           setPendingSessionsPicker(true);
           pushHistory(text);
           return;
@@ -2628,7 +2713,8 @@ function AppInner({
             pushHistory(text);
             return;
           }
-          setCheckpointPickerList([...listCheckpoints(currentRootDir)].reverse());
+          const checkpoints = [...listCheckpoints(currentRootDir)].reverse();
+          setCheckpointPickerList(checkpoints);
           setPendingCheckpointPicker(true);
           pushHistory(text);
           return;
@@ -2660,11 +2746,11 @@ function AppInner({
         }
         if (result.replayPlan) {
           const rp = result.replayPlan;
-          const titleSuffix = rp.summary ? ` — ${rp.summary}` : "";
+          const titleSuffix = rp.summary ? ` 闂?${rp.summary}` : "";
           const done = new Set(rp.completedStepIds);
           setPendingReplayViewer({
             viewerKind: "replay-plan",
-            title: `Replay #${rp.index}/${rp.total} · ${rp.relativeTime}${titleSuffix}`,
+            title: `Replay #${rp.index}/${rp.total} 闂?${rp.relativeTime}${titleSuffix}`,
             body: rp.body,
             steps: rp.steps.map((s) => ({
               id: s.id,
@@ -2688,6 +2774,7 @@ function AppInner({
           resetPendingModals,
           text,
         });
+        if (fromQQ && result.info) qq.sendText(result.info);
         if (outcome.kind === "resubmit") {
           text = outcome.text;
         } else {
@@ -2746,10 +2833,12 @@ function AppInner({
         current: null,
       };
 
+      submittingRef.current = true;
       setBusy(true);
+      qq.noteTurnFromQQ(fromQQ);
       abortedThisTurn.current = false;
       // Seal the in-progress history entry so this turn's edits open
-      // a new one — prior turns are preserved intact for /history and
+      // a new one 闂?prior turns are preserved intact for /history and
       // `/undo` to walk back through independently.
       if (codeMode) sealCurrentEntry();
       // Reset per-turn edit policy so "apply-rest-of-turn" from the
@@ -2757,7 +2846,7 @@ function AppInner({
       // new prompt to start with the normal review gate re-armed.
       turnEditPolicyRef.current = "ask";
       // Pro badge state: if /pro was armed, this turn consumes it; the
-      // loop emits a "⇧ /pro armed" warning we'll catch below. Clear
+      // loop emits a "闂?/pro armed" warning we'll catch below. Clear
       // the armed mirror so the badge flips to "escalated" (via the
       // warning handler) rather than staying at "armed" during the
       // actual run.
@@ -2811,7 +2900,7 @@ function AppInner({
       }
       // Expand `@http(s)://...` URL mentions. Available in any mode (chat
       // OR code) since fetching a URL doesn't need a sandbox root. Awaits
-      // the network sequentially across URLs — for a typical 1-2 URLs in
+      // the network sequentially across URLs 闂?for a typical 1-2 URLs in
       // a prompt this is fine; if a user pastes 10 URLs the latency adds
       // up but their prompt is also already huge.
       if (/(?:^|\s)@https?:\/\//.test(text)) {
@@ -2826,8 +2915,8 @@ function AppInner({
               .filter((ex) => ex.ok)
               .map((ex) => {
                 const tag = ex.title ? `${ex.title} (${ex.url})` : ex.url;
-                const trunc = ex.truncated ? " · truncated" : "";
-                return `${tag} · ${(ex.chars ?? 0).toLocaleString()} chars${trunc}`;
+                const trunc = ex.truncated ? " 闂?truncated" : "";
+                return `${tag} 闂?${(ex.chars ?? 0).toLocaleString()} chars${trunc}`;
               });
             const skipped = urlExpanded.expansions
               .filter((ex) => !ex.ok)
@@ -2845,10 +2934,10 @@ function AppInner({
       }
 
       try {
+        let lastAssistantText = "";
         for await (const ev of loop.step(modelInput)) {
           writeTranscript(ev);
-          // Mirror to the kernel event log sidecar. Pure passthrough —
-          // Eventizer holds the small state (turn boundary detection +
+          // Mirror to the kernel event log sidecar. Pure passthrough 闂?          // Eventizer holds the small state (turn boundary detection +
           // tool callId correlation) needed to translate LoopEvent
           // shape into typed Event variants. Sink + eventizer share the
           // App's lifetime; nothing reads the artifact yet (future
@@ -2869,17 +2958,15 @@ function AppInner({
             const dashMsg = loopEventToDashboard(ev, { assistantId });
             if (dashMsg) broadcastDashboardEvent(dashMsg);
           }
-          // Status lines are transient — any primary event (streaming
+          // Status lines are transient 闂?any primary event (streaming
           // starts, a tool fires, etc.) means whatever we were waiting
           // FOR has now arrived, so drop the hint. We do this uniformly
           // at the top of the loop body for every role except "status"
           // itself (which SETS the line).
-          if (ev.role !== "status" && ev.role !== "steer") {
+          if (ev.role !== "status") {
             setStatusLine((cur) => (cur ? null : cur));
           }
-          if (ev.role === "steer") {
-            setQueuedSubmit(null);
-          } else if (ev.role === "status") {
+          if (ev.role === "status") {
             setStatusLine(ev.content);
           } else if (ev.role === "assistant_delta") {
             if (ev.content) contentBuf.current += ev.content;
@@ -2894,6 +2981,7 @@ function AppInner({
               };
             }
           } else if (ev.role === "assistant_final") {
+            lastAssistantText = ev.content || streamRef.text;
             handleAssistantFinal(ev, {
               flush,
               translator,
@@ -2977,7 +3065,7 @@ function AppInner({
         }
         flush();
 
-        // Stop hooks — turn has ended (or aborted). Block decisions are
+        // Stop hooks 闂?turn has ended (or aborted). Block decisions are
         // meaningless past this point so we treat every non-pass as a
         // warning. Natural place for "after every turn, run the
         // formatter / lint / tests" automation.
@@ -2996,9 +3084,10 @@ function AppInner({
             log.pushWarning(t("app.hookStop"), formatHookOutcomeMessage(o));
           }
         }
+        qq.maybeSendFinalReply(lastAssistantText);
       } finally {
         clearInterval(timer);
-        // Esc aborted the turn — close any in-flight cards (streaming /
+        // Esc aborted the turn 闂?close any in-flight cards (streaming /
         // reasoning / tool / branch) so they leave the live region. Without
         // this, stranded done=false cards stick in CardStream's live tail.
         if (abortedThisTurn.current) {
@@ -3007,10 +3096,12 @@ function AppInner({
         clearToolProgressDisplay();
         setSummary(loop.stats.summary());
         setBusy(false);
+        submittingRef.current = false;
+        qq.clearTurnReply();
         // Clear pro-on-turn badge; armed-for-next-turn already cleared
         // at turn start when it was consumed.
         setTurnOnPro(false);
-        // Refresh balance lazily — don't block the return.
+        // Refresh balance lazily 闂?don't block the return.
         refreshBalance();
       }
     },
@@ -3069,6 +3160,7 @@ function AppInner({
       stopLoop,
       startLoop,
       getLoopStatus,
+      qq,
       isLoopActive,
       isLoopFiring,
       clearFiringFlag,
@@ -3085,12 +3177,11 @@ function AppInner({
       mcpRuntime,
       pushHistory,
       resetCursor,
-      queuedSubmit,
     ],
   );
 
   // Mirror the latest handleSubmit so the /loop timer (set up below)
-  // calls the freshest closure on each firing — config changes during
+  // calls the freshest closure on each firing 闂?config changes during
   // the loop (model, mode, etc.) take effect immediately.
   useEffect(() => {
     handleSubmitRef.current = handleSubmit;
@@ -3099,7 +3190,7 @@ function AppInner({
   /**
    * ShellConfirm callback. Resolves the PauseGate so the
    * blocked tool function can proceed. The tool handles running the
-   * command (or throwing on deny) — no synthetic user message needed.
+   * command (or throwing on deny) 闂?no synthetic user message needed.
    */
   const handleShellConfirm = useCallback(
     (choice: ShellConfirmChoice, denyContext?: string) => {
@@ -3128,7 +3219,7 @@ function AppInner({
     [pendingShell, codeMode, currentRootDir, log],
   );
 
-  /** PathConfirm callback — mirrors handleShellConfirm. Resolves the gate, no synthetic user message. */
+  /** PathConfirm callback 闂?mirrors handleShellConfirm. Resolves the gate, no synthetic user message. */
   const handlePathConfirm = useCallback(
     (choice: "run_once" | "always_allow" | "deny", denyContext?: string) => {
       const pending = pendingPath;
@@ -3146,12 +3237,8 @@ function AppInner({
     [pendingPath],
   );
 
-  /** Holds the PauseGate request id for the current modal so
-   *  handlePlanConfirm / handleCheckpointResponse / etc. can resolve it. */
-  const pendingGateIdRef = useRef<number | null>(null);
-
   /** Bail out of every pending modal + the awaiting tool fn behind it.
-   *  Called by Esc-during-busy and by /new — without this, a tool stuck
+   *  Called by Esc-during-busy and by /new 闂?without this, a tool stuck
    *  on `pauseGate.ask` ignores the AbortSignal and the turn never ends. */
   const resetPendingModals = useCallback(() => {
     const editResolve = editReviewResolveRef.current;
@@ -3170,31 +3257,31 @@ function AppInner({
     setStagedChoiceCustom(null);
     setStagedCheckpointRevise(null);
     pendingGateIdRef.current = null;
+    qq.resetInteractions();
     pauseGate.cancelAll();
-  }, []);
+  }, [qq]);
 
-  // Drain the shell-confirm queue after the in-flight turn tears down.
-  // React closure staleness means handleShellConfirm can't just await
-  // the abort itself — this effect is the reliable edge detector.
-  // When busy ends, drain any queued typeahead. If the steer was
-  // already consumed mid-turn (the loop yielded a "steer" event),
-  // skip — the message is already in the log.
+  // Drain queued submits after the in-flight turn tears down.
+  // QQ pause-gate replies are the one exception: they need to re-enter
+  // handleSubmit while the turn is still "busy" so the blocked
+  // pauseGate.ask() can be resolved from the remote reply.
   useEffect(() => {
-    if (!busy && queuedSubmit !== null) {
+    if (queuedSubmit === null) return;
+    const canBypassBusy = qq.canBypassBusy(queuedSubmit);
+    if ((!busy && !submittingRef.current) || canBypassBusy) {
       const text = queuedSubmit;
       setQueuedSubmit(null);
-      if (loop.steerConsumed) return;
       void handleSubmit(text);
     }
-  }, [busy, queuedSubmit, handleSubmit, loop]);
+  }, [busy, queuedSubmit, handleSubmit, qq]);
 
   /**
    * PlanConfirm callback. Three outcomes, all ending with a synthetic
    * user message so the model sees the verdict on its next turn:
-   *   - approve → exit plan mode, tell the model to implement now.
-   *   - refine  → stay in plan mode, tell the model to revise.
-   *   - cancel  → exit plan mode, tell the model to drop the plan.
-   * Mirrors handleShellConfirm's busy-queue dance — if the turn is
+   *   - approve 闂?exit plan mode, tell the model to implement now.
+   *   - refine  闂?stay in plan mode, tell the model to revise.
+   *   - cancel  闂?exit plan mode, tell the model to drop the plan.
+   * Mirrors handleShellConfirm's busy-queue dance 闂?if the turn is
    * still streaming "plan submitted, waiting" chatter when the user
    * picks, we abort it and queue the synthetic for the effect above.
    *
@@ -3232,7 +3319,7 @@ function AppInner({
       }
 
       // Cancel ("reject"). Open the same staged input as approve/refine so
-      // the user can tell the model *why* — symmetric with the deny-tool
+      // the user can tell the model *why* 闂?symmetric with the deny-tool
       // "press Tab to add reason" pattern. Empty Enter still cancels cleanly.
       if (pendingPlan) {
         const questions = extractOpenQuestionsSection(pendingPlan) ?? undefined;
@@ -3245,7 +3332,7 @@ function AppInner({
 
   // Ref-wrapped stable alias. `handlePlanConfirm` has deps that churn
   // every turn (busy toggles while the model is still streaming its
-  // wrap-up) — passing it directly to `React.memo(PlanConfirm)` breaks
+  // wrap-up) 闂?passing it directly to `React.memo(PlanConfirm)` breaks
   // the memo's shallow prop compare, so even without the ticker the
   // picker re-rendered on every parent state change. The ref keeps the
   // identity stable across the whole picker lifetime; the callback
@@ -3254,6 +3341,9 @@ function AppInner({
   useEffect(() => {
     handlePlanConfirmRef.current = handlePlanConfirm;
   }, [handlePlanConfirm]);
+  useEffect(() => {
+    handlePlanCancelRef.current = () => handlePlanConfirmRef.current("cancel");
+  }, []);
   const stableHandlePlanConfirm = useCallback(
     async (choice: PlanConfirmChoice) => handlePlanConfirmRef.current(choice),
     [],
@@ -3276,7 +3366,7 @@ function AppInner({
       // dispatch path without first having to setStagedInput() (which
       // is async and would race the read below). When the override is
       // present we also clear pendingPlan ourselves since web flow
-      // doesn't go through the picker → input two-step.
+      // doesn't go through the picker 闂?input two-step.
       const staged = override ?? stagedInput;
       if (override) {
         setPendingPlan(null);
@@ -3285,13 +3375,13 @@ function AppInner({
       }
       if (!staged) return;
       const trimmed = feedback.trim();
-      const tail = trimmed.length > 50 ? `${trimmed.slice(0, 50)}…` : trimmed;
+      const tail = trimmed.length > 50 ? `${trimmed.slice(0, 50)}...` : trimmed;
 
       let marker: string;
       if (staged.mode === "approve") {
         togglePlanMode(false);
         // Materialize the approved plan as an "active" card so PlanLiveRow
-        // can dock it at the bottom — without this dispatch, no card with
+        // can dock it at the bottom 闂?without this dispatch, no card with
         // variant: "active" exists and the live strip stays empty.
         const approvedSteps = planStepsRef.current;
         if (approvedSteps && approvedSteps.length > 0) {
@@ -3308,10 +3398,10 @@ function AppInner({
           persistPlanState();
         }
         marker = trimmed
-          ? `▸ plan approved + instructions — ${tail}`
-          : "▸ plan approved — implementing";
+          ? `plan approved + instructions - ${tail}`
+          : "plan approved - implementing";
       } else if (staged.mode === "reject") {
-        // Drop the structured plan state — the user said this path is wrong,
+        // Drop the structured plan state 闂?the user said this path is wrong,
         // no point keeping it around for resume.
         planStepsRef.current = null;
         completedStepIdsRef.current = new Set();
@@ -3320,15 +3410,15 @@ function AppInner({
         persistPlanState();
         togglePlanMode(false);
         agentStore.dispatch({ type: "plan.drop" });
-        marker = trimmed ? `▸ plan rejected — ${tail}` : "▸ plan cancelled";
+        marker = trimmed ? `plan rejected - ${tail}` : "plan cancelled";
       } else {
-        marker = trimmed ? `▸ refining — ${tail}` : "▸ refining — using safe defaults";
+        marker = trimmed ? `refining - ${tail}` : "refining - using safe defaults";
       }
       log.pushInfo(marker);
 
       // Resolve the PauseGate so the blocked submit_plan tool function
       // returns. The user's typed feedback rides on the verdict so the
-      // model sees it as the tool result — without this, refine looked
+      // model sees it as the tool result 闂?without this, refine looked
       // identical to "user requested refinement" with no payload (#533).
       const gateId = pendingGateIdRef.current;
       if (gateId !== null) {
@@ -3345,14 +3435,18 @@ function AppInner({
     [stagedInput, togglePlanMode, persistPlanState, agentStore, log],
   );
   // Ref-mirror so startDashboard's resolvePlanConfirm closure can call
-  // the latest function — handleStagedInputSubmit's deps churn on every
+  // the latest function 闂?handleStagedInputSubmit's deps churn on every
   // stagedInput change, which would freeze a captured reference.
   const handleStagedInputSubmitRef = useRef(handleStagedInputSubmit);
   useEffect(() => {
     handleStagedInputSubmitRef.current = handleStagedInputSubmit;
   }, [handleStagedInputSubmit]);
+  useEffect(() => {
+    handlePlanFeedbackRef.current = (feedback, override) =>
+      handleStagedInputSubmitRef.current(feedback, override);
+  }, []);
 
-  /** Esc on the inline input — restore the picker without resuming. */
+  /** Esc on the inline input 闂?restore the picker without resuming. */
   const handleStagedInputCancel = useCallback(() => {
     if (stagedInput?.plan) setPendingPlan(stagedInput.plan);
     setStagedInput(null);
@@ -3387,16 +3481,19 @@ function AppInner({
 
   // Ref-wrap to keep ChoiceConfirm's React.memo from re-rendering on
   // every parent tick (same pattern as PlanConfirm / CheckpointConfirm).
-  // Stable refs over the modal handlers — used by the web chat-bridge
+  // Stable refs over the modal handlers 闂?used by the web chat-bridge
   // to drive the same code path as a TUI button click without
   // dragging the handlers (and their ever-shifting deps) into
   // startDashboard's useCallback closure.
-  const handleShellConfirmRef = useRef(handleShellConfirm);
   useEffect(() => {
     handleShellConfirmRef.current = handleShellConfirm;
   }, [handleShellConfirm]);
+  useEffect(() => {
+    handlePathConfirmRef.current = handlePathConfirm;
+  }, [handlePathConfirm]);
   // Listen for pause requests from tool functions (via PauseGate).
   // Dispatches to the correct modal based on request.kind.
+  // Also sends notifications to QQ channel when QQ is connected.
   // biome-ignore lint/correctness/useExhaustiveDependencies: setters, editModeRef, and chatScroll (store handle) are stable; the listener installs once per mount and reads only refs/setters from closure
   useEffect(() => {
     return pauseGate.on((request) => {
@@ -3405,6 +3502,8 @@ function AppInner({
       // Modal pickers reserve viewport rows from the bottom; if the chat is
       // scrolled up, the picker mounts off-screen and the user can't see it.
       chatScroll.jumpToBottom();
+
+      qq.handlePauseRequest(request.kind, payload);
 
       switch (request.kind) {
         case "run_command":
@@ -3463,7 +3562,7 @@ function AppInner({
             result: string;
             notes?: string;
           };
-          // completed/total come from planStepsRef — don't have them via gate
+          // completed/total come from planStepsRef 闂?don't have them via gate
           const completed = completedStepIdsRef.current.size;
           const total = planStepsRef.current?.length ?? 0;
           // Shared policy (src/core/pause-policy.ts) decides whether to
@@ -3510,7 +3609,7 @@ function AppInner({
         }
       }
     });
-  }, []);
+  }, [log, qq]);
   // Ref-mirror of pendingPlan so the web's resolvePlanConfirm callback
   // (registered in startDashboard, frozen at boot) can read the live
   // body when the web resolves an approve/refine.
@@ -3538,7 +3637,7 @@ function AppInner({
       setPendingCheckpoint(null);
       const gid = pendingGateIdRef.current;
       if (choice === "revise") {
-        // Don't resolve the gate yet — wait for the staged feedback input
+        // Don't resolve the gate yet 闂?wait for the staged feedback input
         // and let handleCheckpointReviseSubmit resolve with the feedback text.
         setStagedCheckpointRevise(snap);
         return;
@@ -3548,7 +3647,7 @@ function AppInner({
         const paths = touchedPaths();
         if (paths.length > 0) {
           try {
-            const cpName = snap.title ? `${snap.stepId} · ${snap.title}` : snap.stepId;
+            const cpName = snap.title ? `${snap.stepId} - ${snap.title}` : snap.stepId;
             const meta = createCheckpoint({
               rootDir: codeMode.rootDir,
               name: cpName.slice(0, 60),
@@ -3572,7 +3671,7 @@ function AppInner({
           type: choice === "continue" ? "continue" : "stop",
         });
       }
-      const label = snap.title ? `${snap.stepId} · ${snap.title}` : snap.stepId;
+      const label = snap.title ? `${snap.stepId} - ${snap.title}` : snap.stepId;
       const counter = snap.total > 0 ? ` (${snap.completed}/${snap.total})` : "";
       log.pushInfo(
         choice === "continue"
@@ -3582,8 +3681,6 @@ function AppInner({
     },
     [pendingCheckpoint, codeMode, touchedPaths, log],
   );
-
-  const handleCheckpointConfirmRef = useRef(handleCheckpointConfirm);
   useEffect(() => {
     handleCheckpointConfirmRef.current = handleCheckpointConfirm;
   }, [handleCheckpointConfirm]);
@@ -3594,7 +3691,7 @@ function AppInner({
         const paths = touchedPaths();
         if (paths.length > 0) {
           try {
-            const cpName = title ? `${stepId} · ${title}` : stepId;
+            const cpName = title ? `${stepId} - ${title}` : stepId;
             createCheckpoint({
               rootDir: codeMode.rootDir,
               name: cpName.slice(0, 60),
@@ -3608,7 +3705,7 @@ function AppInner({
       }
       const completed = completedStepIdsRef.current.size;
       const total = planStepsRef.current?.length ?? 0;
-      const label = title ? `${stepId} · ${title}` : stepId;
+      const label = title ? `${stepId} - ${title}` : stepId;
       const counter = total > 0 ? ` (${completed}/${total})` : "";
       log.pushInfo(t("app.continuingAfter", { label, counter }));
     },
@@ -3623,13 +3720,13 @@ function AppInner({
     [],
   );
 
-  /** Revise feedback submitted — resolves the gate with feedback. */
+  /** Revise feedback submitted 闂?resolves the gate with feedback. */
   const handleCheckpointReviseSubmit = useCallback(
     (feedback: string, snapOverride?: { stepId: string; title?: string }) => {
       const snap = snapOverride;
       setStagedCheckpointRevise(null);
       if (!snap) return;
-      const label = snap.title ? `${snap.stepId} · ${snap.title}` : snap.stepId;
+      const label = snap.title ? `${snap.stepId} - ${snap.title}` : snap.stepId;
       const trimmed = feedback.trim();
       const gid = pendingGateIdRef.current;
       if (gid !== null) {
@@ -3641,7 +3738,7 @@ function AppInner({
       const marker = trimmed
         ? t("app.revisingAfter", {
             label,
-            feedback: trimmed.length > 50 ? `${trimmed.slice(0, 50)}…` : trimmed,
+            feedback: trimmed.length > 50 ? `${trimmed.slice(0, 50)}...` : trimmed,
           })
         : t("app.continuingAfter", { label, counter: "" });
       log.pushInfo(marker);
@@ -3657,12 +3754,11 @@ function AppInner({
 
   // Ref-mirrors so the web's resolveXxx callbacks (registered in
   // startDashboard, frozen at boot) keep calling the latest handler.
-  const handleCheckpointReviseSubmitRef = useRef(handleCheckpointReviseSubmit);
   useEffect(() => {
     handleCheckpointReviseSubmitRef.current = handleCheckpointReviseSubmit;
   }, [handleCheckpointReviseSubmit]);
 
-  /** Custom free-form answer submitted — resolves the PauseGate with the typed text. */
+  /** Custom free-form answer submitted 闂?resolves the PauseGate with the typed text. */
   const handleChoiceCustomSubmit = useCallback((answer: string) => {
     setStagedChoiceCustom(null);
     const trimmed = answer.trim();
@@ -3672,12 +3768,26 @@ function AppInner({
     }
   }, []);
 
-  /** Esc on the custom input — restore the choice picker. */
+  /** Esc on the custom input 闂?restore the choice picker. */
   const handleChoiceCustomCancel = useCallback(() => {
     const snap = stagedChoiceCustom;
     setStagedChoiceCustom(null);
     if (snap) setPendingChoice(snap);
   }, [stagedChoiceCustom]);
+  useEffect(() => {
+    handleChoiceResolveRef.current = (resolution) => {
+      if (resolution.type === "pick") {
+        void handleChoiceConfirmRef.current({ kind: "pick", optionId: resolution.optionId });
+        return;
+      }
+      if (resolution.type === "text") {
+        setPendingChoice(null);
+        handleChoiceCustomSubmit(resolution.text);
+        return;
+      }
+      void handleChoiceConfirmRef.current({ kind: "cancel" });
+    };
+  }, [handleChoiceCustomSubmit]);
 
   /**
    * PlanReviseConfirm callback. Accept splices the new remaining
@@ -3696,19 +3806,18 @@ function AppInner({
       }
       // Accept: keep the done-step prefix from the existing plan, replace
       // the rest with the proposed remainingSteps. completedStepIds
-      // stays intact — done work isn't undone.
+      // stays intact 闂?done work isn't undone.
       const completed = completedStepIdsRef.current;
       const oldSteps = planStepsRef.current ?? [];
       const donePrefix = oldSteps.filter((s) => completed.has(s.id));
       const merged: PlanStep[] = [...donePrefix];
       for (const s of snap.remainingSteps) {
-        if (completed.has(s.id)) continue; // already done — don't re-queue
+        if (completed.has(s.id)) continue; // already done 闂?don't re-queue
         merged.push(s);
       }
       planStepsRef.current = merged;
       persistPlanState();
-      // Replace the live active card so PlanLiveRow shows the new tail —
-      // existing card's stale ids would fail subsequent step completes.
+      // Replace the live active card so PlanLiveRow shows the new tail 闂?      // existing card's stale ids would fail subsequent step completes.
       agentStore.dispatch({ type: "plan.drop" });
       log.showPlan({
         title: planSummaryRef.current ?? "plan",
@@ -3725,9 +3834,16 @@ function AppInner({
   );
 
   // Ref-wrap to keep PlanReviseConfirm's React.memo from re-rendering.
-  const handleReviseConfirmRef = useRef(handleReviseConfirm);
   useEffect(() => {
-    handleReviseConfirmRef.current = handleReviseConfirm;
+    handleReviseConfirmRef.current = (choice) => {
+      if (choice === "cancel") {
+        const gateId = pendingGateIdRef.current;
+        setPendingRevision(null);
+        if (gateId !== null) pauseGate.resolve(gateId, { type: "cancelled" });
+        return;
+      }
+      return handleReviseConfirm(choice);
+    };
   }, [handleReviseConfirm]);
   const stableHandleReviseConfirm = useCallback(
     async (choice: ReviseChoice) => handleReviseConfirmRef.current(choice),
@@ -3745,11 +3861,8 @@ function AppInner({
       <HistoryTypingCapture
         input={input}
         setInput={setInput}
-        enabled={!modalOpen}
-        onReturnToBottom={() => {
-          if (busy && input.trim()) handleSubmit(input);
-          else chatScroll.jumpToBottom();
-        }}
+        enabled={!modalOpen && !busy}
+        onReturnToBottom={chatScroll.jumpToBottom}
       />
       <TickerProvider disabled={tickerSuspended}>
         <ViewportBudgetProvider>
@@ -3775,7 +3888,7 @@ function AppInner({
                     />
                   ) : null}
                   {/*
-          Live rows are hidden while the ShellConfirm modal is up — the
+          Live rows are hidden while the ShellConfirm modal is up 闂?the
           model's concurrent "please confirm" stream is noise the user
           doesn't need, and the picker shouldn't fight it for visual
           attention. They come back naturally once the user chooses and
@@ -3834,7 +3947,7 @@ function AppInner({
                   !pendingCheckpoint ? (
                     <UndoBanner banner={undoBanner} />
                   ) : null}
-                  {/* Activity row when no targeted indicator is visible — phase label from useActivityLabel. */}
+                  {/* Activity row when no targeted indicator is visible 闂?phase label from useActivityLabel. */}
                   {!pendingShell &&
                   !pendingPath &&
                   !pendingPlan &&
@@ -3925,7 +4038,7 @@ function AppInner({
                         if (!target) return;
                         const result = restoreCheckpoint(currentRootDir, target.id);
                         const lines = [
-                          `▸ restored "${target.name}" (${target.id.slice(0, 7)}, ${fmtAgo(target.createdAt)})`,
+                          `闂?restored "${target.name}" (${target.id.slice(0, 7)}, ${fmtAgo(target.createdAt)})`,
                         ];
                         if (result.restored.length > 0) {
                           lines.push(
@@ -3966,7 +4079,7 @@ function AppInner({
                           onSwitchSession(outcome.name);
                         } else {
                           log.pushInfo(
-                            `▸ to switch to "${outcome.name}", quit and run: reasonix chat --session ${outcome.name}`,
+                            `闂?to switch to "${outcome.name}", quit and run: reasonix chat --session ${outcome.name}`,
                           );
                         }
                         return;
@@ -3977,7 +4090,7 @@ function AppInner({
                           onSwitchSession(freshSessionName(session));
                         } else {
                           log.pushInfo(
-                            "▸ to start a fresh session, quit and run: reasonix chat (no --session flag)",
+                            "闂?to start a fresh session, quit and run: reasonix chat (no --session flag)",
                           );
                         }
                         return;
@@ -4010,7 +4123,7 @@ function AppInner({
                         process.env.REASONIX_THEME,
                       );
                       setThemeName(active);
-                      log.pushInfo(`▸ theme saved: ${outcome.value}\n  active now: ${active}`);
+                      log.pushInfo(`闂?theme saved: ${outcome.value}\n  active now: ${active}`);
                     }}
                   />
                 ) : pendingCopyMode ? (
@@ -4024,7 +4137,7 @@ function AppInner({
                           ? t("copyMode.yankedToast", { size: yanked.size })
                           : t("copyMode.yankedToastFile", {
                               size: yanked.size,
-                              path: path ?? "—",
+                              path: path ?? "unknown",
                             });
                         log.pushInfo(info);
                       }
@@ -4059,10 +4172,10 @@ function AppInner({
                           try {
                             savePreset(inferred);
                           } catch {
-                            /* disk full / perms — runtime change still took effect */
+                            /* disk full / perms 闂?runtime change still took effect */
                           }
                         }
-                        log.pushInfo(`▸ model: ${outcome.id}`);
+                        log.pushInfo(`闂?model: ${outcome.id}`);
                         return;
                       }
                       if (outcome.kind === "preset") {
@@ -4081,9 +4194,9 @@ function AppInner({
                         try {
                           savePreset(outcome.name);
                         } catch {
-                          /* disk full / perms — runtime change still took effect */
+                          /* disk full / perms 闂?runtime change still took effect */
                         }
-                        log.pushInfo(`▸ preset: ${outcome.name} · ${p.model}`);
+                        log.pushInfo(`闂?preset: ${outcome.name} 闂?${p.model}`);
                       }
                     }}
                   />
@@ -4193,20 +4306,11 @@ function AppInner({
                           ) : null}
                           {activeLoop ? <LoopStatusRow loop={activeLoop} /> : null}
                           <StatusRow statusBar={statusBar} />
-                          {queuedSubmit !== null && busy && (
-                            <Box>
-                              <Text color={FG.faint}>
-                                {t("composer.typeaheadStaged", {
-                                  count: queuedSubmit.split("\n").length,
-                                })}
-                              </Text>
-                            </Box>
-                          )}
                           <PromptInput
                             value={input}
                             onChange={setInput}
                             onSubmit={handleSubmit}
-                            disabled={false}
+                            disabled={busy}
                             onHistoryPrev={handleHistoryPrev}
                             onHistoryNext={handleHistoryNext}
                             onOpenExternalEditor={handleOpenExternalEditor}
@@ -4233,7 +4337,6 @@ function AppInner({
                             spec={slashArgContext.spec}
                             kind={slashArgContext.kind}
                             partial={slashArgContext.partial}
-                            pathCandidates={slashArgPathCandidates}
                           />
                         ) : null}
                       </Box>

--- a/src/cli/ui/slash/commands.ts
+++ b/src/cli/ui/slash/commands.ts
@@ -178,6 +178,13 @@ export const SLASH_COMMANDS: readonly SlashCommandSpec[] = [
     summary: "list / run / scaffold skills (project + custom + global + builtin)",
     argCompleter: "skills",
   },
+  {
+    cmd: "qq",
+    group: "extend",
+    argsHint: "<connect|status|disconnect>",
+    summary: "connect, inspect, or disconnect the QQ channel",
+    argCompleter: ["connect", "status", "disconnect"],
+  },
 
   {
     cmd: "init",

--- a/src/cli/ui/slash/dispatch.ts
+++ b/src/cli/ui/slash/dispatch.ts
@@ -14,6 +14,7 @@ import { handlers as modelHandlers } from "./handlers/model.js";
 import { handlers as observabilityHandlers } from "./handlers/observability.js";
 import { handlers as permissionsHandlers } from "./handlers/permissions.js";
 import { handlers as plansHandlers } from "./handlers/plans.js";
+import { handlers as qqHandlers } from "./handlers/qq.js";
 import { handlers as sessionsHandlers } from "./handlers/sessions.js";
 import { handlers as skillHandlers } from "./handlers/skill.js";
 import { handlers as themeHandlers } from "./handlers/theme.js";
@@ -38,6 +39,7 @@ const HANDLERS: Record<string, SlashHandler> = {
   ...observabilityHandlers,
   ...permissionsHandlers,
   ...plansHandlers,
+  ...qqHandlers,
   ...sessionsHandlers,
   ...themeHandlers,
   ...skillHandlers,

--- a/src/cli/ui/slash/handlers/qq.ts
+++ b/src/cli/ui/slash/handlers/qq.ts
@@ -1,0 +1,35 @@
+import type { SlashHandler } from "../dispatch.js";
+
+export const handlers: Record<string, SlashHandler> = {
+  qq(args, _loop, ctx) {
+    const subcommand = (args[0] ?? "status").toLowerCase();
+    const rest = args.slice(1);
+    if (!ctx.qq) {
+      return { info: "/qq is not available in this session." };
+    }
+
+    if (subcommand === "connect") {
+      ctx.postInfo?.("QQ: connecting...");
+      void ctx.qq.connect(rest).then(
+        (message) => ctx.postInfo?.(message),
+        (err) => ctx.postInfo?.(`QQ connect failed: ${(err as Error).message}`),
+      );
+      return {};
+    }
+
+    if (subcommand === "disconnect") {
+      ctx.postInfo?.("QQ: disconnecting...");
+      void ctx.qq.disconnect().then(
+        (message) => ctx.postInfo?.(message),
+        (err) => ctx.postInfo?.(`QQ disconnect failed: ${(err as Error).message}`),
+      );
+      return {};
+    }
+
+    if (subcommand === "status") {
+      return { info: ctx.qq.status() };
+    }
+
+    return { info: "Usage: /qq connect [appId appSecret [sandbox]] | /qq status | /qq disconnect" };
+  },
+};

--- a/src/cli/ui/slash/types.ts
+++ b/src/cli/ui/slash/types.ts
@@ -145,6 +145,11 @@ export interface SlashContext {
   stopDashboard?: () => Promise<void>;
   /** Snapshot the dashboard's URL when running, null otherwise. */
   getDashboardUrl?: () => string | null;
+  qq?: {
+    connect: (args: readonly string[]) => Promise<string>;
+    disconnect: () => Promise<string>;
+    status: () => string;
+  };
   /** Current session id — included in `/feedback`'s diagnostic block when present. */
   sessionId?: string;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -74,6 +74,13 @@ export interface SemanticEmbeddingConfigView {
   };
 }
 
+export interface QQBotConfig {
+  appId?: string;
+  appSecret?: string;
+  sandbox?: boolean;
+  enabled?: boolean;
+}
+
 export interface ReasonixConfig {
   apiKey?: string;
   baseUrl?: string;
@@ -139,6 +146,8 @@ export interface ReasonixConfig {
   memory?: {
     customTypes?: CustomMemoryTypeConfig[];
   };
+  /** QQ Bot configuration */
+  qq?: QQBotConfig;
 }
 
 export interface CustomMemoryTypeConfig {
@@ -851,4 +860,38 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
   const proto = Object.getPrototypeOf(value);
   return proto === Object.prototype || proto === null;
+}
+
+export interface LoadedQQConfig {
+  appId?: string;
+  appSecret?: string;
+  sandbox?: boolean;
+  enabled?: boolean;
+}
+
+export function loadQQConfig(path: string = defaultConfigPath()): LoadedQQConfig {
+  const envSandbox = process.env.QQ_SANDBOX;
+  const fromEnv = {
+    appId: process.env.QQ_APPID,
+    appSecret: process.env.QQ_SECRET,
+    sandbox: envSandbox === "1" ? true : envSandbox === "0" ? false : undefined,
+  };
+  const fromCfg = readConfig(path).qq ?? {};
+  return {
+    appId: fromEnv.appId ?? fromCfg.appId,
+    appSecret: fromEnv.appSecret ?? fromCfg.appSecret,
+    sandbox: fromEnv.sandbox ?? fromCfg.sandbox ?? false,
+    enabled: fromCfg.enabled === true,
+  };
+}
+
+export function saveQQConfig(cfg: LoadedQQConfig, path: string = defaultConfigPath()): void {
+  const rootCfg = readConfig(path);
+  rootCfg.qq = {
+    appId: cfg.appId,
+    appSecret: cfg.appSecret,
+    sandbox: cfg.sandbox,
+    enabled: cfg.enabled,
+  };
+  writeConfig(rootCfg, path);
 }

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -326,6 +326,10 @@ export const EN: TranslationSchema = {
       argsHint: "[N]",
     },
     sessions: { description: "list saved sessions (current marked with ▸)" },
+    qq: {
+      description: "connect, inspect, or disconnect the QQ channel for this session",
+      argsHint: "[connect [appId appSecret [sandbox]]|status|disconnect]",
+    },
     setup: { description: "reminds you to exit and run `reasonix setup`" },
     semantic: {
       description: "show semantic_search status — built? Ollama installed? how to enable",

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -317,6 +317,10 @@ export const zhCN: TranslationSchema = {
       argsHint: "[N]",
     },
     sessions: { description: "列出已保存的会话（当前标记为 ▸）" },
+    qq: {
+      description: "连接、查看或断开当前会话的 QQ 通道",
+      argsHint: "[connect [appId appSecret [sandbox]]|status|disconnect]",
+    },
     setup: { description: "提醒您退出并运行 `reasonix setup`" },
     semantic: {
       description: "显示 semantic_search 状态 — 已构建？Ollama 已安装？如何启用",

--- a/src/qq/bot.ts
+++ b/src/qq/bot.ts
@@ -43,14 +43,16 @@ export class QQBot extends EventEmitter {
   }
 
   private sanitizeHeartbeatInterval(interval: unknown): number | null {
-    if (!Number.isFinite(interval)) {
+    if (typeof interval !== "number" || !Number.isFinite(interval)) {
       return null;
     }
-    const bounded = Math.max(
-      MIN_HEARTBEAT_INTERVAL_MS,
-      Math.min(MAX_HEARTBEAT_INTERVAL_MS, Math.trunc(interval as number)),
-    );
-    return bounded;
+    if (interval < MIN_HEARTBEAT_INTERVAL_MS) {
+      return MIN_HEARTBEAT_INTERVAL_MS;
+    }
+    if (interval > MAX_HEARTBEAT_INTERVAL_MS) {
+      return MAX_HEARTBEAT_INTERVAL_MS;
+    }
+    return Math.trunc(interval);
   }
 
   private validateGatewayUrl(rawUrl: string): string {
@@ -75,7 +77,6 @@ export class QQBot extends EventEmitter {
     if (this.token && Date.now() < this.tokenExpiresAt - 60_000) {
       return this.token;
     }
-    // codeql[js/file-access-to-http]
     const res = await fetch(TOKEN_URL, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -131,7 +132,6 @@ export class QQBot extends EventEmitter {
         });
         const heartbeatInterval = this.sanitizeHeartbeatInterval(d?.heartbeat_interval);
         if (heartbeatInterval) {
-          // codeql[js/resource-exhaustion]
           this.heartbeatTimer = setInterval(() => {
             this.sendOp(1, this.seq || null);
           }, heartbeatInterval);
@@ -256,7 +256,6 @@ export class QQBot extends EventEmitter {
       msg_type: 0,
     };
     if (msgId) body.msg_id = msgId;
-    // codeql[js/file-access-to-http]
     const res = await fetch(`${this.baseUrl}/v2/users/${encodeURIComponent(openid)}/messages`, {
       method: "POST",
       headers: {

--- a/src/qq/bot.ts
+++ b/src/qq/bot.ts
@@ -1,0 +1,275 @@
+import { EventEmitter } from "node:events";
+import WebSocket from "ws";
+
+const TOKEN_URL = "https://bots.qq.com/app/getAppAccessToken";
+const BASE_URL = "https://api.sgroup.qq.com";
+const SANDBOX_URL = "https://sandbox.api.sgroup.qq.com";
+const INTENT_C2C_GROUP = 1 << 25;
+const MIN_HEARTBEAT_INTERVAL_MS = 5_000;
+const MAX_HEARTBEAT_INTERVAL_MS = 60_000;
+const ALLOWED_GATEWAY_HOSTS = ["api.sgroup.qq.com", "sandbox.api.sgroup.qq.com", "qq.com"];
+
+interface QQBotConfig {
+  appid: string;
+  secret: string;
+  sandbox?: boolean;
+}
+
+export interface C2CMessage {
+  author: { user_openid: string };
+  content: string;
+  id: string;
+  timestamp: string;
+}
+
+export class QQBot extends EventEmitter {
+  private config: QQBotConfig;
+  private token = "";
+  private tokenExpiresAt = 0;
+  private ws: WebSocket | null = null;
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private seq = 0;
+  private sessionId = "";
+  private closed = false;
+  private readyReceived = false;
+
+  constructor(config: QQBotConfig) {
+    super();
+    this.config = config;
+  }
+
+  private get baseUrl(): string {
+    return this.config.sandbox ? SANDBOX_URL : BASE_URL;
+  }
+
+  private sanitizeHeartbeatInterval(interval: unknown): number | null {
+    if (!Number.isFinite(interval)) {
+      return null;
+    }
+    const bounded = Math.max(
+      MIN_HEARTBEAT_INTERVAL_MS,
+      Math.min(MAX_HEARTBEAT_INTERVAL_MS, Math.trunc(interval as number)),
+    );
+    return bounded;
+  }
+
+  private validateGatewayUrl(rawUrl: string): string {
+    const url = new URL(rawUrl);
+    const trustedHost = ALLOWED_GATEWAY_HOSTS.some(
+      (host) => url.hostname === host || url.hostname.endsWith(`.${host}`),
+    );
+    if (
+      url.protocol !== "wss:" ||
+      !trustedHost ||
+      url.username ||
+      url.password ||
+      url.search ||
+      url.hash
+    ) {
+      throw new Error(`Unexpected QQ gateway URL: ${rawUrl}`);
+    }
+    return url.toString();
+  }
+
+  private async ensureToken(): Promise<string> {
+    if (this.token && Date.now() < this.tokenExpiresAt - 60_000) {
+      return this.token;
+    }
+    // codeql[js/file-access-to-http]
+    const res = await fetch(TOKEN_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        appId: this.config.appid,
+        clientSecret: this.config.secret,
+      }),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`Failed to get access token (${res.status}): ${text}`);
+    }
+    const data = (await res.json()) as {
+      access_token: string;
+      expires_in: number;
+    };
+    this.token = data.access_token;
+    this.tokenExpiresAt = Date.now() + data.expires_in * 1000;
+    return this.token;
+  }
+
+  private async getGateway(): Promise<string> {
+    const token = await this.ensureToken();
+    const res = await fetch(`${this.baseUrl}/gateway`, {
+      headers: { Authorization: `QQBot ${token}` },
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`Failed to get gateway (${res.status}): ${text}`);
+    }
+    const data = (await res.json()) as { url: string };
+    return this.validateGatewayUrl(data.url);
+  }
+
+  private sendOp(op: number, data?: unknown) {
+    if (!this.ws) return;
+    this.ws.send(JSON.stringify({ op, d: data ?? {} }));
+  }
+
+  private async handlePayload(payload: {
+    op: number;
+    d?: Record<string, unknown>;
+    s?: number;
+    t?: string;
+  }) {
+    switch (payload.op) {
+      case 10: {
+        const d = payload.d as { heartbeat_interval: number } | undefined;
+        this.sendOp(2, {
+          token: `QQBot ${await this.ensureToken()}`,
+          intents: INTENT_C2C_GROUP,
+          shard: [0, 1],
+        });
+        const heartbeatInterval = this.sanitizeHeartbeatInterval(d?.heartbeat_interval);
+        if (heartbeatInterval) {
+          // codeql[js/resource-exhaustion]
+          this.heartbeatTimer = setInterval(() => {
+            this.sendOp(1, this.seq || null);
+          }, heartbeatInterval);
+        }
+        break;
+      }
+      case 0: {
+        if (payload.s) this.seq = payload.s;
+        if (payload.t === "READY") {
+          const d = payload.d as { session_id: string; user?: { id: string } };
+          this.sessionId = d.session_id;
+          this.readyReceived = true;
+          this.emit("online");
+        } else if (payload.t === "C2C_MESSAGE_CREATE") {
+          this.emit("message.private", payload.d as unknown as C2CMessage);
+        } else if (payload.t === "GROUP_AT_MESSAGE_CREATE") {
+          this.emit("message.group", payload.d);
+        }
+        break;
+      }
+      case 7: {
+        this.reconnect();
+        break;
+      }
+      case 9: {
+        this.sessionId = "";
+        this.sendOp(2, {
+          token: `QQBot ${await this.ensureToken()}`,
+          intents: INTENT_C2C_GROUP,
+          shard: [0, 1],
+        });
+        break;
+      }
+    }
+  }
+
+  private async reconnect() {
+    this.cleanup();
+    await this.connect();
+  }
+
+  private cleanup() {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+    if (this.ws) {
+      this.ws.removeAllListeners();
+      this.ws.close();
+      this.ws = null;
+    }
+  }
+
+  private async connect() {
+    const gatewayUrl = await this.getGateway();
+    const token = await this.ensureToken();
+    this.ws = new WebSocket(gatewayUrl, {
+      headers: {
+        Authorization: `QQBot ${token}`,
+        "X-Union-Appid": this.config.appid,
+      },
+    });
+
+    this.ws.on("open", () => {
+      if (this.sessionId) {
+        this.sendOp(6, {
+          token: `QQBot ${this.token}`,
+          session_id: this.sessionId,
+          seq: this.seq,
+        });
+      }
+    });
+
+    this.ws.on("message", (raw) => {
+      try {
+        const payload = JSON.parse(raw.toString());
+        this.handlePayload(payload).catch(() => {});
+      } catch {
+        // ignore parse errors
+      }
+    });
+
+    this.ws.on("close", () => {
+      if (!this.closed) {
+        if (this.readyReceived) {
+          // Was online — transient disconnect, reconnect.
+          console.error("QQ WebSocket reconnecting...");
+          this.cleanup();
+          setTimeout(() => this.reconnect(), 3000);
+        } else {
+          // Never received READY — authentication or network failure.
+          const msg =
+            "QQ WebSocket closed before authentication completed — check your appId and appSecret";
+          this.emit("bot_error", msg);
+          this.closed = true; // prevent further reconnect attempts
+        }
+      }
+    });
+
+    this.ws.on("error", (err) => {
+      const msg = `QQ WebSocket error: ${(err as Error).message}`;
+      console.error(msg);
+      this.emit("bot_error", msg);
+    });
+  }
+
+  async start(): Promise<void> {
+    this.closed = false;
+    this.readyReceived = false;
+    await this.connect();
+  }
+
+  async stop(): Promise<void> {
+    this.closed = true;
+    this.cleanup();
+  }
+
+  async sendPrivateMessage(openid: string, content: string, msgId?: string): Promise<void> {
+    const token = await this.ensureToken();
+    const body: Record<string, unknown> = {
+      content,
+      msg_type: 0,
+    };
+    if (msgId) body.msg_id = msgId;
+    // codeql[js/file-access-to-http]
+    const res = await fetch(`${this.baseUrl}/v2/users/${encodeURIComponent(openid)}/messages`, {
+      method: "POST",
+      headers: {
+        Authorization: `QQBot ${token}`,
+        "Content-Type": "application/json",
+        "X-Union-Appid": this.config.appid,
+      },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      const msg = `QQ sendPrivateMessage failed (${res.status}): ${text}`;
+      throw new Error(msg);
+    }
+  }
+}

--- a/src/qq/channel.ts
+++ b/src/qq/channel.ts
@@ -1,0 +1,160 @@
+import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { loadQQConfig } from "../config.js";
+import { loadDotenv } from "../env.js";
+import { type C2CMessage, QQBot } from "./bot.js";
+
+const QQ_LOCK_FILE = join(homedir(), ".reasonix", "qq-channel.pid");
+
+function chunkMessage(text: string, maxLen = 1500): string[] {
+  const chunks: string[] = [];
+  let remaining = text;
+  while (remaining.length > maxLen) {
+    let splitAt = remaining.lastIndexOf("\n", maxLen);
+    if (splitAt < 0) splitAt = remaining.lastIndexOf(" ", maxLen);
+    if (splitAt < 0) splitAt = maxLen;
+    chunks.push(remaining.slice(0, splitAt));
+    remaining = remaining.slice(splitAt).trim();
+  }
+  if (remaining.length > 0) chunks.push(remaining);
+  return chunks;
+}
+
+export class QQChannel {
+  private bot: QQBot | null = null;
+  private qqUserId: string | null = null;
+  private qqMessageId: string | null = null;
+  private processedMsgIds = new Set<string>();
+  private processedMsgIdQueue: string[] = [];
+  private lockAcquired = false;
+
+  constructor(
+    private callbacks: {
+      onSubmitMessage: (text: string) => void;
+      onError?: (msg: string) => void;
+    },
+  ) {}
+
+  private rememberMessage(id: string): boolean {
+    if (this.processedMsgIds.has(id)) return false;
+    this.processedMsgIds.add(id);
+    this.processedMsgIdQueue.push(id);
+    if (this.processedMsgIdQueue.length > 200) {
+      const oldest = this.processedMsgIdQueue.shift();
+      if (oldest) this.processedMsgIds.delete(oldest);
+    }
+    return true;
+  }
+
+  private acquireLock(): void {
+    try {
+      const existing = Number(readFileSync(QQ_LOCK_FILE, "utf8").trim());
+      if (Number.isInteger(existing) && existing > 0 && existing !== process.pid) {
+        try {
+          process.kill(existing, 0);
+          throw new Error(
+            `QQ channel is already running in process ${existing}. Stop that process before starting another QQ channel.`,
+          );
+        } catch (err) {
+          const e = err as NodeJS.ErrnoException;
+          if (e.code !== "ESRCH") throw err;
+        }
+      }
+    } catch (err) {
+      const e = err as NodeJS.ErrnoException;
+      if (e.code !== "ENOENT") throw err;
+    }
+
+    mkdirSync(dirname(QQ_LOCK_FILE), { recursive: true });
+    writeFileSync(QQ_LOCK_FILE, String(process.pid), "utf8");
+    this.lockAcquired = true;
+  }
+
+  private releaseLock(): void {
+    if (!this.lockAcquired) return;
+    try {
+      const existing = Number(readFileSync(QQ_LOCK_FILE, "utf8").trim());
+      if (existing === process.pid) unlinkSync(QQ_LOCK_FILE);
+    } catch {}
+    this.lockAcquired = false;
+  }
+
+  async start(): Promise<void> {
+    loadDotenv();
+    this.acquireLock();
+
+    const config = loadQQConfig();
+    if (!config.appId) {
+      this.releaseLock();
+      throw new Error("QQ App ID is required. Run `/qq connect` to configure.");
+    }
+    if (!config.appSecret) {
+      this.releaseLock();
+      throw new Error("QQ App Secret is required. Run `/qq connect` to configure.");
+    }
+
+    const bot = new QQBot({
+      appid: config.appId,
+      secret: config.appSecret,
+      sandbox: config.sandbox ?? false,
+    });
+
+    bot.on("online", () => {
+      process.stderr.write("QQ bot is online!\n");
+    });
+
+    bot.on("bot_error", (msg: string) => {
+      this.callbacks.onError?.(msg);
+    });
+
+    bot.on("message.private", (msg: C2CMessage) => {
+      const text = msg.content?.trim();
+      if (!text) return;
+      if (!this.rememberMessage(msg.id)) return;
+      this.qqUserId = msg.author.user_openid;
+      this.qqMessageId = msg.id;
+      this.callbacks.onSubmitMessage(`[QQ] ${text}`);
+    });
+
+    this.bot = bot;
+
+    try {
+      await bot.start();
+
+      const readyOrError = await Promise.race([
+        new Promise<"ready">((resolve) => bot.once("online", () => resolve("ready"))),
+        new Promise<"error">((resolve) => bot.once("bot_error", () => resolve("error"))),
+        new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 15_000)),
+      ]);
+
+      if (readyOrError === "error") {
+        throw new Error("QQ bot authentication failed - check your appId and appSecret");
+      }
+      if (readyOrError === "timeout") {
+        throw new Error("QQ bot did not receive READY within 15s - check your appId and appSecret");
+      }
+    } catch (err) {
+      this.releaseLock();
+      throw err;
+    }
+  }
+
+  async sendResponse(text: string): Promise<void> {
+    if (!this.bot || !this.qqUserId) return;
+    const chunks = chunkMessage(text);
+    for (const chunk of chunks) {
+      try {
+        await this.bot.sendPrivateMessage(this.qqUserId, chunk, this.qqMessageId ?? undefined);
+      } catch (err) {
+        const msg = `QQ sendResponse error: ${(err as Error).message}`;
+        this.callbacks.onError?.(msg);
+      }
+    }
+  }
+
+  async stop(): Promise<void> {
+    await this.bot?.stop();
+    this.releaseLock();
+  }
+}

--- a/src/qq/use-qq-channel.ts
+++ b/src/qq/use-qq-channel.ts
@@ -1,0 +1,771 @@
+import { createInterface } from "node:readline";
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import type { PlanConfirmChoice } from "../cli/ui/PlanConfirm.js";
+import type { ReviseChoice } from "../cli/ui/PlanReviseConfirm.js";
+import type { ThemeChoice } from "../cli/ui/ThemePicker.js";
+import type { SlashResult } from "../cli/ui/slash/types.js";
+import { listThemeNames } from "../cli/ui/theme/tokens.js";
+import { type CheckpointMeta, fmtAgo, restoreCheckpoint } from "../code/checkpoints.js";
+import { loadQQConfig, resolveThemePreference, saveQQConfig } from "../config.js";
+import { type SessionInfo, freshSessionName } from "../memory/session.js";
+import type { ChoiceOption } from "../tools/choice.js";
+import type { PlanStep } from "../tools/plan.js";
+import { QQChannel } from "./channel.js";
+
+type QQInteractionKind =
+  | "run_command"
+  | "run_background"
+  | "path_access"
+  | "plan_proposed"
+  | "plan_checkpoint"
+  | "plan_revision"
+  | "choice";
+
+type QQSlashInteractionKind =
+  | "sessions_picker"
+  | "checkpoint_picker"
+  | "model_picker"
+  | "theme_picker";
+
+interface QQInteractionState {
+  kind: QQInteractionKind | null;
+  payload: unknown;
+}
+
+interface QQSlashInteractionState {
+  kind: QQSlashInteractionKind | null;
+  payload: unknown;
+}
+
+interface QQLogger {
+  pushInfo: (text: string) => void;
+  pushWarning: (title: string, detail: string) => void;
+}
+
+interface UseQQChannelArgs {
+  codeMode: boolean;
+  initialChannel?: QQChannel;
+  log: QQLogger;
+  isRawModeSupported: boolean;
+  setRawMode: (enabled: boolean) => void;
+  setQueuedSubmit: (text: string) => void;
+  qqSubmitRef?: { current: ((text: string) => void) | null };
+  qqErrorRef?: { current: ((msg: string) => void) | null };
+  sessionName?: string | null;
+  currentRootDir: string;
+  pendingGateIdRef: { current: number | null };
+  completedStepIdsRef: { current: Set<string> };
+  planStepsRef: { current: PlanStep[] | null };
+  onCreateSession?: (name: string) => void;
+  onSelectSession?: (name: string) => void;
+  onModelPick: (target: string) => string;
+  onThemePick: (target: ThemeChoice) => string;
+  onShellConfirmRef: {
+    current: (choice: "run_once" | "always_allow" | "deny") => void;
+  };
+  onPathConfirmRef: {
+    current: (choice: "run_once" | "always_allow" | "deny") => void;
+  };
+  onPlanCancelRef: {
+    current: () => void | Promise<void>;
+  };
+  onPlanFeedbackRef: {
+    current: (
+      feedback: string,
+      override: { plan: string; mode: "refine" | "approve" | "reject" },
+    ) => void | Promise<void>;
+  };
+  onCheckpointConfirmRef: {
+    current: (choice: "continue" | "revise" | "stop") => void;
+  };
+  onCheckpointReviseRef: {
+    current: (feedback: string, snap: { stepId: string; title?: string }) => void;
+  };
+  onPlanRevisionRef: {
+    current: (choice: ReviseChoice | "cancel") => void;
+  };
+  onChoiceResolveRef: {
+    current: (
+      resolution:
+        | { type: "pick"; optionId: string }
+        | { type: "text"; text: string }
+        | { type: "cancel" },
+    ) => void;
+  };
+}
+
+interface RemoteSlashHandlingArgs {
+  result: SlashResult;
+  codeMode: boolean;
+  sessions: SessionInfo[];
+  checkpoints: CheckpointMeta[];
+  models: string[] | null | undefined;
+  restoreCodeOnlyMessage: string;
+}
+
+function parseIndexedChoice(text: string): number {
+  const rawIndex = text.match(/^(\d+)/)?.[1];
+  return rawIndex ? Number.parseInt(rawIndex, 10) - 1 : -1;
+}
+
+function isCancelText(text: string): boolean {
+  const lower = text.toLowerCase();
+  return lower === "q" || lower.includes("cancel") || lower.includes("quit");
+}
+
+function isNewText(text: string): boolean {
+  const lower = text.toLowerCase();
+  return lower === "n" || lower.includes("new");
+}
+
+function parseRunPermissionChoice(text: string): "run_once" | "always_allow" | "deny" {
+  const lower = text.toLowerCase();
+  if (lower.includes("1") || lower.includes("run")) return "run_once";
+  if (lower.includes("2") || lower.includes("always")) return "always_allow";
+  return "deny";
+}
+
+function parsePlanChoice(text: string): "approve" | "refine" | "cancel" {
+  const lower = text.toLowerCase();
+  if (lower.includes("1") || lower.includes("approve")) return "approve";
+  if (lower.includes("2") || lower.includes("refine")) return "refine";
+  return "cancel";
+}
+
+function parseCheckpointChoice(text: string): "continue" | "revise" | "stop" {
+  const lower = text.toLowerCase();
+  if (lower.includes("1") || lower.includes("continue")) return "continue";
+  if (lower.includes("2") || lower.includes("revise")) return "revise";
+  return "stop";
+}
+
+function parseRevisionChoice(text: string): ReviseChoice | "cancel" {
+  const lower = text.toLowerCase();
+  if (lower.includes("1") || lower.includes("accept")) return "accept";
+  if (lower.includes("2") || lower.includes("reject")) return "reject";
+  return "cancel";
+}
+
+function stripFollowupPrefix(text: string): string {
+  return text
+    .replace(
+      /^(?:\d+\s*|approve\s*|refine\s*|cancel\s*|continue\s*|revise\s*|stop\s*|accept\s*|reject\s*|run\s*|always\s*|deny\s*)/iu,
+      "",
+    )
+    .trim();
+}
+
+export function useQQChannel({
+  codeMode,
+  initialChannel,
+  log,
+  isRawModeSupported,
+  setRawMode,
+  setQueuedSubmit,
+  qqSubmitRef,
+  qqErrorRef,
+  sessionName,
+  currentRootDir,
+  pendingGateIdRef,
+  completedStepIdsRef,
+  planStepsRef,
+  onCreateSession,
+  onSelectSession,
+  onModelPick,
+  onThemePick,
+  onShellConfirmRef,
+  onPathConfirmRef,
+  onPlanCancelRef,
+  onPlanFeedbackRef,
+  onCheckpointConfirmRef,
+  onCheckpointReviseRef,
+  onPlanRevisionRef,
+  onChoiceResolveRef,
+}: UseQQChannelArgs) {
+  const channelRef = useRef<QQChannel | null>(initialChannel ?? null);
+  const interactionRef = useRef<QQInteractionState>({ kind: null, payload: null });
+  const slashInteractionRef = useRef<QQSlashInteractionState>({ kind: null, payload: null });
+  const replyThisTurnRef = useRef(false);
+
+  const promptLine = useCallback(
+    async (prompt: string, fallback?: string): Promise<string> => {
+      if (isRawModeSupported) setRawMode(false);
+      const rl = createInterface({ input: process.stdin, output: process.stdout });
+      try {
+        const answer = await new Promise<string>((resolve) => {
+          rl.question(prompt, resolve);
+        });
+        return answer.trim() || fallback || "";
+      } finally {
+        rl.close();
+        if (isRawModeSupported) setRawMode(true);
+      }
+    },
+    [isRawModeSupported, setRawMode],
+  );
+
+  const sendText = useCallback(
+    (message: string) => {
+      const send = channelRef.current?.sendResponse(message);
+      send?.catch((err) => {
+        log.pushWarning("QQ", `sendResponse error: ${(err as Error).message}`);
+      });
+    },
+    [log],
+  );
+
+  const sendInfo = useCallback(
+    (message: string) => {
+      log.pushInfo(message);
+      sendText(message);
+    },
+    [log, sendText],
+  );
+
+  const connect = useCallback(
+    async (args: readonly string[]): Promise<string> => {
+      const existing = loadQQConfig();
+      const appId =
+        args[0]?.trim() ||
+        existing.appId ||
+        (await promptLine("QQ Open Platform App ID: ", existing.appId));
+      const appSecret =
+        args[1]?.trim() ||
+        existing.appSecret ||
+        (await promptLine("QQ Open Platform App Secret: ", existing.appSecret));
+      const sandboxArg = args[2]?.trim().toLowerCase();
+      const sandbox =
+        sandboxArg === "sandbox" ||
+        sandboxArg === "true" ||
+        sandboxArg === "1" ||
+        sandboxArg === "yes"
+          ? true
+          : sandboxArg === "prod" ||
+              sandboxArg === "false" ||
+              sandboxArg === "0" ||
+              sandboxArg === "no"
+            ? false
+            : (existing.sandbox ?? false);
+
+      if (!appId || !appSecret) {
+        throw new Error("QQ App ID and App Secret are required.");
+      }
+
+      saveQQConfig({ appId, appSecret, sandbox, enabled: false });
+      if (channelRef.current) {
+        saveQQConfig({ appId, appSecret, sandbox, enabled: true });
+        return `QQ is already connected (${codeMode ? "code" : "chat"} mode). Auto-start is enabled.`;
+      }
+
+      const channel = new QQChannel({
+        onSubmitMessage: (message) => setQueuedSubmit(message),
+        onError: (message) => log.pushWarning("QQ", message),
+      });
+      await channel.start();
+      channelRef.current = channel;
+      saveQQConfig({ appId, appSecret, sandbox, enabled: true });
+      return `QQ connected in ${codeMode ? "code" : "chat"} mode. It will auto-start on future launches.`;
+    },
+    [codeMode, log, promptLine, setQueuedSubmit],
+  );
+
+  const disconnect = useCallback(async (): Promise<string> => {
+    const existing = loadQQConfig();
+    const current = channelRef.current;
+    channelRef.current = null;
+    if (current) await current.stop();
+    saveQQConfig({ ...existing, enabled: false });
+    return "QQ disconnected. Auto-start is disabled.";
+  }, []);
+
+  const status = useCallback((): string => {
+    const config = loadQQConfig();
+    const configured = config.appId && config.appSecret ? "configured" : "not configured";
+    const connected = channelRef.current ? "connected" : "disconnected";
+    const enabled = config.enabled ? "enabled" : "disabled";
+    const appId = config.appId ? `${config.appId.slice(0, 6)}...` : "none";
+    const sandbox = config.sandbox ? "sandbox" : "production";
+    return `QQ: ${connected}, auto-start ${enabled}, credentials ${configured}, appId ${appId}, ${sandbox}, current mode ${codeMode ? "code" : "chat"}.`;
+  }, [codeMode]);
+
+  const resetInteractions = useCallback(() => {
+    interactionRef.current = { kind: null, payload: null };
+    slashInteractionRef.current = { kind: null, payload: null };
+    replyThisTurnRef.current = false;
+  }, []);
+
+  const clearSlashInteraction = useCallback(() => {
+    slashInteractionRef.current = { kind: null, payload: null };
+  }, []);
+
+  const canBypassBusy = useCallback(
+    (queuedSubmit: string) =>
+      queuedSubmit.startsWith("[QQ] ") &&
+      interactionRef.current.kind !== null &&
+      pendingGateIdRef.current !== null,
+    [pendingGateIdRef],
+  );
+
+  const bindTransportRefs = useCallback(() => {
+    if (!qqSubmitRef || !qqErrorRef) return () => undefined;
+    qqSubmitRef.current = setQueuedSubmit;
+    qqErrorRef.current = (msg) => log.pushWarning("QQ", msg);
+    return () => {
+      qqSubmitRef.current = null;
+      qqErrorRef.current = null;
+    };
+  }, [log, qqErrorRef, qqSubmitRef, setQueuedSubmit]);
+
+  useEffect(() => bindTransportRefs(), [bindTransportRefs]);
+
+  const beginSessionsPicker = useCallback(
+    (sessions: SessionInfo[]) => {
+      slashInteractionRef.current = { kind: "sessions_picker", payload: sessions };
+      const lines = sessions.map((s, idx) => `${idx + 1}. ${s.name}`);
+      lines.push("N. New session");
+      lines.push("Q. Cancel");
+      sendText(`Choose a session:\n\n${lines.join("\n")}`);
+    },
+    [sendText],
+  );
+
+  const beginCheckpointPicker = useCallback(
+    (checkpoints: CheckpointMeta[]) => {
+      slashInteractionRef.current = { kind: "checkpoint_picker", payload: checkpoints };
+      const lines = checkpoints.map(
+        (c, idx) => `${idx + 1}. ${c.name} (${c.id.slice(0, 7)}, ${fmtAgo(c.createdAt)})`,
+      );
+      lines.push("Q. Cancel");
+      sendText(`Choose a checkpoint to restore:\n\n${lines.join("\n")}`);
+    },
+    [sendText],
+  );
+
+  const beginModelPicker = useCallback(
+    (models: string[]) => {
+      slashInteractionRef.current = { kind: "model_picker", payload: models };
+      const lines = models.map((model, idx) => `${idx + 1}. ${model}`);
+      lines.push("Q. Cancel");
+      sendText(`Choose a model or preset:\n\n${lines.join("\n")}`);
+    },
+    [sendText],
+  );
+
+  const beginThemePicker = useCallback(
+    (themes: ThemeChoice[]) => {
+      slashInteractionRef.current = { kind: "theme_picker", payload: themes };
+      const lines = themes.map((theme, idx) => `${idx + 1}. ${theme}`);
+      lines.push("Q. Cancel");
+      sendText(`Choose a theme:\n\n${lines.join("\n")}`);
+    },
+    [sendText],
+  );
+
+  const notifyTerminalOnly = useCallback((message: string) => sendText(message), [sendText]);
+
+  const consumeSlashReply = useCallback(
+    (text: string): boolean => {
+      const lowerText = text.toLowerCase();
+      const pickedIndex = parseIndexedChoice(text);
+      switch (slashInteractionRef.current.kind) {
+        case "sessions_picker": {
+          const sessions = (slashInteractionRef.current.payload as SessionInfo[]) ?? [];
+          slashInteractionRef.current = { kind: null, payload: null };
+          if (isCancelText(text)) {
+            return true;
+          }
+          if (isNewText(text)) {
+            if (onCreateSession) {
+              const nextSession = freshSessionName(sessionName ?? undefined);
+              onCreateSession(nextSession);
+              sendText("Switched to a new session.");
+            } else {
+              sendText(
+                "This runtime cannot switch sessions remotely. Create a new session in the terminal.",
+              );
+            }
+            return true;
+          }
+          if (pickedIndex >= 0 && pickedIndex < sessions.length) {
+            const target = sessions[pickedIndex];
+            if (!target) return true;
+            if (onSelectSession) {
+              onSelectSession(target.name);
+              sendText(`Switched to session: ${target.name}`);
+            } else {
+              sendText(`Switch to session in the terminal: ${target.name}`);
+            }
+          }
+          return true;
+        }
+        case "checkpoint_picker": {
+          const checkpoints = (slashInteractionRef.current.payload as CheckpointMeta[]) ?? [];
+          slashInteractionRef.current = { kind: null, payload: null };
+          if (isCancelText(text)) {
+            return true;
+          }
+          if (pickedIndex >= 0 && pickedIndex < checkpoints.length) {
+            const target = checkpoints[pickedIndex];
+            if (!target) return true;
+            const result = restoreCheckpoint(currentRootDir, target.id);
+            const lines = [
+              `Restored "${target.name}" (${target.id.slice(0, 7)}, ${fmtAgo(target.createdAt)})`,
+            ];
+            if (result.restored.length > 0) lines.push(`Wrote ${result.restored.length} file(s)`);
+            if (result.removed.length > 0) lines.push(`Deleted ${result.removed.length} file(s)`);
+            if (result.skipped.length > 0) lines.push(`Skipped ${result.skipped.length} file(s)`);
+            const message = lines.join("\n");
+            log.pushInfo(message);
+            sendText(message);
+          }
+          return true;
+        }
+        case "model_picker": {
+          const choices = (slashInteractionRef.current.payload as string[]) ?? [];
+          slashInteractionRef.current = { kind: null, payload: null };
+          if (isCancelText(text)) {
+            return true;
+          }
+          if (pickedIndex >= 0 && pickedIndex < choices.length) {
+            const target = choices[pickedIndex];
+            if (!target) return true;
+            const message = onModelPick(target);
+            log.pushInfo(message);
+            sendText(message);
+          }
+          return true;
+        }
+        case "theme_picker": {
+          const choices = (slashInteractionRef.current.payload as ThemeChoice[]) ?? [];
+          slashInteractionRef.current = { kind: null, payload: null };
+          if (isCancelText(text)) {
+            return true;
+          }
+          if (pickedIndex >= 0 && pickedIndex < choices.length) {
+            const target = choices[pickedIndex];
+            if (!target) return true;
+            const message = onThemePick(target);
+            log.pushInfo(message);
+            sendText(message);
+          }
+          return true;
+        }
+        default:
+          return false;
+      }
+    },
+    [
+      currentRootDir,
+      log,
+      onCreateSession,
+      onModelPick,
+      onSelectSession,
+      onThemePick,
+      sendText,
+      sessionName,
+    ],
+  );
+
+  const consumePauseReply = useCallback(
+    (text: string): boolean => {
+      if (interactionRef.current.kind === null || pendingGateIdRef.current === null) return false;
+      replyThisTurnRef.current = true;
+      const followup = stripFollowupPrefix(text);
+      const interaction = interactionRef.current;
+      interactionRef.current = { kind: null, payload: null };
+
+      switch (interaction.kind) {
+        case "run_command":
+        case "run_background":
+          onShellConfirmRef.current(parseRunPermissionChoice(text));
+          return true;
+        case "path_access":
+          onPathConfirmRef.current(parseRunPermissionChoice(text));
+          return true;
+        case "plan_proposed": {
+          const payload = (interaction.payload as { plan?: string }) ?? {};
+          const choice = parsePlanChoice(text);
+          if (choice === "cancel") {
+            void onPlanCancelRef.current();
+          } else {
+            void onPlanFeedbackRef.current(followup, {
+              plan: payload.plan ?? "",
+              mode: choice === "approve" ? "approve" : "refine",
+            });
+          }
+          return true;
+        }
+        case "plan_checkpoint": {
+          const payload = (interaction.payload as { stepId?: string; title?: string }) ?? {};
+          const choice = parseCheckpointChoice(text);
+          if (choice === "revise") {
+            onCheckpointReviseRef.current(followup, {
+              stepId: payload.stepId ?? "",
+              title: payload.title,
+            });
+          } else {
+            onCheckpointConfirmRef.current(choice);
+          }
+          return true;
+        }
+        case "plan_revision":
+          onPlanRevisionRef.current(parseRevisionChoice(text));
+          return true;
+        case "choice": {
+          const payload =
+            (interaction.payload as {
+              options?: ChoiceOption[];
+              allowCustom?: boolean;
+            }) ?? {};
+          const options = payload.options ?? [];
+          const pickedIndex = parseIndexedChoice(text);
+          if (pickedIndex >= 0 && pickedIndex < options.length) {
+            const selected = options[pickedIndex];
+            if (selected) onChoiceResolveRef.current({ type: "pick", optionId: selected.id });
+            return true;
+          }
+          for (const option of options) {
+            if (text.toLowerCase().includes(option.title.toLowerCase())) {
+              onChoiceResolveRef.current({ type: "pick", optionId: option.id });
+              return true;
+            }
+          }
+          if (payload.allowCustom) {
+            onChoiceResolveRef.current({ type: "text", text });
+          } else {
+            onChoiceResolveRef.current({ type: "cancel" });
+          }
+          return true;
+        }
+        default:
+          return false;
+      }
+    },
+    [
+      onCheckpointConfirmRef,
+      onCheckpointReviseRef,
+      onChoiceResolveRef,
+      onPathConfirmRef,
+      onPlanCancelRef,
+      onPlanFeedbackRef,
+      onPlanRevisionRef,
+      onShellConfirmRef,
+      pendingGateIdRef,
+    ],
+  );
+
+  const noteTurnFromQQ = useCallback((fromQQ: boolean) => {
+    replyThisTurnRef.current = fromQQ;
+  }, []);
+
+  const maybeSendFinalReply = useCallback(
+    (lastAssistantText: string) => {
+      if (channelRef.current && lastAssistantText && replyThisTurnRef.current) {
+        channelRef.current.sendResponse(lastAssistantText).catch((err) => {
+          log.pushWarning("QQ", `sendResponse error: ${(err as Error).message}`);
+        });
+      }
+    },
+    [log],
+  );
+
+  const clearTurnReply = useCallback(() => {
+    replyThisTurnRef.current = false;
+  }, []);
+
+  const handlePauseRequest = useCallback(
+    (kind: string, payload: Record<string, unknown>) => {
+      if (!channelRef.current) return;
+      interactionRef.current = { kind: kind as QQInteractionKind, payload };
+
+      let qqMessage = "";
+      switch (kind) {
+        case "run_command":
+        case "run_background": {
+          const p = payload as { command: string };
+          qqMessage = `Need confirmation\n\nCommand: \`${p.command}\`\n\nReply with:\n1. Run once\n2. Always allow\n3. Deny`;
+          break;
+        }
+        case "path_access": {
+          const p = payload as { path: string; intent: "read" | "write"; toolName: string };
+          const intentText = p.intent === "read" ? "Read" : "Write";
+          qqMessage = `Need file access confirmation\n\nAction: ${intentText}\nPath: ${p.path}\nTool: ${p.toolName}\n\nReply with:\n1. Run once\n2. Always allow\n3. Deny`;
+          break;
+        }
+        case "plan_proposed": {
+          const p = payload as { plan: string };
+          qqMessage = `Plan confirmation\n\n${p.plan}\n\nReply with:\n1. Approve\n2. Refine\n3. Cancel`;
+          break;
+        }
+        case "plan_checkpoint": {
+          const p = payload as { title?: string; result: string };
+          const completed = completedStepIdsRef.current.size;
+          const total = planStepsRef.current?.length ?? 0;
+          qqMessage = `Step complete (${completed}/${total})\n\n${p.title ? `Step: ${p.title}\n` : ""}Result: ${p.result}\n\nReply with:\n1. Continue\n2. Revise\n3. Stop`;
+          break;
+        }
+        case "plan_revision": {
+          const p = payload as { reason: string };
+          qqMessage = `Plan revision proposed\n\n${p.reason}\n\nReply with:\n1. Accept\n2. Reject\n3. Cancel`;
+          break;
+        }
+        case "choice": {
+          const p = payload as { question: string; options: ChoiceOption[]; allowCustom: boolean };
+          const optionsList = p.options.map((opt, idx) => `${idx + 1}. ${opt.title}`).join("\n");
+          qqMessage = `Please choose\n\n${p.question}\n\nOptions:\n${optionsList}${p.allowCustom ? "\n\n(You can also reply with custom text.)" : ""}`;
+          break;
+        }
+      }
+      if (qqMessage) sendText(qqMessage);
+    },
+    [completedStepIdsRef, planStepsRef, sendText],
+  );
+
+  const buildModelChoices = useCallback(
+    (models: string[] | null | undefined) => [
+      "auto",
+      "flash",
+      "pro",
+      ...((models && models.length > 0
+        ? models
+        : [
+            "deepseek-v4-flash",
+            "deepseek-v4-pro",
+            "deepseek-chat",
+            "deepseek-reasoner",
+          ]) as string[]),
+    ],
+    [],
+  );
+
+  const buildThemeChoices = useCallback((): ThemeChoice[] => ["auto", ...listThemeNames()], []);
+
+  const parseSubmit = useCallback(
+    (raw: string) => {
+      let text = raw.trim();
+      if (!text) return null;
+
+      const fromQQ = text.startsWith("[QQ] ");
+      if (fromQQ) {
+        text = text.slice(5).trimStart() || text;
+        if (consumeSlashReply(text) || consumePauseReply(text)) {
+          return { handled: true, fromQQ, text };
+        }
+      }
+
+      return { handled: false, fromQQ, text };
+    },
+    [consumePauseReply, consumeSlashReply],
+  );
+
+  const handleRemoteSlashResult = useCallback(
+    ({
+      result,
+      codeMode: codeModeOn,
+      sessions,
+      checkpoints,
+      models,
+      restoreCodeOnlyMessage,
+    }: RemoteSlashHandlingArgs): boolean => {
+      if (result.openSessionsPicker) {
+        beginSessionsPicker(sessions);
+        return true;
+      }
+      if (result.openCheckpointPicker) {
+        if (!codeModeOn) {
+          sendInfo(restoreCodeOnlyMessage);
+          return true;
+        }
+        beginCheckpointPicker(checkpoints);
+        return true;
+      }
+      if (result.openMcpHub) {
+        notifyTerminalOnly("`/mcp` interactive management is currently terminal-only.");
+        return true;
+      }
+      if (result.openModelPicker) {
+        beginModelPicker(buildModelChoices(models));
+        return true;
+      }
+      if (result.openThemePicker) {
+        beginThemePicker(buildThemeChoices());
+        return true;
+      }
+      if (result.openCopyMode) {
+        notifyTerminalOnly("`/copy` follow-up interaction is currently terminal-only.");
+        return true;
+      }
+      if (result.openArgPickerFor) {
+        notifyTerminalOnly(
+          `\`/${result.openArgPickerFor}\` needs terminal-side argument completion.`,
+        );
+        return true;
+      }
+      return false;
+    },
+    [
+      beginCheckpointPicker,
+      beginModelPicker,
+      beginSessionsPicker,
+      beginThemePicker,
+      buildModelChoices,
+      buildThemeChoices,
+      notifyTerminalOnly,
+      sendInfo,
+    ],
+  );
+
+  return useMemo(
+    () => ({
+      channelRef,
+      connect,
+      disconnect,
+      status,
+      sendInfo,
+      sendText,
+      resetInteractions,
+      clearSlashInteraction,
+      canBypassBusy,
+      consumeSlashReply,
+      consumePauseReply,
+      beginSessionsPicker,
+      beginCheckpointPicker,
+      beginModelPicker,
+      beginThemePicker,
+      notifyTerminalOnly,
+      noteTurnFromQQ,
+      maybeSendFinalReply,
+      clearTurnReply,
+      handlePauseRequest,
+      buildModelChoices,
+      buildThemeChoices,
+      parseSubmit,
+      handleRemoteSlashResult,
+    }),
+    [
+      beginCheckpointPicker,
+      beginModelPicker,
+      beginSessionsPicker,
+      beginThemePicker,
+      buildModelChoices,
+      buildThemeChoices,
+      canBypassBusy,
+      clearSlashInteraction,
+      clearTurnReply,
+      connect,
+      consumePauseReply,
+      consumeSlashReply,
+      disconnect,
+      handlePauseRequest,
+      handleRemoteSlashResult,
+      maybeSendFinalReply,
+      noteTurnFromQQ,
+      notifyTerminalOnly,
+      parseSubmit,
+      resetInteractions,
+      sendInfo,
+      sendText,
+      status,
+    ],
+  );
+}

--- a/tests/code-prompt.test.ts
+++ b/tests/code-prompt.test.ts
@@ -42,7 +42,7 @@ describe("codeSystemPrompt", () => {
     // The .gitignore block (base + truncated + fences) is bounded.
     // Allow extra slack for the builtin Skills index that applyMemoryStack
     // also injects — that's a fixed-size addition, not unbounded.
-    expect(out.length).toBeLessThan(CODE_SYSTEM_PROMPT.length + 4500);
+    expect(out.length).toBeLessThan(CODE_SYSTEM_PROMPT.length + 5000);
   });
 
   it("reminds the model to skip dependency / build / VCS dirs", () => {

--- a/tests/slash.test.ts
+++ b/tests/slash.test.ts
@@ -538,7 +538,7 @@ describe("handleSlash", () => {
     // Case-insensitive.
     expect(suggestSlashCommands("HE").map((s) => s.cmd)).toEqual(["help"]);
     // Empty prefix returns the full non-advanced release list, including code commands.
-    expect(suggestSlashCommands("", true)).toHaveLength(40);
+    expect(suggestSlashCommands("", true)).toHaveLength(41);
     expect(suggestSlashCommands("", true).map((s) => s.cmd)).toContain("logs");
     expect(suggestSlashCommands("", true).map((s) => s.cmd)).toContain("language");
     expect(suggestSlashCommands("lan").map((s) => s.cmd)).toContain("language");
@@ -1074,28 +1074,41 @@ describe("handleSlash", () => {
 
   describe("/memory", () => {
     let root: string;
-    let home: string;
     const originalEnv = process.env.REASONIX_MEMORY;
+    const originalHome = process.env.HOME;
+    const originalUserProfile = process.env.USERPROFILE;
 
     beforeEach(() => {
       root = mkdtempSync(join(tmpdir(), "reasonix-mem-slash-"));
-      home = mkdtempSync(join(tmpdir(), "reasonix-mem-slash-home-"));
+      process.env.HOME = root;
+      process.env.USERPROFILE = root;
       // biome-ignore lint/performance/noDelete: avoid "undefined" in env
       delete process.env.REASONIX_MEMORY;
     });
     afterEach(() => {
       rmSync(root, { recursive: true, force: true });
-      rmSync(home, { recursive: true, force: true });
       if (originalEnv === undefined) {
         // biome-ignore lint/performance/noDelete: same reason
         delete process.env.REASONIX_MEMORY;
       } else {
         process.env.REASONIX_MEMORY = originalEnv;
       }
+      if (originalHome === undefined) {
+        // biome-ignore lint/performance/noDelete: env restoration needs absence, not "undefined"
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+      if (originalUserProfile === undefined) {
+        // biome-ignore lint/performance/noDelete: env restoration needs absence, not "undefined"
+        delete process.env.USERPROFILE;
+      } else {
+        process.env.USERPROFILE = originalUserProfile;
+      }
     });
 
     it("prints a how-to when no memory (REASONIX.md or ~/.reasonix/memory) exists", () => {
-      const r = handleSlash("memory", [], makeLoop(), { memoryRoot: root, homeDir: home });
+      const r = handleSlash("memory", [], makeLoop(), { memoryRoot: root });
       expect(r.info).toMatch(/no memory pinned/);
       expect(r.info).toMatch(/REASONIX\.md/);
     });
@@ -1106,7 +1119,7 @@ describe("handleSlash", () => {
         "# House rules\nSnake case only in this repo.\n",
         "utf8",
       );
-      const r = handleSlash("memory", [], makeLoop(), { memoryRoot: root, homeDir: home });
+      const r = handleSlash("memory", [], makeLoop(), { memoryRoot: root });
       expect(r.info).toMatch(/▸ REASONIX\.md:/);
       expect(r.info).toContain("Snake case only");
       expect(r.info).toMatch(/chars/);
@@ -1115,7 +1128,7 @@ describe("handleSlash", () => {
     it("says memory is disabled when REASONIX_MEMORY=off, even with a file present", () => {
       writeFileSync(join(root, "REASONIX.md"), "content", "utf8");
       process.env.REASONIX_MEMORY = "off";
-      const r = handleSlash("memory", [], makeLoop(), { memoryRoot: root, homeDir: home });
+      const r = handleSlash("memory", [], makeLoop(), { memoryRoot: root });
       expect(r.info).toMatch(/memory is disabled/);
     });
 

--- a/tests/ui-slash-suggestions.test.tsx
+++ b/tests/ui-slash-suggestions.test.tsx
@@ -84,7 +84,7 @@ describe("SlashSuggestions", () => {
     );
   });
 
-  it("renders the bare slash release command surface as 40 total commands", () => {
+  it("renders the bare slash release command surface as 41 total commands", () => {
     const matches = suggestSlashCommands("", true);
     const names = matches.map((spec) => spec.cmd);
     const { lastFrame, unmount } = render(
@@ -93,11 +93,11 @@ describe("SlashSuggestions", () => {
     const frame = lastFrame() ?? "";
     unmount();
 
-    expect(matches).toHaveLength(40);
+    expect(matches).toHaveLength(41);
     expect(names).toContain("language");
     expect(names).toContain("btw");
     expect(countAdvancedCommands(true)).toBe(11);
-    expect(frame).toContain("40 commands");
+    expect(frame).toContain("41 commands");
     expect(frame).toContain("+ 11 advanced");
   });
 

--- a/tests/user-memory.test.ts
+++ b/tests/user-memory.test.ts
@@ -22,10 +22,14 @@ describe("user-memory", () => {
   let home: string;
   let projectRoot: string;
   const originalEnv = process.env.REASONIX_MEMORY;
+  const originalHome = process.env.HOME;
+  const originalUserProfile = process.env.USERPROFILE;
 
   beforeEach(() => {
     home = mkdtempSync(join(tmpdir(), "reasonix-umem-home-"));
     projectRoot = mkdtempSync(join(tmpdir(), "reasonix-umem-proj-"));
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
     // biome-ignore lint/performance/noDelete: avoid leaking "undefined" into env
     delete process.env.REASONIX_MEMORY;
   });
@@ -38,6 +42,18 @@ describe("user-memory", () => {
       delete process.env.REASONIX_MEMORY;
     } else {
       process.env.REASONIX_MEMORY = originalEnv;
+    }
+    if (originalHome === undefined) {
+      // biome-ignore lint/performance/noDelete: env restoration needs absence, not "undefined"
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+    if (originalUserProfile === undefined) {
+      // biome-ignore lint/performance/noDelete: env restoration needs absence, not "undefined"
+      delete process.env.USERPROFILE;
+    } else {
+      process.env.USERPROFILE = originalUserProfile;
     }
   });
 


### PR DESCRIPTION
## What

This PR adds QQ as a first-class communication channel for Reasonix, integrated into the existing `chat` and `code` modes rather than introducing a separate runtime mode.

It adds QQ connection management through slash commands (`/qq connect`, `/qq status`, `/qq disconnect`), persists QQ credentials/config in local config, and automatically starts the QQ channel in later `chat` / `code` sessions once enabled. It also bridges interactive pause/confirmation flows to QQ, so when a tool call, plan approval, checkpoint, or choice prompt needs user input, the prompt can be delivered to QQ and the reply can continue the same turn remotely. Follow-up assistant output from that turn is also routed back to QQ.

## Why

Reasonix already has strong interactive flows in the terminal UI, but it had no QQ support as a remote communication surface. That made QQ-based workflows awkward, especially when the user needed to monitor or steer a running session away from the terminal.

This change is designed to stay close to the existing Reasonix architecture: QQ is not treated as a third mode, but as an optional channel layered onto the current `chat` / `code` experience. Once connected, the same session can be continued through QQ for notifications, approvals, and replies.

## How to verify

1. Start an interactive session:
   - `npm run dev -- chat`
   - or `npm run dev -- code`

2. Configure QQ:
   - Run `/qq connect`
   - Provide `appId` / `appSecret` if they are not already configured

3. Confirm connection:
   - Run `/qq status`
   - Verify QQ is enabled and connected

4. Verify auto-start:
   - Exit the session
   - Start `chat` or `code` again
   - Verify QQ starts automatically once previously enabled

5. Verify normal QQ messaging:
   - Send a message from QQ
   - Verify Reasonix receives it and sends the reply back to QQ

6. Verify interactive remote approval flows:
   - Trigger a tool confirmation, plan approval, checkpoint decision, or choice prompt
   - Verify the prompt is sent to QQ
   - Reply from QQ with the requested option or follow-up text
   - Verify the turn continues without terminal-side confirmation
   - Verify the final assistant response for that turn is also delivered to QQ

7. Verify slash command handling from QQ:
   - Send a slash command from QQ
   - Verify it is routed through the existing slash-command dispatcher correctly

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time

## Notes

Update: `npm run verify` now passes locally after syncing the QQ-related tests and fixing a few pre-existing test-environment issues surfaced during this work.