### PR TITLE
fix(release): MSI-safe version mapping for tauri.conf.json prereleases

### DIFF
--- a/scripts/sync-desktop-version.mjs
+++ b/scripts/sync-desktop-version.mjs
@@ -22,8 +22,19 @@ const tauriConfPath = join(repoRoot, "desktop/src-tauri/tauri.conf.json");
 const cargoTomlPath = join(repoRoot, "desktop/src-tauri/Cargo.toml");
 const desktopPkgPath = join(repoRoot, "desktop/package.json");
 
+// MSI bundler rejects pre-release identifiers — Windows installer versions
+// must be numeric MAJOR.MINOR.BUILD.REVISION ≤ 65535. Encode a SemVer
+// pre-release's numeric tail (rc.5, beta.2, alpha.1) as the 4th segment so
+// rc/beta tags still produce bundles. Stable versions pass through as-is.
+function tauriBundleVersion(semver) {
+  const m = /^(\d+\.\d+\.\d+)(?:-[A-Za-z-]+(?:\.(\d+))?)?$/.exec(semver);
+  if (!m) return semver;
+  return m[2] !== undefined ? `${m[1]}.${m[2]}` : m[1];
+}
+const tauriVersion = tauriBundleVersion(version);
+
 const tauriConf = JSON.parse(readFileSync(tauriConfPath, "utf8"));
-tauriConf.version = version;
+tauriConf.version = tauriVersion;
 writeFileSync(tauriConfPath, `${JSON.stringify(tauriConf, null, 2)}\n`);
 
 const cargoToml = readFileSync(cargoTomlPath, "utf8");


### PR DESCRIPTION
## Why

v0.44.0-rc.5 push triggered `release.yml` (Tauri desktop bundles) which failed all 3 windows-x64 attempts (unsigned + signed + macOS branches don't apply) with:

```
failed to bundle project 'optional pre-release identifier in app version
must be numeric-only and cannot be greater than 65535 for msi target'
```

Windows MSI installer versions are constrained to numeric `MAJOR.MINOR.BUILD.REVISION` (each ≤ 65535). SemVer `-rc.5` strings are illegal — the MSI bundler can't encode them into the installer's version metadata.

## What

`sync-desktop-version.mjs` now encodes the prerelease's numeric tail as the 4th segment when writing to `tauri.conf.json`:

|  tag  |  tauri.conf.json version  |
|---|---|
| `v0.44.0`         | `0.44.0`     (unchanged) |
| `v0.44.0-rc.5`    | `0.44.0.5`              |
| `v0.44.0-beta.2`  | `0.44.0.2`              |
| `v0.44.0-alpha`   | `0.44.0`     (no numeric tail → strip) |

Cargo.toml + desktop/package.json keep the full SemVer (cargo + npm both accept prerelease identifiers).

## Test plan

- [x] Local unit-test of the mapper covers stable + 3 prerelease shapes
- [ ] Next `v*-rc.N` tag push proves MSI bundle succeeds end-to-end
- [ ] Next `v0.44.0` stable push (no prerelease) is a no-op for the mapper