### PR TITLE
fix(desktop): enable skill execution via slash command syntax

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -1218,12 +1218,25 @@ function TabRuntime({
         return;
       }
 
+      const skillMatch = text.match(/^\/([a-zA-Z0-9_-]+)(\s+.*)?$/);
+      if (skillMatch) {
+        const [, name, args] = skillMatch;
+        const skill = state.skills.find((s) => s.name === name);
+        if (skill) {
+          const clientId = `skill-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+          const trimmedArgs = args?.trim() ?? "";
+          dispatch({ t: "start_skill", skill: { name: skill.name, runAs: skill.runAs }, args: trimmedArgs, clientId });
+          sendRpc({ cmd: "skill_run", name: skill.name, args: trimmedArgs || undefined });
+          if (!override) setDraft("");
+          return;
+        }
+      }
       const clientId = `c-${Date.now()}`;
       dispatch({ t: "send_user", text, clientId });
       sendRpc({ cmd: "user_input", text });
       if (!override) setDraft("");
     },
-    [draft, state.ready, state.busy, sendRpc],
+    [draft, state.ready, state.busy, state.skills, sendRpc],
   );
 
   const abort = useCallback(() => sendRpc({ cmd: "abort" }), [sendRpc]);
@@ -1477,6 +1490,7 @@ function TabRuntime({
     ...state.skills.map((s) => ({
       cmd: `/${s.name}`,
       desc: s.description?.trim() || fallbackSkillDesc(s),
+      insertOnly: true,
       run: () => {
         dispatch({
           t: "start_skill",

--- a/desktop/src/ui/composer.tsx
+++ b/desktop/src/ui/composer.tsx
@@ -64,6 +64,7 @@ export type SlashCmd = {
   desc: string;
   run: () => void;
   kb?: string;
+  insertOnly?: boolean;
 };
 export type MentionItem = {
   name: string;
@@ -292,10 +293,17 @@ export function Composer({
     if (!it || !popup) return;
     if (popup.kind === "slash") {
       const cmd = (it as SlashCmd).cmd;
-      const next = draft.replace(/[/@][^\s]*$/, "").trimEnd();
-      setDraft(next);
-      setChips((c) => [...c, { kind: "slash", label: cmd.replace(/^\//, "") }]);
-      (it as SlashCmd).run();
+      const insertOnly = (it as SlashCmd).insertOnly === true;
+      if (insertOnly) {
+        const next = draft.replace(/[/@][^\s]*$/, "").trimEnd();
+        setDraft(next ? `${next} ${cmd} ` : `${cmd} `);
+        setChips((c) => [...c, { kind: "slash", label: cmd.replace(/^\//, "") }]);
+      } else {
+        const next = draft.replace(/[/@][^\s]*$/, "").trimEnd();
+        setDraft(next);
+        setChips((c) => [...c, { kind: "slash", label: cmd.replace(/^\//, "") }]);
+        (it as SlashCmd).run();
+      }
     } else {
       const mention = it as MentionItem;
       if (mention.name === "..") {


### PR DESCRIPTION
- Implement regex-based slash command detection in `TabRuntime` to trigger skills
- Add `insertOnly` property to `SlashCmd` to support command insertion without immediate execution
- Update `Composer` to handle conditional execution based on `insertOnly` flag
- Include `state.skills` in `TabRuntime` dependency array for correct command matching

<!-- Read CONTRIBUTING.md first if this is your first PR. -->

## What

Related #1227 
When a user types `/skillname [args]` in the composer and presses Enter, the `send()` handler now matches the input against registered skills and dispatches a `skill_run` RPC instead of sending the raw text as a user message.

## Why

Typing `/skillname` manually and hitting Enter sent the command as plain user text, bypassing skill execution. The skill was only invocable through the slash picker dropdown.

## How to verify

Type `/<skillname> <args>` in the composer and press Enter. Verify the `skill_run` RPC is sent instead of `user_input`.

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time