### PR TITLE
feat(search): add Tavily as web_search backend — escape hatch for Mojeek 403s

### DIFF
--- a/src/cli/ui/slash/handlers/web-search-engine.ts
+++ b/src/cli/ui/slash/handlers/web-search-engine.ts
@@ -5,7 +5,10 @@ import type { SlashHandler } from "../dispatch.js";
 export const handlers: Record<string, SlashHandler> = {
   "search-engine": (args, _loop, ctx) => {
     const engine = args[0];
-    if (!engine || (engine !== "mojeek" && engine !== "searxng" && engine !== "metaso")) {
+    if (
+      !engine ||
+      (engine !== "mojeek" && engine !== "searxng" && engine !== "metaso" && engine !== "tavily")
+    ) {
       return {
         info: [
           t("handlers.webSearchEngine.currentEngine", { engine: webSearchEngine() }),
@@ -16,6 +19,7 @@ export const handlers: Record<string, SlashHandler> = {
           t("handlers.webSearchEngine.usageSearxng"),
           t("handlers.webSearchEngine.usageSearxngUrl"),
           t("handlers.webSearchEngine.usageMetaso"),
+          t("handlers.webSearchEngine.usageTavily"),
           "",
           t("handlers.webSearchEngine.alias"),
           "",
@@ -38,7 +42,9 @@ export const handlers: Record<string, SlashHandler> = {
         ? t("handlers.webSearchEngine.switchedSearxngNote", { endpoint: webSearchEndpoint() })
         : engine === "metaso"
           ? t("handlers.webSearchEngine.switchedMetasoNote")
-          : "";
+          : engine === "tavily"
+            ? t("handlers.webSearchEngine.switchedTavilyNote")
+            : "";
     ctx.postInfo?.(t("handlers.webSearchEngine.switched", { engine, note }));
 
     const detail =

--- a/src/config.ts
+++ b/src/config.ts
@@ -141,12 +141,14 @@ export interface ReasonixConfig {
   session?: string | null;
   setupCompleted?: boolean;
   search?: boolean;
-  /** Web search engine backend: "mojeek" (default, scrapes Mojeek), "searxng" (self-hosted SearXNG), or "metaso" (Metaso API). */
-  webSearchEngine?: "mojeek" | "searxng" | "metaso";
+  /** Web search engine backend: "mojeek" (default, scrapes Mojeek), "searxng" (self-hosted SearXNG), "metaso" (Metaso API), or "tavily" (LLM-friendly API, free tier). */
+  webSearchEngine?: "mojeek" | "searxng" | "metaso" | "tavily";
   /** Base URL for SearXNG instance (default http://localhost:8080). */
   webSearchEndpoint?: string;
   /** Metaso API key. Falls back to METASO_API_KEY env var, then a built-in default. */
   metasoApiKey?: string;
+  /** Tavily API key. Falls back to TAVILY_API_KEY env var. No baked-in default — free tier is 1000/mo per account, sharing would burn out. */
+  tavilyApiKey?: string;
   dashboard?: {
     /** Pin the embedded dashboard to a fixed port — required for stable SSH tunnels. 0/absent → ephemeral. */
     port?: number;
@@ -262,6 +264,14 @@ export function loadMetasoApiKey(path: string = defaultConfigPath()): string {
   const cfg = readConfig(path).metasoApiKey;
   if (cfg && typeof cfg === "string" && cfg.trim()) return cfg.trim();
   return DEFAULT_METASO_API_KEY;
+}
+
+/** Tavily API key — env > config > undefined. Returning undefined means the caller must error out with a clear "go get one at tavily.com" message; we deliberately ship no default because the free 1000/mo quota wouldn't survive being shared. */
+export function loadTavilyApiKey(path: string = defaultConfigPath()): string | undefined {
+  if (process.env.TAVILY_API_KEY) return process.env.TAVILY_API_KEY.trim();
+  const cfg = readConfig(path).tavilyApiKey;
+  if (cfg && typeof cfg === "string" && cfg.trim()) return cfg.trim();
+  return undefined;
 }
 
 const DEFAULT_OLLAMA_URL = "http://localhost:11434";

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -1140,6 +1140,8 @@ export const EN: TranslationSchema = {
       usageSearxngUrl: "  /search-engine searxng <url>      use SearXNG at custom endpoint",
       usageMetaso:
         "  /search-engine metaso              use Metaso API (100/d free, configure your own API key for more)",
+      usageTavily:
+        "  /search-engine tavily              use Tavily API (LLM-friendly, free 1000/mo — set TAVILY_API_KEY or tavilyApiKey in config; get one at https://tavily.com)",
       alias: "Alias: /se",
       searxngInfo:
         "SearXNG is a self-hosted metasearch engine (https://github.com/searxng/searxng).",
@@ -1148,6 +1150,8 @@ export const EN: TranslationSchema = {
       switchedSearxngNote: " Make sure SearXNG is running at {endpoint}.",
       switchedMetasoNote:
         " There is a daily quota of 100 (configure your own API key for higher limits).",
+      switchedTavilyNote:
+        " Set TAVILY_API_KEY or `tavilyApiKey` in config; free 1000/mo at https://tavily.com.",
       confirmed:
         '✓ Web search engine set to "{engine}"{detail}. Next assistant turn will pick up the change.',
       confirmedDetail: " ({endpoint})",
@@ -1451,6 +1455,16 @@ export const EN: TranslationSchema = {
     metasoParseError:
       "web_search: Metaso returned unparseable response (HTTP {status}) \u2014 try again later",
     metasoApiError: "web_search: Metaso API error (code {code}: {message}) \u2014 try again later",
+    tavilyMissingKey:
+      "web_search: Tavily backend requires an API key \u2014 set TAVILY_API_KEY env var or `tavilyApiKey` in ~/.reasonix/config.json; free 1000/mo signup at https://tavily.com",
+    tavilyUnauthorized:
+      "web_search: Tavily API key rejected \u2014 check TAVILY_API_KEY or get one at https://tavily.com",
+    tavilyRateLimit:
+      "web_search: Tavily rate-limited or monthly quota exceeded \u2014 wait, switch engine with /search-engine mojeek, or upgrade your Tavily plan",
+    tavilyServerError:
+      "web_search: Tavily server error ({status}) \u2014 try again later, or switch engine with /search-engine mojeek",
+    tavilyParseError:
+      "web_search: Tavily returned unparseable response (HTTP {status}) \u2014 try again later",
     fetchStatus:
       "web_fetch {status} for {url} \u2014 try: confirm the URL resolves in a browser; status suggests the host returned an error page",
     fetchRateLimit429:

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -622,6 +622,11 @@ export interface TranslationSchema {
     metasoServerError: string;
     metasoParseError: string;
     metasoApiError: string;
+    tavilyMissingKey: string;
+    tavilyUnauthorized: string;
+    tavilyRateLimit: string;
+    tavilyServerError: string;
+    tavilyParseError: string;
     fetchStatus: string;
     fetchRateLimit429: string;
     fetchForbidden403: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -1081,12 +1081,16 @@ export const zhCN: TranslationSchema = {
       usageSearxngUrl: "  /search-engine searxng <url>      使用 SearXNG 自定义端点",
       usageMetaso:
         "  /search-engine metaso              使用 Metaso API（每天 100 次免费，配置你自己的 API 密钥可提升限额）",
+      usageTavily:
+        "  /search-engine tavily              使用 Tavily API（LLM 友好，每月 1000 次免费 — 设置 TAVILY_API_KEY 或 config 的 tavilyApiKey；注册 https://tavily.com）",
       alias: "别名：/se",
       searxngInfo: "SearXNG 是一个自托管的元搜索引擎（https://github.com/searxng/searxng）。",
       searxngInstall: "安装命令：  docker run -d -p 8080:8080 searxng/searxng",
       switched: '已切换网页搜索引擎为 "{engine}"。{note}',
       switchedSearxngNote: " 请确保 SearXNG 在 {endpoint} 运行。",
       switchedMetasoNote: " 每日限额 100 次（配置你自己的 API 密钥可提升限额）。",
+      switchedTavilyNote:
+        " 请设置环境变量 TAVILY_API_KEY 或 config 中的 `tavilyApiKey`；https://tavily.com 每月 1000 次免费。",
       confirmed: '✓ 网页搜索引擎已设为 "{engine}"{detail}。下一轮模型调用将生效。',
       confirmedDetail: "（{endpoint}）",
     },
@@ -1376,6 +1380,15 @@ export const zhCN: TranslationSchema = {
       "web_search: Metaso 服务器错误（{status}）— 稍后重试，或使用 /search-engine mojeek 切换引擎",
     metasoParseError: "web_search: Metaso 返回无法解析的响应（HTTP {status}）— 稍后重试",
     metasoApiError: "web_search: Metaso API 错误（code {code}: {message}）— 稍后重试",
+    tavilyMissingKey:
+      "web_search: Tavily 后端需要 API 密钥 — 设置 TAVILY_API_KEY 环境变量，或在 ~/.reasonix/config.json 中配置 `tavilyApiKey`；https://tavily.com 每月 1000 次免费",
+    tavilyUnauthorized:
+      "web_search: Tavily API 密钥被拒绝 — 检查 TAVILY_API_KEY，或在 https://tavily.com 获取密钥",
+    tavilyRateLimit:
+      "web_search: Tavily 请求频率限制或月度配额用尽 — 等待、用 /search-engine mojeek 切换引擎，或升级 Tavily 计划",
+    tavilyServerError:
+      "web_search: Tavily 服务器错误（{status}）— 稍后重试，或使用 /search-engine mojeek 切换引擎",
+    tavilyParseError: "web_search: Tavily 返回无法解析的响应（HTTP {status}）— 稍后重试",
     fetchStatus:
       "web_fetch {status} for {url} — try: 在浏览器中确认该 URL 能否访问；该状态码表明目标主机返回了错误页面",
     fetchRateLimit429:

--- a/src/tools/web.ts
+++ b/src/tools/web.ts
@@ -3,6 +3,7 @@
 import { parse as parseHtml } from "node-html-parser";
 import {
   loadMetasoApiKey,
+  loadTavilyApiKey,
   webSearchEndpoint as loadWebSearchEndpoint,
   webSearchEngine as loadWebSearchEngine,
 } from "../config.js";
@@ -34,8 +35,8 @@ export interface WebFetchOptions {
 export interface WebSearchOptions {
   topK?: number;
   signal?: AbortSignal;
-  /** Backend engine: "mojeek" (scrapes Mojeek HTML), "searxng" (self-hosted SearXNG JSON API), or "metaso" (Metaso API). */
-  engine?: "mojeek" | "searxng" | "metaso";
+  /** Backend engine: "mojeek" (scrapes Mojeek HTML), "searxng" (self-hosted SearXNG JSON API), "metaso" (Metaso API), or "tavily" (LLM-friendly JSON API). */
+  engine?: "mojeek" | "searxng" | "metaso" | "tavily";
   /** Base URL for SearXNG. Default http://localhost:8080. */
   endpoint?: string;
 }
@@ -51,6 +52,7 @@ const USER_AGENT =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
 const MOJEEK_ENDPOINT = "https://www.mojeek.com/search";
 const METASO_ENDPOINT = "https://metaso.cn/api/v1";
+const TAVILY_ENDPOINT = "https://api.tavily.com/search";
 
 /** Pick a status-specific webErrors key so the model gets an actionable hint, not a bare status. */
 function searchStatusError(status: number): string {
@@ -77,6 +79,9 @@ export async function webSearch(
   }
   if (opts.engine === "searxng") {
     return searchSearxng(query, opts);
+  }
+  if (opts.engine === "tavily") {
+    return searchTavily(query, opts);
   }
   return searchMojeek(query, opts);
 }
@@ -241,6 +246,73 @@ async function searchMetaso(query: string, opts: WebSearchOptions = {}): Promise
     title: wp.title,
     url: wp.link,
     snippet: wp.snippet ?? wp.summary ?? "",
+  }));
+}
+
+interface TavilyResultItem {
+  title: string;
+  url: string;
+  content?: string;
+  score?: number;
+}
+
+interface TavilySearchResponse {
+  results?: TavilyResultItem[];
+  // Tavily error responses use { detail: { error: "..." } } shape.
+  detail?: { error?: string } | string;
+}
+
+async function searchTavily(query: string, opts: WebSearchOptions = {}): Promise<SearchResult[]> {
+  const topK = Math.max(1, Math.min(20, opts.topK ?? DEFAULT_TOPK));
+  const apiKey = loadTavilyApiKey();
+  if (!apiKey) throw new Error(t("webErrors.tavilyMissingKey"));
+
+  let resp: Response;
+  try {
+    resp = await fetch(TAVILY_ENDPOINT, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify({
+        api_key: apiKey,
+        query,
+        search_depth: "basic",
+        max_results: topK,
+        include_answer: false,
+        include_raw_content: false,
+        include_images: false,
+      }),
+      signal: opts.signal,
+    });
+  } catch (err) {
+    if (err instanceof TypeError && (err as Error).message.includes("fetch")) {
+      throw new Error(t("webErrors.cannotReach", { endpoint: TAVILY_ENDPOINT }));
+    }
+    throw err;
+  }
+
+  if (!resp.ok) {
+    if (resp.status === 401 || resp.status === 403) {
+      throw new Error(t("webErrors.tavilyUnauthorized"));
+    }
+    if (resp.status === 429) throw new Error(t("webErrors.tavilyRateLimit"));
+    throw new Error(t("webErrors.tavilyServerError", { status: resp.status }));
+  }
+
+  let data: TavilySearchResponse;
+  try {
+    data = (await resp.json()) as TavilySearchResponse;
+  } catch {
+    throw new Error(t("webErrors.tavilyParseError", { status: resp.status }));
+  }
+
+  const results = data.results ?? [];
+  return results.slice(0, topK).map((r) => ({
+    title: r.title,
+    url: r.url,
+    snippet: r.content ?? "",
   }));
 }
 
@@ -509,8 +581,8 @@ export interface WebToolsOptions {
   defaultTopK?: number;
   /** Byte cap for `web_fetch` extracted text. */
   maxFetchChars?: number;
-  /** Backend engine: "mojeek" (default, scrapes Mojeek), "searxng" (self-hosted SearXNG), or "metaso" (Metaso API). */
-  webSearchEngine?: "mojeek" | "searxng" | "metaso";
+  /** Backend engine: "mojeek" (default, scrapes Mojeek), "searxng" (self-hosted SearXNG), "metaso" (Metaso API), or "tavily" (LLM-friendly API). */
+  webSearchEngine?: "mojeek" | "searxng" | "metaso" | "tavily";
   /** Base URL for SearXNG (default http://localhost:8080). */
   webSearchEndpoint?: string;
 }
@@ -523,7 +595,7 @@ export function registerWebTools(registry: ToolRegistry, opts: WebToolsOptions =
     name: "web_search",
     description:
       "Search the public web. Returns ranked results with title, url, and snippet. Call this when the answer's correctness depends on current state — anything that changes over time (events, prices, releases, status of a thing in the real world). Composing such answers from training memory invents stale numbers; search first, then ground the answer in the results. For evergreen / definitional questions you don't need this." +
-      " To change the backend, use /search-engine mojeek|searxng|metaso.",
+      " To change the backend, use /search-engine mojeek|searxng|metaso|tavily.",
     readOnly: true,
     parallelSafe: true,
     parameters: {

--- a/tests/web-tools.test.ts
+++ b/tests/web-tools.test.ts
@@ -450,6 +450,147 @@ describe("searchMetaso", () => {
   });
 });
 
+describe("searchTavily", () => {
+  const sampleResponse = {
+    query: "test query",
+    results: [
+      {
+        title: "First Hit",
+        url: "https://example.com/1",
+        content: "First snippet.",
+        score: 0.93,
+      },
+      {
+        title: "Second Hit",
+        url: "https://example.com/2",
+        content: "Second snippet.",
+        score: 0.81,
+      },
+    ],
+    response_time: 0.42,
+  };
+
+  it("requires an API key — throws a setup-pointing error when none is set", async () => {
+    const origKey = process.env.TAVILY_API_KEY;
+    // biome-ignore lint/performance/noDelete: env var must be absent, not "undefined"
+    delete process.env.TAVILY_API_KEY;
+    try {
+      await expect(webSearch("q", { engine: "tavily" })).rejects.toThrow(/Tavily.*API key/i);
+      await expect(webSearch("q", { engine: "tavily" })).rejects.toThrow(/tavily\.com/);
+    } finally {
+      if (origKey !== undefined) process.env.TAVILY_API_KEY = origKey;
+    }
+  });
+
+  it("POSTs to Tavily with the api_key in the body", async () => {
+    const origKey = process.env.TAVILY_API_KEY;
+    process.env.TAVILY_API_KEY = "tvly-test-key";
+    const captured: { url: string; method: string; body: string } = {
+      url: "",
+      method: "",
+      body: "",
+    };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      captured.url = String(url);
+      captured.method = init?.method ?? "GET";
+      captured.body = String(init?.body ?? "");
+      return new Response(JSON.stringify(sampleResponse), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+    try {
+      const out = await webSearch("test query", { engine: "tavily", topK: 5 });
+      expect(captured.url).toBe("https://api.tavily.com/search");
+      expect(captured.method).toBe("POST");
+      const body = JSON.parse(captured.body);
+      expect(body.api_key).toBe("tvly-test-key");
+      expect(body.query).toBe("test query");
+      expect(body.max_results).toBe(5);
+      expect(out).toHaveLength(2);
+      expect(out[0]).toEqual({
+        title: "First Hit",
+        url: "https://example.com/1",
+        snippet: "First snippet.",
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (origKey === undefined) {
+        // biome-ignore lint/performance/noDelete: same reason — must drop, not set to "undefined"
+        delete process.env.TAVILY_API_KEY;
+      } else {
+        process.env.TAVILY_API_KEY = origKey;
+      }
+    }
+  });
+
+  it("maps 401/403 to a key-rejected error", async () => {
+    const origKey = process.env.TAVILY_API_KEY;
+    process.env.TAVILY_API_KEY = "tvly-bad";
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(
+      async () => new Response("forbidden", { status: 403 }),
+    ) as unknown as typeof fetch;
+    try {
+      await expect(webSearch("q", { engine: "tavily" })).rejects.toThrow(/Tavily.*rejected/i);
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (origKey === undefined) {
+        // biome-ignore lint/performance/noDelete: same reason
+        delete process.env.TAVILY_API_KEY;
+      } else {
+        process.env.TAVILY_API_KEY = origKey;
+      }
+    }
+  });
+
+  it("maps 429 to a quota/rate-limit error", async () => {
+    const origKey = process.env.TAVILY_API_KEY;
+    process.env.TAVILY_API_KEY = "tvly-test-key";
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(
+      async () => new Response("too many", { status: 429 }),
+    ) as unknown as typeof fetch;
+    try {
+      await expect(webSearch("q", { engine: "tavily" })).rejects.toThrow(/quota|rate-limit/i);
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (origKey === undefined) {
+        // biome-ignore lint/performance/noDelete: same reason
+        delete process.env.TAVILY_API_KEY;
+      } else {
+        process.env.TAVILY_API_KEY = origKey;
+      }
+    }
+  });
+
+  it("returns empty array when results is empty", async () => {
+    const origKey = process.env.TAVILY_API_KEY;
+    process.env.TAVILY_API_KEY = "tvly-test-key";
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ query: "x", results: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    ) as unknown as typeof fetch;
+    try {
+      const out = await webSearch("x", { engine: "tavily" });
+      expect(out).toEqual([]);
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (origKey === undefined) {
+        // biome-ignore lint/performance/noDelete: same reason
+        delete process.env.TAVILY_API_KEY;
+      } else {
+        process.env.TAVILY_API_KEY = origKey;
+      }
+    }
+  });
+});
+
 describe("formatSearchResults", () => {
   it("renders a query header + numbered list", () => {
     const out = formatSearchResults("hello", [

--- a/tests/web-tools.test.ts
+++ b/tests/web-tools.test.ts
@@ -476,7 +476,9 @@ describe("searchTavily", () => {
     delete process.env.TAVILY_API_KEY;
     try {
       await expect(webSearch("q", { engine: "tavily" })).rejects.toThrow(/Tavily.*API key/i);
-      await expect(webSearch("q", { engine: "tavily" })).rejects.toThrow(/tavily\.com/);
+      // Plain-string match — checking the error message includes the signup URL,
+      // not testing URL safety; using a regex here trips CodeQL's missing-anchor rule.
+      await expect(webSearch("q", { engine: "tavily" })).rejects.toThrow("tavily.com");
     } finally {
       if (origKey !== undefined) process.env.TAVILY_API_KEY = origKey;
     }


### PR DESCRIPTION
## Why

Users report frequent **403** from `web_search` — that's Mojeek's anti-bot tripping on our HTML-scraping path. Mojeek has no official API, so as a default we're one CDN policy change away from total breakage. SearXNG fixes it but requires self-hosting. Metaso fixes it but is China-focused and needs a Chinese phone number to register a key.

**Tavily** is the AI-agent ecosystem's settled answer to this problem: real JSON API, **1000 searches/month free** per account (no card required), returns LLM-friendly snippets out of the box. This PR adds it as a fourth backend.

No default change — Mojeek stays as the zero-setup default. Users who actually hit 403 now have a one-slash-command escape hatch:

```
/search-engine tavily
```

…paired with `TAVILY_API_KEY` in env or `tavilyApiKey` in `~/.reasonix/config.json`.

## What's in

- `webSearchEngine` accepts `"tavily"` alongside `mojeek`/`searxng`/`metaso`.
- New `tavilyApiKey?: string` config field + `loadTavilyApiKey()` (env > config > undefined). **No baked-in default key** — the shared free quota would be exhausted in a day across the user base. Missing key throws a clear "go get one at tavily.com" error rather than silently failing.
- `searchTavily()` POSTs to `api.tavily.com/search` and maps 401/403/429 to specific actionable hints (`tavilyUnauthorized`, `tavilyRateLimit`, `tavilyServerError`).
- `/search-engine tavily` slash subcommand + `switchedTavilyNote` setup hint.
- Full EN + zh-CN i18n for the 5 new error strings.

## What's not in (deferred until users actually want it)

- **No auto-fallback** from Mojeek → Tavily on 403. Adding that means embedding a default key or silently calling out to a third-party API; both are bigger decisions worth their own discussion.
- **No setup-wizard prompt** for the Tavily key. Users who switch via `/search-engine tavily` get a clear instruction in the response; integrating it into `reasonix setup` is a small follow-up.
- **No quota-tracking UI**. Tavily's response includes `response_time` but not remaining quota; we'd need a separate `/usage` call.

## Test plan

- [x] `npm run verify` — 226 files / 3193 tests passed (was 3188; +5 new Tavily cases).
- [x] New `web-tools.test.ts` cases: missing-key error, request wire shape (URL + method + body keys), 401/403 → key-rejected, 429 → quota/rate-limit, empty results → `[]`.
- [ ] Manual: set `TAVILY_API_KEY`, run `/search-engine tavily`, do a real query; confirm results come back with `tavily.com`-style content.
