### PR TITLE
fix(release): prereleases publish under dist-tag 'next', not 'latest'

### DIFF
--- a/.github/workflows/release-render.yml
+++ b/.github/workflows/release-render.yml
@@ -81,8 +81,18 @@ jobs:
           else
             raw="${GITHUB_REF_NAME}"
           fi
-          # Strip leading v if present so npm sees a clean SemVer.
-          echo "version=${raw#v}" >> "$GITHUB_OUTPUT"
+          # Strip leading v so npm sees a clean SemVer.
+          version="${raw#v}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          # Prereleases (0.44.0-rc.1, 0.44.0-beta.2, ...) ship under
+          # dist-tag 'next' so `npx reasonix@latest` keeps pointing at
+          # the most recent stable. Stable versions get 'latest' (npm's
+          # default — leave the flag empty).
+          if [[ "$version" == *-* ]]; then
+            echo "dist_tag=next" >> "$GITHUB_OUTPUT"
+          else
+            echo "dist_tag=latest" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Setup Node 22
         uses: actions/setup-node@v4
@@ -124,11 +134,11 @@ jobs:
         run: |
           set -e
           for d in subpackages/render-*; do
-            echo "↑ publishing $d"
-            (cd "$d" && npm publish --access public --provenance)
+            echo "↑ publishing $d under dist-tag ${{ steps.tag.outputs.dist_tag }}"
+            (cd "$d" && npm publish --access public --provenance --tag ${{ steps.tag.outputs.dist_tag }})
           done
 
       - name: Publish main reasonix package
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public --provenance
+        run: npm publish --access public --provenance --tag ${{ steps.tag.outputs.dist_tag }}


### PR DESCRIPTION
`npm publish` defaults to dist-tag `latest` regardless of SemVer, so publishing `0.44.0-rc.1` would replace the `0.43.0` stable release as the default for `npx reasonix@latest` users — exactly what an rc smoke test should not do.

Detect prereleases (version string contains `-`) in the workflow's tag resolution step and publish those under dist-tag `next`. Stable versions keep `latest` (npm's default).

After this lands:
- `v0.44.0-rc.1` → all 6 packages published under `next` → `npx reasonix@next` opts in
- `v0.44.0` (stable) → `latest` (default), `npx reasonix@latest` picks it up

## Test plan
- [x] Local dry-run: `raw=v0.44.0-rc.1` → `dist_tag=next`; `raw=v0.44.0` → `dist_tag=latest`
- [ ] Real run gated on this merge: push `v0.44.0-rc.1` tag and confirm `npm view @reasonix/render-linux-x64 dist-tags` shows `next: 0.44.0-rc.1` and `latest` unchanged