### PR TITLE
fix(desktop): wire /help suggestion locally instead of sending to the LLM

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -1293,6 +1293,14 @@ function TabRuntime({
   });
 
   const slashCommands: SlashCmd[] = [
+    {
+      cmd: "/help",
+      desc: t("app.cmd.help"),
+      run: () => {
+        setDraft("/");
+        composerRef.current?.focus();
+      },
+    },
     { cmd: "/new", desc: t("app.cmd.newSession"), run: () => newChat(), kb: "⌘N" },
     { cmd: "/clear", desc: t("app.cmd.clearChat"), run: () => dispatch({ t: "clear" }) },
     { cmd: "/abort", desc: t("app.cmd.abort"), run: () => abort(), kb: "esc" },
@@ -1529,7 +1537,18 @@ function TabRuntime({
 
                   {state.messages.length === 0 ? (
                     <EmptyState
-                      onPick={(t) => send(t)}
+                      onPick={(text) => {
+                        const trimmed = text.trim();
+                        if (trimmed.startsWith("/")) {
+                          const cmd = trimmed.split(/\s+/)[0] ?? "";
+                          const match = slashCommands.find((s) => s.cmd === cmd);
+                          if (match) {
+                            match.run();
+                            return;
+                          }
+                        }
+                        send(text);
+                      }}
                       workspaceDir={state.settings?.workspaceDir}
                     />
                   ) : null}

--- a/desktop/src/i18n/en.ts
+++ b/desktop/src/i18n/en.ts
@@ -268,6 +268,7 @@ export const en = {
       toggleCurrency: "Toggle currency (CNY / USD)",
       toggleLang: "Toggle language (CN / EN)",
       exportMd: "Copy session as Markdown",
+      help: "Show all commands",
     },
     yolo: {
       banner1: "All tool calls, shell commands, and file edits will be ",

--- a/desktop/src/i18n/zh-CN.ts
+++ b/desktop/src/i18n/zh-CN.ts
@@ -275,6 +275,7 @@ export const zhCN: typeof en = {
       toggleCurrency: "切换货币显示 (CNY / USD)",
       toggleLang: "切换界面语言 (中 / 英)",
       exportMd: "复制本会话为 Markdown",
+      help: "查看所有命令",
     },
     yolo: {
       banner1: "所有工具调用、shell 命令、文件编辑都会",

--- a/desktop/src/ui/composer.tsx
+++ b/desktop/src/ui/composer.tsx
@@ -163,6 +163,16 @@ export function Composer({
   const nonceRef = useRef(0);
   const modelWrapRef = useRef<HTMLDivElement>(null);
 
+  // Programmatic draft transitions to "/" (e.g. /help suggestion in EmptyState, #929) must open the slash popup, since handleChange only fires on actual user input.
+  const prevDraftRef = useRef(draft);
+  useEffect(() => {
+    const prev = prevDraftRef.current;
+    prevDraftRef.current = draft;
+    if (draft === "/" && prev !== "/") {
+      setPopup({ kind: "slash", query: "" });
+    }
+  }, [draft]);
+
   useEffect(() => {
     if (!modelMenuOpen) return;
     const onDown = (e: MouseEvent) => {


### PR DESCRIPTION
## Summary
The EmptyState welcome screen lists \`/help\` as one of the suggestion chips, but \`onPick\` piped every string straight to \`send()\`. Clicking the chip shipped the literal string \`/help\` as a user message — the agent started reasoning about how to answer a "help" question instead of opening the local help surface. Reported in #929.

## Fix
1. **\`desktop/src/App.tsx\`** — \`EmptyState.onPick\` now matches the picked text against \`slashCommands\` first. If the leading token (\`/foo\`) maps to a registered local command, run it; otherwise fall through to \`send()\` so non-slash suggestions still behave as before.
2. **\`desktop/src/App.tsx\`** — register a real \`/help\` slash command that primes the composer with \`"/"\` and focuses the textarea. The existing slash popup then renders the full command list with descriptions and shortcuts — no separate help surface needed.
3. **\`desktop/src/ui/composer.tsx\`** — the popup used to open only from \`handleChange\` (real keystrokes), so a programmatic \`setDraft("/")\` left the textarea showing \`/\` with no popup. Added a tiny effect that watches for a \`""\` → \`"/"\` draft transition and opens the slash popup, leaving user-typed slashes and Escape-dismissed popups untouched.
4. New \`app.cmd.help\` i18n strings in en + zh-CN.

## Test plan
- \`npm run verify\` — 207 files / 3124 tests pass.
- \`npx tsc --noEmit\` inside \`desktop/\` — clean.
- Manual: open a fresh desktop session, click the \`/help\` chip → the composer now shows \`/\` with the slash popup listing all available commands; the agent does NOT receive a message. Clicking a non-slash suggestion (e.g. "Translate README to Chinese/English") still sends it as a user message.

Fixes #929