### PR TITLE
feat(scene): give YOU / THINKING / streaming cards a head + body shape

### DIFF
--- a/src/cli/ui/hooks/useSceneTrace.ts
+++ b/src/cli/ui/hooks/useSceneTrace.ts
@@ -13,7 +13,12 @@ export type SceneTraceCard = {
   status?: "ok" | "err" | "running";
   elapsed?: string;
   id?: string;
+  body?: string;
+  ts?: number;
+  meta?: string;
 };
+
+const MAX_CARD_BODY_LINES = 5;
 export type SceneSlashMatch = { cmd: string; summary: string; argsHint?: string };
 export type SceneSessionItem = { title: string; meta?: string };
 
@@ -94,15 +99,35 @@ export function summarizeCard(card: Card | undefined): string | undefined {
 
 export function toSceneCard(card: Card): SceneTraceCard {
   const summary = summarizeCard(card) ?? "";
-  if (card.kind !== "tool") return { kind: card.kind, summary };
-  return {
-    kind: "tool",
-    summary: card.name,
-    args: extractToolArgs(card.args),
-    status: toolStatus(card),
-    elapsed: card.done ? formatElapsed(card.elapsedMs) : undefined,
-    id: shortenId(card.id),
-  };
+  switch (card.kind) {
+    case "tool":
+      return {
+        kind: "tool",
+        summary: card.name,
+        args: extractToolArgs(card.args),
+        status: toolStatus(card),
+        elapsed: card.done ? formatElapsed(card.elapsedMs) : undefined,
+        id: shortenId(card.id),
+      };
+    case "user":
+      return { kind: "user", summary, body: card.text, ts: card.ts };
+    case "reasoning": {
+      const meta = card.endedAt
+        ? `${card.paragraphs} steps · ${formatElapsed(card.endedAt - card.ts)}`
+        : `${card.paragraphs} steps`;
+      return { kind: "reasoning", summary, body: card.text, ts: card.ts, meta };
+    }
+    case "streaming":
+      return {
+        kind: "streaming",
+        summary,
+        body: card.text,
+        ts: card.ts,
+        meta: card.done ? "done" : "streaming…",
+      };
+    default:
+      return { kind: card.kind, summary };
+  }
 }
 
 function toolStatus(card: Card & { kind: "tool" }): "ok" | "err" | "running" {
@@ -241,6 +266,9 @@ export const REASONIX_LOGO_LINES = LOGO_LINES;
 
 function cardBlock(c: SceneTraceCard): SceneNode {
   if (c.kind === "tool") return toolCardBlock(c);
+  if (c.kind === "user" || c.kind === "reasoning" || c.kind === "streaming") {
+    return messageCardBlock(c);
+  }
   const color = colorFor(c.kind);
   const label = kindLabel(c.kind);
   const runs: TextRun[] = [{ text: glyphFor(c.kind), style: { color, bold: true } }, { text: " " }];
@@ -250,6 +278,60 @@ function cardBlock(c: SceneTraceCard): SceneNode {
   }
   runs.push({ text: c.summary || c.kind, style: { color: PALETTE.fg } });
   return text(runs);
+}
+
+function messageCardBlock(c: SceneTraceCard): SceneNode {
+  const color = colorFor(c.kind);
+  const label = kindLabel(c.kind) ?? c.kind;
+  const head = headRow(c, color, label);
+  const lines = bodyLines(c.body ?? c.summary);
+  const rows: SceneNode[] = [head];
+  for (const line of lines) rows.push(bodyRow(line, c.kind));
+  rows.push(text([{ text: "", style: {} }]));
+  return box(rows, { direction: "column" });
+}
+
+function headRow(c: SceneTraceCard, color: Color, label: string): SceneNode {
+  const leftRuns: TextRun[] = [
+    { text: glyphFor(c.kind), style: { color, bold: true } },
+    { text: " " },
+    { text: label, style: { color, bold: true } },
+  ];
+  const rightRuns: TextRun[] = [];
+  if (c.meta) rightRuns.push({ text: c.meta, style: { color: PALETTE.fg3 } });
+  if (c.ts) {
+    if (rightRuns.length > 0) rightRuns.push({ text: "  ·  ", style: { color: PALETTE.fg3 } });
+    rightRuns.push({ text: formatTs(c.ts), style: { color: PALETTE.fg3 } });
+  }
+  if (rightRuns.length === 0) return text(leftRuns);
+  return box([text(leftRuns), box([], { width: "fill" }), text(rightRuns)], { direction: "row" });
+}
+
+function bodyRow(line: string, kind: string): SceneNode {
+  const dim = kind === "reasoning";
+  const style = dim ? { color: PALETTE.fg1, italic: true } : { color: PALETTE.fg };
+  return text([{ text: `  ${line}`, style }]);
+}
+
+function bodyLines(body: string): string[] {
+  if (!body) return [];
+  const out: string[] = [];
+  for (const raw of body.split("\n")) {
+    const line = raw.replace(/\s+$/, "");
+    if (line.length === 0) continue;
+    out.push(line);
+    if (out.length >= MAX_CARD_BODY_LINES) break;
+  }
+  return out;
+}
+
+function formatTs(ts: number): string {
+  if (!Number.isFinite(ts)) return "";
+  const d = new Date(ts);
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  const ss = String(d.getSeconds()).padStart(2, "0");
+  return `${hh}:${mm}:${ss}`;
 }
 
 function toolCardBlock(c: SceneTraceCard): SceneNode {
@@ -685,6 +767,9 @@ export function parseRecentCards(json: string | undefined): SceneTraceCard[] {
     }
     if (typeof obj.elapsed === "string") card.elapsed = obj.elapsed;
     if (typeof obj.id === "string") card.id = obj.id;
+    if (typeof obj.body === "string") card.body = obj.body;
+    if (typeof obj.ts === "number") card.ts = obj.ts;
+    if (typeof obj.meta === "string") card.meta = obj.meta;
     out.push(card);
   }
   return out;

--- a/tests/scene-trace-frame.test.ts
+++ b/tests/scene-trace-frame.test.ts
@@ -230,18 +230,73 @@ describe("buildTraceFrame — v1 single-column layout", () => {
     expect(flatScroll).toContain("hello back");
   });
 
-  it("paints YOU cards with the design accent (ds hex) and bold", () => {
-    const f = buildTraceFrame(
-      { cardCount: 1, busy: false, cards: [{ kind: "user", summary: "hello" }] },
-      142,
-      38,
-    );
-    const row = scrollOf(f)[0];
-    if (row?.kind !== "text") return;
-    const glyph = row.runs[0];
-    expect(glyph?.style?.bold).toBe(true);
-    const color = glyph?.style?.color;
-    expect(typeof color === "object" && color && "hex" in color).toBe(true);
+  it("renders a USER card as a head row + body row(s)", () => {
+    const cards: SceneTraceCard[] = [
+      { kind: "user", summary: "hello world", body: "hello world\nsecond line", ts: 1000 },
+    ];
+    const f = buildTraceFrame({ cardCount: 1, busy: false, cards }, 142, 38);
+    const block = scrollOf(f)[0];
+    if (block?.kind !== "box") throw new Error("expected user card box");
+    expect(block.layout?.direction).toBe("column");
+    expect(block.children.length).toBeGreaterThanOrEqual(3);
+    const head = block.children[0];
+    const flatHead =
+      head?.kind === "text"
+        ? head.runs.map((r) => r.text).join("")
+        : head?.kind === "box"
+          ? head.children
+              .map((c) => (c.kind === "text" ? c.runs.map((r) => r.text).join("") : ""))
+              .join("")
+          : "";
+    expect(flatHead).toContain("YOU");
+    const body1 = block.children[1];
+    const body2 = block.children[2];
+    if (body1?.kind !== "text" || body2?.kind !== "text") throw new Error("expected text bodies");
+    expect(body1.runs.map((r) => r.text).join("")).toContain("hello world");
+    expect(body2.runs.map((r) => r.text).join("")).toContain("second line");
+  });
+
+  it("renders a THINKING card with reasoning meta (steps) + italic dim body", () => {
+    const cards: SceneTraceCard[] = [
+      {
+        kind: "reasoning",
+        summary: "first thought",
+        body: "first thought\nsecond thought",
+        meta: "8 steps",
+      },
+    ];
+    const f = buildTraceFrame({ cardCount: 1, busy: false, cards }, 142, 38);
+    const block = scrollOf(f)[0];
+    if (block?.kind !== "box") throw new Error("expected reasoning card box");
+    const headChild = block.children[0];
+    let headFlat = "";
+    if (headChild?.kind === "text") {
+      headFlat = headChild.runs.map((r) => r.text).join("");
+    } else if (headChild?.kind === "box") {
+      headFlat = headChild.children
+        .map((c) => (c.kind === "text" ? c.runs.map((r) => r.text).join("") : ""))
+        .join("");
+    }
+    expect(headFlat).toContain("THINKING");
+    expect(headFlat).toContain("8 steps");
+    const body1 = block.children[1];
+    if (body1?.kind !== "text") return;
+    expect(body1.runs[0]?.style?.italic).toBe(true);
+  });
+
+  it("caps long bodies at MAX_CARD_BODY_LINES and skips blank lines", () => {
+    const body = ["a", "", "b", "c", "", "d", "e", "f", "g"].join("\n");
+    const cards: SceneTraceCard[] = [{ kind: "user", summary: "a", body }];
+    const f = buildTraceFrame({ cardCount: 1, busy: false, cards }, 142, 38);
+    const block = scrollOf(f)[0];
+    if (block?.kind !== "box") return;
+    const bodyRows = block.children
+      .slice(1)
+      .filter((c) => c.kind === "text")
+      .map((c) => (c.kind === "text" ? c.runs.map((r) => r.text).join("") : ""))
+      .filter((s) => s.trim().length > 0);
+    expect(bodyRows.length).toBeLessThanOrEqual(5);
+    expect(bodyRows.join(" ")).not.toContain("g");
   });
 
   it("dock has composer + meta + status when no overlay is active", () => {
@@ -362,11 +417,29 @@ describe("buildTraceFrame — v1 single-column layout", () => {
 });
 
 describe("toSceneCard — tool card enrichment", () => {
-  it("returns a plain { kind, summary } for non-tool cards", () => {
-    expect(toSceneCard({ id: "u1", ts: 0, kind: "user", text: "hi" })).toEqual({
+  it("returns a head+body shape for user cards (kind / summary / body / ts)", () => {
+    expect(toSceneCard({ id: "u1", ts: 42, kind: "user", text: "hi\nthere" })).toEqual({
       kind: "user",
       summary: "hi",
+      body: "hi\nthere",
+      ts: 42,
     });
+  });
+
+  it("returns a plain { kind, summary } for unhandled kinds", () => {
+    const card = toSceneCard({
+      id: "d1",
+      ts: 0,
+      kind: "diff",
+      file: "src/x.ts",
+      hunks: [],
+      adds: 0,
+      dels: 0,
+    } as Card);
+    expect(card.kind).toBe("diff");
+    expect(card.summary).toBe("src/x.ts");
+    expect(card.body).toBeUndefined();
+    expect(card.ts).toBeUndefined();
   });
 
   it("includes args + status + elapsed + id for a completed tool card", () => {


### PR DESCRIPTION
Matches the v1 mock's chat card layout — a labeled header row with
right-aligned meta and a multi-line indented body underneath.

Before:
\`\`\`
❯ YOU   帮我把 parser.ts 里的 token 流处理改成异步迭代器…
\`\`\`

After:
\`\`\`
❯ YOU                                            14:32:08
  帮我把 parser.ts 里的 token 流处理改成异步迭代器，顺便加点测试。

◆ THINKING                                       12 steps · 3.4s
  需要先看下当前 parser.ts 结构，再决定怎么改。
  流式场景下 AsyncIterator 比 callback 更自然。
\`\`\`

## Schema

\`SceneTraceCard\` gains three optional fields: \`body\` (multi-line
raw text), \`ts\` (Unix ms for the right-aligned timestamp), \`meta\`
(arbitrary right-aligned header string like \`8 steps\` or
\`streaming…\`). \`parseRecentCards\` accepts them when present.

## App side (\`toSceneCard\`)

- \`user\` → \`body\` = raw text, \`ts\` = \`card.ts\`
- \`reasoning\` → \`body\` = raw text, \`ts\`, \`meta\` = \`N steps\`
  (+ \`· N.NNs\` once \`endedAt\` is set)
- \`streaming\` → \`body\` = raw text, \`ts\`, \`meta\` = \`streaming…\`
  or \`done\`
- \`tool\` / others — unchanged

## Renderer (\`messageCardBlock\`)

For \`user\` / \`reasoning\` / \`streaming\` kinds, \`cardBlock\` returns
a column box of \`[head, ...body lines, blank-spacer]\`:

- Head row = \`<glyph> <LABEL>\` on the left + fill-spacer +
  \`<meta>  ·  HH:MM:SS\` on the right. Right side omitted when both
  \`meta\` and \`ts\` are absent.
- Body lines = body text split on \`\n\`, blank lines dropped, capped
  at \`MAX_CARD_BODY_LINES\` (5) — anything beyond is truncated. The
  scrollback is the source of truth; this is just the live view.
- Reasoning body lines render italic + \`fg1\` muted to match the
  mock's \`thinking\` treatment.
- Trailing blank-spacer row separates this card from the next.

Tool card rendering is untouched (still the rich single-line
\`▸ name (args) ✓ elapsed #id\` shape from #1013).

## Tests

\`tests/scene-trace-frame.test.ts\` — 4 new cases (50 total green).

\`npm run verify\` green via prepush gate.

Refs #868