### PR TITLE
[GTC] fix(tokenizer): bound pathological token counting

### DIFF
--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -61,7 +61,7 @@ import {
 } from "../../memory/session.js";
 import { MemoryStore } from "../../memory/user.js";
 import { SkillStore } from "../../skills.js";
-import { countTokens } from "../../tokenizer.js";
+import { countTokensBounded } from "../../tokenizer.js";
 import type { ChoiceOption } from "../../tools/choice.js";
 import type { ChatMessage } from "../../types.js";
 import { VERSION } from "../../version.js";
@@ -548,8 +548,8 @@ function emitMemory(tab: Tab): void {
 function emitCtxBreakdown(tab: Tab): void {
   if (!tab.runtime) return;
   try {
-    const sys = countTokens(tab.runtime.loop.prefix.system);
-    const tools = countTokens(JSON.stringify(tab.runtime.loop.prefix.toolSpecs));
+    const sys = countTokensBounded(tab.runtime.loop.prefix.system);
+    const tools = countTokensBounded(JSON.stringify(tab.runtime.loop.prefix.toolSpecs));
     emit({ type: "$ctx_breakdown", reservedTokens: sys + tools }, tab.id);
   } catch {
     // tokenizer warmup can throw on first call before the data file loads

--- a/src/cli/ui/cards/StreamingCard.tsx
+++ b/src/cli/ui/cards/StreamingCard.tsx
@@ -2,7 +2,7 @@ import { Box, Text, useStdout } from "ink";
 import React, { useContext } from "react";
 import { clipToCells } from "../../../frame/width.js";
 import { t } from "../../../i18n/index.js";
-import { countTokens } from "../../../tokenizer.js";
+import { countTokensBounded } from "../../../tokenizer.js";
 import { LiveExpandContext } from "../layout/LiveExpandContext.js";
 import { useReserveRows } from "../layout/viewport-budget.js";
 import { Markdown } from "../markdown.js";
@@ -51,14 +51,14 @@ function rateFromTokens(tokens: number, startTs: number, endTs: number): TokenRa
 }
 
 function tokenRate(text: string, startTs: number, endTs: number): TokenRate {
-  return rateFromTokens(countTokens(text), startTs, endTs);
+  return rateFromTokens(countTokensBounded(text), startTs, endTs);
 }
 
 export function estimateLiveTokenCount(
   text: string,
   cardId: string,
   calibration: LiveTokenCalibration | null,
-  countFn: (value: string) => number = countTokens,
+  countFn: (value: string) => number = countTokensBounded,
 ): { tokens: number; calibration: LiveTokenCalibration; exact: boolean } {
   const chars = text.length;
   const shouldCalibrate =

--- a/src/cli/ui/ctx-breakdown.tsx
+++ b/src/cli/ui/ctx-breakdown.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { t } from "../../i18n/index.js";
 import type { CacheFirstLoop } from "../../loop.js";
 import { DEEPSEEK_CONTEXT_TOKENS, DEFAULT_CONTEXT_TOKENS } from "../../telemetry/stats.js";
-import { countTokens } from "../../tokenizer.js";
+import { countTokensBounded } from "../../tokenizer.js";
 import { formatTokens } from "./primitives.js";
 import { COLOR } from "./theme.js";
 
@@ -20,13 +20,13 @@ export interface CtxBreakdownData {
 }
 
 /**
- * Walk the loop's prefix + log and tally tokens per category. Cheap
- * after the tokenizer warm-up (~100 ms first call, sub-ms after).
- * Memoize at the call site if used inside a render path.
+ * Walk the loop's prefix + log and tally tokens per category.
+ * Uses bounded counting because `/context` can inspect oversized tool
+ * results before the next loop-healing pass trims them.
  */
 export function computeCtxBreakdown(loop: CacheFirstLoop): CtxBreakdownData {
-  const systemTokens = countTokens(loop.prefix.system);
-  const toolsTokens = countTokens(JSON.stringify(loop.prefix.toolSpecs));
+  const systemTokens = countTokensBounded(loop.prefix.system);
+  const toolsTokens = countTokensBounded(JSON.stringify(loop.prefix.toolSpecs));
   const entries = loop.log.toMessages();
   let userTokens = 0;
   let assistantTokens = 0;
@@ -37,15 +37,15 @@ export function computeCtxBreakdown(loop: CacheFirstLoop): CtxBreakdownData {
   for (const e of entries) {
     const content = typeof e.content === "string" ? e.content : "";
     if (e.role === "user") {
-      userTokens += countTokens(content);
+      userTokens += countTokensBounded(content);
       logTurn += 1;
     } else if (e.role === "assistant") {
-      assistantTokens += countTokens(content);
+      assistantTokens += countTokensBounded(content);
       if (Array.isArray(e.tool_calls) && e.tool_calls.length > 0) {
-        toolCallTokens += countTokens(JSON.stringify(e.tool_calls));
+        toolCallTokens += countTokensBounded(JSON.stringify(e.tool_calls));
       }
     } else if (e.role === "tool") {
-      const n = countTokens(content);
+      const n = countTokensBounded(content);
       toolResultTokens += n;
       toolBreakdown.push({ name: e.name ?? "?", tokens: n, turn: logTurn });
     }

--- a/src/cli/ui/slash/handlers/observability.ts
+++ b/src/cli/ui/slash/handlers/observability.ts
@@ -6,7 +6,7 @@ import {
   DEEPSEEK_PRICING,
   DEFAULT_CONTEXT_TOKENS,
 } from "@/telemetry/stats.js";
-import { countTokens } from "@/tokenizer.js";
+import { countTokensBounded } from "@/tokenizer.js";
 import { VERSION } from "@/version.js";
 import { writeClipboard } from "../../clipboard.js";
 import { computeCtxBreakdown } from "../../ctx-breakdown.js";
@@ -185,7 +185,7 @@ function estimateCost(userText: string, loop: import("@/loop.js").CacheFirstLoop
   if (!pricing) {
     return { info: t("handlers.observability.costNoPricing", { model: loop.model }) };
   }
-  const userTokens = countTokens(userText);
+  const userTokens = countTokensBounded(userText);
   const breakdown = computeCtxBreakdown(loop);
   const promptTokens =
     breakdown.systemTokens + breakdown.toolsTokens + breakdown.logTokens + userTokens;

--- a/src/context-manager.ts
+++ b/src/context-manager.ts
@@ -11,7 +11,7 @@ import {
   DEFAULT_CONTEXT_TOKENS,
   type SessionStats,
 } from "./telemetry/stats.js";
-import { countTokens, estimateRequestTokens } from "./tokenizer.js";
+import { countTokensBounded, estimateRequestTokens } from "./tokenizer.js";
 import type { ChatMessage } from "./types.js";
 
 /** Auto-fold when a turn's response shows promptTokens above this fraction of ctxMax. */
@@ -156,7 +156,7 @@ export class ContextManager {
     if (all.length === 0) return noop;
 
     // Per-message content-only comparison for fold ordering (not exact API match).
-    const tokenCounts = all.map((m) => countTokens(m.content ?? ""));
+    const tokenCounts = all.map((m) => countTokensBounded(m.content ?? ""));
     const totalTokens = tokenCounts.reduce((a, b) => a + b, 0);
 
     let cumTokens = 0;

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -55,7 +55,6 @@ import {
 } from "./memory/session.js";
 import { type RepairReport, ToolCallRepair } from "./repair/index.js";
 import { SessionStats, type TurnStats } from "./telemetry/stats.js";
-import { countTokens } from "./tokenizer.js";
 import { ToolRegistry } from "./tools.js";
 import type { ChatMessage, ToolCall } from "./types.js";
 

--- a/src/loop/shrink.ts
+++ b/src/loop/shrink.ts
@@ -1,5 +1,5 @@
 import { truncateForModel, truncateForModelByTokens } from "../mcp/registry.js";
-import { countTokens } from "../tokenizer.js";
+import { countTokens, countTokensBounded } from "../tokenizer.js";
 import type { ChatMessage } from "../types.js";
 
 /** UI progress feedback only — NOT a dispatch gate. */
@@ -49,7 +49,7 @@ export function shrinkOversizedToolResultsByTokens(
     const content = typeof msg.content === "string" ? msg.content : "";
     // length ≤ maxTokens ⇒ tokens ≤ maxTokens — skip the per-message tokenize.
     if (content.length <= maxTokens) return msg;
-    const beforeTokens = countTokens(content);
+    const beforeTokens = countTokensBounded(content);
     if (beforeTokens <= maxTokens) return msg;
     const truncated = truncateForModelByTokens(content, maxTokens);
     const afterTokens = countTokens(truncated);
@@ -80,7 +80,7 @@ export function shrinkOversizedToolCallArgsByTokens(
     const newCalls = msg.tool_calls.map((call) => {
       const args = call.function?.arguments;
       if (typeof args !== "string" || args.length <= maxTokens) return call;
-      const beforeTokens = countTokens(args);
+      const beforeTokens = countTokensBounded(args);
       if (beforeTokens <= maxTokens) return call;
       const shrunk = shrinkJsonLongStrings(args);
       const afterTokens = countTokens(shrunk);

--- a/src/telemetry/subagent-distillation.ts
+++ b/src/telemetry/subagent-distillation.ts
@@ -1,6 +1,6 @@
 /** Distillation telemetry — measures parent-log growth avoided per spawn. */
 
-import { countTokens } from "../tokenizer.js";
+import { countTokensBounded } from "../tokenizer.js";
 
 /** Minimum shape `computeSpawnDistillation` needs. `SubagentResult` matches structurally; declaring a local interface avoids a stats ↔ subagent ↔ loop import cycle. */
 export interface SubagentResultLike {
@@ -24,7 +24,7 @@ export interface SpawnDistillation {
 }
 
 export function computeSpawnDistillation(result: SubagentResultLike): SpawnDistillation {
-  const outputTokens = countTokens(result.output);
+  const outputTokens = countTokensBounded(result.output);
   const completionTokens = result.usage.completionTokens;
   const savingsTokens = Math.max(0, completionTokens - outputTokens);
   const compressionRatio = completionTokens > 0 ? outputTokens / completionTokens : 1;

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -254,6 +254,27 @@ export function countTokens(text: string): number {
   return encode(text).length;
 }
 
+export const DEFAULT_BOUNDED_TOKENIZE_CHARS = 2 * 1024;
+
+export function countTokensBounded(
+  text: string,
+  maxChars = DEFAULT_BOUNDED_TOKENIZE_CHARS,
+): number {
+  if (text.length === 0) return 0;
+  const cap = Math.floor(maxChars);
+  if (cap > 0 && text.length <= cap) return countTokens(text);
+  if (cap <= 0) return Math.max(1, Math.ceil(text.length * 0.3));
+
+  const headChars = Math.ceil(cap / 2);
+  const tailChars = Math.floor(cap / 2);
+  const head = text.slice(0, headChars);
+  const tail = tailChars > 0 ? text.slice(-tailChars) : "";
+  const sampleChars = head.length + tail.length;
+  const sampleTokens = countTokens(head) + countTokens(tail);
+  const ratio = sampleChars > 0 ? sampleTokens / sampleChars : 0.3;
+  return Math.max(1, Math.ceil(text.length * ratio));
+}
+
 const BOS = "<｜begin▁of▁sentence｜>";
 const EOS = "<｜end▁of▁sentence｜>";
 const USER_SP = "<｜User｜>";
@@ -472,7 +493,7 @@ export function estimateConversationTokens(
   drop_thinking = false,
 ): number {
   if (messages.length === 0) return 0;
-  return countTokens(formatDeepSeekPrompt(messages, drop_thinking));
+  return countTokensBounded(formatDeepSeekPrompt(messages, drop_thinking));
 }
 
 /** Total request tokens (messages + tool specs) as the API counts them. Tool specs rendered via V4 TOOLS_TEMPLATE and added to message token count. */
@@ -489,7 +510,7 @@ export function estimateRequestTokens(
 ): number {
   let total = estimateConversationTokens(messages, drop_thinking);
   if (toolSpecs && toolSpecs.length > 0) {
-    total += countTokens(renderTools(toolSpecs));
+    total += countTokensBounded(renderTools(toolSpecs));
   }
   return total;
 }

--- a/tests/ctx-breakdown.test.ts
+++ b/tests/ctx-breakdown.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { computeCtxBreakdown } from "../src/cli/ui/ctx-breakdown.js";
+import type { CacheFirstLoop } from "../src/loop.js";
+import type { ChatMessage } from "../src/types.js";
+
+function fakeLoop(messages: ChatMessage[]): CacheFirstLoop {
+  return {
+    model: "deepseek-v4-flash",
+    prefix: { system: "system", toolSpecs: [] },
+    log: { toMessages: () => messages },
+  } as unknown as CacheFirstLoop;
+}
+
+describe("computeCtxBreakdown", () => {
+  it("bounds token counting for pathological large tool results", () => {
+    const loop = fakeLoop([
+      { role: "user", content: "read log" },
+      { role: "tool", name: "read_file", tool_call_id: "t1", content: "A".repeat(100_000) },
+    ]);
+
+    const t0 = performance.now();
+    const breakdown = computeCtxBreakdown(loop);
+    const t1 = performance.now();
+
+    expect(breakdown.logTokens).toBeGreaterThan(0);
+    expect(breakdown.topTools[0]?.name).toBe("read_file");
+    expect(t1 - t0).toBeLessThan(1000);
+  });
+});

--- a/tests/tokenizer.test.ts
+++ b/tests/tokenizer.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  DEFAULT_BOUNDED_TOKENIZE_CHARS,
   countTokens,
+  countTokensBounded,
   encode,
   estimateConversationTokens,
   estimateRequestTokens,
@@ -280,6 +282,40 @@ describe("estimateRequestTokens", () => {
     const withDrop = estimateConversationTokens(msgs, true);
     const withoutDrop = estimateConversationTokens(msgs, false);
     expect(withDrop).toBeLessThan(withoutDrop);
+  });
+});
+
+describe("countTokensBounded", () => {
+  it("keeps the default sample cap conservative for pathological BPE input", () => {
+    expect(DEFAULT_BOUNDED_TOKENIZE_CHARS).toBeLessThanOrEqual(2048);
+  });
+
+  it("returns the exact token count when input is within the char cap", () => {
+    const text = "Hello world! 你好 deepseek.";
+    expect(countTokensBounded(text, text.length)).toBe(countTokens(text));
+  });
+
+  it("estimates oversized input from a bounded head/tail sample", () => {
+    const head = "Hello world! ".repeat(40);
+    const middle = "A".repeat(100_000);
+    const tail = "你好 deepseek ".repeat(40);
+    const text = head + middle + tail;
+
+    const estimate = countTokensBounded(text, 512);
+
+    expect(estimate).toBeGreaterThan(0);
+    expect(estimate).toBeLessThan(text.length);
+    expect(estimate).toBeGreaterThan(Math.floor(text.length * 0.05));
+  });
+
+  it("bounds pathological repetitive input without multi-second BPE work", () => {
+    const text = "A".repeat(100_000);
+    const t0 = performance.now();
+    const estimate = countTokensBounded(text);
+    const t1 = performance.now();
+
+    expect(estimate).toBeGreaterThan(0);
+    expect(t1 - t0).toBeLessThan(1000);
   });
 });
 


### PR DESCRIPTION
## What

Adds bounded token counting for oversized text and routes the hot token-estimation paths through it: request estimation, context shrink ordering, `/context` breakdowns, desktop context telemetry, `/cost`, streaming token-rate estimates, and subagent distillation metrics. This keeps exact counting for normal-sized inputs while sampling pathological large strings.

## Why

Fixes #558. A reproduction is a very large repetitive payload such as `"A".repeat(100_000)` flowing into token-counting paths; exact BPE counting can spend multiple seconds there before shrink/healing gets a chance to reduce the content. The bounded counter avoids that stall while preserving a proportional estimate for context budgeting and UI telemetry.

## How to verify

`npm run verify`

Regression coverage added for `countTokensBounded("A".repeat(100_000))` and for `/context` breakdown over a 100KB tool result, both asserting the pathological path stays under 1 second.

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time