### PR TITLE
feat(scene): render the SessionPicker list inside the scene frame

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -628,6 +628,7 @@ function AppInner({
   /** True while the SessionPicker is open mid-chat (triggered by `/sessions`). */
   const [pendingSessionsPicker, setPendingSessionsPicker] = useState(false);
   const [sessionsPickerList, setSessionsPickerList] = useState<ReturnType<typeof listSessions>>([]);
+  const [sessionsPickerFocus, setSessionsPickerFocus] = useState(0);
   /** True while the CheckpointPicker is open mid-chat (triggered by bare `/restore`). */
   const [pendingCheckpointPicker, setPendingCheckpointPicker] = useState(false);
   const [checkpointPickerList, setCheckpointPickerList] = useState<CheckpointMeta[]>([]);
@@ -1315,6 +1316,17 @@ function AppInner({
     );
   }, [slashMatches]);
 
+  const sessionsJson = useMemo(() => {
+    if (!pendingSessionsPicker || sessionsPickerList.length === 0) return undefined;
+    return JSON.stringify(
+      sessionsPickerList.map((s) => {
+        const branch = s.meta.branch ?? "main";
+        const turns = s.meta.turnCount ?? Math.ceil(s.messageCount / 2);
+        return { title: s.name, meta: `${branch} · ${turns} turns` };
+      }),
+    );
+  }, [pendingSessionsPicker, sessionsPickerList]);
+
   const sceneApproval = useMemo(() => {
     if (pendingShell) return { kind: "shell", prompt: pendingShell.command };
     if (pendingPath) return { kind: "path", prompt: `${pendingPath.intent} ${pendingPath.path}` };
@@ -1336,6 +1348,8 @@ function AppInner({
     slashSelectedIndex: slashMatchesJson ? slashSelected : undefined,
     approvalKind: sceneApproval?.kind,
     approvalPrompt: sceneApproval?.prompt,
+    sessionsJson,
+    sessionsFocusedIndex: sessionsJson ? sessionsPickerFocus : undefined,
   });
 
   // Ctrl+P / Ctrl+N from PromptInput route here. When any input-prefix
@@ -4079,6 +4093,7 @@ function AppInner({
                     workspace={currentRootDir}
                     walletCurrency={walletCurrencyRef.current}
                     pickerPorts={pickerPorts}
+                    onFocusChange={setSessionsPickerFocus}
                     onChoose={(outcome) => {
                       if (outcome.kind === "open") {
                         setPendingSessionsPicker(false);

--- a/src/cli/ui/SessionPicker.tsx
+++ b/src/cli/ui/SessionPicker.tsx
@@ -1,6 +1,6 @@
 import { Box, Text, useStdout } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { t } from "../../i18n/index.js";
 import type { SessionInfo } from "../../memory/session.js";
 import { type PickerBroadcastPorts, usePickerBroadcast } from "./dashboard/use-picker-broadcast.js";
@@ -22,6 +22,7 @@ export interface SessionPickerProps {
   walletCurrency?: string;
   /** When provided, broadcasts to the web dashboard so it can resolve via `/api/modal/resolve`. */
   pickerPorts?: PickerBroadcastPorts;
+  onFocusChange?: (focus: number) => void;
 }
 
 const PAGE_MARGIN = 6;
@@ -32,8 +33,13 @@ export function SessionPicker({
   onChoose,
   walletCurrency,
   pickerPorts,
+  onFocusChange,
 }: SessionPickerProps): React.ReactElement {
   const [focus, setFocus] = useState(0);
+
+  useEffect(() => {
+    onFocusChange?.(focus);
+  }, [focus, onFocusChange]);
   const [renaming, setRenaming] = useState<{ from: string; buf: string } | null>(null);
   const { stdout } = useStdout();
   const rows = stdout?.rows ?? 40;

--- a/src/cli/ui/hooks/useSceneTrace.ts
+++ b/src/cli/ui/hooks/useSceneTrace.ts
@@ -7,6 +7,7 @@ import type { Card } from "../state/cards.js";
 
 export type SceneTraceCard = { kind: string; summary: string };
 export type SceneSlashMatch = { cmd: string; summary: string; argsHint?: string };
+export type SceneSessionItem = { title: string; meta?: string };
 
 export type SceneTraceInput = {
   model?: string;
@@ -24,6 +25,9 @@ export type SceneTraceInput = {
   /** When set, replaces the composer row with a `❓ <prompt> [y/n]` modal stub. */
   approvalKind?: string;
   approvalPrompt?: string;
+  /** JSON-encoded `SceneSessionItem[]`; non-empty replaces composer/slash with the picker block. */
+  sessionsJson?: string;
+  sessionsFocusedIndex?: number;
 };
 
 type BuildInput = {
@@ -38,9 +42,12 @@ type BuildInput = {
   slashSelectedIndex?: number;
   approvalKind?: string;
   approvalPrompt?: string;
+  sessions?: ReadonlyArray<SceneSessionItem>;
+  sessionsFocusedIndex?: number;
 };
 
 const APPROVAL_PROMPT_MAX = 60;
+const MAX_SESSION_ROWS = 8;
 
 const SUMMARY_MAX = 70;
 /** Reserved rows for title + status + composer; the rest can hold cards. */
@@ -84,15 +91,28 @@ export function buildTraceFrame(input: BuildInput, cols: number, rows: number): 
     for (const c of input.cards) children.push(cardRow(c));
   }
   children.push(statusRow(input));
-  if (input.approvalPrompt) {
+  const sessions = input.sessions ?? [];
+  const pickerOwnsBottom = sessions.length > 0;
+  if (pickerOwnsBottom) {
+    children.push(sessionsHeaderRow(sessions.length));
+    const sel = Math.max(0, Math.min(sessions.length - 1, input.sessionsFocusedIndex ?? 0));
+    const { startIndex, matches: shown } = listWindow(sessions, sel, MAX_SESSION_ROWS);
+    for (let i = 0; i < shown.length; i++) {
+      const item = shown[i] as SceneSessionItem;
+      children.push(sessionRow(item, startIndex + i === sel));
+    }
+    const hidden = sessions.length - shown.length;
+    if (hidden > 0) children.push(slashOverflowRow(hidden));
+    children.push(sessionsHintRow());
+  } else if (input.approvalPrompt) {
     children.push(approvalRow(input.approvalKind, input.approvalPrompt));
   } else {
     children.push(composerRow(input));
   }
   const slash = input.slashMatches ?? [];
-  if (!input.approvalPrompt && slash.length > 0) {
+  if (!pickerOwnsBottom && !input.approvalPrompt && slash.length > 0) {
     const sel = Math.max(0, Math.min(slash.length - 1, input.slashSelectedIndex ?? 0));
-    const { startIndex, matches: shown } = slashWindow(slash, sel);
+    const { startIndex, matches: shown } = listWindow(slash, sel, MAX_SLASH_ROWS);
     for (let i = 0; i < shown.length; i++) {
       const absoluteIndex = startIndex + i;
       children.push(slashRow(shown[i] as SceneSlashMatch, absoluteIndex === sel));
@@ -158,15 +178,55 @@ function slashOverflowRow(hidden: number): SceneNode {
   return text([{ text: `…${hidden} more`, style: { dim: true } }]);
 }
 
+export function listWindow<T>(
+  items: ReadonlyArray<T>,
+  selected: number,
+  windowSize: number,
+): { startIndex: number; matches: ReadonlyArray<T> } {
+  if (items.length <= windowSize) return { startIndex: 0, matches: items };
+  const half = Math.floor(windowSize / 2);
+  const maxStart = items.length - windowSize;
+  const startIndex = Math.max(0, Math.min(maxStart, selected - half));
+  return { startIndex, matches: items.slice(startIndex, startIndex + windowSize) };
+}
+
 export function slashWindow(
   matches: ReadonlyArray<SceneSlashMatch>,
   selected: number,
 ): { startIndex: number; matches: ReadonlyArray<SceneSlashMatch> } {
-  if (matches.length <= MAX_SLASH_ROWS) return { startIndex: 0, matches };
-  const half = Math.floor(MAX_SLASH_ROWS / 2);
-  const maxStart = matches.length - MAX_SLASH_ROWS;
-  const startIndex = Math.max(0, Math.min(maxStart, selected - half));
-  return { startIndex, matches: matches.slice(startIndex, startIndex + MAX_SLASH_ROWS) };
+  return listWindow(matches, selected, MAX_SLASH_ROWS);
+}
+
+function sessionsHeaderRow(total: number): SceneNode {
+  return text([
+    { text: "📂 ", style: { color: "cyan", bold: true } },
+    { text: "sessions", style: { bold: true } },
+    { text: ` (${total} saved)`, style: { dim: true } },
+  ]);
+}
+
+function sessionRow(item: SceneSessionItem, focused: boolean): SceneNode {
+  const runs: TextRun[] = [];
+  runs.push({ text: focused ? "▸ " : "  ", style: { color: "cyan" } });
+  runs.push({ text: item.title, style: focused ? { bold: true, color: "cyan" } : undefined });
+  if (item.meta) {
+    runs.push({ text: "  " });
+    runs.push({ text: item.meta, style: { dim: true } });
+  }
+  return text(runs);
+}
+
+function sessionsHintRow(): SceneNode {
+  return text([
+    { text: "↑↓ ", style: { color: "cyan" } },
+    { text: "navigate · ", style: { dim: true } },
+    { text: "⏎ ", style: { color: "cyan" } },
+    { text: "open · ", style: { dim: true } },
+    { text: "n ", style: { color: "cyan" } },
+    { text: "new · ", style: { dim: true } },
+    { text: "esc ", style: { color: "cyan" } },
+    { text: "cancel", style: { dim: true } },
+  ]);
 }
 
 function composerRow(s: BuildInput): SceneNode {
@@ -227,6 +287,27 @@ function colorFor(kind: string): Color {
     default:
       return "default";
   }
+}
+
+export function parseSessions(json: string | undefined): SceneSessionItem[] {
+  if (!json || json.length === 0) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  const out: SceneSessionItem[] = [];
+  for (const item of parsed) {
+    if (typeof item !== "object" || item === null) continue;
+    const obj = item as Record<string, unknown>;
+    if (typeof obj.title !== "string") continue;
+    const s: SceneSessionItem = { title: obj.title };
+    if (typeof obj.meta === "string") s.meta = obj.meta;
+    out.push(s);
+  }
+  return out;
 }
 
 export function parseSlashMatches(json: string | undefined): SceneSlashMatch[] {
@@ -293,12 +374,15 @@ export function useSceneTrace(input: SceneTraceInput): void {
     slashSelectedIndex,
     approvalKind,
     approvalPrompt,
+    sessionsJson,
+    sessionsFocusedIndex,
   } = input;
   useEffect(() => {
     if (!isSceneTraceEnabled()) return;
     const parsed = parseRecentCards(recentCardsJson);
     const cards = cardsForHeight(parsed, rows);
     const slashMatches = parseSlashMatches(slashMatchesJson);
+    const sessions = parseSessions(sessionsJson);
     emitSceneFrame(
       buildTraceFrame(
         {
@@ -313,6 +397,8 @@ export function useSceneTrace(input: SceneTraceInput): void {
           slashSelectedIndex,
           approvalKind,
           approvalPrompt,
+          sessions,
+          sessionsFocusedIndex,
         },
         cols,
         rows,
@@ -332,5 +418,7 @@ export function useSceneTrace(input: SceneTraceInput): void {
     slashSelectedIndex,
     approvalKind,
     approvalPrompt,
+    sessionsJson,
+    sessionsFocusedIndex,
   ]);
 }

--- a/tests/scene-trace-frame.test.ts
+++ b/tests/scene-trace-frame.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
+  type SceneSessionItem,
   type SceneSlashMatch,
   type SceneTraceCard,
   buildTraceFrame,
   cardsForHeight,
   parseRecentCards,
+  parseSessions,
   parseSlashMatches,
   slashWindow,
   summarizeCard,
@@ -430,6 +432,111 @@ describe("buildTraceFrame approval modal", () => {
     );
     if (f.root.kind !== "box") return;
     expect(f.root.children).toHaveLength(4);
+  });
+});
+
+describe("buildTraceFrame sessions picker", () => {
+  function makeSessions(n: number): SceneSessionItem[] {
+    return Array.from({ length: n }, (_, i) => ({
+      title: `session-${i}`,
+      meta: `main · ${i + 1} turns`,
+    }));
+  }
+
+  function buildWithSessions(sessions: SceneSessionItem[], focus: number) {
+    return buildTraceFrame(
+      {
+        cardCount: 0,
+        busy: false,
+        cards: [],
+        composerText: "typing…",
+        sessions,
+        sessionsFocusedIndex: focus,
+      },
+      80,
+      24,
+    );
+  }
+
+  it("replaces composer with a header + one row per session + a hint footer", () => {
+    const f = buildWithSessions(makeSessions(3), 0);
+    if (f.root.kind !== "box") return;
+    expect(f.root.children).toHaveLength(3 + 1 + 3 + 1);
+    const header = f.root.children[3];
+    if (header?.kind !== "text") return;
+    const headerFlat = header.runs.map((r) => r.text).join("");
+    expect(headerFlat).toContain("sessions");
+    expect(headerFlat).toContain("(3 saved)");
+    const row0 = f.root.children[4];
+    if (row0?.kind !== "text") return;
+    expect(row0.runs[0]?.text).toBe("▸ ");
+    expect(row0.runs[1]?.text).toBe("session-0");
+    const hint = f.root.children.at(-1);
+    if (hint?.kind !== "text") return;
+    const hintFlat = hint.runs.map((r) => r.text).join("");
+    expect(hintFlat).toContain("navigate");
+    expect(hintFlat).toContain("open");
+  });
+
+  it("windows a long session list at MAX_SESSION_ROWS (8) with an overflow row", () => {
+    const f = buildWithSessions(makeSessions(20), 15);
+    if (f.root.kind !== "box") return;
+    expect(f.root.children).toHaveLength(3 + 1 + 8 + 1 + 1);
+    const overflow = f.root.children.at(-2);
+    if (overflow?.kind !== "text") return;
+    expect(overflow.runs.map((r) => r.text).join("")).toContain("…12 more");
+  });
+
+  it("suppresses both the composer and the slash overlay while a sessions picker is active", () => {
+    const f = buildTraceFrame(
+      {
+        cardCount: 0,
+        busy: false,
+        cards: [],
+        composerText: "/",
+        slashMatches: [{ cmd: "/help", summary: "show help" }],
+        slashSelectedIndex: 0,
+        sessions: makeSessions(2),
+        sessionsFocusedIndex: 0,
+      },
+      80,
+      24,
+    );
+    if (f.root.kind !== "box") return;
+    const flat = f.root.children
+      .map((c) => (c.kind === "text" ? c.runs.map((r) => r.text).join("") : ""))
+      .join(" | ");
+    expect(flat).not.toContain("/help");
+    expect(flat).not.toContain("❯");
+  });
+
+  it("renders meta after the title when given", () => {
+    const f = buildWithSessions([{ title: "feat-foo", meta: "feat · 12 turns" }], 0);
+    if (f.root.kind !== "box") return;
+    const row = f.root.children[4];
+    if (row?.kind !== "text") return;
+    const flat = row.runs.map((r) => r.text).join("");
+    expect(flat).toContain("feat-foo");
+    expect(flat).toContain("feat · 12 turns");
+  });
+});
+
+describe("parseSessions", () => {
+  it("returns [] for undefined / malformed input", () => {
+    expect(parseSessions(undefined)).toEqual([]);
+    expect(parseSessions("")).toEqual([]);
+    expect(parseSessions("oops")).toEqual([]);
+    expect(parseSessions('{"not":"array"}')).toEqual([]);
+  });
+
+  it("decodes a JSON array of session items and preserves optional meta", () => {
+    const json = JSON.stringify([{ title: "a", meta: "main · 1 turns" }, { title: "b" }]);
+    expect(parseSessions(json)).toEqual([{ title: "a", meta: "main · 1 turns" }, { title: "b" }]);
+  });
+
+  it("skips entries missing a title", () => {
+    const json = JSON.stringify([{ title: "ok" }, { meta: "no-title" }, null, 42]);
+    expect(parseSessions(json)).toEqual([{ title: "ok" }]);
   });
 });
 


### PR DESCRIPTION
Fifth sub-PR under the rust direction-B plan (#868) — last of the
B-line items from the original handoff.

## Why

Under \`REASONIX_RENDERER=rust\` the Ink-side SessionPicker rendered
to the null stdout, so a user opening \`/sessions\` saw nothing but
the "awaiting input" composer they couldn't actually type into.
Keystrokes still flowed (SessionPicker already uses \`useKeystroke\`),
but the user was navigating an invisible list. The scene producer
now mirrors the picker so the fresh-user-with-saved-sessions path
works without falling back to Ink.

## What

\`\`\`
📂 sessions (3 saved)
▸ feat-foo  main · 12 turns
  hotfix-bar  release/4.5 · 3 turns
  spike-baz  main · 47 turns
↑↓ navigate · ⏎ open · n new · esc cancel
\`\`\`

- New \`SceneSessionItem\` (\`{ title, meta? }\`) surfaced via
  \`useSceneTrace\` as a JSON-encoded array plus a primitive
  \`sessionsFocusedIndex\`, same primitive-deps pattern as the other
  picker fields.
- \`buildTraceFrame\`: when \`sessions\` is non-empty, replace composer
  (and any approval / slash overlay) with a header row + one focused
  windowed row per session (cap \`MAX_SESSION_ROWS = 8\`, with a
  \`…N more\` tail when the list is longer) + a hint footer.
- \`listWindow\` extracted as a generic so the slash and sessions
  blocks share centering logic; \`slashWindow\` becomes a thin wrapper.
- \`SessionPicker\` gains a small \`onFocusChange\` callback —
  \`useEffect\` publishes the local \`focus\` state. App.tsx mirrors it
  into a \`useState\` and into the scene input. No restructuring of
  \`SessionPicker\` beyond the prop; its \`useKeystroke\` handling stays
  exactly as is (per the handoff's "don't touch SessionPicker for
  useKeystroke purposes" rule — this is state exposure, not
  restructuring).
- App.tsx builds \`sessionsJson\` via \`useMemo\` from
  \`sessionsPickerList\` with \`\${branch} · \${turns} turns\` as the
  meta line; gated on \`pendingSessionsPicker\` so the overlay only
  appears while the picker is actually open.

## Out of scope

- Rename / delete / quit hints are listed in the hint row but the
  scene doesn't reflect the in-progress rename buffer when the user
  presses \`r\`. The Ink picker still owns that interactive flow.
- Web-dashboard \`pickerPorts\` broadcast is untouched.
- CheckpointPicker / McpHub / Setup get the same treatment in
  later sub-PRs as they show up as felt gaps.

## Tests

\`tests/scene-trace-frame.test.ts\` — 7 new cases:

- composer replaced by header + N session rows + hint row
- long lists windowed at 8 with an overflow line
- composer AND slash overlay suppressed while sessions are active
- meta line rendered after title
- \`parseSessions\` round-trips, drops entries missing a title,
  returns \`[]\` on undefined / empty / non-array / non-JSON input

\`npm run verify\` green via prepush gate.

Refs #868