### PR TITLE
fix(test): switch vitest to forks pool to stop heap OOM on many-core hosts

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,14 @@ export default defineConfig({
     setupFiles: ["tests/setup-lang.ts"],
     environment: "node",
     globals: false,
+    // Forks pool — per-file process isolation, so tokenizer BPE / tree-sitter
+    // wasms / sqlite native handles can't accumulate in a single shared heap.
+    // Threads default OOMs on 16-core boxes where 15 workers × ~300MB blows
+    // past Node's 4GB heap cap.
+    pool: "forks",
+    poolOptions: {
+      forks: { maxForks: 8, minForks: 1 },
+    },
     // One retry absorbs Windows scheduler hiccups in jobs.test.ts / loop.test.ts /
     // bundle-smoke (real spawns + tokenizer cold load). A real failure still re-fails.
     retry: 1,


### PR DESCRIPTION
`npm run verify` was OOMing on 16-core Windows boxes mid-run with V8 `Zone Allocation failed`, causing cascading flake (`spawn UNKNOWN`, dashboard 21s timeouts, `jobs.tailLines` mismatches).

Root cause: vitest defaults to `pool: "threads"`, so all worker threads share one Node process's ~4GB heap. With 16 cores, ~15 workers × ~300MB each — each loading the tokenizer BPE + tree-sitter wasms + sqlite handles — blows past the heap cap. `retry: 1` doubles transient state on flakes, making it worse.

Switch to `pool: "forks"` with `maxForks: 8` so each test file runs in its own process with its own heap; process exit frees everything. Costs ~20% wall-clock (62s → 74s on this box) for full isolation.

3412 tests / 244 files pass, no OOM, no `spawn UNKNOWN`, no zone-allocation failures.
