### PR TITLE
perf(tokenizer): cache renderTools via WeakMap

### DIFF
--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -269,10 +269,8 @@ const INVOKE_END = `</${DSML}invoke>`;
 const PARAM_TEMPLATE = `<${DSML}parameter name="{key}" string="{is_str}">{value}</${DSML}parameter>`;
 const TOOL_RESULT_TEMPLATE = "<tool_result>{content}</tool_result>";
 
-/** Tools template cache.  toolSpecs arrays are reference-stable across turns
- *  (ImmutablePrefix._toolSpecs), so a WeakMap keyed on the array pointer
- *  avoids re-JSONifying 20-40 schema objects and re-allocating the ~1.5 KB
- *  template string on every `decidePreflight` call. */
+// toolSpecs arrays are reference-stable across turns (ImmutablePrefix._toolSpecs).
+// WeakMap keyed on array pointer avoids re-JSONifying schemas + template on every call.
 const toolsTemplateCache = new WeakMap<ReadonlyArray<unknown>, string>();
 
 function renderTools(tools: ReadonlyArray<unknown>): string {

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -269,14 +269,26 @@ const INVOKE_END = `</${DSML}invoke>`;
 const PARAM_TEMPLATE = `<${DSML}parameter name="{key}" string="{is_str}">{value}</${DSML}parameter>`;
 const TOOL_RESULT_TEMPLATE = "<tool_result>{content}</tool_result>";
 
+/** Tools template cache.  toolSpecs arrays are reference-stable across turns
+ *  (ImmutablePrefix._toolSpecs), so a WeakMap keyed on the array pointer
+ *  avoids re-JSONifying 20-40 schema objects and re-allocating the ~1.5 KB
+ *  template string on every `decidePreflight` call. */
+const toolsTemplateCache = new WeakMap<ReadonlyArray<unknown>, string>();
+
 function renderTools(tools: ReadonlyArray<unknown>): string {
+  const cached = toolsTemplateCache.get(tools);
+  if (cached !== undefined) return cached;
+
   const schemas = tools
     .map((t) => {
       const fn = (t as { function?: unknown }).function ?? t;
       return JSON.stringify(fn);
     })
     .join("\n");
-  return `## Tools\n\nYou have access to a set of tools to help answer the user's question. You can invoke tools by writing a \"<${DSML}tool_calls>" block like the following:\n\n<${DSML}tool_calls>\n<${DSML}invoke name="$TOOL_NAME">\n<${DSML}parameter name="$PARAMETER_NAME" string="true|false">$PARAMETER_VALUE</${DSML}parameter>\n...\n</${DSML}invoke>\n<${DSML}invoke name="$TOOL_NAME2">\n...\n</${DSML}invoke>\n</${DSML}tool_calls>\n\nString parameters should be specified as is and set \`string="true"\`. For all other types (numbers, booleans, arrays, objects), pass the value in JSON format and set \`string="false"\`.\n\nIf thinking_mode is enabled (triggered by ${THINK_START}), you MUST output your complete reasoning inside ${THINK_START}...${THINK_END} BEFORE any tool calls or final response.\n\nOtherwise, output directly after ${THINK_END} with tool calls or final response.\n\n### Available Tool Schemas\n\n${schemas}\n\nYou MUST strictly follow the above defined tool name and parameter schemas to invoke tool calls.`;
+  const rendered = `## Tools\n\nYou have access to a set of tools to help answer the user's question. You can invoke tools by writing a \"<${DSML}tool_calls>" block like the following:\n\n<${DSML}tool_calls>\n<${DSML}invoke name="$TOOL_NAME">\n<${DSML}parameter name="$PARAMETER_NAME" string="true|false">$PARAMETER_VALUE</${DSML}parameter>\n...\n</${DSML}invoke>\n<${DSML}invoke name="$TOOL_NAME2">\n...\n</${DSML}invoke>\n</${DSML}tool_calls>\n\nString parameters should be specified as is and set \`string="true"\`. For all other types (numbers, booleans, arrays, objects), pass the value in JSON format and set \`string="false"\`.\n\nIf thinking_mode is enabled (triggered by ${THINK_START}), you MUST output your complete reasoning inside ${THINK_START}...${THINK_END} BEFORE any tool calls or final response.\n\nOtherwise, output directly after ${THINK_END} with tool calls or final response.\n\n### Available Tool Schemas\n\n${schemas}\n\nYou MUST strictly follow the above defined tool name and parameter schemas to invoke tool calls.`;
+
+  toolsTemplateCache.set(tools, rendered);
+  return rendered;
 }
 
 interface ToolCall {


### PR DESCRIPTION
## 分析

\`renderTools\` 在每次 \`decidePreflight\` 中都会被调用（每轮 AI 请求前一次），对 20-40 个工具 schema 执行 \`JSON.stringify\` 后拼入 ~1.5KB 的 TOOLS_TEMPLATE 模板字符串。

核查调用链：
- \`context-manager.ts:decidePreflight\` → \`estimateRequestTokens\` → \`renderTools\`
- \`ImmutablePrefix.toolSpecs\` 返回 \`this._toolSpecs\`（同引用），整个 session 内不变

每轮 JSON.stringify + 模板拼接的开销 (~0.5-1ms) 虽然不大，但工具集在 session 中恒定，完全可缓存。

## 改动

用 \`WeakMap<ReadonlyArray<unknown>, string>\` 按数组引用缓存渲染结果。数组引用不变 → 缓存命中；新数组 → 重新计算（兼容 \`tools()\` 的 structuredClone 场景）。缓存随数组 GC 自动清理，无泄漏。

行数：+12 / -0（仅 \`renderTools\` 函数体）。

## 对齐 #947

\`\`\`
Stage 4 — migrate agent core
  Event log → Rust
  Streaming parser → Rust  
  Tool dispatcher → Rust
  DeepSeek client → Rust (cache-aware request shaping preserved)
\`\`\`

在 tokenizer 迁 Rust 之前，这个缓存减少每轮不必要的字符串分配，直接降低 \`decidePreflight\` 的 CPU 开销，与 \`cache-aware request shaping\` 方向一致。

## 验证

\`\`\`
npm run build       ✅
npm run lint        ✅  (biome, 591 files)
npm run typecheck   ✅  (tsc)
npm test -- tests/tokenizer.test.ts  ✅  (29/29)
\`\`\`