### PR TITLE
docs(jsx): bump REASONIX_VERSION to 0.45.1

### DIFF
--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -121,7 +121,7 @@
         <a class="brand" href="index.html">
           <span class="brand-mark"></span>
           <span class="brand-name">
-            <b>Reasonix</b><span>DS · v0.43.0</span>
+            <b>Reasonix</b><span>DS · v0.45.1</span>
           </span>
         </a>
         <div class="nav-links" role="navigation">
@@ -561,7 +561,7 @@
         <span>© 2026 esengine · MIT License</span>
         <span class="spacer"></span>
         <span>Independent open-source project · not affiliated with DeepSeek</span>
-        <span style="margin-left:18px">v0.43.0 · stable</span>
+        <span style="margin-left:18px">v0.45.1 · stable</span>
       </div>
     </footer>
 

--- a/docs/cli-reference.html
+++ b/docs/cli-reference.html
@@ -121,7 +121,7 @@
         <a class="brand" href="index.html">
           <span class="brand-mark"></span>
           <span class="brand-name">
-            <b>Reasonix</b><span>DS · v0.43.0</span>
+            <b>Reasonix</b><span>DS · v0.45.1</span>
           </span>
         </a>
         <div class="nav-links" role="navigation">
@@ -843,7 +843,7 @@
         <span>© 2026 esengine · MIT License</span>
         <span class="spacer"></span>
         <span>Independent open-source project · not affiliated with DeepSeek</span>
-        <span style="margin-left:18px">v0.43.0 · stable</span>
+        <span style="margin-left:18px">v0.45.1 · stable</span>
       </div>
     </footer>
 

--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -121,7 +121,7 @@
         <a class="brand" href="index.html">
           <span class="brand-mark"></span>
           <span class="brand-name">
-            <b>Reasonix</b><span>DS · v0.43.0</span>
+            <b>Reasonix</b><span>DS · v0.45.1</span>
           </span>
         </a>
         <div class="nav-links" role="navigation">
@@ -750,7 +750,7 @@ created: 2026-05-09
         <span>© 2026 esengine · MIT License</span>
         <span class="spacer"></span>
         <span>Independent open-source project · not affiliated with DeepSeek</span>
-        <span style="margin-left:18px">v0.43.0 · stable</span>
+        <span style="margin-left:18px">v0.45.1 · stable</span>
       </div>
     </footer>
 

--- a/docs/src/i18n.jsx
+++ b/docs/src/i18n.jsx
@@ -1,6 +1,6 @@
 // Lang context + t() helper. `t({zh, en})` returns the active-lang string.
 
-window.REASONIX_VERSION = "0.43.0";
+window.REASONIX_VERSION = "0.45.1";
 
 const LangCtx = React.createContext({ lang: "zh", setLang: () => {} });
 


### PR DESCRIPTION
The previous bump only touched the 3 static HTML pages (architecture / cli-reference / configuration). The React-driven index / download / hero / footer / nav all read `window.REASONIX_VERSION` from `docs/src/i18n.jsx`, which was still pinned at 0.43.0.