### PR TITLE
feat(web): add Metaso web search engine.

### DIFF
--- a/src/cli/ui/slash/handlers/web-search-engine.ts
+++ b/src/cli/ui/slash/handlers/web-search-engine.ts
@@ -5,7 +5,7 @@ import type { SlashHandler } from "../dispatch.js";
 export const handlers: Record<string, SlashHandler> = {
   "search-engine": (args, _loop, ctx) => {
     const engine = args[0];
-    if (!engine || (engine !== "mojeek" && engine !== "searxng")) {
+    if (!engine || (engine !== "mojeek" && engine !== "searxng" && engine !== "metaso")) {
       return {
         info: [
           t("handlers.webSearchEngine.currentEngine", { engine: webSearchEngine() }),
@@ -15,6 +15,7 @@ export const handlers: Record<string, SlashHandler> = {
           t("handlers.webSearchEngine.usageMojeek"),
           t("handlers.webSearchEngine.usageSearxng"),
           t("handlers.webSearchEngine.usageSearxngUrl"),
+          t("handlers.webSearchEngine.usageMetaso"),
           "",
           t("handlers.webSearchEngine.alias"),
           "",
@@ -35,7 +36,9 @@ export const handlers: Record<string, SlashHandler> = {
     const note =
       engine === "searxng"
         ? t("handlers.webSearchEngine.switchedSearxngNote", { endpoint: webSearchEndpoint() })
-        : "";
+        : engine === "metaso"
+          ? t("handlers.webSearchEngine.switchedMetasoNote")
+          : "";
     ctx.postInfo?.(t("handlers.webSearchEngine.switched", { engine, note }));
 
     const detail =

--- a/src/config.ts
+++ b/src/config.ts
@@ -99,10 +99,12 @@ export interface ReasonixConfig {
   session?: string | null;
   setupCompleted?: boolean;
   search?: boolean;
-  /** Web search engine backend: "mojeek" (default, scrapes Mojeek) or "searxng" (self-hosted SearXNG). */
-  webSearchEngine?: "mojeek" | "searxng";
+  /** Web search engine backend: "mojeek" (default, scrapes Mojeek), "searxng" (self-hosted SearXNG), or "metaso" (Metaso API). */
+  webSearchEngine?: "mojeek" | "searxng" | "metaso";
   /** Base URL for SearXNG instance (default http://localhost:8080). */
   webSearchEndpoint?: string;
+  /** Metaso API key. Falls back to METASO_API_KEY env var, then a built-in default. */
+  metasoApiKey?: string;
   dashboard?: {
     /** Pin the embedded dashboard to a fixed port — required for stable SSH tunnels. 0/absent → ephemeral. */
     port?: number;
@@ -196,6 +198,15 @@ export function memoryTypeDefaults(
   return out;
 }
 
+const DEFAULT_METASO_API_KEY = "mk-E384C1DD5E8501BB7EFE27C949AFDE5B";
+
+export function loadMetasoApiKey(path: string = defaultConfigPath()): string {
+  if (process.env.METASO_API_KEY) return process.env.METASO_API_KEY;
+  const cfg = readConfig(path).metasoApiKey;
+  if (cfg && typeof cfg === "string" && cfg.trim()) return cfg.trim();
+  return DEFAULT_METASO_API_KEY;
+}
+
 const DEFAULT_OLLAMA_URL = "http://localhost:11434";
 const DEFAULT_EMBED_MODEL = "nomic-embed-text";
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -283,9 +294,12 @@ export function searchEnabled(path: string = defaultConfigPath()): boolean {
   return true;
 }
 
-export function webSearchEngine(path: string = defaultConfigPath()): "mojeek" | "searxng" {
+export function webSearchEngine(
+  path: string = defaultConfigPath(),
+): "mojeek" | "searxng" | "metaso" {
   const cfg = readConfig(path).webSearchEngine;
   if (cfg === "searxng") return "searxng";
+  if (cfg === "metaso") return "metaso";
   return "mojeek";
 }
 

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -396,8 +396,9 @@ export const EN: TranslationSchema = {
       argsHint: "<question>",
     },
     "search-engine": {
-      description: "switch web search backend — mojeek (default, no deps) or searxng (self-hosted)",
-      argsHint: "<mojeek|searxng> [<endpoint>]",
+      description:
+        "switch web search backend — mojeek (default, no deps), searxng (self-hosted), or metaso (free quota 100/d)",
+      argsHint: "<mojeek|searxng|metaso> [<endpoint>]",
     },
   },
   wizard: {
@@ -1057,12 +1058,15 @@ export const EN: TranslationSchema = {
       usageMojeek: "  /search-engine mojeek            use Mojeek (default, no external deps)",
       usageSearxng: "  /search-engine searxng            use SearXNG at default endpoint",
       usageSearxngUrl: "  /search-engine searxng <url>      use SearXNG at custom endpoint",
+      usageMetaso:
+        "  /search-engine metaso              use Metaso API (100/d free, set METASO_API_KEY for more)",
       alias: "Alias: /se",
       searxngInfo:
         "SearXNG is a self-hosted metasearch engine (https://github.com/searxng/searxng).",
       searxngInstall: "Install it with:  docker run -d -p 8080:8080 searxng/searxng",
       switched: 'Switched web search engine to "{engine}".{note}',
       switchedSearxngNote: " Make sure SearXNG is running at {endpoint}.",
+      switchedMetasoNote: " There is a daily quota of 100 (set METASO_API_KEY for higher limits).",
       confirmed:
         '✓ Web search engine set to "{engine}"{detail}. Next assistant turn will pick up the change.',
       confirmedDetail: " ({endpoint})",
@@ -1326,6 +1330,17 @@ export const EN: TranslationSchema = {
       "web_search: Cannot reach SearXNG server at {endpoint} \u2014 try: install and start SearXNG (https://github.com/searxng/searxng, e.g. `docker run -d -p 8080:8080 searxng/searxng`), or switch to the default engine with /search-engine mojeek",
     searxngNoResults:
       "web_search: 0 results but SearXNG response doesn't look like an empty results page ({chars} chars) \u2014 try: rephrase the query with simpler terms, or switch engine with /search-engine mojeek",
+    metasoDailyLimit:
+      "web_search: daily search limit reached for the default API key \u2014 set your own METASO_API_KEY env var or get one at https://metaso.cn/search-api/playground",
+    metasoUnauthorized:
+      "web_search: Metaso API key rejected \u2014 check METASO_API_KEY or get one at https://metaso.cn/search-api/playground",
+    metasoRateLimit:
+      "web_search: Metaso rate-limited \u2014 wait and retry, or get your own API key at https://metaso.cn/search-api/playground",
+    metasoServerError:
+      "web_search: Metaso server error ({status}) \u2014 try again later, or switch engine with /search-engine mojeek",
+    metasoParseError:
+      "web_search: Metaso returned unparseable response (HTTP {status}) \u2014 try again later",
+    metasoApiError: "web_search: Metaso API error (code {code}: {message}) \u2014 try again later",
     fetchStatus:
       "web_fetch {status} for {url} \u2014 try: confirm the URL resolves in a browser; status suggests the host returned an error page",
     fetchRateLimit429:

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -580,6 +580,12 @@ export interface TranslationSchema {
     endpointMustBeHttp: string;
     cannotReach: string;
     searxngNoResults: string;
+    metasoDailyLimit: string;
+    metasoUnauthorized: string;
+    metasoRateLimit: string;
+    metasoServerError: string;
+    metasoParseError: string;
+    metasoApiError: string;
     fetchStatus: string;
     fetchRateLimit429: string;
     fetchForbidden403: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -385,8 +385,9 @@ export const zhCN: TranslationSchema = {
       argsHint: "<question>",
     },
     "search-engine": {
-      description: "切换网络搜索后端 — mojeek（默认，无依赖）或 searxng（自托管）",
-      argsHint: "<mojeek|searxng> [<endpoint>]",
+      description:
+        "切换网络搜索后端 — mojeek（默认，无依赖）、searxng（自托管）或 metaso（每日 100 次免费额度）",
+      argsHint: "<mojeek|searxng|metaso> [<endpoint>]",
     },
   },
   wizard: {
@@ -1003,11 +1004,14 @@ export const zhCN: TranslationSchema = {
       usageMojeek: "  /search-engine mojeek            使用 Mojeek（默认，无外部依赖）",
       usageSearxng: "  /search-engine searxng            使用 SearXNG 默认端点",
       usageSearxngUrl: "  /search-engine searxng <url>      使用 SearXNG 自定义端点",
+      usageMetaso:
+        "  /search-engine metaso              使用 Metaso API（每天 100 次免费，设置 METASO_API_KEY 提高额度）",
       alias: "别名：/se",
       searxngInfo: "SearXNG 是一个自托管的元搜索引擎（https://github.com/searxng/searxng）。",
       searxngInstall: "安装命令：  docker run -d -p 8080:8080 searxng/searxng",
       switched: '已切换网页搜索引擎为 "{engine}"。{note}',
       switchedSearxngNote: " 请确保 SearXNG 在 {endpoint} 运行。",
+      switchedMetasoNote: " 每日限额 100 次（设置 METASO_API_KEY 可提升限额）。",
       confirmed: '✓ 网页搜索引擎已设为 "{engine}"{detail}。下一轮模型调用将生效。',
       confirmedDetail: "（{endpoint}）",
     },
@@ -1259,6 +1263,16 @@ export const zhCN: TranslationSchema = {
       "web_search: 无法访问 SearXNG 服务器 {endpoint} — try: 安装并启动 SearXNG（https://github.com/searxng/searxng，例如 `docker run -d -p 8080:8080 searxng/searxng`），或使用 /search-engine mojeek 切换到默认引擎",
     searxngNoResults:
       "web_search: 返回 0 条结果但 SearXNG 响应看起来不是正常空结果页（{chars} 字符）— try: 使用更简单的关键词改写查询，或使用 /search-engine mojeek 切换引擎",
+    metasoDailyLimit:
+      "web_search: 默认 API 密钥的每日搜索次数已达上限 — 设置 METASO_API_KEY 环境变量，或在 https://metaso.cn/search-api/playground 获取自己的密钥",
+    metasoUnauthorized:
+      "web_search: Metaso API 密钥被拒绝 — 检查 METASO_API_KEY，或在 https://metaso.cn/search-api/playground 获取密钥",
+    metasoRateLimit:
+      "web_search: Metaso 请求频率限制 — 等待后重试，或在 https://metaso.cn/search-api/playground 获取自己的密钥",
+    metasoServerError:
+      "web_search: Metaso 服务器错误（{status}）— 稍后重试，或使用 /search-engine mojeek 切换引擎",
+    metasoParseError: "web_search: Metaso 返回无法解析的响应（HTTP {status}）— 稍后重试",
+    metasoApiError: "web_search: Metaso API 错误（code {code}: {message}）— 稍后重试",
     fetchStatus:
       "web_fetch {status} for {url} — try: 在浏览器中确认该 URL 能否访问；该状态码表明目标主机返回了错误页面",
     fetchRateLimit429:

--- a/src/index.ts
+++ b/src/index.ts
@@ -280,6 +280,7 @@ export {
   isPlausibleKey,
   loadApiKey,
   loadBaseUrl,
+  loadMetasoApiKey,
   readConfig,
   redactKey,
   saveApiKey,

--- a/src/tools/web.ts
+++ b/src/tools/web.ts
@@ -2,6 +2,7 @@
 
 import { parse as parseHtml } from "node-html-parser";
 import {
+  loadMetasoApiKey,
   webSearchEndpoint as loadWebSearchEndpoint,
   webSearchEngine as loadWebSearchEngine,
 } from "../config.js";
@@ -33,8 +34,8 @@ export interface WebFetchOptions {
 export interface WebSearchOptions {
   topK?: number;
   signal?: AbortSignal;
-  /** Backend engine: "mojeek" (scrapes Mojeek HTML) or "searxng" (self-hosted SearXNG JSON API). */
-  engine?: "mojeek" | "searxng";
+  /** Backend engine: "mojeek" (scrapes Mojeek HTML), "searxng" (self-hosted SearXNG JSON API), or "metaso" (Metaso API). */
+  engine?: "mojeek" | "searxng" | "metaso";
   /** Base URL for SearXNG. Default http://localhost:8080. */
   endpoint?: string;
 }
@@ -49,6 +50,7 @@ const FETCH_MAX_BYTES = 10 * 1024 * 1024;
 const USER_AGENT =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
 const MOJEEK_ENDPOINT = "https://www.mojeek.com/search";
+const METASO_ENDPOINT = "https://metaso.cn/api/v1";
 
 /** Pick a status-specific webErrors key so the model gets an actionable hint, not a bare status. */
 function searchStatusError(status: number): string {
@@ -70,6 +72,9 @@ export async function webSearch(
   query: string,
   opts: WebSearchOptions = {},
 ): Promise<SearchResult[]> {
+  if (opts.engine === "metaso") {
+    return searchMetaso(query, opts);
+  }
   if (opts.engine === "searxng") {
     return searchSearxng(query, opts);
   }
@@ -150,6 +155,93 @@ async function searchSearxng(query: string, opts: WebSearchOptions = {}): Promis
     throw new Error(t("webErrors.searxngNoResults", { chars: html.length }));
   }
   return results;
+}
+
+interface MetasoWebpage {
+  title: string;
+  link: string;
+  snippet?: string;
+  summary?: string;
+  score?: string;
+  position?: number;
+  date?: string;
+}
+
+interface MetasoSearchResponse {
+  credits?: number;
+  total?: number;
+  webpages?: MetasoWebpage[];
+  code?: number;
+  message?: string;
+}
+
+async function searchMetaso(query: string, opts: WebSearchOptions = {}): Promise<SearchResult[]> {
+  const topK = Math.max(1, Math.min(100, opts.topK ?? DEFAULT_TOPK));
+  const apiKey = loadMetasoApiKey();
+
+  let resp: Response;
+  try {
+    resp = await fetch(`${METASO_ENDPOINT}/search`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        q: query,
+        scope: "webpage",
+        size: topK,
+      }),
+      signal: opts.signal,
+    });
+  } catch (err) {
+    if (err instanceof TypeError && (err as Error).message.includes("fetch")) {
+      throw new Error(t("webErrors.cannotReach", { endpoint: METASO_ENDPOINT }));
+    }
+    throw err;
+  }
+
+  const raw = await resp.text();
+  let data: MetasoSearchResponse;
+  try {
+    data = JSON.parse(raw) as MetasoSearchResponse;
+  } catch {
+    throw new Error(t("webErrors.metasoParseError", { status: resp.status }));
+  }
+
+  if (!resp.ok) {
+    if (resp.status === 401 || resp.status === 403) {
+      throw new Error(t("webErrors.metasoUnauthorized"));
+    }
+    if (resp.status === 429) {
+      throw new Error(t("webErrors.metasoRateLimit"));
+    }
+    throw new Error(t("webErrors.metasoServerError", { status: resp.status }));
+  }
+
+  if (data.code === 3003) {
+    throw new Error(t("webErrors.metasoDailyLimit"));
+  }
+  if (data.code === 2005) {
+    throw new Error(t("webErrors.metasoUnauthorized"));
+  }
+  if (data.code && data.code !== 0) {
+    throw new Error(
+      t("webErrors.metasoApiError", { code: data.code, message: data.message ?? "" }),
+    );
+  }
+
+  const webpages = data.webpages ?? [];
+  if (webpages.length === 0) {
+    return [];
+  }
+
+  return webpages.slice(0, topK).map((wp) => ({
+    title: wp.title,
+    url: wp.link,
+    snippet: wp.snippet ?? wp.summary ?? "",
+  }));
 }
 
 /** Parse SearXNG HTML search results using node-html-parser. */
@@ -417,8 +509,8 @@ export interface WebToolsOptions {
   defaultTopK?: number;
   /** Byte cap for `web_fetch` extracted text. */
   maxFetchChars?: number;
-  /** Backend engine: "mojeek" (default, scrapes Mojeek) or "searxng" (self-hosted SearXNG). */
-  webSearchEngine?: "mojeek" | "searxng";
+  /** Backend engine: "mojeek" (default, scrapes Mojeek), "searxng" (self-hosted SearXNG), or "metaso" (Metaso API). */
+  webSearchEngine?: "mojeek" | "searxng" | "metaso";
   /** Base URL for SearXNG (default http://localhost:8080). */
   webSearchEndpoint?: string;
 }
@@ -431,7 +523,7 @@ export function registerWebTools(registry: ToolRegistry, opts: WebToolsOptions =
     name: "web_search",
     description:
       "Search the public web. Returns ranked results with title, url, and snippet. Call this when the answer's correctness depends on current state — anything that changes over time (events, prices, releases, status of a thing in the real world). Composing such answers from training memory invents stale numbers; search first, then ground the answer in the results. For evergreen / definitional questions you don't need this." +
-      " To change the backend, use /web-search-engine mojeek|searxng.",
+      " To change the backend, use /search-engine mojeek|searxng|metaso.",
     readOnly: true,
     parallelSafe: true,
     parameters: {

--- a/tests/public-api.test.ts
+++ b/tests/public-api.test.ts
@@ -273,6 +273,7 @@ const PUBLIC_API: readonly string[] = [
   "loadBaseUrl",
   "loadDotenv",
   "loadHooks",
+  "loadMetasoApiKey",
   "loadSessionMessages",
   "matchesTool",
   "memoryEnabled",

--- a/tests/web-tools.test.ts
+++ b/tests/web-tools.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { loadMetasoApiKey } from "../src/config.js";
 import { ToolRegistry } from "../src/tools.js";
 import {
   formatSearchResults,
@@ -293,6 +294,156 @@ describe("webSearch", () => {
     ) as unknown as typeof fetch;
     try {
       await expect(webSearch("q")).rejects.toThrow(/doesn't look like a real empty page/);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+describe("searchMetaso", () => {
+  const sampleResponse = {
+    credits: 3,
+    total: 72,
+    webpages: [
+      {
+        title: "Result One",
+        link: "https://example.com/1",
+        snippet: "Snippet one.",
+        score: "high",
+        position: 1,
+      },
+      {
+        title: "Result Two",
+        link: "https://example.com/2",
+        summary: "Summary two.",
+        score: "medium",
+        position: 2,
+      },
+    ],
+  };
+
+  it("POSTs to metaso API with JSON body and auth header", async () => {
+    const captured: { url: string; method: string; headers: Record<string, string>; body: string } =
+      { url: "", method: "", headers: {}, body: "" };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      captured.url = String(url);
+      captured.method = init?.method ?? "GET";
+      captured.headers = (init?.headers ?? {}) as Record<string, string>;
+      captured.body = String(init?.body ?? "");
+      return new Response(JSON.stringify(sampleResponse), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+    try {
+      const out = await webSearch("test query", { engine: "metaso", topK: 5 });
+      expect(captured.url).toContain("metaso.cn/api/v1/search");
+      expect(captured.method).toBe("POST");
+      expect(captured.headers.Authorization).toBe(`Bearer ${loadMetasoApiKey()}`);
+      expect(captured.headers["Content-Type"]).toBe("application/json");
+      const body = JSON.parse(captured.body);
+      expect(body.q).toBe("test query");
+      expect(body.scope).toBe("webpage");
+      expect(body.size).toBe(5);
+      expect(out).toHaveLength(2);
+      expect(out[0]).toEqual({
+        title: "Result One",
+        url: "https://example.com/1",
+        snippet: "Snippet one.",
+      });
+      expect(out[1]).toEqual({
+        title: "Result Two",
+        url: "https://example.com/2",
+        snippet: "Summary two.",
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("throws daily limit error on code 3003", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ code: 3003, message: "今日调用次数已达上限" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    ) as unknown as typeof fetch;
+    try {
+      await expect(webSearch("q", { engine: "metaso" })).rejects.toThrow(/daily search limit/);
+      await expect(webSearch("q", { engine: "metaso" })).rejects.toThrow(
+        /metaso.cn\/search-api\/playground/,
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("throws unauthorized error on code 2005 (invalid API key)", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ code: 2005, message: "API密钥无效" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    ) as unknown as typeof fetch;
+    try {
+      await expect(webSearch("q", { engine: "metaso" })).rejects.toThrow(/API key rejected/);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("throws rate limit error on 429", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ message: "rate limited" }), {
+          status: 429,
+          headers: { "Content-Type": "application/json" },
+        }),
+    ) as unknown as typeof fetch;
+    try {
+      await expect(webSearch("q", { engine: "metaso" })).rejects.toThrow(/rate-limited/);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("returns empty array on 0 results", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ credits: 1, total: 0 }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    ) as unknown as typeof fetch;
+    try {
+      const out = await webSearch("q", { engine: "metaso" });
+      expect(out).toEqual([]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("clamps topK to [1, 100]", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify(sampleResponse), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    ) as unknown as typeof fetch;
+    try {
+      const outMax = await webSearch("x", { engine: "metaso", topK: 999 });
+      expect(outMax.length).toBeLessThanOrEqual(2);
+      const outMin = await webSearch("x", { engine: "metaso", topK: 0 });
+      expect(outMin.length).toBe(1);
     } finally {
       globalThis.fetch = originalFetch;
     }


### PR DESCRIPTION
## What

Add [Metaso](https://metaso.cn/) as a web search engine backend (alongside Mojeek and SearXNG).

## Why

Provides a zero-setup, free-quota (100 searches/day) alternative to self-hosted SearXNG.

## How to verify

`npm run verify` passes. Test switching engines with /search-engine metaso, and verify web_search tool works via the Metaso API.

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time
