### PR TITLE
feat(scene): richer trace frame — title row + last card + status

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -136,7 +136,7 @@ import { useLanguageReload } from "./hooks/useLanguageReload.js";
 import { useLoopMode } from "./hooks/useLoopMode.js";
 import { usePresetMode } from "./hooks/usePresetMode.js";
 import { useQuit } from "./hooks/useQuit.js";
-import { useSceneTrace } from "./hooks/useSceneTrace.js";
+import { summarizeCard, useSceneTrace } from "./hooks/useSceneTrace.js";
 import { useScrollback } from "./hooks/useScrollback.js";
 import { useTerminalSetup } from "./hooks/useTerminalSetup.js";
 import { useToolProgressDisplay } from "./hooks/useToolProgressDisplay.js";
@@ -469,6 +469,8 @@ function AppInner({
   );
   const isStreaming = useAgentState((s) => s.cards.some((c) => c.kind === "streaming" && !c.done));
   const cardCount = useAgentState((s) => s.cards.length);
+  const lastCardKind = useAgentState((s) => s.cards.at(-1)?.kind);
+  const lastCardSummary = useAgentState((s) => summarizeCard(s.cards.at(-1)));
   const activityLabel = useActivityLabel();
   const chatScroll = useChatScrollActions();
   const [input, setInput] = useState("");
@@ -507,7 +509,14 @@ function AppInner({
   useEffect(() => {
     busyRef.current = busy;
   }, [busy]);
-  useSceneTrace({ cardCount, busy, activity: activityLabel });
+  useSceneTrace({
+    cardCount,
+    busy,
+    activity: activityLabel,
+    model,
+    lastCardKind,
+    lastCardSummary,
+  });
   const {
     ongoingTool,
     setOngoingTool,

--- a/src/cli/ui/hooks/useSceneTrace.ts
+++ b/src/cli/ui/hooks/useSceneTrace.ts
@@ -2,28 +2,148 @@ import { useStdout } from "ink";
 import { useEffect } from "react";
 import { box, frame, text } from "../scene/build.js";
 import { emitSceneFrame, isSceneTraceEnabled } from "../scene/trace.js";
-import type { TextRun } from "../scene/types.js";
+import type { Color, SceneFrame, SceneNode, TextRun } from "../scene/types.js";
+import type { Card } from "../state/cards.js";
 
-export type SceneTraceSummary = {
+export type SceneTraceInput = {
+  model?: string;
   cardCount: number;
+  lastCardKind?: string;
+  lastCardSummary?: string;
   busy: boolean;
   activity?: string;
 };
 
-export function useSceneTrace(summary: SceneTraceSummary): void {
+const SUMMARY_MAX = 70;
+
+export function summarizeCard(card: Card | undefined): string | undefined {
+  if (!card) return undefined;
+  switch (card.kind) {
+    case "user":
+    case "reasoning":
+    case "streaming":
+      return clip(card.text);
+    case "tool":
+      return clip(card.done ? card.name : `${card.name} …`);
+    case "error":
+    case "warn":
+      return clip(card.title);
+    case "task":
+    case "plan":
+      return clip(card.title);
+    case "diff":
+      return clip(card.file);
+    default:
+      return card.kind;
+  }
+}
+
+function clip(s: string): string {
+  const firstLine = s.split("\n", 1)[0] ?? "";
+  return firstLine.length > SUMMARY_MAX ? `${firstLine.slice(0, SUMMARY_MAX - 1)}…` : firstLine;
+}
+
+export function buildTraceFrame(input: SceneTraceInput, cols: number, rows: number): SceneFrame {
+  return frame(
+    cols,
+    rows,
+    box([titleRow(input), cardRow(input), statusRow(input)], {
+      direction: "column",
+      paddingX: 1,
+    }),
+  );
+}
+
+function titleRow(s: SceneTraceInput): SceneNode {
+  const runs: TextRun[] = [{ text: "reasonix", style: { bold: true } }];
+  if (s.model) runs.push({ text: ` · ${s.model}`, style: { dim: true } });
+  return text(runs);
+}
+
+function cardRow(s: SceneTraceInput): SceneNode {
+  if (!s.lastCardKind) {
+    return text([{ text: "(no cards yet)", style: { dim: true } }]);
+  }
+  const runs: TextRun[] = [
+    { text: iconFor(s.lastCardKind), style: { color: colorFor(s.lastCardKind) } },
+    { text: " " },
+    {
+      text: s.lastCardSummary ?? s.lastCardKind,
+      style: s.lastCardKind === "user" ? { bold: true } : undefined,
+    },
+  ];
+  return text(runs);
+}
+
+function statusRow(s: SceneTraceInput): SceneNode {
+  const runs: TextRun[] = [
+    { text: `${s.cardCount} cards`, style: { dim: true } },
+    { text: " · " },
+    { text: s.busy ? "busy" : "idle", style: { color: s.busy ? "yellow" : "green" } },
+  ];
+  if (s.activity) runs.push({ text: ` · ${s.activity}`, style: { dim: true } });
+  return text(runs);
+}
+
+function iconFor(kind: string): string {
+  switch (kind) {
+    case "user":
+      return ">";
+    case "streaming":
+      return "●";
+    case "reasoning":
+      return "⟐";
+    case "tool":
+      return "▸";
+    case "error":
+      return "✗";
+    case "warn":
+      return "!";
+    case "plan":
+    case "task":
+      return "□";
+    case "diff":
+      return "Δ";
+    default:
+      return "·";
+  }
+}
+
+function colorFor(kind: string): Color {
+  switch (kind) {
+    case "user":
+      return "cyan";
+    case "streaming":
+      return "green";
+    case "reasoning":
+      return "magenta";
+    case "tool":
+    case "plan":
+    case "task":
+      return "blue";
+    case "error":
+      return "red";
+    case "warn":
+    case "diff":
+      return "yellow";
+    default:
+      return "default";
+  }
+}
+
+export function useSceneTrace(input: SceneTraceInput): void {
   const { stdout } = useStdout();
   const cols = stdout?.columns ?? 80;
   const rows = stdout?.rows ?? 24;
+  const { model, cardCount, lastCardKind, lastCardSummary, busy, activity } = input;
   useEffect(() => {
     if (!isSceneTraceEnabled()) return;
-    const runs: TextRun[] = [
-      { text: "reasonix · " },
-      { text: `${summary.cardCount} cards`, style: { dim: true } },
-      { text: summary.busy ? " · busy" : " · idle" },
-    ];
-    if (summary.activity) {
-      runs.push({ text: ` · ${summary.activity}`, style: { dim: true } });
-    }
-    emitSceneFrame(frame(cols, rows, box([text(runs)], { paddingX: 1 })));
-  }, [cols, rows, summary.cardCount, summary.busy, summary.activity]);
+    emitSceneFrame(
+      buildTraceFrame(
+        { model, cardCount, lastCardKind, lastCardSummary, busy, activity },
+        cols,
+        rows,
+      ),
+    );
+  }, [cols, rows, model, cardCount, lastCardKind, lastCardSummary, busy, activity]);
 }

--- a/tests/scene-trace-frame.test.ts
+++ b/tests/scene-trace-frame.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { buildTraceFrame, summarizeCard } from "../src/cli/ui/hooks/useSceneTrace.js";
+import type { Card } from "../src/cli/ui/state/cards.js";
+
+function userCard(text: string): Card {
+  return { id: "u1", ts: 0, kind: "user", text };
+}
+
+function toolCard(name: string, done: boolean): Card {
+  return {
+    id: "t1",
+    ts: 0,
+    kind: "tool",
+    name,
+    args: {},
+    output: "",
+    done,
+    elapsedMs: 0,
+  };
+}
+
+describe("summarizeCard", () => {
+  it("returns the first line for a user card", () => {
+    expect(summarizeCard(userCard("hello\nworld"))).toBe("hello");
+  });
+
+  it("clips long first lines and appends an ellipsis", () => {
+    const s = summarizeCard(userCard("x".repeat(200)));
+    expect(s).toHaveLength(70);
+    expect(s?.endsWith("…")).toBe(true);
+  });
+
+  it("returns the tool name with a running marker when not done", () => {
+    expect(summarizeCard(toolCard("bash", false))).toBe("bash …");
+  });
+
+  it("returns the tool name plain when done", () => {
+    expect(summarizeCard(toolCard("bash", true))).toBe("bash");
+  });
+
+  it("returns undefined for no card", () => {
+    expect(summarizeCard(undefined)).toBeUndefined();
+  });
+});
+
+describe("buildTraceFrame", () => {
+  it("returns a column box with three children: title, card, status", () => {
+    const f = buildTraceFrame({ cardCount: 0, busy: false }, 80, 24);
+    expect(f.schemaVersion).toBe(1);
+    expect(f.cols).toBe(80);
+    expect(f.rows).toBe(24);
+    expect(f.root.kind).toBe("box");
+    if (f.root.kind !== "box") return;
+    expect(f.root.layout?.direction).toBe("column");
+    expect(f.root.layout?.paddingX).toBe(1);
+    expect(f.root.children).toHaveLength(3);
+  });
+
+  it("renders the model name in the title row when given", () => {
+    const f = buildTraceFrame({ cardCount: 0, busy: false, model: "deepseek-chat" }, 80, 24);
+    expect(f.root.kind).toBe("box");
+    if (f.root.kind !== "box") return;
+    const title = f.root.children[0];
+    expect(title?.kind).toBe("text");
+    if (title?.kind !== "text") return;
+    const flat = title.runs.map((r) => r.text).join("");
+    expect(flat).toContain("reasonix");
+    expect(flat).toContain("deepseek-chat");
+  });
+
+  it("shows a placeholder card row when no cards exist", () => {
+    const f = buildTraceFrame({ cardCount: 0, busy: false }, 80, 24);
+    if (f.root.kind !== "box") return;
+    const card = f.root.children[1];
+    if (card?.kind !== "text") return;
+    const flat = card.runs.map((r) => r.text).join("");
+    expect(flat).toContain("no cards yet");
+  });
+
+  it("paints the user-card icon cyan and the text bold", () => {
+    const f = buildTraceFrame(
+      {
+        cardCount: 1,
+        busy: false,
+        lastCardKind: "user",
+        lastCardSummary: "hello",
+      },
+      80,
+      24,
+    );
+    if (f.root.kind !== "box") return;
+    const cardRow = f.root.children[1];
+    if (cardRow?.kind !== "text") return;
+    expect(cardRow.runs[0]?.style?.color).toBe("cyan");
+    expect(cardRow.runs[0]?.text).toBe(">");
+    expect(cardRow.runs[2]?.text).toBe("hello");
+    expect(cardRow.runs[2]?.style?.bold).toBe(true);
+  });
+
+  it("paints status as green when idle and yellow when busy", () => {
+    const idle = buildTraceFrame({ cardCount: 3, busy: false }, 80, 24);
+    const busy = buildTraceFrame({ cardCount: 3, busy: true }, 80, 24);
+    if (idle.root.kind !== "box" || busy.root.kind !== "box") return;
+    const idleStatus = idle.root.children[2];
+    const busyStatus = busy.root.children[2];
+    if (idleStatus?.kind !== "text" || busyStatus?.kind !== "text") return;
+    expect(idleStatus.runs[2]?.style?.color).toBe("green");
+    expect(busyStatus.runs[2]?.style?.color).toBe("yellow");
+  });
+
+  it("appends activity to the status row when given", () => {
+    const f = buildTraceFrame({ cardCount: 3, busy: true, activity: "awaiting tools" }, 80, 24);
+    if (f.root.kind !== "box") return;
+    const status = f.root.children[2];
+    if (status?.kind !== "text") return;
+    const flat = status.runs.map((r) => r.text).join("");
+    expect(flat).toContain("awaiting tools");
+  });
+});


### PR DESCRIPTION
The frame \`useSceneTrace\` produces was a one-liner — useful as
wiring proof but uninformative as a render target. When
\`REASONIX_RENDERER=rust\` (#962) the Rust binary just drew that one
line forever.

This PR makes the frame mean something:

\`\`\`
reasonix · deepseek-chat
> hello there                           ← last card (color + icon per kind)
3 cards · busy · awaiting tools         ← status row
\`\`\`

## Card icons + colors

| Kind | Icon | Color |
|---|---|---|
| user | \`>\` | cyan, **bold** content |
| streaming (assistant) | \`●\` | green |
| reasoning | \`⟐\` | magenta |
| tool | \`▸\` | blue |
| plan / task | \`□\` | blue |
| diff | \`Δ\` | yellow |
| error | \`✗\` | red |
| warn | \`!\` | yellow |
| anything else | \`·\` | default |

\`summarizeCard()\` takes a card and returns a clipped first-line
summary (70 chars max, ellipsis on overflow). Tools show their name
with a running marker (\` …\`) when \`done\` is false. The function
is exported alongside \`buildTraceFrame\` because it's both used by
the hook and easy to unit-test independently.

## Why selectors look the way they do

\`\`\`ts
const lastCardKind = useAgentState((s) => s.cards.at(-1)?.kind);
const lastCardSummary = useAgentState((s) => summarizeCard(s.cards.at(-1)));
\`\`\`

Selecting primitives keeps shallow equality on the zustand store
honest — if I selected \`s.cards.at(-1)\` directly that's a new
reference every store update even when the card is unchanged, so
the effect would re-fire on every keystroke. \`kind\` is a string,
\`summarizeCard\` returns a string, both stable.

## What this is NOT

- **Not input visibility.** Composer is still in Ink, which renders
  to \`/dev/null\` when \`REASONIX_RENDERER=rust\`. Stage 2 (Rust input
  layer + semantic events back to JS) closes that.
- **Not a full Ink-tree lowering.** Only the *last* card is
  summarized; the full stream isn't laid out. Needs either a real
  lowering of the Ink render tree (blocked on #565) or a bounded
  ring of card summaries — both bigger PRs.

## Tests

11 cases in \`tests/scene-trace-frame.test.ts\`:

- **summarizeCard** (5): first-line extraction, clipping with
  ellipsis, tool name + running marker, done-state, undefined input.
- **buildTraceFrame** (6): structure (3 children, column,
  paddingX=1), model in title, placeholder when no cards, user-card
  cyan + bold, idle = green / busy = yellow, activity in status.

Refs #868 #947