### PR TITLE
feat(net): honor NO_PROXY + bake DeepSeek bypass into default whitelist

### DIFF
--- a/src/net/proxy.ts
+++ b/src/net/proxy.ts
@@ -1,6 +1,9 @@
-/** Node's built-in fetch ignores HTTPS_PROXY env vars — undici's ProxyAgent has to be wired in explicitly. */
+// Node's built-in fetch ignores HTTPS_PROXY env vars — undici's ProxyAgent has to
+// be wired in explicitly. A custom dispatcher routes around the proxy for hosts
+// matched by NO_PROXY (curl-style) so DeepSeek API stays direct while user-set
+// HTTPS_PROXY still routes everything else through the user's proxy.
 
-import { ProxyAgent, setGlobalDispatcher } from "undici";
+import { Agent, type Dispatcher, ProxyAgent, setGlobalDispatcher } from "undici";
 
 /** Env-var precedence matches curl: HTTPS_PROXY → HTTP_PROXY → ALL_PROXY, upper-case first then lower. */
 const PROXY_ENV_KEYS = [
@@ -12,8 +15,32 @@ const PROXY_ENV_KEYS = [
   "all_proxy",
 ] as const;
 
+const NO_PROXY_ENV_KEYS = ["NO_PROXY", "no_proxy"] as const;
+
+// DeepSeek's API origin is in CN; routing it through a user's clash/v2ray
+// (typically a US-exit pool) lands on shared abuse IPs that DeepSeek 403s.
+// Localhost entries protect the dashboard, MCP stdio sidecars' HTTP probes,
+// and the `reasonix doctor` reachability checks.
+export const DEFAULT_NO_PROXY = [
+  "api.deepseek.com",
+  "*.deepseek.com",
+  "localhost",
+  "127.0.0.1",
+  "::1",
+] as const;
+
 export function detectProxyUrl(env: NodeJS.ProcessEnv = process.env): string | null {
   for (const key of PROXY_ENV_KEYS) {
+    const raw = env[key];
+    if (typeof raw !== "string") continue;
+    const trimmed = raw.trim();
+    if (trimmed) return trimmed;
+  }
+  return null;
+}
+
+export function detectNoProxyRaw(env: NodeJS.ProcessEnv = process.env): string | null {
+  for (const key of NO_PROXY_ENV_KEYS) {
     const raw = env[key];
     if (typeof raw !== "string") continue;
     const trimmed = raw.trim();
@@ -34,12 +61,116 @@ export function normalizeProxyUrl(raw: string): string | null {
   }
 }
 
+export interface NoProxyPattern {
+  /** Raw pattern text, kept for /doctor display. */
+  raw: string;
+  matches: (host: string) => boolean;
+}
+
+/** Curl-style NO_PROXY parsing: comma-separated, supports `*` (all), bare host (exact OR `.host` suffix), `.suffix`, `*.suffix`, IP literals. Strips optional `:port` since we only match by host. */
+export function parseNoProxy(raw: string | null | undefined): NoProxyPattern[] {
+  if (!raw) return [];
+  const out: NoProxyPattern[] = [];
+  for (const segment of raw.split(",")) {
+    const trimmed = segment.trim();
+    if (!trimmed) continue;
+    out.push(buildPattern(trimmed));
+  }
+  return out;
+}
+
+function buildPattern(raw: string): NoProxyPattern {
+  // Strip optional :port — we route by host only.
+  const colon = raw.lastIndexOf(":");
+  const hostPart = colon !== -1 && /^\d+$/.test(raw.slice(colon + 1)) ? raw.slice(0, colon) : raw;
+  const normalized = hostPart.toLowerCase();
+  if (normalized === "*") {
+    return { raw, matches: () => true };
+  }
+  if (normalized.startsWith("*.")) {
+    const suffix = normalized.slice(1); // ".foo.com"
+    const bare = normalized.slice(2); // "foo.com"
+    return {
+      raw,
+      matches: (host) => {
+        const h = host.toLowerCase();
+        return h === bare || h.endsWith(suffix);
+      },
+    };
+  }
+  if (normalized.startsWith(".")) {
+    return {
+      raw,
+      matches: (host) => host.toLowerCase().endsWith(normalized),
+    };
+  }
+  return {
+    raw,
+    matches: (host) => {
+      const h = host.toLowerCase();
+      return h === normalized || h.endsWith(`.${normalized}`);
+    },
+  };
+}
+
+export function matchesNoProxy(host: string, patterns: readonly NoProxyPattern[]): boolean {
+  for (const p of patterns) {
+    if (p.matches(host)) return true;
+  }
+  return false;
+}
+
+class SelectiveProxyDispatcher {
+  private readonly direct: Agent;
+  private readonly proxied: ProxyAgent;
+  private readonly patterns: readonly NoProxyPattern[];
+
+  constructor(proxyUrl: string, patterns: readonly NoProxyPattern[]) {
+    this.direct = new Agent();
+    this.proxied = new ProxyAgent(proxyUrl);
+    this.patterns = patterns;
+  }
+
+  dispatch(
+    opts: Dispatcher.DispatchOptions,
+    handler: Dispatcher.DispatchHandler,
+  ): ReturnType<Dispatcher["dispatch"]> {
+    const origin = opts.origin;
+    let host = "";
+    try {
+      if (typeof origin === "string") {
+        host = new URL(origin).hostname;
+      } else if (origin instanceof URL) {
+        host = origin.hostname;
+      }
+    } catch {
+      // Fall through with empty host — won't match patterns, will route via proxy.
+    }
+    const target = host && matchesNoProxy(host, this.patterns) ? this.direct : this.proxied;
+    return (target as unknown as Dispatcher).dispatch(opts, handler);
+  }
+
+  async close(): Promise<void> {
+    await Promise.allSettled([this.direct.close(), this.proxied.close()]);
+  }
+
+  async destroy(): Promise<void> {
+    await Promise.allSettled([this.direct.destroy(), this.proxied.destroy()]);
+  }
+}
+
 let installed = false;
 
-/** Sets the undici global dispatcher to a ProxyAgent. Returns the proxy URL or null if no env var is set, the value is unparseable, or the ProxyAgent ctor throws. Idempotent. */
+export interface ProxyInstallResult {
+  url: string;
+  reinstalled: boolean;
+  noProxy: readonly NoProxyPattern[];
+}
+
+/** Sets the undici global dispatcher to a SelectiveProxyDispatcher (proxy for non-NO_PROXY hosts, direct for matches). Returns the proxy URL + parsed NO_PROXY patterns, or null when no env var is set, the value is unparseable, or the ProxyAgent ctor throws. Idempotent. */
 export function installProxyIfConfigured(
   env: NodeJS.ProcessEnv = process.env,
-): { url: string; reinstalled: boolean } | null {
+): ProxyInstallResult | null {
   const raw = detectProxyUrl(env);
   if (!raw) return null;
   const url = normalizeProxyUrl(raw);
@@ -49,11 +180,19 @@ export function installProxyIfConfigured(
     );
     return null;
   }
+
+  // Default whitelist always applies; user's NO_PROXY entries are additive.
+  const userNoProxy = parseNoProxy(detectNoProxyRaw(env));
+  const defaultNoProxy = parseNoProxy(DEFAULT_NO_PROXY.join(","));
+  const patterns = [...defaultNoProxy, ...userNoProxy];
+
   try {
     const reinstalled = installed;
-    setGlobalDispatcher(new ProxyAgent(url));
+    setGlobalDispatcher(new SelectiveProxyDispatcher(url, patterns) as unknown as Dispatcher);
     installed = true;
-    return { url, reinstalled };
+    const bypassList = patterns.map((p) => p.raw).join(",");
+    process.stderr.write(`[proxy] using ${url} (NO_PROXY: ${bypassList})\n`);
+    return { url, reinstalled, noProxy: patterns };
   } catch (err) {
     process.stderr.write(
       `▲ proxy install failed (${(err as Error).message}); continuing without proxy.\n`,

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -1,9 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  DEFAULT_NO_PROXY,
   _resetForTests,
+  detectNoProxyRaw,
   detectProxyUrl,
   installProxyIfConfigured,
+  matchesNoProxy,
   normalizeProxyUrl,
+  parseNoProxy,
 } from "../src/net/proxy.js";
 
 describe("detectProxyUrl (issue #646)", () => {
@@ -56,11 +60,97 @@ describe("detectProxyUrl (issue #646)", () => {
   });
 });
 
+describe("detectNoProxyRaw", () => {
+  it("returns null when neither NO_PROXY nor no_proxy is set", () => {
+    expect(detectNoProxyRaw({})).toBeNull();
+  });
+
+  it("uppercase NO_PROXY wins over lowercase", () => {
+    expect(detectNoProxyRaw({ NO_PROXY: "a.com", no_proxy: "b.com" })).toBe("a.com");
+  });
+
+  it("falls back to lowercase no_proxy", () => {
+    expect(detectNoProxyRaw({ no_proxy: "b.com" })).toBe("b.com");
+  });
+});
+
+describe("parseNoProxy + matchesNoProxy", () => {
+  it("returns [] for empty / null input", () => {
+    expect(parseNoProxy(null)).toEqual([]);
+    expect(parseNoProxy("")).toEqual([]);
+    expect(parseNoProxy("   ")).toEqual([]);
+  });
+
+  it("`*` matches every host", () => {
+    const p = parseNoProxy("*");
+    expect(matchesNoProxy("api.deepseek.com", p)).toBe(true);
+    expect(matchesNoProxy("anything.example", p)).toBe(true);
+  });
+
+  it("bare hostname matches exact + dot-prefixed subdomain (curl compat)", () => {
+    const p = parseNoProxy("deepseek.com");
+    expect(matchesNoProxy("deepseek.com", p)).toBe(true);
+    expect(matchesNoProxy("api.deepseek.com", p)).toBe(true);
+    expect(matchesNoProxy("notdeepseek.com", p)).toBe(false);
+  });
+
+  it("`.suffix` matches subdomains only, NOT the bare apex", () => {
+    const p = parseNoProxy(".deepseek.com");
+    expect(matchesNoProxy("api.deepseek.com", p)).toBe(true);
+    expect(matchesNoProxy("deepseek.com", p)).toBe(false);
+  });
+
+  it("`*.suffix` matches subdomains AND apex", () => {
+    const p = parseNoProxy("*.deepseek.com");
+    expect(matchesNoProxy("api.deepseek.com", p)).toBe(true);
+    expect(matchesNoProxy("deepseek.com", p)).toBe(true);
+    expect(matchesNoProxy("nondeepseek.com", p)).toBe(false);
+  });
+
+  it("case-insensitive matching", () => {
+    const p = parseNoProxy("DEEPSEEK.COM");
+    expect(matchesNoProxy("api.DeepSeek.com", p)).toBe(true);
+  });
+
+  it("strips `:port` suffix when present", () => {
+    const p = parseNoProxy("api.deepseek.com:443");
+    expect(matchesNoProxy("api.deepseek.com", p)).toBe(true);
+  });
+
+  it("comma-separated entries are merged", () => {
+    const p = parseNoProxy("a.com, .b.com, *.c.com, 127.0.0.1");
+    expect(matchesNoProxy("a.com", p)).toBe(true);
+    expect(matchesNoProxy("foo.a.com", p)).toBe(true);
+    expect(matchesNoProxy("foo.b.com", p)).toBe(true);
+    expect(matchesNoProxy("b.com", p)).toBe(false);
+    expect(matchesNoProxy("c.com", p)).toBe(true);
+    expect(matchesNoProxy("127.0.0.1", p)).toBe(true);
+    expect(matchesNoProxy("128.0.0.1", p)).toBe(false);
+  });
+
+  it("ignores blank entries between commas", () => {
+    const p = parseNoProxy(",, foo.com , ,");
+    expect(p).toHaveLength(1);
+    expect(matchesNoProxy("foo.com", p)).toBe(true);
+  });
+});
+
 describe("installProxyIfConfigured", () => {
+  let writes: string[];
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
   beforeEach(() => {
     _resetForTests();
+    writes = [];
+    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(((
+      chunk: string | Uint8Array,
+    ): boolean => {
+      writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+      return true;
+    }) as typeof process.stderr.write);
   });
   afterEach(() => {
+    stderrSpy.mockRestore();
     _resetForTests();
   });
 
@@ -68,12 +158,34 @@ describe("installProxyIfConfigured", () => {
     expect(installProxyIfConfigured({})).toBeNull();
   });
 
-  it("returns the detected url + reinstalled=false on the first install", () => {
+  it("returns url + reinstalled=false + default NO_PROXY patterns on first install", () => {
     const result = installProxyIfConfigured({ HTTPS_PROXY: "http://example:8080" });
-    expect(result).toEqual({ url: "http://example:8080/", reinstalled: false });
+    expect(result?.url).toBe("http://example:8080/");
+    expect(result?.reinstalled).toBe(false);
+    const raws = result?.noProxy.map((p) => p.raw) ?? [];
+    for (const expected of DEFAULT_NO_PROXY) {
+      expect(raws).toContain(expected);
+    }
   });
 
-  it("returns reinstalled=true on subsequent installs (idempotent at the env-detect level)", () => {
+  it("merges user NO_PROXY entries onto the default whitelist", () => {
+    const result = installProxyIfConfigured({
+      HTTPS_PROXY: "http://example:8080",
+      NO_PROXY: "internal.corp.example, .private.lan",
+    });
+    const raws = result?.noProxy.map((p) => p.raw) ?? [];
+    expect(raws).toContain("api.deepseek.com");
+    expect(raws).toContain("internal.corp.example");
+    expect(raws).toContain(".private.lan");
+  });
+
+  it("logs the proxy decision to stderr at startup", () => {
+    installProxyIfConfigured({ HTTPS_PROXY: "http://example:8080" });
+    expect(writes.join("")).toMatch(/\[proxy\] using http:\/\/example:8080\//);
+    expect(writes.join("")).toMatch(/NO_PROXY: .*api\.deepseek\.com/);
+  });
+
+  it("returns reinstalled=true on subsequent installs", () => {
     installProxyIfConfigured({ HTTPS_PROXY: "http://first:8080" });
     const second = installProxyIfConfigured({ HTTPS_PROXY: "http://second:8080" });
     expect(second?.reinstalled).toBe(true);
@@ -86,21 +198,8 @@ describe("installProxyIfConfigured", () => {
   });
 
   it("does not throw on a malformed env value — warns to stderr and returns null", () => {
-    const writes: string[] = [];
-    const orig = process.stderr.write.bind(process.stderr);
-    const spy = vi.spyOn(process.stderr, "write").mockImplementation(((
-      chunk: string | Uint8Array,
-    ): boolean => {
-      writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
-      return true;
-    }) as typeof process.stderr.write);
-    try {
-      expect(installProxyIfConfigured({ HTTPS_PROXY: "http://[invalid:::" })).toBeNull();
-      expect(writes.join("")).toMatch(/ignoring proxy env value/);
-    } finally {
-      spy.mockRestore();
-      process.stderr.write = orig;
-    }
+    expect(installProxyIfConfigured({ HTTPS_PROXY: "http://[invalid:::" })).toBeNull();
+    expect(writes.join("")).toMatch(/ignoring proxy env value/);
   });
 });
 


### PR DESCRIPTION
## Summary
Tier 1 of a three-tier proxy UX overhaul. After #650 wired up undici's ProxyAgent on `HTTPS_PROXY`, CN users running clash/v2ray globally have been seeing 403s on `api.deepseek.com`: their HTTPS_PROXY routes the request through a foreign-exit pool, lands on a shared abuse IP, and DeepSeek blocks the request. The API host is in CN — it shouldn't be going through a circumvention proxy in the first place.

- Ship a `SelectiveProxyDispatcher` that selects between `ProxyAgent` and a direct `Agent` per-request based on a curl-style NO_PROXY pattern list.
- Default NO_PROXY (always applied): `api.deepseek.com, *.deepseek.com, localhost, 127.0.0.1, ::1`.
- User-set `NO_PROXY` / `no_proxy` env vars layer on top (additive).
- Pattern syntax matches curl: comma-separated; bare host = exact OR `.host` subdomain; `.suffix` = subdomains only; `*.suffix` = subdomains + apex; `*` = bypass all; trailing `:port` stripped.
- Startup now logs `[proxy] using <url> (NO_PROXY: ...)` on stderr so the routing decision is visible without `/doctor`.

Tier 2 (CLI flag + config field + `REASONIX_NO_PROXY`) and Tier 3 (richer `/doctor` output + per-host routing simulator) are queued separately.

## Test plan
- [x] 13 new tests in `tests/proxy.test.ts` cover NO_PROXY parsing (`*`, bare, `.suffix`, `*.suffix`, port stripping, case, empty segments), default whitelist application, user additive merge, and the startup stderr log. Existing 18 tests for `detectProxyUrl` / `normalizeProxyUrl` / install idempotency stay green. 31/31 total.
- [x] `npm run lint` + `npm run typecheck` clean.
- [x] Pre-push `npm run verify` runs the full suite.