### PR TITLE
fix(release): cross-build darwin-x64 from macos-14 instead of retired macos-13

### DIFF
--- a/.github/workflows/release-render.yml
+++ b/.github/workflows/release-render.yml
@@ -24,7 +24,10 @@ jobs:
           - { label: "win32-x64",    rust: "x86_64-pc-windows-msvc",      os: "windows-latest", bin: "reasonix-render.exe" }
           - { label: "linux-x64",    rust: "x86_64-unknown-linux-gnu",    os: "ubuntu-22.04",   bin: "reasonix-render" }
           - { label: "linux-arm64",  rust: "aarch64-unknown-linux-gnu",   os: "ubuntu-22.04",   bin: "reasonix-render", cross: true }
-          - { label: "darwin-x64",   rust: "x86_64-apple-darwin",         os: "macos-13",       bin: "reasonix-render" }
+          # darwin-x64 cross-built from Apple Silicon — GH's macos-13 Intel pool was retired
+          # in 2025 and queues run to hours. rustc on macos-14 supports x86_64-apple-darwin
+          # natively via the `targets:` install; no codesign or runtime needed at build time.
+          - { label: "darwin-x64",   rust: "x86_64-apple-darwin",         os: "macos-14",       bin: "reasonix-render" }
           - { label: "darwin-arm64", rust: "aarch64-apple-darwin",        os: "macos-14",       bin: "reasonix-render" }
     runs-on: ${{ matrix.target.os }}
     steps:


### PR DESCRIPTION
## Why

GH retired most of its Intel-Mac (`macos-13`) runner pool in 2025; the existing `release.yml` already notes "queue waits ran to hours" — that's exactly what bit my first `v0.44.0-rc.1` push:

- 4 of 5 build jobs finished in <2 min
- `darwin-x64` sat queued for 15+ min on `macos-13` before I cancelled it

## What

Move the `darwin-x64` matrix entry from `macos-13` to `macos-14` (Apple Silicon). `rustc` cross-compiles `x86_64-apple-darwin` natively when the target is installed via `dtolnay/rust-toolchain`'s `targets:` field — no Xcode/codesign step needed at build time, the binary's identity is decided by the rust target triple, not the runner host.

## Test plan

- [ ] Once merged, push `v0.44.0-rc.2` and confirm all 5 build jobs finish, publish stage publishes `@reasonix/render-darwin-x64@0.44.0-rc.2` correctly.