### PR TITLE
feat(scene): show the composer's current text in the trace frame

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -516,6 +516,7 @@ function AppInner({
     model,
     lastCardKind,
     lastCardSummary,
+    composerText: input,
   });
   const {
     ongoingTool,

--- a/src/cli/ui/hooks/useSceneTrace.ts
+++ b/src/cli/ui/hooks/useSceneTrace.ts
@@ -12,6 +12,8 @@ export type SceneTraceInput = {
   lastCardSummary?: string;
   busy: boolean;
   activity?: string;
+  /** Current composer text — what the user is typing but has not yet submitted. */
+  composerText?: string;
 };
 
 const SUMMARY_MAX = 70;
@@ -47,7 +49,7 @@ export function buildTraceFrame(input: SceneTraceInput, cols: number, rows: numb
   return frame(
     cols,
     rows,
-    box([titleRow(input), cardRow(input), statusRow(input)], {
+    box([titleRow(input), cardRow(input), statusRow(input), composerRow(input)], {
       direction: "column",
       paddingX: 1,
     }),
@@ -82,6 +84,18 @@ function statusRow(s: SceneTraceInput): SceneNode {
     { text: s.busy ? "busy" : "idle", style: { color: s.busy ? "yellow" : "green" } },
   ];
   if (s.activity) runs.push({ text: ` · ${s.activity}`, style: { dim: true } });
+  return text(runs);
+}
+
+function composerRow(s: SceneTraceInput): SceneNode {
+  const runs: TextRun[] = [{ text: "❯ ", style: { color: "cyan", bold: true } }];
+  const t = s.composerText ?? "";
+  if (t.length === 0) {
+    runs.push({ text: "(type a message)", style: { dim: true } });
+  } else {
+    runs.push({ text: t });
+    runs.push({ text: "▮", style: { color: "cyan" } });
+  }
   return text(runs);
 }
 
@@ -135,15 +149,15 @@ export function useSceneTrace(input: SceneTraceInput): void {
   const { stdout } = useStdout();
   const cols = stdout?.columns ?? 80;
   const rows = stdout?.rows ?? 24;
-  const { model, cardCount, lastCardKind, lastCardSummary, busy, activity } = input;
+  const { model, cardCount, lastCardKind, lastCardSummary, busy, activity, composerText } = input;
   useEffect(() => {
     if (!isSceneTraceEnabled()) return;
     emitSceneFrame(
       buildTraceFrame(
-        { model, cardCount, lastCardKind, lastCardSummary, busy, activity },
+        { model, cardCount, lastCardKind, lastCardSummary, busy, activity, composerText },
         cols,
         rows,
       ),
     );
-  }, [cols, rows, model, cardCount, lastCardKind, lastCardSummary, busy, activity]);
+  }, [cols, rows, model, cardCount, lastCardKind, lastCardSummary, busy, activity, composerText]);
 }

--- a/tests/scene-trace-frame.test.ts
+++ b/tests/scene-trace-frame.test.ts
@@ -44,7 +44,7 @@ describe("summarizeCard", () => {
 });
 
 describe("buildTraceFrame", () => {
-  it("returns a column box with three children: title, card, status", () => {
+  it("returns a column box with four children: title, card, status, composer", () => {
     const f = buildTraceFrame({ cardCount: 0, busy: false }, 80, 24);
     expect(f.schemaVersion).toBe(1);
     expect(f.cols).toBe(80);
@@ -53,7 +53,7 @@ describe("buildTraceFrame", () => {
     if (f.root.kind !== "box") return;
     expect(f.root.layout?.direction).toBe("column");
     expect(f.root.layout?.paddingX).toBe(1);
-    expect(f.root.children).toHaveLength(3);
+    expect(f.root.children).toHaveLength(4);
   });
 
   it("renders the model name in the title row when given", () => {
@@ -115,5 +115,30 @@ describe("buildTraceFrame", () => {
     if (status?.kind !== "text") return;
     const flat = status.runs.map((r) => r.text).join("");
     expect(flat).toContain("awaiting tools");
+  });
+
+  it("composer row is a dim placeholder when composerText is empty / undefined", () => {
+    for (const f of [
+      buildTraceFrame({ cardCount: 0, busy: false }, 80, 24),
+      buildTraceFrame({ cardCount: 0, busy: false, composerText: "" }, 80, 24),
+    ]) {
+      if (f.root.kind !== "box") return;
+      const composer = f.root.children[3];
+      if (composer?.kind !== "text") return;
+      expect(composer.runs[0]?.text).toBe("❯ ");
+      expect(composer.runs[0]?.style?.color).toBe("cyan");
+      expect(composer.runs[1]?.style?.dim).toBe(true);
+    }
+  });
+
+  it("composer row shows typed text plus a cursor block when composerText is non-empty", () => {
+    const f = buildTraceFrame({ cardCount: 1, busy: false, composerText: "hello" }, 80, 24);
+    if (f.root.kind !== "box") return;
+    const composer = f.root.children[3];
+    if (composer?.kind !== "text") return;
+    expect(composer.runs[0]?.text).toBe("❯ ");
+    expect(composer.runs[1]?.text).toBe("hello");
+    expect(composer.runs[2]?.text).toBe("▮");
+    expect(composer.runs[2]?.style?.color).toBe("cyan");
   });
 });


### PR DESCRIPTION
The trace frame had three rows: title, last card, status. Under
\`REASONIX_RENDERER=rust\` this meant a typing user saw nothing
change until they hit Enter — the composer is in Ink, which
renders to the null stream in that mode. The user had to type blind.

After this PR, a fourth row, always present:

\`\`\`
❯ (type a message)               # empty: dim placeholder
❯ what's the weather▮            # non-empty: typed text + cursor block
\`\`\`

This was the most direct pain point from the 2026-05-15 smoke pass —
the user typed an entire message blind before confirming via Enter
that input was reaching state.

## Wiring

\`useSceneTrace\`'s input gains a \`composerText\` field; \`App.tsx\`
wires its existing \`input\` state into it. The composer state was
already re-rendering App on every keystroke (normal \`useState\`),
so hooking the trace frame in is just one extra effect dep — no new
performance characteristic.

## Why \`❯\` (U+276F) + \`▮\` (U+25AE)

- \`❯\` is a single-cell prompt glyph that renders consistently across
  Windows Terminal, iTerm2, kitty, VSCode terminal. ASCII \`>\` is
  ambiguous with the user-card icon in the row above; using a
  different glyph keeps the rows visually distinct.
- \`▮\` is the vertical-bar cursor block Ink-rendered terminals show;
  it gives the user a place to look at while typing without
  needing a real blinking cursor (which would require timer-driven
  scene frame updates that we don't want to pay for yet).

## What this still does NOT solve

- **Cursor position inside the buffer** — the block is at the end of
  the input; cursor movement (Ctrl+A, arrow keys) inside the buffer
  isn't reflected. Showing in-line cursor position needs the
  composer's cursor offset state, which lives one component down
  from where the trace input is assembled. Follow-up if anyone
  notices.
- **Slash-command autocomplete, history-prev preview,
  paste-marker visualization** — none of those show. They're
  separate panels in Ink. Same lowering-pass-blocked-on-#565 story.

## Tests

13 cases in \`tests/scene-trace-frame.test.ts\`:

- Existing 11 unchanged in intent — the "three children" assertion
  updates to "four children".
- Two new composer-row cases:
  - Empty / undefined → dim "(type a message)" placeholder.
  - Non-empty → typed text + cyan cursor block at end.

Refs #868 #947