### PR TITLE
fix(desktop): catch unknown PauseKind to prevent silent agent-loop hangs

### DIFF
--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -1095,6 +1095,15 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
       );
       return;
     }
+    // Unknown PauseKind — `never` makes a new kind without a handler a compile
+    // error; the runtime cancel is the last-mile defense so the agent loop
+    // doesn't hang waiting on a request no one will resolve.
+    const exhaustive: never = req.kind;
+    process.stderr.write(
+      `[desktop] no handler for pause kind "${String(exhaustive)}" — auto-cancelling gate id=${req.id}\n`,
+    );
+    if (tab) tab.pendingGateIds.delete(req.id);
+    pauseGate.cancel(req.id);
   });
 
   // Fast-path: emit disk-only events immediately so the UI shell renders


### PR DESCRIPTION
## What

Adds a compile-time + runtime safety net at the end of the `pauseGate.on()` listener in `src/cli/commands/desktop.ts` so a `PauseKind` that's missing a handler can't silently hang the agent loop.

```ts
// Unknown PauseKind — `never` makes a new kind without a handler a compile
// error; the runtime cancel is the last-mile defense so the agent loop
// doesn't hang waiting on a request no one will resolve.
const exhaustive: never = req.kind;
process.stderr.write(
  `[desktop] no handler for pause kind "${String(exhaustive)}" — auto-cancelling gate id=${req.id}\n`,
);
if (tab) tab.pendingGateIds.delete(req.id);
pauseGate.cancel(req.id);
```

## Why

The if-chain dispatching `req.kind` to `$*_required` events had no default branch. Today every `PauseKind` defined in `src/core/pause-gate.ts` (`run_command`, `run_background`, `path_access`, `choice`, `plan_proposed`, `plan_checkpoint`, `plan_revision`) has a matching handler — but any future kind added to `pause-gate.ts` without a matching arm here would be silently dropped, leaving the gate request pending forever. The tool that called `gate.ask(...)` would await indefinitely, the agent loop would never resume, and the user would see a hung session with no visible signal that there's an unresolved approval.

`never` flips that from a silent runtime hang into a compile error. The runtime warn + `pauseGate.cancel()` is belt-and-suspenders — if a build somehow slipped past the typecheck, the gate gets resolved with a safe-cancel verdict (delegated to `safeCancelVerdict()` in `pause-gate.ts`, which already exhaustively maps every kind to its appropriate cancel shape), the loop unblocks, and the stderr line gives us a breadcrumb in the logs.

Came out of an investigation into a user-reported desktop hang. The hang itself doesn't appear to be this bug (all 7 current kinds *are* wired), but the gap is a foot-gun worth closing before someone else trips it.

## Checklist

- [x] `npm run lint` clean on the changed file
- [x] `npx tsc --noEmit` passes (confirms the 7 current kinds are exhaustively handled)
- [x] `npm run test` — 2870 tests pass
- [x] No `Co-Authored-By: Claude` trailer
- [x] Comments follow CONTRIBUTING.md (3-line block explaining the non-obvious *why* — future-proofing safety net)
- [x] No edits to `CHANGELOG.md`
