### PR TITLE
feat(slash): add command favorites with Ctrl+S toggle

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -1,5 +1,8 @@
 import { type WriteStream, statSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { relative, resolve } from "node:path";
+import { dirname, join } from "node:path";
 import { Box, Text, useStdin, useStdout } from "ink";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -400,6 +403,37 @@ interface StreamingState {
   toolCallBuild?: { name: string; chars: number };
 }
 
+// ── favorites persistence ─────────────────────────────────────────
+
+function favoritesPath(): string {
+  return join(homedir(), ".reasonix", "favorites.json");
+}
+
+function loadFavorites(): readonly string[] {
+  const path = favoritesPath();
+  if (!existsSync(path)) return [];
+  try {
+    const raw = readFileSync(path, "utf8");
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed) && parsed.every((v) => typeof v === "string")) return parsed;
+    return [];
+  } catch {
+    return [];
+  }
+}
+
+function saveFavorites(favs: readonly string[]): void {
+  const path = favoritesPath();
+  const tmp = `${path}.tmp`;
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(tmp, JSON.stringify(favs), "utf8");
+    renameSync(tmp, path);
+  } catch {
+    /* disk full / perms — non-fatal */
+  }
+}
+
 export function App(props: AppProps): React.ReactElement {
   markPhase("app_render_start");
   const session = useAgentSession({
@@ -509,6 +543,7 @@ function AppInner({
   const [slashUsage, setSlashUsage] = useState<Readonly<Record<string, number>>>(() =>
     loadSlashUsage(),
   );
+  const [favorites, setFavorites] = useState<readonly string[]>(() => loadFavorites());
   // ctrl-o toggles full-tail view on the live streaming card.
   // Auto-resets at the end of every turn so the next reply starts collapsed.
   const [liveExpand, setLiveExpand] = useState(false);
@@ -1483,6 +1518,7 @@ function AppInner({
     models,
     mcpServers: liveMcpServers,
     slashUsage,
+    favorites,
   });
 
   useEffect(() => {
@@ -1634,6 +1670,21 @@ function AppInner({
   // — no modal / picker should swallow it.
   useKeystroke((ev) => {
     if (ev.ctrl && ev.input === "d") quitProcess();
+  });
+
+  // Ctrl+S in slash menu = toggle favorite on the highlighted command.
+  useKeystroke((ev) => {
+    if (!(ev.ctrl && (ev.input === "s" || ev.input === "S"))) return;
+    if (slashMatches === null || slashMatches.length === 0) return;
+    const target = slashMatches[slashSelected];
+    if (!target) return;
+    setFavorites((prev) => {
+      const next = prev.includes(target.cmd)
+        ? prev.filter((c) => c !== target.cmd)
+        : [...prev, target.cmd];
+      saveFavorites(next);
+      return next;
+    });
   });
 
   // Ctrl+R = verbose toggle. ReasoningCard / ToolCard skip elision while on.
@@ -2672,7 +2723,7 @@ function AppInner({
       // input when they know what they want).
       if (text.startsWith("/") && !text.includes(" ")) {
         const typed = text.slice(1).toLowerCase();
-        const matches = suggestSlashCommands(typed, !!codeMode, slashUsage);
+        const matches = suggestSlashCommands(typed, !!codeMode, slashUsage, favorites);
         const exact = matches.find((m) => m.cmd === typed);
         if (!exact && matches.length > 0) {
           const chosen = matches[slashSelected] ?? matches[0];
@@ -3447,6 +3498,7 @@ function AppInner({
       liveMcpServers,
       generateCurrentSessionTitle,
       switchWorkspaceRoot,
+      favorites,
     ],
   );
 
@@ -4579,6 +4631,7 @@ function AppInner({
                     slashSelected={slashSelected}
                     slashGroupMode={slashGroupMode}
                     slashAdvancedHidden={slashAdvancedHidden}
+                    slashFavorites={favorites}
                     atState={atState}
                     atSelected={atSelected}
                     slashArgContext={slashArgContext}

--- a/src/cli/ui/ComposerArea.tsx
+++ b/src/cli/ui/ComposerArea.tsx
@@ -52,6 +52,7 @@ export interface ComposerAreaProps {
   slashSelected: SlashSuggestionsProps["selectedIndex"];
   slashGroupMode: SlashSuggestionsProps["groupMode"];
   slashAdvancedHidden: SlashSuggestionsProps["advancedHidden"];
+  slashFavorites: SlashSuggestionsProps["favorites"];
 
   atState: React.ComponentProps<typeof AtMentionSuggestions>["state"] | null;
   atSelected: React.ComponentProps<typeof AtMentionSuggestions>["selectedIndex"];
@@ -108,6 +109,7 @@ export const ComposerArea: React.FC<ComposerAreaProps> = React.memo(
     slashSelected,
     slashGroupMode,
     slashAdvancedHidden,
+    slashFavorites,
     atState,
     atSelected,
     slashArgContext,
@@ -124,6 +126,7 @@ export const ComposerArea: React.FC<ComposerAreaProps> = React.memo(
               selectedIndex={slashSelected}
               groupMode={slashGroupMode}
               advancedHidden={slashAdvancedHidden}
+              favorites={slashFavorites}
             />
           ) : null}
           {atState !== null ? (

--- a/src/cli/ui/SlashSuggestions.tsx
+++ b/src/cli/ui/SlashSuggestions.tsx
@@ -16,6 +16,8 @@ export interface SlashSuggestionsProps {
   groupMode?: boolean;
   /** Count of hidden `advanced` commands; rendered as a footer hint when groupMode is true. */
   advancedHidden?: number;
+  /** User-favorited command names — shown with a ★ marker. */
+  favorites?: readonly string[];
 }
 
 function groupLabel(group: SlashGroup): string {
@@ -28,6 +30,7 @@ export function SlashSuggestions({
   selectedIndex,
   groupMode,
   advancedHidden,
+  favorites,
 }: SlashSuggestionsProps): React.ReactElement | null {
   const color = useColor();
   const { stdout } = useStdout();
@@ -65,6 +68,7 @@ export function SlashSuggestions({
     );
   }
   const total = matches.length;
+  const favSet = favorites && favorites.length > 0 ? new Set(favorites) : null;
   const items = buildVisibleItems(matches, windowStart, maxRows, groupMode);
   const shownCommands = items.filter((item) => item.kind === "command");
   const hiddenAbove = windowStart;
@@ -95,6 +99,7 @@ export function SlashSuggestions({
             spec={item.spec}
             isSelected={item.index === selectedIndex}
             columns={cols}
+            isFavorite={favSet?.has(item.spec.cmd) ?? false}
           />
         );
       })}
@@ -176,10 +181,12 @@ function SuggestionRow({
   spec,
   isSelected,
   columns,
+  isFavorite,
 }: {
   spec: SlashCommandSpec;
   isSelected: boolean;
   columns: number;
+  isFavorite: boolean;
 }) {
   const color = useColor();
   const name = `/${spec.cmd}`;
@@ -206,6 +213,7 @@ function SuggestionRow({
       <Text color={isSelected ? color.user : color.info} dimColor={!isSelected} wrap="truncate">
         {summaryText}
       </Text>
+      {isFavorite ? <Text color={color.accent}> ★</Text> : null}
     </Box>
   );
 }

--- a/src/cli/ui/slash/commands.ts
+++ b/src/cli/ui/slash/commands.ts
@@ -388,8 +388,10 @@ export function suggestSlashCommands(
   prefix: string,
   codeMode = false,
   counts?: Readonly<Record<string, number>>,
+  favorites?: readonly string[],
 ): SlashCommandSpec[] {
   const p = prefix.toLowerCase();
+  const favSet = favorites && favorites.length > 0 ? new Set(favorites) : null;
   const matches = SLASH_COMMANDS.filter((c) => {
     // Empty prefix = browsing the menu — show the full release command surface except
     // advanced rows, which remain collapsed behind the footer hint.
@@ -398,14 +400,30 @@ export function suggestSlashCommands(
     if (c.cmd.startsWith(p)) return true;
     return c.aliases?.some((a) => a.startsWith(p)) ?? false;
   });
-  if (p === "") return orderSlashCommandsByGroup(matches);
-  if (!counts) return matches;
+  if (p === "") {
+    const grouped = orderSlashCommandsByGroup(matches);
+    if (!favSet) return grouped;
+    // Favorites first, then non-favorites — both preserve group order within.
+    const favs = grouped.filter((c) => favSet.has(c.cmd));
+    const rest = grouped.filter((c) => !favSet.has(c.cmd));
+    return [...favs, ...rest];
+  }
+  if (!counts) {
+    if (!favSet) return matches;
+    const favs = matches.filter((c) => favSet.has(c.cmd));
+    const rest = matches.filter((c) => !favSet.has(c.cmd));
+    return [...favs, ...rest];
+  }
   const indexOf = new Map(matches.map((s, i) => [s.cmd, i]));
-  return [...matches].sort((a, b) => {
+  const sorted = [...matches].sort((a, b) => {
     const diff = (counts[b.cmd] ?? 0) - (counts[a.cmd] ?? 0);
     if (diff !== 0) return diff;
     return (indexOf.get(a.cmd) ?? 0) - (indexOf.get(b.cmd) ?? 0);
   });
+  if (!favSet) return sorted;
+  const favs = sorted.filter((c) => favSet.has(c.cmd));
+  const rest = sorted.filter((c) => !favSet.has(c.cmd));
+  return [...favs, ...rest];
 }
 
 export function countAdvancedCommands(codeMode: boolean): number {

--- a/src/cli/ui/useCompletionPickers.ts
+++ b/src/cli/ui/useCompletionPickers.ts
@@ -31,6 +31,8 @@ export interface UseCompletionPickersParams {
   mcpServers: McpServerSummary[] | undefined;
   /** Cross-session slash invocation counts — used to sort suggestions by frequency. */
   slashUsage?: Readonly<Record<string, number>>;
+  /** User-favorited command names — pinned to top of slash suggestions. */
+  favorites?: readonly string[];
 }
 
 export interface AtPickerEntry {
@@ -97,13 +99,14 @@ export function useCompletionPickers({
   models,
   mcpServers,
   slashUsage,
+  favorites,
 }: UseCompletionPickersParams): UseCompletionPickersResult {
   // ── slash-name picker ──
   const [slashSelected, setSlashSelected] = useState(0);
   const slashMatches = useMemo(() => {
     if (!input.startsWith("/") || input.includes(" ")) return null;
-    return suggestSlashCommands(input.slice(1), !!codeMode, slashUsage);
-  }, [input, codeMode, slashUsage]);
+    return suggestSlashCommands(input.slice(1), !!codeMode, slashUsage, favorites);
+  }, [input, codeMode, slashUsage, favorites]);
   const slashGroupMode = input === "/";
   const slashAdvancedHidden = useMemo(
     () => (slashGroupMode ? countAdvancedCommands(!!codeMode) : 0),

--- a/tests/slash-favorites.test.ts
+++ b/tests/slash-favorites.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { suggestSlashCommands } from "../src/cli/ui/slash/commands.js";
+
+describe("suggestSlashCommands with favorites", () => {
+  it("puts favorited commands first in group mode (empty prefix)", () => {
+    const result = suggestSlashCommands("", false, undefined, ["help", "new"]);
+    // help and new should be the first two
+    expect(result[0]?.cmd).toBe("help");
+    expect(result[1]?.cmd).toBe("new");
+    // Non-favorites come after
+    const rest = result.slice(2);
+    for (const c of rest) {
+      expect(c.cmd).not.toBe("help");
+      expect(c.cmd).not.toBe("new");
+    }
+  });
+
+  it("puts favorited commands first in search mode", () => {
+    const result = suggestSlashCommands("c", false, undefined, ["compact", "copy"]);
+    expect(result[0]?.cmd).toBe("compact");
+    expect(result[1]?.cmd).toBe("copy");
+  });
+
+  it("puts favorited commands first with counts-based sorting", () => {
+    const counts: Record<string, number> = { help: 5, new: 3, retry: 10, compact: 1 };
+    const result = suggestSlashCommands("", false, counts, ["compact", "retry"]);
+    // Favorites first (preserving group order: retry before compact in SLASH_COMMANDS)
+    expect(result[0]?.cmd).toBe("retry");
+    expect(result[1]?.cmd).toBe("compact");
+    // Then non-favorites sorted by count
+    const rest = result.slice(2);
+    const helpIdx = rest.findIndex((c) => c.cmd === "help");
+    const newIdx = rest.findIndex((c) => c.cmd === "new");
+    expect(helpIdx).toBeGreaterThanOrEqual(0);
+    expect(newIdx).toBeGreaterThanOrEqual(0);
+  });
+
+  it("works correctly with no favorites", () => {
+    const withFavs = suggestSlashCommands("", false, undefined, []);
+    const withoutFavs = suggestSlashCommands("", false, undefined, undefined);
+    expect(withFavs.map((c) => c.cmd)).toEqual(withoutFavs.map((c) => c.cmd));
+  });
+
+  it("ignores favorite names that don't match any command", () => {
+    const result = suggestSlashCommands("", false, undefined, ["nonexistent", "help"]);
+    expect(result[0]?.cmd).toBe("help");
+  });
+});


### PR DESCRIPTION
## Summary

Users can mark commands as favorites in the \`/\` slash menu by pressing \`Ctrl+S\` on the highlighted command. Favorited commands appear first (with a ★ marker) and persist across sessions.

## Design

- **Storage:** \`~/.reasonix/favorites.json\` (global, cross-project) — a \`string[]\` of command names
- **Interaction:** \`Ctrl+S\` toggles favorite on the currently selected slash command in the \`/\` menu
- **Sorting:** Favorited commands appear first (preserving group order), unfavorited ones follow (sorted by usage frequency)
- **UI:** ★ appended to the right of favorited command rows

## Files changed

| File | Change |
|------|--------|
| \`src/cli/ui/slash/commands.ts\` | \`suggestSlashCommands\` accepts optional \`favorites\` array; favorited commands prioritized in all three sort modes |
| \`src/cli/ui/App.tsx\` | Load/save \`favorites.json\`, Ctrl+S keystroke handler, pass favorites to suggestions |
| \`src/cli/ui/SlashSuggestions.tsx\` | ★ marker on favorited rows |
| \`src/cli/ui/ComposerArea.tsx\` | Passes \`favorites\` prop through |
| \`tests/slash-favorites.test.ts\` | 5 tests covering sort logic (group mode, search mode, counts, no favorites, unknown commands) |

## Demo

\`\`\`
/                           ← 用户输入 /
  ★ help    查看所有命令    ← Ctrl+S 收藏的
  ★ compact 折叠旧轮次
  ★ feedback 提交反馈
  ─────────────────
    new     新会话          ← 按使用频率排
    retry   重发
    ...
\`\`\`