### PR TITLE
feat(dashboard): new / switch / delete sessions in-place, no CLI bounce

### DIFF
--- a/dashboard/src/i18n/en.ts
+++ b/dashboard/src/i18n/en.ts
@@ -304,6 +304,16 @@ export const en = {
     loadingTranscript: "loading transcript…",
     emptyTranscript: "empty transcript.",
     messages: "{count} message{s}",
+    newBtn: "New session",
+    newHint: "Archive the current conversation and start a fresh one",
+    switchBtn: "Switch to this session",
+    deleteBtn: "Delete",
+    deleteConfirm: "Delete session \"{name}\"? This removes the transcript file and cannot be undone.",
+    cantDeleteActive: "Switch to a different session before deleting this one.",
+    attachRequired:
+      "Live session operations need an attached CLI session. Launch via reasonix chat or open the dashboard from inside a TUI session.",
+    activeChip: "active",
+    activePill: "active",
   },
   tools: {
     loading: "loading tools…",

--- a/dashboard/src/i18n/zh-CN.ts
+++ b/dashboard/src/i18n/zh-CN.ts
@@ -300,6 +300,16 @@ export const zhCN = {
     loadingTranscript: "加载转录稿…",
     emptyTranscript: "空的转录稿。",
     messages: "{count} 条消息",
+    newBtn: "新建会话",
+    newHint: "归档当前会话并开启新会话",
+    switchBtn: "切换到此会话",
+    deleteBtn: "删除",
+    deleteConfirm: "确定删除会话「{name}」？转录文件将被移除，无法撤销。",
+    cantDeleteActive: "请先切换到其他会话，再删除当前会话。",
+    attachRequired:
+      "实时会话操作需要已连接的 CLI 会话。请通过 reasonix chat 启动，或在 TUI 会话中打开仪表盘。",
+    activeChip: "当前",
+    activePill: "当前",
   },
   tools: {
     loading: "加载工具…",

--- a/dashboard/src/panels/sessions.ts
+++ b/dashboard/src/panels/sessions.ts
@@ -15,6 +15,8 @@ interface SessionEntry {
 
 interface SessionsData {
   sessions?: SessionEntry[];
+  currentSession?: string | null;
+  canSwitch?: boolean;
 }
 
 interface OpenSession {
@@ -25,10 +27,12 @@ interface OpenSession {
 
 export function SessionsPanel() {
   useLang();
-  const { data, error, loading } = usePoll<SessionsData>("/sessions", 5000);
+  const { data, error, loading, refresh } = usePoll<SessionsData>("/sessions", 5000);
   const [open, setOpen] = useState<OpenSession | null>(null);
   const [openLoading, setOpenLoading] = useState(false);
   const [filter, setFilter] = useState("");
+  const [busy, setBusy] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
 
   const view = useCallback(async (name: string) => {
     setOpen({ name, messages: null });
@@ -43,13 +47,62 @@ export function SessionsPanel() {
     }
   }, []);
 
+  const newSession = useCallback(async () => {
+    setBusy("new");
+    setActionError(null);
+    try {
+      await api("/sessions/new", { method: "POST" });
+      setOpen(null);
+      await refresh();
+    } catch (err) {
+      setActionError((err as Error).message);
+    } finally {
+      setBusy(null);
+    }
+  }, [refresh]);
+
+  const switchTo = useCallback(
+    async (name: string) => {
+      setBusy(`switch:${name}`);
+      setActionError(null);
+      try {
+        await api(`/sessions/${encodeURIComponent(name)}/switch`, { method: "POST" });
+        setOpen(null);
+        await refresh();
+      } catch (err) {
+        setActionError((err as Error).message);
+      } finally {
+        setBusy(null);
+      }
+    },
+    [refresh],
+  );
+
+  const remove = useCallback(
+    async (name: string) => {
+      if (!confirm(t("sessions.deleteConfirm", { name }))) return;
+      setBusy(`delete:${name}`);
+      setActionError(null);
+      try {
+        await api(`/sessions/${encodeURIComponent(name)}`, { method: "DELETE" });
+        if (open?.name === name) setOpen(null);
+        await refresh();
+      } catch (err) {
+        setActionError((err as Error).message);
+      } finally {
+        setBusy(null);
+      }
+    },
+    [open, refresh],
+  );
+
   if (loading && !data)
     return html`<div class="card" style="color:var(--fg-3)">${t("sessions.loading")}</div>`;
-  if (error) return html`<div class="card accent-err">${t("common.loadingFailed", { name: "sessions", error: error.message })}</div>`;
+  if (error)
+    return html`<div class="card accent-err">${t("common.loadingFailed", { name: "sessions", error: error.message })}</div>`;
   const sessions = data?.sessions ?? [];
-
-  if (sessions.length === 0)
-    return html`<div class="card" style="color:var(--fg-3)">${t("sessions.noSessions")}</div>`;
+  const currentSession = data?.currentSession ?? null;
+  const canSwitch = data?.canSwitch ?? false;
 
   const filtered = filter.trim()
     ? sessions.filter((s) => s.name.toLowerCase().includes(filter.toLowerCase()))
@@ -58,7 +111,7 @@ export function SessionsPanel() {
   return html`
     <div class="sessions-grid">
       <div class="sessions-list">
-        <div class="ssl-h">
+        <div class="ssl-h" style="display:flex;gap:6px">
           <input
             type="text"
             placeholder=${t("sessions.filterPlaceholder")}
@@ -66,27 +119,54 @@ export function SessionsPanel() {
             onInput=${(e: Event) => setFilter((e.target as HTMLInputElement).value)}
             style="flex:1"
           />
+          <button
+            class="btn primary"
+            disabled=${!canSwitch || busy === "new"}
+            title=${canSwitch ? t("sessions.newHint") : t("sessions.attachRequired")}
+            onClick=${newSession}
+          >
+            ${busy === "new" ? t("common.loading") : `+ ${t("sessions.newBtn")}`}
+          </button>
         </div>
+        ${
+          !canSwitch
+            ? html`<div style="padding:0 12px 6px;font-size:11.5px;color:var(--fg-3)">${t("sessions.attachRequired")}</div>`
+            : null
+        }
+        ${
+          actionError
+            ? html`<div class="card accent-err" style="margin:0 12px 8px;padding:6px 10px;font-size:12px">${actionError}</div>`
+            : null
+        }
         <div class="chips" style="padding:0 12px 8px">
           <span class="chip-f static active">${t("common.all")} <span class="ct">${sessions.length}</span></span>
+          ${currentSession ? html`<span class="chip-f static">${t("sessions.activeChip")} <span class="ct">${currentSession}</span></span>` : null}
         </div>
-        <div class="ssl-rows">
-          ${filtered.map(
-            (s) => html`
-              <div
-                class=${`ssl-row ${open?.name === s.name ? "sel" : ""}`}
-                onClick=${() => view(s.name)}
-              >
-                <span class="name">${s.name}</span>
-                <span class="meta">
-                  <span><span class="v">${fmtNum(s.messageCount)}</span> ${t("sessions.msgs")}</span>
-                  <span><span class="v">${fmtBytes(s.size)}</span></span>
-                  <span>${fmtRelativeTime(s.mtime)}</span>
-                </span>
-              </div>
-            `,
-          )}
-        </div>
+        ${
+          sessions.length === 0
+            ? html`<div class="ctx-empty" style="padding:24px 12px;color:var(--fg-3)">${t("sessions.noSessions")}</div>`
+            : html`<div class="ssl-rows">
+                ${filtered.map((s) => {
+                  const isCurrent = currentSession === s.name;
+                  return html`
+                    <div
+                      class=${`ssl-row ${open?.name === s.name ? "sel" : ""}`}
+                      onClick=${() => view(s.name)}
+                    >
+                      <span class="name">
+                        ${isCurrent ? html`<span class="pill ok" style="margin-right:6px">${t("sessions.activePill")}</span>` : null}
+                        ${s.name}
+                      </span>
+                      <span class="meta">
+                        <span><span class="v">${fmtNum(s.messageCount)}</span> ${t("sessions.msgs")}</span>
+                        <span><span class="v">${fmtBytes(s.size)}</span></span>
+                        <span>${fmtRelativeTime(s.mtime)}</span>
+                      </span>
+                    </div>
+                  `;
+                })}
+              </div>`
+        }
       </div>
 
       <div class="sessions-detail">
@@ -95,9 +175,14 @@ export function SessionsPanel() {
             ? html`<div style="color:var(--fg-3);font-size:13px;text-align:center;padding:60px 20px">
                 ${t("sessions.pickHint")}
               </div>`
-            : html`
+            : (() => {
+                const isCurrent = currentSession === open.name;
+                return html`
                 <div class="sessions-detail-h">
-                  <span class="name">${open.name}</span>
+                  <span class="name">
+                    ${isCurrent ? html`<span class="pill ok" style="margin-right:6px">${t("sessions.activePill")}</span>` : null}
+                    ${open.name}
+                  </span>
                   <span class="ws">
                     ${
                       open.messages
@@ -106,16 +191,32 @@ export function SessionsPanel() {
                     }
                   </span>
                   <span class="actions">
+                    ${
+                      canSwitch && !isCurrent
+                        ? html`<button class="btn primary" disabled=${busy === `switch:${open.name}`} onClick=${() => switchTo(open.name)}>${busy === `switch:${open.name}` ? t("common.loading") : t("sessions.switchBtn")}</button>`
+                        : null
+                    }
+                    <button
+                      class="btn"
+                      disabled=${isCurrent || busy === `delete:${open.name}`}
+                      title=${isCurrent ? t("sessions.cantDeleteActive") : t("sessions.deleteBtn")}
+                      style="border-color:var(--c-err);color:var(--c-err)"
+                      onClick=${() => remove(open.name)}
+                    >${busy === `delete:${open.name}` ? t("common.loading") : t("sessions.deleteBtn")}</button>
                     <button class="btn ghost" onClick=${() => setOpen(null)}>${t("common.back")}</button>
                   </span>
                 </div>
-                <div class="card accent-brand" style="margin-bottom:10px">
-                  <div class="card-h"><span class="title">${t("sessions.resumeTitle")}</span></div>
-                  <div class="card-b" style="font-size:12.5px;color:var(--fg-2)">
-                    ${t("sessions.resumeDesc")}
-                    <code class="mono" style="display:block;margin-top:8px;padding:8px 10px;background:var(--bg-input);border-radius:var(--r);color:var(--fg-0);font-size:12px;user-select:all">reasonix chat --session ${open.name}</code>
-                  </div>
-                </div>
+                ${
+                  !canSwitch
+                    ? html`<div class="card accent-brand" style="margin-bottom:10px">
+                        <div class="card-h"><span class="title">${t("sessions.resumeTitle")}</span></div>
+                        <div class="card-b" style="font-size:12.5px;color:var(--fg-2)">
+                          ${t("sessions.resumeDesc")}
+                          <code class="mono" style="display:block;margin-top:8px;padding:8px 10px;background:var(--bg-input);border-radius:var(--r);color:var(--fg-0);font-size:12px;user-select:all">reasonix chat --session ${open.name}</code>
+                        </div>
+                      </div>`
+                    : null
+                }
                 ${
                   openLoading
                     ? html`<div style="color:var(--fg-3)">${t("sessions.loadingTranscript")}</div>`
@@ -147,7 +248,8 @@ export function SessionsPanel() {
                           </div>`
                         : html`<div style="color:var(--fg-3)">${t("sessions.emptyTranscript")}</div>`
                 }
-              `
+              `;
+              })()
         }
       </div>
     </div>

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -2288,6 +2288,12 @@ function AppInner({
                 return r.summaries.length;
               }
             : undefined,
+          switchSession: onSwitchSession
+            ? (name) => {
+                onSwitchSession(name);
+                return { ok: true as const };
+              }
+            : undefined,
         },
         { port: dashboardPort, host: dashboardHost, token: dashboardToken },
       );
@@ -2323,6 +2329,7 @@ function AppInner({
     currentRootDirRef,
     reloadHooks,
     setPreset,
+    onSwitchSession,
     dashboardPort,
     dashboardHost,
     dashboardToken,

--- a/src/server/api/sessions.ts
+++ b/src/server/api/sessions.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
-import { listSessions, sessionPath } from "../../memory/session.js";
+import { deleteSession, listSessions, sessionPath } from "../../memory/session.js";
 import type { DashboardContext } from "../context.js";
 import type { ApiResult } from "../router.js";
 
@@ -45,15 +45,12 @@ export async function handleSessions(
   method: string,
   rest: string[],
   _body: string,
-  _ctx: DashboardContext,
+  ctx: DashboardContext,
 ): Promise<ApiResult> {
-  if (method !== "GET") {
-    return { status: 405, body: { error: "GET only" } };
-  }
-
   // Listing.
-  if (rest.length === 0) {
+  if (method === "GET" && rest.length === 0) {
     const sessions = listSessions();
+    const currentName = ctx.getSessionName?.() ?? null;
     return {
       status: 200,
       body: {
@@ -64,25 +61,80 @@ export async function handleSessions(
           messageCount: s.messageCount,
           mtime: s.mtime.getTime(),
         })),
+        currentSession: currentName,
+        canSwitch: Boolean(ctx.switchSession),
       },
     };
   }
 
-  // Single-session detail. URL-decode in case the name had spaces / CJK
-  // (sanitizeName allows them).
+  // New session — mints a fresh session by calling switchSession(undefined),
+  // which routes through the same path the SessionPicker "new" branch takes.
+  if (method === "POST" && rest.length === 1 && rest[0] === "new") {
+    if (!ctx.switchSession) {
+      return {
+        status: 503,
+        body: { error: "live session swap requires an attached CLI session." },
+      };
+    }
+    const result = ctx.switchSession(undefined);
+    if (!result.ok) return { status: 500, body: { error: result.reason } };
+    return { status: 200, body: { ok: true } };
+  }
+
+  if (rest.length === 0) {
+    return { status: 405, body: { error: `method ${method} not supported on /sessions` } };
+  }
+
+  // Single-session detail / switch / delete. URL-decode in case the name
+  // had spaces / CJK (sanitizeName allows them).
   const name = decodeURIComponent(rest[0]!);
   const path = sessionPath(name);
-  if (!existsSync(path)) {
-    return { status: 404, body: { error: `no such session: ${name}` } };
+  const currentName = ctx.getSessionName?.() ?? null;
+
+  if (method === "POST" && rest[1] === "switch") {
+    if (!ctx.switchSession) {
+      return {
+        status: 503,
+        body: { error: "live session swap requires an attached CLI session." },
+      };
+    }
+    if (!existsSync(path)) return { status: 404, body: { error: `no such session: ${name}` } };
+    const result = ctx.switchSession(name);
+    if (!result.ok) return { status: 500, body: { error: result.reason } };
+    return { status: 200, body: { ok: true } };
   }
-  const messages = parseTranscript(path);
-  return {
-    status: 200,
-    body: {
-      name,
-      path,
-      messages,
-      messageCount: messages.length,
-    },
-  };
+
+  if (method === "DELETE") {
+    if (rest.length !== 1) {
+      return { status: 405, body: { error: `method ${method} not supported on this path` } };
+    }
+    // Refuse to delete the currently-attached session — the live process
+    // still has the file open for append, and deleting it would resurrect
+    // an empty file on the next message.
+    if (currentName && name === currentName) {
+      return {
+        status: 409,
+        body: { error: "cannot delete the currently-active session — switch away first." },
+      };
+    }
+    if (!existsSync(path)) return { status: 404, body: { error: `no such session: ${name}` } };
+    const removed = deleteSession(name);
+    if (!removed) return { status: 500, body: { error: `failed to delete ${name}` } };
+    ctx.audit?.({ ts: Date.now(), action: "delete-session", payload: { name } });
+    return { status: 200, body: { ok: true, deleted: name } };
+  }
+
+  if (method === "GET") {
+    if (rest.length !== 1) {
+      return { status: 405, body: { error: `method ${method} not supported on this path` } };
+    }
+    if (!existsSync(path)) return { status: 404, body: { error: `no such session: ${name}` } };
+    const messages = parseTranscript(path);
+    return {
+      status: 200,
+      body: { name, path, messages, messageCount: messages.length },
+    };
+  }
+
+  return { status: 405, body: { error: `method ${method} not supported on this path` } };
 }

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -85,6 +85,8 @@ export interface DashboardContext {
 
   reloadHooks?: () => number;
   reloadMcp?: () => Promise<number>;
+  /** Live session swap — pass a name to switch into an existing session, or `undefined` to mint a fresh one. Available only in attached mode (an active CLI session to swap inside of). */
+  switchSession?: (name: string | undefined) => { ok: true } | { ok: false; reason: string };
   invokeMcpTool?: (
     serverLabel: string,
     toolName: string,

--- a/tests/dashboard-sessions-ops.test.ts
+++ b/tests/dashboard-sessions-ops.test.ts
@@ -1,0 +1,134 @@
+/** Dashboard sessions API — new / switch / delete with an attached switchSession callback wired in. */
+
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { appendSessionMessage, patchSessionMeta, sessionPath } from "../src/memory/session.js";
+import { type DashboardServerHandle, startDashboardServer } from "../src/server/index.js";
+
+const TOKEN = "e".repeat(64);
+
+interface FetchResult {
+  status: number;
+  body: any;
+}
+
+async function call(
+  url: string,
+  opts: { method?: string; body?: unknown } = {},
+): Promise<FetchResult> {
+  const u = new URL(url);
+  u.searchParams.set("token", TOKEN);
+  const method = opts.method ?? "GET";
+  const headers: Record<string, string> = {};
+  // POST / DELETE require the token in the header (CSRF defence — query alone rejected).
+  if (method !== "GET") headers["X-Reasonix-Token"] = TOKEN;
+  if (opts.body !== undefined) headers["Content-Type"] = "application/json";
+  const res = await fetch(u.toString(), {
+    method,
+    headers,
+    body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+  });
+  const text = await res.text();
+  let parsed: any = null;
+  try {
+    parsed = text ? JSON.parse(text) : null;
+  } catch {
+    parsed = text;
+  }
+  return { status: res.status, body: parsed };
+}
+
+describe("dashboard /sessions: new / switch / delete (attached)", () => {
+  let dir: string;
+  let handle: DashboardServerHandle | null = null;
+  const switchCalls: Array<string | undefined> = [];
+  let currentName: string | null = "alpha";
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "reasonix-sess-ops-"));
+    // Re-home so listSessions reads from our temp dir, not the user's real ~/.reasonix.
+    vi.stubEnv("USERPROFILE", dir);
+    vi.stubEnv("HOME", dir);
+    vi.spyOn(require("node:os"), "homedir").mockReturnValue(dir);
+
+    // Seed two sessions: alpha (active) + beta.
+    appendSessionMessage("alpha", { role: "user", content: "hi" });
+    appendSessionMessage("beta", { role: "user", content: "hello" });
+    patchSessionMeta("alpha", { workspace: dir });
+    patchSessionMeta("beta", { workspace: dir });
+
+    switchCalls.length = 0;
+    currentName = "alpha";
+
+    handle = await startDashboardServer(
+      {
+        mode: "attached",
+        configPath: join(dir, "config.json"),
+        usageLogPath: join(dir, "usage.jsonl"),
+        getSessionName: () => currentName,
+        switchSession: (name) => {
+          switchCalls.push(name);
+          currentName = name ?? "(fresh)";
+          return { ok: true as const };
+        },
+      },
+      { token: TOKEN },
+    );
+  });
+
+  afterEach(async () => {
+    await handle?.close();
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("GET /api/sessions includes currentSession + canSwitch=true when wired", async () => {
+    const base = handle!.url.split("?")[0]!;
+    const r = await call(`${base}api/sessions`);
+    expect(r.status).toBe(200);
+    expect(r.body.currentSession).toBe("alpha");
+    expect(r.body.canSwitch).toBe(true);
+    const names = r.body.sessions.map((s: any) => s.name).sort();
+    expect(names).toEqual(["alpha", "beta"]);
+  });
+
+  it("POST /api/sessions/new calls switchSession(undefined)", async () => {
+    const base = handle!.url.split("?")[0]!;
+    const r = await call(`${base}api/sessions/new`, { method: "POST" });
+    expect(r.status).toBe(200);
+    expect(switchCalls).toEqual([undefined]);
+  });
+
+  it("POST /api/sessions/<name>/switch calls switchSession(name)", async () => {
+    const base = handle!.url.split("?")[0]!;
+    const r = await call(`${base}api/sessions/beta/switch`, { method: "POST" });
+    expect(r.status).toBe(200);
+    expect(switchCalls).toEqual(["beta"]);
+  });
+
+  it("POST /api/sessions/<missing>/switch returns 404 without calling switchSession", async () => {
+    const base = handle!.url.split("?")[0]!;
+    const r = await call(`${base}api/sessions/ghost/switch`, { method: "POST" });
+    expect(r.status).toBe(404);
+    expect(switchCalls).toEqual([]);
+  });
+
+  it("DELETE /api/sessions/<active> returns 409 and leaves the file intact", async () => {
+    const base = handle!.url.split("?")[0]!;
+    const r = await call(`${base}api/sessions/alpha`, { method: "DELETE" });
+    expect(r.status).toBe(409);
+    expect(existsSync(sessionPath("alpha"))).toBe(true);
+  });
+
+  it("DELETE /api/sessions/<non-active> unlinks the jsonl", async () => {
+    const base = handle!.url.split("?")[0]!;
+    expect(existsSync(sessionPath("beta"))).toBe(true);
+    const r = await call(`${base}api/sessions/beta`, { method: "DELETE" });
+    expect(r.status).toBe(200);
+    expect(r.body.deleted).toBe("beta");
+    expect(existsSync(sessionPath("beta"))).toBe(false);
+  });
+});

--- a/tests/server-dashboard.test.ts
+++ b/tests/server-dashboard.test.ts
@@ -801,6 +801,33 @@ describe("dashboard server: v0.13 panels", () => {
     expect(r.status).toBe(404);
   });
 
+  it("GET /api/sessions returns canSwitch=false when no switchSession callback is wired", async () => {
+    const base = handle!.url.split("?")[0]!;
+    const r = await call(`${base}api/sessions`, { token: TOKEN });
+    expect(r.status).toBe(200);
+    expect(r.body.canSwitch).toBe(false);
+  });
+
+  it("POST /api/sessions/new returns 503 without an attached switchSession callback", async () => {
+    const base = handle!.url.split("?")[0]!;
+    const r = await call(`${base}api/sessions/new`, {
+      token: TOKEN,
+      tokenInHeader: true,
+      method: "POST",
+    });
+    expect(r.status).toBe(503);
+  });
+
+  it("DELETE /api/sessions/<missing> returns 404", async () => {
+    const base = handle!.url.split("?")[0]!;
+    const r = await call(`${base}api/sessions/never-existed`, {
+      token: TOKEN,
+      tokenInHeader: true,
+      method: "DELETE",
+    });
+    expect(r.status).toBe(404);
+  });
+
   it("GET /api/plans returns empty array when no archives exist", async () => {
     const base = handle!.url.split("?")[0]!;
     const r = await call(`${base}api/plans`, { token: TOKEN });


### PR DESCRIPTION
## Problem

The dashboard's \`/sessions\` panel could only **browse** — you could click into a session to read its transcript, but to actually create a new one, switch into a different one, or delete a stale one you had to drop back to the CLI. The panel even printed a \`reasonix chat --session X\` hint with no in-place action button. Users got stuck wondering why nothing on the panel was clickable. Issue #1216.

## Fix

Wire the existing CLI-side \`onSwitchSession\` callback (used by the in-TUI \`SessionPicker\`) through to the dashboard context, then expose three endpoints + matching panel actions:

| Method | Path                              | Action                                           |
|--------|-----------------------------------|--------------------------------------------------|
| POST   | \`/api/sessions/new\`             | \`switchSession(undefined)\` — mint a fresh one  |
| POST   | \`/api/sessions/<name>/switch\`   | \`switchSession(name)\` — swap into an existing  |
| DELETE | \`/api/sessions/<name>\`          | \`deleteSession(name)\`; 409 on the active session, 404 if missing |

\`GET /api/sessions\` now also returns \`currentSession\` + \`canSwitch\` so the SPA can degrade gracefully in **standalone mode**: when no CLI is attached, the buttons disable themselves and the existing \"resume in TUI\" hint stays as a fallback.

### Panel UX

- Top-of-list **+ New session** button.
- Active-session pill + chip so users see which one is live before they touch anything.
- Per-row **Switch to this session** (disabled on the active row) and **Delete** (disabled on the active row, with confirm + i18n).
- Action errors render inline above the list instead of vanishing into the console.

## Verify

- \`npm run verify\` — green (lint + typecheck + 3150 tests).
- New tests:
  - \`tests/dashboard-sessions-ops.test.ts\` (6 cases, attached path): GET shape with \`canSwitch\`/\`currentSession\`, POST new fires \`switchSession(undefined)\`, POST switch fires the name, missing-name 404, DELETE refuses the active session with 409, DELETE actually unlinks a non-active jsonl.
  - \`tests/server-dashboard.test.ts\` (3 cases, standalone path): \`canSwitch:false\` in the response, POST new returns 503 without the callback, DELETE missing returns 404.

## Safety notes

- **DELETE on the active session is refused (409)** — the live process still holds the file open for append; unlinking would resurrect an empty file on the next message.
- POST mutations require the \`X-Reasonix-Token\` header (CSRF defence already in place); the SPA's \`api\` helper sets it.

Closes #1216