### PR TITLE
fix(session): make session rewrites recoverable

### DIFF
--- a/src/memory/session.ts
+++ b/src/memory/session.ts
@@ -4,6 +4,7 @@ import { execFileSync } from "node:child_process";
 import {
   appendFileSync,
   chmodSync,
+  copyFileSync,
   existsSync,
   mkdirSync,
   readFileSync,
@@ -16,6 +17,14 @@ import {
 import { homedir } from "node:os";
 import { dirname, join, posix as posixPath, win32 as win32Path } from "node:path";
 import type { ChatMessage } from "../types.js";
+
+const SESSION_SIDECAR_EXTS = [
+  ".events.jsonl",
+  ".meta.json",
+  ".pending.json",
+  ".plan.json",
+  ".jsonl.bak",
+] as const;
 
 /** Best-effort git branch sniff; returns undefined if not a git repo or git missing. */
 export function detectGitBranch(cwd: string): string | undefined {
@@ -139,23 +148,34 @@ export function resolveSession(
 export function loadSessionMessages(name: string): ChatMessage[] {
   const path = sessionPath(name);
   if (!existsSync(path)) return [];
+  const live = readSessionMessages(path);
+  if (live && (live.messages.length > 0 || !live.hadContent)) return live.messages;
+
+  const backup = readSessionMessages(sessionBackupPath(path));
+  return backup?.messages ?? live?.messages ?? [];
+}
+
+function readSessionMessages(
+  path: string,
+): { messages: ChatMessage[]; hadContent: boolean } | null {
+  let raw: string;
   try {
-    const raw = readFileSync(path, "utf8");
-    const out: ChatMessage[] = [];
-    for (const line of raw.split(/\r?\n/)) {
-      const trimmed = line.trim();
-      if (!trimmed) continue;
-      try {
-        const msg = JSON.parse(trimmed) as ChatMessage;
-        if (msg && typeof msg === "object" && "role" in msg) out.push(msg);
-      } catch {
-        /* skip malformed line */
-      }
-    }
-    return out;
+    raw = readFileSync(path, "utf8");
   } catch {
-    return [];
+    return null;
   }
+  const out: ChatMessage[] = [];
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const msg = JSON.parse(trimmed) as ChatMessage;
+      if (msg && typeof msg === "object" && "role" in msg) out.push(msg);
+    } catch {
+      /* skip malformed line */
+    }
+  }
+  return { messages: out, hadContent: raw.trim().length > 0 };
 }
 
 export function appendSessionMessage(name: string, message: ChatMessage): void {
@@ -259,7 +279,7 @@ export function renameSession(oldName: string, newName: string): boolean {
   const newJsonl = sessionPath(newName);
   if (!existsSync(oldJsonl) || existsSync(newJsonl)) return false;
   renameSync(oldJsonl, newJsonl);
-  for (const ext of [".events.jsonl", ".meta.json", ".pending.json", ".plan.json"]) {
+  for (const ext of SESSION_SIDECAR_EXTS) {
     const oldP = oldJsonl.replace(/\.jsonl$/, ext);
     const newP = newJsonl.replace(/\.jsonl$/, ext);
     if (existsSync(oldP)) {
@@ -289,7 +309,7 @@ export function deleteSession(name: string): boolean {
   const path = sessionPath(name);
   try {
     unlinkSync(path);
-    for (const ext of [".events.jsonl", ".pending.json", ".meta.json", ".plan.json"]) {
+    for (const ext of SESSION_SIDECAR_EXTS) {
       const sidecar = path.replace(/\.jsonl$/, ext);
       try {
         unlinkSync(sidecar);
@@ -303,16 +323,29 @@ export function deleteSession(name: string): boolean {
   }
 }
 
-/** Non-atomic truncate+write window is acceptable — a concurrent crash leaves the session file empty, same end state as the user deleting it. */
+/** Crash-safe rewrite: snapshot the previous live log, write a sibling tmp file, then atomically swap it in. */
 export function rewriteSession(name: string, messages: ChatMessage[]): void {
   const path = sessionPath(name);
   mkdirSync(dirname(path), { recursive: true });
   const body = messages.map((m) => JSON.stringify(m)).join("\n");
-  writeFileSync(path, body ? `${body}\n` : "", "utf8");
+  const tmp = `${path}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}.tmp`;
   try {
-    chmodSync(path, 0o600);
-  } catch {
-    /* chmod not supported */
+    writeFileSync(tmp, body ? `${body}\n` : "", "utf8");
+    chmodPrivate(tmp);
+    if (existsSync(path) && statSync(path).size > 0) {
+      const backup = sessionBackupPath(path);
+      copyFileSync(path, backup);
+      chmodPrivate(backup);
+    }
+    renameSync(tmp, path);
+    chmodPrivate(path);
+  } catch (err) {
+    try {
+      unlinkSync(tmp);
+    } catch {
+      /* tmp may not exist */
+    }
+    throw err;
   }
 }
 
@@ -338,5 +371,17 @@ function countLines(path: string): number {
     return raw.split(/\r?\n/).filter((l) => l.trim()).length;
   } catch {
     return 0;
+  }
+}
+
+function sessionBackupPath(path: string): string {
+  return `${path}.bak`;
+}
+
+function chmodPrivate(path: string): void {
+  try {
+    chmodSync(path, 0o600);
+  } catch {
+    /* chmod not supported */
   }
 }

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -19,6 +19,7 @@ import {
   pruneStaleSessions,
   renameSession,
   resolveSession,
+  rewriteSession,
   sanitizeName,
   sessionPath,
   sessionsDir,
@@ -89,6 +90,42 @@ describe("session persistence", () => {
     expect(msgs.length).toBe(2);
   });
 
+  it("rewriteSession snapshots a non-empty live transcript before replacing it", () => {
+    appendSessionMessage("safe-rewrite", { role: "user", content: "old" });
+
+    rewriteSession("safe-rewrite", [{ role: "user", content: "new" }]);
+
+    expect(loadSessionMessages("safe-rewrite")).toEqual([{ role: "user", content: "new" }]);
+    expect(readFileSync(`${sessionPath("safe-rewrite")}.bak`, "utf8")).toBe(
+      `${JSON.stringify({ role: "user", content: "old" })}\n`,
+    );
+  });
+
+  it("loadSessionMessages falls back to backup when the live transcript has no valid entries", () => {
+    appendSessionMessage("recover-corrupt", { role: "user", content: "saved" });
+    const p = sessionPath("recover-corrupt");
+    writeFileSync(`${p}.bak`, readFileSync(p, "utf8"));
+    writeFileSync(p, "not json\nalso not json\n");
+
+    expect(loadSessionMessages("recover-corrupt")).toEqual([{ role: "user", content: "saved" }]);
+  });
+
+  it("loadSessionMessages does not resurrect backup when the live transcript is empty", () => {
+    appendSessionMessage("empty-live", { role: "user", content: "old" });
+    const p = sessionPath("empty-live");
+    writeFileSync(`${p}.bak`, readFileSync(p, "utf8"));
+    writeFileSync(p, "");
+
+    expect(loadSessionMessages("empty-live")).toEqual([]);
+  });
+
+  it("listSessions ignores jsonl backup sidecars", () => {
+    appendSessionMessage("visible", { role: "user", content: "x" });
+    writeFileSync(`${sessionPath("visible")}.bak`, `${JSON.stringify({ role: "user" })}\n`);
+
+    expect(listSessions().map((s) => s.name)).toEqual(["visible"]);
+  });
+
   it("listSessions returns metadata sorted by mtime desc", () => {
     appendSessionMessage("alpha", { role: "user", content: "x" });
     appendSessionMessage("beta", { role: "user", content: "y" });
@@ -136,12 +173,33 @@ describe("session persistence", () => {
     expect(existsSync(sessionPath("renamed").replace(/\.jsonl$/, ".events.jsonl"))).toBe(true);
   });
 
+  it("renameSession also moves the .jsonl.bak recovery sidecar", () => {
+    appendSessionMessage("bak-orig", { role: "user", content: "x" });
+    const oldBackup = `${sessionPath("bak-orig")}.bak`;
+    writeFileSync(oldBackup, `${JSON.stringify({ role: "user", content: "backup" })}\n`);
+
+    expect(renameSession("bak-orig", "bak-renamed")).toBe(true);
+
+    expect(existsSync(oldBackup)).toBe(false);
+    expect(existsSync(`${sessionPath("bak-renamed")}.bak`)).toBe(true);
+  });
+
   it("deleteSession removes the .events.jsonl sidecar too", () => {
     appendSessionMessage("trash", { role: "user", content: "x" });
     const events = sessionPath("trash").replace(/\.jsonl$/, ".events.jsonl");
     writeFileSync(events, '{"id":1}\n');
     deleteSession("trash");
     expect(existsSync(events)).toBe(false);
+  });
+
+  it("deleteSession removes the .jsonl.bak recovery sidecar too", () => {
+    appendSessionMessage("backup-trash", { role: "user", content: "x" });
+    const backup = `${sessionPath("backup-trash")}.bak`;
+    writeFileSync(backup, `${JSON.stringify({ role: "user", content: "backup" })}\n`);
+
+    deleteSession("backup-trash");
+
+    expect(existsSync(backup)).toBe(false);
   });
 
   it("deleteSession removes the file", () => {
@@ -215,8 +273,10 @@ describe("session persistence", () => {
       appendSessionMessage("live", { role: "user", content: "hi" });
       const events = sessionPath("live").replace(/\.jsonl$/, ".events.jsonl");
       const meta = sessionPath("live").replace(/\.jsonl$/, ".meta.json");
+      const backup = `${sessionPath("live")}.bak`;
       writeFileSync(events, '{"id":1}\n');
       writeFileSync(meta, "{}");
+      writeFileSync(backup, `${JSON.stringify({ role: "user", content: "backup" })}\n`);
 
       const archived = archiveSession("live");
       expect(archived).toMatch(/^live__archive_\d{12}/);
@@ -224,8 +284,10 @@ describe("session persistence", () => {
       expect(existsSync(sessionPath(archived!))).toBe(true);
       expect(existsSync(events)).toBe(false);
       expect(existsSync(meta)).toBe(false);
+      expect(existsSync(backup)).toBe(false);
       expect(existsSync(sessionPath(archived!).replace(/\.jsonl$/, ".events.jsonl"))).toBe(true);
       expect(existsSync(sessionPath(archived!).replace(/\.jsonl$/, ".meta.json"))).toBe(true);
+      expect(existsSync(`${sessionPath(archived!)}.bak`)).toBe(true);
       expect(loadSessionMessages(archived!)).toEqual([{ role: "user", content: "hi" }]);
     });
 


### PR DESCRIPTION
## Summary
- make session rewrites crash-safer by writing a sibling temp file before replacing the live JSONL
- keep a `.jsonl.bak` recovery copy and fall back to it when the live transcript has no valid entries
- carry the recovery sidecar through rename, delete, and archive session flows

## Test Plan
- [x] npm run test -- tests/session.test.ts tests/loop-error.test.ts
- [x] npm run verify

Refs #1079
