### PR TITLE
fix(cli): align status bar with web dashboard (decimal K + session-aggregate cache-hit)

### DIFF
--- a/src/cli/ui/hooks/handle-assistant-final.ts
+++ b/src/cli/ui/hooks/handle-assistant-final.ts
@@ -69,8 +69,12 @@ export function handleAssistantFinal(ev: LoopEvent, ctx: AssistantFinalContext):
       model: ev.stats.model,
       usage: ev.stats.usage,
     });
+    // Pass the session-aggregate cache-hit so the persistent status bar
+    // mirrors what the web dashboard reads from `loop.stats.summary()`
+    // (issue #1028) instead of showing this single turn's ratio.
     ctx.translator.turnEnd(ev.stats, ctx.streamRef.reasoning, {
       promptCap: ctx.ctxMax > 0 ? ctx.ctxMax : undefined,
+      sessionCacheHit: ctx.getSessionSummary().cacheHitRatio,
     });
     if (ctx.ctxMax > 0) {
       ctx.log.pushCtxPressureIfHigh(ev.stats.usage.promptTokens, ctx.ctxMax);

--- a/src/cli/ui/hooks/useScrollback.ts
+++ b/src/cli/ui/hooks/useScrollback.ts
@@ -93,7 +93,7 @@ export interface Scrollback {
       cacheHit: number;
       cost: number;
     },
-    extras?: { promptCap?: number; elapsedMs?: number },
+    extras?: { promptCap?: number; elapsedMs?: number; sessionCacheHit?: number },
   ): void;
   /** Wipe every card + toast — used by /clear and /new. */
   reset(): void;
@@ -306,6 +306,7 @@ export function useScrollback(): Scrollback {
           usage,
           promptCap: extras?.promptCap,
           elapsedMs: extras?.elapsedMs,
+          sessionCacheHit: extras?.sessionCacheHit,
         });
       },
       reset() {

--- a/src/cli/ui/primitives.tsx
+++ b/src/cli/ui/primitives.tsx
@@ -17,10 +17,10 @@ export function ChromeRule(): React.ReactElement {
   return <Text dimColor>{"─".repeat(w)}</Text>;
 }
 
-/** Compact binary-K formatter — `1234 → "1.2K"`, `131072 → "128K"`. */
+/** Compact decimal-K token formatter — `1234 → "1.2K"`, `131000 → "131K"`. Base-1000 matches DeepSeek's "1M context" / "128K" wording and the web dashboard's display, so the CLI bottom bar and the web bar agree on ctx capacity. */
 export function formatTokens(n: number): string {
-  if (n < 1024) return String(n);
-  const k = n / 1024;
+  if (n < 1000) return String(n);
+  const k = n / 1000;
   return k >= 100 ? `${k.toFixed(0)}K` : `${k.toFixed(1)}K`;
 }
 

--- a/src/cli/ui/state/TurnTranslator.ts
+++ b/src/cli/ui/state/TurnTranslator.ts
@@ -69,7 +69,7 @@ export class TurnTranslator {
   turnEnd(
     stats: TurnStats,
     reasoningText: string,
-    extras?: { promptCap?: number; elapsedMs?: number },
+    extras?: { promptCap?: number; elapsedMs?: number; sessionCacheHit?: number },
   ): void {
     this.log.endTurn(
       {

--- a/src/cli/ui/state/events.ts
+++ b/src/cli/ui/state/events.ts
@@ -100,6 +100,8 @@ const turnEnd = z.object({
   /** Model context window — drives the prompt-bar denominator on the auto-emitted UsageCard. */
   promptCap: z.number().int().positive().optional(),
   elapsedMs: z.number().nonnegative().optional(),
+  /** Session-aggregate cache-hit ratio routed into `status.cacheHit` so the persistent bottom bar matches the web dashboard's number. When absent, the reducer falls back to the per-turn `usage.cacheHit`. */
+  sessionCacheHit: z.number().min(0).max(1).optional(),
 });
 
 const modeChange = z.object({

--- a/src/cli/ui/state/reducer.ts
+++ b/src/cli/ui/state/reducer.ts
@@ -98,7 +98,7 @@ export function reduce(state: AgentState, event: AgentEvent): AgentState {
           ...state.status,
           cost: event.usage.cost,
           sessionCost,
-          cacheHit: event.usage.cacheHit,
+          cacheHit: event.sessionCacheHit ?? event.usage.cacheHit,
           promptTokens: event.usage.prompt,
           promptCap: event.promptCap ?? state.status.promptCap,
           sessionInputTokens,

--- a/tests/ui-reducer.test.ts
+++ b/tests/ui-reducer.test.ts
@@ -165,6 +165,27 @@ describe("ui reducer", () => {
     expect(s.status.cacheHit).toBeCloseTo(0.92);
   });
 
+  it("turn.end routes sessionCacheHit (when provided) into status.cacheHit so the bar matches the web aggregate (issue #1028)", () => {
+    const s = run([
+      {
+        type: "turn.end",
+        usage: { prompt: 1000, reason: 0, output: 50, cacheHit: 0.98, cost: 0.001 },
+        sessionCacheHit: 0.951,
+      },
+    ]);
+    expect(s.status.cacheHit).toBeCloseTo(0.951);
+  });
+
+  it("turn.end falls back to per-turn usage.cacheHit when sessionCacheHit is absent (back-compat)", () => {
+    const s = run([
+      {
+        type: "turn.end",
+        usage: { prompt: 1000, reason: 0, output: 50, cacheHit: 0.85, cost: 0.001 },
+      },
+    ]);
+    expect(s.status.cacheHit).toBeCloseTo(0.85);
+  });
+
   it("turn.end records promptTokens and remembers promptCap across turns", () => {
     const s = run([
       {

--- a/tests/ui-status-row-balance.test.tsx
+++ b/tests/ui-status-row-balance.test.tsx
@@ -201,7 +201,7 @@ describe("StatusRow — statusBar config toggles", () => {
     );
     expect(text).toContain("ctx");
     expect(text).toContain("72%");
-    expect(text).toContain("703K/977K");
+    expect(text).toContain("720K/1000K");
   });
 
   it("showCtxUsage=false hides ctx pill", async () => {


### PR DESCRIPTION
Closes #1028

## Reported

The persistent CLI status bar and the web dashboard's bottom bar / side rail show different numbers for the **same running session** — ctx capacity, cache-hit ratio. Two independent causes:

## (1) K unit mismatch

\`formatTokens\` (\`src/cli/ui/primitives.tsx\`) divided by **1024** — \`1_000_000\` rendered as \`977K\`. The dashboard formats via \`(ctxCap / 1000).toFixed(0)\` and shows \`1000K\`. Same underlying value, different K convention. DeepSeek's own docs say \"1M context\" / \"128K\" (base-1000), so the CLI was the outlier. **Switched to base-1000.**

## (2) Cache-hit metric mismatch

- Web reads \`loop.stats.summary().cacheHitRatio\` — session aggregate (carryover + weighted hit/miss across all turns).
- CLI status bar's \`status.cacheHit\` was being fed the per-turn \`stats.cacheHitRatio\` from the just-completed call.

Same loop, different semantics, no label disambiguation. **Routed the aggregate through a new optional \`sessionCacheHit\` on the \`turn.end\` event**; the reducer prefers it for \`status.cacheHit\` and falls back to the per-turn value when absent (back-compat). The per-turn UsageCard in scrollback still shows the per-turn ratio — only the persistent status bar changes.

## Test plan

- [x] \`npm verify\` — 203 files / 3097 tests passing
- [x] **ui-reducer**: \`turn.end\` honours \`sessionCacheHit\` when present; falls back to \`usage.cacheHit\` when absent
- [x] **ui-status-row-balance**: ctx pill renders \`720K/1000K\` for the 720k/1M case (was \`703K/977K\` under base-1024)