### PR TITLE
fix(ui): normalize Windows paste line endings

### DIFF
--- a/src/cli/edit/external-editor.ts
+++ b/src/cli/edit/external-editor.ts
@@ -40,7 +40,7 @@ export async function openInExternalEditor(initial: string): Promise<OpenEditorR
     writeFileSync(path, initial, "utf8");
     await spawnEditor(editor, path);
     const raw = readFileSync(path, "utf8");
-    return { kind: "ok", content: stripTrailingNewline(raw) };
+    return { kind: "ok", content: normalizeEditorBuffer(raw) };
   } catch (err) {
     return {
       kind: "failed",
@@ -73,8 +73,8 @@ function spawnEditor(editor: string, path: string): Promise<void> {
   });
 }
 
-function stripTrailingNewline(s: string): string {
-  if (s.endsWith("\r\n")) return s.slice(0, -2);
-  if (s.endsWith("\n")) return s.slice(0, -1);
-  return s;
+export function normalizeEditorBuffer(s: string): string {
+  const normalized = s.replace(/\r\n?/g, "\n");
+  if (normalized.endsWith("\n")) return normalized.slice(0, -1);
+  return normalized;
 }

--- a/src/cli/ui/stdin-reader.ts
+++ b/src/cli/ui/stdin-reader.ts
@@ -192,7 +192,9 @@ function tryDecodeGenericCsi(seq: string): KeyEvent | null {
 const PASTE_INVISIBLE_RE = /[\u200B\u200E\u200F\u202A-\u202E\u2060\u2066-\u2069\u00AD\uFEFF]/g;
 
 export function sanitizePasteText(s: string): string {
-  return s.replace(PASTE_INVISIBLE_RE, "");
+  // `ev.paste` bypasses the multiline reducer, so normalize Windows
+  // clipboard line endings here before raw CR can reach Ink's <Text>.
+  return s.replace(PASTE_INVISIBLE_RE, "").replace(/\r\n?/g, "\n");
 }
 
 /** Heuristic paste-burst detector — wraps raw multi-line chunks when the terminal didn't (#522). */

--- a/tests/external-editor.test.ts
+++ b/tests/external-editor.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { detectEditor } from "../src/cli/edit/external-editor.js";
+import { detectEditor, normalizeEditorBuffer } from "../src/cli/edit/external-editor.js";
 
 describe("detectEditor (issue #647)", () => {
   it("returns null when no editor env var is set", () => {
@@ -31,5 +31,11 @@ describe("detectEditor (issue #647)", () => {
   it("treats an empty / whitespace-only var as unset", () => {
     expect(detectEditor({ EDITOR: "   " })).toBeNull();
     expect(detectEditor({ EDITOR: "" })).toBeNull();
+  });
+});
+
+describe("normalizeEditorBuffer", () => {
+  it("normalizes Windows CRLF and bare CR while preserving the existing one-trailing-newline strip", () => {
+    expect(normalizeEditorBuffer("first\r\nsecond\rthird\r\n")).toBe("first\nsecond\nthird");
   });
 });

--- a/tests/stdin-reader.test.ts
+++ b/tests/stdin-reader.test.ts
@@ -226,6 +226,12 @@ describe("StdinReader — bracketed paste", () => {
     expect(events).toEqual([{ input: "hello\nworld", paste: true }]);
   });
 
+  it("normalizes Windows CRLF and bare CR line endings inside paste events", () => {
+    const { reader, events } = setup();
+    reader.feed("\x1b[200~first\r\nsecond\rthird\x1b[201~");
+    expect(events).toEqual([{ input: "first\nsecond\nthird", paste: true }]);
+  });
+
   it("paste content is collected across multiple feed calls (chunked stdin)", () => {
     const { reader, events } = setup();
     reader.feed("\x1b[200~hello\n");
@@ -266,13 +272,13 @@ describe("StdinReader — heuristic paste rescue (#522)", () => {
     // multi-line content used to fire one Enter per \r and submit N times.
     const { reader, events } = setup();
     reader.feed("first line\rsecond line\rthird line");
-    expect(events).toEqual([{ input: "first line\rsecond line\rthird line", paste: true }]);
+    expect(events).toEqual([{ input: "first line\nsecond line\nthird line", paste: true }]);
   });
 
   it("treats a single-break chunk with text on both sides as a paste", () => {
     const { reader, events } = setup();
     reader.feed("hello\rworld");
-    expect(events).toEqual([{ input: "hello\rworld", paste: true }]);
+    expect(events).toEqual([{ input: "hello\nworld", paste: true }]);
   });
 
   it("leaves a bare Enter alone (\\r submits as before)", () => {
@@ -324,8 +330,8 @@ describe("StdinReader — heuristic paste rescue (#522)", () => {
   it("normalizes \\r\\n line endings inside the heuristic so Windows pastes still get one event", () => {
     const { reader, events } = setup();
     reader.feed("first\r\nsecond\r\nthird");
-    // Whole chunk wrapped → paste accumulator delivers verbatim
-    expect(events).toEqual([{ input: "first\r\nsecond\r\nthird", paste: true }]);
+    // Whole chunk wrapped → paste accumulator delivers normalized logical lines.
+    expect(events).toEqual([{ input: "first\nsecond\nthird", paste: true }]);
   });
 });
 
@@ -428,6 +434,10 @@ describe("StdinReader — SGR mouse reports (issue #867)", () => {
 });
 
 describe("sanitizePasteText (issue #849)", () => {
+  it("normalizes Windows CRLF and bare CR line endings (issue #1030)", () => {
+    expect(sanitizePasteText("first\r\nsecond\rthird")).toBe("first\nsecond\nthird");
+  });
+
   it("strips bidi override controls (LRE/RLE/PDF/LRO/RLO/isolates)", () => {
     const raw = "\u202ahello\u202c \u202bworld\u202c \u2066isolated\u2069";
     expect(sanitizePasteText(raw)).toBe("hello world isolated");


### PR DESCRIPTION
## What

Normalize Windows paste/editor line endings before composer text reaches Ink rendering. Bracketed paste, heuristic multi-line paste rescue, and external-editor readback now convert CRLF / bare CR into LF while preserving existing trailing-newline behavior.

## Why

Fixes #1030. Windows Terminal + PowerShell can deliver pasted multi-line clipboard text with carriage returns. Paste events bypass the multiline reducer, so raw CR could reach `<Text>` and move the terminal cursor back to the line start, making pasted content appear overwritten or misaligned. The external editor readback path had the same display-risk shape.

## How to verify

`npm run verify`

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time