### PR TITLE
fix(proxy): tolerate bare host:port and malformed values

### DIFF
--- a/src/net/proxy.ts
+++ b/src/net/proxy.ts
@@ -22,18 +22,44 @@ export function detectProxyUrl(env: NodeJS.ProcessEnv = process.env): string | n
   return null;
 }
 
+/** Auto-prefix `http://` when the env value is bare `host:port` (issue #1034 — Windows users routinely set `HTTPS_PROXY=127.0.0.1:10888` without a scheme, and undici's ProxyAgent ctor calls `new URL(...)` which throws and kills startup). */
+export function normalizeProxyUrl(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const candidate = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`;
+  try {
+    return new URL(candidate).toString();
+  } catch {
+    return null;
+  }
+}
+
 let installed = false;
 
-/** Sets the undici global dispatcher to a ProxyAgent. Returns the proxy URL or null if no env var is set. Idempotent. */
+/** Sets the undici global dispatcher to a ProxyAgent. Returns the proxy URL or null if no env var is set, the value is unparseable, or the ProxyAgent ctor throws. Idempotent. */
 export function installProxyIfConfigured(
   env: NodeJS.ProcessEnv = process.env,
 ): { url: string; reinstalled: boolean } | null {
-  const url = detectProxyUrl(env);
-  if (!url) return null;
-  const reinstalled = installed;
-  setGlobalDispatcher(new ProxyAgent(url));
-  installed = true;
-  return { url, reinstalled };
+  const raw = detectProxyUrl(env);
+  if (!raw) return null;
+  const url = normalizeProxyUrl(raw);
+  if (!url) {
+    process.stderr.write(
+      `▲ ignoring proxy env value ${JSON.stringify(raw)} — not a valid URL. Expected something like \`http://host:port\` or \`socks5://host:port\`.\n`,
+    );
+    return null;
+  }
+  try {
+    const reinstalled = installed;
+    setGlobalDispatcher(new ProxyAgent(url));
+    installed = true;
+    return { url, reinstalled };
+  } catch (err) {
+    process.stderr.write(
+      `▲ proxy install failed (${(err as Error).message}); continuing without proxy.\n`,
+    );
+    return null;
+  }
 }
 
 /** Test-only escape hatch so the installed flag doesn't leak between vitest cases. */

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -1,5 +1,10 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { _resetForTests, detectProxyUrl, installProxyIfConfigured } from "../src/net/proxy.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  _resetForTests,
+  detectProxyUrl,
+  installProxyIfConfigured,
+  normalizeProxyUrl,
+} from "../src/net/proxy.js";
 
 describe("detectProxyUrl (issue #646)", () => {
   it("returns null when no proxy env var is set", () => {
@@ -65,13 +70,57 @@ describe("installProxyIfConfigured", () => {
 
   it("returns the detected url + reinstalled=false on the first install", () => {
     const result = installProxyIfConfigured({ HTTPS_PROXY: "http://example:8080" });
-    expect(result).toEqual({ url: "http://example:8080", reinstalled: false });
+    expect(result).toEqual({ url: "http://example:8080/", reinstalled: false });
   });
 
   it("returns reinstalled=true on subsequent installs (idempotent at the env-detect level)", () => {
     installProxyIfConfigured({ HTTPS_PROXY: "http://first:8080" });
     const second = installProxyIfConfigured({ HTTPS_PROXY: "http://second:8080" });
     expect(second?.reinstalled).toBe(true);
-    expect(second?.url).toBe("http://second:8080");
+    expect(second?.url).toBe("http://second:8080/");
+  });
+
+  it("auto-prefixes http:// for bare host:port (issue #1034)", () => {
+    const result = installProxyIfConfigured({ HTTPS_PROXY: "127.0.0.1:10888" });
+    expect(result?.url).toBe("http://127.0.0.1:10888/");
+  });
+
+  it("does not throw on a malformed env value — warns to stderr and returns null", () => {
+    const writes: string[] = [];
+    const orig = process.stderr.write.bind(process.stderr);
+    const spy = vi.spyOn(process.stderr, "write").mockImplementation(((
+      chunk: string | Uint8Array,
+    ): boolean => {
+      writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+      return true;
+    }) as typeof process.stderr.write);
+    try {
+      expect(installProxyIfConfigured({ HTTPS_PROXY: "http://[invalid:::" })).toBeNull();
+      expect(writes.join("")).toMatch(/ignoring proxy env value/);
+    } finally {
+      spy.mockRestore();
+      process.stderr.write = orig;
+    }
+  });
+});
+
+describe("normalizeProxyUrl (issue #1034)", () => {
+  it("returns null for empty / whitespace input", () => {
+    expect(normalizeProxyUrl("")).toBeNull();
+    expect(normalizeProxyUrl("   ")).toBeNull();
+  });
+
+  it("auto-prefixes http:// when the scheme is missing", () => {
+    expect(normalizeProxyUrl("127.0.0.1:10888")).toBe("http://127.0.0.1:10888/");
+    expect(normalizeProxyUrl("proxy.example:8080")).toBe("http://proxy.example:8080/");
+  });
+
+  it("leaves an already-prefixed URL intact", () => {
+    expect(normalizeProxyUrl("http://example:8080")).toBe("http://example:8080/");
+    expect(normalizeProxyUrl("socks5://example:1080")).toBe("socks5://example:1080");
+  });
+
+  it("returns null for unparseable values", () => {
+    expect(normalizeProxyUrl("http://[invalid:::")).toBeNull();
   });
 });


### PR DESCRIPTION
Closes #1034

## Why

undici's \`ProxyAgent\` ctor calls \`new URL(input)\`, and Windows users routinely set \`HTTPS_PROXY=127.0.0.1:10888\` (no scheme). Without a scheme the URL ctor throws — the throw escapes the top-level \`installProxyIfConfigured()\` call in \`src/cli/index.ts:22\`, killing startup before any UI renders:

\`\`\`
TypeError: Invalid URL  code: 'ERR_INVALID_URL'
    input: '127.0.0.1:10888'
    at new URL (node:internal/url:818:25)
    at #getUrl (.../ProxyAgent)
    at installProxyIfConfigured
\`\`\`

## What changed

Two edits in \`src/net/proxy.ts\`:

- New \`normalizeProxyUrl\` auto-prefixes \`http://\` when the env value has no \`scheme://\`, then validates via \`new URL\`. Bare \`host:port\` becomes \`http://host:port/\`; already-prefixed values pass through; unparseable values return null.
- \`installProxyIfConfigured\` wraps the \`setGlobalDispatcher(new ProxyAgent)\` call in try/catch and emits a stderr warning on either normalization failure or ProxyAgent ctor failure instead of throwing. Proxy misconfig should never block startup.

## Test plan

- [x] \`npm verify\` — 199 files / 3041 tests passing
- [x] New cases in \`tests/proxy.test.ts\`: bare \`host:port\` auto-prefix, already-prefixed URLs preserved, malformed values warn + return null without throwing
- [x] \`normalizeProxyUrl\` direct-call cases cover the four input shapes