### PR TITLE
feat(rust): ratatui renderer for SceneFrame, alt-screen TUI binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,287 @@
 version = 4
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "proc-macro2"
@@ -33,12 +304,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "reasonix-render"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "crossterm",
+ "ratatui",
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -84,6 +419,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,6 +505,151 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zmij"

--- a/crates/reasonix-render/Cargo.toml
+++ b/crates/reasonix-render/Cargo.toml
@@ -6,5 +6,8 @@ license.workspace = true
 publish.workspace = true
 
 [dependencies]
+anyhow = "1"
+crossterm = "0.28"
+ratatui = "0.29"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/reasonix-render/src/lib.rs
+++ b/crates/reasonix-render/src/lib.rs
@@ -1,1 +1,2 @@
+pub mod render;
 pub mod scene;

--- a/crates/reasonix-render/src/main.rs
+++ b/crates/reasonix-render/src/main.rs
@@ -1,34 +1,81 @@
 use std::io::{self, BufRead, Write};
-use std::process::ExitCode;
+use std::time::Duration;
 
+use anyhow::{Context, Result};
+use crossterm::event::{self, Event, KeyCode};
+use crossterm::execute;
+use crossterm::terminal::{
+    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+};
+use ratatui::backend::CrosstermBackend;
+use ratatui::Terminal;
+
+use reasonix_render::render::render_frame;
 use reasonix_render::scene::SceneFrame;
 
-fn main() -> ExitCode {
-    let stdin = io::stdin();
-    let stdout = io::stdout();
-    let mut out = stdout.lock();
-    let mut frame_count = 0u64;
+fn main() -> Result<()> {
+    let frames = read_frames()?;
+    if frames.is_empty() {
+        anyhow::bail!("no frames on stdin");
+    }
+    let mut stdout = io::stdout();
+    enable_raw_mode().context("enable raw mode")?;
+    execute!(stdout, EnterAlternateScreen).context("enter alt screen")?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend).context("create terminal")?;
 
+    let result = run_loop(&mut terminal, &frames);
+
+    disable_raw_mode().ok();
+    execute!(terminal.backend_mut(), LeaveAlternateScreen).ok();
+    terminal.show_cursor().ok();
+    result
+}
+
+fn read_frames() -> Result<Vec<SceneFrame>> {
+    let stdin = io::stdin();
+    let mut out = Vec::new();
     for (lineno, line) in stdin.lock().lines().enumerate() {
-        let line = match line {
-            Ok(l) => l,
-            Err(e) => {
-                eprintln!("read error on line {}: {}", lineno + 1, e);
-                return ExitCode::from(2);
-            }
-        };
+        let line = line.with_context(|| format!("read line {}", lineno + 1))?;
         if line.trim().is_empty() {
             continue;
         }
-        let frame: SceneFrame = match serde_json::from_str(&line) {
-            Ok(f) => f,
-            Err(e) => {
-                eprintln!("decode error on line {}: {}", lineno + 1, e);
-                return ExitCode::from(2);
-            }
-        };
-        frame_count += 1;
-        writeln!(out, "frame {frame_count}: {frame:?}").ok();
+        let frame: SceneFrame =
+            serde_json::from_str(&line).with_context(|| format!("decode line {}", lineno + 1))?;
+        out.push(frame);
     }
-    ExitCode::SUCCESS
+    Ok(out)
+}
+
+fn run_loop(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    frames: &[SceneFrame],
+) -> Result<()> {
+    let mut idx = 0usize;
+    let dwell = Duration::from_millis(800);
+    loop {
+        let frame = &frames[idx];
+        terminal.draw(|f| {
+            let area = f.area();
+            render_frame(frame, f.buffer_mut(), area);
+        })?;
+        if event::poll(dwell)? {
+            if let Event::Key(k) = event::read()? {
+                match k.code {
+                    KeyCode::Char('q') | KeyCode::Esc => return Ok(()),
+                    KeyCode::Char('n') | KeyCode::Right => {
+                        idx = (idx + 1) % frames.len();
+                        continue;
+                    }
+                    KeyCode::Char('p') | KeyCode::Left => {
+                        idx = if idx == 0 { frames.len() - 1 } else { idx - 1 };
+                        continue;
+                    }
+                    _ => {}
+                }
+            }
+        }
+        idx = (idx + 1) % frames.len();
+        writeln!(io::sink()).ok();
+    }
 }

--- a/crates/reasonix-render/src/render.rs
+++ b/crates/reasonix-render/src/render.rs
@@ -1,0 +1,275 @@
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::{Color as RColor, Modifier, Style};
+
+use crate::scene::{
+    BoxLayout, Color, FlexDirection, NamedColor, SceneFrame, SceneNode, TextRun, TextStyle,
+};
+
+pub fn render_frame(frame: &SceneFrame, buf: &mut Buffer, area: Rect) {
+    render_node(&frame.root, buf, area);
+}
+
+fn render_node(node: &SceneNode, buf: &mut Buffer, area: Rect) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+    match node {
+        SceneNode::Text { runs, .. } => render_text_runs(runs, buf, area),
+        SceneNode::Box { layout, children } => {
+            render_box(layout.as_ref(), children, buf, area);
+        }
+    }
+}
+
+fn render_text_runs(runs: &[TextRun], buf: &mut Buffer, area: Rect) {
+    let mut x = area.x;
+    let max_x = area.x.saturating_add(area.width);
+    for run in runs {
+        if x >= max_x {
+            break;
+        }
+        let style = ratatui_style(run.style.as_ref());
+        for ch in run.text.chars() {
+            if x >= max_x {
+                break;
+            }
+            let cell = &mut buf[(x, area.y)];
+            cell.set_char(ch);
+            cell.set_style(style);
+            x = x.saturating_add(1);
+        }
+    }
+}
+
+fn render_box(layout: Option<&BoxLayout>, children: &[SceneNode], buf: &mut Buffer, area: Rect) {
+    let inner = apply_padding(layout, area);
+    if inner.width == 0 || inner.height == 0 {
+        return;
+    }
+    let direction = layout
+        .and_then(|l| l.direction)
+        .unwrap_or(FlexDirection::Column);
+    let gap = layout
+        .and_then(|l| l.gap)
+        .filter(|g| *g >= 0)
+        .map(|g| g as u16)
+        .unwrap_or(0);
+    match direction {
+        FlexDirection::Column => render_column(children, gap, buf, inner),
+        FlexDirection::Row => render_row(children, gap, buf, inner),
+    }
+}
+
+fn render_column(children: &[SceneNode], gap: u16, buf: &mut Buffer, area: Rect) {
+    let mut y = area.y;
+    let max_y = area.y.saturating_add(area.height);
+    let last = children.len().saturating_sub(1);
+    for (i, child) in children.iter().enumerate() {
+        if y >= max_y {
+            break;
+        }
+        let remaining = max_y - y;
+        let h = intrinsic_height(child).min(remaining);
+        let child_area = Rect {
+            x: area.x,
+            y,
+            width: area.width,
+            height: h,
+        };
+        render_node(child, buf, child_area);
+        y = y.saturating_add(h);
+        if i < last && gap > 0 {
+            y = y.saturating_add(gap);
+        }
+    }
+}
+
+fn render_row(children: &[SceneNode], gap: u16, buf: &mut Buffer, area: Rect) {
+    let mut x = area.x;
+    let max_x = area.x.saturating_add(area.width);
+    let last = children.len().saturating_sub(1);
+    for (i, child) in children.iter().enumerate() {
+        if x >= max_x {
+            break;
+        }
+        let remaining = max_x - x;
+        let w = intrinsic_width(child).min(remaining);
+        let child_area = Rect {
+            x,
+            y: area.y,
+            width: w,
+            height: area.height,
+        };
+        render_node(child, buf, child_area);
+        x = x.saturating_add(w);
+        if i < last && gap > 0 {
+            x = x.saturating_add(gap);
+        }
+    }
+}
+
+fn apply_padding(layout: Option<&BoxLayout>, area: Rect) -> Rect {
+    let px = layout
+        .and_then(|l| l.padding_x)
+        .filter(|p| *p >= 0)
+        .map(|p| p as u16)
+        .unwrap_or(0);
+    let py = layout
+        .and_then(|l| l.padding_y)
+        .filter(|p| *p >= 0)
+        .map(|p| p as u16)
+        .unwrap_or(0);
+    let shrink_w = px.saturating_mul(2);
+    let shrink_h = py.saturating_mul(2);
+    Rect {
+        x: area.x.saturating_add(px),
+        y: area.y.saturating_add(py),
+        width: area.width.saturating_sub(shrink_w),
+        height: area.height.saturating_sub(shrink_h),
+    }
+}
+
+fn intrinsic_height(node: &SceneNode) -> u16 {
+    match node {
+        SceneNode::Text { .. } => 1,
+        SceneNode::Box {
+            layout, children, ..
+        } => {
+            let py = layout
+                .as_ref()
+                .and_then(|l| l.padding_y)
+                .filter(|p| *p >= 0)
+                .map(|p| p as u16)
+                .unwrap_or(0);
+            let gap = layout
+                .as_ref()
+                .and_then(|l| l.gap)
+                .filter(|g| *g >= 0)
+                .map(|g| g as u16)
+                .unwrap_or(0);
+            let direction = layout
+                .as_ref()
+                .and_then(|l| l.direction)
+                .unwrap_or(FlexDirection::Column);
+            let body = match direction {
+                FlexDirection::Column => {
+                    let mut total: u16 = 0;
+                    for (i, c) in children.iter().enumerate() {
+                        total = total.saturating_add(intrinsic_height(c));
+                        if i + 1 < children.len() {
+                            total = total.saturating_add(gap);
+                        }
+                    }
+                    total
+                }
+                FlexDirection::Row => children.iter().map(intrinsic_height).max().unwrap_or(0),
+            };
+            body.saturating_add(py.saturating_mul(2))
+        }
+    }
+}
+
+fn intrinsic_width(node: &SceneNode) -> u16 {
+    match node {
+        SceneNode::Text { runs, .. } => {
+            let chars: usize = runs.iter().map(|r| r.text.chars().count()).sum();
+            chars.min(u16::MAX as usize) as u16
+        }
+        SceneNode::Box {
+            layout, children, ..
+        } => {
+            let px = layout
+                .as_ref()
+                .and_then(|l| l.padding_x)
+                .filter(|p| *p >= 0)
+                .map(|p| p as u16)
+                .unwrap_or(0);
+            let gap = layout
+                .as_ref()
+                .and_then(|l| l.gap)
+                .filter(|g| *g >= 0)
+                .map(|g| g as u16)
+                .unwrap_or(0);
+            let direction = layout
+                .as_ref()
+                .and_then(|l| l.direction)
+                .unwrap_or(FlexDirection::Column);
+            let body = match direction {
+                FlexDirection::Row => {
+                    let mut total: u16 = 0;
+                    for (i, c) in children.iter().enumerate() {
+                        total = total.saturating_add(intrinsic_width(c));
+                        if i + 1 < children.len() {
+                            total = total.saturating_add(gap);
+                        }
+                    }
+                    total
+                }
+                FlexDirection::Column => children.iter().map(intrinsic_width).max().unwrap_or(0),
+            };
+            body.saturating_add(px.saturating_mul(2))
+        }
+    }
+}
+
+fn ratatui_style(style: Option<&TextStyle>) -> Style {
+    let Some(s) = style else {
+        return Style::default();
+    };
+    let mut out = Style::default();
+    if let Some(c) = s.color.as_ref() {
+        out = out.fg(color_to_ratatui(c));
+    }
+    if let Some(c) = s.bg.as_ref() {
+        out = out.bg(color_to_ratatui(c));
+    }
+    if s.bold == Some(true) {
+        out = out.add_modifier(Modifier::BOLD);
+    }
+    if s.dim == Some(true) {
+        out = out.add_modifier(Modifier::DIM);
+    }
+    if s.italic == Some(true) {
+        out = out.add_modifier(Modifier::ITALIC);
+    }
+    if s.underline == Some(true) {
+        out = out.add_modifier(Modifier::UNDERLINED);
+    }
+    if s.inverse == Some(true) {
+        out = out.add_modifier(Modifier::REVERSED);
+    }
+    if s.strikethrough == Some(true) {
+        out = out.add_modifier(Modifier::CROSSED_OUT);
+    }
+    out
+}
+
+fn color_to_ratatui(c: &Color) -> RColor {
+    match c {
+        Color::Named(n) => match n {
+            NamedColor::Default => RColor::Reset,
+            NamedColor::Black => RColor::Black,
+            NamedColor::Red => RColor::Red,
+            NamedColor::Green => RColor::Green,
+            NamedColor::Yellow => RColor::Yellow,
+            NamedColor::Blue => RColor::Blue,
+            NamedColor::Magenta => RColor::Magenta,
+            NamedColor::Cyan => RColor::Cyan,
+            NamedColor::White => RColor::White,
+            NamedColor::Gray => RColor::Gray,
+        },
+        Color::Hex { hex } => parse_hex(hex).unwrap_or(RColor::Reset),
+    }
+}
+
+fn parse_hex(hex: &str) -> Option<RColor> {
+    let s = hex.strip_prefix('#')?;
+    if s.len() != 6 {
+        return None;
+    }
+    let r = u8::from_str_radix(&s[0..2], 16).ok()?;
+    let g = u8::from_str_radix(&s[2..4], 16).ok()?;
+    let b = u8::from_str_radix(&s[4..6], 16).ok()?;
+    Some(RColor::Rgb(r, g, b))
+}

--- a/crates/reasonix-render/tests/render.rs
+++ b/crates/reasonix-render/tests/render.rs
@@ -1,0 +1,183 @@
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::{Color as RColor, Modifier};
+
+use reasonix_render::render::render_frame;
+use reasonix_render::scene::{
+    BoxLayout, Color, FlexDirection, NamedColor, SceneFrame, SceneNode, TextRun, TextStyle,
+};
+
+fn frame_of(root: SceneNode) -> SceneFrame {
+    SceneFrame {
+        schema_version: 1,
+        cols: 80,
+        rows: 24,
+        root,
+    }
+}
+
+fn collect_row(buf: &Buffer, y: u16, width: u16) -> String {
+    let mut out = String::new();
+    for x in 0..width {
+        out.push_str(buf[(x, y)].symbol());
+    }
+    out.trim_end().to_string()
+}
+
+#[test]
+fn renders_a_plain_text_frame_at_row_zero() {
+    let frame = frame_of(SceneNode::Text {
+        runs: vec![TextRun {
+            text: "hello".to_string(),
+            style: None,
+        }],
+        wrap: None,
+    });
+    let area = Rect::new(0, 0, 10, 3);
+    let mut buf = Buffer::empty(area);
+    render_frame(&frame, &mut buf, area);
+    assert_eq!(collect_row(&buf, 0, 10), "hello");
+}
+
+#[test]
+fn applies_color_and_bold_to_text() {
+    let frame = frame_of(SceneNode::Text {
+        runs: vec![TextRun {
+            text: "ok".to_string(),
+            style: Some(TextStyle {
+                color: Some(Color::Named(NamedColor::Green)),
+                bold: Some(true),
+                ..Default::default()
+            }),
+        }],
+        wrap: None,
+    });
+    let area = Rect::new(0, 0, 5, 1);
+    let mut buf = Buffer::empty(area);
+    render_frame(&frame, &mut buf, area);
+    let cell = &buf[(0, 0)];
+    assert_eq!(cell.symbol(), "o");
+    assert_eq!(cell.style().fg, Some(RColor::Green));
+    assert!(cell.style().add_modifier.contains(Modifier::BOLD));
+}
+
+#[test]
+fn stacks_column_children_vertically_with_gap() {
+    let frame = frame_of(SceneNode::Box {
+        layout: Some(BoxLayout {
+            direction: Some(FlexDirection::Column),
+            gap: Some(1),
+            ..Default::default()
+        }),
+        children: vec![
+            SceneNode::Text {
+                runs: vec![TextRun {
+                    text: "first".to_string(),
+                    style: None,
+                }],
+                wrap: None,
+            },
+            SceneNode::Text {
+                runs: vec![TextRun {
+                    text: "second".to_string(),
+                    style: None,
+                }],
+                wrap: None,
+            },
+        ],
+    });
+    let area = Rect::new(0, 0, 10, 5);
+    let mut buf = Buffer::empty(area);
+    render_frame(&frame, &mut buf, area);
+    assert_eq!(collect_row(&buf, 0, 10), "first");
+    assert_eq!(collect_row(&buf, 1, 10), "");
+    assert_eq!(collect_row(&buf, 2, 10), "second");
+}
+
+#[test]
+fn lays_out_row_children_horizontally() {
+    let frame = frame_of(SceneNode::Box {
+        layout: Some(BoxLayout {
+            direction: Some(FlexDirection::Row),
+            ..Default::default()
+        }),
+        children: vec![
+            SceneNode::Text {
+                runs: vec![TextRun {
+                    text: "ab".to_string(),
+                    style: None,
+                }],
+                wrap: None,
+            },
+            SceneNode::Text {
+                runs: vec![TextRun {
+                    text: "cd".to_string(),
+                    style: None,
+                }],
+                wrap: None,
+            },
+        ],
+    });
+    let area = Rect::new(0, 0, 10, 1);
+    let mut buf = Buffer::empty(area);
+    render_frame(&frame, &mut buf, area);
+    assert_eq!(collect_row(&buf, 0, 10), "abcd");
+}
+
+#[test]
+fn padding_shifts_children_in_and_shrinks_area() {
+    let frame = frame_of(SceneNode::Box {
+        layout: Some(BoxLayout {
+            padding_x: Some(2),
+            padding_y: Some(1),
+            ..Default::default()
+        }),
+        children: vec![SceneNode::Text {
+            runs: vec![TextRun {
+                text: "x".to_string(),
+                style: None,
+            }],
+            wrap: None,
+        }],
+    });
+    let area = Rect::new(0, 0, 10, 5);
+    let mut buf = Buffer::empty(area);
+    render_frame(&frame, &mut buf, area);
+    assert_eq!(buf[(2, 1)].symbol(), "x");
+    assert_eq!(buf[(0, 0)].symbol(), " ");
+}
+
+#[test]
+fn truncates_text_overflowing_its_area() {
+    let frame = frame_of(SceneNode::Text {
+        runs: vec![TextRun {
+            text: "abcdefghij".to_string(),
+            style: None,
+        }],
+        wrap: None,
+    });
+    let area = Rect::new(0, 0, 4, 1);
+    let mut buf = Buffer::empty(area);
+    render_frame(&frame, &mut buf, area);
+    assert_eq!(collect_row(&buf, 0, 4), "abcd");
+}
+
+#[test]
+fn renders_hex_color_as_truecolor() {
+    let frame = frame_of(SceneNode::Text {
+        runs: vec![TextRun {
+            text: "z".to_string(),
+            style: Some(TextStyle {
+                color: Some(Color::Hex {
+                    hex: "#aabbcc".to_string(),
+                }),
+                ..Default::default()
+            }),
+        }],
+        wrap: None,
+    });
+    let area = Rect::new(0, 0, 3, 1);
+    let mut buf = Buffer::empty(area);
+    render_frame(&frame, &mut buf, area);
+    assert_eq!(buf[(0, 0)].style().fg, Some(RColor::Rgb(0xaa, 0xbb, 0xcc)));
+}


### PR DESCRIPTION
First visible Rust output. \`reasonix-render\` now reads JSONL frames
from stdin, sets up an alt-screen TUI, and renders each frame through
a recursive walker that paints into ratatui's \`Buffer\`. The trace
files written by \`REASONIX_SCENE_TRACE\` (#952, #958) are now
*viewable* end-to-end.

## How to try

\`\`\`
REASONIX_SCENE_TRACE=/tmp/frames.jsonl reasonix   # run a session, hit a few keys
cargo run -q --bin reasonix-render < /tmp/frames.jsonl
\`\`\`

\`n\` / Right advances, \`p\` / Left goes back, \`q\` / Esc exits. Frames
also auto-advance after an 800ms dwell.

## Layout model

- **Text** runs paint left-to-right into a single row. Overflow
  truncates at the right edge. No wrap yet — the \`Wrap\` enum is
  in the contract but the renderer ignores it; that lands when we
  hit a real wrapped Text node.
- **Box** applies symmetric padding, then splits the inner rect by
  \`direction\`. Column stacks vertically with children's intrinsic
  heights (1 for Text, recursive for nested Box + gap + padding).
  Row lays out horizontally with intrinsic widths.
- **Gap** is between siblings, not after the last.
- **Colors**: hex → \`Color::Rgb\` (truecolor); named → 1:1; \`"default"\`
  → \`Color::Reset\`.

## Tests

7 new cell-level assertions in \`tests/render.rs\`:

- plain text renders at row 0
- color + bold modifier land on the right cell
- column stacks with gap leaves the gap row blank
- row layout places siblings horizontally
- padding shifts the child two cells right + one cell down
- overflow truncates at column width
- hex colors arrive as \`Color::Rgb(0xaa, 0xbb, 0xcc)\`

Existing 6 round-trip tests still pass.

## What's deferred

- **Wrap modes** — the \`Wrap\` enum is in the contract; renderer
  treats every text run as single-line and truncating. First real
  wrapped frame from the producer forces a renderer extension.
- **Width / height constraints** — \`Dim::Fill\` and explicit \`Dim::Cells\`
  on Box don't influence layout yet. Today the layout uses intrinsic
  sizes. Comes when a producer needs to pin a region.
- **Border rendering** — \`borderStyle\` / \`borderColor\` deserialize
  fine; renderer ignores them. Same rule.

Each deferred field is in the contract and decodes cleanly — the
renderer just chooses not to use them yet. No silent drops; future
extensions are additive.

Refs #868 #947