### PR TITLE
fix(desktop): drop regex lookbehind so the bundle parses on macOS Monterey WKWebView

### DIFF
--- a/desktop/src/Markdown.tsx
+++ b/desktop/src/Markdown.tsx
@@ -44,8 +44,12 @@ function resolveAgainstWorkspace(rel: string, ws: string | undefined): string {
 
 const KNOWN_EXTS =
   "ts|tsx|mts|cts|js|jsx|mjs|cjs|py|pyi|rs|go|json|jsonc|md|mdx|css|scss|less|html|htm|xml|svg|yaml|yml|toml|sh|bash|zsh|fish|sql|rb|java|kt|swift|c|cpp|cc|cxx|h|hpp|hxx|cs|php|lua|dart|ex|exs|erl|hs|clj|cljs|zig|vue|svelte|graphql|gql|proto";
+// No lookbehind here — Tauri's WKWebView on macOS Monterey (Safari < 16.4)
+// can't parse `(?<=...)` and the whole bundle fails to load with an
+// "invalid group specifier name" error. Capture the leading char as
+// group 1 instead and let splitFilePaths skip past it. Issue #1209.
 const FILE_PATH_RE = new RegExp(
-  `(?:^|(?<=[\\s\`'"(\\[]))((?:[\\w.-]+\\/)+[\\w.-]+\\.(?:${KNOWN_EXTS}))(?::(\\d+(?:-\\d+)?))?(?=[\\s.,;!?\\]\\)'"\`]|$)`,
+  `(^|[\\s\`'"(\\[])((?:[\\w.-]+\\/)+[\\w.-]+\\.(?:${KNOWN_EXTS}))(?::(\\d+(?:-\\d+)?))?(?=[\\s.,;!?\\]\\)'"\`]|$)`,
   "g",
 );
 
@@ -113,9 +117,13 @@ function splitFilePaths(text: string): ReactNode[] | string {
   let last = 0;
   let m: RegExpExecArray | null = FILE_PATH_RE.exec(text);
   while (m !== null) {
-    if (m.index > last) out.push(text.slice(last, m.index));
-    out.push(<FilePill key={`fp-${m.index}`} path={m[1]!} line={m[2]} />);
-    last = m.index + m[0].length;
+    const prefix = m[1] ?? "";
+    const path = m[2]!;
+    const line = m[3];
+    const pillStart = m.index + prefix.length;
+    if (pillStart > last) out.push(text.slice(last, pillStart));
+    out.push(<FilePill key={`fp-${pillStart}`} path={path} line={line} />);
+    last = pillStart + path.length + (line ? line.length + 1 : 0);
     m = FILE_PATH_RE.exec(text);
   }
   if (out.length === 0) return text;

--- a/desktop/vite.config.ts
+++ b/desktop/vite.config.ts
@@ -1,14 +1,37 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import react from "@vitejs/plugin-react";
-import { defineConfig } from "vite";
+import { type Plugin, defineConfig } from "vite";
 
 const pkg = JSON.parse(
   readFileSync(fileURLToPath(new URL("./package.json", import.meta.url)), "utf8"),
 ) as { version: string };
 
+/**
+ * Strip variable-length lookbehind from mdast-util-gfm-autolink-literal's
+ * email regex. Tauri's WKWebView on macOS Monterey (Safari < 16.4) can't
+ * parse `(?<=^|\s|\p{P}|\p{S})` — the bundle fails to load with an "invalid
+ * group specifier name" SyntaxError before any script runs. The lookbehind
+ * was just a fast-path; the package's `previous()` check still filters
+ * neighbours after the match. Issue #1209.
+ */
+function patchGfmAutolinkLookbehind(): Plugin {
+  return {
+    name: "patch-gfm-autolink-lookbehind",
+    enforce: "pre",
+    transform(code, id) {
+      if (!id.includes("mdast-util-gfm-autolink-literal")) return null;
+      if (!code.includes("(?<=^|\\s|\\p{P}|\\p{S})")) return null;
+      return {
+        code: code.replace("(?<=^|\\s|\\p{P}|\\p{S})", ""),
+        map: null,
+      };
+    },
+  };
+}
+
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), patchGfmAutolinkLookbehind()],
   clearScreen: false,
   server: {
     host: "127.0.0.1",


### PR DESCRIPTION
## Problem

A user on macOS 12.7.6 (Monterey) reported the desktop app launches into a fully black window. Their Safari Web Inspector caught:

> \`SyntaxError: Invalid regular expression: invalid group specifier name\`

macOS 12 ships with a WKWebView older than Safari 16.4, which has **no lookbehind support at all**. When such an engine hits \`(?<=...)\` it falls through to the named-capture-group parser, sees \`=\` as the first character of the "name", and throws. This happens at **script parse time**, before any JS runs — so React never mounts and the user sees a black window.

Our bundle was shipping two lookbehinds.

## Fix

- **\`desktop/src/Markdown.tsx\` \`FILE_PATH_RE\`** used \`(?<=[\s\\`'"(\[])\` to gate the file-path match without consuming the prefix. Rewritten as a leading capture group; \`splitFilePaths\` advances past the captured prefix so FilePill boundaries stay the same. Same matches, no lookbehind.

- **\`mdast-util-gfm-autolink-literal\`** (bundled via \`remark-gfm\`) has a variable-length \`(?<=^|\s|\p{P}|\p{S})\` on its email pattern. The package's own \`previous()\` callback already validates the preceding character *after* the match, so the lookbehind is just a fast-fail optimisation. Stripped it at build time via a small Vite \`transform\` plugin scoped to that module's id. Behaviour identical; only the pre-filter is gone.

## Verify

- \`npm run verify\` — green (lint + typecheck + 3141 tests).
- \`npm --prefix desktop run build\` rebuilds cleanly.
- \`grep '(?<' dist/assets/index-*.js\` — **zero hits** after the rebuild (was 2 before).
- The Vite plugin is narrowly scoped (only touches files whose id includes \`mdast-util-gfm-autolink-literal\`), no other regexes are altered.

## Note for future regressions

If a new dependency or feature reintroduces lookbehind, the symptom will be the same: black window on macOS 12 Tauri WebView, with an "invalid group specifier name" SyntaxError visible in Safari Web Inspector. A grep of the built bundle for \`(?<\` would catch it.

Closes #1209