### PR TITLE
fix(mcp): pipe child stderr instead of inheriting

### DIFF
--- a/src/mcp/stdio.ts
+++ b/src/mcp/stdio.ts
@@ -54,18 +54,20 @@ export class StdioTransport implements McpTransport {
       this.child = spawn(line, [], {
         env,
         cwd: opts.cwd,
-        stdio: ["pipe", "pipe", "inherit"],
+        stdio: ["pipe", "pipe", "pipe"],
         shell: true,
       });
     } else {
       this.child = spawn(opts.command, opts.args ?? [], {
         env,
         cwd: opts.cwd,
-        stdio: ["pipe", "pipe", "inherit"],
+        stdio: ["pipe", "pipe", "pipe"],
       });
     }
     this.child.stdout!.setEncoding("utf8");
     this.child.stdout!.on("data", (chunk: string) => this.onStdout(chunk));
+    this.child.stderr!.setEncoding("utf8");
+    this.child.stderr!.on("data", (chunk: string) => this.onStderr(chunk));
     this.child.on("close", () => this.onClose());
     this.child.on("error", (err) => {
       // Surface spawn errors as a synthetic JsonRpcError so callers don't
@@ -138,13 +140,21 @@ export class StdioTransport implements McpTransport {
         const msg = JSON.parse(line) as JsonRpcMessage;
         this.push(msg);
       } catch {
-        // Malformed lines are dropped — some servers emit startup banners
-        // before the JSON-RPC loop begins. We surface the noise to stderr
-        // via the inherited stderr stream, not our event queue.
+        // Malformed stdout lines are dropped — some servers emit startup
+        // banners before the JSON-RPC loop begins. Surface only under
+        // REASONIX_DEBUG_MCP=1; otherwise the noise corrupts the TUI render.
         if (process.env.REASONIX_DEBUG_MCP === "1") {
           process.stderr.write(`[mcp-stdio] dropped malformed line: ${line}\n`);
         }
       }
+    }
+  }
+
+  // Python MCP SDK writes info logs (`server.py:534 ListPromptsRequest`)
+  // to stderr — letting those through would corrupt the TUI render.
+  private onStderr(chunk: string): void {
+    if (process.env.REASONIX_DEBUG_MCP === "1") {
+      process.stderr.write(chunk);
     }
   }
 

--- a/tests/mcp-stdio-stderr-leak.test.ts
+++ b/tests/mcp-stdio-stderr-leak.test.ts
@@ -1,0 +1,54 @@
+/** Child stderr is piped, not inherited — only forwarded under REASONIX_DEBUG_MCP=1. */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { StdioTransport } from "../src/mcp/stdio.js";
+
+const STDERR_THEN_EXIT =
+  "process.stderr.write('INFO server.py:534 Processing request of type ListPromptsRequest\\n'); process.exit(0)";
+
+async function awaitChildExit(t: StdioTransport): Promise<void> {
+  for await (const _msg of t.messages()) {
+    // The script never emits JSON-RPC, so the body never runs.
+  }
+}
+
+describe("StdioTransport child stderr handling", { timeout: 5_000 }, () => {
+  let writeSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    writeSpy.mockRestore();
+    vi.unstubAllEnvs();
+  });
+
+  it("does not forward child stderr to our stderr when REASONIX_DEBUG_MCP is unset", async () => {
+    vi.stubEnv("REASONIX_DEBUG_MCP", "");
+    const t = new StdioTransport({
+      command: "node",
+      args: ["-e", STDERR_THEN_EXIT],
+      shell: false,
+    });
+    await awaitChildExit(t);
+    await t.close();
+
+    const stderrCalls = writeSpy.mock.calls.map((c) => String(c[0]));
+    expect(stderrCalls.some((s) => s.includes("server.py:534"))).toBe(false);
+  });
+
+  it("forwards child stderr to our stderr when REASONIX_DEBUG_MCP=1", async () => {
+    vi.stubEnv("REASONIX_DEBUG_MCP", "1");
+    const t = new StdioTransport({
+      command: "node",
+      args: ["-e", STDERR_THEN_EXIT],
+      shell: false,
+    });
+    await awaitChildExit(t);
+    await t.close();
+
+    const stderrCalls = writeSpy.mock.calls.map((c) => String(c[0]));
+    expect(stderrCalls.some((s) => s.includes("server.py:534"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## What
Switch the MCP stdio transport from `stdio: ["pipe", "pipe", "inherit"]` to `stdio: ["pipe", "pipe", "pipe"]`, drain the child's stderr in a new `onStderr` handler, and forward to our own stderr only under `REASONIX_DEBUG_MCP=1`.

## Why
Python MCP SDK servers write info logs (e.g. `INFO server.py:534 Processing request of type ListPromptsRequest`) to stderr. With stderr inherited from the reasonix process, those lines write straight into the TUI's render buffer and stick around until a `SIGWINCH` triggers a full redraw — visible as the four leaked lines in the screenshot on #1146.

Forwarding under the existing `REASONIX_DEBUG_MCP=1` gate matches the gating already used for malformed stdout lines, so the diagnostic path is preserved.

## How to verify
- `npm run verify` — all 3112 tests pass locally, including the new regression and the existing comment-policy gate.
- `tests/mcp-stdio-stderr-leak.test.ts` covers both branches: silent by default, forwarded when `REASONIX_DEBUG_MCP=1`.

Closes #1146
