### PR TITLE
fix(ui): elide tool-card output beyond recent window to cap heap growth

### DIFF
--- a/src/cli/ui/state/reducer.ts
+++ b/src/cli/ui/state/reducer.ts
@@ -319,8 +319,37 @@ export function reduce(state: AgentState, event: AgentEvent): AgentState {
   }
 }
 
+/** Tool outputs older than this many cards get stubbed so a 7-hour session doesn't drag GBs of one-off file reads / search results / screenshots through the heap (issue #1031). */
+const RECENT_CARDS_WINDOW = 200;
+/** Don't bother eliding tiny outputs — the stub is itself ~150 chars and the savings aren't worth the lost context. */
+const MIN_ELIDE_OUTPUT_LENGTH = 4096;
+/** Marker for already-elided outputs so we don't re-stub on every subsequent append. */
+const ELIDED_TOOL_OUTPUT_PREFIX = "[elided — older than the last ";
+
+function elideOldToolOutputs(cards: ReadonlyArray<Card>): ReadonlyArray<Card> {
+  // Caller is about to append a new card. Anticipate that — so once
+  // cards.length hits the window, the very next append starts eliding.
+  if (cards.length < RECENT_CARDS_WINDOW) return cards;
+  const cutoff = cards.length + 1 - RECENT_CARDS_WINDOW;
+  let next: Card[] | null = null;
+  for (let i = 0; i < cutoff; i++) {
+    const c = cards[i]!;
+    if (c.kind !== "tool") continue;
+    const out = (c as ToolCard).output;
+    if (typeof out !== "string") continue;
+    if (out.length <= MIN_ELIDE_OUTPUT_LENGTH) continue;
+    if (out.startsWith(ELIDED_TOOL_OUTPUT_PREFIX)) continue;
+    if (next === null) next = cards.slice();
+    next[i] = {
+      ...(c as ToolCard),
+      output: `${ELIDED_TOOL_OUTPUT_PREFIX}${RECENT_CARDS_WINDOW} cards; ${out.length.toLocaleString()} chars dropped to save memory. Full output is on disk in the session log.]`,
+    };
+  }
+  return next ?? cards;
+}
+
 function appendCard(state: AgentState, card: Card): AgentState {
-  return { ...state, cards: [...state.cards, card] };
+  return { ...state, cards: [...elideOldToolOutputs(state.cards), card] };
 }
 
 function mutateCard<K extends Card["kind"]>(

--- a/tests/reducer-cards-elide.test.ts
+++ b/tests/reducer-cards-elide.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import type { ToolCard, UserCard } from "../src/cli/ui/state/cards.js";
+import type { AgentEvent } from "../src/cli/ui/state/events.js";
+import { reduce } from "../src/cli/ui/state/reducer.js";
+import { type AgentState, type SessionInfo, initialState } from "../src/cli/ui/state/state.js";
+
+const session: SessionInfo = {
+  id: "test-session",
+  branch: "main",
+  workspace: "/tmp/repo",
+  model: "deepseek-chat",
+};
+
+function run(events: AgentEvent[], from: AgentState = initialState(session)): AgentState {
+  return events.reduce(reduce, from);
+}
+
+/** Larger than the elision MIN_ELIDE_OUTPUT_LENGTH (4096) so the helper considers it. */
+const BIG_OUTPUT = "x".repeat(8000);
+const RECENT_CARDS_WINDOW = 200;
+
+function buildBigToolEvents(count: number, idPrefix = "t"): AgentEvent[] {
+  const out: AgentEvent[] = [];
+  for (let i = 0; i < count; i++) {
+    out.push({ type: "tool.start", id: `${idPrefix}${i}`, name: "read_file", args: { i } });
+    out.push({
+      type: "tool.end",
+      id: `${idPrefix}${i}`,
+      output: `${BIG_OUTPUT}::${i}`,
+      elapsedMs: 1,
+    });
+  }
+  return out;
+}
+
+describe("reducer card-output elision (issue #1031 memory mitigation)", () => {
+  it("leaves all tool outputs intact below the recent window", () => {
+    const s = run(buildBigToolEvents(50));
+    for (const c of s.cards) {
+      if (c.kind === "tool") {
+        expect((c as ToolCard).output.startsWith("[elided")).toBe(false);
+        expect((c as ToolCard).output.length).toBeGreaterThan(7000);
+      }
+    }
+  });
+
+  it("stubs old tool outputs once the window is exceeded", () => {
+    const total = RECENT_CARDS_WINDOW + 50;
+    const s = run(buildBigToolEvents(total));
+    expect(s.cards).toHaveLength(total);
+    // Cards beyond the window from the end should be stubbed.
+    const cutoff = s.cards.length - RECENT_CARDS_WINDOW;
+    for (let i = 0; i < cutoff; i++) {
+      const c = s.cards[i]!;
+      expect(c.kind).toBe("tool");
+      const out = (c as ToolCard).output;
+      expect(out.startsWith("[elided")).toBe(true);
+      expect(out.length).toBeLessThan(300);
+      expect(out).toMatch(/chars dropped to save memory/);
+    }
+    // Recent cards stay full.
+    for (let i = cutoff; i < s.cards.length; i++) {
+      const c = s.cards[i] as ToolCard;
+      expect(c.output.startsWith("[elided")).toBe(false);
+      expect(c.output.length).toBeGreaterThan(7000);
+    }
+  });
+
+  it("doesn't double-elide cards on subsequent appends", () => {
+    const s1 = run(buildBigToolEvents(RECENT_CARDS_WINDOW + 10));
+    const firstOldOutput = (s1.cards[0] as ToolCard).output;
+    expect(firstOldOutput.startsWith("[elided")).toBe(true);
+    const lenAfterFirst = firstOldOutput.length;
+    const s2 = run(buildBigToolEvents(20, "u"), s1);
+    expect((s2.cards[0] as ToolCard).output).toBe(firstOldOutput);
+    expect((s2.cards[0] as ToolCard).output.length).toBe(lenAfterFirst);
+  });
+
+  it("leaves small tool outputs alone (no point eliding a 200-byte result)", () => {
+    const small = "tiny result";
+    const events: AgentEvent[] = [];
+    for (let i = 0; i < RECENT_CARDS_WINDOW + 10; i++) {
+      events.push({ type: "tool.start", id: `t${i}`, name: "ls", args: {} });
+      events.push({ type: "tool.end", id: `t${i}`, output: small, elapsedMs: 1 });
+    }
+    const s = run(events);
+    for (const c of s.cards) {
+      if (c.kind === "tool") expect((c as ToolCard).output).toBe(small);
+    }
+  });
+
+  it("only touches tool cards — user / other card kinds are untouched", () => {
+    const events: AgentEvent[] = [];
+    for (let i = 0; i < RECENT_CARDS_WINDOW + 5; i++) {
+      events.push({ type: "user.submit", text: `${BIG_OUTPUT}::${i}` });
+    }
+    const s = run(events);
+    for (const c of s.cards) {
+      expect(c.kind).toBe("user");
+      expect((c as UserCard).text.startsWith("[elided")).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
Partial mitigation for #1031.

## Why

Issue #1031 reports the heap creeping monotonically in long sessions and Mark-Compact eventually giving up:

\`\`\`
Mark-Compact 4081.3 (4096.9) -> 4074.7 (4097.1) MB ... task; scavenge might not succeed
FATAL ERROR: Ineffective mark-compacts near heap limit
\`\`\`

Tool cards in the agent store retain their full \`output\` string for the life of the process. A 7-hour session that reads files, runs greps, fetches pages, or screenshots a browser via Puppeteer drags every one of those payloads through the heap — even though only the most recent few are visible at a time.

## What changed

\`appendCard\` (\`src/cli/ui/state/reducer.ts\`) now runs the existing cards through \`elideOldToolOutputs\` before attaching the new one. Tool cards that have slid past the recent window (default 200) have their \`output\` replaced with a short stub recording the original length and pointing the user at the session log on disk:

\`\`\`
[elided — older than the last 200 cards; 1,234,567 chars dropped to save memory. Full output is on disk in the session log.]
\`\`\`

- UI ordering preserved — only the heavy payload field is stripped.
- Recent cards untouched.
- Already-stubbed cards skipped (idempotent on re-pass).
- Small outputs (≤4 KiB) left alone — the stub itself is ~150 chars.
- Non-tool cards never modified.

## Out of scope

This addresses **one** likely contributor. The diagnostic suggests other heap-resident sources (streaming buffers, MCP subprocess handles, possible closure retention on \`/mcp reconnect\`) may also contribute. **#1031 stays open** until a heap-snapshot reproducer narrows the remaining root cause.

## Test plan

- [x] \`npm verify\` — 202 files / 3093 tests passing
- [x] New \`tests/reducer-cards-elide.test.ts\` covers: below-window untouched, beyond-window stubbed, idempotent on second-pass, small outputs skipped, non-tool cards never modified