### PR TITLE
feat(desktop): disable right-click and DevTools in production builds

### DIFF
--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = ["devtools", "macos-private-api"] }
+tauri = { version = "2", features = ["macos-private-api"] }
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
 tauri-plugin-opener = "2"

--- a/desktop/src/main.tsx
+++ b/desktop/src/main.tsx
@@ -11,6 +11,7 @@ import "@fontsource/inter/600.css";
 import "@fontsource/inter/700.css";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
+import { applyProductionLockdown } from "./prod-guard";
 import { isTheme } from "./theme";
 
 const stored = localStorage.getItem("reasonix.theme");
@@ -21,6 +22,8 @@ if (isTheme(stored)) {
 const platform = /Mac|macOS/i.test(navigator.userAgent) ? "macos" : "default";
 document.documentElement.dataset.platform = platform;
 document.body.dataset.platform = platform;
+
+applyProductionLockdown();
 
 const host = document.getElementById("root");
 if (!host) throw new Error("#root missing");

--- a/desktop/src/prod-guard.ts
+++ b/desktop/src/prod-guard.ts
@@ -1,0 +1,15 @@
+// Release builds also drop the `devtools` Cargo feature, so the inspector
+// is compiled out entirely — this only needs to handle the context menu.
+
+// Inputs keep their native menu so copy/paste still works; everything else loses it.
+function isEditable(el: EventTarget | null): boolean {
+  if (!(el instanceof HTMLElement)) return false;
+  return el.isContentEditable || el.tagName === "INPUT" || el.tagName === "TEXTAREA";
+}
+
+export function applyProductionLockdown(): void {
+  if (import.meta.env.DEV) return;
+  window.addEventListener("contextmenu", (e) => {
+    if (!isEditable(e.target)) e.preventDefault();
+  });
+}

--- a/desktop/src/vite-env.d.ts
+++ b/desktop/src/vite-env.d.ts
@@ -1,1 +1,3 @@
+/// <reference types="vite/client" />
+
 declare const __APP_VERSION__: string;


### PR DESCRIPTION
## What

Locks down the desktop app in **release builds only** — right-click
context menu and DevTools are no longer reachable by end users.
`tauri dev` keeps both for development.

- **DevTools** — drop the `devtools` Cargo feature. Tauri auto-enables
  the inspector on debug builds, so `tauri dev` is unchanged; release
  builds compile it out entirely. The single `open_devtools()` call is
  already `#[cfg(debug_assertions)]`-gated, so release still compiles.
- **Context menu** — `prod-guard.ts` suppresses the `contextmenu` event
  in production, gated on `import.meta.env.DEV`. Inputs / textareas /
  contenteditable are exempt so native copy-paste still works.
- Add `vite/client` types to `vite-env.d.ts` for `import.meta.env`.

## Why

Closes #1187. The web inspector exposes internal state, source and the
IPC surface — it shouldn't ship to end users. Disabling the context
menu also removes the "Inspect Element" GUI path.

## How to verify

- `npm run verify` (lint + typecheck + tests + comment-policy gate).
- `cd desktop && npm run tauri dev` — right-click works, DevTools opens.
- `cd desktop && npm run tauri build` — right-click is suppressed
  (except in text fields), DevTools cannot be opened.
- `cargo check` and `cargo check --release` both pass.

## Screenshots

n/a — no visible UI change.

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time
