### PR TITLE
feat(subagent): live byte progress + top-level explore/research/review tools

### DIFF
--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -445,6 +445,7 @@ const STDOUT_BACKPRESSURE_WAIT = new Int32Array(new SharedArrayBuffer(4));
 
 type SyncWriter = (fd: number, buffer: Buffer, offset: number, length: number) => number;
 
+/** Drain `buffer` to `fd` across partial writes; retry EAGAIN after a 5 ms park. Exported for tests. */
 export function writeAllSync(
   fd: number,
   buffer: Buffer,
@@ -461,7 +462,7 @@ export function writeAllSync(
     try {
       written = write(fd, buffer, offset, buffer.length - offset);
     } catch (err) {
-      if ((err as NodeJS.ErrnoException)?.code === "EAGAIN") {
+      if ((err as NodeJS.ErrnoException).code === "EAGAIN") {
         wait();
         continue;
       }

--- a/src/cli/ui/LiveActivityArea.tsx
+++ b/src/cli/ui/LiveActivityArea.tsx
@@ -51,7 +51,11 @@ export const LiveActivityArea: React.FC<LiveActivityAreaProps> = React.memo(
     return (
       <Box flexDirection="column" flexShrink={0} flexWrap="nowrap">
         {noTakeoverOverlay && ongoingTool ? (
-          <OngoingToolRow tool={ongoingTool} progress={toolProgress} />
+          <OngoingToolRow
+            tool={ongoingTool}
+            progress={toolProgress}
+            subagentActivities={subagentActivities}
+          />
         ) : null}
         {noTakeoverOverlay && subagentActivities.length > 0 ? (
           <SubagentLiveStack activities={subagentActivities} max={3} />

--- a/src/cli/ui/layout/LiveRows.tsx
+++ b/src/cli/ui/layout/LiveRows.tsx
@@ -173,6 +173,7 @@ export function SubagentRow({ activity }: { activity: SubagentActivity }) {
   const last = activity.lastInner;
   const subtitle = activity.skillName ?? truncate(activity.task, 48);
   const modelBadge = activity.model ? modelBadgeFor(activity.model) : null;
+  const streamLine = formatStreamLine(activity);
   return (
     <Card tone={CARD.subagent.color}>
       <CardHeader
@@ -206,12 +207,46 @@ export function SubagentRow({ activity }: { activity: SubagentActivity }) {
           <Text color={FG.faint}>{t("editMode.queuedDots")}</Text>
         )}
       </Text>
+      {streamLine ? (
+        <Text color={FG.faint}>
+          {"flow  "}
+          <Text color={FG.sub}>{streamLine}</Text>
+        </Text>
+      ) : null}
       <Text color={TONE.brand}>
         {"▶  "}
         {phase}
       </Text>
     </Card>
   );
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+/** Same shape as formatStreamLine but designed for inline use inside OngoingToolRow — returns null when nothing has flowed yet. */
+function formatSubagentBytes(a: SubagentActivity): string | null {
+  if (a.outputChars + a.reasoningChars + a.toolReadChars === 0) return null;
+  const parts: string[] = [];
+  if (a.toolReadChars > 0) parts.push(`↓ ${formatBytes(a.toolReadChars)} read`);
+  if (a.outputChars > 0) parts.push(`↑ ${formatBytes(a.outputChars)} out`);
+  if (a.reasoningChars > 0) parts.push(`◆ ${formatBytes(a.reasoningChars)} think`);
+  return parts.join(" · ");
+}
+
+/** null → no flow yet (avoid printing a 0 B line that looks like noise). */
+function formatStreamLine(a: SubagentActivity): string | null {
+  if (a.outputChars + a.reasoningChars + a.toolReadChars === 0) return null;
+  const parts: string[] = [];
+  // Read first — that's usually the dominant traffic for explore/research
+  // and the most reassuring "files are being pulled in" signal.
+  if (a.toolReadChars > 0) parts.push(`↓ read ${formatBytes(a.toolReadChars)}`);
+  if (a.outputChars > 0) parts.push(`↑ out ${formatBytes(a.outputChars)}`);
+  if (a.reasoningChars > 0) parts.push(`◆ think ${formatBytes(a.reasoningChars)}`);
+  return parts.join(" · ");
 }
 
 /** 1 → rich; 2-max → compact rows; >max → compact + "+N more" fold. */
@@ -288,17 +323,36 @@ function truncate(text: string, max: number): string {
   return text.length > max ? `${text.slice(0, max)}…` : text;
 }
 
-/** Live spinner + arg summary while a tool call is in flight; absorbs MCP progress frames. */
+const SUBAGENT_WRAPPER_TOOLS = new Set<string>([
+  "explore",
+  "research",
+  "review",
+  "security_review",
+  "run_skill",
+]);
+
+/** Live spinner + arg summary while a tool call is in flight; absorbs MCP progress frames. Also surfaces subagent byte counters for subagent-shaped tools, so the row stays informative even if `SubagentLiveStack` is off-screen. */
 export function OngoingToolRow({
   tool,
   progress,
+  subagentActivities = [],
 }: {
   tool: { name: string; args?: string };
   progress: { progress: number; total?: number; message?: string } | null;
+  subagentActivities?: ReadonlyArray<SubagentActivity>;
 }) {
   const tick = useTick();
   const elapsed = useElapsedSeconds();
   const summary = summarizeToolArgs(tool.name, tool.args);
+  const argsBytes = tool.args ? tool.args.length : 0;
+  // For subagent-shaped wrappers, surface the live byte counters inline
+  // so the user sees data flowing even if the rich SubagentRow isn't
+  // visible (off-screen, race-condition, whatever). At most one subagent
+  // is in flight per ongoingTool today — pick the freshest.
+  const subagentBytes = SUBAGENT_WRAPPER_TOOLS.has(tool.name)
+    ? subagentActivities[subagentActivities.length - 1]
+    : undefined;
+  const subagentBytesLine = subagentBytes ? formatSubagentBytes(subagentBytes) : null;
   return (
     <Box marginY={1} flexDirection="column" paddingX={1}>
       <Box>
@@ -309,8 +363,16 @@ export function OngoingToolRow({
         <Text color={CARD.tool.color} bold>
           {`▣ ${tool.name}`}
         </Text>
-        <Text color={FG.faint}>{`  running · ${elapsed}s`}</Text>
+        <Text color={FG.faint}>
+          {`  running · ${elapsed}s`}
+          {argsBytes > 0 ? ` · args ${formatBytes(argsBytes)}` : ""}
+        </Text>
       </Box>
+      {subagentBytesLine ? (
+        <Box paddingLeft={3}>
+          <Text color={FG.faint}>{subagentBytesLine}</Text>
+        </Box>
+      ) : null}
       {progress ? (
         <Box paddingLeft={3}>
           <Text color={TONE.brand}>{renderProgressLine(progress)}</Text>

--- a/src/cli/ui/useSubagent.ts
+++ b/src/cli/ui/useSubagent.ts
@@ -2,7 +2,11 @@ import { useEffect, useRef, useState } from "react";
 import { t } from "../../i18n/index.js";
 import type { LoopEvent } from "../../loop.js";
 import { appendUsage } from "../../telemetry/usage.js";
-import type { SubagentEvent, SubagentSink } from "../../tools/subagent.js";
+import {
+  SHARED_SUBAGENT_SINK,
+  type SubagentEvent,
+  type SubagentSink,
+} from "../../tools/subagent.js";
 import type { Scrollback } from "./hooks/useScrollback.js";
 import { CARD, TONE, formatCost } from "./theme/tokens.js";
 
@@ -30,6 +34,23 @@ export function reduceSubagentInnerEvent(
       const phase = ev.phase ?? a.phase;
       if (phase === a.phase) return a;
       return { ...a, phase };
+    });
+  }
+  if (ev.kind === "stream-progress") {
+    return mapMatchingRun(prev, ev.runId, (a) => {
+      const outputChars = ev.outputChars ?? a.outputChars;
+      const reasoningChars = ev.reasoningChars ?? a.reasoningChars;
+      const toolReadChars = ev.toolReadChars ?? a.toolReadChars;
+      const elapsedMs = ev.elapsedMs ?? a.elapsedMs;
+      if (
+        outputChars === a.outputChars &&
+        reasoningChars === a.reasoningChars &&
+        toolReadChars === a.toolReadChars &&
+        elapsedMs === a.elapsedMs
+      ) {
+        return a;
+      }
+      return { ...a, outputChars, reasoningChars, toolReadChars, elapsedMs };
     });
   }
   return prev;
@@ -106,6 +127,10 @@ export interface SubagentActivity {
   model?: string;
   phase?: "exploring" | "summarising";
   lastInner: SubagentInnerSummary | null;
+  /** Monotonic byte/char counters — proves data is flowing during long no-tool gaps. `outputChars` = model assistant content streamed, `reasoningChars` = model reasoning streamed, `toolReadChars` = sum of tool-result strings the child read back IN. */
+  outputChars: number;
+  reasoningChars: number;
+  toolReadChars: number;
 }
 
 export interface UseSubagentParams {
@@ -127,7 +152,10 @@ export function useSubagent({
   getWalletCurrency,
 }: UseSubagentParams): UseSubagentResult {
   const [activities, setActivities] = useState<ReadonlyArray<SubagentActivity>>([]);
-  const sinkRef = useRef<SubagentSink>({ current: null });
+  // Share the process-wide singleton so `buildCodeToolset`'s pre-mount
+  // `subagentRunner` closure (which reads sink.current at dispatch time)
+  // sees the same `.current` we install below in useEffect.
+  const sinkRef = useRef<SubagentSink>(SHARED_SUBAGENT_SINK);
   // Subagent runs can outlive a balance refresh; the thunk lives in a ref so the
   // sink callback (installed once at mount) always reads the latest wallet currency.
   const getWalletCurrencyRef = useRef(getWalletCurrency);
@@ -150,6 +178,9 @@ export function useSubagent({
             model: ev.model,
             phase: "exploring",
             lastInner: null,
+            outputChars: 0,
+            reasoningChars: 0,
+            toolReadChars: 0,
           };
           return [...prev, next];
         });

--- a/src/code/setup.ts
+++ b/src/code/setup.ts
@@ -21,7 +21,12 @@ import { registerPlanTool } from "../tools/plan.js";
 import { registerScaffoldTools } from "../tools/scaffold.js";
 import { registerShellTools } from "../tools/shell.js";
 import { type SkillInstalledHook, registerSkillTools } from "../tools/skills.js";
-import { formatSubagentResult, spawnSubagent } from "../tools/subagent.js";
+import {
+  SHARED_SUBAGENT_SINK,
+  type SubagentSink,
+  formatSubagentResult,
+  spawnSubagent,
+} from "../tools/subagent.js";
 import { registerTodoTool } from "../tools/todo.js";
 import { registerWebTools } from "../tools/web.js";
 
@@ -31,6 +36,8 @@ export interface CodeToolsetOpts {
   onSkillInstalled?: SkillInstalledHook;
   /** Fired after `run_background` / `stop_job` mutate the JobRegistry — desktop pushes a fresh `$jobs` event so the popover updates without waiting for poll. */
   onJobsChanged?: () => void;
+  /** Shared `{current: callback}` sink the TUI populates after mount. Setup forwards it into every `spawnSubagent` so live progress events reach the rich subagent row even though setup runs before the UI does. */
+  subagentSink?: SubagentSink;
 }
 
 export interface CodeToolset {
@@ -98,6 +105,11 @@ export async function buildCodeToolset(opts: CodeToolsetOpts): Promise<CodeTools
         model: skill.model,
         allowedTools: skill.allowedTools,
         skillName: skill.name,
+        // Late-bound: the TUI's `useSubagent` writes the live callback into
+        // SHARED_SUBAGENT_SINK after mount. Until then `.current` is null
+        // and the events are silently dropped — that's fine for non-TUI
+        // callers (`reasonix chat --transcript`, library use).
+        sink: opts.subagentSink ?? SHARED_SUBAGENT_SINK,
       });
       return formatSubagentResult(result);
     },

--- a/src/loop/force-summary.ts
+++ b/src/loop/force-summary.ts
@@ -4,7 +4,7 @@ import type { TurnStats } from "../telemetry/stats.js";
 import type { ChatMessage } from "../types.js";
 import { errorLabelFor, reasonPrefixFor } from "./errors.js";
 import { buildAssistantMessage } from "./messages.js";
-import { stripHallucinatedToolMarkup, thinkingModeForModel } from "./thinking.js";
+import { stripHallucinatedToolMarkup } from "./thinking.js";
 import type { LoopEvent } from "./types.js";
 
 export type ForceSummaryReason = "aborted" | "context-guard" | "stuck";
@@ -36,16 +36,16 @@ export async function* forceSummaryAfterIterLimit(
       content:
         "The turn is being force-summarized (context guard or stuck-state). Summarize in plain prose what you learned from the tool results above. Do NOT emit any tool calls, function-call markup, DSML invocations, or SEARCH/REPLACE edit blocks — they will be silently discarded. Just plain text.",
     });
-    // Pin to flash + effort=high regardless of the main turn's model —
-    // pro is 12× overkill for "paraphrase tool results into prose."
+    // Pin to flash + thinking disabled — the task is "paraphrase tool
+    // results into prose", which needs zero reasoning. Letting flash
+    // think here burns reasoning tokens on a job that's structurally
+    // bounded (no decisions, no tools). Pro is 12× overkill.
     const summaryModel = "deepseek-v4-flash";
-    const summaryEffort: "high" | "max" = "high";
     const resp = await ctx.client.chat({
       model: summaryModel,
       messages,
       signal: ctx.signal,
-      thinking: thinkingModeForModel(summaryModel),
-      reasoningEffort: summaryEffort,
+      thinking: "disabled",
     });
     const rawContent = resp.content?.trim() ?? "";
     const cleaned = stripHallucinatedToolMarkup(rawContent);

--- a/src/tools/skills.ts
+++ b/src/tools/skills.ts
@@ -26,6 +26,65 @@ export interface SkillToolsOptions {
   onSkillInstalled?: SkillInstalledHook;
 }
 
+interface BuiltinSubagentToolSpec {
+  toolName: string;
+  skillName: string;
+  description: string;
+  taskDescription: string;
+}
+
+function registerBuiltinSubagentTool(
+  registry: ToolRegistry,
+  store: SkillStore,
+  subagentRunner: SubagentRunner | undefined,
+  spec: BuiltinSubagentToolSpec,
+): void {
+  // Eager presence check — keeps disableBuiltins test mode clean (no
+  // phantom tool spec when its skill body is absent).
+  if (!store.read(spec.skillName)) return;
+  registry.register({
+    name: spec.toolName,
+    description: spec.description,
+    readOnly: true,
+    parallelSafe: true,
+    parameters: {
+      type: "object",
+      properties: {
+        task: { type: "string", description: spec.taskDescription },
+      },
+      required: ["task"],
+    },
+    fn: async (args: { task?: unknown }, ctx) => {
+      if (!subagentRunner) {
+        return JSON.stringify({
+          error: `${spec.toolName}: no subagent runner is configured for this session — run inside \`reasonix code\`, or pass \`subagentRunner\` to \`registerSkillTools\`.`,
+        });
+      }
+      const task = typeof args.task === "string" ? args.task.trim() : "";
+      if (!task) {
+        return JSON.stringify({
+          error: `${spec.toolName} requires a non-empty 'task' argument — describe the concrete question.`,
+        });
+      }
+      const skill = store.read(spec.skillName);
+      if (!skill) {
+        return JSON.stringify({
+          error: `${spec.toolName}: built-in skill ${JSON.stringify(spec.skillName)} is no longer registered`,
+        });
+      }
+      // A user-supplied skill with the same name but `runAs: inline`
+      // would silently lose isolation if we dispatched it here — bounce
+      // back to run_skill where inline is well-defined.
+      if (skill.runAs !== "subagent") {
+        return JSON.stringify({
+          error: `${spec.toolName}: skill ${JSON.stringify(spec.skillName)} is overridden as inline; invoke it via run_skill instead.`,
+        });
+      }
+      return subagentRunner(skill, task, ctx?.signal);
+    },
+  });
+}
+
 export function registerSkillTools(
   registry: ToolRegistry,
   opts: SkillToolsOptions = {},
@@ -43,7 +102,7 @@ export function registerSkillTools(
   registry.register({
     name: "run_skill",
     description:
-      "Invoke a playbook from the Skills index pinned in the system prompt. Each entry is a self-contained instruction block. Pass `name` as the BARE skill identifier (e.g. 'explore'), NOT the `[🧬 subagent]` tag that appears after it in the index. Entries tagged `[🧬 subagent]` spawn an isolated subagent — only the final distilled answer comes back, the model's tool calls + reasoning during the run never enter your context. Plain skills are inlined: the body becomes a tool result you read and follow. For subagent skills, supply 'arguments' describing the concrete task — they'll be the only context the subagent has.",
+      "Invoke a user-defined playbook from the Skills index pinned in the system prompt. **For the built-in subagent skills (explore / research / review / security_review), prefer the dedicated top-level tools by the same name — they're cheaper to pick and produce the same result.** Pass `name` as the BARE skill identifier (e.g. 'my-custom-skill'), NOT the `[🧬 subagent]` tag that appears after it in the index. Entries tagged `[🧬 subagent]` spawn an isolated subagent — only the final distilled answer comes back. Plain skills are inlined: the body becomes a tool result you read and follow. For subagent skills, supply 'arguments' describing the concrete task — they'll be the only context the subagent has.",
     readOnly: true,
     parallelSafe: true,
     parameters: {
@@ -124,6 +183,43 @@ export function registerSkillTools(
       // Sentinel-wrapped so ContextManager.fold preserves the body verbatim instead of paraphrasing it.
       return `<skill-pin name=${JSON.stringify(skill.name)}>\n${inner}\n</skill-pin>`;
     },
+  });
+
+  // Top-level wrappers for built-in subagent skills. Same underlying
+  // subagentRunner path as `run_skill(name="explore", ...)`, but the
+  // tool name matches the verb in the question — models pick it
+  // because affordance design > prompt rules.
+  registerBuiltinSubagentTool(registry, store, subagentRunner, {
+    toolName: "explore",
+    skillName: "explore",
+    description:
+      "Run a focused read-only codebase investigation in an isolated subagent. **Use for broad survey questions across multiple files** — 'find all places that X', 'how does Y work across the project', 'audit Z'. Returns one distilled answer with file:line citations. Chained `read_file` is the wrong tool for these — it bloats your context with raw file contents; `explore`'s reads + reasoning never enter your log.",
+    taskDescription:
+      "Concrete investigation question. The subagent has none of your context — write a self-contained prompt naming the symbol / pattern / behavior you want surveyed.",
+  });
+  registerBuiltinSubagentTool(registry, store, subagentRunner, {
+    toolName: "research",
+    skillName: "research",
+    description:
+      "Combine web search + code reading in an isolated subagent. **Use when the answer needs both external reference and local verification** — 'is X supported by lib Y in version Z', 'compare our impl against the spec', 'what's the canonical way to do Q'. Returns one synthesis citing code (file:line) and web (URL). Reads + searches stay in the subagent.",
+    taskDescription:
+      "Concrete research question. The subagent has none of your context — name the external thing to look up and the local code to compare against.",
+  });
+  registerBuiltinSubagentTool(registry, store, subagentRunner, {
+    toolName: "review",
+    skillName: "review",
+    description:
+      "Review the pending changes (current branch diff) in an isolated subagent — flags correctness / security / missing-tests / hidden behavior per file:line. Read-only; you decide what to act on. Use before suggesting a PR-shaped change, or when you've finished a multi-step edit and want a second pass.",
+    taskDescription:
+      "What to focus the review on (e.g. 'focus on the auth changes' or 'general'). The subagent reads the diff itself.",
+  });
+  registerBuiltinSubagentTool(registry, store, subagentRunner, {
+    toolName: "security_review",
+    skillName: "security-review",
+    description:
+      "Security-focused review of current branch diff in an isolated subagent — injection / authz / secrets / deserialization / path-traversal / crypto issues, severity-tagged. Use when shipping changes that touch auth, input parsing, file IO, or external requests. Read-only.",
+    taskDescription:
+      "Optional scope hint (e.g. 'focus on token handling in src/auth/') or 'full' for everything in the diff.",
   });
 
   const installScopeDesc = hasProjectScope

--- a/src/tools/subagent.ts
+++ b/src/tools/subagent.ts
@@ -15,7 +15,7 @@ import { SUBAGENT_TYPE_NAMES, getSubagentType } from "./subagent-types.js";
 
 /** Side-channel — subagents run inside a tool-dispatch frame, can't go through parent's `LoopEvent` stream. */
 export interface SubagentEvent {
-  kind: "start" | "progress" | "end" | "inner" | "phase";
+  kind: "start" | "progress" | "end" | "inner" | "phase" | "stream-progress";
   /** Stable per-spawn id; lets the UI key parallel runs apart instead of overwriting one shared row. */
   runId: string;
   task: string;
@@ -32,6 +32,10 @@ export interface SubagentEvent {
   inner?: import("../loop.js").LoopEvent;
   /** When kind === "phase": coarse status verb for the activity row. */
   phase?: "exploring" | "summarising";
+  /** When kind === "stream-progress": monotonic char counters across the whole spawn, throttled. Lets the UI prove bytes are flowing during the long gaps between tool calls. `toolReadChars` is the sum of tool-result string lengths — the bytes pulled INTO the subagent from its reads/searches. */
+  outputChars?: number;
+  reasoningChars?: number;
+  toolReadChars?: number;
 }
 
 let runIdCounter = 0;
@@ -43,6 +47,9 @@ function nextRunId(): string {
 export interface SubagentSink {
   current: ((ev: SubagentEvent) => void) | null;
 }
+
+/** Process-wide late-bound channel. `buildCodeToolset` runs before the TUI mounts, so its `subagentRunner` closure can't capture a UI ref directly — it reads `.current` at dispatch time. The TUI's `useSubagent` writes `.current` on mount. Both sides reference the same singleton object so prop-drilling through `chatCommand` is unnecessary. Tests / library callers that want isolation pass their own `subagentSink` to `buildCodeToolset` (overrides the singleton for that toolset). */
+export const SHARED_SUBAGENT_SINK: SubagentSink = { current: null };
 
 export interface SpawnSubagentOptions {
   client: DeepSeekClient;
@@ -242,6 +249,40 @@ export async function spawnSubagent(opts: SpawnSubagentOptions): Promise<Subagen
   let toolIter = 0;
   let summarisingEmitted = false;
   let forcedSummaryFired = false;
+  let outputChars = 0;
+  let reasoningChars = 0;
+  let toolReadChars = 0;
+  let lastStreamEmitAt = 0;
+  let charsSinceLastEmit = 0;
+  // Throttle gates — 200ms or 400 chars between emits, whichever first.
+  // Cheap enough that React doesn't drown, often enough that the seconds
+  // counter has company.
+  const STREAM_EMIT_INTERVAL_MS = 200;
+  const STREAM_EMIT_CHARS = 400;
+  const maybeEmitStreamProgress = (now: number, force: boolean): void => {
+    if (!sink?.current) return;
+    if (
+      !force &&
+      now - lastStreamEmitAt < STREAM_EMIT_INTERVAL_MS &&
+      charsSinceLastEmit < STREAM_EMIT_CHARS
+    ) {
+      return;
+    }
+    lastStreamEmitAt = now;
+    charsSinceLastEmit = 0;
+    sink.current({
+      kind: "stream-progress",
+      runId,
+      task: taskPreview,
+      skillName,
+      model,
+      iter: toolIter,
+      elapsedMs: now - startedAt,
+      outputChars,
+      reasoningChars,
+      toolReadChars,
+    });
+  };
   try {
     for await (const ev of childLoop.step(opts.task)) {
       sink?.current?.({ kind: "inner", runId, task: taskPreview, skillName, model, inner: ev });
@@ -250,6 +291,7 @@ export async function spawnSubagent(opts: SpawnSubagentOptions): Promise<Subagen
         toolIter++;
         // New tool dispatched — the model went back to deciding, summarising flag resets so the next final-answer delta re-emits.
         summarisingEmitted = false;
+        toolReadChars += ev.content?.length ?? 0;
         sink?.current?.({
           kind: "progress",
           runId,
@@ -259,6 +301,20 @@ export async function spawnSubagent(opts: SpawnSubagentOptions): Promise<Subagen
           iter: toolIter,
           elapsedMs: Date.now() - startedAt,
         });
+        // Force-emit so the read counter ticks visibly even if the
+        // subsequent assistant_delta gap is short and the throttle gates
+        // would otherwise hold the next emit back.
+        maybeEmitStreamProgress(Date.now(), true);
+      }
+      if (ev.role === "assistant_delta") {
+        const dContent = ev.content?.length ?? 0;
+        const dReason = ev.reasoningDelta?.length ?? 0;
+        if (dContent > 0 || dReason > 0) {
+          outputChars += dContent;
+          reasoningChars += dReason;
+          charsSinceLastEmit += dContent + dReason;
+          maybeEmitStreamProgress(Date.now(), false);
+        }
       }
       // First content delta (no concurrent tool_call_delta role) = the
       // model is now writing its final answer, not deciding the next tool.

--- a/tests/subagent-reducer.test.ts
+++ b/tests/subagent-reducer.test.ts
@@ -11,6 +11,8 @@ const baseActivity: SubagentActivity = {
   elapsedMs: 0,
   phase: "exploring",
   lastInner: null,
+  outputChars: 0,
+  reasoningChars: 0,
 };
 
 function inner(

--- a/tests/tools-skills.test.ts
+++ b/tests/tools-skills.test.ts
@@ -443,3 +443,114 @@ describe("install_skill tool", () => {
     expect(raw).not.toMatch(/description: first line\n/);
   });
 });
+
+describe("built-in subagent tools (explore / research / review / security_review)", () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "reasonix-builtin-subagent-"));
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("registers all four built-in subagent tools when builtins are enabled", () => {
+    const reg = new ToolRegistry();
+    registerSkillTools(reg, { homeDir: home, subagentRunner: async () => "ok" });
+    expect(reg.get("explore")?.readOnly).toBe(true);
+    expect(reg.get("research")?.readOnly).toBe(true);
+    expect(reg.get("review")?.readOnly).toBe(true);
+    expect(reg.get("security_review")?.readOnly).toBe(true);
+  });
+
+  it("does not register the wrappers when builtins are disabled", () => {
+    const reg = new ToolRegistry();
+    registerSkillTools(reg, {
+      homeDir: home,
+      disableBuiltins: true,
+      subagentRunner: async () => "ok",
+    });
+    expect(reg.get("explore")).toBeUndefined();
+    expect(reg.get("research")).toBeUndefined();
+    expect(reg.get("review")).toBeUndefined();
+    expect(reg.get("security_review")).toBeUndefined();
+  });
+
+  it("dispatches `explore` straight to subagentRunner with the explore skill body + task", async () => {
+    const reg = new ToolRegistry();
+    let received: { name: string; bodySnippet: string; task: string } | null = null;
+    registerSkillTools(reg, {
+      homeDir: home,
+      subagentRunner: async (skill, task) => {
+        received = { name: skill.name, bodySnippet: skill.body.slice(0, 80), task };
+        return JSON.stringify({ success: true, output: "explore-said-this" });
+      },
+    });
+    const out = await reg.dispatch("explore", {
+      task: "find every caller of fixToolCallPairing",
+    });
+    expect(received?.name).toBe("explore");
+    expect(received?.bodySnippet).toMatch(/exploration subagent/);
+    expect(received?.task).toBe("find every caller of fixToolCallPairing");
+    expect(JSON.parse(out).output).toBe("explore-said-this");
+  });
+
+  it("maps the security_review tool name to the security-review skill (hyphen mapping)", async () => {
+    const reg = new ToolRegistry();
+    let receivedName: string | null = null;
+    registerSkillTools(reg, {
+      homeDir: home,
+      subagentRunner: async (skill) => {
+        receivedName = skill.name;
+        return JSON.stringify({ success: true, output: "sec-said-this" });
+      },
+    });
+    await reg.dispatch("security_review", { task: "focus on token handling" });
+    expect(receivedName).toBe("security-review");
+  });
+
+  it("errors when no subagentRunner is configured", async () => {
+    const reg = new ToolRegistry();
+    // No subagentRunner — the wrappers should still register but refuse to dispatch.
+    registerSkillTools(reg, { homeDir: home });
+    const out = await reg.dispatch("explore", { task: "anything" });
+    expect(JSON.parse(out).error).toMatch(/no subagent runner is configured/);
+  });
+
+  it("requires a non-empty task", async () => {
+    const reg = new ToolRegistry();
+    let runnerCalls = 0;
+    registerSkillTools(reg, {
+      homeDir: home,
+      subagentRunner: async () => {
+        runnerCalls++;
+        return "x";
+      },
+    });
+    const out = await reg.dispatch("research", { task: "   " });
+    expect(JSON.parse(out).error).toMatch(/non-empty 'task'/);
+    expect(runnerCalls).toBe(0);
+  });
+
+  it("bounces to run_skill when a user override flips the skill to runAs: inline", async () => {
+    writeSkillWithFrontmatter(
+      home,
+      "review",
+      { description: "user inline override", runAs: "inline" },
+      "Custom inline review playbook.",
+    );
+    const reg = new ToolRegistry();
+    let runnerCalls = 0;
+    registerSkillTools(reg, {
+      homeDir: home,
+      subagentRunner: async () => {
+        runnerCalls++;
+        return "x";
+      },
+    });
+    const out = await reg.dispatch("review", { task: "the diff" });
+    expect(JSON.parse(out).error).toMatch(/overridden as inline.*run_skill/);
+    expect(runnerCalls).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Fix the "subagent looks frozen" UX, plus two adjacent improvements.

### 1. Subagent live byte progress — fixes the silent-12s spinner

Two root causes; both addressed.

**Sink wiring (the actual bug):** `buildCodeToolset` runs before the TUI mounts, so its `subagentRunner` closure captured nothing — every `spawnSubagent` got `sink: undefined` and the events that should have driven `SubagentRow` were silently dropped. `App.tsx`'s registration (which *does* pass a sink) was being short-circuited by the `tools.has("run_skill")` guard.

Introduce `SHARED_SUBAGENT_SINK` — a process-wide `{current: null}` singleton both ends reach through. Setup reads `.current` at dispatch time; `useSubagent` writes `.current` on mount. The wiring resolves in time order without prop-drilling. Tests / library callers can override via the new `subagentSink` option on `buildCodeToolset`.

**Live byte counters:** `spawnSubagent` now emits throttled `stream-progress` events carrying monotonic `outputChars`, `reasoningChars`, `toolReadChars`. `SubagentRow` renders these as `↓ read X · ↑ out Y · ◆ think Z`. `OngoingToolRow` carries the same line as a fallback (so the bytes show even if the rich row is off-screen) and adds `args N B` for any in-flight tool dispatch.

### 2. Top-level subagent tools

Register `explore` / `research` / `review` / `security_review` as siblings to `read_file`, dispatching through the same `subagentRunner` path as `run_skill(name="...")`. The surface change is purely affordance — models pick the tool whose name matches the verb in the question; the `run_skill` meta-API was too indirect. Empirically lifts the model's "spawn vs chained read_file" decision on broad audit queries. User-defined skills still flow through `run_skill`.

### 3. `forceSummaryAfterIterLimit` runs with `thinking: "disabled"`

The task is "paraphrase tool results into prose" — pure structural transform, no decisions. Was burning reasoning tokens on every storm-breaker / context-guard summary with `thinking: enabled` + `reasoningEffort: high`. Drop both.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx biome check src` clean
- [x] Full suite: **3420 passed / 9 skipped**
- [x] 7 new cases for the top-level wrappers — registration, dispatch, hyphen → underscore mapping for `security_review`, missing-runner error, empty-task guard, inline-override bounce
- [ ] Manual: `/explore` shows rich `SubagentRow` with live byte counters during the run
