### PR TITLE
fix(scene): redirect Node stderr to a log file under REASONIX_RENDERER=rust

### DIFF
--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -1,3 +1,6 @@
+import { closeSync, mkdirSync, openSync, writeSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { render } from "ink";
 import React, { useState } from "react";
 import {
@@ -51,6 +54,34 @@ function parseInputCmd(raw: string | undefined): readonly string[] | undefined {
     // fall through
   }
   return undefined;
+}
+
+// Under REASONIX_RENDERER=rust the alt-screen is owned by the Rust child. Any
+// stderr write from the Node parent overwrites whatever ratatui just drew at
+// the same cells, and stays visible until the next frame redraws — so Node's
+// own warnings (MaxListeners etc.) and any stray library logs all corrupt the
+// view. Redirect stderr to a log file for the duration of the session.
+function redirectStderrToLogFile(): () => void {
+  const dir = join(homedir(), ".reasonix");
+  mkdirSync(dir, { recursive: true });
+  const logPath = join(dir, "rust-render-stderr.log");
+  const fd = openSync(logPath, "a");
+  const origWrite = process.stderr.write.bind(process.stderr);
+  (process.stderr.write as unknown as (chunk: string | Uint8Array) => boolean) = (
+    chunk: string | Uint8Array,
+  ): boolean => {
+    const buf = typeof chunk === "string" ? Buffer.from(chunk, "utf8") : Buffer.from(chunk);
+    writeSync(fd, buf);
+    return true;
+  };
+  return () => {
+    process.stderr.write = origWrite;
+    try {
+      closeSync(fd);
+    } catch {
+      // already closed — ignore
+    }
+  };
 }
 
 export interface ChatOptions {
@@ -360,6 +391,7 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
   const keystrokeReader = rustRendererActive
     ? createRustKeystrokeReader(inputCmdOverride ? { command: inputCmdOverride } : {})
     : undefined;
+  const stderrRestore = rustRendererActive ? redirectStderrToLogFile() : undefined;
 
   const { waitUntilExit } = render(
     <Root
@@ -403,6 +435,7 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
     await runtime.closeAll();
     qqChannel?.stop();
     if (keystrokeReader) await keystrokeReader.close();
+    if (stderrRestore) stderrRestore();
     // Eat any pending terminal-feature-detection responses (#365) so the
     // parent shell doesn't print them as junk after exit.
     await drainTtyResponses();

--- a/src/cli/ui/scene/null-stdout.ts
+++ b/src/cli/ui/scene/null-stdout.ts
@@ -6,6 +6,12 @@ export function makeNullStdout(real: NodeJS.WriteStream = process.stdout): NodeJ
       callback();
     },
   });
+  // Ink consumers — every <Box>/<Text>/useStdout — subscribe to the stdout's
+  // `resize` event. The App tree has 11+ such subscribers, which trips Node's
+  // default 10-listener leak warning. The warning text then writes to stderr
+  // and corrupts the alt-screen the Rust child draws (the user sees garbage
+  // mid-row). Raise the cap above the realistic subscriber count.
+  writable.setMaxListeners(50);
   applyDimensions(writable, real);
   if (typeof real.on === "function") {
     real.on("resize", () => {


### PR DESCRIPTION
Two cousins of one screen-corruption bug, caught during the
2026-05-15 manual smoke test. The user saw their composer row
overwritten by raw Node \`MaxListenersExceededWarning\` text mid-row.

## Symptoms (user screenshot)

\`\`\`
reasonix · deepseek-v4-pro
· live
9(node:41912) MaxListenersExceededWarning: Possible EventEmitter…
ita(type a message)rs is 10. Use emitter.setMaxListeners() to inc…
(Use \`node --trace-warnings ...\` to show where the warning was c…
\`\`\`

The status row (\`9 cards · …\`) and composer row (\`❯ (type a message)\`)
are interleaved with Node's warning. The warning persists until the
next frame redraws (which won't happen if input also gets stuck).

## Two root causes

1. **Ink subscribes to its stdout's \`resize\` event from every
   \`useStdout\` consumer.** App has 11+ such components, which trips
   Node's default 10-listener leak warning. The warning text writes
   to stderr.
2. **Under \`REASONIX_RENDERER=rust\` the alt-screen is owned by the
   Rust child.** Any stderr write from the Node parent overwrites
   whatever ratatui drew at the same cells.

## Fix both ends

- \`makeNullStdout()\` calls \`setMaxListeners(50)\` on its return value
  so the realistic Ink subscriber count fits under the cap and the
  MaxListeners warning never fires.
- \`chatCommand\` redirects \`process.stderr.write\` to
  \`~/.reasonix/rust-render-stderr.log\` for the duration of the
  session when the Rust path is active. Restored in the \`finally\`
  block alongside the other cleanup.

Even with \`setMaxListeners\`, library code or future warnings could
still hit stderr — the log-file redirect catches all of them. The
log persists across sessions so a user noticing missing output can
tail it.

## Limitations

- Rust child's stderr is still \`"inherit"\` — its errors (rare)
  still print to the terminal and corrupt the screen. Routing the
  Rust child's stderr to a separate file is a follow-up if it ever
  bites.
- The redirect only covers writes via \`process.stderr.write\`. Code
  that opens fd 2 directly (rare in Node) bypasses it.

Refs #868 #947