### PR TITLE
fix(desktop): remove Geist sans-serif from serif font stack

### DIFF
--- a/desktop/src/theme.ts
+++ b/desktop/src/theme.ts
@@ -42,5 +42,5 @@ export function isFontFamily(value: unknown): value is FontFamily {
 export const FONT_FAMILY_STACK: Record<FontFamily, string> = {
   sans: '"Geist", system-ui, sans-serif',
   system: '-apple-system, system-ui, "Segoe UI", Roboto, sans-serif',
-  serif: '"Geist", Georgia, serif',
+  serif: 'Georgia, "Times New Roman", serif',
 };


### PR DESCRIPTION
## Problem

Reported in #1212 — on macOS desktop, switching the font family to "Serif" in Settings → General does not change the English typeface. The user expects Georgia / Times New Roman (serif) but English text remains in Geist (sans-serif).

## Root cause

In `desktop/src/theme.ts`, the serif font stack includes `"Geist"` as the first entry:

```ts
serif: '"Geist", Georgia, serif',
```

**Geist is a geometric sans-serif typeface** (the same one used for the "Sans" option). Since Geist is bundled via `@fontsource` and always available, the browser matches it immediately — English/Latin glyphs never fall through to Georgia.

The user's screenshot confirms the exact symptom: Chinese characters changed (they fall through Geist and Georgia because neither covers CJK), but English stays in Geist — same as Sans.

## Fix

Remove `"Geist"` from the serif stack:

```diff
- serif: '"Geist", Georgia, serif',
+ serif: 'Georgia, "Times New Roman", serif',
```

| Font | macOS | Windows | Linux |
|------|:-----:|:-------:|:-----:|
| Georgia | built-in | built-in | widely available |
| Times New Roman | built-in | built-in | widely available |
| `serif` | system default | system default | system default |

## Testing

- [ ] `npm run lint` — no code changes beyond this line
- [ ] Manual: open desktop Settings → General → Font Family → Serif, verify English text renders in Georgia/Times New Roman

Closes #1212
