### PR TITLE
feat(skills): install_skill tool — AI-authored playbooks with live desktop pickup

### DIFF
--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -754,7 +754,10 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
 
   /** Builds the toolset / system prompt / runtime / MCP bridge for a freshly-created skeleton. Reads `tab.currentModel` at call time so preset changes that landed during the wait are honored. */
   async function initTabToolset(tab: Tab): Promise<void> {
-    const toolset = await buildCodeToolset({ rootDir: tab.rootDir });
+    const toolset = await buildCodeToolset({
+      rootDir: tab.rootDir,
+      onSkillInstalled: () => emitSkills(tab),
+    });
     tab.toolset = toolset;
     tab.system = codeSystemPrompt(tab.rootDir, {
       hasSemanticSearch: toolset.semantic.enabled,
@@ -910,7 +913,10 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
     tab.symbolBuilding = null;
     tab.recentMentions.length = 0;
     tab.currentSession = mintSessionFor(target);
-    tab.toolset = await buildCodeToolset({ rootDir: target });
+    tab.toolset = await buildCodeToolset({
+      rootDir: target,
+      onSkillInstalled: () => emitSkills(tab),
+    });
     tab.system = codeSystemPrompt(target, {
       hasSemanticSearch: tab.toolset.semantic.enabled,
       modelId: tab.currentModel,

--- a/src/cli/ui/slash/handlers/memory.ts
+++ b/src/cli/ui/slash/handlers/memory.ts
@@ -36,7 +36,7 @@ const memory: SlashHandler = (args, _loop, ctx) => {
   if (!ctx.memoryRoot) {
     return { info: t("handlers.memory.noRoot") };
   }
-  const store = new MemoryStore({ projectRoot: ctx.codeRoot });
+  const store = new MemoryStore({ projectRoot: ctx.codeRoot, homeDir: ctx.homeDir });
   const { type: typeFilter, rest: filteredArgs } = pickTypeFlag(args);
   const sub = (filteredArgs[0] ?? args[0] ?? "").toLowerCase();
 

--- a/src/cli/ui/slash/types.ts
+++ b/src/cli/ui/slash/types.ts
@@ -69,6 +69,8 @@ export interface SlashContext {
   mcpServers?: McpServerSummary[];
   /** Absent → tests context; `/memory` MUST reply "root unknown" rather than silently reading wrong dir. */
   memoryRoot?: string;
+  /** Override `~/.reasonix` lookup root — production leaves this absent (defaults to `os.homedir()`); tests inject a tmpdir so they don't read the dev's real global memory. */
+  homeDir?: string;
   planMode?: boolean;
   editMode?: EditMode;
   setEditMode?: (mode: EditMode) => void;

--- a/src/code/setup.ts
+++ b/src/code/setup.ts
@@ -16,13 +16,15 @@ import { registerMemoryTools } from "../tools/memory.js";
 import { registerPlanTool } from "../tools/plan.js";
 import { registerScaffoldTools } from "../tools/scaffold.js";
 import { registerShellTools } from "../tools/shell.js";
-import { registerSkillTools } from "../tools/skills.js";
+import { type SkillInstalledHook, registerSkillTools } from "../tools/skills.js";
 import { formatSubagentResult, spawnSubagent } from "../tools/subagent.js";
 import { registerTodoTool } from "../tools/todo.js";
 import { registerWebTools } from "../tools/web.js";
 
 export interface CodeToolsetOpts {
   rootDir: string;
+  /** Fired after `install_skill` writes a new skill — desktop wires this to push a fresh `$skills` event so the sidebar updates without a tab reload. */
+  onSkillInstalled?: SkillInstalledHook;
 }
 
 export interface CodeToolset {
@@ -72,6 +74,7 @@ export async function buildCodeToolset(opts: CodeToolsetOpts): Promise<CodeTools
   let subagentClient: DeepSeekClient | null = null;
   registerSkillTools(tools, {
     projectRoot: opts.rootDir,
+    onSkillInstalled: opts.onSkillInstalled,
     subagentRunner: async (skill, task, signal) => {
       if (!subagentClient) subagentClient = new DeepSeekClient({ baseUrl: loadBaseUrl() });
       const result = await spawnSubagent({

--- a/src/memory/user.ts
+++ b/src/memory/user.ts
@@ -410,9 +410,19 @@ export function applyUserMemory(
   return parts.join("\n");
 }
 
-export function applyMemoryStack(basePrompt: string, rootDir: string): string {
+export function applyMemoryStack(
+  basePrompt: string,
+  rootDir: string,
+  opts: { homeDir?: string } = {},
+): string {
   const withProject = applyProjectMemory(basePrompt, rootDir);
-  const withGlobal = applyGlobalReasonixMemory(withProject);
-  const withMemory = applyUserMemory(withGlobal, { projectRoot: rootDir });
-  return applySkillsIndex(withMemory, { projectRoot: rootDir });
+  const withGlobal = applyGlobalReasonixMemory(
+    withProject,
+    opts.homeDir ? join(opts.homeDir, ".reasonix") : undefined,
+  );
+  const withMemory = applyUserMemory(withGlobal, {
+    projectRoot: rootDir,
+    homeDir: opts.homeDir,
+  });
+  return applySkillsIndex(withMemory, { projectRoot: rootDir, homeDir: opts.homeDir });
 }

--- a/src/tools/skills.ts
+++ b/src/tools/skills.ts
@@ -6,6 +6,13 @@ import type { ToolRegistry } from "../tools.js";
 /** Returns serialized tool-result string — dispatch path is pure pass-through. */
 export type SubagentRunner = (skill: Skill, task: string, signal?: AbortSignal) => Promise<string>;
 
+/** Fired after a successful `install_skill` write — host wires this to push a fresh `$skills` event so the desktop sidebar updates without a tab reload. */
+export type SkillInstalledHook = (info: {
+  name: string;
+  path: string;
+  scope: "project" | "global";
+}) => void;
+
 export interface SkillToolsOptions {
   /** Override `$HOME` — tests set this to a tmpdir. */
   homeDir?: string;
@@ -14,6 +21,8 @@ export interface SkillToolsOptions {
   subagentRunner?: SubagentRunner;
   /** Hide built-in skills (test-only knob; production callers leave off). */
   disableBuiltins?: boolean;
+  /** Called synchronously after `install_skill` successfully writes a new skill file. */
+  onSkillInstalled?: SkillInstalledHook;
 }
 
 export function registerSkillTools(
@@ -26,6 +35,8 @@ export function registerSkillTools(
     disableBuiltins: opts.disableBuiltins,
   });
   const subagentRunner = opts.subagentRunner;
+  const onSkillInstalled = opts.onSkillInstalled;
+  const hasProjectScope = store.hasProjectScope();
 
   registry.register({
     name: "run_skill",
@@ -110,6 +121,150 @@ export function registerSkillTools(
       const inner = `${header}\n\n${skill.body}${argsBlock}`;
       // Sentinel-wrapped so ContextManager.fold preserves the body verbatim instead of paraphrasing it.
       return `<skill-pin name=${JSON.stringify(skill.name)}>\n${inner}\n</skill-pin>`;
+    },
+  });
+
+  const installScopeDesc = hasProjectScope
+    ? "'project' (default) writes to <repo>/.reasonix/skills/, scoped to this workspace only; 'global' writes to ~/.reasonix/skills/, available in every project."
+    : "'global' (only option here — no project workspace) writes to ~/.reasonix/skills/.";
+
+  registry.register({
+    name: "install_skill",
+    description:
+      "Author and save a new skill — a reusable playbook future turns can invoke via `run_skill`. Use when the same multi-step instruction would benefit from being callable by name instead of re-pasted. The skill is written to disk and runnable immediately (call `run_skill` with the same name in this very turn); it appears in the pinned Skills index only on the next `/new` or launch. WARNING: skill bodies become prompts for future agent turns — treat what you write as instructions you are giving your future self.",
+    parameters: {
+      type: "object",
+      properties: {
+        name: {
+          type: "string",
+          description:
+            "Skill identifier — letters/digits/_/-/., 1-64 chars, starts alnum. Becomes the filename and what callers pass to `run_skill`.",
+        },
+        description: {
+          type: "string",
+          description:
+            "One-line summary shown in the pinned Skills index. Keep under ~120 chars; this is what future agents read to decide whether to invoke the skill.",
+        },
+        body: {
+          type: "string",
+          description:
+            "Full skill playbook in markdown — the instructions a future turn (or subagent) follows when this skill runs. For inline skills, write 'how to do X'. For subagent skills, write the subagent's persona + operating rules; remember the subagent has NO other context besides the `arguments` passed at runtime.",
+        },
+        scope: {
+          type: "string",
+          enum: ["project", "global"],
+          description: installScopeDesc,
+        },
+        runAs: {
+          type: "string",
+          enum: ["inline", "subagent"],
+          description:
+            "'inline' (default) — body becomes a tool-result the parent agent reads and acts on (cheap, shares parent context). 'subagent' — spawns an isolated child loop; only the final answer returns to the parent (use when the work would flood context, e.g. exploration / research).",
+        },
+        model: {
+          type: "string",
+          description:
+            "Optional model override for subagent skills (e.g. 'deepseek-chat'). Ignored for runAs=inline. Only `deepseek-*` ids are honored.",
+        },
+        maxToolIters: {
+          type: "number",
+          description:
+            "Optional pause cadence for subagent skills (default 16). Not a hard budget — the parent gets a checkpoint every N tool calls and may resume. Ignored for runAs=inline.",
+        },
+        allowedTools: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Optional tool-name allowlist for subagent skills (e.g. ['read_file','search_content']). When set, the spawned subagent's registry is scoped to these literal names. Ignored for runAs=inline.",
+        },
+      },
+      required: ["name", "description", "body"],
+    },
+    fn: async (args: {
+      name?: unknown;
+      description?: unknown;
+      body?: unknown;
+      scope?: unknown;
+      runAs?: unknown;
+      model?: unknown;
+      maxToolIters?: unknown;
+      allowedTools?: unknown;
+    }) => {
+      const name = typeof args.name === "string" ? args.name.trim() : "";
+      const description =
+        typeof args.description === "string"
+          ? args.description.replace(/[\r\n]+/g, " ").trim()
+          : "";
+      const body = typeof args.body === "string" ? args.body : "";
+      if (!name) return JSON.stringify({ error: "install_skill requires a non-empty 'name'" });
+      if (!description) {
+        return JSON.stringify({
+          error:
+            "install_skill requires a non-empty 'description' — it is what appears in the Skills index and how future agents decide whether to invoke the skill",
+        });
+      }
+      if (!body.trim()) {
+        return JSON.stringify({
+          error:
+            "install_skill requires a non-empty 'body' — the playbook the skill executes when invoked",
+        });
+      }
+
+      const scopeRaw = typeof args.scope === "string" ? args.scope.trim() : "";
+      let scope: "project" | "global";
+      if (scopeRaw === "global") scope = "global";
+      else if (scopeRaw === "project") scope = "project";
+      else scope = hasProjectScope ? "project" : "global";
+      if (scope === "project" && !hasProjectScope) {
+        return JSON.stringify({
+          error:
+            "install_skill: scope='project' requires a workspace — run from `reasonix code`, or use scope='global'",
+        });
+      }
+
+      const runAsRaw = typeof args.runAs === "string" ? args.runAs.trim() : "";
+      const runAs: "inline" | "subagent" = runAsRaw === "subagent" ? "subagent" : "inline";
+
+      const fmLines = ["---", `name: ${name}`, `description: ${description}`];
+      if (runAs === "subagent") {
+        fmLines.push("runAs: subagent");
+        const model = typeof args.model === "string" ? args.model.trim() : "";
+        if (model) fmLines.push(`model: ${model}`);
+        const maxToolIters =
+          typeof args.maxToolIters === "number" && Number.isFinite(args.maxToolIters)
+            ? Math.max(1, Math.floor(args.maxToolIters))
+            : undefined;
+        if (maxToolIters !== undefined) fmLines.push(`max-iters: ${maxToolIters}`);
+        if (Array.isArray(args.allowedTools)) {
+          const tools = args.allowedTools
+            .filter((t): t is string => typeof t === "string")
+            .map((t) => t.trim())
+            .filter(Boolean);
+          if (tools.length > 0) fmLines.push(`allowed-tools: ${tools.join(", ")}`);
+        }
+      }
+      fmLines.push("---", "");
+      const content = `${fmLines.join("\n")}${body.replace(/\s+$/, "")}\n`;
+
+      const result = store.createWithContent(name, scope, content);
+      if ("error" in result) {
+        return JSON.stringify({ error: result.error });
+      }
+
+      try {
+        onSkillInstalled?.({ name, path: result.path, scope });
+      } catch {
+        // host hook failure must not undo a successful write
+      }
+
+      return JSON.stringify({
+        ok: true,
+        name,
+        scope,
+        path: result.path,
+        runAs,
+        note: "Skill is callable right now via run_skill({ name }). It will appear in the pinned Skills index after the next /new or launch.",
+      });
     },
   });
 

--- a/tests/slash.test.ts
+++ b/tests/slash.test.ts
@@ -1074,15 +1074,18 @@ describe("handleSlash", () => {
 
   describe("/memory", () => {
     let root: string;
+    let home: string;
     const originalEnv = process.env.REASONIX_MEMORY;
 
     beforeEach(() => {
       root = mkdtempSync(join(tmpdir(), "reasonix-mem-slash-"));
+      home = mkdtempSync(join(tmpdir(), "reasonix-mem-slash-home-"));
       // biome-ignore lint/performance/noDelete: avoid "undefined" in env
       delete process.env.REASONIX_MEMORY;
     });
     afterEach(() => {
       rmSync(root, { recursive: true, force: true });
+      rmSync(home, { recursive: true, force: true });
       if (originalEnv === undefined) {
         // biome-ignore lint/performance/noDelete: same reason
         delete process.env.REASONIX_MEMORY;
@@ -1092,7 +1095,7 @@ describe("handleSlash", () => {
     });
 
     it("prints a how-to when no memory (REASONIX.md or ~/.reasonix/memory) exists", () => {
-      const r = handleSlash("memory", [], makeLoop(), { memoryRoot: root });
+      const r = handleSlash("memory", [], makeLoop(), { memoryRoot: root, homeDir: home });
       expect(r.info).toMatch(/no memory pinned/);
       expect(r.info).toMatch(/REASONIX\.md/);
     });
@@ -1103,7 +1106,7 @@ describe("handleSlash", () => {
         "# House rules\nSnake case only in this repo.\n",
         "utf8",
       );
-      const r = handleSlash("memory", [], makeLoop(), { memoryRoot: root });
+      const r = handleSlash("memory", [], makeLoop(), { memoryRoot: root, homeDir: home });
       expect(r.info).toMatch(/▸ REASONIX\.md:/);
       expect(r.info).toContain("Snake case only");
       expect(r.info).toMatch(/chars/);
@@ -1112,7 +1115,7 @@ describe("handleSlash", () => {
     it("says memory is disabled when REASONIX_MEMORY=off, even with a file present", () => {
       writeFileSync(join(root, "REASONIX.md"), "content", "utf8");
       process.env.REASONIX_MEMORY = "off";
-      const r = handleSlash("memory", [], makeLoop(), { memoryRoot: root });
+      const r = handleSlash("memory", [], makeLoop(), { memoryRoot: root, homeDir: home });
       expect(r.info).toMatch(/memory is disabled/);
     });
 

--- a/tests/tools-skills.test.ts
+++ b/tests/tools-skills.test.ts
@@ -1,9 +1,10 @@
 /** run_skill — temp homeDir / projectRoot so the tool never reads real skill dirs. */
 
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SkillStore } from "../src/skills.js";
 import { ToolRegistry } from "../src/tools.js";
 import { registerSkillTools } from "../src/tools/skills.js";
 
@@ -203,5 +204,208 @@ describe("run_skill tool", () => {
     const out = await reg.dispatch("run_skill", { name: "inline-skill" });
     expect(out).toContain("Step 1, Step 2.");
     expect(runnerCalls).toBe(0);
+  });
+});
+
+describe("install_skill tool", () => {
+  let home: string;
+  let projectRoot: string;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "reasonix-installskill-"));
+    projectRoot = mkdtempSync(join(tmpdir(), "reasonix-installskill-proj-"));
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  it("registers install_skill alongside run_skill", () => {
+    const reg = new ToolRegistry();
+    registerSkillTools(reg, { homeDir: home, disableBuiltins: true });
+    expect(reg.get("install_skill")).toBeDefined();
+    expect(reg.get("run_skill")).toBeDefined();
+  });
+
+  it("writes a project-scope skill file with valid frontmatter and returns its path", async () => {
+    const reg = new ToolRegistry();
+    registerSkillTools(reg, { homeDir: home, projectRoot, disableBuiltins: true });
+    const out = await reg.dispatch("install_skill", {
+      name: "summarize-prs",
+      description: "Summarize merged PRs from the last week",
+      body: "Run gh pr list and group by author.",
+    });
+    const parsed = JSON.parse(out);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.scope).toBe("project");
+    expect(parsed.runAs).toBe("inline");
+    expect(parsed.path).toContain(projectRoot);
+    expect(existsSync(parsed.path)).toBe(true);
+    const raw = readFileSync(parsed.path, "utf8");
+    expect(raw).toContain("name: summarize-prs");
+    expect(raw).toContain("description: Summarize merged PRs from the last week");
+    expect(raw).toContain("Run gh pr list");
+  });
+
+  it("the newly-installed skill is immediately runnable via run_skill in the same registry", async () => {
+    const reg = new ToolRegistry();
+    registerSkillTools(reg, { homeDir: home, projectRoot, disableBuiltins: true });
+    await reg.dispatch("install_skill", {
+      name: "lint-fix",
+      description: "Run linter and apply autofixes",
+      body: "Step 1: npm run lint --fix.",
+    });
+    const out = await reg.dispatch("run_skill", { name: "lint-fix" });
+    expect(out).toContain("# Skill: lint-fix");
+    expect(out).toContain("Step 1: npm run lint --fix");
+  });
+
+  it("defaults scope to global when no projectRoot is set", async () => {
+    const reg = new ToolRegistry();
+    registerSkillTools(reg, { homeDir: home, disableBuiltins: true });
+    const out = await reg.dispatch("install_skill", {
+      name: "everywhere",
+      description: "Available in every project",
+      body: "do a thing",
+    });
+    const parsed = JSON.parse(out);
+    expect(parsed.scope).toBe("global");
+    expect(parsed.path).toContain(home);
+  });
+
+  it("rejects scope=project when no workspace is configured", async () => {
+    const reg = new ToolRegistry();
+    registerSkillTools(reg, { homeDir: home, disableBuiltins: true });
+    const out = await reg.dispatch("install_skill", {
+      name: "x",
+      description: "y",
+      body: "z",
+      scope: "project",
+    });
+    expect(JSON.parse(out).error).toMatch(/requires a workspace/);
+  });
+
+  it("rejects an empty name / description / body", async () => {
+    const reg = new ToolRegistry();
+    registerSkillTools(reg, { homeDir: home, projectRoot, disableBuiltins: true });
+    expect(
+      JSON.parse(await reg.dispatch("install_skill", { name: "", description: "d", body: "b" }))
+        .error,
+    ).toMatch(/'name'/);
+    expect(
+      JSON.parse(await reg.dispatch("install_skill", { name: "ok", description: "", body: "b" }))
+        .error,
+    ).toMatch(/'description'/);
+    expect(
+      JSON.parse(await reg.dispatch("install_skill", { name: "ok", description: "d", body: "" }))
+        .error,
+    ).toMatch(/'body'/);
+  });
+
+  it("rejects invalid skill names", async () => {
+    const reg = new ToolRegistry();
+    registerSkillTools(reg, { homeDir: home, projectRoot, disableBuiltins: true });
+    const out = await reg.dispatch("install_skill", {
+      name: "../etc/passwd",
+      description: "d",
+      body: "b",
+    });
+    expect(JSON.parse(out).error).toMatch(/invalid skill name/);
+  });
+
+  it("refuses to overwrite an existing skill", async () => {
+    const reg = new ToolRegistry();
+    registerSkillTools(reg, { homeDir: home, projectRoot, disableBuiltins: true });
+    await reg.dispatch("install_skill", {
+      name: "dup",
+      description: "first",
+      body: "first body",
+    });
+    const out = await reg.dispatch("install_skill", {
+      name: "dup",
+      description: "second",
+      body: "second body",
+    });
+    expect(JSON.parse(out).error).toMatch(/already exists/);
+  });
+
+  it("fires onSkillInstalled with the name + scope + path", async () => {
+    const reg = new ToolRegistry();
+    const calls: Array<{ name: string; scope: string; path: string }> = [];
+    registerSkillTools(reg, {
+      homeDir: home,
+      projectRoot,
+      disableBuiltins: true,
+      onSkillInstalled: (info) => calls.push(info),
+    });
+    await reg.dispatch("install_skill", {
+      name: "watched",
+      description: "trigger the hook",
+      body: "noop",
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.name).toBe("watched");
+    expect(calls[0]?.scope).toBe("project");
+    expect(calls[0]?.path).toContain(projectRoot);
+  });
+
+  it("writes subagent frontmatter (runAs/model/max-iters/allowed-tools) when runAs=subagent", async () => {
+    const reg = new ToolRegistry();
+    registerSkillTools(reg, { homeDir: home, projectRoot, disableBuiltins: true });
+    const out = await reg.dispatch("install_skill", {
+      name: "deep-research",
+      description: "research subagent",
+      body: "You are a research subagent. Investigate and answer.",
+      runAs: "subagent",
+      model: "deepseek-chat",
+      maxToolIters: 24,
+      allowedTools: ["read_file", "search_content"],
+    });
+    const parsed = JSON.parse(out);
+    expect(parsed.runAs).toBe("subagent");
+    const raw = readFileSync(parsed.path, "utf8");
+    expect(raw).toContain("runAs: subagent");
+    expect(raw).toContain("model: deepseek-chat");
+    expect(raw).toContain("max-iters: 24");
+    expect(raw).toContain("allowed-tools: read_file, search_content");
+
+    const store = new SkillStore({ homeDir: home, projectRoot, disableBuiltins: true });
+    const skill = store.read("deep-research");
+    expect(skill?.runAs).toBe("subagent");
+    expect(skill?.model).toBe("deepseek-chat");
+    expect(skill?.maxToolIters).toBe(24);
+    expect(skill?.allowedTools).toEqual(["read_file", "search_content"]);
+  });
+
+  it("skips subagent-only frontmatter for inline skills", async () => {
+    const reg = new ToolRegistry();
+    registerSkillTools(reg, { homeDir: home, projectRoot, disableBuiltins: true });
+    const out = await reg.dispatch("install_skill", {
+      name: "plain",
+      description: "inline skill",
+      body: "do the thing",
+      model: "deepseek-chat",
+      maxToolIters: 42,
+      allowedTools: ["read_file"],
+    });
+    const raw = readFileSync(JSON.parse(out).path, "utf8");
+    expect(raw).not.toContain("runAs:");
+    expect(raw).not.toContain("model:");
+    expect(raw).not.toContain("max-iters:");
+    expect(raw).not.toContain("allowed-tools:");
+  });
+
+  it("normalizes newlines in description to spaces (frontmatter is single-line per key)", async () => {
+    const reg = new ToolRegistry();
+    registerSkillTools(reg, { homeDir: home, projectRoot, disableBuiltins: true });
+    const out = await reg.dispatch("install_skill", {
+      name: "multiline-desc",
+      description: "first line\nsecond line\nthird",
+      body: "x",
+    });
+    const raw = readFileSync(JSON.parse(out).path, "utf8");
+    expect(raw).toContain("description: first line second line third");
+    expect(raw).not.toMatch(/description: first line\n/);
   });
 });

--- a/tests/user-memory.test.ts
+++ b/tests/user-memory.test.ts
@@ -380,11 +380,9 @@ describe("user-memory", () => {
     });
 
     it("applyMemoryStack injects no memory blocks when no memory is set", () => {
-      // No REASONIX.md, no HOME memory → no memory blocks. The bundled
-      // builtin skills (`explore`, `research`) still inject a Skills
-      // index, so we assert the absence of the memory-specific blocks
-      // rather than raw equality with BASE.
-      const out = applyMemoryStack(BASE, projectRoot);
+      // homeDir override required — otherwise the helper falls back to the
+      // dev's real ~/.reasonix and bleeds in whatever memory they have.
+      const out = applyMemoryStack(BASE, projectRoot, { homeDir: home });
       expect(out).toContain(BASE);
       expect(out).not.toMatch(/# Project memory/);
       expect(out).not.toMatch(/# User memory/);


### PR DESCRIPTION
## Summary

- New `install_skill` tool — the agent can author and save a skill mid-session (project or global scope), and the freshly-written skill is callable immediately via `run_skill` in the same turn (reads disk fresh). The pinned Skills index in the system prompt refreshes on the next `/new`, matching the `remember` precedent.
- Desktop sidebar updates without a tab reload: `CodeToolsetOpts` now has an `onSkillInstalled` hook that the desktop tab wires to `emitSkills(tab)`, pushing a `$skills` event the moment the file lands.
- Bonus fix in a separate commit: two `/memory` tests were silently reading the dev's real `~/.reasonix/memory/` and failing whenever local global memory was present. Threaded an optional `homeDir` through `applyMemoryStack` + `SlashContext` so tests can isolate themselves. Production paths still default to `os.homedir()` — no behavior change.

Permissions ride the existing tool-permission tiers — default prompts (the dialog already shows the call args, so the body is reviewable before approval), `acceptEdits` auto-approves, yolo skips entirely. No special install path needed.

## Test plan

- [x] `tests/tools-skills.test.ts` — 12 new tests cover write + frontmatter, immediate `run_skill` resolution in same registry, scope defaults, validation, duplicate refusal, host hook firing, subagent frontmatter, inline-skill frontmatter pruning, newline normalization in description
- [x] `tests/user-memory.test.ts` + `tests/slash.test.ts` — failing memory tests now pass with the `homeDir` override
- [x] Full suite green: 2897 passed, 3 skipped, 0 failed
- [x] `tsc --noEmit` clean
