### PR TITLE
docs(qq): add desktop quick start and trim README surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,35 +96,14 @@ Other subcommands (`replay` · `diff` · `events` · `stats` · `index` · `mcp`
 
 ### QQ channel
 
-Reasonix can attach QQ as a remote communication channel for existing `chat` and `code` sessions. It is not a separate runtime mode.
+QQ can extend an existing `chat`, `code`, or desktop session as a remote channel. It is part of the current session flow, not a separate runtime mode.
 
-Start a session first:
+- CLI: start a session, then run `/qq connect`
+- Desktop: open `Settings -> General -> QQ Channel`
 
-~~~bash
-reasonix code
-# or
-reasonix chat
-~~~
+Once connected, QQ messages can enter the current session, assistant replies route back to QQ, and follow-up interactions can continue remotely.
 
-Then connect QQ from inside the session:
-
-~~~text
-/qq connect
-~~~
-
-On first use, Reasonix asks for the QQ `App ID` and `App Secret` inside the current TUI. Later `/qq connect` calls reuse the saved credentials directly.
-
-Available commands:
-
-- `/qq connect`
-- `/qq status`
-- `/qq disconnect`
-
-Once enabled, later `chat` / `code` sessions auto-start the QQ channel. Slash commands, confirmation prompts, and follow-up assistant replies can continue through QQ without terminal-side input.
-
-Desktop users can configure the same channel from `Settings -> General -> QQ Channel`.
-
-See [QQ channel setup](./docs/qq-connect.md) for the CLI flow, desktop entry, and QQ Open Platform setup.
+For full setup, desktop quick start, and troubleshooting, see [QQ channel setup](./docs/qq-connect.md).
 
 ### Desktop client (prerelease)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -80,35 +80,14 @@ npx reasonix code   # 首次运行粘贴 DeepSeek API Key，之后会记住
 
 ### QQ 通道
 
-Reasonix 可以把 QQ 挂到现有的 `chat` / `code` 会话上，作为远程通信通道使用。它不是一个独立的新模式。
+Reasonix 可以把现有的 `chat`、`code` 或桌面端会话延伸到 QQ 上，作为远程通道使用；它扩展的是当前会话，不是独立的新运行模式。
 
-先启动一个会话：
+- CLI：先启动会话，再执行 `/qq connect`
+- 桌面端：打开 `设置 -> 通用 -> QQ通道`
 
-~~~bash
-reasonix code
-# 或
-reasonix chat
-~~~
+连接成功后，QQ 消息可以进入当前会话，助手回复会回到 QQ，后续确认和跟进交互也可以继续在 QQ 上完成。
 
-然后在会话里连接 QQ：
-
-~~~text
-/qq connect
-~~~
-
-第一次使用时，Reasonix 会直接在当前 TUI 里引导输入 QQ 的 `App ID` 和 `App Secret`；之后再次执行 `/qq connect` 会直接复用已保存凭据。
-
-可用命令：
-
-- `/qq connect`
-- `/qq status`
-- `/qq disconnect`
-
-启用后，后续的 `chat` / `code` 会话会自动启动 QQ 通道。斜杠命令、确认提示，以及后续助手回复都可以通过 QQ 继续完成，不需要回到终端交互。
-
-桌面端也可以在 `Settings -> General -> QQ Channel` 里配置同一条通道。
-
-详细说明见 [QQ 连接指南](./docs/qq-connect.zh-CN.md)。
+完整配置、桌面端快速上手与排障说明见：[QQ 连接指南](./docs/qq-connect.zh-CN.md)。
 
 <details>
 <summary><strong>切换工作区 · chat vs. code · 写第一个 Skill</strong></summary>

--- a/docs/qq-connect.md
+++ b/docs/qq-connect.md
@@ -74,17 +74,24 @@ Other QQ commands:
 
 After the first successful connection, later `chat` and `code` sessions auto-start the QQ channel while it stays enabled.
 
-## Connect from the desktop app
+## Desktop quick start
 
 If you use the desktop client:
 
-1. Open `Settings`.
-2. Go to `General`.
-3. Find `QQ Channel` near the bottom.
-4. Click `Configure...` to enter `App ID`, `App Secret`, and `Sandbox` / `Production`.
-5. Click `Save and connect`.
+1. Open `Settings -> General -> QQ Channel`.
+2. Click `Configure`.
+3. Enter `App ID`, `App Secret`, and the correct QQ environment.
+4. Click `Save and connect`.
+5. Send a message from QQ and check that it appears in the current desktop transcript.
+6. Wait for the desktop reply to route back to QQ.
 
-The desktop app uses the same underlying QQ config as the CLI.
+The desktop app uses the same underlying QQ config as the CLI, but the runtime is attached to the current active desktop tab.
+
+That means:
+
+- QQ messages enter the current active tab
+- replies from that tab route back to QQ
+- if you switch tabs, later QQ messages follow the new active tab
 
 ## Typical usage
 
@@ -120,6 +127,16 @@ Check that the local Reasonix session is still running and the channel is still 
 ~~~text
 /qq status
 ~~~
+
+### Desktop shows QQ configured, but no message round-tripping happens
+
+First confirm you are using a desktop build that already includes desktop QQ runtime support.
+
+Then check:
+
+- the status in `Settings -> General -> QQ Channel`
+- that the current active desktop tab is the one you expect QQ to drive
+- that the local desktop session is still running
 
 ### `/qq` commands do not exist in your installed package
 

--- a/docs/qq-connect.zh-CN.md
+++ b/docs/qq-connect.zh-CN.md
@@ -1,6 +1,6 @@
 # QQ 连接指南
 
-Reasonix 可以把 QQ 挂到现有的 `chat` 或 `code` 会话上，作为远程通道使用。QQ 不是第三种运行模式。
+Reasonix 可以把现有的 `chat`、`code` 或桌面端会话延伸到 QQ 上，作为远程通道使用。QQ 扩展的是当前会话，不是独立的新运行模式。
 
 连接成功后，QQ 可以：
 
@@ -29,11 +29,11 @@ QQ 开放平台入口：
 
 QQ 开放平台界面可能会变化，但通常流程是：
 
-1. 打开 [QQ 开放平台](https://q.qq.com/qqbot/openclaw/login.html) 并登录。
-2. 创建 QQ 机器人。
-3. 打开机器人的开发设置。
-4. 复制 `App ID`。
-5. 查看并保存 `App Secret`。
+1. 打开 [QQ 开放平台](https://q.qq.com/qqbot/openclaw/login.html) 并登录
+2. 创建 QQ 机器人
+3. 打开机器人的开发设置
+4. 复制 `App ID`
+5. 查看并保存 `App Secret`
 
 ## 在 CLI 里连接
 
@@ -41,8 +41,7 @@ QQ 开放平台界面可能会变化，但通常流程是：
 
 ~~~bash
 reasonix code
-# 或
-reasonix chat
+# 或 reasonix chat
 ~~~
 
 然后运行：
@@ -58,7 +57,6 @@ reasonix chat
 3. 任一步输入 `/cancel` 都可以取消
 
 这些提示和 `/qq` 结果会跟随当前 CLI 语言切换。
-
 如果本地已经保存过凭据，`/qq connect` 会直接复用，不会重复询问。
 
 也可以直接一次性传参：
@@ -69,28 +67,38 @@ reasonix chat
 
 其他相关命令：
 
+- `/qq connect`
 - `/qq status`
 - `/qq disconnect`
 
 第一次连接成功后，只要 QQ 保持启用，后续 `chat` 和 `code` 会话都会自动启动 QQ 通道。
 
-## 在桌面端连接
+## 桌面端快速上手
 
 如果你使用桌面客户端：
 
-1. 打开 `Settings`
-2. 进入 `General`
-3. 在底部找到 `QQ Channel`
-4. 点击 `Configure...`
-5. 填入 `App ID`、`App Secret`，再选择 `Sandbox` / `Production`
-6. 点击 `Save and connect`
+1. 打开 `设置 -> 通用 -> QQ通道`
+2. 点击 `配置`
+3. 填入 `App ID` 和 `App Secret`
+4. 选择正确的 QQ 环境：测试用 `沙箱`，正式机器人选 `正式`
+5. 点击 `保存并连接`
+6. 从 QQ 给机器人发一条消息，确认这条消息会出现在当前桌面会话记录里
+7. 等待助手回复，确认回复会回到 QQ
 
 桌面端和 CLI 复用同一份 QQ 配置。
+
+### 当前活动标签页绑定
+
+桌面端会把 QQ 绑定到**当前活动标签页**：
+
+- 来自 QQ 的新消息会进入当前活动标签页
+- 该标签页中的助手回复会回到同一个 QQ 通道
+- 如果你切换到另一个标签页，后续 QQ 消息会进入新的当前标签页
 
 ## 典型使用方式
 
 1. 启动 `reasonix code` 或 `reasonix chat`
-2. 先完成一次 QQ 连接
+2. 完成一次 QQ 连接
 3. 从 QQ 发一条消息
 4. 本地 Reasonix 会话继续运行
 5. 需要时直接在 QQ 里继续回复、确认或选择
@@ -108,11 +116,20 @@ QQ 只是扩展当前会话，不替代 `chat` 或 `code`。
 - QQ 开放平台里的机器人是否已启用
 - 当前环境是否选对了：`sandbox` 或 `prod`
 
-必要时可以直接显式传参重连：
+必要时可以直接显式传参重试：
 
 ~~~text
 /qq connect <appId> <appSecret> [sandbox|prod]
 ~~~
+
+### 桌面端里已经配置 QQ，但没有消息往返
+
+优先检查：
+
+- 使用的桌面端版本是否已经包含桌面 QQ runtime 支持
+- `设置 -> 通用 -> QQ通道` 里当前状态是否正常
+- 当前活动标签页是否仍然停留在你希望接收 QQ 消息的会话上
+- 本地桌面会话是否仍然在运行
 
 ### QQ 能收到消息，但没有后续回复
 


### PR DESCRIPTION
﻿## Summary
- shorten the README QQ surface in both languages and keep it as a pointer to the dedicated guide
- add a clearer desktop quick-start section to the QQ setup docs
- align the Chinese copy with the current desktop labels and active-tab runtime behavior

## What changed
- README.md / README.zh-CN.md now keep QQ to a short overview plus entry points
- docs/qq-connect.md now includes a desktop quick start and active-tab binding note
- docs/qq-connect.zh-CN.md mirrors the same flow and updates the Chinese UI path to `设置 -> 通用 -> QQ通道`

## Why
Issue #1343 asked for a clearer desktop QQ usage path. Since desktop QQ runtime is now in main, the docs should explain the current behavior without keeping a long tutorial block in the top-level README.

## Verification
- `git diff --check`
- `npm run lint`
- `npm run verify`
