### PR TITLE
fix: don't pass undefined stdout/stdin to Ink render()

### DIFF
--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -423,8 +423,7 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
       qqErrorRef={qqErrorRef}
     />,
     {
-      stdout: inkStdout,
-      stdin: inkStdin,
+      ...(rustRendererActive ? { stdout: inkStdout, stdin: inkStdin } : {}),
       exitOnCtrlC: true,
       // patchConsole:false — winpty/MINTTY redraw-glitch source.
       patchConsole: false,


### PR DESCRIPTION
When `rustRendererActive` is `false` (the default), `inkStdout` and `inkStdin` are `undefined`. Passing `{ stdout: undefined }` to `render()` overrides Ink's internal `process.stdout` default, causing:

```
TypeError: Cannot read properties of undefined (reading 'isTTY')
    at Ink.resolveInteractiveOption
```

This happens on every `reasonix code` launch (without `REASONIX_RENDERER=rust`).

Only spread `stdout/stdin` into render options when the Rust renderer is actually active — otherwise let Ink fall back to its defaults.