### PR TITLE
feat(scene): render the real sessions list in the sidebar, not a placeholder

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -627,7 +627,9 @@ function AppInner({
   const [pendingReviseEditor, setPendingReviseEditor] = useState<string | null>(null);
   /** True while the SessionPicker is open mid-chat (triggered by `/sessions`). */
   const [pendingSessionsPicker, setPendingSessionsPicker] = useState(false);
-  const [sessionsPickerList, setSessionsPickerList] = useState<ReturnType<typeof listSessions>>([]);
+  const [sessionsPickerList, setSessionsPickerList] = useState<ReturnType<typeof listSessions>>(
+    () => listSessionsForWorkspace(currentRootDir),
+  );
   const [sessionsPickerFocus, setSessionsPickerFocus] = useState(0);
   /** True while the CheckpointPicker is open mid-chat (triggered by bare `/restore`). */
   const [pendingCheckpointPicker, setPendingCheckpointPicker] = useState(false);
@@ -1316,6 +1318,10 @@ function AppInner({
     );
   }, [slashMatches]);
 
+  useEffect(() => {
+    setSessionsPickerList(listSessionsForWorkspace(currentRootDir));
+  }, [currentRootDir]);
+
   const sessionsJson = useMemo(() => {
     if (!pendingSessionsPicker || sessionsPickerList.length === 0) return undefined;
     return JSON.stringify(
@@ -1326,6 +1332,16 @@ function AppInner({
       }),
     );
   }, [pendingSessionsPicker, sessionsPickerList]);
+
+  const sidebarSessionsJson = useMemo(() => {
+    if (sessionsPickerList.length === 0) return undefined;
+    return JSON.stringify(
+      sessionsPickerList.map((s) => ({
+        title: s.name,
+        meta: s.meta.branch ?? "main",
+      })),
+    );
+  }, [sessionsPickerList]);
 
   const sceneApproval = useMemo(() => {
     if (pendingShell) return { kind: "shell", prompt: pendingShell.command };
@@ -1352,6 +1368,8 @@ function AppInner({
     sessionsFocusedIndex: sessionsJson ? sessionsPickerFocus : undefined,
     walletBalance: balance?.total,
     walletCurrency: balance?.currency,
+    sidebarSessionsJson,
+    sidebarActiveSession: session ?? undefined,
   });
 
   // Ctrl+P / Ctrl+N from PromptInput route here. When any input-prefix

--- a/src/cli/ui/hooks/useSceneTrace.ts
+++ b/src/cli/ui/hooks/useSceneTrace.ts
@@ -32,6 +32,10 @@ export type SceneTraceInput = {
   /** Wallet balance — appears right-aligned in the status row. Null/undefined hides the segment. */
   walletBalance?: number;
   walletCurrency?: string;
+  /** JSON-encoded `SceneSessionItem[]` for the persistent sidebar list. */
+  sidebarSessionsJson?: string;
+  /** Name of the currently-active session — highlighted in the sidebar list. */
+  sidebarActiveSession?: string;
 };
 
 type BuildInput = {
@@ -50,7 +54,11 @@ type BuildInput = {
   sessionsFocusedIndex?: number;
   walletBalance?: number;
   walletCurrency?: string;
+  sidebarSessions?: ReadonlyArray<SceneSessionItem>;
+  sidebarActiveSession?: string;
 };
+
+const MAX_SIDEBAR_SESSIONS = 8;
 
 const APPROVAL_PROMPT_MAX = 60;
 const MAX_SESSION_ROWS = 8;
@@ -101,7 +109,7 @@ export function buildTraceFrame(input: BuildInput, cols: number, rows: number): 
   const status = statusRow(input, { suppressWallet: showCtxPane });
   const main = mainPane(input);
   const middleChildren: SceneNode[] = [];
-  if (showSidebar) middleChildren.push(sidebarPane());
+  if (showSidebar) middleChildren.push(sidebarPane(input));
   middleChildren.push(main);
   if (showCtxPane) middleChildren.push(ctxPane(input));
   const middle = box(middleChildren, { direction: "row", height: "fill", gap: 1 });
@@ -151,22 +159,44 @@ function mainPane(input: BuildInput): SceneNode {
   return box(children, { direction: "column", width: "fill", paddingX: 1 });
 }
 
-function sidebarPane(): SceneNode {
-  return box(
-    [
-      sectionHeaderRow("SESSIONS"),
-      text([{ text: "use /sessions", style: { color: PALETTE.muted } }]),
-      text([{ text: "to browse", style: { color: PALETTE.muted } }]),
-    ],
-    {
-      direction: "column",
-      width: SIDEBAR_WIDTH,
-      paddingX: 1,
-      borderStyle: "round",
-      borderColor: PALETTE.border,
-      background: PALETTE.bg2,
-    },
-  );
+function sidebarPane(input: BuildInput): SceneNode {
+  const children: SceneNode[] = [sectionHeaderRow("SESSIONS")];
+  const list = input.sidebarSessions ?? [];
+  if (list.length === 0) {
+    children.push(text([{ text: "no saved sessions", style: { color: PALETTE.muted } }]));
+    children.push(text([{ text: "type to start one", style: { color: PALETTE.muted } }]));
+  } else {
+    const shown = list.slice(0, MAX_SIDEBAR_SESSIONS);
+    for (const s of shown) {
+      const isActive = !!input.sidebarActiveSession && s.title === input.sidebarActiveSession;
+      children.push(sidebarSessionRow(s, isActive));
+    }
+    const hidden = list.length - shown.length;
+    if (hidden > 0) {
+      children.push(text([{ text: `…${hidden} more`, style: { color: PALETTE.muted } }]));
+    }
+  }
+  return box(children, {
+    direction: "column",
+    width: SIDEBAR_WIDTH,
+    paddingX: 1,
+    borderStyle: "round",
+    borderColor: PALETTE.border,
+    background: PALETTE.bg2,
+  });
+}
+
+function sidebarSessionRow(item: SceneSessionItem, active: boolean): SceneNode {
+  const runs: TextRun[] = [];
+  runs.push({
+    text: active ? "▸ " : "  ",
+    style: { color: active ? PALETTE.accent : PALETTE.muted },
+  });
+  runs.push({
+    text: item.title,
+    style: active ? { bold: true, color: PALETTE.accent } : { color: PALETTE.fg2 },
+  });
+  return text(runs);
 }
 
 function ctxPane(input: BuildInput): SceneNode {
@@ -498,6 +528,8 @@ export function useSceneTrace(input: SceneTraceInput): void {
     sessionsFocusedIndex,
     walletBalance,
     walletCurrency,
+    sidebarSessionsJson,
+    sidebarActiveSession,
   } = input;
   useEffect(() => {
     if (!isSceneTraceEnabled()) return;
@@ -505,6 +537,7 @@ export function useSceneTrace(input: SceneTraceInput): void {
     const cards = cardsForHeight(parsed, rows);
     const slashMatches = parseSlashMatches(slashMatchesJson);
     const sessions = parseSessions(sessionsJson);
+    const sidebarSessions = parseSessions(sidebarSessionsJson);
     emitSceneFrame(
       buildTraceFrame(
         {
@@ -523,6 +556,8 @@ export function useSceneTrace(input: SceneTraceInput): void {
           sessionsFocusedIndex,
           walletBalance,
           walletCurrency,
+          sidebarSessions,
+          sidebarActiveSession,
         },
         cols,
         rows,
@@ -546,6 +581,8 @@ export function useSceneTrace(input: SceneTraceInput): void {
     sessionsFocusedIndex,
     walletBalance,
     walletCurrency,
+    sidebarSessionsJson,
+    sidebarActiveSession,
   ]);
 }
 

--- a/tests/scene-trace-frame.test.ts
+++ b/tests/scene-trace-frame.test.ts
@@ -309,6 +309,98 @@ describe("buildTraceFrame", () => {
     expect(status.layout?.background).toBeDefined();
   });
 
+  it("renders the persistent sessions list in the sidebar when sidebarSessions is given", () => {
+    const f = buildTraceFrame(
+      {
+        cardCount: 0,
+        busy: false,
+        cards: [],
+        sidebarSessions: [
+          { title: "feat-foo", meta: "main" },
+          { title: "spike-bar", meta: "release/4.5" },
+        ],
+        sidebarActiveSession: "feat-foo",
+      },
+      80,
+      24,
+    );
+    if (f.root.kind !== "box") return;
+    const middle = f.root.children[1];
+    if (middle?.kind !== "box") return;
+    const sidebar = middle.children[0];
+    if (sidebar?.kind !== "box") return;
+    const flat = sidebar.children
+      .map((c) => (c.kind === "text" ? c.runs.map((r) => r.text).join("") : ""))
+      .join("\n");
+    expect(flat).toContain("SESSIONS");
+    expect(flat).toContain("feat-foo");
+    expect(flat).toContain("spike-bar");
+  });
+
+  it("marks the active session row with a ▸ accent in the sidebar", () => {
+    const f = buildTraceFrame(
+      {
+        cardCount: 0,
+        busy: false,
+        cards: [],
+        sidebarSessions: [
+          { title: "feat-foo", meta: "main" },
+          { title: "spike-bar", meta: "release/4.5" },
+        ],
+        sidebarActiveSession: "spike-bar",
+      },
+      80,
+      24,
+    );
+    if (f.root.kind !== "box") return;
+    const middle = f.root.children[1];
+    if (middle?.kind !== "box") return;
+    const sidebar = middle.children[0];
+    if (sidebar?.kind !== "box") return;
+    const rows = sidebar.children.filter((c) => c.kind === "text") as ReadonlyArray<
+      Extract<SceneNode, { kind: "text" }>
+    >;
+    const fooRow = rows.find((r) => r.runs.some((x) => x.text === "feat-foo"));
+    const barRow = rows.find((r) => r.runs.some((x) => x.text === "spike-bar"));
+    expect(fooRow?.runs[0]?.text.trim()).toBe("");
+    expect(barRow?.runs[0]?.text.trim()).toBe("▸");
+  });
+
+  it("falls back to a placeholder hint in the sidebar when no sessions exist", () => {
+    const f = buildTraceFrame(
+      { cardCount: 0, busy: false, cards: [], sidebarSessions: [] },
+      80,
+      24,
+    );
+    if (f.root.kind !== "box") return;
+    const middle = f.root.children[1];
+    if (middle?.kind !== "box") return;
+    const sidebar = middle.children[0];
+    if (sidebar?.kind !== "box") return;
+    const flat = sidebar.children
+      .map((c) => (c.kind === "text" ? c.runs.map((r) => r.text).join("") : ""))
+      .join("\n");
+    expect(flat).toContain("no saved sessions");
+  });
+
+  it("caps the sidebar list and emits an overflow row when there are too many sessions", () => {
+    const sessions = Array.from({ length: 14 }, (_, i) => ({ title: `s${i}`, meta: "main" }));
+    const f = buildTraceFrame(
+      { cardCount: 0, busy: false, cards: [], sidebarSessions: sessions },
+      80,
+      24,
+    );
+    if (f.root.kind !== "box") return;
+    const middle = f.root.children[1];
+    if (middle?.kind !== "box") return;
+    const sidebar = middle.children[0];
+    if (sidebar?.kind !== "box") return;
+    const flat = sidebar.children
+      .map((c) => (c.kind === "text" ? c.runs.map((r) => r.text).join("") : ""))
+      .join("\n");
+    expect(flat).toContain("…6 more");
+  });
+
   it("decorates side / ctx panes with a rounded border and bg-2 background", () => {
     const f = buildTraceFrame({ cardCount: 0, busy: false, cards: [] }, 120, 24);
     if (f.root.kind !== "box") return;


### PR DESCRIPTION
Closes the most obvious \"placeholder\" in the three-pane layout. The
sidebar previously read \`use /sessions to browse\` — accurate but
visually empty. Now it shows the actual saved sessions for the
current workspace with the active one highlighted, matching the
sidebar in the design mock.

## Wiring

- \`App.tsx\` initializes \`sessionsPickerList\` from
  \`listSessionsForWorkspace(currentRootDir)\` on mount (was \`[]\` —
  only populated when the picker opened).
- A \`useEffect\` re-reads the list whenever \`currentRootDir\` changes
  (\`/cwd\` switching).
- New \`SceneTraceInput.sidebarSessionsJson\` + \`sidebarActiveSession\`
  scalars — same primitive-deps pattern as the picker overlay's
  \`sessionsJson\`. \`sidebarSessionsJson\` carries \`{ title, meta:
  branch }\` per session; \`sidebarActiveSession\` is the active
  session name for highlighting.

## Sidebar rendering

- Empty case: \`no saved sessions / type to start one\` (more accurate
  than the previous \`/sessions to browse\` instruction).
- Non-empty: one row per session, \`▸\` accent marker on the active
  one, others dimmed. Caps at \`MAX_SIDEBAR_SESSIONS\` (8) with an
  \`…N more\` overflow row.
- Meta (branch) is intentionally omitted in this PR — the 24-cell
  sidebar gets cramped fast once you add a second line per row.
  Showing meta inline is a follow-up if it matters.

## Tests

\`tests/scene-trace-frame.test.ts\` — 4 new cases (list rendered,
active row marker, empty-state placeholder, overflow at 8). 67
scene-trace tests green in total.

\`npm run verify\` green via prepush gate.

Refs #868