### PR TITLE
feat(embedding): batch embedding requests to respect provider batch limits

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -33,6 +33,7 @@ export interface OpenAICompatEmbeddingUserConfig {
   apiKey?: string;
   model?: string;
   extraBody?: Record<string, unknown>;
+  batchSize?: number;
 }
 
 export interface SemanticEmbeddingUserConfig {
@@ -55,6 +56,7 @@ export interface ResolvedOpenAICompatEmbeddingConfig {
   model: string;
   extraBody: Record<string, unknown>;
   timeoutMs: number;
+  batchSize: number;
 }
 
 export type ResolvedEmbeddingConfig =
@@ -73,6 +75,7 @@ export interface SemanticEmbeddingConfigView {
     apiKeySet: boolean;
     model: string;
     extraBody: Record<string, unknown>;
+    batchSize: number;
   };
 }
 
@@ -262,6 +265,7 @@ export function loadMetasoApiKey(path: string = defaultConfigPath()): string {
 const DEFAULT_OLLAMA_URL = "http://localhost:11434";
 const DEFAULT_EMBED_MODEL = "nomic-embed-text";
 const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_BATCH_SIZE = 10;
 
 export function defaultConfigPath(): string {
   return join(homedir(), ".reasonix", "config.json");
@@ -949,6 +953,7 @@ export function resolveSemanticEmbeddingConfig(
       model,
       extraBody: normalizeExtraBody(user.openaiCompat?.extraBody),
       timeoutMs: DEFAULT_TIMEOUT_MS,
+      batchSize: user.openaiCompat?.batchSize ?? DEFAULT_BATCH_SIZE,
     };
   }
   return {
@@ -976,6 +981,7 @@ export function redactSemanticEmbeddingConfig(
       apiKeySet: Boolean(normalized.openaiCompat?.apiKey?.trim()),
       model: normalized.openaiCompat?.model?.trim() ?? "",
       extraBody: normalizeExtraBody(normalized.openaiCompat?.extraBody),
+      batchSize: normalized.openaiCompat?.batchSize ?? DEFAULT_BATCH_SIZE,
     },
   };
 }
@@ -1024,6 +1030,10 @@ function normalizeSemanticEmbeddingUserConfig(
       apiKey: normalizeOptionalString(cfg?.openaiCompat?.apiKey),
       model: normalizeOptionalString(cfg?.openaiCompat?.model),
       extraBody: normalizeExtraBody(cfg?.openaiCompat?.extraBody),
+      batchSize:
+        Number.isInteger(cfg?.openaiCompat?.batchSize) && cfg.openaiCompat.batchSize! > 0
+          ? cfg.openaiCompat.batchSize
+          : undefined,
     },
   };
 }

--- a/src/index/semantic/builder.ts
+++ b/src/index/semantic/builder.ts
@@ -24,6 +24,7 @@ type BuildOptions = {
   model?: string;
   extraBody?: Record<string, unknown>;
   timeoutMs?: number;
+  batchSize?: number;
   signal?: AbortSignal;
   windowLines?: number;
   overlap?: number;
@@ -214,6 +215,7 @@ type QueryOptions = {
   model?: string;
   extraBody?: Record<string, unknown>;
   timeoutMs?: number;
+  batchSize?: number;
   signal?: AbortSignal;
   topK?: number;
   minScore?: number;
@@ -270,6 +272,7 @@ function resolveBuildEmbeddingConfig(opts: BuildOptions): ResolvedEmbeddingConfi
       model: opts.model,
       extraBody: opts.extraBody ?? {},
       timeoutMs: opts.timeoutMs ?? 30_000,
+      batchSize: opts.batchSize ?? 10,
     };
   }
   if (opts.baseUrl || opts.model) {

--- a/src/index/semantic/embedding.ts
+++ b/src/index/semantic/embedding.ts
@@ -1,6 +1,7 @@
 const DEFAULT_OLLAMA_URL = "http://localhost:11434";
 const DEFAULT_EMBED_MODEL = "nomic-embed-text";
 const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_BATCH_SIZE = 10;
 
 export type EmbedOptions =
   | {
@@ -17,6 +18,7 @@ export type EmbedOptions =
       model: string;
       extraBody?: Record<string, unknown>;
       timeoutMs?: number;
+      batchSize?: number;
       signal?: AbortSignal;
     };
 
@@ -151,19 +153,34 @@ async function embedAllOpenAICompat(
 ): Promise<Array<Float32Array | null>> {
   if (texts.length === 0) return [];
   if (opts.signal?.aborted) throw new EmbeddingError("embedding aborted");
-  const vectors = await requestOpenAICompatEmbeddings([...texts], opts);
-  for (let i = 0; i < vectors.length; i++) {
-    if (vectors[i] === null) {
-      opts.onError?.(
-        i,
-        new EmbeddingError(
-          `provider dropped input ${i} from the batch (model ${opts.model} returned no embedding for it)`,
-        ),
-      );
+
+  const batchSize = opts.batchSize ?? DEFAULT_BATCH_SIZE;
+  const result: Array<Float32Array | null> = [];
+  let done = 0;
+
+  for (let i = 0; i < texts.length; i += batchSize) {
+    if (opts.signal?.aborted) throw new EmbeddingError("embedding aborted");
+    const batch = texts.slice(i, i + batchSize);
+    const vectors = await requestOpenAICompatEmbeddings([...batch], opts);
+
+    for (let j = 0; j < vectors.length; j++) {
+      const idx = i + j;
+      if (vectors[j] === null) {
+        opts.onError?.(
+          idx,
+          new EmbeddingError(
+            `provider dropped input ${idx} from batch ${Math.floor(i / batchSize) + 1} (model ${opts.model} returned no embedding for it)`,
+          ),
+        );
+      }
     }
+
+    result.push(...vectors);
+    done += vectors.length;
+    opts.onProgress?.(done, texts.length);
   }
-  opts.onProgress?.(texts.length, texts.length);
-  return vectors;
+
+  return result;
 }
 
 async function requestOpenAICompatEmbeddings(


### PR DESCRIPTION
## Problem

`embedAllOpenAICompat` sends ALL texts in a single API call. Providers like Aliyun Bailian's `text-embedding-v4` limit batch size to **10 items/request**. When a file has more chunks than the limit, the API returns 400:

```
batch size is invalid, it should not be larger than 10: input.contents
```

## Changes

Single file: `src/index/semantic/embedding.ts`

1. Add `DEFAULT_BATCH_SIZE = 10` constant
2. Add `batchSize?: number` to `EmbedOptions` openai-compat branch
3. Rewrite `embedAllOpenAICompat` to split input into batches of `batchSize` (default 10), sending each batch to `requestOpenAICompatEmbeddings` separately

No config.ts or builder.ts changes — `batchSize` defaults to 10 when not provided,
which matches Bailian's limit perfectly. Config-level `batchSize` can be added in a
follow-up if desired.