### PR TITLE
feat(plan): surface step evidence summaries

### DIFF
--- a/src/cli/ui/hooks/handle-tool-event.ts
+++ b/src/cli/ui/hooks/handle-tool-event.ts
@@ -3,7 +3,7 @@ import { archivePlanState } from "../../../code/plan-store.js";
 import { t } from "../../../i18n/index.js";
 import type { LoopEvent } from "../../../loop.js";
 import type { ChoiceOption } from "../../../tools/choice.js";
-import type { PlanStep, StepCompletion } from "../../../tools/plan.js";
+import type { PlanStep, StepCompletion, StepEvidence } from "../../../tools/plan.js";
 import type { TurnTranslator } from "../state/TurnTranslator.js";
 import type { Scrollback } from "./useScrollback.js";
 
@@ -60,6 +60,8 @@ export function handleToolEvent(ev: LoopEvent, ctx: ToolEventContext): void {
         const stepFromPlan = ctx.planStepsRef.current?.find((s) => s.id === stepId);
         const title = parsed.title ?? stepFromPlan?.title;
         if (title) ctx.log.pushStepProgress(completed, total, title);
+        const evidenceSummary = formatStepEvidenceSummary(parsed.evidence);
+        if (evidenceSummary) ctx.log.pushInfo(evidenceSummary, "ghost");
         if (ctx.session && total > 0 && completed >= total) {
           const archive = archivePlanState(ctx.session);
           if (archive) {
@@ -71,4 +73,20 @@ export function handleToolEvent(ev: LoopEvent, ctx: ToolEventContext): void {
       /* malformed payload — skip the progress row */
     }
   }
+}
+
+function formatStepEvidenceSummary(evidence: StepCompletion["evidence"]): string | null {
+  if (!evidence || evidence.length === 0) return null;
+  const parts = evidence.map(formatStepEvidenceItem).filter((part) => part.length > 0);
+  if (parts.length === 0) return null;
+  return `evidence: ${parts.join("; ")}`;
+}
+
+function formatStepEvidenceItem(evidence: StepEvidence): string {
+  const extras: string[] = [];
+  if (evidence.command) extras.push(evidence.command);
+  if (evidence.paths && evidence.paths.length > 0)
+    extras.push(evidence.paths.slice(0, 3).join(", "));
+  const suffix = extras.length > 0 ? ` (${extras.join("; ")})` : "";
+  return `${evidence.kind} - ${evidence.summary}${suffix}`;
 }

--- a/tests/handle-tool-event.test.ts
+++ b/tests/handle-tool-event.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { handleToolEvent } from "../src/cli/ui/hooks/handle-tool-event.js";
+import type { Scrollback } from "../src/cli/ui/hooks/useScrollback.js";
+import type { TurnTranslator } from "../src/cli/ui/state/TurnTranslator.js";
+import type { LoopEvent } from "../src/loop.js";
+
+interface Call {
+  method: string;
+  args: unknown[];
+}
+
+function makeLog(): { log: Scrollback; calls: Call[] } {
+  const calls: Call[] = [];
+  const record =
+    <A extends unknown[], R>(method: string, value: R) =>
+    (...args: A): R => {
+      calls.push({ method, args });
+      return value;
+    };
+  const log: Scrollback = {
+    pushUser: record("pushUser", "user"),
+    pushWarning: record("pushWarning", "warning"),
+    pushError: record("pushError", "error"),
+    pushInfo: record("pushInfo", "info"),
+    pushTip: record("pushTip", "tip"),
+    pushCtxPressureIfHigh: record("pushCtxPressureIfHigh", undefined),
+    pushStepProgress: record("pushStepProgress", "step"),
+    pushPlanAnnounce: record("pushPlanAnnounce", "plan"),
+    showDoctor: record("showDoctor", "doctor"),
+    showUsageVerbose: record("showUsageVerbose", "usage"),
+    showPlan: record("showPlan", "plan"),
+    completePlanStep: record("completePlanStep", undefined),
+    showCtx: record("showCtx", "ctx"),
+    startReasoning: record("startReasoning", "reasoning"),
+    appendReasoning: record("appendReasoning", undefined),
+    endReasoning: record("endReasoning", undefined),
+    startStreaming: record("startStreaming", "streaming"),
+    appendStreaming: record("appendStreaming", undefined),
+    endStreaming: record("endStreaming", undefined),
+    startTool: record("startTool", "tool"),
+    appendToolOutput: record("appendToolOutput", undefined),
+    endTool: record("endTool", undefined),
+    retryTool: record("retryTool", undefined),
+    thinking: record("thinking", "thinking"),
+    abortTurn: record("abortTurn", undefined),
+    endTurn: record("endTurn", undefined),
+    reset: record("reset", undefined),
+  };
+  return { log, calls };
+}
+
+function makeEvent(content: unknown): LoopEvent {
+  return {
+    turn: 1,
+    role: "tool",
+    toolName: "mark_step_complete",
+    content: JSON.stringify(content),
+  };
+}
+
+describe("handleToolEvent", () => {
+  it("logs a compact evidence summary for completed plan steps", () => {
+    const { log, calls } = makeLog();
+    const completions = new Map();
+
+    handleToolEvent(
+      makeEvent({
+        kind: "step_completed",
+        stepId: "step-1",
+        result: "Updated lifecycle tests.",
+        evidence: [
+          {
+            kind: "verification",
+            summary: "lifecycle tests passed",
+            command: "npm test -- tests/lifecycle.test.ts",
+          },
+          {
+            kind: "diff",
+            summary: "runtime transition added",
+            paths: ["src/code/lifecycle.ts", "tests/lifecycle.test.ts"],
+          },
+        ],
+      }),
+      {
+        flush: () => undefined,
+        translator: { toolEnd: () => undefined } as unknown as TurnTranslator,
+        setOngoingTool: () => undefined,
+        setToolProgress: () => undefined,
+        toolStartedAtRef: { current: null },
+        setPendingShell: () => undefined,
+        setPendingPlan: () => undefined,
+        setPendingRevision: () => undefined,
+        setPendingChoice: () => undefined,
+        planStepsRef: { current: [{ id: "step-1", title: "Lifecycle", action: "Update tests" }] },
+        completedStepIdsRef: { current: new Set<string>() },
+        stepCompletionsRef: { current: completions },
+        planBodyRef: { current: null },
+        planSummaryRef: { current: null },
+        persistPlanState: () => undefined,
+        log,
+        session: null,
+        codeModeOn: true,
+      },
+    );
+
+    expect(calls).toContainEqual({
+      method: "pushInfo",
+      args: [
+        "evidence: verification - lifecycle tests passed (npm test -- tests/lifecycle.test.ts); diff - runtime transition added (src/code/lifecycle.ts, tests/lifecycle.test.ts)",
+        "ghost",
+      ],
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- log a compact evidence summary when `mark_step_complete` returns structured evidence
- include evidence kind, summary, command, and touched paths in the scrollback line
- keep the existing plan store format unchanged
- add focused coverage for the tool-event evidence log path

## Why
Reasonix already persists step evidence in plan state, but during an active engineering lifecycle the user only sees generic step completion progress. This makes verification/diff/checkpoint/manual evidence immediately visible in the run log without a larger UI redesign.

## Validation
- `npm test -- tests/handle-tool-event.test.ts`
- `npm test -- tests/handle-tool-event.test.ts tests/plan.test.ts tests/plan-store.test.ts`
- `npm run typecheck`
- `npm run lint` (passes with existing warning in `tests/welcome-banner-hints.test.tsx`)
- `npm test`
- pre-push `npm run verify`

Part of the engineering reliability follow-up from #1285.