### PR TITLE
fix(multi_edit): roll back files that may have been modified on write failure (supersedes #1325)

### DIFF
--- a/src/code/prompt.ts
+++ b/src/code/prompt.ts
@@ -80,7 +80,7 @@ Rules:
     >>>>>>> REPLACE
 - Don't use write_file to change existing files — the user reviews edits as SEARCH/REPLACE. write_file is for wholesale overwrites only.
 - Paths are relative to the working directory.
-- For multi-site changes use \`multi_edit\` — all edits validate before any file is written; any failure → all files untouched.
+- For multi-site changes use \`multi_edit\` — validation runs before any write; validation failures leave all files untouched. Write-phase failures attempt best-effort rollback of files that may have been modified.
 
 # Trust what you already know
 

--- a/src/tools/filesystem.ts
+++ b/src/tools/filesystem.ts
@@ -673,7 +673,7 @@ export function registerFilesystemTools(
   registry.register({
     name: "multi_edit",
     description:
-      "Apply N SEARCH/REPLACE edits across ONE OR MORE files in a single atomic call. Edits run sequentially in array order; for edits that touch the same file, a later edit can match text inserted by an earlier one. If ANY edit fails (search not found, ambiguous match, empty search, file unreadable), NO files are written — atomic at the validation layer. Same per-edit rules as edit_file: `search` is exact text (whitespace sensitive, no regex) and must be unique in its target file at the moment that edit applies. Use this for renames spanning multiple files, cross-file refactors, or any batch where you'd otherwise loop edit_file.",
+      "Apply N SEARCH/REPLACE edits across ONE OR MORE files in one call. Edits validate across the full batch before writing. Validation failures leave all files untouched; disk write failures trigger best-effort rollback of files that may have been modified. Per-file edits run in array order, so a later edit can match text inserted by an earlier one. Same per-edit rules as edit_file: `search` is exact text (whitespace sensitive, no regex) and must be unique in its target file at the moment that edit applies. Use this for renames spanning multiple files, cross-file refactors, or any batch where you'd otherwise loop edit_file.",
     parameters: {
       type: "object",
       properties: {

--- a/src/tools/fs/edit.ts
+++ b/src/tools/fs/edit.ts
@@ -51,6 +51,7 @@ export async function applyMultiEdit(
     throw new Error("multi_edit: edits must contain at least one entry");
   }
   type FileState = {
+    before: string;
     buf: string;
     le: string;
     hunks: string[];
@@ -89,7 +90,7 @@ export async function applyMultiEdit(
         );
       }
       const le = before.includes("\r\n") ? "\r\n" : "\n";
-      state = { buf: before, le, hunks: [], deltaChars: 0, touched: 0 };
+      state = { before, buf: before, le, hunks: [], deltaChars: 0, touched: 0 };
       filesByPath.set(e.abs, state);
     }
     const adaptedSearch = e.search.replace(/\r?\n/g, state.le);
@@ -97,7 +98,7 @@ export async function applyMultiEdit(
     const firstIdx = state.buf.indexOf(adaptedSearch);
     if (firstIdx < 0) {
       throw new Error(
-        `multi_edit: edit #${i + 1} search text not found in ${rel} — no edits applied (multi_edit is atomic)`,
+        `multi_edit: edit #${i + 1} search text not found in ${rel} — no edits applied`,
       );
     }
     const nextIdx = state.buf.indexOf(adaptedSearch, firstIdx + 1);
@@ -116,8 +117,31 @@ export async function applyMultiEdit(
     state.touched++;
   }
 
-  for (const [abs, state] of filesByPath) {
-    await fs.writeFile(abs, state.buf, "utf8");
+  // Push to `attempted` BEFORE writeFile so a write that truncates or
+  // partially-writes before failing is also rolled back.
+  const attempted: Array<{ abs: string; before: string }> = [];
+  try {
+    for (const [abs, state] of filesByPath) {
+      attempted.push({ abs, before: state.before });
+      await fs.writeFile(abs, state.buf, "utf8");
+    }
+  } catch (writeErr) {
+    const rollbackFailures: string[] = [];
+    for (const item of [...attempted].reverse()) {
+      try {
+        await fs.writeFile(item.abs, item.before, "utf8");
+      } catch (restoreErr) {
+        rollbackFailures.push(`${displayRel(rootDir, item.abs)}: ${(restoreErr as Error).message}`);
+      }
+    }
+    if (rollbackFailures.length > 0) {
+      throw new Error(
+        `multi_edit: write failed after partial application: ${(writeErr as Error).message}; rollback failed for ${rollbackFailures.join("; ")}`,
+      );
+    }
+    throw new Error(
+      `multi_edit: write failed: ${(writeErr as Error).message}; rolled back all files that may have been modified`,
+    );
   }
 
   const fileCount = filesByPath.size;

--- a/tests/filesystem-tools.test.ts
+++ b/tests/filesystem-tools.test.ts
@@ -1185,6 +1185,52 @@ describe("filesystem tools (built-in, sandbox-enforced)", () => {
       expect(disk).toBe("ONE\r\ntwo\r\nTHREE\r\n");
     });
 
+    it("rolls back attempted files when a disk write fails mid-batch", async () => {
+      await fs.writeFile(join(root, "a.txt"), "alpha\n");
+      await fs.writeFile(join(root, "b.txt"), "bravo\n");
+
+      const originalWriteFile = fs.writeFile.bind(fs);
+      // First attempt to write b.txt fails; rollback retry passes through.
+      let bTxtFailed = false;
+      const spy = vi
+        .spyOn(fs, "writeFile")
+        .mockImplementation(
+          async (
+            path: string | URL | import("node:fs/promises").FileHandle,
+            data: any,
+            ...rest: any[]
+          ) => {
+            const resolved = typeof path === "string" ? path : path.toString();
+            if (resolved.endsWith("b.txt") && !bTxtFailed) {
+              bTxtFailed = true;
+              // Simulate partial write before failure (truncation from writeFile open).
+              await originalWriteFile(path, "PARTIAL", ...rest);
+              throw new Error("SIMULATED DISK FULL");
+            }
+            return originalWriteFile(path, data, ...rest);
+          },
+        );
+
+      try {
+        const out = await tools.dispatch(
+          "multi_edit",
+          JSON.stringify({
+            edits: [
+              { path: "a.txt", search: "alpha", replace: "ALPHA" },
+              { path: "b.txt", search: "bravo", replace: "BRAVO" },
+            ],
+          }),
+        );
+        expect(out).toMatch(/write failed/);
+        expect(out).toMatch(/rolled back/);
+      } finally {
+        spy.mockRestore();
+      }
+      // Both files must be restored to original content
+      expect(await fs.readFile(join(root, "a.txt"), "utf8")).toBe("alpha\n");
+      expect(await fs.readFile(join(root, "b.txt"), "utf8")).toBe("bravo\n");
+    });
+
     it("refuses when an edit references a non-existent file (atomic — no other files written)", async () => {
       await fs.writeFile(join(root, "a.txt"), "alpha\n");
       const out = await tools.dispatch(


### PR DESCRIPTION
Rebased version of #1325 (authored by @T1anjiu) onto current main. Original PR had merge conflicts with #1323 (system prompt compression) and the new `tests/prompt-budget.test.ts` from #1320 caught its prompt growth.

Resolution:
- `src/code/prompt.ts`: kept the compressed phrasing from #1323 and folded the new rollback semantic into one tight line: "validation runs before any write; validation failures leave all files untouched. Write-phase failures attempt best-effort rollback of files that may have been modified."
- `src/tools/filesystem.ts`: auto-merged cleanly — `multi_edit` tool description now reads "Validation failures leave all files untouched; disk write failures trigger best-effort rollback of files that may have been modified."
- All other code (`src/tools/fs/edit.ts` rollback logic + new test in `tests/filesystem-tools.test.ts`) is unchanged from the original PR.

Original commit + authorship preserved (T1anjiu). Closes #1325 in favor of this branch.

## Summary (from the original PR)

Add rollback-on-failure to `multi_edit`: when a disk write fails mid-batch, files that may have been modified (including the currently-failing file) are restored to their pre-edit content using the original text captured during validation.

### Problem

`multi_edit` was described as "atomic" but only had atomic validation — if validation passed and the write phase began, a write failure (disk full, permission change, IO error) would leave earlier files in the batch already modified. The error message claimed "no edits applied" even though partial writes had already landed on disk.

Furthermore, the failing file itself was excluded from rollback because the tracking array was pushed *after* `fs.writeFile` — a file that was truncated or partially written before the error was not restored.

### Fix

Three changes to `src/tools/fs/edit.ts`:

1. **Push to the tracking array before `fs.writeFile`** — ensures the current file is also rolled back if truncation or partial content was written before the error.
2. **Use original content from validation, not a re-read** — `FileState.before` is set at initial `fs.readFile` during validation; rollback uses it directly, eliminating the TOCTOU window between validation and snapshot re-read.
3. **Reverse-order rollback** — most-recently-attempted files are restored first.

## Verification

- [x] `npm run verify` — 231 test files / 3,246 tests pass
- [x] `tests/prompt-budget.test.ts` — system prompt stays under budget (was the original CI red)
- [x] `tests/filesystem-tools.test.ts` — 121 tests including the new rollback test
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean

Closes #1299 ← wait, that was the other one. Closes nothing additional; original `Closes #1325` will land once this merges.