### PR TITLE
Support custom skill roots and update React import in tests

### DIFF
--- a/dashboard/src/i18n/en.ts
+++ b/dashboard/src/i18n/en.ts
@@ -138,6 +138,10 @@ export const en = {
     loopRunning: "running",
     loopIter: "iter {iter}",
     loopFiresIn: "fires in {remaining}",
+    sectionSkills: "Skills",
+    skillPaths: "skill paths",
+    skillPathsPlaceholder: "/path/to/skills-a, /path/to/skills-b",
+    skillPathsNote: "comma-separated · next /new or new session",
     sectionRuntime: "Runtime",
     activeModel: "active model",
     modelPricingLine: "${hit} hit · ${miss} miss · ${out} out  per 1M tok",
@@ -306,41 +310,72 @@ export const en = {
     write: "write",
     flat: "flat",
     desc: {
-      web_search: "Search the public web. Returns ranked results with title, url, and snippet. Call this when the answer depends on current state — events, prices, releases, real-world status.",
-      web_fetch: "Download a URL and return its visible text content (scripts/styles/nav stripped). Use after web_search when a snippet isn't enough.",
-      run_command: "Run a shell command in the project root; returns combined stdout+stderr. Allowlisted read-only commands run immediately; mutations are gated by user confirmation.",
-      run_background: "Spawn a long-running process and detach. Returns a job id for tailing logs, waiting for completion, or killing. Use for dev servers, watchers, and one-shot long jobs.",
-      job_output: "Read the latest output of a background job. Returns the tail of the buffer and tells you whether the job is still running.",
-      wait_for_job: "Block server-side until a background job finishes, bounded by timeout. Use instead of polling job_output in a loop.",
-      stop_job: "Stop a background job. SIGTERM first, SIGKILL after a grace period. Safe to call on an already-exited job.",
-      list_jobs: "List every background job started this session — running and exited — with id, command, pid, and status.",
-      remember: "Save a memory for future sessions. Use when the user states a preference, corrects your approach, shares a non-obvious fact, or asks you to remember something.",
-      forget: "Delete a memory file and remove it from MEMORY.md. Use when the user asks to forget something or a remembered fact is now wrong.",
-      recall_memory: "Read the full body of a memory file when its one-line summary isn't enough detail.",
-      read_file: "Read a file under the sandbox root. Supports head/tail/range scoping to save context. Auto-returns a preview for files over 200 lines.",
-      list_directory: "List entries in a directory. Returns one line per entry, marking directories with a trailing slash.",
-      directory_tree: "Recursively list entries in a directory as an indented tree. Budget-aware with auto-collapse for large subtrees.",
-      search_files: "Find files whose NAME matches a substring or regex. Case-insensitive. Skips dependency/build directories by default.",
-      search_content: "Recursively grep file CONTENTS for a substring or regex. Returns matches in path:line:text format. The right tool for finding references.",
+      web_search:
+        "Search the public web. Returns ranked results with title, url, and snippet. Call this when the answer depends on current state — events, prices, releases, real-world status.",
+      web_fetch:
+        "Download a URL and return its visible text content (scripts/styles/nav stripped). Use after web_search when a snippet isn't enough.",
+      run_command:
+        "Run a shell command in the project root; returns combined stdout+stderr. Allowlisted read-only commands run immediately; mutations are gated by user confirmation.",
+      run_background:
+        "Spawn a long-running process and detach. Returns a job id for tailing logs, waiting for completion, or killing. Use for dev servers, watchers, and one-shot long jobs.",
+      job_output:
+        "Read the latest output of a background job. Returns the tail of the buffer and tells you whether the job is still running.",
+      wait_for_job:
+        "Block server-side until a background job finishes, bounded by timeout. Use instead of polling job_output in a loop.",
+      stop_job:
+        "Stop a background job. SIGTERM first, SIGKILL after a grace period. Safe to call on an already-exited job.",
+      list_jobs:
+        "List every background job started this session — running and exited — with id, command, pid, and status.",
+      remember:
+        "Save a memory for future sessions. Use when the user states a preference, corrects your approach, shares a non-obvious fact, or asks you to remember something.",
+      forget:
+        "Delete a memory file and remove it from MEMORY.md. Use when the user asks to forget something or a remembered fact is now wrong.",
+      recall_memory:
+        "Read the full body of a memory file when its one-line summary isn't enough detail.",
+      read_file:
+        "Read a file under the sandbox root. Supports head/tail/range scoping to save context. Auto-returns a preview for files over 200 lines.",
+      list_directory:
+        "List entries in a directory. Returns one line per entry, marking directories with a trailing slash.",
+      directory_tree:
+        "Recursively list entries in a directory as an indented tree. Budget-aware with auto-collapse for large subtrees.",
+      search_files:
+        "Find files whose NAME matches a substring or regex. Case-insensitive. Skips dependency/build directories by default.",
+      search_content:
+        "Recursively grep file CONTENTS for a substring or regex. Returns matches in path:line:text format. The right tool for finding references.",
       glob: "List files matching a glob pattern, sorted by mtime. Default limit 200, max 1000. Skips node_modules/.git/dist by default.",
       get_file_info: "Stat a path under the sandbox root. Returns type, size in bytes, and mtime.",
-      write_file: "Create or overwrite a file with the given content. Parent directories are created as needed.",
-      edit_file: "Apply a SEARCH/REPLACE edit to an existing file. The search must match exactly and be unique in the file.",
-      multi_edit: "Apply N SEARCH/REPLACE edits across one or more files atomically. If any edit fails, no files are written.",
+      write_file:
+        "Create or overwrite a file with the given content. Parent directories are created as needed.",
+      edit_file:
+        "Apply a SEARCH/REPLACE edit to an existing file. The search must match exactly and be unique in the file.",
+      multi_edit:
+        "Apply N SEARCH/REPLACE edits across one or more files atomically. If any edit fails, no files are written.",
       create_directory: "Create a directory (and any missing parents) under the sandbox root.",
       move_file: "Rename or move a file or directory under the sandbox root.",
-      delete_file: "Delete one file under the sandbox root. Refuses directories — use delete_directory for those.",
-      delete_directory: "Recursively delete a directory under the sandbox root. Pass recursive:false to refuse non-empty directories.",
-      copy_file: "Copy a file or directory under the sandbox root. Refuses to overwrite an existing destination.",
-      submit_plan: "Submit one concrete plan for a review gate. Use for multi-file refactors, architecture changes, or anything expensive to undo.",
-      mark_step_complete: "Mark one step of the approved plan as done. Call exactly once after finishing each step.",
-      revise_plan: "Surgically replace the remaining steps of an in-flight plan. Done steps are never touched.",
-      run_skill: "Invoke a playbook from the Skills index. Pass the bare skill name. Subagent-tagged skills spawn an isolated subagent.",
-      spawn_subagent: "Spawn an isolated subagent for a self-contained subtask. Use for parallel fan-out or when the work needs many file reads.",
-      todo_write: "In-session task tracker for multi-step work. Replaces the entire list every call. No approval gate or file writes.",
-      ask_choice: "Present 2-6 alternatives to the user. Use when the user asks for options or you need a preference decision.",
-      create_skill: "Scaffold a new skill the user can invoke later via /skill. Supports inline and subagent run modes.",
-      add_mcp_server: "Register a new MCP server in the user's config. Takes effect on the next session. Supports stdio, SSE, and streamable-http.",
+      delete_file:
+        "Delete one file under the sandbox root. Refuses directories — use delete_directory for those.",
+      delete_directory:
+        "Recursively delete a directory under the sandbox root. Pass recursive:false to refuse non-empty directories.",
+      copy_file:
+        "Copy a file or directory under the sandbox root. Refuses to overwrite an existing destination.",
+      submit_plan:
+        "Submit one concrete plan for a review gate. Use for multi-file refactors, architecture changes, or anything expensive to undo.",
+      mark_step_complete:
+        "Mark one step of the approved plan as done. Call exactly once after finishing each step.",
+      revise_plan:
+        "Surgically replace the remaining steps of an in-flight plan. Done steps are never touched.",
+      run_skill:
+        "Invoke a playbook from the Skills index. Pass the bare skill name. Subagent-tagged skills spawn an isolated subagent.",
+      spawn_subagent:
+        "Spawn an isolated subagent for a self-contained subtask. Use for parallel fan-out or when the work needs many file reads.",
+      todo_write:
+        "In-session task tracker for multi-step work. Replaces the entire list every call. No approval gate or file writes.",
+      ask_choice:
+        "Present 2-6 alternatives to the user. Use when the user asks for options or you need a preference decision.",
+      create_skill:
+        "Scaffold a new skill the user can invoke later via /skill. Supports inline and subagent run modes.",
+      add_mcp_server:
+        "Register a new MCP server in the user's config. Takes effect on the next session. Supports stdio, SSE, and streamable-http.",
     },
   },
   permissions: {
@@ -461,6 +496,7 @@ export const en = {
     loading: "loading skills…",
     filterPlaceholder: "filter skills",
     project: "project",
+    custom: "custom",
     global: "global",
     builtin: "builtin",
     newSkill: "new skill",
@@ -468,6 +504,7 @@ export const en = {
     runs7d: "runs · 7d",
     pickHint: "Pick a skill on the left, or create a new one above.",
     readOnlyBuiltin: "read-only · builtin",
+    readOnlyCustom: "read-only · custom path",
     builtinDesc:
       "Built-in skills ship with Reasonix; the model picks them up automatically. To customize, create a project- or global-scoped skill with the same name.",
     saved: "saved {scope}/{name}",
@@ -552,7 +589,8 @@ export const en = {
     lastBuild: "last build",
     builtWith: "built with",
     currentTarget: "current target",
-    incompatibleHint: "This on-disk index was built for a different provider or model. Run Rebuild to replace it.",
+    incompatibleHint:
+      "This on-disk index was built for a different provider or model. Run Rebuild to replace it.",
     runIndexHint: "Run an index to enable semantic_search.",
     reIndex: "Re-index",
     build: "Build",

--- a/dashboard/src/i18n/zh-CN.ts
+++ b/dashboard/src/i18n/zh-CN.ts
@@ -130,6 +130,10 @@ export const zhCN = {
     loopRunning: "运行中",
     loopIter: "第 {iter} 次",
     loopFiresIn: "{remaining} 后触发",
+    sectionSkills: "技能",
+    skillPaths: "技能路径",
+    skillPathsPlaceholder: "/path/to/skills-a, /path/to/skills-b",
+    skillPathsNote: "英文逗号分隔 · 下次 /new 或新会话生效",
     sectionRuntime: "运行时",
     activeModel: "当前模型",
     modelPricingLine: "${hit} 命中 · ${miss} 未命中 · ${out} 输出  / 100 万 tok",
@@ -139,7 +143,6 @@ export const zhCN = {
     language: "语言",
     langEn: "English",
     langZhCn: "简体中文",
-
   },
   chat: {
     modeMirror: "TUI 镜像",
@@ -295,41 +298,53 @@ export const zhCN = {
     write: "写入",
     flat: "扁平",
     desc: {
-      web_search: "搜索公共网络。返回带标题、URL 和摘要的排序结果。当答案的正确性依赖于当前状态时调用——事件、价格、发布、现实世界的状态。",
-      web_fetch: "下载 URL 并返回其可见文本内容（已剥离脚本/样式/导航）。在 web_search 摘要不够时使用。",
-      run_command: "在项目根目录执行 shell 命令，返回合并的标准输出和标准错误。白名单中的只读命令立即执行；可能修改状态的操作需用户确认。",
-      run_background: "启动一个长时间运行的进程并分离。返回任务 ID 用于查看日志、等待完成或终止。用于开发服务器、文件监听器和一次性长时间任务。",
+      web_search:
+        "搜索公共网络。返回带标题、URL 和摘要的排序结果。当答案的正确性依赖于当前状态时调用——事件、价格、发布、现实世界的状态。",
+      web_fetch:
+        "下载 URL 并返回其可见文本内容（已剥离脚本/样式/导航）。在 web_search 摘要不够时使用。",
+      run_command:
+        "在项目根目录执行 shell 命令，返回合并的标准输出和标准错误。白名单中的只读命令立即执行；可能修改状态的操作需用户确认。",
+      run_background:
+        "启动一个长时间运行的进程并分离。返回任务 ID 用于查看日志、等待完成或终止。用于开发服务器、文件监听器和一次性长时间任务。",
       job_output: "读取后台任务的最新输出。返回缓冲区末尾内容并告知任务是否仍在运行。",
       wait_for_job: "在服务端阻塞直到后台任务完成（有超时限制）。用于替代轮询 job_output。",
       stop_job: "停止后台任务。先发送 SIGTERM，宽限期后发送 SIGKILL。可安全调用已退出的任务。",
       list_jobs: "列出本次会话启动的所有后台任务——运行中和已退出的——包含 ID、命令、PID 和状态。",
-      remember: "保存一条记忆供未来会话使用。当用户陈述偏好、纠正你的方法、分享非显而易见的事实或要求你记住某事时使用。",
-      forget: "删除记忆文件并从 MEMORY.md 中移除。当用户要求忘记某事或之前记住的事实已不再正确时使用。",
+      remember:
+        "保存一条记忆供未来会话使用。当用户陈述偏好、纠正你的方法、分享非显而易见的事实或要求你记住某事时使用。",
+      forget:
+        "删除记忆文件并从 MEMORY.md 中移除。当用户要求忘记某事或之前记住的事实已不再正确时使用。",
       recall_memory: "当记忆文件的一行摘要不够详细时，读取其完整内容。",
-      read_file: "读取沙箱根目录下的文件。支持 head/tail/range 范围读取以节省上下文。超过 200 行的文件自动返回预览。",
+      read_file:
+        "读取沙箱根目录下的文件。支持 head/tail/range 范围读取以节省上下文。超过 200 行的文件自动返回预览。",
       list_directory: "列出目录中的条目。每行一个条目，目录以斜杠标记。",
       directory_tree: "递归列出目录中的条目，以缩进树形结构显示。对大子目录自动折叠以节省预算。",
       search_files: "根据名称匹配子串或正则表达式查找文件。不区分大小写。默认跳过依赖/构建目录。",
-      search_content: "递归搜索文件内容中的子串或正则表达式。以 path:line:text 格式返回匹配结果。查找引用的正确工具。",
+      search_content:
+        "递归搜索文件内容中的子串或正则表达式。以 path:line:text 格式返回匹配结果。查找引用的正确工具。",
       glob: "按 glob 模式列出文件，按修改时间排序。默认限制 200，最大 1000。默认跳过 node_modules/.git/dist。",
       get_file_info: "获取沙箱根目录下路径的状态信息。返回类型、字节大小和修改时间。",
       write_file: "创建或覆盖文件，内容由参数指定。按需创建父目录。",
       edit_file: "对现有文件应用 SEARCH/REPLACE 编辑。搜索必须完全匹配且在文件中唯一。",
-      multi_edit: "跨一个或多个文件原子性地应用 N 个 SEARCH/REPLACE 编辑。如果任何编辑失败，不写入任何文件。",
+      multi_edit:
+        "跨一个或多个文件原子性地应用 N 个 SEARCH/REPLACE 编辑。如果任何编辑失败，不写入任何文件。",
       create_directory: "在沙箱根目录下创建目录（以及任何缺失的父目录）。",
       move_file: "重命名或移动沙箱根目录下的文件或目录。",
       delete_file: "删除沙箱根目录下的一个文件。拒绝目录——请使用 delete_directory 删除目录。",
       delete_directory: "递归删除沙箱根目录下的目录。传入 recursive:false 可拒绝非空目录。",
       copy_file: "复制沙箱根目录下的文件或目录。拒绝覆盖已存在的目标。",
-      submit_plan: "提交一个具体的计划以供审查审批。用于多文件重构、架构变更或任何撤销代价高昂的操作。",
+      submit_plan:
+        "提交一个具体的计划以供审查审批。用于多文件重构、架构变更或任何撤销代价高昂的操作。",
       mark_step_complete: "将已批准计划的一个步骤标记为完成。完成每个步骤后恰好调用一次。",
       revise_plan: "外科手术式替换进行中计划的剩余步骤。已完成的步骤永远不会被触及。",
-      run_skill: "从技能索引中调用一个 playbook。传入裸技能名称。标记为子代理的技能将启动独立的子代理。",
+      run_skill:
+        "从技能索引中调用一个 playbook。传入裸技能名称。标记为子代理的技能将启动独立的子代理。",
       spawn_subagent: "为一个独立子任务启动隔离的子代理。用于并行分发或需要大量文件读取的工作。",
       todo_write: "多步工作的会话内任务跟踪器。每次调用替换整个列表。无审批关卡，不写入文件。",
       ask_choice: "向用户展示 2-6 个选项。当用户要求选择或需要偏好决策时使用。",
       create_skill: "创建一个新技能，用户可通过 /skill 命令调用。支持内联和子代理两种运行模式。",
-      add_mcp_server: "在用户配置中注册新的 MCP 服务器。下次会话生效。支持 stdio、SSE 和 streamable-http。",
+      add_mcp_server:
+        "在用户配置中注册新的 MCP 服务器。下次会话生效。支持 stdio、SSE 和 streamable-http。",
     },
   },
   permissions: {
@@ -448,6 +463,7 @@ export const zhCN = {
     loading: "加载技能…",
     filterPlaceholder: "筛选技能",
     project: "项目",
+    custom: "自定义",
     global: "全局",
     builtin: "内置",
     newSkill: "新技能",
@@ -455,6 +471,7 @@ export const zhCN = {
     runs7d: "次运行 · 7 天",
     pickHint: "选择左侧的技能，或在上方创建新技能。",
     readOnlyBuiltin: "只读 · 内置",
+    readOnlyCustom: "只读 · 自定义路径",
     builtinDesc:
       "内置技能随 Reasonix 一起发布；模型会自动识别。如需自定义，请创建同名的项目或全局技能。",
     saved: "已保存 {scope}/{name}",
@@ -537,7 +554,8 @@ export const zhCN = {
     lastBuild: "上次构建",
     builtWith: "构建来源",
     currentTarget: "当前目标",
-    incompatibleHint: "磁盘上的这个索引是为不同的 provider 或 model 构建的。运行“完全重建”即可替换。",
+    incompatibleHint:
+      "磁盘上的这个索引是为不同的 provider 或 model 构建的。运行“完全重建”即可替换。",
     runIndexHint: "运行索引以启用 semantic_search。",
     reIndex: "重建索引",
     build: "构建",

--- a/dashboard/src/panels/settings.ts
+++ b/dashboard/src/panels/settings.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "preact/hooks";
+import { type DashboardLang, getLang, setLang, t, useLang } from "../i18n/index.js";
 import { api } from "../lib/api.js";
 import {
   type BudgetState,
@@ -15,7 +16,6 @@ import {
   formatRemaining,
   parseCustomInterval,
 } from "../lib/loop-control.js";
-import { type DashboardLang, getLang, setLang, t, useLang } from "../i18n/index.js";
 
 interface SettingsData {
   apiKey?: string | null;
@@ -29,6 +29,7 @@ interface SettingsData {
   budgetUsd?: number | null;
   /** Cumulative session spend (USD); null when no session is attached. */
   sessionSpendUsd?: number | null;
+  skillPaths?: string[];
 }
 
 function fmtUsd2(n: number): string {
@@ -498,6 +499,11 @@ export function SettingsPanel() {
     [load],
   );
 
+  const skillPathsDraft = draft.skillPaths ?? data?.skillPaths ?? [];
+  const skillPathsText = Array.isArray(skillPathsDraft)
+    ? skillPathsDraft.join(", ")
+    : String(skillPathsDraft ?? "");
+
   if (!data && !error)
     return html`<div class="card" style="color:var(--fg-3)">${t("settings.loading")}</div>`;
   if (error && !data) return html`<div class="card accent-err">${error}</div>`;
@@ -507,11 +513,7 @@ export function SettingsPanel() {
   const sectionH3 = (text: string) => html`
     <h3 style="margin:18px 0 8px;font-family:var(--font-mono);font-size:11px;color:var(--fg-3);text-transform:uppercase;letter-spacing:.1em">${text}</h3>
   `;
-  const fieldRow = (
-    label: string,
-    control: unknown,
-    note?: string,
-  ) => html`
+  const fieldRow = (label: string, control: unknown, note?: string) => html`
     <div style="display:flex;align-items:center;gap:10px;padding:6px 0">
       <span style="flex:0 0 110px;font-family:var(--font-mono);font-size:11.5px;color:var(--fg-3)">${label}</span>
       <div style="flex:1;display:flex;align-items:center;gap:8px">${control}</div>
@@ -523,12 +525,8 @@ export function SettingsPanel() {
 
   return html`
     <div style="max-width:760px;display:flex;flex-direction:column;gap:6px">
-      ${
-        saved ? html`<div><span class="pill ok">${saved}</span></div>` : null
-      }
-      ${
-        error ? html`<div class="card accent-err">${error}</div>` : null
-      }
+      ${saved ? html`<div><span class="pill ok">${saved}</span></div>` : null}
+      ${error ? html`<div class="card accent-err">${error}</div>` : null}
 
       ${sectionH3(t("settings.sectionLanguage"))}
       <div class="card">
@@ -632,6 +630,35 @@ export function SettingsPanel() {
             >${v.search ? t("common.on") : t("common.off")}</button>
           `,
           t("settings.webSearchNote"),
+        )}
+      </div>
+
+      ${sectionH3(t("settings.sectionSkills"))}
+      <div class="card">
+        ${fieldRow(
+          t("settings.skillPaths"),
+          html`
+            <input
+              type="text"
+              value=${skillPathsText}
+              placeholder=${t("settings.skillPathsPlaceholder")}
+              onInput=${(e: Event) =>
+                setDraft({
+                  ...draft,
+                  skillPaths: (e.target as HTMLInputElement).value
+                    .split(",")
+                    .map((s) => s.trim())
+                    .filter(Boolean),
+                })}
+              style="flex:1;font-family:var(--font-mono)"
+            />
+            <button
+              class="btn"
+              disabled=${saving || skillPathsText === (v.skillPaths ?? []).join(", ")}
+              onClick=${() => save({ skillPaths: draft.skillPaths ?? [] })}
+            >${t("common.save")}</button>
+          `,
+          t("settings.skillPathsNote"),
         )}
       </div>
 

--- a/dashboard/src/panels/skills.ts
+++ b/dashboard/src/panels/skills.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "preact/hooks";
+import { t, useLang } from "../i18n/index.js";
 import { api } from "../lib/api.js";
 import { html } from "../lib/html.js";
-import { t, useLang } from "../i18n/index.js";
 
 interface SkillEntry {
   name: string;
@@ -9,14 +9,22 @@ interface SkillEntry {
   runs7d?: number;
 }
 
+interface SkillPathInfo {
+  dir: string;
+  scope: "custom";
+  status: string;
+  priority: number;
+}
+
 interface SkillsData {
-  paths: { project?: string };
+  paths: { project?: string; custom?: SkillPathInfo[] };
   project: SkillEntry[];
+  custom: SkillEntry[];
   global: SkillEntry[];
   builtin: SkillEntry[];
 }
 
-type Scope = "project" | "global" | "builtin";
+type Scope = "project" | "custom" | "global" | "builtin";
 
 export function SkillsPanel() {
   useLang();
@@ -44,7 +52,7 @@ export function SkillsPanel() {
 
   const openSkill = useCallback(async (scope: Scope, name: string) => {
     setOpen({ scope, name });
-    if (scope === "builtin") {
+    if (scope === "builtin" || scope === "custom") {
       setBody("");
       return;
     }
@@ -118,6 +126,7 @@ export function SkillsPanel() {
 
   const allWith = [
     ...data.project.map((s) => ({ scope: "project" as Scope, ...s })),
+    ...data.custom.map((s) => ({ scope: "custom" as Scope, ...s })),
     ...data.global.map((s) => ({ scope: "global" as Scope, ...s })),
     ...data.builtin.map((s) => ({ scope: "builtin" as Scope, ...s })),
   ];
@@ -152,6 +161,10 @@ export function SkillsPanel() {
             class=${`chip-f ${scopeFilter === "project" ? "active" : ""}`}
             onClick=${() => setScopeFilter("project")}
           >${t("skills.project")} <span class="ct">${data.project.length}</span></span>
+          <span
+            class=${`chip-f ${scopeFilter === "custom" ? "active" : ""}`}
+            onClick=${() => setScopeFilter("custom")}
+          >${t("skills.custom")} <span class="ct">${data.custom.length}</span></span>
           <span
             class=${`chip-f ${scopeFilter === "global" ? "active" : ""}`}
             onClick=${() => setScopeFilter("global")}
@@ -192,6 +205,7 @@ export function SkillsPanel() {
                 <span class="name">
                   ${s.name}
                   ${s.scope === "builtin" ? html`<span class="pill">${t("skills.builtin")}</span>` : null}
+                  ${s.scope === "custom" ? html`<span class="pill">${t("skills.custom")}</span>` : null}
                 </span>
                 <span class="preview">${s.description ?? t("skills.noDescription")}</span>
                 <span class="meta">
@@ -233,7 +247,26 @@ export function SkillsPanel() {
                     </div>
                   `;
                 })()
-              : html`
+              : open.scope === "custom"
+                ? (() => {
+                    const custom = data.custom.find((b) => b.name === open.name);
+                    return html`
+                      <div class="sessions-detail-h">
+                        <span class="name">${open.scope}/${open.name}</span>
+                        <span class="ws"><span class="pill">${t("skills.readOnlyCustom")}</span></span>
+                        <span class="actions">
+                          <button class="btn ghost" onClick=${() => setOpen(null)}>${t("common.back")}</button>
+                        </span>
+                      </div>
+                      <div style="color:var(--fg-2);font-size:13px;line-height:1.6">
+                        ${custom?.description ?? t("skills.noDescription")}
+                      </div>
+                      <div style="margin-top:14px;color:var(--fg-3);font-size:11.5px;font-family:var(--font-mono)">
+                        ${data.paths.custom?.map((p) => html`<div>${p.status} · ${p.dir}</div>`)}
+                      </div>
+                    `;
+                  })()
+                : html`
                 <div class="sessions-detail-h">
                   <span class="name">${open.scope}/${open.name}</span>
                   <span class="ws">${body.length.toLocaleString()} chars</span>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reasonix",
-  "version": "0.40.0",
+  "version": "0.43.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reasonix",
-      "version": "0.40.0",
+      "version": "0.43.0",
       "license": "MIT",
       "dependencies": {
         "cli-highlight": "^2.1.11",

--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -24,6 +24,7 @@ import {
   loadPreset,
   loadReasoningEffort,
   loadRecentWorkspaces,
+  loadResolvedSkillPaths,
   loadWorkspaceDir,
   pushRecentWorkspace,
   readConfig,
@@ -310,7 +311,7 @@ interface MemoryEvent {
 interface SkillInfo {
   name: string;
   description: string;
-  scope: "project" | "global" | "builtin";
+  scope: "project" | "custom" | "global" | "builtin";
   path: string;
   runAs: "inline" | "subagent";
   model?: string;
@@ -557,7 +558,10 @@ function emitCtxBreakdown(tab: Tab): void {
 
 function emitSkills(tab: Tab): void {
   try {
-    const store = new SkillStore({ projectRoot: tab.rootDir });
+    const store = new SkillStore({
+      projectRoot: tab.rootDir,
+      customSkillPaths: loadResolvedSkillPaths(tab.rootDir),
+    });
     const items = store.list().map((s) => ({
       name: s.name,
       description: s.description,
@@ -1438,7 +1442,10 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
         return;
       }
       try {
-        const store = new SkillStore({ projectRoot: tab.rootDir });
+        const store = new SkillStore({
+          projectRoot: tab.rootDir,
+          customSkillPaths: loadResolvedSkillPaths(tab.rootDir),
+        });
         const found = store.read(msg.name);
         if (!found) {
           emit({ type: "$error", message: `skill not found: ${msg.name}` }, tab.id);

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -2441,6 +2441,7 @@ function AppInner({
         }
         setSlashUsage(recordSlashUse(slash.cmd));
         const result = handleSlash(slash.cmd, slash.args, loop, {
+          configPath: defaultConfigPath(),
           mcpSpecs,
           mcpServers: liveMcpServers,
           codeUndo: codeMode ? codeUndo : undefined,

--- a/src/cli/ui/slash/commands.ts
+++ b/src/cli/ui/slash/commands.ts
@@ -173,8 +173,9 @@ export const SLASH_COMMANDS: readonly SlashCommandSpec[] = [
   {
     cmd: "skill",
     group: "extend",
-    argsHint: "[list|show <name>|new <name>|<name> [args]]",
-    summary: "list / run / scaffold user skills (<project>/.reasonix/skills + ~/.reasonix/skills)",
+    argsHint:
+      "[list|paths|paths add <path>|paths remove <path|N>|show <name>|new <name>|<name> [args]]",
+    summary: "list / run / scaffold skills (project + custom + global + builtin)",
     argCompleter: "skills",
   },
 

--- a/src/cli/ui/slash/handlers/skill.ts
+++ b/src/cli/ui/slash/handlers/skill.ts
@@ -1,9 +1,22 @@
+import {
+  addSkillPath,
+  defaultConfigPath,
+  loadResolvedSkillPaths,
+  loadSkillPaths,
+  removeSkillPath,
+} from "@/config.js";
 import { t } from "@/i18n/index.js";
 import { SkillStore } from "@/skills.js";
 import type { SlashHandler } from "../dispatch.js";
 
 const skill: SlashHandler = (args, _loop, ctx) => {
-  const store = new SkillStore({ projectRoot: ctx.codeRoot });
+  const baseDir = ctx.codeRoot ?? process.cwd();
+  const configPath = ctx.configPath ?? defaultConfigPath();
+  const rawSkillPaths = loadSkillPaths(baseDir, configPath);
+  const store = new SkillStore({
+    projectRoot: ctx.codeRoot,
+    customSkillPaths: loadResolvedSkillPaths(baseDir, configPath),
+  });
   const sub = (args[0] ?? "").toLowerCase();
 
   if (sub === "new" || sub === "init") {
@@ -15,6 +28,53 @@ const skill: SlashHandler = (args, _loop, ctx) => {
       return { info: t("handlers.skill.newError", { reason: result.error }) };
     }
     return { info: t("handlers.skill.newCreated", { name, path: result.path }) };
+  }
+
+  if (sub === "paths") {
+    const action = (args[1] ?? "list").toLowerCase();
+    if (action === "add") {
+      const raw = args.slice(2).join(" ").trim();
+      if (!raw) return { info: t("handlers.skill.pathsAddUsage") };
+      const result = addSkillPath(raw, baseDir, configPath);
+      if ("error" in result) return { info: result.error };
+      return {
+        info: [
+          result.added
+            ? t("handlers.skill.pathsAdded", { path: result.path })
+            : t("handlers.skill.pathsAlready", { path: result.path }),
+          t("handlers.skill.pathsRestartHint"),
+        ].join("\n"),
+      };
+    }
+    if (action === "remove" || action === "rm") {
+      const raw = args.slice(2).join(" ").trim();
+      if (!raw) return { info: t("handlers.skill.pathsRemoveUsage") };
+      const result = removeSkillPath(raw, baseDir, configPath);
+      if (!result.removed)
+        return { info: t("handlers.skill.pathsRemoveNotFound", { target: raw }) };
+      return {
+        info: [
+          t("handlers.skill.pathsRemoved", { path: result.path ?? raw }),
+          t("handlers.skill.pathsRestartHint"),
+        ].join("\n"),
+      };
+    }
+    if (action !== "list") return { info: t("handlers.skill.pathsUsage") };
+    const roots = store.roots();
+    const customRoots = store.customRoots();
+    const lines = [t("handlers.skill.pathsHeader")];
+    for (const root of roots) {
+      const customIndex =
+        root.scope === "custom" ? customRoots.findIndex((r) => r.dir === root.dir) : -1;
+      const label = customIndex >= 0 ? `${root.scope} #${customIndex + 1}` : root.scope;
+      const raw = customIndex >= 0 ? rawSkillPaths[customIndex] : undefined;
+      const suffix = raw && raw !== root.dir ? ` raw=${raw} resolved=${root.dir}` : root.dir;
+      lines.push(
+        `  ${String(root.priority + 1).padStart(2, " ")}. ${label.padEnd(10)} ${root.status.padEnd(13)} ${suffix}`,
+      );
+    }
+    lines.push("", t("handlers.skill.pathsPriority"));
+    return { info: lines.join("\n") };
   }
 
   if (sub === "" || sub === "list" || sub === "ls") {
@@ -42,7 +102,8 @@ const skill: SlashHandler = (args, _loop, ctx) => {
       const scope = `(${s.scope})`.padEnd(11);
       const name = s.name.padEnd(24);
       const desc = s.description.length > 70 ? `${s.description.slice(0, 69)}…` : s.description;
-      lines.push(`  ${scope} ${name}  ${desc}`);
+      const shortPath = s.path.replace(baseDir, ".");
+      lines.push(`  ${scope} ${name}  ${desc}  ${shortPath}`);
     }
     lines.push("");
     lines.push(t("handlers.skill.listFooter"));

--- a/src/cli/ui/slash/types.ts
+++ b/src/cli/ui/slash/types.ts
@@ -58,6 +58,7 @@ export interface SlashResult {
 }
 
 export interface SlashContext {
+  configPath?: string;
   mcpSpecs?: string[];
   codeUndo?: (args: readonly string[]) => string;
   codeApply?: (indices?: readonly number[]) => string;

--- a/src/cli/ui/useCompletionPickers.ts
+++ b/src/cli/ui/useCompletionPickers.ts
@@ -9,6 +9,7 @@ import {
   rankPickerCandidates,
   walkFilesStream,
 } from "../../at-mentions.js";
+import { loadResolvedSkillPaths } from "../../config.js";
 import { SkillStore } from "../../skills.js";
 import {
   type McpServerSummary,
@@ -230,7 +231,11 @@ export function useCompletionPickers({
       return names.filter((n) => n.toLowerCase().includes(needle)).slice(0, 40);
     }
     if (completer === "skills") {
-      const store = new SkillStore({ projectRoot: codeMode?.rootDir });
+      const baseDir = codeMode?.rootDir ?? process.cwd();
+      const store = new SkillStore({
+        projectRoot: codeMode?.rootDir,
+        customSkillPaths: loadResolvedSkillPaths(baseDir),
+      });
       const names = store
         .list()
         .filter((s) => s.scope !== "builtin")

--- a/src/code/setup.ts
+++ b/src/code/setup.ts
@@ -3,6 +3,7 @@ import {
   loadBaseUrl,
   loadEditMode,
   loadProjectShellAllowed,
+  loadResolvedSkillPaths,
   searchEnabled,
   webSearchEndpoint,
   webSearchEngine,
@@ -77,6 +78,7 @@ export async function buildCodeToolset(opts: CodeToolsetOpts): Promise<CodeTools
   let subagentClient: DeepSeekClient | null = null;
   registerSkillTools(tools, {
     projectRoot: opts.rootDir,
+    customSkillPaths: loadResolvedSkillPaths(opts.rootDir),
     onSkillInstalled: opts.onSkillInstalled,
     subagentRunner: async (skill, task, signal) => {
       if (!subagentClient) subagentClient = new DeepSeekClient({ baseUrl: loadBaseUrl() });

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,7 @@
 
 import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, isAbsolute, join, resolve } from "node:path";
 import { type ThemeName, isThemeName, resolveThemeName } from "./cli/ui/theme/tokens.js";
 import type { LanguageCode } from "./i18n/types.js";
 import {
@@ -132,6 +132,9 @@ export interface ReasonixConfig {
   };
   index?: IndexUserConfig;
   semantic?: SemanticEmbeddingUserConfig;
+  skills?: {
+    paths?: string[];
+  };
   /** User-declared extensions to the built-in memory types (#709). Unknown types round-trip even without a declaration; declaring one lets you attach a default priority + lifecycle. */
   memory?: {
     customTypes?: CustomMemoryTypeConfig[];
@@ -284,6 +287,132 @@ export function saveBaseUrl(url: string, path: string = defaultConfigPath()): vo
     cfg.baseUrl = undefined;
   }
   writeConfig(cfg, path);
+}
+
+export interface SkillPathEntry {
+  raw: string;
+  resolved: string;
+}
+
+export function resolveSkillPath(raw: string, baseDir: string): string {
+  const homeExpanded = expandCurrentUserHome(raw.trim());
+  return resolve(isAbsolute(homeExpanded) ? homeExpanded : join(baseDir, homeExpanded));
+}
+
+export function normalizeSkillPathEntries(
+  paths: readonly unknown[],
+  baseDir: string,
+): SkillPathEntry[] {
+  const out: SkillPathEntry[] = [];
+  const seen = new Set<string>();
+  for (const value of paths) {
+    if (typeof value !== "string") continue;
+    const raw = value.trim();
+    if (!raw) continue;
+    const resolved = resolveSkillPath(raw, baseDir);
+    const key = skillPathKey(resolved);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({ raw, resolved });
+  }
+  return out;
+}
+
+export function normalizeSkillPaths(paths: readonly unknown[], baseDir: string): string[] {
+  return normalizeSkillPathEntries(paths, baseDir).map((entry) => entry.raw);
+}
+
+export function resolveSkillPaths(paths: readonly unknown[], baseDir: string): string[] {
+  return normalizeSkillPathEntries(paths, baseDir).map((entry) => entry.resolved);
+}
+
+function skillPathKey(path: string): string {
+  return process.platform === "win32" ? path.toLowerCase() : path;
+}
+
+function expandCurrentUserHome(path: string): string {
+  if (path === "~") return homedir();
+  if (path.startsWith("~/") || path.startsWith("~\\")) return join(homedir(), path.slice(2));
+  return path;
+}
+
+export function loadSkillPaths(
+  baseDir: string = process.cwd(),
+  path: string = defaultConfigPath(),
+): string[] {
+  const raw = readConfig(path).skills?.paths;
+  return Array.isArray(raw) ? normalizeSkillPaths(raw, baseDir) : [];
+}
+
+export function loadResolvedSkillPaths(
+  baseDir: string = process.cwd(),
+  path: string = defaultConfigPath(),
+): string[] {
+  const raw = readConfig(path).skills?.paths;
+  return Array.isArray(raw) ? resolveSkillPaths(raw, baseDir) : [];
+}
+
+export function saveSkillPaths(
+  paths: readonly unknown[],
+  baseDir: string = process.cwd(),
+  path: string = defaultConfigPath(),
+): string[] {
+  const cfg = readConfig(path);
+  const normalized = normalizeSkillPaths(paths, baseDir);
+  cfg.skills = { ...(cfg.skills ?? {}), paths: normalized };
+  writeConfig(cfg, path);
+  return normalized;
+}
+
+export function addSkillPath(
+  skillPath: string,
+  baseDir: string = process.cwd(),
+  path: string = defaultConfigPath(),
+): { added: boolean; path: string; resolved: string; paths: string[] } | { error: string } {
+  const entry = normalizeSkillPathEntries([skillPath], baseDir)[0];
+  if (!entry) return { error: "skill path is empty" };
+  const existing = loadSkillPaths(baseDir, path);
+  const seen = new Set(resolveSkillPaths(existing, baseDir).map(skillPathKey));
+  const key = skillPathKey(entry.resolved);
+  if (seen.has(key))
+    return { added: false, path: entry.raw, resolved: entry.resolved, paths: existing };
+  const paths = saveSkillPaths([...existing, entry.raw], baseDir, path);
+  return { added: true, path: entry.raw, resolved: entry.resolved, paths };
+}
+
+export function removeSkillPath(
+  target: string,
+  baseDir: string = process.cwd(),
+  path: string = defaultConfigPath(),
+): { removed: boolean; path?: string; resolved?: string; paths: string[] } {
+  const existing = loadSkillPaths(baseDir, path);
+  const trimmed = target.trim();
+  if (!trimmed) return { removed: false, paths: existing };
+  const existingEntries = normalizeSkillPathEntries(existing, baseDir);
+  const idx = /^\d+$/.test(trimmed) ? Number.parseInt(trimmed, 10) - 1 : -1;
+  let removeAt = idx >= 0 && idx < existing.length ? idx : -1;
+  if (removeAt < 0) {
+    const targetEntry = normalizeSkillPathEntries([trimmed], baseDir)[0];
+    const targetKey = targetEntry ? skillPathKey(targetEntry.resolved) : undefined;
+    removeAt = existingEntries.findIndex(
+      (entry) =>
+        entry.raw === trimmed ||
+        (targetKey !== undefined && skillPathKey(entry.resolved) === targetKey),
+    );
+  }
+  if (removeAt < 0) return { removed: false, paths: existing };
+  const removed = existingEntries[removeAt];
+  const paths = saveSkillPaths(
+    existing.filter((_, i) => i !== removeAt),
+    baseDir,
+    path,
+  );
+  return {
+    removed: true,
+    path: removed?.raw ?? existing[removeAt],
+    resolved: removed?.resolved,
+    paths,
+  };
 }
 
 export function searchEnabled(path: string = defaultConfigPath()): boolean {

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -278,8 +278,8 @@ export const EN: TranslationSchema = {
       argsHint: "[list|show <name>|forget <name>|clear <scope> confirm]",
     },
     skill: {
-      description: "list / run user skills (<project>/.reasonix/skills + ~/.reasonix/skills)",
-      argsHint: "[list|show <name>|<name> [args]]",
+      description: "list / run user skills (project + custom + global + builtin)",
+      argsHint: "[list|paths|show <name>|<name> [args]]",
     },
     hooks: {
       description: "list active hooks (settings.json under .reasonix/) · reload re-reads from disk",
@@ -1091,6 +1091,19 @@ export const EN: TranslationSchema = {
       newUsage: "usage: /skill new <name> [--global]",
       newCreated: "▸ created skill: {name}\n  {path}\n  edit it, then `/skill {name}` to invoke",
       newError: "▲ /skill new failed: {reason}",
+      pathsHeader: "Skill paths (priority order):",
+      pathsPriority:
+        "Priority: project > custom paths in config order > global > builtin. Changes affect the system prompt on next /new or new session.",
+      pathsUsage:
+        "usage: /skill paths [list]\n       /skill paths add <path>\n       /skill paths remove <path|N>",
+      pathsAddUsage: "usage: /skill paths add <path>",
+      pathsRemoveUsage: "usage: /skill paths remove <path|N>",
+      pathsAdded: "▸ added custom skills path: {path}",
+      pathsAlready: "▸ custom skills path already configured: {path}",
+      pathsRemoved: "▸ removed custom skills path: {path}",
+      pathsRemoveNotFound: "▸ no custom skills path matches: {target}",
+      pathsRestartHint:
+        "The current session's system prompt is unchanged; run /new or start a new session to refresh the skills index.",
     },
   },
   statusBar: {

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -271,8 +271,8 @@ export const zhCN: TranslationSchema = {
       argsHint: "[list|show <name>|forget <name>|clear <scope> confirm]",
     },
     skill: {
-      description: "列出 / 运行用户技能（<project>/.reasonix/skills + ~/.reasonix/skills）",
-      argsHint: "[list|show <name>|<name> [args]]",
+      description: "列出 / 运行用户技能（项目 + 自定义 + 全局 + 内置）",
+      argsHint: "[list|paths|show <name>|<name> [args]]",
     },
     hooks: {
       description: "列出活跃的 hooks（.reasonix/ 下的 settings.json）· reload 从磁盘重新读取",
@@ -1034,6 +1034,18 @@ export const zhCN: TranslationSchema = {
       newUsage: "用法：/skill new <name> [--global]",
       newCreated: "▸ 已创建技能：{name}\n  {path}\n  编辑后用 `/skill {name}` 调用",
       newError: "▲ /skill new 失败：{reason}",
+      pathsHeader: "技能路径（按优先级）：",
+      pathsPriority:
+        "优先级：项目 > 配置顺序中的自定义路径 > 全局 > 内置。更改会在下次 /new 或新会话刷新系统提示词时生效。",
+      pathsUsage:
+        "用法：/skill paths [list]\n       /skill paths add <path>\n       /skill paths remove <path|N>",
+      pathsAddUsage: "用法：/skill paths add <path>",
+      pathsRemoveUsage: "用法：/skill paths remove <path|N>",
+      pathsAdded: "▸ 已添加自定义技能路径：{path}",
+      pathsAlready: "▸ 自定义技能路径已存在：{path}",
+      pathsRemoved: "▸ 已移除自定义技能路径：{path}",
+      pathsRemoveNotFound: "▸ 没有匹配的自定义技能路径：{target}",
+      pathsRestartHint: "当前会话的系统提示词不会热更新；运行 /new 或启动新会话以刷新技能索引。",
     },
   },
   statusBar: {

--- a/src/memory/user.ts
+++ b/src/memory/user.ts
@@ -11,7 +11,12 @@ import {
 } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
-import { type ReasonixConfig, memoryTypeDefaults } from "../config.js";
+import {
+  type ReasonixConfig,
+  loadResolvedSkillPaths,
+  memoryTypeDefaults,
+  resolveSkillPaths,
+} from "../config.js";
 import { parseFrontmatter } from "../frontmatter.js";
 import { applySkillsIndex } from "../skills.js";
 import { applyProjectMemory, memoryEnabled } from "./project.js";
@@ -413,16 +418,18 @@ export function applyUserMemory(
 export function applyMemoryStack(
   basePrompt: string,
   rootDir: string,
-  opts: { homeDir?: string } = {},
+  opts: { homeDir?: string; cfg?: ReasonixConfig } = {},
 ): string {
+  const homeDir = opts.homeDir;
+  const cfg = opts.cfg;
   const withProject = applyProjectMemory(basePrompt, rootDir);
   const withGlobal = applyGlobalReasonixMemory(
     withProject,
-    opts.homeDir ? join(opts.homeDir, ".reasonix") : undefined,
+    homeDir ? join(homeDir, ".reasonix") : undefined,
   );
-  const withMemory = applyUserMemory(withGlobal, {
-    projectRoot: rootDir,
-    homeDir: opts.homeDir,
-  });
-  return applySkillsIndex(withMemory, { projectRoot: rootDir, homeDir: opts.homeDir });
+  const withMemory = applyUserMemory(withGlobal, { projectRoot: rootDir, homeDir, cfg });
+  const customSkillPaths = cfg?.skills?.paths
+    ? resolveSkillPaths(cfg.skills.paths, rootDir)
+    : loadResolvedSkillPaths(rootDir);
+  return applySkillsIndex(withMemory, { projectRoot: rootDir, homeDir, customSkillPaths });
 }

--- a/src/server/api/settings.ts
+++ b/src/server/api/settings.ts
@@ -1,6 +1,14 @@
 /** apiKey is write-only on the wire; GET always returns a redacted form so dashboard screenshots don't leak credentials. */
 
-import { isPlausibleKey, readConfig, redactKey, saveEditMode, writeConfig } from "../../config.js";
+import {
+  isPlausibleKey,
+  normalizeSkillPathEntries,
+  normalizeSkillPaths,
+  readConfig,
+  redactKey,
+  saveEditMode,
+  writeConfig,
+} from "../../config.js";
 import { getLanguage, getSupportedLanguages, setLanguage } from "../../i18n/index.js";
 import type { LanguageCode } from "../../i18n/types.js";
 import type { DashboardContext } from "../context.js";
@@ -16,6 +24,7 @@ interface SettingsBody {
   model?: unknown;
   proNext?: unknown;
   budgetUsd?: unknown;
+  skillPaths?: unknown;
 }
 
 function parseBody(raw: string): SettingsBody {
@@ -63,6 +72,14 @@ export async function handleSettings(
         proNext: live?.proArmed ?? false,
         budgetUsd: live?.budgetUsd ?? null,
         sessionSpendUsd: ctx.getStats?.()?.totalCostUsd ?? null,
+        skillPaths: normalizeSkillPaths(
+          cfg.skills?.paths ?? [],
+          ctx.getCurrentCwd?.() ?? process.cwd(),
+        ),
+        skillPathEntries: normalizeSkillPathEntries(
+          cfg.skills?.paths ?? [],
+          ctx.getCurrentCwd?.() ?? process.cwd(),
+        ),
         // Hint to the SPA which fields require restart.
         appliesAt: {
           apiKey: "next-session",
@@ -73,6 +90,7 @@ export async function handleSettings(
           model: "next-turn",
           proNext: "next-turn",
           budgetUsd: "live",
+          skillPaths: "next-session",
         },
       },
     };
@@ -177,6 +195,22 @@ export async function handleSettings(
         };
       }
       changed.push("budgetUsd");
+    }
+
+    if (fields.skillPaths !== undefined) {
+      const raw = Array.isArray(fields.skillPaths)
+        ? fields.skillPaths
+        : typeof fields.skillPaths === "string"
+          ? fields.skillPaths.split(",")
+          : null;
+      if (!raw) {
+        return { status: 400, body: { error: "skillPaths must be a string or string[]" } };
+      }
+      cfg.skills = {
+        ...(cfg.skills ?? {}),
+        paths: normalizeSkillPaths(raw, ctx.getCurrentCwd?.() ?? process.cwd()),
+      };
+      changed.push("skillPaths");
     }
 
     if (changed.length > 0) {

--- a/src/server/api/skills.ts
+++ b/src/server/api/skills.ts
@@ -15,8 +15,9 @@ import {
 } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+import { loadResolvedSkillPaths } from "../../config.js";
 import { parseFrontmatter } from "../../frontmatter.js";
-import { SKILLS_DIRNAME, SKILL_FILE, validateSkillFrontmatter } from "../../skills.js";
+import { SKILLS_DIRNAME, SKILL_FILE, SkillStore, validateSkillFrontmatter } from "../../skills.js";
 import { readUsageLog } from "../../telemetry/usage.js";
 import type { DashboardContext } from "../context.js";
 import type { ApiResult } from "../router.js";
@@ -47,7 +48,7 @@ function projectSkillsDir(rootDir: string): string {
 
 interface SkillListEntry {
   name: string;
-  scope: "project" | "global" | "builtin";
+  scope: "project" | "custom" | "global" | "builtin";
   description?: string;
   path: string;
   size: number;
@@ -69,7 +70,7 @@ function parseFrontmatterDescription(raw: string): string | undefined {
 function readSkillListEntry(
   skillPath: string,
   name: string,
-  scope: "project" | "global",
+  scope: "project" | "custom" | "global",
 ): SkillListEntry | null {
   try {
     // Open once and reuse the fd so size/mtime/content all bind to
@@ -126,7 +127,7 @@ function defaultSkillPath(dir: string, name: string): ResolvedSkillPath {
   return { path: join(dir, name, SKILL_FILE), layout: "folder" };
 }
 
-function listSkills(dir: string, scope: "project" | "global"): SkillListEntry[] {
+function listSkills(dir: string, scope: "project" | "custom" | "global"): SkillListEntry[] {
   if (!existsSync(dir)) return [];
   const out: SkillListEntry[] = [];
   try {
@@ -177,10 +178,16 @@ export async function handleSkills(
     const runs7d = countSubagentRuns(ctx.usageLogPath);
     const tag = (rows: SkillListEntry[]) =>
       rows.map((r) => ({ ...r, runs7d: runs7d.get(r.name) ?? 0 }));
+    const store = new SkillStore({
+      projectRoot: cwd,
+      customSkillPaths: loadResolvedSkillPaths(cwd ?? process.cwd(), ctx.configPath),
+    });
+    const customRoots = store.customRoots();
     return {
       status: 200,
       body: {
         global: tag(listSkills(globalSkillsDir(), "global")),
+        custom: tag(customRoots.flatMap((root) => listSkills(root.dir, "custom"))),
         project: cwd ? tag(listSkills(projectSkillsDir(cwd), "project")) : [],
         builtin: [
           {
@@ -199,6 +206,7 @@ export async function handleSkills(
         paths: {
           global: globalSkillsDir(),
           project: cwd ? projectSkillsDir(cwd) : null,
+          custom: customRoots,
         },
       },
     };

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -1,8 +1,17 @@
 /** Project scope wins over global. Only names+descriptions enter the prefix; bodies load lazily into the append-only log. */
 
-import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import {
+  constants,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { accessSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { dirname, isAbsolute, join, resolve } from "node:path";
 import { parseFrontmatter } from "./frontmatter.js";
 import { NEGATIVE_CLAIM_RULE, TUI_FORMATTING_RULES } from "./prompt-fragments.js";
 
@@ -13,7 +22,9 @@ export const SKILLS_INDEX_MAX_CHARS = 4000;
 /** Skill identifier shape — alnum + `_` + `-` + interior `.`, 1-64 chars. */
 const VALID_SKILL_NAME = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$/;
 
-export type SkillScope = "project" | "global" | "builtin";
+export type SkillScope = "project" | "custom" | "global" | "builtin";
+
+export type SkillPathStatus = "ok" | "missing" | "not-directory" | "unreadable";
 
 /** inline = body enters parent log; subagent = isolated child loop, only final answer returns. */
 export type SkillRunAs = "inline" | "subagent";
@@ -38,11 +49,19 @@ export interface Skill {
   maxToolIters?: number;
 }
 
+export interface SkillRoot {
+  dir: string;
+  scope: Exclude<SkillScope, "builtin">;
+  status: SkillPathStatus;
+  priority: number;
+}
+
 export interface SkillStoreOptions {
   /** Override `$HOME` — tests point this at a tmpdir. */
   homeDir?: string;
   /** Required for project-scope skills; omit to read only the global scope. */
   projectRoot?: string;
+  customSkillPaths?: readonly string[];
   /** Suppress bundled built-ins — for tests asserting exact list contents. */
   disableBuiltins?: boolean;
 }
@@ -84,11 +103,16 @@ function parseMaxToolIters(raw: string | undefined): number | undefined {
 export class SkillStore {
   private readonly homeDir: string;
   private readonly projectRoot: string | undefined;
+  private readonly customSkillPaths: readonly string[];
   private readonly disableBuiltins: boolean;
 
   constructor(opts: SkillStoreOptions = {}) {
     this.homeDir = opts.homeDir ?? homedir();
     this.projectRoot = opts.projectRoot ? resolve(opts.projectRoot) : undefined;
+    const baseDir = this.projectRoot ?? process.cwd();
+    this.customSkillPaths = dedupePaths(
+      opts.customSkillPaths?.map((p) => resolveCustomSkillPath(p, baseDir, this.homeDir)) ?? [],
+    );
     this.disableBuiltins = opts.disableBuiltins === true;
   }
 
@@ -97,24 +121,29 @@ export class SkillStore {
     return this.projectRoot !== undefined;
   }
 
-  /** Project scope first so per-repo skill overrides a global with the same name. */
-  roots(): Array<{ dir: string; scope: SkillScope }> {
-    const out: Array<{ dir: string; scope: SkillScope }> = [];
+  /** Project scope first so per-repo skill overrides custom/global entries with the same name. */
+  roots(): SkillRoot[] {
+    const out: Array<{ dir: string; scope: Exclude<SkillScope, "builtin"> }> = [];
     if (this.projectRoot) {
       out.push({
         dir: join(this.projectRoot, ".reasonix", SKILLS_DIRNAME),
         scope: "project",
       });
     }
+    for (const dir of this.customSkillPaths) out.push({ dir, scope: "custom" });
     out.push({ dir: join(this.homeDir, ".reasonix", SKILLS_DIRNAME), scope: "global" });
-    return out;
+    return out.map((root, priority) => ({ ...root, priority, status: skillPathStatus(root.dir) }));
   }
 
-  /** Higher-priority root wins on collision (project > global > builtin); sorted for stable prefix hash. */
+  customRoots(): SkillRoot[] {
+    return this.roots().filter((root) => root.scope === "custom");
+  }
+
+  /** Higher-priority root wins on collision (project > custom > global > builtin); sorted for stable prefix hash. */
   list(): Skill[] {
     const byName = new Map<string, Skill>();
-    for (const { dir, scope } of this.roots()) {
-      if (!existsSync(dir)) continue;
+    for (const { dir, scope, status } of this.roots()) {
+      if (status !== "ok") continue;
       let entries: import("node:fs").Dirent[];
       try {
         entries = readdirSync(dir, { withFileTypes: true });
@@ -177,8 +206,8 @@ export class SkillStore {
   /** Resolve one skill by name. Returns `null` if not found or malformed. */
   read(name: string): Skill | null {
     if (!isValidSkillName(name)) return null;
-    for (const { dir, scope } of this.roots()) {
-      if (!existsSync(dir)) continue;
+    for (const { dir, scope, status } of this.roots()) {
+      if (status !== "ok") continue;
       const dirCandidate = join(dir, name, SKILL_FILE);
       if (existsSync(dirCandidate) && statSync(dirCandidate).isFile()) {
         return this.parse(dirCandidate, name, scope);
@@ -231,6 +260,42 @@ export class SkillStore {
       model: data.model?.startsWith("deepseek-") ? data.model : undefined,
       maxToolIters: parseMaxToolIters(data["max-iters"]),
     };
+  }
+}
+
+function dedupePaths(paths: readonly string[]): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const path of paths) {
+    const key = process.platform === "win32" ? path.toLowerCase() : path;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(path);
+  }
+  return out;
+}
+
+function resolveCustomSkillPath(path: string, baseDir: string, homeDir: string): string {
+  const trimmed = path.trim();
+  const expanded =
+    trimmed === "~"
+      ? homeDir
+      : trimmed.startsWith("~/") || trimmed.startsWith("~\\")
+        ? join(homeDir, trimmed.slice(2))
+        : trimmed;
+  return resolve(isAbsolute(expanded) ? expanded : join(baseDir, expanded));
+}
+
+export function skillPathStatus(dir: string): SkillPathStatus {
+  try {
+    const stat = statSync(dir);
+    if (!stat.isDirectory()) return "not-directory";
+    accessSync(dir, constants.R_OK);
+    return "ok";
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") return "missing";
+    return "unreadable";
   }
 }
 

--- a/src/tools/scaffold.ts
+++ b/src/tools/scaffold.ts
@@ -1,6 +1,6 @@
 /** Agent-facing tools for scaffolding skills + MCP servers from chat. Persists via the same paths the wizard / `/skill new` use. */
 
-import { defaultConfigPath, readConfig, writeConfig } from "../config.js";
+import { defaultConfigPath, loadResolvedSkillPaths, readConfig, writeConfig } from "../config.js";
 import { MCP_CATALOG } from "../mcp/catalog.js";
 import { preflightStdioSpec } from "../mcp/preflight.js";
 import { type McpSpec, parseMcpSpec } from "../mcp/spec.js";
@@ -123,6 +123,9 @@ export function registerScaffoldTools(
       const store = new SkillStore({
         homeDir: opts.homeDir,
         projectRoot: opts.projectRoot,
+        customSkillPaths: opts.projectRoot
+          ? loadResolvedSkillPaths(opts.projectRoot, configPath)
+          : [],
       });
       const result = store.createWithContent(name, scope, content);
       if ("error" in result) {

--- a/src/tools/skills.ts
+++ b/src/tools/skills.ts
@@ -17,6 +17,7 @@ export interface SkillToolsOptions {
   /** Override `$HOME` — tests set this to a tmpdir. */
   homeDir?: string;
   projectRoot?: string;
+  customSkillPaths?: readonly string[];
   /** When omitted, subagent skills error rather than silently falling back to inline (loses isolation). */
   subagentRunner?: SubagentRunner;
   /** Hide built-in skills (test-only knob; production callers leave off). */
@@ -32,6 +33,7 @@ export function registerSkillTools(
   const store = new SkillStore({
     homeDir: opts.homeDir,
     projectRoot: opts.projectRoot,
+    customSkillPaths: opts.customSkillPaths,
     disableBuiltins: opts.disableBuiltins,
   });
   const subagentRunner = opts.subagentRunner;

--- a/tests/plan-confirm.test.tsx
+++ b/tests/plan-confirm.test.tsx
@@ -9,7 +9,7 @@ import { makeFakeStdin, makeFakeStdout } from "./helpers/ink-stdio.js";
 
 function bytesFor(plan: string, steps?: { id: string; title: string }[]): string {
   const { lastFrame, unmount } = render(
-    <PlanConfirm plan={plan} steps={steps as never} onChoose={() => {}} />,
+    React.createElement(PlanConfirm, { plan, steps: steps as never, onChoose: () => {} }),
   );
   const out = lastFrame() ?? "";
   unmount();

--- a/tests/server-dashboard.test.ts
+++ b/tests/server-dashboard.test.ts
@@ -355,6 +355,35 @@ describe("dashboard server: endpoints", () => {
     }
   });
 
+  it("GET /api/skills returns custom skills and path status", async () => {
+    const proj = mkdtempSync(join(tmpdir(), "reasonix-dash-skills-custom-proj-"));
+    const custom = mkdtempSync(join(tmpdir(), "reasonix-dash-skills-custom-"));
+    try {
+      await writeFile(
+        cfgPath,
+        JSON.stringify({ skills: { paths: [custom, join(proj, "missing")] } }),
+        "utf8",
+      );
+      await mkdir(join(custom, "custom-skill"), { recursive: true });
+      await writeFile(
+        join(custom, "custom-skill", "SKILL.md"),
+        "---\ndescription: Custom skill\n---\ncustom body\n",
+        "utf8",
+      );
+      const base = await boot({ getCurrentCwd: () => proj });
+      const list = await call(`${base}api/skills`, { token: TOKEN });
+      expect(list.status).toBe(200);
+      expect(list.body.custom.map((s: { name: string }) => s.name)).toEqual(["custom-skill"]);
+      expect(list.body.paths.custom.map((p: { status: string }) => p.status)).toEqual([
+        "ok",
+        "missing",
+      ]);
+    } finally {
+      rmSync(proj, { recursive: true, force: true });
+      rmSync(custom, { recursive: true, force: true });
+    }
+  });
+
   it("POST /api/skills rejects content missing a description frontmatter line (#583)", async () => {
     const proj = mkdtempSync(join(tmpdir(), "reasonix-dash-skills-desc-"));
     try {

--- a/tests/settings-api.test.ts
+++ b/tests/settings-api.test.ts
@@ -1,7 +1,13 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  addSkillPath,
+  loadResolvedSkillPaths,
+  loadSkillPaths,
+  resolveSkillPath,
+} from "../src/config.js";
 import { handleSettings } from "../src/server/api/settings.js";
 import type { DashboardContext } from "../src/server/context.js";
 
@@ -116,6 +122,141 @@ describe("settings API — combined POST persistence (#274)", () => {
     expect(res.status).toBe(200);
     expect((res.body as { search: boolean }).search).toBe(false);
     expect(readFileSync(configPath, "utf8")).toBe(before);
+  });
+
+  it("GET/POST supports skillPaths as a comma-separated string", async () => {
+    const customA = join(dir, "custom-a");
+    const customB = join(dir, "custom-b");
+    mkdirSync(customA, { recursive: true });
+    const post = await handleSettings(
+      "POST",
+      [],
+      JSON.stringify({ skillPaths: `${customA}, ${customB}, ${customA}` }),
+      { ...makeCtx(configPath), getCurrentCwd: () => dir },
+    );
+    expect(post.status).toBe(200);
+    expect((post.body as { changed: string[] }).changed).toContain("skillPaths");
+    expect(readCfg(configPath).skills).toEqual({ paths: [customA, customB] });
+
+    const get = await handleSettings("GET", [], "", {
+      ...makeCtx(configPath),
+      getCurrentCwd: () => dir,
+    });
+    expect((get.body as { skillPaths: string[] }).skillPaths).toEqual([customA, customB]);
+  });
+
+  it("POST keeps relative, home, and absolute skillPaths raw while exposing resolved entries", async () => {
+    const absolute = "/opt/skills";
+    const post = await handleSettings(
+      "POST",
+      [],
+      JSON.stringify({
+        skillPaths: "skills-local, ~/.agents/skills/find-skills, /opt/skills, skills-local",
+      }),
+      { ...makeCtx(configPath), getCurrentCwd: () => dir },
+    );
+    expect(post.status).toBe(200);
+    expect(readCfg(configPath).skills).toEqual({
+      paths: ["skills-local", "~/.agents/skills/find-skills", absolute],
+    });
+
+    const get = await handleSettings("GET", [], "", {
+      ...makeCtx(configPath),
+      getCurrentCwd: () => dir,
+    });
+    expect(get.status).toBe(200);
+    expect((get.body as { skillPaths: string[] }).skillPaths).toEqual([
+      "skills-local",
+      "~/.agents/skills/find-skills",
+      absolute,
+    ]);
+    expect(
+      (get.body as { skillPathEntries: Array<{ raw: string; resolved: string }> }).skillPathEntries,
+    ).toEqual([
+      { raw: "skills-local", resolved: resolve(dir, "skills-local") },
+      {
+        raw: "~/.agents/skills/find-skills",
+        resolved: join(homedir(), ".agents", "skills", "find-skills"),
+      },
+      { raw: absolute, resolved: absolute },
+    ]);
+  });
+
+  it("POST supports skillPaths as an array and stores relative paths raw", async () => {
+    const res = await handleSettings(
+      "POST",
+      [],
+      JSON.stringify({ skillPaths: ["skills-a", "", "skills-b"] }),
+      { ...makeCtx(configPath), getCurrentCwd: () => dir },
+    );
+    expect(res.status).toBe(200);
+    expect(readCfg(configPath).skills).toEqual({ paths: ["skills-a", "skills-b"] });
+    expect(loadResolvedSkillPaths(dir, configPath)).toEqual([
+      join(dir, "skills-a"),
+      join(dir, "skills-b"),
+    ]);
+  });
+
+  it("GET reads raw skillPaths written through the CLI helper", async () => {
+    const result = addSkillPath("cli-skills", dir, configPath);
+    expect("error" in result).toBe(false);
+
+    const get = await handleSettings("GET", [], "", {
+      ...makeCtx(configPath),
+      getCurrentCwd: () => dir,
+    });
+    expect(get.status).toBe(200);
+    expect((get.body as { skillPaths: string[] }).skillPaths).toEqual(["cli-skills"]);
+  });
+
+  it("GET returns settings POST skillPaths without expanding current user home", async () => {
+    const post = await handleSettings(
+      "POST",
+      [],
+      JSON.stringify({ skillPaths: ["~/.agents/skills/find-skills"] }),
+      { ...makeCtx(configPath), getCurrentCwd: () => dir },
+    );
+    expect(post.status).toBe(200);
+    expect(readCfg(configPath).skills).toEqual({ paths: ["~/.agents/skills/find-skills"] });
+
+    const get = await handleSettings("GET", [], "", {
+      ...makeCtx(configPath),
+      getCurrentCwd: () => dir,
+    });
+    expect(get.status).toBe(200);
+    expect((get.body as { skillPaths: string[] }).skillPaths).toEqual([
+      "~/.agents/skills/find-skills",
+    ]);
+    expect(loadResolvedSkillPaths(dir, configPath)).toEqual([
+      join(homedir(), ".agents", "skills", "find-skills"),
+    ]);
+  });
+
+  it("CLI helper reads raw skillPaths written through settings POST", async () => {
+    const post = await handleSettings("POST", [], JSON.stringify({ skillPaths: ["web-skills"] }), {
+      ...makeCtx(configPath),
+      getCurrentCwd: () => dir,
+    });
+    expect(post.status).toBe(200);
+    expect(loadSkillPaths(dir, configPath)).toEqual(["web-skills"]);
+    expect(loadResolvedSkillPaths(dir, configPath)).toEqual([join(dir, "web-skills")]);
+  });
+
+  it("CLI helper preserves raw skillPaths and exposes resolved paths", () => {
+    const result = addSkillPath("skills-local", dir, configPath);
+    expect("error" in result).toBe(false);
+    expect(loadSkillPaths(dir, configPath)).toEqual(["skills-local"]);
+    expect(loadResolvedSkillPaths(dir, configPath)).toEqual([join(dir, "skills-local")]);
+    expect(resolveSkillPath("skills-local", dir)).toBe(join(dir, "skills-local"));
+  });
+
+  it("CLI helper preserves home raw skillPaths and resolves them internally", () => {
+    const result = addSkillPath("~/.agents/skills/find-skills", dir, configPath);
+    expect("error" in result).toBe(false);
+    expect(loadSkillPaths(dir, configPath)).toEqual(["~/.agents/skills/find-skills"]);
+    expect(loadResolvedSkillPaths(dir, configPath)).toEqual([
+      join(homedir(), ".agents", "skills", "find-skills"),
+    ]);
   });
 
   it("fires applyPresetLive only after the disk write succeeds", async () => {

--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -2,13 +2,13 @@
 
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { SkillStore, applySkillsIndex, validateSkillFrontmatter } from "../src/skills.js";
 
 const BASE = "You are a test assistant.";
 
-type SkillRoot = "project" | "global";
+type SkillRoot = "project" | "global" | "custom";
 
 function writeSkillDir(
   root: string,
@@ -21,7 +21,9 @@ function writeSkillDir(
   const parent =
     which === "global"
       ? join(homeOrProject, ".reasonix", "skills")
-      : join(root, ".reasonix", "skills");
+      : which === "project"
+        ? join(root, ".reasonix", "skills")
+        : homeOrProject;
   const dir = join(parent, name);
   mkdirSync(dir, { recursive: true });
   const fmLines = ["---"];
@@ -146,6 +148,103 @@ describe("SkillStore", () => {
     writeFileSync(join(dotDir, ".hidden.md"), "---\ndescription: x\n---\nbody\n", "utf8");
     const list = new SkillStore({ homeDir: home, projectRoot, disableBuiltins: true }).list();
     expect(list.map((s) => s.name)).toEqual(["ok"]);
+  });
+
+  it("reads custom flat and dir-layout skills directly from configured roots", () => {
+    const custom = mkdtempSync(join(tmpdir(), "reasonix-skills-custom-"));
+    try {
+      writeSkillDir(
+        projectRoot,
+        "custom",
+        "custom-dir",
+        { description: "custom dir" },
+        "D",
+        custom,
+      );
+      const flatPath = join(custom, "custom-flat.md");
+      writeFileSync(flatPath, "---\ndescription: custom flat\n---\nF\n", "utf8");
+      const list = new SkillStore({
+        homeDir: home,
+        projectRoot,
+        customSkillPaths: [custom],
+        disableBuiltins: true,
+      }).list();
+      expect(list.map((s) => `${s.scope}:${s.name}`)).toEqual([
+        "custom:custom-dir",
+        "custom:custom-flat",
+      ]);
+      expect(list.find((s) => s.name === "custom-flat")?.path).toBe(flatPath);
+    } finally {
+      rmSync(custom, { recursive: true, force: true });
+    }
+  });
+
+  it("deduplicates custom roots and preserves first priority", () => {
+    const custom = mkdtempSync(join(tmpdir(), "reasonix-skills-custom-"));
+    try {
+      const roots = new SkillStore({
+        homeDir: home,
+        projectRoot,
+        customSkillPaths: [custom, custom],
+        disableBuiltins: true,
+      }).customRoots();
+      expect(roots.map((r) => r.dir)).toEqual([custom]);
+    } finally {
+      rmSync(custom, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves relative custom roots against projectRoot for discovery", () => {
+    const relativeRoot = "skills-local";
+    const custom = join(projectRoot, relativeRoot);
+    writeSkillDir(projectRoot, "custom", "local-skill", { description: "local" }, "L", custom);
+    const store = new SkillStore({
+      homeDir: home,
+      projectRoot,
+      customSkillPaths: [relativeRoot, custom],
+      disableBuiltins: true,
+    });
+    expect(store.customRoots().map((r) => r.dir)).toEqual([resolve(projectRoot, relativeRoot)]);
+    expect(store.list().map((s) => s.name)).toEqual(["local-skill"]);
+  });
+
+  it("keeps priority project > custom > global on same-name collisions", () => {
+    const custom = mkdtempSync(join(tmpdir(), "reasonix-skills-custom-"));
+    try {
+      writeSkillDir(projectRoot, "global", "same", { description: "global" }, "G", home);
+      writeSkillDir(projectRoot, "custom", "same", { description: "custom" }, "C", custom);
+      const customWinner = new SkillStore({
+        homeDir: home,
+        projectRoot,
+        customSkillPaths: [custom],
+        disableBuiltins: true,
+      }).read("same");
+      expect(customWinner?.scope).toBe("custom");
+      writeSkillDir(projectRoot, "project", "same", { description: "project" }, "P", home);
+      const projectWinner = new SkillStore({
+        homeDir: home,
+        projectRoot,
+        customSkillPaths: [custom],
+        disableBuiltins: true,
+      }).read("same");
+      expect(projectWinner?.scope).toBe("project");
+    } finally {
+      rmSync(custom, { recursive: true, force: true });
+    }
+  });
+
+  it("reports invalid custom root status without throwing", () => {
+    const missing = join(projectRoot, "missing-skills");
+    const notDir = join(projectRoot, "file.txt");
+    writeFileSync(notDir, "x", "utf8");
+    const store = new SkillStore({
+      homeDir: home,
+      projectRoot,
+      customSkillPaths: [missing, notDir],
+      disableBuiltins: true,
+    });
+    expect(store.list()).toEqual([]);
+    expect(store.customRoots().map((r) => r.status)).toEqual(["missing", "not-directory"]);
   });
 
   describe("create() — /skill new scaffold (#366)", () => {

--- a/tests/tools-skills.test.ts
+++ b/tests/tools-skills.test.ts
@@ -74,6 +74,45 @@ describe("run_skill tool", () => {
     expect(out).toContain("Run pipeline");
   });
 
+  it("returns a custom path skill when customSkillPaths is passed", async () => {
+    const custom = mkdtempSync(join(tmpdir(), "reasonix-skilltool-custom-"));
+    try {
+      const dir = join(custom, "custom-run");
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(
+        join(dir, "SKILL.md"),
+        "---\nname: custom-run\ndescription: Custom run\n---\n\nCustom body\n",
+        "utf8",
+      );
+      const reg = new ToolRegistry();
+      registerSkillTools(reg, { homeDir: home, customSkillPaths: [custom], disableBuiltins: true });
+      const out = await reg.dispatch("run_skill", { name: "custom-run" });
+      expect(out).toContain("scope: custom");
+      expect(out).toContain("Custom body");
+    } finally {
+      rmSync(custom, { recursive: true, force: true });
+    }
+  });
+
+  it("unknown skill available list includes custom skills", async () => {
+    const custom = mkdtempSync(join(tmpdir(), "reasonix-skilltool-custom-"));
+    try {
+      const dir = join(custom, "custom-known");
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(
+        join(dir, "SKILL.md"),
+        "---\nname: custom-known\ndescription: Custom known\n---\n\nbody\n",
+        "utf8",
+      );
+      const reg = new ToolRegistry();
+      registerSkillTools(reg, { homeDir: home, customSkillPaths: [custom], disableBuiltins: true });
+      const out = await reg.dispatch("run_skill", { name: "missing" });
+      expect(JSON.parse(out).available).toContain("custom-known");
+    } finally {
+      rmSync(custom, { recursive: true, force: true });
+    }
+  });
+
   it("appends a forwarded 'Arguments:' line when provided", async () => {
     writeSkill(home, "greet", "Greet someone", "Say hello to the name in args.");
     const reg = new ToolRegistry();


### PR DESCRIPTION
<!-- Read CONTRIBUTING.md first if this is your first PR. -->

## What

Adds configurable custom skill roots for Reasonix. Users can add, list, and remove custom skill paths from the CLI, configure the same paths from the Web UI settings page, and have those paths participate in skill discovery alongside project, global, and built-in skills. The implementation keeps the user-entered path text as the saved/displayed value while resolving paths internally for discovery, status checks, and deduplication.

<!-- One paragraph: what does this change? -->

## Why

Fixes the workflow requested in issue #870: users need to reuse skills stored outside the built-in/project/global skill directories and manage those locations consistently across CLI and Web UI. This also fixes follow-up path handling issues so CLI-saved paths appear in Web UI settings, ~/... is resolved correctly for runtime use, and relative paths are not rewritten in the saved configuration.

<!-- Bug fix? Pre-existing issue? Linked discussion? -->

## How to verify

Run npm run verify.
In the CLI, run /skill paths add ~/.agents/skills/find-skills, then /skill paths and confirm the configured value remains ~/.agents/skills/find-skills while the resolved/status information points at the home directory.
Open the Web UI settings page and confirm the same skill path appears in the skills paths field.
Save comma-separated paths from the Web UI, then confirm /skill paths shows the same configured values in the CLI.
Confirm custom skills from those paths appear in /skill list, the Web UI skills panel, and are usable through the skill runner.

<!-- Steps the reviewer can run. `npm run verify` is assumed. -->

## Checklist

- [ ✅] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [ ✅] No `Co-Authored-By: Claude` trailer in commits
- [ ✅] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [ ✅] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time
