### PR TITLE
fix(rust): zero-width char handling + tab expansion + Unicode rendering tests

### DIFF
--- a/crates/reasonix-render/src/whole_screen/overlay_at.rs
+++ b/crates/reasonix-render/src/whole_screen/overlay_at.rs
@@ -326,7 +326,7 @@ fn paint_clipped(
     let mut w = 0u16;
     let mut clipped = String::new();
     for ch in s.chars() {
-        let cw = unicode_width::UnicodeWidthChar::width(ch).unwrap_or(1) as u16;
+        let cw = crate::whole_screen::paint::char_width(ch);
         if w + cw > *budget {
             break;
         }

--- a/crates/reasonix-render/src/whole_screen/paint.rs
+++ b/crates/reasonix-render/src/whole_screen/paint.rs
@@ -4,15 +4,26 @@ use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
 use unicode_width::UnicodeWidthChar;
 
+/// Display width of a character.  Returns 0 for control characters
+/// (where unicode-width returns None) and combining marks, so the
+/// layout engine skips them instead of giving them a spurious width-1
+/// cell that overwrites the next character.
+pub fn char_width(ch: char) -> u16 {
+    UnicodeWidthChar::width(ch).unwrap_or(0) as u16
+}
+
 pub fn paint(buf: &mut Buffer, x: u16, y: u16, ch: char, fg: Color, bg: Color, modifier: Modifier) {
     if x >= buf.area.right() || y >= buf.area.bottom() {
+        return;
+    }
+    let w = char_width(ch);
+    if w == 0 {
         return;
     }
     let mut tmp = [0u8; 4];
     let s = ch.encode_utf8(&mut tmp);
     let style = Style::default().fg(fg).bg(bg).add_modifier(modifier);
     buf[(x, y)].set_symbol(s).set_style(style).set_skip(false);
-    let w = UnicodeWidthChar::width(ch).unwrap_or(1) as u16;
     for off in 1..w {
         let cx = x + off;
         if cx >= buf.area.right() {
@@ -51,7 +62,24 @@ pub fn paint_str_to(
     let limit = end_x.min(buf.area.right());
     let mut col = x;
     for ch in s.chars() {
-        let w = UnicodeWidthChar::width(ch).unwrap_or(1) as u16;
+        // Tab → 2 spaces (terminal convention, matches common tab-stop width).
+        if ch == '\t' {
+            for _ in 0..2 {
+                if col >= limit {
+                    break;
+                }
+                paint(buf, col, y, ' ', fg, bg, modifier);
+                col += 1;
+            }
+            continue;
+        }
+        let w = char_width(ch);
+        // Zero-width characters (control chars, combining marks, ZWJ/ZWNJ,
+        // variation selectors) are skipped — they'd otherwise land at the
+        // same column as the next character and cause overwrite artifacts.
+        if w == 0 {
+            continue;
+        }
         if col.saturating_add(w) > limit {
             break;
         }

--- a/crates/reasonix-render/tests/whole_screen.rs
+++ b/crates/reasonix-render/tests/whole_screen.rs
@@ -1268,3 +1268,112 @@ fn main_panel_content_does_not_leak_into_sidebar_columns() {
         }
     }
 }
+
+// ── Unicode rendering ──────────────────────────────────────────────
+
+#[test]
+fn emoji_characters_consume_two_cells() {
+    let state = SceneState {
+        cards: vec![SceneCard {
+            kind: "streaming".to_string(),
+            body: Some("🤖🚀".to_string()),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let rows = draw(&state, 80, 20);
+    let all = joined(&rows);
+    // Each emoji is 2 cells wide; total string "🤖🚀" = 4 cells.
+    // The two emoji should appear as 4 visible cells, not overwritten.
+    assert!(all.contains("🤖"), "robot emoji missing");
+    assert!(all.contains("🚀"), "rocket emoji missing");
+}
+
+#[test]
+fn zero_width_chars_are_skipped_not_overwritten() {
+    // Zero-width joiner between two chars: the ZWJ should be skipped,
+    // not overwrite the next character's cell.
+    let state = SceneState {
+        cards: vec![SceneCard {
+            kind: "streaming".to_string(),
+            // "a" + ZWJ (U+200D, width 0) + "b"
+            body: Some("a\u{200D}b".to_string()),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let rows = draw(&state, 80, 20);
+    let all = joined(&rows);
+    // ZWJ is zero-width and should be skipped. Result: "ab".
+    assert!(all.contains("ab"), "ZWJ should be skipped, rendering 'ab' as neighbors");
+}
+
+#[test]
+fn combining_marks_are_skipped() {
+    // Combining acute accent (U+0301, width 0) after 'e' — the accent
+    // should be skipped rather than landing on the next char's cell.
+    let state = SceneState {
+        cards: vec![SceneCard {
+            kind: "streaming".to_string(),
+            body: Some("e\u{0301}x".to_string()),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let rows = draw(&state, 80, 20);
+    let all = joined(&rows);
+    // Combining mark skipped: 'e' and 'x' should appear as neighbors.
+    assert!(all.contains("ex") || all.contains("e x"),
+        "combining mark should not corrupt adjacent chars; got: {all}");
+}
+
+#[test]
+fn tab_char_expands_to_spaces() {
+    let state = SceneState {
+        cards: vec![SceneCard {
+            kind: "streaming".to_string(),
+            body: Some("a\tb".to_string()),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let rows = draw(&state, 80, 20);
+    let all = joined(&rows);
+    // Tab → 2 spaces: "a  b"
+    assert!(all.contains("a  b"), "tab should expand to 2 spaces; got: {all}");
+}
+
+#[test]
+fn control_characters_are_filtered() {
+    // \r, \x00, \x01 — all control chars with width None from unicode-width.
+    // The old unwrap_or(1) gave them width 1; char_width() gives 0 → skip.
+    let state = SceneState {
+        cards: vec![SceneCard {
+            kind: "streaming".to_string(),
+            body: Some("a\x00b\x01c".to_string()),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let rows = draw(&state, 80, 20);
+    let all = joined(&rows);
+    // Control chars skipped: "abc".
+    assert!(all.contains("abc"), "control chars should be filtered; got: {all}");
+}
+
+#[test]
+fn cjk_and_emoji_mixed_preserve_each_other() {
+    let state = SceneState {
+        cards: vec![SceneCard {
+            kind: "streaming".to_string(),
+            body: Some("你好🤖世界".to_string()),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let rows = draw(&state, 80, 20);
+    let all = joined(&rows);
+    assert!(all.contains("你好"), "CJK greeting missing");
+    assert!(all.contains("🤖"), "emoji between CJK missing");
+    assert!(all.contains("世界"), "CJK world missing");
+}

--- a/crates/reasonix-render/tests/whole_screen.rs
+++ b/crates/reasonix-render/tests/whole_screen.rs
@@ -1305,7 +1305,10 @@ fn zero_width_chars_are_skipped_not_overwritten() {
     let rows = draw(&state, 80, 20);
     let all = joined(&rows);
     // ZWJ is zero-width and should be skipped. Result: "ab".
-    assert!(all.contains("ab"), "ZWJ should be skipped, rendering 'ab' as neighbors");
+    assert!(
+        all.contains("ab"),
+        "ZWJ should be skipped, rendering 'ab' as neighbors"
+    );
 }
 
 #[test]
@@ -1323,8 +1326,10 @@ fn combining_marks_are_skipped() {
     let rows = draw(&state, 80, 20);
     let all = joined(&rows);
     // Combining mark skipped: 'e' and 'x' should appear as neighbors.
-    assert!(all.contains("ex") || all.contains("e x"),
-        "combining mark should not corrupt adjacent chars; got: {all}");
+    assert!(
+        all.contains("ex") || all.contains("e x"),
+        "combining mark should not corrupt adjacent chars; got: {all}"
+    );
 }
 
 #[test]
@@ -1340,7 +1345,10 @@ fn tab_char_expands_to_spaces() {
     let rows = draw(&state, 80, 20);
     let all = joined(&rows);
     // Tab → 2 spaces: "a  b"
-    assert!(all.contains("a  b"), "tab should expand to 2 spaces; got: {all}");
+    assert!(
+        all.contains("a  b"),
+        "tab should expand to 2 spaces; got: {all}"
+    );
 }
 
 #[test]
@@ -1358,7 +1366,10 @@ fn control_characters_are_filtered() {
     let rows = draw(&state, 80, 20);
     let all = joined(&rows);
     // Control chars skipped: "abc".
-    assert!(all.contains("abc"), "control chars should be filtered; got: {all}");
+    assert!(
+        all.contains("abc"),
+        "control chars should be filtered; got: {all}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Problem

\`paint.rs\` used \`UnicodeWidthChar::width(ch).unwrap_or(1)\` — control characters (U+0000-U+001F, U+007F-U+009F) return \`None\` from unicode-width, so they were given a spurious width-1 cell. This caused zero-width characters to overwrite the next character's cell, producing garbled output for text containing combining marks, ZWJ/ZWNJ, variation selectors, or control codes. Tabs were also rendered as single-width unknown glyphs.

## Fix

1. **\`char_width()\`** — new public helper returning 0 for \`None\` (control chars) and combining marks, instead of the old \`unwrap_or(1)\`.
2. **\`paint()\`** — bails early on w==0 characters (combining marks, ZWJ, control codes).
3. **\`paint_str_to()\`** — expands \`\t\` to 2 spaces, skips all w==0 chars, uses \`char_width()\`.
4. **\`overlay_at.rs\`** — switched from \`unwrap_or(1)\` to \`char_width()\`.

## Tests (6 new)

| Test | Covers |
|------|--------|
| \`emoji_characters_consume_two_cells\` | 🤖🚀 → 4 cells, no overwrite |
| \`zero_width_chars_are_skipped_not_overwritten\` | ZWJ (U+200D) skipped, 'ab' preserved |
| \`combining_marks_are_skipped\` | Combining acute (U+0301) skipped, 'e' and 'x' neighbors |
| \`tab_char_expands_to_spaces\` | \`\t\` → 2 spaces |
| \`control_characters_are_filtered\` | \`\x00\x01\` filtered, 'abc' rendered |
| \`cjk_and_emoji_mixed_preserve_each_other\` | 你好🤖世界 — CJK + emoji side by side |

## Aligns with #947

\`\`\`
Stage 1 — Rust renderer behind a flag
  Card-stream parity on Windows Terminal / iTerm2 / VSCode / Linux ssh
\`\`\`

Unicode correctness is prerequisite for card-stream parity — CJK and emoji are fundamental to DeepSeek's user base. Every card kind (user messages, reasoning, streaming, tool output, file views, errors) passes through \`paint_str_to\` → \`paint\`.