### PR TITLE
fix(lifecycle): let slash plan off release rails

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -174,7 +174,13 @@ import { openUrl } from "./open-url.js";
 import { formatLongPaste } from "./paste-collapse.js";
 import { extractOpenQuestionsSection } from "./plan-open-questions.js";
 import { PRESETS, resolvePreset } from "./presets.js";
-import { type McpServerSummary, handleSlash, parseSlash, suggestSlashCommands } from "./slash.js";
+import {
+  type McpServerSummary,
+  type PlanModeToggleSource,
+  handleSlash,
+  parseSlash,
+  suggestSlashCommands,
+} from "./slash.js";
 import { TurnTranslator } from "./state/TurnTranslator.js";
 import { cardsToDashboardMessages } from "./state/cards-to-messages.js";
 import {
@@ -2071,11 +2077,13 @@ function AppInner({
    * by funneling every toggle through this setter.
    */
   const togglePlanMode = useCallback(
-    (on: boolean) => {
+    (on: boolean, source?: PlanModeToggleSource) => {
       setPlanMode(on);
       tools?.setPlanMode(on);
       if (on) {
         engineeringLifecycleRef.current?.setMode("strict");
+      } else if (source === "slash") {
+        engineeringLifecycleRef.current?.setMode("off");
       } else {
         const state = engineeringLifecycleRef.current?.snapshot().state;
         if (
@@ -2149,8 +2157,8 @@ function AppInner({
             saveEditMode(m);
             return m;
           },
-          setPlanMode: (on: boolean) => {
-            if (codeMode) togglePlanMode(on);
+          setPlanMode: (on: boolean, source?: PlanModeToggleSource) => {
+            if (codeMode) togglePlanMode(on, source);
           },
           applyPresetLive: (name: string) => {
             const settings = resolvePreset(name as PresetName);

--- a/src/cli/ui/slash.ts
+++ b/src/cli/ui/slash.ts
@@ -17,6 +17,7 @@ export { handleSlash } from "./slash/dispatch.js";
 export type { SlashHandler } from "./slash/dispatch.js";
 export type {
   McpServerSummary,
+  PlanModeToggleSource,
   SlashArgContext,
   SlashCommandSpec,
   SlashContext,

--- a/src/cli/ui/slash/handlers/edits.ts
+++ b/src/cli/ui/slash/handlers/edits.ts
@@ -72,7 +72,7 @@ const plan: SlashHandler = (args, _loop, ctx) => {
   if (raw === "on" || raw === "true" || raw === "1" || raw === "strict") target = true;
   else if (raw === "off" || raw === "false" || raw === "0") target = false;
   else target = !currentOn;
-  ctx.setPlanMode(target);
+  ctx.setPlanMode(target, "slash");
   if (target) {
     return { info: t("handlers.edits.planOn") };
   }

--- a/src/cli/ui/slash/types.ts
+++ b/src/cli/ui/slash/types.ts
@@ -59,6 +59,8 @@ export interface SlashResult {
   };
 }
 
+export type PlanModeToggleSource = "slash";
+
 export interface SlashContext {
   configPath?: string;
   mcpSpecs?: string[];
@@ -109,7 +111,7 @@ export interface SlashContext {
     footer?: string;
   }) => void;
   dispatch?: (event: import("../state/events.js").AgentEvent) => void;
-  setPlanMode?: (on: boolean) => void;
+  setPlanMode?: (on: boolean, source?: PlanModeToggleSource) => void;
   /** Manual escape valve when the model forgot to call `mark_step_complete` — used by `/plans done <id>`. */
   markPlanStepDone?: (stepId: string) => "ok" | "not-in-plan" | "already-done" | "no-plan";
   /** Mark every still-queued step done — used by `/plans done all`. Returns the count newly marked. */

--- a/tests/lifecycle.test.ts
+++ b/tests/lifecycle.test.ts
@@ -62,6 +62,18 @@ describe("EngineeringLifecycleRuntime", () => {
     expect(lifecycle.snapshot().state).toBe("armed");
   });
 
+  it("explicitly turning the lifecycle off releases strict rails", () => {
+    const lifecycle = new EngineeringLifecycleRuntime({ mode: "strict" });
+    lifecycle.observeUserPrompt("Refactor the shell and filesystem tool gates");
+
+    expect(lifecycle.guardToolCall("delete_file", { path: "src/old.ts" })).not.toBeNull();
+
+    lifecycle.setMode("off");
+
+    expect(lifecycle.snapshot()).toMatchObject({ mode: "off", state: "idle" });
+    expect(lifecycle.guardToolCall("delete_file", { path: "src/old.ts" })).toBeNull();
+  });
+
   it("allows high-risk mutations after plan approval and then requires step evidence", () => {
     const lifecycle = new EngineeringLifecycleRuntime({ mode: "strict" });
     lifecycle.observeUserPrompt("Refactor the shell and filesystem tool gates");

--- a/tests/slash.test.ts
+++ b/tests/slash.test.ts
@@ -1219,6 +1219,15 @@ describe("handleSlash", () => {
       expect(calls).toEqual([true]);
     });
 
+    it("/plan off marks the change as a user slash action", () => {
+      const calls: Array<{ on: boolean; source?: string }> = [];
+      handleSlash("plan", ["off"], makeLoop(), {
+        planMode: true,
+        setPlanMode: (on, source) => calls.push({ on, source }),
+      });
+      expect(calls).toEqual([{ on: false, source: "slash" }]);
+    });
+
     it("/plan explains the stronger-constraint relationship with autonomous submit_plan", () => {
       const r = handleSlash("plan", ["on"], makeLoop(), {
         setPlanMode: () => {},


### PR DESCRIPTION
## Summary
- tag `/plan` toggles as user-initiated slash actions
- let explicit `/plan off` disable strict engineering lifecycle rails immediately
- keep internal plan approval transitions from disabling lifecycle execution state

## Why
After #1306, strict lifecycle is opt-in, but users still need a clear escape hatch. Previously App could not distinguish explicit `/plan off` from internal plan-mode shutdown after approval, so lifecycle rails could remain armed even after the user asked to leave plan mode.

## Validation
- `npm test -- tests/slash.test.ts tests/lifecycle.test.ts`
- `npm run typecheck`
- `npm run lint` (passes with existing warning in `tests/welcome-banner-hints.test.tsx`)
- `npm test`
- pre-push `npm run verify`

Part of the engineering reliability follow-up from #1285.