### PR TITLE
fix(desktop): preload host libwayland in AppImage to fix EGL abort (#892)

### DIFF
--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -6,6 +6,50 @@ use rpc::{RpcState, rpc_kill, rpc_send, rpc_spawn};
 use serde::Serialize;
 use std::path::Path;
 
+/// #892: bundled libwayland in AppImage can ABI-mismatch the host Wayland
+/// compositor → WebKitWebProcess `abort()`s on EGL display creation. Redirect
+/// the child to the host's libwayland via LD_PRELOAD before WebKit forks.
+#[cfg(target_os = "linux")]
+fn linux_webkit_compat() {
+    fn set_default(key: &str, value: &str) {
+        if std::env::var_os(key).is_none() {
+            std::env::set_var(key, value);
+        }
+    }
+
+    // Always-on: DMABUF renderer breaks on a wider set of Mesa stacks than
+    // libwayland bundling does. Cheap to disable, slow path is still fine.
+    set_default("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+
+    let in_appimage = std::env::var_os("APPDIR").is_some();
+    let on_wayland = std::env::var_os("WAYLAND_DISPLAY").is_some();
+    if !(in_appimage && on_wayland) {
+        return;
+    }
+
+    // Disable accelerated compositing as well — same EGL init path.
+    set_default("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
+
+    // Skip /usr/lib/libwayland-client.so.0 — on 64-bit Fedora that path can
+    // resolve to a 32-bit library and the loader prints a wrong-ELF-class
+    // warning instead of preloading.
+    const CANDIDATES: &[&str] = &[
+        "/usr/lib64/libwayland-client.so.0",
+        "/usr/lib/x86_64-linux-gnu/libwayland-client.so.0",
+        "/lib/x86_64-linux-gnu/libwayland-client.so.0",
+    ];
+    let Some(lib) = CANDIDATES.iter().find(|p| Path::new(p).exists()) else {
+        return;
+    };
+    let existing = std::env::var("LD_PRELOAD").unwrap_or_default();
+    let merged = if existing.is_empty() {
+        (*lib).to_string()
+    } else {
+        format!("{lib}:{existing}")
+    };
+    std::env::set_var("LD_PRELOAD", merged);
+}
+
 #[derive(Serialize)]
 struct FileEntry {
     path: String,
@@ -160,15 +204,8 @@ fn open_in_editor(command: String, path: String, line: Option<u32>) -> Result<()
 }
 
 fn main() {
-    // #892: WebKitGTK 2.42+ DMABUF renderer SIGABRTs on some Wayland + Mesa
-    // combos (black screen on launch). Disable it before WebKitWebProcess
-    // spawns; users can opt back in by exporting the var themselves.
     #[cfg(target_os = "linux")]
-    {
-        if std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_none() {
-            std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
-        }
-    }
+    linux_webkit_compat();
 
     tauri::Builder::default()
         .plugin(tauri_plugin_updater::Builder::new().build())


### PR DESCRIPTION
## Summary
- `#895` shipped `WEBKIT_DISABLE_DMABUF_RENDERER=1` for #892, but the reporter still hits the same `WebKitWebProcess` SIGABRT on openSUSE Tumbleweed + KDE Plasma 6 Wayland + Intel UHD. Reproduced in a Tumbleweed VM — the actual abort message is `Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...`, which fires *before* DMABUF init, so #895 was treating a symptom that isn't on the failing path.
- Root cause: AppImages bundle `libwayland-client.so.0` from the Ubuntu CI runner; distros with a divergent libwayland ABI (Tumbleweed / Fedora / Arch on some weeks) make `eglGetDisplay()` return `EGL_BAD_PARAMETER` and WebKitGTK 2.42+ aborts unconditionally. Same pattern Tauri ecosystem has hit repeatedly — see [tauri-apps/tauri#11988](https://github.com/tauri-apps/tauri/issues/11988), [gitbutlerapp/gitbutler#5282](https://github.com/gitbutlerapp/gitbutler/issues/5282), Tolaria's auto-handling, yaak.app's writeup.
- Fix: at `main()` entry, when we detect AppImage (`APPDIR`) + Wayland (`WAYLAND_DISPLAY`) on Linux, set `LD_PRELOAD` to the first existing host libwayland (`/usr/lib64/...`, then Debian-multiarch path). `WebKitWebProcess` is fork+exec'd from us, inherits the env, and links against the host libwayland instead of the bundled one. Also force `WEBKIT_DISABLE_COMPOSITING_MODE=1` on the same code path. The DMABUF disable from #895 becomes a small helper but stays always-on for Linux (covers Mesa stacks that DON'T need the libwayland swap).

## Test plan
- [x] `cargo check --target x86_64-pc-windows-msvc` — confirms the rest of `main.rs` still compiles
- [x] CI build matrix (Ubuntu/macOS/Windows) — exercises the `target_os = "linux"` body on Linux runners
- [ ] **Out-of-CI**: rebuild AppImage from this branch via `workflow_dispatch` and hand to the #892 reporter for a real-hardware confirmation before declaring fixed. The fix is environment-specific enough that VM testing alone isn't sufficient — the Tumbleweed VM hits the same EGL abort because the VBox vmwgfx driver is independently broken, which masked the libwayland-mismatch theory until we actually read the error message.

Refs #892. Will close once huangsijun17 confirms on real hardware.
