### PR TITLE
feat(scene): spawn the Rust renderer as a child process

### DIFF
--- a/src/cli/ui/scene/renderer-process.ts
+++ b/src/cli/ui/scene/renderer-process.ts
@@ -1,0 +1,57 @@
+import { spawn } from "node:child_process";
+import type { SceneFrame } from "./types.js";
+
+export type RendererProcess = {
+  emit(frame: SceneFrame): void;
+  close(): Promise<number | null>;
+};
+
+export type SpawnRendererOptions = {
+  command?: readonly string[];
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+};
+
+const DEFAULT_COMMAND: readonly string[] = ["cargo", "run", "--quiet", "--bin", "reasonix-render"];
+
+export function spawnRenderer(opts: SpawnRendererOptions = {}): RendererProcess {
+  const command = opts.command ?? DEFAULT_COMMAND;
+  const [cmd, ...args] = command;
+  if (!cmd) {
+    throw new Error("spawnRenderer: empty command");
+  }
+
+  const child = spawn(cmd, args, {
+    cwd: opts.cwd,
+    env: opts.env ?? process.env,
+    stdio: ["pipe", "inherit", "inherit"],
+  });
+
+  let exited = false;
+  const exitPromise = new Promise<number | null>((resolve) => {
+    child.once("exit", (code) => {
+      exited = true;
+      resolve(code);
+    });
+  });
+
+  child.stdin?.on("error", () => {
+    exited = true;
+  });
+
+  return {
+    emit(frame: SceneFrame): void {
+      if (exited) return;
+      const stdin = child.stdin;
+      if (!stdin || stdin.destroyed || !stdin.writable) return;
+      stdin.write(`${JSON.stringify(frame)}\n`);
+    },
+    close(): Promise<number | null> {
+      const stdin = child.stdin;
+      if (stdin && !stdin.destroyed && stdin.writable) {
+        stdin.end();
+      }
+      return exitPromise;
+    },
+  };
+}

--- a/tests/fixtures/scene-echo-stub.mjs
+++ b/tests/fixtures/scene-echo-stub.mjs
@@ -1,0 +1,24 @@
+import { appendFileSync } from "node:fs";
+
+const out = process.env.SCENE_ECHO_OUT;
+if (!out) {
+  process.stderr.write("SCENE_ECHO_OUT not set\n");
+  process.exit(2);
+}
+
+let buf = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  buf += chunk;
+  let nl = buf.indexOf("\n");
+  while (nl >= 0) {
+    const line = buf.slice(0, nl);
+    buf = buf.slice(nl + 1);
+    if (line.trim().length > 0) appendFileSync(out, `${line}\n`);
+    nl = buf.indexOf("\n");
+  }
+});
+process.stdin.on("end", () => {
+  if (buf.trim().length > 0) appendFileSync(out, `${buf}\n`);
+  process.exit(0);
+});

--- a/tests/scene-renderer-process.test.ts
+++ b/tests/scene-renderer-process.test.ts
@@ -1,0 +1,63 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import process from "node:process";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { frame, text } from "../src/cli/ui/scene/build.js";
+import { spawnRenderer } from "../src/cli/ui/scene/renderer-process.js";
+
+const STUB = "tests/fixtures/scene-echo-stub.mjs";
+
+describe("spawnRenderer", () => {
+  let dir: string;
+  let outPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "scene-spawn-"));
+    outPath = join(dir, "received.jsonl");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("forwards each emitted frame to the child as one JSONL line", async () => {
+    const proc = spawnRenderer({
+      command: [process.execPath, STUB],
+      env: { ...process.env, SCENE_ECHO_OUT: outPath },
+    });
+    proc.emit(frame(80, 24, text("alpha")));
+    proc.emit(frame(120, 40, text("beta")));
+    const code = await proc.close();
+    expect(code).toBe(0);
+    const lines = readFileSync(outPath, "utf8").trimEnd().split("\n");
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0]).root.runs[0].text).toBe("alpha");
+    expect(JSON.parse(lines[1]).root.runs[0].text).toBe("beta");
+  });
+
+  it("close() resolves with the child exit code", async () => {
+    const proc = spawnRenderer({
+      command: [process.execPath, STUB],
+      env: { ...process.env, SCENE_ECHO_OUT: outPath },
+    });
+    const code = await proc.close();
+    expect(code).toBe(0);
+  });
+
+  it("emit() after close is a no-op, not an error", async () => {
+    const proc = spawnRenderer({
+      command: [process.execPath, STUB],
+      env: { ...process.env, SCENE_ECHO_OUT: outPath },
+    });
+    proc.emit(frame(80, 24, text("first")));
+    await proc.close();
+    expect(() => proc.emit(frame(80, 24, text("after-close")))).not.toThrow();
+    const lines = readFileSync(outPath, "utf8").trimEnd().split("\n");
+    expect(lines).toHaveLength(1);
+  });
+
+  it("throws synchronously on an empty command", () => {
+    expect(() => spawnRenderer({ command: [] })).toThrow(/empty command/);
+  });
+});


### PR DESCRIPTION
JS-side plumbing for the \`REASONIX_RENDERER=rust\` runtime switch.
\`spawnRenderer()\` starts the \`reasonix-render\` binary, returns an
\`emit(frame)\` that writes one JSONL line to the child's stdin and a
\`close()\` that resolves with the child's exit code.

## What this PR is not

Not the flip. \`App.tsx\` doesn't call this yet. The flip-the-flag PR
lands once Ink can be mounted to a non-stdout backend — both Ink
and the spawned Rust process want the terminal, and exactly one can
have it. That's the Stage 1 mid-cut design problem; this PR is the
piece that doesn't depend on solving it.

## Why test with a Node stub

- The real binary takes over the terminal (alt screen + raw mode).
  Running it inside a CI process would be hostile to the test
  runner.
- The plumbing contract is JS-side: spawn succeeds, frames pipe in
  order as JSONL, stdin closes cleanly, exit code surfaces, post-
  close \`emit\` is a no-op. None of that needs a real terminal — a
  Node script that echoes stdin lines to a file is enough.
- Keeps the JS test suite Rust-toolchain-free. CI doesn't have to
  build the crate just to run vitest.

## Default command

\`DEFAULT_COMMAND\` is \`cargo run --quiet --bin reasonix-render\` so
in-tree smoke tests work today without installing anything. Release
tooling will swap this to the installed binary path when
distribution is wired up.

## Tests

Four cases in \`tests/scene-renderer-process.test.ts\`:

- Two frames emit → two JSONL lines arrive in order at the child.
- \`close()\` resolves with the child exit code.
- \`emit()\` after \`close()\` is a no-op (no crash, no extra line).
- Empty command throws synchronously.

Refs #868 #947