### PR TITLE
feat(desktop): queue messages while the agent is busy, auto-send on turn-complete

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -221,6 +221,8 @@ type State = {
   memory: MemoryEntryInfo[];
   /** Live "skill running" indicator — set when a `skill_run` RPC dispatches, cleared on `$turn_complete`. */
   activeSkill: SkillOrigin | null;
+  /** Messages typed while busy=true — auto-sent FIFO once the current turn completes. Cleared on `clear`, `rpc_exit`, `session_loaded`. */
+  queuedSends: string[];
 };
 
 export type SessionFile = {
@@ -250,7 +252,10 @@ type Action =
   | { t: "resolve_revision"; id: number; verdict: RevisionVerdict }
   | { t: "dismiss_plan" }
   | { t: "mention_results"; results: MentionResults }
-  | { t: "mention_preview"; preview: MentionPreviewState };
+  | { t: "mention_preview"; preview: MentionPreviewState }
+  | { t: "enqueue_send"; text: string }
+  | { t: "dequeue_send"; index: number }
+  | { t: "shift_queued_send" };
 
 function reduce(state: State, action: Action): State {
   switch (action.t) {
@@ -296,6 +301,7 @@ function reduce(state: State, action: Action): State {
         ready: false,
         busy: false,
         activeSkill: null,
+        queuedSends: [],
         messages: [
           ...state.messages,
           { kind: "error", message: `reasonix exited (code ${action.code ?? "?"})` },
@@ -347,6 +353,7 @@ function reduce(state: State, action: Action): State {
         usage: zeroUsage(),
         sessionFiles: [],
         activeSkill: null,
+        queuedSends: [],
       };
     case "resolve_confirm":
       return {
@@ -410,6 +417,15 @@ function reduce(state: State, action: Action): State {
       return { ...state, mentionResults: action.results };
     case "mention_preview":
       return { ...state, mentionPreview: action.preview };
+    case "enqueue_send":
+      return { ...state, queuedSends: [...state.queuedSends, action.text] };
+    case "dequeue_send":
+      return {
+        ...state,
+        queuedSends: state.queuedSends.filter((_, i) => i !== action.index),
+      };
+    case "shift_queued_send":
+      return { ...state, queuedSends: state.queuedSends.slice(1) };
   }
 }
 
@@ -697,6 +713,7 @@ function applyIncoming(state: State, ev: IncomingEvent): State {
         },
         sessionFiles,
         activeSkill: null,
+        queuedSends: [],
       };
     }
     case "$error":
@@ -922,6 +939,7 @@ function TabRuntime({
     sessionFiles: [],
     memory: [],
     activeSkill: null,
+    queuedSends: [],
   });
   useLang();
   const [draft, setDraft] = useState("");
@@ -1078,6 +1096,14 @@ function TabRuntime({
   );
 
   const abort = useCallback(() => sendRpc({ cmd: "abort" }), [sendRpc]);
+
+  useEffect(() => {
+    if (state.busy || !state.ready || state.queuedSends.length === 0) return;
+    const next = state.queuedSends[0];
+    if (!next) return;
+    dispatch({ t: "shift_queued_send" });
+    send(next);
+  }, [state.busy, state.ready, state.queuedSends, send]);
 
   const resolveConfirm = useCallback(
     (id: number, response: ConfirmationChoice) => {
@@ -1627,6 +1653,12 @@ function TabRuntime({
                 onMentionPreview={previewMention}
                 onMentionPicked={markMentionPicked}
                 mentionResults={state.mentionResults}
+                queuedSends={state.queuedSends}
+                onQueueWhileBusy={(text) => {
+                  dispatch({ t: "enqueue_send", text });
+                  setDraft("");
+                }}
+                onDequeueSend={(index) => dispatch({ t: "dequeue_send", index })}
               />
             </>
           )}

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -2474,6 +2474,52 @@ button {
   flex-shrink: 0;
 }
 
+.composer-queued {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  padding: 4px 6px 6px;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 10.5px;
+}
+.composer-queued-label {
+  color: var(--muted-2);
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
+.composer-queue-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  max-width: 240px;
+  padding: 2px 4px 2px 8px;
+  border: 1px dashed var(--border-strong);
+  border-radius: 999px;
+  background: var(--panel);
+  color: var(--fg-2);
+}
+.composer-queue-chip .text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+.composer-queue-chip .x {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  cursor: pointer;
+  color: var(--muted);
+}
+.composer-queue-chip .x:hover {
+  background: var(--border);
+  color: var(--fg);
+}
+
 /* ---- queued tab-row indicator (multiple sessions running) ---- */
 .queue-strip {
   display: flex;

--- a/desktop/src/ui/composer.tsx
+++ b/desktop/src/ui/composer.tsx
@@ -125,6 +125,9 @@ export function Composer({
   onMentionPicked,
   mentionResults,
   workspaceDir,
+  queuedSends,
+  onQueueWhileBusy,
+  onDequeueSend,
 }: {
   draft: string;
   setDraft: (s: string) => void;
@@ -147,6 +150,11 @@ export function Composer({
   onMentionPicked?: (path: string) => void;
   mentionResults?: { nonce: number; query: string; results: string[] } | null;
   workspaceDir?: string;
+  /** Messages typed while busy=true; rendered as removable chips above the textarea and auto-drained FIFO on turn-complete. */
+  queuedSends?: string[];
+  /** Called when the user presses Enter while busy with a non-empty draft. Owns clearing the draft. */
+  onQueueWhileBusy?: (text: string) => void;
+  onDequeueSend?: (index: number) => void;
 }) {
   const [chips, setChips] = useState<Chip[]>([]);
   const [popup, setPopup] = useState<Popup>(null);
@@ -301,7 +309,11 @@ export function Composer({
     if (e.key === "Enter" && !e.shiftKey && !popup) {
       e.preventDefault();
       if (busy) {
-        onAbort();
+        const text = draft.trim();
+        if (text && onQueueWhileBusy) {
+          onQueueWhileBusy(text);
+          setChips([]);
+        }
       } else if (!disabled && draft.trim()) {
         onSend();
         setChips([]);
@@ -312,6 +324,22 @@ export function Composer({
   return (
     <div className="composer-wrap">
       <div className="composer-inner">
+        {queuedSends && queuedSends.length > 0 ? (
+          <div className="composer-queued">
+            <span className="composer-queued-label">排队 {queuedSends.length}</span>
+            {queuedSends.map((text, i) => (
+              <span key={i} className="composer-queue-chip" title={text}>
+                <span className="text">{text}</span>
+                {onDequeueSend ? (
+                  <span className="x" onClick={() => onDequeueSend(i)}>
+                    <I.x size={10} />
+                  </span>
+                ) : null}
+              </span>
+            ))}
+          </div>
+        ) : null}
+
         <div className="hint-row">
           {busy && busyLabel ? (
             <>
@@ -321,7 +349,7 @@ export function Composer({
                 <span className="composer-busy-time">{fmtElapsed(busyElapsedMs ?? 0)}</span>
               </span>
               <span>
-                <kbd>⏎</kbd>/<kbd>esc</kbd> 中断
+                <kbd>⏎</kbd> 排队 &nbsp;·&nbsp; <kbd>esc</kbd> 中断
               </span>
             </>
           ) : (


### PR DESCRIPTION
## Summary

- **Before** (#894): pressing Enter while the agent was busy aborted the current turn — there was no way to leave a follow-up without throwing away in-progress reasoning. The user had to wait out the whole turn before typing the next message.
- **After**: Enter while busy + non-empty draft enqueues the text and clears the textarea. Messages render as removable chips above the composer and drain FIFO when `$turn_complete` fires (routed through the existing `send(override)` path — same prefix cache, same user-card render). `esc` remains the canonical abort. The hint row right-side becomes `⏎ 排队 · esc 中断` so the new behavior is discoverable.

The whole change lives above the loop / streaming layer:
- `state.queuedSends: string[]` in the TabRuntime reducer + `enqueue_send` / `dequeue_send` / `shift_queued_send` actions.
- A small useEffect watches `(busy, ready, queuedSends.length)`; on the busy→idle edge with a non-empty queue, it shifts the head and calls `send(next)`. No new RPC, no streaming-layer changes.
- Queue is cleared on `clear`, `rpc_exit`, `$session_loaded` (queued text from session A shouldn't auto-fire in session B).

Closes #894

## Test plan

- [x] `tsc && vite build` — clean
- [x] `vitest run tests/comment-policy.test.ts` — pass
- [x] State-machine trace by hand: `send→busy=true` → user types `Enter` → queue grows; `$turn_complete` → busy false → effect drains head → `send(override)` → busy true; second drain on next turn complete; `esc` aborts the head turn but leaves the queue intact (next turn complete drains it); `/new` (`clear`) wipes the queue; switching session (`$session_loaded`) wipes the queue.
- [ ] Manual visual smoke not run in this session (Tauri dev requires the desktop window; the change is contained to props + reducer + CSS so structural confidence is high).
