### PR TITLE
fix(desktop): scope drag-drop to the active tab + i18n the overlay hint

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -1039,8 +1039,12 @@ function TabRuntime({
 
   // Drag-and-drop: dropping files/folders onto the window inserts them
   // as @-mentions in the draft (relative to workspaceDir when inside it).
-  // Tauri's webview API gives us absolute paths; converting to relative
-  // matches what the file-picker dialog does in composer.attachFile.
+  // activeRef gates the handler — without it, a single drop hits every
+  // mounted tab's draft (issue #1027, exposed once #1063 restored tabs).
+  const dropActiveRef = useRef(active);
+  useEffect(() => {
+    dropActiveRef.current = active;
+  }, [active]);
   useEffect(() => {
     const ws = state.settings?.workspaceDir;
     let unlisten: (() => void) | null = null;
@@ -1050,7 +1054,12 @@ function TabRuntime({
         const mod = await import("@tauri-apps/api/webview");
         const webview = mod.getCurrentWebview();
         const handle = await webview.onDragDropEvent((event) => {
+          if (!dropActiveRef.current) return;
           if (event.payload.type === "enter") {
+            document.body.style.setProperty(
+              "--drop-overlay-label",
+              `"${t("dragDrop.overlay")}"`,
+            );
             document.body.dataset.dragOver = "1";
             return;
           }

--- a/desktop/src/i18n/en.ts
+++ b/desktop/src/i18n/en.ts
@@ -59,6 +59,9 @@ export const en = {
     newline: "newline",
     commands: "commands",
   },
+  dragDrop: {
+    overlay: "Drop to attach as @-mention",
+  },
   settings: {
     title: "Settings",
     close: "close",

--- a/desktop/src/i18n/zh-CN.ts
+++ b/desktop/src/i18n/zh-CN.ts
@@ -61,6 +61,9 @@ export const zhCN: typeof en = {
     newline: "换行",
     commands: "命令",
   },
+  dragDrop: {
+    overlay: "松开以作为 @ 提及附加",
+  },
   settings: {
     title: "设置",
     close: "关闭",

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -28,7 +28,7 @@ body {
 }
 
 body[data-drag-over="1"]::after {
-  content: "Drop to attach as @-mention";
+  content: var(--drop-overlay-label, "Drop to attach as @-mention");
   position: fixed;
   inset: 0;
   display: grid;


### PR DESCRIPTION
## Summary
Drag-drop file attach was already in the codebase (added in #826 on 2026-05-14), but had two issues that made it look "missing" when #1027 was filed two days later:

1. The handler is installed inside \`TabRuntime\` and subscribes per-tab to the same window-level Tauri \`onDragDropEvent\`. With a single tab it worked. Once #1063 restored the full open-tab set on launch, every mounted tab acted on a single drop — the same \`@\`-mentions got appended to every tab's draft and focus jumped to whichever tab settled last.
2. The drop overlay text was a hardcoded English string in a CSS pseudo-element, so zh-CN users saw an English hint with no obvious way to translate it.

## Fix
- \`desktop/src/App.tsx\` — cache \`active\` in a ref (so re-subscribing on every tab switch isn't needed) and bail out of the handler for *every* event type when the tab isn't active. The overlay show/hide and the draft mutation now only fire on the focused tab.
- \`desktop/src/styles.css\` — switch the \`::after\` content to \`var(--drop-overlay-label, "...")\` so the hint can be set from JS.
- JS sets that custom property from the existing i18n dict on drag-enter.
- New \`dragDrop.overlay\` keys in \`en.ts\` / \`zh-CN.ts\`.

## Test plan
- \`npm run verify\` — 207 files / 3124 tests pass.
- \`npx tsc --noEmit\` inside \`desktop/\` — clean.
- Manual: open 2+ tabs, drop a file → the @-mention only lands in the active tab's draft (before the fix it landed in every tab). zh-CN locale shows "松开以作为 @ 提及附加" in the overlay.

Fixes #1027