### PR TITLE
fix(slash): /help hanging-indent wrap + fill btw/search-engine zh-CN keys

### DIFF
--- a/src/cli/ui/slash/handlers/basic.ts
+++ b/src/cli/ui/slash/handlers/basic.ts
@@ -1,3 +1,4 @@
+import { wrapToCells } from "@/frame/width.js";
 import { t, tObj } from "@/i18n/index.js";
 import { formatDuration, formatLoopStatus, parseLoopCommand } from "../../loop.js";
 import { SLASH_COMMANDS, SLASH_GROUP_ORDER, orderSlashCommandsByGroup } from "../commands.js";
@@ -22,14 +23,25 @@ function groupHeader(group: SlashGroup): string {
   return `${label}  ·  ${detail}`;
 }
 
-function renderRow(spec: SlashCommandSpec): string {
+const HELP_NAME_COL = 28;
+const HELP_HANGING_INDENT = 2 + HELP_NAME_COL + 2;
+
+function renderRow(spec: SlashCommandSpec, cols: number): string {
   const name = `/${spec.cmd}${spec.argsHint ? ` ${spec.argsHint}` : ""}`;
   const desc = t(`slash.${spec.cmd}.description`);
   const summary = desc === `slash.${spec.cmd}.description` ? spec.summary : desc;
-  return `  ${name.padEnd(28)}  ${summary}`;
+  const descWidth = Math.max(20, cols - HELP_HANGING_INDENT);
+  const chunks = wrapToCells(summary, descWidth);
+  const head = `  ${name.padEnd(HELP_NAME_COL)}  ${chunks[0] ?? ""}`;
+  if (chunks.length <= 1) return head;
+  const tail = chunks.slice(1).map((c) => `${" ".repeat(HELP_HANGING_INDENT)}${c}`);
+  return [head, ...tail].join("\n");
 }
 
 const help: SlashHandler = () => {
+  // Match the info-card chrome (`markdown.tsx` BODY_LEFT_CELLS=7) so wide
+  // CJK descriptions wrap inside the card, not past its right edge.
+  const cols = (process.stdout.columns ?? 80) - 7;
   const lines: string[] = [t("handlers.basic.helpTitle"), ""];
   const rowsByGroup = new Map<SlashGroup, SlashCommandSpec[]>();
   for (const group of SLASH_GROUP_ORDER) rowsByGroup.set(group, []);
@@ -40,7 +52,7 @@ const help: SlashHandler = () => {
     const rows = rowsByGroup.get(group) ?? [];
     if (rows.length === 0) continue;
     lines.push(`  ${groupHeader(group)}`);
-    for (const r of rows) lines.push(renderRow(r));
+    for (const r of rows) lines.push(renderRow(r, cols));
     lines.push("");
   }
   lines.push(

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -390,6 +390,15 @@ export const EN: TranslationSchema = {
       description: "tail a background job's output (default last 80 lines)",
       argsHint: "<id> [lines]",
     },
+    btw: {
+      description:
+        "ask a quick side question — answered from a blank slate, never added to the conversation context",
+      argsHint: "<question>",
+    },
+    "search-engine": {
+      description: "switch web search backend — mojeek (default, no deps) or searxng (self-hosted)",
+      argsHint: "<mojeek|searxng> [<endpoint>]",
+    },
   },
   wizard: {
     languageTitle: "Choose your language",

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -380,6 +380,14 @@ export const zhCN: TranslationSchema = {
       description: "跟踪后台作业的输出（默认最后 80 行）",
       argsHint: "<id> [lines]",
     },
+    btw: {
+      description: "顺便问一下 — 从空白上下文回答，不写入会话历史",
+      argsHint: "<question>",
+    },
+    "search-engine": {
+      description: "切换网络搜索后端 — mojeek（默认，无依赖）或 searxng（自托管）",
+      argsHint: "<mojeek|searxng> [<endpoint>]",
+    },
   },
   wizard: {
     languageTitle: "选择语言",

--- a/tests/slash-help-i18n.test.ts
+++ b/tests/slash-help-i18n.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { SLASH_COMMANDS } from "../src/cli/ui/slash/commands.js";
+import { EN } from "../src/i18n/EN.ts";
+import { zhCN } from "../src/i18n/zh-CN.ts";
+
+describe("slash help i18n coverage", () => {
+  it("every registered slash command has an EN description key", () => {
+    const missing = SLASH_COMMANDS.filter((c) => !EN.slash[c.cmd]?.description);
+    expect(missing.map((c) => c.cmd)).toEqual([]);
+  });
+
+  it("every registered slash command has a zh-CN description key", () => {
+    const missing = SLASH_COMMANDS.filter((c) => !zhCN.slash[c.cmd]?.description);
+    expect(missing.map((c) => c.cmd)).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #865.

## What

`/help` rendered broken on zh-CN: CJK summaries are double-wide, so long descriptions overflowed the terminal width and the terminal-level wrap dropped the continuation at column 0 — breaking the visual column alignment of the rest of the help list. Two zh-CN entries (`btw`, `search-engine`) were also missing, falling back to the hardcoded English summary even under Chinese locale.

## Changes

- **`src/cli/ui/slash/handlers/basic.ts`** — `renderRow` now takes the terminal width, wraps the description with `wrapToCells` (grapheme-safe, accounts for visual cell width via `string-width`), and hangs continuation lines at column 32 (2 indent + 28 name + 2 gap). Width budget subtracts the info-card's `BODY_LEFT_CELLS=7` chrome so CJK descriptions wrap inside the card instead of past its right edge.
- **`src/i18n/EN.ts` + `src/i18n/zh-CN.ts`** — fill the missing `slash.btw.description` and `slash.search-engine.description` keys. Bot fall back to the hardcoded English summary before — now they resolve through `t()` properly.
- **`tests/slash-help-i18n.test.ts`** — regression gate that asserts every `SLASH_COMMANDS` entry has both an EN and a zh-CN `slash.<cmd>.description` key. Future drift fails the build.

## Notes

- `clear`, `models`, `semantic`, `setup` are still dead i18n entries (in both EN and zh-CN under `slash.*`, no matching `cmd` in commands.ts and not aliases either). Out of scope here — leaving for a separate cleanup so this PR stays focused on the reported bug.
- The new test only enforces forward coverage (`every command has keys`), not reverse (`every key maps to a command`); reverse would fail on those stale entries until the cleanup PR.

## Checklist

- [x] `npx tsc --noEmit` clean
- [x] `npx biome check` clean on changed files
- [x] `npx vitest run` — 2872 tests pass (2 new)
- [x] Comment-policy gate green
- [x] No `Co-Authored-By: Claude` trailer
- [x] No `CHANGELOG.md` edits
