### PR TITLE
fix(desktop): replace right-click-to-delete with a discoverable hover X

### DIFF
--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -1061,6 +1061,34 @@ html[data-platform="macos"] .titlebar .tb-left {
 .session-item .body .meta .sep {
   color: var(--border-strong);
 }
+.session-item .delete-btn {
+  flex-shrink: 0;
+  width: 22px;
+  height: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 120ms, background 120ms, color 120ms;
+}
+.session-item:hover .delete-btn,
+.session-item:focus-within .delete-btn,
+.session-item .delete-btn:focus-visible {
+  opacity: 1;
+}
+.session-item .delete-btn:hover {
+  background: var(--panel-2, rgba(255, 80, 80, 0.12));
+  color: var(--danger, #e25555);
+}
+.session-item .delete-btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--accent-soft);
+}
 
 /* ---- right-click session menu ---- */
 .session-menu {

--- a/desktop/src/ui/sidebar.tsx
+++ b/desktop/src/ui/sidebar.tsx
@@ -146,15 +146,6 @@ export function Sidebar({
                 className="session-item"
                 data-active={active}
                 onClick={() => onLoadSession(s.name)}
-                onContextMenu={(e) => {
-                  e.preventDefault();
-                  setPendingDelete({
-                    name: s.name,
-                    pretty: prettyName(s),
-                    x: e.clientX,
-                    y: e.clientY,
-                  });
-                }}
                 role="button"
                 tabIndex={0}
                 title={s.name}
@@ -174,6 +165,27 @@ export function Sidebar({
                     <span>{updated}</span>
                   </span>
                 </div>
+                <button
+                  type="button"
+                  className="delete-btn"
+                  title="删除会话"
+                  aria-label="删除会话"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    const rect = e.currentTarget.getBoundingClientRect();
+                    setPendingDelete({
+                      name: s.name,
+                      pretty: prettyName(s),
+                      x: rect.right,
+                      y: rect.bottom,
+                    });
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") e.stopPropagation();
+                  }}
+                >
+                  <I.x size={12} />
+                </button>
               </div>
             );
           })}


### PR DESCRIPTION
## What
Remove the `onContextMenu` (right-click) handler on each session item in the desktop sidebar. Surface deletion via a small `X` icon inside the row, hidden by default and revealed on `:hover` / `:focus-within`.

## Why
Right-click on a list item doesn't read as "delete" in any standard desktop UI (Finder, Explorer, VS Code, Cursor — all of them open a context menu with multiple options on right-click, never a delete dialog). The popover introduced in #906 obscured the row enough that users in #1116 perceived sessions as "disappeared". One commenter explicitly asked whether right-click-to-delete was a bug or intentional, which is a strong discoverability signal.

A hover-revealed `X` is the convention every chat-with-session-list UI uses (Claude, ChatGPT, Cursor, etc.), and it leaves left-click free to mean what it has always meant: "open this session".

## How
- Remove `onContextMenu` from the row.
- Add a `<button class="delete-btn">` after `.body` in the row. `stopPropagation` keeps its click from also firing the row's `onClick` (which loads the session).
- CSS hides the button at `opacity: 0` by default, reveals at `1` on `.session-item:hover`, `.session-item:focus-within`, and `.delete-btn:focus-visible` — so keyboard navigation still reaches it.
- Anchor the existing delete popover to the icon's bounding rect instead of the cursor coordinates.

The popover itself, its dismiss-on-outside-click + Esc handling, and the auto-focused Cancel button (so Enter cancels by default) all stay — only the entry gesture changes.

Closes #1116
