### PR TITLE
fix(loop): persist send-time session healing

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -502,11 +502,25 @@ export class CacheFirstLoop {
   private _inflightCounter = 0;
 
   private buildMessages(pendingUser: string | null): ChatMessage[] {
-    // DeepSeek 400s on either unpaired tool_calls or stray tool entries — heal before sending.
-    const healed = healLoadedMessages(this.log.toMessages(), DEFAULT_MAX_RESULT_CHARS);
-    const msgs: ChatMessage[] = [...this.prefix.toMessages(), ...healed.messages];
+    const healedMessages = this.healActiveLogBeforeSend();
+    const msgs: ChatMessage[] = [...this.prefix.toMessages(), ...healedMessages];
     if (pendingUser !== null) msgs.push({ role: "user", content: pendingUser });
     return msgs;
+  }
+
+  private healActiveLogBeforeSend(): ChatMessage[] {
+    const current = this.log.toMessages();
+    const healed = healLoadedMessages(current, DEFAULT_MAX_RESULT_CHARS);
+    if (healed.healedCount === 0) return current;
+    this.log.compactInPlace(healed.messages);
+    if (this.sessionName) {
+      try {
+        rewriteSession(this.sessionName, healed.messages);
+      } catch {
+        /* disk issue shouldn't block the in-memory heal */
+      }
+    }
+    return healed.messages;
   }
 
   abort(): void {

--- a/tests/loop-user-persist.test.ts
+++ b/tests/loop-user-persist.test.ts
@@ -6,6 +6,7 @@ import { DeepSeekClient } from "../src/client.js";
 import { CacheFirstLoop } from "../src/loop.js";
 import { ImmutablePrefix } from "../src/memory/runtime.js";
 import { loadSessionMessages } from "../src/memory/session.js";
+import type { ChatMessage } from "../src/types.js";
 
 describe("loop persists user message at step entry (issue #943)", () => {
   let tmp: string;
@@ -109,5 +110,57 @@ describe("loop persists user message at step entry (issue #943)", () => {
     // No duplicate user copies.
     const userMsgs = persisted.filter((m) => m.role === "user");
     expect(userMsgs).toHaveLength(1);
+  });
+
+  it("persists send-time healing of dangling tool_calls so the session does not stay poisoned", async () => {
+    const requestMessages: ChatMessage[][] = [];
+    const client = new DeepSeekClient({
+      apiKey: "sk-test",
+      fetch: vi.fn(async (_url: unknown, init: { body?: string } | undefined) => {
+        const body = init?.body ? JSON.parse(init.body) : {};
+        requestMessages.push(body.messages as ChatMessage[]);
+        return new Response(
+          JSON.stringify({
+            choices: [
+              {
+                index: 0,
+                message: { role: "assistant", content: "recovered" },
+                finish_reason: "stop",
+              },
+            ],
+            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }) as unknown as typeof fetch,
+    });
+
+    const sessionName = "issue1079-dangling-tool-heal";
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s" }),
+      stream: false,
+      session: sessionName,
+    });
+    loop.appendAndPersist({ role: "user", content: "before sleep" });
+    loop.appendAndPersist({
+      role: "assistant",
+      content: "",
+      tool_calls: [{ id: "lost", type: "function", function: { name: "read", arguments: "{}" } }],
+    });
+
+    await loop.run("continue after wake");
+
+    expect(
+      requestMessages[0]!.some((m) => m.role === "assistant" && (m.tool_calls?.length ?? 0) > 0),
+    ).toBe(false);
+    expect(
+      loop.log.entries.some((m) => m.role === "assistant" && (m.tool_calls?.length ?? 0) > 0),
+    ).toBe(false);
+    expect(
+      loadSessionMessages(sessionName).some(
+        (m) => m.role === "assistant" && (m.tool_calls?.length ?? 0) > 0,
+      ),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- persist the existing send-time session healing back into the active log before each model request
- rewrite the session JSONL when a dangling `assistant.tool_calls` tail or stray tool result is removed during send preparation
- add a regression that simulates a session poisoned in-process after sleep/network interruption and verifies both memory and disk are healed

## Test Plan
- [x] npm run test -- tests/loop-user-persist.test.ts tests/loop-error.test.ts tests/loop.test.ts
- [x] npm run verify

Refs #1079
