### PR TITLE
fix(chat): eager rust child spawn for mac (0.44.2-rc.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to Reasonix. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.44.2-rc.2] — 2026-05-17
+
+**Fix:** macOS hang on `npx reasonix@next code` — keep-alive interval
+from rc.1 prevented Node from exiting, but the rust child was never
+actually spawned. Root cause: spawn was triggered by a React
+`useEffect` (`useSceneTrace` → `emitSceneMessage` → `trace.ts`
+`ensureInitialized`), and that effect simply never fired in some
+macOS npx contexts. Node sat alive with the keep-alive holding the
+event loop open, nothing on screen, no rust process.
+
+Fix: spawn rust eagerly in `chat.tsx` via new
+`ensureSceneTraceReady()` export, after `setIntegratedEventHandler` so
+the integrated event callback is wired before spawn. Also:
+- `renderer-process.ts` synthesizes an `exit` event when the rust child
+  dies on its own (panic / SIGKILL / terminal close) so the integrated
+  event handler tears Node down instead of hanging forever.
+- `trace.ts` now logs a clear warning to stderr when `resolveRenderer`
+  returns no usable command, instead of bailing silently — anyone
+  hitting "TUI never appears" can find the cause in
+  `~/.reasonix/rust-render-stderr.log`.
+
 ## [0.44.2-rc.1] — 2026-05-17
 
 **Fix:** macOS `npx reasonix code` (default rust + integrated TUI) exited

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reasonix",
-  "version": "0.44.2-rc.1",
+  "version": "0.44.2-rc.2",
   "description": "DeepSeek-native coding agent: cache-first loop, flash-first cost control, tool-call repair.",
   "type": "module",
   "bin": {
@@ -110,10 +110,10 @@
     "vitest": "^2.1.5"
   },
   "optionalDependencies": {
-    "@reasonix/render-darwin-arm64": "0.44.2-rc.1",
-    "@reasonix/render-darwin-x64": "0.44.2-rc.1",
-    "@reasonix/render-linux-arm64": "0.44.2-rc.1",
-    "@reasonix/render-linux-x64": "0.44.2-rc.1",
-    "@reasonix/render-win32-x64": "0.44.2-rc.1"
+    "@reasonix/render-darwin-arm64": "0.44.2-rc.2",
+    "@reasonix/render-darwin-x64": "0.44.2-rc.2",
+    "@reasonix/render-linux-arm64": "0.44.2-rc.2",
+    "@reasonix/render-linux-x64": "0.44.2-rc.2",
+    "@reasonix/render-win32-x64": "0.44.2-rc.2"
   }
 }

--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -41,7 +41,11 @@ import { makeNullStdin } from "../ui/scene/null-stdin.js";
 import { makeNullStdout } from "../ui/scene/null-stdout.js";
 import { cancelAllPromptInputs, resolvePromptInput } from "../ui/scene/prompt-input-store.js";
 import { resolveRenderer } from "../ui/scene/renderer-resolver.js";
-import { isIntegratedRendererRequested, setIntegratedEventHandler } from "../ui/scene/trace.js";
+import {
+  ensureSceneTraceReady,
+  isIntegratedRendererRequested,
+  setIntegratedEventHandler,
+} from "../ui/scene/trace.js";
 import type { McpServerSummary } from "../ui/slash.js";
 import {
   type McpLifecycleNotice,
@@ -473,6 +477,13 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
       }
       // interrupt: no-op for now; terminal SIGINT already reaches Node.
     });
+    // Eagerly spawn the rust child now that the event handler is set.
+    // Previously we relied on a React useEffect (useSceneTrace →
+    // emitSceneMessage → trace.ts ensureInitialized) to trigger spawn,
+    // but on macOS that effect simply never fired in some npx contexts
+    // — Node held the event loop open (via the keep-alive interval) but
+    // the rust child was never spawned and nothing rendered.
+    ensureSceneTraceReady();
   }
 
   const { waitUntilExit } = render(

--- a/src/cli/ui/scene/renderer-process.ts
+++ b/src/cli/ui/scene/renderer-process.ts
@@ -50,6 +50,18 @@ export function spawnRenderer(opts: SpawnRendererOptions): RendererProcess {
     child.once("exit", (code) => {
       exited = true;
       resolve(code);
+      // Synthesize an exit event for integrated mode so the Node parent
+      // tears down cleanly when the rust child dies on its own (panic,
+      // SIGKILL, terminal close). Without this, Node's keep-alive +
+      // unread event-handler combo would leave the process hanging
+      // forever waiting for a child that's already gone.
+      if (opts.integrated && opts.onEvent) {
+        try {
+          opts.onEvent({ event: "exit" });
+        } catch {
+          // handler errors mustn't block the close pipeline
+        }
+      }
     });
   });
 

--- a/src/cli/ui/scene/trace.ts
+++ b/src/cli/ui/scene/trace.ts
@@ -68,6 +68,11 @@ export async function flushSceneTrace(): Promise<void> {
   }
 }
 
+/** Force the trace child to spawn now — React useEffect in useSceneTrace was unreliable on macOS (sometimes never fired under npx). */
+export function ensureSceneTraceReady(): void {
+  ensureInitialized();
+}
+
 function ensureInitialized(): void {
   if (state.opened) return;
   state.opened = true;
@@ -82,7 +87,15 @@ function ensureInitialized(): void {
   }
   if (process.env[RENDERER_VAR] === "node") return;
   const { command, source } = resolveRenderer();
-  if (source === null || command.length === 0) return;
+  if (source === null || command.length === 0) {
+    // Surface the bail so users hitting "TUI never appears" can grep
+    // the stderr log file for the cause.
+    process.stderr.write(
+      "▲ trace.ts: resolveRenderer() returned no usable command — scene trace stays off. " +
+        "Check optional-dep install (`ls node_modules/@reasonix/render-*`) or set REASONIX_RENDER_BIN.\n",
+    );
+    return;
+  }
   const integrated = process.env[INTEGRATED_VAR] !== "0";
   state.mode = "child";
   state.child = spawnRenderer({

--- a/subpackages/render-darwin-arm64/package.json
+++ b/subpackages/render-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reasonix/render-darwin-arm64",
-  "version": "0.44.2-rc.1",
+  "version": "0.44.2-rc.2",
   "description": "Reasonix ratatui renderer — macOS Apple Silicon (M-series) binary. Installed automatically as an optional dependency of the main `reasonix` package; do not depend on it directly.",
   "license": "MIT",
   "repository": {

--- a/subpackages/render-darwin-x64/package.json
+++ b/subpackages/render-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reasonix/render-darwin-x64",
-  "version": "0.44.2-rc.1",
+  "version": "0.44.2-rc.2",
   "description": "Reasonix ratatui renderer — macOS Intel x64 binary. Installed automatically as an optional dependency of the main `reasonix` package; do not depend on it directly.",
   "license": "MIT",
   "repository": {

--- a/subpackages/render-linux-arm64/package.json
+++ b/subpackages/render-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reasonix/render-linux-arm64",
-  "version": "0.44.2-rc.1",
+  "version": "0.44.2-rc.2",
   "description": "Reasonix ratatui renderer — Linux ARM64 (glibc) binary. Installed automatically as an optional dependency of the main `reasonix` package; do not depend on it directly.",
   "license": "MIT",
   "repository": {

--- a/subpackages/render-linux-x64/package.json
+++ b/subpackages/render-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reasonix/render-linux-x64",
-  "version": "0.44.2-rc.1",
+  "version": "0.44.2-rc.2",
   "description": "Reasonix ratatui renderer — Linux x64 (glibc) binary. Installed automatically as an optional dependency of the main `reasonix` package; do not depend on it directly.",
   "license": "MIT",
   "repository": {

--- a/subpackages/render-win32-x64/package.json
+++ b/subpackages/render-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reasonix/render-win32-x64",
-  "version": "0.44.2-rc.1",
+  "version": "0.44.2-rc.2",
   "description": "Reasonix ratatui renderer — Windows x64 binary. Installed automatically as an optional dependency of the main `reasonix` package; do not depend on it directly.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Why

rc.1's event-loop keep-alive prevented Node from exiting but the rust child was **never actually spawned** on macOS. User report: terminal shows the startup info line then sits forever, no alt-screen switch, `ps -ef | grep reasonix-render` shows nothing, `~/.reasonix/rust-render-stderr.log` is empty.

## Root cause

Spawn was triggered by a React useEffect (`useSceneTrace` → `emitSceneMessage` → `trace.ts` `ensureInitialized` → `spawnRenderer`). On macOS that effect simply never fired in some npx contexts. Node held the event loop open via the keep-alive interval, but the spawn callback chain never ran.

## Fix (three layered)

1. **trace.ts** exports `ensureSceneTraceReady()` — chat.tsx calls it right after `setIntegratedEventHandler` so spawn happens eagerly, before Ink mounts. No more React-effect-timing dependency.
2. **renderer-process.ts** synthesizes `{event:'exit'}` when the rust child dies on its own (panic / SIGKILL / terminal close) so the integrated event handler can tear Node down. Previously Node's keep-alive would hang forever waiting for a dead child.
3. **trace.ts** logs to stderr (redirected to `~/.reasonix/rust-render-stderr.log`) when `resolveRenderer` returns no usable command, instead of bailing silently — anyone hitting 'TUI never appears' can grep the log for the cause.

## Test plan

- [ ] After merge, push v0.44.2-rc.2 → mac user runs `rm -rf ~/.npm/_npx && npx reasonix@next code` and confirms TUI renders.