### PR TITLE
feat(scene): add the REASONIX ASCII banner + denser boot block

### DIFF
--- a/src/cli/ui/hooks/useSceneTrace.ts
+++ b/src/cli/ui/hooks/useSceneTrace.ts
@@ -112,47 +112,77 @@ function scrollArea(input: BuildInput): SceneNode {
     direction: "column",
     height: "fill",
     width: "fill",
-    paddingX: 1,
+    paddingX: 2,
     paddingY: 1,
   });
 }
 
+const LOGO_LINES: readonly string[] = [
+  "██████╗ ███████╗ █████╗ ███████╗ ██████╗ ███╗   ██╗██╗██╗  ██╗",
+  "██╔══██╗██╔════╝██╔══██╗██╔════╝██╔═══██╗████╗  ██║██║╚██╗██╔╝",
+  "██████╔╝█████╗  ███████║███████╗██║   ██║██╔██╗ ██║██║ ╚███╔╝ ",
+  "██╔══██╗██╔══╝  ██╔══██║╚════██║██║   ██║██║╚██╗██║██║ ██╔██╗ ",
+  "██║  ██║███████╗██║  ██║███████║╚██████╔╝██║ ╚████║██║██╔╝ ██╗",
+  "╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝╚══════╝ ╚═════╝ ╚═╝  ╚═══╝╚═╝╚═╝  ╚═╝",
+];
+
 function bootBlock(input: BuildInput): SceneNode[] {
   const rows: SceneNode[] = [];
+  rows.push(blankRow());
+  for (const line of LOGO_LINES) {
+    rows.push(text([{ text: line, style: { color: PALETTE.ds, bold: true } }]));
+  }
+  rows.push(blankRow());
   rows.push(
     text([
-      { text: "● ", style: { color: PALETTE.ds, bold: true } },
-      { text: "REASONIX", style: { bold: true, color: PALETTE.dsBright } },
-      { text: "  DeepSeek code agent", style: { color: PALETTE.fg2 } },
+      { text: " DeepSeek code agent  ", style: { color: PALETTE.fg } },
+      { text: "· terminal-native, cache-first ·", style: { color: PALETTE.fg2 } },
     ]),
   );
-  rows.push(text([{ text: "", style: { color: PALETTE.fg2 } }]));
-  if (input.model) rows.push(bootField("model", input.model, PALETTE.ds));
-  if (input.cwd) rows.push(bootField("cwd", input.cwd, PALETTE.fg1));
-  if (input.mcpServerCount !== undefined) {
-    rows.push(bootField("mcp", `${input.mcpServerCount} server(s)`, PALETTE.fg1));
+  rows.push(blankRow());
+  if (input.model) rows.push(bootField("model", input.model, PALETTE.dsBright));
+  if (input.cwd) rows.push(bootField("workdir", input.cwd, PALETTE.fg));
+  if (input.mcpServerCount !== undefined && input.mcpServerCount > 0) {
+    rows.push(bootField("mcp", `${input.mcpServerCount} server(s) connected`, PALETTE.fg));
   }
-  rows.push(text([{ text: "", style: { color: PALETTE.fg2 } }]));
+  rows.push(bootField("tools", "read · write · edit · bash · grep · fetch · todo", PALETTE.fg));
+  rows.push(blankRow());
   rows.push(
     text([
-      { text: "type to chat · ", style: { color: PALETTE.fg2 } },
-      { text: "/", style: { color: PALETTE.ds } },
-      { text: " commands · ", style: { color: PALETTE.fg2 } },
-      { text: "@", style: { color: PALETTE.ds } },
-      { text: " file refs · ", style: { color: PALETTE.fg2 } },
-      { text: "!", style: { color: PALETTE.ds } },
-      { text: " shell", style: { color: PALETTE.fg2 } },
+      { text: " ", style: {} },
+      { text: "type to chat  ", style: { color: PALETTE.fg2 } },
+      { text: "·  ", style: { color: PALETTE.fg3 } },
+      { text: "/", style: { color: PALETTE.ds, bold: true } },
+      { text: " commands  ", style: { color: PALETTE.fg2 } },
+      { text: "·  ", style: { color: PALETTE.fg3 } },
+      { text: "@", style: { color: PALETTE.ds, bold: true } },
+      { text: " file refs  ", style: { color: PALETTE.fg2 } },
+      { text: "·  ", style: { color: PALETTE.fg3 } },
+      { text: "!", style: { color: PALETTE.ds, bold: true } },
+      { text: " shell  ", style: { color: PALETTE.fg2 } },
+      { text: "·  ", style: { color: PALETTE.fg3 } },
+      { text: "Ctrl+C", style: { color: PALETTE.ds, bold: true } },
+      { text: " cancel  ", style: { color: PALETTE.fg2 } },
+      { text: "·  ", style: { color: PALETTE.fg3 } },
+      { text: "Ctrl+D", style: { color: PALETTE.ds, bold: true } },
+      { text: " exit", style: { color: PALETTE.fg2 } },
     ]),
   );
   return rows;
 }
 
+function blankRow(): SceneNode {
+  return text([{ text: "", style: {} }]);
+}
+
 function bootField(key: string, value: string, valueColor: Color): SceneNode {
   return text([
-    { text: ` ${key.padEnd(8)}`, style: { color: PALETTE.fg2 } },
+    { text: ` ${key.padEnd(10)}`, style: { color: PALETTE.fg2 } },
     { text: value, style: { color: valueColor } },
   ]);
 }
+
+export const REASONIX_LOGO_LINES = LOGO_LINES;
 
 function cardBlock(c: SceneTraceCard): SceneNode {
   const color = colorFor(c.kind);

--- a/tests/scene-trace-frame.test.ts
+++ b/tests/scene-trace-frame.test.ts
@@ -206,9 +206,11 @@ describe("buildTraceFrame — v1 single-column layout", () => {
   it("renders a boot block in the scroll area when there are no cards", () => {
     const f = buildEmpty({ model: "deepseek-chat" });
     const flatScroll = flatRows(scrollOf(f));
-    expect(flatScroll).toContain("REASONIX");
+    expect(flatScroll).toContain("██████╗");
+    expect(flatScroll).toContain("DeepSeek code agent");
     expect(flatScroll).toContain("model");
     expect(flatScroll).toContain("deepseek-chat");
+    expect(flatScroll).toContain("tools");
   });
 
   it("renders one card row per card in the scroll area", () => {


### PR DESCRIPTION
Addresses the \"empty space\" feedback on the v1 layout — the empty
scroll area was mostly bg fill. The boot block now carries real
visual weight matching the v1 mock's empty-state screen.

## What

- 6-row REASONIX ASCII block-letter banner (the exact ANSI Shadow
  art from the v1 mock's \`<pre class=\"logo\">\` block), drawn in
  \`PALETTE.ds\` blue + bold.
- Tagline row: \`DeepSeek code agent · terminal-native, cache-first ·\`
  underneath the logo.
- Key/value rows widened from 8 → 10 cell key width: \`model\` ·
  \`workdir\` · \`mcp\` · \`tools\`.
- \`tools\` row enumerates the actual tool kinds (\`read · write · edit ·
  bash · grep · fetch · todo\`) so users see what's actually wired.
- Hint row gets \`Ctrl+C\` / \`Ctrl+D\` added to the existing \`/ @ !\`
  glyphs; rendered with ds-blue glyphs and fg2-muted labels — same
  kbd-chip pattern the meta row uses.
- scroll-area paddingX bumped 1 → 2 so the wide banner doesn't sit
  flush against the left edge.

## What's not changing (intentional)

The vertical empty between boot block and dock is unchanged on
purpose — that's the design's behavior too. The v1 mock's
01-01-default screen fills the middle with chat cards once a turn
starts; an empty fresh session naturally has space below the boot
block.

## Tests

The existing \"renders a boot block in the scroll area\" test was
asserting on the literal string \`REASONIX\` — now switched to the
banner's first row (\`██████╗\`) + the tagline + the \`tools\` field
so we keep coverage on the new shape.

38 scene-trace tests pass. \`npm run verify\` green via prepush gate.

Refs #868