### PR TITLE
docs: bump version banner to v0.45.1

### DIFF
--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -121,7 +121,7 @@
         <a class="brand" href="index.html">
           <span class="brand-mark"></span>
           <span class="brand-name">
-            <b>Reasonix</b><span>DS · v0.43.0</span>
+            <b>Reasonix</b><span>DS · v0.45.1</span>
           </span>
         </a>
         <div class="nav-links" role="navigation">
@@ -561,7 +561,7 @@
         <span>© 2026 esengine · MIT License</span>
         <span class="spacer"></span>
         <span>Independent open-source project · not affiliated with DeepSeek</span>
-        <span style="margin-left:18px">v0.43.0 · stable</span>
+        <span style="margin-left:18px">v0.45.1 · stable</span>
       </div>
     </footer>
 

--- a/docs/cli-reference.html
+++ b/docs/cli-reference.html
@@ -121,7 +121,7 @@
         <a class="brand" href="index.html">
           <span class="brand-mark"></span>
           <span class="brand-name">
-            <b>Reasonix</b><span>DS · v0.43.0</span>
+            <b>Reasonix</b><span>DS · v0.45.1</span>
           </span>
         </a>
         <div class="nav-links" role="navigation">
@@ -843,7 +843,7 @@
         <span>© 2026 esengine · MIT License</span>
         <span class="spacer"></span>
         <span>Independent open-source project · not affiliated with DeepSeek</span>
-        <span style="margin-left:18px">v0.43.0 · stable</span>
+        <span style="margin-left:18px">v0.45.1 · stable</span>
       </div>
     </footer>
 

--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -121,7 +121,7 @@
         <a class="brand" href="index.html">
           <span class="brand-mark"></span>
           <span class="brand-name">
-            <b>Reasonix</b><span>DS · v0.43.0</span>
+            <b>Reasonix</b><span>DS · v0.45.1</span>
           </span>
         </a>
         <div class="nav-links" role="navigation">
@@ -750,7 +750,7 @@ created: 2026-05-09
         <span>© 2026 esengine · MIT License</span>
         <span class="spacer"></span>
         <span>Independent open-source project · not affiliated with DeepSeek</span>
-        <span style="margin-left:18px">v0.43.0 · stable</span>
+        <span style="margin-left:18px">v0.45.1 · stable</span>
       </div>
     </footer>
 


### PR DESCRIPTION
Stale `v0.43.0` banner on architecture / cli-reference / configuration pages. Other version slots on the site fetch from npm dynamically; only these three pages have hardcoded brand banners + footer status strings.