### PR TITLE
feat(lifecycle): preserve state across plan revisions

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -4100,10 +4100,7 @@ function AppInner({
         merged.push(s);
       }
       planStepsRef.current = merged;
-      engineeringLifecycleRef.current?.recordPlanApproved(merged);
-      for (const s of merged) {
-        if (completed.has(s.id)) engineeringLifecycleRef.current?.recordStepCompleted(s.id);
-      }
+      engineeringLifecycleRef.current?.recordPlanRevised(snap.remainingSteps);
       persistPlanState();
       // Replace the live active card so PlanLiveRow shows the new tail —      // existing card's stale ids would fail subsequent step completes.
       agentStore.dispatch({ type: "plan.drop" });

--- a/src/code/lifecycle.ts
+++ b/src/code/lifecycle.ts
@@ -146,6 +146,24 @@ export class EngineeringLifecycleRuntime {
     this._mutatedSinceLastStep = false;
   }
 
+  recordPlanRevised(remainingSteps: readonly PlanStep[]): void {
+    if (this._mode === "off") return;
+
+    const donePrefix = this._planSteps.filter((step) => this._completedStepIds.has(step.id));
+    const merged: PlanStep[] = [...donePrefix];
+    for (const step of remainingSteps) {
+      if (this._completedStepIds.has(step.id)) continue;
+      merged.push(step);
+    }
+
+    this._planSteps = merged;
+    if (this._planSteps.length > 0 && this._completedStepIds.size >= this._planSteps.length) {
+      this._state = "complete";
+    } else {
+      this._state = "executing";
+    }
+  }
+
   recordStepCompleted(stepId: string): void {
     if (!stepId) return;
     this._completedStepIds.add(stepId);

--- a/tests/lifecycle.test.ts
+++ b/tests/lifecycle.test.ts
@@ -152,6 +152,62 @@ describe("EngineeringLifecycleRuntime", () => {
     ).toBeNull();
   });
 
+  it("keeps completed plan steps when accepting a revision", () => {
+    const lifecycle = new EngineeringLifecycleRuntime({ mode: "strict" });
+    lifecycle.observeUserPrompt("Refactor the command router");
+    lifecycle.recordPlanApproved([
+      { id: "step-1", title: "Extract router", action: "Move routing helpers.", risk: "low" },
+      { id: "step-2", title: "Migrate callers", action: "Update call sites.", risk: "med" },
+      { id: "step-3", title: "Update tests", action: "Refresh tests.", risk: "low" },
+    ]);
+    lifecycle.recordStepCompleted("step-1");
+
+    lifecycle.recordPlanRevised([
+      { id: "step-3", title: "Update tests", action: "Refresh tests first.", risk: "low" },
+      {
+        id: "step-4",
+        title: "Document fallout",
+        action: "Document skipped migration.",
+        risk: "low",
+      },
+    ]);
+
+    expect(lifecycle.snapshot()).toMatchObject({
+      state: "executing",
+      completedStepIds: ["step-1"],
+      planSteps: [
+        { id: "step-1", title: "Extract router" },
+        { id: "step-3", title: "Update tests" },
+        { id: "step-4", title: "Document fallout" },
+      ],
+    });
+  });
+
+  it("does not clear mutation evidence requirements when accepting a revision", () => {
+    const lifecycle = new EngineeringLifecycleRuntime({ mode: "strict" });
+    lifecycle.observeUserPrompt("Refactor formatting across modules");
+    lifecycle.recordPlanApproved([
+      { id: "step-1", title: "Attempt formatter", action: "Change formatter code.", risk: "low" },
+      { id: "step-2", title: "Repair tests", action: "Update focused tests.", risk: "low" },
+    ]);
+    lifecycle.recordToolResult(
+      "write_file",
+      { path: "src/format.ts" },
+      "▸ edit blocks: 1/1 applied\n  ✓ created     src/format.ts",
+    );
+
+    lifecycle.recordPlanRevised([
+      { id: "step-2", title: "Repair tests", action: "Update focused tests.", risk: "low" },
+    ]);
+
+    const rejected = lifecycle.guardToolCall("mark_step_complete", {
+      stepId: "step-2",
+      result: "Updated tests after revision.",
+    });
+    expect(rejected).not.toBeNull();
+    expect(JSON.parse(rejected!).rejectedReason).toBe("engineering-lifecycle-evidence");
+  });
+
   it("does not mutate the immutable prefix as lifecycle state changes", () => {
     const prefix = new ImmutablePrefix({ system: "s", toolSpecs: [] });
     const before = prefix.fingerprint;


### PR DESCRIPTION
## Summary
- add a lifecycle runtime API for accepted plan revisions
- preserve completed plan steps while replacing only the remaining tail
- keep mutation-driven evidence requirements across revision acceptance
- route the App plan revision acceptance path through the lifecycle runtime API

## Why
The opt-in lifecycle now has plan approval and evidence checks, but accepted revisions should be a first-class lifecycle transition rather than resetting the plan through `recordPlanApproved()`. Resetting approval state can accidentally clear mutation evidence obligations, which weakens the reliability rail after a failed or redirected step.

## Validation
- `npm test -- tests/lifecycle.test.ts`
- `npm test -- tests/lifecycle.test.ts tests/plan.test.ts`
- `npm run typecheck`
- `npm run lint` (passes with existing warning in `tests/welcome-banner-hints.test.tsx`)
- `npm test`
- pre-push `npm run verify`

Part of the engineering reliability follow-up from #1285.