### PR TITLE
test(shell-tools): raise run_background dispatch test timeout to 15s

### DIFF
--- a/tests/shell-tools.test.ts
+++ b/tests/shell-tools.test.ts
@@ -677,7 +677,7 @@ describe("registerShellTools — dispatch integration", () => {
     } finally {
       await jobs.shutdown(2000);
     }
-  });
+  }, 15000);
 
   it("job_output / stop_job report not-found for unknown jobId", async () => {
     const registry = new ToolRegistry();


### PR DESCRIPTION
The end-to-end `run_background → list_jobs → wait_for_job → job_output → stop_job` test added in #1400 (`tests/shell-tools.test.ts:647`) used the default 5s vitest timeout. On Windows the full chain — Node child spawn + 500ms `wait_for_job` + SIGTERM grace inside `stop_job` — runs ~3-8s depending on load. Verified failing on plain main under moderate load.

Raise the per-test timeout to 15s. No functional change.
