### PR TITLE
feat(embedding): batch OpenAI-compat embedding requests to respect provider batch limits

### DIFF
--- a/dashboard/src/i18n/en.ts
+++ b/dashboard/src/i18n/en.ts
@@ -614,6 +614,7 @@ export const en = {
     customRequestBodyMustBeObject: "Custom request body must be a JSON object.",
     saveBeforeIndex: "Save semantic settings before starting an index.",
     extraBody: "extra body",
+    batchSize: "batch size",
     keepExistingKey: "leave blank to keep existing key",
     remoteProvider: "Remote embedding provider",
     remoteProviderDesc:

--- a/dashboard/src/i18n/zh-CN.ts
+++ b/dashboard/src/i18n/zh-CN.ts
@@ -587,6 +587,7 @@ export const zhCN = {
     customRequestBodyMustBeObject: "自定义请求体必须是 JSON 对象。",
     saveBeforeIndex: "请先保存语义设置，再启动索引。",
     extraBody: "扩展请求体",
+    batchSize: "批次大小",
     keepExistingKey: "留空则保留现有 Key",
     remoteProvider: "远程向量服务",
     remoteProviderDesc:

--- a/dashboard/src/panels/semantic.ts
+++ b/dashboard/src/panels/semantic.ts
@@ -16,6 +16,7 @@ interface SemanticConfigView {
     apiKeySet: boolean;
     model: string;
     extraBody: Record<string, unknown>;
+    batchSize: number;
   };
 }
 
@@ -44,6 +45,7 @@ interface SemanticData {
         apiKeySet: boolean;
         model: string;
         extraBodyKeys: string[];
+        batchSize: number;
       };
   index?: IndexInfo;
   job?: SemanticJob | null;
@@ -106,6 +108,7 @@ interface SemanticConfigDraft {
     apiKey: string;
     model: string;
     extraBodyText: string;
+    batchSize: number;
     apiKeySet: boolean;
   };
 }
@@ -243,6 +246,7 @@ export function SemanticPanel() {
             apiKey: draft.openaiCompat.apiKey,
             model: draft.openaiCompat.model,
             extraBody,
+            batchSize: draft.openaiCompat.batchSize,
           },
         },
       });
@@ -409,6 +413,27 @@ export function SemanticPanel() {
                         openaiCompat: {
                           ...draft.openaiCompat,
                           model: (e.target as HTMLInputElement).value,
+                        },
+                      });
+                    }}
+                  />
+                </div>
+                <div class="form-row">
+                  <span class="lbl">${t("semantic.batchSize")}</span>
+                  <input
+                    class="input mono"
+                    type="number"
+                    min="1"
+                    value=${draft.openaiCompat.batchSize}
+                    onInput=${(e: Event) => {
+                      const v = Number.parseInt((e.target as HTMLInputElement).value, 10);
+                      draftDirtyRef.current = true;
+                      setDraftDirty(true);
+                      setDraft({
+                        ...draft,
+                        openaiCompat: {
+                          ...draft.openaiCompat,
+                          batchSize: Number.isInteger(v) && v > 0 ? v : 10,
                         },
                       });
                     }}
@@ -600,6 +625,7 @@ export function SemanticPanel() {
                 <div class="rail-kv"><span class="k">${t("semantic.apiKey")}</span><span class="v">${remote?.apiKeySet ? html`<span class="pill ok">${t("semantic.found")}</span>` : html`<span class="pill warn">${t("semantic.missing")}</span>`}</span></div>
                 <div class="rail-kv"><span class="k">${t("semantic.model")}</span><span class="v" style="font-size:11px">${remote?.model ?? draft.openaiCompat.model}</span></div>
                 <div class="rail-kv"><span class="k">${t("semantic.extraBody")}</span><span class="v">${fmtNum(remote?.extraBodyKeys.length ?? 0)}</span></div>
+                <div class="rail-kv"><span class="k">${t("semantic.batchSize")}</span><span class="v">${remote?.batchSize ?? 10}</span></div>
               `
           }
         </div>
@@ -622,6 +648,7 @@ function toConfigDraft(config: SemanticConfigView): SemanticConfigDraft {
       apiKey: "",
       model: config.openaiCompat.model,
       extraBodyText: JSON.stringify(config.openaiCompat.extraBody ?? {}, null, 2),
+      batchSize: config.openaiCompat.batchSize,
       apiKeySet: config.openaiCompat.apiKeySet,
     },
   };

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,6 +33,7 @@ export interface OpenAICompatEmbeddingUserConfig {
   apiKey?: string;
   model?: string;
   extraBody?: Record<string, unknown>;
+  batchSize?: number;
 }
 
 export interface SemanticEmbeddingUserConfig {
@@ -55,6 +56,7 @@ export interface ResolvedOpenAICompatEmbeddingConfig {
   model: string;
   extraBody: Record<string, unknown>;
   timeoutMs: number;
+  batchSize: number;
 }
 
 export type ResolvedEmbeddingConfig =
@@ -73,6 +75,7 @@ export interface SemanticEmbeddingConfigView {
     apiKeySet: boolean;
     model: string;
     extraBody: Record<string, unknown>;
+    batchSize: number;
   };
 }
 
@@ -262,6 +265,7 @@ export function loadMetasoApiKey(path: string = defaultConfigPath()): string {
 const DEFAULT_OLLAMA_URL = "http://localhost:11434";
 const DEFAULT_EMBED_MODEL = "nomic-embed-text";
 const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_BATCH_SIZE = 10;
 
 export function defaultConfigPath(): string {
   return join(homedir(), ".reasonix", "config.json");
@@ -949,6 +953,7 @@ export function resolveSemanticEmbeddingConfig(
       model,
       extraBody: normalizeExtraBody(user.openaiCompat?.extraBody),
       timeoutMs: DEFAULT_TIMEOUT_MS,
+      batchSize: user.openaiCompat?.batchSize ?? DEFAULT_BATCH_SIZE,
     };
   }
   return {
@@ -976,6 +981,7 @@ export function redactSemanticEmbeddingConfig(
       apiKeySet: Boolean(normalized.openaiCompat?.apiKey?.trim()),
       model: normalized.openaiCompat?.model?.trim() ?? "",
       extraBody: normalizeExtraBody(normalized.openaiCompat?.extraBody),
+      batchSize: normalized.openaiCompat?.batchSize ?? DEFAULT_BATCH_SIZE,
     },
   };
 }
@@ -1024,6 +1030,7 @@ function normalizeSemanticEmbeddingUserConfig(
       apiKey: normalizeOptionalString(cfg?.openaiCompat?.apiKey),
       model: normalizeOptionalString(cfg?.openaiCompat?.model),
       extraBody: normalizeExtraBody(cfg?.openaiCompat?.extraBody),
+      batchSize: normalizePositiveInt(cfg?.openaiCompat?.batchSize),
     },
   };
 }
@@ -1031,6 +1038,10 @@ function normalizeSemanticEmbeddingUserConfig(
 function normalizeOptionalString(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
   return trimmed ? trimmed : undefined;
+}
+
+function normalizePositiveInt(value: number | undefined): number | undefined {
+  return value !== undefined && Number.isInteger(value) && value > 0 ? value : undefined;
 }
 
 function normalizeExtraBody(value: Record<string, unknown> | undefined): Record<string, unknown> {

--- a/src/index/semantic/builder.ts
+++ b/src/index/semantic/builder.ts
@@ -24,6 +24,7 @@ type BuildOptions = {
   model?: string;
   extraBody?: Record<string, unknown>;
   timeoutMs?: number;
+  batchSize?: number;
   signal?: AbortSignal;
   windowLines?: number;
   overlap?: number;
@@ -214,6 +215,7 @@ type QueryOptions = {
   model?: string;
   extraBody?: Record<string, unknown>;
   timeoutMs?: number;
+  batchSize?: number;
   signal?: AbortSignal;
   topK?: number;
   minScore?: number;
@@ -270,6 +272,7 @@ function resolveBuildEmbeddingConfig(opts: BuildOptions): ResolvedEmbeddingConfi
       model: opts.model,
       extraBody: opts.extraBody ?? {},
       timeoutMs: opts.timeoutMs ?? 30_000,
+      batchSize: opts.batchSize ?? 10,
     };
   }
   if (opts.baseUrl || opts.model) {

--- a/src/index/semantic/embedding.ts
+++ b/src/index/semantic/embedding.ts
@@ -1,6 +1,7 @@
 const DEFAULT_OLLAMA_URL = "http://localhost:11434";
 const DEFAULT_EMBED_MODEL = "nomic-embed-text";
 const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_BATCH_SIZE = 10;
 
 export type EmbedOptions =
   | {
@@ -17,6 +18,7 @@ export type EmbedOptions =
       model: string;
       extraBody?: Record<string, unknown>;
       timeoutMs?: number;
+      batchSize?: number;
       signal?: AbortSignal;
     };
 
@@ -151,19 +153,34 @@ async function embedAllOpenAICompat(
 ): Promise<Array<Float32Array | null>> {
   if (texts.length === 0) return [];
   if (opts.signal?.aborted) throw new EmbeddingError("embedding aborted");
-  const vectors = await requestOpenAICompatEmbeddings([...texts], opts);
-  for (let i = 0; i < vectors.length; i++) {
-    if (vectors[i] === null) {
-      opts.onError?.(
-        i,
-        new EmbeddingError(
-          `provider dropped input ${i} from the batch (model ${opts.model} returned no embedding for it)`,
-        ),
-      );
+
+  const batchSize = opts.batchSize ?? DEFAULT_BATCH_SIZE;
+  const result: Array<Float32Array | null> = [];
+  let done = 0;
+
+  for (let i = 0; i < texts.length; i += batchSize) {
+    if (opts.signal?.aborted) throw new EmbeddingError("embedding aborted");
+    const batch = texts.slice(i, i + batchSize);
+    const vectors = await requestOpenAICompatEmbeddings([...batch], opts);
+
+    for (let j = 0; j < vectors.length; j++) {
+      const idx = i + j;
+      if (vectors[j] === null) {
+        opts.onError?.(
+          idx,
+          new EmbeddingError(
+            `provider dropped input ${idx} from batch ${Math.floor(i / batchSize) + 1} (model ${opts.model} returned no embedding for it)`,
+          ),
+        );
+      }
     }
+
+    result.push(...vectors);
+    done += vectors.length;
+    opts.onProgress?.(done, texts.length);
   }
-  opts.onProgress?.(texts.length, texts.length);
-  return vectors;
+
+  return result;
 }
 
 async function requestOpenAICompatEmbeddings(

--- a/src/index/semantic/tool.ts
+++ b/src/index/semantic/tool.ts
@@ -9,6 +9,7 @@ type SemanticToolOptions = {
   model?: string;
   extraBody?: Record<string, unknown>;
   timeoutMs?: number;
+  batchSize?: number;
   root: string;
   defaultTopK?: number;
   defaultMinScore?: number;
@@ -57,6 +58,7 @@ export async function registerSemanticSearchTool(
         apiKey: opts.apiKey,
         model: opts.model,
         extraBody: opts.extraBody,
+        batchSize: opts.batchSize,
         signal: ctx?.signal,
       });
       if (hits === null) {

--- a/src/server/api/semantic.ts
+++ b/src/server/api/semantic.ts
@@ -485,6 +485,7 @@ function saveSemanticConfigApi(rawBody: string, ctx: DashboardContext): ApiResul
       apiKey?: unknown;
       model?: unknown;
       extraBody?: unknown;
+      batchSize?: unknown;
     };
   };
   try {
@@ -520,6 +521,13 @@ function saveSemanticConfigApi(rawBody: string, ctx: DashboardContext): ApiResul
         parsed.openaiCompat?.extraBody === undefined
           ? existing.openaiCompat?.extraBody
           : (parsed.openaiCompat.extraBody as Record<string, unknown>),
+      batchSize:
+        parsed.openaiCompat?.batchSize === undefined
+          ? existing.openaiCompat?.batchSize
+          : Number.isInteger(parsed.openaiCompat.batchSize) &&
+              (parsed.openaiCompat.batchSize as number) > 0
+            ? (parsed.openaiCompat.batchSize as number)
+            : undefined,
     },
   };
   try {
@@ -572,6 +580,7 @@ async function getProviderStatusFromConfig(
       apiKeySet: boolean;
       model: string;
       extraBodyKeys: string[];
+      batchSize: number;
     }
 > {
   if (config.provider === "openai-compat") {
@@ -584,6 +593,7 @@ async function getProviderStatusFromConfig(
       apiKeySet: config.openaiCompat.apiKeySet,
       model: config.openaiCompat.model,
       extraBodyKeys: Object.keys(config.openaiCompat.extraBody),
+      batchSize: config.openaiCompat.batchSize,
     };
   }
   const ollama = await checkOllamaStatus(config.ollama.model, config.ollama.baseUrl).catch(
@@ -625,6 +635,7 @@ async function getProviderStatus(
       apiKeySet: boolean;
       model: string;
       extraBodyKeys: string[];
+      batchSize: number;
     }
 > {
   if (resolved.provider === "openai-compat") {
@@ -635,6 +646,7 @@ async function getProviderStatus(
       apiKeySet: Boolean(resolved.apiKey),
       model: resolved.model,
       extraBodyKeys: Object.keys(resolved.extraBody),
+      batchSize: resolved.batchSize,
     };
   }
   const ollama = await checkOllamaStatus(resolved.model, resolved.baseUrl).catch((err) => ({


### PR DESCRIPTION
## Problem

`embedAllOpenAICompat` sends ALL texts in a single API call. Providers like Aliyun Bailian's `text-embedding-v4` limit batch size to **10 items/request**. When a file has more chunks than the limit, the API returns 400.

## Changes

- **`src/index/semantic/embedding.ts`** — core fix: split input into batches of `batchSize` (default 10)
- **`src/config.ts`** — thread `batchSize` through `OpenAICompatEmbeddingUserConfig`, `ResolvedOpenAICompatEmbeddingConfig`, `SemanticEmbeddingConfigView`, and resolve/normalize/view functions
- **`src/index/semantic/builder.ts`** — pass `batchSize` through `BuildOptions`, `QueryOptions`, `resolveBuildEmbeddingConfig`

## Configuration

```json
{
  "semantic": {
    "provider": "openai-compat",
    "openaiCompat": {
      "baseUrl": "https://dashscope.aliyuncs.com/compatible-mode/v1/embeddings",
      "apiKey": "sk-xxx",
      "model": "text-embedding-v4",
      "extraBody": { "dimensions": 1024 }
    }
  }
}
```

`batchSize` defaults to 10 — matches Bailian's limit, no explicit config needed.