### PR TITLE
fix(tui): gate u-undo to the 5s banner window so stale taps can't revert

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -1767,10 +1767,10 @@ function AppInner({
       log.pushInfo(message);
       return;
     }
-    // Undo banner keybind: `u` rolls back the last auto-apply. Gated
-    // on an empty prompt buffer so typing "user" into the input doesn't
-    // steal from the first keystroke. 5-second window; after that the
-    // banner self-dismisses and /undo remains the only path.
+    // Undo banner keybind: `u` rolls back the last auto-apply, only
+    // while the 5-second banner is visible. Older batches go through
+    // /undo so a stray `u` long after the fact can't quietly revert
+    // unrelated work (issue #1249).
     if (
       codeMode &&
       input.length === 0 &&
@@ -1788,10 +1788,7 @@ function AppInner({
       !pendingChoice &&
       !stagedChoiceCustom &&
       !pendingRevision &&
-      // Fire when EITHER the banner is up OR there's any non-undone
-      // history entry —the keybind is useful long after the 5-second
-      // banner expires, which users rightly want.
-      (undoBanner || hasUndoable())
+      undoBanner
     ) {
       const out = codeUndo([]);
       log.pushInfo(out);


### PR DESCRIPTION
Closes #1249.

## Problem

`u` (with an empty composer, in code mode) used to fire whenever **any** non-undone edit batch sat in history, not just while the 5-second auto-apply banner was visible. The keystroke gate was `undoBanner || hasUndoable()`. The "or" branch meant a stray `u` minutes — or hours — after the banner had self-dismissed quietly rolled back the most recent batch, even if the user had moved on to unrelated work.

Two users on the issue thread independently described accidental reverts across files they didn't want to touch. The UI copy ("press u within 5s to undo", "u to undo within 5s") was already telling users it was a banner-window action; the gate was lying.

## Fix

Drop the `|| hasUndoable()` half of the gate. `u` now only fires while `undoBanner` is set — i.e., during the visible 5-second window with its own countdown. The Space-pause keybind right next to it was already banner-only; this just makes the pair symmetric and matches the on-screen copy.

```diff
- (undoBanner || hasUndoable())
+ undoBanner
```

## What about older batches?

`/undo` (handler at `src/cli/ui/slash/handlers/edits.ts`) already exists and accepts an optional index — it's the deliberate, non-zero-friction path for reverting older work. Nothing is taken away; only the no-confirmation shortcut narrows to the banner window where the user has just-now visual confirmation that an edit landed.

## What about the i18n strings?

Already aligned. `EN.ts` / `zh-CN.ts` say "within the 5s banner" / "within 5s" everywhere `u` is mentioned (`tipEditBindings.u`, `keysReference.u`, `editModeAuto`, the AUTO mode help line). No copy changes.

## Test plan

- [x] `npm run verify` — 227 files / 3202 tests pass.
- [ ] Manual: trigger an auto-apply, see the banner, press `u` within 5s → reverts (unchanged behaviour).
- [ ] Manual: trigger an auto-apply, let the banner expire, press `u` on an empty composer → nothing reverts (was: silently rolled back the last batch).
- [ ] Manual: with stale undoable history, run `/undo` → reverts (unchanged).
