### PR TITLE
feat(desktop): add /compact, /retry, /btw + /feedback slash commands

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -62,6 +62,7 @@ import { WorkdirPop } from "./ui/workdir-pop";
 import { useAutoScroll } from "./ui/useAutoScroll";
 import { useDisableTextAssist } from "./ui/useDisableTextAssist";
 import { useWindowBounds } from "./ui/useWindowBounds";
+import { openUrl } from "@tauri-apps/plugin-opener";
 
 export type AssistantSegment =
   | { kind: "text"; text: string }
@@ -232,6 +233,9 @@ type State = {
   activeSkill: SkillOrigin | null;
   /** Messages typed while busy=true — auto-sent FIFO once the current turn completes. Cleared on `clear`, `rpc_exit`, `session_loaded`. */
   queuedSends: string[];
+  /** Populated by $retry_result — component useEffect reads and sets composer draft. */
+  retryText?: string;
+  retryNonce: number;
 };
 
 export type SessionFile = {
@@ -377,6 +381,7 @@ function reduce(state: State, action: Action): State {
         sessionFiles: [],
         activeSkill: null,
         queuedSends: [],
+        retryNonce: 0,
       };
     case "resolve_confirm":
       return {
@@ -673,6 +678,7 @@ function applyIncoming(state: State, ev: IncomingEvent): State {
         activePlan: wsChanged ? null : state.activePlan,
         usage: wsChanged ? zeroUsage() : state.usage,
         sessionFiles: wsChanged ? [] : state.sessionFiles,
+        retryNonce: wsChanged ? 0 : state.retryNonce,
         settings: {
           reasoningEffort: ev.reasoningEffort,
           editMode: ev.editMode,
@@ -743,6 +749,7 @@ function applyIncoming(state: State, ev: IncomingEvent): State {
         sessionFiles,
         activeSkill: null,
         queuedSends: [],
+        retryNonce: 0,
       };
     }
     case "$session_empty": {
@@ -896,6 +903,16 @@ function applyIncoming(state: State, ev: IncomingEvent): State {
           return mutated ? { ...m, segments: segs } : m;
         }),
       };
+    case "$retry_result":
+      return { ...state, retryText: ev.text, retryNonce: state.retryNonce + 1 };
+    case "$btw_result":
+      return {
+        ...state,
+        messages: [
+          ...state.messages,
+          { kind: "status", text: `≫ btw\n${ev.answer}` },
+        ],
+      };
     case "status":
       return state;
     default:
@@ -989,6 +1006,7 @@ function TabRuntime({
     jobs: [],
     activeSkill: null,
     queuedSends: [],
+    retryNonce: 0,
   });
   useLang();
   useDisableTextAssist();
@@ -1152,6 +1170,17 @@ function TabRuntime({
     (override?: string) => {
       const text = (override ?? draft).trim();
       if (!text || !state.ready || state.busy) return;
+
+      // /btw <question> — route to side-question RPC instead of user_input
+      const btwMatch = /^\/btw(?:\s+([\s\S]+))?$/.exec(text);
+      if (btwMatch) {
+        const question = btwMatch[1]?.trim() ?? "";
+        if (!question) return;
+        sendRpc({ cmd: "btw", text: question });
+        if (!override) setDraft("");
+        return;
+      }
+
       const clientId = `c-${Date.now()}`;
       dispatch({ t: "send_user", text, clientId });
       sendRpc({ cmd: "user_input", text });
@@ -1161,6 +1190,16 @@ function TabRuntime({
   );
 
   const abort = useCallback(() => sendRpc({ cmd: "abort" }), [sendRpc]);
+
+  // When /retry returns the last user text, set it as the composer draft
+  useEffect(() => {
+    if (state.retryNonce > 0 && state.retryText) {
+      setDraft(state.retryText);
+      composerRef.current?.focus();
+    }
+    // Only fire when retryNonce changes — retryText alone would re-fire on re-renders
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.retryNonce]);
 
   useEffect(() => {
     if (state.busy || !state.ready || state.queuedSends.length === 0) return;
@@ -1389,6 +1428,35 @@ function TabRuntime({
       cmd: "/export",
       desc: t("app.cmd.exportMd"),
       run: () => exportConversation(),
+    },
+    {
+      cmd: "/feedback",
+      desc: t("app.cmd.feedback"),
+      run: () => {
+        void openUrl("https://github.com/esengine/DeepSeek-Reasonix/issues/new/choose").catch(
+          () => undefined,
+        );
+      },
+    },
+    {
+      cmd: "/compact",
+      desc: t("app.cmd.compact"),
+      run: () => sendRpc({ cmd: "compact_history" }),
+    },
+    {
+      cmd: "/retry",
+      desc: t("app.cmd.retry"),
+      run: () => sendRpc({ cmd: "retry" }),
+    },
+    {
+      cmd: "/btw",
+      desc: t("app.cmd.btw"),
+      run: () => {
+        // Sets the draft to /btw so the user can type their question.
+        // The send() handler detects the /btw prefix and routes to the btw RPC.
+        setDraft("/btw ");
+        composerRef.current?.focus();
+      },
     },
     ...state.skills.map((s) => ({
       cmd: `/${s.name}`,

--- a/desktop/src/i18n/en.ts
+++ b/desktop/src/i18n/en.ts
@@ -317,6 +317,10 @@ export const en = {
       toggleLang: "Toggle language (CN / EN)",
       exportMd: "Copy session as Markdown",
       help: "Show all commands",
+      feedback: "Submit feedback on GitHub (opens browser)",
+      compact: "Fold older turns into a summary (save context)",
+      retry: "Truncate and resend your last message",
+      btw: "Ask a side question (never added to context)",
     },
     skill: {
       generic: "{scope} skill · {runAs}",

--- a/desktop/src/i18n/zh-CN.ts
+++ b/desktop/src/i18n/zh-CN.ts
@@ -334,6 +334,10 @@ export const zhCN: typeof en = {
       toggleLang: "切换界面语言 (中 / 英)",
       exportMd: "复制本会话为 Markdown",
       help: "查看所有命令",
+      feedback: "在 GitHub 提交反馈（打开浏览器）",
+      compact: "折叠旧轮次为摘要（节省上下文）",
+      retry: "截断并重发你的最后一条消息",
+      btw: "旁路提问（不写入会话上下文）",
     },
     skill: {
       generic: "{scope}技能 · {runAs}",

--- a/desktop/src/protocol.ts
+++ b/desktop/src/protocol.ts
@@ -181,6 +181,10 @@ export type MemoryEvent = {
   entries: MemoryEntryInfo[];
 };
 
+export type RetryResultEvent = { type: "$retry_result"; text: string };
+
+export type BtwResultEvent = { type: "$btw_result"; question: string; answer: string };
+
 export type JobInfo = {
   id: number;
   tabId: string;
@@ -406,6 +410,8 @@ export type IncomingEvent = { tabId?: string } & (
   | ToolResultEvent
   | StatusEvent
   | KernelErrorEvent
+  | RetryResultEvent
+  | BtwResultEvent
 );
 
 export type OutgoingCommand = { tabId?: string } & (
@@ -436,4 +442,7 @@ export type OutgoingCommand = { tabId?: string } & (
   | { cmd: "jobs_list" }
   | { cmd: "jobs_stop"; jobId: number }
   | { cmd: "jobs_stop_all" }
+  | { cmd: "compact_history" }
+  | { cmd: "retry" }
+  | { cmd: "btw"; text: string }
 );

--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -115,6 +115,9 @@ type InMessage = { tabId?: string } & (
   | { cmd: "jobs_list" }
   | { cmd: "jobs_stop"; jobId: number }
   | { cmd: "jobs_stop_all" }
+  | { cmd: "compact_history" }
+  | { cmd: "retry" }
+  | { cmd: "btw"; text: string }
 );
 
 interface NeedsSetupEvent {
@@ -349,6 +352,17 @@ interface JobsEvent {
   items: JobInfoPayload[];
 }
 
+interface RetryResultEvent {
+  type: "$retry_result";
+  text: string;
+}
+
+interface BtwResultEvent {
+  type: "$btw_result";
+  question: string;
+  answer: string;
+}
+
 /** Direct fd write — bypasses Node's stream layer (and its piped-output
  *  block buffering) so every JSON line reaches Rust the moment it's
  *  produced, not whenever the next 8 KB flushes. */
@@ -373,6 +387,8 @@ type EmittableEvent =
   | BalanceEvent
   | MentionResultsEvent
   | MentionPreviewEvent
+  | RetryResultEvent
+  | BtwResultEvent
   | TabOpenedEvent
   | TabClosedEvent
   | McpSpecsEvent
@@ -1701,6 +1717,42 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
         .catch(() => {
           emit({ type: "$mention_preview", nonce, path: rel, head: "", totalLines: 0 }, tab.id);
         });
+      return;
+    }
+    if (msg.cmd === "compact_history") {
+      if (!tab.runtime) return;
+      void tab.runtime.loop.compactHistory().catch((err: Error) => {
+        emit({ type: "$error", message: `/compact failed: ${err.message}` }, tab.id);
+      });
+      return;
+    }
+    if (msg.cmd === "retry") {
+      if (!tab.runtime) return;
+      const prev = tab.runtime.loop.retryLastUser();
+      if (prev) {
+        emit({ type: "$retry_result", text: prev }, tab.id);
+      }
+      return;
+    }
+    if (msg.cmd === "btw") {
+      if (!tab.runtime) return;
+      const question = msg.text.trim();
+      if (!question) return;
+      void (async () => {
+        try {
+          const reply = await tab.runtime!.loop.client.chat({
+            messages: [
+              { role: "system", content: tab.system },
+              { role: "user", content: question },
+            ],
+          });
+          const answer =
+            (typeof reply.content === "string" ? reply.content.trim() : "") || "(no answer)";
+          emit({ type: "$btw_result", question, answer }, tab.id);
+        } catch (err) {
+          emit({ type: "$error", message: `/btw failed: ${(err as Error).message}` }, tab.id);
+        }
+      })();
       return;
     }
     if (msg.cmd === "user_input") {

--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -1741,6 +1741,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
       void (async () => {
         try {
           const reply = await tab.runtime!.loop.client.chat({
+            model: tab.currentModel,
             messages: [
               { role: "system", content: tab.system },
               { role: "user", content: question },


### PR DESCRIPTION
## Summary

Adds `/compact`, `/retry`, `/btw`, and `/feedback` slash commands to the desktop client, together with backend RPC support. Previously only `/feedback` was feasible (pure desktop-side URL open); the other three required new backend RPC commands which are implemented here.

Refs #1220 — desktop command parity with CLI.

## What changed

### Backend — `src/cli/commands/desktop.ts`

| RPC command | Implementation |
|-------------|---------------|
| `compact_history` | Calls `loop.compactHistory()` asynchronously, emits `$error` on failure |
| `retry` | Calls `loop.retryLastUser()`, emits `$retry_result` with the truncated text |
| `btw` | One-shot `loop.client.chat()` with clean system prompt + user question, emits `$btw_result` |

New event types: `RetryResultEvent` (`$retry_result`), `BtwResultEvent` (`$btw_result`).

### Protocol — `desktop/src/protocol.ts`

- Added `compact_history`, `retry`, `btw` to `OutgoingCommand`
- Added `RetryResultEvent` and `BtwResultEvent` to `IncomingEvent`

### Frontend — `desktop/src/App.tsx`

| Slash command | Behavior |
|---------------|----------|
| `/feedback` | Opens GitHub new-issue page in system browser |
| `/compact` | Sends `compact_history` RPC |
| `/retry` | Sends `retry` RPC; `$retry_result` event sets composer draft |
| `/btw` | Sets draft to `/btw ` — user types question, `send()` handler intercepts `/btw` prefix and routes to `btw` RPC; `$btw_result` appends answer as status message |

i18n keys added for all four commands (EN + zh-CN).

## Verification

- `npm run verify` passes locally
- Manual: desktop Settings → General → slash commands should show all four new entries
