### PR TITLE
feat(scene): wire spawnInputSource into KeystrokeProvider as a reader

### DIFF
--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -28,6 +28,7 @@ import { SessionPicker } from "../ui/SessionPicker.js";
 import { Setup } from "../ui/Setup.js";
 import { drainTtyResponses } from "../ui/drain-tty.js";
 import { KeystrokeProvider } from "../ui/keystroke-context.js";
+import { type RustKeystrokeReader, createRustKeystrokeReader } from "../ui/scene/input-adapter.js";
 import { makeNullStdin } from "../ui/scene/null-stdin.js";
 import { makeNullStdout } from "../ui/scene/null-stdout.js";
 import type { McpServerSummary } from "../ui/slash.js";
@@ -137,6 +138,8 @@ interface RootProps extends ChatOptions {
   qqSubmitRef: { current: ((text: string) => void) | null };
   /** App fills this ref on mount so QQ errors appear in the TUI log. */
   qqErrorRef: { current: ((msg: string) => void) | null };
+  /** Custom keystroke source — populated when REASONIX_RENDERER=rust so keys flow from the spawned input child instead of stdin (which is the null stream in that mode). */
+  keystrokeReader?: RustKeystrokeReader;
 }
 
 function Root({
@@ -148,6 +151,7 @@ function Root({
   showPicker,
   mcpRuntime,
   startupInfoHints,
+  keystrokeReader,
   ...appProps
 }: RootProps) {
   const [key, setKey] = useState<string | undefined>(initialKey);
@@ -170,7 +174,7 @@ function Root({
 
   if (pickerOpen) {
     return (
-      <KeystrokeProvider>
+      <KeystrokeProvider reader={keystrokeReader}>
         <SessionPicker
           sessions={sessions}
           workspace={workspaceRoot}
@@ -208,7 +212,7 @@ function Root({
   }
 
   return (
-    <KeystrokeProvider>
+    <KeystrokeProvider reader={keystrokeReader}>
       <App
         // key forces a full remount (and fresh transcript / scrollback / cards) on switch.
         key={activeSession ?? "__new__"}
@@ -341,6 +345,7 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
   const rustRendererActive = process.env.REASONIX_RENDERER === "rust";
   const inkStdout = rustRendererActive ? makeNullStdout() : undefined;
   const inkStdin = rustRendererActive ? makeNullStdin() : undefined;
+  const keystrokeReader = rustRendererActive ? createRustKeystrokeReader() : undefined;
 
   const { waitUntilExit } = render(
     <Root
@@ -352,6 +357,7 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
       progressSink={progressSink}
       startupInfoHints={startupInfoHints}
       showPicker={showPicker}
+      keystrokeReader={keystrokeReader}
       {...opts}
       session={resolvedSession}
       qqChannel={qqChannel}
@@ -382,6 +388,7 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
   } finally {
     await runtime.closeAll();
     qqChannel?.stop();
+    if (keystrokeReader) await keystrokeReader.close();
     // Eat any pending terminal-feature-detection responses (#365) so the
     // parent shell doesn't print them as junk after exit.
     await drainTtyResponses();

--- a/src/cli/ui/keystroke-context.tsx
+++ b/src/cli/ui/keystroke-context.tsx
@@ -32,16 +32,25 @@ interface KeystrokeBus {
 
 export type KeystrokeHandler = (ev: KeyEvent) => void;
 
+/** Minimum surface KeystrokeProvider needs from a key source. StdinReader implements this; the Rust input adapter does too. */
+export interface KeystrokeReader {
+  start(): void;
+  subscribe(handler: KeystrokeHandler): () => void;
+}
+
 const KeystrokeContext = createContext<KeystrokeBus | null>(null);
 
 export interface KeystrokeProviderProps {
   children: React.ReactNode;
   /**
    * Optional reader override. Tests inject a synthetic reader so
-   * they can `feed()` chunks instead of touching real stdin. Production
-   * callers leave this unset and get the singleton.
+   * they can `feed()` chunks instead of touching real stdin; the
+   * Rust input adapter (when `REASONIX_RENDERER=rust`) injects one
+   * that receives events from a spawned `reasonix-render --emit-input`
+   * child. Production stdin callers leave this unset and get the
+   * singleton.
    */
-  reader?: StdinReader;
+  reader?: KeystrokeReader;
 }
 
 export function KeystrokeProvider({

--- a/src/cli/ui/scene/input-adapter.ts
+++ b/src/cli/ui/scene/input-adapter.ts
@@ -1,0 +1,100 @@
+import type { KeystrokeHandler, KeystrokeReader } from "../keystroke-context.js";
+import type { KeyEvent } from "../stdin-reader.js";
+import {
+  type KeyInputEvent,
+  type SpawnInputSourceOptions,
+  spawnInputSource,
+} from "./input-source.js";
+
+export type RustKeystrokeReader = KeystrokeReader & {
+  /** Send SIGINT to the input child and await exit. */
+  close(): Promise<number | null>;
+  /** Await the child's natural exit without signaling. */
+  wait(): Promise<number | null>;
+};
+
+export function createRustKeystrokeReader(opts: SpawnInputSourceOptions = {}): RustKeystrokeReader {
+  const source = spawnInputSource(opts);
+  const handlers = new Set<KeystrokeHandler>();
+
+  source.onKey((rust) => {
+    const ev = translate(rust);
+    if (!ev) return;
+    for (const h of handlers) h(ev);
+  });
+
+  return {
+    start() {
+      // The child is already running from spawn — no-op so KeystrokeProvider's
+      // existing call site stays unchanged.
+    },
+    subscribe(handler) {
+      handlers.add(handler);
+      return () => {
+        handlers.delete(handler);
+      };
+    },
+    close(): Promise<number | null> {
+      return source.close();
+    },
+    wait(): Promise<number | null> {
+      return source.wait();
+    },
+  };
+}
+
+export function translate(rust: KeyInputEvent): KeyEvent | null {
+  const mods = new Set(rust.modifiers ?? []);
+  const ctrl = mods.has("ctrl");
+  const shift = mods.has("shift");
+  const alt = mods.has("alt");
+  switch (rust.code) {
+    case "Char": {
+      if (rust.char === undefined) return null;
+      const ev: KeyEvent = { input: rust.char };
+      if (ctrl) ev.ctrl = true;
+      if (alt) ev.meta = true;
+      if (shift) ev.shift = true;
+      return ev;
+    }
+    case "Enter":
+      return withMods({ input: "", return: true }, ctrl, shift, alt);
+    case "Esc":
+      return { input: "", escape: true };
+    case "Up":
+      return { input: "", upArrow: true };
+    case "Down":
+      return { input: "", downArrow: true };
+    case "Left":
+      return { input: "", leftArrow: true };
+    case "Right":
+      return { input: "", rightArrow: true };
+    case "Backspace":
+      return { input: "", backspace: true };
+    case "Tab":
+      return withMods({ input: "", tab: true }, ctrl, shift, alt);
+    case "BackTab":
+      return { input: "", tab: true, shift: true };
+    case "Home":
+      return { input: "", home: true };
+    case "End":
+      return { input: "", end: true };
+    case "PageUp":
+      return { input: "", pageUp: true };
+    case "PageDown":
+      return { input: "", pageDown: true };
+    case "Delete":
+      return { input: "", delete: true };
+    default:
+      // F1-F12 and anything unrecognized — KeyEvent has no slot for them.
+      // Better to drop than to fake-fill a different field.
+      return null;
+  }
+}
+
+function withMods(ev: KeyEvent, ctrl: boolean, shift: boolean, alt: boolean): KeyEvent {
+  if (ctrl) ev.ctrl = true;
+  if (shift) ev.shift = true;
+  if (alt) ev.meta = true;
+  return ev;
+}

--- a/tests/scene-input-adapter.test.ts
+++ b/tests/scene-input-adapter.test.ts
@@ -1,0 +1,156 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import process from "node:process";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createRustKeystrokeReader, translate } from "../src/cli/ui/scene/input-adapter.js";
+import type { KeyInputEvent } from "../src/cli/ui/scene/input-source.js";
+
+const STUB = "tests/fixtures/input-emit-stub.mjs";
+
+describe("translate (KeyInputEvent → KeyEvent)", () => {
+  it("plain char becomes one-character input", () => {
+    expect(translate({ event: "key", code: "Char", char: "a" })).toEqual({ input: "a" });
+  });
+
+  it("Ctrl+letter sets ctrl=true and keeps the char as input", () => {
+    expect(translate({ event: "key", code: "Char", char: "c", modifiers: ["ctrl"] })).toEqual({
+      input: "c",
+      ctrl: true,
+    });
+  });
+
+  it("Alt+letter maps to meta (Reasonix's name for Alt)", () => {
+    expect(translate({ event: "key", code: "Char", char: "k", modifiers: ["alt"] })).toEqual({
+      input: "k",
+      meta: true,
+    });
+  });
+
+  it("Shift+letter passes char as-is plus shift=true", () => {
+    expect(translate({ event: "key", code: "Char", char: "A", modifiers: ["shift"] })).toEqual({
+      input: "A",
+      shift: true,
+    });
+  });
+
+  it("Enter becomes return=true", () => {
+    expect(translate({ event: "key", code: "Enter" })).toEqual({ input: "", return: true });
+  });
+
+  it("Shift+Enter carries the shift modifier", () => {
+    expect(translate({ event: "key", code: "Enter", modifiers: ["shift"] })).toEqual({
+      input: "",
+      return: true,
+      shift: true,
+    });
+  });
+
+  it.each<
+    [string, Partial<KeyInputEvent["code"]>, keyof import("../src/cli/ui/stdin-reader.js").KeyEvent]
+  >([
+    ["Esc", "Esc", "escape"],
+    ["Up", "Up", "upArrow"],
+    ["Down", "Down", "downArrow"],
+    ["Left", "Left", "leftArrow"],
+    ["Right", "Right", "rightArrow"],
+    ["Backspace", "Backspace", "backspace"],
+    ["Tab", "Tab", "tab"],
+    ["Home", "Home", "home"],
+    ["End", "End", "end"],
+    ["PageUp", "PageUp", "pageUp"],
+    ["PageDown", "PageDown", "pageDown"],
+    ["Delete", "Delete", "delete"],
+  ])("%s maps to the corresponding KeyEvent field", (_label, code, field) => {
+    expect(translate({ event: "key", code: code as string })).toEqual({ input: "", [field]: true });
+  });
+
+  it("BackTab becomes tab+shift", () => {
+    expect(translate({ event: "key", code: "BackTab" })).toEqual({
+      input: "",
+      tab: true,
+      shift: true,
+    });
+  });
+
+  it("F-keys and unrecognized codes drop to null", () => {
+    expect(translate({ event: "key", code: "F5" })).toBeNull();
+    expect(translate({ event: "key", code: "CapsLock" })).toBeNull();
+  });
+
+  it("Char with no char field drops to null", () => {
+    expect(translate({ event: "key", code: "Char" })).toBeNull();
+  });
+});
+
+describe("createRustKeystrokeReader", () => {
+  let dir: string;
+  let eventsPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "input-adapter-"));
+    eventsPath = join(dir, "events.jsonl");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writeEvents(events: KeyInputEvent[]): void {
+    writeFileSync(eventsPath, `${events.map((e) => JSON.stringify(e)).join("\n")}\n`);
+  }
+
+  it("forwards translated events to subscribers", async () => {
+    writeEvents([
+      { event: "key", code: "Char", char: "a" },
+      { event: "key", code: "Enter" },
+      { event: "key", code: "Char", char: "c", modifiers: ["ctrl"] },
+    ]);
+    const reader = createRustKeystrokeReader({
+      command: [process.execPath, STUB],
+      env: { ...process.env, INPUT_EMIT_FILE: eventsPath },
+    });
+    const received: Array<{ input: string; ctrl?: boolean; return?: boolean }> = [];
+    reader.start();
+    reader.subscribe((ev) => received.push(ev));
+    await reader.wait();
+    expect(received).toEqual([
+      { input: "a" },
+      { input: "", return: true },
+      { input: "c", ctrl: true },
+    ]);
+  });
+
+  it("skips events that translate to null", async () => {
+    writeEvents([
+      { event: "key", code: "F5" },
+      { event: "key", code: "Enter" },
+    ]);
+    const reader = createRustKeystrokeReader({
+      command: [process.execPath, STUB],
+      env: { ...process.env, INPUT_EMIT_FILE: eventsPath },
+    });
+    const received: unknown[] = [];
+    reader.subscribe((ev) => received.push(ev));
+    await reader.wait();
+    expect(received).toEqual([{ input: "", return: true }]);
+  });
+
+  it("unsubscribe stops further deliveries", async () => {
+    writeEvents([
+      { event: "key", code: "Char", char: "a" },
+      { event: "key", code: "Char", char: "b" },
+    ]);
+    const reader = createRustKeystrokeReader({
+      command: [process.execPath, STUB],
+      env: { ...process.env, INPUT_EMIT_FILE: eventsPath },
+    });
+    const received: unknown[] = [];
+    const unsubscribe = reader.subscribe((ev) => {
+      received.push(ev);
+      if (received.length === 1) unsubscribe();
+    });
+    await reader.wait();
+    expect(received).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Closes the input loop for \`REASONIX_RENDERER=rust\`. The Rust input
child (\`reasonix-render --emit-input\` from #966) now feeds keystrokes
back into the React tree via KeystrokeProvider's existing \`reader\`
slot — the same slot tests have always used for synthetic stdin.

## End-to-end after this merges

| Piece | Where | Status |
|---|---|---|
| JS produces SceneFrames | \`useSceneTrace\` | landed #964 |
| Rust child renders alt-screen TUI | \`reasonix-render\` | landed #962 |
| Ink stdout → null sink | \`makeNullStdout\` | landed #962 |
| Ink stdin → null source | \`makeNullStdin\` | landed #971 |
| Rust emits keystrokes as JSONL | \`reasonix-render --emit-input\` | landed #966 |
| JS reads + dispatches them | \`createRustKeystrokeReader\` | **this PR** |

A user with \`REASONIX_RENDERER=rust reasonix\` now sees the Rust
render *and* can type into the composer / navigate pickers / approve
prompts. Stage 1 + Stage 2 minimum closure.

## Pieces

### \`KeystrokeReader\` interface

Lifted out of \`keystroke-context.tsx\` — the minimum shape
KeystrokeProvider already required from a reader (\`start\` +
\`subscribe\`). \`StdinReader\` satisfies it; the prop type was tightened
from the concrete class to the interface. No behavior change for any
existing caller; the only new caller is below.

### \`createRustKeystrokeReader()\`

Spawns the input source (#969 plumbing), translates \`KeyInputEvent\`
→ Reasonix's \`KeyEvent\` shape, fans out to subscribers.

| Rust event | KeyEvent fields set |
|---|---|
| \`Char\` + char + modifiers | \`input\` = char, optional \`ctrl\` / \`shift\` / \`meta\` |
| \`Enter\` + modifiers | \`return: true\` + optional modifiers |
| \`Esc\` | \`escape: true\` |
| Arrows | \`upArrow\` / \`downArrow\` / \`leftArrow\` / \`rightArrow\`: true |
| \`Backspace\` / \`Tab\` / \`BackTab\` / \`Home\` / \`End\` / \`PageUp\` / \`PageDown\` / \`Delete\` | corresponding field |
| F-keys, unrecognized | drop to \`null\` — KeyEvent has no slot, fake-filling a different field would hide the gap |

Reasonix's \`KeyEvent.meta\` is the Alt modifier (Ink vocabulary).
Mapping is one-way and explicit; no inference from raw bytes.

### \`chat.tsx\` wiring

When \`REASONIX_RENDERER=rust\`, \`chatCommand\` builds one reader
before \`render()\` and threads it through \`Root\` to both
\`KeystrokeProvider\` instances (the session picker mount and the
main App mount). The \`finally\` block calls \`close()\` so the input
child doesn't linger after \`waitUntilExit\` resolves.

## Tests

24 cases in \`tests/scene-input-adapter.test.ts\`:

- Every translation branch covered individually — single chars,
  Ctrl+letter, Alt+letter, Shift+letter, Enter, Shift+Enter, all
  named codes via \`.each\`, BackTab → tab+shift, F-keys + unknown
  codes → null, Char without char → null.
- End-to-end via the Node stub: spawn → emit → subscriber receives
  in order with correct translation; \`null\`-translated events are
  silently filtered; \`unsubscribe()\` stops further deliveries.

## What this does NOT yet do

The Rust side is now single-source-of-truth for modifier
resolution. The escape-sequence variants the JS \`StdinReader\` has
accreted (modifyOtherKeys, Kitty protocol, ConPTY ESC-stripping)
are mostly handled by crossterm in the Rust binary, but I have not
yet verified the full matrix against real terminal traces. Stage 3
tightens that.

Refs #868 #947