### PR TITLE
feat(scene): forward mouse events (click/drag/release/scroll) from Rust

### DIFF
--- a/crates/reasonix-render/src/input.rs
+++ b/crates/reasonix-render/src/input.rs
@@ -1,4 +1,6 @@
-use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use crossterm::event::{
+    KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
+};
 use serde::Serialize;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -77,4 +79,35 @@ pub fn is_quit(event: &KeyEvent) -> bool {
     event.kind == KeyEventKind::Press
         && event.code == KeyCode::Char('c')
         && event.modifiers.contains(KeyModifiers::CONTROL)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct MouseInputEvent {
+    pub event: &'static str,
+    pub kind: &'static str,
+    /// 1-based row, matching the VT mouse-report convention the JS side expects.
+    pub row: u16,
+    /// 1-based column, same convention as row.
+    pub col: u16,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub modifiers: Vec<&'static str>,
+}
+
+pub fn translate_mouse(event: &MouseEvent) -> Option<MouseInputEvent> {
+    let kind = match event.kind {
+        MouseEventKind::Down(MouseButton::Left) => "click",
+        MouseEventKind::Drag(MouseButton::Left) => "drag",
+        MouseEventKind::Up(_) => "release",
+        MouseEventKind::ScrollUp => "scroll-up",
+        MouseEventKind::ScrollDown => "scroll-down",
+        _ => return None,
+    };
+    Some(MouseInputEvent {
+        event: "mouse",
+        kind,
+        // crossterm reports 0-based row/col; bump to 1-based on the wire.
+        row: event.row.saturating_add(1),
+        col: event.column.saturating_add(1),
+        modifiers: collect_modifiers(event.modifiers),
+    })
 }

--- a/crates/reasonix-render/src/main.rs
+++ b/crates/reasonix-render/src/main.rs
@@ -1,7 +1,10 @@
 use std::io::{self, BufRead, Write};
 
 use anyhow::{Context, Result};
-use crossterm::event::{self, DisableBracketedPaste, EnableBracketedPaste, Event};
+use crossterm::event::{
+    self, DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
+    Event,
+};
 use crossterm::execute;
 use crossterm::terminal::{
     disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
@@ -10,7 +13,7 @@ use ratatui::backend::CrosstermBackend;
 use ratatui::Terminal;
 
 use reasonix_render::decode_only::run_decode_only;
-use reasonix_render::input::{is_quit, paste_event, translate_key};
+use reasonix_render::input::{is_quit, paste_event, translate_key, translate_mouse};
 use reasonix_render::render::render_frame;
 use reasonix_render::scene::SceneFrame;
 
@@ -59,7 +62,11 @@ fn run_emit_input() -> Result<()> {
     enable_raw_mode().context("enable raw mode")?;
     let mut stdout_for_setup = io::stdout();
     let paste_enabled = execute!(stdout_for_setup, EnableBracketedPaste).is_ok();
+    let mouse_enabled = execute!(stdout_for_setup, EnableMouseCapture).is_ok();
     let result = emit_input_loop();
+    if mouse_enabled {
+        execute!(stdout_for_setup, DisableMouseCapture).ok();
+    }
     if paste_enabled {
         execute!(stdout_for_setup, DisableBracketedPaste).ok();
     }
@@ -87,6 +94,14 @@ fn emit_input_loop() -> Result<()> {
                 let event = paste_event(text);
                 let json = serde_json::to_string(&event).context("serialize paste event")?;
                 writeln!(out, "{json}").context("write paste event")?;
+                out.flush().context("flush stdout")?;
+            }
+            Event::Mouse(m) => {
+                let Some(translated) = translate_mouse(&m) else {
+                    continue;
+                };
+                let json = serde_json::to_string(&translated).context("serialize mouse event")?;
+                writeln!(out, "{json}").context("write mouse event")?;
                 out.flush().context("flush stdout")?;
             }
             _ => {}

--- a/src/cli/ui/scene/input-adapter.ts
+++ b/src/cli/ui/scene/input-adapter.ts
@@ -2,6 +2,7 @@ import type { KeystrokeHandler, KeystrokeReader } from "../keystroke-context.js"
 import { type KeyEvent, sanitizePasteText } from "../stdin-reader.js";
 import {
   type KeyInputEvent,
+  type MouseInputEvent,
   type PasteInputEvent,
   type SpawnInputSourceOptions,
   spawnInputSource,
@@ -25,6 +26,10 @@ export function createRustKeystrokeReader(opts: SpawnInputSourceOptions = {}): R
   });
   source.onPaste((rust) => {
     const ev = translatePaste(rust);
+    for (const h of handlers) h(ev);
+  });
+  source.onMouse((rust) => {
+    const ev = translateMouse(rust);
     for (const h of handlers) h(ev);
   });
 
@@ -106,4 +111,26 @@ function withMods(ev: KeyEvent, ctrl: boolean, shift: boolean, alt: boolean): Ke
 
 export function translatePaste(rust: PasteInputEvent): KeyEvent {
   return { input: sanitizePasteText(rust.text), paste: true };
+}
+
+export function translateMouse(rust: MouseInputEvent): KeyEvent {
+  const ev: KeyEvent = { input: "", mouseRow: rust.row, mouseCol: rust.col };
+  switch (rust.kind) {
+    case "click":
+      ev.mouseClick = true;
+      break;
+    case "drag":
+      ev.mouseDrag = true;
+      break;
+    case "release":
+      ev.mouseRelease = true;
+      break;
+    case "scroll-up":
+      ev.mouseScrollUp = true;
+      break;
+    case "scroll-down":
+      ev.mouseScrollDown = true;
+      break;
+  }
+  return ev;
 }

--- a/src/cli/ui/scene/input-source.ts
+++ b/src/cli/ui/scene/input-source.ts
@@ -15,9 +15,22 @@ export type PasteInputEvent = {
   text: string;
 };
 
+export type MouseInputKind = "click" | "drag" | "release" | "scroll-up" | "scroll-down";
+
+export type MouseInputEvent = {
+  event: "mouse";
+  kind: MouseInputKind;
+  /** 1-based row, matching the VT mouse-report convention the JS side uses elsewhere. */
+  row: number;
+  /** 1-based column, same convention as row. */
+  col: number;
+  modifiers?: readonly InputModifier[];
+};
+
 export type InputSource = {
   onKey(handler: (event: KeyInputEvent) => void): () => void;
   onPaste(handler: (event: PasteInputEvent) => void): () => void;
+  onMouse(handler: (event: MouseInputEvent) => void): () => void;
   /** Send SIGINT to the child if it's still alive, then await exit. */
   close(): Promise<number | null>;
   /** Await the child's natural exit without signaling. */
@@ -35,6 +48,7 @@ export const DEFAULT_INPUT_COMMAND: readonly string[] = [...DEFAULT_COMMAND, "--
 type Buses = {
   keys: Set<(event: KeyInputEvent) => void>;
   pastes: Set<(event: PasteInputEvent) => void>;
+  mice: Set<(event: MouseInputEvent) => void>;
 };
 
 export function spawnInputSource(opts: SpawnInputSourceOptions = {}): InputSource {
@@ -50,7 +64,7 @@ export function spawnInputSource(opts: SpawnInputSourceOptions = {}): InputSourc
     stdio: ["ignore", "pipe", "inherit"],
   });
 
-  const buses: Buses = { keys: new Set(), pastes: new Set() };
+  const buses: Buses = { keys: new Set(), pastes: new Set(), mice: new Set() };
   let buf = "";
 
   child.stdout?.setEncoding("utf8");
@@ -88,6 +102,12 @@ export function spawnInputSource(opts: SpawnInputSourceOptions = {}): InputSourc
         buses.pastes.delete(handler);
       };
     },
+    onMouse(handler) {
+      buses.mice.add(handler);
+      return () => {
+        buses.mice.delete(handler);
+      };
+    },
     async close(): Promise<number | null> {
       if (child.exitCode === null && !child.killed) {
         child.kill("SIGINT");
@@ -116,6 +136,10 @@ function dispatch(line: string, buses: Buses): void {
     for (const handler of buses.pastes) handler(parsed);
     return;
   }
+  if (isMouseEvent(parsed)) {
+    for (const handler of buses.mice) handler(parsed);
+    return;
+  }
 }
 
 function isKeyEvent(value: unknown): value is KeyInputEvent {
@@ -131,4 +155,22 @@ function isPasteEvent(value: unknown): value is PasteInputEvent {
   if (typeof value !== "object" || value === null) return false;
   const obj = value as Record<string, unknown>;
   return obj.event === "paste" && typeof obj.text === "string";
+}
+
+const MOUSE_KINDS: ReadonlySet<string> = new Set([
+  "click",
+  "drag",
+  "release",
+  "scroll-up",
+  "scroll-down",
+]);
+
+function isMouseEvent(value: unknown): value is MouseInputEvent {
+  if (typeof value !== "object" || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  if (obj.event !== "mouse") return false;
+  if (typeof obj.kind !== "string" || !MOUSE_KINDS.has(obj.kind)) return false;
+  if (typeof obj.row !== "number" || typeof obj.col !== "number") return false;
+  if (obj.modifiers !== undefined && !Array.isArray(obj.modifiers)) return false;
+  return true;
 }

--- a/tests/scene-input-adapter.test.ts
+++ b/tests/scene-input-adapter.test.ts
@@ -6,9 +6,14 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   createRustKeystrokeReader,
   translate,
+  translateMouse,
   translatePaste,
 } from "../src/cli/ui/scene/input-adapter.js";
-import type { KeyInputEvent, PasteInputEvent } from "../src/cli/ui/scene/input-source.js";
+import type {
+  KeyInputEvent,
+  MouseInputEvent,
+  PasteInputEvent,
+} from "../src/cli/ui/scene/input-source.js";
 
 const STUB = "tests/fixtures/input-emit-stub.mjs";
 
@@ -100,7 +105,7 @@ describe("createRustKeystrokeReader", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  function writeEvents(events: (KeyInputEvent | PasteInputEvent)[]): void {
+  function writeEvents(events: (KeyInputEvent | PasteInputEvent | MouseInputEvent)[]): void {
     writeFileSync(eventsPath, `${events.map((e) => JSON.stringify(e)).join("\n")}\n`);
   }
 
@@ -192,5 +197,77 @@ describe("translatePaste", () => {
     const result = translatePaste({ event: "paste", text: polluted });
     expect(result.input).toBe("abc");
     expect(result.paste).toBe(true);
+  });
+});
+
+describe("translateMouse", () => {
+  it("click sets mouseClick=true with row/col", () => {
+    expect(translateMouse({ event: "mouse", kind: "click", row: 5, col: 10 })).toEqual({
+      input: "",
+      mouseClick: true,
+      mouseRow: 5,
+      mouseCol: 10,
+    });
+  });
+
+  it("drag sets mouseDrag=true", () => {
+    expect(translateMouse({ event: "mouse", kind: "drag", row: 5, col: 11 }).mouseDrag).toBe(true);
+  });
+
+  it("release sets mouseRelease=true", () => {
+    expect(translateMouse({ event: "mouse", kind: "release", row: 5, col: 11 }).mouseRelease).toBe(
+      true,
+    );
+  });
+
+  it("scroll-up sets mouseScrollUp=true", () => {
+    expect(
+      translateMouse({ event: "mouse", kind: "scroll-up", row: 5, col: 10 }).mouseScrollUp,
+    ).toBe(true);
+  });
+
+  it("scroll-down sets mouseScrollDown=true", () => {
+    expect(
+      translateMouse({ event: "mouse", kind: "scroll-down", row: 5, col: 10 }).mouseScrollDown,
+    ).toBe(true);
+  });
+});
+
+describe("createRustKeystrokeReader forwards mouse events end-to-end", () => {
+  let dir: string;
+  let eventsPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "input-adapter-mouse-"));
+    eventsPath = join(dir, "events.jsonl");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("delivers click + scroll-up + drag in order via the child", async () => {
+    writeFileSync(
+      eventsPath,
+      `${[
+        '{"event":"mouse","kind":"click","row":3,"col":7}',
+        '{"event":"mouse","kind":"scroll-up","row":3,"col":7}',
+        '{"event":"mouse","kind":"drag","row":4,"col":8}',
+      ].join("\n")}\n`,
+    );
+    const reader = createRustKeystrokeReader({
+      command: [process.execPath, STUB],
+      env: { ...process.env, INPUT_EMIT_FILE: eventsPath },
+    });
+    const received: import("../src/cli/ui/stdin-reader.js").KeyEvent[] = [];
+    reader.subscribe((ev) => received.push(ev));
+    await reader.wait();
+    expect(received).toHaveLength(3);
+    expect(received[0].mouseClick).toBe(true);
+    expect(received[0].mouseRow).toBe(3);
+    expect(received[0].mouseCol).toBe(7);
+    expect(received[1].mouseScrollUp).toBe(true);
+    expect(received[2].mouseDrag).toBe(true);
+    expect(received[2].mouseCol).toBe(8);
   });
 });


### PR DESCRIPTION
Stage 2 polish — and the #867 fix the RFC promised. The Rust input
child now enables xterm mouse capture and forwards click / drag /
release / scroll events as JSONL. The JS adapter translates them to
a \`KeyEvent\` with the existing mouse fields (\`mouseClick\` /
\`mouseDrag\` / \`mouseRelease\` / \`mouseScrollUp\` / \`mouseScrollDown\`
plus row+col).

Mouse-wheel SGR escape sequences no longer leak into the composer
because the Rust child captures + decodes them; JS receives a
structured event with mouseRow / mouseCol set, the same shape the
Ink-path StdinReader produces from raw SGR mouse reports.

## Rust

- \`EnableMouseCapture\` before the loop, \`DisableMouseCapture\` on
  cleanup. crossterm's default (mode 1000 + SGR 1006) matches what
  the JS StdinReader's SGR mouse parser was decoding from raw bytes.
- \`translate_mouse(MouseEvent) -> Option<MouseInputEvent>\`. Maps:
  | crossterm | wire kind |
  |---|---|
  | \`Down(Left)\` | \`click\` |
  | \`Drag(Left)\` | \`drag\` |
  | \`Up(any)\` | \`release\` |
  | \`ScrollUp\` | \`scroll-up\` |
  | \`ScrollDown\` | \`scroll-down\` |
  Right/middle clicks, \`Moved\`, \`ScrollLeft\`/\`Right\` drop to
  \`None\` — KeyEvent has no slot for them, better silent than
  fake-filling.
- crossterm rows/cols are 0-based; bumped to 1-based on the wire so
  the JS side keeps the VT mouse-report convention it already uses
  for Ink-path mouse events.

## JS

- \`MouseInputEvent\` type + \`onMouse()\` on InputSource. The
  discriminator + kind narrow in \`isMouseEvent\` so unknown future
  event variants drop silently (forward-compat for resize when it
  lands).
- \`translateMouse(rust) -> KeyEvent\` sets the appropriate mouse
  flag plus mouseRow / mouseCol; the rest of KeyEvent stays empty
  (\`input: \"\"\`) so the composer's mouse-click handlers see
  exactly what they got from the Ink path.

## Tests

- 5 translation cases (each kind + row/col preservation).
- End-to-end via the Node stub mixing click + scroll-up + drag —
  events arrive at subscribers in order, with the right flags set.

## Closes

#867 — mouse-wheel SGR escape leak. Stays open until someone
manually confirms on the four target hosts, but the code path that
generated the bug is gone in \`REASONIX_RENDERER=rust\` mode.

Refs #868 #947