### PR TITLE
fix(scene): seed empty trace frame on rust child spawn (0.44.2-rc.4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reasonix",
-  "version": "0.44.2-rc.3",
+  "version": "0.44.2-rc.4",
   "description": "DeepSeek-native coding agent: cache-first loop, flash-first cost control, tool-call repair.",
   "type": "module",
   "bin": {
@@ -110,10 +110,10 @@
     "vitest": "^2.1.5"
   },
   "optionalDependencies": {
-    "@reasonix/render-darwin-arm64": "0.44.2-rc.3",
-    "@reasonix/render-darwin-x64": "0.44.2-rc.3",
-    "@reasonix/render-linux-arm64": "0.44.2-rc.3",
-    "@reasonix/render-linux-x64": "0.44.2-rc.3",
-    "@reasonix/render-win32-x64": "0.44.2-rc.3"
+    "@reasonix/render-darwin-arm64": "0.44.2-rc.4",
+    "@reasonix/render-darwin-x64": "0.44.2-rc.4",
+    "@reasonix/render-linux-arm64": "0.44.2-rc.4",
+    "@reasonix/render-linux-x64": "0.44.2-rc.4",
+    "@reasonix/render-win32-x64": "0.44.2-rc.4"
   }
 }

--- a/src/cli/ui/scene/trace.ts
+++ b/src/cli/ui/scene/trace.ts
@@ -71,6 +71,14 @@ export async function flushSceneTrace(): Promise<void> {
 /** Force the trace child to spawn now — React useEffect in useSceneTrace was unreliable on macOS (sometimes never fired under npx). */
 export function ensureSceneTraceReady(): void {
   ensureInitialized();
+  // Seed an empty trace frame so the rust integrated loop has `have_state=true`
+  // immediately — without this, if the stdin pipe closes before the first
+  // useSceneTrace effect fires (Ink unmount cascade on macOS), rust hits its
+  // `if stdin_closed && !have_state { return Ok(()) }` early-exit at ~100ms.
+  if (state.mode === "child" && state.child) {
+    state.child.emit({ type: "trace" });
+    process.stderr.write("[trace] seed frame written\n");
+  }
 }
 
 function ensureInitialized(): void {

--- a/subpackages/render-darwin-arm64/package.json
+++ b/subpackages/render-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reasonix/render-darwin-arm64",
-  "version": "0.44.2-rc.3",
+  "version": "0.44.2-rc.4",
   "description": "Reasonix ratatui renderer — macOS Apple Silicon (M-series) binary. Installed automatically as an optional dependency of the main `reasonix` package; do not depend on it directly.",
   "license": "MIT",
   "repository": {

--- a/subpackages/render-darwin-x64/package.json
+++ b/subpackages/render-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reasonix/render-darwin-x64",
-  "version": "0.44.2-rc.3",
+  "version": "0.44.2-rc.4",
   "description": "Reasonix ratatui renderer — macOS Intel x64 binary. Installed automatically as an optional dependency of the main `reasonix` package; do not depend on it directly.",
   "license": "MIT",
   "repository": {

--- a/subpackages/render-linux-arm64/package.json
+++ b/subpackages/render-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reasonix/render-linux-arm64",
-  "version": "0.44.2-rc.3",
+  "version": "0.44.2-rc.4",
   "description": "Reasonix ratatui renderer — Linux ARM64 (glibc) binary. Installed automatically as an optional dependency of the main `reasonix` package; do not depend on it directly.",
   "license": "MIT",
   "repository": {

--- a/subpackages/render-linux-x64/package.json
+++ b/subpackages/render-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reasonix/render-linux-x64",
-  "version": "0.44.2-rc.3",
+  "version": "0.44.2-rc.4",
   "description": "Reasonix ratatui renderer — Linux x64 (glibc) binary. Installed automatically as an optional dependency of the main `reasonix` package; do not depend on it directly.",
   "license": "MIT",
   "repository": {

--- a/subpackages/render-win32-x64/package.json
+++ b/subpackages/render-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reasonix/render-win32-x64",
-  "version": "0.44.2-rc.3",
+  "version": "0.44.2-rc.4",
   "description": "Reasonix ratatui renderer — Windows x64 binary. Installed automatically as an optional dependency of the main `reasonix` package; do not depend on it directly.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
rc.3 diagnostics pinned it: rust exits in 118ms via `if stdin_closed && !have_state { return Ok(()) }` because Node never wrote any scene state before Ink's null-stdio cascade closed the pipe.

Seed an empty trace frame in `ensureSceneTraceReady` right after spawn so `have_state=true` from t=0. The early-exit no longer fires; rust keeps drawing on inherited stdout even if Node's pipe later closes.

## Test plan
- [ ] Mac rc.4: rust should now stay alive, alt-screen switch, TUI visible