### PR TITLE
chore(desktop): document writeAllSync + drop redundant optional chain

### DIFF
--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -445,6 +445,7 @@ const STDOUT_BACKPRESSURE_WAIT = new Int32Array(new SharedArrayBuffer(4));
 
 type SyncWriter = (fd: number, buffer: Buffer, offset: number, length: number) => number;
 
+/** Drain `buffer` to `fd` across partial writes; retry EAGAIN after a 5 ms park. Exported for tests. */
 export function writeAllSync(
   fd: number,
   buffer: Buffer,
@@ -461,7 +462,7 @@ export function writeAllSync(
     try {
       written = write(fd, buffer, offset, buffer.length - offset);
     } catch (err) {
-      if ((err as NodeJS.ErrnoException)?.code === "EAGAIN") {
+      if ((err as NodeJS.ErrnoException).code === "EAGAIN") {
         wait();
         continue;
       }


### PR DESCRIPTION
Follow-up polish on #1405:

- Add a 1-line JSDoc to `writeAllSync` so the contract (drains across partial writes, parks 5 ms on `EAGAIN`) is visible at the call site without reading the body.
- Drop the redundant `?.` on `(err as NodeJS.ErrnoException).code` — `err` is already bound by `catch`, so the optional chain narrows nothing.

No behavior change; existing test still passes.
