### PR TITLE
feat(scene): forward bracketed-paste bursts as paste KeyEvents

### DIFF
--- a/crates/reasonix-render/src/input.rs
+++ b/crates/reasonix-render/src/input.rs
@@ -11,6 +11,19 @@ pub struct InputEvent {
     pub modifiers: Vec<&'static str>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PasteEvent {
+    pub event: &'static str,
+    pub text: String,
+}
+
+pub fn paste_event(text: String) -> PasteEvent {
+    PasteEvent {
+        event: "paste",
+        text,
+    }
+}
+
 pub fn translate_key(event: &KeyEvent) -> Option<InputEvent> {
     if event.kind != KeyEventKind::Press {
         return None;

--- a/crates/reasonix-render/src/main.rs
+++ b/crates/reasonix-render/src/main.rs
@@ -1,7 +1,7 @@
 use std::io::{self, BufRead, Write};
 
 use anyhow::{Context, Result};
-use crossterm::event::{self, Event};
+use crossterm::event::{self, DisableBracketedPaste, EnableBracketedPaste, Event};
 use crossterm::execute;
 use crossterm::terminal::{
     disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
@@ -10,7 +10,7 @@ use ratatui::backend::CrosstermBackend;
 use ratatui::Terminal;
 
 use reasonix_render::decode_only::run_decode_only;
-use reasonix_render::input::{is_quit, translate_key};
+use reasonix_render::input::{is_quit, paste_event, translate_key};
 use reasonix_render::render::render_frame;
 use reasonix_render::scene::SceneFrame;
 
@@ -57,7 +57,12 @@ fn run_stream_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Res
 
 fn run_emit_input() -> Result<()> {
     enable_raw_mode().context("enable raw mode")?;
+    let mut stdout_for_setup = io::stdout();
+    let paste_enabled = execute!(stdout_for_setup, EnableBracketedPaste).is_ok();
     let result = emit_input_loop();
+    if paste_enabled {
+        execute!(stdout_for_setup, DisableBracketedPaste).ok();
+    }
     disable_raw_mode().ok();
     result
 }
@@ -66,17 +71,25 @@ fn emit_input_loop() -> Result<()> {
     let stdout = io::stdout();
     let mut out = stdout.lock();
     loop {
-        let Event::Key(key) = event::read()? else {
-            continue;
-        };
-        if is_quit(&key) {
-            return Ok(());
+        match event::read()? {
+            Event::Key(key) => {
+                if is_quit(&key) {
+                    return Ok(());
+                }
+                let Some(translated) = translate_key(&key) else {
+                    continue;
+                };
+                let json = serde_json::to_string(&translated).context("serialize input event")?;
+                writeln!(out, "{json}").context("write input event")?;
+                out.flush().context("flush stdout")?;
+            }
+            Event::Paste(text) => {
+                let event = paste_event(text);
+                let json = serde_json::to_string(&event).context("serialize paste event")?;
+                writeln!(out, "{json}").context("write paste event")?;
+                out.flush().context("flush stdout")?;
+            }
+            _ => {}
         }
-        let Some(translated) = translate_key(&key) else {
-            continue;
-        };
-        let json = serde_json::to_string(&translated).context("serialize input event")?;
-        writeln!(out, "{json}").context("write input event")?;
-        out.flush().context("flush stdout")?;
     }
 }

--- a/src/cli/ui/scene/input-adapter.ts
+++ b/src/cli/ui/scene/input-adapter.ts
@@ -1,7 +1,8 @@
 import type { KeystrokeHandler, KeystrokeReader } from "../keystroke-context.js";
-import type { KeyEvent } from "../stdin-reader.js";
+import { type KeyEvent, sanitizePasteText } from "../stdin-reader.js";
 import {
   type KeyInputEvent,
+  type PasteInputEvent,
   type SpawnInputSourceOptions,
   spawnInputSource,
 } from "./input-source.js";
@@ -20,6 +21,10 @@ export function createRustKeystrokeReader(opts: SpawnInputSourceOptions = {}): R
   source.onKey((rust) => {
     const ev = translate(rust);
     if (!ev) return;
+    for (const h of handlers) h(ev);
+  });
+  source.onPaste((rust) => {
+    const ev = translatePaste(rust);
     for (const h of handlers) h(ev);
   });
 
@@ -97,4 +102,8 @@ function withMods(ev: KeyEvent, ctrl: boolean, shift: boolean, alt: boolean): Ke
   if (shift) ev.shift = true;
   if (alt) ev.meta = true;
   return ev;
+}
+
+export function translatePaste(rust: PasteInputEvent): KeyEvent {
+  return { input: sanitizePasteText(rust.text), paste: true };
 }

--- a/src/cli/ui/scene/input-source.ts
+++ b/src/cli/ui/scene/input-source.ts
@@ -10,8 +10,14 @@ export type KeyInputEvent = {
   modifiers?: readonly InputModifier[];
 };
 
+export type PasteInputEvent = {
+  event: "paste";
+  text: string;
+};
+
 export type InputSource = {
   onKey(handler: (event: KeyInputEvent) => void): () => void;
+  onPaste(handler: (event: PasteInputEvent) => void): () => void;
   /** Send SIGINT to the child if it's still alive, then await exit. */
   close(): Promise<number | null>;
   /** Await the child's natural exit without signaling. */
@@ -26,6 +32,11 @@ export type SpawnInputSourceOptions = {
 
 export const DEFAULT_INPUT_COMMAND: readonly string[] = [...DEFAULT_COMMAND, "--", "--emit-input"];
 
+type Buses = {
+  keys: Set<(event: KeyInputEvent) => void>;
+  pastes: Set<(event: PasteInputEvent) => void>;
+};
+
 export function spawnInputSource(opts: SpawnInputSourceOptions = {}): InputSource {
   const command = opts.command ?? DEFAULT_INPUT_COMMAND;
   const [cmd, ...args] = command;
@@ -39,7 +50,7 @@ export function spawnInputSource(opts: SpawnInputSourceOptions = {}): InputSourc
     stdio: ["ignore", "pipe", "inherit"],
   });
 
-  const handlers = new Set<(event: KeyInputEvent) => void>();
+  const buses: Buses = { keys: new Set(), pastes: new Set() };
   let buf = "";
 
   child.stdout?.setEncoding("utf8");
@@ -49,13 +60,13 @@ export function spawnInputSource(opts: SpawnInputSourceOptions = {}): InputSourc
     while (nl >= 0) {
       const line = buf.slice(0, nl);
       buf = buf.slice(nl + 1);
-      dispatch(line, handlers);
+      dispatch(line, buses);
       nl = buf.indexOf("\n");
     }
   });
   child.stdout?.on("end", () => {
     if (buf.length > 0) {
-      dispatch(buf, handlers);
+      dispatch(buf, buses);
       buf = "";
     }
   });
@@ -66,9 +77,15 @@ export function spawnInputSource(opts: SpawnInputSourceOptions = {}): InputSourc
 
   return {
     onKey(handler) {
-      handlers.add(handler);
+      buses.keys.add(handler);
       return () => {
-        handlers.delete(handler);
+        buses.keys.delete(handler);
+      };
+    },
+    onPaste(handler) {
+      buses.pastes.add(handler);
+      return () => {
+        buses.pastes.delete(handler);
       };
     },
     async close(): Promise<number | null> {
@@ -83,7 +100,7 @@ export function spawnInputSource(opts: SpawnInputSourceOptions = {}): InputSourc
   };
 }
 
-function dispatch(line: string, handlers: Set<(event: KeyInputEvent) => void>): void {
+function dispatch(line: string, buses: Buses): void {
   if (line.trim().length === 0) return;
   let parsed: unknown;
   try {
@@ -91,8 +108,14 @@ function dispatch(line: string, handlers: Set<(event: KeyInputEvent) => void>): 
   } catch {
     return;
   }
-  if (!isKeyEvent(parsed)) return;
-  for (const handler of handlers) handler(parsed);
+  if (isKeyEvent(parsed)) {
+    for (const handler of buses.keys) handler(parsed);
+    return;
+  }
+  if (isPasteEvent(parsed)) {
+    for (const handler of buses.pastes) handler(parsed);
+    return;
+  }
 }
 
 function isKeyEvent(value: unknown): value is KeyInputEvent {
@@ -102,4 +125,10 @@ function isKeyEvent(value: unknown): value is KeyInputEvent {
   if (obj.char !== undefined && typeof obj.char !== "string") return false;
   if (obj.modifiers !== undefined && !Array.isArray(obj.modifiers)) return false;
   return true;
+}
+
+function isPasteEvent(value: unknown): value is PasteInputEvent {
+  if (typeof value !== "object" || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  return obj.event === "paste" && typeof obj.text === "string";
 }

--- a/tests/scene-input-adapter.test.ts
+++ b/tests/scene-input-adapter.test.ts
@@ -3,8 +3,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import process from "node:process";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { createRustKeystrokeReader, translate } from "../src/cli/ui/scene/input-adapter.js";
-import type { KeyInputEvent } from "../src/cli/ui/scene/input-source.js";
+import {
+  createRustKeystrokeReader,
+  translate,
+  translatePaste,
+} from "../src/cli/ui/scene/input-adapter.js";
+import type { KeyInputEvent, PasteInputEvent } from "../src/cli/ui/scene/input-source.js";
 
 const STUB = "tests/fixtures/input-emit-stub.mjs";
 
@@ -96,7 +100,7 @@ describe("createRustKeystrokeReader", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  function writeEvents(events: KeyInputEvent[]): void {
+  function writeEvents(events: (KeyInputEvent | PasteInputEvent)[]): void {
     writeFileSync(eventsPath, `${events.map((e) => JSON.stringify(e)).join("\n")}\n`);
   }
 
@@ -152,5 +156,41 @@ describe("createRustKeystrokeReader", () => {
     });
     await reader.wait();
     expect(received).toHaveLength(1);
+  });
+
+  it("forwards paste events as KeyEvent with paste=true", async () => {
+    writeEvents([
+      { event: "key", code: "Char", char: "a" },
+      { event: "paste", text: "hello world" },
+      { event: "key", code: "Enter" },
+    ]);
+    const reader = createRustKeystrokeReader({
+      command: [process.execPath, STUB],
+      env: { ...process.env, INPUT_EMIT_FILE: eventsPath },
+    });
+    const received: Array<{ input: string; paste?: boolean; return?: boolean }> = [];
+    reader.subscribe((ev) => received.push(ev));
+    await reader.wait();
+    expect(received).toEqual([
+      { input: "a" },
+      { input: "hello world", paste: true },
+      { input: "", return: true },
+    ]);
+  });
+});
+
+describe("translatePaste", () => {
+  it("wraps the text as a KeyEvent with paste=true", () => {
+    expect(translatePaste({ event: "paste", text: "hello" })).toEqual({
+      input: "hello",
+      paste: true,
+    });
+  });
+
+  it("strips invisible bidi/zero-width chars via sanitizePasteText", () => {
+    const polluted = "a\u200Bb\u202Ec";
+    const result = translatePaste({ event: "paste", text: polluted });
+    expect(result.input).toBe("abc");
+    expect(result.paste).toBe(true);
   });
 });


### PR DESCRIPTION
Stage 2 polish. The Rust input child now enables DECSET 2004
(bracketed paste) and emits multi-byte paste bursts as a distinct
event, not as a flood of \`Char\` events. The JS adapter translates
them to a \`KeyEvent\` with \`paste: true\` — matching what the existing
\`StdinReader\` produces on the Ink path, so the composer's
paste-suppress logic (don't interpret \`\n\` as submit) just works
under \`REASONIX_RENDERER=rust\` too.

## Rust

- \`EnableBracketedPaste\` before the read loop,
  \`DisableBracketedPaste\` on cleanup. Both are best-effort — terminals
  that don't support bracketed paste keep working, individual chars
  just keep arriving as \`Char\` events.
- \`Event::Paste(text)\` handled in the same \`match\` arm; emits
  \`{"event":"paste","text":"..."}\` JSON.
- \`PasteEvent\` struct + \`paste_event()\` factory live in \`input.rs\`
  next to the existing key translation, so the two output shapes are
  visible side-by-side.

## JS

- \`PasteInputEvent\` type + \`onPaste()\` on the InputSource.
  \`dispatch()\` routes JSONL lines to either bus by the \`event\`
  discriminator; unknown event kinds drop silently
  (forward-compat for \`resize\` / \`mouse\` when they land).
- \`translatePaste()\` runs the text through \`sanitizePasteText()\` —
  the same bidi/zero-width strip the stdin path uses (#849) — and
  emits \`{ input: <clean>, paste: true }\`.

## Tests

- End-to-end paste round-trip through the Node stub, mixed with
  regular key events to confirm both buses fire in order.
- \`translatePaste\` strips invisibles like \`\u200B\`, \`\u202E\`.
- Existing adapter / source tests untouched and still passing.

## What this does NOT cover

Heuristic paste-burst rescue when bracketed paste markers are
stripped by the terminal (the JS \`looksLikeUnbracketedPaste\`
heuristic from \`stdin-reader.ts\`) is not ported. crossterm doesn't
currently expose the raw byte stream the way the JS path does, so
the heuristic doesn't apply. Real-world terminals that need the
rescue (some Windows pipes, screen/tmux without passthrough) will
fall back to individual char events under the Rust path; that's a
regression vs Ink in those niche environments. Stage 3 prep should
add a trace pass to confirm coverage on the four target hosts before
the default flips.

Refs #868 #947