### PR TITLE
fix(qq): annotate ws callback params so verify passes

### DIFF
--- a/src/qq/bot.ts
+++ b/src/qq/bot.ts
@@ -205,7 +205,7 @@ export class QQBot extends EventEmitter {
       }
     });
 
-    this.ws.on("message", (raw) => {
+    this.ws.on("message", (raw: WebSocket.RawData) => {
       try {
         const payload = JSON.parse(raw.toString());
         this.handlePayload(payload).catch(() => {});
@@ -231,8 +231,8 @@ export class QQBot extends EventEmitter {
       }
     });
 
-    this.ws.on("error", (err) => {
-      const msg = `QQ WebSocket error: ${(err as Error).message}`;
+    this.ws.on("error", (err: Error) => {
+      const msg = `QQ WebSocket error: ${err.message}`;
       console.error(msg);
       this.emit("bot_error", msg);
     });


### PR DESCRIPTION
## Summary
- `src/qq/bot.ts` message/error handlers used implicit-any callback params, which trips strict TS on every `pre-push` run. Annotating `raw: WebSocket.RawData` and `err: Error` unblocks `verify` without runtime changes.
- The `@types/ws` devDep is already declared in `package.json` from #864 — this is purely a type-annotation fix on the consuming code.

## Test plan
- [x] `npx tsc --noEmit` clean
