### PR TITLE
fix(tools): walk .reasonix/ from FS tools so user skills stay reachable

### DIFF
--- a/src/tools/filesystem.ts
+++ b/src/tools/filesystem.ts
@@ -42,8 +42,13 @@ const HARD_MAX_FILE_BYTES = 32 * 1024 * 1024;
 /** Lines shown for orientation when a file is too big for full content. */
 const OUTLINE_HEAD_LINES = 80;
 
-/** Skipped unless `include_deps:true` — shared with the semantic indexer via DEFAULT_INDEX_EXCLUDES. */
-const SKIP_DIR_NAMES: ReadonlySet<string> = new Set(DEFAULT_INDEX_EXCLUDES.dirs);
+// Skipped unless `include_deps:true`. Derived from the semantic indexer's exclude
+// list, minus `.reasonix` — the indexer shouldn't embed session logs / cache, but
+// user skills live at `<root>/.reasonix/skills/` (and `~/.reasonix/skills/`) and
+// must stay reachable to read_file / search_files / search_content (#1357).
+const SKIP_DIR_NAMES: ReadonlySet<string> = new Set(
+  DEFAULT_INDEX_EXCLUDES.dirs.filter((d) => d !== ".reasonix"),
+);
 
 /** First line of binary defense; NUL-byte sniff is the second (catches mislabeled `.txt`). */
 const BINARY_EXTENSIONS: ReadonlySet<string> = new Set(DEFAULT_INDEX_EXCLUDES.exts);

--- a/tests/filesystem-tools.test.ts
+++ b/tests/filesystem-tools.test.ts
@@ -387,6 +387,13 @@ describe("filesystem tools (built-in, sandbox-enforced)", () => {
       expect(out).toContain("node_modules/lib/marker.ts");
     });
 
+    it("walks .reasonix/ by default so user skills stay reachable (#1357)", async () => {
+      await fs.mkdir(join(root, ".reasonix", "skills"), { recursive: true });
+      await fs.writeFile(join(root, ".reasonix", "skills", "my-skill.md"), "# my-skill\n");
+      const out = await tools.dispatch("search_files", JSON.stringify({ pattern: "my-skill" }));
+      expect(out).toContain(".reasonix/skills/my-skill.md");
+    });
+
     it("honors AbortSignal during recursive search", async () => {
       await fs.mkdir(join(root, "src", "nested"), { recursive: true });
       await fs.writeFile(join(root, "src", "nested", "marker.ts"), "x");


### PR DESCRIPTION
## Summary
\`src/tools/filesystem.ts\` aliased \`SKIP_DIR_NAMES\` directly to the semantic indexer's exclude list (\`DEFAULT_INDEX_EXCLUDES.dirs\`), which contains \`.reasonix\`. The indexer correctly skips that path so session logs and caches don't get embedded — but the same alias made \`search_files\` / \`search_content\` / \`directory_tree\` / glob blind to user skills living at \`<root>/.reasonix/skills/\` and \`~/.reasonix/skills/\`. Agents would see the skill in \`/skills\` but report "no skill found" when \`search_files\` went looking for it.

Decouple the two: filter \`.reasonix\` out of \`SKIP_DIR_NAMES\` while leaving \`DEFAULT_INDEX_EXCLUDES.dirs\` untouched. Indexer behavior is unchanged; FS tools now reach into \`.reasonix/\` on a normal walk.

## Test plan
- [x] New \`filesystem-tools.test.ts\` case: \`search_files my-skill\` finds \`.reasonix/skills/my-skill.md\`
- [x] Existing skip-dir tests (\`node_modules\` / \`dist\` / \`.git\` still hidden) still pass — 122 / 122 green
- [x] \`npm run lint\` clean
- [x] Pre-push \`npm run verify\` runs the full suite

Closes #1357.