### PR TITLE
chore(desktop): i18n the per-message copy button tooltips

### DIFF
--- a/desktop/src/i18n/en.ts
+++ b/desktop/src/i18n/en.ts
@@ -599,6 +599,8 @@ export const en = {
     userChoiceKind: "user choice",
     optionCount: "{count} options",
     subagent: "subagent",
+    copyMessage: "Copy this message",
+    copyResponse: "Copy this response",
   },
   live: {
     reasoning: "live · reasoning",

--- a/desktop/src/i18n/zh-CN.ts
+++ b/desktop/src/i18n/zh-CN.ts
@@ -586,6 +586,8 @@ export const zhCN: typeof en = {
     userChoiceKind: "用户选择",
     optionCount: "{count} 个选项",
     subagent: "subagent",
+    copyMessage: "复制这条消息",
+    copyResponse: "复制这条回复",
   },
   live: {
     reasoning: "live · reasoning",

--- a/desktop/src/ui/thread.tsx
+++ b/desktop/src/ui/thread.tsx
@@ -55,7 +55,7 @@ export const UserMsg = memo(function UserMsg({
             type="button"
             className={`copy-btn ${copied ? "done" : ""}`}
             onClick={onCopy}
-            title="Copy this message"
+            title={t("thread.copyMessage")}
           >
             <Copy size={11} />
             {copied ? t("markdown.copied") : null}
@@ -174,7 +174,7 @@ export const AssistantMsg = memo(function AssistantMsg({
               type="button"
               className={`copy-btn ${copied ? "done" : ""}`}
               onClick={onCopy}
-              title="Copy this response"
+              title={t("thread.copyResponse")}
             >
               <Copy size={11} />
               {copied ? t("markdown.copied") : null}


### PR DESCRIPTION
Two hardcoded English \`title\` attributes (\"Copy this message\" / \"Copy this response\") slipped past #1208 in \`desktop/src/ui/thread.tsx\`. Routes them through new \`thread.copyMessage\` / \`thread.copyResponse\` keys (en + zh-CN) so the tooltips swap with the rest of the UI.

3 files, 6/2 lines, no behaviour change.