### PR TITLE
feat(desktop): persist window size and position across sessions

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -61,6 +61,7 @@ import {
 import { WorkdirPop } from "./ui/workdir-pop";
 import { useAutoScroll } from "./ui/useAutoScroll";
 import { useDisableTextAssist } from "./ui/useDisableTextAssist";
+import { useWindowBounds } from "./ui/useWindowBounds";
 
 export type AssistantSegment =
   | { kind: "text"; text: string }
@@ -2482,6 +2483,8 @@ export function App() {
     window.addEventListener("reasonix:currency", onCur);
     return () => window.removeEventListener("reasonix:currency", onCur);
   }, []);
+
+  useWindowBounds();
 
   const deliverToTab = useCallback((tabId: string, action: TabAction) => {
     const dispatch = dispatchersRef.current.get(tabId);

--- a/desktop/src/ui/useWindowBounds.ts
+++ b/desktop/src/ui/useWindowBounds.ts
@@ -1,0 +1,66 @@
+import { LogicalPosition, LogicalSize, getCurrentWindow } from "@tauri-apps/api/window";
+import { useEffect } from "react";
+
+const STORAGE_KEY = "reasonix.windowBounds";
+const MIN_WIDTH = 400;
+const MIN_HEIGHT = 300;
+const SAVE_DEBOUNCE_MS = 300;
+
+interface WindowBounds {
+  width: number;
+  height: number;
+  x: number;
+  y: number;
+}
+
+export function useWindowBounds() {
+  useEffect(() => {
+    const win = getCurrentWindow();
+
+    // Restore saved bounds
+    (async () => {
+      try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (!raw) return;
+        const saved = JSON.parse(raw) as WindowBounds;
+        if (saved.width >= MIN_WIDTH && saved.height >= MIN_HEIGHT) {
+          await win.setSize(new LogicalSize(saved.width, saved.height));
+          await win.setPosition(new LogicalPosition(saved.x, saved.y));
+        }
+      } catch {
+        localStorage.removeItem(STORAGE_KEY);
+      }
+    })();
+
+    // Debounced save on resize and move
+    let timer: ReturnType<typeof setTimeout>;
+    const scheduleSave = () => {
+      clearTimeout(timer);
+      timer = setTimeout(async () => {
+        try {
+          if (await win.isMaximized()) return;
+          const bounds: WindowBounds = {
+            width: window.innerWidth,
+            height: window.innerHeight,
+            x: window.screenX,
+            y: window.screenY,
+          };
+          localStorage.setItem(STORAGE_KEY, JSON.stringify(bounds));
+        } catch {
+          /* silently give up — localStorage full or window closed */
+        }
+      }, SAVE_DEBOUNCE_MS);
+    };
+
+    let unlistenResize: (() => void) | undefined;
+    let unlistenMove: (() => void) | undefined;
+    win.listen("tauri://resize", scheduleSave).then((fn) => { unlistenResize = fn; });
+    win.listen("tauri://move", scheduleSave).then((fn) => { unlistenMove = fn; });
+
+    return () => {
+      clearTimeout(timer);
+      unlistenResize?.();
+      unlistenMove?.();
+    };
+  }, []);
+}


### PR DESCRIPTION
## Summary

Persist the desktop window's size and position across sessions via `localStorage`, matching the existing persistence pattern already used for theme, font scale, font family, and currency. Fixes #1206.

## Problem

**Window resets to default bounds every launch.** The desktop client already persists theme (`reasonix.theme`), font scale (`reasonix.fontScale`), font family (`reasonix.fontFamily`), and currency (`reasonix.currency`) via `localStorage` in `App()` [App.tsx:2427-2443](desktop/src/App.tsx:2427-2443). The `isMaximized` state is tracked via `tauri://resize` event [App.tsx:1898-1904](desktop/src/App.tsx:1898-1904), but no saved size or position is restored on the next launch — the window always opens at Tauri's built-in default (typically centered, ~1024×768). Users who prefer a specific layout must manually resize and reposition every session.

## Fix

**New hook: `desktop/src/ui/useWindowBounds.ts`** — follows the existing extraction pattern (`useAutoScroll`, `useDisableTextAssist`):

- On mount, reads `localStorage("reasonix.windowBounds")` and restores the saved `{ width, height, x, y }` via Tauri's `LogicalSize` / `LogicalPosition` from `@tauri-apps/api/window` [useWindowBounds.ts:25-34](desktop/src/ui/useWindowBounds.ts:25-34).
- Listens to `tauri://resize` and `tauri://move` events, debounced 300ms, saving the current `window.innerWidth` / `innerHeight` / `screenX` / `screenY` [useWindowBounds.ts:38-53](desktop/src/ui/useWindowBounds.ts:38-53).
- Skips saving when maximized — full-screen state belongs to the OS, not the app [useWindowBounds.ts:43](desktop/src/ui/useWindowBounds.ts:43).
- Minimum thresholds (400×300) prevent restoring a tiny/unusable window from corrupted data [useWindowBounds.ts:6-7](desktop/src/ui/useWindowBounds.ts:6-7).

**Wire into App: `desktop/src/App.tsx`** — import + single call `useWindowBounds()` alongside other persistence hooks [App.tsx:2471](desktop/src/App.tsx:2470-2471).

## Verification

| Check | Result |
|---|---|
| `npm run lint` | ✅ 608 files, no fixes needed |
| `npm run typecheck` | ✅ passes |
| `npm run build` | ✅ both CLI and dashboard bundles succeed |

**Test suite:**



The single failure (`tests/chat-mcp-startup-summary.test.ts`) is a pre-existing MCP flaky test — it fails on `main` identically and is unrelated to this change.

**Local smoke test (recommended):**
1. Launch the desktop app, resize and reposition the window.
2. Quit and relaunch — the window should open at the same size and position.
3. Maximize, quit, relaunch — should open at the previous non-maximized bounds (not the maximized dimensions).
