### PR TITLE
feat(plan): persist step evidence metadata

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -90,7 +90,7 @@ import { defaultUsageLogPath } from "../../telemetry/usage.js";
 import type { ToolRegistry } from "../../tools.js";
 import type { ChoiceOption } from "../../tools/choice.js";
 import { looksLikeAbsoluteSystemPath, pathIsUnder } from "../../tools/filesystem.js";
-import type { PlanStep } from "../../tools/plan.js";
+import type { PlanStep, StepCompletion } from "../../tools/plan.js";
 import { formatCommandResult, runCommand } from "../../tools/shell.js";
 import { registerSkillTools } from "../../tools/skills.js";
 import { formatSubagentResult, spawnSubagent } from "../../tools/subagent.js";
@@ -361,6 +361,15 @@ function LoopStatusRow({
       <Text color="cyan">{`> ${formatLoopStatus(loop.prompt, nextFireMs, loop.iter)} - /loop stop or type to cancel`}</Text>
     </Box>
   );
+}
+
+function completedCountIncludingStep(
+  completedStepIds: Set<string>,
+  stepId: string,
+  total: number,
+): number {
+  const completed = completedStepIds.size + (completedStepIds.has(stepId) ? 0 : 1);
+  return total > 0 ? Math.min(completed, total) : completed;
 }
 
 function lastMessageContent(
@@ -848,6 +857,7 @@ function AppInner({
   // revised plan starts fresh —old completions don't spill over.
   const planStepsRef = useRef<PlanStep[] | null>(null);
   const completedStepIdsRef = useRef<Set<string>>(new Set());
+  const stepCompletionsRef = useRef<Map<string, StepCompletion>>(new Map());
   // Markdown body + human-friendly summary captured from submit_plan.
   // Persisted alongside the structured state so a future Time-Travel
   // replay can show the model's full original proposal without re-
@@ -873,9 +883,14 @@ function AppInner({
       clearPlanState(session);
       return;
     }
-    const extras: { body?: string; summary?: string } = {};
+    const extras: {
+      body?: string;
+      summary?: string;
+      stepCompletions?: Map<string, StepCompletion>;
+    } = {};
     if (planBodyRef.current) extras.body = planBodyRef.current;
     if (planSummaryRef.current) extras.summary = planSummaryRef.current;
+    if (stepCompletionsRef.current.size > 0) extras.stepCompletions = stepCompletionsRef.current;
     savePlanState(session, steps, completedStepIdsRef.current, extras);
   }, [session]);
   const [summary, setSummary] = useState<SessionSummary>({
@@ -1549,6 +1564,7 @@ function AppInner({
       if (restoredPlan && restoredPlan.steps.length > 0) {
         planStepsRef.current = restoredPlan.steps;
         completedStepIdsRef.current = new Set(restoredPlan.completedStepIds);
+        stepCompletionsRef.current = new Map(Object.entries(restoredPlan.stepCompletions ?? {}));
         planBodyRef.current = restoredPlan.body ?? null;
         planSummaryRef.current = restoredPlan.summary ?? null;
         const when = relativeTime(restoredPlan.updatedAt);
@@ -3212,6 +3228,7 @@ function AppInner({
               setPendingChoice,
               planStepsRef,
               completedStepIdsRef,
+              stepCompletionsRef,
               planBodyRef,
               planSummaryRef,
               persistPlanState,
@@ -3574,6 +3591,7 @@ function AppInner({
         const approvedSteps = planStepsRef.current;
         if (approvedSteps && approvedSteps.length > 0) {
           completedStepIdsRef.current = new Set();
+          stepCompletionsRef.current = new Map();
           log.showPlan({
             title: planSummaryRef.current ?? "plan",
             steps: approvedSteps.map((s) => ({
@@ -3593,6 +3611,7 @@ function AppInner({
         // no point keeping it around for resume.
         planStepsRef.current = null;
         completedStepIdsRef.current = new Set();
+        stepCompletionsRef.current = new Map();
         planBodyRef.current = null;
         planSummaryRef.current = null;
         persistPlanState();
@@ -3741,6 +3760,7 @@ function AppInner({
           planStepsRef.current = p.steps ?? null;
           planSummaryRef.current = p.summary ?? null;
           planBodyRef.current = p.plan;
+          stepCompletionsRef.current = new Map();
           break;
         }
         case "plan_checkpoint": {
@@ -3750,9 +3770,13 @@ function AppInner({
             result: string;
             notes?: string;
           };
-          // completed/total come from planStepsRef —don't have them via gate
-          const completed = completedStepIdsRef.current.size;
+          // completed/total come from planStepsRef — don't have them via gate.
           const total = planStepsRef.current?.length ?? 0;
+          const completed = completedCountIncludingStep(
+            completedStepIdsRef.current,
+            p.stepId,
+            total,
+          );
           // Shared policy (src/core/pause-policy.ts) decides whether to
           // auto-resolve. Per-step rollback snapshot still runs so /restore
           // granularity is preserved.
@@ -3895,8 +3919,8 @@ function AppInner({
           }
         }
       }
-      const completed = completedStepIdsRef.current.size;
       const total = planStepsRef.current?.length ?? 0;
+      const completed = completedCountIncludingStep(completedStepIdsRef.current, stepId, total);
       const label = title ? `${stepId} - ${title}` : stepId;
       const counter = total > 0 ? ` (${completed}/${total})` : "";
       log.pushInfo(t("app.continuingAfter", { label, counter }));

--- a/src/cli/ui/PlanCheckpointConfirm.tsx
+++ b/src/cli/ui/PlanCheckpointConfirm.tsx
@@ -48,12 +48,12 @@ function PlanCheckpointConfirmInner({
         </Box>
       ) : null}
       <SingleSelect
-        initialValue={isLast ? "stop" : "continue"}
+        initialValue="continue"
         items={[
           {
             value: "continue",
-            label: t("planFlow.checkpoint.continue"),
-            hint: t("planFlow.checkpoint.continueHint"),
+            label: t(isLast ? "planFlow.checkpoint.finish" : "planFlow.checkpoint.continue"),
+            hint: t(isLast ? "planFlow.checkpoint.finishHint" : "planFlow.checkpoint.continueHint"),
           },
           {
             value: "revise",

--- a/src/cli/ui/hooks/handle-tool-event.ts
+++ b/src/cli/ui/hooks/handle-tool-event.ts
@@ -27,9 +27,11 @@ export interface ToolEventContext {
   >;
   planStepsRef: MutableRefObject<PlanStep[] | null>;
   completedStepIdsRef: MutableRefObject<Set<string>>;
+  stepCompletionsRef?: MutableRefObject<Map<string, StepCompletion>>;
   planBodyRef: MutableRefObject<string | null>;
   planSummaryRef: MutableRefObject<string | null>;
   persistPlanState: () => void;
+  onPlanStepCompleted?: (stepId: string) => void;
   log: Scrollback;
   session: string | null;
   codeModeOn: boolean;
@@ -49,8 +51,10 @@ export function handleToolEvent(ev: LoopEvent, ctx: ToolEventContext): void {
       const stepId = parsed.stepId;
       if (parsed.kind === "step_completed" && typeof stepId === "string") {
         ctx.completedStepIdsRef.current.add(stepId);
+        ctx.stepCompletionsRef?.current.set(stepId, parsed as StepCompletion);
         ctx.persistPlanState();
         ctx.log.completePlanStep(stepId);
+        ctx.onPlanStepCompleted?.(stepId);
         const total = ctx.planStepsRef.current?.length ?? 0;
         const completed = ctx.completedStepIdsRef.current.size;
         const stepFromPlan = ctx.planStepsRef.current?.find((s) => s.id === stepId);

--- a/src/code/plan-store.ts
+++ b/src/code/plan-store.ts
@@ -12,13 +12,14 @@ import {
 } from "node:fs";
 import { dirname, join } from "node:path";
 import { sanitizeName, sessionsDir } from "../memory/session.js";
-import type { PlanStep } from "../tools/plan.js";
+import type { PlanStep, StepCompletion, StepEvidence } from "../tools/plan.js";
 
 export interface PlanStateOnDisk {
   /** File format version — bump when shape changes. */
-  version: 1;
+  version: 1 | 2;
   steps: PlanStep[];
   completedStepIds: string[];
+  stepCompletions?: Record<string, StepCompletion>;
   /** ISO8601 timestamp of the last write. */
   updatedAt: string;
   body?: string;
@@ -36,7 +37,7 @@ export function loadPlanState(sessionName: string): PlanStateOnDisk | null {
     const raw = readFileSync(path, "utf8");
     const parsed = JSON.parse(raw) as Partial<PlanStateOnDisk>;
     if (!parsed || typeof parsed !== "object") return null;
-    if (parsed.version !== 1) return null;
+    if (parsed.version !== 1 && parsed.version !== 2) return null;
     if (!Array.isArray(parsed.steps)) return null;
     if (!Array.isArray(parsed.completedStepIds)) return null;
     if (typeof parsed.updatedAt !== "string") return null;
@@ -51,18 +52,27 @@ export function loadPlanState(sessionName: string): PlanStateOnDisk | null {
       if (typeof e.action !== "string" || !e.action) continue;
       const step: PlanStep = { id: e.id, title: e.title, action: e.action };
       if (e.risk === "low" || e.risk === "med" || e.risk === "high") step.risk = e.risk;
+      const targets = stringList(e.targets);
+      if (targets) step.targets = targets;
+      if (typeof e.acceptance === "string" && e.acceptance.trim()) {
+        step.acceptance = e.acceptance.trim();
+      }
+      const verification = stringList(e.verification);
+      if (verification) step.verification = verification;
       steps.push(step);
     }
     if (steps.length === 0) return null;
     const completedStepIds = parsed.completedStepIds.filter(
       (id): id is string => typeof id === "string" && id.length > 0,
     );
+    const stepCompletions = sanitizeStepCompletions(parsed.stepCompletions);
     const out: PlanStateOnDisk = {
-      version: 1,
+      version: parsed.version,
       steps,
       completedStepIds,
       updatedAt: parsed.updatedAt,
     };
+    if (stepCompletions) out.stepCompletions = stepCompletions;
     if (typeof parsed.body === "string" && parsed.body) out.body = parsed.body;
     if (typeof parsed.summary === "string" && parsed.summary) out.summary = parsed.summary;
     return out;
@@ -76,17 +86,23 @@ export function savePlanState(
   sessionName: string,
   steps: PlanStep[],
   completedStepIds: Iterable<string>,
-  extras?: { body?: string; summary?: string },
+  extras?: {
+    body?: string;
+    summary?: string;
+    stepCompletions?: ReadonlyMap<string, StepCompletion> | Record<string, StepCompletion>;
+  },
 ): void {
   const path = planStatePath(sessionName);
   try {
     mkdirSync(dirname(path), { recursive: true });
     const state: PlanStateOnDisk = {
-      version: 1,
+      version: 2,
       steps,
       completedStepIds: [...completedStepIds],
       updatedAt: new Date().toISOString(),
     };
+    const stepCompletions = normalizeStepCompletionsForWrite(extras?.stepCompletions);
+    if (stepCompletions) state.stepCompletions = stepCompletions;
     if (extras?.body) state.body = extras.body;
     if (extras?.summary) state.summary = extras.summary;
     writeFileSync(path, `${JSON.stringify(state, null, 2)}\n`, "utf8");
@@ -133,6 +149,7 @@ export interface PlanArchiveSummary {
   completedAt: string;
   steps: PlanStep[];
   completedStepIds: string[];
+  stepCompletions?: Record<string, StepCompletion>;
   /** Markdown body, when the archive carried it. */
   body?: string;
   /** One-line human-friendly title, when supplied. */
@@ -157,7 +174,7 @@ export function listPlanArchives(sessionName: string): PlanArchiveSummary[] {
     try {
       const raw = readFileSync(full, "utf8");
       const parsed = JSON.parse(raw) as Partial<PlanStateOnDisk>;
-      if (parsed.version !== 1) continue;
+      if (parsed.version !== 1 && parsed.version !== 2) continue;
       if (!Array.isArray(parsed.steps) || parsed.steps.length === 0) continue;
       const steps = parsed.steps.filter(
         (s): s is PlanStep =>
@@ -182,6 +199,8 @@ export function listPlanArchives(sessionName: string): PlanArchiveSummary[] {
         }
       }
       const entry: PlanArchiveSummary = { path: full, completedAt, steps, completedStepIds };
+      const stepCompletions = sanitizeStepCompletions(parsed.stepCompletions);
+      if (stepCompletions) entry.stepCompletions = stepCompletions;
       if (typeof parsed.body === "string" && parsed.body) entry.body = parsed.body;
       if (typeof parsed.summary === "string" && parsed.summary) entry.summary = parsed.summary;
       summaries.push(entry);
@@ -220,7 +239,7 @@ export function listAllPlanArchives(): PlanArchiveWithSession[] {
     try {
       const raw = readFileSync(full, "utf8");
       const parsed = JSON.parse(raw) as Partial<PlanStateOnDisk>;
-      if (parsed.version !== 1) continue;
+      if (parsed.version !== 1 && parsed.version !== 2) continue;
       if (!Array.isArray(parsed.steps) || parsed.steps.length === 0) continue;
       const steps = parsed.steps.filter(
         (s): s is PlanStep =>
@@ -249,6 +268,8 @@ export function listAllPlanArchives(): PlanArchiveWithSession[] {
         steps,
         completedStepIds,
       };
+      const stepCompletions = sanitizeStepCompletions(parsed.stepCompletions);
+      if (stepCompletions) entry.stepCompletions = stepCompletions;
       if (typeof parsed.body === "string" && parsed.body) entry.body = parsed.body;
       if (typeof parsed.summary === "string" && parsed.summary) entry.summary = parsed.summary;
       out.push(entry);
@@ -258,6 +279,80 @@ export function listAllPlanArchives(): PlanArchiveWithSession[] {
   }
   out.sort((a, b) => b.completedAt.localeCompare(a.completedAt));
   return out;
+}
+
+function stringList(raw: unknown): string[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const out = raw
+    .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+    .filter((entry) => entry.length > 0);
+  return out.length > 0 ? out : undefined;
+}
+
+function normalizeStepCompletionsForWrite(
+  raw: ReadonlyMap<string, StepCompletion> | Record<string, StepCompletion> | undefined,
+): Record<string, StepCompletion> | undefined {
+  if (!raw) return undefined;
+  const entries =
+    raw instanceof Map
+      ? [...raw.entries()]
+      : (Object.entries(raw) as Array<[string, StepCompletion]>);
+  const out: Record<string, StepCompletion> = {};
+  for (const [key, value] of entries) {
+    const completion = sanitizeStepCompletion(value, key);
+    if (completion) out[completion.stepId] = completion;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function sanitizeStepCompletions(raw: unknown): Record<string, StepCompletion> | undefined {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+  const out: Record<string, StepCompletion> = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    const completion = sanitizeStepCompletion(value, key);
+    if (completion) out[completion.stepId] = completion;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function sanitizeStepCompletion(raw: unknown, fallbackStepId?: string): StepCompletion | undefined {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+  const entry = raw as Record<string, unknown>;
+  const stepId =
+    typeof entry.stepId === "string" && entry.stepId.trim()
+      ? entry.stepId.trim()
+      : fallbackStepId?.trim();
+  const result = typeof entry.result === "string" ? entry.result.trim() : "";
+  if (!stepId || !result) return undefined;
+  const completion: StepCompletion = { kind: "step_completed", stepId, result };
+  if (typeof entry.title === "string" && entry.title.trim()) completion.title = entry.title.trim();
+  if (typeof entry.notes === "string" && entry.notes.trim()) completion.notes = entry.notes.trim();
+  const evidence = sanitizeEvidenceList(entry.evidence);
+  if (evidence) completion.evidence = evidence;
+  return completion;
+}
+
+function sanitizeEvidenceList(raw: unknown): StepEvidence[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const out: StepEvidence[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) continue;
+    const entry = item as Record<string, unknown>;
+    const kind = entry.kind;
+    if (kind !== "verification" && kind !== "diff" && kind !== "checkpoint" && kind !== "manual") {
+      continue;
+    }
+    const summary = typeof entry.summary === "string" ? entry.summary.trim() : "";
+    if (!summary) continue;
+    const evidence: StepEvidence = { kind, summary };
+    if (typeof entry.command === "string" && entry.command.trim()) {
+      evidence.command = entry.command.trim();
+    }
+    const paths = stringList(entry.paths);
+    if (paths) evidence.paths = paths;
+    out.push(evidence);
+  }
+  return out.length > 0 ? out : undefined;
 }
 
 /** Falls back to raw ISO string past a week — "47 days ago" misleads more than it helps. */

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -545,6 +545,8 @@ export const EN: TranslationSchema = {
       title: "Checkpoint — step done",
       continue: "Continue — run the next step",
       continueHint: "Model resumes with the next step.",
+      finish: "Finish — summarize and close",
+      finishHint: "Model records the final step and summarizes the completed plan.",
       revise: "Revise — give feedback before the next step",
       reviseHint: "Stay paused, type guidance; model adjusts the remaining plan.",
       stop: "Stop — end the plan here",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -367,6 +367,8 @@ export interface TranslationSchema {
       title: string;
       continue: string;
       continueHint: string;
+      finish: string;
+      finishHint: string;
       revise: string;
       reviseHint: string;
       stop: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -526,6 +526,8 @@ export const zhCN: TranslationSchema = {
       title: "检查点 —— 当前步骤已完成",
       continue: "继续 —— 执行下一步",
       continueHint: "模型从下一步继续。",
+      finish: "完成 —— 总结并收尾",
+      finishHint: "模型记录最后一步，然后总结已完成的计划。",
       revise: "调整 —— 在下一步前给反馈",
       reviseHint: "先暂停，输入指引；模型会调整剩余计划。",
       stop: "停止 —— 在此结束计划",

--- a/src/tools/plan-core.ts
+++ b/src/tools/plan-core.ts
@@ -1,15 +1,15 @@
 import { pauseGate } from "../core/pause-gate.js";
 import type { ToolRegistry } from "../tools.js";
 import { PlanProposedError, PlanRevisionProposedError } from "./plan-errors.js";
-import type { PlanStep, PlanStepRisk, StepCompletion } from "./plan-types.js";
+import type { PlanStep, PlanStepRisk, StepCompletion, StepEvidence } from "./plan-types.js";
 
 // Tool descriptions (teaching prompts for the model). Edit here, not inline.
 
 const SUBMIT_PLAN_DESCRIPTION =
-  "Submit ONE concrete plan you've already decided on. Use this for tasks that warrant a review gate — multi-file refactors, architecture changes, anything that would be expensive or confusing to undo. Skip it for small fixes (one-line typo, obvious bug with a clear fix) — just make the change. The user will either approve (you then implement it), ask for refinement, or cancel. If the user has already enabled /plan mode, writes are blocked at dispatch and you MUST use this. CRITICAL: do NOT use submit_plan to present alternative routes (A/B/C, option 1/2/3) for the user to pick from — the picker only exposes approve/refine/cancel, so a menu plan strands the user with no way to choose. For branching decisions, call `ask_choice` instead; only call submit_plan once the user has picked a direction and you have a single actionable plan. Write the plan as markdown with a one-line summary, a bulleted list of files to touch and what will change, and any risks or open questions. STRONGLY PREFERRED: pass `steps` — an array of {id, title, action, risk?} — so the UI renders a structured step list above the approval picker and tracks per-step progress. Use risk='high' for steps that touch prod data / break public APIs / are hard to undo; 'med' for non-trivial but reversible (multi-file edits, schema tweaks); 'low' for safe local work. After each step, call `mark_step_complete` so the user sees progress ticks.";
+  "Submit ONE concrete plan you've already decided on. Use this for tasks that warrant a review gate — multi-file refactors, architecture changes, anything that would be expensive or confusing to undo. Skip it for small fixes (one-line typo, obvious bug with a clear fix) — just make the change. The user will either approve (you then implement it), ask for refinement, or cancel. If the user has already enabled /plan mode, writes are blocked at dispatch and you MUST use this. CRITICAL: do NOT use submit_plan to present alternative routes (A/B/C, option 1/2/3) for the user to pick from — the picker only exposes approve/refine/cancel, so a menu plan strands the user with no way to choose. For branching decisions, call `ask_choice` instead; only call submit_plan once the user has picked a direction and you have a single actionable plan. Write the plan as markdown with a one-line summary, a bulleted list of files to touch and what will change, and any risks or open questions. STRONGLY PREFERRED: pass `steps` — an array of {id, title, action, risk?, targets?, acceptance?, verification?} — so the UI renders a structured step list above the approval picker and tracks per-step progress. Use risk='high' for steps that touch prod data / break public APIs / are hard to undo; 'med' for non-trivial but reversible (multi-file edits, schema tweaks); 'low' for safe local work. After each step, call `mark_step_complete` so the user sees progress ticks.";
 
 const MARK_STEP_COMPLETE_DESCRIPTION =
-  "Mark one step of the approved plan as done. MANDATORY: call this exactly once after finishing each step, before starting the next one — skipping it leaves the user staring at `0/N done` on the resume banner even when the work is finished, and they have no way to know which steps actually ran. The TUI updates the plan card's progress in place; the count is persisted to disk so it survives session resume. After the FINAL step, write a brief reply summarizing what was done and end the turn. Pass the `stepId` from the plan's steps array, a short `result` (what you did), and optional `notes` for anything surprising (errors, scope changes, follow-ups). This tool doesn't change any files. Don't call it if the plan didn't include structured steps, and don't invent ids that weren't in the original plan. If you only realized at the end that you skipped marking steps, mark them then — late is still better than never.";
+  "Mark one step of the approved plan as done. MANDATORY: call this exactly once after finishing each step, before starting the next one — skipping it leaves the user staring at `0/N done` on the resume banner even when the work is finished, and they have no way to know which steps actually ran. The TUI updates the plan card's progress in place; the count is persisted to disk so it survives session resume. After the FINAL step, write a brief reply summarizing what was done and end the turn. Pass the `stepId` from the plan's steps array, a short `result` (what you did), optional `notes` for anything surprising, and `evidence` when the step had medium/high risk, verification criteria, or code mutations. This tool doesn't change any files. Don't call it if the plan didn't include structured steps, and don't invent ids that weren't in the original plan. If you only realized at the end that you skipped marking steps, mark them then — late is still better than never.";
 
 const REVISE_PLAN_DESCRIPTION =
   "Surgically replace the REMAINING steps of an in-flight plan. Call this when the user has given feedback at a checkpoint that warrants a structured plan change — skip a step, swap two steps, add a new step, change risk, etc. Pass: `reason` (one sentence why), `remainingSteps` (the new tail of the plan, replacing whatever steps haven't been done yet), and optional `summary` (updated one-line plan summary). Done steps are NEVER touched — keep them out of `remainingSteps`. The TUI shows a diff (removed in red, kept in gray, added in green) and the user accepts or rejects. Don't call this for trivial mid-step adjustments — just keep executing. Don't call submit_plan for revisions either — that resets the whole plan including completed steps. Use submit_plan only when the entire approach has changed; use revise_plan when the tail needs editing.";
@@ -29,6 +29,23 @@ const STEP_ITEM_SCHEMA = {
       description:
         "Self-assessed risk. 'high' = hard-to-undo / touches prod / breaks API; 'med' = non-trivial but reversible; 'low' = safe local work. The UI shows a colored dot per step so the user knows where to focus review. Omit if you're unsure.",
     },
+    targets: {
+      type: "array",
+      description:
+        "Optional. Files, directories, or modules this step expects to touch. Used by the host lifecycle guard for risk/evidence tracking.",
+      items: { type: "string" },
+    },
+    acceptance: {
+      type: "string",
+      description:
+        "Optional. One-sentence acceptance criterion for this step; what must be true before it is marked complete.",
+    },
+    verification: {
+      type: "array",
+      description:
+        "Optional. Verification commands or checks expected before this step is marked complete.",
+      items: { type: "string" },
+    },
   },
   required: ["id", "title", "action"],
 };
@@ -39,6 +56,7 @@ export interface PlanToolOptions {
   onPlanSubmitted?: (plan: string, steps?: PlanStep[]) => void;
   onStepCompleted?: (update: StepCompletion) => void;
   onPlanRevisionProposed?: (reason: string, remainingSteps: PlanStep[], summary?: string) => void;
+  requireStepEvidence?: (args: { stepId: string; title?: string }) => string | null | undefined;
 }
 
 // Arg sanitizers — defensive cleanup shared between submit_plan and revise_plan
@@ -61,9 +79,45 @@ function sanitizeSteps(raw: unknown): PlanStep[] | undefined {
     const step: PlanStep = { id, title, action };
     const risk = sanitizeRisk(e.risk);
     if (risk) step.risk = risk;
+    const targets = sanitizeStringList(e.targets);
+    if (targets) step.targets = targets;
+    const acceptance = typeof e.acceptance === "string" ? e.acceptance.trim() : "";
+    if (acceptance) step.acceptance = acceptance;
+    const verification = sanitizeStringList(e.verification);
+    if (verification) step.verification = verification;
     steps.push(step);
   }
   return steps.length > 0 ? steps : undefined;
+}
+
+function sanitizeStringList(raw: unknown): string[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const out = raw
+    .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+    .filter((entry) => entry.length > 0);
+  return out.length > 0 ? out : undefined;
+}
+
+function sanitizeEvidence(raw: unknown): StepEvidence[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const out: StepEvidence[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== "object") continue;
+    const e = item as Record<string, unknown>;
+    const kind = e.kind;
+    if (kind !== "verification" && kind !== "diff" && kind !== "checkpoint" && kind !== "manual") {
+      continue;
+    }
+    const summary = typeof e.summary === "string" ? e.summary.trim() : "";
+    if (!summary) continue;
+    const evidence: StepEvidence = { kind, summary };
+    const command = typeof e.command === "string" ? e.command.trim() : "";
+    if (command) evidence.command = command;
+    const paths = sanitizeStringList(e.paths);
+    if (paths) evidence.paths = paths;
+    out.push(evidence);
+  }
+  return out.length > 0 ? out : undefined;
 }
 
 // Individual tool registrations — one per screen
@@ -148,10 +202,34 @@ function registerMarkStepComplete(registry: ToolRegistry, opts: PlanToolOptions)
           description:
             "Optional. Anything surprising — blockers hit, assumptions revised, follow-ups for later steps.",
         },
+        evidence: {
+          type: "array",
+          description:
+            "Optional. Evidence that this step is complete: verification command output summary, diff/checkpoint reference, or a manual note when no command applies.",
+          items: {
+            type: "object",
+            properties: {
+              kind: { type: "string", enum: ["verification", "diff", "checkpoint", "manual"] },
+              summary: { type: "string" },
+              command: { type: "string" },
+              paths: { type: "array", items: { type: "string" } },
+            },
+            required: ["kind", "summary"],
+          },
+        },
       },
       required: ["stepId", "result"],
     },
-    fn: async (args: { stepId: string; title?: string; result: string; notes?: string }, ctx) => {
+    fn: async (
+      args: {
+        stepId: string;
+        title?: string;
+        result: string;
+        notes?: string;
+        evidence?: unknown;
+      },
+      ctx,
+    ) => {
       const stepId = (args?.stepId ?? "").trim();
       const result = (args?.result ?? "").trim();
       if (!stepId) {
@@ -164,9 +242,15 @@ function registerMarkStepComplete(registry: ToolRegistry, opts: PlanToolOptions)
       }
       const title = typeof args?.title === "string" ? args.title.trim() || undefined : undefined;
       const notes = typeof args?.notes === "string" ? args.notes.trim() || undefined : undefined;
+      const evidence = sanitizeEvidence(args?.evidence);
+      const evidenceReason = opts.requireStepEvidence?.({ stepId, title });
+      if (evidenceReason && (!evidence || evidence.length === 0)) {
+        throw new Error(`mark_step_complete: evidence required — ${evidenceReason}`);
+      }
       const update: StepCompletion = { kind: "step_completed", stepId, result };
       if (title) update.title = title;
       if (notes) update.notes = notes;
+      if (evidence) update.evidence = evidence;
       opts.onStepCompleted?.(update);
       // Block until the user continues, revises, or stops
       const verdict = await (ctx?.confirmationGate ?? pauseGate).ask({

--- a/src/tools/plan-types.ts
+++ b/src/tools/plan-types.ts
@@ -5,6 +5,18 @@ export interface PlanStep {
   title: string;
   action: string;
   risk?: PlanStepRisk;
+  targets?: string[];
+  acceptance?: string;
+  verification?: string[];
+}
+
+export type StepEvidenceKind = "verification" | "diff" | "checkpoint" | "manual";
+
+export interface StepEvidence {
+  kind: StepEvidenceKind;
+  summary: string;
+  command?: string;
+  paths?: string[];
 }
 
 export interface StepCompletion {
@@ -13,4 +25,5 @@ export interface StepCompletion {
   title?: string;
   result: string;
   notes?: string;
+  evidence?: StepEvidence[];
 }

--- a/src/tools/plan.ts
+++ b/src/tools/plan.ts
@@ -1,4 +1,10 @@
 export { PlanProposedError, PlanRevisionProposedError } from "./plan-errors.js";
-export type { PlanStep, PlanStepRisk, StepCompletion } from "./plan-types.js";
+export type {
+  PlanStep,
+  PlanStepRisk,
+  StepCompletion,
+  StepEvidence,
+  StepEvidenceKind,
+} from "./plan-types.js";
 export { registerPlanTool } from "./plan-core.js";
 export type { PlanToolOptions } from "./plan-core.js";

--- a/tests/plan-checkpoint-confirm.test.tsx
+++ b/tests/plan-checkpoint-confirm.test.tsx
@@ -1,0 +1,29 @@
+import { render } from "ink-testing-library";
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { PlanCheckpointConfirm } from "../src/cli/ui/PlanCheckpointConfirm.js";
+
+describe("PlanCheckpointConfirm", () => {
+  it("labels the primary action as finish when the last step is complete", () => {
+    const { lastFrame, unmount } = render(
+      <PlanCheckpointConfirm
+        stepId="step-3"
+        title="Run tests"
+        completed={3}
+        total={3}
+        steps={[
+          { id: "step-1", title: "Create file", action: "Create file" },
+          { id: "step-2", title: "Update import", action: "Update import" },
+          { id: "step-3", title: "Run tests", action: "Run tests" },
+        ]}
+        completedStepIds={new Set(["step-1", "step-2", "step-3"])}
+        onChoose={() => {}}
+      />,
+    );
+
+    const out = lastFrame() ?? "";
+    expect(out).toContain("Finish");
+    expect(out).not.toContain("Continue — run the next step");
+    unmount();
+  });
+});

--- a/tests/plan-store.test.ts
+++ b/tests/plan-store.test.ts
@@ -57,7 +57,7 @@ describe("plan-store roundtrip", () => {
     expect(loaded).not.toBeNull();
     expect(loaded?.steps).toEqual(steps);
     expect(loaded?.completedStepIds).toEqual(["step-1"]);
-    expect(loaded?.version).toBe(1);
+    expect(loaded?.version).toBe(2);
     expect(typeof loaded?.updatedAt).toBe("string");
   });
 
@@ -162,6 +162,26 @@ describe("plan-store roundtrip", () => {
     expect(loaded?.steps[1]?.risk).toBe("low");
   });
 
+  it("loads v2 lifecycle metadata fields and persists them on save", () => {
+    const steps = [
+      {
+        id: "step-1",
+        title: "refactor",
+        action: "change gates",
+        risk: "med" as const,
+        targets: ["src/tools.ts"],
+        acceptance: "high-risk mutations are gated",
+        verification: ["npm test tests/lifecycle.test.ts"],
+      },
+    ];
+    savePlanState("v2-fields", steps, []);
+
+    const loaded = loadPlanState("v2-fields");
+
+    expect(loaded?.version).toBe(2);
+    expect(loaded?.steps).toEqual(steps);
+  });
+
   it("filters out non-string entries from completedStepIds", () => {
     writeFixture(
       planStatePath("badcompleted"),
@@ -211,7 +231,40 @@ describe("archivePlanState", () => {
     const parsed = JSON.parse(raw);
     expect(parsed.steps).toEqual(steps);
     expect(parsed.completedStepIds).toEqual(["step-1"]);
-    expect(parsed.version).toBe(1);
+    expect(parsed.version).toBe(2);
+  });
+
+  it("persists step completion evidence in active and archived plan state", () => {
+    const steps = [
+      {
+        id: "step-1",
+        title: "verify",
+        action: "run tests",
+        verification: ["npm test"],
+      },
+    ];
+    const completion = {
+      kind: "step_completed" as const,
+      stepId: "step-1",
+      result: "npm test passed",
+      evidence: [
+        {
+          kind: "verification" as const,
+          summary: "npm test exited 0",
+          command: "npm test",
+        },
+      ],
+    };
+
+    savePlanState("evidence-test", steps, ["step-1"], {
+      stepCompletions: new Map([["step-1", completion]]),
+    });
+
+    expect(loadPlanState("evidence-test")?.stepCompletions?.["step-1"]).toEqual(completion);
+    const archive = archivePlanState("evidence-test");
+    expect(archive).not.toBeNull();
+    const archived = listPlanArchives("evidence-test")[0];
+    expect(archived?.stepCompletions?.["step-1"]).toEqual(completion);
   });
 
   it("two archives within the same millisecond don't collide", () => {

--- a/tests/plan.test.ts
+++ b/tests/plan.test.ts
@@ -311,6 +311,41 @@ describe("registerPlanTool + submit_plan", () => {
     ]);
   });
 
+  it("accepts optional lifecycle metadata on steps", async () => {
+    const reg = new ToolRegistry();
+    const submitted: Array<{ steps?: unknown }> = [];
+    registerPlanTool(reg, { onPlanSubmitted: (_p, steps) => submitted.push({ steps }) });
+    reg.setPlanMode(true);
+    const gate = new AutoGate({ type: "approve" });
+    await reg.dispatch(
+      "submit_plan",
+      JSON.stringify({
+        plan: "# Plan",
+        steps: [
+          {
+            id: "step-1",
+            title: "refactor",
+            action: "change tool gates",
+            targets: ["src/tools.ts", "src/cli/ui/App.tsx"],
+            acceptance: "high-risk mutations require an approved plan",
+            verification: ["npm test tests/lifecycle.test.ts"],
+          },
+        ],
+      }),
+      { confirmationGate: gate },
+    );
+    expect(submitted[0]?.steps).toEqual([
+      {
+        id: "step-1",
+        title: "refactor",
+        action: "change tool gates",
+        targets: ["src/tools.ts", "src/cli/ui/App.tsx"],
+        acceptance: "high-risk mutations require an approved plan",
+        verification: ["npm test tests/lifecycle.test.ts"],
+      },
+    ]);
+  });
+
   it("drops malformed risk values rather than letting them through", async () => {
     const reg = new ToolRegistry();
     const submitted: Array<{ steps?: unknown }> = [];
@@ -455,6 +490,52 @@ describe("registerPlanTool + mark_step_complete", () => {
     expect(parsed.notes).toBeUndefined();
     expect(parsed.result).toBe("done");
     expect(parsed.error).toBeUndefined();
+  });
+
+  it("preserves structured evidence when supplied", async () => {
+    const reg = new ToolRegistry();
+    const seen: StepCompletion[] = [];
+    registerPlanTool(reg, { onStepCompleted: (u) => seen.push(u) });
+    const gate = new AutoGate({ type: "continue" });
+    await reg.dispatch(
+      "mark_step_complete",
+      JSON.stringify({
+        stepId: "step-1",
+        result: "updated lifecycle guard",
+        evidence: [
+          {
+            kind: "verification",
+            summary: "targeted tests passed",
+            command: "npm test tests/lifecycle.test.ts",
+            paths: ["tests/lifecycle.test.ts"],
+          },
+        ],
+      }),
+      { confirmationGate: gate },
+    );
+
+    expect(seen[0]?.evidence).toEqual([
+      {
+        kind: "verification",
+        summary: "targeted tests passed",
+        command: "npm test tests/lifecycle.test.ts",
+        paths: ["tests/lifecycle.test.ts"],
+      },
+    ]);
+  });
+
+  it("rejects completion without evidence when the host requires it", async () => {
+    const reg = new ToolRegistry();
+    registerPlanTool(reg, {
+      requireStepEvidence: () => "step touched high-risk code",
+    });
+    const out = await reg.dispatch(
+      "mark_step_complete",
+      JSON.stringify({ stepId: "step-1", result: "updated lifecycle guard" }),
+    );
+
+    expect(JSON.parse(out).error).toMatch(/evidence required/);
+    expect(JSON.parse(out).error).toMatch(/high-risk code/);
   });
 
   it("rejects an empty stepId", async () => {


### PR DESCRIPTION
## Summary

- Extend structured plan steps with optional `targets`, `acceptance`, and `verification` fields while keeping v1 plans readable.
- Add structured `evidence` to `mark_step_complete` and expose a host-side `requireStepEvidence` hook.
- Persist step completions and evidence in plan store v2, including archived plans.
- Preserve completion evidence through the TUI event path and polish the final checkpoint label to finish/summarize.

## Split context

Split out of #1296 after maintainer review on #1293. This is additive plan/evidence work and does not add lifecycle rails.

## Validation

- `npm test -- tests/plan.test.ts tests/plan-store.test.ts tests/plan-checkpoint-confirm.test.tsx`
- `npm run typecheck`

The local pre-push full `verify` is blocked by the heap-limit launcher issue that is being submitted as a separate fix PR.