### PR TITLE
fix(desktop): tighten slash picker labels

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -264,6 +264,20 @@ type Action =
   | { t: "dequeue_send"; index: number }
   | { t: "shift_queued_send" };
 
+function fallbackSkillDesc(skill: SkillInfo): string {
+  const scope =
+    skill.scope === "builtin"
+      ? t("app.skill.scope.builtin")
+      : skill.scope === "global"
+        ? t("app.skill.scope.global")
+        : t("app.skill.scope.project");
+  const runAs =
+    skill.runAs === "subagent"
+      ? t("app.skill.runAs.subagent")
+      : t("app.skill.runAs.inline");
+  return t("app.skill.generic", { scope, runAs });
+}
+
 function reduce(state: State, action: Action): State {
   switch (action.t) {
     case "send_user": {
@@ -1353,7 +1367,7 @@ function TabRuntime({
     },
     ...state.skills.map((s) => ({
       cmd: `/${s.name}`,
-      desc: s.description || `skill · ${s.scope}`,
+      desc: s.description?.trim() || fallbackSkillDesc(s),
       run: () => {
         dispatch({
           t: "start_skill",

--- a/desktop/src/i18n/en.ts
+++ b/desktop/src/i18n/en.ts
@@ -308,6 +308,18 @@ export const en = {
       exportMd: "Copy session as Markdown",
       help: "Show all commands",
     },
+    skill: {
+      generic: "{scope} skill · {runAs}",
+      scope: {
+        builtin: "Builtin",
+        global: "Global",
+        project: "Project",
+      },
+      runAs: {
+        inline: "inline",
+        subagent: "subagent",
+      },
+    },
     yolo: {
       banner1: "All tool calls, shell commands, and file edits will be ",
       bannerBold: "auto-approved",

--- a/desktop/src/i18n/zh-CN.ts
+++ b/desktop/src/i18n/zh-CN.ts
@@ -315,6 +315,18 @@ export const zhCN: typeof en = {
       exportMd: "复制本会话为 Markdown",
       help: "查看所有命令",
     },
+    skill: {
+      generic: "{scope}技能 · {runAs}",
+      scope: {
+        builtin: "内置",
+        global: "全局",
+        project: "项目",
+      },
+      runAs: {
+        inline: "内联",
+        subagent: "子代理",
+      },
+    },
     yolo: {
       banner1: "所有工具调用、shell 命令、文件编辑都会",
       bannerBold: "自动批准",

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -2863,8 +2863,12 @@ html[data-platform="macos"] .titlebar .tb-left {
   margin-right: 6px;
 }
 .popup-item .desc {
+  display: block;
   font-size: 14px;
   color: var(--muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .popup-item .kb {
   font-family: inherit;

--- a/desktop/src/ui/composer.tsx
+++ b/desktop/src/ui/composer.tsx
@@ -21,8 +21,8 @@ type ModeEntry = { k: EditMode; label: string; icon: React.ReactNode; hint: TKey
 
 const PRESET_INFO: Record<PresetName, PresetEntry> = {
   auto: { label: "auto", badge: "AUTO", desc: "preset.autoDesc" },
-  flash: { label: "deepseek-v4-flash", badge: "FLASH", desc: "preset.flashDesc" },
-  pro: { label: "deepseek-v4-pro", badge: "PRO", desc: "preset.proDesc" },
+  flash: { label: "v4-flash", badge: "FLASH", desc: "preset.flashDesc" },
+  pro: { label: "v4-pro", badge: "PRO", desc: "preset.proDesc" },
 };
 
 const MODE_INFO: ModeEntry[] = [


### PR DESCRIPTION
## Summary
- shorten the desktop preset labels to `auto` / `v4-flash` / `v4-pro`
- use the skill's own slash-picker description when available, with a localized generic fallback when it is missing
- generically truncate long slash-picker descriptions so they do not dominate the picker UI

## What changed
- update the desktop preset labels in `desktop/src/ui/composer.tsx`
- replace the desktop-side curated skill summary path with a localized generic fallback in `desktop/src/App.tsx`
- add the generic fallback strings in both desktop i18n dictionaries
- keep slash-picker descriptions to a single line in desktop CSS

## Verification
- `npm run verify`