### PR TITLE
feat(scene): spawnInputSource — JS adapter for Rust --emit-input

### DIFF
--- a/src/cli/ui/scene/input-source.ts
+++ b/src/cli/ui/scene/input-source.ts
@@ -1,0 +1,105 @@
+import { spawn } from "node:child_process";
+import { DEFAULT_COMMAND } from "./renderer-process.js";
+
+export type InputModifier = "ctrl" | "alt" | "shift" | "super";
+
+export type KeyInputEvent = {
+  event: "key";
+  code: string;
+  char?: string;
+  modifiers?: readonly InputModifier[];
+};
+
+export type InputSource = {
+  onKey(handler: (event: KeyInputEvent) => void): () => void;
+  /** Send SIGINT to the child if it's still alive, then await exit. */
+  close(): Promise<number | null>;
+  /** Await the child's natural exit without signaling. */
+  wait(): Promise<number | null>;
+};
+
+export type SpawnInputSourceOptions = {
+  command?: readonly string[];
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+};
+
+export const DEFAULT_INPUT_COMMAND: readonly string[] = [...DEFAULT_COMMAND, "--", "--emit-input"];
+
+export function spawnInputSource(opts: SpawnInputSourceOptions = {}): InputSource {
+  const command = opts.command ?? DEFAULT_INPUT_COMMAND;
+  const [cmd, ...args] = command;
+  if (!cmd) {
+    throw new Error("spawnInputSource: empty command");
+  }
+
+  const child = spawn(cmd, args, {
+    cwd: opts.cwd,
+    env: opts.env ?? process.env,
+    stdio: ["ignore", "pipe", "inherit"],
+  });
+
+  const handlers = new Set<(event: KeyInputEvent) => void>();
+  let buf = "";
+
+  child.stdout?.setEncoding("utf8");
+  child.stdout?.on("data", (chunk: string) => {
+    buf += chunk;
+    let nl = buf.indexOf("\n");
+    while (nl >= 0) {
+      const line = buf.slice(0, nl);
+      buf = buf.slice(nl + 1);
+      dispatch(line, handlers);
+      nl = buf.indexOf("\n");
+    }
+  });
+  child.stdout?.on("end", () => {
+    if (buf.length > 0) {
+      dispatch(buf, handlers);
+      buf = "";
+    }
+  });
+
+  const exitPromise = new Promise<number | null>((resolve) => {
+    child.once("exit", (code) => resolve(code));
+  });
+
+  return {
+    onKey(handler) {
+      handlers.add(handler);
+      return () => {
+        handlers.delete(handler);
+      };
+    },
+    async close(): Promise<number | null> {
+      if (child.exitCode === null && !child.killed) {
+        child.kill("SIGINT");
+      }
+      return exitPromise;
+    },
+    wait(): Promise<number | null> {
+      return exitPromise;
+    },
+  };
+}
+
+function dispatch(line: string, handlers: Set<(event: KeyInputEvent) => void>): void {
+  if (line.trim().length === 0) return;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    return;
+  }
+  if (!isKeyEvent(parsed)) return;
+  for (const handler of handlers) handler(parsed);
+}
+
+function isKeyEvent(value: unknown): value is KeyInputEvent {
+  if (typeof value !== "object" || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  if (obj.event !== "key" || typeof obj.code !== "string") return false;
+  if (obj.char !== undefined && typeof obj.char !== "string") return false;
+  if (obj.modifiers !== undefined && !Array.isArray(obj.modifiers)) return false;
+  return true;
+}

--- a/tests/fixtures/input-emit-stub.mjs
+++ b/tests/fixtures/input-emit-stub.mjs
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+
+const path = process.env.INPUT_EMIT_FILE;
+if (!path) {
+  process.stderr.write("INPUT_EMIT_FILE not set\n");
+  process.exit(2);
+}
+
+const lines = readFileSync(path, "utf8")
+  .split("\n")
+  .filter((l) => l.trim().length > 0);
+
+for (const line of lines) {
+  process.stdout.write(`${line}\n`);
+}
+
+process.stdout.end();

--- a/tests/scene-input-source.test.ts
+++ b/tests/scene-input-source.test.ts
@@ -1,0 +1,110 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import process from "node:process";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { type KeyInputEvent, spawnInputSource } from "../src/cli/ui/scene/input-source.js";
+
+const STUB = "tests/fixtures/input-emit-stub.mjs";
+
+describe("spawnInputSource", () => {
+  let dir: string;
+  let eventsPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "input-source-"));
+    eventsPath = join(dir, "events.jsonl");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writeEvents(events: KeyInputEvent[]): void {
+    writeFileSync(eventsPath, `${events.map((e) => JSON.stringify(e)).join("\n")}\n`);
+  }
+
+  function writeRaw(lines: string[]): void {
+    writeFileSync(eventsPath, `${lines.join("\n")}\n`);
+  }
+
+  it("forwards key events from the child to registered handlers in order", async () => {
+    const events: KeyInputEvent[] = [
+      { event: "key", code: "Char", char: "a" },
+      { event: "key", code: "Enter" },
+      { event: "key", code: "Char", char: "c", modifiers: ["ctrl"] },
+    ];
+    writeEvents(events);
+    const source = spawnInputSource({
+      command: [process.execPath, STUB],
+      env: { ...process.env, INPUT_EMIT_FILE: eventsPath },
+    });
+    const received: KeyInputEvent[] = [];
+    source.onKey((e) => received.push(e));
+    const code = await source.wait();
+    expect(code).toBe(0);
+    expect(received).toEqual(events);
+  });
+
+  it("dispatches to multiple handlers", async () => {
+    writeEvents([{ event: "key", code: "Enter" }]);
+    const source = spawnInputSource({
+      command: [process.execPath, STUB],
+      env: { ...process.env, INPUT_EMIT_FILE: eventsPath },
+    });
+    const a: KeyInputEvent[] = [];
+    const b: KeyInputEvent[] = [];
+    source.onKey((e) => a.push(e));
+    source.onKey((e) => b.push(e));
+    await source.wait();
+    expect(a).toHaveLength(1);
+    expect(b).toHaveLength(1);
+  });
+
+  it("stops calling a handler after its unsubscriber runs", async () => {
+    writeEvents([
+      { event: "key", code: "Char", char: "a" },
+      { event: "key", code: "Char", char: "b" },
+    ]);
+    const source = spawnInputSource({
+      command: [process.execPath, STUB],
+      env: { ...process.env, INPUT_EMIT_FILE: eventsPath },
+    });
+    const received: KeyInputEvent[] = [];
+    const unsubscribe = source.onKey((e) => {
+      received.push(e);
+      if (received.length === 1) unsubscribe();
+    });
+    await source.wait();
+    expect(received).toHaveLength(1);
+  });
+
+  it("skips malformed lines without crashing or dropping later events", async () => {
+    writeRaw(['{"event":"key","code":"Enter"}', "not-json", '{"event":"key","code":"Esc"}', ""]);
+    const source = spawnInputSource({
+      command: [process.execPath, STUB],
+      env: { ...process.env, INPUT_EMIT_FILE: eventsPath },
+    });
+    const received: KeyInputEvent[] = [];
+    source.onKey((e) => received.push(e));
+    await source.wait();
+    expect(received.map((e) => e.code)).toEqual(["Enter", "Esc"]);
+  });
+
+  it("ignores JSON objects that aren't key events", async () => {
+    writeRaw(['{"event":"resize","cols":120}', '{"event":"key","code":"Enter"}']);
+    const source = spawnInputSource({
+      command: [process.execPath, STUB],
+      env: { ...process.env, INPUT_EMIT_FILE: eventsPath },
+    });
+    const received: KeyInputEvent[] = [];
+    source.onKey((e) => received.push(e));
+    await source.wait();
+    expect(received).toHaveLength(1);
+    expect(received[0].code).toBe("Enter");
+  });
+
+  it("throws synchronously on an empty command", () => {
+    expect(() => spawnInputSource({ command: [] })).toThrow(/empty command/);
+  });
+});


### PR DESCRIPTION
Stage 2 PR-2. \`spawnInputSource()\` runs the Rust binary in
\`--emit-input\` mode (from #966), reads its JSONL stdout, parses
each line into a \`KeyInputEvent\`, and dispatches to registered
\`onKey\` handlers.

No production callers wire it in yet — that's the next PR. This is
the plumbing.

## API shape

\`\`\`ts
const source = spawnInputSource();
const unsubscribe = source.onKey((event) => {
  // event: { event: "key", code, char?, modifiers? }
});
// ...
await source.close();   // signal child + await exit
// OR
await source.wait();    // just await natural exit
\`\`\`

## Two methods, not one

- \`close()\` sends \`SIGINT\` and awaits exit. **Production needs this**
  — the Rust binary reads \`/dev/tty\` directly, so there's no stdin
  pipe to close; the only way to stop the child cleanly is a signal.
- \`wait()\` just awaits exit without signaling. **Tests need this** —
  the stub finishes naturally; without \`wait()\`, the SIGINT inside
  \`close()\` would race against the stub's writes and kill it mid-emit.

## Line parser is forgiving

- **Malformed JSON**: skip and keep going. Don't drop later valid
  events. (A Rust panic might emit a stderr trace that bleeds into
  stdout briefly; one bad byte shouldn't take down the input stream
  for the rest of the session.)
- **JSON that isn't a key event**: skip. Future event kinds
  (\`resize\`, \`mouse\`) ride on the same channel; \`isKeyEvent()\`
  narrows.

## Tests

6 cases via \`tests/fixtures/input-emit-stub.mjs\` — a Node script
that replays a JSONL fixture file to stdout. Covers:

- ordered delivery
- multi-handler dispatch
- unsubscribe stops further calls
- malformed-line tolerance
- non-key-event filtering
- empty-command rejection

The stub stands in for the real binary so vitest doesn't need the
Rust toolchain at test time.

Refs #868 #947