### PR TITLE
fix(ui): highlight selected picker rows

### DIFF
--- a/src/cli/ui/AtMentionSuggestions.tsx
+++ b/src/cli/ui/AtMentionSuggestions.tsx
@@ -3,6 +3,7 @@ import { Box, Text } from "ink";
 import React from "react";
 import { t } from "../../i18n/index.js";
 import { GLYPH, useColor } from "./theme.js";
+import { SURFACE } from "./theme/tokens.js";
 import type { AtPickerEntry, AtPickerState } from "./useCompletionPickers.js";
 
 export interface AtMentionSuggestionsProps {
@@ -123,7 +124,7 @@ function EntryRow({ entry, isSelected }: { entry: AtPickerEntry; isSelected: boo
   const labelColor = entry.isDir ? color.accent : color.primary;
   const labelText = entry.isDir ? `${entry.label}/` : entry.label;
   return (
-    <Box>
+    <Box backgroundColor={isSelected ? SURFACE.bgElev : undefined}>
       <Text color={isSelected ? color.primary : color.info} bold={isSelected}>
         {cursor}
       </Text>

--- a/src/cli/ui/SlashArgPicker.tsx
+++ b/src/cli/ui/SlashArgPicker.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { t } from "../../i18n/index.js";
 import type { SlashCommandSpec } from "./slash.js";
 import { GLYPH, useColor } from "./theme.js";
+import { SURFACE } from "./theme/tokens.js";
 import type { AtPickerEntry } from "./useCompletionPickers.js";
 
 export interface SlashArgPickerProps {
@@ -124,7 +125,7 @@ function ArgRow({
 }) {
   const color = useColor();
   return (
-    <Box>
+    <Box backgroundColor={isSelected ? SURFACE.bgElev : undefined}>
       <Text color={isSelected ? color.primary : color.info} bold={isSelected}>
         {isSelected ? `${GLYPH.cur} ` : "  "}
       </Text>

--- a/src/cli/ui/SlashSuggestions.tsx
+++ b/src/cli/ui/SlashSuggestions.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { t } from "../../i18n/index.js";
 import type { SlashCommandSpec, SlashGroup } from "./slash.js";
 import { GLYPH, useColor } from "./theme.js";
+import { SURFACE } from "./theme/tokens.js";
 
 const GROUP_MODE_MAX_ROWS = 24;
 const SEARCH_MODE_MAX_ROWS = 8;
@@ -192,7 +193,14 @@ function SuggestionRow({
   const summaryBudget = Math.max(8, columns - reservedCells);
   const summaryText = truncateCells(`${summary}${aliasHint}`, summaryBudget);
   return (
-    <Box flexDirection="row" flexWrap="nowrap" flexShrink={0} height={1} minHeight={1}>
+    <Box
+      flexDirection="row"
+      flexWrap="nowrap"
+      flexShrink={0}
+      height={1}
+      minHeight={1}
+      backgroundColor={isSelected ? SURFACE.bgElev : undefined}
+    >
       <Text color={isSelected ? color.primary : color.info} bold={isSelected} wrap="truncate">
         {isSelected ? `${GLYPH.cur} ` : "  "}
       </Text>


### PR DESCRIPTION
## Summary

Add background highlight to selected rows in `@`-mention, `/`-command, and
`/`-argument suggestion pickers so the active item remains clearly visible
when navigating with arrow keys in light themes.

## Problem

In light themes (`light`, `github-light`), selected rows in the three
input-prefix pickers were visually indistinguishable from unselected rows.
The only cues were `bold` weight and a `▸` cursor glyph — but on a light
background, bold rendering is often too subtle (many terminal emulators
render it as a minor weight change). The result was a poor UX where users
could not tell which item was selected while scrolling through file or
command suggestions (issue #1311).

The initial implementation used `SURFACE.bgInput` as the highlight background,
but this token (`#f8fafc` in `light`, `#f6f8fa` in `github-light`) differs
from the canvas white (`#ffffff`) by only ~3 % luminance — still too weak
for reliable visual discrimination.

## Fix

Replace `SURFACE.bgInput` with `SURFACE.bgElev` in three picker row components:

| File | Component | Change |
|---|---|---|
| [`src/cli/ui/AtMentionSuggestions.tsx:127`](src/cli/ui/AtMentionSuggestions.tsx:127) | `EntryRow` | `bgInput` → `bgElev` |
| [`src/cli/ui/SlashArgPicker.tsx:128`](src/cli/ui/SlashArgPicker.tsx:128) | `ArgRow` | `bgInput` → `bgElev` |
| [`src/cli/ui/SlashSuggestions.tsx:202`](src/cli/ui/SlashSuggestions.tsx:202) | `SuggestionRow` | `bgInput` → `bgElev` |

`bgElev` (`#eef2f7` in `light`, `#eaeef2` in `github-light`) is the same
surface token already used by `EditPicker.tsx` (`EditPicker.tsx:91`) for
its focused-row highlight, providing consistent focus rendering across the
TUI.

## Verification

| Check | Result |
|---|---|
| `npm run lint` | ✅ 627 files, no fixes applied |
| `npm run typecheck` | ✅ passes |
| `npm run test` | ✅ 3236 passed, 2 pre-existing MCP net failures (unrelated) |
| Manual: `theme=light` `/` picker | ✅ selected row visually distinct |
| Manual: `theme=github-light` `@` picker | ✅ selected row visually distinct |
| Manual: `theme=dark` `/` picker | ✅ no regression — highlight visible but not harsh |

Closed #1311 