### PR TITLE
feat(ui): add /cwd path tab-completion with async directory picker

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -1260,6 +1260,7 @@ function AppInner({
     slashArgMatches,
     slashArgSelected,
     setSlashArgSelected,
+    slashArgPathCandidates,
     pickSlashArg,
   } = useCompletionPickers({
     input,
@@ -1637,9 +1638,10 @@ function AppInner({
     }
 
     // Slash-argument picker. Fires inside `/<cmd> <partial>` — either
-    // a file picker (for /edit), enum picker (for /preset, /model,
+    // a path picker (for /cwd), enum picker (for /preset, /model,
     // /plan, /branch, /harvest), or hint-only row. Navigation + Tab
-    // substitute the highlighted value at the arg's offset.
+    // substitute the highlighted value at the arg's offset. For path
+    // completers, directories drill (trailing `/`), files commit.
     if (slashArgMatches && slashArgMatches.length > 0) {
       if (key.upArrow) {
         setSlashArgSelected((i) => Math.max(0, i - 1));
@@ -1651,7 +1653,11 @@ function AppInner({
       }
       if (key.tab) {
         const sel = slashArgMatches[slashArgSelected] ?? slashArgMatches[0];
-        if (sel) pickSlashArg(sel);
+        if (sel) {
+          const candidate =
+            slashArgPathCandidates?.[slashArgSelected] ?? slashArgPathCandidates?.[0];
+          pickSlashArg(sel, candidate?.isDir);
+        }
         return;
       }
     }
@@ -2280,7 +2286,17 @@ function AppInner({
       // /model, /plan, …) we splice without trailing space; those
       // commands take no further args, so the user presses Enter a
       // second time to run.
-      if (slashArgMatches && slashArgMatches.length > 0 && slashArgContext) {
+      //
+      // When the partial ends with `/` (browse mode, e.g. after Tab-
+      // completing a directory in `/cwd`), the user has already landed
+      // on the path they want — skip the picker and let Enter submit
+      // the command directly.
+      if (
+        slashArgMatches &&
+        slashArgMatches.length > 0 &&
+        slashArgContext &&
+        !slashArgContext.partial.endsWith("/")
+      ) {
         const sel = slashArgMatches[slashArgSelected] ?? slashArgMatches[0];
         if (sel) {
           pickSlashArg(sel);
@@ -4176,6 +4192,7 @@ function AppInner({
                             spec={slashArgContext.spec}
                             kind={slashArgContext.kind}
                             partial={slashArgContext.partial}
+                            pathCandidates={slashArgPathCandidates}
                           />
                         ) : null}
                       </Box>

--- a/src/cli/ui/SlashArgPicker.tsx
+++ b/src/cli/ui/SlashArgPicker.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { t } from "../../i18n/index.js";
 import type { SlashCommandSpec } from "./slash.js";
 import { GLYPH, useColor } from "./theme.js";
+import type { AtPickerEntry } from "./useCompletionPickers.js";
 
 export interface SlashArgPickerProps {
   /**
@@ -24,6 +25,11 @@ export interface SlashArgPickerProps {
   kind: "picker" | "hint";
   /** The user's partial input — shown in the "no matches" hint. */
   partial: string;
+  /**
+   * When the completer is `"path"`, carries the rich entries (with `isDir`)
+   * so the picker can render a trailing `/` on directories.
+   */
+  pathCandidates?: readonly AtPickerEntry[] | null;
 }
 
 /**
@@ -37,6 +43,7 @@ export function SlashArgPicker({
   spec,
   kind,
   partial,
+  pathCandidates,
 }: SlashArgPickerProps): React.ReactElement | null {
   const color = useColor();
   const headerRow = (
@@ -89,9 +96,13 @@ export function SlashArgPicker({
       {hiddenAbove > 0 ? (
         <Text dimColor>{t("slashArgPicker.above", { hidden: hiddenAbove })}</Text>
       ) : null}
-      {shown.map((value, i) => (
-        <ArgRow key={value} value={value} isSelected={windowStart + i === selectedIndex} />
-      ))}
+      {shown.map((value, i) => {
+        const idx = windowStart + i;
+        const isDir = pathCandidates?.[idx]?.isDir ?? false;
+        return (
+          <ArgRow key={value} value={value} isSelected={idx === selectedIndex} isDir={isDir} />
+        );
+      })}
       {hiddenBelow > 0 ? (
         <Text dimColor>{t("slashArgPicker.below", { hidden: hiddenBelow })}</Text>
       ) : null}
@@ -102,7 +113,15 @@ export function SlashArgPicker({
   );
 }
 
-function ArgRow({ value, isSelected }: { value: string; isSelected: boolean }) {
+function ArgRow({
+  value,
+  isSelected,
+  isDir,
+}: {
+  value: string;
+  isSelected: boolean;
+  isDir: boolean;
+}) {
   const color = useColor();
   return (
     <Box>
@@ -112,6 +131,7 @@ function ArgRow({ value, isSelected }: { value: string; isSelected: boolean }) {
       <Text color={isSelected ? color.user : color.info} bold={isSelected} dimColor={!isSelected}>
         {value}
       </Text>
+      {isDir ? <Text dimColor>/</Text> : null}
     </Box>
   );
 }

--- a/src/cli/ui/slash/commands.ts
+++ b/src/cli/ui/slash/commands.ts
@@ -276,6 +276,7 @@ export const SLASH_COMMANDS: readonly SlashCommandSpec[] = [
       "switch the workspace root mid-session — re-points fs / shell / memory tools, reloads project hooks, refreshes the at-mention walker",
     contextual: "code",
     aliases: ["sandbox"],
+    argCompleter: "path",
   },
 
   {

--- a/src/cli/ui/slash/types.ts
+++ b/src/cli/ui/slash/types.ts
@@ -166,8 +166,8 @@ export interface SlashCommandSpec {
   group: SlashGroup;
   /** If the command takes args, hint text shown after the name. */
   argsHint?: string;
-  /** First-arg picker source — file paths intentionally absent (use `@path` mentions instead). */
-  argCompleter?: "models" | "mcp-resources" | "mcp-prompts" | "skills" | readonly string[];
+  /** First-arg picker source. `"path"` async-lists the filesystem for directory completion (used by `/cwd`). */
+  argCompleter?: "models" | "mcp-resources" | "mcp-prompts" | "skills" | "path" | readonly string[];
   /** Alternate names — typing any of these resolves to `cmd` for dispatch / suggestion / arg-context. */
   aliases?: readonly string[];
 }

--- a/src/cli/ui/useCompletionPickers.ts
+++ b/src/cli/ui/useCompletionPickers.ts
@@ -1,3 +1,4 @@
+import { isAbsolute, parse, relative, resolve } from "node:path";
 import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react";
 import {
   type DirEntry,
@@ -73,7 +74,11 @@ export interface UseCompletionPickersResult {
   slashArgMatches: readonly string[] | null;
   slashArgSelected: number;
   setSlashArgSelected: React.Dispatch<React.SetStateAction<number>>;
-  pickSlashArg: (chosen: string) => void;
+  /** When the completer is `"path"`, carries the rich entries (with `isDir`) so
+   *  callers can distinguish directories from files for drill-down vs commit. */
+  slashArgPathCandidates: readonly AtPickerEntry[] | null;
+  /** `isDir` controls drill vs. commit for path completers; ignored for other types. */
+  pickSlashArg: (chosen: string, isDir?: boolean) => void;
 }
 
 const SEARCH_DEBOUNCE_MS = 80;
@@ -191,6 +196,16 @@ export function useCompletionPickers({
     if (slashMatches !== null) return null;
     return detectSlashArgContext(input, !!codeMode);
   }, [input, slashMatches, codeMode]);
+
+  // Path completion: async directory listing for `argCompleter: "path"`.
+  const slashArgPathCandidates = usePathCandidates(
+    rootDir,
+    slashArgContext?.kind === "picker" && slashArgContext.spec.argCompleter === "path"
+      ? slashArgContext.partial
+      : null,
+    slashArgContext?.kind === "picker" && slashArgContext.spec.argCompleter === "path",
+  );
+
   const slashArgMatches = useMemo<readonly string[] | null>(() => {
     if (!slashArgContext || slashArgContext.kind !== "picker") return null;
     const completer = slashArgContext.spec.argCompleter;
@@ -239,8 +254,14 @@ export function useCompletionPickers({
       if (!partial) return names.slice(0, 40);
       return names.filter((n) => n.toLowerCase().includes(needle)).slice(0, 40);
     }
+    if (completer === "path") {
+      // Async-listed entries — map the rich candidates to strings.
+      // `slashArgPathCandidates` is populated by `usePathCandidates`;
+      // this memo re-fires when the async listing completes.
+      return slashArgPathCandidates.map((e) => e.insertPath);
+    }
     return null;
-  }, [slashArgContext, models, mcpServers, codeMode]);
+  }, [slashArgContext, models, mcpServers, codeMode, slashArgPathCandidates]);
   useEffect(() => {
     setSlashArgSelected((prev) => {
       if (!slashArgMatches || slashArgMatches.length === 0) return 0;
@@ -249,10 +270,19 @@ export function useCompletionPickers({
     });
   }, [slashArgMatches]);
   const pickSlashArg = useCallback(
-    (chosen: string) => {
+    (chosen: string, isDir?: boolean) => {
       if (!slashArgContext) return;
       const before = input.slice(0, slashArgContext.partialOffset);
-      setInput(`${before}${chosen}`);
+      if (isDir === true) {
+        // Directory drill-down — trailing slash re-opens the picker for deeper navigation.
+        setInput(`${before}${chosen}/`);
+      } else if (isDir === false) {
+        // Leaf commit — trailing space closes the picker (the user lands on Enter-to-run).
+        setInput(`${before}${chosen} `);
+      } else {
+        // Non-path completer (models, skills, etc.) — no suffix.
+        setInput(`${before}${chosen}`);
+      }
     },
     [slashArgContext, input, setInput],
   );
@@ -272,8 +302,116 @@ export function useCompletionPickers({
     slashArgMatches,
     slashArgSelected,
     setSlashArgSelected,
+    slashArgPathCandidates,
     pickSlashArg,
   };
+}
+
+/** Async directory listing for `argCompleter: "path"` (e.g. `/cwd`). Lists entries, sorts dirs first, caps at SEARCH_RESULT_CAP. */
+function usePathCandidates(
+  rootDir: string,
+  partial: string | null,
+  isActive: boolean,
+): readonly AtPickerEntry[] {
+  const [entries, setEntries] = useState<readonly AtPickerEntry[]>([]);
+
+  useEffect(() => {
+    if (!isActive) {
+      setEntries([]);
+      return;
+    }
+    if (partial === null) {
+      setEntries([]);
+      return;
+    }
+    let cancelled = false;
+
+    // Resolve the partial to a (listRoot, relPartial) pair.
+    // Absolute paths list from filesystem root.  Relative paths that escape
+    // rootDir via `..` resolve to absolute and list from / instead.
+    const hasTrailingSlash = partial.endsWith("/");
+    let listRoot: string;
+    let relPartial: string;
+    let insertIsAbsolute: boolean;
+
+    if (isAbsolute(partial)) {
+      // Absolute path → list from the drive root (C:\ on Windows, / on POSIX).
+      const root = parse(partial).root;
+      listRoot = root;
+      relPartial = partial.slice(root.length).replace(/\\/g, "/");
+      insertIsAbsolute = true;
+    } else {
+      // Relative path — check whether it escapes rootDir.
+      const resolved = resolve(rootDir, partial);
+      const relToRoot = relative(rootDir, resolved);
+      if (relToRoot.startsWith("..") || isAbsolute(relToRoot)) {
+        // Escapes rootDir — resolve to absolute and list from the drive root.
+        const root = parse(resolved).root;
+        listRoot = root;
+        relPartial = resolved.slice(root.length).replace(/\\/g, "/");
+        if (hasTrailingSlash && !relPartial.endsWith("/")) relPartial += "/";
+        insertIsAbsolute = true;
+      } else {
+        // Stays inside rootDir — normal relative listing.
+        listRoot = rootDir;
+        relPartial = partial;
+        insertIsAbsolute = false;
+      }
+    }
+
+    // Parse the partial argument to split parent-dir from filename filter.
+    const parsed = parseAtQuery(relPartial);
+    const dir = parsed.dir; // parent directory (empty = root)
+    const filter = parsed.filter.toLowerCase();
+
+    listDirectory(listRoot, dir)
+      .then((raw) => {
+        if (cancelled) return;
+
+        // Only directories — /cwd only accepts directory paths.
+        let result: DirEntry[] = raw.filter((e) => e.isDir);
+        if (filter) {
+          result = result.filter((e) => e.name.toLowerCase().startsWith(filter));
+        }
+
+        // Cap to match @-mention search so a directory with 10k+ entries
+        // doesn't blow out memory or block the UI on a single render.
+        if (result.length > SEARCH_RESULT_CAP) {
+          result = result.slice(0, SEARCH_RESULT_CAP);
+        }
+
+        const listRootNorm = listRoot.replace(/\\/g, "/");
+        const mapped: AtPickerEntry[] = result.map((e) => ({
+          label: e.name,
+          insertPath: insertIsAbsolute
+            ? dir
+              ? `${listRootNorm}${dir}/${e.name}`
+              : `${listRootNorm}${e.name}`
+            : dir
+              ? `${dir}/${e.name}`
+              : e.name,
+          dirSuffix: "",
+          isDir: e.isDir,
+        }));
+
+        // Directories first, then files; alpha within each group.
+        mapped.sort((a, b) => {
+          if (a.isDir !== b.isDir) return a.isDir ? -1 : 1;
+          return a.label.localeCompare(b.label);
+        });
+
+        setEntries(mapped);
+      })
+      .catch(() => {
+        if (!cancelled) setEntries([]);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [rootDir, partial, isActive]);
+
+  return entries;
 }
 
 function useBrowseListing(rootDir: string, dir: string | null) {


### PR DESCRIPTION
The /cwd slash command now exposes \`argCompleter: "path"\`, a new completer type that async-lists the filesystem via \`listDirectory()\`. Tab drills into directories (trailing '/'), Enter commits. Matches are capped at SEARCH_RESULT_CAP (200) to match @-mention search.

- types.ts: add "path" to argCompleter union
- commands.ts: wire /cwd to argCompleter: "path"
- useCompletionPickers.ts: new usePathCandidates hook; update pickSlashArg for dir drill-down; expose slashArgPathCandidates
- App.tsx: Tab handler checks candidate.isDir for drill vs. commit
- SlashArgPicker.tsx: optional pathCandidates prop, renders trailing / on directory rows

<!-- Read CONTRIBUTING.md first if this is your first PR. -->

## What

<!-- One paragraph: what does this change? -->

https://github.com/user-attachments/assets/c2116781-041e-4864-b5c4-65389c8127e2



## Why

<!-- Bug fix? Pre-existing issue? Linked discussion? -->

## How to verify

<!-- Steps the reviewer can run. `npm run verify` is assumed. -->

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time
