### PR TITLE
fix(desktop): catch context-panel render errors instead of white-screening the app

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -619,7 +619,11 @@ function applyIncoming(state: State, ev: IncomingEvent): State {
     case "$sessions":
       return { ...state, sessions: ev.items };
     case "$mcp_specs":
-      return { ...state, mcpSpecs: ev.specs, mcpBridged: ev.bridged };
+      return {
+        ...state,
+        mcpSpecs: Array.isArray(ev.specs) ? ev.specs : [],
+        mcpBridged: Boolean(ev.bridged),
+      };
     case "$skills":
       return { ...state, skills: ev.items };
     case "$ctx_breakdown":

--- a/desktop/src/i18n/en.ts
+++ b/desktop/src/i18n/en.ts
@@ -595,4 +595,7 @@ export const en = {
     secondsAgo: "{seconds}s ago",
     deliveredWaiting: "Delivered · waiting for agent",
   },
+  panel: {
+    renderError: "{panel} panel render error",
+  },
 };

--- a/desktop/src/i18n/zh-CN.ts
+++ b/desktop/src/i18n/zh-CN.ts
@@ -582,4 +582,7 @@ export const zhCN: typeof en = {
     secondsAgo: "{seconds}s 前",
     deliveredWaiting: "已送达 · 等待 agent 响应",
   },
+  panel: {
+    renderError: "{panel} 面板渲染错误",
+  },
 };

--- a/desktop/src/ui/context-panel.tsx
+++ b/desktop/src/ui/context-panel.tsx
@@ -3,6 +3,7 @@ import type { SessionFile, Settings, UsageStats } from "../App";
 import { t, useLang } from "../i18n";
 import { I } from "../icons";
 import type { McpSpecInfo, MemoryEntryInfo } from "../protocol";
+import { PanelErrorBoundary } from "./error-boundary";
 
 type Tab = "files" | "tools" | "memory" | "rules";
 
@@ -85,10 +86,12 @@ export function ContextPanel({
           </div>
         </div>
 
-        {tab === "files" && <CtxFiles files={sessionFiles} />}
-        {tab === "tools" && <CtxTools specs={mcpSpecs} bridged={mcpBridged} />}
-        {tab === "memory" && <CtxMemory entries={memory} />}
-        {tab === "rules" && <CtxRules settings={settings} />}
+        <PanelErrorBoundary key={tab} label={tab}>
+          {tab === "files" && <CtxFiles files={sessionFiles} />}
+          {tab === "tools" && <CtxTools specs={mcpSpecs} bridged={mcpBridged} />}
+          {tab === "memory" && <CtxMemory entries={memory} />}
+          {tab === "rules" && <CtxRules settings={settings} />}
+        </PanelErrorBoundary>
       </div>
     </aside>
   );

--- a/desktop/src/ui/error-boundary.tsx
+++ b/desktop/src/ui/error-boundary.tsx
@@ -1,0 +1,37 @@
+import { Component, type ReactNode } from "react";
+import { t } from "../i18n";
+
+type Props = { label: string; children: ReactNode };
+type State = { error: Error | null };
+
+export class PanelErrorBoundary extends Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: { componentStack?: string | null }): void {
+    console.error(`[panel:${this.props.label}] render error`, error, info);
+  }
+
+  render(): ReactNode {
+    if (!this.state.error) return this.props.children;
+    return (
+      <div
+        className="ctx-empty"
+        style={{
+          color: "var(--danger, #e25555)",
+          padding: 12,
+          fontSize: 12,
+          whiteSpace: "pre-wrap",
+          wordBreak: "break-word",
+        }}
+      >
+        {t("panel.renderError", { panel: this.props.label })}
+        {": "}
+        {this.state.error.message}
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
## Problem

A user reported that opening the right-side context panel's **工具 / Tools** tab after configuring an MCP server made the entire desktop window go white (#1197). The desktop has no error boundary, so a render error in any panel sub-tree unmounts the whole React tree.

## Fix

- Add a small \`PanelErrorBoundary\` class and wrap the context-panel tab body with it, keyed by \`tab\` so switching away resets the boundary.
- A render error in any one tab now shows an inline message (\`<tab> 面板渲染错误: <message>\`) instead of taking the rest of the app down. The user can still use other tabs and **can read the actual error string** to report.
- Harden the \`\$mcp_specs\` reducer path: coerce non-array \`specs\` to \`[]\` and non-boolean \`bridged\` to \`false\`. Cheap insurance — the reducer can never feed CtxTools something that crashes the render.

## Verify

- \`npm run verify\` — green (lint + typecheck + 3123 tests).
- This doesn't pinpoint the underlying CtxTools crash — the user's screenshots don't show the error and we couldn't reproduce locally on the current build — but the boundary turns the report from \"white screen, no info\" into \"inline error with the message\" on the next release, which is the diagnostic step we need next.

Closes #1197