### PR TITLE
test(prompt-budget): lock cache-prefix byte budget

### DIFF
--- a/tests/prompt-budget.test.ts
+++ b/tests/prompt-budget.test.ts
@@ -1,0 +1,121 @@
+/** Locks cache-prefix byte budget — every byte ships in every request. PRs that
+ *  grow it must compress elsewhere or raise the constant with a commit-message reason. */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { CODE_SYSTEM_PROMPT, codeSystemPrompt } from "../src/code/prompt.js";
+import { ToolRegistry } from "../src/tools.js";
+import { registerChoiceTool } from "../src/tools/choice.js";
+import { registerFilesystemTools } from "../src/tools/filesystem.js";
+import { JobRegistry } from "../src/tools/jobs.js";
+import { registerMemoryTools } from "../src/tools/memory.js";
+import { registerPlanTool } from "../src/tools/plan.js";
+import { registerScaffoldTools } from "../src/tools/scaffold.js";
+import { registerShellTools } from "../src/tools/shell.js";
+import { registerSkillTools } from "../src/tools/skills.js";
+import { registerTodoTool } from "../src/tools/todo.js";
+import { registerWebTools } from "../src/tools/web.js";
+
+/** Base system prompt — no memory, no .gitignore, no built-in skills index. */
+const SYSTEM_PROMPT_BUDGET = 24_500;
+/** Adds the built-in skills index `applySkillsIndex` injects on top of the base. */
+const SYSTEM_PROMPT_BUDGET_WITH_SKILLS = 26_500;
+/** Full code-mode tool spec list — descriptions + JSON-schema parameters, all 35 tools. */
+const TOOL_LIST_BUDGET = 40_000;
+
+function buildCodeToolset(root: string): ToolRegistry {
+  const tools = new ToolRegistry();
+  const jobs = new JobRegistry();
+  registerFilesystemTools(tools, { rootDir: root });
+  registerShellTools(tools, { rootDir: root, jobs });
+  registerMemoryTools(tools, { projectRoot: root });
+  registerPlanTool(tools);
+  registerChoiceTool(tools);
+  registerTodoTool(tools);
+  registerScaffoldTools(tools, { projectRoot: root });
+  registerWebTools(tools);
+  registerSkillTools(tools, { projectRoot: root, disableBuiltins: true });
+  return tools;
+}
+
+function totalToolBytes(tools: ToolRegistry): {
+  total: number;
+  perTool: Array<{ name: string; descBytes: number; schemaBytes: number; total: number }>;
+} {
+  const specs = tools.specs();
+  const perTool = specs.map((s) => {
+    const descBytes = (s.function?.description ?? "").length;
+    const schemaBytes = JSON.stringify(s.function?.parameters ?? {}).length;
+    return {
+      name: s.function?.name ?? "?",
+      descBytes,
+      schemaBytes,
+      total: descBytes + schemaBytes,
+    };
+  });
+  const total = perTool.reduce((sum, t) => sum + t.total, 0);
+  return { total, perTool };
+}
+
+describe("prompt budget — cache prefix size regression net", () => {
+  it("system prompt stays under the byte budget", () => {
+    const actual = CODE_SYSTEM_PROMPT.length;
+    if (actual > SYSTEM_PROMPT_BUDGET) {
+      throw new Error(
+        `CODE_SYSTEM_PROMPT is ${actual} bytes — exceeds budget ${SYSTEM_PROMPT_BUDGET}. Either compress an equivalent section in src/code/prompt.ts OR raise SYSTEM_PROMPT_BUDGET in tests/prompt-budget.test.ts with a justification in the commit message.`,
+      );
+    }
+    expect(actual).toBeLessThanOrEqual(SYSTEM_PROMPT_BUDGET);
+  });
+
+  it("code-mode tool list stays under the byte budget", () => {
+    const root = mkdtempSync(join(tmpdir(), "reasonix-budget-"));
+    try {
+      const tools = buildCodeToolset(root);
+      const { total, perTool } = totalToolBytes(tools);
+      if (total > TOOL_LIST_BUDGET) {
+        const top = perTool
+          .sort((a, b) => b.total - a.total)
+          .slice(0, 5)
+          .map((t) => `  ${t.name}: ${t.total} (${t.descBytes} desc + ${t.schemaBytes} schema)`)
+          .join("\n");
+        throw new Error(
+          `Tool spec list is ${total} bytes — exceeds budget ${TOOL_LIST_BUDGET}.\nTop 5 by size:\n${top}\nEither compress a description in src/tools/*.ts OR raise TOOL_LIST_BUDGET in tests/prompt-budget.test.ts with a justification.`,
+        );
+      }
+      expect(total).toBeLessThanOrEqual(TOOL_LIST_BUDGET);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("no single tool description exceeds 8 KiB on its own", () => {
+    const root = mkdtempSync(join(tmpdir(), "reasonix-budget-"));
+    try {
+      const tools = buildCodeToolset(root);
+      const { perTool } = totalToolBytes(tools);
+      const oversized = perTool.filter((t) => t.descBytes > 8 * 1024);
+      if (oversized.length > 0) {
+        const lines = oversized.map((t) => `  ${t.name}: ${t.descBytes} bytes`).join("\n");
+        throw new Error(
+          `Tools with descriptions over 8 KiB (every byte ships in every request):\n${lines}\nLong descriptions belong in tool error messages (shown on overrun) or the system prompt (where one copy serves the whole tool list), not in the tool spec.`,
+        );
+      }
+      expect(oversized).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("codeSystemPrompt with no memory stays under the budget too (defense in depth)", () => {
+    const root = mkdtempSync(join(tmpdir(), "reasonix-budget-"));
+    try {
+      const built = codeSystemPrompt(root);
+      expect(built.length).toBeLessThanOrEqual(SYSTEM_PROMPT_BUDGET_WITH_SKILLS);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Every byte of the system prompt and tool spec list ships in **every** request to DeepSeek — paid at full miss price the first time, ~10% on every subsequent cache hit. Recent PRs have grown both without anyone tracking the cumulative cost, and several users have reported higher token consumption since 0.46.0.

This PR adds `tests/prompt-budget.test.ts`, a regression net that locks the current values:

- `CODE_SYSTEM_PROMPT.length` ≤ **24,500 bytes** (currently 24,387 — under cap)
- code-mode tool spec list ≤ **40,000 bytes** (currently 39,377 across 35 tools — under cap)
- `codeSystemPrompt(root)` with built-in skills ≤ **26,500 bytes** (currently 26,337 — under cap)
- no single tool description > **8 KiB** on its own

A failing assertion forces the PR author to either compress an equivalent section, or raise the budget explicitly in the commit message — visible in code review.

This is PR #1 of a four-PR token-optimization series:
- #1 (this) — lock the budget so future regressions are caught
- #2 — compress the largest tool descriptions (search_content / install_skill / create_skill / remember / read_file)
- #3 — compress the system prompt (cut redundant tool inventory, merge audit rails)
- #4 — lower `read_file` outline threshold from 512 KiB → 64 KiB (recover the 0.46.0 regression)

## Test plan

- [x] `npm run verify` — all 231 test files / 3,241 tests pass
- [x] New `tests/prompt-budget.test.ts` — 4 tests, all pass
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean