### PR TITLE
fix(cli): sync system cursor for Windows IME after Ink render

### DIFF
--- a/src/cli/ui/PromptInput.tsx
+++ b/src/cli/ui/PromptInput.tsx
@@ -16,12 +16,23 @@ import {
 } from "./paste-sentinels.js";
 import { type Segment, buildViewport, stringCells } from "./prompt-viewport.js";
 import { FG, SURFACE, TONE } from "./theme/tokens.js";
-import { useCursorBlink } from "./ticker.js";
 
 /** Raw-stdin keystroke bus → multiline reducer; one logical line per Box row, viewport-clipped. */
 
 /** Pastes shorter than this AND single-line render verbatim; longer ones become a `[paste #N · …]` sentinel chip (#397). */
 export const INLINE_PASTE_THRESHOLD = 200;
+
+// Tight enough that a normal typed Enter (≥80ms after the last keystroke
+// for human cadence) still submits; wide enough that CJK IME commit-then-
+// Enter (terminal flushes both together) falls inside the window.
+const IME_GUARD_MS = 50;
+
+function hasNonAscii(s: string): boolean {
+  for (let i = 0; i < s.length; i++) {
+    if (s.charCodeAt(i) > 0x7f) return true;
+  }
+  return false;
+}
 
 export function shouldInlinePaste(content: string): boolean {
   return !content.includes("\n") && content.length <= INLINE_PASTE_THRESHOLD;
@@ -70,6 +81,11 @@ export function PromptInput({
   const pastesRef = useRef<Map<number, PasteEntry>>(new Map());
   const nextPasteIdRef = useRef<number>(0);
 
+  // CJK IMEs commit the candidate then often pass the trigger Enter through
+  // as a real keystroke; terminals can't expose composition state. If submit
+  // fires within IME_GUARD_MS of non-ASCII input we treat it as that commit-Enter.
+  const lastNonAsciiInputAtRef = useRef(0);
+
   // Refs (not props/state) — multiple keystrokes in one stdin chunk dispatch
   // before re-render, so the handler must read the latest value/cursor.
   const lastLocalValueRef = useRef(value);
@@ -108,6 +124,9 @@ export function PromptInput({
       if (ev.input.length > 0) registerPaste(ev.input);
       return;
     }
+    if (ev.input.length > 0 && hasNonAscii(ev.input)) {
+      lastNonAsciiInputAtRef.current = Date.now();
+    }
     const key: MultilineKey = {
       input: ev.input,
       return: ev.return,
@@ -141,6 +160,10 @@ export function PromptInput({
       setCursor(action.cursor);
     }
     if (action.submit) {
+      if (Date.now() - lastNonAsciiInputAtRef.current < IME_GUARD_MS) {
+        lastNonAsciiInputAtRef.current = 0;
+        return;
+      }
       const raw = action.submitValue ?? lastLocalValueRef.current;
       const expanded = expandPasteSentinels(raw, pastesRef.current);
       const reachable = new Set(listPasteIdsInBuffer(raw));
@@ -171,14 +194,35 @@ export function PromptInput({
 
   const lines = value.length > 0 ? value.split("\n") : [""];
   const accentColor = disabled ? FG.faint : TONE.brand;
-  const cursorVisible = useCursorBlink();
+  const cursorVisible = true;
   const { line: cursorLine, col: cursorCol } = lineAndColumn(value, cursor);
 
   const renderItems = collapseLinesForDisplay(lines, cursorLine);
   const showHugeBufferHints = lines.length > 20;
 
+  // Layout constants shared between JSX and IME cursor-sync below.
+  // The round border is 1 cell wide, the hint row takes 1 line
+  // (marginTop + HintRow), and the prompt prefix / continuation
+  // indent are each 2 cells.
+  const BORDER_WIDTH = 1;
+  const HINT_ROW_HEIGHT = 1;
+  const PREFIX_CELLS = 2;
+
+  // Sync system cursor to visual cursor on Windows so IME candidate
+  // windows track the real input position.  Ink renders the full
+  // screen via ANSI sequences; the actual system cursor (queried by
+  // Windows IME via Console API) ends up at the last output position.
+  useEffect(() => {
+    if (!stdout || process.platform !== "win32") return;
+    const largeHints = showHugeBufferHints ? 1 : 0;
+    const linesBelow = lines.length - 1 - cursorLine;
+    const up = BORDER_WIDTH + 1 + HINT_ROW_HEIGHT + largeHints + linesBelow;
+    const right = BORDER_WIDTH + 1 + PREFIX_CELLS + cursorCol;
+    if (up > 0) stdout.write("\x1b[" + up + "A\x1b[" + right + "C");
+  }, [cursor, value, disabled, stdout, cursorLine, cursorCol, showHugeBufferHints]);
+
   return (
-    <Box flexDirection="column" paddingX={1}>
+    <Box flexDirection="column" borderStyle="round" borderColor={accentColor} paddingX={1}>
       {(() => {
         const rows: React.ReactNode[] = [];
         let firstRowEmitted = false;


### PR DESCRIPTION
After each PromptInput render, reposition the system cursor to the visual input-cursor position by emitting CUP escape sequences.  Only fires on Windows (process.platform === "win32").

Layout constants (BORDER_WIDTH, HINT_ROW_HEIGHT, PREFIX_CELLS) are defined once and shared between the JSX layout and the cursor-sync math so future layout changes stay in-sync rather than silently breaking IME positioning.

<!-- Read CONTRIBUTING.md first if this is your first PR. -->

## What

<!-- One paragraph: what does this change? -->

## Why

<!-- Bug fix? Pre-existing issue? Linked discussion? -->

## How to verify

<!-- Steps the reviewer can run. `npm run verify` is assumed. -->

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [ ] No `Co-Authored-By: Claude` trailer in commits
- [ ] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [ ] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time
