### PR TITLE
refactor(app): extract noTakeoverOverlay constant, dedupe 5 live-row guards

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -722,6 +722,21 @@ function AppInner({
     !!pendingRevision ||
     !!stagedCheckpointRevise ||
     !!pendingCheckpoint;
+  // Truthy when the live activity rows (ongoing tool, subagent stack, thinking
+  // row, plan live row) can render. Hidden whenever a take-over modal is up so
+  // they don't fight the picker for visual attention. Tighter than `modalOpen` —
+  // doesn't include model/theme/copy-mode pickers that overlay without owning
+  // the bottom rows.
+  const noTakeoverOverlay =
+    !pendingShell &&
+    !pendingPath &&
+    !pendingPlan &&
+    !pendingReviseEditor &&
+    !pendingSessionsPicker &&
+    !pendingCheckpointPicker &&
+    !pendingMcpHub &&
+    !stagedInput &&
+    !pendingEditReview;
   // Plan-mode indicator 闂?displayed in the StatsPanel, mirrored onto
   // the ToolRegistry so dispatch enforces read-only. Toggled via the
   // `/plan` slash and PlanConfirm picker. Ephemeral 闂?not persisted
@@ -3909,41 +3924,13 @@ function AppInner({
           attention. They come back naturally once the user chooses and
           the next turn begins.
         */}
-                  {!pendingShell &&
-                  !pendingPath &&
-                  !pendingPlan &&
-                  !pendingReviseEditor &&
-                  !pendingSessionsPicker &&
-                  !pendingCheckpointPicker &&
-                  !pendingMcpHub &&
-                  !stagedInput &&
-                  !pendingEditReview &&
-                  ongoingTool ? (
+                  {noTakeoverOverlay && ongoingTool ? (
                     <OngoingToolRow tool={ongoingTool} progress={toolProgress} />
                   ) : null}
-                  {!pendingShell &&
-                  !pendingPath &&
-                  !pendingPlan &&
-                  !pendingReviseEditor &&
-                  !pendingSessionsPicker &&
-                  !pendingCheckpointPicker &&
-                  !pendingMcpHub &&
-                  !stagedInput &&
-                  !pendingEditReview &&
-                  subagentActivities.length > 0 ? (
+                  {noTakeoverOverlay && subagentActivities.length > 0 ? (
                     <SubagentLiveStack activities={subagentActivities} max={3} />
                   ) : null}
-                  {!pendingShell &&
-                  !pendingPath &&
-                  !pendingPlan &&
-                  !pendingReviseEditor &&
-                  !pendingSessionsPicker &&
-                  !pendingCheckpointPicker &&
-                  !pendingMcpHub &&
-                  !stagedInput &&
-                  !pendingEditReview &&
-                  !ongoingTool &&
-                  statusLine ? (
+                  {noTakeoverOverlay && !ongoingTool && statusLine ? (
                     <ThinkingRow text={statusLine} />
                   ) : null}
                   {undoBanner &&
@@ -3963,32 +3950,10 @@ function AppInner({
                     <UndoBanner banner={undoBanner} />
                   ) : null}
                   {/* Activity row when no targeted indicator is visible 闂?phase label from useActivityLabel. */}
-                  {!pendingShell &&
-                  !pendingPath &&
-                  !pendingPlan &&
-                  !pendingReviseEditor &&
-                  !pendingSessionsPicker &&
-                  !pendingCheckpointPicker &&
-                  !pendingMcpHub &&
-                  !stagedInput &&
-                  !pendingEditReview &&
-                  busy &&
-                  !isStreaming &&
-                  !ongoingTool &&
-                  !statusLine ? (
+                  {noTakeoverOverlay && busy && !isStreaming && !ongoingTool && !statusLine ? (
                     <ThinkingRow text={activityLabel} />
                   ) : null}
-                  {!pendingShell &&
-                  !pendingPath &&
-                  !pendingPlan &&
-                  !pendingReviseEditor &&
-                  !pendingSessionsPicker &&
-                  !pendingCheckpointPicker &&
-                  !pendingMcpHub &&
-                  !stagedInput &&
-                  !pendingEditReview ? (
-                    <PlanLiveRow />
-                  ) : null}
+                  {noTakeoverOverlay ? <PlanLiveRow /> : null}
                   <ToastRail />
                 </Box>
                 {stagedInput ? (


### PR DESCRIPTION
First sub-PR of #565 phase 2. Not a sub-component extraction yet —
pure dedupe of the guard expression that gates whether the "live
activity" rows render. The helper boolean is what the component
extraction in a follow-up PR will use as its visibility prop.

## What

App.tsx had five JSX blocks each repeating the same nine-condition
chain:

\`\`\`tsx
{!pendingShell && !pendingPath && !pendingPlan &&
 !pendingReviseEditor && !pendingSessionsPicker &&
 !pendingCheckpointPicker && !pendingMcpHub && !stagedInput &&
 !pendingEditReview && <extra> ? <LiveRow /> : null}
\`\`\`

Replaced with:

\`\`\`tsx
{noTakeoverOverlay && <extra> ? <LiveRow /> : null}
\`\`\`

Defined alongside the existing \`modalOpen\` so the two distinct
"which UI is up" concepts live next to each other.

## Why \`noTakeoverOverlay\`, not \`modalOpen\`

\`modalOpen\` is the broader check used by global hotkey gates — it
includes the model picker, theme picker, copy-mode overlay, etc.
Those overlay on top of the bottom rows without claiming them, so
live rows still render underneath them. \`noTakeoverOverlay\` is the
narrower "no picker has stolen the bottom rows" check that the
five live-row sites actually want.

## Blocks consolidated

- OngoingToolRow
- SubagentLiveStack
- ThinkingRow (statusLine variant)
- ThinkingRow (activityLabel variant)
- PlanLiveRow

## Blocks NOT consolidated (deliberately)

UndoBanner has a different rule — it allows pendingPath but
additionally excludes pendingChoice, stagedChoiceCustom,
pendingRevision, stagedCheckpointRevise, pendingCheckpoint. Folding
those into \`noTakeoverOverlay\` would change visibility for the
other rows. A separate constant for UndoBanner is a follow-up if it
ever needs more callers.

## Metric

\`App.tsx\` 4368 → 4333 lines (-35).

3034 tests pass; full \`npm test\` green.

Refs #565 #868