### PR TITLE
Fix desktop session loading hang from partial stdout writes

### DIFF
--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -439,9 +439,40 @@ type EmittableEvent =
   | MemoryEvent
   | JobsEvent;
 
+const STDOUT_BACKPRESSURE_WAIT = new Int32Array(new SharedArrayBuffer(4));
+
+type SyncWriter = (fd: number, buffer: Buffer, offset: number, length: number) => number;
+
+export function writeAllSync(
+  fd: number,
+  buffer: Buffer,
+  opts: {
+    write?: SyncWriter;
+    wait?: () => void;
+  } = {},
+): void {
+  const write = opts.write ?? writeSync;
+  const wait = opts.wait ?? (() => Atomics.wait(STDOUT_BACKPRESSURE_WAIT, 0, 0, 5));
+  let offset = 0;
+  while (offset < buffer.length) {
+    let written: number;
+    try {
+      written = write(fd, buffer, offset, buffer.length - offset);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException)?.code === "EAGAIN") {
+        wait();
+        continue;
+      }
+      throw err;
+    }
+    if (written <= 0) throw new Error("stdout write returned 0 bytes");
+    offset += written;
+  }
+}
+
 function emit(ev: EmittableEvent, tabId?: string): void {
   const payload = tabId ? { ...ev, tabId } : ev;
-  writeSync(1, Buffer.from(`${JSON.stringify(payload)}\n`, "utf8"));
+  writeAllSync(1, Buffer.from(`${JSON.stringify(payload)}\n`, "utf8"));
 }
 
 function tailLines(s: string, n: number): string {

--- a/tests/desktop-stdout-write.test.ts
+++ b/tests/desktop-stdout-write.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { writeAllSync } from "../src/cli/commands/desktop.js";
+
+describe("desktop stdout writes", () => {
+  it("continues after partial writes and EAGAIN", () => {
+    const input = Buffer.from('{"type":"$session_loaded","messages":["large"]}\n', "utf8");
+    const chunks: Buffer[] = [];
+    let calls = 0;
+    let waits = 0;
+
+    writeAllSync(1, input, {
+      write: (_fd, buffer, offset, length) => {
+        calls++;
+        if (calls === 1) {
+          const written = Math.min(4, length);
+          chunks.push(Buffer.from(buffer.subarray(offset, offset + written)));
+          return written;
+        }
+        if (calls === 2) {
+          const err = new Error("try again") as NodeJS.ErrnoException;
+          err.code = "EAGAIN";
+          throw err;
+        }
+        chunks.push(Buffer.from(buffer.subarray(offset, offset + length)));
+        return length;
+      },
+      wait: () => {
+        waits++;
+      },
+    });
+
+    expect(Buffer.concat(chunks).toString("utf8")).toBe(input.toString("utf8"));
+    expect(calls).toBe(3);
+    expect(waits).toBe(1);
+  });
+});


### PR DESCRIPTION
Fixes desktop kernel JSON event corruption when large `$session_loaded` payloads are written to stdout.

`emit()` previously assumed `writeSync` writes the whole buffer in one call. For large history sessions, stdout can partially write or throw `EAGAIN`, which corrupts the newline-delimited JSON stream and causes the desktop UI to hang while connecting to the kernel.

This change writes the full buffer in a loop and retries `EAGAIN`.

Verification:
- `npm test -- tests/desktop-stdout-write.test.ts`
- `npx tsc --noEmit --pretty false`
- `npx biome check src/cli/commands/desktop.ts tests/desktop-stdout-write.test.ts`
- `npm run build`
- pre-push `npm run verify`