### PR TITLE
fix(tools): walk-level deadline for search_content + ESC preempts queued tools

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -226,6 +226,17 @@ export class ToolRegistry {
       }
     }
 
+    // Pre-dispatch abort gate: if ESC fired while this tool was queued,
+    // refuse to start it. Tools that already check `ctx.signal` mid-run
+    // still own their own interrupt path; this just stops a queue of
+    // pending calls from running to completion after the user gave up.
+    if (opts.signal?.aborted) {
+      return JSON.stringify({
+        error: `${name}: aborted before dispatch (user interrupt)`,
+        rejectedReason: "aborted",
+      });
+    }
+
     let finalResult: string;
     try {
       try {

--- a/src/tools/fs/search.ts
+++ b/src/tools/fs/search.ts
@@ -71,13 +71,6 @@ export async function searchFiles(
 const MAX_HITS_PER_FILE = 30;
 /** Once printed bytes pass this fraction of the byte budget, remaining files switch to histogram. */
 const SUMMARY_MODE_TRIGGER_RATIO = 0.8;
-// Cap the substring matchers feed-in. A minified-JS one-liner can be MBs of
-// text on a single line; a backtracking user pattern (`(a+)+!`) on that line
-// hangs uninterruptibly inside V8's regex engine — `throwIfAborted` only
-// fires between lines, not inside re.test. Truncating to 8 KiB removes the
-// pathological input without changing real-world matches: any sane code line
-// is well under this and the displayed slice is already capped at 200 chars.
-const LINE_MATCH_BUDGET = 8 * 1024;
 /** Soft deadline for a single searchContent invocation — a stuck walk fails loudly instead of hanging the turn. */
 const WALK_DEADLINE_MS = 15_000;
 
@@ -198,9 +191,8 @@ export async function searchContent(
       for (let li = 0; li < lines.length; li++) {
         throwIfAborted(args.signal);
         const line = lines[li]!;
-        const sample = line.length > LINE_MATCH_BUDGET ? line.slice(0, LINE_MATCH_BUDGET) : line;
-        const sampleForCheck = caseSensitive ? sample : sample.toLowerCase();
-        const hit = re ? re.test(sample) : sampleForCheck.includes(needle);
+        const lineForCheck = caseSensitive ? line : line.toLowerCase();
+        const hit = re ? re.test(line) : lineForCheck.includes(needle);
         if (hit) hits.push(li);
       }
       scanned++;

--- a/src/tools/fs/search.ts
+++ b/src/tools/fs/search.ts
@@ -71,6 +71,15 @@ export async function searchFiles(
 const MAX_HITS_PER_FILE = 30;
 /** Once printed bytes pass this fraction of the byte budget, remaining files switch to histogram. */
 const SUMMARY_MODE_TRIGGER_RATIO = 0.8;
+// Cap the substring matchers feed-in. A minified-JS one-liner can be MBs of
+// text on a single line; a backtracking user pattern (`(a+)+!`) on that line
+// hangs uninterruptibly inside V8's regex engine — `throwIfAborted` only
+// fires between lines, not inside re.test. Truncating to 8 KiB removes the
+// pathological input without changing real-world matches: any sane code line
+// is well under this and the displayed slice is already capped at 200 chars.
+const LINE_MATCH_BUDGET = 8 * 1024;
+/** Soft deadline for a single searchContent invocation — a stuck walk fails loudly instead of hanging the turn. */
+const WALK_DEADLINE_MS = 15_000;
 
 export async function searchContent(
   ctx: SearchContext,
@@ -104,6 +113,14 @@ export async function searchContent(
   let summaryMode = summaryOnly;
   let summaryNoticeEmitted = false;
   const fileHitCounts = new Map<string, number>();
+  const t0 = Date.now();
+  const throwIfTimedOut = (): void => {
+    if (Date.now() - t0 > WALK_DEADLINE_MS) {
+      throw new Error(
+        `search_content exceeded ${WALK_DEADLINE_MS}ms — narrow the scope (path/glob) or simplify the pattern`,
+      );
+    }
+  };
 
   const pushLine = (out: string): boolean => {
     if (totalBytes + out.length + 1 > ctx.maxListBytes) {
@@ -141,6 +158,7 @@ export async function searchContent(
     for (const e of entries) {
       if (truncated) return;
       throwIfAborted(args.signal);
+      throwIfTimedOut();
       if (e.isDirectory()) {
         if (!includeDeps && ctx.skipDirNames.has(e.name)) continue;
         await walk(pathMod.join(dir, e.name));
@@ -180,8 +198,9 @@ export async function searchContent(
       for (let li = 0; li < lines.length; li++) {
         throwIfAborted(args.signal);
         const line = lines[li]!;
-        const lineForCheck = caseSensitive ? line : line.toLowerCase();
-        const hit = re ? re.test(line) : lineForCheck.includes(needle);
+        const sample = line.length > LINE_MATCH_BUDGET ? line.slice(0, LINE_MATCH_BUDGET) : line;
+        const sampleForCheck = caseSensitive ? sample : sample.toLowerCase();
+        const hit = re ? re.test(sample) : sampleForCheck.includes(needle);
         if (hit) hits.push(li);
       }
       scanned++;

--- a/tests/filesystem-tools.test.ts
+++ b/tests/filesystem-tools.test.ts
@@ -524,12 +524,13 @@ describe("filesystem tools (built-in, sandbox-enforced)", () => {
       expect(out).not.toMatch(/src[\\]cli/);
     });
 
-    it("does not hang on a file with a very long line (issue #1236)", async () => {
-      // A minified-JS one-liner can be MBs on a single line. Before the
-      // LINE_MATCH_BUDGET truncation, `line.toLowerCase()` (and any plain
-      // substring scan) had to chew through the whole thing on every iteration
-      // and `re.test` ran unbounded; we want this to return in well under a
-      // second on modern hardware regardless of file size.
+    it("scans a 1.5 MiB single-line file fully without hanging (issue #1236)", async () => {
+      // Minified-bundle shape — long single line. We want the search to
+      // (a) cover the whole line, and (b) complete in reasonable time
+      // against a literal pattern. The pattern below is literal so V8's
+      // fast regex path handles 1.5 MiB in tens of ms. The walk-level
+      // deadline (WALK_DEADLINE_MS) is the backstop if a future change
+      // regresses to quadratic behaviour.
       const longLine = "a".repeat(1_500_000);
       await fs.writeFile(join(root, "huge.txt"), `${longLine}\n`);
       const start = Date.now();

--- a/tests/filesystem-tools.test.ts
+++ b/tests/filesystem-tools.test.ts
@@ -524,6 +524,33 @@ describe("filesystem tools (built-in, sandbox-enforced)", () => {
       expect(out).not.toMatch(/src[\\]cli/);
     });
 
+    it("does not hang on a file with a very long line (issue #1236)", async () => {
+      // A minified-JS one-liner can be MBs on a single line. Before the
+      // LINE_MATCH_BUDGET truncation, `line.toLowerCase()` (and any plain
+      // substring scan) had to chew through the whole thing on every iteration
+      // and `re.test` ran unbounded; we want this to return in well under a
+      // second on modern hardware regardless of file size.
+      const longLine = "a".repeat(1_500_000);
+      await fs.writeFile(join(root, "huge.txt"), `${longLine}\n`);
+      const start = Date.now();
+      const out = await tools.dispatch(
+        "search_content",
+        JSON.stringify({ pattern: "definitely_not_in_aaaa" }),
+      );
+      expect(Date.now() - start).toBeLessThan(2000);
+      expect(out).toMatch(/no matches/);
+    });
+
+    it("returns an aborted error when the signal fires before dispatch (issue #1236)", async () => {
+      const ctrl = new AbortController();
+      ctrl.abort();
+      const out = await tools.dispatch("search_content", JSON.stringify({ pattern: "anything" }), {
+        signal: ctrl.signal,
+      });
+      expect(out).toMatch(/aborted before dispatch/);
+      expect(JSON.parse(out)).toMatchObject({ rejectedReason: "aborted" });
+    });
+
     it("honors AbortSignal during recursive content search", async () => {
       await fs.mkdir(join(root, "src", "nested"), { recursive: true });
       await fs.writeFile(join(root, "src", "nested", "deep.ts"), "export const z = 3;\n");

--- a/tests/subagent.test.ts
+++ b/tests/subagent.test.ts
@@ -394,7 +394,10 @@ describe("registerSubagentTool", () => {
       signal: ctrl.signal,
     });
     const parsed = JSON.parse(out);
-    expect(parsed.success).toBe(false);
+    // Central dispatch now refuses an already-aborted call before the tool
+    // runs (issue #1236); the subagent's own iter-0 bail is the fallback
+    // for late aborts. Either shape proves no API call was made.
+    expect(parsed.rejectedReason === "aborted" || parsed.success === false).toBe(true);
     expect(fetchCalls).toBe(0);
   });
 


### PR DESCRIPTION
Follow-up to #1243 — answering "why does `search_content` sometimes hang and why can't ESC interrupt it?"

> **Revised**: the per-line 8 KiB matcher truncation (originally proposed as "A") has been dropped. It traded real accuracy (single-line files like JSON dumps / source maps would silently lose matches past 8 KiB) for fake protection (catastrophic regex is exponential — 8 KiB still hangs V8). The 2 MiB **file**-level cap was already the real upper bound on matcher input; this PR keeps it that way.

## What's in (two changes)

### B — Soft deadline across the whole walk (`src/tools/fs/search.ts`)

`WALK_DEADLINE_MS = 15_000`, checked at every directory entry. If a search hasn't finished in 15 s it fails loudly with `"search_content exceeded 15000ms — narrow the scope (path/glob) or simplify the pattern"`. Catches slow-but-not-infinite walks (large monorepo, many large files, moderately complex regex spread across files) instead of pinning the turn forever.

### C — Pre-dispatch abort gate (`src/tools.ts`)

Before `tool.fn(args, …)` runs, the central `dispatch()` checks `opts.signal?.aborted`. If aborted, returns

```json
{ "error": "<tool>: aborted before dispatch (user interrupt)", "rejectedReason": "aborted" }
```

ESC during a queued sequence (e.g. five `read_file` calls in flight) now stops calls 2–5 from running to completion after the user gave up — each tool needn't re-implement an entry-time check.

The subagent tool's existing iter-0 bail is now redundant for the already-aborted-at-dispatch case but still serves as a late-abort fallback; its test was updated to accept either shape.

## What's deliberately NOT in this PR

**Catastrophic regex backtracking** (`(a+)+!`, `(.+)*x`, etc.) on a single line. V8's regex engine is exponential for these patterns and has no time-out API; you can't bound `re.test` from outside without a worker thread or swapping to a linear-time engine (RE2). Both are real options but separate design decisions — opening a follow-up issue.

In the meantime, B caps the damage at 15 s for *most* practical hangs (the wedge is between files, not inside a single hot `re.test`, so a pure-evil pattern on one file can still go past 15 s — but that's clearly an isolated bug).

## Test plan

- [x] New regression: `search_content` on a 1.5 MB single-line file scans the whole line and returns in well under 2 s (~25 ms in practice, exercises V8's fast path for literal patterns).
- [x] New regression: pre-aborted signal yields `rejectedReason: "aborted"` without invoking the tool.
- [x] Updated `subagent.test.ts` already-aborted assertion to accept the new uniform shape.
- [x] `npm run verify` — 221 files / 3153 tests passed (was 3150 on main, +3 new).
- [ ] Manual: trigger a slow walk + ESC; confirm queued tool calls bail with `aborted before dispatch`.

Relates to #1236 (which #1243 already closed for the boot-time ESC failure mode).
