### PR TITLE
feat(desktop): add platform-aware keyboard shortcut rendering

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -42,6 +42,7 @@ import { useElapsed } from "./ui/live";
 import { AboutModal } from "./ui/about";
 import { SettingsModal, type PageId as SettingsPageId } from "./ui/settings";
 import { Sidebar } from "./ui/sidebar";
+import { Shortcut, localizeShortcutText, shortcutText } from "./ui/shortcut";
 import { Splash, shouldShowSplash } from "./ui/splash";
 import { StatusBar } from "./ui/statusbar";
 import {
@@ -1309,7 +1310,7 @@ function TabRuntime({
         composerRef.current?.focus();
       },
     },
-    { cmd: "/new", desc: t("app.cmd.newSession"), run: () => newChat(), kb: "⌘N" },
+    { cmd: "/new", desc: t("app.cmd.newSession"), run: () => newChat(), kb: shortcutText(["mod", "N"]) },
     { cmd: "/clear", desc: t("app.cmd.clearChat"), run: () => dispatch({ t: "clear" }) },
     { cmd: "/abort", desc: t("app.cmd.abort"), run: () => abort(), kb: "esc" },
     {
@@ -1941,7 +1942,7 @@ function TitleBar({
           type="button"
           className="iconbtn"
           data-on={sideOn}
-          title={t("app.titlebar.sidebar")}
+          title={localizeShortcutText(t("app.titlebar.sidebar"))}
           onClick={onToggleSide}
         >
           <I.panel_l size={14} />
@@ -1993,7 +1994,9 @@ function TitleBar({
                 <div className="popup-item" onClick={() => { onOpenCommands(); setMenuOpen(false); }}>
                   <span className="ico"><I.search size={12} /></span>
                   <div className="nm"><span>{t("app.titlebar.commandPalette")}</span></div>
-                  <span className="kb">⌘K</span>
+                  <span className="kb">
+                    <Shortcut keys={["mod", "K"]} />
+                  </span>
                 </div>
                 <div
                   className="popup-item"
@@ -2010,7 +2013,9 @@ function TitleBar({
                 <div className="popup-item" onClick={() => { onOpenSettings(); setMenuOpen(false); }}>
                   <span className="ico"><I.cog size={12} /></span>
                   <div className="nm"><span>{t("app.titlebar.settings")}</span></div>
-                  <span className="kb">⌘,</span>
+                  <span className="kb">
+                    <Shortcut keys={["mod", ","]} />
+                  </span>
                 </div>
               </div>
             </div>
@@ -2100,7 +2105,7 @@ function TabBar({
           </div>
         );
       })}
-      <div className="tab newtab" title={t("app.tab.newTabTitle")} onClick={onNew}>
+      <div className="tab newtab" title={localizeShortcutText(t("app.tab.newTabTitle"))} onClick={onNew}>
         <I.plus size={12} />
         <span style={{ fontSize: 11, marginLeft: 4 }}>{t("app.tab.newTab")}</span>
       </div>

--- a/desktop/src/CommandPalette.tsx
+++ b/desktop/src/CommandPalette.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { t, useLang } from "./i18n";
+import { Shortcut, type ShortcutKey } from "./ui/shortcut";
 
 export type CommandGroup = "nav" | "action" | "workspace" | "settings";
 
@@ -22,7 +23,7 @@ export type Command = {
   label: string;
   hint?: string;
   icon: ReactNode;
-  shortcut?: string[];
+  shortcut?: ShortcutKey[];
   group: CommandGroup;
   run: () => void;
 };
@@ -72,7 +73,7 @@ export function buildCommands(handlers: CommandHandlers): Command[] {
       label: t("palette.newChat"),
       hint: t("palette.newChatHint"),
       icon: <FilePlus size={13} />,
-      shortcut: ["⌘", "N"],
+      shortcut: ["mod", "N"],
       run: handlers.newChat,
     },
     {
@@ -81,7 +82,7 @@ export function buildCommands(handlers: CommandHandlers): Command[] {
       label: t("palette.newTab"),
       hint: t("palette.newTabHint"),
       icon: <Plus size={13} />,
-      shortcut: ["⌘", "T"],
+      shortcut: ["mod", "T"],
       run: handlers.newTab,
     },
   ];
@@ -92,7 +93,7 @@ export function buildCommands(handlers: CommandHandlers): Command[] {
       label: t("palette.closeTab"),
       hint: t("palette.closeTabHint"),
       icon: <SquareX size={13} />,
-      shortcut: ["⌘", "W"],
+      shortcut: ["mod", "W"],
       run: handlers.closeTab,
     });
   }
@@ -101,7 +102,7 @@ export function buildCommands(handlers: CommandHandlers): Command[] {
     group: "nav",
     label: t("palette.focusComposer"),
     icon: <FocusIcon size={13} />,
-    shortcut: ["⌘", "L"],
+    shortcut: ["mod", "L"],
     run: handlers.focusComposer,
   });
   if (handlers.busy) {
@@ -262,7 +263,7 @@ export function CommandPalette({
             }}
           />
           <span className="hint">
-            <kbd>esc</kbd>
+            <Shortcut keys={["esc"]} />
           </span>
         </div>
         <div className="cmdk-body" ref={listRef}>
@@ -287,7 +288,9 @@ export function CommandPalette({
                     <span className="l">{c.label}</span>
                     <span className="g">{groupLabel(c.group)}</span>
                     {c.shortcut ? (
-                      <span className="kb">{c.shortcut.join("")}</span>
+                      <span className="kb">
+                        <Shortcut keys={c.shortcut} />
+                      </span>
                     ) : (
                       <span className="kb-empty" />
                     )}
@@ -299,15 +302,15 @@ export function CommandPalette({
         </div>
         <div className="cmdk-foot">
           <span>
-            <kbd>↑↓</kbd>
+            <Shortcut keys={["updown"]} />
             {t("palette.footMove")}
           </span>
           <span>
-            <kbd>⏎</kbd>
+            <Shortcut keys={["enter"]} />
             {t("palette.footRun")}
           </span>
           <span>
-            <kbd>esc</kbd>
+            <Shortcut keys={["esc"]} />
             {t("palette.footClose")}
           </span>
           <span style={{ marginLeft: "auto", color: "var(--muted)" }}>

--- a/desktop/src/main.tsx
+++ b/desktop/src/main.tsx
@@ -19,7 +19,11 @@ if (isTheme(stored)) {
   document.documentElement.dataset.theme = stored;
 }
 
-const platform = /Mac|macOS/i.test(navigator.userAgent) ? "macos" : "default";
+const platform = /Mac|macOS/i.test(navigator.userAgent)
+  ? "macos"
+  : /Windows/i.test(navigator.userAgent)
+    ? "windows"
+    : "default";
 document.documentElement.dataset.platform = platform;
 document.body.dataset.platform = platform;
 

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -758,13 +758,15 @@ html[data-platform="macos"] .titlebar .tb-left {
   background: var(--accent-strong);
 }
 .side-head .new-btn kbd {
-  margin-left: auto;
   font-family: inherit;
   font-size: 14px;
   background: oklch(100% 0 0 / 0.18);
   padding: 1px 5px;
   border-radius: 3px;
   font-weight: 500;
+}
+.side-head .new-btn .shortcut {
+  margin-left: auto;
 }
 .side-head .icon-btn {
   width: 30px;
@@ -1323,6 +1325,32 @@ html[data-platform="macos"] .titlebar .tb-left {
   font-family: inherit;
   font-size: 14px;
   color: var(--muted);
+}
+
+.shortcut {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  vertical-align: -0.12em;
+  white-space: nowrap;
+}
+.shortcut kbd {
+  min-width: 18px;
+  text-align: center;
+  line-height: 1.25;
+  font-variant-numeric: tabular-nums;
+  font-family: inherit;
+  font-size: 12px;
+  color: var(--fg-2);
+  background: linear-gradient(180deg, var(--card), var(--panel));
+  border: 1px solid var(--border);
+  border-bottom-color: var(--border-strong);
+  border-radius: 4px;
+  padding: 1px 5px;
+  box-shadow: inset 0 1px 0 oklch(100% 0 0 / 0.05);
+}
+html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
+  min-width: 30px;
 }
 
 /* ---------- MAIN ---------- */
@@ -2873,6 +2901,17 @@ html[data-platform="macos"] .titlebar .tb-left {
   background: var(--panel-2);
   padding: 1px 5px;
   border-radius: 4px;
+}
+.popup-item .kb .shortcut kbd,
+.cmdk-row .kb .shortcut kbd {
+  min-width: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+}
+html:not([data-platform="macos"]) .popup-item .kb .shortcut kbd[data-key="mod"],
+html:not([data-platform="macos"]) .cmdk-row .kb .shortcut kbd[data-key="mod"] {
+  min-width: 24px;
 }
 
 .popup-foot {

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -768,6 +768,18 @@ html[data-platform="macos"] .titlebar .tb-left {
 .side-head .new-btn .shortcut {
   margin-left: auto;
 }
+.side-head .new-btn .shortcut kbd {
+  min-width: 0;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: inherit;
+  color: inherit;
+  background: oklch(100% 0 0 / 0.18);
+  border: none;
+  border-radius: 3px;
+  padding: 1px 5px;
+  box-shadow: none;
+}
 .side-head .icon-btn {
   width: 30px;
   height: 30px;
@@ -1331,7 +1343,7 @@ html[data-platform="macos"] .titlebar .tb-left {
   display: inline-flex;
   align-items: center;
   gap: 2px;
-  vertical-align: -0.12em;
+  vertical-align: baseline;
   white-space: nowrap;
 }
 .shortcut kbd {
@@ -2807,6 +2819,13 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
   border-radius: 3px;
   padding: 0 4px;
   font-size: 14px;
+}
+.hint-row .shortcut kbd {
+  min-width: 0;
+  font-size: 14px;
+  padding: 0 4px;
+  border: 1px solid var(--border);
+  background: var(--panel);
 }
 /* ModeSwitch inside hint-row — slightly smaller to sit inline with text */
 .hint-row .mode-switch {

--- a/desktop/src/ui/cards.tsx
+++ b/desktop/src/ui/cards.tsx
@@ -2,6 +2,7 @@ import { memo, useState, type ReactNode } from "react";
 import { I } from "../icons";
 import { Markdown } from "../Markdown";
 import { t, useLang } from "../i18n";
+import { Shortcut } from "./shortcut";
 
 type Tone = "default" | "success" | "warning" | "danger" | "accent" | "violet";
 
@@ -271,11 +272,11 @@ export function ShellCard({
               ) : null}
               {onReject ? (
                 <button type="button" className="btn" onClick={onReject}>
-                  {t("cards.shellReject")} <kbd>⌘.</kbd>
+                  {t("cards.shellReject")} <Shortcut keys={["mod", "."]} />
                 </button>
               ) : null}
               <button type="button" className="btn primary" onClick={onApprove}>
-                {t("cards.shellRun")} <kbd>⌘⏎</kbd>
+                {t("cards.shellRun")} <Shortcut keys={["mod", "enter"]} />
               </button>
             </div>
           </div>
@@ -421,7 +422,7 @@ export function DiffCard({
               ) : null}
               {onApply ? (
                 <button type="button" className="btn primary" onClick={onApply}>
-                  {t("cards.diffApply")} <kbd>⌘⏎</kbd>
+                  {t("cards.diffApply")} <Shortcut keys={["mod", "enter"]} />
                 </button>
               ) : null}
             </div>

--- a/desktop/src/ui/composer.tsx
+++ b/desktop/src/ui/composer.tsx
@@ -12,6 +12,7 @@ import { open as openFileDialog } from "@tauri-apps/plugin-dialog";
 import { t, type TKey } from "../i18n";
 import { I } from "../icons";
 import { fmtElapsed } from "./live";
+import { Shortcut } from "./shortcut";
 
 export type PresetName = "auto" | "flash" | "pro";
 export type EditMode = "review" | "auto" | "yolo";
@@ -418,20 +419,23 @@ export function Composer({
               <ModeSwitch mode={editMode} onChange={onEditModeChange} />
               <span className="hint-sep" />
               <span>
-                <kbd>⏎</kbd> {t("composer.queue")} &nbsp;·&nbsp; <kbd>esc</kbd> {t("composer.interrupt")}
+                <Shortcut keys={["enter"]} /> {t("composer.queue")} &nbsp;·&nbsp;{" "}
+                <Shortcut keys={["esc"]} /> {t("composer.interrupt")}
               </span>
             </>
           ) : (
             <>
               <span>
-                <kbd>/</kbd> {t("composer.commands")} &nbsp;·&nbsp; <kbd>@</kbd> {t("composer.mentionFiles")}
-                &nbsp;·&nbsp; <kbd>⌘K</kbd> {t("composer.commandPalette")}
+                <Shortcut keys={["/"]} /> {t("composer.commands")} &nbsp;·&nbsp;{" "}
+                <Shortcut keys={["@"]} /> {t("composer.mentionFiles")}
+                &nbsp;·&nbsp; <Shortcut keys={["mod", "K"]} /> {t("composer.commandPalette")}
               </span>
               <span className="grow" />
               <ModeSwitch mode={editMode} onChange={onEditModeChange} />
               <span className="hint-sep" />
               <span>
-                <kbd>⏎</kbd> {t("composer.send")} &nbsp; <kbd>⇧⏎</kbd> {t("composer.newline")}
+                <Shortcut keys={["enter"]} /> {t("composer.send")} &nbsp;{" "}
+                <Shortcut keys={["shift", "enter"]} /> {t("composer.newline")}
               </span>
             </>
           )}
@@ -667,13 +671,13 @@ function Popup({
       </div>
       <div className="popup-foot">
         <span>
-          <kbd>↑↓</kbd> {t("composer.select")}
+          <Shortcut keys={["updown"]} /> {t("composer.select")}
         </span>
         <span>
-          <kbd>⏎</kbd> {t("composer.confirm")}
+          <Shortcut keys={["enter"]} /> {t("composer.confirm")}
         </span>
         <span>
-          <kbd>esc</kbd> {t("composer.close")}
+          <Shortcut keys={["esc"]} /> {t("composer.close")}
         </span>
       </div>
     </div>

--- a/desktop/src/ui/jobs-pop.tsx
+++ b/desktop/src/ui/jobs-pop.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { I } from "../icons";
 import { t, useLang } from "../i18n";
 import type { JobInfo } from "../protocol";
+import { Shortcut } from "./shortcut";
 
 export function JobsPop({
   open,
@@ -96,7 +97,8 @@ export function JobsPop({
             </span>
             <span className="grow" />
             <span>
-              <kbd>⌘J</kbd> {t("jobs.kbToggle")} · <kbd>esc</kbd> {t("jobs.kbClose")}
+              <Shortcut keys={["mod", "J"]} /> {t("jobs.kbToggle")} ·{" "}
+              <Shortcut keys={["esc"]} /> {t("jobs.kbClose")}
             </span>
           </div>
         </div>

--- a/desktop/src/ui/settings.tsx
+++ b/desktop/src/ui/settings.tsx
@@ -4,6 +4,7 @@ import { setLang, t, useLang } from "../i18n";
 import { I } from "../icons";
 import type { McpSpecInfo, SettingsPatch, SkillInfo } from "../protocol";
 import { FONT_FAMILY, FONT_SCALE, type FontFamily, type FontScale, THEME, type Theme } from "../theme";
+import { Shortcut, type ShortcutKey } from "./shortcut";
 
 export type PageId =
   | "general"
@@ -777,15 +778,15 @@ function PageBilling({
 }
 
 function PageShortcuts() {
-  const rows: { nm: string; keys: string[] }[] = [
-    { nm: t("settings.shortcutNewChat"), keys: ["⌘", "N"] },
-    { nm: t("settings.shortcutNewTab"), keys: ["⌘", "T"] },
-    { nm: t("settings.shortcutCloseTab"), keys: ["⌘", "W"] },
-    { nm: t("settings.shortcutCommandPalette"), keys: ["⌘", "K"] },
-    { nm: t("settings.shortcutFocusComposer"), keys: ["⌘", "L"] },
-    { nm: t("settings.shortcutSwitchTab"), keys: ["⌘", "⇥"] },
+  const rows: { nm: string; keys: ShortcutKey[] }[] = [
+    { nm: t("settings.shortcutNewChat"), keys: ["mod", "N"] },
+    { nm: t("settings.shortcutNewTab"), keys: ["mod", "T"] },
+    { nm: t("settings.shortcutCloseTab"), keys: ["mod", "W"] },
+    { nm: t("settings.shortcutCommandPalette"), keys: ["mod", "K"] },
+    { nm: t("settings.shortcutFocusComposer"), keys: ["mod", "L"] },
+    { nm: t("settings.shortcutSwitchTab"), keys: ["mod", "tab"] },
     { nm: t("settings.shortcutAbort"), keys: ["esc"] },
-    { nm: t("settings.shortcutSettings"), keys: ["⌘", ","] },
+    { nm: t("settings.shortcutSettings"), keys: ["mod", ","] },
   ];
   return (
     <section className="section">
@@ -798,14 +799,12 @@ function PageShortcuts() {
   );
 }
 
-function SectionRow({ nm, keys }: { nm: string; keys: string[] }): ReactNode {
+function SectionRow({ nm, keys }: { nm: string; keys: ShortcutKey[] }): ReactNode {
   return (
     <>
       <div className="nm">{nm}</div>
       <div className="keys">
-        {keys.map((k, j) => (
-          <kbd key={j}>{k}</kbd>
-        ))}
+        <Shortcut keys={keys} />
       </div>
     </>
   );

--- a/desktop/src/ui/shortcut.tsx
+++ b/desktop/src/ui/shortcut.tsx
@@ -1,0 +1,60 @@
+import type { ReactNode } from "react";
+
+export type ShortcutKey = "mod" | "shift" | "enter" | "tab" | "esc" | "updown" | string;
+
+function isMacPlatform(): boolean {
+  if (typeof document === "undefined") return false;
+  return document.documentElement.dataset.platform === "macos";
+}
+
+function keyLabel(key: ShortcutKey, mac: boolean): string {
+  switch (key) {
+    case "mod":
+    case "⌘":
+      return mac ? "⌘" : "Ctrl";
+    case "shift":
+    case "⇧":
+      return mac ? "⇧" : "Shift";
+    case "enter":
+    case "⏎":
+      return "Enter";
+    case "tab":
+    case "⇥":
+      return "Tab";
+    case "esc":
+      return "Esc";
+    case "updown":
+    case "↑↓":
+      return "↑↓";
+    default:
+      return key;
+  }
+}
+
+export function shortcutText(keys: readonly ShortcutKey[]): string {
+  const mac = isMacPlatform();
+  return keys.map((key) => keyLabel(key, mac)).join(mac ? "" : "+");
+}
+
+export function localizeShortcutText(text: string): string {
+  return text.replace(/⌘/g, keyLabel("mod", isMacPlatform()));
+}
+
+export function Shortcut({
+  keys,
+  className,
+}: {
+  keys: readonly ShortcutKey[];
+  className?: string;
+}): ReactNode {
+  const mac = isMacPlatform();
+  return (
+    <span className={["shortcut", className].filter(Boolean).join(" ")}>
+      {keys.map((key, index) => (
+        <kbd key={`${key}-${index}`} data-key={key}>
+          {keyLabel(key, mac)}
+        </kbd>
+      ))}
+    </span>
+  );
+}

--- a/desktop/src/ui/sidebar.tsx
+++ b/desktop/src/ui/sidebar.tsx
@@ -2,6 +2,7 @@ import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { SessionInfo } from "../App";
 import { t, useLang } from "../i18n";
 import { I } from "../icons";
+import { Shortcut } from "./shortcut";
 
 type PendingDelete = {
   name: string;
@@ -92,7 +93,7 @@ export function Sidebar({
         <button type="button" className="new-btn" onClick={onNewChat}>
           <I.plus size={14} />
           <span>{t("sidebarPanel.newChat")}</span>
-          <kbd>⌘N</kbd>
+          <Shortcut keys={["mod", "N"]} />
         </button>
         <button
           type="button"
@@ -112,7 +113,7 @@ export function Sidebar({
             value={query}
             onChange={(e) => setQuery(e.target.value)}
           />
-          <kbd>⌘K</kbd>
+          <Shortcut keys={["mod", "K"]} />
         </div>
       </div>
 
@@ -219,7 +220,9 @@ export function Sidebar({
             <I.cog size={13} />
           </span>
           <span>{t("sidebarPanel.settings")}</span>
-          <span className="right">⌘,</span>
+          <span className="right">
+            <Shortcut keys={["mod", ","]} />
+          </span>
         </div>
       </div>
 

--- a/desktop/src/ui/statusbar.tsx
+++ b/desktop/src/ui/statusbar.tsx
@@ -3,6 +3,7 @@ import { t } from "../i18n";
 import type { Balance, Settings, UsageStats } from "../App";
 import type { JobInfo } from "../protocol";
 import { THEME, type Theme } from "../theme";
+import { localizeShortcutText } from "./shortcut";
 
 function formatMoney(amount: number, currency: "CNY" | "USD"): string {
   const symbol = currency === "CNY" ? "¥" : "$";
@@ -84,7 +85,7 @@ export function StatusBar({
       <span
         className={`seg jobs ${jobsOpen ? "active" : ""}`}
         onClick={onToggleJobs}
-        title={t("statusbar.jobsTip")}
+        title={localizeShortcutText(t("statusbar.jobsTip"))}
       >
         <I.cpu size={11} />
         <span>{t("statusbar.jobs")}</span>

--- a/desktop/src/ui/workdir-pop.tsx
+++ b/desktop/src/ui/workdir-pop.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { I } from "../icons";
 import { t, useLang } from "../i18n";
+import { Shortcut } from "./shortcut";
 
 type Anchor = { top?: number; bottom?: number; left: number };
 
@@ -61,7 +62,7 @@ export function WorkdirPop({
               color: "var(--muted)",
             }}
           >
-            ⌘O
+            <Shortcut keys={["mod", "O"]} />
           </span>
         </div>
         <input


### PR DESCRIPTION
## Summary

Replace hardcoded Mac-only keyboard symbols (⌘, ⇧, etc.) with a platform-aware \`<Shortcut>\` component, so Windows and Linux users see "Ctrl" instead of "⌘".

Closes #1095

## Changes

- **New** \`desktop/src/ui/shortcut.tsx\` — \`Shortcut\` React component + \`shortcutText()\` + \`localizeShortcutText()\` utility functions
- **Platform detection** — \`desktop/src/main.tsx\`: recognize Windows in addition to macOS
- **CSS** — \`desktop/src/styles.css\`: platform-aware styling for \`.shortcut\` and its \`kbd\` children
- **All keyboard shortcut references** updated across \`App.tsx\`, \`CommandPalette.tsx\`, \`cards.tsx\`, \`composer.tsx\`, \`jobs-pop.tsx\`, \`settings.tsx\`, \`sidebar.tsx\`, \`statusbar.tsx\`, \`workdir-pop.tsx\`

## Behavior

| Platform | \`mod\` renders as |
|---|---|
| macOS | ⌘ |
| Windows | Ctrl |
| Linux | Ctrl |

## Screenshots

*(Insert before/after screenshots on Windows here if available)*