### PR TITLE
fix(desktop): normalize workspace path for session sidebar filter

### DIFF
--- a/src/memory/session.ts
+++ b/src/memory/session.ts
@@ -14,7 +14,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, posix as posixPath, win32 as win32Path } from "node:path";
 import type { ChatMessage } from "../types.js";
 
 /** Best-effort git branch sniff; returns undefined if not a git repo or git missing. */
@@ -198,9 +198,27 @@ export function listSessions(): SessionInfo[] {
   }
 }
 
-/** Strict match — legacy sessions without meta.workspace are hidden; resume by name still works. */
+/** Canonical form for workspace path comparisons — Windows drive-case + separator drift between session writes (yesterday) and reads (today) used to hide sessions from the sidebar. Issue #878. */
+export function normalizeWorkspace(
+  p: string | undefined,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  if (typeof p !== "string" || p.length === 0) return "";
+  if (platform === "win32") {
+    const resolved = win32Path.resolve(p);
+    return resolved
+      .replace(/\\/g, "/")
+      .replace(/^([A-Z]):/i, (_, d: string) => `${d.toLowerCase()}:`);
+  }
+  return posixPath.resolve(p);
+}
+
+/** Sessions without `meta.workspace` are still hidden — resume by name still works. */
 export function listSessionsForWorkspace(workspace: string): SessionInfo[] {
-  return listSessions().filter((s) => s.meta.workspace === workspace);
+  const want = normalizeWorkspace(workspace);
+  return listSessions().filter(
+    (s) => typeof s.meta.workspace === "string" && normalizeWorkspace(s.meta.workspace) === want,
+  );
 }
 
 function metaPath(name: string): string {

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -14,6 +14,7 @@ import {
   listSessions,
   listSessionsForWorkspace,
   loadSessionMessages,
+  normalizeWorkspace,
   patchSessionMeta,
   pruneStaleSessions,
   renameSession,
@@ -109,7 +110,7 @@ describe("session persistence", () => {
     expect(names).toEqual(["real"]);
   });
 
-  it("listSessionsForWorkspace strict-matches meta.workspace", () => {
+  it("listSessionsForWorkspace matches meta.workspace and hides untagged sessions", () => {
     appendSessionMessage("here", { role: "user", content: "x" });
     appendSessionMessage("there", { role: "user", content: "x" });
     appendSessionMessage("untagged", { role: "user", content: "x" });
@@ -117,6 +118,13 @@ describe("session persistence", () => {
     patchSessionMeta("there", { workspace: "/proj/b" });
     const names = listSessionsForWorkspace("/proj/a").map((s) => s.name);
     expect(names).toEqual(["here"]);
+  });
+
+  it("listSessionsForWorkspace tolerates trailing-slash drift", () => {
+    appendSessionMessage("a", { role: "user", content: "x" });
+    patchSessionMeta("a", { workspace: "/proj/a/" });
+    const names = listSessionsForWorkspace("/proj/a").map((s) => s.name);
+    expect(names).toEqual(["a"]);
   });
 
   it("renameSession also moves the .events.jsonl sidecar", () => {
@@ -524,5 +532,33 @@ describe("session persistence", () => {
       expect(summary.cacheHitRatio).toBeCloseTo(366976 / (366976 + 109), 4);
       expect(summary.lastPromptTokens).toBe(367085);
     });
+  });
+});
+
+describe("normalizeWorkspace", () => {
+  it("collapses trailing slashes and `.` segments on posix", () => {
+    expect(normalizeWorkspace("/proj/a/", "linux")).toBe("/proj/a");
+    expect(normalizeWorkspace("/proj/./a", "linux")).toBe("/proj/a");
+  });
+
+  it("lowercases drive letter and unifies separators on win32", () => {
+    expect(normalizeWorkspace("C:\\Users\\Foo\\proj", "win32")).toBe("c:/Users/Foo/proj");
+    expect(normalizeWorkspace("c:/users/foo/proj", "win32")).toBe("c:/users/foo/proj");
+  });
+
+  it("yields the same canonical form for win32 drive-case + separator variants", () => {
+    const variants = [
+      "C:\\Users\\foo\\proj",
+      "c:\\Users\\foo\\proj",
+      "C:/Users/foo/proj",
+      "c:/Users/foo/proj/",
+    ];
+    const canonicals = variants.map((v) => normalizeWorkspace(v, "win32"));
+    for (const c of canonicals) expect(c).toBe(canonicals[0]);
+  });
+
+  it("returns empty string for undefined or empty input", () => {
+    expect(normalizeWorkspace(undefined)).toBe("");
+    expect(normalizeWorkspace("")).toBe("");
   });
 });


### PR DESCRIPTION
## Symptom

#878 — a Windows 10 user reported that yesterday's sessions disappeared from the desktop sidebar after relaunching today. The session .jsonl files were still on disk; only the sidebar's filter was hiding them.

## Cause

`listSessionsForWorkspace` (`src/memory/session.ts:202`) compared paths via strict `===` against `meta.workspace`. On Windows that's fragile: drive-letter case (`C:\` vs `c:\`), separator style (`\` vs `/`), and trailing slashes can drift between the session write (yesterday's process) and the read (today's process), depending on whether the path came from `process.cwd()`, `loadWorkspaceDir()`, or the user clicking "switch workspace". Any of those produce a non-equal string, so the filter excludes the session and the sidebar looks wiped.

## Fix

Add `normalizeWorkspace(p, platform?)` that:
- Resolves the path (handles `.`, `..`, trailing slashes, relative inputs).
- On `win32`, lowercases the drive letter and rewrites `\` → `/` so all four common variants of the same path produce the same canonical string.

Apply it on **both** sides of the filter so existing sessions whose meta was written before this fix recover automatically — no migration script, no data touch.

Sessions with no `meta.workspace` stay hidden (same as before; resume by name still works).

## Test plan

- [x] `tests/session.test.ts` — kept the original strict-match test, added a trailing-slash-drift test, and added a `normalizeWorkspace` describe block covering: posix collapse, win32 drive-case + separator normalization, equivalence of four common Windows variants, and undefined/empty input.
- [x] 55 / 55 session tests pass on this branch.
- [x] `tsc --noEmit` clean.

Closes #878