### PR TITLE
chore(lockfile): sync package-lock.json to 0.45.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reasonix",
-  "version": "0.44.2-rc.1",
+  "version": "0.45.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reasonix",
-      "version": "0.44.2-rc.1",
+      "version": "0.45.0",
       "license": "MIT",
       "dependencies": {
         "cli-highlight": "^2.1.11",
@@ -53,11 +53,11 @@
         "node": ">=22"
       },
       "optionalDependencies": {
-        "@reasonix/render-darwin-arm64": "0.44.2-rc.1",
-        "@reasonix/render-darwin-x64": "0.44.2-rc.1",
-        "@reasonix/render-linux-arm64": "0.44.2-rc.1",
-        "@reasonix/render-linux-x64": "0.44.2-rc.1",
-        "@reasonix/render-win32-x64": "0.44.2-rc.1"
+        "@reasonix/render-darwin-arm64": "0.45.0",
+        "@reasonix/render-darwin-x64": "0.45.0",
+        "@reasonix/render-linux-arm64": "0.45.0",
+        "@reasonix/render-linux-x64": "0.45.0",
+        "@reasonix/render-win32-x64": "0.45.0"
       }
     },
     "node_modules/@alcalzone/ansi-tokenize": {
@@ -1708,9 +1708,9 @@
       }
     },
     "node_modules/@reasonix/render-darwin-arm64": {
-      "version": "0.44.2-rc.1",
-      "resolved": "https://registry.npmjs.org/@reasonix/render-darwin-arm64/-/render-darwin-arm64-0.44.2-rc.1.tgz",
-      "integrity": "sha512-QQZj//YtggHhs9HKnYqZUSGvmHwff+JEN6R7FjhQhGFEA0MOz03lmGMf/Yb62uQsc9/WwUAUKlzBD0JVUA5dYQ==",
+      "version": "0.45.0",
+      "resolved": "https://registry.npmjs.org/@reasonix/render-darwin-arm64/-/render-darwin-arm64-0.45.0.tgz",
+      "integrity": "sha512-jYCucuJi/vi/BX0fq7BOep6p5PMaFI9Fc+ZA+ckOzTTvYtaWgUYuwsnjQoPEXInKuy6lL6XLeySCin+bp98n7w==",
       "cpu": [
         "arm64"
       ],
@@ -1718,15 +1718,12 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "bin": {
-        "reasonix-render": "bin/reasonix-render"
-      }
+      ]
     },
     "node_modules/@reasonix/render-darwin-x64": {
-      "version": "0.44.2-rc.1",
-      "resolved": "https://registry.npmjs.org/@reasonix/render-darwin-x64/-/render-darwin-x64-0.44.2-rc.1.tgz",
-      "integrity": "sha512-MrfgF0BlJ+YxMcifWrDzJNRrsQQ05QmclkxYyzCr7m9ZLYhSJD+G8tdrM8psXXF4mKEMFX2YvERO/wH+CLamaw==",
+      "version": "0.45.0",
+      "resolved": "https://registry.npmjs.org/@reasonix/render-darwin-x64/-/render-darwin-x64-0.45.0.tgz",
+      "integrity": "sha512-hHTXBkUtvpj1qcqxDLCrjvS/h/gajcBaFx4kqJrjffkhYdaCc6SXvteqjyss6b6/yPgGp5zfzsDSp1HAoey+dg==",
       "cpu": [
         "x64"
       ],
@@ -1734,53 +1731,38 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "bin": {
-        "reasonix-render": "bin/reasonix-render"
-      }
+      ]
     },
     "node_modules/@reasonix/render-linux-arm64": {
-      "version": "0.44.2-rc.1",
-      "resolved": "https://registry.npmjs.org/@reasonix/render-linux-arm64/-/render-linux-arm64-0.44.2-rc.1.tgz",
-      "integrity": "sha512-YIot4u9yuvqRxGlnfnzloXRR0NvYg8pohgjOJSOHdyYw+JuCk0oidP5nyDCgcfBTKJZ9RwfRKdIU7pLYBnMtHw==",
+      "version": "0.45.0",
+      "resolved": "https://registry.npmjs.org/@reasonix/render-linux-arm64/-/render-linux-arm64-0.45.0.tgz",
+      "integrity": "sha512-pJ/3FYgVpDy38sGiAks0vGDblFD4uDRps9gUYZjAMxl7PdjyMm8I1kct8EbIsFh4Lf09lzhcVxbmz9mtnR6Zzw==",
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "bin": {
-        "reasonix-render": "bin/reasonix-render"
-      }
+      ]
     },
     "node_modules/@reasonix/render-linux-x64": {
-      "version": "0.44.2-rc.1",
-      "resolved": "https://registry.npmjs.org/@reasonix/render-linux-x64/-/render-linux-x64-0.44.2-rc.1.tgz",
-      "integrity": "sha512-jji6LUjktNOboT16jYwuBL0N6s0YVzX5BD+tulBi4CsIC9LiYZf5RXQnpvAKizEC/EDHeOKWyCHnEEMks9Uq6w==",
+      "version": "0.45.0",
+      "resolved": "https://registry.npmjs.org/@reasonix/render-linux-x64/-/render-linux-x64-0.45.0.tgz",
+      "integrity": "sha512-iqF4MuPsDUpmdBbpKH7WQ53SVnX2oiRTpdL9W9Pt3irnMpKTQ5XXQTIH0rDttHxNsfTzbm700C2Qj6DC/aXHZQ==",
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "bin": {
-        "reasonix-render": "bin/reasonix-render"
-      }
+      ]
     },
     "node_modules/@reasonix/render-win32-x64": {
-      "version": "0.44.2-rc.1",
-      "resolved": "https://registry.npmjs.org/@reasonix/render-win32-x64/-/render-win32-x64-0.44.2-rc.1.tgz",
-      "integrity": "sha512-48abp0NgB5JscahOkETg6/8u/TF5SYHVTzMRHvpC5NjChSXXPh/MtR7MWCdkRKOOQwhDxq7Z0GExJ/4TCp1EZg==",
+      "version": "0.45.0",
+      "resolved": "https://registry.npmjs.org/@reasonix/render-win32-x64/-/render-win32-x64-0.45.0.tgz",
+      "integrity": "sha512-gOxannIA0wmewwJ0sq4dU/qxA1eRc3OHUiEIQwPdt5b8aYJFrprTBqp7z5b6JNZUDwRpVaAhmbw5Euus5N2oHA==",
       "cpu": [
         "x64"
       ],
@@ -1788,10 +1770,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "bin": {
-        "reasonix-render": "bin/reasonix-render.exe"
-      }
+      ]
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.3",


### PR DESCRIPTION
\`sync-render-versions.mjs\` updates \`package.json\` + subpackages but not \`package-lock.json\`. The 0.45.0 release commit landed without regenerating the lockfile, so \`npm ci\` on main rejects the install:

\`\`\`
npm error Invalid: lock file's @reasonix/render-darwin-arm64@0.44.2-rc.1
                   does not satisfy @reasonix/render-darwin-arm64@0.45.0
\`\`\`

This unblocks main. The lockfile-sync gap in the release script is a separate follow-up — sync-render-versions.mjs should run \`npm install --package-lock-only\` (or equivalent) so this stays in sync without a manual step.