### PR TITLE
fix(desktop): strip leading slash from command chip label

### DIFF
--- a/desktop/src/ui/composer.tsx
+++ b/desktop/src/ui/composer.tsx
@@ -253,7 +253,7 @@ export function Composer({
       const cmd = (it as SlashCmd).cmd;
       const next = draft.replace(/[/@][^\s]*$/, "").trimEnd();
       setDraft(next);
-      setChips((c) => [...c, { kind: "slash", label: cmd }]);
+      setChips((c) => [...c, { kind: "slash", label: cmd.replace(/^\//, "") }]);
       (it as SlashCmd).run();
     } else {
       const mention = it as MentionItem;


### PR DESCRIPTION
## Summary
- After picking a command from the slash popup the chip rendered `/ /theme` because the chip already draws an `<I.slash />` icon next to the `label`, and we stored the raw `/theme` (icon + slash-prefixed text).
- Mention chips already store the bare name (`@` icon + `name`); slash chips now match.

## Root cause
`pickItem` in `desktop/src/ui/composer.tsx` pushed `{ kind: "slash", label: cmd }` with `cmd` carrying the `/` prefix. The render path is `<I.slash /> + <span>{label}</span>`, so the icon and the label both contributed a `/`.

## Test plan
- Open desktop, type `/`, pick `/theme` → chip reads `/ theme` (icon + name), not `/ /theme`.
- Type `@`, pick a file → mention chip unchanged.

Fixes #930