### PR TITLE
fix(desktop): persist & restore the full open-tab set across restarts

### DIFF
--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -19,6 +19,7 @@ import {
   isPlausibleKey,
   loadApiKey,
   loadBaseUrl,
+  loadDesktopOpenTabs,
   loadEditMode,
   loadEditor,
   loadPreset,
@@ -30,6 +31,7 @@ import {
   readConfig,
   saveApiKey,
   saveBaseUrl,
+  saveDesktopOpenTabs,
   saveEditMode,
   saveEditor,
   savePreset,
@@ -856,6 +858,15 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
       });
   }
 
+  /** Snapshot of every open tab's workspace dir, in tab order. Persisted after open/close so a restart restores the full tab set (issue #933). */
+  function persistOpenTabs(): void {
+    try {
+      saveDesktopOpenTabs(Array.from(tabs.values()).map((t) => t.rootDir));
+    } catch {
+      // best-effort — disk / perms shouldn't break tab management
+    }
+  }
+
   async function closeTab(tab: Tab): Promise<void> {
     abortTurn(tab);
     try {
@@ -871,6 +882,11 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
       }
     }
     tabs.delete(tab.id);
+    if (first && first.id === tab.id) {
+      const next = tabs.values().next().value;
+      if (next) first = next;
+    }
+    persistOpenTabs();
     emit({ type: "$tab_closed" }, tab.id);
   }
 
@@ -1049,7 +1065,11 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
     }
   }
 
-  const first = createTabSkeleton();
+  // `first` is the fallback tab for legacy tabId-less RPC messages. We
+  // assign it lazily below so saved-tabs restore (issue #933) can choose
+  // the boot dir before construction, and rotate `first` to the next
+  // surviving tab when its source closes.
+  let first: Tab;
 
   let shuttingDown = false;
   async function gracefulShutdown(): Promise<void> {
@@ -1235,22 +1255,46 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
   // `$ready` when it completes — until then `state.ready` keeps the
   // composer disabled, so users can't send a message before the runtime
   // exists. emitBalance was already fire-and-forget.
-  emit({ type: "$tab_opened", workspaceDir: first.rootDir }, first.id);
-  emitSessions(first);
-  emitSettings(first);
-  emitMcpSpecs(first);
-  emitSkills(first);
-  emitMemory(first);
-  if (!loadApiKey()) emit({ type: "$needs_setup", reason: "no_api_key" }, first.id);
-  void emitBalance(first);
-  void initTabToolset(first)
-    .then(() => {
-      if (loadApiKey()) emit({ type: "$ready" }, first.id);
-      emitCtxBreakdown(first);
-    })
-    .catch((err) => {
-      emit({ type: "$error", message: `init failed: ${(err as Error).message}` }, first.id);
-    });
+  function bootstrapTab(initialDir?: string): Tab {
+    const tab = createTabSkeleton(initialDir);
+    emit({ type: "$tab_opened", workspaceDir: tab.rootDir }, tab.id);
+    emitSessions(tab);
+    emitSettings(tab);
+    emitMcpSpecs(tab);
+    emitSkills(tab);
+    emitMemory(tab);
+    if (!loadApiKey()) emit({ type: "$needs_setup", reason: "no_api_key" }, tab.id);
+    void emitBalance(tab);
+    void initTabToolset(tab)
+      .then(() => {
+        if (loadApiKey()) emit({ type: "$ready" }, tab.id);
+        emitCtxBreakdown(tab);
+      })
+      .catch((err) => {
+        emit({ type: "$error", message: `init failed: ${(err as Error).message}` }, tab.id);
+      });
+    return tab;
+  }
+
+  // Restore the full tab set from the previous session (issue #933).
+  // `--dir` overrides saved tabs so a CLI-supplied workspace stays
+  // authoritative. Missing dirs are silently skipped — a deleted
+  // workspace shouldn't block boot.
+  const savedTabDirs = opts.dir
+    ? []
+    : loadDesktopOpenTabs().filter((d) => {
+        try {
+          return existsSync(d) && statSync(d).isDirectory();
+        } catch {
+          return false;
+        }
+      });
+  first = bootstrapTab(savedTabDirs[0]);
+  for (const d of savedTabDirs.slice(1)) {
+    if (resolve(d) === first.rootDir) continue;
+    bootstrapTab(d);
+  }
+  persistOpenTabs();
 
   const rl = createInterface({ input: stdin });
   rl.on("line", (line) => {
@@ -1266,23 +1310,8 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
 
     if (msg.cmd === "tab_open") {
       try {
-        const tab = createTabSkeleton(msg.workspaceDir);
-        emit({ type: "$tab_opened", workspaceDir: tab.rootDir }, tab.id);
-        emitSessions(tab);
-        emitSettings(tab);
-        emitMcpSpecs(tab);
-        emitSkills(tab);
-        emitMemory(tab);
-        if (!loadApiKey()) emit({ type: "$needs_setup", reason: "no_api_key" }, tab.id);
-        void emitBalance(tab);
-        void initTabToolset(tab)
-          .then(() => {
-            if (loadApiKey()) emit({ type: "$ready" }, tab.id);
-            emitCtxBreakdown(tab);
-          })
-          .catch((err) => {
-            emit({ type: "$error", message: `init failed: ${(err as Error).message}` }, tab.id);
-          });
+        bootstrapTab(msg.workspaceDir);
+        persistOpenTabs();
       } catch (err) {
         emit({ type: "$error", message: `tab_open failed: ${(err as Error).message}` });
       }

--- a/src/config.ts
+++ b/src/config.ts
@@ -107,6 +107,8 @@ export interface ReasonixConfig {
   workspaceDir?: string;
   /** Last N workspace paths the desktop client has opened, most recent first. */
   recentWorkspaces?: string[];
+  /** Desktop only — workspace dir per open tab in tab order, persisted so restart restores every tab (issue #933). Empty/absent → boot with a single default tab. */
+  desktopOpenTabs?: string[];
   /** Desktop only — `openWith` value for clicking file links. Empty/undefined = OS default app. Examples: "code", "cursor", "C:\\path\\to\\editor.exe". */
   editor?: string;
   theme?: ThemeName | "auto";
@@ -823,6 +825,24 @@ export function pushRecentWorkspace(dir: string, path: string = defaultConfigPat
   const list = (cfg.recentWorkspaces ?? []).filter((s) => s !== trimmed);
   list.unshift(trimmed);
   cfg.recentWorkspaces = list.slice(0, MAX_RECENT_WORKSPACES);
+  writeConfig(cfg, path);
+}
+
+export function loadDesktopOpenTabs(path: string = defaultConfigPath()): string[] {
+  const v = readConfig(path).desktopOpenTabs;
+  return Array.isArray(v)
+    ? v.filter((s): s is string => typeof s === "string" && s.length > 0)
+    : [];
+}
+
+export function saveDesktopOpenTabs(dirs: string[], path: string = defaultConfigPath()): void {
+  const cfg = readConfig(path);
+  const cleaned = dirs.filter((s): s is string => typeof s === "string" && s.length > 0);
+  if (cleaned.length === 0) {
+    cfg.desktopOpenTabs = undefined;
+  } else {
+    cfg.desktopOpenTabs = cleaned;
+  }
   writeConfig(cfg, path);
 }
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -11,6 +11,7 @@ import {
   isPlausibleKey,
   loadApiKey,
   loadBaseUrl,
+  loadDesktopOpenTabs,
   loadEditMode,
   loadIndexConfig,
   loadIndexUserConfig,
@@ -29,6 +30,7 @@ import {
   resolveThemePreference,
   saveApiKey,
   saveBaseUrl,
+  saveDesktopOpenTabs,
   saveEditMode,
   saveIndexConfig,
   saveReasoningEffort,
@@ -517,5 +519,33 @@ describe("config", () => {
         path,
       ),
     ).toThrow(/JSON object/);
+  });
+
+  describe("desktopOpenTabs — issue #933", () => {
+    it("returns [] when unset", () => {
+      expect(loadDesktopOpenTabs(path)).toEqual([]);
+    });
+
+    it("round-trips an ordered list", () => {
+      saveDesktopOpenTabs(["/a", "/b", "/c"], path);
+      expect(loadDesktopOpenTabs(path)).toEqual(["/a", "/b", "/c"]);
+    });
+
+    it("filters out empty / non-string entries on read", () => {
+      writeConfig({ desktopOpenTabs: ["/a", "", null as unknown as string, "/b"] }, path);
+      expect(loadDesktopOpenTabs(path)).toEqual(["/a", "/b"]);
+    });
+
+    it("clears the key when saving an empty list", () => {
+      saveDesktopOpenTabs(["/a"], path);
+      saveDesktopOpenTabs([], path);
+      expect(readConfig(path).desktopOpenTabs).toBeUndefined();
+    });
+
+    it("preserves order across multiple saves (tab reordering)", () => {
+      saveDesktopOpenTabs(["/a", "/b", "/c"], path);
+      saveDesktopOpenTabs(["/c", "/a", "/b"], path);
+      expect(loadDesktopOpenTabs(path)).toEqual(["/c", "/a", "/b"]);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- The desktop client always booted with a single tab. Tabs opened with Ctrl+T lived in React state only, so a restart silently dropped everything except the boot tab.
- Persist the open-tab list in \`config.desktopOpenTabs\` and rebuild every tab at startup.

## Implementation
- \`config.ts\` — add \`desktopOpenTabs: string[]\` with \`loadDesktopOpenTabs\` / \`saveDesktopOpenTabs\` helpers (clear the key when the list is empty so we don't leave dead state behind).
- \`desktop.ts\` — extract \`bootstrapTab(initialDir?)\` to share the emit-events + \`initTabToolset\` chain between the boot path and the \`tab_open\` RPC. Boot iterates saved dirs in order, skips any that no longer exist on disk, and dedupes against the first tab. \`--dir\` still wins so a CLI override stays authoritative. Persist after every open/close.
- The \`first\` fallback tab (used for legacy tabId-less RPC messages) rotates to the next surviving tab when its source closes.

## Test plan
- New \`describe(\"desktopOpenTabs — issue #933\")\` block in \`tests/config.test.ts\` (5 cases): round-trip, ordering across re-saves, empty list clearing the key, malformed entries filtered out, missing key returns \`[]\`.
- \`npm run verify\` — 205 files / 3116 tests pass.

## Manual repro
1. Open the desktop client, press Ctrl+T twice to add two more tabs (3 total).
2. Quit the app.
3. Relaunch — all three tabs restore in the original order. Before this fix only one tab was left.

Fixes #933