### PR TITLE
docs(qq): tighten setup guide and readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ Then connect QQ from inside the session:
 /qq connect
 ~~~
 
+On first use, Reasonix asks for the QQ `App ID` and `App Secret` inside the current TUI. Later `/qq connect` calls reuse the saved credentials directly.
+
 Available commands:
 
 - `/qq connect`
@@ -120,7 +122,10 @@ Available commands:
 
 Once enabled, later `chat` / `code` sessions auto-start the QQ channel. Slash commands, confirmation prompts, and follow-up assistant replies can continue through QQ without terminal-side input.
 
-See [QQ channel setup](./docs/qq-connect.md) for setup details and QQ Open Platform bot registration.
+Desktop users can configure the same channel from `Settings -> General -> QQ Channel`.
+
+See [QQ channel setup](./docs/qq-connect.md) for the CLI flow, desktop entry, and QQ Open Platform setup.
+
 ### Desktop client (prerelease)
 
 A native Tauri client for users who want a GUI over the same loop. Multi-tab, the right-panel shows files the agent has read or edited this session, the same cost / cache / token meters live at the bottom. Same DeepSeek API key, same `~/.reasonix` config — the desktop bundles its own Node runtime, no separate `npm install` step.
@@ -234,7 +239,7 @@ For live cache-hit rates, costs, and methodology, see [`benchmarks/`](./benchmar
 
 - [**Architecture**](./docs/ARCHITECTURE.md) — three pillars: cache-first loop, tool-call repair, cost control
 - [**CLI Reference**](./docs/CLI-REFERENCE.md) — every shell subcommand, every slash command, every keybinding
-- [**QQ channel setup**](./docs/qq-connect.md) — what it is, commands, setup flow, and QQ Open Platform credentials
+- [**QQ channel setup**](./docs/qq-connect.md) — CLI first-connect flow, desktop entry, and QQ Open Platform credentials
 - [**Benchmarks**](./benchmarks/) — τ-bench-lite harness, transcripts, cost methodology
 - [**Website**](https://esengine.github.io/DeepSeek-Reasonix/) — getting started, dashboard mockup, TUI mockup
 - [**Contributing**](./CONTRIBUTING.md) — comment policy, error-handling rules, library-over-hand-rolled

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -96,6 +96,8 @@ reasonix chat
 /qq connect
 ~~~
 
+第一次使用时，Reasonix 会直接在当前 TUI 里引导输入 QQ 的 `App ID` 和 `App Secret`；之后再次执行 `/qq connect` 会直接复用已保存凭据。
+
 可用命令：
 
 - `/qq connect`
@@ -104,7 +106,10 @@ reasonix chat
 
 启用后，后续的 `chat` / `code` 会话会自动启动 QQ 通道。斜杠命令、确认提示，以及后续助手回复都可以通过 QQ 继续完成，不需要回到终端交互。
 
+桌面端也可以在 `Settings -> General -> QQ Channel` 里配置同一条通道。
+
 详细说明见 [QQ 连接指南](./docs/qq-connect.zh-CN.md)。
+
 <details>
 <summary><strong>切换工作区 · chat vs. code · 写第一个 Skill</strong></summary>
 
@@ -197,7 +202,7 @@ npx reasonix code --dir /path/to/project
 
 - [**架构**](./docs/ARCHITECTURE.md) —— 四大支柱、缓存优先循环、思维提取、脚手架
 - [**CLI 参考**](./docs/CLI-REFERENCE.md) —— 每个 shell 子命令、每个 slash 命令、每个快捷键
-- [**QQ 连接指南**](./docs/qq-connect.zh-CN.md) —— 通道定位、命令、配置流程和 QQ 开放平台凭据
+- [**QQ 连接指南**](./docs/qq-connect.zh-CN.md) —— CLI 首次连接流程、桌面端入口和 QQ 开放平台凭据
 - [**基准测试**](./benchmarks/) —— τ-bench-lite harness、transcript、成本方法论
 - [**官方网站**](https://esengine.github.io/DeepSeek-Reasonix/) —— 入门、Dashboard 设计稿、TUI 设计稿
 - [**贡献指南**](./CONTRIBUTING.md) —— 注释规则、错误处理、用现成库不手写

--- a/docs/qq-connect.md
+++ b/docs/qq-connect.md
@@ -1,30 +1,41 @@
 # QQ channel setup
 
-Reasonix can attach QQ as a remote communication channel for existing `chat` and `code` sessions. QQ is not a separate runtime mode.
+Reasonix can attach QQ to an existing `chat` or `code` session as a remote channel. QQ is not a third runtime mode.
 
-Once connected, QQ messages can be routed into the active session, and interactive prompts can continue remotely without terminal-side input.
+Once connected, QQ can:
 
-## What it supports
+- send normal user messages into the active session
+- receive follow-up assistant replies
+- continue confirmation, choice, checkpoint, and plan-style follow-up interactions
 
-The QQ channel can be used for:
+## Before you start
 
-- sending normal user messages into the active session
-- receiving follow-up assistant replies in QQ
-- handling slash commands from QQ
-- handling confirmation and pause flows remotely
-- continuing plan, checkpoint, and choice-style follow-up interactions through QQ
+Prepare these first:
 
-QQ acts as a remote surface for the same running `chat` or `code` session.
+- a recent Reasonix release that already includes QQ support
+- a QQ account that has completed real-name verification
+- a QQ bot `App ID` and `App Secret` from QQ Open Platform
 
-## Commands
+QQ Open Platform entry:
 
-Available commands inside a Reasonix session:
+- [QQ Open Platform](https://q.qq.com/qqbot/openclaw/login.html)
 
-- `/qq connect`
-- `/qq status`
-- `/qq disconnect`
+Important:
 
-## Quick start
+- save the `App Secret` when it is shown
+- depending on your bot, you may need `sandbox` or `prod`
+
+## Get your QQ bot credentials
+
+The exact QQ Open Platform UI may change, but the flow is usually:
+
+1. Open [QQ Open Platform](https://q.qq.com/qqbot/openclaw/login.html) and sign in.
+2. Create a QQ bot.
+3. Open the bot's developer settings.
+4. Copy the `App ID`.
+5. Reveal and save the `App Secret`.
+
+## Connect from the CLI
 
 Start a session first:
 
@@ -34,102 +45,82 @@ reasonix code
 reasonix chat
 ~~~
 
-Then connect QQ from inside the session:
+Then run:
 
 ~~~text
 /qq connect
 ~~~
 
-If credentials are already configured, Reasonix reuses them directly. If not, it prompts for the QQ Open Platform `App ID` and `App Secret`.
+First-time behavior:
 
-You can also provide credentials inline:
+1. Reasonix asks for the QQ `App ID` in the current TUI.
+2. Then it asks for the `App Secret`.
+3. Enter `/cancel` at either step to abort.
+
+The prompts and `/qq` status messages follow the current CLI language.
+
+If credentials are already saved, `/qq connect` reuses them directly.
+
+You can also pass credentials inline:
 
 ~~~text
 /qq connect <appId> <appSecret> [sandbox|prod]
 ~~~
 
-After a successful connection, later `chat` and `code` sessions auto-start the QQ channel when it is enabled.
+Other QQ commands:
 
-## Runtime model
+- `/qq status`
+- `/qq disconnect`
 
-QQ is attached to the existing session runtime:
+After the first successful connection, later `chat` and `code` sessions auto-start the QQ channel while it stays enabled.
 
-- `reasonix code` keeps filesystem, shell, and edit workflows
-- `reasonix chat` stays chat-only
-- QQ only adds a remote communication channel on top
+## Connect from the desktop app
 
-This keeps the interaction model aligned with the rest of Reasonix instead of introducing a third mode.
+If you use the desktop client:
 
-## QQ Open Platform setup
+1. Open `Settings`.
+2. Go to `General`.
+3. Find `QQ Channel` near the bottom.
+4. Click `Configure...` to enter `App ID`, `App Secret`, and `Sandbox` / `Production`.
+5. Click `Save and connect`.
 
-To use the QQ channel, you need a bot application from QQ Open Platform.
+The desktop app uses the same underlying QQ config as the CLI.
 
-The general setup flow is:
+## Typical usage
 
-1. Sign in to QQ Open Platform.
-2. Create a bot application.
-3. Open the bot's developer settings.
-4. Copy the `App ID` and `App Secret`.
-5. Use those credentials with `/qq connect`.
+1. Start `reasonix code` or `reasonix chat`.
+2. Connect QQ once.
+3. Send a message from QQ.
+4. Let the local Reasonix session keep running.
+5. Continue replies, approvals, and follow-up interactions from QQ when needed.
 
-Depending on your bot's environment, you may also need to choose `sandbox` or `prod`.
-
-Official entry point: [QQ Open Platform](https://q.qq.com/)
-
-## Registering a QQ bot
-
-The QQ Open Platform UI may change over time, but the usual process is:
-
-1. Open the QQ Open Platform developer console.
-2. Create a new bot application.
-3. Complete the required registration fields.
-4. Enable the bot capability for the application.
-5. Copy the generated `App ID` and `App Secret`.
-6. Use those credentials in Reasonix.
-
-Example:
-
-~~~text
-/qq connect 1234567890 your_app_secret_here sandbox
-~~~
-
-Or run `/qq connect` and enter the values interactively when prompted.
-
-## Typical workflow
-
-1. Start `reasonix code`.
-2. Run `/qq connect`.
-3. Send a task from QQ.
-4. Let the session continue in the terminal.
-5. Receive confirmations or follow-up replies back in QQ.
-6. Reply from QQ when approval or selection is required.
-
-## Notes
-
-- QQ does not replace `chat` or `code`; it extends them.
-- `code` mode remains the only mode with filesystem and shell access.
-- Auto-start only happens after QQ has been connected successfully and enabled.
-- If QQ is disconnected, the terminal session continues normally.
+QQ extends the current session. It does not replace `chat` or `code`.
 
 ## Troubleshooting
 
-### `/qq connect` does not connect
+### `/qq connect` fails on first setup
 
-Check that:
+Check these first:
 
-- your `App ID` is correct
-- your `App Secret` is correct
-- the bot application is enabled in QQ Open Platform
-- you selected the correct environment (`sandbox` or `prod`)
+- `App ID` is correct
+- `App Secret` is correct
+- the QQ bot is enabled in QQ Open Platform
+- you selected the right environment: `sandbox` or `prod`
 
-### QQ messages arrive, but no reply is returned
+If needed, reconnect with explicit arguments:
 
-Check that the active session is still running and that the QQ channel is still connected:
+~~~text
+/qq connect <appId> <appSecret> [sandbox|prod]
+~~~
+
+### QQ receives the message, but no reply comes back
+
+Check that the local Reasonix session is still running and the channel is still connected:
 
 ~~~text
 /qq status
 ~~~
 
-### The npm package does not show QQ commands
+### `/qq` commands do not exist in your installed package
 
-QQ support is only available in versions published after the QQ channel merge landed. If the published package is older than that merge, use the current repository `main` branch until a newer npm release is published.
+Your installed npm version is too old. Upgrade to a release that already includes QQ support, or use the current repository `main` branch.

--- a/docs/qq-connect.zh-CN.md
+++ b/docs/qq-connect.zh-CN.md
@@ -1,30 +1,41 @@
 # QQ 连接指南
 
-Reasonix 可以把 QQ 挂到现有的 `chat` 和 `code` 会话上，作为远程通信通道使用。QQ 不是一个独立的新运行模式。
+Reasonix 可以把 QQ 挂到现有的 `chat` 或 `code` 会话上，作为远程通道使用。QQ 不是第三种运行模式。
 
-连接成功后，QQ 消息可以进入当前会话；需要继续确认、选择或补充输入时，也可以直接在 QQ 里完成，不需要回到终端。
+连接成功后，QQ 可以：
 
-## 支持什么
+- 把普通消息送进当前会话
+- 接收后续助手回复
+- 继续确认、选择、checkpoint、plan 这类二次交互
 
-QQ 通道可以用于：
+## 开始前先准备
 
-- 把普通用户消息发送到当前会话
-- 在 QQ 中接收后续助手回复
-- 从 QQ 触发斜杠命令
-- 远程处理确认和暂停类交互
-- 继续处理 plan、checkpoint、choice 这类二次交互
+请先确认：
 
-换句话说，QQ 是同一个 `chat` 或 `code` 会话的远程交互面。
+- 使用的是已经包含 QQ 支持的较新 Reasonix 版本
+- QQ 账号已经完成实名认证
+- 已经从 QQ 开放平台拿到机器人 `App ID` 和 `App Secret`
 
-## 命令
+QQ 开放平台入口：
 
-在 Reasonix 会话内可用的 QQ 命令：
+- [QQ 开放平台](https://q.qq.com/qqbot/openclaw/login.html)
 
-- `/qq connect`
-- `/qq status`
-- `/qq disconnect`
+注意：
 
-## 快速开始
+- `App Secret` 显示时就要保存好
+- 你的机器人环境可能需要选择 `sandbox` 或 `prod`
+
+## 获取 QQ 机器人凭据
+
+QQ 开放平台界面可能会变化，但通常流程是：
+
+1. 打开 [QQ 开放平台](https://q.qq.com/qqbot/openclaw/login.html) 并登录。
+2. 创建 QQ 机器人。
+3. 打开机器人的开发设置。
+4. 复制 `App ID`。
+5. 查看并保存 `App Secret`。
+
+## 在 CLI 里连接
 
 先启动一个会话：
 
@@ -34,102 +45,83 @@ reasonix code
 reasonix chat
 ~~~
 
-然后在会话里连接 QQ：
+然后运行：
 
 ~~~text
 /qq connect
 ~~~
 
-如果本地已经保存了凭据，Reasonix 会直接复用；如果没有，则会提示输入 QQ 开放平台的 `App ID` 和 `App Secret`。
+首次连接时会这样引导：
 
-也可以直接内联传入：
+1. 先在当前 TUI 里提示你输入 `App ID`
+2. 再提示你输入 `App Secret`
+3. 任一步输入 `/cancel` 都可以取消
+
+这些提示和 `/qq` 结果会跟随当前 CLI 语言切换。
+
+如果本地已经保存过凭据，`/qq connect` 会直接复用，不会重复询问。
+
+也可以直接一次性传参：
 
 ~~~text
 /qq connect <appId> <appSecret> [sandbox|prod]
 ~~~
 
-连接成功后，只要 QQ 保持启用，后续的 `chat` 和 `code` 会话都会自动启动 QQ 通道。
+其他相关命令：
 
-## 它和运行模式的关系
+- `/qq status`
+- `/qq disconnect`
 
-QQ 只是挂接到现有会话上的通道：
+第一次连接成功后，只要 QQ 保持启用，后续 `chat` 和 `code` 会话都会自动启动 QQ 通道。
 
-- `reasonix code` 仍然负责文件、Shell 和编辑流程
-- `reasonix chat` 仍然保持纯聊天
-- QQ 只是在其上增加一个远程通信入口
+## 在桌面端连接
 
-这样可以保持现有交互模型的一致性，而不是引入第三种模式。
+如果你使用桌面客户端：
 
-## QQ 开放平台准备
+1. 打开 `Settings`
+2. 进入 `General`
+3. 在底部找到 `QQ Channel`
+4. 点击 `Configure...`
+5. 填入 `App ID`、`App Secret`，再选择 `Sandbox` / `Production`
+6. 点击 `Save and connect`
 
-要使用 QQ 通道，需要先在 QQ 开放平台创建一个机器人应用。
-
-一般流程是：
-
-1. 登录 QQ 开放平台。
-2. 创建机器人应用。
-3. 打开该机器人的开发设置。
-4. 复制 `App ID` 和 `App Secret`。
-5. 在 Reasonix 里用 `/qq connect` 录入这些凭据。
-
-根据机器人当前环境，你可能还需要选择 `sandbox` 或 `prod`。
-
-官方入口：[QQ 开放平台](https://q.qq.com/)
-
-## 如何申请 QQ 机器人
-
-QQ 开放平台界面可能会调整，但通常流程是：
-
-1. 打开 QQ 开放平台开发者控制台。
-2. 创建一个新的机器人应用。
-3. 按要求填写注册信息。
-4. 为该应用启用机器人能力。
-5. 在开发设置里复制 `App ID` 和 `App Secret`。
-6. 回到 Reasonix 完成连接。
-
-例如：
-
-~~~text
-/qq connect 1234567890 your_app_secret_here sandbox
-~~~
-
-或者直接运行 `/qq connect`，按提示交互式输入。
+桌面端和 CLI 复用同一份 QQ 配置。
 
 ## 典型使用方式
 
-1. 启动 `reasonix code`
-2. 运行 `/qq connect`
-3. 从 QQ 发起一个任务
-4. 让会话在终端继续执行
-5. 在 QQ 中接收确认提示或后续回复
-6. 当需要确认或选择时，直接在 QQ 中回复
+1. 启动 `reasonix code` 或 `reasonix chat`
+2. 先完成一次 QQ 连接
+3. 从 QQ 发一条消息
+4. 本地 Reasonix 会话继续运行
+5. 需要时直接在 QQ 里继续回复、确认或选择
 
-## 说明
+QQ 只是扩展当前会话，不替代 `chat` 或 `code`。
 
-- QQ 不替代 `chat` 或 `code`，只是扩展它们
-- 只有 `code` 模式具备文件系统和 Shell 能力
-- 只有在 QQ 成功连接并启用之后，后续会话才会自动启动 QQ 通道
-- 如果 QQ 断开，终端会话本身仍然可以继续运行
+## 排障
 
-## 排查
+### 首次 `/qq connect` 失败
 
-### `/qq connect` 没有连接成功
-
-请检查：
+优先检查：
 
 - `App ID` 是否正确
 - `App Secret` 是否正确
-- QQ 开放平台上的机器人应用是否已启用
-- 当前选择的环境是否正确（`sandbox` 或 `prod`）
+- QQ 开放平台里的机器人是否已启用
+- 当前环境是否选对了：`sandbox` 或 `prod`
+
+必要时可以直接显式传参重连：
+
+~~~text
+/qq connect <appId> <appSecret> [sandbox|prod]
+~~~
 
 ### QQ 能收到消息，但没有后续回复
 
-先确认当前会话还在运行，并且 QQ 通道仍然在线：
+先确认本地 Reasonix 会话还在运行，而且 QQ 通道仍然在线：
 
 ~~~text
 /qq status
 ~~~
 
-### npm 发布版里看不到 QQ 命令
+### 已安装的 npm 版本里没有 `/qq` 命令
 
-QQ 支持只会出现在合并该功能之后发布的 npm 版本里。如果当前 npm 发布版早于该次合并，请先使用仓库的最新 `main` 分支，等后续 npm 版本发布。
+说明本地包版本太旧。请升级到已经包含 QQ 支持的发行版，或者直接使用仓库最新 `main` 分支。


### PR DESCRIPTION
﻿## Summary
- trim the QQ setup guide down to the actual user path: get App ID / App Secret, connect once, then use QQ as a remote channel for an existing session
- document the current first-connect CLI behavior (`/qq connect` now prompts inside the TUI, supports `/cancel`, and follows the active CLI language)
- update both READMEs to mention the desktop settings entry and point to the tighter setup guide

## Why
The earlier QQ docs still reflected the first merge era and had too much repeated platform/setup prose. They also missed the current UX details that matter most in practice:

- first-time `/qq connect` is now a two-step in-TUI onboarding flow
- `/qq` prompts/results are localized
- desktop now has a native `Settings -> General -> QQ Channel` entry

This keeps the docs aligned with the shipped experience and removes repeated explanation that does not help users get connected faster.

## Testing
- `git diff --check`
- `npm run lint`
- `npm run verify`
