### PR TITLE
chore(search): bump regex worker timeout 5s → 60s, walk deadline 15s → 120s

### DIFF
--- a/src/tools/fs/regex-runner.ts
+++ b/src/tools/fs/regex-runner.ts
@@ -25,7 +25,11 @@ parentPort.on("message", (msg) => {
 });
 `;
 
-const DEFAULT_TIMEOUT_MS = 5_000;
+// 60s gives slow machines (WSL, low-end laptops) generous headroom for any
+// non-catastrophic regex on the 2 MiB per-file cap — V8 finishes those in
+// seconds at most. ESC still tears the worker down immediately; this is the
+// automatic backstop for an unattended terminal.
+const DEFAULT_TIMEOUT_MS = 60_000;
 
 type Pending = {
   resolve: (hits: number[]) => void;

--- a/src/tools/fs/search.ts
+++ b/src/tools/fs/search.ts
@@ -72,8 +72,11 @@ export async function searchFiles(
 const MAX_HITS_PER_FILE = 30;
 /** Once printed bytes pass this fraction of the byte budget, remaining files switch to histogram. */
 const SUMMARY_MODE_TRIGGER_RATIO = 0.8;
-/** Soft deadline for a single searchContent invocation — a stuck walk fails loudly instead of hanging the turn. */
-const WALK_DEADLINE_MS = 15_000;
+// Walk-level deadline must be larger than the per-file regex timeout
+// (DEFAULT_TIMEOUT_MS in regex-runner = 60 s) so one timed-out file doesn't
+// immediately trip this guard; 120 s leaves room for a second slow file
+// plus the rest of the walk before declaring the search a lost cause.
+const WALK_DEADLINE_MS = 120_000;
 
 export async function searchContent(
   ctx: SearchContext,


### PR DESCRIPTION
Follow-up to #1250 — bumping the regex worker timeout from 5 s to **60 s** and the walk deadline from 15 s to **120 s**.

## Why

5 s was conservatively chosen to balance "kill ReDoS fast" against "don't false-positive slow legitimate regex". In practice V8 finishes any non-catastrophic regex on the 2 MiB per-file cap in seconds even on slow hardware (WSL, low-end laptops, ARM Chromebooks), and:

- ESC already tears the worker down immediately via the AbortSignal path — users on slow hardware don't have to wait the full 60 s before they can recover.
- ReDoS patterns (`(a+)+!`, `(.+)*x`) are exponential — they hit minutes / hours, not "between 5 and 60 seconds." A bigger timeout still catches them; just after a longer unattended wait.
- The trade-off is asymmetric: a false-positive timeout on legitimate slow regex silently drops a file from results and confuses the user, while a slightly later catch on ReDoS just means the user waits longer to see "regex timed out on N files" (or hits ESC).

The walk deadline has to stay larger than the per-file timeout — otherwise a single timed-out file would always trip the walk guard, blowing away partial results. 120 s leaves room for one regex timeout + a second slow file + the rest of a normal walk.

## Diff

Two constants:

- `src/tools/fs/regex-runner.ts`: `DEFAULT_TIMEOUT_MS` 5 000 → 60 000
- `src/tools/fs/search.ts`: `WALK_DEADLINE_MS` 15 000 → 120 000

Both call sites already use `setTimeout` and the existing tests inject their own `defaultTimeoutMs: 300` for fast-fail behaviour, so no test rewrites were needed.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run tests/regex-runner.test.ts tests/filesystem-tools.test.ts` — 125 tests pass (the runner test still asserts a 300 ms-timeout-based ReDoS termination; production constant doesn't affect it).
- [ ] Manual: run a real `search_content` against a workspace with a benign complex regex; confirm no spurious timeout on slow hardware.
