### PR TITLE
feat(rust): honor width / height / fill on row + column scene layouts

### DIFF
--- a/crates/reasonix-render/src/render.rs
+++ b/crates/reasonix-render/src/render.rs
@@ -4,8 +4,15 @@ use ratatui::style::{Color as RColor, Modifier, Style};
 use unicode_width::UnicodeWidthChar;
 
 use crate::scene::{
-    BoxLayout, Color, FlexDirection, NamedColor, SceneFrame, SceneNode, TextRun, TextStyle,
+    BoxLayout, Color, Dim, FillToken, FlexDirection, NamedColor, SceneFrame, SceneNode, TextRun,
+    TextStyle,
 };
+
+#[derive(Clone, Copy)]
+enum Axis {
+    Row,
+    Column,
+}
 
 pub fn render_frame(frame: &SceneFrame, buf: &mut Buffer, area: Rect) {
     render_node(&frame.root, buf, area);
@@ -71,6 +78,7 @@ fn render_box(layout: Option<&BoxLayout>, children: &[SceneNode], buf: &mut Buff
 }
 
 fn render_column(children: &[SceneNode], gap: u16, buf: &mut Buffer, area: Rect) {
+    let sizes = compute_axis_sizes(children, gap, area.height, Axis::Column);
     let mut y = area.y;
     let max_y = area.y.saturating_add(area.height);
     let last = children.len().saturating_sub(1);
@@ -78,8 +86,7 @@ fn render_column(children: &[SceneNode], gap: u16, buf: &mut Buffer, area: Rect)
         if y >= max_y {
             break;
         }
-        let remaining = max_y - y;
-        let h = intrinsic_height(child).min(remaining);
+        let h = sizes[i].min(max_y - y);
         let child_area = Rect {
             x: area.x,
             y,
@@ -95,6 +102,7 @@ fn render_column(children: &[SceneNode], gap: u16, buf: &mut Buffer, area: Rect)
 }
 
 fn render_row(children: &[SceneNode], gap: u16, buf: &mut Buffer, area: Rect) {
+    let sizes = compute_axis_sizes(children, gap, area.width, Axis::Row);
     let mut x = area.x;
     let max_x = area.x.saturating_add(area.width);
     let last = children.len().saturating_sub(1);
@@ -102,8 +110,7 @@ fn render_row(children: &[SceneNode], gap: u16, buf: &mut Buffer, area: Rect) {
         if x >= max_x {
             break;
         }
-        let remaining = max_x - x;
-        let w = intrinsic_width(child).min(remaining);
+        let w = sizes[i].min(max_x - x);
         let child_area = Rect {
             x,
             y: area.y,
@@ -116,6 +123,63 @@ fn render_row(children: &[SceneNode], gap: u16, buf: &mut Buffer, area: Rect) {
             x = x.saturating_add(gap);
         }
     }
+}
+
+fn compute_axis_sizes(children: &[SceneNode], gap: u16, total: u16, axis: Axis) -> Vec<u16> {
+    let n = children.len();
+    if n == 0 {
+        return vec![];
+    }
+    let gap_total = gap.saturating_mul((n.saturating_sub(1)) as u16);
+    let mut available = total.saturating_sub(gap_total);
+    let mut sizes = vec![0u16; n];
+    let mut fill_indices: Vec<usize> = Vec::new();
+
+    for (i, child) in children.iter().enumerate() {
+        match axis_dim(child, axis) {
+            Some(Dim::Cells(c)) => {
+                let want = c.max(0) as u16;
+                let take = want.min(available);
+                sizes[i] = take;
+                available = available.saturating_sub(take);
+            }
+            Some(Dim::Fill(FillToken::Fill)) => {
+                fill_indices.push(i);
+            }
+            None => {
+                let want = match axis {
+                    Axis::Row => intrinsic_width(child),
+                    Axis::Column => intrinsic_height(child),
+                };
+                let take = want.min(available);
+                sizes[i] = take;
+                available = available.saturating_sub(take);
+            }
+        }
+    }
+
+    if !fill_indices.is_empty() && available > 0 {
+        let count = fill_indices.len() as u16;
+        let per = available / count;
+        let remainder = available % count;
+        for (j, &i) in fill_indices.iter().enumerate() {
+            sizes[i] = per + if (j as u16) < remainder { 1 } else { 0 };
+        }
+    }
+
+    sizes
+}
+
+fn axis_dim(node: &SceneNode, axis: Axis) -> Option<Dim> {
+    let layout = match node {
+        SceneNode::Box { layout, .. } => layout.as_ref()?,
+        SceneNode::Text { .. } => return None,
+    };
+    let dim = match axis {
+        Axis::Row => layout.width.as_ref(),
+        Axis::Column => layout.height.as_ref(),
+    };
+    dim.cloned()
 }
 
 fn apply_padding(layout: Option<&BoxLayout>, area: Rect) -> Rect {

--- a/crates/reasonix-render/tests/render.rs
+++ b/crates/reasonix-render/tests/render.rs
@@ -4,8 +4,41 @@ use ratatui::style::{Color as RColor, Modifier};
 
 use reasonix_render::render::render_frame;
 use reasonix_render::scene::{
-    BoxLayout, Color, FlexDirection, NamedColor, SceneFrame, SceneNode, TextRun, TextStyle,
+    BoxLayout, Color, Dim, FillToken, FlexDirection, NamedColor, SceneFrame, SceneNode, TextRun,
+    TextStyle,
 };
+
+fn box_with_width(text: &str, width: Dim) -> SceneNode {
+    SceneNode::Box {
+        layout: Some(BoxLayout {
+            width: Some(width),
+            ..Default::default()
+        }),
+        children: vec![SceneNode::Text {
+            runs: vec![TextRun {
+                text: text.to_string(),
+                style: None,
+            }],
+            wrap: None,
+        }],
+    }
+}
+
+fn box_with_height(text: &str, height: Dim) -> SceneNode {
+    SceneNode::Box {
+        layout: Some(BoxLayout {
+            height: Some(height),
+            ..Default::default()
+        }),
+        children: vec![SceneNode::Text {
+            runs: vec![TextRun {
+                text: text.to_string(),
+                style: None,
+            }],
+            wrap: None,
+        }],
+    }
+}
 
 fn frame_of(root: SceneNode) -> SceneFrame {
     SceneFrame {
@@ -184,6 +217,195 @@ fn truncates_text_overflowing_its_area() {
     let mut buf = Buffer::empty(area);
     render_frame(&frame, &mut buf, area);
     assert_eq!(collect_row(&buf, 0, 4), "abcd");
+}
+
+#[test]
+fn row_with_fixed_cell_widths_reserves_those_widths_first() {
+    let frame = frame_of(SceneNode::Box {
+        layout: Some(BoxLayout {
+            direction: Some(FlexDirection::Row),
+            ..Default::default()
+        }),
+        children: vec![
+            box_with_width("L", Dim::Cells(4)),
+            box_with_width("R", Dim::Cells(3)),
+        ],
+    });
+    let area = Rect::new(0, 0, 20, 1);
+    let mut buf = Buffer::empty(area);
+    render_frame(&frame, &mut buf, area);
+    assert_eq!(buf[(0, 0)].symbol(), "L");
+    assert_eq!(buf[(4, 0)].symbol(), "R");
+}
+
+#[test]
+fn row_with_one_fill_child_takes_all_remaining_space() {
+    let frame = frame_of(SceneNode::Box {
+        layout: Some(BoxLayout {
+            direction: Some(FlexDirection::Row),
+            ..Default::default()
+        }),
+        children: vec![
+            box_with_width("L", Dim::Cells(3)),
+            box_with_width("M", Dim::Fill(FillToken::Fill)),
+            box_with_width("R", Dim::Cells(3)),
+        ],
+    });
+    let area = Rect::new(0, 0, 20, 1);
+    let mut buf = Buffer::empty(area);
+    render_frame(&frame, &mut buf, area);
+    assert_eq!(buf[(0, 0)].symbol(), "L");
+    assert_eq!(buf[(3, 0)].symbol(), "M");
+    assert_eq!(buf[(17, 0)].symbol(), "R");
+}
+
+#[test]
+fn row_with_multiple_fill_children_splits_remainder_evenly() {
+    let frame = frame_of(SceneNode::Box {
+        layout: Some(BoxLayout {
+            direction: Some(FlexDirection::Row),
+            ..Default::default()
+        }),
+        children: vec![
+            box_with_width("A", Dim::Fill(FillToken::Fill)),
+            box_with_width("B", Dim::Fill(FillToken::Fill)),
+            box_with_width("C", Dim::Fill(FillToken::Fill)),
+        ],
+    });
+    let area = Rect::new(0, 0, 12, 1);
+    let mut buf = Buffer::empty(area);
+    render_frame(&frame, &mut buf, area);
+    assert_eq!(buf[(0, 0)].symbol(), "A");
+    assert_eq!(buf[(4, 0)].symbol(), "B");
+    assert_eq!(buf[(8, 0)].symbol(), "C");
+}
+
+#[test]
+fn row_distributes_uneven_remainder_to_leading_fill_children() {
+    let frame = frame_of(SceneNode::Box {
+        layout: Some(BoxLayout {
+            direction: Some(FlexDirection::Row),
+            ..Default::default()
+        }),
+        children: vec![
+            box_with_width("A", Dim::Fill(FillToken::Fill)),
+            box_with_width("B", Dim::Fill(FillToken::Fill)),
+        ],
+    });
+    let area = Rect::new(0, 0, 11, 1);
+    let mut buf = Buffer::empty(area);
+    render_frame(&frame, &mut buf, area);
+    assert_eq!(buf[(0, 0)].symbol(), "A");
+    assert_eq!(buf[(6, 0)].symbol(), "B");
+}
+
+#[test]
+fn row_caps_a_fixed_width_at_the_remaining_space() {
+    let frame = frame_of(SceneNode::Box {
+        layout: Some(BoxLayout {
+            direction: Some(FlexDirection::Row),
+            ..Default::default()
+        }),
+        children: vec![
+            box_with_width("ABCDE", Dim::Cells(50)),
+            box_with_width("X", Dim::Cells(3)),
+        ],
+    });
+    let area = Rect::new(0, 0, 8, 1);
+    let mut buf = Buffer::empty(area);
+    render_frame(&frame, &mut buf, area);
+    assert_eq!(buf[(0, 0)].symbol(), "A");
+    assert_eq!(buf[(7, 0)].symbol(), " ");
+}
+
+#[test]
+fn row_unspecified_children_keep_their_intrinsic_widths() {
+    let frame = frame_of(SceneNode::Box {
+        layout: Some(BoxLayout {
+            direction: Some(FlexDirection::Row),
+            ..Default::default()
+        }),
+        children: vec![
+            SceneNode::Text {
+                runs: vec![TextRun {
+                    text: "ab".to_string(),
+                    style: None,
+                }],
+                wrap: None,
+            },
+            SceneNode::Text {
+                runs: vec![TextRun {
+                    text: "cd".to_string(),
+                    style: None,
+                }],
+                wrap: None,
+            },
+        ],
+    });
+    let area = Rect::new(0, 0, 10, 1);
+    let mut buf = Buffer::empty(area);
+    render_frame(&frame, &mut buf, area);
+    assert_eq!(collect_row(&buf, 0, 10), "abcd");
+}
+
+#[test]
+fn row_gap_is_subtracted_from_available_before_distributing() {
+    let frame = frame_of(SceneNode::Box {
+        layout: Some(BoxLayout {
+            direction: Some(FlexDirection::Row),
+            gap: Some(1),
+            ..Default::default()
+        }),
+        children: vec![
+            box_with_width("A", Dim::Fill(FillToken::Fill)),
+            box_with_width("B", Dim::Fill(FillToken::Fill)),
+        ],
+    });
+    let area = Rect::new(0, 0, 9, 1);
+    let mut buf = Buffer::empty(area);
+    render_frame(&frame, &mut buf, area);
+    assert_eq!(buf[(0, 0)].symbol(), "A");
+    assert_eq!(buf[(5, 0)].symbol(), "B");
+}
+
+#[test]
+fn column_with_fixed_cell_heights_reserves_those_heights_first() {
+    let frame = frame_of(SceneNode::Box {
+        layout: Some(BoxLayout {
+            direction: Some(FlexDirection::Column),
+            ..Default::default()
+        }),
+        children: vec![
+            box_with_height("T", Dim::Cells(2)),
+            box_with_height("B", Dim::Cells(1)),
+        ],
+    });
+    let area = Rect::new(0, 0, 5, 10);
+    let mut buf = Buffer::empty(area);
+    render_frame(&frame, &mut buf, area);
+    assert_eq!(buf[(0, 0)].symbol(), "T");
+    assert_eq!(buf[(0, 2)].symbol(), "B");
+}
+
+#[test]
+fn column_fill_child_consumes_remaining_height() {
+    let frame = frame_of(SceneNode::Box {
+        layout: Some(BoxLayout {
+            direction: Some(FlexDirection::Column),
+            ..Default::default()
+        }),
+        children: vec![
+            box_with_height("T", Dim::Cells(1)),
+            box_with_height("M", Dim::Fill(FillToken::Fill)),
+            box_with_height("B", Dim::Cells(1)),
+        ],
+    });
+    let area = Rect::new(0, 0, 5, 10);
+    let mut buf = Buffer::empty(area);
+    render_frame(&frame, &mut buf, area);
+    assert_eq!(buf[(0, 0)].symbol(), "T");
+    assert_eq!(buf[(0, 1)].symbol(), "M");
+    assert_eq!(buf[(0, 9)].symbol(), "B");
 }
 
 #[test]

--- a/src/cli/ui/hooks/useSceneTrace.ts
+++ b/src/cli/ui/hooks/useSceneTrace.ts
@@ -124,9 +124,13 @@ export function buildTraceFrame(input: BuildInput, cols: number, rows: number): 
 }
 
 function titleRow(s: BuildInput): SceneNode {
-  const runs: TextRun[] = [{ text: "reasonix", style: { bold: true } }];
-  if (s.model) runs.push({ text: ` · ${s.model}`, style: { dim: true } });
-  return text(runs);
+  const left = text([{ text: "reasonix", style: { bold: true } }]);
+  const spacer = box([], { width: "fill" });
+  const children: SceneNode[] = [left, spacer];
+  if (s.model) {
+    children.push(text([{ text: s.model, style: { dim: true } }]));
+  }
+  return box(children, { direction: "row" });
 }
 
 function noCardsRow(): SceneNode {

--- a/tests/scene-trace-frame.test.ts
+++ b/tests/scene-trace-frame.test.ts
@@ -138,15 +138,28 @@ describe("buildTraceFrame", () => {
     expect(f.root.children).toHaveLength(4);
   });
 
-  it("renders the model name in the title row when given", () => {
+  it("renders the title as a row with brand on the left and model on the right separated by a fill spacer", () => {
     const f = buildEmpty({ model: "deepseek-chat" });
-    expect(f.root.kind).toBe("box");
-    if (f.root.kind !== "box") return;
+    if (f.root.kind !== "box") throw new Error("expected box root");
     const title = f.root.children[0];
-    if (title?.kind !== "text") return;
-    const flat = title.runs.map((r) => r.text).join("");
-    expect(flat).toContain("reasonix");
-    expect(flat).toContain("deepseek-chat");
+    if (title?.kind !== "box") throw new Error("expected title to be a box");
+    expect(title.layout?.direction).toBe("row");
+    expect(title.children).toHaveLength(3);
+    const [brand, spacer, model] = title.children;
+    if (brand?.kind !== "text") throw new Error("expected brand text");
+    expect(brand.runs.map((r) => r.text).join("")).toContain("reasonix");
+    if (spacer?.kind !== "box") throw new Error("expected spacer box");
+    expect(spacer.layout?.width).toBe("fill");
+    if (model?.kind !== "text") throw new Error("expected model text");
+    expect(model.runs.map((r) => r.text).join("")).toBe("deepseek-chat");
+  });
+
+  it("omits the model node from the title row when no model is given", () => {
+    const f = buildEmpty();
+    if (f.root.kind !== "box") throw new Error("expected box root");
+    const title = f.root.children[0];
+    if (title?.kind !== "box") throw new Error("expected title to be a box");
+    expect(title.children).toHaveLength(2);
   });
 
   it("shows a placeholder card row when no cards exist", () => {


### PR DESCRIPTION
Unblocks multi-pane scene layouts. Foundation PR for the
\`Sidebar / Main / ContextPanel\` three-pane layout the user's
design mock points at.

## Why

The scene schema already declared \`width\` / \`height\` on
\`BoxLayout\` as \`Dim::Cells(n) | Dim::Fill\`, but the Rust render
layer ignored both — every row child fell back to its intrinsic
width and every column child to its intrinsic height. That made
\`direction: row\` only useful for content-packed rows, never for
sized panes (244-cell sidebar + fluid main + 320-cell context panel
was literally not expressible end-to-end).

## Algorithm

Single-pass distribution per axis:

1. Reserve gap_total = gap × (n − 1) up front.
2. Walk children; classify each:
   - \`Dim::Cells(n)\` → reserve n cells, clamped at remaining
     (first-come basis, source order).
   - \`Dim::Fill\` → defer.
   - unsized → reserve intrinsic size, clamped at remaining.
3. Split whatever's left equally among deferred Fill children.
   Pixel remainder goes to the leading Fill children so the total
   adds up to exactly the gap-adjusted axis budget.

Backward compatible — every existing scene (column with unsized
children, row with intrinsic-width chips) keeps rendering identically.

## Visible use

\`titleRow\` is now a row box: brand on the left, model name on the
right, \`width: \"fill\"\` spacer between them. Same pattern the
upcoming three-pane layout PR will use — sidebar with
\`Dim::Cells(n)\`, main with \`Dim::Fill\`, ctx panel with its own
fixed cell width.

## Tests

\`crates/reasonix-render/tests/render.rs\` — 9 new cases:

- fixed cell widths reserved in source order
- one Fill child consumes all remaining row width
- multiple Fill children split remainder evenly
- uneven remainder goes to leading Fill children
- fixed width clamped at remaining when oversized
- unsized children keep their intrinsic widths
- gap subtracted from available before distributing
- column variant for both Cells + Fill

\`tests/scene-trace-frame.test.ts\` — 2 new cases on the producer-side
\`titleRow\` restructure.

\`cargo test -p reasonix-render --test render\` → 17/17 green.
\`npm run verify\` → green via prepush gate.

## What still doesn't work

- \`flexGrow\` / \`flexShrink\` — schema fields exist, render layer
  still ignores them. \`Dim::Fill\` is the primary way to grow.
- \`marginX\` / \`marginY\` — same.
- \`align\` / \`justify\` — same. (Right-alignment in a row is
  currently done by inserting a Fill spacer before the right-aligned
  child, as the new \`titleRow\` does.)
- \`borderStyle\` / \`borderColor\` — same.

Each of these is a small isolated follow-up; \`width\` / \`height\`
was the highest-impact one because it unlocks fixed-sized panes.

Refs #868