### PR TITLE
feat(scene): place composer ▮ at the live cursor offset, not always end

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -477,6 +477,7 @@ function AppInner({
   const activityLabel = useActivityLabel();
   const chatScroll = useChatScrollActions();
   const [input, setInput] = useState("");
+  const [composerCursor, setComposerCursor] = useState(0);
   const [busy, setBusy] = useState(false);
   const [slashUsage, setSlashUsage] = useState<Readonly<Record<string, number>>>(() =>
     loadSlashUsage(),
@@ -519,6 +520,7 @@ function AppInner({
     model,
     recentCardsJson,
     composerText: input,
+    composerCursor,
   });
   const {
     ongoingTool,
@@ -4294,6 +4296,7 @@ function AppInner({
                             onHistoryPrev={handleHistoryPrev}
                             onHistoryNext={handleHistoryNext}
                             onOpenExternalEditor={handleOpenExternalEditor}
+                            onCursorChange={setComposerCursor}
                           />
                         </Box>
                         <Box flexDirection="column" flexShrink={0} flexWrap="nowrap">

--- a/src/cli/ui/PromptInput.tsx
+++ b/src/cli/ui/PromptInput.tsx
@@ -1,5 +1,5 @@
 import { Box, Text, useStdout } from "ink";
-import React, { useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { t } from "../../i18n/index.js";
 import { useKeystroke } from "./keystroke-context.js";
 import { useReserveRows } from "./layout/viewport-budget.js";
@@ -38,6 +38,7 @@ export interface PromptInputProps {
   onHistoryNext?: () => void;
   /** Ctrl+X — parent spawns $EDITOR with the current buffer and re-injects on exit. */
   onOpenExternalEditor?: () => void;
+  onCursorChange?: (cursor: number) => void;
 }
 
 export function PromptInput({
@@ -49,6 +50,7 @@ export function PromptInput({
   onHistoryPrev,
   onHistoryNext,
   onOpenExternalEditor,
+  onCursorChange,
 }: PromptInputProps) {
   // Cap at 24 — collapseLinesForDisplay hides content past ~20 logical lines.
   // Quantize spec.max to 4-row buckets so per-keystroke line-count changes
@@ -59,6 +61,10 @@ export function PromptInput({
   useReserveRows("input", { min: 1, max: reserveMax });
 
   const [cursor, setCursor] = useState(value.length);
+
+  useEffect(() => {
+    onCursorChange?.(cursor);
+  }, [cursor, onCursorChange]);
 
   // Paste registry — keyed by sentinel id, holds original content.
   const pastesRef = useRef<Map<number, PasteEntry>>(new Map());

--- a/src/cli/ui/hooks/useSceneTrace.ts
+++ b/src/cli/ui/hooks/useSceneTrace.ts
@@ -16,6 +16,7 @@ export type SceneTraceInput = {
   activity?: string;
   /** Current composer text — what the user is typing but has not yet submitted. */
   composerText?: string;
+  composerCursor?: number;
 };
 
 type BuildInput = {
@@ -25,6 +26,7 @@ type BuildInput = {
   busy: boolean;
   activity?: string;
   composerText?: string;
+  composerCursor?: number;
 };
 
 const SUMMARY_MAX = 70;
@@ -106,10 +108,12 @@ function composerRow(s: BuildInput): SceneNode {
   const t = s.composerText ?? "";
   if (t.length === 0) {
     runs.push({ text: "(type a message)", style: { dim: true } });
-  } else {
-    runs.push({ text: t });
-    runs.push({ text: "▮", style: { color: "cyan" } });
+    return text(runs);
   }
+  const cur = Math.max(0, Math.min(t.length, s.composerCursor ?? t.length));
+  if (cur > 0) runs.push({ text: t.slice(0, cur) });
+  runs.push({ text: "▮", style: { color: "cyan" } });
+  if (cur < t.length) runs.push({ text: t.slice(cur) });
   return text(runs);
 }
 
@@ -190,13 +194,17 @@ export function useSceneTrace(input: SceneTraceInput): void {
   const { stdout } = useStdout();
   const cols = stdout?.columns ?? 80;
   const rows = stdout?.rows ?? 24;
-  const { model, cardCount, recentCardsJson, busy, activity, composerText } = input;
+  const { model, cardCount, recentCardsJson, busy, activity, composerText, composerCursor } = input;
   useEffect(() => {
     if (!isSceneTraceEnabled()) return;
     const parsed = parseRecentCards(recentCardsJson);
     const cards = cardsForHeight(parsed, rows);
     emitSceneFrame(
-      buildTraceFrame({ model, cardCount, cards, busy, activity, composerText }, cols, rows),
+      buildTraceFrame(
+        { model, cardCount, cards, busy, activity, composerText, composerCursor },
+        cols,
+        rows,
+      ),
     );
-  }, [cols, rows, model, cardCount, recentCardsJson, busy, activity, composerText]);
+  }, [cols, rows, model, cardCount, recentCardsJson, busy, activity, composerText, composerCursor]);
 }

--- a/tests/scene-trace-frame.test.ts
+++ b/tests/scene-trace-frame.test.ts
@@ -231,4 +231,37 @@ describe("buildTraceFrame", () => {
     expect(composer.runs[2]?.text).toBe("▮");
     expect(composer.runs[2]?.style?.color).toBe("cyan");
   });
+
+  function composerRunsAt(cursor: number | undefined): string[] {
+    const f = buildTraceFrame(
+      { cardCount: 1, busy: false, cards: [], composerText: "hello", composerCursor: cursor },
+      80,
+      24,
+    );
+    if (f.root.kind !== "box") throw new Error("expected box");
+    const composer = f.root.children[3];
+    if (composer?.kind !== "text") throw new Error("expected text");
+    return composer.runs.map((r) => r.text);
+  }
+
+  it("splits composer text around the cursor block at an interior offset", () => {
+    expect(composerRunsAt(2)).toEqual(["❯ ", "he", "▮", "llo"]);
+  });
+
+  it("places the cursor at the start when offset is 0", () => {
+    expect(composerRunsAt(0)).toEqual(["❯ ", "▮", "hello"]);
+  });
+
+  it("places the cursor at the end when offset equals text length", () => {
+    expect(composerRunsAt(5)).toEqual(["❯ ", "hello", "▮"]);
+  });
+
+  it("clamps an out-of-range cursor to the text bounds", () => {
+    expect(composerRunsAt(99)).toEqual(["❯ ", "hello", "▮"]);
+    expect(composerRunsAt(-3)).toEqual(["❯ ", "▮", "hello"]);
+  });
+
+  it("falls back to end-of-text when composerCursor is undefined", () => {
+    expect(composerRunsAt(undefined)).toEqual(["❯ ", "hello", "▮"]);
+  });
 });


### PR DESCRIPTION
Second sub-PR under the rust direction-B plan (#868) — extend the
scene producer so more UI features render without needing the Ink tree.
First B-line win: composer cursor position.

## What

`composerRow()` in `useSceneTrace.ts` painted `▮` after the composer
text regardless of where the cursor actually was. Under
`REASONIX_RENDERER=rust` the rendered scene was the only thing the
user saw, so left/right-arrow / Home / End / Ctrl+A / Ctrl+E looked
like dead keys — the buffer mutated correctly under the hood but the
cursor never moved.

- `PromptInput` already owns the cursor offset in `useState`. It now
  publishes changes through a new optional `onCursorChange(cursor)`
  callback.
- `App.tsx` mirrors the value into local state and feeds it to
  `useSceneTrace` as `composerCursor`.
- `composerRow()` splits the text around `▮`: `text.slice(0, cur)` +
  `▮` + `text.slice(cur)`, with `cur` clamped to `[0, text.length]`.

Unchanged when `composerCursor` is omitted — falls back to end-of-text,
so existing callers and tests keep working.

## Why this layer

Direction B (per #868 discussion): rather than refactor App.tsx so the
Ink-tree lowering pass can walk it, we extend the scene producer until
Ink has nothing left to render. Composer cursor is the smallest
visible feature that the scene didn't yet cover.

## Tests

\`tests/scene-trace-frame.test.ts\` — 5 new cases covering interior /
start / end / out-of-range / undefined offsets. Existing "composer row
shows typed text plus a cursor block" assertion still passes because
the undefined-cursor path is the legacy end-of-text behaviour.

\`npm run verify\` green: 3039 / 3042 (3 pre-existing skipped).

Refs #868