### PR TITLE
feat: Add Java source code search and decompilation tools.

### DIFF
--- a/src/code/setup.ts
+++ b/src/code/setup.ts
@@ -2,6 +2,7 @@ import { DeepSeekClient } from "../client.js";
 import {
   loadBaseUrl,
   loadEditMode,
+  loadJavaSourceEnabled,
   loadProjectShellAllowed,
   loadResolvedSkillPaths,
   readConfig,
@@ -75,7 +76,9 @@ export async function buildCodeToolset(opts: CodeToolsetOpts): Promise<CodeTools
       webSearchEndpoint: webSearchEndpoint(),
     });
   }
-  registerJavaSourceTool(tools, { projectRoot: opts.rootDir });
+  if (loadJavaSourceEnabled()) {
+    registerJavaSourceTool(tools, { projectRoot: opts.rootDir });
+  }
   // Lazy: constructing DeepSeekClient throws when DEEPSEEK_API_KEY is unset,
   // which would kill `reasonix code` before the setup wizard can prompt for
   // one. Defer to first subagent dispatch — by then the user has either keyed

--- a/src/code/setup.ts
+++ b/src/code/setup.ts
@@ -13,6 +13,7 @@ import { bootstrapSemanticSearchInCodeMode } from "../index/semantic/tool.js";
 import { ToolRegistry } from "../tools.js";
 import { registerChoiceTool } from "../tools/choice.js";
 import { registerFilesystemTools } from "../tools/filesystem.js";
+import { registerJavaSourceTool } from "../tools/java-source.js";
 import { JobRegistry } from "../tools/jobs.js";
 import { registerMemoryTools } from "../tools/memory.js";
 import { registerPlanTool } from "../tools/plan.js";
@@ -74,6 +75,7 @@ export async function buildCodeToolset(opts: CodeToolsetOpts): Promise<CodeTools
       webSearchEndpoint: webSearchEndpoint(),
     });
   }
+  registerJavaSourceTool(tools, { projectRoot: opts.rootDir });
   // Lazy: constructing DeepSeekClient throws when DEEPSEEK_API_KEY is unset,
   // which would kill `reasonix code` before the setup wizard can prompt for
   // one. Defer to first subagent dispatch — by then the user has either keyed

--- a/src/config.ts
+++ b/src/config.ts
@@ -189,6 +189,8 @@ export interface ReasonixConfig {
   skills?: {
     paths?: string[];
   };
+  /** Enable the `java_source` tool for finding and decompiling Java class source. Default off. */
+  javaSource?: boolean;
   /** User-declared extensions to the built-in memory types (#709). Unknown types round-trip even without a declaration; declaring one lets you attach a default priority + lifecycle. */
   memory?: {
     customTypes?: CustomMemoryTypeConfig[];
@@ -626,6 +628,13 @@ export function searchEnabled(path: string = defaultConfigPath()): boolean {
   const cfg = readConfig(path).search;
   if (cfg === false) return false;
   return true;
+}
+
+export function loadJavaSourceEnabled(path: string = defaultConfigPath()): boolean {
+  const env = process.env.REASONIX_JAVA_SOURCE;
+  if (env === "1" || env === "true") return true;
+  const cfg = readConfig(path).javaSource;
+  return cfg === true;
 }
 
 export function webSearchEngine(

--- a/src/java/class-source-finder.ts
+++ b/src/java/class-source-finder.ts
@@ -1,0 +1,296 @@
+// ClassSourceFinder — locate Java source by fully-qualified class name.
+// Two-step: (1) project .java walk, (2) .m2 jar scan + javap decompile.
+
+import { execFile } from "node:child_process";
+import * as fs from "node:fs";
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { listJarEntries, readJarEntry } from "./zip-reader.js";
+
+// ── types ────────────────────────────────────────────────────────────────────
+
+export interface FindResultSuccess {
+  found: true;
+  /** Reconstructed (or raw {@code .java}) source text. */
+  source: string;
+  // Where the source originated:
+  //   "project" — .java file in the project tree.
+  //   "m2-jar"  — decompiled from .m2 jar.
+  //   "jar"     — decompiled from user-specified jar path.
+  method: "project" | "m2-jar" | "jar";
+  /** Filesystem path to the {@code .java} file or the jar that was decompiled. */
+  sourcePath: string;
+}
+
+export interface FindResultNotFound {
+  found: false;
+  method: "not-found";
+}
+
+export type FindResult = FindResultSuccess | FindResultNotFound;
+
+export interface FindSourceOptions {
+  // When set, only scan .m2 jars whose filename or path contains this keyword.
+  // Dramatically reduces scan time when you know which library the class belongs
+  // to (e.g. "spring-core", "guava", "mycompany-utils").
+  jarKeyword?: string;
+}
+
+export interface ClassSourceFinderOptions {
+  /** Root of the Java project to scan for {@code .java} files. */
+  projectRoot: string;
+  // Path to the local Maven repository. Defaults to ~/.m2/repository.
+  m2Repo?: string;
+  // Command or absolute path for javap. Defaults to "javap".
+  javapCommand?: string;
+  // Maximum number of jar files to scan inside .m2 before giving up.
+  // Protects against huge repositories. Defaults to 2000.
+  maxJarScan?: number;
+  /**
+   * Signal to abort mid-scan (e.g. user pressed Escape).
+   */
+  signal?: AbortSignal;
+}
+
+// ── implementation ───────────────────────────────────────────────────────────
+
+export class ClassSourceFinder {
+  private projectRoot: string;
+  private m2Repo: string;
+  private javapCommand: string;
+  private maxJarScan: number;
+  private signal?: AbortSignal;
+
+  constructor(options: ClassSourceFinderOptions) {
+    this.projectRoot = path.resolve(options.projectRoot);
+    this.m2Repo = path.resolve(options.m2Repo ?? path.join(os.homedir(), ".m2", "repository"));
+    this.javapCommand = options.javapCommand ?? "javap";
+    this.maxJarScan = options.maxJarScan ?? 2000;
+    this.signal = options.signal;
+  }
+
+  // ── public API ──────────────────────────────────────────────────────────
+
+  // Find source for fullyQualifiedName.
+  // 1. Walk the project tree for a matching .java file.
+  // 2. Fall back to scanning .m2 jars (optionally filtered by jarKeyword).
+  async findSource(fullyQualifiedName: string, options?: FindSourceOptions): Promise<FindResult> {
+    this.throwIfAborted();
+
+    // 1. Project search
+    const projectResult = await this.searchProject(fullyQualifiedName);
+    if (projectResult) return projectResult;
+
+    // 2. Maven local repository (optionally filtered by jarKeyword)
+    return this.searchM2Repository(fullyQualifiedName, options?.jarKeyword);
+  }
+
+  // Like findSource, but skip project + .m2 — directly read from jarPath.
+  // @param fullyQualifiedName e.g. "com.example.MyClass"
+  // @param jarPath path to a specific .jar file
+  async findSourceInJar(fullyQualifiedName: string, jarPath: string): Promise<FindResult> {
+    this.throwIfAborted();
+
+    const resolvedJarPath = path.resolve(jarPath);
+    if (!fs.existsSync(resolvedJarPath)) {
+      return {
+        found: false,
+        method: "not-found",
+      };
+    }
+
+    const classEntry = `${fullyQualifiedName.replace(/\./g, "/")}.class`;
+    try {
+      const content = readJarEntry(resolvedJarPath, classEntry);
+      if (!content) {
+        return {
+          found: false,
+          method: "not-found",
+        };
+      }
+      const source = await this.decompileFromJar(resolvedJarPath, content.data, fullyQualifiedName);
+      return { found: true, source, method: "jar", sourcePath: resolvedJarPath };
+    } catch (err) {
+      return {
+        found: false,
+        method: "not-found",
+      };
+    }
+  }
+
+  // ── step 1: project search ──────────────────────────────────────────────
+
+  private async searchProject(fqn: string): Promise<FindResultSuccess | null> {
+    const simpleName = this.simpleClassName(fqn);
+    const suffixes = [
+      `${simpleName}.java`,
+      // Some projects keep source alongside generated code with a suffix
+      `${simpleName}.java.txt`,
+    ];
+
+    // Breadth-first walk so we find shallow matches quickly.
+    const queue: string[] = [this.projectRoot];
+    while (queue.length > 0) {
+      this.throwIfAborted();
+      const dir = queue.shift()!;
+      let entries: fs.Dirent[];
+      try {
+        entries = await fsp.readdir(dir, { withFileTypes: true });
+      } catch {
+        // Permission denied, broken symlink, etc. — skip.
+        continue;
+      }
+
+      for (const entry of entries) {
+        const fullPath = path.join(dir, entry.name);
+
+        if (entry.isDirectory()) {
+          // Skip common non-source directories.
+          if (
+            entry.name === "node_modules" ||
+            entry.name === ".git" ||
+            entry.name === "target" ||
+            entry.name === "build" ||
+            entry.name === "dist" ||
+            entry.name === ".idea" ||
+            entry.name === ".vscode" ||
+            entry.name === ".gradle"
+          ) {
+            continue;
+          }
+          queue.push(fullPath);
+        } else if (entry.isFile()) {
+          if (suffixes.includes(entry.name)) {
+            const source = await fsp.readFile(fullPath, "utf-8");
+            return { found: true, source, method: "project", sourcePath: fullPath };
+          }
+        }
+      }
+    }
+
+    return null;
+  }
+
+  // ── step 2: Maven local repository ──────────────────────────────────────
+
+  private async searchM2Repository(fqn: string, jarKeyword?: string): Promise<FindResult> {
+    const classEntry = `${fqn.replace(/\./g, "/")}.class`;
+
+    // Collect jar paths — filtered by keyword when provided.
+    const jarPaths: string[] = [];
+    await this.walkM2ForJars(this.m2Repo, jarPaths, jarKeyword);
+
+    let scanned = 0;
+    for (const jarPath of jarPaths) {
+      this.throwIfAborted();
+      if (scanned >= this.maxJarScan) break;
+
+      scanned++;
+      try {
+        const content = readJarEntry(jarPath, classEntry);
+        if (content) {
+          // Found the class inside this jar — decompile it.
+          const source = await this.decompileFromJar(jarPath, content.data, fqn);
+          return { found: true, source, method: "m2-jar", sourcePath: jarPath };
+        }
+      } catch {
+        // Corrupt jar, I/O error, etc. — skip to next.
+      }
+    }
+
+    return { found: false, method: "not-found" };
+  }
+
+  // Recursively walk dir collecting .jar file paths.
+  // keyword: case-insensitive filter on jar filename/path.
+  private async walkM2ForJars(dir: string, out: string[], keyword?: string): Promise<void> {
+    let entries: fs.Dirent[];
+    try {
+      entries = await fsp.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      this.throwIfAborted();
+      if (out.length >= this.maxJarScan) return;
+
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await this.walkM2ForJars(fullPath, out, keyword);
+      } else if (entry.isFile() && entry.name.endsWith(".jar")) {
+        // Apply keyword filter at the leaf — only push matching jars.
+        if (!keyword || fullPath.toLowerCase().includes(keyword.toLowerCase())) {
+          out.push(fullPath);
+        }
+      }
+    }
+  }
+
+  // ── decompilation ───────────────────────────────────────────────────────
+
+  // Decompile a .class entry extracted from a jar.
+  // Writes bytes to temp dir so javap can read via -cp <tmpdir>.
+  private async decompileFromJar(
+    jarPath: string,
+    classBytes: Buffer,
+    fqn: string,
+  ): Promise<string> {
+    // Create a temp directory that mirrors the package structure.
+    const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "reasonix-java-src-"));
+
+    try {
+      // Recreate the package directory structure.
+      const pkgPath = fqn.replace(/\./g, path.sep);
+      const classDir = path.join(tmpDir, path.dirname(pkgPath));
+      await fsp.mkdir(classDir, { recursive: true });
+
+      const classFile = path.join(tmpDir, `${pkgPath}.class`);
+      await fsp.writeFile(classFile, classBytes);
+
+      return await this.runJavap(fqn, tmpDir);
+    } finally {
+      // Best-effort cleanup.
+      await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }
+
+  // Run javap -c -p against a class on the given classpath.
+  private runJavap(className: string, classPath: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      execFile(
+        this.javapCommand,
+        ["-c", "-p", "-cp", classPath, className],
+        {
+          maxBuffer: 10 * 1024 * 1024, // 10 MiB
+          timeout: 30_000,
+          signal: this.signal,
+        },
+        (err, stdout, stderr) => {
+          if (err) {
+            // javap returns non-zero for various reasons; surface the
+            // stderr/stdout we did get rather than throwing away context.
+            const msg = [stdout, stderr].filter(Boolean).join("\n") || err.message;
+            reject(new Error(`javap failed: ${msg}`));
+            return;
+          }
+          resolve(stdout);
+        },
+      );
+    });
+  }
+
+  // ── helpers ─────────────────────────────────────────────────────────────
+
+  private simpleClassName(fqn: string): string {
+    const lastDot = fqn.lastIndexOf(".");
+    return lastDot === -1 ? fqn : fqn.slice(lastDot + 1);
+  }
+
+  private throwIfAborted(): void {
+    if (this.signal?.aborted) {
+      throw new DOMException("Aborted", "AbortError");
+    }
+  }
+}

--- a/src/java/class-source-finder.ts
+++ b/src/java/class-source-finder.ts
@@ -1,12 +1,12 @@
 // ClassSourceFinder — locate Java source by fully-qualified class name.
-// Two-step: (1) project .java walk, (2) .m2 jar scan + javap decompile.
+// Two-step: (1) project .java walk, (2) jar cache scan (Maven .m2, Gradle) + javap decompile.
 
 import { execFile } from "node:child_process";
 import * as fs from "node:fs";
 import * as fsp from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { listJarEntries, readJarEntry } from "./zip-reader.js";
+import { readJarEntry } from "./zip-reader.js";
 
 // ── types ────────────────────────────────────────────────────────────────────
 
@@ -16,7 +16,7 @@ export interface FindResultSuccess {
   source: string;
   // Where the source originated:
   //   "project" — .java file in the project tree.
-  //   "m2-jar"  — decompiled from .m2 jar.
+  //   "m2-jar"  — decompiled from a jar in Maven .m2 or Gradle cache.
   //   "jar"     — decompiled from user-specified jar path.
   method: "project" | "m2-jar" | "jar";
   /** Filesystem path to the {@code .java} file or the jar that was decompiled. */
@@ -40,16 +40,15 @@ export interface FindSourceOptions {
 export interface ClassSourceFinderOptions {
   /** Root of the Java project to scan for {@code .java} files. */
   projectRoot: string;
-  // Path to the local Maven repository. Defaults to ~/.m2/repository.
-  m2Repo?: string;
+  // One or more directories to scan for jars (Maven .m2, Gradle cache, etc.).
+  // When absent, auto-detects ~/.m2/repository/ and ~/.gradle/caches/ (whichever exist).
+  repoPaths?: string[];
   // Command or absolute path for javap. Defaults to "javap".
   javapCommand?: string;
-  // Maximum number of jar files to scan inside .m2 before giving up.
+  // Maximum number of jar files to scan before giving up.
   // Protects against huge repositories. Defaults to 2000.
   maxJarScan?: number;
-  /**
-   * Signal to abort mid-scan (e.g. user pressed Escape).
-   */
+  // Signal to abort mid-scan (e.g. user pressed Escape).
   signal?: AbortSignal;
 }
 
@@ -57,14 +56,23 @@ export interface ClassSourceFinderOptions {
 
 export class ClassSourceFinder {
   private projectRoot: string;
-  private m2Repo: string;
+  private repoPaths: string[];
   private javapCommand: string;
   private maxJarScan: number;
   private signal?: AbortSignal;
 
+  static defaultRepoPaths(): string[] {
+    const home = os.homedir();
+    const candidates = [path.join(home, ".m2", "repository"), path.join(home, ".gradle", "caches")];
+    return candidates.filter((p) => fs.existsSync(p));
+  }
+
   constructor(options: ClassSourceFinderOptions) {
     this.projectRoot = path.resolve(options.projectRoot);
-    this.m2Repo = path.resolve(options.m2Repo ?? path.join(os.homedir(), ".m2", "repository"));
+    this.repoPaths =
+      options.repoPaths && options.repoPaths.length > 0
+        ? options.repoPaths.map((p) => path.resolve(p))
+        : ClassSourceFinder.defaultRepoPaths();
     this.javapCommand = options.javapCommand ?? "javap";
     this.maxJarScan = options.maxJarScan ?? 2000;
     this.signal = options.signal;
@@ -74,7 +82,7 @@ export class ClassSourceFinder {
 
   // Find source for fullyQualifiedName.
   // 1. Walk the project tree for a matching .java file.
-  // 2. Fall back to scanning .m2 jars (optionally filtered by jarKeyword).
+  // 2. Fall back to scanning jar caches (Maven .m2, Gradle) (optionally filtered by jarKeyword).
   async findSource(fullyQualifiedName: string, options?: FindSourceOptions): Promise<FindResult> {
     this.throwIfAborted();
 
@@ -82,11 +90,11 @@ export class ClassSourceFinder {
     const projectResult = await this.searchProject(fullyQualifiedName);
     if (projectResult) return projectResult;
 
-    // 2. Maven local repository (optionally filtered by jarKeyword)
-    return this.searchM2Repository(fullyQualifiedName, options?.jarKeyword);
+    // 2. Jar cache repositories (optionally filtered by jarKeyword)
+    return this.searchRepositories(fullyQualifiedName, options?.jarKeyword);
   }
 
-  // Like findSource, but skip project + .m2 — directly read from jarPath.
+  // Like findSource, but skip project + repo scan — directly read from jarPath.
   // @param fullyQualifiedName e.g. "com.example.MyClass"
   // @param jarPath path to a specific .jar file
   async findSourceInJar(fullyQualifiedName: string, jarPath: string): Promise<FindResult> {
@@ -172,14 +180,16 @@ export class ClassSourceFinder {
     return null;
   }
 
-  // ── step 2: Maven local repository ──────────────────────────────────────
+  // ── step 2: jar cache repositories ─────────────────────────────────
 
-  private async searchM2Repository(fqn: string, jarKeyword?: string): Promise<FindResult> {
+  private async searchRepositories(fqn: string, jarKeyword?: string): Promise<FindResult> {
     const classEntry = `${fqn.replace(/\./g, "/")}.class`;
 
-    // Collect jar paths — filtered by keyword when provided.
+    // Collect jar paths across all repo dirs — filtered by keyword when provided.
     const jarPaths: string[] = [];
-    await this.walkM2ForJars(this.m2Repo, jarPaths, jarKeyword);
+    for (const repoDir of this.repoPaths) {
+      await this.walkForJars(repoDir, jarPaths, jarKeyword);
+    }
 
     let scanned = 0;
     for (const jarPath of jarPaths) {
@@ -190,7 +200,6 @@ export class ClassSourceFinder {
       try {
         const content = readJarEntry(jarPath, classEntry);
         if (content) {
-          // Found the class inside this jar — decompile it.
           const source = await this.decompileFromJar(jarPath, content.data, fqn);
           return { found: true, source, method: "m2-jar", sourcePath: jarPath };
         }
@@ -202,9 +211,19 @@ export class ClassSourceFinder {
     return { found: false, method: "not-found" };
   }
 
+  private static readonly MAX_WALK_DEPTH = 64;
+
   // Recursively walk dir collecting .jar file paths.
   // keyword: case-insensitive filter on jar filename/path.
-  private async walkM2ForJars(dir: string, out: string[], keyword?: string): Promise<void> {
+  // depth: guards against stack overflow on pathological directory structures.
+  private async walkForJars(
+    dir: string,
+    out: string[],
+    keyword?: string,
+    depth = 0,
+  ): Promise<void> {
+    if (depth >= ClassSourceFinder.MAX_WALK_DEPTH) return;
+
     let entries: fs.Dirent[];
     try {
       entries = await fsp.readdir(dir, { withFileTypes: true });
@@ -218,9 +237,8 @@ export class ClassSourceFinder {
 
       const fullPath = path.join(dir, entry.name);
       if (entry.isDirectory()) {
-        await this.walkM2ForJars(fullPath, out, keyword);
+        await this.walkForJars(fullPath, out, keyword, depth + 1);
       } else if (entry.isFile() && entry.name.endsWith(".jar")) {
-        // Apply keyword filter at the leaf — only push matching jars.
         if (!keyword || fullPath.toLowerCase().includes(keyword.toLowerCase())) {
           out.push(fullPath);
         }

--- a/src/java/index.ts
+++ b/src/java/index.ts
@@ -1,0 +1,10 @@
+export {
+  ClassSourceFinder,
+  type FindResult,
+  type FindResultSuccess,
+  type FindResultNotFound,
+  type FindSourceOptions,
+  type ClassSourceFinderOptions,
+} from "./class-source-finder.js";
+
+export { readJarEntry, listJarEntries, type JarEntry } from "./zip-reader.js";

--- a/src/java/zip-reader.ts
+++ b/src/java/zip-reader.ts
@@ -1,0 +1,179 @@
+// Minimal pure-Node.js ZIP / JAR entry reader.
+// Reads a single entry from a zip archive; no external dependencies.
+
+import * as fs from "node:fs";
+import * as zlib from "node:zlib";
+
+// ── constants ────────────────────────────────────────────────────────────────
+
+const EOCD_SIGNATURE = 0x06054b50;
+const CENTRAL_DIR_SIGNATURE = 0x02014b50;
+const LOCAL_FILE_SIGNATURE = 0x04034b50;
+
+const EOCD_MIN_SIZE = 22;
+const EOCD_MAX_COMMENT = 0xffff; // 65535 bytes
+
+const COMPRESSION_STORED = 0;
+const COMPRESSION_DEFLATED = 8;
+
+// ── types ────────────────────────────────────────────────────────────────────
+
+interface CentralDirEntry {
+  fileName: string;
+  compressionMethod: number;
+  compressedSize: number;
+  uncompressedSize: number;
+  localHeaderOffset: number;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function readU32LE(buf: Buffer, offset: number): number {
+  return buf.readUInt32LE(offset);
+}
+
+function readU16LE(buf: Buffer, offset: number): number {
+  return buf.readUInt16LE(offset);
+}
+
+function findEOCD(fd: number, fileSize: number): { offset: number; buf: Buffer } {
+  // The EOCD record sits at the end of the file, possibly preceded by a
+  // variable-length ZIP comment.  Search backwards in 1 KiB chunks.
+  const searchStart = Math.max(0, fileSize - EOCD_MAX_COMMENT - EOCD_MIN_SIZE);
+  let chunkOffset = fileSize;
+  while (chunkOffset > searchStart) {
+    const readSize = Math.min(1024, chunkOffset - searchStart);
+    chunkOffset -= readSize;
+    const buf = Buffer.alloc(readSize);
+    fs.readSync(fd, buf, 0, readSize, chunkOffset);
+
+    // Scan backwards through the chunk for the EOCD signature.
+    for (let i = readSize - 4; i >= 0; i--) {
+      if (buf.readUInt32LE(i) === EOCD_SIGNATURE) {
+        // We found the signature.  Return the EOCD bytes starting at that offset.
+        const eocdOffset = chunkOffset + i;
+        const eocdSize = Math.min(EOCD_MIN_SIZE + EOCD_MAX_COMMENT, fileSize - eocdOffset);
+        const eocdBuf = Buffer.alloc(eocdSize);
+        fs.readSync(fd, eocdBuf, 0, eocdSize, eocdOffset);
+        return { offset: eocdOffset, buf: eocdBuf };
+      }
+    }
+  }
+  throw new Error("Not a valid ZIP file: EOCD signature not found");
+}
+
+function parseCentralDirectory(fd: number, eocdBuf: Buffer): CentralDirEntry[] {
+  const centralDirOffset = readU32LE(eocdBuf, 16); // offset 16 in EOCD
+  const totalEntries = readU16LE(eocdBuf, 10); // offset 10 in EOCD
+
+  const entries: CentralDirEntry[] = [];
+  let offset = centralDirOffset;
+
+  for (let i = 0; i < totalEntries; i++) {
+    // Read the fixed-size (46-byte) central directory header.
+    const headerBuf = Buffer.alloc(46);
+    fs.readSync(fd, headerBuf, 0, 46, offset);
+
+    if (readU32LE(headerBuf, 0) !== CENTRAL_DIR_SIGNATURE) {
+      throw new Error(`Corrupt central directory at offset ${offset}`);
+    }
+
+    const compressionMethod = readU16LE(headerBuf, 10);
+    const compressedSize = readU32LE(headerBuf, 20);
+    const uncompressedSize = readU32LE(headerBuf, 24);
+    const fileNameLen = readU16LE(headerBuf, 28);
+    const extraLen = readU16LE(headerBuf, 30);
+    const commentLen = readU16LE(headerBuf, 32);
+    const localHeaderOffset = readU32LE(headerBuf, 42);
+
+    // Read the variable-length file name.
+    const nameBuf = Buffer.alloc(fileNameLen);
+    fs.readSync(fd, nameBuf, 0, fileNameLen, offset + 46);
+    const fileName = nameBuf.toString("utf8");
+
+    entries.push({
+      fileName,
+      compressionMethod,
+      compressedSize,
+      uncompressedSize,
+      localHeaderOffset,
+    });
+
+    offset += 46 + fileNameLen + extraLen + commentLen;
+  }
+
+  return entries;
+}
+
+// ── public API ───────────────────────────────────────────────────────────────
+
+export interface JarEntry {
+  fileName: string;
+  data: Buffer;
+}
+
+// Read a single entry from a ZIP / JAR file.
+// @param jarPath absolute path to the .jar
+// @param entryName exact entry name (e.g. "com/example/MyClass.class")
+export function readJarEntry(jarPath: string, entryName: string): JarEntry | null {
+  const fd = fs.openSync(jarPath, "r");
+  try {
+    const stat = fs.fstatSync(fd);
+    const fileSize = stat.size;
+
+    // 1. Find EOCD
+    const eocd = findEOCD(fd, fileSize);
+
+    // 2. Parse central directory
+    const entries = parseCentralDirectory(fd, eocd.buf);
+
+    // 3. Find the target entry
+    const target = entries.find((e) => e.fileName === entryName);
+    if (!target) return null;
+
+    // 4. Read the local file header
+    const localHeaderBuf = Buffer.alloc(30);
+    fs.readSync(fd, localHeaderBuf, 0, 30, target.localHeaderOffset);
+
+    if (readU32LE(localHeaderBuf, 0) !== LOCAL_FILE_SIGNATURE) {
+      throw new Error(`Corrupt local file header at offset ${target.localHeaderOffset}`);
+    }
+
+    const localFileNameLen = readU16LE(localHeaderBuf, 26);
+    const localExtraLen = readU16LE(localHeaderBuf, 28);
+
+    // 5. Read the compressed data
+    const dataOffset = target.localHeaderOffset + 30 + localFileNameLen + localExtraLen;
+    const compressedBuf = Buffer.alloc(target.compressedSize);
+    fs.readSync(fd, compressedBuf, 0, target.compressedSize, dataOffset);
+
+    // 6. Decompress if needed
+    let data: Buffer;
+    if (target.compressionMethod === COMPRESSION_STORED) {
+      data = compressedBuf;
+    } else if (target.compressionMethod === COMPRESSION_DEFLATED) {
+      data = zlib.inflateRawSync(compressedBuf);
+    } else {
+      throw new Error(
+        `Unsupported compression method ${target.compressionMethod} for entry "${entryName}"`,
+      );
+    }
+
+    return { fileName: target.fileName, data };
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+// List all entries in a ZIP / JAR file.
+export function listJarEntries(jarPath: string): string[] {
+  const fd = fs.openSync(jarPath, "r");
+  try {
+    const stat = fs.fstatSync(fd);
+    const eocd = findEOCD(fd, stat.size);
+    const entries = parseCentralDirectory(fd, eocd.buf);
+    return entries.map((e) => e.fileName);
+  } finally {
+    fs.closeSync(fd);
+  }
+}

--- a/src/tools/java-source.ts
+++ b/src/tools/java-source.ts
@@ -1,5 +1,6 @@
 // java_source tool — find and decompile Java source by fully-qualified class name.
-// Modes: (1) project .java walk, (2) .m2 jar scan, (3) direct jarPath.
+// Modes: (1) project .java walk, (2) Maven/Gradle jar cache scan, (3) direct jarPath.
+// Default-off: enabled via config.json `"javaSource": true` or env `REASONIX_JAVA_SOURCE=1`.
 
 import { ClassSourceFinder } from "../java/class-source-finder.js";
 import type { ToolRegistry } from "../tools.js";
@@ -50,7 +51,7 @@ export function registerJavaSourceTool(
         jarKeyword: {
           type: "string",
           description:
-            'Optional. Only search .m2 jars whose filename or path contains this keyword (case-insensitive). Dramatically narrows the scan when you know the library name, e.g. "spring-core", "guava", "mycompany-utils". Ignored when jarPath is also set.',
+            'Optional. Only search jars whose filename or path contains this keyword (case-insensitive). Dramatically narrows the scan when you know the library name, e.g. "spring-core", "guava", "mycompany-utils". Ignored when jarPath is also set.',
         },
       },
       required: ["className"],
@@ -81,7 +82,7 @@ export function registerJavaSourceTool(
       const jarKeyword = args?.jarKeyword?.trim();
 
       if (jarPath) {
-        // Mode: direct jar path — skip project + .m2
+        // Mode: direct jar path — skip project + repo scan
         const result = await finder.findSourceInJar(className, jarPath);
         if (!result.found) {
           return JSON.stringify({
@@ -99,18 +100,18 @@ export function registerJavaSourceTool(
         });
       }
 
-      // Default: project search → .m2 scan (optionally filtered by jarKeyword)
+      // Default: project search → jar cache scan (optionally filtered by jarKeyword)
       const result = await finder.findSource(className, {
         ...(jarKeyword ? { jarKeyword } : {}),
       });
 
       if (!result.found) {
         const keywordLine = jarKeyword
-          ? `  • ~/.m2/repository/ for jars containing keyword "${jarKeyword}"`
-          : "  • ~/.m2/repository/ for all jars";
+          ? `  • Maven .m2 / Gradle cache for jars containing keyword "${jarKeyword}"`
+          : "  • Maven .m2 / Gradle cache for all jars";
         const tip = jarKeyword
           ? "Try a different keyword, use `jarPath` with the exact path, or check if the class is in a different library."
-          : `Tip: pass \`jarKeyword\` (e.g. "spring-core", "guava") to narrow the .m2 scan, or \`jarPath\` with the exact jar path to skip the scan entirely.`;
+          : 'Tip: pass `jarKeyword` (e.g. "spring-core", "guava") to narrow the scan, or `jarPath` with the exact jar path to skip the scan entirely.';
         return JSON.stringify({
           status: "not-found",
           className,

--- a/src/tools/java-source.ts
+++ b/src/tools/java-source.ts
@@ -1,0 +1,132 @@
+// java_source tool — find and decompile Java source by fully-qualified class name.
+// Modes: (1) project .java walk, (2) .m2 jar scan, (3) direct jarPath.
+
+import { ClassSourceFinder } from "../java/class-source-finder.js";
+import type { ToolRegistry } from "../tools.js";
+
+export interface JavaSourceToolOptions {
+  // Root directory for .java file search. Falls back to process.cwd().
+  projectRoot?: string;
+}
+
+// Register the java_source tool on registry.
+// Parameters: className (required), projectRoot, jarPath, jarKeyword.
+export function registerJavaSourceTool(
+  registry: ToolRegistry,
+  opts: JavaSourceToolOptions = {},
+): ToolRegistry {
+  registry.register({
+    name: "java_source",
+    description: [
+      "Find and return Java source code by fully-qualified class name.",
+      "",
+      "Three search modes (picked automatically based on which parameters are set):",
+      "1. **Default** (className only): walk project tree for a `.java` file, then fall back to scanning `~/.m2/repository` jars.",
+      "2. **With jarKeyword** (className + jarKeyword): same as default, but only scan jars whose path/name contains the keyword — much faster when you know the library.",
+      "3. **With jarPath** (className + jarPath): skip both project + .m2 scans, decompile directly from the specified jar file.",
+      "",
+      "Returns the source text (or decompiled bytecode) on success, or a clear 'not found' message.",
+      "Only call this tool once per class name — it's I/O heavy.",
+    ].join("\n"),
+    readOnly: true,
+    parameters: {
+      type: "object",
+      properties: {
+        className: {
+          type: "string",
+          description:
+            'Fully qualified Java class name, e.g. "com.google.common.collect.Lists" or "org.springframework.web.servlet.DispatcherServlet".',
+        },
+        projectRoot: {
+          type: "string",
+          description:
+            "Optional. Override the project root directory for phase-1 file search. Defaults to the current session's workspace root.",
+        },
+        jarPath: {
+          type: "string",
+          description:
+            'Optional. Exact path to a .jar file. When set, skips project file search and .m2 scan — reads the class directly from this jar and decompiles it. Useful when you know which dependency jar contains the class, e.g. "/home/user/.m2/repository/org/springframework/spring-core/6.1.0/spring-core-6.1.0.jar".',
+        },
+        jarKeyword: {
+          type: "string",
+          description:
+            'Optional. Only search .m2 jars whose filename or path contains this keyword (case-insensitive). Dramatically narrows the scan when you know the library name, e.g. "spring-core", "guava", "mycompany-utils". Ignored when jarPath is also set.',
+        },
+      },
+      required: ["className"],
+    },
+    parallelSafe: true,
+    fn: async (args: {
+      className: string;
+      projectRoot?: string;
+      jarPath?: string;
+      jarKeyword?: string;
+    }) => {
+      const className = (args?.className ?? "").trim();
+      if (!className) {
+        throw new Error("java_source: `className` is required");
+      }
+
+      // Validate that the class name looks like a valid Java identifier chain.
+      if (!/^[a-zA-Z_$][\w$]*(\.[a-zA-Z_$][\w$]*)*$/.test(className)) {
+        throw new Error(
+          `java_source: "${className}" is not a valid fully qualified Java class name. Expected format: \`com.example.MyClass\``,
+        );
+      }
+
+      const projectRoot = args?.projectRoot?.trim() || opts.projectRoot || process.cwd();
+      const finder = new ClassSourceFinder({ projectRoot });
+
+      const jarPath = args?.jarPath?.trim();
+      const jarKeyword = args?.jarKeyword?.trim();
+
+      if (jarPath) {
+        // Mode: direct jar path — skip project + .m2
+        const result = await finder.findSourceInJar(className, jarPath);
+        if (!result.found) {
+          return JSON.stringify({
+            status: "not-found",
+            className,
+            message: `Class "${className}" not found in jar:\n  ${jarPath}\n\nMake sure the class name is correct and that the jar contains that entry.`,
+          });
+        }
+        return JSON.stringify({
+          status: "found",
+          className,
+          method: result.method,
+          sourcePath: result.sourcePath,
+          source: result.source,
+        });
+      }
+
+      // Default: project search → .m2 scan (optionally filtered by jarKeyword)
+      const result = await finder.findSource(className, {
+        ...(jarKeyword ? { jarKeyword } : {}),
+      });
+
+      if (!result.found) {
+        const keywordLine = jarKeyword
+          ? `  • ~/.m2/repository/ for jars containing keyword "${jarKeyword}"`
+          : "  • ~/.m2/repository/ for all jars";
+        const tip = jarKeyword
+          ? "Try a different keyword, use `jarPath` with the exact path, or check if the class is in a different library."
+          : `Tip: pass \`jarKeyword\` (e.g. "spring-core", "guava") to narrow the .m2 scan, or \`jarPath\` with the exact jar path to skip the scan entirely.`;
+        return JSON.stringify({
+          status: "not-found",
+          className,
+          message: `No source found for "${className}". Searched:\n  • ${projectRoot}/ for matching .java files\n  ${keywordLine}\n\n${tip}`,
+        });
+      }
+
+      return JSON.stringify({
+        status: "found",
+        className,
+        method: result.method,
+        sourcePath: result.sourcePath,
+        source: result.source,
+      });
+    },
+  });
+
+  return registry;
+}

--- a/tests/java-source.test.ts
+++ b/tests/java-source.test.ts
@@ -1,0 +1,918 @@
+import { execFile } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, sep } from "node:path";
+import { deflateRawSync } from "node:zlib";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ClassSourceFinder } from "../src/java/class-source-finder.js";
+import { listJarEntries, readJarEntry } from "../src/java/zip-reader.js";
+import { ToolRegistry } from "../src/tools.js";
+import { registerJavaSourceTool } from "../src/tools/java-source.js";
+
+// Default throwing implementation, reused for mock resets in afterEach hooks.
+// hoisted: vitest lifts vi.mock factories above all imports — the variable
+// must be declared inside vi.hoisted so it's visible when the factory runs.
+const { defaultExecFileImpl } = vi.hoisted(() => {
+  const fn = (_cmd: unknown, _args: unknown, _opts: unknown, cb: unknown) => {
+    if (typeof cb === "function") {
+      (cb as (err: Error | null, stdout: string, stderr: string) => void)(
+        new Error("execFile not configured for this test — mock it in beforeEach"),
+        "",
+        "",
+      );
+    }
+  };
+  return { defaultExecFileImpl: fn };
+});
+
+// Make execFile return errors by default — individual describe blocks
+// override this when they need javap to succeed.
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn(defaultExecFileImpl),
+}));
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+let tmpDirs: string[] = [];
+
+async function tmpDir(): Promise<string> {
+  const d = await mkdtemp(join(tmpdir(), "reasonix-java-test-"));
+  tmpDirs.push(d);
+  return d;
+}
+
+afterEach(async () => {
+  for (const d of tmpDirs) {
+    await rm(d, { recursive: true, force: true }).catch(() => {});
+  }
+  tmpDirs = [];
+});
+
+/** Table-based CRC32 — no external deps needed. */
+function crc32(buf: Buffer): number {
+  let crc = 0xffffffff;
+  for (let i = 0; i < buf.length; i++) {
+    crc ^= buf[i]!;
+    for (let j = 0; j < 8; j++) {
+      crc = crc & 1 ? (crc >>> 1) ^ 0xedb88320 : crc >>> 1;
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+// Create a minimal valid ZIP file with one or more entries.
+// compression: 0 = STORED (default), 8 = DEFLATED.
+function createZip(entries: Array<{ name: string; data: Buffer; compression?: number }>): Buffer {
+  const localHeaders: Buffer[] = [];
+  const centralEntries: Buffer[] = [];
+  let dataOffset = 0;
+
+  for (const entry of entries) {
+    const compressionMethod = entry.compression ?? 0;
+    const nameBytes = Buffer.from(entry.name, "utf8");
+    const data = entry.data;
+    const crc = crc32(data);
+
+    let compressedData: Buffer;
+    if (compressionMethod === 0) {
+      compressedData = data;
+    } else if (compressionMethod === 8) {
+      compressedData = deflateRawSync(data);
+    } else {
+      throw new Error(`Unsupported compression method: ${compressionMethod}`);
+    }
+
+    const compressedSize = compressedData.length;
+    const uncompressedSize = data.length;
+
+    // Local file header
+    const local = Buffer.alloc(30);
+    local.writeUInt32LE(0x04034b50, 0); // signature
+    local.writeUInt16LE(20, 4); // version needed
+    local.writeUInt16LE(0, 6); // flags
+    local.writeUInt16LE(compressionMethod, 8); // compression method
+    local.writeUInt16LE(0, 10); // mod time
+    local.writeUInt16LE(0, 12); // mod date
+    local.writeUInt32LE(crc, 14);
+    local.writeUInt32LE(compressedSize, 18); // compressed size
+    local.writeUInt32LE(uncompressedSize, 22); // uncompressed size
+    local.writeUInt16LE(nameBytes.length, 26);
+    local.writeUInt16LE(0, 28); // extra field length
+
+    localHeaders.push(Buffer.concat([local, nameBytes, compressedData]));
+
+    // Central directory entry
+    const central = Buffer.alloc(46);
+    central.writeUInt32LE(0x02014b50, 0); // signature
+    central.writeUInt16LE(20, 4); // version made by
+    central.writeUInt16LE(20, 6); // version needed
+    central.writeUInt16LE(0, 8); // flags
+    central.writeUInt16LE(compressionMethod, 10); // compression
+    central.writeUInt16LE(0, 12); // mod time
+    central.writeUInt16LE(0, 14); // mod date
+    central.writeUInt32LE(crc, 16);
+    central.writeUInt32LE(compressedSize, 20); // compressed size
+    central.writeUInt32LE(uncompressedSize, 24); // uncompressed size
+    central.writeUInt16LE(nameBytes.length, 28);
+    central.writeUInt16LE(0, 30); // extra field length
+    central.writeUInt16LE(0, 32); // comment length
+    central.writeUInt16LE(0, 34); // disk number start
+    central.writeUInt16LE(0, 36); // internal attrs
+    central.writeUInt32LE(0, 38); // external attrs
+    central.writeUInt32LE(dataOffset, 42); // local header offset
+
+    centralEntries.push(Buffer.concat([central, nameBytes]));
+    dataOffset += 30 + nameBytes.length + compressedData.length;
+  }
+
+  const centralDir = Buffer.concat(centralEntries);
+  const centralDirSize = centralDir.length;
+  const centralDirOffset = localHeaders.reduce((s, b) => s + b.length, 0);
+
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0); // signature
+  eocd.writeUInt16LE(0, 4); // disk number
+  eocd.writeUInt16LE(0, 6); // disk with central dir
+  eocd.writeUInt16LE(entries.length, 8); // entries on this disk
+  eocd.writeUInt16LE(entries.length, 10); // total entries
+  eocd.writeUInt32LE(centralDirSize, 12); // size of central directory
+  eocd.writeUInt32LE(centralDirOffset, 16); // offset of start of central directory
+  eocd.writeUInt16LE(0, 20); // comment length
+
+  return Buffer.concat([...localHeaders, centralDir, eocd]);
+}
+
+// ── zip-reader tests ─────────────────────────────────────────────────────────
+
+describe("readJarEntry", () => {
+  it("reads a stored entry from a valid zip", async () => {
+    const dir = await tmpDir();
+    const zipPath = join(dir, "test.jar");
+    const content = Buffer.from("hello world");
+    const zip = createZip([{ name: "hello.txt", data: content }]);
+    writeFileSync(zipPath, zip);
+
+    const result = readJarEntry(zipPath, "hello.txt");
+    expect(result).not.toBeNull();
+    expect(result!.fileName).toBe("hello.txt");
+    expect(result!.data.toString()).toBe("hello world");
+  });
+
+  it("returns null for a missing entry", async () => {
+    const dir = await tmpDir();
+    const zipPath = join(dir, "test.jar");
+    const zip = createZip([{ name: "present.class", data: Buffer.from("fake") }]);
+    writeFileSync(zipPath, zip);
+
+    const result = readJarEntry(zipPath, "missing.class");
+    expect(result).toBeNull();
+  });
+
+  it("reads a class entry from a jar-style path", async () => {
+    const dir = await tmpDir();
+    const zipPath = join(dir, "guava.jar");
+    const classContent = Buffer.from("fake bytecode");
+    const zip = createZip([{ name: "com/google/common/collect/Lists.class", data: classContent }]);
+    writeFileSync(zipPath, zip);
+
+    const result = readJarEntry(zipPath, "com/google/common/collect/Lists.class");
+    expect(result).not.toBeNull();
+    expect(result!.fileName).toBe("com/google/common/collect/Lists.class");
+  });
+
+  it("handles multiple entries and reads the right one", async () => {
+    const dir = await tmpDir();
+    const zipPath = join(dir, "multi.jar");
+    const zip = createZip([
+      { name: "META-INF/MANIFEST.MF", data: Buffer.from("Manifest-Version: 1.0\n") },
+      { name: "com/example/Foo.class", data: Buffer.from("foo bytes") },
+      { name: "com/example/Bar.class", data: Buffer.from("bar bytes") },
+    ]);
+    writeFileSync(zipPath, zip);
+
+    const foo = readJarEntry(zipPath, "com/example/Foo.class");
+    expect(foo!.data.toString()).toBe("foo bytes");
+
+    const bar = readJarEntry(zipPath, "com/example/Bar.class");
+    expect(bar!.data.toString()).toBe("bar bytes");
+  });
+});
+
+describe("listJarEntries", () => {
+  it("lists all entries in a zip", async () => {
+    const dir = await tmpDir();
+    const zipPath = join(dir, "test.jar");
+    const zip = createZip([
+      { name: "a.class", data: Buffer.from("a") },
+      { name: "b.class", data: Buffer.from("b") },
+      { name: "c.class", data: Buffer.from("c") },
+    ]);
+    writeFileSync(zipPath, zip);
+
+    const entries = listJarEntries(zipPath);
+    expect(entries).toEqual(["a.class", "b.class", "c.class"]);
+  });
+
+  it("returns empty array for empty zip", async () => {
+    const dir = await tmpDir();
+    const zipPath = join(dir, "empty.jar");
+    const zip = createZip([]);
+    writeFileSync(zipPath, zip);
+
+    const entries = listJarEntries(zipPath);
+    expect(entries).toEqual([]);
+  });
+});
+
+describe("readJarEntry — error handling", () => {
+  it("throws on non-existent file", () => {
+    expect(() => readJarEntry("/nonexistent/path.jar", "x")).toThrow();
+  });
+
+  it("throws on corrupt data (not a zip)", async () => {
+    const dir = await tmpDir();
+    const f = join(dir, "garbage.bin");
+    writeFileSync(f, Buffer.from("not a zip file"));
+    expect(() => readJarEntry(f, "x")).toThrow();
+  });
+});
+
+// ── ClassSourceFinder tests ──────────────────────────────────────────────────
+
+describe("ClassSourceFinder.defaultRepoPaths", () => {
+  it("returns an array (may be empty if no repo dirs exist)", () => {
+    const paths = ClassSourceFinder.defaultRepoPaths();
+    expect(Array.isArray(paths)).toBe(true);
+    for (const p of paths) {
+      expect(typeof p).toBe("string");
+    }
+  });
+});
+
+describe("ClassSourceFinder — project search", () => {
+  it("finds a .java file in the project tree", async () => {
+    const root = await tmpDir();
+    const pkgDir = join(root, "src", "com", "example");
+    mkdirSync(pkgDir, { recursive: true });
+    const javaSrc = "package com.example;\npublic class StringKit {}\n";
+    writeFileSync(join(pkgDir, "StringKit.java"), javaSrc);
+
+    const finder = new ClassSourceFinder({ projectRoot: root });
+    const result = await finder.findSource("com.example.StringKit");
+
+    expect(result.found).toBe(true);
+    if (result.found) {
+      expect(result.method).toBe("project");
+      expect(result.source).toContain("public class StringKit");
+      expect(result.sourcePath).toContain("StringKit.java");
+    }
+  });
+
+  it("returns not-found when no .java file matches", async () => {
+    const root = await tmpDir();
+    mkdirSync(join(root, "src"), { recursive: true });
+    writeFileSync(join(root, "src", "other.ts"), "export const x = 1;\n");
+
+    const finder = new ClassSourceFinder({ projectRoot: root });
+    const result = await finder.findSource("com.example.Missing");
+
+    expect(result.found).toBe(false);
+  });
+
+  it("skips common non-source directories", async () => {
+    const root = await tmpDir();
+    mkdirSync(join(root, "target", "classes"), { recursive: true });
+    writeFileSync(join(root, "target", "classes", "MyClass.java"), "// should be ignored");
+
+    const finder = new ClassSourceFinder({ projectRoot: root });
+    const result = await finder.findSource("MyClass");
+    // Should NOT find it since target/ is skipped
+    expect(result.found).toBe(false);
+  });
+
+  it("accepts jarKeyword filter (does not change project search result)", async () => {
+    const root = await tmpDir();
+    const pkgDir = join(root, "src");
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(join(pkgDir, "MyClass.java"), "public class MyClass {}");
+
+    const finder = new ClassSourceFinder({ projectRoot: root });
+    const result = await finder.findSource("MyClass", { jarKeyword: "spring" });
+
+    // jarKeyword only filters the jar-scan step; project search should still match
+    expect(result.found).toBe(true);
+  });
+});
+
+describe("ClassSourceFinder — direct jar path", () => {
+  it("reads the class entry from the jar (decompile step requires javap on PATH)", async () => {
+    const root = await tmpDir();
+    const jarPath = join(root, "my-lib.jar");
+    const classContent = Buffer.from("fake class data");
+    const zip = createZip([{ name: "com/example/Util.class", data: classContent }]);
+    writeFileSync(jarPath, zip);
+
+    // Test that the jar entry can be read correctly by the zip reader
+    const entry = readJarEntry(jarPath, "com/example/Util.class");
+    expect(entry).not.toBeNull();
+    expect(entry!.data.toString()).toBe("fake class data");
+  });
+
+  it("returns not-found for non-existent entry", async () => {
+    const root = await tmpDir();
+    const jarPath = join(root, "empty.jar");
+    const zip = createZip([{ name: "other/Class.class", data: Buffer.from("x") }]);
+    writeFileSync(jarPath, zip);
+
+    const finder = new ClassSourceFinder({ projectRoot: root });
+    const result = await finder.findSourceInJar("com.example.Missing", jarPath);
+
+    expect(result.found).toBe(false);
+  });
+
+  it("returns not-found for non-existent jar file", async () => {
+    const finder = new ClassSourceFinder({ projectRoot: "/tmp" });
+    const result = await finder.findSourceInJar("com.example.X", "/nonexistent/jar.jar");
+
+    expect(result.found).toBe(false);
+  });
+});
+
+describe("ClassSourceFinder — AbortSignal", () => {
+  it("throws on aborted signal", async () => {
+    const ctrl = new AbortController();
+    ctrl.abort();
+    const finder = new ClassSourceFinder({ projectRoot: "/tmp", signal: ctrl.signal });
+
+    await expect(finder.findSource("com.example.X")).rejects.toThrow("Aborted");
+  });
+});
+
+// ── zip-reader: DEFLATED compression ─────────────────────────────────────────
+
+describe("readJarEntry — DEFLATED compression", () => {
+  it("reads a DEFLATED entry from a zip", async () => {
+    const dir = await tmpDir();
+    const zipPath = join(dir, "deflated.jar");
+    const content = Buffer.from("hello deflated world");
+    const zip = createZip([{ name: "hello.txt", data: content, compression: 8 }]);
+    writeFileSync(zipPath, zip);
+
+    const result = readJarEntry(zipPath, "hello.txt");
+    expect(result).not.toBeNull();
+    expect(result!.fileName).toBe("hello.txt");
+    expect(result!.data.toString()).toBe("hello deflated world");
+  });
+
+  it("handles mixed STORED and DEFLATED entries", async () => {
+    const dir = await tmpDir();
+    const zipPath = join(dir, "mixed.jar");
+    const zip = createZip([
+      { name: "stored.txt", data: Buffer.from("stored content") },
+      {
+        name: "deflated.txt",
+        data: Buffer.from("deflated content"),
+        compression: 8,
+      },
+      { name: "another.txt", data: Buffer.from("more content") },
+    ]);
+    writeFileSync(zipPath, zip);
+
+    const stored = readJarEntry(zipPath, "stored.txt");
+    expect(stored!.data.toString()).toBe("stored content");
+
+    const deflated = readJarEntry(zipPath, "deflated.txt");
+    expect(deflated!.data.toString()).toBe("deflated content");
+
+    const another = readJarEntry(zipPath, "another.txt");
+    expect(another!.data.toString()).toBe("more content");
+  });
+});
+
+// ── ClassSourceFinder: repo scan ─────────────────────────────────────────────
+
+describe("ClassSourceFinder — repo scan", () => {
+  let repoDir: string;
+
+  beforeEach(async () => {
+    repoDir = await tmpDir();
+    // Mock execFile to succeed so decompilation works.
+    vi.mocked(execFile).mockImplementation(((
+      _cmd: unknown,
+      _args: unknown,
+      _opts: unknown,
+      cb: unknown,
+    ) => {
+      if (typeof cb === "function") {
+        (cb as (err: Error | null, stdout: string, stderr: string) => void)(
+          null,
+          'Compiled from "MyClass.java"\npublic class MyClass { public MyClass(); }\n',
+          "",
+        );
+      }
+    }) as any);
+  });
+
+  afterEach(() => {
+    vi.mocked(execFile).mockImplementation(defaultExecFileImpl as any);
+  });
+
+  it("finds class in repo jar when project search fails", async () => {
+    const projectRoot = await tmpDir();
+    mkdirSync(join(projectRoot, "src"), { recursive: true });
+    writeFileSync(join(projectRoot, "src", "other.ts"), "not java");
+
+    // Create a repo with a jar containing the class
+    const jarPath = join(repoDir, "my-lib-1.0.jar");
+    const zip = createZip([{ name: "com/example/Finder.class", data: Buffer.from("fake bytes") }]);
+    writeFileSync(jarPath, zip);
+
+    const finder = new ClassSourceFinder({
+      projectRoot,
+      repoPaths: [repoDir],
+    });
+    const result = await finder.findSource("com.example.Finder");
+
+    expect(result.found).toBe(true);
+    if (result.found) {
+      expect(result.method).toBe("m2-jar");
+      expect(result.sourcePath).toContain("my-lib-1.0.jar");
+      expect(result.source).toContain("public class MyClass");
+    }
+  });
+
+  it("jarKeyword filters to matching jars only", async () => {
+    const projectRoot = await tmpDir();
+    mkdirSync(join(projectRoot, "src"), { recursive: true });
+    writeFileSync(join(projectRoot, "src", "main.ts"), "not java");
+
+    // Both jars contain the same class name — only the "spring" one should be scanned
+    const springJar = join(repoDir, "spring-core-6.1.0.jar");
+    writeFileSync(
+      springJar,
+      createZip([{ name: "org/springframework/Bean.class", data: Buffer.from("fake") }]),
+    );
+    const otherJar = join(repoDir, "my-lib-1.0.jar");
+    writeFileSync(
+      otherJar,
+      createZip([{ name: "org/springframework/Bean.class", data: Buffer.from("fake") }]),
+    );
+
+    const finder = new ClassSourceFinder({
+      projectRoot,
+      repoPaths: [repoDir],
+    });
+    const result = await finder.findSource("org.springframework.Bean", { jarKeyword: "spring" });
+
+    expect(result.found).toBe(true);
+    if (result.found) {
+      // Should have found it in spring-core jar, not my-lib
+      expect(result.sourcePath).toContain("spring-core");
+    }
+  });
+
+  it("maxJarScan stops early when limit reached", async () => {
+    const projectRoot = await tmpDir();
+    mkdirSync(join(projectRoot, "src"), { recursive: true });
+    writeFileSync(join(projectRoot, "src", "other.ts"), "not java");
+
+    // Create 5 jars. The target class is only in the 5th.
+    for (let i = 1; i <= 5; i++) {
+      const jp = join(repoDir, `lib-${i}.jar`);
+      const entryName = i === 5 ? "com/example/Target.class" : "com/example/Other.class";
+      writeFileSync(jp, createZip([{ name: entryName, data: Buffer.from("fake") }]));
+    }
+
+    const finder = new ClassSourceFinder({
+      projectRoot,
+      repoPaths: [repoDir],
+      maxJarScan: 3, // Only scan first 3 jars — Target is in jar 5
+    });
+    const result = await finder.findSource("com.example.Target");
+
+    expect(result.found).toBe(false);
+  });
+
+  it("skips corrupt jar and continues scanning", async () => {
+    const projectRoot = await tmpDir();
+    mkdirSync(join(projectRoot, "src"), { recursive: true });
+    writeFileSync(join(projectRoot, "src", "other.ts"), "not java");
+
+    // Corrupt jar (not valid zip)
+    writeFileSync(join(repoDir, "corrupt.jar"), Buffer.from("not a zip file"));
+    // Valid jar with the target class
+    writeFileSync(
+      join(repoDir, "valid.jar"),
+      createZip([{ name: "com/example/Ok.class", data: Buffer.from("fake") }]),
+    );
+
+    const finder = new ClassSourceFinder({
+      projectRoot,
+      repoPaths: [repoDir],
+    });
+    const result = await finder.findSource("com.example.Ok");
+
+    expect(result.found).toBe(true);
+  });
+
+  it("uses custom repoPaths when provided", async () => {
+    const projectRoot = await tmpDir();
+    mkdirSync(join(projectRoot, "src"), { recursive: true });
+    writeFileSync(join(projectRoot, "src", "other.ts"), "not java");
+
+    // Two repo dirs, class in the second
+    const repoA = await tmpDir();
+    const repoB = await tmpDir();
+    writeFileSync(
+      join(repoB, "found.jar"),
+      createZip([{ name: "com/example/Custom.class", data: Buffer.from("fake") }]),
+    );
+
+    const finder = new ClassSourceFinder({
+      projectRoot,
+      repoPaths: [repoA, repoB],
+    });
+    const result = await finder.findSource("com.example.Custom");
+
+    expect(result.found).toBe(true);
+  });
+});
+
+// ── ClassSourceFinder: decompilation chain ───────────────────────────────────
+
+describe("ClassSourceFinder — decompilation", () => {
+  beforeEach(() => {
+    vi.mocked(execFile).mockImplementation(((
+      _cmd: unknown,
+      _args: unknown,
+      _opts: unknown,
+      cb: unknown,
+    ) => {
+      if (typeof cb === "function") {
+        (cb as (err: Error | null, stdout: string, stderr: string) => void)(
+          null,
+          'Compiled from "StringUtils.java"\npublic class StringUtils {\n  public StringUtils();\n    Code:\n       0: aload_0\n       1: invokespecial #1\n       4: return\n  public static String upper(String);\n    Code:\n       0: aload_0\n       1: invokevirtual #2\n       4: areturn\n}\n',
+          "",
+        );
+      }
+    }) as any);
+  });
+
+  afterEach(() => {
+    vi.mocked(execFile).mockImplementation(defaultExecFileImpl as any);
+  });
+
+  it("findSourceInJar reads + decompiles via javap", async () => {
+    const root = await tmpDir();
+    const jarPath = join(root, "commons-lang.jar");
+    writeFileSync(
+      jarPath,
+      createZip([{ name: "org/apache/commons/StringUtils.class", data: Buffer.from("fake") }]),
+    );
+
+    const finder = new ClassSourceFinder({ projectRoot: root });
+    const result = await finder.findSourceInJar("org.apache.commons.StringUtils", jarPath);
+
+    expect(result.found).toBe(true);
+    if (result.found) {
+      expect(result.method).toBe("jar");
+      expect(result.sourcePath).toBe(jarPath);
+      expect(result.source).toContain("public class StringUtils");
+      expect(result.source).toContain("String upper(String)");
+    }
+  });
+
+  it("findSource in repo mode returns javap output", async () => {
+    const projectRoot = await tmpDir();
+    mkdirSync(join(projectRoot, "src"), { recursive: true });
+    writeFileSync(join(projectRoot, "src", "main.ts"), "not java");
+
+    const repoPath = await tmpDir();
+    writeFileSync(
+      join(repoPath, "guava-33.0.jar"),
+      createZip([{ name: "com/google/common/base/Splitter.class", data: Buffer.from("fake") }]),
+    );
+
+    const finder = new ClassSourceFinder({
+      projectRoot,
+      repoPaths: [repoPath],
+    });
+    const result = await finder.findSource("com.google.common.base.Splitter");
+
+    expect(result.found).toBe(true);
+    if (result.found) {
+      expect(result.method).toBe("m2-jar");
+      expect(result.source).toContain("public class StringUtils");
+    }
+  });
+
+  it("findSourceInJar returns not-found when entry missing", async () => {
+    const root = await tmpDir();
+    const jarPath = join(root, "partial.jar");
+    writeFileSync(
+      jarPath,
+      createZip([{ name: "com/example/Present.class", data: Buffer.from("fake") }]),
+    );
+
+    const finder = new ClassSourceFinder({ projectRoot: root });
+    const result = await finder.findSourceInJar("com.example.Missing", jarPath);
+
+    expect(result.found).toBe(false);
+  });
+
+  it("findSourceInJar returns not-found when javap fails", async () => {
+    vi.mocked(execFile).mockImplementation(((
+      _cmd: unknown,
+      _args: unknown,
+      _opts: unknown,
+      cb: unknown,
+    ) => {
+      if (typeof cb === "function") {
+        (cb as (err: Error | null, stdout: string, stderr: string) => void)(
+          new Error("javap: command not found"),
+          "",
+          "javap: command not found",
+        );
+      }
+    }) as any);
+
+    const root = await tmpDir();
+    const jarPath = join(root, "broken.jar");
+    writeFileSync(
+      jarPath,
+      createZip([{ name: "com/example/Broken.class", data: Buffer.from("fake") }]),
+    );
+
+    const finder = new ClassSourceFinder({ projectRoot: root });
+    const result = await finder.findSourceInJar("com.example.Broken", jarPath);
+
+    // Should gracefully return not-found, not throw.
+    expect(result.found).toBe(false);
+  });
+});
+
+// ── ClassSourceFinder: AbortSignal mid-scan ──────────────────────────────────
+
+describe("ClassSourceFinder — AbortSignal mid-scan", () => {
+  it("can abort during jar directory walk", async () => {
+    const projectRoot = await tmpDir();
+    mkdirSync(join(projectRoot, "src"), { recursive: true });
+    writeFileSync(join(projectRoot, "src", "other.ts"), "not java");
+
+    // Seed a repo with many directories so the asynchronous walk is underway
+    // when the abort fires.
+    const repoDir = projectRoot;
+    for (let i = 0; i < 20; i++) {
+      const dir = join(repoDir, `repo-${i}`);
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, "lib.jar"), createZip([]));
+    }
+
+    const ctrl = new AbortController();
+    const finder = new ClassSourceFinder({
+      projectRoot,
+      repoPaths: [repoDir],
+      signal: ctrl.signal,
+    });
+
+    // Start the scan, then abort after the walk has begun.
+    const promise = finder.findSource("com.example.X");
+    // Yield the microtask queue so the walk enters its first readdir + loop.
+    await new Promise((r) => setTimeout(r, 0));
+    ctrl.abort();
+
+    await expect(promise).rejects.toThrow("Aborted");
+  });
+});
+
+// ── ClassSourceFinder: edge cases ────────────────────────────────────────────
+
+describe("ClassSourceFinder — edge cases", () => {
+  it("handles multiple .java files with same simple name — picks first encountered", async () => {
+    const root = await tmpDir();
+    // Two Java files with the same simple name in different packages
+    const dirA = join(root, "src", "com", "foo");
+    const dirB = join(root, "src", "org", "bar");
+    mkdirSync(dirA, { recursive: true });
+    mkdirSync(dirB, { recursive: true });
+    writeFileSync(join(dirA, "Target.java"), "package com.foo;\npublic class Target {}");
+    writeFileSync(join(dirB, "Target.java"), "package org.bar;\npublic class Target {}");
+
+    const finder = new ClassSourceFinder({ projectRoot: root });
+    // BFS order means com/foo found first
+    const result = await finder.findSource("com.foo.Target");
+
+    expect(result.found).toBe(true);
+    if (result.found) {
+      expect(result.source).toContain("com.foo");
+    }
+  });
+
+  it("handles empty project root gracefully", async () => {
+    const root = await tmpDir();
+    // No .java, no src dir — should not crash, just not find
+    const finder = new ClassSourceFinder({ projectRoot: root });
+    const result = await finder.findSource("com.example.Nonexistent");
+
+    expect(result.found).toBe(false);
+  });
+
+  it("handles fully-qualified class name that is also a simple name", async () => {
+    const root = await tmpDir();
+    mkdirSync(root, { recursive: true });
+    writeFileSync(join(root, "MyClass.java"), "public class MyClass {}");
+
+    const finder = new ClassSourceFinder({ projectRoot: root });
+    const result = await finder.findSource("MyClass");
+
+    expect(result.found).toBe(true);
+  });
+});
+
+// ── Tool registration tests ──────────────────────────────────────────────────
+
+describe("registerJavaSourceTool", () => {
+  it("registers tool with correct name, description, and schema", async () => {
+    const reg = new ToolRegistry();
+    registerJavaSourceTool(reg);
+
+    const spec = reg.get("java_source");
+    expect(spec).toBeDefined();
+    expect(spec!.name).toBe("java_source");
+    expect(spec!.description).toContain("Find and return Java source code");
+    expect(spec!.readOnly).toBe(true);
+    expect(spec!.parameters).toBeDefined();
+    expect(spec!.parameters!.properties).toHaveProperty("className");
+    expect(spec!.parameters!.required).toContain("className");
+  });
+
+  it("validates className is required — returns error JSON", async () => {
+    const reg = new ToolRegistry();
+    registerJavaSourceTool(reg);
+
+    const result = await reg.dispatch("java_source", JSON.stringify({}));
+    const parsed = JSON.parse(result);
+    expect(parsed).toHaveProperty("error");
+    expect(parsed.error).toContain("className");
+  });
+
+  it("validates empty className — returns error JSON", async () => {
+    const reg = new ToolRegistry();
+    registerJavaSourceTool(reg);
+
+    const result = await reg.dispatch("java_source", JSON.stringify({ className: "  " }));
+    const parsed = JSON.parse(result);
+    expect(parsed).toHaveProperty("error");
+    expect(parsed.error).toContain("className");
+  });
+
+  it("rejects invalid className format — returns error JSON", async () => {
+    const reg = new ToolRegistry();
+    registerJavaSourceTool(reg);
+
+    const invalid = [
+      "com.example.123class", // starts with digit
+      "com..example.Foo", // double dot
+      "com.example.Foo.Bar.", // trailing dot
+      ".com.example.Foo", // leading dot
+      "com/example/Foo", // slash instead of dot
+      "com.example Foo", // space
+    ];
+    for (const cls of invalid) {
+      const result = await reg.dispatch("java_source", JSON.stringify({ className: cls }));
+      const parsed = JSON.parse(result);
+      expect(parsed).toHaveProperty("error");
+      expect(parsed.error).toContain("not a valid fully qualified Java class name");
+    }
+  });
+
+  it("accepts valid class names — returns search result, not error", async () => {
+    const root = await tmpDir();
+    // Prevent slo-o-o-w repo scan by emptying defaultRepoPaths
+    vi.spyOn(ClassSourceFinder, "defaultRepoPaths").mockReturnValue([]);
+    const reg = new ToolRegistry();
+    registerJavaSourceTool(reg, { projectRoot: root });
+
+    const valid = [
+      "com.example.MyClass",
+      "MyClass",
+      "java.lang.String",
+      "com.example.Foo_Bar",
+      "com.example.Foo$Bar",
+      "a.b.C",
+    ];
+    for (const cls of valid) {
+      const result = await reg.dispatch("java_source", JSON.stringify({ className: cls }));
+      const parsed = JSON.parse(result);
+      // Should be a search result (not-found), not a validation error
+      expect(parsed).not.toHaveProperty("error");
+      expect(parsed).toHaveProperty("status");
+    }
+  });
+
+  it("mode 1: project search dispatch finds .java", async () => {
+    const root = await tmpDir();
+    const pkgDir = join(root, "src", "com", "test");
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(join(pkgDir, "Hello.java"), "package com.test;\npublic class Hello {}");
+
+    const reg = new ToolRegistry();
+    registerJavaSourceTool(reg, { projectRoot: root });
+
+    const result = await reg.dispatch(
+      "java_source",
+      JSON.stringify({ className: "com.test.Hello" }),
+    );
+    const parsed = JSON.parse(result);
+    expect(parsed.status).toBe("found");
+    expect(parsed.method).toBe("project");
+    expect(parsed.source).toContain("public class Hello");
+    expect(parsed.sourcePath).toContain("Hello.java");
+  });
+
+  it("mode 2: jarPath dispatch reads + decompiles", async () => {
+    const root = await tmpDir();
+    const jarPath = join(root, "lib.jar");
+    // Need execFile to return javap output
+    vi.mocked(execFile).mockImplementation(((
+      _cmd: unknown,
+      _args: unknown,
+      _opts: unknown,
+      cb: unknown,
+    ) => {
+      if (typeof cb === "function") {
+        (cb as (err: Error | null, stdout: string, stderr: string) => void)(
+          null,
+          'Compiled from "Util.java"\npublic class Util { public Util(); }\n',
+          "",
+        );
+      }
+    }) as any);
+    writeFileSync(
+      jarPath,
+      createZip([{ name: "com/example/Util.class", data: Buffer.from("fake") }]),
+    );
+
+    const reg = new ToolRegistry();
+    registerJavaSourceTool(reg, { projectRoot: root });
+
+    const result = await reg.dispatch(
+      "java_source",
+      JSON.stringify({
+        className: "com.example.Util",
+        jarPath,
+      }),
+    );
+    const parsed = JSON.parse(result);
+    expect(parsed.status).toBe("found");
+    expect(parsed.method).toBe("jar");
+    expect(parsed.source).toContain("public class Util");
+  });
+
+  it("mode 3: jarKeyword dispatch accepts keyword without error", async () => {
+    const root = await tmpDir();
+    mkdirSync(join(root, "src"), { recursive: true });
+    writeFileSync(join(root, "src", "main.ts"), "not java");
+    // Prevent slo-o-o-w repo scan by emptying defaultRepoPaths
+    vi.spyOn(ClassSourceFinder, "defaultRepoPaths").mockReturnValue([]);
+
+    const reg = new ToolRegistry();
+    registerJavaSourceTool(reg, { projectRoot: root });
+
+    // The tool accepts jarKeyword and passes it to findSource.
+    // Since repoPaths is empty, the result will be not-found.
+    // We just verify the dispatch completes with a valid response.
+    const result = await reg.dispatch(
+      "java_source",
+      JSON.stringify({
+        className: "org.springframework.SomeClass",
+        jarKeyword: "spring",
+      }),
+    );
+    const parsed = JSON.parse(result);
+    expect(parsed).toHaveProperty("status");
+    expect(parsed.status).toBe("not-found");
+    expect(parsed.className).toBe("org.springframework.SomeClass");
+  });
+
+  it("returns proper not-found response format", async () => {
+    const root = await tmpDir();
+    mkdirSync(join(root, "src"), { recursive: true });
+    writeFileSync(join(root, "src", "main.ts"), "not java");
+    // Prevent slo-o-o-w repo scan by emptying defaultRepoPaths
+    vi.spyOn(ClassSourceFinder, "defaultRepoPaths").mockReturnValue([]);
+
+    const reg = new ToolRegistry();
+    registerJavaSourceTool(reg, { projectRoot: root });
+
+    const result = await reg.dispatch(
+      "java_source",
+      JSON.stringify({ className: "com.example.Nonexistent" }),
+    );
+    const parsed = JSON.parse(result);
+    expect(parsed.status).toBe("not-found");
+    expect(parsed.className).toBe("com.example.Nonexistent");
+    expect(parsed.message).toContain("No source found");
+  });
+});


### PR DESCRIPTION
## What

Add a `java_source` tool that lets the agent find and decompile Java source code by fully-qualified class name. **Default off** — enabled via config `"javaSource": true` or env `REASONIX_JAVA_SOURCE=1`.

**New modules:**
- `src/java/zip-reader.ts` — zero-dependency pure-Node ZIP/JAR entry reader (STORED + DEFLATED). No JDK `jar` command required.
- `src/java/class-source-finder.ts` — three-phase search engine: (1) BFS walk of the project tree for `.java` files, (2) recursive scan of Maven `.m2` and Gradle caches for matching jars, (3) `javap -c -p` decompilation. Supports keyword filtering, `maxJarScan` guard, `AbortSignal` cancellation, and direct `jarPath` mode.
- `src/java/index.ts` — barrel export.

**New tool (`parallelSafe`, `readOnly`):**
- `java_source(className, projectRoot?, jarPath?, jarKeyword?)` — registered in `buildCodeToolset()` via `registerJavaSourceTool()`, gated by `loadJavaSourceEnabled()`.

**Wiring:**
- `src/config.ts`: `javaSource` config field + `loadJavaSourceEnabled()` (env `REASONIX_JAVA_SOURCE` takes precedence).
- `src/code/setup.ts`: conditional registration in `buildCodeToolset()`.

## Why

Java developers working on Maven/Gradle projects need to inspect library source without leaving the agent session. The tool is default-off because `javap` decompilation is I/O-heavy and not relevant to non-Java projects.

## How to verify

1. `npm run verify` passes (lint + typecheck + tests).
2. 41 unit tests in `tests/java-source.test.ts` cover zip reading, project search, repo scan, keyword filtering, `maxJarScan` truncation, corrupt jar resilience, `AbortSignal`, decompilation, javap failure, and tool registration + dispatch.
3. The tool does **not** appear in the registry unless `javaSource: true` is set.

## Checklist

- [√] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [√] No `Co-Authored-By: Claude` trailer in commits
- [√] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [√] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time
