### PR TITLE
fix(desktop): surface "session loaded empty" instead of looking like a no-op click

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -730,6 +730,25 @@ function applyIncoming(state: State, ev: IncomingEvent): State {
         queuedSends: [],
       };
     }
+    case "$session_empty": {
+      // The sidecar successfully ran loadSessionMessages but the jsonl is
+      // empty / all-malformed. Without this, the click looks like a no-op
+      // because the chat just re-renders empty. Issue #1179.
+      const sizeNote = ev.sizeBytes === 0 ? "0 bytes" : `${ev.sizeBytes} bytes, no valid entries`;
+      return {
+        ...state,
+        messages: [
+          ...state.messages,
+          {
+            kind: "error",
+            message:
+              `Session "${ev.name}" loaded with no messages (${sizeNote}). ` +
+              `The file ~/.reasonix/sessions/${ev.name}.jsonl exists but couldn't be parsed — ` +
+              `start a new chat or restore from .jsonl.bak if you have one.`,
+          },
+        ],
+      };
+    }
     case "$error":
     case "error":
       return {

--- a/desktop/src/protocol.ts
+++ b/desktop/src/protocol.ts
@@ -231,6 +231,12 @@ export type SessionLoadedEvent = {
   };
 };
 
+export type SessionEmptyEvent = {
+  type: "$session_empty";
+  name: string;
+  sizeBytes: number;
+};
+
 export type NeedsSetupEvent = {
   type: "$needs_setup";
   reason: "no_api_key";
@@ -374,6 +380,7 @@ export type IncomingEvent = { tabId?: string } & (
   | PlanRequiredEvent
   | SessionsEvent
   | SessionLoadedEvent
+  | SessionEmptyEvent
   | NeedsSetupEvent
   | SettingsEvent
   | BalanceEvent

--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -59,6 +59,7 @@ import {
   loadSessionMessages,
   loadSessionMeta,
   patchSessionMeta,
+  sessionPath,
   timestampSuffix,
 } from "../../memory/session.js";
 import { MemoryStore } from "../../memory/user.js";
@@ -212,6 +213,12 @@ interface SessionLoadedEvent {
   };
 }
 
+interface SessionEmptyEvent {
+  type: "$session_empty";
+  name: string;
+  sizeBytes: number;
+}
+
 interface ConfirmRequiredEvent {
   type: "$confirm_required";
   id: number;
@@ -360,6 +367,7 @@ type EmittableEvent =
   | PlanClearedEvent
   | SessionsEvent
   | SessionLoadedEvent
+  | SessionEmptyEvent
   | NeedsSetupEvent
   | SettingsEvent
   | BalanceEvent
@@ -1413,7 +1421,12 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
 
     const tab = msg.tabId ? tabs.get(msg.tabId) : first;
     if (!tab) {
-      emit({ type: "$error", message: `unknown tab: ${msg.tabId}` });
+      // No tabId on the emit ⇒ the renderer's per-tab router drops it
+      // silently. Surface to stderr instead so it's at least visible
+      // when the desktop is launched from a terminal.
+      process.stderr.write(
+        `rpc dispatch: unknown tabId=${msg.tabId} for cmd=${msg.cmd} — dropping\n`,
+      );
       return;
     }
 
@@ -1521,11 +1534,29 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
         cancelPendingGates(tab);
         tab.currentSession = msg.name;
         if (tab.runtime) tab.runtime = buildRuntimeFor(tab);
+        const loadedMessages = buildLoadedMessages(records);
+        // Empty load is a known silent-failure path (file 0 bytes, all
+        // lines malformed, etc.). Log to stderr so a terminal-launched
+        // desktop reports something diagnostic, and emit a $session_empty
+        // event so the UI can surface "loaded but empty" instead of
+        // looking like the click did nothing. Issue #1179.
+        if (loadedMessages.length === 0) {
+          let sizeBytes = 0;
+          try {
+            sizeBytes = statSync(sessionPath(msg.name)).size;
+          } catch {
+            /* file may not exist */
+          }
+          process.stderr.write(
+            `session_load: "${msg.name}" returned 0 messages (file size=${sizeBytes}B) — empty or unreadable jsonl\n`,
+          );
+          emit({ type: "$session_empty", name: msg.name, sizeBytes }, tab.id);
+        }
         emit(
           {
             type: "$session_loaded",
             name: msg.name,
-            messages: buildLoadedMessages(records),
+            messages: loadedMessages,
             carryover: {
               totalCostUsd: meta.totalCostUsd ?? 0,
               cacheHitTokens: meta.cacheHitTokens ?? 0,
@@ -1535,6 +1566,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
           tab.id,
         );
       } catch (err) {
+        process.stderr.write(`session_load: "${msg.name}" threw — ${(err as Error).message}\n`);
         emit({ type: "$error", message: `session_load failed: ${(err as Error).message}` }, tab.id);
       }
       return;


### PR DESCRIPTION
## Problem

The original report in #1179 — *click a session in the sidebar, nothing happens, terminal shows no logs* — has a quieter cause than the slow-list path #1207 just addressed.

If \`loadSessionMessages\` returns \`[]\` (file 0 bytes, all lines malformed, etc.), the sidecar emits \`\$session_loaded\` with \`messages: []\` and the renderer happily re-renders an empty chat. From the user's seat, the click looks dead and stderr stays silent because *nothing actually failed* — the success path was just a no-op.

#1207 fixes the slow case (the maintainer's repro). This PR addresses the silent-no-op case (the original reporter's repro).

## Fix

Three changes:

- **\`desktop.ts\` session_load** — when the loaded message list is empty, write a diagnostic line to stderr (\`session_load: \"<name>\" returned 0 messages (file size=NB) — empty or unreadable jsonl\`) AND emit a new \`\$session_empty\` event with the byte count. Also stderr-log session_load throws (they were also silent unless the renderer happened to render the resulting \`\$error\`).
- **\`App.tsx\` reducer** — handle \`\$session_empty\` by pushing a visible inline error into the chat: *\"Session 'X' loaded with no messages (N bytes). The file ~/.reasonix/sessions/X.jsonl exists but couldn't be parsed — start a new chat or restore from .jsonl.bak if you have one.\"* The click is no longer indistinguishable from a no-op.
- **\`desktop.ts\` rpc dispatch** — stop silently dropping events that target an unknown tabId. The previous \`emit({type:\"\$error\", ...})\` lacked a tabId, so the renderer's per-tab router ignored it. Replaced with \`process.stderr.write\` so this failure mode is observable from a terminal-launched desktop.

## Verify

- \`npm run verify\` — green (lint + typecheck + 3141 tests).
- Manual reproduction recipe for a future reporter: \`truncate -s 0 ~/.reasonix/sessions/foo.jsonl\` to simulate an empty session, then click it in the sidebar. Before this PR: looks like nothing happened. After: chat shows the error message *and* the terminal (if launched from one) prints \`session_load: \"foo\" returned 0 messages (file size=0B) — empty or unreadable jsonl\`.

Closes #1179 (follow-up to #1207)