### PR TITLE
fix(lifecycle): keep strict rails cache-neutral

### DIFF
--- a/scripts/probe-lifecycle-cache-neutral.mts
+++ b/scripts/probe-lifecycle-cache-neutral.mts
@@ -1,0 +1,130 @@
+/**
+ * Live DeepSeek cache probe for the runtime-only Engineering Lifecycle design.
+ *
+ * This is intentionally NOT wired into CI. It needs DEEPSEEK_API_KEY and the
+ * live provider cache. Run manually when validating cache neutrality:
+ *
+ *   npx tsx scripts/probe-lifecycle-cache-neutral.mts
+ *
+ * The deterministic invariant lives in tests/code-prompt.test.ts. This probe
+ * checks the economic side: off/strict prompts are byte-identical, and warm
+ * turns should report >=99% prompt-cache hit after the cold start.
+ */
+
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { codeSystemPrompt } from "../src/code/prompt.js";
+
+function loadDotenv(path: string): void {
+  try {
+    const txt = readFileSync(path, "utf8");
+    for (const line of txt.split(/\r?\n/)) {
+      const m = line.match(/^([A-Z_][A-Z0-9_]*)=(.*)$/);
+      if (m && !process.env[m[1]]) process.env[m[1]] = m[2];
+    }
+  } catch {
+    /* optional */
+  }
+}
+
+loadDotenv("./.env.testbak");
+
+const KEY = process.env.DEEPSEEK_API_KEY;
+const BASE = process.env.DEEPSEEK_BASE_URL ?? "https://api.deepseek.com";
+const MODEL = process.env.REASONIX_CACHE_PROBE_MODEL ?? "deepseek-v4-flash";
+
+if (!KEY) {
+  throw new Error("DEEPSEEK_API_KEY missing; set it or add .env.testbak.");
+}
+
+const filler = (label: string, n: number): string =>
+  Array.from(
+    { length: n },
+    (_, i) =>
+      `${label} line ${i}: cache-neutral lifecycle probe context with stable deterministic bytes for DeepSeek prefix-cache measurement.`,
+  ).join("\n");
+
+function messages(system: string, turn: number) {
+  const out: Array<{ role: "system" | "user" | "assistant"; content: string }> = [
+    { role: "system", content: system },
+    { role: "user", content: `seed block A:\n${filler("A", 80)}` },
+    { role: "assistant", content: "seed A acknowledged." },
+    { role: "user", content: `seed block B:\n${filler("B", 80)}` },
+    { role: "assistant", content: "seed B acknowledged." },
+  ];
+  for (let i = 0; i < turn; i++) {
+    out.push({ role: "user", content: `historical turn ${i}: ${filler(`H${i}`, 12)}` });
+    out.push({ role: "assistant", content: `historical answer ${i}: ok.` });
+  }
+  out.push({ role: "user", content: `probe turn ${turn}: reply with exactly "ok ${turn}".` });
+  return out;
+}
+
+async function call(label: string, system: string, turn: number): Promise<number> {
+  const res = await fetch(`${BASE}/chat/completions`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${KEY}`,
+    },
+    body: JSON.stringify({
+      model: MODEL,
+      messages: messages(system, turn),
+      temperature: 0,
+      max_tokens: 8,
+      stream: false,
+    }),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`${label}: HTTP ${res.status}: ${text.slice(0, 400)}`);
+  }
+  const json = (await res.json()) as {
+    usage?: {
+      prompt_tokens?: number;
+      prompt_cache_hit_tokens?: number;
+      prompt_cache_miss_tokens?: number;
+    };
+  };
+  const usage = json.usage ?? {};
+  const hit = usage.prompt_cache_hit_tokens ?? 0;
+  const miss = usage.prompt_cache_miss_tokens ?? Math.max(0, (usage.prompt_tokens ?? 0) - hit);
+  const ratio = hit + miss > 0 ? hit / (hit + miss) : 0;
+  console.log(
+    `${label}: prompt=${usage.prompt_tokens ?? 0} hit=${hit} miss=${miss} hit%=${(ratio * 100).toFixed(2)}`,
+  );
+  return ratio;
+}
+
+async function main(): Promise<void> {
+  const root = mkdtempSync(join(tmpdir(), "reasonix-cache-neutral-"));
+  try {
+    const offSystem = codeSystemPrompt(root, { engineeringLifecycleMode: "off" });
+    const strictSystem = codeSystemPrompt(root, { engineeringLifecycleMode: "strict" });
+    if (offSystem !== strictSystem) {
+      throw new Error("off/strict system prompts differ; runtime-only cache invariant is broken.");
+    }
+
+    const ratios: number[] = [];
+    for (let turn = 0; turn < 5; turn++) {
+      const offRatio = await call(`off-${turn}`, offSystem, turn);
+      const strictRatio = await call(`strict-${turn}`, strictSystem, turn);
+      if (turn > 0) ratios.push(offRatio, strictRatio);
+      await new Promise((resolve) => setTimeout(resolve, 1200));
+    }
+
+    const avg = ratios.reduce((sum, value) => sum + value, 0) / ratios.length;
+    console.log(`warm average hit%=${(avg * 100).toFixed(2)}`);
+    if (avg < 0.99) {
+      throw new Error(`warm cache hit below target: ${(avg * 100).toFixed(2)}% < 99%`);
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/cli/commands/code.tsx
+++ b/src/cli/commands/code.tsx
@@ -21,7 +21,7 @@
 import { readFileSync } from "node:fs";
 import { basename, resolve } from "node:path";
 import { buildCodeToolset } from "../../code/setup.js";
-import { loadApiKey, loadEngineeringLifecycleMode, loadPreset, readConfig } from "../../config.js";
+import { loadApiKey, loadPreset, readConfig } from "../../config.js";
 import { loadDotenv } from "../../env.js";
 import { t } from "../../i18n/index.js";
 import { detectForeignAgentPlatform } from "../../memory/project.js";
@@ -151,7 +151,6 @@ export async function codeCommand(opts: CodeOptions = {}): Promise<void> {
       systemAppend: opts.systemAppend,
       systemAppendFile: systemAppendFileContents,
       modelId: resolvedModel,
-      engineeringLifecycleMode: loadEngineeringLifecycleMode(),
     });
   await chatCommand({
     model: resolvedModel,

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -881,6 +881,7 @@ function AppInner({
   const planStepsRef = useRef<PlanStep[] | null>(null);
   const completedStepIdsRef = useRef<Set<string>>(new Set());
   const stepCompletionsRef = useRef<Map<string, StepCompletion>>(new Map());
+  const pendingStepCompletionsRef = useRef<Map<string, StepCompletion>>(new Map());
   // Markdown body + human-friendly summary captured from submit_plan.
   // Persisted alongside the structured state so a future Time-Travel
   // replay can show the model's full original proposal without re-
@@ -1588,6 +1589,7 @@ function AppInner({
         planStepsRef.current = restoredPlan.steps;
         completedStepIdsRef.current = new Set(restoredPlan.completedStepIds);
         stepCompletionsRef.current = new Map(Object.entries(restoredPlan.stepCompletions ?? {}));
+        pendingStepCompletionsRef.current = new Map();
         planBodyRef.current = restoredPlan.body ?? null;
         planSummaryRef.current = restoredPlan.summary ?? null;
         engineeringLifecycleRef.current?.recordPlanApproved(restoredPlan.steps);
@@ -3300,6 +3302,7 @@ function AppInner({
               planStepsRef,
               completedStepIdsRef,
               stepCompletionsRef,
+              pendingStepCompletionsRef,
               planBodyRef,
               planSummaryRef,
               persistPlanState,
@@ -3666,6 +3669,7 @@ function AppInner({
         if (approvedSteps && approvedSteps.length > 0) {
           completedStepIdsRef.current = new Set();
           stepCompletionsRef.current = new Map();
+          pendingStepCompletionsRef.current = new Map();
           log.showPlan({
             title: planSummaryRef.current ?? "plan",
             steps: approvedSteps.map((s) => ({
@@ -3686,6 +3690,7 @@ function AppInner({
         planStepsRef.current = null;
         completedStepIdsRef.current = new Set();
         stepCompletionsRef.current = new Map();
+        pendingStepCompletionsRef.current = new Map();
         planBodyRef.current = null;
         planSummaryRef.current = null;
         persistPlanState();
@@ -3836,6 +3841,7 @@ function AppInner({
           planSummaryRef.current = p.summary ?? null;
           planBodyRef.current = p.plan;
           stepCompletionsRef.current = new Map();
+          pendingStepCompletionsRef.current = new Map();
           engineeringLifecycleRef.current?.recordPlanProposed(p.steps);
           break;
         }
@@ -3845,7 +3851,11 @@ function AppInner({
             title?: string;
             result: string;
             notes?: string;
+            completion?: StepCompletion;
           };
+          if (p.completion?.kind === "step_completed") {
+            pendingStepCompletionsRef.current.set(p.stepId, p.completion);
+          }
           // completed/total come from planStepsRef — don't have them via gate.
           const total = planStepsRef.current?.length ?? 0;
           const completed = completedCountIncludingStep(

--- a/src/cli/ui/hooks/handle-tool-event.ts
+++ b/src/cli/ui/hooks/handle-tool-event.ts
@@ -28,6 +28,7 @@ export interface ToolEventContext {
   planStepsRef: MutableRefObject<PlanStep[] | null>;
   completedStepIdsRef: MutableRefObject<Set<string>>;
   stepCompletionsRef?: MutableRefObject<Map<string, StepCompletion>>;
+  pendingStepCompletionsRef?: MutableRefObject<Map<string, StepCompletion>>;
   planBodyRef: MutableRefObject<string | null>;
   planSummaryRef: MutableRefObject<string | null>;
   persistPlanState: () => void;
@@ -50,17 +51,25 @@ export function handleToolEvent(ev: LoopEvent, ctx: ToolEventContext): void {
       const parsed = JSON.parse(ev.content) as Partial<StepCompletion>;
       const stepId = parsed.stepId;
       if (parsed.kind === "step_completed" && typeof stepId === "string") {
+        const fullCompletion = ctx.pendingStepCompletionsRef?.current.get(stepId);
+        ctx.pendingStepCompletionsRef?.current.delete(stepId);
+        const completion = fullCompletion ?? (parsed as StepCompletion);
         ctx.completedStepIdsRef.current.add(stepId);
-        ctx.stepCompletionsRef?.current.set(stepId, parsed as StepCompletion);
+        ctx.stepCompletionsRef?.current.set(stepId, completion);
         ctx.persistPlanState();
         ctx.log.completePlanStep(stepId);
         ctx.onPlanStepCompleted?.(stepId);
         const total = ctx.planStepsRef.current?.length ?? 0;
         const completed = ctx.completedStepIdsRef.current.size;
         const stepFromPlan = ctx.planStepsRef.current?.find((s) => s.id === stepId);
-        const title = parsed.title ?? stepFromPlan?.title;
+        const title = completion.title ?? parsed.title ?? stepFromPlan?.title;
         if (title) ctx.log.pushStepProgress(completed, total, title);
-        const evidenceSummary = formatStepEvidenceSummary(parsed.evidence);
+        const compactEvidenceSummary =
+          typeof parsed.evidenceSummary === "string" && parsed.evidenceSummary.trim()
+            ? `evidence: ${parsed.evidenceSummary.trim()}`
+            : null;
+        const evidenceSummary =
+          formatStepEvidenceSummary(completion.evidence) ?? compactEvidenceSummary;
         if (evidenceSummary) ctx.log.pushInfo(evidenceSummary, "ghost");
         if (ctx.session && total > 0 && completed >= total) {
           const archive = archivePlanState(ctx.session);

--- a/src/code/lifecycle.ts
+++ b/src/code/lifecycle.ts
@@ -206,9 +206,10 @@ export class EngineeringLifecycleRuntime {
 
     if (this._state !== "approved" && this._state !== "executing") {
       return JSON.stringify({
-        error: `${name}: blocked by Engineering Lifecycle — high-risk engineering work requires an approved structured plan first. Explore with read-only tools, call ask_choice for real forks, then call submit_plan with concrete steps.`,
+        error: `${name}: blocked by Engineering Lifecycle — submit an approved plan before high-risk mutation.`,
         rejectedReason: "engineering-lifecycle",
         state: this._state,
+        nextAction: "submit_plan",
       });
     }
 
@@ -238,9 +239,10 @@ export class EngineeringLifecycleRuntime {
     if (evidenceRequired && evidence.length === 0) {
       return JSON.stringify({
         error:
-          "mark_step_complete: evidence required by Engineering Lifecycle — include verification, diff, checkpoint, or manual evidence before completing this step.",
+          "mark_step_complete: evidence required — add verification, diff, checkpoint, or manual evidence.",
         rejectedReason: "engineering-lifecycle-evidence",
         stepId,
+        nextAction: "add_evidence",
       });
     }
     return null;

--- a/src/code/prompt.ts
+++ b/src/code/prompt.ts
@@ -131,14 +131,6 @@ You have BOTH \`semantic_search\` (vector index) and \`search_content\` (literal
 
 If \`semantic_search\` returns nothing useful (low scores, off-topic), THEN fall back to \`search_content\`. Don't go the other way — grepping a paraphrased question wastes turns.`;
 
-const ENGINEERING_LIFECYCLE_CONTRACT = `
-
-# Engineering lifecycle contract
-
-Reasonix may enforce a prefix-stable Engineering Lifecycle for explicitly enabled high-risk engineering work. The runtime keeps lifecycle state outside the system prompt and tool list, so do not expect stage-specific prompt changes or new tools to appear. Treat any lifecycle block as a host constraint, not as a suggestion.
-
-When high-risk mutations are bounced with \`rejectedReason: "engineering-lifecycle"\`, switch to read-only exploration, then call \`submit_plan\` with concrete steps before trying the mutation again. Add optional per-step \`targets\`, \`acceptance\`, and \`verification\` fields when they clarify scope or success criteria. For medium/high-risk steps, steps with verification criteria, or steps that changed code, \`mark_step_complete\` requires \`evidence\` entries such as verification output, diff summary, checkpoint id, or manual rationale.`;
-
 export interface CodeSystemPromptOptions {
   /** True when semantic_search is registered for this run. Adds an
    *  explicit routing fragment so the model picks it for intent-style
@@ -152,15 +144,12 @@ export interface CodeSystemPromptOptions {
   systemAppendFile?: string;
   /** Model the loop will run on — interpolated into the escalation contract so the model can name itself correctly when asked (#582). */
   modelId?: string;
-  /** Include the lifecycle contract only for users who explicitly opt in. */
+  /** Back-compat no-op: lifecycle is runtime-only so strict/off do not change the cache prefix. */
   engineeringLifecycleMode?: "off" | "strict";
 }
 
 export function codeSystemPrompt(rootDir: string, opts: CodeSystemPromptOptions = {}): string {
-  let codeBase = codeSystemBase(opts.modelId ?? DEFAULT_CODE_MODEL);
-  if (opts.engineeringLifecycleMode === "strict") {
-    codeBase = `${codeBase}${ENGINEERING_LIFECYCLE_CONTRACT}`;
-  }
+  const codeBase = codeSystemBase(opts.modelId ?? DEFAULT_CODE_MODEL);
   const base = opts.hasSemanticSearch ? `${codeBase}${SEMANTIC_SEARCH_ROUTING}` : codeBase;
   const withMemory = applyMemoryStack(base, rootDir);
   const gitignorePath = join(rootDir, ".gitignore");

--- a/src/core/pause-gate.ts
+++ b/src/core/pause-gate.ts
@@ -59,7 +59,13 @@ interface PausePayloadMap {
     allowPrefix: string;
   };
   plan_proposed: { plan: string; steps?: unknown[]; summary?: string };
-  plan_checkpoint: { stepId: string; title?: string; result: string; notes?: string };
+  plan_checkpoint: {
+    stepId: string;
+    title?: string;
+    result: string;
+    notes?: string;
+    completion?: unknown;
+  };
   plan_revision: { reason: string; remainingSteps: unknown[]; summary?: string };
   choice: { question: string; options: unknown[]; allowCustom: boolean };
 }

--- a/src/tools/plan-core.ts
+++ b/src/tools/plan-core.ts
@@ -113,6 +113,23 @@ function sanitizeEvidence(raw: unknown): StepEvidence[] | undefined {
   return out.length > 0 ? out : undefined;
 }
 
+function summarizeEvidence(evidence: StepEvidence[] | undefined): string | undefined {
+  if (!evidence || evidence.length === 0) return undefined;
+  const parts = evidence.map((item) => `${item.kind}: ${item.summary}`);
+  return parts.join("; ");
+}
+
+function compactStepCompletion(update: StepCompletion): StepCompletion {
+  const compact: StepCompletion = {
+    kind: "step_completed",
+    stepId: update.stepId,
+    result: update.result,
+  };
+  const evidenceSummary = summarizeEvidence(update.evidence);
+  if (evidenceSummary) compact.evidenceSummary = evidenceSummary;
+  return compact;
+}
+
 // Individual tool registrations — one per screen
 
 function registerSubmitPlan(registry: ToolRegistry, opts: PlanToolOptions): void {
@@ -243,9 +260,9 @@ function registerMarkStepComplete(registry: ToolRegistry, opts: PlanToolOptions)
       // Block until the user continues, revises, or stops
       const verdict = await (ctx?.confirmationGate ?? pauseGate).ask({
         kind: "plan_checkpoint",
-        payload: { stepId, title, result, notes },
+        payload: { stepId, title, result, notes, completion: update },
       });
-      if (verdict.type === "continue") return JSON.stringify(update);
+      if (verdict.type === "continue") return JSON.stringify(compactStepCompletion(update));
       if (verdict.type === "revise") {
         if (verdict.feedback) return `revision requested: ${verdict.feedback}`;
         throw new Error("user requested revision at checkpoint");

--- a/src/tools/plan-types.ts
+++ b/src/tools/plan-types.ts
@@ -25,5 +25,6 @@ export interface StepCompletion {
   title?: string;
   result: string;
   notes?: string;
+  evidenceSummary?: string;
   evidence?: StepEvidence[];
 }

--- a/tests/code-prompt.test.ts
+++ b/tests/code-prompt.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { CODE_SYSTEM_PROMPT, codeSystemPrompt } from "../src/code/prompt.js";
+import { ImmutablePrefix } from "../src/memory/runtime.js";
 
 describe("codeSystemPrompt", () => {
   let root: string;
@@ -155,14 +156,27 @@ describe("codeSystemPrompt", () => {
   });
 
   describe("system append", () => {
-    it("omits lifecycle contract by default and includes it only for strict mode", () => {
-      expect(codeSystemPrompt(root)).not.toMatch(/# Engineering lifecycle contract/);
-      expect(codeSystemPrompt(root, { engineeringLifecycleMode: "off" })).not.toMatch(
-        /# Engineering lifecycle contract/,
-      );
-      expect(codeSystemPrompt(root, { engineeringLifecycleMode: "strict" })).toMatch(
-        /# Engineering lifecycle contract/,
-      );
+    it("keeps engineering lifecycle mode cache-neutral", () => {
+      const bare = codeSystemPrompt(root);
+      const off = codeSystemPrompt(root, { engineeringLifecycleMode: "off" });
+      const strict = codeSystemPrompt(root, { engineeringLifecycleMode: "strict" });
+
+      expect(bare).toBe(off);
+      expect(strict).toBe(off);
+      expect(strict).not.toMatch(/# Engineering lifecycle contract/);
+    });
+
+    it("keeps immutable prefix fingerprints identical across lifecycle modes", () => {
+      const off = new ImmutablePrefix({
+        system: codeSystemPrompt(root, { engineeringLifecycleMode: "off" }),
+        toolSpecs: [],
+      });
+      const strict = new ImmutablePrefix({
+        system: codeSystemPrompt(root, { engineeringLifecycleMode: "strict" }),
+        toolSpecs: [],
+      });
+
+      expect(strict.fingerprint).toBe(off.fingerprint);
     });
 
     it("does not add a User System Append section when neither option is provided", () => {

--- a/tests/handle-tool-event.test.ts
+++ b/tests/handle-tool-event.test.ts
@@ -111,4 +111,68 @@ describe("handleToolEvent", () => {
       ],
     });
   });
+
+  it("stores full host-side evidence when the model payload is compact", () => {
+    const { log, calls } = makeLog();
+    const completions = new Map();
+    const pendingCompletions = new Map([
+      [
+        "step-1",
+        {
+          kind: "step_completed" as const,
+          stepId: "step-1",
+          result: "Updated lifecycle tests.",
+          evidence: [
+            {
+              kind: "verification" as const,
+              summary: "lifecycle tests passed",
+              command: "npm test -- tests/lifecycle.test.ts",
+            },
+          ],
+        },
+      ],
+    ]);
+
+    handleToolEvent(
+      makeEvent({
+        kind: "step_completed",
+        stepId: "step-1",
+        result: "Updated lifecycle tests.",
+        evidenceSummary: "verification: lifecycle tests passed",
+      }),
+      {
+        flush: () => undefined,
+        translator: { toolEnd: () => undefined } as unknown as TurnTranslator,
+        setOngoingTool: () => undefined,
+        setToolProgress: () => undefined,
+        toolStartedAtRef: { current: null },
+        setPendingShell: () => undefined,
+        setPendingPlan: () => undefined,
+        setPendingRevision: () => undefined,
+        setPendingChoice: () => undefined,
+        planStepsRef: { current: [{ id: "step-1", title: "Lifecycle", action: "Update tests" }] },
+        completedStepIdsRef: { current: new Set<string>() },
+        stepCompletionsRef: { current: completions },
+        pendingStepCompletionsRef: { current: pendingCompletions },
+        planBodyRef: { current: null },
+        planSummaryRef: { current: null },
+        persistPlanState: () => undefined,
+        log,
+        session: null,
+        codeModeOn: true,
+      },
+    );
+
+    expect(completions.get("step-1")?.evidence?.[0]).toMatchObject({
+      command: "npm test -- tests/lifecycle.test.ts",
+    });
+    expect(pendingCompletions.has("step-1")).toBe(false);
+    expect(calls).toContainEqual({
+      method: "pushInfo",
+      args: [
+        "evidence: verification - lifecycle tests passed (npm test -- tests/lifecycle.test.ts)",
+        "ghost",
+      ],
+    });
+  });
 });

--- a/tests/lifecycle.test.ts
+++ b/tests/lifecycle.test.ts
@@ -58,7 +58,10 @@ describe("EngineeringLifecycleRuntime", () => {
     });
 
     expect(out).not.toBeNull();
-    expect(JSON.parse(out!).rejectedReason).toBe("engineering-lifecycle");
+    const parsed = JSON.parse(out!);
+    expect(parsed.rejectedReason).toBe("engineering-lifecycle");
+    expect(parsed.nextAction).toBe("submit_plan");
+    expect(parsed.error.length).toBeLessThan(180);
     expect(lifecycle.snapshot().state).toBe("armed");
   });
 
@@ -100,7 +103,10 @@ describe("EngineeringLifecycleRuntime", () => {
       result: "Refactored the gate path.",
     });
     expect(rejected).not.toBeNull();
-    expect(JSON.parse(rejected!).error).toMatch(/evidence/);
+    const parsed = JSON.parse(rejected!);
+    expect(parsed.error).toMatch(/evidence/);
+    expect(parsed.nextAction).toBe("add_evidence");
+    expect(parsed.error.length).toBeLessThan(180);
 
     expect(
       lifecycle.guardToolCall("mark_step_complete", {

--- a/tests/plan.test.ts
+++ b/tests/plan.test.ts
@@ -6,6 +6,7 @@ import { ToolRegistry } from "../src/tools.js";
 import {
   PlanProposedError,
   PlanRevisionProposedError,
+  type StepCompletion,
   registerPlanTool,
 } from "../src/tools/plan.js";
 
@@ -449,9 +450,9 @@ describe("registerPlanTool + mark_step_complete", () => {
     expect(reg.get("mark_step_complete")?.readOnly).toBe(true);
   });
 
-  it("blocks on PauseGate on step complete and returns step_completed payload on continue", async () => {
+  it("blocks on PauseGate on step complete and returns compact payload on continue", async () => {
     const reg = new ToolRegistry();
-    const seen: unknown[] = [];
+    const seen: StepCompletion[] = [];
     registerPlanTool(reg, { onStepCompleted: (u) => seen.push(u) });
     const gate = new AutoGate({ type: "continue" });
     const out = await reg.dispatch(
@@ -467,13 +468,15 @@ describe("registerPlanTool + mark_step_complete", () => {
     const parsed = JSON.parse(out);
     expect(parsed.kind).toBe("step_completed");
     expect(parsed.stepId).toBe("step-1");
-    expect(parsed.title).toBe("Refactor auth");
     expect(parsed.result).toBe("Moved tokens into src/auth/tokens.ts.");
-    expect(parsed.notes).toBe("Had to rename one export.");
+    expect(parsed.title).toBeUndefined();
+    expect(parsed.notes).toBeUndefined();
     // No error wrapper — gate returns the structured payload directly
     expect(parsed.error).toBeUndefined();
     expect(seen).toHaveLength(1);
-    expect((seen[0] as { stepId: string }).stepId).toBe("step-1");
+    expect(seen[0]?.stepId).toBe("step-1");
+    expect(seen[0]?.title).toBe("Refactor auth");
+    expect(seen[0]?.notes).toBe("Had to rename one export.");
   });
 
   it("omits optional fields when empty", async () => {
@@ -492,12 +495,12 @@ describe("registerPlanTool + mark_step_complete", () => {
     expect(parsed.error).toBeUndefined();
   });
 
-  it("preserves structured evidence when supplied", async () => {
+  it("keeps full evidence host-side but returns a compact model payload", async () => {
     const reg = new ToolRegistry();
     const seen: StepCompletion[] = [];
     registerPlanTool(reg, { onStepCompleted: (u) => seen.push(u) });
     const gate = new AutoGate({ type: "continue" });
-    await reg.dispatch(
+    const out = await reg.dispatch(
       "mark_step_complete",
       JSON.stringify({
         stepId: "step-1",
@@ -513,6 +516,7 @@ describe("registerPlanTool + mark_step_complete", () => {
       }),
       { confirmationGate: gate },
     );
+    const parsed = JSON.parse(out);
 
     expect(seen[0]?.evidence).toEqual([
       {
@@ -522,6 +526,15 @@ describe("registerPlanTool + mark_step_complete", () => {
         paths: ["tests/lifecycle.test.ts"],
       },
     ]);
+    expect(parsed).toMatchObject({
+      kind: "step_completed",
+      stepId: "step-1",
+      result: "updated lifecycle guard",
+      evidenceSummary: "verification: targeted tests passed",
+    });
+    expect(parsed.evidence).toBeUndefined();
+    expect(out).not.toContain("npm test tests/lifecycle.test.ts");
+    expect(out).not.toContain("tests/lifecycle.test.ts");
   });
 
   it("rejects completion without evidence when the host requires it", async () => {


### PR DESCRIPTION
## Summary
- make `engineeringLifecycleMode` prompt handling a back-compat no-op so strict/off produce identical system prompts and prefix fingerprints
- keep lifecycle guidance runtime-only through compact structured gate results with `nextAction` hints
- return compact `mark_step_complete` payloads to the model while preserving full evidence host-side for UI/plan-store
- add a manual live cache probe for off vs strict runtime-only warm hit validation

## Validation
- `npm test -- tests/code-prompt.test.ts`
- `npm test -- tests/lifecycle.test.ts`
- `npm test -- tests/plan.test.ts`
- `npm test -- tests/handle-tool-event.test.ts`
- `npm test -- tests/code-prompt.test.ts tests/lifecycle.test.ts tests/plan.test.ts tests/handle-tool-event.test.ts tests/plan-store.test.ts tests/slash.test.ts tests/tools.test.ts`
- `npm run typecheck`
- `npm run lint` (passes with existing warning in `tests/welcome-banner-hints.test.tsx`)
- `npm run build`
- push hook `npm run verify`

Part of the engineering reliability/cache-neutral lifecycle follow-up from #1285.