### PR TITLE
feat(scene): define JSON scene-graph contract for Stage 0

### DIFF
--- a/src/cli/ui/scene/types.ts
+++ b/src/cli/ui/scene/types.ts
@@ -1,0 +1,73 @@
+export type Color =
+  | "default"
+  | "black"
+  | "red"
+  | "green"
+  | "yellow"
+  | "blue"
+  | "magenta"
+  | "cyan"
+  | "white"
+  | "gray"
+  | { hex: string };
+
+export type TextStyle = {
+  color?: Color;
+  bg?: Color;
+  bold?: boolean;
+  dim?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  inverse?: boolean;
+  strikethrough?: boolean;
+};
+
+export type TextRun = {
+  text: string;
+  style?: TextStyle;
+};
+
+export type FlexDirection = "row" | "column";
+export type FlexAlign = "start" | "center" | "end" | "stretch";
+export type FlexJustify = "start" | "center" | "end" | "between" | "around";
+export type BorderStyle = "single" | "double" | "round" | "bold";
+export type Wrap = "wrap" | "truncate" | "truncate-start" | "truncate-middle" | "none";
+export type Dim = number | "fill";
+
+export type BoxLayout = {
+  direction?: FlexDirection;
+  gap?: number;
+  paddingX?: number;
+  paddingY?: number;
+  marginX?: number;
+  marginY?: number;
+  width?: Dim;
+  height?: Dim;
+  flexGrow?: number;
+  flexShrink?: number;
+  align?: FlexAlign;
+  justify?: FlexJustify;
+  borderStyle?: BorderStyle;
+  borderColor?: Color;
+};
+
+export type TextNode = {
+  kind: "text";
+  runs: TextRun[];
+  wrap?: Wrap;
+};
+
+export type BoxNode = {
+  kind: "box";
+  layout?: BoxLayout;
+  children: SceneNode[];
+};
+
+export type SceneNode = TextNode | BoxNode;
+
+export type SceneFrame = {
+  schemaVersion: 1;
+  cols: number;
+  rows: number;
+  root: SceneNode;
+};


### PR DESCRIPTION
First piece of #868 Stage 0 — the JSON contract the Rust renderer will
eventually consume over stdio.

No producer (Ink → scene lowering) and no consumer (Rust renderer) yet.
This PR is just the **shape**: type definitions in `src/cli/ui/scene/types.ts`,
so the lowering pass and the Rust spike can both branch from a fixed
contract instead of negotiating in flight.

## Design notes

- **Two primitives only** — `text` and `box`, mirroring Ink. Anything more
  is premature; the lowering pass will tell us what's missing.
- **Layout fields are hints**, not absolute positions. Rust runs the
  layout (ratatui constraints). Yoga is what we're getting rid of, not
  what we replicate.
- **`schemaVersion: 1`** — explicit version tag so we can evolve the
  contract without ambiguity. Bumping the value is the breaking-change
  signal.
- **Colors as named / hex only**, no rgb tuples for now. ANSI 16 covers
  most cases; hex covers truecolor when we need it.
- **Wrap modes** include `truncate-start` / `truncate-middle` for paths
  and long identifiers — preserving info we already render today.

## Non-goals

- No serializer / deserializer yet. Comes in PR-2 once a real lowering
  target exists.
- No zod schema. The boundary validation lives on the Rust side (serde);
  zod would only buy us JS-side test fixtures, which are cheaper as
  inline literals at this stage.
- No fields added speculatively. If the lowering pass needs `minWidth`,
  `overflow`, etc., they get added in the PR that uses them.

## Tracking

This is the first concrete deliverable from #868. Stage 0's other half
(finishing #565 — App.tsx ≤ 500 lines) continues separately.

Refs #868