### PR TITLE
Fix dashboard crash on structured MCP specs

### DIFF
--- a/dashboard/src/lib/mcp-spec.ts
+++ b/dashboard/src/lib/mcp-spec.ts
@@ -1,0 +1,46 @@
+type SpecRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is SpecRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringField(obj: SpecRecord, key: string): string | null {
+  const value = obj[key];
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function stringArgs(obj: SpecRecord): string[] {
+  const args = obj.args;
+  if (!Array.isArray(args)) return [];
+  return args.filter((arg): arg is string => typeof arg === "string" && arg.length > 0);
+}
+
+export function normalizeMcpSpec(spec: unknown): string | null {
+  if (typeof spec === "string") return spec;
+  if (!isRecord(spec)) return null;
+
+  const raw = stringField(spec, "raw") ?? stringField(spec, "spec");
+  if (raw) return raw;
+
+  const name = stringField(spec, "name") ?? stringField(spec, "label");
+  const command = stringField(spec, "command");
+  const url = stringField(spec, "url");
+  const transport = stringField(spec, "transport");
+  if (name && url) return `${name}=${transport === "streamable-http" ? "streamable+" : ""}${url}`;
+  if (name && command) return `${name}=${[command, ...stringArgs(spec)].join(" ")}`;
+  if (command) return [command, ...stringArgs(spec)].join(" ");
+
+  return null;
+}
+
+export function mcpSpecLabel(spec: unknown): string {
+  const text = normalizeMcpSpec(spec) ?? "";
+  const eq = text.indexOf("=");
+  return eq > 0 ? text.slice(0, eq) : text;
+}
+
+export function mcpSpecCommand(spec: unknown): string {
+  const text = normalizeMcpSpec(spec) ?? "";
+  const eq = text.indexOf("=");
+  return eq > 0 ? text.slice(eq + 1) : text;
+}

--- a/dashboard/src/panels/mcp.ts
+++ b/dashboard/src/panels/mcp.ts
@@ -3,6 +3,11 @@ import { t, useLang } from "../i18n/index.js";
 import { api } from "../lib/api.js";
 import { fmtNum } from "../lib/format.js";
 import { html } from "../lib/html.js";
+import {
+  normalizeMcpSpec,
+  mcpSpecCommand as specCommand,
+  mcpSpecLabel as specLabel,
+} from "../lib/mcp-spec.js";
 
 interface McpServer {
   label: string;
@@ -63,6 +68,10 @@ function specForEntry(e: RegistryEntryDto): string | null {
   return null;
 }
 
+function hideBrokenIcon(ev: Event): void {
+  (ev.target as HTMLImageElement).style.display = "none";
+}
+
 interface RegistryListResponse {
   source: "official" | "smithery" | "local";
   fromCache: boolean;
@@ -72,16 +81,6 @@ interface RegistryListResponse {
   matched: number;
   entries: RegistryEntryDto[];
   errors: string[];
-}
-
-function specLabel(spec: string): string {
-  const eq = spec.indexOf("=");
-  return eq > 0 ? spec.slice(0, eq) : spec;
-}
-
-function specCommand(spec: string): string {
-  const eq = spec.indexOf("=");
-  return eq > 0 ? spec.slice(eq + 1) : spec;
 }
 
 type McpFilter = "all" | "live" | "unbridged" | "marketplace";
@@ -164,8 +163,19 @@ export function McpPanel() {
 
   const load = useCallback(async () => {
     try {
-      setData(await api<McpData>("/mcp"));
-      setSpecs((await api<{ specs: string[] }>("/mcp/specs")).specs);
+      const mcpData = await api<McpData>("/mcp");
+      setData({
+        ...mcpData,
+        servers: (Array.isArray(mcpData.servers) ? mcpData.servers : []).map((server) => ({
+          ...server,
+          spec: normalizeMcpSpec(server.spec) ?? "",
+        })),
+      });
+      const specResponse = await api<{ specs?: unknown[] }>("/mcp/specs");
+      const normalized = (Array.isArray(specResponse.specs) ? specResponse.specs : [])
+        .map(normalizeMcpSpec)
+        .filter((spec): spec is string => spec !== null && spec.length > 0);
+      setSpecs(normalized);
     } catch (err) {
       setError((err as Error).message);
     }
@@ -551,7 +561,7 @@ function renderMarketplaceRows({
           ? html` <span class="dim">· ${fmtNum(e.popularity)}</span>`
           : null;
       const icon = e.iconUrl
-        ? html`<img src=${e.iconUrl} alt="" style="width:16px;height:16px;border-radius:3px;margin-right:6px;vertical-align:middle;object-fit:cover" loading="lazy" referrerpolicy="no-referrer" onError=${(ev: Event) => ((ev.target as HTMLImageElement).style.display = "none")} />`
+        ? html`<img src=${e.iconUrl} alt="" style="width:16px;height:16px;border-radius:3px;margin-right:6px;vertical-align:middle;object-fit:cover" loading="lazy" referrerpolicy="no-referrer" onError=${hideBrokenIcon} />`
         : null;
       return html`
         <div class=${`ssl-row ${sel ? "sel" : ""}`} onClick=${() => setOpenRegistry(e)}>
@@ -594,7 +604,7 @@ function renderRegistryDetail({
       }${entry.install.version ? `@${entry.install.version}` : ""}`
     : "";
   const icon = entry.iconUrl
-    ? html`<img src=${entry.iconUrl} alt="" style="width:24px;height:24px;border-radius:4px;margin-right:8px;vertical-align:middle;object-fit:cover" loading="lazy" referrerpolicy="no-referrer" onError=${(ev: Event) => ((ev.target as HTMLImageElement).style.display = "none")} />`
+    ? html`<img src=${entry.iconUrl} alt="" style="width:24px;height:24px;border-radius:4px;margin-right:8px;vertical-align:middle;object-fit:cover" loading="lazy" referrerpolicy="no-referrer" onError=${hideBrokenIcon} />`
     : null;
   return html`
     <div class="sessions-detail-h">

--- a/tests/dashboard-mcp-spec.test.ts
+++ b/tests/dashboard-mcp-spec.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { mcpSpecCommand, mcpSpecLabel, normalizeMcpSpec } from "../dashboard/src/lib/mcp-spec.js";
+
+describe("dashboard MCP spec display helpers", () => {
+  it("keeps legacy string specs unchanged", () => {
+    const spec = "fs=npx -y @modelcontextprotocol/server-filesystem";
+
+    expect(normalizeMcpSpec(spec)).toBe(spec);
+    expect(mcpSpecLabel(spec)).toBe("fs");
+    expect(mcpSpecCommand(spec)).toBe("npx -y @modelcontextprotocol/server-filesystem");
+  });
+
+  it("accepts object specs from attached dashboard payloads without throwing", () => {
+    const spec = { raw: "browser=npx -y @mcp/browser", status: "configured" };
+
+    expect(normalizeMcpSpec(spec)).toBe("browser=npx -y @mcp/browser");
+    expect(mcpSpecLabel(spec)).toBe("browser");
+    expect(mcpSpecCommand(spec)).toBe("npx -y @mcp/browser");
+  });
+
+  it("derives a display string from structured command specs", () => {
+    const spec = { name: "git", command: "uvx", args: ["mcp-git", "--repository", "."] };
+
+    expect(normalizeMcpSpec(spec)).toBe("git=uvx mcp-git --repository .");
+    expect(mcpSpecLabel(spec)).toBe("git");
+    expect(mcpSpecCommand(spec)).toBe("uvx mcp-git --repository .");
+  });
+
+  it("drops unrecognized object specs instead of stringifying them", () => {
+    const spec = { env: { API_KEY: "secret" } };
+
+    expect(normalizeMcpSpec(spec)).toBeNull();
+    expect(mcpSpecLabel(spec)).toBe("");
+    expect(mcpSpecCommand(spec)).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary
- Normalize MCP spec payloads before rendering dashboard labels and commands.
- Support legacy string specs plus structured `{ raw/spec }`, command, and URL-style specs.
- Drop unrecognized object specs instead of stringifying them into the UI.

## Root Cause
The MCP dashboard assumed every spec returned to the panel was a string and called `indexOf` directly. Structured MCP config payloads can reach the dashboard as objects, which crashed rendering with `spec.indexOf is not a function`.

## Testing
- `npm test -- tests/dashboard-mcp-spec.test.ts`
- `npx biome check dashboard/src/lib/mcp-spec.ts dashboard/src/panels/mcp.ts tests/dashboard-mcp-spec.test.ts`
- `npm run verify`

Fixes #1049
