### PR TITLE
chore(desktop): point updater at R2 mirror so CLI releases can't break it

### DIFF
--- a/.github/workflows/release-mirror.yml
+++ b/.github/workflows/release-mirror.yml
@@ -41,6 +41,35 @@ jobs:
             -R "${{ github.repository }}" \
             -D assets
 
+      # Rewrite bundle URLs inside latest.json (Tauri updater manifest)
+      # so the desktop pulls bundles from R2, not GitHub. Without this the
+      # updater fetches the small JSON from R2 but still downloads the
+      # heavy installer from github.com — defeating the mirror.
+      # No-op when latest.json is absent (CLI-only releases).
+      - name: Rewrite latest.json URLs → R2
+        if: env.HAS_R2 == 'true'
+        env:
+          R2_PUBLIC_BASE: https://pub-147fb53b9c1e4bbf891a257968619ea7.r2.dev
+          TAG: ${{ steps.tag.outputs.name }}
+        run: |
+          file=assets/latest.json
+          if [ ! -f "$file" ]; then
+            echo "no latest.json in release — skipping rewrite"
+            exit 0
+          fi
+          # GitHub URLs look like:
+          #   https://github.com/<owner>/<repo>/releases/download/<TAG>/<file>
+          # Rewrite to:
+          #   <R2_PUBLIC_BASE>/<TAG>/<file>
+          jq --arg base "$R2_PUBLIC_BASE" --arg tag "$TAG" '
+            .platforms |= with_entries(
+              .value.url |= sub("https://github.com/[^/]+/[^/]+/releases/download/[^/]+/"; "\($base)/\($tag)/")
+            )
+          ' "$file" > "$file.new"
+          mv "$file.new" "$file"
+          echo "rewrote latest.json:"
+          cat "$file"
+
       - name: Configure AWS CLI for R2
         if: env.HAS_R2 == 'true'
         run: |

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -58,6 +58,7 @@
     "updater": {
       "active": true,
       "endpoints": [
+        "https://pub-147fb53b9c1e4bbf891a257968619ea7.r2.dev/latest/latest.json",
         "https://github.com/esengine/reasonix/releases/latest/download/latest.json"
       ],
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDI5RkE3RDJDQTgzMkFDNkMKUldSc3JES29MSDM2S1pwcjR2MnZZMW15eG5ydnQrRUJtdjdteFJiaHF6cnE0NzYyb09Wc2k0ZHEK"


### PR DESCRIPTION
## Why

`tauri.conf.json` was pointing the desktop updater at `github.com/esengine/reasonix/releases/latest/download/latest.json`. GitHub's `releases/latest` is a single repo-wide pointer — every CLI patch release moves it, so the desktop updater either chases a 404 (CLI release has no `latest.json` asset) or, worse, locks the desktop to whichever desktop version happened to be `latest` at the time. With CLI and desktop on independent release cadences, this would only get more painful as CLI ships more often.

The mirror infra is already there: every release publish runs `release-mirror.yml`, downloading all assets and uploading them to R2 under both `${TAG}/` (versioned) and `latest/` (moving). CLI releases don't include a `latest.json` artifact, so the moving `latest/latest.json` in R2 belongs to the desktop pipeline exclusively. Repointing the updater at R2 decouples the two release tracks.

## What

**1. `desktop/src-tauri/tauri.conf.json`** — list the R2 manifest URL first, keep the GitHub URL as a fallback so the updater still works during R2 outages or before the next mirror run lands.

```diff
       "endpoints": [
+        "https://pub-147fb53b9c1e4bbf891a257968619ea7.r2.dev/latest/latest.json",
         "https://github.com/esengine/reasonix/releases/latest/download/latest.json"
       ],
```

**2. `.github/workflows/release-mirror.yml`** — rewrite the platform `.url` fields inside `latest.json` to `<R2_BASE>/<TAG>/<file>` before uploading to R2. Without this, the updater would fetch the small JSON from R2 but still pull the heavy installer from `github.com` (the JSON's URLs are absolute GitHub release links), defeating the mirror. Implemented with a one-line `jq` that's a no-op when `latest.json` isn't in the release (e.g. CLI-only tags).

minisign signatures inside `latest.json` are content checksums of the bundles themselves, so swapping the URL field doesn't invalidate them — and `aws s3 cp` is a byte-identical copy, so the bundles served from R2 verify against the same signature.

The R2 base URL matches the one already hardcoded in `docs/src/mirrors.jsx`, so the download page and the in-app updater agree on where bundles live.

## Edge cases

| Scenario | Result |
|---|---|
| Desktop release published | R2 mirror runs, `latest.json` URLs rewritten to R2, updater hits R2 |
| CLI release published | No `latest.json` in assets, rewrite is a no-op, R2's `latest/latest.json` from the previous desktop release persists |
| R2 outage | Updater falls through to the GitHub fallback endpoint |
| R2 secrets missing | Mirror skip happens before rewrite — no broken state |

## Test plan

- [x] `npm run verify` — touches no TS, but lint passed via pre-commit hook
- [x] Local jq dry-run on a sample `latest.json` — confirmed all platform URLs rewrite to `pub-…r2.dev/<TAG>/`
- [ ] Manual: cut a desktop release after this lands; confirm the updater on an older build picks up the new version and downloads from `pub-…r2.dev` rather than `github.com`
- [ ] Manual: cut a CLI patch release right after the desktop release; confirm desktop's updater still sees the desktop version (CLI release didn't disturb `latest/latest.json`)
