### PR TITLE
fix(desktop): gate per-tab keyboard shortcuts on active so background tabs don't react

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -885,7 +885,7 @@ function TabRuntime({
     setSettingsPage(page);
     setSettingsOpen(true);
   }, []);
-  const palette = useCommandPalette();
+  const palette = useCommandPalette(active);
 
   useEffect(() => {
     registerDispatch(tabId, dispatch);
@@ -1086,6 +1086,8 @@ function TabRuntime({
   }, [state.messages.length]);
 
   useEffect(() => {
+    // Every TabRuntime stays mounted (display:none on inactive), so each registers its own keydown — without this gate Cmd+N would fire newChat() in every tab and wipe the inactive ones' sessions.
+    if (!active) return;
     const onKey = (e: KeyboardEvent) => {
       const mod = e.ctrlKey || e.metaKey;
       if (mod && (e.key === "l" || e.key === "L")) {
@@ -1111,7 +1113,7 @@ function TabRuntime({
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [state.busy, abort, newChat, settingsOpen, openSettingsAt]);
+  }, [active, state.busy, abort, newChat, settingsOpen, openSettingsAt]);
 
   const commands = buildCommands({
     newChat: () => {

--- a/desktop/src/CommandPalette.tsx
+++ b/desktop/src/CommandPalette.tsx
@@ -27,9 +27,11 @@ export type Command = {
   run: () => void;
 };
 
-export function useCommandPalette() {
+export function useCommandPalette(active: boolean = true) {
   const [open, setOpen] = useState(false);
   useEffect(() => {
+    // Skip in background tabs — each TabRuntime calls this hook, so without the gate Cmd+K toggles every tab's palette at once.
+    if (!active) return;
     const onKey = (e: KeyboardEvent) => {
       const mod = e.ctrlKey || e.metaKey;
       if (mod && (e.key === "k" || e.key === "K")) {
@@ -41,7 +43,7 @@ export function useCommandPalette() {
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, []);
+  }, [active]);
   return { open, setOpen };
 }
 


### PR DESCRIPTION
## Symptom

User reports that switching between two top tabs on the desktop UI causes "weird issues" on the left-side session — the session highlight in the sidebar disappears, in-flight turns abort unexpectedly, the workspace picker pops up in the wrong tab, etc.

## Cause

Every `TabRuntime` stays mounted: inactive tabs are hidden via `style={{display: active ? undefined : "none"}}` (App.tsx:1293), not unmounted. Each TabRuntime instance registers its own window-level keydown listener at `desktop/src/App.tsx:1088-1114` with no `active` gate, so a single Cmd+N fires `newChat()` in every tab:

- Both tabs send `new_chat` to the backend and locally `dispatch({t: "clear"})`, blanking out `state.currentSession` and `state.messages`.
- The inactive tab's sidebar — which was correctly highlighting session A — loses its active session, matching the user's "left-side session weird issue" description.
- The same path catches Cmd+L (focus composer), Cmd+O (workspace picker), Cmd+, (settings) and Escape-while-busy (turn abort).

`useCommandPalette` (`desktop/src/CommandPalette.tsx:32-44`) has the same shape — Cmd+K toggled every tab's palette in parallel.

## Fix

- TabRuntime keydown effect: early-return `if (!active) return;` and add `active` to the dep array.
- `useCommandPalette`: accept an `active` parameter (default `true` keeps existing callers working), gate the keydown the same way, pass `active` from the TabRuntime call site.

Both listeners are still attached/detached cleanly on tab switch via the effect's existing cleanup function.

## Test plan

- [x] `desktop/` typecheck — no new errors (8 pre-existing i18n key errors are unrelated; verified with `git stash` baseline).
- [ ] Manual: open two tabs, load different sessions in each, switch back and forth, hit Cmd+N / Cmd+L / Cmd+O / Cmd+K / Cmd+, / Escape on the active tab — only the active tab reacts; the inactive tab's session highlight and composer state remain intact.