### PR TITLE
test(lifecycle): add strict e2e harness

### DIFF
--- a/tests/lifecycle-e2e.test.ts
+++ b/tests/lifecycle-e2e.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+import { createStrictLifecycleHarness } from "./support/lifecycle-harness.js";
+
+describe("strict engineering lifecycle e2e harness", () => {
+  it("blocks high-risk mutation before an approved plan", async () => {
+    const harness = createStrictLifecycleHarness();
+
+    const rejected = await harness.dispatch("delete_file", { path: "src/old.ts" });
+
+    expect(JSON.parse(rejected)).toMatchObject({
+      rejectedReason: "engineering-lifecycle",
+      state: "armed",
+      nextAction: "submit_plan",
+    });
+  });
+
+  it("runs a multi-step strict lifecycle from plan approval through final evidence", async () => {
+    const harness = createStrictLifecycleHarness();
+
+    const beforePlan = await harness.dispatch("delete_file", { path: "src/old.ts" });
+    expect(JSON.parse(beforePlan)).toMatchObject({
+      rejectedReason: "engineering-lifecycle",
+      nextAction: "submit_plan",
+    });
+
+    harness.queue({ type: "approve" });
+    await harness.dispatch("submit_plan", {
+      plan: "Refactor the formatter and refresh tests.",
+      steps: [
+        {
+          id: "step-1",
+          title: "Remove old formatter",
+          action: "Delete the old formatter file.",
+          risk: "high",
+          targets: ["src/old.ts"],
+          verification: ["npm test -- tests/lifecycle.test.ts"],
+        },
+        {
+          id: "step-2",
+          title: "Write replacement",
+          action: "Create the new formatter module.",
+          risk: "low",
+          targets: ["src/format.ts"],
+        },
+      ],
+    });
+    expect(harness.lifecycle.snapshot().state).toBe("approved");
+
+    const mutation = await harness.dispatch("delete_file", { path: "src/old.ts" });
+    expect(mutation).toBe("deleted src/old.ts");
+    expect(harness.lifecycle.snapshot()).toMatchObject({
+      state: "executing",
+      mutatedSinceLastStep: true,
+    });
+
+    const missingEvidence = await harness.dispatch("mark_step_complete", {
+      stepId: "step-1",
+      result: "Removed the old formatter.",
+    });
+    expect(JSON.parse(missingEvidence)).toMatchObject({
+      rejectedReason: "engineering-lifecycle-evidence",
+      nextAction: "add_evidence",
+    });
+
+    harness.queue({ type: "continue" });
+    const stepOneDone = await harness.dispatch("mark_step_complete", {
+      stepId: "step-1",
+      result: "Removed the old formatter.",
+      evidence: [
+        {
+          kind: "verification",
+          summary: "focused lifecycle tests passed",
+          command: "npm test -- tests/lifecycle.test.ts",
+        },
+      ],
+    });
+    expect(JSON.parse(stepOneDone)).toMatchObject({
+      kind: "step_completed",
+      stepId: "step-1",
+      evidenceSummary: "verification: focused lifecycle tests passed",
+    });
+    expect(JSON.parse(stepOneDone).evidence).toBeUndefined();
+    expect(harness.completions[0]?.evidence?.[0]).toMatchObject({
+      command: "npm test -- tests/lifecycle.test.ts",
+    });
+    expect(harness.lifecycle.snapshot()).toMatchObject({
+      state: "executing",
+      completedStepIds: ["step-1"],
+      mutatedSinceLastStep: false,
+    });
+
+    await harness.dispatch("write_file", { path: "src/format.ts", content: "export {};\n" });
+    const lowRiskMissingEvidence = await harness.dispatch("mark_step_complete", {
+      stepId: "step-2",
+      result: "Created src/format.ts.",
+    });
+    expect(JSON.parse(lowRiskMissingEvidence)).toMatchObject({
+      rejectedReason: "engineering-lifecycle-evidence",
+      stepId: "step-2",
+    });
+
+    harness.queue({ type: "continue" });
+    await harness.dispatch("mark_step_complete", {
+      stepId: "step-2",
+      result: "Created src/format.ts.",
+      evidence: [{ kind: "diff", summary: "added src/format.ts", paths: ["src/format.ts"] }],
+    });
+    expect(harness.lifecycle.snapshot()).toMatchObject({
+      state: "complete",
+      completedStepIds: ["step-1", "step-2"],
+      mutatedSinceLastStep: false,
+    });
+  });
+
+  it("preserves completed prefix through an accepted revision", async () => {
+    const harness = createStrictLifecycleHarness();
+    harness.queue({ type: "approve" });
+    await harness.dispatch("submit_plan", {
+      plan: "Refactor command routing.",
+      steps: [
+        { id: "step-1", title: "Extract router", action: "Move helpers.", risk: "low" },
+        { id: "step-2", title: "Migrate callers", action: "Update call sites.", risk: "med" },
+      ],
+    });
+
+    await harness.dispatch("write_file", { path: "src/router.ts", content: "export {};\n" });
+    harness.queue({ type: "continue" });
+    await harness.dispatch("mark_step_complete", {
+      stepId: "step-1",
+      result: "Extracted the router.",
+      evidence: [{ kind: "diff", summary: "added router", paths: ["src/router.ts"] }],
+    });
+
+    harness.queue({ type: "accepted" });
+    const revision = await harness.dispatch("revise_plan", {
+      reason: "User asked to skip caller migration and document the follow-up.",
+      remainingSteps: [
+        {
+          id: "step-3",
+          title: "Document follow-up",
+          action: "Document the skipped migration.",
+          risk: "low",
+        },
+      ],
+    });
+
+    expect(revision).toBe("revision accepted");
+    expect(harness.lifecycle.snapshot()).toMatchObject({
+      state: "executing",
+      completedStepIds: ["step-1"],
+      planSteps: [
+        { id: "step-1", title: "Extract router" },
+        { id: "step-3", title: "Document follow-up" },
+      ],
+    });
+  });
+
+  it("cancels the runtime when the user stops at a checkpoint", async () => {
+    const harness = createStrictLifecycleHarness();
+    harness.queue({ type: "approve" });
+    await harness.dispatch("submit_plan", {
+      plan: "Remove old formatter.",
+      steps: [
+        {
+          id: "step-1",
+          title: "Remove old formatter",
+          action: "Delete old formatter.",
+          risk: "high",
+        },
+      ],
+    });
+    await harness.dispatch("delete_file", { path: "src/old-format.ts" });
+
+    harness.queue({ type: "stop" });
+    const stopped = await harness.dispatch("mark_step_complete", {
+      stepId: "step-1",
+      result: "Removed old formatter.",
+      evidence: [{ kind: "manual", summary: "user wants to stop before continuing" }],
+    });
+
+    expect(JSON.parse(stopped).error).toMatch(/user stopped at checkpoint/);
+    expect(harness.lifecycle.snapshot()).toMatchObject({
+      state: "cancelled",
+      planSteps: [],
+      completedStepIds: [],
+      mutatedSinceLastStep: false,
+    });
+    const afterStop = await harness.dispatch("delete_file", { path: "src/another-old-file.ts" });
+    expect(JSON.parse(afterStop)).toMatchObject({
+      rejectedReason: "engineering-lifecycle",
+      state: "cancelled",
+    });
+  });
+});

--- a/tests/support/lifecycle-harness.ts
+++ b/tests/support/lifecycle-harness.ts
@@ -1,0 +1,115 @@
+import { EngineeringLifecycleRuntime } from "../../src/code/lifecycle.js";
+import {
+  type CheckpointVerdict,
+  PauseGate,
+  type PlanVerdict,
+  type RevisionVerdict,
+} from "../../src/core/pause-gate.js";
+import { ToolRegistry } from "../../src/tools.js";
+import { type PlanStep, type StepCompletion, registerPlanTool } from "../../src/tools/plan.js";
+
+type GateVerdict = PlanVerdict | CheckpointVerdict | RevisionVerdict;
+
+class QueueGate extends PauseGate {
+  readonly requests: Array<{ kind: string; payload: unknown }> = [];
+  private readonly lifecycle: EngineeringLifecycleRuntime;
+  private readonly verdicts: GateVerdict[] = [];
+
+  constructor(lifecycle: EngineeringLifecycleRuntime) {
+    super();
+    this.lifecycle = lifecycle;
+  }
+
+  push(verdict: GateVerdict): void {
+    this.verdicts.push(verdict);
+  }
+
+  override ask(opts: { kind: string; payload?: unknown }): Promise<any> {
+    this.requests.push({ kind: opts.kind, payload: opts.payload });
+    const verdict = this.verdicts.shift();
+    if (!verdict) throw new Error(`no queued verdict for ${opts.kind}`);
+
+    if (opts.kind === "plan_proposed" && verdict.type === "approve") {
+      const payload = opts.payload as { steps?: PlanStep[] } | undefined;
+      this.lifecycle.recordPlanApproved(payload?.steps);
+    }
+    if (opts.kind === "plan_checkpoint") {
+      this.lifecycle.recordCheckpointReached();
+      if (verdict.type === "stop") this.lifecycle.cancel();
+    }
+    if (opts.kind === "plan_revision" && verdict.type === "accepted") {
+      const payload = opts.payload as { remainingSteps?: PlanStep[] } | undefined;
+      this.lifecycle.recordPlanRevised(payload?.remainingSteps ?? []);
+    }
+
+    return Promise.resolve(verdict);
+  }
+}
+
+export interface StrictLifecycleHarness {
+  lifecycle: EngineeringLifecycleRuntime;
+  gate: QueueGate;
+  completions: StepCompletion[];
+  dispatch(name: string, args: Record<string, unknown>): Promise<string>;
+  queue(verdict: GateVerdict): void;
+}
+
+export function createStrictLifecycleHarness(): StrictLifecycleHarness {
+  const lifecycle = new EngineeringLifecycleRuntime({ mode: "strict" });
+  const registry = new ToolRegistry();
+  const gate = new QueueGate(lifecycle);
+  const completions: StepCompletion[] = [];
+
+  registry.addToolInterceptor("engineering-lifecycle", lifecycle.guardToolCall);
+  registry.setResultAugmenter((name, args, result) => {
+    lifecycle.recordToolResult(name, args, result);
+    return result;
+  });
+  registerPlanTool(registry, {
+    onPlanSubmitted: (_plan, steps) => lifecycle.recordPlanProposed(steps),
+    onStepCompleted: (completion) => completions.push(completion),
+  });
+  registerMutationTools(registry);
+
+  return {
+    lifecycle,
+    gate,
+    completions,
+    queue: (verdict) => gate.push(verdict),
+    dispatch: async (name, args) => {
+      const result = await registry.dispatch(name, JSON.stringify(args), {
+        confirmationGate: gate,
+      });
+      try {
+        const parsed = JSON.parse(result) as Partial<StepCompletion>;
+        if (parsed.kind === "step_completed" && typeof parsed.stepId === "string") {
+          lifecycle.recordStepCompleted(parsed.stepId);
+        }
+      } catch {
+        // Non-JSON tool results are normal for plan approval/revision text.
+      }
+      return result;
+    },
+  };
+}
+
+function registerMutationTools(registry: ToolRegistry): void {
+  registry.register({
+    name: "delete_file",
+    parameters: {
+      type: "object",
+      properties: { path: { type: "string" } },
+      required: ["path"],
+    },
+    fn: (args: { path: string }) => `deleted ${args.path}`,
+  });
+  registry.register({
+    name: "write_file",
+    parameters: {
+      type: "object",
+      properties: { path: { type: "string" }, content: { type: "string" } },
+      required: ["path", "content"],
+    },
+    fn: (args: { path: string }) => `▸ edit blocks: 1/1 applied\n  ✓ wrote       ${args.path}`,
+  });
+}


### PR DESCRIPTION
## Summary
- add a strict engineering lifecycle e2e harness that wires the runtime, ToolRegistry interceptors, result augmenter, plan tools, and PauseGate verdicts together
- cover high-risk mutation blocking before approval, approved mutation execution, evidence-required completion, compact model-visible step completion, host-side evidence retention, final completion, accepted revision, and checkpoint stop/cancel recovery
- keep this slice test-only so it does not expand runtime behavior or prompt/tool surface

## Validation
- `npm test -- tests/lifecycle-e2e.test.ts`
- `npm test -- tests/lifecycle-e2e.test.ts tests/lifecycle.test.ts tests/plan.test.ts tests/tools.test.ts`
- `npm run typecheck`
- `npm run lint` (passes with existing warning in `tests/welcome-banner-hints.test.tsx`)
- `npm run build`
- `npm test`
- push hook `npm run verify`

Follow-up to the engineering reliability lifecycle work in #1285.