### PR TITLE
feat(scene): render the slash-command suggestion overlay in scene frames

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -513,15 +513,6 @@ function AppInner({
   useEffect(() => {
     busyRef.current = busy;
   }, [busy]);
-  useSceneTrace({
-    cardCount,
-    busy,
-    activity: activityLabel,
-    model,
-    recentCardsJson,
-    composerText: input,
-    composerCursor,
-  });
   const {
     ongoingTool,
     setOngoingTool,
@@ -1311,6 +1302,29 @@ function AppInner({
     models,
     mcpServers: liveMcpServers,
     slashUsage,
+  });
+
+  const slashMatchesJson = useMemo(() => {
+    if (!slashMatches || slashMatches.length === 0) return undefined;
+    return JSON.stringify(
+      slashMatches.map((m) => ({
+        cmd: m.cmd,
+        summary: m.summary,
+        ...(m.argsHint !== undefined ? { argsHint: m.argsHint } : {}),
+      })),
+    );
+  }, [slashMatches]);
+
+  useSceneTrace({
+    cardCount,
+    busy,
+    activity: activityLabel,
+    model,
+    recentCardsJson,
+    composerText: input,
+    composerCursor,
+    slashMatchesJson,
+    slashSelectedIndex: slashMatchesJson ? slashSelected : undefined,
   });
 
   // Ctrl+P / Ctrl+N from PromptInput route here. When any input-prefix

--- a/src/cli/ui/hooks/useSceneTrace.ts
+++ b/src/cli/ui/hooks/useSceneTrace.ts
@@ -6,6 +6,7 @@ import type { Color, SceneFrame, SceneNode, TextRun } from "../scene/types.js";
 import type { Card } from "../state/cards.js";
 
 export type SceneTraceCard = { kind: string; summary: string };
+export type SceneSlashMatch = { cmd: string; summary: string; argsHint?: string };
 
 export type SceneTraceInput = {
   model?: string;
@@ -17,6 +18,9 @@ export type SceneTraceInput = {
   /** Current composer text — what the user is typing but has not yet submitted. */
   composerText?: string;
   composerCursor?: number;
+  /** JSON-encoded `SceneSlashMatch[]`; undefined/empty hides the overlay. */
+  slashMatchesJson?: string;
+  slashSelectedIndex?: number;
 };
 
 type BuildInput = {
@@ -27,6 +31,8 @@ type BuildInput = {
   activity?: string;
   composerText?: string;
   composerCursor?: number;
+  slashMatches?: ReadonlyArray<SceneSlashMatch>;
+  slashSelectedIndex?: number;
 };
 
 const SUMMARY_MAX = 70;
@@ -34,6 +40,7 @@ const SUMMARY_MAX = 70;
 const RESERVED_ROWS = 3;
 /** Hard cap so a tall terminal doesn't make the payload absurd. */
 const MAX_CARDS = 24;
+const MAX_SLASH_ROWS = 6;
 
 export function summarizeCard(card: Card | undefined): string | undefined {
   if (!card) return undefined;
@@ -71,6 +78,17 @@ export function buildTraceFrame(input: BuildInput, cols: number, rows: number): 
   }
   children.push(statusRow(input));
   children.push(composerRow(input));
+  const slash = input.slashMatches ?? [];
+  if (slash.length > 0) {
+    const sel = Math.max(0, Math.min(slash.length - 1, input.slashSelectedIndex ?? 0));
+    const { startIndex, matches: shown } = slashWindow(slash, sel);
+    for (let i = 0; i < shown.length; i++) {
+      const absoluteIndex = startIndex + i;
+      children.push(slashRow(shown[i] as SceneSlashMatch, absoluteIndex === sel));
+    }
+    const hidden = slash.length - shown.length;
+    if (hidden > 0) children.push(slashOverflowRow(hidden));
+  }
   return frame(cols, rows, box(children, { direction: "column", paddingX: 1 }));
 }
 
@@ -101,6 +119,33 @@ function statusRow(s: BuildInput): SceneNode {
   ];
   if (s.activity) runs.push({ text: ` · ${s.activity}`, style: { dim: true } });
   return text(runs);
+}
+
+function slashRow(m: SceneSlashMatch, selected: boolean): SceneNode {
+  const runs: TextRun[] = [];
+  runs.push({ text: selected ? "▸ " : "  ", style: { color: "cyan" } });
+  runs.push({ text: m.cmd, style: selected ? { bold: true, color: "cyan" } : undefined });
+  if (m.argsHint) runs.push({ text: ` ${m.argsHint}`, style: { dim: true } });
+  if (m.summary) {
+    runs.push({ text: " — ", style: { dim: true } });
+    runs.push({ text: m.summary, style: { dim: true } });
+  }
+  return text(runs);
+}
+
+function slashOverflowRow(hidden: number): SceneNode {
+  return text([{ text: `…${hidden} more`, style: { dim: true } }]);
+}
+
+export function slashWindow(
+  matches: ReadonlyArray<SceneSlashMatch>,
+  selected: number,
+): { startIndex: number; matches: ReadonlyArray<SceneSlashMatch> } {
+  if (matches.length <= MAX_SLASH_ROWS) return { startIndex: 0, matches };
+  const half = Math.floor(MAX_SLASH_ROWS / 2);
+  const maxStart = matches.length - MAX_SLASH_ROWS;
+  const startIndex = Math.max(0, Math.min(maxStart, selected - half));
+  return { startIndex, matches: matches.slice(startIndex, startIndex + MAX_SLASH_ROWS) };
 }
 
 function composerRow(s: BuildInput): SceneNode {
@@ -163,6 +208,27 @@ function colorFor(kind: string): Color {
   }
 }
 
+export function parseSlashMatches(json: string | undefined): SceneSlashMatch[] {
+  if (!json || json.length === 0) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  const out: SceneSlashMatch[] = [];
+  for (const item of parsed) {
+    if (typeof item !== "object" || item === null) continue;
+    const obj = item as Record<string, unknown>;
+    if (typeof obj.cmd !== "string" || typeof obj.summary !== "string") continue;
+    const m: SceneSlashMatch = { cmd: obj.cmd, summary: obj.summary };
+    if (typeof obj.argsHint === "string") m.argsHint = obj.argsHint;
+    out.push(m);
+  }
+  return out;
+}
+
 export function parseRecentCards(json: string | undefined): SceneTraceCard[] {
   if (!json || json.length === 0) return [];
   let parsed: unknown;
@@ -194,17 +260,50 @@ export function useSceneTrace(input: SceneTraceInput): void {
   const { stdout } = useStdout();
   const cols = stdout?.columns ?? 80;
   const rows = stdout?.rows ?? 24;
-  const { model, cardCount, recentCardsJson, busy, activity, composerText, composerCursor } = input;
+  const {
+    model,
+    cardCount,
+    recentCardsJson,
+    busy,
+    activity,
+    composerText,
+    composerCursor,
+    slashMatchesJson,
+    slashSelectedIndex,
+  } = input;
   useEffect(() => {
     if (!isSceneTraceEnabled()) return;
     const parsed = parseRecentCards(recentCardsJson);
     const cards = cardsForHeight(parsed, rows);
+    const slashMatches = parseSlashMatches(slashMatchesJson);
     emitSceneFrame(
       buildTraceFrame(
-        { model, cardCount, cards, busy, activity, composerText, composerCursor },
+        {
+          model,
+          cardCount,
+          cards,
+          busy,
+          activity,
+          composerText,
+          composerCursor,
+          slashMatches,
+          slashSelectedIndex,
+        },
         cols,
         rows,
       ),
     );
-  }, [cols, rows, model, cardCount, recentCardsJson, busy, activity, composerText, composerCursor]);
+  }, [
+    cols,
+    rows,
+    model,
+    cardCount,
+    recentCardsJson,
+    busy,
+    activity,
+    composerText,
+    composerCursor,
+    slashMatchesJson,
+    slashSelectedIndex,
+  ]);
 }

--- a/tests/scene-trace-frame.test.ts
+++ b/tests/scene-trace-frame.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
+  type SceneSlashMatch,
   type SceneTraceCard,
   buildTraceFrame,
   cardsForHeight,
   parseRecentCards,
+  parseSlashMatches,
+  slashWindow,
   summarizeCard,
 } from "../src/cli/ui/hooks/useSceneTrace.js";
 import type { Card } from "../src/cli/ui/state/cards.js";
@@ -263,5 +266,128 @@ describe("buildTraceFrame", () => {
 
   it("falls back to end-of-text when composerCursor is undefined", () => {
     expect(composerRunsAt(undefined)).toEqual(["❯ ", "hello", "▮"]);
+  });
+
+  function makeMatches(n: number): SceneSlashMatch[] {
+    return Array.from({ length: n }, (_, i) => ({
+      cmd: `/cmd${i}`,
+      summary: `summary ${i}`,
+    }));
+  }
+
+  function buildWithSlash(matches: SceneSlashMatch[], selected: number) {
+    return buildTraceFrame(
+      {
+        cardCount: 0,
+        busy: false,
+        cards: [],
+        composerText: "/",
+        slashMatches: matches,
+        slashSelectedIndex: selected,
+      },
+      80,
+      24,
+    );
+  }
+
+  it("omits slash rows when slashMatches is empty / undefined", () => {
+    const f = buildEmpty();
+    if (f.root.kind !== "box") return;
+    expect(f.root.children).toHaveLength(4);
+  });
+
+  it("appends one slash row per match below the composer with a ▸ on the selected one", () => {
+    const f = buildWithSlash(makeMatches(3), 1);
+    if (f.root.kind !== "box") return;
+    expect(f.root.children).toHaveLength(4 + 3);
+    const rows = f.root.children.slice(4);
+    const rendered = rows.map((r) => (r.kind === "text" ? r.runs.map((x) => x.text).join("") : ""));
+    expect(rendered[0]?.startsWith("  /cmd0")).toBe(true);
+    expect(rendered[1]?.startsWith("▸ /cmd1")).toBe(true);
+    expect(rendered[2]?.startsWith("  /cmd2")).toBe(true);
+  });
+
+  it("includes argsHint after the cmd when given", () => {
+    const f = buildWithSlash([{ cmd: "/model", summary: "switch model", argsHint: "<name>" }], 0);
+    if (f.root.kind !== "box") return;
+    const row = f.root.children[4];
+    if (row?.kind !== "text") return;
+    const flat = row.runs.map((r) => r.text).join("");
+    expect(flat).toContain("/model");
+    expect(flat).toContain("<name>");
+    expect(flat).toContain("switch model");
+  });
+
+  it("windows long match lists and shows an overflow row with the hidden count", () => {
+    const f = buildWithSlash(makeMatches(20), 0);
+    if (f.root.kind !== "box") return;
+    expect(f.root.children).toHaveLength(4 + 6 + 1);
+    const overflow = f.root.children.at(-1);
+    if (overflow?.kind !== "text") return;
+    expect(overflow.runs.map((r) => r.text).join("")).toContain("…14 more");
+  });
+
+  it("keeps the selected match inside the window", () => {
+    const w = slashWindow(makeMatches(20), 15);
+    expect(w.startIndex).toBe(12);
+    expect(w.matches.map((m) => m.cmd)).toEqual([
+      "/cmd12",
+      "/cmd13",
+      "/cmd14",
+      "/cmd15",
+      "/cmd16",
+      "/cmd17",
+    ]);
+  });
+
+  it("anchors the window at the end when the selection is near the tail", () => {
+    const w = slashWindow(makeMatches(20), 19);
+    expect(w.startIndex).toBe(14);
+    expect(w.matches.map((m) => m.cmd).at(-1)).toBe("/cmd19");
+  });
+
+  it("anchors the window at the start when the selection is at index 0", () => {
+    const w = slashWindow(makeMatches(20), 0);
+    expect(w.startIndex).toBe(0);
+    expect(w.matches.map((m) => m.cmd)[0]).toBe("/cmd0");
+  });
+
+  it("clamps an out-of-range slashSelectedIndex", () => {
+    const f = buildWithSlash(makeMatches(3), 99);
+    if (f.root.kind !== "box") return;
+    const rows = f.root.children.slice(4);
+    const flat = rows.map((r) => (r.kind === "text" ? r.runs.map((x) => x.text).join("") : ""));
+    expect(flat[2]?.startsWith("▸ /cmd2")).toBe(true);
+  });
+});
+
+describe("parseSlashMatches", () => {
+  it("returns [] for undefined / empty / malformed input", () => {
+    expect(parseSlashMatches(undefined)).toEqual([]);
+    expect(parseSlashMatches("")).toEqual([]);
+    expect(parseSlashMatches("not-json")).toEqual([]);
+    expect(parseSlashMatches('{"not":"array"}')).toEqual([]);
+  });
+
+  it("decodes a JSON array of slash specs and preserves optional argsHint", () => {
+    const json = JSON.stringify([
+      { cmd: "/help", summary: "show help" },
+      { cmd: "/model", summary: "switch model", argsHint: "<name>" },
+    ]);
+    expect(parseSlashMatches(json)).toEqual([
+      { cmd: "/help", summary: "show help" },
+      { cmd: "/model", summary: "switch model", argsHint: "<name>" },
+    ]);
+  });
+
+  it("skips entries missing cmd or summary", () => {
+    const json = JSON.stringify([
+      { cmd: "/ok", summary: "ok" },
+      { cmd: "/no-summary" },
+      { summary: "no-cmd" },
+      null,
+      "string",
+    ]);
+    expect(parseSlashMatches(json)).toEqual([{ cmd: "/ok", summary: "ok" }]);
   });
 });


### PR DESCRIPTION
Third sub-PR under the rust direction-B plan (#868) — keep extending
the scene producer so more UI features render without needing the
Ink tree.

## What

Under \`REASONIX_RENDERER=rust\` the slash overlay was Ink-only —
typing \`/\` showed nothing in the Rust-drawn scene, so the user
couldn't see which command they were about to fire. The scene
producer now mirrors the overlay:

- New \`SceneSlashMatch\` (\`{ cmd, summary, argsHint? }\`) surfaced
  through \`useSceneTrace\` as a JSON-encoded array plus a primitive
  \`slashSelectedIndex\`, so the effect deps stay primitive (same
  pattern as \`recentCardsJson\`).
- \`buildTraceFrame\` appends one row per match below the composer
  with a \`▸\` on the selected one, plus an optional \`…N more\`
  tail when the list exceeds \`MAX_SLASH_ROWS\` (6).
- \`slashWindow\` keeps the selected row inside a centered 6-row
  window for long match lists.
- \`App.tsx\` moves \`useSceneTrace\` below \`useCompletionPickers\`
  so it can read \`slashMatches\` / \`slashSelected\`, and JSON-encodes
  a minimal view-model via \`useMemo\` so array refs don't churn
  deps.

## What is deliberately NOT mirrored

The Ink overlay also shows section headers (group mode), an advanced
footer hint, and a yellow "no match" warning. Those are intentionally
left out of the scene version — direction B prefers shipping the
smallest visible win per PR. Adding them is a straight extension when
they show up as a felt gap.

## Tests

\`tests/scene-trace-frame.test.ts\` — 11 new cases:

- omitted slashMatches keeps the frame at 4 rows
- one row per match with \`▸\` on the selected one
- \`argsHint\` rendered between cmd and summary
- long lists windowed at 6 with an overflow row
- \`slashWindow\` centering + start/end anchor behavior
- out-of-range \`slashSelectedIndex\` clamped to the last match
- \`parseSlashMatches\` round-trips, drops malformed entries, returns
  \`[]\` on undefined / empty / non-array / non-JSON input

\`npm run verify\` green (green via prepush gate).

Refs #868
