### PR TITLE
feat(tui): align composer keys + visuals with Claude Code

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -483,6 +483,7 @@ function AppInner({
   const lastTurnMs = useAgentState((s) => s.status.lastTurnMs);
   const activityLabel = useActivityLabel();
   const chatScroll = useChatScrollActions();
+  const composerPinned = useChatScrollState((s) => s.pinned);
   const [input, setInput] = useState("");
   const [composerCursor, setComposerCursor] = useState(0);
   const [busy, setBusy] = useState(false);
@@ -1587,24 +1588,17 @@ function AppInner({
     if (ev.ctrl && ev.input === "d") quitProcess();
   });
 
-  // ↑/↓ / PgUp/PgDn always scroll chat; wheel arrives as ↑/↓ via
-  // DECSET 1007 alternate-scroll so it joins the same path. Pickers
-  // (slash / @-mention / slash-arg / shell-confirm) own ↑/↓ — when
-  // any of them is open we skip the arrow path so chat doesn't scroll
-  // alongside picker navigation; PgUp/PgDn/End still scroll. Prompt
-  // history + multi-line cursor moves live on Ctrl+P / Ctrl+N.
+  // Chat scroll keys. Mouse wheel + PgUp/PgDn always scroll; End jumps
+  // to bottom. ↑/↓ belong to the composer (prompt history / per-line
+  // cursor) whenever the composer is visible — so we only consume
+  // arrows here when the composer is hidden (chat is scrolled up and
+  // InputAreaWithHistoryHint has replaced it).
   useKeystroke((ev) => {
-    const pickerOwnsArrows =
-      (atState?.entries.length ?? 0) > 0 ||
-      (slashMatches?.length ?? 0) > 0 ||
-      (slashArgMatches?.length ?? 0) > 0 ||
-      pendingShell != null ||
-      pendingPath != null;
     if (ev.pageUp || ev.mouseScrollUp) chatScroll.scrollPageUp();
     else if (ev.pageDown || ev.mouseScrollDown) chatScroll.scrollPageDown();
     else if (ev.end) chatScroll.jumpToBottom();
-    else if (!pickerOwnsArrows && ev.upArrow) chatScroll.scrollUp();
-    else if (!pickerOwnsArrows && ev.downArrow) chatScroll.scrollDown();
+    else if (!composerPinned && ev.upArrow) chatScroll.scrollUp();
+    else if (!composerPinned && ev.downArrow) chatScroll.scrollDown();
   }, !modalOpen);
 
   // Esc/Ctrl+C during an active model turn forward to the loop as an
@@ -1806,41 +1800,19 @@ function AppInner({
     // (hidden) prompt buffer. Bail early.
     if (pendingShell || pendingPath) return;
 
-    // @-mention picker takes the same priority tier as slash. ↑/↓ walk
-    // the list; Tab on a folder drills into it, Tab on a file commits.
-    // Enter is caught in handleSubmit. Right arrow stays cursor-move
-    // (would otherwise fight PromptInput's multiline cursor). Must come
-    // BEFORE slash so the two pickers don't share arrow keys.
+    // Picker arrow nav lives on the PromptInput → historyHandoff →
+    // handleHistoryPrev/Next path (which checks pickers before recall).
+    // Tab stays here — multiline-keys treats Tab as parent-owned.
     if (atState && atState.entries.length > 0) {
-      const entries = atState.entries;
-      if (key.upArrow) {
-        setAtSelected((i) => Math.max(0, i - 1));
-        return;
-      }
-      if (key.downArrow) {
-        setAtSelected((i) => Math.min(entries.length - 1, i + 1));
-        return;
-      }
       if (key.tab) {
+        const entries = atState.entries;
         const sel = entries[atSelected] ?? entries[0];
         if (sel) pickAtMention(sel, sel.isDir ? "drill" : "commit");
         return;
       }
     }
 
-    // Slash-argument picker. Fires inside `/<cmd> <partial>` —either
-    // a file picker (for /edit), enum picker (for /preset, /model,
-    // /plan, /branch, /harvest), or hint-only row. Navigation + Tab
-    // substitute the highlighted value at the arg's offset.
     if (slashArgMatches && slashArgMatches.length > 0) {
-      if (key.upArrow) {
-        setSlashArgSelected((i) => Math.max(0, i - 1));
-        return;
-      }
-      if (key.downArrow) {
-        setSlashArgSelected((i) => Math.min(slashArgMatches.length - 1, i + 1));
-        return;
-      }
       if (key.tab) {
         const sel = slashArgMatches[slashArgSelected] ?? slashArgMatches[0];
         if (sel) pickSlashArg(sel);
@@ -1848,32 +1820,13 @@ function AppInner({
       }
     }
 
-    // Slash-suggestion mode takes priority over history recall.
-    // When the user is typing a `/` prefix and there are matches,
-    // ↑/↓ walk the suggestion list and Tab snaps the input to the
-    // highlighted command. Enter is handled in `handleSubmit` so
-    // TextInput's onSubmit still fires cleanly.
     if (slashMatches && slashMatches.length > 0) {
-      if (key.upArrow) {
-        setSlashSelected((i) => Math.max(0, i - 1));
-        return;
-      }
-      if (key.downArrow) {
-        setSlashSelected((i) => Math.min(slashMatches.length - 1, i + 1));
-        return;
-      }
       if (key.tab) {
         const sel = slashMatches[slashSelected] ?? slashMatches[0];
         if (sel) setInput(`/${sel.cmd}`);
         return;
       }
     }
-
-    // Prompt history is now Ctrl+P / Ctrl+N (PromptInput → multiline
-    // keys → historyHandoff → recallPrev / recallNext below). ↑/↓ are
-    // reserved for chat scroll — without that move, native drag-select
-    // and right-click paste don't work on most terminals because we'd
-    // have to keep xterm mouse tracking on to grab the wheel.
   });
 
   // Edit-gate interceptor. Reroutes `edit_file` / `write_file` tool

--- a/src/cli/ui/ComposerArea.tsx
+++ b/src/cli/ui/ComposerArea.tsx
@@ -3,8 +3,9 @@
  * Extracted from App.tsx per #565 Phase 2.
  */
 
-import { Box, Text } from "ink";
+import { Box, Text, useStdout } from "ink";
 import React from "react";
+import stringWidth from "string-width";
 
 import type { EditMode } from "../../config.js";
 import type { JobRegistry } from "../../tools/jobs.js";
@@ -19,7 +20,7 @@ import { ModeStatusBar } from "./layout/LiveRows.js";
 import { StatusRow } from "./layout/StatusRow.js";
 import { formatLoopStatus } from "./loop.js";
 import { useChatScrollState } from "./state/chat-scroll-provider.js";
-import { FG } from "./theme/tokens.js";
+import { FG, SURFACE } from "./theme/tokens.js";
 
 import type { StatusBarConfig } from "./layout/StatusRow.js";
 
@@ -68,10 +69,14 @@ export interface ComposerAreaProps {
 
 const HistoryHint: React.FC<{ children: React.ReactNode }> = React.memo(({ children }) => {
   const pinned = useChatScrollState((s: { pinned: boolean }) => s.pinned);
+  const { stdout } = useStdout();
   if (!pinned) {
+    const text = "scrolled up — reading history — End / PgDn to return — ↓ to advance one line";
+    const cols = stdout?.columns ?? 80;
+    const pad = Math.max(0, cols - stringWidth(text));
     return (
-      <Text color={FG.faint}>
-        scrolled up — reading history — End / PgDn to return — ↓ to advance one line
+      <Text color={FG.faint} backgroundColor={SURFACE.bgElev}>
+        {text + " ".repeat(pad)}
       </Text>
     );
   }

--- a/src/cli/ui/PromptInput.tsx
+++ b/src/cli/ui/PromptInput.tsx
@@ -194,6 +194,7 @@ export function PromptInput({
 
   const lines = value.length > 0 ? value.split("\n") : [""];
   const accentColor = disabled ? FG.faint : TONE.brand;
+  const borderColor = disabled ? FG.faint : FG.meta;
   const cursorVisible = true;
   const { line: cursorLine, col: cursorCol } = lineAndColumn(value, cursor);
 
@@ -201,7 +202,16 @@ export function PromptInput({
   const showHugeBufferHints = lines.length > 20;
 
   return (
-    <Box flexDirection="column" borderStyle="round" borderColor={accentColor} paddingX={1}>
+    <Box
+      flexDirection="column"
+      borderStyle="single"
+      borderTop
+      borderBottom
+      borderLeft={false}
+      borderRight={false}
+      borderColor={borderColor}
+      paddingX={1}
+    >
       {(() => {
         const rows: React.ReactNode[] = [];
         let firstRowEmitted = false;
@@ -338,7 +348,7 @@ export function HintRow(): React.ReactElement {
     { key: "\u23ce", tKey: "composer.hintSend" },
     { key: "\u21e7\u23ce", tKey: "composer.hintNewline" },
     { key: "^U", tKey: "composer.hintClear" },
-    { key: "^P/^N", tKey: "composer.hintHistory" },
+    { key: "\u2191\u2193", tKey: "composer.hintHistory" },
     { key: "esc", tKey: "composer.hintAbort" },
     { key: "^C", tKey: "composer.hintQuit" },
   ];

--- a/src/cli/ui/cards/UserCard.tsx
+++ b/src/cli/ui/cards/UserCard.tsx
@@ -5,7 +5,7 @@ import { t } from "../../../i18n/index.js";
 import { Card } from "../primitives/Card.js";
 import { CardHeader } from "../primitives/CardHeader.js";
 import type { UserCard as UserCardData } from "../state/cards.js";
-import { CARD, FG } from "../theme/tokens.js";
+import { CARD, FG, SURFACE } from "../theme/tokens.js";
 import { formatRelativeTime } from "./time.js";
 
 export function UserCard({ card }: { card: UserCardData }): React.ReactElement {
@@ -19,7 +19,7 @@ export function UserCard({ card }: { card: UserCardData }): React.ReactElement {
       />
       <Box flexDirection="row" gap={1}>
         <Text color={FG.sub}>↳</Text>
-        <Text>{card.text}</Text>
+        <Text backgroundColor={SURFACE.bgElev}>{` ${card.text} `}</Text>
       </Box>
     </Card>
   );

--- a/src/cli/ui/layout/CardStream.tsx
+++ b/src/cli/ui/layout/CardStream.tsx
@@ -1,11 +1,12 @@
-import { Box, type DOMElement, Text, useBoxMetrics } from "ink";
+import { Box, type DOMElement, Text, useBoxMetrics, useStdout } from "ink";
 import React, { useEffect, useMemo, useRef } from "react";
+import stringWidth from "string-width";
 import { t } from "../../../i18n/index.js";
 import { CardRenderer } from "../cards/CardRenderer.js";
 import type { Card } from "../state/cards.js";
 import { useChatScrollActions, useChatScrollState } from "../state/chat-scroll-provider.js";
 import { useAgentState } from "../state/provider.js";
-import { FG, TONE } from "../theme/tokens.js";
+import { FG, SURFACE, TONE } from "../theme/tokens.js";
 
 /** Buffer of rows kept rendered on each side of the viewport so a single scroll
  * step doesn't reveal an unmeasured card. Larger = smoother but renders more. */
@@ -182,8 +183,18 @@ function ScrollIndicator({
       ? t("cardStream.scrollAbove", { scroll: scrollRows, max: maxScroll })
       : t("cardStream.scrollAbovePlural", { scroll: scrollRows, max: maxScroll });
   const more = remaining > 0 ? t("cardStream.scrollMore", { remaining }) : "";
-  const text = `${above}${more}${t("cardStream.scrollPgUp")}`;
-  return <Text color={hot ? TONE.accent : FG.faint}>{text}</Text>;
+  // `/copy` lives next to the scroll keys so users see the existing copy-mode
+  // entry without having to dig through /help. Padded to full terminal width
+  // so the background covers the whole row, not just up to the last char.
+  const text = `${above}${more}${t("cardStream.scrollPgUp")}${t("cardStream.scrollCopy")}`;
+  const { stdout } = useStdout();
+  const cols = stdout?.columns ?? 80;
+  const pad = Math.max(0, cols - stringWidth(text));
+  return (
+    <Text color={hot ? TONE.accent : FG.faint} backgroundColor={SURFACE.bgElev}>
+      {text + " ".repeat(pad)}
+    </Text>
+  );
 }
 
 function isFullySettled(card: Card): boolean {

--- a/src/cli/ui/layout/InputAreaWithHistoryHint.tsx
+++ b/src/cli/ui/layout/InputAreaWithHistoryHint.tsx
@@ -1,9 +1,10 @@
-import { Text } from "ink";
+import { Text, useStdout } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for fragments
 import React from "react";
+import stringWidth from "string-width";
 import { t } from "../../../i18n/index.js";
 import { useChatScrollState } from "../state/chat-scroll-provider.js";
-import { FG } from "../theme/tokens.js";
+import { FG, SURFACE } from "../theme/tokens.js";
 
 /**
  * Renders either the input area (pinned) or the "reading history" hint
@@ -16,8 +17,16 @@ export function InputAreaWithHistoryHint({
   inputArea: React.ReactNode;
 }): React.ReactElement {
   const pinned = useChatScrollState((s) => s.pinned);
+  const { stdout } = useStdout();
   if (!pinned) {
-    return <Text color={FG.faint}>{t("app.historyScrollHint")}</Text>;
+    const text = t("app.historyScrollHint");
+    const cols = stdout?.columns ?? 80;
+    const pad = Math.max(0, cols - stringWidth(text));
+    return (
+      <Text color={FG.faint} backgroundColor={SURFACE.bgElev}>
+        {text + " ".repeat(pad)}
+      </Text>
+    );
   }
   return <>{inputArea}</>;
 }

--- a/src/cli/ui/layout/StatusRow.tsx
+++ b/src/cli/ui/layout/StatusRow.tsx
@@ -9,7 +9,7 @@ import { Countdown } from "../primitives/Countdown.js";
 import { useAgentState } from "../state/provider.js";
 import type { Mode, NetworkState, StatusBar } from "../state/state.js";
 import { GLYPH } from "../theme.js";
-import { FG, TONE, balanceColor, formatBalance, formatCost } from "../theme/tokens.js";
+import { FG, SURFACE, TONE, balanceColor, formatBalance, formatCost } from "../theme/tokens.js";
 
 export interface StatusBarConfig {
   showBalance: boolean;
@@ -39,6 +39,22 @@ const DEFAULT_STATUS_BAR_CONFIG: StatusBarConfig = {
   showFeedbackHint: true,
 };
 
+const BG = SURFACE.bgElev;
+
+function Pill({ children }: { children: React.ReactNode }): React.ReactElement {
+  return (
+    <Box flexDirection="row" flexShrink={0}>
+      <Text backgroundColor={BG}> </Text>
+      {children}
+      <Text backgroundColor={BG}> </Text>
+    </Box>
+  );
+}
+
+function Gap(): React.ReactElement {
+  return <Text> </Text>;
+}
+
 export function StatusRow({
   statusBar = DEFAULT_STATUS_BAR_CONFIG,
 }: { statusBar?: StatusBarConfig }): React.ReactElement {
@@ -56,70 +72,112 @@ export function StatusRow({
   return (
     <Box flexDirection="column" flexShrink={0}>
       <Box flexDirection="row" flexWrap="wrap" flexShrink={0}>
-        <Text>{"  "}</Text>
+        <Text> </Text>
         {status.recording ? (
-          <RecordingPill rec={status.recording} />
+          <Pill>
+            <RecordingPill rec={status.recording} />
+          </Pill>
         ) : status.countdownSeconds !== undefined ? (
-          <CountdownRow mode={status.mode} secondsLeft={status.countdownSeconds} />
+          <Pill>
+            <CountdownRow mode={status.mode} secondsLeft={status.countdownSeconds} />
+          </Pill>
         ) : (
-          <ModePill mode={status.mode} network={status.network} detail={status.networkDetail} />
+          <Pill>
+            <ModePill mode={status.mode} network={status.network} detail={status.networkDetail} />
+          </Pill>
         )}
         {cols >= PRESET_MIN_COLS && status.preset !== undefined && (
-          <PresetPill preset={status.preset} model={session.model} />
+          <>
+            <Gap />
+            <Pill>
+              <PresetPill preset={status.preset} model={session.model} />
+            </Pill>
+          </>
         )}
-        <Sep />
-        <Text color={FG.sub}>{`${session.id} · ${session.branch}`}</Text>
+        <Gap />
+        <Pill>
+          <Text color={FG.sub} backgroundColor={BG}>{`${session.id} · ${session.branch}`}</Text>
+        </Pill>
         {hasTurn && statusBar.showTurnCost && (
           <>
-            <Sep />
-            <Text bold color={TONE.brand}>
-              {"▸ "}
-            </Text>
-            <Text bold color={FG.body}>
-              {`${formatCost(status.cost, status.balanceCurrency)} ${t("statusBar.turn")}`}
-            </Text>
+            <Gap />
+            <Pill>
+              <Text bold color={TONE.brand} backgroundColor={BG}>
+                {"▸ "}
+              </Text>
+              <Text bold color={FG.body} backgroundColor={BG}>
+                {`${formatCost(status.cost, status.balanceCurrency)} ${t("statusBar.turn")}`}
+              </Text>
+            </Pill>
           </>
         )}
         {statusBar.showCacheHit && (
           <>
-            <Sep />
-            <Text
-              color={TONE.accent}
-            >{`${t("statusBar.cache")} ${Math.round(status.cacheHit * 100)}%`}</Text>
+            <Gap />
+            <Pill>
+              <Text color={TONE.accent} backgroundColor={BG}>
+                {`${t("statusBar.cache")} ${Math.round(status.cacheHit * 100)}%`}
+              </Text>
+            </Pill>
           </>
         )}
         {statusBar.showCtxUsage && status.promptTokens !== undefined && status.promptTokens > 0 && (
-          <CtxUsagePill
-            tokens={status.promptTokens}
-            cap={
-              status.promptCap ?? DEEPSEEK_CONTEXT_TOKENS[session.model] ?? DEFAULT_CONTEXT_TOKENS
-            }
-            cols={cols}
-          />
+          <>
+            <Gap />
+            <Pill>
+              <CtxUsagePill
+                tokens={status.promptTokens}
+                cap={
+                  status.promptCap ??
+                  DEEPSEEK_CONTEXT_TOKENS[session.model] ??
+                  DEFAULT_CONTEXT_TOKENS
+                }
+                cols={cols}
+              />
+            </Pill>
+          </>
         )}
         {status.mcpLoading && status.mcpLoading.ready < status.mcpLoading.total && (
-          <McpLoadingPill ready={status.mcpLoading.ready} total={status.mcpLoading.total} />
+          <>
+            <Gap />
+            <Pill>
+              <McpLoadingPill ready={status.mcpLoading.ready} total={status.mcpLoading.total} />
+            </Pill>
+          </>
         )}
         {showWallet && (
-          <WalletPill
-            sessionCostUsd={status.sessionCost}
-            balance={status.balance}
-            currency={status.balanceCurrency}
-            showSessionCost={statusBar.showSessionCost}
-            showBalance={statusBar.showBalance}
-          />
+          <>
+            <Gap />
+            <Pill>
+              <WalletPill
+                sessionCostUsd={status.sessionCost}
+                balance={status.balance}
+                currency={status.balanceCurrency}
+                showSessionCost={statusBar.showSessionCost}
+                showBalance={statusBar.showBalance}
+              />
+            </Pill>
+          </>
         )}
         {statusBar.showVersion && cols >= VERSION_MIN_COLS && (
           <>
-            <Sep />
-            <Text color={FG.faint}>{`v${VERSION}`}</Text>
+            <Gap />
+            <Pill>
+              <Text color={FG.faint} backgroundColor={BG}>{`v${VERSION}`}</Text>
+            </Pill>
           </>
         )}
         {statusBar.showFeedbackHint && cols >= FEEDBACK_HINT_MIN_COLS && (
           <>
-            <Sep />
-            <Text color={FG.meta}>{"⚑ "}</Text>
-            <Text color={FG.sub}>{"/feedback"}</Text>
+            <Gap />
+            <Pill>
+              <Text color={FG.meta} backgroundColor={BG}>
+                {"⚑ "}
+              </Text>
+              <Text color={FG.sub} backgroundColor={BG}>
+                {"/feedback"}
+              </Text>
+            </Pill>
           </>
         )}
       </Box>
@@ -138,11 +196,10 @@ function PresetPill({
   const color = preset === "pro" ? TONE.accent : preset === "flash" ? TONE.brand : FG.sub;
   return (
     <>
-      <Sep />
-      <Text color={FG.meta} wrap="truncate">
+      <Text color={FG.meta} backgroundColor={BG} wrap="truncate">
         {"▴ "}
       </Text>
-      <Text color={color} wrap="truncate">
+      <Text color={color} backgroundColor={BG} wrap="truncate">
         {label}
       </Text>
     </>
@@ -172,22 +229,25 @@ function CtxUsagePill({
   const filled = Math.round(CTX_BAR_CELLS * ratio);
   return (
     <>
-      <Sep />
-      <Text color={FG.meta} wrap="truncate">{`${t("statusBar.ctx")} `}</Text>
+      <Text color={FG.meta} backgroundColor={BG} wrap="truncate">{`${t("statusBar.ctx")} `}</Text>
       {showBar && (
         <>
-          <Text color={color} wrap="truncate">
+          <Text color={color} backgroundColor={BG} wrap="truncate">
             {GLYPH.block.repeat(filled)}
           </Text>
-          <Text color={FG.faint} wrap="truncate">
+          <Text color={FG.faint} backgroundColor={BG} wrap="truncate">
             {GLYPH.shade1.repeat(CTX_BAR_CELLS - filled)}
           </Text>
-          <Text wrap="truncate"> </Text>
+          <Text backgroundColor={BG} wrap="truncate">
+            {" "}
+          </Text>
         </>
       )}
-      <Text color={color} wrap="truncate">{`${pct}%`}</Text>
+      <Text color={color} backgroundColor={BG} wrap="truncate">{`${pct}%`}</Text>
       {showTokens && (
-        <Text color={FG.faint}>{` · ${formatTokens(tokens)}/${formatTokens(cap)}`}</Text>
+        <Text color={FG.faint} backgroundColor={BG}>
+          {` · ${formatTokens(tokens)}/${formatTokens(cap)}`}
+        </Text>
       )}
     </>
   );
@@ -202,11 +262,13 @@ function McpLoadingPill({
 }): React.ReactElement {
   return (
     <>
-      <Sep />
-      <Text color={TONE.brand} wrap="truncate">
+      <Text color={TONE.brand} backgroundColor={BG} wrap="truncate">
         {"⌁ "}
       </Text>
-      <Text color={FG.body}>{`${t("statusBar.mcpLoading")} ${ready}/${total}`}</Text>
+      <Text
+        color={FG.body}
+        backgroundColor={BG}
+      >{`${t("statusBar.mcpLoading")} ${ready}/${total}`}</Text>
     </>
   );
 }
@@ -228,27 +290,26 @@ function WalletPill({
   const showBalanceLine = showBalanceCfg && typeof balance === "number";
   return (
     <>
-      <Sep />
-      <Text color={FG.meta} wrap="truncate">
+      <Text color={FG.meta} backgroundColor={BG} wrap="truncate">
         {"⛁ "}
       </Text>
       {showSpent && (
-        <Text
-          color={FG.body}
-        >{`${formatCost(sessionCostUsd, currency, 2)} ${t("statusBar.spent")}`}</Text>
+        <Text color={FG.body} backgroundColor={BG}>
+          {`${formatCost(sessionCostUsd, currency, 2)} ${t("statusBar.spent")}`}
+        </Text>
       )}
       {showSpent && showBalanceLine && (
-        <Text color={FG.meta} wrap="truncate">
+        <Text color={FG.meta} backgroundColor={BG} wrap="truncate">
           {"  /  "}
         </Text>
       )}
       {showBalanceLine && (
-        <Text bold color={balanceColor(balance, currency)} wrap="truncate">
+        <Text bold color={balanceColor(balance, currency)} backgroundColor={BG} wrap="truncate">
           {formatBalance(balance, currency, { fractionDigits: 2 })}
         </Text>
       )}
       {showBalanceLine && (
-        <Text color={FG.faint} wrap="truncate">
+        <Text color={FG.faint} backgroundColor={BG} wrap="truncate">
           {t("statusBar.left")}
         </Text>
       )}
@@ -269,46 +330,50 @@ function ModePill({
   if (network === "online") {
     const pill = modeGlyph(mode);
     return (
-      <Box flexDirection="row" height={1} flexWrap="nowrap">
-        <Text color={pill.color} wrap="truncate">
+      <>
+        <Text color={pill.color} backgroundColor={BG} wrap="truncate">
           {pill.glyph}
         </Text>
-        <Text color={FG.sub} wrap="truncate">{` ${modeLabel}`}</Text>
-      </Box>
+        <Text color={FG.sub} backgroundColor={BG} wrap="truncate">{` ${modeLabel}`}</Text>
+      </>
     );
   }
   const dot = networkDot(network);
   if (network === "slow") {
     const tail = detail ? ` · ${detail}` : "";
     return (
-      <Box flexDirection="row" height={1} flexWrap="nowrap">
-        <Text color={dot.color} wrap="truncate">
+      <>
+        <Text color={dot.color} backgroundColor={BG} wrap="truncate">
           {dot.glyph}
         </Text>
-        <Text color={dot.color}>{` ${modeLabel} · ${t("statusBar.slow")}${tail}`}</Text>
-      </Box>
+        <Text color={dot.color} backgroundColor={BG}>
+          {` ${modeLabel} · ${t("statusBar.slow")}${tail}`}
+        </Text>
+      </>
     );
   }
   if (network === "disconnected") {
     const tail = detail ? ` · ${detail}` : "";
     return (
-      <Box flexDirection="row" height={1} flexWrap="nowrap">
-        <Text color={dot.color} wrap="truncate">
+      <>
+        <Text color={dot.color} backgroundColor={BG} wrap="truncate">
           {dot.glyph}
         </Text>
-        <Text color={dot.color} wrap="truncate">{` ${t("statusBar.disconnect")}${tail}`}</Text>
-      </Box>
+        <Text color={dot.color} backgroundColor={BG} wrap="truncate">
+          {` ${t("statusBar.disconnect")}${tail}`}
+        </Text>
+      </>
     );
   }
   return (
-    <Box flexDirection="row" height={1} flexWrap="nowrap">
-      <Text color={dot.color} wrap="truncate">
+    <>
+      <Text color={dot.color} backgroundColor={BG} wrap="truncate">
         {dot.glyph}
       </Text>
-      <Text color={dot.color} wrap="truncate">
+      <Text color={dot.color} backgroundColor={BG} wrap="truncate">
         {` ${t("statusBar.reconnecting")}`}
       </Text>
-    </Box>
+    </>
   );
 }
 
@@ -322,43 +387,35 @@ function CountdownRow({
   const pill = modeGlyph(mode);
   const endsAt = Date.now() + secondsLeft * 1000;
   return (
-    <Box flexDirection="row" height={1} flexWrap="nowrap">
-      <Text color={pill.color} wrap="truncate">
+    <>
+      <Text color={pill.color} backgroundColor={BG} wrap="truncate">
         {pill.glyph}
       </Text>
-      <Text color={FG.sub} wrap="truncate">
-        {` ${t("statusBar.editsLabel")}${mode}   ·   `}
+      <Text color={FG.sub} backgroundColor={BG} wrap="truncate">
+        {` ${t("statusBar.editsLabel")}${mode} · `}
       </Text>
-      <Text color={TONE.warn} wrap="truncate">
+      <Text color={TONE.warn} backgroundColor={BG} wrap="truncate">
         {t("statusBar.approvingIn")}
       </Text>
-      <Countdown endsAt={endsAt} />
-      <Text color={TONE.warn} wrap="truncate">
+      <Countdown endsAt={endsAt} backgroundColor={BG} />
+      <Text color={TONE.warn} backgroundColor={BG} wrap="truncate">
         {t("statusBar.escToInterrupt")}
       </Text>
-    </Box>
+    </>
   );
 }
 
 function RecordingPill({ rec }: { rec: NonNullable<StatusBar["recording"]> }): React.ReactElement {
   const sizeMb = (rec.sizeBytes / (1024 * 1024)).toFixed(1);
   return (
-    <Box flexDirection="row" height={1} flexWrap="nowrap">
-      <Text bold color={TONE.err} wrap="truncate">
+    <>
+      <Text bold color={TONE.err} backgroundColor={BG} wrap="truncate">
         {t("statusBar.recordingGlyph")}
       </Text>
-      <Text
-        color={TONE.err}
-      >{` ${sizeMb}${t("statusBar.mb")} · ${rec.events}${t("statusBar.evt")}`}</Text>
-    </Box>
-  );
-}
-
-function Sep(): React.ReactElement {
-  return (
-    <Text color={FG.meta} wrap="truncate">
-      {"   ·   "}
-    </Text>
+      <Text color={TONE.err} backgroundColor={BG}>
+        {` ${sizeMb}${t("statusBar.mb")} · ${rec.events}${t("statusBar.evt")}`}
+      </Text>
+    </>
   );
 }
 

--- a/src/cli/ui/multiline-keys.ts
+++ b/src/cli/ui/multiline-keys.ts
@@ -1,4 +1,4 @@
-/** Pure keystroke→action reducer; ↑/↓ NOOP (chat-scroll), Ctrl+P/N do per-line cursor + history. */
+/** Pure keystroke→action reducer; ↑/↓ and Ctrl+P/N do per-line cursor + history. */
 
 export interface MultilineKey {
   input: string;
@@ -66,8 +66,8 @@ export function processMultilineKey(
   }
 
   // PageUp/PageDown jump to start/end of the WHOLE buffer — useful
-  // after pasting a 500-line blob. Per-line motion lives on Ctrl+P /
-  // Ctrl+N now (↑/↓ are owned by chat scroll at the App level).
+  // after pasting a 500-line blob. Per-line motion lives on ↑/↓ (and
+  // their Ctrl+P / Ctrl+N readline aliases).
   if (key.pageUp) {
     return cursor === 0 ? NOOP : { next: null, cursor: 0, submit: false };
   }
@@ -75,18 +75,17 @@ export function processMultilineKey(
     return cursor === value.length ? NOOP : { next: null, cursor: value.length, submit: false };
   }
 
-  // ↑/↓ belong to chat-scroll at the App level. Ctrl+P / Ctrl+N take
-  // over what ↑/↓ used to do here:
+  // ↑/↓ (and Ctrl+P / Ctrl+N readline aliases):
   //   • multi-line buffer → cursor up/down within the buffer
-  //   • single-line / empty → hand off to prompt history (readline parity)
-  if (key.ctrl && key.input === "p") {
+  //   • single-line / empty / already at top-or-bottom line → hand off to prompt history
+  if (key.upArrow || (key.ctrl && key.input === "p")) {
     if (value.includes("\n")) {
       const moved = moveCursorUp(value, cursor);
       if (moved !== cursor) return { next: null, cursor: moved, submit: false };
     }
     return { ...NOOP, historyHandoff: "prev" };
   }
-  if (key.ctrl && key.input === "n") {
+  if (key.downArrow || (key.ctrl && key.input === "n")) {
     if (value.includes("\n")) {
       const moved = moveCursorDown(value, cursor);
       if (moved !== cursor) return { next: null, cursor: moved, submit: false };
@@ -99,9 +98,6 @@ export function processMultilineKey(
   }
   if (key.rightArrow) {
     return { next: null, cursor: Math.min(value.length, cursor + 1), submit: false };
-  }
-  if (key.upArrow || key.downArrow) {
-    return NOOP;
   }
 
   // Emacs-style line jumps. Home/End come through our own stdin reader

--- a/src/cli/ui/primitives/Countdown.tsx
+++ b/src/cli/ui/primitives/Countdown.tsx
@@ -9,13 +9,18 @@ export interface CountdownProps {
   endsAt: number;
   /** Override digit color — default brand sky. */
   color?: string;
+  backgroundColor?: string;
 }
 
-export function Countdown({ endsAt, color = TONE.brand }: CountdownProps): React.ReactElement {
+export function Countdown({
+  endsAt,
+  color = TONE.brand,
+  backgroundColor,
+}: CountdownProps): React.ReactElement {
   useSlowTick();
   const remainingSec = Math.max(0, Math.ceil((endsAt - Date.now()) / 1000));
   return (
-    <Text bold color={color}>
+    <Text bold color={color} backgroundColor={backgroundColor}>
       {String(remainingSec)}
     </Text>
   );

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -109,8 +109,9 @@ export const EN: TranslationSchema = {
             { key: "wheel", text: "scrolls chat history (works on web/cloud/SSH terminals too)" },
             {
               key: "↑ / ↓",
-              text: "scroll chat · use Ctrl+P / Ctrl+N for prompt history + multi-line cursor",
+              text: "prompt history (or per-line cursor in a multi-line draft) — Ctrl+P / Ctrl+N alias",
             },
+            { key: "PgUp / PgDn", text: "scroll chat history (mouse wheel routes here too)" },
           ],
         },
       ],
@@ -124,11 +125,11 @@ export const EN: TranslationSchema = {
           rows: [
             { key: "Enter", text: "submit the prompt" },
             { key: "Shift+Enter", text: "insert a newline in the prompt" },
-            { key: "↑ / ↓", text: "scroll chat history (mouse wheel routes here too)" },
             {
-              key: "Ctrl+P / Ctrl+N",
+              key: "↑ / ↓",
               text: "previous / next prompt history · cursor up / down in a multi-line draft",
             },
+            { key: "Ctrl+P / Ctrl+N", text: "readline alias for ↑ / ↓" },
             { key: "Ctrl+A / Ctrl+E", text: "jump to start / end of the current line" },
             { key: "Ctrl+W", text: "delete the word before the cursor" },
             { key: "Ctrl+U", text: "clear the entire prompt buffer" },
@@ -177,7 +178,7 @@ export const EN: TranslationSchema = {
         },
       ],
       footer:
-        "Wheel→↑/↓ via DECSET 1007 (alternate-scroll) — wheel scrolls chat on most terminals (web/cloud/SSH included) without disturbing native selection. Drag to select stays modifier-free. Pass --no-mouse to opt out.",
+        "Wheel scrolls chat on most terminals (web/cloud/SSH included) — SGR mouse tracking is on by default and stays out of the way of native drag-select and right-click. Pass --no-mouse to opt out.",
     },
     tipShownOnce: "shown once",
     modelOverride: "override the default model",
@@ -1594,8 +1595,8 @@ export const EN: TranslationSchema = {
     scrollAbove: " \u2191 {scroll} / {max} row above",
     scrollAbovePlural: " \u2191 {scroll} / {max} rows above",
     scrollMore: " \u2014 {remaining} more",
-    scrollPgUp: " \u00b7 PgUp / wheel / \u2191",
-    scrollCopy: " \u00b7 /copy to select",
+    scrollPgUp: " \u00b7 PgUp / wheel",
+    scrollCopy: " \u00b7 /copy enters copy mode",
   },
   slashArgPicker: {
     noMatch: 'no match for "{partial}"',

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -1595,6 +1595,7 @@ export const EN: TranslationSchema = {
     scrollAbovePlural: " \u2191 {scroll} / {max} rows above",
     scrollMore: " \u2014 {remaining} more",
     scrollPgUp: " \u00b7 PgUp / wheel / \u2191",
+    scrollCopy: " \u00b7 /copy to select",
   },
   slashArgPicker: {
     noMatch: 'no match for "{partial}"',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -746,6 +746,7 @@ export interface TranslationSchema {
     scrollAbovePlural: string;
     scrollMore: string;
     scrollPgUp: string;
+    scrollCopy: string;
   };
   slashArgPicker: {
     noMatch: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -105,8 +105,9 @@ export const zhCN: TranslationSchema = {
             { key: "滚轮", text: "滚动聊天记录（Web / 云端 / SSH 终端也能用）" },
             {
               key: "↑ / ↓",
-              text: "滚动聊天 · 输入框历史 + 多行光标用 Ctrl+P / Ctrl+N",
+              text: "输入历史（多行草稿时按行移动光标）— Ctrl+P / Ctrl+N 同义",
             },
+            { key: "PgUp / PgDn", text: "滚动聊天记录（鼠标滚轮也走这条路径）" },
           ],
         },
       ],
@@ -120,11 +121,11 @@ export const zhCN: TranslationSchema = {
           rows: [
             { key: "Enter", text: "提交输入" },
             { key: "Shift+Enter", text: "在输入框中插入换行" },
-            { key: "↑ / ↓", text: "滚动聊天记录（鼠标滚轮也走这条路径）" },
             {
-              key: "Ctrl+P / Ctrl+N",
+              key: "↑ / ↓",
               text: "上一条 / 下一条输入历史 · 多行草稿中按行移动光标",
             },
+            { key: "Ctrl+P / Ctrl+N", text: "↑ / ↓ 的 readline 同义键" },
             { key: "Ctrl+A / Ctrl+E", text: "跳到当前行的开头 / 结尾" },
             { key: "Ctrl+W", text: "删除光标前的一个词" },
             { key: "Ctrl+U", text: "清空整个输入缓冲区" },
@@ -173,7 +174,7 @@ export const zhCN: TranslationSchema = {
         },
       ],
       footer:
-        "通过 DECSET 1007（alternate-scroll），终端把滚轮翻译成 ↑/↓ 发给应用 — 大多数终端（含 Web / 云端 / SSH）都能滚，且不影响终端原生选区。直接拖动选中文本无需 Shift。传入 --no-mouse 可关闭。",
+        "滚轮在大多数终端（含 Web / 云端 / SSH）都能滚聊天 — 默认开启 SGR 鼠标跟踪，但不会影响终端原生拖选和右键菜单。直接拖动选中文本无需 Shift。传入 --no-mouse 可关闭。",
     },
     tipShownOnce: "仅显示一次",
     modelOverride: "覆盖默认模型",
@@ -1516,8 +1517,8 @@ export const zhCN: TranslationSchema = {
     scrollAbove: " \u2191 {scroll}/{max} 行",
     scrollAbovePlural: " \u2191 {scroll}/{max} 行",
     scrollMore: " \u2014 还有 {remaining} 行",
-    scrollPgUp: " \u00b7 PgUp/\u6eda\u8f6e/\u2191",
-    scrollCopy: " \u00b7 /copy \u590d\u5236",
+    scrollPgUp: " \u00b7 PgUp/\u6eda\u8f6e",
+    scrollCopy: " \u00b7 /copy \u8fdb\u5165\u590d\u5236\u6a21\u5f0f",
   },
   slashArgPicker: {
     noMatch: '\u6ca1\u6709\u5339\u914d "{partial}"',

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -1517,6 +1517,7 @@ export const zhCN: TranslationSchema = {
     scrollAbovePlural: " \u2191 {scroll}/{max} 行",
     scrollMore: " \u2014 还有 {remaining} 行",
     scrollPgUp: " \u00b7 PgUp/\u6eda\u8f6e/\u2191",
+    scrollCopy: " \u00b7 /copy \u590d\u5236",
   },
   slashArgPicker: {
     noMatch: '\u6ca1\u6709\u5339\u914d "{partial}"',

--- a/tests/composer-hint.test.tsx
+++ b/tests/composer-hint.test.tsx
@@ -48,11 +48,10 @@ describe("composer hint bar — issue #564", () => {
       const { lastFrame, unmount } = render(<HintRow />);
       const out = lastFrame() ?? "";
       unmount();
-      // ⏎ send · ⇧⏎ newline · ^U clear · ^P/^N history · esc abort · ^C quit
       expect(out).toContain("send");
       expect(out).toContain("newline");
       expect(out).toContain("clear");
-      expect(out).toContain("^P/^N");
+      expect(out).toContain("\u2191\u2193");
       expect(out).toContain("history");
       expect(out).toContain("esc");
       expect(out).toContain("abort");

--- a/tests/multiline-keys.test.ts
+++ b/tests/multiline-keys.test.ts
@@ -148,20 +148,21 @@ describe("processMultilineKey — cursor motion", () => {
     expect(processMultilineKey("abc", 3, key({ rightArrow: true })).cursor).toBe(3);
   });
 
-  it("↑/↓ are NOOP — reserved for chat scroll at the App level", () => {
-    expect(processMultilineKey("hello", 3, key({ upArrow: true }))).toEqual({
-      next: null,
-      cursor: null,
-      submit: false,
-    });
-    expect(processMultilineKey("hello", 3, key({ downArrow: true }))).toEqual({
-      next: null,
-      cursor: null,
-      submit: false,
-    });
-    expect(processMultilineKey("", 0, key({ upArrow: true })).historyHandoff).toBeUndefined();
-    expect(processMultilineKey("", 0, key({ downArrow: true })).historyHandoff).toBeUndefined();
-    expect(processMultilineKey("hello\nworld", 9, key({ upArrow: true })).cursor).toBeNull();
+  it("↑/↓ on single-line buffer hand off to prompt history", () => {
+    expect(processMultilineKey("hello", 3, key({ upArrow: true })).historyHandoff).toBe("prev");
+    expect(processMultilineKey("hello", 3, key({ downArrow: true })).historyHandoff).toBe("next");
+    expect(processMultilineKey("", 0, key({ upArrow: true })).historyHandoff).toBe("prev");
+    expect(processMultilineKey("", 0, key({ downArrow: true })).historyHandoff).toBe("next");
+  });
+
+  it("↑/↓ in multi-line buffer move the cursor between lines", () => {
+    const v = "hello\nworld";
+    const up = processMultilineKey(v, 9, key({ upArrow: true }));
+    expect(up.cursor).toBe(3);
+    expect(up.historyHandoff).toBeUndefined();
+    const down = processMultilineKey(v, 2, key({ downArrow: true }));
+    expect(down.cursor).toBe(8);
+    expect(down.historyHandoff).toBeUndefined();
   });
 
   it("Ctrl+P / Ctrl+N on single-line / empty buffer hand off to history recall", () => {
@@ -227,17 +228,9 @@ describe("processMultilineKey — cursor motion", () => {
     expect(down.cursor).toBeNull();
   });
 
-  it("raw `\\x1b[A` / `\\x1b[B` escape sequences are NOOP (chat-scroll handled at App level)", () => {
-    expect(processMultilineKey("", 0, { input: "\x1b[A" })).toEqual({
-      next: null,
-      cursor: null,
-      submit: false,
-    });
-    expect(processMultilineKey("", 0, { input: "\x1b[B" })).toEqual({
-      next: null,
-      cursor: null,
-      submit: false,
-    });
+  it("raw `\\x1b[A` / `\\x1b[B` escape sequences fire history handoff (same as ↑/↓)", () => {
+    expect(processMultilineKey("", 0, { input: "\x1b[A" }).historyHandoff).toBe("prev");
+    expect(processMultilineKey("", 0, { input: "\x1b[B" }).historyHandoff).toBe("next");
   });
 
   it("raw `\\x1b[C` rightArrow / `\\x1b[D` leftArrow still move the cursor", () => {


### PR DESCRIPTION
Two commits, both nudging the TUI closer to Claude Code's feel so users coming from there don't need to relearn anything.

## c2f174e — `/copy` discoverability + history-hint band

The original scope of this branch:

- `ScrollIndicator` (in `CardStream.tsx`) now surfaces `· /copy to select` immediately after the existing `↑ N/M rows above · PgUp / wheel` line. Users who notice the scroll affordance also see the copy entry point — no `/help` dig needed.
- Three hint surfaces (`ScrollIndicator`, `InputAreaWithHistoryHint`, `ComposerArea.HistoryHint`) now pad to full terminal width and apply `SURFACE.bgElev` as background. The row reads as a deliberate status band instead of a stray faint sentence. `string-width` handles the CJK + arrow glyphs in the localized strings.

## 1fa0cf5 — composer keys + visuals aligned with Claude Code

Scope expanded from the original PR after the user reported that the mouse wheel and the keyboard arrows both scrolled chat at the same time (very uncomfortable) and asked to align the whole CLI with Claude Code:

- **↑/↓** now walks prompt history (single-line) / moves the per-line cursor (multi-line). `Ctrl+P / Ctrl+N` stay as readline aliases. Chat scroll is owned by `PgUp/PgDn`, mouse wheel, and `End`; arrows only scroll when the composer is hidden (chat scrolled up).
- Picker `↑/↓` branches in `App.tsx` (`@-mention`, slash-arg, slash) removed — picker navigation now flows through the same `PromptInput → historyHandoff → handleHistoryPrev/Next` path as recall, which already checks pickers first. Avoids the double-decrement that would have happened with the new wiring.
- Composer **border** drops the left/right verticals and the bright brand outline — just a muted top + bottom rule in `FG.meta`, Claude-Code style.
- **StatusRow** rewritten as packed pills: each segment wraps in a `Pill` with `SURFACE.bgElev` background + 1-space padding, separated by a 1-cell gap. The old `   ·   ` dot separators are gone.
- **UserCard** body picks up a subtle `bgElev` background so previous user turns are easy to spot while scrolling.
- HintRow shows `↑↓ history` instead of `^P/^N history`.
- `/keys`, `tipMouseClipboard`, `scrollPgUp`, `scrollCopy` strings updated in EN + zh-CN. `/copy` reads "enters copy mode" / "进入复制模式" so users don't misread it as a literal copy action.

## Test plan

- [x] `npm run verify` — 227 files / 3199 tests pass, lint + typecheck clean
- [x] `multiline-keys.test.ts` rewritten to assert the new ↑/↓ semantics
- [x] `composer-hint.test.tsx` updated to expect `↑↓` instead of `^P/^N`
- [ ] Manual: scroll the chat with the wheel, confirm composer ↑/↓ walks history without dragging the chat
- [ ] Manual: open `@` and `/` pickers, confirm ↑/↓ still navigate them
- [ ] Manual: confirm the status row reads as discrete pills against the chat background, and the user card body has a visible elevated band

## Follow-ups (not in this PR)

Three Claude Code features Reasonix still doesn't have — feature-level work, not key remaps:

1. **Esc Esc** — rewind to / edit a previous user turn (needs "fork session at turn N").
2. **Ctrl+R** — toggle verbose / transcript mode.
3. **`#` prefix** — quick memory append (`/memory` exists but no shortcut).
