### PR TITLE
feat(scene): REASONIX_RENDERER=rust pipes frames to the binary

### DIFF
--- a/crates/reasonix-render/src/decode_only.rs
+++ b/crates/reasonix-render/src/decode_only.rs
@@ -1,0 +1,20 @@
+use std::io::{BufRead, Write};
+
+use anyhow::{Context, Result};
+
+use crate::scene::SceneFrame;
+
+pub fn run_decode_only<R: BufRead, W: Write>(input: R, mut output: W) -> Result<u64> {
+    let mut count = 0u64;
+    for (lineno, line) in input.lines().enumerate() {
+        let line = line.with_context(|| format!("read line {}", lineno + 1))?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let _frame: SceneFrame =
+            serde_json::from_str(&line).with_context(|| format!("decode line {}", lineno + 1))?;
+        count += 1;
+        writeln!(output, "frame {count}").ok();
+    }
+    Ok(count)
+}

--- a/crates/reasonix-render/src/lib.rs
+++ b/crates/reasonix-render/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod decode_only;
 pub mod render;
 pub mod scene;

--- a/crates/reasonix-render/src/main.rs
+++ b/crates/reasonix-render/src/main.rs
@@ -10,10 +10,17 @@ use crossterm::terminal::{
 use ratatui::backend::CrosstermBackend;
 use ratatui::Terminal;
 
+use reasonix_render::decode_only::run_decode_only;
 use reasonix_render::render::render_frame;
 use reasonix_render::scene::SceneFrame;
 
 fn main() -> Result<()> {
+    if std::env::args().skip(1).any(|a| a == "--decode-only") {
+        let stdin = io::stdin();
+        let stdout = io::stdout();
+        run_decode_only(stdin.lock(), stdout.lock())?;
+        return Ok(());
+    }
     let frames = read_frames()?;
     if frames.is_empty() {
         anyhow::bail!("no frames on stdin");

--- a/crates/reasonix-render/tests/decode_only.rs
+++ b/crates/reasonix-render/tests/decode_only.rs
@@ -1,0 +1,45 @@
+use reasonix_render::decode_only::run_decode_only;
+
+#[test]
+fn counts_and_emits_one_line_per_frame() {
+    let input = concat!(
+        r#"{"schemaVersion":1,"cols":80,"rows":24,"root":{"kind":"text","runs":[{"text":"a"}]}}"#,
+        "\n",
+        r#"{"schemaVersion":1,"cols":80,"rows":24,"root":{"kind":"text","runs":[{"text":"b"}]}}"#,
+        "\n",
+    );
+    let mut out = Vec::<u8>::new();
+    let count = run_decode_only(input.as_bytes(), &mut out).expect("decode");
+    assert_eq!(count, 2);
+    let s = String::from_utf8(out).expect("utf8");
+    assert!(s.contains("frame 1"), "{s}");
+    assert!(s.contains("frame 2"), "{s}");
+}
+
+#[test]
+fn skips_blank_lines_and_keeps_counting() {
+    let input = concat!(
+        "\n",
+        r#"{"schemaVersion":1,"cols":80,"rows":24,"root":{"kind":"text","runs":[{"text":"a"}]}}"#,
+        "\n",
+        "   \n",
+        r#"{"schemaVersion":1,"cols":80,"rows":24,"root":{"kind":"text","runs":[{"text":"b"}]}}"#,
+        "\n",
+    );
+    let mut out = Vec::<u8>::new();
+    let count = run_decode_only(input.as_bytes(), &mut out).expect("decode");
+    assert_eq!(count, 2);
+}
+
+#[test]
+fn surfaces_decode_errors_with_line_context() {
+    let input = concat!(
+        r#"{"schemaVersion":1,"cols":80,"rows":24,"root":{"kind":"text","runs":[{"text":"a"}]}}"#,
+        "\n",
+        r#"{"kind":"text"}"#,
+        "\n",
+    );
+    let mut out = Vec::<u8>::new();
+    let err = run_decode_only(input.as_bytes(), &mut out).unwrap_err();
+    assert!(err.to_string().contains("line 2"), "{err}");
+}

--- a/src/cli/ui/scene/renderer-process.ts
+++ b/src/cli/ui/scene/renderer-process.ts
@@ -12,7 +12,13 @@ export type SpawnRendererOptions = {
   env?: NodeJS.ProcessEnv;
 };
 
-const DEFAULT_COMMAND: readonly string[] = ["cargo", "run", "--quiet", "--bin", "reasonix-render"];
+export const DEFAULT_COMMAND: readonly string[] = [
+  "cargo",
+  "run",
+  "--quiet",
+  "--bin",
+  "reasonix-render",
+];
 
 export function spawnRenderer(opts: SpawnRendererOptions = {}): RendererProcess {
   const command = opts.command ?? DEFAULT_COMMAND;

--- a/src/cli/ui/scene/trace.ts
+++ b/src/cli/ui/scene/trace.ts
@@ -1,35 +1,87 @@
 import { appendFileSync, closeSync, openSync } from "node:fs";
+import { DEFAULT_COMMAND, type RendererProcess, spawnRenderer } from "./renderer-process.js";
 import type { SceneFrame } from "./types.js";
 
-const ENV_VAR = "REASONIX_SCENE_TRACE";
+const FILE_VAR = "REASONIX_SCENE_TRACE";
+const RENDERER_VAR = "REASONIX_RENDERER";
+const COMMAND_OVERRIDE_VAR = "REASONIX_RENDER_CMD";
 
-type TraceState = { path: string | null; opened: boolean };
+type Mode = "off" | "file" | "child";
 
-const state: TraceState = { path: null, opened: false };
+type TraceState = {
+  mode: Mode;
+  opened: boolean;
+  path: string | null;
+  child: RendererProcess | null;
+};
+
+const state: TraceState = { mode: "off", opened: false, path: null, child: null };
 
 export function isSceneTraceEnabled(): boolean {
   ensureInitialized();
-  return state.path !== null;
+  return state.mode !== "off";
 }
 
 export function emitSceneFrame(frame: SceneFrame): void {
   ensureInitialized();
-  if (!state.path) return;
-  appendFileSync(state.path, `${JSON.stringify(frame)}\n`);
+  switch (state.mode) {
+    case "off":
+      return;
+    case "file":
+      if (state.path) {
+        appendFileSync(state.path, `${JSON.stringify(frame)}\n`);
+      }
+      return;
+    case "child":
+      state.child?.emit(frame);
+      return;
+  }
 }
 
 export function resetSceneTrace(): void {
-  state.path = null;
+  if (state.child) {
+    state.child.close();
+  }
+  state.mode = "off";
   state.opened = false;
+  state.path = null;
+  state.child = null;
+}
+
+export async function flushSceneTrace(): Promise<void> {
+  if (state.child) {
+    await state.child.close();
+  }
 }
 
 function ensureInitialized(): void {
   if (state.opened) return;
   state.opened = true;
-  const raw = process.env[ENV_VAR];
+  if (process.env[RENDERER_VAR] === "rust") {
+    state.mode = "child";
+    state.child = spawnRenderer({ command: rendererCommand() });
+    return;
+  }
+  const raw = process.env[FILE_VAR];
   if (!raw || raw.length === 0) return;
+  state.mode = "file";
   state.path = raw;
   truncate(raw);
+}
+
+function rendererCommand(): readonly string[] {
+  const override = process.env[COMMAND_OVERRIDE_VAR];
+  if (override && override.length > 0) {
+    try {
+      const parsed = JSON.parse(override);
+      if (Array.isArray(parsed) && parsed.every((p) => typeof p === "string")) {
+        return parsed;
+      }
+    } catch {
+      // fall through to default
+    }
+  }
+  return [...DEFAULT_COMMAND, "--", "--decode-only"];
 }
 
 function truncate(path: string): void {

--- a/tests/scene-trace.test.ts
+++ b/tests/scene-trace.test.ts
@@ -1,77 +1,114 @@
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import process from "node:process";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { frame, text } from "../src/cli/ui/scene/build.js";
-import { emitSceneFrame, isSceneTraceEnabled, resetSceneTrace } from "../src/cli/ui/scene/trace.js";
+import {
+  emitSceneFrame,
+  flushSceneTrace,
+  isSceneTraceEnabled,
+  resetSceneTrace,
+} from "../src/cli/ui/scene/trace.js";
+
+const STUB = "tests/fixtures/scene-echo-stub.mjs";
+
+const ENV_KEYS = [
+  "REASONIX_SCENE_TRACE",
+  "REASONIX_RENDERER",
+  "REASONIX_RENDER_CMD",
+  "SCENE_ECHO_OUT",
+] as const;
+type EnvKey = (typeof ENV_KEYS)[number];
 
 describe("scene trace harness", () => {
   let dir: string;
-  let path: string;
-  let prev: string | undefined;
+  let filePath: string;
+  let stubOut: string;
+  let prev: Partial<Record<EnvKey, string | undefined>>;
 
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), "scene-trace-"));
-    path = join(dir, "frames.jsonl");
-    prev = process.env.REASONIX_SCENE_TRACE;
+    filePath = join(dir, "frames.jsonl");
+    stubOut = join(dir, "child-frames.jsonl");
+    prev = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]])) as typeof prev;
+    for (const k of ENV_KEYS) {
+      delete process.env[k];
+    }
     resetSceneTrace();
   });
 
-  afterEach(() => {
-    if (prev === undefined) {
-      // biome-ignore lint/performance/noDelete: env vars are strings; assignment to undefined stores the literal "undefined"
-      delete process.env.REASONIX_SCENE_TRACE;
-    } else {
-      process.env.REASONIX_SCENE_TRACE = prev;
-    }
+  afterEach(async () => {
+    await flushSceneTrace();
     resetSceneTrace();
+    for (const k of ENV_KEYS) {
+      const v = prev[k];
+      if (v === undefined) {
+        delete process.env[k];
+      } else {
+        process.env[k] = v;
+      }
+    }
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("is disabled when the env var is unset", () => {
-    // biome-ignore lint/performance/noDelete: env vars are strings; assignment to undefined stores the literal "undefined"
-    delete process.env.REASONIX_SCENE_TRACE;
-    resetSceneTrace();
+  it("is disabled when no env vars are set", () => {
     expect(isSceneTraceEnabled()).toBe(false);
     emitSceneFrame(frame(80, 24, text("noop")));
   });
 
-  it("is disabled when the env var is empty", () => {
+  it("is disabled when REASONIX_SCENE_TRACE is empty", () => {
     process.env.REASONIX_SCENE_TRACE = "";
     resetSceneTrace();
     expect(isSceneTraceEnabled()).toBe(false);
   });
 
-  it("writes each emitted frame as one JSONL line", () => {
-    process.env.REASONIX_SCENE_TRACE = path;
+  it("writes each emitted frame as one JSONL line in file mode", () => {
+    process.env.REASONIX_SCENE_TRACE = filePath;
     resetSceneTrace();
     expect(isSceneTraceEnabled()).toBe(true);
     emitSceneFrame(frame(80, 24, text("first")));
     emitSceneFrame(frame(120, 40, text("second")));
-    const lines = readFileSync(path, "utf8").trimEnd().split("\n");
+    const lines = readFileSync(filePath, "utf8").trimEnd().split("\n");
     expect(lines).toHaveLength(2);
-    expect(JSON.parse(lines[0])).toEqual({
-      schemaVersion: 1,
-      cols: 80,
-      rows: 24,
-      root: { kind: "text", runs: [{ text: "first" }] },
-    });
-    expect(JSON.parse(lines[1])).toEqual({
-      schemaVersion: 1,
-      cols: 120,
-      rows: 40,
-      root: { kind: "text", runs: [{ text: "second" }] },
-    });
+    expect(JSON.parse(lines[0]).root.runs[0].text).toBe("first");
+    expect(JSON.parse(lines[1]).root.runs[0].text).toBe("second");
   });
 
-  it("truncates the file on init, so a stale trace from a previous run does not bleed into the new one", () => {
-    process.env.REASONIX_SCENE_TRACE = path;
+  it("truncates the file on init, so a stale trace from a previous run does not bleed", () => {
+    process.env.REASONIX_SCENE_TRACE = filePath;
     resetSceneTrace();
     emitSceneFrame(frame(80, 24, text("first run")));
     resetSceneTrace();
     emitSceneFrame(frame(80, 24, text("second run")));
-    const lines = readFileSync(path, "utf8").trimEnd().split("\n");
+    const lines = readFileSync(filePath, "utf8").trimEnd().split("\n");
     expect(lines).toHaveLength(1);
     expect(JSON.parse(lines[0]).root.runs[0].text).toBe("second run");
+  });
+
+  it("dispatches frames to a child process when REASONIX_RENDERER=rust", async () => {
+    process.env.REASONIX_RENDERER = "rust";
+    process.env.REASONIX_RENDER_CMD = JSON.stringify([process.execPath, STUB]);
+    process.env.SCENE_ECHO_OUT = stubOut;
+    resetSceneTrace();
+    expect(isSceneTraceEnabled()).toBe(true);
+    emitSceneFrame(frame(80, 24, text("via-child")));
+    await flushSceneTrace();
+    const lines = readFileSync(stubOut, "utf8").trimEnd().split("\n");
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0]).root.runs[0].text).toBe("via-child");
+  });
+
+  it("child mode wins over file mode when both env vars are set", async () => {
+    process.env.REASONIX_RENDERER = "rust";
+    process.env.REASONIX_RENDER_CMD = JSON.stringify([process.execPath, STUB]);
+    process.env.SCENE_ECHO_OUT = stubOut;
+    process.env.REASONIX_SCENE_TRACE = filePath;
+    resetSceneTrace();
+    emitSceneFrame(frame(80, 24, text("priority")));
+    await flushSceneTrace();
+    const childLines = readFileSync(stubOut, "utf8").trimEnd().split("\n");
+    expect(childLines).toHaveLength(1);
+    expect(() => readFileSync(filePath, "utf8")).toThrow();
   });
 });


### PR DESCRIPTION
Cut B of the runtime switch. When \`REASONIX_RENDERER=rust\` is set,
\`useSceneTrace\` spawns the Rust binary with \`--decode-only\` and
pipes frames to its stdin instead of writing to a file. The binary
stays headless — no alt screen, no raw mode, no terminal takeover —
so Ink keeps owning the visible TUI while the Rust process consumes
frames in the background.

## Why not the full flip yet

Both Ink and a full Rust renderer want the terminal; exactly one can
have it. The full flip needs Ink mounted to a null-stdout backend,
which is its own refactoring problem worth a separate PR. This cut
is the intermediate stop that proves the producer → consumer loop
end-to-end during a real session **without** fighting Ink.

## End-to-end demo

\`\`\`
REASONIX_RENDERER=rust reasonix  # runs the session; Ink renders; child decodes silently
\`\`\`

## Mode selection in trace.ts

| Env state | Mode |
|---|---|
| \`REASONIX_RENDERER=rust\` set | **child** — spawn binary, pipe frames |
| \`REASONIX_SCENE_TRACE=/path\` set, no renderer | **file** — write JSONL |
| Both set | **child** (renderer wins) |
| Neither | **off** — \`emitSceneFrame\` is a no-op |

## Rust side

- \`decode_only::run_decode_only<R, W>\` — generic over input/output,
  reads JSONL, deserializes, emits \`frame N\` lines per accepted
  frame. Internal; tested directly.
- \`main.rs\` checks argv for \`--decode-only\` **before** touching
  ratatui, so the headless path never enables raw mode.

## Tests

- **Rust** (\`tests/decode_only.rs\`): count, blank-line skipping,
  decode-error line context. 3 cases.
- **JS** (\`tests/scene-trace.test.ts\`): re-organized the env save /
  restore to cover the new vars; added two cases — child mode
  receives frames via the Node stub, and child wins over file mode
  when both vars are set.

## Knobs

- \`REASONIX_RENDER_CMD\` (JSON array) overrides the default
  \`cargo run --bin reasonix-render -- --decode-only\` command.
  Internal — tests use it to point at the Node stub. Production
  users have no reason to set it. We will swap the default to the
  installed binary path when distribution lands.

Refs #868 #947