### PR TITLE
feat(lifecycle): add opt-in engineering lifecycle

### DIFF
--- a/src/cli/commands/code.tsx
+++ b/src/cli/commands/code.tsx
@@ -21,7 +21,7 @@
 import { readFileSync } from "node:fs";
 import { basename, resolve } from "node:path";
 import { buildCodeToolset } from "../../code/setup.js";
-import { loadApiKey, loadPreset, readConfig } from "../../config.js";
+import { loadApiKey, loadEngineeringLifecycleMode, loadPreset, readConfig } from "../../config.js";
 import { loadDotenv } from "../../env.js";
 import { t } from "../../i18n/index.js";
 import { detectForeignAgentPlatform } from "../../memory/project.js";
@@ -149,6 +149,7 @@ export async function codeCommand(opts: CodeOptions = {}): Promise<void> {
       systemAppend: opts.systemAppend,
       systemAppendFile: systemAppendFileContents,
       modelId: resolvedModel,
+      engineeringLifecycleMode: loadEngineeringLifecycleMode(),
     });
   await chatCommand({
     model: resolvedModel,

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -22,6 +22,7 @@ import {
   snapshotBeforeEdits,
   toWholeFileEditBlock,
 } from "../../code/edit-blocks.js";
+import { EngineeringLifecycleRuntime } from "../../code/lifecycle.js";
 import { clearPendingEdits, loadPendingEdits } from "../../code/pending-edits.js";
 import {
   clearPlanState,
@@ -31,10 +32,12 @@ import {
 } from "../../code/plan-store.js";
 import {
   type EditMode,
+  type EngineeringLifecycleMode,
   type PresetName,
   defaultConfigPath,
   editModeHintShown,
   loadBaseUrl,
+  loadEngineeringLifecycleMode,
   loadReasoningEffort,
   loadTheme,
   markEditModeHintShown,
@@ -594,6 +597,15 @@ function AppInner({
     model,
     initialPreset,
   );
+  const engineeringLifecycleBaseModeRef = useRef<EngineeringLifecycleMode>(
+    loadEngineeringLifecycleMode(),
+  );
+  const engineeringLifecycleRef = useRef<EngineeringLifecycleRuntime | null>(null);
+  if (engineeringLifecycleRef.current === null) {
+    engineeringLifecycleRef.current = new EngineeringLifecycleRuntime({
+      mode: engineeringLifecycleBaseModeRef.current,
+    });
+  }
   // Refs that mirror state for stable read-callbacks handed to the
   // embedded dashboard server. The server's `getXxx()` closures are
   // captured once at startDashboard time; without ref-mirrors the
@@ -1567,6 +1579,10 @@ function AppInner({
         stepCompletionsRef.current = new Map(Object.entries(restoredPlan.stepCompletions ?? {}));
         planBodyRef.current = restoredPlan.body ?? null;
         planSummaryRef.current = restoredPlan.summary ?? null;
+        engineeringLifecycleRef.current?.recordPlanApproved(restoredPlan.steps);
+        for (const stepId of restoredPlan.completedStepIds) {
+          engineeringLifecycleRef.current?.recordStepCompleted(stepId);
+        }
         const when = relativeTime(restoredPlan.updatedAt);
         const done = new Set(restoredPlan.completedStepIds);
         const summary = restoredPlan.summary ? ` - ${restoredPlan.summary}` : "";
@@ -1894,6 +1910,22 @@ function AppInner({
     }
   });
 
+  useEffect(() => {
+    if (!tools || !codeMode) return;
+    return tools.addToolInterceptor("engineering-lifecycle", (name, args) => {
+      return engineeringLifecycleRef.current?.guardToolCall(name, args) ?? null;
+    });
+  }, [tools, codeMode]);
+
+  useEffect(() => {
+    if (!tools || !codeMode) return;
+    tools.setResultAugmenter((name, args, result) => {
+      engineeringLifecycleRef.current?.recordToolResult(name, args, result);
+      return result;
+    });
+    return () => tools.setResultAugmenter(null);
+  }, [tools, codeMode]);
+
   // Edit-gate interceptor. Reroutes `edit_file` / `write_file` tool
   // calls through the review queue (in `review` mode) or the auto-apply
   // snapshot/banner path (in `auto` mode) so the model's tool usage
@@ -2037,6 +2069,19 @@ function AppInner({
     (on: boolean) => {
       setPlanMode(on);
       tools?.setPlanMode(on);
+      if (on) {
+        engineeringLifecycleRef.current?.setMode("strict");
+      } else {
+        const state = engineeringLifecycleRef.current?.snapshot().state;
+        if (
+          state === undefined ||
+          state === "idle" ||
+          state === "complete" ||
+          state === "cancelled"
+        ) {
+          engineeringLifecycleRef.current?.setMode(engineeringLifecycleBaseModeRef.current);
+        }
+      }
     },
     [tools],
   );
@@ -2832,6 +2877,7 @@ function AppInner({
             completedStepIdsRef.current.add(stepId);
             persistPlanState();
             log.completePlanStep(stepId);
+            engineeringLifecycleRef.current?.recordStepCompleted(stepId);
             return "ok";
           },
           markAllPlanStepsDone: () => {
@@ -2842,6 +2888,7 @@ function AppInner({
               if (completedStepIdsRef.current.has(s.id)) continue;
               completedStepIdsRef.current.add(s.id);
               log.completePlanStep(s.id);
+              engineeringLifecycleRef.current?.recordStepCompleted(s.id);
               added++;
             }
             if (added > 0) persistPlanState();
@@ -2980,6 +3027,17 @@ function AppInner({
           log.pushWarning(t("app.hookUserPromptSubmit"), formatHookOutcomeMessage(o));
         }
         if (promptReport.blocked) return;
+      }
+
+      if (codeMode) {
+        const before = engineeringLifecycleRef.current?.snapshot().state;
+        engineeringLifecycleRef.current?.observeUserPrompt(text);
+        const after = engineeringLifecycleRef.current?.snapshot().state;
+        if (before === "idle" && after === "armed") {
+          log.pushInfo(
+            "Engineering lifecycle armed: high-risk mutations now require an approved structured plan.",
+          );
+        }
       }
 
       // Large pastes (stack traces, log dumps, file contents) get a
@@ -3232,6 +3290,8 @@ function AppInner({
               planBodyRef,
               planSummaryRef,
               persistPlanState,
+              onPlanStepCompleted: (stepId) =>
+                engineeringLifecycleRef.current?.recordStepCompleted(stepId),
               log,
               session: session ?? null,
               codeModeOn: !!codeMode,
@@ -3589,6 +3649,7 @@ function AppInner({
         // can dock it at the bottom —without this dispatch, no card with
         // variant: "active" exists and the live strip stays empty.
         const approvedSteps = planStepsRef.current;
+        engineeringLifecycleRef.current?.recordPlanApproved(approvedSteps ?? []);
         if (approvedSteps && approvedSteps.length > 0) {
           completedStepIdsRef.current = new Set();
           stepCompletionsRef.current = new Map();
@@ -3615,6 +3676,7 @@ function AppInner({
         planBodyRef.current = null;
         planSummaryRef.current = null;
         persistPlanState();
+        engineeringLifecycleRef.current?.cancel();
         togglePlanMode(false);
         agentStore.dispatch({ type: "plan.drop" });
         marker = trimmed ? `plan rejected - ${tail}` : "plan cancelled";
@@ -3761,6 +3823,7 @@ function AppInner({
           planSummaryRef.current = p.summary ?? null;
           planBodyRef.current = p.plan;
           stepCompletionsRef.current = new Map();
+          engineeringLifecycleRef.current?.recordPlanProposed(p.steps);
           break;
         }
         case "plan_checkpoint": {
@@ -4032,6 +4095,10 @@ function AppInner({
         merged.push(s);
       }
       planStepsRef.current = merged;
+      engineeringLifecycleRef.current?.recordPlanApproved(merged);
+      for (const s of merged) {
+        if (completed.has(s.id)) engineeringLifecycleRef.current?.recordStepCompleted(s.id);
+      }
       persistPlanState();
       // Replace the live active card so PlanLiveRow shows the new tail —      // existing card's stale ids would fail subsequent step completes.
       agentStore.dispatch({ type: "plan.drop" });

--- a/src/cli/ui/slash/commands.ts
+++ b/src/cli/ui/slash/commands.ts
@@ -261,10 +261,10 @@ export const SLASH_COMMANDS: readonly SlashCommandSpec[] = [
   {
     cmd: "plan",
     group: "code",
-    argsHint: "[on|off]",
-    summary: "toggle read-only plan mode (writes bounced until submit_plan + approval)",
+    argsHint: "[on|off|strict]",
+    summary: "toggle read-only plan mode / strict lifecycle rails",
     contextual: "code",
-    argCompleter: ["on", "off"],
+    argCompleter: ["on", "off", "strict"],
   },
   {
     cmd: "checkpoint",

--- a/src/cli/ui/slash/handlers/edits.ts
+++ b/src/cli/ui/slash/handlers/edits.ts
@@ -69,7 +69,7 @@ const plan: SlashHandler = (args, _loop, ctx) => {
   const currentOn = Boolean(ctx.planMode);
   const raw = (args[0] ?? "").toLowerCase();
   let target: boolean;
-  if (raw === "on" || raw === "true" || raw === "1") target = true;
+  if (raw === "on" || raw === "true" || raw === "1" || raw === "strict") target = true;
   else if (raw === "off" || raw === "false" || raw === "0") target = false;
   else target = !currentOn;
   ctx.setPlanMode(target);

--- a/src/code/lifecycle.ts
+++ b/src/code/lifecycle.ts
@@ -1,0 +1,358 @@
+import type { ToolInterceptor } from "../tools.js";
+import type { PlanStep, StepEvidence } from "../tools/plan.js";
+
+export type EngineeringLifecycleMode = "off" | "strict";
+export type EngineeringLifecycleState =
+  | "idle"
+  | "armed"
+  | "planning"
+  | "approved"
+  | "executing"
+  | "checkpoint"
+  | "complete"
+  | "cancelled";
+
+export interface EngineeringLifecycleSnapshot {
+  mode: EngineeringLifecycleMode;
+  state: EngineeringLifecycleState;
+  planSteps: PlanStep[];
+  completedStepIds: string[];
+  mutatedSinceLastStep: boolean;
+}
+
+export interface EngineeringLifecycleOptions {
+  mode?: EngineeringLifecycleMode;
+}
+
+const SAFE_TOOL_NAMES = new Set([
+  "read_file",
+  "list_directory",
+  "directory_tree",
+  "search_files",
+  "search_content",
+  "glob",
+  "get_file_info",
+  "semantic_search",
+  "web_search",
+  "web_fetch",
+  "recall_memory",
+  "todo_write",
+  "ask_choice",
+  "submit_plan",
+  "mark_step_complete",
+  "revise_plan",
+  "job_output",
+  "wait_for_job",
+  "list_jobs",
+]);
+
+const HIGH_RISK_TOOL_NAMES = new Set([
+  "multi_edit",
+  "move_file",
+  "delete_file",
+  "delete_directory",
+  "copy_file",
+  "create_directory",
+  "run_background",
+  "stop_job",
+]);
+
+const MUTATION_TOOL_NAMES = new Set([
+  "edit_file",
+  "write_file",
+  "multi_edit",
+  "move_file",
+  "delete_file",
+  "delete_directory",
+  "copy_file",
+  "create_directory",
+  "run_background",
+  "stop_job",
+]);
+
+export function isHighRiskLifecycleToolCall(name: string, args: Record<string, unknown>): boolean {
+  if (HIGH_RISK_TOOL_NAMES.has(name)) return true;
+  if (SAFE_TOOL_NAMES.has(name)) return false;
+  if (name === "write_file") {
+    const path = typeof args.path === "string" ? args.path : "";
+    return isPackageOrConfigPath(path);
+  }
+  if (name === "edit_file") {
+    const path = typeof args.path === "string" ? args.path : "";
+    return isPackageOrConfigPath(path);
+  }
+  if (name === "run_command") {
+    const command = typeof args.command === "string" ? args.command : "";
+    return isHighRiskCommand(command);
+  }
+  return false;
+}
+
+export function isLifecycleMutationToolCall(name: string, args: Record<string, unknown>): boolean {
+  if (MUTATION_TOOL_NAMES.has(name)) return true;
+  if (name === "run_command") {
+    const command = typeof args.command === "string" ? args.command : "";
+    return isHighRiskCommand(command);
+  }
+  return false;
+}
+
+export class EngineeringLifecycleRuntime {
+  private _mode: EngineeringLifecycleMode;
+  private _state: EngineeringLifecycleState = "idle";
+  private _planSteps: PlanStep[] = [];
+  private readonly _completedStepIds = new Set<string>();
+  private _mutatedSinceLastStep = false;
+
+  constructor(opts: EngineeringLifecycleOptions = {}) {
+    this._mode = opts.mode ?? "off";
+    if (this._mode === "strict") this._state = "armed";
+  }
+
+  get mode(): EngineeringLifecycleMode {
+    return this._mode;
+  }
+
+  setMode(mode: EngineeringLifecycleMode): void {
+    this._mode = mode;
+    if (mode === "off") {
+      this.reset();
+      return;
+    }
+    if (mode === "strict" && this._state === "idle") this._state = "armed";
+  }
+
+  observeUserPrompt(_text: string): void {
+    if (this._mode === "off") return;
+    if (this._state === "complete" || this._state === "cancelled") {
+      this.reset();
+    }
+    if (this._state === "idle") this._state = "armed";
+  }
+
+  recordPlanProposed(steps?: readonly PlanStep[]): void {
+    if (this._mode === "off") return;
+    this._state = "planning";
+    this._planSteps = [...(steps ?? [])];
+    this._completedStepIds.clear();
+    this._mutatedSinceLastStep = false;
+  }
+
+  recordPlanApproved(steps?: readonly PlanStep[]): void {
+    if (this._mode === "off") return;
+    this._state = "approved";
+    this._planSteps = [...(steps ?? this._planSteps)];
+    this._completedStepIds.clear();
+    this._mutatedSinceLastStep = false;
+  }
+
+  recordStepCompleted(stepId: string): void {
+    if (!stepId) return;
+    this._completedStepIds.add(stepId);
+    this._mutatedSinceLastStep = false;
+    if (this._planSteps.length > 0 && this._completedStepIds.size >= this._planSteps.length) {
+      this._state = "complete";
+    } else if (this._state !== "idle" && this._state !== "cancelled") {
+      this._state = "executing";
+    }
+  }
+
+  recordToolResult(name: string, args: Record<string, unknown>, result: string): void {
+    if (this._mode === "off") return;
+    if (!isLifecycleMutationToolCall(name, args)) return;
+    if (!toolResultLooksSuccessful(result)) return;
+    if (this._state === "approved" || this._state === "executing") {
+      this._state = "executing";
+      this._mutatedSinceLastStep = true;
+    }
+  }
+
+  cancel(): void {
+    this._state = "cancelled";
+    this._planSteps = [];
+    this._completedStepIds.clear();
+    this._mutatedSinceLastStep = false;
+  }
+
+  reset(): void {
+    this._state = this._mode === "strict" ? "armed" : "idle";
+    this._planSteps = [];
+    this._completedStepIds.clear();
+    this._mutatedSinceLastStep = false;
+  }
+
+  guardToolCall: ToolInterceptor = (name, args) => {
+    if (this._mode === "off") return null;
+    if (name === "mark_step_complete") return this.guardStepCompletion(args);
+    if (!isHighRiskLifecycleToolCall(name, args)) return null;
+
+    if (this._state !== "approved" && this._state !== "executing") {
+      return JSON.stringify({
+        error: `${name}: blocked by Engineering Lifecycle — high-risk engineering work requires an approved structured plan first. Explore with read-only tools, call ask_choice for real forks, then call submit_plan with concrete steps.`,
+        rejectedReason: "engineering-lifecycle",
+        state: this._state,
+      });
+    }
+
+    this._state = "executing";
+    return null;
+  };
+
+  snapshot(): EngineeringLifecycleSnapshot {
+    return {
+      mode: this._mode,
+      state: this._state,
+      planSteps: [...this._planSteps],
+      completedStepIds: [...this._completedStepIds],
+      mutatedSinceLastStep: this._mutatedSinceLastStep,
+    };
+  }
+
+  private guardStepCompletion(args: Record<string, unknown>): string | null {
+    const stepId = typeof args.stepId === "string" ? args.stepId.trim() : "";
+    const step = this._planSteps.find((s) => s.id === stepId);
+    const evidence = Array.isArray(args.evidence) ? (args.evidence as StepEvidence[]) : [];
+    const evidenceRequired =
+      this._mutatedSinceLastStep ||
+      step?.risk === "med" ||
+      step?.risk === "high" ||
+      (step?.verification?.length ?? 0) > 0;
+    if (evidenceRequired && evidence.length === 0) {
+      return JSON.stringify({
+        error:
+          "mark_step_complete: evidence required by Engineering Lifecycle — include verification, diff, checkpoint, or manual evidence before completing this step.",
+        rejectedReason: "engineering-lifecycle-evidence",
+        stepId,
+      });
+    }
+    return null;
+  }
+}
+
+function toolResultLooksSuccessful(result: string): boolean {
+  const text = result.trim();
+  if (!text) return false;
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    if (parsed && typeof parsed === "object" && "error" in parsed) return false;
+  } catch {
+    // Non-JSON tool results are normal.
+  }
+  if (/\b0\/\d+\s+applied\b/i.test(text)) return false;
+  return !/(user rejected|rejected this edit|discarded|unavailable in plan mode|interceptor failed|\berror\b|failed)/i.test(
+    text,
+  );
+}
+
+function isPackageOrConfigPath(path: string): boolean {
+  const normalized = path.replaceAll("\\", "/").toLowerCase();
+  return (
+    /(^|\/)package(-lock)?\.json$/.test(normalized) ||
+    /(^|\/)pnpm-lock\.yaml$/.test(normalized) ||
+    /(^|\/)yarn\.lock$/.test(normalized) ||
+    /(^|\/)tsconfig[^/]*\.json$/.test(normalized) ||
+    /(^|\/)vitest\.config\./.test(normalized) ||
+    /(^|\/)biome\.json$/.test(normalized) ||
+    normalized.startsWith(".github/workflows/")
+  );
+}
+
+function isHighRiskCommand(command: string): boolean {
+  const tokens = shellTokens(command);
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i]?.toLowerCase();
+    if (!token || !isCommandPosition(tokens, i)) continue;
+    if (
+      (token === "npm" || token === "pnpm" || token === "yarn") &&
+      isPackageMutation(tokens[i + 1])
+    ) {
+      return true;
+    }
+    if (token === "git" && isHighRiskGitCommand(tokens.slice(i + 1))) return true;
+    if (token === "rm" || token === "mv" || token === "cp") return true;
+  }
+  return false;
+}
+
+function shellTokens(command: string): string[] {
+  const out: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | null = null;
+  for (let i = 0; i < command.length; i++) {
+    const ch = command[i] ?? "";
+    if (quote) {
+      if (ch === quote) quote = null;
+      else current += ch;
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      quote = ch;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      if (current) {
+        out.push(current);
+        current = "";
+      }
+      continue;
+    }
+    if (ch === ";" || ch === "|" || ch === "&") {
+      if (current) {
+        out.push(current);
+        current = "";
+      }
+      const next = command[i + 1];
+      if ((ch === "|" || ch === "&") && next === ch) {
+        out.push(`${ch}${next}`);
+        i++;
+      } else {
+        out.push(ch);
+      }
+      continue;
+    }
+    current += ch;
+  }
+  if (current) out.push(current);
+  return out;
+}
+
+function isCommandPosition(tokens: string[], index: number): boolean {
+  if (index === 0) return true;
+  const previous = tokens[index - 1];
+  return previous === ";" || previous === "|" || previous === "&&" || previous === "||";
+}
+
+function isPackageMutation(token: string | undefined): boolean {
+  const normalized = token?.toLowerCase();
+  return (
+    normalized === "install" ||
+    normalized === "add" ||
+    normalized === "remove" ||
+    normalized === "update"
+  );
+}
+
+function isHighRiskGitCommand(args: string[]): boolean {
+  const subcommandIndex = args.findIndex((arg) => arg && !arg.startsWith("-"));
+  const subcommand = args[subcommandIndex]?.toLowerCase();
+  if (!subcommand) return false;
+  if (
+    subcommand === "push" ||
+    subcommand === "reset" ||
+    subcommand === "clean" ||
+    subcommand === "switch"
+  ) {
+    return true;
+  }
+  if (subcommand !== "checkout") return false;
+  const checkoutArgs = args.slice(subcommandIndex + 1);
+  if (checkoutArgs[0] === "--") return false;
+  if (checkoutArgs.some((arg) => arg === "-b" || arg === "-B" || arg === "--orphan")) return true;
+  const positional = checkoutArgs.filter((arg) => arg && !arg.startsWith("-"));
+  if (positional.length === 0) return false;
+  return !positional.every(looksLikePathCheckout);
+}
+
+function looksLikePathCheckout(arg: string): boolean {
+  return arg.includes("/") || arg.includes("\\") || arg.includes(".");
+}

--- a/src/code/prompt.ts
+++ b/src/code/prompt.ts
@@ -253,6 +253,14 @@ You have BOTH \`semantic_search\` (vector index) and \`search_content\` (literal
 
 If \`semantic_search\` returns nothing useful (low scores, off-topic), THEN fall back to \`search_content\`. Don't go the other way — grepping a paraphrased question wastes turns.`;
 
+const ENGINEERING_LIFECYCLE_CONTRACT = `
+
+# Engineering lifecycle contract
+
+Reasonix may enforce a prefix-stable Engineering Lifecycle for explicitly enabled high-risk engineering work. The runtime keeps lifecycle state outside the system prompt and tool list, so do not expect stage-specific prompt changes or new tools to appear. Treat any lifecycle block as a host constraint, not as a suggestion.
+
+When high-risk mutations are bounced with \`rejectedReason: "engineering-lifecycle"\`, switch to read-only exploration, then call \`submit_plan\` with concrete steps before trying the mutation again. Add optional per-step \`targets\`, \`acceptance\`, and \`verification\` fields when they clarify scope or success criteria. For medium/high-risk steps, steps with verification criteria, or steps that changed code, \`mark_step_complete\` requires \`evidence\` entries such as verification output, diff summary, checkpoint id, or manual rationale.`;
+
 export interface CodeSystemPromptOptions {
   /** True when semantic_search is registered for this run. Adds an
    *  explicit routing fragment so the model picks it for intent-style
@@ -266,10 +274,15 @@ export interface CodeSystemPromptOptions {
   systemAppendFile?: string;
   /** Model the loop will run on — interpolated into the escalation contract so the model can name itself correctly when asked (#582). */
   modelId?: string;
+  /** Include the lifecycle contract only for users who explicitly opt in. */
+  engineeringLifecycleMode?: "off" | "strict";
 }
 
 export function codeSystemPrompt(rootDir: string, opts: CodeSystemPromptOptions = {}): string {
-  const codeBase = codeSystemBase(opts.modelId ?? DEFAULT_CODE_MODEL);
+  let codeBase = codeSystemBase(opts.modelId ?? DEFAULT_CODE_MODEL);
+  if (opts.engineeringLifecycleMode === "strict") {
+    codeBase = `${codeBase}${ENGINEERING_LIFECYCLE_CONTRACT}`;
+  }
   const base = opts.hasSemanticSearch ? `${codeBase}${SEMANTIC_SEARCH_ROUTING}` : codeBase;
   const withMemory = applyMemoryStack(base, rootDir);
   const gitignorePath = join(rootDir, ".gitignore");

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,6 +21,8 @@ export type EditMode = "review" | "auto" | "yolo";
 
 export type ReasoningEffort = "high" | "max";
 
+export type EngineeringLifecycleMode = "off" | "strict";
+
 export type EmbeddingProvider = "ollama" | "openai-compat";
 
 export interface OllamaEmbeddingUserConfig {
@@ -195,6 +197,10 @@ export interface ReasonixConfig {
   };
   pricingOverride?: Record<string, PricingOverride>;
   rateLimit?: RateLimitConfig;
+  /** Host-enforced engineering lifecycle. Defaults to off so opt-outs pay zero prefix cost. */
+  engineeringLifecycle?: {
+    mode?: EngineeringLifecycleMode;
+  };
   /** QQ Bot configuration */
   qq?: QQBotConfig;
 }
@@ -801,6 +807,15 @@ export function saveEditMode(mode: EditMode, path: string = defaultConfigPath())
   const cfg = readConfig(path);
   cfg.editMode = mode;
   writeConfig(cfg, path);
+}
+
+/** Unknown values fall back to "off" so bad config keeps the zero-cost default. */
+export function loadEngineeringLifecycleMode(
+  path: string = defaultConfigPath(),
+): EngineeringLifecycleMode {
+  const v = readConfig(path).engineeringLifecycle?.mode;
+  if (v === "off" || v === "strict") return v;
+  return "off";
 }
 
 /** True when the onboarding tip for the review/AUTO gate has been shown. */

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -64,6 +64,8 @@ export class ToolRegistry {
   private _resultAugmenter: ToolResultAugmenter | null = null;
   /** Per-tool fingerprint of the last call that failed schema validation. Cleared by any successful validation for that tool. */
   private readonly _lastMalformed = new Map<string, string>();
+  /** Per-tool fingerprint of the last host-side interceptor rejection. */
+  private readonly _lastInterceptorRejection = new Map<string, string>();
 
   constructor(opts: ToolRegistryOptions = {}) {
     this._autoFlatten = opts.autoFlatten !== false;
@@ -235,13 +237,17 @@ export class ToolRegistry {
     for (const interceptor of chain) {
       try {
         const short = await interceptor(name, args);
-        if (typeof short === "string") return this._augmentResult(name, args, short);
+        if (typeof short === "string") {
+          const guarded = this._noteInterceptorRejection(name, fingerprint, short);
+          return this._augmentResult(name, args, guarded);
+        }
       } catch (err) {
         return JSON.stringify({
           error: `${name}: interceptor failed — ${(err as Error).message}`,
         });
       }
     }
+    this._lastInterceptorRejection.delete(name);
 
     // Pre-dispatch abort gate: if ESC fired while this tool was queued,
     // refuse to start it. Tools that already check `ctx.signal` mid-run
@@ -326,6 +332,36 @@ export class ToolRegistry {
       });
     }
     return JSON.stringify({ error: `${name}: ${detail}` });
+  }
+
+  private _noteInterceptorRejection(name: string, fingerprint: string, result: string): string {
+    const reason = rejectedReason(result);
+    if (!reason) {
+      this._lastInterceptorRejection.delete(name);
+      return result;
+    }
+    const key = `${reason}:${fingerprint}`;
+    const prev = this._lastInterceptorRejection.get(name);
+    this._lastInterceptorRejection.set(name, key);
+    if (prev === key) {
+      return JSON.stringify({
+        error: `${name}: same call was just rejected by ${reason} — do not retry identical args. Switch to read-only exploration, submit or revise the plan, or choose a different tool call.`,
+        rejectedReason: reason,
+        consecutiveInterceptorRejection: true,
+      });
+    }
+    return result;
+  }
+}
+
+function rejectedReason(result: string): string | null {
+  try {
+    const parsed = JSON.parse(result) as unknown;
+    if (!parsed || typeof parsed !== "object") return null;
+    const reason = (parsed as { rejectedReason?: unknown }).rejectedReason;
+    return typeof reason === "string" && reason ? reason : null;
+  } catch {
+    return null;
   }
 }
 

--- a/tests/code-prompt.test.ts
+++ b/tests/code-prompt.test.ts
@@ -155,6 +155,16 @@ describe("codeSystemPrompt", () => {
   });
 
   describe("system append", () => {
+    it("omits lifecycle contract by default and includes it only for strict mode", () => {
+      expect(codeSystemPrompt(root)).not.toMatch(/# Engineering lifecycle contract/);
+      expect(codeSystemPrompt(root, { engineeringLifecycleMode: "off" })).not.toMatch(
+        /# Engineering lifecycle contract/,
+      );
+      expect(codeSystemPrompt(root, { engineeringLifecycleMode: "strict" })).toMatch(
+        /# Engineering lifecycle contract/,
+      );
+    });
+
     it("does not add a User System Append section when neither option is provided", () => {
       const out = codeSystemPrompt(root);
       expect(out).not.toMatch(/# User System Append/);

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -14,6 +14,7 @@ import {
   loadBaseUrl,
   loadDesktopOpenTabs,
   loadEditMode,
+  loadEngineeringLifecycleMode,
   loadIndexConfig,
   loadIndexUserConfig,
   loadPricingOverride,
@@ -370,6 +371,22 @@ describe("config", () => {
   it("loadEditMode coerces unknown values back to 'review'", () => {
     writeConfig({ editMode: "garbage" as any }, path);
     expect(loadEditMode(path)).toBe("review");
+  });
+
+  it("loadEngineeringLifecycleMode defaults to 'off' when unset", () => {
+    expect(loadEngineeringLifecycleMode(path)).toBe("off");
+  });
+
+  it("loadEngineeringLifecycleMode accepts off and strict", () => {
+    writeConfig({ engineeringLifecycle: { mode: "off" } }, path);
+    expect(loadEngineeringLifecycleMode(path)).toBe("off");
+    writeConfig({ engineeringLifecycle: { mode: "strict" } }, path);
+    expect(loadEngineeringLifecycleMode(path)).toBe("strict");
+  });
+
+  it("loadEngineeringLifecycleMode coerces unknown values back to 'off'", () => {
+    writeConfig({ engineeringLifecycle: { mode: "garbage" as any } }, path);
+    expect(loadEngineeringLifecycleMode(path)).toBe("off");
   });
 
   it("loadReasoningEffort defaults to 'max' when unset", () => {

--- a/tests/lifecycle.test.ts
+++ b/tests/lifecycle.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+import { EngineeringLifecycleRuntime, isHighRiskLifecycleToolCall } from "../src/code/lifecycle.js";
+import { ImmutablePrefix } from "../src/memory/runtime.js";
+
+describe("engineering lifecycle high-risk tool detection", () => {
+  it("treats read-only exploration as safe", () => {
+    expect(isHighRiskLifecycleToolCall("read_file", { path: "src/index.ts" })).toBe(false);
+    expect(isHighRiskLifecycleToolCall("search_content", { pattern: "foo" })).toBe(false);
+  });
+
+  it("treats batch edits and destructive filesystem calls as high risk", () => {
+    expect(
+      isHighRiskLifecycleToolCall("multi_edit", {
+        edits: [
+          { path: "src/a.ts", search: "a", replace: "b" },
+          { path: "src/b.ts", search: "a", replace: "b" },
+        ],
+      }),
+    ).toBe(true);
+    expect(isHighRiskLifecycleToolCall("delete_file", { path: "src/a.ts" })).toBe(true);
+  });
+
+  it("does not treat ordinary read-like shell paths as high risk", () => {
+    expect(isHighRiskLifecycleToolCall("run_command", { command: "git checkout README.md" })).toBe(
+      false,
+    );
+    expect(
+      isHighRiskLifecycleToolCall("run_command", { command: "git checkout -- README.md" }),
+    ).toBe(false);
+    expect(isHighRiskLifecycleToolCall("run_command", { command: "grep -rn 'mv ' src/" })).toBe(
+      false,
+    );
+    expect(isHighRiskLifecycleToolCall("run_command", { command: "echo cp would copy here" })).toBe(
+      false,
+    );
+  });
+});
+
+describe("EngineeringLifecycleRuntime", () => {
+  it("defaults to off and does not auto-arm prompts", () => {
+    const lifecycle = new EngineeringLifecycleRuntime();
+    lifecycle.observeUserPrompt("Refactor the shell and filesystem tool gates");
+
+    expect(lifecycle.snapshot().mode).toBe("off");
+    expect(lifecycle.snapshot().state).toBe("idle");
+    expect(lifecycle.guardToolCall("multi_edit", { edits: [] })).toBeNull();
+  });
+
+  it("blocks high-risk mutations before an approved plan", () => {
+    const lifecycle = new EngineeringLifecycleRuntime({ mode: "strict" });
+    lifecycle.observeUserPrompt("Refactor the shell and filesystem tool gates");
+
+    const out = lifecycle.guardToolCall("multi_edit", {
+      edits: [
+        { path: "src/a.ts", search: "a", replace: "b" },
+        { path: "src/b.ts", search: "a", replace: "b" },
+      ],
+    });
+
+    expect(out).not.toBeNull();
+    expect(JSON.parse(out!).rejectedReason).toBe("engineering-lifecycle");
+    expect(lifecycle.snapshot().state).toBe("armed");
+  });
+
+  it("allows high-risk mutations after plan approval and then requires step evidence", () => {
+    const lifecycle = new EngineeringLifecycleRuntime({ mode: "strict" });
+    lifecycle.observeUserPrompt("Refactor the shell and filesystem tool gates");
+    lifecycle.recordPlanApproved([
+      {
+        id: "step-1",
+        title: "Refactor gates",
+        action: "Change multiple tool gate files.",
+        risk: "med",
+      },
+    ]);
+
+    expect(
+      lifecycle.guardToolCall("multi_edit", {
+        edits: [
+          { path: "src/a.ts", search: "a", replace: "b" },
+          { path: "src/b.ts", search: "a", replace: "b" },
+        ],
+      }),
+    ).toBeNull();
+
+    const rejected = lifecycle.guardToolCall("mark_step_complete", {
+      stepId: "step-1",
+      result: "Refactored the gate path.",
+    });
+    expect(rejected).not.toBeNull();
+    expect(JSON.parse(rejected!).error).toMatch(/evidence/);
+
+    expect(
+      lifecycle.guardToolCall("mark_step_complete", {
+        stepId: "step-1",
+        result: "Refactored the gate path.",
+        evidence: [{ kind: "verification", summary: "npm test tests/lifecycle.test.ts passed" }],
+      }),
+    ).toBeNull();
+  });
+
+  it("requires evidence for low-risk steps after a successful code mutation", () => {
+    const lifecycle = new EngineeringLifecycleRuntime({ mode: "strict" });
+    lifecycle.observeUserPrompt("Refactor formatting across modules");
+    lifecycle.recordPlanApproved([
+      {
+        id: "step-1",
+        title: "Extract formatter",
+        action: "Move formatting into src/format.ts.",
+        risk: "low",
+        targets: ["src/format.ts"],
+      },
+    ]);
+
+    lifecycle.recordToolResult(
+      "write_file",
+      { path: "src/format.ts" },
+      "▸ edit blocks: 1/1 applied\n  ✓ created     src/format.ts",
+    );
+
+    const rejected = lifecycle.guardToolCall("mark_step_complete", {
+      stepId: "step-1",
+      result: "Created src/format.ts.",
+    });
+    expect(rejected).not.toBeNull();
+    expect(JSON.parse(rejected!).rejectedReason).toBe("engineering-lifecycle-evidence");
+  });
+
+  it("does not require mutation evidence when an edit was rejected before touching disk", () => {
+    const lifecycle = new EngineeringLifecycleRuntime({ mode: "strict" });
+    lifecycle.observeUserPrompt("Refactor formatting across modules");
+    lifecycle.recordPlanApproved([
+      {
+        id: "step-1",
+        title: "Try formatter",
+        action: "Attempt a formatter edit.",
+        risk: "low",
+      },
+    ]);
+
+    lifecycle.recordToolResult(
+      "edit_file",
+      { path: "src/app.ts" },
+      "User rejected this edit to src/app.ts. Don't retry the same SEARCH/REPLACE.",
+    );
+
+    expect(
+      lifecycle.guardToolCall("mark_step_complete", {
+        stepId: "step-1",
+        result: "No code was changed.",
+      }),
+    ).toBeNull();
+  });
+
+  it("does not mutate the immutable prefix as lifecycle state changes", () => {
+    const prefix = new ImmutablePrefix({ system: "s", toolSpecs: [] });
+    const before = prefix.fingerprint;
+    const lifecycle = new EngineeringLifecycleRuntime({ mode: "strict" });
+
+    lifecycle.observeUserPrompt("Refactor everything");
+    lifecycle.recordPlanApproved([
+      { id: "step-1", title: "Do work", action: "Do high risk work.", risk: "high" },
+    ]);
+    lifecycle.guardToolCall("delete_file", { path: "src/old.ts" });
+
+    expect(prefix.verifyFingerprint()).toBe(before);
+  });
+
+  it("starts a fresh lifecycle after cancellation or completion", () => {
+    const lifecycle = new EngineeringLifecycleRuntime({ mode: "strict" });
+    lifecycle.observeUserPrompt("Refactor the command router");
+    lifecycle.cancel();
+
+    lifecycle.observeUserPrompt("Fix the typo in README.md");
+    expect(lifecycle.snapshot().state).toBe("armed");
+
+    lifecycle.observeUserPrompt("Refactor the command router again");
+    lifecycle.recordPlanApproved([
+      { id: "step-1", title: "Refactor", action: "Refactor command routing.", risk: "low" },
+    ]);
+    lifecycle.recordStepCompleted("step-1");
+    expect(lifecycle.snapshot().state).toBe("complete");
+
+    lifecycle.observeUserPrompt("Fix another typo");
+    expect(lifecycle.snapshot().state).toBe("armed");
+  });
+});

--- a/tests/slash.test.ts
+++ b/tests/slash.test.ts
@@ -417,7 +417,7 @@ describe("handleSlash", () => {
       const ctx = detectSlashArgContext("/plan o", true);
       expect(ctx).not.toBeNull();
       expect(ctx!.kind).toBe("picker");
-      expect(ctx!.spec.argCompleter).toEqual(["on", "off"]);
+      expect(ctx!.spec.argCompleter).toEqual(["on", "off", "strict"]);
     });
 
     it("hides /plan outside code mode (command is contextual)", () => {
@@ -1192,7 +1192,7 @@ describe("handleSlash", () => {
       expect(r2.info).toMatch(/plan mode OFF/);
     });
 
-    it("/plan on / off / true / false / 0 / 1 parse correctly", () => {
+    it("/plan on / off / true / false / 0 / 1 / strict parse correctly", () => {
       const check = (arg: string, expected: boolean) => {
         const calls: boolean[] = [];
         handleSlash("plan", [arg], makeLoop(), {
@@ -1207,6 +1207,16 @@ describe("handleSlash", () => {
       check("off", false);
       check("false", false);
       check("0", false);
+      check("strict", true);
+    });
+
+    it("/plan strict is explicit, not a toggle", () => {
+      const calls: boolean[] = [];
+      handleSlash("plan", ["strict"], makeLoop(), {
+        planMode: true,
+        setPlanMode: (on) => calls.push(on),
+      });
+      expect(calls).toEqual([true]);
     });
 
     it("/plan explains the stronger-constraint relationship with autonomous submit_plan", () => {

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -331,6 +331,24 @@ describe("ToolRegistry", () => {
       expect(out).toBe("ok");
     });
 
+    it("sharpens repeated identical interceptor rejections", async () => {
+      const reg = new ToolRegistry();
+      reg.register({ name: "multi_edit", fn: () => "ok" });
+      reg.addToolInterceptor("lifecycle", () =>
+        JSON.stringify({
+          error: "multi_edit blocked",
+          rejectedReason: "engineering-lifecycle",
+        }),
+      );
+
+      const first = JSON.parse(await reg.dispatch("multi_edit", '{"edits":[]}'));
+      const second = JSON.parse(await reg.dispatch("multi_edit", '{"edits":[]}'));
+
+      expect(first.consecutiveInterceptorRejection).toBeUndefined();
+      expect(second.consecutiveInterceptorRejection).toBe(true);
+      expect(second.error).toMatch(/do not retry identical args/);
+    });
+
     it("surfaces interceptor throws as structured errors", async () => {
       const reg = new ToolRegistry();
       reg.register({ name: "edit_file", fn: () => "ok" });


### PR DESCRIPTION
## Summary

- Add host-side `EngineeringLifecycleRuntime` as an opt-in strict lifecycle.
- Default `engineeringLifecycle.mode` to `off`; unknown config values also fall back to `off`.
- Remove the previous regex auto-arm/classifier path. Users opt in via `/plan strict` or persistent `engineeringLifecycle.mode: "strict"`.
- Gate the lifecycle prompt contract so `off` users pay zero static-prefix cost.
- Keep lifecycle state in runtime/plan store and do not mutate system prompt or tool lists during lifecycle stage changes.
- Tokenize shell commands for high-risk detection to avoid the false positives from the first RFC branch (`grep 'mv '`, `echo cp`, single-file `git checkout`).
- Add repeated interceptor-rejection protection so identical lifecycle-bounced calls get a sharper stop/replan error.

## Split context

Final lifecycle slice after #1301, #1302, and #1303 landed. Split out of #1296 after maintainer review on #1293.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm test -- tests/lifecycle.test.ts tests/tools.test.ts tests/config.test.ts tests/slash.test.ts tests/code-prompt.test.ts tests/plan.test.ts tests/plan-store.test.ts tests/plan-checkpoint-confirm.test.tsx`
- After rebasing on latest main with #1301/#1302/#1303 merged: `npm test -- tests/lifecycle.test.ts tests/tools.test.ts tests/config.test.ts tests/slash.test.ts tests/code-prompt.test.ts`
- After rebasing on latest main with #1301/#1302/#1303 merged: `npm run typecheck`
