### PR TITLE
fix(multi_edit): roll back files that may have been modified on write…

### DIFF
--- a/src/code/prompt.ts
+++ b/src/code/prompt.ts
@@ -165,7 +165,7 @@ Rules:
     >>>>>>> REPLACE
 - Do NOT use write_file to change existing files — the user reviews your edits as SEARCH/REPLACE. write_file is only for files you explicitly want to overwrite wholesale (rare).
 - Paths are relative to the working directory. Don't use absolute paths.
-- For multi-site changes — same file or across files — prefer \`multi_edit\` over N \`edit_file\` calls. Shape: \`{ edits: [{ path, search, replace }, ...] }\`. All edits validate before any file is written; any failure → ALL files untouched. Per-file edits run in array order, so a later edit can match text inserted by an earlier one.
+- For multi-site changes — same file or across files — prefer \`multi_edit\` over N \`edit_file\` calls. Shape: \`{ edits: [{ path, search, replace }, ...] }\`. All edits validate before any file is written; validation failures leave all files untouched. If a disk write fails after writing begins, multi_edit attempts to roll back files that may have been modified and reports any rollback failures. Per-file edits run in array order, so a later edit can match text inserted by an earlier one.
 
 # Trust what you already know
 

--- a/src/tools/filesystem.ts
+++ b/src/tools/filesystem.ts
@@ -681,7 +681,7 @@ Prefer \`list_directory\` for a single-level view, \`search_files\` to find spec
   registry.register({
     name: "multi_edit",
     description:
-      "Apply N SEARCH/REPLACE edits across ONE OR MORE files in a single atomic call. Edits run sequentially in array order; for edits that touch the same file, a later edit can match text inserted by an earlier one. If ANY edit fails (search not found, ambiguous match, empty search, file unreadable), NO files are written — atomic at the validation layer. Same per-edit rules as edit_file: `search` is exact text (whitespace sensitive, no regex) and must be unique in its target file at the moment that edit applies. Use this for renames spanning multiple files, cross-file refactors, or any batch where you'd otherwise loop edit_file.",
+      "Apply N SEARCH/REPLACE edits across ONE OR MORE files in one call. Edits validate across the full batch before writing. Validation failures leave all files untouched; disk write failures trigger best-effort rollback of files that may have been modified. Per-file edits run in array order, so a later edit can match text inserted by an earlier one. Same per-edit rules as edit_file: `search` is exact text (whitespace sensitive, no regex) and must be unique in its target file at the moment that edit applies. Use this for renames spanning multiple files, cross-file refactors, or any batch where you'd otherwise loop edit_file.",
     parameters: {
       type: "object",
       properties: {

--- a/src/tools/fs/edit.ts
+++ b/src/tools/fs/edit.ts
@@ -51,6 +51,7 @@ export async function applyMultiEdit(
     throw new Error("multi_edit: edits must contain at least one entry");
   }
   type FileState = {
+    before: string;
     buf: string;
     le: string;
     hunks: string[];
@@ -89,7 +90,7 @@ export async function applyMultiEdit(
         );
       }
       const le = before.includes("\r\n") ? "\r\n" : "\n";
-      state = { buf: before, le, hunks: [], deltaChars: 0, touched: 0 };
+      state = { before, buf: before, le, hunks: [], deltaChars: 0, touched: 0 };
       filesByPath.set(e.abs, state);
     }
     const adaptedSearch = e.search.replace(/\r?\n/g, state.le);
@@ -97,7 +98,7 @@ export async function applyMultiEdit(
     const firstIdx = state.buf.indexOf(adaptedSearch);
     if (firstIdx < 0) {
       throw new Error(
-        `multi_edit: edit #${i + 1} search text not found in ${rel} — no edits applied (multi_edit is atomic)`,
+        `multi_edit: edit #${i + 1} search text not found in ${rel} — no edits applied`,
       );
     }
     const nextIdx = state.buf.indexOf(adaptedSearch, firstIdx + 1);
@@ -116,8 +117,31 @@ export async function applyMultiEdit(
     state.touched++;
   }
 
-  for (const [abs, state] of filesByPath) {
-    await fs.writeFile(abs, state.buf, "utf8");
+  // Push to `attempted` BEFORE writeFile so a write that truncates or
+  // partially-writes before failing is also rolled back.
+  const attempted: Array<{ abs: string; before: string }> = [];
+  try {
+    for (const [abs, state] of filesByPath) {
+      attempted.push({ abs, before: state.before });
+      await fs.writeFile(abs, state.buf, "utf8");
+    }
+  } catch (writeErr) {
+    const rollbackFailures: string[] = [];
+    for (const item of [...attempted].reverse()) {
+      try {
+        await fs.writeFile(item.abs, item.before, "utf8");
+      } catch (restoreErr) {
+        rollbackFailures.push(`${displayRel(rootDir, item.abs)}: ${(restoreErr as Error).message}`);
+      }
+    }
+    if (rollbackFailures.length > 0) {
+      throw new Error(
+        `multi_edit: write failed after partial application: ${(writeErr as Error).message}; rollback failed for ${rollbackFailures.join("; ")}`,
+      );
+    }
+    throw new Error(
+      `multi_edit: write failed: ${(writeErr as Error).message}; rolled back all files that may have been modified`,
+    );
   }
 
   const fileCount = filesByPath.size;

--- a/tests/filesystem-tools.test.ts
+++ b/tests/filesystem-tools.test.ts
@@ -1185,6 +1185,52 @@ describe("filesystem tools (built-in, sandbox-enforced)", () => {
       expect(disk).toBe("ONE\r\ntwo\r\nTHREE\r\n");
     });
 
+    it("rolls back attempted files when a disk write fails mid-batch", async () => {
+      await fs.writeFile(join(root, "a.txt"), "alpha\n");
+      await fs.writeFile(join(root, "b.txt"), "bravo\n");
+
+      const originalWriteFile = fs.writeFile.bind(fs);
+      // First attempt to write b.txt fails; rollback retry passes through.
+      let bTxtFailed = false;
+      const spy = vi
+        .spyOn(fs, "writeFile")
+        .mockImplementation(
+          async (
+            path: string | URL | import("node:fs/promises").FileHandle,
+            data: any,
+            ...rest: any[]
+          ) => {
+            const resolved = typeof path === "string" ? path : path.toString();
+            if (resolved.endsWith("b.txt") && !bTxtFailed) {
+              bTxtFailed = true;
+              // Simulate partial write before failure (truncation from writeFile open).
+              await originalWriteFile(path, "PARTIAL", ...rest);
+              throw new Error("SIMULATED DISK FULL");
+            }
+            return originalWriteFile(path, data, ...rest);
+          },
+        );
+
+      try {
+        const out = await tools.dispatch(
+          "multi_edit",
+          JSON.stringify({
+            edits: [
+              { path: "a.txt", search: "alpha", replace: "ALPHA" },
+              { path: "b.txt", search: "bravo", replace: "BRAVO" },
+            ],
+          }),
+        );
+        expect(out).toMatch(/write failed/);
+        expect(out).toMatch(/rolled back/);
+      } finally {
+        spy.mockRestore();
+      }
+      // Both files must be restored to original content
+      expect(await fs.readFile(join(root, "a.txt"), "utf8")).toBe("alpha\n");
+      expect(await fs.readFile(join(root, "b.txt"), "utf8")).toBe("bravo\n");
+    });
+
     it("refuses when an edit references a non-existent file (atomic — no other files written)", async () => {
       await fs.writeFile(join(root, "a.txt"), "alpha\n");
       const out = await tools.dispatch(


### PR DESCRIPTION
## Summary

Add rollback-on-failure to `multi_edit`: when a disk write fails mid-batch, files that may have been modified (including the currently-failing file) are restored to their pre-edit content using the original text captured during validation.

## Problem

`multi_edit` was described as "atomic" but only had atomic validation — if validation passed and the write phase began, a write failure (disk full, permission change, IO error) would leave earlier files in the batch already modified. The error message claimed "no edits applied" even though partial writes had already landed on disk.

Furthermore, the failing file itself was excluded from rollback because the tracking array was pushed *after* `fs.writeFile` — a file that was truncated or partially written before the error was not restored.

## Fix

Three changes to [`src/tools/fs/edit.ts`](src/tools/fs/edit.ts:119-148):

1. **Push to the tracking array *before* `fs.writeFile`** — ensures the current file is also rolled back if truncation or partial content was written before the error.
2. **Use original content from validation, not a re-read** — `FileState.before` is set at initial `fs.readFile` during validation; rollback uses it directly, eliminating the TOCTOU window between validation and snapshot re-read.
3. **Reverse-order rollback** — most-recently-attempted files are restored first, conventional ordering for batch recovery.

Supporting changes:

- [`src/tools/filesystem.ts`](src/tools/filesystem.ts:684) — tool description updated from "atomic call" to "best-effort rollback of files that may have been modified".
- [`src/code/prompt.ts`](src/code/prompt.ts:168) — system prompt updated to reflect the same semantics.
- [`tests/filesystem-tools.test.ts`](tests/filesystem-tools.test.ts:1188-1230) — new test simulates partial write to `b.txt` followed by failure, asserts both `a.txt` and `b.txt` are restored to original content.

## Verification

| Check | Result |
|---|---|
| `npm run lint` | ✅ 625 files, no fixes applied |
| `npm run typecheck` | ✅ passes |
| `npm run test` | ✅ 3227 passed, **0 failed** (filesystem-tools: 121/121 including new rollback test) |
