### PR TITLE
fix(loop): persist send-time session healing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reasonix",
-  "version": "0.43.0",
+  "version": "0.44.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reasonix",
-      "version": "0.43.0",
+      "version": "0.44.1",
       "license": "MIT",
       "dependencies": {
         "cli-highlight": "^2.1.11",
@@ -51,6 +51,13 @@
       },
       "engines": {
         "node": ">=22"
+      },
+      "optionalDependencies": {
+        "@reasonix/render-darwin-arm64": "0.44.1",
+        "@reasonix/render-darwin-x64": "0.44.1",
+        "@reasonix/render-linux-arm64": "0.44.1",
+        "@reasonix/render-linux-x64": "0.44.1",
+        "@reasonix/render-win32-x64": "0.44.1"
       }
     },
     "node_modules/@alcalzone/ansi-tokenize": {
@@ -1698,6 +1705,92 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@reasonix/render-darwin-arm64": {
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@reasonix/render-darwin-arm64/-/render-darwin-arm64-0.44.1.tgz",
+      "integrity": "sha512-HFh1GDVFDzffytyW2URPWFdilCEuS4jH+uYiTGyX9K3hSeSgDO9jnIkwy/p/e5DOTl3opqejtU1R7uqX5Rfwdg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "reasonix-render": "bin/reasonix-render"
+      }
+    },
+    "node_modules/@reasonix/render-darwin-x64": {
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@reasonix/render-darwin-x64/-/render-darwin-x64-0.44.1.tgz",
+      "integrity": "sha512-M8okR3igIM78JNRb0BKKXZx4eAnA1CFbt64LQt3BeEplHwXcKN15bs71AwC92nKdVM92K1GPQw5C+/UUvF2PMg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "reasonix-render": "bin/reasonix-render"
+      }
+    },
+    "node_modules/@reasonix/render-linux-arm64": {
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@reasonix/render-linux-arm64/-/render-linux-arm64-0.44.1.tgz",
+      "integrity": "sha512-bONm9WZJDpzV6L3R9coNvjsrFInHHkz9KuxSifAWDSCUUkdG2uIALoW4Skg4UY19DYyS504WTGuyeO3T94K2Qw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "reasonix-render": "bin/reasonix-render"
+      }
+    },
+    "node_modules/@reasonix/render-linux-x64": {
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@reasonix/render-linux-x64/-/render-linux-x64-0.44.1.tgz",
+      "integrity": "sha512-5BWm7D18FckfOohSurq9pNC9/i7Dunji7BXnWnfzo+r0LNlj455rgoTqFXgQrjQH5WQ265TOy9Zm08DXqmSAGw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "reasonix-render": "bin/reasonix-render"
+      }
+    },
+    "node_modules/@reasonix/render-win32-x64": {
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@reasonix/render-win32-x64/-/render-win32-x64-0.44.1.tgz",
+      "integrity": "sha512-bgpQDzyKhFqateJbq1E5eQ5y9OikTc6jVFEsS14ueEy+Lq5Josc1HZ081VLXmjnZVHMG0EjrtWltOWcXOHrUJA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "reasonix-render": "bin/reasonix-render.exe"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -502,11 +502,25 @@ export class CacheFirstLoop {
   private _inflightCounter = 0;
 
   private buildMessages(pendingUser: string | null): ChatMessage[] {
-    // DeepSeek 400s on either unpaired tool_calls or stray tool entries — heal before sending.
-    const healed = healLoadedMessages(this.log.toMessages(), DEFAULT_MAX_RESULT_CHARS);
-    const msgs: ChatMessage[] = [...this.prefix.toMessages(), ...healed.messages];
+    const healedMessages = this.healActiveLogBeforeSend();
+    const msgs: ChatMessage[] = [...this.prefix.toMessages(), ...healedMessages];
     if (pendingUser !== null) msgs.push({ role: "user", content: pendingUser });
     return msgs;
+  }
+
+  private healActiveLogBeforeSend(): ChatMessage[] {
+    const current = this.log.toMessages();
+    const healed = healLoadedMessages(current, DEFAULT_MAX_RESULT_CHARS);
+    if (healed.healedCount === 0) return current;
+    this.log.compactInPlace(healed.messages);
+    if (this.sessionName) {
+      try {
+        rewriteSession(this.sessionName, healed.messages);
+      } catch {
+        /* disk issue shouldn't block the in-memory heal */
+      }
+    }
+    return healed.messages;
   }
 
   abort(): void {

--- a/tests/loop-user-persist.test.ts
+++ b/tests/loop-user-persist.test.ts
@@ -6,6 +6,7 @@ import { DeepSeekClient } from "../src/client.js";
 import { CacheFirstLoop } from "../src/loop.js";
 import { ImmutablePrefix } from "../src/memory/runtime.js";
 import { loadSessionMessages } from "../src/memory/session.js";
+import type { ChatMessage } from "../src/types.js";
 
 describe("loop persists user message at step entry (issue #943)", () => {
   let tmp: string;
@@ -109,5 +110,57 @@ describe("loop persists user message at step entry (issue #943)", () => {
     // No duplicate user copies.
     const userMsgs = persisted.filter((m) => m.role === "user");
     expect(userMsgs).toHaveLength(1);
+  });
+
+  it("persists send-time healing of dangling tool_calls so the session does not stay poisoned", async () => {
+    const requestMessages: ChatMessage[][] = [];
+    const client = new DeepSeekClient({
+      apiKey: "sk-test",
+      fetch: vi.fn(async (_url: unknown, init: { body?: string } | undefined) => {
+        const body = init?.body ? JSON.parse(init.body) : {};
+        requestMessages.push(body.messages as ChatMessage[]);
+        return new Response(
+          JSON.stringify({
+            choices: [
+              {
+                index: 0,
+                message: { role: "assistant", content: "recovered" },
+                finish_reason: "stop",
+              },
+            ],
+            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }) as unknown as typeof fetch,
+    });
+
+    const sessionName = "issue1079-dangling-tool-heal";
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s" }),
+      stream: false,
+      session: sessionName,
+    });
+    loop.appendAndPersist({ role: "user", content: "before sleep" });
+    loop.appendAndPersist({
+      role: "assistant",
+      content: "",
+      tool_calls: [{ id: "lost", type: "function", function: { name: "read", arguments: "{}" } }],
+    });
+
+    await loop.run("continue after wake");
+
+    expect(
+      requestMessages[0]!.some((m) => m.role === "assistant" && (m.tool_calls?.length ?? 0) > 0),
+    ).toBe(false);
+    expect(
+      loop.log.entries.some((m) => m.role === "assistant" && (m.tool_calls?.length ?? 0) > 0),
+    ).toBe(false);
+    expect(
+      loadSessionMessages(sessionName).some(
+        (m) => m.role === "assistant" && (m.tool_calls?.length ?? 0) > 0,
+      ),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- persist send-time healing before requests by compacting the active log after dropping invalid tool-call tails
- rewrite the active session JSONL after send-time healing so a poisoned session does not come back on the next run
- add a regression test for dangling assistant tool_calls being removed from the request, in-memory log, and persisted session
- sync package-lock renderer optionalDependencies with current package.json so CI npm ci can install cleanly

## Test Plan
- [x] npm ci --dry-run --ignore-scripts
- [x] npm run test -- tests/loop-user-persist.test.ts tests/loop-error.test.ts tests/session.test.ts
- [x] npm run verify

Resubmits the withdrawn #1102 on the latest main base and folds in the lockfile sync to keep this as one PR for #1079 second-batch work.