### PR TITLE
feat(tui): ctrl+r verbose toggle + esc-esc rewind picker

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -105,6 +105,7 @@ import { CheckpointPicker } from "./CheckpointPicker.js";
 import { ChoiceConfirm, type ChoiceConfirmChoice } from "./ChoiceConfirm.js";
 import { ComposerArea } from "./ComposerArea.js";
 import { EditConfirm, type EditReviewChoice } from "./EditConfirm.js";
+import { EditPicker, type UserTurnEntry } from "./EditPicker.js";
 import { LiveActivityArea } from "./LiveActivityArea.js";
 import { McpHub } from "./McpHub.js";
 import { ModelPicker } from "./ModelPicker.js";
@@ -180,6 +181,7 @@ import {
 import { hydrateCardsFromMessages } from "./state/hydrate.js";
 import { InflightProvider } from "./state/inflight-context.js";
 import { AgentStoreProvider, useAgentState, useAgentStore } from "./state/provider.js";
+import { VerboseContext } from "./state/verbose-context.js";
 import { ThemeProvider } from "./theme/context.js";
 import { listThemeNames } from "./theme/tokens.js";
 import { FG, type ThemeName } from "./theme/tokens.js";
@@ -496,6 +498,9 @@ function AppInner({
   useEffect(() => {
     if (!isStreaming && liveExpand) setLiveExpand(false);
   }, [isStreaming, liveExpand]);
+  // ctrl-r toggles verbose mode — ReasoningCard / ToolCard skip elision while on.
+  // Survives turn boundaries; resets on session restart.
+  const [verboseMode, setVerboseMode] = useState(false);
   const languageVersion = useLanguageReload();
   // Boot splash: skip when config has banner:false, otherwise show
   // one full whale-spout cycle (~1.4s) so the brand mark lands clean.
@@ -639,6 +644,10 @@ function AppInner({
   const [pendingReviseEditor, setPendingReviseEditor] = useState<string | null>(null);
   /** True while the SessionPicker is open mid-chat (triggered by `/sessions`). */
   const [pendingSessionsPicker, setPendingSessionsPicker] = useState(false);
+  /** Open by double-Esc — lists user turns; picking forks the session at that turn. */
+  const [pendingEditPicker, setPendingEditPicker] = useState<ReadonlyArray<UserTurnEntry> | null>(
+    null,
+  );
   const [sessionsPickerList, setSessionsPickerList] = useState<ReturnType<typeof listSessions>>(
     () => listSessionsForWorkspace(currentRootDir),
   );
@@ -722,6 +731,7 @@ function AppInner({
     !!pendingPlan ||
     !!pendingReviseEditor ||
     !!pendingSessionsPicker ||
+    !!pendingEditPicker ||
     !!pendingWorkspacePicker ||
     !!pendingCheckpointPicker ||
     !!pendingMcpHub ||
@@ -747,6 +757,7 @@ function AppInner({
     !pendingPlan &&
     !pendingReviseEditor &&
     !pendingSessionsPicker &&
+    !pendingEditPicker &&
     !pendingWorkspacePicker &&
     !pendingCheckpointPicker &&
     !pendingMcpHub &&
@@ -1588,6 +1599,16 @@ function AppInner({
     if (ev.ctrl && ev.input === "d") quitProcess();
   });
 
+  // Ctrl+R = verbose toggle. ReasoningCard / ToolCard skip elision while on.
+  useKeystroke((ev) => {
+    if (!(ev.ctrl && ev.input === "r")) return;
+    setVerboseMode((v) => {
+      const next = !v;
+      log.pushInfo(next ? t("app.verboseOn") : t("app.verboseOff"));
+      return next;
+    });
+  });
+
   // Chat scroll keys. Mouse wheel + PgUp/PgDn always scroll; End jumps
   // to bottom. ↑/↓ belong to the composer (prompt history / per-line
   // cursor) whenever the composer is visible — so we only consume
@@ -1599,6 +1620,37 @@ function AppInner({
     else if (ev.end) chatScroll.jumpToBottom();
     else if (!composerPinned && ev.upArrow) chatScroll.scrollUp();
     else if (!composerPinned && ev.downArrow) chatScroll.scrollDown();
+  }, !modalOpen);
+
+  // Double-Esc — opens the rewind/edit picker when idle with an empty
+  // composer. Tracks the prior Esc timestamp; a second Esc inside 500 ms
+  // collects user turns and dispatches the picker. First Esc just records.
+  const lastEscAtRef = useRef(0);
+  useKeystroke((ev) => {
+    if (!ev.escape) return;
+    if (busy || submittingRef.current || isLoopActive()) return;
+    if (input.length > 0) return;
+    const now = Date.now();
+    const prev = lastEscAtRef.current;
+    lastEscAtRef.current = now;
+    if (prev === 0 || now - prev > 500) return;
+    const turns: UserTurnEntry[] = [];
+    const cards = agentStore.getState().cards;
+    let userTurnIndex = 0;
+    for (const c of cards) {
+      if (c.kind === "user") {
+        turns.push({
+          cardId: c.id,
+          userTurnIndex,
+          text: c.text,
+          ts: c.ts,
+        });
+        userTurnIndex++;
+      }
+    }
+    if (turns.length === 0) return;
+    setPendingEditPicker(turns);
+    lastEscAtRef.current = 0;
   }, !modalOpen);
 
   // Esc/Ctrl+C during an active model turn forward to the loop as an
@@ -4014,7 +4066,9 @@ function AppInner({
               <Box flexDirection="column" flexGrow={1}>
                 <Box flexDirection="column" flexGrow={1}>
                   <LiveExpandContext.Provider value={liveExpand}>
-                    <CardStream suppressLive={modalOpen} />
+                    <VerboseContext.Provider value={verboseMode}>
+                      <CardStream suppressLive={modalOpen} />
+                    </VerboseContext.Provider>
                   </LiveExpandContext.Provider>
                   {/*
           Welcome card on the empty state. Visible only when nothing
@@ -4224,6 +4278,27 @@ function AppInner({
                       );
                       setThemeName(active);
                       log.pushInfo(`theme saved: ${outcome.value}\n  active now: ${active}`);
+                    }}
+                  />
+                ) : pendingEditPicker ? (
+                  <EditPicker
+                    entries={pendingEditPicker}
+                    onChoose={(outcome) => {
+                      setPendingEditPicker(null);
+                      if (outcome.kind === "cancel") return;
+                      const userText = loop.rewindToUserTurn(outcome.entry.userTurnIndex);
+                      if (userText === null) {
+                        log.pushInfo(t("editPicker.empty"));
+                        return;
+                      }
+                      agentStore.dispatch({
+                        type: "session.fork",
+                        cardId: outcome.entry.cardId,
+                      });
+                      setInput(outcome.entry.text);
+                      log.pushInfo(
+                        t("editPicker.forked", { turn: outcome.entry.userTurnIndex + 1 }),
+                      );
                     }}
                   />
                 ) : pendingCopyMode ? (

--- a/src/cli/ui/EditPicker.tsx
+++ b/src/cli/ui/EditPicker.tsx
@@ -1,0 +1,120 @@
+import { Box, Text, useStdout } from "ink";
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React, { useEffect, useState } from "react";
+import stringWidth from "string-width";
+import { t } from "../../i18n/index.js";
+import { useKeystroke } from "./keystroke-context.js";
+import { FG, SURFACE, TONE } from "./theme/tokens.js";
+
+export interface UserTurnEntry {
+  /** Card id in AgentState.cards — used to splice on selection. */
+  cardId: string;
+  /** 0-based count of user turns; maps to entries[] role==="user" by ordinal. */
+  userTurnIndex: number;
+  /** Verbatim user text — pre-fills the composer on selection. */
+  text: string;
+  ts: number;
+}
+
+export type EditPickerOutcome = { kind: "pick"; entry: UserTurnEntry } | { kind: "cancel" };
+
+const PAGE_MARGIN = 6;
+const PREVIEW_CELLS = 70;
+
+export function EditPicker({
+  entries,
+  onChoose,
+}: {
+  entries: ReadonlyArray<UserTurnEntry>;
+  onChoose: (outcome: EditPickerOutcome) => void;
+}): React.ReactElement {
+  const [focus, setFocus] = useState(Math.max(0, entries.length - 1));
+  const { stdout } = useStdout();
+  const rows = stdout?.rows ?? 40;
+  const visibleCount = Math.max(3, rows - PAGE_MARGIN);
+  const maxFocus = Math.max(0, entries.length - 1);
+
+  useEffect(() => {
+    setFocus((f) => Math.max(0, Math.min(f, maxFocus)));
+  }, [maxFocus]);
+
+  useKeystroke((ev) => {
+    if (ev.escape) return onChoose({ kind: "cancel" });
+    if (ev.upArrow) return setFocus((f) => Math.max(0, f - 1));
+    if (ev.downArrow) return setFocus((f) => Math.min(maxFocus, f + 1));
+    if (ev.pageUp) return setFocus((f) => Math.max(0, f - visibleCount));
+    if (ev.pageDown) return setFocus((f) => Math.min(maxFocus, f + visibleCount));
+    if (ev.home) return setFocus(0);
+    if (ev.end) return setFocus(maxFocus);
+    if (ev.return) {
+      const entry = entries[focus];
+      if (entry) onChoose({ kind: "pick", entry });
+    }
+  });
+
+  if (entries.length === 0) {
+    return (
+      <Box flexDirection="column" paddingY={1} paddingX={2}>
+        <Text color={TONE.warn}>{t("editPicker.empty")}</Text>
+        <Text color={FG.faint}>{t("editPicker.dismiss")}</Text>
+      </Box>
+    );
+  }
+
+  const start = Math.max(
+    0,
+    Math.min(focus - Math.floor(visibleCount / 2), entries.length - visibleCount),
+  );
+  const shown = entries.slice(start, start + visibleCount);
+
+  return (
+    <Box flexDirection="column" paddingY={1} paddingX={2}>
+      <Text bold color={TONE.brand}>
+        {t("editPicker.title")}
+      </Text>
+      <Text color={FG.faint}>{t("editPicker.hint")}</Text>
+      <Box flexDirection="column" marginTop={1}>
+        {shown.map((entry, i) => {
+          const globalIdx = start + i;
+          const focused = globalIdx === focus;
+          return <Row key={entry.cardId} entry={entry} focused={focused} />;
+        })}
+      </Box>
+    </Box>
+  );
+}
+
+function Row({ entry, focused }: { entry: UserTurnEntry; focused: boolean }): React.ReactElement {
+  const marker = focused ? "▸" : " ";
+  const preview = oneLinePreview(entry.text, PREVIEW_CELLS);
+  const numLabel = `#${entry.userTurnIndex + 1}`;
+  const bg = focused ? SURFACE.bgElev : undefined;
+  const fg = focused ? FG.strong : FG.body;
+  return (
+    <Box flexDirection="row" gap={1}>
+      <Text color={focused ? TONE.brand : FG.faint} backgroundColor={bg}>
+        {marker}
+      </Text>
+      <Text color={FG.meta} backgroundColor={bg}>
+        {numLabel}
+      </Text>
+      <Text color={fg} backgroundColor={bg}>
+        {preview}
+      </Text>
+    </Box>
+  );
+}
+
+function oneLinePreview(text: string, cells: number): string {
+  const firstLine = text.split(/\n/, 1)[0] ?? "";
+  if (stringWidth(firstLine) <= cells) return firstLine;
+  let s = "";
+  let w = 0;
+  for (const ch of firstLine) {
+    const cw = stringWidth(ch);
+    if (w + cw > cells - 1) break;
+    s += ch;
+    w += cw;
+  }
+  return `${s}…`;
+}

--- a/src/cli/ui/cards/ReasoningCard.tsx
+++ b/src/cli/ui/cards/ReasoningCard.tsx
@@ -1,5 +1,4 @@
 import { Box, Text, useStdout } from "ink";
-// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React from "react";
 import { clipToCells } from "../../../frame/width.js";
 import { t } from "../../../i18n/index.js";
@@ -9,6 +8,7 @@ import { CursorBlock } from "../primitives/CursorBlock.js";
 import { PILL_MODEL, PILL_SECTION, Pill, modelBadgeFor } from "../primitives/Pill.js";
 import { Spinner } from "../primitives/Spinner.js";
 import type { ReasoningCard as ReasoningCardData } from "../state/cards.js";
+import { VerboseContext } from "../state/verbose-context.js";
 import { FG, TONE, TONE_ACTIVE } from "../theme/tokens.js";
 import { useIncrementalWrap } from "./useIncrementalWrap.js";
 
@@ -28,6 +28,7 @@ export function ReasoningCard({
   const { stdout } = useStdout();
   const cols = stdout?.columns ?? 80;
   const lineCells = Math.max(20, cols - 4);
+  const verbose = React.useContext(VerboseContext);
 
   const wrapped = useIncrementalWrap(card.text, lineCells);
   const visualLines = card.text.length === 0 ? [] : wrapped;
@@ -43,6 +44,8 @@ export function ReasoningCard({
           <EmptyHint />
         ) : card.streaming ? (
           <StreamingPreview card={card} visualLines={visualLines} lineCells={lineCells} />
+        ) : verbose ? (
+          <BodyLines card={card} lines={visualLines} lineCells={lineCells} anchor />
         ) : (
           <SettledPreview card={card} visualLines={visualLines} lineCells={lineCells} />
         ))}

--- a/src/cli/ui/cards/ToolCard.tsx
+++ b/src/cli/ui/cards/ToolCard.tsx
@@ -8,6 +8,7 @@ import { CardHeader, type MetaItem } from "../primitives/CardHeader.js";
 import { Spinner } from "../primitives/Spinner.js";
 import type { ToolCard as ToolCardData } from "../state/cards.js";
 import { useIsInflight } from "../state/inflight-context.js";
+import { VerboseContext } from "../state/verbose-context.js";
 import { FG, TONE, TONE_ACTIVE } from "../theme/tokens.js";
 
 const READ_TAIL = 2;
@@ -33,9 +34,10 @@ export function ToolCard({ card }: { card: ToolCardData }): React.ReactElement {
     [card.name, card.output],
   );
 
+  const verbose = React.useContext(VerboseContext);
   const allLines = card.output.length > 0 ? card.output.split("\n") : [];
   const tail = tailLinesFor(card.name);
-  const truncated = allLines.length > tail;
+  const truncated = !verbose && allLines.length > tail;
   const visible = truncated ? allLines.slice(-tail) : allLines;
   const hidden = truncated ? allLines.length - visible.length : 0;
   const isInflight = useIsInflight(card.id);

--- a/src/cli/ui/state/events.ts
+++ b/src/cli/ui/state/events.ts
@@ -198,6 +198,12 @@ const sessionReset = z.object({
   type: z.literal("session.reset"),
 });
 
+const sessionFork = z.object({
+  type: z.literal("session.fork"),
+  /** Drop this card and everything after it. */
+  cardId: cardId,
+});
+
 const sessionWorkspaceChange = z.object({
   type: z.literal("session.workspace.change"),
   id: z.string().min(1),
@@ -353,6 +359,7 @@ export const AgentEventSchema = z.discriminatedUnion("type", [
   liveShow,
   tipShow,
   sessionReset,
+  sessionFork,
   sessionWorkspaceChange,
   planShow,
   planStepComplete,

--- a/src/cli/ui/state/reducer.ts
+++ b/src/cli/ui/state/reducer.ts
@@ -226,6 +226,12 @@ export function reduce(state: AgentState, event: AgentEvent): AgentState {
         },
       };
 
+    case "session.fork": {
+      const idx = state.cards.findIndex((c) => c.id === event.cardId);
+      if (idx < 0) return state;
+      return { ...state, cards: state.cards.slice(0, idx), focusedCardId: null };
+    }
+
     case "session.workspace.change":
       return state.session.id === event.id && state.session.workspace === event.workspace
         ? state

--- a/src/cli/ui/state/verbose-context.ts
+++ b/src/cli/ui/state/verbose-context.ts
@@ -1,0 +1,4 @@
+import { createContext } from "react";
+
+/** Ctrl+R toggles this; ReasoningCard / ToolCard show full content (no head/tail elision) when true. */
+export const VerboseContext = createContext<boolean>(false);

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -139,6 +139,10 @@ export const EN: TranslationSchema = {
             { key: "Ctrl+C", text: "abort the running model turn (NOT copy — see clipboard)" },
             { key: "PgUp / PgDn", text: "scroll chat history a page at a time" },
             { key: "End", text: "jump chat to the most recent line" },
+            {
+              key: "Ctrl+R",
+              text: "toggle verbose mode — full reasoning + tool output, no head/tail elision",
+            },
           ],
         },
         {
@@ -583,6 +587,8 @@ export const EN: TranslationSchema = {
     notedVerbCreated: "created",
     notedVerbAppended: "appended to",
     memoryWriteFailed: "# memory write failed",
+    verboseOn: "▸ verbose mode on — full reasoning + tool output",
+    verboseOff: "▸ verbose mode off — head/tail elision restored",
     commandFailed: "! command failed",
     btwUsage: "▸ /btw <question> — ask a side question without polluting the conversation context.",
     btwHeader: "≫ btw",
@@ -1302,6 +1308,13 @@ export const EN: TranslationSchema = {
     linesAbovePlural: "  \u2191 {count} lines above  (\u2191/k or PgUp)",
     linesBelow: "  \u2193 {count} line below  (\u2193/j or Space/PgDn)",
     linesBelowPlural: "  \u2193 {count} lines below  (\u2193/j or Space/PgDn)",
+  },
+  editPicker: {
+    title: "edit a previous message",
+    hint: "↑↓ pick · Enter to load into composer · Esc to cancel",
+    empty: "no user turns yet — nothing to edit",
+    dismiss: "Esc to dismiss",
+    forked: "▸ forked at turn #{turn} — buffer holds the original text",
   },
   sessionPicker: {
     header: " \u25c8 REASONIX \u00b7 pick a session ",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -182,6 +182,8 @@ export interface TranslationSchema {
     notedVerbCreated: string;
     notedVerbAppended: string;
     memoryWriteFailed: string;
+    verboseOn: string;
+    verboseOff: string;
     commandFailed: string;
     btwUsage: string;
     btwHeader: string;
@@ -488,6 +490,13 @@ export interface TranslationSchema {
     linesAbovePlural: string;
     linesBelow: string;
     linesBelowPlural: string;
+  };
+  editPicker: {
+    title: string;
+    hint: string;
+    empty: string;
+    dismiss: string;
+    forked: string;
   };
   sessionPicker: {
     header: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -135,6 +135,7 @@ export const zhCN: TranslationSchema = {
             { key: "Ctrl+C", text: "中止当前模型回合（不是复制 — 见剪贴板段）" },
             { key: "PgUp / PgDn", text: "整页滚动聊天记录" },
             { key: "End", text: "跳到聊天的最新一行" },
+            { key: "Ctrl+R", text: "切换详细模式 — 显示完整推理 + 工具输出，不省略" },
           ],
         },
         {
@@ -568,6 +569,8 @@ export const zhCN: TranslationSchema = {
     notedVerbCreated: "创建",
     notedVerbAppended: "追加到",
     memoryWriteFailed: "# 记忆写入失败",
+    verboseOn: "▸ 详细模式已开 — 显示完整推理 + 工具输出",
+    verboseOff: "▸ 详细模式已关 — 恢复头尾省略",
     commandFailed: "! 命令失败",
     btwUsage: "▸ /btw <问题> — 顺便问个题外话，不会写入当前会话上下文。",
     btwHeader: "≫ btw",
@@ -1232,6 +1235,13 @@ export const zhCN: TranslationSchema = {
     linesAbovePlural: "  ↑ 上方 {count} 行（↑/k 或 PgUp）",
     linesBelow: "  ↓ 下方 {count} 行（↓/j 或 Space/PgDn）",
     linesBelowPlural: "  ↓ 下方 {count} 行（↓/j 或 Space/PgDn）",
+  },
+  editPicker: {
+    title: "编辑之前的消息",
+    hint: "↑↓ 选择 · Enter 加载到输入框 · Esc 取消",
+    empty: "还没有用户发言 — 没什么可以编辑的",
+    dismiss: "Esc 关闭",
+    forked: "▸ 从第 #{turn} 轮分叉 — 原文已填回输入框",
   },
   sessionPicker: {
     header: " ◈ REASONIX · 选择会话 ",

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -536,6 +536,34 @@ export class CacheFirstLoop {
     return userText;
   }
 
+  /** Rewind to the N-th user turn (0-indexed). Drops that turn + everything after. */
+  rewindToUserTurn(userTurnIndex: number): string | null {
+    const entries = this.log.entries;
+    let count = 0;
+    let targetIdx = -1;
+    for (let i = 0; i < entries.length; i++) {
+      if (entries[i]!.role !== "user") continue;
+      if (count === userTurnIndex) {
+        targetIdx = i;
+        break;
+      }
+      count++;
+    }
+    if (targetIdx < 0) return null;
+    const raw = entries[targetIdx]!.content;
+    const userText = typeof raw === "string" ? raw : "";
+    const preserved = entries.slice(0, targetIdx).map((m) => ({ ...m }));
+    this.log.compactInPlace(preserved);
+    if (this.sessionName) {
+      try {
+        rewriteSession(this.sessionName, preserved);
+      } catch {
+        /* disk-full / perms — in-memory compaction still applies */
+      }
+    }
+    return userText;
+  }
+
   async *step(userInput: string): AsyncGenerator<LoopEvent> {
     // Reset per-turn flags.
     this._steerConsumed = false;

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -1102,6 +1102,58 @@ describe("CacheFirstLoop - setBudget / clearLog / retryLastUser / proArm", () =>
     expect(loop.log.entries[1]!.content).toBe("an answer");
   });
 
+  it("rewindToUserTurn(0) drops everything from the first user turn", () => {
+    const client = makeClient([{ content: "ok" }]);
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s" }),
+      stream: false,
+    });
+    loop.log.append({ role: "user", content: "turn one" });
+    loop.log.append({ role: "assistant", content: "reply one" });
+    loop.log.append({ role: "user", content: "turn two" });
+    loop.log.append({ role: "assistant", content: "reply two" });
+
+    const result = loop.rewindToUserTurn(0);
+    expect(result).toBe("turn one");
+    expect(loop.log.length).toBe(0);
+  });
+
+  it("rewindToUserTurn(1) keeps turn 0 and drops turn 1+ onwards", () => {
+    const client = makeClient([{ content: "ok" }]);
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s" }),
+      stream: false,
+    });
+    loop.log.append({ role: "user", content: "turn one" });
+    loop.log.append({ role: "assistant", content: "reply one" });
+    loop.log.append({ role: "user", content: "turn two" });
+    loop.log.append({ role: "assistant", content: "reply two" });
+    loop.log.append({ role: "user", content: "turn three" });
+    loop.log.append({ role: "assistant", content: "reply three" });
+
+    const result = loop.rewindToUserTurn(1);
+    expect(result).toBe("turn two");
+    expect(loop.log.length).toBe(2);
+    expect(loop.log.entries[0]!.content).toBe("turn one");
+    expect(loop.log.entries[1]!.content).toBe("reply one");
+  });
+
+  it("rewindToUserTurn(N) returns null when N exceeds available user turns", () => {
+    const client = makeClient([{ content: "ok" }]);
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s" }),
+      stream: false,
+    });
+    loop.log.append({ role: "user", content: "only one" });
+    loop.log.append({ role: "assistant", content: "reply" });
+
+    expect(loop.rewindToUserTurn(5)).toBeNull();
+    expect(loop.log.length).toBe(2);
+  });
+
   it("armProForNextTurn sets proArmed and step consumes it producing warning", async () => {
     const client = makeClient([{ content: "ok" }]);
     const loop = new CacheFirstLoop({


### PR DESCRIPTION
Closes the last two Claude-Code-parity gaps after #1263 — both are feature-level, not just key remaps. (The `#` memory prefix is already wired up via `hash-memory.ts`, so this PR doesn't touch it.)

## Ctrl+R — verbose mode

- `VerboseContext` provided at App.tsx, toggled by a global `Ctrl+R` keystroke (idempotent — no modal gating needed).
- `ReasoningCard` skips head/tail elision while verbose, rendering the full body through the existing `BodyLines` slice. The streaming case is unchanged (only the trailing N lines render while a thought is in flight).
- `ToolCard` drops the per-tool tail cap while verbose; full stdout flows through instead of `READ_TAIL` / `OTHER_TAIL`.
- The bottom info row toasts the new state on every toggle (`▸ verbose mode on — …` / `▸ verbose mode off — …`).
- Survives turn boundaries; resets on session restart. (Persisting across runs is intentionally out of scope — easy follow-up if anyone wants it sticky.)

## Esc Esc — rewind to a previous user turn

- New `loop.rewindToUserTurn(userTurnIndex)` mirrors `retryLastUser` but takes a 0-based user-turn ordinal so the picker can target any earlier turn, not just the last. Reuses `rewriteSession` for disk persistence; in-memory log compacts even if the disk write fails (matches the existing retry behaviour).
- New `session.fork` reducer event splices `state.cards` at a given `cardId`; everything from that card onward is dropped.
- New `EditPicker` overlay lists user cards with previews — ↑↓ to focus, Enter to pick, Esc to cancel. Same layout grammar as `SessionPicker` but trimmed (no search, no rename).
- App.tsx tracks the previous Esc timestamp in a ref. A second Esc inside 500 ms, with an empty composer + no other modal + no active turn, collects user turns and opens the picker. First-Esc just records the timestamp; existing single-Esc semantics (abort turn / dismiss picker / exit walk) are untouched because the gate excludes those states.
- On selection, the loop rewinds, the cards splice via `session.fork`, the composer pre-fills with the original text, and the info row reports the fork turn number.

## i18n + keys reference

- EN + zh-CN strings for `editPicker.{title,hint,empty,dismiss,forked}` and `app.{verboseOn,verboseOff}`.
- `/keys` reference picks up `Ctrl+R — toggle verbose mode` in both locales.

## Test plan

- [x] `npm run verify` — 227 files / 3202 tests pass (3 new for `rewindToUserTurn`).
- [x] Existing `retryLastUser` tests still pass — `rewindToUserTurn` is a sibling, not a replacement.
- [ ] Manual: press `Ctrl+R` mid-conversation, confirm reasoning + long tool outputs expand inline; toggle off, confirm they collapse back.
- [ ] Manual: with at least three user turns on screen, press `Esc Esc`, pick the second turn, confirm cards from that turn onward disappear and the composer pre-fills.
- [ ] Manual: confirm single-Esc still aborts mid-turn (no false-positive double-Esc trigger during streaming).
