### PR TITLE
fix(skill): surface /skill in welcome hints + drop stale built-ins line (#1213)

### DIFF
--- a/src/cli/ui/WelcomeBanner.tsx
+++ b/src/cli/ui/WelcomeBanner.tsx
@@ -17,7 +17,7 @@ export interface WelcomeBannerProps {
   languageVersion?: number;
 }
 
-const HINTS = ["/help", "/init", "/memory", "/cost"] as const;
+const HINTS = ["/help", "/skill", "/init", "/memory", "/cost"] as const;
 
 export function WelcomeBanner({
   inCodeMode,

--- a/src/code/prompt.ts
+++ b/src/code/prompt.ts
@@ -43,9 +43,7 @@ Stronger constraint than submit_plan: writes + non-allowlisted run_command are b
 
 # Delegating to subagents via Skills
 
-The pinned Skills index lists playbooks for \`run_skill\`. Entries tagged \`[🧬 subagent]\` spawn an isolated child loop and return only the final answer — their tool calls never enter your context. Pass \`name\` as the BARE identifier (e.g. \`"explore"\`), not the \`[🧬 subagent]\` tag.
-
-Built-ins: **explore** (read-only codebase investigation) and **research** (web + code).
+The pinned Skills index below lists every available playbook (built-ins + user-installed). Entries tagged \`[🧬 subagent]\` spawn an isolated child loop and return only the final answer — their tool calls never enter your context. Pass \`name\` as the BARE identifier (e.g. \`"explore"\`), not the \`[🧬 subagent]\` tag.
 
 **Default: don't delegate.** Direct tools are cheaper and keep evidence in your context. Spawn ONLY for (a) true parallelism — 2+ independent investigations in one batch — or (b) context blow-up — >10 file reads where you only need the conclusion. Skip for single grep, 1-3 file cross-references, "to keep context clean for one question", anything needing user interaction, or work where you must track intermediate results yourself. Always pass clear, self-contained \`arguments\` — the subagent gets no other context.
 

--- a/tests/welcome-banner-hints.test.tsx
+++ b/tests/welcome-banner-hints.test.tsx
@@ -1,0 +1,19 @@
+/** #1213 — discoverability net: /skill must remain in the empty-session hint row. */
+
+import { render } from "ink-testing-library";
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { WelcomeBanner } from "../src/cli/ui/WelcomeBanner.js";
+
+describe("WelcomeBanner hint row", () => {
+  it("surfaces /skill alongside the other starter commands (#1213)", () => {
+    const { lastFrame } = render(<WelcomeBanner />);
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("/help");
+    expect(frame).toContain("/skill");
+    expect(frame).toContain("/init");
+    expect(frame).toContain("/memory");
+    expect(frame).toContain("/cost");
+  });
+});


### PR DESCRIPTION
## Summary

Issue #1213 reads as two complaints — "the model doesn't proactively call skills" and "we need more built-in skills" — but the root cause is upstream of both: **users don't discover the skill system at all.**

Five built-in skills already ship (`explore`, `research`, `review`, `security-review`, `test`) and `/skill list` shows them, but the empty-session WelcomeBanner only hints `/help /init /memory /cost`. `/skill` is absent. New users never see the surface exists, so the system's existing capability *looks* missing — and they file issues asking for it.

## Changes

- **`src/cli/ui/WelcomeBanner.tsx`** — add `/skill` to the starter hint row. Five chips instead of four; first-launch users now see the surface.
- **`src/code/prompt.ts`** — drop the static "Built-ins: **explore** ... and **research** ..." line. It enumerated 2 of the actual 5 built-ins (stale since `review` / `security-review` / `test` were added in #791 / #893), and the dynamic Skills index injected right below already lists every available playbook with its description. Saves ~80 bytes and stops understating what we ship.

## What is deliberately not changed

- **The "Default: don't delegate" rail stays.** Subagent spawning costs a fresh cache miss + a full child loop, and the project is cheap-first. Making the model more aggressive about Skills would burn tokens for marginal benefit — the opposite direction from the recent #1320 / #1321 / #1323 / #1324 token-optimization sweep. If a user wants `/review` to run, they can either invoke it via slash or describe their task in a way that explicitly asks for it.
- **No new built-in skills.** The five we ship cover the common cases; workflow-specific skills are exactly what `install_skill` / `create_skill` exist for, on a per-user basis without taxing the global prompt for everyone.

## Test plan

- [x] `npm run verify` — 234 test files / 3,256 tests pass
- [x] `tests/welcome-banner-hints.test.tsx` — new regression net asserts all five hint chips render
- [x] `tests/code-prompt.test.ts` + `tests/prompt-budget.test.ts` — green (the dropped line was not asserted on, and the deletion shrinks the prompt within budget)
- [x] `npm run lint` / `npm run typecheck` clean

Closes #1213