### PR TITLE
feat(desktop): show download progress in the update banner

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -981,6 +981,7 @@ interface TabRuntimeProps {
   currency: "CNY" | "USD";
   pendingUpdate: Update | null;
   updateStatus: "idle" | "installing" | "error";
+  updateProgress: { downloaded: number; total: number | null } | null;
   installUpdate: () => void;
   dismissUpdate: () => void;
   registerDispatch: (tabId: string, d: TabDispatcher | null) => void;
@@ -1010,6 +1011,7 @@ function TabRuntime({
   currency,
   pendingUpdate,
   updateStatus,
+  updateProgress,
   installUpdate,
   dismissUpdate,
   registerDispatch,
@@ -1710,6 +1712,7 @@ function TabRuntime({
                       version={pendingUpdate.version}
                       currentVersion={pendingUpdate.currentVersion}
                       status={updateStatus}
+                      progress={updateProgress}
                       onInstall={installUpdate}
                       onDismiss={dismissUpdate}
                     />
@@ -2573,21 +2576,37 @@ function UpdateBanner({
   version,
   currentVersion,
   status,
+  progress,
   onInstall,
   onDismiss,
 }: {
   version: string;
   currentVersion: string;
   status: "idle" | "installing" | "error";
+  progress: { downloaded: number; total: number | null } | null;
   onInstall: () => void;
   onDismiss: () => void;
 }) {
   useLang();
+  const ratio =
+    progress && progress.total && progress.total > 0
+      ? Math.min(1, progress.downloaded / progress.total)
+      : null;
   const statusText =
-    status === "installing"
-      ? t("app.update.installing")
-      : status === "error"
-        ? t("app.update.failed")
+    status === "error"
+      ? t("app.update.failed")
+      : status === "installing"
+        ? progress
+          ? ratio !== null
+            ? t("app.update.downloading", {
+                downloaded: formatBytes(progress.downloaded),
+                total: formatBytes(progress.total ?? 0),
+                pct: Math.round(ratio * 100),
+              })
+            : t("app.update.downloadingUnknown", {
+                downloaded: formatBytes(progress.downloaded),
+              })
+          : t("app.update.installing")
         : t("app.update.clickToInstall");
   return (
     <div
@@ -2602,17 +2621,29 @@ function UpdateBanner({
           {t("app.update.available", { current: currentVersion, latest: version })}
         </div>
         <div className="s">{statusText}</div>
+        {status === "installing" && ratio !== null ? (
+          <div className="meter-mini" aria-label="download progress">
+            <span style={{ width: `${Math.round(ratio * 100)}%` }} />
+          </div>
+        ) : null}
       </div>
       <div className="prog">
         <button type="button" onClick={onInstall} disabled={status === "installing"}>
           {t("app.update.install")}
         </button>
-        <button type="button" onClick={onDismiss}>
+        <button type="button" onClick={onDismiss} disabled={status === "installing"}>
           {t("app.update.later")}
         </button>
       </div>
     </div>
   );
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(n / (1024 * 1024 * 1024)).toFixed(2)} GB`;
 }
 
 type TabMeta = { id: string; workspaceDir?: string; busy?: boolean };
@@ -2631,6 +2662,10 @@ export function App() {
 
   const [pendingUpdate, setPendingUpdate] = useState<Update | null>(null);
   const [updateStatus, setUpdateStatus] = useState<"idle" | "installing" | "error">("idle");
+  const [updateProgress, setUpdateProgress] = useState<{
+    downloaded: number;
+    total: number | null;
+  } | null>(null);
   const [currency, setCurrency] = useState<"CNY" | "USD">(() => {
     const v = localStorage.getItem("reasonix.currency");
     return v === "USD" ? "USD" : "CNY";
@@ -2730,8 +2765,19 @@ export function App() {
   const installUpdate = useCallback(async () => {
     if (!pendingUpdate) return;
     setUpdateStatus("installing");
+    setUpdateProgress(null);
     try {
-      await pendingUpdate.downloadAndInstall();
+      await pendingUpdate.downloadAndInstall((evt) => {
+        if (evt.event === "Started") {
+          setUpdateProgress({ downloaded: 0, total: evt.data.contentLength ?? null });
+        } else if (evt.event === "Progress") {
+          setUpdateProgress((p) =>
+            p ? { ...p, downloaded: p.downloaded + evt.data.chunkLength } : p,
+          );
+        } else if (evt.event === "Finished") {
+          setUpdateProgress((p) => (p ? { ...p, downloaded: p.total ?? p.downloaded } : p));
+        }
+      });
       await relaunch();
     } catch (err) {
       console.error("update failed", err);
@@ -2954,6 +3000,7 @@ export function App() {
           currency={currency}
           pendingUpdate={pendingUpdate}
           updateStatus={updateStatus}
+          updateProgress={updateProgress}
           installUpdate={installUpdate}
           dismissUpdate={() => setPendingUpdate(null)}
           registerDispatch={registerDispatch}

--- a/desktop/src/i18n/en.ts
+++ b/desktop/src/i18n/en.ts
@@ -429,6 +429,8 @@ export const en = {
     update: {
       available: "New version available · {current} → {latest}",
       installing: "Installing…",
+      downloading: "Downloading · {downloaded} / {total} ({pct}%)",
+      downloadingUnknown: "Downloading · {downloaded}",
       failed: "Installation failed",
       clickToInstall: "Click to install & restart",
       install: "Install",

--- a/desktop/src/i18n/zh-CN.ts
+++ b/desktop/src/i18n/zh-CN.ts
@@ -445,6 +445,8 @@ export const zhCN: typeof en = {
     update: {
       available: "新版本可用 · {current} → {latest}",
       installing: "正在安装…",
+      downloading: "下载中 · {downloaded} / {total}（{pct}%）",
+      downloadingUnknown: "下载中 · {downloaded}",
       failed: "安装失败",
       clickToInstall: "点击安装并重启",
       install: "安装",


### PR DESCRIPTION
## Why

The banner used to flip to "Installing…" the moment the user clicked Install and stayed there until `relaunch()` fired. On a 30+ MB install over a slow link that read as a hang — no signal that anything was happening, no way to tell whether to wait or kill the app and retry.

## What

Pass an `onEvent` callback to `pendingUpdate.downloadAndInstall(...)` so the Tauri updater's per-chunk events feed a `{ downloaded, total }` state in `App`:

- **`Started`** — capture `contentLength` if the server advertised one
- **`Progress`** — accumulate `chunkLength` into the running counter
- **`Finished`** — pin progress to `total` so we don't undershoot at the end (some servers send a chunk count one short of the announced length)

The progress state threads through `TabRuntime` props (same way `updateStatus` already did) into `UpdateBanner`, which now renders:

- `Downloading · 4.2 MB / 31.7 MB (13%)` plus the existing `.meter-mini` progress bar (already in `styles.css`, just unused until now)
- `Downloading · 4.2 MB` with no bar when the server doesn't send Content-Length — better honesty than a fake ratio

The **Later** button disables during install so the user can't accidentally dismiss a half-completed download. Failure state still shows the same "Installation failed" line as before.

## i18n

Two new keys in `desktop/src/i18n/{en,zh-CN}.ts`:

```
downloading: "Downloading · {downloaded} / {total} ({pct}%)"   "下载中 · {downloaded} / {total}（{pct}%）"
downloadingUnknown: "Downloading · {downloaded}"               "下载中 · {downloaded}"
```

`formatBytes` is a small local helper (`B / KB / MB / GB` with one decimal) since the existing format helpers in the desktop are tied to chat-side concerns.

## Test plan

- [x] `npx tsc --noEmit -p desktop` clean
- [x] `npm run typecheck` (main repo + dashboard) clean
- [x] `npm run lint` clean
- [ ] Manual on Windows: trigger the updater against R2 (now that #1275 landed), confirm the banner shows live MB / total and the bar advances
- [ ] Manual: throttle network in dev tools and confirm the bar moves smoothly rather than in big chunks
- [ ] Manual: a server without Content-Length (`curl -I` shows missing header) should drop the ratio + bar, just showing the byte counter
