### PR TITLE
feat(lifecycle): gate mutations during checkpoints

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -3853,6 +3853,7 @@ function AppInner({
             p.stepId,
             total,
           );
+          engineeringLifecycleRef.current?.recordCheckpointReached();
           // Shared policy (src/core/pause-policy.ts) decides whether to
           // auto-resolve. Per-step rollback snapshot still runs so /restore
           // granularity is preserved.
@@ -3933,6 +3934,9 @@ function AppInner({
         // and let handleCheckpointReviseSubmit resolve with the feedback text.
         setStagedCheckpointRevise(snap);
         return;
+      }
+      if (choice === "stop") {
+        engineeringLifecycleRef.current?.cancel();
       }
       // Auto file-snapshot per plan step
       if (codeMode && choice === "continue") {

--- a/src/code/lifecycle.ts
+++ b/src/code/lifecycle.ts
@@ -164,6 +164,13 @@ export class EngineeringLifecycleRuntime {
     }
   }
 
+  recordCheckpointReached(): void {
+    if (this._mode === "off") return;
+    if (this._state === "approved" || this._state === "executing") {
+      this._state = "checkpoint";
+    }
+  }
+
   recordStepCompleted(stepId: string): void {
     if (!stepId) return;
     this._completedStepIds.add(stepId);

--- a/tests/lifecycle.test.ts
+++ b/tests/lifecycle.test.ts
@@ -220,6 +220,49 @@ describe("EngineeringLifecycleRuntime", () => {
     expect(JSON.parse(rejected!).rejectedReason).toBe("engineering-lifecycle-evidence");
   });
 
+  it("holds high-risk mutations while waiting at a checkpoint", () => {
+    const lifecycle = new EngineeringLifecycleRuntime({ mode: "strict" });
+    lifecycle.observeUserPrompt("Refactor formatting across modules");
+    lifecycle.recordPlanApproved([
+      { id: "step-1", title: "Extract formatter", action: "Move formatter code.", risk: "low" },
+      { id: "step-2", title: "Update tests", action: "Refresh focused tests.", risk: "low" },
+    ]);
+    lifecycle.recordToolResult(
+      "write_file",
+      { path: "src/format.ts" },
+      "▸ edit blocks: 1/1 applied\n  ✓ created     src/format.ts",
+    );
+
+    lifecycle.recordCheckpointReached();
+
+    expect(lifecycle.snapshot().state).toBe("checkpoint");
+    const rejected = lifecycle.guardToolCall("delete_file", { path: "src/old-format.ts" });
+    expect(rejected).not.toBeNull();
+    expect(JSON.parse(rejected!).state).toBe("checkpoint");
+
+    lifecycle.recordStepCompleted("step-1");
+    expect(lifecycle.snapshot().state).toBe("executing");
+  });
+
+  it("can cancel cleanly from a checkpoint", () => {
+    const lifecycle = new EngineeringLifecycleRuntime({ mode: "strict" });
+    lifecycle.observeUserPrompt("Refactor formatting across modules");
+    lifecycle.recordPlanApproved([
+      { id: "step-1", title: "Extract formatter", action: "Move formatter code.", risk: "low" },
+    ]);
+    lifecycle.recordCheckpointReached();
+
+    lifecycle.cancel();
+
+    expect(lifecycle.snapshot()).toMatchObject({
+      state: "cancelled",
+      planSteps: [],
+      completedStepIds: [],
+      mutatedSinceLastStep: false,
+    });
+    expect(lifecycle.guardToolCall("delete_file", { path: "src/old-format.ts" })).not.toBeNull();
+  });
+
   it("does not mutate the immutable prefix as lifecycle state changes", () => {
     const prefix = new ImmutablePrefix({ system: "s", toolSpecs: [] });
     const before = prefix.fingerprint;


### PR DESCRIPTION
## Summary
- add a lifecycle transition for active plan checkpoints
- block high-risk mutations while a checkpoint is waiting for continue/revise/stop
- cancel the lifecycle when the user chooses stop at a checkpoint
- add regression coverage for checkpoint gating and clean cancellation

## Why
The lifecycle state machine already exposed a `checkpoint` state, but the runtime never entered it. That meant checkpoint pauses were not represented as a guarded state, and a stopped checkpoint could leave the lifecycle in an execution-shaped state. This makes checkpoint/revise/stop behavior more explicit without changing the default opt-in posture.

## Validation
- `npm test -- tests/lifecycle.test.ts`
- `npm test -- tests/lifecycle.test.ts tests/plan.test.ts`
- `npm run typecheck`
- `npm run lint` (passes with existing warning in `tests/welcome-banner-hints.test.tsx`)
- `npm test`
- pre-push `npm run verify`

Part of the engineering reliability follow-up from #1285.