### PR TITLE
fix(dashboard): plans API timed out on users with many sessions

### DIFF
--- a/src/code/plan-store.ts
+++ b/src/code/plan-store.ts
@@ -193,6 +193,73 @@ export function listPlanArchives(sessionName: string): PlanArchiveSummary[] {
   return summaries;
 }
 
+export interface PlanArchiveWithSession extends PlanArchiveSummary {
+  sessionName: string;
+}
+
+/** Cross-session enumeration in a single dir scan — used by the dashboard plans panel where the per-session loop was O(N×M) and timed out for users with hundreds of sessions. */
+export function listAllPlanArchives(): PlanArchiveWithSession[] {
+  const dir = sessionsDir();
+  if (!existsSync(dir)) return [];
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return [];
+  }
+  const out: PlanArchiveWithSession[] = [];
+  const suffix = ".done.json";
+  const planMarker = ".plan.";
+  for (const name of entries) {
+    if (!name.endsWith(suffix)) continue;
+    const planIdx = name.indexOf(planMarker);
+    if (planIdx < 0) continue;
+    const sessionName = name.slice(0, planIdx);
+    if (!sessionName) continue;
+    const full = join(dir, name);
+    try {
+      const raw = readFileSync(full, "utf8");
+      const parsed = JSON.parse(raw) as Partial<PlanStateOnDisk>;
+      if (parsed.version !== 1) continue;
+      if (!Array.isArray(parsed.steps) || parsed.steps.length === 0) continue;
+      const steps = parsed.steps.filter(
+        (s): s is PlanStep =>
+          !!s &&
+          typeof s === "object" &&
+          typeof (s as PlanStep).id === "string" &&
+          typeof (s as PlanStep).title === "string" &&
+          typeof (s as PlanStep).action === "string",
+      );
+      if (steps.length === 0) continue;
+      const completedStepIds = Array.isArray(parsed.completedStepIds)
+        ? parsed.completedStepIds.filter((id): id is string => typeof id === "string" && !!id)
+        : [];
+      let completedAt = typeof parsed.updatedAt === "string" ? parsed.updatedAt : "";
+      if (!completedAt || Number.isNaN(Date.parse(completedAt))) {
+        try {
+          completedAt = statSync(full).mtime.toISOString();
+        } catch {
+          completedAt = new Date(0).toISOString();
+        }
+      }
+      const entry: PlanArchiveWithSession = {
+        sessionName,
+        path: full,
+        completedAt,
+        steps,
+        completedStepIds,
+      };
+      if (typeof parsed.body === "string" && parsed.body) entry.body = parsed.body;
+      if (typeof parsed.summary === "string" && parsed.summary) entry.summary = parsed.summary;
+      out.push(entry);
+    } catch {
+      // Skip the corrupt archive entirely.
+    }
+  }
+  out.sort((a, b) => b.completedAt.localeCompare(a.completedAt));
+  return out;
+}
+
 /** Falls back to raw ISO string past a week — "47 days ago" misleads more than it helps. */
 export function relativeTime(updatedAt: string, now: number = Date.now()): string {
   const t = Date.parse(updatedAt);

--- a/src/server/api/plans.ts
+++ b/src/server/api/plans.ts
@@ -1,5 +1,4 @@
-import { listPlanArchives } from "../../code/plan-store.js";
-import { listSessions } from "../../memory/session.js";
+import { listAllPlanArchives } from "../../code/plan-store.js";
 import type { PlanStep } from "../../tools/plan.js";
 import type { DashboardContext } from "../context.js";
 import type { ApiResult } from "../router.js";
@@ -28,27 +27,21 @@ export async function handlePlans(
   if (method !== "GET") {
     return { status: 405, body: { error: "GET only" } };
   }
-  const out: PlanRow[] = [];
-  for (const session of listSessions()) {
-    const archives = listPlanArchives(session.name);
-    for (const a of archives) {
-      const total = a.steps.length;
-      const done = a.completedStepIds.length;
-      const row: PlanRow = {
-        session: session.name,
-        path: a.path,
-        completedAt: a.completedAt,
-        totalSteps: total,
-        completedSteps: done,
-        completionRatio: total > 0 ? done / total : 0,
-        steps: a.steps,
-        completedStepIds: a.completedStepIds,
-      };
-      if (a.summary) row.summary = a.summary;
-      out.push(row);
-    }
-  }
-  // Newest archive first across the whole pool.
-  out.sort((a, b) => b.completedAt.localeCompare(a.completedAt));
+  const out: PlanRow[] = listAllPlanArchives().map((a) => {
+    const total = a.steps.length;
+    const done = a.completedStepIds.length;
+    const row: PlanRow = {
+      session: a.sessionName,
+      path: a.path,
+      completedAt: a.completedAt,
+      totalSteps: total,
+      completedSteps: done,
+      completionRatio: total > 0 ? done / total : 0,
+      steps: a.steps,
+      completedStepIds: a.completedStepIds,
+    };
+    if (a.summary) row.summary = a.summary;
+    return row;
+  });
   return { status: 200, body: { plans: out } };
 }


### PR DESCRIPTION
## What

`/api/plans` previously iterated `listSessions()` (which calls `countLines()` on every `.jsonl` file in `~/.reasonix/sessions/`) and then `listPlanArchives(name)` per session (which re-scanned the same directory each iteration). On a developer machine with hundreds of accumulated sessions the handler ran past the 5s test timeout, and `tests/server-dashboard.test.ts > GET /api/plans returns empty array when no archives exist` got flagged as flaky in pre-push verify runs.

Replace the O(N × M) per-session walk with a single dir scan helper, `listAllPlanArchives()` in `src/code/plan-store.ts`, that derives the session name from the archive filename pattern `<session>.plan.<id>.done.json`. The dashboard handler now does O(archive-files) work instead of O(sessions × archive-files).

## Why

The plans endpoint never actually needed session-level metadata — it only used `session.name`, which it then re-resolved via `listPlanArchives(name)` against the same directory. Both calls' costs were paid for nothing.

## Validation

- `npx vitest run tests/server-dashboard.test.ts tests/plan-store.test.ts` → 72 + 28 = 100 tests green; the previously-timing-out plans test now completes in ~3ms.
- Three consecutive full-suite `npx vitest run` → 2880/2880 green.

## Checklist

- [x] `npx tsc --noEmit` clean
- [x] `npx biome check` clean on changed files
- [x] No `Co-Authored-By: Claude` trailer
- [x] No `CHANGELOG.md` edits
