### PR TITLE
fix(i18n): mop up 4 remaining hardcoded strings in stats/run/sessions

### DIFF
--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -11,6 +11,7 @@ import {
   saveApiKey,
 } from "../../config.js";
 import { loadDotenv } from "../../env.js";
+import { t } from "../../i18n/index.js";
 import { CacheFirstLoop, DeepSeekClient, ImmutablePrefix } from "../../index.js";
 import { McpClient } from "../../mcp/client.js";
 import { preflightStdioSpec } from "../../mcp/preflight.js";
@@ -43,10 +44,7 @@ async function ensureApiKey(): Promise<string> {
   if (existing) return existing;
 
   if (!stdin.isTTY) {
-    process.stderr.write(
-      "DEEPSEEK_API_KEY is not set and stdin is not a TTY (cannot prompt).\n" +
-        "Set the env var, or run `reasonix chat` once interactively to save a key.\n",
-    );
+    process.stderr.write(t("run.missingApiKey"));
     process.exit(1);
   }
 
@@ -134,7 +132,7 @@ export async function runCommand(opts: RunOptions): Promise<void> {
         // not even touch.
         await mcp?.close().catch(() => undefined);
         process.stderr.write(
-          `${formatMcpLifecycleEvent({ state: "failed", name: label, reason: (err as Error).message })}\n  → run \`reasonix setup\` to remove broken entries from your saved config.\n`,
+          `${formatMcpLifecycleEvent({ state: "failed", name: label, reason: (err as Error).message })}\n  → ${t("mcpLifecycle.failedSetupConfigHint")}\n`,
         );
       }
     }

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -132,7 +132,7 @@ export async function runCommand(opts: RunOptions): Promise<void> {
         // not even touch.
         await mcp?.close().catch(() => undefined);
         process.stderr.write(
-          `${formatMcpLifecycleEvent({ state: "failed", name: label, reason: (err as Error).message })}\n  → ${t("mcpLifecycle.failedSetupConfigHint")}\n`,
+          `${formatMcpLifecycleEvent({ state: "failed", name: label, reason: (err as Error).message })}\n  ${t("mcpLifecycle.failedSetupConfigHint")}\n`,
         );
       }
     }

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -1,3 +1,4 @@
+import { t } from "../../i18n/index.js";
 import { listSessions, loadSessionMessages, sessionPath } from "../../index.js";
 import type { ChatMessage } from "../../index.js";
 
@@ -19,9 +20,7 @@ export function sessionsCommand(opts: SessionsOptions): void {
 function listAll(): void {
   const items = listSessions();
   if (items.length === 0) {
-    console.log(
-      "no saved sessions yet — run `reasonix chat` (sessions are auto-saved unless --no-session).",
-    );
+    console.log(t("sessions.emptyHint"));
     return;
   }
   console.log("Saved sessions (~/.reasonix/sessions/):");

--- a/src/cli/commands/stats.ts
+++ b/src/cli/commands/stats.ts
@@ -1,6 +1,7 @@
 /** `reasonix stats [path]` — path arg switches to per-transcript mode; default is the cross-session dashboard. */
 
 import { existsSync, readFileSync } from "node:fs";
+import { t } from "../../i18n/index.js";
 import {
   type UsageAggregate,
   type UsageBucket,
@@ -62,8 +63,8 @@ function dashboard(opts: StatsOptions): void {
     console.log("");
     console.log(`  ${path}`);
     console.log("");
-    console.log("run `reasonix chat`, `reasonix code`, or `reasonix run <task>` — every turn");
-    console.log("appends one line to the log and `reasonix stats` will roll it up.");
+    console.log(t("stats.usageHint"));
+    console.log(t("stats.usageDetail"));
     return;
   }
 

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -34,6 +34,19 @@ export const EN: TranslationSchema = {
     update: "Check for a newer Reasonix and install it.",
     index: "Build (or incrementally refresh) a local semantic search index.",
   },
+  stats: {
+    usageHint: "run `reasonix chat`, `reasonix code`, or `reasonix run <task>` — every turn",
+    usageDetail: "appends one line to the log and `reasonix stats` will roll it up.",
+  },
+  run: {
+    missingApiKey:
+      "DEEPSEEK_API_KEY is not set and stdin is not a TTY (cannot prompt).\n" +
+      "Set the env var, or run `reasonix chat` once interactively to save a key.\n",
+  },
+  sessions: {
+    emptyHint:
+      "no saved sessions yet — run `reasonix chat` (sessions are auto-saved unless --no-session).",
+  },
   ui: {
     welcome: "Run `reasonix` any time to start chatting — your settings are remembered.",
     taglineChat: "DeepSeek-native agent",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -34,6 +34,16 @@ export interface TranslationSchema {
     update: string;
     index: string;
   };
+  stats: {
+    usageHint: string;
+    usageDetail: string;
+  };
+  run: {
+    missingApiKey: string;
+  };
+  sessions: {
+    emptyHint: string;
+  };
   ui: {
     welcome: string;
     taglineChat: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -34,6 +34,19 @@ export const zhCN: TranslationSchema = {
     update: "检查较新版本的 Reasonix 并安装。",
     index: "构建（或增量刷新）本地语义搜索索引。",
   },
+  stats: {
+    usageHint: "运行 `reasonix chat`、`reasonix code` 或 `reasonix run <task>` — 每次对话都会记录",
+    usageDetail: "每次对话在日志中追加一行，`reasonix stats` 会将其汇总统计。",
+  },
+  run: {
+    missingApiKey:
+      "未设置 DEEPSEEK_API_KEY 且标准输入不是 TTY（无法交互式输入）。\n" +
+      "请设置环境变量，或先运行 `reasonix chat` 交互一次以保存密钥。\n",
+  },
+  sessions: {
+    emptyHint:
+      "暂无已保存的会话 — 运行 `reasonix chat`（会话会自动保存，除非使用了 --no-session）。",
+  },
   ui: {
     welcome: "随时运行 `reasonix` 开始聊天 — 您的设置将被记住。",
     taglineChat: "DeepSeek 原生智能体",


### PR DESCRIPTION
## Summary

补漏 4 处 CLI 硬编码字符串。

**CLI** (3 files):
- `stats.ts` — 两条 CLI 用法提示改用 `t()`
- `run.ts` — API key 缺失提示改用 `t()`，MCP hint 复用已有 key
- `sessions.ts` — 空会话提示改用 `t()`

**i18n**:
- `src/i18n/EN.ts` + `zh-CN.ts`: +3 sections (stats, run, sessions), 4 keys

**Test plan**
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `grep -rn 'run \\\\`reasonix\\|no saved sessions' src/cli/commands/` — clean