### PR TITLE
fix(loop): avoid stalled context fold and unsafe preflight compaction

### DIFF
--- a/src/context-manager.ts
+++ b/src/context-manager.ts
@@ -12,7 +12,11 @@ import {
   DEFAULT_CONTEXT_TOKENS,
   type SessionStats,
 } from "./telemetry/stats.js";
-import { countTokensBounded, estimateRequestTokens } from "./tokenizer.js";
+import {
+  countTokensBounded,
+  estimateConversationTokens,
+  estimateRequestTokens,
+} from "./tokenizer.js";
 import type { ChatMessage } from "./types.js";
 
 /** Auto-fold when a turn's response shows promptTokens above this fraction of ctxMax. */
@@ -29,6 +33,10 @@ export const HISTORY_FOLD_MIN_SAVINGS_FRACTION = 0.3;
 export const FORCE_SUMMARY_THRESHOLD = 0.8;
 /** Local preflight estimate above this fraction trips the emergency in-place compact path. */
 export const PREFLIGHT_EMERGENCY_THRESHOLD = 0.95;
+/** Emergency preflight target after local truncation, as a fraction of ctxMax. */
+export const PREFLIGHT_MECHANICAL_TARGET_FRACTION = 0.7;
+/** Hard deadline for semantic fold summaries so a hung request cannot stall the turn loop. */
+export const HISTORY_FOLD_SUMMARY_TIMEOUT_MS = 15_000;
 /** Prepended to fold summary content so the model knows it's a synthesized recap. */
 export const HISTORY_FOLD_MARKER =
   "[CONVERSATION HISTORY SUMMARY — earlier turns folded for context efficiency]\n\n";
@@ -202,6 +210,63 @@ export class ContextManager {
     };
   }
 
+  /** Pure local emergency compaction for preflight: drop oldest log entries and keep a valid tail. */
+  mechanicalTruncate(
+    model: string,
+    opts?: { targetTokens?: number; allowEmpty?: boolean },
+  ): FoldResult {
+    const ctxMax = DEEPSEEK_CONTEXT_TOKENS[model] ?? DEFAULT_CONTEXT_TOKENS;
+    const targetTokens =
+      opts?.targetTokens ?? Math.floor(ctxMax * PREFLIGHT_MECHANICAL_TARGET_FRACTION);
+    const all = this.deps.log.toMessages();
+    const noop: FoldResult = {
+      folded: false,
+      beforeMessages: all.length,
+      afterMessages: all.length,
+      summaryChars: 0,
+    };
+    if (all.length === 0) return noop;
+
+    const tokenCounts = all.map((m) => estimateConversationTokens([m], true));
+    let latestUserBoundary = -1;
+    for (let i = all.length - 1; i >= 0; i--) {
+      if (all[i]!.role === "user") {
+        latestUserBoundary = i;
+        break;
+      }
+    }
+    let cumTokens = 0;
+    let boundary = all.length;
+    let foundSafeBoundary = false;
+    for (let i = all.length - 1; i >= 0; i--) {
+      const next = cumTokens + tokenCounts[i]!;
+      if (next > targetTokens) break;
+      cumTokens = next;
+      if (all[i]!.role === "user") {
+        boundary = i;
+        foundSafeBoundary = true;
+      }
+    }
+    if (boundary <= 0) return noop;
+
+    const replacement = foundSafeBoundary
+      ? all.slice(boundary)
+      : opts?.allowEmpty
+        ? []
+        : latestUserBoundary >= 0
+          ? all.slice(latestUserBoundary)
+          : all;
+    if (replacement.length === all.length) return noop;
+    this.deps.log.compactInPlace(replacement);
+    this.persistRewrite(replacement);
+    return {
+      folded: true,
+      beforeMessages: all.length,
+      afterMessages: replacement.length,
+      summaryChars: 0,
+    };
+  }
+
   /** Drop a trailing in-flight assistant-with-tool_calls before a forced summary. Tail-only mutation; prefix cache safe. */
   trimTrailingToolCalls(): boolean {
     const tail = this.deps.log.entries[this.deps.log.entries.length - 1];
@@ -235,14 +300,40 @@ export class ContextManager {
           "Summarize the conversation above as plain prose. This summary replaces the original turns to free context — make it self-contained.",
       },
     ];
+    const turnSignal = this.deps.getAbortSignal();
+    const foldCtrl = new AbortController();
+    let cleanupAbort = (): void => {};
+    let timeout: ReturnType<typeof setTimeout> | undefined;
     try {
-      const resp = await this.deps.client.chat({
-        model: summaryModel,
-        messages,
-        signal: this.deps.getAbortSignal(),
-        thinking: thinkingModeForModel(summaryModel),
-        reasoningEffort: "high",
+      const abortPromise = new Promise<never>((_, reject) => {
+        const abort = () => {
+          foldCtrl.abort();
+          reject(new Error("fold-aborted"));
+        };
+        if (turnSignal.aborted) {
+          abort();
+        } else {
+          turnSignal.addEventListener("abort", abort, { once: true });
+          cleanupAbort = () => turnSignal.removeEventListener("abort", abort);
+        }
       });
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => {
+          foldCtrl.abort();
+          reject(new Error("fold-timeout"));
+        }, HISTORY_FOLD_SUMMARY_TIMEOUT_MS);
+      });
+      const resp = await Promise.race([
+        this.deps.client.chat({
+          model: summaryModel,
+          messages,
+          signal: foldCtrl.signal,
+          thinking: thinkingModeForModel(summaryModel),
+          reasoningEffort: "high",
+        }),
+        abortPromise,
+        timeoutPromise,
+      ]);
       this.deps.stats.record(this.deps.getCurrentTurn(), summaryModel, resp.usage ?? new Usage());
       return {
         content: stripHallucinatedToolMarkup((resp.content ?? "").trim()),
@@ -250,6 +341,9 @@ export class ContextManager {
       };
     } catch {
       return { content: "", reasoningContent: "" };
+    } finally {
+      if (timeout) clearTimeout(timeout);
+      cleanupAbort();
     }
   }
 

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -624,11 +624,13 @@ export const EN: TranslationSchema = {
     abortedAtIter:
       "aborted at iter {iter} — stopped without producing a summary (press ↑ + Enter or /retry to resume)",
     toolUploadStatus: "tool result uploaded · model thinking before next response…",
-    preflightFoldStatus: "preflight: context near full, attempting fold…",
-    preflightFolded:
-      "preflight: request ~{estimate}/{ctxMax} tokens ({pct}%) — folded {beforeMessages} messages → {afterMessages} (summary {summaryChars} chars). Sending.",
+    preflightTruncateStatus: "preflight: context near full, truncating oldest history…",
+    preflightTruncated:
+      "preflight: request ~{estimate}/{ctxMax} tokens ({pct}%) — truncated {beforeMessages} messages → {afterMessages}. Sending.",
+    preflightTruncatedStillFull:
+      "preflight: request still ~{estimate}/{ctxMax} tokens ({pct}%) after truncating {beforeMessages} messages → {afterMessages}. DeepSeek will likely 400. Run /clear or /new to start fresh.",
     preflightNoFold:
-      "preflight: request ~{estimate}/{ctxMax} tokens ({pct}%) and nothing left to fold — DeepSeek will likely 400. Run /clear or /new to start fresh.",
+      "preflight: request ~{estimate}/{ctxMax} tokens ({pct}%) and nothing left to truncate — DeepSeek will likely 400. Run /clear or /new to start fresh.",
     flashEscalation: "⇧ flash requested escalation — retrying this turn on {model}{reasonSuffix}",
     harvestStatus: "extracting plan state from reasoning…",
     autoEscalation:

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -221,8 +221,9 @@ export interface TranslationSchema {
     proArmed: string;
     abortedAtIter: string;
     toolUploadStatus: string;
-    preflightFoldStatus: string;
-    preflightFolded: string;
+    preflightTruncateStatus: string;
+    preflightTruncated: string;
+    preflightTruncatedStillFull: string;
     preflightNoFold: string;
     flashEscalation: string;
     harvestStatus: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -608,11 +608,13 @@ export const zhCN: TranslationSchema = {
     proArmed: "⇧ /pro 已装备 — 本轮使用 deepseek-v4-pro（一次性 · 本轮后自动解除）",
     abortedAtIter: "在第 {iter} 次工具调用处中断 — 未生成总结即停止（按 ↑ + Enter 或 /retry 恢复）",
     toolUploadStatus: "工具结果已上传 · 模型在生成下一条响应前思考中…",
-    preflightFoldStatus: "预检：上下文接近上限，尝试折叠…",
-    preflightFolded:
-      "预检：请求约 {estimate}/{ctxMax} tokens（{pct}%）— 已折叠 {beforeMessages} 条消息 → {afterMessages}（总结 {summaryChars} 字）。发送中。",
+    preflightTruncateStatus: "预检：上下文接近上限，正在裁剪最早历史…",
+    preflightTruncated:
+      "预检：请求约 {estimate}/{ctxMax} tokens（{pct}%）— 已裁剪 {beforeMessages} 条消息 → {afterMessages}。发送中。",
+    preflightTruncatedStillFull:
+      "预检：裁剪 {beforeMessages} 条消息 → {afterMessages} 后，请求仍约 {estimate}/{ctxMax} tokens（{pct}%）— DeepSeek 大概率会返回 400。请运行 /clear 或 /new 重新开始。",
     preflightNoFold:
-      "预检：请求约 {estimate}/{ctxMax} tokens（{pct}%）且没有可折叠的内容 — DeepSeek 大概率会返回 400。请运行 /clear 或 /new 重新开始。",
+      "预检：请求约 {estimate}/{ctxMax} tokens（{pct}%）且没有可裁剪的内容 — DeepSeek 大概率会返回 400。请运行 /clear 或 /new 重新开始。",
     flashEscalation: "⇧ flash 请求升级 — 本轮改用 {model}{reasonSuffix}",
     harvestStatus: "正在从推理过程提取计划状态…",
     autoEscalation:

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -708,10 +708,8 @@ export class CacheFirstLoop {
 
       // Preflight context check. Local estimate of the outgoing payload
       // catches cases where prior usage didn't warn us (fresh resume, one
-      // huge tool result). Above 95% we attempt a fold as a last resort —
-      // it costs one summary call but stays cache-friendly. If the fold
-      // can't shrink anything, we surface a warning and let the request
-      // go (and likely 400) so the user knows to /clear.
+      // huge tool result). Above 95% we truncate locally instead of making
+      // the user wait on another model call before their request goes out.
       {
         const decision = this.context.decidePreflight(messages, this.prefix.toolSpecs, this.model);
         if (decision.needsAction) {
@@ -719,24 +717,29 @@ export class CacheFirstLoop {
           yield {
             turn: this._turn,
             role: "status",
-            content: t("loop.preflightFoldStatus"),
+            content: t("loop.preflightTruncateStatus"),
           };
-          const result = await this.context.fold(this.model);
+          const result = this.context.mechanicalTruncate(this.model, {
+            allowEmpty: pendingUser !== null,
+          });
           if (result.folded) {
+            messages = this.buildMessages(pendingUser);
+            const after = this.context.decidePreflight(messages, this.prefix.toolSpecs, this.model);
+            const stillFull = after.needsAction;
             yield {
               turn: this._turn,
               role: "warning",
-              content: t("loop.preflightFolded", {
-                estimate: estimate.toLocaleString(),
-                ctxMax: ctxMax.toLocaleString(),
-                pct: Math.round((estimate / ctxMax) * 100),
-                beforeMessages: result.beforeMessages,
-                afterMessages: result.afterMessages,
-                summaryChars: result.summaryChars,
-              }),
+              content: t(
+                stillFull ? "loop.preflightTruncatedStillFull" : "loop.preflightTruncated",
+                {
+                  estimate: after.estimateTokens.toLocaleString(),
+                  ctxMax: after.ctxMax.toLocaleString(),
+                  pct: Math.round((after.estimateTokens / after.ctxMax) * 100),
+                  beforeMessages: result.beforeMessages,
+                  afterMessages: result.afterMessages,
+                },
+              ),
             };
-            // Rebuild with the folded log so we send the smaller payload.
-            messages = this.buildMessages(pendingUser);
           } else {
             yield {
               turn: this._turn,

--- a/tests/context-manager-fold-timeout.test.ts
+++ b/tests/context-manager-fold-timeout.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DeepSeekClient } from "../src/client.js";
+import { CacheFirstLoop } from "../src/loop.js";
+import { ImmutablePrefix } from "../src/memory/runtime.js";
+
+function abortableNeverFetch(): typeof fetch {
+  return vi.fn((_url: unknown, init: { signal?: AbortSignal } | undefined) => {
+    const signal = init?.signal;
+    return new Promise<Response>((_resolve, reject) => {
+      if (signal?.aborted) {
+        reject(new Error("aborted"));
+        return;
+      }
+      signal?.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+    });
+  }) as unknown as typeof fetch;
+}
+
+function seedTurns(loop: CacheFirstLoop, n: number): void {
+  for (let i = 0; i < n; i++) {
+    loop.log.append({
+      role: "user",
+      content: `question ${i}: ${"context padding for fold timeout regression ".repeat(8)}`,
+    });
+    loop.log.append({
+      role: "assistant",
+      content: `answer ${i}: ${"more context padding for fold timeout regression ".repeat(8)}`,
+    });
+  }
+}
+
+describe("ContextManager fold timeout", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("fails open when the summary request hangs", async () => {
+    vi.useFakeTimers();
+    const client = new DeepSeekClient({ apiKey: "sk-test", fetch: abortableNeverFetch() });
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s" }),
+      stream: false,
+    });
+    seedTurns(loop, 6);
+    const beforeMessages = loop.log.length;
+
+    const resultPromise = loop.compactHistory({ keepRecentTokens: 40 });
+    await vi.advanceTimersByTimeAsync(15_000);
+
+    const result = await Promise.race([resultPromise, Promise.resolve("still-pending" as const)]);
+    expect(result).not.toBe("still-pending");
+    expect(result).toMatchObject({
+      folded: false,
+      beforeMessages,
+      afterMessages: beforeMessages,
+      summaryChars: 0,
+    });
+    expect(loop.log.length).toBe(beforeMessages);
+  });
+});

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -5,6 +5,7 @@ import { DeepSeekClient } from "../src/client.js";
 import { CacheFirstLoop } from "../src/loop.js";
 import { ImmutablePrefix } from "../src/memory/runtime.js";
 import { DEEPSEEK_CONTEXT_TOKENS } from "../src/telemetry/stats.js";
+import { ToolRegistry } from "../src/tools.js";
 import type { ChatMessage } from "../src/types.js";
 
 interface FakeResponseShape {
@@ -48,11 +49,12 @@ describe("preflight context-size check", () => {
     delete DEEPSEEK_CONTEXT_TOKENS[TEST_MODEL];
   });
 
-  it("auto-compacts when the estimated request exceeds 95% of the context window", async () => {
+  it("mechanically truncates when the estimated request exceeds 95% of the context window", async () => {
     // Tiny 1000-token budget so modest content can overflow.
     DEEPSEEK_CONTEXT_TOKENS[TEST_MODEL] = 1000;
 
-    const client = makeClient([{ content: "ack" }]);
+    const fetchFn = fakeFetch([{ content: "ack" }]);
+    const client = new DeepSeekClient({ apiKey: "sk-test", fetch: fetchFn });
     const loop = new CacheFirstLoop({
       client,
       prefix: new ImmutablePrefix({ system: "be brief" }),
@@ -83,17 +85,158 @@ describe("preflight context-size check", () => {
       events.push({ role: ev.role, content: ev.content });
     }
 
-    // Preflight fires BEFORE the request — expect a warning naming the
-    // preflight path and the fold result (cache-safe: append-only summary).
+    // Preflight fires BEFORE the request, but the emergency path is
+    // local-only: no summary LLM call should run before the user's call.
     const warn = events.find((e) => e.role === "warning" && /^preflight:/.test(e.content ?? ""));
     expect(warn).toBeDefined();
-    expect(warn!.content).toMatch(/folded \d+ messages/);
-    expect(warn!.content).toMatch(/summary \d+ chars/);
+    expect(warn!.content).toMatch(/truncated \d+ messages/);
+    expect(warn!.content).not.toMatch(/summary \d+ chars/);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
 
     // Loop still completed normally (no forced summary, no error).
     expect(events.find((e) => e.role === "error")).toBeUndefined();
     const finals = events.filter((e) => e.role === "assistant_final");
     expect(finals.length).toBe(1);
+  });
+
+  it("mechanically truncates when oversized tool-call arguments dominate the estimate", async () => {
+    DEEPSEEK_CONTEXT_TOKENS[TEST_MODEL] = 500;
+
+    const fetchFn = fakeFetch([{ content: "ack" }]);
+    const loop = new CacheFirstLoop({
+      client: new DeepSeekClient({ apiKey: "sk-test", fetch: fetchFn }),
+      prefix: new ImmutablePrefix({ system: "s" }),
+      stream: false,
+      model: TEST_MODEL,
+    });
+
+    const largeArgs = JSON.stringify({
+      command: Array.from({ length: 600 }, (_, i) => `inspect-file-${i}`).join(" "),
+    });
+    loop.log.append({ role: "user", content: "prior request" });
+    loop.log.append({
+      role: "assistant",
+      content: "",
+      tool_calls: [
+        { id: "prior", type: "function", function: { name: "probe", arguments: largeArgs } },
+      ],
+    });
+    loop.log.append({ role: "tool", tool_call_id: "prior", content: "ok" });
+
+    const events: { role: string; content?: string }[] = [];
+    for await (const ev of loop.step("hi")) {
+      events.push({ role: ev.role, content: ev.content });
+    }
+
+    const warn = events.find((e) => e.role === "warning" && /^preflight:/.test(e.content ?? ""));
+    expect(warn).toBeDefined();
+    expect(warn!.content).toMatch(/truncated \d+ messages/);
+    expect(warn!.content).not.toMatch(/nothing left to truncate/);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("warns when truncation cannot get the full request under 95%", async () => {
+    DEEPSEEK_CONTEXT_TOKENS[TEST_MODEL] = 500;
+
+    const fetchFn = fakeFetch([{ content: "ack" }]);
+    const loop = new CacheFirstLoop({
+      client: new DeepSeekClient({ apiKey: "sk-test", fetch: fetchFn }),
+      prefix: new ImmutablePrefix({ system: "You are a careful assistant. ".repeat(300) }),
+      stream: false,
+      model: TEST_MODEL,
+    });
+
+    loop.log.append({ role: "user", content: "prior request" });
+    loop.log.append({
+      role: "assistant",
+      content: "",
+      tool_calls: [{ id: "prior", type: "function", function: { name: "probe", arguments: "{}" } }],
+    });
+    loop.log.append({
+      role: "tool",
+      tool_call_id: "prior",
+      content: "ERROR: step failed with trailing detail\n".repeat(500),
+    });
+
+    const events: { role: string; content?: string }[] = [];
+    for await (const ev of loop.step("hi")) {
+      events.push({ role: ev.role, content: ev.content });
+    }
+
+    const warn = events.find((e) => e.role === "warning" && /^preflight:/.test(e.content ?? ""));
+    expect(warn).toBeDefined();
+    expect(warn!.content).toMatch(/still/);
+    expect(warn!.content).toMatch(/truncat(?:ed|ing) \d+ messages/);
+    expect(warn!.content).not.toMatch(/Sending/);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not clear the active tool turn when a tool result cannot fit the target", async () => {
+    DEEPSEEK_CONTEXT_TOKENS[TEST_MODEL] = 500;
+
+    const tools = new ToolRegistry();
+    tools.register({
+      name: "big_result",
+      description: "return an oversized result",
+      parameters: { type: "object", properties: {}, additionalProperties: false },
+      fn: () => "ERROR: tool output with important context\n".repeat(5000),
+    });
+
+    const payloads: Array<{ messages: ChatMessage[] }> = [];
+    let calls = 0;
+    const fetchFn = vi.fn(async (_url: unknown, init: RequestInit | undefined) => {
+      payloads.push(JSON.parse(String(init?.body ?? "{}")) as { messages: ChatMessage[] });
+      calls++;
+      const message =
+        calls === 1
+          ? {
+              role: "assistant",
+              content: "",
+              tool_calls: [
+                {
+                  id: "call-1",
+                  type: "function",
+                  function: { name: "big_result", arguments: "{}" },
+                },
+              ],
+            }
+          : { role: "assistant", content: "final answer", tool_calls: undefined };
+      return new Response(
+        JSON.stringify({
+          choices: [{ index: 0, message, finish_reason: "stop" }],
+          usage: {
+            prompt_tokens: 100,
+            completion_tokens: 10,
+            total_tokens: 110,
+            prompt_cache_hit_tokens: 0,
+            prompt_cache_miss_tokens: 100,
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+
+    const loop = new CacheFirstLoop({
+      client: new DeepSeekClient({ apiKey: "sk-test", fetch: fetchFn }),
+      prefix: new ImmutablePrefix({ system: "s" }),
+      tools,
+      stream: false,
+      model: TEST_MODEL,
+    });
+
+    const events: { role: string; content?: string }[] = [];
+    for await (const ev of loop.step("please use the big tool")) {
+      events.push({ role: ev.role, content: ev.content });
+    }
+
+    expect(payloads).toHaveLength(2);
+    expect(payloads[1]!.messages).not.toEqual([{ role: "system", content: "s" }]);
+    expect(payloads[1]!.messages.some((m) => m.role === "user")).toBe(true);
+    expect(payloads[1]!.messages.some((m) => m.role === "tool")).toBe(true);
+    expect(loop.log.toMessages().some((m) => m.role === "user")).toBe(true);
+    expect(
+      events.find((e) => e.role === "warning" && /^preflight:/.test(e.content ?? "")),
+    ).toBeDefined();
   });
 
   it("does NOT fire when the estimate is comfortably under 95%", async () => {
@@ -116,9 +259,9 @@ describe("preflight context-size check", () => {
     expect(anyPreflight).toBeUndefined();
   });
 
-  it("warns (but does not block) when over 95% with nothing to fold", async () => {
+  it("warns (but does not block) when over 95% with nothing to truncate", async () => {
     // Tiny budget AND a system prompt that alone overwhelms it. The log
-    // is empty, so fold has nothing to shrink — the preflight surfaces
+    // is empty, so truncation has nothing to shrink — the preflight surfaces
     // a warning so the failure isn't mysterious; the request goes out
     // regardless and DeepSeek decides.
     DEEPSEEK_CONTEXT_TOKENS[TEST_MODEL] = 500;
@@ -139,7 +282,7 @@ describe("preflight context-size check", () => {
 
     const warn = events.find((e) => e.role === "warning" && /^preflight:/.test(e.content ?? ""));
     expect(warn).toBeDefined();
-    expect(warn!.content).toMatch(/nothing left to fold/);
+    expect(warn!.content).toMatch(/nothing left to truncate/);
     // Run still reaches the final step — the user sees the warning
     // and can react, but we don't short-circuit on our own.
     const finals = events.filter((e) => e.role === "assistant_final");


### PR DESCRIPTION
## What

Adds a bounded context-fold summary path and switches the emergency preflight path to local mechanical truncation. The truncation now accounts for rendered message cost, including tool-call arguments, reruns the preflight estimate after compaction, and preserves the active tool turn when a large tool result cannot safely fit under the target.

## Why

Fixes #561. A semantic fold during preflight could stall the user's turn, and a naive mechanical truncation could either miss large tool-call arguments or drop the active user/tool context before the follow-up request.

## How to verify

- `npm run verify`

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time