### PR TITLE
fix(desktop): sync context token meter after /compact (#1305)

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -671,8 +671,16 @@ export function applyIncoming(state: State, ev: IncomingEvent): State {
       };
     case "$skills":
       return { ...state, skills: ev.items };
-    case "$ctx_breakdown":
-      return { ...state, usage: { ...state.usage, reservedTokens: ev.reservedTokens } };
+    case "$ctx_breakdown": {
+      const next: UsageStats = { ...state.usage, reservedTokens: ev.reservedTokens };
+      if (typeof ev.logTokens === "number") {
+        // After /compact the backend sends a real-time log token count;
+        // reset the meter so it reflects the actual current context size.
+        next.cacheHitTokens = 0;
+        next.cacheMissTokens = ev.logTokens;
+      }
+      return { ...state, usage: next };
+    }
     case "$memory":
       return { ...state, memory: ev.entries };
     case "$jobs":

--- a/desktop/src/protocol.ts
+++ b/desktop/src/protocol.ts
@@ -167,6 +167,8 @@ export type SkillsEvent = {
 export type CtxBreakdownEvent = {
   type: "$ctx_breakdown";
   reservedTokens: number;
+  /** Current log token count (real-time) — sent after /compact to refresh the meter. */
+  logTokens?: number;
 };
 
 export type MemoryEntryInfo = {

--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -341,6 +341,8 @@ interface McpSpecsEvent {
 interface CtxBreakdownEvent {
   type: "$ctx_breakdown";
   reservedTokens: number;
+  /** Current log token count (real-time) — sent after /compact to refresh the meter. */
+  logTokens?: number;
 }
 
 interface MemoryEntryInfo {
@@ -631,7 +633,8 @@ function emitCtxBreakdown(tab: Tab): void {
   try {
     const sys = countTokensBounded(tab.runtime.loop.prefix.system);
     const tools = countTokensBounded(JSON.stringify(tab.runtime.loop.prefix.toolSpecs));
-    emit({ type: "$ctx_breakdown", reservedTokens: sys + tools }, tab.id);
+    const logTokens = tab.runtime.loop.getCurrentLogTokens();
+    emit({ type: "$ctx_breakdown", reservedTokens: sys + tools, logTokens }, tab.id);
   } catch {
     // tokenizer warmup can throw on first call before the data file loads
   }
@@ -2260,9 +2263,12 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
     }
     if (msg.cmd === "compact_history") {
       if (!tab.runtime) return;
-      void tab.runtime.loop.compactHistory().catch((err: Error) => {
-        emit({ type: "$error", message: `/compact failed: ${err.message}` }, tab.id);
-      });
+      void tab.runtime.loop
+        .compactHistory()
+        .then(() => emitCtxBreakdown(tab))
+        .catch((err: Error) => {
+          emit({ type: "$error", message: `/compact failed: ${err.message}` }, tab.id);
+        });
       return;
     }
     if (msg.cmd === "retry") {

--- a/src/context-manager.ts
+++ b/src/context-manager.ts
@@ -103,6 +103,21 @@ function extractPinnedSkills(head: ChatMessage[]): {
 export class ContextManager {
   constructor(private deps: ContextManagerDeps) {}
 
+  /** Real-time token count of the current log — used by Desktop to refresh the
+   *  context meter after /compact when no API usage event is available. */
+  getLogTokens(): number {
+    const entries = this.deps.log.toMessages();
+    let total = 0;
+    for (const e of entries) {
+      const content = typeof e.content === "string" ? e.content : "";
+      total += countTokensBounded(content);
+      if (e.role === "assistant" && Array.isArray(e.tool_calls) && e.tool_calls.length > 0) {
+        total += countTokensBounded(JSON.stringify(e.tool_calls));
+      }
+    }
+    return total;
+  }
+
   /** Decision after a turn's response — fold, exit with summary, or carry on. */
   decideAfterUsage(
     usage: Usage | null,

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -266,6 +266,11 @@ export class CacheFirstLoop {
     return this.context.fold(this.model, opts);
   }
 
+  /** Real-time token count of the current log — forwarded to Desktop for meter refresh. */
+  getCurrentLogTokens(): number {
+    return this.context.getLogTokens();
+  }
+
   appendAndPersist(message: ChatMessage): void {
     this.log.append(message);
     if (this.sessionName) {

--- a/tests/context-manager-log-tokens.test.ts
+++ b/tests/context-manager-log-tokens.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { DeepSeekClient } from "../src/client.js";
+import { ContextManager } from "../src/context-manager.js";
+import { AppendOnlyLog } from "../src/memory/runtime.js";
+import { SessionStats } from "../src/telemetry/stats.js";
+
+function makeManager(log: AppendOnlyLog): ContextManager {
+  const client = new DeepSeekClient({ apiKey: "sk-test" });
+  return new ContextManager({
+    client,
+    log,
+    stats: new SessionStats(),
+    sessionName: null,
+    getAbortSignal: () => new AbortController().signal,
+    getCurrentTurn: () => 1,
+  });
+}
+
+describe("ContextManager.getLogTokens", () => {
+  it("returns 0 for an empty log", () => {
+    const log = new AppendOnlyLog();
+    const mgr = makeManager(log);
+    expect(mgr.getLogTokens()).toBe(0);
+  });
+
+  it("counts user + assistant message content", () => {
+    const log = new AppendOnlyLog();
+    log.append({ role: "user", content: "hello world" });
+    log.append({ role: "assistant", content: "hi there" });
+    const mgr = makeManager(log);
+    const tokens = mgr.getLogTokens();
+    expect(tokens).toBeGreaterThan(0);
+  });
+
+  it("counts tool result messages", () => {
+    const log = new AppendOnlyLog();
+    log.append({ role: "user", content: "read file" });
+    log.append({
+      role: "tool",
+      name: "read_file",
+      tool_call_id: "t1",
+      content: "file contents here",
+    });
+    const mgr = makeManager(log);
+    const tokens = mgr.getLogTokens();
+    expect(tokens).toBeGreaterThan(0);
+  });
+
+  it("counts assistant tool_calls when present", () => {
+    const log = new AppendOnlyLog();
+    log.append({ role: "user", content: "do something" });
+    log.append({
+      role: "assistant",
+      content: "",
+      tool_calls: [{ id: "t1", type: "function", function: { name: "test", arguments: "{}" } }],
+    });
+    const mgr = makeManager(log);
+    const tokens = mgr.getLogTokens();
+    expect(tokens).toBeGreaterThan(0);
+  });
+
+  it("ignores empty assistant tool_calls array", () => {
+    const log = new AppendOnlyLog();
+    log.append({ role: "user", content: "hello" });
+    log.append({ role: "assistant", content: "hi", tool_calls: [] });
+    const mgr = makeManager(log);
+    const tokensWithEmpty = mgr.getLogTokens();
+
+    const log2 = new AppendOnlyLog();
+    log2.append({ role: "user", content: "hello" });
+    log2.append({ role: "assistant", content: "hi" });
+    const mgr2 = makeManager(log2);
+    const tokensWithout = mgr2.getLogTokens();
+
+    expect(tokensWithEmpty).toBe(tokensWithout);
+  });
+
+  it("drops after compact to reflect smaller log", () => {
+    const log = new AppendOnlyLog();
+    for (let i = 0; i < 10; i++) {
+      log.append({ role: "user", content: `question ${i}` });
+      log.append({ role: "assistant", content: `answer ${i}` });
+    }
+    const mgr = makeManager(log);
+    const before = mgr.getLogTokens();
+    expect(before).toBeGreaterThan(0);
+
+    // Simulate compact: keep only last 2 turns
+    const all = log.toMessages();
+    log.compactInPlace(all.slice(all.length - 4));
+    const after = mgr.getLogTokens();
+    expect(after).toBeLessThan(before);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1305 — Desktop ContextPanel shows stale token counts after `/compact`.

## Root Cause

Desktop's `ContextPanel` relies on `model.final` API usage events to update `cacheHitTokens`/`cacheMissTokens`. `/compact` is a local operation (no API call), so no usage event fires and the meter never refreshes.

TUI side uses `computeCtxBreakdown()` which re-counts tokens from `loop.log` every time — it's always accurate.

## Fix (high-cohesion)

1. `ContextManager.getLogTokens()` — real-time token count of current log.
2. `Loop.getCurrentLogTokens()` — forwards to ContextManager.
3. Extend `\$ctx_breakdown` event with optional `logTokens` field.
4. `emitCtxBreakdown()` now computes + pushes `logTokens` alongside `reservedTokens`, becoming the unified context-refresh entrypoint.
5. `compact_history` handler calls `emitCtxBreakdown(tab)` on success so the frontend immediately receives the compressed token count.
6. `App.tsx` `\$ctx_breakdown` handler resets `cacheHitTokens=0` and `cacheMissTokens=logTokens` when `logTokens` is present, calibrating the meter to the actual current context size.

## Test Plan

- [x] `npm run verify` passes (build + lint + typecheck + 3343 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)