### PR TITLE
test(tools): close dispatch-level E2E gaps for shell jobs, web, and scaffold

### DIFF
--- a/tests/shell-tools.test.ts
+++ b/tests/shell-tools.test.ts
@@ -616,6 +616,67 @@ describe("registerShellTools — dispatch integration", () => {
     expect(afterYolo).toMatch(/user denied/);
     expect(afterYolo).toMatch(/node -e/);
   });
+
+  it("run_background dispatch starts a job, list_jobs sees it, job_output reads it, stop_job ends it", async () => {
+    const registry = new ToolRegistry();
+    const jobs = new (await import("../src/tools/jobs.js")).JobRegistry();
+    registerShellTools(registry, { rootDir: tmp, jobs, extraAllowed: ["node"] });
+
+    try {
+      const startOut = await registry.dispatch(
+        "run_background",
+        JSON.stringify({
+          command: `node -e "setInterval(()=>console.log('tick'), 50)"`,
+          waitSec: 0.1,
+        }),
+      );
+      const jobIdMatch = startOut.match(/job (\d+) started/);
+      expect(jobIdMatch).not.toBeNull();
+      const jobId = Number(jobIdMatch![1]);
+
+      const listOut = await registry.dispatch("list_jobs", "{}");
+      expect(listOut).toMatch(new RegExp(`\\b${jobId}\\b`));
+      expect(listOut).toContain("node -e");
+
+      await registry.dispatch(
+        "wait_for_job",
+        JSON.stringify({ jobId, timeoutMs: 500, waitFor: "output-or-exit" }),
+      );
+      const outputOut = await registry.dispatch("job_output", JSON.stringify({ jobId }));
+      expect(outputOut).toContain("tick");
+
+      const stopOut = await registry.dispatch("stop_job", JSON.stringify({ jobId }));
+      expect(stopOut).toContain(`job ${jobId}`);
+    } finally {
+      await jobs.shutdown(2000);
+    }
+  });
+
+  it("job_output / stop_job report not-found for unknown jobId", async () => {
+    const registry = new ToolRegistry();
+    registerShellTools(registry, { rootDir: tmp });
+    const outNoRead = await registry.dispatch("job_output", JSON.stringify({ jobId: 9999 }));
+    expect(outNoRead).toMatch(/job 9999: not found/);
+    const outNoStop = await registry.dispatch("stop_job", JSON.stringify({ jobId: 9999 }));
+    expect(outNoStop).toMatch(/job 9999: not found/);
+  });
+
+  it("list_jobs reports an empty session when nothing has been started", async () => {
+    const registry = new ToolRegistry();
+    registerShellTools(registry, { rootDir: tmp });
+    const out = await registry.dispatch("list_jobs", "{}");
+    expect(out).toContain("no background jobs");
+  });
+
+  it("run_background dispatch rejects a cwd that escapes the workspace root", async () => {
+    const registry = new ToolRegistry();
+    registerShellTools(registry, { rootDir: tmp, extraAllowed: ["node"] });
+    const out = await registry.dispatch(
+      "run_background",
+      JSON.stringify({ command: "node --version", cwd: "../../etc" }),
+    );
+    expect(out).toMatch(/resolves outside the workspace root/);
+  });
 });
 
 describe("formatCommandResult", () => {

--- a/tests/tools-scaffold.test.ts
+++ b/tests/tools-scaffold.test.ts
@@ -30,10 +30,8 @@ function teardown(s: Setup): void {
 }
 
 async function call(reg: ToolRegistry, name: string, args: Record<string, unknown>): Promise<any> {
-  const def = reg.get(name);
-  if (!def) throw new Error(`tool ${name} not registered`);
-  const out = await def.fn(args);
-  return JSON.parse(out as string);
+  const out = await reg.dispatch(name, JSON.stringify(args));
+  return JSON.parse(out);
 }
 
 describe("create_skill", () => {

--- a/tests/web-tools.test.ts
+++ b/tests/web-tools.test.ts
@@ -907,6 +907,55 @@ describe("registerWebTools", () => {
     const out = await registry.dispatch("web_fetch", JSON.stringify({ url: "file:///etc/passwd" }));
     expect(out).toMatch(/must start with http/);
   });
+
+  it("web_search dispatch returns formatted results", async () => {
+    const html = `
+      <a class="title" href="https://example.com/a">A</a>
+      <p class="s">snippet A</p>
+      <a class="title" href="https://example.com/b">B</a>
+      <p class="s">snippet B</p>`;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(
+      async () => new Response(html, { status: 200, headers: { "Content-Type": "text/html" } }),
+    ) as unknown as typeof fetch;
+    try {
+      const registry = new ToolRegistry();
+      registerWebTools(registry);
+      const out = await registry.dispatch(
+        "web_search",
+        JSON.stringify({ query: "flutter 3.19", topK: 2 }),
+      );
+      expect(out).toContain("query: flutter 3.19");
+      expect(out).toContain("https://example.com/a");
+      expect(out).toContain("snippet A");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("web_fetch dispatch returns title + body text", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(
+          "<html><head><title>Demo</title></head><body><p>Hello world.</p></body></html>",
+          { status: 200, headers: { "Content-Type": "text/html; charset=utf-8" } },
+        ),
+    ) as unknown as typeof fetch;
+    try {
+      const registry = new ToolRegistry();
+      registerWebTools(registry);
+      const out = await registry.dispatch(
+        "web_fetch",
+        JSON.stringify({ url: "https://example.com/" }),
+      );
+      expect(out).toContain("Demo");
+      expect(out).toContain("https://example.com/");
+      expect(out).toContain("Hello world.");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });
 
 describe("webFetch", () => {


### PR DESCRIPTION
## Summary

Audited the registered tools against the test suite — 7 tools were registered with `ToolRegistry` but never exercised through `dispatch()`, so the dispatch boundary itself (plan-mode gating, parallel-safe checks, error wrapping, result augmentation) wasn't covered for them. A tool could regress on any of those without a single test failing.

- **shell-tools**: new dispatch tests for `run_background` / `job_output` / `stop_job` / `list_jobs` — full round-trip (start → list → read → stop), plus not-found and `cwd` escaping the workspace root. `wait_for_job` already had one dispatch test.
- **web-tools**: dispatch tests for `web_search` (mocked Mojeek fetch) and `web_fetch` (mocked HTML). The existing suite only covered the lower-level `webSearch` / `webFetch` functions and `htmlToText` / parsers.
- **tools-scaffold**: switched the in-file `call()` helper from `def.fn(args)` to `reg.dispatch(name, JSON.stringify(args))`. All 16 existing `create_skill` / `add_mcp_server` tests now run through dispatch with zero per-test edits.

Net: 3388 → 3394 passing tests.

## Audit notes for future me

Other registered tools (`read_file` / `write_file` / `edit_file` / `multi_edit` / `list_directory` / `directory_tree` / `search_files` / `search_content` / `glob` / `get_file_info` / `create_directory` / `delete_file` / `delete_directory` / `copy_file` / `move_file` / `java_source` / `get_symbols` / `find_in_code` / `ask_choice` / `remember` / `recall_memory` / `forget` / `submit_plan` / `revise_plan` / `mark_step_complete` / `todo_write` / `run_command` / `wait_for_job` / `run_skill` / `install_skill` / `spawn_subagent`) all have at least one dispatch-level test. Confirmed by multiline grep across `tests/`.

## Test plan

- [x] `npm run verify` (build + lint + typecheck + 3394 tests) passes locally
