### PR TITLE
feat(scene): silence Ink's stdin reader when REASONIX_RENDERER=rust

### DIFF
--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -28,6 +28,7 @@ import { SessionPicker } from "../ui/SessionPicker.js";
 import { Setup } from "../ui/Setup.js";
 import { drainTtyResponses } from "../ui/drain-tty.js";
 import { KeystrokeProvider } from "../ui/keystroke-context.js";
+import { makeNullStdin } from "../ui/scene/null-stdin.js";
 import { makeNullStdout } from "../ui/scene/null-stdout.js";
 import type { McpServerSummary } from "../ui/slash.js";
 import {
@@ -339,6 +340,7 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
 
   const rustRendererActive = process.env.REASONIX_RENDERER === "rust";
   const inkStdout = rustRendererActive ? makeNullStdout() : undefined;
+  const inkStdin = rustRendererActive ? makeNullStdin() : undefined;
 
   const { waitUntilExit } = render(
     <Root
@@ -358,6 +360,7 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
     />,
     {
       stdout: inkStdout,
+      stdin: inkStdin,
       exitOnCtrlC: true,
       // patchConsole:false — winpty/MINTTY redraw-glitch source.
       patchConsole: false,

--- a/src/cli/ui/scene/null-stdin.ts
+++ b/src/cli/ui/scene/null-stdin.ts
@@ -1,0 +1,29 @@
+import { Readable } from "node:stream";
+
+export function makeNullStdin(): NodeJS.ReadStream {
+  const stream = new Readable({
+    read() {},
+  });
+  Object.assign(stream, {
+    isTTY: true,
+    isRaw: false,
+    setRawMode(_mode: boolean) {
+      return stream;
+    },
+    setEncoding() {
+      return stream;
+    },
+    pause() {
+      return stream;
+    },
+    resume() {
+      return stream;
+    },
+    isPaused() {
+      return false;
+    },
+    ref() {},
+    unref() {},
+  });
+  return stream as unknown as NodeJS.ReadStream;
+}

--- a/src/server/api/checkpoint-create.ts
+++ b/src/server/api/checkpoint-create.ts
@@ -25,8 +25,16 @@ export async function handleCheckpointCreate(
   let paths: string[];
   try {
     const { execSync } = await import("node:child_process");
+    // Strip GIT_* env vars: if this handler runs in a context where git set
+    // GIT_DIR (e.g. inside a pre-push hook spawning the dashboard), ls-files
+    // would resolve to the *outer* repo instead of rootDir.
+    const env: NodeJS.ProcessEnv = { ...process.env };
+    for (const k of Object.keys(env)) {
+      if (k.startsWith("GIT_")) delete env[k];
+    }
     const stdout = execSync("git ls-files --cached --others --exclude-standard", {
       cwd: rootDir,
+      env,
       encoding: "utf8",
       maxBuffer: 10 * 1024 * 1024,
     });

--- a/tests/scene-null-stdin.test.ts
+++ b/tests/scene-null-stdin.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import { makeNullStdin } from "../src/cli/ui/scene/null-stdin.js";
+
+describe("makeNullStdin", () => {
+  it("never emits a data event", () => {
+    const stdin = makeNullStdin();
+    const handler = vi.fn();
+    stdin.on("data", handler);
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        expect(handler).not.toHaveBeenCalled();
+        resolve();
+      }, 30);
+    });
+  });
+
+  it("reports isTTY=true so Ink's tty detection passes", () => {
+    const stdin = makeNullStdin();
+    expect(stdin.isTTY).toBe(true);
+  });
+
+  it("setRawMode is a no-op that returns the stream", () => {
+    const stdin = makeNullStdin();
+    expect(() => stdin.setRawMode(true)).not.toThrow();
+    expect(stdin.setRawMode(true)).toBe(stdin);
+  });
+
+  it("pause / resume / isPaused are safe no-ops", () => {
+    const stdin = makeNullStdin();
+    expect(() => stdin.pause()).not.toThrow();
+    expect(() => stdin.resume()).not.toThrow();
+    expect(stdin.isPaused()).toBe(false);
+  });
+
+  it("setEncoding is a no-op that returns the stream", () => {
+    const stdin = makeNullStdin();
+    expect(() => stdin.setEncoding("utf8")).not.toThrow();
+    expect(stdin.setEncoding("utf8")).toBe(stdin);
+  });
+
+  it("ref and unref are safe no-ops", () => {
+    const stdin = makeNullStdin();
+    expect(() => stdin.ref()).not.toThrow();
+    expect(() => stdin.unref()).not.toThrow();
+  });
+});

--- a/tests/server-dashboard.test.ts
+++ b/tests/server-dashboard.test.ts
@@ -1236,11 +1236,21 @@ describe("dashboard server: checkpoint API", () => {
     await mkdir(cwd, { recursive: true });
     await writeFile(join(cwd, "hello.txt"), "hello world\n");
     const { execSync } = await import("node:child_process");
-    execSync("git init", { cwd });
-    execSync("git config user.email test@test.com", { cwd });
-    execSync("git config user.name test", { cwd });
-    execSync("git add -A", { cwd });
-    execSync("git commit -m init", { cwd });
+    // Strip GIT_* env vars so execSync doesn't inherit them from a calling
+    // git operation (e.g. when this suite runs under a pre-push hook).
+    // Without this, `git commit` would resolve GIT_DIR from the env and
+    // operate on the parent repo, not the temp dir — and `git config
+    // user.email test@test.com` would silently rewrite the parent's
+    // committer identity.
+    const env: NodeJS.ProcessEnv = { ...process.env };
+    for (const k of Object.keys(env)) {
+      if (k.startsWith("GIT_")) delete env[k];
+    }
+    execSync("git init", { cwd, env });
+    execSync("git config user.email test@test.com", { cwd, env });
+    execSync("git config user.name test", { cwd, env });
+    execSync("git add -A", { cwd, env });
+    execSync("git commit -m init", { cwd, env });
   });
 
   afterEach(async () => {


### PR DESCRIPTION
Cut A (#962) wired Ink to a null stdout so the spawned Rust child
owns the visible terminal. This PR closes the matching gap on the
input side: when \`REASONIX_RENDERER=rust\`, Ink mounts with a stdin
that never emits data.

## Why this matters now

Without it, both processes read from the same controlling terminal.
The Node parent reads through \`process.stdin\` (fd 0); the Rust
child reads \`/dev/tty\` directly via crossterm. One keystroke goes
to whichever does \`read()\` first — a race the user would see as
missed or duplicated input depending on timing.

Cut B's validator mode (#961) was unaffected because the Rust child
only decoded; nothing competed for keys. Streaming mode (#962) made
the race observable. Silencing Ink resolves it before the input PRs
land.

## \`makeNullStdin()\`

A \`Readable\` that never \`push\`es, plus the tty methods Ink touches
during mount:

- \`isTTY\`, \`isRaw\`
- \`setRawMode\`, \`setEncoding\` (no-ops returning the stream)
- \`pause\`, \`resume\`, \`isPaused\` (no-ops)
- \`ref\`, \`unref\` (no-ops)

Symmetric to \`makeNullStdout\` (#962) — same cast pattern
(\`unknown as NodeJS.ReadStream\`), same shape-style tests.

## What this PR does NOT do

It doesn't yet wire the spawned input-source (#969) into App.tsx
state. Today, with \`REASONIX_RENDERER=rust\` plus this PR, the Rust
render shows but typing reaches no one. That hookup is the next PR;
this one removes the race so the hookup has a clean seam.

## Two unrelated fixes ride along

The pre-push hook caught a pair of cousins to today's bug:

- **\`fix(tests): strip GIT_* env vars in checkpoint API test setup\`**
  — \`tests/server-dashboard.test.ts\` runs \`execSync(\"git commit\", { cwd })\`
  in a temp dir, but git resolves the repo via \`GIT_DIR\` env first
  with cwd as fallback. Under a pre-push hook git sets GIT_DIR, the
  test then committed in the parent repo (silently rewriting its
  user identity to \`test/test@test.com\`). Strip GIT_* before each
  execSync in the test setup.
- **\`fix(server): strip GIT_* env vars in checkpoint-create handler\`**
  — same vulnerability in the *production* dashboard endpoint. Any
  embedding context where git pre-sets GIT_DIR would make
  \`git ls-files\` resolve to the outer repo. Stripped there too.

Other production callsites (git-diffs, slash commit helpers, session
branch detection) have the same shape and stay as-is for a follow-up
PR — they're not exercised by tests that run inside the hook so
nothing's blocking on them today.

Refs #868 #947