### PR TITLE
fix(tui): raise stdout MaxListeners ceiling for long chats

### DIFF
--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -342,6 +342,11 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
     }
   }
 
+  // One stdout `resize` listener per card (Ink's useBoxMetrics); long
+  // chats legitimately hold dozens, so Node's default cap of 10 fires
+  // a spurious MaxListenersExceededWarning. Raise the ceiling.
+  process.stdout.setMaxListeners(200);
+
   const { waitUntilExit } = render(
     <Root
       initialKey={initialKey}


### PR DESCRIPTION
## What
Call `process.stdout.setMaxListeners(200)` right before `render()` in the `chat`/`code` entry path.

## Why
Each `MeasuredCard` in `CardStream.tsx` registers a `stdout.on('resize', …)` listener via Ink's `useBoxMetrics` hook — by design, since every card needs its post-resize layout metrics. A long conversation legitimately keeps dozens of cards mounted at once.

Node's default `EventEmitter.defaultMaxListeners = 10` fires a `Possible EventEmitter memory leak detected. 11 resize listeners added to [WriteStream]` warning the moment the user hits the 11th card. Reported in #1157 — user saw it on macOS 26 in both Warp and iTerm on 0.46.0; v0.43.0 (pre pure-Ink rebuild) didn't trip it.

Raising the ceiling to 200 keeps a real leak (one *not* bounded by card count) above the new bar while normal use stays quiet.

## Scope
This fixes the spurious warning only. The other half of #1157 — terminal-native mouse-wheel scrollback not showing prior turns — is architectural (Ink owns the screen in interactive mode; `<Static>` would be needed for past cards to land in scrollback) and tracked separately on the issue thread.

Refs #1157
