### PR TITLE
feat(read_file): full content by default, outline mode for large files

### DIFF
--- a/src/tools/filesystem.ts
+++ b/src/tools/filesystem.ts
@@ -19,20 +19,20 @@ export interface FilesystemToolsOptions {
   rootDir: string;
   /** false → register only read-side tools. Default true. */
   allowWriting?: boolean;
-  /** Per-read byte cap; floor against OOM on a multi-GB blob. */
-  maxReadBytes?: number;
+  /** Files at or under this size get full content; larger go to outline mode. Default 512 KiB. */
+  outlineThresholdBytes?: number;
   /** Cap on total bytes from listing/grep tools — bounds tree-as-one-string accidents. */
   maxListBytes?: number;
 }
 
-const DEFAULT_MAX_READ_BYTES = 2 * 1024 * 1024;
+const DEFAULT_OUTLINE_THRESHOLD_BYTES = 512 * 1024;
 const DEFAULT_MAX_LIST_BYTES = 256 * 1024;
 
-/** Auto-preview threshold — files above this force the model to scope (range/head/tail). */
-const DEFAULT_AUTO_PREVIEW_LINES = 200;
-const AUTO_PREVIEW_HEAD_LINES = 80;
-const AUTO_PREVIEW_TAIL_LINES = 40;
-const OUTLINE_MAX_ENTRIES = 30;
+/** Refuse load above this; outline-mode would have to slurp the whole file to scan it. */
+const HARD_MAX_FILE_BYTES = 32 * 1024 * 1024;
+
+/** Lines shown for orientation when a file is too big for full content. */
+const OUTLINE_HEAD_LINES = 80;
 
 /** Skipped unless `include_deps:true` — shared with the semantic indexer via DEFAULT_INDEX_EXCLUDES. */
 const SKIP_DIR_NAMES: ReadonlySet<string> = new Set(DEFAULT_INDEX_EXCLUDES.dirs);
@@ -66,13 +66,29 @@ function isLikelyBinaryByName(name: string): boolean {
   return BINARY_EXTENSIONS.has(name.slice(dot).toLowerCase());
 }
 
+/** Sniff first 8 KiB for a NUL byte — catches binary files whose extension lied. UTF-16 (rare in source) is an accepted false positive. */
+function looksBinary(buf: Buffer): boolean {
+  const end = Math.min(buf.length, 8192);
+  for (let i = 0; i < end; i++) {
+    if (buf[i] === 0) return true;
+  }
+  return false;
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KiB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)} MiB`;
+  return `${(n / (1024 * 1024 * 1024)).toFixed(2)} GiB`;
+}
+
 export function registerFilesystemTools(
   registry: ToolRegistry,
   opts: FilesystemToolsOptions,
 ): ToolRegistry {
   const rootDir = pathMod.resolve(opts.rootDir);
   const allowWriting = opts.allowWriting !== false;
-  const maxReadBytes = opts.maxReadBytes ?? DEFAULT_MAX_READ_BYTES;
+  const outlineThresholdBytes = opts.outlineThresholdBytes ?? DEFAULT_OUTLINE_THRESHOLD_BYTES;
   const maxListBytes = opts.maxListBytes ?? DEFAULT_MAX_LIST_BYTES;
 
   const normRoot = pathMod.resolve(rootDir);
@@ -175,11 +191,11 @@ export function registerFilesystemTools(
   registry.register({
     name: "read_file",
     parallelSafe: true,
-    description: `Read a file under the sandbox root. To save context, PREFER to scope the read instead of pulling the whole file:
-  - head: N  → first N lines (imports, public API, small configs)
-  - tail: N  → last N lines (recently-added code, log tails)
-  - range: "A-B"  → inclusive line range A..B, 1-indexed (e.g. "120-180" around an edit site)
-When none of these is given AND the file is longer than ${DEFAULT_AUTO_PREVIEW_LINES} lines, the tool auto-returns a head+tail preview with an "N lines omitted" marker, plus a top-level symbol outline (TS/JS exports, Python def/class, Go func/type, Rust fn/struct/impl/trait, Markdown headings, with line numbers, capped at ${OUTLINE_MAX_ENTRIES}) so you can pick a smart range without a follow-up grep. If you need the middle, re-call with a range. Prefer search_content to locate a symbol first only when the outline doesn't have what you want — one scoped read beats three full-file reads.`,
+    description: `Read a file under the sandbox root. Default behaviour returns FULL CONTENT for files at or under ${Math.round(DEFAULT_OUTLINE_THRESHOLD_BYTES / 1024)} KiB — trust the prompt cache, don't pre-truncate. Optional scoping:
+  - head: N  → first N lines (cheap probe of imports / config head)
+  - tail: N  → last N lines (recent-tail of a log)
+  - range: "A-B"  → inclusive 1-indexed range (e.g. "120-180" around an edit site)
+Files OVER the threshold auto-switch to outline mode: file metadata + first ${OUTLINE_HEAD_LINES} lines + a top-level symbol outline (TS/JS exports, Python def/class, Go func/type, Rust fn/struct/impl/trait, Markdown headings, Protobuf message/service/rpc, plain-text chapter markers) + concrete next-step commands. No middle bytes — drill in with range / search_content. Files over ${Math.round(HARD_MAX_FILE_BYTES / (1024 * 1024))} MiB are refused entirely (use grep / range). Binary files are refused — use get_file_info if you only need stat.`,
     readOnly: true,
     stormExempt: true,
     parameters: {
@@ -201,23 +217,36 @@ When none of these is given AND the file is longer than ${DEFAULT_AUTO_PREVIEW_L
       ctx?: ToolCallContext,
     ) => {
       const abs = await safePath(args.path, "read_file", ctx);
+      const rel = displayRel(rootDir, abs);
       // Open once and reuse the fd so the directory check and the read
       // bind to the same inode — closes the stat→read TOCTOU race.
       const fh = await fs.open(abs, "r");
       let raw: Buffer;
+      let sizeBytes: number;
       try {
         const stat = await fh.stat();
         if (stat.isDirectory()) {
           throw new Error(`not a file: ${args.path} (it's a directory)`);
         }
+        sizeBytes = stat.size;
+        if (sizeBytes > HARD_MAX_FILE_BYTES) {
+          return [
+            `[refused: ${rel} is ${formatBytes(sizeBytes)} (> ${formatBytes(HARD_MAX_FILE_BYTES)} hard ceiling) — too large to load]`,
+            "Use one of:",
+            `  - search_content path:"${rel}" pattern:"<your regex>"  — grep within the file`,
+            `  - read_file path:"${rel}" range:"A-B"                   — read a specific 1-indexed line range`,
+            `  - read_file path:"${rel}" head:N  /  tail:N             — read N lines at the start or end`,
+          ].join("\n");
+        }
         raw = await fh.readFile();
       } finally {
         await fh.close();
       }
-      if (raw.length > maxReadBytes) {
-        const headBytes = raw.slice(0, maxReadBytes).toString("utf8");
-        return `${headBytes}\n\n[…truncated ${raw.length - maxReadBytes} bytes — file is ${raw.length} B, cap ${maxReadBytes} B. Retry with head/tail/range for targeted view.]`;
+
+      if (looksBinary(raw)) {
+        return `[refused: ${rel} appears to be binary (${formatBytes(sizeBytes)}) — read_file returns text only. Use get_file_info for stat.]`;
       }
+
       const text = raw.toString("utf8");
       let lines = text.split(/\r?\n/);
       // Most files end with '\n' which splits into an empty trailing
@@ -228,7 +257,7 @@ When none of these is given AND the file is longer than ${DEFAULT_AUTO_PREVIEW_L
 
       // range wins over head/tail when set — the most precise ask
       // should dominate. Parse "A-B" strictly; bad formats fall through
-      // to head/tail / auto-preview instead of erroring.
+      // to head/tail / outline-mode instead of erroring.
       if (typeof args.range === "string" && /^\d+\s*-\s*\d+$/.test(args.range)) {
         const [rawStart, rawEnd] = args.range.split("-").map((s) => Number.parseInt(s, 10));
         const start = Math.max(1, rawStart ?? 1);
@@ -256,26 +285,30 @@ When none of these is given AND the file is longer than ${DEFAULT_AUTO_PREVIEW_L
         return marker + slice.join("\n");
       }
 
-      // No explicit scope + file is small → full content.
-      if (totalLines <= DEFAULT_AUTO_PREVIEW_LINES) return lines.join("\n");
+      // No explicit scope + file fits the threshold → full content.
+      // Trust the prompt cache: a 100K-token file read once amortizes
+      // across every turn of the same conversation.
+      if (sizeBytes <= outlineThresholdBytes) return lines.join("\n");
 
-      // No explicit scope + file is large → head + tail preview plus
-      // a marker telling the model how much it missed and how to get
-      // it. This is the single biggest lever on read_file token cost —
-      // historically a 500-line file dumped ~4K tokens into the turn
-      // even when the model only needed 20 of them.
-      const head = lines.slice(0, AUTO_PREVIEW_HEAD_LINES).join("\n");
-      const tail = lines.slice(totalLines - AUTO_PREVIEW_TAIL_LINES).join("\n");
-      const omitted = totalLines - AUTO_PREVIEW_HEAD_LINES - AUTO_PREVIEW_TAIL_LINES;
+      // No explicit scope + file is over the threshold → outline mode.
+      // Return enough for the model to orient (head + symbol map) plus
+      // concrete next-step commands. Avoids dumping a 5 MB proto into
+      // every cached prefix while still surfacing what's inside.
+      const head = lines.slice(0, Math.min(OUTLINE_HEAD_LINES, totalLines)).join("\n");
       const outline = formatOutline(extractOutline(abs, lines));
       const parts: string[] = [
-        `[auto-preview: head ${AUTO_PREVIEW_HEAD_LINES} + tail ${AUTO_PREVIEW_TAIL_LINES} of ${totalLines} lines]`,
+        `[large file: ${formatBytes(sizeBytes)}, ${totalLines} lines — outline mode (threshold ${formatBytes(outlineThresholdBytes)})]`,
+        "",
+        `[head ${Math.min(OUTLINE_HEAD_LINES, totalLines)} lines for orientation]`,
         head,
       ];
       if (outline) parts.push("", outline);
       parts.push(
-        `\n[… ${omitted} lines omitted — call read_file again with range:"A-B" (1-indexed) or head / tail to get the middle]\n`,
-        tail,
+        "",
+        "[to read more, call one of:",
+        `  - read_file path:"${rel}" range:"A-B"          — 1-indexed line range`,
+        `  - read_file path:"${rel}" head:N  /  tail:N    — first/last N lines`,
+        `  - search_content path:"${rel}" pattern:"..."   — grep within this file]`,
       );
       return parts.join("\n");
     },

--- a/src/tools/fs/outline.ts
+++ b/src/tools/fs/outline.ts
@@ -23,7 +23,23 @@ const MD_HEADING_RE = /^(#{1,6})\s+(.+?)\s*$/;
 
 const MD_FENCE_RE = /^```/;
 
-type Lang = "ts" | "py" | "go" | "rust" | "md";
+const PROTO_TOP_RE = /^(message|service|enum|extend)\s+(\w+)/;
+
+const PROTO_RPC_RE = /^\s+rpc\s+(\w+)/;
+
+const CN_NUM = "[\\d零一二三四五六七八九十百千万０-９]+";
+
+const TXT_CHAPTER_PATTERNS: readonly RegExp[] = [
+  new RegExp(`^第${CN_NUM}[章节回].{0,80}$`),
+  new RegExp(`^卷${CN_NUM}.{0,80}$`),
+  /^(?:序章|楔子|番外篇?|前言|后记|尾声|引子)(?:[\s\u3000：:、—\-.].{0,80})?$/,
+  /^Chapter\s+(?:\d+|[IVXLCDMivxlcdm]+|[A-Za-z]+)\b.{0,80}$/,
+  /^CHAPTER\s+.{1,80}$/,
+  /^Part\s+(?:\d+|[IVXLCDMivxlcdm]+)\b.{0,80}$/,
+  /^PART\s+.{1,80}$/,
+];
+
+type Lang = "ts" | "py" | "go" | "rust" | "md" | "proto" | "txt";
 
 const EXT_TO_LANG: Record<string, Lang> = {
   ".ts": "ts",
@@ -41,6 +57,9 @@ const EXT_TO_LANG: Record<string, Lang> = {
   ".md": "md",
   ".markdown": "md",
   ".mdx": "md",
+  ".proto": "proto",
+  ".txt": "txt",
+  ".text": "txt",
 };
 
 export function extractOutline(filename: string, lines: readonly string[]): OutlineEntry[] {
@@ -58,6 +77,10 @@ export function extractOutline(filename: string, lines: readonly string[]): Outl
       return extractRust(lines);
     case "md":
       return extractMarkdown(lines);
+    case "proto":
+      return extractProto(lines);
+    case "txt":
+      return extractText(lines);
   }
 }
 
@@ -110,6 +133,38 @@ function extractRust(lines: readonly string[]): OutlineEntry[] {
     const m = RUST_DECL_RE.exec(line);
     if (!m) continue;
     out.push({ line: i + 1, text: `${m[1]} ${m[2]}` });
+  }
+  return out;
+}
+
+function extractProto(lines: readonly string[]): OutlineEntry[] {
+  const out: OutlineEntry[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (!line.startsWith(" ") && !line.startsWith("\t")) {
+      const m = PROTO_TOP_RE.exec(line);
+      if (m) {
+        out.push({ line: i + 1, text: `${m[1]} ${m[2]}` });
+        continue;
+      }
+    }
+    const rpc = PROTO_RPC_RE.exec(line);
+    if (rpc) out.push({ line: i + 1, text: `rpc ${rpc[1]}` });
+  }
+  return out;
+}
+
+function extractText(lines: readonly string[]): OutlineEntry[] {
+  const out: OutlineEntry[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!.trim();
+    if (line.length === 0 || line.length > 100) continue;
+    for (const re of TXT_CHAPTER_PATTERNS) {
+      if (re.test(line)) {
+        out.push({ line: i + 1, text: line });
+        break;
+      }
+    }
   }
   return out;
 }

--- a/tests/filesystem-tools.test.ts
+++ b/tests/filesystem-tools.test.ts
@@ -77,84 +77,122 @@ describe("filesystem tools (built-in, sandbox-enforced)", () => {
       expect(out).toContain("line 3");
     });
 
-    it("auto-previews large files when no scope is given", async () => {
-      // File larger than DEFAULT_AUTO_PREVIEW_LINES (200) triggers the
-      // head+tail preview + omitted-lines marker.
-      const bigLines = Array.from({ length: 250 }, (_, i) => `line ${i + 1}`);
+    it("returns full content for many-line files when bytes fit under the threshold", async () => {
+      const bigLines = Array.from({ length: 1000 }, (_, i) => `line ${i + 1}`);
       await fs.writeFile(join(root, "huge.txt"), bigLines.join("\n"));
       const out = await tools.dispatch("read_file", JSON.stringify({ path: "huge.txt" }));
-      expect(out).toMatch(/auto-preview: head 80 \+ tail 40 of 250 lines/);
-      expect(out).toMatch(/130 lines omitted/);
+      expect(out).toContain("line 1");
+      expect(out).toContain("line 500");
+      expect(out).toContain("line 1000");
+      expect(out).not.toMatch(/outline mode/);
+      expect(out).not.toMatch(/omitted/);
+    });
+
+    it("switches to outline mode when file size exceeds outlineThresholdBytes", async () => {
+      const reg = new ToolRegistry();
+      registerFilesystemTools(reg, { rootDir: root, outlineThresholdBytes: 200 });
+      const bigLines = Array.from({ length: 250 }, (_, i) => `line ${i + 1}`);
+      await fs.writeFile(join(root, "big.txt"), bigLines.join("\n"));
+      const out = await reg.dispatch("read_file", JSON.stringify({ path: "big.txt" }));
+      expect(out).toMatch(/large file:.*outline mode/);
+      expect(out).toMatch(/head \d+ lines for orientation/);
       expect(out).toContain("line 1");
       expect(out).toContain("line 80");
-      expect(out).toContain("line 211");
-      expect(out).toContain("line 250");
-      expect(out).not.toContain("line 100");
       expect(out).not.toContain("line 200");
+      expect(out).toMatch(/search_content path:"big\.txt"/);
+      expect(out).toMatch(/read_file path:"big\.txt" range:"A-B"/);
     });
 
-    it("auto-preview embeds a top-level export outline for TS-shaped files", async () => {
+    it("outline mode surfaces TS exports as the symbol map", async () => {
+      const reg = new ToolRegistry();
+      registerFilesystemTools(reg, { rootDir: root, outlineThresholdBytes: 200 });
       const filler = (n: number) => Array.from({ length: n }, () => "  // filler").join("\n");
       const src = [
-        'import { foo } from "./foo";',
-        'import { bar } from "./bar";',
-        "",
-        "export interface AppProps {",
-        "  id: string;",
-        "}",
-        "",
-        filler(120),
-        "export function AppInner(props: AppProps) {",
-        "  return null;",
-        "}",
-        filler(80),
+        "export interface AppProps {}",
+        filler(40),
+        "export function AppInner() {}",
+        filler(40),
         "export const handleSubmit = () => {};",
-        filler(38),
-        "export default AppInner;",
       ].join("\n");
       await fs.writeFile(join(root, "App.tsx"), src);
-      const out = await tools.dispatch("read_file", JSON.stringify({ path: "App.tsx" }));
+      const out = await reg.dispatch("read_file", JSON.stringify({ path: "App.tsx" }));
       expect(out).toMatch(/\[outline: 3 symbols\]/);
-      expect(out).toMatch(/L\s*4\s+export interface AppProps/);
-      expect(out).toMatch(/L128\s+export function AppInner/);
-      expect(out).toMatch(/L211\s+export const handleSubmit/);
+      expect(out).toMatch(/export interface AppProps/);
+      expect(out).toMatch(/export function AppInner/);
+      expect(out).toMatch(/export const handleSubmit/);
     });
 
-    it("auto-preview omits the outline when no top-level exports are present", async () => {
-      const src = Array.from({ length: 220 }, (_, i) => `line ${i + 1}`).join("\n");
-      await fs.writeFile(join(root, "plain.txt"), src);
-      const out = await tools.dispatch("read_file", JSON.stringify({ path: "plain.txt" }));
-      expect(out).toMatch(/auto-preview: /);
+    it("outline mode surfaces protobuf messages, services, and rpcs", async () => {
+      const reg = new ToolRegistry();
+      registerFilesystemTools(reg, { rootDir: root, outlineThresholdBytes: 200 });
+      const src = [
+        'syntax = "proto3";',
+        "package demo;",
+        "",
+        "message User {",
+        "  string id = 1;",
+        "}",
+        "",
+        "message Account {",
+        "  string owner = 1;",
+        "}",
+        "",
+        "service AccountService {",
+        "  rpc GetAccount(GetReq) returns (Account);",
+        "  rpc ListAccounts(ListReq) returns (ListResp);",
+        "}",
+      ].join("\n");
+      await fs.writeFile(join(root, "demo.proto"), src);
+      const out = await reg.dispatch("read_file", JSON.stringify({ path: "demo.proto" }));
+      expect(out).toMatch(/large file:.*outline mode/);
+      expect(out).toMatch(/message User/);
+      expect(out).toMatch(/message Account/);
+      expect(out).toMatch(/service AccountService/);
+      expect(out).toMatch(/rpc GetAccount/);
+      expect(out).toMatch(/rpc ListAccounts/);
+    });
+
+    it("outline mode surfaces chapter markers in a Chinese novel .txt", async () => {
+      const reg = new ToolRegistry();
+      registerFilesystemTools(reg, { rootDir: root, outlineThresholdBytes: 200 });
+      const filler = Array.from({ length: 20 }, (_, i) => `这是第${i + 1}段普通正文内容。`).join(
+        "\n",
+      );
+      const src = [
+        "楔子",
+        filler,
+        "第一章 启程",
+        filler,
+        "第二章 风雪",
+        filler,
+        "卷二 江湖",
+        filler,
+        "Chapter 3 The Return",
+        filler,
+      ].join("\n");
+      await fs.writeFile(join(root, "novel.txt"), src);
+      const out = await reg.dispatch("read_file", JSON.stringify({ path: "novel.txt" }));
+      expect(out).toMatch(/large file:.*outline mode/);
+      expect(out).toMatch(/楔子/);
+      expect(out).toMatch(/第一章 启程/);
+      expect(out).toMatch(/第二章 风雪/);
+      expect(out).toMatch(/卷二 江湖/);
+      expect(out).toMatch(/Chapter 3 The Return/);
+    });
+
+    it("outline mode skips the outline section when no symbols match the file type", async () => {
+      const reg = new ToolRegistry();
+      registerFilesystemTools(reg, { rootDir: root, outlineThresholdBytes: 200 });
+      const src = Array.from({ length: 50 }, (_, i) => `prose line ${i + 1}`).join("\n");
+      await fs.writeFile(join(root, "plain.log"), src);
+      const out = await reg.dispatch("read_file", JSON.stringify({ path: "plain.log" }));
+      expect(out).toMatch(/large file:.*outline mode/);
       expect(out).not.toMatch(/\[outline:/);
+      expect(out).toContain("prose line 1");
+      expect(out).toMatch(/search_content/);
     });
 
-    it("auto-preview outline elides the middle when more than 30 exports", async () => {
-      // Spread the 35 exports out so head/tail slices don't mask the elision.
-      const lines: string[] = [];
-      const exportPositions: number[] = [];
-      for (let i = 0; i < 35; i++) {
-        for (let f = 0; f < 6; f++) lines.push(`// filler block ${i}-${f}`);
-        exportPositions.push(lines.length + 1);
-        lines.push(`export const sym${String(i + 1).padStart(2, "0")} = ${i + 1};`);
-      }
-      for (let i = 0; i < 60; i++) lines.push(`// trailer ${i}`);
-      await fs.writeFile(join(root, "many.ts"), lines.join("\n"));
-      const out = await tools.dispatch("read_file", JSON.stringify({ path: "many.ts" }));
-      const outlineMatch = /\[outline: 35 symbols\]([\s\S]*?)\n\n/.exec(out);
-      expect(outlineMatch).not.toBeNull();
-      const outlineBlock = outlineMatch![1]!;
-      expect(outlineBlock).toMatch(/export const sym01/);
-      expect(outlineBlock).toMatch(/export const sym25/);
-      expect(outlineBlock).not.toMatch(/export const sym26/);
-      expect(outlineBlock).not.toMatch(/export const sym30/);
-      expect(outlineBlock).toMatch(/export const sym31/);
-      expect(outlineBlock).toMatch(/export const sym35/);
-      const gapStart = exportPositions[24]!;
-      const gapEnd = exportPositions[30]!;
-      expect(outlineBlock).toContain(`[… 5 more symbols between L${gapStart} and L${gapEnd} …]`);
-    });
-
-    it("returns full content when file is at or below the auto-preview threshold", async () => {
+    it("returns full content for small files at or below the threshold", async () => {
       const out = await tools.dispatch("read_file", JSON.stringify({ path: "hello.txt" }));
       expect(out).toBe("line 1\nline 2\nline 3");
     });
@@ -180,11 +218,20 @@ describe("filesystem tools (built-in, sandbox-enforced)", () => {
       expect(out).toContain("line 1");
     });
 
-    it("returns a truncation notice when file exceeds maxReadBytes", async () => {
+    it("triggers outline mode when file exceeds outlineThresholdBytes", async () => {
       const tiny = new ToolRegistry();
-      registerFilesystemTools(tiny, { rootDir: root, maxReadBytes: 10 });
+      registerFilesystemTools(tiny, { rootDir: root, outlineThresholdBytes: 10 });
       const out = await tiny.dispatch("read_file", JSON.stringify({ path: "hello.txt" }));
-      expect(out).toMatch(/truncated/);
+      expect(out).toMatch(/outline mode/);
+      expect(out).toMatch(/threshold 10 B/);
+    });
+
+    it("refuses binary files (NUL byte in first 8 KiB)", async () => {
+      const buf = Buffer.from([0x47, 0x49, 0x46, 0x38, 0x00, 0x01, 0x02, 0x03]);
+      await fs.writeFile(join(root, "fake.png"), buf);
+      const out = await tools.dispatch("read_file", JSON.stringify({ path: "fake.png" }));
+      expect(out).toMatch(/appears to be binary/);
+      expect(out).toMatch(/get_file_info/);
     });
 
     it("refuses to read a directory as a file", async () => {

--- a/tests/outline.test.ts
+++ b/tests/outline.test.ts
@@ -177,10 +177,66 @@ describe("extractOutline", () => {
     });
   });
 
+  describe("Protobuf", () => {
+    it("captures top-level message / service / enum + nested rpc", () => {
+      const src = lines(
+        [
+          'syntax = "proto3";',
+          "package demo;",
+          "",
+          "message User {",
+          "  string id = 1;",
+          "}",
+          "",
+          "enum Status { OK = 0; }",
+          "",
+          "service Accounts {",
+          "  rpc Get(GetReq) returns (User);",
+          "  rpc List(ListReq) returns (ListResp);",
+          "}",
+        ].join("\n"),
+      );
+      const out = extractOutline("demo.proto", src);
+      expect(out.map((e) => e.text)).toEqual([
+        "message User",
+        "enum Status",
+        "service Accounts",
+        "rpc Get",
+        "rpc List",
+      ]);
+    });
+  });
+
+  describe("Plain text — novel / document chapter markers", () => {
+    it("captures Chinese chapter, volume, prologue markers", () => {
+      const src = lines(
+        ["楔子", "今天天气不错。", "第一章 启程", "故事开始。", "卷二 江湖", "另一段。"].join("\n"),
+      );
+      const out = extractOutline("novel.txt", src);
+      expect(out.map((e) => e.text)).toEqual(["楔子", "第一章 启程", "卷二 江湖"]);
+    });
+
+    it("captures English Chapter / Part markers", () => {
+      const src = lines(
+        ["Some intro.", "Chapter 1 The Beginning", "body.", "Part II Aftermath", "more body."].join(
+          "\n",
+        ),
+      );
+      const out = extractOutline("story.txt", src);
+      expect(out.map((e) => e.text)).toEqual(["Chapter 1 The Beginning", "Part II Aftermath"]);
+    });
+
+    it("ignores prose lines that don't match a chapter pattern", () => {
+      const src = lines(
+        ["just some regular text", "another paragraph", "no chapters here"].join("\n"),
+      );
+      expect(extractOutline("plain.txt", src)).toEqual([]);
+    });
+  });
+
   describe("unknown extensions", () => {
     it("returns empty outline for unsupported file types", () => {
       const src = lines("function not_recognized() {}");
-      expect(extractOutline("a.txt", src)).toEqual([]);
       expect(extractOutline("a.yml", src)).toEqual([]);
       expect(extractOutline("Makefile", src)).toEqual([]);
     });


### PR DESCRIPTION
## Why

The 200-line head+tail preview was actively hurting model reasoning. A 500-line source file dumped a stitched fragment (80 head + outline + 40 tail) instead of the actual code, so any follow-up reasoning ran on a half-blind view. That preview also penalised non-code users — a novel `.txt` or a generated `.proto` got the same broken stitch with no useful outline.

The fix is to trust the prompt cache: full content for anything that fits, structured outline mode (no raw bytes) for anything that doesn't.

## What changed

**Read policy (`src/tools/filesystem.ts`)**
- Files ≤ 512 KiB → **full content**. No more line-based preview.
- Files > 512 KiB → **outline mode**: metadata + first 80 lines + symbol outline + concrete next-step commands (`search_content` / `range` / `head` / `tail`). No middle bytes.
- Files > 32 MiB → refused with the same next-step menu.
- NUL-byte sniff over the first 8 KiB rejects mislabeled binaries cleanly instead of dumping UTF-8 garbage.
- Rename `FilesystemToolsOptions.maxReadBytes` → `outlineThresholdBytes` to reflect the new semantic (was hard truncate, now outline trigger).

**Outline coverage (`src/tools/fs/outline.ts`)**
- `.proto`: top-level `message` / `service` / `enum` + nested `rpc`.
- `.txt`: chapter markers for novels / long documents — Chinese (`第N章/节/回`, `卷N`, `楔子`, `番外`, `前言`, `后记`, ...) and English (`Chapter N`, `Part N`).

## Test plan

- [x] `npm verify` — 202 files / 3109 tests passing, comment-policy gate clean
- [x] Outline extractor covered for proto + Chinese/English novel markers in `tests/outline.test.ts`
- [x] `read_file` outline-mode behaviour covered in `tests/filesystem-tools.test.ts`: TS exports, protobuf, Chinese novel, no-symbol fallback, binary refusal, hard ceiling, size-based trigger via `outlineThresholdBytes: 200`