### PR TITLE
feat(scene): render approval/confirm modals as a y/n stub row

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -1315,6 +1315,15 @@ function AppInner({
     );
   }, [slashMatches]);
 
+  const sceneApproval = useMemo(() => {
+    if (pendingShell) return { kind: "shell", prompt: pendingShell.command };
+    if (pendingPath) return { kind: "path", prompt: `${pendingPath.intent} ${pendingPath.path}` };
+    if (pendingEditReview) return { kind: "edit", prompt: `review ${pendingEditReview.path}` };
+    if (pendingChoice) return { kind: "choice", prompt: pendingChoice.question };
+    if (pendingPlan) return { kind: "plan", prompt: "approve plan" };
+    return null;
+  }, [pendingShell, pendingPath, pendingEditReview, pendingChoice, pendingPlan]);
+
   useSceneTrace({
     cardCount,
     busy,
@@ -1325,6 +1334,8 @@ function AppInner({
     composerCursor,
     slashMatchesJson,
     slashSelectedIndex: slashMatchesJson ? slashSelected : undefined,
+    approvalKind: sceneApproval?.kind,
+    approvalPrompt: sceneApproval?.prompt,
   });
 
   // Ctrl+P / Ctrl+N from PromptInput route here. When any input-prefix

--- a/src/cli/ui/hooks/useSceneTrace.ts
+++ b/src/cli/ui/hooks/useSceneTrace.ts
@@ -21,6 +21,9 @@ export type SceneTraceInput = {
   /** JSON-encoded `SceneSlashMatch[]`; undefined/empty hides the overlay. */
   slashMatchesJson?: string;
   slashSelectedIndex?: number;
+  /** When set, replaces the composer row with a `❓ <prompt> [y/n]` modal stub. */
+  approvalKind?: string;
+  approvalPrompt?: string;
 };
 
 type BuildInput = {
@@ -33,7 +36,11 @@ type BuildInput = {
   composerCursor?: number;
   slashMatches?: ReadonlyArray<SceneSlashMatch>;
   slashSelectedIndex?: number;
+  approvalKind?: string;
+  approvalPrompt?: string;
 };
+
+const APPROVAL_PROMPT_MAX = 60;
 
 const SUMMARY_MAX = 70;
 /** Reserved rows for title + status + composer; the rest can hold cards. */
@@ -77,9 +84,13 @@ export function buildTraceFrame(input: BuildInput, cols: number, rows: number): 
     for (const c of input.cards) children.push(cardRow(c));
   }
   children.push(statusRow(input));
-  children.push(composerRow(input));
+  if (input.approvalPrompt) {
+    children.push(approvalRow(input.approvalKind, input.approvalPrompt));
+  } else {
+    children.push(composerRow(input));
+  }
   const slash = input.slashMatches ?? [];
-  if (slash.length > 0) {
+  if (!input.approvalPrompt && slash.length > 0) {
     const sel = Math.max(0, Math.min(slash.length - 1, input.slashSelectedIndex ?? 0));
     const { startIndex, matches: shown } = slashWindow(slash, sel);
     for (let i = 0; i < shown.length; i++) {
@@ -118,6 +129,16 @@ function statusRow(s: BuildInput): SceneNode {
     { text: s.busy ? "busy" : "idle", style: { color: s.busy ? "yellow" : "green" } },
   ];
   if (s.activity) runs.push({ text: ` · ${s.activity}`, style: { dim: true } });
+  return text(runs);
+}
+
+function approvalRow(kind: string | undefined, prompt: string): SceneNode {
+  const clipped =
+    prompt.length > APPROVAL_PROMPT_MAX ? `${prompt.slice(0, APPROVAL_PROMPT_MAX - 1)}…` : prompt;
+  const runs: TextRun[] = [{ text: "❓ ", style: { color: "yellow", bold: true } }];
+  if (kind) runs.push({ text: `[${kind}] `, style: { dim: true } });
+  runs.push({ text: clipped });
+  runs.push({ text: "  [y/n]", style: { color: "yellow", bold: true } });
   return text(runs);
 }
 
@@ -270,6 +291,8 @@ export function useSceneTrace(input: SceneTraceInput): void {
     composerCursor,
     slashMatchesJson,
     slashSelectedIndex,
+    approvalKind,
+    approvalPrompt,
   } = input;
   useEffect(() => {
     if (!isSceneTraceEnabled()) return;
@@ -288,6 +311,8 @@ export function useSceneTrace(input: SceneTraceInput): void {
           composerCursor,
           slashMatches,
           slashSelectedIndex,
+          approvalKind,
+          approvalPrompt,
         },
         cols,
         rows,
@@ -305,5 +330,7 @@ export function useSceneTrace(input: SceneTraceInput): void {
     composerCursor,
     slashMatchesJson,
     slashSelectedIndex,
+    approvalKind,
+    approvalPrompt,
   ]);
 }

--- a/tests/scene-trace-frame.test.ts
+++ b/tests/scene-trace-frame.test.ts
@@ -361,6 +361,78 @@ describe("buildTraceFrame", () => {
   });
 });
 
+describe("buildTraceFrame approval modal", () => {
+  function buildWithApproval(kind: string | undefined, prompt: string | undefined) {
+    return buildTraceFrame(
+      {
+        cardCount: 0,
+        busy: false,
+        cards: [],
+        composerText: "typing…",
+        approvalKind: kind,
+        approvalPrompt: prompt,
+      },
+      80,
+      24,
+    );
+  }
+
+  it("replaces the composer row with an approval row when approvalPrompt is set", () => {
+    const f = buildWithApproval("shell", "rm -rf /tmp/x");
+    if (f.root.kind !== "box") return;
+    expect(f.root.children).toHaveLength(4);
+    const row = f.root.children[3];
+    if (row?.kind !== "text") return;
+    const flat = row.runs.map((r) => r.text).join("");
+    expect(flat).toContain("❓");
+    expect(flat).toContain("[shell]");
+    expect(flat).toContain("rm -rf /tmp/x");
+    expect(flat).toContain("[y/n]");
+    expect(flat).not.toContain("❯");
+    expect(flat).not.toContain("typing…");
+  });
+
+  it("clips an overlong approval prompt to 60 chars with an ellipsis", () => {
+    const long = "x".repeat(120);
+    const f = buildWithApproval("shell", long);
+    if (f.root.kind !== "box") return;
+    const row = f.root.children[3];
+    if (row?.kind !== "text") return;
+    const promptRun = row.runs.find((r) => r.text.includes("x"));
+    expect(promptRun?.text).toHaveLength(60);
+    expect(promptRun?.text.endsWith("…")).toBe(true);
+  });
+
+  it("omits the kind tag when approvalKind is undefined", () => {
+    const f = buildWithApproval(undefined, "go ahead?");
+    if (f.root.kind !== "box") return;
+    const row = f.root.children[3];
+    if (row?.kind !== "text") return;
+    const flat = row.runs.map((r) => r.text).join("");
+    expect(flat).not.toContain("[]");
+    expect(flat).toContain("go ahead?");
+  });
+
+  it("hides the slash overlay while an approval is active", () => {
+    const f = buildTraceFrame(
+      {
+        cardCount: 0,
+        busy: false,
+        cards: [],
+        composerText: "/",
+        slashMatches: [{ cmd: "/help", summary: "show help" }],
+        slashSelectedIndex: 0,
+        approvalKind: "shell",
+        approvalPrompt: "rm -rf /tmp/x",
+      },
+      80,
+      24,
+    );
+    if (f.root.kind !== "box") return;
+    expect(f.root.children).toHaveLength(4);
+  });
+});
+
 describe("parseSlashMatches", () => {
   it("returns [] for undefined / empty / malformed input", () => {
     expect(parseSlashMatches(undefined)).toEqual([]);


### PR DESCRIPTION
Fourth sub-PR under the rust direction-B plan (#868).

## What

Under \`REASONIX_RENDERER=rust\` the various pending\* confirmation
modals — shell command, sandbox path, edit review, free-form choice,
plan approval — had no scene representation. The user saw the
composer prompt while the loop was actually waiting on a y/n. The
composer is now replaced with a stub row whenever any of those
states is set:

\`\`\`
❓ [shell] rm -rf /tmp/x  [y/n]
\`\`\`

- New \`SceneTraceInput.approvalKind\` / \`approvalPrompt\` scalar pair
  — primitives keep effect deps stable (no JSON encoding needed for
  one object with two strings).
- \`buildTraceFrame\`: when \`approvalPrompt\` is set, push \`approvalRow\`
  in place of \`composerRow\`, and suppress the slash overlay so the
  modal owns the bottom of the frame.
- Prompt clipped to 60 chars with a trailing ellipsis so a long
  shell command stays readable.
- \`App.tsx\` derives the pair via \`useMemo\` from \`pendingShell\` /
  \`pendingPath\` / \`pendingEditReview\` / \`pendingChoice\` /
  \`pendingPlan\`, in that priority order.

## Deliberately a stub

Per-modal refinement (the choice options for \`pendingChoice\`, a diff
preview for \`pendingEditReview\`, the full plan text and Approve/Refine/
Cancel for \`pendingPlan\`, etc.) lives in later sub-PRs — this is the
"smallest visible win" so the user at least knows the loop is blocked
on a yes/no question.

Also skipped on purpose: \`pendingSessionsPicker\` /
\`pendingCheckpointPicker\` / \`pendingMcpHub\` (list-pickers, get their
own scene step — handoff step #5), \`pendingReviseEditor\` (full editor
takeover, owns the screen), \`stagedInput\` / \`stagedChoiceCustom\`
(free-form input where the composer should remain visible).

## Tests

\`tests/scene-trace-frame.test.ts\` — 4 new cases:

- approval row replaces composer; the run sequence contains the kind
  tag, the prompt, and the \`[y/n]\` suffix
- overlong prompts are clipped to 60 chars with an ellipsis
- kind tag is omitted when \`approvalKind\` is undefined
- slash overlay is suppressed while an approval is active

\`npm run verify\` green via prepush gate.

Refs #868