### PR TITLE
chore(docs): pull version from the R2 mirror, drop the manual bump

### DIFF
--- a/docs/src/download-page.jsx
+++ b/docs/src/download-page.jsx
@@ -1,6 +1,6 @@
 // Dedicated /download page — hero + smart mirror grid + platform notes
 
-const PLATFORM_NOTES = {
+function buildPlatformNotes(version) { return {
   mac: {
     title: 'macOS · Gatekeeper',
     en_label: 'first-launch unquarantine',
@@ -33,15 +33,18 @@ const PLATFORM_NOTES = {
       en: 'AppImages need an executable bit; some distros also need libfuse2:',
     },
     steps: [
-      { cmd: `chmod +x Reasonix_${window.REASONIX_VERSION}_amd64.AppImage`, note: { zh: '赋予可执行权限', en: 'Mark it executable' } },
+      { cmd: `chmod +x Reasonix_${version}_amd64.AppImage`, note: { zh: '赋予可执行权限', en: 'Mark it executable' } },
       { cmd: 'sudo apt install libfuse2 # debian/ubuntu', note: { zh: 'AppImage 运行时依赖', en: 'AppImage runtime dependency' } },
     ],
   },
-};
+}; }
 
 function PlatformNotes({ os }) {
   const { lang } = useLang();
-  const n = PLATFORM_NOTES[os] || PLATFORM_NOTES.mac;
+  const { version: rxVersion, status: rxStatus } = useVersion();
+  const versionLabel = rxStatus === "ok" && rxVersion ? rxVersion : "<version>";
+  const notes = React.useMemo(() => buildPlatformNotes(versionLabel), [versionLabel]);
+  const n = notes[os] || notes.mac;
   return (
     <div className="platform-note">
       <div className="platform-note-head">
@@ -65,12 +68,17 @@ function PlatformNotes({ os }) {
 
 function DownloadHero() {
   const { lang } = useLang();
+  const { version: rxVersion, status: rxStatus } = useVersion();
+  const heroBadge =
+    rxStatus === "ok" && rxVersion
+      ? `Reasonix Desktop · ${rxVersion}`
+      : t({ zh: "Reasonix Desktop · 正在获取版本…", en: "Reasonix Desktop · fetching version…" }, lang);
   return (
     <section className="dl-hero">
       <div className="hero-head">
         <span>§00 · Download</span>
         <span className="rule"></span>
-        <span className="v">Reasonix Desktop · {window.REASONIX_VERSION}</span>
+        <span className="v">{heroBadge}</span>
       </div>
       <div className="dl-hero-grid">
         <div>

--- a/docs/src/footer.jsx
+++ b/docs/src/footer.jsx
@@ -2,6 +2,13 @@
 
 function Footer() {
   const { lang } = useLang();
+  const { version: rxVersion, status: rxStatus } = useVersion();
+  const rxLabel =
+    rxStatus === "ok" && rxVersion
+      ? `v${rxVersion} · stable`
+      : rxStatus === "failed"
+        ? t({ zh: "版本获取失败", en: "version unavailable" }, lang)
+        : t({ zh: "正在获取版本…", en: "fetching version…" }, lang);
   return (
     <footer className="footer">
       <div className="footer-inner">
@@ -58,7 +65,7 @@ function Footer() {
           zh: 'Independent open-source project · 与 DeepSeek 官方无关',
           en: 'Independent open-source project · not affiliated with DeepSeek',
         }, lang)}</span>
-        <span style={{marginLeft:18}}>v{window.REASONIX_VERSION} · stable</span>
+        <span style={{marginLeft:18}}>{rxLabel}</span>
       </div>
     </footer>
   );

--- a/docs/src/hero.jsx
+++ b/docs/src/hero.jsx
@@ -2,9 +2,9 @@
 
 // Based on the actual reasonix code TUI: cache-first loop, SEARCH/REPLACE edits,
 // tool calls sandboxed to launch dir.
-const TERM_SCRIPT = [
+const buildTermScript = (version) => [
   { t: 'cmd', text: 'npx reasonix code' },
-  { t: 'out', text: `⏺ reasonix ${window.REASONIX_VERSION} · model: deepseek-v4-flash · workspace: ~/app`, cls: 'term-info', delay: 280 },
+  { t: 'out', text: `⏺ reasonix ${version} · model: deepseek-v4-flash · workspace: ~/app`, cls: 'term-info', delay: 280 },
   { t: 'out', text: '⏺ cache: 94.2% hit · session: 18m23s · cost: $0.043', cls: 'term-dim', delay: 220 },
   { t: 'blank' },
   { t: 'cmd', text: 'fix the case-sensitivity bug in findByEmail' },
@@ -26,6 +26,14 @@ const TERM_SCRIPT = [
 ];
 
 function Terminal() {
+  const { version: rxVersion, status: rxStatus } = useVersion();
+  const versionLabel = rxStatus === "ok" && rxVersion ? rxVersion : "…";
+  const TERM_SCRIPT = React.useMemo(() => buildTermScript(versionLabel), [versionLabel]);
+  // Animation closure reads through this ref so a late version arrival
+  // updates the next loop without restarting mid-typewriter.
+  const scriptRef = React.useRef(TERM_SCRIPT);
+  scriptRef.current = TERM_SCRIPT;
+
   const [lines, setLines] = React.useState([]);
   const [typing, setTyping] = React.useState('');
   const stepRef = React.useRef(0);
@@ -37,8 +45,9 @@ function Terminal() {
 
     const run = () => {
       if (cancelled) return;
+      const script = scriptRef.current;
       const i = stepRef.current;
-      if (i >= TERM_SCRIPT.length) {
+      if (i >= script.length) {
         timer = setTimeout(() => {
           if (cancelled) return;
           stepRef.current = 0;
@@ -48,7 +57,7 @@ function Terminal() {
         }, 3600);
         return;
       }
-      const step = TERM_SCRIPT[i];
+      const step = script[i];
       if (step.t === 'cmd') {
         const text = step.text;
         if (charRef.current < text.length) {
@@ -121,12 +130,17 @@ function Terminal() {
 
 function Hero() {
   const { lang } = useLang();
+  const { version: rxVersion, status: rxStatus } = useVersion();
+  const rxBadge =
+    rxStatus === "ok" && rxVersion
+      ? `v${rxVersion} · open source`
+      : t({ zh: "正在获取版本…", en: "fetching version…" }, lang);
   return (
     <section className="hero" id="top">
       <div className="hero-head">
         <span>§00 · Reasonix</span>
         <span className="rule"></span>
-        <span className="v">v{window.REASONIX_VERSION} · open source</span>
+        <span className="v">{rxBadge}</span>
       </div>
       <div className="hero-grid">
         <div>

--- a/docs/src/i18n.jsx
+++ b/docs/src/i18n.jsx
@@ -1,6 +1,57 @@
 // Lang context + t() helper. `t({zh, en})` returns the active-lang string.
 
-window.REASONIX_VERSION = "0.45.1";
+// Version is pulled from the R2 mirror's `latest/latest.json` on every page
+// load. Empty until the fetch resolves so consumers can render a loading
+// state instead of a stale literal — pre-empts the "docs version is wrong"
+// drift that hardcoding caused. Each release just overwrites latest.json.
+window.REASONIX_VERSION = window.REASONIX_VERSION || "";
+window.REASONIX_VERSION_STATUS = window.REASONIX_VERSION
+  ? "ok"
+  : "loading";
+
+(function fetchVersion() {
+  var url = "https://pub-147fb53b9c1e4bbf891a257968619ea7.r2.dev/latest/latest.json";
+  var ctrl = new AbortController();
+  var timer = setTimeout(function () {
+    ctrl.abort();
+  }, 5000);
+  fetch(url, { signal: ctrl.signal, cache: "no-cache" })
+    .then(function (r) {
+      return r.ok ? r.json() : null;
+    })
+    .then(function (j) {
+      clearTimeout(timer);
+      if (j && j.version) {
+        window.REASONIX_VERSION = String(j.version).replace(/^v/, "");
+        window.REASONIX_VERSION_STATUS = "ok";
+      } else {
+        window.REASONIX_VERSION_STATUS = "failed";
+      }
+      window.dispatchEvent(new Event("reasonix:version"));
+    })
+    .catch(function () {
+      clearTimeout(timer);
+      window.REASONIX_VERSION_STATUS = "failed";
+      window.dispatchEvent(new Event("reasonix:version"));
+    });
+})();
+
+function useVersion() {
+  const [v, setV] = React.useState({
+    version: window.REASONIX_VERSION,
+    status: window.REASONIX_VERSION_STATUS,
+  });
+  React.useEffect(() => {
+    const handler = () =>
+      setV({
+        version: window.REASONIX_VERSION,
+        status: window.REASONIX_VERSION_STATUS,
+      });
+    window.addEventListener("reasonix:version", handler);
+    return () => window.removeEventListener("reasonix:version", handler);
+  }, []);
+  return v;
+}
 
 const LangCtx = React.createContext({ lang: "zh", setLang: () => {} });
 
@@ -49,4 +100,5 @@ function t(s, lang) {
 window.LangCtx = LangCtx;
 window.LangProvider = LangProvider;
 window.useLang = useLang;
+window.useVersion = useVersion;
 window.t = t;

--- a/docs/src/mirrors.jsx
+++ b/docs/src/mirrors.jsx
@@ -1,52 +1,55 @@
 // Smart mirror grid — probes R2 / GitHub Releases for fastest TTFB and offers
 // a per-platform installer link from whichever wins.
 
-const VERSION = window.REASONIX_VERSION;
 const GH_REPO = "esengine/DeepSeek-Reasonix";
 const R2_BASE = "https://pub-147fb53b9c1e4bbf891a257968619ea7.r2.dev";
 
-const MIRRORS = [
-  {
-    id: "r2",
-    name: "Cloudflare R2",
-    region: "GLOBAL · CF Edge",
-    icon: "Cloud",
-    base: `${R2_BASE}/v${VERSION}`,
-    probe: `${R2_BASE}/latest/latest.json`,
-  },
-  {
-    id: "github",
-    name: "GitHub Releases",
-    region: "GLOBAL · US",
-    icon: "Github",
-    base: `https://github.com/${GH_REPO}/releases/download/v${VERSION}`,
-    probe: `https://github.com/${GH_REPO}/releases/download/v${VERSION}/latest.json`,
-  },
-];
+function buildMirrors(version) {
+  return [
+    {
+      id: "r2",
+      name: "Cloudflare R2",
+      region: "GLOBAL · CF Edge",
+      icon: "Cloud",
+      base: `${R2_BASE}/v${version}`,
+      probe: `${R2_BASE}/latest/latest.json`,
+    },
+    {
+      id: "github",
+      name: "GitHub Releases",
+      region: "GLOBAL · US",
+      icon: "Github",
+      base: `https://github.com/${GH_REPO}/releases/download/v${version}`,
+      probe: `https://github.com/${GH_REPO}/releases/download/v${version}/latest.json`,
+    },
+  ];
+}
 
-const OS_OPTIONS = [
-  {
-    id: "mac",
-    label: "macOS",
-    file: `Reasonix_${VERSION}_universal.dmg`,
-    size: "52 MB",
-    note: "Universal — Apple Silicon + Intel",
-  },
-  {
-    id: "win",
-    label: "Windows",
-    file: `Reasonix_${VERSION}_x64-setup.exe`,
-    size: "30 MB",
-    note: "NSIS installer · x64",
-  },
-  {
-    id: "linux",
-    label: "Linux",
-    file: `Reasonix_${VERSION}_amd64.AppImage`,
-    size: "128 MB",
-    note: "AppImage · x86_64",
-  },
-];
+function buildOsOptions(version) {
+  return [
+    {
+      id: "mac",
+      label: "macOS",
+      file: `Reasonix_${version}_universal.dmg`,
+      size: "52 MB",
+      note: "Universal — Apple Silicon + Intel",
+    },
+    {
+      id: "win",
+      label: "Windows",
+      file: `Reasonix_${version}_x64-setup.exe`,
+      size: "30 MB",
+      note: "NSIS installer · x64",
+    },
+    {
+      id: "linux",
+      label: "Linux",
+      file: `Reasonix_${version}_amd64.AppImage`,
+      size: "128 MB",
+      note: "AppImage · x86_64",
+    },
+  ];
+}
 
 function MirrorIcon({ name }) {
   const Icon = Ic[name];
@@ -80,12 +83,22 @@ async function probeMirror(url) {
 
 function MirrorGrid({ os, setOs }) {
   const { lang } = useLang();
-  const [testing, setTesting] = React.useState(true);
-  const [results, setResults] = React.useState(() =>
-    MIRRORS.map(m => ({ id: m.id, lat: null, done: false, ok: false }))
+  const { version: rxVersion, status: rxStatus } = useVersion();
+  const versionReady = rxStatus === "ok" && !!rxVersion;
+  const MIRRORS = React.useMemo(
+    () => (versionReady ? buildMirrors(rxVersion) : []),
+    [versionReady, rxVersion],
+  );
+  const OS_OPTIONS = React.useMemo(
+    () => (versionReady ? buildOsOptions(rxVersion) : []),
+    [versionReady, rxVersion],
   );
 
+  const [testing, setTesting] = React.useState(true);
+  const [results, setResults] = React.useState([]);
+
   const runTest = React.useCallback(() => {
+    if (MIRRORS.length === 0) return;
     setTesting(true);
     setResults(MIRRORS.map(m => ({ id: m.id, lat: null, done: false, ok: false })));
     let remaining = MIRRORS.length;
@@ -98,18 +111,31 @@ function MirrorGrid({ os, setOs }) {
         if (remaining === 0) setTesting(false);
       });
     });
-  }, []);
+  }, [MIRRORS]);
 
   React.useEffect(() => {
+    if (!versionReady) return undefined;
     const t = setTimeout(runTest, 200);
     return () => clearTimeout(t);
-  }, [runTest]);
+  }, [runTest, versionReady]);
 
   const fastest = React.useMemo(() => {
     const done = results.filter(r => r.done && r.ok && r.lat != null);
     if (done.length === 0) return null;
     return done.reduce((a, b) => (a.lat <= b.lat ? a : b)).id;
   }, [results]);
+
+  if (!versionReady) {
+    const msg =
+      rxStatus === "failed"
+        ? t({ zh: "版本信息获取失败 · 请刷新重试", en: "Could not fetch the version · refresh to retry" }, lang)
+        : t({ zh: "正在获取最新版本…", en: "Fetching latest version…" }, lang);
+    return (
+      <div className="dl-loading" style={{ padding: 32, textAlign: "center", color: "var(--cream-mute)" }}>
+        {msg}
+      </div>
+    );
+  }
 
   const currentOs = OS_OPTIONS.find(o => o.id === os) || OS_OPTIONS[0];
   const fastestMirror = MIRRORS.find(m => m.id === fastest);

--- a/docs/src/nav.jsx
+++ b/docs/src/nav.jsx
@@ -1,6 +1,8 @@
 // Top nav — single bar shared between index and download pages
 
 function Nav({ active }) {
+  const { version: rxVersion, status: rxStatus } = useVersion();
+  const rxLabel = rxStatus === "ok" && rxVersion ? `v${rxVersion}` : "…";
   const [scrolled, setScrolled] = React.useState(false);
   const { lang, setLang } = useLang();
   React.useEffect(() => {
@@ -26,7 +28,7 @@ function Nav({ active }) {
         <a className="brand" href="index.html">
           <span className="brand-mark"></span>
           <span className="brand-name">
-            <b>Reasonix</b><span>DS · v{window.REASONIX_VERSION}</span>
+            <b>Reasonix</b><span>DS · {rxLabel}</span>
           </span>
         </a>
         <div className="nav-links" role="navigation">


### PR DESCRIPTION
## Why

The docs site hardcoded `window.REASONIX_VERSION = "0.45.1"` in `i18n.jsx`. Every release that didn't remember to bump that line left the install commands, the smart-mirror grid URLs, the footer badge, the terminal demo, and the hero badge stuck at a stale value. The bump was easy to forget because nothing in CI caught it — by the time CLI shipped 0.46.1 the docs still said 0.45.1.

R2's `latest/latest.json` is already a single source of truth that updates on every desktop release (it's the desktop updater manifest, untouched by CLI tags). Verified live: `https://pub-147fb53b9c1e4bbf891a257968619ea7.r2.dev/latest/latest.json` returns 200 with a clean `.version` field.

## What

**`i18n.jsx`:**

- Drop the hardcoded fallback; start with empty `REASONIX_VERSION` + `status: "loading"`.
- Kick off an async `fetch(latest.json)` immediately (5s `AbortController` timeout). On success set the global + `status: "ok"`; on any failure set `status: "failed"`. Dispatch a `reasonix:version` event on settle either way.
- New `useVersion()` hook subscribes to that event and returns `{ version, status }`. Exported on `window` like the other helpers.

**Consumers** (`nav`, `footer`, `hero`, `mirrors`, `download-page`) now call `useVersion()` and render a localised loading state:

- text-only badges (`nav`, `footer`, `hero`) show `正在获取版本…` / `fetching version…` while loading, the real `v0.46.1` once `status === "ok"`, and `版本获取失败` / `version unavailable` on failure.
- `mirrors` and `download-page` go further: their URLs/install commands need the actual version, so the whole mirror grid swaps for a `Fetching latest version…` line until `status === "ok"`. Otherwise we'd hand out broken download links.

The first attempt was a synchronous `<script src=".../version.js">` shim emitted by the release workflow, but `version.js` doesn't exist on R2 yet (workflow hasn't run for a desktop release with the new step), and pre-deploying it would cost a 404 on every page load until the next desktop release. Pulling from `latest.json` — which is already there — avoids that.

## Test plan

- [x] `curl https://pub-…r2.dev/latest/latest.json` → 200, `.version` = `0.45.1`
- [x] `python -m http.server` on docs/, page loads, served JS shows `useVersion` wiring
- [x] `npm run lint` clean (docs is outside biome's path but the pre-commit hook still ran)
- [ ] Manual: open docs/index.html, watch footer/nav flicker from "fetching version…" to `v0.45.1` on first paint
- [ ] Manual: open docs/download.html, confirm the mirror grid swaps from the "fetching" line to the platform-tab UI once the version resolves
- [ ] Manual: throttle network in DevTools to make the fetch slow, confirm the loading copy stays visible during the wait
- [ ] Manual: block `pub-*.r2.dev` in DevTools, confirm the "version unavailable" message renders cleanly after the 5s timeout
