### PR TITLE
fix(desktop): add sticky-to-bottom auto-scroll for chat area

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -56,6 +56,7 @@ import {
   UserMsg,
 } from "./ui/thread";
 import { WorkdirPop } from "./ui/workdir-pop";
+import { useAutoScroll } from "./ui/useAutoScroll";
 
 export type AssistantSegment =
   | { kind: "text"; text: string }
@@ -957,6 +958,7 @@ function TabRuntime({
   >(undefined);
   const composerRef = useRef<HTMLTextAreaElement>(null);
   const threadRef = useRef<HTMLDivElement>(null);
+  const threadInnerRef = useRef<HTMLDivElement>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [settingsPage, setSettingsPage] = useState<SettingsPageId>("general");
   const [jobsOpen, setJobsOpen] = useState(false);
@@ -1167,10 +1169,11 @@ function TabRuntime({
     [sendRpc],
   );
 
-  useEffect(() => {
-    if (!threadRef.current) return;
-    threadRef.current.scrollTo({ top: threadRef.current.scrollHeight, behavior: "smooth" });
-  }, [state.messages.length]);
+  const { showJumpButton, scrollToBottom } = useAutoScroll(
+    threadRef,
+    threadInnerRef,
+    state.busy,
+  );
 
   useEffect(() => {
     if (!active) return;
@@ -1494,7 +1497,7 @@ function TabRuntime({
               ) : null}
 
               <div className="thread" ref={threadRef}>
-                <div className="thread-inner">
+                <div className="thread-inner" ref={threadInnerRef}>
                   {pendingUpdate ? (
                     <UpdateBanner
                       version={pendingUpdate.version}
@@ -1642,6 +1645,16 @@ function TabRuntime({
                     </div>
                   ) : null}
                 </div>
+                {showJumpButton ? (
+                  <button
+                    className="thread-jump-bottom"
+                    onClick={() => scrollToBottom(true)}
+                    title={t("app.jumpToBottom") ?? "Jump to bottom"}
+                    aria-label={t("app.jumpToBottom") ?? "Jump to bottom"}
+                  >
+                    <I.chev size={16} />
+                  </button>
+                ) : null}
               </div>
 
               <Composer

--- a/desktop/src/i18n/en.ts
+++ b/desktop/src/i18n/en.ts
@@ -273,6 +273,7 @@ export const en = {
       switchBack: "Switch to Review",
     },
     errorLabel: "Error",
+    jumpToBottom: "Jump to bottom",
     connecting: "Connecting to reasonix core…",
     langZH: "Chinese",
     langEN: "English",

--- a/desktop/src/i18n/zh-CN.ts
+++ b/desktop/src/i18n/zh-CN.ts
@@ -280,6 +280,7 @@ export const zhCN: typeof en = {
       switchBack: "切回 Review",
     },
     errorLabel: "错误",
+    jumpToBottom: "回到底部",
     connecting: "正在连接 reasonix 内核…",
     langZH: "中文",
     langEN: "English",

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -759,6 +759,36 @@ button {
   gap: 14px;
 }
 
+/* Jump-to-bottom button — shown when user has scrolled up during streaming */
+.thread-jump-bottom {
+  position: sticky;
+  bottom: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--fg);
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+  transition: opacity 0.15s, transform 0.15s;
+  opacity: 0.9;
+}
+.thread-jump-bottom:hover {
+  opacity: 1;
+  background: var(--bg-strong);
+  transform: translateX(-50%) scale(1.05);
+}
+[data-theme="light"] .thread-jump-bottom {
+  box-shadow: 0 2px 12px rgba(0,0,0,0.10);
+}
+
 /* ---------- TURN HEADERS ---------- */
 
 .turn-divider {

--- a/desktop/src/ui/useAutoScroll.ts
+++ b/desktop/src/ui/useAutoScroll.ts
@@ -1,0 +1,123 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const PIN_THRESHOLD = 80; // px from bottom to consider "pinned"
+
+/**
+ * Auto-scroll to bottom when content grows, as long as the user is pinned to the bottom.
+ * When the user scrolls up, auto-scroll pauses. A "jump to bottom" button appears.
+ */
+export function useAutoScroll(
+  containerRef: React.RefObject<HTMLDivElement | null>,
+  contentRef: React.RefObject<HTMLDivElement | null>,
+  busy: boolean,
+) {
+  const [showJumpButton, setShowJumpButton] = useState(false);
+  const isPinnedRef = useRef(true);
+  const wasBusyRef = useRef(busy);
+  const rafIdRef = useRef<number>(0);
+
+  const updateJumpButton = useCallback(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const elScrollHeight = el.scrollHeight;
+    const elClientHeight = el.clientHeight;
+    const isPinned =
+      el.scrollTop + elClientHeight >= elScrollHeight - PIN_THRESHOLD;
+    isPinnedRef.current = isPinned;
+    setShowJumpButton(
+      !isPinned && elScrollHeight > elClientHeight + PIN_THRESHOLD,
+    );
+  }, [containerRef]);
+
+  // Scroll to bottom
+  const scrollToBottom = useCallback(
+    (smooth = true) => {
+      const el = containerRef.current;
+      if (!el) return;
+      el.scrollTo({
+        top: el.scrollHeight,
+        behavior: smooth ? "smooth" : "instant",
+      });
+      isPinnedRef.current = true;
+      setShowJumpButton(false);
+    },
+    [containerRef],
+  );
+
+  // Listen for scroll events on the container
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    el.addEventListener("scroll", updateJumpButton, { passive: true });
+    return () => el.removeEventListener("scroll", updateJumpButton);
+  }, [containerRef, updateJumpButton]);
+
+  // When busy→idle (turn completes), always scroll to final answer
+  useEffect(() => {
+    if (wasBusyRef.current && !busy) {
+      scrollToBottom(true);
+    }
+    wasBusyRef.current = busy;
+  }, [busy, scrollToBottom]);
+
+  // Watch content size changes (streaming text, tool results, new messages)
+  // and auto-scroll if user is pinned to bottom.
+  // Uses requestAnimationFrame to batch rapid resize events during streaming.
+  useEffect(() => {
+    const content = contentRef.current;
+    if (!content) return;
+
+    const ro = new ResizeObserver(() => {
+      // Cancel any pending rAF to batch rapid resize events
+      if (rafIdRef.current) {
+        cancelAnimationFrame(rafIdRef.current);
+      }
+      rafIdRef.current = requestAnimationFrame(() => {
+        rafIdRef.current = 0;
+        const el = containerRef.current;
+        if (!el) return;
+
+        if (isPinnedRef.current) {
+          el.scrollTo({ top: el.scrollHeight, behavior: "instant" });
+          // After scrolling, re-check if we're still at bottom
+          const stillPinned =
+            el.scrollTop + el.clientHeight >=
+            el.scrollHeight - PIN_THRESHOLD;
+          if (!stillPinned) {
+            isPinnedRef.current = false;
+            setShowJumpButton(
+              el.scrollHeight > el.clientHeight + PIN_THRESHOLD,
+            );
+          }
+        } else {
+          setShowJumpButton(
+            el.scrollHeight > el.clientHeight + PIN_THRESHOLD,
+          );
+        }
+      });
+    });
+
+    ro.observe(content);
+    return () => {
+      ro.disconnect();
+      if (rafIdRef.current) {
+        cancelAnimationFrame(rafIdRef.current);
+        rafIdRef.current = 0;
+      }
+    };
+  }, [containerRef, contentRef]);
+
+  // Initial scroll to bottom when hook mounts (e.g., session loaded)
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const id = setTimeout(() => {
+      el.scrollTo({ top: el.scrollHeight, behavior: "instant" });
+      isPinnedRef.current = true;
+      setShowJumpButton(false);
+    }, 50);
+    return () => clearTimeout(id);
+  }, [containerRef]);
+
+  return { showJumpButton, scrollToBottom };
+}


### PR DESCRIPTION
Refs #955 (item 1: sticky-to-bottom auto-scroll — #955 is an umbrella with 10 items, keeping it open)

## Summary

Implements sticky-to-bottom auto-scroll for the desktop chat area, addressing the first suggestion in #955.

## Problem

During long tasks with streaming output, the chat area's auto-scroll only triggered on message count changes (`state.messages.length`). As content grew within existing messages (streaming text, tool results, reasoning), the scroll position would drift — leaving users stranded mid-history, unable to see the latest output without manual scrolling.

## What changed

- **New `useAutoScroll` hook** (`desktop/src/ui/useAutoScroll.ts`) that:
  - Uses `ResizeObserver` on `.thread-inner` to detect **content growth during streaming** (not just message count changes)
  - Uses `requestAnimationFrame` batching to throttle rapid resize events
  - Tracks user scroll position via `scroll` event listener (pinned threshold: 80px)
  - **Auto-scrolls only when the user is pinned to the bottom** — respects user's intent to review history
  - **Auto-scrolls to final answer on turn completion** (busy -> idle transition)
  - Exposes `showJumpButton` + `scrollToBottom` for UI binding

- **`App.tsx`**: Replaced the old `useEffect` scroll hook with `useAutoScroll`; added a floating "jump to bottom" button with chevron icon, positioned after `.thread-inner` inside the scroll container

- **`styles.css`**: Added `.thread-jump-bottom` styles — circular sticky button with shadow, hover scale effect, light/dark theme support

- **i18n**: Added `app.jumpToBottom` key for EN ("Jump to bottom") and zh-CN ("回到底部")

## Behavior

| State | Behavior |
|-------|----------|
| User at bottom + streaming | Auto-scroll follows new content (instant) |
| User scrolled up + streaming | Auto-scroll pauses; jump button appears |
| Task completes (busy->idle) | Always scroll to final answer (smooth) |
| Click jump button | Smooth scroll to bottom, re-pin |