### PR TITLE
fix(qq): add msg_seq for chunked C2C replies

### DIFF
--- a/src/qq/bot.ts
+++ b/src/qq/bot.ts
@@ -249,13 +249,19 @@ export class QQBot extends EventEmitter {
     this.cleanup();
   }
 
-  async sendPrivateMessage(openid: string, content: string, msgId?: string): Promise<void> {
+  async sendPrivateMessage(
+    openid: string,
+    content: string,
+    msgId?: string,
+    msgSeq?: number,
+  ): Promise<void> {
     const token = await this.ensureToken();
     const body: Record<string, unknown> = {
       content,
       msg_type: 0,
     };
     if (msgId) body.msg_id = msgId;
+    if (typeof msgSeq === "number" && Number.isFinite(msgSeq)) body.msg_seq = Math.trunc(msgSeq);
     const res = await fetch(`${this.baseUrl}/v2/users/${encodeURIComponent(openid)}/messages`, {
       method: "POST",
       headers: {

--- a/src/qq/channel.ts
+++ b/src/qq/channel.ts
@@ -6,18 +6,45 @@ import { loadDotenv } from "../env.js";
 import { type C2CMessage, QQBot } from "./bot.js";
 
 const QQ_LOCK_FILE = join(homedir(), ".reasonix", "qq-channel.pid");
+const QQ_MAX_CHUNK_BYTES = 1500;
+const NATURAL_SPLIT_MIN_FRACTION = 0.6;
 
-function chunkMessage(text: string, maxLen = 1500): string[] {
+function fitUtf8Slice(text: string, maxBytes: number): string {
+  let end = 0;
+  let bytes = 0;
+  for (const char of text) {
+    const nextBytes = Buffer.byteLength(char, "utf8");
+    if (bytes > 0 && bytes + nextBytes > maxBytes) break;
+    end += char.length;
+    bytes += nextBytes;
+  }
+  return end > 0 ? text.slice(0, end) : text.slice(0, 1);
+}
+
+function pickNaturalSplit(candidate: string): number {
+  const minSplit = Math.floor(candidate.length * NATURAL_SPLIT_MIN_FRACTION);
+  const splitters = ["\n\n", "\n", " "];
+  for (const splitter of splitters) {
+    const at = candidate.lastIndexOf(splitter);
+    if (at >= minSplit) return at + splitter.length;
+  }
+  return candidate.length;
+}
+
+export function splitQQMessage(text: string, maxBytes = QQ_MAX_CHUNK_BYTES): string[] {
   const chunks: string[] = [];
   let remaining = text;
-  while (remaining.length > maxLen) {
-    let splitAt = remaining.lastIndexOf("\n", maxLen);
-    if (splitAt < 0) splitAt = remaining.lastIndexOf(" ", maxLen);
-    if (splitAt < 0) splitAt = maxLen;
-    chunks.push(remaining.slice(0, splitAt));
-    remaining = remaining.slice(splitAt).trim();
+  while (remaining.length > 0) {
+    if (Buffer.byteLength(remaining, "utf8") <= maxBytes) {
+      chunks.push(remaining);
+      break;
+    }
+
+    const candidate = fitUtf8Slice(remaining, maxBytes);
+    const splitAt = pickNaturalSplit(candidate);
+    chunks.push(candidate.slice(0, splitAt));
+    remaining = remaining.slice(splitAt).trimStart();
   }
-  if (remaining.length > 0) chunks.push(remaining);
   return chunks;
 }
 
@@ -28,6 +55,7 @@ export class QQChannel {
   private processedMsgIds = new Set<string>();
   private processedMsgIdQueue: string[] = [];
   private lockAcquired = false;
+  private nextOutboundMsgSeq = 1;
 
   constructor(
     private callbacks: {
@@ -142,13 +170,21 @@ export class QQChannel {
 
   async sendResponse(text: string): Promise<void> {
     if (!this.bot || !this.qqUserId) return;
-    const chunks = chunkMessage(text);
-    for (const chunk of chunks) {
+    const chunks = splitQQMessage(text);
+    for (let index = 0; index < chunks.length; index++) {
+      const chunk = chunks[index];
+      if (!chunk) continue;
       try {
-        await this.bot.sendPrivateMessage(this.qqUserId, chunk, this.qqMessageId ?? undefined);
+        await this.bot.sendPrivateMessage(
+          this.qqUserId,
+          chunk,
+          this.qqMessageId ?? undefined,
+          this.nextOutboundMsgSeq++,
+        );
       } catch (err) {
-        const msg = `QQ sendResponse error: ${(err as Error).message}`;
+        const msg = `QQ sendResponse chunk ${index + 1}/${chunks.length} failed: ${(err as Error).message}`;
         this.callbacks.onError?.(msg);
+        break;
       }
     }
   }

--- a/tests/qq-channel.test.ts
+++ b/tests/qq-channel.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+import { QQChannel, splitQQMessage } from "../src/qq/channel.js";
+
+describe("splitQQMessage", () => {
+  it("keeps every chunk within the UTF-8 byte budget", () => {
+    const chunks = splitQQMessage("中".repeat(600), 1500);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(Buffer.byteLength(chunk, "utf8")).toBeLessThanOrEqual(1500);
+    }
+  });
+});
+
+describe("QQChannel.sendResponse", () => {
+  it("assigns incrementing msg_seq values across chunks", async () => {
+    const bot = { sendPrivateMessage: vi.fn().mockResolvedValue(undefined) };
+    const channel = new QQChannel({ onSubmitMessage: () => undefined }) as QQChannel & {
+      bot: typeof bot;
+      qqUserId: string;
+      qqMessageId: string;
+      nextOutboundMsgSeq: number;
+    };
+    channel.bot = bot;
+    channel.qqUserId = "user-openid";
+    channel.qqMessageId = "msg-id";
+    channel.nextOutboundMsgSeq = 41;
+
+    await channel.sendResponse("a".repeat(1501));
+
+    expect(bot.sendPrivateMessage).toHaveBeenCalledTimes(2);
+    expect(bot.sendPrivateMessage).toHaveBeenNthCalledWith(
+      1,
+      "user-openid",
+      "a".repeat(1500),
+      "msg-id",
+      41,
+    );
+    expect(bot.sendPrivateMessage).toHaveBeenNthCalledWith(2, "user-openid", "a", "msg-id", 42);
+  });
+
+  it("stops after the first failed chunk and reports which chunk failed", async () => {
+    const bot = {
+      sendPrivateMessage: vi
+        .fn()
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error("duplicate msgseq"))
+        .mockResolvedValue(undefined),
+    };
+    const onError = vi.fn();
+    const channel = new QQChannel({
+      onSubmitMessage: () => undefined,
+      onError,
+    }) as QQChannel & {
+      bot: typeof bot;
+      qqUserId: string;
+      qqMessageId: string;
+    };
+    channel.bot = bot;
+    channel.qqUserId = "user-openid";
+    channel.qqMessageId = "msg-id";
+
+    await channel.sendResponse("a".repeat(3001));
+
+    expect(bot.sendPrivateMessage).toHaveBeenCalledTimes(2);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0]?.[0]).toContain("chunk 2/3 failed");
+  });
+});


### PR DESCRIPTION
## Summary
- add explicit `msg_seq` support when sending QQ C2C messages
- split long QQ replies by UTF-8 byte budget instead of naive string length
- stop after the first failed chunk so long replies do not silently lose later segments
- add regression coverage for chunk splitting and outbound `msg_seq` sequencing

## Why
Long QQ replies were being delivered partially: the first chunk reached QQ, but later chunks could fail with `40054005` (`消息被去重，请检查请求msgseq`).

The current implementation already chunks long replies, but it did not attach an explicit `msg_seq` to each outbound chunk. That makes multi-part replies look like duplicate sends on the QQ side.

## Changes
- extend `QQBot.sendPrivateMessage(...)` to accept and send `msg_seq`
- track a monotonic outbound sequence inside `QQChannel`
- assign incrementing `msg_seq` values per chunk in `sendResponse(...)`
- replace fixed `string.length` chunking with UTF-8 byte-aware splitting and natural break preference
- stop sending later chunks after the first failure and surface which chunk failed

## Verification
- `npm run verify`
- added `tests/qq-channel.test.ts` to cover:
  - UTF-8 byte-bounded chunking
  - incrementing `msg_seq` assignment across chunks
  - stopping after the first failed chunk

## Scope
This PR stays narrow: QQ transport/channel fixes only. It does not change the chat/code session loop or desktop-side architecture.