### PR TITLE
fix(dashboard): resolve dangling CSS var refs that left h3 / hr invisible

### DIFF
--- a/dashboard/app.css
+++ b/dashboard/app.css
@@ -59,7 +59,14 @@
 
   /* Spacing / radius — tiny radius (2px) keeps web feel without going SaaS */
   --r:    2px;
+  --r-sm: 4px;
   --r-md: 4px;
+
+  /* Inline elevation step above --bg-elev-2 for nested cards/dropdowns. */
+  --bg-elev-3: #1d2230;
+
+  /* Brand sweep — used by .md hr and the mini status bar fill. */
+  --gradient-rule: linear-gradient(90deg, var(--c-brand), var(--c-accent));
 }
 
 * { box-sizing: border-box; }
@@ -1157,7 +1164,7 @@ input:focus, textarea:focus, select:focus { border-color: var(--c-brand); }
   font-size: 16px;
 }
 .md h3 {
-  background: var(--grad-8);
+  background: var(--s2);
   font-size: 14px;
 }
 
@@ -2064,7 +2071,7 @@ input:focus, textarea:focus, select:focus { border-color: var(--c-brand); }
 }
 
 .modal-picker-row.selected {
-  border-color: var(--accent, #fcd34d);
+  border-color: var(--c-accent);
   background: var(--bg-elev-3, var(--bg-elev-2));
 }
 
@@ -2079,7 +2086,7 @@ input:focus, textarea:focus, select:focus { border-color: var(--c-brand); }
   color: var(--fg-2);
   padding: 1px 6px;
   border-radius: 999px;
-  background: var(--bg-elev-1, var(--bg-elev-2));
+  background: var(--bg-elev);
 }
 
 .modal-picker-subtitle {
@@ -2669,7 +2676,7 @@ input:focus, textarea:focus, select:focus { border-color: var(--c-brand); }
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  background: var(--bg-elev-1);
+  background: var(--bg-elev);
   border: 1px solid var(--bd);
   border-radius: 6px;
   padding: 6px 10px;
@@ -3054,6 +3061,9 @@ input:focus, textarea:focus, select:focus { border-color: var(--c-brand); }
   /* Borders */
   --bd:         #e4e7ed;
   --bd-strong:  #dcdfe6;
+
+  /* Elevation step above --bg-elev-2 in light mode — matches the surface scale. */
+  --bg-elev-3: #e4e7ed;
 }
 
 /* ── Light-theme fixups for hardcoded hex / rgba values ────────────────

--- a/tests/dashboard-css-vars.test.ts
+++ b/tests/dashboard-css-vars.test.ts
@@ -1,0 +1,43 @@
+/** Catches dangling `var(--foo)` references like the #919 invisible h3 — where var(--grad-8) was undefined and the heading text fell back to near-black on the dark page background. */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const cssPath = fileURLToPath(new URL("../dashboard/app.css", import.meta.url));
+const css = readFileSync(cssPath, "utf8");
+
+const STRIPPED = css.replace(/\/\*[\s\S]*?\*\//g, "");
+
+function definedVars(src: string): Set<string> {
+  const defs = new Set<string>();
+  const re = /(--[A-Za-z0-9-]+)\s*:/g;
+  let m: RegExpExecArray | null = re.exec(src);
+  while (m !== null) {
+    defs.add(m[1] ?? "");
+    m = re.exec(src);
+  }
+  defs.delete("");
+  return defs;
+}
+
+function referencedVars(src: string): Set<string> {
+  const refs = new Set<string>();
+  const re = /var\(\s*(--[A-Za-z0-9-]+)(\s*,\s*[^)]*)?\)/g;
+  let m: RegExpExecArray | null = re.exec(src);
+  while (m !== null) {
+    refs.add(m[1] ?? "");
+    m = re.exec(src);
+  }
+  refs.delete("");
+  return refs;
+}
+
+describe("dashboard/app.css — CSS custom property references", () => {
+  it("every var(--foo) resolves to a defined custom property (regression for #919)", () => {
+    const defs = definedVars(STRIPPED);
+    const refs = referencedVars(STRIPPED);
+    const undefinedRefs = [...refs].filter((r) => !defs.has(r)).sort();
+    expect(undefinedRefs).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- The most user-visible bug from #919: \`.md h3\` paints a near-black \`color: #0a0e14\` on a \`var(--grad-8)\` background, and \`--grad-8\` is never defined anywhere — so sub-headings render as black text on the dark page background (invisible).
- Walking the rest of the file with the new regression test turned up four more dangling \`var(--...)\` references in the same style.

## Root cause
\`dashboard/app.css\` had five \`var(--foo)\` references with no matching definition:

| Selector | Variable | Effect |
|---|---|---|
| \`.md h3\` | \`--grad-8\` | no background → black heading on dark bg (#919) |
| \`.md hr\` | \`--gradient-rule\` | no fill → markdown rules disappear |
| \`.status-bar-mini-fill\` | \`--gradient-rule\` | mini progress bar fill missing |
| \`.modal-picker-row.selected\` | \`--accent\` | typo for \`--c-accent\`; fallback masked it |
| \`.comment-card\` / \`.modal-picker-row .pill\` | \`--bg-elev-1\` | typo for \`--bg-elev\` |
| (referenced w/ fallback) | \`--bg-elev-3\`, \`--r-sm\` | tokens missing, intent obvious from fallback |

## Fix
- Define \`--gradient-rule\` (brand → accent sweep), \`--bg-elev-3\` (one step above \`--bg-elev-2\` in both themes), and \`--r-sm\` in \`:root\`.
- Replace \`--grad-8\` with \`--s2\` so the three heading levels stay distinct (sky → purple → teal). All three already exist in the chart palette so light-mode contrast follows automatically.
- Fix the two typo references (\`--accent\` → \`--c-accent\`, \`--bg-elev-1\` → \`--bg-elev\`).
- New \`tests/dashboard-css-vars.test.ts\` walks every \`var(--foo)\` in the stylesheet and asserts the variable is defined — so the next dangling reference fails the build instead of shipping invisible UI.

## Test plan
- \`npx vitest run tests/dashboard-css-vars.test.ts\` — passes; baseline removed before the fix would have failed with all five names.
- \`npm run verify\` — 206 files / 3120 tests pass.
- Manually loaded the dashboard with the regression test as a guard: \`### sub-headings\` now render on the teal pill with near-black text (matches the h1/h2 visual language); markdown \`---\` rules render as a brand→accent gradient bar.

Fixes #919

> Note on the issue's second ask ("没有切换风格的功能"): the dashboard already exposes a theme toggle button in the top nav (☀/☾ — wired via \`useTheme\` in \`dashboard/app.js\`). Worth surfacing more discoverably, but that's a separate UX change outside this fix.