### PR TITLE
fix(scene): wire KeystrokeProvider around <Setup> so MaskedInput receives keys under rust mode

### DIFF
--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -204,12 +204,14 @@ function Root({
 
   if (!key) {
     return (
-      <Setup
-        onReady={(k) => {
-          process.env.DEEPSEEK_API_KEY = k;
-          setKey(k);
-        }}
-      />
+      <KeystrokeProvider reader={keystrokeReader}>
+        <Setup
+          onReady={(k) => {
+            process.env.DEEPSEEK_API_KEY = k;
+            setKey(k);
+          }}
+        />
+      </KeystrokeProvider>
     );
   }
   process.env.DEEPSEEK_API_KEY = key;

--- a/src/cli/ui/MaskedInput.tsx
+++ b/src/cli/ui/MaskedInput.tsx
@@ -1,6 +1,7 @@
-import { Text, useInput } from "ink";
+import { Text } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React, { useRef } from "react";
+import { useKeystroke } from "./keystroke-context.js";
 import { FG } from "./theme/tokens.js";
 
 export interface MaskedInputProps {
@@ -27,20 +28,20 @@ export function MaskedInput({
   const valueRef = useRef(value);
   valueRef.current = value;
 
-  useInput((input, key) => {
-    if (key.return) {
+  useKeystroke((ev) => {
+    if (ev.return) {
       onSubmit(stripPasteMarkers(valueRef.current));
       return;
     }
-    if (key.backspace || key.delete) {
+    if (ev.backspace || ev.delete) {
       if (valueRef.current.length === 0) return;
       const next = valueRef.current.slice(0, -1);
       valueRef.current = next;
       onChange(next);
       return;
     }
-    if (input && !key.ctrl && !key.meta && !key.escape) {
-      const cleaned = stripPasteMarkers(input);
+    if (ev.input && !ev.ctrl && !ev.meta && !ev.escape) {
+      const cleaned = stripPasteMarkers(ev.input);
       if (cleaned.length === 0) return;
       const next = stripPasteMarkers(valueRef.current + cleaned);
       valueRef.current = next;


### PR DESCRIPTION
Closes the keystroke half of the rust-renderer Setup gap. The visible
mirror landed in #998; this one makes the form actually interactive
under \`REASONIX_RENDERER=rust\`.

## Why

Under \`REASONIX_RENDERER=rust\` the JS process runs Ink with a null
stdin (see \`src/cli/ui/scene/null-stdin.ts\`). \`MaskedInput\` was
calling Ink's \`useInput\`, which subscribes to that null stream, so
keys never reached the form. Combined with the previously-invisible
Ink stdout, a fresh user with no saved key sat at a completely dead
prompt.

## What

- \`chat.tsx\`: the pre-App \`<Setup>\` branch is now wrapped in
  \`<KeystrokeProvider reader={keystrokeReader}>\` — the same reader
  the main \`<App>\` tree below it already uses. So under rust mode
  keys flow from the spawned \`reasonix-render --emit-input\` child,
  and under the default mode they flow from the singleton
  \`StdinReader\`.
- \`MaskedInput.tsx\`: \`useInput\` → \`useKeystroke\`. The hook in
  \`keystroke-context.tsx\` already falls back to Ink's \`useInput\`
  when no provider is mounted, so any future caller that mounts
  \`MaskedInput\` outside a provider keeps working unchanged.

That's the whole change — 15 added / 12 removed across two files.

## Result

Combined with #998 (\`useSetupSceneTrace\` visible feedback), the
\`REASONIX_RENDERER=rust\` fresh-user path now works end-to-end:

- User launches with no \`DEEPSEEK_API_KEY\` set
- Rust renderer draws the welcome / "enter your DeepSeek API key:"
  / masked-input row in the scene frame
- Keys typed in the terminal flow through the rust input child and
  back into \`MaskedInput\` via the provider
- \`saveApiKey\` runs on Enter; Setup resolves; \`<App>\` mounts

## Not in scope

- Stage 3 smoke verification — running the binary on Windows Terminal
  end-to-end to confirm both halves work in practice — is a separate
  step. The unit tests cover the wiring; the UX needs human eyes.
- \`pendingReviseEditor\` (full-screen editor takeover) is still
  Ink-only; it's a richer modal and gets its own follow-up.

Refs #868