### PR TITLE
feat: rust integrated-mode P0 parity — pickers, missing cards, paste

### DIFF
--- a/crates/reasonix-render/src/integrated.rs
+++ b/crates/reasonix-render/src/integrated.rs
@@ -5,8 +5,8 @@ use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
 use crossterm::event::{
-    self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind, KeyModifiers,
-    MouseButton, MouseEventKind,
+    self, DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
+    Event, KeyCode, KeyEventKind, KeyModifiers, MouseButton, MouseEventKind,
 };
 use ratatui::backend::CrosstermBackend;
 use ratatui::layout::Rect;
@@ -36,6 +36,7 @@ enum Evt {
 pub fn run_integrated_loop(terminal: &mut Terminal) -> Result<()> {
     let mut stdout = io::stdout();
     let mouse_enabled = crossterm::execute!(stdout, EnableMouseCapture).is_ok();
+    let paste_enabled = crossterm::execute!(stdout, EnableBracketedPaste).is_ok();
 
     let (tx, rx) = mpsc::channel::<Evt>();
     let tx_stdin = tx.clone();
@@ -646,6 +647,41 @@ pub fn run_integrated_loop(terminal: &mut Terminal) -> Result<()> {
                     }
                 }
             }
+            Event::Paste(text) => {
+                if let Some(prompt) = scene.prompt_input.as_ref() {
+                    if prompt.secret {
+                        // Don't accept multi-line / control chars into a
+                        // secret prompt — pasted secrets in a non-line
+                        // editor are messy. Strip newlines and append.
+                        let clean: String = text.chars().filter(|c| !c.is_control()).collect();
+                        for ch in clean.chars() {
+                            insert_char_at(&mut buffer, cursor, ch);
+                            cursor += 1;
+                        }
+                    } else {
+                        // Strip leading/trailing whitespace + collapse
+                        // newlines to a single line — same shape an
+                        // interactive setup prompt would expect.
+                        let line = text.lines().next().unwrap_or("").trim();
+                        for ch in line.chars() {
+                            insert_char_at(&mut buffer, cursor, ch);
+                            cursor += 1;
+                        }
+                    }
+                } else {
+                    selection = None;
+                    for ch in text.chars() {
+                        if ch == '\r' {
+                            continue;
+                        }
+                        insert_char_at(&mut buffer, cursor, ch);
+                        cursor += 1;
+                    }
+                    slash_idx = 0;
+                    at_idx = 0;
+                    scroll_offset = 0;
+                }
+            }
             Event::Resize(_, _) => {}
             _ => {}
         }
@@ -653,6 +689,9 @@ pub fn run_integrated_loop(terminal: &mut Terminal) -> Result<()> {
 
     if mouse_enabled {
         let _ = crossterm::execute!(io::stdout(), DisableMouseCapture);
+    }
+    if paste_enabled {
+        let _ = crossterm::execute!(io::stdout(), DisableBracketedPaste);
     }
     result
 }

--- a/crates/reasonix-render/src/integrated.rs
+++ b/crates/reasonix-render/src/integrated.rs
@@ -90,6 +90,8 @@ pub fn run_integrated_loop(terminal: &mut Terminal) -> Result<()> {
     let mut last_approval_signature: Option<String> = None;
     let mut mode_picker: Option<usize> = None;
     let mut preset_picker: Option<usize> = None;
+    let mut list_picker_idx: usize = 0;
+    let mut last_list_picker_id: Option<String> = None;
     let mut sidebar_visible = true;
     let mut tick: u32 = 0;
     let anim_interval = Duration::from_millis(80);
@@ -180,6 +182,24 @@ pub fn run_integrated_loop(terminal: &mut Terminal) -> Result<()> {
         } else if at_idx >= at_count {
             at_idx = at_count - 1;
         }
+        // Reset list-picker selection when a new picker shows up (id
+        // changes) so the cursor doesn't carry over from the previous
+        // session into a totally different option set.
+        let lp_id = scene.list_picker.as_ref().map(|p| p.id.clone());
+        if lp_id != last_list_picker_id {
+            list_picker_idx = 0;
+            last_list_picker_id = lp_id.clone();
+        }
+        let list_picker_len = scene
+            .list_picker
+            .as_ref()
+            .map(|p| p.options.len())
+            .unwrap_or(0);
+        if list_picker_len == 0 {
+            list_picker_idx = 0;
+        } else if list_picker_idx >= list_picker_len {
+            list_picker_idx = list_picker_len - 1;
+        }
 
         if last_anim_at.elapsed() >= anim_interval {
             last_anim_at = Instant::now();
@@ -227,6 +247,7 @@ pub fn run_integrated_loop(terminal: &mut Terminal) -> Result<()> {
                                 .with_approval_index(approval_idx)
                                 .with_mode_picker(mode_picker)
                                 .with_preset_picker(preset_picker)
+                                .with_list_picker_index(list_picker_idx)
                                 .with_sidebar_visible(sidebar_visible)
                                 .with_tick(tick),
                             area,
@@ -325,6 +346,10 @@ pub fn run_integrated_loop(terminal: &mut Terminal) -> Result<()> {
                 }
                 if mode_picker.is_some() || preset_picker.is_some() {
                     handle_mode_picker_key(&key, &mut mode_picker, &mut preset_picker);
+                    continue;
+                }
+                if let Some(picker) = scene.list_picker.as_ref() {
+                    handle_list_picker_key(&key, picker, &mut list_picker_idx);
                     continue;
                 }
                 if let Some(prompt) = scene.prompt_input.as_ref() {
@@ -771,6 +796,54 @@ fn current_preset_idx(scene: &SceneState) -> usize {
         Some("flash") => 1,
         Some("pro") => 2,
         _ => 0,
+    }
+}
+
+fn handle_list_picker_key(
+    key: &crossterm::event::KeyEvent,
+    picker: &crate::state::ListPicker,
+    selected: &mut usize,
+) {
+    let n = picker.options.len();
+    if n == 0 {
+        if matches!(key.code, KeyCode::Esc) {
+            emit_event(serde_json::json!({
+                "event": "list-picker-response",
+                "id": picker.id,
+                "cancelled": true,
+            }));
+        }
+        return;
+    }
+    match key.code {
+        KeyCode::Up | KeyCode::Char('k') => {
+            *selected = if *selected == 0 { n - 1 } else { *selected - 1 };
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            *selected = (*selected + 1) % n;
+        }
+        KeyCode::Char(d) if d.is_ascii_digit() => {
+            let pick = d.to_digit(10).unwrap_or(0) as usize;
+            if pick >= 1 && pick <= n {
+                *selected = pick - 1;
+            }
+        }
+        KeyCode::Enter => {
+            let chosen = (*selected).min(n - 1);
+            emit_event(serde_json::json!({
+                "event": "list-picker-response",
+                "id": picker.id,
+                "key": picker.options[chosen].key,
+            }));
+        }
+        KeyCode::Esc => {
+            emit_event(serde_json::json!({
+                "event": "list-picker-response",
+                "id": picker.id,
+                "cancelled": true,
+            }));
+        }
+        _ => {}
     }
 }
 

--- a/crates/reasonix-render/src/state.rs
+++ b/crates/reasonix-render/src/state.rs
@@ -71,6 +71,32 @@ pub struct SceneState {
     pub at_state: Option<AtState>,
     #[serde(default)]
     pub prompt_input: Option<PromptInput>,
+    #[serde(default)]
+    pub list_picker: Option<ListPicker>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct ListPicker {
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub title: String,
+    #[serde(default)]
+    pub hint: Option<String>,
+    #[serde(default)]
+    pub options: Vec<ListPickerOption>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct ListPickerOption {
+    #[serde(default)]
+    pub key: String,
+    #[serde(default)]
+    pub label: String,
+    #[serde(default)]
+    pub sublabel: Option<String>,
+    #[serde(default)]
+    pub meta: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]

--- a/crates/reasonix-render/src/whole_screen/cards/mod.rs
+++ b/crates/reasonix-render/src/whole_screen/cards/mod.rs
@@ -141,6 +141,27 @@ fn render_idle_banner(buf: &mut Buffer, area: Rect, start_row: u16) {
         tcol = paint_str(buf, tcol, row, " ", FG2, BG, Modifier::empty());
         tcol = paint_str(buf, tcol, row, label, FG2, BG, Modifier::empty());
     }
+
+    // Starter hints — surfaces the most-likely-useful slash commands
+    // upfront, matches the Node TUI WelcomeBanner; helps brand-new
+    // users discover the surface without /help.
+    let starters: [(&str, &str); 4] = [
+        ("/help", "see all commands"),
+        ("/cost", "session spend + tokens"),
+        ("/init", "scan repo into REASONIX.md"),
+        ("/sessions", "switch / resume past sessions"),
+    ];
+    for (i, (cmd, desc)) in starters.iter().enumerate() {
+        let r = start_row + 3 + i as u16;
+        if r >= bottom {
+            break;
+        }
+        paint_rail(buf, area, r, OK);
+        let mut sc = area.x + 4;
+        sc = paint_str(buf, sc, r, cmd, DS, BG, Modifier::BOLD);
+        sc = paint_str(buf, sc, r, "  ", FG3, BG, Modifier::empty());
+        paint_str(buf, sc, r, desc, FG2, BG, Modifier::empty());
+    }
 }
 
 pub(super) fn total_cards_height(state: &SceneState, body_width: u16) -> u16 {

--- a/crates/reasonix-render/src/whole_screen/cards/mod.rs
+++ b/crates/reasonix-render/src/whole_screen/cards/mod.rs
@@ -218,7 +218,8 @@ fn card_height(card: &SceneCard, body_width: u16) -> u16 {
     match card.kind.as_str() {
         "user" | "reasoning" | "think" | "thinking" | "assistant" | "streaming" | "diff"
         | "cmd" | "fileview" | "search" | "subagent" | "confirm" | "await" | "await_input"
-        | "error" | "info" | "warn" | "usage" => 1 + body_lines + 1,
+        | "error" | "info" | "warn" | "usage" | "doctor" | "memory" | "ctx" | "plan-card"
+        | "task" => 1 + body_lines + 1,
         "todo" | "plan" => {
             let items = card
                 .body
@@ -259,6 +260,11 @@ fn render_card(
         "info" => notify::render_info_card(buf, area, row, card, super::theme::INFO, "ⓘ"),
         "warn" => notify::render_info_card(buf, area, row, card, super::theme::WARN, "▲"),
         "usage" => notify::render_info_card(buf, area, row, card, super::theme::DS_BRIGHT, "$"),
+        "doctor" => notify::render_info_card(buf, area, row, card, super::theme::OK, "✚"),
+        "memory" => notify::render_info_card(buf, area, row, card, super::theme::DS_PURPLE, "◈"),
+        "ctx" => notify::render_info_card(buf, area, row, card, super::theme::INFO, "▦"),
+        "plan-card" => notify::render_info_card(buf, area, row, card, super::theme::DS_PURPLE, "◆"),
+        "task" => notify::render_info_card(buf, area, row, card, super::theme::DS_BRIGHT, "▸"),
         _ => row,
     }
 }

--- a/crates/reasonix-render/src/whole_screen/dock.rs
+++ b/crates/reasonix-render/src/whole_screen/dock.rs
@@ -279,9 +279,19 @@ fn right_block_width(pairs: &[(&str, &str)]) -> u16 {
 fn render_status_bar(buf: &mut Buffer, area: Rect, row: u16, w: u16, state: &SceneState) {
     let mut col = area.x + 1;
 
-    paint(buf, col, row, '●', OK, BG, Modifier::BOLD);
+    // Brand dot pulses to a brighter color while busy so the user can
+    // tell the agent is actually doing something even when the cards
+    // pane is scrolled off-screen. Visual width stays at 1 cell so the
+    // rest of the status bar layout doesn't shift.
+    let dot_color = if state.busy { DS_BRIGHT } else { OK };
+    paint(buf, col, row, '●', dot_color, BG, Modifier::BOLD);
     col = col.saturating_add(2);
-    col = paint_str(buf, col, row, "reasonix", DS_BRIGHT, BG, Modifier::BOLD);
+    let label = if state.busy {
+        activity_label(state.activity.as_deref())
+    } else {
+        "reasonix"
+    };
+    col = paint_str(buf, col, row, label, DS_BRIGHT, BG, Modifier::BOLD);
     col = col.saturating_add(2);
 
     if let Some(mode) = state.edit_mode.as_ref() {
@@ -359,6 +369,18 @@ fn render_status_bar(buf: &mut Buffer, area: Rect, row: u16, w: u16, state: &Sce
             let rcol = area.x + w.saturating_sub(bal_w);
             paint_str(buf, rcol, row, &bal_text, FG2, BG, Modifier::empty());
         }
+    }
+}
+
+fn activity_label(activity: Option<&str>) -> &'static str {
+    match activity.unwrap_or("") {
+        "reasoning" | "thinking" => "reasoning…",
+        "streaming" => "streaming…",
+        "tool" | "tools" => "running tool…",
+        "planning" | "plan" => "planning…",
+        "compacting" | "compact" => "compacting context…",
+        "" => "working…",
+        _ => "working…",
     }
 }
 

--- a/crates/reasonix-render/src/whole_screen/list_picker.rs
+++ b/crates/reasonix-render/src/whole_screen/list_picker.rs
@@ -1,0 +1,143 @@
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::Modifier;
+use unicode_width::UnicodeWidthStr;
+
+use crate::state::ListPicker;
+
+use super::paint::{paint, paint_str};
+use super::theme::{BG, DS, DS_BRIGHT, FG, FG2, FG3};
+
+pub fn render_list_picker(buf: &mut Buffer, area: Rect, picker: &ListPicker, selected: usize) {
+    if picker.options.is_empty() {
+        return;
+    }
+    let max_label_w = picker
+        .options
+        .iter()
+        .map(|o| o.label.width() + o.sublabel.as_deref().map(|s| s.width() + 4).unwrap_or(0))
+        .max()
+        .unwrap_or(20);
+    let max_meta_w = picker
+        .options
+        .iter()
+        .map(|o| o.meta.as_deref().map(UnicodeWidthStr::width).unwrap_or(0))
+        .max()
+        .unwrap_or(0);
+    let title_w = picker.title.width();
+    let inner_w = title_w
+        .max(max_label_w + if max_meta_w > 0 { max_meta_w + 4 } else { 0 })
+        .max(40);
+    let popup_w = (inner_w as u16 + 6).min(area.width.saturating_sub(4));
+    if popup_w < 30 {
+        return;
+    }
+    let visible_cap = (area.height as usize).saturating_sub(6).clamp(3, 16);
+    let visible = picker.options.len().min(visible_cap) as u16;
+    let popup_h = 4 + visible + if picker.hint.is_some() { 1 } else { 0 };
+    if popup_h > area.height {
+        return;
+    }
+    let popup_x = area.x + (area.width.saturating_sub(popup_w)) / 2;
+    let popup_y = area.y + (area.height.saturating_sub(popup_h)) / 2;
+    let popup = Rect::new(popup_x, popup_y, popup_w, popup_h);
+
+    draw_box(buf, popup);
+    paint_str(
+        buf,
+        popup.x + 2,
+        popup.y + 1,
+        &picker.title,
+        DS_BRIGHT,
+        BG,
+        Modifier::BOLD,
+    );
+    let count_text = format!(
+        "{} option{}",
+        picker.options.len(),
+        if picker.options.len() == 1 { "" } else { "s" }
+    );
+    let ccol = popup.x + popup.width.saturating_sub(count_text.width() as u16 + 2);
+    paint_str(
+        buf,
+        ccol,
+        popup.y + 1,
+        &count_text,
+        FG3,
+        BG,
+        Modifier::empty(),
+    );
+
+    let chosen = selected.min(picker.options.len().saturating_sub(1));
+    let visible_usz = visible as usize;
+    let start = if chosen >= visible_usz {
+        chosen + 1 - visible_usz
+    } else {
+        0
+    };
+    let row_top = popup.y + 3;
+    for (i, opt) in picker
+        .options
+        .iter()
+        .enumerate()
+        .skip(start)
+        .take(visible_usz)
+    {
+        let row = row_top + (i - start) as u16;
+        let is_sel = i == chosen;
+        let label_fg = if is_sel { FG } else { DS_BRIGHT };
+        let modifier = if is_sel {
+            Modifier::BOLD
+        } else {
+            Modifier::empty()
+        };
+        if is_sel {
+            paint_str(buf, popup.x + 2, row, "▸", DS_BRIGHT, BG, Modifier::BOLD);
+        }
+        let mut col = popup.x + 4;
+        col = paint_str(buf, col, row, &opt.label, label_fg, BG, modifier);
+        if let Some(sub) = opt.sublabel.as_deref() {
+            col = col.saturating_add(2);
+            paint_str(buf, col, row, sub, FG2, BG, Modifier::empty());
+        }
+        if let Some(meta) = opt.meta.as_deref() {
+            let mw = meta.width() as u16;
+            let mcol = popup.x + popup.width.saturating_sub(mw + 2);
+            paint_str(buf, mcol, row, meta, FG3, BG, Modifier::ITALIC);
+        }
+    }
+
+    let hint_row = popup.y + popup.height.saturating_sub(2);
+    let hint = picker
+        .hint
+        .as_deref()
+        .unwrap_or("↑↓ move  ↵ select  esc cancel");
+    paint_str(buf, popup.x + 2, hint_row, hint, FG2, BG, Modifier::empty());
+}
+
+fn draw_box(buf: &mut Buffer, area: Rect) {
+    let w = area.width;
+    if w < 2 {
+        return;
+    }
+    let top = area.y;
+    let bot = area.y + area.height - 1;
+    let right = area.x + w - 1;
+    paint(buf, area.x, top, '╭', DS, BG, Modifier::empty());
+    paint(buf, right, top, '╮', DS, BG, Modifier::empty());
+    for x in 1..w - 1 {
+        paint(buf, area.x + x, top, '─', DS, BG, Modifier::empty());
+    }
+    for y in (top + 1)..bot {
+        paint(buf, area.x, y, '│', DS, BG, Modifier::empty());
+        paint(buf, right, y, '│', DS, BG, Modifier::empty());
+        for x in 1..w - 1 {
+            paint(buf, area.x + x, y, ' ', FG, BG, Modifier::empty());
+        }
+    }
+    paint(buf, area.x, bot, '╰', DS, BG, Modifier::empty());
+    paint(buf, right, bot, '╯', DS, BG, Modifier::empty());
+    for x in 1..w - 1 {
+        paint(buf, area.x + x, bot, '─', DS, BG, Modifier::empty());
+    }
+}

--- a/crates/reasonix-render/src/whole_screen/mod.rs
+++ b/crates/reasonix-render/src/whole_screen/mod.rs
@@ -3,6 +3,7 @@ mod boot;
 mod cards;
 mod demo;
 mod dock;
+mod list_picker;
 mod markdown;
 mod md_render;
 mod mode_picker;
@@ -31,6 +32,7 @@ pub use selection::{cards_layout, extract_text, CardsLayout, ScrollbarGeom, Sele
 use approval::render_approval;
 use boot::render_scroll;
 use dock::render_dock;
+use list_picker::render_list_picker;
 use mode_picker::{mode_picker_options, preset_picker_options, render_picker};
 use overlay::{render_slash_arg_overlay, render_slash_overlay};
 use overlay_at::render_at_overlay;
@@ -50,6 +52,7 @@ pub struct WholeScreen<'a> {
     approval_idx: usize,
     mode_picker_idx: Option<usize>,
     preset_picker_idx: Option<usize>,
+    list_picker_idx: usize,
     sidebar_visible: bool,
     tick: u32,
 }
@@ -66,6 +69,7 @@ impl<'a> WholeScreen<'a> {
             approval_idx: 0,
             mode_picker_idx: None,
             preset_picker_idx: None,
+            list_picker_idx: 0,
             sidebar_visible: true,
             tick: 0,
         }
@@ -120,6 +124,11 @@ impl<'a> WholeScreen<'a> {
         self.preset_picker_idx = idx;
         self
     }
+
+    pub fn with_list_picker_index(mut self, idx: usize) -> Self {
+        self.list_picker_idx = idx;
+        self
+    }
 }
 
 impl Widget for WholeScreen<'_> {
@@ -164,6 +173,9 @@ impl Widget for WholeScreen<'_> {
                 &opts,
                 idx,
             );
+        }
+        if let Some(picker) = self.state.list_picker.as_ref() {
+            render_list_picker(buf, area, picker, self.list_picker_idx);
         }
     }
 }

--- a/crates/reasonix-render/tests/whole_screen.rs
+++ b/crates/reasonix-render/tests/whole_screen.rs
@@ -68,17 +68,16 @@ fn homepage_input_box_drawn_with_corners() {
 #[test]
 fn homepage_status_bar_has_segments_and_ctx_meter() {
     let rows = draw(&demo_state(), 120, 36);
+    // Status row carries "ctx" + a context bar + cost — find by ctx
+    // since the brand cell now swaps to an activity label when busy.
     let last = rows
         .iter()
         .rev()
-        .find(|r| r.contains("reasonix"))
+        .find(|r| r.contains("ctx") && r.contains("cache"))
         .expect("status row");
     assert!(last.contains("●"), "brand dot missing");
-    assert!(last.contains("ctx"));
     assert!(last.contains("19.2k/128k"));
-    assert!(last.contains("cache"));
     assert!(last.contains("87%"));
-    assert!(last.contains("cost"));
     assert!(last.contains("$0.043"));
     assert!(last.contains("▰") && last.contains("▱"), "ctx bar segments");
 }
@@ -305,6 +304,33 @@ fn catalog_state() -> reasonix_render::state::SceneState {
         ),
         ..Default::default()
     }
+}
+
+#[test]
+fn idle_banner_includes_starter_command_hints() {
+    let rows = draw(&SceneState::default(), 120, 30);
+    let all = joined(&rows);
+    assert!(all.contains("● idle"), "idle marker");
+    assert!(all.contains("/help"), "starter /help");
+    assert!(all.contains("/cost"), "starter /cost");
+    assert!(all.contains("/init"), "starter /init");
+    assert!(all.contains("/sessions"), "starter /sessions");
+}
+
+#[test]
+fn status_bar_shows_activity_phase_when_busy() {
+    let state = SceneState {
+        busy: true,
+        activity: Some("reasoning".to_string()),
+        ..Default::default()
+    };
+    let rows = draw(&state, 140, 36);
+    let last = rows
+        .iter()
+        .rev()
+        .find(|r| r.contains("reasoning"))
+        .expect("status row with phase label");
+    assert!(last.contains("●"), "brand dot visible: {last}");
 }
 
 #[test]

--- a/crates/reasonix-render/tests/whole_screen.rs
+++ b/crates/reasonix-render/tests/whole_screen.rs
@@ -308,6 +308,44 @@ fn catalog_state() -> reasonix_render::state::SceneState {
 }
 
 #[test]
+fn renders_doctor_memory_ctx_plan_card_task_kinds() {
+    let cards = [
+        ("doctor", "/doctor", "✓ git\n✕ docker"),
+        (
+            "memory",
+            "memory · 2",
+            "· [user] ds engineer\n· [project] rust port",
+        ),
+        (
+            "ctx",
+            "context breakdown",
+            "8.0k / 128k used (6%)\nsystem 1.2k",
+        ),
+        ("plan-card", "rewrite renderer", "○ scaffold\n◆ port cards"),
+        ("task", "build · 1/3", "✓ install\n◆ compile"),
+    ];
+    for (kind, summary, body) in cards {
+        let state = SceneState {
+            cards: vec![SceneCard {
+                kind: kind.to_string(),
+                summary: summary.to_string(),
+                body: Some(body.to_string()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let rows = draw(&state, 140, 30);
+        let all = joined(&rows);
+        assert!(all.contains(summary), "{kind} summary missing: {summary}");
+        let first_body_line = body.lines().next().unwrap();
+        assert!(
+            all.contains(first_body_line),
+            "{kind} body missing: {first_body_line}"
+        );
+    }
+}
+
+#[test]
 fn dashboard_url_renders_in_boot_block() {
     let state = SceneState {
         model: Some("deepseek-v3.2-coder".to_string()),

--- a/crates/reasonix-render/tests/whole_screen.rs
+++ b/crates/reasonix-render/tests/whole_screen.rs
@@ -308,6 +308,41 @@ fn catalog_state() -> reasonix_render::state::SceneState {
 }
 
 #[test]
+fn list_picker_modal_renders_when_scene_carries_one() {
+    use reasonix_render::state::{ListPicker, ListPickerOption, SceneState};
+    let state = SceneState {
+        list_picker: Some(ListPicker {
+            id: "pick-1".to_string(),
+            title: "switch session".to_string(),
+            hint: Some("↑↓ move  ↵ open".to_string()),
+            options: vec![
+                ListPickerOption {
+                    key: "s-2026-05-17".to_string(),
+                    label: "s-2026-05-17".to_string(),
+                    sublabel: Some("branch main".to_string()),
+                    meta: Some("2h ago".to_string()),
+                },
+                ListPickerOption {
+                    key: "s-2026-05-16".to_string(),
+                    label: "s-2026-05-16".to_string(),
+                    sublabel: None,
+                    meta: Some("1d ago".to_string()),
+                },
+            ],
+        }),
+        ..Default::default()
+    };
+    let rows = draw(&state, 120, 30);
+    let all = joined(&rows);
+    assert!(all.contains("switch session"), "picker title missing");
+    assert!(all.contains("s-2026-05-17"), "first option missing");
+    assert!(all.contains("s-2026-05-16"), "second option missing");
+    assert!(all.contains("branch main"), "sublabel missing");
+    assert!(all.contains("2h ago"), "meta missing");
+    assert!(all.contains("↵"), "hint visible");
+}
+
+#[test]
 fn renders_doctor_memory_ctx_plan_card_task_kinds() {
     let cards = [
         ("doctor", "/doctor", "✓ git\n✕ docker"),

--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -36,6 +36,7 @@ import {
   createRustKeystrokeReader,
   nullKeystrokeReader,
 } from "../ui/scene/input-adapter.js";
+import { cancelAllListPickers, resolveListPicker } from "../ui/scene/list-picker-store.js";
 import { makeNullStdin } from "../ui/scene/null-stdin.js";
 import { makeNullStdout } from "../ui/scene/null-stdout.js";
 import { cancelAllPromptInputs, resolvePromptInput } from "../ui/scene/prompt-input-store.js";
@@ -451,6 +452,7 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
       } else if (event.event === "exit") {
         void (async () => {
           cancelAllPromptInputs();
+          cancelAllListPickers();
           await stopAndSaveCpuProfile();
           process.exit(0);
         })();
@@ -464,6 +466,8 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
         presetSetRef.current?.(event.value);
       } else if (event.event === "prompt-response") {
         resolvePromptInput(event.id, event.cancelled ? null : (event.text ?? ""));
+      } else if (event.event === "list-picker-response") {
+        resolveListPicker(event.id, event.cancelled ? null : (event.key ?? null));
       }
       // interrupt: no-op for now; terminal SIGINT already reaches Node.
     });

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -2635,6 +2635,34 @@ function AppInner({
     };
   }, [pendingModelPicker, models, loop, agentStore, setPreset, log]);
 
+  // MCP hub: the full Live/Marketplace tabbed modal is heavy and
+  // interactive (install / configure flows). Under integrated mode
+  // dump a read-only inventory of currently-connected servers so the
+  // user at least sees what's wired up; full hub still works in non-
+  // integrated mode for now.
+  useEffect(() => {
+    if (!pendingMcpHub) return;
+    if (!isIntegratedRendererRequested()) return;
+    const lines: string[] = [];
+    if (liveMcpServers.length === 0) {
+      lines.push("(no MCP servers connected)");
+    } else {
+      for (const s of liveMcpServers) {
+        const tools = s.report.tools.supported ? s.report.tools.items.length : 0;
+        const res = s.report.resources.supported ? s.report.resources.items.length : 0;
+        const prompts = s.report.prompts.supported ? s.report.prompts.items.length : 0;
+        lines.push(
+          `· ${s.label}  —  ${tools} tool${tools === 1 ? "" : "s"}, ${res} resource${res === 1 ? "" : "s"}, ${prompts} prompt${prompts === 1 ? "" : "s"}`,
+        );
+        lines.push(`    ${s.spec}`);
+      }
+    }
+    lines.push("");
+    lines.push("Install / configure flows are only available in non-integrated mode.");
+    log.pushInfo(`MCP hub (live)\n${lines.join("\n")}`);
+    setPendingMcpHub(null);
+  }, [pendingMcpHub, liveMcpServers, log]);
+
   // Auto-start the dashboard once the TUI is mounted unless the user
   // opted out with --no-dashboard. The whole point is discoverability:
   // most users had no idea /dashboard existed, so the URL needs to be

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -2555,6 +2555,86 @@ function AppInner({
     };
   }, [pendingThemePicker, themeName, setThemeName, log]);
 
+  useEffect(() => {
+    if (!pendingCheckpointPicker) return;
+    if (!isIntegratedRendererRequested()) return;
+    if (checkpointPickerList.length === 0) return;
+    let cancelled = false;
+    requestListPicker({
+      title: "restore checkpoint",
+      hint: "↑↓ move  ↵ restore  esc cancel",
+      options: checkpointPickerList.map((c) => ({
+        key: c.id,
+        label: c.name,
+        sublabel: c.id.slice(0, 7),
+        meta: fmtAgo(c.createdAt),
+      })),
+    })
+      .then((picked) => {
+        if (cancelled) return;
+        setPendingCheckpointPicker(false);
+        if (!picked) return;
+        const target = checkpointPickerList.find((c) => c.id === picked);
+        if (!target) return;
+        const result = restoreCheckpoint(currentRootDir, target.id);
+        const lines = [
+          `restored "${target.name}" (${target.id.slice(0, 7)}, ${fmtAgo(target.createdAt)})`,
+        ];
+        if (result.restored.length > 0) {
+          lines.push(`  wrote ${result.restored.length} file(s)`);
+        }
+        if (result.removed.length > 0) {
+          lines.push(`  removed ${result.removed.length} file(s)`);
+        }
+        if (result.skipped.length > 0) {
+          lines.push(`  skipped ${result.skipped.length} file(s)`);
+        }
+        log.pushInfo(lines.join("\n"));
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [pendingCheckpointPicker, checkpointPickerList, currentRootDir, log]);
+
+  useEffect(() => {
+    if (!pendingModelPicker) return;
+    if (!isIntegratedRendererRequested()) return;
+    const modelList = models ?? [];
+    if (modelList.length === 0) return;
+    let cancelled = false;
+    requestListPicker({
+      title: "pick model",
+      hint: "↑↓ move  ↵ select  esc cancel",
+      options: modelList.map((m) => ({
+        key: m,
+        label: m,
+        sublabel: m === loop.model ? "current" : undefined,
+      })),
+    })
+      .then((picked) => {
+        if (cancelled) return;
+        setPendingModelPicker(false);
+        if (!picked) return;
+        loop.configure({ model: picked, autoEscalate: false });
+        agentStore.dispatch({ type: "session.model.change", model: picked });
+        const inferred =
+          picked === "deepseek-v4-pro" ? "pro" : picked === "deepseek-v4-flash" ? "flash" : null;
+        setPreset(inferred ?? "flash");
+        agentStore.dispatch({ type: "session.preset.change", preset: inferred });
+        if (inferred) {
+          try {
+            savePreset(inferred);
+          } catch {}
+        }
+        log.pushInfo(`model: ${picked}`);
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [pendingModelPicker, models, loop, agentStore, setPreset, log]);
+
   // Auto-start the dashboard once the TUI is mounted unless the user
   // opted out with --no-dashboard. The whole point is discoverability:
   // most users had no idea /dashboard existed, so the URL needs to be

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -174,7 +174,10 @@ import { openUrl } from "./open-url.js";
 import { formatLongPaste } from "./paste-collapse.js";
 import { extractOpenQuestionsSection } from "./plan-open-questions.js";
 import { PRESETS, resolvePreset } from "./presets.js";
+import { requestListPicker } from "./scene/list-picker-store.js";
+import { getActiveListPicker, subscribeListPicker } from "./scene/list-picker-store.js";
 import { getActivePromptInput, subscribePromptInput } from "./scene/prompt-input-store.js";
+import { isIntegratedRendererRequested } from "./scene/trace.js";
 import { type McpServerSummary, handleSlash, parseSlash, suggestSlashCommands } from "./slash.js";
 import { TurnTranslator } from "./state/TurnTranslator.js";
 import { cardsToDashboardMessages } from "./state/cards-to-messages.js";
@@ -1436,6 +1439,16 @@ function AppInner({
     [activePromptInput],
   );
 
+  const activeListPicker = useSyncExternalStore(
+    subscribeListPicker,
+    getActiveListPicker,
+    getActiveListPicker,
+  );
+  const listPickerJson = useMemo(
+    () => (activeListPicker ? JSON.stringify(activeListPicker) : undefined),
+    [activeListPicker],
+  );
+
   useEffect(() => {
     setSessionsPickerList(listSessionsForWorkspace(currentRootDir));
   }, [currentRootDir]);
@@ -1569,6 +1582,7 @@ function AppInner({
     approvalJson,
     atStateJson,
     promptInputJson,
+    listPickerJson,
   });
 
   // Ctrl+P / Ctrl+N from PromptInput route here. When any input-prefix
@@ -2472,6 +2486,74 @@ function AppInner({
   // pill the moment the server is up. Updated by both the auto-start
   // effect below and the explicit /dashboard slash path (via
   // startDashboard).
+
+  // Integrated-mode picker bridge: under REASONIX_RENDERER_INTEGRATED=1
+  // the rust child owns the alt-screen, so React modals (SessionPicker,
+  // ThemePicker) aren't visible. Intercept the pendingXPicker state
+  // changes and route through scene-driven requestListPicker, dispatch
+  // the choice to the same handlers the modal would call.
+  useEffect(() => {
+    if (!pendingSessionsPicker) return;
+    if (!isIntegratedRendererRequested()) return;
+    if (sessionsPickerList.length === 0) return;
+    let cancelled = false;
+    requestListPicker({
+      title: "switch session",
+      hint: "↑↓ move  ↵ open  esc cancel",
+      options: sessionsPickerList.map((s) => ({
+        key: s.name,
+        label: s.name,
+        sublabel: s.meta.branch ? `branch ${s.meta.branch}` : undefined,
+        meta: fmtAgo(s.mtime.getTime()),
+      })),
+    })
+      .then((picked) => {
+        if (cancelled) return;
+        setPendingSessionsPicker(false);
+        if (picked && onSwitchSession) onSwitchSession(picked);
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [pendingSessionsPicker, sessionsPickerList, onSwitchSession]);
+
+  useEffect(() => {
+    if (!pendingThemePicker) return;
+    if (!isIntegratedRendererRequested()) return;
+    let cancelled = false;
+    const active = themeName;
+    const preference = loadTheme() ?? "auto";
+    const all = ["auto", ...listThemeNames()];
+    requestListPicker({
+      title: "pick theme",
+      hint: "↑↓ move  ↵ select  esc cancel",
+      options: all.map((name) => ({
+        key: name,
+        label: name,
+        sublabel:
+          name === preference
+            ? `saved · active: ${active}`
+            : name === active
+              ? "active"
+              : undefined,
+      })),
+    })
+      .then((picked) => {
+        if (cancelled) return;
+        setPendingThemePicker(false);
+        if (!picked) return;
+        const choice = picked as ThemeChoice;
+        saveTheme(choice);
+        const resolved = resolveThemePreference(choice, process.env.REASONIX_THEME);
+        setThemeName(resolved);
+        log.pushInfo(`theme: ${choice} (active: ${resolved})`);
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [pendingThemePicker, themeName, setThemeName, log]);
 
   // Auto-start the dashboard once the TUI is mounted unless the user
   // opted out with --no-dashboard. The whole point is discoverability:

--- a/src/cli/ui/hooks/useSceneTrace.ts
+++ b/src/cli/ui/hooks/useSceneTrace.ts
@@ -144,9 +144,123 @@ export function toSceneCard(card: Card): SceneCard {
       };
     case "tip":
       return { kind: "info", summary, body: formatTipBody(card), ts: card.ts };
+    case "doctor":
+      return {
+        kind: "doctor",
+        summary: "/doctor",
+        body: formatDoctorBody(card),
+        ts: card.ts,
+      };
+    case "memory":
+      return {
+        kind: "memory",
+        summary: `memory · ${card.entries.length} entr${card.entries.length === 1 ? "y" : "ies"}`,
+        body: formatMemoryBody(card),
+        ts: card.ts,
+        meta: `${formatTokens(card.tokens)} tok`,
+      };
+    case "ctx":
+      return {
+        kind: "ctx",
+        summary: card.text,
+        body: formatCtxBody(card),
+        ts: card.ts,
+      };
+    case "plan":
+      return {
+        kind: "plan-card",
+        summary: card.title,
+        body: formatPlanBody(card),
+        ts: card.ts,
+        meta: card.variant,
+      };
+    case "task":
+      return {
+        kind: "task",
+        summary: `${card.title} · ${card.index + 1}/${card.total}`,
+        body: formatTaskBody(card),
+        ts: card.ts,
+        meta: card.status,
+      };
     default:
       return { kind: card.kind, summary };
   }
+}
+
+function formatDoctorBody(card: Extract<Card, { kind: "doctor" }>): string {
+  return card.checks
+    .map((c) => {
+      const glyph = c.level === "ok" ? "✓" : c.level === "warn" ? "▲" : "✕";
+      return `${glyph} ${c.label}  —  ${c.detail}`;
+    })
+    .join("\n");
+}
+
+function formatMemoryBody(card: Extract<Card, { kind: "memory" }>): string {
+  if (card.entries.length === 0) return "(no memories)";
+  return card.entries.map((e) => `· [${e.category}] ${e.summary}`).join("\n");
+}
+
+function formatCtxBody(card: Extract<Card, { kind: "ctx" }>): string {
+  const used = card.systemTokens + card.toolsTokens + card.logTokens + card.inputTokens;
+  const pct = card.ctxMax > 0 ? Math.round((used / card.ctxMax) * 100) : 0;
+  const lines = [
+    `${formatTokens(used)} / ${formatTokens(card.ctxMax)} used (${pct}%)`,
+    `system ${formatTokens(card.systemTokens)}    tools ${formatTokens(card.toolsTokens)} (${card.toolsCount})    log ${formatTokens(card.logTokens)} (${card.logMessages} msgs)    input ${formatTokens(card.inputTokens)}`,
+  ];
+  if (card.topTools.length > 0) {
+    lines.push("top tools:");
+    for (const t of card.topTools.slice(0, 5)) {
+      lines.push(`  · ${t.name}  ${formatTokens(t.tokens)} (turn ${t.turn})`);
+    }
+  }
+  return lines.join("\n");
+}
+
+function formatPlanBody(card: Extract<Card, { kind: "plan" }>): string {
+  return card.steps
+    .map((s) => {
+      const glyph = (() => {
+        switch (s.status) {
+          case "done":
+            return "✓";
+          case "running":
+            return "◆";
+          case "failed":
+            return "✕";
+          case "blocked":
+            return "⊘";
+          case "skipped":
+            return "·";
+          default:
+            return "○";
+        }
+      })();
+      return `${glyph} ${s.title}`;
+    })
+    .join("\n");
+}
+
+function formatTaskBody(card: Extract<Card, { kind: "task" }>): string {
+  if (card.steps.length === 0) return "(no steps)";
+  return card.steps
+    .map((s) => {
+      const glyph = (() => {
+        switch (s.status) {
+          case "done":
+            return "✓";
+          case "running":
+            return "◆";
+          case "failed":
+            return "✕";
+          default:
+            return "○";
+        }
+      })();
+      const detail = s.detail ? `  — ${s.detail}` : "";
+      return `${glyph} ${s.title}${detail}`;
+    })
+    .join("\n");
 }
 
 function formatUsageBody(card: Extract<Card, { kind: "usage" }>): string {

--- a/src/cli/ui/hooks/useSceneTrace.ts
+++ b/src/cli/ui/hooks/useSceneTrace.ts
@@ -60,6 +60,8 @@ export type SceneTraceInput = {
   atStateJson?: string;
   /** Active text-input prompt — rust intercepts composer Enter to send the answer back as `prompt-response` instead of submitting it as a chat message. Used by /qq connect and friends under integrated mode. */
   promptInputJson?: string;
+  /** Active list picker — rust renders a modal of {key,label} options and posts the chosen key back as `list-picker-response`. Used by /sessions, /theme, /model, /restore under integrated mode. */
+  listPickerJson?: string;
 };
 
 export type SetupSceneInput = {
@@ -429,6 +431,7 @@ export function useSceneTrace(input: SceneTraceInput): void {
     approvalJson,
     atStateJson,
     promptInputJson,
+    listPickerJson,
   } = input;
   useEffect(() => {
     if (!isSceneTraceEnabled()) return;
@@ -468,6 +471,7 @@ export function useSceneTrace(input: SceneTraceInput): void {
       approval: parseApproval(approvalJson),
       atState: parseApproval(atStateJson),
       promptInput: parseApproval(promptInputJson),
+      listPicker: parseApproval(listPickerJson),
       fallbackCols,
       fallbackRows,
     });
@@ -508,6 +512,7 @@ export function useSceneTrace(input: SceneTraceInput): void {
     approvalJson,
     atStateJson,
     promptInputJson,
+    listPickerJson,
   ]);
 }
 

--- a/src/cli/ui/scene/list-picker-store.ts
+++ b/src/cli/ui/scene/list-picker-store.ts
@@ -1,0 +1,77 @@
+export type ListPickerOption = {
+  key: string;
+  label: string;
+  sublabel?: string;
+  meta?: string;
+};
+
+export type ListPicker = {
+  id: string;
+  title: string;
+  hint?: string;
+  options: ListPickerOption[];
+};
+
+type Listener = () => void;
+
+let active: ListPicker | null = null;
+const resolvers = new Map<string, (key: string | null) => void>();
+const listeners = new Set<Listener>();
+let counter = 0;
+
+function notify(): void {
+  for (const fn of listeners) fn();
+}
+
+export function getActiveListPicker(): ListPicker | null {
+  return active;
+}
+
+export function subscribeListPicker(fn: Listener): () => void {
+  listeners.add(fn);
+  return () => {
+    listeners.delete(fn);
+  };
+}
+
+export function requestListPicker(opts: {
+  title: string;
+  hint?: string;
+  options: ListPickerOption[];
+}): Promise<string | null> {
+  counter += 1;
+  const id = `list-${Date.now()}-${counter}`;
+  active = {
+    id,
+    title: opts.title,
+    hint: opts.hint,
+    options: opts.options,
+  };
+  notify();
+  return new Promise<string | null>((resolve) => {
+    resolvers.set(id, resolve);
+  });
+}
+
+export function resolveListPicker(id: string, key: string | null): void {
+  const resolver = resolvers.get(id);
+  if (resolver) {
+    resolvers.delete(id);
+    resolver(key);
+  }
+  if (active?.id === id) {
+    active = null;
+    notify();
+  }
+}
+
+export function cancelAllListPickers(): void {
+  for (const [id, resolver] of resolvers) {
+    resolver(null);
+    resolvers.delete(id);
+  }
+  if (active !== null) {
+    active = null;
+    notify();
+  }
+}

--- a/src/cli/ui/scene/renderer-process.ts
+++ b/src/cli/ui/scene/renderer-process.ts
@@ -8,7 +8,8 @@ export type RustEvent =
   | { event: "composer"; text: string }
   | { event: "mode-set"; value: "review" | "auto" | "yolo" }
   | { event: "preset-set"; value: "auto" | "flash" | "pro" }
-  | { event: "prompt-response"; id: string; text?: string; cancelled?: boolean };
+  | { event: "prompt-response"; id: string; text?: string; cancelled?: boolean }
+  | { event: "list-picker-response"; id: string; key?: string; cancelled?: boolean };
 
 export type RendererProcess = {
   emit(message: unknown): void;


### PR DESCRIPTION
## Summary

P0 feature-parity sweep so the rust integrated renderer covers the slash flows the Node TUI already supports. Survey turned up a bunch of card kinds rust silently dropped, four modal pickers that simply didn't render under integrated mode, and a couple of input-path bugs.

## Commits

1. **`feat(rust): render doctor/memory/ctx/plan-card/task + bracketed paste`** — five card kinds were round-tripping through scene as `{kind, summary}` only (default arm = 0 height = nothing drawn). Adds Node-side formatters that fill in a multi-line body, plus rust render arms reusing `render_info_card` with per-kind accent + glyph. Enables crossterm bracketed paste so multi-line pastes land in the composer (or the active prompt-input) cleanly instead of arriving as a key storm.

2. **`feat(scene): list-picker overlay — /sessions and /theme work in integrated mode`** — generic scene-driven list picker (mirrors prompt-input-store). New `list-picker-store.ts` singleton + `listPickerJson` scene field + rust `list_picker.rs` modal render + `handle_list_picker_key` (Up/Down/jk, digit jumps, Enter, Esc). chat.tsx routes the new `list-picker-response` event back to the resolver. App.tsx bridges `pendingSessionsPicker` / `pendingThemePicker` to `requestListPicker` via `useEffect` when integrated mode is active.

3. **`feat(scene): list-picker bridges for /restore and /model`** — same shape for the checkpoint picker (with short SHA + fmtAgo meta) and the model picker (marks current model). On pick, dispatches to `restoreCheckpoint` / `loop.configure` exactly like the Ink modals.

## What this unblocks under `REASONIX_RENDERER_INTEGRATED=1`

| Slash | Before | After |
|---|---|---|
| `/cost` | usage card invisible | rendered as `$ cost · turn N` card |
| `/doctor` | nothing | `✚ /doctor` card with per-check glyph + detail |
| `/memory` | nothing | `◈ memory` card with category-tagged entries |
| `/context` | nothing | `▦` card with used/cap + per-segment + top-tools |
| `/sessions` | hung | scene picker, ↑↓↵esc, opens chosen session |
| `/theme` | hung | scene picker showing active + preference markers |
| `/restore` (bare) | hung | scene picker with checkpoint list, restores on Enter |
| `/model` (bare) | hung | scene picker with model list, configures loop on Enter |
| Multi-line paste | arrived as keystrokes | inserted as one block (or single line for prompts; control chars stripped from secret prompts) |
| `/qq connect` | crashed screen / pre-existing fix | now uses scene-driven prompt-input |

## Test plan

- [x] `cargo +1.95.0 clippy -p reasonix-render --all-targets -- -D warnings`
- [x] `cargo fmt -p reasonix-render --check`
- [x] `cargo test -p reasonix-render` — 47 passing + 2 new (`renders_doctor_memory_ctx_plan_card_task_kinds`, `list_picker_modal_renders_when_scene_carries_one`)
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [ ] Smoke: `REASONIX_RENDERER=rust REASONIX_RENDERER_INTEGRATED=1 reasonix`, exercise `/cost`, `/doctor`, `/context`, `/memory`, `/sessions`, `/theme`, `/restore`, `/model`, multi-line paste.

## Out of scope (deferred to next PR)

- MCP hub (tabs Live/Marketplace, requires more complex render)
- Copy mode (visual selection with j/k/v/y)
- WelcomeBanner polish (taglines + starter hints — the existing idle banner covers basic empty state)
- Activity phase labels (reasoning/streaming/tool contextual labels)
