### PR TITLE
fix(desktop): apply USD→CNY conversion to cost meter and session-cost card

### DIFF
--- a/desktop/src/ui/settings.tsx
+++ b/desktop/src/ui/settings.tsx
@@ -999,6 +999,7 @@ function PageBilling({
   currency: "CNY" | "USD";
 }) {
   const symbol = currency === "CNY" ? "¥" : "$";
+  const sessionCost = currency === "CNY" ? usage.totalCostUsd * 7.2 : usage.totalCostUsd;
   const totalTokens = usage.cacheHitTokens + usage.cacheMissTokens;
   const hitPct = totalTokens > 0 ? Math.round((usage.cacheHitTokens / totalTokens) * 100) : 0;
   return (
@@ -1020,7 +1021,7 @@ function PageBilling({
         <div className="bill-card">
           <div className="l">{t("settings.sessionCost")}</div>
           <div className="v">
-            {symbol} {usage.totalCostUsd.toFixed(4)}
+            {symbol} {sessionCost.toFixed(4)}
           </div>
           <div className="sub">prompt {usage.totalPromptTokens.toLocaleString()} t</div>
         </div>

--- a/desktop/src/ui/statusbar.tsx
+++ b/desktop/src/ui/statusbar.tsx
@@ -6,8 +6,11 @@ import type { JobInfo } from "../protocol";
 import { THEME, THEME_STYLES, type Theme, type ThemeStyle, themeForStyle } from "../theme";
 import { localizeShortcutText } from "./shortcut";
 
-function formatMoney(amount: number, currency: "CNY" | "USD"): string {
+const USD_TO_CNY = 7.2;
+
+function formatMoney(amountUsd: number, currency: "CNY" | "USD"): string {
   const symbol = currency === "CNY" ? "¥" : "$";
+  const amount = currency === "CNY" ? amountUsd * USD_TO_CNY : amountUsd;
   return `${symbol} ${amount.toFixed(4)}`;
 }
 


### PR DESCRIPTION
## Summary
The desktop bottom cost meter and the Settings → Billing session-cost card both swap in the `¥` symbol when the wallet currency is CNY but forget to multiply the underlying USD value by the 7.2 FX factor. A turn that costs ~\$0.14 (actual DeepSeek deduction ~¥1.03) showed as `¥ 0.1428` — wrong by roughly the FX rate.

The TUI's `src/cli/ui/theme/tokens.ts:formatCost` has done this conversion correctly all along; only the desktop forgot. The `costCurrencyHint` copy already claimed the conversion happens, which is what masked the regression past review.

## Test plan
- [x] `npm run lint` clean
- [x] `cd desktop && npx tsc --noEmit` clean
- [x] Pre-push `npm run verify` will run the full suite

Closes #1354.
Closes #1367.