### PR TITLE
fix(cli): add opt-out for terminal mouse tracking

### DIFF
--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -100,6 +100,8 @@ export interface ChatOptions {
   dashboardHost?: string;
   /** Stable dashboard URL token (#968). `undefined` mints a fresh per-boot token. */
   dashboardToken?: string;
+  /** Disable SGR mouse tracking so the terminal keeps native selection and right-click behavior. */
+  noMouse?: boolean;
 }
 
 interface RootProps extends ChatOptions {
@@ -349,7 +351,7 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
   // prefer native drag-select copy (Shift+drag still selects with mouse
   // mode on in most terminals). exit hooks cover hard kills so the
   // sequence doesn't leak into the parent shell.
-  if (cfg.mouseTracking !== false) {
+  if (!opts.noMouse && cfg.mouseTracking !== false) {
     enableMouseMode();
     process.once("exit", disableMouseMode);
     process.once("SIGINT", () => {

--- a/src/cli/commands/code.tsx
+++ b/src/cli/commands/code.tsx
@@ -63,6 +63,8 @@ export interface CodeOptions {
   systemAppend?: string;
   /** Path to a UTF-8 text file whose contents are appended to the code system prompt. */
   systemAppendFile?: string;
+  /** Disable SGR mouse tracking so the terminal keeps native selection and right-click behavior. */
+  noMouse?: boolean;
 }
 
 export async function codeCommand(opts: CodeOptions = {}): Promise<void> {
@@ -182,5 +184,6 @@ export async function codeCommand(opts: CodeOptions = {}): Promise<void> {
     dashboardPort: opts.dashboardPort,
     dashboardHost: opts.dashboardHost,
     dashboardToken: opts.dashboardToken,
+    noMouse: opts.noMouse,
   });
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -124,12 +124,13 @@ program
   .name("reasonix")
   .description(t("cli.description"))
   .version(VERSION)
-  .option("-c, --continue", t("cli.continue"));
+  .option("-c, --continue", t("cli.continue"))
+  .option("--no-mouse", t("ui.noMouseHint"));
 
 // `reasonix` with no subcommand → setup wizard on first run, otherwise `code`
 // in the current directory. Filesystem-less chat stays reachable via
 // `reasonix chat`.
-program.action(async (opts: { continue?: boolean }) => {
+program.action(async (opts: { continue?: boolean; mouse?: boolean }) => {
   const cfg = readConfig();
   const mode = resolveBareCommandMode(cfg);
   if (mode === "setup") {
@@ -138,7 +139,11 @@ program.action(async (opts: { continue?: boolean }) => {
     return;
   }
   const { codeCommand } = await import("./commands/code.js");
-  await codeCommand({ dir: process.cwd(), forceResume: !!opts.continue });
+  await codeCommand({
+    dir: process.cwd(),
+    forceResume: !!opts.continue,
+    noMouse: opts.mouse === false,
+  });
 });
 
 program
@@ -154,6 +159,7 @@ program
   .description(t("cli.code"))
   .option("-m, --model <id>", t("ui.modelOverride"))
   .option("--no-session", t("ui.noSession"))
+  .option("--no-mouse", t("ui.noMouseHint"))
   .option("-r, --resume", t("ui.resumeHint"))
   .option("-n, --new", t("ui.newHint"))
   .option("--transcript <path>", t("ui.transcriptHint"))
@@ -188,6 +194,7 @@ program
         dashboardPort: resolveDashboardPort(parseDashboardPortFlag(opts.dashboardPort), false),
         dashboardHost: resolveDashboardHost(opts.dashboardHost, false),
         dashboardToken: resolveDashboardToken(false),
+        noMouse: opts.mouse === false,
         systemAppend: opts.systemAppend,
         systemAppendFile: opts.systemAppendFile,
       });
@@ -206,6 +213,7 @@ program
   .option("--budget <usd>", t("ui.budgetHint"), (v) => Number.parseFloat(v))
   .option("--session <name>", t("ui.sessionNameHint"))
   .option("--no-session", t("ui.ephemeralHint"))
+  .option("--no-mouse", t("ui.noMouseHint"))
   .option("-r, --resume", t("ui.resumeHint"))
   .option("-c, --continue", t("cli.continue"))
   .option("-n, --new", t("ui.newHint"))
@@ -275,6 +283,7 @@ program
         ),
         dashboardHost: resolveDashboardHost(opts.dashboardHost, opts.config === false),
         dashboardToken: resolveDashboardToken(opts.config === false),
+        noMouse: opts.mouse === false,
       });
     } finally {
       if (profiling) await stopAndSaveCpuProfile();

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -187,6 +187,7 @@ export const EN: TranslationSchema = {
     tipShownOnce: "shown once",
     modelOverride: "override the default model",
     noSession: "disable session persistence for this run",
+    noMouseHint: "disable SGR mouse tracking; restores native drag-select and right-click",
     resumeHint: "force-resume the named session (even if idle)",
     newHint: "force a fresh session (ignore --session / --continue)",
     transcriptHint: "path to write the JSONL transcript",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -96,6 +96,7 @@ export interface TranslationSchema {
     tipShownOnce: string;
     modelOverride: string;
     noSession: string;
+    noMouseHint: string;
     resumeHint: string;
     newHint: string;
     transcriptHint: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -180,6 +180,7 @@ export const zhCN: TranslationSchema = {
     tipShownOnce: "仅显示一次",
     modelOverride: "覆盖默认模型",
     noSession: "禁用本次运行的会话持久化",
+    noMouseHint: "关闭 SGR 鼠标跟踪；恢复终端原生拖选和右键行为",
     resumeHint: "强制恢复指定会话（即使空闲）",
     newHint: "强制创建新会话（忽略 --session / --continue）",
     transcriptHint: "JSONL 转录稿的写入路径",

--- a/tests/chat-mcp-startup-summary.test.ts
+++ b/tests/chat-mcp-startup-summary.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => {
   const renderMock = vi.fn();
+  const enableMouseModeMock = vi.fn();
+  const disableMouseModeMock = vi.fn();
   const loadApiKeyMock = vi.fn(() => "sk-test");
   const readConfigMock = vi.fn(() => ({ mcpDisabled: [] as string[] }));
   const searchEnabledMock = vi.fn(() => false);
@@ -55,6 +57,8 @@ const mocks = vi.hoisted(() => {
   return {
     bridgeMcpToolsMock,
     closeMock,
+    disableMouseModeMock,
+    enableMouseModeMock,
     FakeMcpClient,
     FakeTransport,
     initializeMock,
@@ -86,6 +90,11 @@ vi.mock("../src/config.js", async (importOriginal) => {
 
 vi.mock("../src/env.js", () => ({
   loadDotenv: mocks.loadDotenvMock,
+}));
+
+vi.mock("../src/cli/ui/mouse-mode.js", () => ({
+  disableMouseMode: mocks.disableMouseModeMock,
+  enableMouseMode: mocks.enableMouseModeMock,
 }));
 
 vi.mock("../src/memory/session.js", () => ({
@@ -129,9 +138,12 @@ async function captureStartupState(opts?: {
   bridgeError?: Error;
   mcp?: string[];
   lang?: "EN" | "zh-CN";
+  noMouse?: boolean;
 }) {
   vi.resetModules();
   mocks.renderMock.mockReset();
+  mocks.enableMouseModeMock.mockClear();
+  mocks.disableMouseModeMock.mockClear();
   mocks.loadDotenvMock.mockClear();
   mocks.loadApiKeyMock.mockClear();
   mocks.initializeMock.mockReset();
@@ -198,6 +210,7 @@ async function captureStartupState(opts?: {
     system: "s",
     mcp: opts?.mcp ?? ["fs=npx -y @scope/fs /tmp"],
     seedTools: new ToolRegistry(),
+    noMouse: opts?.noMouse,
   });
 
   expect(capturedProps).not.toBeNull();
@@ -237,6 +250,14 @@ describe("chatCommand MCP startup summary states", { timeout: 15_000 }, () => {
     expect(props.mcpSpecs).toEqual(["fs=npx -y @scope/fs /tmp"]);
     expect(props.mcpServers).toEqual([]);
     expect(mocks.bridgeMcpToolsMock).not.toHaveBeenCalled();
+  });
+
+  it("enables mouse tracking by default and honors noMouse opt-out", async () => {
+    await captureStartupState();
+    expect(mocks.enableMouseModeMock).toHaveBeenCalledTimes(1);
+
+    await captureStartupState({ noMouse: true });
+    expect(mocks.enableMouseModeMock).not.toHaveBeenCalled();
   });
 
   it("never blocks chatCommand on bridge failure — App.tsx surfaces the lifecycle error post-mount", async () => {

--- a/tests/cli-bare-routing.test.ts
+++ b/tests/cli-bare-routing.test.ts
@@ -72,7 +72,7 @@ describe("bare CLI routing", () => {
     await importCli([]);
 
     await vi.waitFor(() =>
-      expect(codeCommand).toHaveBeenCalledWith({ dir: cwd, forceResume: false }),
+      expect(codeCommand).toHaveBeenCalledWith({ dir: cwd, forceResume: false, noMouse: false }),
     );
     expect(chatCommand).not.toHaveBeenCalled();
   });
@@ -83,7 +83,7 @@ describe("bare CLI routing", () => {
     await importCli([]);
 
     await vi.waitFor(() =>
-      expect(codeCommand).toHaveBeenCalledWith({ dir: cwd, forceResume: false }),
+      expect(codeCommand).toHaveBeenCalledWith({ dir: cwd, forceResume: false, noMouse: false }),
     );
     expect(chatCommand).not.toHaveBeenCalled();
     expect(stderr.mock.calls.map((call) => String(call[0])).join("")).not.toContain(
@@ -97,7 +97,17 @@ describe("bare CLI routing", () => {
     await importCli(["-c"]);
 
     await vi.waitFor(() =>
-      expect(codeCommand).toHaveBeenCalledWith({ dir: cwd, forceResume: true }),
+      expect(codeCommand).toHaveBeenCalledWith({ dir: cwd, forceResume: true, noMouse: false }),
+    );
+  });
+
+  it("forwards bare --no-mouse to code mode", async () => {
+    writeConfig({ setupCompleted: true }, join(home, ".reasonix", "config.json"));
+
+    await importCli(["--no-mouse"]);
+
+    await vi.waitFor(() =>
+      expect(codeCommand).toHaveBeenCalledWith({ dir: cwd, forceResume: false, noMouse: true }),
     );
   });
 


### PR DESCRIPTION
<!-- Read CONTRIBUTING.md first if this is your first PR. -->

## What

- Add `--no-mouse` to bare, `code`, and `chat` CLI entrypoints.
- 
- Thread the opt-out through code mode into chat mode so SGR mouse tracking is skipped when requested.
- 
  - Add English/Chinese help text and tests for bare routing plus chat mouse-mode behavior.
  - 
<!-- One paragraph: what does this change? -->

## Why

https://github.com/esengine/DeepSeek-Reasonix/issues/1337
<!-- Bug fix? Pre-existing issue? Linked discussion? -->

## How to verify

<!-- Steps the reviewer can run. `npm run verify` is assumed. -->

## Checklist

- [ ✓ ] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [ ✓ ] No `Co-Authored-By: Claude` trailer in commits
- [ ✓ ] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [ ✓ ] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time
