### PR TITLE
fix(code): stop write_file silently redirecting absolute system paths

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -1,5 +1,5 @@
 import { type WriteStream, statSync } from "node:fs";
-import { resolve } from "node:path";
+import { relative, resolve } from "node:path";
 import { Box, Text, useStdin, useStdout } from "ink";
 import React, {
   useCallback,
@@ -90,6 +90,7 @@ import {
 import { defaultUsageLogPath } from "../../telemetry/usage.js";
 import type { ToolRegistry } from "../../tools.js";
 import type { ChoiceOption } from "../../tools/choice.js";
+import { looksLikeAbsoluteSystemPath, pathIsUnder } from "../../tools/filesystem.js";
 import type { PlanStep } from "../../tools/plan.js";
 import { formatCommandResult, runCommand } from "../../tools/shell.js";
 import { registerSkillTools } from "../../tools/skills.js";
@@ -2002,19 +2003,30 @@ function AppInner({
       if (name !== "edit_file" && name !== "write_file") return null;
       const rawPath = typeof args.path === "string" ? args.path : "";
       if (!rawPath) return null;
-      // Mirror filesystem.ts safePath's leading-slash tolerance so
-      // `/src/foo.ts` doesn't get misrouted through applyEditBlock's
-      // rootDir-escape check.
-      let relPath = rawPath;
-      while (relPath.startsWith("/") || relPath.startsWith("\\")) {
-        relPath = relPath.slice(1);
-      }
-      if (!relPath) return null;
 
       // Read root via ref so a workspace swap (which runs reregisterTools
-      // for read_file/run_command) is also visible to this interceptor 闂?      // otherwise edit_file writes to the OLD root while read_file looks in
+      // for read_file/run_command) is also visible to this interceptor
+      // otherwise edit_file writes to the OLD root while read_file looks in
       // the NEW one, producing ENOENT on the next read of a just-edited file.
       const rootForEdit = currentRootDirRef.current;
+      const absRoot = resolve(rootForEdit);
+
+      // Absolute system paths (issue #942): defer outside-rootDir writes to the tool fn's safePath gate instead of stripping the leading slash and silently rewriting to <rootDir>/...
+      let relPath: string;
+      if (looksLikeAbsoluteSystemPath(rawPath)) {
+        const abs = resolve(rawPath);
+        if (!pathIsUnder(abs, absRoot)) return null;
+        const rel = relative(absRoot, abs);
+        if (!rel) return null;
+        relPath = rel;
+      } else {
+        let stripped = rawPath;
+        while (stripped.startsWith("/") || stripped.startsWith("\\")) {
+          stripped = stripped.slice(1);
+        }
+        if (!stripped) return null;
+        relPath = stripped;
+      }
       let block: EditBlock;
       if (name === "edit_file") {
         const search = typeof args.search === "string" ? args.search : "";

--- a/src/tools/filesystem.ts
+++ b/src/tools/filesystem.ts
@@ -44,6 +44,19 @@ export function displayRel(rootDir: string, full: string): string {
   return pathMod.relative(rootDir, full).replaceAll("\\", "/");
 }
 
+/** Windows drive-letter prefixes always count; POSIX absolutes only count when their first segment is a known system root. */
+export function looksLikeAbsoluteSystemPath(raw: string): boolean {
+  if (/^[A-Za-z]:[\\/]/.test(raw)) return true;
+  return /^\/(?:home|Users|etc|var|opt|tmp|usr|mnt|Library|Volumes|proc|sys|dev|run|srv|media|Applications|System|root|boot|private)(?:[/\\]|$)/.test(
+    raw,
+  );
+}
+
+export function pathIsUnder(child: string, parent: string): boolean {
+  const rel = pathMod.relative(parent, child);
+  return rel === "" || (!rel.startsWith("..") && !pathMod.isAbsolute(rel));
+}
+
 const GLOB_METACHARS = /[*?{[]/;
 
 /** Glob via picomatch when metachars present, else case-insensitive substring — keeps `.ts` / `test` callers working. Slash in pattern → match rel-path; otherwise basename. */
@@ -96,19 +109,6 @@ export function registerFilesystemTools(
   const sessionApproved = new Set<string>();
   /** In-flight gate prompts keyed by `allowPrefix` so parallel reads under the same dir only fire one modal. */
   const inflightGate = new Map<string, Promise<ConfirmationChoice>>();
-
-  function pathIsUnder(child: string, parent: string): boolean {
-    const rel = pathMod.relative(parent, child);
-    return rel === "" || (!rel.startsWith("..") && !pathMod.isAbsolute(rel));
-  }
-
-  /** Heuristic: does the raw input express "I really mean this absolute system path" rather than the model-convention sandbox-relative form? Windows drive-letter prefixes always count; POSIX absolutes only count when their first segment is a known system root. */
-  function looksLikeAbsoluteSystemPath(raw: string): boolean {
-    if (/^[A-Za-z]:[\\/]/.test(raw)) return true;
-    return /^\/(?:home|Users|etc|var|opt|tmp|usr|mnt|Library|Volumes|proc|sys|dev|run|srv|media|Applications|System|root|boot|private)(?:[/\\]|$)/.test(
-      raw,
-    );
-  }
 
   async function ensureOutsideSandboxAllowed(
     abs: string,

--- a/tests/path-helpers.test.ts
+++ b/tests/path-helpers.test.ts
@@ -1,0 +1,110 @@
+/** Regression for #942 — write_file interceptor must NOT strip the slash off a real absolute system path. */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve, sep } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { looksLikeAbsoluteSystemPath, pathIsUnder } from "../src/tools/filesystem.js";
+
+describe("looksLikeAbsoluteSystemPath", () => {
+  it("flags POSIX system roots", () => {
+    expect(looksLikeAbsoluteSystemPath("/Users/x/.claude/skills/foo.md")).toBe(true);
+    expect(looksLikeAbsoluteSystemPath("/home/x/foo")).toBe(true);
+    expect(looksLikeAbsoluteSystemPath("/etc/hosts")).toBe(true);
+    expect(looksLikeAbsoluteSystemPath("/tmp/x")).toBe(true);
+  });
+
+  it("flags Windows drive-letter absolutes", () => {
+    expect(looksLikeAbsoluteSystemPath("C:\\Users\\x\\foo.md")).toBe(true);
+    expect(looksLikeAbsoluteSystemPath("D:/projects/foo")).toBe(true);
+  });
+
+  it("does NOT flag sandbox-shorthand leading slashes", () => {
+    expect(looksLikeAbsoluteSystemPath("/src/foo.ts")).toBe(false);
+    expect(looksLikeAbsoluteSystemPath("/foo.md")).toBe(false);
+    expect(looksLikeAbsoluteSystemPath("foo.md")).toBe(false);
+    expect(looksLikeAbsoluteSystemPath("./foo.md")).toBe(false);
+  });
+});
+
+describe("pathIsUnder", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "reasonix-path-"));
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("recognises a child path", () => {
+    expect(pathIsUnder(join(root, "a", "b.ts"), root)).toBe(true);
+  });
+
+  it("recognises the root itself", () => {
+    expect(pathIsUnder(root, root)).toBe(true);
+  });
+
+  it("rejects a sibling", () => {
+    const other = mkdtempSync(join(tmpdir(), "reasonix-other-"));
+    try {
+      expect(pathIsUnder(join(other, "a"), root)).toBe(false);
+    } finally {
+      rmSync(other, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a `..`-escape", () => {
+    expect(pathIsUnder(resolve(root, "..", "elsewhere"), root)).toBe(false);
+  });
+});
+
+describe("write_file interceptor logic — issue #942 reproduction", () => {
+  // Mirrors the rewritten interceptor in src/cli/ui/App.tsx: a path that
+  // looksLikeAbsoluteSystemPath AND falls outside rootDir must NOT be
+  // turned into a rootDir-relative path. The interceptor returns null in
+  // that case so the native write_file tool fn handles it through the
+  // safePath approval gate.
+  function resolveInterceptedRelPath(rawPath: string, rootForEdit: string): string | null {
+    if (!rawPath) return null;
+    const absRoot = resolve(rootForEdit);
+    if (looksLikeAbsoluteSystemPath(rawPath)) {
+      const abs = resolve(rawPath);
+      if (!pathIsUnder(abs, absRoot)) return null;
+      const rel = abs === absRoot ? "" : abs.slice(absRoot.length + 1);
+      return rel || null;
+    }
+    let stripped = rawPath;
+    while (stripped.startsWith("/") || stripped.startsWith("\\")) {
+      stripped = stripped.slice(1);
+    }
+    return stripped || null;
+  }
+
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "reasonix-root-"));
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("defers an outside-root absolute system path back to the tool fn (returns null)", () => {
+    const outsidePath =
+      process.platform === "win32"
+        ? "C:\\Users\\someone\\.claude\\skills\\foo.md"
+        : "/Users/someone/.claude/skills/foo.md";
+    expect(resolveInterceptedRelPath(outsidePath, root)).toBeNull();
+  });
+
+  it("keeps intercepting when an absolute path resolves under rootDir", () => {
+    const inside = join(root, "sub", "foo.md");
+    const rel = resolveInterceptedRelPath(inside, root);
+    expect(rel).toBe(`sub${sep}foo.md`);
+  });
+
+  it("still treats a model-style leading slash as sandbox-relative", () => {
+    expect(resolveInterceptedRelPath("/src/foo.ts", root)).toBe("src/foo.ts");
+  });
+});


### PR DESCRIPTION
## Summary
- The auto-edit-mode interceptor for \`edit_file\` / \`write_file\` blindly stripped a leading \`/\` off every path. That's correct for the model-convention sandbox shorthand (\`/src/foo.ts\`) but it also fired on real absolute system paths like \`/Users/x/.claude/skills/foo.md\`, silently rewriting them to \`<rootDir>/Users/x/.claude/skills/foo.md\`.
- \`applyEditBlock\` then reported "created" while the file landed where the user wasn't looking — visible in #942 as "\`write_file\` returns success but the file isn't on disk."

## Root cause
\`src/cli/ui/App.tsx\` interceptor:
\`\`\`ts
let relPath = rawPath;
while (relPath.startsWith("/") || relPath.startsWith("\\")) {
  relPath = relPath.slice(1);
}
\`\`\`
The native \`write_file\` tool fn already gates this correctly via \`safePath\` + \`looksLikeAbsoluteSystemPath\` in \`tools/filesystem.ts\`, but the interceptor pre-empts that path in auto mode.

## Fix
- Lift \`looksLikeAbsoluteSystemPath\` and \`pathIsUnder\` to module-level exports in \`tools/filesystem.ts\`.
- In the App.tsx interceptor: if the raw path looks like a real system absolute, resolve it and only continue intercepting when it lands inside \`rootDir\`. Outside-root paths return \`null\` so the native tool fn handles them through the approval gate (and writes to the path the user actually meant). The model-convention leading-slash shorthand still gets stripped as before.

## Test plan
- New \`tests/path-helpers.test.ts\` (10 cases) — covers the helper predicates and reproduces the interceptor branch logic for the macOS / Windows / sandbox-shorthand cases.
- \`npm run verify\` — 205 files / 3111 tests pass.

Fixes #942