### PR TITLE
feat(scene): show recent N cards in the trace frame, not just the latest

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -469,8 +469,11 @@ function AppInner({
   );
   const isStreaming = useAgentState((s) => s.cards.some((c) => c.kind === "streaming" && !c.done));
   const cardCount = useAgentState((s) => s.cards.length);
-  const lastCardKind = useAgentState((s) => s.cards.at(-1)?.kind);
-  const lastCardSummary = useAgentState((s) => summarizeCard(s.cards.at(-1)));
+  const recentCardsJson = useAgentState((s) =>
+    JSON.stringify(
+      s.cards.slice(-24).map((c) => ({ kind: c.kind, summary: summarizeCard(c) ?? "" })),
+    ),
+  );
   const activityLabel = useActivityLabel();
   const chatScroll = useChatScrollActions();
   const [input, setInput] = useState("");
@@ -514,8 +517,7 @@ function AppInner({
     busy,
     activity: activityLabel,
     model,
-    lastCardKind,
-    lastCardSummary,
+    recentCardsJson,
     composerText: input,
   });
   const {

--- a/src/cli/ui/hooks/useSceneTrace.ts
+++ b/src/cli/ui/hooks/useSceneTrace.ts
@@ -5,18 +5,33 @@ import { emitSceneFrame, isSceneTraceEnabled } from "../scene/trace.js";
 import type { Color, SceneFrame, SceneNode, TextRun } from "../scene/types.js";
 import type { Card } from "../state/cards.js";
 
+export type SceneTraceCard = { kind: string; summary: string };
+
 export type SceneTraceInput = {
   model?: string;
   cardCount: number;
-  lastCardKind?: string;
-  lastCardSummary?: string;
+  /** JSON-encoded `SceneTraceCard[]`, most recent last. Passed as a string so React deps stay primitive — array refs would re-fire the effect every render. */
+  recentCardsJson?: string;
   busy: boolean;
   activity?: string;
   /** Current composer text — what the user is typing but has not yet submitted. */
   composerText?: string;
 };
 
+type BuildInput = {
+  model?: string;
+  cardCount: number;
+  cards: ReadonlyArray<SceneTraceCard>;
+  busy: boolean;
+  activity?: string;
+  composerText?: string;
+};
+
 const SUMMARY_MAX = 70;
+/** Reserved rows for title + status + composer; the rest can hold cards. */
+const RESERVED_ROWS = 3;
+/** Hard cap so a tall terminal doesn't make the payload absurd. */
+const MAX_CARDS = 24;
 
 export function summarizeCard(card: Card | undefined): string | undefined {
   if (!card) return undefined;
@@ -45,39 +60,38 @@ function clip(s: string): string {
   return firstLine.length > SUMMARY_MAX ? `${firstLine.slice(0, SUMMARY_MAX - 1)}…` : firstLine;
 }
 
-export function buildTraceFrame(input: SceneTraceInput, cols: number, rows: number): SceneFrame {
-  return frame(
-    cols,
-    rows,
-    box([titleRow(input), cardRow(input), statusRow(input), composerRow(input)], {
-      direction: "column",
-      paddingX: 1,
-    }),
-  );
+export function buildTraceFrame(input: BuildInput, cols: number, rows: number): SceneFrame {
+  const children: SceneNode[] = [titleRow(input)];
+  if (input.cards.length === 0) {
+    children.push(noCardsRow());
+  } else {
+    for (const c of input.cards) children.push(cardRow(c));
+  }
+  children.push(statusRow(input));
+  children.push(composerRow(input));
+  return frame(cols, rows, box(children, { direction: "column", paddingX: 1 }));
 }
 
-function titleRow(s: SceneTraceInput): SceneNode {
+function titleRow(s: BuildInput): SceneNode {
   const runs: TextRun[] = [{ text: "reasonix", style: { bold: true } }];
   if (s.model) runs.push({ text: ` · ${s.model}`, style: { dim: true } });
   return text(runs);
 }
 
-function cardRow(s: SceneTraceInput): SceneNode {
-  if (!s.lastCardKind) {
-    return text([{ text: "(no cards yet)", style: { dim: true } }]);
-  }
+function noCardsRow(): SceneNode {
+  return text([{ text: "(no cards yet)", style: { dim: true } }]);
+}
+
+function cardRow(c: SceneTraceCard): SceneNode {
   const runs: TextRun[] = [
-    { text: iconFor(s.lastCardKind), style: { color: colorFor(s.lastCardKind) } },
+    { text: iconFor(c.kind), style: { color: colorFor(c.kind) } },
     { text: " " },
-    {
-      text: s.lastCardSummary ?? s.lastCardKind,
-      style: s.lastCardKind === "user" ? { bold: true } : undefined,
-    },
+    { text: c.summary || c.kind, style: c.kind === "user" ? { bold: true } : undefined },
   ];
   return text(runs);
 }
 
-function statusRow(s: SceneTraceInput): SceneNode {
+function statusRow(s: BuildInput): SceneNode {
   const runs: TextRun[] = [
     { text: `${s.cardCount} cards`, style: { dim: true } },
     { text: " · " },
@@ -87,7 +101,7 @@ function statusRow(s: SceneTraceInput): SceneNode {
   return text(runs);
 }
 
-function composerRow(s: SceneTraceInput): SceneNode {
+function composerRow(s: BuildInput): SceneNode {
   const runs: TextRun[] = [{ text: "❯ ", style: { color: "cyan", bold: true } }];
   const t = s.composerText ?? "";
   if (t.length === 0) {
@@ -145,19 +159,44 @@ function colorFor(kind: string): Color {
   }
 }
 
+export function parseRecentCards(json: string | undefined): SceneTraceCard[] {
+  if (!json || json.length === 0) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  const out: SceneTraceCard[] = [];
+  for (const item of parsed) {
+    if (typeof item !== "object" || item === null) continue;
+    const obj = item as Record<string, unknown>;
+    if (typeof obj.kind !== "string" || typeof obj.summary !== "string") continue;
+    out.push({ kind: obj.kind, summary: obj.summary });
+  }
+  return out;
+}
+
+export function cardsForHeight(
+  cards: ReadonlyArray<SceneTraceCard>,
+  rows: number,
+): SceneTraceCard[] {
+  const room = Math.max(1, Math.min(MAX_CARDS, rows - RESERVED_ROWS));
+  return cards.slice(-room);
+}
+
 export function useSceneTrace(input: SceneTraceInput): void {
   const { stdout } = useStdout();
   const cols = stdout?.columns ?? 80;
   const rows = stdout?.rows ?? 24;
-  const { model, cardCount, lastCardKind, lastCardSummary, busy, activity, composerText } = input;
+  const { model, cardCount, recentCardsJson, busy, activity, composerText } = input;
   useEffect(() => {
     if (!isSceneTraceEnabled()) return;
+    const parsed = parseRecentCards(recentCardsJson);
+    const cards = cardsForHeight(parsed, rows);
     emitSceneFrame(
-      buildTraceFrame(
-        { model, cardCount, lastCardKind, lastCardSummary, busy, activity, composerText },
-        cols,
-        rows,
-      ),
+      buildTraceFrame({ model, cardCount, cards, busy, activity, composerText }, cols, rows),
     );
-  }, [cols, rows, model, cardCount, lastCardKind, lastCardSummary, busy, activity, composerText]);
+  }, [cols, rows, model, cardCount, recentCardsJson, busy, activity, composerText]);
 }

--- a/tests/scene-trace-frame.test.ts
+++ b/tests/scene-trace-frame.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { buildTraceFrame, summarizeCard } from "../src/cli/ui/hooks/useSceneTrace.js";
+import {
+  type SceneTraceCard,
+  buildTraceFrame,
+  cardsForHeight,
+  parseRecentCards,
+  summarizeCard,
+} from "../src/cli/ui/hooks/useSceneTrace.js";
 import type { Card } from "../src/cli/ui/state/cards.js";
 
 function userCard(text: string): Card {
@@ -17,6 +23,10 @@ function toolCard(name: string, done: boolean): Card {
     done,
     elapsedMs: 0,
   };
+}
+
+function buildEmpty(extra: Partial<{ model: string; busy: boolean; composerText: string }> = {}) {
+  return buildTraceFrame({ cardCount: 0, busy: false, cards: [], ...extra }, 80, 24);
 }
 
 describe("summarizeCard", () => {
@@ -43,9 +53,75 @@ describe("summarizeCard", () => {
   });
 });
 
+describe("parseRecentCards", () => {
+  it("returns [] for undefined / empty / malformed input", () => {
+    expect(parseRecentCards(undefined)).toEqual([]);
+    expect(parseRecentCards("")).toEqual([]);
+    expect(parseRecentCards("not-json")).toEqual([]);
+    expect(parseRecentCards('{"not":"array"}')).toEqual([]);
+  });
+
+  it("decodes a JSON array of {kind, summary} objects", () => {
+    const json = JSON.stringify([
+      { kind: "user", summary: "hi" },
+      { kind: "streaming", summary: "hello back" },
+    ]);
+    expect(parseRecentCards(json)).toEqual([
+      { kind: "user", summary: "hi" },
+      { kind: "streaming", summary: "hello back" },
+    ]);
+  });
+
+  it("skips items missing kind or summary fields", () => {
+    const json = JSON.stringify([
+      { kind: "user", summary: "ok" },
+      { kind: "tool" }, // missing summary
+      { summary: "no kind" }, // missing kind
+      "string item",
+      null,
+      { kind: "warn", summary: "trailer" },
+    ]);
+    expect(parseRecentCards(json)).toEqual([
+      { kind: "user", summary: "ok" },
+      { kind: "warn", summary: "trailer" },
+    ]);
+  });
+});
+
+describe("cardsForHeight", () => {
+  function makeCards(n: number): SceneTraceCard[] {
+    return Array.from({ length: n }, (_, i) => ({ kind: "user", summary: String(i) }));
+  }
+
+  it("returns the last (rows - 3) cards by default", () => {
+    const cards = makeCards(30);
+    const fit = cardsForHeight(cards, 24);
+    expect(fit).toHaveLength(21);
+    expect(fit[0]?.summary).toBe("9");
+    expect(fit.at(-1)?.summary).toBe("29");
+  });
+
+  it("caps at the hard ceiling (24) even on tall terminals", () => {
+    const cards = makeCards(100);
+    const fit = cardsForHeight(cards, 200);
+    expect(fit).toHaveLength(24);
+  });
+
+  it("returns at least 1 card slot even on absurdly short terminals", () => {
+    const cards = makeCards(5);
+    expect(cardsForHeight(cards, 0)).toHaveLength(1);
+    expect(cardsForHeight(cards, 2)).toHaveLength(1);
+  });
+
+  it("returns all cards when there are fewer than the available slots", () => {
+    const cards = makeCards(3);
+    expect(cardsForHeight(cards, 24)).toHaveLength(3);
+  });
+});
+
 describe("buildTraceFrame", () => {
-  it("returns a column box with four children: title, card, status, composer", () => {
-    const f = buildTraceFrame({ cardCount: 0, busy: false }, 80, 24);
+  it("returns a column box with title + placeholder + status + composer when no cards", () => {
+    const f = buildEmpty();
     expect(f.schemaVersion).toBe(1);
     expect(f.cols).toBe(80);
     expect(f.rows).toBe(24);
@@ -57,11 +133,10 @@ describe("buildTraceFrame", () => {
   });
 
   it("renders the model name in the title row when given", () => {
-    const f = buildTraceFrame({ cardCount: 0, busy: false, model: "deepseek-chat" }, 80, 24);
+    const f = buildEmpty({ model: "deepseek-chat" });
     expect(f.root.kind).toBe("box");
     if (f.root.kind !== "box") return;
     const title = f.root.children[0];
-    expect(title?.kind).toBe("text");
     if (title?.kind !== "text") return;
     const flat = title.runs.map((r) => r.text).join("");
     expect(flat).toContain("reasonix");
@@ -69,22 +144,32 @@ describe("buildTraceFrame", () => {
   });
 
   it("shows a placeholder card row when no cards exist", () => {
-    const f = buildTraceFrame({ cardCount: 0, busy: false }, 80, 24);
+    const f = buildEmpty();
     if (f.root.kind !== "box") return;
     const card = f.root.children[1];
     if (card?.kind !== "text") return;
-    const flat = card.runs.map((r) => r.text).join("");
-    expect(flat).toContain("no cards yet");
+    expect(card.runs.map((r) => r.text).join("")).toContain("no cards yet");
+  });
+
+  it("stacks one row per card between the title and status rows", () => {
+    const cards: SceneTraceCard[] = [
+      { kind: "user", summary: "hi" },
+      { kind: "streaming", summary: "hello back" },
+      { kind: "user", summary: "follow up" },
+    ];
+    const f = buildTraceFrame({ cardCount: 3, busy: false, cards }, 80, 24);
+    if (f.root.kind !== "box") return;
+    expect(f.root.children).toHaveLength(3 + 3);
+    const firstCard = f.root.children[1];
+    const lastCard = f.root.children[3];
+    if (firstCard?.kind !== "text" || lastCard?.kind !== "text") return;
+    expect(firstCard.runs[2]?.text).toBe("hi");
+    expect(lastCard.runs[2]?.text).toBe("follow up");
   });
 
   it("paints the user-card icon cyan and the text bold", () => {
     const f = buildTraceFrame(
-      {
-        cardCount: 1,
-        busy: false,
-        lastCardKind: "user",
-        lastCardSummary: "hello",
-      },
+      { cardCount: 1, busy: false, cards: [{ kind: "user", summary: "hello" }] },
       80,
       24,
     );
@@ -98,9 +183,10 @@ describe("buildTraceFrame", () => {
   });
 
   it("paints status as green when idle and yellow when busy", () => {
-    const idle = buildTraceFrame({ cardCount: 3, busy: false }, 80, 24);
-    const busy = buildTraceFrame({ cardCount: 3, busy: true }, 80, 24);
+    const idle = buildTraceFrame({ cardCount: 3, busy: false, cards: [] }, 80, 24);
+    const busy = buildTraceFrame({ cardCount: 3, busy: true, cards: [] }, 80, 24);
     if (idle.root.kind !== "box" || busy.root.kind !== "box") return;
+    // children: title, placeholder, status, composer
     const idleStatus = idle.root.children[2];
     const busyStatus = busy.root.children[2];
     if (idleStatus?.kind !== "text" || busyStatus?.kind !== "text") return;
@@ -109,19 +195,19 @@ describe("buildTraceFrame", () => {
   });
 
   it("appends activity to the status row when given", () => {
-    const f = buildTraceFrame({ cardCount: 3, busy: true, activity: "awaiting tools" }, 80, 24);
+    const f = buildTraceFrame(
+      { cardCount: 3, busy: true, cards: [], activity: "awaiting tools" },
+      80,
+      24,
+    );
     if (f.root.kind !== "box") return;
     const status = f.root.children[2];
     if (status?.kind !== "text") return;
-    const flat = status.runs.map((r) => r.text).join("");
-    expect(flat).toContain("awaiting tools");
+    expect(status.runs.map((r) => r.text).join("")).toContain("awaiting tools");
   });
 
   it("composer row is a dim placeholder when composerText is empty / undefined", () => {
-    for (const f of [
-      buildTraceFrame({ cardCount: 0, busy: false }, 80, 24),
-      buildTraceFrame({ cardCount: 0, busy: false, composerText: "" }, 80, 24),
-    ]) {
+    for (const f of [buildEmpty(), buildEmpty({ composerText: "" })]) {
       if (f.root.kind !== "box") return;
       const composer = f.root.children[3];
       if (composer?.kind !== "text") return;
@@ -132,7 +218,11 @@ describe("buildTraceFrame", () => {
   });
 
   it("composer row shows typed text plus a cursor block when composerText is non-empty", () => {
-    const f = buildTraceFrame({ cardCount: 1, busy: false, composerText: "hello" }, 80, 24);
+    const f = buildTraceFrame(
+      { cardCount: 1, busy: false, cards: [], composerText: "hello" },
+      80,
+      24,
+    );
     if (f.root.kind !== "box") return;
     const composer = f.root.children[3];
     if (composer?.kind !== "text") return;


### PR DESCRIPTION
The trace frame had one row for the latest card. Under
\`REASONIX_RENDERER=rust\` that meant the user could only see the
*current* moment of the conversation, not the history — typing a
follow-up question lost the prior assistant reply from view since
the Ink card stream is invisible behind the null stdout.

After this PR, the scene stacks one row per card between the title
and status rows:

\`\`\`
reasonix · deepseek-v4-pro
> what's the weather                  <-- recent[0]
⟐ The user is asking about today...   <-- recent[1]
● It's sunny, 22°C in your area      <-- recent[2]
> any rain tomorrow?                  <-- recent[3]
⟐ Checking forecast for tomorrow...   <-- recent[4]
● Tomorrow looks clear, …             <-- recent[5]
6 cards · idle
❯ thanks▮
\`\`\`

Capped at \`min(rows - 3, 24)\`. A 24-row terminal shows up to 21
cards; a 50-row terminal still caps at 24 to keep the JSON payload
small.

## Architecture choice — JSON string in the deps

The cards come from \`App.tsx\` as a JSON-encoded string, not a plain
array. Reason: the \`useSceneTrace\` effect deps must be primitive
— an array selector returning a new ref every render would re-fire
the effect on every keystroke even when the cards haven't changed.
JSON.stringify of a small projection (\`{kind, summary}\` × ≤24) is
shallow-equal-stable inside zustand without needing custom
comparators.

## Splits

- **\`SceneTraceCard\`** type — narrow \`{kind, summary}\` shape sent
  over the React boundary.
- **\`parseRecentCards(json)\`** — defensive deserializer; bad JSON or
  malformed items drop silently.
- **\`cardsForHeight(cards, rows)\`** — clamps the slice to terminal
  height with a 24-card hard cap. Pure function, easy to test.
- **\`buildTraceFrame\`** now takes \`cards: ReadonlyArray<...>\`
  directly, not the old \`lastCardKind\` / \`lastCardSummary\` pair.
  Tests updated.

\`App.tsx\` selector hashes the last 24 cards to JSON; the previous
\`lastCardKind\` + \`lastCardSummary\` selectors are gone (replaced by
the one JSON selector — fewer store reads per render).

## Tests

21 cases total in \`tests/scene-trace-frame.test.ts\`:

- 4 new \`parseRecentCards\` cases (empty / malformed / well-formed /
  partial items skipped).
- 4 new \`cardsForHeight\` cases (default slice, hard cap on tall
  terminals, ≥1 slot on tiny terminals, fewer-than-slots passthrough).
- One new frame assertion: "stacks one row per card between title
  and status".
- 12 existing buildTraceFrame tests updated to the new input shape.

Refs #868 #947