### PR TITLE
fix(cli): brighten user card so scrollback messages are scannable

### DIFF
--- a/src/cli/ui/primitives/Pill.tsx
+++ b/src/cli/ui/primitives/Pill.tsx
@@ -25,7 +25,7 @@ export const PILL_SECTION = {
   taskDone: { bg: "#102815", fg: "#7ee787" },
   taskFailed: { bg: "#2c1416", fg: "#ff8b81" },
   plan: { bg: "#2a1f3d", fg: "#d2a8ff" },
-  user: { bg: "#11141a", fg: "#8b949e" },
+  user: { bg: "#1a2433", fg: "#79c0ff" },
   empty: { bg: "#11141a", fg: "#6e7681" },
 } as const;
 

--- a/src/cli/ui/theme/tokens.ts
+++ b/src/cli/ui/theme/tokens.ts
@@ -57,7 +57,7 @@ type ThemeBase = Omit<ThemeTokens, "card">;
 
 function card(fg: ThemeTokens["fg"], tone: ThemeTokens["tone"]): ThemeTokens["card"] {
   return {
-    user: { color: fg.meta, glyph: "◇" },
+    user: { color: tone.brand, glyph: "◇" },
     reasoning: { color: tone.accent, glyph: "◆" },
     streaming: { color: tone.brand, glyph: "◈" },
     task: { color: tone.warn, glyph: "▶" },


### PR DESCRIPTION
## Summary
- The user card was the only card whose tone was `fg.meta` (grey) and whose title pill was near-black (`#11141a` bg + `#8b949e` fg). Once a card scrolls out of the active view, `Card` drops the colored left stripe, so the "You" row collapses into surrounding meta text and becomes hard to spot — see [#910](https://github.com/esengine/DeepSeek-Reasonix/issues/910).
- Switch the card tone to `tone.brand` (themed across all 7 themes) and re-tint the pill to brand blue. Every other card already pulls a tone color; this brings the user card in line.

## Test plan
- [x] `npx vitest run tests/user-card-verbatim.test.tsx tests/ui-reducer.test.ts tests/hydrate-cards.test.ts` — 51 passed
- [ ] Eyeball scrollback after 5+ exchanges and confirm "You" rows stand out from tool / reasoning / assistant cards on the default theme

Refs #910 — addresses the visibility half. The `@`-mention "file not found" half stays open pending a concrete repro from the reporter.
