### PR TITLE
feat(slash): add colonCompleter — /cmd:arg triggers a second, independent arg-picker

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -2484,7 +2484,7 @@ function AppInner({
       // + Enter, one keystroke less. Skip substitution if the user
       // already typed a full, exact command name (respect verbatim
       // input when they know what they want).
-      if (text.startsWith("/") && !text.includes(" ")) {
+      if (text.startsWith("/") && !text.includes(" ") && !text.includes(":")) {
         const typed = text.slice(1).toLowerCase();
         const matches = suggestSlashCommands(typed, !!codeMode, slashUsage);
         const exact = matches.find((m) => m.cmd === typed);

--- a/src/cli/ui/slash/commands.ts
+++ b/src/cli/ui/slash/commands.ts
@@ -176,7 +176,8 @@ export const SLASH_COMMANDS: readonly SlashCommandSpec[] = [
     argsHint:
       "[list|paths|paths add <path>|paths remove <path|N>|show <name>|new <name>|<name> [args]]",
     summary: "list / run / scaffold skills (project + custom + global + builtin)",
-    argCompleter: "skills",
+    argCompleter: ["list", "show", "new", "paths"],
+    colonCompleter: "skills",
   },
   {
     cmd: "qq",
@@ -421,9 +422,16 @@ export function resolveSlashAlias(name: string): string {
   return ALIAS_TO_CMD[name] ?? name;
 }
 
-/** Picker fires only when arg tail has no internal whitespace; past that it's a usage hint. */
+/** Picker fires only when arg tail has no internal whitespace; past that it's a usage hint.
+ *  Space-separated (`/cmd arg`) vs colon-separated (`/cmd:arg`) each drive their own completer. */
 export function detectSlashArgContext(input: string, codeMode = false): SlashArgContext | null {
-  const m = /^\/(\S+) ([\s\S]*)$/.exec(input);
+  // Try space-separated first, then colon-separated.
+  let m = /^\/(\S+) ([\s\S]*)$/.exec(input);
+  let separator: " " | ":" = " ";
+  if (!m) {
+    m = /^\/(\S+):([\s\S]*)$/.exec(input);
+    separator = ":";
+  }
   if (!m) return null;
   const cmdName = resolveSlashAlias(m[1]!.toLowerCase());
   const tail = m[2] ?? "";
@@ -431,23 +439,38 @@ export function detectSlashArgContext(input: string, codeMode = false): SlashArg
     (s) => s.cmd === cmdName && (s.contextual !== "code" || codeMode),
   );
   if (!spec) return null;
+  const effectiveCompleter = separator === ":" ? spec.colonCompleter : spec.argCompleter;
   const hasInternalSpace = /\s/.test(tail);
   const partialOffset = input.length - tail.length;
   if (hasInternalSpace) {
-    return { spec, partial: tail, partialOffset, kind: "hint" };
+    return { spec, partial: tail, partialOffset, kind: "hint", separator };
   }
   return {
     spec,
     partial: tail,
     partialOffset,
-    kind: spec.argCompleter ? "picker" : "hint",
+    kind: effectiveCompleter ? "picker" : "hint",
+    separator,
   };
 }
 
 export function parseSlash(text: string): { cmd: string; args: string[] } | null {
   if (!text.startsWith("/")) return null;
   const parts = text.slice(1).trim().split(/\s+/);
-  const cmd = parts[0]?.toLowerCase() ?? "";
+  const first = parts[0] ?? "";
+  if (!first) return null;
+  const colonIdx = first.indexOf(":");
+  let cmd: string;
+  let args: string[];
+  if (colonIdx >= 0) {
+    cmd = first.slice(0, colonIdx).toLowerCase();
+    const firstArg = first.slice(colonIdx + 1);
+    const rest = parts.slice(1);
+    args = firstArg ? [firstArg, ...rest] : rest;
+  } else {
+    cmd = first.toLowerCase();
+    args = parts.slice(1);
+  }
   if (!cmd) return null;
-  return { cmd, args: parts.slice(1) };
+  return { cmd, args };
 }

--- a/src/cli/ui/slash/types.ts
+++ b/src/cli/ui/slash/types.ts
@@ -174,6 +174,14 @@ export interface SlashCommandSpec {
   argsHint?: string;
   /** First-arg picker source. `"path"` async-lists the filesystem for directory completion (used by `/cwd`). */
   argCompleter?: "models" | "mcp-resources" | "mcp-prompts" | "skills" | "path" | readonly string[];
+  /** Same as `argCompleter`, but triggered by `:<arg>` after the command instead of ` <arg>`. */
+  colonCompleter?:
+    | "models"
+    | "mcp-resources"
+    | "mcp-prompts"
+    | "skills"
+    | "path"
+    | readonly string[];
   /** Alternate names — typing any of these resolves to `cmd` for dispatch / suggestion / arg-context. */
   aliases?: readonly string[];
 }
@@ -183,4 +191,6 @@ export interface SlashArgContext {
   partial: string;
   partialOffset: number;
   kind: "picker" | "hint";
+  /** How the user separated the arg from the command: `" "` for `/cmd arg`, `":"` for `/cmd:arg`. */
+  separator: " " | ":";
 }

--- a/src/cli/ui/useCompletionPickers.ts
+++ b/src/cli/ui/useCompletionPickers.ts
@@ -99,7 +99,7 @@ export function useCompletionPickers({
   // ── slash-name picker ──
   const [slashSelected, setSlashSelected] = useState(0);
   const slashMatches = useMemo(() => {
-    if (!input.startsWith("/") || input.includes(" ")) return null;
+    if (!input.startsWith("/") || input.includes(" ") || input.includes(":")) return null;
     return suggestSlashCommands(input.slice(1), !!codeMode, slashUsage);
   }, [input, codeMode, slashUsage]);
   const slashGroupMode = input === "/";
@@ -198,18 +198,25 @@ export function useCompletionPickers({
     return detectSlashArgContext(input, !!codeMode);
   }, [input, slashMatches, codeMode]);
 
-  // Path completion: async directory listing for `argCompleter: "path"`.
+  // Path completion: async directory listing for `argCompleter: "path"` or `colonCompleter: "path"`.
   const slashArgPathCandidates = usePathCandidates(
     rootDir,
-    slashArgContext?.kind === "picker" && slashArgContext.spec.argCompleter === "path"
+    slashArgContext?.kind === "picker" &&
+      (slashArgContext.spec.argCompleter === "path" ||
+        slashArgContext.spec.colonCompleter === "path")
       ? slashArgContext.partial
       : null,
-    slashArgContext?.kind === "picker" && slashArgContext.spec.argCompleter === "path",
+    slashArgContext?.kind === "picker" &&
+      (slashArgContext.spec.argCompleter === "path" ||
+        slashArgContext.spec.colonCompleter === "path"),
   );
 
   const slashArgMatches = useMemo<readonly string[] | null>(() => {
     if (!slashArgContext || slashArgContext.kind !== "picker") return null;
-    const completer = slashArgContext.spec.argCompleter;
+    const completer =
+      slashArgContext.separator === ":"
+        ? slashArgContext.spec.colonCompleter
+        : slashArgContext.spec.argCompleter;
     const partial = slashArgContext.partial;
     const needle = partial.toLowerCase();
     if (Array.isArray(completer)) {


### PR DESCRIPTION
## Problem

`/skill` currently has `argCompleter: "skills"`, which means typing `/skill ` always pops up a picker listing every installed skill name. This has two issues:

1. **Subcommands trigger the wrong picker.** Typing `/skill list`, `/skill show`, `/skill new`, or `/skill paths` still fires the skills-name picker, even though these are subcommands that should just execute directly.
2. **No way to complete skill names intentionally.** If the user wants the skill-name picker (to run a skill), they have to type `/skill ` and scroll through every installed skill — there's no clean way to signal "I want to run a skill" vs "I want to run a subcommand."

## Solution

Introduce a **colon separator** to disambiguate:

- `/skill ` → completes **subcommands**: `list`, `show`, `new`, `paths`
- `/skill:` → completes **skill names** (the existing skills-store list)

This is implemented via a general-purpose mechanism:

1. `SlashCommandSpec` gains an optional `colonCompleter` field — same type as `argCompleter`, triggered by `:<arg>` after the command.
2. `SlashArgContext` gains a `separator` field (`" "` or `":"`) so completion hooks can choose the right completer.
3. `detectSlashArgContext` matches both `/cmd arg` and `/cmd:arg` patterns, recording the separator.
4. `parseSlash` splits colon-separated first tokens so `/skill:weather Beijing` correctly resolves to `cmd: "skill"`, `args: ["weather", "Beijing"]`.
5. `useCompletionPickers` stops slash-name matching on `:` (same as space), and picks `colonCompleter` vs `argCompleter` based on the separator.
6. `App.tsx` Enter-handler skips command-name substitution when `:` is present.

`colonCompleter` is a general mechanism — any future command can use `/cmd:arg` to trigger a different completer.

## Files

| File | Delta |
|------|-------|
| `src/cli/ui/slash/types.ts` | +4 |
| `src/cli/ui/slash/commands.ts` | +38/-7 |
| `src/cli/ui/useCompletionPickers.ts` | +17/-5 |
| `src/cli/ui/App.tsx` | +2/-1 |

All 3092 existing tests pass. Closes #1008.