### PR TITLE
feat(tools): add ordered interceptor chain

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -59,6 +59,7 @@ export class ToolRegistry {
   private readonly _autoFlatten: boolean;
   private _planMode = false;
   private _interceptor: ToolInterceptor | null = null;
+  private readonly _interceptors: Array<{ id: string; fn: ToolInterceptor }> = [];
   private _auditListener: ToolCallAuditListener | null = null;
   private _resultAugmenter: ToolResultAugmenter | null = null;
   /** Per-tool fingerprint of the last call that failed schema validation. Cleared by any successful validation for that tool. */
@@ -81,6 +82,19 @@ export class ToolRegistry {
   /** At most one interceptor active; calling twice replaces. */
   setToolInterceptor(fn: ToolInterceptor | null): void {
     this._interceptor = fn;
+  }
+
+  /** Ordered host-side interceptors. They run before the legacy single interceptor. */
+  addToolInterceptor(id: string, fn: ToolInterceptor): () => void {
+    const normalized = id.trim();
+    if (!normalized) throw new Error("tool interceptor requires a non-empty id");
+    const existing = this._interceptors.findIndex((entry) => entry.id === normalized);
+    if (existing >= 0) this._interceptors.splice(existing, 1);
+    this._interceptors.push({ id: normalized, fn });
+    return () => {
+      const idx = this._interceptors.findIndex((entry) => entry.id === normalized);
+      if (idx >= 0) this._interceptors.splice(idx, 1);
+    };
   }
 
   setAuditListener(fn: ToolCallAuditListener | null): void {
@@ -210,15 +224,18 @@ export class ToolRegistry {
       });
     }
 
-    // Interceptor runs after plan-mode (so a plan-mode refusal still
+    // Interceptors run after plan-mode (so a plan-mode refusal still
     // wins) but before the real tool fn. A string return is treated as
     // the full tool result; null / undefined means "not my concern,
-    // fall through." Uncaught throws from the interceptor are surfaced
-    // through the same error path as a failed tool fn below.
-    if (this._interceptor) {
+    // fall through." Uncaught throws are surfaced through the same
+    // structured error path as the legacy single interceptor.
+    const chain = this._interceptor
+      ? [...this._interceptors.map((entry) => entry.fn), this._interceptor]
+      : this._interceptors.map((entry) => entry.fn);
+    for (const interceptor of chain) {
       try {
-        const short = await this._interceptor(name, args);
-        if (typeof short === "string") return short;
+        const short = await interceptor(name, args);
+        if (typeof short === "string") return this._augmentResult(name, args, short);
       } catch (err) {
         return JSON.stringify({
           error: `${name}: interceptor failed — ${(err as Error).message}`,
@@ -284,14 +301,18 @@ export class ToolRegistry {
       }
     }
 
+    return this._augmentResult(name, args, finalResult);
+  }
+
+  private _augmentResult(name: string, args: Record<string, unknown>, result: string): string {
     if (this._resultAugmenter) {
       try {
-        return this._resultAugmenter(name, args, finalResult);
+        return this._resultAugmenter(name, args, result);
       } catch {
         /* augmenter must never break the tool result */
       }
     }
-    return finalResult;
+    return result;
   }
 
   /** Records the failed call's fingerprint; on the 2nd consecutive identical malformed call to the same tool, returns a sharper error that tells the model to stop retrying. */

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -230,6 +230,22 @@ describe("ToolRegistry", () => {
       expect(fnCalled).toBe(false);
     });
 
+    it("passes intercepted tool results through the result augmenter", async () => {
+      const reg = new ToolRegistry();
+      const seen: Array<{ name: string; result: string }> = [];
+      reg.register({ name: "edit_file", fn: () => "should not run" });
+      reg.addToolInterceptor("review-gate", () => "▸ edit blocks: 1/1 applied");
+      reg.setResultAugmenter((name, _args, result) => {
+        seen.push({ name, result });
+        return `${result}\naugmented`;
+      });
+
+      const out = await reg.dispatch("edit_file", '{"path":"src/app.ts"}');
+
+      expect(out).toBe("▸ edit blocks: 1/1 applied\naugmented");
+      expect(seen).toEqual([{ name: "edit_file", result: "▸ edit blocks: 1/1 applied" }]);
+    });
+
     it("falls through to tool.fn when interceptor returns null", async () => {
       const reg = new ToolRegistry();
       reg.register({ name: "read_file", fn: () => "content" });
@@ -279,6 +295,40 @@ describe("ToolRegistry", () => {
       expect(await reg.dispatch("edit_file", "{}")).toBe("queued");
       reg.setToolInterceptor(null);
       expect(await reg.dispatch("edit_file", "{}")).toBe("fn-output");
+    });
+
+    it("runs ordered interceptors before the legacy interceptor", async () => {
+      const reg = new ToolRegistry();
+      const seen: string[] = [];
+      reg.register({ name: "edit_file", fn: () => "ok" });
+      reg.addToolInterceptor("first", () => {
+        seen.push("first");
+        return null;
+      });
+      reg.addToolInterceptor("second", () => {
+        seen.push("second");
+        return "blocked";
+      });
+      reg.setToolInterceptor(() => {
+        seen.push("legacy");
+        return null;
+      });
+
+      const out = await reg.dispatch("edit_file", "{}");
+
+      expect(out).toBe("blocked");
+      expect(seen).toEqual(["first", "second"]);
+    });
+
+    it("can remove an ordered interceptor by id", async () => {
+      const reg = new ToolRegistry();
+      reg.register({ name: "edit_file", fn: () => "ok" });
+      const remove = reg.addToolInterceptor("blocker", () => "blocked");
+      remove();
+
+      const out = await reg.dispatch("edit_file", "{}");
+
+      expect(out).toBe("ok");
     });
 
     it("surfaces interceptor throws as structured errors", async () => {


### PR DESCRIPTION
## Summary

- Add `ToolRegistry.addToolInterceptor(id, fn)` for ordered host-side interceptors.
- Preserve the existing single `setToolInterceptor` API by running it after the ordered chain.
- Route intercepted short-circuit results through the existing result augmenter, matching normal tool results.

## Split context

Split out of #1296 after maintainer review on #1293. This is the infrastructure-only slice and does not add lifecycle behavior.

## Validation

- `npm test -- tests/tools.test.ts`

I also attempted the local pre-push `npm run verify`; it currently fails on the pre-existing heap-limit launcher test path, which is being split into its own fix PR as requested.