### PR TITLE
fix(desktop): inline busy status into composer, drop floating Reasoning pill

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -35,7 +35,7 @@ import type {
 } from "./protocol";
 import { Composer, type SlashCmd } from "./ui/composer";
 import { ContextPanel } from "./ui/context-panel";
-import { InterruptBar, useElapsed } from "./ui/live";
+import { useElapsed } from "./ui/live";
 import { SettingsModal, type PageId as SettingsPageId } from "./ui/settings";
 import { Sidebar } from "./ui/sidebar";
 import { Splash, shouldShowSplash } from "./ui/splash";
@@ -1601,6 +1601,14 @@ function TabRuntime({
                 onAbort={abort}
                 disabled={!state.ready}
                 busy={state.busy}
+                busyLabel={
+                  state.busy
+                    ? state.activeSkill
+                      ? `Skill · ${state.activeSkill.name}`
+                      : "Reasoning"
+                    : undefined
+                }
+                busyElapsedMs={elapsed}
                 textareaRef={composerRef}
                 preset={state.settings?.preset ?? "auto"}
                 modelLabel={state.settings?.model ?? "deepseek-v4-flash"}
@@ -1620,15 +1628,6 @@ function TabRuntime({
                 onMentionPicked={markMentionPicked}
                 mentionResults={state.mentionResults}
               />
-
-              {state.busy ? (
-                <InterruptBar
-                  visible={true}
-                  elapsedMs={elapsed}
-                  label={state.activeSkill ? `Skill · ${state.activeSkill.name}` : "Reasoning"}
-                  onStop={abort}
-                />
-              ) : null}
             </>
           )}
         </main>

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -2443,56 +2443,35 @@ button {
   to { opacity: 1; }
 }
 
-/* ---- interrupt floating bar ---- */
-
-.interrupt-bar {
-  position: absolute;
-  left: 50%;
-  bottom: 88px;
-  transform: translateX(-50%);
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  background: var(--card);
-  border: 1px solid var(--border-strong);
-  box-shadow: var(--shadow-lg);
-  border-radius: 999px;
-  padding: 6px 6px 6px 14px;
-  font-size: 11.5px;
-  color: var(--fg-2);
-  font-family: "IBM Plex Mono", monospace;
-  z-index: 30;
-  animation: rise 0.25s ease-out;
-}
 @keyframes rise {
   from { opacity: 0; transform: translate(-50%, 8px); }
   to { opacity: 1; transform: translate(-50%, 0); }
 }
-.interrupt-bar .pip {
-  width: 7px;
-  height: 7px;
+
+.composer-busy-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+.composer-busy-pip {
+  width: 6px;
+  height: 6px;
   border-radius: 50%;
   background: var(--accent);
   animation: blink 1.2s ease-in-out infinite;
+  flex-shrink: 0;
 }
-.interrupt-bar .timer {
+.composer-busy-label {
+  color: var(--fg-2);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.composer-busy-time {
   color: var(--muted);
   font-variant-numeric: tabular-nums;
-  min-width: 36px;
-}
-.interrupt-bar button {
-  background: var(--danger);
-  color: oklch(99% 0 0);
-  border-radius: 999px;
-  padding: 4px 10px;
-  font-family: inherit;
-  font-size: 11px;
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-}
-.interrupt-bar button:hover {
-  background: oklch(58% 0.18 22);
+  flex-shrink: 0;
 }
 
 /* ---- queued tab-row indicator (multiple sessions running) ---- */

--- a/desktop/src/ui/composer.tsx
+++ b/desktop/src/ui/composer.tsx
@@ -10,6 +10,7 @@ import {
 import type React from "react";
 import { open as openFileDialog } from "@tauri-apps/plugin-dialog";
 import { I } from "../icons";
+import { fmtElapsed } from "./live";
 
 export type PresetName = "auto" | "flash" | "pro";
 export type EditMode = "review" | "auto" | "yolo";
@@ -110,6 +111,8 @@ export function Composer({
   onAbort,
   disabled,
   busy,
+  busyLabel,
+  busyElapsedMs,
   preset,
   modelLabel,
   onPresetChange,
@@ -129,6 +132,9 @@ export function Composer({
   onAbort: () => void;
   disabled?: boolean;
   busy?: boolean;
+  /** Replaces the hint-row left side while the agent is running — typically "Reasoning" or "Skill · <name>". */
+  busyLabel?: string;
+  busyElapsedMs?: number;
   preset: PresetName;
   modelLabel: string;
   onPresetChange: (preset: PresetName) => void;
@@ -307,12 +313,27 @@ export function Composer({
     <div className="composer-wrap">
       <div className="composer-inner">
         <div className="hint-row">
-          <span>
-            <kbd>/</kbd> 命令 &nbsp;·&nbsp; <kbd>@</kbd> 提及文件 &nbsp;·&nbsp; <kbd>⌘K</kbd> 命令面板
-          </span>
-          <span>
-            <kbd>⏎</kbd> 发送 &nbsp; <kbd>⇧⏎</kbd> 换行
-          </span>
+          {busy && busyLabel ? (
+            <>
+              <span className="composer-busy-status">
+                <span className="composer-busy-pip" />
+                <span className="composer-busy-label">{busyLabel}</span>
+                <span className="composer-busy-time">{fmtElapsed(busyElapsedMs ?? 0)}</span>
+              </span>
+              <span>
+                <kbd>⏎</kbd>/<kbd>esc</kbd> 中断
+              </span>
+            </>
+          ) : (
+            <>
+              <span>
+                <kbd>/</kbd> 命令 &nbsp;·&nbsp; <kbd>@</kbd> 提及文件 &nbsp;·&nbsp; <kbd>⌘K</kbd> 命令面板
+              </span>
+              <span>
+                <kbd>⏎</kbd> 发送 &nbsp; <kbd>⇧⏎</kbd> 换行
+              </span>
+            </>
+          )}
         </div>
 
         <div className="composer">

--- a/desktop/src/ui/live.tsx
+++ b/desktop/src/ui/live.tsx
@@ -70,57 +70,6 @@ export function LiveReasoning({ lines }: { lines: string[] }) {
   );
 }
 
-export function InterruptBar({
-  visible,
-  elapsedMs,
-  tps,
-  label,
-  onStop,
-}: {
-  visible: boolean;
-  elapsedMs: number;
-  tps?: number;
-  label: string;
-  onStop: () => void;
-}) {
-  if (!visible) return null;
-  return (
-    <div className="interrupt-bar">
-      <span className="pip" />
-      <span>
-        <span className="shimmer">{label}</span>
-      </span>
-      <span className="timer">{fmtElapsed(elapsedMs)}</span>
-      {tps !== undefined ? (
-        <span className="tps">
-          <span className="bars">
-            <span />
-            <span />
-            <span />
-            <span />
-            <span />
-          </span>
-          <span>{tps} t/s</span>
-        </span>
-      ) : null}
-      <button type="button" onClick={onStop}>
-        <I.stop size={11} /> 中断
-        <kbd
-          style={{
-            background: "oklch(100% 0 0 / 0.2)",
-            padding: "0 4px",
-            borderRadius: 3,
-            fontSize: 9,
-            marginLeft: 2,
-          }}
-        >
-          esc
-        </kbd>
-      </button>
-    </div>
-  );
-}
-
 export function ToolRunningCard({
   kind = "tool",
   name,


### PR DESCRIPTION
## Summary

- The "Reasoning Xs / 中断 esc" pill floated absolutely-positioned 88px above the bottom, centered over the input area — covering the top edge of the textarea AND duplicating the stop button the composer already shows (the send button flips red 中断 while busy). Reported in #896.
- Collapse the busy state into the existing `hint-row` above the textarea: animated pip + label (`Reasoning` or `Skill · <name>`) + elapsed timer on the left, `⏎/esc 中断` hint on the right. No floating overlay, no overlap, single canonical stop control.
- `InterruptBar` and the `.interrupt-bar` CSS block are removed. `@keyframes rise` is preserved — other modals (settings, cmdk) still reference it by name.

Before: floating pill obscures the input's top edge; two stop buttons (floating + inline).
After: thin status row inside the composer, no floating element, one stop button.

Closes #896

## Test plan

- [x] `tsc --noEmit` on `desktop/` — clean
- [x] `npm run build` (vite + tsc) — clean, no warnings beyond the pre-existing bundle-size note
- [x] `vitest run tests/comment-policy.test.ts` — pass
- [x] Grep for `InterruptBar` / `interrupt-bar` — no leftover references
- [ ] Smoke test: launch dev build, send a message → verify hint-row shows pip + label + timer + esc hint; press esc → aborts; send response settles → hint-row reverts to default hints. (Visual change is straightforward; reviewers / the reporter can verify.)
