### PR TITLE
feat(tools): limit tool dispatch rate

### DIFF
--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -1,6 +1,6 @@
 import { render } from "ink";
 import React, { useMemo, useState } from "react";
-import { loadApiKey, readConfig, searchEnabled } from "../../config.js";
+import { loadApiKey, loadToolRateLimit, readConfig, searchEnabled } from "../../config.js";
 import { loadDotenv } from "../../env.js";
 import { t } from "../../i18n/index.js";
 import {
@@ -261,7 +261,9 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
   // replacing. When no seed AND no MCP, tools stays undefined and
   // the loop runs as a bare chat.
   let tools: ToolRegistry | undefined = opts.seedTools;
-  if (requestedSpecs.length > 0 && !tools) tools = new ToolRegistry();
+  if (requestedSpecs.length > 0 && !tools) {
+    tools = new ToolRegistry({ rateLimit: loadToolRateLimit() });
+  }
 
   const runtime = createMcpRuntime({
     getTools: () => tools,
@@ -287,7 +289,7 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
   // backs them with no key required; the model invokes them whenever
   // a question needs info fresher than its training data.
   if (searchEnabled()) {
-    if (!tools) tools = new ToolRegistry();
+    if (!tools) tools = new ToolRegistry({ rateLimit: loadToolRateLimit() });
     registerWebTools(tools);
   }
 
@@ -299,7 +301,7 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
   // exists) so it can wire the subagent runner for runAs:subagent
   // skills.
   if (!opts.seedTools) {
-    if (!tools) tools = new ToolRegistry();
+    if (!tools) tools = new ToolRegistry({ rateLimit: loadToolRateLimit() });
     registerMemoryTools(tools, {});
     // `ask_choice` — branching primitive, useful in chat too (stylistic
     // preferences, doc language, library picks). Independent of plan

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -6,6 +6,7 @@ import {
   isPlausibleKey,
   loadApiKey,
   loadBaseUrl,
+  loadToolRateLimit,
   normalizeMcpConfig,
   readConfig,
   saveApiKey,
@@ -82,7 +83,7 @@ export async function runCommand(opts: RunOptions): Promise<void> {
   let tools: ToolRegistry | undefined;
   let successCount = 0;
   if (normalizedSpecs.length > 0) {
-    tools = new ToolRegistry();
+    tools = new ToolRegistry({ rateLimit: loadToolRateLimit() });
     for (const spec of normalizedSpecs) {
       let label = "anon";
       let mcp: McpClient | undefined;

--- a/src/code/setup.ts
+++ b/src/code/setup.ts
@@ -6,6 +6,7 @@ import {
   loadJavaSourceEnabled,
   loadProjectShellAllowed,
   loadResolvedSkillPaths,
+  loadToolRateLimit,
   readConfig,
   searchEnabled,
 } from "../config.js";
@@ -49,7 +50,7 @@ export interface CodeToolset {
 }
 
 export async function buildCodeToolset(opts: CodeToolsetOpts): Promise<CodeToolset> {
-  const tools = new ToolRegistry();
+  const tools = new ToolRegistry({ rateLimit: loadToolRateLimit() });
   const jobs = new JobRegistry();
 
   const outlineThresholdBytes = loadFilesystemOutlineThresholdBytes();

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,11 @@ import {
 } from "./index/config.js";
 import { type McpServerSpec, parseMcpSpec } from "./mcp/spec.js";
 import { normalizeQQAllowlist, normalizeQQOpenId } from "./qq/access.js";
+import {
+  type NormalizedToolRateLimitConfig,
+  type ToolRateLimitConfig,
+  normalizeToolRateLimitConfig,
+} from "./tools/rate-limit.js";
 
 /** Legacy `fast|smart|max` kept for back-compat with existing config.json files. */
 export type PresetName = "auto" | "flash" | "pro" | "fast" | "smart" | "max";
@@ -214,6 +219,7 @@ export interface ReasonixConfig {
   /** Per-app proxy override. Layered on top of HTTPS_PROXY / NO_PROXY env vars + the default DeepSeek-bypass whitelist. */
   proxy?: ProxyConfig;
   rateLimit?: RateLimitConfig;
+  toolRateLimit?: ToolRateLimitConfig;
   /** Host-enforced engineering lifecycle. Defaults to off so opt-outs pay zero prefix cost. */
   engineeringLifecycle?: {
     mode?: EngineeringLifecycleMode;
@@ -590,6 +596,12 @@ export function loadRateLimit(path: string = defaultConfigPath()): RateLimitConf
   const rpm = readConfig(path).rateLimit?.rpm;
   if (typeof rpm !== "number" || !Number.isInteger(rpm) || rpm <= 0) return undefined;
   return { rpm };
+}
+
+export function loadToolRateLimit(
+  path: string = defaultConfigPath(),
+): false | NormalizedToolRateLimitConfig {
+  return normalizeToolRateLimitConfig(readConfig(path).toolRateLimit);
 }
 
 export function saveBaseUrl(url: string, path: string = defaultConfigPath()): void {

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -51,6 +51,7 @@ import {
 import { type RepairReport, ToolCallRepair } from "./repair/index.js";
 import { SessionStats, type TurnStats } from "./telemetry/stats.js";
 import { ToolRegistry } from "./tools.js";
+import { parseRateLimitedToolResult } from "./tools/rate-limit.js";
 import type { ChatMessage, ToolCall } from "./types.js";
 
 const ESCALATION_MODEL = "deepseek-v4-pro";
@@ -655,6 +656,7 @@ export class CacheFirstLoop {
     this.appendAndPersist({ role: "user", content: userInput });
     let pendingUser: string | null = null;
     const toolSpecs = this.prefix.tools();
+    let rateLimitWarningShown = false;
 
     for (let iter = 0; ; iter++) {
       if (signal.aborted) {
@@ -1193,6 +1195,17 @@ export class CacheFirstLoop {
 
           for (const w of preWarnings) yield w;
           for (const w of postWarnings) yield w;
+
+          // Keep the structured result in history; the warning is only host-side visibility.
+          const rateLimited = parseRateLimitedToolResult(result);
+          if (rateLimited && !rateLimitWarningShown) {
+            rateLimitWarningShown = true;
+            yield {
+              turn: this._turn,
+              role: "warning",
+              content: rateLimited.message,
+            };
+          }
 
           this.appendAndPersist({
             role: "tool",

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,6 +1,11 @@
 import type { PauseGate } from "./core/pause-gate.js";
 import { truncateForModel, truncateForModelByTokens } from "./mcp/registry.js";
 import { analyzeSchema, flattenSchema, nestArguments } from "./repair/flatten.js";
+import {
+  type NormalizedToolRateLimitConfig,
+  type ToolRateLimitOption,
+  ToolRateLimiter,
+} from "./tools/rate-limit.js";
 import type { JSONSchema, ToolSpec } from "./types.js";
 
 export interface ToolCallContext {
@@ -32,6 +37,7 @@ interface InternalTool extends ToolDefinition {
 export interface ToolRegistryOptions {
   /** Auto-flatten + re-nest at dispatch; default true. */
   autoFlatten?: boolean;
+  rateLimit?: ToolRateLimitOption;
 }
 
 export type ToolCallAuditEvent = {
@@ -62,6 +68,7 @@ export class ToolRegistry {
   private readonly _interceptors: Array<{ id: string; fn: ToolInterceptor }> = [];
   private _auditListener: ToolCallAuditListener | null = null;
   private _resultAugmenter: ToolResultAugmenter | null = null;
+  private readonly _rateLimiter: ToolRateLimiter;
   /** Per-tool fingerprint of the last call that failed schema validation. Cleared by any successful validation for that tool. */
   private readonly _lastMalformed = new Map<string, string>();
   /** Per-tool fingerprint of the last host-side gate rejection. */
@@ -69,6 +76,7 @@ export class ToolRegistry {
 
   constructor(opts: ToolRegistryOptions = {}) {
     this._autoFlatten = opts.autoFlatten !== false;
+    this._rateLimiter = new ToolRateLimiter(opts.rateLimit);
   }
 
   /** Enable / disable plan-mode enforcement at dispatch. */
@@ -111,6 +119,10 @@ export class ToolRegistry {
   /** True when an augmenter is already wired — lets late-installing callers skip clobbering an earlier one. */
   get hasResultAugmenter(): boolean {
     return this._resultAugmenter !== null;
+  }
+
+  get rateLimitPolicy(): false | NormalizedToolRateLimitConfig {
+    return this._rateLimiter.policy;
   }
 
   register<A, R>(def: ToolDefinition<A, R>): this {
@@ -258,6 +270,12 @@ export class ToolRegistry {
         error: `${name}: aborted before dispatch (user interrupt)`,
         rejectedReason: "aborted",
       });
+    }
+
+    // Only real dispatch attempts consume quota; earlier refusals are guidance, not work.
+    const rateLimit = this._rateLimiter.consume(name);
+    if (!rateLimit.allowed) {
+      return JSON.stringify(rateLimit.result);
     }
 
     let finalResult: string;

--- a/src/tools/rate-limit.ts
+++ b/src/tools/rate-limit.ts
@@ -1,0 +1,177 @@
+/** Sliding-window limits for per-session tool dispatch, with aggregate and per-tool buckets. */
+
+export interface ToolRateLimitBucketConfig {
+  maxCalls?: number;
+  windowSeconds?: number;
+}
+
+export interface ToolRateLimitConfig {
+  enabled?: boolean;
+  aggregate?: ToolRateLimitBucketConfig;
+  tools?: Record<string, false | ToolRateLimitBucketConfig>;
+}
+
+export interface NormalizedToolRateLimitBucket {
+  maxCalls: number;
+  windowSeconds: number;
+}
+
+export interface NormalizedToolRateLimitConfig {
+  aggregate: NormalizedToolRateLimitBucket;
+  tools: Record<string, false | NormalizedToolRateLimitBucket>;
+}
+
+export interface RateLimitedToolResult {
+  error: "rate_limited";
+  tool: string;
+  scope: string;
+  limit: number;
+  windowSeconds: number;
+  retryAfterMs: number;
+  message: string;
+}
+
+export type ToolRateLimitDecision =
+  | { allowed: true }
+  | { allowed: false; result: RateLimitedToolResult };
+
+// Generous defaults make this a host-pressure guard, not a normal workload budget.
+export const DEFAULT_TOOL_RATE_LIMIT: NormalizedToolRateLimitConfig = {
+  aggregate: { maxCalls: 200, windowSeconds: 60 },
+  tools: {
+    run_command: { maxCalls: 60, windowSeconds: 60 },
+    run_background: { maxCalls: 10, windowSeconds: 60 },
+  },
+};
+
+export type ToolRateLimitOption = false | ToolRateLimitConfig;
+
+type Clock = () => number;
+
+export class ToolRateLimiter {
+  private readonly config: false | NormalizedToolRateLimitConfig;
+  private readonly clock: Clock;
+  private readonly aggregate: number[] = [];
+  private readonly tools = new Map<string, number[]>();
+
+  constructor(config: ToolRateLimitOption | undefined = {}, clock: Clock = () => Date.now()) {
+    this.config = normalizeToolRateLimitConfig(config);
+    this.clock = clock;
+  }
+
+  get policy(): false | NormalizedToolRateLimitConfig {
+    return this.config;
+  }
+
+  consume(tool: string): ToolRateLimitDecision {
+    if (this.config === false) return { allowed: true };
+
+    const now = this.clock();
+    const toolBucket = this.config.tools[tool];
+    if (toolBucket !== false && toolBucket !== undefined) {
+      const timestamps = this.timestampsFor(tool);
+      const blocked = inspectBucket(tool, timestamps, toolBucket, now);
+      if (blocked) return { allowed: false, result: blocked };
+    }
+
+    const aggregateBlocked = inspectBucket(
+      tool,
+      this.aggregate,
+      this.config.aggregate,
+      now,
+      "all_tools",
+    );
+    if (aggregateBlocked) return { allowed: false, result: aggregateBlocked };
+
+    // Count at dispatch start so concurrent slow tools still occupy the active window.
+    this.aggregate.push(now);
+    if (toolBucket !== false && toolBucket !== undefined) this.timestampsFor(tool).push(now);
+    return { allowed: true };
+  }
+
+  private timestampsFor(tool: string): number[] {
+    const existing = this.tools.get(tool);
+    if (existing) return existing;
+    const created: number[] = [];
+    this.tools.set(tool, created);
+    return created;
+  }
+}
+
+export function normalizeToolRateLimitConfig(
+  config: ToolRateLimitOption | undefined,
+): false | NormalizedToolRateLimitConfig {
+  if (config === false || config?.enabled === false) return false;
+  const aggregate = normalizeBucket(config?.aggregate, DEFAULT_TOOL_RATE_LIMIT.aggregate);
+  const tools: Record<string, false | NormalizedToolRateLimitBucket> = {
+    ...DEFAULT_TOOL_RATE_LIMIT.tools,
+  };
+  for (const [name, value] of Object.entries(config?.tools ?? {})) {
+    if (value === false) {
+      tools[name] = false;
+      continue;
+    }
+    const fallback = DEFAULT_TOOL_RATE_LIMIT.tools[name];
+    tools[name] = normalizeBucket(
+      value,
+      fallback === false || fallback === undefined ? DEFAULT_TOOL_RATE_LIMIT.aggregate : fallback,
+    );
+  }
+  return { aggregate, tools };
+}
+
+export function parseRateLimitedToolResult(result: string): RateLimitedToolResult | null {
+  try {
+    const parsed = JSON.parse(result) as unknown;
+    if (!parsed || typeof parsed !== "object") return null;
+    const value = parsed as Partial<RateLimitedToolResult>;
+    if (value.error !== "rate_limited") return null;
+    if (typeof value.tool !== "string" || typeof value.scope !== "string") return null;
+    if (typeof value.limit !== "number" || typeof value.windowSeconds !== "number") return null;
+    if (typeof value.retryAfterMs !== "number" || typeof value.message !== "string") return null;
+    return value as RateLimitedToolResult;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeBucket(
+  raw: ToolRateLimitBucketConfig | undefined,
+  fallback: NormalizedToolRateLimitBucket,
+): NormalizedToolRateLimitBucket {
+  return {
+    maxCalls: positiveInteger(raw?.maxCalls) ?? fallback.maxCalls,
+    windowSeconds: positiveInteger(raw?.windowSeconds) ?? fallback.windowSeconds,
+  };
+}
+
+function positiveInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : undefined;
+}
+
+function inspectBucket(
+  tool: string,
+  timestamps: number[],
+  bucket: NormalizedToolRateLimitBucket,
+  now: number,
+  scope = tool,
+): RateLimitedToolResult | null {
+  const windowMs = bucket.windowSeconds * 1_000;
+  while (timestamps.length > 0 && now - timestamps[0]! >= windowMs) timestamps.shift();
+  if (timestamps.length < bucket.maxCalls) return null;
+  const retryAfterMs = Math.max(0, timestamps[0]! + windowMs - now);
+  return {
+    error: "rate_limited",
+    tool,
+    scope,
+    limit: bucket.maxCalls,
+    windowSeconds: bucket.windowSeconds,
+    retryAfterMs,
+    message: `${scope} rate-limited: ${bucket.maxCalls} calls / ${bucket.windowSeconds}s. Wait ${formatWait(retryAfterMs)} or summarize what you know.`,
+  };
+}
+
+function formatWait(ms: number): string {
+  const seconds = ms / 1_000;
+  return `${Number.isInteger(seconds) ? seconds.toFixed(0) : seconds.toFixed(1)}s`;
+}

--- a/src/tools/subagent.ts
+++ b/src/tools/subagent.ts
@@ -576,11 +576,12 @@ export function registerSubagentTool(
 }
 
 /** Plan-mode state propagates — a subagent spawned under `/plan` MUST NOT escape it. */
+// Registry forks inherit the policy but start with fresh counters, preserving session-local limits.
 export function forkRegistryExcluding(
   parent: ToolRegistry,
   exclude: ReadonlySet<string>,
 ): ToolRegistry {
-  const child = new ToolRegistry();
+  const child = new ToolRegistry({ rateLimit: parent.rateLimitPolicy });
   for (const spec of parent.specs()) {
     const name = spec.function.name;
     if (exclude.has(name)) continue;
@@ -601,7 +602,7 @@ export function forkRegistryWithAllowList(
   allow: ReadonlySet<string>,
   alsoExclude: ReadonlySet<string>,
 ): ToolRegistry {
-  const child = new ToolRegistry();
+  const child = new ToolRegistry({ rateLimit: parent.rateLimitPolicy });
   for (const spec of parent.specs()) {
     const name = spec.function.name;
     if (!allow.has(name)) continue;

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -26,6 +26,7 @@ import {
   loadReasoningEffort,
   loadSemanticEmbeddingUserConfig,
   loadTheme,
+  loadToolRateLimit,
   markEditModeHintShown,
   readConfig,
   redactKey,
@@ -201,6 +202,36 @@ describe("config", () => {
 
     writeConfig({}, path);
     expect(loadProxyConfig(path)).toEqual({});
+  });
+
+  it("loads toolRateLimit with defaults and opt-out", () => {
+    writeConfig(
+      {
+        toolRateLimit: {
+          aggregate: { maxCalls: 5, windowSeconds: 10 },
+          tools: {
+            run_command: { maxCalls: 2, windowSeconds: 3 },
+            run_background: false,
+          },
+        },
+      },
+      path,
+    );
+    expect(loadToolRateLimit(path)).toMatchObject({
+      aggregate: { maxCalls: 5, windowSeconds: 10 },
+      tools: {
+        run_command: { maxCalls: 2, windowSeconds: 3 },
+        run_background: false,
+      },
+    });
+
+    writeConfig({ toolRateLimit: { enabled: false } }, path);
+    expect(loadToolRateLimit(path)).toBe(false);
+
+    writeConfig({ toolRateLimit: { aggregate: { maxCalls: 0, windowSeconds: 1.5 } } }, path);
+    expect(loadToolRateLimit(path)).toMatchObject({
+      aggregate: { maxCalls: 200, windowSeconds: 60 },
+    });
   });
 
   it("redactKey hides the middle", () => {

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -196,6 +196,67 @@ describe("CacheFirstLoop (non-streaming)", () => {
     expect(roleOrder[1]).toEqual({ role: "tool", toolName: "add" });
   });
 
+  it("surfaces a warning when a tool call is rate-limited", async () => {
+    const client = makeClient([
+      {
+        content: "",
+        tool_calls: [
+          {
+            id: "call_1",
+            type: "function",
+            function: { name: "echo", arguments: '{"msg":"one"}' },
+          },
+          {
+            id: "call_2",
+            type: "function",
+            function: { name: "echo", arguments: '{"msg":"two"}' },
+          },
+          {
+            id: "call_3",
+            type: "function",
+            function: { name: "echo", arguments: '{"msg":"three"}' },
+          },
+        ],
+      },
+      { content: "done" },
+    ]);
+    const tools = new ToolRegistry({
+      rateLimit: { aggregate: { maxCalls: 2, windowSeconds: 60 }, tools: {} },
+    });
+    const seen: string[] = [];
+    tools.register<{ msg: string }, string>({
+      name: "echo",
+      parallelSafe: true,
+      parameters: {
+        type: "object",
+        properties: { msg: { type: "string" } },
+        required: ["msg"],
+      },
+      fn: ({ msg }) => {
+        seen.push(msg);
+        return msg;
+      },
+    });
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s", toolSpecs: tools.specs() }),
+      tools,
+      stream: false,
+    });
+
+    const warnings: string[] = [];
+    const toolResults: string[] = [];
+    for await (const ev of loop.step("go")) {
+      if (ev.role === "warning") warnings.push(ev.content);
+      if (ev.role === "tool") toolResults.push(ev.content);
+    }
+
+    expect(seen).toEqual(["one", "two"]);
+    expect(toolResults).toHaveLength(3);
+    expect(JSON.parse(toolResults[2]!).error).toBe("rate_limited");
+    expect(warnings.filter((content) => content.includes("rate-limited"))).toHaveLength(1);
+  });
+
   it("immutable prefix is preserved across turns (cache-stability invariant)", async () => {
     const sharedFetch = fakeFetch([{ content: "a" }, { content: "b" }]);
     const client = new DeepSeekClient({ apiKey: "sk-test", fetch: sharedFetch });

--- a/tests/tools-rate-limit.test.ts
+++ b/tests/tools-rate-limit.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import { ToolRateLimiter, normalizeToolRateLimitConfig } from "../src/tools/rate-limit.js";
+
+describe("ToolRateLimiter", () => {
+  it("allows calls under the aggregate limit", () => {
+    const now = 1_000;
+    const limiter = new ToolRateLimiter(
+      { aggregate: { maxCalls: 2, windowSeconds: 60 }, tools: {} },
+      () => now,
+    );
+
+    expect(limiter.consume("read_file").allowed).toBe(true);
+    expect(limiter.consume("search_files").allowed).toBe(true);
+  });
+
+  it("blocks the first call over the aggregate limit", () => {
+    const now = 1_000;
+    const limiter = new ToolRateLimiter(
+      { aggregate: { maxCalls: 2, windowSeconds: 60 }, tools: {} },
+      () => now,
+    );
+
+    limiter.consume("read_file");
+    limiter.consume("search_files");
+    const blocked = limiter.consume("list_directory");
+
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.result).toMatchObject({
+      error: "rate_limited",
+      scope: "all_tools",
+      limit: 2,
+      windowSeconds: 60,
+    });
+    expect(blocked.result?.retryAfterMs).toBe(60_000);
+  });
+
+  it("lets a per-tool bucket block before the aggregate bucket", () => {
+    const now = 1_000;
+    const limiter = new ToolRateLimiter(
+      {
+        aggregate: { maxCalls: 10, windowSeconds: 60 },
+        tools: { run_command: { maxCalls: 1, windowSeconds: 60 } },
+      },
+      () => now,
+    );
+
+    expect(limiter.consume("run_command").allowed).toBe(true);
+    const blocked = limiter.consume("run_command");
+
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.result).toMatchObject({
+      tool: "run_command",
+      scope: "run_command",
+      limit: 1,
+      windowSeconds: 60,
+    });
+  });
+
+  it("per-tool false disables only that tool bucket while aggregate still applies", () => {
+    const now = 1_000;
+    const limiter = new ToolRateLimiter(
+      {
+        aggregate: { maxCalls: 2, windowSeconds: 60 },
+        tools: { run_command: false },
+      },
+      () => now,
+    );
+
+    expect(limiter.consume("run_command").allowed).toBe(true);
+    expect(limiter.consume("run_command").allowed).toBe(true);
+    const blocked = limiter.consume("run_command");
+
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.result?.scope).toBe("all_tools");
+  });
+
+  it("expires old timestamps after the window", () => {
+    let now = 1_000;
+    const limiter = new ToolRateLimiter(
+      { aggregate: { maxCalls: 1, windowSeconds: 1 }, tools: {} },
+      () => now,
+    );
+
+    expect(limiter.consume("read_file").allowed).toBe(true);
+    expect(limiter.consume("read_file").allowed).toBe(false);
+    now = 2_001;
+    expect(limiter.consume("read_file").allowed).toBe(true);
+  });
+
+  it("enabled false never blocks", () => {
+    const now = 1_000;
+    const limiter = new ToolRateLimiter(false, () => now);
+
+    expect(limiter.consume("run_command").allowed).toBe(true);
+    expect(limiter.consume("run_command").allowed).toBe(true);
+    expect(limiter.consume("run_command").allowed).toBe(true);
+  });
+
+  it("normalizes invalid values to defaults", () => {
+    const normalized = normalizeToolRateLimitConfig({
+      aggregate: { maxCalls: 0, windowSeconds: 0 },
+      tools: {
+        run_command: { maxCalls: -1, windowSeconds: 1.5 },
+        custom_tool: { maxCalls: 3, windowSeconds: 4 },
+      },
+    });
+
+    expect(normalized).toMatchObject({
+      aggregate: { maxCalls: 200, windowSeconds: 60 },
+      tools: {
+        run_command: { maxCalls: 60, windowSeconds: 60 },
+        run_background: { maxCalls: 10, windowSeconds: 60 },
+        custom_tool: { maxCalls: 3, windowSeconds: 4 },
+      },
+    });
+  });
+});

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -436,6 +436,117 @@ describe("ToolRegistry", () => {
     });
   });
 
+  describe("rate limit", () => {
+    it("does not consume quota for unknown tools", async () => {
+      const reg = new ToolRegistry({
+        rateLimit: { aggregate: { maxCalls: 1, windowSeconds: 60 }, tools: {} },
+      });
+      let calls = 0;
+      reg.register({ name: "ok", fn: () => String(++calls) });
+
+      await reg.dispatch("missing", "{}");
+      expect(await reg.dispatch("ok", "{}")).toBe("1");
+      expect(JSON.parse(await reg.dispatch("ok", "{}")).error).toBe("rate_limited");
+      expect(calls).toBe(1);
+    });
+
+    it("does not consume quota for malformed or missing required args", async () => {
+      const reg = new ToolRegistry({
+        rateLimit: { aggregate: { maxCalls: 1, windowSeconds: 60 }, tools: {} },
+      });
+      let calls = 0;
+      reg.register({
+        name: "read_file",
+        parameters: {
+          type: "object",
+          properties: { path: { type: "string" } },
+          required: ["path"],
+        },
+        fn: () => String(++calls),
+      });
+
+      await reg.dispatch("read_file", "{bad json");
+      await reg.dispatch("read_file", "{}");
+      expect(await reg.dispatch("read_file", '{"path":"a"}')).toBe("1");
+      expect(JSON.parse(await reg.dispatch("read_file", '{"path":"b"}')).error).toBe(
+        "rate_limited",
+      );
+      expect(calls).toBe(1);
+    });
+
+    it("does not consume quota for plan-mode refusals", async () => {
+      const reg = new ToolRegistry({
+        rateLimit: { aggregate: { maxCalls: 1, windowSeconds: 60 }, tools: {} },
+      });
+      let calls = 0;
+      reg.register({ name: "edit_file", fn: () => String(++calls) });
+
+      reg.setPlanMode(true);
+      await reg.dispatch("edit_file", "{}");
+      reg.setPlanMode(false);
+
+      expect(await reg.dispatch("edit_file", "{}")).toBe("1");
+      expect(JSON.parse(await reg.dispatch("edit_file", "{}")).error).toBe("rate_limited");
+      expect(calls).toBe(1);
+    });
+
+    it("does not consume quota for interceptor short-circuits", async () => {
+      const reg = new ToolRegistry({
+        rateLimit: { aggregate: { maxCalls: 1, windowSeconds: 60 }, tools: {} },
+      });
+      let calls = 0;
+      reg.register({ name: "edit_file", fn: () => String(++calls) });
+      reg.setToolInterceptor(() => "queued");
+
+      expect(await reg.dispatch("edit_file", "{}")).toBe("queued");
+      reg.setToolInterceptor(null);
+      expect(await reg.dispatch("edit_file", "{}")).toBe("1");
+      expect(JSON.parse(await reg.dispatch("edit_file", "{}")).error).toBe("rate_limited");
+      expect(calls).toBe(1);
+    });
+
+    it("consumes quota before the tool fn awaits", async () => {
+      const reg = new ToolRegistry({
+        rateLimit: { aggregate: { maxCalls: 1, windowSeconds: 60 }, tools: {} },
+      });
+      let release!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      reg.register({
+        name: "slow",
+        fn: async () => {
+          await gate;
+          return "done";
+        },
+      });
+
+      const first = reg.dispatch("slow", "{}");
+      const second = reg.dispatch("slow", "{}");
+      release();
+
+      expect(JSON.parse(await second).error).toBe("rate_limited");
+      expect(await first).toBe("done");
+    });
+
+    it("does not call fn or audit when rate-limited", async () => {
+      const reg = new ToolRegistry({
+        rateLimit: { aggregate: { maxCalls: 1, windowSeconds: 60 }, tools: {} },
+      });
+      let calls = 0;
+      const audit: string[] = [];
+      reg.register({ name: "echo", fn: () => String(++calls) });
+      reg.setAuditListener((event) => audit.push(event.name));
+
+      expect(await reg.dispatch("echo", "{}")).toBe("1");
+      const blocked = JSON.parse(await reg.dispatch("echo", "{}"));
+
+      expect(blocked).toMatchObject({ error: "rate_limited", tool: "echo" });
+      expect(calls).toBe(1);
+      expect(audit).toEqual(["echo"]);
+    });
+  });
+
   describe("isParallelSafe", () => {
     it("returns true when the tool opts in", () => {
       const reg = new ToolRegistry();


### PR DESCRIPTION
Addresses #262.

## Summary
- Add a per-ToolRegistry sliding-window limiter with aggregate and per-tool buckets.
- Return structured `rate_limited` tool results before audit/tool execution, with configurable `toolRateLimit` defaults and opt-out.
- Surface one warning when a rate-limited tool result is appended to loop history.

## Tests
- `npm run verify`
- `git merge-tree --write-tree` checked against current open PR branches #1350, #1345, #1344, #1352, and #1334.
