### PR TITLE
fix(desktop): surface user skills in the / autocomplete popup

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -1238,6 +1238,11 @@ function TabRuntime({
       desc: t("app.cmd.exportMd"),
       run: () => exportConversation(),
     },
+    ...state.skills.map((s) => ({
+      cmd: `/${s.name}`,
+      desc: s.description || `skill · ${s.scope}`,
+      run: () => sendRpc({ cmd: "skill_run", name: s.name }),
+    })),
   ];
 
   const elapsed = useElapsed(state.busy);

--- a/desktop/src/protocol.ts
+++ b/desktop/src/protocol.ts
@@ -406,4 +406,5 @@ export type OutgoingCommand = { tabId?: string } & (
   | { cmd: "mcp_specs_add"; spec: string }
   | { cmd: "mcp_specs_remove"; spec: string }
   | { cmd: "skills_get" }
+  | { cmd: "skill_run"; name: string; args?: string }
 );

--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -107,6 +107,7 @@ type InMessage = { tabId?: string } & (
   | { cmd: "mcp_specs_add"; spec: string }
   | { cmd: "mcp_specs_remove"; spec: string }
   | { cmd: "skills_get" }
+  | { cmd: "skill_run"; name: string; args?: string }
 );
 
 interface NeedsSetupEvent {
@@ -1295,6 +1296,31 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
     }
     if (msg.cmd === "skills_get") {
       emitSkills(tab);
+      return;
+    }
+    if (msg.cmd === "skill_run") {
+      if (!tab.runtime) {
+        emit(
+          { type: "$error", message: "Not configured yet — paste your DeepSeek API key first." },
+          tab.id,
+        );
+        return;
+      }
+      try {
+        const store = new SkillStore({ projectRoot: tab.rootDir });
+        const found = store.read(msg.name);
+        if (!found) {
+          emit({ type: "$error", message: `skill not found: ${msg.name}` }, tab.id);
+          return;
+        }
+        const extra = msg.args?.trim() ?? "";
+        const header = `# Skill: ${found.name}${found.description ? `\n> ${found.description}` : ""}`;
+        const argsLine = extra ? `\n\nArguments: ${extra}` : "";
+        const payload = `${header}\n\n${found.body}${argsLine}`;
+        void runTurn(tab, payload);
+      } catch (err) {
+        emit({ type: "$error", message: `skill_run: ${(err as Error).message}` }, tab.id);
+      }
       return;
     }
     if (msg.cmd === "session_list") {


### PR DESCRIPTION
Closes #854 (autocomplete half).

## What

The slash command popup hard-coded 9 built-in actions and never folded in the user's `~/.reasonix/skills` and `.reasonix/skills` entries — typing `/myskill` produced "no matches" even though the skill loaded fine and showed up in the Skills tab. Skills also had no execution path on the desktop side at all: `user_input` ships text straight to the model loop, so a typed `/skill_name` reached the model as plain text rather than triggering the skill.

## Changes

- **`desktop/src/protocol.ts` + `src/cli/commands/desktop.ts`** — add a `skill_run` RPC. Backend handler resolves the skill via `SkillStore`, builds the same `# Skill: <name>\n> <desc>\n\n<body>` payload the CLI uses, and feeds it through `runTurn` so the skill enters the conversation as user-authored content.
- **`desktop/src/App.tsx`** — merge `state.skills` into `slashCommands` so each user-authored skill shows up in the popup with its description and an invocation handler that fires `skill_run`.

## Not in scope here

Issue #854 also asked for a "skill is running" indicator. That's a separate UX surface (status row / live row) and lands separately.

## Checklist

- [x] `npx tsc --noEmit` clean on the top-level repo
- [x] `npx biome check` clean on the changed `src/` file (desktop/ has pre-existing biome diffs unrelated to this PR; not enforced by CI)
- [x] No `Co-Authored-By: Claude` trailer
- [x] No `CHANGELOG.md` edits
