### PR TITLE
feat(config): add mcpServers canonical object format with headers support

### DIFF
--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -203,7 +203,8 @@
   "search": false,                    <span class="hash"># <span data-i18n="cfg.k.search">enable web_search/web_fetch tools</span></span>
   "webSearchEngine": "mojeek",        <span class="hash"># <span data-i18n="cfg.k.engine">mojeek | searxng | metaso</span></span>
   "webSearchEndpoint": "http://localhost:8080",
-  "mcp": [],                          <span class="hash"># <span data-i18n="cfg.k.mcp">MCP server specs</span></span>
+  "mcp": [],                          <span class="hash"># <span data-i18n="cfg.k.mcp">MCP server specs (legacy string format)</span></span>
+  "mcpServers": {},                   <span class="hash"># <span data-i18n="cfg.k.mcpsrv">MCP server objects (canonical format)</span></span>
   "mcpDisabled": [],                  <span class="hash"># <span data-i18n="cfg.k.mcpoff">names skipped at startup</span></span>
   "projects": {                       <span class="hash"># <span data-i18n="cfg.k.projects">per-workspace overrides</span></span>
     "/abs/path": {
@@ -267,6 +268,36 @@
             <p data-i18n="mcp.body.streamable">
               Opt in with the <code>streamable+</code> URL prefix.
             </p>
+
+            <h3 data-i18n="mcp.h.servers">mcpServers (canonical format)</h3>
+            <pre class="code"><code>{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": { "GITHUB_TOKEN": "ghp_***" }
+    },
+    "postgres": {
+      "transport": "sse",
+      "url": "https://mcp.internal/pg/sse",
+      "headers": { "Authorization": "Bearer ***" }
+    },
+    "edge": {
+      "transport": "streamable-http",
+      "url": "https://edge.example.com/mcp",
+      "headers": { "X-API-Key": "key_***" }
+    }
+  }
+}</code></pre>
+            <p data-i18n="mcp.body.servers">
+              The <code>mcpServers</code> object format is the canonical way to declare
+              MCP servers. Each key is the server name; the value is an object with
+              <code>command</code> + <code>args</code> (stdio), <code>url</code> (SSE /
+              Streamable HTTP), optional <code>transport</code> (auto-detected from url
+              when omitted), <code>env</code> (stdio only), <code>headers</code> (SSE /
+              Streamable HTTP only), and <code>disabled</code> (declarative toggle).
+              When both <code>mcp</code> and <code>mcpServers</code> are present and a
+              name overlaps, <code>mcpServers</code> wins silently.
 
             <h3 data-i18n="mcp.h.cli">CLI flags &amp; slash commands</h3>
             <pre class="code"><code>npx reasonix code --mcp "fs=npx -y @mcp/server-filesystem /tmp"

--- a/docs/src/config.jsx
+++ b/docs/src/config.jsx
@@ -35,7 +35,8 @@ const CONFIG_TABS = [
     },
     "postgres": {
       "transport": "sse",
-      "url": "https://mcp.internal/pg/sse"
+      "url": "https://mcp.internal/pg/sse",
+      "headers": { "Authorization": "Bearer ***" }
     }
   }
 }`,

--- a/src/cli/commands/acp.ts
+++ b/src/cli/commands/acp.ts
@@ -28,7 +28,7 @@ import {
   loadBaseUrl,
   loadPreset,
   loadReasoningEffort,
-  mcpEnvFor,
+  normalizeMcpConfig,
   readConfig,
 } from "../../config.js";
 import { loadEditMode } from "../../config.js";
@@ -41,7 +41,6 @@ import { CacheFirstLoop, DeepSeekClient, ImmutablePrefix } from "../../index.js"
 import { McpClient } from "../../mcp/client.js";
 import { preflightStdioSpec } from "../../mcp/preflight.js";
 import { bridgeMcpTools } from "../../mcp/registry.js";
-import { parseMcpSpec } from "../../mcp/spec.js";
 import { buildTransportFromSpec } from "../../mcp/transport-from-spec.js";
 import { timestampSuffix } from "../../memory/session.js";
 import { openTranscriptFile, recordFromLoopEvent, writeRecord } from "../../transcript/log.js";
@@ -93,22 +92,21 @@ export async function loadMcpServers(
   const clients: McpClient[] = [];
   if (specs.length === 0) return clients;
   const cfg = readConfig();
-  const disabledNames = new Set(cfg.mcpDisabled ?? []);
-  for (const raw of specs) {
+  const normalizedSpecs = normalizeMcpConfig(cfg, specs);
+  for (const spec of normalizedSpecs) {
     let label = "anon";
     let mcp: McpClient | undefined;
     try {
-      const spec = parseMcpSpec(raw);
       label = spec.name ?? "anon";
-      if (spec.name && disabledNames.has(spec.name)) {
+      if (spec.disabled) {
         process.stderr.write(`${formatMcpLifecycleEvent({ state: "disabled", name: label })}\n`);
         continue;
       }
       process.stderr.write(`${formatMcpLifecycleEvent({ state: "handshake", name: label })}\n`);
       const t0 = Date.now();
-      const prefix = resolveMcpPrefix(spec.name, specs.length, globalPrefix);
+      const prefix = resolveMcpPrefix(spec.name, normalizedSpecs.length, globalPrefix);
       if (spec.transport === "stdio") preflightStdioSpec(spec);
-      const transport = buildTransportFromSpec(spec, { env: mcpEnvFor(spec.name, cfg) });
+      const transport = buildTransportFromSpec(spec);
       mcp = new McpClient({ transport });
       await mcp.initialize();
       const bridge = await bridgeMcpTools(mcp, {

--- a/src/cli/commands/mcp-inspect.ts
+++ b/src/cli/commands/mcp-inspect.ts
@@ -18,14 +18,27 @@ export async function mcpInspectCommand(opts: McpInspectOptions): Promise<void> 
   const cfg = readConfig();
   const normalized = normalizeMcpConfig(cfg);
   const matched = parsed.name ? normalized.find((s) => s.name === parsed.name) : undefined;
-  const spec = (matched
-    ? {
-        ...parsed,
-        disabled: matched.disabled,
-        env: getMcpServerEnv(matched),
-        headers: getMcpServerHeaders(matched),
-      }
-    : { ...parsed }) as unknown as import("../../mcp/spec.js").McpServerSpec;
+  const spec: import("../../mcp/spec.js").McpServerSpec = matched
+    ? (() => {
+        switch (parsed.transport) {
+          case "stdio":
+            return { ...parsed, disabled: matched.disabled, env: getMcpServerEnv(matched) };
+          case "sse":
+            return { ...parsed, disabled: matched.disabled, headers: getMcpServerHeaders(matched) };
+          case "streamable-http":
+            return { ...parsed, disabled: matched.disabled, headers: getMcpServerHeaders(matched) };
+        }
+      })()
+    : (() => {
+        switch (parsed.transport) {
+          case "stdio":
+            return { ...parsed };
+          case "sse":
+            return { ...parsed };
+          case "streamable-http":
+            return { ...parsed };
+        }
+      })();
   if (spec.transport === "stdio") preflightStdioSpec(spec);
   const transport = buildTransportFromSpec(spec);
   const client = new McpClient({ transport });

--- a/src/cli/commands/mcp-inspect.ts
+++ b/src/cli/commands/mcp-inspect.ts
@@ -3,7 +3,7 @@ import { McpClient } from "../../mcp/client.js";
 import { inspectMcpServer } from "../../mcp/inspect.js";
 import type { InspectionReport } from "../../mcp/inspect.js";
 import { preflightStdioSpec } from "../../mcp/preflight.js";
-import { getMcpServerEnv, getMcpServerHeaders, parseMcpSpec } from "../../mcp/spec.js";
+import { overlayMatchedSpec, parseMcpSpec } from "../../mcp/spec.js";
 import { buildTransportFromSpec } from "../../mcp/transport-from-spec.js";
 
 export interface McpInspectOptions {
@@ -18,27 +18,7 @@ export async function mcpInspectCommand(opts: McpInspectOptions): Promise<void> 
   const cfg = readConfig();
   const normalized = normalizeMcpConfig(cfg);
   const matched = parsed.name ? normalized.find((s) => s.name === parsed.name) : undefined;
-  const spec: import("../../mcp/spec.js").McpServerSpec = matched
-    ? (() => {
-        switch (parsed.transport) {
-          case "stdio":
-            return { ...parsed, disabled: matched.disabled, env: getMcpServerEnv(matched) };
-          case "sse":
-            return { ...parsed, disabled: matched.disabled, headers: getMcpServerHeaders(matched) };
-          case "streamable-http":
-            return { ...parsed, disabled: matched.disabled, headers: getMcpServerHeaders(matched) };
-        }
-      })()
-    : (() => {
-        switch (parsed.transport) {
-          case "stdio":
-            return { ...parsed };
-          case "sse":
-            return { ...parsed };
-          case "streamable-http":
-            return { ...parsed };
-        }
-      })();
+  const spec = overlayMatchedSpec(parsed, matched);
   if (spec.transport === "stdio") preflightStdioSpec(spec);
   const transport = buildTransportFromSpec(spec);
   const client = new McpClient({ transport });

--- a/src/cli/commands/mcp-inspect.ts
+++ b/src/cli/commands/mcp-inspect.ts
@@ -1,9 +1,9 @@
-import { mcpEnvFor, readConfig } from "../../config.js";
+import { normalizeMcpConfig, readConfig } from "../../config.js";
 import { McpClient } from "../../mcp/client.js";
 import { inspectMcpServer } from "../../mcp/inspect.js";
 import type { InspectionReport } from "../../mcp/inspect.js";
 import { preflightStdioSpec } from "../../mcp/preflight.js";
-import { parseMcpSpec } from "../../mcp/spec.js";
+import { getMcpServerEnv, getMcpServerHeaders, parseMcpSpec } from "../../mcp/spec.js";
 import { buildTransportFromSpec } from "../../mcp/transport-from-spec.js";
 
 export interface McpInspectOptions {
@@ -14,9 +14,20 @@ export interface McpInspectOptions {
 }
 
 export async function mcpInspectCommand(opts: McpInspectOptions): Promise<void> {
-  const spec = parseMcpSpec(opts.spec);
+  const parsed = parseMcpSpec(opts.spec);
+  const cfg = readConfig();
+  const normalized = normalizeMcpConfig(cfg);
+  const matched = parsed.name ? normalized.find((s) => s.name === parsed.name) : undefined;
+  const spec = (matched
+    ? {
+        ...parsed,
+        disabled: matched.disabled,
+        env: getMcpServerEnv(matched),
+        headers: getMcpServerHeaders(matched),
+      }
+    : { ...parsed }) as unknown as import("../../mcp/spec.js").McpServerSpec;
   if (spec.transport === "stdio") preflightStdioSpec(spec);
-  const transport = buildTransportFromSpec(spec, { env: mcpEnvFor(spec.name, readConfig()) });
+  const transport = buildTransportFromSpec(spec);
   const client = new McpClient({ transport });
   try {
     await client.initialize();

--- a/src/cli/commands/mcp-runtime.ts
+++ b/src/cli/commands/mcp-runtime.ts
@@ -141,14 +141,35 @@ export function createMcpRuntime(ctx: RuntimeContext): McpRuntime {
       // env/headers/disabled from the normalized config. Transport stays
       // what the raw string parsed to so the runtime key (raw) remains stable.
       const matched = parsed.name ? normalized.find((s) => s.name === parsed.name) : undefined;
-      const spec = (matched
-        ? {
-            ...parsed,
-            disabled: matched.disabled,
-            env: getMcpServerEnv(matched),
-            headers: getMcpServerHeaders(matched),
-          }
-        : { ...parsed }) as unknown as import("../../mcp/spec.js").McpServerSpec;
+      const spec: import("../../mcp/spec.js").McpServerSpec = matched
+        ? (() => {
+            switch (parsed.transport) {
+              case "stdio":
+                return { ...parsed, disabled: matched.disabled, env: getMcpServerEnv(matched) };
+              case "sse":
+                return {
+                  ...parsed,
+                  disabled: matched.disabled,
+                  headers: getMcpServerHeaders(matched),
+                };
+              case "streamable-http":
+                return {
+                  ...parsed,
+                  disabled: matched.disabled,
+                  headers: getMcpServerHeaders(matched),
+                };
+            }
+          })()
+        : (() => {
+            switch (parsed.transport) {
+              case "stdio":
+                return { ...parsed };
+              case "sse":
+                return { ...parsed };
+              case "streamable-http":
+                return { ...parsed };
+            }
+          })();
       if (spec.disabled) {
         sink({ kind: "disabled", name: label });
         rejectReady(new Error(`MCP server "${label}" is disabled`));

--- a/src/cli/commands/mcp-runtime.ts
+++ b/src/cli/commands/mcp-runtime.ts
@@ -1,11 +1,11 @@
-import { mcpEnvFor, readConfig } from "../../config.js";
+import { normalizeMcpConfig, readConfig } from "../../config.js";
 import { t } from "../../i18n/index.js";
 import type { CacheFirstLoop } from "../../loop.js";
 import { McpClient } from "../../mcp/client.js";
 import { type InspectionReport, inspectMcpServer } from "../../mcp/inspect.js";
 import { preflightStdioSpec } from "../../mcp/preflight.js";
 import { type McpClientHost, bridgeMcpTools } from "../../mcp/registry.js";
-import { parseMcpSpec } from "../../mcp/spec.js";
+import { getMcpServerEnv, getMcpServerHeaders, parseMcpSpec, specToRaw } from "../../mcp/spec.js";
 import { buildMcpServerSummary } from "../../mcp/summary.js";
 import { buildTransportFromSpec } from "../../mcp/transport-from-spec.js";
 import type { ToolRegistry } from "../../tools.js";
@@ -117,7 +117,8 @@ export function createMcpRuntime(ctx: RuntimeContext): McpRuntime {
     }
     const tools = ctx.getTools();
     if (!tools) return { ok: false, reason: "no tool registry available" };
-    const disabledNames = new Set(readConfig().mcpDisabled ?? []);
+    const cfg = readConfig();
+    const normalized = normalizeMcpConfig(cfg);
     let label = "anon";
     let mcp: McpClient | undefined;
     // Per-server readiness gate — tool dispatches via the bridge await
@@ -134,9 +135,21 @@ export function createMcpRuntime(ctx: RuntimeContext): McpRuntime {
     // Avoid unhandledRejection if no consumer awaits `ready` yet.
     ready.catch(() => undefined);
     try {
-      const spec = parseMcpSpec(raw);
-      label = spec.name ?? "anon";
-      if (spec.name && disabledNames.has(spec.name)) {
+      const parsed = parseMcpSpec(raw);
+      label = parsed.name ?? "anon";
+      // If a mcpServers entry exists with the same name, it wins — overlay
+      // env/headers/disabled from the normalized config. Transport stays
+      // what the raw string parsed to so the runtime key (raw) remains stable.
+      const matched = parsed.name ? normalized.find((s) => s.name === parsed.name) : undefined;
+      const spec = (matched
+        ? {
+            ...parsed,
+            disabled: matched.disabled,
+            env: getMcpServerEnv(matched),
+            headers: getMcpServerHeaders(matched),
+          }
+        : { ...parsed }) as unknown as import("../../mcp/spec.js").McpServerSpec;
+      if (spec.disabled) {
         sink({ kind: "disabled", name: label });
         rejectReady(new Error(`MCP server "${label}" is disabled`));
         return { ok: false, reason: "disabled by user" };
@@ -149,7 +162,7 @@ export function createMcpRuntime(ctx: RuntimeContext): McpRuntime {
           ? (ctx.getMcpPrefix() as string)
           : "";
       if (spec.transport === "stdio") preflightStdioSpec(spec);
-      const transport = buildTransportFromSpec(spec, { env: mcpEnvFor(spec.name, readConfig()) });
+      const transport = buildTransportFromSpec(spec);
       mcp = new McpClient({ transport });
       await mcp.initialize();
       const host: McpClientHost = { client: mcp };
@@ -249,7 +262,8 @@ export function createMcpRuntime(ctx: RuntimeContext): McpRuntime {
     failed: Array<{ spec: string; reason: string }>;
     summaries: McpServerSummary[];
   }> {
-    const desired = readConfig().mcp ?? [];
+    const normalized = normalizeMcpConfig(readConfig());
+    const desired = normalized.map(specToRaw);
     const desiredSet = new Set(desired);
     const currentSet = new Set(records.keys());
     const added: string[] = [];

--- a/src/cli/commands/mcp-runtime.ts
+++ b/src/cli/commands/mcp-runtime.ts
@@ -5,7 +5,7 @@ import { McpClient } from "../../mcp/client.js";
 import { type InspectionReport, inspectMcpServer } from "../../mcp/inspect.js";
 import { preflightStdioSpec } from "../../mcp/preflight.js";
 import { type McpClientHost, bridgeMcpTools } from "../../mcp/registry.js";
-import { getMcpServerEnv, getMcpServerHeaders, parseMcpSpec, specToRaw } from "../../mcp/spec.js";
+import { overlayMatchedSpec, parseMcpSpec, specToRaw } from "../../mcp/spec.js";
 import { buildMcpServerSummary } from "../../mcp/summary.js";
 import { buildTransportFromSpec } from "../../mcp/transport-from-spec.js";
 import type { ToolRegistry } from "../../tools.js";
@@ -137,39 +137,8 @@ export function createMcpRuntime(ctx: RuntimeContext): McpRuntime {
     try {
       const parsed = parseMcpSpec(raw);
       label = parsed.name ?? "anon";
-      // If a mcpServers entry exists with the same name, it wins — overlay
-      // env/headers/disabled from the normalized config. Transport stays
-      // what the raw string parsed to so the runtime key (raw) remains stable.
       const matched = parsed.name ? normalized.find((s) => s.name === parsed.name) : undefined;
-      const spec: import("../../mcp/spec.js").McpServerSpec = matched
-        ? (() => {
-            switch (parsed.transport) {
-              case "stdio":
-                return { ...parsed, disabled: matched.disabled, env: getMcpServerEnv(matched) };
-              case "sse":
-                return {
-                  ...parsed,
-                  disabled: matched.disabled,
-                  headers: getMcpServerHeaders(matched),
-                };
-              case "streamable-http":
-                return {
-                  ...parsed,
-                  disabled: matched.disabled,
-                  headers: getMcpServerHeaders(matched),
-                };
-            }
-          })()
-        : (() => {
-            switch (parsed.transport) {
-              case "stdio":
-                return { ...parsed };
-              case "sse":
-                return { ...parsed };
-              case "streamable-http":
-                return { ...parsed };
-            }
-          })();
+      const spec = overlayMatchedSpec(parsed, matched);
       if (spec.disabled) {
         sink({ kind: "disabled", name: label });
         rejectReady(new Error(`MCP server "${label}" is disabled`));

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -6,7 +6,7 @@ import {
   isPlausibleKey,
   loadApiKey,
   loadBaseUrl,
-  mcpEnvFor,
+  normalizeMcpConfig,
   readConfig,
   saveApiKey,
 } from "../../config.js";
@@ -16,7 +16,6 @@ import { CacheFirstLoop, DeepSeekClient, ImmutablePrefix } from "../../index.js"
 import { McpClient } from "../../mcp/client.js";
 import { preflightStdioSpec } from "../../mcp/preflight.js";
 import { bridgeMcpTools } from "../../mcp/registry.js";
-import { parseMcpSpec } from "../../mcp/spec.js";
 import { buildTransportFromSpec } from "../../mcp/transport-from-spec.js";
 import { appendUsage } from "../../telemetry/usage.js";
 import { ToolRegistry } from "../../tools.js";
@@ -76,20 +75,22 @@ export async function runCommand(opts: RunOptions): Promise<void> {
 
   // Optional MCP setup — mirrors chat's flow. Must happen before loop
   // construction so the tools make it into the prefix.
-  const requestedSpecs = opts.mcp ?? [];
+  const cfg = readConfig();
+  const normalizedSpecs = normalizeMcpConfig(
+    cfg,
+    opts.mcp && opts.mcp.length > 0 ? opts.mcp : undefined,
+  );
   const clients: McpClient[] = [];
   let tools: ToolRegistry | undefined;
   let successCount = 0;
-  const disabledNames = new Set(readConfig().mcpDisabled ?? []);
-  if (requestedSpecs.length > 0) {
+  if (normalizedSpecs.length > 0) {
     tools = new ToolRegistry();
-    for (const raw of requestedSpecs) {
+    for (const spec of normalizedSpecs) {
       let label = "anon";
       let mcp: McpClient | undefined;
       try {
-        const spec = parseMcpSpec(raw);
         label = spec.name ?? "anon";
-        if (spec.name && disabledNames.has(spec.name)) {
+        if (spec.disabled) {
           process.stderr.write(`${formatMcpLifecycleEvent({ state: "disabled", name: label })}\n`);
           continue;
         }
@@ -97,13 +98,11 @@ export async function runCommand(opts: RunOptions): Promise<void> {
         const t0 = Date.now();
         const prefix = spec.name
           ? `${spec.name}_`
-          : requestedSpecs.length === 1 && opts.mcpPrefix
+          : normalizedSpecs.length === 1 && opts.mcpPrefix
             ? opts.mcpPrefix
             : "";
         if (spec.transport === "stdio") preflightStdioSpec(spec);
-        const transport = buildTransportFromSpec(spec, {
-          env: mcpEnvFor(spec.name, readConfig()),
-        });
+        const transport = buildTransportFromSpec(spec);
         mcp = new McpClient({ transport });
         await mcp.initialize();
         const bridge = await bridgeMcpTools(mcp, {

--- a/src/cli/resolve.ts
+++ b/src/cli/resolve.ts
@@ -2,7 +2,8 @@
 
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
-import { type PresetName, type ReasonixConfig, readConfig } from "../config.js";
+import { type PresetName, type ReasonixConfig, normalizeMcpConfig, readConfig } from "../config.js";
+import { specToRaw } from "../mcp/spec.js";
 import { resolvePreset } from "./ui/presets.js";
 
 export interface ResolvedDefaults {
@@ -34,7 +35,11 @@ export function resolveDefaults(flags: RawCliFlags): ResolvedDefaults {
   // `--mcp` accumulator is [] when absent. Treat empty from flags as
   // "user didn't pass" → fall through to config. Users who explicitly
   // want zero MCP servers can pass `--no-config` or edit the file.
-  const mcp = flags.mcp && flags.mcp.length > 0 ? flags.mcp : (cfg.mcp ?? []);
+  const normalizedMcp = normalizeMcpConfig(
+    cfg,
+    flags.mcp && flags.mcp.length > 0 ? flags.mcp : undefined,
+  );
+  const mcp = normalizedMcp.map(specToRaw);
 
   const session = resolveSession(flags.session, cfg.session);
 

--- a/src/cli/ui/mcp-reconnect-kickoff.ts
+++ b/src/cli/ui/mcp-reconnect-kickoff.ts
@@ -1,6 +1,6 @@
 /** Shared async-fire-and-forget reconnect trigger — called by both `/mcp reconnect` and the McpBrowser `r` keybind. */
 
-import { mcpEnvFor, readConfig } from "../../config.js";
+import { normalizeMcpConfig, readConfig } from "../../config.js";
 import { reconnectMcpServer } from "../../mcp/reconnect.js";
 import { parseMcpSpec } from "../../mcp/spec.js";
 import type { McpTool } from "../../mcp/types.js";
@@ -25,19 +25,22 @@ export function kickOffMcpReconnect(
   let liveTarget = target;
   void (async () => {
     try {
-      const env = (() => {
-        try {
-          return mcpEnvFor(parseMcpSpec(liveTarget.spec).name, readConfig());
-        } catch {
-          return undefined;
-        }
-      })();
+      const parsed = parseMcpSpec(liveTarget.spec);
+      const cfg = readConfig();
+      const normalized = normalizeMcpConfig(cfg);
+      const matched = parsed.name ? normalized.find((s) => s.name === parsed.name) : undefined;
+      const env = matched && matched.transport === "stdio" ? matched.env : undefined;
+      const headers =
+        matched && (matched.transport === "sse" || matched.transport === "streamable-http")
+          ? matched.headers
+          : undefined;
       const result = await reconnectMcpServer({
         host: liveTarget.host,
         spec: liveTarget.spec,
         beforeTools,
         accept,
         env,
+        headers,
       });
       if (result.ok) {
         if (result.kind === "append" && applyAppend) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,7 @@ import {
   type ResolvedIndexConfig,
   resolveIndexConfig,
 } from "./index/config.js";
+import { type McpServerSpec, parseMcpSpec } from "./mcp/spec.js";
 
 /** Legacy `fast|smart|max` kept for back-compat with existing config.json files. */
 export type PresetName = "auto" | "flash" | "pro" | "fast" | "smart" | "max";
@@ -74,6 +75,16 @@ export interface SemanticEmbeddingConfigView {
   };
 }
 
+export interface McpServerConfig {
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  transport?: "stdio" | "sse" | "streamable-http";
+  url?: string;
+  headers?: Record<string, string>;
+  disabled?: boolean;
+}
+
 export interface QQBotConfig {
   appId?: string;
   appSecret?: string;
@@ -105,6 +116,8 @@ export interface ReasonixConfig {
   mcpDisabled?: string[];
   /** Env overlay per MCP server name (matches the `name=` prefix of the spec). Stdio transports merge this over process.env; SSE/HTTP ignore it. */
   mcpEnv?: Record<string, Record<string, string>>;
+  /** Canonical MCP server configuration — merges with and overrides legacy `mcp`/`mcpEnv`/`mcpDisabled`. */
+  mcpServers?: Record<string, McpServerConfig>;
   session?: string | null;
   setupCompleted?: boolean;
   search?: boolean;
@@ -268,6 +281,113 @@ export function mcpEnvFor(
     if (typeof v === "string" && v.length > 0) filtered[k] = v;
   }
   return Object.keys(filtered).length > 0 ? filtered : undefined;
+}
+
+function inferMcpTransport(cfg: McpServerConfig): "stdio" | "sse" | "streamable-http" {
+  if (cfg.transport) return cfg.transport;
+  const url = cfg.url?.trim() ?? "";
+  if (/^streamable\+https?:\/\//i.test(url)) return "streamable-http";
+  if (/^https?:\/\//i.test(url)) return "sse";
+  return "stdio";
+}
+
+function normalizeStringRecord(value: unknown): Record<string, string> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(value)) {
+    if (typeof v === "string" && v.length > 0) out[k] = v;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+export function normalizeMcpConfig(cfg: ReasonixConfig, extraLegacy?: string[]): McpServerSpec[] {
+  const result: McpServerSpec[] = [];
+  const seen = new Set<string>();
+
+  // 1. Legacy specs first.
+  const disabledFromLegacy = new Set(cfg.mcpDisabled ?? []);
+  const legacySpecs = extraLegacy && extraLegacy.length > 0 ? extraLegacy : (cfg.mcp ?? []);
+  for (const raw of legacySpecs) {
+    if (typeof raw !== "string") continue;
+    try {
+      const spec = parseMcpSpec(raw);
+      const env = spec.name ? normalizeStringRecord(cfg.mcpEnv?.[spec.name]) : undefined;
+      const disabled = spec.name ? disabledFromLegacy.has(spec.name) : false;
+      if (spec.transport === "stdio") {
+        result.push({ ...spec, env, disabled });
+      } else if (spec.transport === "sse") {
+        result.push({ ...spec, disabled });
+      } else {
+        result.push({ ...spec, disabled });
+      }
+      if (spec.name) seen.add(spec.name);
+    } catch {
+      /* skip invalid legacy specs */
+    }
+  }
+
+  // 2. mcpServers objects override on name conflict.
+  for (const [name, serverCfg] of Object.entries(cfg.mcpServers ?? {})) {
+    if (!serverCfg || typeof serverCfg !== "object") continue;
+    const transport = inferMcpTransport(serverCfg as McpServerConfig);
+    const disabled = (serverCfg as McpServerConfig).disabled === true;
+    if (transport === "stdio") {
+      const env = normalizeStringRecord((serverCfg as McpServerConfig).env);
+      const spec: McpServerSpec = {
+        transport: "stdio",
+        name,
+        command: (serverCfg as McpServerConfig).command ?? "",
+        args: (serverCfg as McpServerConfig).args ?? [],
+        env,
+        disabled,
+      };
+      if (seen.has(name)) {
+        const idx = result.findIndex((s) => s.name === name);
+        if (idx >= 0) result[idx] = spec;
+      } else {
+        seen.add(name);
+        result.push(spec);
+      }
+    } else {
+      let url = (serverCfg as McpServerConfig).url ?? "";
+      const streamMatch = /^streamable\+(https?:\/\/.+)$/i.exec(url);
+      if (streamMatch) url = streamMatch[1]!;
+      const headers = normalizeStringRecord((serverCfg as McpServerConfig).headers);
+      if (transport === "sse") {
+        const spec: McpServerSpec = {
+          transport: "sse",
+          name,
+          url,
+          headers,
+          disabled,
+        };
+        if (seen.has(name)) {
+          const idx = result.findIndex((s) => s.name === name);
+          if (idx >= 0) result[idx] = spec;
+        } else {
+          seen.add(name);
+          result.push(spec);
+        }
+      } else {
+        const spec: McpServerSpec = {
+          transport: "streamable-http",
+          name,
+          url,
+          headers,
+          disabled,
+        };
+        if (seen.has(name)) {
+          const idx = result.findIndex((s) => s.name === name);
+          if (idx >= 0) result[idx] = spec;
+        } else {
+          seen.add(name);
+          result.push(spec);
+        }
+      }
+    }
+  }
+
+  return result;
 }
 
 /** Persist the language so it survives a relaunch. */

--- a/src/mcp/reconnect.ts
+++ b/src/mcp/reconnect.ts
@@ -18,6 +18,8 @@ export interface ReconnectArgs {
   accept?: ReadonlyArray<"identity" | "append">;
   /** Stdio env overlay — same lookup that produced the live client's env. */
   env?: Record<string, string>;
+  /** SSE / Streamable-HTTP headers overlay. */
+  headers?: Record<string, string>;
 }
 
 export type ReconnectResult =
@@ -56,7 +58,10 @@ export async function reconnectMcpServer(args: ReconnectArgs): Promise<Reconnect
       ms: Date.now() - t0,
     };
   }
-  const transport = buildTransportFromSpec(parsed, { env: args.env });
+  const transport = buildTransportFromSpec(parsed as import("./spec.js").McpServerSpec, {
+    env: args.env,
+    headers: args.headers,
+  });
   const next = new McpClient({ transport });
   try {
     await next.initialize();

--- a/src/mcp/reconnect.ts
+++ b/src/mcp/reconnect.ts
@@ -58,22 +58,10 @@ export async function reconnectMcpServer(args: ReconnectArgs): Promise<Reconnect
       ms: Date.now() - t0,
     };
   }
-  const transport = buildTransportFromSpec(
-    (() => {
-      switch (parsed.transport) {
-        case "stdio":
-          return { ...parsed };
-        case "sse":
-          return { ...parsed };
-        case "streamable-http":
-          return { ...parsed };
-      }
-    })(),
-    {
-      env: args.env,
-      headers: args.headers,
-    },
-  );
+  const transport = buildTransportFromSpec(parsed, {
+    env: args.env,
+    headers: args.headers,
+  });
   const next = new McpClient({ transport });
   try {
     await next.initialize();

--- a/src/mcp/reconnect.ts
+++ b/src/mcp/reconnect.ts
@@ -58,10 +58,22 @@ export async function reconnectMcpServer(args: ReconnectArgs): Promise<Reconnect
       ms: Date.now() - t0,
     };
   }
-  const transport = buildTransportFromSpec(parsed as import("./spec.js").McpServerSpec, {
-    env: args.env,
-    headers: args.headers,
-  });
+  const transport = buildTransportFromSpec(
+    (() => {
+      switch (parsed.transport) {
+        case "stdio":
+          return { ...parsed };
+        case "sse":
+          return { ...parsed };
+        case "streamable-http":
+          return { ...parsed };
+      }
+    })(),
+    {
+      env: args.env,
+      headers: args.headers,
+    },
+  );
   const next = new McpClient({ transport });
   try {
     await next.initialize();

--- a/src/mcp/spec.ts
+++ b/src/mcp/spec.ts
@@ -28,6 +28,40 @@ export interface StreamableHttpMcpSpec {
 
 export type McpSpec = StdioMcpSpec | SseMcpSpec | StreamableHttpMcpSpec;
 
+export type McpServerSpec =
+  | (StdioMcpSpec & { env?: Record<string, string>; disabled?: boolean })
+  | (SseMcpSpec & { headers?: Record<string, string>; disabled?: boolean })
+  | (StreamableHttpMcpSpec & { headers?: Record<string, string>; disabled?: boolean });
+
+export function getMcpServerEnv(spec: McpServerSpec): Record<string, string> | undefined {
+  return spec.transport === "stdio" ? spec.env : undefined;
+}
+
+export function getMcpServerHeaders(spec: McpServerSpec): Record<string, string> | undefined {
+  return spec.transport !== "stdio" ? spec.headers : undefined;
+}
+
+/** Serialize a normalized spec back to the `--mcp` string format. Round-trips through `parseMcpSpec`. */
+export function specToRaw(spec: McpServerSpec): string {
+  if (spec.transport === "stdio") {
+    const args = spec.args
+      .map((a) => {
+        if (a.includes(" ") || a.includes('"') || a.includes("\t")) {
+          // Double-quote and escape internal double quotes + backslashes.
+          return `"${a.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+        }
+        return a;
+      })
+      .join(" ");
+    const body = args ? `${spec.command} ${args}` : spec.command;
+    return spec.name ? `${spec.name}=${body}` : body;
+  }
+  if (spec.transport === "sse") {
+    return spec.name ? `${spec.name}=${spec.url}` : spec.url;
+  }
+  return spec.name ? `${spec.name}=streamable+${spec.url}` : `streamable+${spec.url}`;
+}
+
 const NAME_PREFIX = /^([a-zA-Z_][a-zA-Z0-9_-]*)=(.*)$/;
 const HTTP_URL = /^https?:\/\//i;
 const STREAMABLE_PREFIX = /^streamable\+(https?:\/\/.+)$/i;

--- a/src/mcp/spec.ts
+++ b/src/mcp/spec.ts
@@ -41,6 +41,26 @@ export function getMcpServerHeaders(spec: McpServerSpec): Record<string, string>
   return spec.transport !== "stdio" ? spec.headers : undefined;
 }
 
+export function overlayMatchedSpec(
+  parsed: McpSpec,
+  matched: McpServerSpec | undefined,
+): McpServerSpec {
+  switch (parsed.transport) {
+    case "stdio":
+      return matched
+        ? { ...parsed, disabled: matched.disabled, env: getMcpServerEnv(matched) }
+        : { ...parsed };
+    case "sse":
+      return matched
+        ? { ...parsed, disabled: matched.disabled, headers: getMcpServerHeaders(matched) }
+        : { ...parsed };
+    case "streamable-http":
+      return matched
+        ? { ...parsed, disabled: matched.disabled, headers: getMcpServerHeaders(matched) }
+        : { ...parsed };
+  }
+}
+
 /** Serialize a normalized spec back to the `--mcp` string format. Round-trips through `parseMcpSpec`. */
 export function specToRaw(spec: McpServerSpec): string {
   if (spec.transport === "stdio") {

--- a/src/mcp/transport-from-spec.ts
+++ b/src/mcp/transport-from-spec.ts
@@ -1,4 +1,4 @@
-import type { McpSpec } from "./spec.js";
+import type { McpServerSpec } from "./spec.js";
 import { SseTransport } from "./sse.js";
 import { type McpTransport, StdioTransport } from "./stdio.js";
 import { StreamableHttpTransport } from "./streamable-http.js";
@@ -6,13 +6,26 @@ import { StreamableHttpTransport } from "./streamable-http.js";
 export interface BuildTransportOptions {
   /** Stdio-only env overlay — merged over process.env. SSE/Streamable-HTTP ignore it. */
   env?: Record<string, string>;
+  /** SSE / Streamable-HTTP only. Ignored by stdio. */
+  headers?: Record<string, string>;
 }
 
 export function buildTransportFromSpec(
-  spec: McpSpec,
+  spec: McpServerSpec,
   opts: BuildTransportOptions = {},
 ): McpTransport {
-  if (spec.transport === "sse") return new SseTransport({ url: spec.url });
-  if (spec.transport === "streamable-http") return new StreamableHttpTransport({ url: spec.url });
-  return new StdioTransport({ command: spec.command, args: spec.args, env: opts.env });
+  if (spec.transport === "sse") {
+    return new SseTransport({ url: spec.url, headers: opts.headers ?? spec.headers });
+  }
+  if (spec.transport === "streamable-http") {
+    return new StreamableHttpTransport({
+      url: spec.url,
+      headers: opts.headers ?? spec.headers,
+    });
+  }
+  return new StdioTransport({
+    command: spec.command,
+    args: spec.args,
+    env: opts.env ?? spec.env,
+  });
 }

--- a/tests/mcp-normalize-config.test.ts
+++ b/tests/mcp-normalize-config.test.ts
@@ -1,0 +1,434 @@
+import { describe, expect, it } from "vitest";
+import { type ReasonixConfig, normalizeMcpConfig } from "../src/config.js";
+import type { McpServerSpec } from "../src/mcp/spec.js";
+import { SseTransport } from "../src/mcp/sse.js";
+import { StdioTransport } from "../src/mcp/stdio.js";
+import { StreamableHttpTransport } from "../src/mcp/streamable-http.js";
+import { buildTransportFromSpec } from "../src/mcp/transport-from-spec.js";
+
+function names(specs: McpServerSpec[]): (string | null)[] {
+  return specs.map((s) => s.name);
+}
+
+function findByName(specs: McpServerSpec[], name: string): McpServerSpec | undefined {
+  return specs.find((s) => s.name === name);
+}
+
+describe("normalizeMcpConfig: legacy-only", () => {
+  it("parses mcp: string[] into McpServerSpec[]", () => {
+    const cfg: ReasonixConfig = {
+      mcp: ["fs=npx -y @scope/fs /tmp", "git=uvx mcp-server-git"],
+    };
+    const result = normalizeMcpConfig(cfg);
+    expect(result).toHaveLength(2);
+    expect(names(result)).toEqual(["fs", "git"]);
+    const fs = findByName(result, "fs")!;
+    expect(fs.transport).toBe("stdio");
+    if (fs.transport !== "stdio") throw new Error("unreachable");
+    expect(fs.command).toBe("npx");
+    expect(fs.args).toEqual(["-y", "@scope/fs", "/tmp"]);
+    expect(fs.env).toBeUndefined();
+    expect(fs.disabled).toBe(false);
+  });
+
+  it("parses anonymous legacy specs", () => {
+    const cfg: ReasonixConfig = {
+      mcp: ["npx -y @scope/fs /tmp"],
+    };
+    const result = normalizeMcpConfig(cfg);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.name).toBeNull();
+  });
+
+  it("parses SSE legacy specs", () => {
+    const cfg: ReasonixConfig = {
+      mcp: ["remote=https://example.com/sse"],
+    };
+    const result = normalizeMcpConfig(cfg);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.transport).toBe("sse");
+  });
+
+  it("parses streamable-http legacy specs", () => {
+    const cfg: ReasonixConfig = {
+      mcp: ["edge=streamable+https://edge.example.com/mcp"],
+    };
+    const result = normalizeMcpConfig(cfg);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.transport).toBe("streamable-http");
+  });
+
+  it("skips invalid legacy specs silently", () => {
+    const cfg: ReasonixConfig = {
+      mcp: ["fs=npx -y @scope/fs", "", "   "],
+    };
+    const result = normalizeMcpConfig(cfg);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.name).toBe("fs");
+  });
+});
+
+describe("normalizeMcpConfig: object-only", () => {
+  it("parses mcpServers into McpServerSpec[]", () => {
+    const cfg: ReasonixConfig = {
+      mcpServers: {
+        github: {
+          command: "npx",
+          args: ["-y", "@modelcontextprotocol/server-github"],
+          env: { GITHUB_TOKEN: "ghp_abc" },
+        },
+        filesystem: {
+          command: "npx",
+          args: ["-y", "@modelcontextprotocol/server-filesystem", "/data"],
+        },
+      },
+    };
+    const result = normalizeMcpConfig(cfg);
+    expect(result).toHaveLength(2);
+    expect(names(result)).toEqual(["github", "filesystem"]);
+    const gh = findByName(result, "github")!;
+    expect(gh.transport).toBe("stdio");
+    if (gh.transport !== "stdio") throw new Error("unreachable");
+    expect(gh.command).toBe("npx");
+    expect(gh.args).toEqual(["-y", "@modelcontextprotocol/server-github"]);
+    expect(gh.env).toEqual({ GITHUB_TOKEN: "ghp_abc" });
+  });
+
+  it("parses SSE mcpServers with headers", () => {
+    const cfg: ReasonixConfig = {
+      mcpServers: {
+        remote: {
+          transport: "sse",
+          url: "https://example.com/sse",
+          headers: { Authorization: "Bearer tok_abc" },
+        },
+      },
+    };
+    const result = normalizeMcpConfig(cfg);
+    expect(result).toHaveLength(1);
+    const spec = result[0]!;
+    expect(spec.transport).toBe("sse");
+    if (spec.transport !== "sse") throw new Error("unreachable");
+    expect(spec.url).toBe("https://example.com/sse");
+    expect(spec.headers).toEqual({ Authorization: "Bearer tok_abc" });
+  });
+
+  it("parses streamable-http mcpServers with headers", () => {
+    const cfg: ReasonixConfig = {
+      mcpServers: {
+        edge: {
+          transport: "streamable-http",
+          url: "https://edge.example.com/mcp",
+          headers: { "X-API-Key": "key_xyz" },
+        },
+      },
+    };
+    const result = normalizeMcpConfig(cfg);
+    expect(result).toHaveLength(1);
+    const spec = result[0]!;
+    expect(spec.transport).toBe("streamable-http");
+    if (spec.transport !== "streamable-http") throw new Error("unreachable");
+    expect(spec.url).toBe("https://edge.example.com/mcp");
+    expect(spec.headers).toEqual({ "X-API-Key": "key_xyz" });
+  });
+
+  it("infers transport from url when transport is omitted", () => {
+    const cfg: ReasonixConfig = {
+      mcpServers: {
+        sseSvc: { url: "https://example.com/sse" },
+        stdioSvc: { command: "npx", args: ["-y", "pkg"] },
+      },
+    };
+    const result = normalizeMcpConfig(cfg);
+    expect(result).toHaveLength(2);
+    const sse = findByName(result, "sseSvc")!;
+    expect(sse.transport).toBe("sse");
+    const stdio = findByName(result, "stdioSvc")!;
+    expect(stdio.transport).toBe("stdio");
+  });
+
+  it("strips streamable+ prefix from url when transport is omitted", () => {
+    const cfg: ReasonixConfig = {
+      mcpServers: {
+        edge: { url: "streamable+https://edge.example.com/mcp" },
+      },
+    };
+    const result = normalizeMcpConfig(cfg);
+    expect(result).toHaveLength(1);
+    const spec = result[0]!;
+    expect(spec.transport).toBe("streamable-http");
+    if (spec.transport !== "streamable-http") throw new Error("unreachable");
+    expect(spec.url).toBe("https://edge.example.com/mcp");
+  });
+});
+
+describe("normalizeMcpConfig: merge with name conflict", () => {
+  it("mcpServers wins silently when both sources have the same name", () => {
+    const cfg: ReasonixConfig = {
+      mcp: ["fs=npx -y @scope/fs /tmp"],
+      mcpServers: {
+        fs: {
+          command: "node",
+          args: ["server.js"],
+          env: { CUSTOM: "value" },
+        },
+      },
+    };
+    const result = normalizeMcpConfig(cfg);
+    expect(result).toHaveLength(1);
+    const spec = result[0]!;
+    expect(spec.name).toBe("fs");
+    if (spec.transport !== "stdio") throw new Error("unreachable");
+    // mcpServers wins: command and args from mcpServers
+    expect(spec.command).toBe("node");
+    expect(spec.args).toEqual(["server.js"]);
+    expect(spec.env).toEqual({ CUSTOM: "value" });
+  });
+
+  it("mcpServers entry shadows legacy spec with same name", () => {
+    const cfg: ReasonixConfig = {
+      mcp: ["fs=npx -y @scope/fs /tmp", "git=uvx mcp-server-git"],
+      mcpServers: {
+        fs: {
+          transport: "sse",
+          url: "https://mcp.internal/fs/sse",
+          headers: { Authorization: "Bearer tok" },
+        },
+      },
+    };
+    const result = normalizeMcpConfig(cfg);
+    expect(result).toHaveLength(2);
+    const fs = findByName(result, "fs")!;
+    // mcpServers wins: fs is now SSE, not stdio
+    expect(fs.transport).toBe("sse");
+    if (fs.transport !== "sse") throw new Error("unreachable");
+    expect(fs.url).toBe("https://mcp.internal/fs/sse");
+    expect(fs.headers).toEqual({ Authorization: "Bearer tok" });
+    // git is still from legacy
+    const git = findByName(result, "git")!;
+    expect(git.transport).toBe("stdio");
+  });
+});
+
+describe("normalizeMcpConfig: disabled handling", () => {
+  it("honors disabled: true from mcpServers entry", () => {
+    const cfg: ReasonixConfig = {
+      mcpServers: {
+        github: {
+          command: "npx",
+          args: ["-y", "@scope/github"],
+          disabled: true,
+        },
+      },
+    };
+    const result = normalizeMcpConfig(cfg);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.disabled).toBe(true);
+  });
+
+  it("honors disabled from legacy mcpDisabled array", () => {
+    const cfg: ReasonixConfig = {
+      mcp: ["fs=npx -y @scope/fs /tmp"],
+      mcpDisabled: ["fs"],
+    };
+    const result = normalizeMcpConfig(cfg);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.disabled).toBe(true);
+  });
+
+  it("combines both disabled sources", () => {
+    const cfg: ReasonixConfig = {
+      mcp: ["fs=npx -y @scope/fs /tmp", "git=uvx mcp-server-git"],
+      mcpDisabled: ["fs"],
+      mcpServers: {
+        db: {
+          command: "npx",
+          args: ["-y", "@scope/db"],
+          disabled: true,
+        },
+      },
+    };
+    const result = normalizeMcpConfig(cfg);
+    expect(result).toHaveLength(3);
+    expect(findByName(result, "fs")!.disabled).toBe(true);
+    expect(findByName(result, "git")!.disabled).toBe(false);
+    expect(findByName(result, "db")!.disabled).toBe(true);
+  });
+
+  it("mcpServers disabled:true overrides legacy mcpDisabled for same name", () => {
+    const cfg: ReasonixConfig = {
+      mcp: ["fs=npx -y @scope/fs"],
+      mcpDisabled: [],
+      mcpServers: {
+        fs: { command: "node", args: ["srv.js"], disabled: true },
+      },
+    };
+    const result = normalizeMcpConfig(cfg);
+    const fs = findByName(result, "fs")!;
+    expect(fs.disabled).toBe(true);
+  });
+});
+
+describe("normalizeMcpConfig: env and headers", () => {
+  it("env from mcpServers is present on stdio specs", () => {
+    const cfg: ReasonixConfig = {
+      mcpServers: {
+        github: {
+          command: "npx",
+          args: ["-y", "@scope/github"],
+          env: { GITHUB_TOKEN: "ghp_abc" },
+        },
+      },
+    };
+    const result = normalizeMcpConfig(cfg);
+    const spec = result[0]!;
+    if (spec.transport !== "stdio") throw new Error("unreachable");
+    expect(spec.env).toEqual({ GITHUB_TOKEN: "ghp_abc" });
+  });
+
+  it("env from legacy mcpEnv is present on stdio specs", () => {
+    const cfg: ReasonixConfig = {
+      mcp: ["github=npx -y @scope/github"],
+      mcpEnv: { github: { GITHUB_TOKEN: "ghp_abc" } },
+    };
+    const result = normalizeMcpConfig(cfg);
+    const spec = result[0]!;
+    if (spec.transport !== "stdio") throw new Error("unreachable");
+    expect(spec.env).toEqual({ GITHUB_TOKEN: "ghp_abc" });
+  });
+
+  it("headers from mcpServers are present on SSE specs", () => {
+    const cfg: ReasonixConfig = {
+      mcpServers: {
+        remote: {
+          transport: "sse",
+          url: "https://example.com/sse",
+          headers: { Authorization: "Bearer tok" },
+        },
+      },
+    };
+    const result = normalizeMcpConfig(cfg);
+    const spec = result[0]!;
+    if (spec.transport !== "sse") throw new Error("unreachable");
+    expect(spec.headers).toEqual({ Authorization: "Bearer tok" });
+  });
+
+  it("headers from mcpServers are present on streamable-http specs", () => {
+    const cfg: ReasonixConfig = {
+      mcpServers: {
+        edge: {
+          transport: "streamable-http",
+          url: "https://edge.example.com/mcp",
+          headers: { "X-API-Key": "key_xyz" },
+        },
+      },
+    };
+    const result = normalizeMcpConfig(cfg);
+    const spec = result[0]!;
+    if (spec.transport !== "streamable-http") throw new Error("unreachable");
+    expect(spec.headers).toEqual({ "X-API-Key": "key_xyz" });
+  });
+
+  it("anonymous legacy spec has no env overlay", () => {
+    const cfg: ReasonixConfig = {
+      mcp: ["npx -y @scope/fs"],
+      mcpEnv: { anon: { TOKEN: "val" } },
+    };
+    const result = normalizeMcpConfig(cfg);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.name).toBeNull();
+    if (result[0]!.transport !== "stdio") throw new Error("unreachable");
+    expect(result[0]!.env).toBeUndefined();
+  });
+});
+
+describe("normalizeMcpConfig: headers round-trip into transport", () => {
+  it("headers on SSE spec are passed to SseTransport", () => {
+    const cfg: ReasonixConfig = {
+      mcpServers: {
+        remote: {
+          transport: "sse",
+          url: "https://example.com/sse",
+          headers: { Authorization: "Bearer tok" },
+        },
+      },
+    };
+    const specs = normalizeMcpConfig(cfg);
+    const transport = buildTransportFromSpec(specs[0]!);
+    expect(transport).toBeInstanceOf(SseTransport);
+  });
+
+  it("headers on streamable-http spec are passed to StreamableHttpTransport", () => {
+    const cfg: ReasonixConfig = {
+      mcpServers: {
+        edge: {
+          transport: "streamable-http",
+          url: "https://edge.example.com/mcp",
+          headers: { "X-API-Key": "key_xyz" },
+        },
+      },
+    };
+    const specs = normalizeMcpConfig(cfg);
+    const transport = buildTransportFromSpec(specs[0]!);
+    expect(transport).toBeInstanceOf(StreamableHttpTransport);
+  });
+
+  it("stdio server with headers ignores headers", () => {
+    const cfg: ReasonixConfig = {
+      mcpServers: {
+        local: {
+          command: "npx",
+          args: ["-y", "@scope/local"],
+          headers: { Authorization: "Bearer tok" },
+        },
+      },
+    };
+    const specs = normalizeMcpConfig(cfg);
+    const spec = specs[0]!;
+    if (spec.transport !== "stdio") throw new Error("unreachable");
+    // headers should not be present on stdio spec
+    expect((spec as Record<string, unknown>).headers).toBeUndefined();
+    const transport = buildTransportFromSpec(spec);
+    expect(transport).toBeInstanceOf(StdioTransport);
+    void transport.close();
+  });
+
+  it("env on stdio spec is passed to StdioTransport", () => {
+    const cfg: ReasonixConfig = {
+      mcpServers: {
+        local: {
+          command: "node",
+          args: ["-e", "console.log('hi')"],
+          env: { FOO: "bar" },
+        },
+      },
+    };
+    const specs = normalizeMcpConfig(cfg);
+    const transport = buildTransportFromSpec(specs[0]!);
+    expect(transport).toBeInstanceOf(StdioTransport);
+    void transport.close();
+  });
+});
+
+describe("normalizeMcpConfig: extraLegacy parameter", () => {
+  it("extraLegacy replaces cfg.mcp when provided", () => {
+    const cfg: ReasonixConfig = {
+      mcp: ["fs=npx -y @scope/fs"],
+      mcpServers: {
+        db: { command: "npx", args: ["-y", "@scope/db"] },
+      },
+    };
+    const result = normalizeMcpConfig(cfg, ["cli=npx -y @scope/cli"]);
+    expect(result).toHaveLength(2);
+    expect(names(result)).toEqual(["cli", "db"]);
+  });
+
+  it("extraLegacy is empty array falls back to cfg.mcp", () => {
+    const cfg: ReasonixConfig = {
+      mcp: ["fs=npx -y @scope/fs"],
+    };
+    const result = normalizeMcpConfig(cfg, []);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.name).toBe("fs");
+  });
+});


### PR DESCRIPTION
## What

Introduces `mcpServers: Record<string, McpServerConfig>` as the canonical way to declare MCP servers, alongside a single `normalizeMcpConfig()` normalization layer that merges the new object format with legacy `mcp[]` / `mcpEnv` / `mcpDisabled` fields. Headers are plumbed through `buildTransportFromSpec` into `SseTransport` and `StreamableHttpTransport`, enabling HTTP auth for SSE and Streamable HTTP transports.

## Why

The legacy `mcp: string[]` format cannot express HTTP headers (e.g. `Authorization`, `X-API-Key`) needed for authenticated SSE / Streamable HTTP MCP servers. The new `mcpServers` object format fills this gap while remaining fully backward-compatible.

## How to verify

1. `npm run verify` — lint, typecheck, and all 3125 tests pass (203 test files).
2. New tests: `tests/mcp-normalize-config.test.ts` (27 tests) cover legacy-only, object-only, merge conflicts, disabled flags, env/headers, and transport round-trips.
3. Existing MCP tests all pass: `mcp-env-config`, `mcp-spec`, `mcp-integration`, `mcp-reconnect`, `acp-mcp`, `chat-mcp-startup-summary`, `resolve`.

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time

Closes #1032 