### PR TITLE
feat(desktop): visible skill running indicator while a user skill executes

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -69,8 +69,13 @@ export type AssistantSegment =
       durationMs?: number;
     };
 
+export type SkillOrigin = {
+  name: string;
+  runAs: "inline" | "subagent";
+};
+
 export type ChatMessage =
-  | { kind: "user"; text: string; clientId: string; turn: number }
+  | { kind: "user"; text: string; clientId: string; turn: number; skill?: SkillOrigin }
   | {
       kind: "assistant";
       turn: number;
@@ -214,6 +219,8 @@ type State = {
   /** Files the agent has read or modified this session — paths as the tool args provided them. */
   sessionFiles: SessionFile[];
   memory: MemoryEntryInfo[];
+  /** Live "skill running" indicator — set when a `skill_run` RPC dispatches, cleared on `$turn_complete`. */
+  activeSkill: SkillOrigin | null;
 };
 
 export type SessionFile = {
@@ -230,6 +237,7 @@ type DeltaBatchItem = {
 
 type Action =
   | { t: "send_user"; text: string; clientId: string }
+  | { t: "start_skill"; skill: SkillOrigin; args?: string; clientId: string }
   | { t: "incoming"; event: IncomingEvent }
   | { t: "batch_delta"; items: DeltaBatchItem[] }
   | { t: "rpc_exit"; code: number | null }
@@ -260,11 +268,34 @@ function reduce(state: State, action: Action): State {
         ],
       };
     }
+    case "start_skill": {
+      const lastTurn = state.messages.reduce((max, m) => {
+        if (m.kind === "user" || m.kind === "assistant") return Math.max(max, m.turn);
+        return max;
+      }, 0);
+      const argsLine = action.args ? ` ${action.args}` : "";
+      return {
+        ...state,
+        busy: true,
+        activeSkill: action.skill,
+        messages: [
+          ...state.messages,
+          {
+            kind: "user",
+            text: `/${action.skill.name}${argsLine}`,
+            clientId: action.clientId,
+            turn: lastTurn + 1,
+            skill: action.skill,
+          },
+        ],
+      };
+    }
     case "rpc_exit":
       return {
         ...state,
         ready: false,
         busy: false,
+        activeSkill: null,
         messages: [
           ...state.messages,
           { kind: "error", message: `reasonix exited (code ${action.code ?? "?"})` },
@@ -315,6 +346,7 @@ function reduce(state: State, action: Action): State {
         activePlan: null,
         usage: zeroUsage(),
         sessionFiles: [],
+        activeSkill: null,
       };
     case "resolve_confirm":
       return {
@@ -465,7 +497,7 @@ function applyIncoming(state: State, ev: IncomingEvent): State {
     case "$needs_setup":
       return { ...state, needsSetup: true, ready: false };
     case "$turn_complete":
-      return { ...state, busy: false };
+      return { ...state, busy: false, activeSkill: null };
     case "$confirm_required":
       return {
         ...state,
@@ -664,6 +696,7 @@ function applyIncoming(state: State, ev: IncomingEvent): State {
           cacheMissTokens: ev.carryover.cacheMissTokens,
         },
         sessionFiles,
+        activeSkill: null,
       };
     }
     case "$error":
@@ -671,6 +704,7 @@ function applyIncoming(state: State, ev: IncomingEvent): State {
       return {
         ...state,
         busy: false,
+        activeSkill: null,
         messages: [...state.messages, { kind: "error", message: ev.message }],
       };
     case "model.turn.started":
@@ -887,6 +921,7 @@ function TabRuntime({
     skills: [],
     sessionFiles: [],
     memory: [],
+    activeSkill: null,
   });
   useLang();
   const [draft, setDraft] = useState("");
@@ -1241,7 +1276,14 @@ function TabRuntime({
     ...state.skills.map((s) => ({
       cmd: `/${s.name}`,
       desc: s.description || `skill · ${s.scope}`,
-      run: () => sendRpc({ cmd: "skill_run", name: s.name }),
+      run: () => {
+        dispatch({
+          t: "start_skill",
+          skill: { name: s.name, runAs: s.runAs },
+          clientId: `skill-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        });
+        sendRpc({ cmd: "skill_run", name: s.name });
+      },
     })),
   ];
 
@@ -1438,7 +1480,7 @@ function TabRuntime({
                       return (
                         <div key={`u-${i}`}>
                           {needsDivider ? <TurnDivider label={dividerLabel} /> : null}
-                          <UserMsg text={m.text} />
+                          <UserMsg text={m.text} skill={m.skill} />
                         </div>
                       );
                     }
@@ -1580,7 +1622,12 @@ function TabRuntime({
               />
 
               {state.busy ? (
-                <InterruptBar visible={true} elapsedMs={elapsed} label="Reasoning" onStop={abort} />
+                <InterruptBar
+                  visible={true}
+                  elapsedMs={elapsed}
+                  label={state.activeSkill ? `Skill · ${state.activeSkill.name}` : "Reasoning"}
+                  onStop={abort}
+                />
               ) : null}
             </>
           )}

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -773,6 +773,24 @@ button {
   padding: 1px 6px;
   border-radius: 4px;
 }
+.msg .who .skill-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10.5px;
+  font-family: "IBM Plex Mono", monospace;
+  color: var(--warning);
+  background: oklch(from var(--warning) l c h / 0.14);
+  padding: 1px 6px;
+  border-radius: 4px;
+}
+.msg .who .skill-chip .sub {
+  font-size: 9px;
+  color: var(--muted);
+  margin-left: 2px;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
 
 .msg-text {
   font-size: 13.5px;

--- a/desktop/src/ui/thread.tsx
+++ b/desktop/src/ui/thread.tsx
@@ -1,7 +1,7 @@
 import { memo, type ReactNode } from "react";
 import { I } from "../icons";
 import { t, useLang } from "../i18n";
-import type { AssistantSegment, ActivePlan, PendingPlan, PendingCheckpoint, PendingRevision, PendingConfirm, PendingChoice } from "../App";
+import type { AssistantSegment, ActivePlan, PendingPlan, PendingCheckpoint, PendingRevision, PendingConfirm, PendingChoice, SkillOrigin } from "../App";
 import { AssistantText, PlanCardView, ReasoningCard, ShellCard, ToolCard, type PlanItem } from "./cards";
 import { ApprovalCard, TaskCard, type TaskStepView } from "./extra-cards";
 
@@ -14,13 +14,27 @@ export function TurnDivider({ label }: { label: string }) {
   );
 }
 
-export const UserMsg = memo(function UserMsg({ text, time }: { text: string; time?: string }) {
+export const UserMsg = memo(function UserMsg({
+  text,
+  time,
+  skill,
+}: {
+  text: string;
+  time?: string;
+  skill?: SkillOrigin;
+}) {
   return (
     <div className="msg user">
       <div className="avatar">YOU</div>
       <div className="body">
         <div className="who">
           <span className="name">你</span>
+          {skill ? (
+            <span className="skill-chip" title={`skill · ${skill.runAs}`}>
+              <I.zap size={10} /> /{skill.name}
+              {skill.runAs === "subagent" ? <span className="sub">subagent</span> : null}
+            </span>
+          ) : null}
           {time ? <span className="time">{time}</span> : null}
         </div>
         <div className="msg-text">{text}</div>


### PR DESCRIPTION
## Summary

Closes #882.

When the user invoked `/skillname` from the palette, the desktop was silent until the assistant response streamed — no surface differentiated "skill in flight" from a regular long reasoning turn, and the synthetic user message wasn't even shown.

Two surfaces, both client-side:

1. **Live status row.** `InterruptBar` now reads `state.activeSkill` and renders `Skill · <name>` instead of `Reasoning` for the duration of the turn, keeping the same elapsed timer + esc-to-stop affordance.
2. **User-message card chip.** The synthetic user card the client now injects on `start_skill` carries a `skill: { name, runAs }` field. `UserMsg` renders a warning-toned `/name` chip in the header (with a subagent micro-badge when `runAs === "subagent"`).

## State

- `activeSkill: SkillOrigin | null` on `State`; set by the new `start_skill` reducer action, cleared on `$turn_complete`, `clear`, `$session_loaded`, `error`, and `rpc_exit`.
- Palette skill entries now dispatch `start_skill` (which pushes a tagged user card) before sending the `skill_run` RPC.

## Why no backend changes

The issue suggested either a `$skill_started` / `$skill_ended` pair or piggybacking on `$turn_complete` with frontend tagging. The client already knows the skill's `name` and `runAs` (from `state.skills`) and already controls the RPC dispatch, so tagging on the client and clearing on the existing `$turn_complete` event is the smaller change.

## Out of scope

- No progress bar for `runAs: "subagent"` — subagent progress streaming isn't fleshed out yet.
- No detection of implicit skill use by the model.

## Test plan

- [x] Desktop `tsc --noEmit` clean.
- [ ] Manual: invoke `/skillname` from the palette → user card with `/skillname` chip appears, status bar shows `Skill · skillname · Ns`, both clear when the assistant finishes the turn.
- [ ] Manual: invoke a subagent skill → chip carries a `subagent` badge.
- [ ] Manual: skill fires, click `esc` mid-turn → activeSkill clears via `$turn_complete`.