### PR TITLE
fix(rust): Enter submits exact slash match instead of re-completing

### DIFF
--- a/crates/reasonix-render/src/integrated.rs
+++ b/crates/reasonix-render/src/integrated.rs
@@ -188,7 +188,11 @@ pub fn run_integrated_loop(terminal: &mut Terminal) -> Result<()> {
             }
         }
 
-        if buffer != prev_emitted_buffer {
+        // While a prompt-input is active the composer buffer is a
+        // private text answer (e.g. an API secret), not a chat draft.
+        // Don't echo it back to Node — handle_prompt_input_key emits a
+        // single `prompt-response` on Enter instead.
+        if scene.prompt_input.is_none() && buffer != prev_emitted_buffer {
             emit_event(serde_json::json!({
                 "event": "composer",
                 "text": buffer.clone(),
@@ -320,6 +324,10 @@ pub fn run_integrated_loop(terminal: &mut Terminal) -> Result<()> {
                 }
                 if mode_picker.is_some() || preset_picker.is_some() {
                     handle_mode_picker_key(&key, &mut mode_picker, &mut preset_picker);
+                    continue;
+                }
+                if let Some(prompt) = scene.prompt_input.as_ref() {
+                    handle_prompt_input_key(&key, prompt, &mut buffer, &mut cursor);
                     continue;
                 }
                 if let Some(approval) = scene.approval.as_ref() {
@@ -724,6 +732,55 @@ fn current_preset_idx(scene: &SceneState) -> usize {
         Some("flash") => 1,
         Some("pro") => 2,
         _ => 0,
+    }
+}
+
+fn handle_prompt_input_key(
+    key: &crossterm::event::KeyEvent,
+    prompt: &crate::state::PromptInput,
+    buffer: &mut String,
+    cursor: &mut usize,
+) {
+    match key.code {
+        KeyCode::Enter => {
+            let answer = if buffer.is_empty() {
+                prompt.default_value.clone().unwrap_or_default()
+            } else {
+                std::mem::take(buffer)
+            };
+            *cursor = 0;
+            emit_event(serde_json::json!({
+                "event": "prompt-response",
+                "id": prompt.id,
+                "text": answer,
+            }));
+        }
+        KeyCode::Esc => {
+            buffer.clear();
+            *cursor = 0;
+            emit_event(serde_json::json!({
+                "event": "prompt-response",
+                "id": prompt.id,
+                "cancelled": true,
+            }));
+        }
+        KeyCode::Backspace if *cursor > 0 => {
+            remove_char_at(buffer, *cursor - 1);
+            *cursor -= 1;
+        }
+        KeyCode::Left => {
+            *cursor = cursor.saturating_sub(1);
+        }
+        KeyCode::Right => {
+            *cursor = (*cursor + 1).min(buffer.chars().count());
+        }
+        KeyCode::Home => *cursor = 0,
+        KeyCode::End => *cursor = buffer.chars().count(),
+        KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+            insert_char_at(buffer, *cursor, c);
+            *cursor += 1;
+        }
+        _ => {}
     }
 }
 

--- a/crates/reasonix-render/src/integrated.rs
+++ b/crates/reasonix-render/src/integrated.rs
@@ -19,8 +19,8 @@ use crate::input::is_quit;
 use crate::state::{decode_message, Payload, SceneState};
 use crate::view::render_setup;
 use crate::whole_screen::{
-    at_completion, at_match_count, cards_layout, extract_text, slash_completion, slash_match_count,
-    Selection, WholeScreen,
+    at_completion, at_match_count, cards_layout, extract_text, slash_completion, slash_is_exact,
+    slash_match_count, Selection, WholeScreen,
 };
 
 type Terminal = ratatui::Terminal<CrosstermBackend<BufWriter<io::Stdout>>>;
@@ -321,6 +321,7 @@ pub fn run_integrated_loop(terminal: &mut Terminal) -> Result<()> {
                 }
                 let slash_active = slash_count > 0;
                 let at_active = !slash_active && at_count > 0;
+                let slash_complete_only = slash_active && !slash_is_exact(&buffer, &scene);
                 match key.code {
                     KeyCode::Up if slash_active => {
                         slash_idx = slash_idx.saturating_sub(1);
@@ -342,7 +343,7 @@ pub fn run_integrated_loop(terminal: &mut Terminal) -> Result<()> {
                             slash_idx - 1
                         };
                     }
-                    KeyCode::Enter if slash_active => {
+                    KeyCode::Enter if slash_complete_only => {
                         if let Some(completion) = slash_completion(&buffer, slash_idx, &scene) {
                             cursor = completion.chars().count();
                             buffer = completion;

--- a/crates/reasonix-render/src/integrated.rs
+++ b/crates/reasonix-render/src/integrated.rs
@@ -19,8 +19,9 @@ use crate::input::is_quit;
 use crate::state::{decode_message, Payload, SceneState};
 use crate::view::render_setup;
 use crate::whole_screen::{
-    at_completion, at_match_count, cards_layout, extract_text, slash_completion, slash_is_exact,
-    slash_match_count, Selection, WholeScreen,
+    at_completion, at_match_count, cards_layout, extract_text, slash_arg_completion,
+    slash_arg_match_count, slash_completion, slash_is_exact, slash_match_count, Selection,
+    WholeScreen,
 };
 
 type Terminal = ratatui::Terminal<CrosstermBackend<BufWriter<io::Stdout>>>;
@@ -81,6 +82,7 @@ pub fn run_integrated_loop(terminal: &mut Terminal) -> Result<()> {
     let mut dragging = false;
     let mut scrollbar_drag: Option<i32> = None;
     let mut slash_idx: usize = 0;
+    let mut slash_arg_idx: usize = 0;
     let mut at_idx: usize = 0;
     let mut history_cursor: i32 = -1;
     let mut approval_idx: usize = 0;
@@ -157,7 +159,17 @@ pub fn run_integrated_loop(terminal: &mut Terminal) -> Result<()> {
         } else if slash_idx >= slash_count {
             slash_idx = slash_count - 1;
         }
-        let at_count = if slash_count > 0 {
+        let slash_arg_count = if slash_count > 0 {
+            0
+        } else {
+            slash_arg_match_count(&buffer, &scene)
+        };
+        if slash_arg_count == 0 {
+            slash_arg_idx = 0;
+        } else if slash_arg_idx >= slash_arg_count {
+            slash_arg_idx = slash_arg_count - 1;
+        }
+        let at_count = if slash_count > 0 || slash_arg_count > 0 {
             0
         } else {
             at_match_count(&buffer, &scene)
@@ -205,6 +217,7 @@ pub fn run_integrated_loop(terminal: &mut Terminal) -> Result<()> {
                                 .with_scroll(scroll_offset)
                                 .with_selection(selection)
                                 .with_slash_index(slash_idx)
+                                .with_slash_arg_index(slash_arg_idx)
                                 .with_at_index(at_idx)
                                 .with_approval_index(approval_idx)
                                 .with_mode_picker(mode_picker)
@@ -320,7 +333,8 @@ pub fn run_integrated_loop(terminal: &mut Terminal) -> Result<()> {
                     continue;
                 }
                 let slash_active = slash_count > 0;
-                let at_active = !slash_active && at_count > 0;
+                let slash_arg_active = !slash_active && slash_arg_count > 0;
+                let at_active = !slash_active && !slash_arg_active && at_count > 0;
                 let slash_complete_only = slash_active && !slash_is_exact(&buffer, &scene);
                 match key.code {
                     KeyCode::Up if slash_active => {
@@ -344,6 +358,35 @@ pub fn run_integrated_loop(terminal: &mut Terminal) -> Result<()> {
                     }
                     KeyCode::Enter if slash_complete_only => {
                         if let Some(completion) = slash_completion(&buffer, slash_idx, &scene) {
+                            cursor = completion.chars().count();
+                            buffer = completion;
+                        }
+                    }
+                    KeyCode::Up if slash_arg_active => {
+                        slash_arg_idx = slash_arg_idx.saturating_sub(1);
+                    }
+                    KeyCode::Down if slash_arg_active => {
+                        slash_arg_idx = (slash_arg_idx + 1).min(slash_arg_count - 1);
+                    }
+                    KeyCode::Tab if slash_arg_active => {
+                        if let Some(completion) =
+                            slash_arg_completion(&buffer, slash_arg_idx, &scene)
+                        {
+                            cursor = completion.chars().count();
+                            buffer = completion;
+                        }
+                    }
+                    KeyCode::BackTab if slash_arg_active => {
+                        slash_arg_idx = if slash_arg_idx == 0 {
+                            slash_arg_count - 1
+                        } else {
+                            slash_arg_idx - 1
+                        };
+                    }
+                    KeyCode::Enter if slash_arg_active => {
+                        if let Some(completion) =
+                            slash_arg_completion(&buffer, slash_arg_idx, &scene)
+                        {
                             cursor = completion.chars().count();
                             buffer = completion;
                         }

--- a/crates/reasonix-render/src/integrated.rs
+++ b/crates/reasonix-render/src/integrated.rs
@@ -330,11 +330,10 @@ pub fn run_integrated_loop(terminal: &mut Terminal) -> Result<()> {
                         slash_idx = (slash_idx + 1).min(slash_count - 1);
                     }
                     KeyCode::Tab if slash_active => {
-                        slash_idx = if key.modifiers.contains(KeyModifiers::SHIFT) {
-                            slash_idx.saturating_sub(1)
-                        } else {
-                            (slash_idx + 1) % slash_count
-                        };
+                        if let Some(completion) = slash_completion(&buffer, slash_idx, &scene) {
+                            buffer = completion.trim_end().to_string();
+                            cursor = buffer.chars().count();
+                        }
                     }
                     KeyCode::BackTab if slash_active => {
                         slash_idx = if slash_idx == 0 {
@@ -356,11 +355,10 @@ pub fn run_integrated_loop(terminal: &mut Terminal) -> Result<()> {
                         at_idx = (at_idx + 1).min(at_count - 1);
                     }
                     KeyCode::Tab if at_active => {
-                        at_idx = if key.modifiers.contains(KeyModifiers::SHIFT) {
-                            at_idx.saturating_sub(1)
-                        } else {
-                            (at_idx + 1) % at_count
-                        };
+                        if let Some(completion) = at_completion(&buffer, at_idx, &scene) {
+                            cursor = completion.chars().count();
+                            buffer = completion;
+                        }
                     }
                     KeyCode::BackTab if at_active => {
                         at_idx = if at_idx == 0 {

--- a/crates/reasonix-render/src/main.rs
+++ b/crates/reasonix-render/src/main.rs
@@ -20,7 +20,7 @@ use reasonix_render::state::{decode_message, Payload};
 use reasonix_render::view::render_setup;
 use reasonix_render::whole_screen::{
     at_completion, at_match_count, cards_layout, demo_state, extract_text, slash_completion,
-    slash_match_count, Selection, WholeScreen,
+    slash_is_exact, slash_match_count, Selection, WholeScreen,
 };
 
 type RenderTerminal = ratatui::Terminal<CrosstermBackend<BufWriter<io::Stdout>>>;
@@ -245,6 +245,7 @@ fn run_demo_loop(terminal: &mut RenderTerminal) -> Result<()> {
                 }
                 let slash_active = slash_count > 0;
                 let at_active = !slash_active && at_count > 0;
+                let slash_complete_only = slash_active && !slash_is_exact(&buffer, &state);
                 match key.code {
                     KeyCode::Up if slash_active => {
                         slash_idx = slash_idx.saturating_sub(1);
@@ -266,7 +267,7 @@ fn run_demo_loop(terminal: &mut RenderTerminal) -> Result<()> {
                             slash_idx - 1
                         };
                     }
-                    KeyCode::Enter if slash_active => {
+                    KeyCode::Enter if slash_complete_only => {
                         if let Some(completion) = slash_completion(&buffer, slash_idx, &state) {
                             cursor = completion.chars().count();
                             buffer = completion;

--- a/crates/reasonix-render/src/main.rs
+++ b/crates/reasonix-render/src/main.rs
@@ -254,10 +254,9 @@ fn run_demo_loop(terminal: &mut RenderTerminal) -> Result<()> {
                         slash_idx = (slash_idx + 1).min(slash_count - 1);
                     }
                     KeyCode::Tab if slash_active => {
-                        if key.modifiers.contains(KeyModifiers::SHIFT) {
-                            slash_idx = slash_idx.saturating_sub(1);
-                        } else {
-                            slash_idx = (slash_idx + 1) % slash_count;
+                        if let Some(completion) = slash_completion(&buffer, slash_idx, &state) {
+                            buffer = completion.trim_end().to_string();
+                            cursor = buffer.chars().count();
                         }
                     }
                     KeyCode::BackTab if slash_active => {
@@ -280,10 +279,9 @@ fn run_demo_loop(terminal: &mut RenderTerminal) -> Result<()> {
                         at_idx = (at_idx + 1).min(at_count - 1);
                     }
                     KeyCode::Tab if at_active => {
-                        if key.modifiers.contains(KeyModifiers::SHIFT) {
-                            at_idx = at_idx.saturating_sub(1);
-                        } else {
-                            at_idx = (at_idx + 1) % at_count;
+                        if let Some(completion) = at_completion(&buffer, at_idx, &state) {
+                            cursor = completion.chars().count();
+                            buffer = completion;
                         }
                     }
                     KeyCode::BackTab if at_active => {

--- a/crates/reasonix-render/src/state.rs
+++ b/crates/reasonix-render/src/state.rs
@@ -67,6 +67,20 @@ pub struct SceneState {
     pub approval: Option<Approval>,
     #[serde(default)]
     pub at_state: Option<AtState>,
+    #[serde(default)]
+    pub prompt_input: Option<PromptInput>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct PromptInput {
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub label: String,
+    #[serde(default, rename = "defaultValue")]
+    pub default_value: Option<String>,
+    #[serde(default)]
+    pub secret: bool,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]

--- a/crates/reasonix-render/src/state.rs
+++ b/crates/reasonix-render/src/state.rs
@@ -182,10 +182,14 @@ pub struct SlashMatch {
     pub cmd: String,
     #[serde(default)]
     pub summary: String,
+    #[serde(default)]
+    pub group: Option<String>,
     #[serde(default, rename = "argsHint")]
     pub args_hint: Option<String>,
     #[serde(default)]
     pub aliases: Vec<String>,
+    #[serde(default, rename = "argCompleter")]
+    pub arg_completer: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/reasonix-render/src/state.rs
+++ b/crates/reasonix-render/src/state.rs
@@ -41,6 +41,8 @@ pub struct SceneState {
     pub preset: Option<String>,
     #[serde(default)]
     pub cwd: Option<String>,
+    #[serde(default, rename = "dashboardUrl")]
+    pub dashboard_url: Option<String>,
     #[serde(default)]
     pub ctx_tokens: Option<u32>,
     #[serde(default)]

--- a/crates/reasonix-render/src/state.rs
+++ b/crates/reasonix-render/src/state.rs
@@ -60,11 +60,23 @@ pub struct SceneState {
     #[serde(default)]
     pub slash_catalog: Option<Vec<SlashMatch>>,
     #[serde(default)]
+    pub slash_arg_state: Option<SlashArgState>,
+    #[serde(default)]
     pub prompt_history: Option<Vec<String>>,
     #[serde(default)]
     pub approval: Option<Approval>,
     #[serde(default)]
     pub at_state: Option<AtState>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct SlashArgState {
+    #[serde(default)]
+    pub cmd: String,
+    #[serde(default)]
+    pub partial: String,
+    #[serde(default)]
+    pub matches: Vec<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/reasonix-render/src/whole_screen/boot.rs
+++ b/crates/reasonix-render/src/whole_screen/boot.rs
@@ -5,7 +5,7 @@ use ratatui::style::Modifier;
 use crate::state::SceneState;
 
 use super::cards::render_cards;
-use super::paint::paint_str_to;
+use super::paint::{paint_link, paint_str_to};
 use super::theme::{DS, FG, FG2, FG3, LOGO};
 
 pub fn render_scroll(
@@ -135,21 +135,7 @@ fn render_boot_meta(buf: &mut Buffer, area: Rect, start_row: u16, state: &SceneS
                 BG,
                 Modifier::empty(),
             );
-            // Most modern terminals (Windows Terminal, iTerm2, WezTerm,
-            // gnome-terminal ≥3.26) auto-detect URLs and make them
-            // Ctrl+click-able without needing OSC 8. Render as plain
-            // text in the accent color so it's obvious where the web UI
-            // lives — and selectable with the mouse for copy/paste.
-            paint_str_to(
-                buf,
-                val_col,
-                row,
-                url,
-                end_x,
-                DS_BRIGHT,
-                BG,
-                Modifier::UNDERLINED,
-            );
+            paint_link(buf, val_col, row, url, url, DS_BRIGHT, BG);
             row += 1;
         }
     }

--- a/crates/reasonix-render/src/whole_screen/boot.rs
+++ b/crates/reasonix-render/src/whole_screen/boot.rs
@@ -123,6 +123,37 @@ fn render_boot_meta(buf: &mut Buffer, area: Rect, start_row: u16, state: &SceneS
         }
     }
 
+    if row < bottom {
+        if let Some(url) = state.dashboard_url.as_deref() {
+            paint_str_to(
+                buf,
+                key_col,
+                row,
+                "dashboard",
+                end_x,
+                FG2,
+                BG,
+                Modifier::empty(),
+            );
+            // Most modern terminals (Windows Terminal, iTerm2, WezTerm,
+            // gnome-terminal ≥3.26) auto-detect URLs and make them
+            // Ctrl+click-able without needing OSC 8. Render as plain
+            // text in the accent color so it's obvious where the web UI
+            // lives — and selectable with the mouse for copy/paste.
+            paint_str_to(
+                buf,
+                val_col,
+                row,
+                url,
+                end_x,
+                DS_BRIGHT,
+                BG,
+                Modifier::UNDERLINED,
+            );
+            row += 1;
+        }
+    }
+
     row
 }
 

--- a/crates/reasonix-render/src/whole_screen/cards/mod.rs
+++ b/crates/reasonix-render/src/whole_screen/cards/mod.rs
@@ -218,7 +218,7 @@ fn card_height(card: &SceneCard, body_width: u16) -> u16 {
     match card.kind.as_str() {
         "user" | "reasoning" | "think" | "thinking" | "assistant" | "streaming" | "diff"
         | "cmd" | "fileview" | "search" | "subagent" | "confirm" | "await" | "await_input"
-        | "error" => 1 + body_lines + 1,
+        | "error" | "info" | "warn" | "usage" => 1 + body_lines + 1,
         "todo" | "plan" => {
             let items = card
                 .body
@@ -256,6 +256,9 @@ fn render_card(
         "confirm" => notify::render_confirm_card(buf, area, row, card),
         "await" | "await_input" => notify::render_await_card(buf, area, row, card),
         "error" => notify::render_error_card(buf, area, row, card),
+        "info" => notify::render_info_card(buf, area, row, card, super::theme::INFO, "ⓘ"),
+        "warn" => notify::render_info_card(buf, area, row, card, super::theme::WARN, "▲"),
+        "usage" => notify::render_info_card(buf, area, row, card, super::theme::DS_BRIGHT, "$"),
         _ => row,
     }
 }

--- a/crates/reasonix-render/src/whole_screen/cards/notify.rs
+++ b/crates/reasonix-render/src/whole_screen/cards/notify.rs
@@ -177,6 +177,44 @@ fn paint_await_option(buf: &mut Buffer, x: u16, row: u16, line: &str) {
     }
 }
 
+pub(super) fn render_info_card(
+    buf: &mut Buffer,
+    area: Rect,
+    start_row: u16,
+    card: &SceneCard,
+    accent: ratatui::style::Color,
+    glyph: &str,
+) -> u16 {
+    let bottom = area.y + area.height;
+    let mut row = start_row;
+    let meta = card.meta.as_deref().map(|m| (m, FG2));
+    render_card_header(
+        buf,
+        area,
+        row,
+        accent,
+        glyph,
+        accent,
+        &card.summary,
+        accent,
+        meta,
+    );
+    row += 1;
+    if let Some(body) = card.body.as_deref() {
+        let width = body_width_for(area);
+        for raw in body.split('\n') {
+            for line in wrap_visual(raw, width) {
+                if row >= bottom {
+                    return row;
+                }
+                paint_body_line(buf, area, row, accent, &line, FG1, Modifier::empty());
+                row += 1;
+            }
+        }
+    }
+    paint_blank_after(buf, area, row, accent)
+}
+
 pub(super) fn render_error_card(
     buf: &mut Buffer,
     area: Rect,

--- a/crates/reasonix-render/src/whole_screen/demo.rs
+++ b/crates/reasonix-render/src/whole_screen/demo.rs
@@ -35,8 +35,10 @@ pub fn demo_state() -> SceneState {
             .map(|(cmd, summary)| SlashMatch {
                 cmd: (*cmd).to_string(),
                 summary: (*summary).to_string(),
+                group: Some("chat".to_string()),
                 args_hint: None,
                 aliases: Vec::new(),
+                arg_completer: None,
             })
             .collect(),
         ),

--- a/crates/reasonix-render/src/whole_screen/dock.rs
+++ b/crates/reasonix-render/src/whole_screen/dock.rs
@@ -55,17 +55,39 @@ fn render_input_box(buf: &mut Buffer, area: Rect, rows: u16, state: &SceneState,
     paint(buf, right, bot, '╯', FG3, BG, Modifier::empty());
 
     let content_rows = rows.saturating_sub(2);
-    let prompt_color = match state
-        .composer_text
-        .as_deref()
-        .and_then(|s| s.chars().next())
-    {
-        Some('!') => OK,
-        Some('/') => DS_BRIGHT,
-        Some('@') => DS_PURPLE,
-        _ => DS_BRIGHT,
+    let prompt_input = state.prompt_input.as_ref();
+    let prompt_color = if prompt_input.is_some() {
+        WARN
+    } else {
+        match state
+            .composer_text
+            .as_deref()
+            .and_then(|s| s.chars().next())
+        {
+            Some('!') => OK,
+            Some('/') => DS_BRIGHT,
+            Some('@') => DS_PURPLE,
+            _ => DS_BRIGHT,
+        }
     };
-    let text = state.composer_text.as_deref().unwrap_or("");
+    let raw_text = state.composer_text.as_deref().unwrap_or("");
+    let masked_storage: String;
+    let text: &str = if let Some(p) = prompt_input {
+        if p.secret {
+            masked_storage = "•".repeat(raw_text.chars().count());
+            &masked_storage
+        } else {
+            raw_text
+        }
+    } else {
+        raw_text
+    };
+    let placeholder: &str = if let Some(p) = prompt_input {
+        &p.label
+    } else {
+        COMPOSER_PLACEHOLDER
+    };
+    let prompt_glyph: &str = if prompt_input.is_some() { "? " } else { "❯ " };
     let show_caret = (tick / 6).is_multiple_of(2);
     let total_chars = text.chars().count();
     let cursor = state
@@ -91,19 +113,19 @@ fn render_input_box(buf: &mut Buffer, area: Rect, rows: u16, state: &SceneState,
     for i in 0..content_rows {
         let y = top + 1 + i;
         if i == 0 {
-            paint_str(buf, col_start, y, "❯ ", prompt_color, BG, Modifier::BOLD);
+            paint_str(
+                buf,
+                col_start,
+                y,
+                prompt_glyph,
+                prompt_color,
+                BG,
+                Modifier::BOLD,
+            );
         }
         let vidx = scroll_off + i as usize;
         if text.is_empty() && i == 0 {
-            paint_str(
-                buf,
-                text_start,
-                y,
-                COMPOSER_PLACEHOLDER,
-                FG3,
-                BG,
-                Modifier::empty(),
-            );
+            paint_str(buf, text_start, y, placeholder, FG3, BG, Modifier::empty());
             if show_caret {
                 paint(buf, text_start, y, '▮', DS_BRIGHT, BG, Modifier::empty());
             }

--- a/crates/reasonix-render/src/whole_screen/mod.rs
+++ b/crates/reasonix-render/src/whole_screen/mod.rs
@@ -20,7 +20,10 @@ use ratatui::widgets::Widget;
 use crate::state::SceneState;
 
 pub use demo::demo_state;
-pub use overlay::{slash_completion, slash_is_exact, slash_match_count};
+pub use overlay::{
+    slash_arg_completion, slash_arg_match_count, slash_completion, slash_is_exact,
+    slash_match_count,
+};
 pub use overlay_at::{at_completion, at_match_count};
 pub use paint::{paint, paint_str};
 pub use selection::{cards_layout, extract_text, CardsLayout, ScrollbarGeom, Selection};
@@ -29,7 +32,7 @@ use approval::render_approval;
 use boot::render_scroll;
 use dock::render_dock;
 use mode_picker::{mode_picker_options, preset_picker_options, render_picker};
-use overlay::render_slash_overlay;
+use overlay::{render_slash_arg_overlay, render_slash_overlay};
 use overlay_at::render_at_overlay;
 use paint::fill_bg;
 use selection::apply_highlight;
@@ -42,6 +45,7 @@ pub struct WholeScreen<'a> {
     scroll_offset: u16,
     selection: Option<Selection>,
     slash_idx: usize,
+    slash_arg_idx: usize,
     at_idx: usize,
     approval_idx: usize,
     mode_picker_idx: Option<usize>,
@@ -57,6 +61,7 @@ impl<'a> WholeScreen<'a> {
             scroll_offset: 0,
             selection: None,
             slash_idx: 0,
+            slash_arg_idx: 0,
             at_idx: 0,
             approval_idx: 0,
             mode_picker_idx: None,
@@ -96,6 +101,11 @@ impl<'a> WholeScreen<'a> {
         self
     }
 
+    pub fn with_slash_arg_index(mut self, idx: usize) -> Self {
+        self.slash_arg_idx = idx;
+        self
+    }
+
     pub fn with_approval_index(mut self, idx: usize) -> Self {
         self.approval_idx = idx;
         self
@@ -127,6 +137,7 @@ impl Widget for WholeScreen<'_> {
         let dock_h = dock_height_for(self.state).min(area.height);
         let full_dock = Rect::new(area.x, area.y + area.height - dock_h, area.width, dock_h);
         render_slash_overlay(buf, full_dock, self.state, self.slash_idx);
+        render_slash_arg_overlay(buf, full_dock, self.state, self.slash_arg_idx);
         render_at_overlay(buf, full_dock, self.state, self.at_idx);
         if let Some(approval) = self.state.approval.as_ref() {
             render_approval(buf, area, approval, self.approval_idx, dock_h);

--- a/crates/reasonix-render/src/whole_screen/mod.rs
+++ b/crates/reasonix-render/src/whole_screen/mod.rs
@@ -20,7 +20,7 @@ use ratatui::widgets::Widget;
 use crate::state::SceneState;
 
 pub use demo::demo_state;
-pub use overlay::{slash_completion, slash_match_count};
+pub use overlay::{slash_completion, slash_is_exact, slash_match_count};
 pub use overlay_at::{at_completion, at_match_count};
 pub use paint::{paint, paint_str};
 pub use selection::{cards_layout, extract_text, CardsLayout, ScrollbarGeom, Selection};

--- a/crates/reasonix-render/src/whole_screen/overlay.rs
+++ b/crates/reasonix-render/src/whole_screen/overlay.rs
@@ -6,7 +6,7 @@ use unicode_width::UnicodeWidthStr;
 use crate::state::{SceneState, SlashMatch};
 
 use super::paint::{paint, paint_str};
-use super::theme::{BG, DS, DS_BRIGHT, FG, FG2};
+use super::theme::{BG, DS, DS_BRIGHT, FG, FG2, FG3};
 
 const FALLBACK_COMMANDS: &[(&str, &str)] = &[
     ("/clear", "reset conversation context"),
@@ -95,6 +95,7 @@ pub fn render_slash_overlay(
     }
     let all_rows: Vec<SlashRow> = collect_rows(text, state);
     if all_rows.is_empty() {
+        render_no_match(buf, dock_area, text);
         return;
     }
     let total = all_rows.len();
@@ -273,11 +274,12 @@ fn description_with_aliases(row: &SlashRow) -> String {
 }
 
 fn row_visual_height(row: &SlashRow, layout: &ColumnLayout, selected: bool) -> usize {
+    let header = if row.header_above { 1 } else { 0 };
     if !selected {
-        return 1;
+        return header + 1;
     }
     let desc = description_with_aliases(row);
-    wrap_desc(&desc, layout.desc_w as usize).len().max(1)
+    header + wrap_desc(&desc, layout.desc_w as usize).len().max(1)
 }
 
 fn wrap_desc(text: &str, width: usize) -> Vec<String> {
@@ -327,12 +329,18 @@ struct SlashRow {
     desc: String,
     args_hint: Option<String>,
     aliases: Vec<String>,
+    group: Option<String>,
+    /// Render a group header row just above this command. Set true for
+    /// the first row of each group when the user is browsing the bare
+    /// `/` menu (group mode); always false in search mode.
+    header_above: bool,
 }
 
 fn collect_rows(query: &str, state: &SceneState) -> Vec<SlashRow> {
     let needle = query.trim_start_matches('/').to_lowercase();
-    if let Some(catalog) = state.slash_catalog.as_ref() {
-        return catalog
+    let group_mode = needle.is_empty();
+    let raw: Vec<SlashRow> = if let Some(catalog) = state.slash_catalog.as_ref() {
+        catalog
             .iter()
             .filter(|m| matches_query(&m.cmd, &needle))
             .map(|m: &SlashMatch| SlashRow {
@@ -340,19 +348,77 @@ fn collect_rows(query: &str, state: &SceneState) -> Vec<SlashRow> {
                 desc: m.summary.clone(),
                 args_hint: m.args_hint.clone(),
                 aliases: m.aliases.clone(),
+                group: m.group.clone(),
+                header_above: false,
             })
-            .collect();
+            .collect()
+    } else {
+        FALLBACK_COMMANDS
+            .iter()
+            .filter(|(name, _)| matches_query(name.trim_start_matches('/'), &needle))
+            .map(|(name, desc)| SlashRow {
+                name: (*name).to_string(),
+                desc: (*desc).to_string(),
+                args_hint: None,
+                aliases: Vec::new(),
+                group: None,
+                header_above: false,
+            })
+            .collect()
+    };
+    if !group_mode {
+        return raw;
     }
-    FALLBACK_COMMANDS
-        .iter()
-        .filter(|(name, _)| matches_query(name.trim_start_matches('/'), &needle))
-        .map(|(name, desc)| SlashRow {
-            name: (*name).to_string(),
-            desc: (*desc).to_string(),
-            args_hint: None,
-            aliases: Vec::new(),
-        })
-        .collect()
+    let mut out = raw;
+    let mut prev_group: Option<&str> = None;
+    for row in out.iter_mut() {
+        let g = row.group.as_deref();
+        if g != prev_group {
+            row.header_above = true;
+            prev_group = g;
+        }
+    }
+    out
+}
+
+fn render_no_match(buf: &mut Buffer, dock_area: Rect, query: &str) {
+    let popup_w = dock_area.width.saturating_sub(4).min(80);
+    if popup_w < 30 {
+        return;
+    }
+    let popup_h: u16 = 3;
+    if popup_h > dock_area.y {
+        return;
+    }
+    let popup_x = dock_area.x + 2;
+    let popup_y = dock_area.y - popup_h;
+    let popup = Rect::new(popup_x, popup_y, popup_w, popup_h);
+    draw_box(buf, popup);
+    let msg = format!("no command matches '{query}'");
+    paint_str(buf, popup.x + 2, popup.y + 1, "▲", FG2, BG, Modifier::BOLD);
+    paint_str(
+        buf,
+        popup.x + 4,
+        popup.y + 1,
+        &msg,
+        FG2,
+        BG,
+        Modifier::empty(),
+    );
+}
+
+fn group_label(group: &str) -> &'static str {
+    match group {
+        "setup" => "SETUP",
+        "info" => "INFO",
+        "chat" => "CHAT",
+        "extend" => "EXTEND",
+        "session" => "SESSION",
+        "code" => "CODE",
+        "jobs" => "JOBS",
+        "advanced" => "ADVANCED",
+        _ => "OTHER",
+    }
 }
 
 fn draw_box(buf: &mut Buffer, area: Rect) {
@@ -429,6 +495,18 @@ fn draw_rows_wrapped(
     for (i, row_data) in rows_data.iter().enumerate() {
         if row >= bottom {
             break;
+        }
+        if row_data.header_above {
+            let label = row_data
+                .group
+                .as_deref()
+                .map(group_label)
+                .unwrap_or("OTHER");
+            paint_str(buf, area.x + 2, row, label, FG3, BG, Modifier::BOLD);
+            row += 1;
+            if row >= bottom {
+                break;
+            }
         }
         let selected = i == selected_idx;
 

--- a/crates/reasonix-render/src/whole_screen/overlay.rs
+++ b/crates/reasonix-render/src/whole_screen/overlay.rs
@@ -120,7 +120,11 @@ fn split_slash_arg(query: &str) -> Option<(&str, &str)> {
 }
 
 fn match_iter<'a>(query: &'a str, state: &'a SceneState) -> Box<dyn Iterator<Item = &'a str> + 'a> {
-    let needle = query.trim_start_matches('/').to_lowercase();
+    // strip_prefix removes ONE leading '/', not all of them — so "//" has
+    // needle "/" which matches nothing (intended: user typed two slashes
+    // as literal punctuation). trim_start_matches('/') would collapse
+    // them and surface the whole catalog instead.
+    let needle = query.strip_prefix('/').unwrap_or("").to_lowercase();
     if let Some(catalog) = state.slash_catalog.as_ref() {
         return Box::new(
             catalog
@@ -500,7 +504,8 @@ struct SlashRow {
 }
 
 fn collect_rows(query: &str, state: &SceneState) -> Vec<SlashRow> {
-    let needle = query.trim_start_matches('/').to_lowercase();
+    // See match_iter for why strip_prefix instead of trim_start_matches.
+    let needle = query.strip_prefix('/').unwrap_or("").to_lowercase();
     let group_mode = needle.is_empty();
     let raw: Vec<SlashRow> = if let Some(catalog) = state.slash_catalog.as_ref() {
         catalog

--- a/crates/reasonix-render/src/whole_screen/overlay.rs
+++ b/crates/reasonix-render/src/whole_screen/overlay.rs
@@ -56,6 +56,60 @@ pub fn slash_completion(query: &str, idx: usize, state: &SceneState) -> Option<S
         .map(|name| format!("/{name} "))
 }
 
+/// Number of arg-completer matches for `/<cmd> <partial>`. Returns 0 when
+/// the command has no static argCompleter, partial already exact-matches a
+/// value, or partial has progressed past the first argument (contains a
+/// space). Dynamic completers (`"models"`, `"path"`, `"mcp-resources"`,
+/// `"mcp-prompts"`, `"skills"`) are not surfaced here yet — those live on
+/// the Node side.
+pub fn slash_arg_match_count(query: &str, state: &SceneState) -> usize {
+    slash_arg_matches(query, state)
+        .map(|v| v.len())
+        .unwrap_or(0)
+}
+
+/// Build the full composer text after picking arg `idx` — replaces the
+/// trailing partial with the chosen value. Returns None when there are
+/// no matches.
+pub fn slash_arg_completion(query: &str, idx: usize, state: &SceneState) -> Option<String> {
+    let matches = slash_arg_matches(query, state)?;
+    let chosen = matches.get(idx)?;
+    let (cmd, _partial) = split_slash_arg(query)?;
+    Some(format!("/{cmd} {chosen}"))
+}
+
+fn slash_arg_matches(query: &str, state: &SceneState) -> Option<Vec<String>> {
+    let (cmd, partial) = split_slash_arg(query)?;
+    if partial.contains(' ') {
+        return None;
+    }
+    let catalog = state.slash_catalog.as_ref()?;
+    let m = catalog.iter().find(|m| m.cmd.eq_ignore_ascii_case(cmd))?;
+    let completer = m.arg_completer.as_ref()?;
+    let needle = partial.to_lowercase();
+    if !partial.is_empty() && completer.iter().any(|v| v.to_lowercase() == needle) {
+        return None;
+    }
+    if partial.is_empty() {
+        return Some(completer.clone());
+    }
+    Some(
+        completer
+            .iter()
+            .filter(|v| v.to_lowercase().starts_with(&needle))
+            .cloned()
+            .collect(),
+    )
+}
+
+fn split_slash_arg(query: &str) -> Option<(&str, &str)> {
+    let stripped = query.strip_prefix('/')?;
+    let space_pos = stripped.find(' ')?;
+    let cmd = &stripped[..space_pos];
+    let partial = &stripped[space_pos + 1..];
+    Some((cmd, partial))
+}
+
 fn match_iter<'a>(query: &'a str, state: &'a SceneState) -> Box<dyn Iterator<Item = &'a str> + 'a> {
     let needle = query.trim_start_matches('/').to_lowercase();
     if let Some(catalog) = state.slash_catalog.as_ref() {
@@ -79,6 +133,106 @@ fn matches_query(cmd: &str, needle_lower: &str) -> bool {
         return true;
     }
     cmd.to_lowercase().starts_with(needle_lower)
+}
+
+pub fn render_slash_arg_overlay(
+    buf: &mut Buffer,
+    dock_area: Rect,
+    state: &SceneState,
+    selected_idx: usize,
+) {
+    let Some(text) = state.composer_text.as_deref() else {
+        return;
+    };
+    let Some(matches) = slash_arg_matches(text, state) else {
+        return;
+    };
+    if matches.is_empty() {
+        return;
+    }
+    let Some((cmd, partial)) = split_slash_arg(text) else {
+        return;
+    };
+    let max_value_w = matches.iter().map(|s| s.width()).max().unwrap_or(8);
+    let header = format!("/{cmd} <arg>");
+    let header_w = header.width();
+    let popup_w = (header_w.max(max_value_w + 4) as u16 + 4).min(dock_area.width.saturating_sub(4));
+    if popup_w < 12 {
+        return;
+    }
+    let cap = (dock_area.y as usize).saturating_sub(3).clamp(1, 10);
+    let visible = matches.len().min(cap) as u16;
+    let popup_h = 3 + visible;
+    if popup_h > dock_area.y {
+        return;
+    }
+    let popup_x = dock_area.x + 2;
+    let popup_y = dock_area.y - popup_h;
+    let popup = Rect::new(popup_x, popup_y, popup_w, popup_h);
+    draw_box(buf, popup);
+    paint_str(
+        buf,
+        popup.x + 2,
+        popup.y + 1,
+        &header,
+        DS_BRIGHT,
+        BG,
+        Modifier::BOLD,
+    );
+    let count_text = if matches.len() == 1 {
+        "1 option".to_string()
+    } else {
+        format!("{} options", matches.len())
+    };
+    let ccol = popup.x + popup.width.saturating_sub(count_text.width() as u16 + 2);
+    paint_str(
+        buf,
+        ccol,
+        popup.y + 1,
+        &count_text,
+        FG3,
+        BG,
+        Modifier::empty(),
+    );
+    let selected = selected_idx.min(matches.len().saturating_sub(1));
+    let start = if selected >= visible as usize {
+        selected + 1 - visible as usize
+    } else {
+        0
+    };
+    let needle = partial.to_lowercase();
+    for (i, value) in matches
+        .iter()
+        .enumerate()
+        .skip(start)
+        .take(visible as usize)
+    {
+        let row = popup.y + 2 + (i - start) as u16;
+        let is_sel = i == selected;
+        if is_sel {
+            paint_str(buf, popup.x + 2, row, "▸", DS_BRIGHT, BG, Modifier::BOLD);
+        }
+        let fg = if is_sel { FG } else { DS_BRIGHT };
+        let modifier = if is_sel {
+            Modifier::BOLD
+        } else {
+            Modifier::empty()
+        };
+        paint_str(buf, popup.x + 4, row, value, fg, BG, modifier);
+        if !partial.is_empty() && value.to_lowercase().starts_with(&needle) {
+            let suffix: String = value.chars().skip(partial.chars().count()).collect();
+            let typed_w = partial.width() as u16;
+            paint_str(
+                buf,
+                popup.x + 4 + typed_w,
+                row,
+                &suffix,
+                FG2,
+                BG,
+                Modifier::empty(),
+            );
+        }
+    }
 }
 
 pub fn render_slash_overlay(

--- a/crates/reasonix-render/src/whole_screen/overlay.rs
+++ b/crates/reasonix-render/src/whole_screen/overlay.rs
@@ -83,6 +83,15 @@ fn slash_arg_matches(query: &str, state: &SceneState) -> Option<Vec<String>> {
     if partial.contains(' ') {
         return None;
     }
+    // Prefer the Node-resolved scene field: it's the only way to surface
+    // dynamic completers (models / path / mcp-resources / mcp-prompts /
+    // skills) because rust can't read MCP catalogs or the filesystem from
+    // here. Match by cmd + partial so a stale push doesn't leak in.
+    if let Some(s) = state.slash_arg_state.as_ref() {
+        if s.cmd.eq_ignore_ascii_case(cmd) && s.partial == partial && !s.matches.is_empty() {
+            return Some(s.matches.clone());
+        }
+    }
     let catalog = state.slash_catalog.as_ref()?;
     let m = catalog.iter().find(|m| m.cmd.eq_ignore_ascii_case(cmd))?;
     let completer = m.arg_completer.as_ref()?;

--- a/crates/reasonix-render/src/whole_screen/overlay.rs
+++ b/crates/reasonix-render/src/whole_screen/overlay.rs
@@ -23,6 +23,30 @@ pub fn slash_match_count(query: &str, state: &SceneState) -> usize {
     match_iter(query, state).count()
 }
 
+/// True when `query` is `/<cmd>` for a `<cmd>` that exists in the catalog
+/// (case-insensitive). The composer uses this to decide whether Enter
+/// should auto-complete the highlighted match or submit the typed command
+/// directly. Without this, typing the full name (e.g. `/cost`) re-completes
+/// to `/cost ` and the user has to press Enter twice.
+pub fn slash_is_exact(query: &str, state: &SceneState) -> bool {
+    let Some(needle) = query.strip_prefix('/') else {
+        return false;
+    };
+    if needle.is_empty() || needle.contains(' ') {
+        return false;
+    }
+    let needle_lower = needle.to_lowercase();
+    if let Some(catalog) = state.slash_catalog.as_ref() {
+        return catalog
+            .iter()
+            .any(|m| m.cmd.eq_ignore_ascii_case(&needle_lower));
+    }
+    FALLBACK_COMMANDS.iter().any(|(name, _)| {
+        name.trim_start_matches('/')
+            .eq_ignore_ascii_case(&needle_lower)
+    })
+}
+
 pub fn slash_completion(query: &str, idx: usize, state: &SceneState) -> Option<String> {
     if !query.starts_with('/') {
         return None;

--- a/crates/reasonix-render/src/whole_screen/paint.rs
+++ b/crates/reasonix-render/src/whole_screen/paint.rs
@@ -61,6 +61,53 @@ pub fn paint_str_to(
     col
 }
 
+/// OSC 8 hyperlink — the entire escape sequence (open + visible text +
+/// close) lives in one cell's symbol; subsequent cells covered by the
+/// visible width are flagged `skip` so the diff layer doesn't repaint
+/// them. Terminals that understand OSC 8 (Windows Terminal, iTerm2,
+/// WezTerm, gnome-terminal ≥3.26, kitty, etc.) render this as a
+/// clickable link; older terminals print the escapes as no-ops and
+/// fall back to plain underlined text.
+pub fn paint_link(
+    buf: &mut Buffer,
+    x: u16,
+    y: u16,
+    url: &str,
+    visible: &str,
+    fg: Color,
+    bg: Color,
+) -> u16 {
+    use ratatui::style::Style;
+    use unicode_width::UnicodeWidthStr;
+    if x >= buf.area.right() || y >= buf.area.bottom() {
+        return x;
+    }
+    let width = UnicodeWidthStr::width(visible) as u16;
+    if width == 0 {
+        return x;
+    }
+    let symbol = format!("\x1b]8;;{url}\x1b\\{visible}\x1b]8;;\x1b\\");
+    let style = Style::default()
+        .fg(fg)
+        .bg(bg)
+        .add_modifier(Modifier::UNDERLINED);
+    buf[(x, y)]
+        .set_symbol(&symbol)
+        .set_style(style)
+        .set_skip(false);
+    for off in 1..width {
+        let cx = x + off;
+        if cx >= buf.area.right() {
+            break;
+        }
+        buf[(cx, y)]
+            .set_symbol("")
+            .set_style(Style::default().bg(bg))
+            .set_skip(true);
+    }
+    x + width
+}
+
 pub fn fill_bg(buf: &mut Buffer, area: Rect, bg: Color) {
     let style = Style::default().bg(bg);
     for y in area.y..area.y.saturating_add(area.height) {

--- a/crates/reasonix-render/tests/whole_screen.rs
+++ b/crates/reasonix-render/tests/whole_screen.rs
@@ -308,6 +308,34 @@ fn catalog_state() -> reasonix_render::state::SceneState {
 }
 
 #[test]
+fn dashboard_url_renders_in_boot_block() {
+    let state = SceneState {
+        model: Some("deepseek-v3.2-coder".to_string()),
+        cwd: Some("~/work/reasonix-core".to_string()),
+        dashboard_url: Some("http://localhost:7777".to_string()),
+        ..Default::default()
+    };
+    let rows = draw(&state, 120, 36);
+    let all = joined(&rows);
+    assert!(all.contains("dashboard"), "dashboard label missing");
+    assert!(
+        all.contains("http://localhost:7777"),
+        "dashboard URL missing"
+    );
+}
+
+#[test]
+fn dashboard_line_hidden_when_url_absent() {
+    let state = SceneState {
+        model: Some("deepseek-v3.2-coder".to_string()),
+        ..Default::default()
+    };
+    let rows = draw(&state, 120, 30);
+    let all = joined(&rows);
+    assert!(!all.contains("dashboard"), "no dashboard line without URL");
+}
+
+#[test]
 fn double_slash_does_not_match_anything() {
     let state = catalog_state();
     // Bare "/" is browse mode — every catalog entry surfaces.

--- a/crates/reasonix-render/tests/whole_screen.rs
+++ b/crates/reasonix-render/tests/whole_screen.rs
@@ -308,6 +308,26 @@ fn catalog_state() -> reasonix_render::state::SceneState {
 }
 
 #[test]
+fn double_slash_does_not_match_anything() {
+    let state = catalog_state();
+    // Bare "/" is browse mode — every catalog entry surfaces.
+    assert_eq!(slash_match_count("/", &state), 6, "bare slash shows all");
+    // "//" is two literal slashes, not "bare slash with prefix" — the
+    // user is most likely typing a chat message starting with //, so the
+    // overlay should NOT explode into the whole catalog.
+    assert_eq!(
+        slash_match_count("//", &state),
+        0,
+        "double slash matches nothing"
+    );
+    assert_eq!(
+        slash_match_count("///c", &state),
+        0,
+        "triple slash also matches nothing"
+    );
+}
+
+#[test]
 fn slash_arg_picker_static_completer() {
     use reasonix_render::state::{SceneState, SlashMatch};
     let state = SceneState {

--- a/crates/reasonix-render/tests/whole_screen.rs
+++ b/crates/reasonix-render/tests/whole_screen.rs
@@ -2,8 +2,9 @@ use ratatui::backend::TestBackend;
 use ratatui::Terminal;
 use reasonix_render::state::{SceneCard, SceneState};
 use reasonix_render::whole_screen::{
-    at_completion, at_match_count, cards_layout, demo_state, extract_text, slash_completion,
-    slash_is_exact, slash_match_count, Selection, WholeScreen,
+    at_completion, at_match_count, cards_layout, demo_state, extract_text, slash_arg_completion,
+    slash_arg_match_count, slash_completion, slash_is_exact, slash_match_count, Selection,
+    WholeScreen,
 };
 use unicode_width::UnicodeWidthStr;
 
@@ -304,6 +305,74 @@ fn catalog_state() -> reasonix_render::state::SceneState {
         ),
         ..Default::default()
     }
+}
+
+#[test]
+fn slash_arg_picker_static_completer() {
+    use reasonix_render::state::{SceneState, SlashMatch};
+    let state = SceneState {
+        slash_catalog: Some(vec![
+            SlashMatch {
+                cmd: "preset".to_string(),
+                summary: String::new(),
+                group: Some("setup".to_string()),
+                args_hint: Some("<auto|flash|pro>".to_string()),
+                aliases: Vec::new(),
+                arg_completer: Some(vec![
+                    "auto".to_string(),
+                    "flash".to_string(),
+                    "pro".to_string(),
+                ]),
+            },
+            SlashMatch {
+                cmd: "language".to_string(),
+                summary: String::new(),
+                group: Some("setup".to_string()),
+                args_hint: Some("<EN|zh-CN>".to_string()),
+                aliases: Vec::new(),
+                arg_completer: Some(vec!["EN".to_string(), "zh-CN".to_string()]),
+            },
+            SlashMatch {
+                cmd: "help".to_string(),
+                summary: String::new(),
+                group: Some("chat".to_string()),
+                args_hint: None,
+                aliases: Vec::new(),
+                arg_completer: None,
+            },
+        ]),
+        ..Default::default()
+    };
+    assert_eq!(
+        slash_arg_match_count("/preset ", &state),
+        3,
+        "bare arg shows all"
+    );
+    assert_eq!(
+        slash_arg_match_count("/preset fl", &state),
+        1,
+        "prefix filters"
+    );
+    assert_eq!(
+        slash_arg_match_count("/preset flash", &state),
+        0,
+        "exact dismisses"
+    );
+    assert_eq!(slash_arg_match_count("/help ", &state), 0, "no completer");
+    assert_eq!(
+        slash_arg_match_count("/preset auto x", &state),
+        0,
+        "past first arg"
+    );
+    assert_eq!(slash_arg_match_count("/zzz ", &state), 0, "unknown cmd");
+    assert_eq!(
+        slash_arg_completion("/preset fl", 0, &state).as_deref(),
+        Some("/preset flash"),
+    );
+    assert_eq!(
+        slash_arg_completion("/language ", 1, &state).as_deref(),
+        Some("/language zh-CN"),
+    );
 }
 
 #[test]

--- a/crates/reasonix-render/tests/whole_screen.rs
+++ b/crates/reasonix-render/tests/whole_screen.rs
@@ -376,6 +376,50 @@ fn slash_arg_picker_static_completer() {
 }
 
 #[test]
+fn slash_arg_state_overrides_catalog_for_dynamic_completers() {
+    use reasonix_render::state::{SceneState, SlashArgState, SlashMatch};
+    let state = SceneState {
+        slash_catalog: Some(vec![SlashMatch {
+            cmd: "model".to_string(),
+            summary: String::new(),
+            group: Some("setup".to_string()),
+            args_hint: Some("<id>".to_string()),
+            aliases: Vec::new(),
+            arg_completer: None,
+        }]),
+        slash_arg_state: Some(SlashArgState {
+            cmd: "model".to_string(),
+            partial: "ds".to_string(),
+            matches: vec!["deepseek-v3.2-coder".to_string(), "deepseek-r1".to_string()],
+        }),
+        ..Default::default()
+    };
+    assert_eq!(
+        slash_arg_match_count("/model ds", &state),
+        2,
+        "scene picks up dynamic matches"
+    );
+    assert_eq!(
+        slash_arg_completion("/model ds", 0, &state).as_deref(),
+        Some("/model deepseek-v3.2-coder"),
+    );
+    let no_match = SceneState {
+        slash_catalog: state.slash_catalog.clone(),
+        slash_arg_state: Some(SlashArgState {
+            cmd: "model".to_string(),
+            partial: "old".to_string(),
+            matches: vec!["irrelevant".to_string()],
+        }),
+        ..Default::default()
+    };
+    assert_eq!(
+        slash_arg_match_count("/model ds", &no_match),
+        0,
+        "stale scene partial does not leak in",
+    );
+}
+
+#[test]
 fn slash_is_exact_matches_full_command_only() {
     let state = catalog_state();
     assert!(slash_is_exact("/clear", &state), "full name matches");

--- a/crates/reasonix-render/tests/whole_screen.rs
+++ b/crates/reasonix-render/tests/whole_screen.rs
@@ -3,7 +3,7 @@ use ratatui::Terminal;
 use reasonix_render::state::{SceneCard, SceneState};
 use reasonix_render::whole_screen::{
     at_completion, at_match_count, cards_layout, demo_state, extract_text, slash_completion,
-    slash_match_count, Selection, WholeScreen,
+    slash_is_exact, slash_match_count, Selection, WholeScreen,
 };
 use unicode_width::UnicodeWidthStr;
 
@@ -302,6 +302,25 @@ fn catalog_state() -> reasonix_render::state::SceneState {
         ),
         ..Default::default()
     }
+}
+
+#[test]
+fn slash_is_exact_matches_full_command_only() {
+    let state = catalog_state();
+    assert!(slash_is_exact("/clear", &state), "full name matches");
+    assert!(slash_is_exact("/CLEAR", &state), "case-insensitive");
+    assert!(!slash_is_exact("/cl", &state), "prefix is not exact");
+    assert!(
+        !slash_is_exact("/clear ", &state),
+        "trailing space is not exact"
+    );
+    assert!(
+        !slash_is_exact("/clear foo", &state),
+        "with args is not exact"
+    );
+    assert!(!slash_is_exact("clear", &state), "no leading slash");
+    assert!(!slash_is_exact("/zzz", &state), "unknown command");
+    assert!(!slash_is_exact("/", &state), "empty cmd");
 }
 
 #[test]

--- a/crates/reasonix-render/tests/whole_screen.rs
+++ b/crates/reasonix-render/tests/whole_screen.rs
@@ -295,8 +295,10 @@ fn catalog_state() -> reasonix_render::state::SceneState {
                 .map(|cmd| SlashMatch {
                     cmd: (*cmd).to_string(),
                     summary: String::new(),
+                    group: None,
                     args_hint: None,
                     aliases: Vec::new(),
+                    arg_completer: None,
                 })
                 .collect(),
         ),

--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -38,6 +38,7 @@ import {
 } from "../ui/scene/input-adapter.js";
 import { makeNullStdin } from "../ui/scene/null-stdin.js";
 import { makeNullStdout } from "../ui/scene/null-stdout.js";
+import { cancelAllPromptInputs, resolvePromptInput } from "../ui/scene/prompt-input-store.js";
 import { isIntegratedRendererRequested, setIntegratedEventHandler } from "../ui/scene/trace.js";
 import type { McpServerSummary } from "../ui/slash.js";
 import {
@@ -449,6 +450,7 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
         qqSubmitRef.current?.(event.text);
       } else if (event.event === "exit") {
         void (async () => {
+          cancelAllPromptInputs();
           await stopAndSaveCpuProfile();
           process.exit(0);
         })();
@@ -460,6 +462,8 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
         modeSetRef.current?.(event.value);
       } else if (event.event === "preset-set") {
         presetSetRef.current?.(event.value);
+      } else if (event.event === "prompt-response") {
+        resolvePromptInput(event.id, event.cancelled ? null : (event.text ?? ""));
       }
       // interrupt: no-op for now; terminal SIGINT already reaches Node.
     });

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -1381,12 +1381,20 @@ function AppInner({
   const slashCatalogJson = useMemo(() => {
     const all = suggestSlashCommands("", !!codeMode);
     return JSON.stringify(
-      all.map((m) => ({
-        cmd: m.cmd,
-        summary: m.summary,
-        ...(m.argsHint !== undefined ? { argsHint: m.argsHint } : {}),
-        ...(m.aliases && m.aliases.length > 0 ? { aliases: m.aliases } : {}),
-      })),
+      all.map((m) => {
+        const i18nKey = `slash.${m.cmd}.description`;
+        const translated = t(i18nKey);
+        const summary = translated === i18nKey ? m.summary : translated;
+        const argCompleter = Array.isArray(m.argCompleter) ? [...m.argCompleter] : undefined;
+        return {
+          cmd: m.cmd,
+          summary,
+          group: m.group,
+          ...(m.argsHint !== undefined ? { argsHint: m.argsHint } : {}),
+          ...(m.aliases && m.aliases.length > 0 ? { aliases: [...m.aliases] } : {}),
+          ...(argCompleter ? { argCompleter } : {}),
+        };
+      }),
     );
   }, [codeMode]);
 

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -1527,6 +1527,11 @@ function AppInner({
     return undefined;
   }, [pendingPlan, pendingShell, pendingPath, pendingEditReview, pendingChoice, pendingCheckpoint]);
 
+  // Hoisted above useSceneTrace so the dashboard URL can ride the
+  // scene frame to the rust renderer. Definition (incl. setter) lives
+  // here; the auto-start effect that populates it follows further down.
+  const [dashboardUrl, setDashboardUrlState] = useState<string | null>(null);
+
   useSceneTrace({
     cardCount,
     busy,
@@ -1549,6 +1554,7 @@ function AppInner({
     editMode,
     preset: presetForDisplay,
     cwd: currentRootDir,
+    dashboardUrl: dashboardUrl ?? undefined,
     ctxTokens,
     ctxCap,
     sessionCostUsd,
@@ -2460,11 +2466,12 @@ function AppInner({
     return dashboardRef.current?.url ?? null;
   }, []);
 
-  // Mirror of the dashboard URL into React state so the StatsPanel
-  // header can render a clickable pill the moment the server is up.
-  // Updated by both the auto-start effect below and the explicit
-  // /dashboard slash path (via startDashboard).
-  const [dashboardUrl, setDashboardUrlState] = useState<string | null>(null);
+  // dashboardUrl state lives near the top of this component so it can
+  // ride the scene frame (see useSceneTrace input above). Mirror of
+  // the dashboard URL so the StatsPanel header can render a clickable
+  // pill the moment the server is up. Updated by both the auto-start
+  // effect below and the explicit /dashboard slash path (via
+  // startDashboard).
 
   // Auto-start the dashboard once the TUI is mounted unless the user
   // opted out with --no-dashboard. The whole point is discoverability:

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -1,7 +1,14 @@
 import { type WriteStream, statSync } from "node:fs";
 import { resolve } from "node:path";
 import { Box, Text, useStdin, useStdout } from "ink";
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import {
   type JsonlEventSink,
   eventLogPath,
@@ -167,6 +174,7 @@ import { openUrl } from "./open-url.js";
 import { formatLongPaste } from "./paste-collapse.js";
 import { extractOpenQuestionsSection } from "./plan-open-questions.js";
 import { PRESETS, resolvePreset } from "./presets.js";
+import { getActivePromptInput, subscribePromptInput } from "./scene/prompt-input-store.js";
 import { type McpServerSummary, handleSlash, parseSlash, suggestSlashCommands } from "./slash.js";
 import { TurnTranslator } from "./state/TurnTranslator.js";
 import { cardsToDashboardMessages } from "./state/cards-to-messages.js";
@@ -1418,6 +1426,16 @@ function AppInner({
     [promptHistory],
   );
 
+  const activePromptInput = useSyncExternalStore(
+    subscribePromptInput,
+    getActivePromptInput,
+    getActivePromptInput,
+  );
+  const promptInputJson = useMemo(
+    () => (activePromptInput ? JSON.stringify(activePromptInput) : undefined),
+    [activePromptInput],
+  );
+
   useEffect(() => {
     setSessionsPickerList(listSessionsForWorkspace(currentRootDir));
   }, [currentRootDir]);
@@ -1544,6 +1562,7 @@ function AppInner({
     promptHistoryJson,
     approvalJson,
     atStateJson,
+    promptInputJson,
   });
 
   // Ctrl+P / Ctrl+N from PromptInput route here. When any input-prefix

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -1403,6 +1403,16 @@ function AppInner({
     return JSON.stringify(atState);
   }, [atState]);
 
+  const slashArgStateJson = useMemo(() => {
+    if (!slashArgContext || slashArgContext.kind !== "picker") return undefined;
+    if (!slashArgMatches || slashArgMatches.length === 0) return undefined;
+    return JSON.stringify({
+      cmd: slashArgContext.spec.cmd,
+      partial: slashArgContext.partial,
+      matches: [...slashArgMatches],
+    });
+  }, [slashArgContext, slashArgMatches]);
+
   const promptHistoryJson = useMemo(
     () => (promptHistory.length === 0 ? undefined : JSON.stringify(promptHistory)),
     [promptHistory],
@@ -1530,6 +1540,7 @@ function AppInner({
     sessionOutputTokens,
     lastTurnMs: lastTurnMs > 0 ? lastTurnMs : undefined,
     slashCatalogJson,
+    slashArgStateJson,
     promptHistoryJson,
     approvalJson,
     atStateJson,

--- a/src/cli/ui/hooks/useSceneTrace.ts
+++ b/src/cli/ui/hooks/useSceneTrace.ts
@@ -56,6 +56,8 @@ export type SceneTraceInput = {
   promptHistoryJson?: string;
   approvalJson?: string;
   atStateJson?: string;
+  /** Active text-input prompt — rust intercepts composer Enter to send the answer back as `prompt-response` instead of submitting it as a chat message. Used by /qq connect and friends under integrated mode. */
+  promptInputJson?: string;
 };
 
 export type SetupSceneInput = {
@@ -309,6 +311,7 @@ export function useSceneTrace(input: SceneTraceInput): void {
     promptHistoryJson,
     approvalJson,
     atStateJson,
+    promptInputJson,
   } = input;
   useEffect(() => {
     if (!isSceneTraceEnabled()) return;
@@ -346,6 +349,7 @@ export function useSceneTrace(input: SceneTraceInput): void {
       promptHistory: parseStringArray(promptHistoryJson),
       approval: parseApproval(approvalJson),
       atState: parseApproval(atStateJson),
+      promptInput: parseApproval(promptInputJson),
       fallbackCols,
       fallbackRows,
     });
@@ -384,6 +388,7 @@ export function useSceneTrace(input: SceneTraceInput): void {
     promptHistoryJson,
     approvalJson,
     atStateJson,
+    promptInputJson,
   ]);
 }
 

--- a/src/cli/ui/hooks/useSceneTrace.ts
+++ b/src/cli/ui/hooks/useSceneTrace.ts
@@ -42,6 +42,8 @@ export type SceneTraceInput = {
   editMode?: "review" | "auto" | "yolo";
   preset?: "auto" | "flash" | "pro";
   cwd?: string;
+  /** Local URL of the running dashboard server — surfaced in the rust boot block so users can discover the web UI. Null when --no-dashboard or while the server is still starting. */
+  dashboardUrl?: string;
   ctxTokens?: number;
   ctxCap?: number;
   sessionCostUsd?: number;
@@ -298,6 +300,7 @@ export function useSceneTrace(input: SceneTraceInput): void {
     editMode,
     preset,
     cwd,
+    dashboardUrl,
     ctxTokens,
     ctxCap,
     sessionCostUsd,
@@ -336,6 +339,7 @@ export function useSceneTrace(input: SceneTraceInput): void {
       editMode,
       preset,
       cwd,
+      dashboardUrl,
       ctxTokens,
       ctxCap,
       sessionCostUsd,
@@ -375,6 +379,7 @@ export function useSceneTrace(input: SceneTraceInput): void {
     editMode,
     preset,
     cwd,
+    dashboardUrl,
     ctxTokens,
     ctxCap,
     sessionCostUsd,

--- a/src/cli/ui/hooks/useSceneTrace.ts
+++ b/src/cli/ui/hooks/useSceneTrace.ts
@@ -118,9 +118,65 @@ export function toSceneCard(card: Card): SceneCard {
         ts: card.ts,
         meta: card.done ? "done" : "streaming…",
       };
+    case "live":
+      return { kind: "info", summary, body: card.text, ts: card.ts, meta: card.meta };
+    case "warn":
+      return {
+        kind: "warn",
+        summary: card.title,
+        body: card.message,
+        ts: card.ts,
+        meta: card.detail,
+      };
+    case "usage":
+      return {
+        kind: "usage",
+        summary: `cost · turn ${card.turn}`,
+        body: formatUsageBody(card),
+        ts: card.ts,
+        meta: card.elapsedMs ? formatElapsed(card.elapsedMs) : undefined,
+      };
+    case "tip":
+      return { kind: "info", summary, body: formatTipBody(card), ts: card.ts };
     default:
       return { kind: card.kind, summary };
   }
+}
+
+function formatUsageBody(card: Extract<Card, { kind: "usage" }>): string {
+  const { tokens } = card;
+  const pct = Math.round(card.cacheHit * 100);
+  const lines = [
+    `turn ${card.turn} · this ${formatCost(card.cost)} · session ${formatCost(card.sessionCost)}`,
+    `prompt ${formatTokens(tokens.prompt)} / ${formatTokens(tokens.promptCap)}    output ${formatTokens(tokens.output)} (reason ${formatTokens(tokens.reason)})`,
+    `cache ${pct}%`,
+  ];
+  if (card.balance !== undefined) {
+    lines.push(`balance ${card.balance.toFixed(2)} ${card.balanceCurrency ?? ""}`.trim());
+  }
+  return lines.join("\n");
+}
+
+function formatTipBody(card: Extract<Card, { kind: "tip" }>): string {
+  const parts: string[] = [];
+  for (const sec of card.sections) {
+    if (sec.title) parts.push(sec.title);
+    for (const r of sec.rows) {
+      parts.push(r.key ? `  ${r.key}  ${r.text}` : `  ${r.text}`);
+    }
+  }
+  if (card.footer) parts.push(card.footer);
+  return parts.join("\n");
+}
+
+function formatCost(usd: number): string {
+  return usd < 0.01 ? `$${usd.toFixed(5)}` : `$${usd.toFixed(4)}`;
+}
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
 }
 
 function toolStatus(card: Card & { kind: "tool" }): "ok" | "err" | "running" {

--- a/src/cli/ui/hooks/useSceneTrace.ts
+++ b/src/cli/ui/hooks/useSceneTrace.ts
@@ -51,6 +51,8 @@ export type SceneTraceInput = {
   sessionInputTokens?: number;
   sessionOutputTokens?: number;
   slashCatalogJson?: string;
+  /** Resolved {cmd, partial, matches} for the active slash-arg picker — covers static AND dynamic completers (models / path / mcp-resources / mcp-prompts / skills) since Node has the data to resolve them. */
+  slashArgStateJson?: string;
   promptHistoryJson?: string;
   approvalJson?: string;
   atStateJson?: string;
@@ -303,6 +305,7 @@ export function useSceneTrace(input: SceneTraceInput): void {
     sessionInputTokens,
     sessionOutputTokens,
     slashCatalogJson,
+    slashArgStateJson,
     promptHistoryJson,
     approvalJson,
     atStateJson,
@@ -339,6 +342,7 @@ export function useSceneTrace(input: SceneTraceInput): void {
       sessionInputTokens,
       sessionOutputTokens,
       slashCatalog: parseSlashMatches(slashCatalogJson),
+      slashArgState: parseApproval(slashArgStateJson),
       promptHistory: parseStringArray(promptHistoryJson),
       approval: parseApproval(approvalJson),
       atState: parseApproval(atStateJson),
@@ -376,6 +380,7 @@ export function useSceneTrace(input: SceneTraceInput): void {
     sessionInputTokens,
     sessionOutputTokens,
     slashCatalogJson,
+    slashArgStateJson,
     promptHistoryJson,
     approvalJson,
     atStateJson,

--- a/src/cli/ui/scene/prompt-input-store.ts
+++ b/src/cli/ui/scene/prompt-input-store.ts
@@ -1,0 +1,70 @@
+export type PromptInput = {
+  id: string;
+  label: string;
+  defaultValue?: string;
+  secret?: boolean;
+};
+
+type Listener = () => void;
+
+let activePrompt: PromptInput | null = null;
+const pendingResolvers = new Map<string, (text: string | null) => void>();
+const listeners = new Set<Listener>();
+let counter = 0;
+
+function notify(): void {
+  for (const fn of listeners) fn();
+}
+
+export function getActivePromptInput(): PromptInput | null {
+  return activePrompt;
+}
+
+export function subscribePromptInput(fn: Listener): () => void {
+  listeners.add(fn);
+  return () => {
+    listeners.delete(fn);
+  };
+}
+
+export function requestPromptInput(opts: {
+  label: string;
+  defaultValue?: string;
+  secret?: boolean;
+}): Promise<string | null> {
+  counter += 1;
+  const id = `prompt-${Date.now()}-${counter}`;
+  activePrompt = {
+    id,
+    label: opts.label,
+    defaultValue: opts.defaultValue,
+    secret: opts.secret,
+  };
+  notify();
+  return new Promise<string | null>((resolve) => {
+    pendingResolvers.set(id, resolve);
+  });
+}
+
+export function resolvePromptInput(id: string, text: string | null): void {
+  const resolver = pendingResolvers.get(id);
+  if (resolver) {
+    pendingResolvers.delete(id);
+    resolver(text);
+  }
+  if (activePrompt?.id === id) {
+    activePrompt = null;
+    notify();
+  }
+}
+
+export function cancelAllPromptInputs(): void {
+  for (const [id, resolver] of pendingResolvers) {
+    resolver(null);
+    pendingResolvers.delete(id);
+  }
+  if (activePrompt !== null) {
+    activePrompt = null;
+    notify();
+  }
+}

--- a/src/cli/ui/scene/renderer-process.ts
+++ b/src/cli/ui/scene/renderer-process.ts
@@ -7,7 +7,8 @@ export type RustEvent =
   | { event: "approval-response"; kind: string; choice: unknown }
   | { event: "composer"; text: string }
   | { event: "mode-set"; value: "review" | "auto" | "yolo" }
-  | { event: "preset-set"; value: "auto" | "flash" | "pro" };
+  | { event: "preset-set"; value: "auto" | "flash" | "pro" }
+  | { event: "prompt-response"; id: string; text?: string; cancelled?: boolean };
 
 export type RendererProcess = {
   emit(message: unknown): void;

--- a/src/qq/use-qq-channel.ts
+++ b/src/qq/use-qq-channel.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useRef } from "react";
 import type { PlanConfirmChoice } from "../cli/ui/PlanConfirm.js";
 import type { ReviseChoice } from "../cli/ui/PlanReviseConfirm.js";
 import type { ThemeChoice } from "../cli/ui/ThemePicker.js";
+import { requestPromptInput } from "../cli/ui/scene/prompt-input-store.js";
 import { isIntegratedRendererRequested } from "../cli/ui/scene/trace.js";
 import type { SlashResult } from "../cli/ui/slash/types.js";
 import { listThemeNames } from "../cli/ui/theme/tokens.js";
@@ -189,16 +190,20 @@ export function useQQChannel({
   const replyThisTurnRef = useRef(false);
 
   const promptLine = useCallback(
-    async (prompt: string, fallback?: string): Promise<string> => {
-      // readline.question() drops out of raw mode and writes directly to
-      // stdout — both incompatible with the rust integrated renderer,
-      // which owns the alt-screen, the keyboard, and is composing frames
-      // around the same fd. Fail fast with a helpful message instead of
-      // garbling the screen.
+    async (prompt: string, fallback?: string, opts?: { secret?: boolean }): Promise<string> => {
+      // Under REASONIX_RENDERER_INTEGRATED=1 the rust child owns the
+      // alt-screen and the keyboard reader on the same fd. readline
+      // would collide with it; route through the scene-driven prompt
+      // overlay instead — rust composer intercepts Enter and posts the
+      // answer back via `prompt-response`.
       if (isIntegratedRendererRequested()) {
-        throw new Error(
-          `interactive prompt "${prompt.trim()}" is unavailable under REASONIX_RENDERER_INTEGRATED=1. Pass the values inline (e.g. /qq connect <appId> <appSecret> [sandbox]) or run without integrated mode for the first-time setup.`,
-        );
+        const answer = await requestPromptInput({
+          label: prompt.replace(/[:：]\s*$/u, "").trim(),
+          defaultValue: fallback,
+          secret: opts?.secret,
+        });
+        if (answer === null) throw new Error("input cancelled");
+        return answer.trim() || fallback || "";
       }
       if (isRawModeSupported) setRawMode(false);
       const rl = createInterface({ input: process.stdin, output: process.stdout });
@@ -243,7 +248,9 @@ export function useQQChannel({
       const appSecret =
         args[1]?.trim() ||
         existing.appSecret ||
-        (await promptLine("QQ Open Platform App Secret: ", existing.appSecret));
+        (await promptLine("QQ Open Platform App Secret: ", existing.appSecret, {
+          secret: true,
+        }));
       const sandboxArg = args[2]?.trim().toLowerCase();
       const sandbox =
         sandboxArg === "sandbox" ||

--- a/src/qq/use-qq-channel.ts
+++ b/src/qq/use-qq-channel.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useRef } from "react";
 import type { PlanConfirmChoice } from "../cli/ui/PlanConfirm.js";
 import type { ReviseChoice } from "../cli/ui/PlanReviseConfirm.js";
 import type { ThemeChoice } from "../cli/ui/ThemePicker.js";
+import { isIntegratedRendererRequested } from "../cli/ui/scene/trace.js";
 import type { SlashResult } from "../cli/ui/slash/types.js";
 import { listThemeNames } from "../cli/ui/theme/tokens.js";
 import { type CheckpointMeta, fmtAgo, restoreCheckpoint } from "../code/checkpoints.js";
@@ -189,6 +190,16 @@ export function useQQChannel({
 
   const promptLine = useCallback(
     async (prompt: string, fallback?: string): Promise<string> => {
+      // readline.question() drops out of raw mode and writes directly to
+      // stdout — both incompatible with the rust integrated renderer,
+      // which owns the alt-screen, the keyboard, and is composing frames
+      // around the same fd. Fail fast with a helpful message instead of
+      // garbling the screen.
+      if (isIntegratedRendererRequested()) {
+        throw new Error(
+          `interactive prompt "${prompt.trim()}" is unavailable under REASONIX_RENDERER_INTEGRATED=1. Pass the values inline (e.g. /qq connect <appId> <appSecret> [sandbox]) or run without integrated mode for the first-time setup.`,
+        );
+      }
       if (isRawModeSupported) setRawMode(false);
       const rl = createInterface({ input: process.stdin, output: process.stdout });
       try {


### PR DESCRIPTION
## Summary

`/cost`, `/help`, `/clear` (and any other slash command typed in full) appeared dead in the rust composer: pressing Enter did nothing visible — the command only ran on a *second* Enter.

Root cause: `KeyCode::Enter if slash_active` always re-ran `slash_completion`. For a partially-typed command (e.g. `/cl` → `/clear `) that's the correct UX. For an already-complete one (`/cost`) it rewrites the buffer to `/cost ` (same content + trailing space), so the user sees no feedback and assumes the command doesn't work.

The Node-side `handleSubmit` already guards against this — it skips auto-complete when the typed text is an exact catalog hit. Mirror that on the rust side.

## What changed

- New `slash_is_exact(query, state)` in `overlay.rs`. Returns true only for `/<cmd>` (no trailing space, no args) matching a catalog entry case-insensitively.
- Wired through `whole_screen::mod` re-export.
- `integrated.rs` + `main.rs` compute `slash_complete_only = slash_active && !slash_is_exact(&buffer, &scene)`, and the Enter-completes arm uses that guard. The exact-match case falls through to the general `KeyCode::Enter` arm and submits.
- Test coverage: `slash_is_exact_matches_full_command_only` (case-insensitive, rejects prefix / trailing space / args / unknown / no-slash).

## Test plan

- [x] `cargo fmt -p reasonix-render --check`
- [x] `cargo +1.95.0 clippy -p reasonix-render --all-targets -- -D warnings`
- [x] `cargo test -p reasonix-render` — 41 + side tests green
- [ ] Smoke: `REASONIX_RENDERER_INTEGRATED=1`, type `/cost` + Enter → command runs immediately
- [ ] Smoke: type `/c` + Enter → still auto-completes to `/clear ` (or whichever is highlighted)
