### PR TITLE
feat: transparent rtk integration for token-optimized command output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,6 @@ bun.lock
 # Local portable Node/npm used for development on machines without npm.
 .tools/
 .npm-cache/
-nodejs/
 
 # Tauri desktop shell build artifacts.
 desktop/src-tauri/target/

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ bun.lock
 # Local portable Node/npm used for development on machines without npm.
 .tools/
 .npm-cache/
+nodejs/
 
 # Tauri desktop shell build artifacts.
 desktop/src-tauri/target/

--- a/nodejs/CHANGELOG.md
+++ b/nodejs/CHANGELOG.md
@@ -1,0 +1,1400 @@
+# Node.js Changelog
+
+Select a Node.js version below to view the changelog history:
+
+* [Node.js 24](doc/changelogs/CHANGELOG_V24.md) **Long Term Support**
+* [Node.js 23](doc/changelogs/CHANGELOG_V23.md) **Current**
+* [Node.js 22](doc/changelogs/CHANGELOG_V22.md) Long Term Support
+* [Node.js 21](doc/changelogs/CHANGELOG_V21.md) End-of-Life
+* [Node.js 20](doc/changelogs/CHANGELOG_V20.md) Long Term Support
+* [Node.js 19](doc/changelogs/CHANGELOG_V19.md) End-of-Life
+* [Node.js 18](doc/changelogs/CHANGELOG_V18.md) End-of-Life
+* [Node.js 17](doc/changelogs/CHANGELOG_V17.md) End-of-Life
+* [Node.js 16](doc/changelogs/CHANGELOG_V16.md) End-of-Life
+* [Node.js 15](doc/changelogs/CHANGELOG_V15.md) End-of-Life
+* [Node.js 14](doc/changelogs/CHANGELOG_V14.md) End-of-Life
+* [Node.js 13](doc/changelogs/CHANGELOG_V13.md) End-of-Life
+* [Node.js 12](doc/changelogs/CHANGELOG_V12.md) End-of-Life
+* [Node.js 11](doc/changelogs/CHANGELOG_V11.md) End-of-Life
+* [Node.js 10](doc/changelogs/CHANGELOG_V10.md) End-of-Life
+* [Node.js 9](doc/changelogs/CHANGELOG_V9.md) End-of-Life
+* [Node.js 8](doc/changelogs/CHANGELOG_V8.md) End-of-Life
+* [Node.js 7](doc/changelogs/CHANGELOG_V7.md) End-of-Life
+* [Node.js 6](doc/changelogs/CHANGELOG_V6.md) End-of-Life
+* [Node.js 5](doc/changelogs/CHANGELOG_V5.md) End-of-Life
+* [Node.js 4](doc/changelogs/CHANGELOG_V4.md) End-of-Life
+* [io.js](doc/changelogs/CHANGELOG_IOJS.md) End-of-Life
+* [Node.js 0.12](doc/changelogs/CHANGELOG_V012.md) End-of-Life
+* [Node.js 0.10](doc/changelogs/CHANGELOG_V010.md) End-of-Life
+* [Archive](doc/changelogs/CHANGELOG_ARCHIVE.md)
+
+Please use the following table to find the changelog for a specific Node.js
+release.
+
+<table>
+<tr>
+  <th title="LTS Until 2028-04"><a href="doc/changelogs/CHANGELOG_V24.md">24</a> (LTS)</th>
+  <th title="Current"><a href="doc/changelogs/CHANGELOG_V23.md">23</a> (Current)</th>
+  <th title="LTS Until 2027-04"><a href="doc/changelogs/CHANGELOG_V22.md">22</a> (LTS)</th>
+  <th title="LTS Until 2026-04"><a href="doc/changelogs/CHANGELOG_V20.md">20</a> (LTS)</th>
+</tr>
+<tr>
+  <td valign="top">
+<b><a href="doc/changelogs/CHANGELOG_V24.md#24.15.0">24.15.0</a></b><br/>
+<a href="doc/changelogs/CHANGELOG_V24.md#24.14.1">24.14.1</a><br/>
+<a href="doc/changelogs/CHANGELOG_V24.md#24.14.0">24.14.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V24.md#24.13.1">24.13.1</a><br/>
+<a href="doc/changelogs/CHANGELOG_V24.md#24.13.0">24.13.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V24.md#24.12.0">24.12.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V24.md#24.11.1">24.11.1</a><br/>
+<a href="doc/changelogs/CHANGELOG_V24.md#24.11.0">24.11.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V24.md#24.10.0">24.10.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V24.md#24.9.0">24.9.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V24.md#24.8.0">24.8.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V24.md#24.7.0">24.7.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V24.md#24.6.0">24.6.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V24.md#24.5.0">24.5.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V24.md#24.4.1">24.4.1</a><br/>
+<a href="doc/changelogs/CHANGELOG_V24.md#24.4.0">24.4.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V24.md#24.3.0">24.3.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V24.md#24.2.0">24.2.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V24.md#24.1.0">24.1.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V24.md#24.0.2">24.0.2</a><br/>
+<a href="doc/changelogs/CHANGELOG_V24.md#24.0.1">24.0.1</a><br/>
+<a href="doc/changelogs/CHANGELOG_V24.md#24.0.0">24.0.0</a><br/>
+  </td>
+  <td valign="top">
+<b><a href="doc/changelogs/CHANGELOG_V23.md#23.11.0">23.11.0</a></b><br/>
+<a href="doc/changelogs/CHANGELOG_V23.md#23.10.0">23.10.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V23.md#23.9.0">23.9.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V23.md#23.8.0">23.8.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V23.md#23.7.0">23.7.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V23.md#23.6.1">23.6.1</a><br/>
+<a href="doc/changelogs/CHANGELOG_V23.md#23.6.0">23.6.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V23.md#23.5.0">23.5.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V23.md#23.4.0">23.4.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V23.md#23.3.0">23.3.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V23.md#23.2.0">23.2.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V23.md#23.1.0">23.1.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V23.md#23.0.0">23.0.0</a><br/>
+  </td>
+  <td valign="top">
+<b><a href="doc/changelogs/CHANGELOG_V22.md#22.15.0">22.15.0</a></b><br/>
+<a href="doc/changelogs/CHANGELOG_V22.md#22.14.0">22.14.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V22.md#22.13.1">22.13.1</a><br/>
+<a href="doc/changelogs/CHANGELOG_V22.md#22.13.0">22.13.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V22.md#22.12.0">22.12.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V22.md#22.11.0">22.11.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V22.md#22.10.0">22.10.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V22.md#22.9.0">22.9.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V22.md#22.8.0">22.8.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V22.md#22.7.0">22.7.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V22.md#22.6.0">22.6.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V22.md#22.5.1">22.5.1</a><br/>
+<a href="doc/changelogs/CHANGELOG_V22.md#22.5.0">22.5.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V22.md#22.4.1">22.4.1</a><br/>
+<a href="doc/changelogs/CHANGELOG_V22.md#22.4.0">22.4.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V22.md#22.3.0">22.3.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V22.md#22.2.0">22.2.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V22.md#22.1.0">22.1.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V22.md#22.0.0">22.0.0</a><br/>
+  </td>
+  <td valign="top">
+<b><a href="doc/changelogs/CHANGELOG_V20.md#20.19.1">20.19.1</a></b><br/>
+<a href="doc/changelogs/CHANGELOG_V20.md#20.19.0">20.19.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V20.md#20.18.3">20.18.3</a><br/>
+<a href="doc/changelogs/CHANGELOG_V20.md#20.18.2">20.18.2</a><br/>
+<a href="doc/changelogs/CHANGELOG_V20.md#20.18.1">20.18.1</a><br/>
+<a href="doc/changelogs/CHANGELOG_V20.md#20.18.0">20.18.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V20.md#20.17.0">20.17.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V20.md#20.16.0">20.16.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V20.md#20.15.1">20.15.1</a><br/>
+<a href="doc/changelogs/CHANGELOG_V20.md#20.15.0">20.15.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V20.md#20.14.0">20.14.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V20.md#20.13.1">20.13.1</a><br/>
+<a href="doc/changelogs/CHANGELOG_V20.md#20.13.0">20.13.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V20.md#20.12.2">20.12.2</a><br/>
+<a href="doc/changelogs/CHANGELOG_V20.md#20.12.1">20.12.1</a><br/>
+<a href="doc/changelogs/CHANGELOG_V20.md#20.12.0">20.12.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V20.md#20.11.1">20.11.1</a><br/>
+<a href="doc/changelogs/CHANGELOG_V20.md#20.11.0">20.11.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V20.md#20.10.0">20.10.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V20.md#20.9.0">20.9.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V20.md#20.8.1">20.8.1</a><br/>
+<a href="doc/changelogs/CHANGELOG_V20.md#20.8.0">20.8.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V20.md#20.7.0">20.7.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V20.md#20.6.1">20.6.1</a><br/>
+<a href="doc/changelogs/CHANGELOG_V20.md#20.6.0">20.6.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V20.md#20.5.1">20.5.1</a><br/>
+<a href="doc/changelogs/CHANGELOG_V20.md#20.5.0">20.5.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V20.md#20.4.0">20.4.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V20.md#20.3.1">20.3.1</a><br/>
+<a href="doc/changelogs/CHANGELOG_V20.md#20.3.0">20.3.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V20.md#20.2.0">20.2.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V20.md#20.1.0">20.1.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V20.md#20.0.0">20.0.0</a><br/>
+  </td>
+</tr>
+</table>
+
+## Notes
+
+* The [Node.js Long Term Support plan](https://github.com/nodejs/Release) covers
+  LTS releases.
+* Release versions in **bold** text are the most recent supported releases.
+
+***
+
+***
+
+## 2016-05-06, Version 0.12.14 (Maintenance), @rvagg
+
+<a href="doc/changelogs/CHANGELOG_V012.md#0.12.14">Moved to doc/changelogs/CHANGELOG\_V012.md#0.12.14</a>.
+
+## 2016-05-06, Version 0.10.45 (Maintenance), @rvagg
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.45">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.45</a>.
+
+## 2016-05-05, Version 6.1.0 (Current), @Fishrock123
+
+<a href="doc/changelogs/CHANGELOG_V6.md#6.1.0">Moved to doc/changelogs/CHANGELOG\_V6.md#6.1.0</a>.
+
+## 2016-05-05, Version 5.11.1 (Stable), @evanlucas
+
+<a href="doc/changelogs/CHANGELOG_V5.md#5.11.1">Moved to doc/changelogs/CHANGELOG\_V5.md#5.11.1</a>.
+
+## 2016-05-05, Version 4.4.4 'Argon' (LTS), @thealphanerd
+
+<a href="doc/changelogs/CHANGELOG_V4.md#4.4.4">Moved to doc/changelogs/CHANGELOG\_V4.md#4.4.4</a>.
+
+## 2016-04-26, Version 6.0.0 (Current), @jasnell
+
+<a href="doc/changelogs/CHANGELOG_V6.md#6.0.0">Moved to doc/changelogs/CHANGELOG\_V6.md#6.0.0</a>.
+
+## 2016-04-20, Version 5.11.0 (Stable), @thealphanerd
+
+<a href="doc/changelogs/CHANGELOG_V5.md#5.11.0">Moved to doc/changelogs/CHANGELOG\_V5.md#5.11.0</a>.
+
+## 2016-04-05, Version 5.10.1 (Stable), @thealphanerd
+
+<a href="doc/changelogs/CHANGELOG_V5.md#5.10.1">Moved to doc/changelogs/CHANGELOG\_V5.md#5.10.1</a>.
+
+## 2016-03-31, Version 0.10.44 (Maintenance), @rvagg
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.44">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.44</a>.
+
+## 2016-03-31, Version 5.10.0 (Stable), @evanlucas
+
+<a href="doc/changelogs/CHANGELOG_V5.md#5.10.0">Moved to doc/changelogs/CHANGELOG\_V5.md#5.10.0</a>.
+
+## 2016-03-31, Version 4.4.2 'Argon' (LTS), @thealphanerd
+
+<a href="doc/changelogs/CHANGELOG_V4.md#4.4.2">Moved to doc/changelogs/CHANGELOG\_V4.md#4.4.2</a>.
+
+## 2016-03-31, Version 0.12.13 (LTS), @rvagg
+
+<a href="doc/changelogs/CHANGELOG_V012.md#0.12.13">Moved to doc/changelogs/CHANGELOG\_V012.md#0.12.13</a>.
+
+## 2016-03-23, Version 5.9.1 (Stable), @Fishrock123
+
+<a href="doc/changelogs/CHANGELOG_V5.md#5.9.1">Moved to doc/changelogs/CHANGELOG\_V5.md#5.9.1</a>.
+
+## 2016-03-22, Version 4.4.1 'Argon' (LTS), @thealphanerd
+
+<a href="doc/changelogs/CHANGELOG_V4.md#4.4.1">Moved to doc/changelogs/CHANGELOG\_V4.md#4.4.1</a>.
+
+## 2016-03-16, Version 5.9.0 (Stable), @evanlucas
+
+<a href="doc/changelogs/CHANGELOG_V5.md#5.9.0">Moved to doc/changelogs/CHANGELOG\_V5.md#5.9.0</a>.
+
+## 2016-03-08, Version 5.8.0 (Stable), @Fishrock123
+
+<a href="doc/changelogs/CHANGELOG_V5.md#5.8.0">Moved to doc/changelogs/CHANGELOG\_V5.md#5.8.0</a>.
+
+## 2016-03-08, Version 4.4.0 'Argon' (LTS), @thealphanerd
+
+<a href="doc/changelogs/CHANGELOG_V4.md#4.4.0">Moved to doc/changelogs/CHANGELOG\_V4.md#4.4.0</a>.
+
+## 2016-03-08, Version 0.12.12 (LTS), @rvagg
+
+<a href="doc/changelogs/CHANGELOG_V012.md#0.12.12">Moved to doc/changelogs/CHANGELOG\_V012.md#0.12.12</a>.
+
+## 2016-03-03, Version 0.12.11 (LTS), @rvagg
+
+<a href="doc/changelogs/CHANGELOG_V012.md#0.12.11">Moved to doc/changelogs/CHANGELOG\_V012.md#0.12.11</a>.
+
+## 2016-03-02, Version 5.7.1 (Stable), @Fishrock123
+
+<a href="doc/changelogs/CHANGELOG_V5.md#5.7.1">Moved to doc/changelogs/CHANGELOG\_V5.md#5.7.1</a>.
+
+## 2016-03-02, Version 4.3.2 'Argon' (LTS), @thealphanerd
+
+<a href="doc/changelogs/CHANGELOG_V4.md#4.3.2">Moved to doc/changelogs/CHANGELOG\_V4.md#4.3.2</a>.
+
+## 2016-02-23, Version 5.7.0 (Stable), @rvagg
+
+<a href="doc/changelogs/CHANGELOG_V5.md#5.7.0">Moved to doc/changelogs/CHANGELOG\_V5.md#5.7.0</a>.
+
+## 2016-02-16, Version 4.3.1 'Argon' (LTS), @thealphanerd
+
+<a href="doc/changelogs/CHANGELOG_V4.md#4.3.1">Moved to doc/changelogs/CHANGELOG\_V4.md#4.3.1</a>.
+
+## 2016-02-09, Version 5.6.0 (Stable), @jasnell
+
+<a href="doc/changelogs/CHANGELOG_V5.md#5.6.0">Moved to doc/changelogs/CHANGELOG\_V5.md#5.6.0</a>.
+
+## 2016-02-09, Version 4.3.0 'Argon' (LTS), @jasnell
+
+<a href="doc/changelogs/CHANGELOG_V4.md#4.3.0">Moved to doc/changelogs/CHANGELOG\_V4.md#4.3.0</a>.
+
+## 2016-02-09, Version 0.12.10 (LTS), @jasnell
+
+<a href="doc/changelogs/CHANGELOG_V012.md#0.12.10">Moved to doc/changelogs/CHANGELOG\_V012.md#0.12.10</a>.
+
+## 2016-02-09, Version 0.10.42 (Maintenance), @jasnell
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.42">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.42</a>.
+
+## 2016-01-21, Version 4.2.6 'Argon' (LTS), @TheAlphaNerd
+
+<a href="doc/changelogs/CHANGELOG_V4.md#4.2.6">Moved to doc/changelogs/CHANGELOG\_V4.md#4.2.6</a>.
+
+## 2016-01-20, Version 5.5.0 (Stable), @evanlucas
+
+<a href="doc/changelogs/CHANGELOG_V5.md#5.5.0">Moved to doc/changelogs/CHANGELOG\_V5.md#5.5.0</a>.
+
+## 2016-01-20, Version 4.2.5 'Argon' (LTS), @TheAlphaNerd
+
+<a href="doc/changelogs/CHANGELOG_V4.md#4.2.5">Moved to doc/changelogs/CHANGELOG\_V4.md#4.2.5</a>.
+
+## 2016-01-12, Version 5.4.1 (Stable), @TheAlphaNerd
+
+<a href="doc/changelogs/CHANGELOG_V5.md#5.4.1">Moved to doc/changelogs/CHANGELOG\_V5.md#5.4.1</a>.
+
+## 2016-01-06, Version 5.4.0 (Stable), @Fishrock123
+
+<a href="doc/changelogs/CHANGELOG_V5.md#5.4.0">Moved to doc/changelogs/CHANGELOG\_V5.md#5.4.0</a>.
+
+## 2015-12-23, Version 4.2.4 'Argon' (LTS), @jasnell
+
+<a href="doc/changelogs/CHANGELOG_V4.md#4.2.4">Moved to doc/changelogs/CHANGELOG\_V4.md#4.2.4</a>.
+
+## 2015-12-16, Version 5.3.0 (Stable), @cjihrig
+
+<a href="doc/changelogs/CHANGELOG_V5.md#5.3.0">Moved to doc/changelogs/CHANGELOG\_V5.md#5.3.0</a>.
+
+## 2015-12-09, Version 5.2.0 (Stable), @rvagg
+
+<a href="doc/changelogs/CHANGELOG_V5.md#5.2.0">Moved to doc/changelogs/CHANGELOG\_V5.md#5.2.0</a>.
+
+## 2015-12-04, Version 5.1.1 (Stable), @rvagg
+
+<a href="doc/changelogs/CHANGELOG_V5.md#5.1.1">Moved to doc/changelogs/CHANGELOG\_V5.md#5.1.1</a>.
+
+## 2015-12-04, Version 4.2.3 'Argon' (LTS), @rvagg
+
+<a href="doc/changelogs/CHANGELOG_V4.md#4.2.3">Moved to doc/changelogs/CHANGELOG\_V4.md#4.2.3</a>.
+
+## 2015-12-04, Version 0.12.9 (LTS), @rvagg
+
+<a href="doc/changelogs/CHANGELOG_V012.md#0.12.9">Moved to doc/changelogs/CHANGELOG\_V012.md#0.12.9</a>.
+
+## 2015-12-04, Version 0.10.41 (Maintenance), @rvagg
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.41">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.41</a>.
+
+## 2015.11.25, Version 0.12.8 (LTS), @rvagg
+
+<a href="doc/changelogs/CHANGELOG_V012.md#0.12.8">Moved to doc/changelogs/CHANGELOG\_V012.md#0.12.8</a>.
+
+## 2015-11-17, Version 5.1.0 (Stable), @Fishrock123
+
+<a href="doc/changelogs/CHANGELOG_V5.md#5.1.0">Moved to doc/changelogs/CHANGELOG\_V5.md#5.1.0</a>.
+
+## 2015-11-03, Version 4.2.2 'Argon' (LTS), @jasnell
+
+<a href="doc/changelogs/CHANGELOG_V4.md#4.2.2">Moved to doc/changelogs/CHANGELOG\_V4.md#4.2.2</a>.
+
+## 2015-10-29, Version 5.0.0 (Stable), @rvagg
+
+<a href="doc/changelogs/CHANGELOG_V5.md#5.0.0">Moved to doc/changelogs/CHANGELOG\_V5.md#5.0.0</a>.
+
+## 2015-10-13, Version 4.2.1 'Argon' (LTS), @jasnell
+
+<a href="doc/changelogs/CHANGELOG_V4.md#4.2.1">Moved to doc/changelogs/CHANGELOG\_V4.md#4.2.1</a>.
+
+## 2015-10-07, Version 4.2.0 'Argon' (LTS), @jasnell
+
+<a href="doc/changelogs/CHANGELOG_V4.md#4.2.0">Moved to doc/changelogs/CHANGELOG\_V4.md#4.2.0</a>.
+
+## 2015-10-05, Version 4.1.2 (Stable), @rvagg
+
+<a href="doc/changelogs/CHANGELOG_V4.md#4.1.2">Moved to doc/changelogs/CHANGELOG\_V4.md#4.1.2</a>.
+
+## 2015-09-22, Version 4.1.1 (Stable), @rvagg
+
+<a href="doc/changelogs/CHANGELOG_V4.md#4.1.1">Moved to doc/changelogs/CHANGELOG\_V4.md#4.1.1</a>.
+
+## 2015-09-17, Version 4.1.0 (Stable), @Fishrock123
+
+<a href="doc/changelogs/CHANGELOG_V4.md#4.1.0">Moved to doc/changelogs/CHANGELOG\_V4.md#4.1.0</a>.
+
+## 2015-09-15, io.js Version 3.3.1 @rvagg
+
+<a href="doc/changelogs/CHANGELOG_IOJS.md#3.3.1">Moved to doc/changelogs/CHANGELOG\_IOJS.md#3.3.1</a>.
+
+## 2015-09-08, Version 4.0.0 (Stable), @rvagg
+
+<a href="doc/changelogs/CHANGELOG_V4.md#4.0.0">Moved to doc/changelogs/CHANGELOG\_V6.md#6.0.0</a>.
+
+## 2015-09-02, Version 3.3.0, @rvagg
+
+<a href="doc/changelogs/CHANGELOG_IOJS.md#3.3.0">Moved to doc/changelogs/CHANGELOG\_IOJS.md#3.3.0</a>.
+
+## 2015-08-25, Version 3.2.0, @rvagg
+
+<a href="doc/changelogs/CHANGELOG_IOJS.md#3.2.0">Moved to doc/changelogs/CHANGELOG\_IOJS.md#3.2.0</a>.
+
+## 2015-08-18, Version 3.1.0, @Fishrock123
+
+<a href="doc/changelogs/CHANGELOG_IOJS.md#3.1.0">Moved to doc/changelogs/CHANGELOG\_IOJS.md#3.1.0</a>.
+
+## 2015-08-04, Version 3.0.0, @rvagg
+
+<a href="doc/changelogs/CHANGELOG_IOJS.md#3.0.0">Moved to doc/changelogs/CHANGELOG\_IOJS.md#3.0.0</a>.
+
+## 2015-07-28, Version 2.5.0, @cjihrig
+
+<a href="doc/changelogs/CHANGELOG_IOJS.md#2.5.0">Moved to doc/changelogs/CHANGELOG\_IOJS.md#2.5.0</a>.
+
+## 2015-07-17, Version 2.4.0, @Fishrock123
+
+<a href="doc/changelogs/CHANGELOG_IOJS.md#2.4.0">Moved to doc/changelogs/CHANGELOG\_IOJS.md#2.4.0</a>.
+
+## 2015-07-09, Version 2.3.4, @Fishrock123
+
+<a href="doc/changelogs/CHANGELOG_IOJS.md#2.3.4">Moved to doc/changelogs/CHANGELOG\_IOJS.md#2.3.4</a>.
+
+## 2015-07-09, Version 1.8.4, @Fishrock123
+
+<a href="doc/changelogs/CHANGELOG_IOJS.md#1.8.4">Moved to doc/changelogs/CHANGELOG\_IOJS.md#1.8.4</a>.
+
+## 2015-07-09, Version 0.12.7 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V012.md#0.12.7">Moved to doc/changelogs/CHANGELOG\_V012.md#0.12.7</a>.
+
+## 2015-07-04, Version 2.3.3, @Fishrock123
+
+<a href="doc/changelogs/CHANGELOG_IOJS.md#2.3.3">Moved to doc/changelogs/CHANGELOG\_IOJS.md#2.3.3</a>.
+
+## 2015-07-04, Version 1.8.3, @rvagg
+
+<a href="doc/changelogs/CHANGELOG_IOJS.md#1.8.3">Moved to doc/changelogs/CHANGELOG\_IOJS.md#1.8.3</a>.
+
+## 2015-07-03, Version 0.12.6 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V012.md#0.12.6">Moved to doc/changelogs/CHANGELOG\_V012.md#0.12.6</a>.
+
+## 2015-07-01, Version 2.3.2, @rvagg
+
+<a href="doc/changelogs/CHANGELOG_IOJS.md#2.3.2">Moved to doc/changelogs/CHANGELOG\_IOJS.md#2.3.2</a>.
+
+## 2015-06-23, Version 2.3.1, @rvagg
+
+<a href="doc/changelogs/CHANGELOG_IOJS.md#2.3.1">Moved to doc/changelogs/CHANGELOG\_IOJS.md#2.3.1</a>.
+
+## 2015-06-22, Version 0.12.5 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V012.md#0.12.5">Moved to doc/changelogs/CHANGELOG\_V012.md#0.12.5</a>.
+
+## 2015-06-18, Version 0.10.39 (Maintenance)
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.39">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.39</a>.
+
+## 2015-06-13, Version 2.3.0, @rvagg
+
+<a href="doc/changelogs/CHANGELOG_IOJS.md#2.3.0">Moved to doc/changelogs/CHANGELOG\_IOJS.md#2.3.0</a>.
+
+## 2015-06-01, Version 2.2.1, @rvagg
+
+<a href="doc/changelogs/CHANGELOG_IOJS.md#2.2.1">Moved to doc/changelogs/CHANGELOG\_IOJS.md#2.2.1</a>.
+
+## 2015-05-31, Version 2.2.0, @rvagg
+
+<a href="doc/changelogs/CHANGELOG_IOJS.md#2.2.0">Moved to doc/changelogs/CHANGELOG\_IOJS.md#2.2.0</a>.
+
+## 2015-05-24, Version 2.1.0, @rvagg
+
+<a href="doc/changelogs/CHANGELOG_IOJS.md#2.1.0">Moved to doc/changelogs/CHANGELOG\_IOJS.md#2.1.0</a>.
+
+## 2015-05-22, Version 0.12.4 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V012.md#0.12.4">Moved to doc/changelogs/CHANGELOG\_V012.md#0.12.4</a>.
+
+## 2015-05-17, Version 1.8.2, @rvagg
+
+<a href="doc/changelogs/CHANGELOG_IOJS.md#1.8.2">Moved to doc/changelogs/CHANGELOG\_IOJS.md#1.8.2</a>.
+
+## 2015-05-15, Version 2.0.2, @Fishrock123
+
+<a href="doc/changelogs/CHANGELOG_IOJS.md#2.0.2">Moved to doc/changelogs/CHANGELOG\_IOJS.md#2.0.2</a>.
+
+## 2015-05-13, Version 0.12.3 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V012.md#0.12.3">Moved to doc/changelogs/CHANGELOG\_V012.md#0.12.3</a>.
+
+## 2015-05-07, Version 2.0.1, @rvagg
+
+<a href="doc/changelogs/CHANGELOG_IOJS.md#2.0.1">Moved to doc/changelogs/CHANGELOG\_IOJS.md#2.0.1</a>.
+
+## 2015-05-04, Version 2.0.0, @rvagg
+
+<a href="doc/changelogs/CHANGELOG_IOJS.md#2.0.0">Moved to doc/changelogs/CHANGELOG\_IOJS.md#2.0.0</a>.
+
+## 2015-04-20, Version 1.8.1, @chrisdickinson
+
+<a href="doc/changelogs/CHANGELOG_IOJS.md#1.8.1">Moved to doc/changelogs/CHANGELOG\_IOJS.md#1.8.1</a>.
+
+## 2015-04-14, Version 1.7.1, @rvagg
+
+<a href="doc/changelogs/CHANGELOG_IOJS.md#1.7.1">Moved to doc/changelogs/CHANGELOG\_IOJS.md#1.7.1</a>.
+
+## 2015-04-14, Version 1.7.0, @rvagg
+
+<a href="doc/changelogs/CHANGELOG_IOJS.md#1.7.0">Moved to doc/changelogs/CHANGELOG\_IOJS.md#1.7.0</a>.
+
+## 2015-04-06, Version 1.6.4, @Fishrock123
+
+<a href="doc/changelogs/CHANGELOG_IOJS.md#1.6.4">Moved to doc/changelogs/CHANGELOG\_IOJS.md#1.6.4</a>.
+
+## 2015-03-31, Version 1.6.3, @rvagg
+
+<a href="doc/changelogs/CHANGELOG_IOJS.md#1.6.3">Moved to doc/changelogs/CHANGELOG\_IOJS.md#1.6.3</a>.
+
+## 2015-03-31, Version 0.12.2 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V012.md#0.12.2">Moved to doc/changelogs/CHANGELOG\_V012.md#0.12.2</a>.
+
+## 2015-03-23, Version 1.6.2, @rvagg
+
+<a href="doc/changelogs/CHANGELOG_IOJS.md#1.6.2">Moved to doc/changelogs/CHANGELOG\_IOJS.md#1.6.2</a>.
+
+## 2015-03-23, Version 0.12.1 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V012.md#0.12.1">Moved to doc/changelogs/CHANGELOG\_V012.md#0.12.1</a>.
+
+## 2015-03-23, Version 0.10.38 (Maintenance)
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.38">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.38</a>.
+
+## 2015-03-20, Version 1.6.1, @rvagg
+
+<a href="doc/changelogs/CHANGELOG_IOJS.md#1.6.1">Moved to doc/changelogs/CHANGELOG\_IOJS.md#1.6.1</a>.
+
+## 2015-03-19, Version 1.6.0, @chrisdickinson
+
+<a href="doc/changelogs/CHANGELOG_IOJS.md#1.6.0">Moved to doc/changelogs/CHANGELOG\_IOJS.md#1.6.0</a>.
+
+## 2015-03-11, Version 0.10.37 (Maintenance)
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.37">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.37</a>.
+
+## 2015-03-09, Version 1.5.1, @rvagg
+
+<a href="doc/changelogs/CHANGELOG_IOJS.md#1.5.1">Moved to doc/changelogs/CHANGELOG\_IOJS.md#1.5.1</a>.
+
+## 2015-03-06, Version 1.5.0, @rvagg
+
+<a href="doc/changelogs/CHANGELOG_IOJS.md#1.5.0">Moved to doc/changelogs/CHANGELOG\_IOJS.md#1.5.0</a>.
+
+## 2015-03-02, Version 1.4.3, @rvagg
+
+<a href="doc/changelogs/CHANGELOG_IOJS.md#1.4.3">Moved to doc/changelogs/CHANGELOG\_IOJS.md#1.4.3</a>.
+
+## 2015-02-28, Version 1.4.2, @rvagg
+
+<a href="doc/changelogs/CHANGELOG_IOJS.md#1.4.2">Moved to doc/changelogs/CHANGELOG\_IOJS.md#1.4.2</a>.
+
+## 2015-02-26, Version 1.4.1, @rvagg
+
+<a href="doc/changelogs/CHANGELOG_IOJS.md#1.4.1">Moved to doc/changelogs/CHANGELOG\_IOJS.md#1.4.1</a>.
+
+## 2015-02-20, Version 1.3.0, @rvagg
+
+<a href="doc/changelogs/CHANGELOG_IOJS.md#1.3.0">Moved to doc/changelogs/CHANGELOG\_IOJS.md#1.3.0</a>.
+
+## 2015-02-10, Version 1.2.0, @rvagg
+
+<a href="doc/changelogs/CHANGELOG_IOJS.md#1.2.0">Moved to doc/changelogs/CHANGELOG\_IOJS.md#1.2.0</a>.
+
+## 2015-02-06, Version 0.12.0 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V012.md#0.12.0">Moved to doc/changelogs/CHANGELOG\_V012.md#0.12.0</a>.
+
+## 2015-02-03, Version 1.1.0, @chrisdickinson
+
+<a href="doc/changelogs/CHANGELOG_IOJS.md#1.1.0">Moved to doc/changelogs/CHANGELOG\_IOJS.md#1.1.0</a>.
+
+## 2015-01-26, Version 0.10.36 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.36">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.36</a>.
+
+## 2015-01-24, Version 1.0.4, @rvagg
+
+<a href="doc/changelogs/CHANGELOG_IOJS.md#1.0.4">Moved to doc/changelogs/CHANGELOG\_IOJS.md#1.0.4</a>.
+
+## 2015-01-20, Version 1.0.3, @rvagg
+
+<a href="doc/changelogs/CHANGELOG_IOJS.md#1.0.3">Moved to doc/changelogs/CHANGELOG\_IOJS.md#1.0.3</a>.
+
+## 2015-01-16, Version 1.0.2, @rvagg
+
+<a href="doc/changelogs/CHANGELOG_IOJS.md#1.0.2">Moved to doc/changelogs/CHANGELOG\_IOJS.md#1.0.2</a>.
+
+## 2015-01-14, Version 1.0.1, @rvagg
+
+<a href="doc/changelogs/CHANGELOG_IOJS.md#1.0.1">Moved to doc/changelogs/CHANGELOG\_IOJS.md#1.0.1</a>.
+
+## 2014.09.24, Version 0.11.14 (Unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.11.14">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.11.14</a>.
+
+## 2014.05.01, Version 0.11.13 (Unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.11.13">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.11.13</a>.
+
+## 2014.03.11, Version 0.11.12 (Unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.11.12">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.11.12</a>.
+
+## 2014.01.29, Version 0.11.11 (Unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.11.11">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.11.11</a>.
+
+## 2013.12.31, Version 0.11.10 (Unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.11.10">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.11.10</a>.
+
+## 2013.11.20, Version 0.11.9 (Unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.11.9">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.11.9</a>.
+
+## 2013.10.30, Version 0.11.8 (Unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.11.8">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.11.8</a>.
+
+## 2013.08.21, Version 0.11.7 (Unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.11.7">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.11.7</a>.
+
+## 2013.08.21, Version 0.11.6 (Unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.11.6">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.11.6</a>.
+
+## 2013.08.06, Version 0.11.5 (Unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.11.5">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.11.5</a>.
+
+## 2013.07.12, Version 0.11.4 (Unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.11.4">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.11.4</a>.
+
+## 2013.06.26, Version 0.11.3 (Unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.11.3">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.11.3</a>.
+
+## 2013.05.13, Version 0.11.2 (Unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.11.2">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.11.2</a>.
+
+## 2013.04.19, Version 0.11.1 (Unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.11.1">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.11.1</a>.
+
+## 2013.03.28, Version 0.11.0 (Unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.11.0">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.11.0</a>.
+
+## 2014.12.22, Version 0.10.35 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.35">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.35</a>.
+
+## 2014.12.17, Version 0.10.34 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.34">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.34</a>.
+
+## 2014.10.20, Version 0.10.33 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.33">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.33</a>.
+
+## 2014.09.16, Version 0.10.32 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.32">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.32</a>.
+
+## 2014.08.19, Version 0.10.31 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.31">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.31</a>.
+
+## 2014.07.31, Version 0.10.30 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.30">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.30</a>.
+
+## 2014.06.05, Version 0.10.29 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.29">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.29</a>.
+
+## 2014.05.01, Version 0.10.28 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.28">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.28</a>.
+
+## 2014.05.01, Version 0.10.27 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.27">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.27</a>.
+
+## 2014.02.18, Version 0.10.26 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.26">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.26</a>.
+
+## 2014.01.23, Version 0.10.25 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.25">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.25</a>.
+
+## 2013.12.18, Version 0.10.24 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.24">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.24</a>.
+
+## 2013.12.12, Version 0.10.23 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.23">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.23</a>.
+
+## 2013.11.12, Version 0.10.22 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.22">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.22</a>.
+
+## 2013.10.18, Version 0.10.21 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.21">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.21</a>.
+
+## 2013.09.30, Version 0.10.20 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.20">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.20</a>.
+
+## 2013.09.24, Version 0.10.19 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.19">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.19</a>.
+
+## 2013.09.04, Version 0.10.18 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.18">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.18</a>.
+
+## 2013.08.21, Version 0.10.17 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.17">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.17</a>.
+
+## 2013.08.16, Version 0.10.16 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.16">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.16</a>.
+
+## 2013.07.25, Version 0.10.15 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.15">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.15</a>.
+
+## 2013.07.25, Version 0.10.14 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.14">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.14</a>.
+
+## 2013.07.09, Version 0.10.13 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.13">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.13</a>.
+
+## 2013.06.18, Version 0.10.12 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.12">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.12</a>.
+
+## 2013.06.13, Version 0.10.11 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.11">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.11</a>.
+
+## 2013.06.04, Version 0.10.10 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.10">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.10</a>.
+
+## 2013.05.30, Version 0.10.9 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.9">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.9</a>.
+
+## 2013.05.24, Version 0.10.8 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.8">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.8</a>.
+
+## 2013.05.17, Version 0.10.7 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.7">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.7</a>.
+
+## 2013.05.14, Version 0.10.6 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.6">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.6</a>.
+
+## 2013.04.23, Version 0.10.5 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.5">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.5</a>.
+
+## 2013.04.11, Version 0.10.4 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.4">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.4</a>.
+
+## 2013.04.03, Version 0.10.3 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.3">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.3</a>.
+
+## 2013.03.28, Version 0.10.2 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.2">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.2</a>.
+
+## 2013.03.21, Version 0.10.1 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.1">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.1</a>.
+
+## 2013.03.11, Version 0.10.0 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.0">Moved to doc/changelogs/CHANGELOG\_V010.md#0.10.0</a>.
+
+## 2013.03.06, Version 0.9.12 (Unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.9.12">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.9.12</a>.
+
+## 2013.03.01, Version 0.9.11 (Unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.9.11">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.9.11</a>.
+
+## 2013.02.19, Version 0.9.10 (Unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.9.10">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.9.10</a>.
+
+## 2013.02.07, Version 0.9.9 (Unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.9.9">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.9.9</a>.
+
+## 2013.01.24, Version 0.9.8 (Unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.9.8">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.9.8</a>.
+
+## 2013.01.18, Version 0.9.7 (Unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.9.7">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.9.7</a>.
+
+## 2013.01.11, Version 0.9.6 (Unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.9.6">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.9.6</a>.
+
+## 2012.12.30, Version 0.9.5 (Unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.9.5">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.9.5</a>.
+
+## 2012.12.21, Version 0.9.4 (Unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.9.4">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.9.4</a>.
+
+## 2012.10.24, Version 0.9.3 (Unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.9.3">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.9.3</a>.
+
+## 2012.09.17, Version 0.9.2 (Unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.9.2">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.9.2</a>.
+
+## 2012.08.28, Version 0.9.1 (Unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.9.1">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.9.1</a>.
+
+## 2012.07.20, Version 0.9.0 (Unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.9.0">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.9.0</a>.
+
+## 2013.06.13, Version 0.8.25 (maintenance)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.8.25">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.8.25</a>.
+
+## 2013.06.04, Version 0.8.24 (maintenance)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.8.24">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.8.24</a>.
+
+## 2013.04.09, Version 0.8.23 (maintenance)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.8.23">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.8.23</a>.
+
+## 2013.03.07, Version 0.8.22 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.8.22">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.8.22</a>.
+
+## 2013.02.25, Version 0.8.21 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.8.21">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.8.21</a>.
+
+## 2013.02.15, Version 0.8.20 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.8.20">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.8.20</a>.
+
+## 2013.02.06, Version 0.8.19 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.8.19">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.8.19</a>.
+
+## 2013.01.18, Version 0.8.18 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.8.18">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.8.18</a>.
+
+## 2013.01.09, Version 0.8.17 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.8.17">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.8.17</a>.
+
+## 2012.12.13, Version 0.8.16 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.8.16">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.8.16</a>.
+
+## 2012.11.26, Version 0.8.15 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.8.15">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.8.15</a>.
+
+## 2012.10.25, Version 0.8.14 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.8.14">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.8.14</a>.
+
+## 2012.10.25, Version 0.8.13 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.8.13">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.8.13</a>.
+
+## 2012.10.12, Version 0.8.12 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.8.12">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.8.12</a>.
+
+## 2012.09.27, Version 0.8.11 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.8.11">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.8.11</a>.
+
+## 2012.09.25, Version 0.8.10 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.8.10">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.8.10</a>.
+
+## 2012.09.11, Version 0.8.9 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.8.9">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.8.9</a>.
+
+## 2012.08.22, Version 0.8.8 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.8.8">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.8.8</a>.
+
+## 2012.08.15, Version 0.8.7 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.8.7">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.8.7</a>.
+
+## 2012.08.07, Version 0.8.6 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.8.6">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.8.6</a>.
+
+## 2012.08.02, Version 0.8.5 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.8.5">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.8.5</a>.
+
+## 2012.07.25, Version 0.8.4 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.8.4">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.8.4</a>.
+
+## 2012.07.19, Version 0.8.3 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.8.3">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.8.3</a>.
+
+## 2012.07.09, Version 0.8.2 (Stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.8.2">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.8.2</a>.
+
+## 2012.06.29, Version 0.8.1 (stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.8.1">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.8.1</a>.
+
+## 2012.06.25, Version 0.8.0 (stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.8.0">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.8.0</a>.
+
+## 2012.06.19, Version 0.7.12 (unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.7.12">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.7.12</a>.
+
+## 2012.06.15, Version 0.7.11 (unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.7.11">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.7.11</a>.
+
+## 2012.06.11, Version 0.7.10 (unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.7.10">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.7.10</a>.
+
+## 2012.05.28, Version 0.7.9 (unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.7.9">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.7.9</a>.
+
+## 2012.04.18, Version 0.7.8 (unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.7.8">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.7.8</a>.
+
+## 2012.03.30, Version 0.7.7 (unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.7.7">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.7.7</a>.
+
+## 2012.03.13, Version 0.7.6 (unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.7.6">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.7.6</a>.
+
+## 2012.02.23, Version 0.7.5 (unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.7.5">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.7.5</a>.
+
+## 2012.02.14, Version 0.7.4 (unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.7.4">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.7.4</a>.
+
+## 2012.02.07, Version 0.7.3 (unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.7.3">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.7.3</a>.
+
+## 2012.02.01, Version 0.7.2 (unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.7.2">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.7.2</a>.
+
+## 2012.01.23, Version 0.7.1 (unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.7.1">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.7.1</a>.
+
+## 2012.01.16, Version 0.7.0 (unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.7.0">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.7.0</a>.
+
+## 2012.07.10 Version 0.6.20 (maintenance)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.6.20">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.6.20</a>.
+
+## 2012.06.06 Version 0.6.19 (stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.6.19">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.6.19</a>.
+
+## 2012.05.15 Version 0.6.18 (stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.6.18">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.6.18</a>.
+
+## 2012.05.04 Version 0.6.17 (stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.6.17">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.6.17</a>.
+
+## 2012.04.30 Version 0.6.16 (stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.6.16">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.6.16</a>.
+
+## 2012.04.09 Version 0.6.15 (stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.6.15">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.6.15</a>.
+
+## 2012.03.22 Version 0.6.14 (stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.6.14">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.6.14</a>.
+
+## 2012.03.15 Version 0.6.13 (stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.6.13">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.6.13</a>.
+
+## 2012.03.02 Version 0.6.12 (stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.6.12">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.6.12</a>.
+
+## 2012.02.17 Version 0.6.11 (stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.6.11">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.6.11</a>.
+
+## 2012.02.02, Version 0.6.10 (stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.6.10">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.6.10</a>.
+
+## 2012.01.27, Version 0.6.9 (stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.6.9">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.6.9</a>.
+
+## 2012.01.19, Version 0.6.8 (stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.6.8">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.6.8</a>.
+
+## 2012.01.06, Version 0.6.7 (stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.6.7">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.6.7</a>.
+
+## 2011.12.14, Version 0.6.6 (stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.6.6">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.6.6</a>.
+
+## 2011.12.04, Version 0.6.5 (stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.6.5">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.6.5</a>.
+
+## 2011.12.02, Version 0.6.4 (stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.6.4">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.6.4</a>.
+
+## 2011.11.25, Version 0.6.3 (stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.6.3">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.6.3</a>.
+
+## 2011.11.18, Version 0.6.2 (stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.6.2">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.6.2</a>.
+
+## 2011.11.11, Version 0.6.1 (stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.6.1">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.6.1</a>.
+
+## 2011.11.04, Version 0.6.0 (stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.6.0">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.6.0</a>.
+
+## 2011.10.21, Version 0.5.10 (unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.5.10">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.5.10</a>.
+
+## 2011.10.10, Version 0.5.9 (unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.5.9">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.5.9</a>.
+
+## 2011.09.30, Version 0.5.8 (unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.5.8">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.5.8</a>.
+
+## 2011.09.16, Version 0.5.7 (unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.5.7">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.5.7</a>.
+
+## 2011.09.08, Version 0.5.6 (unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.5.6">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.5.6</a>.
+
+## 2011.08.26, Version 0.5.5 (unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.5.5">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.5.5</a>.
+
+## 2011.08.12, Version 0.5.4 (unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.5.4">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.5.4</a>.
+
+## 2011.08.01, Version 0.5.3 (unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.5.3">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.5.3</a>.
+
+## 2011.07.22, Version 0.5.2 (unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.5.2">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.5.2</a>.
+
+## 2011.07.14, Version 0.5.1 (unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.5.1">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.5.1</a>.
+
+## 2011.07.05, Version 0.5.0 (unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.5.0">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.5.0</a>.
+
+## 2011.09.15, Version 0.4.12 (stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.4.12">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.4.12</a>.
+
+## 2011.08.17, Version 0.4.11 (stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.4.11">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.4.11</a>.
+
+## 2011.07.19, Version 0.4.10 (stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.4.10">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.4.10</a>.
+
+## 2011.06.29, Version 0.4.9 (stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.4.9">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.4.9</a>.
+
+## 2011.05.20, Version 0.4.8 (stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.4.8">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.4.8</a>.
+
+## 2011.04.22, Version 0.4.7 (stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.4.7">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.4.7</a>.
+
+## 2011.04.13, Version 0.4.6 (stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.4.6">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.4.6</a>.
+
+## 2011.04.01, Version 0.4.5 (stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.4.5">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.4.5</a>.
+
+## 2011.03.26, Version 0.4.4 (stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.4.4">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.4.4</a>.
+
+## 2011.03.18, Version 0.4.3 (stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.4.3">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.4.3</a>.
+
+## 2011.03.02, Version 0.4.2 (stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.4.2">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.4.2</a>.
+
+## 2011.02.19, Version 0.4.1 (stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.4.1">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.4.1</a>.
+
+## 2011.02.10, Version 0.4.0 (stable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.4.0">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.4.0</a>.
+
+## 2011.02.04, Version 0.3.8 (unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.3.8">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.3.8</a>.
+
+## 2011.01.27, Version 0.3.7 (unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.3.7">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.3.7</a>.
+
+## 2011.01.21, Version 0.3.6 (unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.3.6">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.3.6</a>.
+
+## 2011.01.16, Version 0.3.5 (unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.3.5">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.3.5</a>.
+
+## 2011.01.08, Version 0.3.4 (unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.3.4">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.3.4</a>.
+
+## 2011.01.02, Version 0.3.3 (unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.3.3">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.3.3</a>.
+
+## 2010.12.16, Version 0.3.2 (unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.3.2">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.3.2</a>.
+
+## 2010.11.16, Version 0.3.1 (unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.3.1">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.3.1</a>.
+
+## 2010.10.23, Version 0.3.0 (unstable)
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.3.0">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.3.0</a>.
+
+## 2010.08.20, Version 0.2.0
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.2.0">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.2.0</a>.
+
+## 2010.08.13, Version 0.1.104
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.104">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.104</a>.
+
+## 2010.08.04, Version 0.1.103
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.103">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.103</a>.
+
+## 2010.07.25, Version 0.1.102
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.102">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.102</a>.
+
+## 2010.07.16, Version 0.1.101
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.101">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.101</a>.
+
+## 2010.07.03, Version 0.1.100
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.100">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.100</a>.
+
+## 2010.06.21, Version 0.1.99
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.99">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.99</a>.
+
+## 2010.06.11, Version 0.1.98
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.98">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.98</a>.
+
+## 2010.05.29, Version 0.1.97
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.97">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.97</a>.
+
+## 2010.05.21, Version 0.1.96
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.96">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.96</a>.
+
+## 2010.05.13, Version 0.1.95
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.95">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.95</a>.
+
+## 2010.05.06, Version 0.1.94
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.94">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.94</a>.
+
+## 2010.04.29, Version 0.1.93
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.93">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.93</a>.
+
+## 2010.04.23, Version 0.1.92
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.92">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.92</a>.
+
+## 2010.04.15, Version 0.1.91
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.91">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.91</a>.
+
+## 2010.04.09, Version 0.1.90
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.90">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.90</a>.
+
+## 2010.03.19, Version 0.1.33
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.33">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.33</a>.
+
+## 2010.03.12, Version 0.1.32
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.32">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.32</a>.
+
+## 2010.03.05, Version 0.1.31
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.31">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.31</a>.
+
+## 2010.02.22, Version 0.1.30
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.30">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.30</a>.
+
+## 2010.02.17, Version 0.1.29
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.29">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.29</a>.
+
+## 2010.02.09, Version 0.1.28
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.28">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.28</a>.
+
+## 2010.02.03, Version 0.1.27
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.27">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.27</a>.
+
+## 2010.01.20, Version 0.1.26
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.26">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.26</a>.
+
+## 2010.01.09, Version 0.1.25
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.25">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.25</a>.
+
+## 2009.12.31, Version 0.1.24
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.24">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.24</a>.
+
+## 2009.12.22, Version 0.1.23
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.23">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.23</a>.
+
+## 2009.12.19, Version 0.1.22
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.22">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.22</a>.
+
+## 2009.12.06, Version 0.1.21
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.21">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.21</a>.
+
+## 2009.11.28, Version 0.1.20
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.20">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.20</a>.
+
+## 2009.11.28, Version 0.1.19
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.19">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.19</a>.
+
+## 2009.11.17, Version 0.1.18
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.18">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.18</a>.
+
+## 2009.11.07, Version 0.1.17
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.17">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.17</a>.
+
+## 2009.11.03, Version 0.1.16
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.16">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.16</a>.
+
+## 2009.10.28, Version 0.1.15
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.15">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.15</a>.
+
+## 2009.10.09, Version 0.1.14
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.14">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.14</a>.
+
+## 2009.09.30, Version 0.1.13
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.13">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.13</a>.
+
+## 2009.09.24, Version 0.1.12
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.12">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.12</a>.
+
+## 2009.09.18, Version 0.1.11
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.11">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.11</a>.
+
+## 2009.09.11, Version 0.1.10
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.10">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.10</a>.
+
+## 2009.09.05, Version 0.1.9
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.9">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.9</a>.
+
+## 2009.09.04, Version 0.1.8
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.8">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.8</a>.
+
+## 2009.08.27, Version 0.1.7
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.7">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.7</a>.
+
+## 2009.08.22, Version 0.1.6
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.6">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.6</a>.
+
+## 2009.08.21, Version 0.1.5
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.5">Moved to doc/changelogs/CHANGELOG\_V6.md#6.0.0</a>.
+
+## 2009.08.13, Version 0.1.4
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.4">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.4</a>.
+
+## 2009.08.06, Version 0.1.3
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.3">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.3</a>.
+
+## 2009.08.01, Version 0.1.2
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.2">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.2</a>.
+
+## 2009.07.27, Version 0.1.1
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.1">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.1</a>.
+
+## 2009.06.30, Version 0.1.0
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.1.0">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.1.0</a>.
+
+## 2009.06.24, Version 0.0.6
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.0.6">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.0.6</a>.
+
+## 2009.06.18, Version 0.0.5
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.0.5">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.0.5</a>.
+
+## 2009.06.13, Version 0.0.4
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.0.4">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.0.4</a>.
+
+## 2009.06.11, Version 0.0.3
+
+<a href="doc/changelogs/CHANGELOG_ARCHIVE.md#0.0.3">Moved to doc/changelogs/CHANGELOG\_ARCHIVE.md#0.0.3</a>.

--- a/nodejs/LICENSE
+++ b/nodejs/LICENSE
@@ -1,0 +1,2946 @@
+Node.js is licensed for use as follows:
+
+"""
+Copyright Node.js contributors. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.
+"""
+
+This license applies to parts of Node.js originating from the
+https://github.com/joyent/node repository:
+
+"""
+Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.
+"""
+
+The Node.js license applies to all parts of Node.js that are not externally
+maintained libraries.
+
+The externally maintained libraries used by Node.js are:
+
+- Acorn, located at deps/acorn, is licensed as follows:
+  """
+    MIT License
+
+    Copyright (C) 2012-2022 by various contributors (see AUTHORS)
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+  """
+
+- c-ares, located at deps/cares, is licensed as follows:
+  """
+    MIT License
+
+    Copyright (c) 1998 Massachusetts Institute of Technology
+    Copyright (c) 2007 - 2023 Daniel Stenberg with many contributors, see AUTHORS
+    file.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+    the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+  """
+
+- merve, located at deps/merve, is licensed as follows:
+  """
+    Copyright 2026 Yagiz Nizipli
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+    the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  """
+
+- ittapi, located at deps/v8/third_party/ittapi, is licensed as follows:
+  """
+    Copyright (c) 2019 Intel Corporation. All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  """
+
+- amaro, located at deps/amaro, is licensed as follows:
+  """
+    MIT License
+
+    Copyright (c) Marco Ippolito and Amaro contributors
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+  """
+
+- swc, located at deps/amaro/dist, is licensed as follows:
+  """
+                                  Apache License
+                            Version 2.0, January 2004
+                         http://www.apache.org/licenses/
+
+    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+    1. Definitions.
+
+       "License" shall mean the terms and conditions for use, reproduction,
+       and distribution as defined by Sections 1 through 9 of this document.
+
+       "Licensor" shall mean the copyright owner or entity authorized by
+       the copyright owner that is granting the License.
+
+       "Legal Entity" shall mean the union of the acting entity and all
+       other entities that control, are controlled by, or are under common
+       control with that entity. For the purposes of this definition,
+       "control" means (i) the power, direct or indirect, to cause the
+       direction or management of such entity, whether by contract or
+       otherwise, or (ii) ownership of fifty percent (50%) or more of the
+       outstanding shares, or (iii) beneficial ownership of such entity.
+
+       "You" (or "Your") shall mean an individual or Legal Entity
+       exercising permissions granted by this License.
+
+       "Source" form shall mean the preferred form for making modifications,
+       including but not limited to software source code, documentation
+       source, and configuration files.
+
+       "Object" form shall mean any form resulting from mechanical
+       transformation or translation of a Source form, including but
+       not limited to compiled object code, generated documentation,
+       and conversions to other media types.
+
+       "Work" shall mean the work of authorship, whether in Source or
+       Object form, made available under the License, as indicated by a
+       copyright notice that is included in or attached to the work
+       (an example is provided in the Appendix below).
+
+       "Derivative Works" shall mean any work, whether in Source or Object
+       form, that is based on (or derived from) the Work and for which the
+       editorial revisions, annotations, elaborations, or other modifications
+       represent, as a whole, an original work of authorship. For the purposes
+       of this License, Derivative Works shall not include works that remain
+       separable from, or merely link (or bind by name) to the interfaces of,
+       the Work and Derivative Works thereof.
+
+       "Contribution" shall mean any work of authorship, including
+       the original version of the Work and any modifications or additions
+       to that Work or Derivative Works thereof, that is intentionally
+       submitted to Licensor for inclusion in the Work by the copyright owner
+       or by an individual or Legal Entity authorized to submit on behalf of
+       the copyright owner. For the purposes of this definition, "submitted"
+       means any form of electronic, verbal, or written communication sent
+       to the Licensor or its representatives, including but not limited to
+       communication on electronic mailing lists, source code control systems,
+       and issue tracking systems that are managed by, or on behalf of, the
+       Licensor for the purpose of discussing and improving the Work, but
+       excluding communication that is conspicuously marked or otherwise
+       designated in writing by the copyright owner as "Not a Contribution."
+
+       "Contributor" shall mean Licensor and any individual or Legal Entity
+       on behalf of whom a Contribution has been received by Licensor and
+       subsequently incorporated within the Work.
+
+    2. Grant of Copyright License. Subject to the terms and conditions of
+       this License, each Contributor hereby grants to You a perpetual,
+       worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+       copyright license to reproduce, prepare Derivative Works of,
+       publicly display, publicly perform, sublicense, and distribute the
+       Work and such Derivative Works in Source or Object form.
+
+    3. Grant of Patent License. Subject to the terms and conditions of
+       this License, each Contributor hereby grants to You a perpetual,
+       worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+       (except as stated in this section) patent license to make, have made,
+       use, offer to sell, sell, import, and otherwise transfer the Work,
+       where such license applies only to those patent claims licensable
+       by such Contributor that are necessarily infringed by their
+       Contribution(s) alone or by combination of their Contribution(s)
+       with the Work to which such Contribution(s) was submitted. If You
+       institute patent litigation against any entity (including a
+       cross-claim or counterclaim in a lawsuit) alleging that the Work
+       or a Contribution incorporated within the Work constitutes direct
+       or contributory patent infringement, then any patent licenses
+       granted to You under this License for that Work shall terminate
+       as of the date such litigation is filed.
+
+    4. Redistribution. You may reproduce and distribute copies of the
+       Work or Derivative Works thereof in any medium, with or without
+       modifications, and in Source or Object form, provided that You
+       meet the following conditions:
+
+       (a) You must give any other recipients of the Work or
+           Derivative Works a copy of this License; and
+
+       (b) You must cause any modified files to carry prominent notices
+           stating that You changed the files; and
+
+       (c) You must retain, in the Source form of any Derivative Works
+           that You distribute, all copyright, patent, trademark, and
+           attribution notices from the Source form of the Work,
+           excluding those notices that do not pertain to any part of
+           the Derivative Works; and
+
+       (d) If the Work includes a "NOTICE" text file as part of its
+           distribution, then any Derivative Works that You distribute must
+           include a readable copy of the attribution notices contained
+           within such NOTICE file, excluding those notices that do not
+           pertain to any part of the Derivative Works, in at least one
+           of the following places: within a NOTICE text file distributed
+           as part of the Derivative Works; within the Source form or
+           documentation, if provided along with the Derivative Works; or,
+           within a display generated by the Derivative Works, if and
+           wherever such third-party notices normally appear. The contents
+           of the NOTICE file are for informational purposes only and
+           do not modify the License. You may add Your own attribution
+           notices within Derivative Works that You distribute, alongside
+           or as an addendum to the NOTICE text from the Work, provided
+           that such additional attribution notices cannot be construed
+           as modifying the License.
+
+       You may add Your own copyright statement to Your modifications and
+       may provide additional or different license terms and conditions
+       for use, reproduction, or distribution of Your modifications, or
+       for any such Derivative Works as a whole, provided Your use,
+       reproduction, and distribution of the Work otherwise complies with
+       the conditions stated in this License.
+
+    5. Submission of Contributions. Unless You explicitly state otherwise,
+       any Contribution intentionally submitted for inclusion in the Work
+       by You to the Licensor shall be under the terms and conditions of
+       this License, without any additional terms or conditions.
+       Notwithstanding the above, nothing herein shall supersede or modify
+       the terms of any separate license agreement you may have executed
+       with Licensor regarding such Contributions.
+
+    6. Trademarks. This License does not grant permission to use the trade
+       names, trademarks, service marks, or product names of the Licensor,
+       except as required for reasonable and customary use in describing the
+       origin of the Work and reproducing the content of the NOTICE file.
+
+    7. Disclaimer of Warranty. Unless required by applicable law or
+       agreed to in writing, Licensor provides the Work (and each
+       Contributor provides its Contributions) on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+       implied, including, without limitation, any warranties or conditions
+       of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+       PARTICULAR PURPOSE. You are solely responsible for determining the
+       appropriateness of using or redistributing the Work and assume any
+       risks associated with Your exercise of permissions under this License.
+
+    8. Limitation of Liability. In no event and under no legal theory,
+       whether in tort (including negligence), contract, or otherwise,
+       unless required by applicable law (such as deliberate and grossly
+       negligent acts) or agreed to in writing, shall any Contributor be
+       liable to You for damages, including any direct, indirect, special,
+       incidental, or consequential damages of any character arising as a
+       result of this License or out of the use or inability to use the
+       Work (including but not limited to damages for loss of goodwill,
+       work stoppage, computer failure or malfunction, or any and all
+       other commercial damages or losses), even if such Contributor
+       has been advised of the possibility of such damages.
+
+    9. Accepting Warranty or Additional Liability. While redistributing
+       the Work or Derivative Works thereof, You may choose to offer,
+       and charge a fee for, acceptance of support, warranty, indemnity,
+       or other liability obligations and/or rights consistent with this
+       License. However, in accepting such obligations, You may act only
+       on Your own behalf and on Your sole responsibility, not on behalf
+       of any other Contributor, and only if You agree to indemnify,
+       defend, and hold each Contributor harmless for any liability
+       incurred by, or claims asserted against, such Contributor by reason
+       of your accepting any such warranty or additional liability.
+
+    END OF TERMS AND CONDITIONS
+
+    APPENDIX: How to apply the Apache License to your work.
+
+       To apply the Apache License to your work, attach the following
+       boilerplate notice, with the fields enclosed by brackets "[]"
+       replaced with your own identifying information. (Don't include
+       the brackets!)  The text should be enclosed in the appropriate
+       comment syntax for the file format. We also recommend that a
+       file or class name and description of purpose be included on the
+       same "printed page" as the copyright notice for easier
+       identification within third-party archives.
+
+    Copyright 2024 SWC contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    	http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  """
+
+- ICU, located at deps/icu-small, is licensed as follows:
+  """
+    UNICODE LICENSE V3
+
+    COPYRIGHT AND PERMISSION NOTICE
+
+    Copyright © 2016-2025 Unicode, Inc.
+
+    NOTICE TO USER: Carefully read the following legal agreement. BY
+    DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
+    SOFTWARE, YOU UNEQUIVOCALLY ACCEPT, AND AGREE TO BE BOUND BY, ALL OF THE
+    TERMS AND CONDITIONS OF THIS AGREEMENT. IF YOU DO NOT AGREE, DO NOT
+    DOWNLOAD, INSTALL, COPY, DISTRIBUTE OR USE THE DATA FILES OR SOFTWARE.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of data files and any associated documentation (the "Data Files") or
+    software and any associated documentation (the "Software") to deal in the
+    Data Files or Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, and/or sell
+    copies of the Data Files or Software, and to permit persons to whom the
+    Data Files or Software are furnished to do so, provided that either (a)
+    this copyright and permission notice appear with all copies of the Data
+    Files or Software, or (b) this copyright and permission notice appear in
+    associated Documentation.
+
+    THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+    KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+    THIRD PARTY RIGHTS.
+
+    IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS NOTICE
+    BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES,
+    OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+    WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+    ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THE DATA
+    FILES OR SOFTWARE.
+
+    Except as contained in this notice, the name of a copyright holder shall
+    not be used in advertising or otherwise to promote the sale, use or other
+    dealings in these Data Files or Software without prior written
+    authorization of the copyright holder.
+
+    SPDX-License-Identifier: Unicode-3.0
+
+    ----------------------------------------------------------------------
+
+    Third-Party Software Licenses
+
+    This section contains third-party software notices and/or additional
+    terms for licensed third-party software components included within ICU
+    libraries.
+
+    ----------------------------------------------------------------------
+
+    ICU License - ICU 1.8.1 to ICU 57.1
+
+    COPYRIGHT AND PERMISSION NOTICE
+
+    Copyright (c) 1995-2016 International Business Machines Corporation and others
+    All rights reserved.
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, and/or sell copies of the Software, and to permit persons
+    to whom the Software is furnished to do so, provided that the above
+    copyright notice(s) and this permission notice appear in all copies of
+    the Software and that both the above copyright notice(s) and this
+    permission notice appear in supporting documentation.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+    OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+    HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY
+    SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
+    RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
+    CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+    CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+    Except as contained in this notice, the name of a copyright holder
+    shall not be used in advertising or otherwise to promote the sale, use
+    or other dealings in this Software without prior written authorization
+    of the copyright holder.
+
+    All trademarks and registered trademarks mentioned herein are the
+    property of their respective owners.
+
+    ----------------------------------------------------------------------
+
+    Chinese/Japanese Word Break Dictionary Data (cjdict.txt)
+
+     #     The Google Chrome software developed by Google is licensed under
+     # the BSD license. Other software included in this distribution is
+     # provided under other licenses, as set forth below.
+     #
+     #  The BSD License
+     #  http://opensource.org/licenses/bsd-license.php
+     #  Copyright (C) 2006-2008, Google Inc.
+     #
+     #  All rights reserved.
+     #
+     #  Redistribution and use in source and binary forms, with or without
+     # modification, are permitted provided that the following conditions are met:
+     #
+     #  Redistributions of source code must retain the above copyright notice,
+     # this list of conditions and the following disclaimer.
+     #  Redistributions in binary form must reproduce the above
+     # copyright notice, this list of conditions and the following
+     # disclaimer in the documentation and/or other materials provided with
+     # the distribution.
+     #  Neither the name of  Google Inc. nor the names of its
+     # contributors may be used to endorse or promote products derived from
+     # this software without specific prior written permission.
+     #
+     #
+     #  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+     # CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+     # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+     # MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+     # DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+     # LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+     # CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+     # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+     # BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+     # LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+     # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+     # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+     #
+     #
+     #  The word list in cjdict.txt are generated by combining three word lists
+     # listed below with further processing for compound word breaking. The
+     # frequency is generated with an iterative training against Google web
+     # corpora.
+     #
+     #  * Libtabe (Chinese)
+     #    - https://sourceforge.net/project/?group_id=1519
+     #    - Its license terms and conditions are shown below.
+     #
+     #  * IPADIC (Japanese)
+     #    - http://chasen.aist-nara.ac.jp/chasen/distribution.html
+     #    - Its license terms and conditions are shown below.
+     #
+     #  ---------COPYING.libtabe ---- BEGIN--------------------
+     #
+     #  /*
+     #   * Copyright (c) 1999 TaBE Project.
+     #   * Copyright (c) 1999 Pai-Hsiang Hsiao.
+     #   * All rights reserved.
+     #   *
+     #   * Redistribution and use in source and binary forms, with or without
+     #   * modification, are permitted provided that the following conditions
+     #   * are met:
+     #   *
+     #   * . Redistributions of source code must retain the above copyright
+     #   *   notice, this list of conditions and the following disclaimer.
+     #   * . Redistributions in binary form must reproduce the above copyright
+     #   *   notice, this list of conditions and the following disclaimer in
+     #   *   the documentation and/or other materials provided with the
+     #   *   distribution.
+     #   * . Neither the name of the TaBE Project nor the names of its
+     #   *   contributors may be used to endorse or promote products derived
+     #   *   from this software without specific prior written permission.
+     #   *
+     #   * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+     #   * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+     #   * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+     #   * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+     #   * REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+     #   * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+     #   * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+     #   * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+     #   * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+     #   * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+     #   * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+     #   * OF THE POSSIBILITY OF SUCH DAMAGE.
+     #   */
+     #
+     #  /*
+     #   * Copyright (c) 1999 Computer Systems and Communication Lab,
+     #   *                    Institute of Information Science, Academia
+     #       *                    Sinica. All rights reserved.
+     #   *
+     #   * Redistribution and use in source and binary forms, with or without
+     #   * modification, are permitted provided that the following conditions
+     #   * are met:
+     #   *
+     #   * . Redistributions of source code must retain the above copyright
+     #   *   notice, this list of conditions and the following disclaimer.
+     #   * . Redistributions in binary form must reproduce the above copyright
+     #   *   notice, this list of conditions and the following disclaimer in
+     #   *   the documentation and/or other materials provided with the
+     #   *   distribution.
+     #   * . Neither the name of the Computer Systems and Communication Lab
+     #   *   nor the names of its contributors may be used to endorse or
+     #   *   promote products derived from this software without specific
+     #   *   prior written permission.
+     #   *
+     #   * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+     #   * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+     #   * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+     #   * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+     #   * REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+     #   * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+     #   * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+     #   * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+     #   * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+     #   * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+     #   * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+     #   * OF THE POSSIBILITY OF SUCH DAMAGE.
+     #   */
+     #
+     #  Copyright 1996 Chih-Hao Tsai @ Beckman Institute,
+     #      University of Illinois
+     #  c-tsai4@uiuc.edu  http://casper.beckman.uiuc.edu/~c-tsai4
+     #
+     #  ---------------COPYING.libtabe-----END--------------------------------
+     #
+     #
+     #  ---------------COPYING.ipadic-----BEGIN-------------------------------
+     #
+     #  Copyright 2000, 2001, 2002, 2003 Nara Institute of Science
+     #  and Technology.  All Rights Reserved.
+     #
+     #  Use, reproduction, and distribution of this software is permitted.
+     #  Any copy of this software, whether in its original form or modified,
+     #  must include both the above copyright notice and the following
+     #  paragraphs.
+     #
+     #  Nara Institute of Science and Technology (NAIST),
+     #  the copyright holders, disclaims all warranties with regard to this
+     #  software, including all implied warranties of merchantability and
+     #  fitness, in no event shall NAIST be liable for
+     #  any special, indirect or consequential damages or any damages
+     #  whatsoever resulting from loss of use, data or profits, whether in an
+     #  action of contract, negligence or other tortuous action, arising out
+     #  of or in connection with the use or performance of this software.
+     #
+     #  A large portion of the dictionary entries
+     #  originate from ICOT Free Software.  The following conditions for ICOT
+     #  Free Software applies to the current dictionary as well.
+     #
+     #  Each User may also freely distribute the Program, whether in its
+     #  original form or modified, to any third party or parties, PROVIDED
+     #  that the provisions of Section 3 ("NO WARRANTY") will ALWAYS appear
+     #  on, or be attached to, the Program, which is distributed substantially
+     #  in the same form as set out herein and that such intended
+     #  distribution, if actually made, will neither violate or otherwise
+     #  contravene any of the laws and regulations of the countries having
+     #  jurisdiction over the User or the intended distribution itself.
+     #
+     #  NO WARRANTY
+     #
+     #  The program was produced on an experimental basis in the course of the
+     #  research and development conducted during the project and is provided
+     #  to users as so produced on an experimental basis.  Accordingly, the
+     #  program is provided without any warranty whatsoever, whether express,
+     #  implied, statutory or otherwise.  The term "warranty" used herein
+     #  includes, but is not limited to, any warranty of the quality,
+     #  performance, merchantability and fitness for a particular purpose of
+     #  the program and the nonexistence of any infringement or violation of
+     #  any right of any third party.
+     #
+     #  Each user of the program will agree and understand, and be deemed to
+     #  have agreed and understood, that there is no warranty whatsoever for
+     #  the program and, accordingly, the entire risk arising from or
+     #  otherwise connected with the program is assumed by the user.
+     #
+     #  Therefore, neither ICOT, the copyright holder, or any other
+     #  organization that participated in or was otherwise related to the
+     #  development of the program and their respective officials, directors,
+     #  officers and other employees shall be held liable for any and all
+     #  damages, including, without limitation, general, special, incidental
+     #  and consequential damages, arising out of or otherwise in connection
+     #  with the use or inability to use the program or any product, material
+     #  or result produced or otherwise obtained by using the program,
+     #  regardless of whether they have been advised of, or otherwise had
+     #  knowledge of, the possibility of such damages at any time during the
+     #  project or thereafter.  Each user will be deemed to have agreed to the
+     #  foregoing by his or her commencement of use of the program.  The term
+     #  "use" as used herein includes, but is not limited to, the use,
+     #  modification, copying and distribution of the program and the
+     #  production of secondary products from the program.
+     #
+     #  In the case where the program, whether in its original form or
+     #  modified, was distributed or delivered to or received by a user from
+     #  any person, organization or entity other than ICOT, unless it makes or
+     #  grants independently of ICOT any specific warranty to the user in
+     #  writing, such person, organization or entity, will also be exempted
+     #  from and not be held liable to the user for any such damages as noted
+     #  above as far as the program is concerned.
+     #
+     #  ---------------COPYING.ipadic-----END----------------------------------
+
+    ----------------------------------------------------------------------
+
+    Lao Word Break Dictionary Data (laodict.txt)
+
+     # Copyright (C) 2016 and later: Unicode, Inc. and others.
+     # License & terms of use: http://www.unicode.org/copyright.html
+     # Copyright (c) 2015 International Business Machines Corporation
+     # and others. All Rights Reserved.
+     #
+     # Project: https://github.com/rober42539/lao-dictionary
+     # Dictionary: https://github.com/rober42539/lao-dictionary/laodict.txt
+     # License: https://github.com/rober42539/lao-dictionary/LICENSE.txt
+     #          (copied below)
+     #
+     # This file is derived from the above dictionary version of Nov 22, 2020
+     #  ----------------------------------------------------------------------
+     #  Copyright (C) 2013 Brian Eugene Wilson, Robert Martin Campbell.
+     #  All rights reserved.
+     #
+     #  Redistribution and use in source and binary forms, with or without
+     #  modification, are permitted provided that the following conditions are met:
+     #
+     #  Redistributions of source code must retain the above copyright notice, this
+     #  list of conditions and the following disclaimer. Redistributions in binary
+     #  form must reproduce the above copyright notice, this list of conditions and
+     #  the following disclaimer in the documentation and/or other materials
+     #  provided with the distribution.
+     #
+     # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+     # "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+     # LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+     # FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+     # COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+     # INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+     # (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+     # SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+     # HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+     # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+     # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+     # OF THE POSSIBILITY OF SUCH DAMAGE.
+     #  --------------------------------------------------------------------------
+
+    ----------------------------------------------------------------------
+
+    Burmese Word Break Dictionary Data (burmesedict.txt)
+
+     #  Copyright (c) 2014 International Business Machines Corporation
+     #  and others. All Rights Reserved.
+     #
+     #  This list is part of a project hosted at:
+     #    github.com/kanyawtech/myanmar-karen-word-lists
+     #
+     #  --------------------------------------------------------------------------
+     #  Copyright (c) 2013, LeRoy Benjamin Sharon
+     #  All rights reserved.
+     #
+     #  Redistribution and use in source and binary forms, with or without
+     #  modification, are permitted provided that the following conditions
+     #  are met: Redistributions of source code must retain the above
+     #  copyright notice, this list of conditions and the following
+     #  disclaimer.  Redistributions in binary form must reproduce the
+     #  above copyright notice, this list of conditions and the following
+     #  disclaimer in the documentation and/or other materials provided
+     #  with the distribution.
+     #
+     #    Neither the name Myanmar Karen Word Lists, nor the names of its
+     #    contributors may be used to endorse or promote products derived
+     #    from this software without specific prior written permission.
+     #
+     #  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+     #  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+     #  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+     #  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+     #  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+     #  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+     #  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+     #  TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+     #  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+     #  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+     #  TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+     #  THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+     #  SUCH DAMAGE.
+     #  --------------------------------------------------------------------------
+
+    ----------------------------------------------------------------------
+
+    Time Zone Database
+
+      ICU uses the public domain data and code derived from Time Zone
+    Database for its time zone support. The ownership of the TZ database
+    is explained in BCP 175: Procedure for Maintaining the Time Zone
+    Database section 7.
+
+     # 7.  Database Ownership
+     #
+     #    The TZ database itself is not an IETF Contribution or an IETF
+     #    document.  Rather it is a pre-existing and regularly updated work
+     #    that is in the public domain, and is intended to remain in the
+     #    public domain.  Therefore, BCPs 78 [RFC5378] and 79 [RFC3979] do
+     #    not apply to the TZ Database or contributions that individuals make
+     #    to it.  Should any claims be made and substantiated against the TZ
+     #    Database, the organization that is providing the IANA
+     #    Considerations defined in this RFC, under the memorandum of
+     #    understanding with the IETF, currently ICANN, may act in accordance
+     #    with all competent court orders.  No ownership claims will be made
+     #    by ICANN or the IETF Trust on the database or the code.  Any person
+     #    making a contribution to the database or code waives all rights to
+     #    future claims in that contribution or in the TZ Database.
+
+    ----------------------------------------------------------------------
+
+    Google double-conversion
+
+    Copyright 2006-2011, the V8 project authors. All rights reserved.
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+        * Redistributions of source code must retain the above copyright
+          notice, this list of conditions and the following disclaimer.
+        * Redistributions in binary form must reproduce the above
+          copyright notice, this list of conditions and the following
+          disclaimer in the documentation and/or other materials provided
+          with the distribution.
+        * Neither the name of Google Inc. nor the names of its
+          contributors may be used to endorse or promote products derived
+          from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+    ----------------------------------------------------------------------
+
+    JSON parsing library (nlohmann/json)
+
+    File: vendor/json/upstream/single_include/nlohmann/json.hpp (only for ICU4C)
+
+    MIT License
+
+    Copyright (c) 2013-2022 Niels Lohmann
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+
+    ----------------------------------------------------------------------
+
+    File: aclocal.m4 (only for ICU4C)
+    Section: pkg.m4 - Macros to locate and utilise pkg-config.
+
+    Copyright © 2004 Scott James Remnant .
+    Copyright © 2012-2015 Dan Nicholson
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+    02111-1307, USA.
+
+    As a special exception to the GNU General Public License, if you
+    distribute this file as part of a program that contains a
+    configuration script generated by Autoconf, you may include it under
+    the same distribution terms that you use for the rest of that
+    program.
+
+    (The condition for the exception is fulfilled because
+    ICU4C includes a configuration script generated by Autoconf,
+    namely the `configure` script.)
+
+    ----------------------------------------------------------------------
+
+    File: config.guess (only for ICU4C)
+
+    This file is free software; you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, see .
+
+    As a special exception to the GNU General Public License, if you
+    distribute this file as part of a program that contains a
+    configuration script generated by Autoconf, you may include it under
+    the same distribution terms that you use for the rest of that
+    program.  This Exception is an additional permission under section 7
+    of the GNU General Public License, version 3 ("GPLv3").
+
+    (The condition for the exception is fulfilled because
+    ICU4C includes a configuration script generated by Autoconf,
+    namely the `configure` script.)
+
+    ----------------------------------------------------------------------
+
+    File: install-sh (only for ICU4C)
+
+    Copyright 1991 by the Massachusetts Institute of Technology
+
+    Permission to use, copy, modify, distribute, and sell this software and its
+    documentation for any purpose is hereby granted without fee, provided that
+    the above copyright notice appear in all copies and that both that
+    copyright notice and this permission notice appear in supporting
+    documentation, and that the name of M.I.T. not be used in advertising or
+    publicity pertaining to distribution of the software without specific,
+    written prior permission.  M.I.T. makes no representations about the
+    suitability of this software for any purpose.  It is provided "as is"
+    without express or implied warranty.
+
+    ----------------------------------------------------------------------
+
+    File: sorttable.js (only for ICU4J)
+
+    The MIT Licence, for code from kryogenix.org
+
+    Code downloaded from the Browser Experiments section of kryogenix.org is
+    licenced under the so-called MIT licence. The licence is below.
+
+    Copyright (c) 1997-date Stuart Langridge
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+  """
+
+- libuv, located at deps/uv, is licensed as follows:
+  """
+    Copyright (c) 2015-present libuv project contributors.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to
+    deal in the Software without restriction, including without limitation the
+    rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+    sell copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+    IN THE SOFTWARE.
+    This license applies to parts of libuv originating from the
+    https://github.com/joyent/libuv repository:
+
+    ====
+
+    Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to
+    deal in the Software without restriction, including without limitation the
+    rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+    sell copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+    IN THE SOFTWARE.
+
+    ====
+
+    This license applies to all parts of libuv that are not externally
+    maintained libraries.
+
+    The externally maintained libraries used by libuv are:
+
+      - tree.h (from FreeBSD), copyright Niels Provos. Two clause BSD license.
+
+      - inet_pton and inet_ntop implementations, contained in src/inet.c, are
+        copyright the Internet Systems Consortium, Inc., and licensed under the ISC
+        license.
+  """
+
+- LIEF, located at deps/LIEF, is licensed as follows:
+  """
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2017 - 2025 R. Thomas
+   Copyright 2017 - 2025 Quarkslab
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+  """
+
+- llhttp, located at deps/llhttp, is licensed as follows:
+  """
+    This software is licensed under the MIT License.
+
+    Copyright Fedor Indutny, 2018.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to permit
+    persons to whom the Software is furnished to do so, subject to the
+    following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+    NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+    OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+    USE OR OTHER DEALINGS IN THE SOFTWARE.
+  """
+
+- corepack, located at deps/corepack, is licensed as follows:
+  """
+    **Copyright © Corepack contributors**
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  """
+
+- undici, located at deps/undici, is licensed as follows:
+  """
+    MIT License
+
+    Copyright (c) Matteo Collina and Undici contributors
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+  """
+
+- postject, located at test/fixtures/postject-copy, is licensed as follows:
+  """
+    Postject is licensed for use as follows:
+
+    """
+    MIT License
+
+    Copyright (c) 2022 Postman, Inc
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+    """
+
+    The Postject license applies to all parts of Postject that are not externally
+    maintained libraries.
+
+    The externally maintained libraries used by Postject are:
+
+    - LIEF, located at vendor/LIEF, is licensed as follows:
+      """
+                                         Apache License
+                                   Version 2.0, January 2004
+                                http://www.apache.org/licenses/
+
+           TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+           1. Definitions.
+
+              "License" shall mean the terms and conditions for use, reproduction,
+              and distribution as defined by Sections 1 through 9 of this document.
+
+              "Licensor" shall mean the copyright owner or entity authorized by
+              the copyright owner that is granting the License.
+
+              "Legal Entity" shall mean the union of the acting entity and all
+              other entities that control, are controlled by, or are under common
+              control with that entity. For the purposes of this definition,
+              "control" means (i) the power, direct or indirect, to cause the
+              direction or management of such entity, whether by contract or
+              otherwise, or (ii) ownership of fifty percent (50%) or more of the
+              outstanding shares, or (iii) beneficial ownership of such entity.
+
+              "You" (or "Your") shall mean an individual or Legal Entity
+              exercising permissions granted by this License.
+
+              "Source" form shall mean the preferred form for making modifications,
+              including but not limited to software source code, documentation
+              source, and configuration files.
+
+              "Object" form shall mean any form resulting from mechanical
+              transformation or translation of a Source form, including but
+              not limited to compiled object code, generated documentation,
+              and conversions to other media types.
+
+              "Work" shall mean the work of authorship, whether in Source or
+              Object form, made available under the License, as indicated by a
+              copyright notice that is included in or attached to the work
+              (an example is provided in the Appendix below).
+
+              "Derivative Works" shall mean any work, whether in Source or Object
+              form, that is based on (or derived from) the Work and for which the
+              editorial revisions, annotations, elaborations, or other modifications
+              represent, as a whole, an original work of authorship. For the purposes
+              of this License, Derivative Works shall not include works that remain
+              separable from, or merely link (or bind by name) to the interfaces of,
+              the Work and Derivative Works thereof.
+
+              "Contribution" shall mean any work of authorship, including
+              the original version of the Work and any modifications or additions
+              to that Work or Derivative Works thereof, that is intentionally
+              submitted to Licensor for inclusion in the Work by the copyright owner
+              or by an individual or Legal Entity authorized to submit on behalf of
+              the copyright owner. For the purposes of this definition, "submitted"
+              means any form of electronic, verbal, or written communication sent
+              to the Licensor or its representatives, including but not limited to
+              communication on electronic mailing lists, source code control systems,
+              and issue tracking systems that are managed by, or on behalf of, the
+              Licensor for the purpose of discussing and improving the Work, but
+              excluding communication that is conspicuously marked or otherwise
+              designated in writing by the copyright owner as "Not a Contribution."
+
+              "Contributor" shall mean Licensor and any individual or Legal Entity
+              on behalf of whom a Contribution has been received by Licensor and
+              subsequently incorporated within the Work.
+
+           2. Grant of Copyright License. Subject to the terms and conditions of
+              this License, each Contributor hereby grants to You a perpetual,
+              worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+              copyright license to reproduce, prepare Derivative Works of,
+              publicly display, publicly perform, sublicense, and distribute the
+              Work and such Derivative Works in Source or Object form.
+
+           3. Grant of Patent License. Subject to the terms and conditions of
+              this License, each Contributor hereby grants to You a perpetual,
+              worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+              (except as stated in this section) patent license to make, have made,
+              use, offer to sell, sell, import, and otherwise transfer the Work,
+              where such license applies only to those patent claims licensable
+              by such Contributor that are necessarily infringed by their
+              Contribution(s) alone or by combination of their Contribution(s)
+              with the Work to which such Contribution(s) was submitted. If You
+              institute patent litigation against any entity (including a
+              cross-claim or counterclaim in a lawsuit) alleging that the Work
+              or a Contribution incorporated within the Work constitutes direct
+              or contributory patent infringement, then any patent licenses
+              granted to You under this License for that Work shall terminate
+              as of the date such litigation is filed.
+
+           4. Redistribution. You may reproduce and distribute copies of the
+              Work or Derivative Works thereof in any medium, with or without
+              modifications, and in Source or Object form, provided that You
+              meet the following conditions:
+
+              (a) You must give any other recipients of the Work or
+                  Derivative Works a copy of this License; and
+
+              (b) You must cause any modified files to carry prominent notices
+                  stating that You changed the files; and
+
+              (c) You must retain, in the Source form of any Derivative Works
+                  that You distribute, all copyright, patent, trademark, and
+                  attribution notices from the Source form of the Work,
+                  excluding those notices that do not pertain to any part of
+                  the Derivative Works; and
+
+              (d) If the Work includes a "NOTICE" text file as part of its
+                  distribution, then any Derivative Works that You distribute must
+                  include a readable copy of the attribution notices contained
+                  within such NOTICE file, excluding those notices that do not
+                  pertain to any part of the Derivative Works, in at least one
+                  of the following places: within a NOTICE text file distributed
+                  as part of the Derivative Works; within the Source form or
+                  documentation, if provided along with the Derivative Works; or,
+                  within a display generated by the Derivative Works, if and
+                  wherever such third-party notices normally appear. The contents
+                  of the NOTICE file are for informational purposes only and
+                  do not modify the License. You may add Your own attribution
+                  notices within Derivative Works that You distribute, alongside
+                  or as an addendum to the NOTICE text from the Work, provided
+                  that such additional attribution notices cannot be construed
+                  as modifying the License.
+
+              You may add Your own copyright statement to Your modifications and
+              may provide additional or different license terms and conditions
+              for use, reproduction, or distribution of Your modifications, or
+              for any such Derivative Works as a whole, provided Your use,
+              reproduction, and distribution of the Work otherwise complies with
+              the conditions stated in this License.
+
+           5. Submission of Contributions. Unless You explicitly state otherwise,
+              any Contribution intentionally submitted for inclusion in the Work
+              by You to the Licensor shall be under the terms and conditions of
+              this License, without any additional terms or conditions.
+              Notwithstanding the above, nothing herein shall supersede or modify
+              the terms of any separate license agreement you may have executed
+              with Licensor regarding such Contributions.
+
+           6. Trademarks. This License does not grant permission to use the trade
+              names, trademarks, service marks, or product names of the Licensor,
+              except as required for reasonable and customary use in describing the
+              origin of the Work and reproducing the content of the NOTICE file.
+
+           7. Disclaimer of Warranty. Unless required by applicable law or
+              agreed to in writing, Licensor provides the Work (and each
+              Contributor provides its Contributions) on an "AS IS" BASIS,
+              WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+              implied, including, without limitation, any warranties or conditions
+              of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+              PARTICULAR PURPOSE. You are solely responsible for determining the
+              appropriateness of using or redistributing the Work and assume any
+              risks associated with Your exercise of permissions under this License.
+
+           8. Limitation of Liability. In no event and under no legal theory,
+              whether in tort (including negligence), contract, or otherwise,
+              unless required by applicable law (such as deliberate and grossly
+              negligent acts) or agreed to in writing, shall any Contributor be
+              liable to You for damages, including any direct, indirect, special,
+              incidental, or consequential damages of any character arising as a
+              result of this License or out of the use or inability to use the
+              Work (including but not limited to damages for loss of goodwill,
+              work stoppage, computer failure or malfunction, or any and all
+              other commercial damages or losses), even if such Contributor
+              has been advised of the possibility of such damages.
+
+           9. Accepting Warranty or Additional Liability. While redistributing
+              the Work or Derivative Works thereof, You may choose to offer,
+              and charge a fee for, acceptance of support, warranty, indemnity,
+              or other liability obligations and/or rights consistent with this
+              License. However, in accepting such obligations, You may act only
+              on Your own behalf and on Your sole responsibility, not on behalf
+              of any other Contributor, and only if You agree to indemnify,
+              defend, and hold each Contributor harmless for any liability
+              incurred by, or claims asserted against, such Contributor by reason
+              of your accepting any such warranty or additional liability.
+
+           END OF TERMS AND CONDITIONS
+
+           APPENDIX: How to apply the Apache License to your work.
+
+              To apply the Apache License to your work, attach the following
+              boilerplate notice, with the fields enclosed by brackets "{}"
+              replaced with your own identifying information. (Don't include
+              the brackets!)  The text should be enclosed in the appropriate
+              comment syntax for the file format. We also recommend that a
+              file or class name and description of purpose be included on the
+              same "printed page" as the copyright notice for easier
+              identification within third-party archives.
+
+           Copyright 2017 - 2022 R. Thomas
+           Copyright 2017 - 2022 Quarkslab
+
+           Licensed under the Apache License, Version 2.0 (the "License");
+           you may not use this file except in compliance with the License.
+           You may obtain a copy of the License at
+
+               http://www.apache.org/licenses/LICENSE-2.0
+
+           Unless required by applicable law or agreed to in writing, software
+           distributed under the License is distributed on an "AS IS" BASIS,
+           WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+           See the License for the specific language governing permissions and
+           limitations under the License.
+      """
+  """
+
+- OpenSSL, located at deps/openssl, is licensed as follows:
+  """
+                                     Apache License
+                               Version 2.0, January 2004
+                            https://www.apache.org/licenses/
+
+       TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+       1. Definitions.
+
+          "License" shall mean the terms and conditions for use, reproduction,
+          and distribution as defined by Sections 1 through 9 of this document.
+
+          "Licensor" shall mean the copyright owner or entity authorized by
+          the copyright owner that is granting the License.
+
+          "Legal Entity" shall mean the union of the acting entity and all
+          other entities that control, are controlled by, or are under common
+          control with that entity. For the purposes of this definition,
+          "control" means (i) the power, direct or indirect, to cause the
+          direction or management of such entity, whether by contract or
+          otherwise, or (ii) ownership of fifty percent (50%) or more of the
+          outstanding shares, or (iii) beneficial ownership of such entity.
+
+          "You" (or "Your") shall mean an individual or Legal Entity
+          exercising permissions granted by this License.
+
+          "Source" form shall mean the preferred form for making modifications,
+          including but not limited to software source code, documentation
+          source, and configuration files.
+
+          "Object" form shall mean any form resulting from mechanical
+          transformation or translation of a Source form, including but
+          not limited to compiled object code, generated documentation,
+          and conversions to other media types.
+
+          "Work" shall mean the work of authorship, whether in Source or
+          Object form, made available under the License, as indicated by a
+          copyright notice that is included in or attached to the work
+          (an example is provided in the Appendix below).
+
+          "Derivative Works" shall mean any work, whether in Source or Object
+          form, that is based on (or derived from) the Work and for which the
+          editorial revisions, annotations, elaborations, or other modifications
+          represent, as a whole, an original work of authorship. For the purposes
+          of this License, Derivative Works shall not include works that remain
+          separable from, or merely link (or bind by name) to the interfaces of,
+          the Work and Derivative Works thereof.
+
+          "Contribution" shall mean any work of authorship, including
+          the original version of the Work and any modifications or additions
+          to that Work or Derivative Works thereof, that is intentionally
+          submitted to Licensor for inclusion in the Work by the copyright owner
+          or by an individual or Legal Entity authorized to submit on behalf of
+          the copyright owner. For the purposes of this definition, "submitted"
+          means any form of electronic, verbal, or written communication sent
+          to the Licensor or its representatives, including but not limited to
+          communication on electronic mailing lists, source code control systems,
+          and issue tracking systems that are managed by, or on behalf of, the
+          Licensor for the purpose of discussing and improving the Work, but
+          excluding communication that is conspicuously marked or otherwise
+          designated in writing by the copyright owner as "Not a Contribution."
+
+          "Contributor" shall mean Licensor and any individual or Legal Entity
+          on behalf of whom a Contribution has been received by Licensor and
+          subsequently incorporated within the Work.
+
+       2. Grant of Copyright License. Subject to the terms and conditions of
+          this License, each Contributor hereby grants to You a perpetual,
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+          copyright license to reproduce, prepare Derivative Works of,
+          publicly display, publicly perform, sublicense, and distribute the
+          Work and such Derivative Works in Source or Object form.
+
+       3. Grant of Patent License. Subject to the terms and conditions of
+          this License, each Contributor hereby grants to You a perpetual,
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+          (except as stated in this section) patent license to make, have made,
+          use, offer to sell, sell, import, and otherwise transfer the Work,
+          where such license applies only to those patent claims licensable
+          by such Contributor that are necessarily infringed by their
+          Contribution(s) alone or by combination of their Contribution(s)
+          with the Work to which such Contribution(s) was submitted. If You
+          institute patent litigation against any entity (including a
+          cross-claim or counterclaim in a lawsuit) alleging that the Work
+          or a Contribution incorporated within the Work constitutes direct
+          or contributory patent infringement, then any patent licenses
+          granted to You under this License for that Work shall terminate
+          as of the date such litigation is filed.
+
+       4. Redistribution. You may reproduce and distribute copies of the
+          Work or Derivative Works thereof in any medium, with or without
+          modifications, and in Source or Object form, provided that You
+          meet the following conditions:
+
+          (a) You must give any other recipients of the Work or
+              Derivative Works a copy of this License; and
+
+          (b) You must cause any modified files to carry prominent notices
+              stating that You changed the files; and
+
+          (c) You must retain, in the Source form of any Derivative Works
+              that You distribute, all copyright, patent, trademark, and
+              attribution notices from the Source form of the Work,
+              excluding those notices that do not pertain to any part of
+              the Derivative Works; and
+
+          (d) If the Work includes a "NOTICE" text file as part of its
+              distribution, then any Derivative Works that You distribute must
+              include a readable copy of the attribution notices contained
+              within such NOTICE file, excluding those notices that do not
+              pertain to any part of the Derivative Works, in at least one
+              of the following places: within a NOTICE text file distributed
+              as part of the Derivative Works; within the Source form or
+              documentation, if provided along with the Derivative Works; or,
+              within a display generated by the Derivative Works, if and
+              wherever such third-party notices normally appear. The contents
+              of the NOTICE file are for informational purposes only and
+              do not modify the License. You may add Your own attribution
+              notices within Derivative Works that You distribute, alongside
+              or as an addendum to the NOTICE text from the Work, provided
+              that such additional attribution notices cannot be construed
+              as modifying the License.
+
+          You may add Your own copyright statement to Your modifications and
+          may provide additional or different license terms and conditions
+          for use, reproduction, or distribution of Your modifications, or
+          for any such Derivative Works as a whole, provided Your use,
+          reproduction, and distribution of the Work otherwise complies with
+          the conditions stated in this License.
+
+       5. Submission of Contributions. Unless You explicitly state otherwise,
+          any Contribution intentionally submitted for inclusion in the Work
+          by You to the Licensor shall be under the terms and conditions of
+          this License, without any additional terms or conditions.
+          Notwithstanding the above, nothing herein shall supersede or modify
+          the terms of any separate license agreement you may have executed
+          with Licensor regarding such Contributions.
+
+       6. Trademarks. This License does not grant permission to use the trade
+          names, trademarks, service marks, or product names of the Licensor,
+          except as required for reasonable and customary use in describing the
+          origin of the Work and reproducing the content of the NOTICE file.
+
+       7. Disclaimer of Warranty. Unless required by applicable law or
+          agreed to in writing, Licensor provides the Work (and each
+          Contributor provides its Contributions) on an "AS IS" BASIS,
+          WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+          implied, including, without limitation, any warranties or conditions
+          of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+          PARTICULAR PURPOSE. You are solely responsible for determining the
+          appropriateness of using or redistributing the Work and assume any
+          risks associated with Your exercise of permissions under this License.
+
+       8. Limitation of Liability. In no event and under no legal theory,
+          whether in tort (including negligence), contract, or otherwise,
+          unless required by applicable law (such as deliberate and grossly
+          negligent acts) or agreed to in writing, shall any Contributor be
+          liable to You for damages, including any direct, indirect, special,
+          incidental, or consequential damages of any character arising as a
+          result of this License or out of the use or inability to use the
+          Work (including but not limited to damages for loss of goodwill,
+          work stoppage, computer failure or malfunction, or any and all
+          other commercial damages or losses), even if such Contributor
+          has been advised of the possibility of such damages.
+
+       9. Accepting Warranty or Additional Liability. While redistributing
+          the Work or Derivative Works thereof, You may choose to offer,
+          and charge a fee for, acceptance of support, warranty, indemnity,
+          or other liability obligations and/or rights consistent with this
+          License. However, in accepting such obligations, You may act only
+          on Your own behalf and on Your sole responsibility, not on behalf
+          of any other Contributor, and only if You agree to indemnify,
+          defend, and hold each Contributor harmless for any liability
+          incurred by, or claims asserted against, such Contributor by reason
+          of your accepting any such warranty or additional liability.
+
+       END OF TERMS AND CONDITIONS
+  """
+
+- Punycode.js, located at lib/punycode.js, is licensed as follows:
+  """
+    Copyright Mathias Bynens <https://mathiasbynens.be/>
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to
+    permit persons to whom the Software is furnished to do so, subject to
+    the following conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+    LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+    OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+    WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  """
+
+- V8, located at deps/v8, is licensed as follows:
+  """
+    This license applies to all parts of V8 that are not externally
+    maintained libraries.  The externally maintained libraries used by V8
+    are:
+
+      - PCRE test suite, located in
+        test/mjsunit/third_party/regexp-pcre/regexp-pcre.js.  This is based on the
+        test suite from PCRE-7.3, which is copyrighted by the University
+        of Cambridge and Google, Inc.  The copyright notice and license
+        are embedded in regexp-pcre.js.
+
+      - Layout tests, located in test/mjsunit/third_party/object-keys.  These are
+        based on layout tests from webkit.org which are copyrighted by
+        Apple Computer, Inc. and released under a 3-clause BSD license.
+
+      - Strongtalk assembler, the basis of the files assembler-arm-inl.h,
+        assembler-arm.cc, assembler-arm.h, assembler-ia32-inl.h,
+        assembler-ia32.cc, assembler-ia32.h, assembler-x64-inl.h,
+        assembler-x64.cc, assembler-x64.h, assembler.cc and assembler.h.
+        This code is copyrighted by Sun Microsystems Inc. and released
+        under a 3-clause BSD license.
+
+      - Valgrind client API header, located at third_party/valgrind/valgrind.h
+        This is released under the BSD license.
+
+      - The Wasm C/C++ API headers, located at third_party/wasm-api/wasm.{h,hh}
+        This is released under the Apache license. The API's upstream prototype
+        implementation also formed the basis of V8's implementation in
+        src/wasm/c-api.cc.
+
+    These libraries have their own licenses; we recommend you read them,
+    as their terms may differ from the terms below.
+
+    Further license information can be found in LICENSE files located in
+    sub-directories.
+
+    Copyright 2014, the V8 project authors. All rights reserved.
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+        * Redistributions of source code must retain the above copyright
+          notice, this list of conditions and the following disclaimer.
+        * Redistributions in binary form must reproduce the above
+          copyright notice, this list of conditions and the following
+          disclaimer in the documentation and/or other materials provided
+          with the distribution.
+        * Neither the name of Google Inc. nor the names of its
+          contributors may be used to endorse or promote products derived
+          from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  """
+
+- SipHash, located at deps/v8/src/third_party/siphash, is licensed as follows:
+  """
+    SipHash reference C implementation
+
+    Copyright (c) 2016 Jean-Philippe Aumasson <jeanphilippe.aumasson@gmail.com>
+
+    To the extent possible under law, the author(s) have dedicated all
+    copyright and related and neighboring rights to this software to the public
+    domain worldwide. This software is distributed without any warranty.
+  """
+
+- zlib, located at deps/zlib, is licensed as follows:
+  """
+    zlib.h -- interface of the 'zlib' general purpose compression library
+    version 1.3.1, January 22nd, 2024
+
+    Copyright (C) 1995-2024 Jean-loup Gailly and Mark Adler
+
+    This software is provided 'as-is', without any express or implied
+    warranty.  In no event will the authors be held liable for any damages
+    arising from the use of this software.
+
+    Permission is granted to anyone to use this software for any purpose,
+    including commercial applications, and to alter it and redistribute it
+    freely, subject to the following restrictions:
+
+    1. The origin of this software must not be misrepresented; you must not
+    claim that you wrote the original software. If you use this software
+    in a product, an acknowledgment in the product documentation would be
+    appreciated but is not required.
+    2. Altered source versions must be plainly marked as such, and must not be
+    misrepresented as being the original software.
+    3. This notice may not be removed or altered from any source distribution.
+
+    Jean-loup Gailly        Mark Adler
+    jloup@gzip.org          madler@alumni.caltech.edu
+  """
+
+- simdjson, located at deps/simdjson, is licensed as follows:
+  """
+                                     Apache License
+                               Version 2.0, January 2004
+                            http://www.apache.org/licenses/
+
+       TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+       1. Definitions.
+
+          "License" shall mean the terms and conditions for use, reproduction,
+          and distribution as defined by Sections 1 through 9 of this document.
+
+          "Licensor" shall mean the copyright owner or entity authorized by
+          the copyright owner that is granting the License.
+
+          "Legal Entity" shall mean the union of the acting entity and all
+          other entities that control, are controlled by, or are under common
+          control with that entity. For the purposes of this definition,
+          "control" means (i) the power, direct or indirect, to cause the
+          direction or management of such entity, whether by contract or
+          otherwise, or (ii) ownership of fifty percent (50%) or more of the
+          outstanding shares, or (iii) beneficial ownership of such entity.
+
+          "You" (or "Your") shall mean an individual or Legal Entity
+          exercising permissions granted by this License.
+
+          "Source" form shall mean the preferred form for making modifications,
+          including but not limited to software source code, documentation
+          source, and configuration files.
+
+          "Object" form shall mean any form resulting from mechanical
+          transformation or translation of a Source form, including but
+          not limited to compiled object code, generated documentation,
+          and conversions to other media types.
+
+          "Work" shall mean the work of authorship, whether in Source or
+          Object form, made available under the License, as indicated by a
+          copyright notice that is included in or attached to the work
+          (an example is provided in the Appendix below).
+
+          "Derivative Works" shall mean any work, whether in Source or Object
+          form, that is based on (or derived from) the Work and for which the
+          editorial revisions, annotations, elaborations, or other modifications
+          represent, as a whole, an original work of authorship. For the purposes
+          of this License, Derivative Works shall not include works that remain
+          separable from, or merely link (or bind by name) to the interfaces of,
+          the Work and Derivative Works thereof.
+
+          "Contribution" shall mean any work of authorship, including
+          the original version of the Work and any modifications or additions
+          to that Work or Derivative Works thereof, that is intentionally
+          submitted to Licensor for inclusion in the Work by the copyright owner
+          or by an individual or Legal Entity authorized to submit on behalf of
+          the copyright owner. For the purposes of this definition, "submitted"
+          means any form of electronic, verbal, or written communication sent
+          to the Licensor or its representatives, including but not limited to
+          communication on electronic mailing lists, source code control systems,
+          and issue tracking systems that are managed by, or on behalf of, the
+          Licensor for the purpose of discussing and improving the Work, but
+          excluding communication that is conspicuously marked or otherwise
+          designated in writing by the copyright owner as "Not a Contribution."
+
+          "Contributor" shall mean Licensor and any individual or Legal Entity
+          on behalf of whom a Contribution has been received by Licensor and
+          subsequently incorporated within the Work.
+
+       2. Grant of Copyright License. Subject to the terms and conditions of
+          this License, each Contributor hereby grants to You a perpetual,
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+          copyright license to reproduce, prepare Derivative Works of,
+          publicly display, publicly perform, sublicense, and distribute the
+          Work and such Derivative Works in Source or Object form.
+
+       3. Grant of Patent License. Subject to the terms and conditions of
+          this License, each Contributor hereby grants to You a perpetual,
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+          (except as stated in this section) patent license to make, have made,
+          use, offer to sell, sell, import, and otherwise transfer the Work,
+          where such license applies only to those patent claims licensable
+          by such Contributor that are necessarily infringed by their
+          Contribution(s) alone or by combination of their Contribution(s)
+          with the Work to which such Contribution(s) was submitted. If You
+          institute patent litigation against any entity (including a
+          cross-claim or counterclaim in a lawsuit) alleging that the Work
+          or a Contribution incorporated within the Work constitutes direct
+          or contributory patent infringement, then any patent licenses
+          granted to You under this License for that Work shall terminate
+          as of the date such litigation is filed.
+
+       4. Redistribution. You may reproduce and distribute copies of the
+          Work or Derivative Works thereof in any medium, with or without
+          modifications, and in Source or Object form, provided that You
+          meet the following conditions:
+
+          (a) You must give any other recipients of the Work or
+              Derivative Works a copy of this License; and
+
+          (b) You must cause any modified files to carry prominent notices
+              stating that You changed the files; and
+
+          (c) You must retain, in the Source form of any Derivative Works
+              that You distribute, all copyright, patent, trademark, and
+              attribution notices from the Source form of the Work,
+              excluding those notices that do not pertain to any part of
+              the Derivative Works; and
+
+          (d) If the Work includes a "NOTICE" text file as part of its
+              distribution, then any Derivative Works that You distribute must
+              include a readable copy of the attribution notices contained
+              within such NOTICE file, excluding those notices that do not
+              pertain to any part of the Derivative Works, in at least one
+              of the following places: within a NOTICE text file distributed
+              as part of the Derivative Works; within the Source form or
+              documentation, if provided along with the Derivative Works; or,
+              within a display generated by the Derivative Works, if and
+              wherever such third-party notices normally appear. The contents
+              of the NOTICE file are for informational purposes only and
+              do not modify the License. You may add Your own attribution
+              notices within Derivative Works that You distribute, alongside
+              or as an addendum to the NOTICE text from the Work, provided
+              that such additional attribution notices cannot be construed
+              as modifying the License.
+
+          You may add Your own copyright statement to Your modifications and
+          may provide additional or different license terms and conditions
+          for use, reproduction, or distribution of Your modifications, or
+          for any such Derivative Works as a whole, provided Your use,
+          reproduction, and distribution of the Work otherwise complies with
+          the conditions stated in this License.
+
+       5. Submission of Contributions. Unless You explicitly state otherwise,
+          any Contribution intentionally submitted for inclusion in the Work
+          by You to the Licensor shall be under the terms and conditions of
+          this License, without any additional terms or conditions.
+          Notwithstanding the above, nothing herein shall supersede or modify
+          the terms of any separate license agreement you may have executed
+          with Licensor regarding such Contributions.
+
+       6. Trademarks. This License does not grant permission to use the trade
+          names, trademarks, service marks, or product names of the Licensor,
+          except as required for reasonable and customary use in describing the
+          origin of the Work and reproducing the content of the NOTICE file.
+
+       7. Disclaimer of Warranty. Unless required by applicable law or
+          agreed to in writing, Licensor provides the Work (and each
+          Contributor provides its Contributions) on an "AS IS" BASIS,
+          WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+          implied, including, without limitation, any warranties or conditions
+          of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+          PARTICULAR PURPOSE. You are solely responsible for determining the
+          appropriateness of using or redistributing the Work and assume any
+          risks associated with Your exercise of permissions under this License.
+
+       8. Limitation of Liability. In no event and under no legal theory,
+          whether in tort (including negligence), contract, or otherwise,
+          unless required by applicable law (such as deliberate and grossly
+          negligent acts) or agreed to in writing, shall any Contributor be
+          liable to You for damages, including any direct, indirect, special,
+          incidental, or consequential damages of any character arising as a
+          result of this License or out of the use or inability to use the
+          Work (including but not limited to damages for loss of goodwill,
+          work stoppage, computer failure or malfunction, or any and all
+          other commercial damages or losses), even if such Contributor
+          has been advised of the possibility of such damages.
+
+       9. Accepting Warranty or Additional Liability. While redistributing
+          the Work or Derivative Works thereof, You may choose to offer,
+          and charge a fee for, acceptance of support, warranty, indemnity,
+          or other liability obligations and/or rights consistent with this
+          License. However, in accepting such obligations, You may act only
+          on Your own behalf and on Your sole responsibility, not on behalf
+          of any other Contributor, and only if You agree to indemnify,
+          defend, and hold each Contributor harmless for any liability
+          incurred by, or claims asserted against, such Contributor by reason
+          of your accepting any such warranty or additional liability.
+
+       END OF TERMS AND CONDITIONS
+
+       APPENDIX: How to apply the Apache License to your work.
+
+          To apply the Apache License to your work, attach the following
+          boilerplate notice, with the fields enclosed by brackets "{}"
+          replaced with your own identifying information. (Don't include
+          the brackets!)  The text should be enclosed in the appropriate
+          comment syntax for the file format. We also recommend that a
+          file or class name and description of purpose be included on the
+          same "printed page" as the copyright notice for easier
+          identification within third-party archives.
+
+       Copyright 2018-2025 The simdjson authors
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+  """
+
+- simdutf, located at deps/v8/third_party/simdutf, is licensed as follows:
+  """
+    Copyright 2021 The simdutf authors
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+    the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  """
+
+- ada, located at deps/ada, is licensed as follows:
+  """
+    Copyright 2023 Yagiz Nizipli and Daniel Lemire
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+    the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  """
+
+- minimatch, located at deps/minimatch, is licensed as follows:
+  """
+    # Blue Oak Model License
+
+    Version 1.0.0
+
+    ## Purpose
+
+    This license gives everyone as much permission to work with
+    this software as possible, while protecting contributors
+    from liability.
+
+    ## Acceptance
+
+    In order to receive this license, you must agree to its
+    rules. The rules of this license are both obligations
+    under that agreement and conditions to your license.
+    You must not do anything with this software that triggers
+    a rule that you cannot or will not follow.
+
+    ## Copyright
+
+    Each contributor licenses you to do everything with this
+    software that would otherwise infringe that contributor's
+    copyright in it.
+
+    ## Notices
+
+    You must ensure that everyone who gets a copy of
+    any part of this software from you, with or without
+    changes, also gets the text of this license or a link to
+    <https://blueoakcouncil.org/license/1.0.0>.
+
+    ## Excuse
+
+    If anyone notifies you in writing that you have not
+    complied with [Notices](#notices), you can keep your
+    license by taking all practical steps to comply within 30
+    days after the notice. If you do not do so, your license
+    ends immediately.
+
+    ## Patent
+
+    Each contributor licenses you to do everything with this
+    software that would otherwise infringe any patent claims
+    they can license or become able to license.
+
+    ## Reliability
+
+    No contributor can revoke this license.
+
+    ## No Liability
+
+    **_As far as the law allows, this software comes as is,
+    without any warranty or condition, and no contributor
+    will be liable to anyone for any damages related to this
+    software or this license, under any kind of legal claim._**
+  """
+
+- npm, located at deps/npm, is licensed as follows:
+  """
+    The npm application
+    Copyright (c) npm, Inc. and Contributors
+    Licensed on the terms of The Artistic License 2.0
+
+    Node package dependencies of the npm application
+    Copyright (c) their respective copyright owners
+    Licensed on their respective license terms
+
+    The npm public registry at https://registry.npmjs.org
+    and the npm website at https://www.npmjs.com
+    Operated by npm, Inc.
+    Use governed by terms published on https://www.npmjs.com
+
+    "Node.js"
+    Trademark Joyent, Inc., https://joyent.com
+    Neither npm nor npm, Inc. are affiliated with Joyent, Inc.
+
+    The Node.js application
+    Project of Node Foundation, https://nodejs.org
+
+    The npm Logo
+    Copyright (c) Mathias Pettersson and Brian Hammond
+
+    "Gubblebum Blocky" typeface
+    Copyright (c) Tjarda Koster, https://jelloween.deviantart.com
+    Used with permission
+
+    --------
+
+    The Artistic License 2.0
+
+    Copyright (c) 2000-2006, The Perl Foundation.
+
+    Everyone is permitted to copy and distribute verbatim copies
+    of this license document, but changing it is not allowed.
+
+    Preamble
+
+    This license establishes the terms under which a given free software
+    Package may be copied, modified, distributed, and/or redistributed.
+    The intent is that the Copyright Holder maintains some artistic
+    control over the development of that Package while still keeping the
+    Package available as open source and free software.
+
+    You are always permitted to make arrangements wholly outside of this
+    license directly with the Copyright Holder of a given Package.  If the
+    terms of this license do not permit the full use that you propose to
+    make of the Package, you should contact the Copyright Holder and seek
+    a different licensing arrangement.
+
+    Definitions
+
+        "Copyright Holder" means the individual(s) or organization(s)
+        named in the copyright notice for the entire Package.
+
+        "Contributor" means any party that has contributed code or other
+        material to the Package, in accordance with the Copyright Holder's
+        procedures.
+
+        "You" and "your" means any person who would like to copy,
+        distribute, or modify the Package.
+
+        "Package" means the collection of files distributed by the
+        Copyright Holder, and derivatives of that collection and/or of
+        those files. A given Package may consist of either the Standard
+        Version, or a Modified Version.
+
+        "Distribute" means providing a copy of the Package or making it
+        accessible to anyone else, or in the case of a company or
+        organization, to others outside of your company or organization.
+
+        "Distributor Fee" means any fee that you charge for Distributing
+        this Package or providing support for this Package to another
+        party.  It does not mean licensing fees.
+
+        "Standard Version" refers to the Package if it has not been
+        modified, or has been modified only in ways explicitly requested
+        by the Copyright Holder.
+
+        "Modified Version" means the Package, if it has been changed, and
+        such changes were not explicitly requested by the Copyright
+        Holder.
+
+        "Original License" means this Artistic License as Distributed with
+        the Standard Version of the Package, in its current version or as
+        it may be modified by The Perl Foundation in the future.
+
+        "Source" form means the source code, documentation source, and
+        configuration files for the Package.
+
+        "Compiled" form means the compiled bytecode, object code, binary,
+        or any other form resulting from mechanical transformation or
+        translation of the Source form.
+
+    Permission for Use and Modification Without Distribution
+
+    (1)  You are permitted to use the Standard Version and create and use
+    Modified Versions for any purpose without restriction, provided that
+    you do not Distribute the Modified Version.
+
+    Permissions for Redistribution of the Standard Version
+
+    (2)  You may Distribute verbatim copies of the Source form of the
+    Standard Version of this Package in any medium without restriction,
+    either gratis or for a Distributor Fee, provided that you duplicate
+    all of the original copyright notices and associated disclaimers.  At
+    your discretion, such verbatim copies may or may not include a
+    Compiled form of the Package.
+
+    (3)  You may apply any bug fixes, portability changes, and other
+    modifications made available from the Copyright Holder.  The resulting
+    Package will still be considered the Standard Version, and as such
+    will be subject to the Original License.
+
+    Distribution of Modified Versions of the Package as Source
+
+    (4)  You may Distribute your Modified Version as Source (either gratis
+    or for a Distributor Fee, and with or without a Compiled form of the
+    Modified Version) provided that you clearly document how it differs
+    from the Standard Version, including, but not limited to, documenting
+    any non-standard features, executables, or modules, and provided that
+    you do at least ONE of the following:
+
+        (a)  make the Modified Version available to the Copyright Holder
+        of the Standard Version, under the Original License, so that the
+        Copyright Holder may include your modifications in the Standard
+        Version.
+
+        (b)  ensure that installation of your Modified Version does not
+        prevent the user installing or running the Standard Version. In
+        addition, the Modified Version must bear a name that is different
+        from the name of the Standard Version.
+
+        (c)  allow anyone who receives a copy of the Modified Version to
+        make the Source form of the Modified Version available to others
+        under
+
+            (i)  the Original License or
+
+            (ii)  a license that permits the licensee to freely copy,
+            modify and redistribute the Modified Version using the same
+            licensing terms that apply to the copy that the licensee
+            received, and requires that the Source form of the Modified
+            Version, and of any works derived from it, be made freely
+            available in that license fees are prohibited but Distributor
+            Fees are allowed.
+
+    Distribution of Compiled Forms of the Standard Version
+    or Modified Versions without the Source
+
+    (5)  You may Distribute Compiled forms of the Standard Version without
+    the Source, provided that you include complete instructions on how to
+    get the Source of the Standard Version.  Such instructions must be
+    valid at the time of your distribution.  If these instructions, at any
+    time while you are carrying out such distribution, become invalid, you
+    must provide new instructions on demand or cease further distribution.
+    If you provide valid instructions or cease distribution within thirty
+    days after you become aware that the instructions are invalid, then
+    you do not forfeit any of your rights under this license.
+
+    (6)  You may Distribute a Modified Version in Compiled form without
+    the Source, provided that you comply with Section 4 with respect to
+    the Source of the Modified Version.
+
+    Aggregating or Linking the Package
+
+    (7)  You may aggregate the Package (either the Standard Version or
+    Modified Version) with other packages and Distribute the resulting
+    aggregation provided that you do not charge a licensing fee for the
+    Package.  Distributor Fees are permitted, and licensing fees for other
+    components in the aggregation are permitted. The terms of this license
+    apply to the use and Distribution of the Standard or Modified Versions
+    as included in the aggregation.
+
+    (8) You are permitted to link Modified and Standard Versions with
+    other works, to embed the Package in a larger work of your own, or to
+    build stand-alone binary or bytecode versions of applications that
+    include the Package, and Distribute the result without restriction,
+    provided the result does not expose a direct interface to the Package.
+
+    Items That are Not Considered Part of a Modified Version
+
+    (9) Works (including, but not limited to, modules and scripts) that
+    merely extend or make use of the Package, do not, by themselves, cause
+    the Package to be a Modified Version.  In addition, such works are not
+    considered parts of the Package itself, and are not subject to the
+    terms of this license.
+
+    General Provisions
+
+    (10)  Any use, modification, and distribution of the Standard or
+    Modified Versions is governed by this Artistic License. By using,
+    modifying or distributing the Package, you accept this license. Do not
+    use, modify, or distribute the Package, if you do not accept this
+    license.
+
+    (11)  If your Modified Version has been derived from a Modified
+    Version made by someone other than you, you are nevertheless required
+    to ensure that your Modified Version complies with the requirements of
+    this license.
+
+    (12)  This license does not grant you the right to use any trademark,
+    service mark, tradename, or logo of the Copyright Holder.
+
+    (13)  This license includes the non-exclusive, worldwide,
+    free-of-charge patent license to make, have made, use, offer to sell,
+    sell, import and otherwise transfer the Package with respect to any
+    patent claims licensable by the Copyright Holder that are necessarily
+    infringed by the Package. If you institute patent litigation
+    (including a cross-claim or counterclaim) against any party alleging
+    that the Package constitutes direct or contributory patent
+    infringement, then this Artistic License to you shall terminate on the
+    date that such litigation is filed.
+
+    (14)  Disclaimer of Warranty:
+    THE PACKAGE IS PROVIDED BY THE COPYRIGHT HOLDER AND CONTRIBUTORS "AS
+    IS' AND WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES. THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, OR
+    NON-INFRINGEMENT ARE DISCLAIMED TO THE EXTENT PERMITTED BY YOUR LOCAL
+    LAW. UNLESS REQUIRED BY LAW, NO COPYRIGHT HOLDER OR CONTRIBUTOR WILL
+    BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+    DAMAGES ARISING IN ANY WAY OUT OF THE USE OF THE PACKAGE, EVEN IF
+    ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+    --------
+  """
+
+- GYP, located at tools/gyp, is licensed as follows:
+  """
+    Copyright (c) 2020 Node.js contributors. All rights reserved.
+    Copyright (c) 2009 Google Inc. All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+       * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+       * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following disclaimer
+    in the documentation and/or other materials provided with the
+    distribution.
+       * Neither the name of Google Inc. nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  """
+
+- inspector_protocol, located at deps/inspector_protocol, is licensed as follows:
+  """
+    // Copyright 2016 The Chromium Authors.
+    //
+    // Redistribution and use in source and binary forms, with or without
+    // modification, are permitted provided that the following conditions are
+    // met:
+    //
+    //    * Redistributions of source code must retain the above copyright
+    // notice, this list of conditions and the following disclaimer.
+    //    * Redistributions in binary form must reproduce the above
+    // copyright notice, this list of conditions and the following disclaimer
+    // in the documentation and/or other materials provided with the
+    // distribution.
+    //    * Neither the name of Google Inc. nor the names of its
+    // contributors may be used to endorse or promote products derived from
+    // this software without specific prior written permission.
+    //
+    // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    // A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    // OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    // SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    // LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    // DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  """
+
+- jinja2, located at tools/inspector_protocol/jinja2, is licensed as follows:
+  """
+    Copyright (c) 2009 by the Jinja Team, see AUTHORS for more details.
+
+    Some rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+        * Redistributions of source code must retain the above copyright
+          notice, this list of conditions and the following disclaimer.
+
+        * Redistributions in binary form must reproduce the above
+          copyright notice, this list of conditions and the following
+          disclaimer in the documentation and/or other materials provided
+          with the distribution.
+
+        * The names of the contributors may not be used to endorse or
+          promote products derived from this software without specific
+          prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  """
+
+- markupsafe, located at tools/inspector_protocol/markupsafe, is licensed as follows:
+  """
+    Copyright (c) 2010 by Armin Ronacher and contributors.  See AUTHORS
+    for more details.
+
+    Some rights reserved.
+
+    Redistribution and use in source and binary forms of the software as well
+    as documentation, with or without modification, are permitted provided
+    that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * The names of the contributors may not be used to endorse or
+      promote products derived from this software without specific
+      prior written permission.
+
+    THIS SOFTWARE AND DOCUMENTATION IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+    CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+    NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+    OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+    EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+    PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+    PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+    LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+    NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE AND DOCUMENTATION, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+    DAMAGE.
+  """
+
+- cpplint.py, located at tools/cpplint.py, is licensed as follows:
+  """
+    Copyright (c) 2009 Google Inc. All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+       * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+       * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following disclaimer
+    in the documentation and/or other materials provided with the
+    distribution.
+       * Neither the name of Google Inc. nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  """
+
+- gypi_to_gn.py, located at tools/gypi_to_gn.py, is licensed as follows:
+  """
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+       * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+       * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following disclaimer
+    in the documentation and/or other materials provided with the
+    distribution.
+       * Neither the name of Google LLC nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  """
+
+- gtest, located at deps/googletest, is licensed as follows:
+  """
+    Copyright 2008, Google Inc.
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+        * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+        * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following disclaimer
+    in the documentation and/or other materials provided with the
+    distribution.
+        * Neither the name of Google Inc. nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  """
+
+- nghttp2, located at deps/nghttp2, is licensed as follows:
+  """
+    The MIT License
+
+    Copyright (c) 2012, 2014, 2015, 2016 Tatsuhiro Tsujikawa
+    Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to
+    permit persons to whom the Software is furnished to do so, subject to
+    the following conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+    LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+    OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+    WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  """
+
+- large_pages, located at src/large_pages, is licensed as follows:
+  """
+     Copyright (C) 2018 Intel Corporation
+
+     Permission is hereby granted, free of charge, to any person obtaining a copy
+     of this software and associated documentation files (the "Software"),
+     to deal in the Software without restriction, including without limitation
+     the rights to use, copy, modify, merge, publish, distribute, sublicense,
+     and/or sell copies of the Software, and to permit persons to whom
+     the Software is furnished to do so, subject to the following conditions:
+
+     The above copyright notice and this permission notice shall be included
+     in all copies or substantial portions of the Software.
+
+     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+     OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+     THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+     OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+     ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+     OR OTHER DEALINGS IN THE SOFTWARE.
+  """
+
+- caja, located at lib/internal/freeze_intrinsics.js, is licensed as follows:
+  """
+     Adapted from SES/Caja - Copyright (C) 2011 Google Inc.
+     Copyright (C) 2018 Agoric
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+  """
+
+- brotli, located at deps/brotli, is licensed as follows:
+  """
+    Copyright (c) 2009, 2010, 2013-2016 by the Brotli Authors.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+  """
+
+- zstd, located at deps/zstd, is licensed as follows:
+  """
+    BSD License
+
+    For Zstandard software
+
+    Copyright (c) Meta Platforms, Inc. and affiliates. All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without modification,
+    are permitted provided that the following conditions are met:
+
+     * Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+
+     * Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+
+     * Neither the name Facebook, nor Meta, nor the names of its contributors may
+       be used to endorse or promote products derived from this software without
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+    ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  """
+
+- HdrHistogram, located at deps/histogram, is licensed as follows:
+  """
+    The code in this repository code was Written by Gil Tene, Michael Barker,
+    and Matt Warren, and released to the public domain, as explained at
+    http://creativecommons.org/publicdomain/zero/1.0/
+
+    For users of this code who wish to consume it under the "BSD" license
+    rather than under the public domain or CC0 contribution text mentioned
+    above, the code found under this directory is *also* provided under the
+    following license (commonly referred to as the BSD 2-Clause License). This
+    license does not detract from the above stated release of the code into
+    the public domain, and simply represents an additional license granted by
+    the Author.
+
+    -----------------------------------------------------------------------------
+    ** Beginning of "BSD 2-Clause License" text. **
+
+     Copyright (c) 2012, 2013, 2014 Gil Tene
+     Copyright (c) 2014 Michael Barker
+     Copyright (c) 2014 Matt Warren
+     All rights reserved.
+
+     Redistribution and use in source and binary forms, with or without
+     modification, are permitted provided that the following conditions are met:
+
+     1. Redistributions of source code must retain the above copyright notice,
+        this list of conditions and the following disclaimer.
+
+     2. Redistributions in binary form must reproduce the above copyright notice,
+        this list of conditions and the following disclaimer in the documentation
+        and/or other materials provided with the distribution.
+
+     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+     AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+     IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+     ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+     LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+     CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+     SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+     INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+     CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+     ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+     THE POSSIBILITY OF SUCH DAMAGE.
+  """
+
+- node-heapdump, located at src/heap_utils.cc, is licensed as follows:
+  """
+    ISC License
+
+    Copyright (c) 2012, Ben Noordhuis <info@bnoordhuis.nl>
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+    MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+    === src/compat.h src/compat-inl.h ===
+
+    ISC License
+
+    Copyright (c) 2014, StrongLoop Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+    MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+  """
+
+- rimraf, located at lib/internal/fs/rimraf.js, is licensed as follows:
+  """
+    The ISC License
+
+    Copyright (c) Isaac Z. Schlueter and Contributors
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+    MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+    IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+  """
+
+- uvwasi, located at deps/uvwasi, is licensed as follows:
+  """
+    MIT License
+
+    Copyright (c) 2019 Colin Ihrig and Contributors
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+  """
+
+- ngtcp2, located at deps/ngtcp2/ngtcp2/, is licensed as follows:
+  """
+    The MIT License
+
+    Copyright (c) 2016 ngtcp2 contributors
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to
+    permit persons to whom the Software is furnished to do so, subject to
+    the following conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+    LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+    OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+    WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  """
+
+- nghttp3, located at deps/ngtcp2/nghttp3/, is licensed as follows:
+  """
+    The MIT License
+
+    Copyright (c) 2019 nghttp3 contributors
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to
+    permit persons to whom the Software is furnished to do so, subject to
+    the following conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+    LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+    OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+    WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  """
+
+- node-fs-extra, located at lib/internal/fs/cp, is licensed as follows:
+  """
+    (The MIT License)
+
+    Copyright (c) 2011-2017 JP Richardson
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files
+    (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify,
+     merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+     furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+    WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+    OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+     ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  """
+
+- on-exit-leak-free, located at lib/internal/process/finalization, is licensed as follows:
+  """
+    MIT License
+
+    Copyright (c) 2021 Matteo Collina
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+  """
+
+- sonic-boom, located at lib/internal/streams/fast-utf8-stream.js, is licensed as follows:
+  """
+    MIT License
+
+    Copyright (c) 2017 Matteo Collina
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+  """

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -1,0 +1,927 @@
+# Node.js
+
+Node.js is an open-source, cross-platform JavaScript runtime environment.
+
+For information on using Node.js, see the [Node.js website][].
+
+The Node.js project uses an [open governance model](./GOVERNANCE.md). The
+[OpenJS Foundation][] provides support for the project.
+
+Contributors are expected to act in a collaborative manner to move
+the project forward. We encourage the constructive exchange of contrary
+opinions and compromise. The [TSC](./GOVERNANCE.md#technical-steering-committee)
+reserves the right to limit or block contributors who repeatedly act in ways
+that discourage, exhaust, or otherwise negatively affect other participants.
+
+**This project has a [Code of Conduct][].**
+
+## Table of contents
+
+* [Support](#support)
+* [Release types](#release-types)
+  * [Download](#download)
+    * [Current and LTS releases](#current-and-lts-releases)
+    * [Nightly releases](#nightly-releases)
+    * [API documentation](#api-documentation)
+  * [Verifying binaries](#verifying-binaries)
+* [Building Node.js](#building-nodejs)
+* [Security](#security)
+* [Contributing to Node.js](#contributing-to-nodejs)
+* [Current project team members](#current-project-team-members)
+  * [TSC (Technical Steering Committee)](#tsc-technical-steering-committee)
+  * [Collaborators](#collaborators)
+  * [Triagers](#triagers)
+  * [Release keys](#release-keys)
+* [License](#license)
+
+## Support
+
+Looking for help? Check out the
+[instructions for getting support](.github/SUPPORT.md).
+
+## Release types
+
+* **Current**: Under active development. Code for the Current release is in the
+  branch for its major version number (for example,
+  [v22.x](https://github.com/nodejs/node/tree/v22.x)). Node.js releases a new
+  major version every 6 months, allowing for breaking changes. This happens in
+  April and October every year. Releases appearing each October have a support
+  life of 8 months. Releases appearing each April convert to LTS (see below)
+  each October.
+* **LTS**: Releases that receive Long Term Support, with a focus on stability
+  and security. Every even-numbered major version will become an LTS release.
+  LTS releases receive 12 months of _Active LTS_ support and a further 18 months
+  of _Maintenance_. LTS release lines have alphabetically-ordered code names,
+  beginning with v4 Argon. There are no breaking changes or feature additions,
+  except in some special circumstances.
+* **Nightly**: Code from the Current branch built every 24-hours when there are
+  changes. Use with caution.
+
+Current and LTS releases follow [semantic versioning](https://semver.org). A
+member of the Release Team [signs](#release-keys) each Current and LTS release.
+For more information, see the
+[Release README](https://github.com/nodejs/Release#readme).
+
+### Download
+
+Binaries, installers, and source tarballs are available at
+<https://nodejs.org/en/download/>.
+
+#### Current and LTS releases
+
+<https://nodejs.org/download/release/>
+
+The [latest](https://nodejs.org/download/release/latest/) directory is an
+alias for the latest Current release. The latest-_codename_ directory is an
+alias for the latest release from an LTS line. For example, the
+[latest-hydrogen](https://nodejs.org/download/release/latest-hydrogen/)
+directory contains the latest Hydrogen (Node.js 18) release.
+
+#### Nightly releases
+
+<https://nodejs.org/download/nightly/>
+
+Each directory and filename includes the version (e.g., `v22.0.0`),
+followed by the UTC date (e.g., `20240424` for April 24, 2024),
+and the short commit SHA of the HEAD of the release (e.g., `ddd0a9e494`).
+For instance, a full directory name might look like `v22.0.0-nightly20240424ddd0a9e494`.
+
+#### API documentation
+
+Documentation for the latest Current release is at <https://nodejs.org/api/>.
+Version-specific documentation is available in each release directory in the
+_docs_ subdirectory. Version-specific documentation is also at
+<https://nodejs.org/download/docs/>.
+
+### Verifying binaries
+
+Download directories contain a `SHASUMS256.txt.asc` file with SHA checksums for the
+files and the releaser PGP signature.
+
+You can get a trusted keyring from nodejs/release-keys, e.g. using `curl`:
+
+```bash
+curl -fsLo "/path/to/nodejs-keyring.kbx" "https://github.com/nodejs/release-keys/raw/HEAD/gpg/pubring.kbx"
+```
+
+Alternatively, you can import the releaser keys in your default keyring, see
+[Release keys](#release-keys) for commands on how to do that.
+
+Then, you can verify the files you've downloaded locally
+(if you're using your default keyring, pass `--keyring="${GNUPGHOME:-~/.gnupg}/pubring.kbx"`):
+
+```bash
+curl -fsO "https://nodejs.org/dist/${VERSION}/SHASUMS256.txt.asc" \
+&& gpgv --keyring="/path/to/nodejs-keyring.kbx" --output SHASUMS256.txt < SHASUMS256.txt.asc \
+&& shasum --check SHASUMS256.txt --ignore-missing
+```
+
+## Building Node.js
+
+See [BUILDING.md](BUILDING.md) for instructions on how to build Node.js from
+source and a list of supported platforms.
+
+## Security
+
+For information on reporting security vulnerabilities in Node.js, see
+[SECURITY.md](./SECURITY.md).
+
+## Contributing to Node.js
+
+* [Contributing to the project][]
+* [Working Groups][]
+* [Strategic initiatives][]
+* [Technical values and prioritization][]
+
+## Current project team members
+
+For information about the governance of the Node.js project, see
+[GOVERNANCE.md](./GOVERNANCE.md).
+
+<!-- node-core-utils and find-inactive-tsc.mjs depend on the format of the TSC
+     list. If the format changes, those utilities need to be tested and
+     updated. -->
+
+### TSC (Technical Steering Committee)
+
+#### TSC voting members
+
+<!--lint disable prohibited-strings-->
+
+* [aduh95](https://github.com/aduh95) -
+  **Antoine du Hamel** <<duhamelantoine1995@gmail.com>> (he/him)
+* [anonrig](https://github.com/anonrig) -
+  **Yagiz Nizipli** <<yagiz@nizipli.com>> (he/him)
+* [benjamingr](https://github.com/benjamingr) -
+  **Benjamin Gruenbaum** <<benjamingr@gmail.com>>
+* [BridgeAR](https://github.com/BridgeAR) -
+  **Ruben Bridgewater** <<ruben@bridgewater.de>> (he/him)
+* [gireeshpunathil](https://github.com/gireeshpunathil) -
+  **Gireesh Punathil** <<gpunathi@in.ibm.com>> (he/him)
+* [jasnell](https://github.com/jasnell) -
+  **James M Snell** <<jasnell@gmail.com>> (he/him)
+* [joyeecheung](https://github.com/joyeecheung) -
+  **Joyee Cheung** <<joyeec9h3@gmail.com>> (she/her)
+* [legendecas](https://github.com/legendecas) -
+  **Chengzhong Wu** <<legendecas@gmail.com>> (he/him)
+* [marco-ippolito](https://github.com/marco-ippolito) -
+  **Marco Ippolito** <<marcoippolito54@gmail.com>> (he/him)
+* [mcollina](https://github.com/mcollina) -
+  **Matteo Collina** <<matteo.collina@gmail.com>> (he/him)
+* [panva](https://github.com/panva) -
+  **Filip Skokan** <<panva.ip@gmail.com>> (he/him)
+* [RafaelGSS](https://github.com/RafaelGSS) -
+  **Rafael Gonzaga** <<rafael.nunu@hotmail.com>> (he/him)
+* [RaisinTen](https://github.com/RaisinTen) -
+  **Darshan Sen** <<raisinten@gmail.com>> (he/him)
+* [richardlau](https://github.com/richardlau) -
+  **Richard Lau** <<richard.lau@ibm.com>>
+* [ronag](https://github.com/ronag) -
+  **Robert Nagy** <<ronagy@icloud.com>>
+* [ruyadorno](https://github.com/ruyadorno) -
+  **Ruy Adorno** <<ruy@vlt.sh>> (he/him)
+* [ShogunPanda](https://github.com/ShogunPanda) -
+  **Paolo Insogna** <<paolo@cowtech.it>> (he/him)
+* [targos](https://github.com/targos) -
+  **Michaël Zasso** <<targos@protonmail.com>> (he/him)
+* [tniessen](https://github.com/tniessen) -
+  **Tobias Nießen** <<tniessen@tnie.de>> (he/him)
+
+#### TSC regular members
+
+* [BethGriggs](https://github.com/BethGriggs) -
+  **Beth Griggs** <<bethanyngriggs@gmail.com>> (she/her)
+* [bnoordhuis](https://github.com/bnoordhuis) -
+  **Ben Noordhuis** <<info@bnoordhuis.nl>>
+* [cjihrig](https://github.com/cjihrig) -
+  **Colin Ihrig** <<cjihrig@gmail.com>> (he/him)
+* [codebytere](https://github.com/codebytere) -
+  **Shelley Vohr** <<shelley.vohr@gmail.com>> (she/her)
+* [GeoffreyBooth](https://github.com/GeoffreyBooth) -
+  **Geoffrey Booth** <<webadmin@geoffreybooth.com>> (he/him)
+* [MoLow](https://github.com/MoLow) -
+  **Moshe Atlow** <<moshe@atlow.co.il>> (he/him)
+* [Trott](https://github.com/Trott) -
+  **Rich Trott** <<rtrott@gmail.com>> (he/him)
+
+<details>
+
+<summary>TSC emeriti members</summary>
+
+#### TSC emeriti members
+
+* [addaleax](https://github.com/addaleax) -
+  **Anna Henningsen** <<anna@addaleax.net>> (she/her)
+* [apapirovski](https://github.com/apapirovski) -
+  **Anatoli Papirovski** <<apapirovski@mac.com>> (he/him)
+* [ChALkeR](https://github.com/ChALkeR) -
+  **Сковорода Никита Андреевич** <<chalkerx@gmail.com>> (he/him)
+* [chrisdickinson](https://github.com/chrisdickinson) -
+  **Chris Dickinson** <<christopher.s.dickinson@gmail.com>>
+* [danbev](https://github.com/danbev) -
+  **Daniel Bevenius** <<daniel.bevenius@gmail.com>> (he/him)
+* [danielleadams](https://github.com/danielleadams) -
+  **Danielle Adams** <<adamzdanielle@gmail.com>> (she/her)
+* [evanlucas](https://github.com/evanlucas) -
+  **Evan Lucas** <<evanlucas@me.com>> (he/him)
+* [fhinkel](https://github.com/fhinkel) -
+  **Franziska Hinkelmann** <<franziska.hinkelmann@gmail.com>> (she/her)
+* [Fishrock123](https://github.com/Fishrock123) -
+  **Jeremiah Senkpiel** <<fishrock123@rocketmail.com>> (he/they)
+* [gabrielschulhof](https://github.com/gabrielschulhof) -
+  **Gabriel Schulhof** <<gabrielschulhof@gmail.com>>
+* [gibfahn](https://github.com/gibfahn) -
+  **Gibson Fahnestock** <<gibfahn@gmail.com>> (he/him)
+* [indutny](https://github.com/indutny) -
+  **Fedor Indutny** <<fedor@indutny.com>>
+* [isaacs](https://github.com/isaacs) -
+  **Isaac Z. Schlueter** <<i@izs.me>>
+* [joshgav](https://github.com/joshgav) -
+  **Josh Gavant** <<josh.gavant@outlook.com>>
+* [mhdawson](https://github.com/mhdawson) -
+  **Michael Dawson** <<midawson@redhat.com>> (he/him)
+* [mmarchini](https://github.com/mmarchini) -
+  **Mary Marchini** <<oss@mmarchini.me>> (she/her)
+* [mscdex](https://github.com/mscdex) -
+  **Brian White** <<mscdex@mscdex.net>>
+* [MylesBorins](https://github.com/MylesBorins) -
+  **Myles Borins** <<myles.borins@gmail.com>> (he/him)
+* [nebrius](https://github.com/nebrius) -
+  **Bryan Hughes** <<bryan@nebri.us>>
+* [ofrobots](https://github.com/ofrobots) -
+  **Ali Ijaz Sheikh** <<ofrobots@google.com>> (he/him)
+* [orangemocha](https://github.com/orangemocha) -
+  **Alexis Campailla** <<orangemocha@nodejs.org>>
+* [piscisaureus](https://github.com/piscisaureus) -
+  **Bert Belder** <<bertbelder@gmail.com>>
+* [rvagg](https://github.com/rvagg) -
+  **Rod Vagg** <<r@va.gg>>
+* [sam-github](https://github.com/sam-github) -
+  **Sam Roberts** <<vieuxtech@gmail.com>>
+* [shigeki](https://github.com/shigeki) -
+  **Shigeki Ohtsu** <<ohtsu@ohtsu.org>> (he/him)
+* [thefourtheye](https://github.com/thefourtheye) -
+  **Sakthipriyan Vairamani** <<thechargingvolcano@gmail.com>> (he/him)
+* [TimothyGu](https://github.com/TimothyGu) -
+  **Tiancheng "Timothy" Gu** <<timothygu99@gmail.com>> (he/him)
+* [trevnorris](https://github.com/trevnorris) -
+  **Trevor Norris** <<trev.norris@gmail.com>>
+
+</details>
+
+<!-- node-core-utils and find-inactive-collaborators.mjs depend on the format
+     of the collaborator list. If the format changes, those utilities need to be
+     tested and updated. -->
+
+### Collaborators
+
+* [abmusse](https://github.com/abmusse) -
+  **Abdirahim Musse** <<abdirahim.musse@ibm.com>>
+* [addaleax](https://github.com/addaleax) -
+  **Anna Henningsen** <<anna@addaleax.net>> (she/her)
+* [Aditi-1400](https://github.com/Aditi-1400) -
+  **Aditi Singh** <<aditisingh1400@gmail.com>> (she/her)
+* [aduh95](https://github.com/aduh95) -
+  **Antoine du Hamel** <<duhamelantoine1995@gmail.com>> (he/him) - [Support me](https://github.com/sponsors/aduh95)
+* [anonrig](https://github.com/anonrig) -
+  **Yagiz Nizipli** <<yagiz@nizipli.com>> (he/him) - [Support me](https://github.com/sponsors/anonrig)
+* [atlowChemi](https://github.com/atlowChemi) -
+  **Chemi Atlow** <<chemi@atlow.co.il>> (he/him)
+* [avivkeller](https://github.com/avivkeller) -
+  **Aviv Keller** <<me@aviv.sh>> (he/him) - [Support me](https://github.com/sponsors/avivkeller)
+* [Ayase-252](https://github.com/Ayase-252) -
+  **Qingyu Deng** <<i@ayase-lab.com>>
+* [bengl](https://github.com/bengl) -
+  **Bryan English** <<bryan@bryanenglish.com>> (he/him)
+* [benjamingr](https://github.com/benjamingr) -
+  **Benjamin Gruenbaum** <<benjamingr@gmail.com>>
+* [BethGriggs](https://github.com/BethGriggs) -
+  **Beth Griggs** <<bethanyngriggs@gmail.com>> (she/her)
+* [bnb](https://github.com/bnb) -
+  **Tierney Cyren** <<hello@bnb.im>> (they/them)
+* [bnoordhuis](https://github.com/bnoordhuis) -
+  **Ben Noordhuis** <<info@bnoordhuis.nl>>
+* [BridgeAR](https://github.com/BridgeAR) -
+  **Ruben Bridgewater** <<ruben@bridgewater.de>> (he/him)
+* [cclauss](https://github.com/cclauss) -
+  **Christian Clauss** <<cclauss@me.com>> (he/him)
+* [ChALkeR](https://github.com/ChALkeR) -
+  **Сковорода Никита Андреевич** <<chalkerx@gmail.com>> (he/him)
+* [cjihrig](https://github.com/cjihrig) -
+  **Colin Ihrig** <<cjihrig@gmail.com>> (he/him)
+* [codebytere](https://github.com/codebytere) -
+  **Shelley Vohr** <<shelley.vohr@gmail.com>> (she/her)
+* [cola119](https://github.com/cola119) -
+  **Kohei Ueno** <<kohei.ueno119@gmail.com>> (he/him)
+* [daeyeon](https://github.com/daeyeon) -
+  **Daeyeon Jeong** <<daeyeon.dev@gmail.com>> (he/him)
+* [dario-piotrowicz](https://github.com/dario-piotrowicz) -
+  **Dario Piotrowicz** <<dario.piotrowicz@gmail.com>> (he/him)
+* [debadree25](https://github.com/debadree25) -
+  **Debadree Chatterjee** <<debadree333@gmail.com>> (he/him)
+* [deokjinkim](https://github.com/deokjinkim) -
+  **Deokjin Kim** <<deokjin81.kim@gmail.com>> (he/him)
+* [edsadr](https://github.com/edsadr) -
+  **Adrian Estrada** <<edsadr@gmail.com>> (he/him)
+* [ErickWendel](https://github.com/ErickWendel) -
+  **Erick Wendel** <<erick.workspace@gmail.com>> (he/him)
+* [Ethan-Arrowood](https://github.com/Ethan-Arrowood) -
+  **Ethan Arrowood** <<ethan@arrowood.dev>> (he/him)
+* [fhinkel](https://github.com/fhinkel) -
+  **Franziska Hinkelmann** <<franziska.hinkelmann@gmail.com>> (she/her)
+* [Flarna](https://github.com/Flarna) -
+  **Gerhard Stöbich** <<deb2001-github@yahoo.de>> (he/they)
+* [gabrielschulhof](https://github.com/gabrielschulhof) -
+  **Gabriel Schulhof** <<gabrielschulhof@gmail.com>>
+* [geeksilva97](https://github.com/geeksilva97) -
+  **Edy Silva** <<edigleyssonsilva@gmail.com>> (he/him)
+* [gengjiawen](https://github.com/gengjiawen) -
+  **Jiawen Geng** <<technicalcute@gmail.com>>
+* [GeoffreyBooth](https://github.com/GeoffreyBooth) -
+  **Geoffrey Booth** <<webadmin@geoffreybooth.com>> (he/him)
+* [gireeshpunathil](https://github.com/gireeshpunathil) -
+  **Gireesh Punathil** <<gpunathi@in.ibm.com>> (he/him)
+* [gurgunday](https://github.com/gurgunday) -
+  **Gürgün Dayıoğlu** <<hey@gurgun.day>> (he/him)
+* [guybedford](https://github.com/guybedford) -
+  **Guy Bedford** <<guybedford@gmail.com>> (he/him)
+* [H4ad](https://github.com/H4ad) -
+  **Vinícius Lourenço Claro Cardoso** <<contact@viniciusl.com.br>> (he/him)
+* [HarshithaKP](https://github.com/HarshithaKP) -
+  **Harshitha K P** <<harshitha014@gmail.com>> (she/her)
+* [himself65](https://github.com/himself65) -
+  **Zeyu "Alex" Yang** <<himself65@outlook.com>> (he/him)
+* [hybrist](https://github.com/hybrist) -
+  **Jan Martin** <<jan.krems@gmail.com>> (he/him)
+* [IlyasShabi](https://github.com/IlyasShabi) -
+  **Ilyas Shabi** <<ilyasshabi94@gmail.com>> (he/him)
+* [islandryu](https://github.com/islandryu) -
+  **Ryuhei Shima** <<shimaryuhei@gmail.com>> (he/him)
+* [jakecastelli](https://github.com/jakecastelli) -
+  **Jake Yuesong Li** <<jake.yuesong@gmail.com>> (he/him)
+* [JakobJingleheimer](https://github.com/JakobJingleheimer) -
+  **Jacob Smith** <<jacob@frende.me>> (he/him)
+* [jasnell](https://github.com/jasnell) -
+  **James M Snell** <<jasnell@gmail.com>> (he/him)
+* [jazelly](https://github.com/jazelly) -
+  **Jason Zhang** <<xzha4350@gmail.com>> (he/him)
+* [JonasBa](https://github.com/JonasBa) -
+  **Jonas Badalic** <<jonas.badalic@gmail.com>> (he/him)
+* [joyeecheung](https://github.com/joyeecheung) -
+  **Joyee Cheung** <<joyeec9h3@gmail.com>> (she/her)
+* [juanarbol](https://github.com/juanarbol) -
+  **Juan José Arboleda** <<soyjuanarbol@gmail.com>> (he/him)
+* [JungMinu](https://github.com/JungMinu) -
+  **Minwoo Jung** <<nodecorelab@gmail.com>> (he/him)
+* [KhafraDev](https://github.com/KhafraDev) -
+  **Matthew Aitken** <<maitken033380023@gmail.com>> (he/him)
+* [legendecas](https://github.com/legendecas) -
+  **Chengzhong Wu** <<legendecas@gmail.com>> (he/him)
+* [lemire](https://github.com/lemire) -
+  **Daniel Lemire** <<daniel@lemire.me>>
+* [LiviaMedeiros](https://github.com/LiviaMedeiros) -
+  **LiviaMedeiros** <<livia@cirno.name>>
+* [ljharb](https://github.com/ljharb) -
+  **Jordan Harband** <<ljharb@gmail.com>>
+* [lpinca](https://github.com/lpinca) -
+  **Luigi Pinca** <<luigipinca@gmail.com>> (he/him)
+* [Lxxyx](https://github.com/Lxxyx) -
+  **Zijian Liu** <<lxxyxzj@gmail.com>> (he/him)
+* [marco-ippolito](https://github.com/marco-ippolito) -
+  **Marco Ippolito** <<marcoippolito54@gmail.com>> (he/him) - [Support me](https://github.com/sponsors/marco-ippolito)
+* [marsonya](https://github.com/marsonya) -
+  **Akhil Marsonya** <<akhil.marsonya27@gmail.com>> (he/him)
+* [MattiasBuelens](https://github.com/MattiasBuelens) -
+  **Mattias Buelens** <<mattias@buelens.com>> (he/him)
+* [mcollina](https://github.com/mcollina) -
+  **Matteo Collina** <<matteo.collina@gmail.com>> (he/him) - [Support me](https://github.com/sponsors/mcollina)
+* [meixg](https://github.com/meixg) -
+  **Xuguang Mei** <<meixuguang@gmail.com>> (he/him)
+* [mhdawson](https://github.com/mhdawson) -
+  **Michael Dawson** <<midawson@redhat.com>> (he/him)
+* [MoLow](https://github.com/MoLow) -
+  **Moshe Atlow** <<moshe@atlow.co.il>> (he/him)
+* [MrJithil](https://github.com/MrJithil) -
+  **Jithil P Ponnan** <<jithil@outlook.com>> (he/him)
+* [ovflowd](https://github.com/ovflowd) -
+  **Claudio Wunder** <<cwunder@gnome.org>> (he/they)
+* [panva](https://github.com/panva) -
+  **Filip Skokan** <<panva.ip@gmail.com>> (he/him) - [Support me](https://github.com/sponsors/panva)
+* [pimterry](https://github.com/pimterry) -
+  **Tim Perry** <<pimterry@gmail.com>> (he/him)
+* [pmarchini](https://github.com/pmarchini) -
+  **Pietro Marchini** <<pietro.marchini94@gmail.com>> (he/him)
+* [puskin](https://github.com/puskin) -
+  **Giovanni Bucci** <<github@puskin.it>> (he/him)
+* [Qard](https://github.com/Qard) -
+  **Stephen Belanger** <<admin@stephenbelanger.com>> (he/him)
+* [RafaelGSS](https://github.com/RafaelGSS) -
+  **Rafael Gonzaga** <<rafael.nunu@hotmail.com>> (he/him) - [Support me](https://github.com/sponsors/RafaelGSS)
+* [RaisinTen](https://github.com/RaisinTen) -
+  **Darshan Sen** <<raisinten@gmail.com>> (he/him) - [Support me](https://github.com/sponsors/RaisinTen)
+* [Renegade334](https://github.com/Renegade334) -
+  **René** <<contact.9a5d6388@renegade334.me.uk>>
+* [richardlau](https://github.com/richardlau) -
+  **Richard Lau** <<richard.lau@ibm.com>>
+* [rluvaton](https://github.com/rluvaton) -
+  **Raz Luvaton** <<rluvaton@gmail.com>> (he/him)
+* [ronag](https://github.com/ronag) -
+  **Robert Nagy** <<ronagy@icloud.com>>
+* [ruyadorno](https://github.com/ruyadorno) -
+  **Ruy Adorno** <<ruy@vlt.sh>> (he/him)
+* [santigimeno](https://github.com/santigimeno) -
+  **Santiago Gimeno** <<santiago.gimeno@gmail.com>>
+* [ShogunPanda](https://github.com/ShogunPanda) -
+  **Paolo Insogna** <<paolo@cowtech.it>> (he/him)
+* [srl295](https://github.com/srl295) -
+  **Steven R Loomis** <<srl295@gmail.com>>
+* [StefanStojanovic](https://github.com/StefanStojanovic) -
+  **Stefan Stojanovic** <<stefan.stojanovic@janeasystems.com>> (he/him)
+* [sxa](https://github.com/sxa) -
+  **Stewart X Addison** <<sxa@redhat.com>> (he/him)
+* [targos](https://github.com/targos) -
+  **Michaël Zasso** <<targos@protonmail.com>> (he/him)
+* [theanarkh](https://github.com/theanarkh) -
+  **theanarkh** <<theratliter@gmail.com>> (he/him)
+* [tniessen](https://github.com/tniessen) -
+  **Tobias Nießen** <<tniessen@tnie.de>> (he/him)
+* [trivikr](https://github.com/trivikr) -
+  **Trivikram Kamat** <<trivikr.dev@gmail.com>>
+* [Trott](https://github.com/Trott) -
+  **Rich Trott** <<rtrott@gmail.com>> (he/him)
+* [UlisesGascon](https://github.com/UlisesGascon) -
+  **Ulises Gascón** <<ulisesgascongonzalez@gmail.com>> (he/him)
+* [vmoroz](https://github.com/vmoroz) -
+  **Vladimir Morozov** <<vmorozov@microsoft.com>> (he/him)
+* [VoltrexKeyva](https://github.com/VoltrexKeyva) -
+  **Mohammed Keyvanzadeh** <<mohammadkeyvanzade94@gmail.com>> (he/him)
+* [watilde](https://github.com/watilde) -
+  **Daijiro Wachi** <<daijiro.wachi@gmail.com>> (he/him)
+* [zcbenz](https://github.com/zcbenz) -
+  **Cheng Zhao** <<zcbenz@gmail.com>> (he/him)
+* [ZYSzys](https://github.com/ZYSzys) -
+  **Yongsheng Zhang** <<zyszys98@gmail.com>> (he/him)
+
+<details>
+
+<summary>Emeriti</summary>
+
+<!-- find-inactive-collaborators.mjs depends on the format of the emeriti list.
+     If the format changes, those utilities need to be tested and updated. -->
+
+### Collaborator emeriti
+
+* [ak239](https://github.com/ak239) -
+  **Aleksei Koziatinskii** <<ak239spb@gmail.com>>
+* [andrasq](https://github.com/andrasq) -
+  **Andras** <<andras@kinvey.com>>
+* [AndreasMadsen](https://github.com/AndreasMadsen) -
+  **Andreas Madsen** <<amwebdk@gmail.com>> (he/him)
+* [AnnaMag](https://github.com/AnnaMag) -
+  **Anna M. Kedzierska** <<anna.m.kedzierska@gmail.com>>
+* [antsmartian](https://github.com/antsmartian) -
+  **Anto Aravinth** <<anto.aravinth.cse@gmail.com>> (he/him)
+* [apapirovski](https://github.com/apapirovski) -
+  **Anatoli Papirovski** <<apapirovski@mac.com>> (he/him)
+* [aqrln](https://github.com/aqrln) -
+  **Alexey Orlenko** <<eaglexrlnk@gmail.com>> (he/him)
+* [AshCripps](https://github.com/AshCripps) -
+  **Ash Cripps** <<email@ashleycripps.co.uk>>
+* [bcoe](https://github.com/bcoe) -
+  **Ben Coe** <<bencoe@gmail.com>> (he/him)
+* [bmeck](https://github.com/bmeck) -
+  **Bradley Farias** <<bradley.meck@gmail.com>>
+* [bmeurer](https://github.com/bmeurer) -
+  **Benedikt Meurer** <<benedikt.meurer@gmail.com>>
+* [boneskull](https://github.com/boneskull) -
+  **Christopher Hiller** <<boneskull@boneskull.com>> (he/him)
+* [brendanashworth](https://github.com/brendanashworth) -
+  **Brendan Ashworth** <<brendan.ashworth@me.com>>
+* [bzoz](https://github.com/bzoz) -
+  **Bartosz Sosnowski** <<bartosz@janeasystems.com>>
+* [calvinmetcalf](https://github.com/calvinmetcalf) -
+  **Calvin Metcalf** <<calvin.metcalf@gmail.com>>
+* [chrisdickinson](https://github.com/chrisdickinson) -
+  **Chris Dickinson** <<christopher.s.dickinson@gmail.com>>
+* [claudiorodriguez](https://github.com/claudiorodriguez) -
+  **Claudio Rodriguez** <<cjrodr@yahoo.com>>
+* [danbev](https://github.com/danbev) -
+  **Daniel Bevenius** <<daniel.bevenius@gmail.com>> (he/him)
+* [danielleadams](https://github.com/danielleadams) -
+  **Danielle Adams** <<adamzdanielle@gmail.com>> (she/her)
+* [DavidCai1111](https://github.com/DavidCai1111) -
+  **David Cai** <<davidcai1993@yahoo.com>> (he/him)
+* [davisjam](https://github.com/davisjam) -
+  **Jamie Davis** <<davisjam@vt.edu>> (he/him)
+* [devnexen](https://github.com/devnexen) -
+  **David Carlier** <<devnexen@gmail.com>>
+* [devsnek](https://github.com/devsnek) -
+  **Gus Caplan** <<me@gus.host>> (they/them)
+* [digitalinfinity](https://github.com/digitalinfinity) -
+  **Hitesh Kanwathirtha** <<digitalinfinity@gmail.com>> (he/him)
+* [dmabupt](https://github.com/dmabupt) -
+  **Xu Meng** <<dmabupt@gmail.com>> (he/him)
+* [dnlup](https://github.com/dnlup) -
+  **dnlup** <<dnlup.dev@gmail.com>>
+* [eljefedelrodeodeljefe](https://github.com/eljefedelrodeodeljefe) -
+  **Robert Jefe Lindstaedt** <<robert.lindstaedt@gmail.com>>
+* [estliberitas](https://github.com/estliberitas) -
+  **Alexander Makarenko** <<estliberitas@gmail.com>>
+* [eugeneo](https://github.com/eugeneo) -
+  **Eugene Ostroukhov** <<eostroukhov@google.com>>
+* [evanlucas](https://github.com/evanlucas) -
+  **Evan Lucas** <<evanlucas@me.com>> (he/him)
+* [F3n67u](https://github.com/F3n67u) -
+  **Feng Yu** <<F3n67u@outlook.com>> (he/him)
+* [firedfox](https://github.com/firedfox) -
+  **Daniel Wang** <<wangyang0123@gmail.com>>
+* [Fishrock123](https://github.com/Fishrock123) -
+  **Jeremiah Senkpiel** <<fishrock123@rocketmail.com>> (he/they)
+* [gdams](https://github.com/gdams) -
+  **George Adams** <<gadams@microsoft.com>> (he/him)
+* [geek](https://github.com/geek) -
+  **Wyatt Preul** <<wpreul@gmail.com>>
+* [gibfahn](https://github.com/gibfahn) -
+  **Gibson Fahnestock** <<gibfahn@gmail.com>> (he/him)
+* [glentiki](https://github.com/glentiki) -
+  **Glen Keane** <<glenkeane.94@gmail.com>> (he/him)
+* [hashseed](https://github.com/hashseed) -
+  **Yang Guo** <<yangguo@chromium.org>> (he/him)
+* [hiroppy](https://github.com/hiroppy) -
+  **Yuta Hiroto** <<hello@hiroppy.me>> (he/him)
+* [iansu](https://github.com/iansu) -
+  **Ian Sutherland** <<ian@iansutherland.ca>>
+* [iarna](https://github.com/iarna) -
+  **Rebecca Turner** <<me@re-becca.org>>
+* [imran-iq](https://github.com/imran-iq) -
+  **Imran Iqbal** <<imran@imraniqbal.org>>
+* [imyller](https://github.com/imyller) -
+  **Ilkka Myller** <<ilkka.myller@nodefield.com>>
+* [indutny](https://github.com/indutny) -
+  **Fedor Indutny** <<fedor@indutny.com>>
+* [isaacs](https://github.com/isaacs) -
+  **Isaac Z. Schlueter** <<i@izs.me>>
+* [italoacasas](https://github.com/italoacasas) -
+  **Italo A. Casas** <<me@italoacasas.com>> (he/him)
+* [JacksonTian](https://github.com/JacksonTian) -
+  **Jackson Tian** <<shyvo1987@gmail.com>>
+* [jasongin](https://github.com/jasongin) -
+  **Jason Ginchereau** <<jasongin@microsoft.com>>
+* [jbergstroem](https://github.com/jbergstroem) -
+  **Johan Bergström** <<bugs@bergstroem.nu>>
+* [jdalton](https://github.com/jdalton) -
+  **John-David Dalton** <<john.david.dalton@gmail.com>>
+* [jhamhader](https://github.com/jhamhader) -
+  **Yuval Brik** <<yuval@brik.org.il>>
+* [joaocgreis](https://github.com/joaocgreis) -
+  **João Reis** <<reis@janeasystems.com>>
+* [joesepi](https://github.com/joesepi) -
+  **Joe Sepi** <<sepi@joesepi.com>> (he/him)
+* [joshgav](https://github.com/joshgav) -
+  **Josh Gavant** <<josh.gavant@outlook.com>>
+* [julianduque](https://github.com/julianduque) -
+  **Julian Duque** <<julianduquej@gmail.com>> (he/him)
+* [kfarnung](https://github.com/kfarnung) -
+  **Kyle Farnung** <<kfarnung@microsoft.com>> (he/him)
+* [kunalspathak](https://github.com/kunalspathak) -
+  **Kunal Pathak** <<kunal.pathak@microsoft.com>>
+* [kuriyosh](https://github.com/kuriyosh) -
+  **Yoshiki Kurihara** <<yosyos0306@gmail.com>> (he/him)
+* [kvakil](https://github.com/kvakil) -
+  **Keyhan Vakil** <<kvakil@sylph.kvakil.me>>
+* [lance](https://github.com/lance) -
+  **Lance Ball** <<lball@redhat.com>> (he/him)
+* [Leko](https://github.com/Leko) -
+  **Shingo Inoue** <<leko.noor@gmail.com>> (he/him)
+* [Linkgoron](https://github.com/Linkgoron) -
+  **Nitzan Uziely** <<linkgoron@gmail.com>>
+* [lucamaraschi](https://github.com/lucamaraschi) -
+  **Luca Maraschi** <<luca.maraschi@gmail.com>> (he/him)
+* [lukekarrys](https://github.com/lukekarrys) -
+  **Luke Karrys** <<luke@lukekarrys.com>> (he/him)
+* [lundibundi](https://github.com/lundibundi) -
+  **Denys Otrishko** <<shishugi@gmail.com>> (he/him)
+* [lxe](https://github.com/lxe) -
+  **Aleksey Smolenchuk** <<lxe@lxe.co>>
+* [maclover7](https://github.com/maclover7) -
+  **Jon Moss** <<me@jonathanmoss.me>> (he/him)
+* [mafintosh](https://github.com/mafintosh) -
+  **Mathias Buus** <<mathiasbuus@gmail.com>> (he/him)
+* [matthewloring](https://github.com/matthewloring) -
+  **Matthew Loring** <<mattloring@google.com>>
+* [Mesteery](https://github.com/Mesteery) -
+  **Mestery** <<mestery@protonmail.com>> (he/him)
+* [micnic](https://github.com/micnic) -
+  **Nicu Micleușanu** <<micnic90@gmail.com>> (he/him)
+* [mikeal](https://github.com/mikeal) -
+  **Mikeal Rogers** <<mikeal.rogers@gmail.com>>
+* [miladfarca](https://github.com/miladfarca) -
+  **Milad Fa** <<mfarazma@redhat.com>> (he/him)
+* [mildsunrise](https://github.com/mildsunrise) -
+  **Alba Mendez** <<me@alba.sh>> (she/her)
+* [misterdjules](https://github.com/misterdjules) -
+  **Julien Gilli** <<jgilli@netflix.com>>
+* [mmarchini](https://github.com/mmarchini) -
+  **Mary Marchini** <<oss@mmarchini.me>> (she/her)
+* [monsanto](https://github.com/monsanto) -
+  **Christopher Monsanto** <<chris@monsan.to>>
+* [MoonBall](https://github.com/MoonBall) -
+  **Chen Gang** <<gangc.cxy@foxmail.com>>
+* [mscdex](https://github.com/mscdex) -
+  **Brian White** <<mscdex@mscdex.net>>
+* [MylesBorins](https://github.com/MylesBorins) -
+  **Myles Borins** <<myles.borins@gmail.com>> (he/him)
+* [not-an-aardvark](https://github.com/not-an-aardvark) -
+  **Teddy Katz** <<teddy.katz@gmail.com>> (he/him)
+* [ofrobots](https://github.com/ofrobots) -
+  **Ali Ijaz Sheikh** <<ofrobots@google.com>> (he/him)
+* [Olegas](https://github.com/Olegas) -
+  **Oleg Elifantiev** <<oleg@elifantiev.ru>>
+* [orangemocha](https://github.com/orangemocha) -
+  **Alexis Campailla** <<orangemocha@nodejs.org>>
+* [othiym23](https://github.com/othiym23) -
+  **Forrest L Norvell** <<ogd@aoaioxxysz.net>> (they/them/themself)
+* [oyyd](https://github.com/oyyd) -
+  **Ouyang Yadong** <<oyydoibh@gmail.com>> (he/him)
+* [petkaantonov](https://github.com/petkaantonov) -
+  **Petka Antonov** <<petka_antonov@hotmail.com>>
+* [phillipj](https://github.com/phillipj) -
+  **Phillip Johnsen** <<johphi@gmail.com>>
+* [piscisaureus](https://github.com/piscisaureus) -
+  **Bert Belder** <<bertbelder@gmail.com>>
+* [pmq20](https://github.com/pmq20) -
+  **Minqi Pan** <<pmq2001@gmail.com>>
+* [PoojaDurgad](https://github.com/PoojaDurgad) -
+  **Pooja D P** <<Pooja.D.P@ibm.com>> (she/her)
+* [princejwesley](https://github.com/princejwesley) -
+  **Prince John Wesley** <<princejohnwesley@gmail.com>>
+* [psmarshall](https://github.com/psmarshall) -
+  **Peter Marshall** <<petermarshall@chromium.org>> (he/him)
+* [puzpuzpuz](https://github.com/puzpuzpuz) -
+  **Andrey Pechkurov** <<apechkurov@gmail.com>> (he/him)
+* [refack](https://github.com/refack) -
+  **Refael Ackermann (רפאל פלחי)** <<refack@gmail.com>> (he/him/הוא/אתה)
+* [rexagod](https://github.com/rexagod) -
+  **Pranshu Srivastava** <<rexagod@gmail.com>> (he/him)
+* [rickyes](https://github.com/rickyes) -
+  **Ricky Zhou** <<0x19951125@gmail.com>> (he/him)
+* [rlidwka](https://github.com/rlidwka) -
+  **Alex Kocharin** <<alex@kocharin.ru>>
+* [rmg](https://github.com/rmg) -
+  **Ryan Graham** <<r.m.graham@gmail.com>>
+* [robertkowalski](https://github.com/robertkowalski) -
+  **Robert Kowalski** <<rok@kowalski.gd>>
+* [romankl](https://github.com/romankl) -
+  **Roman Klauke** <<romaaan.git@gmail.com>>
+* [ronkorving](https://github.com/ronkorving) -
+  **Ron Korving** <<ron@ronkorving.nl>>
+* [RReverser](https://github.com/RReverser) -
+  **Ingvar Stepanyan** <<me@rreverser.com>>
+* [rubys](https://github.com/rubys) -
+  **Sam Ruby** <<rubys@intertwingly.net>>
+* [rvagg](https://github.com/rvagg) -
+  **Rod Vagg** <<rod@vagg.org>>
+* [ryzokuken](https://github.com/ryzokuken) -
+  **Ujjwal Sharma** <<ryzokuken@disroot.org>> (he/him)
+* [saghul](https://github.com/saghul) -
+  **Saúl Ibarra Corretgé** <<s@saghul.net>>
+* [sam-github](https://github.com/sam-github) -
+  **Sam Roberts** <<vieuxtech@gmail.com>>
+* [sebdeckers](https://github.com/sebdeckers) -
+  **Sebastiaan Deckers** <<sebdeckers83@gmail.com>>
+* [seishun](https://github.com/seishun) -
+  **Nikolai Vavilov** <<vvnicholas@gmail.com>>
+* [shigeki](https://github.com/shigeki) -
+  **Shigeki Ohtsu** <<ohtsu@ohtsu.org>> (he/him)
+* [shisama](https://github.com/shisama) -
+  **Masashi Hirano** <<shisama07@gmail.com>> (he/him)
+* [silverwind](https://github.com/silverwind) -
+  **Roman Reiss** <<me@silverwind.io>>
+* [starkwang](https://github.com/starkwang) -
+  **Weijia Wang** <<starkwang@126.com>>
+* [stefanmb](https://github.com/stefanmb) -
+  **Stefan Budeanu** <<stefan@budeanu.com>>
+* [tellnes](https://github.com/tellnes) -
+  **Christian Tellnes** <<christian@tellnes.no>>
+* [thefourtheye](https://github.com/thefourtheye) -
+  **Sakthipriyan Vairamani** <<thechargingvolcano@gmail.com>> (he/him)
+* [thlorenz](https://github.com/thlorenz) -
+  **Thorsten Lorenz** <<thlorenz@gmx.de>>
+* [TimothyGu](https://github.com/TimothyGu) -
+  **Tiancheng "Timothy" Gu** <<timothygu99@gmail.com>> (he/him)
+* [trevnorris](https://github.com/trevnorris) -
+  **Trevor Norris** <<trev.norris@gmail.com>>
+* [tunniclm](https://github.com/tunniclm) -
+  **Mike Tunnicliffe** <<m.j.tunnicliffe@gmail.com>>
+* [vdeturckheim](https://github.com/vdeturckheim) -
+  **Vladimir de Turckheim** <<vlad2t@hotmail.com>> (he/him)
+* [vkurchatkin](https://github.com/vkurchatkin) -
+  **Vladimir Kurchatkin** <<vladimir.kurchatkin@gmail.com>>
+* [vsemozhetbyt](https://github.com/vsemozhetbyt) -
+  **Vse Mozhet Byt** <<vsemozhetbyt@gmail.com>> (he/him)
+* [watson](https://github.com/watson) -
+  **Thomas Watson** <<w@tson.dk>>
+* [whitlockjc](https://github.com/whitlockjc) -
+  **Jeremy Whitlock** <<jwhitlock@apache.org>>
+* [XadillaX](https://github.com/XadillaX) -
+  **Khaidi Chu** <<i@2333.moe>> (he/him)
+* [yashLadha](https://github.com/yashLadha) -
+  **Yash Ladha** <<yash@yashladha.in>> (he/him)
+* [yhwang](https://github.com/yhwang) -
+  **Yihong Wang** <<yh.wang@ibm.com>>
+* [yorkie](https://github.com/yorkie) -
+  **Yorkie Liu** <<yorkiefixer@gmail.com>>
+* [yosuke-furukawa](https://github.com/yosuke-furukawa) -
+  **Yosuke Furukawa** <<yosuke.furukawa@gmail.com>>
+
+</details>
+
+<!--lint enable prohibited-strings-->
+
+Collaborators follow the [Collaborator Guide](./doc/contributing/collaborator-guide.md) in
+maintaining the Node.js project.
+
+### Triagers
+
+* [1ilsang](https://github.com/1ilsang) -
+  **Sangchul Lee** <<1ilsang.dev@gmail.com>> (he/him)
+* [atlowChemi](https://github.com/atlowChemi) -
+  **Chemi Atlow** <<chemi@atlow.co.il>> (he/him)
+* [Ayase-252](https://github.com/Ayase-252) -
+  **Qingyu Deng** <<i@ayase-lab.com>>
+* [bjohansebas](https://github.com/bjohansebas) -
+  **Sebastian Beltran** <<bjohansebas@gmail.com>>
+* [bmuenzenmeyer](https://github.com/bmuenzenmeyer) -
+  **Brian Muenzenmeyer** <<brian.muenzenmeyer@gmail.com>> (he/him)
+* [CanadaHonk](https://github.com/CanadaHonk) -
+  **Oliver Medhurst** <<honk@goose.icu>> (they/them)
+* [daeyeon](https://github.com/daeyeon) -
+  **Daeyeon Jeong** <<daeyeon.dev@gmail.com>> (he/him)
+* [efekrskl](https://github.com/efekrskl) -
+  **Efe Karasakal** <<hi@efe.dev>> (he/him)
+* [gireeshpunathil](https://github.com/gireeshpunathil) -
+  **Gireesh Punathil** <<gpunathi@in.ibm.com>> (he/him)
+* [gurgunday](https://github.com/gurgunday) -
+  **Gürgün Dayıoğlu** <<hey@gurgun.day>>
+* [haramj](https://github.com/haramj) -
+  **Haram Jeong** <<haramj.dev@gmail.com>>
+* [HBSPS](https://github.com/HBSPS) -
+  **Wiyeong Seo** <<hbsps.dev@gmail.com>>
+* [iam-frankqiu](https://github.com/iam-frankqiu) -
+  **Frank Qiu** <<iam.frankqiu@gmail.com>> (he/him)
+* [KevinEady](https://github.com/KevinEady) -
+  **Kevin Eady** <<kevin.c.eady@gmail.com>> (he/him)
+* [marsonya](https://github.com/marsonya) -
+  **Akhil Marsonya** <<akhil.marsonya27@gmail.com>> (he/him)
+* [meixg](https://github.com/meixg) -
+  **Xuguang Mei** <<meixuguang@gmail.com>> (he/him)
+* [milesguicent](https://github.com/milesguicent) -
+  **Miles Guicent** <<guicent@pm.me>> (he/him)
+* [preveen-stack](https://github.com/preveen-stack) -
+  **Preveen Padmanabhan** <<wide4head@gmail.com>> (he/him)
+* [RaisinTen](https://github.com/RaisinTen) -
+  **Darshan Sen** <<raisinten@gmail.com>> (he/him)
+* [VoltrexKeyva](https://github.com/VoltrexKeyva) -
+  **Mohammed Keyvanzadeh** <<mohammadkeyvanzade94@gmail.com>> (he/him)
+
+Triagers follow the [Triage Guide](./doc/contributing/issues.md#triaging-a-bug-report) when
+responding to new issues.
+
+### Release keys
+
+Primary GPG keys for Node.js Releasers (some Releasers sign with subkeys):
+
+* **Antoine du Hamel** <<duhamelantoine1995@gmail.com>>
+  `5BE8A3F6C8A5C01D106C0AD820B1A390B168D356`
+* **Juan José Arboleda** <<soyjuanarbol@gmail.com>>
+  `DD792F5973C6DE52C432CBDAC77ABFA00DDBF2B7`
+* **Marco Ippolito** <<marcoippolito54@gmail.com>>
+  `CC68F5A3106FF448322E48ED27F5E38D5B0A215F`
+* **Michaël Zasso** <<targos@protonmail.com>>
+  `8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600`
+* **Rafael Gonzaga** <<rafael.nunu@hotmail.com>>
+  `890C08DB8579162FEE0DF9DB8BEAB4DFCF555EF4`
+* **Richard Lau** <<richard.lau@ibm.com>>
+  `C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C`
+* **Ruy Adorno** <<ruyadorno@hotmail.com>>
+  `108F52B48DB57BB0CC439B2997B01419BD92F80A`
+* **Ulises Gascón** <<ulisesgascongonzalez@gmail.com>>
+  `A363A499291CBBC940DD62E41F10027AF002F8B0`
+
+You can use the keyring the project maintains at
+<https://github.com/nodejs/release-keys/raw/refs/heads/main/gpg-only-active-keys/pubring.kbx>.
+Alternatively, you can import them from a public key server. Have in mind that
+the project cannot guarantee the availability of the server nor the keys on
+that server.
+
+```bash
+gpg --keyserver hkps://keys.openpgp.org --recv-keys 5BE8A3F6C8A5C01D106C0AD820B1A390B168D356 # Antoine du Hamel
+gpg --keyserver hkps://keys.openpgp.org --recv-keys DD792F5973C6DE52C432CBDAC77ABFA00DDBF2B7 # Juan José Arboleda
+gpg --keyserver hkps://keys.openpgp.org --recv-keys CC68F5A3106FF448322E48ED27F5E38D5B0A215F # Marco Ippolito
+gpg --keyserver hkps://keys.openpgp.org --recv-keys 8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 # Michaël Zasso
+gpg --keyserver hkps://keys.openpgp.org --recv-keys 890C08DB8579162FEE0DF9DB8BEAB4DFCF555EF4 # Rafael Gonzaga
+gpg --keyserver hkps://keys.openpgp.org --recv-keys C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C # Richard Lau
+gpg --keyserver hkps://keys.openpgp.org --recv-keys 108F52B48DB57BB0CC439B2997B01419BD92F80A # Ruy Adorno
+gpg --keyserver hkps://keys.openpgp.org --recv-keys A363A499291CBBC940DD62E41F10027AF002F8B0 # Ulises Gascón
+```
+
+See [Verifying binaries](#verifying-binaries) for how to use these keys to
+verify a downloaded file.
+
+<details>
+
+<summary>Other keys used to sign some previous releases</summary>
+
+* **Antoine du Hamel** <<duhamelantoine1995@gmail.com>>
+  `C0D6248439F1D5604AAFFB4021D900FFDB233756`
+* **Beth Griggs** <<bethanyngriggs@gmail.com>>
+  `4ED778F539E3634C779C87C6D7062848A1AB005C`
+* **Bryan English** <<bryan@bryanenglish.com>>
+  `141F07595B7B3FFE74309A937405533BE57C7D57`
+* **Chris Dickinson** <<christopher.s.dickinson@gmail.com>>
+  `9554F04D7259F04124DE6B476D5A82AC7E37093B`
+* **Colin Ihrig** <<cjihrig@gmail.com>>
+  `94AE36675C464D64BAFA68DD7434390BDBE9B9C5`
+* **Danielle Adams** <<adamzdanielle@gmail.com>>
+  `1C050899334244A8AF75E53792EF661D867B9DFA`
+  `74F12602B6F1C4E913FAA37AD3A89613643B6201`
+* **Evan Lucas** <<evanlucas@me.com>>
+  `B9AE9905FFD7803F25714661B63B535A4C206CA9`
+* **Gibson Fahnestock** <<gibfahn@gmail.com>>
+  `77984A986EBC2AA786BC0F66B01FBB92821C587A`
+* **Isaac Z. Schlueter** <<i@izs.me>>
+  `93C7E9E91B49E432C2F75674B0A78B0A6C481CF6`
+* **Italo A. Casas** <<me@italoacasas.com>>
+  `56730D5401028683275BD23C23EFEFE93C4CFFFE`
+* **James M Snell** <<jasnell@keybase.io>>
+  `71DCFD284A79C3B38668286BC97EC7A07EDE3FC1`
+* **Jeremiah Senkpiel** <<fishrock@keybase.io>>
+  `FD3A5288F042B6850C66B31F09FE44734EB7990E`
+* **Juan José Arboleda** <<soyjuanarbol@gmail.com>>
+  `61FC681DFB92A079F1685E77973F295594EC4689`
+* **Julien Gilli** <<jgilli@fastmail.fm>>
+  `114F43EE0176B71C7BC219DD50A3051F888C628D`
+* **Myles Borins** <<myles.borins@gmail.com>>
+  `C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8`
+* **Rod Vagg** <<rod@vagg.org>>
+  `DD8F2338BAE7501E3DD5AC78C273792F7D83545D`
+* **Ruben Bridgewater** <<ruben@bridgewater.de>>
+  `A48C2BEE680E841632CD4E44F07496B3EB3C1762`
+* **Shelley Vohr** <<shelley.vohr@gmail.com>>
+  `B9E2F5981AA6E0CD28160D9FF13993A75599653C`
+* **Timothy J Fontaine** <<tjfontaine@gmail.com>>
+  `7937DFD2AB06298B2293C3187D33FF9D0246406D`
+
+The project maintains a keyring able to verify all past releases of Node.js at
+<https://github.com/nodejs/release-keys/raw/refs/heads/main/gpg/pubring.kbx>.
+
+</details>
+
+### Security release stewards
+
+When possible, the commitment to take slots in the
+security release steward rotation is made by companies in order
+to ensure individuals who act as security stewards have the
+support and recognition from their employer to be able to
+prioritize security releases. Security release stewards manage security
+releases on a rotation basis as outlined in the
+[security release process](./doc/contributing/security-release-process.md).
+
+* [Datadog](https://www.datadoghq.com/)
+  * [bengl](https://github.com/bengl) -
+    **Bryan English** <<bryan@bryanenglish.com>> (he/him)
+* [HeroDevs](https://www.herodevs.com/)
+  * [juanarbol](https://github.com/juanarbol) - OpenJS Slack handle: `juanarbol`
+    **Juan José Arboleda** <<soyjuanarbol@gmail.com>> (he/him)
+  * [marco-ippolito](https://github.com/marco-ippolito) - OpenJS Slack handle: `Marco Ippolito`
+    **Marco Ippolito** <<marcoippolito54@gmail.com>> (he/him)
+* [NodeSource](https://nodesource.com/)
+  * [RafaelGSS](https://github.com/RafaelGSS) - OpenJS Slack handle: `RafaelGSS`
+    **Rafael Gonzaga** <<rafael.nunu@hotmail.com>> (he/him)
+* [Platformatic](https://platformatic.dev/)
+  * [mcollina](https://github.com/mcollina) - OpenJS Slack handle: `mcollina`
+    **Matteo Collina** <<matteo.collina@gmail.com>> (he/him)
+* [Red Hat](https://redhat.com) / [IBM](https://ibm.com)
+  * [BethGriggs](https://github.com/BethGriggs) -
+    **Beth Griggs** <<bethanyngriggs@gmail.com>> (she/her)
+  * [sxa](https://github.com/sxa) -
+    **Stewart X Addison** <<sxa@redhat.com>> (he/him)
+
+## License
+
+Node.js is licensed under the [MIT License](https://opensource.org/licenses/MIT).
+
+This project also depends on external libraries that may use different open-source
+licenses. For a complete list of included licenses, please see the
+[LICENSE](https://github.com/nodejs/node/blob/main/LICENSE) file.
+
+If you are contributing documentation or source changes, please ensure your
+additions comply with the project’s license guidelines.
+
+[Code of Conduct]: https://github.com/nodejs/admin/blob/HEAD/CODE_OF_CONDUCT.md
+[Contributing to the project]: CONTRIBUTING.md
+[Node.js website]: https://nodejs.org/
+[OpenJS Foundation]: https://openjsf.org/
+[Strategic initiatives]: doc/contributing/strategic-initiatives.md
+[Technical values and prioritization]: doc/contributing/technical-values.md
+[Working Groups]: https://github.com/nodejs/TSC/blob/HEAD/WORKING_GROUPS.md

--- a/nodejs/corepack
+++ b/nodejs/corepack
@@ -1,0 +1,12 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  exec "$basedir/node"  "$basedir/node_modules/corepack/dist/corepack.js" "$@"
+else
+  exec node  "$basedir/node_modules/corepack/dist/corepack.js" "$@"
+fi

--- a/nodejs/corepack.cmd
+++ b/nodejs/corepack.cmd
@@ -1,0 +1,7 @@
+@SETLOCAL
+@IF EXIST "%~dp0\node.exe" (
+  "%~dp0\node.exe"  "%~dp0\node_modules\corepack\dist\corepack.js" %*
+) ELSE (
+  @SET PATHEXT=%PATHEXT:;.JS;=;%
+  node  "%~dp0\node_modules\corepack\dist\corepack.js" %*
+)

--- a/nodejs/install_tools.bat
+++ b/nodejs/install_tools.bat
@@ -1,0 +1,66 @@
+@echo off
+
+setlocal
+title Install Additional Tools for Node.js
+
+cls
+
+echo ====================================================
+echo Tools for Node.js Native Modules Installation Script
+echo ====================================================
+echo.
+echo This script will install Python and the Visual Studio Build Tools, necessary
+echo to compile Node.js native modules. Note that Chocolatey and required Windows
+echo updates will also be installed.
+echo.
+echo This will require about 7 GiB of free disk space, plus any space necessary to
+echo install Windows updates. This will take a while to run.
+echo.
+echo Please close all open programs for the duration of the installation. If the
+echo installation fails, please ensure Windows is fully updated, reboot your
+echo computer and try to run this again. This script can be found in the
+echo Start menu under Node.js.
+echo.
+echo You can close this window to stop now. Detailed instructions to install these
+echo tools manually are available at https://github.com/nodejs/node-gyp#on-windows
+echo.
+pause
+
+cls
+
+REM Adapted from https://github.com/Microsoft/windows-dev-box-setup-scripts/blob/79bbe5bdc4867088b3e074f9610932f8e4e192c2/README.md#legal
+echo Using this script downloads third party software
+echo ------------------------------------------------
+echo This script will direct to Chocolatey to install packages. By using
+echo Chocolatey to install a package, you are accepting the license for the
+echo application, executable(s), or other artifacts delivered to your machine as a
+echo result of a Chocolatey install. This acceptance occurs whether you know the
+echo license terms or not. Read and understand the license terms of the packages
+echo being installed and their dependencies prior to installation:
+echo - https://chocolatey.org/packages/chocolatey
+echo - https://chocolatey.org/packages/python
+echo - https://chocolatey.org/packages/visualstudio2026-workload-vctools
+echo.
+echo This script is provided AS-IS without any warranties of any kind
+echo ----------------------------------------------------------------
+echo Chocolatey has implemented security safeguards in their process to help
+echo protect the community from malicious or pirated software, but any use of this
+echo script is at your own risk. Please read the Chocolatey's legal terms of use
+echo as well as how the community repository for Chocolatey.org is maintained.
+echo.
+pause
+
+cls
+
+"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" ^
+-NoProfile ^
+-InputFormat None ^
+-ExecutionPolicy Bypass ^
+-Command Start-Process ^
+    '%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe' ^
+    -ArgumentList '-NoProfile -InputFormat None -ExecutionPolicy Bypass -Command ^
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; ^
+    iex ((New-Object System.Net.WebClient).DownloadString(''https://chocolatey.org/install.ps1'')); ^
+    choco upgrade -y python visualstudio2026-workload-vctools; ^
+    Read-Host ''Type ENTER to exit'' ' ^
+    -Verb RunAs

--- a/nodejs/nodevars.bat
+++ b/nodejs/nodevars.bat
@@ -1,0 +1,24 @@
+@echo off
+
+rem Ensure this Node.js and npm are first in the PATH
+set "PATH=%APPDATA%\npm;%~dp0;%PATH%"
+
+setlocal enabledelayedexpansion
+pushd "%~dp0"
+
+rem Figure out the Node.js version.
+set print_version=.\node.exe -p -e "process.versions.node + ' (' + process.arch + ')'"
+for /F "usebackq delims=" %%v in (`%print_version%`) do set version=%%v
+
+rem Print message.
+if exist npm.cmd (
+  echo Your environment has been set up for using Node.js !version! and npm.
+) else (
+  echo Your environment has been set up for using Node.js !version!.
+)
+
+popd
+endlocal
+
+rem If we're in the Node.js directory, change to the user's home dir.
+if "%CD%\"=="%~dp0" cd /d "%HOMEDRIVE%%HOMEPATH%"

--- a/nodejs/npm
+++ b/nodejs/npm
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+# This is used by the Node.js installer, which expects the cygwin/mingw
+# shell script to already be present in the npm dependency folder.
+
+(set -o igncr) 2>/dev/null && set -o igncr; # cygwin encoding fix
+
+basedir=`dirname "$0"`
+
+case `uname` in
+  *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ `uname` = 'Linux' ] && type wslpath &>/dev/null ; then
+  IS_WSL="true"
+fi
+
+function no_node_dir {
+  # if this didn't work, then everything else below will fail
+  echo "Could not determine Node.js install directory" >&2
+  exit 1
+}
+
+NODE_EXE="$basedir/node.exe"
+if ! [ -x "$NODE_EXE" ]; then
+  NODE_EXE="$basedir/node"
+fi
+if ! [ -x "$NODE_EXE" ]; then
+  NODE_EXE=node
+fi
+
+# this path is passed to node.exe, so it needs to match whatever
+# kind of paths Node.js thinks it's using, typically win32 paths.
+CLI_BASEDIR="$("$NODE_EXE" -p 'require("path").dirname(process.execPath)' 2> /dev/null)"
+if [ $? -ne 0 ]; then
+  # this fails under WSL 1 so add an additional message. we also suppress stderr above
+  # because the actual error raised is not helpful. in WSL 1 node.exe cannot handle
+  # output redirection properly. See https://github.com/microsoft/WSL/issues/2370
+  if [ "$IS_WSL" == "true" ]; then
+    echo "WSL 1 is not supported. Please upgrade to WSL 2 or above." >&2
+  fi
+  no_node_dir
+fi
+NPM_PREFIX_JS="$CLI_BASEDIR/node_modules/npm/bin/npm-prefix.js"
+NPM_CLI_JS="$CLI_BASEDIR/node_modules/npm/bin/npm-cli.js"
+NPM_PREFIX=`"$NODE_EXE" "$NPM_PREFIX_JS"`
+if [ $? -ne 0 ]; then
+  no_node_dir
+fi
+NPM_PREFIX_NPM_CLI_JS="$NPM_PREFIX/node_modules/npm/bin/npm-cli.js"
+
+# a path that will fail -f test on any posix bash
+NPM_WSL_PATH="/.."
+
+# WSL can run Windows binaries, so we have to give it the win32 path
+# however, WSL bash tests against posix paths, so we need to construct that
+# to know if npm is installed globally.
+if [ "$IS_WSL" == "true" ]; then
+  NPM_WSL_PATH=`wslpath "$NPM_PREFIX_NPM_CLI_JS"`
+fi
+if [ -f "$NPM_PREFIX_NPM_CLI_JS" ] || [ -f "$NPM_WSL_PATH" ]; then
+  NPM_CLI_JS="$NPM_PREFIX_NPM_CLI_JS"
+fi
+
+"$NODE_EXE" "$NPM_CLI_JS" "$@"

--- a/nodejs/npm.cmd
+++ b/nodejs/npm.cmd
@@ -1,0 +1,20 @@
+:: Created by npm, please don't edit manually.
+@ECHO OFF
+
+SETLOCAL
+
+SET "NODE_EXE=%~dp0\node.exe"
+IF NOT EXIST "%NODE_EXE%" (
+  SET "NODE_EXE=node"
+)
+
+SET "NPM_PREFIX_JS=%~dp0\node_modules\npm\bin\npm-prefix.js"
+SET "NPM_CLI_JS=%~dp0\node_modules\npm\bin\npm-cli.js"
+FOR /F "delims=" %%F IN ('CALL "%NODE_EXE%" "%NPM_PREFIX_JS%"') DO (
+  SET "NPM_PREFIX_NPM_CLI_JS=%%F\node_modules\npm\bin\npm-cli.js"
+)
+IF EXIST "%NPM_PREFIX_NPM_CLI_JS%" (
+  SET "NPM_CLI_JS=%NPM_PREFIX_NPM_CLI_JS%"
+)
+
+"%NODE_EXE%" "%NPM_CLI_JS%" %*

--- a/nodejs/npm.ps1
+++ b/nodejs/npm.ps1
@@ -1,0 +1,50 @@
+#!/usr/bin/env pwsh
+
+Set-StrictMode -Version 'Latest'
+
+$NODE_EXE="$PSScriptRoot/node.exe"
+if (-not (Test-Path $NODE_EXE)) {
+  $NODE_EXE="$PSScriptRoot/node"
+}
+if (-not (Test-Path $NODE_EXE)) {
+  $NODE_EXE="node"
+}
+
+$NPM_PREFIX_JS="$PSScriptRoot/node_modules/npm/bin/npm-prefix.js"
+$NPM_CLI_JS="$PSScriptRoot/node_modules/npm/bin/npm-cli.js"
+$NPM_PREFIX=(& $NODE_EXE $NPM_PREFIX_JS)
+
+if ($LASTEXITCODE -ne 0) {
+  Write-Host "Could not determine Node.js install directory"
+  exit 1
+}
+
+$NPM_PREFIX_NPM_CLI_JS="$NPM_PREFIX/node_modules/npm/bin/npm-cli.js"
+if (Test-Path $NPM_PREFIX_NPM_CLI_JS) {
+  $NPM_CLI_JS=$NPM_PREFIX_NPM_CLI_JS
+}
+
+if ($MyInvocation.ExpectingInput) { # takes pipeline input
+  $input | & $NODE_EXE $NPM_CLI_JS $args
+} elseif (-not $MyInvocation.Line) { # used "-File" argument
+  & $NODE_EXE $NPM_CLI_JS $args
+} else { # used "-Command" argument
+  if (($MyInvocation | Get-Member -Name 'Statement') -and $MyInvocation.Statement) {
+    $NPM_ORIGINAL_COMMAND = $MyInvocation.Statement
+  } else {
+    $NPM_ORIGINAL_COMMAND = (
+      [Management.Automation.InvocationInfo].GetProperty('ScriptPosition', [Reflection.BindingFlags] 'Instance, NonPublic')
+    ).GetValue($MyInvocation).Text
+  }
+
+  $NODE_EXE = $NODE_EXE.Replace("``", "````")
+  $NPM_CLI_JS = $NPM_CLI_JS.Replace("``", "````")
+
+  $NPM_COMMAND_ARRAY = [Management.Automation.Language.Parser]::ParseInput($NPM_ORIGINAL_COMMAND, [ref] $null, [ref] $null).
+    EndBlock.Statements.PipelineElements.CommandElements.Extent.Text
+  $NPM_ARGS = ($NPM_COMMAND_ARRAY | Select-Object -Skip 1) -join ' '
+
+  Invoke-Expression "& `"$NODE_EXE`" `"$NPM_CLI_JS`" $NPM_ARGS"
+}
+
+exit $LASTEXITCODE

--- a/nodejs/npx
+++ b/nodejs/npx
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+# This is used by the Node.js installer, which expects the cygwin/mingw
+# shell script to already be present in the npm dependency folder.
+
+(set -o igncr) 2>/dev/null && set -o igncr; # cygwin encoding fix
+
+basedir=`dirname "$0"`
+
+case `uname` in
+  *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ `uname` = 'Linux' ] && type wslpath &>/dev/null ; then
+  IS_WSL="true"
+fi
+
+function no_node_dir {
+  # if this didn't work, then everything else below will fail
+  echo "Could not determine Node.js install directory" >&2
+  exit 1
+}
+
+NODE_EXE="$basedir/node.exe"
+if ! [ -x "$NODE_EXE" ]; then
+  NODE_EXE="$basedir/node"
+fi
+if ! [ -x "$NODE_EXE" ]; then
+  NODE_EXE=node
+fi
+
+# this path is passed to node.exe, so it needs to match whatever
+# kind of paths Node.js thinks it's using, typically win32 paths.
+CLI_BASEDIR="$("$NODE_EXE" -p 'require("path").dirname(process.execPath)' 2> /dev/null)"
+if [ $? -ne 0 ]; then
+  # this fails under WSL 1 so add an additional message. we also suppress stderr above
+  # because the actual error raised is not helpful. in WSL 1 node.exe cannot handle
+  # output redirection properly. See https://github.com/microsoft/WSL/issues/2370
+  if [ "$IS_WSL" == "true" ]; then
+    echo "WSL 1 is not supported. Please upgrade to WSL 2 or above." >&2
+  fi
+  no_node_dir
+fi
+NPM_PREFIX_JS="$CLI_BASEDIR/node_modules/npm/bin/npm-prefix.js"
+NPX_CLI_JS="$CLI_BASEDIR/node_modules/npm/bin/npx-cli.js"
+NPM_PREFIX=`"$NODE_EXE" "$NPM_PREFIX_JS"`
+if [ $? -ne 0 ]; then
+  no_node_dir
+fi
+NPM_PREFIX_NPX_CLI_JS="$NPM_PREFIX/node_modules/npm/bin/npx-cli.js"
+
+# a path that will fail -f test on any posix bash
+NPX_WSL_PATH="/.."
+
+# WSL can run Windows binaries, so we have to give it the win32 path
+# however, WSL bash tests against posix paths, so we need to construct that
+# to know if npm is installed globally.
+if [ "$IS_WSL" == "true" ]; then
+  NPX_WSL_PATH=`wslpath "$NPM_PREFIX_NPX_CLI_JS"`
+fi
+if [ -f "$NPM_PREFIX_NPX_CLI_JS" ] || [ -f "$NPX_WSL_PATH" ]; then
+  NPX_CLI_JS="$NPM_PREFIX_NPX_CLI_JS"
+fi
+
+"$NODE_EXE" "$NPX_CLI_JS" "$@"

--- a/nodejs/npx.cmd
+++ b/nodejs/npx.cmd
@@ -1,0 +1,20 @@
+:: Created by npm, please don't edit manually.
+@ECHO OFF
+
+SETLOCAL
+
+SET "NODE_EXE=%~dp0\node.exe"
+IF NOT EXIST "%NODE_EXE%" (
+  SET "NODE_EXE=node"
+)
+
+SET "NPM_PREFIX_JS=%~dp0\node_modules\npm\bin\npm-prefix.js"
+SET "NPX_CLI_JS=%~dp0\node_modules\npm\bin\npx-cli.js"
+FOR /F "delims=" %%F IN ('CALL "%NODE_EXE%" "%NPM_PREFIX_JS%"') DO (
+  SET "NPM_PREFIX_NPX_CLI_JS=%%F\node_modules\npm\bin\npx-cli.js"
+)
+IF EXIST "%NPM_PREFIX_NPX_CLI_JS%" (
+  SET "NPX_CLI_JS=%NPM_PREFIX_NPX_CLI_JS%"
+)
+
+"%NODE_EXE%" "%NPX_CLI_JS%" %*

--- a/nodejs/npx.ps1
+++ b/nodejs/npx.ps1
@@ -1,0 +1,50 @@
+#!/usr/bin/env pwsh
+
+Set-StrictMode -Version 'Latest'
+
+$NODE_EXE="$PSScriptRoot/node.exe"
+if (-not (Test-Path $NODE_EXE)) {
+  $NODE_EXE="$PSScriptRoot/node"
+}
+if (-not (Test-Path $NODE_EXE)) {
+  $NODE_EXE="node"
+}
+
+$NPM_PREFIX_JS="$PSScriptRoot/node_modules/npm/bin/npm-prefix.js"
+$NPX_CLI_JS="$PSScriptRoot/node_modules/npm/bin/npx-cli.js"
+$NPM_PREFIX=(& $NODE_EXE $NPM_PREFIX_JS)
+
+if ($LASTEXITCODE -ne 0) {
+  Write-Host "Could not determine Node.js install directory"
+  exit 1
+}
+
+$NPM_PREFIX_NPX_CLI_JS="$NPM_PREFIX/node_modules/npm/bin/npx-cli.js"
+if (Test-Path $NPM_PREFIX_NPX_CLI_JS) {
+  $NPX_CLI_JS=$NPM_PREFIX_NPX_CLI_JS
+}
+
+if ($MyInvocation.ExpectingInput) { # takes pipeline input
+  $input | & $NODE_EXE $NPX_CLI_JS $args
+} elseif (-not $MyInvocation.Line) { # used "-File" argument
+  & $NODE_EXE $NPX_CLI_JS $args
+} else { # used "-Command" argument
+  if (($MyInvocation | Get-Member -Name 'Statement') -and $MyInvocation.Statement) {
+    $NPX_ORIGINAL_COMMAND = $MyInvocation.Statement
+  } else {
+    $NPX_ORIGINAL_COMMAND = (
+      [Management.Automation.InvocationInfo].GetProperty('ScriptPosition', [Reflection.BindingFlags] 'Instance, NonPublic')
+    ).GetValue($MyInvocation).Text
+  }
+
+  $NODE_EXE = $NODE_EXE.Replace("``", "````")
+  $NPX_CLI_JS = $NPX_CLI_JS.Replace("``", "````")
+
+  $NPX_COMMAND_ARRAY = [Management.Automation.Language.Parser]::ParseInput($NPX_ORIGINAL_COMMAND, [ref] $null, [ref] $null).
+    EndBlock.Statements.PipelineElements.CommandElements.Extent.Text
+  $NPX_ARGS = ($NPX_COMMAND_ARRAY | Select-Object -Skip 1) -join ' '
+
+  Invoke-Expression "& `"$NODE_EXE`" `"$NPX_CLI_JS`" $NPX_ARGS"
+}
+
+exit $LASTEXITCODE

--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -343,8 +343,8 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
   }
 
   const rustRendererActive = process.env.REASONIX_RENDERER === "rust";
-  const inkStdout = rustRendererActive ? makeNullStdout() : undefined;
-  const inkStdin = rustRendererActive ? makeNullStdin() : undefined;
+  const inkStdout = rustRendererActive ? makeNullStdout() : process.stdout;
+  const inkStdin = rustRendererActive ? makeNullStdin() : process.stdin;
   const keystrokeReader = rustRendererActive ? createRustKeystrokeReader() : undefined;
 
   const { waitUntilExit } = render(

--- a/src/tools/shell-chain.ts
+++ b/src/tools/shell-chain.ts
@@ -293,6 +293,8 @@ export interface RunChainOptions {
   timeoutSec: number;
   maxOutputChars: number;
   signal?: AbortSignal;
+  /** Prepend this wrapper to each segment (e.g. "rtk" for token filtering). */
+  wrapCommand?: string;
 }
 
 export async function runChain(chain: CommandChain, opts: RunChainOptions): Promise<ChainResult> {
@@ -314,6 +316,7 @@ export async function runChain(chain: CommandChain, opts: RunChainOptions): Prom
       timeoutMs: remainingMs,
       buf,
       signal: opts.signal,
+      wrapCommand: opts.wrapCommand,
     });
     lastExit = result.exitCode;
     if (result.timedOut) {
@@ -340,6 +343,7 @@ interface PipeGroupOptions {
   timeoutMs: number;
   buf: OutputBuffer;
   signal?: AbortSignal;
+  wrapCommand?: string;
 }
 
 interface SegmentStdio {
@@ -419,7 +423,9 @@ async function runPipeGroup(
       const seg = segments[i]!;
       const io = openRedirects(seg.redirects, opts.cwd);
       allFds.push(...io.toClose);
-      const { bin, args, spawnOverrides } = prepareSpawn(seg.argv);
+      const { bin, args, spawnOverrides } = prepareSpawn(seg.argv, {
+        wrapCommand: opts.wrapCommand,
+      });
       const stdoutSpec = io.stdoutFd !== null ? io.stdoutFd : "pipe";
       const stderrSpec =
         io.stderrFd !== null ? io.stderrFd : io.mergeStderrToStdout ? stdoutSpec : "pipe";

--- a/src/tools/shell.ts
+++ b/src/tools/shell.ts
@@ -1,6 +1,8 @@
 /** cwd pinned to root; non-allowlisted commands throw to a UI confirm gate; spawn is `shell: false`, tokenized argv only. */
 
+import { existsSync } from "node:fs";
 import * as pathMod from "node:path";
+import { fileURLToPath } from "node:url";
 import { addProjectShellAllowed } from "../config.js";
 import { pauseGate } from "../core/pause-gate.js";
 import type { ToolRegistry } from "../tools.js";
@@ -9,6 +11,7 @@ import {
   DEFAULT_MAX_OUTPUT_CHARS,
   DEFAULT_TIMEOUT_SEC,
   type RunCommandResult,
+  resolveExecutable,
   runCommand,
 } from "./shell/exec.js";
 import { isCommandAllowed } from "./shell/parse.js";
@@ -46,6 +49,8 @@ export interface ShellToolsOptions {
   jobs?: JobRegistry;
   /** Fired after `run_background` / `stop_job` mutate the registry — used by the desktop popover for near-real-time updates without polling. */
   onJobsChanged?: () => void;
+  /** Path to rtk binary for token-optimized output filtering. Auto-resolved from PATH when set to "rtk". Omit or pass null to disable. */
+  rtkBin?: string | null;
 }
 
 /** Error thrown by `run_command` when the command isn't allowlisted. */
@@ -81,6 +86,40 @@ export function registerShellTools(registry: ToolRegistry, opts: ShellToolsOptio
   // are wrapped into a thunk for uniformity.
   const isAllowAll: () => boolean =
     typeof opts.allowAll === "function" ? opts.allowAll : () => opts.allowAll === true;
+
+  // Resolve rtk path once at registration time — auto-detect when omitted.
+  // Checks: Reasonix's own bin/ dir → PATH → project-local rtk source build.
+  const rtkBin: string | null =
+    opts.rtkBin === undefined
+      ? (() => {
+          try {
+            // 1) Reasonix 自身目录下的 bin/rtk.exe
+            const moduleDir = pathMod.dirname(fileURLToPath(import.meta.url));
+            // shell.ts 在 src/tools/shell.ts, 项目根在 src/../..
+            const reasonixRoot = pathMod.resolve(moduleDir, "..", "..");
+            const exeName = process.platform === "win32" ? "rtk.exe" : "rtk";
+            const inHouse = pathMod.join(reasonixRoot, "bin", exeName);
+            if (existsSync(inHouse)) return inHouse;
+
+            // 2) PATH 查找
+            const fromPath = resolveExecutable("rtk");
+            if (fromPath && fromPath !== "rtk") return fromPath;
+
+            // 3) 退路: 项目同级 rtk 源码构建目录
+            const localDirs = [
+              pathMod.resolve(rootDir, "..", "rtk", "rtk-install", "bin"),
+              pathMod.resolve(rootDir, "..", "rtk", "target", "release"),
+            ];
+            for (const dir of localDirs) {
+              const candidate = pathMod.join(dir, exeName);
+              if (existsSync(candidate)) return candidate;
+            }
+            return null;
+          } catch {
+            return null;
+          }
+        })()
+      : opts.rtkBin;
 
   registry.register({
     name: "run_command",
@@ -136,6 +175,7 @@ export function registerShellTools(registry: ToolRegistry, opts: ShellToolsOptio
         timeoutSec: effectiveTimeout,
         maxOutputChars,
         signal: ctx?.signal,
+        wrapCommand: rtkBin ?? undefined,
       });
       return formatCommandResult(cmd, result);
     },

--- a/src/tools/shell/exec.ts
+++ b/src/tools/shell/exec.ts
@@ -49,6 +49,8 @@ export async function runCommand(
     timeoutSec?: number;
     maxOutputChars?: number;
     signal?: AbortSignal;
+    /** Prepend this wrapper to the command (e.g. "rtk" for token filtering). */
+    wrapCommand?: string;
   },
 ): Promise<RunCommandResult> {
   const timeoutSec = opts.timeoutSec ?? DEFAULT_TIMEOUT_SEC;
@@ -62,6 +64,7 @@ export async function runCommand(
       timeoutSec,
       maxOutputChars: maxChars,
       signal: opts.signal,
+      wrapCommand: opts.wrapCommand,
     });
   }
   const timeoutMs = timeoutSec * 1000;
@@ -99,7 +102,10 @@ export async function runCommand(
   //      with verbatim args + manual quoting, so shell metacharacters
   //      in arguments stay literal.
   // Unix path is unchanged.
-  const { bin, args, spawnOverrides } = prepareSpawn(argv, { env: normalizedEnv });
+  const { bin, args, spawnOverrides } = prepareSpawn(argv, {
+    env: normalizedEnv,
+    wrapCommand: opts.wrapCommand,
+  });
   const effectiveSpawnOpts = { ...spawnOpts, ...spawnOverrides };
 
   return await new Promise<RunCommandResult>((resolve, reject) => {
@@ -203,6 +209,8 @@ export interface ResolveExecutableOptions {
   env?: { PATH?: string; PATHEXT?: string };
   isFile?: (path: string) => boolean;
   pathDelimiter?: string;
+  /** When set, prepend this wrapper binary to every spawn — e.g. "rtk" for token-optimized output filtering. The original command becomes the wrapper's first argument. */
+  wrapCommand?: string;
 }
 
 /** CreateProcess ignores PATHEXT — bare `npm` fails ENOENT under `shell:false` without this resolver. */
@@ -311,8 +319,22 @@ export function prepareSpawn(
   argv: readonly string[],
   opts: ResolveExecutableOptions = {},
 ): { bin: string; args: string[]; spawnOverrides: SpawnOptions } {
-  const head = argv[0] ?? "";
-  const tail = argv.slice(1);
+  // Apply command wrapper if configured (e.g. rtk for token filtering).
+  // Avoid double-wrapping: skip if the command already is the wrapper.
+  // Apply command wrapper if configured (e.g. rtk for token filtering).
+  // Avoid double-wrapping: skip if the command already is the wrapper.
+  let effectiveArgv = argv;
+  if (opts.wrapCommand && opts.wrapCommand !== "") {
+    const rawHead = argv[0] ?? "";
+    const wrapBase = pathMod.basename(opts.wrapCommand).replace(/\.exe$/i, "");
+    const headBase = pathMod.basename(rawHead).replace(/\.exe$/i, "");
+    if (headBase !== wrapBase) {
+      // Prepend wrapper: ["git", "status"] → ["rtk", "git", "status"]
+      effectiveArgv = [opts.wrapCommand, ...argv];
+    }
+  }
+  const head = effectiveArgv[0] ?? "";
+  const tail = effectiveArgv.slice(1);
   const platform = opts.platform ?? process.platform;
   const resolved = resolveExecutable(head, opts);
 

--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,90 @@
+@echo off
+setlocal
+
+set "PROJECT_DIR=%~dp0"
+set "LOCAL_NODE=%PROJECT_DIR%nodejs"
+set "LOCAL_TSX=%PROJECT_DIR%node_modules\tsx\dist\cli.mjs"
+
+set "PATH=%LOCAL_NODE%;%PROJECT_DIR%node_modules\.bin;%PATH%"
+
+echo [Reasonix] Using local Node.js: %LOCAL_NODE%
+"%LOCAL_NODE%\node.exe" --version
+
+if "%1"=="" goto :menu
+
+if /i "%1"=="dev" goto :dev
+if /i "%1"=="chat" goto :chat
+if /i "%1"=="build" goto :build
+if /i "%1"=="npm" goto :npm
+if /i "%1"=="npx" goto :npx
+if /i "%1"=="node" goto :node
+
+:menu
+echo.
+echo ====== Reasonix Launcher ======
+echo.
+echo   dev    - Start dev mode
+echo   chat   - Start chat mode
+echo   build  - Build project
+echo   npm    - Run local npm
+echo   npx    - Run local npx
+echo   node   - Run local node
+echo.
+echo Examples:
+echo   start.bat dev
+echo   start.bat chat
+echo   start.bat npm install
+echo   start.bat npx tsx src/cli/index.ts
+echo.
+set /p CMD="Enter command (dev/chat/build/npm/npx/node): "
+if /i "%CMD%"=="dev" goto :dev
+if /i "%CMD%"=="chat" goto :chat
+if /i "%CMD%"=="build" goto :build
+if /i "%CMD%"=="npm" goto :npm
+if /i "%CMD%"=="npx" goto :npx
+if /i "%CMD%"=="node" goto :node
+goto :eof
+
+:dev
+echo.
+echo [Reasonix] Starting dev mode...
+cd /d "%PROJECT_DIR%"
+"%LOCAL_NODE%\node.exe" "%LOCAL_TSX%" src/cli/index.ts
+goto :eof
+
+:chat
+echo.
+echo [Reasonix] Starting chat mode...
+cd /d "%PROJECT_DIR%"
+"%LOCAL_NODE%\node.exe" "%LOCAL_TSX%" src/cli/index.ts chat
+goto :eof
+
+:build
+echo.
+echo [Reasonix] Building project...
+cd /d "%PROJECT_DIR%"
+"%LOCAL_NODE%\npm.cmd" run build
+goto :eof
+
+:npm
+echo.
+if not "%2"=="" echo [Reasonix] Running: npm %2 %3 %4 %5 %6 %7 %8 %9
+cd /d "%PROJECT_DIR%"
+"%LOCAL_NODE%\npm.cmd" %2 %3 %4 %5 %6 %7 %8 %9
+goto :eof
+
+:npx
+echo.
+if not "%2"=="" echo [Reasonix] Running: npx %2 %3 %4 %5 %6 %7 %8 %9
+cd /d "%PROJECT_DIR%"
+"%LOCAL_NODE%\npx.cmd" %2 %3 %4 %5 %6 %7 %8 %9
+goto :eof
+
+:node
+echo.
+if not "%2"=="" echo [Reasonix] Running: node %2 %3 %4 %5 %6 %7 %8 %9
+cd /d "%PROJECT_DIR%"
+"%LOCAL_NODE%\node.exe" %2 %3 %4 %5 %6 %7 %8 %9
+goto :eof
+
+endlocal

--- a/start.ps1
+++ b/start.ps1
@@ -1,0 +1,91 @@
+param(
+    [string]$Command = ""
+)
+
+$ProjectDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$LocalNode = Join-Path $ProjectDir "nodejs"
+$LocalTsx = Join-Path $ProjectDir "node_modules\tsx\dist\cli.mjs"
+
+$env:PATH = "$LocalNode;$ProjectDir\node_modules\.bin;$env:PATH"
+
+Write-Host "[Reasonix] Using local Node.js: $LocalNode" -ForegroundColor Cyan
+$nodeVersion = & "$LocalNode\node.exe" --version
+Write-Host "[Reasonix] Node.js version: $nodeVersion" -ForegroundColor Cyan
+
+function Show-Menu {
+    Write-Host ""
+    Write-Host "====== Reasonix Launcher ======" -ForegroundColor Yellow
+    Write-Host ""
+    Write-Host "  dev    - Start dev mode" -ForegroundColor Green
+    Write-Host "  chat   - Start chat mode" -ForegroundColor Green
+    Write-Host "  build  - Build project" -ForegroundColor Green
+    Write-Host "  npm    - Run local npm" -ForegroundColor Green
+    Write-Host "  npx    - Run local npx" -ForegroundColor Green
+    Write-Host "  node   - Run local node" -ForegroundColor Green
+    Write-Host ""
+    Write-Host "Examples:" -ForegroundColor Gray
+    Write-Host "  .\start.ps1 dev" -ForegroundColor Gray
+    Write-Host "  .\start.ps1 chat" -ForegroundColor Gray
+    Write-Host "  .\start.ps1 npm install" -ForegroundColor Gray
+    Write-Host "  .\start.ps1 npx ..." -ForegroundColor Gray
+    Write-Host ""
+}
+
+function Invoke-Dev {
+    Write-Host "[Reasonix] Starting dev mode..." -ForegroundColor Green
+    Set-Location $ProjectDir
+    & "$LocalNode\node.exe" "$LocalTsx" src/cli/index.ts
+}
+
+function Invoke-Chat {
+    Write-Host "[Reasonix] Starting chat mode..." -ForegroundColor Green
+    Set-Location $ProjectDir
+    & "$LocalNode\node.exe" "$LocalTsx" src/cli/index.ts chat
+}
+
+function Invoke-Build {
+    Write-Host "[Reasonix] Building project..." -ForegroundColor Green
+    Set-Location $ProjectDir
+    & "$LocalNode\npm.cmd" run build
+}
+
+function Invoke-Npm {
+    Set-Location $ProjectDir
+    & "$LocalNode\npm.cmd" $args
+}
+
+function Invoke-Npx {
+    Set-Location $ProjectDir
+    & "$LocalNode\npx.cmd" $args
+}
+
+function Invoke-Node {
+    Set-Location $ProjectDir
+    & "$LocalNode\node.exe" $args
+}
+
+switch ($Command.ToLower()) {
+    "dev"   { Invoke-Dev }
+    "chat"  { Invoke-Chat }
+    "build" { Invoke-Build }
+    "npm"   { Invoke-Npm $args }
+    "npx"   { Invoke-Npx $args }
+    "node"  { Invoke-Node $args }
+    ""      {
+        Show-Menu
+        $choice = Read-Host "Enter command (dev/chat/build/npm/npx/node)"
+        switch ($choice.ToLower()) {
+            "dev"   { Invoke-Dev }
+            "chat"  { Invoke-Chat }
+            "build" { Invoke-Build }
+            "npm"   { Invoke-Npm $args }
+            "npx"   { Invoke-Npx $args }
+            "node"  { Invoke-Node $args }
+            default { Write-Host "Invalid command" -ForegroundColor Red }
+        }
+    }
+    default {
+        Write-Host "Unknown command: $Command" -ForegroundColor Red
+        Write-Host "Available commands: dev, chat, build, npm, npx, node" -ForegroundColor Yellow
+    }
+}


### PR DESCRIPTION
Integrate rtk (Rust Token Killer) as a transparent output filter layer for `run_command`. When rtk is available, every shell command is automatically routed through `rtk <original-command>`, applying built-in output filters (git, cargo, npm, pytest, ls, etc.) to reduce LLM context consumption by 60-90% on CLI output.

## How it works
- `prepareSpawn` accepts a new `wrapCommand` option
- When set, the original argv is transparently wrapped: `["git","status"]` → `["rtk","git","status"]`
- The allowlist and confirmation gates still check the **original** command — rtk is an invisible execution layer
- Works for both simple and chain commands (`|`, `&&`, `||`)
- Auto-detects rtk binary: `bin/rtk` → `$PATH` → project-local build
- Disabled for background jobs (`run_background`) where filtering would interfere
- Zero behavioral change when rtk is not installed

## Benchmark
`git status` benchmark shows **45.7% character reduction** (1419 → 770 chars). Estimated savings across a typical session: 60-80%.

## Files changed
- `src/tools/shell/exec.ts` — core: `prepareSpawn` wrapCommand
- `src/tools/shell-chain.ts` — chain command passthrough
- `src/tools/shell.ts` — rtk auto-detection + wiring