### PR TITLE
fix(tui): sync system cursor after ink render so IME popups track ▌

### DIFF
--- a/src/cli/ui/ComposerArea.tsx
+++ b/src/cli/ui/ComposerArea.tsx
@@ -148,6 +148,7 @@ export const ComposerArea: React.FC<ComposerAreaProps> = React.memo(
           onHistoryNext={onHistoryNext}
           onOpenExternalEditor={onOpenExternalEditor}
           onCursorChange={onCursorChange}
+          rowsAfter={1 + (activeLoop ? 1 : 0) + (jobs ? 1 : 0)}
         />
         {activeLoop ? <LoopStatusRow loop={activeLoop} /> : null}
         {jobs ? (

--- a/src/cli/ui/PromptInput.tsx
+++ b/src/cli/ui/PromptInput.tsx
@@ -50,6 +50,8 @@ export interface PromptInputProps {
   /** Ctrl+X — parent spawns $EDITOR with the current buffer and re-injects on exit. */
   onOpenExternalEditor?: () => void;
   onCursorChange?: (cursor: number) => void;
+  /** Rows the parent renders below this box — drives IME cursor sync so fcitx5/ibus/Win-IME candidate popups land next to the visual ▌. */
+  rowsAfter?: number;
 }
 
 export function PromptInput({
@@ -62,6 +64,7 @@ export function PromptInput({
   onHistoryNext,
   onOpenExternalEditor,
   onCursorChange,
+  rowsAfter = 0,
 }: PromptInputProps) {
   // Cap at 24 — collapseLinesForDisplay hides content past ~20 logical lines.
   // Quantize spec.max to 4-row buckets so per-keystroke line-count changes
@@ -200,6 +203,36 @@ export function PromptInput({
 
   const renderItems = collapseLinesForDisplay(lines, cursorLine);
   const showHugeBufferHints = lines.length > 20;
+
+  // IME cursor sync. Ink writes a full ANSI frame each render; the
+  // terminal cursor ends up at the bottom of that frame and IMEs
+  // (fcitx5 / ibus on Linux, Microsoft Pinyin on Windows) query it for
+  // candidate-window placement. Without this, popups land at screen
+  // bottom instead of next to the visual ▌. Issue #1261.
+  const cursorLineText = lines[cursorLine] ?? "";
+  const cursorCellsInLine = stringCells(cursorLineText.slice(0, cursorCol), pastesRef.current);
+  useEffect(() => {
+    if (!stdout || disabled) return;
+    const totalRows = stdout.rows;
+    if (!totalRows || totalRows < 4) return;
+    const linesBelow = Math.max(0, lines.length - 1 - cursorLine);
+    const largeHint = showHugeBufferHints ? 1 : 0;
+    // Inside our bordered Box, below the visual cursor: remaining input
+    // lines, optional huge-hint, blank marginTop, HintRow, bottom border.
+    const rowsBelow = linesBelow + largeHint + 3 + rowsAfter;
+    const targetRow = Math.max(1, totalRows - rowsBelow);
+    // Column 1-indexed. No left border, paddingX=1, prompt prefix "› " = 2 cells.
+    const targetCol = 1 + 1 + 2 + cursorCellsInLine;
+    stdout.write(`\x1b[${targetRow};${targetCol}H`);
+  }, [
+    stdout,
+    disabled,
+    cursorLine,
+    cursorCellsInLine,
+    lines.length,
+    showHugeBufferHints,
+    rowsAfter,
+  ]);
 
   return (
     <Box


### PR DESCRIPTION
Closes #1261.

## What

Ink writes a full ANSI frame each render; the terminal's system cursor ends up at the bottom of that output. IMEs query the system cursor for candidate-window placement, so fcitx5 / ibus / Microsoft Pinyin draw their popup at screen bottom instead of next to the visual `▌`.

PromptInput now emits an absolute CUP escape (`\x1b[<row>;<col>H`) inside a render-effect, landing the system cursor on the same cell as the visual cursor block:

- **Absolute row** = `stdout.rows − (linesBelow + largeHint + 3 + rowsAfter)`. The constant `3` covers the blank `marginTop`, `HintRow`, and bottom border of the prompt box; `rowsAfter` is parent-supplied and accounts for `LoopStatusRow`, `ModeStatusBar`, and `StatusRow` rendered below the prompt box.
- **Absolute col** = `paddingX(1) + prefix(2) + cell width of the typed prefix on the cursor line`, computed via `stringCells` so CJK and paste-sentinel widths land correctly.

`ComposerArea` passes `rowsAfter = 1 + (activeLoop ? 1 : 0) + (jobs ? 1 : 0)`.

## Why an absolute CUP, not relative CUU/CUF

The closed earlier attempts (#1222 / #1225 / #1232) all used relative `CUU + CUF` without a leading `\r`. Two failure modes:

1. **CJK column drift** — `CUF` advances by codepoint count, but the typed prefix has been laid out in display cells; one full-width character means the cursor lands a column short. The issue reporter on #1261 hit this exact symptom on Linux.
2. **Platform gating** — the closed PRs gated on `process.platform === "win32"`, excluding fcitx5 / ibus / macOS IMEs from the same fix.

Going absolute removes both: `stringCells` gives a real display-cell column, and `stdout.rows`-anchored row works on every platform Ink runs on.

## Known limitation (carried over from the issue thread)

The issue reporter noted that the very first IME input after a turn ends still lands at the wrong row, because Ink flushes the frame after `useEffect` fires. This PR ships the absolute-positioning + cross-platform foundation; chasing the post-flush race in the same PR risks scope creep. If the race persists in practice, a follow-up can re-emit on `setImmediate` (or hook Ink's renderer notification) without changing this PR's math.

## Test plan

- [x] `npm run verify` — 227 files / 3202 tests pass, lint + typecheck clean.
- [ ] Manual on Linux with fcitx5: type拼音, confirm candidate popup tracks `▌`.
- [ ] Manual on Linux with ibus: same.
- [ ] Manual on Windows + Microsoft Pinyin (Windows Terminal / cmd.exe): same.
- [ ] Manual: multi-line buffer (paste 5+ lines), move cursor up to line 0 mid-buffer, confirm popup lands on the right row.
- [ ] Manual: resize the terminal while typing CJK — `stdout.rows` updates and the next keystroke realigns.
