### PR TITLE
fix(release): make sync-desktop-version idempotent

### DIFF
--- a/scripts/sync-desktop-version.mjs
+++ b/scripts/sync-desktop-version.mjs
@@ -27,15 +27,12 @@ tauriConf.version = version;
 writeFileSync(tauriConfPath, `${JSON.stringify(tauriConf, null, 2)}\n`);
 
 const cargoToml = readFileSync(cargoTomlPath, "utf8");
-const nextCargo = cargoToml.replace(
-  /^version = ".*"$/m,
-  `version = "${version}"`,
-);
-if (nextCargo === cargoToml) {
+const versionLine = /^version = ".*"$/m;
+if (!versionLine.test(cargoToml)) {
   console.error(`Cargo.toml: no version line matched`);
   process.exit(1);
 }
-writeFileSync(cargoTomlPath, nextCargo);
+writeFileSync(cargoTomlPath, cargoToml.replace(versionLine, `version = "${version}"`));
 
 const desktopPkg = JSON.parse(readFileSync(desktopPkgPath, "utf8"));
 desktopPkg.version = version;


### PR DESCRIPTION
## Summary

CI's \`Sync desktop version from tag\` step died on v0.43.0 with \`Cargo.toml: no version line matched\` because the release commit had already bumped \`Cargo.toml\` to 0.43.0. The old guard fired on \`nextCargo === cargoToml\` — true both when the regex didn't match AND when the value was already correct.

Switch to a regex \`.test()\` so re-syncing to the same value is legitimate; only error if the version line is genuinely missing.

## Test plan

- [x] Script re-run on a tree where \`Cargo.toml\` is already at the target version succeeds locally
- [ ] After merge: re-tag v0.43.0 on the merged commit, confirm release workflow gets past the sync step