### PR TITLE
feat(desktop): add /feedback slash command

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -61,6 +61,7 @@ import {
 import { WorkdirPop } from "./ui/workdir-pop";
 import { useAutoScroll } from "./ui/useAutoScroll";
 import { useDisableTextAssist } from "./ui/useDisableTextAssist";
+import { openUrl } from "@tauri-apps/plugin-opener";
 
 export type AssistantSegment =
   | { kind: "text"; text: string }
@@ -1374,6 +1375,15 @@ function TabRuntime({
       cmd: "/export",
       desc: t("app.cmd.exportMd"),
       run: () => exportConversation(),
+    },
+    {
+      cmd: "/feedback",
+      desc: t("app.cmd.feedback"),
+      run: () => {
+        void openUrl("https://github.com/esengine/DeepSeek-Reasonix/issues/new/choose").catch(
+          () => undefined,
+        );
+      },
     },
     ...state.skills.map((s) => ({
       cmd: `/${s.name}`,

--- a/desktop/src/i18n/en.ts
+++ b/desktop/src/i18n/en.ts
@@ -317,6 +317,7 @@ export const en = {
       toggleLang: "Toggle language (CN / EN)",
       exportMd: "Copy session as Markdown",
       help: "Show all commands",
+      feedback: "Submit feedback on GitHub (opens browser)",
     },
     yolo: {
       banner1: "All tool calls, shell commands, and file edits will be ",

--- a/desktop/src/i18n/zh-CN.ts
+++ b/desktop/src/i18n/zh-CN.ts
@@ -334,6 +334,7 @@ export const zhCN: typeof en = {
       toggleLang: "切换界面语言 (中 / 英)",
       exportMd: "复制本会话为 Markdown",
       help: "查看所有命令",
+      feedback: "在 GitHub 提交反馈（打开浏览器）",
     },
     yolo: {
       banner1: "所有工具调用、shell 命令、文件编辑都会",


### PR DESCRIPTION
## Summary

Adds `/feedback` to the desktop slash command palette — opens the GitHub new-issue page in the system browser so users can report bugs and request features directly from the desktop client.

Refs #1220 (desktop command parity with CLI).

## What

| File | Change |
|------|--------|
| `desktop/src/App.tsx` | +`/feedback` slash command using `@tauri-apps/plugin-opener` |
| `desktop/src/i18n/en.ts` | +`app.cmd.feedback` English label |
| `desktop/src/i18n/zh-CN.ts` | +`app.cmd.feedback` Chinese label |

## Notes

- No backend RPC needed — this is a pure desktop-side operation (open URL)
- `/compact`, `/retry`, `/btw` require backend RPC support and will follow in a separate PR
- Uses `@tauri-apps/plugin-opener` which is already a dependency (used by About modal and Markdown links)
