### PR TITLE
style(desktop): replace pill-tag status labels with compact icons

### DIFF
--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -3316,21 +3316,47 @@ html:not([data-platform="macos"]) .cmdk-row .kb .shortcut kbd[data-key="mod"] {
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
-.pill-tag.run {
-  background: var(--accent-soft);
-  color: var(--accent);
-}
 .pill-tag.ok {
   background: var(--success-soft);
   color: var(--success);
 }
-.pill-tag.warn {
-  background: var(--warning-soft);
-  color: var(--warning);
-}
 .pill-tag.err {
   background: var(--danger-soft);
   color: var(--danger);
+}
+
+/* status icons for card meta — replaces most text pill labels */
+.spin-meta {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: 1.5px solid var(--accent-soft);
+  border-top-color: var(--accent);
+  animation: spin 0.9s linear infinite;
+  display: inline-block;
+}
+
+.status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  display: inline-block;
+  flex-shrink: 0;
+}
+.status-dot.warn { background: var(--warning); }
+
+.meta-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  line-height: 1;
+  color: var(--muted);
+}
+
+.meta-dur {
+  font-size: 10px;
+  color: var(--muted-2);
+  font-variant-numeric: tabular-nums;
 }
 
 /* spinner */
@@ -3532,7 +3558,7 @@ html:not([data-platform="macos"]) .cmdk-row .kb .shortcut kbd[data-key="mod"] {
 .skel-card .h .timer {
   font-variant-numeric: tabular-nums;
   color: var(--muted);
-  font-size: 14px;
+  font-size: 12px;
 }
 .skel-card .body {
   padding: 10px 12px 12px;

--- a/desktop/src/ui/cards.tsx
+++ b/desktop/src/ui/cards.tsx
@@ -70,12 +70,27 @@ export type PlanItem = {
   note?: string;
 };
 
-function derivePlanBadge(items: PlanItem[]): { cls: "run" | "ok" | "warn" | "err"; label: string } {
-  if (items.some((x) => x.status === "failed")) return { cls: "err", label: t("planBadge.failed") };
-  if (items.some((x) => x.status === "blocked")) return { cls: "warn", label: t("planBadge.blocked") };
-  if (items.some((x) => x.status === "active")) return { cls: "run", label: t("planBadge.running") };
-  if (items.length > 0 && items.every((x) => x.status === "done")) return { cls: "ok", label: t("planBadge.done") };
-  return { cls: "run", label: t("planBadge.pending") };
+function derivePlanBadge(items: PlanItem[]): { state: "running" | "done" | "failed" | "waiting" | "blocked"; label: string } {
+  if (items.some((x) => x.status === "failed")) return { state: "failed", label: t("planBadge.failed") };
+  if (items.some((x) => x.status === "blocked")) return { state: "blocked", label: t("planBadge.blocked") };
+  if (items.some((x) => x.status === "active")) return { state: "running", label: t("planBadge.running") };
+  if (items.length > 0 && items.every((x) => x.status === "done")) return { state: "done", label: t("planBadge.done") };
+  return { state: "waiting", label: t("planBadge.pending") };
+}
+
+function StatusIcon({ state, label }: { state: "running" | "done" | "failed" | "waiting" | "blocked"; label: string }) {
+  switch (state) {
+    case "running":
+      return <span className="spin-meta" role="img" aria-label={label} title={label} />;
+    case "done":
+      return <I.check size={10} style={{ color: "var(--success)" }} aria-label={label} />;
+    case "failed":
+      return <I.x size={10} style={{ color: "var(--danger)" }} aria-label={label} />;
+    case "waiting":
+      return <span className="status-dot warn" role="img" aria-label={label} title={label} />;
+    case "blocked":
+      return <I.slash size={10} style={{ color: "var(--warning)" }} aria-label={label} />;
+  }
 }
 
 export function PlanCardView({ items, title }: { items: PlanItem[]; title?: string }) {
@@ -94,7 +109,8 @@ export function PlanCardView({ items, title }: { items: PlanItem[]; title?: stri
           <span>
             {done}/{items.length}
           </span>
-          <span className={`pill-tag ${badge.cls}`}>{badge.label}</span>
+          <StatusIcon state={badge.state} label={badge.label} />
+          <span className="meta-label">{badge.label}</span>
         </>
       }
     >
@@ -151,11 +167,9 @@ export function ReasoningCard({
             </span>
           ) : null}
           {streaming ? (
-            <span className="pill-tag warn">
-              <span className="shimmer">{t("cards.streaming")}</span>
-            </span>
+            <StatusIcon state="running" label={t("cards.streaming")} />
           ) : (
-            <span className="pill-tag ok">{t("cards.reasoningComplete")}</span>
+            <StatusIcon state="done" label={t("cards.reasoningComplete")} />
           )}
         </>
       }
@@ -215,7 +229,6 @@ export function ShellCard({
 }) {
   useLang();
   const tone: Tone = state === "failed" ? "danger" : state === "done" ? "success" : "warning";
-  const durationLabel = durationMs ? ` · ${(durationMs / 1000).toFixed(2)}s` : "";
   return (
     <Card
       tone={tone}
@@ -224,15 +237,20 @@ export function ShellCard({
       name="shell"
       compact
       meta={
-        state === "await" ? (
-          <span className="pill-tag warn">{t("cards.shellAwaiting")}</span>
-        ) : state === "running" ? (
-          <span className="pill-tag run">{t("cards.shellRunning")}</span>
-        ) : state === "failed" ? (
-          <span className="pill-tag err">{t("cards.failed")}{durationLabel}</span>
-        ) : (
-          <span className="pill-tag ok">{t("cards.done")}{durationLabel}</span>
-        )
+        <>
+          {state === "await" ? (
+            <StatusIcon state="waiting" label={t("cards.shellAwaiting")} />
+          ) : state === "running" ? (
+            <StatusIcon state="running" label={t("cards.shellRunning")} />
+          ) : state === "failed" ? (
+            <StatusIcon state="failed" label={t("cards.failed")} />
+          ) : (
+            <StatusIcon state="done" label={t("cards.done")} />
+          )}
+          {(state === "done" || state === "failed") && durationMs ? (
+            <span className="meta-dur">{(durationMs / 1000).toFixed(2)}s</span>
+          ) : null}
+        </>
       }
     >
       <div className="shell">
@@ -304,7 +322,6 @@ export function ToolCard({
   useLang();
   const running = result === undefined;
   const tone: Tone = running ? "default" : ok === false ? "danger" : "success";
-  const dur = durationMs ? `${durationMs} ms` : "—";
   return (
     <Card
       tone={tone}
@@ -314,13 +331,18 @@ export function ToolCard({
       defaultOpen={false}
       compact
       meta={
-        running ? (
-          <span className="pill-tag run">{t("cards.running")}</span>
-        ) : ok === false ? (
-          <span className="pill-tag err">{t("cards.error")} · {dur}</span>
-        ) : (
-          <span className="pill-tag ok">{t("cards.done")} · {dur}</span>
-        )
+        <>
+          {running ? (
+            <StatusIcon state="running" label={t("cards.running")} />
+          ) : ok === false ? (
+            <StatusIcon state="failed" label={t("cards.error")} />
+          ) : (
+            <StatusIcon state="done" label={t("cards.done")} />
+          )}
+          {!running && durationMs !== undefined ? (
+            <span className="meta-dur">{durationMs} ms</span>
+          ) : null}
+        </>
       }
     >
       <div className="tool-call">
@@ -381,7 +403,11 @@ export function DiffCard({
         <>
           <span style={{ color: "var(--success)" }}>+{adds}</span>
           <span style={{ color: "var(--danger)" }}>−{rms}</span>
-          {applied ? <span className="pill-tag ok">{t("cards.applied")}</span> : <span className="pill-tag warn">{t("cards.diffAwaiting")}</span>}
+          {applied ? (
+            <StatusIcon state="done" label={t("cards.applied")} />
+          ) : (
+            <StatusIcon state="waiting" label={t("cards.diffAwaiting")} />
+          )}
         </>
       }
     >
@@ -520,11 +546,11 @@ export function SubagentCard({
             {done} / {children.length} {t("cards.subagentDoneProgress")}
           </span>
           {status === "done" ? (
-            <span className="pill-tag ok">{t("cards.subagentDone")}</span>
+            <StatusIcon state="done" label={t("cards.subagentDone")} />
           ) : status === "failed" ? (
-            <span className="pill-tag err">{t("cards.subagentFailed")}</span>
+            <StatusIcon state="failed" label={t("cards.subagentFailed")} />
           ) : (
-            <span className="pill-tag run">{t("cards.subagentRunning")}</span>
+            <StatusIcon state="running" label={t("cards.subagentRunning")} />
           )}
         </>
       }

--- a/desktop/src/ui/live.tsx
+++ b/desktop/src/ui/live.tsx
@@ -93,7 +93,7 @@ export function ToolRunningCard({
         <span className="kind">{kind}</span>
         <span style={{ color: "var(--fg)", fontWeight: 500 }}>{name}</span>
         <span className="grow" />
-        <span className="pill-tag run">{t("live.running")}</span>
+        <span className="spin-meta" role="img" aria-label={t("live.running")} title={t("live.running")} />
         <span className="timer">{fmtElapsed(elapsedMs)}</span>
       </div>
       {logLines && logLines.length > 0 ? (


### PR DESCRIPTION
## What

Replace pill-tag status labels ("RUNNING", "DONE", "failed") across desktop chat cards with compact colored icons (spinner / check / cross / dot). Duration text reduced to 10px muted.

## Why

The heavy background pills and bold ms labels drew more attention than the agent's actual response. Icons keep state readable without pulling focus.

## How to verify

Input following prompt:

```
Make a plan and execute it step by step, confirming results after each step:

1. Search the web for "TypeScript 5.6 new features" and summarize the findings
2. Create a new file .test/reasonix-test.md with the summary (the directory and file don't exist yet)
3. Run cat .test/reasonix-test.md to verify the file content is correct
4. If cat succeeds, spawn a sub-agent to redo step 2's search independently, then compare the results

After all steps are done, append ## Comparison and your judgment to .test/reasonix-test.md.
```

3. Verify each card (plan, reasoning, shell, tool, diff, subagent, live) shows the right icon per state
4. Toggle dark/light theme

<img width="1892" height="1532" alt="image" src="https://github.com/user-attachments/assets/4910e798-3783-4206-8e57-cdf27821a9f7" />
<img width="1892" height="1532" alt="image" src="https://github.com/user-attachments/assets/b877c594-8798-40bd-8ec9-739615db8a7e" />

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time
