### PR TITLE
fix(desktop): abort button now actually halts the in-flight turn

### DIFF
--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -824,7 +824,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
   }
 
   async function closeTab(tab: Tab): Promise<void> {
-    tab.aborter?.abort();
+    abortTurn(tab);
     try {
       await tab.toolset?.jobs.shutdown();
     } catch {
@@ -897,7 +897,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
       emitSettings(tab);
       return;
     }
-    tab.aborter?.abort();
+    abortTurn(tab);
     try {
       await tab.toolset?.jobs.shutdown();
     } catch {
@@ -932,6 +932,11 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
       if (t.pendingGateIds.delete(id)) return t;
     }
     return undefined;
+  }
+
+  function abortTurn(tab: Tab): void {
+    tab.aborter?.abort();
+    tab.runtime?.loop.abort();
   }
 
   function cancelPendingGates(tab: Tab): void {
@@ -1246,7 +1251,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
     }
 
     if (msg.cmd === "abort") {
-      tab.aborter?.abort();
+      abortTurn(tab);
       cancelPendingGates(tab);
       return;
     }
@@ -1342,7 +1347,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
       try {
         const records = loadSessionMessages(msg.name);
         const meta = loadSessionMeta(msg.name);
-        tab.aborter?.abort();
+        abortTurn(tab);
         cancelPendingGates(tab);
         tab.currentSession = msg.name;
         if (tab.runtime) tab.runtime = buildRuntimeFor(tab);
@@ -1365,7 +1370,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
       return;
     }
     if (msg.cmd === "new_chat") {
-      tab.aborter?.abort();
+      abortTurn(tab);
       cancelPendingGates(tab);
       tab.currentSession = mintSessionFor(tab.rootDir);
       if (tab.runtime) tab.runtime = buildRuntimeFor(tab);


### PR DESCRIPTION
## Summary

- Pressing the desktop interrupt button (or Esc) only flipped `tab.aborter`, a controller that's checked between events yielded by `rt.loop.step()`. When the underlying DeepSeek stream was blocked on a network read, no events yielded — the abort flag never got read and the "Reasoning" timer kept counting forever.
- The loop owns a second `AbortController` (`_turnAbort`) that's threaded directly into `client.stream({ signal })`. The TUI has always called `loop.abort()` to fire it; the desktop transport just never wired it up.
- New `abortTurn(tab)` helper fires both controllers, and the five sites that needed cancellation now go through it: `abort` cmd, `new_chat`, `session_load`, `switchWorkspace`, `closeTab`. The loop's existing reset of `_turnAbort` inside `step()`'s aborted path keeps the next turn clean.

Closes #905

## Test plan

- [x] `npm run verify` (2906 tests, all green)
- [ ] Manual: start a long Reasoning turn, press the stop button, confirm the turn unwinds within a second
- [ ] Manual: during a Reasoning turn, click a different session in the sidebar — confirm it loads instead of hanging
