### PR TITLE
feat(scene): cut A — Rust child owns the visible terminal

### DIFF
--- a/crates/reasonix-render/src/main.rs
+++ b/crates/reasonix-render/src/main.rs
@@ -1,12 +1,8 @@
-use std::io::{self, BufRead, Write};
-use std::time::Duration;
+use std::io::{self, BufRead};
 
 use anyhow::{Context, Result};
-use crossterm::event::{self, Event, KeyCode};
 use crossterm::execute;
-use crossterm::terminal::{
-    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
-};
+use crossterm::terminal::{EnterAlternateScreen, LeaveAlternateScreen};
 use ratatui::backend::CrosstermBackend;
 use ratatui::Terminal;
 
@@ -21,27 +17,21 @@ fn main() -> Result<()> {
         run_decode_only(stdin.lock(), stdout.lock())?;
         return Ok(());
     }
-    let frames = read_frames()?;
-    if frames.is_empty() {
-        anyhow::bail!("no frames on stdin");
-    }
+
     let mut stdout = io::stdout();
-    enable_raw_mode().context("enable raw mode")?;
     execute!(stdout, EnterAlternateScreen).context("enter alt screen")?;
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend).context("create terminal")?;
 
-    let result = run_loop(&mut terminal, &frames);
+    let result = run_stream_loop(&mut terminal);
 
-    disable_raw_mode().ok();
     execute!(terminal.backend_mut(), LeaveAlternateScreen).ok();
     terminal.show_cursor().ok();
     result
 }
 
-fn read_frames() -> Result<Vec<SceneFrame>> {
+fn run_stream_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()> {
     let stdin = io::stdin();
-    let mut out = Vec::new();
     for (lineno, line) in stdin.lock().lines().enumerate() {
         let line = line.with_context(|| format!("read line {}", lineno + 1))?;
         if line.trim().is_empty() {
@@ -49,40 +39,10 @@ fn read_frames() -> Result<Vec<SceneFrame>> {
         }
         let frame: SceneFrame =
             serde_json::from_str(&line).with_context(|| format!("decode line {}", lineno + 1))?;
-        out.push(frame);
-    }
-    Ok(out)
-}
-
-fn run_loop(
-    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
-    frames: &[SceneFrame],
-) -> Result<()> {
-    let mut idx = 0usize;
-    let dwell = Duration::from_millis(800);
-    loop {
-        let frame = &frames[idx];
         terminal.draw(|f| {
             let area = f.area();
-            render_frame(frame, f.buffer_mut(), area);
+            render_frame(&frame, f.buffer_mut(), area);
         })?;
-        if event::poll(dwell)? {
-            if let Event::Key(k) = event::read()? {
-                match k.code {
-                    KeyCode::Char('q') | KeyCode::Esc => return Ok(()),
-                    KeyCode::Char('n') | KeyCode::Right => {
-                        idx = (idx + 1) % frames.len();
-                        continue;
-                    }
-                    KeyCode::Char('p') | KeyCode::Left => {
-                        idx = if idx == 0 { frames.len() - 1 } else { idx - 1 };
-                        continue;
-                    }
-                    _ => {}
-                }
-            }
-        }
-        idx = (idx + 1) % frames.len();
-        writeln!(io::sink()).ok();
     }
+    Ok(())
 }

--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -28,6 +28,7 @@ import { SessionPicker } from "../ui/SessionPicker.js";
 import { Setup } from "../ui/Setup.js";
 import { drainTtyResponses } from "../ui/drain-tty.js";
 import { KeystrokeProvider } from "../ui/keystroke-context.js";
+import { makeNullStdout } from "../ui/scene/null-stdout.js";
 import type { McpServerSummary } from "../ui/slash.js";
 import {
   type McpLifecycleNotice,
@@ -336,6 +337,9 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
     }
   }
 
+  const rustRendererActive = process.env.REASONIX_RENDERER === "rust";
+  const inkStdout = rustRendererActive ? makeNullStdout() : undefined;
+
   const { waitUntilExit } = render(
     <Root
       initialKey={initialKey}
@@ -353,6 +357,7 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
       qqErrorRef={qqErrorRef}
     />,
     {
+      stdout: inkStdout,
       exitOnCtrlC: true,
       // patchConsole:false — winpty/MINTTY redraw-glitch source.
       patchConsole: false,
@@ -365,7 +370,8 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
       // Default true — alt-screen is the only mode without scrollback-
       // reflow ghosting. `--no-alt-screen` opts back into scrollback mode
       // for users who need chat output preserved in shell history on exit.
-      alternateScreen: opts.altScreen !== false,
+      // Off when the Rust child owns the terminal — it runs its own alt-screen.
+      alternateScreen: !rustRendererActive && opts.altScreen !== false,
     },
   );
   try {

--- a/src/cli/ui/scene/null-stdout.ts
+++ b/src/cli/ui/scene/null-stdout.ts
@@ -1,0 +1,25 @@
+import { Writable } from "node:stream";
+
+export function makeNullStdout(real: NodeJS.WriteStream = process.stdout): NodeJS.WriteStream {
+  const writable = new Writable({
+    write(_chunk, _encoding, callback) {
+      callback();
+    },
+  });
+  applyDimensions(writable, real);
+  if (typeof real.on === "function") {
+    real.on("resize", () => {
+      applyDimensions(writable, real);
+      writable.emit("resize");
+    });
+  }
+  return writable as unknown as NodeJS.WriteStream;
+}
+
+function applyDimensions(target: Writable, real: NodeJS.WriteStream): void {
+  Object.assign(target, {
+    columns: real.columns ?? 80,
+    rows: real.rows ?? 24,
+    isTTY: true,
+  });
+}

--- a/src/cli/ui/scene/trace.ts
+++ b/src/cli/ui/scene/trace.ts
@@ -81,7 +81,7 @@ function rendererCommand(): readonly string[] {
       // fall through to default
     }
   }
-  return [...DEFAULT_COMMAND, "--", "--decode-only"];
+  return [...DEFAULT_COMMAND];
 }
 
 function truncate(path: string): void {

--- a/tests/scene-null-stdout.test.ts
+++ b/tests/scene-null-stdout.test.ts
@@ -1,0 +1,41 @@
+import { PassThrough } from "node:stream";
+import { describe, expect, it } from "vitest";
+import { makeNullStdout } from "../src/cli/ui/scene/null-stdout.js";
+
+function fakeTty(columns: number, rows: number): NodeJS.WriteStream {
+  const t = new PassThrough();
+  Object.assign(t, { columns, rows, isTTY: true });
+  return t as unknown as NodeJS.WriteStream;
+}
+
+describe("makeNullStdout", () => {
+  it("discards writes without throwing", () => {
+    const stdout = makeNullStdout(fakeTty(80, 24));
+    expect(() => stdout.write("anything\n")).not.toThrow();
+    expect(() => stdout.write(Buffer.from([0x1b, 0x5b, 0x32, 0x4a]))).not.toThrow();
+  });
+
+  it("reports the real tty's columns and rows", () => {
+    const real = fakeTty(120, 48);
+    const stdout = makeNullStdout(real);
+    expect(stdout.columns).toBe(120);
+    expect(stdout.rows).toBe(48);
+  });
+
+  it("reports isTTY=true so Ink's tty detection passes", () => {
+    const stdout = makeNullStdout(fakeTty(80, 24));
+    expect(stdout.isTTY).toBe(true);
+  });
+
+  it("re-emits resize when the real tty resizes", () => {
+    const real = fakeTty(80, 24);
+    const stdout = makeNullStdout(real);
+    let observed: { cols: number; rows: number } | null = null;
+    stdout.on("resize", () => {
+      observed = { cols: stdout.columns, rows: stdout.rows };
+    });
+    Object.assign(real, { columns: 100, rows: 30 });
+    real.emit("resize");
+    expect(observed).toEqual({ cols: 100, rows: 30 });
+  });
+});


### PR DESCRIPTION
\`REASONIX_RENDERER=rust\` now actually flips the renderer. The
spawned Rust process takes the user-facing terminal (alt-screen +
ratatui); Ink keeps running for state, hooks, and the SceneFrame
producer but writes to a null sink whose \`columns\` / \`rows\` still
proxy the real tty.

End-to-end: state in JS → frames over child stdin → ratatui on
screen.

## Three pieces

### 1. Rust streaming

The non-decode-only path is a tight stdin-line / parse / draw loop.
No pre-load, no keyboard handling, no \`enable_raw_mode\`. crossterm
reads its own keys from \`/dev/tty\`; we don't read keys here at all
so the parent (Ink) keeps undivided ownership of stdin and raw-mode.

Exit condition: stdin EOF, which fires when the parent closes the
pipe during shutdown.

### 2. Null Ink stdout

\`makeNullStdout(real)\` returns a Writable that discards bytes but
exposes \`real.columns\` / \`real.rows\` and re-emits \`resize\`. Yoga
still computes correct layouts; only the *output* vanishes. The
cast is honest: \`unknown as NodeJS.WriteStream\`, not \`any as ...\`.

### 3. Default command

\`trace.ts\`'s child-mode default drops \`--decode-only\`. The
validator mode from #961 is still reachable via
\`REASONIX_RENDER_CMD\`; the default for \`REASONIX_RENDERER=rust\`
is now the streaming TUI.

## Known limitations (Stage 2 territory)

- **No input wiring.** The user can see Rust's render and type keys
  (Ink receives them and updates state, which produces new frames),
  but Ink's composer / completions / pickers are invisible because
  Ink itself isn't drawn. Stage 2 (Rust input layer + semantic
  events back to JS) closes this.
- **Initial blank moment.** Spawning the child has a small startup
  cost; until the first frame arrives the alt-screen is empty.
- **alt-screen** disabled on the JS side when the flag is on, so
  the Rust child's alt-screen entry is the only one in flight.

## Tests

- 4 new cases for \`makeNullStdout\`: discards writes, proxies
  cols/rows, reports \`isTTY=true\`, re-emits resize.
- Existing 6 scene-trace tests still pass with the new default
  command path.
- Rust test suite unchanged (streaming loop is composed from
  already-tested \`render_frame\` + serde).

## How to try

\`\`\`
REASONIX_RENDERER=rust reasonix
\`\`\`

You'll see a column-laid-out one-liner ("reasonix · N cards · …")
that updates as the React tree re-renders.

Refs #868 #947