### PR TITLE
docs(readme): document Claude-format skill paths + OpenSpec recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,13 @@ npx reasonix code --dir /path/to/project
 /skill new my-skill --global     # ~/.reasonix/skills for cross-project use
 ~~~
 
+**Claude-format skills also load.** `<project>/.claude/skills/<name>/SKILL.md` and `~/.claude/skills/` are read alongside Reasonix's native paths, so tooling that emits Claude-format skills works out of the box. Example — drop OpenSpec workflows in without an upstream adapter:
+
+~~~bash
+npx openspec init --tools claude    # writes .claude/skills/openspec-*/SKILL.md
+/skill openspec-propose <task>      # then invoke from Reasonix
+~~~
+
 </details>
 
 <br/>


### PR DESCRIPTION
## Summary

- README now spells out that `.claude/skills/<name>/SKILL.md` (project + global) loads alongside Reasonix's native paths — the Claude-compat layer from #1259 was undocumented.
- Concrete OpenSpec recipe: `openspec init --tools claude` writes `openspec-*` skills that Reasonix picks up automatically; invoke via `/skill openspec-propose <task>`. No upstream `--tools reasonix` adapter needed.

Closes #1184

## Test plan

- [x] Local diff reads correctly inside the existing `<details>` block on skills.
- [ ] Render the README on GitHub after merge and confirm the new block sits cleanly between `/skill new` and the closing `</details>`.
