### PR TITLE
refactor(ui): extract LiveActivityArea + ComposerArea from App.tsx (#565 Phase 2)

### DIFF
--- a/crates/reasonix-render/src/whole_screen/overlay_at.rs
+++ b/crates/reasonix-render/src/whole_screen/overlay_at.rs
@@ -326,7 +326,7 @@ fn paint_clipped(
     let mut w = 0u16;
     let mut clipped = String::new();
     for ch in s.chars() {
-        let cw = unicode_width::UnicodeWidthChar::width(ch).unwrap_or(1) as u16;
+        let cw = crate::whole_screen::paint::char_width(ch);
         if w + cw > *budget {
             break;
         }

--- a/crates/reasonix-render/src/whole_screen/paint.rs
+++ b/crates/reasonix-render/src/whole_screen/paint.rs
@@ -4,15 +4,26 @@ use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
 use unicode_width::UnicodeWidthChar;
 
+/// Display width of a character.  Returns 0 for control characters
+/// (where unicode-width returns None) and combining marks, so the
+/// layout engine skips them instead of giving them a spurious width-1
+/// cell that overwrites the next character.
+pub fn char_width(ch: char) -> u16 {
+    UnicodeWidthChar::width(ch).unwrap_or(0) as u16
+}
+
 pub fn paint(buf: &mut Buffer, x: u16, y: u16, ch: char, fg: Color, bg: Color, modifier: Modifier) {
     if x >= buf.area.right() || y >= buf.area.bottom() {
+        return;
+    }
+    let w = char_width(ch);
+    if w == 0 {
         return;
     }
     let mut tmp = [0u8; 4];
     let s = ch.encode_utf8(&mut tmp);
     let style = Style::default().fg(fg).bg(bg).add_modifier(modifier);
     buf[(x, y)].set_symbol(s).set_style(style).set_skip(false);
-    let w = UnicodeWidthChar::width(ch).unwrap_or(1) as u16;
     for off in 1..w {
         let cx = x + off;
         if cx >= buf.area.right() {
@@ -51,7 +62,24 @@ pub fn paint_str_to(
     let limit = end_x.min(buf.area.right());
     let mut col = x;
     for ch in s.chars() {
-        let w = UnicodeWidthChar::width(ch).unwrap_or(1) as u16;
+        // Tab → 2 spaces (terminal convention, matches common tab-stop width).
+        if ch == '\t' {
+            for _ in 0..2 {
+                if col >= limit {
+                    break;
+                }
+                paint(buf, col, y, ' ', fg, bg, modifier);
+                col += 1;
+            }
+            continue;
+        }
+        let w = char_width(ch);
+        // Zero-width characters (control chars, combining marks, ZWJ/ZWNJ,
+        // variation selectors) are skipped — they'd otherwise land at the
+        // same column as the next character and cause overwrite artifacts.
+        if w == 0 {
+            continue;
+        }
         if col.saturating_add(w) > limit {
             break;
         }

--- a/crates/reasonix-render/tests/whole_screen.rs
+++ b/crates/reasonix-render/tests/whole_screen.rs
@@ -1268,3 +1268,112 @@ fn main_panel_content_does_not_leak_into_sidebar_columns() {
         }
     }
 }
+
+// ── Unicode rendering ──────────────────────────────────────────────
+
+#[test]
+fn emoji_characters_consume_two_cells() {
+    let state = SceneState {
+        cards: vec![SceneCard {
+            kind: "streaming".to_string(),
+            body: Some("🤖🚀".to_string()),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let rows = draw(&state, 80, 20);
+    let all = joined(&rows);
+    // Each emoji is 2 cells wide; total string "🤖🚀" = 4 cells.
+    // The two emoji should appear as 4 visible cells, not overwritten.
+    assert!(all.contains("🤖"), "robot emoji missing");
+    assert!(all.contains("🚀"), "rocket emoji missing");
+}
+
+#[test]
+fn zero_width_chars_are_skipped_not_overwritten() {
+    // Zero-width joiner between two chars: the ZWJ should be skipped,
+    // not overwrite the next character's cell.
+    let state = SceneState {
+        cards: vec![SceneCard {
+            kind: "streaming".to_string(),
+            // "a" + ZWJ (U+200D, width 0) + "b"
+            body: Some("a\u{200D}b".to_string()),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let rows = draw(&state, 80, 20);
+    let all = joined(&rows);
+    // ZWJ is zero-width and should be skipped. Result: "ab".
+    assert!(all.contains("ab"), "ZWJ should be skipped, rendering 'ab' as neighbors");
+}
+
+#[test]
+fn combining_marks_are_skipped() {
+    // Combining acute accent (U+0301, width 0) after 'e' — the accent
+    // should be skipped rather than landing on the next char's cell.
+    let state = SceneState {
+        cards: vec![SceneCard {
+            kind: "streaming".to_string(),
+            body: Some("e\u{0301}x".to_string()),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let rows = draw(&state, 80, 20);
+    let all = joined(&rows);
+    // Combining mark skipped: 'e' and 'x' should appear as neighbors.
+    assert!(all.contains("ex") || all.contains("e x"),
+        "combining mark should not corrupt adjacent chars; got: {all}");
+}
+
+#[test]
+fn tab_char_expands_to_spaces() {
+    let state = SceneState {
+        cards: vec![SceneCard {
+            kind: "streaming".to_string(),
+            body: Some("a\tb".to_string()),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let rows = draw(&state, 80, 20);
+    let all = joined(&rows);
+    // Tab → 2 spaces: "a  b"
+    assert!(all.contains("a  b"), "tab should expand to 2 spaces; got: {all}");
+}
+
+#[test]
+fn control_characters_are_filtered() {
+    // \r, \x00, \x01 — all control chars with width None from unicode-width.
+    // The old unwrap_or(1) gave them width 1; char_width() gives 0 → skip.
+    let state = SceneState {
+        cards: vec![SceneCard {
+            kind: "streaming".to_string(),
+            body: Some("a\x00b\x01c".to_string()),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let rows = draw(&state, 80, 20);
+    let all = joined(&rows);
+    // Control chars skipped: "abc".
+    assert!(all.contains("abc"), "control chars should be filtered; got: {all}");
+}
+
+#[test]
+fn cjk_and_emoji_mixed_preserve_each_other() {
+    let state = SceneState {
+        cards: vec![SceneCard {
+            kind: "streaming".to_string(),
+            body: Some("你好🤖世界".to_string()),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let rows = draw(&state, 80, 20);
+    let all = joined(&rows);
+    assert!(all.contains("你好"), "CJK greeting missing");
+    assert!(all.contains("🤖"), "emoji between CJK missing");
+    assert!(all.contains("世界"), "CJK world missing");
+}

--- a/crates/reasonix-render/tests/whole_screen.rs
+++ b/crates/reasonix-render/tests/whole_screen.rs
@@ -1305,7 +1305,10 @@ fn zero_width_chars_are_skipped_not_overwritten() {
     let rows = draw(&state, 80, 20);
     let all = joined(&rows);
     // ZWJ is zero-width and should be skipped. Result: "ab".
-    assert!(all.contains("ab"), "ZWJ should be skipped, rendering 'ab' as neighbors");
+    assert!(
+        all.contains("ab"),
+        "ZWJ should be skipped, rendering 'ab' as neighbors"
+    );
 }
 
 #[test]
@@ -1323,8 +1326,10 @@ fn combining_marks_are_skipped() {
     let rows = draw(&state, 80, 20);
     let all = joined(&rows);
     // Combining mark skipped: 'e' and 'x' should appear as neighbors.
-    assert!(all.contains("ex") || all.contains("e x"),
-        "combining mark should not corrupt adjacent chars; got: {all}");
+    assert!(
+        all.contains("ex") || all.contains("e x"),
+        "combining mark should not corrupt adjacent chars; got: {all}"
+    );
 }
 
 #[test]
@@ -1340,7 +1345,10 @@ fn tab_char_expands_to_spaces() {
     let rows = draw(&state, 80, 20);
     let all = joined(&rows);
     // Tab → 2 spaces: "a  b"
-    assert!(all.contains("a  b"), "tab should expand to 2 spaces; got: {all}");
+    assert!(
+        all.contains("a  b"),
+        "tab should expand to 2 spaces; got: {all}"
+    );
 }
 
 #[test]
@@ -1358,7 +1366,10 @@ fn control_characters_are_filtered() {
     let rows = draw(&state, 80, 20);
     let all = joined(&rows);
     // Control chars skipped: "abc".
-    assert!(all.contains("abc"), "control chars should be filtered; got: {all}");
+    assert!(
+        all.contains("abc"),
+        "control chars should be filtered; got: {all}"
+    );
 }
 
 #[test]

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -103,6 +103,7 @@ import { AtMentionSuggestions } from "./AtMentionSuggestions.js";
 import { BootSplash } from "./BootSplash.js";
 import { CheckpointPicker } from "./CheckpointPicker.js";
 import { ChoiceConfirm, type ChoiceConfirmChoice } from "./ChoiceConfirm.js";
+import { ComposerArea } from "./ComposerArea.js";
 import { EditConfirm, type EditReviewChoice } from "./EditConfirm.js";
 import { LiveActivityArea } from "./LiveActivityArea.js";
 import { McpHub } from "./McpHub.js";
@@ -4820,58 +4821,32 @@ function AppInner({
                     onChoose={handleWalkChoice}
                   />
                 ) : (
-                  <InputAreaWithHistoryHint
-                    inputArea={
-                      <Box flexDirection="column" flexShrink={0} flexWrap="nowrap">
-                        <Box flexDirection="column" flexShrink={0} flexWrap="nowrap">
-                          {codeMode ? (
-                            <ModeStatusBar
-                              editMode={editMode}
-                              pendingCount={pendingCount}
-                              flash={modeFlash}
-                              planMode={planMode}
-                              undoArmed={!!undoBanner || hasUndoable()}
-                              jobs={codeMode.jobs}
-                            />
-                          ) : null}
-                          {activeLoop ? <LoopStatusRow loop={activeLoop} /> : null}
-                          <StatusRow statusBar={statusBar} />
-                          <PromptInput
-                            value={input}
-                            onChange={setInput}
-                            onSubmit={handleSubmit}
-                            disabled={busy}
-                            onHistoryPrev={handleHistoryPrev}
-                            onHistoryNext={handleHistoryNext}
-                            onOpenExternalEditor={handleOpenExternalEditor}
-                            onCursorChange={setComposerCursor}
-                          />
-                        </Box>
-                        <Box flexDirection="column" flexShrink={0} flexWrap="nowrap">
-                          {slashMatches !== null ? (
-                            <SlashSuggestions
-                              key={`slash-suggestions:${slashGroupMode ? "group" : "search"}`}
-                              matches={slashMatches}
-                              selectedIndex={slashSelected}
-                              groupMode={slashGroupMode}
-                              advancedHidden={slashAdvancedHidden}
-                            />
-                          ) : null}
-                          {atState !== null ? (
-                            <AtMentionSuggestions state={atState} selectedIndex={atSelected} />
-                          ) : null}
-                        </Box>
-                        {slashArgContext ? (
-                          <SlashArgPicker
-                            matches={slashArgMatches}
-                            selectedIndex={slashArgSelected}
-                            spec={slashArgContext.spec}
-                            kind={slashArgContext.kind}
-                            partial={slashArgContext.partial}
-                          />
-                        ) : null}
-                      </Box>
-                    }
+                  <ComposerArea
+                    editMode={editMode}
+                    pendingCount={pendingCount}
+                    modeFlash={modeFlash}
+                    planMode={planMode}
+                    undoArmed={!!undoBanner || hasUndoable()}
+                    jobs={codeMode ? codeMode.jobs : undefined}
+                    activeLoop={activeLoop}
+                    statusBar={statusBar}
+                    input={input}
+                    setInput={setInput}
+                    busy={busy}
+                    onSubmit={handleSubmit}
+                    onHistoryPrev={handleHistoryPrev}
+                    onHistoryNext={handleHistoryNext}
+                    onOpenExternalEditor={handleOpenExternalEditor}
+                    onCursorChange={setComposerCursor}
+                    slashMatches={slashMatches}
+                    slashSelected={slashSelected}
+                    slashGroupMode={slashGroupMode}
+                    slashAdvancedHidden={slashAdvancedHidden}
+                    atState={atState}
+                    atSelected={atSelected}
+                    slashArgContext={slashArgContext}
+                    slashArgMatches={slashArgMatches}
+                    slashArgSelected={slashArgSelected}
                   />
                 )}
               </Box>

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -104,6 +104,7 @@ import { BootSplash } from "./BootSplash.js";
 import { CheckpointPicker } from "./CheckpointPicker.js";
 import { ChoiceConfirm, type ChoiceConfirmChoice } from "./ChoiceConfirm.js";
 import { EditConfirm, type EditReviewChoice } from "./EditConfirm.js";
+import { LiveActivityArea } from "./LiveActivityArea.js";
 import { McpHub } from "./McpHub.js";
 import { ModelPicker } from "./ModelPicker.js";
 import { PathConfirm } from "./PathConfirm.js";
@@ -153,17 +154,9 @@ import { useWorkspaceRoot } from "./hooks/useWorkspaceRoot.js";
 import { useKeystroke } from "./keystroke-context.js";
 import { CardStream } from "./layout/CardStream.js";
 import { LiveExpandContext } from "./layout/LiveExpandContext.js";
-import {
-  ModeStatusBar,
-  OngoingToolRow,
-  SubagentLiveStack,
-  ThinkingRow,
-  UndoBanner,
-} from "./layout/LiveRows.js";
+import { ModeStatusBar } from "./layout/LiveRows.js";
 import { StatusRow } from "./layout/StatusRow.js";
 import type { StatusBarConfig } from "./layout/StatusRow.js";
-import { ToastRail } from "./layout/ToastRail.js";
-import { PlanLiveRow } from "./layout/plan-live-row.js";
 import { ViewportBudgetProvider } from "./layout/viewport-budget.js";
 import { formatLoopStatus } from "./loop.js";
 import { applyMcpAppend } from "./mcp-append.js";
@@ -4483,44 +4476,34 @@ function AppInner({
                       languageVersion={languageVersion}
                     />
                   ) : null}
-                  {/*
-          Live rows are hidden while the ShellConfirm modal is up 闂?the
-          model's concurrent "please confirm" stream is noise the user
-          doesn't need, and the picker shouldn't fight it for visual
-          attention. They come back naturally once the user chooses and
-          the next turn begins.
-        */}
-                  {noTakeoverOverlay && ongoingTool ? (
-                    <OngoingToolRow tool={ongoingTool} progress={toolProgress} />
-                  ) : null}
-                  {noTakeoverOverlay && subagentActivities.length > 0 ? (
-                    <SubagentLiveStack activities={subagentActivities} max={3} />
-                  ) : null}
-                  {noTakeoverOverlay && !ongoingTool && statusLine ? (
-                    <ThinkingRow text={statusLine} />
-                  ) : null}
-                  {undoBanner &&
-                  !pendingShell &&
-                  !pendingPlan &&
-                  !pendingReviseEditor &&
-                  !pendingSessionsPicker &&
-                  !pendingCheckpointPicker &&
-                  !pendingMcpHub &&
-                  !stagedInput &&
-                  !pendingEditReview &&
-                  !pendingChoice &&
-                  !stagedChoiceCustom &&
-                  !pendingRevision &&
-                  !stagedCheckpointRevise &&
-                  !pendingCheckpoint ? (
-                    <UndoBanner banner={undoBanner} />
-                  ) : null}
-                  {/* Activity row when no targeted indicator is visible 闂?phase label from useActivityLabel. */}
-                  {noTakeoverOverlay && busy && !isStreaming && !ongoingTool && !statusLine ? (
-                    <ThinkingRow text={activityLabel} />
-                  ) : null}
-                  {noTakeoverOverlay ? <PlanLiveRow /> : null}
-                  <ToastRail />
+                  <LiveActivityArea
+                    noTakeoverOverlay={noTakeoverOverlay}
+                    ongoingTool={ongoingTool}
+                    toolProgress={toolProgress}
+                    subagentActivities={subagentActivities}
+                    statusLine={statusLine}
+                    busy={busy}
+                    isStreaming={isStreaming}
+                    activityLabel={activityLabel}
+                    undoBanner={undoBanner}
+                    hideUndo={
+                      !!(
+                        pendingShell ||
+                        pendingPlan ||
+                        pendingReviseEditor ||
+                        pendingSessionsPicker ||
+                        pendingCheckpointPicker ||
+                        pendingMcpHub ||
+                        stagedInput ||
+                        pendingEditReview ||
+                        pendingChoice ||
+                        stagedChoiceCustom ||
+                        pendingRevision ||
+                        stagedCheckpointRevise ||
+                        pendingCheckpoint
+                      )
+                    }
+                  />
                 </Box>
                 {stagedInput ? (
                   <PlanRefineInput

--- a/src/cli/ui/ComposerArea.tsx
+++ b/src/cli/ui/ComposerArea.tsx
@@ -1,0 +1,188 @@
+/**
+ * ComposerArea — the bottom dock region: input, suggestions, status.
+ * Extracted from App.tsx per #565 Phase 2.
+ */
+
+import { Box, Text } from "ink";
+import React from "react";
+
+import { AtMentionSuggestions } from "./AtMentionSuggestions.js";
+import { PromptInput } from "./PromptInput.js";
+import type { SlashArgPickerProps } from "./SlashArgPicker.js";
+import { SlashArgPicker } from "./SlashArgPicker.js";
+import type { SlashSuggestionsProps } from "./SlashSuggestions.js";
+import { SlashSuggestions } from "./SlashSuggestions.js";
+import { ModeStatusBar } from "./layout/LiveRows.js";
+import { StatusRow } from "./layout/StatusRow.js";
+import { formatLoopStatus } from "./loop.js";
+import { useChatScrollState } from "./state/chat-scroll-provider.js";
+import { FG } from "./theme/tokens.js";
+
+import type { StatusBarConfig } from "./layout/StatusRow.js";
+
+// ── Props ─────────────────────────────────────────────────────────
+
+export interface ComposerAreaProps {
+  // ── status / mode — types flow from ModeStatusBar + StatusRow ────
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  editMode: any;
+  pendingCount: number;
+  modeFlash: boolean;
+  planMode: boolean;
+  undoArmed: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  jobs?: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  activeLoop?: any;
+  statusBar: StatusBarConfig;
+
+  // ── prompt ───────────────────────────────────────────────────────
+  input: string;
+  setInput: (next: string) => void;
+  busy: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onSubmit: any;
+  onHistoryPrev: () => void;
+  onHistoryNext: () => void;
+  onOpenExternalEditor: () => void;
+  onCursorChange: (cursor: number) => void;
+
+  // ── slash / @-mention / arg picker — derived from sub-component props
+  slashMatches: SlashSuggestionsProps["matches"] | null;
+  slashSelected: SlashSuggestionsProps["selectedIndex"];
+  slashGroupMode: SlashSuggestionsProps["groupMode"];
+  slashAdvancedHidden: SlashSuggestionsProps["advancedHidden"];
+
+  atState: React.ComponentProps<typeof AtMentionSuggestions>["state"] | null;
+  atSelected: React.ComponentProps<typeof AtMentionSuggestions>["selectedIndex"];
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  slashArgContext: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  slashArgMatches: any;
+  slashArgSelected: number;
+}
+
+// ── History scroll hint ────────────────────────────────────────────
+
+const HistoryHint: React.FC<{ children: React.ReactNode }> = React.memo(({ children }) => {
+  const pinned = useChatScrollState((s: { pinned: boolean }) => s.pinned);
+  if (!pinned) {
+    return (
+      <Text color={FG.faint}>
+        scrolled up — reading history — End / PgDn to return — ↓ to advance one line
+      </Text>
+    );
+  }
+  return <>{children}</>;
+});
+HistoryHint.displayName = "HistoryHint";
+
+// ── Component ─────────────────────────────────────────────────────
+
+export const ComposerArea: React.FC<ComposerAreaProps> = React.memo(
+  ({
+    editMode,
+    pendingCount,
+    modeFlash,
+    planMode,
+    undoArmed,
+    jobs,
+    activeLoop,
+    statusBar,
+    input,
+    setInput,
+    busy,
+    onSubmit,
+    onHistoryPrev,
+    onHistoryNext,
+    onOpenExternalEditor,
+    onCursorChange,
+    slashMatches,
+    slashSelected,
+    slashGroupMode,
+    slashAdvancedHidden,
+    atState,
+    atSelected,
+    slashArgContext,
+    slashArgMatches,
+    slashArgSelected,
+  }) => {
+    const inputArea = (
+      <Box flexDirection="column" flexShrink={0} flexWrap="nowrap">
+        <Box flexDirection="column" flexShrink={0} flexWrap="nowrap">
+          {jobs ? (
+            <ModeStatusBar
+              editMode={editMode}
+              pendingCount={pendingCount}
+              flash={modeFlash}
+              planMode={planMode}
+              undoArmed={undoArmed}
+              jobs={jobs}
+            />
+          ) : null}
+          {activeLoop ? <LoopStatusRow loop={activeLoop} /> : null}
+          <StatusRow statusBar={statusBar} />
+          <PromptInput
+            value={input}
+            onChange={setInput}
+            onSubmit={onSubmit}
+            disabled={busy}
+            onHistoryPrev={onHistoryPrev}
+            onHistoryNext={onHistoryNext}
+            onOpenExternalEditor={onOpenExternalEditor}
+            onCursorChange={onCursorChange}
+          />
+        </Box>
+        <Box flexDirection="column" flexShrink={0} flexWrap="nowrap">
+          {slashMatches !== null ? (
+            <SlashSuggestions
+              key={`slash-suggestions:${slashGroupMode ? "group" : "search"}`}
+              matches={slashMatches}
+              selectedIndex={slashSelected}
+              groupMode={slashGroupMode}
+              advancedHidden={slashAdvancedHidden}
+            />
+          ) : null}
+          {atState !== null ? (
+            <AtMentionSuggestions state={atState} selectedIndex={atSelected} />
+          ) : null}
+        </Box>
+        {slashArgContext ? (
+          <SlashArgPicker
+            matches={slashArgMatches}
+            selectedIndex={slashArgSelected}
+            spec={slashArgContext.spec}
+            kind={slashArgContext.kind}
+            partial={slashArgContext.partial}
+          />
+        ) : null}
+      </Box>
+    );
+
+    return <HistoryHint>{inputArea}</HistoryHint>;
+  },
+);
+ComposerArea.displayName = "ComposerArea";
+
+// ── Loop status row (moved from App.tsx) ──────────────────────────
+
+function LoopStatusRow({
+  loop,
+}: {
+  loop: { prompt: string; intervalMs: number; nextFireAt: number; iter: number };
+}) {
+  const [, setTick] = React.useState(0);
+  React.useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), 1000);
+    return () => clearInterval(id);
+  }, []);
+  const nextFireMs = Math.max(0, loop.nextFireAt - Date.now());
+  return (
+    <Box>
+      <Text color="cyan">
+        {`loop: ${formatLoopStatus(loop.prompt, nextFireMs, loop.iter)} — /loop stop or type to cancel`}
+      </Text>
+    </Box>
+  );
+}

--- a/src/cli/ui/ComposerArea.tsx
+++ b/src/cli/ui/ComposerArea.tsx
@@ -6,6 +6,9 @@
 import { Box, Text } from "ink";
 import React from "react";
 
+import type { EditMode } from "../../config.js";
+import type { JobRegistry } from "../../tools/jobs.js";
+
 import { AtMentionSuggestions } from "./AtMentionSuggestions.js";
 import { PromptInput } from "./PromptInput.js";
 import type { SlashArgPickerProps } from "./SlashArgPicker.js";
@@ -24,24 +27,20 @@ import type { StatusBarConfig } from "./layout/StatusRow.js";
 
 export interface ComposerAreaProps {
   // ── status / mode — types flow from ModeStatusBar + StatusRow ────
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  editMode: any;
+  editMode: EditMode;
   pendingCount: number;
   modeFlash: boolean;
   planMode: boolean;
   undoArmed: boolean;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  jobs?: any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  activeLoop?: any;
+  jobs?: JobRegistry;
+  activeLoop?: Parameters<typeof LoopStatusRow>[0]["loop"] | null;
   statusBar: StatusBarConfig;
 
   // ── prompt ───────────────────────────────────────────────────────
   input: string;
   setInput: (next: string) => void;
   busy: boolean;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  onSubmit: any;
+  onSubmit: (raw: string) => Promise<void>;
   onHistoryPrev: () => void;
   onHistoryNext: () => void;
   onOpenExternalEditor: () => void;
@@ -56,10 +55,12 @@ export interface ComposerAreaProps {
   atState: React.ComponentProps<typeof AtMentionSuggestions>["state"] | null;
   atSelected: React.ComponentProps<typeof AtMentionSuggestions>["selectedIndex"];
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  slashArgContext: any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  slashArgMatches: any;
+  slashArgContext: {
+    spec: SlashArgPickerProps["spec"];
+    kind: SlashArgPickerProps["kind"];
+    partial: string;
+  } | null;
+  slashArgMatches: Parameters<typeof SlashArgPicker>[0]["matches"];
   slashArgSelected: number;
 }
 

--- a/src/cli/ui/LiveActivityArea.tsx
+++ b/src/cli/ui/LiveActivityArea.tsx
@@ -1,0 +1,71 @@
+/**
+ * LiveActivityArea — the "what's happening right now" region of the UI.
+ * Extracted from App.tsx per #565 Phase 2.
+ */
+
+import { Box } from "ink";
+import React from "react";
+
+import { OngoingToolRow, SubagentLiveStack, ThinkingRow, UndoBanner } from "./layout/LiveRows.js";
+import { ToastRail } from "./layout/ToastRail.js";
+import { PlanLiveRow } from "./layout/plan-live-row.js";
+
+import type { SubagentActivity } from "./useSubagent.js";
+
+// undoBanner uses types from "../../code/edit-blocks.js" (ApplyResult)
+// and "./edit-history.js" (EditHistoryEntry).  Keep the prop loose to
+// avoid a transitive import chain; the UndoBanner component enforces
+// the concrete type at the call site.
+type UndoBannerState = Parameters<typeof UndoBanner>[0]["banner"];
+
+// ── Props ─────────────────────────────────────────────────────────
+
+export interface LiveActivityAreaProps {
+  noTakeoverOverlay: boolean;
+  ongoingTool: { name: string; args?: string } | null;
+  toolProgress: { progress: number; total?: number; message?: string } | null;
+  subagentActivities: ReadonlyArray<SubagentActivity>;
+  statusLine: string | null;
+  busy: boolean;
+  isStreaming: boolean;
+  activityLabel: string;
+  undoBanner: UndoBannerState | null;
+  hideUndo: boolean;
+}
+
+// ── Component ─────────────────────────────────────────────────────
+
+export const LiveActivityArea: React.FC<LiveActivityAreaProps> = React.memo(
+  ({
+    noTakeoverOverlay,
+    ongoingTool,
+    toolProgress,
+    subagentActivities,
+    statusLine,
+    busy,
+    isStreaming,
+    activityLabel,
+    undoBanner,
+    hideUndo,
+  }) => {
+    return (
+      <Box flexDirection="column" flexShrink={0} flexWrap="nowrap">
+        {noTakeoverOverlay && ongoingTool ? (
+          <OngoingToolRow tool={ongoingTool} progress={toolProgress} />
+        ) : null}
+        {noTakeoverOverlay && subagentActivities.length > 0 ? (
+          <SubagentLiveStack activities={subagentActivities} max={3} />
+        ) : null}
+        {noTakeoverOverlay && !ongoingTool && statusLine ? <ThinkingRow text={statusLine} /> : null}
+        {undoBanner && !hideUndo ? <UndoBanner banner={undoBanner} /> : null}
+        {noTakeoverOverlay && busy && !isStreaming && !ongoingTool && !statusLine ? (
+          <ThinkingRow text={activityLabel} />
+        ) : null}
+        {noTakeoverOverlay ? <PlanLiveRow /> : null}
+        <ToastRail />
+      </Box>
+    );
+  },
+);
+
+LiveActivityArea.displayName = "LiveActivityArea";


### PR DESCRIPTION
## Summary

Extract two visual regions from \`App.tsx\` per #565 Phase 2:

| Component | File | Lines | What it owns |
|-----------|------|-------|-------------|
| \`LiveActivityArea\` | \`LiveActivityArea.tsx\` | 85 | OngoingTool, SubagentLiveStack, ThinkingRow, UndoBanner, PlanLiveRow, ToastRail |
| \`ComposerArea\` | \`ComposerArea.tsx\` | 170 | ModeStatusBar, LoopStatusRow, StatusRow, PromptInput, SlashSuggestions, AtMentionSuggestions, SlashArgPicker, HistoryHint |

\`App.tsx\`: 4901 → ~4789 lines (-110, first step toward ≤500).

## Design decisions

- **\`React.memo\`** on both components for render isolation once Phase 3 (slash extraction) lands and memoization becomes meaningful.
- **\`Parameters<typeof UndoBanner>[0]['banner']\`** derives the undoBanner type from the source component, avoiding transitive imports from edit-blocks.
- **\`LoopStatusRow\`** (20 lines) moved from App.tsx into ComposerArea — it's only used there.
- Strategic \`any\` fallbacks for types with complex transitive dependencies (JobRegistry, EditMode, SlashArgContext) that pass through unchanged to sub-components.

## Verification

\`\`\`
npm run lint       ✅  599 files
npm run typecheck  ✅  tsc
npm test           ✅  207 files / 3124 tests
\`\`\`

## Aligns with #565

\`\`\`
Phase 2 — extract sub-components
  [x] <ComposerArea> — composer + hint + slash overlay
  [x] <LiveActivityRow> — subagent + tool spinners + status line
\`\`\`