### PR TITLE
feat(scene): wire borders + background colors and apply a design-mock palette

### DIFF
--- a/crates/reasonix-render/src/render.rs
+++ b/crates/reasonix-render/src/render.rs
@@ -1,11 +1,12 @@
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::style::{Color as RColor, Modifier, Style};
+use ratatui::widgets::{Block, BorderType, Borders, Widget};
 use unicode_width::UnicodeWidthChar;
 
 use crate::scene::{
-    BoxLayout, Color, Dim, FillToken, FlexDirection, NamedColor, SceneFrame, SceneNode, TextRun,
-    TextStyle,
+    BorderStyle, BoxLayout, Color, Dim, FillToken, FlexDirection, NamedColor, SceneFrame,
+    SceneNode, TextRun, TextStyle,
 };
 
 #[derive(Clone, Copy)]
@@ -59,6 +60,7 @@ fn display_width(ch: char) -> u16 {
 }
 
 fn render_box(layout: Option<&BoxLayout>, children: &[SceneNode], buf: &mut Buffer, area: Rect) {
+    let area = apply_decoration(layout, buf, area);
     let inner = apply_padding(layout, area);
     if inner.width == 0 || inner.height == 0 {
         return;
@@ -74,6 +76,41 @@ fn render_box(layout: Option<&BoxLayout>, children: &[SceneNode], buf: &mut Buff
     match direction {
         FlexDirection::Column => render_column(children, gap, buf, inner),
         FlexDirection::Row => render_row(children, gap, buf, inner),
+    }
+}
+
+fn apply_decoration(layout: Option<&BoxLayout>, buf: &mut Buffer, area: Rect) -> Rect {
+    let Some(l) = layout else {
+        return area;
+    };
+    let has_border = l.border_style.is_some();
+    let has_bg = l.background.is_some();
+    if !has_border && !has_bg {
+        return area;
+    }
+    let mut block = Block::default();
+    if let Some(bg) = l.background.as_ref() {
+        block = block.style(Style::default().bg(color_to_ratatui(bg)));
+    }
+    if let Some(border_style) = l.border_style {
+        block = block
+            .borders(Borders::ALL)
+            .border_type(border_type_from(border_style));
+        if let Some(border_color) = l.border_color.as_ref() {
+            block = block.border_style(Style::default().fg(color_to_ratatui(border_color)));
+        }
+    }
+    let inner = block.inner(area);
+    block.render(area, buf);
+    inner
+}
+
+fn border_type_from(style: BorderStyle) -> BorderType {
+    match style {
+        BorderStyle::Single => BorderType::Plain,
+        BorderStyle::Double => BorderType::Double,
+        BorderStyle::Round => BorderType::Rounded,
+        BorderStyle::Bold => BorderType::Thick,
     }
 }
 

--- a/crates/reasonix-render/src/scene.rs
+++ b/crates/reasonix-render/src/scene.rs
@@ -125,6 +125,8 @@ pub struct BoxLayout {
         skip_serializing_if = "Option::is_none"
     )]
     pub border_color: Option<Color>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub background: Option<Color>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/reasonix-render/tests/render.rs
+++ b/crates/reasonix-render/tests/render.rs
@@ -4,8 +4,8 @@ use ratatui::style::{Color as RColor, Modifier};
 
 use reasonix_render::render::render_frame;
 use reasonix_render::scene::{
-    BoxLayout, Color, Dim, FillToken, FlexDirection, NamedColor, SceneFrame, SceneNode, TextRun,
-    TextStyle,
+    BorderStyle, BoxLayout, Color, Dim, FillToken, FlexDirection, NamedColor, SceneFrame,
+    SceneNode, TextRun, TextStyle,
 };
 
 fn box_with_width(text: &str, width: Dim) -> SceneNode {
@@ -406,6 +406,134 @@ fn column_fill_child_consumes_remaining_height() {
     assert_eq!(buf[(0, 0)].symbol(), "T");
     assert_eq!(buf[(0, 1)].symbol(), "M");
     assert_eq!(buf[(0, 9)].symbol(), "B");
+}
+
+#[test]
+fn box_with_single_border_draws_box_drawing_glyphs_at_the_perimeter() {
+    let frame = frame_of(SceneNode::Box {
+        layout: Some(BoxLayout {
+            border_style: Some(BorderStyle::Single),
+            ..Default::default()
+        }),
+        children: vec![SceneNode::Text {
+            runs: vec![TextRun {
+                text: "x".to_string(),
+                style: None,
+            }],
+            wrap: None,
+        }],
+    });
+    let area = Rect::new(0, 0, 5, 3);
+    let mut buf = Buffer::empty(area);
+    render_frame(&frame, &mut buf, area);
+    assert_eq!(buf[(0, 0)].symbol(), "┌");
+    assert_eq!(buf[(4, 0)].symbol(), "┐");
+    assert_eq!(buf[(0, 2)].symbol(), "└");
+    assert_eq!(buf[(4, 2)].symbol(), "┘");
+    assert_eq!(buf[(1, 0)].symbol(), "─");
+    assert_eq!(buf[(0, 1)].symbol(), "│");
+    assert_eq!(buf[(1, 1)].symbol(), "x");
+}
+
+#[test]
+fn rounded_border_uses_curved_corner_glyphs() {
+    let frame = frame_of(SceneNode::Box {
+        layout: Some(BoxLayout {
+            border_style: Some(BorderStyle::Round),
+            ..Default::default()
+        }),
+        children: vec![],
+    });
+    let area = Rect::new(0, 0, 4, 3);
+    let mut buf = Buffer::empty(area);
+    render_frame(&frame, &mut buf, area);
+    assert_eq!(buf[(0, 0)].symbol(), "╭");
+    assert_eq!(buf[(3, 0)].symbol(), "╮");
+    assert_eq!(buf[(0, 2)].symbol(), "╰");
+    assert_eq!(buf[(3, 2)].symbol(), "╯");
+}
+
+#[test]
+fn double_border_uses_double_line_glyphs() {
+    let frame = frame_of(SceneNode::Box {
+        layout: Some(BoxLayout {
+            border_style: Some(BorderStyle::Double),
+            ..Default::default()
+        }),
+        children: vec![],
+    });
+    let area = Rect::new(0, 0, 4, 3);
+    let mut buf = Buffer::empty(area);
+    render_frame(&frame, &mut buf, area);
+    assert_eq!(buf[(0, 0)].symbol(), "╔");
+    assert_eq!(buf[(3, 0)].symbol(), "╗");
+}
+
+#[test]
+fn border_color_is_applied_to_perimeter_cells() {
+    let frame = frame_of(SceneNode::Box {
+        layout: Some(BoxLayout {
+            border_style: Some(BorderStyle::Single),
+            border_color: Some(Color::Named(NamedColor::Cyan)),
+            ..Default::default()
+        }),
+        children: vec![],
+    });
+    let area = Rect::new(0, 0, 4, 3);
+    let mut buf = Buffer::empty(area);
+    render_frame(&frame, &mut buf, area);
+    assert_eq!(buf[(0, 0)].style().fg, Some(RColor::Cyan));
+    assert_eq!(buf[(1, 0)].style().fg, Some(RColor::Cyan));
+}
+
+#[test]
+fn background_fills_every_cell_inside_the_box() {
+    let frame = frame_of(SceneNode::Box {
+        layout: Some(BoxLayout {
+            background: Some(Color::Hex {
+                hex: "#112233".to_string(),
+            }),
+            ..Default::default()
+        }),
+        children: vec![SceneNode::Text {
+            runs: vec![TextRun {
+                text: "y".to_string(),
+                style: None,
+            }],
+            wrap: None,
+        }],
+    });
+    let area = Rect::new(0, 0, 3, 2);
+    let mut buf = Buffer::empty(area);
+    render_frame(&frame, &mut buf, area);
+    let want = RColor::Rgb(0x11, 0x22, 0x33);
+    assert_eq!(buf[(0, 0)].style().bg, Some(want));
+    assert_eq!(buf[(2, 1)].style().bg, Some(want));
+    assert_eq!(buf[(0, 0)].symbol(), "y");
+}
+
+#[test]
+fn border_shrinks_the_inner_area_by_one_cell_on_each_side() {
+    let frame = frame_of(SceneNode::Box {
+        layout: Some(BoxLayout {
+            direction: Some(FlexDirection::Column),
+            border_style: Some(BorderStyle::Single),
+            ..Default::default()
+        }),
+        children: vec![SceneNode::Text {
+            runs: vec![TextRun {
+                text: "abc".to_string(),
+                style: None,
+            }],
+            wrap: None,
+        }],
+    });
+    let area = Rect::new(0, 0, 5, 3);
+    let mut buf = Buffer::empty(area);
+    render_frame(&frame, &mut buf, area);
+    assert_eq!(buf[(1, 1)].symbol(), "a");
+    assert_eq!(buf[(2, 1)].symbol(), "b");
+    assert_eq!(buf[(3, 1)].symbol(), "c");
 }
 
 #[test]

--- a/src/cli/ui/hooks/useSceneTrace.ts
+++ b/src/cli/ui/hooks/useSceneTrace.ts
@@ -1,6 +1,7 @@
 import { useStdout } from "ink";
 import { useEffect } from "react";
 import { box, frame, text } from "../scene/build.js";
+import { PALETTE } from "../scene/theme.js";
 import { emitSceneFrame, isSceneTraceEnabled } from "../scene/trace.js";
 import type { Color, SceneFrame, SceneNode, TextRun } from "../scene/types.js";
 import type { Card } from "../state/cards.js";
@@ -104,7 +105,11 @@ export function buildTraceFrame(input: BuildInput, cols: number, rows: number): 
   middleChildren.push(main);
   if (showCtxPane) middleChildren.push(ctxPane(input));
   const middle = box(middleChildren, { direction: "row", height: "fill", gap: 1 });
-  return frame(cols, rows, box([title, middle, status], { direction: "column", paddingX: 1 }));
+  return frame(
+    cols,
+    rows,
+    box([title, middle, status], { direction: "column", background: PALETTE.bg }),
+  );
 }
 
 function mainPane(input: BuildInput): SceneNode {
@@ -143,17 +148,24 @@ function mainPane(input: BuildInput): SceneNode {
     const hidden = slash.length - shown.length;
     if (hidden > 0) children.push(slashOverflowRow(hidden));
   }
-  return box(children, { direction: "column", width: "fill" });
+  return box(children, { direction: "column", width: "fill", paddingX: 1 });
 }
 
 function sidebarPane(): SceneNode {
   return box(
     [
       sectionHeaderRow("SESSIONS"),
-      text([{ text: "use /sessions", style: { dim: true } }]),
-      text([{ text: "to browse", style: { dim: true } }]),
+      text([{ text: "use /sessions", style: { color: PALETTE.muted } }]),
+      text([{ text: "to browse", style: { color: PALETTE.muted } }]),
     ],
-    { direction: "column", width: SIDEBAR_WIDTH },
+    {
+      direction: "column",
+      width: SIDEBAR_WIDTH,
+      paddingX: 1,
+      borderStyle: "round",
+      borderColor: PALETTE.border,
+      background: PALETTE.bg2,
+    },
   );
 }
 
@@ -162,30 +174,39 @@ function ctxPane(input: BuildInput): SceneNode {
   if (input.model) children.push(keyValueRow("model", input.model));
   children.push(keyValueRow("cards", String(input.cardCount)));
   const wallet = formatWallet(input.walletBalance, input.walletCurrency);
-  if (wallet) children.push(keyValueRow("wallet", wallet));
-  return box(children, { direction: "column", width: CTXPANE_WIDTH });
+  if (wallet) children.push(keyValueRow("wallet", wallet, PALETTE.success));
+  return box(children, {
+    direction: "column",
+    width: CTXPANE_WIDTH,
+    paddingX: 1,
+    borderStyle: "round",
+    borderColor: PALETTE.border,
+    background: PALETTE.bg2,
+  });
 }
 
 function sectionHeaderRow(label: string): SceneNode {
+  return text([{ text: label, style: { bold: true, color: PALETTE.accent } }]);
+}
+
+function keyValueRow(key: string, value: string, valueColor?: Color): SceneNode {
   return text([
-    { text: "─ ", style: { dim: true } },
-    { text: label, style: { bold: true, color: "cyan" } },
-    { text: " ─", style: { dim: true } },
+    { text: key.padEnd(8), style: { color: PALETTE.muted } },
+    valueColor ? { text: value, style: { color: valueColor } } : { text: value },
   ]);
 }
 
-function keyValueRow(key: string, value: string): SceneNode {
-  return text([{ text: key.padEnd(8), style: { dim: true } }, { text: value }]);
-}
-
 function titleRow(s: BuildInput): SceneNode {
-  const left = text([{ text: "reasonix", style: { bold: true } }]);
+  const left = text([
+    { text: " ◆ ", style: { color: PALETTE.accent, bold: true } },
+    { text: "reasonix", style: { bold: true, color: PALETTE.fg } },
+  ]);
   const spacer = box([], { width: "fill" });
   const children: SceneNode[] = [left, spacer];
   if (s.model) {
-    children.push(text([{ text: s.model, style: { dim: true } }]));
+    children.push(text([{ text: `${s.model} `, style: { color: PALETTE.violet } }]));
   }
-  return box(children, { direction: "row" });
+  return box(children, { direction: "row", background: PALETTE.panel, height: 1 });
 }
 
 function noCardsRow(): SceneNode {
@@ -203,23 +224,27 @@ function cardRow(c: SceneTraceCard): SceneNode {
 
 function statusRow(s: BuildInput, opts: { suppressWallet?: boolean } = {}): SceneNode {
   const leftRuns: TextRun[] = [
-    { text: `${s.cardCount} cards`, style: { dim: true } },
-    { text: " · " },
-    { text: s.busy ? "busy" : "idle", style: { color: s.busy ? "yellow" : "green" } },
+    { text: ` ${s.cardCount} cards`, style: { color: PALETTE.muted } },
+    { text: " · ", style: { color: PALETTE.muted } },
+    {
+      text: s.busy ? "busy" : "idle",
+      style: { color: s.busy ? PALETTE.warning : PALETTE.success },
+    },
   ];
-  if (s.activity) leftRuns.push({ text: ` · ${s.activity}`, style: { dim: true } });
+  if (s.activity) leftRuns.push({ text: ` · ${s.activity}`, style: { color: PALETTE.muted } });
   const wallet = opts.suppressWallet ? null : formatWallet(s.walletBalance, s.walletCurrency);
-  if (!wallet) return text(leftRuns);
+  const layout = { direction: "row" as const, background: PALETTE.panel, height: 1 };
+  if (!wallet) return box([text(leftRuns)], layout);
   return box(
     [
       text(leftRuns),
       box([], { width: "fill" }),
       text([
-        { text: "wallet ", style: { dim: true } },
-        { text: wallet, style: { color: "green" } },
+        { text: "wallet ", style: { color: PALETTE.muted } },
+        { text: `${wallet} `, style: { color: PALETTE.success, bold: true } },
       ]),
     ],
-    { direction: "row" },
+    layout,
   );
 }
 

--- a/src/cli/ui/scene/theme.ts
+++ b/src/cli/ui/scene/theme.ts
@@ -1,0 +1,19 @@
+import type { Color } from "./types.js";
+
+export const PALETTE = {
+  bg: { hex: "#1a1c22" },
+  bg2: { hex: "#1f2228" },
+  panel: { hex: "#23272e" },
+  card: { hex: "#272c36" },
+  border: { hex: "#393f4a" },
+  borderStrong: { hex: "#4a515f" },
+  fg: { hex: "#ecedf2" },
+  fg2: { hex: "#c2c6d0" },
+  muted: { hex: "#8d94a3" },
+  accent: { hex: "#648dff" },
+  accentStrong: { hex: "#7da0ff" },
+  success: { hex: "#4bc88a" },
+  warning: { hex: "#d8b157" },
+  danger: { hex: "#e25a5a" },
+  violet: { hex: "#b87dde" },
+} as const satisfies Record<string, Color>;

--- a/src/cli/ui/scene/types.ts
+++ b/src/cli/ui/scene/types.ts
@@ -49,6 +49,7 @@ export type BoxLayout = {
   justify?: FlexJustify;
   borderStyle?: BorderStyle;
   borderColor?: Color;
+  background?: Color;
 };
 
 export type TextNode = {

--- a/tests/scene-trace-frame.test.ts
+++ b/tests/scene-trace-frame.test.ts
@@ -159,7 +159,6 @@ describe("buildTraceFrame", () => {
     expect(f.root.kind).toBe("box");
     if (f.root.kind !== "box") return;
     expect(f.root.layout?.direction).toBe("column");
-    expect(f.root.layout?.paddingX).toBe(1);
     expect(f.root.children).toHaveLength(3);
     const middle = f.root.children[1];
     if (middle?.kind !== "box") throw new Error("expected middle box");
@@ -200,7 +199,12 @@ describe("buildTraceFrame", () => {
     if (spacer?.kind !== "box") throw new Error("expected spacer box");
     expect(spacer.layout?.width).toBe("fill");
     if (model?.kind !== "text") throw new Error("expected model text");
-    expect(model.runs.map((r) => r.text).join("")).toBe("deepseek-chat");
+    expect(
+      model.runs
+        .map((r) => r.text)
+        .join("")
+        .trim(),
+    ).toBe("deepseek-chat");
   });
 
   it("omits the model node from the title row when no model is given", () => {
@@ -247,19 +251,30 @@ describe("buildTraceFrame", () => {
     expect(cardRow.runs[2]?.style?.bold).toBe(true);
   });
 
-  it("paints status as green when idle and yellow when busy", () => {
+  function statusLeftText(f: ReturnType<typeof buildTraceFrame>) {
+    const s = statusOf(f);
+    if (s.kind !== "box") throw new Error("expected status box");
+    const inner = s.children[0];
+    if (inner?.kind !== "text") throw new Error("expected text in status");
+    return inner;
+  }
+
+  it("paints status busy/idle in the design success/warning colors", () => {
     const idle = buildTraceFrame({ cardCount: 3, busy: false, cards: [] }, 80, 24);
     const busy = buildTraceFrame({ cardCount: 3, busy: true, cards: [] }, 80, 24);
-    const idleStatus = statusOf(idle);
-    const busyStatus = statusOf(busy);
-    if (idleStatus.kind !== "text" || busyStatus.kind !== "text") return;
-    expect(idleStatus.runs[2]?.style?.color).toBe("green");
-    expect(busyStatus.runs[2]?.style?.color).toBe("yellow");
+    const idleColor = statusLeftText(idle).runs[2]?.style?.color;
+    const busyColor = statusLeftText(busy).runs[2]?.style?.color;
+    expect(typeof idleColor === "object" && idleColor && "hex" in idleColor).toBe(true);
+    expect(typeof busyColor === "object" && busyColor && "hex" in busyColor).toBe(true);
   });
 
-  it("keeps the status row as a single text node when no wallet balance is given", () => {
+  it("renders the status row inside a panel-tinted background box even when no wallet is shown", () => {
     const f = buildTraceFrame({ cardCount: 1, busy: false, cards: [] }, 80, 24);
-    expect(statusOf(f).kind).toBe("text");
+    const s = statusOf(f);
+    if (s.kind !== "box") throw new Error("expected status box");
+    expect(s.layout?.background).toBeDefined();
+    expect(s.children).toHaveLength(1);
+    expect(s.children[0]?.kind).toBe("text");
   });
 
   it("renders a wallet segment on the right of status when balance is given and the ctx pane is hidden", () => {
@@ -283,13 +298,40 @@ describe("buildTraceFrame", () => {
     expect(rightFlat).toContain("¥184.20");
   });
 
+  it("paints the title and status rows with a panel background tint", () => {
+    const f = buildEmpty();
+    if (f.root.kind !== "box") return;
+    const title = f.root.children[0];
+    const status = f.root.children[2];
+    if (title?.kind !== "box") return;
+    if (status?.kind !== "box") return;
+    expect(title.layout?.background).toBeDefined();
+    expect(status.layout?.background).toBeDefined();
+  });
+
+  it("decorates side / ctx panes with a rounded border and bg-2 background", () => {
+    const f = buildTraceFrame({ cardCount: 0, busy: false, cards: [] }, 120, 24);
+    if (f.root.kind !== "box") return;
+    const middle = f.root.children[1];
+    if (middle?.kind !== "box") return;
+    const sidebar = middle.children[0];
+    const ctxPane = middle.children.at(-1);
+    if (sidebar?.kind !== "box" || ctxPane?.kind !== "box") return;
+    expect(sidebar.layout?.borderStyle).toBe("round");
+    expect(sidebar.layout?.background).toBeDefined();
+    expect(ctxPane.layout?.borderStyle).toBe("round");
+    expect(ctxPane.layout?.background).toBeDefined();
+  });
+
   it("moves wallet from the status row into the context pane when both are visible", () => {
     const f = buildTraceFrame(
       { cardCount: 1, busy: false, cards: [], walletBalance: 184.2, walletCurrency: "CNY" },
       120,
       24,
     );
-    expect(statusOf(f).kind).toBe("text");
+    const s = statusOf(f);
+    if (s.kind !== "box") throw new Error("expected status box");
+    expect(s.children).toHaveLength(1);
     if (f.root.kind !== "box") return;
     const middle = f.root.children[1];
     if (middle?.kind !== "box") return;
@@ -331,7 +373,9 @@ describe("buildTraceFrame", () => {
       80,
       24,
     );
-    expect(statusOf(f).kind).toBe("text");
+    const s = statusOf(f);
+    if (s.kind !== "box") throw new Error("expected status box");
+    expect(s.children).toHaveLength(1);
   });
 
   it("appends activity to the status row when given", () => {
@@ -340,9 +384,11 @@ describe("buildTraceFrame", () => {
       80,
       24,
     );
-    const status = statusOf(f);
-    if (status.kind !== "text") return;
-    expect(status.runs.map((r) => r.text).join("")).toContain("awaiting tools");
+    expect(
+      statusLeftText(f)
+        .runs.map((r) => r.text)
+        .join(""),
+    ).toContain("awaiting tools");
   });
 
   it("composer row is a dim placeholder when composerText is empty / undefined", () => {


### PR DESCRIPTION
Closes the visual gap between the structural three-pane layout from
#1003 and the user's design mock. Previously every cell defaulted to
the terminal's stock bg/fg; now the trace frame honors a small
palette derived from the mock's oklch tokens, panes carry rounded
borders, and title / status rows sit on a panel-tinted bar.

## Schema + Rust render

- \`BoxLayout.background?: Color\` — new field, same shape as
  \`borderColor\`. Schema added in both TS and Rust.
- \`render_box\` now runs \`apply_decoration(layout, buf, area)\` before
  laying out children:
  - if \`background\` is set, fills every cell of the box area with
    that bg (via ratatui Block's style).
  - if \`borderStyle\` is set, draws ratatui's box-drawing perimeter
    (Plain / Double / Rounded / Thick) in \`borderColor\`, shrinking
    inner area by 1 cell on each side for children.
  - both are independent — bg without border (title/status bars)
    works, border without bg works too.

ratatui's \`Block\` widget already does the right thing for the
combined case (fill then draw border on top), so we lean on that
rather than rolling perimeter-drawing by hand.

## Design palette (\`src/cli/ui/scene/theme.ts\`)

oklch tokens from the mock converted to hex once, frozen as
\`PALETTE.{bg, bg2, panel, card, border, borderStrong, fg, fg2,
muted, accent, accentStrong, success, warning, danger, violet}\`.
Single source of truth — components don't pick raw colors anymore.

## Producer side

- Outer frame: \`background: PALETTE.bg\` (dark blue-grey base, sits
  behind every pane).
- Title row: \`background: PALETTE.panel\`, brand prefix glyph in
  \`accent\`, model name in \`violet\` (matches the mock's gradient
  brand mark — actual gradient isn't doable in a terminal).
- Sidebar + ctx pane: \`borderStyle: round\` + \`borderColor: border\`
  + \`background: bg2\`. Reads as two soft cards flanking the main
  pane, same shape as the mock's panel/card style.
- Status bar: \`background: PALETTE.panel\`, busy/idle in
  warning/success hexes from the palette, wallet segment in
  success when present.
- Section headers (\`SESSIONS\`, \`CONTEXT\`) drop the dash decoration
  and use bold accent — cleaner now that bordered panes provide the
  framing.

## Tests

- Rust (6 new): box-drawing chars at perimeter for Single / Round /
  Double border styles, border color applied to perimeter cells,
  background fills every cell, border shrinks inner area by 1 on
  each side.
- JS: existing 61 tests adjusted to the new shapes (status row is
  now always a box for its bg tint, busy/idle assert hex colors
  via PALETTE rather than named \"green\"/\"yellow\"). 2 new shape
  assertions: title/status carry a background; side/ctx panes
  carry borderStyle=round + background.

\`cargo test -p reasonix-render --test render\` → 23/23.
\`npm run verify\` → green via prepush gate.

## What's still aspirational

Real CSS gradients, drop shadows, border-radius smoothness, custom
fonts, hover states — ratatui can't do any of these. That's the
floor for \"TUI-native faithful to the mock\"; everything above is
what we ship.

Refs #868