### PR TITLE
feat(dashboard): configurable bind host + stable token for LAN/mobile access

### DIFF
--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -151,6 +151,10 @@ export interface ChatOptions {
   openDashboard?: boolean;
   /** Pin the dashboard to a fixed port. `undefined` keeps ephemeral assignment. */
   dashboardPort?: number;
+  /** Dashboard bind address (#968). `undefined` keeps the default 127.0.0.1. */
+  dashboardHost?: string;
+  /** Stable dashboard URL token (#968). `undefined` mints a fresh per-boot token. */
+  dashboardToken?: string;
   /**
    * Render into the terminal's alternate screen buffer. Default true —
    * alt-screen avoids the scrollback-mode resize/wrap ghost class. Pass
@@ -296,6 +300,8 @@ function Root({
         noDashboard={appProps.noDashboard}
         openDashboard={appProps.openDashboard}
         dashboardPort={appProps.dashboardPort}
+        dashboardHost={appProps.dashboardHost}
+        dashboardToken={appProps.dashboardToken}
         mouse={appProps.mouse}
         qqChannel={appProps.qqChannel}
         qqSubmitRef={appProps.qqSubmitRef}

--- a/src/cli/commands/code.tsx
+++ b/src/cli/commands/code.tsx
@@ -57,6 +57,10 @@ export interface CodeOptions {
   openDashboard?: boolean;
   /** Pin the dashboard to a fixed port. `undefined` keeps ephemeral assignment. */
   dashboardPort?: number;
+  /** Dashboard bind address (#968). `undefined` keeps the default 127.0.0.1. */
+  dashboardHost?: string;
+  /** Stable dashboard URL token (#968). `undefined` mints a fresh per-boot token. */
+  dashboardToken?: string;
   /** Inline string appended to the code system prompt after the generated base prompt. */
   systemAppend?: string;
   /** Path to a UTF-8 text file whose contents are appended to the code system prompt. */
@@ -178,6 +182,8 @@ export async function codeCommand(opts: CodeOptions = {}): Promise<void> {
     noDashboard: opts.noDashboard,
     openDashboard: opts.openDashboard,
     dashboardPort: opts.dashboardPort,
+    dashboardHost: opts.dashboardHost,
+    dashboardToken: opts.dashboardToken,
     altScreen: opts.altScreen,
     mouse: opts.mouse,
   });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -119,6 +119,35 @@ function resolveDashboardPort(
     : undefined;
 }
 
+/** Resolution order: flag → REASONIX_DASHBOARD_HOST env → config.dashboard.host → undefined (server defaults to 127.0.0.1). */
+function resolveDashboardHost(
+  flagValue: string | undefined,
+  noConfig: boolean,
+): string | undefined {
+  const fromFlag = flagValue?.trim();
+  if (fromFlag) return fromFlag;
+  const fromEnv = process.env.REASONIX_DASHBOARD_HOST?.trim();
+  if (fromEnv) return fromEnv;
+  if (noConfig) return undefined;
+  const fromCfg = readConfig().dashboard?.host;
+  return typeof fromCfg === "string" && fromCfg.trim() ? fromCfg.trim() : undefined;
+}
+
+/** Resolution order: REASONIX_DASHBOARD_TOKEN env → config.dashboard.token → undefined (server mints a fresh per-boot token). Min 16 chars; shorter values are dropped with a warning to avoid trivially-guessable tokens. */
+function resolveDashboardToken(noConfig: boolean): string | undefined {
+  const fromEnv = process.env.REASONIX_DASHBOARD_TOKEN?.trim();
+  const fromCfg = noConfig ? undefined : readConfig().dashboard?.token?.trim();
+  const candidate = fromEnv || fromCfg;
+  if (!candidate) return undefined;
+  if (candidate.length < 16) {
+    process.stderr.write(
+      `▲ ignoring dashboard token (${candidate.length} chars; min 16) — using ephemeral per-boot token instead\n`,
+    );
+    return undefined;
+  }
+  return candidate;
+}
+
 const program = new Command();
 program
   .name("reasonix")
@@ -193,6 +222,10 @@ program
   .option("--no-dashboard", t("ui.noDashboard"))
   .option("--open-dashboard", t("ui.openDashboardHint"))
   .option("--dashboard-port <port>", t("ui.dashboardPortHint"))
+  .option(
+    "--dashboard-host <host>",
+    "bind address for the dashboard (default 127.0.0.1; use 0.0.0.0 for LAN access — the URL token is then the only auth)",
+  )
   .option("--no-alt-screen", "keep chat output in shell scrollback (legacy mode, ghost-prone)")
   .option("--no-mouse", "disable SGR mouse tracking (keeps drag-select 100% native)")
   .option("--system-append <prompt>", t("ui.systemAppendHint"))
@@ -220,6 +253,8 @@ program
         noDashboard: opts.dashboard === false,
         openDashboard: opts.openDashboard === true,
         dashboardPort: resolveDashboardPort(parseDashboardPortFlag(opts.dashboardPort), false),
+        dashboardHost: resolveDashboardHost(opts.dashboardHost, false),
+        dashboardToken: resolveDashboardToken(false),
         systemAppend: opts.systemAppend,
         systemAppendFile: opts.systemAppendFile,
         altScreen: opts.altScreen !== false,
@@ -259,6 +294,10 @@ program
   .option("--no-dashboard", t("ui.noDashboard"))
   .option("--open-dashboard", t("ui.openDashboardHint"))
   .option("--dashboard-port <port>", t("ui.dashboardPortHint"))
+  .option(
+    "--dashboard-host <host>",
+    "bind address for the dashboard (default 127.0.0.1; use 0.0.0.0 for LAN access — the URL token is then the only auth)",
+  )
   .option("--no-alt-screen", "keep chat output in shell scrollback (legacy mode, ghost-prone)")
   .option("--no-mouse", "disable SGR mouse tracking (keeps drag-select 100% native)")
   .option(
@@ -312,6 +351,8 @@ program
           parseDashboardPortFlag(opts.dashboardPort),
           opts.config === false,
         ),
+        dashboardHost: resolveDashboardHost(opts.dashboardHost, opts.config === false),
+        dashboardToken: resolveDashboardToken(opts.config === false),
         altScreen: opts.altScreen !== false,
         mouse: opts.mouse !== false,
       });

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -279,6 +279,10 @@ export interface AppProps {
   openDashboard?: boolean;
   /** Pin the dashboard to a fixed port. `undefined` keeps ephemeral assignment. */
   dashboardPort?: number;
+  /** Dashboard bind address (#968). `undefined` keeps the default 127.0.0.1. */
+  dashboardHost?: string;
+  /** Stable dashboard URL token (#968). `undefined` mints a fresh per-boot token. */
+  dashboardToken?: string;
   /** Mid-chat session swap 闂?Root remounts App with the new session via key. */
   onSwitchSession?: (name: string | undefined) => void;
   /**
@@ -475,6 +479,8 @@ function AppInner({
   noDashboard,
   openDashboard,
   dashboardPort,
+  dashboardHost,
+  dashboardToken,
   onSwitchSession,
   mouse = true,
   startupInfoHints,
@@ -2458,7 +2464,7 @@ function AppInner({
               }
             : undefined,
         },
-        { port: dashboardPort },
+        { port: dashboardPort, host: dashboardHost, token: dashboardToken },
       );
       dashboardRef.current = handle;
       setDashboardUrlState(handle.url);
@@ -2493,6 +2499,8 @@ function AppInner({
     reloadHooks,
     setPreset,
     dashboardPort,
+    dashboardHost,
+    dashboardToken,
   ]);
 
   const stopDashboard = useCallback(async (): Promise<void> => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -132,6 +132,10 @@ export interface ReasonixConfig {
   dashboard?: {
     /** Pin the embedded dashboard to a fixed port — required for stable SSH tunnels. 0/absent → ephemeral. */
     port?: number;
+    /** Bind address (#968). Defaults to 127.0.0.1 (loopback only). Set to 0.0.0.0 / :: / a LAN IP to expose to other devices; the URL token is then the only auth, so keep it secret. */
+    host?: string;
+    /** Stable URL token (#968). If unset, a fresh token is minted each boot. Min 16 chars enforced at load time. */
+    token?: string;
   };
   escalation?: {
     /** Per-turn repair/error signal count required to escalate flash→pro. Defaults to 3. Out-of-range → default. */

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,4 +1,4 @@
-/** Dashboard HTTP server — pinned to 127.0.0.1, ephemeral per-boot token; mutations require the token in the header (CSRF). */
+/** Dashboard HTTP server — defaults to 127.0.0.1 with an ephemeral per-boot token; mutations require the token in the header (CSRF). Host + token can be pinned for LAN / mobile access (#968). */
 
 import { randomBytes } from "node:crypto";
 import { type IncomingMessage, type ServerResponse, createServer } from "node:http";
@@ -8,11 +8,15 @@ import { renderIndexHtml, serveAsset } from "./assets.js";
 import type { DashboardContext } from "./context.js";
 import { handleApi } from "./router.js";
 
+/** Strict loopback set — anything outside this gets the LAN-exposure warning. */
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1", "localhost"]);
+
 export interface StartDashboardOptions {
   /** Force a specific port. 0 = ephemeral. Default: 0. */
   port?: number;
-  /** Host to bind. Argument exists for tests; production must keep 127.0.0.1 (no remote auth). */
+  /** Host to bind. Default 127.0.0.1. Set to 0.0.0.0 / :: / a LAN IP to expose to other devices (#968) — the URL token then becomes the only auth. */
   host?: string;
+  /** Pin a token across boots (#968). When unset, mintToken() generates a fresh 32-byte hex string. Min 16 chars; the caller enforces. */
   token?: string;
 }
 
@@ -212,6 +216,11 @@ export function startDashboardServer(
       const addr = server.address() as AddressInfo;
       const finalPort = addr.port;
       const url = `http://${host}:${finalPort}/?token=${token}`;
+      if (!LOOPBACK_HOSTS.has(host)) {
+        process.stderr.write(
+          `▲ Dashboard bound to ${host}:${finalPort} (non-loopback). The URL token is the only auth — keep it secret.\n`,
+        );
+      }
 
       let closed = false;
       const close = (): Promise<void> =>

--- a/tests/dashboard-host-and-token.test.ts
+++ b/tests/dashboard-host-and-token.test.ts
@@ -1,0 +1,63 @@
+/** `startDashboardServer({ host, token })` — LAN exposure + stable token (#968). */
+
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { type DashboardServerHandle, startDashboardServer } from "../src/server/index.js";
+
+const TOKEN = "stable-pinned-token-1234567890";
+
+function ctx(dir: string) {
+  return {
+    mode: "standalone" as const,
+    configPath: join(dir, "config.json"),
+    usageLogPath: join(dir, "usage.jsonl"),
+  };
+}
+
+describe("startDashboardServer host + token (#968)", () => {
+  let dir: string;
+  let handle: DashboardServerHandle | undefined;
+  let writeSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "reasonix-dashhost-"));
+    writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  });
+
+  afterEach(async () => {
+    await handle?.close();
+    handle = undefined;
+    writeSpy.mockRestore();
+    if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("defaults to 127.0.0.1 when no host is given and emits no LAN warning", async () => {
+    handle = await startDashboardServer(ctx(dir), { token: TOKEN });
+    expect(handle.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/\?token=/);
+    const warnings = writeSpy.mock.calls.map((c) => String(c[0])).filter((s) => s.includes("▲"));
+    expect(warnings).toEqual([]);
+  });
+
+  it("reuses opts.token verbatim instead of minting a fresh one", async () => {
+    handle = await startDashboardServer(ctx(dir), { token: TOKEN });
+    expect(handle.token).toBe(TOKEN);
+    expect(handle.url).toContain(`token=${TOKEN}`);
+  });
+
+  it("binds 0.0.0.0 when requested and prints a stderr warning", async () => {
+    handle = await startDashboardServer(ctx(dir), { token: TOKEN, host: "0.0.0.0" });
+    expect(handle.url).toMatch(/^http:\/\/0\.0\.0\.0:\d+\/\?token=/);
+    const warnings = writeSpy.mock.calls.map((c) => String(c[0])).filter((s) => s.includes("▲"));
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toContain("non-loopback");
+    expect(warnings[0]).toContain("token");
+  });
+
+  it("does not warn for ::1 or localhost (still loopback)", async () => {
+    handle = await startDashboardServer(ctx(dir), { token: TOKEN, host: "localhost" });
+    const warnings = writeSpy.mock.calls.map((c) => String(c[0])).filter((s) => s.includes("▲"));
+    expect(warnings).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Open the dashboard from a phone or another laptop on the same LAN (bind \`0.0.0.0\` instead of \`127.0.0.1\`).
- Pin the URL token across boots so a bookmarked link keeps working — also lets you treat the token as a fixed "password."

Both are opt-in; defaults are unchanged.

## What ships
- \`config.dashboard.host\` (default \`127.0.0.1\`) and \`config.dashboard.token\` (default: minted per boot).
- \`--dashboard-host <host>\` flag on \`code\` and \`chat\`.
- \`REASONIX_DASHBOARD_HOST\` and \`REASONIX_DASHBOARD_TOKEN\` env vars.
- Resolver order: CLI flag → env → config → server default. Tokens shorter than 16 chars are rejected with a stderr warning so users can't pin \`"password"\` by accident.
- When the bind host isn't loopback (\`127.0.0.1\` / \`::1\` / \`localhost\`), the server writes one stderr line at boot:
  > ▲ Dashboard bound to 0.0.0.0:7860 (non-loopback). The URL token is the only auth — keep it secret.

## Why this is OK security-wise
The token is already the only auth (constant-time check + CSRF header for mutations). Pinning it across boots doesn't weaken anything — a 32-byte hex token is unguessable; the 16-char minimum keeps users from regressing that property. Loopback-only stays the default; you have to opt in to expose.

## Test plan
- New \`tests/dashboard-host-and-token.test.ts\` (4 cases): localhost default → no warning; \`opts.token\` reused verbatim; \`0.0.0.0\` binds + emits the stderr warning; \`localhost\` host also stays quiet.
- \`npm run verify\` — 210 files / 3152 tests pass.

## Recipe for the requester
\`\`\`jsonc
// ~/.reasonix/config.json
{
  "dashboard": {
    "port": 7860,
    "host": "0.0.0.0",
    "token": "pick-something-random-at-least-16-chars"
  }
}
\`\`\`
Or one-off: \`REASONIX_DASHBOARD_HOST=0.0.0.0 REASONIX_DASHBOARD_TOKEN=… reasonix code\`.

Closes #968