### PR TITLE
fix(desktop): bundle universal Node on macOS so Intel Macs don't blank-screen

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,23 @@ jobs:
         working-directory: desktop
         run: npm run bundle:node
 
+      - name: Verify bundled Node is universal (macOS)
+        if: startsWith(matrix.target.os, 'macos-')
+        working-directory: desktop
+        run: |
+          archs=$(lipo -archs src-tauri/binaries/node)
+          echo "node archs: $archs"
+          echo "$archs" | grep -q "arm64"
+          echo "$archs" | grep -q "x86_64"
+
+      - name: Build & verify desktop frontend
+        working-directory: desktop
+        shell: bash
+        run: |
+          npm run build
+          test -f dist/index.html
+          ls dist/assets/*.js >/dev/null
+
       # tauri-action signs OS bundles whenever the corresponding env vars are
       # defined — including when they're defined to the empty string, which is
       # what `secrets.UNSET` evaluates to. Gate each signing block on its

--- a/desktop/scripts/bundle-node.mjs
+++ b/desktop/scripts/bundle-node.mjs
@@ -1,12 +1,5 @@
-/**
- * Cross-platform Node 22 downloader. Detects host platform + arch and pulls
- * the matching official Node distribution from nodejs.org, then extracts the
- * node binary into desktop/src-tauri/binaries/. Tauri's per-platform conf
- * overlay (tauri.<platform>.conf.json) picks it up at bundle time.
- *
- * Usage: `npm run bundle:node` from desktop/.
- * Re-run when bumping NODE_VERSION. The download is gitignored.
- */
+// Pulls Node 22 from nodejs.org into desktop/src-tauri/binaries/.
+// Mac always produces a universal Mach-O so Intel + Apple Silicon ship from one .dmg (issue #1234).
 import { execSync } from "node:child_process";
 import { chmodSync, createWriteStream, existsSync, mkdirSync, renameSync, rmSync, statSync } from "node:fs";
 import https from "node:https";
@@ -20,32 +13,35 @@ const binDir = join(here, "..", "src-tauri", "binaries");
 
 const PLAT = process.platform;
 const ARCH_RAW = process.arch;
-const ARCH = ARCH_RAW === "arm64" ? "arm64" : ARCH_RAW === "x64" ? "x64" : null;
+const HOST_ARCH = ARCH_RAW === "arm64" ? "arm64" : ARCH_RAW === "x64" ? "x64" : null;
 
-if (!ARCH || !["win32", "darwin", "linux"].includes(PLAT)) {
+if (!HOST_ARCH || !["win32", "darwin", "linux"].includes(PLAT)) {
   console.error(`Unsupported host: ${PLAT}/${ARCH_RAW}. Supported: win32 / darwin / linux × x64 / arm64.`);
   process.exit(1);
 }
 
 const isWin = PLAT === "win32";
-const triple =
-  PLAT === "win32" ? `win-${ARCH}` : PLAT === "darwin" ? `darwin-${ARCH}` : `linux-${ARCH}`;
-const archiveExt = PLAT === "win32" ? "zip" : PLAT === "darwin" ? "tar.gz" : "tar.xz";
-const archiveBase = `node-v${NODE_VERSION}-${triple}`;
-const archiveFile = `${archiveBase}.${archiveExt}`;
-const url = `https://nodejs.org/dist/v${NODE_VERSION}/${archiveFile}`;
-
 const targetExe = join(binDir, isWin ? "node.exe" : "node");
-const archivePath = join(binDir, archiveFile);
-const extractDir = join(binDir, "_extract");
 
-if (existsSync(targetExe)) {
-  const size = statSync(targetExe).size;
-  if (size > 1024 * 1024) {
-    console.log(`${targetExe} already present (${(size / 1024 / 1024).toFixed(1)} MB) — delete to refetch`);
+if (existsSync(targetExe) && statSync(targetExe).size > 1024 * 1024) {
+  if (PLAT === "darwin") {
+    try {
+      const archs = execSync(`lipo -archs "${targetExe}"`, { encoding: "utf8" }).trim();
+      if (archs.includes("arm64") && archs.includes("x86_64")) {
+        console.log(`${targetExe} already universal (${archs}) — delete to refetch`);
+        process.exit(0);
+      }
+      console.log(`${targetExe} present but not universal (${archs}) — rebuilding`);
+      rmSync(targetExe);
+    } catch {
+      console.log(`${targetExe} present but not verifiable as Mach-O — rebuilding`);
+      rmSync(targetExe);
+    }
+  } else {
+    const mb = (statSync(targetExe).size / 1024 / 1024).toFixed(1);
+    console.log(`${targetExe} already present (${mb} MB) — delete to refetch`);
     process.exit(0);
   }
-  // < 1 MB = placeholder, refetch.
 }
 
 mkdirSync(binDir, { recursive: true });
@@ -82,43 +78,73 @@ function follow(url, dest, redirects = 5) {
   });
 }
 
-console.log(`Downloading ${archiveFile} (Node v${NODE_VERSION} ${triple}) ...`);
-await follow(url, archivePath);
-process.stdout.write("\n");
+async function fetchAndExtract(arch) {
+  const triple =
+    PLAT === "win32" ? `win-${arch}` : PLAT === "darwin" ? `darwin-${arch}` : `linux-${arch}`;
+  const archiveExt = PLAT === "win32" ? "zip" : PLAT === "darwin" ? "tar.gz" : "tar.xz";
+  const archiveBase = `node-v${NODE_VERSION}-${triple}`;
+  const archiveFile = `${archiveBase}.${archiveExt}`;
+  const url = `https://nodejs.org/dist/v${NODE_VERSION}/${archiveFile}`;
+  const archivePath = join(binDir, archiveFile);
+  const extractDir = join(binDir, `_extract_${arch}`);
 
-rmSync(extractDir, { recursive: true, force: true });
-mkdirSync(extractDir, { recursive: true });
+  console.log(`Downloading ${archiveFile} ...`);
+  await follow(url, archivePath);
+  process.stdout.write("\n");
 
-console.log("Extracting ...");
-if (isWin) {
-  execSync(
-    `powershell -NoProfile -Command "Expand-Archive -Force -Path '${archivePath}' -DestinationPath '${extractDir}'"`,
-    { stdio: "inherit" },
-  );
-} else {
-  // tar handles both .tar.gz (with -z auto) and .tar.xz (needs xz-utils on host).
-  execSync(`tar -xf "${archivePath}" -C "${extractDir}"`, { stdio: "inherit" });
-}
+  rmSync(extractDir, { recursive: true, force: true });
+  mkdirSync(extractDir, { recursive: true });
 
-const inner = isWin
-  ? join(extractDir, archiveBase, "node.exe")
-  : join(extractDir, archiveBase, "bin", "node");
-if (!existsSync(inner)) {
-  console.error(`Extracted binary not found at expected path: ${inner}`);
-  process.exit(1);
-}
-
-if (existsSync(targetExe)) rmSync(targetExe);
-renameSync(inner, targetExe);
-if (!isWin) {
-  try {
-    chmodSync(targetExe, 0o755);
-  } catch {
-    /* ignore */
+  console.log(`Extracting ${arch} ...`);
+  if (isWin) {
+    execSync(
+      `powershell -NoProfile -Command "Expand-Archive -Force -Path '${archivePath}' -DestinationPath '${extractDir}'"`,
+      { stdio: "inherit" },
+    );
+  } else {
+    execSync(`tar -xf "${archivePath}" -C "${extractDir}"`, { stdio: "inherit" });
   }
-}
-rmSync(extractDir, { recursive: true, force: true });
-rmSync(archivePath);
 
-const mb = (statSync(targetExe).size / 1024 / 1024).toFixed(1);
-console.log(`Done: ${targetExe} (${mb} MB)`);
+  const inner = isWin
+    ? join(extractDir, archiveBase, "node.exe")
+    : join(extractDir, archiveBase, "bin", "node");
+  if (!existsSync(inner)) {
+    console.error(`Extracted binary not found at expected path: ${inner}`);
+    process.exit(1);
+  }
+
+  rmSync(archivePath);
+  return { inner, extractDir };
+}
+
+if (PLAT === "darwin") {
+  const [arm, x64] = await Promise.all([fetchAndExtract("arm64"), fetchAndExtract("x64")]);
+
+  console.log("Creating universal binary with lipo ...");
+  if (existsSync(targetExe)) rmSync(targetExe);
+  execSync(`lipo -create "${arm.inner}" "${x64.inner}" -output "${targetExe}"`, { stdio: "inherit" });
+  chmodSync(targetExe, 0o755);
+
+  rmSync(arm.extractDir, { recursive: true, force: true });
+  rmSync(x64.extractDir, { recursive: true, force: true });
+
+  const archs = execSync(`lipo -archs "${targetExe}"`, { encoding: "utf8" }).trim();
+  const mb = (statSync(targetExe).size / 1024 / 1024).toFixed(1);
+  console.log(`Done: ${targetExe} (${mb} MB, archs: ${archs})`);
+} else {
+  const { inner, extractDir } = await fetchAndExtract(HOST_ARCH);
+
+  if (existsSync(targetExe)) rmSync(targetExe);
+  renameSync(inner, targetExe);
+  if (!isWin) {
+    try {
+      chmodSync(targetExe, 0o755);
+    } catch {
+      /* ignore */
+    }
+  }
+  rmSync(extractDir, { recursive: true, force: true });
+
+  const mb = (statSync(targetExe).size / 1024 / 1024).toFixed(1);
+  console.log(`Done: ${targetExe} (${mb} MB)`);
+}


### PR DESCRIPTION
## Summary

- `desktop/scripts/bundle-node.mjs` now downloads both `darwin-arm64` and `darwin-x64` Node distributions on macOS and runs `lipo -create` to produce a universal Mach-O sidecar. The previous script bundled host-arch only, so the macos-universal release job (which runs on an ARM64 runner) shipped an ARM-only `Resources/node` inside a universal `.app` — Intel Macs couldn't exec the sidecar and the WebView came up blank with no error dialog.
- `.github/workflows/release.yml` gains two guard steps: `lipo -archs` on the bundled Node asserts both archs are present on macOS, and `test -f desktop/dist/index.html` + a glob on `dist/assets/*.js` runs before tauri-action so a silent frontend build failure can't ship an empty bundle.

The reporter also flagged `index.html` as missing from the bundle. Tauri 2 embeds the frontend into the executable rather than copying it to `Contents/Resources/`, so the absence is expected — but the new pre-bundle check makes sure the embed input itself isn't empty.

Closes #1234

## Test plan

- [x] `node --check desktop/scripts/bundle-node.mjs` parses
- [x] Existing-binary fast path still short-circuits on non-darwin hosts
- [x] `npm run verify` at repo root (build + lint + typecheck + 3150 tests) passes
- [ ] Cut a `desktop-vX.Y.Z` tag and confirm:
  - the `Verify bundled Node is universal (macOS)` step prints `arm64 x86_64`
  - the resulting `.dmg` launches with UI on an Intel Mac
