### PR TITLE
chore(release): 0.45.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reasonix",
-  "version": "0.45.0-rc.0",
+  "version": "0.45.0",
   "description": "DeepSeek-native coding agent: cache-first loop, flash-first cost control, tool-call repair.",
   "type": "module",
   "bin": {
@@ -110,10 +110,10 @@
     "vitest": "^2.1.5"
   },
   "optionalDependencies": {
-    "@reasonix/render-darwin-arm64": "0.45.0-rc.0",
-    "@reasonix/render-darwin-x64": "0.45.0-rc.0",
-    "@reasonix/render-linux-arm64": "0.45.0-rc.0",
-    "@reasonix/render-linux-x64": "0.45.0-rc.0",
-    "@reasonix/render-win32-x64": "0.45.0-rc.0"
+    "@reasonix/render-darwin-arm64": "0.45.0",
+    "@reasonix/render-darwin-x64": "0.45.0",
+    "@reasonix/render-linux-arm64": "0.45.0",
+    "@reasonix/render-linux-x64": "0.45.0",
+    "@reasonix/render-win32-x64": "0.45.0"
   }
 }

--- a/subpackages/render-darwin-arm64/package.json
+++ b/subpackages/render-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reasonix/render-darwin-arm64",
-  "version": "0.45.0-rc.0",
+  "version": "0.45.0",
   "description": "Reasonix ratatui renderer — macOS Apple Silicon native Node addon. Installed automatically as an optional dependency of the main `reasonix` package; do not depend on it directly.",
   "license": "MIT",
   "repository": {

--- a/subpackages/render-darwin-x64/package.json
+++ b/subpackages/render-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reasonix/render-darwin-x64",
-  "version": "0.45.0-rc.0",
+  "version": "0.45.0",
   "description": "Reasonix ratatui renderer — macOS Intel x64 native Node addon. Installed automatically as an optional dependency of the main `reasonix` package; do not depend on it directly.",
   "license": "MIT",
   "repository": {

--- a/subpackages/render-linux-arm64/package.json
+++ b/subpackages/render-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reasonix/render-linux-arm64",
-  "version": "0.45.0-rc.0",
+  "version": "0.45.0",
   "description": "Reasonix ratatui renderer — Linux ARM64 (glibc) native Node addon. Installed automatically as an optional dependency of the main `reasonix` package; do not depend on it directly.",
   "license": "MIT",
   "repository": {

--- a/subpackages/render-linux-x64/package.json
+++ b/subpackages/render-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reasonix/render-linux-x64",
-  "version": "0.45.0-rc.0",
+  "version": "0.45.0",
   "description": "Reasonix ratatui renderer — Linux x64 (glibc) native Node addon. Installed automatically as an optional dependency of the main `reasonix` package; do not depend on it directly.",
   "license": "MIT",
   "repository": {

--- a/subpackages/render-win32-x64/package.json
+++ b/subpackages/render-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reasonix/render-win32-x64",
-  "version": "0.45.0-rc.0",
+  "version": "0.45.0",
   "description": "Reasonix ratatui renderer — Windows x64 native Node addon. Installed automatically as an optional dependency of the main `reasonix` package; do not depend on it directly.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Promote the NAPI renderer to stable.

- Main package: \`0.45.0-rc.0\` → \`0.45.0\`
- All five \`@reasonix/render-<platform>-<arch>\` subpackages synced to \`0.45.0\`
- npm dist-tag will resolve to \`latest\` (currently \`0.43.0\`)
- Same tag triggers Tauri desktop bundles via release.yml

## Verified on rc.0
- Windows 11 + Windows Terminal: chat renders end-to-end, IME composition stable, exit clean
- macOS arm64: chat renders end-to-end, exit clean
- npm install of the optional-dep @reasonix/render-*@0.45.0-rc.0 resolves correctly per platform