### PR TITLE
fix(desktop): prevent browser Select All when composer is not focused

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -1414,6 +1414,11 @@ function TabRuntime({
     if (!active) return;
     const onKey = (e: KeyboardEvent) => {
       const mod = e.ctrlKey || e.metaKey;
+      if (mod && (e.key === "a" || e.key === "A")) {
+        const tag = (e.target as HTMLElement)?.tagName;
+        if (tag !== "INPUT" && tag !== "TEXTAREA") e.preventDefault();
+        return;
+      }
       if (mod && (e.key === "l" || e.key === "L")) {
         e.preventDefault();
         composerRef.current?.focus();


### PR DESCRIPTION
## Summary

Prevent the browser's native "Select All" (`Ctrl+A` / `Cmd+A`) from highlighting the entire app UI when the composer textarea is not focused.

## Problem

The desktop app has two global `keydown` handlers — one per-tab [App.tsx:1413](desktop/src/App.tsx:1413) and one app-wide [App.tsx:2954](desktop/src/App.tsx:2954). Neither intercepts `mod+A`. When the composer is blurred and the user presses `Ctrl+A`, the event falls through to the webview's native layer, triggering Chromium's default Select All behavior — every visible DOM text node gets highlighted, making the entire interface flash as selected.

Some UI elements have `user-select: none` (titlebar, line numbers, card headers), but the main content area does not, and CSS alone can only suppress the visual highlight — it does not prevent the Select All action itself.

## Fix

Added a `mod+A` guard at the top of the per-tab keydown handler:

- Focus is on `INPUT` or `TEXTAREA` → **let through** (normal text selection within an input)
- Focus is anywhere else → **`e.preventDefault()`**, blocking the webview's native Select All

[App.tsx:1417-1421](desktop/src/App.tsx:1417-1421) — 5 new lines, following the existing `mod + key` guard pattern, zero dependencies.

## Verification

| Check | Result |
|---|---|
| `npm run typecheck` | ✅ passes |
| `npm run lint` | ✅ 625 files, no fixes applied |
| `npm run test` | ✅ 3218 passed, 9 skipped, **1 failed (pre-existing, unrelated to this change)** |

**Note:** `chat-mcp-startup-summary.test.ts` timed out during the full `npm run test` run, but both pass when targeted individually: `tests/chat-mcp-startup-summary.test.ts`. The timeouts are unrelated to this change.
