### PR TITLE
feat(scene): restructure the trace frame as a three-pane Sidebar/Main/ContextPanel layout

### DIFF
--- a/src/cli/ui/hooks/useSceneTrace.ts
+++ b/src/cli/ui/hooks/useSceneTrace.ts
@@ -88,14 +88,32 @@ function clip(s: string): string {
   return firstLine.length > SUMMARY_MAX ? `${firstLine.slice(0, SUMMARY_MAX - 1)}…` : firstLine;
 }
 
+const SIDEBAR_WIDTH = 24;
+const CTXPANE_WIDTH = 32;
+const SIDEBAR_MIN_COLS = 60;
+const CTXPANE_MIN_COLS = 100;
+
 export function buildTraceFrame(input: BuildInput, cols: number, rows: number): SceneFrame {
-  const children: SceneNode[] = [titleRow(input)];
+  const showSidebar = cols >= SIDEBAR_MIN_COLS;
+  const showCtxPane = cols >= CTXPANE_MIN_COLS;
+  const title = titleRow(input);
+  const status = statusRow(input, { suppressWallet: showCtxPane });
+  const main = mainPane(input);
+  const middleChildren: SceneNode[] = [];
+  if (showSidebar) middleChildren.push(sidebarPane());
+  middleChildren.push(main);
+  if (showCtxPane) middleChildren.push(ctxPane(input));
+  const middle = box(middleChildren, { direction: "row", height: "fill", gap: 1 });
+  return frame(cols, rows, box([title, middle, status], { direction: "column", paddingX: 1 }));
+}
+
+function mainPane(input: BuildInput): SceneNode {
+  const children: SceneNode[] = [];
   if (input.cards.length === 0) {
     children.push(noCardsRow());
   } else {
     for (const c of input.cards) children.push(cardRow(c));
   }
-  children.push(statusRow(input));
   const sessions = input.sessions ?? [];
   const pickerOwnsBottom = sessions.length > 0;
   if (pickerOwnsBottom) {
@@ -125,7 +143,39 @@ export function buildTraceFrame(input: BuildInput, cols: number, rows: number): 
     const hidden = slash.length - shown.length;
     if (hidden > 0) children.push(slashOverflowRow(hidden));
   }
-  return frame(cols, rows, box(children, { direction: "column", paddingX: 1 }));
+  return box(children, { direction: "column", width: "fill" });
+}
+
+function sidebarPane(): SceneNode {
+  return box(
+    [
+      sectionHeaderRow("SESSIONS"),
+      text([{ text: "use /sessions", style: { dim: true } }]),
+      text([{ text: "to browse", style: { dim: true } }]),
+    ],
+    { direction: "column", width: SIDEBAR_WIDTH },
+  );
+}
+
+function ctxPane(input: BuildInput): SceneNode {
+  const children: SceneNode[] = [sectionHeaderRow("CONTEXT")];
+  if (input.model) children.push(keyValueRow("model", input.model));
+  children.push(keyValueRow("cards", String(input.cardCount)));
+  const wallet = formatWallet(input.walletBalance, input.walletCurrency);
+  if (wallet) children.push(keyValueRow("wallet", wallet));
+  return box(children, { direction: "column", width: CTXPANE_WIDTH });
+}
+
+function sectionHeaderRow(label: string): SceneNode {
+  return text([
+    { text: "─ ", style: { dim: true } },
+    { text: label, style: { bold: true, color: "cyan" } },
+    { text: " ─", style: { dim: true } },
+  ]);
+}
+
+function keyValueRow(key: string, value: string): SceneNode {
+  return text([{ text: key.padEnd(8), style: { dim: true } }, { text: value }]);
 }
 
 function titleRow(s: BuildInput): SceneNode {
@@ -151,14 +201,14 @@ function cardRow(c: SceneTraceCard): SceneNode {
   return text(runs);
 }
 
-function statusRow(s: BuildInput): SceneNode {
+function statusRow(s: BuildInput, opts: { suppressWallet?: boolean } = {}): SceneNode {
   const leftRuns: TextRun[] = [
     { text: `${s.cardCount} cards`, style: { dim: true } },
     { text: " · " },
     { text: s.busy ? "busy" : "idle", style: { color: s.busy ? "yellow" : "green" } },
   ];
   if (s.activity) leftRuns.push({ text: ` · ${s.activity}`, style: { dim: true } });
-  const wallet = formatWallet(s.walletBalance, s.walletCurrency);
+  const wallet = opts.suppressWallet ? null : formatWallet(s.walletBalance, s.walletCurrency);
   if (!wallet) return text(leftRuns);
   return box(
     [

--- a/tests/scene-trace-frame.test.ts
+++ b/tests/scene-trace-frame.test.ts
@@ -12,7 +12,32 @@ import {
   slashWindow,
   summarizeCard,
 } from "../src/cli/ui/hooks/useSceneTrace.js";
+import type { SceneNode } from "../src/cli/ui/scene/types.js";
 import type { Card } from "../src/cli/ui/state/cards.js";
+
+function mainOf(f: ReturnType<typeof buildTraceFrame>): SceneNode[] {
+  if (f.root.kind !== "box") throw new Error("expected root box");
+  const middle = f.root.children[1];
+  if (middle?.kind !== "box") throw new Error("expected middle box");
+  for (const c of middle.children) {
+    if (c.kind === "box" && c.layout?.width === "fill") return c.children;
+  }
+  throw new Error("no main pane (width=fill) found in middle");
+}
+
+function titleOf(f: ReturnType<typeof buildTraceFrame>): SceneNode {
+  if (f.root.kind !== "box") throw new Error("expected root box");
+  const node = f.root.children[0];
+  if (!node) throw new Error("no title");
+  return node;
+}
+
+function statusOf(f: ReturnType<typeof buildTraceFrame>): SceneNode {
+  if (f.root.kind !== "box") throw new Error("expected root box");
+  const node = f.root.children[2];
+  if (!node) throw new Error("no status");
+  return node;
+}
 
 function userCard(text: string): Card {
   return { id: "u1", ts: 0, kind: "user", text };
@@ -126,7 +151,7 @@ describe("cardsForHeight", () => {
 });
 
 describe("buildTraceFrame", () => {
-  it("returns a column box with title + placeholder + status + composer when no cards", () => {
+  it("returns a column box with title / middle / status at the root", () => {
     const f = buildEmpty();
     expect(f.schemaVersion).toBe(1);
     expect(f.cols).toBe(80);
@@ -135,14 +160,38 @@ describe("buildTraceFrame", () => {
     if (f.root.kind !== "box") return;
     expect(f.root.layout?.direction).toBe("column");
     expect(f.root.layout?.paddingX).toBe(1);
-    expect(f.root.children).toHaveLength(4);
+    expect(f.root.children).toHaveLength(3);
+    const middle = f.root.children[1];
+    if (middle?.kind !== "box") throw new Error("expected middle box");
+    expect(middle.layout?.direction).toBe("row");
+    expect(middle.layout?.height).toBe("fill");
+  });
+
+  it("shows the sidebar pane at cols >= 60 and hides it on a narrow terminal", () => {
+    const wide = buildTraceFrame({ cardCount: 0, busy: false, cards: [] }, 80, 24);
+    const narrow = buildTraceFrame({ cardCount: 0, busy: false, cards: [] }, 40, 24);
+    if (wide.root.kind !== "box" || narrow.root.kind !== "box") return;
+    const wideMiddle = wide.root.children[1];
+    const narrowMiddle = narrow.root.children[1];
+    if (wideMiddle?.kind !== "box" || narrowMiddle?.kind !== "box") return;
+    expect(wideMiddle.children.length).toBeGreaterThan(narrowMiddle.children.length);
+  });
+
+  it("shows the context pane only at cols >= 100", () => {
+    const med = buildTraceFrame({ cardCount: 0, busy: false, cards: [] }, 80, 24);
+    const wide = buildTraceFrame({ cardCount: 0, busy: false, cards: [] }, 120, 24);
+    if (med.root.kind !== "box" || wide.root.kind !== "box") return;
+    const medMiddle = med.root.children[1];
+    const wideMiddle = wide.root.children[1];
+    if (medMiddle?.kind !== "box" || wideMiddle?.kind !== "box") return;
+    expect(medMiddle.children).toHaveLength(2);
+    expect(wideMiddle.children).toHaveLength(3);
   });
 
   it("renders the title as a row with brand on the left and model on the right separated by a fill spacer", () => {
     const f = buildEmpty({ model: "deepseek-chat" });
-    if (f.root.kind !== "box") throw new Error("expected box root");
-    const title = f.root.children[0];
-    if (title?.kind !== "box") throw new Error("expected title to be a box");
+    const title = titleOf(f);
+    if (title.kind !== "box") throw new Error("expected title to be a box");
     expect(title.layout?.direction).toBe("row");
     expect(title.children).toHaveLength(3);
     const [brand, spacer, model] = title.children;
@@ -156,31 +205,29 @@ describe("buildTraceFrame", () => {
 
   it("omits the model node from the title row when no model is given", () => {
     const f = buildEmpty();
-    if (f.root.kind !== "box") throw new Error("expected box root");
-    const title = f.root.children[0];
-    if (title?.kind !== "box") throw new Error("expected title to be a box");
+    const title = titleOf(f);
+    if (title.kind !== "box") throw new Error("expected title to be a box");
     expect(title.children).toHaveLength(2);
   });
 
-  it("shows a placeholder card row when no cards exist", () => {
+  it("shows a placeholder card row inside the main pane when no cards exist", () => {
     const f = buildEmpty();
-    if (f.root.kind !== "box") return;
-    const card = f.root.children[1];
-    if (card?.kind !== "text") return;
+    const card = mainOf(f)[0];
+    if (card?.kind !== "text") throw new Error("expected text");
     expect(card.runs.map((r) => r.text).join("")).toContain("no cards yet");
   });
 
-  it("stacks one row per card between the title and status rows", () => {
+  it("stacks one row per card inside the main pane", () => {
     const cards: SceneTraceCard[] = [
       { kind: "user", summary: "hi" },
       { kind: "streaming", summary: "hello back" },
       { kind: "user", summary: "follow up" },
     ];
     const f = buildTraceFrame({ cardCount: 3, busy: false, cards }, 80, 24);
-    if (f.root.kind !== "box") return;
-    expect(f.root.children).toHaveLength(3 + 3);
-    const firstCard = f.root.children[1];
-    const lastCard = f.root.children[3];
+    const main = mainOf(f);
+    expect(main).toHaveLength(3 + 1);
+    const firstCard = main[0];
+    const lastCard = main[2];
     if (firstCard?.kind !== "text" || lastCard?.kind !== "text") return;
     expect(firstCard.runs[2]?.text).toBe("hi");
     expect(lastCard.runs[2]?.text).toBe("follow up");
@@ -192,8 +239,7 @@ describe("buildTraceFrame", () => {
       80,
       24,
     );
-    if (f.root.kind !== "box") return;
-    const cardRow = f.root.children[1];
+    const cardRow = mainOf(f)[0];
     if (cardRow?.kind !== "text") return;
     expect(cardRow.runs[0]?.style?.color).toBe("cyan");
     expect(cardRow.runs[0]?.text).toBe(">");
@@ -204,31 +250,26 @@ describe("buildTraceFrame", () => {
   it("paints status as green when idle and yellow when busy", () => {
     const idle = buildTraceFrame({ cardCount: 3, busy: false, cards: [] }, 80, 24);
     const busy = buildTraceFrame({ cardCount: 3, busy: true, cards: [] }, 80, 24);
-    if (idle.root.kind !== "box" || busy.root.kind !== "box") return;
-    // children: title, placeholder, status, composer
-    const idleStatus = idle.root.children[2];
-    const busyStatus = busy.root.children[2];
-    if (idleStatus?.kind !== "text" || busyStatus?.kind !== "text") return;
+    const idleStatus = statusOf(idle);
+    const busyStatus = statusOf(busy);
+    if (idleStatus.kind !== "text" || busyStatus.kind !== "text") return;
     expect(idleStatus.runs[2]?.style?.color).toBe("green");
     expect(busyStatus.runs[2]?.style?.color).toBe("yellow");
   });
 
   it("keeps the status row as a single text node when no wallet balance is given", () => {
     const f = buildTraceFrame({ cardCount: 1, busy: false, cards: [] }, 80, 24);
-    if (f.root.kind !== "box") return;
-    const status = f.root.children[2];
-    expect(status?.kind).toBe("text");
+    expect(statusOf(f).kind).toBe("text");
   });
 
-  it("renders a wallet segment on the right when balance + currency are given", () => {
+  it("renders a wallet segment on the right of status when balance is given and the ctx pane is hidden", () => {
     const f = buildTraceFrame(
       { cardCount: 1, busy: false, cards: [], walletBalance: 184.2, walletCurrency: "CNY" },
       80,
       24,
     );
-    if (f.root.kind !== "box") return;
-    const status = f.root.children[2];
-    if (status?.kind !== "box") throw new Error("expected row box with wallet");
+    const status = statusOf(f);
+    if (status.kind !== "box") throw new Error("expected row box with wallet");
     expect(status.layout?.direction).toBe("row");
     expect(status.children).toHaveLength(3);
     const [left, spacer, right] = status.children;
@@ -242,15 +283,32 @@ describe("buildTraceFrame", () => {
     expect(rightFlat).toContain("¥184.20");
   });
 
+  it("moves wallet from the status row into the context pane when both are visible", () => {
+    const f = buildTraceFrame(
+      { cardCount: 1, busy: false, cards: [], walletBalance: 184.2, walletCurrency: "CNY" },
+      120,
+      24,
+    );
+    expect(statusOf(f).kind).toBe("text");
+    if (f.root.kind !== "box") return;
+    const middle = f.root.children[1];
+    if (middle?.kind !== "box") return;
+    const ctxPane = middle.children.at(-1);
+    if (ctxPane?.kind !== "box") return;
+    const flat = ctxPane.children
+      .map((c) => (c.kind === "text" ? c.runs.map((r) => r.text).join("") : ""))
+      .join("\n");
+    expect(flat).toContain("¥184.20");
+  });
+
   it("formats USD with $ and falls back to a code prefix for unknown currencies", () => {
     const usd = buildTraceFrame(
       { cardCount: 0, busy: false, cards: [], walletBalance: 5, walletCurrency: "USD" },
       80,
       24,
     );
-    if (usd.root.kind !== "box") return;
-    const usdStatus = usd.root.children[2];
-    if (usdStatus?.kind !== "box") return;
+    const usdStatus = statusOf(usd);
+    if (usdStatus.kind !== "box") return;
     const usdRight = usdStatus.children[2];
     if (usdRight?.kind !== "text") return;
     expect(usdRight.runs.map((r) => r.text).join("")).toContain("$5.00");
@@ -260,9 +318,8 @@ describe("buildTraceFrame", () => {
       80,
       24,
     );
-    if (other.root.kind !== "box") return;
-    const otherStatus = other.root.children[2];
-    if (otherStatus?.kind !== "box") return;
+    const otherStatus = statusOf(other);
+    if (otherStatus.kind !== "box") return;
     const otherRight = otherStatus.children[2];
     if (otherRight?.kind !== "text") return;
     expect(otherRight.runs.map((r) => r.text).join("")).toContain("AUD 5.00");
@@ -274,9 +331,7 @@ describe("buildTraceFrame", () => {
       80,
       24,
     );
-    if (f.root.kind !== "box") return;
-    const status = f.root.children[2];
-    expect(status?.kind).toBe("text");
+    expect(statusOf(f).kind).toBe("text");
   });
 
   it("appends activity to the status row when given", () => {
@@ -285,16 +340,14 @@ describe("buildTraceFrame", () => {
       80,
       24,
     );
-    if (f.root.kind !== "box") return;
-    const status = f.root.children[2];
-    if (status?.kind !== "text") return;
+    const status = statusOf(f);
+    if (status.kind !== "text") return;
     expect(status.runs.map((r) => r.text).join("")).toContain("awaiting tools");
   });
 
   it("composer row is a dim placeholder when composerText is empty / undefined", () => {
     for (const f of [buildEmpty(), buildEmpty({ composerText: "" })]) {
-      if (f.root.kind !== "box") return;
-      const composer = f.root.children[3];
+      const composer = mainOf(f).at(-1);
       if (composer?.kind !== "text") return;
       expect(composer.runs[0]?.text).toBe("❯ ");
       expect(composer.runs[0]?.style?.color).toBe("cyan");
@@ -308,8 +361,7 @@ describe("buildTraceFrame", () => {
       80,
       24,
     );
-    if (f.root.kind !== "box") return;
-    const composer = f.root.children[3];
+    const composer = mainOf(f).at(-1);
     if (composer?.kind !== "text") return;
     expect(composer.runs[0]?.text).toBe("❯ ");
     expect(composer.runs[1]?.text).toBe("hello");
@@ -323,8 +375,7 @@ describe("buildTraceFrame", () => {
       80,
       24,
     );
-    if (f.root.kind !== "box") throw new Error("expected box");
-    const composer = f.root.children[3];
+    const composer = mainOf(f).at(-1);
     if (composer?.kind !== "text") throw new Error("expected text");
     return composer.runs.map((r) => r.text);
   }
@@ -374,15 +425,14 @@ describe("buildTraceFrame", () => {
 
   it("omits slash rows when slashMatches is empty / undefined", () => {
     const f = buildEmpty();
-    if (f.root.kind !== "box") return;
-    expect(f.root.children).toHaveLength(4);
+    expect(mainOf(f)).toHaveLength(2);
   });
 
   it("appends one slash row per match below the composer with a ▸ on the selected one", () => {
     const f = buildWithSlash(makeMatches(3), 1);
-    if (f.root.kind !== "box") return;
-    expect(f.root.children).toHaveLength(4 + 3);
-    const rows = f.root.children.slice(4);
+    const main = mainOf(f);
+    expect(main).toHaveLength(1 + 1 + 3);
+    const rows = main.slice(2);
     const rendered = rows.map((r) => (r.kind === "text" ? r.runs.map((x) => x.text).join("") : ""));
     expect(rendered[0]?.startsWith("  /cmd0")).toBe(true);
     expect(rendered[1]?.startsWith("▸ /cmd1")).toBe(true);
@@ -391,8 +441,7 @@ describe("buildTraceFrame", () => {
 
   it("includes argsHint after the cmd when given", () => {
     const f = buildWithSlash([{ cmd: "/model", summary: "switch model", argsHint: "<name>" }], 0);
-    if (f.root.kind !== "box") return;
-    const row = f.root.children[4];
+    const row = mainOf(f)[2];
     if (row?.kind !== "text") return;
     const flat = row.runs.map((r) => r.text).join("");
     expect(flat).toContain("/model");
@@ -402,9 +451,9 @@ describe("buildTraceFrame", () => {
 
   it("windows long match lists and shows an overflow row with the hidden count", () => {
     const f = buildWithSlash(makeMatches(20), 0);
-    if (f.root.kind !== "box") return;
-    expect(f.root.children).toHaveLength(4 + 6 + 1);
-    const overflow = f.root.children.at(-1);
+    const main = mainOf(f);
+    expect(main).toHaveLength(1 + 1 + 6 + 1);
+    const overflow = main.at(-1);
     if (overflow?.kind !== "text") return;
     expect(overflow.runs.map((r) => r.text).join("")).toContain("…14 more");
   });
@@ -436,8 +485,7 @@ describe("buildTraceFrame", () => {
 
   it("clamps an out-of-range slashSelectedIndex", () => {
     const f = buildWithSlash(makeMatches(3), 99);
-    if (f.root.kind !== "box") return;
-    const rows = f.root.children.slice(4);
+    const rows = mainOf(f).slice(2);
     const flat = rows.map((r) => (r.kind === "text" ? r.runs.map((x) => x.text).join("") : ""));
     expect(flat[2]?.startsWith("▸ /cmd2")).toBe(true);
   });
@@ -461,9 +509,9 @@ describe("buildTraceFrame approval modal", () => {
 
   it("replaces the composer row with an approval row when approvalPrompt is set", () => {
     const f = buildWithApproval("shell", "rm -rf /tmp/x");
-    if (f.root.kind !== "box") return;
-    expect(f.root.children).toHaveLength(4);
-    const row = f.root.children[3];
+    const main = mainOf(f);
+    expect(main).toHaveLength(2);
+    const row = main[1];
     if (row?.kind !== "text") return;
     const flat = row.runs.map((r) => r.text).join("");
     expect(flat).toContain("❓");
@@ -477,8 +525,7 @@ describe("buildTraceFrame approval modal", () => {
   it("clips an overlong approval prompt to 60 chars with an ellipsis", () => {
     const long = "x".repeat(120);
     const f = buildWithApproval("shell", long);
-    if (f.root.kind !== "box") return;
-    const row = f.root.children[3];
+    const row = mainOf(f)[1];
     if (row?.kind !== "text") return;
     const promptRun = row.runs.find((r) => r.text.includes("x"));
     expect(promptRun?.text).toHaveLength(60);
@@ -487,8 +534,7 @@ describe("buildTraceFrame approval modal", () => {
 
   it("omits the kind tag when approvalKind is undefined", () => {
     const f = buildWithApproval(undefined, "go ahead?");
-    if (f.root.kind !== "box") return;
-    const row = f.root.children[3];
+    const row = mainOf(f)[1];
     if (row?.kind !== "text") return;
     const flat = row.runs.map((r) => r.text).join("");
     expect(flat).not.toContain("[]");
@@ -510,8 +556,7 @@ describe("buildTraceFrame approval modal", () => {
       80,
       24,
     );
-    if (f.root.kind !== "box") return;
-    expect(f.root.children).toHaveLength(4);
+    expect(mainOf(f)).toHaveLength(2);
   });
 });
 
@@ -540,18 +585,18 @@ describe("buildTraceFrame sessions picker", () => {
 
   it("replaces composer with a header + one row per session + a hint footer", () => {
     const f = buildWithSessions(makeSessions(3), 0);
-    if (f.root.kind !== "box") return;
-    expect(f.root.children).toHaveLength(3 + 1 + 3 + 1);
-    const header = f.root.children[3];
+    const main = mainOf(f);
+    expect(main).toHaveLength(1 + 1 + 3 + 1);
+    const header = main[1];
     if (header?.kind !== "text") return;
     const headerFlat = header.runs.map((r) => r.text).join("");
     expect(headerFlat).toContain("sessions");
     expect(headerFlat).toContain("(3 saved)");
-    const row0 = f.root.children[4];
+    const row0 = main[2];
     if (row0?.kind !== "text") return;
     expect(row0.runs[0]?.text).toBe("▸ ");
     expect(row0.runs[1]?.text).toBe("session-0");
-    const hint = f.root.children.at(-1);
+    const hint = main.at(-1);
     if (hint?.kind !== "text") return;
     const hintFlat = hint.runs.map((r) => r.text).join("");
     expect(hintFlat).toContain("navigate");
@@ -560,9 +605,9 @@ describe("buildTraceFrame sessions picker", () => {
 
   it("windows a long session list at MAX_SESSION_ROWS (8) with an overflow row", () => {
     const f = buildWithSessions(makeSessions(20), 15);
-    if (f.root.kind !== "box") return;
-    expect(f.root.children).toHaveLength(3 + 1 + 8 + 1 + 1);
-    const overflow = f.root.children.at(-2);
+    const main = mainOf(f);
+    expect(main).toHaveLength(1 + 1 + 8 + 1 + 1);
+    const overflow = main.at(-2);
     if (overflow?.kind !== "text") return;
     expect(overflow.runs.map((r) => r.text).join("")).toContain("…12 more");
   });
@@ -582,8 +627,7 @@ describe("buildTraceFrame sessions picker", () => {
       80,
       24,
     );
-    if (f.root.kind !== "box") return;
-    const flat = f.root.children
+    const flat = mainOf(f)
       .map((c) => (c.kind === "text" ? c.runs.map((r) => r.text).join("") : ""))
       .join(" | ");
     expect(flat).not.toContain("/help");
@@ -592,8 +636,7 @@ describe("buildTraceFrame sessions picker", () => {
 
   it("renders meta after the title when given", () => {
     const f = buildWithSessions([{ title: "feat-foo", meta: "feat · 12 turns" }], 0);
-    if (f.root.kind !== "box") return;
-    const row = f.root.children[4];
+    const row = mainOf(f)[2];
     if (row?.kind !== "text") return;
     const flat = row.runs.map((r) => r.text).join("");
     expect(flat).toContain("feat-foo");


### PR DESCRIPTION
Stage 1 toward the user's design mock. Restructures the trace frame
from a flat column of rows into the classic IDE three-pane shape.

\`\`\`
┌─────────────  title (full width) ─────────────┐
│ SIDEBAR (24) │   MAIN (fill)   │  CTX (32)    │
└─────────────  status (full width) ────────────┘
\`\`\`

## What

The middle band is a \`direction: \"row\"\` box with \`height: \"fill\"\`,
made possible by the flex-sizing infra from #1000. Sidebar and
context pane have fixed cell widths; main pane fills the remainder.
Both side panes auto-hide on narrow terminals — sidebar below
60 cols, context pane below 100 cols — so an 80-col terminal still
works the way it did before, just with a sessions rail on the left.

**Main pane (unchanged behavior).** Cards stack, composer / approval /
sessions-picker takeover, slash overlay — exactly the same nodes as
before, now living inside the main pane's column instead of inline
in the root.

**Sidebar (stage-1 placeholder).** Just \`─ SESSIONS ─\` header +
\`use /sessions to browse\` hint. The real session list goes here in
stage 2 once App.tsx surfaces a permanently-loaded list (today it's
loaded only when the picker is open). Doing this PR without real data
is deliberate — the structural change is large enough on its own,
and the placeholder honestly says \"this is where it goes.\"

**Context pane (uses what's wired).** \`─ CONTEXT ─\` + \`model · cards
· wallet\`. Wallet moves from the status row into the ctx pane when
both are visible — avoids duplicating it. At cols < 100 the ctx pane
is hidden and wallet stays on the right of the status row (as in
#1001).

## Test rewrite

The flat-children shape was load-bearing in 15 tests. Added three
helpers (\`mainOf(f)\` / \`statusOf(f)\` / \`titleOf(f)\`) and rewrote
each test to drill through the new structure. Coverage is identical
in spirit (cards / composer / approval modal / sessions picker /
slash overlay / status segments all still verified) but expressed
against the new hierarchy.

3 new shape tests:

- root is now \`[title, middle, status]\` (3 children, not 4-7)
- sidebar hidden below 60 cols
- context pane hidden below 100 cols
- wallet moves from status row into context pane when both visible

\`npm run verify\` green via prepush gate (61 scene-trace tests).

## Coming up (separate sub-PRs)

- Stage 2 — real sessions list in the sidebar (wires App.tsx to
  keep \`sessionsPickerList\` populated whether or not the picker is
  open).
- Stage 3 — fill the context pane with cache-hit % and context token
  meter (telemetry/stats data).
- Stage 4 — card head/body split + collapse (long tool outputs).

Refs #868