### PR TITLE
refactor(scene): move the entire scene producer from TS to Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,16 +9,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "cassowary"
@@ -36,10 +57,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.2.62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "compact_str"
@@ -54,6 +98,12 @@ dependencies = [
  "ryu",
  "static_assertions",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crossterm"
@@ -137,10 +187,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "hashbrown"
@@ -158,6 +238,30 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "ident_case"
@@ -201,6 +305,18 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "libc"
@@ -257,6 +373,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,6 +415,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "proc-macro2"
@@ -329,6 +466,7 @@ name = "reasonix-render"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "crossterm",
  "ratatui",
  "serde",
@@ -420,6 +558,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,6 +593,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -543,6 +693,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -565,10 +760,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/crates/reasonix-render/Cargo.toml
+++ b/crates/reasonix-render/Cargo.toml
@@ -7,6 +7,7 @@ publish.workspace = true
 
 [dependencies]
 anyhow = "1"
+chrono = { version = "0.4", features = ["clock"] }
 crossterm = "0.28"
 ratatui = "0.29"
 serde = { version = "1", features = ["derive"] }

--- a/crates/reasonix-render/src/lib.rs
+++ b/crates/reasonix-render/src/lib.rs
@@ -1,4 +1,7 @@
 pub mod decode_only;
 pub mod input;
+pub mod producer;
 pub mod render;
 pub mod scene;
+pub mod state;
+pub mod theme;

--- a/crates/reasonix-render/src/main.rs
+++ b/crates/reasonix-render/src/main.rs
@@ -14,8 +14,10 @@ use ratatui::Terminal;
 
 use reasonix_render::decode_only::run_decode_only;
 use reasonix_render::input::{is_quit, paste_event, translate_key, translate_mouse};
+use reasonix_render::producer::{build_setup_frame, build_trace_frame};
 use reasonix_render::render::render_frame;
 use reasonix_render::scene::SceneFrame;
+use reasonix_render::state::{Message, SceneState, SetupState};
 
 fn main() -> Result<()> {
     let args: Vec<String> = std::env::args().skip(1).collect();
@@ -48,14 +50,38 @@ fn run_stream_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Res
         if line.trim().is_empty() {
             continue;
         }
-        let frame: SceneFrame =
-            serde_json::from_str(&line).with_context(|| format!("decode line {}", lineno + 1))?;
+        let frame = decode_to_frame(&line, terminal_size(terminal))
+            .with_context(|| format!("decode line {}", lineno + 1))?;
         terminal.draw(|f| {
             let area = f.area();
             render_frame(&frame, f.buffer_mut(), area);
         })?;
     }
     Ok(())
+}
+
+fn terminal_size(terminal: &Terminal<CrosstermBackend<io::Stdout>>) -> (u16, u16) {
+    match terminal.size() {
+        Ok(size) => (size.width, size.height),
+        Err(_) => (80, 24),
+    }
+}
+
+fn decode_to_frame(line: &str, (cols, rows): (u16, u16)) -> Result<SceneFrame> {
+    if let Ok(msg) = serde_json::from_str::<Message>(line) {
+        return Ok(match msg {
+            Message::Trace(state) => build_trace_frame(&state, cols, rows),
+            Message::Setup(state) => build_setup_frame(&state, cols, rows),
+        });
+    }
+    if let Ok(state) = serde_json::from_str::<SceneState>(line) {
+        return Ok(build_trace_frame(&state, cols, rows));
+    }
+    if let Ok(state) = serde_json::from_str::<SetupState>(line) {
+        return Ok(build_setup_frame(&state, cols, rows));
+    }
+    let legacy: SceneFrame = serde_json::from_str(line)?;
+    Ok(legacy)
 }
 
 fn run_emit_input() -> Result<()> {

--- a/crates/reasonix-render/src/producer.rs
+++ b/crates/reasonix-render/src/producer.rs
@@ -1,0 +1,1389 @@
+use chrono::{DateTime, Local, TimeZone};
+
+use crate::scene::{
+    BoxLayout, Color, Dim, FillToken, FlexDirection, SceneFrame, SceneNode, TextRun, TextStyle,
+};
+use crate::state::{SceneCard, SceneState, SessionItem, SetupState, SlashMatch, ToolStatus};
+use crate::theme::palette;
+
+const MAX_CARD_BODY_LINES: usize = 5;
+const MAX_SLASH_ROWS: usize = 6;
+const MAX_SESSION_ROWS: usize = 8;
+const APPROVAL_PROMPT_MAX: usize = 60;
+
+const LOGO_LINES: [&str; 6] = [
+    "██████╗ ███████╗ █████╗ ███████╗ ██████╗ ███╗   ██╗██╗██╗  ██╗",
+    "██╔══██╗██╔════╝██╔══██╗██╔════╝██╔═══██╗████╗  ██║██║╚██╗██╔╝",
+    "██████╔╝█████╗  ███████║███████╗██║   ██║██╔██╗ ██║██║ ╚███╔╝ ",
+    "██╔══██╗██╔══╝  ██╔══██║╚════██║██║   ██║██║╚██╗██║██║ ██╔██╗ ",
+    "██║  ██║███████╗██║  ██║███████║╚██████╔╝██║ ╚████║██║██╔╝ ██╗",
+    "╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝╚══════╝ ╚═════╝ ╚═╝  ╚═══╝╚═╝╚═╝  ╚═╝",
+];
+
+pub fn build_trace_frame(state: &SceneState, cols: u16, rows: u16) -> SceneFrame {
+    SceneFrame {
+        schema_version: 1,
+        cols: cols as u32,
+        rows: rows as u32,
+        root: outer_box(state),
+    }
+}
+
+pub fn build_setup_frame(state: &SetupState, cols: u16, rows: u16) -> SceneFrame {
+    SceneFrame {
+        schema_version: 1,
+        cols: cols as u32,
+        rows: rows as u32,
+        root: setup_root(state),
+    }
+}
+
+fn outer_box(state: &SceneState) -> SceneNode {
+    column(
+        vec![scroll_area(state), dock(state)],
+        BoxLayout {
+            background: Some(palette::bg()),
+            ..Default::default()
+        },
+    )
+}
+
+fn scroll_area(state: &SceneState) -> SceneNode {
+    let mut children: Vec<SceneNode> = Vec::new();
+    if state.cards.is_empty() {
+        children.extend(boot_block(state));
+    } else {
+        for card in &state.cards {
+            children.push(card_block(card));
+        }
+    }
+    column(
+        children,
+        BoxLayout {
+            height: Some(Dim::Fill(FillToken::Fill)),
+            width: Some(Dim::Fill(FillToken::Fill)),
+            padding_x: Some(2),
+            padding_y: Some(1),
+            ..Default::default()
+        },
+    )
+}
+
+fn boot_block(state: &SceneState) -> Vec<SceneNode> {
+    let mut rows: Vec<SceneNode> = Vec::new();
+    rows.push(blank_row());
+    for line in LOGO_LINES.iter() {
+        rows.push(text(vec![styled_run(
+            line,
+            TextStyle {
+                color: Some(palette::ds()),
+                bold: Some(true),
+                ..Default::default()
+            },
+        )]));
+    }
+    rows.push(blank_row());
+    rows.push(text(vec![
+        styled_run(
+            " DeepSeek code agent  ",
+            TextStyle {
+                color: Some(palette::fg()),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            "· terminal-native, cache-first ·",
+            TextStyle {
+                color: Some(palette::fg2()),
+                ..Default::default()
+            },
+        ),
+    ]));
+    rows.push(blank_row());
+    if let Some(model) = state.model.as_deref() {
+        rows.push(boot_field("model", model, palette::ds_bright()));
+    }
+    if let Some(cwd) = state.cwd.as_deref() {
+        rows.push(boot_field("workdir", cwd, palette::fg()));
+    }
+    if let Some(n) = state.mcp_server_count {
+        if n > 0 {
+            rows.push(boot_field("mcp", &format!("{} server(s) connected", n), palette::fg()));
+        }
+    }
+    rows.push(boot_field(
+        "tools",
+        "read · write · edit · bash · grep · fetch · todo",
+        palette::fg(),
+    ));
+    rows.push(blank_row());
+    rows.push(text(vec![
+        plain_run(" ", TextStyle::default()),
+        styled_run(
+            "type to chat  ",
+            TextStyle {
+                color: Some(palette::fg2()),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            "·  ",
+            TextStyle {
+                color: Some(palette::fg3()),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            "/",
+            TextStyle {
+                color: Some(palette::ds()),
+                bold: Some(true),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            " commands  ",
+            TextStyle {
+                color: Some(palette::fg2()),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            "·  ",
+            TextStyle {
+                color: Some(palette::fg3()),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            "@",
+            TextStyle {
+                color: Some(palette::ds()),
+                bold: Some(true),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            " file refs  ",
+            TextStyle {
+                color: Some(palette::fg2()),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            "·  ",
+            TextStyle {
+                color: Some(palette::fg3()),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            "!",
+            TextStyle {
+                color: Some(palette::ds()),
+                bold: Some(true),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            " shell  ",
+            TextStyle {
+                color: Some(palette::fg2()),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            "·  ",
+            TextStyle {
+                color: Some(palette::fg3()),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            "Ctrl+C",
+            TextStyle {
+                color: Some(palette::ds()),
+                bold: Some(true),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            " cancel  ",
+            TextStyle {
+                color: Some(palette::fg2()),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            "·  ",
+            TextStyle {
+                color: Some(palette::fg3()),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            "Ctrl+D",
+            TextStyle {
+                color: Some(palette::ds()),
+                bold: Some(true),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            " exit",
+            TextStyle {
+                color: Some(palette::fg2()),
+                ..Default::default()
+            },
+        ),
+    ]));
+    rows
+}
+
+fn boot_field(key: &str, value: &str, value_color: Color) -> SceneNode {
+    let key_str = format!(" {:<10}", key);
+    text(vec![
+        styled_run(
+            &key_str,
+            TextStyle {
+                color: Some(palette::fg2()),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            value,
+            TextStyle {
+                color: Some(value_color),
+                ..Default::default()
+            },
+        ),
+    ])
+}
+
+fn card_block(c: &SceneCard) -> SceneNode {
+    if c.kind == "tool" {
+        return tool_card_block(c);
+    }
+    if c.kind == "user" || c.kind == "reasoning" || c.kind == "streaming" {
+        return message_card_block(c);
+    }
+    let color = color_for(&c.kind);
+    let label = kind_label(&c.kind);
+    let mut runs = vec![
+        styled_run(
+            glyph_for(&c.kind),
+            TextStyle {
+                color: Some(color.clone()),
+                bold: Some(true),
+                ..Default::default()
+            },
+        ),
+        plain_run(" ", TextStyle::default()),
+    ];
+    if let Some(label) = label {
+        runs.push(styled_run(
+            label,
+            TextStyle {
+                color: Some(color),
+                bold: Some(true),
+                ..Default::default()
+            },
+        ));
+        runs.push(plain_run("  ", TextStyle::default()));
+    }
+    let summary = if c.summary.is_empty() { &c.kind } else { &c.summary };
+    runs.push(styled_run(
+        summary,
+        TextStyle {
+            color: Some(palette::fg()),
+            ..Default::default()
+        },
+    ));
+    text(runs)
+}
+
+fn tool_card_block(c: &SceneCard) -> SceneNode {
+    let mut runs = vec![
+        styled_run(
+            "▸ ",
+            TextStyle {
+                color: Some(palette::fg2()),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            if c.summary.is_empty() { "tool" } else { &c.summary },
+            TextStyle {
+                color: Some(palette::fg()),
+                bold: Some(true),
+                ..Default::default()
+            },
+        ),
+    ];
+    if let Some(args) = c.args.as_deref() {
+        runs.push(styled_run(
+            " (",
+            TextStyle {
+                color: Some(palette::fg2()),
+                ..Default::default()
+            },
+        ));
+        runs.push(styled_run(
+            args,
+            TextStyle {
+                color: Some(palette::ds_bright()),
+                ..Default::default()
+            },
+        ));
+        runs.push(styled_run(
+            ")",
+            TextStyle {
+                color: Some(palette::fg2()),
+                ..Default::default()
+            },
+        ));
+    }
+    runs.push(plain_run("  ", TextStyle::default()));
+    match c.status {
+        Some(ToolStatus::Ok) => runs.push(styled_run(
+            "✓",
+            TextStyle {
+                color: Some(palette::ok()),
+                bold: Some(true),
+                ..Default::default()
+            },
+        )),
+        Some(ToolStatus::Err) => runs.push(styled_run(
+            "✗",
+            TextStyle {
+                color: Some(palette::err()),
+                bold: Some(true),
+                ..Default::default()
+            },
+        )),
+        _ => runs.push(styled_run(
+            "…",
+            TextStyle {
+                color: Some(palette::warn()),
+                ..Default::default()
+            },
+        )),
+    }
+    if let Some(elapsed) = c.elapsed.as_deref() {
+        runs.push(styled_run(
+            &format!(" {}", elapsed),
+            TextStyle {
+                color: Some(palette::fg2()),
+                ..Default::default()
+            },
+        ));
+    }
+    if let Some(id) = c.id.as_deref() {
+        runs.push(styled_run(
+            &format!("  {}", id),
+            TextStyle {
+                color: Some(palette::fg3()),
+                ..Default::default()
+            },
+        ));
+    }
+    text(runs)
+}
+
+fn message_card_block(c: &SceneCard) -> SceneNode {
+    let color = color_for(&c.kind);
+    let label = kind_label(&c.kind).unwrap_or(&c.kind).to_string();
+    let head = head_row(c, color.clone(), &label);
+    let mut rows = vec![head];
+    let body_source = c.body.clone().unwrap_or_else(|| c.summary.clone());
+    for line in body_lines(&body_source) {
+        rows.push(body_row(&line, &c.kind));
+    }
+    rows.push(blank_row());
+    column(rows, BoxLayout::default())
+}
+
+fn head_row(c: &SceneCard, color: Color, label: &str) -> SceneNode {
+    let left_runs = vec![
+        styled_run(
+            glyph_for(&c.kind),
+            TextStyle {
+                color: Some(color.clone()),
+                bold: Some(true),
+                ..Default::default()
+            },
+        ),
+        plain_run(" ", TextStyle::default()),
+        styled_run(
+            label,
+            TextStyle {
+                color: Some(color),
+                bold: Some(true),
+                ..Default::default()
+            },
+        ),
+    ];
+    let mut right_runs: Vec<TextRun> = Vec::new();
+    if let Some(meta) = c.meta.as_deref() {
+        right_runs.push(styled_run(
+            meta,
+            TextStyle {
+                color: Some(palette::fg3()),
+                ..Default::default()
+            },
+        ));
+    }
+    if let Some(ts) = c.ts {
+        if !right_runs.is_empty() {
+            right_runs.push(styled_run(
+                "  ·  ",
+                TextStyle {
+                    color: Some(palette::fg3()),
+                    ..Default::default()
+                },
+            ));
+        }
+        right_runs.push(styled_run(
+            &format_ts(ts),
+            TextStyle {
+                color: Some(palette::fg3()),
+                ..Default::default()
+            },
+        ));
+    }
+    if right_runs.is_empty() {
+        return text(left_runs);
+    }
+    row(
+        vec![text(left_runs), spacer_box(), text(right_runs)],
+        BoxLayout {
+            direction: Some(FlexDirection::Row),
+            ..Default::default()
+        },
+    )
+}
+
+fn body_row(line: &str, kind: &str) -> SceneNode {
+    let style = if kind == "reasoning" {
+        TextStyle {
+            color: Some(palette::fg1()),
+            italic: Some(true),
+            ..Default::default()
+        }
+    } else {
+        TextStyle {
+            color: Some(palette::fg()),
+            ..Default::default()
+        }
+    };
+    text(vec![styled_run(&format!("  {}", line), style)])
+}
+
+fn body_lines(body: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for raw in body.split('\n') {
+        let line = raw.trim_end();
+        if line.is_empty() {
+            continue;
+        }
+        out.push(line.to_string());
+        if out.len() >= MAX_CARD_BODY_LINES {
+            break;
+        }
+    }
+    out
+}
+
+fn format_ts(ts: i64) -> String {
+    let dt: DateTime<Local> = match Local.timestamp_millis_opt(ts) {
+        chrono::offset::LocalResult::Single(dt) => dt,
+        _ => return String::new(),
+    };
+    dt.format("%H:%M:%S").to_string()
+}
+
+fn glyph_for(kind: &str) -> &'static str {
+    match kind {
+        "user" => "❯",
+        "reasoning" | "streaming" | "plan" | "task" => "◆",
+        "tool" => "▸",
+        "diff" => "Δ",
+        "error" => "✗",
+        "warn" => "!",
+        _ => "·",
+    }
+}
+
+fn color_for(kind: &str) -> Color {
+    match kind {
+        "user" => palette::ds(),
+        "reasoning" | "diff" | "plan" | "task" => palette::ds_purple(),
+        "streaming" => palette::ok(),
+        "tool" => palette::fg1(),
+        "error" => palette::err(),
+        "warn" => palette::warn(),
+        _ => palette::fg2(),
+    }
+}
+
+fn kind_label(kind: &str) -> Option<&'static str> {
+    match kind {
+        "user" => Some("YOU"),
+        "reasoning" => Some("THINKING"),
+        "streaming" => Some("reasonix"),
+        _ => None,
+    }
+}
+
+fn dock(state: &SceneState) -> SceneNode {
+    let mut children: Vec<SceneNode> = Vec::new();
+    let has_sessions = state
+        .sessions
+        .as_ref()
+        .map(|s| !s.is_empty())
+        .unwrap_or(false);
+    let has_slash = state
+        .slash_matches
+        .as_ref()
+        .map(|s| !s.is_empty())
+        .unwrap_or(false);
+    if has_sessions {
+        children.extend(sessions_picker_block(state));
+    } else if has_slash && state.approval_prompt.is_none() {
+        children.extend(slash_overlay_block(state));
+    }
+    if let Some(prompt) = state.approval_prompt.as_deref() {
+        children.push(approval_row(state.approval_kind.as_deref(), prompt));
+    } else {
+        children.push(composer_row(state));
+    }
+    children.push(meta_row());
+    children.push(status_bar_row(state));
+    column(
+        children,
+        BoxLayout {
+            direction: Some(FlexDirection::Column),
+            ..Default::default()
+        },
+    )
+}
+
+fn composer_row(state: &SceneState) -> SceneNode {
+    let t = state.composer_text.as_deref().unwrap_or("");
+    let mut runs = vec![
+        plain_run(" ", TextStyle::default()),
+        styled_run(
+            "❯ ",
+            TextStyle {
+                color: Some(palette::ds()),
+                bold: Some(true),
+                ..Default::default()
+            },
+        ),
+    ];
+    if t.is_empty() {
+        runs.push(styled_run(
+            "type to chat · / for commands · @ for files",
+            TextStyle {
+                color: Some(palette::fg2()),
+                ..Default::default()
+            },
+        ));
+        return row(
+            vec![text(runs)],
+            BoxLayout {
+                direction: Some(FlexDirection::Row),
+                background: Some(palette::bg2()),
+                height: Some(Dim::Cells(1)),
+                ..Default::default()
+            },
+        );
+    }
+    let cursor = state
+        .composer_cursor
+        .map(|c| c.min(t.chars().count()))
+        .unwrap_or_else(|| t.chars().count());
+    let (before, after) = split_at_char(t, cursor);
+    if !before.is_empty() {
+        runs.push(styled_run(
+            &before,
+            TextStyle {
+                color: Some(palette::fg()),
+                ..Default::default()
+            },
+        ));
+    }
+    runs.push(styled_run(
+        "▮",
+        TextStyle {
+            color: Some(palette::ds()),
+            ..Default::default()
+        },
+    ));
+    if !after.is_empty() {
+        runs.push(styled_run(
+            &after,
+            TextStyle {
+                color: Some(palette::fg()),
+                ..Default::default()
+            },
+        ));
+    }
+    row(
+        vec![text(runs)],
+        BoxLayout {
+            direction: Some(FlexDirection::Row),
+            background: Some(palette::bg2()),
+            height: Some(Dim::Cells(1)),
+            ..Default::default()
+        },
+    )
+}
+
+fn split_at_char(s: &str, char_idx: usize) -> (String, String) {
+    let mut before = String::new();
+    let mut after = String::new();
+    for (i, ch) in s.chars().enumerate() {
+        if i < char_idx {
+            before.push(ch);
+        } else {
+            after.push(ch);
+        }
+    }
+    (before, after)
+}
+
+fn meta_row() -> SceneNode {
+    let left = text(vec![
+        plain_run(" ", TextStyle::default()),
+        styled_run(
+            "↵",
+            TextStyle {
+                color: Some(palette::ds()),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            " send  ",
+            TextStyle {
+                color: Some(palette::fg2()),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            "⇧↵",
+            TextStyle {
+                color: Some(palette::ds()),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            " newline  ",
+            TextStyle {
+                color: Some(palette::fg2()),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            "/",
+            TextStyle {
+                color: Some(palette::ds()),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            " cmd  ",
+            TextStyle {
+                color: Some(palette::fg2()),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            "@",
+            TextStyle {
+                color: Some(palette::ds()),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            " file  ",
+            TextStyle {
+                color: Some(palette::fg2()),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            "!",
+            TextStyle {
+                color: Some(palette::ds()),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            " shell",
+            TextStyle {
+                color: Some(palette::fg2()),
+                ..Default::default()
+            },
+        ),
+    ]);
+    let right = text(vec![
+        styled_run(
+            "esc",
+            TextStyle {
+                color: Some(palette::ds()),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            " cancel  ",
+            TextStyle {
+                color: Some(palette::fg2()),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            "↑",
+            TextStyle {
+                color: Some(palette::ds()),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            " history ",
+            TextStyle {
+                color: Some(palette::fg2()),
+                ..Default::default()
+            },
+        ),
+    ]);
+    row(
+        vec![left, spacer_box(), right],
+        BoxLayout {
+            direction: Some(FlexDirection::Row),
+            height: Some(Dim::Cells(1)),
+            ..Default::default()
+        },
+    )
+}
+
+fn status_bar_row(state: &SceneState) -> SceneNode {
+    let mut children: Vec<SceneNode> = Vec::new();
+    children.push(text(vec![
+        styled_run(
+            " ●",
+            TextStyle {
+                color: Some(palette::ok()),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            " reasonix",
+            TextStyle {
+                bold: Some(true),
+                color: Some(palette::fg()),
+                ..Default::default()
+            },
+        ),
+    ]));
+    if let Some(model) = state.model.as_deref() {
+        children.push(text(vec![
+            styled_run(
+                "  model ",
+                TextStyle {
+                    color: Some(palette::fg2()),
+                    ..Default::default()
+                },
+            ),
+            styled_run(
+                model,
+                TextStyle {
+                    color: Some(palette::ds()),
+                    ..Default::default()
+                },
+            ),
+        ]));
+    }
+    if let Some(mode) = state.edit_mode.as_ref() {
+        let mode_color = match mode {
+            crate::state::EditMode::Yolo => palette::err(),
+            crate::state::EditMode::Auto => palette::warn(),
+            crate::state::EditMode::Review => palette::ds(),
+        };
+        children.push(text(vec![
+            styled_run(
+                "  mode ",
+                TextStyle {
+                    color: Some(palette::fg2()),
+                    ..Default::default()
+                },
+            ),
+            styled_run(
+                mode.as_str(),
+                TextStyle {
+                    color: Some(mode_color),
+                    bold: Some(true),
+                    ..Default::default()
+                },
+            ),
+        ]));
+    }
+    children.push(text(vec![
+        plain_run("  ", TextStyle::default()),
+        styled_run(
+            if state.busy { "busy" } else { "idle" },
+            TextStyle {
+                color: Some(if state.busy { palette::warn() } else { palette::ok() }),
+                ..Default::default()
+            },
+        ),
+    ]));
+    if let Some(activity) = state.activity.as_deref() {
+        children.push(text(vec![styled_run(
+            &format!(" · {}", activity),
+            TextStyle {
+                color: Some(palette::fg2()),
+                ..Default::default()
+            },
+        )]));
+    }
+    children.push(spacer_box());
+    if let Some(wallet) = format_wallet(state.wallet_balance, state.wallet_currency.as_deref()) {
+        children.push(text(vec![
+            styled_run(
+                "wallet ",
+                TextStyle {
+                    color: Some(palette::fg2()),
+                    ..Default::default()
+                },
+            ),
+            styled_run(
+                &format!("{} ", wallet),
+                TextStyle {
+                    color: Some(palette::ok()),
+                    bold: Some(true),
+                    ..Default::default()
+                },
+            ),
+        ]));
+    }
+    if let Some(cwd) = state.cwd.as_deref() {
+        children.push(text(vec![
+            styled_run(
+                "cwd ",
+                TextStyle {
+                    color: Some(palette::fg2()),
+                    ..Default::default()
+                },
+            ),
+            styled_run(
+                &format!("{} ", trunc_cwd(cwd)),
+                TextStyle {
+                    color: Some(palette::fg1()),
+                    ..Default::default()
+                },
+            ),
+        ]));
+    }
+    row(
+        children,
+        BoxLayout {
+            direction: Some(FlexDirection::Row),
+            background: Some(palette::bg2()),
+            height: Some(Dim::Cells(1)),
+            ..Default::default()
+        },
+    )
+}
+
+fn trunc_cwd(cwd: &str) -> String {
+    if cwd.chars().count() <= 30 {
+        return cwd.to_string();
+    }
+    let tail: String = cwd.chars().rev().take(29).collect::<Vec<_>>().into_iter().rev().collect();
+    format!("…{}", tail)
+}
+
+fn format_wallet(total: Option<f64>, currency: Option<&str>) -> Option<String> {
+    let total = total?;
+    if !total.is_finite() {
+        return None;
+    }
+    let symbol = currency_symbol(currency);
+    Some(format!("{}{:.2}", symbol, total))
+}
+
+fn currency_symbol(currency: Option<&str>) -> String {
+    match currency.map(|c| c.to_ascii_uppercase()) {
+        Some(ref c) if c == "CNY" || c == "RMB" || c == "JPY" => "¥".to_string(),
+        Some(ref c) if c == "USD" => "$".to_string(),
+        Some(ref c) if c == "EUR" => "€".to_string(),
+        Some(ref c) if c == "GBP" => "£".to_string(),
+        Some(c) if !c.is_empty() => format!("{} ", c),
+        _ => String::new(),
+    }
+}
+
+fn approval_row(kind: Option<&str>, prompt: &str) -> SceneNode {
+    let clipped: String = if prompt.chars().count() > APPROVAL_PROMPT_MAX {
+        let head: String = prompt.chars().take(APPROVAL_PROMPT_MAX - 1).collect();
+        format!("{}…", head)
+    } else {
+        prompt.to_string()
+    };
+    let mut runs = vec![styled_run(
+        " ❓ ",
+        TextStyle {
+            color: Some(palette::warn()),
+            bold: Some(true),
+            ..Default::default()
+        },
+    )];
+    if let Some(kind) = kind {
+        runs.push(styled_run(
+            &format!("[{}] ", kind),
+            TextStyle {
+                color: Some(palette::fg2()),
+                ..Default::default()
+            },
+        ));
+    }
+    runs.push(styled_run(
+        &clipped,
+        TextStyle {
+            color: Some(palette::fg()),
+            ..Default::default()
+        },
+    ));
+    runs.push(styled_run(
+        "  [y/n]",
+        TextStyle {
+            color: Some(palette::warn()),
+            bold: Some(true),
+            ..Default::default()
+        },
+    ));
+    row(
+        vec![text(runs)],
+        BoxLayout {
+            direction: Some(FlexDirection::Row),
+            background: Some(palette::bg2()),
+            height: Some(Dim::Cells(1)),
+            ..Default::default()
+        },
+    )
+}
+
+fn slash_overlay_block(state: &SceneState) -> Vec<SceneNode> {
+    let matches = state.slash_matches.as_ref().unwrap();
+    let sel = state
+        .slash_selected_index
+        .unwrap_or(0)
+        .min(matches.len().saturating_sub(1));
+    let (start, shown) = list_window(matches, sel, MAX_SLASH_ROWS);
+    let mut rows: Vec<SceneNode> = Vec::new();
+    let plural = if matches.len() == 1 { "" } else { "es" };
+    rows.push(text(vec![
+        plain_run(" ", TextStyle::default()),
+        styled_run(
+            "/",
+            TextStyle {
+                color: Some(palette::ds()),
+                bold: Some(true),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            " commands",
+            TextStyle {
+                color: Some(palette::fg2()),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            &format!("  {} match{}", matches.len(), plural),
+            TextStyle {
+                color: Some(palette::fg3()),
+                ..Default::default()
+            },
+        ),
+    ]));
+    for (i, m) in shown.iter().enumerate() {
+        rows.push(slash_row(m, start + i == sel));
+    }
+    let hidden = matches.len() - shown.len();
+    if hidden > 0 {
+        rows.push(overflow_row(hidden));
+    }
+    rows
+}
+
+fn slash_row(m: &SlashMatch, selected: bool) -> SceneNode {
+    let prefix = if selected { " ▸ " } else { "   " };
+    let mut runs = vec![
+        styled_run(
+            prefix,
+            TextStyle {
+                color: Some(if selected { palette::ds() } else { palette::fg3() }),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            &m.cmd,
+            if selected {
+                TextStyle {
+                    bold: Some(true),
+                    color: Some(palette::ds_bright()),
+                    ..Default::default()
+                }
+            } else {
+                TextStyle {
+                    color: Some(palette::fg1()),
+                    ..Default::default()
+                }
+            },
+        ),
+    ];
+    if let Some(args_hint) = m.args_hint.as_deref() {
+        runs.push(styled_run(
+            &format!(" {}", args_hint),
+            TextStyle {
+                color: Some(palette::fg2()),
+                ..Default::default()
+            },
+        ));
+    }
+    if !m.summary.is_empty() {
+        runs.push(plain_run("  ", TextStyle::default()));
+        runs.push(styled_run(
+            &m.summary,
+            TextStyle {
+                color: Some(palette::fg2()),
+                ..Default::default()
+            },
+        ));
+    }
+    text(runs)
+}
+
+fn sessions_picker_block(state: &SceneState) -> Vec<SceneNode> {
+    let list = state.sessions.as_ref().unwrap();
+    let sel = state
+        .sessions_focused_index
+        .unwrap_or(0)
+        .min(list.len().saturating_sub(1));
+    let (start, shown) = list_window(list, sel, MAX_SESSION_ROWS);
+    let mut rows: Vec<SceneNode> = Vec::new();
+    rows.push(text(vec![
+        plain_run(" ", TextStyle::default()),
+        styled_run(
+            "◇",
+            TextStyle {
+                color: Some(palette::ds()),
+                bold: Some(true),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            " sessions",
+            TextStyle {
+                color: Some(palette::fg2()),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            &format!("  {} saved", list.len()),
+            TextStyle {
+                color: Some(palette::fg3()),
+                ..Default::default()
+            },
+        ),
+    ]));
+    for (i, s) in shown.iter().enumerate() {
+        rows.push(session_row(s, start + i == sel));
+    }
+    let hidden = list.len() - shown.len();
+    if hidden > 0 {
+        rows.push(overflow_row(hidden));
+    }
+    rows.push(text(vec![
+        plain_run(" ", TextStyle::default()),
+        styled_run(
+            "↑↓",
+            TextStyle {
+                color: Some(palette::ds()),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            " navigate  ",
+            TextStyle {
+                color: Some(palette::fg2()),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            "⏎",
+            TextStyle {
+                color: Some(palette::ds()),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            " open  ",
+            TextStyle {
+                color: Some(palette::fg2()),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            "n",
+            TextStyle {
+                color: Some(palette::ds()),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            " new  ",
+            TextStyle {
+                color: Some(palette::fg2()),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            "esc",
+            TextStyle {
+                color: Some(palette::ds()),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            " cancel",
+            TextStyle {
+                color: Some(palette::fg2()),
+                ..Default::default()
+            },
+        ),
+    ]));
+    rows
+}
+
+fn session_row(item: &SessionItem, focused: bool) -> SceneNode {
+    let prefix = if focused { " ▸ " } else { "   " };
+    let mut runs = vec![
+        styled_run(
+            prefix,
+            TextStyle {
+                color: Some(if focused { palette::ds() } else { palette::fg3() }),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            &item.title,
+            if focused {
+                TextStyle {
+                    bold: Some(true),
+                    color: Some(palette::ds_bright()),
+                    ..Default::default()
+                }
+            } else {
+                TextStyle {
+                    color: Some(palette::fg1()),
+                    ..Default::default()
+                }
+            },
+        ),
+    ];
+    if let Some(meta) = item.meta.as_deref() {
+        runs.push(plain_run("  ", TextStyle::default()));
+        runs.push(styled_run(
+            meta,
+            TextStyle {
+                color: Some(palette::fg2()),
+                ..Default::default()
+            },
+        ));
+    }
+    text(runs)
+}
+
+fn overflow_row(hidden: usize) -> SceneNode {
+    text(vec![styled_run(
+        &format!("   …{} more", hidden),
+        TextStyle {
+            color: Some(palette::fg3()),
+            ..Default::default()
+        },
+    )])
+}
+
+fn list_window<T>(items: &[T], selected: usize, window_size: usize) -> (usize, &[T]) {
+    if items.len() <= window_size {
+        return (0, items);
+    }
+    let half = window_size / 2;
+    let max_start = items.len() - window_size;
+    let start = selected.saturating_sub(half).min(max_start);
+    (start, &items[start..start + window_size])
+}
+
+fn setup_root(state: &SetupState) -> SceneNode {
+    let mut children: Vec<SceneNode> = Vec::new();
+    children.push(text(vec![
+        styled_run(
+            " ● ",
+            TextStyle {
+                color: Some(palette::ds()),
+                bold: Some(true),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            "REASONIX",
+            TextStyle {
+                bold: Some(true),
+                color: Some(palette::ds_bright()),
+                ..Default::default()
+            },
+        ),
+        styled_run(
+            "  welcome",
+            TextStyle {
+                color: Some(palette::fg2()),
+                ..Default::default()
+            },
+        ),
+    ]));
+    children.push(blank_row());
+    children.push(text(vec![styled_run(
+        " Enter your DeepSeek API key:",
+        TextStyle {
+            color: Some(palette::ds()),
+            ..Default::default()
+        },
+    )]));
+    children.push(text(vec![styled_run(
+        "   get one at https://platform.deepseek.com",
+        TextStyle {
+            color: Some(palette::fg2()),
+            ..Default::default()
+        },
+    )]));
+    let mut masked = vec![styled_run(
+        " ❯ ",
+        TextStyle {
+            color: Some(palette::ds()),
+            bold: Some(true),
+            ..Default::default()
+        },
+    )];
+    if state.buffer_length == 0 {
+        masked.push(styled_run(
+            "(start typing your key)",
+            TextStyle {
+                color: Some(palette::fg2()),
+                ..Default::default()
+            },
+        ));
+    } else {
+        let dots: String = "•".repeat(state.buffer_length);
+        masked.push(styled_run(
+            &dots,
+            TextStyle {
+                color: Some(palette::fg()),
+                ..Default::default()
+            },
+        ));
+        masked.push(styled_run(
+            "▮",
+            TextStyle {
+                color: Some(palette::ds()),
+                ..Default::default()
+            },
+        ));
+    }
+    children.push(text(masked));
+    if let Some(err) = state.error.as_deref() {
+        children.push(text(vec![
+            styled_run(
+                " ✗ ",
+                TextStyle {
+                    color: Some(palette::err()),
+                    bold: Some(true),
+                    ..Default::default()
+                },
+            ),
+            styled_run(
+                err,
+                TextStyle {
+                    color: Some(palette::err()),
+                    ..Default::default()
+                },
+            ),
+        ]));
+    }
+    children.push(blank_row());
+    children.push(text(vec![styled_run(
+        " Ctrl+C to exit · /exit to quit",
+        TextStyle {
+            color: Some(palette::fg2()),
+            ..Default::default()
+        },
+    )]));
+    column(
+        children,
+        BoxLayout {
+            background: Some(palette::bg()),
+            ..Default::default()
+        },
+    )
+}
+
+fn column(children: Vec<SceneNode>, mut layout: BoxLayout) -> SceneNode {
+    layout.direction = Some(layout.direction.unwrap_or(FlexDirection::Column));
+    SceneNode::Box {
+        layout: Some(layout),
+        children,
+    }
+}
+
+fn row(children: Vec<SceneNode>, mut layout: BoxLayout) -> SceneNode {
+    layout.direction = Some(FlexDirection::Row);
+    SceneNode::Box {
+        layout: Some(layout),
+        children,
+    }
+}
+
+fn text(runs: Vec<TextRun>) -> SceneNode {
+    SceneNode::Text { runs, wrap: None }
+}
+
+fn blank_row() -> SceneNode {
+    text(vec![plain_run("", TextStyle::default())])
+}
+
+fn spacer_box() -> SceneNode {
+    SceneNode::Box {
+        layout: Some(BoxLayout {
+            width: Some(Dim::Fill(FillToken::Fill)),
+            ..Default::default()
+        }),
+        children: vec![],
+    }
+}
+
+fn styled_run(text: &str, style: TextStyle) -> TextRun {
+    TextRun {
+        text: text.to_string(),
+        style: Some(style),
+    }
+}
+
+fn plain_run(text: &str, _style: TextStyle) -> TextRun {
+    TextRun {
+        text: text.to_string(),
+        style: None,
+    }
+}
+

--- a/crates/reasonix-render/src/state.rs
+++ b/crates/reasonix-render/src/state.rs
@@ -1,0 +1,122 @@
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SceneState {
+    #[serde(default)]
+    pub model: Option<String>,
+    #[serde(default)]
+    pub card_count: u32,
+    #[serde(default)]
+    pub cards: Vec<SceneCard>,
+    #[serde(default)]
+    pub busy: bool,
+    #[serde(default)]
+    pub activity: Option<String>,
+    #[serde(default)]
+    pub composer_text: Option<String>,
+    #[serde(default)]
+    pub composer_cursor: Option<usize>,
+    #[serde(default)]
+    pub slash_matches: Option<Vec<SlashMatch>>,
+    #[serde(default)]
+    pub slash_selected_index: Option<usize>,
+    #[serde(default)]
+    pub approval_kind: Option<String>,
+    #[serde(default)]
+    pub approval_prompt: Option<String>,
+    #[serde(default)]
+    pub sessions: Option<Vec<SessionItem>>,
+    #[serde(default)]
+    pub sessions_focused_index: Option<usize>,
+    #[serde(default)]
+    pub wallet_balance: Option<f64>,
+    #[serde(default)]
+    pub wallet_currency: Option<String>,
+    #[serde(default)]
+    pub mcp_server_count: Option<u32>,
+    #[serde(default)]
+    pub edit_mode: Option<EditMode>,
+    #[serde(default)]
+    pub cwd: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SceneCard {
+    pub kind: String,
+    #[serde(default)]
+    pub summary: String,
+    #[serde(default)]
+    pub args: Option<String>,
+    #[serde(default)]
+    pub status: Option<ToolStatus>,
+    #[serde(default)]
+    pub elapsed: Option<String>,
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub body: Option<String>,
+    #[serde(default)]
+    pub ts: Option<i64>,
+    #[serde(default)]
+    pub meta: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ToolStatus {
+    Ok,
+    Err,
+    Running,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum EditMode {
+    Review,
+    Auto,
+    Yolo,
+}
+
+impl EditMode {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            EditMode::Review => "review",
+            EditMode::Auto => "auto",
+            EditMode::Yolo => "yolo",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SlashMatch {
+    pub cmd: String,
+    #[serde(default)]
+    pub summary: String,
+    #[serde(default, rename = "argsHint")]
+    pub args_hint: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SessionItem {
+    pub title: String,
+    #[serde(default)]
+    pub meta: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetupState {
+    #[serde(default)]
+    pub buffer_length: usize,
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum Message {
+    Trace(SceneState),
+    Setup(SetupState),
+}

--- a/crates/reasonix-render/src/theme.rs
+++ b/crates/reasonix-render/src/theme.rs
@@ -1,0 +1,51 @@
+use crate::scene::{Color, NamedColor};
+
+pub fn hex(s: &'static str) -> Color {
+    Color::Hex { hex: s.to_string() }
+}
+
+pub fn default_color() -> Color {
+    Color::Named(NamedColor::Default)
+}
+
+pub mod palette {
+    use super::hex;
+    use crate::scene::Color;
+
+    pub fn bg() -> Color {
+        hex("#0f1018")
+    }
+    pub fn bg2() -> Color {
+        hex("#161824")
+    }
+    pub fn fg() -> Color {
+        hex("#e8e9f3")
+    }
+    pub fn fg1() -> Color {
+        hex("#a8aabd")
+    }
+    pub fn fg2() -> Color {
+        hex("#6b6e85")
+    }
+    pub fn fg3() -> Color {
+        hex("#3d4055")
+    }
+    pub fn ds() -> Color {
+        hex("#6b85ff")
+    }
+    pub fn ds_bright() -> Color {
+        hex("#8b9fff")
+    }
+    pub fn ds_purple() -> Color {
+        hex("#a78bfa")
+    }
+    pub fn ok() -> Color {
+        hex("#5eead4")
+    }
+    pub fn warn() -> Color {
+        hex("#fbbf24")
+    }
+    pub fn err() -> Color {
+        hex("#fb7185")
+    }
+}

--- a/crates/reasonix-render/tests/producer.rs
+++ b/crates/reasonix-render/tests/producer.rs
@@ -1,0 +1,335 @@
+use reasonix_render::producer::{build_setup_frame, build_trace_frame};
+use reasonix_render::scene::{SceneNode, TextRun};
+use reasonix_render::state::{EditMode, SceneCard, SceneState, SessionItem, SetupState, SlashMatch, ToolStatus};
+
+fn root(state: SceneState) -> SceneNode {
+    let frame = build_trace_frame(&state, 142, 38);
+    frame.root
+}
+
+fn flatten(node: &SceneNode) -> String {
+    let mut out = String::new();
+    walk(node, &mut out);
+    out
+}
+
+fn walk(node: &SceneNode, out: &mut String) {
+    match node {
+        SceneNode::Text { runs, .. } => {
+            for run in runs {
+                out.push_str(&run.text);
+            }
+            out.push('\n');
+        }
+        SceneNode::Box { children, .. } => {
+            for child in children {
+                walk(child, out);
+            }
+        }
+    }
+}
+
+fn scroll_children(root: &SceneNode) -> &[SceneNode] {
+    let outer = unbox(root).expect("outer box");
+    let scroll = unbox(&outer[0]).expect("scroll box");
+    scroll
+}
+
+fn dock_children(root: &SceneNode) -> &[SceneNode] {
+    let outer = unbox(root).expect("outer box");
+    let dock = unbox(&outer[1]).expect("dock box");
+    dock
+}
+
+fn unbox(node: &SceneNode) -> Option<&[SceneNode]> {
+    match node {
+        SceneNode::Box { children, .. } => Some(children),
+        _ => None,
+    }
+}
+
+fn run_text(runs: &[TextRun]) -> String {
+    runs.iter().map(|r| r.text.as_str()).collect()
+}
+
+#[test]
+fn empty_state_renders_boot_block_with_reasonix_logo_and_tools_row() {
+    let root = root(SceneState {
+        model: Some("deepseek-chat".to_string()),
+        cwd: Some("/work/reasonix".to_string()),
+        ..Default::default()
+    });
+    let flat = flatten(&root);
+    assert!(flat.contains("██████╗"), "missing logo");
+    assert!(flat.contains("DeepSeek code agent"), "missing tagline");
+    assert!(flat.contains("model"), "missing model field");
+    assert!(flat.contains("deepseek-chat"), "missing model value");
+    assert!(flat.contains("workdir"), "missing workdir field");
+    assert!(flat.contains("/work/reasonix"), "missing cwd");
+    assert!(flat.contains("tools"), "missing tools row");
+}
+
+#[test]
+fn cards_state_replaces_boot_block_with_one_card_block_per_card() {
+    let root = root(SceneState {
+        cards: vec![
+            SceneCard {
+                kind: "user".to_string(),
+                summary: "hello".to_string(),
+                body: Some("hello".to_string()),
+                ts: Some(0),
+                ..Default::default()
+            },
+            SceneCard {
+                kind: "streaming".to_string(),
+                summary: "hi back".to_string(),
+                body: Some("hi back".to_string()),
+                ..Default::default()
+            },
+        ],
+        card_count: 2,
+        ..Default::default()
+    });
+    let scroll = scroll_children(&root);
+    assert_eq!(scroll.len(), 2, "two cards expected");
+    let flat = flatten(&root);
+    assert!(flat.contains("YOU"), "missing YOU label");
+    assert!(flat.contains("hello"), "missing user body");
+    assert!(flat.contains("reasonix"), "missing reasonix label");
+    assert!(flat.contains("hi back"), "missing streaming body");
+    assert!(!flat.contains("██████╗"), "boot block should be hidden with cards");
+}
+
+#[test]
+fn dock_has_composer_meta_status_when_no_overlay() {
+    let root = root(SceneState::default());
+    let dock = dock_children(&root);
+    assert_eq!(dock.len(), 3, "composer + meta + status");
+    let flat = flatten(&root);
+    assert!(flat.contains("type to chat"));
+    assert!(flat.contains("send"));
+    assert!(flat.contains("newline"));
+    assert!(flat.contains("reasonix"));
+}
+
+#[test]
+fn composer_renders_text_with_cursor_block_at_offset() {
+    let root = root(SceneState {
+        composer_text: Some("hello".to_string()),
+        composer_cursor: Some(2),
+        ..Default::default()
+    });
+    let dock = dock_children(&root);
+    let composer = unbox(&dock[0]).expect("composer box");
+    let inner = match &composer[0] {
+        SceneNode::Text { runs, .. } => run_text(runs),
+        _ => panic!("expected text"),
+    };
+    assert!(inner.contains("he"), "before-cursor missing");
+    assert!(inner.contains("▮"), "cursor block missing");
+    assert!(inner.contains("llo"), "after-cursor missing");
+}
+
+#[test]
+fn approval_replaces_composer_with_y_n_stub() {
+    let root = root(SceneState {
+        approval_kind: Some("shell".to_string()),
+        approval_prompt: Some("rm -rf /tmp/x".to_string()),
+        composer_text: Some("typing…".to_string()),
+        ..Default::default()
+    });
+    let flat = flatten(&root);
+    assert!(flat.contains("❓"));
+    assert!(flat.contains("[shell]"));
+    assert!(flat.contains("rm -rf /tmp/x"));
+    assert!(flat.contains("[y/n]"));
+    assert!(!flat.contains("typing…"));
+}
+
+#[test]
+fn slash_overlay_renders_above_composer() {
+    let root = root(SceneState {
+        slash_matches: Some(vec![
+            SlashMatch {
+                cmd: "/help".to_string(),
+                summary: "show help".to_string(),
+                args_hint: None,
+            },
+            SlashMatch {
+                cmd: "/model".to_string(),
+                summary: "switch model".to_string(),
+                args_hint: Some("<name>".to_string()),
+            },
+        ]),
+        slash_selected_index: Some(1),
+        ..Default::default()
+    });
+    let flat = flatten(&root);
+    assert!(flat.contains("/help"));
+    assert!(flat.contains("/model"));
+    assert!(flat.contains("<name>"));
+    assert!(flat.contains("switch model"));
+    assert!(flat.contains("▸"));
+}
+
+#[test]
+fn sessions_picker_block_appears_with_header_and_hint() {
+    let root = root(SceneState {
+        sessions: Some(vec![
+            SessionItem {
+                title: "feat-foo".to_string(),
+                meta: Some("main · 12 turns".to_string()),
+            },
+            SessionItem {
+                title: "spike-bar".to_string(),
+                meta: Some("release/4.5".to_string()),
+            },
+        ]),
+        sessions_focused_index: Some(0),
+        ..Default::default()
+    });
+    let flat = flatten(&root);
+    assert!(flat.contains("sessions"));
+    assert!(flat.contains("2 saved"));
+    assert!(flat.contains("feat-foo"));
+    assert!(flat.contains("spike-bar"));
+    assert!(flat.contains("navigate"));
+    assert!(flat.contains("open"));
+}
+
+#[test]
+fn status_bar_carries_model_and_wallet_and_cwd_segments() {
+    let root = root(SceneState {
+        model: Some("deepseek-chat".to_string()),
+        wallet_balance: Some(184.2),
+        wallet_currency: Some("CNY".to_string()),
+        cwd: Some("/workspace/reasonix-core".to_string()),
+        cards: vec![SceneCard {
+            kind: "user".to_string(),
+            summary: "x".to_string(),
+            body: Some("x".to_string()),
+            ..Default::default()
+        }],
+        card_count: 1,
+        ..Default::default()
+    });
+    let dock = dock_children(&root);
+    let status = &dock[dock.len() - 1];
+    let flat: String = match status {
+        SceneNode::Box { children, .. } => children
+            .iter()
+            .map(|c| match c {
+                SceneNode::Text { runs, .. } => run_text(runs),
+                _ => String::new(),
+            })
+            .collect::<Vec<_>>()
+            .join(" | "),
+        _ => panic!("expected status box"),
+    };
+    assert!(flat.contains("reasonix"));
+    assert!(flat.contains("deepseek-chat"));
+    assert!(flat.contains("¥184.20"));
+    assert!(flat.contains("reasonix-core"));
+}
+
+#[test]
+fn edit_mode_segment_uses_per_mode_color_glyph() {
+    let root_yolo = root(SceneState {
+        edit_mode: Some(EditMode::Yolo),
+        ..Default::default()
+    });
+    let flat = flatten(&root_yolo);
+    assert!(flat.contains("mode"));
+    assert!(flat.contains("yolo"));
+}
+
+#[test]
+fn tool_card_renders_in_rich_arrow_args_status_format() {
+    let root = root(SceneState {
+        cards: vec![SceneCard {
+            kind: "tool".to_string(),
+            summary: "Read".to_string(),
+            args: Some("src/parser.ts".to_string()),
+            status: Some(ToolStatus::Ok),
+            elapsed: Some("120ms".to_string()),
+            id: Some("#a4f1".to_string()),
+            ..Default::default()
+        }],
+        card_count: 1,
+        ..Default::default()
+    });
+    let flat = flatten(&root);
+    assert!(flat.contains("▸"));
+    assert!(flat.contains("Read"));
+    assert!(flat.contains("(src/parser.ts)"));
+    assert!(flat.contains("✓"));
+    assert!(flat.contains("120ms"));
+    assert!(flat.contains("#a4f1"));
+}
+
+#[test]
+fn tool_card_with_err_status_uses_x_glyph() {
+    let root = root(SceneState {
+        cards: vec![SceneCard {
+            kind: "tool".to_string(),
+            summary: "Bash".to_string(),
+            args: Some("false".to_string()),
+            status: Some(ToolStatus::Err),
+            ..Default::default()
+        }],
+        card_count: 1,
+        ..Default::default()
+    });
+    assert!(flatten(&root).contains("✗"));
+}
+
+#[test]
+fn setup_frame_renders_welcome_banner_and_masked_input() {
+    let frame = build_setup_frame(
+        &SetupState {
+            buffer_length: 4,
+            error: None,
+        },
+        80,
+        24,
+    );
+    let flat = flatten(&frame.root);
+    assert!(flat.contains("REASONIX"));
+    assert!(flat.contains("welcome"));
+    assert!(flat.contains("API key"));
+    assert!(flat.contains("••••"));
+    assert!(flat.contains("▮"));
+    assert!(flat.contains("Ctrl+C"));
+}
+
+#[test]
+fn setup_frame_with_error_renders_err_row() {
+    let frame = build_setup_frame(
+        &SetupState {
+            buffer_length: 0,
+            error: Some("key malformed".to_string()),
+        },
+        80,
+        24,
+    );
+    let flat = flatten(&frame.root);
+    assert!(flat.contains("✗"));
+    assert!(flat.contains("key malformed"));
+}
+
+#[test]
+fn long_card_body_capped_at_max_lines_with_blanks_skipped() {
+    let body = vec!["a", "", "b", "c", "", "d", "e", "f", "g"].join("\n");
+    let root = root(SceneState {
+        cards: vec![SceneCard {
+            kind: "user".to_string(),
+            summary: "a".to_string(),
+            body: Some(body),
+            ..Default::default()
+        }],
+        card_count: 1,
+        ..Default::default()
+    });
+    let flat = flatten(&root);
+    assert!(!flat.contains(" g"), "body lines should cap before g");
+}

--- a/src/cli/ui/hooks/useSceneTrace.ts
+++ b/src/cli/ui/hooks/useSceneTrace.ts
@@ -1,21 +1,24 @@
 import { useStdout } from "ink";
 import { useEffect } from "react";
-import { box, frame, text } from "../scene/build.js";
-import { PALETTE } from "../scene/theme.js";
-import { emitSceneFrame, isSceneTraceEnabled } from "../scene/trace.js";
-import type { Color, SceneFrame, SceneNode, TextRun } from "../scene/types.js";
+import { emitSceneMessage, isSceneTraceEnabled } from "../scene/trace.js";
 import type { Card } from "../state/cards.js";
 
-export type SceneTraceCard = {
+export type SceneCard = {
   kind: string;
   summary: string;
   args?: string;
   status?: "ok" | "err" | "running";
   elapsed?: string;
   id?: string;
+  body?: string;
+  ts?: number;
+  meta?: string;
 };
+
 export type SceneSlashMatch = { cmd: string; summary: string; argsHint?: string };
 export type SceneSessionItem = { title: string; meta?: string };
+
+export type SceneTraceCard = SceneCard;
 
 export type SceneTraceInput = {
   model?: string;
@@ -40,35 +43,12 @@ export type SceneTraceInput = {
   cwd?: string;
 };
 
-type BuildInput = {
-  model?: string;
-  cardCount: number;
-  cards: ReadonlyArray<SceneTraceCard>;
-  busy: boolean;
-  activity?: string;
-  composerText?: string;
-  composerCursor?: number;
-  slashMatches?: ReadonlyArray<SceneSlashMatch>;
-  slashSelectedIndex?: number;
-  approvalKind?: string;
-  approvalPrompt?: string;
-  sessions?: ReadonlyArray<SceneSessionItem>;
-  sessionsFocusedIndex?: number;
-  walletBalance?: number;
-  walletCurrency?: string;
-  sidebarSessions?: ReadonlyArray<SceneSessionItem>;
-  sidebarActiveSession?: string;
-  mcpServerCount?: number;
-  editMode?: "review" | "auto" | "yolo";
-  cwd?: string;
+export type SetupSceneInput = {
+  bufferLength: number;
+  error?: string;
 };
 
 const SUMMARY_MAX = 70;
-const RESERVED_ROWS = 4;
-const MAX_CARDS = 24;
-const MAX_SLASH_ROWS = 6;
-const MAX_SESSION_ROWS = 8;
-const APPROVAL_PROMPT_MAX = 60;
 
 export function summarizeCard(card: Card | undefined): string | undefined {
   if (!card) return undefined;
@@ -92,17 +72,42 @@ export function summarizeCard(card: Card | undefined): string | undefined {
   }
 }
 
-export function toSceneCard(card: Card): SceneTraceCard {
+function clip(s: string): string {
+  const firstLine = s.split("\n", 1)[0] ?? "";
+  return firstLine.length > SUMMARY_MAX ? `${firstLine.slice(0, SUMMARY_MAX - 1)}…` : firstLine;
+}
+
+export function toSceneCard(card: Card): SceneCard {
   const summary = summarizeCard(card) ?? "";
-  if (card.kind !== "tool") return { kind: card.kind, summary };
-  return {
-    kind: "tool",
-    summary: card.name,
-    args: extractToolArgs(card.args),
-    status: toolStatus(card),
-    elapsed: card.done ? formatElapsed(card.elapsedMs) : undefined,
-    id: shortenId(card.id),
-  };
+  switch (card.kind) {
+    case "tool":
+      return {
+        kind: "tool",
+        summary: card.name,
+        args: extractToolArgs(card.args),
+        status: toolStatus(card),
+        elapsed: card.done ? formatElapsed(card.elapsedMs) : undefined,
+        id: shortenId(card.id),
+      };
+    case "user":
+      return { kind: "user", summary, body: card.text, ts: card.ts };
+    case "reasoning": {
+      const meta = card.endedAt
+        ? `${card.paragraphs} steps · ${formatElapsed(card.endedAt - card.ts)}`
+        : `${card.paragraphs} steps`;
+      return { kind: "reasoning", summary, body: card.text, ts: card.ts, meta };
+    }
+    case "streaming":
+      return {
+        kind: "streaming",
+        summary,
+        body: card.text,
+        ts: card.ts,
+        meta: card.done ? "done" : "streaming…",
+      };
+    default:
+      return { kind: card.kind, summary };
+  }
 }
 
 function toolStatus(card: Card & { kind: "tool" }): "ok" | "err" | "running" {
@@ -140,568 +145,66 @@ function shortenId(id: string): string | undefined {
   return tail ? `#${tail}` : undefined;
 }
 
-function clip(s: string): string {
-  const firstLine = s.split("\n", 1)[0] ?? "";
-  return firstLine.length > SUMMARY_MAX ? `${firstLine.slice(0, SUMMARY_MAX - 1)}…` : firstLine;
-}
-
-export function buildTraceFrame(input: BuildInput, cols: number, rows: number): SceneFrame {
-  return frame(
-    cols,
-    rows,
-    box([scrollArea(input), dock(input)], {
-      direction: "column",
-      background: PALETTE.bg,
-    }),
-  );
-}
-
-function scrollArea(input: BuildInput): SceneNode {
-  const children: SceneNode[] = [];
-  if (input.cards.length === 0) {
-    children.push(...bootBlock(input));
-  } else {
-    for (const c of input.cards) children.push(cardBlock(c));
-  }
-  return box(children, {
-    direction: "column",
-    height: "fill",
-    width: "fill",
-    paddingX: 2,
-    paddingY: 1,
+export function parseSlashMatches(json: string | undefined): SceneSlashMatch[] {
+  return parseArrayJson(json, (obj) => {
+    if (typeof obj.cmd !== "string" || typeof obj.summary !== "string") return undefined;
+    const m: SceneSlashMatch = { cmd: obj.cmd, summary: obj.summary };
+    if (typeof obj.argsHint === "string") m.argsHint = obj.argsHint;
+    return m;
   });
-}
-
-const LOGO_LINES: readonly string[] = [
-  "██████╗ ███████╗ █████╗ ███████╗ ██████╗ ███╗   ██╗██╗██╗  ██╗",
-  "██╔══██╗██╔════╝██╔══██╗██╔════╝██╔═══██╗████╗  ██║██║╚██╗██╔╝",
-  "██████╔╝█████╗  ███████║███████╗██║   ██║██╔██╗ ██║██║ ╚███╔╝ ",
-  "██╔══██╗██╔══╝  ██╔══██║╚════██║██║   ██║██║╚██╗██║██║ ██╔██╗ ",
-  "██║  ██║███████╗██║  ██║███████║╚██████╔╝██║ ╚████║██║██╔╝ ██╗",
-  "╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝╚══════╝ ╚═════╝ ╚═╝  ╚═══╝╚═╝╚═╝  ╚═╝",
-];
-
-function bootBlock(input: BuildInput): SceneNode[] {
-  const rows: SceneNode[] = [];
-  rows.push(blankRow());
-  for (const line of LOGO_LINES) {
-    rows.push(text([{ text: line, style: { color: PALETTE.ds, bold: true } }]));
-  }
-  rows.push(blankRow());
-  rows.push(
-    text([
-      { text: " DeepSeek code agent  ", style: { color: PALETTE.fg } },
-      { text: "· terminal-native, cache-first ·", style: { color: PALETTE.fg2 } },
-    ]),
-  );
-  rows.push(blankRow());
-  if (input.model) rows.push(bootField("model", input.model, PALETTE.dsBright));
-  if (input.cwd) rows.push(bootField("workdir", input.cwd, PALETTE.fg));
-  if (input.mcpServerCount !== undefined && input.mcpServerCount > 0) {
-    rows.push(bootField("mcp", `${input.mcpServerCount} server(s) connected`, PALETTE.fg));
-  }
-  rows.push(bootField("tools", "read · write · edit · bash · grep · fetch · todo", PALETTE.fg));
-  rows.push(blankRow());
-  rows.push(
-    text([
-      { text: " ", style: {} },
-      { text: "type to chat  ", style: { color: PALETTE.fg2 } },
-      { text: "·  ", style: { color: PALETTE.fg3 } },
-      { text: "/", style: { color: PALETTE.ds, bold: true } },
-      { text: " commands  ", style: { color: PALETTE.fg2 } },
-      { text: "·  ", style: { color: PALETTE.fg3 } },
-      { text: "@", style: { color: PALETTE.ds, bold: true } },
-      { text: " file refs  ", style: { color: PALETTE.fg2 } },
-      { text: "·  ", style: { color: PALETTE.fg3 } },
-      { text: "!", style: { color: PALETTE.ds, bold: true } },
-      { text: " shell  ", style: { color: PALETTE.fg2 } },
-      { text: "·  ", style: { color: PALETTE.fg3 } },
-      { text: "Ctrl+C", style: { color: PALETTE.ds, bold: true } },
-      { text: " cancel  ", style: { color: PALETTE.fg2 } },
-      { text: "·  ", style: { color: PALETTE.fg3 } },
-      { text: "Ctrl+D", style: { color: PALETTE.ds, bold: true } },
-      { text: " exit", style: { color: PALETTE.fg2 } },
-    ]),
-  );
-  return rows;
-}
-
-function blankRow(): SceneNode {
-  return text([{ text: "", style: {} }]);
-}
-
-function bootField(key: string, value: string, valueColor: Color): SceneNode {
-  return text([
-    { text: ` ${key.padEnd(10)}`, style: { color: PALETTE.fg2 } },
-    { text: value, style: { color: valueColor } },
-  ]);
-}
-
-export const REASONIX_LOGO_LINES = LOGO_LINES;
-
-function cardBlock(c: SceneTraceCard): SceneNode {
-  if (c.kind === "tool") return toolCardBlock(c);
-  const color = colorFor(c.kind);
-  const label = kindLabel(c.kind);
-  const runs: TextRun[] = [{ text: glyphFor(c.kind), style: { color, bold: true } }, { text: " " }];
-  if (label) {
-    runs.push({ text: label, style: { color, bold: true } });
-    runs.push({ text: "  " });
-  }
-  runs.push({ text: c.summary || c.kind, style: { color: PALETTE.fg } });
-  return text(runs);
-}
-
-function toolCardBlock(c: SceneTraceCard): SceneNode {
-  const runs: TextRun[] = [
-    { text: "▸ ", style: { color: PALETTE.fg2 } },
-    { text: c.summary || "tool", style: { color: PALETTE.fg, bold: true } },
-  ];
-  if (c.args) {
-    runs.push({ text: " (", style: { color: PALETTE.fg2 } });
-    runs.push({ text: c.args, style: { color: PALETTE.dsBright } });
-    runs.push({ text: ")", style: { color: PALETTE.fg2 } });
-  }
-  runs.push({ text: "  ", style: {} });
-  if (c.status === "ok") {
-    runs.push({ text: "✓", style: { color: PALETTE.ok, bold: true } });
-  } else if (c.status === "err") {
-    runs.push({ text: "✗", style: { color: PALETTE.err, bold: true } });
-  } else {
-    runs.push({ text: "…", style: { color: PALETTE.warn } });
-  }
-  if (c.elapsed) runs.push({ text: ` ${c.elapsed}`, style: { color: PALETTE.fg2 } });
-  if (c.id) runs.push({ text: `  ${c.id}`, style: { color: PALETTE.fg3 } });
-  return text(runs);
-}
-
-function glyphFor(kind: string): string {
-  switch (kind) {
-    case "user":
-      return "❯";
-    case "reasoning":
-      return "◆";
-    case "streaming":
-      return "◆";
-    case "tool":
-      return "▸";
-    case "diff":
-      return "Δ";
-    case "error":
-      return "✗";
-    case "warn":
-      return "!";
-    case "plan":
-    case "task":
-      return "◆";
-    default:
-      return "·";
-  }
-}
-
-function colorFor(kind: string): Color {
-  switch (kind) {
-    case "user":
-      return PALETTE.ds;
-    case "reasoning":
-      return PALETTE.dsPurple;
-    case "streaming":
-      return PALETTE.ok;
-    case "tool":
-      return PALETTE.fg1;
-    case "diff":
-      return PALETTE.dsPurple;
-    case "error":
-      return PALETTE.err;
-    case "warn":
-      return PALETTE.warn;
-    case "plan":
-    case "task":
-      return PALETTE.dsPurple;
-    default:
-      return PALETTE.fg2;
-  }
-}
-
-function kindLabel(kind: string): string | null {
-  switch (kind) {
-    case "user":
-      return "YOU";
-    case "reasoning":
-      return "THINKING";
-    case "streaming":
-      return "reasonix";
-    case "tool":
-    case "diff":
-    case "error":
-    case "warn":
-    case "plan":
-    case "task":
-      return null;
-    default:
-      return null;
-  }
-}
-
-function dock(input: BuildInput): SceneNode {
-  const children: SceneNode[] = [];
-  const sessions = input.sessions ?? [];
-  const slash = input.slashMatches ?? [];
-  if (sessions.length > 0) {
-    children.push(...sessionsPickerBlock(input, sessions));
-  } else if (slash.length > 0 && !input.approvalPrompt) {
-    children.push(...slashOverlayBlock(input, slash));
-  }
-  if (input.approvalPrompt) {
-    children.push(approvalRow(input.approvalKind, input.approvalPrompt));
-  } else {
-    children.push(composerRow(input));
-  }
-  children.push(metaRow());
-  children.push(statusBarRow(input));
-  return box(children, { direction: "column" });
-}
-
-function composerRow(s: BuildInput): SceneNode {
-  const runs: TextRun[] = [
-    { text: " ", style: { color: PALETTE.fg } },
-    { text: "❯ ", style: { color: PALETTE.ds, bold: true } },
-  ];
-  const t = s.composerText ?? "";
-  if (t.length === 0) {
-    runs.push({
-      text: "type to chat · / for commands · @ for files",
-      style: { color: PALETTE.fg2 },
-    });
-    return box([text(runs)], { direction: "row", background: PALETTE.bg2, height: 1 });
-  }
-  const cur = Math.max(0, Math.min(t.length, s.composerCursor ?? t.length));
-  if (cur > 0) runs.push({ text: t.slice(0, cur), style: { color: PALETTE.fg } });
-  runs.push({ text: "▮", style: { color: PALETTE.ds } });
-  if (cur < t.length) runs.push({ text: t.slice(cur), style: { color: PALETTE.fg } });
-  return box([text(runs)], { direction: "row", background: PALETTE.bg2, height: 1 });
-}
-
-function metaRow(): SceneNode {
-  const left = text([
-    { text: " ", style: {} },
-    { text: "↵", style: { color: PALETTE.ds } },
-    { text: " send  ", style: { color: PALETTE.fg2 } },
-    { text: "⇧↵", style: { color: PALETTE.ds } },
-    { text: " newline  ", style: { color: PALETTE.fg2 } },
-    { text: "/", style: { color: PALETTE.ds } },
-    { text: " cmd  ", style: { color: PALETTE.fg2 } },
-    { text: "@", style: { color: PALETTE.ds } },
-    { text: " file  ", style: { color: PALETTE.fg2 } },
-    { text: "!", style: { color: PALETTE.ds } },
-    { text: " shell", style: { color: PALETTE.fg2 } },
-  ]);
-  const right = text([
-    { text: "esc", style: { color: PALETTE.ds } },
-    { text: " cancel  ", style: { color: PALETTE.fg2 } },
-    { text: "↑", style: { color: PALETTE.ds } },
-    { text: " history ", style: { color: PALETTE.fg2 } },
-  ]);
-  return box([left, box([], { width: "fill" }), right], { direction: "row", height: 1 });
-}
-
-function statusBarRow(s: BuildInput): SceneNode {
-  const children: SceneNode[] = [];
-  children.push(
-    text([
-      { text: " ●", style: { color: PALETTE.ok } },
-      { text: " reasonix", style: { bold: true, color: PALETTE.fg } },
-    ]),
-  );
-  if (s.model) {
-    children.push(
-      text([
-        { text: "  model ", style: { color: PALETTE.fg2 } },
-        { text: s.model, style: { color: PALETTE.ds } },
-      ]),
-    );
-  }
-  if (s.editMode) {
-    const modeColor =
-      s.editMode === "yolo" ? PALETTE.err : s.editMode === "auto" ? PALETTE.warn : PALETTE.ds;
-    children.push(
-      text([
-        { text: "  mode ", style: { color: PALETTE.fg2 } },
-        { text: s.editMode, style: { color: modeColor, bold: true } },
-      ]),
-    );
-  }
-  children.push(
-    text([
-      { text: "  ", style: {} },
-      { text: s.busy ? "busy" : "idle", style: { color: s.busy ? PALETTE.warn : PALETTE.ok } },
-    ]),
-  );
-  if (s.activity) {
-    children.push(text([{ text: ` · ${s.activity}`, style: { color: PALETTE.fg2 } }]));
-  }
-  children.push(box([], { width: "fill" }));
-  const wallet = formatWallet(s.walletBalance, s.walletCurrency);
-  if (wallet) {
-    children.push(
-      text([
-        { text: "wallet ", style: { color: PALETTE.fg2 } },
-        { text: `${wallet} `, style: { color: PALETTE.ok, bold: true } },
-      ]),
-    );
-  }
-  if (s.cwd) {
-    children.push(
-      text([
-        { text: "cwd ", style: { color: PALETTE.fg2 } },
-        { text: `${truncCwd(s.cwd)} `, style: { color: PALETTE.fg1 } },
-      ]),
-    );
-  }
-  return box(children, { direction: "row", background: PALETTE.bg2, height: 1 });
-}
-
-function truncCwd(cwd: string): string {
-  if (cwd.length <= 30) return cwd;
-  return `…${cwd.slice(-29)}`;
-}
-
-function formatWallet(total: number | undefined, currency: string | undefined): string | null {
-  if (total === undefined || !Number.isFinite(total)) return null;
-  const symbol = currencySymbol(currency);
-  return `${symbol}${total.toFixed(2)}`;
-}
-
-function currencySymbol(currency: string | undefined): string {
-  switch ((currency ?? "").toUpperCase()) {
-    case "CNY":
-    case "RMB":
-      return "¥";
-    case "USD":
-      return "$";
-    case "EUR":
-      return "€";
-    case "GBP":
-      return "£";
-    case "JPY":
-      return "¥";
-    default:
-      return currency ? `${currency} ` : "";
-  }
-}
-
-function approvalRow(kind: string | undefined, prompt: string): SceneNode {
-  const clipped =
-    prompt.length > APPROVAL_PROMPT_MAX ? `${prompt.slice(0, APPROVAL_PROMPT_MAX - 1)}…` : prompt;
-  const runs: TextRun[] = [{ text: " ❓ ", style: { color: PALETTE.warn, bold: true } }];
-  if (kind) runs.push({ text: `[${kind}] `, style: { color: PALETTE.fg2 } });
-  runs.push({ text: clipped, style: { color: PALETTE.fg } });
-  runs.push({ text: "  [y/n]", style: { color: PALETTE.warn, bold: true } });
-  return box([text(runs)], { direction: "row", background: PALETTE.bg2, height: 1 });
-}
-
-function slashOverlayBlock(
-  input: BuildInput,
-  matches: ReadonlyArray<SceneSlashMatch>,
-): SceneNode[] {
-  const sel = Math.max(0, Math.min(matches.length - 1, input.slashSelectedIndex ?? 0));
-  const { startIndex, matches: shown } = listWindow(matches, sel, MAX_SLASH_ROWS);
-  const rows: SceneNode[] = [];
-  rows.push(
-    text([
-      { text: " ", style: {} },
-      { text: "/", style: { color: PALETTE.ds, bold: true } },
-      { text: " commands", style: { color: PALETTE.fg2 } },
-      {
-        text: `  ${matches.length} match${matches.length === 1 ? "" : "es"}`,
-        style: { color: PALETTE.fg3 },
-      },
-    ]),
-  );
-  for (let i = 0; i < shown.length; i++) {
-    const absoluteIndex = startIndex + i;
-    rows.push(slashRow(shown[i] as SceneSlashMatch, absoluteIndex === sel));
-  }
-  const hidden = matches.length - shown.length;
-  if (hidden > 0) rows.push(overflowRow(hidden));
-  return rows;
-}
-
-function slashRow(m: SceneSlashMatch, selected: boolean): SceneNode {
-  const runs: TextRun[] = [];
-  runs.push({
-    text: selected ? " ▸ " : "   ",
-    style: { color: selected ? PALETTE.ds : PALETTE.fg3 },
-  });
-  runs.push({
-    text: m.cmd,
-    style: selected ? { bold: true, color: PALETTE.dsBright } : { color: PALETTE.fg1 },
-  });
-  if (m.argsHint) runs.push({ text: ` ${m.argsHint}`, style: { color: PALETTE.fg2 } });
-  if (m.summary) {
-    runs.push({ text: "  ", style: {} });
-    runs.push({ text: m.summary, style: { color: PALETTE.fg2 } });
-  }
-  return text(runs);
-}
-
-function sessionsPickerBlock(
-  input: BuildInput,
-  list: ReadonlyArray<SceneSessionItem>,
-): SceneNode[] {
-  const sel = Math.max(0, Math.min(list.length - 1, input.sessionsFocusedIndex ?? 0));
-  const { startIndex, matches: shown } = listWindow(list, sel, MAX_SESSION_ROWS);
-  const rows: SceneNode[] = [];
-  rows.push(
-    text([
-      { text: " ", style: {} },
-      { text: "◇", style: { color: PALETTE.ds, bold: true } },
-      { text: " sessions", style: { color: PALETTE.fg2 } },
-      { text: `  ${list.length} saved`, style: { color: PALETTE.fg3 } },
-    ]),
-  );
-  for (let i = 0; i < shown.length; i++) {
-    const absoluteIndex = startIndex + i;
-    rows.push(sessionRow(shown[i] as SceneSessionItem, absoluteIndex === sel));
-  }
-  const hidden = list.length - shown.length;
-  if (hidden > 0) rows.push(overflowRow(hidden));
-  rows.push(
-    text([
-      { text: " ", style: {} },
-      { text: "↑↓", style: { color: PALETTE.ds } },
-      { text: " navigate  ", style: { color: PALETTE.fg2 } },
-      { text: "⏎", style: { color: PALETTE.ds } },
-      { text: " open  ", style: { color: PALETTE.fg2 } },
-      { text: "n", style: { color: PALETTE.ds } },
-      { text: " new  ", style: { color: PALETTE.fg2 } },
-      { text: "esc", style: { color: PALETTE.ds } },
-      { text: " cancel", style: { color: PALETTE.fg2 } },
-    ]),
-  );
-  return rows;
-}
-
-function sessionRow(item: SceneSessionItem, focused: boolean): SceneNode {
-  const runs: TextRun[] = [];
-  runs.push({
-    text: focused ? " ▸ " : "   ",
-    style: { color: focused ? PALETTE.ds : PALETTE.fg3 },
-  });
-  runs.push({
-    text: item.title,
-    style: focused ? { bold: true, color: PALETTE.dsBright } : { color: PALETTE.fg1 },
-  });
-  if (item.meta) {
-    runs.push({ text: "  ", style: {} });
-    runs.push({ text: item.meta, style: { color: PALETTE.fg2 } });
-  }
-  return text(runs);
-}
-
-function overflowRow(hidden: number): SceneNode {
-  return text([{ text: `   …${hidden} more`, style: { color: PALETTE.fg3 } }]);
-}
-
-export function listWindow<T>(
-  items: ReadonlyArray<T>,
-  selected: number,
-  windowSize: number,
-): { startIndex: number; matches: ReadonlyArray<T> } {
-  if (items.length <= windowSize) return { startIndex: 0, matches: items };
-  const half = Math.floor(windowSize / 2);
-  const maxStart = items.length - windowSize;
-  const startIndex = Math.max(0, Math.min(maxStart, selected - half));
-  return { startIndex, matches: items.slice(startIndex, startIndex + windowSize) };
-}
-
-export function slashWindow(
-  matches: ReadonlyArray<SceneSlashMatch>,
-  selected: number,
-): { startIndex: number; matches: ReadonlyArray<SceneSlashMatch> } {
-  return listWindow(matches, selected, MAX_SLASH_ROWS);
 }
 
 export function parseSessions(json: string | undefined): SceneSessionItem[] {
-  if (!json || json.length === 0) return [];
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(json);
-  } catch {
-    return [];
-  }
-  if (!Array.isArray(parsed)) return [];
-  const out: SceneSessionItem[] = [];
-  for (const item of parsed) {
-    if (typeof item !== "object" || item === null) continue;
-    const obj = item as Record<string, unknown>;
-    if (typeof obj.title !== "string") continue;
+  return parseArrayJson(json, (obj) => {
+    if (typeof obj.title !== "string") return undefined;
     const s: SceneSessionItem = { title: obj.title };
     if (typeof obj.meta === "string") s.meta = obj.meta;
-    out.push(s);
-  }
-  return out;
+    return s;
+  });
 }
 
-export function parseSlashMatches(json: string | undefined): SceneSlashMatch[] {
-  if (!json || json.length === 0) return [];
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(json);
-  } catch {
-    return [];
-  }
-  if (!Array.isArray(parsed)) return [];
-  const out: SceneSlashMatch[] = [];
-  for (const item of parsed) {
-    if (typeof item !== "object" || item === null) continue;
-    const obj = item as Record<string, unknown>;
-    if (typeof obj.cmd !== "string" || typeof obj.summary !== "string") continue;
-    const m: SceneSlashMatch = { cmd: obj.cmd, summary: obj.summary };
-    if (typeof obj.argsHint === "string") m.argsHint = obj.argsHint;
-    out.push(m);
-  }
-  return out;
-}
-
-export function parseRecentCards(json: string | undefined): SceneTraceCard[] {
-  if (!json || json.length === 0) return [];
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(json);
-  } catch {
-    return [];
-  }
-  if (!Array.isArray(parsed)) return [];
-  const out: SceneTraceCard[] = [];
-  for (const item of parsed) {
-    if (typeof item !== "object" || item === null) continue;
-    const obj = item as Record<string, unknown>;
-    if (typeof obj.kind !== "string" || typeof obj.summary !== "string") continue;
-    const card: SceneTraceCard = { kind: obj.kind, summary: obj.summary };
+export function parseRecentCards(json: string | undefined): SceneCard[] {
+  return parseArrayJson(json, (obj) => {
+    if (typeof obj.kind !== "string" || typeof obj.summary !== "string") return undefined;
+    const card: SceneCard = { kind: obj.kind, summary: obj.summary };
     if (typeof obj.args === "string") card.args = obj.args;
     if (obj.status === "ok" || obj.status === "err" || obj.status === "running") {
       card.status = obj.status;
     }
     if (typeof obj.elapsed === "string") card.elapsed = obj.elapsed;
     if (typeof obj.id === "string") card.id = obj.id;
-    out.push(card);
+    if (typeof obj.body === "string") card.body = obj.body;
+    if (typeof obj.ts === "number") card.ts = obj.ts;
+    if (typeof obj.meta === "string") card.meta = obj.meta;
+    return card;
+  });
+}
+
+function parseArrayJson<T>(
+  json: string | undefined,
+  pick: (obj: Record<string, unknown>) => T | undefined,
+): T[] {
+  if (!json || json.length === 0) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  const out: T[] = [];
+  for (const item of parsed) {
+    if (typeof item !== "object" || item === null) continue;
+    const picked = pick(item as Record<string, unknown>);
+    if (picked !== undefined) out.push(picked);
   }
   return out;
 }
 
-export function cardsForHeight(
-  cards: ReadonlyArray<SceneTraceCard>,
-  rows: number,
-): SceneTraceCard[] {
-  const room = Math.max(1, Math.min(MAX_CARDS, rows - RESERVED_ROWS));
-  return cards.slice(-room);
-}
-
 export function useSceneTrace(input: SceneTraceInput): void {
   const { stdout } = useStdout();
-  const cols = stdout?.columns ?? 80;
-  const rows = stdout?.rows ?? 24;
+  const fallbackCols = stdout?.columns ?? 80;
+  const fallbackRows = stdout?.rows ?? 24;
   const {
     model,
     cardCount,
@@ -724,39 +227,32 @@ export function useSceneTrace(input: SceneTraceInput): void {
   } = input;
   useEffect(() => {
     if (!isSceneTraceEnabled()) return;
-    const parsed = parseRecentCards(recentCardsJson);
-    const cards = cardsForHeight(parsed, rows);
-    const slashMatches = parseSlashMatches(slashMatchesJson);
-    const sessions = parseSessions(sessionsJson);
-    emitSceneFrame(
-      buildTraceFrame(
-        {
-          model,
-          cardCount,
-          cards,
-          busy,
-          activity,
-          composerText,
-          composerCursor,
-          slashMatches,
-          slashSelectedIndex,
-          approvalKind,
-          approvalPrompt,
-          sessions,
-          sessionsFocusedIndex,
-          walletBalance,
-          walletCurrency,
-          mcpServerCount,
-          editMode,
-          cwd,
-        },
-        cols,
-        rows,
-      ),
-    );
+    emitSceneMessage({
+      type: "trace",
+      model,
+      cardCount,
+      cards: parseRecentCards(recentCardsJson),
+      busy,
+      activity,
+      composerText,
+      composerCursor,
+      slashMatches: parseSlashMatches(slashMatchesJson),
+      slashSelectedIndex,
+      approvalKind,
+      approvalPrompt,
+      sessions: parseSessions(sessionsJson),
+      sessionsFocusedIndex,
+      walletBalance,
+      walletCurrency,
+      mcpServerCount,
+      editMode,
+      cwd,
+      fallbackCols,
+      fallbackRows,
+    });
   }, [
-    cols,
-    rows,
+    fallbackCols,
+    fallbackRows,
     model,
     cardCount,
     recentCardsJson,
@@ -778,53 +274,10 @@ export function useSceneTrace(input: SceneTraceInput): void {
   ]);
 }
 
-export type SetupSceneInput = {
-  bufferLength: number;
-  error?: string;
-};
-
-export function buildSetupFrame(input: SetupSceneInput, cols: number, rows: number): SceneFrame {
-  const children: SceneNode[] = [];
-  children.push(
-    text([
-      { text: " ● ", style: { color: PALETTE.ds, bold: true } },
-      { text: "REASONIX", style: { bold: true, color: PALETTE.dsBright } },
-      { text: "  welcome", style: { color: PALETTE.fg2 } },
-    ]),
-  );
-  children.push(text([{ text: "", style: {} }]));
-  children.push(text([{ text: " Enter your DeepSeek API key:", style: { color: PALETTE.ds } }]));
-  children.push(
-    text([{ text: "   get one at https://platform.deepseek.com", style: { color: PALETTE.fg2 } }]),
-  );
-  const maskedRuns: TextRun[] = [{ text: " ❯ ", style: { color: PALETTE.ds, bold: true } }];
-  if (input.bufferLength === 0) {
-    maskedRuns.push({ text: "(start typing your key)", style: { color: PALETTE.fg2 } });
-  } else {
-    maskedRuns.push({ text: "•".repeat(input.bufferLength), style: { color: PALETTE.fg } });
-    maskedRuns.push({ text: "▮", style: { color: PALETTE.ds } });
-  }
-  children.push(text(maskedRuns));
-  if (input.error) {
-    children.push(
-      text([
-        { text: " ✗ ", style: { color: PALETTE.err, bold: true } },
-        { text: input.error, style: { color: PALETTE.err } },
-      ]),
-    );
-  }
-  children.push(text([{ text: "", style: {} }]));
-  children.push(text([{ text: " Ctrl+C to exit · /exit to quit", style: { color: PALETTE.fg2 } }]));
-  return frame(cols, rows, box(children, { direction: "column", background: PALETTE.bg }));
-}
-
 export function useSetupSceneTrace(input: SetupSceneInput): void {
-  const { stdout } = useStdout();
-  const cols = stdout?.columns ?? 80;
-  const rows = stdout?.rows ?? 24;
   const { bufferLength, error } = input;
   useEffect(() => {
     if (!isSceneTraceEnabled()) return;
-    emitSceneFrame(buildSetupFrame({ bufferLength, error }, cols, rows));
-  }, [cols, rows, bufferLength, error]);
+    emitSceneMessage({ type: "setup", bufferLength, error });
+  }, [bufferLength, error]);
 }

--- a/src/cli/ui/scene/renderer-process.ts
+++ b/src/cli/ui/scene/renderer-process.ts
@@ -1,8 +1,7 @@
 import { spawn } from "node:child_process";
-import type { SceneFrame } from "./types.js";
 
 export type RendererProcess = {
-  emit(frame: SceneFrame): void;
+  emit(message: unknown): void;
   close(): Promise<number | null>;
 };
 
@@ -46,11 +45,11 @@ export function spawnRenderer(opts: SpawnRendererOptions = {}): RendererProcess 
   });
 
   return {
-    emit(frame: SceneFrame): void {
+    emit(message: unknown): void {
       if (exited) return;
       const stdin = child.stdin;
       if (!stdin || stdin.destroyed || !stdin.writable) return;
-      stdin.write(`${JSON.stringify(frame)}\n`);
+      stdin.write(`${JSON.stringify(message)}\n`);
     },
     close(): Promise<number | null> {
       const stdin = child.stdin;

--- a/src/cli/ui/scene/trace.ts
+++ b/src/cli/ui/scene/trace.ts
@@ -1,6 +1,5 @@
 import { appendFileSync, closeSync, openSync } from "node:fs";
 import { DEFAULT_COMMAND, type RendererProcess, spawnRenderer } from "./renderer-process.js";
-import type { SceneFrame } from "./types.js";
 
 const FILE_VAR = "REASONIX_SCENE_TRACE";
 const RENDERER_VAR = "REASONIX_RENDERER";
@@ -22,21 +21,24 @@ export function isSceneTraceEnabled(): boolean {
   return state.mode !== "off";
 }
 
-export function emitSceneFrame(frame: SceneFrame): void {
+export function emitSceneMessage(message: unknown): void {
   ensureInitialized();
   switch (state.mode) {
     case "off":
       return;
     case "file":
       if (state.path) {
-        appendFileSync(state.path, `${JSON.stringify(frame)}\n`);
+        appendFileSync(state.path, `${JSON.stringify(message)}\n`);
       }
       return;
     case "child":
-      state.child?.emit(frame);
+      state.child?.emit(message);
       return;
   }
 }
+
+/** @deprecated kept for transition only; prefer emitSceneMessage. */
+export const emitSceneFrame = emitSceneMessage;
 
 export function resetSceneTrace(): void {
   if (state.child) {

--- a/tests/scene-trace-frame.test.ts
+++ b/tests/scene-trace-frame.test.ts
@@ -1,83 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
-  type SceneSessionItem,
-  type SceneSlashMatch,
-  type SceneTraceCard,
-  buildSetupFrame,
-  buildTraceFrame,
-  cardsForHeight,
   parseRecentCards,
   parseSessions,
   parseSlashMatches,
-  slashWindow,
   summarizeCard,
   toSceneCard,
 } from "../src/cli/ui/hooks/useSceneTrace.js";
-import type { SceneNode } from "../src/cli/ui/scene/types.js";
 import type { Card } from "../src/cli/ui/state/cards.js";
-
-function rootChildren(f: ReturnType<typeof buildTraceFrame>): SceneNode[] {
-  if (f.root.kind !== "box") throw new Error("expected root box");
-  return f.root.children;
-}
-
-function scrollOf(f: ReturnType<typeof buildTraceFrame>): SceneNode[] {
-  const scroll = rootChildren(f)[0];
-  if (scroll?.kind !== "box") throw new Error("expected scroll box");
-  return scroll.children;
-}
-
-function dockOf(f: ReturnType<typeof buildTraceFrame>): SceneNode[] {
-  const dock = rootChildren(f)[1];
-  if (dock?.kind !== "box") throw new Error("expected dock box");
-  return dock.children;
-}
-
-function flat(node: SceneNode | undefined): string {
-  if (!node || node.kind !== "text") return "";
-  return node.runs.map((r) => r.text).join("");
-}
-
-function flatRows(nodes: SceneNode[]): string {
-  return nodes
-    .map((c) => {
-      if (c.kind === "text") return flat(c);
-      if (c.kind === "box") return c.children.map((cc) => flat(cc)).join("");
-      return "";
-    })
-    .join("\n");
-}
-
-function findText(nodes: SceneNode[], predicate: (s: string) => boolean): SceneNode | undefined {
-  return nodes.find((c) => c.kind === "text" && predicate(flat(c)));
-}
-
-function composerRowOf(f: ReturnType<typeof buildTraceFrame>): SceneNode {
-  const dock = dockOf(f);
-  const row = dock.find((c) => {
-    if (c.kind !== "box") return false;
-    const first = c.children[0];
-    if (first?.kind !== "text") return false;
-    return first.runs.some((r) => r.text === "❯ ");
-  });
-  if (!row) throw new Error("composer row not found");
-  return row;
-}
-
-function statusRowOf(f: ReturnType<typeof buildTraceFrame>): SceneNode {
-  const dock = dockOf(f);
-  const last = dock.at(-1);
-  if (!last) throw new Error("status row not found");
-  return last;
-}
-
-function metaRowOf(f: ReturnType<typeof buildTraceFrame>): SceneNode {
-  const dock = dockOf(f);
-  const idx = dock.length - 2;
-  const row = dock[idx];
-  if (!row) throw new Error("meta row not found");
-  return row;
-}
 
 function userCard(text: string): Card {
   return { id: "u1", ts: 0, kind: "user", text };
@@ -94,10 +23,6 @@ function toolCard(name: string, done: boolean): Card {
     done,
     elapsedMs: 0,
   };
-}
-
-function buildEmpty(extra: Partial<{ model: string; busy: boolean; composerText: string }> = {}) {
-  return buildTraceFrame({ cardCount: 0, busy: false, cards: [], ...extra }, 142, 38);
 }
 
 describe("summarizeCard", () => {
@@ -124,248 +49,13 @@ describe("summarizeCard", () => {
   });
 });
 
-describe("parseRecentCards", () => {
-  it("returns [] for undefined / empty / malformed input", () => {
-    expect(parseRecentCards(undefined)).toEqual([]);
-    expect(parseRecentCards("")).toEqual([]);
-    expect(parseRecentCards("not-json")).toEqual([]);
-    expect(parseRecentCards('{"not":"array"}')).toEqual([]);
-  });
-
-  it("decodes a JSON array of {kind, summary} objects", () => {
-    const json = JSON.stringify([
-      { kind: "user", summary: "hi" },
-      { kind: "streaming", summary: "hello back" },
-    ]);
-    expect(parseRecentCards(json)).toEqual([
-      { kind: "user", summary: "hi" },
-      { kind: "streaming", summary: "hello back" },
-    ]);
-  });
-
-  it("skips items missing kind or summary fields", () => {
-    const json = JSON.stringify([
-      { kind: "user", summary: "ok" },
-      { kind: "tool" },
-      { summary: "no kind" },
-      "string item",
-      null,
-      { kind: "warn", summary: "trailer" },
-    ]);
-    expect(parseRecentCards(json)).toEqual([
-      { kind: "user", summary: "ok" },
-      { kind: "warn", summary: "trailer" },
-    ]);
-  });
-});
-
-describe("cardsForHeight", () => {
-  function makeCards(n: number): SceneTraceCard[] {
-    return Array.from({ length: n }, (_, i) => ({ kind: "user", summary: String(i) }));
-  }
-
-  it("returns the last (rows - 4) cards by default", () => {
-    const cards = makeCards(30);
-    const fit = cardsForHeight(cards, 24);
-    expect(fit).toHaveLength(20);
-    expect(fit[0]?.summary).toBe("10");
-    expect(fit.at(-1)?.summary).toBe("29");
-  });
-
-  it("caps at the hard ceiling (24) even on tall terminals", () => {
-    const cards = makeCards(100);
-    const fit = cardsForHeight(cards, 200);
-    expect(fit).toHaveLength(24);
-  });
-
-  it("returns at least 1 card slot even on absurdly short terminals", () => {
-    const cards = makeCards(5);
-    expect(cardsForHeight(cards, 0)).toHaveLength(1);
-    expect(cardsForHeight(cards, 2)).toHaveLength(1);
-  });
-
-  it("returns all cards when there are fewer than the available slots", () => {
-    const cards = makeCards(3);
-    expect(cardsForHeight(cards, 24)).toHaveLength(3);
-  });
-});
-
-describe("buildTraceFrame — v1 single-column layout", () => {
-  it("has scroll + dock at the root, with bg fill on the outer column", () => {
-    const f = buildEmpty();
-    if (f.root.kind !== "box") return;
-    expect(f.root.layout?.direction).toBe("column");
-    expect(f.root.layout?.background).toBeDefined();
-    expect(f.root.children).toHaveLength(2);
-    const [scroll, dock] = f.root.children;
-    if (scroll?.kind !== "box") throw new Error("expected scroll box");
-    expect(scroll.layout?.height).toBe("fill");
-    if (dock?.kind !== "box") throw new Error("expected dock box");
-    expect(dock.layout?.direction).toBe("column");
-  });
-
-  it("renders a boot block in the scroll area when there are no cards", () => {
-    const f = buildEmpty({ model: "deepseek-chat" });
-    const flatScroll = flatRows(scrollOf(f));
-    expect(flatScroll).toContain("██████╗");
-    expect(flatScroll).toContain("DeepSeek code agent");
-    expect(flatScroll).toContain("model");
-    expect(flatScroll).toContain("deepseek-chat");
-    expect(flatScroll).toContain("tools");
-  });
-
-  it("renders one card row per card in the scroll area", () => {
-    const cards: SceneTraceCard[] = [
-      { kind: "user", summary: "hi" },
-      { kind: "streaming", summary: "hello back" },
-      { kind: "user", summary: "follow up" },
-    ];
-    const f = buildTraceFrame({ cardCount: 3, busy: false, cards }, 142, 38);
-    const scroll = scrollOf(f);
-    expect(scroll).toHaveLength(3);
-    const flatScroll = flatRows(scroll);
-    expect(flatScroll).toContain("YOU");
-    expect(flatScroll).toContain("reasonix");
-    expect(flatScroll).toContain("hi");
-    expect(flatScroll).toContain("hello back");
-  });
-
-  it("paints YOU cards with the design accent (ds hex) and bold", () => {
-    const f = buildTraceFrame(
-      { cardCount: 1, busy: false, cards: [{ kind: "user", summary: "hello" }] },
-      142,
-      38,
-    );
-    const row = scrollOf(f)[0];
-    if (row?.kind !== "text") return;
-    const glyph = row.runs[0];
-    expect(glyph?.style?.bold).toBe(true);
-    const color = glyph?.style?.color;
-    expect(typeof color === "object" && color && "hex" in color).toBe(true);
-  });
-
-  it("dock has composer + meta + status when no overlay is active", () => {
-    const f = buildEmpty();
-    const dock = dockOf(f);
-    expect(dock).toHaveLength(3);
-  });
-
-  it("composer row uses ❯ prefix and a bg-2 background", () => {
-    const f = buildEmpty();
-    const row = composerRowOf(f);
-    if (row.kind !== "box") return;
-    expect(row.layout?.background).toBeDefined();
-    expect(row.layout?.height).toBe(1);
-    const inner = row.children[0];
-    if (inner?.kind !== "text") return;
-    expect(inner.runs.some((r) => r.text === "❯ ")).toBe(true);
-  });
-
-  it("composer shows the typed text with a ▮ cursor at the offset", () => {
-    const f = buildTraceFrame(
-      { cardCount: 0, busy: false, cards: [], composerText: "hello", composerCursor: 2 },
-      142,
-      38,
-    );
-    const row = composerRowOf(f);
-    if (row.kind !== "box") return;
-    const inner = row.children[0];
-    if (inner?.kind !== "text") return;
-    const flatRow = inner.runs.map((r) => r.text);
-    expect(flatRow).toContain("he");
-    expect(flatRow).toContain("llo");
-    expect(flatRow).toContain("▮");
-  });
-
-  it("meta row carries the design's kbd shortcut hints", () => {
-    const f = buildEmpty();
-    const row = metaRowOf(f);
-    if (row.kind !== "box") return;
-    const allText = row.children
-      .map((c) => (c.kind === "text" ? c.runs.map((r) => r.text).join("") : ""))
-      .join(" ");
-    expect(allText).toContain("send");
-    expect(allText).toContain("newline");
-    expect(allText).toContain("cmd");
-    expect(allText).toContain("file");
-    expect(allText).toContain("shell");
-    expect(allText).toContain("esc");
-    expect(allText).toContain("cancel");
-    expect(allText).toContain("history");
-  });
-
-  it("status bar renders ● reasonix on the left and wallet/cwd on the right", () => {
-    const f = buildTraceFrame(
-      {
-        cardCount: 0,
-        busy: false,
-        cards: [],
-        model: "deepseek-chat",
-        walletBalance: 184.2,
-        walletCurrency: "CNY",
-        cwd: "/workspace/reasonix-core",
-      },
-      142,
-      38,
-    );
-    const row = statusRowOf(f);
-    if (row.kind !== "box") return;
-    expect(row.layout?.background).toBeDefined();
-    const allText = row.children
-      .map((c) => (c.kind === "text" ? c.runs.map((r) => r.text).join("") : ""))
-      .join(" | ");
-    expect(allText).toContain("reasonix");
-    expect(allText).toContain("deepseek-chat");
-    expect(allText).toContain("¥184.20");
-    expect(allText).toContain("reasonix-core");
-  });
-
-  it("status bar paints busy/idle in warn/ok hex colors and surfaces editMode", () => {
-    const busy = buildTraceFrame(
-      { cardCount: 0, busy: true, cards: [], editMode: "yolo" },
-      142,
-      38,
-    );
-    const row = statusRowOf(busy);
-    if (row.kind !== "box") return;
-    const text = row.children
-      .map((c) => (c.kind === "text" ? c.runs.map((r) => r.text).join("") : ""))
-      .join(" | ");
-    expect(text).toContain("busy");
-    expect(text).toContain("yolo");
-  });
-
-  it("truncates a long cwd to keep the status row from blowing out", () => {
-    const long = `/some/very/long/path/${"x".repeat(60)}/end`;
-    const f = buildTraceFrame({ cardCount: 0, busy: false, cards: [], cwd: long }, 142, 38);
-    const row = statusRowOf(f);
-    if (row.kind !== "box") return;
-    const segments = row.children
-      .map((c) => (c.kind === "text" ? c.runs.map((r) => r.text).join("") : ""))
-      .filter((s) => s.includes("/end"));
-    expect(segments.length).toBeGreaterThan(0);
-    const cwdSegment = segments[0] ?? "";
-    expect(cwdSegment.startsWith("cwd")).toBe(true);
-    expect(cwdSegment).toContain("…");
-    expect(cwdSegment.length).toBeLessThan(long.length);
-  });
-
-  it("default-empty cwd: cwd segment is omitted", () => {
-    const f = buildEmpty();
-    const row = statusRowOf(f);
-    if (row.kind !== "box") return;
-    const flatRow = row.children
-      .map((c) => (c.kind === "text" ? c.runs.map((r) => r.text).join("") : ""))
-      .join(" | ");
-    expect(flatRow).not.toContain("cwd ");
-  });
-});
-
-describe("toSceneCard — tool card enrichment", () => {
-  it("returns a plain { kind, summary } for non-tool cards", () => {
-    expect(toSceneCard({ id: "u1", ts: 0, kind: "user", text: "hi" })).toEqual({
+describe("toSceneCard — wire-format serializer", () => {
+  it("returns kind + summary + body + ts for user cards", () => {
+    expect(toSceneCard({ id: "u1", ts: 42, kind: "user", text: "hi\nthere" })).toEqual({
       kind: "user",
       summary: "hi",
+      body: "hi\nthere",
+      ts: 42,
     });
   });
 
@@ -381,12 +71,14 @@ describe("toSceneCard — tool card enrichment", () => {
       exitCode: 0,
       elapsedMs: 120,
     });
-    expect(card.kind).toBe("tool");
-    expect(card.summary).toBe("Read");
-    expect(card.args).toBe("src/parser.ts");
-    expect(card.status).toBe("ok");
-    expect(card.elapsed).toBe("120ms");
-    expect(card.id).toBe("#def4");
+    expect(card).toEqual({
+      kind: "tool",
+      summary: "Read",
+      args: "src/parser.ts",
+      status: "ok",
+      elapsed: "120ms",
+      id: "#def4",
+    });
   });
 
   it("marks running tool cards with status=running and omits elapsed", () => {
@@ -447,7 +139,7 @@ describe("toSceneCard — tool card enrichment", () => {
     expect(c.elapsed).toBe("2.12s");
   });
 
-  it("extracts the primary arg by common key preference (path / file / pattern)", () => {
+  it("extracts the primary arg by common-key preference (path > pattern > etc.)", () => {
     const withPath = toSceneCard({
       id: "t",
       ts: 0,
@@ -471,182 +163,107 @@ describe("toSceneCard — tool card enrichment", () => {
     });
     expect(withPattern.args).toBe("foo");
   });
+
+  it("returns reasoning cards with paragraphs/elapsed meta + raw body", () => {
+    const c = toSceneCard({
+      id: "r1",
+      ts: 1000,
+      kind: "reasoning",
+      text: "step one\nstep two",
+      paragraphs: 2,
+      tokens: 100,
+      streaming: false,
+      endedAt: 4500,
+    });
+    expect(c.kind).toBe("reasoning");
+    expect(c.body).toBe("step one\nstep two");
+    expect(c.ts).toBe(1000);
+    expect(c.meta).toBe("2 steps · 3.50s");
+  });
+
+  it("returns streaming cards with done/streaming meta", () => {
+    const running = toSceneCard({
+      id: "s1",
+      ts: 0,
+      kind: "streaming",
+      text: "hi",
+      done: false,
+    });
+    expect(running.meta).toBe("streaming…");
+
+    const done = toSceneCard({
+      id: "s2",
+      ts: 0,
+      kind: "streaming",
+      text: "hi",
+      done: true,
+    });
+    expect(done.meta).toBe("done");
+  });
+
+  it("falls back to plain { kind, summary } for unhandled kinds", () => {
+    const card = toSceneCard({
+      id: "d1",
+      ts: 0,
+      kind: "diff",
+      file: "src/x.ts",
+      hunks: [],
+      adds: 0,
+      dels: 0,
+    } as Card);
+    expect(card.kind).toBe("diff");
+    expect(card.summary).toBe("src/x.ts");
+    expect(card.body).toBeUndefined();
+    expect(card.ts).toBeUndefined();
+  });
 });
 
-describe("buildTraceFrame — tool cards render in rich format", () => {
-  it("renders a tool card as ▸ name (args) ✓ elapsed #id", () => {
-    const cards: SceneTraceCard[] = [
+describe("parseRecentCards", () => {
+  it("returns [] for undefined / empty / malformed input", () => {
+    expect(parseRecentCards(undefined)).toEqual([]);
+    expect(parseRecentCards("")).toEqual([]);
+    expect(parseRecentCards("not-json")).toEqual([]);
+    expect(parseRecentCards('{"not":"array"}')).toEqual([]);
+  });
+
+  it("decodes a JSON array of card payloads with optional fields", () => {
+    const json = JSON.stringify([
+      { kind: "user", summary: "hi", body: "hi", ts: 1 },
       {
         kind: "tool",
         summary: "Read",
-        args: "src/parser.ts",
+        args: "src/x.ts",
         status: "ok",
-        elapsed: "120ms",
-        id: "#a4f1",
+        elapsed: "12ms",
+        id: "#abc",
       },
-    ];
-    const f = buildTraceFrame({ cardCount: 1, busy: false, cards }, 142, 38);
-    const row = scrollOf(f)[0];
-    if (row?.kind !== "text") throw new Error("expected text row");
-    const flatRow = row.runs.map((r) => r.text).join("");
-    expect(flatRow.trimStart().startsWith("▸ Read")).toBe(true);
-    expect(flatRow).toContain("(src/parser.ts)");
-    expect(flatRow).toContain("✓");
-    expect(flatRow).toContain("120ms");
-    expect(flatRow).toContain("#a4f1");
-  });
-
-  it("renders a failed tool card with ✗", () => {
-    const cards: SceneTraceCard[] = [
-      { kind: "tool", summary: "Bash", args: "false", status: "err", elapsed: "10ms" },
-    ];
-    const f = buildTraceFrame({ cardCount: 1, busy: false, cards }, 142, 38);
-    const row = scrollOf(f)[0];
-    if (row?.kind !== "text") throw new Error("expected text row");
-    expect(row.runs.map((r) => r.text).join("")).toContain("✗");
-  });
-
-  it("renders a running tool card with … instead of a check mark", () => {
-    const cards: SceneTraceCard[] = [
-      { kind: "tool", summary: "Bash", args: "pnpm test", status: "running" },
-    ];
-    const f = buildTraceFrame({ cardCount: 1, busy: false, cards }, 142, 38);
-    const row = scrollOf(f)[0];
-    if (row?.kind !== "text") throw new Error("expected text row");
-    expect(row.runs.map((r) => r.text).join("")).toContain("…");
-  });
-});
-
-describe("buildTraceFrame — composer overlays", () => {
-  it("approval prompt replaces the composer row with a y/n stub", () => {
-    const f = buildTraceFrame(
+    ]);
+    expect(parseRecentCards(json)).toEqual([
+      { kind: "user", summary: "hi", body: "hi", ts: 1 },
       {
-        cardCount: 0,
-        busy: false,
-        cards: [],
-        composerText: "typing…",
-        approvalKind: "shell",
-        approvalPrompt: "rm -rf /tmp/x",
+        kind: "tool",
+        summary: "Read",
+        args: "src/x.ts",
+        status: "ok",
+        elapsed: "12ms",
+        id: "#abc",
       },
-      142,
-      38,
-    );
-    const dock = dockOf(f);
-    const composerLike = dock.find((c) => {
-      if (c.kind !== "box") return false;
-      const inner = c.children[0];
-      return inner?.kind === "text" && inner.runs.some((r) => r.text === " ❓ ");
-    });
-    expect(composerLike).toBeDefined();
-    const allText = dock
-      .map((c) => {
-        if (c.kind === "box") {
-          return c.children
-            .map((cc) => (cc.kind === "text" ? cc.runs.map((r) => r.text).join("") : ""))
-            .join("");
-        }
-        return c.kind === "text" ? c.runs.map((r) => r.text).join("") : "";
-      })
-      .join(" | ");
-    expect(allText).toContain("[shell]");
-    expect(allText).toContain("rm -rf /tmp/x");
-    expect(allText).toContain("[y/n]");
-    expect(allText).not.toContain("typing…");
-  });
-
-  it("slash overlay renders inline above the composer row", () => {
-    const matches: SceneSlashMatch[] = [
-      { cmd: "/help", summary: "show help" },
-      { cmd: "/model", summary: "switch model", argsHint: "<name>" },
-    ];
-    const f = buildTraceFrame(
-      { cardCount: 0, busy: false, cards: [], slashMatches: matches, slashSelectedIndex: 1 },
-      142,
-      38,
-    );
-    const dock = dockOf(f);
-    const flatDock = flatRows(dock);
-    expect(flatDock).toContain("/help");
-    expect(flatDock).toContain("/model");
-    expect(flatDock).toContain("<name>");
-    expect(flatDock).toContain("switch model");
-    const selectedRow = dock.find((c) => c.kind === "text" && flat(c).includes("▸"));
-    expect(selectedRow).toBeDefined();
-  });
-
-  it("sessions picker takes over the dock with a header + rows + hint", () => {
-    const sessions: SceneSessionItem[] = [
-      { title: "feat-foo", meta: "main · 12 turns" },
-      { title: "spike-bar", meta: "release/4.5 · 3 turns" },
-    ];
-    const f = buildTraceFrame(
-      { cardCount: 0, busy: false, cards: [], sessions, sessionsFocusedIndex: 0 },
-      142,
-      38,
-    );
-    const dock = dockOf(f);
-    const flatDock = flatRows(dock);
-    expect(flatDock).toContain("sessions");
-    expect(flatDock).toContain("2 saved");
-    expect(flatDock).toContain("feat-foo");
-    expect(flatDock).toContain("spike-bar");
-    expect(flatDock).toContain("navigate");
-    expect(flatDock).toContain("open");
-  });
-
-  it("clamps an out-of-range slashSelectedIndex onto the last match", () => {
-    const matches: SceneSlashMatch[] = [
-      { cmd: "/a", summary: "" },
-      { cmd: "/b", summary: "" },
-      { cmd: "/c", summary: "" },
-    ];
-    const f = buildTraceFrame(
-      { cardCount: 0, busy: false, cards: [], slashMatches: matches, slashSelectedIndex: 99 },
-      142,
-      38,
-    );
-    const dock = dockOf(f);
-    const selected = dock.find((c) => c.kind === "text" && flat(c).includes("▸"));
-    expect(selected).toBeDefined();
-    if (selected?.kind === "text") {
-      expect(selected.runs.map((r) => r.text).join("")).toContain("/c");
-    }
-  });
-});
-
-describe("slashWindow", () => {
-  function makeMatches(n: number): SceneSlashMatch[] {
-    return Array.from({ length: n }, (_, i) => ({ cmd: `/cmd${i}`, summary: `s${i}` }));
-  }
-
-  it("keeps the selected match centered inside the window", () => {
-    const w = slashWindow(makeMatches(20), 15);
-    expect(w.startIndex).toBe(12);
-    expect(w.matches.map((m) => m.cmd)).toEqual([
-      "/cmd12",
-      "/cmd13",
-      "/cmd14",
-      "/cmd15",
-      "/cmd16",
-      "/cmd17",
     ]);
   });
 
-  it("anchors at the end when the selection is near the tail", () => {
-    const w = slashWindow(makeMatches(20), 19);
-    expect(w.startIndex).toBe(14);
-    expect(w.matches.map((m) => m.cmd).at(-1)).toBe("/cmd19");
-  });
-
-  it("anchors at the start when the selection is at index 0", () => {
-    const w = slashWindow(makeMatches(20), 0);
-    expect(w.startIndex).toBe(0);
-  });
-
-  it("returns the original list when there are fewer items than the window", () => {
-    const w = slashWindow(makeMatches(3), 0);
-    expect(w.startIndex).toBe(0);
-    expect(w.matches).toHaveLength(3);
+  it("drops entries missing kind or summary", () => {
+    const json = JSON.stringify([
+      { kind: "user", summary: "ok" },
+      { kind: "tool" },
+      { summary: "no-kind" },
+      "string",
+      null,
+      { kind: "warn", summary: "trailer" },
+    ]);
+    expect(parseRecentCards(json)).toEqual([
+      { kind: "user", summary: "ok" },
+      { kind: "warn", summary: "trailer" },
+    ]);
   });
 });
 
@@ -675,35 +292,5 @@ describe("parseSlashMatches / parseSessions edge cases", () => {
     expect(parseSessions(undefined)).toEqual([]);
     expect(parseSessions("oops")).toEqual([]);
     expect(parseSessions('{"not":"array"}')).toEqual([]);
-  });
-});
-
-describe("buildSetupFrame", () => {
-  it("renders welcome + masked input + exit hint when buffer is empty", () => {
-    const f = buildSetupFrame({ bufferLength: 0 }, 80, 24);
-    if (f.root.kind !== "box") throw new Error("expected box");
-    const flatRoot = flatRows(f.root.children);
-    expect(flatRoot).toContain("REASONIX");
-    expect(flatRoot).toContain("API key");
-    expect(flatRoot).toContain("(start typing your key)");
-    expect(flatRoot).toContain("Ctrl+C");
-  });
-
-  it("renders one • per typed char and a ▮ cursor", () => {
-    const f = buildSetupFrame({ bufferLength: 5 }, 80, 24);
-    if (f.root.kind !== "box") throw new Error("expected box");
-    const flatRoot = flatRows(f.root.children);
-    expect(flatRoot).toContain("•••••");
-    expect(flatRoot).toContain("▮");
-  });
-
-  it("renders the error row in err color when set", () => {
-    const f = buildSetupFrame({ bufferLength: 0, error: "key malformed" }, 80, 24);
-    if (f.root.kind !== "box") throw new Error("expected box");
-    const errRow = findText(f.root.children, (s) => s.includes("✗"));
-    expect(errRow).toBeDefined();
-    if (errRow?.kind === "text") {
-      expect(flat(errRow)).toContain("key malformed");
-    }
   });
 });


### PR DESCRIPTION
Stage A of the architectural pivot the user asked for —
\"先看一下这些底层架构机制，这个一定要先搭建好\".

The JS side no longer builds a \`SceneFrame\` layout tree; it just
serializes the latest input state. Rust deserializes the state and
runs the full layout / palette / row-shape logic against the **real**
terminal area.

## Why

The TS scene producer was a recurring source of \"things don't look
right\" bugs:

- JS reads its idea of terminal size from Ink's \`useStdout()\`, which
  is the **null stream** under \`REASONIX_RENDERER=rust\` mode. Cols
  and rows fell back to 80 × 24 every render, so layout decisions
  (boot block size, card cap, dock thickness) were divorced from the
  actual terminal — even though the renderer rendered against the
  real area. Producer + renderer disagreed on dimensions.
- Two languages held the same constants (palette hexes, row counts,
  glyphs). Every visual tweak required keeping both sides in sync.
- Behavior changes required JS rebuild + Rust rebuild and both had
  to land together.

Moving the producer to Rust makes the renderer authoritative for
layout. Single source of truth. Single rebuild target.

## What

New Rust modules under \`crates/reasonix-render/src/\`:

- \`state.rs\` — \`SceneState\` / \`SceneCard\` / \`SlashMatch\` /
  \`SessionItem\` / \`SetupState\` / \`Message\` (tagged enum
  \`{ type: \"trace\" | \"setup\", ... }\`).
- \`theme.rs\` — \`palette::{bg, bg2, fg, fg1..3, ds, ds_bright,
  ds_purple, ok, warn, err}\` matching the v1 mock's oklch tokens.
- \`producer.rs\` — \`build_trace_frame(&state, cols, rows)\` +
  \`build_setup_frame(&state, cols, rows)\`. Ports the boot block
  (REASONIX ASCII banner), card kinds (\`user\` / \`reasoning\` /
  \`streaming\` head+body, \`tool\` rich row, generic single-line for
  others), composer / meta / status dock, slash overlay, sessions
  picker, approval modal — all from the old TS producer.

\`main.rs\` reads messages from stdin (tries \`Message\`, then bare
\`SceneState\`, then \`SetupState\`, then legacy \`SceneFrame\` for
back-compat). Each frame calls \`terminal.size()\` to get the real
cols/rows and feeds them into the producer.

## JS side

\`useSceneTrace.ts\` shrunk from ~700 LOC to ~270 LOC — purely state
shaping now. The hook builds a plain object
(\`{ type: \"trace\", ...state }\`) and emits via the renamed
\`emitSceneMessage(message: unknown)\`. Same for \`useSetupSceneTrace\`.

Helpers that survived (still used to serialize wire-format payloads):
\`toSceneCard\`, \`parseRecentCards\`, \`parseSlashMatches\`,
\`parseSessions\`, \`summarizeCard\`.

Gone (moved to Rust): \`buildTraceFrame\`, \`buildSetupFrame\`, all the
row builders, the kind-glyph / color / label tables, \`PALETTE\`,
\`listWindow\`, \`slashWindow\`, \`cardsForHeight\`.

## Tests

- Rust (\`crates/reasonix-render/tests/producer.rs\`) — 14 new cases
  covering boot block, card kinds, composer cursor, dock rows,
  approval / slash / sessions overlays, status bar segments, edit
  mode color, rich tool format, setup frame, body line cap.
- TS (\`tests/scene-trace-frame.test.ts\`) — pared down to the 20
  wire-format tests that still apply (\`summarizeCard\`,
  \`toSceneCard\`, \`parseRecentCards\`, \`parseSlashMatches\`,
  \`parseSessions\`).

\`cargo test -p reasonix-render\` — 51 / 51 green.
\`npm run verify\` — 3071 / 3074 green via prepush gate.

## Migration notes

- Rust binary **must** be rebuilt for users running off the prebuilt
  \`target/release/reasonix-render.exe\` — the new producer is the
  binary's job now. \`cargo build --release --bin reasonix-render\`.
- The legacy \`SceneFrame\` JSON shape is still accepted by Rust as a
  fourth-tier fallback, so a stale JS bundle paired with a fresh
  Rust binary keeps working until both roll forward.

Refs #868