### PR TITLE
fix(desktop): jobs popover live-refresh + always-visible segment + run_background cwd

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -2443,6 +2443,13 @@ export function App() {
               );
             }
 
+            if (ev.type === "$jobs") {
+              for (const id of dispatchersRef.current.keys()) {
+                deliverToTab(id, { t: "incoming", event: ev });
+              }
+              return;
+            }
+
             const target = tabId;
             if (target) {
               flushTabDeltas(target);

--- a/desktop/src/ui/statusbar.tsx
+++ b/desktop/src/ui/statusbar.tsx
@@ -47,6 +47,7 @@ export function StatusBar({
 }) {
   const totalTokens = usage.cacheHitTokens + usage.cacheMissTokens;
   const cacheHitPct = totalTokens > 0 ? Math.round((usage.cacheHitTokens / totalTokens) * 100) : 0;
+  const runningJobs = jobs.filter((j) => j.running).length;
   const spent = formatMoney(usage.totalCostUsd, currency);
   const balanceLabel = balance
     ? `${balance.currency === "USD" ? "$" : "¥"} ${balance.total.toFixed(2)}`
@@ -80,17 +81,15 @@ export function StatusBar({
 
       <span className="grow" />
 
-      {jobs.length > 0 ? (
-        <span
-          className={`seg jobs ${jobsOpen ? "active" : ""}`}
-          onClick={onToggleJobs}
-          title={t("statusbar.jobsTip")}
-        >
-          <I.cpu size={11} />
-          <span>{t("statusbar.jobs")}</span>
-          <span className="v acc">{jobs.filter((j) => j.running).length}</span>
-        </span>
-      ) : null}
+      <span
+        className={`seg jobs ${jobsOpen ? "active" : ""}`}
+        onClick={onToggleJobs}
+        title={t("statusbar.jobsTip")}
+      >
+        <I.cpu size={11} />
+        <span>{t("statusbar.jobs")}</span>
+        <span className={runningJobs > 0 ? "v acc" : "v"}>{runningJobs}</span>
+      </span>
 
       {settings?.workspaceDir ? (
         <span

--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -785,6 +785,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
     const toolset = await buildCodeToolset({
       rootDir: tab.rootDir,
       onSkillInstalled: () => emitSkills(tab),
+      onJobsChanged: () => emitJobs(),
     });
     tab.toolset = toolset;
     tab.system = codeSystemPrompt(tab.rootDir, {
@@ -944,6 +945,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
     tab.toolset = await buildCodeToolset({
       rootDir: target,
       onSkillInstalled: () => emitSkills(tab),
+      onJobsChanged: () => emitJobs(),
     });
     tab.system = codeSystemPrompt(target, {
       hasSemanticSearch: tab.toolset.semantic.enabled,

--- a/src/code/setup.ts
+++ b/src/code/setup.ts
@@ -25,6 +25,8 @@ export interface CodeToolsetOpts {
   rootDir: string;
   /** Fired after `install_skill` writes a new skill — desktop wires this to push a fresh `$skills` event so the sidebar updates without a tab reload. */
   onSkillInstalled?: SkillInstalledHook;
+  /** Fired after `run_background` / `stop_job` mutate the JobRegistry — desktop pushes a fresh `$jobs` event so the popover updates without waiting for poll. */
+  onJobsChanged?: () => void;
 }
 
 export interface CodeToolset {
@@ -46,6 +48,7 @@ export async function buildCodeToolset(opts: CodeToolsetOpts): Promise<CodeTools
       extraAllowed: () => loadProjectShellAllowed(root),
       allowAll: () => loadEditMode() === "yolo",
       jobs,
+      onJobsChanged: opts.onJobsChanged,
     });
     registerMemoryTools(tools, { projectRoot: root });
   };

--- a/src/tools/shell.ts
+++ b/src/tools/shell.ts
@@ -44,6 +44,8 @@ export interface ShellToolsOptions {
   /** Getter form lets `editMode === "yolo"` flip mid-session without re-registering tools. */
   allowAll?: boolean | (() => boolean);
   jobs?: JobRegistry;
+  /** Fired after `run_background` / `stop_job` mutate the registry — used by the desktop popover for near-real-time updates without polling. */
+  onJobsChanged?: () => void;
 }
 
 /** Error thrown by `run_command` when the command isn't allowlisted. */
@@ -142,7 +144,7 @@ export function registerShellTools(registry: ToolRegistry, opts: ShellToolsOptio
   registry.register({
     name: "run_background",
     description:
-      "Spawn a long-running process and detach. Waits up to `waitSec` for startup or a readiness signal ('Local:', 'listening on', 'compiled successfully'), then returns the job id + startup preview. Tail logs with `job_output`, block on completion with `wait_for_job`, kill with `stop_job`, list with `list_jobs`.\n\nSingle process only — chains / redirects / `cd` work as in run_command, but a typical invocation is one binary. Use the binary's own --cwd / --prefix flag for subdirectories. Vite gotcha: npm's `--prefix` only finds package.json; vite's server root still uses process cwd — pass `vite <project-dir>` instead.\n\nUSE THIS — not run_command — for:\n- Dev servers / watchers: npm/yarn/pnpm dev, uvicorn / flask run, cargo watch, tsc --watch, webpack serve, anything with dev/serve/watch in the name.\n- One-shot long jobs: curl / wget large downloads, `huggingface-cli download`, multi-GB `pip install` / `npm install`, big `cargo build` / `docker build`. Start with `run_background`, then call `wait_for_job` once (default `waitFor: 'exit'`, timeoutMs up to 300_000) — the harness blocks server-side so a 5-minute download costs ONE tool call, not 30 polls.",
+      "Spawn a long-running process and detach. Waits up to `waitSec` for startup or a readiness signal ('Local:', 'listening on', 'compiled successfully'), then returns the job id + startup preview. Tail logs with `job_output`, block on completion with `wait_for_job`, kill with `stop_job`, list with `list_jobs`.\n\nSingle process only — no chains / redirects. For subdirectories use the `cwd` parameter (workspace-relative or absolute, must stay inside the workspace root); do NOT write `cd X && cmd`, that gets rejected.\n\nUSE THIS — not run_command — for:\n- Dev servers / watchers: npm/yarn/pnpm dev, uvicorn / flask run, cargo watch, tsc --watch, webpack serve, anything with dev/serve/watch in the name.\n- One-shot long jobs: curl / wget large downloads, `huggingface-cli download`, multi-GB `pip install` / `npm install`, big `cargo build` / `docker build`. Start with `run_background`, then call `wait_for_job` once (default `waitFor: 'exit'`, timeoutMs up to 300_000) — the harness blocks server-side so a 5-minute download costs ONE tool call, not 30 polls.",
     parameters: {
       type: "object",
       properties: {
@@ -150,6 +152,11 @@ export function registerShellTools(registry: ToolRegistry, opts: ShellToolsOptio
           type: "string",
           description:
             "Full command line. Same quoting rules as run_command (no pipes / redirects / chaining).",
+        },
+        cwd: {
+          type: "string",
+          description:
+            "Working directory for the spawn. Workspace-relative or absolute. Defaults to the workspace root. Must resolve inside the workspace — paths escaping the root are rejected.",
         },
         waitSec: {
           type: "integer",
@@ -159,14 +166,15 @@ export function registerShellTools(registry: ToolRegistry, opts: ShellToolsOptio
       },
       required: ["command"],
     },
-    fn: async (args: { command: string; waitSec?: number }, ctx) => {
+    fn: async (args: { command: string; cwd?: string; waitSec?: number }, ctx) => {
       const cmd = args.command.trim();
       if (!cmd) throw new Error("run_background: empty command");
+      const cwd = resolveCwdInsideRoot(rootDir, args.cwd);
       if (!isAllowAll() && !isCommandAllowed(cmd, getExtraAllowed())) {
         const gate = ctx?.confirmationGate ?? pauseGate;
         const choice = await gate.ask({
           kind: "run_background",
-          payload: { command: cmd, cwd: rootDir, waitSec: args.waitSec },
+          payload: { command: cmd, cwd, waitSec: args.waitSec },
         });
         if (choice.type === "deny") {
           throw new Error(
@@ -179,10 +187,11 @@ export function registerShellTools(registry: ToolRegistry, opts: ShellToolsOptio
         // "run_once" — fall through and execute
       }
       const result = await jobs.start(cmd, {
-        cwd: rootDir,
+        cwd,
         waitSec: args.waitSec,
         signal: ctx?.signal,
       });
+      opts.onJobsChanged?.();
       return formatJobStart(result);
     },
   });
@@ -255,6 +264,7 @@ export function registerShellTools(registry: ToolRegistry, opts: ShellToolsOptio
         waitFor: args.waitFor,
       });
       if (!out) return `job ${args.jobId}: not found (use list_jobs)`;
+      if (out.exited) opts.onJobsChanged?.();
       return {
         jobId: args.jobId,
         exited: out.exited,
@@ -277,6 +287,7 @@ export function registerShellTools(registry: ToolRegistry, opts: ShellToolsOptio
     },
     fn: async (args: { jobId: number }) => {
       const rec = await jobs.stop(args.jobId);
+      opts.onJobsChanged?.();
       if (!rec) return `job ${args.jobId}: not found`;
       return formatJobStop(rec);
     },
@@ -298,6 +309,19 @@ export function registerShellTools(registry: ToolRegistry, opts: ShellToolsOptio
   });
 
   return registry;
+}
+
+function resolveCwdInsideRoot(rootDir: string, raw: string | undefined): string {
+  const root = pathMod.resolve(rootDir);
+  if (!raw || !raw.trim()) return root;
+  const resolved = pathMod.resolve(root, raw);
+  const rel = pathMod.relative(root, resolved);
+  if (rel.startsWith("..") || pathMod.isAbsolute(rel)) {
+    throw new Error(
+      `run_background: cwd "${raw}" resolves outside the workspace root (${root}). Pass a workspace-relative path.`,
+    );
+  }
+  return resolved;
 }
 
 function formatJobStart(r: import("./jobs.js").JobStartResult): string {


### PR DESCRIPTION
## Summary

Three follow-ups to #917 that turn the jobs popover from "polled but silently dropped" into a real surface.

1. **`$jobs` events were never delivered to the UI.** `emitJobs()` emits without a `tabId` (the snapshot is cross-tab by design), but the desktop event router at `App.tsx:2446` only delivers events when `tabId` is set — anything untagged was thrown away. Both the 1.5s popover poll and the turn-complete one-shot were sending requests to the agent and then dropping the response. Add a broadcast branch for `$jobs` that fans out to every registered tab dispatcher.

2. **Status-bar segment was hidden until a job existed**, so users with no prior `run_background` calls had no visible entry point. `⌘J` worked but wasn't discoverable. Render unconditionally; show `0` in the muted `.v` color when idle, accent when something's live.

3. **`run_background` rejected `cd X && cmd`** patterns (correctly — JobRegistry needs single processes for tree-kill), and the model fell back to `run_command` which doesn't go through the registry and so doesn't show up in the popover at all. Add an optional `cwd` to `run_background` (workspace-relative or absolute, must stay inside the workspace root — path-traversal check throws otherwise). Tool description updated to point at `cwd` instead of `cd X && cmd`.

Plumb a new `onJobsChanged` from `ShellToolsOptions` through `CodeToolsetOpts` so the desktop CLI re-emits `$jobs` after `run_background` / `stop_job` / `wait_for_job` (when it returned because the child exited). That gives sub-second updates without relying on the 1.5s poll.

## Test plan

- [x] `npm run verify` (2906 tests pass; pre-push gate)
- [x] desktop `tsc --noEmit` + `vite build` clean
- [ ] Manual: status bar shows `jobs 0` on a fresh launch, `⌘J` opens the popover
- [ ] Manual: agent calls `run_background({command: "npm run dev", cwd: "backend"})` — popover updates immediately (not after 1.5s)
- [ ] Manual: `wait_for_job` returning with `exited:true` flips the row to `exited` within sub-second
- [ ] Manual: `run_background({command: "echo hi", cwd: "../escape"})` rejects with a clear path-outside-root error
