### PR TITLE
feat(lifecycle): add prefix-stable engineering lifecycle

### DIFF
--- a/src/cli/heap-limit-launch.ts
+++ b/src/cli/heap-limit-launch.ts
@@ -2,24 +2,34 @@
 
 import { spawnSync } from "node:child_process";
 import { totalmem } from "node:os";
+import { fileURLToPath } from "node:url";
 import { getHeapStatistics } from "node:v8";
 import { RX_HEAP_REEXEC_ENV, decideHeapTargetMb } from "./heap-limit.js";
+
+const runningUnderVitest =
+  process.env.VITEST === "true" || process.env.VITEST_WORKER_ID !== undefined;
 
 const target = decideHeapTargetMb({
   currentLimitMb: Math.floor(getHeapStatistics().heap_size_limit / 1024 / 1024),
   totalMemMb: Math.floor(totalmem() / 1024 / 1024),
   nodeOptions: process.env.NODE_OPTIONS ?? "",
   execArgv: process.execArgv,
-  alreadyReexec: process.env[RX_HEAP_REEXEC_ENV] === "1",
+  alreadyReexec: process.env[RX_HEAP_REEXEC_ENV] === "1" || runningUnderVitest,
 });
 
 if (target !== null) {
   const existing = process.env.NODE_OPTIONS ?? "";
   const nextOptions = `${existing} --max-old-space-size=${target}`.trim();
   const childEnv = { ...process.env, NODE_OPTIONS: nextOptions, [RX_HEAP_REEXEC_ENV]: "1" };
-  const result = spawnSync(process.execPath, process.argv.slice(1), {
-    env: childEnv,
-    stdio: "inherit",
-  });
+  const extension = import.meta.url.endsWith(".ts") ? "ts" : "js";
+  const entrypoint = fileURLToPath(new URL(`./index.${extension}`, import.meta.url));
+  const result = spawnSync(
+    process.execPath,
+    [...process.execArgv, entrypoint, ...process.argv.slice(2)],
+    {
+      env: childEnv,
+      stdio: "inherit",
+    },
+  );
   process.exit(result.status ?? 0);
 }

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -22,6 +22,7 @@ import {
   snapshotBeforeEdits,
   toWholeFileEditBlock,
 } from "../../code/edit-blocks.js";
+import { EngineeringLifecycleRuntime } from "../../code/lifecycle.js";
 import { clearPendingEdits, loadPendingEdits } from "../../code/pending-edits.js";
 import {
   clearPlanState,
@@ -31,10 +32,12 @@ import {
 } from "../../code/plan-store.js";
 import {
   type EditMode,
+  type EngineeringLifecycleMode,
   type PresetName,
   defaultConfigPath,
   editModeHintShown,
   loadBaseUrl,
+  loadEngineeringLifecycleMode,
   loadReasoningEffort,
   loadTheme,
   markEditModeHintShown,
@@ -90,7 +93,7 @@ import { defaultUsageLogPath } from "../../telemetry/usage.js";
 import type { ToolRegistry } from "../../tools.js";
 import type { ChoiceOption } from "../../tools/choice.js";
 import { looksLikeAbsoluteSystemPath, pathIsUnder } from "../../tools/filesystem.js";
-import type { PlanStep } from "../../tools/plan.js";
+import type { PlanStep, StepCompletion } from "../../tools/plan.js";
 import { formatCommandResult, runCommand } from "../../tools/shell.js";
 import { registerSkillTools } from "../../tools/skills.js";
 import { formatSubagentResult, spawnSubagent } from "../../tools/subagent.js";
@@ -363,6 +366,15 @@ function LoopStatusRow({
   );
 }
 
+function completedCountIncludingStep(
+  completedStepIds: Set<string>,
+  stepId: string,
+  total: number,
+): number {
+  const completed = completedStepIds.size + (completedStepIds.has(stepId) ? 0 : 1);
+  return total > 0 ? Math.min(completed, total) : completed;
+}
+
 function lastMessageContent(
   entries: ReadonlyArray<{ role: string; content?: string | null }>,
   role: "user" | "assistant",
@@ -585,6 +597,15 @@ function AppInner({
     model,
     initialPreset,
   );
+  const engineeringLifecycleBaseModeRef = useRef<EngineeringLifecycleMode>(
+    loadEngineeringLifecycleMode(),
+  );
+  const engineeringLifecycleRef = useRef<EngineeringLifecycleRuntime | null>(null);
+  if (engineeringLifecycleRef.current === null) {
+    engineeringLifecycleRef.current = new EngineeringLifecycleRuntime({
+      mode: engineeringLifecycleBaseModeRef.current,
+    });
+  }
   // Refs that mirror state for stable read-callbacks handed to the
   // embedded dashboard server. The server's `getXxx()` closures are
   // captured once at startDashboard time; without ref-mirrors the
@@ -848,6 +869,7 @@ function AppInner({
   // revised plan starts fresh —old completions don't spill over.
   const planStepsRef = useRef<PlanStep[] | null>(null);
   const completedStepIdsRef = useRef<Set<string>>(new Set());
+  const stepCompletionsRef = useRef<Map<string, StepCompletion>>(new Map());
   // Markdown body + human-friendly summary captured from submit_plan.
   // Persisted alongside the structured state so a future Time-Travel
   // replay can show the model's full original proposal without re-
@@ -873,9 +895,14 @@ function AppInner({
       clearPlanState(session);
       return;
     }
-    const extras: { body?: string; summary?: string } = {};
+    const extras: {
+      body?: string;
+      summary?: string;
+      stepCompletions?: Map<string, StepCompletion>;
+    } = {};
     if (planBodyRef.current) extras.body = planBodyRef.current;
     if (planSummaryRef.current) extras.summary = planSummaryRef.current;
+    if (stepCompletionsRef.current.size > 0) extras.stepCompletions = stepCompletionsRef.current;
     savePlanState(session, steps, completedStepIdsRef.current, extras);
   }, [session]);
   const [summary, setSummary] = useState<SessionSummary>({
@@ -1549,8 +1576,13 @@ function AppInner({
       if (restoredPlan && restoredPlan.steps.length > 0) {
         planStepsRef.current = restoredPlan.steps;
         completedStepIdsRef.current = new Set(restoredPlan.completedStepIds);
+        stepCompletionsRef.current = new Map(Object.entries(restoredPlan.stepCompletions ?? {}));
         planBodyRef.current = restoredPlan.body ?? null;
         planSummaryRef.current = restoredPlan.summary ?? null;
+        engineeringLifecycleRef.current?.recordPlanApproved(restoredPlan.steps);
+        for (const stepId of restoredPlan.completedStepIds) {
+          engineeringLifecycleRef.current?.recordStepCompleted(stepId);
+        }
         const when = relativeTime(restoredPlan.updatedAt);
         const done = new Set(restoredPlan.completedStepIds);
         const summary = restoredPlan.summary ? ` - ${restoredPlan.summary}` : "";
@@ -1878,6 +1910,22 @@ function AppInner({
     }
   });
 
+  useEffect(() => {
+    if (!tools || !codeMode) return;
+    return tools.addToolInterceptor("engineering-lifecycle", (name, args) => {
+      return engineeringLifecycleRef.current?.guardToolCall(name, args) ?? null;
+    });
+  }, [tools, codeMode]);
+
+  useEffect(() => {
+    if (!tools || !codeMode) return;
+    tools.setResultAugmenter((name, args, result) => {
+      engineeringLifecycleRef.current?.recordToolResult(name, args, result);
+      return result;
+    });
+    return () => tools.setResultAugmenter(null);
+  }, [tools, codeMode]);
+
   // Edit-gate interceptor. Reroutes `edit_file` / `write_file` tool
   // calls through the review queue (in `review` mode) or the auto-apply
   // snapshot/banner path (in `auto` mode) so the model's tool usage
@@ -2021,6 +2069,9 @@ function AppInner({
     (on: boolean) => {
       setPlanMode(on);
       tools?.setPlanMode(on);
+      engineeringLifecycleRef.current?.setMode(
+        on ? "strict" : engineeringLifecycleBaseModeRef.current,
+      );
     },
     [tools],
   );
@@ -2816,6 +2867,7 @@ function AppInner({
             completedStepIdsRef.current.add(stepId);
             persistPlanState();
             log.completePlanStep(stepId);
+            engineeringLifecycleRef.current?.recordStepCompleted(stepId);
             return "ok";
           },
           markAllPlanStepsDone: () => {
@@ -2826,6 +2878,7 @@ function AppInner({
               if (completedStepIdsRef.current.has(s.id)) continue;
               completedStepIdsRef.current.add(s.id);
               log.completePlanStep(s.id);
+              engineeringLifecycleRef.current?.recordStepCompleted(s.id);
               added++;
             }
             if (added > 0) persistPlanState();
@@ -2964,6 +3017,17 @@ function AppInner({
           log.pushWarning(t("app.hookUserPromptSubmit"), formatHookOutcomeMessage(o));
         }
         if (promptReport.blocked) return;
+      }
+
+      if (codeMode) {
+        const before = engineeringLifecycleRef.current?.snapshot().state;
+        engineeringLifecycleRef.current?.observeUserPrompt(text);
+        const after = engineeringLifecycleRef.current?.snapshot().state;
+        if (before === "idle" && after === "armed") {
+          log.pushInfo(
+            "Engineering lifecycle armed: high-risk mutations now require an approved structured plan.",
+          );
+        }
       }
 
       // Large pastes (stack traces, log dumps, file contents) get a
@@ -3212,9 +3276,12 @@ function AppInner({
               setPendingChoice,
               planStepsRef,
               completedStepIdsRef,
+              stepCompletionsRef,
               planBodyRef,
               planSummaryRef,
               persistPlanState,
+              onPlanStepCompleted: (stepId) =>
+                engineeringLifecycleRef.current?.recordStepCompleted(stepId),
               log,
               session: session ?? null,
               codeModeOn: !!codeMode,
@@ -3572,8 +3639,10 @@ function AppInner({
         // can dock it at the bottom —without this dispatch, no card with
         // variant: "active" exists and the live strip stays empty.
         const approvedSteps = planStepsRef.current;
+        engineeringLifecycleRef.current?.recordPlanApproved(approvedSteps ?? []);
         if (approvedSteps && approvedSteps.length > 0) {
           completedStepIdsRef.current = new Set();
+          stepCompletionsRef.current = new Map();
           log.showPlan({
             title: planSummaryRef.current ?? "plan",
             steps: approvedSteps.map((s) => ({
@@ -3593,10 +3662,12 @@ function AppInner({
         // no point keeping it around for resume.
         planStepsRef.current = null;
         completedStepIdsRef.current = new Set();
+        stepCompletionsRef.current = new Map();
         planBodyRef.current = null;
         planSummaryRef.current = null;
         persistPlanState();
         togglePlanMode(false);
+        engineeringLifecycleRef.current?.cancel();
         agentStore.dispatch({ type: "plan.drop" });
         marker = trimmed ? `plan rejected - ${tail}` : "plan cancelled";
       } else {
@@ -3741,6 +3812,8 @@ function AppInner({
           planStepsRef.current = p.steps ?? null;
           planSummaryRef.current = p.summary ?? null;
           planBodyRef.current = p.plan;
+          stepCompletionsRef.current = new Map();
+          engineeringLifecycleRef.current?.recordPlanProposed(p.steps);
           break;
         }
         case "plan_checkpoint": {
@@ -3750,9 +3823,13 @@ function AppInner({
             result: string;
             notes?: string;
           };
-          // completed/total come from planStepsRef —don't have them via gate
-          const completed = completedStepIdsRef.current.size;
+          // completed/total come from planStepsRef — don't have them via gate.
           const total = planStepsRef.current?.length ?? 0;
+          const completed = completedCountIncludingStep(
+            completedStepIdsRef.current,
+            p.stepId,
+            total,
+          );
           // Shared policy (src/core/pause-policy.ts) decides whether to
           // auto-resolve. Per-step rollback snapshot still runs so /restore
           // granularity is preserved.
@@ -3895,8 +3972,8 @@ function AppInner({
           }
         }
       }
-      const completed = completedStepIdsRef.current.size;
       const total = planStepsRef.current?.length ?? 0;
+      const completed = completedCountIncludingStep(completedStepIdsRef.current, stepId, total);
       const label = title ? `${stepId} - ${title}` : stepId;
       const counter = total > 0 ? ` (${completed}/${total})` : "";
       log.pushInfo(t("app.continuingAfter", { label, counter }));
@@ -4008,6 +4085,10 @@ function AppInner({
         merged.push(s);
       }
       planStepsRef.current = merged;
+      engineeringLifecycleRef.current?.recordPlanApproved(merged);
+      for (const s of merged) {
+        if (completed.has(s.id)) engineeringLifecycleRef.current?.recordStepCompleted(s.id);
+      }
       persistPlanState();
       // Replace the live active card so PlanLiveRow shows the new tail —      // existing card's stale ids would fail subsequent step completes.
       agentStore.dispatch({ type: "plan.drop" });

--- a/src/cli/ui/PlanCheckpointConfirm.tsx
+++ b/src/cli/ui/PlanCheckpointConfirm.tsx
@@ -48,12 +48,12 @@ function PlanCheckpointConfirmInner({
         </Box>
       ) : null}
       <SingleSelect
-        initialValue={isLast ? "stop" : "continue"}
+        initialValue="continue"
         items={[
           {
             value: "continue",
-            label: t("planFlow.checkpoint.continue"),
-            hint: t("planFlow.checkpoint.continueHint"),
+            label: t(isLast ? "planFlow.checkpoint.finish" : "planFlow.checkpoint.continue"),
+            hint: t(isLast ? "planFlow.checkpoint.finishHint" : "planFlow.checkpoint.continueHint"),
           },
           {
             value: "revise",

--- a/src/cli/ui/hooks/handle-tool-event.ts
+++ b/src/cli/ui/hooks/handle-tool-event.ts
@@ -27,9 +27,11 @@ export interface ToolEventContext {
   >;
   planStepsRef: MutableRefObject<PlanStep[] | null>;
   completedStepIdsRef: MutableRefObject<Set<string>>;
+  stepCompletionsRef?: MutableRefObject<Map<string, StepCompletion>>;
   planBodyRef: MutableRefObject<string | null>;
   planSummaryRef: MutableRefObject<string | null>;
   persistPlanState: () => void;
+  onPlanStepCompleted?: (stepId: string) => void;
   log: Scrollback;
   session: string | null;
   codeModeOn: boolean;
@@ -49,8 +51,10 @@ export function handleToolEvent(ev: LoopEvent, ctx: ToolEventContext): void {
       const stepId = parsed.stepId;
       if (parsed.kind === "step_completed" && typeof stepId === "string") {
         ctx.completedStepIdsRef.current.add(stepId);
+        ctx.stepCompletionsRef?.current.set(stepId, parsed as StepCompletion);
         ctx.persistPlanState();
         ctx.log.completePlanStep(stepId);
+        ctx.onPlanStepCompleted?.(stepId);
         const total = ctx.planStepsRef.current?.length ?? 0;
         const completed = ctx.completedStepIdsRef.current.size;
         const stepFromPlan = ctx.planStepsRef.current?.find((s) => s.id === stepId);

--- a/src/cli/ui/slash/commands.ts
+++ b/src/cli/ui/slash/commands.ts
@@ -261,10 +261,10 @@ export const SLASH_COMMANDS: readonly SlashCommandSpec[] = [
   {
     cmd: "plan",
     group: "code",
-    argsHint: "[on|off]",
-    summary: "toggle read-only plan mode (writes bounced until submit_plan + approval)",
+    argsHint: "[on|off|strict|auto]",
+    summary: "toggle read-only plan mode / strict lifecycle rails",
     contextual: "code",
-    argCompleter: ["on", "off"],
+    argCompleter: ["on", "off", "strict", "auto"],
   },
   {
     cmd: "checkpoint",

--- a/src/cli/ui/slash/handlers/edits.ts
+++ b/src/cli/ui/slash/handlers/edits.ts
@@ -69,8 +69,8 @@ const plan: SlashHandler = (args, _loop, ctx) => {
   const currentOn = Boolean(ctx.planMode);
   const raw = (args[0] ?? "").toLowerCase();
   let target: boolean;
-  if (raw === "on" || raw === "true" || raw === "1") target = true;
-  else if (raw === "off" || raw === "false" || raw === "0") target = false;
+  if (raw === "on" || raw === "true" || raw === "1" || raw === "strict") target = true;
+  else if (raw === "off" || raw === "false" || raw === "0" || raw === "auto") target = false;
   else target = !currentOn;
   ctx.setPlanMode(target);
   if (target) {

--- a/src/code/lifecycle.ts
+++ b/src/code/lifecycle.ts
@@ -1,0 +1,300 @@
+import type { ToolInterceptor } from "../tools.js";
+import type { PlanStep, StepEvidence } from "../tools/plan.js";
+
+export type EngineeringLifecycleMode = "off" | "auto" | "strict";
+export type EngineeringLifecyclePromptClass = "small" | "large";
+export type EngineeringLifecycleState =
+  | "idle"
+  | "armed"
+  | "planning"
+  | "approved"
+  | "executing"
+  | "checkpoint"
+  | "complete"
+  | "cancelled";
+
+export interface EngineeringLifecycleSnapshot {
+  mode: EngineeringLifecycleMode;
+  state: EngineeringLifecycleState;
+  planSteps: PlanStep[];
+  completedStepIds: string[];
+  mutatedSinceLastStep: boolean;
+}
+
+export interface EngineeringLifecycleOptions {
+  mode?: EngineeringLifecycleMode;
+}
+
+const LARGE_PROMPT_PATTERNS = [
+  /\brefactor\b/i,
+  /\bmigration\b/i,
+  /\bmigrate\b/i,
+  /\barchitecture\b/i,
+  /\bpublic API\b/i,
+  /\bbreaking\b/i,
+  /\bacross\b/i,
+  /\bmulti[- ]?file\b/i,
+  /重构/,
+  /迁移/,
+  /架构/,
+  /多文件/,
+  /大型/,
+  /强约束/,
+];
+
+const SAFE_TOOL_NAMES = new Set([
+  "read_file",
+  "list_directory",
+  "directory_tree",
+  "search_files",
+  "search_content",
+  "glob",
+  "get_file_info",
+  "semantic_search",
+  "web_search",
+  "web_fetch",
+  "recall_memory",
+  "todo_write",
+  "ask_choice",
+  "submit_plan",
+  "mark_step_complete",
+  "revise_plan",
+  "job_output",
+  "wait_for_job",
+  "list_jobs",
+]);
+
+const HIGH_RISK_TOOL_NAMES = new Set([
+  "multi_edit",
+  "move_file",
+  "delete_file",
+  "delete_directory",
+  "copy_file",
+  "create_directory",
+  "run_background",
+  "stop_job",
+]);
+
+const MUTATION_TOOL_NAMES = new Set([
+  "edit_file",
+  "write_file",
+  "multi_edit",
+  "move_file",
+  "delete_file",
+  "delete_directory",
+  "copy_file",
+  "create_directory",
+  "run_background",
+  "stop_job",
+]);
+
+export function classifyEngineeringPrompt(text: string): EngineeringLifecyclePromptClass {
+  const trimmed = text.trim();
+  if (!trimmed) return "small";
+  return LARGE_PROMPT_PATTERNS.some((rx) => rx.test(trimmed)) ? "large" : "small";
+}
+
+export function isHighRiskLifecycleToolCall(name: string, args: Record<string, unknown>): boolean {
+  if (HIGH_RISK_TOOL_NAMES.has(name)) return true;
+  if (SAFE_TOOL_NAMES.has(name)) return false;
+  if (name === "write_file") {
+    const path = typeof args.path === "string" ? args.path : "";
+    return isPackageOrConfigPath(path);
+  }
+  if (name === "edit_file") {
+    const path = typeof args.path === "string" ? args.path : "";
+    return isPackageOrConfigPath(path);
+  }
+  if (name === "run_command") {
+    const command = typeof args.command === "string" ? args.command : "";
+    return isHighRiskCommand(command);
+  }
+  return false;
+}
+
+export function isLifecycleMutationToolCall(name: string, args: Record<string, unknown>): boolean {
+  if (MUTATION_TOOL_NAMES.has(name)) return true;
+  if (name === "run_command") {
+    const command = typeof args.command === "string" ? args.command : "";
+    return isHighRiskCommand(command);
+  }
+  return false;
+}
+
+export class EngineeringLifecycleRuntime {
+  private _mode: EngineeringLifecycleMode;
+  private _state: EngineeringLifecycleState = "idle";
+  private _planSteps: PlanStep[] = [];
+  private readonly _completedStepIds = new Set<string>();
+  private _mutatedSinceLastStep = false;
+
+  constructor(opts: EngineeringLifecycleOptions = {}) {
+    this._mode = opts.mode ?? "auto";
+    if (this._mode === "strict") this._state = "armed";
+  }
+
+  get mode(): EngineeringLifecycleMode {
+    return this._mode;
+  }
+
+  setMode(mode: EngineeringLifecycleMode): void {
+    this._mode = mode;
+    if (mode === "off") {
+      this.reset();
+      return;
+    }
+    if (mode === "strict" && this._state === "idle") this._state = "armed";
+  }
+
+  observeUserPrompt(text: string): void {
+    if (this._mode === "off") return;
+    if (this._state === "complete" || this._state === "cancelled") {
+      this.reset();
+    }
+    if (this._mode === "strict") {
+      if (this._state === "idle") this._state = "armed";
+      return;
+    }
+    if (this._state === "idle" && classifyEngineeringPrompt(text) === "large") {
+      this._state = "armed";
+    }
+  }
+
+  recordPlanProposed(steps?: readonly PlanStep[]): void {
+    if (this._mode === "off") return;
+    this._state = "planning";
+    this._planSteps = [...(steps ?? [])];
+    this._completedStepIds.clear();
+    this._mutatedSinceLastStep = false;
+  }
+
+  recordPlanApproved(steps?: readonly PlanStep[]): void {
+    if (this._mode === "off") return;
+    this._state = "approved";
+    this._planSteps = [...(steps ?? this._planSteps)];
+    this._completedStepIds.clear();
+    this._mutatedSinceLastStep = false;
+  }
+
+  recordStepCompleted(stepId: string): void {
+    if (!stepId) return;
+    this._completedStepIds.add(stepId);
+    this._mutatedSinceLastStep = false;
+    if (this._planSteps.length > 0 && this._completedStepIds.size >= this._planSteps.length) {
+      this._state = "complete";
+    } else if (this._state !== "idle" && this._state !== "cancelled") {
+      this._state = "executing";
+    }
+  }
+
+  recordToolResult(name: string, args: Record<string, unknown>, result: string): void {
+    if (this._mode === "off") return;
+    if (!isLifecycleMutationToolCall(name, args)) return;
+    if (!toolResultLooksSuccessful(result)) return;
+    if (this._state === "approved" || this._state === "executing") {
+      this._state = "executing";
+      this._mutatedSinceLastStep = true;
+    }
+  }
+
+  cancel(): void {
+    this._state = "cancelled";
+    this._planSteps = [];
+    this._completedStepIds.clear();
+    this._mutatedSinceLastStep = false;
+  }
+
+  reset(): void {
+    this._state = this._mode === "strict" ? "armed" : "idle";
+    this._planSteps = [];
+    this._completedStepIds.clear();
+    this._mutatedSinceLastStep = false;
+  }
+
+  guardToolCall: ToolInterceptor = (name, args) => {
+    if (this._mode === "off") return null;
+    if (name === "mark_step_complete") return this.guardStepCompletion(args);
+    if (!isHighRiskLifecycleToolCall(name, args)) return null;
+
+    if (this._mode === "auto" && this._state === "idle") {
+      this._state = "armed";
+    }
+
+    if (this._state !== "approved" && this._state !== "executing") {
+      return JSON.stringify({
+        error: `${name}: blocked by Engineering Lifecycle — high-risk engineering work requires an approved structured plan first. Explore with read-only tools, call ask_choice for real forks, then call submit_plan with concrete steps.`,
+        rejectedReason: "engineering-lifecycle",
+        state: this._state,
+      });
+    }
+
+    this._state = "executing";
+    return null;
+  };
+
+  snapshot(): EngineeringLifecycleSnapshot {
+    return {
+      mode: this._mode,
+      state: this._state,
+      planSteps: [...this._planSteps],
+      completedStepIds: [...this._completedStepIds],
+      mutatedSinceLastStep: this._mutatedSinceLastStep,
+    };
+  }
+
+  private guardStepCompletion(args: Record<string, unknown>): string | null {
+    const stepId = typeof args.stepId === "string" ? args.stepId.trim() : "";
+    const step = this._planSteps.find((s) => s.id === stepId);
+    const evidence = Array.isArray(args.evidence) ? (args.evidence as StepEvidence[]) : [];
+    const evidenceRequired =
+      this._mutatedSinceLastStep ||
+      step?.risk === "med" ||
+      step?.risk === "high" ||
+      (step?.verification?.length ?? 0) > 0;
+    if (evidenceRequired && evidence.length === 0) {
+      return JSON.stringify({
+        error:
+          "mark_step_complete: evidence required by Engineering Lifecycle — include verification, diff, checkpoint, or manual evidence before completing this step.",
+        rejectedReason: "engineering-lifecycle-evidence",
+        stepId,
+      });
+    }
+    return null;
+  }
+}
+
+function toolResultLooksSuccessful(result: string): boolean {
+  const text = result.trim();
+  if (!text) return false;
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    if (parsed && typeof parsed === "object" && "error" in parsed) return false;
+  } catch {
+    // Non-JSON tool results are normal.
+  }
+  if (/\b0\/\d+\s+applied\b/i.test(text)) return false;
+  return !/(user rejected|rejected this edit|discarded|unavailable in plan mode|interceptor failed|\berror\b|failed)/i.test(
+    text,
+  );
+}
+
+function isPackageOrConfigPath(path: string): boolean {
+  const normalized = path.replaceAll("\\", "/").toLowerCase();
+  return (
+    /(^|\/)package(-lock)?\.json$/.test(normalized) ||
+    /(^|\/)pnpm-lock\.yaml$/.test(normalized) ||
+    /(^|\/)yarn\.lock$/.test(normalized) ||
+    /(^|\/)tsconfig[^/]*\.json$/.test(normalized) ||
+    /(^|\/)vitest\.config\./.test(normalized) ||
+    /(^|\/)biome\.json$/.test(normalized) ||
+    normalized.startsWith(".github/workflows/")
+  );
+}
+
+function isHighRiskCommand(command: string): boolean {
+  return (
+    /\b(npm|pnpm|yarn)\s+(install|add|remove|update)\b/i.test(command) ||
+    /\b(git)\s+(push|reset|clean|checkout|switch)\b/i.test(command) ||
+    /\b(rm|mv|cp)\b/.test(command)
+  );
+}

--- a/src/code/plan-store.ts
+++ b/src/code/plan-store.ts
@@ -12,13 +12,14 @@ import {
 } from "node:fs";
 import { dirname, join } from "node:path";
 import { sanitizeName, sessionsDir } from "../memory/session.js";
-import type { PlanStep } from "../tools/plan.js";
+import type { PlanStep, StepCompletion, StepEvidence } from "../tools/plan.js";
 
 export interface PlanStateOnDisk {
   /** File format version — bump when shape changes. */
-  version: 1;
+  version: 1 | 2;
   steps: PlanStep[];
   completedStepIds: string[];
+  stepCompletions?: Record<string, StepCompletion>;
   /** ISO8601 timestamp of the last write. */
   updatedAt: string;
   body?: string;
@@ -36,7 +37,7 @@ export function loadPlanState(sessionName: string): PlanStateOnDisk | null {
     const raw = readFileSync(path, "utf8");
     const parsed = JSON.parse(raw) as Partial<PlanStateOnDisk>;
     if (!parsed || typeof parsed !== "object") return null;
-    if (parsed.version !== 1) return null;
+    if (parsed.version !== 1 && parsed.version !== 2) return null;
     if (!Array.isArray(parsed.steps)) return null;
     if (!Array.isArray(parsed.completedStepIds)) return null;
     if (typeof parsed.updatedAt !== "string") return null;
@@ -51,18 +52,27 @@ export function loadPlanState(sessionName: string): PlanStateOnDisk | null {
       if (typeof e.action !== "string" || !e.action) continue;
       const step: PlanStep = { id: e.id, title: e.title, action: e.action };
       if (e.risk === "low" || e.risk === "med" || e.risk === "high") step.risk = e.risk;
+      const targets = stringList(e.targets);
+      if (targets) step.targets = targets;
+      if (typeof e.acceptance === "string" && e.acceptance.trim()) {
+        step.acceptance = e.acceptance.trim();
+      }
+      const verification = stringList(e.verification);
+      if (verification) step.verification = verification;
       steps.push(step);
     }
     if (steps.length === 0) return null;
     const completedStepIds = parsed.completedStepIds.filter(
       (id): id is string => typeof id === "string" && id.length > 0,
     );
+    const stepCompletions = sanitizeStepCompletions(parsed.stepCompletions);
     const out: PlanStateOnDisk = {
-      version: 1,
+      version: parsed.version,
       steps,
       completedStepIds,
       updatedAt: parsed.updatedAt,
     };
+    if (stepCompletions) out.stepCompletions = stepCompletions;
     if (typeof parsed.body === "string" && parsed.body) out.body = parsed.body;
     if (typeof parsed.summary === "string" && parsed.summary) out.summary = parsed.summary;
     return out;
@@ -76,17 +86,23 @@ export function savePlanState(
   sessionName: string,
   steps: PlanStep[],
   completedStepIds: Iterable<string>,
-  extras?: { body?: string; summary?: string },
+  extras?: {
+    body?: string;
+    summary?: string;
+    stepCompletions?: ReadonlyMap<string, StepCompletion> | Record<string, StepCompletion>;
+  },
 ): void {
   const path = planStatePath(sessionName);
   try {
     mkdirSync(dirname(path), { recursive: true });
     const state: PlanStateOnDisk = {
-      version: 1,
+      version: 2,
       steps,
       completedStepIds: [...completedStepIds],
       updatedAt: new Date().toISOString(),
     };
+    const stepCompletions = normalizeStepCompletionsForWrite(extras?.stepCompletions);
+    if (stepCompletions) state.stepCompletions = stepCompletions;
     if (extras?.body) state.body = extras.body;
     if (extras?.summary) state.summary = extras.summary;
     writeFileSync(path, `${JSON.stringify(state, null, 2)}\n`, "utf8");
@@ -133,6 +149,7 @@ export interface PlanArchiveSummary {
   completedAt: string;
   steps: PlanStep[];
   completedStepIds: string[];
+  stepCompletions?: Record<string, StepCompletion>;
   /** Markdown body, when the archive carried it. */
   body?: string;
   /** One-line human-friendly title, when supplied. */
@@ -157,7 +174,7 @@ export function listPlanArchives(sessionName: string): PlanArchiveSummary[] {
     try {
       const raw = readFileSync(full, "utf8");
       const parsed = JSON.parse(raw) as Partial<PlanStateOnDisk>;
-      if (parsed.version !== 1) continue;
+      if (parsed.version !== 1 && parsed.version !== 2) continue;
       if (!Array.isArray(parsed.steps) || parsed.steps.length === 0) continue;
       const steps = parsed.steps.filter(
         (s): s is PlanStep =>
@@ -182,6 +199,8 @@ export function listPlanArchives(sessionName: string): PlanArchiveSummary[] {
         }
       }
       const entry: PlanArchiveSummary = { path: full, completedAt, steps, completedStepIds };
+      const stepCompletions = sanitizeStepCompletions(parsed.stepCompletions);
+      if (stepCompletions) entry.stepCompletions = stepCompletions;
       if (typeof parsed.body === "string" && parsed.body) entry.body = parsed.body;
       if (typeof parsed.summary === "string" && parsed.summary) entry.summary = parsed.summary;
       summaries.push(entry);
@@ -220,7 +239,7 @@ export function listAllPlanArchives(): PlanArchiveWithSession[] {
     try {
       const raw = readFileSync(full, "utf8");
       const parsed = JSON.parse(raw) as Partial<PlanStateOnDisk>;
-      if (parsed.version !== 1) continue;
+      if (parsed.version !== 1 && parsed.version !== 2) continue;
       if (!Array.isArray(parsed.steps) || parsed.steps.length === 0) continue;
       const steps = parsed.steps.filter(
         (s): s is PlanStep =>
@@ -249,6 +268,8 @@ export function listAllPlanArchives(): PlanArchiveWithSession[] {
         steps,
         completedStepIds,
       };
+      const stepCompletions = sanitizeStepCompletions(parsed.stepCompletions);
+      if (stepCompletions) entry.stepCompletions = stepCompletions;
       if (typeof parsed.body === "string" && parsed.body) entry.body = parsed.body;
       if (typeof parsed.summary === "string" && parsed.summary) entry.summary = parsed.summary;
       out.push(entry);
@@ -258,6 +279,80 @@ export function listAllPlanArchives(): PlanArchiveWithSession[] {
   }
   out.sort((a, b) => b.completedAt.localeCompare(a.completedAt));
   return out;
+}
+
+function stringList(raw: unknown): string[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const out = raw
+    .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+    .filter((entry) => entry.length > 0);
+  return out.length > 0 ? out : undefined;
+}
+
+function normalizeStepCompletionsForWrite(
+  raw: ReadonlyMap<string, StepCompletion> | Record<string, StepCompletion> | undefined,
+): Record<string, StepCompletion> | undefined {
+  if (!raw) return undefined;
+  const entries =
+    raw instanceof Map
+      ? [...raw.entries()]
+      : (Object.entries(raw) as Array<[string, StepCompletion]>);
+  const out: Record<string, StepCompletion> = {};
+  for (const [key, value] of entries) {
+    const completion = sanitizeStepCompletion(value, key);
+    if (completion) out[completion.stepId] = completion;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function sanitizeStepCompletions(raw: unknown): Record<string, StepCompletion> | undefined {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+  const out: Record<string, StepCompletion> = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    const completion = sanitizeStepCompletion(value, key);
+    if (completion) out[completion.stepId] = completion;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function sanitizeStepCompletion(raw: unknown, fallbackStepId?: string): StepCompletion | undefined {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+  const entry = raw as Record<string, unknown>;
+  const stepId =
+    typeof entry.stepId === "string" && entry.stepId.trim()
+      ? entry.stepId.trim()
+      : fallbackStepId?.trim();
+  const result = typeof entry.result === "string" ? entry.result.trim() : "";
+  if (!stepId || !result) return undefined;
+  const completion: StepCompletion = { kind: "step_completed", stepId, result };
+  if (typeof entry.title === "string" && entry.title.trim()) completion.title = entry.title.trim();
+  if (typeof entry.notes === "string" && entry.notes.trim()) completion.notes = entry.notes.trim();
+  const evidence = sanitizeEvidenceList(entry.evidence);
+  if (evidence) completion.evidence = evidence;
+  return completion;
+}
+
+function sanitizeEvidenceList(raw: unknown): StepEvidence[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const out: StepEvidence[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) continue;
+    const entry = item as Record<string, unknown>;
+    const kind = entry.kind;
+    if (kind !== "verification" && kind !== "diff" && kind !== "checkpoint" && kind !== "manual") {
+      continue;
+    }
+    const summary = typeof entry.summary === "string" ? entry.summary.trim() : "";
+    if (!summary) continue;
+    const evidence: StepEvidence = { kind, summary };
+    if (typeof entry.command === "string" && entry.command.trim()) {
+      evidence.command = entry.command.trim();
+    }
+    const paths = stringList(entry.paths);
+    if (paths) evidence.paths = paths;
+    out.push(evidence);
+  }
+  return out.length > 0 ? out : undefined;
 }
 
 /** Falls back to raw ISO string past a week — "47 days ago" misleads more than it helps. */

--- a/src/code/prompt.ts
+++ b/src/code/prompt.ts
@@ -64,6 +64,12 @@ Plan body: one-sentence summary, then a file-by-file breakdown of what you'll ch
 
 **Do NOT use submit_plan to present A/B/C route menus.** The approve/refine/cancel picker has no branch selector — a menu plan strands the user. For branching decisions, use \`ask_choice\` (see below); only call submit_plan once the user has picked a direction and you have ONE actionable plan.
 
+# Engineering lifecycle contract
+
+Reasonix may enforce a prefix-stable Engineering Lifecycle for large or high-risk engineering work. The runtime keeps lifecycle state outside the system prompt and tool list, so do not expect stage-specific prompt changes or new tools to appear. Treat any lifecycle block as a host constraint, not as a suggestion.
+
+When high-risk mutations are bounced with \`rejectedReason: "engineering-lifecycle"\`, switch to read-only exploration, then call \`submit_plan\` with concrete steps before trying the mutation again. Add optional per-step \`targets\`, \`acceptance\`, and \`verification\` fields when they clarify scope or success criteria. For medium/high-risk steps, steps with verification criteria, or steps that changed code, \`mark_step_complete\` requires \`evidence\` entries such as verification output, diff summary, checkpoint id, or manual rationale.
+
 # When to ask the user to pick (ask_choice)
 
 You have an \`ask_choice\` tool. **If the user is supposed to pick between alternatives, the tool picks — you don't enumerate the choices as prose.** Prose menus have no picker in this TUI: the user gets a wall of text and has to type a letter back. The tool fires an arrow-key picker that's strictly better.

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,6 +21,8 @@ export type EditMode = "review" | "auto" | "yolo";
 
 export type ReasoningEffort = "high" | "max";
 
+export type EngineeringLifecycleMode = "off" | "auto" | "strict";
+
 export type EmbeddingProvider = "ollama" | "openai-compat";
 
 export interface OllamaEmbeddingUserConfig {
@@ -195,6 +197,10 @@ export interface ReasonixConfig {
   };
   pricingOverride?: Record<string, PricingOverride>;
   rateLimit?: RateLimitConfig;
+  /** Host-enforced engineering lifecycle. "auto" keeps small tasks light while arming rails for larger/high-risk work. */
+  engineeringLifecycle?: {
+    mode?: EngineeringLifecycleMode;
+  };
   /** QQ Bot configuration */
   qq?: QQBotConfig;
 }
@@ -801,6 +807,15 @@ export function saveEditMode(mode: EditMode, path: string = defaultConfigPath())
   const cfg = readConfig(path);
   cfg.editMode = mode;
   writeConfig(cfg, path);
+}
+
+/** Unknown values fall back to "auto" so bad config keeps the cache-safe lightweight default. */
+export function loadEngineeringLifecycleMode(
+  path: string = defaultConfigPath(),
+): EngineeringLifecycleMode {
+  const v = readConfig(path).engineeringLifecycle?.mode;
+  if (v === "off" || v === "strict") return v;
+  return "auto";
 }
 
 /** True when the onboarding tip for the review/AUTO gate has been shown. */

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -543,6 +543,8 @@ export const EN: TranslationSchema = {
       title: "Checkpoint — step done",
       continue: "Continue — run the next step",
       continueHint: "Model resumes with the next step.",
+      finish: "Finish — summarize and close",
+      finishHint: "Model records the final step and summarizes the completed plan.",
       revise: "Revise — give feedback before the next step",
       reviseHint: "Stay paused, type guidance; model adjusts the remaining plan.",
       stop: "Stop — end the plan here",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -366,6 +366,8 @@ export interface TranslationSchema {
       title: string;
       continue: string;
       continueHint: string;
+      finish: string;
+      finishHint: string;
       revise: string;
       reviseHint: string;
       stop: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -524,6 +524,8 @@ export const zhCN: TranslationSchema = {
       title: "检查点 —— 当前步骤已完成",
       continue: "继续 —— 执行下一步",
       continueHint: "模型从下一步继续。",
+      finish: "完成 —— 总结并收尾",
+      finishHint: "模型记录最后一步，然后总结已完成的计划。",
       revise: "调整 —— 在下一步前给反馈",
       reviseHint: "先暂停，输入指引；模型会调整剩余计划。",
       stop: "停止 —— 在此结束计划",

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -59,6 +59,7 @@ export class ToolRegistry {
   private readonly _autoFlatten: boolean;
   private _planMode = false;
   private _interceptor: ToolInterceptor | null = null;
+  private readonly _interceptors: Array<{ id: string; fn: ToolInterceptor }> = [];
   private _auditListener: ToolCallAuditListener | null = null;
   private _resultAugmenter: ToolResultAugmenter | null = null;
   /** Per-tool fingerprint of the last call that failed schema validation. Cleared by any successful validation for that tool. */
@@ -81,6 +82,19 @@ export class ToolRegistry {
   /** At most one interceptor active; calling twice replaces. */
   setToolInterceptor(fn: ToolInterceptor | null): void {
     this._interceptor = fn;
+  }
+
+  /** Ordered host-side interceptors. They run before the legacy single interceptor. */
+  addToolInterceptor(id: string, fn: ToolInterceptor): () => void {
+    const normalized = id.trim();
+    if (!normalized) throw new Error("tool interceptor requires a non-empty id");
+    const existing = this._interceptors.findIndex((entry) => entry.id === normalized);
+    if (existing >= 0) this._interceptors.splice(existing, 1);
+    this._interceptors.push({ id: normalized, fn });
+    return () => {
+      const idx = this._interceptors.findIndex((entry) => entry.id === normalized);
+      if (idx >= 0) this._interceptors.splice(idx, 1);
+    };
   }
 
   setAuditListener(fn: ToolCallAuditListener | null): void {
@@ -210,15 +224,18 @@ export class ToolRegistry {
       });
     }
 
-    // Interceptor runs after plan-mode (so a plan-mode refusal still
+    // Interceptors run after plan-mode (so a plan-mode refusal still
     // wins) but before the real tool fn. A string return is treated as
     // the full tool result; null / undefined means "not my concern,
-    // fall through." Uncaught throws from the interceptor are surfaced
-    // through the same error path as a failed tool fn below.
-    if (this._interceptor) {
+    // fall through." Uncaught throws are surfaced through the same
+    // structured error path as the legacy single interceptor.
+    const chain = this._interceptor
+      ? [...this._interceptors.map((entry) => entry.fn), this._interceptor]
+      : this._interceptors.map((entry) => entry.fn);
+    for (const interceptor of chain) {
       try {
-        const short = await this._interceptor(name, args);
-        if (typeof short === "string") return short;
+        const short = await interceptor(name, args);
+        if (typeof short === "string") return this._augmentResult(name, args, short);
       } catch (err) {
         return JSON.stringify({
           error: `${name}: interceptor failed — ${(err as Error).message}`,
@@ -284,14 +301,18 @@ export class ToolRegistry {
       }
     }
 
+    return this._augmentResult(name, args, finalResult);
+  }
+
+  private _augmentResult(name: string, args: Record<string, unknown>, result: string): string {
     if (this._resultAugmenter) {
       try {
-        return this._resultAugmenter(name, args, finalResult);
+        return this._resultAugmenter(name, args, result);
       } catch {
         /* augmenter must never break the tool result */
       }
     }
-    return finalResult;
+    return result;
   }
 
   /** Records the failed call's fingerprint; on the 2nd consecutive identical malformed call to the same tool, returns a sharper error that tells the model to stop retrying. */

--- a/src/tools/plan-core.ts
+++ b/src/tools/plan-core.ts
@@ -1,15 +1,15 @@
 import { pauseGate } from "../core/pause-gate.js";
 import type { ToolRegistry } from "../tools.js";
 import { PlanProposedError, PlanRevisionProposedError } from "./plan-errors.js";
-import type { PlanStep, PlanStepRisk, StepCompletion } from "./plan-types.js";
+import type { PlanStep, PlanStepRisk, StepCompletion, StepEvidence } from "./plan-types.js";
 
 // Tool descriptions (teaching prompts for the model). Edit here, not inline.
 
 const SUBMIT_PLAN_DESCRIPTION =
-  "Submit ONE concrete plan you've already decided on. Use this for tasks that warrant a review gate — multi-file refactors, architecture changes, anything that would be expensive or confusing to undo. Skip it for small fixes (one-line typo, obvious bug with a clear fix) — just make the change. The user will either approve (you then implement it), ask for refinement, or cancel. If the user has already enabled /plan mode, writes are blocked at dispatch and you MUST use this. CRITICAL: do NOT use submit_plan to present alternative routes (A/B/C, option 1/2/3) for the user to pick from — the picker only exposes approve/refine/cancel, so a menu plan strands the user with no way to choose. For branching decisions, call `ask_choice` instead; only call submit_plan once the user has picked a direction and you have a single actionable plan. Write the plan as markdown with a one-line summary, a bulleted list of files to touch and what will change, and any risks or open questions. STRONGLY PREFERRED: pass `steps` — an array of {id, title, action, risk?} — so the UI renders a structured step list above the approval picker and tracks per-step progress. Use risk='high' for steps that touch prod data / break public APIs / are hard to undo; 'med' for non-trivial but reversible (multi-file edits, schema tweaks); 'low' for safe local work. After each step, call `mark_step_complete` so the user sees progress ticks.";
+  "Submit ONE concrete plan you've already decided on. Use this for tasks that warrant a review gate — multi-file refactors, architecture changes, anything that would be expensive or confusing to undo. Skip it for small fixes (one-line typo, obvious bug with a clear fix) — just make the change. The user will either approve (you then implement it), ask for refinement, or cancel. If the user has already enabled /plan mode, writes are blocked at dispatch and you MUST use this. CRITICAL: do NOT use submit_plan to present alternative routes (A/B/C, option 1/2/3) for the user to pick from — the picker only exposes approve/refine/cancel, so a menu plan strands the user with no way to choose. For branching decisions, call `ask_choice` instead; only call submit_plan once the user has picked a direction and you have a single actionable plan. Write the plan as markdown with a one-line summary, a bulleted list of files to touch and what will change, and any risks or open questions. STRONGLY PREFERRED: pass `steps` — an array of {id, title, action, risk?, targets?, acceptance?, verification?} — so the UI renders a structured step list above the approval picker and tracks per-step progress. Use risk='high' for steps that touch prod data / break public APIs / are hard to undo; 'med' for non-trivial but reversible (multi-file edits, schema tweaks); 'low' for safe local work. After each step, call `mark_step_complete` so the user sees progress ticks.";
 
 const MARK_STEP_COMPLETE_DESCRIPTION =
-  "Mark one step of the approved plan as done. MANDATORY: call this exactly once after finishing each step, before starting the next one — skipping it leaves the user staring at `0/N done` on the resume banner even when the work is finished, and they have no way to know which steps actually ran. The TUI updates the plan card's progress in place; the count is persisted to disk so it survives session resume. After the FINAL step, write a brief reply summarizing what was done and end the turn. Pass the `stepId` from the plan's steps array, a short `result` (what you did), and optional `notes` for anything surprising (errors, scope changes, follow-ups). This tool doesn't change any files. Don't call it if the plan didn't include structured steps, and don't invent ids that weren't in the original plan. If you only realized at the end that you skipped marking steps, mark them then — late is still better than never.";
+  "Mark one step of the approved plan as done. MANDATORY: call this exactly once after finishing each step, before starting the next one — skipping it leaves the user staring at `0/N done` on the resume banner even when the work is finished, and they have no way to know which steps actually ran. The TUI updates the plan card's progress in place; the count is persisted to disk so it survives session resume. After the FINAL step, write a brief reply summarizing what was done and end the turn. Pass the `stepId` from the plan's steps array, a short `result` (what you did), optional `notes` for anything surprising, and `evidence` when the step had medium/high risk, verification criteria, or code mutations. This tool doesn't change any files. Don't call it if the plan didn't include structured steps, and don't invent ids that weren't in the original plan. If you only realized at the end that you skipped marking steps, mark them then — late is still better than never.";
 
 const REVISE_PLAN_DESCRIPTION =
   "Surgically replace the REMAINING steps of an in-flight plan. Call this when the user has given feedback at a checkpoint that warrants a structured plan change — skip a step, swap two steps, add a new step, change risk, etc. Pass: `reason` (one sentence why), `remainingSteps` (the new tail of the plan, replacing whatever steps haven't been done yet), and optional `summary` (updated one-line plan summary). Done steps are NEVER touched — keep them out of `remainingSteps`. The TUI shows a diff (removed in red, kept in gray, added in green) and the user accepts or rejects. Don't call this for trivial mid-step adjustments — just keep executing. Don't call submit_plan for revisions either — that resets the whole plan including completed steps. Use submit_plan only when the entire approach has changed; use revise_plan when the tail needs editing.";
@@ -29,6 +29,23 @@ const STEP_ITEM_SCHEMA = {
       description:
         "Self-assessed risk. 'high' = hard-to-undo / touches prod / breaks API; 'med' = non-trivial but reversible; 'low' = safe local work. The UI shows a colored dot per step so the user knows where to focus review. Omit if you're unsure.",
     },
+    targets: {
+      type: "array",
+      description:
+        "Optional. Files, directories, or modules this step expects to touch. Used by the host lifecycle guard for risk/evidence tracking.",
+      items: { type: "string" },
+    },
+    acceptance: {
+      type: "string",
+      description:
+        "Optional. One-sentence acceptance criterion for this step; what must be true before it is marked complete.",
+    },
+    verification: {
+      type: "array",
+      description:
+        "Optional. Verification commands or checks expected before this step is marked complete.",
+      items: { type: "string" },
+    },
   },
   required: ["id", "title", "action"],
 };
@@ -39,6 +56,7 @@ export interface PlanToolOptions {
   onPlanSubmitted?: (plan: string, steps?: PlanStep[]) => void;
   onStepCompleted?: (update: StepCompletion) => void;
   onPlanRevisionProposed?: (reason: string, remainingSteps: PlanStep[], summary?: string) => void;
+  requireStepEvidence?: (args: { stepId: string; title?: string }) => string | null | undefined;
 }
 
 // Arg sanitizers — defensive cleanup shared between submit_plan and revise_plan
@@ -61,9 +79,45 @@ function sanitizeSteps(raw: unknown): PlanStep[] | undefined {
     const step: PlanStep = { id, title, action };
     const risk = sanitizeRisk(e.risk);
     if (risk) step.risk = risk;
+    const targets = sanitizeStringList(e.targets);
+    if (targets) step.targets = targets;
+    const acceptance = typeof e.acceptance === "string" ? e.acceptance.trim() : "";
+    if (acceptance) step.acceptance = acceptance;
+    const verification = sanitizeStringList(e.verification);
+    if (verification) step.verification = verification;
     steps.push(step);
   }
   return steps.length > 0 ? steps : undefined;
+}
+
+function sanitizeStringList(raw: unknown): string[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const out = raw
+    .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+    .filter((entry) => entry.length > 0);
+  return out.length > 0 ? out : undefined;
+}
+
+function sanitizeEvidence(raw: unknown): StepEvidence[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const out: StepEvidence[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== "object") continue;
+    const e = item as Record<string, unknown>;
+    const kind = e.kind;
+    if (kind !== "verification" && kind !== "diff" && kind !== "checkpoint" && kind !== "manual") {
+      continue;
+    }
+    const summary = typeof e.summary === "string" ? e.summary.trim() : "";
+    if (!summary) continue;
+    const evidence: StepEvidence = { kind, summary };
+    const command = typeof e.command === "string" ? e.command.trim() : "";
+    if (command) evidence.command = command;
+    const paths = sanitizeStringList(e.paths);
+    if (paths) evidence.paths = paths;
+    out.push(evidence);
+  }
+  return out.length > 0 ? out : undefined;
 }
 
 // Individual tool registrations — one per screen
@@ -148,10 +202,34 @@ function registerMarkStepComplete(registry: ToolRegistry, opts: PlanToolOptions)
           description:
             "Optional. Anything surprising — blockers hit, assumptions revised, follow-ups for later steps.",
         },
+        evidence: {
+          type: "array",
+          description:
+            "Optional. Evidence that this step is complete: verification command output summary, diff/checkpoint reference, or a manual note when no command applies.",
+          items: {
+            type: "object",
+            properties: {
+              kind: { type: "string", enum: ["verification", "diff", "checkpoint", "manual"] },
+              summary: { type: "string" },
+              command: { type: "string" },
+              paths: { type: "array", items: { type: "string" } },
+            },
+            required: ["kind", "summary"],
+          },
+        },
       },
       required: ["stepId", "result"],
     },
-    fn: async (args: { stepId: string; title?: string; result: string; notes?: string }, ctx) => {
+    fn: async (
+      args: {
+        stepId: string;
+        title?: string;
+        result: string;
+        notes?: string;
+        evidence?: unknown;
+      },
+      ctx,
+    ) => {
       const stepId = (args?.stepId ?? "").trim();
       const result = (args?.result ?? "").trim();
       if (!stepId) {
@@ -164,9 +242,15 @@ function registerMarkStepComplete(registry: ToolRegistry, opts: PlanToolOptions)
       }
       const title = typeof args?.title === "string" ? args.title.trim() || undefined : undefined;
       const notes = typeof args?.notes === "string" ? args.notes.trim() || undefined : undefined;
+      const evidence = sanitizeEvidence(args?.evidence);
+      const evidenceReason = opts.requireStepEvidence?.({ stepId, title });
+      if (evidenceReason && (!evidence || evidence.length === 0)) {
+        throw new Error(`mark_step_complete: evidence required — ${evidenceReason}`);
+      }
       const update: StepCompletion = { kind: "step_completed", stepId, result };
       if (title) update.title = title;
       if (notes) update.notes = notes;
+      if (evidence) update.evidence = evidence;
       opts.onStepCompleted?.(update);
       // Block until the user continues, revises, or stops
       const verdict = await (ctx?.confirmationGate ?? pauseGate).ask({

--- a/src/tools/plan-types.ts
+++ b/src/tools/plan-types.ts
@@ -5,6 +5,18 @@ export interface PlanStep {
   title: string;
   action: string;
   risk?: PlanStepRisk;
+  targets?: string[];
+  acceptance?: string;
+  verification?: string[];
+}
+
+export type StepEvidenceKind = "verification" | "diff" | "checkpoint" | "manual";
+
+export interface StepEvidence {
+  kind: StepEvidenceKind;
+  summary: string;
+  command?: string;
+  paths?: string[];
 }
 
 export interface StepCompletion {
@@ -13,4 +25,5 @@ export interface StepCompletion {
   title?: string;
   result: string;
   notes?: string;
+  evidence?: StepEvidence[];
 }

--- a/src/tools/plan.ts
+++ b/src/tools/plan.ts
@@ -1,4 +1,10 @@
 export { PlanProposedError, PlanRevisionProposedError } from "./plan-errors.js";
-export type { PlanStep, PlanStepRisk, StepCompletion } from "./plan-types.js";
+export type {
+  PlanStep,
+  PlanStepRisk,
+  StepCompletion,
+  StepEvidence,
+  StepEvidenceKind,
+} from "./plan-types.js";
 export { registerPlanTool } from "./plan-core.js";
 export type { PlanToolOptions } from "./plan-core.js";

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -14,6 +14,7 @@ import {
   loadBaseUrl,
   loadDesktopOpenTabs,
   loadEditMode,
+  loadEngineeringLifecycleMode,
   loadIndexConfig,
   loadIndexUserConfig,
   loadPricingOverride,
@@ -370,6 +371,24 @@ describe("config", () => {
   it("loadEditMode coerces unknown values back to 'review'", () => {
     writeConfig({ editMode: "garbage" as any }, path);
     expect(loadEditMode(path)).toBe("review");
+  });
+
+  it("loadEngineeringLifecycleMode defaults to 'auto' when unset", () => {
+    expect(loadEngineeringLifecycleMode(path)).toBe("auto");
+  });
+
+  it("loadEngineeringLifecycleMode accepts off, auto, and strict", () => {
+    writeConfig({ engineeringLifecycle: { mode: "off" } }, path);
+    expect(loadEngineeringLifecycleMode(path)).toBe("off");
+    writeConfig({ engineeringLifecycle: { mode: "auto" } }, path);
+    expect(loadEngineeringLifecycleMode(path)).toBe("auto");
+    writeConfig({ engineeringLifecycle: { mode: "strict" } }, path);
+    expect(loadEngineeringLifecycleMode(path)).toBe("strict");
+  });
+
+  it("loadEngineeringLifecycleMode coerces unknown values back to 'auto'", () => {
+    writeConfig({ engineeringLifecycle: { mode: "garbage" as any } }, path);
+    expect(loadEngineeringLifecycleMode(path)).toBe("auto");
   });
 
   it("loadReasoningEffort defaults to 'max' when unset", () => {

--- a/tests/lifecycle.test.ts
+++ b/tests/lifecycle.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vitest";
+import {
+  EngineeringLifecycleRuntime,
+  classifyEngineeringPrompt,
+  isHighRiskLifecycleToolCall,
+} from "../src/code/lifecycle.js";
+import { ImmutablePrefix } from "../src/memory/runtime.js";
+
+describe("engineering lifecycle classifier", () => {
+  it("keeps small single-file fixes lightweight", () => {
+    expect(classifyEngineeringPrompt("Fix the typo in README.md")).toBe("small");
+    expect(classifyEngineeringPrompt("Explain how /plan works")).toBe("small");
+  });
+
+  it("arms for large engineering prompts", () => {
+    expect(classifyEngineeringPrompt("Refactor the auth layer across frontend and backend")).toBe(
+      "large",
+    );
+    expect(classifyEngineeringPrompt("Implement a migration that changes the public API")).toBe(
+      "large",
+    );
+  });
+});
+
+describe("engineering lifecycle high-risk tool detection", () => {
+  it("treats read-only exploration as safe", () => {
+    expect(isHighRiskLifecycleToolCall("read_file", { path: "src/index.ts" })).toBe(false);
+    expect(isHighRiskLifecycleToolCall("search_content", { pattern: "foo" })).toBe(false);
+  });
+
+  it("treats batch edits and destructive filesystem calls as high risk", () => {
+    expect(
+      isHighRiskLifecycleToolCall("multi_edit", {
+        edits: [
+          { path: "src/a.ts", search: "a", replace: "b" },
+          { path: "src/b.ts", search: "a", replace: "b" },
+        ],
+      }),
+    ).toBe(true);
+    expect(isHighRiskLifecycleToolCall("delete_file", { path: "src/a.ts" })).toBe(true);
+  });
+});
+
+describe("EngineeringLifecycleRuntime", () => {
+  it("blocks high-risk mutations before an approved plan", () => {
+    const lifecycle = new EngineeringLifecycleRuntime({ mode: "auto" });
+    lifecycle.observeUserPrompt("Refactor the shell and filesystem tool gates");
+
+    const out = lifecycle.guardToolCall("multi_edit", {
+      edits: [
+        { path: "src/a.ts", search: "a", replace: "b" },
+        { path: "src/b.ts", search: "a", replace: "b" },
+      ],
+    });
+
+    expect(out).not.toBeNull();
+    expect(JSON.parse(out!).rejectedReason).toBe("engineering-lifecycle");
+    expect(lifecycle.snapshot().state).toBe("armed");
+  });
+
+  it("allows high-risk mutations after plan approval and then requires step evidence", () => {
+    const lifecycle = new EngineeringLifecycleRuntime({ mode: "auto" });
+    lifecycle.observeUserPrompt("Refactor the shell and filesystem tool gates");
+    lifecycle.recordPlanApproved([
+      {
+        id: "step-1",
+        title: "Refactor gates",
+        action: "Change multiple tool gate files.",
+        risk: "med",
+      },
+    ]);
+
+    expect(
+      lifecycle.guardToolCall("multi_edit", {
+        edits: [
+          { path: "src/a.ts", search: "a", replace: "b" },
+          { path: "src/b.ts", search: "a", replace: "b" },
+        ],
+      }),
+    ).toBeNull();
+
+    const rejected = lifecycle.guardToolCall("mark_step_complete", {
+      stepId: "step-1",
+      result: "Refactored the gate path.",
+    });
+    expect(rejected).not.toBeNull();
+    expect(JSON.parse(rejected!).error).toMatch(/evidence/);
+
+    expect(
+      lifecycle.guardToolCall("mark_step_complete", {
+        stepId: "step-1",
+        result: "Refactored the gate path.",
+        evidence: [{ kind: "verification", summary: "npm test tests/lifecycle.test.ts passed" }],
+      }),
+    ).toBeNull();
+  });
+
+  it("requires evidence for low-risk steps after a successful code mutation", () => {
+    const lifecycle = new EngineeringLifecycleRuntime({ mode: "auto" });
+    lifecycle.observeUserPrompt("Refactor formatting across modules");
+    lifecycle.recordPlanApproved([
+      {
+        id: "step-1",
+        title: "Extract formatter",
+        action: "Move formatting into src/format.ts.",
+        risk: "low",
+        targets: ["src/format.ts"],
+      },
+    ]);
+
+    lifecycle.recordToolResult(
+      "write_file",
+      { path: "src/format.ts" },
+      "▸ edit blocks: 1/1 applied\n  ✓ created     src/format.ts",
+    );
+
+    const rejected = lifecycle.guardToolCall("mark_step_complete", {
+      stepId: "step-1",
+      result: "Created src/format.ts.",
+    });
+    expect(rejected).not.toBeNull();
+    expect(JSON.parse(rejected!).rejectedReason).toBe("engineering-lifecycle-evidence");
+  });
+
+  it("does not require mutation evidence when an edit was rejected before touching disk", () => {
+    const lifecycle = new EngineeringLifecycleRuntime({ mode: "auto" });
+    lifecycle.observeUserPrompt("Refactor formatting across modules");
+    lifecycle.recordPlanApproved([
+      {
+        id: "step-1",
+        title: "Try formatter",
+        action: "Attempt a formatter edit.",
+        risk: "low",
+      },
+    ]);
+
+    lifecycle.recordToolResult(
+      "edit_file",
+      { path: "src/app.ts" },
+      "User rejected this edit to src/app.ts. Don't retry the same SEARCH/REPLACE.",
+    );
+
+    expect(
+      lifecycle.guardToolCall("mark_step_complete", {
+        stepId: "step-1",
+        result: "No code was changed.",
+      }),
+    ).toBeNull();
+  });
+
+  it("does not mutate the immutable prefix as lifecycle state changes", () => {
+    const prefix = new ImmutablePrefix({ system: "s", toolSpecs: [] });
+    const before = prefix.fingerprint;
+    const lifecycle = new EngineeringLifecycleRuntime({ mode: "strict" });
+
+    lifecycle.observeUserPrompt("Refactor everything");
+    lifecycle.recordPlanApproved([
+      { id: "step-1", title: "Do work", action: "Do high risk work.", risk: "high" },
+    ]);
+    lifecycle.guardToolCall("delete_file", { path: "src/old.ts" });
+
+    expect(prefix.verifyFingerprint()).toBe(before);
+  });
+
+  it("starts a fresh lifecycle after cancellation or completion", () => {
+    const lifecycle = new EngineeringLifecycleRuntime({ mode: "auto" });
+    lifecycle.observeUserPrompt("Refactor the command router");
+    lifecycle.cancel();
+
+    lifecycle.observeUserPrompt("Fix the typo in README.md");
+    expect(lifecycle.snapshot().state).toBe("idle");
+
+    lifecycle.observeUserPrompt("Refactor the command router again");
+    lifecycle.recordPlanApproved([
+      { id: "step-1", title: "Refactor", action: "Refactor command routing.", risk: "low" },
+    ]);
+    lifecycle.recordStepCompleted("step-1");
+    expect(lifecycle.snapshot().state).toBe("complete");
+
+    lifecycle.observeUserPrompt("Fix another typo");
+    expect(lifecycle.snapshot().state).toBe("idle");
+  });
+});

--- a/tests/plan-checkpoint-confirm.test.tsx
+++ b/tests/plan-checkpoint-confirm.test.tsx
@@ -1,0 +1,29 @@
+import { render } from "ink-testing-library";
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { PlanCheckpointConfirm } from "../src/cli/ui/PlanCheckpointConfirm.js";
+
+describe("PlanCheckpointConfirm", () => {
+  it("labels the primary action as finish when the last step is complete", () => {
+    const { lastFrame, unmount } = render(
+      <PlanCheckpointConfirm
+        stepId="step-3"
+        title="Run tests"
+        completed={3}
+        total={3}
+        steps={[
+          { id: "step-1", title: "Create file", action: "Create file" },
+          { id: "step-2", title: "Update import", action: "Update import" },
+          { id: "step-3", title: "Run tests", action: "Run tests" },
+        ]}
+        completedStepIds={new Set(["step-1", "step-2", "step-3"])}
+        onChoose={() => {}}
+      />,
+    );
+
+    const out = lastFrame() ?? "";
+    expect(out).toContain("Finish");
+    expect(out).not.toContain("Continue — run the next step");
+    unmount();
+  });
+});

--- a/tests/plan-store.test.ts
+++ b/tests/plan-store.test.ts
@@ -57,7 +57,7 @@ describe("plan-store roundtrip", () => {
     expect(loaded).not.toBeNull();
     expect(loaded?.steps).toEqual(steps);
     expect(loaded?.completedStepIds).toEqual(["step-1"]);
-    expect(loaded?.version).toBe(1);
+    expect(loaded?.version).toBe(2);
     expect(typeof loaded?.updatedAt).toBe("string");
   });
 
@@ -162,6 +162,26 @@ describe("plan-store roundtrip", () => {
     expect(loaded?.steps[1]?.risk).toBe("low");
   });
 
+  it("loads v2 lifecycle metadata fields and persists them on save", () => {
+    const steps = [
+      {
+        id: "step-1",
+        title: "refactor",
+        action: "change gates",
+        risk: "med" as const,
+        targets: ["src/tools.ts"],
+        acceptance: "high-risk mutations are gated",
+        verification: ["npm test tests/lifecycle.test.ts"],
+      },
+    ];
+    savePlanState("v2-fields", steps, []);
+
+    const loaded = loadPlanState("v2-fields");
+
+    expect(loaded?.version).toBe(2);
+    expect(loaded?.steps).toEqual(steps);
+  });
+
   it("filters out non-string entries from completedStepIds", () => {
     writeFixture(
       planStatePath("badcompleted"),
@@ -211,7 +231,40 @@ describe("archivePlanState", () => {
     const parsed = JSON.parse(raw);
     expect(parsed.steps).toEqual(steps);
     expect(parsed.completedStepIds).toEqual(["step-1"]);
-    expect(parsed.version).toBe(1);
+    expect(parsed.version).toBe(2);
+  });
+
+  it("persists step completion evidence in active and archived plan state", () => {
+    const steps = [
+      {
+        id: "step-1",
+        title: "verify",
+        action: "run tests",
+        verification: ["npm test"],
+      },
+    ];
+    const completion = {
+      kind: "step_completed" as const,
+      stepId: "step-1",
+      result: "npm test passed",
+      evidence: [
+        {
+          kind: "verification" as const,
+          summary: "npm test exited 0",
+          command: "npm test",
+        },
+      ],
+    };
+
+    savePlanState("evidence-test", steps, ["step-1"], {
+      stepCompletions: new Map([["step-1", completion]]),
+    });
+
+    expect(loadPlanState("evidence-test")?.stepCompletions?.["step-1"]).toEqual(completion);
+    const archive = archivePlanState("evidence-test");
+    expect(archive).not.toBeNull();
+    const archived = listPlanArchives("evidence-test")[0];
+    expect(archived?.stepCompletions?.["step-1"]).toEqual(completion);
   });
 
   it("two archives within the same millisecond don't collide", () => {

--- a/tests/plan.test.ts
+++ b/tests/plan.test.ts
@@ -311,6 +311,41 @@ describe("registerPlanTool + submit_plan", () => {
     ]);
   });
 
+  it("accepts optional lifecycle metadata on steps", async () => {
+    const reg = new ToolRegistry();
+    const submitted: Array<{ steps?: unknown }> = [];
+    registerPlanTool(reg, { onPlanSubmitted: (_p, steps) => submitted.push({ steps }) });
+    reg.setPlanMode(true);
+    const gate = new AutoGate({ type: "approve" });
+    await reg.dispatch(
+      "submit_plan",
+      JSON.stringify({
+        plan: "# Plan",
+        steps: [
+          {
+            id: "step-1",
+            title: "refactor",
+            action: "change tool gates",
+            targets: ["src/tools.ts", "src/cli/ui/App.tsx"],
+            acceptance: "high-risk mutations require an approved plan",
+            verification: ["npm test tests/lifecycle.test.ts"],
+          },
+        ],
+      }),
+      { confirmationGate: gate },
+    );
+    expect(submitted[0]?.steps).toEqual([
+      {
+        id: "step-1",
+        title: "refactor",
+        action: "change tool gates",
+        targets: ["src/tools.ts", "src/cli/ui/App.tsx"],
+        acceptance: "high-risk mutations require an approved plan",
+        verification: ["npm test tests/lifecycle.test.ts"],
+      },
+    ]);
+  });
+
   it("drops malformed risk values rather than letting them through", async () => {
     const reg = new ToolRegistry();
     const submitted: Array<{ steps?: unknown }> = [];
@@ -455,6 +490,52 @@ describe("registerPlanTool + mark_step_complete", () => {
     expect(parsed.notes).toBeUndefined();
     expect(parsed.result).toBe("done");
     expect(parsed.error).toBeUndefined();
+  });
+
+  it("preserves structured evidence when supplied", async () => {
+    const reg = new ToolRegistry();
+    const seen: StepCompletion[] = [];
+    registerPlanTool(reg, { onStepCompleted: (u) => seen.push(u) });
+    const gate = new AutoGate({ type: "continue" });
+    await reg.dispatch(
+      "mark_step_complete",
+      JSON.stringify({
+        stepId: "step-1",
+        result: "updated lifecycle guard",
+        evidence: [
+          {
+            kind: "verification",
+            summary: "targeted tests passed",
+            command: "npm test tests/lifecycle.test.ts",
+            paths: ["tests/lifecycle.test.ts"],
+          },
+        ],
+      }),
+      { confirmationGate: gate },
+    );
+
+    expect(seen[0]?.evidence).toEqual([
+      {
+        kind: "verification",
+        summary: "targeted tests passed",
+        command: "npm test tests/lifecycle.test.ts",
+        paths: ["tests/lifecycle.test.ts"],
+      },
+    ]);
+  });
+
+  it("rejects completion without evidence when the host requires it", async () => {
+    const reg = new ToolRegistry();
+    registerPlanTool(reg, {
+      requireStepEvidence: () => "step touched high-risk code",
+    });
+    const out = await reg.dispatch(
+      "mark_step_complete",
+      JSON.stringify({ stepId: "step-1", result: "updated lifecycle guard" }),
+    );
+
+    expect(JSON.parse(out).error).toMatch(/evidence required/);
+    expect(JSON.parse(out).error).toMatch(/high-risk code/);
   });
 
   it("rejects an empty stepId", async () => {

--- a/tests/slash.test.ts
+++ b/tests/slash.test.ts
@@ -409,7 +409,7 @@ describe("handleSlash", () => {
       const ctx = detectSlashArgContext("/plan o", true);
       expect(ctx).not.toBeNull();
       expect(ctx!.kind).toBe("picker");
-      expect(ctx!.spec.argCompleter).toEqual(["on", "off"]);
+      expect(ctx!.spec.argCompleter).toEqual(["on", "off", "strict", "auto"]);
     });
 
     it("hides /plan outside code mode (command is contextual)", () => {
@@ -1184,7 +1184,7 @@ describe("handleSlash", () => {
       expect(r2.info).toMatch(/plan mode OFF/);
     });
 
-    it("/plan on / off / true / false / 0 / 1 parse correctly", () => {
+    it("/plan on / off / true / false / 0 / 1 / strict / auto parse correctly", () => {
       const check = (arg: string, expected: boolean) => {
         const calls: boolean[] = [];
         handleSlash("plan", [arg], makeLoop(), {
@@ -1199,6 +1199,24 @@ describe("handleSlash", () => {
       check("off", false);
       check("false", false);
       check("0", false);
+      check("strict", true);
+      check("auto", false);
+    });
+
+    it("/plan strict and auto are explicit lifecycle modes, not toggles", () => {
+      const strictCalls: boolean[] = [];
+      handleSlash("plan", ["strict"], makeLoop(), {
+        planMode: true,
+        setPlanMode: (on) => strictCalls.push(on),
+      });
+      expect(strictCalls).toEqual([true]);
+
+      const autoCalls: boolean[] = [];
+      handleSlash("plan", ["auto"], makeLoop(), {
+        planMode: false,
+        setPlanMode: (on) => autoCalls.push(on),
+      });
+      expect(autoCalls).toEqual([false]);
     });
 
     it("/plan explains the stronger-constraint relationship with autonomous submit_plan", () => {

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -230,6 +230,22 @@ describe("ToolRegistry", () => {
       expect(fnCalled).toBe(false);
     });
 
+    it("passes intercepted tool results through the result augmenter", async () => {
+      const reg = new ToolRegistry();
+      const seen: Array<{ name: string; result: string }> = [];
+      reg.register({ name: "edit_file", fn: () => "should not run" });
+      reg.addToolInterceptor("review-gate", () => "▸ edit blocks: 1/1 applied");
+      reg.setResultAugmenter((name, _args, result) => {
+        seen.push({ name, result });
+        return `${result}\naugmented`;
+      });
+
+      const out = await reg.dispatch("edit_file", '{"path":"src/app.ts"}');
+
+      expect(out).toBe("▸ edit blocks: 1/1 applied\naugmented");
+      expect(seen).toEqual([{ name: "edit_file", result: "▸ edit blocks: 1/1 applied" }]);
+    });
+
     it("falls through to tool.fn when interceptor returns null", async () => {
       const reg = new ToolRegistry();
       reg.register({ name: "read_file", fn: () => "content" });
@@ -279,6 +295,40 @@ describe("ToolRegistry", () => {
       expect(await reg.dispatch("edit_file", "{}")).toBe("queued");
       reg.setToolInterceptor(null);
       expect(await reg.dispatch("edit_file", "{}")).toBe("fn-output");
+    });
+
+    it("runs ordered interceptors before the legacy interceptor", async () => {
+      const reg = new ToolRegistry();
+      const seen: string[] = [];
+      reg.register({ name: "edit_file", fn: () => "ok" });
+      reg.addToolInterceptor("first", () => {
+        seen.push("first");
+        return null;
+      });
+      reg.addToolInterceptor("second", () => {
+        seen.push("second");
+        return "blocked";
+      });
+      reg.setToolInterceptor(() => {
+        seen.push("legacy");
+        return null;
+      });
+
+      const out = await reg.dispatch("edit_file", "{}");
+
+      expect(out).toBe("blocked");
+      expect(seen).toEqual(["first", "second"]);
+    });
+
+    it("can remove an ordered interceptor by id", async () => {
+      const reg = new ToolRegistry();
+      reg.register({ name: "edit_file", fn: () => "ok" });
+      const remove = reg.addToolInterceptor("blocker", () => "blocked");
+      remove();
+
+      const out = await reg.dispatch("edit_file", "{}");
+
+      expect(out).toBe("ok");
     });
 
     it("surfaces interceptor throws as structured errors", async () => {


### PR DESCRIPTION
## Summary

Refs #1285.

This PR implements a prefix-stable Engineering Lifecycle for larger Reasonix coding tasks while preserving the existing cache-first loop, lightweight defaults, and edit/shell review UX.

## What Changed

- Added `EngineeringLifecycleRuntime` with host-managed lifecycle state outside mutable prompt/tool prefix state.
- Added `engineeringLifecycle.mode` config with `off`, `auto`, and `strict` modes; default is `auto`.
- Extended `/plan` so `/plan strict` enables the strict lifecycle and `/plan auto` restores configured auto behavior.
- Added automatic arming for large engineering prompts such as refactors, migrations, architecture changes, and multi-file tasks.
- Added ordered tool interceptors so the lifecycle guard composes with the existing edit gate.
- Extended structured plan steps with optional `targets`, `acceptance`, and `verification` fields while keeping old plans compatible.
- Enforced evidence for medium/high-risk steps, steps with verification criteria, and steps that successfully changed code.
- Persisted step completions and evidence in v2 plan store/archive files.
- Polished checkpoint UX so the final checkpoint presents a finish action and progress includes the just-completed step.
- Fixed heap-limit reexec behavior in test/cwd contexts while preserving existing heap launch behavior.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm test` — 229 files passed, 3225 passed, 10 skipped after rebasing onto upstream `main`
- `npm run build`
- Push-time `npm run verify` also passed via the repository hook

## Manual Exercise

I tested the built CLI on a temporary project with a multi-file refactor prompt. Reasonix auto-armed the lifecycle, explored read-only first, submitted a structured plan, waited for approval, preserved edit review gates, checkpointed each step, required verification evidence for the test step, archived the completed plan, and kept cache hits high across the flow.
