### PR TITLE
fix(desktop): rename nsis.languageFiles → nsis.customLanguageFiles

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -47,7 +47,7 @@
     "windows": {
       "nsis": {
         "languages": ["English", "SimpChinese"],
-        "languageFiles": {
+        "customLanguageFiles": {
           "English": "nsis/English.nsh",
           "SimpChinese": "nsis/SimpChinese.nsh"
         }


### PR DESCRIPTION
Tauri 2.x renamed the NSIS config field; `@tauri-apps/cli@2.11.1` rejects the old name with a schema validation error that blocks `tauri dev` startup:

```
Error "tauri.conf.json" error on `bundle > windows > nsis`:
{"languages":["English","SimpChinese"],"languageFiles":{...}} is not valid under any of the schemas listed in the 'anyOf' keyword
```

The schema at https://schema.tauri.app/config/2 only documents `customLanguageFiles` for the per-language `.nsh` path map.

## Test plan
- [x] `tauri dev` no longer rejects the config