### PR TITLE
feat(scene): builders for SceneFrame + JSON round-trip test

### DIFF
--- a/src/cli/ui/scene/build.ts
+++ b/src/cli/ui/scene/build.ts
@@ -1,0 +1,27 @@
+import type {
+  BoxLayout,
+  BoxNode,
+  SceneFrame,
+  SceneNode,
+  TextNode,
+  TextRun,
+  TextStyle,
+  Wrap,
+} from "./types.js";
+
+export function run(text: string, style?: TextStyle): TextRun {
+  return style ? { text, style } : { text };
+}
+
+export function text(content: string | TextRun[], wrap?: Wrap): TextNode {
+  const runs = typeof content === "string" ? [{ text: content }] : content;
+  return wrap ? { kind: "text", runs, wrap } : { kind: "text", runs };
+}
+
+export function box(children: SceneNode[], layout?: BoxLayout): BoxNode {
+  return layout ? { kind: "box", layout, children } : { kind: "box", children };
+}
+
+export function frame(cols: number, rows: number, root: SceneNode): SceneFrame {
+  return { schemaVersion: 1, cols, rows, root };
+}

--- a/src/cli/ui/scene/types.ts
+++ b/src/cli/ui/scene/types.ts
@@ -1,0 +1,73 @@
+export type Color =
+  | "default"
+  | "black"
+  | "red"
+  | "green"
+  | "yellow"
+  | "blue"
+  | "magenta"
+  | "cyan"
+  | "white"
+  | "gray"
+  | { hex: string };
+
+export type TextStyle = {
+  color?: Color;
+  bg?: Color;
+  bold?: boolean;
+  dim?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  inverse?: boolean;
+  strikethrough?: boolean;
+};
+
+export type TextRun = {
+  text: string;
+  style?: TextStyle;
+};
+
+export type FlexDirection = "row" | "column";
+export type FlexAlign = "start" | "center" | "end" | "stretch";
+export type FlexJustify = "start" | "center" | "end" | "between" | "around";
+export type BorderStyle = "single" | "double" | "round" | "bold";
+export type Wrap = "wrap" | "truncate" | "truncate-start" | "truncate-middle" | "none";
+export type Dim = number | "fill";
+
+export type BoxLayout = {
+  direction?: FlexDirection;
+  gap?: number;
+  paddingX?: number;
+  paddingY?: number;
+  marginX?: number;
+  marginY?: number;
+  width?: Dim;
+  height?: Dim;
+  flexGrow?: number;
+  flexShrink?: number;
+  align?: FlexAlign;
+  justify?: FlexJustify;
+  borderStyle?: BorderStyle;
+  borderColor?: Color;
+};
+
+export type TextNode = {
+  kind: "text";
+  runs: TextRun[];
+  wrap?: Wrap;
+};
+
+export type BoxNode = {
+  kind: "box";
+  layout?: BoxLayout;
+  children: SceneNode[];
+};
+
+export type SceneNode = TextNode | BoxNode;
+
+export type SceneFrame = {
+  schemaVersion: 1;
+  cols: number;
+  rows: number;
+  root: SceneNode;
+};

--- a/tests/scene-build.test.ts
+++ b/tests/scene-build.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { box, frame, run, text } from "../src/cli/ui/scene/build.js";
+import type { SceneFrame } from "../src/cli/ui/scene/types.js";
+
+describe("scene builders", () => {
+  it("text shorthand expands to a single run with no style", () => {
+    expect(text("hello")).toEqual({
+      kind: "text",
+      runs: [{ text: "hello" }],
+    });
+  });
+
+  it("text accepts a run array with styles", () => {
+    const node = text([run("ok ", { color: "green", bold: true }), run("more")]);
+    expect(node).toEqual({
+      kind: "text",
+      runs: [{ text: "ok ", style: { color: "green", bold: true } }, { text: "more" }],
+    });
+  });
+
+  it("box omits the layout field when none is given", () => {
+    expect(box([text("a")])).toEqual({
+      kind: "box",
+      children: [{ kind: "text", runs: [{ text: "a" }] }],
+    });
+  });
+
+  it("frame round-trips through JSON without losing fields", () => {
+    const original: SceneFrame = frame(
+      80,
+      24,
+      box(
+        [
+          text([run("status: ", { dim: true }), run("ok", { color: "green" })]),
+          text("ready", "truncate"),
+        ],
+        { direction: "column", gap: 1, paddingX: 1 },
+      ),
+    );
+    const round = JSON.parse(JSON.stringify(original)) as SceneFrame;
+    expect(round).toEqual(original);
+    expect(round.schemaVersion).toBe(1);
+  });
+});


### PR DESCRIPTION
Stacked on #946. Adds the authoring API for the scene-graph contract
and pins the JSON shape with a round-trip test.

## What

- `src/cli/ui/scene/build.ts` — `frame()` / `box()` / `text()` / `run()`.
  Builders carry the `kind` discriminator and omit empty optional fields
  so `JSON.stringify` produces clean output. `text("hello")` shorthand
  expands to a single-run text node.
- `tests/scene-build.test.ts` — four small tests:
  - Text shorthand expansion.
  - Styled run-array form.
  - Box omits `layout` when none given.
  - **Round-trip**: a sample frame serializes through `JSON.stringify` /
    `JSON.parse` and comes back deep-equal. This is the load-bearing
    invariant — anything non-JSON-able (functions, Maps, BigInt) breaks
    this test before it can hide in the contract.

## What this is not

- Not the Ink-tree walker. That comes once a real consumer wants it
  (the Stage 1 spike, or a snapshot-test target).
- Not a serializer module — `JSON.stringify` is the serializer. We will
  add a typed `serialize()` when stdio framing actually needs more than
  one line per frame (length-prefix, newline-delimited, etc.).

## Tracking

Stage 0 row in #947, second checkbox.

Refs #868 #947