### PR TITLE
fix(desktop): keep the sidecar alive on unhandled rejection / exception

### DIFF
--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -740,8 +740,22 @@ function pushMentionRecent(tab: Tab, path: string): void {
   if (tab.recentMentions.length > MAX) tab.recentMentions.length = MAX;
 }
 
+/** The desktop sidecar is a long-running daemon — Tauri spawns this Node process once per app launch and pipes JSON over stdin/stdout. Without these handlers, any orphaned promise rejection (e.g. from an aborted turn whose cleanup races a session-switch — #1074) crashes the process with exit code 1, which the Tauri host surfaces as "reasonix exited (code 1)" and a full reconnect cycle. Log loudly so we can find the underlying bug, but don't take the daemon down. */
+export function installDesktopCrashGuards(
+  stderr: { write: (s: string) => unknown } = process.stderr,
+): void {
+  process.on("unhandledRejection", (reason) => {
+    const err = reason instanceof Error ? reason : new Error(String(reason));
+    stderr.write(`[desktop] unhandledRejection: ${err.stack ?? err.message}\n`);
+  });
+  process.on("uncaughtException", (err) => {
+    stderr.write(`[desktop] uncaughtException: ${err.stack ?? err.message}\n`);
+  });
+}
+
 export async function desktopCommand(opts: DesktopOptions): Promise<void> {
   loadDotenv();
+  installDesktopCrashGuards();
 
   const tabs = new Map<string, Tab>();
   const tabContext = new AsyncLocalStorage<string>();

--- a/tests/desktop-crash-guards.test.ts
+++ b/tests/desktop-crash-guards.test.ts
@@ -1,0 +1,70 @@
+/** #1074 — the desktop sidecar must survive an unhandled rejection / uncaught exception rather than exit(1) (which Tauri surfaces as "reasonix exited (code 1)" and forces a full reconnect). */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { installDesktopCrashGuards } from "../src/cli/commands/desktop.js";
+
+function snapshotListeners() {
+  return {
+    unhandled: process.listeners("unhandledRejection").slice(),
+    uncaught: process.listeners("uncaughtException").slice(),
+  };
+}
+
+function restoreListeners(snap: ReturnType<typeof snapshotListeners>) {
+  for (const l of process.listeners("unhandledRejection")) {
+    if (!snap.unhandled.includes(l)) process.off("unhandledRejection", l);
+  }
+  for (const l of process.listeners("uncaughtException")) {
+    if (!snap.uncaught.includes(l)) process.off("uncaughtException", l);
+  }
+}
+
+describe("installDesktopCrashGuards", () => {
+  let snap: ReturnType<typeof snapshotListeners>;
+
+  beforeEach(() => {
+    snap = snapshotListeners();
+  });
+  afterEach(() => {
+    restoreListeners(snap);
+  });
+
+  it("registers one unhandledRejection + one uncaughtException listener", () => {
+    installDesktopCrashGuards();
+    expect(process.listeners("unhandledRejection").length).toBe(snap.unhandled.length + 1);
+    expect(process.listeners("uncaughtException").length).toBe(snap.uncaught.length + 1);
+  });
+
+  it("forwards rejection reasons to the injected stderr sink", () => {
+    const writes: string[] = [];
+    const fakeStderr = { write: (s: string) => writes.push(s) };
+    installDesktopCrashGuards(fakeStderr);
+
+    // Find the freshly-installed listener and call it directly — actually
+    // emitting the event would race with vitest's own watchers.
+    const installed = process.listeners("unhandledRejection").at(-1) as (reason: unknown) => void;
+    installed(new Error("synthetic boom"));
+
+    expect(writes).toHaveLength(1);
+    expect(writes[0]).toContain("[desktop] unhandledRejection");
+    expect(writes[0]).toContain("synthetic boom");
+  });
+
+  it("coerces non-Error rejection reasons", () => {
+    const writes: string[] = [];
+    installDesktopCrashGuards({ write: (s: string) => writes.push(s) });
+    const installed = process.listeners("unhandledRejection").at(-1) as (reason: unknown) => void;
+    installed("plain string");
+    expect(writes[0]).toContain("plain string");
+  });
+
+  it("forwards uncaughtException to the same sink", () => {
+    const writes: string[] = [];
+    installDesktopCrashGuards({ write: (s: string) => writes.push(s) });
+    const installed = process.listeners("uncaughtException").at(-1) as (err: Error) => void;
+    installed(new Error("synthetic crash"));
+    expect(writes).toHaveLength(1);
+    expect(writes[0]).toContain("[desktop] uncaughtException");
+    expect(writes[0]).toContain("synthetic crash");
+  });
+});


### PR DESCRIPTION
## Summary
#1074 — clicking a history session a few times surfaces **"reasonix exited (code 1)"** and reverts the UI to "正在连接 reasonix 内核…". The exit-1 is Node 16+'s default for an unhandled promise rejection, and the desktop daemon never registered the process-level guards a long-running sidecar needs.

## Root cause
The desktop sidecar is a long-running Node child process. The most likely upstream trigger is the abort + rebuild cycle in the \`session_load\` handler:

\`\`\`ts
abortTurn(tab);                       // signals the loop; in-flight fetch still rejects async
cancelPendingGates(tab);
tab.currentSession = msg.name;
if (tab.runtime) tab.runtime = buildRuntimeFor(tab);   // orphan the old runtime
\`\`\`

Replacing \`tab.runtime\` orphans whatever in-flight fetch the old client still had pending. That fetch eventually rejects with no awaiter → unhandled → process exits → Tauri shows the "exited (code 1)" banner and resets.

Locating the exact leaking promise is environment-dependent; the right behaviour for a daemon either way is to log loudly and keep serving rather than exit and force a full reconnect.

## Fix
- New \`installDesktopCrashGuards()\` registers \`unhandledRejection\` and \`uncaughtException\` listeners that forward the stack to stderr (surfaces through Tauri's existing \`rpc:stderr\` channel for debugging) but do **not** call \`process.exit\`.
- Called once from \`desktopCommand\` right after \`loadDotenv()\`.

## Test plan
- \`tests/desktop-crash-guards.test.ts\` (4 cases): listeners are installed; Error rejection forwarded; non-Error reason coerced; uncaughtException branch covered.
- \`npm run verify\` — 212 files / 3162 tests pass.

Fixes #1074