### PR TITLE
fix(ui): refresh status-row summary on session switch

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -961,6 +961,13 @@ function AppInner({
     return l;
   }, [model, system, rebuildSystem, budgetUsd, failureThreshold, session, tools, codeMode]);
 
+  // Loop is rebuilt on session switch with seeded carryover totals from
+  // the resumed session's meta; mirror them into summary state so the
+  // StatusRow doesn't keep showing the prior session's cost until the next turn.
+  useEffect(() => {
+    setSummary(loop.stats.summary());
+  }, [loop]);
+
   const generateCurrentSessionTitle = useCallback(
     async (seed?: { userText?: string; assistantText?: string; auto?: boolean }) => {
       if (!session || !onSwitchSession) return t("app.sessionTitleNoSession");


### PR DESCRIPTION
## What
`AppInner` runs a `useEffect` keyed on the memoized `loop` that mirrors `loop.stats.summary()` into the `summary` state. The loop's `useMemo` already depends on `session`, so this fires immediately on every session switch.

## Why
`CacheFirstLoop`'s constructor calls `stats.seedCarryover({ totalCostUsd, turnCount, cacheHitTokens, cacheMissTokens, lastPromptTokens })` from the resumed session's `meta.json`, so the totals are correct on the loop side from the first frame. But the TUI's `summary` state was only ever updated inside the turn-end handler in `App.tsx`. Until the user submitted a new turn:

- switching from session A → B would keep showing A's cost,
- launching with `reasonix code --resume X` would show `$0`,

even though the loop already knew the right number. Issue #1143 calls this out as "切换会话即为 0".

## Scope
This fixes the per-session/window display. The reporter also mentions "总计费 in settings resets after an upgrade" — that one refers to the `~/.reasonix/usage.jsonl` aggregated log, which is separate persistence and shouldn't be affected by an `npm i -g reasonix@latest`. I asked for clarification on the issue.

## How to verify
- `npm run verify` — full suite passes locally (the only file changed is `src/cli/ui/App.tsx`, 7 lines added)
- Manual: start two sessions with different cost totals, switch between them via `/sessions` — the StatusRow cost updates immediately on the switch instead of waiting for the next turn

Refs #1143
