### PR TITLE
feat(rust): signal cleanup hook restores terminal on SIGTERM / console close

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,6 +266,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix 0.31.3",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,6 +364,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.11.1",
+ "block2",
+ "libc",
  "objc2",
 ]
 
@@ -740,7 +762,7 @@ version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
 dependencies = [
- "nix",
+ "nix 0.29.0",
  "winapi",
 ]
 
@@ -794,6 +816,18 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -1230,6 +1264,7 @@ dependencies = [
  "arboard",
  "chrono",
  "crossterm",
+ "ctrlc",
  "pulldown-cmark",
  "ratatui",
  "serde",
@@ -1524,7 +1559,7 @@ dependencies = [
  "libc",
  "log",
  "memmem",
- "nix",
+ "nix 0.29.0",
  "num-derive",
  "num-traits",
  "ordered-float",

--- a/crates/reasonix-render/Cargo.toml
+++ b/crates/reasonix-render/Cargo.toml
@@ -10,6 +10,7 @@ anyhow = "1"
 arboard = { version = "3", default-features = false }
 chrono = { version = "0.4", features = ["clock"] }
 crossterm = "0.29"
+ctrlc = { version = "3", features = ["termination"] }
 pulldown-cmark = { version = "0.13", default-features = false }
 ratatui = "0.30"
 serde = { version = "1", features = ["derive"] }

--- a/crates/reasonix-render/src/main.rs
+++ b/crates/reasonix-render/src/main.rs
@@ -63,10 +63,12 @@ fn main() -> Result<()> {
         return Ok(());
     }
     if args.iter().any(|a| a == "--emit-input") {
+        install_signal_cleanup();
         return run_emit_input();
     }
 
     install_panic_hook();
+    install_signal_cleanup();
     let mut terminal = init_terminal().context("init terminal")?;
     terminal.hide_cursor().ok();
     terminal.clear().ok();
@@ -108,6 +110,25 @@ fn restore_terminal(terminal: &mut RenderTerminal) {
     )
     .ok();
     disable_raw_mode().ok();
+}
+
+/// Best-effort terminal restore on SIGTERM / SIGHUP / Windows console-close.
+/// In raw mode ctrl+c is delivered as the byte 0x03 to crossterm and never
+/// fires SIGINT, so the existing `is_quit` event-loop branch handles
+/// interactive ctrl+c with a clean restore_terminal. This guard covers the
+/// other paths — `taskkill`, parent process death, terminal disconnect — that
+/// would otherwise leave the alt-screen + raw mode dirty and corrupt the
+/// next launch's rendering.
+fn install_signal_cleanup() {
+    let _ = ctrlc::set_handler(|| {
+        let _ = disable_raw_mode();
+        let _ = crossterm::execute!(
+            io::stdout(),
+            crossterm::terminal::LeaveAlternateScreen,
+            crossterm::cursor::Show,
+        );
+        std::process::exit(130);
+    });
 }
 
 fn install_panic_hook() {


### PR DESCRIPTION
## Summary

Plugs the remaining terminal-state-leak path for the rust renderer. Today the alt-screen + raw mode get restored on three exits:

1. **Normal return** — `restore_terminal` runs after the loop returns
2. **Interactive ctrl+c** — in raw mode the byte `0x03` is delivered as a key event, `is_quit` catches it, loop returns normally → `restore_terminal`
3. **Panic** — `install_panic_hook` runs `disable_raw_mode` + `LeaveAlternateScreen` before re-raising

But **`taskkill`, parent-process death, terminal disconnect (SIGHUP), and external `kill` (SIGTERM)** all bypass those — the OS kills the process before any cleanup can run, leaving the alt-screen + raw mode dirty and corrupting the next launch's rendering (cursor lands in the wrong row, alt-screen toggles get out of sync).

`ctrlc::set_handler` with the `termination` feature covers all those paths cross-platform: SIGINT / SIGTERM on unix, ctrl-c / ctrl-break / console-close on Windows. The handler best-effort runs `disable_raw_mode` + `LeaveAlternateScreen` + `cursor::Show` and exits 130. Installed for both `--emit-input` (which also enters raw mode) and the render modes.

Note: in raw mode interactive ctrl+c does NOT fire this handler — crossterm masks ISIG so 0x03 is a byte, not a signal. That keeps the existing `is_quit` event-loop branch authoritative for the common case.

## Test plan

- [x] `cargo build --release --bin reasonix-render` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `cargo test` 57 passed
- [ ] Manual: `kill -TERM $(pgrep reasonix-render)` from an external shell while the TUI is up — terminal should return to a clean prompt with cursor visible and alt-screen exited. Will verify on Linux once cross-platform smoke run starts.

## Out of scope

The renderer-resolver continues to spawn the binary via the parent npm process — no change to that contract.
