### PR TITLE
ci: split desktop + npm releases into separate tag namespaces

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,66 @@
+name: Publish npm
+
+# Tag namespace: plain `v<semver>` triggers npm publish for the
+# reasonix CLI package. Desktop Tauri releases use `desktop-v*`
+# (see release.yml) — pushing one of those never reaches this
+# workflow, so the two release tracks are fully decoupled.
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish (e.g. v0.47.0). Required when running manually."
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  # `id-token: write` is the npm provenance handshake — harmless if we
+  # don't enable provenance, required if we ever do.
+  id-token: write
+
+jobs:
+  publish:
+    name: publish to npm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # workflow_dispatch lets a maintainer publish an older tag
+          # without re-pushing it; tag pushes already point HEAD at the
+          # right ref so the fallback is a no-op.
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Setup Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          registry-url: https://registry.npmjs.org/
+
+      # Fail-fast if someone tags without bumping package.json. npm itself
+      # would reject the duplicate publish, but the error there is
+      # opaque ("403 You cannot publish over the previously published
+      # versions") and CI is the place to catch it cleanly.
+      - name: Verify tag matches package.json version
+        shell: bash
+        run: |
+          tag="${{ github.event.inputs.tag || github.ref_name }}"
+          tag_version="${tag#v}"
+          pkg_version=$(node -p "require('./package.json').version")
+          if [ "$tag_version" != "$pkg_version" ]; then
+            echo "::error::tag $tag (version $tag_version) does not match package.json version $pkg_version"
+            exit 1
+          fi
+          echo "tag $tag matches package.json $pkg_version"
+
+      - name: Install dependencies
+        run: npm ci
+
+      # `npm publish` runs the prepublishOnly hook (lint + typecheck +
+      # test + build) automatically, so no separate verify step here.
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,16 @@
-name: Release
+name: Release desktop
 
+# Tag namespace: `desktop-v<semver>` triggers desktop Tauri bundles.
+# Plain `v<semver>` tags are reserved for the npm CLI release (see
+# publish-npm.yml) — they intentionally do NOT trigger this workflow.
+# Bump the desktop with: `git tag desktop-vX.Y.Z && git push origin desktop-vX.Y.Z`.
 on:
   push:
-    tags: ["v*"]
+    tags: ["desktop-v*"]
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to publish (e.g. v0.40.0). Required when running manually."
+        description: "Tag to publish (e.g. desktop-v0.47.0). Required when running manually."
         required: true
         type: string
 

--- a/scripts/sync-desktop-version.mjs
+++ b/scripts/sync-desktop-version.mjs
@@ -12,7 +12,7 @@ if (!tag) {
   process.exit(1);
 }
 
-const version = tag.replace(/^v/, "");
+const version = tag.replace(/^(?:desktop-)?v/, "");
 if (!/^\d+\.\d+\.\d+(-[\w.-]+)?(\+[\w.-]+)?$/.test(version)) {
   console.error(`refusing to write non-SemVer version: ${version}`);
   process.exit(1);


### PR DESCRIPTION
## Summary

Pushing `v0.46.0` for the npm release just kicked off the desktop Tauri bundle matrix too — `release.yml` was listening on `tags: ["v*"]`, same namespace the CLI release uses. The desktop run was cancelled mid-flight (`gh run cancel 26009308879`), so no stray draft escaped, but the wiring needs fixing or the next CLI tag does it again.

**Split the tag namespace** so each release surface is independent:

| Surface | Tag shape           | Workflow            |
|---------|---------------------|---------------------|
| npm CLI | `vX.Y.Z`            | `publish-npm.yml` (new) |
| Desktop | `desktop-vX.Y.Z`    | `release.yml` (existing, retriggered) |

A `vX.Y.Z` tag now only reaches `publish-npm.yml`; a `desktop-vX.Y.Z` tag only reaches `release.yml`. The two tag shapes are disjoint as glob patterns, no overlap risk.

**Bonus — npm publish stops being a manual local step.** `publish-npm.yml` does `npm ci && npm publish`; the existing `prepublishOnly` hook re-runs lint + typecheck + test + build inside the publish call, so the safety net is preserved without a duplicate verify step. A tag-vs-package.json version mismatch check fails fast with a clear error before the publish call, so a forgotten version bump errors at the CI level instead of hitting an opaque npm 403.

`sync-desktop-version.mjs` learns to strip both `^v` and `^desktop-v` prefixes; the desktop bundle's tauri.conf.json / Cargo.toml / desktop/package.json continue to receive the same SemVer string.

## Test plan

- [ ] Push a throwaway test tag `desktop-v0.0.0-ci-test` → confirm `release.yml` fires + `publish-npm.yml` does NOT fire
- [ ] Push a throwaway test tag `v0.0.0-ci-test` → confirm `publish-npm.yml` fires + `release.yml` does NOT fire (the version-mismatch check will reject it before publish, so npm registry stays untouched — and it's not a valid semver tail anyway, so even mismatch passes wouldn't go through)
- [ ] Verify `secrets.NPM_TOKEN` is configured in repo settings (publish-npm.yml needs it)
- [ ] Once merged, the next CLI release is `git tag vX.Y.Z && git push origin vX.Y.Z` — no local `npm publish` needed
- [ ] Once merged, the next desktop release is `git tag desktop-vX.Y.Z && git push origin desktop-vX.Y.Z`
