### PR TITLE
fix(release): npm publish --ignore-scripts (build CI is the test gate)

### DIFF
--- a/.github/workflows/release-render.yml
+++ b/.github/workflows/release-render.yml
@@ -138,10 +138,16 @@ jobs:
           set -e
           for d in subpackages/render-*; do
             echo "↑ publishing $d under dist-tag ${{ steps.tag.outputs.dist_tag }}"
-            (cd "$d" && npm publish --access public --provenance --tag ${{ steps.tag.outputs.dist_tag }})
+            (cd "$d" && npm publish --access public --provenance --tag ${{ steps.tag.outputs.dist_tag }} --ignore-scripts)
           done
 
       - name: Publish main reasonix package
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public --provenance --tag ${{ steps.tag.outputs.dist_tag }}
+        # --ignore-scripts: the explicit `npm run build` step above already
+        # produces dist/, and CI's build job already ran the full test +
+        # typecheck + lint matrix on every push. Re-running prepublishOnly's
+        # entire pipeline here just doubles latency and re-exposes us to
+        # flaky tests (ink stdout rendering, etc.) that have nothing to do
+        # with publishability.
+        run: npm publish --access public --provenance --tag ${{ steps.tag.outputs.dist_tag }} --ignore-scripts


### PR DESCRIPTION
rc.4 publish failed because prepublishOnly re-ran the test suite and a flaky ink stdout-rendering test failed mysteriously on the publish runner — same test passed on the build CI matrix on the same commit. Trace:

```
##[error]AssertionError: expected '  ──────────────────────────────────…' to contain '$0.0308 turn'
```

Re-running the entire test suite during `npm publish` is redundant — every push already runs lint + typecheck + test:coverage on ubuntu + windows before merge — and adds 60-90s of flakiness surface on every publish.

Workflow already builds `dist/` explicitly via `npm run build` before publish, so dropping prepublishOnly (via `--ignore-scripts`) doesn't lose anything that matters. prepublishOnly stays available for one-off manual publishes from a contributor's machine.

## Test plan

- [ ] Push v0.44.0-rc.5 after this merges, confirm all 6 publishes succeed and `npm view @reasonix/render-* dist-tags` shows the new version under `next`.