### PR TITLE
fix(desktop): drop -50% X translate from @keyframes rise so popovers don't snap horizontally

### DIFF
--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -2506,8 +2506,8 @@ button {
 }
 
 @keyframes rise {
-  from { opacity: 0; transform: translate(-50%, 8px); }
-  to { opacity: 1; transform: translate(-50%, 0); }
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
 }
 
 .composer-busy-status {


### PR DESCRIPTION
## Summary

User reported all modal/popover open animations look "weird" — they slide in horizontally before snapping into place. Tracked it to leftover state from PR #898 (interrupt-bar removal).

`@keyframes rise` was defined alongside the interrupt-bar's CSS, and used `translate(-50%, ...)` because the bar needed `transform: translateX(-50%)` to stay centered while the keyframe drove its Y motion. When that bar was removed in #898, the keyframe was kept (still referenced by the settings modal, cmdk, plan modal, and now #906's session-delete popover) but its hardcoded `-50%` X offset went with it.

For every consumer that isn't centered, that means: animate in offset -50% of width to the left, then snap right when the animation ends. Reads as a horizontal pop, not a clean fade-up.

Switch the keyframe to a pure `translateY`. All current users want the same vertical slide-up + fade-in; none have a baseline horizontal transform that depended on the keyframe preserving it.

```diff
 @keyframes rise {
-  from { opacity: 0; transform: translate(-50%, 8px); }
-  to { opacity: 1; transform: translate(-50%, 0); }
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
 }
```

## Test plan

- [x] `tsc && vite build` — clean
- [ ] Manual smoke: open settings modal, ⌘K cmdk, plan modal, right-click a session — each should slide up + fade in vertically, no horizontal flicker.
