### PR TITLE
ci(rust): add cargo fmt + clippy + test job for the workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,26 @@ jobs:
       # runner (POSIX + Windows) — beats hardcoding /tmp.
       - name: τ-bench harness dry-run
         run: npx tsx benchmarks/tau-bench/runner.ts --dry --out "${{ runner.temp }}/tau-dry.json"
+
+  rust:
+    name: rust (ubuntu-latest)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cargo cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: rustfmt
+        run: cargo fmt --all -- --check
+
+      - name: clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: cargo test
+        run: cargo test --manifest-path Cargo.toml

--- a/crates/reasonix-render/src/scene.rs
+++ b/crates/reasonix-render/src/scene.rs
@@ -103,15 +103,27 @@ pub struct BoxLayout {
     pub height: Option<Dim>,
     #[serde(default, rename = "flexGrow", skip_serializing_if = "Option::is_none")]
     pub flex_grow: Option<i32>,
-    #[serde(default, rename = "flexShrink", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        rename = "flexShrink",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub flex_shrink: Option<i32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub align: Option<FlexAlign>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub justify: Option<FlexJustify>,
-    #[serde(default, rename = "borderStyle", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        rename = "borderStyle",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub border_style: Option<BorderStyle>,
-    #[serde(default, rename = "borderColor", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        rename = "borderColor",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub border_color: Option<Color>,
 }
 

--- a/crates/reasonix-render/tests/round_trip.rs
+++ b/crates/reasonix-render/tests/round_trip.rs
@@ -4,8 +4,7 @@ use reasonix_render::scene::{
 
 #[test]
 fn deserializes_a_simple_text_frame() {
-    let json =
-        r#"{"schemaVersion":1,"cols":80,"rows":24,"root":{"kind":"text","runs":[{"text":"hello"}]}}"#;
+    let json = r#"{"schemaVersion":1,"cols":80,"rows":24,"root":{"kind":"text","runs":[{"text":"hello"}]}}"#;
     let frame: SceneFrame = serde_json::from_str(json).expect("valid frame");
     assert_eq!(frame.schema_version, 1);
     assert_eq!(frame.cols, 80);
@@ -101,8 +100,7 @@ fn round_trips_through_serde_without_field_loss() {
 
 #[test]
 fn rejects_unknown_node_kind() {
-    let json =
-        r#"{"schemaVersion":1,"cols":80,"rows":24,"root":{"kind":"image","src":"x.png"}}"#;
+    let json = r#"{"schemaVersion":1,"cols":80,"rows":24,"root":{"kind":"image","src":"x.png"}}"#;
     let err = serde_json::from_str::<SceneFrame>(json).unwrap_err();
     let msg = err.to_string();
     assert!(msg.contains("kind") || msg.contains("variant"), "{msg}");


### PR DESCRIPTION
Locks the formatting and lint gates on the reasonix-render crate
before the next Rust PR adds anything substantial. Without this,
the Rust side drifts silently — JS contributors don't run cargo,
and the existing serde annotations are exactly the kind of code
where one missed rename rots the boundary.

## What runs

- \`cargo fmt --all -- --check\` — formatting matches what stable
  rustfmt produces.
- \`cargo clippy --all-targets -- -D warnings\` — warnings are errors.
  No project-wide allowlist; suppressions live next to the code with
  a one-line reason.
- \`cargo test --manifest-path Cargo.toml\` — runs the round-trip
  suite from #953 at the workspace root. The Tauri shell at
  \`desktop/src-tauri\` (excluded workspace) is untouched.

## Linux-only for now

macOS / Windows Rust runners cost real CI minutes. Today the crate
is serde + std; multi-OS rendering coverage matters once ratatui is
actually drawing things. Adding the matrix at that point is one
line.

## Cosmetic fixes ride along

\`cargo fmt\` wants three wraps in the existing crate (\`scene.rs\` × 2,
\`round_trip.rs\` × 1) that the original PR didn't catch because there
was no CI to enforce it. Folded into this PR rather than a separate
fmt-only one — splitting would land a no-behavior-change diff with
no protection behind it.

Refs #868 #947