### PR TITLE
fix(cli): preserve flash preset auto-escalate semantics

### DIFF
--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -41,6 +41,10 @@ export type { McpLifecycleNotice, McpLifecycleSink, McpRuntime, ProgressInfo };
 
 export interface ChatOptions {
   model: string;
+  /** Preset resolved at launch; keeps flash distinct from auto when both use the same model. */
+  preset?: "auto" | "flash" | "pro";
+  /** Whether flash may auto-upgrade hard turns to pro. */
+  autoEscalate?: boolean;
   system: string;
   /** Re-runs the prompt builder on /new so REASONIX.md edits don't need a restart. Should produce the same string `system` was built from. */
   rebuildSystem?: () => string;
@@ -214,6 +218,8 @@ function Root({
       <App
         key={activeSession ?? "__new__"}
         model={appProps.model}
+        preset={appProps.preset}
+        autoEscalate={appProps.autoEscalate}
         system={appProps.system}
         rebuildSystem={appProps.rebuildSystem}
         transcript={appProps.transcript}

--- a/src/cli/commands/code.tsx
+++ b/src/cli/commands/code.tsx
@@ -27,7 +27,7 @@ import { t } from "../../i18n/index.js";
 import { detectForeignAgentPlatform } from "../../memory/project.js";
 import { sanitizeName } from "../../memory/session.js";
 import { markPhase } from "../startup-profile.js";
-import { resolvePreset } from "../ui/presets.js";
+import { presetNameForSettings, resolvePreset } from "../ui/presets.js";
 import { chatCommand } from "./chat.js";
 
 export interface CodeOptions {
@@ -67,7 +67,9 @@ export interface CodeOptions {
 
 export async function codeCommand(opts: CodeOptions = {}): Promise<void> {
   markPhase("code_command_enter");
-  const resolvedModel = opts.model ?? resolvePreset(loadPreset()).model;
+  const loadedPreset = loadPreset();
+  const presetSettings = resolvePreset(loadedPreset);
+  const resolvedModel = opts.model ?? presetSettings.model;
   // Bridge .env + ~/.reasonix/config.json into process.env so buildCodeToolset's
   // eager DeepSeekClient constructions (subagent client; semantic embedder) can
   // pick up a key the user already configured via `reasonix setup`. chatCommand
@@ -150,6 +152,8 @@ export async function codeCommand(opts: CodeOptions = {}): Promise<void> {
     });
   await chatCommand({
     model: resolvedModel,
+    preset: opts.model ? undefined : presetNameForSettings(presetSettings),
+    autoEscalate: opts.model ? false : presetSettings.autoEscalate,
     budgetUsd: opts.budgetUsd,
     system: codeRebuildSystem(),
     rebuildSystem: codeRebuildSystem,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -256,6 +256,8 @@ program
       const chatRebuildSystem = () => applyMemoryStack(chatBase, chatCwd);
       await chatCommand({
         model: defaults.model,
+        preset: defaults.preset,
+        autoEscalate: defaults.autoEscalate,
         system: chatRebuildSystem(),
         rebuildSystem: chatRebuildSystem,
         transcript: opts.transcript,

--- a/src/cli/resolve.ts
+++ b/src/cli/resolve.ts
@@ -2,10 +2,12 @@
 
 import { type PresetName, type ReasonixConfig, normalizeMcpConfig, readConfig } from "../config.js";
 import { specToRaw } from "../mcp/spec.js";
-import { resolvePreset } from "./ui/presets.js";
+import { presetNameForSettings, resolvePreset } from "./ui/presets.js";
 
 export interface ResolvedDefaults {
   model: string;
+  preset?: "auto" | "flash" | "pro";
+  autoEscalate: boolean;
   reasoningEffort: "high" | "max";
   mcp: string[];
   session: string | undefined;
@@ -28,6 +30,8 @@ export function resolveDefaults(flags: RawCliFlags): ResolvedDefaults {
   const presetSettings = resolvePreset(preset);
 
   const model = flags.model ?? presetSettings.model;
+  const presetName = flags.model ? undefined : presetNameForSettings(presetSettings);
+  const autoEscalate = flags.model ? false : presetSettings.autoEscalate;
   const reasoningEffort = presetSettings.reasoningEffort;
 
   // `--mcp` accumulator is [] when absent. Treat empty from flags as
@@ -41,7 +45,7 @@ export function resolveDefaults(flags: RawCliFlags): ResolvedDefaults {
 
   const session = resolveSession(flags.session, cfg.session);
 
-  return { model, reasoningEffort, mcp, session };
+  return { model, preset: presetName, autoEscalate, reasoningEffort, mcp, session };
 }
 
 function pickPreset(

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -192,6 +192,10 @@ import { useSubagent } from "./useSubagent.js";
 
 export interface AppProps {
   model: string;
+  /** Preset resolved at launch; keeps flash distinct from auto when both use deepseek-v4-flash. */
+  preset?: "auto" | "flash" | "pro";
+  /** Whether flash may auto-upgrade hard turns to pro. */
+  autoEscalate?: boolean;
   system: string;
   /** Re-runs the prompt builder on /new so REASONIX.md edits don't need a restart. Must produce the same shape as `system` was built from. */
   rebuildSystem?: () => string;
@@ -427,6 +431,8 @@ type AppInnerProps = AppProps & {
 
 function AppInner({
   model,
+  preset: initialPreset,
+  autoEscalate,
   system,
   rebuildSystem,
   transcript,
@@ -569,8 +575,10 @@ function AppInner({
     editModeRef,
     modeFlash,
   } = useEditGate(!!codeMode);
-  const { preset, setPreset, proArmed, setProArmed, turnOnPro, setTurnOnPro } =
-    usePresetMode(model);
+  const { preset, setPreset, proArmed, setProArmed, turnOnPro, setTurnOnPro } = usePresetMode(
+    model,
+    initialPreset,
+  );
   // Refs that mirror state for stable read-callbacks handed to the
   // embedded dashboard server. The server's `getXxx()` closures are
   // captured once at startDashboard time; without ref-mirrors the
@@ -962,6 +970,7 @@ function AppInner({
       // `/effort high` silently reverted to `max` on relaunch —the
       // loop's constructor default wins over persisted state.
       reasoningEffort: loadReasoningEffort(),
+      autoEscalate,
       rebuildSystem,
     });
     loopRef.current = l;
@@ -1112,13 +1121,14 @@ function AppInner({
   // biome-ignore lint/correctness/useExhaustiveDependencies: mount-only seed
   useEffect(() => {
     const canonical: "auto" | "flash" | "pro" | null =
-      loop.model === "deepseek-v4-pro"
+      initialPreset ??
+      (loop.model === "deepseek-v4-pro"
         ? "pro"
         : loop.model === "deepseek-v4-flash"
           ? loop.autoEscalate
             ? "auto"
             : "flash"
-          : null;
+          : null);
     agentStore.dispatch({ type: "session.preset.change", preset: canonical });
   }, []);
 

--- a/src/cli/ui/hooks/usePresetMode.ts
+++ b/src/cli/ui/hooks/usePresetMode.ts
@@ -12,9 +12,9 @@ export interface PresetMode {
   setTurnOnPro: Dispatch<SetStateAction<boolean>>;
 }
 
-export function usePresetMode(model: string): PresetMode {
-  const [preset, setPreset] = useState<"auto" | "flash" | "pro">(() =>
-    model === "deepseek-v4-pro" ? "pro" : "auto",
+export function usePresetMode(model: string, initialPreset?: "auto" | "flash" | "pro"): PresetMode {
+  const [preset, setPreset] = useState<"auto" | "flash" | "pro">(
+    () => initialPreset ?? (model === "deepseek-v4-pro" ? "pro" : "auto"),
   );
   const [proArmed, setProArmed] = useState(false);
   const [turnOnPro, setTurnOnPro] = useState(false);

--- a/src/cli/ui/presets.ts
+++ b/src/cli/ui/presets.ts
@@ -57,3 +57,8 @@ export function canonicalPresetName(name: PresetName | undefined): "auto" | "fla
   if (name === "auto" || name === "flash" || name === "pro") return name;
   return "auto";
 }
+
+export function presetNameForSettings(settings: PresetSettings): "auto" | "flash" | "pro" {
+  if (settings.model === "deepseek-v4-pro") return "pro";
+  return settings.autoEscalate ? "auto" : "flash";
+}

--- a/tests/resolve.test.ts
+++ b/tests/resolve.test.ts
@@ -45,10 +45,20 @@ describe("resolveDefaults", () => {
     expect(r.session).toBe("default");
   });
 
+  it("config.preset 'flash' preserves no-auto-escalate semantics", () => {
+    writeConfig({ preset: "flash" }, join(home, ".reasonix", "config.json"));
+    const r = resolveDefaults({});
+    expect(r.model).toBe("deepseek-v4-flash");
+    expect(r.preset).toBe("flash");
+    expect(r.autoEscalate).toBe(false);
+  });
+
   it("config.preset 'fast' drops effort to high (still flash)", () => {
     writeConfig({ preset: "fast" }, join(home, ".reasonix", "config.json"));
     const r = resolveDefaults({});
     expect(r.model).toBe("deepseek-v4-flash");
+    expect(r.preset).toBe("flash");
+    expect(r.autoEscalate).toBe(false);
     expect(r.reasoningEffort).toBe("high");
   });
 
@@ -62,7 +72,16 @@ describe("resolveDefaults", () => {
   it("--model wins even when --preset is set", () => {
     const r = resolveDefaults({ preset: "max", model: "deepseek-v4-flash" });
     expect(r.model).toBe("deepseek-v4-flash");
+    expect(r.preset).toBeUndefined();
+    expect(r.autoEscalate).toBe(false);
     expect(r.reasoningEffort).toBe("max");
+  });
+
+  it("--model with a custom id does not infer a preset", () => {
+    const r = resolveDefaults({ preset: "max", model: "custom-model" });
+    expect(r.model).toBe("custom-model");
+    expect(r.preset).toBeUndefined();
+    expect(r.autoEscalate).toBe(false);
   });
 
   it("--mcp overrides config.mcp wholesale (no merging)", () => {


### PR DESCRIPTION
Pass resolved preset metadata through chat/code startup so flash remains pinned without auto escalation and the UI initializes with the correct preset label.

<!-- Read CONTRIBUTING.md first if this is your first PR. -->

## What

<!-- One paragraph: what does this change? -->

## Why

fix https://github.com/esengine/DeepSeek-Reasonix/issues/1228
<!-- Bug fix? Pre-existing issue? Linked discussion? -->

## How to verify

<!-- Steps the reviewer can run. `npm run verify` is assumed. -->

## Checklist

- [y ] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [y ] No `Co-Authored-By: Claude` trailer in commits
- [y ] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [y ] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time
