### PR TITLE
fix(ui): less-sensitive wheel scroll + collapse per-card stdout resize listeners

### DIFF
--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -23,6 +23,7 @@ import { Setup } from "../ui/Setup.js";
 import { drainTtyResponses } from "../ui/drain-tty.js";
 import { KeystrokeProvider } from "../ui/keystroke-context.js";
 import { disableMouseMode, enableMouseMode } from "../ui/mouse-mode.js";
+import { installResizeBroadcaster } from "../ui/resize-broadcaster.js";
 import type { McpServerSummary } from "../ui/slash.js";
 import {
   type McpLifecycleNotice,
@@ -342,10 +343,9 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
     }
   }
 
-  // One stdout `resize` listener per card (Ink's useBoxMetrics); long
-  // chats legitimately hold dozens, so Node's default cap of 10 fires
-  // a spurious MaxListenersExceededWarning. Raise the ceiling.
-  process.stdout.setMaxListeners(200);
+  // Before render() — shims Ink's per-card useBoxMetrics resize subscribe
+  // path so N cards don't accumulate N native stdout listeners.
+  installResizeBroadcaster();
 
   // Wheel scrolling. Opt-out via `mouseTracking: false` for users who
   // prefer native drag-select copy (Shift+drag still selects with mouse

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -1660,8 +1660,10 @@ function AppInner({
   // arrows here when the composer is hidden (chat is scrolled up and
   // InputAreaWithHistoryHint has replaced it).
   useKeystroke((ev) => {
-    if (ev.pageUp || ev.mouseScrollUp) chatScroll.scrollPageUp();
-    else if (ev.pageDown || ev.mouseScrollDown) chatScroll.scrollPageDown();
+    if (ev.pageUp) chatScroll.scrollPageUp();
+    else if (ev.pageDown) chatScroll.scrollPageDown();
+    else if (ev.mouseScrollUp) chatScroll.scrollWheelUp();
+    else if (ev.mouseScrollDown) chatScroll.scrollWheelDown();
     else if (ev.end) chatScroll.jumpToBottom();
     else if (!composerPinned && ev.upArrow) chatScroll.scrollUp();
     else if (!composerPinned && ev.downArrow) chatScroll.scrollDown();

--- a/src/cli/ui/PlanConfirm.tsx
+++ b/src/cli/ui/PlanConfirm.tsx
@@ -94,17 +94,17 @@ function PlanConfirmInner({ plan, steps, summary, onChoose }: PlanConfirmProps) 
       return;
     }
     if (!isDetailScrollKey(ev)) return;
-    if (ev.pageUp || ev.mouseScrollUp) {
+    if (ev.pageUp) {
       setDetailOffset((n) => Math.max(0, n - detailViewRows));
-    } else if (ev.pageDown || ev.mouseScrollDown) {
+    } else if (ev.pageDown) {
       setDetailOffset((n) => Math.min(maxDetailOffset, n + detailViewRows));
     } else if (ev.home) {
       setDetailOffset(0);
     } else if (ev.end) {
       setDetailOffset(maxDetailOffset);
-    } else if (ev.upArrow) {
+    } else if (ev.upArrow || ev.mouseScrollUp) {
       setDetailOffset((n) => Math.max(0, n - 1));
-    } else if (ev.downArrow) {
+    } else if (ev.downArrow || ev.mouseScrollDown) {
       setDetailOffset((n) => Math.min(maxDetailOffset, n + 1));
     }
   });

--- a/src/cli/ui/resize-broadcaster.ts
+++ b/src/cli/ui/resize-broadcaster.ts
@@ -1,0 +1,57 @@
+/** Shimmed stdout 'resize' to one real listener + a subscriber Set. */
+
+import type { WriteStream } from "node:tty";
+
+type Listener = (...args: unknown[]) => void;
+type Registrar = (event: string | symbol, listener: Listener) => WriteStream;
+
+interface State {
+  stream: WriteStream;
+  subscribers: Set<Listener>;
+}
+
+let state: State | null = null;
+
+export function installResizeBroadcaster(stream: WriteStream = process.stdout): void {
+  if (state) return;
+  if (typeof stream.on !== "function" || typeof stream.off !== "function") return;
+
+  const subscribers = new Set<Listener>();
+  const realOn = stream.on.bind(stream) as Registrar;
+  const realOff = stream.off.bind(stream) as Registrar;
+
+  const broadcast: Listener = (...args) => {
+    for (const l of subscribers) l(...args);
+  };
+  realOn("resize", broadcast);
+
+  const shimOn: Registrar = (event, listener) => {
+    if (event === "resize") {
+      subscribers.add(listener);
+      return stream;
+    }
+    return realOn(event, listener);
+  };
+  const shimOff: Registrar = (event, listener) => {
+    if (event === "resize") {
+      subscribers.delete(listener);
+      return stream;
+    }
+    return realOff(event, listener);
+  };
+
+  stream.on = shimOn as WriteStream["on"];
+  stream.addListener = shimOn as WriteStream["addListener"];
+  stream.off = shimOff as WriteStream["off"];
+  stream.removeListener = shimOff as WriteStream["removeListener"];
+
+  state = { stream, subscribers };
+}
+
+export function _uninstallResizeBroadcaster(): void {
+  state = null;
+}
+
+export function _resizeSubscriberCount(): number {
+  return state ? state.subscribers.size : 0;
+}

--- a/src/cli/ui/state/chat-scroll-provider.tsx
+++ b/src/cli/ui/state/chat-scroll-provider.tsx
@@ -37,6 +37,8 @@ export function useChatScrollActions(): Pick<
   | "scrollDown"
   | "scrollPageUp"
   | "scrollPageDown"
+  | "scrollWheelUp"
+  | "scrollWheelDown"
   | "jumpToBottom"
   | "setMaxScroll"
   | "setCardHeight"

--- a/src/cli/ui/state/chat-scroll-store.ts
+++ b/src/cli/ui/state/chat-scroll-store.ts
@@ -22,6 +22,8 @@ export interface ChatScrollStore {
   scrollDown(): void;
   scrollPageUp(): void;
   scrollPageDown(): void;
+  scrollWheelUp(): void;
+  scrollWheelDown(): void;
   jumpToBottom(): void;
   setMaxScroll(rows: number): void;
   /** Reports a card's measured height. No-op if value matches the cache. */
@@ -32,6 +34,9 @@ export interface ChatScrollStore {
 
 export const SCROLL_ARROW_ROWS = 3;
 export const SCROLL_PAGE_ROWS = 5;
+/** One wheel notch on most mice emits 2-5 SGR mouse reports back-to-back,
+ * so anything larger here multiplies into a 10-25 row jump per notch. */
+export const SCROLL_WHEEL_ROWS = 1;
 const COALESCE_MS = 16;
 
 const EMPTY_HEIGHTS: ReadonlyMap<string, number> = new Map();
@@ -127,6 +132,8 @@ export function createChatScrollStore(): ChatScrollStore {
     scrollDown: () => schedule(SCROLL_ARROW_ROWS),
     scrollPageUp: () => schedule(-SCROLL_PAGE_ROWS),
     scrollPageDown: () => schedule(SCROLL_PAGE_ROWS),
+    scrollWheelUp: () => schedule(-SCROLL_WHEEL_ROWS),
+    scrollWheelDown: () => schedule(SCROLL_WHEEL_ROWS),
     jumpToBottom() {
       pendingDelta = 0;
       if (flushTimer !== null) {

--- a/tests/chat-scroll-wheel.test.ts
+++ b/tests/chat-scroll-wheel.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  SCROLL_PAGE_ROWS,
+  SCROLL_WHEEL_ROWS,
+  createChatScrollStore,
+} from "../src/cli/ui/state/chat-scroll-store.js";
+
+describe("chatScroll wheel step (issue #1419)", () => {
+  it("one wheel tick moves a single row, not a full page", () => {
+    const store = createChatScrollStore();
+    store.setMaxScroll(200);
+    store.scrollWheelUp();
+    expect(store.getState().scrollRows).toBe(200 - SCROLL_WHEEL_ROWS);
+  });
+
+  it("a burst of wheel ticks accumulates rows-per-tick, not pages-per-tick", async () => {
+    vi.useFakeTimers();
+    try {
+      const store = createChatScrollStore();
+      store.setMaxScroll(500);
+      const before = store.getState().scrollRows;
+
+      for (let i = 0; i < 5; i++) store.scrollWheelUp();
+      await vi.advanceTimersByTimeAsync(32);
+
+      const moved = before - store.getState().scrollRows;
+      expect(moved).toBe(5 * SCROLL_WHEEL_ROWS);
+      expect(moved).toBeLessThan(5 * SCROLL_PAGE_ROWS);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("page step stays at SCROLL_PAGE_ROWS for keyboard PgUp / PgDn", () => {
+    const store = createChatScrollStore();
+    store.setMaxScroll(200);
+    store.scrollPageUp();
+    expect(store.getState().scrollRows).toBe(200 - SCROLL_PAGE_ROWS);
+  });
+});

--- a/tests/resize-broadcaster.test.ts
+++ b/tests/resize-broadcaster.test.ts
@@ -1,0 +1,89 @@
+import { EventEmitter } from "node:events";
+import type { WriteStream } from "node:tty";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  _resizeSubscriberCount,
+  _uninstallResizeBroadcaster,
+  installResizeBroadcaster,
+} from "../src/cli/ui/resize-broadcaster.js";
+
+function fakeStdout(): WriteStream {
+  const ee = new EventEmitter();
+  ee.setMaxListeners(10);
+  return ee as unknown as WriteStream;
+}
+
+afterEach(() => {
+  _uninstallResizeBroadcaster();
+});
+
+describe("resize broadcaster", () => {
+  it("collapses N virtual subscribers into a single native resize listener", () => {
+    const stdout = fakeStdout();
+    installResizeBroadcaster(stdout);
+
+    for (let i = 0; i < 50; i++) {
+      stdout.on("resize", () => {});
+    }
+
+    expect(_resizeSubscriberCount()).toBe(50);
+    expect((stdout as unknown as EventEmitter).listenerCount("resize")).toBe(1);
+  });
+
+  it("broadcasts emit to every virtual subscriber", () => {
+    const stdout = fakeStdout();
+    installResizeBroadcaster(stdout);
+    const seen: number[] = [];
+    for (let i = 0; i < 5; i++) {
+      stdout.on("resize", () => seen.push(i));
+    }
+
+    (stdout as unknown as EventEmitter).emit("resize");
+
+    expect(seen).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it("off() drops the subscriber so subsequent emits skip it", () => {
+    const stdout = fakeStdout();
+    installResizeBroadcaster(stdout);
+    let aCount = 0;
+    let bCount = 0;
+    const a = (): void => {
+      aCount++;
+    };
+    const b = (): void => {
+      bCount++;
+    };
+    stdout.on("resize", a);
+    stdout.on("resize", b);
+
+    (stdout as unknown as EventEmitter).emit("resize");
+    stdout.off("resize", a);
+    (stdout as unknown as EventEmitter).emit("resize");
+
+    expect(aCount).toBe(1);
+    expect(bCount).toBe(2);
+  });
+
+  it("does not touch listeners for other events", () => {
+    const stdout = fakeStdout();
+    installResizeBroadcaster(stdout);
+    let dataCount = 0;
+    stdout.on("data", () => {
+      dataCount++;
+    });
+
+    expect((stdout as unknown as EventEmitter).listenerCount("data")).toBe(1);
+    (stdout as unknown as EventEmitter).emit("data");
+    expect(dataCount).toBe(1);
+  });
+
+  it("install is idempotent — calling twice does not double-shim", () => {
+    const stdout = fakeStdout();
+    installResizeBroadcaster(stdout);
+    installResizeBroadcaster(stdout);
+
+    stdout.on("resize", () => {});
+    expect((stdout as unknown as EventEmitter).listenerCount("resize")).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Wheel ticks were routed to `scrollPageUp/Down` (5 rows each); with 2-5 SGR mouse reports per physical notch, one flick jumped 10-25 rows. Split wheel into its own action backed by `SCROLL_WHEEL_ROWS=1`; PgUp/PgDn keep page semantics. Same split applied to the PlanConfirm detail pane.
- `MaxListenersExceededWarning`: Ink's `useBoxMetrics` attaches one `stdout.on('resize', ...)` per card, so any fixed cap was a band-aid. Shim `stdout.on/off` for `'resize'` into a subscriber `Set` with a single real native listener installed before `render()`, and drop the previous `setMaxListeners(200)`.

Closes #1419

## Test plan
- [x] `tests/chat-scroll-wheel.test.ts` — wheel tick = 1 row, burst of 5 ticks ≠ page step, PgUp still steps by `SCROLL_PAGE_ROWS`
- [x] `tests/resize-broadcaster.test.ts` — 50 virtual subscribers → 1 native listener, emit fans out, `off()` drops, idempotent install, non-`resize` events untouched
- [x] `npm run verify` (build + lint + typecheck + 3431-test suite) green on the push gate