### PR TITLE
fix(mcp): surface actual bridge-failure reason in dashboard, not just "restart"

### DIFF
--- a/dashboard/src/i18n/en.ts
+++ b/dashboard/src/i18n/en.ts
@@ -431,6 +431,10 @@ export const en = {
     whyUnbridgedDesc:
       "This spec lives in your config.json but isn't bridged into the live session. MCP servers attach when reasonix code starts; the dashboard alone can't spawn the child process.",
     whyUnbridgedHint: "To activate: restart reasonix code, then refresh this dashboard.",
+    bridgeFailed: "Bridge failed",
+    bridgeFailedTitle: "bridge failed · in config",
+    bridgeFailedHint:
+      "Reasonix tried to bridge this server and the attempt errored. Common causes: wrong URL, missing auth header, upstream 404/5xx, missing local command. Fix and restart reasonix code to retry.",
     pickHint: "Pick an MCP server on the left to inspect tools / resources / prompts.",
     toolsTitle: "Tools · {count}",
     resourcesTitle: "Resources · {count}",

--- a/dashboard/src/i18n/zh-CN.ts
+++ b/dashboard/src/i18n/zh-CN.ts
@@ -407,6 +407,10 @@ export const zhCN = {
     whyUnbridgedDesc:
       "此规格存在于您的 config.json 中，但未桥接到实时会话。MCP 服务器在 reasonix code 启动时连接；仪表盘本身无法生成子进程。",
     whyUnbridgedHint: "激活方法：重启 reasonix code，然后刷新此仪表盘。",
+    bridgeFailed: "桥接失败",
+    bridgeFailedTitle: "桥接失败 · 在配置中",
+    bridgeFailedHint:
+      "已尝试桥接但失败。常见原因：URL 错误、需要鉴权、上游 404 / 5xx、本地命令缺失。修复后重启 reasonix code 重试。",
     pickHint: "选择左侧的 MCP 服务器以检查工具 / 资源 / 提示。",
     toolsTitle: "工具 · {count}",
     resourcesTitle: "资源 · {count}",

--- a/dashboard/src/panels/mcp.ts
+++ b/dashboard/src/panels/mcp.ts
@@ -85,10 +85,18 @@ interface RegistryListResponse {
 
 type McpFilter = "all" | "live" | "unbridged" | "marketplace";
 
+interface McpFailure {
+  spec: string;
+  name: string;
+  reason: string;
+  at: number;
+}
+
 export function McpPanel() {
   useLang();
   const [data, setData] = useState<McpData | null>(null);
   const [specs, setSpecs] = useState<string[] | null>(null);
+  const [failures, setFailures] = useState<McpFailure[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [info, setInfo] = useState<string | null>(null);
   const [newSpec, setNewSpec] = useState("");
@@ -171,11 +179,27 @@ export function McpPanel() {
           spec: normalizeMcpSpec(server.spec) ?? "",
         })),
       });
-      const specResponse = await api<{ specs?: unknown[] }>("/mcp/specs");
+      const specResponse = await api<{ specs?: unknown[]; failures?: unknown[] }>("/mcp/specs");
       const normalized = (Array.isArray(specResponse.specs) ? specResponse.specs : [])
         .map(normalizeMcpSpec)
         .filter((spec): spec is string => spec !== null && spec.length > 0);
       setSpecs(normalized);
+      const rawFailures = Array.isArray(specResponse.failures) ? specResponse.failures : [];
+      const validFailures: McpFailure[] = [];
+      for (const f of rawFailures) {
+        if (typeof f !== "object" || f === null) continue;
+        const o = f as Record<string, unknown>;
+        const rawSpec = typeof o.spec === "string" ? o.spec : "";
+        const norm = normalizeMcpSpec(rawSpec);
+        if (!norm) continue;
+        validFailures.push({
+          spec: norm,
+          name: typeof o.name === "string" ? o.name : "",
+          reason: typeof o.reason === "string" ? o.reason : "",
+          at: typeof o.at === "number" ? o.at : 0,
+        });
+      }
+      setFailures(validFailures);
     } catch (err) {
       setError((err as Error).message);
     }
@@ -341,8 +365,9 @@ export function McpPanel() {
           }
           ${
             showUnbridged
-              ? unbridgedSpecs.map(
-                  (spec) => html`
+              ? unbridgedSpecs.map((spec) => {
+                  const failure = failures.find((f) => f.spec === spec);
+                  return html`
                   <div
                     class=${`ssl-row ${openUnbridged === spec ? "sel" : ""}`}
                     onClick=${() => {
@@ -350,12 +375,12 @@ export function McpPanel() {
                       setOpen(null);
                     }}
                   >
-                    <span class="name">${specLabel(spec)} <span class="pill">${t("mcp.unbridged")}</span></span>
+                    <span class="name">${specLabel(spec)} <span class=${`pill ${failure ? "err" : ""}`}>${failure ? t("mcp.bridgeFailed") : t("mcp.unbridged")}</span></span>
                     <span class="preview">${specCommand(spec)}</span>
-                    <span class="meta"><span class="dim">${t("mcp.inConfig")}</span></span>
+                    <span class="meta"><span class=${failure ? "" : "dim"} style=${failure ? "color:var(--c-err)" : ""}>${failure ? failure.reason : t("mcp.inConfig")}</span></span>
                   </div>
-                `,
-                )
+                `;
+                })
               : null
           }
         </div>
@@ -376,10 +401,12 @@ export function McpPanel() {
                 onClose: () => setOpenRegistry(null),
               })
             : openUnbridged != null
-              ? html`
+              ? (() => {
+                  const failure = failures.find((f) => f.spec === openUnbridged);
+                  return html`
               <div class="sessions-detail-h">
                 <span class="name">${specLabel(openUnbridged)}</span>
-                <span class="ws"><span class="pill">${t("mcp.unbridgedTitle")}</span></span>
+                <span class="ws"><span class="pill">${failure ? t("mcp.bridgeFailedTitle") : t("mcp.unbridgedTitle")}</span></span>
                 <span class="actions">
                   <button class="btn" disabled=${busy} onClick=${() => removeSpec(openUnbridged)}
                     style="border-color:var(--c-err);color:var(--c-err)">${t("mcp.removeBtn")}</button>
@@ -390,16 +417,29 @@ export function McpPanel() {
                 <div class="card-h"><span class="title">${t("mcp.spec")}</span></div>
                 <code class="mono" style="font-size:11.5px;color:var(--fg-2);word-break:break-all">${openUnbridged}</code>
               </div>
-              <div class="card accent-warn">
-                <div class="card-h"><span class="title" style="color:var(--c-warn)">${t("mcp.whyUnbridged")}</span></div>
-                <div class="card-b" style="font-size:13px;line-height:1.6">
-                  ${t("mcp.whyUnbridgedDesc")}
-                  <div style="margin-top:10px;color:var(--fg-3);font-size:12px">
-                    ${t("mcp.whyUnbridgedHint")}
-                  </div>
-                </div>
-              </div>
-            `
+              ${
+                failure
+                  ? html`<div class="card accent-err">
+                      <div class="card-h"><span class="title" style="color:var(--c-err)">${t("mcp.bridgeFailed")}</span></div>
+                      <div class="card-b" style="font-size:13px;line-height:1.6">
+                        <code class="mono" style="font-size:12px;color:var(--fg-1);word-break:break-word;white-space:pre-wrap">${failure.reason}</code>
+                        <div style="margin-top:10px;color:var(--fg-3);font-size:12px">
+                          ${t("mcp.bridgeFailedHint")}
+                        </div>
+                      </div>
+                    </div>`
+                  : html`<div class="card accent-warn">
+                      <div class="card-h"><span class="title" style="color:var(--c-warn)">${t("mcp.whyUnbridged")}</span></div>
+                      <div class="card-b" style="font-size:13px;line-height:1.6">
+                        ${t("mcp.whyUnbridgedDesc")}
+                        <div style="margin-top:10px;color:var(--fg-3);font-size:12px">
+                          ${t("mcp.whyUnbridgedHint")}
+                        </div>
+                      </div>
+                    </div>`
+              }
+            `;
+                })()
               : open == null
                 ? html`<div style="color:var(--fg-3);font-size:13px;text-align:center;padding:60px 20px">
                 ${showMarketplace ? t("mcp.marketplacePickHint") : t("mcp.pickHint")}

--- a/src/cli/commands/mcp-runtime.ts
+++ b/src/cli/commands/mcp-runtime.ts
@@ -100,10 +100,19 @@ export const stderrLifecycleSink: McpLifecycleSink = (n) => {
   );
 };
 
+export interface McpFailure {
+  spec: string;
+  name: string;
+  reason: string;
+  at: number;
+}
+
 export interface McpRuntime {
   size(): number;
   specs(): string[];
   summaries(): McpServerSummary[];
+  /** Last bridge failure per spec — drives the "未桥接" reason shown in the dashboard. */
+  failures(): McpFailure[];
   addSpec(
     raw: string,
     loop?: CacheFirstLoop,
@@ -123,6 +132,7 @@ export interface McpRuntime {
 export function createMcpRuntime(ctx: RuntimeContext): McpRuntime {
   const records = new Map<string, SpecRecord>();
   const insertionOrder: string[] = [];
+  const failureMap = new Map<string, McpFailure>();
   let sink: McpLifecycleSink = stderrLifecycleSink;
 
   async function addSpec(
@@ -132,6 +142,7 @@ export function createMcpRuntime(ctx: RuntimeContext): McpRuntime {
     if (records.has(raw)) {
       return { ok: true, summary: records.get(raw)!.summary };
     }
+    failureMap.delete(raw);
     const tools = ctx.getTools();
     if (!tools) return { ok: false, reason: "no tool registry available" };
     const cfg = readConfig();
@@ -159,6 +170,7 @@ export function createMcpRuntime(ctx: RuntimeContext): McpRuntime {
       if (spec.disabled) {
         sink({ kind: "disabled", name: label });
         rejectReady(new Error(`MCP server "${label}" is disabled`));
+        failureMap.set(raw, { spec: raw, name: label, reason: "disabled by user", at: Date.now() });
         return { ok: false, reason: "disabled by user" };
       }
       sink({ kind: "handshake", name: label });
@@ -291,6 +303,7 @@ export function createMcpRuntime(ctx: RuntimeContext): McpRuntime {
         await mcp?.close().catch(() => undefined);
         rejectReady(new Error(`MCP server "${label}" failed to start: ${reason}`));
         sink({ kind: "failed", name: label, reason });
+        failureMap.set(raw, { spec: raw, name: label, reason, at: Date.now() });
         return { ok: false, reason };
       }
       sink({ kind: "warn", name: label, reason });
@@ -299,6 +312,7 @@ export function createMcpRuntime(ctx: RuntimeContext): McpRuntime {
   }
 
   async function removeSpec(raw: string, loop?: CacheFirstLoop): Promise<boolean> {
+    failureMap.delete(raw);
     const record = records.get(raw);
     if (!record) return false;
     await record.client.close().catch(() => undefined);
@@ -354,6 +368,10 @@ export function createMcpRuntime(ctx: RuntimeContext): McpRuntime {
     for (const r of records.values()) await r.client.close().catch(() => undefined);
     records.clear();
     insertionOrder.length = 0;
+    failureMap.clear();
+  }
+  function failures(): McpFailure[] {
+    return [...failureMap.values()];
   }
   function setLifecycleSink(s: McpLifecycleSink): void {
     sink = s;
@@ -362,6 +380,7 @@ export function createMcpRuntime(ctx: RuntimeContext): McpRuntime {
     size: () => records.size,
     specs,
     summaries,
+    failures,
     addSpec,
     removeSpec,
     reloadFromConfig,

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -2042,6 +2042,7 @@ function AppInner({
           loop,
           tools,
           getMcpServers: () => liveMcpServersRef.current,
+          getMcpFailures: () => mcpRuntime?.failures() ?? [],
           getCurrentCwd: () => (codeMode ? currentRootDirRef.current : undefined),
           getEditMode: () => (codeMode ? editModeRef.current : undefined),
           getPlanMode: () => planModeRef.current,

--- a/src/server/api/mcp.ts
+++ b/src/server/api/mcp.ts
@@ -93,7 +93,10 @@ export async function handleMcp(
   // bridged set (a recent edit hasn't been reloaded yet).
   if (method === "GET" && rest[0] === "specs") {
     const cfg = readConfig(ctx.configPath);
-    return { status: 200, body: { specs: cfg.mcp ?? [] } };
+    return {
+      status: 200,
+      body: { specs: cfg.mcp ?? [], failures: ctx.getMcpFailures?.() ?? [] },
+    };
   }
 
   if (method === "POST" && rest[0] === "specs") {

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -17,6 +17,8 @@ export interface DashboardContext {
   loop?: CacheFirstLoop;
   tools?: ToolRegistry;
   getMcpServers?: () => McpServerSummary[];
+  /** Per-spec bridge failures — drives the "未桥接" reason shown in the dashboard. */
+  getMcpFailures?: () => Array<{ spec: string; name: string; reason: string; at: number }>;
   jobs?: JobRegistry;
 
   /** Current code-mode root, if any. Drives the project-scoped allowlist. */

--- a/tests/mcp-runtime-failures.test.ts
+++ b/tests/mcp-runtime-failures.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const initializeMock = vi.fn(async () => undefined);
+  const closeMock = vi.fn(async () => undefined);
+  const bridgeMcpToolsMock = vi.fn(async (_client: unknown, opts: any) => ({
+    registeredNames: [],
+    env: {
+      registry: opts.registry,
+      host: opts.host,
+      prefix: opts.namePrefix ?? "",
+      maxResultChars: 32_000,
+      tracker: null,
+    },
+  }));
+  const inspectMcpServerMock = vi.fn(async () => ({
+    protocolVersion: "2024-11-05",
+    serverInfo: { name: "fake", version: "1.0.0" },
+    capabilities: { tools: {} },
+    tools: { supported: true as const, items: [] },
+    resources: { supported: false as const, reason: "method not found" },
+    prompts: { supported: false as const, reason: "method not found" },
+    elapsedMs: 1,
+  }));
+  const readConfigMock = vi.fn(() => ({ mcpDisabled: [] as string[] }));
+
+  class FakeMcpClient {
+    protocolVersion = "2024-11-05";
+    serverInfo = { name: "fake", version: "1.0.0" };
+    serverCapabilities = { tools: {} };
+    async initialize() {
+      return initializeMock();
+    }
+    async close() {
+      return closeMock();
+    }
+  }
+
+  class FakeTransport {}
+
+  return {
+    initializeMock,
+    closeMock,
+    bridgeMcpToolsMock,
+    inspectMcpServerMock,
+    readConfigMock,
+    FakeMcpClient,
+    FakeTransport,
+  };
+});
+
+vi.mock("../src/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/config.js")>();
+  return { ...actual, readConfig: mocks.readConfigMock };
+});
+
+vi.mock("../src/mcp/client.js", () => ({ McpClient: mocks.FakeMcpClient }));
+vi.mock("../src/mcp/inspect.js", () => ({ inspectMcpServer: mocks.inspectMcpServerMock }));
+vi.mock("../src/mcp/registry.js", () => ({ bridgeMcpTools: mocks.bridgeMcpToolsMock }));
+vi.mock("../src/mcp/sse.js", () => ({ SseTransport: mocks.FakeTransport }));
+vi.mock("../src/mcp/stdio.js", () => ({ StdioTransport: mocks.FakeTransport }));
+vi.mock("../src/mcp/streamable-http.js", () => ({
+  StreamableHttpTransport: mocks.FakeTransport,
+}));
+
+describe("createMcpRuntime — failure tracking", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    mocks.initializeMock.mockReset();
+    mocks.bridgeMcpToolsMock.mockClear();
+    mocks.readConfigMock.mockReset();
+  });
+
+  async function buildRuntime() {
+    const [{ createMcpRuntime }, { ToolRegistry }] = await Promise.all([
+      import("../src/cli/commands/mcp-runtime.js"),
+      import("../src/tools.js"),
+    ]);
+    const tools = new ToolRegistry();
+    return createMcpRuntime({
+      getTools: () => tools,
+      getMcpPrefix: () => undefined,
+      getRequestedCount: () => 1,
+      progressSink: { current: null },
+    });
+  }
+
+  it("records a failure entry when initialize() throws", async () => {
+    mocks.readConfigMock.mockReturnValue({ mcpDisabled: [] });
+    mocks.initializeMock.mockImplementation(async () => {
+      throw new Error("ECONNREFUSED 127.0.0.1:1");
+    });
+    const runtime = await buildRuntime();
+    const spec = "ctx7=streamable+https://server.smithery.ai/@example/ctx7";
+
+    const result = await runtime.addSpec(spec);
+
+    expect(result.ok).toBe(false);
+    expect(runtime.failures()).toEqual([
+      expect.objectContaining({
+        spec,
+        name: "ctx7",
+        reason: "ECONNREFUSED 127.0.0.1:1",
+      }),
+    ]);
+  });
+
+  it("clears a prior failure when a later addSpec succeeds", async () => {
+    mocks.readConfigMock.mockReturnValue({ mcpDisabled: [] });
+    mocks.initializeMock.mockImplementationOnce(async () => {
+      throw new Error("transient");
+    });
+    mocks.initializeMock.mockImplementation(async () => undefined);
+    const runtime = await buildRuntime();
+    const spec = "ctx7=streamable+https://example.test/mcp";
+
+    const firstResult = await runtime.addSpec(spec);
+    expect(firstResult.ok).toBe(false);
+    expect(runtime.failures()).toHaveLength(1);
+
+    const secondResult = await runtime.addSpec(spec);
+    expect(secondResult.ok).toBe(true);
+    expect(runtime.failures()).toEqual([]);
+  });
+
+  it("clears a failure when removeSpec runs", async () => {
+    mocks.readConfigMock.mockReturnValue({ mcpDisabled: [] });
+    mocks.initializeMock.mockImplementation(async () => {
+      throw new Error("boom");
+    });
+    const runtime = await buildRuntime();
+    const spec = "ctx7=streamable+https://example.test/mcp";
+
+    await runtime.addSpec(spec);
+    expect(runtime.failures()).toHaveLength(1);
+
+    await runtime.removeSpec(spec);
+    expect(runtime.failures()).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

When an MCP server in \`config.json\` failed to bridge — wrong URL,
network 404, smithery streamable endpoint unreachable, missing auth
header, etc. — the dashboard would show the spec as \"未桥接 / unbridged\"
with a generic \"restart reasonix code, then refresh\" hint.

A user with \`renCosta2025-context7fork=streamable+https://server.smithery.ai/...\`
hit this and restart didn't fix it, because the issue wasn't \"the
bridge hasn't run yet\" — the bridge ran, errored, and we threw the
reason on the floor.

The reason was already captured in the lifecycle sink. We just never
surfaced it back to the UI that asks about unbridged specs.

## Fix

- **mcp-runtime**: track the last bridge failure per spec in a Map.
  Populate on the catch path of \`addSpec\` and on the \`disabled\` path.
  Clear on a later successful add or \`removeSpec\`. Expose via
  \`runtime.failures()\`.
- **server context + /mcp/specs**: extend the response with a
  \`failures\` array. Backward compatible — older clients ignore it.
- **App.tsx**: wire \`mcpRuntime.failures()\` into the dashboard context.
- **dashboard panel**: read failures alongside specs. In the list
  row, swap the \"in config\" sublabel for the actual error reason
  (colored as error). In the detail card, render the reason inline
  with a more actionable hint than \"restart\".
- **i18n (zh-CN + en)**: new strings — \`mcp.bridgeFailed\`,
  \`mcp.bridgeFailedTitle\`, \`mcp.bridgeFailedHint\`.

## Verify

- \`npm run verify\` — green (lint + typecheck + 3123 tests).
- 3 new unit tests in \`tests/mcp-runtime-failures.test.ts\` cover the
  failure tracker (record on \`initialize\` throw, clear on retry
  success, clear on \`removeSpec\`).
- Manual: with a deliberately broken \`streamable+https://...\` spec,
  the dashboard MCP panel now shows \"桥接失败\" plus the actual error
  text instead of pointing the user at a restart that wouldn't help.

cc users reporting MCP entries stuck on \"未桥接\" after restart.