### PR TITLE
fix(desktop): render single newlines as hard breaks in markdown

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reasonix-desktop",
-  "version": "0.0.0",
+  "version": "0.43.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reasonix-desktop",
-      "version": "0.0.0",
+      "version": "0.43.0",
       "dependencies": {
         "@fontsource/ibm-plex-mono": "^5.2.7",
         "@fontsource/ibm-plex-sans": "^5.2.8",
@@ -22,6 +22,7 @@
         "react-dom": "^19.2.0",
         "react-markdown": "^9.0.1",
         "react-virtuoso": "^4.12.5",
+        "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.0"
       },
       "devDependencies": {
@@ -2260,6 +2261,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-newline-to-break": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz",
+      "integrity": "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-find-and-replace": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-phrasing": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
@@ -3074,6 +3089,21 @@
       "peerDependencies": {
         "react": ">=16 || >=17 || >= 18 || >= 19",
         "react-dom": ">=16 || >=17 || >= 18 || >=19"
+      }
+    },
+    "node_modules/remark-breaks": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
+      "integrity": "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-newline-to-break": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-gfm": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -25,6 +25,7 @@
     "react-dom": "^19.2.0",
     "react-markdown": "^9.0.1",
     "react-virtuoso": "^4.12.5",
+    "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.0"
   },
   "devDependencies": {

--- a/desktop/src/Markdown.tsx
+++ b/desktop/src/Markdown.tsx
@@ -13,6 +13,7 @@ import {
   useState,
 } from "react";
 import ReactMarkdown from "react-markdown";
+import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 import { CodeView } from "./CodeView";
 
@@ -139,7 +140,7 @@ export const Markdown = memo(function Markdown({ source }: { source: string }) {
   return (
     <div className="markdown">
       <ReactMarkdown
-        remarkPlugins={[remarkGfm]}
+        remarkPlugins={[remarkGfm, remarkBreaks]}
         components={{
           pre: ({ children }) => {
             const codeEl = Children.toArray(children).find(


### PR DESCRIPTION
## Summary
- Desktop markdown rendering collapsed line-by-line content into one wrapped paragraph when each line used inline backticks (e.g. tree views like `blog/` / `├──` / `backend/` / …). Soft breaks became spaces, so every segment flowed as an inline-code pill on a single line.
- Added `remark-breaks` to the React-Markdown plugin chain so single newlines render as `<br/>`. This matches chat-UI conventions (GitHub comments, Claude.ai, ChatGPT) and restores tree / ASCII-table / hand-formatted layouts without touching fenced code blocks.

## Test plan
- [x] `tsc --noEmit` in `desktop/` passes
- [ ] Manually paste an AI response containing an inline-backtick tree structure and confirm each entry renders on its own line
- [ ] Verify fenced code blocks (```lang ... ```) still render through `CodeBlock` / `CodeView` unchanged
- [ ] Verify normal prose paragraphs still flow (single newlines inside an authored paragraph now hard-break — accepted tradeoff for chat content)
