### PR TITLE
feat(skills): auto-discover .agents/skills as a default root (closes #870)

### DIFF
--- a/src/skills.ts
+++ b/src/skills.ts
@@ -129,9 +129,16 @@ export class SkillStore {
         dir: join(this.projectRoot, ".reasonix", SKILLS_DIRNAME),
         scope: "project",
       });
+      // #870: pick up `.agents/skills` automatically — common convention shared
+      // by skills.sh-style tooling, no config required.
+      out.push({
+        dir: join(this.projectRoot, ".agents", SKILLS_DIRNAME),
+        scope: "project",
+      });
     }
     for (const dir of this.customSkillPaths) out.push({ dir, scope: "custom" });
     out.push({ dir: join(this.homeDir, ".reasonix", SKILLS_DIRNAME), scope: "global" });
+    out.push({ dir: join(this.homeDir, ".agents", SKILLS_DIRNAME), scope: "global" });
     return out.map((root, priority) => ({ ...root, priority, status: skillPathStatus(root.dir) }));
   }
 

--- a/tests/settings-api.test.ts
+++ b/tests/settings-api.test.ts
@@ -178,7 +178,7 @@ describe("settings API — combined POST persistence (#274)", () => {
         raw: "~/.agents/skills/find-skills",
         resolved: join(homedir(), ".agents", "skills", "find-skills"),
       },
-      { raw: absolute, resolved: absolute },
+      { raw: absolute, resolved: resolve(absolute) },
     ]);
   });
 

--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -114,6 +114,25 @@ describe("SkillStore", () => {
     expect(list[0]?.path).toContain(projectRoot);
   });
 
+  it("discovers .agents/skills as a default root (#870) — both project and global", () => {
+    const projParent = join(projectRoot, ".agents", "skills");
+    mkdirSync(projParent, { recursive: true });
+    const projPath = join(projParent, "deploy", "SKILL.md");
+    mkdirSync(join(projParent, "deploy"));
+    writeFileSync(projPath, "---\ndescription: from .agents\n---\nbody\n", "utf8");
+
+    const globParent = join(home, ".agents", "skills");
+    mkdirSync(globParent, { recursive: true });
+    const globPath = join(globParent, "review", "SKILL.md");
+    mkdirSync(join(globParent, "review"));
+    writeFileSync(globPath, "---\ndescription: glob agents\n---\nbody\n", "utf8");
+
+    const store = new SkillStore({ homeDir: home, projectRoot, disableBuiltins: true });
+    const names = store.list().map((s) => s.name);
+    expect(names).toContain("deploy");
+    expect(names).toContain("review");
+  });
+
   it("project scope wins on a name collision with global", () => {
     writeSkillDir(projectRoot, "global", "review", { description: "global one" }, "G", home);
     writeSkillDir(projectRoot, "project", "review", { description: "project one" }, "P", home);


### PR DESCRIPTION
## Summary

Closes #870. PR #925 landed a configurable-paths system, but the original issue's core ask — *existing* skills sitting in `~/.agents/skills` or `<project>/.agents/skills` should be picked up automatically — still wasn't covered. A user on that convention still had to discover the new setting and configure it, which is exactly the friction the issue asked us to avoid.

Append `.agents/skills` to the default discovery list in `SkillStore.roots()` at both project and global scope, alongside the existing `.reasonix/skills` entries. Skills in skills.sh-style locations now just work on first launch; the configurable-paths layer from #925 is unchanged for everything else.

Side fix: `tests/settings-api.test.ts:181` hardcoded `resolved: "/opt/skills"` which only holds on POSIX. On Windows `/opt/skills` isn't absolute, `path.resolve` rebases it to the current drive, and the production resolver returns `F:\opt\skills`. Wrap the expected in `resolve(absolute)` so both sides compute the value through the same function. This would have been caught by the matrix CI from #926, but #925's build ran a few minutes before that landed.

## Test plan

- [x] `npm run verify` (pre-push gate, all 2923 tests green on Windows + Git Bash)
- [x] New test in `tests/skills.test.ts` — `discovers .agents/skills as a default root (#870) — both project and global` verifies both layers
- [ ] Matrix CI run on this PR will exercise the `windows-latest` job for the first time on the post-#925 codebase
