### PR TITLE
feat: transparent rtk integration for token-optimized command output

### DIFF
--- a/src/tools/shell-chain.ts
+++ b/src/tools/shell-chain.ts
@@ -293,6 +293,8 @@ export interface RunChainOptions {
   timeoutSec: number;
   maxOutputChars: number;
   signal?: AbortSignal;
+  /** Prepend this wrapper to each segment (e.g. "rtk" for token filtering). */
+  wrapCommand?: string;
 }
 
 export async function runChain(chain: CommandChain, opts: RunChainOptions): Promise<ChainResult> {
@@ -314,6 +316,7 @@ export async function runChain(chain: CommandChain, opts: RunChainOptions): Prom
       timeoutMs: remainingMs,
       buf,
       signal: opts.signal,
+      wrapCommand: opts.wrapCommand,
     });
     lastExit = result.exitCode;
     if (result.timedOut) {
@@ -340,6 +343,7 @@ interface PipeGroupOptions {
   timeoutMs: number;
   buf: OutputBuffer;
   signal?: AbortSignal;
+  wrapCommand?: string;
 }
 
 interface SegmentStdio {
@@ -419,7 +423,9 @@ async function runPipeGroup(
       const seg = segments[i]!;
       const io = openRedirects(seg.redirects, opts.cwd);
       allFds.push(...io.toClose);
-      const { bin, args, spawnOverrides } = prepareSpawn(seg.argv);
+      const { bin, args, spawnOverrides } = prepareSpawn(seg.argv, {
+        wrapCommand: opts.wrapCommand,
+      });
       const stdoutSpec = io.stdoutFd !== null ? io.stdoutFd : "pipe";
       const stderrSpec =
         io.stderrFd !== null ? io.stderrFd : io.mergeStderrToStdout ? stdoutSpec : "pipe";

--- a/src/tools/shell.ts
+++ b/src/tools/shell.ts
@@ -1,6 +1,8 @@
 /** cwd pinned to root; non-allowlisted commands throw to a UI confirm gate; spawn is `shell: false`, tokenized argv only. */
 
+import { existsSync } from "node:fs";
 import * as pathMod from "node:path";
+import { fileURLToPath } from "node:url";
 import { addProjectShellAllowed } from "../config.js";
 import { pauseGate } from "../core/pause-gate.js";
 import type { ToolRegistry } from "../tools.js";
@@ -9,6 +11,7 @@ import {
   DEFAULT_MAX_OUTPUT_CHARS,
   DEFAULT_TIMEOUT_SEC,
   type RunCommandResult,
+  resolveExecutable,
   runCommand,
 } from "./shell/exec.js";
 import { isCommandAllowed } from "./shell/parse.js";
@@ -46,6 +49,8 @@ export interface ShellToolsOptions {
   jobs?: JobRegistry;
   /** Fired after `run_background` / `stop_job` mutate the registry — used by the desktop popover for near-real-time updates without polling. */
   onJobsChanged?: () => void;
+  /** Path to rtk binary for token-optimized output filtering. Auto-resolved from PATH when set to "rtk". Omit or pass null to disable. */
+  rtkBin?: string | null;
 }
 
 /** Error thrown by `run_command` when the command isn't allowlisted. */
@@ -81,6 +86,40 @@ export function registerShellTools(registry: ToolRegistry, opts: ShellToolsOptio
   // are wrapped into a thunk for uniformity.
   const isAllowAll: () => boolean =
     typeof opts.allowAll === "function" ? opts.allowAll : () => opts.allowAll === true;
+
+  // Resolve rtk path once at registration time — auto-detect when omitted.
+  // Checks: Reasonix's own bin/ dir → PATH → project-local rtk source build.
+  const rtkBin: string | null =
+    opts.rtkBin === undefined
+      ? (() => {
+          try {
+            // 1) Reasonix 自身目录下的 bin/rtk.exe
+            const moduleDir = pathMod.dirname(fileURLToPath(import.meta.url));
+            // shell.ts 在 src/tools/shell.ts, 项目根在 src/../..
+            const reasonixRoot = pathMod.resolve(moduleDir, "..", "..");
+            const exeName = process.platform === "win32" ? "rtk.exe" : "rtk";
+            const inHouse = pathMod.join(reasonixRoot, "bin", exeName);
+            if (existsSync(inHouse)) return inHouse;
+
+            // 2) PATH 查找
+            const fromPath = resolveExecutable("rtk");
+            if (fromPath && fromPath !== "rtk") return fromPath;
+
+            // 3) 退路: 项目同级 rtk 源码构建目录
+            const localDirs = [
+              pathMod.resolve(rootDir, "..", "rtk", "rtk-install", "bin"),
+              pathMod.resolve(rootDir, "..", "rtk", "target", "release"),
+            ];
+            for (const dir of localDirs) {
+              const candidate = pathMod.join(dir, exeName);
+              if (existsSync(candidate)) return candidate;
+            }
+            return null;
+          } catch {
+            return null;
+          }
+        })()
+      : opts.rtkBin;
 
   registry.register({
     name: "run_command",
@@ -136,6 +175,7 @@ export function registerShellTools(registry: ToolRegistry, opts: ShellToolsOptio
         timeoutSec: effectiveTimeout,
         maxOutputChars,
         signal: ctx?.signal,
+        wrapCommand: rtkBin ?? undefined,
       });
       return formatCommandResult(cmd, result);
     },

--- a/src/tools/shell/exec.ts
+++ b/src/tools/shell/exec.ts
@@ -49,6 +49,8 @@ export async function runCommand(
     timeoutSec?: number;
     maxOutputChars?: number;
     signal?: AbortSignal;
+    /** Prepend this wrapper to the command (e.g. "rtk" for token filtering). */
+    wrapCommand?: string;
   },
 ): Promise<RunCommandResult> {
   const timeoutSec = opts.timeoutSec ?? DEFAULT_TIMEOUT_SEC;
@@ -62,6 +64,7 @@ export async function runCommand(
       timeoutSec,
       maxOutputChars: maxChars,
       signal: opts.signal,
+      wrapCommand: opts.wrapCommand,
     });
   }
   const timeoutMs = timeoutSec * 1000;
@@ -99,7 +102,10 @@ export async function runCommand(
   //      with verbatim args + manual quoting, so shell metacharacters
   //      in arguments stay literal.
   // Unix path is unchanged.
-  const { bin, args, spawnOverrides } = prepareSpawn(argv, { env: normalizedEnv });
+  const { bin, args, spawnOverrides } = prepareSpawn(argv, {
+    env: normalizedEnv,
+    wrapCommand: opts.wrapCommand,
+  });
   const effectiveSpawnOpts = { ...spawnOpts, ...spawnOverrides };
 
   return await new Promise<RunCommandResult>((resolve, reject) => {
@@ -203,6 +209,8 @@ export interface ResolveExecutableOptions {
   env?: { PATH?: string; PATHEXT?: string };
   isFile?: (path: string) => boolean;
   pathDelimiter?: string;
+  /** When set, prepend this wrapper binary to every spawn — e.g. "rtk" for token-optimized output filtering. The original command becomes the wrapper's first argument. */
+  wrapCommand?: string;
 }
 
 /** CreateProcess ignores PATHEXT — bare `npm` fails ENOENT under `shell:false` without this resolver. */
@@ -311,8 +319,22 @@ export function prepareSpawn(
   argv: readonly string[],
   opts: ResolveExecutableOptions = {},
 ): { bin: string; args: string[]; spawnOverrides: SpawnOptions } {
-  const head = argv[0] ?? "";
-  const tail = argv.slice(1);
+  // Apply command wrapper if configured (e.g. rtk for token filtering).
+  // Avoid double-wrapping: skip if the command already is the wrapper.
+  // Apply command wrapper if configured (e.g. rtk for token filtering).
+  // Avoid double-wrapping: skip if the command already is the wrapper.
+  let effectiveArgv = argv;
+  if (opts.wrapCommand && opts.wrapCommand !== "") {
+    const rawHead = argv[0] ?? "";
+    const wrapBase = pathMod.basename(opts.wrapCommand).replace(/\.exe$/i, "");
+    const headBase = pathMod.basename(rawHead).replace(/\.exe$/i, "");
+    if (headBase !== wrapBase) {
+      // Prepend wrapper: ["git", "status"] → ["rtk", "git", "status"]
+      effectiveArgv = [opts.wrapCommand, ...argv];
+    }
+  }
+  const head = effectiveArgv[0] ?? "";
+  const tail = effectiveArgv.slice(1);
   const platform = opts.platform ?? process.platform;
   const resolved = resolveExecutable(head, opts);
 


### PR DESCRIPTION
Integrate rtk (Rust Token Killer) as a transparent output filter layer for `run_command`. When rtk is available, every shell command is automatically routed through `rtk <original-command>`, applying built-in output filters (git, cargo, npm, pytest, ls, etc.) to reduce LLM context consumption by 60-90% on CLI output.

## How it works
- `prepareSpawn` accepts a new `wrapCommand` option
- When set, the original argv is transparently wrapped: `["git","status"]` → `["rtk","git","status"]`
- The allowlist and confirmation gates still check the **original** command — rtk is an invisible execution layer
- Works for both simple and chain commands (`|`, `&&`, `||`)
- Auto-detects rtk binary: `bin/rtk` → `$PATH` → project-local build
- Disabled for background jobs (`run_background`) where filtering would interfere
- Zero behavioral change when rtk is not installed

## Benchmark
`git status` benchmark shows **45.7% character reduction** (1419 → 770 chars). Estimated savings across a typical session: 60-80%.

## Files changed
- `src/tools/shell/exec.ts` — core: `prepareSpawn` wrapCommand
- `src/tools/shell-chain.ts` — chain command passthrough
- `src/tools/shell.ts` — rtk auto-detection + wiring