### PR TITLE
fix(desktop): also re-pin auto-scroll on turn start, not just turn end

### DIFF
--- a/desktop/src/ui/useAutoScroll.ts
+++ b/desktop/src/ui/useAutoScroll.ts
@@ -84,9 +84,10 @@ export function useAutoScroll(
     };
   }, [containerRef, isAtBottom, refreshJumpButton]);
 
-  // When busy→idle (turn completes), re-pin and scroll to final answer.
+  // Both busy edges re-pin: turn start = user just sent and expects to
+  // see the reply; turn end = settle on the final answer (issue #1182).
   useEffect(() => {
-    if (wasBusyRef.current && !busy) {
+    if (wasBusyRef.current !== busy) {
       scrollToBottom(true);
     }
     wasBusyRef.current = busy;


### PR DESCRIPTION
## Problem

If the user had scrolled up earlier (un-pinned) and then sent a new
message, the new turn rendered off-screen until either the turn
completed or streaming happened to land them back at the bottom. The
user had to manually scroll down on every reply.

## Fix

Treat both \`busy\` edges the same in \`useAutoScroll\`:

- Turn start (busy: false → true) — user just sent and expects to see
  the new turn.
- Turn end (busy: true → false) — settle on the final answer (existing
  behavior).

One-line condition change from \`wasBusyRef.current && !busy\` to
\`wasBusyRef.current !== busy\`.

## Verify

- \`npm run verify\` — green (lint + typecheck + 3120 tests).
- Manual: scroll up mid-conversation, send a new message → view jumps
  to the new turn immediately, streaming follows.

Closes #1182