### PR TITLE
ci: add windows-latest to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,12 @@ on:
 
 jobs:
   build:
-    name: build (node ${{ matrix.node }})
-    runs-on: ubuntu-latest
+    name: build (${{ matrix.os }} · node ${{ matrix.node }})
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest]
         node: ["22"]
     steps:
       - uses: actions/checkout@v4
@@ -45,6 +46,7 @@ jobs:
       # Smoke-test the bench harnesses themselves. --dry skips all LLM
       # calls, so this catches wiring regressions (task factories, CLI
       # parsing, file IO, checker determinism) without needing a
-      # DEEPSEEK_API_KEY in CI.
+      # DEEPSEEK_API_KEY in CI. RUNNER_TEMP is set on every GH Actions
+      # runner (POSIX + Windows) — beats hardcoding /tmp.
       - name: τ-bench harness dry-run
-        run: npx tsx benchmarks/tau-bench/runner.ts --dry --out /tmp/tau-dry.json
+        run: npx tsx benchmarks/tau-bench/runner.ts --dry --out "${{ runner.temp }}/tau-dry.json"


### PR DESCRIPTION
## Summary

Recent PRs landed Windows-specific bugs that Ubuntu-only CI couldn't catch — literal forward-slash separators in path comparisons (#911) and `partial.startsWith("/")` as the "is absolute path" heuristic (#922) both sailed through green on `ubuntu-latest` while shipping broken on the platform the bulk of our users actually run.

Add `windows-latest` to the existing matrix so every PR exercises the Windows code paths (taskkill tree-kill, MS Store node-shim detection, path separator handling, `CREATE_NO_WINDOW`, etc.) before review. Job name now includes the OS so the two runs are distinguishable in branch protection.

Side fix: the τ-bench dry-run hardcoded `/tmp/tau-dry.json`, which isn't a path on Windows. Swap for `${{ runner.temp }}` — set on every GH Actions runner, POSIX and Windows alike.

## Test plan

- All 2906 tests pass locally on Windows + Git Bash before opening this — that's a strong (not perfect) signal that `windows-latest` will be mostly green.
- If something breaks on `windows-latest` in CI that didn't break locally, I'll triage in a follow-up commit on this branch: either fix the test (preferred) or mark `it.skipIf(process.platform === "win32")` with a one-line reason. Goal is the matrix lands green; we'll inspect the first run's output to decide which path each failure takes.

## Why not also macOS

Most behaviors mirror Linux. The differences (BSD-style `ps` / `pkill`, `detached` process-group semantics) aren't currently exercised by any test that doesn't also run on Linux. Cheap to add later if a Mac-specific bug surfaces.
