### PR TITLE
feat(ui): ".." parent entry in the @ mention picker (desktop + CLI)

### DIFF
--- a/desktop/src/ui/composer.tsx
+++ b/desktop/src/ui/composer.tsx
@@ -95,6 +95,18 @@ function slashIcon(cmd: string) {
   return m[cmd] || <I.slash size={12} />;
 }
 
+/** Parent dir of the current @ query, with trailing slash. `null` = no parent to show (at workspace root). */
+function parentOfAtQuery(query: string): string | null {
+  const normalized = query.replace(/\\/g, "/");
+  const trailingSlash = normalized.endsWith("/");
+  const lastSlash = normalized.lastIndexOf("/");
+  if (lastSlash < 0) return null;
+  const dirContext = trailingSlash ? normalized.slice(0, -1) : normalized.slice(0, lastSlash);
+  if (!dirContext) return null;
+  const parentIdx = dirContext.lastIndexOf("/");
+  return parentIdx >= 0 ? `${dirContext.slice(0, parentIdx)}/` : "";
+}
+
 function atIcon(k: MentionItem["kind"]) {
   if (k === "file") return <I.file size={12} />;
   if (k === "dir") return <I.folder size={12} />;
@@ -218,11 +230,21 @@ export function Composer({
   const atItems = useMemo<MentionItem[]>(() => {
     if (!popup || popup.kind !== "at") return [];
     if (!mentionResults || mentionResults.nonce !== popup.nonce) return [];
-    return mentionResults.results.map((path) => ({
+    const base: MentionItem[] = mentionResults.results.map((path) => ({
       name: path,
       kind: path.endsWith("/") || path.endsWith("\\") ? "dir" : "file",
       desc: path,
     }));
+    // "../" entry (#1019): one level up whenever the @ query is inside a subdir.
+    const parent = parentOfAtQuery(popup.query);
+    if (parent !== null) {
+      base.unshift({
+        name: "..",
+        kind: "dir",
+        desc: parent ? `↑ ${parent}` : "↑ workspace root",
+      });
+    }
+    return base;
   }, [popup, mentionResults]);
 
   const items = popup?.kind === "slash" ? slashItems : popup?.kind === "at" ? atItems : [];
@@ -267,6 +289,15 @@ export function Composer({
       (it as SlashCmd).run();
     } else {
       const mention = it as MentionItem;
+      if (mention.name === "..") {
+        const parent = parentOfAtQuery(popup.query) ?? "";
+        const next = draft.replace(/[@][^\s]*$/, `@${parent}`);
+        setDraft(next);
+        const nonce = ++nonceRef.current;
+        setPopup({ kind: "at", query: parent, nonce });
+        textareaRef.current?.focus();
+        return;
+      }
       const next = draft.replace(/[/@][^\s]*$/, "").trimEnd();
       setDraft(next ? `${next} @${mention.name} ` : `@${mention.name} `);
       setChips((c) => [...c, { kind: "at", label: mention.name }]);
@@ -296,10 +327,21 @@ export function Composer({
       if (e.key === "Tab" && popup.kind === "at" && items.length > 0) {
         // Tab on a directory enters it — replaces `@src` with `@src/`
         // and re-queries so the popup shows that directory's children.
+        // `..` is the synthetic parent-dir entry (#1019); same shape
+        // but rewrites to the parent path.
         const it = items[activeIdx];
         if (it && (it as MentionItem).kind === "dir") {
           e.preventDefault();
-          const dirPath = (it as MentionItem).name.replace(/\/+$/, "");
+          const mention = it as MentionItem;
+          if (mention.name === "..") {
+            const parent = parentOfAtQuery(popup.query) ?? "";
+            const next = draft.replace(/[@][^\s]*$/, `@${parent}`);
+            setDraft(next);
+            const nonce = ++nonceRef.current;
+            setPopup({ kind: "at", query: parent, nonce });
+            return;
+          }
+          const dirPath = mention.name.replace(/\/+$/, "");
           const next = draft.replace(/[@][^\s]*$/, `@${dirPath}/`);
           setDraft(next);
           const nonce = ++nonceRef.current;

--- a/src/cli/ui/useCompletionPickers.ts
+++ b/src/cli/ui/useCompletionPickers.ts
@@ -41,6 +41,8 @@ export interface AtPickerEntry {
   /** Dim suffix shown after the label ("src/auth/" for "src/auth/login.ts" search hits). Empty in browse mode. */
   dirSuffix: string;
   isDir: boolean;
+  /** Synthetic parent-nav entry (#1019) — always drills regardless of pick action so Enter doesn't commit "@<parent> " as a literal mention. */
+  synthetic?: "parent";
 }
 
 export type AtPickerState =
@@ -154,10 +156,13 @@ export function useCompletionPickers({
   const atState = useMemo<AtPickerState | null>(() => {
     if (!parsed) return null;
     if (atMode === "browse") {
+      const entries = browseDir
+        ? ([parentBrowseEntry(browseDir), ...browse.entries] as readonly AtPickerEntry[])
+        : browse.entries;
       return {
         kind: "browse",
         baseDir: browseDir,
-        entries: browse.entries,
+        entries,
         loading: browse.loading,
       };
     }
@@ -183,8 +188,8 @@ export function useCompletionPickers({
     (entry: AtPickerEntry, action: "commit" | "drill") => {
       if (!atPicker) return;
       const before = input.slice(0, atPicker.atOffset);
-      const tail =
-        action === "drill" && entry.isDir ? `${entry.insertPath}/` : `${entry.insertPath} `;
+      const shouldDrill = entry.synthetic === "parent" || (action === "drill" && entry.isDir);
+      const tail = shouldDrill ? `${entry.insertPath}/` : `${entry.insertPath} `;
       setInput(`${before}@${tail}`);
     },
     [atPicker, input, setInput],
@@ -451,6 +456,19 @@ function useBrowseListing(rootDir: string, dir: string | null) {
 
 function toBrowseEntry(d: DirEntry): AtPickerEntry {
   return { label: d.name, insertPath: d.path, dirSuffix: "", isDir: d.isDir };
+}
+
+/** Synthetic "go to parent" entry for browse mode (#1019). insertPath = "" routes drill back to the workspace root. */
+function parentBrowseEntry(currentDir: string): AtPickerEntry {
+  const idx = currentDir.lastIndexOf("/");
+  const parentDir = idx >= 0 ? currentDir.slice(0, idx) : "";
+  return {
+    label: "..",
+    insertPath: parentDir,
+    dirSuffix: parentDir ? `↑ ${parentDir}/` : "↑ /",
+    isDir: true,
+    synthetic: "parent",
+  };
 }
 
 function useStreamingSearch(

--- a/tests/mention-parent-entry.test.ts
+++ b/tests/mention-parent-entry.test.ts
@@ -1,0 +1,57 @@
+/** Synthetic "go to parent" entry for @ pickers (#1019) — pure path-math helpers used by both the desktop composer and the CLI at-mention browser. */
+
+import { describe, expect, it } from "vitest";
+
+/** Replicates `parentOfAtQuery` in desktop/src/ui/composer.tsx — returning the parent directory (with trailing slash) of the @ query, or null when there's nowhere to go. */
+function parentOfAtQuery(query: string): string | null {
+  const normalized = query.replace(/\\/g, "/");
+  const trailingSlash = normalized.endsWith("/");
+  const lastSlash = normalized.lastIndexOf("/");
+  if (lastSlash < 0) return null;
+  const dirContext = trailingSlash ? normalized.slice(0, -1) : normalized.slice(0, lastSlash);
+  if (!dirContext) return null;
+  const parentIdx = dirContext.lastIndexOf("/");
+  return parentIdx >= 0 ? `${dirContext.slice(0, parentIdx)}/` : "";
+}
+
+/** Replicates `parentBrowseEntry` in src/cli/ui/useCompletionPickers.ts — returning the insertPath to wire into the CLI synthetic ".." entry. Browse mode only fires when the current dir is non-empty so we never call this at the root. */
+function parentBrowseInsertPath(currentDir: string): string {
+  const idx = currentDir.lastIndexOf("/");
+  return idx >= 0 ? currentDir.slice(0, idx) : "";
+}
+
+describe("parentOfAtQuery (desktop)", () => {
+  it("returns null for a bare filter at the root", () => {
+    expect(parentOfAtQuery("App")).toBeNull();
+    expect(parentOfAtQuery("")).toBeNull();
+  });
+
+  it("returns '' (workspace root) for a one-level query", () => {
+    expect(parentOfAtQuery("src/")).toBe("");
+    expect(parentOfAtQuery("src/App")).toBe("");
+  });
+
+  it("strips one segment when nested", () => {
+    expect(parentOfAtQuery("pkg/module/")).toBe("pkg/");
+    expect(parentOfAtQuery("pkg/module/Foo")).toBe("pkg/");
+    expect(parentOfAtQuery("a/b/c/d/")).toBe("a/b/c/");
+    expect(parentOfAtQuery("frontend/components/")).toBe("frontend/");
+  });
+
+  it("normalises Windows separators", () => {
+    expect(parentOfAtQuery("frontend\\components\\")).toBe("frontend/");
+    expect(parentOfAtQuery("a\\b\\c\\App")).toBe("a/b/");
+  });
+});
+
+describe("parentBrowseInsertPath (CLI)", () => {
+  it("returns '' for a single-segment browse dir (back to workspace root)", () => {
+    expect(parentBrowseInsertPath("src")).toBe("");
+    expect(parentBrowseInsertPath("frontend")).toBe("");
+  });
+
+  it("pops one segment for nested dirs", () => {
+    expect(parentBrowseInsertPath("pkg/module")).toBe("pkg");
+    expect(parentBrowseInsertPath("a/b/c")).toBe("a/b");
+  });
+});


### PR DESCRIPTION
## Summary
#1019 — once you Tab into a subdir via \`@\` to browse, there's no way to back out without retyping the path. Add a synthetic \`..\` entry at the top of the picker whenever the browse context is inside a subdir; absent at the workspace root where it'd be meaningless.

## Desktop composer
- \`atItems\` prepends a \`{ name: "..", kind: "dir" }\` mention when \`parentOfAtQuery(popup.query)\` is non-null, with a dim hint showing the parent path (or "↑ workspace root" at the top level).
- \`pickItem\` and the Tab handler intercept the \`..\` entry before the normal dir-drill path and rewrite the \`@\` token to the parent's path, then re-query so the popup repaints with the parent dir.

## CLI / Ink picker
- \`useCompletionPickers\` adds a \`parentBrowseEntry\` at the head of the browse list when \`browseDir !== ""\`.
- New \`synthetic: "parent"\` flag on \`AtPickerEntry\` — \`pickAtMention\` always drills on it (otherwise Enter on \`..\` would commit \`@<parent>\` as a literal mention).
- Rust renderer's \`at_completion\` already builds \`@<insertPath>/\` for any \`is_dir: true\` entry, so the synthetic entry drills there too without a Rust-side change. The \`synthetic\` field is silently ignored by the Rust deserializer.

## Test plan
- New \`tests/mention-parent-entry.test.ts\` (6 cases) — path-math helpers for both surfaces (root short-circuit, one-level pop, multi-level nested, Windows separator normalisation).
- \`npm run verify\` — 211 files / 3158 tests pass.
- Manual:
  1. Desktop: type \`@\`, Tab into \`src/\`, Tab again into \`auth/\`. \`..\` row appears as the first entry. Tab on it → back to \`src/\` browse. Tab again → back to root.
  2. CLI: same flow inside \`reasonix code\`.

Closes #1019