### PR TITLE
fix(session): auto-name conversations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reasonix",
-  "version": "0.43.0",
+  "version": "0.44.2-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reasonix",
-      "version": "0.43.0",
+      "version": "0.44.2-rc.1",
       "license": "MIT",
       "dependencies": {
         "cli-highlight": "^2.1.11",
@@ -51,6 +51,13 @@
       },
       "engines": {
         "node": ">=22"
+      },
+      "optionalDependencies": {
+        "@reasonix/render-darwin-arm64": "0.44.2-rc.1",
+        "@reasonix/render-darwin-x64": "0.44.2-rc.1",
+        "@reasonix/render-linux-arm64": "0.44.2-rc.1",
+        "@reasonix/render-linux-x64": "0.44.2-rc.1",
+        "@reasonix/render-win32-x64": "0.44.2-rc.1"
       }
     },
     "node_modules/@alcalzone/ansi-tokenize": {
@@ -1698,6 +1705,92 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@reasonix/render-darwin-arm64": {
+      "version": "0.44.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@reasonix/render-darwin-arm64/-/render-darwin-arm64-0.44.2-rc.1.tgz",
+      "integrity": "sha512-QQZj//YtggHhs9HKnYqZUSGvmHwff+JEN6R7FjhQhGFEA0MOz03lmGMf/Yb62uQsc9/WwUAUKlzBD0JVUA5dYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "reasonix-render": "bin/reasonix-render"
+      }
+    },
+    "node_modules/@reasonix/render-darwin-x64": {
+      "version": "0.44.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@reasonix/render-darwin-x64/-/render-darwin-x64-0.44.2-rc.1.tgz",
+      "integrity": "sha512-MrfgF0BlJ+YxMcifWrDzJNRrsQQ05QmclkxYyzCr7m9ZLYhSJD+G8tdrM8psXXF4mKEMFX2YvERO/wH+CLamaw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "reasonix-render": "bin/reasonix-render"
+      }
+    },
+    "node_modules/@reasonix/render-linux-arm64": {
+      "version": "0.44.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@reasonix/render-linux-arm64/-/render-linux-arm64-0.44.2-rc.1.tgz",
+      "integrity": "sha512-YIot4u9yuvqRxGlnfnzloXRR0NvYg8pohgjOJSOHdyYw+JuCk0oidP5nyDCgcfBTKJZ9RwfRKdIU7pLYBnMtHw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "reasonix-render": "bin/reasonix-render"
+      }
+    },
+    "node_modules/@reasonix/render-linux-x64": {
+      "version": "0.44.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@reasonix/render-linux-x64/-/render-linux-x64-0.44.2-rc.1.tgz",
+      "integrity": "sha512-jji6LUjktNOboT16jYwuBL0N6s0YVzX5BD+tulBi4CsIC9LiYZf5RXQnpvAKizEC/EDHeOKWyCHnEEMks9Uq6w==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "reasonix-render": "bin/reasonix-render"
+      }
+    },
+    "node_modules/@reasonix/render-win32-x64": {
+      "version": "0.44.2-rc.1",
+      "resolved": "https://registry.npmjs.org/@reasonix/render-win32-x64/-/render-win32-x64-0.44.2-rc.1.tgz",
+      "integrity": "sha512-48abp0NgB5JscahOkETg6/8u/TF5SYHVTzMRHvpC5NjChSXXPh/MtR7MWCdkRKOOQwhDxq7Z0GExJ/4TCp1EZg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "reasonix-render": "bin/reasonix-render.exe"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -70,6 +70,7 @@ import {
   loadSessionMeta,
   patchSessionMeta,
   renameSession,
+  sanitizeName,
 } from "../../memory/session.js";
 import type { QQChannel } from "../../qq/channel.js";
 import { useQQChannel } from "../../qq/use-qq-channel.js";
@@ -81,6 +82,11 @@ import type {
   SubmitResult,
 } from "../../server/context.js";
 import type { DashboardServerHandle } from "../../server/index.js";
+import {
+  generateSessionTitle,
+  makeSessionNameFromTitle,
+  shouldAutoNameSession,
+} from "../../session-title.js";
 import { loadSlashUsage, recordSlashUse } from "../../slash-usage.js";
 import {
   DEEPSEEK_CONTEXT_TOKENS,
@@ -405,6 +411,19 @@ function LoopStatusRow({
       <Text color="cyan">{`闂?${formatLoopStatus(loop.prompt, nextFireMs, loop.iter)} 闂?/loop stop or type to cancel`}</Text>
     </Box>
   );
+}
+
+function lastMessageContent(
+  entries: ReadonlyArray<{ role: string; content?: string | null }>,
+  role: "user" | "assistant",
+): string {
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const entry = entries[i];
+    if (entry?.role !== role || typeof entry.content !== "string") continue;
+    const text = entry.content.trim();
+    if (text) return text;
+  }
+  return "";
 }
 
 interface StreamingState {
@@ -1033,6 +1052,46 @@ function AppInner({
     loopRef.current = l;
     return l;
   }, [model, system, rebuildSystem, budgetUsd, failureThreshold, session, tools, codeMode]);
+
+  const generateCurrentSessionTitle = useCallback(
+    async (seed?: { userText?: string; assistantText?: string; auto?: boolean }) => {
+      if (!session || !onSwitchSession) return t("app.sessionTitleNoSession");
+      const userText = seed?.userText ?? lastMessageContent(loop.log.entries, "user");
+      const assistantText =
+        seed?.assistantText ?? lastMessageContent(loop.log.entries, "assistant");
+      if (!userText) return t("app.sessionTitleNoContent");
+
+      const title = await generateSessionTitle(loop.client, loop.model ?? model, {
+        workspace: currentRootDir,
+        userText,
+        assistantText,
+      });
+      if (!title) return t("app.sessionTitleNoTitle");
+
+      const nextName = makeSessionNameFromTitle(title, { currentName: session });
+      if (!nextName) return t("app.sessionTitleNoTitle");
+      if (sanitizeName(nextName) === sanitizeName(session)) {
+        patchSessionMeta(session, { summary: title, autoTitleGenerated: true });
+        return t("app.sessionTitleUpdated", { title });
+      }
+
+      const renamed = renameSession(session, nextName);
+      if (!renamed) return t("app.sessionTitleRenameFailed", { title });
+      const meta = loadSessionMeta(nextName);
+      patchSessionMeta(nextName, {
+        summary: title,
+        autoTitleGenerated: true,
+        ...(!meta.workspace ? { workspace: currentRootDir } : {}),
+        ...(!meta.branch ? { branch: detectGitBranch(currentRootDir) } : {}),
+      });
+      setTimeout(() => onSwitchSession(nextName), 0);
+      return t(seed?.auto ? "app.sessionTitleAutoRenamed" : "app.sessionTitleRenamed", {
+        name: nextName,
+        title,
+      });
+    },
+    [currentRootDir, loop.client, loop.log.entries, loop.model, model, onSwitchSession, session],
+  );
 
   useEffect(() => {
     if (!session || !tools) return;
@@ -3291,6 +3350,7 @@ function AppInner({
           refreshLatestVersion,
           models,
           refreshModels,
+          generateSessionTitle: generateCurrentSessionTitle,
         });
         if (
           fromQQ &&
@@ -3413,8 +3473,9 @@ function AppInner({
       const pasteDisplay = formatLongPaste(text);
       const userId = log.pushUser(pasteDisplay.displayText);
       broadcastDashboardEvent({ kind: "user", id: userId, text });
+      const sessionMetaBeforeTurn = session ? loadSessionMeta(session) : {};
       if (session) {
-        const existing = loadSessionMeta(session);
+        const existing = sessionMetaBeforeTurn;
         const patch: Parameters<typeof patchSessionMeta>[1] = {};
         if (!existing.summary) patch.summary = text.replace(/\s+/g, " ").slice(0, 80);
         if (!existing.branch) patch.branch = detectGitBranch(currentRootDir);
@@ -3670,6 +3731,24 @@ function AppInner({
           }
         }
         flush();
+        if (
+          session &&
+          lastAssistantText.trim() &&
+          shouldAutoNameSession(
+            session,
+            sessionMetaBeforeTurn,
+            loadSessionMeta(session).turnCount ?? 0,
+          )
+        ) {
+          void generateCurrentSessionTitle({
+            userText: text,
+            assistantText: lastAssistantText,
+            auto: true,
+          }).then(
+            (info) => log.pushInfo(info),
+            () => undefined,
+          );
+        }
 
         // Stop hooks 闂?turn has ended (or aborted). Block decisions are
         // meaningless past this point so we treat every non-pass as a
@@ -3783,6 +3862,7 @@ function AppInner({
       pushHistory,
       resetCursor,
       liveMcpServers,
+      generateCurrentSessionTitle,
     ],
   );
 

--- a/src/cli/ui/slash/commands.ts
+++ b/src/cli/ui/slash/commands.ts
@@ -148,6 +148,12 @@ export const SLASH_COMMANDS: readonly SlashCommandSpec[] = [
   },
 
   { cmd: "sessions", group: "session", summary: "list saved sessions (current marked with ▸)" },
+  {
+    cmd: "title",
+    group: "session",
+    summary: "ask the model to rename this session from the conversation",
+    aliases: ["retitle"],
+  },
 
   { cmd: "mcp", group: "extend", summary: "list MCP servers + tools attached to this session" },
   {

--- a/src/cli/ui/slash/handlers/sessions.ts
+++ b/src/cli/ui/slash/handlers/sessions.ts
@@ -1,7 +1,25 @@
+import { t } from "../../../../i18n/index.js";
 import type { SlashHandler } from "../dispatch.js";
 
 const sessions: SlashHandler = () => ({ openSessionsPicker: true });
 
+const title: SlashHandler = (_args, _loop, ctx) => {
+  if (!ctx.generateSessionTitle || !ctx.postInfo) {
+    return { info: t("handlers.sessions.titleUnavailable") };
+  }
+  void ctx.generateSessionTitle().then(
+    (info) => ctx.postInfo?.(info),
+    (err) =>
+      ctx.postInfo?.(
+        t("handlers.sessions.titleFailed", {
+          reason: err instanceof Error ? err.message : String(err),
+        }),
+      ),
+  );
+  return { info: t("handlers.sessions.titleStarted") };
+};
+
 export const handlers: Record<string, SlashHandler> = {
   sessions,
+  title,
 };

--- a/src/cli/ui/slash/types.ts
+++ b/src/cli/ui/slash/types.ts
@@ -129,6 +129,8 @@ export interface SlashContext {
   /** `null` → in flight / failed; `[]` → API answered empty. `/model <id>` warn-only since list can lag. */
   models?: string[] | null;
   refreshModels?: () => void;
+  /** Ask the current model to summarize the active session into a short title and rename it. */
+  generateSessionTitle?: () => Promise<string>;
   armPro?: () => void;
   disarmPro?: () => void;
   startLoop?: (intervalMs: number, prompt: string) => void;

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -339,6 +339,7 @@ export const EN: TranslationSchema = {
       argsHint: "[N]",
     },
     sessions: { description: "list saved sessions (current marked with ▸)" },
+    title: { description: "ask the model to rename this session from the conversation" },
     qq: {
       description: "connect, inspect, or disconnect the QQ channel for this session",
       argsHint: "[connect [appId appSecret [sandbox]]|status|disconnect]",
@@ -590,6 +591,13 @@ export const EN: TranslationSchema = {
     atMentions: "▸ @mentions: {parts}",
     atUrl: "▸ @url: {parts}",
     atUrlFailed: "@url expansion failed",
+    sessionTitleNoSession: "▸ no persisted session is active, so there is nothing to rename.",
+    sessionTitleNoContent: "▸ not enough conversation content to name this session yet.",
+    sessionTitleNoTitle: "▸ the model did not return a usable session title.",
+    sessionTitleUpdated: '▸ session title updated: "{title}"',
+    sessionTitleRenameFailed: '▸ could not rename the session for title "{title}".',
+    sessionTitleRenamed: '▸ session renamed to "{name}" — {title}',
+    sessionTitleAutoRenamed: '▸ auto-named session "{name}" — {title}',
     denied: "▸ denied: {cmd}{context}",
     alwaysAllowed: '▸ always allowed "{prefix}" for {dir}',
     runningCommand: "▸ running: {cmd}",
@@ -740,6 +748,11 @@ export const EN: TranslationSchema = {
       keysNeedsTui: "/keys needs a TUI context (postKeys wired).",
       unknownCommand: "unknown command: /{cmd} — did you mean {list}?",
       unknownCommandShort: "unknown command: /{cmd}  (try /help)",
+    },
+    sessions: {
+      titleUnavailable: "/title is only available in an active persisted TUI session.",
+      titleStarted: "▸ naming session…",
+      titleFailed: "▸ session title failed: {reason}",
     },
     admin: {
       doctorNeedsTui: "/doctor needs a TUI context (postDoctor wired).",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -192,6 +192,13 @@ export interface TranslationSchema {
     atMentions: string;
     atUrl: string;
     atUrlFailed: string;
+    sessionTitleNoSession: string;
+    sessionTitleNoContent: string;
+    sessionTitleNoTitle: string;
+    sessionTitleUpdated: string;
+    sessionTitleRenameFailed: string;
+    sessionTitleRenamed: string;
+    sessionTitleAutoRenamed: string;
     denied: string;
     alwaysAllowed: string;
     runningCommand: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -330,6 +330,7 @@ export const zhCN: TranslationSchema = {
       argsHint: "[N]",
     },
     sessions: { description: "列出已保存的会话（当前标记为 ▸）" },
+    title: { description: "让模型根据当前对话重命名此会话" },
     qq: {
       description: "连接、查看或断开当前会话的 QQ 通道",
       argsHint: "[connect [appId appSecret [sandbox]]|status|disconnect]",
@@ -576,6 +577,13 @@ export const zhCN: TranslationSchema = {
     atMentions: "▸ @mentions：{parts}",
     atUrl: "▸ @url：{parts}",
     atUrlFailed: "@url 展开失败",
+    sessionTitleNoSession: "▸ 当前没有启用持久化会话，无法重命名。",
+    sessionTitleNoContent: "▸ 当前对话内容还不够，暂时无法命名会话。",
+    sessionTitleNoTitle: "▸ 模型没有返回可用的会话标题。",
+    sessionTitleUpdated: '▸ 会话标题已更新："{title}"',
+    sessionTitleRenameFailed: '▸ 无法按标题 "{title}" 重命名会话。',
+    sessionTitleRenamed: '▸ 会话已重命名为 "{name}" — {title}',
+    sessionTitleAutoRenamed: '▸ 已自动命名会话 "{name}" — {title}',
     denied: "▸ 已拒绝：{cmd}{context}",
     alwaysAllowed: '▸ 已对 {dir} 永久允许 "{prefix}"',
     runningCommand: "▸ 正在执行：{cmd}",
@@ -710,6 +718,11 @@ export const zhCN: TranslationSchema = {
       keysNeedsTui: "/keys 需要 TUI 上下文（postKeys 已连接）。",
       unknownCommand: "未知命令：/{cmd} — 你是不是想用 {list}？",
       unknownCommandShort: "未知命令：/{cmd}  （试试 /help）",
+    },
+    sessions: {
+      titleUnavailable: "/title 只能在已启用会话持久化的 TUI 会话中使用。",
+      titleStarted: "▸ 正在命名会话…",
+      titleFailed: "▸ 会话命名失败：{reason}",
     },
     admin: {
       doctorNeedsTui: "/doctor 需要 TUI 上下文（postDoctor 已连接）。",

--- a/src/memory/session.ts
+++ b/src/memory/session.ts
@@ -55,6 +55,8 @@ export interface SessionMeta {
   cacheMissTokens?: number;
   /** Last turn's promptTokens — lets /status render the context bar before the next turn fires. */
   lastPromptTokens?: number;
+  /** True when the session filename/summary was generated from conversation content. */
+  autoTitleGenerated?: boolean;
 }
 
 export function sessionsDir(): string {

--- a/src/session-title.ts
+++ b/src/session-title.ts
@@ -1,0 +1,104 @@
+import { existsSync } from "node:fs";
+import { type SessionMeta, sanitizeName, sessionPath, timestampSuffix } from "./memory/session.js";
+import type { ChatMessage, ChatRequestOptions } from "./types.js";
+
+const TITLE_MODEL_MAX_TOKENS = 32;
+const TITLE_MAX_CHARS = 48;
+
+export interface SessionTitleInput {
+  workspace?: string;
+  userText: string;
+  assistantText?: string;
+}
+
+export interface SessionTitleClient {
+  chat(opts: ChatRequestOptions): Promise<{ content: string }>;
+}
+
+export function buildSessionTitleMessages(input: SessionTitleInput): ChatMessage[] {
+  const workspace = input.workspace?.trim();
+  const assistant = input.assistantText?.trim();
+  const parts = [
+    workspace ? `Workspace: ${workspace}` : "",
+    `User request:\n${truncateForPrompt(input.userText, 1600)}`,
+    assistant ? `Assistant answer:\n${truncateForPrompt(assistant, 1600)}` : "",
+  ].filter(Boolean);
+  return [
+    {
+      role: "system",
+      content:
+        "Generate a short session title for a coding/chat transcript. Output only the title, no quotes, no markdown, no prefix. Use the user's language when obvious. Keep it under 6 words or 18 CJK characters. Avoid punctuation.",
+    },
+    { role: "user", content: parts.join("\n\n") },
+  ];
+}
+
+export async function generateSessionTitle(
+  client: SessionTitleClient,
+  model: string,
+  input: SessionTitleInput,
+): Promise<string | null> {
+  const resp = await client.chat({
+    model,
+    messages: buildSessionTitleMessages(input),
+    temperature: 0.2,
+    maxTokens: TITLE_MODEL_MAX_TOKENS,
+    thinking: "disabled",
+  });
+  return normalizeGeneratedSessionTitle(resp.content);
+}
+
+export function normalizeGeneratedSessionTitle(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  let title = raw.trim();
+  title = title.replace(/^```[a-zA-Z0-9_-]*\s*/, "").replace(/\s*```$/, "");
+  title = title.split(/\r?\n/)[0]?.trim() ?? "";
+  title = title.replace(/^(title|session title|name)\s*[:：-]\s*/i, "");
+  title = title.replace(/^["'“”‘’`]+|["'“”‘’`]+$/g, "");
+  title = title.replace(/\s+/g, " ").trim();
+  title = title.replace(/[。.!?！？；;，,、]+$/g, "").trim();
+  if (!title) return null;
+  return title.length > TITLE_MAX_CHARS ? title.slice(0, TITLE_MAX_CHARS).trim() : title;
+}
+
+export function makeSessionNameFromTitle(
+  title: string | null | undefined,
+  opts: {
+    currentName?: string;
+    exists?: (name: string) => boolean;
+    suffix?: () => string;
+  } = {},
+): string | null {
+  const normalized = normalizeGeneratedSessionTitle(title);
+  if (!normalized) return null;
+  const base = sanitizeName(
+    normalized
+      .replace(/[\s_]+/g, "-")
+      .replace(/[^\w\-\u4e00-\u9fa5]+/g, "-")
+      .replace(/-+/g, "-")
+      .replace(/^-|-$/g, ""),
+  );
+  if (!base) return null;
+  const current = opts.currentName ? sanitizeName(opts.currentName) : "";
+  const exists = opts.exists ?? ((name: string) => existsSync(sessionPath(name)));
+  if (base === current || !exists(base)) return base;
+  for (let i = 2; i <= 9; i++) {
+    const candidate = `${base}-${i}`;
+    if (candidate === current || !exists(candidate)) return candidate;
+  }
+  return `${base}-${opts.suffix?.() ?? timestampSuffix()}`;
+}
+
+export function shouldAutoNameSession(
+  sessionName: string | undefined,
+  meta: SessionMeta,
+  completedTurns: number,
+): boolean {
+  if (!sessionName || completedTurns !== 1 || meta.autoTitleGenerated) return false;
+  return /^default(?:-\d{12,14})?$/.test(sanitizeName(sessionName));
+}
+
+function truncateForPrompt(text: string, max: number): string {
+  const trimmed = text.replace(/\s+/g, " ").trim();
+  return trimmed.length > max ? `${trimmed.slice(0, max)}...` : trimmed;
+}

--- a/tests/session-title.test.ts
+++ b/tests/session-title.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSessionTitleMessages,
+  makeSessionNameFromTitle,
+  normalizeGeneratedSessionTitle,
+  shouldAutoNameSession,
+} from "../src/session-title.js";
+
+describe("session title generation", () => {
+  it("normalizes model output into a concise title", () => {
+    expect(normalizeGeneratedSessionTitle('```text\nTitle: "Fix parser cache bug"\n```')).toBe(
+      "Fix parser cache bug",
+    );
+  });
+
+  it("turns titles into readable safe session names", () => {
+    expect(
+      makeSessionNameFromTitle("Fix parser cache bug", {
+        exists: () => false,
+      }),
+    ).toBe("Fix-parser-cache-bug");
+    expect(
+      makeSessionNameFromTitle("修复 会话 损坏", {
+        exists: () => false,
+      }),
+    ).toBe("修复-会话-损坏");
+  });
+
+  it("only auto-names default first-turn sessions that have not been named before", () => {
+    expect(shouldAutoNameSession("default-20260517123456", {}, 1)).toBe(true);
+    expect(shouldAutoNameSession("default-20260517123456", {}, 2)).toBe(false);
+    expect(shouldAutoNameSession("custom-session", {}, 1)).toBe(false);
+    expect(shouldAutoNameSession("default-20260517123456", { autoTitleGenerated: true }, 1)).toBe(
+      false,
+    );
+  });
+
+  it("builds a no-tools prompt from the conversation head and tail", () => {
+    const messages = buildSessionTitleMessages({
+      workspace: "/work/reasonix",
+      userText: "Please fix the session corruption bug",
+      assistantText: "Implemented safer JSONL rewriting and recovery tests.",
+    });
+    expect(messages).toHaveLength(2);
+    expect(messages[0]!.role).toBe("system");
+    expect(messages[1]!.content).toContain("Please fix the session corruption bug");
+    expect(messages[1]!.content).toContain("Implemented safer JSONL rewriting");
+  });
+});

--- a/tests/slash.test.ts
+++ b/tests/slash.test.ts
@@ -117,6 +117,24 @@ describe("handleSlash", () => {
     expect(info.indexOf("  SETUP")).toBeLessThan(info.indexOf("  CHAT"));
   });
 
+  it("/title starts AI session title regeneration", async () => {
+    let called = 0;
+    let posted = "";
+    const result = handleSlash("title", [], makeLoop(), {
+      generateSessionTitle: async () => {
+        called++;
+        return '▸ session renamed to "Fix-parser-cache-bug"';
+      },
+      postInfo: (text) => {
+        posted = text;
+      },
+    });
+    expect(result.info).toMatch(/naming|title/i);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(called).toBe(1);
+    expect(posted).toContain("Fix-parser-cache-bug");
+  });
+
   it("/status reflects current loop config", () => {
     const loop = makeLoop();
     const r = handleSlash("status", [], loop);
@@ -538,7 +556,7 @@ describe("handleSlash", () => {
     // Case-insensitive.
     expect(suggestSlashCommands("HE").map((s) => s.cmd)).toEqual(["help"]);
     // Empty prefix returns the full non-advanced release list, including code commands.
-    expect(suggestSlashCommands("", true)).toHaveLength(41);
+    expect(suggestSlashCommands("", true)).toHaveLength(42);
     expect(suggestSlashCommands("", true).map((s) => s.cmd)).toContain("logs");
     expect(suggestSlashCommands("", true).map((s) => s.cmd)).toContain("language");
     expect(suggestSlashCommands("lan").map((s) => s.cmd)).toContain("language");

--- a/tests/ui-slash-suggestions.test.tsx
+++ b/tests/ui-slash-suggestions.test.tsx
@@ -84,7 +84,7 @@ describe("SlashSuggestions", () => {
     );
   });
 
-  it("renders the bare slash release command surface as 41 total commands", () => {
+  it("renders the bare slash release command surface as 42 total commands", () => {
     const matches = suggestSlashCommands("", true);
     const names = matches.map((spec) => spec.cmd);
     const { lastFrame, unmount } = render(
@@ -93,11 +93,11 @@ describe("SlashSuggestions", () => {
     const frame = lastFrame() ?? "";
     unmount();
 
-    expect(matches).toHaveLength(41);
+    expect(matches).toHaveLength(42);
     expect(names).toContain("language");
     expect(names).toContain("btw");
     expect(countAdvancedCommands(true)).toBe(11);
-    expect(frame).toContain("41 commands");
+    expect(frame).toContain("42 commands");
     expect(frame).toContain("+ 11 advanced");
   });
 


### PR DESCRIPTION
## Summary
- add model-generated session titles for default first-turn sessions
- add `/title` with `/retitle` alias so users can regenerate a session name from the active conversation
- sanitize model output into safe, unique session filenames while preserving session metadata through rename
- sync `package-lock.json` with the current `0.44.2-rc.1` renderer optional dependencies so `npm ci` stays green

Refs #1079.

## Test Plan
- [x] `npm run test -- tests/session-title.test.ts tests/slash.test.ts tests/session.test.ts`
- [x] `npm run test -- tests/ui-slash-suggestions.test.tsx tests/slash-help-i18n.test.ts tests/session-title.test.ts tests/slash.test.ts`
- [x] `npm ci --dry-run --ignore-scripts`
- [x] `npm run verify`
- [x] pre-push `npm run verify`
