### PR TITLE
feat(scene): REASONIX_INPUT_CMD env var lets input child skip cargo

### DIFF
--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -42,6 +42,17 @@ import {
 
 export type { McpLifecycleNotice, McpLifecycleSink, McpRuntime, ProgressInfo };
 
+function parseInputCmd(raw: string | undefined): readonly string[] | undefined {
+  if (!raw || raw.length === 0) return undefined;
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed) && parsed.every((p) => typeof p === "string")) return parsed;
+  } catch {
+    // fall through
+  }
+  return undefined;
+}
+
 export interface ChatOptions {
   model: string;
   system: string;
@@ -345,7 +356,10 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
   const rustRendererActive = process.env.REASONIX_RENDERER === "rust";
   const inkStdout = rustRendererActive ? makeNullStdout() : undefined;
   const inkStdin = rustRendererActive ? makeNullStdin() : undefined;
-  const keystrokeReader = rustRendererActive ? createRustKeystrokeReader() : undefined;
+  const inputCmdOverride = parseInputCmd(process.env.REASONIX_INPUT_CMD);
+  const keystrokeReader = rustRendererActive
+    ? createRustKeystrokeReader(inputCmdOverride ? { command: inputCmdOverride } : {})
+    : undefined;
 
   const { waitUntilExit } = render(
     <Root


### PR DESCRIPTION
Symmetric to \`REASONIX_RENDER_CMD\` (from #961). Lets a smoke-test
script or dev wrapper point both the renderer child and the input
child at a pre-built binary so the first launch isn't a 30s wait
on \`cargo\`'s dev-profile compile.

## Why this PR exists

During the 2026-05-15 manual smoke pass on Windows Terminal, the
first run of \`REASONIX_RENDERER=rust reasonix\` hung on a black
screen for ~30s while the input child cold-compiled in the dev
profile. The renderer child had been pointed at the release binary
via \`REASONIX_RENDER_CMD\`, so it started instantly — but the input
child still went through \`cargo run --bin reasonix-render --
--emit-input\`. Without instrumentation, the symptom is
indistinguishable from "broken".

Pre-building the dev binary fixes the cold-compile but still pays
cargo's per-invoke staleness-check cost (~hundreds of ms on Windows
where filesystem stat is slow). Pointing the input child at the
release binary skips all of that.

## API

\`\`\`
$env:REASONIX_INPUT_CMD = ConvertTo-Json -Compress @(
  "F:/Reasonix-rust/target/release/reasonix-render.exe",
  "--emit-input"
)
\`\`\`

JSON array of strings, same shape as \`REASONIX_RENDER_CMD\`. When
unset or malformed, \`createRustKeystrokeReader()\` falls back to the
existing default (\`cargo run --bin reasonix-render -- --emit-input\`).
Production users have no reason to set it.

## What this is not

This is not a production-distribution wire-up. Once installer
plumbing lands (Stage 5), the default for both env vars becomes
the installed binary path and these knobs become test-only.

Refs #868 #947