### PR TITLE
fix(desktop): render markdown code blocks properly (no-lang fences + chrome CSS)

### DIFF
--- a/desktop/src/Markdown.tsx
+++ b/desktop/src/Markdown.tsx
@@ -7,6 +7,7 @@ import {
   createContext,
   isValidElement,
   memo,
+  type ReactElement,
   type ReactNode,
   useContext,
   useState,
@@ -140,15 +141,17 @@ export const Markdown = memo(function Markdown({ source }: { source: string }) {
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={{
-          pre: ({ children }) => <>{children}</>,
-          code: ({ className, children }) => {
-            const langMatch = /language-([\w-]+)/.exec(className ?? "");
-            const text = String(children).replace(/\n$/, "");
-            if (!langMatch) {
-              return <code className={className}>{children}</code>;
-            }
-            return <CodeBlock lang={langMatch[1] ?? "text"} text={text} />;
+          pre: ({ children }) => {
+            const codeEl = Children.toArray(children).find(
+              (c): c is ReactElement<{ className?: string; children?: ReactNode }> =>
+                isValidElement(c) && c.type === "code",
+            );
+            if (!codeEl) return <pre>{children}</pre>;
+            const text = String(codeEl.props.children ?? "").replace(/\n$/, "");
+            const lang = /language-([\w-]+)/.exec(codeEl.props.className ?? "")?.[1] ?? "text";
+            return <CodeBlock lang={lang} text={text} />;
           },
+          code: ({ className, children }) => <code className={className}>{children}</code>,
           a: ({ href, children }) => <SafeLink href={href}>{children}</SafeLink>,
           p: ({ children }) => <p>{withFilePills(children)}</p>,
           li: ({ children }) => <li>{withFilePills(children)}</li>,

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -887,6 +887,78 @@ button {
   margin: 6px 0;
 }
 
+.markdown .codeblock {
+  margin: 10px 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-2);
+  overflow: hidden;
+}
+.markdown .codeblock-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 5px 12px;
+  background: var(--panel);
+  border-bottom: 1px solid var(--border);
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px;
+  color: var(--muted);
+}
+.markdown .codeblock-lang {
+  text-transform: lowercase;
+  letter-spacing: 0.02em;
+}
+.markdown .copy-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px;
+  color: var(--muted);
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  cursor: pointer;
+}
+.markdown .copy-btn:hover {
+  color: var(--fg-2);
+  border-color: var(--border-strong);
+}
+.markdown .copy-btn.done {
+  color: var(--success);
+  border-color: var(--success-soft);
+}
+.markdown .codeview {
+  margin: 0;
+  padding: 10px 12px;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 12.5px;
+  line-height: 1.55;
+  overflow-x: auto;
+  white-space: pre;
+  color: var(--fg);
+}
+.markdown .codeview-line {
+  display: flex;
+  gap: 14px;
+  min-width: 0;
+}
+.markdown .codeview-line-num {
+  flex: 0 0 auto;
+  min-width: 2ch;
+  text-align: right;
+  color: var(--muted-2);
+  user-select: none;
+}
+.markdown .codeview-line-content {
+  flex: 1 1 auto;
+  min-width: 0;
+  white-space: pre;
+}
+
 /* ============================================================
    styles part 3 — cards
    ============================================================ */


### PR DESCRIPTION
## Summary

Two real breaks in how the desktop renders fenced code in assistant messages.

1. **Langless fenced blocks rendered as inline `<code>`.** ` ```\nfoo\n``` ` (no `ts`/`py`/etc.) only matched the `code` override, which gated `CodeBlock` on a `language-*` class — and the `pre` override had already stripped the `<pre>` wrapper. Multi-line content collapsed onto a single line as inline pills. The dispatch now lives in `pre`: it finds the inner `<code>` child, pulls a lang off the className if present, falls back to `"text"`, and routes everything through `CodeBlock` + `CodeView` so whitespace and the copy button survive. `code` is now purely the inline path.

2. **The CodeBlock chrome had no CSS at all.** `.codeblock`, `.codeblock-head`, `.codeblock-lang`, `.copy-btn`, `.codeview`, `.codeview-line`, `.codeview-line-num`, `.codeview-line-content` were emitted by `Markdown.tsx` / `CodeView.tsx` but never appeared in `styles.css` — code blocks rendered as a column of prism-colored tokens with no border, no background, no header bar, and the copy button as a browser default. Added the missing rules under `.markdown …` so they only target the md-rendered tree (cards' own pre/code styles untouched).

Inline `` `code` `` keeps its existing `.msg-text code` pill style since the new selectors are all scoped to `.markdown .…` and `CodeBlock`'s output contains no nested `<code>` element to collide with.

## Test plan

- [x] `npm run verify` (2906 tests pass; pre-push gate)
- [x] desktop `tsc --noEmit` clean
- [x] desktop `vite build` clean
- [ ] Manual: ask the agent for code in a fenced block with a language tag — expect a bordered panel with `ts` / `py` / etc. in the header, copy button, line numbers, syntax colors
- [ ] Manual: same with a langless ` ``` ` block — expect the same chrome with `text` in the header and whitespace preserved
- [ ] Manual: inline `` `foo` `` in a paragraph — expect the existing pill style, unchanged
