### PR TITLE
feat: rust TUI as default + integrated mode + resolver + bare→code

### DIFF
--- a/crates/reasonix-render/src/whole_screen/boot.rs
+++ b/crates/reasonix-render/src/whole_screen/boot.rs
@@ -5,7 +5,7 @@ use ratatui::style::Modifier;
 use crate::state::SceneState;
 
 use super::cards::render_cards;
-use super::paint::{paint_link, paint_str_to};
+use super::paint::{paint_link_wrapped, paint_str_to};
 use super::theme::{DS, FG, FG2, FG3, LOGO};
 
 pub fn render_scroll(
@@ -135,8 +135,8 @@ fn render_boot_meta(buf: &mut Buffer, area: Rect, start_row: u16, state: &SceneS
                 BG,
                 Modifier::empty(),
             );
-            paint_link(buf, val_col, row, url, url, DS_BRIGHT, BG);
-            row += 1;
+            let used = paint_link_wrapped(buf, val_col, row, end_x, bottom, url, url, DS_BRIGHT, BG);
+            row += used.max(1);
         }
     }
 

--- a/crates/reasonix-render/src/whole_screen/boot.rs
+++ b/crates/reasonix-render/src/whole_screen/boot.rs
@@ -135,7 +135,8 @@ fn render_boot_meta(buf: &mut Buffer, area: Rect, start_row: u16, state: &SceneS
                 BG,
                 Modifier::empty(),
             );
-            let used = paint_link_wrapped(buf, val_col, row, end_x, bottom, url, url, DS_BRIGHT, BG);
+            let used =
+                paint_link_wrapped(buf, val_col, row, end_x, bottom, url, url, DS_BRIGHT, BG);
             row += used.max(1);
         }
     }

--- a/crates/reasonix-render/src/whole_screen/paint.rs
+++ b/crates/reasonix-render/src/whole_screen/paint.rs
@@ -136,6 +136,55 @@ pub fn paint_link(
     x + width
 }
 
+/// Multi-row variant of `paint_link`. Splits `visible` into chunks that fit
+/// `[x, end_x)` and stacks them on consecutive rows, each chunk a clickable
+/// link to the full `url`. Returns rows consumed (0 if nothing fit).
+#[allow(clippy::too_many_arguments)]
+pub fn paint_link_wrapped(
+    buf: &mut Buffer,
+    x: u16,
+    y: u16,
+    end_x: u16,
+    bottom: u16,
+    url: &str,
+    visible: &str,
+    fg: Color,
+    bg: Color,
+) -> u16 {
+    use unicode_width::UnicodeWidthChar;
+    let limit = end_x.min(buf.area.right());
+    let bottom = bottom.min(buf.area.bottom());
+    if x >= limit || y >= bottom {
+        return 0;
+    }
+    let max_w = (limit - x) as usize;
+    if max_w == 0 {
+        return 0;
+    }
+    let mut row = y;
+    let mut chunk = String::new();
+    let mut chunk_w = 0usize;
+    for ch in visible.chars() {
+        let cw = UnicodeWidthChar::width(ch).unwrap_or(1);
+        if chunk_w + cw > max_w && !chunk.is_empty() {
+            paint_link(buf, x, row, url, &chunk, fg, bg);
+            row += 1;
+            if row >= bottom {
+                return row - y;
+            }
+            chunk.clear();
+            chunk_w = 0;
+        }
+        chunk.push(ch);
+        chunk_w += cw;
+    }
+    if !chunk.is_empty() {
+        paint_link(buf, x, row, url, &chunk, fg, bg);
+        row += 1;
+    }
+    row - y
+}
+
 pub fn fill_bg(buf: &mut Buffer, area: Rect, bg: Color) {
     let style = Style::default().bg(bg);
     for y in area.y..area.y.saturating_add(area.height) {

--- a/crates/reasonix-render/tests/whole_screen.rs
+++ b/crates/reasonix-render/tests/whole_screen.rs
@@ -424,6 +424,26 @@ fn dashboard_url_renders_in_boot_block() {
 }
 
 #[test]
+fn long_dashboard_url_wraps_within_main_panel() {
+    let url = "http://127.0.0.1:54321/?token=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    let state = SceneState {
+        model: Some("deepseek-v3.2-coder".to_string()),
+        cwd: Some("~/work/reasonix-core".to_string()),
+        dashboard_url: Some(url.to_string()),
+        ..Default::default()
+    };
+    let rows = draw(&state, 120, 40);
+    let all = joined(&rows);
+    assert!(all.contains("dashboard"), "dashboard label missing");
+    let occurrences = all.matches(url).count();
+    assert!(
+        occurrences >= 2,
+        "expected long URL to wrap across multiple rows (got {occurrences} OSC 8 entries)"
+    );
+    assert!(all.contains("MISSION CONTROL"), "sidebar should still render alongside wrapped URL");
+}
+
+#[test]
 fn dashboard_line_hidden_when_url_absent() {
     let state = SceneState {
         model: Some("deepseek-v3.2-coder".to_string()),

--- a/crates/reasonix-render/tests/whole_screen.rs
+++ b/crates/reasonix-render/tests/whole_screen.rs
@@ -440,7 +440,10 @@ fn long_dashboard_url_wraps_within_main_panel() {
         occurrences >= 2,
         "expected long URL to wrap across multiple rows (got {occurrences} OSC 8 entries)"
     );
-    assert!(all.contains("MISSION CONTROL"), "sidebar should still render alongside wrapped URL");
+    assert!(
+        all.contains("MISSION CONTROL"),
+        "sidebar should still render alongside wrapped URL"
+    );
 }
 
 #[test]

--- a/package.json
+++ b/package.json
@@ -26,8 +26,10 @@
   ],
   "scripts": {
     "build": "tsup && node scripts/copy-dashboard-vendor-css.mjs",
-    "dev": "tsx src/cli/index.ts",
-    "chat": "tsx src/cli/index.ts chat",
+    "rust:build": "cargo build --release --bin reasonix-render",
+    "dev:prepare": "node scripts/dev-prepare.mjs",
+    "dev": "npm run dev:prepare && tsx src/cli/index.ts",
+    "chat": "npm run dev:prepare && tsx src/cli/index.ts chat",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/scripts/dev-prepare.mjs
+++ b/scripts/dev-prepare.mjs
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+// Pre-step for `npm run dev`: build the Rust renderer once before tsx
+// hands off. Silent no-op when cargo isn't installed (TS-only contributors)
+// or when the source tree isn't present (published install). The resolver
+// then picks the freshly-built target/release binary instead of falling
+// back to `cargo run` (slower per-invocation overhead) or a stale binary.
+
+import { spawnSync } from "node:child_process";
+
+const cargoCheck = spawnSync("cargo", ["--version"], { stdio: "ignore" });
+if (cargoCheck.status !== 0) {
+  process.exit(0);
+}
+
+const build = spawnSync("cargo", ["build", "--release", "--quiet", "--bin", "reasonix-render"], {
+  stdio: "inherit",
+});
+
+if (build.status !== 0) {
+  process.stderr.write(
+    "▲ cargo build for reasonix-render failed — the resolver will fall back to `cargo run` (slower) or the Node TUI.\n",
+  );
+}
+process.exit(0);

--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -40,6 +40,7 @@ import { cancelAllListPickers, resolveListPicker } from "../ui/scene/list-picker
 import { makeNullStdin } from "../ui/scene/null-stdin.js";
 import { makeNullStdout } from "../ui/scene/null-stdout.js";
 import { cancelAllPromptInputs, resolvePromptInput } from "../ui/scene/prompt-input-store.js";
+import { resolveRenderer } from "../ui/scene/renderer-resolver.js";
 import { isIntegratedRendererRequested, setIntegratedEventHandler } from "../ui/scene/trace.js";
 import type { McpServerSummary } from "../ui/slash.js";
 import {
@@ -52,20 +53,9 @@ import {
 
 export type { McpLifecycleNotice, McpLifecycleSink, McpRuntime, ProgressInfo };
 
-function parseInputCmd(raw: string | undefined): readonly string[] | undefined {
-  if (!raw || raw.length === 0) return undefined;
-  try {
-    const parsed = JSON.parse(raw);
-    if (Array.isArray(parsed) && parsed.every((p) => typeof p === "string")) return parsed;
-  } catch {
-    // fall through
-  }
-  return undefined;
-}
-
-// Under REASONIX_RENDERER=rust the alt-screen is owned by the Rust child. Any
-// stderr write from the Node parent overwrites whatever ratatui just drew at
-// the same cells, and stays visible until the next frame redraws — so Node's
+// When the Rust renderer is active the alt-screen is owned by the Rust child.
+// Any stderr write from the Node parent overwrites whatever ratatui just drew
+// at the same cells and stays visible until the next frame redraws — so Node's
 // own warnings (MaxListeners etc.) and any stray library logs all corrupt the
 // view. Redirect stderr to a log file for the duration of the session.
 function redirectStderrToLogFile(): () => void {
@@ -203,7 +193,7 @@ interface RootProps extends ChatOptions {
   };
   /** App fills this ref on mount so QQ errors appear in the TUI log. */
   qqErrorRef: { current: ((msg: string) => void) | null };
-  /** Custom keystroke source — populated when REASONIX_RENDERER=rust so keys flow from the spawned input child (or a no-op reader in integrated mode) instead of process.stdin. */
+  /** Custom keystroke source — populated when the Rust renderer is active so keys flow from the spawned input child (or a no-op reader in integrated mode) instead of process.stdin. */
   keystrokeReader?: KeystrokeReader;
 }
 
@@ -425,26 +415,22 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
     }
   }
 
-  const rustRendererRequested = process.env.REASONIX_RENDERER === "rust";
-  // If REASONIX_RENDERER=rust is set but no API key is saved, the first screen
-  // is Setup — which renders to Ink's stdout and reads stdin directly. Under
-  // the Rust path both would be the null streams, leaving the user typing their
-  // key blind. Fall back to the Ink renderer for this launch; the next launch
-  // (with the key saved) gets the Rust path.
-  const rustRendererActive = rustRendererRequested && initialKey !== undefined;
-  if (rustRendererRequested && !rustRendererActive) {
+  let rustRendererActive = process.env.REASONIX_RENDERER !== "node";
+  let resolved = rustRendererActive ? resolveRenderer() : undefined;
+  if (rustRendererActive && (!resolved || resolved.source === null)) {
     process.stderr.write(
-      "REASONIX_RENDERER=rust ignored for this launch: no saved API key. " +
-        "Complete Setup once, then re-launch with the flag.\n",
+      `▲ Rust renderer binary not found — falling back to the Node/Ink TUI.\n  Install @reasonix/render-${process.platform}-${process.arch}, set REASONIX_RENDER_BIN to a built binary, or run from source with cargo on PATH.\n`,
     );
+    process.env.REASONIX_RENDERER = "node";
+    rustRendererActive = false;
+    resolved = undefined;
   }
   const rustIntegrated = rustRendererActive && isIntegratedRendererRequested();
   const inkStdout = rustRendererActive ? makeNullStdout() : undefined;
   const inkStdin = rustRendererActive ? makeNullStdin() : undefined;
-  const inputCmdOverride = parseInputCmd(process.env.REASONIX_INPUT_CMD);
   const rustInputChild: RustKeystrokeReader | undefined =
-    rustRendererActive && !rustIntegrated
-      ? createRustKeystrokeReader(inputCmdOverride ? { command: inputCmdOverride } : {})
+    rustRendererActive && !rustIntegrated && resolved
+      ? createRustKeystrokeReader({ command: resolved.inputCommand })
       : undefined;
   const keystrokeReader: KeystrokeReader | undefined = rustIntegrated
     ? nullKeystrokeReader

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -155,47 +155,23 @@ program
   .version(VERSION)
   .option("-c, --continue", t("cli.continue"));
 
-// `reasonix` with no subcommand → launch the friendliest flow.
-// First run (no config yet) → interactive setup wizard.
-// Otherwise → chat with saved defaults. This is the "one command to
-// rule them all" entry for non-power-users: they don't need to learn
-// `chat` / `setup` / `--mcp` — just type `reasonix`.
-program.action(async (opts: { continue?: boolean }) => {
-  const cfg = readConfig();
-  const cwd = process.cwd();
-  const mode = resolveBareCommandMode(cwd, cfg);
-  if (mode === "setup") {
-    const { setupCommand } = await import("./commands/setup.js");
-    await setupCommand({ forceKeyStep: true });
-    return;
-  }
-  if (mode === "code") {
+// `reasonix` with no subcommand → setup wizard on first run, otherwise `code`
+// in the current directory. Filesystem-less chat stays reachable via
+// `reasonix chat`.
+program
+  .option("--node", "use the legacy Node/Ink TUI (default is the Rust renderer)")
+  .action(async (opts: { continue?: boolean; node?: boolean }) => {
+    if (opts.node) process.env.REASONIX_RENDERER = "node";
+    const cfg = readConfig();
+    const mode = resolveBareCommandMode(cfg);
+    if (mode === "setup") {
+      const { setupCommand } = await import("./commands/setup.js");
+      await setupCommand({ forceKeyStep: true });
+      return;
+    }
     const { codeCommand } = await import("./commands/code.js");
-    await codeCommand({ dir: cwd });
-    return;
-  }
-  const defaults = resolveDefaults({});
-  const continueOpts = resolveContinueFlag(
-    opts.continue,
-    defaults.session,
-    () => listSessions()[0],
-    (msg) => process.stderr.write(`${msg}\n`),
-  );
-  process.stderr.write(
-    "ℹ chat mode (no filesystem tools). Run `reasonix code` to work on files in this folder.\n",
-  );
-  const { chatCommand } = await import("./commands/chat.js");
-  const defaultBase = defaultSystemPrompt(defaults.model);
-  const defaultRebuildSystem = () => applyMemoryStack(defaultBase, cwd);
-  await chatCommand({
-    model: defaults.model,
-    system: defaultRebuildSystem(),
-    rebuildSystem: defaultRebuildSystem,
-    session: continueOpts.session,
-    mcp: defaults.mcp,
-    forceResume: continueOpts.forceResume,
+    await codeCommand({ dir: process.cwd(), forceResume: !!opts.continue });
   });
-});
 
 program
   .command("setup")
@@ -234,7 +210,9 @@ program
     "--profile [path]",
     "record a V8 CPU profile; saved on exit. Send the .cpuprofile back if you're reporting a perf bug.",
   )
+  .option("--node", "use the legacy Node/Ink TUI (default is the Rust renderer)")
   .action(async (dir: string | undefined, opts) => {
+    if (opts.node) process.env.REASONIX_RENDERER = "node";
     const profiling = await maybeStartCpuProfile(opts.profile);
     try {
       const { codeCommand } = await import("./commands/code.js");
@@ -304,7 +282,9 @@ program
     "--profile [path]",
     "record a V8 CPU profile; saved on exit. Send the .cpuprofile back if you're reporting a perf bug.",
   )
+  .option("--node", "use the legacy Node/Ink TUI (default is the Rust renderer)")
   .action(async (opts) => {
+    if (opts.node) process.env.REASONIX_RENDERER = "node";
     const profiling = await maybeStartCpuProfile(opts.profile);
     try {
       const defaults = resolveDefaults({

--- a/src/cli/resolve.ts
+++ b/src/cli/resolve.ts
@@ -1,7 +1,5 @@
 /** Precedence: per-setting flag > --preset > config.preset > "auto" defaults. */
 
-import { existsSync } from "node:fs";
-import { resolve } from "node:path";
 import { type PresetName, type ReasonixConfig, normalizeMcpConfig, readConfig } from "../config.js";
 import { specToRaw } from "../mcp/spec.js";
 import { resolvePreset } from "./ui/presets.js";
@@ -94,28 +92,9 @@ export function resolveContinueFlag(
   return { session: latest.name, forceResume: true };
 }
 
-const PROJECT_MARKERS = [
-  ".git",
-  "package.json",
-  "pyproject.toml",
-  "Cargo.toml",
-  "go.mod",
-  "pom.xml",
-  "build.gradle",
-  "CMakeLists.txt",
-];
-
-export function looksLikeProjectDir(cwd: string, recentWorkspaces: string[] = []): boolean {
-  const root = resolve(cwd);
-  if (recentWorkspaces.some((workspace) => resolve(workspace) === root)) return true;
-
-  return PROJECT_MARKERS.some((marker) => existsSync(resolve(root, marker)));
-}
-
 export function resolveBareCommandMode(
-  cwd: string,
-  cfg: Pick<ReasonixConfig, "setupCompleted" | "recentWorkspaces">,
-): "setup" | "code" | "chat" {
+  cfg: Pick<ReasonixConfig, "setupCompleted">,
+): "setup" | "code" {
   if (!cfg.setupCompleted) return "setup";
-  return looksLikeProjectDir(cwd, cfg.recentWorkspaces) ? "code" : "chat";
+  return "code";
 }

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -1746,6 +1746,12 @@ function AppInner({
   // Esc handles "abort the current turn" separately; Ctrl+C is the universal "I'm done" key.
   const quitProcess = useQuit(transcriptRef);
 
+  // Ctrl+D = standard TUI exit (matches the boot-banner hint). Always-on
+  // — no modal / picker should swallow it.
+  useKeystroke((ev) => {
+    if (ev.ctrl && ev.input === "d") quitProcess();
+  });
+
   // 闂?闂?PgUp/PgDn always scroll chat; wheel arrives as 闂?闂?via
   // DECSET 1007 alternate-scroll so it joins the same path. Pickers
   // (slash / @-mention / slash-arg / shell-confirm) own 闂?闂?闂?when

--- a/src/cli/ui/keystroke-context.tsx
+++ b/src/cli/ui/keystroke-context.tsx
@@ -45,10 +45,10 @@ export interface KeystrokeProviderProps {
   /**
    * Optional reader override. Tests inject a synthetic reader so
    * they can `feed()` chunks instead of touching real stdin; the
-   * Rust input adapter (when `REASONIX_RENDERER=rust`) injects one
-   * that receives events from a spawned `reasonix-render --emit-input`
-   * child. Production stdin callers leave this unset and get the
-   * singleton.
+   * Rust input adapter (active by default; off under `--node` /
+   * `REASONIX_RENDERER=node`) injects one that receives events from
+   * a spawned `reasonix-render --emit-input` child. Production stdin
+   * callers leave this unset and get the singleton.
    */
   reader?: KeystrokeReader;
 }

--- a/src/cli/ui/scene/input-adapter.ts
+++ b/src/cli/ui/scene/input-adapter.ts
@@ -23,7 +23,7 @@ export const nullKeystrokeReader: KeystrokeReader = {
   },
 };
 
-export function createRustKeystrokeReader(opts: SpawnInputSourceOptions = {}): RustKeystrokeReader {
+export function createRustKeystrokeReader(opts: SpawnInputSourceOptions): RustKeystrokeReader {
   const source = spawnInputSource(opts);
   const handlers = new Set<KeystrokeHandler>();
 

--- a/src/cli/ui/scene/input-source.ts
+++ b/src/cli/ui/scene/input-source.ts
@@ -1,5 +1,4 @@
 import { spawn } from "node:child_process";
-import { DEFAULT_COMMAND } from "./renderer-process.js";
 
 export type InputModifier = "ctrl" | "alt" | "shift" | "super";
 
@@ -38,12 +37,10 @@ export type InputSource = {
 };
 
 export type SpawnInputSourceOptions = {
-  command?: readonly string[];
+  command: readonly string[];
   cwd?: string;
   env?: NodeJS.ProcessEnv;
 };
-
-export const DEFAULT_INPUT_COMMAND: readonly string[] = [...DEFAULT_COMMAND, "--", "--emit-input"];
 
 type Buses = {
   keys: Set<(event: KeyInputEvent) => void>;
@@ -51,8 +48,8 @@ type Buses = {
   mice: Set<(event: MouseInputEvent) => void>;
 };
 
-export function spawnInputSource(opts: SpawnInputSourceOptions = {}): InputSource {
-  const command = opts.command ?? DEFAULT_INPUT_COMMAND;
+export function spawnInputSource(opts: SpawnInputSourceOptions): InputSource {
+  const command = opts.command;
   const [cmd, ...args] = command;
   if (!cmd) {
     throw new Error("spawnInputSource: empty command");

--- a/src/cli/ui/scene/renderer-process.ts
+++ b/src/cli/ui/scene/renderer-process.ts
@@ -17,7 +17,7 @@ export type RendererProcess = {
 };
 
 export type SpawnRendererOptions = {
-  command?: readonly string[];
+  command: readonly string[];
   cwd?: string;
   env?: NodeJS.ProcessEnv;
   /** When true the rust child owns keyboard + composer; its stderr is parsed for {event:"submit"|"interrupt"|"exit"} lines. */
@@ -26,16 +26,8 @@ export type SpawnRendererOptions = {
   onEvent?: (event: RustEvent) => void;
 };
 
-export const DEFAULT_COMMAND: readonly string[] = [
-  "cargo",
-  "run",
-  "--quiet",
-  "--bin",
-  "reasonix-render",
-];
-
-export function spawnRenderer(opts: SpawnRendererOptions = {}): RendererProcess {
-  const command = opts.command ?? DEFAULT_COMMAND;
+export function spawnRenderer(opts: SpawnRendererOptions): RendererProcess {
+  const command = opts.command;
   const baseArgs: string[] = [];
   const [cmd, ...rest] = command;
   baseArgs.push(...rest);

--- a/src/cli/ui/scene/renderer-resolver.ts
+++ b/src/cli/ui/scene/renderer-resolver.ts
@@ -4,7 +4,14 @@ import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-export type RendererSource = "env-cmd" | "env-bin" | "optional-dep" | "cargo" | null;
+export type RendererSource =
+  | "env-cmd"
+  | "env-bin"
+  | "optional-dep"
+  | "prebuilt-release"
+  | "prebuilt-debug"
+  | "cargo"
+  | null;
 
 export interface ResolvedRenderer {
   command: readonly string[];
@@ -17,7 +24,7 @@ export interface ResolverIO {
   envBin(): string | undefined;
   hasFile(path: string): boolean;
   resolveOptionalDep(platform: string, arch: string): string | undefined;
-  hasReasonixSourceTree(): boolean;
+  findReasonixSourceTree(): string | undefined;
   hasCargo(): boolean;
   platform: NodeJS.Platform;
 }
@@ -53,7 +60,15 @@ function pickBase(io: ResolverIO): ResolvedRenderer {
   const optional = io.resolveOptionalDep(io.platform, process.arch);
   if (optional) return fromBinary(optional, "optional-dep");
 
-  if (io.hasReasonixSourceTree() && io.hasCargo()) return fromCargo();
+  const sourceRoot = io.findReasonixSourceTree();
+  if (sourceRoot) {
+    const binName = io.platform === "win32" ? "reasonix-render.exe" : "reasonix-render";
+    const release = join(sourceRoot, "target", "release", binName);
+    if (io.hasFile(release)) return fromBinary(release, "prebuilt-release");
+    const debug = join(sourceRoot, "target", "debug", binName);
+    if (io.hasFile(debug)) return fromBinary(debug, "prebuilt-debug");
+    if (io.hasCargo()) return fromCargo();
+  }
 
   return { command: [], inputCommand: [], source: null };
 }
@@ -73,7 +88,7 @@ function defaultIO(): ResolverIO {
     envBin: () => process.env.REASONIX_RENDER_BIN,
     hasFile: existsSync,
     resolveOptionalDep: locateOptionalDepBinary,
-    hasReasonixSourceTree: detectReasonixSourceTree,
+    findReasonixSourceTree: detectReasonixSourceTree,
     hasCargo: detectCargo,
     platform: process.platform,
   };
@@ -104,15 +119,15 @@ function locateOptionalDepBinary(platform: NodeJS.Platform, arch: string): strin
   }
 }
 
-function detectReasonixSourceTree(): boolean {
+function detectReasonixSourceTree(): string | undefined {
   let dir = dirname(fileURLToPath(import.meta.url));
   for (let i = 0; i < 12; i++) {
-    if (existsSync(join(dir, "crates", "reasonix-render", "Cargo.toml"))) return true;
+    if (existsSync(join(dir, "crates", "reasonix-render", "Cargo.toml"))) return dir;
     const parent = dirname(dir);
     if (parent === dir) break;
     dir = parent;
   }
-  return false;
+  return undefined;
 }
 
 function detectCargo(): boolean {

--- a/src/cli/ui/scene/renderer-resolver.ts
+++ b/src/cli/ui/scene/renderer-resolver.ts
@@ -1,0 +1,125 @@
+import { execSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export type RendererSource = "env-cmd" | "env-bin" | "optional-dep" | "cargo" | null;
+
+export interface ResolvedRenderer {
+  command: readonly string[];
+  inputCommand: readonly string[];
+  source: RendererSource;
+}
+
+export interface ResolverIO {
+  envCmd(name: string): readonly string[] | undefined;
+  envBin(): string | undefined;
+  hasFile(path: string): boolean;
+  resolveOptionalDep(platform: string, arch: string): string | undefined;
+  hasReasonixSourceTree(): boolean;
+  hasCargo(): boolean;
+  platform: NodeJS.Platform;
+}
+
+let cached: ResolvedRenderer | undefined;
+
+export function resolveRenderer(): ResolvedRenderer {
+  if (cached) return cached;
+  cached = resolveRendererWith(defaultIO());
+  return cached;
+}
+
+export function resetResolverCache(): void {
+  cached = undefined;
+}
+
+export function resolveRendererWith(io: ResolverIO): ResolvedRenderer {
+  const base = pickBase(io);
+  const renderEnv = io.envCmd("REASONIX_RENDER_CMD");
+  const inputEnv = io.envCmd("REASONIX_INPUT_CMD");
+  if (!renderEnv && !inputEnv) return base;
+  return {
+    command: renderEnv ?? base.command,
+    inputCommand: inputEnv ?? base.inputCommand,
+    source: base.source ?? "env-cmd",
+  };
+}
+
+function pickBase(io: ResolverIO): ResolvedRenderer {
+  const binEnv = io.envBin();
+  if (binEnv && io.hasFile(binEnv)) return fromBinary(binEnv, "env-bin");
+
+  const optional = io.resolveOptionalDep(io.platform, process.arch);
+  if (optional) return fromBinary(optional, "optional-dep");
+
+  if (io.hasReasonixSourceTree() && io.hasCargo()) return fromCargo();
+
+  return { command: [], inputCommand: [], source: null };
+}
+
+function fromBinary(bin: string, source: RendererSource): ResolvedRenderer {
+  return { command: [bin], inputCommand: [bin, "--emit-input"], source };
+}
+
+function fromCargo(): ResolvedRenderer {
+  const cmd = ["cargo", "run", "--quiet", "--bin", "reasonix-render"];
+  return { command: cmd, inputCommand: [...cmd, "--", "--emit-input"], source: "cargo" };
+}
+
+function defaultIO(): ResolverIO {
+  return {
+    envCmd: parseEnvCmd,
+    envBin: () => process.env.REASONIX_RENDER_BIN,
+    hasFile: existsSync,
+    resolveOptionalDep: locateOptionalDepBinary,
+    hasReasonixSourceTree: detectReasonixSourceTree,
+    hasCargo: detectCargo,
+    platform: process.platform,
+  };
+}
+
+function parseEnvCmd(name: string): readonly string[] | undefined {
+  const raw = process.env[name];
+  if (!raw || raw.length === 0) return undefined;
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed) && parsed.every((p) => typeof p === "string")) return parsed;
+  } catch {
+    /* not JSON — caller treats as absent */
+  }
+  return undefined;
+}
+
+function locateOptionalDepBinary(platform: NodeJS.Platform, arch: string): string | undefined {
+  const pkg = `@reasonix/render-${platform}-${arch}`;
+  try {
+    const require_ = createRequire(import.meta.url);
+    const pkgJson = require_.resolve(`${pkg}/package.json`);
+    const binName = platform === "win32" ? "reasonix-render.exe" : "reasonix-render";
+    const binPath = join(dirname(pkgJson), "bin", binName);
+    return existsSync(binPath) ? binPath : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function detectReasonixSourceTree(): boolean {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 12; i++) {
+    if (existsSync(join(dir, "crates", "reasonix-render", "Cargo.toml"))) return true;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return false;
+}
+
+function detectCargo(): boolean {
+  try {
+    execSync("cargo --version", { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/cli/ui/scene/trace.ts
+++ b/src/cli/ui/scene/trace.ts
@@ -12,8 +12,9 @@ export function setIntegratedEventHandler(handler: (event: RustEvent) => void): 
   integratedHandler = handler;
 }
 
+/** Default-on when the rust renderer is active; set REASONIX_RENDERER_INTEGRATED=0 to opt back to the --emit-input split. */
 export function isIntegratedRendererRequested(): boolean {
-  return process.env[RENDERER_VAR] !== "node" && process.env[INTEGRATED_VAR] === "1";
+  return process.env[RENDERER_VAR] !== "node" && process.env[INTEGRATED_VAR] !== "0";
 }
 
 type Mode = "off" | "file" | "child";
@@ -82,7 +83,7 @@ function ensureInitialized(): void {
   if (process.env[RENDERER_VAR] === "node") return;
   const { command, source } = resolveRenderer();
   if (source === null || command.length === 0) return;
-  const integrated = process.env[INTEGRATED_VAR] === "1";
+  const integrated = process.env[INTEGRATED_VAR] !== "0";
   state.mode = "child";
   state.child = spawnRenderer({
     command,

--- a/src/cli/ui/scene/trace.ts
+++ b/src/cli/ui/scene/trace.ts
@@ -1,14 +1,9 @@
 import { appendFileSync, closeSync, openSync } from "node:fs";
-import {
-  DEFAULT_COMMAND,
-  type RendererProcess,
-  type RustEvent,
-  spawnRenderer,
-} from "./renderer-process.js";
+import { type RendererProcess, type RustEvent, spawnRenderer } from "./renderer-process.js";
+import { resolveRenderer } from "./renderer-resolver.js";
 
 const FILE_VAR = "REASONIX_SCENE_TRACE";
 const RENDERER_VAR = "REASONIX_RENDERER";
-const COMMAND_OVERRIDE_VAR = "REASONIX_RENDER_CMD";
 const INTEGRATED_VAR = "REASONIX_RENDERER_INTEGRATED";
 
 let integratedHandler: ((event: RustEvent) => void) | null = null;
@@ -18,7 +13,7 @@ export function setIntegratedEventHandler(handler: (event: RustEvent) => void): 
 }
 
 export function isIntegratedRendererRequested(): boolean {
-  return process.env[RENDERER_VAR] === "rust" && process.env[INTEGRATED_VAR] === "1";
+  return process.env[RENDERER_VAR] !== "node" && process.env[INTEGRATED_VAR] === "1";
 }
 
 type Mode = "off" | "file" | "child";
@@ -75,36 +70,25 @@ export async function flushSceneTrace(): Promise<void> {
 function ensureInitialized(): void {
   if (state.opened) return;
   state.opened = true;
-  if (process.env[RENDERER_VAR] === "rust") {
-    state.mode = "child";
-    const integrated = process.env[INTEGRATED_VAR] === "1";
-    state.child = spawnRenderer({
-      command: rendererCommand(),
-      integrated,
-      onEvent: integrated && integratedHandler ? integratedHandler : undefined,
-    });
+  // Explicit file-trace opt-in wins over the renderer choice — it's the
+  // dev/replay surface and the user has clearly asked for it.
+  const raw = process.env[FILE_VAR];
+  if (raw && raw.length > 0) {
+    state.mode = "file";
+    state.path = raw;
+    truncate(raw);
     return;
   }
-  const raw = process.env[FILE_VAR];
-  if (!raw || raw.length === 0) return;
-  state.mode = "file";
-  state.path = raw;
-  truncate(raw);
-}
-
-function rendererCommand(): readonly string[] {
-  const override = process.env[COMMAND_OVERRIDE_VAR];
-  if (override && override.length > 0) {
-    try {
-      const parsed = JSON.parse(override);
-      if (Array.isArray(parsed) && parsed.every((p) => typeof p === "string")) {
-        return parsed;
-      }
-    } catch {
-      // fall through to default
-    }
-  }
-  return [...DEFAULT_COMMAND];
+  if (process.env[RENDERER_VAR] === "node") return;
+  const { command, source } = resolveRenderer();
+  if (source === null || command.length === 0) return;
+  const integrated = process.env[INTEGRATED_VAR] === "1";
+  state.mode = "child";
+  state.child = spawnRenderer({
+    command,
+    integrated,
+    onEvent: integrated && integratedHandler ? integratedHandler : undefined,
+  });
 }
 
 function truncate(path: string): void {

--- a/tests/cli-bare-routing.test.ts
+++ b/tests/cli-bare-routing.test.ts
@@ -1,4 +1,4 @@
-/** Bare `reasonix` routing — project-like cwd should launch code mode, explicit `chat` must stay chat. */
+/** Bare `reasonix` routing — defaults to code mode in the current directory; explicit `chat` stays chat. */
 
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -61,38 +61,40 @@ describe("bare CLI routing", () => {
     }
   });
 
-  it("routes bare reasonix in a .git directory to code mode rooted at cwd", async () => {
+  it("routes bare reasonix to code mode rooted at cwd", async () => {
     writeConfig({ setupCompleted: true }, join(home, ".reasonix", "config.json"));
     mkdirSync(join(cwd, ".git"));
 
     await importCli([]);
 
-    await vi.waitFor(() => expect(codeCommand).toHaveBeenCalledWith({ dir: cwd }));
+    await vi.waitFor(() =>
+      expect(codeCommand).toHaveBeenCalledWith({ dir: cwd, forceResume: false }),
+    );
     expect(chatCommand).not.toHaveBeenCalled();
   });
 
-  it("routes bare reasonix in a non-project directory to chat mode and prints the filesystem hint", async () => {
+  it("routes bare reasonix in a non-project directory to code mode too", async () => {
     writeConfig({ setupCompleted: true }, join(home, ".reasonix", "config.json"));
 
     await importCli([]);
 
-    await vi.waitFor(() => expect(chatCommand).toHaveBeenCalled());
-    expect(codeCommand).not.toHaveBeenCalled();
-    expect(stderr.mock.calls.map((call) => String(call[0])).join("")).toContain(
-      "chat mode (no filesystem tools). Run `reasonix code` to work on files in this folder.",
+    await vi.waitFor(() =>
+      expect(codeCommand).toHaveBeenCalledWith({ dir: cwd, forceResume: false }),
+    );
+    expect(chatCommand).not.toHaveBeenCalled();
+    expect(stderr.mock.calls.map((call) => String(call[0])).join("")).not.toContain(
+      "chat mode (no filesystem tools)",
     );
   });
 
-  it("routes bare reasonix in a recent workspace to code mode", async () => {
-    writeConfig(
-      { setupCompleted: true, recentWorkspaces: [cwd] },
-      join(home, ".reasonix", "config.json"),
+  it("forwards -c to code mode as forceResume", async () => {
+    writeConfig({ setupCompleted: true }, join(home, ".reasonix", "config.json"));
+
+    await importCli(["-c"]);
+
+    await vi.waitFor(() =>
+      expect(codeCommand).toHaveBeenCalledWith({ dir: cwd, forceResume: true }),
     );
-
-    await importCli([]);
-
-    await vi.waitFor(() => expect(codeCommand).toHaveBeenCalledWith({ dir: cwd }));
-    expect(chatCommand).not.toHaveBeenCalled();
   });
 
   it("keeps explicit reasonix chat in chat mode even inside a project", async () => {

--- a/tests/renderer-resolver.test.ts
+++ b/tests/renderer-resolver.test.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { type ResolverIO, resolveRendererWith } from "../src/cli/ui/scene/renderer-resolver.js";
 
@@ -9,7 +10,7 @@ function makeIO(overrides: IOOverrides = {}): ResolverIO {
     envBin: () => undefined,
     hasFile: () => false,
     resolveOptionalDep: () => undefined,
-    hasReasonixSourceTree: () => false,
+    findReasonixSourceTree: () => undefined,
     hasCargo: () => false,
     platform: "linux",
     ...overrides,
@@ -58,17 +59,40 @@ describe("resolveRendererWith", () => {
     expect(r.source).toBe("optional-dep");
   });
 
-  it("falls back to cargo only when source tree AND cargo are both present", () => {
-    expect(
-      resolveRendererWith(makeIO({ hasReasonixSourceTree: () => true, hasCargo: () => false }))
-        .source,
-    ).toBeNull();
-    expect(
-      resolveRendererWith(makeIO({ hasReasonixSourceTree: () => false, hasCargo: () => true }))
-        .source,
-    ).toBeNull();
+  it("prefers source-tree target/release over cargo run", () => {
+    const releasePath = join("/repo", "target", "release", "reasonix-render");
     const r = resolveRendererWith(
-      makeIO({ hasReasonixSourceTree: () => true, hasCargo: () => true }),
+      makeIO({
+        findReasonixSourceTree: () => "/repo",
+        hasCargo: () => true,
+        hasFile: (p) => p === releasePath,
+      }),
+    );
+    expect(r.source).toBe("prebuilt-release");
+    expect(r.command).toEqual([releasePath]);
+    expect(r.inputCommand).toEqual([releasePath, "--emit-input"]);
+  });
+
+  it("falls back to source-tree target/debug when release is absent", () => {
+    const debugPath = join("/repo", "target", "debug", "reasonix-render");
+    const r = resolveRendererWith(
+      makeIO({
+        findReasonixSourceTree: () => "/repo",
+        hasCargo: () => true,
+        hasFile: (p) => p === debugPath,
+      }),
+    );
+    expect(r.source).toBe("prebuilt-debug");
+    expect(r.command).toEqual([debugPath]);
+  });
+
+  it("falls back to cargo run only when no prebuilt binary exists", () => {
+    const r = resolveRendererWith(
+      makeIO({
+        findReasonixSourceTree: () => "/repo",
+        hasCargo: () => true,
+        hasFile: () => false,
+      }),
     );
     expect(r.source).toBe("cargo");
     expect(r.command).toEqual(["cargo", "run", "--quiet", "--bin", "reasonix-render"]);
@@ -83,17 +107,36 @@ describe("resolveRendererWith", () => {
     ]);
   });
 
-  it("uses .exe suffix correctly via the optional-dep callback", () => {
+  it("requires source tree for cargo fallback", () => {
+    expect(
+      resolveRendererWith(makeIO({ findReasonixSourceTree: () => undefined, hasCargo: () => true }))
+        .source,
+    ).toBeNull();
+  });
+
+  it("requires cargo for cargo fallback", () => {
+    expect(
+      resolveRendererWith(
+        makeIO({
+          findReasonixSourceTree: () => "/repo",
+          hasCargo: () => false,
+          hasFile: () => false,
+        }),
+      ).source,
+    ).toBeNull();
+  });
+
+  it("uses .exe suffix on win32", () => {
+    const releasePath = "C:\\repo\\target\\release\\reasonix-render.exe";
     const r = resolveRendererWith(
       makeIO({
         platform: "win32",
-        resolveOptionalDep: (platform) => {
-          expect(platform).toBe("win32");
-          return "C:/x/reasonix-render.exe";
-        },
+        findReasonixSourceTree: () => "C:\\repo",
+        hasFile: (p) => p === releasePath,
       }),
     );
-    expect(r.command).toEqual(["C:/x/reasonix-render.exe"]);
+    expect(r.source).toBe("prebuilt-release");
+    expect(r.command[0]).toBe(releasePath);
   });
 
   it("REASONIX_RENDER_CMD overrides only the renderer channel; input falls back to base", () => {

--- a/tests/renderer-resolver.test.ts
+++ b/tests/renderer-resolver.test.ts
@@ -126,17 +126,21 @@ describe("resolveRendererWith", () => {
     ).toBeNull();
   });
 
-  it("uses .exe suffix on win32", () => {
-    const releasePath = "C:\\repo\\target\\release\\reasonix-render.exe";
+  it("uses .exe suffix when platform is win32", () => {
+    let probed: string | undefined;
     const r = resolveRendererWith(
       makeIO({
         platform: "win32",
-        findReasonixSourceTree: () => "C:\\repo",
-        hasFile: (p) => p === releasePath,
+        findReasonixSourceTree: () => "/repo",
+        hasFile: (p) => {
+          probed = probed ?? p;
+          return p.endsWith("reasonix-render.exe");
+        },
       }),
     );
     expect(r.source).toBe("prebuilt-release");
-    expect(r.command[0]).toBe(releasePath);
+    expect(r.command[0]).toMatch(/reasonix-render\.exe$/);
+    expect(probed).toMatch(/reasonix-render\.exe$/);
   });
 
   it("REASONIX_RENDER_CMD overrides only the renderer channel; input falls back to base", () => {

--- a/tests/renderer-resolver.test.ts
+++ b/tests/renderer-resolver.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import { type ResolverIO, resolveRendererWith } from "../src/cli/ui/scene/renderer-resolver.js";
+
+type IOOverrides = Partial<ResolverIO>;
+
+function makeIO(overrides: IOOverrides = {}): ResolverIO {
+  return {
+    envCmd: () => undefined,
+    envBin: () => undefined,
+    hasFile: () => false,
+    resolveOptionalDep: () => undefined,
+    hasReasonixSourceTree: () => false,
+    hasCargo: () => false,
+    platform: "linux",
+    ...overrides,
+  };
+}
+
+describe("resolveRendererWith", () => {
+  it("returns source=null when nothing is available", () => {
+    const r = resolveRendererWith(makeIO());
+    expect(r.source).toBeNull();
+    expect(r.command).toEqual([]);
+    expect(r.inputCommand).toEqual([]);
+  });
+
+  it("picks the optional-dep binary when present", () => {
+    const r = resolveRendererWith(
+      makeIO({
+        resolveOptionalDep: () => "/opt/render/bin/reasonix-render",
+      }),
+    );
+    expect(r.source).toBe("optional-dep");
+    expect(r.command).toEqual(["/opt/render/bin/reasonix-render"]);
+    expect(r.inputCommand).toEqual(["/opt/render/bin/reasonix-render", "--emit-input"]);
+  });
+
+  it("prefers env-bin over optional-dep", () => {
+    const r = resolveRendererWith(
+      makeIO({
+        envBin: () => "/usr/local/bin/reasonix-render",
+        hasFile: (p) => p === "/usr/local/bin/reasonix-render",
+        resolveOptionalDep: () => "/opt/render/bin/reasonix-render",
+      }),
+    );
+    expect(r.source).toBe("env-bin");
+    expect(r.command).toEqual(["/usr/local/bin/reasonix-render"]);
+  });
+
+  it("ignores env-bin when the file does not exist", () => {
+    const r = resolveRendererWith(
+      makeIO({
+        envBin: () => "/usr/local/bin/missing",
+        hasFile: () => false,
+        resolveOptionalDep: () => "/opt/render/bin/reasonix-render",
+      }),
+    );
+    expect(r.source).toBe("optional-dep");
+  });
+
+  it("falls back to cargo only when source tree AND cargo are both present", () => {
+    expect(
+      resolveRendererWith(makeIO({ hasReasonixSourceTree: () => true, hasCargo: () => false }))
+        .source,
+    ).toBeNull();
+    expect(
+      resolveRendererWith(makeIO({ hasReasonixSourceTree: () => false, hasCargo: () => true }))
+        .source,
+    ).toBeNull();
+    const r = resolveRendererWith(
+      makeIO({ hasReasonixSourceTree: () => true, hasCargo: () => true }),
+    );
+    expect(r.source).toBe("cargo");
+    expect(r.command).toEqual(["cargo", "run", "--quiet", "--bin", "reasonix-render"]);
+    expect(r.inputCommand).toEqual([
+      "cargo",
+      "run",
+      "--quiet",
+      "--bin",
+      "reasonix-render",
+      "--",
+      "--emit-input",
+    ]);
+  });
+
+  it("uses .exe suffix correctly via the optional-dep callback", () => {
+    const r = resolveRendererWith(
+      makeIO({
+        platform: "win32",
+        resolveOptionalDep: (platform) => {
+          expect(platform).toBe("win32");
+          return "C:/x/reasonix-render.exe";
+        },
+      }),
+    );
+    expect(r.command).toEqual(["C:/x/reasonix-render.exe"]);
+  });
+
+  it("REASONIX_RENDER_CMD overrides only the renderer channel; input falls back to base", () => {
+    const r = resolveRendererWith(
+      makeIO({
+        envCmd: (name) =>
+          name === "REASONIX_RENDER_CMD" ? ["custom-render", "--flag"] : undefined,
+        resolveOptionalDep: () => "/opt/bin/reasonix-render",
+      }),
+    );
+    expect(r.command).toEqual(["custom-render", "--flag"]);
+    expect(r.inputCommand).toEqual(["/opt/bin/reasonix-render", "--emit-input"]);
+    expect(r.source).toBe("optional-dep");
+  });
+
+  it("REASONIX_INPUT_CMD overrides only the input channel", () => {
+    const r = resolveRendererWith(
+      makeIO({
+        envCmd: (name) => (name === "REASONIX_INPUT_CMD" ? ["custom-input", "--flag"] : undefined),
+        resolveOptionalDep: () => "/opt/bin/reasonix-render",
+      }),
+    );
+    expect(r.command).toEqual(["/opt/bin/reasonix-render"]);
+    expect(r.inputCommand).toEqual(["custom-input", "--flag"]);
+  });
+
+  it("legacy env vars work even with no base (source becomes env-cmd)", () => {
+    const r = resolveRendererWith(
+      makeIO({
+        envCmd: (name) =>
+          name === "REASONIX_RENDER_CMD"
+            ? ["render"]
+            : name === "REASONIX_INPUT_CMD"
+              ? ["input"]
+              : undefined,
+      }),
+    );
+    expect(r.command).toEqual(["render"]);
+    expect(r.inputCommand).toEqual(["input"]);
+    expect(r.source).toBe("env-cmd");
+  });
+});


### PR DESCRIPTION
## Summary

Three commits stacked on `origin/main` that make the Rust TUI the default user-facing experience, with auto-fallback and proper integrated-mode wiring.

- **`fe649f9` integrated mode is the default** — flipped `REASONIX_RENDERER_INTEGRATED` semantics from opt-in (`=1`) to opt-out (`=0`). Now that #1064 is merged, integrated mode is the right default: Ctrl+D / Ctrl+C exit in one press (rust event loop owns them), mouse-click on preset / mode rows actually routes to React via `preset-set` / `mode-set` events, and Ctrl+C exit runs `restore_terminal` cleanly so the next launch doesn't render with an offset.
- **`2d8b062` resolver auto-finds prebuilt binary + npm dev auto-builds + Ctrl+D wired** — resolver checks source-tree `target/release/reasonix-render(.exe)` then `target/debug` before falling back to `cargo run`. New `scripts/dev-prepare.mjs` runs `cargo build --release --quiet --bin reasonix-render` ahead of `tsx` (silent no-op when cargo missing) so contributors never spawn a stale rust binary. New `npm run rust:build`. App.tsx wires Ctrl+D → `quitProcess()` (still useful in non-integrated mode).
- **`38dfd57` rust TUI default + bare `reasonix` → code + URL wrap** — `--node` flag (or `REASONIX_RENDERER=node`) is now the opt-out for the Ink renderer; default is rust. Bare `reasonix` routes to `code` in the cwd (drops the project-marker heuristic — chat stays reachable via the explicit subcommand). New `renderer-resolver.ts` with priority chain (env-cmd → env-bin → optional-dep → source-tree binary → cargo run → missing); chat.tsx auto-falls-back to Ink with a stderr warning when the rust binary can't be found, removing the old "no API key → bypass rust" Setup bail. New `paint_link_wrapped` in `whole_screen/paint.rs` so long dashboard URLs with tokens wrap inside the main panel instead of bleeding into the sidebar.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `cargo check` clean
- [x] `cargo test` (rust crate)
- [x] Vitest: 77 passing across resolver / bare-routing / scene tests; 9 new resolver unit tests + 1 dashboard-URL-wrap test + 4 prebuilt-binary resolver tests
- [x] `reasonix --help` / `reasonix code --help` show `--node` flag
- [x] Manual: integrated mode confirms cards / sidebar / dashboard URL render without overlap; Ctrl+D exits in one press; setup wizard runs end-to-end under rust on a fresh profile

## Out of scope (release-pipeline followups)

CI matrix cross-compile + `@reasonix/render-{platform}-{arch}` subpackages + `optionalDependencies` wiring — to be done in a follow-up PR before the next release. Today the resolver falls back to `cargo run` if no prebuilt binary is found, which means published users without cargo on PATH would see the auto-fallback warning and land in the Node/Ink TUI. That fallback is correct behavior — it's just not the eventual ship target.
