### PR TITLE
fix(ci): sync renderer optional dependency lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reasonix",
-  "version": "0.43.0",
+  "version": "0.44.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reasonix",
-      "version": "0.43.0",
+      "version": "0.44.1",
       "license": "MIT",
       "dependencies": {
         "cli-highlight": "^2.1.11",
@@ -51,6 +51,13 @@
       },
       "engines": {
         "node": ">=22"
+      },
+      "optionalDependencies": {
+        "@reasonix/render-darwin-arm64": "0.44.1",
+        "@reasonix/render-darwin-x64": "0.44.1",
+        "@reasonix/render-linux-arm64": "0.44.1",
+        "@reasonix/render-linux-x64": "0.44.1",
+        "@reasonix/render-win32-x64": "0.44.1"
       }
     },
     "node_modules/@alcalzone/ansi-tokenize": {
@@ -1698,6 +1705,92 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@reasonix/render-darwin-arm64": {
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@reasonix/render-darwin-arm64/-/render-darwin-arm64-0.44.1.tgz",
+      "integrity": "sha512-HFh1GDVFDzffytyW2URPWFdilCEuS4jH+uYiTGyX9K3hSeSgDO9jnIkwy/p/e5DOTl3opqejtU1R7uqX5Rfwdg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "reasonix-render": "bin/reasonix-render"
+      }
+    },
+    "node_modules/@reasonix/render-darwin-x64": {
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@reasonix/render-darwin-x64/-/render-darwin-x64-0.44.1.tgz",
+      "integrity": "sha512-M8okR3igIM78JNRb0BKKXZx4eAnA1CFbt64LQt3BeEplHwXcKN15bs71AwC92nKdVM92K1GPQw5C+/UUvF2PMg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "reasonix-render": "bin/reasonix-render"
+      }
+    },
+    "node_modules/@reasonix/render-linux-arm64": {
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@reasonix/render-linux-arm64/-/render-linux-arm64-0.44.1.tgz",
+      "integrity": "sha512-bONm9WZJDpzV6L3R9coNvjsrFInHHkz9KuxSifAWDSCUUkdG2uIALoW4Skg4UY19DYyS504WTGuyeO3T94K2Qw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "reasonix-render": "bin/reasonix-render"
+      }
+    },
+    "node_modules/@reasonix/render-linux-x64": {
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@reasonix/render-linux-x64/-/render-linux-x64-0.44.1.tgz",
+      "integrity": "sha512-5BWm7D18FckfOohSurq9pNC9/i7Dunji7BXnWnfzo+r0LNlj455rgoTqFXgQrjQH5WQ265TOy9Zm08DXqmSAGw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "reasonix-render": "bin/reasonix-render"
+      }
+    },
+    "node_modules/@reasonix/render-win32-x64": {
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@reasonix/render-win32-x64/-/render-win32-x64-0.44.1.tgz",
+      "integrity": "sha512-bgpQDzyKhFqateJbq1E5eQ5y9OikTc6jVFEsS14ueEy+Lq5Josc1HZ081VLXmjnZVHMG0EjrtWltOWcXOHrUJA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "reasonix-render": "bin/reasonix-render.exe"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {


### PR DESCRIPTION
## Summary
- sync package-lock root metadata to 0.44.1
- add lock entries for the @reasonix/render-* optional packages declared in package.json
- restore npm ci on GitHub Actions after the renderer package split

## Test Plan
- [x] npm ci --dry-run --ignore-scripts
- [x] npm run verify

Unblocks the withdrawn #1102 resubmission.