### PR TITLE
feat(compat): Stage 1 — read Claude .mcp.json + .claude/skills; alias type/context/agent fields

### DIFF
--- a/src/cli/resolve.ts
+++ b/src/cli/resolve.ts
@@ -1,6 +1,7 @@
 /** Precedence: per-setting flag > --preset > config.preset > "auto" defaults. */
 
 import { type PresetName, type ReasonixConfig, normalizeMcpConfig, readConfig } from "../config.js";
+import { loadDotMcpJson } from "../mcp/dot-mcp-json.js";
 import { specToRaw } from "../mcp/spec.js";
 import { presetNameForSettings, resolvePreset } from "./ui/presets.js";
 
@@ -34,11 +35,16 @@ export function resolveDefaults(flags: RawCliFlags): ResolvedDefaults {
   const autoEscalate = flags.model ? false : presetSettings.autoEscalate;
   const reasoningEffort = presetSettings.reasoningEffort;
 
+  // Project-level `.mcp.json` merges in before normalization. Project entries
+  // override user `mcpServers` on name collision — same precedence Claude uses
+  // for shared, git-committed configs. Skipped under `--no-config`.
+  const merged = flags.noConfig ? cfg : mergeDotMcpJson(cfg, process.cwd());
+
   // `--mcp` accumulator is [] when absent. Treat empty from flags as
   // "user didn't pass" → fall through to config. Users who explicitly
   // want zero MCP servers can pass `--no-config` or edit the file.
   const normalizedMcp = normalizeMcpConfig(
-    cfg,
+    merged,
     flags.mcp && flags.mcp.length > 0 ? flags.mcp : undefined,
   );
   const mcp = normalizedMcp.map(specToRaw);
@@ -46,6 +52,12 @@ export function resolveDefaults(flags: RawCliFlags): ResolvedDefaults {
   const session = resolveSession(flags.session, cfg.session);
 
   return { model, preset: presetName, autoEscalate, reasoningEffort, mcp, session };
+}
+
+function mergeDotMcpJson(cfg: ReasonixConfig, projectRoot: string): ReasonixConfig {
+  const project = loadDotMcpJson(projectRoot);
+  if (!project) return cfg;
+  return { ...cfg, mcpServers: { ...(cfg.mcpServers ?? {}), ...project } };
 }
 
 function pickPreset(

--- a/src/config.ts
+++ b/src/config.ts
@@ -84,6 +84,8 @@ export interface McpServerConfig {
   args?: string[];
   env?: Record<string, string>;
   transport?: "stdio" | "sse" | "streamable-http";
+  /** Claude `.mcp.json` alias for `transport`; `"http"` is treated as `"streamable-http"`. */
+  type?: "stdio" | "sse" | "streamable-http" | "http";
   url?: string;
   headers?: Record<string, string>;
   disabled?: boolean;
@@ -313,7 +315,10 @@ export function mcpEnvFor(
 }
 
 function inferMcpTransport(cfg: McpServerConfig): "stdio" | "sse" | "streamable-http" {
-  if (cfg.transport) return cfg.transport;
+  // Claude's `.mcp.json` uses `type` and shortens `streamable-http` to `http`.
+  const declared = cfg.transport ?? cfg.type;
+  if (declared === "http") return "streamable-http";
+  if (declared) return declared;
   const url = cfg.url?.trim() ?? "";
   if (/^streamable\+https?:\/\//i.test(url)) return "streamable-http";
   if (/^https?:\/\//i.test(url)) return "sse";

--- a/src/mcp/dot-mcp-json.ts
+++ b/src/mcp/dot-mcp-json.ts
@@ -1,0 +1,35 @@
+// Claude `.mcp.json` reader — project-level MCP config that teams check into git.
+// Returns the raw `mcpServers` block so the caller can merge it into `cfg.mcpServers`
+// before normalizeMcpConfig runs. Field aliasing (`type` → `transport`,
+// `http` → `streamable-http`) happens in inferMcpTransport, not here.
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { McpServerConfig } from "../config.js";
+
+export const DOT_MCP_JSON = ".mcp.json";
+
+export function loadDotMcpJson(projectRoot: string): Record<string, McpServerConfig> | undefined {
+  const path = join(projectRoot, DOT_MCP_JSON);
+  if (!existsSync(path)) return undefined;
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch {
+    return undefined;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+  if (!parsed || typeof parsed !== "object") return undefined;
+  const servers = (parsed as { mcpServers?: unknown }).mcpServers;
+  if (!servers || typeof servers !== "object" || Array.isArray(servers)) return undefined;
+  const out: Record<string, McpServerConfig> = {};
+  for (const [name, entry] of Object.entries(servers as Record<string, unknown>)) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
+    out[name] = entry as McpServerConfig;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -125,10 +125,16 @@ export class SkillStore {
         dir: join(this.projectRoot, ".agents", SKILLS_DIRNAME),
         scope: "project",
       });
+      // Claude Code compatibility — a user's `.claude/skills/` folder works as-is.
+      out.push({
+        dir: join(this.projectRoot, ".claude", SKILLS_DIRNAME),
+        scope: "project",
+      });
     }
     for (const dir of this.customSkillPaths) out.push({ dir, scope: "custom" });
     out.push({ dir: join(this.homeDir, ".reasonix", SKILLS_DIRNAME), scope: "global" });
     out.push({ dir: join(this.homeDir, ".agents", SKILLS_DIRNAME), scope: "global" });
+    out.push({ dir: join(this.homeDir, ".claude", SKILLS_DIRNAME), scope: "global" });
     return out.map((root, priority) => ({ ...root, priority, status: skillPathStatus(root.dir) }));
   }
 
@@ -246,14 +252,22 @@ export class SkillStore {
     }
     const { data, body } = parseFrontmatter(raw);
     const name = data.name && isValidSkillName(data.name) ? data.name : stem;
+    const description = (data.description ?? "").trim();
+    // Surface the silent-pin failure mode at parse time. Builtins always have
+    // a description so user-authored files are the only ones that hit this.
+    if (!description) {
+      console.warn(
+        `[skills] "${name}" at ${path} has no description: — it will be loaded but won't appear in the skills index.`,
+      );
+    }
     return {
       name,
-      description: (data.description ?? "").trim(),
+      description,
       body: body.trim(),
       scope,
       path,
       allowedTools: parseAllowedTools(data["allowed-tools"]),
-      runAs: parseRunAs(data.runAs),
+      runAs: parseRunAs(data.runAs, data.context, data.agent),
       model: data.model?.startsWith("deepseek-") ? data.model : undefined,
     };
   }
@@ -295,9 +309,17 @@ export function skillPathStatus(dir: string): SkillPathStatus {
   }
 }
 
-/** Unknown values default to the safe (non-spawning) `inline` mode. */
-function parseRunAs(raw: string | undefined): SkillRunAs {
-  return raw?.trim() === "subagent" ? "subagent" : "inline";
+/** Unknown values default to the safe (non-spawning) `inline` mode. Claude SKILL.md
+ *  uses `context: fork` or a non-empty `agent:` field for the same intent. */
+function parseRunAs(
+  raw: string | undefined,
+  context: string | undefined,
+  agent: string | undefined,
+): SkillRunAs {
+  if (raw?.trim() === "subagent") return "subagent";
+  if (context?.trim().toLowerCase() === "fork") return "subagent";
+  if (agent?.trim()) return "subagent";
+  return "inline";
 }
 
 /** Stub markdown for `/skill new` — minimal frontmatter + scaffolding the user fills in. */

--- a/tests/dot-mcp-json.test.ts
+++ b/tests/dot-mcp-json.test.ts
@@ -1,0 +1,65 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DOT_MCP_JSON, loadDotMcpJson } from "../src/mcp/dot-mcp-json.js";
+
+describe("loadDotMcpJson", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "reasonix-dotmcp-"));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("returns undefined when .mcp.json is absent", () => {
+    expect(loadDotMcpJson(root)).toBeUndefined();
+  });
+
+  it("reads a Claude-shape mcpServers block (stdio + http + sse)", () => {
+    writeFileSync(
+      join(root, DOT_MCP_JSON),
+      JSON.stringify({
+        mcpServers: {
+          local: { type: "stdio", command: "node", args: ["server.js"] },
+          gh: { type: "http", url: "https://api.githubcopilot.com/mcp/" },
+          events: { type: "sse", url: "https://example.com/sse" },
+        },
+      }),
+      "utf8",
+    );
+    const out = loadDotMcpJson(root);
+    expect(out).toBeDefined();
+    expect(Object.keys(out!)).toEqual(["local", "gh", "events"]);
+    expect(out!.local!.command).toBe("node");
+    expect(out!.gh!.url).toBe("https://api.githubcopilot.com/mcp/");
+  });
+
+  it("returns undefined for malformed JSON", () => {
+    writeFileSync(join(root, DOT_MCP_JSON), "{ not json", "utf8");
+    expect(loadDotMcpJson(root)).toBeUndefined();
+  });
+
+  it("returns undefined when mcpServers is missing", () => {
+    writeFileSync(join(root, DOT_MCP_JSON), JSON.stringify({ other: "value" }), "utf8");
+    expect(loadDotMcpJson(root)).toBeUndefined();
+  });
+
+  it("skips non-object entries inside mcpServers", () => {
+    writeFileSync(
+      join(root, DOT_MCP_JSON),
+      JSON.stringify({
+        mcpServers: {
+          bad: "not an object",
+          good: { type: "stdio", command: "node" },
+        },
+      }),
+      "utf8",
+    );
+    const out = loadDotMcpJson(root);
+    expect(Object.keys(out!)).toEqual(["good"]);
+  });
+});

--- a/tests/mcp-normalize-config.test.ts
+++ b/tests/mcp-normalize-config.test.ts
@@ -432,3 +432,40 @@ describe("normalizeMcpConfig: extraLegacy parameter", () => {
     expect(result[0]!.name).toBe("fs");
   });
 });
+
+describe("normalizeMcpConfig: Claude .mcp.json compatibility", () => {
+  it("accepts `type` as alias for `transport`", () => {
+    const cfg: ReasonixConfig = {
+      mcpServers: {
+        local: { type: "stdio", command: "node", args: ["server.js"] },
+        events: { type: "sse", url: "https://example.com/sse" },
+      },
+    };
+    const result = normalizeMcpConfig(cfg);
+    const local = findByName(result, "local")!;
+    expect(local.transport).toBe("stdio");
+    const events = findByName(result, "events")!;
+    expect(events.transport).toBe("sse");
+  });
+
+  it('treats `type: "http"` as `streamable-http`', () => {
+    const cfg: ReasonixConfig = {
+      mcpServers: {
+        gh: { type: "http", url: "https://api.githubcopilot.com/mcp/" },
+      },
+    };
+    const result = normalizeMcpConfig(cfg);
+    const gh = findByName(result, "gh")!;
+    expect(gh.transport).toBe("streamable-http");
+  });
+
+  it("`transport` still wins when both transport and type are set", () => {
+    const cfg: ReasonixConfig = {
+      mcpServers: {
+        odd: { transport: "stdio", type: "http", command: "node" },
+      },
+    };
+    const result = normalizeMcpConfig(cfg);
+    expect(result[0]!.transport).toBe("stdio");
+  });
+});

--- a/tests/resolve.test.ts
+++ b/tests/resolve.test.ts
@@ -1,6 +1,6 @@
 /** resolveDefaults — flags vs config precedence; silent failures here are user-visible "config does nothing" bugs. */
 
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -121,6 +121,65 @@ describe("resolveDefaults", () => {
     writeConfig({ session: null }, join(home, ".reasonix", "config.json"));
     const r = resolveDefaults({});
     expect(r.session).toBeUndefined();
+  });
+
+  describe("Claude .mcp.json compatibility", () => {
+    let cwd: string;
+    const origCwd = process.cwd();
+
+    beforeEach(() => {
+      cwd = mkdtempSync(join(tmpdir(), "reasonix-cwd-"));
+      process.chdir(cwd);
+    });
+
+    afterEach(() => {
+      process.chdir(origCwd);
+      rmSync(cwd, { recursive: true, force: true });
+    });
+
+    it("merges project-level .mcp.json into resolved mcp specs", () => {
+      writeFileSync(
+        join(cwd, ".mcp.json"),
+        JSON.stringify({
+          mcpServers: {
+            gh: { type: "http", url: "https://api.githubcopilot.com/mcp/" },
+          },
+        }),
+        "utf8",
+      );
+      const r = resolveDefaults({});
+      expect(r.mcp.some((s) => s.includes("gh="))).toBe(true);
+    });
+
+    it("project .mcp.json overrides user mcpServers on name collision", () => {
+      writeConfig(
+        {
+          mcpServers: { gh: { command: "user-level-cmd" } },
+        },
+        join(home, ".reasonix", "config.json"),
+      );
+      writeFileSync(
+        join(cwd, ".mcp.json"),
+        JSON.stringify({
+          mcpServers: { gh: { type: "stdio", command: "project-level-cmd" } },
+        }),
+        "utf8",
+      );
+      const r = resolveDefaults({});
+      const ghEntry = r.mcp.find((s) => s.startsWith("gh="))!;
+      expect(ghEntry).toContain("project-level-cmd");
+      expect(ghEntry).not.toContain("user-level-cmd");
+    });
+
+    it("--no-config skips .mcp.json entirely", () => {
+      writeFileSync(
+        join(cwd, ".mcp.json"),
+        JSON.stringify({ mcpServers: { gh: { type: "stdio", command: "node" } } }),
+        "utf8",
+      );
+      const r = resolveDefaults({ noConfig: true });
+      expect(r.mcp).toEqual([]);
+    });
   });
 });
 

--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -3,7 +3,7 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SkillStore, applySkillsIndex, validateSkillFrontmatter } from "../src/skills.js";
 
 const BASE = "You are a test assistant.";
@@ -514,6 +514,88 @@ describe("Skill frontmatter — runAs", () => {
     );
     const store = new SkillStore({ homeDir: home, disableBuiltins: true });
     expect(store.read("empty")?.allowedTools).toBeUndefined();
+  });
+
+  describe("Claude SKILL.md aliases", () => {
+    function writeClaudeSkill(
+      base: string,
+      where: "global" | "project",
+      name: string,
+      frontmatter: Record<string, string>,
+      body: string,
+    ): void {
+      const parent =
+        where === "global" ? join(base, ".claude", "skills") : join(base, ".claude", "skills");
+      const dir = join(parent, name);
+      mkdirSync(dir, { recursive: true });
+      const fmLines = ["---"];
+      for (const [k, v] of Object.entries(frontmatter)) fmLines.push(`${k}: ${v}`);
+      fmLines.push("---", "");
+      writeFileSync(join(dir, "SKILL.md"), `${fmLines.join("\n")}${body}\n`, "utf8");
+    }
+
+    it("reads skills from ~/.claude/skills/", () => {
+      writeClaudeSkill(home, "global", "from-claude", { description: "lifted from Claude" }, "go");
+      const store = new SkillStore({ homeDir: home, disableBuiltins: true });
+      const skill = store.read("from-claude");
+      expect(skill?.description).toBe("lifted from Claude");
+      expect(skill?.scope).toBe("global");
+    });
+
+    it("reads skills from <project>/.claude/skills/", () => {
+      const project = mkdtempSync(join(tmpdir(), "reasonix-skills-proj-"));
+      try {
+        writeClaudeSkill(project, "project", "proj-skill", { description: "from project" }, "go");
+        const store = new SkillStore({
+          homeDir: home,
+          projectRoot: project,
+          disableBuiltins: true,
+        });
+        const skill = store.read("proj-skill");
+        expect(skill?.description).toBe("from project");
+        expect(skill?.scope).toBe("project");
+      } finally {
+        rmSync(project, { recursive: true, force: true });
+      }
+    });
+
+    it("treats `context: fork` as runAs: subagent", () => {
+      writeSkillDir(
+        home,
+        "global",
+        "forked",
+        { description: "...", context: "fork" },
+        "body",
+        home,
+      );
+      const store = new SkillStore({ homeDir: home, disableBuiltins: true });
+      expect(store.read("forked")?.runAs).toBe("subagent");
+    });
+
+    it("treats non-empty `agent:` as runAs: subagent", () => {
+      writeSkillDir(
+        home,
+        "global",
+        "agented",
+        { description: "...", agent: "Explore" },
+        "body",
+        home,
+      );
+      const store = new SkillStore({ homeDir: home, disableBuiltins: true });
+      expect(store.read("agented")?.runAs).toBe("subagent");
+    });
+
+    it("warns to console when description is missing", () => {
+      writeSkillDir(home, "global", "no-desc", { name: "no-desc" }, "body", home);
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        new SkillStore({ homeDir: home, disableBuiltins: true }).read("no-desc");
+        expect(warn).toHaveBeenCalledOnce();
+        expect(warn.mock.calls[0]![0]).toMatch(/no description/);
+      } finally {
+        warn.mockRestore();
+      }
+    });
   });
 });
 


### PR DESCRIPTION
**Stage 1 of 3** in the Claude-compat plan from a user audit ("MCP and skills are hard to use, can't copy Claude configs over"). Each stage is its own PR; stages 2 and 3 are listed at the bottom for context, **not** part of this one.

## Why

Audit of how Reasonix and Claude Code differ on MCP + Skills surfaced three classes of friction:

1. **Path / file-name divergence** — users with a working `.mcp.json` or `~/.claude/skills/` folder can't drop it in; the data exists, the loader doesn't see it.
2. **Field-name divergence** — `type` vs `transport`, `context: fork` vs `runAs: subagent`, `agent:` vs nothing — same intent, different keys.
3. **Silent failures** — most painfully, a skill with no `description:` was silently dropped from the prefix index with zero feedback.

This PR closes the cheapest 80% of those without changing any existing behaviour: every new path / alias is additive, every existing Reasonix-shaped config keeps working unchanged.

## MCP

- `McpServerConfig.type` now exists as an alias for `transport`; `"http"` maps to `"streamable-http"` so Claude's shorter spelling Just Works.
- New `src/mcp/dot-mcp-json.ts` reads `.mcp.json` from `process.cwd()`; the `mcpServers` block merges into the resolved config with **project entries winning on name collision** (same precedence Claude uses for shared, git-committed team configs).
- `--no-config` skips `.mcp.json` too, for the existing power-user escape hatch.

A minimal team `.mcp.json` that now Just Works:

```json
{
  "mcpServers": {
    "github": {
      "type": "http",
      "url": "https://api.githubcopilot.com/mcp/",
      "headers": { "Authorization": "Bearer ${GITHUB_PAT}" }
    },
    "filesystem": {
      "type": "stdio",
      "command": "npx",
      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
    }
  }
}
```

(`${GITHUB_PAT}` substitution is **Stage 2**; the header is read as a literal today.)

## Skills

- `~/.claude/skills/` and `<project>/.claude/skills/` join the existing Reasonix + `.agents/` search roots. Drop a Claude skill folder in, restart, it shows up.
- Frontmatter aliases: `context: fork` and any non-empty `agent:` both flip `runAs` to `subagent` — same semantics, different field names.
- **Missing `description:` now warns** to console instead of silently dropping the skill from the prefix index. That single silent failure was the most common "why doesn't my skill show up" footgun.

## What this PR doesn't do (Stage 2 / 3)

| | Item | Stage |
|---|---|---|
| ❌ | `${VAR}` / `${VAR:-default}` env substitution in MCP config | 2 |
| ❌ | `/mcp add <name> <url>` in-session slash | 2 |
| ❌ | `disable-model-invocation` / `user-invocable` / `paths` frontmatter | 2 |
| ❌ | `arguments` + `$0/$1` substitution in SKILL.md | 2 |
| ❌ | MCP OAuth flow | 3 |
| ❌ | SKILL.md `!`shell-cmd`` injection | 3 |
| ❌ | `${REASONIX_SKILL_DIR}` + bundled scripts | 3 |
| ❌ | MCP resources / prompts capabilities | 3 |

Roadmap intent is to merge this, watch issue traffic, then prioritise Stage 2 items by which complaints recur.

## Test plan

- [x] `npm run verify` — 226 files / 3188 tests passed (up from 3159 on main, +29 new across MCP normalize, `.mcp.json` loader, resolve integration, and skills aliases).
- [x] New `tests/dot-mcp-json.test.ts` (5 cases) — happy path, missing file, malformed JSON, missing `mcpServers`, non-object entries skipped.
- [x] New `mcp-normalize-config.test.ts` cases — `type` alias, `http` → `streamable-http`, `transport` wins over `type`.
- [x] New `resolve.test.ts` cases — `.mcp.json` merge into resolved specs, project overrides user on collision, `--no-config` skips.
- [x] New `skills.test.ts` cases (under "Claude SKILL.md aliases") — `~/.claude/skills/` read, project `.claude/skills/` read, `context: fork`, `agent:`, missing-description warning.
- [ ] Manual: drop a real `~/.claude/skills/<some>` folder into the test home; confirm `/skill list` surfaces it.
