### PR TITLE
test(code-prompt): bound .gitignore truncation against a baseline

### DIFF
--- a/tests/code-prompt.test.ts
+++ b/tests/code-prompt.test.ts
@@ -35,14 +35,18 @@ describe("codeSystemPrompt", () => {
   });
 
   it("truncates a .gitignore larger than 2000 chars", () => {
+    // Baseline prompt with a tiny .gitignore — isolates the truncation
+    // delta from unrelated, fixed-size additions (e.g. the builtin Skills
+    // index), so the bound doesn't go stale as the prompt grows.
+    writeFileSync(join(root, ".gitignore"), "node_modules/\n", "utf8");
+    const small = codeSystemPrompt(root);
     const huge = `${"# comment ".repeat(500)}\n`; // ~5000 chars
     writeFileSync(join(root, ".gitignore"), huge, "utf8");
     const out = codeSystemPrompt(root);
     expect(out).toMatch(/truncated \d+ chars/);
-    // The .gitignore block (base + truncated + fences) is bounded.
-    // Allow extra slack for the builtin Skills index that applyMemoryStack
-    // also injects — that's a fixed-size addition, not unbounded.
-    expect(out.length).toBeLessThan(CODE_SYSTEM_PROMPT.length + 5000);
+    // A 5 KB .gitignore must be capped near the 2000-char limit — only a
+    // little larger than the tiny-.gitignore baseline, not 5 KB larger.
+    expect(out.length).toBeLessThan(small.length + 2500);
   });
 
   it("reminds the model to skip dependency / build / VCS dirs", () => {


### PR DESCRIPTION
## What

Fixes a stale assertion in the `codeSystemPrompt` `.gitignore`
truncation test. It asserted `out.length < CODE_SYSTEM_PROMPT.length +
5000`; the builtin Skills index that `applyMemoryStack` injects has
since grown past that 5000-char slack, so the test fails even though
`.gitignore` truncation still works correctly.

The test now builds a baseline prompt with a tiny `.gitignore` and
asserts the huge-`.gitignore` prompt is only slightly larger than that
baseline. This isolates the truncation delta from fixed-size, unrelated
prompt additions, so the bound no longer goes stale as the prompt grows.

## Why

`tests/code-prompt.test.ts › truncates a .gitignore larger than 2000
chars` fails on `main`:

```
AssertionError: expected 31863 to be less than 29387
```

`npm run verify` (and the pre-push hook / CI) fails because of it. The
`.gitignore` truncation itself is unaffected — only the magic-number
bound was stale.

## How to verify

- `npm run verify` — previously 1 failed, now all 3151 tests pass.
- `npx vitest run tests/code-prompt.test.ts` — 25 passed.

## Screenshots

n/a

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time
