### PR TITLE
fix(rust): advance render cursor by char display width, not codepoint count

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,6 +333,7 @@ dependencies = [
  "ratatui",
  "serde",
  "serde_json",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]

--- a/crates/reasonix-render/Cargo.toml
+++ b/crates/reasonix-render/Cargo.toml
@@ -11,3 +11,4 @@ crossterm = "0.28"
 ratatui = "0.29"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+unicode-width = "0.2"

--- a/crates/reasonix-render/src/render.rs
+++ b/crates/reasonix-render/src/render.rs
@@ -1,6 +1,7 @@
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::style::{Color as RColor, Modifier, Style};
+use unicode_width::UnicodeWidthChar;
 
 use crate::scene::{
     BoxLayout, Color, FlexDirection, NamedColor, SceneFrame, SceneNode, TextRun, TextStyle,
@@ -31,15 +32,23 @@ fn render_text_runs(runs: &[TextRun], buf: &mut Buffer, area: Rect) {
         }
         let style = ratatui_style(run.style.as_ref());
         for ch in run.text.chars() {
-            if x >= max_x {
+            let w = display_width(ch);
+            if w == 0 {
+                continue;
+            }
+            if x.saturating_add(w) > max_x {
                 break;
             }
             let cell = &mut buf[(x, area.y)];
             cell.set_char(ch);
             cell.set_style(style);
-            x = x.saturating_add(1);
+            x = x.saturating_add(w);
         }
     }
+}
+
+fn display_width(ch: char) -> u16 {
+    UnicodeWidthChar::width(ch).unwrap_or(0) as u16
 }
 
 fn render_box(layout: Option<&BoxLayout>, children: &[SceneNode], buf: &mut Buffer, area: Rect) {
@@ -173,8 +182,12 @@ fn intrinsic_height(node: &SceneNode) -> u16 {
 fn intrinsic_width(node: &SceneNode) -> u16 {
     match node {
         SceneNode::Text { runs, .. } => {
-            let chars: usize = runs.iter().map(|r| r.text.chars().count()).sum();
-            chars.min(u16::MAX as usize) as u16
+            let cells: usize = runs
+                .iter()
+                .flat_map(|r| r.text.chars())
+                .map(|c| display_width(c) as usize)
+                .sum();
+            cells.min(u16::MAX as usize) as u16
         }
         SceneNode::Box {
             layout, children, ..

--- a/crates/reasonix-render/tests/render.rs
+++ b/crates/reasonix-render/tests/render.rs
@@ -25,6 +25,30 @@ fn collect_row(buf: &Buffer, y: u16, width: u16) -> String {
 }
 
 #[test]
+fn cjk_chars_advance_by_their_display_width_so_neighbors_dont_overlap() {
+    // Smoke test for the wide-char bug seen on 2026-05-15: typing 测试123
+    // showed up as "测 23" because every char advanced x by 1 instead of by
+    // the char's display width.
+    let frame = frame_of(SceneNode::Text {
+        runs: vec![TextRun {
+            text: "测试123".to_string(),
+            style: None,
+        }],
+        wrap: None,
+    });
+    let area = Rect::new(0, 0, 20, 1);
+    let mut buf = Buffer::empty(area);
+    render_frame(&frame, &mut buf, area);
+    // Cell 0 holds 测 (width 2); cell 1 is the continuation. Cell 2 holds 试
+    // (width 2); cell 3 continuation. Cells 4/5/6 hold 1/2/3.
+    assert_eq!(buf[(0, 0)].symbol(), "测");
+    assert_eq!(buf[(2, 0)].symbol(), "试");
+    assert_eq!(buf[(4, 0)].symbol(), "1");
+    assert_eq!(buf[(5, 0)].symbol(), "2");
+    assert_eq!(buf[(6, 0)].symbol(), "3");
+}
+
+#[test]
 fn renders_a_plain_text_frame_at_row_zero() {
     let frame = frame_of(SceneNode::Text {
         runs: vec![TextRun {


### PR DESCRIPTION
The render loop did \`x += 1\` for every char. East-Asian wide chars
(CJK 测/试/中, fullwidth punctuation, some box-drawing) are 2 cells
wide, so the next char got written at the cell that was already
covered by the wide char's right half. ratatui's flush logic
silently dropped one of them.

Symptom (2026-05-15 smoke test):

\`\`\`
typed:    测试123
composer: ❯ 测 23▮     (试 and 1 both lost to overlap)
\`\`\`

## Fix

\`unicode-width::UnicodeWidthChar\` gives the actual display width.
Render loop advances \`x\` by that width per char. Zero-width chars
(combining marks, control codes surviving past the input parser)
skip without consuming a cell. Multi-cell chars consume the full
width and leave the continuation cell blank — which is what ratatui
expects.

Same fix on \`intrinsic_width\` for box layout — was counting
codepoints, now counts display cells.

## Test

\`cjk_chars_advance_by_their_display_width_so_neighbors_dont_overlap\`
renders \`测试123\` into a buffer and asserts each char lands at the
correct column (0, 2, 4, 5, 6 — not 0, 1, 2, 3, 4).

## Dep added

\`unicode-width = "0.2"\` — small (\`<10kb\`), no transitive deps,
de-facto standard in the Rust TUI ecosystem (ratatui itself pulls
it transitively, so the workspace already has it cached).

Refs #868 #947