### PR TITLE
feat(rust): --emit-input mode for keyboard events as JSONL

### DIFF
--- a/crates/reasonix-render/src/input.rs
+++ b/crates/reasonix-render/src/input.rs
@@ -1,0 +1,67 @@
+use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use serde::Serialize;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct InputEvent {
+    pub event: &'static str,
+    pub code: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub char: Option<char>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub modifiers: Vec<&'static str>,
+}
+
+pub fn translate_key(event: &KeyEvent) -> Option<InputEvent> {
+    if event.kind != KeyEventKind::Press {
+        return None;
+    }
+    let (code, ch) = match event.code {
+        KeyCode::Char(c) => ("Char".to_string(), Some(c)),
+        KeyCode::Enter => ("Enter".to_string(), None),
+        KeyCode::Esc => ("Esc".to_string(), None),
+        KeyCode::Up => ("Up".to_string(), None),
+        KeyCode::Down => ("Down".to_string(), None),
+        KeyCode::Left => ("Left".to_string(), None),
+        KeyCode::Right => ("Right".to_string(), None),
+        KeyCode::Backspace => ("Backspace".to_string(), None),
+        KeyCode::Tab => ("Tab".to_string(), None),
+        KeyCode::BackTab => ("BackTab".to_string(), None),
+        KeyCode::Home => ("Home".to_string(), None),
+        KeyCode::End => ("End".to_string(), None),
+        KeyCode::PageUp => ("PageUp".to_string(), None),
+        KeyCode::PageDown => ("PageDown".to_string(), None),
+        KeyCode::Delete => ("Delete".to_string(), None),
+        KeyCode::Insert => ("Insert".to_string(), None),
+        KeyCode::F(n) => (format!("F{n}"), None),
+        _ => return None,
+    };
+    Some(InputEvent {
+        event: "key",
+        code,
+        char: ch,
+        modifiers: collect_modifiers(event.modifiers),
+    })
+}
+
+fn collect_modifiers(m: KeyModifiers) -> Vec<&'static str> {
+    let mut out = Vec::new();
+    if m.contains(KeyModifiers::CONTROL) {
+        out.push("ctrl");
+    }
+    if m.contains(KeyModifiers::ALT) {
+        out.push("alt");
+    }
+    if m.contains(KeyModifiers::SHIFT) {
+        out.push("shift");
+    }
+    if m.contains(KeyModifiers::SUPER) {
+        out.push("super");
+    }
+    out
+}
+
+pub fn is_quit(event: &KeyEvent) -> bool {
+    event.kind == KeyEventKind::Press
+        && event.code == KeyCode::Char('c')
+        && event.modifiers.contains(KeyModifiers::CONTROL)
+}

--- a/crates/reasonix-render/src/lib.rs
+++ b/crates/reasonix-render/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod decode_only;
+pub mod input;
 pub mod render;
 pub mod scene;

--- a/crates/reasonix-render/src/main.rs
+++ b/crates/reasonix-render/src/main.rs
@@ -1,21 +1,29 @@
-use std::io::{self, BufRead};
+use std::io::{self, BufRead, Write};
 
 use anyhow::{Context, Result};
+use crossterm::event::{self, Event};
 use crossterm::execute;
-use crossterm::terminal::{EnterAlternateScreen, LeaveAlternateScreen};
+use crossterm::terminal::{
+    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+};
 use ratatui::backend::CrosstermBackend;
 use ratatui::Terminal;
 
 use reasonix_render::decode_only::run_decode_only;
+use reasonix_render::input::{is_quit, translate_key};
 use reasonix_render::render::render_frame;
 use reasonix_render::scene::SceneFrame;
 
 fn main() -> Result<()> {
-    if std::env::args().skip(1).any(|a| a == "--decode-only") {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.iter().any(|a| a == "--decode-only") {
         let stdin = io::stdin();
         let stdout = io::stdout();
         run_decode_only(stdin.lock(), stdout.lock())?;
         return Ok(());
+    }
+    if args.iter().any(|a| a == "--emit-input") {
+        return run_emit_input();
     }
 
     let mut stdout = io::stdout();
@@ -45,4 +53,30 @@ fn run_stream_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Res
         })?;
     }
     Ok(())
+}
+
+fn run_emit_input() -> Result<()> {
+    enable_raw_mode().context("enable raw mode")?;
+    let result = emit_input_loop();
+    disable_raw_mode().ok();
+    result
+}
+
+fn emit_input_loop() -> Result<()> {
+    let stdout = io::stdout();
+    let mut out = stdout.lock();
+    loop {
+        let Event::Key(key) = event::read()? else {
+            continue;
+        };
+        if is_quit(&key) {
+            return Ok(());
+        }
+        let Some(translated) = translate_key(&key) else {
+            continue;
+        };
+        let json = serde_json::to_string(&translated).context("serialize input event")?;
+        writeln!(out, "{json}").context("write input event")?;
+        out.flush().context("flush stdout")?;
+    }
 }

--- a/crates/reasonix-render/tests/input.rs
+++ b/crates/reasonix-render/tests/input.rs
@@ -1,0 +1,96 @@
+use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
+
+use reasonix_render::input::{is_quit, translate_key};
+
+fn press(code: KeyCode, modifiers: KeyModifiers) -> KeyEvent {
+    KeyEvent {
+        code,
+        modifiers,
+        kind: KeyEventKind::Press,
+        state: KeyEventState::NONE,
+    }
+}
+
+#[test]
+fn translates_a_plain_char() {
+    let e = press(KeyCode::Char('a'), KeyModifiers::NONE);
+    let t = translate_key(&e).expect("translate");
+    assert_eq!(t.code, "Char");
+    assert_eq!(t.char, Some('a'));
+    assert!(t.modifiers.is_empty());
+}
+
+#[test]
+fn translates_enter_with_no_char() {
+    let e = press(KeyCode::Enter, KeyModifiers::NONE);
+    let t = translate_key(&e).expect("translate");
+    assert_eq!(t.code, "Enter");
+    assert_eq!(t.char, None);
+}
+
+#[test]
+fn translates_ctrl_a_with_a_ctrl_modifier() {
+    let e = press(KeyCode::Char('a'), KeyModifiers::CONTROL);
+    let t = translate_key(&e).expect("translate");
+    assert_eq!(t.char, Some('a'));
+    assert_eq!(t.modifiers, vec!["ctrl"]);
+}
+
+#[test]
+fn collects_multiple_modifiers_in_canonical_order() {
+    let e = press(
+        KeyCode::Char('x'),
+        KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SHIFT,
+    );
+    let t = translate_key(&e).expect("translate");
+    assert_eq!(t.modifiers, vec!["ctrl", "alt", "shift"]);
+}
+
+#[test]
+fn renders_function_keys_as_f1_through_f12() {
+    let t = translate_key(&press(KeyCode::F(5), KeyModifiers::NONE)).expect("translate");
+    assert_eq!(t.code, "F5");
+}
+
+#[test]
+fn skips_release_events_so_only_presses_emit() {
+    let e = KeyEvent {
+        code: KeyCode::Char('a'),
+        modifiers: KeyModifiers::NONE,
+        kind: KeyEventKind::Release,
+        state: KeyEventState::NONE,
+    };
+    assert!(translate_key(&e).is_none());
+}
+
+#[test]
+fn serializes_a_plain_key_to_one_compact_json_line() {
+    let t = translate_key(&press(KeyCode::Enter, KeyModifiers::NONE)).expect("translate");
+    let json = serde_json::to_string(&t).expect("serialize");
+    assert_eq!(json, r#"{"event":"key","code":"Enter"}"#);
+}
+
+#[test]
+fn serializes_a_char_event_with_a_char_field() {
+    let t = translate_key(&press(KeyCode::Char('z'), KeyModifiers::NONE)).expect("translate");
+    let json = serde_json::to_string(&t).expect("serialize");
+    assert_eq!(json, r#"{"event":"key","code":"Char","char":"z"}"#);
+}
+
+#[test]
+fn serializes_modifiers_as_a_string_array() {
+    let t = translate_key(&press(KeyCode::Char('c'), KeyModifiers::CONTROL)).expect("translate");
+    let json = serde_json::to_string(&t).expect("serialize");
+    assert_eq!(
+        json,
+        r#"{"event":"key","code":"Char","char":"c","modifiers":["ctrl"]}"#
+    );
+}
+
+#[test]
+fn is_quit_matches_only_ctrl_c() {
+    assert!(is_quit(&press(KeyCode::Char('c'), KeyModifiers::CONTROL)));
+    assert!(!is_quit(&press(KeyCode::Char('c'), KeyModifiers::NONE)));
+    assert!(!is_quit(&press(KeyCode::Char('d'), KeyModifiers::CONTROL)));
+    assert!(!is_quit(&press(KeyCode::Esc, KeyModifiers::NONE)));
+}


### PR DESCRIPTION
Stage 2 PR-1. The Rust binary gains a third mode alongside the
default streaming renderer and \`--decode-only\`:

\`\`\`
reasonix-render --emit-input
\`\`\`

reads keys from the terminal and writes one JSON line per press to
stdout. Nothing wires this to JS yet — that's the next PR — but
the keyboard-to-event mapping is isolated, tested, and stable.

## Event shape

\`\`\`
{"event":"key","code":"Enter"}
{"event":"key","code":"Char","char":"a"}
{"event":"key","code":"Char","char":"c","modifiers":["ctrl"]}
{"event":"key","code":"F5"}
\`\`\`

\`translate_key()\` returns \`Option<InputEvent>\` so non-press events
(Release / Repeat on Windows-style key events) and unsupported codes
(Media keys, capslock, etc.) collapse to \`None\` rather than emitting
noise. The caller skips \`None\`s.

## Why pre-mapped (but not all the way to "semantic")

- **Pre-mapped from bytes** because raw byte sequences are
  ambiguous across terminal encodings (xterm vs modifyOtherKeys
  vs Kitty protocol). The translation absorbs that — JS gets a
  canonical event shape regardless of which protocol the user's
  terminal speaks.
- **Not pre-mapped to semantic events** (submit, history-prev,
  approve) because that mapping is contextual: Enter inside the
  composer is "submit", inside a picker it's "select", inside an
  approval modal it's "approve". The contextual mapping lives
  JS-side in the next PR, where the active component knows what
  Enter means.

Modifiers serialize in canonical order: \`ctrl\`, \`alt\`, \`shift\`,
\`super\`. \`is_quit()\` recognizes Ctrl+C so \`--emit-input\` exits
cleanly on the standard interrupt sequence.

## Tests

10 cases in \`tests/input.rs\`:

- plain char, Enter, Ctrl-prefixed, multi-modifier in canonical order
- function keys (F1–F12)
- release events suppressed
- three JSON serialization shapes (plain, char, char+modifiers)
- \`is_quit\` matches only Ctrl+C, not bare 'c' or bare Esc or Ctrl+D

## What's next

PR-2: JS adapter that spawns \`reasonix-render --emit-input\` as a
side process (alongside the renderer), reads its stdout, and feeds
the events into a context-aware mapper that produces semantic
events the composer / picker / approval handlers already understand.

Refs #868 #947