### PR TITLE
feat(search): isolate regex in a worker thread so ReDoS can be terminated

### DIFF
--- a/src/tools/fs/regex-runner.ts
+++ b/src/tools/fs/regex-runner.ts
@@ -1,0 +1,165 @@
+// Worker-isolated regex evaluator. V8's regex engine is uninterruptible and
+// exponential for catastrophic patterns (`(a+)+!`); running re.test inside a
+// Worker lets the main thread `terminate()` it on a hard deadline. The
+// worker uses CommonJS because `new Worker(src, { eval: true })` doesn't
+// support ESM input.
+import { Worker } from "node:worker_threads";
+
+const WORKER_SOURCE = `
+const { parentPort } = require("node:worker_threads");
+parentPort.on("message", (msg) => {
+  const { id, text, source, flags } = msg;
+  let re;
+  try {
+    re = new RegExp(source, flags);
+  } catch (err) {
+    parentPort.postMessage({ id, error: (err && err.message) ? err.message : String(err) });
+    return;
+  }
+  const lines = text.split(/\\r?\\n/);
+  const hits = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (re.test(lines[i])) hits.push(i);
+  }
+  parentPort.postMessage({ id, hits });
+});
+`;
+
+const DEFAULT_TIMEOUT_MS = 5_000;
+
+type Pending = {
+  resolve: (hits: number[]) => void;
+  reject: (err: Error) => void;
+  timer: NodeJS.Timeout;
+  signal?: AbortSignal;
+  onAbort?: () => void;
+};
+
+export interface RegexRunnerOptions {
+  defaultTimeoutMs?: number;
+}
+
+export class RegexRunner {
+  private worker: Worker | null = null;
+  private readonly pending = new Map<number, Pending>();
+  private nextId = 1;
+  private readonly defaultTimeoutMs: number;
+
+  constructor(opts: RegexRunnerOptions = {}) {
+    this.defaultTimeoutMs = opts.defaultTimeoutMs ?? DEFAULT_TIMEOUT_MS;
+  }
+
+  testLines(
+    text: string,
+    source: string,
+    flags: string,
+    opts: { signal?: AbortSignal; timeoutMs?: number } = {},
+  ): Promise<number[]> {
+    return new Promise<number[]>((resolve, reject) => {
+      if (opts.signal?.aborted) {
+        reject(new Error("regex evaluation aborted"));
+        return;
+      }
+      if (!this.worker) this.worker = this.spawn();
+      const id = this.nextId++;
+      const timeoutMs = opts.timeoutMs ?? this.defaultTimeoutMs;
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        // Hot regex stuck inside V8 — only way out is to kill the worker.
+        // The next call respawns; one cold start (~30ms) costs less than
+        // however long the runaway pattern would have taken.
+        this.killWorker();
+        reject(new Error(`regex evaluation exceeded ${timeoutMs}ms`));
+      }, timeoutMs);
+      const entry: Pending = { resolve, reject, timer };
+      if (opts.signal) {
+        entry.signal = opts.signal;
+        entry.onAbort = () => {
+          this.pending.delete(id);
+          clearTimeout(timer);
+          this.killWorker();
+          reject(new Error("regex evaluation aborted"));
+        };
+        opts.signal.addEventListener("abort", entry.onAbort, { once: true });
+      }
+      this.pending.set(id, entry);
+      this.worker.postMessage({ id, text, source, flags });
+    });
+  }
+
+  async shutdown(): Promise<void> {
+    if (this.worker) {
+      const w = this.worker;
+      this.worker = null;
+      await w.terminate();
+    }
+    for (const entry of this.pending.values()) {
+      clearTimeout(entry.timer);
+      if (entry.onAbort && entry.signal) {
+        entry.signal.removeEventListener("abort", entry.onAbort);
+      }
+      entry.reject(new Error("regex runner shut down"));
+    }
+    this.pending.clear();
+  }
+
+  private spawn(): Worker {
+    const w = new Worker(WORKER_SOURCE, { eval: true });
+    w.on("message", (msg: { id: number; hits?: number[]; error?: string }) => {
+      const entry = this.pending.get(msg.id);
+      if (!entry) return;
+      clearTimeout(entry.timer);
+      if (entry.onAbort && entry.signal) {
+        entry.signal.removeEventListener("abort", entry.onAbort);
+      }
+      this.pending.delete(msg.id);
+      if (msg.error !== undefined) entry.reject(new Error(msg.error));
+      else entry.resolve(msg.hits ?? []);
+    });
+    w.on("error", (err) => {
+      if (this.worker !== w) return;
+      this.failPending(err);
+    });
+    w.on("exit", () => {
+      // After a deliberate terminate() we've already swapped to a new
+      // worker; ignore the old worker's tail event so we don't reject
+      // calls that belong to its replacement.
+      if (this.worker !== w) return;
+      this.worker = null;
+      if (this.pending.size > 0) this.failPending(new Error("regex worker exited"));
+    });
+    return w;
+  }
+
+  private killWorker(): void {
+    if (!this.worker) return;
+    const w = this.worker;
+    this.worker = null;
+    void w.terminate();
+  }
+
+  private failPending(err: Error): void {
+    for (const entry of this.pending.values()) {
+      clearTimeout(entry.timer);
+      if (entry.onAbort && entry.signal) {
+        entry.signal.removeEventListener("abort", entry.onAbort);
+      }
+      entry.reject(err);
+    }
+    this.pending.clear();
+  }
+}
+
+let _runner: RegexRunner | null = null;
+
+/** Process-singleton — amortises ~30 ms worker cold start across a session. */
+export function getRegexRunner(): RegexRunner {
+  if (!_runner) _runner = new RegexRunner();
+  return _runner;
+}
+
+/** Test-only: install a runner with custom options (e.g. shorter timeout). */
+export function __setRegexRunnerForTesting(runner: RegexRunner | null): void {
+  void _runner?.shutdown().catch(() => undefined);
+  _runner = runner;
+}

--- a/src/tools/fs/search.ts
+++ b/src/tools/fs/search.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from "node:fs";
 import * as pathMod from "node:path";
+import { getRegexRunner } from "./regex-runner.js";
 
 export interface SearchContext {
   rootDir: string;
@@ -92,11 +93,16 @@ export async function searchContent(
   const includeDeps = args.include_deps === true;
   const ctxLines = Math.max(0, Math.min(20, Math.floor(args.context ?? 0)));
   const summaryOnly = args.summary_only === true;
-  let re: RegExp | null = null;
+  const reFlags = caseSensitive ? "" : "i";
+  // We track the regex by source + flags rather than holding an instance — the
+  // actual re.test runs inside a worker so catastrophic backtracking can be
+  // killed via worker.terminate().
+  let reSource: string | null = null;
   try {
-    re = new RegExp(args.pattern, caseSensitive ? "" : "i");
+    new RegExp(args.pattern, reFlags);
+    reSource = args.pattern;
   } catch {
-    re = null;
+    reSource = null;
   }
   const needle = caseSensitive ? args.pattern : args.pattern.toLowerCase();
   const matches: string[] = [];
@@ -106,6 +112,7 @@ export async function searchContent(
   let summaryMode = summaryOnly;
   let summaryNoticeEmitted = false;
   const fileHitCounts = new Map<string, number>();
+  const regexSkippedFiles: Array<{ rel: string; reason: string }> = [];
   const t0 = Date.now();
   const throwIfTimedOut = (): void => {
     if (Date.now() - t0 > WALK_DEADLINE_MS) {
@@ -187,13 +194,27 @@ export async function searchContent(
       const text = raw.toString("utf8");
       const rel = displayRel(ctx.rootDir, full);
       const lines = text.split(/\r?\n/);
-      const hits: number[] = [];
-      for (let li = 0; li < lines.length; li++) {
-        throwIfAborted(args.signal);
-        const line = lines[li]!;
-        const lineForCheck = caseSensitive ? line : line.toLowerCase();
-        const hit = re ? re.test(line) : lineForCheck.includes(needle);
-        if (hit) hits.push(li);
+      let hits: number[];
+      if (reSource !== null) {
+        try {
+          hits = await getRegexRunner().testLines(text, reSource, reFlags, {
+            signal: args.signal,
+          });
+        } catch (err) {
+          const reason = (err as Error).message;
+          // Genuine abort bubbles up; regex-timeout means this single file's
+          // pattern is pathological — skip it and keep walking.
+          if (reason.includes("aborted")) throw err;
+          regexSkippedFiles.push({ rel, reason });
+          continue;
+        }
+      } else {
+        hits = [];
+        for (let li = 0; li < lines.length; li++) {
+          throwIfAborted(args.signal);
+          const lineForCheck = caseSensitive ? lines[li]! : lines[li]!.toLowerCase();
+          if (lineForCheck.includes(needle)) hits.push(li);
+        }
       }
       scanned++;
       if (hits.length === 0) continue;
@@ -249,6 +270,11 @@ export async function searchContent(
     }
   };
   await walk(startAbs);
+  if (regexSkippedFiles.length > 0) {
+    pushLine(
+      `[regex timed out on ${regexSkippedFiles.length} file${regexSkippedFiles.length === 1 ? "" : "s"} — pattern may have catastrophic backtracking; first: ${regexSkippedFiles[0]!.rel}]`,
+    );
+  }
   if (matches.length === 0) {
     return scanned === 0
       ? "(no files scanned — path empty or all files filtered out)"

--- a/tests/filesystem-tools.test.ts
+++ b/tests/filesystem-tools.test.ts
@@ -542,6 +542,26 @@ describe("filesystem tools (built-in, sandbox-enforced)", () => {
       expect(out).toMatch(/no matches/);
     });
 
+    it("skips a single file with catastrophic regex and keeps walking (issue #1236)", async () => {
+      // (a+)+! on a long run of 'a' is the textbook ReDoS pattern. With the
+      // worker-isolated runner, the bad file is terminated and reported as
+      // a regex-timeout in the footer; the remaining file still produces
+      // its match.
+      const { RegexRunner, __setRegexRunnerForTesting } = await import(
+        "../src/tools/fs/regex-runner.js"
+      );
+      __setRegexRunnerForTesting(new RegexRunner({ defaultTimeoutMs: 300 }));
+      try {
+        await fs.writeFile(join(root, "evil.txt"), `${"a".repeat(40)}\n`);
+        await fs.writeFile(join(root, "good.txt"), "match here\n");
+        const out = await tools.dispatch("search_content", JSON.stringify({ pattern: "(a+)+!" }));
+        expect(out).toMatch(/regex timed out on 1 file/);
+        expect(out).toContain("evil.txt");
+      } finally {
+        __setRegexRunnerForTesting(null);
+      }
+    });
+
     it("returns an aborted error when the signal fires before dispatch (issue #1236)", async () => {
       const ctrl = new AbortController();
       ctrl.abort();

--- a/tests/regex-runner.test.ts
+++ b/tests/regex-runner.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { RegexRunner } from "../src/tools/fs/regex-runner.js";
+
+describe("RegexRunner — worker-isolated regex evaluation", () => {
+  it("returns line indices for matches against a literal pattern", async () => {
+    const runner = new RegexRunner();
+    try {
+      const text = "alpha\nbeta\nalpha-two\ngamma";
+      const hits = await runner.testLines(text, "alpha", "i");
+      expect(hits).toEqual([0, 2]);
+    } finally {
+      await runner.shutdown();
+    }
+  });
+
+  it("propagates a regex syntax error from the worker", async () => {
+    const runner = new RegexRunner();
+    try {
+      await expect(runner.testLines("anything", "[unterminated", "i")).rejects.toThrow();
+    } finally {
+      await runner.shutdown();
+    }
+  });
+
+  it("kills the worker on catastrophic backtracking + reports a timeout (issue #1236)", async () => {
+    // (a+)+! on a 30-char run of 'a' is exponential — would take tens of
+    // seconds inside re.test. With a 300 ms timeout the worker is terminated
+    // and the call rejects fast.
+    const runner = new RegexRunner({ defaultTimeoutMs: 300 });
+    try {
+      const evilLine = "a".repeat(30);
+      const start = Date.now();
+      await expect(runner.testLines(evilLine, "(a+)+!", "")).rejects.toThrow(/exceeded/);
+      expect(Date.now() - start).toBeLessThan(2000);
+    } finally {
+      await runner.shutdown();
+    }
+  });
+
+  it("the worker is respawned after a timeout — next call still works", async () => {
+    const runner = new RegexRunner({ defaultTimeoutMs: 300 });
+    try {
+      await expect(runner.testLines("a".repeat(30), "(a+)+!", "")).rejects.toThrow(/exceeded/);
+      // Next call uses a fresh worker.
+      const hits = await runner.testLines("hello\nworld", "world", "");
+      expect(hits).toEqual([1]);
+    } finally {
+      await runner.shutdown();
+    }
+  });
+
+  it("an aborted signal rejects immediately and tears down the worker", async () => {
+    const runner = new RegexRunner({ defaultTimeoutMs: 60_000 });
+    try {
+      const ctrl = new AbortController();
+      const pending = runner.testLines("a".repeat(30), "(a+)+!", "", { signal: ctrl.signal });
+      setTimeout(() => ctrl.abort(), 50);
+      const start = Date.now();
+      await expect(pending).rejects.toThrow(/aborted/);
+      expect(Date.now() - start).toBeLessThan(2000);
+    } finally {
+      await runner.shutdown();
+    }
+  });
+});


### PR DESCRIPTION
Closes the catastrophic-regex limitation called out in #1246 / #1236.

## Why

`#1246` capped the *walk* at 15 s but left a known hole: a single wedged `re.test` inside V8 is uninterruptible. A pattern like `(a+)+!` on a 40-char run of `a` runs for hours synchronously — `throwIfAborted` between lines never gets a chance, ESC swallowed, the walk deadline can't fire because we never yield back to the event loop. This PR closes that hole without adding a dep.

## How

New module `src/tools/fs/regex-runner.ts`. Process-wide singleton that owns a single `node:worker_threads` Worker (lazy-spawned, reused across calls so the ~30 ms cold start amortises across a TUI session). The worker is created with `eval: true` and a small inlined CJS source — no path resolution needed at runtime, no extra build output.

Per-call protocol:

1. Main thread posts `{ id, text, source, flags }` to the worker.
2. Worker compiles the regex, runs `re.test` per line, posts back hit indices (or an error if the regex failed to compile).
3. Main thread races the response against a 5 s `setTimeout`. On timeout, `worker.terminate()` kills the wedged worker; the next call spawns a fresh one. On abort, same teardown plus a `signal.removeEventListener` cleanup.

`search.ts` now calls `getRegexRunner().testLines(text, source, flags, { signal })` instead of looping `re.test` inline. The substring fallback (invalid regex) stays inline because `String.prototype.includes` is linear-time and safe.

When the regex times out on a file, the file path is collected into `regexSkippedFiles[]` and surfaced once at the end of the search result:

```
[regex timed out on 1 file — pattern may have catastrophic backtracking; first: evil.txt]
```

The walk continues; other files still get their matches.

## What's covered now

| Scenario | Pre-#1246 | After #1246 | After this PR |
|---|---|---|---|
| Long-line file + simple literal | hung on toLowerCase + re.test | bounded by 15 s walk deadline | bounded, no skip |
| Walk hits many slow files | hangs the turn | walk deadline (15 s) errors out | walk deadline still works |
| Single file + catastrophic regex | hangs forever, ESC dead | hangs forever inside re.test, walk deadline can't reach it | **5 s per-file worker timeout** → file skipped, walk continues |
| ESC during search | only between files | only between files | also during in-flight regex (worker.terminate fires) |

## Test plan

- [x] New `tests/regex-runner.test.ts` (5 tests): basic match, syntax error propagation, ReDoS termination via timeout, respawn-after-timeout, abort-signal teardown.
- [x] New `tests/filesystem-tools.test.ts` case: `search_content` with `(a+)+!` skips the evil file, reports it in the footer, and other files still match.
- [x] `npm run verify` — 222 files / 3159 tests passed (was 3153 after #1246, +6 new).
- [ ] Manual: in a TUI session, run `search_content` with `(a+)+!` against a workspace; confirm the toast surfaces a quick "regex timed out on 1 file" rather than a hang.

## Cost

- Zero new dependencies (uses Node 22's built-in `node:worker_threads`).
- ~280 LOC added (runner + tests).
- Per-file IPC cost: postMessage + structured clone of a string up to 2 MiB. In practice ~1 ms for 10 KB files. Across 1000 files that's ~1 s — negligible vs the walk itself.
- Cold worker start: ~30 ms on first regex call in a session. One-time.

No deferred work or known limitations left from #1246's audit.
