### PR TITLE
fix(loop): reset _turnAbort in finally so consumer break can't lock the session

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -658,49 +658,30 @@ export class CacheFirstLoop {
 
     for (let iter = 0; ; iter++) {
       if (signal.aborted) {
-        // Esc means "stop now" — not "stop and force another 30-90s
-        // reasoner call to produce a summary I didn't ask for". The
-        // user's mental model of cancel is immediate. We emit a
-        // synthetic assistant_final (tagged forcedSummary so the
-        // code-mode applier ignores it) with a short stopped
-        // message, then done. The prior tool outputs are still in
-        // the log if the user wants to continue — asking again
-        // will hit a warm cache and be cheap.
-        //
-        // Context-guard still calls forceSummary because there the USER
-        // didn't choose to stop — we did — and leaving them staring at
-        // nothing is worse than one extra call.
-        yield {
-          turn: this._turn,
-          role: "warning",
-          content: t("loop.abortedAtIter", { iter }),
-        };
-        const stoppedMsg =
-          "[aborted by user (Esc) — no summary produced. Ask again or /retry when ready; prior tool output is still in the log.]";
-        // Synthetic assistant turn — no real model output exists. For
-        // reasoner sessions R1 still demands `reasoning_content` on
-        // every assistant message, so we attach an empty-string
-        // placeholder to satisfy the validator without inventing
-        // reasoning we don't have. V3 gets a plain message as before.
-        this.appendAndPersist(buildSyntheticAssistantMessage(stoppedMsg, this.model));
-        yield {
-          turn: this._turn,
-          role: "assistant_final",
-          content: stoppedMsg,
-          forcedSummary: true,
-        };
-        yield { turn: this._turn, role: "done", content: stoppedMsg };
-        // Reset to a fresh, non-aborted controller before returning.
-        // Without this the carry-abort logic above sees the still-
-        // aborted controller on the NEXT step() entry and immediately
-        // re-aborts at iter 0, locking the session: every subsequent
-        // user message produces "stopped without producing a summary"
-        // before any work happens. A user-initiated Esc is a discrete
-        // event tied to ONE turn; it must not bleed into the next.
-        // (The race scenario the carry-abort handles — abort fired in
-        // the async window before step() entry — still works: a fresh
-        // abort() between turns aborts the new controller below.)
-        this._turnAbort = new AbortController();
+        // Reset in finally — the consumer (desktop runTurn) breaks the
+        // for-await on its own aborter between our yields, which calls
+        // generator.return() and skips post-yield straight-line code.
+        // Without finally the reset is lost and carryAbort locks every
+        // future step() at iter 0.
+        try {
+          yield {
+            turn: this._turn,
+            role: "warning",
+            content: t("loop.abortedAtIter", { iter }),
+          };
+          const stoppedMsg =
+            "[aborted by user (Esc) — no summary produced. Ask again or /retry when ready; prior tool output is still in the log.]";
+          this.appendAndPersist(buildSyntheticAssistantMessage(stoppedMsg, this.model));
+          yield {
+            turn: this._turn,
+            role: "assistant_final",
+            content: stoppedMsg,
+            forcedSummary: true,
+          };
+          yield { turn: this._turn, role: "done", content: stoppedMsg };
+        } finally {
+          this._turnAbort = new AbortController();
+        }
         return;
       }
       // Bridge the silence between the PREVIOUS iter's tool result and
@@ -949,14 +930,15 @@ export class CacheFirstLoop {
         // synthetic OR user re-prompt) starts immediately and gets to
         // produce its own answer.
         if (signal.aborted) {
-          yield { turn: this._turn, role: "done", content: "" };
-          // Reset the controller so the carry-abort check at the top of
-          // the NEXT step() doesn't inherit this turn's aborted state.
-          // Without this, a queued-submit triggered by App.tsx (e.g.
-          // ShellConfirm "run once" → loop.abort() + setQueuedSubmit)
-          // produces a spurious "aborted at iter 0/64" the moment the
-          // synthetic message starts processing, locking the session.
-          this._turnAbort = new AbortController();
+          // Reset in finally — same rationale as the iter-start handler:
+          // if the consumer breaks the for-await before draining `done`,
+          // generator.return() would skip a bare post-yield reset and
+          // leave carryAbort locked on the next step().
+          try {
+            yield { turn: this._turn, role: "done", content: "" };
+          } finally {
+            this._turnAbort = new AbortController();
+          }
           return;
         }
         const probe = is5xxError(err) ? await probeDeepSeekReachable(this.client) : undefined;

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -343,6 +343,64 @@ describe("CacheFirstLoop (non-streaming)", () => {
     ).toBe(false);
   });
 
+  it("does not bleed when consumer breaks for-await mid-abort-yield", async () => {
+    // Desktop runTurn checks its own outer aborter after each yielded
+    // event and `break`s out. That calls generator.return() on step(),
+    // which throws into the suspended yield and skips any straight-line
+    // code after it. If `_turnAbort = new AbortController()` sits after
+    // a yield (rather than in finally), the reset is lost and every
+    // subsequent step() locks at iter 0 via carryAbort.
+    const reg = new ToolRegistry();
+    reg.register({
+      name: "probe",
+      description: "no-op",
+      parameters: { type: "object", properties: {} },
+      fn: async () => "ok",
+    });
+    const chainingToolCall = {
+      content: "",
+      tool_calls: [{ id: "c", type: "function", function: { name: "probe", arguments: "{}" } }],
+    };
+    const finalAnswer = { content: "second turn ran cleanly", tool_calls: [] };
+    const client = new DeepSeekClient({
+      apiKey: "sk-test",
+      fetch: fakeFetch([chainingToolCall, finalAnswer]) as unknown as typeof fetch,
+    });
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s", toolSpecs: reg.specs() }),
+      tools: reg,
+      stream: false,
+      maxToolIters: 16,
+    });
+
+    let aborted = false;
+    for await (const ev of loop.step("first")) {
+      if (!aborted && ev.role === "tool") {
+        aborted = true;
+        loop.abort();
+        continue;
+      }
+      if (aborted && ev.role === "warning") {
+        // Mirror desktop runTurn: drop out of for-await right after the
+        // abort warning, before assistant_final / done are drained.
+        break;
+      }
+    }
+
+    const turn2Events: { role: string; content?: string }[] = [];
+    for await (const ev of loop.step("second")) {
+      turn2Events.push({ role: ev.role, content: ev.content });
+    }
+
+    const finals = turn2Events.filter((e) => e.role === "assistant_final");
+    expect(finals).toHaveLength(1);
+    expect(finals[0]!.content).toBe("second turn ran cleanly");
+    expect(
+      turn2Events.some((e) => e.role === "warning" && /aborted at iter/.test(e.content ?? "")),
+    ).toBe(false);
+  });
+
   it("first all-suppressed storm self-corrects in-turn instead of stopping", async () => {
     const reg = new ToolRegistry();
     reg.register({


### PR DESCRIPTION
Related: #1379 (second half — "在它自己运行时进行打断，再次输入会出现以下错误提示" + screenshot of the iter-0 abort warning). Doesn't fully close #1379 because the issue also reports a separate `/plan` dialog-input concern that's out of scope here.

## Summary

On the desktop, after stopping mid-turn and typing a new message, users sometimes see "在第 0 次工具调用处中断 — 未生成总结即停止" before any work could possibly have happened on the new turn.

## Cause

`runTurn` in `src/cli/commands/desktop.ts` consumes events from `loop.step()` and checks its own outer aborter (`tab.aborter`) after each event, breaking out of the for-await loop on stop. `abortTurn(tab)` aborts both `tab.aborter` and `loop._turnAbort` in the same tick.

Both abort branches in `loop.step()` (iter-start at line 660, in-flight catch at line 932) had this shape:

```ts
yield warning;          // first of several events
yield assistant_final;
yield done;
this._turnAbort = new AbortController();  // critical reset
return;
```

As soon as the consumer receives the first yielded event, its break check trips and `for await ... break` calls `generator.return()` on `step()`. That throws into the suspended yield point and skips all straight-line code that follows — including the reset.

Next call to `step()` hits the carry-abort check at line 637: `carryAbort = this._turnAbort.signal.aborted` reads the stale aborted state, propagates it into the fresh controller, and iter 0 immediately falls into the abort branch and re-emits the same warning — without making any API call. This matches #1379's report that a second send is needed after the spurious warning before the session unsticks.

The probabilistic aspect: only reproduces when abort fires while `step()` is inside one of these two branches and the consumer's break wins the race against the post-yield reset.

## Fix

Move `this._turnAbort = new AbortController()` into `try { yields... } finally { reset }` in both branches. `generator.return()` still runs `finally` blocks, so the reset is guaranteed regardless of whether the consumer drains the events or breaks early.

## Test plan

- [x] New regression in `tests/loop.test.ts`: `does not bleed when consumer breaks for-await mid-abort-yield` — mirrors desktop's `runTurn` pattern by breaking out of `for-await` immediately after the abort `warning` event
- [x] Verified the new test fails without the fix (turn 2 yields `"[aborted by user (Esc)...]"` instead of `"second turn ran cleanly"`), confirming it actually catches the bug
- [x] Existing `does not bleed the prior turn's abort into the next step` test still passes — it only covers the "consumer drains all events" path and couldn't catch this bug, so the new case lives alongside it rather than replacing it
- [x] Full `tests/loop.test.ts` suite (72 tests) passes
- [x] `tests/comment-policy.test.ts` passes
- [x] `npm run lint` clean (no new warnings from this change)
- [x] `tsc --noEmit` clean