### PR TITLE
修复 DeepSeek 计费价格与新会话花费重置

### DIFF
--- a/src/cli/ui/state/reducer.ts
+++ b/src/cli/ui/state/reducer.ts
@@ -206,7 +206,20 @@ export function reduce(state: AgentState, event: AgentEvent): AgentState {
       });
 
     case "session.reset":
-      return { ...state, cards: [], focusedCardId: null, toasts: [] };
+      return {
+        ...state,
+        cards: [],
+        focusedCardId: null,
+        toasts: [],
+        status: {
+          ...state.status,
+          cost: 0,
+          sessionCost: 0,
+          cacheHit: 0,
+          promptTokens: undefined,
+          promptCap: undefined,
+        },
+      };
 
     case "session.workspace.change":
       return state.session.id === event.id && state.session.workspace === event.workspace

--- a/src/client.ts
+++ b/src/client.ts
@@ -18,12 +18,16 @@ export class Usage {
 
   static fromApi(raw: RawUsage | undefined | null): Usage {
     const u = raw ?? {};
+    const promptTokens = u.prompt_tokens ?? 0;
+    const cacheHitTokens = u.prompt_cache_hit_tokens ?? 0;
+    const cacheMissTokens =
+      u.prompt_cache_miss_tokens ?? Math.max(0, promptTokens - cacheHitTokens);
     return new Usage(
-      u.prompt_tokens ?? 0,
+      promptTokens,
       u.completion_tokens ?? 0,
       u.total_tokens ?? 0,
-      u.prompt_cache_hit_tokens ?? 0,
-      u.prompt_cache_miss_tokens ?? 0,
+      cacheHitTokens,
+      cacheMissTokens,
     );
   }
 }

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -347,6 +347,10 @@ export class CacheFirstLoop {
     }
     this.scratch.reset();
     this._inflight.clear();
+    this.stats.reset();
+    this._turn = 0;
+    this._turnFailures.reset();
+    this._budgetWarned = false;
     let systemRebuilt = false;
     if (this._rebuildSystem) {
       try {

--- a/src/telemetry/stats.ts
+++ b/src/telemetry/stats.ts
@@ -1,15 +1,15 @@
 import type { Usage } from "../client.js";
 
-/** USD per 1M tokens; CNY sheet converted at fixed 7.2 — revisit if FX moves >±5%. */
+/** USD per 1M tokens; display currency conversion happens at the UI boundary. */
 export const DEEPSEEK_PRICING: Record<
   string,
   { inputCacheHit: number; inputCacheMiss: number; output: number }
 > = {
-  "deepseek-v4-flash": { inputCacheHit: 0.028, inputCacheMiss: 0.139, output: 0.278 },
-  "deepseek-v4-pro": { inputCacheHit: 0.139, inputCacheMiss: 1.667, output: 3.333 },
+  "deepseek-v4-flash": { inputCacheHit: 0.0028, inputCacheMiss: 0.14, output: 0.28 },
+  "deepseek-v4-pro": { inputCacheHit: 0.003625, inputCacheMiss: 0.435, output: 0.87 },
   // Compat aliases — priced as v4-flash per the deprecation notice.
-  "deepseek-chat": { inputCacheHit: 0.028, inputCacheMiss: 0.139, output: 0.278 },
-  "deepseek-reasoner": { inputCacheHit: 0.028, inputCacheMiss: 0.139, output: 0.278 },
+  "deepseek-chat": { inputCacheHit: 0.0028, inputCacheMiss: 0.14, output: 0.28 },
+  "deepseek-reasoner": { inputCacheHit: 0.0028, inputCacheMiss: 0.14, output: 0.28 },
 };
 
 /** Reference Claude Sonnet 4.6 pricing (USD per 1M tokens). */
@@ -128,6 +128,15 @@ export class SessionStats {
     if (typeof opts.lastPromptTokens === "number" && opts.lastPromptTokens > 0) {
       this._carryoverLastPromptTokens = opts.lastPromptTokens;
     }
+  }
+
+  reset(): void {
+    this.turns.length = 0;
+    this._carryoverCost = 0;
+    this._carryoverTurns = 0;
+    this._carryoverCacheHit = 0;
+    this._carryoverCacheMiss = 0;
+    this._carryoverLastPromptTokens = 0;
   }
 
   record(turn: number, model: string, usage: Usage): TurnStats {

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -1,7 +1,7 @@
 /** CacheFirstLoop integration — fake-fetch DeepSeekClient, non-streaming path. */
 
 import { describe, expect, it, vi } from "vitest";
-import { DeepSeekClient } from "../src/client.js";
+import { DeepSeekClient, Usage } from "../src/client.js";
 import { type ConfirmationChoice, PauseGate } from "../src/core/pause-gate.js";
 import { CacheFirstLoop } from "../src/loop.js";
 import { ImmutablePrefix } from "../src/memory/runtime.js";
@@ -1393,12 +1393,17 @@ describe("CacheFirstLoop - setBudget / clearLog / retryLastUser / proArm", () =>
     expect(loop.log.length).toBeGreaterThan(0);
     loop.scratch.notes = ["stale note"];
     loop.scratch.reasoning = "stale reasoning";
+    loop.stats.record(1, "deepseek-chat", new Usage(1000, 100, 1100, 800, 200));
+    expect(loop.stats.summary().totalCostUsd).toBeGreaterThan(0);
 
     const { dropped } = loop.clearLog();
     expect(dropped).toBe(2);
     expect(loop.log.length).toBe(0);
     expect(loop.scratch.notes).toEqual([]);
     expect(loop.scratch.reasoning).toBeNull();
+    expect(loop.stats.summary().totalCostUsd).toBe(0);
+    expect(loop.stats.summary().turns).toBe(0);
+    expect(loop.currentTurn).toBe(0);
   });
 
   it("clearLog returns 0 dropped when already empty", () => {

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -23,9 +23,33 @@ describe("Usage.cacheHitRatio", () => {
   it("is zero on empty", () => {
     expect(new Usage().cacheHitRatio).toBe(0);
   });
+
+  it("falls back cache miss tokens from prompt minus cache hit when the API omits miss", () => {
+    const u = Usage.fromApi({
+      prompt_tokens: 1000,
+      completion_tokens: 100,
+      total_tokens: 1100,
+      prompt_cache_hit_tokens: 800,
+    });
+    expect(u.promptCacheHitTokens).toBe(800);
+    expect(u.promptCacheMissTokens).toBe(200);
+  });
 });
 
 describe("costUsd", () => {
+  it("matches DeepSeek's published V4 USD pricing sheet", () => {
+    expect(DEEPSEEK_PRICING["deepseek-v4-flash"]).toEqual({
+      inputCacheHit: 0.0028,
+      inputCacheMiss: 0.14,
+      output: 0.28,
+    });
+    expect(DEEPSEEK_PRICING["deepseek-v4-pro"]).toEqual({
+      inputCacheHit: 0.003625,
+      inputCacheMiss: 0.435,
+      output: 0.87,
+    });
+  });
+
   it("applies DeepSeek pricing tiers", () => {
     const u = new Usage(1000, 100, 0, 800, 200);
     const c = costUsd("deepseek-chat", u);
@@ -82,6 +106,28 @@ describe("SessionStats", () => {
     // Sum of input+output equals total (within rounding).
     expect(s.totalInputCostUsd + s.totalOutputCostUsd).toBeCloseTo(s.totalCostUsd, 6);
   });
+
+  it("reset clears live and carryover totals for /new", () => {
+    const stats = new SessionStats();
+    stats.seedCarryover({
+      totalCostUsd: 0.05,
+      turnCount: 3,
+      cacheHitTokens: 1000,
+      cacheMissTokens: 100,
+      lastPromptTokens: 1100,
+    });
+    stats.record(4, "deepseek-chat", new Usage(1000, 100, 1100, 800, 200));
+    stats.reset();
+    expect(stats.turns).toHaveLength(0);
+    expect(stats.totalCost).toBe(0);
+    expect(stats.summary()).toMatchObject({
+      turns: 0,
+      totalCostUsd: 0,
+      cacheHitRatio: 0,
+      lastPromptTokens: 0,
+      lastTurnCostUsd: 0,
+    });
+  });
 });
 
 describe("inputCostUsd / outputCostUsd", () => {
@@ -124,7 +170,7 @@ describe("inputCostUsd / outputCostUsd", () => {
     const u = new Usage(0, 100, 0, 0, 1000);
     const flashCost = costUsd("deepseek-v4-flash", u);
     const proCost = costUsd("deepseek-v4-pro", u);
-    expect(proCost).toBeGreaterThan(flashCost * 5); // ~12x on output+miss
+    expect(proCost).toBeGreaterThan(flashCost * 3); // current pro promo is ~3.1x flash
   });
 
   it("both return 0 for an unknown model", () => {

--- a/tests/ui-reducer.test.ts
+++ b/tests/ui-reducer.test.ts
@@ -222,6 +222,28 @@ describe("ui reducer", () => {
     expect(s.status.balanceCurrency).toBe("CNY");
   });
 
+  it("session.reset clears visible cost counters but keeps wallet info", () => {
+    const s = run([
+      {
+        type: "session.update",
+        patch: { balance: 5.0, balanceCurrency: "CNY" },
+      },
+      {
+        type: "turn.end",
+        usage: { prompt: 1000, reason: 0, output: 100, cacheHit: 0.8, cost: 0.01 },
+        promptCap: 1_000_000,
+      },
+      { type: "session.reset" },
+    ]);
+    expect(s.status.cost).toBe(0);
+    expect(s.status.sessionCost).toBe(0);
+    expect(s.status.cacheHit).toBe(0);
+    expect(s.status.promptTokens).toBeUndefined();
+    expect(s.status.promptCap).toBeUndefined();
+    expect(s.status.balance).toBe(5.0);
+    expect(s.status.balanceCurrency).toBe("CNY");
+  });
+
   it("focus.move walks cards forward and back, clamped at edges", () => {
     let s = run([
       { type: "user.submit", text: "a" },


### PR DESCRIPTION
## 概要
- 将 DeepSeek V4 的计费常量更新为官方当前公布的 USD 单价
- 当 API 没有返回 `prompt_cache_miss_tokens` 时，用 `prompt_tokens - prompt_cache_hit_tokens` 兜底，避免漏算未命中输入
- `/new` 新建对话时同步重置 loop 统计和状态栏花费，避免新会话继承旧的“本会话已花费”

## 原因
当前官方价格页显示：
- `deepseek-v4-flash`: cache hit input $0.0028 / 1M tokens，cache miss input $0.14 / 1M tokens，output $0.28 / 1M tokens
- `deepseek-v4-pro`: 当前优惠期 cache hit input $0.003625 / 1M tokens，cache miss input $0.435 / 1M tokens，output $0.87 / 1M tokens

旧表中 flash 兼容模型的 cache hit input 被高估了 10 倍，v4-pro 也还是旧的更高价格。另外 `/new` 只清聊天记录，没有清 `SessionStats` 和 UI 状态栏计数，所以新对话里“本会话已花费”可能继续沿用旧累计。

参考：https://api-docs.deepseek.com/quick_start/pricing/

## 验证
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test -- --run`
- push 前自动 `npm run verify`