### PR TITLE
fix(release): restore +x on rust binary so mac/linux npx doesn't EACCES (0.44.1)

### DIFF
--- a/.github/workflows/release-render.yml
+++ b/.github/workflows/release-render.yml
@@ -125,6 +125,14 @@ jobs:
             mkdir -p subpackages/render-${label}/bin
             cp -r "$d"/bin/* subpackages/render-${label}/bin/
           done
+          # actions/download-artifact@v4 strips Unix file modes — restore +x
+          # on the non-Windows binaries so users hitting them via spawn() (not
+          # via npm's bin symlink) don't EACCES. The bin field in each
+          # subpackage's package.json is a second layer for the normal
+          # install path.
+          for bin in subpackages/render-{linux,darwin}-*/bin/reasonix-render; do
+            [ -f "$bin" ] && chmod +x "$bin"
+          done
           ls -la subpackages/*/bin/
 
       - name: Build main package dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to Reasonix. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.44.1] — 2026-05-17
+
+**Fix:** Mac/Linux `npx reasonix@latest` failed with `EACCES` when spawning
+the rust renderer (`spawn ... reasonix-render EACCES`). `actions/download-artifact@v4`
+strips Unix file modes during the release pipeline's artifact round-trip,
+so the binaries in the published 0.44.0 subpackages landed without the
+executable bit. Two-layer fix:
+
+- Each `@reasonix/render-*` subpackage now declares its binary in the
+  `bin` field of `package.json`, so `npm install` chmod +x's the file
+  during extraction (standard npm behavior for bin-declared files).
+- The publish workflow explicitly `chmod +x`'s the non-Windows binaries
+  after staging from artifacts, so the tarball itself ships with the
+  right mode regardless of npm version.
+
+No code changes — same renderer binary as 0.44.0, just a republish with
+correct file modes.
+
 ## [0.44.0] — 2026-05-17
 
 **Headline:** The Rust TUI is now the default TUI. `npx reasonix@latest`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reasonix",
-  "version": "0.44.0",
+  "version": "0.44.1",
   "description": "DeepSeek-native coding agent: cache-first loop, flash-first cost control, tool-call repair.",
   "type": "module",
   "bin": {
@@ -110,10 +110,10 @@
     "vitest": "^2.1.5"
   },
   "optionalDependencies": {
-    "@reasonix/render-darwin-arm64": "0.44.0",
-    "@reasonix/render-darwin-x64": "0.44.0",
-    "@reasonix/render-linux-arm64": "0.44.0",
-    "@reasonix/render-linux-x64": "0.44.0",
-    "@reasonix/render-win32-x64": "0.44.0"
+    "@reasonix/render-darwin-arm64": "0.44.1",
+    "@reasonix/render-darwin-x64": "0.44.1",
+    "@reasonix/render-linux-arm64": "0.44.1",
+    "@reasonix/render-linux-x64": "0.44.1",
+    "@reasonix/render-win32-x64": "0.44.1"
   }
 }

--- a/subpackages/render-darwin-arm64/package.json
+++ b/subpackages/render-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reasonix/render-darwin-arm64",
-  "version": "0.44.0",
+  "version": "0.44.1",
   "description": "Reasonix ratatui renderer — macOS Apple Silicon (M-series) binary. Installed automatically as an optional dependency of the main `reasonix` package; do not depend on it directly.",
   "license": "MIT",
   "repository": {
@@ -16,5 +16,8 @@
   ],
   "files": [
     "bin/"
-  ]
+  ],
+  "bin": {
+    "reasonix-render": "bin/reasonix-render"
+  }
 }

--- a/subpackages/render-darwin-x64/package.json
+++ b/subpackages/render-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reasonix/render-darwin-x64",
-  "version": "0.44.0",
+  "version": "0.44.1",
   "description": "Reasonix ratatui renderer — macOS Intel x64 binary. Installed automatically as an optional dependency of the main `reasonix` package; do not depend on it directly.",
   "license": "MIT",
   "repository": {
@@ -16,5 +16,8 @@
   ],
   "files": [
     "bin/"
-  ]
+  ],
+  "bin": {
+    "reasonix-render": "bin/reasonix-render"
+  }
 }

--- a/subpackages/render-linux-arm64/package.json
+++ b/subpackages/render-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reasonix/render-linux-arm64",
-  "version": "0.44.0",
+  "version": "0.44.1",
   "description": "Reasonix ratatui renderer — Linux ARM64 (glibc) binary. Installed automatically as an optional dependency of the main `reasonix` package; do not depend on it directly.",
   "license": "MIT",
   "repository": {
@@ -19,5 +19,8 @@
   ],
   "files": [
     "bin/"
-  ]
+  ],
+  "bin": {
+    "reasonix-render": "bin/reasonix-render"
+  }
 }

--- a/subpackages/render-linux-x64/package.json
+++ b/subpackages/render-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reasonix/render-linux-x64",
-  "version": "0.44.0",
+  "version": "0.44.1",
   "description": "Reasonix ratatui renderer — Linux x64 (glibc) binary. Installed automatically as an optional dependency of the main `reasonix` package; do not depend on it directly.",
   "license": "MIT",
   "repository": {
@@ -19,5 +19,8 @@
   ],
   "files": [
     "bin/"
-  ]
+  ],
+  "bin": {
+    "reasonix-render": "bin/reasonix-render"
+  }
 }

--- a/subpackages/render-win32-x64/package.json
+++ b/subpackages/render-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reasonix/render-win32-x64",
-  "version": "0.44.0",
+  "version": "0.44.1",
   "description": "Reasonix ratatui renderer — Windows x64 binary. Installed automatically as an optional dependency of the main `reasonix` package; do not depend on it directly.",
   "license": "MIT",
   "repository": {
@@ -16,5 +16,8 @@
   ],
   "files": [
     "bin/"
-  ]
+  ],
+  "bin": {
+    "reasonix-render": "bin/reasonix-render.exe"
+  }
 }


### PR DESCRIPTION
User report on macOS:

```
Error: spawn .../node_modules/@reasonix/render-darwin-arm64/bin/reasonix-render EACCES
```

`actions/download-artifact@v4` strips Unix file modes when round-tripping artifacts in the publish pipeline, so 0.44.0 mac/linux tarballs landed without the executable bit. Two-layer fix:

1. Each `@reasonix/render-*` subpackage now declares its binary in the `bin` field of `package.json` — npm install `chmod +x`'s bin-declared files during extraction (standard behavior).
2. The publish workflow explicitly `chmod +x`'s the non-Windows binaries after staging from artifacts, so the tarball itself ships with the right mode regardless of npm version.

Bumps to 0.44.1. No code changes — same renderer binary as 0.44.0, republished with correct file modes.

## Test plan

- [ ] After merge, push `v0.44.1` tag; smoke-test `npx reasonix@latest` on macOS hits the binary without EACCES.