### PR TITLE
fix(desktop): restore augmentProcessPath() lost in #1334 rebase

### DIFF
--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -52,6 +52,7 @@ import {
   pauseGate,
 } from "../../core/pause-gate.js";
 import { autoResolveVerdict } from "../../core/pause-policy.js";
+import { augmentProcessPath } from "../../desktop/login-shell-path.js";
 import {
   loadDesktopQQState,
   saveDesktopQQSettings,
@@ -833,6 +834,16 @@ export function installDesktopCrashGuards(
 
 export async function desktopCommand(opts: DesktopOptions): Promise<void> {
   loadDotenv();
+  // Tauri spawns the bundled Node from the GUI process, which never runs the
+  // user's shell init (`.bashrc` / `.zshrc` / profile). Probe the login shell
+  // once so nvm / asdf / fnm / volta / mise PATH entries reach `run_command`
+  // children too (#1252). No-op on Windows — system PATH already covers GUI apps.
+  const augmented = augmentProcessPath();
+  if (augmented.added.length > 0) {
+    process.stderr.write(
+      `[desktop] augmented PATH with ${augmented.added.length} login-shell entries\n`,
+    );
+  }
   installDesktopCrashGuards();
 
   const tabs = new Map<string, Tab>();


### PR DESCRIPTION
## Summary
- #1331 added `augmentProcessPath()` so the Tauri-spawned Node can see nvm/asdf/fnm/volta/mise PATH entries — the GUI process never runs the user's shell init
- #1334 branched off main before #1331 landed; the rebase dropped the import + call site without it being part of the QQ-runtime work
- Re-add the import and the call. No behavior change beyond restoring the previous fix

## Test plan
- [x] `tests/desktop-login-shell-path.test.ts` still green
- [x] Full `npm run verify` green (235 files / 3256 tests via pre-push hook)