### PR TITLE
fix: reject ambiguous search-replace edit blocks

### DIFF
--- a/src/code/edit-blocks.ts
+++ b/src/code/edit-blocks.ts
@@ -146,10 +146,16 @@ export function applyEditBlock(block: EditBlock, rootDir: string): ApplyResult {
           message: "SEARCH text does not match the current file content exactly",
         };
       }
-      // Replace only the first occurrence — if the model needs multiple
-      // identical edits it should emit multiple blocks (each anchored by
-      // more surrounding context). Auto-expanding to replace-all is a
-      // footgun when the same string legitimately appears in several
+      const nextIdx = content.indexOf(adaptedSearch, idx + 1);
+      if (nextIdx !== -1) {
+        return {
+          path: block.path,
+          status: "not-found",
+          message: "SEARCH text appears multiple times; include more context to disambiguate",
+        };
+      }
+      // Apply one unambiguous occurrence. Auto-expanding to replace-all is
+      // a footgun when the same string legitimately appears in several
       // unrelated places.
       const replaced = `${content.slice(0, idx)}${adaptedReplace}${content.slice(idx + adaptedSearch.length)}`;
       // Truncate first so a shorter result doesn't leave stale tail

--- a/tests/edit-blocks.test.ts
+++ b/tests/edit-blocks.test.ts
@@ -155,15 +155,15 @@ describe("applyEditBlock", () => {
     expect(existsSync(join(root, "..", "escape.txt"))).toBe(false);
   });
 
-  it("replaces only the first occurrence when SEARCH appears twice", () => {
+  it("refuses ambiguous SEARCH text that appears twice", () => {
     writeFileSync(join(root, "a.txt"), "foo bar foo\n", "utf8");
     const result = applyEditBlock(
       { path: "a.txt", search: "foo", replace: "FOO", offset: 0 },
       root,
     );
-    expect(result.status).toBe("applied");
-    // First "foo" replaced, second left alone.
-    expect(readFileSync(join(root, "a.txt"), "utf8")).toBe("FOO bar foo\n");
+    expect(result.status).toBe("not-found");
+    expect(result.message).toMatch(/multiple times/);
+    expect(readFileSync(join(root, "a.txt"), "utf8")).toBe("foo bar foo\n");
   });
 
   it("matches LF search against CRLF file content", () => {


### PR DESCRIPTION
Refuse text edit blocks when the SEARCH content matches more than once in the target file. This keeps the `/apply` path aligned with `edit_file` behavior and prevents silently modifying the first matching occurrence when the model did not provide enough context.

Update the edit block test to assert that ambiguous SEARCH text leaves the file unchanged.

<!-- Read CONTRIBUTING.md first if this is your first PR. -->

## What

<!-- One paragraph: what does this change? -->

## Why

<!-- Bug fix? Pre-existing issue? Linked discussion? -->

## How to verify

<!-- Steps the reviewer can run. `npm run verify` is assumed. -->

## Checklist

- [ ] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [ ] No `Co-Authored-By: Claude` trailer in commits
- [ ] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [ ] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time
