### PR TITLE
feat(scene): walker that lowers Ink Text/Box to SceneNode

### DIFF
--- a/src/cli/ui/scene/build.ts
+++ b/src/cli/ui/scene/build.ts
@@ -1,0 +1,27 @@
+import type {
+  BoxLayout,
+  BoxNode,
+  SceneFrame,
+  SceneNode,
+  TextNode,
+  TextRun,
+  TextStyle,
+  Wrap,
+} from "./types.js";
+
+export function run(text: string, style?: TextStyle): TextRun {
+  return style ? { text, style } : { text };
+}
+
+export function text(content: string | TextRun[], wrap?: Wrap): TextNode {
+  const runs = typeof content === "string" ? [{ text: content }] : content;
+  return wrap ? { kind: "text", runs, wrap } : { kind: "text", runs };
+}
+
+export function box(children: SceneNode[], layout?: BoxLayout): BoxNode {
+  return layout ? { kind: "box", layout, children } : { kind: "box", children };
+}
+
+export function frame(cols: number, rows: number, root: SceneNode): SceneFrame {
+  return { schemaVersion: 1, cols, rows, root };
+}

--- a/src/cli/ui/scene/lower.ts
+++ b/src/cli/ui/scene/lower.ts
@@ -1,0 +1,285 @@
+import { Box, Text } from "ink";
+import { type ReactElement, type ReactNode, isValidElement } from "react";
+import type {
+  BoxLayout,
+  BoxNode,
+  Color,
+  Dim,
+  SceneNode,
+  TextNode,
+  TextRun,
+  TextStyle,
+  Wrap,
+} from "./types.js";
+
+type AnyProps = Record<string, unknown>;
+
+export function lowerInkToScene(element: ReactElement): SceneNode {
+  if (element.type === Text) return lowerText(element);
+  if (element.type === Box) return lowerBox(element);
+  const name =
+    typeof element.type === "function" ? element.type.name || "anonymous" : String(element.type);
+  throw new Error(`lowerInkToScene: only Ink Text/Box supported, got ${name}`);
+}
+
+function lowerText(el: ReactElement): TextNode {
+  const props = el.props as AnyProps;
+  const style = textStyleFrom(props);
+  const wrap = mapWrap(props.wrap);
+  const runs: TextRun[] = [];
+  collectRuns(props.children as ReactNode, style, runs);
+  return wrap ? { kind: "text", runs, wrap } : { kind: "text", runs };
+}
+
+function collectRuns(node: ReactNode, inherited: TextStyle | undefined, out: TextRun[]): void {
+  if (node === null || node === undefined || node === false || node === true) return;
+  if (typeof node === "string" || typeof node === "number") {
+    const text = String(node);
+    out.push(inherited ? { text, style: inherited } : { text });
+    return;
+  }
+  if (Array.isArray(node)) {
+    for (const c of node) collectRuns(c, inherited, out);
+    return;
+  }
+  if (isValidElement(node) && node.type === Text) {
+    const own = textStyleFrom(node.props as AnyProps);
+    const merged = mergeStyle(inherited, own);
+    collectRuns((node.props as AnyProps).children as ReactNode, merged, out);
+    return;
+  }
+  throw new Error("lowerInkToScene: Text children must be strings, numbers, or nested Text");
+}
+
+function textStyleFrom(props: AnyProps): TextStyle | undefined {
+  const style: TextStyle = {};
+  for (const [key, value] of Object.entries(props)) {
+    if (key === "children" || key === "wrap" || value === undefined) continue;
+    switch (key) {
+      case "color":
+        style.color = asColor(value);
+        break;
+      case "backgroundColor":
+        style.bg = asColor(value);
+        break;
+      case "dimColor":
+        if (value) style.dim = true;
+        break;
+      case "bold":
+        if (value) style.bold = true;
+        break;
+      case "italic":
+        if (value) style.italic = true;
+        break;
+      case "underline":
+        if (value) style.underline = true;
+        break;
+      case "strikethrough":
+        if (value) style.strikethrough = true;
+        break;
+      case "inverse":
+        if (value) style.inverse = true;
+        break;
+      default:
+        throw new Error(`lowerInkToScene: unsupported Text prop "${key}"`);
+    }
+  }
+  return hasAnyKey(style) ? style : undefined;
+}
+
+const NAMED_COLORS: ReadonlySet<string> = new Set([
+  "default",
+  "black",
+  "red",
+  "green",
+  "yellow",
+  "blue",
+  "magenta",
+  "cyan",
+  "white",
+  "gray",
+]);
+
+function asColor(value: unknown): Color {
+  if (typeof value !== "string") throw new Error("lowerInkToScene: color must be a string");
+  if (/^#[0-9a-fA-F]{6}$/.test(value)) return { hex: value };
+  if (NAMED_COLORS.has(value)) return value as Color;
+  throw new Error(`lowerInkToScene: unsupported color "${value}"`);
+}
+
+function mergeStyle(
+  parent: TextStyle | undefined,
+  own: TextStyle | undefined,
+): TextStyle | undefined {
+  if (!parent) return own;
+  if (!own) return parent;
+  return { ...parent, ...own };
+}
+
+function hasAnyKey(obj: object): boolean {
+  for (const _ in obj) return true;
+  return false;
+}
+
+function mapWrap(value: unknown): Wrap | undefined {
+  if (value === undefined) return undefined;
+  switch (value) {
+    case "wrap":
+      return "wrap";
+    case "end":
+    case "truncate":
+    case "truncate-end":
+      return "truncate";
+    case "middle":
+    case "truncate-middle":
+      return "truncate-middle";
+    case "truncate-start":
+      return "truncate-start";
+    default:
+      throw new Error(`lowerInkToScene: unsupported wrap "${String(value)}"`);
+  }
+}
+
+function lowerBox(el: ReactElement): BoxNode {
+  const props = el.props as AnyProps;
+  const layout = boxLayoutFrom(props);
+  const children: SceneNode[] = [];
+  collectBoxChildren(props.children as ReactNode, children);
+  return layout ? { kind: "box", layout, children } : { kind: "box", children };
+}
+
+function collectBoxChildren(node: ReactNode, out: SceneNode[]): void {
+  if (node === null || node === undefined || node === false || node === true) return;
+  if (typeof node === "string" || typeof node === "number") {
+    out.push({ kind: "text", runs: [{ text: String(node) }] });
+    return;
+  }
+  if (Array.isArray(node)) {
+    for (const c of node) collectBoxChildren(c, out);
+    return;
+  }
+  if (isValidElement(node)) {
+    out.push(lowerInkToScene(node));
+    return;
+  }
+  throw new Error("lowerInkToScene: Box children must be strings, numbers, Text, or Box");
+}
+
+function boxLayoutFrom(props: AnyProps): BoxLayout | undefined {
+  const out: BoxLayout = {};
+  for (const [key, value] of Object.entries(props)) {
+    if (key === "children" || value === undefined) continue;
+    switch (key) {
+      case "flexDirection":
+        if (value !== "row" && value !== "column")
+          throw new Error(`lowerInkToScene: unsupported flexDirection "${String(value)}"`);
+        out.direction = value;
+        break;
+      case "gap":
+        out.gap = asInt(value, "gap");
+        break;
+      case "padding": {
+        const n = asInt(value, "padding");
+        out.paddingX = n;
+        out.paddingY = n;
+        break;
+      }
+      case "paddingX":
+        out.paddingX = asInt(value, "paddingX");
+        break;
+      case "paddingY":
+        out.paddingY = asInt(value, "paddingY");
+        break;
+      case "margin": {
+        const n = asInt(value, "margin");
+        out.marginX = n;
+        out.marginY = n;
+        break;
+      }
+      case "marginX":
+        out.marginX = asInt(value, "marginX");
+        break;
+      case "marginY":
+        out.marginY = asInt(value, "marginY");
+        break;
+      case "width":
+        out.width = asDim(value, "width");
+        break;
+      case "height":
+        out.height = asDim(value, "height");
+        break;
+      case "flexGrow":
+        out.flexGrow = asInt(value, "flexGrow");
+        break;
+      case "flexShrink":
+        out.flexShrink = asInt(value, "flexShrink");
+        break;
+      case "alignItems":
+        out.align = mapAlign(value);
+        break;
+      case "justifyContent":
+        out.justify = mapJustify(value);
+        break;
+      case "borderStyle":
+        out.borderStyle = mapBorder(value);
+        break;
+      case "borderColor":
+        out.borderColor = asColor(value);
+        break;
+      default:
+        throw new Error(`lowerInkToScene: unsupported Box prop "${key}"`);
+    }
+  }
+  return hasAnyKey(out) ? out : undefined;
+}
+
+function asInt(value: unknown, name: string): number {
+  if (typeof value !== "number" || !Number.isInteger(value)) {
+    throw new Error(`lowerInkToScene: ${name} must be an integer, got ${typeof value}`);
+  }
+  return value;
+}
+
+function asDim(value: unknown, name: string): Dim {
+  if (typeof value === "number" && Number.isInteger(value)) return value;
+  if (value === "100%") return "fill";
+  throw new Error(`lowerInkToScene: ${name} must be an integer or "100%", got ${String(value)}`);
+}
+
+function mapAlign(value: unknown): BoxLayout["align"] {
+  switch (value) {
+    case "flex-start":
+      return "start";
+    case "flex-end":
+      return "end";
+    case "center":
+      return "center";
+    case "stretch":
+      return "stretch";
+    default:
+      throw new Error(`lowerInkToScene: unsupported alignItems "${String(value)}"`);
+  }
+}
+
+function mapJustify(value: unknown): BoxLayout["justify"] {
+  switch (value) {
+    case "flex-start":
+      return "start";
+    case "flex-end":
+      return "end";
+    case "center":
+      return "center";
+    case "space-between":
+      return "between";
+    case "space-around":
+      return "around";
+    default:
+      throw new Error(`lowerInkToScene: unsupported justifyContent "${String(value)}"`);
+  }
+}
+
+function mapBorder(value: unknown): BoxLayout["borderStyle"] {
+  if (value === "single" || value === "double" || value === "round" || value === "bold")
+    return value;
+  throw new Error(`lowerInkToScene: unsupported borderStyle "${String(value)}"`);
+}

--- a/src/cli/ui/scene/types.ts
+++ b/src/cli/ui/scene/types.ts
@@ -1,0 +1,73 @@
+export type Color =
+  | "default"
+  | "black"
+  | "red"
+  | "green"
+  | "yellow"
+  | "blue"
+  | "magenta"
+  | "cyan"
+  | "white"
+  | "gray"
+  | { hex: string };
+
+export type TextStyle = {
+  color?: Color;
+  bg?: Color;
+  bold?: boolean;
+  dim?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  inverse?: boolean;
+  strikethrough?: boolean;
+};
+
+export type TextRun = {
+  text: string;
+  style?: TextStyle;
+};
+
+export type FlexDirection = "row" | "column";
+export type FlexAlign = "start" | "center" | "end" | "stretch";
+export type FlexJustify = "start" | "center" | "end" | "between" | "around";
+export type BorderStyle = "single" | "double" | "round" | "bold";
+export type Wrap = "wrap" | "truncate" | "truncate-start" | "truncate-middle" | "none";
+export type Dim = number | "fill";
+
+export type BoxLayout = {
+  direction?: FlexDirection;
+  gap?: number;
+  paddingX?: number;
+  paddingY?: number;
+  marginX?: number;
+  marginY?: number;
+  width?: Dim;
+  height?: Dim;
+  flexGrow?: number;
+  flexShrink?: number;
+  align?: FlexAlign;
+  justify?: FlexJustify;
+  borderStyle?: BorderStyle;
+  borderColor?: Color;
+};
+
+export type TextNode = {
+  kind: "text";
+  runs: TextRun[];
+  wrap?: Wrap;
+};
+
+export type BoxNode = {
+  kind: "box";
+  layout?: BoxLayout;
+  children: SceneNode[];
+};
+
+export type SceneNode = TextNode | BoxNode;
+
+export type SceneFrame = {
+  schemaVersion: 1;
+  cols: number;
+  rows: number;
+  root: SceneNode;
+};

--- a/tests/scene-build.test.ts
+++ b/tests/scene-build.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { box, frame, run, text } from "../src/cli/ui/scene/build.js";
+import type { SceneFrame } from "../src/cli/ui/scene/types.js";
+
+describe("scene builders", () => {
+  it("text shorthand expands to a single run with no style", () => {
+    expect(text("hello")).toEqual({
+      kind: "text",
+      runs: [{ text: "hello" }],
+    });
+  });
+
+  it("text accepts a run array with styles", () => {
+    const node = text([run("ok ", { color: "green", bold: true }), run("more")]);
+    expect(node).toEqual({
+      kind: "text",
+      runs: [{ text: "ok ", style: { color: "green", bold: true } }, { text: "more" }],
+    });
+  });
+
+  it("box omits the layout field when none is given", () => {
+    expect(box([text("a")])).toEqual({
+      kind: "box",
+      children: [{ kind: "text", runs: [{ text: "a" }] }],
+    });
+  });
+
+  it("frame round-trips through JSON without losing fields", () => {
+    const original: SceneFrame = frame(
+      80,
+      24,
+      box(
+        [
+          text([run("status: ", { dim: true }), run("ok", { color: "green" })]),
+          text("ready", "truncate"),
+        ],
+        { direction: "column", gap: 1, paddingX: 1 },
+      ),
+    );
+    const round = JSON.parse(JSON.stringify(original)) as SceneFrame;
+    expect(round).toEqual(original);
+    expect(round.schemaVersion).toBe(1);
+  });
+});

--- a/tests/scene-lower.test.ts
+++ b/tests/scene-lower.test.ts
@@ -1,0 +1,138 @@
+import { Box, Text } from "ink";
+import { createElement } from "react";
+import { describe, expect, it } from "vitest";
+import { lowerInkToScene } from "../src/cli/ui/scene/lower.js";
+
+describe("lowerInkToScene", () => {
+  it("lowers a plain Text", () => {
+    expect(lowerInkToScene(createElement(Text, null, "hello"))).toEqual({
+      kind: "text",
+      runs: [{ text: "hello" }],
+    });
+  });
+
+  it("lowers Text with color + bold", () => {
+    expect(lowerInkToScene(createElement(Text, { color: "green", bold: true }, "ok"))).toEqual({
+      kind: "text",
+      runs: [{ text: "ok", style: { color: "green", bold: true } }],
+    });
+  });
+
+  it("lowers hex color to { hex } form", () => {
+    expect(lowerInkToScene(createElement(Text, { color: "#aabbcc" }, "x"))).toEqual({
+      kind: "text",
+      runs: [{ text: "x", style: { color: { hex: "#aabbcc" } } }],
+    });
+  });
+
+  it("flattens nested Text into runs", () => {
+    const el = createElement(
+      Text,
+      null,
+      createElement(Text, { color: "red" }, "a"),
+      "b",
+      createElement(Text, { bold: true }, "c"),
+    );
+    expect(lowerInkToScene(el)).toEqual({
+      kind: "text",
+      runs: [
+        { text: "a", style: { color: "red" } },
+        { text: "b" },
+        { text: "c", style: { bold: true } },
+      ],
+    });
+  });
+
+  it("merges parent + child Text styles, child wins on conflict", () => {
+    const el = createElement(
+      Text,
+      { bold: true, color: "blue" },
+      createElement(Text, { color: "red" }, "x"),
+    );
+    expect(lowerInkToScene(el)).toEqual({
+      kind: "text",
+      runs: [{ text: "x", style: { bold: true, color: "red" } }],
+    });
+  });
+
+  it("lowers a Box with children", () => {
+    const el = createElement(
+      Box,
+      { flexDirection: "column", paddingX: 1 },
+      createElement(Text, null, "a"),
+      createElement(Text, null, "b"),
+    );
+    expect(lowerInkToScene(el)).toEqual({
+      kind: "box",
+      layout: { direction: "column", paddingX: 1 },
+      children: [
+        { kind: "text", runs: [{ text: "a" }] },
+        { kind: "text", runs: [{ text: "b" }] },
+      ],
+    });
+  });
+
+  it("maps Ink padding to symmetric paddingX/paddingY", () => {
+    const el = createElement(Box, { padding: 2 });
+    expect(lowerInkToScene(el)).toEqual({
+      kind: "box",
+      layout: { paddingX: 2, paddingY: 2 },
+      children: [],
+    });
+  });
+
+  it("maps alignItems / justifyContent vocabulary", () => {
+    const el = createElement(Box, {
+      alignItems: "flex-start",
+      justifyContent: "space-between",
+    });
+    expect(lowerInkToScene(el)).toEqual({
+      kind: "box",
+      layout: { align: "start", justify: "between" },
+      children: [],
+    });
+  });
+
+  it("maps width 100% to fill", () => {
+    const el = createElement(Box, { width: "100%", height: 5 });
+    expect(lowerInkToScene(el)).toEqual({
+      kind: "box",
+      layout: { width: "fill", height: 5 },
+      children: [],
+    });
+  });
+
+  it("skips falsy children (null / undefined / false)", () => {
+    const el = createElement(Box, null, null, undefined, false, createElement(Text, null, "x"));
+    expect(lowerInkToScene(el)).toEqual({
+      kind: "box",
+      children: [{ kind: "text", runs: [{ text: "x" }] }],
+    });
+  });
+
+  it("throws on a function component", () => {
+    function MyComponent() {
+      return createElement(Text, null, "x");
+    }
+    expect(() => lowerInkToScene(createElement(MyComponent))).toThrow(
+      /only Ink Text\/Box supported/,
+    );
+  });
+
+  it("throws on an unsupported Text prop", () => {
+    expect(() => lowerInkToScene(createElement(Text, { fontSize: 12 } as never, "x"))).toThrow(
+      /unsupported Text prop "fontSize"/,
+    );
+  });
+
+  it("throws on an unsupported Box prop", () => {
+    expect(() => lowerInkToScene(createElement(Box, { display: "flex" } as never))).toThrow(
+      /unsupported Box prop "display"/,
+    );
+  });
+
+  it("throws on a Text child that is not a string or nested Text", () => {
+    const el = createElement(Text, null, createElement(Box, null) as never);
+    expect(() => lowerInkToScene(el)).toThrow(/Text children must be/);
+  });
+});


### PR DESCRIPTION
Stacked on #948. Third piece of Stage 0 — `lowerInkToScene(element)`
takes a React element whose type is Ink's `Text` or `Box` and returns
a `SceneNode`.

## Why strict, not permissive

Every unsupported Ink prop throws by name. The temptation is to
silently drop unknown fields so existing components migrate without
friction — but that's how the contract ends up under-specified and
the Rust side starts inheriting accidental holes. The friction is
the point: when a real component needs `paddingLeft` separately from
`paddingRight`, we'll add it and that addition is documented by the
diff that uses it.

## What's mapped

- **Text style props** — color (named or `#rrggbb`), backgroundColor,
  dimColor (→ `dim`), bold, italic, underline, strikethrough, inverse.
- **Wrap modes** — Ink's `end` / `truncate-end` collapse to `truncate`;
  `middle` / `truncate-middle` to `truncate-middle`; `truncate-start`
  passes through.
- **Box layout** — flexDirection (row/column only), gap, symmetric
  padding/margin, width/height (integer or `"100%"` → `"fill"`),
  flexGrow / flexShrink, alignItems / justifyContent (Ink's
  `flex-start` / `space-between` vocabulary normalized to ours),
  borderStyle / borderColor.

## What throws

- Function components (the caller has to expand them first — by
  hand or via a later renderer-driven walker).
- Asymmetric padding/margin (`paddingLeft`, etc.).
- Percentage widths other than `100%`.
- Any prop not in the explicit mapping above.
- Text children that aren't strings, numbers, or nested Text.

## Tests

14 cases in `tests/scene-lower.test.ts` — happy paths for both
primitives, nested-Text flattening, style inheritance, vocabulary
mapping, plus a throw assertion at every error site.

Refs #868 #947