### PR TITLE
fix(chat): rust TUI input — setup capture, paste burst, Ctrl+V

### DIFF
--- a/crates/reasonix-render/src/integrated.rs
+++ b/crates/reasonix-render/src/integrated.rs
@@ -104,6 +104,18 @@ pub fn run_integrated_loop(terminal: &mut Terminal) -> Result<()> {
     let mut should_exit = false;
     let mut pending_term: Option<Event> = None;
     let mut prev_emitted_buffer: String = String::new();
+    // Rust-owned buffer for the Ink Setup screen. In integrated mode Node's
+    // Setup gets a null keystroke reader (rust owns the terminal), so the
+    // dots / submission have to live here and Node only learns the final
+    // text via the `setup-submit` event below.
+    let mut setup_buffer: String = String::new();
+    // Timestamp of the previous key event — used to detect paste-as-
+    // keystrokes when the terminal doesn't speak bracketed paste (Apple
+    // Terminal, cmd.exe pre-ConPTY, some tmux configs). Pasted chars
+    // arrive at <2ms intervals; humans top out around 80ms, and even
+    // key-repeat is usually ≥30ms. A <15ms gap on Enter is treated as
+    // "newline inside a paste", not "submit".
+    let mut last_key_at: Option<Instant> = None;
 
     let result: Result<()> = (|| loop {
         while let Ok(evt) = rx.try_recv() {
@@ -125,6 +137,15 @@ pub fn run_integrated_loop(terminal: &mut Terminal) -> Result<()> {
                                 );
                             }
                             Payload::Setup(s) => {
+                                // Fresh setup screen — start with an empty
+                                // buffer. Re-renders (e.g. error after a
+                                // rejected key) come back as Setup payloads
+                                // too, but by then we've already cleared the
+                                // buffer on submit, so the no-reset branch
+                                // is a no-op anyway.
+                                if setup_pending.is_none() {
+                                    setup_buffer.clear();
+                                }
                                 setup_pending = Some(s);
                             }
                         }
@@ -227,8 +248,14 @@ pub fn run_integrated_loop(terminal: &mut Terminal) -> Result<()> {
                 crossterm::terminal::BeginSynchronizedUpdate
             );
             if let Some(setup) = setup_pending.as_ref() {
+                // Render the local buffer length, not the value Node sent —
+                // Node's Setup buffer always stays empty in integrated mode
+                // because its keystroke reader is null. Without this
+                // override the user types but sees no dots.
+                let mut display = setup.clone();
+                display.buffer_length = setup_buffer.chars().count();
                 terminal
-                    .draw(|f| render_setup(setup, f))
+                    .draw(|f| render_setup(&display, f))
                     .context("terminal draw")?;
             } else {
                 let mut display = scene.clone();
@@ -289,6 +316,9 @@ pub fn run_integrated_loop(terminal: &mut Terminal) -> Result<()> {
                                     );
                                 }
                                 Payload::Setup(s) => {
+                                    if setup_pending.is_none() {
+                                        setup_buffer.clear();
+                                    }
                                     setup_pending = Some(s);
                                 }
                             }
@@ -307,6 +337,55 @@ pub fn run_integrated_loop(terminal: &mut Terminal) -> Result<()> {
             }
         };
         if setup_pending.is_some() {
+            // Setup screen — Node's MaskedInput can't read keys (integrated
+            // mode hands stdin to rust), so handle them here and forward the
+            // final string back as `setup-submit` for Setup.handleSubmit.
+            match &evt {
+                Event::Key(key) if key.kind == KeyEventKind::Press => {
+                    if is_quit(key) {
+                        emit_event(serde_json::json!({"event": "exit"}));
+                        return Ok(());
+                    }
+                    if key.code == KeyCode::Char('d')
+                        && key.modifiers.contains(KeyModifiers::CONTROL)
+                    {
+                        emit_event(serde_json::json!({"event": "exit"}));
+                        return Ok(());
+                    }
+                    match key.code {
+                        KeyCode::Enter => {
+                            let text = std::mem::take(&mut setup_buffer);
+                            emit_event(serde_json::json!({
+                                "event": "setup-submit",
+                                "text": text,
+                            }));
+                        }
+                        KeyCode::Backspace => {
+                            // pop one char by char-boundary, not byte.
+                            if let Some((idx, _)) = setup_buffer.char_indices().next_back() {
+                                setup_buffer.truncate(idx);
+                            }
+                        }
+                        KeyCode::Char(c)
+                            if !key.modifiers.contains(KeyModifiers::CONTROL) =>
+                        {
+                            setup_buffer.push(c);
+                        }
+                        _ => {}
+                    }
+                }
+                Event::Paste(text) => {
+                    // API keys often come with a trailing newline from copy —
+                    // strip all control chars so the key validates cleanly.
+                    for ch in text.chars() {
+                        if !ch.is_control() {
+                            setup_buffer.push(ch);
+                        }
+                    }
+                }
+                _ => {}
+            }
+            dirty = true;
             continue;
         }
         dirty = true;
@@ -344,6 +423,12 @@ pub fn run_integrated_loop(terminal: &mut Terminal) -> Result<()> {
                     sidebar_visible = !sidebar_visible;
                     continue;
                 }
+                let now = Instant::now();
+                let since_last_key = last_key_at.map(|t| now.duration_since(t));
+                last_key_at = Some(now);
+                let paste_burst = since_last_key
+                    .map(|d| d < Duration::from_millis(15))
+                    .unwrap_or(false);
                 if mode_picker.is_some() || preset_picker.is_some() {
                     handle_mode_picker_key(&key, &mut mode_picker, &mut preset_picker);
                     continue;
@@ -353,6 +438,16 @@ pub fn run_integrated_loop(terminal: &mut Terminal) -> Result<()> {
                     continue;
                 }
                 if let Some(prompt) = scene.prompt_input.as_ref() {
+                    // Paste-as-keystrokes safeguard: a mid-burst Enter is
+                    // part of the pasted content, not the user submitting.
+                    // prompt_input is single-line so we can't insert '\n';
+                    // dropping the Enter lets the rest of the paste finish.
+                    if paste_burst
+                        && key.code == KeyCode::Enter
+                        && !key.modifiers.contains(KeyModifiers::SHIFT)
+                    {
+                        continue;
+                    }
                     handle_prompt_input_key(&key, prompt, &mut buffer, &mut cursor);
                     continue;
                 }
@@ -371,6 +466,40 @@ pub fn run_integrated_loop(terminal: &mut Terminal) -> Result<()> {
                 let at_active = !slash_active && !slash_arg_active && at_count > 0;
                 let slash_complete_only = slash_active && !slash_is_exact(&buffer, &scene);
                 match key.code {
+                    // Paste-as-keystrokes fallback: when bracketed paste is
+                    // off, an Enter in the middle of a burst is part of the
+                    // pasted content, not a submit. Wins over the picker
+                    // Enter arms because guard arms match top-down.
+                    KeyCode::Enter
+                        if paste_burst && !key.modifiers.contains(KeyModifiers::SHIFT) =>
+                    {
+                        selection = None;
+                        insert_char_at(&mut buffer, cursor, '\n');
+                        cursor += 1;
+                        slash_idx = 0;
+                        at_idx = 0;
+                        scroll_offset = 0;
+                    }
+                    KeyCode::Char('v') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                        // Explicit clipboard paste — the only path that works
+                        // on terminals without bracketed paste (Apple Terminal
+                        // default). Bypasses the burst heuristic above.
+                        if let Ok(mut cb) = arboard::Clipboard::new() {
+                            if let Ok(text) = cb.get_text() {
+                                selection = None;
+                                for ch in text.chars() {
+                                    if ch == '\r' {
+                                        continue;
+                                    }
+                                    insert_char_at(&mut buffer, cursor, ch);
+                                    cursor += 1;
+                                }
+                                slash_idx = 0;
+                                at_idx = 0;
+                                scroll_offset = 0;
+                            }
+                        }
+                    }
                     KeyCode::Up if slash_active => {
                         slash_idx = slash_idx.saturating_sub(1);
                     }
@@ -888,6 +1017,28 @@ fn handle_prompt_input_key(
         }
         KeyCode::Home => *cursor = 0,
         KeyCode::End => *cursor = buffer.chars().count(),
+        KeyCode::Char('v') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            // Explicit clipboard paste — same shape as the Event::Paste
+            // path: secrets strip every control char (API keys often have a
+            // trailing newline), non-secrets keep the first line only since
+            // prompt_input is single-line by design.
+            if let Ok(mut cb) = arboard::Clipboard::new() {
+                if let Ok(text) = cb.get_text() {
+                    if prompt.secret {
+                        for ch in text.chars().filter(|c| !c.is_control()) {
+                            insert_char_at(buffer, *cursor, ch);
+                            *cursor += 1;
+                        }
+                    } else {
+                        let first = text.lines().next().unwrap_or("").trim();
+                        for ch in first.chars() {
+                            insert_char_at(buffer, *cursor, ch);
+                            *cursor += 1;
+                        }
+                    }
+                }
+            }
+        }
         KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
             insert_char_at(buffer, *cursor, c);
             *cursor += 1;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reasonix",
-  "version": "0.44.2-rc.1",
+  "version": "0.44.2-rc.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reasonix",
-      "version": "0.44.2-rc.1",
+      "version": "0.44.2-rc.4",
       "license": "MIT",
       "dependencies": {
         "cli-highlight": "^2.1.11",
@@ -53,11 +53,11 @@
         "node": ">=22"
       },
       "optionalDependencies": {
-        "@reasonix/render-darwin-arm64": "0.44.2-rc.1",
-        "@reasonix/render-darwin-x64": "0.44.2-rc.1",
-        "@reasonix/render-linux-arm64": "0.44.2-rc.1",
-        "@reasonix/render-linux-x64": "0.44.2-rc.1",
-        "@reasonix/render-win32-x64": "0.44.2-rc.1"
+        "@reasonix/render-darwin-arm64": "0.44.2-rc.4",
+        "@reasonix/render-darwin-x64": "0.44.2-rc.4",
+        "@reasonix/render-linux-arm64": "0.44.2-rc.4",
+        "@reasonix/render-linux-x64": "0.44.2-rc.4",
+        "@reasonix/render-win32-x64": "0.44.2-rc.4"
       }
     },
     "node_modules/@alcalzone/ansi-tokenize": {
@@ -1708,9 +1708,9 @@
       }
     },
     "node_modules/@reasonix/render-darwin-arm64": {
-      "version": "0.44.2-rc.1",
-      "resolved": "https://registry.npmjs.org/@reasonix/render-darwin-arm64/-/render-darwin-arm64-0.44.2-rc.1.tgz",
-      "integrity": "sha512-QQZj//YtggHhs9HKnYqZUSGvmHwff+JEN6R7FjhQhGFEA0MOz03lmGMf/Yb62uQsc9/WwUAUKlzBD0JVUA5dYQ==",
+      "version": "0.44.2-rc.4",
+      "resolved": "https://registry.npmjs.org/@reasonix/render-darwin-arm64/-/render-darwin-arm64-0.44.2-rc.4.tgz",
+      "integrity": "sha512-yCJPScJ2gDKPw3Gwy8e93RYtOKJMp49p3rIeajSvqKNzR15BlP7k6gYl4zxxzbY36CpJ1sbtzYOrFJ/HrraxUQ==",
       "cpu": [
         "arm64"
       ],
@@ -1724,9 +1724,9 @@
       }
     },
     "node_modules/@reasonix/render-darwin-x64": {
-      "version": "0.44.2-rc.1",
-      "resolved": "https://registry.npmjs.org/@reasonix/render-darwin-x64/-/render-darwin-x64-0.44.2-rc.1.tgz",
-      "integrity": "sha512-MrfgF0BlJ+YxMcifWrDzJNRrsQQ05QmclkxYyzCr7m9ZLYhSJD+G8tdrM8psXXF4mKEMFX2YvERO/wH+CLamaw==",
+      "version": "0.44.2-rc.4",
+      "resolved": "https://registry.npmjs.org/@reasonix/render-darwin-x64/-/render-darwin-x64-0.44.2-rc.4.tgz",
+      "integrity": "sha512-GPfEkl+DpJ28x2zkYrPYE3WZnRC2UDHv7hAOZ/thUb7JWO6x/e6iJO333YISHUZufMcfQbaCdDkzgd4UHtd/WQ==",
       "cpu": [
         "x64"
       ],
@@ -1740,9 +1740,9 @@
       }
     },
     "node_modules/@reasonix/render-linux-arm64": {
-      "version": "0.44.2-rc.1",
-      "resolved": "https://registry.npmjs.org/@reasonix/render-linux-arm64/-/render-linux-arm64-0.44.2-rc.1.tgz",
-      "integrity": "sha512-YIot4u9yuvqRxGlnfnzloXRR0NvYg8pohgjOJSOHdyYw+JuCk0oidP5nyDCgcfBTKJZ9RwfRKdIU7pLYBnMtHw==",
+      "version": "0.44.2-rc.4",
+      "resolved": "https://registry.npmjs.org/@reasonix/render-linux-arm64/-/render-linux-arm64-0.44.2-rc.4.tgz",
+      "integrity": "sha512-P6MRwhthBHyTPY8Wy8gZ3hURh4cabjZJWL0QCBs49N+aaS1vtChTRnu9KyLh7oxN01TDy5HKekqi+HdQz+68Sg==",
       "cpu": [
         "arm64"
       ],
@@ -1759,9 +1759,9 @@
       }
     },
     "node_modules/@reasonix/render-linux-x64": {
-      "version": "0.44.2-rc.1",
-      "resolved": "https://registry.npmjs.org/@reasonix/render-linux-x64/-/render-linux-x64-0.44.2-rc.1.tgz",
-      "integrity": "sha512-jji6LUjktNOboT16jYwuBL0N6s0YVzX5BD+tulBi4CsIC9LiYZf5RXQnpvAKizEC/EDHeOKWyCHnEEMks9Uq6w==",
+      "version": "0.44.2-rc.4",
+      "resolved": "https://registry.npmjs.org/@reasonix/render-linux-x64/-/render-linux-x64-0.44.2-rc.4.tgz",
+      "integrity": "sha512-3gRvs7BgUs65698ah/vMbHSl2eowSekGNMVQG0k+8lQoRNlMbN0SRxKu7v1Q39d6blNGzJhbPt+0Oz1/qpKQVw==",
       "cpu": [
         "x64"
       ],
@@ -1778,9 +1778,9 @@
       }
     },
     "node_modules/@reasonix/render-win32-x64": {
-      "version": "0.44.2-rc.1",
-      "resolved": "https://registry.npmjs.org/@reasonix/render-win32-x64/-/render-win32-x64-0.44.2-rc.1.tgz",
-      "integrity": "sha512-48abp0NgB5JscahOkETg6/8u/TF5SYHVTzMRHvpC5NjChSXXPh/MtR7MWCdkRKOOQwhDxq7Z0GExJ/4TCp1EZg==",
+      "version": "0.44.2-rc.4",
+      "resolved": "https://registry.npmjs.org/@reasonix/render-win32-x64/-/render-win32-x64-0.44.2-rc.4.tgz",
+      "integrity": "sha512-YZbRGX4gobtin4dmCkcisyUJh7JMhXXAx3XNUGaFh5wIZUvp/MI3xSc9YA8Hj/RUghTikcOdnheDLmAMLe8JYw==",
       "cpu": [
         "x64"
       ],

--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -199,6 +199,8 @@ interface RootProps extends ChatOptions {
   qqErrorRef: { current: ((msg: string) => void) | null };
   /** Custom keystroke source — populated when the Rust renderer is active so keys flow from the spawned input child (or a no-op reader in integrated mode) instead of process.stdin. */
   keystrokeReader?: KeystrokeReader;
+  /** Integrated rust child accumulates the api-key locally (Node's stdin is null) and posts the final text via setup-submit; the integrated handler calls into this ref so Setup.handleSubmit runs unchanged. */
+  setupSubmitRef?: { current: ((text: string) => void) | null };
 }
 
 function Root({
@@ -211,6 +213,7 @@ function Root({
   mcpRuntime,
   startupInfoHints,
   keystrokeReader,
+  setupSubmitRef,
   ...appProps
 }: RootProps) {
   const [key, setKey] = useState<string | undefined>(initialKey);
@@ -227,6 +230,7 @@ function Root({
             process.env.DEEPSEEK_API_KEY = k;
             setKey(k);
           }}
+          submitRef={setupSubmitRef}
         />
       </KeystrokeProvider>
     );
@@ -402,6 +406,7 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
   const presetSetRef: {
     current: ((value: "auto" | "flash" | "pro") => void) | null;
   } = { current: null };
+  const setupSubmitRef: { current: ((text: string) => void) | null } = { current: null };
   const qqRequested = cfg.qq?.enabled === true;
   let qqChannel: QQChannel | undefined;
   if (qqRequested) {
@@ -474,6 +479,8 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
         resolvePromptInput(event.id, event.cancelled ? null : (event.text ?? ""));
       } else if (event.event === "list-picker-response") {
         resolveListPicker(event.id, event.cancelled ? null : (event.key ?? null));
+      } else if (event.event === "setup-submit") {
+        setupSubmitRef.current?.(event.text);
       }
       // interrupt: no-op for now; terminal SIGINT already reaches Node.
     });
@@ -506,6 +513,7 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
       modeSetRef={modeSetRef}
       presetSetRef={presetSetRef}
       qqErrorRef={qqErrorRef}
+      setupSubmitRef={setupSubmitRef}
     />,
     {
       ...(rustRendererActive ? { stdout: inkStdout, stdin: inkStdin } : {}),

--- a/src/cli/ui/Setup.tsx
+++ b/src/cli/ui/Setup.tsx
@@ -1,5 +1,5 @@
 import { Box, Text, useApp } from "ink";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { defaultConfigPath, isPlausibleKey, redactKey, saveApiKey } from "../../config.js";
 import { t } from "../../i18n/index.js";
 import { MaskedInput } from "./MaskedInput.js";
@@ -8,9 +8,11 @@ import { COLOR, GLYPH, GRADIENT } from "./theme.js";
 
 export interface SetupProps {
   onReady: (apiKey: string) => void;
+  /** Integrated rust renderer routes its setup-submit event here — Node's MaskedInput can't read keys when rust owns stdin, so the rust child accumulates the text and Node calls handleSubmit via this ref instead. */
+  submitRef?: { current: ((text: string) => void) | null };
 }
 
-export function Setup({ onReady }: SetupProps) {
+export function Setup({ onReady, submitRef }: SetupProps) {
   const [value, setValue] = useState("");
   const [error, setError] = useState<string | null>(null);
   const { exit } = useApp();
@@ -36,6 +38,18 @@ export function Setup({ onReady }: SetupProps) {
     }
     onReady(trimmed);
   };
+
+  // Re-bind on every render so handleSubmit's captured `onReady` stays fresh.
+  // Cleanup is split into a mount-only effect so the ref never goes null between renders.
+  useEffect(() => {
+    if (submitRef) submitRef.current = handleSubmit;
+  });
+  useEffect(() => {
+    if (!submitRef) return undefined;
+    return () => {
+      submitRef.current = null;
+    };
+  }, [submitRef]);
 
   return (
     <Box flexDirection="column" paddingX={1} marginY={1}>

--- a/src/cli/ui/scene/renderer-process.ts
+++ b/src/cli/ui/scene/renderer-process.ts
@@ -9,7 +9,8 @@ export type RustEvent =
   | { event: "mode-set"; value: "review" | "auto" | "yolo" }
   | { event: "preset-set"; value: "auto" | "flash" | "pro" }
   | { event: "prompt-response"; id: string; text?: string; cancelled?: boolean }
-  | { event: "list-picker-response"; id: string; key?: string; cancelled?: boolean };
+  | { event: "list-picker-response"; id: string; key?: string; cancelled?: boolean }
+  | { event: "setup-submit"; text: string };
 
 export type RendererProcess = {
   emit(message: unknown): void;

--- a/tests/cli-bare-routing.test.ts
+++ b/tests/cli-bare-routing.test.ts
@@ -1,6 +1,6 @@
 /** Bare `reasonix` routing — defaults to code mode in the current directory; explicit `chat` stays chat. */
 
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -31,7 +31,11 @@ describe("bare CLI routing", () => {
 
   beforeEach(() => {
     home = mkdtempSync(join(tmpdir(), "reasonix-cli-home-"));
-    cwd = mkdtempSync(join(tmpdir(), "reasonix-cli-cwd-"));
+    // macOS's tmpdir is /var/folders/... but realpath is /private/var/folders/...;
+    // process.chdir followed by process.cwd() returns the resolved form, so
+    // normalise here too or the toHaveBeenCalledWith({ dir: cwd, ... }) assertions
+    // compare mismatched paths.
+    cwd = realpathSync(mkdtempSync(join(tmpdir(), "reasonix-cli-cwd-")));
     process.env.HOME = home;
     process.env.USERPROFILE = home;
     process.chdir(cwd);


### PR DESCRIPTION
## Summary
Three input-path fixes for the integrated rust renderer, plus a Mac-only test fix that was already blocking pre-push.

- **Setup screen**: rust now owns the keystroke buffer while \`setup_pending\` is \`Some\`. Previously every event was dropped via \`continue\`, so Ink's \`MaskedInput\` (null keystroke reader in integrated mode) sat on a screen that ignored every keypress — Windows users (and any Mac user after the rc.2 eager-spawn change) couldn't enter their API key. Buffer is forwarded to \`Setup.handleSubmit\` via a new \`setup-submit\` event and a \`submitRef\` on the Setup component.
- **Paste-with-newline submits**: track \`last_key_at\` and treat an Enter that arrives within 15 ms of the previous key as paste-as-keystrokes — insert \`\n\` literally instead of submitting. Bracketed paste is the happy path, but Apple Terminal (macOS default) and cmd.exe pre-ConPTY don't speak it, so multi-line pastes used to submit on the first \`\n\`. Same guard short-circuits a mid-paste Enter inside \`prompt_input\` so partial answers don't submit either.
- **Ctrl+V**: explicit clipboard paste via \`arboard::get_text\` in both composer and \`prompt_input\` — the only working paste path when bracketed paste is unavailable.
- **Test**: \`tests/cli-bare-routing.test.ts\` was comparing the unresolved \`/var/folders/...\` tmpdir against \`process.cwd()\`'s \`/private/var/...\` realpath form, failing on every Mac. \`realpathSync\` at setup so the assertion sees one path.

## Test plan
- [x] \`cargo test -p reasonix-render\` — 72 tests pass
- [x] \`npm test\` — 3173 pass / 10 skipped (was 3 failing on Mac before the test fix)
- [x] \`npm run typecheck\` — clean
- [x] Pre-push hook (\`npm run verify\`) — clean
- [ ] Manual: \`npm run chat\` on a fresh install (no API key) — Setup accepts typed key
- [ ] Manual: paste \`hello\nworld\` into composer from a terminal without bracketed paste — stays as two lines, doesn't submit
- [ ] Manual: Ctrl+V from system clipboard into composer — pastes
- [ ] Manual: Ctrl+V into a \`/qq connect\`-style prompt — pastes

## Follow-ups (not in this PR)
- Same burst heuristic for the non-integrated split-process renderer (\`main.rs\`) — needs Node-side handling since composer state lives in Ink there
- Keyboard selection (Shift+arrows), double-click word / triple-click line
- OSC 52 clipboard for SSH/remote sessions
- Long-paste collapse to \`[Pasted N lines]\` placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)