### PR TITLE
fix(desktop): disable WebKit DMABUF renderer on Linux (AppImage black screen)

### DIFF
--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -160,6 +160,16 @@ fn open_in_editor(command: String, path: String, line: Option<u32>) -> Result<()
 }
 
 fn main() {
+    // #892: WebKitGTK 2.42+ DMABUF renderer SIGABRTs on some Wayland + Mesa
+    // combos (black screen on launch). Disable it before WebKitWebProcess
+    // spawns; users can opt back in by exporting the var themselves.
+    #[cfg(target_os = "linux")]
+    {
+        if std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_none() {
+            std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+        }
+    }
+
     tauri::Builder::default()
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())


### PR DESCRIPTION
## Summary

- Force `WEBKIT_DISABLE_DMABUF_RENDERER=1` on Linux at the very top of `main()`, before `WebKitWebProcess` spawns. Only set when the user hasn't exported the var themselves — opt-out stays available for users on stacks where the newer DMABUF path works fine.
- Fixes the AppImage black-screen at launch reported in #892: `WebKitWebProcess` SIGABRT on openSUSE Tumbleweed + KDE Plasma 6.6 (Wayland) + Intel UHD. Same crash signature shows up across the Tauri / WebKit2GTK ecosystem on WebKitGTK 2.42+ where the new DMABUF renderer is incompatible with certain Mesa releases.
- Linux-only via `#[cfg(target_os = "linux")]`; macOS / Windows builds are byte-for-byte unchanged.

Closes #892

## Test plan

- [x] `cargo check` from `desktop/src-tauri/` — clean
- [x] Temporarily flipped the cfg to `target_os = "windows"` to force-compile the body on this machine — clean, no warnings
- [x] Full `npm run test` (vitest) — 2897 passed, 3 skipped
- [ ] Smoke test on a Linux box: download AppImage, launch — should render instead of black-screening. (Cannot verify from Windows dev host; needs a Linux user to confirm — the reporter in #892 is well-placed to validate.)
