### PR TITLE
fix(slash): reject // line-comment input as slash command

### DIFF
--- a/src/cli/ui/slash/commands.ts
+++ b/src/cli/ui/slash/commands.ts
@@ -453,6 +453,8 @@ export function detectSlashArgContext(input: string, codeMode = false): SlashArg
 
 export function parseSlash(text: string): { cmd: string; args: string[] } | null {
   if (!text.startsWith("/")) return null;
+  // "//" is a line comment, not a slash command
+  if (text.startsWith("//")) return null;
   const parts = text.slice(1).trim().split(/\s+/);
   const cmd = parts[0]?.toLowerCase() ?? "";
   if (!cmd) return null;

--- a/tests/slash.test.ts
+++ b/tests/slash.test.ts
@@ -39,6 +39,12 @@ describe("parseSlash", () => {
     expect(parseSlash("")).toBeNull();
     expect(parseSlash("/")).toBeNull();
   });
+  it("returns null on comment-like input starting with //", () => {
+    expect(parseSlash("// some comment")).toBeNull();
+    expect(parseSlash("//")).toBeNull();
+    expect(parseSlash("//help")).toBeNull();
+    expect(parseSlash("// /still/a/comment")).toBeNull();
+  });
   it("lowercases the command and splits args", () => {
     expect(parseSlash("/Harvest on")).toEqual({ cmd: "harvest", args: ["on"] });
     expect(parseSlash("/branch 3")).toEqual({ cmd: "branch", args: ["3"] });


### PR DESCRIPTION
## Summary

Reject `//`-prefixed input in `parseSlash()` so line-comment text is treated as ordinary user input, not as an unknown slash command.

## Problem

A user typing code or text that starts with `//` (e.g. `// TODO: refactor` or `// some comment`) triggers the slash-command parser, which extracts the second `/` as the command name, finds no matching handler, and reports:

```
未知命令：//  （试试 /help）
```

The root cause is in `parseSlash()` [commands.ts:454](src/cli/ui/slash/commands.ts:454): it only checks `text.startsWith("/")` to enter the command path. `//` satisfies this check but is not an actual slash command — it's a line comment in dozens of programming languages, and should flow through as ordinary text.

## Fix

A single guard in `parseSlash()`:

- **`src/cli/ui/slash/commands.ts`** — Added an early return `if (text.startsWith("//")) return null;` before the command-splitting logic, so `//`-prefixed input bypasses command parsing entirely.
- **`tests/slash.test.ts`** — 4 new test cases verifying `//` variants all return `null`: with trailing comment text, bare `//`, `//help` (no space), and `// /still/a/comment` (nested slash within comment).

## Verification

| Check | Result |
|---|---|
| `npm run typecheck` | ✅ passes |
| `npm run lint` | ✅ 607 files, no fixes needed |
| `tests/slash.test.ts` | ✅ 124 pass (4 new + 120 existing) |

**Note:** `acp-mcp.test.ts` and `chat-mcp-startup-summary.test.ts` timed out during the full `npm run test` run, but both pass when targeted individually: `npx vitest run tests/acp-mcp.test.ts tests/chat-mcp-startup-summary.test.ts`. The timeouts are unrelated to this change.

closed #1283