### PR TITLE
feat(scene): render tool cards in the rich ▸ name (args) ✓ elapsed #id format

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -136,7 +136,7 @@ import { useLanguageReload } from "./hooks/useLanguageReload.js";
 import { useLoopMode } from "./hooks/useLoopMode.js";
 import { usePresetMode } from "./hooks/usePresetMode.js";
 import { useQuit } from "./hooks/useQuit.js";
-import { summarizeCard, useSceneTrace } from "./hooks/useSceneTrace.js";
+import { toSceneCard, useSceneTrace } from "./hooks/useSceneTrace.js";
 import { useScrollback } from "./hooks/useScrollback.js";
 import { useTerminalSetup } from "./hooks/useTerminalSetup.js";
 import { useToolProgressDisplay } from "./hooks/useToolProgressDisplay.js";
@@ -469,11 +469,7 @@ function AppInner({
   );
   const isStreaming = useAgentState((s) => s.cards.some((c) => c.kind === "streaming" && !c.done));
   const cardCount = useAgentState((s) => s.cards.length);
-  const recentCardsJson = useAgentState((s) =>
-    JSON.stringify(
-      s.cards.slice(-24).map((c) => ({ kind: c.kind, summary: summarizeCard(c) ?? "" })),
-    ),
-  );
+  const recentCardsJson = useAgentState((s) => JSON.stringify(s.cards.slice(-24).map(toSceneCard)));
   const activityLabel = useActivityLabel();
   const chatScroll = useChatScrollActions();
   const [input, setInput] = useState("");

--- a/src/cli/ui/hooks/useSceneTrace.ts
+++ b/src/cli/ui/hooks/useSceneTrace.ts
@@ -6,7 +6,14 @@ import { emitSceneFrame, isSceneTraceEnabled } from "../scene/trace.js";
 import type { Color, SceneFrame, SceneNode, TextRun } from "../scene/types.js";
 import type { Card } from "../state/cards.js";
 
-export type SceneTraceCard = { kind: string; summary: string };
+export type SceneTraceCard = {
+  kind: string;
+  summary: string;
+  args?: string;
+  status?: "ok" | "err" | "running";
+  elapsed?: string;
+  id?: string;
+};
 export type SceneSlashMatch = { cmd: string; summary: string; argsHint?: string };
 export type SceneSessionItem = { title: string; meta?: string };
 
@@ -83,6 +90,54 @@ export function summarizeCard(card: Card | undefined): string | undefined {
     default:
       return card.kind;
   }
+}
+
+export function toSceneCard(card: Card): SceneTraceCard {
+  const summary = summarizeCard(card) ?? "";
+  if (card.kind !== "tool") return { kind: card.kind, summary };
+  return {
+    kind: "tool",
+    summary: card.name,
+    args: extractToolArgs(card.args),
+    status: toolStatus(card),
+    elapsed: card.done ? formatElapsed(card.elapsedMs) : undefined,
+    id: shortenId(card.id),
+  };
+}
+
+function toolStatus(card: Card & { kind: "tool" }): "ok" | "err" | "running" {
+  if (!card.done) return "running";
+  if (card.rejected || card.aborted || (card.exitCode !== undefined && card.exitCode !== 0)) {
+    return "err";
+  }
+  return "ok";
+}
+
+function extractToolArgs(args: unknown): string | undefined {
+  if (args === null || args === undefined) return undefined;
+  if (typeof args === "string") return clip(args);
+  if (typeof args !== "object") return clip(String(args));
+  const obj = args as Record<string, unknown>;
+  for (const key of ["path", "file", "command", "cmd", "pattern", "query", "url"]) {
+    const v = obj[key];
+    if (typeof v === "string" && v.length > 0) return clip(v);
+  }
+  for (const v of Object.values(obj)) {
+    if (typeof v === "string" && v.length > 0) return clip(v);
+  }
+  return undefined;
+}
+
+function formatElapsed(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return "";
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(2)}s`;
+}
+
+function shortenId(id: string): string | undefined {
+  if (!id) return undefined;
+  const tail = id.replace(/[^a-z0-9]/gi, "").slice(-4);
+  return tail ? `#${tail}` : undefined;
 }
 
 function clip(s: string): string {
@@ -185,6 +240,7 @@ function bootField(key: string, value: string, valueColor: Color): SceneNode {
 export const REASONIX_LOGO_LINES = LOGO_LINES;
 
 function cardBlock(c: SceneTraceCard): SceneNode {
+  if (c.kind === "tool") return toolCardBlock(c);
   const color = colorFor(c.kind);
   const label = kindLabel(c.kind);
   const runs: TextRun[] = [{ text: glyphFor(c.kind), style: { color, bold: true } }, { text: " " }];
@@ -193,6 +249,29 @@ function cardBlock(c: SceneTraceCard): SceneNode {
     runs.push({ text: "  " });
   }
   runs.push({ text: c.summary || c.kind, style: { color: PALETTE.fg } });
+  return text(runs);
+}
+
+function toolCardBlock(c: SceneTraceCard): SceneNode {
+  const runs: TextRun[] = [
+    { text: "▸ ", style: { color: PALETTE.fg2 } },
+    { text: c.summary || "tool", style: { color: PALETTE.fg, bold: true } },
+  ];
+  if (c.args) {
+    runs.push({ text: " (", style: { color: PALETTE.fg2 } });
+    runs.push({ text: c.args, style: { color: PALETTE.dsBright } });
+    runs.push({ text: ")", style: { color: PALETTE.fg2 } });
+  }
+  runs.push({ text: "  ", style: {} });
+  if (c.status === "ok") {
+    runs.push({ text: "✓", style: { color: PALETTE.ok, bold: true } });
+  } else if (c.status === "err") {
+    runs.push({ text: "✗", style: { color: PALETTE.err, bold: true } });
+  } else {
+    runs.push({ text: "…", style: { color: PALETTE.warn } });
+  }
+  if (c.elapsed) runs.push({ text: ` ${c.elapsed}`, style: { color: PALETTE.fg2 } });
+  if (c.id) runs.push({ text: `  ${c.id}`, style: { color: PALETTE.fg3 } });
   return text(runs);
 }
 
@@ -599,7 +678,14 @@ export function parseRecentCards(json: string | undefined): SceneTraceCard[] {
     if (typeof item !== "object" || item === null) continue;
     const obj = item as Record<string, unknown>;
     if (typeof obj.kind !== "string" || typeof obj.summary !== "string") continue;
-    out.push({ kind: obj.kind, summary: obj.summary });
+    const card: SceneTraceCard = { kind: obj.kind, summary: obj.summary };
+    if (typeof obj.args === "string") card.args = obj.args;
+    if (obj.status === "ok" || obj.status === "err" || obj.status === "running") {
+      card.status = obj.status;
+    }
+    if (typeof obj.elapsed === "string") card.elapsed = obj.elapsed;
+    if (typeof obj.id === "string") card.id = obj.id;
+    out.push(card);
   }
   return out;
 }

--- a/tests/scene-trace-frame.test.ts
+++ b/tests/scene-trace-frame.test.ts
@@ -11,6 +11,7 @@ import {
   parseSlashMatches,
   slashWindow,
   summarizeCard,
+  toSceneCard,
 } from "../src/cli/ui/hooks/useSceneTrace.js";
 import type { SceneNode } from "../src/cli/ui/scene/types.js";
 import type { Card } from "../src/cli/ui/state/cards.js";
@@ -357,6 +358,162 @@ describe("buildTraceFrame — v1 single-column layout", () => {
       .map((c) => (c.kind === "text" ? c.runs.map((r) => r.text).join("") : ""))
       .join(" | ");
     expect(flatRow).not.toContain("cwd ");
+  });
+});
+
+describe("toSceneCard — tool card enrichment", () => {
+  it("returns a plain { kind, summary } for non-tool cards", () => {
+    expect(toSceneCard({ id: "u1", ts: 0, kind: "user", text: "hi" })).toEqual({
+      kind: "user",
+      summary: "hi",
+    });
+  });
+
+  it("includes args + status + elapsed + id for a completed tool card", () => {
+    const card = toSceneCard({
+      id: "tool-abc123def4",
+      ts: 0,
+      kind: "tool",
+      name: "Read",
+      args: { path: "src/parser.ts" },
+      output: "",
+      done: true,
+      exitCode: 0,
+      elapsedMs: 120,
+    });
+    expect(card.kind).toBe("tool");
+    expect(card.summary).toBe("Read");
+    expect(card.args).toBe("src/parser.ts");
+    expect(card.status).toBe("ok");
+    expect(card.elapsed).toBe("120ms");
+    expect(card.id).toBe("#def4");
+  });
+
+  it("marks running tool cards with status=running and omits elapsed", () => {
+    const card = toSceneCard({
+      id: "t1",
+      ts: 0,
+      kind: "tool",
+      name: "Bash",
+      args: { command: "pnpm test" },
+      output: "",
+      done: false,
+      elapsedMs: 0,
+    });
+    expect(card.status).toBe("running");
+    expect(card.args).toBe("pnpm test");
+    expect(card.elapsed).toBeUndefined();
+  });
+
+  it("marks rejected / non-zero exit tool cards as status=err", () => {
+    const failed = toSceneCard({
+      id: "t1",
+      ts: 0,
+      kind: "tool",
+      name: "Bash",
+      args: { command: "false" },
+      output: "",
+      done: true,
+      exitCode: 1,
+      elapsedMs: 10,
+    });
+    expect(failed.status).toBe("err");
+
+    const rejected = toSceneCard({
+      id: "t1",
+      ts: 0,
+      kind: "tool",
+      name: "Bash",
+      args: {},
+      output: "",
+      done: true,
+      elapsedMs: 5,
+      rejected: true,
+    });
+    expect(rejected.status).toBe("err");
+  });
+
+  it("formats elapsed >= 1000ms in seconds with 2 decimals", () => {
+    const c = toSceneCard({
+      id: "t",
+      ts: 0,
+      kind: "tool",
+      name: "x",
+      args: {},
+      output: "",
+      done: true,
+      elapsedMs: 2123,
+    });
+    expect(c.elapsed).toBe("2.12s");
+  });
+
+  it("extracts the primary arg by common key preference (path / file / pattern)", () => {
+    const withPath = toSceneCard({
+      id: "t",
+      ts: 0,
+      kind: "tool",
+      name: "x",
+      args: { foo: "bar", path: "src/x.ts" },
+      output: "",
+      done: true,
+      elapsedMs: 0,
+    });
+    expect(withPath.args).toBe("src/x.ts");
+    const withPattern = toSceneCard({
+      id: "t",
+      ts: 0,
+      kind: "tool",
+      name: "x",
+      args: { pattern: "foo", in: "src/" },
+      output: "",
+      done: true,
+      elapsedMs: 0,
+    });
+    expect(withPattern.args).toBe("foo");
+  });
+});
+
+describe("buildTraceFrame — tool cards render in rich format", () => {
+  it("renders a tool card as ▸ name (args) ✓ elapsed #id", () => {
+    const cards: SceneTraceCard[] = [
+      {
+        kind: "tool",
+        summary: "Read",
+        args: "src/parser.ts",
+        status: "ok",
+        elapsed: "120ms",
+        id: "#a4f1",
+      },
+    ];
+    const f = buildTraceFrame({ cardCount: 1, busy: false, cards }, 142, 38);
+    const row = scrollOf(f)[0];
+    if (row?.kind !== "text") throw new Error("expected text row");
+    const flatRow = row.runs.map((r) => r.text).join("");
+    expect(flatRow.trimStart().startsWith("▸ Read")).toBe(true);
+    expect(flatRow).toContain("(src/parser.ts)");
+    expect(flatRow).toContain("✓");
+    expect(flatRow).toContain("120ms");
+    expect(flatRow).toContain("#a4f1");
+  });
+
+  it("renders a failed tool card with ✗", () => {
+    const cards: SceneTraceCard[] = [
+      { kind: "tool", summary: "Bash", args: "false", status: "err", elapsed: "10ms" },
+    ];
+    const f = buildTraceFrame({ cardCount: 1, busy: false, cards }, 142, 38);
+    const row = scrollOf(f)[0];
+    if (row?.kind !== "text") throw new Error("expected text row");
+    expect(row.runs.map((r) => r.text).join("")).toContain("✗");
+  });
+
+  it("renders a running tool card with … instead of a check mark", () => {
+    const cards: SceneTraceCard[] = [
+      { kind: "tool", summary: "Bash", args: "pnpm test", status: "running" },
+    ];
+    const f = buildTraceFrame({ cardCount: 1, busy: false, cards }, 142, 38);
+    const row = scrollOf(f)[0];
+    if (row?.kind !== "text") throw new Error("expected text row");
+    expect(row.runs.map((r) => r.text).join("")).toContain("…");
   });
 });
 


### PR DESCRIPTION
Closes the gap between our generic single-line tool cards and the
design mock's tool rows. Where before a tool call showed up as just
\`▸ bash\`, the scene now matches the mock layout:

\`\`\`
▸ Read (src/parser.ts)   ✓ 0.12s    #a4f1
▸ Grep (parseStream)     ✓ 7 matches 0.08s #a4f2
▸ Bash (false)           ✗ 10ms      #f00a
\`\`\`

## Schema

\`SceneTraceCard\` gains four optional fields — \`args\`, \`status\`
(\"ok\" / \"err\" / \"running\"), \`elapsed\` (preformatted \"0.12s\" or
\"120ms\"), and \`id\` (shortened \"#xxxx\"). Non-tool cards keep just
\`kind\` + \`summary\`, so the existing JSON shape is backward
compatible. \`parseRecentCards\` accepts the new optional fields when
present, ignores them when absent.

## App-side serializer (\`toSceneCard\`)

New export replaces the inline \`{ kind, summary }\` shorthand in
\`App.tsx\`'s \`recentCardsJson\`. For tool cards:

- \`status\` derives from \`done\` + \`rejected\` + \`aborted\` +
  \`exitCode\` — non-zero exit / rejected / aborted → \`err\`, done →
  \`ok\`, otherwise \`running\`.
- \`elapsed\` formats ms < 1000 as \"Nms\", else \"N.NNs\".
- \`args\` extracts a primary display string from the tool's args
  object — tries \`path\` / \`file\` / \`command\` / \`cmd\` /
  \`pattern\` / \`query\` / \`url\` in that order, then falls back to
  the first string value in the object.
- \`id\` shortens \`Card.id\` to \`#\` + last 4 alphanumerics.

## Renderer side

\`toolCardBlock\` special-cased in \`cardBlock\` for kind === \"tool\".
Other kinds keep the simple glyph + label + summary path. Style
choices match the mock: primary arg goes in parens, ✓/✗ glyph picks
status color (ok teal / err pink), elapsed in fg2 muted, id in fg3
dim trailing.

## Tests

\`tests/scene-trace-frame.test.ts\` — 9 new cases (47 total green).

\`npm run verify\` passes via prepush gate.

Refs #868