### PR TITLE
chore(tokenizer): tighten tools-cache comment to one line

### DIFF
--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -290,8 +290,7 @@ const INVOKE_END = `</${DSML}invoke>`;
 const PARAM_TEMPLATE = `<${DSML}parameter name="{key}" string="{is_str}">{value}</${DSML}parameter>`;
 const TOOL_RESULT_TEMPLATE = "<tool_result>{content}</tool_result>";
 
-// toolSpecs arrays are reference-stable across turns (ImmutablePrefix._toolSpecs).
-// WeakMap keyed on array pointer avoids re-JSONifying schemas + template on every call.
+/** Keyed by `ImmutablePrefix._toolSpecs` identity — stable for the prefix's lifetime. */
 const toolsTemplateCache = new WeakMap<ReadonlyArray<unknown>, string>();
 
 function renderTools(tools: ReadonlyArray<unknown>): string {


### PR DESCRIPTION
## Summary

- Follow-up to #1046. Replace the 2-line `// ...` comment above `toolsTemplateCache` with a single 1-line JSDoc.
- Matches the repo's trailing-comment cap (CLAUDE.md → "Trailing `//` 1 line"); no behavior change.

## Test plan

- [x] \`npm run verify\` — build + lint + typecheck + 3035 tests pass