### PR TITLE
feat(scene): surface wallet balance as a right-aligned status segment

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -1350,6 +1350,8 @@ function AppInner({
     approvalPrompt: sceneApproval?.prompt,
     sessionsJson,
     sessionsFocusedIndex: sessionsJson ? sessionsPickerFocus : undefined,
+    walletBalance: balance?.total,
+    walletCurrency: balance?.currency,
   });
 
   // Ctrl+P / Ctrl+N from PromptInput route here. When any input-prefix

--- a/src/cli/ui/hooks/useSceneTrace.ts
+++ b/src/cli/ui/hooks/useSceneTrace.ts
@@ -28,6 +28,9 @@ export type SceneTraceInput = {
   /** JSON-encoded `SceneSessionItem[]`; non-empty replaces composer/slash with the picker block. */
   sessionsJson?: string;
   sessionsFocusedIndex?: number;
+  /** Wallet balance — appears right-aligned in the status row. Null/undefined hides the segment. */
+  walletBalance?: number;
+  walletCurrency?: string;
 };
 
 type BuildInput = {
@@ -44,6 +47,8 @@ type BuildInput = {
   approvalPrompt?: string;
   sessions?: ReadonlyArray<SceneSessionItem>;
   sessionsFocusedIndex?: number;
+  walletBalance?: number;
+  walletCurrency?: string;
 };
 
 const APPROVAL_PROMPT_MAX = 60;
@@ -147,13 +152,49 @@ function cardRow(c: SceneTraceCard): SceneNode {
 }
 
 function statusRow(s: BuildInput): SceneNode {
-  const runs: TextRun[] = [
+  const leftRuns: TextRun[] = [
     { text: `${s.cardCount} cards`, style: { dim: true } },
     { text: " · " },
     { text: s.busy ? "busy" : "idle", style: { color: s.busy ? "yellow" : "green" } },
   ];
-  if (s.activity) runs.push({ text: ` · ${s.activity}`, style: { dim: true } });
-  return text(runs);
+  if (s.activity) leftRuns.push({ text: ` · ${s.activity}`, style: { dim: true } });
+  const wallet = formatWallet(s.walletBalance, s.walletCurrency);
+  if (!wallet) return text(leftRuns);
+  return box(
+    [
+      text(leftRuns),
+      box([], { width: "fill" }),
+      text([
+        { text: "wallet ", style: { dim: true } },
+        { text: wallet, style: { color: "green" } },
+      ]),
+    ],
+    { direction: "row" },
+  );
+}
+
+function formatWallet(total: number | undefined, currency: string | undefined): string | null {
+  if (total === undefined || !Number.isFinite(total)) return null;
+  const symbol = currencySymbol(currency);
+  return `${symbol}${total.toFixed(2)}`;
+}
+
+function currencySymbol(currency: string | undefined): string {
+  switch ((currency ?? "").toUpperCase()) {
+    case "CNY":
+    case "RMB":
+      return "¥";
+    case "USD":
+      return "$";
+    case "EUR":
+      return "€";
+    case "GBP":
+      return "£";
+    case "JPY":
+      return "¥";
+    default:
+      return currency ? `${currency} ` : "";
+  }
 }
 
 function approvalRow(kind: string | undefined, prompt: string): SceneNode {
@@ -380,6 +421,8 @@ export function useSceneTrace(input: SceneTraceInput): void {
     approvalPrompt,
     sessionsJson,
     sessionsFocusedIndex,
+    walletBalance,
+    walletCurrency,
   } = input;
   useEffect(() => {
     if (!isSceneTraceEnabled()) return;
@@ -403,6 +446,8 @@ export function useSceneTrace(input: SceneTraceInput): void {
           approvalPrompt,
           sessions,
           sessionsFocusedIndex,
+          walletBalance,
+          walletCurrency,
         },
         cols,
         rows,
@@ -424,6 +469,8 @@ export function useSceneTrace(input: SceneTraceInput): void {
     approvalPrompt,
     sessionsJson,
     sessionsFocusedIndex,
+    walletBalance,
+    walletCurrency,
   ]);
 }
 

--- a/tests/scene-trace-frame.test.ts
+++ b/tests/scene-trace-frame.test.ts
@@ -213,6 +213,72 @@ describe("buildTraceFrame", () => {
     expect(busyStatus.runs[2]?.style?.color).toBe("yellow");
   });
 
+  it("keeps the status row as a single text node when no wallet balance is given", () => {
+    const f = buildTraceFrame({ cardCount: 1, busy: false, cards: [] }, 80, 24);
+    if (f.root.kind !== "box") return;
+    const status = f.root.children[2];
+    expect(status?.kind).toBe("text");
+  });
+
+  it("renders a wallet segment on the right when balance + currency are given", () => {
+    const f = buildTraceFrame(
+      { cardCount: 1, busy: false, cards: [], walletBalance: 184.2, walletCurrency: "CNY" },
+      80,
+      24,
+    );
+    if (f.root.kind !== "box") return;
+    const status = f.root.children[2];
+    if (status?.kind !== "box") throw new Error("expected row box with wallet");
+    expect(status.layout?.direction).toBe("row");
+    expect(status.children).toHaveLength(3);
+    const [left, spacer, right] = status.children;
+    if (left?.kind !== "text") throw new Error("expected left text");
+    expect(left.runs.map((r) => r.text).join("")).toContain("1 cards");
+    if (spacer?.kind !== "box") throw new Error("expected spacer box");
+    expect(spacer.layout?.width).toBe("fill");
+    if (right?.kind !== "text") throw new Error("expected right text");
+    const rightFlat = right.runs.map((r) => r.text).join("");
+    expect(rightFlat).toContain("wallet");
+    expect(rightFlat).toContain("¥184.20");
+  });
+
+  it("formats USD with $ and falls back to a code prefix for unknown currencies", () => {
+    const usd = buildTraceFrame(
+      { cardCount: 0, busy: false, cards: [], walletBalance: 5, walletCurrency: "USD" },
+      80,
+      24,
+    );
+    if (usd.root.kind !== "box") return;
+    const usdStatus = usd.root.children[2];
+    if (usdStatus?.kind !== "box") return;
+    const usdRight = usdStatus.children[2];
+    if (usdRight?.kind !== "text") return;
+    expect(usdRight.runs.map((r) => r.text).join("")).toContain("$5.00");
+
+    const other = buildTraceFrame(
+      { cardCount: 0, busy: false, cards: [], walletBalance: 5, walletCurrency: "AUD" },
+      80,
+      24,
+    );
+    if (other.root.kind !== "box") return;
+    const otherStatus = other.root.children[2];
+    if (otherStatus?.kind !== "box") return;
+    const otherRight = otherStatus.children[2];
+    if (otherRight?.kind !== "text") return;
+    expect(otherRight.runs.map((r) => r.text).join("")).toContain("AUD 5.00");
+  });
+
+  it("hides the wallet segment when balance is missing even with a currency present", () => {
+    const f = buildTraceFrame(
+      { cardCount: 0, busy: false, cards: [], walletCurrency: "CNY" },
+      80,
+      24,
+    );
+    if (f.root.kind !== "box") return;
+    const status = f.root.children[2];
+    expect(status?.kind).toBe("text");
+  });
+
   it("appends activity to the status row when given", () => {
     const f = buildTraceFrame(
       { cardCount: 3, busy: true, cards: [], activity: "awaiting tools" },


### PR DESCRIPTION
First concrete consumer of the flex layout primitive from #1000 and
the smallest visible step toward the multi-segment status bar the
design mock points at. Wallet balance is the most direct visible
signal of reasonix's cheap-positioning claim — users see how slowly
the number goes down across a session.

## What

\`\`\`
3 cards · busy · awaiting tools                  wallet ¥184.20
\`\`\`

- New \`SceneTraceInput.walletBalance\` + \`walletCurrency\` scalars
  — primitives so effect deps stay stable (no JSON encoding for one
  number + one string).
- \`statusRow\` upgrades from a single text node to a row box **only
  when the balance is present**: left segments
  (\`cardCount · busy/idle · activity\`) + fill spacer + right segment
  (\`wallet ¥184.20\`). When balance is null/undefined the row stays
  a single text node — back-compat with the existing test that
  asserts \`kind === "text"\` on the status row.
- Currency rendering: \`¥\` for CNY/RMB/JPY, \`$\` for USD, \`€\` EUR,
  \`£\` GBP; unknown codes fall back to \`CODE 5.00\` so nothing
  silently looks like the wrong currency.
- \`App.tsx\` forwards \`balance.total\` and \`balance.currency\` from
  \`useSessionInfo\` — both null until the first successful
  \`getBalance()\` call, so the wallet segment appears once the
  endpoint responds and stays hidden offline.

## Where next

The design mock also wants cache-hit %, branch, spent (this session),
jobs count on the same row. Each is a small isolated wiring step
from here. Doing them one segment per PR keeps risk + scope low and
lets the bottom row evolve incrementally.

## Tests

\`tests/scene-trace-frame.test.ts\` — 4 new cases:

- status row stays \`kind === "text"\` when wallet is undefined
  (back-compat)
- right-aligned wallet segment when balance + currency given
  (verifies the row structure: text + fill-spacer + text)
- USD uses \`$\`, unknown codes use a \`CODE prefix\` fallback
- balance missing → wallet segment hidden even with currency set

\`npm run verify\` green via prepush gate.

Refs #868