### PR TITLE
feat(memory): inject ancestor AGENTS.md into list_directory, not just read_file

### DIFF
--- a/src/memory/subdir.ts
+++ b/src/memory/subdir.ts
@@ -4,14 +4,14 @@ import { existsSync, readFileSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { PROJECT_MEMORY_FILES, PROJECT_MEMORY_MAX_CHARS } from "./project.js";
 
-/** Ancestor PROJECT_MEMORY_FILES matches for `absPath`, walking from its dir up to (but not including) `rootDir`. Innermost-first. Returns absolute paths. */
-export function findSubdirMemoryAncestors(absPath: string, rootDir: string): string[] {
+/** PROJECT_MEMORY_FILES matches inside `absDir` AND its ancestors, walking up to (but not including) `rootDir`. Innermost-first. Returns absolute paths. */
+export function findDirMemory(absDir: string, rootDir: string): string[] {
   const root = resolve(rootDir);
-  const target = resolve(absPath);
+  const target = resolve(absDir);
   const rel = relative(root, target);
-  if (!rel || rel.startsWith("..")) return [];
+  if (rel.startsWith("..")) return [];
   const found: string[] = [];
-  let cur = dirname(target);
+  let cur = target;
   while (cur !== root) {
     const r = relative(root, cur);
     if (!r || r.startsWith("..")) break;
@@ -27,6 +27,11 @@ export function findSubdirMemoryAncestors(absPath: string, rootDir: string): str
     cur = parent;
   }
   return found;
+}
+
+/** Ancestor PROJECT_MEMORY_FILES matches for a file at `absPath`, walking from its dir up to (but not including) `rootDir`. Innermost-first. */
+export function findSubdirMemoryAncestors(absPath: string, rootDir: string): string[] {
+  return findDirMemory(dirname(resolve(absPath)), rootDir);
 }
 
 export function readSubdirMemoryContent(path: string): string | null {

--- a/src/tools/filesystem.ts
+++ b/src/tools/filesystem.ts
@@ -8,6 +8,7 @@ import { type ConfirmationChoice, pauseGate as defaultPauseGate } from "../core/
 import { DEFAULT_INDEX_EXCLUDES } from "../index/config.js";
 import { memoryEnabled } from "../memory/project.js";
 import {
+  findDirMemory,
   findSubdirMemoryAncestors,
   formatSubdirMemorySection,
   readSubdirMemoryContent,
@@ -118,11 +119,16 @@ export function registerFilesystemTools(
 
   /** Prepend any not-yet-shown ancestor REASONIX.md (between absPath's dir and rootDir) to a read_file body. Outer dirs first so broad rules read before specific overrides. */
   function withSubdirMemory(absPath: string, body: string): string {
-    if (!memoryEnabled()) return body;
-    const ancestors = findSubdirMemoryAncestors(absPath, rootDir);
-    if (ancestors.length === 0) return body;
+    return prependMemorySections(findSubdirMemoryAncestors(absPath, rootDir), body);
+  }
+  /** Same idea as withSubdirMemory but for list_directory — includes the listed dir's own REASONIX.md, not just ancestors. */
+  function withDirMemory(absDir: string, body: string): string {
+    return prependMemorySections(findDirMemory(absDir, rootDir), body);
+  }
+  function prependMemorySections(memPaths: string[], body: string): string {
+    if (!memoryEnabled() || memPaths.length === 0) return body;
     const sections: string[] = [];
-    for (const memPath of [...ancestors].reverse()) {
+    for (const memPath of [...memPaths].reverse()) {
       if (shownSubdirMemory.has(memPath)) continue;
       const content = readSubdirMemoryContent(memPath);
       if (!content) continue;
@@ -359,7 +365,7 @@ Files OVER the threshold auto-switch to outline mode: file metadata + first ${OU
       for (const e of entries.sort((a, b) => a.name.localeCompare(b.name))) {
         lines.push(e.isDirectory() ? `${e.name}/` : e.name);
       }
-      return lines.join("\n") || "(empty directory)";
+      return withDirMemory(abs, lines.join("\n") || "(empty directory)");
     },
   });
 

--- a/tests/subdir-memory.test.ts
+++ b/tests/subdir-memory.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  findDirMemory,
   findSubdirMemoryAncestors,
   formatSubdirMemorySection,
   readSubdirMemoryContent,
@@ -190,5 +191,86 @@ describe("read_file injects subdir memory on first read per session", () => {
         process.env.REASONIX_MEMORY = prev;
       }
     }
+  });
+});
+
+describe("findDirMemory — for list_directory's listed dir", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "reasonix-dir-mem-"));
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("includes the listed dir's own AGENTS.md", () => {
+    mkdirSync(join(root, "pkg"), { recursive: true });
+    writeFileSync(join(root, "pkg", "AGENTS.md"), "pkg rules");
+    expect(findDirMemory(join(root, "pkg"), root)).toEqual([join(root, "pkg", "AGENTS.md")]);
+  });
+
+  it("walks ancestors innermost-first when nested dirs each have memory", () => {
+    mkdirSync(join(root, "pkg", "module"), { recursive: true });
+    writeFileSync(join(root, "pkg", "REASONIX.md"), "pkg rules");
+    writeFileSync(join(root, "pkg", "module", "REASONIX.md"), "module rules");
+    expect(findDirMemory(join(root, "pkg", "module"), root)).toEqual([
+      join(root, "pkg", "module", "REASONIX.md"),
+      join(root, "pkg", "REASONIX.md"),
+    ]);
+  });
+
+  it("returns [] when the listed dir IS the root (root memory lives in system prompt)", () => {
+    writeFileSync(join(root, "REASONIX.md"), "root rules");
+    expect(findDirMemory(root, root)).toEqual([]);
+  });
+
+  it("returns [] for a dir outside rootDir", () => {
+    const outside = mkdtempSync(join(tmpdir(), "reasonix-dir-out-"));
+    try {
+      mkdirSync(join(outside, "sub"), { recursive: true });
+      expect(findDirMemory(join(outside, "sub"), root)).toEqual([]);
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("list_directory injects subdir memory (issue #1160)", () => {
+  let root: string;
+  let tools: ToolRegistry;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "reasonix-ls-mem-"));
+    mkdirSync(join(root, "pkg", "module"), { recursive: true });
+    writeFileSync(join(root, "pkg", "AGENTS.md"), "package rules");
+    writeFileSync(join(root, "pkg", "module", "AGENTS.md"), "module rules");
+    writeFileSync(join(root, "pkg", "module", "code.ts"), "//");
+    tools = new ToolRegistry();
+    registerFilesystemTools(tools, { rootDir: root });
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("prepends [module memory:…] when listing a subdir that has its own AGENTS.md", async () => {
+    const out = await tools.dispatch("list_directory", JSON.stringify({ path: "pkg/module" }));
+    expect(out).toContain("[module memory: pkg/module/AGENTS.md]");
+    expect(out).toContain("module rules");
+    expect(out).toContain("[module memory: pkg/AGENTS.md]");
+    expect(out).toContain("package rules");
+    expect(out).toContain("code.ts");
+  });
+
+  it("does not repeat memory on a follow-up read_file in the same dir", async () => {
+    await tools.dispatch("list_directory", JSON.stringify({ path: "pkg/module" }));
+    const out = await tools.dispatch("read_file", JSON.stringify({ path: "pkg/module/code.ts" }));
+    expect(out).not.toContain("[module memory:");
+  });
+
+  it("does not inject memory when listing the project root", async () => {
+    writeFileSync(join(root, "REASONIX.md"), "root rules");
+    const out = await tools.dispatch("list_directory", JSON.stringify({ path: "." }));
+    expect(out).not.toContain("[module memory:");
   });
 });


### PR DESCRIPTION
## Problem

Subdir AGENTS.md / REASONIX.md / AGENT.md has worked since #1033 — but only via \`read_file\`. If the agent runs \`list_directory pkg/foo\` and then decides what to read next without first reading a file under it, the guidance in \`pkg/foo/AGENTS.md\` never surfaces. The agent's picking decision is made blind.

Issue #1160 asked whether nested AGENTS.md is supported. The honest answer was "yes, but only through read_file" — this PR closes that gap.

## Fix

- New \`findDirMemory(absDir, rootDir)\` in \`src/memory/subdir.ts\` — walks from \`absDir\` **inclusive** up to \`rootDir\` **exclusive**, returning ancestor + same-dir memory files innermost-first.
- \`findSubdirMemoryAncestors\` (used by \`read_file\`) is now a thin wrapper: \`findDirMemory(dirname(absPath), rootDir)\`. Same behavior; one less duplicated walker.
- \`list_directory\` prepends \`[module memory: …]\` sections for the listed dir + any of its ancestors that carry guidance, with the same once-per-session dedupe as \`read_file\`.
- The root's \`REASONIX.md\` stays excluded — it's already in the system prompt via \`applyProjectMemory\`.

## Verify

- \`npm run verify\` — green (lint + typecheck + 3130 tests).
- 7 new tests in \`tests/subdir-memory.test.ts\` cover \`findDirMemory\` (own-dir hit, nested ancestors, root excluded, outside-root rejected) plus the \`list_directory\` integration (subdir surfaces guidance, follow-up read_file dedupes, listing the root injects nothing).

Closes #1160