### PR TITLE
fix(desktop): use updater plugin for update check to bypass CSP

### DIFF
--- a/desktop/src/i18n/en.ts
+++ b/desktop/src/i18n/en.ts
@@ -44,7 +44,6 @@ export const en = {
     updateAvailable: "Update available: {version}",
     openReleases: "View releases",
     checkFailed: "Check failed: {message}",
-    checkNoRelease: "No releases yet",
     close: "Close",
   },
   workdir: {

--- a/desktop/src/i18n/zh-CN.ts
+++ b/desktop/src/i18n/zh-CN.ts
@@ -46,7 +46,6 @@ export const zhCN: typeof en = {
     updateAvailable: "新版本可用：{version}",
     openReleases: "查看发布页",
     checkFailed: "检查失败：{message}",
-    checkNoRelease: "尚无发布",
     close: "关闭",
   },
   workdir: {

--- a/desktop/src/ui/about.tsx
+++ b/desktop/src/ui/about.tsx
@@ -1,10 +1,10 @@
 import { openUrl } from "@tauri-apps/plugin-opener";
+import { check } from "@tauri-apps/plugin-updater";
 import { useCallback, useState } from "react";
 import { t } from "../i18n";
 import { I } from "../icons";
 
 const REPO_URL = "https://github.com/esengine/DeepSeek-Reasonix";
-const RELEASES_API = "https://api.github.com/repos/esengine/DeepSeek-Reasonix/releases";
 const RELEASES_PAGE = `${REPO_URL}/releases`;
 
 type CheckState =
@@ -13,19 +13,6 @@ type CheckState =
   | { kind: "up-to-date"; latest: string }
   | { kind: "outdated"; latest: string }
   | { kind: "error"; message: string };
-
-/** Lexicographic-but-numeric semver compare. Returns 1 if a > b, -1 if a < b, 0 if equal. */
-function cmpSemver(a: string, b: string): number {
-  const pa = a.split(/[.+-]/).map((s) => Number.parseInt(s, 10));
-  const pb = b.split(/[.+-]/).map((s) => Number.parseInt(s, 10));
-  const len = Math.max(pa.length, pb.length);
-  for (let i = 0; i < len; i++) {
-    const av = Number.isFinite(pa[i]) ? (pa[i] as number) : 0;
-    const bv = Number.isFinite(pb[i]) ? (pb[i] as number) : 0;
-    if (av !== bv) return av > bv ? 1 : -1;
-  }
-  return 0;
-}
 
 export function AboutModal({ onClose }: { onClose: () => void }) {
   const [check, setCheck] = useState<CheckState>({ kind: "idle" });
@@ -40,31 +27,12 @@ export function AboutModal({ onClose }: { onClose: () => void }) {
   const checkForUpdates = useCallback(async () => {
     setCheck({ kind: "checking" });
     try {
-      const resp = await fetch(RELEASES_API, {
-        headers: { Accept: "application/vnd.github+json" },
-      });
-      if (!resp.ok) {
-        setCheck({ kind: "error", message: `HTTP ${resp.status}` });
-        return;
+      const update = await check();
+      if (!update) {
+        setCheck({ kind: "up-to-date", latest: __APP_VERSION__ });
+      } else {
+        setCheck({ kind: "outdated", latest: update.version });
       }
-      const releases = (await resp.json()) as Array<{ tag_name?: string; draft?: boolean; prerelease?: boolean }>;
-      // Desktop releases live under the `desktop-v*` tag namespace (#1153).
-      // Fall back to bare `v*` so the check still works before the desktop
-      // track has cut its own tag.
-      const stable = releases.filter((r) => !r.draft && !r.prerelease);
-      const desktopTag = stable.find((r) => r.tag_name?.startsWith("desktop-v"))?.tag_name;
-      const fallbackTag = stable.find((r) => r.tag_name?.startsWith("v"))?.tag_name;
-      const tag = desktopTag ?? fallbackTag;
-      if (!tag) {
-        setCheck({ kind: "error", message: t("about.checkNoRelease") });
-        return;
-      }
-      const latest = tag.replace(/^desktop-v|^v/, "");
-      const current = __APP_VERSION__;
-      setCheck({
-        kind: cmpSemver(latest, current) > 0 ? "outdated" : "up-to-date",
-        latest,
-      });
     } catch (err) {
       setCheck({ kind: "error", message: (err as Error).message });
     }

--- a/desktop/src/ui/about.tsx
+++ b/desktop/src/ui/about.tsx
@@ -1,5 +1,5 @@
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { check } from "@tauri-apps/plugin-updater";
+import { check as checkUpdate } from "@tauri-apps/plugin-updater";
 import { useCallback, useState } from "react";
 import { t } from "../i18n";
 import { I } from "../icons";
@@ -27,7 +27,7 @@ export function AboutModal({ onClose }: { onClose: () => void }) {
   const checkForUpdates = useCallback(async () => {
     setCheck({ kind: "checking" });
     try {
-      const update = await check();
+      const update = await checkUpdate();
       if (!update) {
         setCheck({ kind: "up-to-date", latest: __APP_VERSION__ });
       } else {


### PR DESCRIPTION
## Summary

Replace WebView `fetch()` with the Tauri updater plugin's `check()` in the About modal, so the "Check for updates" button works instead of failing with `Failed to fetch`.

## Problem

The About modal's "Check for updates" button fetches `https://api.github.com/repos/esengine/DeepSeek-Reasonix/releases` directly from the WebView via `fetch()`. The Tauri CSP (`connect-src 'self' ipc: http://ipc.localhost`) blocks this cross-origin request, causing WebView2 to throw a `TypeError: Failed to fetch` before the request ever leaves the browser. The user sees:

```
检查失败：Failed to fetch
```

The root cause is in `checkForUpdates()` [about.tsx:41-43](desktop/src/ui/about.tsx:41-43): a raw `fetch()` to an origin not listed in `connect-src`. The CSP is configured in [tauri.conf.json:27](desktop/src-tauri/tauri.conf.json:27) and does not include `https://api.github.com`.

By contrast, `App.tsx` already uses `check()` from `@tauri-apps/plugin-updater` [App.tsx:2754](desktop/src/App.tsx:2754) for automatic update checks — that call goes through Tauri IPC to Rust-side HTTP (`reqwest`) and is not subject to WebView CSP.

## Fix

- **`desktop/src/ui/about.tsx`** — Replaced the raw `fetch()` + manual tag-parsing logic with a single `await check()` call from `@tauri-apps/plugin-updater`. Removed the now-unused `RELEASES_API` constant, `cmpSemver()` helper, and the GitHub release-tag filtering logic (the updater plugin already handles version comparison and endpoint selection). The `check()` return value is `null` when up-to-date, or an `Update` object with a `.version` string when outdated.
- **`desktop/src/i18n/en.ts`** — Removed the orphaned `checkNoRelease` key (was only reachable from the deleted tag-filtering path).
- **`desktop/src/i18n/zh-CN.ts`** — Same, removed `checkNoRelease`.

## Verification

| Check | Result |
|---|---|
| `npm run typecheck` | ✅ passes |
| `npm run lint` | ✅ 622 files, no fixes applied |
| `npm run test` | ✅ 3199 passed, 9 skipped, **3 failed (unrelated timeouts)** |

**Note:** `acp-mcp.test.ts` and `chat-mcp-startup-summary.test.ts` timed out during the full `npm run test` run, but both pass when targeted individually: `npx vitest run tests/acp-mcp.test.ts tests/chat-mcp-startup-summary.test.ts`. The timeouts are unrelated to this change.
