### PR TITLE
fix(desktop): make session-delete right-click discardable instead of one-shot

### DIFF
--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -564,6 +564,68 @@ button {
   color: var(--muted);
 }
 
+.session-delete-popover {
+  position: fixed;
+  z-index: 80;
+  background: var(--card);
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  box-shadow: var(--shadow-lg);
+  padding: 10px 12px 12px;
+  min-width: 220px;
+  max-width: 280px;
+  font-size: 12px;
+  color: var(--fg);
+  animation: rise 0.16s ease-out;
+}
+.session-delete-popover .msg {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 10px;
+  color: var(--fg-2);
+  line-height: 1.4;
+}
+.session-delete-popover .msg .name {
+  color: var(--fg);
+  font-weight: 500;
+  word-break: break-all;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px;
+}
+.session-delete-popover .actions {
+  display: flex;
+  gap: 6px;
+  justify-content: flex-end;
+}
+.session-delete-popover button {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 12px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-family: inherit;
+  cursor: pointer;
+}
+.session-delete-popover button.cancel {
+  background: var(--panel);
+  color: var(--fg-2);
+  border: 1px solid var(--border);
+}
+.session-delete-popover button.cancel:hover {
+  background: var(--border);
+  color: var(--fg);
+}
+.session-delete-popover button.confirm {
+  background: var(--danger);
+  color: oklch(99% 0 0);
+  border: 1px solid transparent;
+}
+.session-delete-popover button.confirm:hover {
+  background: oklch(58% 0.18 22);
+}
+
 .side-foot {
   padding: 8px;
   border-top: 1px solid var(--border);

--- a/desktop/src/ui/sidebar.tsx
+++ b/desktop/src/ui/sidebar.tsx
@@ -1,6 +1,13 @@
-import { useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { I } from "../icons";
 import type { SessionInfo } from "../App";
+
+type PendingDelete = {
+  name: string;
+  pretty: string;
+  x: number;
+  y: number;
+};
 
 function prettyName(s: SessionInfo): string {
   if (s.summary && s.summary.trim()) return s.summary.trim();
@@ -43,6 +50,7 @@ export function Sidebar({
   onOpenCommands: () => void;
 }) {
   const [query, setQuery] = useState("");
+  const [pendingDelete, setPendingDelete] = useState<PendingDelete | null>(null);
   const filtered = query
     ? sessions.filter((s) => {
         const q = query.toLowerCase();
@@ -51,6 +59,23 @@ export function Sidebar({
         );
       })
     : sessions;
+
+  useEffect(() => {
+    if (!pendingDelete) return;
+    const onMouseDown = (e: MouseEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (!target?.closest(".session-delete-popover")) setPendingDelete(null);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setPendingDelete(null);
+    };
+    window.addEventListener("mousedown", onMouseDown);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("mousedown", onMouseDown);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [pendingDelete]);
 
   return (
     <aside className="sidebar">
@@ -123,7 +148,12 @@ export function Sidebar({
                 onClick={() => onLoadSession(s.name)}
                 onContextMenu={(e) => {
                   e.preventDefault();
-                  if (confirm(`删除会话 "${prettyName(s)}"?`)) onDeleteSession(s.name);
+                  setPendingDelete({
+                    name: s.name,
+                    pretty: prettyName(s),
+                    x: e.clientX,
+                    y: e.clientY,
+                  });
                 }}
                 role="button"
                 tabIndex={0}
@@ -165,6 +195,73 @@ export function Sidebar({
           <span className="right">⌘,</span>
         </div>
       </div>
+
+      {pendingDelete ? (
+        <SessionDeletePopover
+          target={pendingDelete}
+          onCancel={() => setPendingDelete(null)}
+          onConfirm={() => {
+            onDeleteSession(pendingDelete.name);
+            setPendingDelete(null);
+          }}
+        />
+      ) : null}
     </aside>
+  );
+}
+
+function SessionDeletePopover({
+  target,
+  onCancel,
+  onConfirm,
+}: {
+  target: PendingDelete;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  const cancelRef = useRef<HTMLButtonElement>(null);
+  const [pos, setPos] = useState<{ left: number; top: number }>({
+    left: target.x,
+    top: target.y,
+  });
+
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    const pad = 8;
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+    let left = target.x;
+    let top = target.y;
+    if (left + rect.width + pad > vw) left = Math.max(pad, vw - rect.width - pad);
+    if (top + rect.height + pad > vh) top = Math.max(pad, vh - rect.height - pad);
+    if (left !== pos.left || top !== pos.top) setPos({ left, top });
+    cancelRef.current?.focus();
+  }, [target.x, target.y, pos.left, pos.top]);
+
+  return (
+    <div
+      ref={ref}
+      className="session-delete-popover"
+      role="dialog"
+      aria-modal="true"
+      style={{ left: pos.left, top: pos.top }}
+    >
+      <div className="msg">
+        删除会话
+        <span className="name">{target.pretty}</span>
+      </div>
+      <div className="actions">
+        <button ref={cancelRef} type="button" className="cancel" onClick={onCancel}>
+          取消
+        </button>
+        <button type="button" className="confirm" onClick={onConfirm}>
+          <I.x size={11} />
+          删除
+        </button>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

User feedback: right-clicking a session in the sidebar fires a native `window.confirm()` and deletes the session on Enter — too abrupt, easy to misfire on accidental right-clicks.

Replace the blocking native dialog with a discardable in-app popover anchored at the cursor:

- Cancel + delete buttons, cancel autofocused so Enter on an accidental popover *cancels* rather than deletes.
- Click anywhere outside the popover or hit `Esc` to dismiss without touching the session.
- `useLayoutEffect` measures the popover and clamps it inside the viewport, so right-clicks near the window edge don't push it off-screen.
- Confirm button uses the existing `--danger` color; cancel uses the muted panel color — the destructive option is visually distinct.
- Right-click gesture is preserved (no need to retrain muscle memory). The fix is purely making the action surface discardable.

Net diff: -2 / +161, just `desktop/src/ui/sidebar.tsx` and `desktop/src/styles.css`.

## Test plan

- [x] `tsc && vite build` — clean
- [x] `vitest run tests/comment-policy.test.ts` — pass
- [ ] Manual smoke: right-click a session → popover renders at cursor → click outside / Esc dismisses → click "删除" deletes the session.
