### PR TITLE
fix: MCP bridge state — record tools immediately, use live getter for…

### DIFF
--- a/src/cli/commands/mcp-runtime.ts
+++ b/src/cli/commands/mcp-runtime.ts
@@ -10,7 +10,7 @@ import { buildMcpServerSummary } from "../../mcp/summary.js";
 import { buildTransportFromSpec } from "../../mcp/transport-from-spec.js";
 import type { ToolRegistry } from "../../tools.js";
 import type { ToolSpec } from "../../types.js";
-import { formatMcpLifecycleEvent } from "../ui/mcp-lifecycle.js";
+import { type McpLifecycleEvent, formatMcpLifecycleEvent } from "../ui/mcp-lifecycle.js";
 import { formatMcpSlowToast } from "../ui/mcp-toast.js";
 import type { McpServerSummary } from "../ui/slash.js";
 
@@ -50,7 +50,9 @@ export type McpLifecycleNotice =
     }
   | { kind: "disabled"; name: string }
   | { kind: "failed"; name: string; reason: string }
-  | { kind: "slow"; serverName: string; p95Ms: number; sampleSize: number };
+  | { kind: "slow"; serverName: string; p95Ms: number; sampleSize: number }
+  | { kind: "tools-ready"; name: string; tools: number; ms: number }
+  | { kind: "warn"; name: string; reason: string };
 
 export type McpLifecycleSink = (notice: McpLifecycleNotice) => void;
 
@@ -80,7 +82,22 @@ export const stderrLifecycleSink: McpLifecycleSink = (n) => {
     );
     return;
   }
-  process.stderr.write(`${formatMcpLifecycleEvent({ state: n.kind, name: n.name })}\n`);
+  if (n.kind === "tools-ready") {
+    process.stderr.write(
+      `${formatMcpLifecycleEvent({ state: "tools-ready", name: n.name, tools: n.tools, ms: n.ms })}\n`,
+    );
+    return;
+  }
+  if (n.kind === "warn") {
+    process.stderr.write(
+      `${formatMcpLifecycleEvent({ state: "warn", name: n.name, reason: n.reason })}\n`,
+    );
+    return;
+  }
+  // handshake / disabled — no extra fields needed
+  process.stderr.write(
+    `${formatMcpLifecycleEvent({ state: n.kind as "handshake" | "disabled", name: n.name })}\n`,
+  );
 };
 
 export interface McpRuntime {
@@ -201,11 +218,9 @@ export function createMcpRuntime(ctx: RuntimeContext): McpRuntime {
       insertionOrder.push(raw);
       resolveReady();
       sink({
-        kind: "connected",
+        kind: "tools-ready",
         name: label,
         tools: bridge.registeredNames.length,
-        resources: 0,
-        prompts: 0,
         ms,
       });
 
@@ -226,6 +241,15 @@ export function createMcpRuntime(ctx: RuntimeContext): McpRuntime {
       }
       const resourceCount = report.resources.supported ? report.resources.items.length : 0;
       const promptCount = report.prompts.supported ? report.prompts.items.length : 0;
+      // Re-emit with full inspection data (the provisional event reported 0).
+      sink({
+        kind: "connected",
+        name: label,
+        tools: bridge.registeredNames.length,
+        resources: resourceCount,
+        prompts: promptCount,
+        ms,
+      });
       const summary = buildMcpServerSummary({
         label,
         spec: raw,
@@ -248,22 +272,26 @@ export function createMcpRuntime(ctx: RuntimeContext): McpRuntime {
         for (const s of registeredSpecs)
           try {
             loop.prefix.addTool(s);
-          } catch {
-            /* non-critical */
+          } catch (err) {
+            sink({
+              kind: "warn",
+              name: label,
+              reason: `addTool failed for ${s.function.name}: ${(err as Error).message}`,
+            });
           }
       return { ok: true, summary };
     } catch (err) {
       // If we got far enough to create a provisional record, keep it —
       // tools are already registered and usable even after a late failure.
+      const reason = (err as Error).message;
       if (!records.has(raw)) {
         await mcp?.close().catch(() => undefined);
-        rejectReady(new Error(`MCP server "${label}" failed to start: ${(err as Error).message}`));
+        rejectReady(new Error(`MCP server "${label}" failed to start: ${reason}`));
+        sink({ kind: "failed", name: label, reason });
+        return { ok: false, reason };
       }
-      const reason = (err as Error).message;
-      sink({ kind: "failed", name: label, reason });
-      return records.has(raw)
-        ? { ok: true, summary: records.get(raw)!.summary }
-        : { ok: false, reason };
+      sink({ kind: "warn", name: label, reason });
+      return { ok: true, summary: records.get(raw)!.summary };
     }
   }
 

--- a/src/cli/commands/mcp-runtime.ts
+++ b/src/cli/commands/mcp-runtime.ts
@@ -168,6 +168,48 @@ export function createMcpRuntime(ctx: RuntimeContext): McpRuntime {
             sampleSize: info.sampleSize,
           }),
       });
+      // Tools are registered — record the bridge NOW so the UI shows
+      // "bridged" even if later non-critical steps (inspect, hot-add) fail.
+      const ms = Date.now() - t0;
+      const allSpecs = tools.specs();
+      const registeredSpecs = allSpecs.filter((s) =>
+        bridge.registeredNames.includes(s.function.name),
+      );
+      // Create a provisional record immediately (tools already usable).
+      records.set(raw, {
+        spec: raw,
+        client: mcp,
+        summary: buildMcpServerSummary({
+          label,
+          spec: raw,
+          toolCount: bridge.registeredNames.length,
+          report: {
+            protocolVersion: mcp.protocolVersion,
+            serverInfo: mcp.serverInfo,
+            capabilities: mcp.serverCapabilities ?? {},
+            tools: { supported: true, items: [] },
+            resources: { supported: false, reason: "still inspecting" },
+            prompts: { supported: false, reason: "still inspecting" },
+            elapsedMs: ms,
+          },
+          host,
+          bridgeEnv: bridge.env,
+        }),
+        registeredNames: bridge.registeredNames,
+        registeredSpecs,
+      });
+      insertionOrder.push(raw);
+      resolveReady();
+      sink({
+        kind: "connected",
+        name: label,
+        tools: bridge.registeredNames.length,
+        resources: 0,
+        prompts: 0,
+        ms,
+      });
+
+      // Non-critical: inspect + hot-add. Failures here don't un-bridge.
       let report: InspectionReport;
       try {
         report = await inspectMcpServer(mcp);
@@ -182,18 +224,8 @@ export function createMcpRuntime(ctx: RuntimeContext): McpRuntime {
           elapsedMs: 0,
         };
       }
-      const ms = Date.now() - t0;
       const resourceCount = report.resources.supported ? report.resources.items.length : 0;
       const promptCount = report.prompts.supported ? report.prompts.items.length : 0;
-      sink({
-        kind: "connected",
-        name: label,
-        tools: bridge.registeredNames.length,
-        resources: resourceCount,
-        prompts: promptCount,
-        ms,
-      });
-      resolveReady();
       const summary = buildMcpServerSummary({
         label,
         spec: raw,
@@ -202,11 +234,7 @@ export function createMcpRuntime(ctx: RuntimeContext): McpRuntime {
         host,
         bridgeEnv: bridge.env,
       });
-      // Snapshot tool specs AFTER bridge so hot-add can replay them into loop.prefix.
-      const allSpecs = tools.specs();
-      const registeredSpecs = allSpecs.filter((s) =>
-        bridge.registeredNames.includes(s.function.name),
-      );
+      // Replace the provisional record with the fully-inspected summary.
       records.set(raw, {
         spec: raw,
         client: mcp,
@@ -214,17 +242,28 @@ export function createMcpRuntime(ctx: RuntimeContext): McpRuntime {
         registeredNames: bridge.registeredNames,
         registeredSpecs,
       });
-      insertionOrder.push(raw);
       // Hot-add: shift the prefix so the live loop sees the new tools
       // on the very next turn. Each addTool is one cache-miss turn.
-      if (loop) for (const s of registeredSpecs) loop.prefix.addTool(s);
+      if (loop)
+        for (const s of registeredSpecs)
+          try {
+            loop.prefix.addTool(s);
+          } catch {
+            /* non-critical */
+          }
       return { ok: true, summary };
     } catch (err) {
-      await mcp?.close().catch(() => undefined);
+      // If we got far enough to create a provisional record, keep it —
+      // tools are already registered and usable even after a late failure.
+      if (!records.has(raw)) {
+        await mcp?.close().catch(() => undefined);
+        rejectReady(new Error(`MCP server "${label}" failed to start: ${(err as Error).message}`));
+      }
       const reason = (err as Error).message;
       sink({ kind: "failed", name: label, reason });
-      rejectReady(new Error(`MCP server "${label}" failed to start: ${reason}`));
-      return { ok: false, reason };
+      return records.has(raw)
+        ? { ok: true, summary: records.get(raw)!.summary }
+        : { ok: false, reason };
     }
   }
 

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -1060,6 +1060,25 @@ function AppInner({
           `${notice.reason}\n闂?run \`reasonix setup\` to remove this entry, or fix the underlying issue (missing npm package, network, etc.).`,
         );
         bumpReady();
+      } else if (notice.kind === "tools-ready") {
+        log.pushInfo(
+          formatMcpLifecycleEvent({
+            state: "tools-ready",
+            name: notice.name,
+            tools: notice.tools,
+            ms: notice.ms,
+          }),
+        );
+        bumpReady();
+      } else if (notice.kind === "warn") {
+        log.pushWarning(
+          `MCP ${notice.name} warn`,
+          formatMcpLifecycleEvent({
+            state: "warn",
+            name: notice.name,
+            reason: notice.reason,
+          }),
+        );
       } else if (notice.kind === "slow") {
         log.pushInfo(
           formatMcpSlowToast({

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -501,6 +501,8 @@ function AppInner({
   // Live MCP server list: initialized from the boot-time prop, then
   // updated immutably when append-drift adds tools mid-session.
   const [liveMcpServers, setLiveMcpServers] = useState<McpServerSummary[]>(() => mcpServers ?? []);
+  const liveMcpServersRef = useRef(liveMcpServers);
+  liveMcpServersRef.current = liveMcpServers;
   // Tracks whether the current turn has been aborted via Esc, so the
   // Esc handler only fires once per turn (repeated presses would yield
   // stacked warning events).
@@ -1966,7 +1968,7 @@ function AppInner({
           usageLogPath: defaultUsageLogPath(),
           loop,
           tools,
-          mcpServers: liveMcpServers,
+          getMcpServers: () => liveMcpServersRef.current,
           getCurrentCwd: () => (codeMode ? currentRootDirRef.current : undefined),
           getEditMode: () => (codeMode ? editModeRef.current : undefined),
           getPlanMode: () => planModeRef.current,
@@ -2228,7 +2230,6 @@ function AppInner({
   }, [
     loop,
     tools,
-    liveMcpServers,
     codeMode,
     session,
     togglePlanMode,
@@ -3211,7 +3212,6 @@ function AppInner({
       loop,
       latestVersion,
       mcpSpecs,
-      liveMcpServers,
       models,
       planMode,
       session,
@@ -3269,6 +3269,7 @@ function AppInner({
       mcpRuntime,
       pushHistory,
       resetCursor,
+      liveMcpServers,
     ],
   );
 

--- a/src/cli/ui/mcp-lifecycle.ts
+++ b/src/cli/ui/mcp-lifecycle.ts
@@ -14,7 +14,9 @@ export type McpLifecycleEvent =
     }
   | { state: "failed"; name: string; reason: string }
   | { state: "disabled"; name: string }
-  | { state: "reconnect"; name: string };
+  | { state: "reconnect"; name: string }
+  | { state: "tools-ready"; name: string; tools: number; ms: number }
+  | { state: "warn"; name: string; reason: string };
 
 const STATE: Record<McpLifecycleEvent["state"], { glyph: string; label: () => string }> = {
   handshake: { glyph: "↻", label: () => t("mcpLifecycle.handshake") },
@@ -22,6 +24,8 @@ const STATE: Record<McpLifecycleEvent["state"], { glyph: string; label: () => st
   failed: { glyph: "✖", label: () => t("mcpLifecycle.failed") },
   disabled: { glyph: "○", label: () => t("mcpLifecycle.disabled") },
   reconnect: { glyph: "↻", label: () => t("mcpLifecycle.reconnect") },
+  "tools-ready": { glyph: "⚡", label: () => "tools ready" },
+  warn: { glyph: "⚠", label: () => "warn" },
 };
 
 const NAME_COL = 22;
@@ -40,6 +44,8 @@ function describeDetail(ev: McpLifecycleEvent): string {
   if (ev.state === "failed") return ev.reason;
   if (ev.state === "disabled") return t("mcpLifecycle.disabledDetail", { name: ev.name });
   if (ev.state === "reconnect") return t("mcpLifecycle.reconnectDetail");
+  if (ev.state === "tools-ready") return `${ev.tools} tools · ${ev.ms}ms`;
+  if (ev.state === "warn") return ev.reason;
   const parts: string[] = [`${ev.tools} tools`];
   if (ev.resources && ev.resources > 0) parts.push(`${ev.resources} resources`);
   if (ev.prompts && ev.prompts > 0) parts.push(`${ev.prompts} prompts`);

--- a/src/server/api/mcp.ts
+++ b/src/server/api/mcp.ts
@@ -67,7 +67,7 @@ export async function handleMcp(
 ): Promise<ApiResult> {
   // Bridged-server view (live).
   if (method === "GET" && rest.length === 0) {
-    const servers = (ctx.mcpServers ?? []).map((s) => ({
+    const servers = (ctx.getMcpServers?.() ?? []).map((s) => ({
       label: s.label,
       spec: s.spec,
       toolCount: s.toolCount,

--- a/src/server/api/overview.ts
+++ b/src/server/api/overview.ts
@@ -57,7 +57,7 @@ export async function handleOverview(
     editMode: ctx.getEditMode?.() ?? null,
     planMode: ctx.getPlanMode?.() ?? null,
     pendingEdits: ctx.getPendingEditCount?.() ?? null,
-    mcpServerCount: ctx.mcpServers?.length ?? null,
+    mcpServerCount: ctx.getMcpServers?.().length ?? null,
     toolCount: ctx.tools ? ctx.tools.size : null,
     preset: cfg.preset ?? "auto",
     reasoningEffort: cfg.reasoningEffort ?? "max",

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -16,7 +16,7 @@ export interface DashboardContext {
 
   loop?: CacheFirstLoop;
   tools?: ToolRegistry;
-  mcpServers?: McpServerSummary[];
+  getMcpServers?: () => McpServerSummary[];
   jobs?: JobRegistry;
 
   /** Current code-mode root, if any. Drives the project-scoped allowlist. */


### PR DESCRIPTION
## 问题

MCP 管理面板（`/mcp` 和 Dashboard）中，已成功启动的 MCP 服务器（工具已注册、可正常调用）仍显示为"未桥接"。

## 根因（两层）

### 第一层：`addSpec` 过早判定失败（`mcp-runtime.ts`）

`bridgeMcpTools` 成功后工具已注册到 ToolRegistry，但 `records.set()` 在 `inspectMcpServer` 和 `loop.prefix.addTool` 之后才执行。若后两步中任一步抛出异常，整个 spec 被标记为失败，即使工具已可用。`rejectReady` 也会被错误调用。

### 第二层：Dashboard API 读取冻结引用（`context.ts` → `App.tsx`）

`DashboardContext.mcpServers` 是静态数组引用，在上下文创建时冻结。其他实时状态（`planMode`、`editMode` 等）已使用 getter 函数模式，唯独 MCP servers 没有。Dashboard 和 `/api/mcp` 读到的一直是启动时的空数组。

## 修复

### `src/cli/commands/mcp-runtime.ts`

- `bridgeMcpTools` 成功后**立即**创建 provisional record（`records.set` + `insertionOrder.push` + `resolveReady`），不等 inspect 完成
- `inspectMcpServer` 降级为非关键步骤，失败用 fallback 不影响桥接状态
- `loop.prefix.addTool` 用 `try/catch` 包住，失败不回滚
- catch 块中检查 `records.has(raw)`：若已有 provisional record 则保留，不关闭 MCP client

### `src/server/context.ts`

- `mcpServers?: McpServerSummary[]` → `getMcpServers?: () => McpServerSummary[]`

### `src/server/api/mcp.ts` / `src/server/api/overview.ts`

- `ctx.mcpServers` → `ctx.getMcpServers?.()`

### `src/cli/ui/App.tsx`

- 添加 `liveMcpServersRef`，赋值改为 `getMcpServers: () => liveMcpServersRef.current`

## 测试

- 使用带有 2 个 MCP 服务器的 config.json 启动
- 终端 lifecycle 日志显示 `✓ 已连接`
- `/mcp` 面板和 Dashboard 均正确显示"已桥接"状态

## 已知限制

`server-filesystem` 传入多个路径（`C:\ D:\ E:\`）时，子进程无法启动，面板仍显示"未桥接"。此为 config.json 中 MCP 规范格式问题（`server-filesystem` 只接受单个目录参数），与本次修复无关。不影响功能——Reasonix 内置文件系统工具已覆盖所有文件操作。