### PR TITLE
feat: add banner config option to skip boot splash

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -485,13 +485,15 @@ function AppInner({
     if (!isStreaming && liveExpand) setLiveExpand(false);
   }, [isStreaming, liveExpand]);
   const languageVersion = useLanguageReload();
-  // Splash holds for one full whale-spout cycle (~1.4s) so the brand
-  // mark always lands clean and heavy first-paint cost stays hidden.
-  const [bootReady, setBootReady] = useState(false);
+  // Boot splash: skip when config has banner:false, otherwise show
+  // one full whale-spout cycle (~1.4s) so the brand mark lands clean.
+  const showBanner = useMemo(() => readConfig().banner !== false, []);
+  const [bootReady, setBootReady] = useState(!showBanner);
   useEffect(() => {
+    if (!showBanner) return;
     const t = setTimeout(() => setBootReady(true), 1400);
     return () => clearTimeout(t);
-  }, []);
+  }, [showBanner]);
   useEffect(() => {
     markPhase("first_paint");
     dumpStartupProfile();

--- a/src/config.ts
+++ b/src/config.ts
@@ -89,6 +89,8 @@ export interface ReasonixConfig {
   editMode?: EditMode;
   editModeHintShown?: boolean;
   mouseClipboardHintShown?: boolean;
+  /** When false, skip the boot splash animation and show the main UI immediately. Default true. */
+  banner?: boolean;
   reasoningEffort?: ReasoningEffort;
   /** Default workspace root for the desktop client. CLI uses cwd. */
   workspaceDir?: string;


### PR DESCRIPTION
## Summary

Add a `"banner": false` config option that lets users skip the ~1.4s BootSplash animation on startup and jump straight into the UI.

## Benefits

1. **Configurable** — Some users enjoy the brand moment (whale spout animation), others find it slow or tiresome. A single boolean in `config.json` accommodates both camps without losing the splash entirely.

2. **Faster startup** — With `"banner": false` the forced 1.4s delay is eliminated entirely. `bootReady` is `true` from the first render, so the main UI appears as soon as React mounts.

## Changes

| File | Change |
|---|---|
| `src/config.ts` | Add `banner?: boolean` to `ReasonixConfig` (default: `true`) |
| `src/cli/ui/App.tsx` | Read config; skip 1400ms timer when `banner === false` |

## Usage

```
{
  "banner": false
}

```

Default behaviour (no config / `"banner": true`) is unchanged.


https://github.com/user-attachments/assets/9605098d-b0b1-4bc3-a5b7-609112781926

