### PR TITLE
fix(release): surface rust child diagnostic logging (0.44.2-rc.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reasonix",
-  "version": "0.44.2-rc.2",
+  "version": "0.44.2-rc.3",
   "description": "DeepSeek-native coding agent: cache-first loop, flash-first cost control, tool-call repair.",
   "type": "module",
   "bin": {
@@ -110,10 +110,10 @@
     "vitest": "^2.1.5"
   },
   "optionalDependencies": {
-    "@reasonix/render-darwin-arm64": "0.44.2-rc.2",
-    "@reasonix/render-darwin-x64": "0.44.2-rc.2",
-    "@reasonix/render-linux-arm64": "0.44.2-rc.2",
-    "@reasonix/render-linux-x64": "0.44.2-rc.2",
-    "@reasonix/render-win32-x64": "0.44.2-rc.2"
+    "@reasonix/render-darwin-arm64": "0.44.2-rc.3",
+    "@reasonix/render-darwin-x64": "0.44.2-rc.3",
+    "@reasonix/render-linux-arm64": "0.44.2-rc.3",
+    "@reasonix/render-linux-x64": "0.44.2-rc.3",
+    "@reasonix/render-win32-x64": "0.44.2-rc.3"
   }
 }

--- a/src/cli/ui/scene/renderer-process.ts
+++ b/src/cli/ui/scene/renderer-process.ts
@@ -45,17 +45,28 @@ export function spawnRenderer(opts: SpawnRendererOptions): RendererProcess {
     stdio: ["pipe", "inherit", stderrStdio],
   });
 
+  child.on("error", (err) => {
+    process.stderr.write(`[spawnRenderer] child error: ${err.message}\n`);
+  });
+
   let exited = false;
+  let aliveMs = 0;
+  const spawnedAt = Date.now();
   const exitPromise = new Promise<number | null>((resolve) => {
-    child.once("exit", (code) => {
+    child.once("exit", (code, signal) => {
       exited = true;
+      aliveMs = Date.now() - spawnedAt;
+      process.stderr.write(
+        `[spawnRenderer] child exit: code=${code} signal=${signal} aliveMs=${aliveMs}\n`,
+      );
       resolve(code);
-      // Synthesize an exit event for integrated mode so the Node parent
-      // tears down cleanly when the rust child dies on its own (panic,
-      // SIGKILL, terminal close). Without this, Node's keep-alive +
-      // unread event-handler combo would leave the process hanging
-      // forever waiting for a child that's already gone.
-      if (opts.integrated && opts.onEvent) {
+      // Only propagate exit event AFTER the child has been alive long enough
+      // that this is plausibly an "intentional exit" (user pressed Ctrl+D,
+      // /exit slash, etc.). A sub-second death = startup crash; synthesizing
+      // exit there would cascade Node into immediately killing itself and
+      // mask the real error. Let Node stay alive so the user can grep the
+      // stderr log file for what the rust child wrote before dying.
+      if (opts.integrated && opts.onEvent && aliveMs >= 1500) {
         try {
           opts.onEvent({ event: "exit" });
         } catch {
@@ -84,10 +95,15 @@ export function spawnRenderer(opts: SpawnRendererOptions): RendererProcess {
           const parsed = JSON.parse(line) as RustEvent;
           if (parsed && typeof parsed.event === "string") {
             opts.onEvent?.(parsed);
+            continue;
           }
         } catch {
-          // ignore non-JSON stderr lines (panic output, debug, etc.)
+          // not JSON; fall through to log as raw stderr
         }
+        // Surface non-event stderr lines (rust panics, debug prints, anything
+        // crossterm spat out before alt-screen took over). Previously silently
+        // dropped — making "rust child dies immediately" undebuggable.
+        process.stderr.write(`[rust-stderr] ${line}\n`);
       }
     });
   }

--- a/src/cli/ui/scene/trace.ts
+++ b/src/cli/ui/scene/trace.ts
@@ -87,9 +87,8 @@ function ensureInitialized(): void {
   }
   if (process.env[RENDERER_VAR] === "node") return;
   const { command, source } = resolveRenderer();
+  process.stderr.write(`[trace] resolver source=${source} command=${JSON.stringify(command)}\n`);
   if (source === null || command.length === 0) {
-    // Surface the bail so users hitting "TUI never appears" can grep
-    // the stderr log file for the cause.
     process.stderr.write(
       "▲ trace.ts: resolveRenderer() returned no usable command — scene trace stays off. " +
         "Check optional-dep install (`ls node_modules/@reasonix/render-*`) or set REASONIX_RENDER_BIN.\n",
@@ -97,6 +96,7 @@ function ensureInitialized(): void {
     return;
   }
   const integrated = process.env[INTEGRATED_VAR] !== "0";
+  process.stderr.write(`[trace] spawning rust child (integrated=${integrated})\n`);
   state.mode = "child";
   state.child = spawnRenderer({
     command,

--- a/subpackages/render-darwin-arm64/package.json
+++ b/subpackages/render-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reasonix/render-darwin-arm64",
-  "version": "0.44.2-rc.2",
+  "version": "0.44.2-rc.3",
   "description": "Reasonix ratatui renderer — macOS Apple Silicon (M-series) binary. Installed automatically as an optional dependency of the main `reasonix` package; do not depend on it directly.",
   "license": "MIT",
   "repository": {

--- a/subpackages/render-darwin-x64/package.json
+++ b/subpackages/render-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reasonix/render-darwin-x64",
-  "version": "0.44.2-rc.2",
+  "version": "0.44.2-rc.3",
   "description": "Reasonix ratatui renderer — macOS Intel x64 binary. Installed automatically as an optional dependency of the main `reasonix` package; do not depend on it directly.",
   "license": "MIT",
   "repository": {

--- a/subpackages/render-linux-arm64/package.json
+++ b/subpackages/render-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reasonix/render-linux-arm64",
-  "version": "0.44.2-rc.2",
+  "version": "0.44.2-rc.3",
   "description": "Reasonix ratatui renderer — Linux ARM64 (glibc) binary. Installed automatically as an optional dependency of the main `reasonix` package; do not depend on it directly.",
   "license": "MIT",
   "repository": {

--- a/subpackages/render-linux-x64/package.json
+++ b/subpackages/render-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reasonix/render-linux-x64",
-  "version": "0.44.2-rc.2",
+  "version": "0.44.2-rc.3",
   "description": "Reasonix ratatui renderer — Linux x64 (glibc) binary. Installed automatically as an optional dependency of the main `reasonix` package; do not depend on it directly.",
   "license": "MIT",
   "repository": {

--- a/subpackages/render-win32-x64/package.json
+++ b/subpackages/render-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reasonix/render-win32-x64",
-  "version": "0.44.2-rc.2",
+  "version": "0.44.2-rc.3",
   "description": "Reasonix ratatui renderer — Windows x64 binary. Installed automatically as an optional dependency of the main `reasonix` package; do not depend on it directly.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
rc.2 made mac flip from 'hang' to 'exit immediately', but stderr log still empty — no signal on what killed rust. Three diagnostics so rc.3 lands actionable info:

1. `trace.ts` emits `[trace] resolver source=... command=...` + spawn-start line
2. `renderer-process.ts` logs `[spawnRenderer] child exit code/signal/aliveMs`
3. `renderer-process.ts` logs non-JSON child stderr (rust panics / crossterm errors) as `[rust-stderr] ...` — previously silently dropped, exactly the path that hid rc.1/rc.2 cause

Also: don't synthesize an 'exit' event when child dies within 1.5s of spawn. Sub-second death = startup crash; cascading Node into process.exit hides the real error.

## Test plan
- [ ] Mac user runs rc.3 → `cat ~/.reasonix/rust-render-stderr.log` should show concrete signal