### PR TITLE
feat(tui): re-enable SGR mouse wheel by default (revisit #514)

### DIFF
--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -28,6 +28,7 @@ import { SessionPicker } from "../ui/SessionPicker.js";
 import { Setup } from "../ui/Setup.js";
 import { drainTtyResponses } from "../ui/drain-tty.js";
 import { KeystrokeProvider } from "../ui/keystroke-context.js";
+import { disableMouseMode, enableMouseMode } from "../ui/mouse-mode.js";
 import type { McpServerSummary } from "../ui/slash.js";
 import {
   type McpLifecycleNotice,
@@ -353,6 +354,23 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
   // a spurious MaxListenersExceededWarning. Raise the ceiling.
   process.stdout.setMaxListeners(200);
 
+  // Wheel scrolling. Opt-out via `mouseTracking: false` for users who
+  // prefer native drag-select copy (Shift+drag still selects with mouse
+  // mode on in most terminals). exit hooks cover hard kills so the
+  // sequence doesn't leak into the parent shell.
+  if (cfg.mouseTracking !== false) {
+    enableMouseMode();
+    process.once("exit", disableMouseMode);
+    process.once("SIGINT", () => {
+      disableMouseMode();
+      process.exit(130);
+    });
+    process.once("SIGTERM", () => {
+      disableMouseMode();
+      process.exit(143);
+    });
+  }
+
   const { waitUntilExit } = render(
     <Root
       initialKey={initialKey}
@@ -374,6 +392,7 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
   try {
     await waitUntilExit();
   } finally {
+    disableMouseMode();
     await runtime.closeAll();
     qqChannel?.stop();
     await drainTtyResponses();

--- a/src/cli/ui/mouse-mode.ts
+++ b/src/cli/ui/mouse-mode.ts
@@ -1,0 +1,24 @@
+// SGR mouse tracking on/off. Enables the wheel to reach the TUI in every
+// terminal (Windows Terminal in particular doesn't translate wheel→arrow
+// when alt-screen is active for some users). The trade-off — native
+// drag-select stops working — was the reason #514 dropped this; users
+// asked for the wheel back because the native select only sees the
+// current screen anyway. Shift+drag still selects in most terminals.
+
+const ENABLE = "\u001b[?1000h\u001b[?1006h";
+const DISABLE = "\u001b[?1006l\u001b[?1000l";
+
+let active = false;
+
+export function enableMouseMode(): void {
+  if (active) return;
+  if (!process.stdout.isTTY) return;
+  process.stdout.write(ENABLE);
+  active = true;
+}
+
+export function disableMouseMode(): void {
+  if (!active) return;
+  process.stdout.write(DISABLE);
+  active = false;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -149,6 +149,8 @@ export interface ReasonixConfig {
   metasoApiKey?: string;
   /** Tavily API key. Falls back to TAVILY_API_KEY env var. No baked-in default — free tier is 1000/mo per account, sharing would burn out. */
   tavilyApiKey?: string;
+  /** TUI mouse-wheel scrolling via SGR mouse tracking. Default true. Set false to fall back to native terminal drag-select for copy (then wheel is terminal-dependent — most terminals translate wheel→arrow in alt-screen, some don't). */
+  mouseTracking?: boolean;
   dashboard?: {
     /** Pin the embedded dashboard to a fixed port — required for stable SSH tunnels. 0/absent → ephemeral. */
     port?: number;

--- a/tests/mouse-mode.test.ts
+++ b/tests/mouse-mode.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { disableMouseMode, enableMouseMode } from "../src/cli/ui/mouse-mode.js";
+
+describe("mouse-mode SGR enable/disable", () => {
+  let writes: string[];
+  let origWrite: typeof process.stdout.write;
+  let origIsTTY: boolean | undefined;
+
+  beforeEach(() => {
+    writes = [];
+    origWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString());
+      return true;
+    }) as typeof process.stdout.write;
+    origIsTTY = process.stdout.isTTY;
+    Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+    // Reset module state — disable first to clear `active` from any prior test.
+    disableMouseMode();
+    writes.length = 0;
+  });
+
+  afterEach(() => {
+    disableMouseMode();
+    process.stdout.write = origWrite;
+    Object.defineProperty(process.stdout, "isTTY", { value: origIsTTY, configurable: true });
+  });
+
+  it("enable writes the SGR + 1000 + 1006 escape", () => {
+    enableMouseMode();
+    expect(writes.join("")).toBe("\u001b[?1000h\u001b[?1006h");
+  });
+
+  it("enable is idempotent — second call is a no-op", () => {
+    enableMouseMode();
+    enableMouseMode();
+    expect(writes.length).toBe(1);
+  });
+
+  it("disable writes the matching off-escape", () => {
+    enableMouseMode();
+    writes.length = 0;
+    disableMouseMode();
+    expect(writes.join("")).toBe("\u001b[?1006l\u001b[?1000l");
+  });
+
+  it("disable without prior enable is a no-op", () => {
+    disableMouseMode();
+    expect(writes.length).toBe(0);
+  });
+
+  it("enable when stdout isn't a TTY is a no-op", () => {
+    Object.defineProperty(process.stdout, "isTTY", { value: false, configurable: true });
+    enableMouseMode();
+    expect(writes.length).toBe(0);
+    // And subsequent disable is also a no-op (active flag never flipped).
+    disableMouseMode();
+    expect(writes.length).toBe(0);
+  });
+});


### PR DESCRIPTION
Multiple users have hit "I can press PageUp/↑ but the wheel scrolls the whole terminal instead of the chat." Root cause: #514 dropped SGR mouse tracking on the assumption that every terminal in alt-screen translates wheel→arrow for free. In practice (Windows Terminal + PowerShell at least) that translation isn't always active, so wheel falls through to the terminal's native scrollback and the TUI sees nothing.

This re-enables `\x1b[?1000h\x1b[?1006h` (basic mouse reporting + SGR coordinates) at chat-command startup. The SGR parser in `stdin-reader.ts` already maps `mouseScrollUp/Down` to chat scroll, so the wire-up is one `enableMouseMode()` call. Disable escape fires from the `finally` block and from `process.once("exit" | "SIGINT" | "SIGTERM")` so the sequence can't leak into the parent shell on a hard kill.

## The native-copy trade-off

`#514` originally dropped this because mouse tracking blocks terminal-native drag-select. That trade isn't actually as bad as it sounded:

- **Shift+drag still selects natively** in every modern terminal that ships with mouse-mode bypass:

  | Terminal | Bypass |
  |---|---|
  | Windows Terminal, iTerm2, GNOME Terminal, Konsole, WezTerm, Alacritty | Shift+drag |
  | macOS Terminal.app | ⌥-drag |

  This is the same convention vim's `set mouse=a` users rely on. Documented in the new `mouseTracking` config field.

- For users who specifically prefer native drag-select over wheel scroll, `mouseTracking: false` in `~/.reasonix/config.json` opts out and reverts to #514's behavior.

## What's not in this PR

A **proper TUI-native selection layer** — cell-precise drag-select inside Reasonix's own viewport, spanning chat scrollback (not just current screen). That's a separate, much larger project (cell-grid model, selection overlay, clipboard write, edge auto-scroll, double/triple-click semantics — 600-1000 LOC + clipboard dep + cross-terminal testing). Will open a tracking issue once we have a design.

## Test plan

- [x] New `tests/mouse-mode.test.ts` (5 cases): enable writes the SGR sequence, enable is idempotent, disable writes the off-sequence, disable-without-enable is a no-op, non-TTY enable is a no-op.
- [x] `npm run verify` — 227 files / 3198 tests passed (was 3193 on main; +5 new).
- [ ] Manual: launch `reasonix code`, wheel-scroll up in chat → confirm chat scrolls (not the terminal); Shift+drag → confirm text selects + copy works; quit with Ctrl+C → confirm subsequent shell commands work normally (mouse mode cleared).
- [ ] Manual: set `mouseTracking: false`, restart → confirm wheel falls back to #514's behavior.
