### PR TITLE
feat(desktop): font family picker, language picker, and fill missing i18n keys

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -8,7 +8,18 @@ import { CommandPalette, Toast, buildCommands, useCommandPalette } from "./Comma
 import { WorkspaceProvider } from "./Markdown";
 import { getLang, setLang, t, useLang } from "./i18n";
 import { I } from "./icons";
-import { FONT_SCALE, FONT_SCALE_ZOOM, type FontScale, THEME, type Theme, isFontScale } from "./theme";
+import {
+  FONT_FAMILY,
+  FONT_FAMILY_STACK,
+  FONT_SCALE,
+  FONT_SCALE_ZOOM,
+  type FontFamily,
+  type FontScale,
+  THEME,
+  type Theme,
+  isFontFamily,
+  isFontScale,
+} from "./theme";
 import type {
   CheckpointVerdict,
   ChoiceVerdict,
@@ -813,6 +824,8 @@ interface TabRuntimeProps {
   onToggleTheme: () => void;
   fontScale: FontScale;
   onSetFontScale: (scale: FontScale) => void;
+  fontFamily: FontFamily;
+  onSetFontFamily: (family: FontFamily) => void;
   sideCollapsed: boolean;
   ctxCollapsed: boolean;
   onToggleSide: () => void;
@@ -840,6 +853,8 @@ function TabRuntime({
   onToggleTheme,
   fontScale,
   onSetFontScale,
+  fontFamily,
+  onSetFontFamily,
   sideCollapsed,
   ctxCollapsed,
   onToggleSide,
@@ -1618,6 +1633,8 @@ function TabRuntime({
             onSetTheme={onSetTheme}
             fontScale={fontScale}
             onSetFontScale={onSetFontScale}
+            fontFamily={fontFamily}
+            onSetFontFamily={onSetFontFamily}
             initialPage={settingsPage}
             mcpSpecs={state.mcpSpecs}
             mcpBridged={state.mcpBridged}
@@ -1954,7 +1971,7 @@ function EmptyState({
         padding: "48px 16px 24px",
         textAlign: "center",
         color: "var(--muted)",
-        fontFamily: "IBM Plex Sans, sans-serif",
+        fontFamily: "var(--font-sans, 'IBM Plex Sans', sans-serif)",
       }}
     >
       <div
@@ -2154,6 +2171,10 @@ export function App() {
     const v = localStorage.getItem("reasonix.fontScale");
     return isFontScale(v) ? v : FONT_SCALE.MEDIUM;
   });
+  const [fontFamily, setFontFamily] = useState<FontFamily>(() => {
+    const v = localStorage.getItem("reasonix.fontFamily");
+    return isFontFamily(v) ? v : FONT_FAMILY.SANS;
+  });
   const [sideCollapsed, setSideCollapsed] = useState(false);
   const [ctxCollapsed, setCtxCollapsed] = useState(false);
 
@@ -2167,6 +2188,12 @@ export function App() {
     document.documentElement.style.setProperty("zoom", String(FONT_SCALE_ZOOM[fontScale]));
     localStorage.setItem("reasonix.fontScale", fontScale);
   }, [fontScale]);
+
+  useEffect(() => {
+    // CSS rules use var(--font-sans); changing it here re-styles every sans surface in one shot. Mono stays put because code/transcripts hardcode "IBM Plex Mono".
+    document.documentElement.style.setProperty("--font-sans", FONT_FAMILY_STACK[fontFamily]);
+    localStorage.setItem("reasonix.fontFamily", fontFamily);
+  }, [fontFamily]);
 
   useEffect(() => {
     const onCur = (e: Event) => {
@@ -2436,6 +2463,8 @@ export function App() {
           onToggleTheme={onToggleTheme}
           fontScale={fontScale}
           onSetFontScale={setFontScale}
+          fontFamily={fontFamily}
+          onSetFontFamily={setFontFamily}
           sideCollapsed={sideCollapsed}
           ctxCollapsed={ctxCollapsed}
           onToggleSide={() => setSideCollapsed((v) => !v)}

--- a/desktop/src/i18n/en.ts
+++ b/desktop/src/i18n/en.ts
@@ -84,6 +84,11 @@ export const en = {
     fontScaleSmall: "small",
     fontScaleMedium: "medium",
     fontScaleLarge: "large",
+    fontFamily: "Font family",
+    fontFamilyHint: "Body type; code blocks stay monospace either way.",
+    fontFamilySans: "sans",
+    fontFamilySystem: "system",
+    fontFamilySerif: "serif",
     reasoningEffort: "Reasoning effort",
     reasoningEffortHint: "Applies live to the running session.",
     effortHigh: "high",
@@ -360,5 +365,19 @@ export const en = {
     offline: "Offline",
     busy: "Running",
     online: "Online",
+  },
+  contextPanel: {
+    reservedKey: "reserved",
+    usedKey: "used",
+    noFilesMsg: "No files in context yet.",
+    noMemoriesMsg: "No memories saved yet.",
+  },
+  extraCards: {
+    sessionUsage: "Session usage",
+    sessionCost: "Cost {costLabel}",
+  },
+  thread: {
+    keepSteps: "Keep {n} remaining step(s)",
+    keepOriginal: "Keep original",
   },
 };

--- a/desktop/src/i18n/zh-CN.ts
+++ b/desktop/src/i18n/zh-CN.ts
@@ -85,6 +85,11 @@ export const zhCN: typeof en = {
     fontScaleSmall: "小",
     fontScaleMedium: "中",
     fontScaleLarge: "大",
+    fontFamily: "字体",
+    fontFamilyHint: "正文字体；代码块始终用等宽。",
+    fontFamilySans: "无衬线",
+    fontFamilySystem: "系统",
+    fontFamilySerif: "衬线",
     reasoningEffort: "思考深度",
     reasoningEffortHint: "立即生效。",
     effortHigh: "high",
@@ -347,5 +352,19 @@ export const zhCN: typeof en = {
     memoryCountSuffix: "项",
     checkpointRewind: "回到此处",
     planDefaultTitle: "计划",
+  },
+  contextPanel: {
+    reservedKey: "预留",
+    usedKey: "已用",
+    noFilesMsg: "上下文里还没有文件。",
+    noMemoriesMsg: "还没保存任何记忆。",
+  },
+  extraCards: {
+    sessionUsage: "会话用量",
+    sessionCost: "花费 {costLabel}",
+  },
+  thread: {
+    keepSteps: "保留剩余 {n} 步",
+    keepOriginal: "保留原计划",
   },
 };

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -18,7 +18,7 @@ body,
 }
 
 body {
-  font-family: "IBM Plex Sans", -apple-system, system-ui, sans-serif;
+  font-family: var(--font-sans, "IBM Plex Sans", -apple-system, system-ui, sans-serif);
   font-size: 13px;
   line-height: 1.5;
   color: var(--fg);
@@ -1106,7 +1106,7 @@ button {
   font-size: 11.5px;
   color: var(--fg-2);
   flex: 1;
-  font-family: "IBM Plex Sans", sans-serif;
+  font-family: var(--font-sans, "IBM Plex Sans", sans-serif);
 }
 .approve-row .why b {
   color: var(--warning);
@@ -1120,7 +1120,7 @@ button {
   border-radius: 6px;
   font-size: 11.5px;
   font-weight: 500;
-  font-family: "IBM Plex Sans", sans-serif;
+  font-family: var(--font-sans, "IBM Plex Sans", sans-serif);
   border: 1px solid var(--border-strong);
   background: var(--card);
   color: var(--fg);
@@ -2104,7 +2104,7 @@ button {
   box-shadow: var(--shadow-lg);
   padding: 12px;
   width: 280px;
-  font-family: "IBM Plex Sans", sans-serif;
+  font-family: var(--font-sans, "IBM Plex Sans", sans-serif);
   color: var(--fg);
   font-size: 12px;
   z-index: 20;
@@ -4081,7 +4081,7 @@ button {
 [data-theme="light"] .mode-banner .mb-tag { color: oklch(100% 0 0); }
 .mode-banner .mb-msg {
   color: var(--fg);
-  font-family: "IBM Plex Sans", sans-serif;
+  font-family: var(--font-sans, "IBM Plex Sans", sans-serif);
   font-size: 12px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -4580,7 +4580,7 @@ button {
 
 .splash-wordmark {
   margin: 0;
-  font-family: "IBM Plex Sans", sans-serif;
+  font-family: var(--font-sans, "IBM Plex Sans", sans-serif);
   font-weight: 300;
   font-size: clamp(48px, 7.5vw, 92px);
   letter-spacing: -0.025em;

--- a/desktop/src/theme.ts
+++ b/desktop/src/theme.ts
@@ -26,3 +26,21 @@ export const FONT_SCALE_ZOOM: Record<FontScale, number> = {
   medium: 1.0,
   large: 1.125,
 };
+
+export const FONT_FAMILY = {
+  SANS: "sans",
+  SYSTEM: "system",
+  SERIF: "serif",
+} as const;
+
+export type FontFamily = (typeof FONT_FAMILY)[keyof typeof FONT_FAMILY];
+
+export function isFontFamily(value: unknown): value is FontFamily {
+  return value === FONT_FAMILY.SANS || value === FONT_FAMILY.SYSTEM || value === FONT_FAMILY.SERIF;
+}
+
+export const FONT_FAMILY_STACK: Record<FontFamily, string> = {
+  sans: '"IBM Plex Sans", -apple-system, system-ui, sans-serif',
+  system: '-apple-system, system-ui, "Segoe UI", Roboto, sans-serif',
+  serif: '"IBM Plex Serif", "IBM Plex Sans", Georgia, serif',
+};

--- a/desktop/src/ui/settings.tsx
+++ b/desktop/src/ui/settings.tsx
@@ -1,9 +1,9 @@
 import { type ReactNode, useState } from "react";
 import type { Balance, Settings as SettingsType, UsageStats } from "../App";
-import { t } from "../i18n";
+import { setLang, t, useLang } from "../i18n";
 import { I } from "../icons";
 import type { McpSpecInfo, SettingsPatch, SkillInfo } from "../protocol";
-import { FONT_SCALE, type FontScale, THEME, type Theme } from "../theme";
+import { FONT_FAMILY, FONT_SCALE, type FontFamily, type FontScale, THEME, type Theme } from "../theme";
 
 export type PageId =
   | "general"
@@ -35,6 +35,8 @@ export function SettingsModal({
   onSetTheme,
   fontScale,
   onSetFontScale,
+  fontFamily,
+  onSetFontFamily,
   initialPage,
   mcpSpecs,
   mcpBridged,
@@ -54,6 +56,8 @@ export function SettingsModal({
   onSetTheme: (theme: Theme) => void;
   fontScale: FontScale;
   onSetFontScale: (scale: FontScale) => void;
+  fontFamily: FontFamily;
+  onSetFontFamily: (family: FontFamily) => void;
   initialPage?: PageId;
   mcpSpecs: McpSpecInfo[];
   mcpBridged: boolean;
@@ -111,6 +115,8 @@ export function SettingsModal({
                 onSetTheme={onSetTheme}
                 fontScale={fontScale}
                 onSetFontScale={onSetFontScale}
+                fontFamily={fontFamily}
+                onSetFontFamily={onSetFontFamily}
                 onSave={onSave}
                 onPickWorkspace={onPickWorkspace}
               />
@@ -152,6 +158,8 @@ function PageGeneral({
   onSetTheme,
   fontScale,
   onSetFontScale,
+  fontFamily,
+  onSetFontFamily,
   onSave,
   onPickWorkspace,
 }: {
@@ -160,10 +168,13 @@ function PageGeneral({
   onSetTheme: (theme: Theme) => void;
   fontScale: FontScale;
   onSetFontScale: (scale: FontScale) => void;
+  fontFamily: FontFamily;
+  onSetFontFamily: (family: FontFamily) => void;
   onSave: (patch: SettingsPatch) => void;
   onPickWorkspace: () => void;
 }) {
   const [editorDraft, setEditorDraft] = useState(settings.editor ?? "");
+  const lang = useLang();
   return (
     <>
       <section className="section">
@@ -216,6 +227,53 @@ function PageGeneral({
               onClick={() => onSetFontScale(FONT_SCALE.LARGE)}
             >
               {t("settings.fontScaleLarge")}
+            </button>
+          </div>
+        </div>
+        <div className="setting-row">
+          <div className="l">
+            <div className="n">{t("settings.fontFamily")}</div>
+            <div className="h">{t("settings.fontFamilyHint")}</div>
+          </div>
+          <div className="seg-ctrl">
+            <button
+              type="button"
+              data-on={fontFamily === FONT_FAMILY.SANS}
+              onClick={() => onSetFontFamily(FONT_FAMILY.SANS)}
+            >
+              {t("settings.fontFamilySans")}
+            </button>
+            <button
+              type="button"
+              data-on={fontFamily === FONT_FAMILY.SYSTEM}
+              onClick={() => onSetFontFamily(FONT_FAMILY.SYSTEM)}
+            >
+              {t("settings.fontFamilySystem")}
+            </button>
+            <button
+              type="button"
+              data-on={fontFamily === FONT_FAMILY.SERIF}
+              onClick={() => onSetFontFamily(FONT_FAMILY.SERIF)}
+            >
+              {t("settings.fontFamilySerif")}
+            </button>
+          </div>
+        </div>
+        <div className="setting-row">
+          <div className="l">
+            <div className="n">{t("settings.language")}</div>
+            <div className="h">{t("settings.languageHint")}</div>
+          </div>
+          <div className="seg-ctrl">
+            <button
+              type="button"
+              data-on={lang === "zh-CN"}
+              onClick={() => setLang("zh-CN")}
+            >
+              中文
+            </button>
+            <button type="button" data-on={lang === "en"} onClick={() => setLang("en")}>
+              English
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Two follow-ups to #877 plus a long-standing typecheck cleanup that became obvious while wiring up the new keys.

### Font family
Sans / system / serif segmented control under appearance. Driven by a new `--font-sans` CSS variable on the root element; styles.css and the inline `IBM Plex Sans` reference in App.tsx now read through `var(--font-sans, ...)`. Mono is left hardcoded so code blocks and transcripts stay monospace either way.

### Language
Promote the existing `/lang` palette command into a 中文 / English segmented control in the same section. Reads `useLang()` and writes through `setLang()`; the slash command keeps working.

### i18n cleanup
Add the long-missing `contextPanel`, `extraCards`, and `thread` namespaces (en + zh-CN). These keys were referenced in code but absent from the dictionaries, surfacing as 8 `TKey` errors on every `tsc --noEmit` run. Now zero.

## Files

- `desktop/src/theme.ts` — `FONT_FAMILY` constants + stack map
- `desktop/src/App.tsx` — `fontFamily` state, CSS-var effect, threaded through TabRuntime
- `desktop/src/styles.css` — 6 `font-family: "IBM Plex Sans"` rules → `var(--font-sans, ...)`
- `desktop/src/ui/settings.tsx` — font-family + language segmented controls
- `desktop/src/i18n/{en,zh-CN}.ts` — new key labels + the three missing namespaces

## Test plan

- [x] `tsc --noEmit` clean (was: 8 pre-existing TKey errors → now 0).
- [x] Root `tsc --noEmit` clean.
- [ ] Manual: change font family between sans / system / serif — body type updates immediately, code blocks stay mono. Toggle language — UI strings flip, persists on reload.