### PR TITLE
feat: Add Java source code search and decompilation tools.

### DIFF
--- a/src/code/setup.ts
+++ b/src/code/setup.ts
@@ -13,6 +13,7 @@ import { bootstrapSemanticSearchInCodeMode } from "../index/semantic/tool.js";
 import { ToolRegistry } from "../tools.js";
 import { registerChoiceTool } from "../tools/choice.js";
 import { registerFilesystemTools } from "../tools/filesystem.js";
+import { registerJavaSourceTool } from "../tools/java-source.js";
 import { JobRegistry } from "../tools/jobs.js";
 import { registerMemoryTools } from "../tools/memory.js";
 import { registerPlanTool } from "../tools/plan.js";
@@ -74,6 +75,7 @@ export async function buildCodeToolset(opts: CodeToolsetOpts): Promise<CodeTools
       webSearchEndpoint: webSearchEndpoint(),
     });
   }
+  registerJavaSourceTool(tools, { projectRoot: opts.rootDir });
   // Lazy: constructing DeepSeekClient throws when DEEPSEEK_API_KEY is unset,
   // which would kill `reasonix code` before the setup wizard can prompt for
   // one. Defer to first subagent dispatch — by then the user has either keyed

--- a/src/java/class-source-finder.ts
+++ b/src/java/class-source-finder.ts
@@ -1,0 +1,296 @@
+// ClassSourceFinder — locate Java source by fully-qualified class name.
+// Two-step: (1) project .java walk, (2) .m2 jar scan + javap decompile.
+
+import { execFile } from "node:child_process";
+import * as fs from "node:fs";
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { listJarEntries, readJarEntry } from "./zip-reader.js";
+
+// ── types ────────────────────────────────────────────────────────────────────
+
+export interface FindResultSuccess {
+  found: true;
+  /** Reconstructed (or raw {@code .java}) source text. */
+  source: string;
+  // Where the source originated:
+  //   "project" — .java file in the project tree.
+  //   "m2-jar"  — decompiled from .m2 jar.
+  //   "jar"     — decompiled from user-specified jar path.
+  method: "project" | "m2-jar" | "jar";
+  /** Filesystem path to the {@code .java} file or the jar that was decompiled. */
+  sourcePath: string;
+}
+
+export interface FindResultNotFound {
+  found: false;
+  method: "not-found";
+}
+
+export type FindResult = FindResultSuccess | FindResultNotFound;
+
+export interface FindSourceOptions {
+  // When set, only scan .m2 jars whose filename or path contains this keyword.
+  // Dramatically reduces scan time when you know which library the class belongs
+  // to (e.g. "spring-core", "guava", "mycompany-utils").
+  jarKeyword?: string;
+}
+
+export interface ClassSourceFinderOptions {
+  /** Root of the Java project to scan for {@code .java} files. */
+  projectRoot: string;
+  // Path to the local Maven repository. Defaults to ~/.m2/repository.
+  m2Repo?: string;
+  // Command or absolute path for javap. Defaults to "javap".
+  javapCommand?: string;
+  // Maximum number of jar files to scan inside .m2 before giving up.
+  // Protects against huge repositories. Defaults to 2000.
+  maxJarScan?: number;
+  /**
+   * Signal to abort mid-scan (e.g. user pressed Escape).
+   */
+  signal?: AbortSignal;
+}
+
+// ── implementation ───────────────────────────────────────────────────────────
+
+export class ClassSourceFinder {
+  private projectRoot: string;
+  private m2Repo: string;
+  private javapCommand: string;
+  private maxJarScan: number;
+  private signal?: AbortSignal;
+
+  constructor(options: ClassSourceFinderOptions) {
+    this.projectRoot = path.resolve(options.projectRoot);
+    this.m2Repo = path.resolve(options.m2Repo ?? path.join(os.homedir(), ".m2", "repository"));
+    this.javapCommand = options.javapCommand ?? "javap";
+    this.maxJarScan = options.maxJarScan ?? 2000;
+    this.signal = options.signal;
+  }
+
+  // ── public API ──────────────────────────────────────────────────────────
+
+  // Find source for fullyQualifiedName.
+  // 1. Walk the project tree for a matching .java file.
+  // 2. Fall back to scanning .m2 jars (optionally filtered by jarKeyword).
+  async findSource(fullyQualifiedName: string, options?: FindSourceOptions): Promise<FindResult> {
+    this.throwIfAborted();
+
+    // 1. Project search
+    const projectResult = await this.searchProject(fullyQualifiedName);
+    if (projectResult) return projectResult;
+
+    // 2. Maven local repository (optionally filtered by jarKeyword)
+    return this.searchM2Repository(fullyQualifiedName, options?.jarKeyword);
+  }
+
+  // Like findSource, but skip project + .m2 — directly read from jarPath.
+  // @param fullyQualifiedName e.g. "com.example.MyClass"
+  // @param jarPath path to a specific .jar file
+  async findSourceInJar(fullyQualifiedName: string, jarPath: string): Promise<FindResult> {
+    this.throwIfAborted();
+
+    const resolvedJarPath = path.resolve(jarPath);
+    if (!fs.existsSync(resolvedJarPath)) {
+      return {
+        found: false,
+        method: "not-found",
+      };
+    }
+
+    const classEntry = `${fullyQualifiedName.replace(/\./g, "/")}.class`;
+    try {
+      const content = readJarEntry(resolvedJarPath, classEntry);
+      if (!content) {
+        return {
+          found: false,
+          method: "not-found",
+        };
+      }
+      const source = await this.decompileFromJar(resolvedJarPath, content.data, fullyQualifiedName);
+      return { found: true, source, method: "jar", sourcePath: resolvedJarPath };
+    } catch (err) {
+      return {
+        found: false,
+        method: "not-found",
+      };
+    }
+  }
+
+  // ── step 1: project search ──────────────────────────────────────────────
+
+  private async searchProject(fqn: string): Promise<FindResultSuccess | null> {
+    const simpleName = this.simpleClassName(fqn);
+    const suffixes = [
+      `${simpleName}.java`,
+      // Some projects keep source alongside generated code with a suffix
+      `${simpleName}.java.txt`,
+    ];
+
+    // Breadth-first walk so we find shallow matches quickly.
+    const queue: string[] = [this.projectRoot];
+    while (queue.length > 0) {
+      this.throwIfAborted();
+      const dir = queue.shift()!;
+      let entries: fs.Dirent[];
+      try {
+        entries = await fsp.readdir(dir, { withFileTypes: true });
+      } catch {
+        // Permission denied, broken symlink, etc. — skip.
+        continue;
+      }
+
+      for (const entry of entries) {
+        const fullPath = path.join(dir, entry.name);
+
+        if (entry.isDirectory()) {
+          // Skip common non-source directories.
+          if (
+            entry.name === "node_modules" ||
+            entry.name === ".git" ||
+            entry.name === "target" ||
+            entry.name === "build" ||
+            entry.name === "dist" ||
+            entry.name === ".idea" ||
+            entry.name === ".vscode" ||
+            entry.name === ".gradle"
+          ) {
+            continue;
+          }
+          queue.push(fullPath);
+        } else if (entry.isFile()) {
+          if (suffixes.includes(entry.name)) {
+            const source = await fsp.readFile(fullPath, "utf-8");
+            return { found: true, source, method: "project", sourcePath: fullPath };
+          }
+        }
+      }
+    }
+
+    return null;
+  }
+
+  // ── step 2: Maven local repository ──────────────────────────────────────
+
+  private async searchM2Repository(fqn: string, jarKeyword?: string): Promise<FindResult> {
+    const classEntry = `${fqn.replace(/\./g, "/")}.class`;
+
+    // Collect jar paths — filtered by keyword when provided.
+    const jarPaths: string[] = [];
+    await this.walkM2ForJars(this.m2Repo, jarPaths, jarKeyword);
+
+    let scanned = 0;
+    for (const jarPath of jarPaths) {
+      this.throwIfAborted();
+      if (scanned >= this.maxJarScan) break;
+
+      scanned++;
+      try {
+        const content = readJarEntry(jarPath, classEntry);
+        if (content) {
+          // Found the class inside this jar — decompile it.
+          const source = await this.decompileFromJar(jarPath, content.data, fqn);
+          return { found: true, source, method: "m2-jar", sourcePath: jarPath };
+        }
+      } catch {
+        // Corrupt jar, I/O error, etc. — skip to next.
+      }
+    }
+
+    return { found: false, method: "not-found" };
+  }
+
+  // Recursively walk dir collecting .jar file paths.
+  // keyword: case-insensitive filter on jar filename/path.
+  private async walkM2ForJars(dir: string, out: string[], keyword?: string): Promise<void> {
+    let entries: fs.Dirent[];
+    try {
+      entries = await fsp.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      this.throwIfAborted();
+      if (out.length >= this.maxJarScan) return;
+
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await this.walkM2ForJars(fullPath, out, keyword);
+      } else if (entry.isFile() && entry.name.endsWith(".jar")) {
+        // Apply keyword filter at the leaf — only push matching jars.
+        if (!keyword || fullPath.toLowerCase().includes(keyword.toLowerCase())) {
+          out.push(fullPath);
+        }
+      }
+    }
+  }
+
+  // ── decompilation ───────────────────────────────────────────────────────
+
+  // Decompile a .class entry extracted from a jar.
+  // Writes bytes to temp dir so javap can read via -cp <tmpdir>.
+  private async decompileFromJar(
+    jarPath: string,
+    classBytes: Buffer,
+    fqn: string,
+  ): Promise<string> {
+    // Create a temp directory that mirrors the package structure.
+    const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "reasonix-java-src-"));
+
+    try {
+      // Recreate the package directory structure.
+      const pkgPath = fqn.replace(/\./g, path.sep);
+      const classDir = path.join(tmpDir, path.dirname(pkgPath));
+      await fsp.mkdir(classDir, { recursive: true });
+
+      const classFile = path.join(tmpDir, `${pkgPath}.class`);
+      await fsp.writeFile(classFile, classBytes);
+
+      return await this.runJavap(fqn, tmpDir);
+    } finally {
+      // Best-effort cleanup.
+      await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }
+
+  // Run javap -c -p against a class on the given classpath.
+  private runJavap(className: string, classPath: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      execFile(
+        this.javapCommand,
+        ["-c", "-p", "-cp", classPath, className],
+        {
+          maxBuffer: 10 * 1024 * 1024, // 10 MiB
+          timeout: 30_000,
+          signal: this.signal,
+        },
+        (err, stdout, stderr) => {
+          if (err) {
+            // javap returns non-zero for various reasons; surface the
+            // stderr/stdout we did get rather than throwing away context.
+            const msg = [stdout, stderr].filter(Boolean).join("\n") || err.message;
+            reject(new Error(`javap failed: ${msg}`));
+            return;
+          }
+          resolve(stdout);
+        },
+      );
+    });
+  }
+
+  // ── helpers ─────────────────────────────────────────────────────────────
+
+  private simpleClassName(fqn: string): string {
+    const lastDot = fqn.lastIndexOf(".");
+    return lastDot === -1 ? fqn : fqn.slice(lastDot + 1);
+  }
+
+  private throwIfAborted(): void {
+    if (this.signal?.aborted) {
+      throw new DOMException("Aborted", "AbortError");
+    }
+  }
+}

--- a/src/java/index.ts
+++ b/src/java/index.ts
@@ -1,0 +1,10 @@
+export {
+  ClassSourceFinder,
+  type FindResult,
+  type FindResultSuccess,
+  type FindResultNotFound,
+  type FindSourceOptions,
+  type ClassSourceFinderOptions,
+} from "./class-source-finder.js";
+
+export { readJarEntry, listJarEntries, type JarEntry } from "./zip-reader.js";

--- a/src/java/zip-reader.ts
+++ b/src/java/zip-reader.ts
@@ -1,0 +1,179 @@
+// Minimal pure-Node.js ZIP / JAR entry reader.
+// Reads a single entry from a zip archive; no external dependencies.
+
+import * as fs from "node:fs";
+import * as zlib from "node:zlib";
+
+// ── constants ────────────────────────────────────────────────────────────────
+
+const EOCD_SIGNATURE = 0x06054b50;
+const CENTRAL_DIR_SIGNATURE = 0x02014b50;
+const LOCAL_FILE_SIGNATURE = 0x04034b50;
+
+const EOCD_MIN_SIZE = 22;
+const EOCD_MAX_COMMENT = 0xffff; // 65535 bytes
+
+const COMPRESSION_STORED = 0;
+const COMPRESSION_DEFLATED = 8;
+
+// ── types ────────────────────────────────────────────────────────────────────
+
+interface CentralDirEntry {
+  fileName: string;
+  compressionMethod: number;
+  compressedSize: number;
+  uncompressedSize: number;
+  localHeaderOffset: number;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function readU32LE(buf: Buffer, offset: number): number {
+  return buf.readUInt32LE(offset);
+}
+
+function readU16LE(buf: Buffer, offset: number): number {
+  return buf.readUInt16LE(offset);
+}
+
+function findEOCD(fd: number, fileSize: number): { offset: number; buf: Buffer } {
+  // The EOCD record sits at the end of the file, possibly preceded by a
+  // variable-length ZIP comment.  Search backwards in 1 KiB chunks.
+  const searchStart = Math.max(0, fileSize - EOCD_MAX_COMMENT - EOCD_MIN_SIZE);
+  let chunkOffset = fileSize;
+  while (chunkOffset > searchStart) {
+    const readSize = Math.min(1024, chunkOffset - searchStart);
+    chunkOffset -= readSize;
+    const buf = Buffer.alloc(readSize);
+    fs.readSync(fd, buf, 0, readSize, chunkOffset);
+
+    // Scan backwards through the chunk for the EOCD signature.
+    for (let i = readSize - 4; i >= 0; i--) {
+      if (buf.readUInt32LE(i) === EOCD_SIGNATURE) {
+        // We found the signature.  Return the EOCD bytes starting at that offset.
+        const eocdOffset = chunkOffset + i;
+        const eocdSize = Math.min(EOCD_MIN_SIZE + EOCD_MAX_COMMENT, fileSize - eocdOffset);
+        const eocdBuf = Buffer.alloc(eocdSize);
+        fs.readSync(fd, eocdBuf, 0, eocdSize, eocdOffset);
+        return { offset: eocdOffset, buf: eocdBuf };
+      }
+    }
+  }
+  throw new Error("Not a valid ZIP file: EOCD signature not found");
+}
+
+function parseCentralDirectory(fd: number, eocdBuf: Buffer): CentralDirEntry[] {
+  const centralDirOffset = readU32LE(eocdBuf, 16); // offset 16 in EOCD
+  const totalEntries = readU16LE(eocdBuf, 10); // offset 10 in EOCD
+
+  const entries: CentralDirEntry[] = [];
+  let offset = centralDirOffset;
+
+  for (let i = 0; i < totalEntries; i++) {
+    // Read the fixed-size (46-byte) central directory header.
+    const headerBuf = Buffer.alloc(46);
+    fs.readSync(fd, headerBuf, 0, 46, offset);
+
+    if (readU32LE(headerBuf, 0) !== CENTRAL_DIR_SIGNATURE) {
+      throw new Error(`Corrupt central directory at offset ${offset}`);
+    }
+
+    const compressionMethod = readU16LE(headerBuf, 10);
+    const compressedSize = readU32LE(headerBuf, 20);
+    const uncompressedSize = readU32LE(headerBuf, 24);
+    const fileNameLen = readU16LE(headerBuf, 28);
+    const extraLen = readU16LE(headerBuf, 30);
+    const commentLen = readU16LE(headerBuf, 32);
+    const localHeaderOffset = readU32LE(headerBuf, 42);
+
+    // Read the variable-length file name.
+    const nameBuf = Buffer.alloc(fileNameLen);
+    fs.readSync(fd, nameBuf, 0, fileNameLen, offset + 46);
+    const fileName = nameBuf.toString("utf8");
+
+    entries.push({
+      fileName,
+      compressionMethod,
+      compressedSize,
+      uncompressedSize,
+      localHeaderOffset,
+    });
+
+    offset += 46 + fileNameLen + extraLen + commentLen;
+  }
+
+  return entries;
+}
+
+// ── public API ───────────────────────────────────────────────────────────────
+
+export interface JarEntry {
+  fileName: string;
+  data: Buffer;
+}
+
+// Read a single entry from a ZIP / JAR file.
+// @param jarPath absolute path to the .jar
+// @param entryName exact entry name (e.g. "com/example/MyClass.class")
+export function readJarEntry(jarPath: string, entryName: string): JarEntry | null {
+  const fd = fs.openSync(jarPath, "r");
+  try {
+    const stat = fs.fstatSync(fd);
+    const fileSize = stat.size;
+
+    // 1. Find EOCD
+    const eocd = findEOCD(fd, fileSize);
+
+    // 2. Parse central directory
+    const entries = parseCentralDirectory(fd, eocd.buf);
+
+    // 3. Find the target entry
+    const target = entries.find((e) => e.fileName === entryName);
+    if (!target) return null;
+
+    // 4. Read the local file header
+    const localHeaderBuf = Buffer.alloc(30);
+    fs.readSync(fd, localHeaderBuf, 0, 30, target.localHeaderOffset);
+
+    if (readU32LE(localHeaderBuf, 0) !== LOCAL_FILE_SIGNATURE) {
+      throw new Error(`Corrupt local file header at offset ${target.localHeaderOffset}`);
+    }
+
+    const localFileNameLen = readU16LE(localHeaderBuf, 26);
+    const localExtraLen = readU16LE(localHeaderBuf, 28);
+
+    // 5. Read the compressed data
+    const dataOffset = target.localHeaderOffset + 30 + localFileNameLen + localExtraLen;
+    const compressedBuf = Buffer.alloc(target.compressedSize);
+    fs.readSync(fd, compressedBuf, 0, target.compressedSize, dataOffset);
+
+    // 6. Decompress if needed
+    let data: Buffer;
+    if (target.compressionMethod === COMPRESSION_STORED) {
+      data = compressedBuf;
+    } else if (target.compressionMethod === COMPRESSION_DEFLATED) {
+      data = zlib.inflateRawSync(compressedBuf);
+    } else {
+      throw new Error(
+        `Unsupported compression method ${target.compressionMethod} for entry "${entryName}"`,
+      );
+    }
+
+    return { fileName: target.fileName, data };
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+// List all entries in a ZIP / JAR file.
+export function listJarEntries(jarPath: string): string[] {
+  const fd = fs.openSync(jarPath, "r");
+  try {
+    const stat = fs.fstatSync(fd);
+    const eocd = findEOCD(fd, stat.size);
+    const entries = parseCentralDirectory(fd, eocd.buf);
+    return entries.map((e) => e.fileName);
+  } finally {
+    fs.closeSync(fd);
+  }
+}

--- a/src/tools/java-source.ts
+++ b/src/tools/java-source.ts
@@ -1,0 +1,132 @@
+// java_source tool — find and decompile Java source by fully-qualified class name.
+// Modes: (1) project .java walk, (2) .m2 jar scan, (3) direct jarPath.
+
+import { ClassSourceFinder } from "../java/class-source-finder.js";
+import type { ToolRegistry } from "../tools.js";
+
+export interface JavaSourceToolOptions {
+  // Root directory for .java file search. Falls back to process.cwd().
+  projectRoot?: string;
+}
+
+// Register the java_source tool on registry.
+// Parameters: className (required), projectRoot, jarPath, jarKeyword.
+export function registerJavaSourceTool(
+  registry: ToolRegistry,
+  opts: JavaSourceToolOptions = {},
+): ToolRegistry {
+  registry.register({
+    name: "java_source",
+    description: [
+      "Find and return Java source code by fully-qualified class name.",
+      "",
+      "Three search modes (picked automatically based on which parameters are set):",
+      "1. **Default** (className only): walk project tree for a `.java` file, then fall back to scanning `~/.m2/repository` jars.",
+      "2. **With jarKeyword** (className + jarKeyword): same as default, but only scan jars whose path/name contains the keyword — much faster when you know the library.",
+      "3. **With jarPath** (className + jarPath): skip both project + .m2 scans, decompile directly from the specified jar file.",
+      "",
+      "Returns the source text (or decompiled bytecode) on success, or a clear 'not found' message.",
+      "Only call this tool once per class name — it's I/O heavy.",
+    ].join("\n"),
+    readOnly: true,
+    parameters: {
+      type: "object",
+      properties: {
+        className: {
+          type: "string",
+          description:
+            'Fully qualified Java class name, e.g. "com.google.common.collect.Lists" or "org.springframework.web.servlet.DispatcherServlet".',
+        },
+        projectRoot: {
+          type: "string",
+          description:
+            "Optional. Override the project root directory for phase-1 file search. Defaults to the current session's workspace root.",
+        },
+        jarPath: {
+          type: "string",
+          description:
+            'Optional. Exact path to a .jar file. When set, skips project file search and .m2 scan — reads the class directly from this jar and decompiles it. Useful when you know which dependency jar contains the class, e.g. "/home/user/.m2/repository/org/springframework/spring-core/6.1.0/spring-core-6.1.0.jar".',
+        },
+        jarKeyword: {
+          type: "string",
+          description:
+            'Optional. Only search .m2 jars whose filename or path contains this keyword (case-insensitive). Dramatically narrows the scan when you know the library name, e.g. "spring-core", "guava", "mycompany-utils". Ignored when jarPath is also set.',
+        },
+      },
+      required: ["className"],
+    },
+    parallelSafe: true,
+    fn: async (args: {
+      className: string;
+      projectRoot?: string;
+      jarPath?: string;
+      jarKeyword?: string;
+    }) => {
+      const className = (args?.className ?? "").trim();
+      if (!className) {
+        throw new Error("java_source: `className` is required");
+      }
+
+      // Validate that the class name looks like a valid Java identifier chain.
+      if (!/^[a-zA-Z_$][\w$]*(\.[a-zA-Z_$][\w$]*)*$/.test(className)) {
+        throw new Error(
+          `java_source: "${className}" is not a valid fully qualified Java class name. Expected format: \`com.example.MyClass\``,
+        );
+      }
+
+      const projectRoot = args?.projectRoot?.trim() || opts.projectRoot || process.cwd();
+      const finder = new ClassSourceFinder({ projectRoot });
+
+      const jarPath = args?.jarPath?.trim();
+      const jarKeyword = args?.jarKeyword?.trim();
+
+      if (jarPath) {
+        // Mode: direct jar path — skip project + .m2
+        const result = await finder.findSourceInJar(className, jarPath);
+        if (!result.found) {
+          return JSON.stringify({
+            status: "not-found",
+            className,
+            message: `Class "${className}" not found in jar:\n  ${jarPath}\n\nMake sure the class name is correct and that the jar contains that entry.`,
+          });
+        }
+        return JSON.stringify({
+          status: "found",
+          className,
+          method: result.method,
+          sourcePath: result.sourcePath,
+          source: result.source,
+        });
+      }
+
+      // Default: project search → .m2 scan (optionally filtered by jarKeyword)
+      const result = await finder.findSource(className, {
+        ...(jarKeyword ? { jarKeyword } : {}),
+      });
+
+      if (!result.found) {
+        const keywordLine = jarKeyword
+          ? `  • ~/.m2/repository/ for jars containing keyword "${jarKeyword}"`
+          : "  • ~/.m2/repository/ for all jars";
+        const tip = jarKeyword
+          ? "Try a different keyword, use `jarPath` with the exact path, or check if the class is in a different library."
+          : `Tip: pass \`jarKeyword\` (e.g. "spring-core", "guava") to narrow the .m2 scan, or \`jarPath\` with the exact jar path to skip the scan entirely.`;
+        return JSON.stringify({
+          status: "not-found",
+          className,
+          message: `No source found for "${className}". Searched:\n  • ${projectRoot}/ for matching .java files\n  ${keywordLine}\n\n${tip}`,
+        });
+      }
+
+      return JSON.stringify({
+        status: "found",
+        className,
+        method: result.method,
+        sourcePath: result.sourcePath,
+        source: result.source,
+      });
+    },
+  });
+
+  return registry;
+}


### PR DESCRIPTION
## What

Add a `java_source` tool that lets the Reasonix agent find and decompile Java source code by fully-qualified class name.

**New modules:**
- `src/java/class-source-finder.ts` — two-phase search engine: walks the project tree for `.java` files, then falls back to scanning `~/.m2/repository` jars with `javap` decompilation. Supports three modes: project-only, keyword-filtered `.m2` scan, and direct jar path.
- `src/java/zip-reader.ts` — zero-dependency pure-Node ZIP/JAR entry reader using `fs` + `zlib`. No JDK `jar` command required.
- `src/java/index.ts` — barrel export.

**New tool (`parallelSafe`, `readOnly`):**
- `java_source(className, projectRoot?, jarPath?, jarKeyword?)` — registered in `buildCodeToolset()` via `registerJavaSourceTool()`.

**Wiring:**
- `src/code/setup.ts`: added `registerJavaSourceTool` import and call in `buildCodeToolset()`.

## Why

Java developers using Reasonix to work on Maven/Gradle projects need a way to inspect library source code without leaving the agent session.

## How to verify

1. `npm run verify` passes (lint + typecheck + tests + comment-policy gate).
2. The tool appears in the tool registry and is callable by the model in `reasonix code` sessions.

## Checklist

- [√] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [√] No `Co-Authored-By: Claude` trailer in commits
- [√] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [√] No edits to `CHANGELOG.md`