### PR TITLE
style(desktop): add unified button:disabled style

### DIFF
--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -132,6 +132,11 @@ button {
   cursor: pointer;
   padding: 0;
 }
+button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  pointer-events: none;
+}
 
 ::-webkit-scrollbar {
   width: 4px;
@@ -2800,6 +2805,7 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
   background: var(--panel-2);
   color: var(--muted-2);
   cursor: not-allowed;
+  opacity: 1;
 }
 
 /* hint row above composer */


### PR DESCRIPTION
## What

Add a unified button:disabled CSS rule so disabled buttons consistently appear faded and suppress hover effects across light/dark themes.

## Why

The global button reset removes browser-native disabled rendering. Buttons with disabled prop (Copy, Export) look nearly identical to enabled.

## How to verify

1. Build the desktop app, open a session with no messages.
2. Copy and Export buttons in the header should appear faded with no hover.

<img width="670" height="110" alt="image" src="https://github.com/user-attachments/assets/61f96969-298d-4a99-a659-7e6ecdca9901" />
<img width="650" height="124" alt="image" src="https://github.com/user-attachments/assets/6ff9b1b1-d30f-445d-a65e-0c5c29bd02a6" />

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time
