### PR TITLE
fix(tools): guard repeated gate rejections

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -179,7 +179,7 @@ export class ToolRegistry {
     if (!tool) {
       return JSON.stringify({ error: `unknown tool: ${name}` });
     }
-    const fingerprint = fingerprintArgs(argumentsRaw);
+    const rawFingerprint = rawFingerprintArgs(argumentsRaw);
     let args: Record<string, unknown>;
     try {
       args =
@@ -191,7 +191,7 @@ export class ToolRegistry {
     } catch (err) {
       return this._noteMalformed(
         name,
-        fingerprint,
+        rawFingerprint,
         `invalid tool arguments JSON: ${(err as Error).message}`,
       );
     }
@@ -204,6 +204,7 @@ export class ToolRegistry {
     if (tool.flatSchema && args && typeof args === "object" && hasDotKey(args)) {
       args = nestArguments(args);
     }
+    const fingerprint = fingerprintArgs(args);
 
     const missing = tool.parameters ? missingRequiredParam(tool.parameters, args) : null;
     if (missing) {
@@ -386,14 +387,30 @@ function hasDotKey(obj: Record<string, unknown>): boolean {
   return false;
 }
 
-/** Stable per-call key for the malformed-args storm guard. String args compare as-is; objects round-trip through JSON so key order is stable. */
-function fingerprintArgs(argumentsRaw: string | Record<string, unknown>): string {
+/** Raw key for invalid JSON, where there is no parsed argument object to normalize. */
+function rawFingerprintArgs(argumentsRaw: string | Record<string, unknown>): string {
   if (typeof argumentsRaw === "string") return argumentsRaw;
+  return fingerprintArgs(argumentsRaw);
+}
+
+/** Stable per-call key for parsed tool args; object key order should not affect repeat detection. */
+function fingerprintArgs(args: Record<string, unknown>): string {
   try {
-    return JSON.stringify(argumentsRaw);
+    return JSON.stringify(sortJson(args));
   } catch {
     return "";
   }
+}
+
+function sortJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortJson);
+  if (!value || typeof value !== "object") return value;
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(value).sort()) {
+    const item = (value as Record<string, unknown>)[key];
+    if (item !== undefined) out[key] = sortJson(item);
+  }
+  return out;
 }
 
 /** If the schema declares required params, return the first one that's missing. */

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -64,8 +64,8 @@ export class ToolRegistry {
   private _resultAugmenter: ToolResultAugmenter | null = null;
   /** Per-tool fingerprint of the last call that failed schema validation. Cleared by any successful validation for that tool. */
   private readonly _lastMalformed = new Map<string, string>();
-  /** Per-tool fingerprint of the last host-side interceptor rejection. */
-  private readonly _lastInterceptorRejection = new Map<string, string>();
+  /** Per-tool fingerprint of the last host-side gate rejection. */
+  private readonly _lastGateRejection = new Map<string, string>();
 
   constructor(opts: ToolRegistryOptions = {}) {
     this._autoFlatten = opts.autoFlatten !== false;
@@ -239,7 +239,7 @@ export class ToolRegistry {
       try {
         const short = await interceptor(name, args);
         if (typeof short === "string") {
-          const guarded = this._noteInterceptorRejection(name, fingerprint, short);
+          const guarded = this._noteGateRejection(name, fingerprint, short);
           return this._augmentResult(name, args, guarded);
         }
       } catch (err) {
@@ -248,7 +248,6 @@ export class ToolRegistry {
         });
       }
     }
-    this._lastInterceptorRejection.delete(name);
 
     // Pre-dispatch abort gate: if ESC fired while this tool was queued,
     // refuse to start it. Tools that already check `ctx.signal` mid-run
@@ -308,6 +307,7 @@ export class ToolRegistry {
       }
     }
 
+    finalResult = this._noteGateRejection(name, fingerprint, finalResult);
     return this._augmentResult(name, args, finalResult);
   }
 
@@ -335,18 +335,18 @@ export class ToolRegistry {
     return JSON.stringify({ error: `${name}: ${detail}` });
   }
 
-  private _noteInterceptorRejection(name: string, fingerprint: string, result: string): string {
-    const reason = rejectedReason(result);
+  private _noteGateRejection(name: string, fingerprint: string, result: string): string {
+    const reason = rejectedReason(name, result);
     if (!reason) {
-      this._lastInterceptorRejection.delete(name);
+      this._lastGateRejection.delete(name);
       return result;
     }
     const key = `${reason}:${fingerprint}`;
-    const prev = this._lastInterceptorRejection.get(name);
-    this._lastInterceptorRejection.set(name, key);
+    const prev = this._lastGateRejection.get(name);
+    this._lastGateRejection.set(name, key);
     if (prev === key) {
       return JSON.stringify({
-        error: `${name}: same call was just rejected by ${reason} — do not retry identical args. Switch to read-only exploration, submit or revise the plan, or choose a different tool call.`,
+        error: `${name}: same call was just rejected by ${reason} — do not retry identical args. ${rejectionRecoveryHint(reason)}`,
         rejectedReason: reason,
         consecutiveInterceptorRejection: true,
       });
@@ -355,14 +355,44 @@ export class ToolRegistry {
   }
 }
 
-function rejectedReason(result: string): string | null {
+function rejectedReason(name: string, result: string): string | null {
+  const textReason = plainTextRejectedReason(name, result);
+  if (textReason) return textReason;
   try {
     const parsed = JSON.parse(result) as unknown;
     if (!parsed || typeof parsed !== "object") return null;
     const reason = (parsed as { rejectedReason?: unknown }).rejectedReason;
-    return typeof reason === "string" && reason ? reason : null;
+    if (typeof reason === "string" && reason) return reason;
+    const error = (parsed as { error?: unknown }).error;
+    if (typeof error === "string") return plainTextRejectedReason(name, error);
+    return null;
   } catch {
     return null;
+  }
+}
+
+function plainTextRejectedReason(name: string, result: string): string | null {
+  if ((name === "edit_file" || name === "write_file") && /rejected this edit/i.test(result)) {
+    return "edit-gate";
+  }
+  if ((name === "run_command" || name === "run_background") && /\buser denied:/i.test(result)) {
+    return "shell-gate";
+  }
+  return null;
+}
+
+function rejectionRecoveryHint(reason: string): string {
+  switch (reason) {
+    case "edit-gate":
+      return "Do not re-emit the same edit. Try a genuinely different edit or ask the user how to proceed.";
+    case "shell-gate":
+      return "Do not retry the same command. Use an allowlisted/read-only command, wait for approval, or ask the user how to proceed.";
+    case "engineering-lifecycle":
+      return "Switch to read-only exploration, submit or revise the plan, or choose a different tool call.";
+    case "engineering-lifecycle-evidence":
+      return "Submit completion evidence or revise/checkpoint the plan before marking the step complete.";
+    default:
+      return "Choose a different tool call or ask the user how to proceed.";
   }
 }
 

--- a/tests/shell-tools.test.ts
+++ b/tests/shell-tools.test.ts
@@ -526,6 +526,33 @@ describe("registerShellTools — dispatch integration", () => {
     expect(out).not.toMatch(/user denied/);
   });
 
+  it("sharpens repeated shell gate denials for the high-risk call corpus", async () => {
+    const cases: Array<{ name: "run_command" | "run_background"; args: Record<string, unknown> }> =
+      [
+        { name: "run_command", args: { command: "npm install left-pad" } },
+        { name: "run_background", args: { command: "npm run dev", waitSec: 1 } },
+      ];
+
+    for (const item of cases) {
+      const registry = new ToolRegistry();
+      registerShellTools(registry, { rootDir: tmp });
+      const gate = new AutoGate({ type: "deny", denyContext: "too risky" });
+      const rawArgs = JSON.stringify(item.args);
+
+      const first = await registry.dispatch(item.name, rawArgs, { confirmationGate: gate });
+      const second = JSON.parse(
+        await registry.dispatch(item.name, rawArgs, { confirmationGate: gate }),
+      );
+
+      expect(first).toMatch(new RegExp(`user denied: ${String(item.args.command)}`));
+      expect(first).toMatch(/too risky/);
+      expect(second.rejectedReason).toBe("shell-gate");
+      expect(second.consecutiveInterceptorRejection).toBe(true);
+      expect(second.error).toMatch(/do not retry identical args/);
+      expect(second.error).toMatch(/allowlisted/);
+    }
+  });
+
   it("passes the correct kind to the gate — regression check for argument swap", async () => {
     const registry = new ToolRegistry();
     registerShellTools(registry, { rootDir: tmp });

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { EngineeringLifecycleRuntime } from "../src/code/lifecycle.js";
 import { ToolRegistry } from "../src/tools.js";
 
 describe("ToolRegistry", () => {
@@ -347,6 +348,58 @@ describe("ToolRegistry", () => {
       expect(first.consecutiveInterceptorRejection).toBeUndefined();
       expect(second.consecutiveInterceptorRejection).toBe(true);
       expect(second.error).toMatch(/do not retry identical args/);
+    });
+
+    it("sharpens repeated lifecycle gate rejections when JSON key order changes", async () => {
+      const lifecycle = new EngineeringLifecycleRuntime({ mode: "strict" });
+      const reg = new ToolRegistry();
+      reg.register({ name: "run_command", fn: () => "should not run" });
+      reg.addToolInterceptor("engineering-lifecycle", lifecycle.guardToolCall);
+
+      const first = JSON.parse(
+        await reg.dispatch("run_command", '{"command":"rm -rf dist","cwd":"/repo"}'),
+      );
+      const second = JSON.parse(
+        await reg.dispatch("run_command", '{"cwd":"/repo","command":"rm -rf dist"}'),
+      );
+
+      expect(first.rejectedReason).toBe("engineering-lifecycle");
+      expect(first.consecutiveInterceptorRejection).toBeUndefined();
+      expect(second.rejectedReason).toBe("engineering-lifecycle");
+      expect(second.consecutiveInterceptorRejection).toBe(true);
+      expect(second.error).toMatch(/do not retry identical args/);
+    });
+
+    it("sharpens repeated lifecycle gate rejections for high-risk call corpus", async () => {
+      const cases: Array<{ name: string; args: Record<string, unknown> }> = [
+        {
+          name: "multi_edit",
+          args: {
+            edits: [
+              { path: "src/a.ts", search: "a", replace: "b" },
+              { path: "src/b.ts", search: "a", replace: "b" },
+            ],
+          },
+        },
+        { name: "delete_file", args: { path: "src/old.ts" } },
+        { name: "run_command", args: { command: "npm install left-pad", cwd: "/repo" } },
+      ];
+
+      for (const item of cases) {
+        const lifecycle = new EngineeringLifecycleRuntime({ mode: "strict" });
+        const reg = new ToolRegistry();
+        reg.register({ name: item.name, fn: () => "should not run" });
+        reg.addToolInterceptor("engineering-lifecycle", lifecycle.guardToolCall);
+
+        const rawArgs = JSON.stringify(item.args);
+        const first = JSON.parse(await reg.dispatch(item.name, rawArgs));
+        const second = JSON.parse(await reg.dispatch(item.name, rawArgs));
+
+        expect(first.rejectedReason).toBe("engineering-lifecycle");
+        expect(first.consecutiveInterceptorRejection).toBeUndefined();
+        expect(second.rejectedReason).toBe("engineering-lifecycle");
+        expect(second.consecutiveInterceptorRejection).toBe(true);
+      }
     });
 
     it("surfaces interceptor throws as structured errors", async () => {

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -402,6 +402,29 @@ describe("ToolRegistry", () => {
       }
     });
 
+    it("sharpens repeated edit gate rejections from review-mode text", async () => {
+      const reg = new ToolRegistry();
+      reg.register({ name: "edit_file", fn: () => "should not run" });
+      reg.setToolInterceptor((name, args) => {
+        if (name !== "edit_file") return null;
+        return `User rejected this edit to ${String(args.path)}. Don't retry the same SEARCH/REPLACE; either try a different approach or ask the user what they want instead.`;
+      });
+
+      const rawArgs = JSON.stringify({
+        path: "src/app.ts",
+        search: "oldValue",
+        replace: "newValue",
+      });
+      const first = await reg.dispatch("edit_file", rawArgs);
+      const second = JSON.parse(await reg.dispatch("edit_file", rawArgs));
+
+      expect(first).toMatch(/User rejected this edit to src\/app\.ts/);
+      expect(second.rejectedReason).toBe("edit-gate");
+      expect(second.consecutiveInterceptorRejection).toBe(true);
+      expect(second.error).toMatch(/do not retry identical args/);
+      expect(second.error).toMatch(/different edit/);
+    });
+
     it("surfaces interceptor throws as structured errors", async () => {
       const reg = new ToolRegistry();
       reg.register({ name: "edit_file", fn: () => "ok" });


### PR DESCRIPTION
## Summary
- normalize parsed tool arguments before comparing repeated host gate rejections
- keep raw fingerprints for invalid JSON malformed-args feedback
- detect repeated lifecycle gate rejections even when JSON key order changes
- detect repeated edit gate review denials from existing rejection text
- detect repeated shell gate denials from `run_command` / `run_background` confirmation failures
- add corpus coverage for lifecycle, edit, and shell gate repeat loops

## Why
The repeated rejection guard should stop models from repeatedly撞同一个宿主约束，而不只是拦截结构化 lifecycle responses. This keeps strict rails calmer under retries: after the first normal host rejection, the second identical call gets a sharper "do not retry identical args" recovery hint.

## Validation
- `npm test -- tests/tools.test.ts`
- `npm test -- tests/shell-tools.test.ts`
- `npm test -- tests/tools.test.ts tests/shell-tools.test.ts tests/lifecycle.test.ts tests/repair/storm.test.ts tests/repair/pipeline.test.ts`
- `npm run typecheck`
- `npm run lint` (passes with existing warning in `tests/welcome-banner-hints.test.tsx`)
- `npm test`
- pre-push `npm run verify`

Part of the engineering reliability follow-up from #1285.