### PR TITLE
feat(read_file): lower outline threshold 512 KiB → 64 KiB (recover 0.46.0 token regression)

### DIFF
--- a/src/code/setup.ts
+++ b/src/code/setup.ts
@@ -2,6 +2,7 @@ import { DeepSeekClient } from "../client.js";
 import {
   loadBaseUrl,
   loadEditMode,
+  loadFilesystemOutlineThresholdBytes,
   loadProjectShellAllowed,
   loadResolvedSkillPaths,
   readConfig,
@@ -41,8 +42,9 @@ export async function buildCodeToolset(opts: CodeToolsetOpts): Promise<CodeTools
   const tools = new ToolRegistry();
   const jobs = new JobRegistry();
 
+  const outlineThresholdBytes = loadFilesystemOutlineThresholdBytes();
   const registerRooted = (root: string): void => {
-    registerFilesystemTools(tools, { rootDir: root });
+    registerFilesystemTools(tools, { rootDir: root, outlineThresholdBytes });
     const cfg = readConfig();
     registerShellTools(tools, {
       rootDir: root,

--- a/src/config.ts
+++ b/src/config.ts
@@ -201,6 +201,10 @@ export interface ReasonixConfig {
   engineeringLifecycle?: {
     mode?: EngineeringLifecycleMode;
   };
+  filesystem?: {
+    /** read_file flips to outline mode for files above this. Default 64 KiB — keeps the cache prefix slim while covering ~99% of source files. Raise to 524288 (512 KiB) for the pre-0.46.0 "trust the cache" behavior. */
+    outlineThresholdBytes?: number;
+  };
   /** QQ Bot configuration */
   qq?: QQBotConfig;
 }
@@ -817,6 +821,15 @@ export function loadEngineeringLifecycleMode(
   const v = readConfig(path).engineeringLifecycle?.mode;
   if (v === "off" || v === "strict") return v;
   return "off";
+}
+
+/** Bytes above which `read_file` flips to outline mode. Returns `undefined` so callers can apply the registered default; non-positive / non-numeric config values fall through to the default too. */
+export function loadFilesystemOutlineThresholdBytes(
+  path: string = defaultConfigPath(),
+): number | undefined {
+  const v = readConfig(path).filesystem?.outlineThresholdBytes;
+  if (typeof v !== "number" || !Number.isFinite(v) || v <= 0) return undefined;
+  return Math.floor(v);
 }
 
 /** True when the onboarding tip for the review/AUTO gate has been shown. */

--- a/src/tools/filesystem.ts
+++ b/src/tools/filesystem.ts
@@ -26,13 +26,14 @@ export interface FilesystemToolsOptions {
   rootDir: string;
   /** false → register only read-side tools. Default true. */
   allowWriting?: boolean;
-  /** Files at or under this size get full content; larger go to outline mode. Default 512 KiB. */
+  /** Files at or under this size get full content; larger go to outline mode. Default 64 KiB. */
   outlineThresholdBytes?: number;
   /** Cap on total bytes from listing/grep tools — bounds tree-as-one-string accidents. */
   maxListBytes?: number;
 }
 
-const DEFAULT_OUTLINE_THRESHOLD_BYTES = 512 * 1024;
+/** 64 KiB covers ~99% of source files; larger ones (generated bundles, lockfiles, novels) outline-mode by default to keep the cache prefix slim. */
+const DEFAULT_OUTLINE_THRESHOLD_BYTES = 64 * 1024;
 const DEFAULT_MAX_LIST_BYTES = 256 * 1024;
 
 /** Refuse load above this; outline-mode would have to slurp the whole file to scan it. */

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -15,6 +15,7 @@ import {
   loadDesktopOpenTabs,
   loadEditMode,
   loadEngineeringLifecycleMode,
+  loadFilesystemOutlineThresholdBytes,
   loadIndexConfig,
   loadIndexUserConfig,
   loadPricingOverride,
@@ -388,6 +389,24 @@ describe("config", () => {
   it("loadEngineeringLifecycleMode coerces unknown values back to 'off'", () => {
     writeConfig({ engineeringLifecycle: { mode: "garbage" as any } }, path);
     expect(loadEngineeringLifecycleMode(path)).toBe("off");
+  });
+
+  it("loadFilesystemOutlineThresholdBytes returns undefined when unset (caller applies default)", () => {
+    expect(loadFilesystemOutlineThresholdBytes(path)).toBeUndefined();
+  });
+
+  it("loadFilesystemOutlineThresholdBytes accepts a positive integer", () => {
+    writeConfig({ filesystem: { outlineThresholdBytes: 524288 } }, path);
+    expect(loadFilesystemOutlineThresholdBytes(path)).toBe(524288);
+  });
+
+  it("loadFilesystemOutlineThresholdBytes ignores non-positive / non-numeric values", () => {
+    writeConfig({ filesystem: { outlineThresholdBytes: 0 } }, path);
+    expect(loadFilesystemOutlineThresholdBytes(path)).toBeUndefined();
+    writeConfig({ filesystem: { outlineThresholdBytes: -1 } }, path);
+    expect(loadFilesystemOutlineThresholdBytes(path)).toBeUndefined();
+    writeConfig({ filesystem: { outlineThresholdBytes: "big" as any } }, path);
+    expect(loadFilesystemOutlineThresholdBytes(path)).toBeUndefined();
   });
 
   it("loadReasoningEffort defaults to 'max' when unset", () => {


### PR DESCRIPTION
## Summary

#1043 (in 0.46.0) flipped `read_file` from "head + tail + outline preview" to "full content for files ≤ 512 KiB" on the theory that the prompt cache amortizes the cost. Multiple users have reported significantly higher token consumption since — and they are right:

- DeepSeek cache hits cost **~10% of input price**, not zero. A 10× larger tool result still pays ~10× more on the hit path.
- First read of each new file pays the full miss price.
- Once a file gets edited, the next read is fresh bytes — another full miss on the new tool result.

Drop the default outline threshold to **64 KiB**, which covers ~99% of real-world source files. Larger files (generated bundles, lockfiles, novels, fixtures) flip to outline mode: file metadata + first 80 lines + symbol map + concrete drill-in hints (`range:"A-B"`, `search_content`).

Users who want the pre-0.46.0 "trust the cache" behavior can opt in via config:

```json
{
  "filesystem": {
    "outlineThresholdBytes": 524288
  }
}
```

## Implementation

- `src/tools/filesystem.ts` — lower `DEFAULT_OUTLINE_THRESHOLD_BYTES` from `512 * 1024` to `64 * 1024`. The `read_file` description already interpolates this constant, so the tool spec automatically shifts to "FULL CONTENT for files ≤ 64 KiB" without a separate edit.
- `src/config.ts` — new `filesystem.outlineThresholdBytes` field + `loadFilesystemOutlineThresholdBytes` loader. Returns `undefined` on unset / non-positive / non-numeric values so the registered default wins.
- `src/code/setup.ts` — read the config at boot and pass `outlineThresholdBytes` to `registerFilesystemTools`. Other entry points (ACP, desktop) pick up the new default automatically; they're free to wire the loader the same way when needed.
- `tests/config.test.ts` — three new tests for the loader (default / round-trip / coercion).

## Expected impact

5–15k tokens saved per typical session, depending on how many >64 KiB files the user touches. Combined with #1320 / #1321 / #1323 (cache-prefix tax brought down from ~36k to ~16k tokens per request), this PR closes the loop on the original "this version consumes more" complaint.

This is PR #4 (last) of the token-optimization series.

## Test plan

- [x] `npm run verify` — all 230 test files / 3,240 tests pass
- [x] `tests/filesystem-tools.test.ts` — 120 tests still green (they explicitly pass `outlineThresholdBytes: 200` for outline-mode coverage so the new default doesn't break them)
- [x] `tests/config.test.ts` — 3 new tests for the loader, all pass
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean