### PR TITLE
fix(release): repo.url → canonical esengine/DeepSeek-Reasonix for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,12 +62,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/esengine/reasonix.git"
+    "url": "git+https://github.com/esengine/DeepSeek-Reasonix.git"
   },
   "bugs": {
-    "url": "https://github.com/esengine/reasonix/issues"
+    "url": "https://github.com/esengine/DeepSeek-Reasonix/issues"
   },
-  "homepage": "https://github.com/esengine/reasonix#readme",
+  "homepage": "https://github.com/esengine/DeepSeek-Reasonix#readme",
   "engines": {
     "node": ">=22"
   },

--- a/subpackages/render-darwin-arm64/package.json
+++ b/subpackages/render-darwin-arm64/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/esengine/reasonix.git",
+    "url": "git+https://github.com/esengine/DeepSeek-Reasonix.git",
     "directory": "subpackages/render-darwin-arm64"
   },
   "os": [

--- a/subpackages/render-darwin-x64/package.json
+++ b/subpackages/render-darwin-x64/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/esengine/reasonix.git",
+    "url": "git+https://github.com/esengine/DeepSeek-Reasonix.git",
     "directory": "subpackages/render-darwin-x64"
   },
   "os": [

--- a/subpackages/render-linux-arm64/package.json
+++ b/subpackages/render-linux-arm64/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/esengine/reasonix.git",
+    "url": "git+https://github.com/esengine/DeepSeek-Reasonix.git",
     "directory": "subpackages/render-linux-arm64"
   },
   "os": [

--- a/subpackages/render-linux-x64/package.json
+++ b/subpackages/render-linux-x64/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/esengine/reasonix.git",
+    "url": "git+https://github.com/esengine/DeepSeek-Reasonix.git",
     "directory": "subpackages/render-linux-x64"
   },
   "os": [

--- a/subpackages/render-win32-x64/package.json
+++ b/subpackages/render-win32-x64/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/esengine/reasonix.git",
+    "url": "git+https://github.com/esengine/DeepSeek-Reasonix.git",
     "directory": "subpackages/render-win32-x64"
   },
   "os": [


### PR DESCRIPTION
## Why

`npm publish --provenance` validates package.json's `repository.url` against the workflow's actual GitHub repo path via sigstore. The canonical repo name is `esengine/DeepSeek-Reasonix`; we'd been pointing at the legacy `esengine/reasonix` redirect alias, which sigstore rejects:

```
npm error 422 Unprocessable Entity - Error verifying sigstore provenance bundle:
Failed to validate repository information: package.json: "repository.url" is
"git+https://github.com/esengine/reasonix.git", expected to match
"https://github.com/esengine/DeepSeek-Reasonix" from provenance
```

## What

Rewrite `repository.url` (+ `bugs.url` + `homepage` for the main package) across 6 package.json files. Auth (which was the previous blocker) confirmed working in rc.3 — provenance is the only thing left.

## Test plan

- [ ] Push v0.44.0-rc.4 and confirm all 6 `npm publish`es succeed under dist-tag `next`.