### PR TITLE
feat(scene): wire useSceneTrace into App so real sessions emit frames

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -136,6 +136,7 @@ import { useLanguageReload } from "./hooks/useLanguageReload.js";
 import { useLoopMode } from "./hooks/useLoopMode.js";
 import { usePresetMode } from "./hooks/usePresetMode.js";
 import { useQuit } from "./hooks/useQuit.js";
+import { useSceneTrace } from "./hooks/useSceneTrace.js";
 import { useScrollback } from "./hooks/useScrollback.js";
 import { useTerminalSetup } from "./hooks/useTerminalSetup.js";
 import { useToolProgressDisplay } from "./hooks/useToolProgressDisplay.js";
@@ -467,6 +468,7 @@ function AppInner({
     s.cards.some((c) => c.kind === "user" || c.kind === "streaming"),
   );
   const isStreaming = useAgentState((s) => s.cards.some((c) => c.kind === "streaming" && !c.done));
+  const cardCount = useAgentState((s) => s.cards.length);
   const activityLabel = useActivityLabel();
   const chatScroll = useChatScrollActions();
   const [input, setInput] = useState("");
@@ -505,6 +507,7 @@ function AppInner({
   useEffect(() => {
     busyRef.current = busy;
   }, [busy]);
+  useSceneTrace({ cardCount, busy, activity: activityLabel });
   const {
     ongoingTool,
     setOngoingTool,

--- a/src/cli/ui/hooks/useSceneTrace.ts
+++ b/src/cli/ui/hooks/useSceneTrace.ts
@@ -1,0 +1,29 @@
+import { useStdout } from "ink";
+import { useEffect } from "react";
+import { box, frame, text } from "../scene/build.js";
+import { emitSceneFrame, isSceneTraceEnabled } from "../scene/trace.js";
+import type { TextRun } from "../scene/types.js";
+
+export type SceneTraceSummary = {
+  cardCount: number;
+  busy: boolean;
+  activity?: string;
+};
+
+export function useSceneTrace(summary: SceneTraceSummary): void {
+  const { stdout } = useStdout();
+  const cols = stdout?.columns ?? 80;
+  const rows = stdout?.rows ?? 24;
+  useEffect(() => {
+    if (!isSceneTraceEnabled()) return;
+    const runs: TextRun[] = [
+      { text: "reasonix · " },
+      { text: `${summary.cardCount} cards`, style: { dim: true } },
+      { text: summary.busy ? " · busy" : " · idle" },
+    ];
+    if (summary.activity) {
+      runs.push({ text: ` · ${summary.activity}`, style: { dim: true } });
+    }
+    emitSceneFrame(frame(cols, rows, box([text(runs)], { paddingX: 1 })));
+  }, [cols, rows, summary.cardCount, summary.busy, summary.activity]);
+}


### PR DESCRIPTION
Closes the last open Stage 0 item in #947 — \`useSceneTrace\` hooks
into AppInner so a real session running with
\`REASONIX_SCENE_TRACE=path/to/frames.jsonl\` produces one frame per
state change. The Rust binary from #953 can read that trace and
debug-print decoded SceneFrames, end-to-end on real data.

## What gets emitted

A one-line summary today: card count, busy/idle, activity label.
Wrapped in a Box with \`paddingX: 1\` so the frame is a believable
SceneNode shape, not just a string.

\`\`\`
reasonix · 3 cards · busy · awaiting response
\`\`\`

## Why a stub frame, not a full lowering

\`lowerInkToScene\` only handles Ink primitives — \`Text\` and \`Box\`. The
App render tree is mostly function components, and lowering them
automatically requires either (a) finishing #565 enough that
subtrees decompose to primitives, or (b) a function-component
expansion helper. Both are bigger pieces of work.

This PR gets us the **wiring** without committing to that path. The
producer is real, the boundary is proven on real data, and the
shape is stable enough for the Rust side to test against. When
lowering matures, only the body of \`useSceneTrace\` changes; the
call site in App stays one line.

## Surface area in App.tsx

Three lines added:

- 1 new import (alphabetically slotted).
- 1 new \`useAgentState\` selector for \`cardCount\` next to the
  existing \`isStreaming\` selector.
- 1 \`useSceneTrace({ cardCount, busy, activity: activityLabel })\`
  call after the existing \`busyRef\` effect.

No state ownership changes, no render-tree changes, no behavior
change when the env var is unset (which is the default).

Refs #868 #947