### PR TITLE
fix(mcp): let ESC abort hung MCP handshakes during startup

### DIFF
--- a/src/cli/commands/mcp-runtime.ts
+++ b/src/cli/commands/mcp-runtime.ts
@@ -116,6 +116,7 @@ export interface McpRuntime {
   addSpec(
     raw: string,
     loop?: CacheFirstLoop,
+    signal?: AbortSignal,
   ): Promise<{ ok: true; summary: McpServerSummary } | { ok: false; reason: string }>;
   removeSpec(raw: string, loop?: CacheFirstLoop): Promise<boolean>;
   reloadFromConfig(loop?: CacheFirstLoop): Promise<{
@@ -138,6 +139,7 @@ export function createMcpRuntime(ctx: RuntimeContext): McpRuntime {
   async function addSpec(
     raw: string,
     loop?: CacheFirstLoop,
+    signal?: AbortSignal,
   ): Promise<{ ok: true; summary: McpServerSummary } | { ok: false; reason: string }> {
     if (records.has(raw)) {
       return { ok: true, summary: records.get(raw)!.summary };
@@ -183,7 +185,7 @@ export function createMcpRuntime(ctx: RuntimeContext): McpRuntime {
       if (spec.transport === "stdio") preflightStdioSpec(spec);
       const transport = buildTransportFromSpec(spec);
       mcp = new McpClient({ transport });
-      await mcp.initialize();
+      await mcp.initialize({ signal });
       const host: McpClientHost = { client: mcp };
       const bridge = await bridgeMcpTools(mcp, {
         registry: tools,

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -1126,6 +1126,7 @@ function AppInner({
   // background instead of blocking startup, route lifecycle events to
   // the in-app log so they don't corrupt alt-screen via stderr.
   const mcpBridgeStartedRef = useRef(false);
+  const pendingMcpAbortersRef = useRef<Set<AbortController>>(new Set());
   useEffect(() => {
     if (mcpBridgeStartedRef.current) return;
     if (!mcpRuntime || !mcpSpecs || mcpSpecs.length === 0) return;
@@ -1191,7 +1192,10 @@ function AppInner({
       }
     });
     for (const spec of mcpSpecs) {
-      void mcpRuntime.addSpec(spec, loop).then(() => {
+      const ac = new AbortController();
+      pendingMcpAbortersRef.current.add(ac);
+      void mcpRuntime.addSpec(spec, loop, ac.signal).then(() => {
+        pendingMcpAbortersRef.current.delete(ac);
         setLiveMcpServers(mcpRuntime.summaries());
       });
     }
@@ -1625,6 +1629,18 @@ function AppInner({
         loop,
         quitProcess,
       });
+      return;
+    }
+    if (
+      key.escape &&
+      !submittingRef.current &&
+      !isLoopActive() &&
+      pendingMcpAbortersRef.current.size > 0
+    ) {
+      const count = pendingMcpAbortersRef.current.size;
+      for (const ac of pendingMcpAbortersRef.current) ac.abort();
+      pendingMcpAbortersRef.current.clear();
+      log.pushInfo(t("mcpLifecycle.abortedHint", { count }));
       return;
     }
     if (key.escape && (submittingRef.current || isLoopActive())) {

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -1594,6 +1594,8 @@ export const EN: TranslationSchema = {
       "→ run `reasonix setup` to remove this entry, or fix the underlying issue (missing npm package, network, etc.).",
     failedSetupConfigHint:
       "→ run `reasonix setup` to remove broken entries from your saved config.",
+    abortedHint:
+      "MCP startup aborted — {count} server(s) skipped. Run /mcp to retry once you've fixed the underlying issue.",
   },
   checkpointPicker: {
     title: "restore a checkpoint \u2014 {workspace}",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -799,6 +799,7 @@ export interface TranslationSchema {
     disabledDetail: string;
     failedSetupHint: string;
     failedSetupConfigHint: string;
+    abortedHint: string;
   };
   checkpointPicker: {
     title: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -1518,6 +1518,7 @@ export const zhCN: TranslationSchema = {
     disabledDetail: "通过 /mcp disable {name}",
     failedSetupHint: "→ 运行 `reasonix setup` 移除此条目，或修复底层问题（缺少 npm 包、网络等）。",
     failedSetupConfigHint: "→ 运行 `reasonix setup` 从已保存配置中移除损坏的条目。",
+    abortedHint: "已中断 MCP 启动 — 跳过 {count} 个服务器。问题修复后用 /mcp 重新连接。",
   },
   checkpointPicker: {
     title: "恢复检查点 \u2014 {workspace}",

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -85,19 +85,23 @@ export class McpClient {
   }
 
   /** Compliant servers reject other methods until this completes. */
-  async initialize(): Promise<InitializeResult> {
+  async initialize(opts: { signal?: AbortSignal } = {}): Promise<InitializeResult> {
     if (this.initialized) throw new Error("MCP client already initialized");
     this.startReaderIfNeeded();
-    const result = await this.request<InitializeResult>("initialize", {
-      protocolVersion: MCP_PROTOCOL_VERSION,
-      // Advertise every method the client can consume so servers know
-      // they can send listChanged notifications etc. Sub-feature flags
-      // (e.g. `resources.subscribe`) are omitted — we don't implement
-      // those yet and the empty object means "method-level support, no
-      // sub-features."
-      capabilities: { tools: {}, resources: {}, prompts: {} },
-      clientInfo: this.clientInfo,
-    } satisfies InitializeParams);
+    const result = await this.request<InitializeResult>(
+      "initialize",
+      {
+        protocolVersion: MCP_PROTOCOL_VERSION,
+        // Advertise every method the client can consume so servers know
+        // they can send listChanged notifications etc. Sub-feature flags
+        // (e.g. `resources.subscribe`) are omitted — we don't implement
+        // those yet and the empty object means "method-level support, no
+        // sub-features."
+        capabilities: { tools: {}, resources: {}, prompts: {} },
+        clientInfo: this.clientInfo,
+      } satisfies InitializeParams,
+      opts.signal,
+    );
     this._serverCapabilities = result.capabilities ?? {};
     this._serverInfo = result.serverInfo ?? { name: "", version: "" };
     this._protocolVersion = result.protocolVersion ?? "";

--- a/tests/mcp-client-timeout.test.ts
+++ b/tests/mcp-client-timeout.test.ts
@@ -133,4 +133,14 @@ describe("McpClient.request() timeout/no-crash", () => {
       await client.close();
     }
   });
+
+  it("initialize() rejects when the supplied AbortSignal fires (issue #1236)", async () => {
+    const transport = new SilentServerTransport();
+    const client = new McpClient({ transport, requestTimeoutMs: 60_000 });
+    const ac = new AbortController();
+    const pending = client.initialize({ signal: ac.signal });
+    setTimeout(() => ac.abort(), 20);
+    await expect(pending).rejects.toThrow(/aborted/);
+    await client.close();
+  });
 });


### PR DESCRIPTION
## Summary

Issue #1236 reports that when a configured MCP server (e.g. `npx -y gitnexus@latest mcp`) is unresponsive at boot, the TUI hangs and ESC does nothing. Root cause: the ESC handler in `App.tsx` is gated on `submittingRef.current || isLoopActive()` — neither is true during the deferred MCP bridge that runs in a mount-time `useEffect`. A server stuck in `initialize()` therefore pins boot for the full 60s per-request timeout with no way to escape (Ctrl+C still works because it kills the whole process; ESC silently swallowed).

Fix:

- `McpClient.initialize()` now accepts `{ signal?: AbortSignal }` and threads it into the underlying `request()`, which already had abort support (sends `notifications/cancelled` to the server, rejects the caller immediately, drops late responses).
- `mcpRuntime.addSpec()` gains an optional `signal?: AbortSignal` parameter and forwards it to `initialize()`.
- `App.tsx` keeps a `pendingMcpAbortersRef: Set<AbortController>` and gives each `addSpec` call its own controller, removing it from the set on completion.
- New ESC branch fires **before** the existing turn/loop branch: if no turn is active, no loop is active, and there are pending aborters, abort them all and log a hint pointing at `/mcp` for retry. The catch path in `addSpec` already closes the underlying `McpClient`, so the stdio child is killed and the spec is recorded as failed — no leak.

Out of scope (the issue body wandered into several misdiagnoses):

- *"MCP server hangs the shell when run manually"* — that's a category error. Running `npx -y gitnexus@latest mcp` directly in PowerShell holds the terminal open because MCP servers are long-running stdio JSON-RPC processes; it isn't a bug, it's the protocol.
- Per-spec single-instance protection / orphan cleanup across restarts — separate concern, separate issue if it surfaces. The existing spawn is non-detached + `chat.tsx` calls `runtime.closeAll()` in a `finally`, so non-crash exits are clean today.
- Tightening the 60s `requestTimeoutMs` — once ESC works, the timeout is just a backstop. Leaving it untouched avoids touching legitimate slow-starting MCP servers.

## Test plan

- [x] New `tests/mcp-client-timeout.test.ts` case: `initialize({ signal })` rejects with `/aborted/` when the signal fires mid-wait (uses `SilentServerTransport` that never replies).
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm test` — 221 files / 3151 passed (was 3150, +1 from the new abort test)
- [ ] Manual: boot the TUI with a stuck MCP entry, press ESC, confirm the handshake aborts, the toast renders, and `/mcp` re-adds it.

Closes #1236
