### PR TITLE
fix(tui): drop the IME-commit Enter in the prompt input

### DIFF
--- a/src/cli/ui/PromptInput.tsx
+++ b/src/cli/ui/PromptInput.tsx
@@ -22,6 +22,18 @@ import { FG, SURFACE, TONE } from "./theme/tokens.js";
 /** Pastes shorter than this AND single-line render verbatim; longer ones become a `[paste #N · …]` sentinel chip (#397). */
 export const INLINE_PASTE_THRESHOLD = 200;
 
+// Tight enough that a normal typed Enter (≥80ms after the last keystroke
+// for human cadence) still submits; wide enough that CJK IME commit-then-
+// Enter (terminal flushes both together) falls inside the window.
+const IME_GUARD_MS = 50;
+
+function hasNonAscii(s: string): boolean {
+  for (let i = 0; i < s.length; i++) {
+    if (s.charCodeAt(i) > 0x7f) return true;
+  }
+  return false;
+}
+
 export function shouldInlinePaste(content: string): boolean {
   return !content.includes("\n") && content.length <= INLINE_PASTE_THRESHOLD;
 }
@@ -69,6 +81,11 @@ export function PromptInput({
   const pastesRef = useRef<Map<number, PasteEntry>>(new Map());
   const nextPasteIdRef = useRef<number>(0);
 
+  // CJK IMEs commit the candidate then often pass the trigger Enter through
+  // as a real keystroke; terminals can't expose composition state. If submit
+  // fires within IME_GUARD_MS of non-ASCII input we treat it as that commit-Enter.
+  const lastNonAsciiInputAtRef = useRef(0);
+
   // Refs (not props/state) — multiple keystrokes in one stdin chunk dispatch
   // before re-render, so the handler must read the latest value/cursor.
   const lastLocalValueRef = useRef(value);
@@ -107,6 +124,9 @@ export function PromptInput({
       if (ev.input.length > 0) registerPaste(ev.input);
       return;
     }
+    if (ev.input.length > 0 && hasNonAscii(ev.input)) {
+      lastNonAsciiInputAtRef.current = Date.now();
+    }
     const key: MultilineKey = {
       input: ev.input,
       return: ev.return,
@@ -140,6 +160,10 @@ export function PromptInput({
       setCursor(action.cursor);
     }
     if (action.submit) {
+      if (Date.now() - lastNonAsciiInputAtRef.current < IME_GUARD_MS) {
+        lastNonAsciiInputAtRef.current = 0;
+        return;
+      }
       const raw = action.submitValue ?? lastLocalValueRef.current;
       const expanded = expandPasteSentinels(raw, pastesRef.current);
       const reachable = new Set(listPasteIdsInBuffer(raw));


### PR DESCRIPTION
## What
Detect non-ASCII (CJK) input bursts on the TUI prompt's keystroke stream and drop the immediately-following Enter as the IME-commit Enter, with a 50ms window.

## Why
Pressing Enter to commit a candidate from a CJK IME (Microsoft Pinyin, Sogou, etc.) sends the committed text *and* then the Enter that triggered the commit through to the TTY as a real keystroke. Terminals don't expose IME composition state, so the chat composer was treating that Enter as "send message" and submitting whatever the user had so far. Reported in #1136.

## Approach
- Stamp `lastNonAsciiInputAtRef = Date.now()` whenever a keystroke chunk contains a byte > 0x7F.
- When a submit action fires within `IME_GUARD_MS` (50ms) of that stamp, drop the submit and reset the timestamp.
- The next Enter — after the human pauses to read what was committed — fires normally.

## Why 50ms
Human key-up to key-down for separate intentional keystrokes is ≥80ms in practice. IME commit-then-Enter arrives in the same terminal output flush (microseconds apart). 50ms is comfortably in the middle, so:
- A real "type Chinese, then send" sequence still submits the moment the user actually presses Enter to send.
- The IME's incidental Enter is dropped.

## Trade-off
False positive: if the user pastes CJK content then *instantly* hits Enter to submit (faster than 50ms), the first Enter is dropped. Self-corrects on the next press. Acceptable given the alternative is the current "wrong send" bug.

## How to verify
- `npm run verify` passes locally (only file changed is `src/cli/ui/PromptInput.tsx`, +24 lines).
- Manual: in `reasonix code`, switch to a Chinese IME, type some characters, hit Enter to commit a candidate — the message no longer submits. Hit Enter again after a brief pause and the message goes through.

Closes #1136
