### PR TITLE
feat(memory): on-demand subdir REASONIX.md when read_file touches a module

### DIFF
--- a/src/memory/subdir.ts
+++ b/src/memory/subdir.ts
@@ -1,0 +1,49 @@
+/** Module-scoped memory files (#1033). Walks from a file's dir up to rootDir, collecting REASONIX.md (or AGENTS.md / AGENT.md) found along the way. The root's memory is excluded — it's already in the system prompt via applyProjectMemory. */
+
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { PROJECT_MEMORY_FILES, PROJECT_MEMORY_MAX_CHARS } from "./project.js";
+
+/** Ancestor PROJECT_MEMORY_FILES matches for `absPath`, walking from its dir up to (but not including) `rootDir`. Innermost-first. Returns absolute paths. */
+export function findSubdirMemoryAncestors(absPath: string, rootDir: string): string[] {
+  const root = resolve(rootDir);
+  const target = resolve(absPath);
+  const rel = relative(root, target);
+  if (!rel || rel.startsWith("..")) return [];
+  const found: string[] = [];
+  let cur = dirname(target);
+  while (cur !== root) {
+    const r = relative(root, cur);
+    if (!r || r.startsWith("..")) break;
+    for (const name of PROJECT_MEMORY_FILES) {
+      const path = join(cur, name);
+      if (existsSync(path)) {
+        found.push(path);
+        break;
+      }
+    }
+    const parent = dirname(cur);
+    if (parent === cur) break;
+    cur = parent;
+  }
+  return found;
+}
+
+export function readSubdirMemoryContent(path: string): string | null {
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch {
+    return null;
+  }
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  if (trimmed.length <= PROJECT_MEMORY_MAX_CHARS) return trimmed;
+  return `${trimmed.slice(0, PROJECT_MEMORY_MAX_CHARS)}\n… (truncated ${
+    trimmed.length - PROJECT_MEMORY_MAX_CHARS
+  } chars)`;
+}
+
+export function formatSubdirMemorySection(displayPath: string, content: string): string {
+  return `[module memory: ${displayPath}]\n\n${content}`;
+}

--- a/src/tools/filesystem.ts
+++ b/src/tools/filesystem.ts
@@ -6,6 +6,12 @@ import picomatch from "picomatch";
 import { addProjectPathAllowed, loadProjectPathAllowed } from "../config.js";
 import { type ConfirmationChoice, pauseGate as defaultPauseGate } from "../core/pause-gate.js";
 import { DEFAULT_INDEX_EXCLUDES } from "../index/config.js";
+import { memoryEnabled } from "../memory/project.js";
+import {
+  findSubdirMemoryAncestors,
+  formatSubdirMemorySection,
+  readSubdirMemoryContent,
+} from "../memory/subdir.js";
 import type { ToolCallContext, ToolRegistry } from "../tools.js";
 import { applyEdit, applyMultiEdit } from "./fs/edit.js";
 import { globFiles } from "./fs/glob.js";
@@ -107,6 +113,25 @@ export function registerFilesystemTools(
   const normRoot = pathMod.resolve(rootDir);
   /** Approved-this-session directory prefixes — `run_once` keeps the user from being asked twice for follow-up reads in the same dir. Wiped on process exit, not persisted. */
   const sessionApproved = new Set<string>();
+  /** Subdir REASONIX.md paths already injected this session (#1033). Reset per toolset, so each tab/session re-injects on first relevant read. */
+  const shownSubdirMemory = new Set<string>();
+
+  /** Prepend any not-yet-shown ancestor REASONIX.md (between absPath's dir and rootDir) to a read_file body. Outer dirs first so broad rules read before specific overrides. */
+  function withSubdirMemory(absPath: string, body: string): string {
+    if (!memoryEnabled()) return body;
+    const ancestors = findSubdirMemoryAncestors(absPath, rootDir);
+    if (ancestors.length === 0) return body;
+    const sections: string[] = [];
+    for (const memPath of [...ancestors].reverse()) {
+      if (shownSubdirMemory.has(memPath)) continue;
+      const content = readSubdirMemoryContent(memPath);
+      if (!content) continue;
+      shownSubdirMemory.add(memPath);
+      sections.push(formatSubdirMemorySection(displayRel(rootDir, memPath), content));
+    }
+    if (sections.length === 0) return body;
+    return `${sections.join("\n\n")}\n\n${body}`;
+  }
   /** In-flight gate prompts keyed by `allowPrefix` so parallel reads under the same dir only fire one modal. */
   const inflightGate = new Map<string, Promise<ConfirmationChoice>>();
 
@@ -264,7 +289,7 @@ Files OVER the threshold auto-switch to outline mode: file metadata + first ${OU
         const end = Math.min(totalLines, Math.max(start, rawEnd ?? totalLines));
         const slice = lines.slice(start - 1, end);
         const label = `[range ${start}-${end} of ${totalLines} lines]`;
-        return `${label}\n${slice.join("\n")}`;
+        return withSubdirMemory(abs, `${label}\n${slice.join("\n")}`);
       }
       if (typeof args.head === "number" && args.head > 0) {
         const count = Math.min(args.head, totalLines);
@@ -273,7 +298,7 @@ Files OVER the threshold auto-switch to outline mode: file metadata + first ${OU
           count < totalLines
             ? `\n\n[…head ${count} of ${totalLines} lines — call again with range / tail for more]`
             : "";
-        return slice.join("\n") + marker;
+        return withSubdirMemory(abs, slice.join("\n") + marker);
       }
       if (typeof args.tail === "number" && args.tail > 0) {
         const count = Math.min(args.tail, totalLines);
@@ -282,13 +307,13 @@ Files OVER the threshold auto-switch to outline mode: file metadata + first ${OU
           count < totalLines
             ? `[…tail ${count} of ${totalLines} lines — call again with range / head for more]\n\n`
             : "";
-        return marker + slice.join("\n");
+        return withSubdirMemory(abs, marker + slice.join("\n"));
       }
 
       // No explicit scope + file fits the threshold → full content.
       // Trust the prompt cache: a 100K-token file read once amortizes
       // across every turn of the same conversation.
-      if (sizeBytes <= outlineThresholdBytes) return lines.join("\n");
+      if (sizeBytes <= outlineThresholdBytes) return withSubdirMemory(abs, lines.join("\n"));
 
       // No explicit scope + file is over the threshold → outline mode.
       // Return enough for the model to orient (head + symbol map) plus
@@ -310,7 +335,7 @@ Files OVER the threshold auto-switch to outline mode: file metadata + first ${OU
         `  - read_file path:"${rel}" head:N  /  tail:N    — first/last N lines`,
         `  - search_content path:"${rel}" pattern:"..."   — grep within this file]`,
       );
-      return parts.join("\n");
+      return withSubdirMemory(abs, parts.join("\n"));
     },
   });
 

--- a/tests/subdir-memory.test.ts
+++ b/tests/subdir-memory.test.ts
@@ -1,0 +1,194 @@
+/** Per-subdirectory REASONIX.md walker + injection (#1033). */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  findSubdirMemoryAncestors,
+  formatSubdirMemorySection,
+  readSubdirMemoryContent,
+} from "../src/memory/subdir.js";
+import { ToolRegistry } from "../src/tools.js";
+import { registerFilesystemTools } from "../src/tools/filesystem.js";
+
+describe("findSubdirMemoryAncestors", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "reasonix-subdir-mem-"));
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("returns [] for a file directly under rootDir (project memory handles it)", () => {
+    writeFileSync(join(root, "REASONIX.md"), "root rules");
+    writeFileSync(join(root, "foo.ts"), "");
+    expect(findSubdirMemoryAncestors(join(root, "foo.ts"), root)).toEqual([]);
+  });
+
+  it("finds the closest ancestor memory for a file in a subdir", () => {
+    mkdirSync(join(root, "frontend"), { recursive: true });
+    writeFileSync(join(root, "frontend", "REASONIX.md"), "use pnpm");
+    writeFileSync(join(root, "frontend", "App.tsx"), "");
+    expect(findSubdirMemoryAncestors(join(root, "frontend", "App.tsx"), root)).toEqual([
+      join(root, "frontend", "REASONIX.md"),
+    ]);
+  });
+
+  it("returns multiple ancestors innermost-first when both subdirs carry memory", () => {
+    mkdirSync(join(root, "pkg", "module"), { recursive: true });
+    writeFileSync(join(root, "pkg", "REASONIX.md"), "package rules");
+    writeFileSync(join(root, "pkg", "module", "REASONIX.md"), "module rules");
+    writeFileSync(join(root, "pkg", "module", "deep.ts"), "");
+    expect(findSubdirMemoryAncestors(join(root, "pkg", "module", "deep.ts"), root)).toEqual([
+      join(root, "pkg", "module", "REASONIX.md"),
+      join(root, "pkg", "REASONIX.md"),
+    ]);
+  });
+
+  it("skips dirs that have no memory file", () => {
+    mkdirSync(join(root, "a", "b", "c"), { recursive: true });
+    writeFileSync(join(root, "a", "REASONIX.md"), "only at a");
+    writeFileSync(join(root, "a", "b", "c", "x.ts"), "");
+    expect(findSubdirMemoryAncestors(join(root, "a", "b", "c", "x.ts"), root)).toEqual([
+      join(root, "a", "REASONIX.md"),
+    ]);
+  });
+
+  it("excludes the rootDir's own REASONIX.md from the walk", () => {
+    mkdirSync(join(root, "sub"), { recursive: true });
+    writeFileSync(join(root, "REASONIX.md"), "root rules");
+    writeFileSync(join(root, "sub", "REASONIX.md"), "sub rules");
+    writeFileSync(join(root, "sub", "x.ts"), "");
+    const ancestors = findSubdirMemoryAncestors(join(root, "sub", "x.ts"), root);
+    expect(ancestors).toEqual([join(root, "sub", "REASONIX.md")]);
+    expect(ancestors).not.toContain(join(root, "REASONIX.md"));
+  });
+
+  it("returns [] for an absolute path that escapes rootDir", () => {
+    const outside = mkdtempSync(join(tmpdir(), "reasonix-subdir-out-"));
+    try {
+      writeFileSync(join(outside, "foo.ts"), "");
+      expect(findSubdirMemoryAncestors(join(outside, "foo.ts"), root)).toEqual([]);
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  it("also recognises AGENTS.md / AGENT.md alongside REASONIX.md", () => {
+    mkdirSync(join(root, "a"), { recursive: true });
+    mkdirSync(join(root, "b"), { recursive: true });
+    writeFileSync(join(root, "a", "AGENTS.md"), "use agents file");
+    writeFileSync(join(root, "b", "AGENT.md"), "singular agent file");
+    writeFileSync(join(root, "a", "x.ts"), "");
+    writeFileSync(join(root, "b", "y.ts"), "");
+    expect(findSubdirMemoryAncestors(join(root, "a", "x.ts"), root)).toEqual([
+      join(root, "a", "AGENTS.md"),
+    ]);
+    expect(findSubdirMemoryAncestors(join(root, "b", "y.ts"), root)).toEqual([
+      join(root, "b", "AGENT.md"),
+    ]);
+  });
+});
+
+describe("readSubdirMemoryContent", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "reasonix-subdir-read-"));
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("returns trimmed content", () => {
+    const p = join(root, "REASONIX.md");
+    writeFileSync(p, "  hello world  \n\n");
+    expect(readSubdirMemoryContent(p)).toBe("hello world");
+  });
+
+  it("returns null for an empty or whitespace-only file", () => {
+    const p = join(root, "REASONIX.md");
+    writeFileSync(p, "  \n\n");
+    expect(readSubdirMemoryContent(p)).toBeNull();
+  });
+
+  it("returns null for a missing file", () => {
+    expect(readSubdirMemoryContent(join(root, "nope.md"))).toBeNull();
+  });
+
+  it("truncates beyond PROJECT_MEMORY_MAX_CHARS with a marker", () => {
+    const p = join(root, "REASONIX.md");
+    writeFileSync(p, "x".repeat(8100));
+    const out = readSubdirMemoryContent(p);
+    expect(out).not.toBeNull();
+    expect(out!.length).toBeLessThan(8100 + 100);
+    expect(out).toContain("… (truncated 100 chars)");
+  });
+});
+
+describe("formatSubdirMemorySection", () => {
+  it("includes the display path and content in a single block", () => {
+    const out = formatSubdirMemorySection("frontend/REASONIX.md", "use pnpm");
+    expect(out).toContain("frontend/REASONIX.md");
+    expect(out).toContain("use pnpm");
+    expect(out.startsWith("[module memory:")).toBe(true);
+  });
+});
+
+describe("read_file injects subdir memory on first read per session", () => {
+  let root: string;
+  let tools: ToolRegistry;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "reasonix-fs-mem-"));
+    mkdirSync(join(root, "frontend"), { recursive: true });
+    writeFileSync(join(root, "frontend", "REASONIX.md"), "use pnpm, never npm");
+    writeFileSync(join(root, "frontend", "App.tsx"), "export const App = () => null;");
+    tools = new ToolRegistry();
+    registerFilesystemTools(tools, { rootDir: root });
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("prepends [module memory:…] on first read of a file under that subdir", async () => {
+    const out = await tools.dispatch("read_file", JSON.stringify({ path: "frontend/App.tsx" }));
+    expect(out).toContain("[module memory: frontend/REASONIX.md]");
+    expect(out).toContain("use pnpm, never npm");
+    expect(out).toContain("export const App");
+  });
+
+  it("does NOT repeat the memory on subsequent reads in the same subdir", async () => {
+    await tools.dispatch("read_file", JSON.stringify({ path: "frontend/App.tsx" }));
+    const second = await tools.dispatch("read_file", JSON.stringify({ path: "frontend/App.tsx" }));
+    expect(second).not.toContain("[module memory:");
+    expect(second).toContain("export const App");
+  });
+
+  it("does not inject memory for a file directly under rootDir", async () => {
+    writeFileSync(join(root, "root.ts"), "//");
+    const out = await tools.dispatch("read_file", JSON.stringify({ path: "root.ts" }));
+    expect(out).not.toContain("[module memory:");
+  });
+
+  it("respects REASONIX_MEMORY=off and skips injection entirely", async () => {
+    const prev = process.env.REASONIX_MEMORY;
+    process.env.REASONIX_MEMORY = "off";
+    try {
+      const tools2 = new ToolRegistry();
+      registerFilesystemTools(tools2, { rootDir: root });
+      const out = await tools2.dispatch("read_file", JSON.stringify({ path: "frontend/App.tsx" }));
+      expect(out).not.toContain("[module memory:");
+    } finally {
+      if (prev === undefined) {
+        // biome-ignore lint/performance/noDelete: env restore
+        delete process.env.REASONIX_MEMORY;
+      } else {
+        process.env.REASONIX_MEMORY = prev;
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Large monorepo users (#1033) asked for Claude-style per-subdirectory memory: drop a \`frontend/REASONIX.md\` or \`api/REASONIX.md\` and have its rules apply only when the agent is actually working in that subdir. Project-level \`REASONIX.md\` already covered the repo root; nothing in between.

## Design
- New \`src/memory/subdir.ts\` — \`findSubdirMemoryAncestors(absPath, rootDir)\` walks from \`dirname(absPath)\` up to (but **not** including) \`rootDir\` and returns every PROJECT_MEMORY_FILES match (\`REASONIX.md\` / \`AGENTS.md\` / \`AGENT.md\`) it finds, innermost-first.
  - The root's memory is intentionally excluded — \`applyProjectMemory\` already injects it into the system prompt, so re-emitting through a tool result would just bloat the context window.
- \`read_file\` now wraps its return value through \`withSubdirMemory(abs, body)\`. Each not-yet-shown ancestor memory is prepended as \`[module memory: <rel-path>]\n\n<content>\`, outer-first (broad rules read before specific overrides), then the file body.
- The "already shown" set lives in the toolset closure (one per tab/session), so a fresh session re-injects on first relevant read. No injection if \`REASONIX_MEMORY=off\`. Same \`PROJECT_MEMORY_MAX_CHARS\` truncation as project memory.

## Test plan
- New \`tests/subdir-memory.test.ts\` (16 cases) — covers the walker (single subdir, nested subdirs innermost-first, gap dirs without memory, root-only edge case, escape-rootDir, AGENTS.md / AGENT.md fallbacks), the reader (trim, empty → null, missing file, truncation marker), the formatter, and end-to-end through \`ToolRegistry.dispatch("read_file", …)\` proving the injection fires once per session and is gated by \`REASONIX_MEMORY=off\`.
- \`npm run verify\` — 209 files / 3148 tests pass.

## Notes
- Scope is intentionally narrow: only \`read_file\` triggers the injection. Claude's docs describe the same "loaded when reading files in that directory" semantics. \`edit_file\` and \`write_file\` typically follow a \`read_file\`, so they'll inherit the memory through conversation history.
- Docs / dashboard memory panel still describe project + global only — left for a follow-up doc-only PR so this change stays surgical.

Closes #1033