### PR TITLE
fix(tui): /cwd should archive history, swap session name, and rebuild system for the new workspace

### DIFF
--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -81,6 +81,8 @@ export interface ChatOptions {
     reregisterTools?: (rootDir: string) => void;
     /** Async tail of `/cwd` — re-probe the new dir for a semantic index. */
     reBootstrapSemantic?: (rootDir: string) => Promise<{ enabled: boolean }>;
+    /** Notify the launcher that the workspace root just changed — lets the rebuildSystem closure see the new dir. */
+    onRootChange?: (newRoot: string) => void;
   };
   /** Skip the session picker — assume "Resume" (backwards-compatible auto-continue). */
   forceResume?: boolean;

--- a/src/cli/commands/code.tsx
+++ b/src/cli/commands/code.tsx
@@ -138,9 +138,14 @@ export async function codeCommand(opts: CodeOptions = {}): Promise<void> {
     }
   }
 
+  // The rebuilder is re-invoked on `/new` and `/cwd`. `currentRoot` is the live
+  // pointer; `/cwd` updates it via `onRootChange` so the rebuild picks up the
+  // new workspace's REASONIX.md / memory without restarting the loop.
+  let currentRoot = rootDir;
+  let semanticEnabled = semantic.enabled;
   const codeRebuildSystem = () =>
-    codeSystemPrompt(rootDir, {
-      hasSemanticSearch: semantic.enabled,
+    codeSystemPrompt(currentRoot, {
+      hasSemanticSearch: semanticEnabled,
       systemAppend: opts.systemAppend,
       systemAppendFile: systemAppendFileContents,
       modelId: resolvedModel,
@@ -158,7 +163,14 @@ export async function codeCommand(opts: CodeOptions = {}): Promise<void> {
       rootDir,
       jobs,
       reregisterTools: registerRooted,
-      reBootstrapSemantic,
+      reBootstrapSemantic: async (root: string) => {
+        const r = await reBootstrapSemantic(root);
+        semanticEnabled = r.enabled;
+        return r;
+      },
+      onRootChange: (newRoot: string) => {
+        currentRoot = newRoot;
+      },
     },
     mcp: readConfig().mcp,
     forceResume: opts.forceResume,

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -1,5 +1,5 @@
 import { type WriteStream, statSync } from "node:fs";
-import { resolve } from "node:path";
+import { basename, resolve } from "node:path";
 import { Box, Text, useStdin, useStdout } from "ink";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -63,6 +63,7 @@ import {
   loadSessionMeta,
   patchSessionMeta,
   renameSession,
+  sanitizeName,
 } from "../../memory/session.js";
 import type {
   ActiveModal,
@@ -249,6 +250,8 @@ export interface AppProps {
      * isn't blocked on disk I/O.
      */
     reBootstrapSemantic?: (rootDir: string) => Promise<{ enabled: boolean }>;
+    /** Notify the launcher that the workspace root just changed — lets the rebuildSystem closure see the new dir on the next /cwd. */
+    onRootChange?: (newRoot: string) => void;
   };
   /**
    * When `true`, suppress the auto-launch of the embedded web dashboard
@@ -2530,6 +2533,15 @@ function AppInner({
                 codeMode.reregisterTools?.(resolved);
                 setCurrentRootDir(resolved);
                 reloadHooks(resolved);
+                codeMode.onRootChange?.(resolved);
+                // Mirror code.tsx's launch-time formula so the session label tracks the workspace basename.
+                const newSessionName = `code-${sanitizeName(basename(resolved))}`;
+                loop.switchWorkspace({ sessionName: newSessionName });
+                agentStore.dispatch({
+                  type: "session.workspace.change",
+                  id: newSessionName,
+                  workspace: resolved,
+                });
                 const reBootstrap = codeMode.reBootstrapSemantic;
                 if (reBootstrap) {
                   void reBootstrap(resolved).then(
@@ -2547,7 +2559,11 @@ function AppInner({
                     },
                   );
                 }
-                return { ok: true, info: `▸ workspace switched to ${resolved}` };
+                return {
+                  ok: true,
+                  info: `▸ workspace switched to ${resolved} · session: ${newSessionName}`,
+                  clear: true,
+                };
               }
             : undefined,
           reloadMcp: mcpRuntime

--- a/src/cli/ui/slash/handlers/edits.ts
+++ b/src/cli/ui/slash/handlers/edits.ts
@@ -254,7 +254,7 @@ const cwd: SlashHandler = (args, _loop, ctx) => {
     };
   }
   const result = ctx.switchCwd(stripOuterQuotes(target));
-  return { info: result.info };
+  return result.clear ? { info: result.info, clear: true } : { info: result.info };
 };
 
 export const handlers: Record<string, SlashHandler> = {

--- a/src/cli/ui/slash/types.ts
+++ b/src/cli/ui/slash/types.ts
@@ -113,8 +113,8 @@ export interface SlashContext {
   markAllPlanStepsDone?: () => number;
 
   reloadHooks?: () => number;
-  /** Switch the workspace root mid-session — re-targets filesystem/shell/memory tools, hooks, at-mention walker. Code mode only. */
-  switchCwd?: (newPath: string) => { ok: boolean; info: string };
+  /** Switch the workspace root mid-session — re-targets filesystem/shell/memory tools, hooks, at-mention walker. Code mode only. `clear` mirrors `/new` (drops in-memory history + UI cards) so the previous workspace's chat doesn't contaminate the new one. */
+  switchCwd?: (newPath: string) => { ok: boolean; info: string; clear?: boolean };
   /** Diff config.mcp[] vs live bridges → add/close clients accordingly. Wired from chat.tsx mcpRuntime. */
   reloadMcp?: () => Promise<{
     added: string[];

--- a/src/cli/ui/state/events.ts
+++ b/src/cli/ui/state/events.ts
@@ -196,6 +196,12 @@ const sessionReset = z.object({
   type: z.literal("session.reset"),
 });
 
+const sessionWorkspaceChange = z.object({
+  type: z.literal("session.workspace.change"),
+  id: z.string().min(1),
+  workspace: z.string().min(1),
+});
+
 const languageChange = z.object({
   type: z.literal("language.change"),
   lang: z.string(),
@@ -345,6 +351,7 @@ export const AgentEventSchema = z.discriminatedUnion("type", [
   liveShow,
   tipShow,
   sessionReset,
+  sessionWorkspaceChange,
   planShow,
   planStepComplete,
   planDrop,

--- a/src/cli/ui/state/reducer.ts
+++ b/src/cli/ui/state/reducer.ts
@@ -208,6 +208,14 @@ export function reduce(state: AgentState, event: AgentEvent): AgentState {
     case "session.reset":
       return { ...state, cards: [], focusedCardId: null, toasts: [] };
 
+    case "session.workspace.change":
+      return state.session.id === event.id && state.session.workspace === event.workspace
+        ? state
+        : {
+            ...state,
+            session: { ...state.session, id: event.id, workspace: event.workspace },
+          };
+
     case "plan.show":
       return appendCard(state, {
         kind: "plan",

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -340,6 +340,32 @@ export class CacheFirstLoop {
     return { dropped, archived, systemRebuilt };
   }
 
+  /** `/cwd` follow-through — archives the previous session, drops in-memory state, repoints sessionName, and rebuilds the system prompt against whatever the rebuilder closure now resolves (the caller is expected to have already updated the root the closure reads). */
+  switchWorkspace(opts: { sessionName: string }): { dropped: number; archived: string | null } {
+    const dropped = this.log.length;
+    let archived: string | null = null;
+    if (this.sessionName) {
+      try {
+        archived = archiveSession(this.sessionName);
+        if (archived === null) rewriteSession(this.sessionName, []);
+      } catch {
+        /* disk issue shouldn't block the in-memory swap */
+      }
+    }
+    this.log.compactInPlace([]);
+    this.scratch.reset();
+    this._inflight.clear();
+    this.sessionName = opts.sessionName;
+    if (this._rebuildSystem) {
+      try {
+        this.prefix.replaceSystem(this._rebuildSystem());
+      } catch {
+        /* builder threw — keep prior system rather than crash /cwd */
+      }
+    }
+    return { dropped, archived };
+  }
+
   configure(opts: ReconfigurableOptions): void {
     if (opts.model !== undefined) this.model = opts.model;
     if (opts.stream !== undefined) {

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -1462,6 +1462,60 @@ describe("CacheFirstLoop - setBudget / clearLog / retryLastUser / proArm", () =>
     expect(loop.prefix.system).toBe("keep-me");
   });
 
+  it("switchWorkspace drops the log, repoints sessionName, and rebuilds system via the rebuilder closure", () => {
+    const client = makeClient([{ content: "ok" }]);
+    let currentSystem = "system-tmp-a";
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: currentSystem }),
+      stream: false,
+      session: "code-tmp-a",
+      rebuildSystem: () => currentSystem,
+    });
+    loop.log.append({ role: "user", content: "from tmp-a" });
+    loop.log.append({ role: "assistant", content: "ok" });
+    loop.scratch.notes = ["stale"];
+    expect(loop.sessionName).toBe("code-tmp-a");
+    expect(loop.log.length).toBe(2);
+
+    currentSystem = "system-tmp-b";
+    const { dropped } = loop.switchWorkspace({ sessionName: "code-tmp-b" });
+    expect(dropped).toBe(2);
+    expect(loop.log.length).toBe(0);
+    expect(loop.scratch.notes).toEqual([]);
+    expect(loop.sessionName).toBe("code-tmp-b");
+    expect(loop.prefix.system).toBe("system-tmp-b");
+  });
+
+  it("switchWorkspace is a noop on log content when there's nothing to drop", () => {
+    const client = makeClient([{ content: "ok" }]);
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s" }),
+      stream: false,
+      session: "code-old",
+    });
+    const { dropped } = loop.switchWorkspace({ sessionName: "code-new" });
+    expect(dropped).toBe(0);
+    expect(loop.sessionName).toBe("code-new");
+  });
+
+  it("switchWorkspace swallows rebuilder errors and keeps the prior system", () => {
+    const client = makeClient([{ content: "ok" }]);
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "keep-me" }),
+      stream: false,
+      session: "code-a",
+      rebuildSystem: () => {
+        throw new Error("rebuilder went sideways");
+      },
+    });
+    loop.switchWorkspace({ sessionName: "code-b" });
+    expect(loop.prefix.system).toBe("keep-me");
+    expect(loop.sessionName).toBe("code-b");
+  });
+
   it("retryLastUser returns null when no user message exists", () => {
     const client = makeClient([{ content: "ok" }]);
     const loop = new CacheFirstLoop({


### PR DESCRIPTION
## Summary

`/cwd ../tmp-b` re-pointed filesystem / shell / memory / hook tools at the new directory but left **everything stateful** (in-memory chat log, on-disk session transcript, system prompt, status-bar session label) referencing the OLD workspace. Two real problems #902 captures:

- The model kept reasoning over messages that referenced paths from `tmp-a` — cross-workspace contamination on every follow-up.
- The status bar still showed `code-tmp-a` after switching, so users couldn't tell which workspace the active session belonged to.

This patch wires the missing follow-through:

- `CacheFirstLoop.switchWorkspace({ sessionName })` — archives the old session transcript (same path `/new` uses), drops the in-memory log, repoints `sessionName`, re-runs the system-prompt builder.
- `code.tsx` wraps `rootDir` and `semantic.enabled` in `let` bindings and exposes `onRootChange` on `codeMode`, so the rebuilder closure resolves the *live* workspace at call time (otherwise the closure would still produce a system prompt rooted at the launch dir).
- `App.tsx`'s `switchCwd` callback now calls `onRootChange` + `loop.switchWorkspace` + dispatches a new `session.workspace.change` event so the agent store's `SessionInfo.id` / `.workspace` update — that's what the status bar reads.
- The slash handler propagates `clear: true` so `applySlashResult` mirrors `/new`'s UI reset (scrollback, pending edits, modals).

Closes #902

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `vitest run` — 2906 passed, 3 skipped (+3 new `switchWorkspace` cases covering log drop / sessionName swap / rebuilder + the rebuilder-throws path)
- [x] Desktop `tsc && vite build` — clean (this PR doesn't touch the Tauri client, but the rebuilt CSS chunk size hash confirms no accidental drift)
- [ ] Manual repro: from `code-tmp-a`, send a message; `/cwd ../tmp-b`; confirm scrollback resets, status bar reads `code-tmp-b`, next message has no `tmp-a` paths in context.
