### PR TITLE
feat(scene): mirror the API-key Setup form into the scene frame

### DIFF
--- a/src/cli/ui/Setup.tsx
+++ b/src/cli/ui/Setup.tsx
@@ -3,6 +3,7 @@ import React, { useState } from "react";
 import { defaultConfigPath, isPlausibleKey, redactKey, saveApiKey } from "../../config.js";
 import { t } from "../../i18n/index.js";
 import { MaskedInput } from "./MaskedInput.js";
+import { useSetupSceneTrace } from "./hooks/useSceneTrace.js";
 import { COLOR, GLYPH, GRADIENT } from "./theme.js";
 
 export interface SetupProps {
@@ -13,6 +14,8 @@ export function Setup({ onReady }: SetupProps) {
   const [value, setValue] = useState("");
   const [error, setError] = useState<string | null>(null);
   const { exit } = useApp();
+
+  useSetupSceneTrace({ bufferLength: value.length, error: error ?? undefined });
 
   const handleSubmit = (raw: string) => {
     const trimmed = raw.trim();

--- a/src/cli/ui/hooks/useSceneTrace.ts
+++ b/src/cli/ui/hooks/useSceneTrace.ts
@@ -422,3 +422,52 @@ export function useSceneTrace(input: SceneTraceInput): void {
     sessionsFocusedIndex,
   ]);
 }
+
+export type SetupSceneInput = {
+  bufferLength: number;
+  error?: string;
+};
+
+export function buildSetupFrame(input: SetupSceneInput, cols: number, rows: number): SceneFrame {
+  const children: SceneNode[] = [];
+  children.push(
+    text([
+      { text: "✦ ", style: { color: "cyan", bold: true } },
+      { text: "reasonix", style: { bold: true } },
+      { text: " · welcome", style: { dim: true } },
+    ]),
+  );
+  children.push(text([{ text: "Enter your DeepSeek API key:", style: { color: "cyan" } }]));
+  children.push(
+    text([{ text: "  get one at https://platform.deepseek.com", style: { dim: true } }]),
+  );
+  const maskedRuns: TextRun[] = [{ text: "❯ ", style: { color: "cyan", bold: true } }];
+  if (input.bufferLength === 0) {
+    maskedRuns.push({ text: "(start typing your key)", style: { dim: true } });
+  } else {
+    maskedRuns.push({ text: "•".repeat(input.bufferLength) });
+    maskedRuns.push({ text: "▮", style: { color: "cyan" } });
+  }
+  children.push(text(maskedRuns));
+  if (input.error) {
+    children.push(
+      text([
+        { text: "✗ ", style: { color: "red", bold: true } },
+        { text: input.error, style: { color: "red" } },
+      ]),
+    );
+  }
+  children.push(text([{ text: "Ctrl+C to exit · /exit to quit", style: { dim: true } }]));
+  return frame(cols, rows, box(children, { direction: "column", paddingX: 1 }));
+}
+
+export function useSetupSceneTrace(input: SetupSceneInput): void {
+  const { stdout } = useStdout();
+  const cols = stdout?.columns ?? 80;
+  const rows = stdout?.rows ?? 24;
+  const { bufferLength, error } = input;
+  useEffect(() => {
+    if (!isSceneTraceEnabled()) return;
+    emitSceneFrame(buildSetupFrame({ bufferLength, error }, cols, rows));
+  }, [cols, rows, bufferLength, error]);
+}

--- a/tests/scene-trace-frame.test.ts
+++ b/tests/scene-trace-frame.test.ts
@@ -3,6 +3,7 @@ import {
   type SceneSessionItem,
   type SceneSlashMatch,
   type SceneTraceCard,
+  buildSetupFrame,
   buildTraceFrame,
   cardsForHeight,
   parseRecentCards,
@@ -537,6 +538,56 @@ describe("parseSessions", () => {
   it("skips entries missing a title", () => {
     const json = JSON.stringify([{ title: "ok" }, { meta: "no-title" }, null, 42]);
     expect(parseSessions(json)).toEqual([{ title: "ok" }]);
+  });
+});
+
+describe("buildSetupFrame", () => {
+  function flatten(frame: ReturnType<typeof buildSetupFrame>): string[] {
+    if (frame.root.kind !== "box") throw new Error("expected box");
+    return frame.root.children.map((c) =>
+      c.kind === "text" ? c.runs.map((r) => r.text).join("") : "",
+    );
+  }
+
+  it("renders welcome + prompt + masked-input placeholder + exit hint when the buffer is empty", () => {
+    const f = buildSetupFrame({ bufferLength: 0 }, 80, 24);
+    const rows = flatten(f);
+    expect(rows[0]).toContain("reasonix");
+    expect(rows[0]).toContain("welcome");
+    expect(rows[1]).toContain("API key");
+    expect(rows[2]).toContain("platform.deepseek.com");
+    expect(rows[3]).toContain("(start typing your key)");
+    expect(rows[3]).not.toContain("▮");
+    expect(rows.at(-1)).toContain("Ctrl+C");
+  });
+
+  it("masks the buffer with • dots and appends a ▮ cursor when the user has typed", () => {
+    const f = buildSetupFrame({ bufferLength: 5 }, 80, 24);
+    const rows = flatten(f);
+    expect(rows[3]).toContain("•••••");
+    expect(rows[3]).toContain("▮");
+    expect(rows[3]).not.toContain("(start typing");
+  });
+
+  it("never leaks the raw buffer content — bufferLength is the only signal in/out", () => {
+    const f = buildSetupFrame({ bufferLength: 12 }, 80, 24);
+    const rows = flatten(f);
+    expect(rows[3]?.match(/•/g)?.length).toBe(12);
+  });
+
+  it("inserts an error row above the exit hint when an error is set", () => {
+    const f = buildSetupFrame({ bufferLength: 0, error: "key looks malformed" }, 80, 24);
+    const rows = flatten(f);
+    const errIdx = rows.findIndex((r) => r.includes("key looks malformed"));
+    expect(errIdx).toBeGreaterThan(0);
+    expect(rows[errIdx]?.startsWith("✗")).toBe(true);
+    expect(rows.at(-1)).toContain("Ctrl+C");
+  });
+
+  it("omits the error row when error is undefined", () => {
+    const f = buildSetupFrame({ bufferLength: 3 }, 80, 24);
+    const rows = flatten(f);
+    expect(rows.some((r) => r.startsWith("✗"))).toBe(false);
   });
 });
 


### PR DESCRIPTION
First step toward un-blocking the fresh-user path under
\`REASONIX_RENDERER=rust\`. Direction-B follow-on to #997.

## Why

The Ink-side \`Setup\` screen rendered to the null stdout, so a user
with no saved API key saw nothing at all and had no way to know the
loop was waiting on their key. The scene producer now emits a
parallel setup frame so the prompt is visible:

\`\`\`
✦ reasonix · welcome
Enter your DeepSeek API key:
  get one at https://platform.deepseek.com
❯ •••••▮
✗ <error>            (only when error is set)
Ctrl+C to exit · /exit to quit
\`\`\`

## What

- New \`buildSetupFrame(input, cols, rows)\` — completely separate
  from \`buildTraceFrame\`. The setup screen never coexists with
  cards / status / composer, so a shared layout would only constrain
  both.
- New \`useSetupSceneTrace\` hook — \`Setup.tsx\` calls it with
  \`bufferLength\` and the current \`error\` string.
- **Only the buffer length crosses the scene boundary.** Raw key
  material never gets serialized into the scene stream — the scene
  layer never sees the API key, just the count of dots to render.

## Known limitation (next PR)

No keystroke change in this PR — \`MaskedInput\` keeps using Ink's
\`useInput\`. Under \`REASONIX_RENDERER=rust\` Ink is wired to the
null stdin (see \`src/cli/ui/scene/null-stdin.ts\`), so \`useInput\`
receives nothing and the user still can't actually type a key
without falling back to \`REASONIX_RENDERER\`-unset mode. Closing
that gap means wiring \`KeystrokeProvider\` around the pre-App
\`<Setup>\` mount and routing the rust input child's keys to
\`MaskedInput\`. That's a separate, scoped follow-up.

This PR is intentionally just the visible-feedback half — the user
at least learns \"the loop wants my API key\" instead of staring at
a blank terminal.

## Tests

\`tests/scene-trace-frame.test.ts\` — 5 new cases:

- welcome / prompt / placeholder / exit hint when buffer is empty
- \`•\` dots + \`▮\` cursor when the user has typed
- buffer-length-only crossing the boundary (5 chars → exactly 5 \`•\`)
- error row inserted above the exit hint when an error is set
- error row omitted when error is undefined

\`npm run verify\` green via prepush gate.

Refs #868