### PR TITLE
feat(net): --no-proxy CLI flag + REASONIX_NO_PROXY env + cfg.proxy field

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4,7 +4,7 @@
 import "./heap-limit-launch.js";
 
 import { Command } from "commander";
-import { readConfig } from "../config.js";
+import { loadProxyConfig, readConfig } from "../config.js";
 import { t } from "../i18n/index.js";
 import { VERSION } from "../index.js";
 import { listSessions } from "../memory/session.js";
@@ -23,8 +23,15 @@ async function maybeStartCpuProfile(flag: unknown): Promise<boolean> {
 
 // HTTPS_PROXY / HTTP_PROXY only reach Node's fetch via undici's global
 // dispatcher; install before any client (DeepSeek, web tools, dashboard)
-// constructs a fetch closure. Issue #646.
-installProxyIfConfigured();
+// constructs a fetch closure (#646). Argv is peeked manually here — commander
+// hasn't run yet — so position of `--no-proxy` doesn't matter and we can
+// honor it before any fetch closure captures the dispatcher.
+const cliNoProxy = process.argv.includes("--no-proxy");
+const cfgProxy = loadProxyConfig();
+installProxyIfConfigured(process.env, {
+  disabled: cliNoProxy || cfgProxy.disabled === true,
+  extraNoProxy: cfgProxy.noProxy,
+});
 
 markPhase("cli_module_loaded");
 
@@ -125,7 +132,8 @@ program
   .description(t("cli.description"))
   .version(VERSION)
   .option("-c, --continue", t("cli.continue"))
-  .option("--no-mouse", t("ui.noMouseHint"));
+  .option("--no-mouse", t("ui.noMouseHint"))
+  .option("--no-proxy", t("ui.noProxyHint"));
 
 // `reasonix` with no subcommand → setup wizard on first run, otherwise `code`
 // in the current directory. Filesystem-less chat stays reachable via
@@ -160,6 +168,7 @@ program
   .option("-m, --model <id>", t("ui.modelOverride"))
   .option("--no-session", t("ui.noSession"))
   .option("--no-mouse", t("ui.noMouseHint"))
+  .option("--no-proxy", t("ui.noProxyHint"))
   .option("-r, --resume", t("ui.resumeHint"))
   .option("-n, --new", t("ui.newHint"))
   .option("--transcript <path>", t("ui.transcriptHint"))
@@ -214,6 +223,7 @@ program
   .option("--session <name>", t("ui.sessionNameHint"))
   .option("--no-session", t("ui.ephemeralHint"))
   .option("--no-mouse", t("ui.noMouseHint"))
+  .option("--no-proxy", t("ui.noProxyHint"))
   .option("-r, --resume", t("ui.resumeHint"))
   .option("-c, --continue", t("cli.continue"))
   .option("-n, --new", t("ui.newHint"))
@@ -306,6 +316,7 @@ program
   )
   .option("--mcp-prefix <str>", t("ui.mcpPrefixHintShort"))
   .option("--no-config", t("ui.noConfigHint"))
+  .option("--no-proxy", t("ui.noProxyHint"))
   .action(async (task: string, opts) => {
     const defaults = resolveDefaults({
       model: opts.model,

--- a/src/config.ts
+++ b/src/config.ts
@@ -112,6 +112,13 @@ export interface RateLimitConfig {
   rpm?: number;
 }
 
+export interface ProxyConfig {
+  /** Skip proxy detection entirely — equivalent to launching with `--no-proxy`. */
+  disabled?: boolean;
+  /** Additional NO_PROXY patterns (curl syntax). Additive on top of env NO_PROXY and the default DeepSeek-bypass whitelist. */
+  noProxy?: string[];
+}
+
 export interface ReasonixConfig {
   apiKey?: string;
   baseUrl?: string;
@@ -203,6 +210,8 @@ export interface ReasonixConfig {
     customTypes?: CustomMemoryTypeConfig[];
   };
   pricingOverride?: Record<string, PricingOverride>;
+  /** Per-app proxy override. Layered on top of HTTPS_PROXY / NO_PROXY env vars + the default DeepSeek-bypass whitelist. */
+  proxy?: ProxyConfig;
   rateLimit?: RateLimitConfig;
   /** Host-enforced engineering lifecycle. Defaults to off so opt-outs pay zero prefix cost. */
   engineeringLifecycle?: {
@@ -508,6 +517,20 @@ export function loadPricingOverride(
     if (Object.keys(pricing).length > 0) result[model] = pricing;
   }
   return result;
+}
+
+export function loadProxyConfig(path: string = defaultConfigPath()): ProxyConfig {
+  const cfg = readConfig(path).proxy;
+  if (!cfg || typeof cfg !== "object") return {};
+  const out: ProxyConfig = {};
+  if (cfg.disabled === true) out.disabled = true;
+  if (Array.isArray(cfg.noProxy)) {
+    const entries = cfg.noProxy.filter(
+      (p): p is string => typeof p === "string" && p.trim() !== "",
+    );
+    if (entries.length > 0) out.noProxy = entries;
+  }
+  return out;
 }
 
 export function loadRateLimit(path: string = defaultConfigPath()): RateLimitConfig | undefined {

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -188,6 +188,7 @@ export const EN: TranslationSchema = {
     modelOverride: "override the default model",
     noSession: "disable session persistence for this run",
     noMouseHint: "disable SGR mouse tracking; restores native drag-select and right-click",
+    noProxyHint: "ignore HTTPS_PROXY / HTTP_PROXY for this run; go direct",
     resumeHint: "force-resume the named session (even if idle)",
     newHint: "force a fresh session (ignore --session / --continue)",
     transcriptHint: "path to write the JSONL transcript",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -97,6 +97,7 @@ export interface TranslationSchema {
     modelOverride: string;
     noSession: string;
     noMouseHint: string;
+    noProxyHint: string;
     resumeHint: string;
     newHint: string;
     transcriptHint: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -181,6 +181,7 @@ export const zhCN: TranslationSchema = {
     modelOverride: "覆盖默认模型",
     noSession: "禁用本次运行的会话持久化",
     noMouseHint: "关闭 SGR 鼠标跟踪；恢复终端原生拖选和右键行为",
+    noProxyHint: "本次运行忽略 HTTPS_PROXY / HTTP_PROXY，直连",
     resumeHint: "强制恢复指定会话（即使空闲）",
     newHint: "强制创建新会话（忽略 --session / --continue）",
     transcriptHint: "JSONL 转录稿的写入路径",

--- a/src/net/proxy.ts
+++ b/src/net/proxy.ts
@@ -167,10 +167,19 @@ export interface ProxyInstallResult {
   noProxy: readonly NoProxyPattern[];
 }
 
-/** Sets the undici global dispatcher to a SelectiveProxyDispatcher (proxy for non-NO_PROXY hosts, direct for matches). Returns the proxy URL + parsed NO_PROXY patterns, or null when no env var is set, the value is unparseable, or the ProxyAgent ctor throws. Idempotent. */
+export interface InstallProxyOptions {
+  /** Skip proxy install entirely — for `--no-proxy` / `cfg.proxy.disabled` / env-driven kill-switch. */
+  disabled?: boolean;
+  /** Additional NO_PROXY patterns layered on top of defaults + env. Sourced from `cfg.proxy.noProxy` / `REASONIX_NO_PROXY`. */
+  extraNoProxy?: readonly string[];
+}
+
+/** Sets the undici global dispatcher to a SelectiveProxyDispatcher (proxy for non-NO_PROXY hosts, direct for matches). Returns the proxy URL + parsed NO_PROXY patterns, or null when no env var is set, the value is unparseable, the ProxyAgent ctor throws, or opts.disabled is true. Idempotent. */
 export function installProxyIfConfigured(
   env: NodeJS.ProcessEnv = process.env,
+  opts: InstallProxyOptions = {},
 ): ProxyInstallResult | null {
+  if (opts.disabled) return null;
   const raw = detectProxyUrl(env);
   if (!raw) return null;
   const url = normalizeProxyUrl(raw);
@@ -181,10 +190,15 @@ export function installProxyIfConfigured(
     return null;
   }
 
-  // Default whitelist always applies; user's NO_PROXY entries are additive.
-  const userNoProxy = parseNoProxy(detectNoProxyRaw(env));
+  // Default whitelist always applies; env NO_PROXY, REASONIX_NO_PROXY, and
+  // opts.extraNoProxy (config) all layer on top additively.
   const defaultNoProxy = parseNoProxy(DEFAULT_NO_PROXY.join(","));
-  const patterns = [...defaultNoProxy, ...userNoProxy];
+  const envNoProxy = parseNoProxy(detectNoProxyRaw(env));
+  const reasonixNoProxy = parseNoProxy(
+    typeof env.REASONIX_NO_PROXY === "string" ? env.REASONIX_NO_PROXY : null,
+  );
+  const extraNoProxy = parseNoProxy((opts.extraNoProxy ?? []).join(","));
+  const patterns = [...defaultNoProxy, ...envNoProxy, ...reasonixNoProxy, ...extraNoProxy];
 
   try {
     const reinstalled = installed;

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -21,6 +21,7 @@ import {
   loadPricingOverride,
   loadProjectPathAllowed,
   loadProjectShellAllowed,
+  loadProxyConfig,
   loadRateLimit,
   loadReasoningEffort,
   loadSemanticEmbeddingUserConfig,
@@ -181,6 +182,25 @@ describe("config", () => {
     expect(loadRateLimit(path)).toBeUndefined();
     writeConfig({ rateLimit: { rpm: 1.5 } }, path);
     expect(loadRateLimit(path)).toBeUndefined();
+  });
+
+  it("loads proxy.disabled + proxy.noProxy[] when present, drops blank entries", () => {
+    writeConfig(
+      {
+        proxy: {
+          disabled: true,
+          noProxy: ["internal.corp.example", "", "  ", ".workspace.lan"],
+        },
+      },
+      path,
+    );
+    expect(loadProxyConfig(path)).toEqual({
+      disabled: true,
+      noProxy: ["internal.corp.example", ".workspace.lan"],
+    });
+
+    writeConfig({}, path);
+    expect(loadProxyConfig(path)).toEqual({});
   });
 
   it("redactKey hides the middle", () => {

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -179,6 +179,38 @@ describe("installProxyIfConfigured", () => {
     expect(raws).toContain(".private.lan");
   });
 
+  it("layers REASONIX_NO_PROXY on top of system NO_PROXY (app-specific override)", () => {
+    const result = installProxyIfConfigured({
+      HTTPS_PROXY: "http://example:8080",
+      NO_PROXY: "system.corp.example",
+      REASONIX_NO_PROXY: "app.specific.example, .reasonix.lan",
+    });
+    const raws = result?.noProxy.map((p) => p.raw) ?? [];
+    expect(raws).toContain("system.corp.example");
+    expect(raws).toContain("app.specific.example");
+    expect(raws).toContain(".reasonix.lan");
+  });
+
+  it("layers opts.extraNoProxy (config) on top of env-derived patterns", () => {
+    const result = installProxyIfConfigured(
+      { HTTPS_PROXY: "http://example:8080", NO_PROXY: "env.example" },
+      { extraNoProxy: ["config.example", ".workspace.lan"] },
+    );
+    const raws = result?.noProxy.map((p) => p.raw) ?? [];
+    expect(raws).toContain("env.example");
+    expect(raws).toContain("config.example");
+    expect(raws).toContain(".workspace.lan");
+  });
+
+  it("opts.disabled short-circuits — no install, no log", () => {
+    const result = installProxyIfConfigured(
+      { HTTPS_PROXY: "http://example:8080" },
+      { disabled: true },
+    );
+    expect(result).toBeNull();
+    expect(writes.join("")).not.toMatch(/\[proxy\]/);
+  });
+
   it("logs the proxy decision to stderr at startup", () => {
     installProxyIfConfigured({ HTTPS_PROXY: "http://example:8080" });
     expect(writes.join("")).toMatch(/\[proxy\] using http:\/\/example:8080\//);


### PR DESCRIPTION
## Summary
Tier 2 of the proxy UX overhaul (Tier 1 was #1373). Layers app-specific overrides on top of the env-derived defaults so users don't have to fight system-wide \`HTTPS_PROXY\` / \`NO_PROXY\` set for browsers / clash.

- **\`--no-proxy\` CLI flag** registered on the top-level program, \`code\`, \`chat\`, and \`run\`. Detected via argv peek before commander runs so it takes effect for the same boot that set it.
- **\`REASONIX_NO_PROXY\` env var** — curl-style syntax (comma-separated, `*`, `.suffix`, `*.suffix`, exact, port-stripping), additive on top of system \`NO_PROXY\`. Matches the GitHub CLI pattern (\`GH_HTTPS_PROXY\` > \`HTTPS_PROXY\`).
- **\`cfg.proxy.disabled\` / \`cfg.proxy.noProxy[]\`** config fields — persistent per-user override, loaded via new \`loadProxyConfig()\`.

Precedence: \`--no-proxy\` and \`cfg.proxy.disabled === true\` short-circuit the install entirely. Otherwise default whitelist + env \`NO_PROXY\` + \`REASONIX_NO_PROXY\` + \`cfg.proxy.noProxy\` merge additively.

Tier 3 (richer \`/doctor\` output + per-host routing simulator) is next.

## Test plan
- [x] 3 new tests in \`tests/proxy.test.ts\` covering \`REASONIX_NO_PROXY\` layering, \`opts.extraNoProxy\` (config) layering, and \`opts.disabled\` short-circuit. 34/34 green.
- [x] 1 new test in \`tests/config.test.ts\` for \`loadProxyConfig()\` round-trip + blank-entry filtering. 72/72 green.
- [x] \`npm run verify\` — 236 files / 3329 passed, 9 skipped.