### PR TITLE
fix(context-manager): preserve reasoning_content on fold summary

### DIFF
--- a/src/context-manager.ts
+++ b/src/context-manager.ts
@@ -3,6 +3,7 @@ import { Usage } from "./client.js";
 import { healLoadedMessages } from "./loop.js";
 import { thinkingModeForModel } from "./loop.js";
 import { stripHallucinatedToolMarkup } from "./loop.js";
+import { buildAssistantMessage } from "./loop/messages.js";
 import { DEFAULT_MAX_RESULT_CHARS } from "./mcp/registry.js";
 import type { AppendOnlyLog } from "./memory/runtime.js";
 import { rewriteSession } from "./memory/session.js";
@@ -175,14 +176,21 @@ export class ContextManager {
 
     const { stubbedHead, pinnedBodies } = extractPinnedSkills(head);
     const summary = await this.summarizeForFold(stubbedHead);
-    if (!summary) return noop;
+    if (!summary.content) return noop;
 
     const memoTail =
       pinnedBodies.length > 0 ? `\n\n${SKILL_PIN_MEMO_HEADER}\n\n${pinnedBodies.join("\n\n")}` : "";
-    const summaryMsg: ChatMessage = {
-      role: "assistant",
-      content: HISTORY_FOLD_MARKER + summary + memoTail,
-    };
+    // Route via buildAssistantMessage so the synthetic summary carries
+    // reasoning_content under thinking-mode sessions — without it the
+    // next API call 400s with "must be passed back" (#1042). Stamp uses
+    // the SESSION model so an empty placeholder is added even when the
+    // summarizer call somehow returned no reasoning.
+    const summaryMsg = buildAssistantMessage(
+      HISTORY_FOLD_MARKER + summary.content + memoTail,
+      [],
+      model,
+      summary.reasoningContent,
+    );
     const replacement = [summaryMsg, ...tail];
     this.deps.log.compactInPlace(replacement);
     this.persistRewrite(replacement);
@@ -190,7 +198,7 @@ export class ContextManager {
       folded: true,
       beforeMessages: all.length,
       afterMessages: replacement.length,
-      summaryChars: summary.length,
+      summaryChars: summary.content.length,
     };
   }
 
@@ -211,7 +219,9 @@ export class ContextManager {
     return true;
   }
 
-  private async summarizeForFold(messagesToSummarize: ChatMessage[]): Promise<string> {
+  private async summarizeForFold(
+    messagesToSummarize: ChatMessage[],
+  ): Promise<{ content: string; reasoningContent: string }> {
     const summaryModel = "deepseek-v4-flash";
     const systemPrompt =
       "You compress conversation history for a coding agent. Output one prose recap that preserves: the user's overall goal, decisions and conclusions reached, files inspected or modified, important tool results still relevant to ongoing work, and any open todos. Skip turn-by-turn play-by-play. No tool calls, no markdown headings, no SEARCH/REPLACE blocks — plain prose only.";
@@ -234,9 +244,12 @@ export class ContextManager {
         reasoningEffort: "high",
       });
       this.deps.stats.record(this.deps.getCurrentTurn(), summaryModel, resp.usage ?? new Usage());
-      return stripHallucinatedToolMarkup((resp.content ?? "").trim());
+      return {
+        content: stripHallucinatedToolMarkup((resp.content ?? "").trim()),
+        reasoningContent: resp.reasoningContent ?? "",
+      };
     } catch {
-      return "";
+      return { content: "", reasoningContent: "" };
     }
   }
 

--- a/tests/context-manager-thinking-mode.test.ts
+++ b/tests/context-manager-thinking-mode.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from "vitest";
+import { DeepSeekClient } from "../src/client.js";
+import { CacheFirstLoop } from "../src/loop.js";
+import { ImmutablePrefix } from "../src/memory/runtime.js";
+
+interface FakeResponseShape {
+  content?: string;
+  reasoning_content?: string;
+}
+
+function fakeFetch(responses: FakeResponseShape[]): typeof fetch {
+  let i = 0;
+  return vi.fn(async (_url: unknown, _init: { body?: string } | undefined) => {
+    const resp = responses[i++] ?? responses[responses.length - 1]!;
+    return new Response(
+      JSON.stringify({
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: "assistant",
+              content: resp.content ?? "",
+              reasoning_content: resp.reasoning_content,
+            },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 100, completion_tokens: 20, total_tokens: 120 },
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  }) as unknown as typeof fetch;
+}
+
+function makeClient(responses: FakeResponseShape[]) {
+  return new DeepSeekClient({ apiKey: "sk-test", fetch: fakeFetch(responses) });
+}
+
+function seedTurns(loop: CacheFirstLoop, n: number): void {
+  for (let i = 0; i < n; i++) {
+    loop.log.append({ role: "user", content: `q${i} bulk text padding to weigh the turn` });
+    loop.log.append({
+      role: "assistant",
+      content: `a${i} bulk text padding to weigh the turn`,
+      reasoning_content: `r${i} thinking trace`,
+    });
+  }
+}
+
+describe("ContextManager fold preserves reasoning_content for thinking-mode (#1042)", () => {
+  it("stamps reasoning_content on the synthesized fold summary so the next API call doesn't 400", async () => {
+    const client = makeClient([
+      { content: "earlier turns covered the user's auth refactor.", reasoning_content: "thought" },
+    ]);
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s" }),
+      model: "deepseek-v4-flash",
+      stream: false,
+    });
+    seedTurns(loop, 6);
+
+    const result = await loop.compactHistory({ keepRecentTokens: 40 });
+    expect(result.folded).toBe(true);
+
+    const head = loop.log.entries[0]!;
+    expect(head.role).toBe("assistant");
+    expect(head.content).toMatch(/HISTORY SUMMARY/);
+    expect(head.reasoning_content).toBeDefined();
+    expect(head.reasoning_content).toBe("thought");
+  });
+
+  it("stamps empty reasoning_content when the summarizer response omitted it (thinking-mode contract)", async () => {
+    const client = makeClient([{ content: "earlier turns happened." }]);
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s" }),
+      model: "deepseek-v4-flash",
+      stream: false,
+    });
+    seedTurns(loop, 6);
+
+    const result = await loop.compactHistory({ keepRecentTokens: 40 });
+    expect(result.folded).toBe(true);
+
+    const head = loop.log.entries[0]!;
+    expect(head.reasoning_content).toBe("");
+  });
+
+  it("omits reasoning_content for non-thinking-mode session models when summarizer returned none", async () => {
+    const client = makeClient([{ content: "earlier turns happened." }]);
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s" }),
+      model: "deepseek-chat",
+      stream: false,
+    });
+    seedTurns(loop, 6);
+
+    const result = await loop.compactHistory({ keepRecentTokens: 40 });
+    expect(result.folded).toBe(true);
+
+    const head = loop.log.entries[0]!;
+    expect(head.reasoning_content).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #1042

## Why

DeepSeek's thinking-mode contract: every assistant message round-tripped to the API must carry \`reasoning_content\` (even empty-string). When \`ContextManager.fold\` synthesized its history-summary assistant turn it built a bare \`ChatMessage\` literal — \`reasoning_content\` was never set. On the next API call the persisted log replayed that turn and the provider 400'd:

> The \`reasoning_content\` in the thinking mode must be passed back to the API.

This reproduces reliably on long sessions running V4-flash / V4-pro / R1 once the auto-fold (50% of ctxMax) kicks in.

## What changed

Two edits in \`src/context-manager.ts\`:

- \`summarizeForFold\` now returns \`{ content, reasoningContent }\` so the summarizer's own reasoning is preserved.
- \`fold\` builds the synthetic message via \`buildAssistantMessage\` with the SESSION's model as the producing model — so even if the summarizer emits no reasoning, the empty-string stamp lands on thinking-mode sessions and the next call no longer 400s.

## Test plan

- [x] \`npm verify\` — 203 files / 3091 tests passing
- [x] New regression file \`tests/context-manager-thinking-mode.test.ts\`:
  - summarizer's \`reasoning_content\` is carried onto the synthesized fold message
  - thinking-mode sessions get empty-string stamping when the summarizer omits it
  - non-thinking sessions stay clean (no spurious \`reasoning_content\`)
- [x] Existing \`context-manager-skill-pin.test.ts\` still green