### PR TITLE
chore(java): clean up comment style + isolate searchProject tests

### DIFF
--- a/src/java/class-source-finder.ts
+++ b/src/java/class-source-finder.ts
@@ -1,5 +1,4 @@
-// ClassSourceFinder — locate Java source by fully-qualified class name.
-// Two-step: (1) project .java walk, (2) jar cache scan (Maven .m2, Gradle) + javap decompile.
+// Java source resolver: project tree → ~/.m2 + ~/.gradle jar cache → javap decompile.
 
 import { execFile } from "node:child_process";
 import * as fs from "node:fs";
@@ -8,18 +7,10 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { readJarEntry } from "./zip-reader.js";
 
-// ── types ────────────────────────────────────────────────────────────────────
-
 export interface FindResultSuccess {
   found: true;
-  /** Reconstructed (or raw {@code .java}) source text. */
   source: string;
-  // Where the source originated:
-  //   "project" — .java file in the project tree.
-  //   "m2-jar"  — decompiled from a jar in Maven .m2 or Gradle cache.
-  //   "jar"     — decompiled from user-specified jar path.
   method: "project" | "m2-jar" | "jar";
-  /** Filesystem path to the {@code .java} file or the jar that was decompiled. */
   sourcePath: string;
 }
 
@@ -31,28 +22,19 @@ export interface FindResultNotFound {
 export type FindResult = FindResultSuccess | FindResultNotFound;
 
 export interface FindSourceOptions {
-  // When set, only scan .m2 jars whose filename or path contains this keyword.
-  // Dramatically reduces scan time when you know which library the class belongs
-  // to (e.g. "spring-core", "guava", "mycompany-utils").
+  /** Case-insensitive substring match against jar path; dramatically narrows the cache scan. */
   jarKeyword?: string;
 }
 
 export interface ClassSourceFinderOptions {
-  /** Root of the Java project to scan for {@code .java} files. */
   projectRoot: string;
-  // One or more directories to scan for jars (Maven .m2, Gradle cache, etc.).
-  // When absent, auto-detects ~/.m2/repository/ and ~/.gradle/caches/ (whichever exist).
+  /** Jar cache dirs. When absent, auto-detects ~/.m2/repository + ~/.gradle/caches. */
   repoPaths?: string[];
-  // Command or absolute path for javap. Defaults to "javap".
   javapCommand?: string;
-  // Maximum number of jar files to scan before giving up.
-  // Protects against huge repositories. Defaults to 2000.
+  /** Cap on jars walked before bailing. */
   maxJarScan?: number;
-  // Signal to abort mid-scan (e.g. user pressed Escape).
   signal?: AbortSignal;
 }
-
-// ── implementation ───────────────────────────────────────────────────────────
 
 export class ClassSourceFinder {
   private projectRoot: string;
@@ -78,66 +60,36 @@ export class ClassSourceFinder {
     this.signal = options.signal;
   }
 
-  // ── public API ──────────────────────────────────────────────────────────
-
-  // Find source for fullyQualifiedName.
-  // 1. Walk the project tree for a matching .java file.
-  // 2. Fall back to scanning jar caches (Maven .m2, Gradle) (optionally filtered by jarKeyword).
   async findSource(fullyQualifiedName: string, options?: FindSourceOptions): Promise<FindResult> {
     this.throwIfAborted();
-
-    // 1. Project search
     const projectResult = await this.searchProject(fullyQualifiedName);
     if (projectResult) return projectResult;
-
-    // 2. Jar cache repositories (optionally filtered by jarKeyword)
     return this.searchRepositories(fullyQualifiedName, options?.jarKeyword);
   }
 
-  // Like findSource, but skip project + repo scan — directly read from jarPath.
-  // @param fullyQualifiedName e.g. "com.example.MyClass"
-  // @param jarPath path to a specific .jar file
   async findSourceInJar(fullyQualifiedName: string, jarPath: string): Promise<FindResult> {
     this.throwIfAborted();
 
     const resolvedJarPath = path.resolve(jarPath);
     if (!fs.existsSync(resolvedJarPath)) {
-      return {
-        found: false,
-        method: "not-found",
-      };
+      return { found: false, method: "not-found" };
     }
 
     const classEntry = `${fullyQualifiedName.replace(/\./g, "/")}.class`;
     try {
       const content = readJarEntry(resolvedJarPath, classEntry);
-      if (!content) {
-        return {
-          found: false,
-          method: "not-found",
-        };
-      }
+      if (!content) return { found: false, method: "not-found" };
       const source = await this.decompileFromJar(resolvedJarPath, content.data, fullyQualifiedName);
       return { found: true, source, method: "jar", sourcePath: resolvedJarPath };
     } catch (err) {
-      return {
-        found: false,
-        method: "not-found",
-      };
+      return { found: false, method: "not-found" };
     }
   }
 
-  // ── step 1: project search ──────────────────────────────────────────────
-
   private async searchProject(fqn: string): Promise<FindResultSuccess | null> {
     const simpleName = this.simpleClassName(fqn);
-    const suffixes = [
-      `${simpleName}.java`,
-      // Some projects keep source alongside generated code with a suffix
-      `${simpleName}.java.txt`,
-    ];
+    const suffixes = [`${simpleName}.java`, `${simpleName}.java.txt`];
 
-    // Breadth-first walk so we find shallow matches quickly.
     const queue: string[] = [this.projectRoot];
     while (queue.length > 0) {
       this.throwIfAborted();
@@ -146,7 +98,6 @@ export class ClassSourceFinder {
       try {
         entries = await fsp.readdir(dir, { withFileTypes: true });
       } catch {
-        // Permission denied, broken symlink, etc. — skip.
         continue;
       }
 
@@ -154,7 +105,6 @@ export class ClassSourceFinder {
         const fullPath = path.join(dir, entry.name);
 
         if (entry.isDirectory()) {
-          // Skip common non-source directories.
           if (
             entry.name === "node_modules" ||
             entry.name === ".git" ||
@@ -180,12 +130,9 @@ export class ClassSourceFinder {
     return null;
   }
 
-  // ── step 2: jar cache repositories ─────────────────────────────────
-
   private async searchRepositories(fqn: string, jarKeyword?: string): Promise<FindResult> {
     const classEntry = `${fqn.replace(/\./g, "/")}.class`;
 
-    // Collect jar paths across all repo dirs — filtered by keyword when provided.
     const jarPaths: string[] = [];
     for (const repoDir of this.repoPaths) {
       await this.walkForJars(repoDir, jarPaths, jarKeyword);
@@ -204,7 +151,7 @@ export class ClassSourceFinder {
           return { found: true, source, method: "m2-jar", sourcePath: jarPath };
         }
       } catch {
-        // Corrupt jar, I/O error, etc. — skip to next.
+        // skip
       }
     }
 
@@ -213,9 +160,6 @@ export class ClassSourceFinder {
 
   private static readonly MAX_WALK_DEPTH = 64;
 
-  // Recursively walk dir collecting .jar file paths.
-  // keyword: case-insensitive filter on jar filename/path.
-  // depth: guards against stack overflow on pathological directory structures.
   private async walkForJars(
     dir: string,
     out: string[],
@@ -246,20 +190,14 @@ export class ClassSourceFinder {
     }
   }
 
-  // ── decompilation ───────────────────────────────────────────────────────
-
-  // Decompile a .class entry extracted from a jar.
-  // Writes bytes to temp dir so javap can read via -cp <tmpdir>.
   private async decompileFromJar(
     jarPath: string,
     classBytes: Buffer,
     fqn: string,
   ): Promise<string> {
-    // Create a temp directory that mirrors the package structure.
     const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "reasonix-java-src-"));
 
     try {
-      // Recreate the package directory structure.
       const pkgPath = fqn.replace(/\./g, path.sep);
       const classDir = path.join(tmpDir, path.dirname(pkgPath));
       await fsp.mkdir(classDir, { recursive: true });
@@ -269,26 +207,23 @@ export class ClassSourceFinder {
 
       return await this.runJavap(fqn, tmpDir);
     } finally {
-      // Best-effort cleanup.
       await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
     }
   }
 
-  // Run javap -c -p against a class on the given classpath.
   private runJavap(className: string, classPath: string): Promise<string> {
     return new Promise((resolve, reject) => {
       execFile(
         this.javapCommand,
         ["-c", "-p", "-cp", classPath, className],
         {
-          maxBuffer: 10 * 1024 * 1024, // 10 MiB
+          maxBuffer: 10 * 1024 * 1024,
           timeout: 30_000,
           signal: this.signal,
         },
         (err, stdout, stderr) => {
           if (err) {
-            // javap returns non-zero for various reasons; surface the
-            // stderr/stdout we did get rather than throwing away context.
+            // javap exits non-zero on missing class / unsupported bytecode — keep its diagnostics.
             const msg = [stdout, stderr].filter(Boolean).join("\n") || err.message;
             reject(new Error(`javap failed: ${msg}`));
             return;
@@ -298,8 +233,6 @@ export class ClassSourceFinder {
       );
     });
   }
-
-  // ── helpers ─────────────────────────────────────────────────────────────
 
   private simpleClassName(fqn: string): string {
     const lastDot = fqn.lastIndexOf(".");

--- a/src/java/zip-reader.ts
+++ b/src/java/zip-reader.ts
@@ -1,22 +1,17 @@
-// Minimal pure-Node.js ZIP / JAR entry reader.
-// Reads a single entry from a zip archive; no external dependencies.
+// Pure-Node ZIP/JAR entry reader — STORED + DEFLATED only.
 
 import * as fs from "node:fs";
 import * as zlib from "node:zlib";
-
-// ── constants ────────────────────────────────────────────────────────────────
 
 const EOCD_SIGNATURE = 0x06054b50;
 const CENTRAL_DIR_SIGNATURE = 0x02014b50;
 const LOCAL_FILE_SIGNATURE = 0x04034b50;
 
 const EOCD_MIN_SIZE = 22;
-const EOCD_MAX_COMMENT = 0xffff; // 65535 bytes
+const EOCD_MAX_COMMENT = 0xffff;
 
 const COMPRESSION_STORED = 0;
 const COMPRESSION_DEFLATED = 8;
-
-// ── types ────────────────────────────────────────────────────────────────────
 
 interface CentralDirEntry {
   fileName: string;
@@ -25,8 +20,6 @@ interface CentralDirEntry {
   uncompressedSize: number;
   localHeaderOffset: number;
 }
-
-// ── helpers ──────────────────────────────────────────────────────────────────
 
 function readU32LE(buf: Buffer, offset: number): number {
   return buf.readUInt32LE(offset);
@@ -37,8 +30,7 @@ function readU16LE(buf: Buffer, offset: number): number {
 }
 
 function findEOCD(fd: number, fileSize: number): { offset: number; buf: Buffer } {
-  // The EOCD record sits at the end of the file, possibly preceded by a
-  // variable-length ZIP comment.  Search backwards in 1 KiB chunks.
+  // EOCD sits at end-of-file but a variable ZIP comment can push it back up to 64 KiB.
   const searchStart = Math.max(0, fileSize - EOCD_MAX_COMMENT - EOCD_MIN_SIZE);
   let chunkOffset = fileSize;
   while (chunkOffset > searchStart) {
@@ -47,10 +39,8 @@ function findEOCD(fd: number, fileSize: number): { offset: number; buf: Buffer }
     const buf = Buffer.alloc(readSize);
     fs.readSync(fd, buf, 0, readSize, chunkOffset);
 
-    // Scan backwards through the chunk for the EOCD signature.
     for (let i = readSize - 4; i >= 0; i--) {
       if (buf.readUInt32LE(i) === EOCD_SIGNATURE) {
-        // We found the signature.  Return the EOCD bytes starting at that offset.
         const eocdOffset = chunkOffset + i;
         const eocdSize = Math.min(EOCD_MIN_SIZE + EOCD_MAX_COMMENT, fileSize - eocdOffset);
         const eocdBuf = Buffer.alloc(eocdSize);
@@ -63,14 +53,13 @@ function findEOCD(fd: number, fileSize: number): { offset: number; buf: Buffer }
 }
 
 function parseCentralDirectory(fd: number, eocdBuf: Buffer): CentralDirEntry[] {
-  const centralDirOffset = readU32LE(eocdBuf, 16); // offset 16 in EOCD
-  const totalEntries = readU16LE(eocdBuf, 10); // offset 10 in EOCD
+  const centralDirOffset = readU32LE(eocdBuf, 16);
+  const totalEntries = readU16LE(eocdBuf, 10);
 
   const entries: CentralDirEntry[] = [];
   let offset = centralDirOffset;
 
   for (let i = 0; i < totalEntries; i++) {
-    // Read the fixed-size (46-byte) central directory header.
     const headerBuf = Buffer.alloc(46);
     fs.readSync(fd, headerBuf, 0, 46, offset);
 
@@ -86,7 +75,6 @@ function parseCentralDirectory(fd: number, eocdBuf: Buffer): CentralDirEntry[] {
     const commentLen = readU16LE(headerBuf, 32);
     const localHeaderOffset = readU32LE(headerBuf, 42);
 
-    // Read the variable-length file name.
     const nameBuf = Buffer.alloc(fileNameLen);
     fs.readSync(fd, nameBuf, 0, fileNameLen, offset + 46);
     const fileName = nameBuf.toString("utf8");
@@ -105,33 +93,23 @@ function parseCentralDirectory(fd: number, eocdBuf: Buffer): CentralDirEntry[] {
   return entries;
 }
 
-// ── public API ───────────────────────────────────────────────────────────────
-
 export interface JarEntry {
   fileName: string;
   data: Buffer;
 }
 
-// Read a single entry from a ZIP / JAR file.
-// @param jarPath absolute path to the .jar
-// @param entryName exact entry name (e.g. "com/example/MyClass.class")
 export function readJarEntry(jarPath: string, entryName: string): JarEntry | null {
   const fd = fs.openSync(jarPath, "r");
   try {
     const stat = fs.fstatSync(fd);
     const fileSize = stat.size;
 
-    // 1. Find EOCD
     const eocd = findEOCD(fd, fileSize);
-
-    // 2. Parse central directory
     const entries = parseCentralDirectory(fd, eocd.buf);
 
-    // 3. Find the target entry
     const target = entries.find((e) => e.fileName === entryName);
     if (!target) return null;
 
-    // 4. Read the local file header
     const localHeaderBuf = Buffer.alloc(30);
     fs.readSync(fd, localHeaderBuf, 0, 30, target.localHeaderOffset);
 
@@ -142,12 +120,10 @@ export function readJarEntry(jarPath: string, entryName: string): JarEntry | nul
     const localFileNameLen = readU16LE(localHeaderBuf, 26);
     const localExtraLen = readU16LE(localHeaderBuf, 28);
 
-    // 5. Read the compressed data
     const dataOffset = target.localHeaderOffset + 30 + localFileNameLen + localExtraLen;
     const compressedBuf = Buffer.alloc(target.compressedSize);
     fs.readSync(fd, compressedBuf, 0, target.compressedSize, dataOffset);
 
-    // 6. Decompress if needed
     let data: Buffer;
     if (target.compressionMethod === COMPRESSION_STORED) {
       data = compressedBuf;
@@ -165,7 +141,6 @@ export function readJarEntry(jarPath: string, entryName: string): JarEntry | nul
   }
 }
 
-// List all entries in a ZIP / JAR file.
 export function listJarEntries(jarPath: string): string[] {
   const fd = fs.openSync(jarPath, "r");
   try {

--- a/src/tools/java-source.ts
+++ b/src/tools/java-source.ts
@@ -1,17 +1,10 @@
-// java_source tool — find and decompile Java source by fully-qualified class name.
-// Modes: (1) project .java walk, (2) Maven/Gradle jar cache scan, (3) direct jarPath.
-// Default-off: enabled via config.json `"javaSource": true` or env `REASONIX_JAVA_SOURCE=1`.
-
 import { ClassSourceFinder } from "../java/class-source-finder.js";
 import type { ToolRegistry } from "../tools.js";
 
 export interface JavaSourceToolOptions {
-  // Root directory for .java file search. Falls back to process.cwd().
   projectRoot?: string;
 }
 
-// Register the java_source tool on registry.
-// Parameters: className (required), projectRoot, jarPath, jarKeyword.
 export function registerJavaSourceTool(
   registry: ToolRegistry,
   opts: JavaSourceToolOptions = {},
@@ -68,7 +61,6 @@ export function registerJavaSourceTool(
         throw new Error("java_source: `className` is required");
       }
 
-      // Validate that the class name looks like a valid Java identifier chain.
       if (!/^[a-zA-Z_$][\w$]*(\.[a-zA-Z_$][\w$]*)*$/.test(className)) {
         throw new Error(
           `java_source: "${className}" is not a valid fully qualified Java class name. Expected format: \`com.example.MyClass\``,
@@ -82,7 +74,6 @@ export function registerJavaSourceTool(
       const jarKeyword = args?.jarKeyword?.trim();
 
       if (jarPath) {
-        // Mode: direct jar path — skip project + repo scan
         const result = await finder.findSourceInJar(className, jarPath);
         if (!result.found) {
           return JSON.stringify({
@@ -100,7 +91,6 @@ export function registerJavaSourceTool(
         });
       }
 
-      // Default: project search → jar cache scan (optionally filtered by jarKeyword)
       const result = await finder.findSource(className, {
         ...(jarKeyword ? { jarKeyword } : {}),
       });

--- a/tests/java-source.test.ts
+++ b/tests/java-source.test.ts
@@ -274,22 +274,21 @@ describe("ClassSourceFinder — project search", () => {
     mkdirSync(join(root, "src"), { recursive: true });
     writeFileSync(join(root, "src", "other.ts"), "export const x = 1;\n");
 
-    const finder = new ClassSourceFinder({ projectRoot: root });
+    const finder = new ClassSourceFinder({ projectRoot: root, repoPaths: [] });
     const result = await finder.findSource("com.example.Missing");
 
     expect(result.found).toBe(false);
-  });
+  }, 30_000);
 
   it("skips common non-source directories", async () => {
     const root = await tmpDir();
     mkdirSync(join(root, "target", "classes"), { recursive: true });
     writeFileSync(join(root, "target", "classes", "MyClass.java"), "// should be ignored");
 
-    const finder = new ClassSourceFinder({ projectRoot: root });
+    const finder = new ClassSourceFinder({ projectRoot: root, repoPaths: [] });
     const result = await finder.findSource("MyClass");
-    // Should NOT find it since target/ is skipped
     expect(result.found).toBe(false);
-  });
+  }, 30_000);
 
   it("accepts jarKeyword filter (does not change project search result)", async () => {
     const root = await tmpDir();
@@ -711,12 +710,11 @@ describe("ClassSourceFinder — edge cases", () => {
 
   it("handles empty project root gracefully", async () => {
     const root = await tmpDir();
-    // No .java, no src dir — should not crash, just not find
-    const finder = new ClassSourceFinder({ projectRoot: root });
+    const finder = new ClassSourceFinder({ projectRoot: root, repoPaths: [] });
     const result = await finder.findSource("com.example.Nonexistent");
 
     expect(result.found).toBe(false);
-  });
+  }, 30_000);
 
   it("handles fully-qualified class name that is also a simple name", async () => {
     const root = await tmpDir();


### PR DESCRIPTION
## Summary
- Silent follow-up to #1344 to bring the new \`src/java/\` and \`src/tools/java-source.ts\` in line with CLAUDE.md comment rules — section-banner separators (\`// ── types ──\`, \`// ── helpers ──\`), 2–3-line module-header essays, and JSDoc-style \`@param\`/\`@returns\` restating type signatures are all banned. Trimmed to plain code with comments only on hidden constraints (e.g. EOCD comment search up to 64 KiB, javap exit-code diagnostic preservation).
- Isolated three \`searchProject\` tests from the real \`~/.m2\` / \`~/.gradle\` defaults — they were walking real caches and timing out on dev machines under full-suite I/O contention. Pass \`repoPaths: []\` plus a defensive 30s per-test cap.

No behavior change in production code. 41 java-source tests still pass.

## Test plan
- [x] \`npm run verify\` green locally (full suite: 236 files / 3297 passed, 9 skipped)
- [x] \`tests/java-source.test.ts\` standalone still passes (41/41)