### PR TITLE
fix(repair): prevent silent execution with empty args on truncation failure, fix POSIX process-group kill

### DIFF
--- a/src/repair/index.ts
+++ b/src/repair/index.ts
@@ -89,9 +89,22 @@ export class ToolCallRepair {
       const args = call.function?.arguments ?? "";
       const r = repairTruncatedJson(args);
       if (r.changed) {
-        call.function.arguments = r.repaired;
-        report.truncationsFixed++;
-        report.notes.push(...r.notes.map((n) => `[${call.function.name}] ${n}`));
+        if (r.fallback) {
+          // Hard fallback — all repair attempts failed. Leave the
+          // original truncated args untouched so tools.ts dispatch
+          // rejects them with "invalid JSON" rather than silently
+          // running with {} (which would miss required params or
+          // succeed with nonsense args). The JSON parse error is more
+          // informative to the model than "missing required parameter".
+          report.truncationsFixed++;
+          report.notes.push(
+            ...r.notes.map((n) => `[${call.function?.name}] ⚠️ TRUNCATION UNRECOVERABLE: ${n}`),
+          );
+        } else {
+          call.function.arguments = r.repaired;
+          report.truncationsFixed++;
+          report.notes.push(...r.notes.map((n) => `[${call.function.name}] ${n}`));
+        }
       }
     }
 

--- a/src/repair/truncation.ts
+++ b/src/repair/truncation.ts
@@ -11,7 +11,12 @@ export interface TruncationRepairResult {
 export function repairTruncatedJson(input: string): TruncationRepairResult {
   const notes: string[] = [];
   if (!input || !input.trim()) {
-    return { repaired: "{}", changed: input !== "{}", notes: ["empty input → {}"], fallback: false };
+    return {
+      repaired: "{}",
+      changed: input !== "{}",
+      notes: ["empty input → {}"],
+      fallback: false,
+    };
   }
   // Fast path: already parseable.
   try {
@@ -84,8 +89,7 @@ export function repairTruncatedJson(input: string): TruncationRepairResult {
 
   try {
     JSON.parse(s);
-    if (notes.length > 0) return { repaired: s, changed: true, notes, fallback: false };
-    return { repaired: s, changed: false, notes, fallback: false };
+    return { repaired: s, changed: s !== input, notes, fallback: false };
   } catch (err) {
     const preview =
       input.length <= 500 ? input : `${input.slice(0, 500)} …[+${input.length - 500} chars]`;

--- a/src/repair/truncation.ts
+++ b/src/repair/truncation.ts
@@ -4,17 +4,19 @@ export interface TruncationRepairResult {
   repaired: string;
   changed: boolean;
   notes: string[];
+  /** True when all repair attempts failed and the result falls back to "{}" — the original args are unrecoverable. */
+  fallback: boolean;
 }
 
 export function repairTruncatedJson(input: string): TruncationRepairResult {
   const notes: string[] = [];
   if (!input || !input.trim()) {
-    return { repaired: "{}", changed: input !== "{}", notes: ["empty input → {}"] };
+    return { repaired: "{}", changed: input !== "{}", notes: ["empty input → {}"], fallback: false };
   }
   // Fast path: already parseable.
   try {
     JSON.parse(input);
-    return { repaired: input, changed: false, notes: [] };
+    return { repaired: input, changed: false, notes: [], fallback: false };
   } catch {
     /* fall through */
   }
@@ -82,9 +84,13 @@ export function repairTruncatedJson(input: string): TruncationRepairResult {
 
   try {
     JSON.parse(s);
-    return { repaired: s, changed: true, notes };
+    if (notes.length > 0) return { repaired: s, changed: true, notes, fallback: false };
+    return { repaired: s, changed: false, notes, fallback: false };
   } catch (err) {
+    const preview =
+      input.length <= 500 ? input : `${input.slice(0, 500)} …[+${input.length - 500} chars]`;
     notes.push(`fallback to {}: ${(err as Error).message}`);
-    return { repaired: "{}", changed: true, notes };
+    notes.push(`unrecoverable truncation — original args preview: ${preview}`);
+    return { repaired: "{}", changed: true, notes, fallback: true };
   }
 }

--- a/src/tools/shell-chain.ts
+++ b/src/tools/shell-chain.ts
@@ -428,6 +428,10 @@ async function runPipeGroup(
         cwd: opts.cwd,
         shell: false,
         windowsHide: true,
+        // POSIX: detach so the child becomes its own process-group leader,
+        // allowing killProcessTree's neg-pid kill to terminate the whole
+        // pipe chain subtree instead of just the direct child.
+        detached: process.platform !== "win32",
         env,
         stdio: [stdinSpec, stdoutSpec, stderrSpec],
         ...spawnOverrides,

--- a/src/tools/shell/exec.ts
+++ b/src/tools/shell/exec.ts
@@ -69,8 +69,16 @@ export async function runCommand(
 
   const spawnOpts: SpawnOptions = {
     cwd: opts.cwd,
-    shell: false, // no shell-expansion — see header comment
+    shell: false,
     windowsHide: true,
+    // POSIX: detach so the child becomes its own process-group leader.
+    // Required for `process.kill(-pid, …)` in killProcessTree to
+    // terminate the whole subtree (child + grandchildren) instead of
+    // only the leader — without this grandchildren like npm→node→esbuild
+    // become orphaned.
+    // Windows: detached would spawn a new console window; leave the
+    // default and use taskkill /T for tree termination (see killProcessTree).
+    detached: process.platform !== "win32",
     // PYTHONIOENCODING + PYTHONUTF8 force any spawned Python child
     // (run_command running `python script.py`, etc.) to emit UTF-8
     // on stdout/stderr. Without this, Chinese-Windows defaults

--- a/tests/plan-confirm.test.tsx
+++ b/tests/plan-confirm.test.tsx
@@ -1,5 +1,6 @@
 import { Box, Text } from "ink";
 import { render } from "ink-testing-library";
+// biome-ignore lint/style/useImportType: classic JSX transform requires React in scope
 import React from "react";
 import stripAnsi from "strip-ansi";
 import { describe, expect, it } from "vitest";

--- a/tests/plan-confirm.test.tsx
+++ b/tests/plan-confirm.test.tsx
@@ -1,6 +1,5 @@
 import { Box, Text } from "ink";
 import { render } from "ink-testing-library";
-// biome-ignore lint/style/useImportType: classic JSX transform requires React in scope
 import React from "react";
 import stripAnsi from "strip-ansi";
 import { describe, expect, it } from "vitest";


### PR DESCRIPTION
## Summary

- **Truncation repair fallback**: When JSON truncation repair completely fails, keep the original truncated args instead of replacing with `{}`. This lets `tools.ts` reject the call with an informative "invalid JSON" error rather than silently running with empty args that miss required parameters.
- **POSIX process-group fix**: Set `detached: true` on spawn options (POSIX only) so child processes become their own process-group leaders. This allows `killProcessTree` to terminate the entire subtree (e.g., `npm → node → esbuild`) instead of only the direct child.

## Test plan

- [x] `npm run lint` — 562 files, no issues
- [x] `npm run typecheck` — passes
- [x] `npm run test:coverage` — 191 files / 2905 tests passed
- [x] `npm run build` — successful