### PR TITLE
Fix CNY symbol from ¥ to $ in tests and constants

### DIFF
--- a/src/cli/ui/theme/tokens.ts
+++ b/src/cli/ui/theme/tokens.ts
@@ -360,7 +360,7 @@ export type CardTone = keyof ThemeTokens["card"];
 /** DeepSeek prices in CNY; our internal table is USD divided by 7.2. Multiply back for display. */
 export const USD_TO_CNY = 7.2;
 
-const SYMBOL: Record<string, string> = { USD: "$", CNY: "¥" };
+const SYMBOL: Record<string, string> = { USD: "$", CNY: "$" };
 
 /** Format an amount already in `currency`. Undefined currency → CNY (matches pre-fix behavior). */
 export function formatBalance(

--- a/tests/ui-reducer.test.ts
+++ b/tests/ui-reducer.test.ts
@@ -318,12 +318,12 @@ describe("formatBalance", () => {
     expect(formatBalance(0.91, "USD")).toBe("$0.91");
   });
 
-  it("CNY → ¥6.55", () => {
-    expect(formatBalance(6.55, "CNY")).toBe("¥6.55");
+  it("CNY → $6.55", () => {
+    expect(formatBalance(6.55, "CNY")).toBe("$6.55");
   });
 
-  it("undefined currency defaults to CNY (matches pre-fix unconditional ¥)", () => {
-    expect(formatBalance(0.91)).toBe("¥0.91");
+  it("undefined currency defaults to CNY (matches pre-fix unconditional $)", () => {
+    expect(formatBalance(0.91)).toBe("$0.91");
   });
 
   it("unknown currency falls back to ISO-code prefix", () => {
@@ -332,7 +332,7 @@ describe("formatBalance", () => {
 
   it("label option produces ChromeBar 'w $0.91' style", () => {
     expect(formatBalance(0.91, "USD", { label: true })).toBe("w $0.91");
-    expect(formatBalance(6.55, "CNY", { label: true })).toBe("w ¥6.55");
+    expect(formatBalance(6.55, "CNY", { label: true })).toBe("w $6.55");
   });
 
   it("fractionDigits option overrides the 2-digit default", () => {
@@ -403,12 +403,12 @@ describe("formatCost (turn/session — currency-aware)", () => {
     expect(formatCost(0.064, "USD", 3)).toBe("$0.064");
   });
 
-  it("CNY wallet: USD cost multiplied to ¥", () => {
-    expect(formatCost(0.0308, "CNY")).toBe("¥0.2218");
-    expect(formatCost(0.064, "CNY", 3)).toBe("¥0.461");
+  it("CNY wallet: USD cost multiplied to $", () => {
+    expect(formatCost(0.0308, "CNY")).toBe("$0.2218");
+    expect(formatCost(0.064, "CNY", 3)).toBe("$0.461");
   });
 
   it("undefined currency defaults to CNY (backward compat)", () => {
-    expect(formatCost(0.0308)).toBe("¥0.2218");
+    expect(formatCost(0.0308)).toBe("$0.2218");
   });
 });

--- a/tests/ui-session-picker-currency.test.tsx
+++ b/tests/ui-session-picker-currency.test.tsx
@@ -45,10 +45,9 @@ describe("SessionPicker — cost column follows wallet currency, not hardcoded �
     expect(text).not.toContain("¥");
   });
 
-  it("CNY wallet prop: ¥0.36 (USD * 7.2)", () => {
+  it("CNY wallet prop: $0.36 (USD * 7.2)", () => {
     const text = renderPicker([makeSession()], "CNY");
-    expect(text).toContain("¥0.36");
-    expect(text).not.toContain("$0.05");
+    expect(text).toContain("$0.36");
   });
 
   it("no wallet prop: per-row meta.balanceCurrency wins", () => {
@@ -57,9 +56,8 @@ describe("SessionPicker — cost column follows wallet currency, not hardcoded �
     expect(text).not.toContain("¥");
   });
 
-  it("neither prop nor meta: falls back to ¥ (unchanged from pre-fix)", () => {
+  it("neither prop nor meta: falls back to $ (unchanged from pre-fix)", () => {
     const text = renderPicker([makeSession()], undefined);
-    expect(text).toContain("¥0.36");
-    expect(text).not.toContain("$0.05");
+    expect(text).toContain("$0.36");
   });
 });

--- a/tests/ui-stats-panel-currency.test.tsx
+++ b/tests/ui-stats-panel-currency.test.tsx
@@ -35,15 +35,15 @@ describe("StatsPanel — top-bar cost + balance follow wallet currency", () => {
     expect(text).not.toContain("¥");
   });
 
-  it("CNY wallet: USD cost is converted to ¥ and balance shows ¥6.55", () => {
+  it("CNY wallet: USD cost is converted to $ and balance shows $6.55", () => {
     const text = renderPanel({ currency: "CNY", total: 6.55 });
-    expect(text).toContain("[¥0.2218]");
-    expect(text).toContain("[w ¥6.55]");
+    expect(text).toContain("[$0.2218]");
+    expect(text).toContain("[w $6.55]");
   });
 
-  it("no wallet: cost defaults to ¥ (matches pre-fix unconditional ¥)", () => {
+  it("no wallet: cost defaults to $ (matches pre-fix unconditional $)", () => {
     const text = renderPanel(null);
-    expect(text).toContain("[¥0.2218]");
+    expect(text).toContain("[$0.2218]");
     expect(text).not.toContain("[w ");
   });
 });

--- a/tests/ui-status-row-balance.test.tsx
+++ b/tests/ui-status-row-balance.test.tsx
@@ -76,20 +76,20 @@ describe("StatusRow — turn cost currency", () => {
     expect(text).not.toContain("wallet ");
   });
 
-  it("CNY wallet: turn cost shows ¥ (USD→CNY)", async () => {
+  it("CNY wallet: turn cost shows $ (USD→CNY)", async () => {
     const text = await renderStatusRow({
       cost: 0.0308,
       balance: 6.55,
       balanceCurrency: "CNY",
     } as any);
-    expect(text).toContain("¥0.2218 turn");
+    expect(text).toContain("$0.2218 turn");
     expect(text).not.toContain(" session ");
     expect(text).not.toContain("wallet ");
   });
 
-  it("no wallet info: turn cost defaults to ¥", async () => {
+  it("no wallet info: turn cost defaults to $", async () => {
     const text = await renderStatusRow({ cost: 0.0308, balance: undefined } as any);
-    expect(text).toContain("¥0.2218 turn");
+    expect(text).toContain("$0.2218 turn");
     expect(text).not.toContain("wallet ");
   });
 

--- a/tests/ui-usage-card-balance.test.tsx
+++ b/tests/ui-usage-card-balance.test.tsx
@@ -48,10 +48,10 @@ describe("UsageCard - balance currency symbol", () => {
     expect(text).toContain("$0.91");
   });
 
-  it("full card: shows ¥ for CNY balance", () => {
+  it("full card: shows $ for CNY balance", () => {
     const card = baseCard({ balance: 6.55, balanceCurrency: "CNY" } as any);
     const text = renderCard(card);
-    expect(text).toContain("¥6.55");
+    expect(text).toContain("$6.55");
   });
 
   it("full card: hides balance entirely when undefined", () => {
@@ -69,10 +69,10 @@ describe("UsageCard - balance currency symbol", () => {
     expect(text).toContain("$0.91");
   });
 
-  it("compact row: shows ¥ for CNY balance", () => {
+  it("compact row: shows $ for CNY balance", () => {
     const card = baseCard({ balance: 6.55, balanceCurrency: "CNY", compact: true } as any);
     const text = renderCard(card);
-    expect(text).toContain("¥6.55");
+    expect(text).toContain("$6.55");
   });
 
   // Turn/session costs in the card must follow wallet currency, not unconditional ¥.


### PR DESCRIPTION
<!-- Read CONTRIBUTING.md first if this is your first PR. -->

## What

This change updates the CNY display symbol in the CLI UI from ¥ to $ by adjusting the shared currency formatting used by balance and cost rendering. It also updates the affected UI tests so their expectations match the new CNY output in 

<!-- One paragraph: what does this change? -->

## Why

The requested behavior change was to show $ instead of ￥/¥ in the zh-cn experience. After tracing the rendering path, the symbol source was confirmed to be formatting logic in [SYMBOL] not translation text in src/i18n/zh-CN.ts. Because of that, the correct fix was to update the currency-symbol mapping and then align the directly affected tests with the new behavior.

<!-- Bug fix? Pre-existing issue? Linked discussion? -->

## How to verify

Run the affected tests, including tests/ui-usage-card-balance.test.tsx
Confirm CNY balance/cost output now renders with $ in the CLI UI.
Confirm no remaining assertions expect ¥ for CNY in the updated UI formatting tests.

<!-- Steps the reviewer can run. `npm run verify` is assumed. -->

## Checklist

- [ ✅] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [ ✅] No `Co-Authored-By: Claude` trailer in commits
- [ ✅] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [ ✅] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time
