### PR TITLE
fix(scene): fall back to Ink when REASONIX_RENDERER=rust + no saved key

### DIFF
--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -353,7 +353,19 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
     }
   }
 
-  const rustRendererActive = process.env.REASONIX_RENDERER === "rust";
+  const rustRendererRequested = process.env.REASONIX_RENDERER === "rust";
+  // If REASONIX_RENDERER=rust is set but no API key is saved, the first screen
+  // is Setup — which renders to Ink's stdout and reads stdin directly. Under
+  // the Rust path both would be the null streams, leaving the user typing their
+  // key blind. Fall back to the Ink renderer for this launch; the next launch
+  // (with the key saved) gets the Rust path.
+  const rustRendererActive = rustRendererRequested && initialKey !== undefined;
+  if (rustRendererRequested && !rustRendererActive) {
+    process.stderr.write(
+      "REASONIX_RENDERER=rust ignored for this launch: no saved API key. " +
+        "Complete Setup once, then re-launch with the flag.\n",
+    );
+  }
   const inkStdout = rustRendererActive ? makeNullStdout() : undefined;
   const inkStdin = rustRendererActive ? makeNullStdin() : undefined;
   const inputCmdOverride = parseInputCmd(process.env.REASONIX_INPUT_CMD);


### PR DESCRIPTION
A fresh install hitting \`REASONIX_RENDERER=rust reasonix\` cold lands
on the Setup screen — and Setup is invisible. It renders to Ink's
stdout (the null stream under the Rust path) and reads stdin
directly via Ink's \`useInput\` (also the null stream). The user
types the API key blind, never sees the prompts, never sees their
input.

Stage 2's keystroke adapter doesn't help here: Setup isn't wrapped
in \`KeystrokeProvider\`, and even if it were, the visual still
wouldn't appear because the trace frame is built from app state —
Setup isn't in the state.

## What this PR does

Sidesteps the problem for now: if no saved API key, ignore the env
flag this launch. The session runs entirely in Ink (real stdio),
Setup works as it always did, the user enters their key, the
session continues normally. Next launch with the key persisted, the
Rust path engages.

stderr gets a one-line notice so the user understands why the flag
they set was ignored:

\`\`\`
REASONIX_RENDERER=rust ignored for this launch: no saved API key.
Complete Setup once, then re-launch with the flag.
\`\`\`

## What this PR is NOT

This is not the real fix for Setup-in-Rust-mode. Stage 3 (flip
default) will need:

- \`Setup.tsx\` swapped from Ink's \`useInput\` to \`useKeystroke\` so the
  spawned input child can deliver keystrokes
- A scene-producer extension that covers the Setup phase so the
  visual prompts show in the Rust-rendered frame
- Same for \`SessionPicker\` (also Ink-rendered, also invisible under
  null stdout — but at least it has \`KeystrokeProvider\` already)

Tracked for that larger PR, not this one. This PR is the smallest
change that unblocks fresh users today.

## Test

Manual: with no saved API key (clear \`~/.reasonix/config.json\` or
unset \`DEEPSEEK_API_KEY\` if that's all you have), run
\`REASONIX_RENDERER=rust reasonix chat\`. Expect a stderr line then
the normal Ink Setup screen. Complete it; the session proceeds in
Ink. Restart, this time with the key persisted: Rust path engages.

Refs #868 #947