### PR TITLE
fix(loop): persist user message at step entry, not after the first round-trip

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -616,7 +616,15 @@ export class CacheFirstLoop {
         content: t("loop.proArmed"),
       };
     }
-    let pendingUser: string | null = userInput;
+    // Persist the user message before the first API round-trip so a
+    // mid-stream abort or a session switch doesn't drop the prompt and
+    // leave a new session orphaned without a .jsonl on disk (issue #943
+    // — sidebar globs .jsonl files, so an unpersisted new session vanishes
+    // when the user navigates away before the model responds). A failed
+    // first round-trip still leaves the message in the log; the user can
+    // /retry without re-typing.
+    this.appendAndPersist({ role: "user", content: userInput });
+    let pendingUser: string | null = null;
     const toolSpecs = this.prefix.tools();
 
     for (let iter = 0; ; iter++) {
@@ -972,12 +980,6 @@ export class CacheFirstLoop {
         this.modelForCurrentCall(),
         usage ?? new Usage(),
       );
-
-      // Commit the user turn to the log only on success of the first round-trip.
-      if (pendingUser !== null) {
-        this.appendAndPersist({ role: "user", content: pendingUser });
-        pendingUser = null;
-      }
 
       this.scratch.reasoning = reasoningContent || null;
 

--- a/tests/loop-user-persist.test.ts
+++ b/tests/loop-user-persist.test.ts
@@ -1,0 +1,113 @@
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DeepSeekClient } from "../src/client.js";
+import { CacheFirstLoop } from "../src/loop.js";
+import { ImmutablePrefix } from "../src/memory/runtime.js";
+import { loadSessionMessages } from "../src/memory/session.js";
+
+describe("loop persists user message at step entry (issue #943)", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "reasonix-loop943-"));
+    vi.stubEnv("USERPROFILE", tmp);
+    vi.stubEnv("HOME", tmp);
+    vi.spyOn(require("node:os"), "homedir").mockReturnValue(tmp);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    if (existsSync(tmp)) rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("writes the user message to the session log before the first API call settles, so a mid-stream abort doesn't drop it", async () => {
+    // Fake fetch that never resolves on its own — only the abort signal
+    // terminates it. Simulates the desktop user clicking a different
+    // session while the AI is still streaming.
+    const client = new DeepSeekClient({
+      apiKey: "sk-test",
+      fetch: vi.fn(async (_url: unknown, init: { signal?: AbortSignal } | undefined) => {
+        const signal = init?.signal;
+        return new Promise<Response>((_resolve, reject) => {
+          signal?.addEventListener("abort", () =>
+            reject(new DOMException("This operation was aborted", "AbortError")),
+          );
+        });
+      }) as unknown as typeof fetch,
+      retry: { maxAttempts: 1 },
+    });
+
+    const sessionName = "bug943-pre-response-abort";
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s" }),
+      stream: false,
+      session: sessionName,
+    });
+
+    const consumed = (async () => {
+      for await (const ev of loop.step("hello — switching away soon")) {
+        if (ev.role === "done") break;
+      }
+    })();
+
+    // Yield a tick so step() reaches the awaited fetch, then abort to
+    // simulate the session-switch tear-down.
+    await new Promise((r) => setTimeout(r, 10));
+    loop.abort();
+    await consumed;
+
+    // The session JSONL must exist on disk and contain the user prompt.
+    // Pre-fix this file would be missing entirely, making the session
+    // invisible to the sidebar's `listSessions()` glob.
+    const persisted = loadSessionMessages(sessionName);
+    const firstUser = persisted.find((m) => m.role === "user");
+    expect(firstUser).toBeDefined();
+    expect(firstUser?.content).toBe("hello — switching away soon");
+  });
+
+  it("writes the user message immediately even when the API call succeeds normally", async () => {
+    const client = new DeepSeekClient({
+      apiKey: "sk-test",
+      fetch: vi.fn(async () => {
+        return new Response(
+          JSON.stringify({
+            choices: [
+              {
+                index: 0,
+                message: { role: "assistant", content: "ok" },
+                finish_reason: "stop",
+              },
+            ],
+            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }) as unknown as typeof fetch,
+    });
+
+    const sessionName = "bug943-happy-path";
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s" }),
+      stream: false,
+      session: sessionName,
+    });
+
+    for await (const ev of loop.step("happy path")) {
+      if (ev.role === "done") break;
+    }
+
+    const persisted = loadSessionMessages(sessionName);
+    // First entry is the user message; followed by assistant.
+    expect(persisted[0]).toEqual({ role: "user", content: "happy path" });
+    expect(persisted.length).toBeGreaterThanOrEqual(2);
+    expect(persisted.some((m) => m.role === "assistant")).toBe(true);
+    // No duplicate user copies.
+    const userMsgs = persisted.filter((m) => m.role === "user");
+    expect(userMsgs).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Closes #943

## Repro

Open a new session in the desktop app, send the first prompt, then click a different session in the sidebar **before** the AI finishes streaming. The new session vanishes entirely from the sidebar.

## Cause

- A new session writes only \`<name>.meta.json\` at mint time; the \`<name>.jsonl\` file isn't created until the first \`appendSessionMessage\` call.
- \`CacheFirstLoop.step()\` only called \`appendAndPersist\` for the user message **after** the first API round-trip succeeded (\`src/loop.ts:977-980\`).
- Switching sessions tears down the loop via \`abortTurn\` → the in-flight fetch is aborted, the loop never reaches the persist line, the \`.jsonl\` is never written.
- The sidebar's \`listSessionsForWorkspace\` globs \`.jsonl\` only, so the orphan \`.meta.json\` is invisible and the session is gone from the UI.

## What changed

Persist the user message at the very top of \`step()\`, before the API call. If the round-trip fails the message stays on disk and the user can \`/retry\` without re-typing — same UX as ChatGPT / Claude where a failed send leaves the bubble visible. \`pendingUser\` becomes \`null\` since the log already carries it; \`buildMessages(pendingUser)\` keeps working unchanged.

## Test plan

- [x] \`npm verify\` — 203 files / 3095 tests passing
- [x] New \`tests/loop-user-persist.test.ts\`:
  - pre-response abort still writes the user message to the JSONL on disk (the exact #943 scenario, simulated via a never-resolving fetch + \`loop.abort()\`)
  - happy path still writes exactly one user copy followed by the assistant turn (no duplicate-user regression)