### PR TITLE
fix(desktop): prevent React #31 when MCP config contains non-string items (#1295)

### DIFF
--- a/desktop/src/ui/context-panel.tsx
+++ b/desktop/src/ui/context-panel.tsx
@@ -222,7 +222,7 @@ function CtxTools({ specs, bridged }: { specs: McpSpecInfo[]; bridged: boolean }
                 <I.wrench size={12} />
               </span>
               <div className="body">
-                <div className="n">{s.name ?? s.summary}</div>
+                <div className="n">{s.name ?? (typeof s.summary === "string" ? s.summary : "[invalid]")}</div>
                 <div className="m">
                   {s.transport}
                   {suffix}

--- a/desktop/src/ui/settings.tsx
+++ b/desktop/src/ui/settings.tsx
@@ -861,8 +861,8 @@ function PageMCP({
                   <I.wrench size={14} />
                 </span>
                 <div>
-                  <div className="nm">{s.name ?? "(anonymous)"}</div>
-                  <div className="sub">{s.summary}</div>
+                  <div className="nm">{typeof s.name === "string" ? s.name : "(anonymous)"}</div>
+                  <div className="sub">{typeof s.summary === "string" ? s.summary : "[invalid]"}</div>
                 </div>
                 <span className="grow" />
                 <button

--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -564,7 +564,7 @@ function emitSessions(tab: Tab): void {
   }
 }
 
-function summarizeMcpSpec(raw: string): McpSpecInfo {
+export function summarizeMcpSpec(raw: string): McpSpecInfo {
   try {
     const parsed = parseMcpSpec(raw);
     if (parsed.transport === "stdio") {
@@ -585,11 +585,12 @@ function summarizeMcpSpec(raw: string): McpSpecInfo {
       status: "configured",
     };
   } catch (err) {
+    const safe = typeof raw === "string" ? raw : (JSON.stringify(raw) ?? String(raw));
     return {
-      raw,
+      raw: safe,
       name: null,
       transport: "stdio",
-      summary: raw,
+      summary: safe,
       parseError: (err as Error).message,
       status: "failed",
       statusReason: (err as Error).message,
@@ -599,12 +600,14 @@ function summarizeMcpSpec(raw: string): McpSpecInfo {
 
 function emitMcpSpecs(tab: Tab): void {
   const cfg = readConfig();
-  const specs = (cfg.mcp ?? []).map((raw) => {
-    const base = summarizeMcpSpec(raw);
-    const live = tab.mcpStatuses.get(raw);
-    if (!live) return base;
-    return { ...base, status: live.kind, statusReason: live.reason, toolCount: live.toolCount };
-  });
+  const specs = (cfg.mcp ?? [])
+    .filter((raw): raw is string => typeof raw === "string")
+    .map((raw) => {
+      const base = summarizeMcpSpec(raw);
+      const live = tab.mcpStatuses.get(raw);
+      if (!live) return base;
+      return { ...base, status: live.kind, statusReason: live.reason, toolCount: live.toolCount };
+    });
   const bridged = specs.length > 0 && specs.every((s) => s.status === "connected");
   emit({ type: "$mcp_specs", specs, bridged }, tab.id);
 }

--- a/tests/mcp-desktop-react31.test.ts
+++ b/tests/mcp-desktop-react31.test.ts
@@ -1,0 +1,108 @@
+/** Regression test for issue #1295 — React #31 when config.json mcp array contains non-string items */
+
+import { describe, expect, it } from "vitest";
+import { summarizeMcpSpec } from "../src/cli/commands/desktop.js";
+
+describe("summarizeMcpSpec — normal string inputs", () => {
+  it("returns stdio summary for a valid stdio spec", () => {
+    const result = summarizeMcpSpec("fs=npx -y @modelcontextprotocol/server-filesystem /tmp");
+    expect(result.transport).toBe("stdio");
+    expect(result.summary).toBe("stdio · npx -y @modelcontextprotocol/server-filesystem /tmp");
+    expect(result.status).toBe("configured");
+    expect(result.name).toBe("fs");
+    expect(result.raw).toBe("fs=npx -y @modelcontextprotocol/server-filesystem /tmp");
+  });
+
+  it("returns sse summary for a valid sse spec", () => {
+    const result = summarizeMcpSpec("local=https://127.0.0.1:9000/sse");
+    expect(result.transport).toBe("sse");
+    expect(result.summary).toBe("sse · https://127.0.0.1:9000/sse");
+    expect(result.status).toBe("configured");
+    expect(result.name).toBe("local");
+  });
+
+  it("returns streamable-http summary for a valid streamable-http spec", () => {
+    const result = summarizeMcpSpec("remote=streamable+https://example.com/mcp");
+    expect(result.transport).toBe("streamable-http");
+    expect(result.summary).toBe("streamable-http · https://example.com/mcp");
+    expect(result.status).toBe("configured");
+  });
+});
+
+describe("summarizeMcpSpec — malformed / non-string inputs (defensive)", () => {
+  it("stringifies an object input in the catch block instead of returning it raw", () => {
+    const badInput = {
+      name: "github",
+      transport: "stdio",
+      command: "npx",
+      args: ["-y"],
+    } as unknown as string;
+    const result = summarizeMcpSpec(badInput);
+    expect(typeof result.summary).toBe("string");
+    expect(result.summary).not.toEqual(badInput);
+    expect(result.summary).toContain("github");
+    expect(result.status).toBe("failed");
+    expect(result.name).toBeNull();
+    expect(result.parseError).toBeTruthy();
+  });
+
+  it("stringifies an array input in the catch block", () => {
+    const badInput = ["npx", "-y", "pkg"] as unknown as string;
+    const result = summarizeMcpSpec(badInput);
+    expect(typeof result.summary).toBe("string");
+    expect(result.status).toBe("failed");
+    expect(result.name).toBeNull();
+  });
+
+  it("handles null input gracefully", () => {
+    const result = summarizeMcpSpec(null as unknown as string);
+    expect(typeof result.summary).toBe("string");
+    expect(result.summary).toBe("null");
+    expect(result.status).toBe("failed");
+    expect(result.name).toBeNull();
+  });
+
+  it("handles undefined input gracefully", () => {
+    const result = summarizeMcpSpec(undefined as unknown as string);
+    expect(typeof result.summary).toBe("string");
+    expect(result.status).toBe("failed");
+    expect(result.name).toBeNull();
+  });
+
+  it("handles number input gracefully", () => {
+    const result = summarizeMcpSpec(42 as unknown as string);
+    expect(typeof result.summary).toBe("string");
+    expect(result.summary).toBe("42");
+    expect(result.status).toBe("failed");
+  });
+
+  it("preserves the raw string for invalid spec text", () => {
+    const badSpec = "   ";
+    const result = summarizeMcpSpec(badSpec);
+    expect(result.raw).toBe(badSpec);
+    expect(typeof result.summary).toBe("string");
+    expect(result.summary).toBe(badSpec);
+    expect(result.status).toBe("failed");
+  });
+});
+
+describe("summarizeMcpSpec — summary is always a string (React #31 invariant)", () => {
+  it("never returns an object summary for any input", () => {
+    const inputs: unknown[] = [
+      "valid=npx pkg",
+      "",
+      "   ",
+      { foo: "bar" },
+      [1, 2, 3],
+      null,
+      undefined,
+      42,
+      true,
+    ];
+    for (const input of inputs) {
+      const result = summarizeMcpSpec(input as string);
+      expect(typeof result.summary).toBe("string");
+      expect(result.summary === null || typeof result.summary === "object").toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1295 — Desktop MCP tools panel crashes with React error #31 ("Objects are not valid as a React child") when `config.json` contains non-string items in the `mcp` array.

## Root Cause

`readConfig()` does `JSON.parse` without runtime validation, so `config.json`'s `mcp` array can contain objects even though it's typed as `string[]`. When `summarizeMcpSpec()` threw on these object inputs, its catch block returned `summary: raw` directly, leaking objects into JSX.

## Fix (4-layer defense)

1. **`summarizeMcpSpec` catch block** — stringifies non-string `raw` values using `JSON.stringify(raw) ?? String(raw)`, so `summary` is always a string.
2. **`emitMcpSpecs` filter** — filters `cfg.mcp` with `typeof raw === "string"` before mapping, preventing bad items from reaching the renderer at all.
3. **`CtxTools` defensive render** (`context-panel.tsx`) — renders `summary` only if it's a string.
4. **`PageMCP` defensive render** (`settings.tsx`) — renders `name`/`summary` only if they're strings.

## Test Plan

- [x] Added regression test: `tests/mcp-desktop-react31.test.ts`
- [x] `npm run verify` passes (build + lint + typecheck + 3343 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)