### PR TITLE
fix(desktop): Ctrl+K → About opens the modal, not a one-line toast

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -1250,7 +1250,7 @@ function TabRuntime({
     },
     focusComposer: () => composerRef.current?.focus(),
     openSettings: () => openSettingsAt("general"),
-    about: () => flashToast(`Reasonix · ${state.settings?.version ?? "dev"}`),
+    about: () => setAboutOpen(true),
     abort,
     copyLast: () => {
       const last = [...state.messages].reverse().find((m) => m.kind === "assistant");


### PR DESCRIPTION
The command-palette `about` handler was wired to `flashToast("Reasonix · …")` from before the AboutModal existed (#1183). With the modal in place, route the palette entry to the same `setAboutOpen(true)` the sidebar row uses so Ctrl+K → About is consistent with clicking the sidebar entry.