### PR TITLE
fix(wizard): validate key against /models, not /user/balance

### DIFF
--- a/src/cli/ui/Wizard.tsx
+++ b/src/cli/ui/Wizard.tsx
@@ -502,6 +502,10 @@ function ApiKeyStep({
   );
 }
 
+// Hit `/models` instead of DeepSeek's `/user/balance`: the OpenAI-compat
+// listing endpoint exists on every provider that pretends to be OpenAI
+// (DeepSeek, DashScope/Tongyi, Moonshot, Zhipu, …), and 401/403 there
+// still means "key bad" the same way.
 export async function validateDeepSeekApiKey(
   apiKey: string,
   opts: {
@@ -517,14 +521,14 @@ export async function validateDeepSeekApiKey(
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), opts.timeoutMs ?? 10_000);
   try {
-    const resp = await fetchImpl(`${baseUrl}/user/balance`, {
+    const resp = await fetchImpl(`${baseUrl}/models`, {
       method: "GET",
       headers: { Authorization: `Bearer ${apiKey}` },
       signal: ctrl.signal,
     });
     if (resp.ok) return { ok: true };
     if (resp.status === 401 || resp.status === 403) return { ok: false, reason: "rejected" };
-    return { ok: false, reason: "failed", message: `DeepSeek ${resp.status}` };
+    return { ok: false, reason: "failed", message: `HTTP ${resp.status}` };
   } catch (e) {
     return { ok: false, reason: "failed", message: (e as Error).message };
   } finally {

--- a/tests/wizard.test.tsx
+++ b/tests/wizard.test.tsx
@@ -88,6 +88,23 @@ describe("Wizard API-key validation", () => {
 
     await expect(
       validateDeepSeekApiKey("sk-valid1234567890", { fetch: fetcher as typeof fetch }),
-    ).resolves.toMatchObject({ ok: false, reason: "failed", message: "DeepSeek 503" });
+    ).resolves.toMatchObject({ ok: false, reason: "failed", message: "HTTP 503" });
+  });
+
+  it("hits /models, not /user/balance — third-party endpoints (DashScope etc.) accept it", async () => {
+    const calls: string[] = [];
+    const fetcher = async (url: string) => {
+      calls.push(url);
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    };
+
+    await expect(
+      validateDeepSeekApiKey("sk-valid1234567890", {
+        baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        fetch: fetcher as typeof fetch,
+      }),
+    ).resolves.toEqual({ ok: true });
+
+    expect(calls).toEqual(["https://dashscope.aliyuncs.com/compatible-mode/v1/models"]);
   });
 });


### PR DESCRIPTION
## What
Change the setup wizard's API-key probe from `${baseUrl}/user/balance` to `${baseUrl}/models`, and relabel the non-auth-failure message from `DeepSeek <status>` to `HTTP <status>`.

## Why
`/user/balance` is a DeepSeek-only endpoint. Users in #1168 pointed `baseUrl` at Tongyi Qianwen (DashScope `compatible-mode/v1`) and the wizard refused their valid key with `暂时无法验证 API key (DeepSeek 404)` — the key was fine, the probe was hitting an endpoint that doesn't exist on the third party.

`/models` is the standard OpenAI-compatible listing endpoint, present on every provider this codebase already talks to (`client.ts:listModels` uses the same path, including against DeepSeek itself), and 401/403 there still means "key rejected" the same way. So the new probe works for DeepSeek, DashScope/Tongyi, Moonshot, Zhipu, etc.

## Test coverage
- Existing tests (200 / 401 / 503) updated for the new `HTTP <status>` label.
- New regression test pins the probe URL to DashScope's `compatible-mode/v1` base — a future revert can't silently re-DeepSeek-ify the validator without breaking this test.

Closes #1168
