### PR TITLE
docs(site): bump to v0.43.0 + extract REASONIX_VERSION constant

### DIFF
--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -121,7 +121,7 @@
         <a class="brand" href="index.html">
           <span class="brand-mark"></span>
           <span class="brand-name">
-            <b>Reasonix</b><span>DS · v0.42.0-3</span>
+            <b>Reasonix</b><span>DS · v0.43.0</span>
           </span>
         </a>
         <div class="nav-links" role="navigation">
@@ -561,7 +561,7 @@
         <span>© 2026 esengine · MIT License</span>
         <span class="spacer"></span>
         <span>Independent open-source project · not affiliated with DeepSeek</span>
-        <span style="margin-left:18px">v0.42.0-3 · prerelease</span>
+        <span style="margin-left:18px">v0.43.0 · stable</span>
       </div>
     </footer>
 

--- a/docs/cli-reference.html
+++ b/docs/cli-reference.html
@@ -121,7 +121,7 @@
         <a class="brand" href="index.html">
           <span class="brand-mark"></span>
           <span class="brand-name">
-            <b>Reasonix</b><span>DS · v0.42.0-3</span>
+            <b>Reasonix</b><span>DS · v0.43.0</span>
           </span>
         </a>
         <div class="nav-links" role="navigation">
@@ -843,7 +843,7 @@
         <span>© 2026 esengine · MIT License</span>
         <span class="spacer"></span>
         <span>Independent open-source project · not affiliated with DeepSeek</span>
-        <span style="margin-left:18px">v0.42.0-3 · prerelease</span>
+        <span style="margin-left:18px">v0.43.0 · stable</span>
       </div>
     </footer>
 

--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -121,7 +121,7 @@
         <a class="brand" href="index.html">
           <span class="brand-mark"></span>
           <span class="brand-name">
-            <b>Reasonix</b><span>DS · v0.42.0-3</span>
+            <b>Reasonix</b><span>DS · v0.43.0</span>
           </span>
         </a>
         <div class="nav-links" role="navigation">
@@ -712,7 +712,7 @@ created: 2026-05-09
         <span>© 2026 esengine · MIT License</span>
         <span class="spacer"></span>
         <span>Independent open-source project · not affiliated with DeepSeek</span>
-        <span style="margin-left:18px">v0.42.0-3 · prerelease</span>
+        <span style="margin-left:18px">v0.43.0 · stable</span>
       </div>
     </footer>
 

--- a/docs/src/download-page.jsx
+++ b/docs/src/download-page.jsx
@@ -33,7 +33,7 @@ const PLATFORM_NOTES = {
       en: 'AppImages need an executable bit; some distros also need libfuse2:',
     },
     steps: [
-      { cmd: 'chmod +x Reasonix_0.42.0-3_amd64.AppImage', note: { zh: '赋予可执行权限', en: 'Mark it executable' } },
+      { cmd: `chmod +x Reasonix_${window.REASONIX_VERSION}_amd64.AppImage`, note: { zh: '赋予可执行权限', en: 'Mark it executable' } },
       { cmd: 'sudo apt install libfuse2 # debian/ubuntu', note: { zh: 'AppImage 运行时依赖', en: 'AppImage runtime dependency' } },
     ],
   },
@@ -70,7 +70,7 @@ function DownloadHero() {
       <div className="hero-head">
         <span>§00 · Download</span>
         <span className="rule"></span>
-        <span className="v">Reasonix Desktop · 0.42.0-3</span>
+        <span className="v">Reasonix Desktop · {window.REASONIX_VERSION}</span>
       </div>
       <div className="dl-hero-grid">
         <div>

--- a/docs/src/footer.jsx
+++ b/docs/src/footer.jsx
@@ -58,7 +58,7 @@ function Footer() {
           zh: 'Independent open-source project · 与 DeepSeek 官方无关',
           en: 'Independent open-source project · not affiliated with DeepSeek',
         }, lang)}</span>
-        <span style={{marginLeft:18}}>v0.42.0-3 · prerelease</span>
+        <span style={{marginLeft:18}}>v{window.REASONIX_VERSION} · stable</span>
       </div>
     </footer>
   );

--- a/docs/src/hero.jsx
+++ b/docs/src/hero.jsx
@@ -4,7 +4,7 @@
 // tool calls sandboxed to launch dir.
 const TERM_SCRIPT = [
   { t: 'cmd', text: 'npx reasonix code' },
-  { t: 'out', text: '⏺ reasonix 0.42.0-3 · model: deepseek-v4-flash · workspace: ~/app', cls: 'term-info', delay: 280 },
+  { t: 'out', text: `⏺ reasonix ${window.REASONIX_VERSION} · model: deepseek-v4-flash · workspace: ~/app`, cls: 'term-info', delay: 280 },
   { t: 'out', text: '⏺ cache: 94.2% hit · session: 18m23s · cost: $0.043', cls: 'term-dim', delay: 220 },
   { t: 'blank' },
   { t: 'cmd', text: 'fix the case-sensitivity bug in findByEmail' },
@@ -126,7 +126,7 @@ function Hero() {
       <div className="hero-head">
         <span>§00 · Reasonix</span>
         <span className="rule"></span>
-        <span className="v">v0.42.0-3 · open source</span>
+        <span className="v">v{window.REASONIX_VERSION} · open source</span>
       </div>
       <div className="hero-grid">
         <div>

--- a/docs/src/i18n.jsx
+++ b/docs/src/i18n.jsx
@@ -1,5 +1,7 @@
 // Lang context + t() helper. `t({zh, en})` returns the active-lang string.
 
+window.REASONIX_VERSION = "0.43.0";
+
 const LangCtx = React.createContext({ lang: "zh", setLang: () => {} });
 
 function detectInitialLang() {

--- a/docs/src/mirrors.jsx
+++ b/docs/src/mirrors.jsx
@@ -1,7 +1,7 @@
 // Smart mirror grid — probes R2 / GitHub Releases for fastest TTFB and offers
 // a per-platform installer link from whichever wins.
 
-const VERSION = "0.42.0-3";
+const VERSION = window.REASONIX_VERSION;
 const GH_REPO = "esengine/DeepSeek-Reasonix";
 const R2_BASE = "https://pub-147fb53b9c1e4bbf891a257968619ea7.r2.dev";
 
@@ -29,7 +29,7 @@ const OS_OPTIONS = [
     id: "mac",
     label: "macOS",
     file: `Reasonix_${VERSION}_universal.dmg`,
-    size: "53 MB",
+    size: "52 MB",
     note: "Universal — Apple Silicon + Intel",
   },
   {
@@ -43,7 +43,7 @@ const OS_OPTIONS = [
     id: "linux",
     label: "Linux",
     file: `Reasonix_${VERSION}_amd64.AppImage`,
-    size: "122 MB",
+    size: "128 MB",
     note: "AppImage · x86_64",
   },
 ];
@@ -208,4 +208,3 @@ function MirrorGrid({ os, setOs }) {
 
 window.MirrorGrid = MirrorGrid;
 window.detectOS = detectOS;
-window.REASONIX_VERSION = VERSION;

--- a/docs/src/nav.jsx
+++ b/docs/src/nav.jsx
@@ -26,7 +26,7 @@ function Nav({ active }) {
         <a className="brand" href="index.html">
           <span className="brand-mark"></span>
           <span className="brand-name">
-            <b>Reasonix</b><span>DS · v0.42.0-3</span>
+            <b>Reasonix</b><span>DS · v{window.REASONIX_VERSION}</span>
           </span>
         </a>
         <div className="nav-links" role="navigation">

--- a/docs/src/roadmap.jsx
+++ b/docs/src/roadmap.jsx
@@ -11,11 +11,11 @@ const ROADMAP = [
       { zh: 'Tool-Call Repair · 工具参数自愈', en: 'Tool-Call Repair · schema-aware self-heal' },
       { zh: 'MCP first-class (stdio / SSE / HTTP)', en: 'MCP first-class (stdio / SSE / HTTP)' },
       { zh: 'Skills · Markdown frontmatter 剧本', en: 'Skills · Markdown frontmatter scripts' },
-      { zh: '原生 Tauri 桌面端 (prerelease)', en: 'Native Tauri desktop (prerelease)' },
+      { zh: '原生 Tauri 桌面端', en: 'Native Tauri desktop' },
     ],
   },
   {
-    key: 'v0.42.x',
+    key: 'v0.44.x',
     title: { zh: '迭代中', en: 'In progress' },
     state: 'now',
     items: [


### PR DESCRIPTION
## Summary

The docs site had hardcoded \`0.42.0-3\` in 8 files (3 static HTML pages + 5 JSX modules) — every release silently shipped pointing at the previous prerelease. This PR bumps to v0.43.0 and centralises the version on the JSX side so future bumps are a one-line edit.

- \`docs/src/i18n.jsx\` (loaded first on every page) sets \`window.REASONIX_VERSION = "0.43.0"\`.
- \`nav.jsx\` / \`footer.jsx\` / \`hero.jsx\` / \`download-page.jsx\` / \`mirrors.jsx\` now read from the global instead of inlining the version.
- Static HTML pages (\`architecture.html\` / \`cli-reference.html\` / \`configuration.html\`) still hardcode \`v0.43.0\` — they don't load any JS, so the manual touch is unavoidable. Only 2 lines per file though.

Side effects bundled in:
- Footer / nav strip reads "stable" instead of "prerelease" (desktop is GA in 0.43.0).
- Mirror grid file sizes refreshed from the actual v0.43.0 assets (universal.dmg 53 → 52 MB, AppImage 122 → 128 MB; .exe unchanged).
- Roadmap drops "(prerelease)" from the shipped Tauri item; in-progress column key v0.42.x → v0.44.x.

## Test plan

- [x] grep confirms no remaining \`0.42.0-3\` in \`docs/\` outside the agent-dashboard mock (where \`¥0.42\` is a price, not a version).
- [ ] After merge: open https://esengine.github.io/DeepSeek-Reasonix/ and verify nav badge / hero terminal / footer all read v0.43.0; download page resolves correct asset URLs.