### PR TITLE
fix(settings): allow clearing baseUrl from the dashboard

### DIFF
--- a/src/server/api/settings.ts
+++ b/src/server/api/settings.ts
@@ -127,10 +127,12 @@ export async function handleSettings(
       changed.push("apiKey");
     }
     if (fields.baseUrl !== undefined) {
-      if (typeof fields.baseUrl !== "string" || !fields.baseUrl.trim()) {
-        return { status: 400, body: { error: "baseUrl must be a non-empty string" } };
+      if (typeof fields.baseUrl !== "string") {
+        return { status: 400, body: { error: "baseUrl must be a string" } };
       }
-      cfg.baseUrl = fields.baseUrl.trim();
+      // Empty means clear — falls back to DEEPSEEK_BASE_URL / built-in default.
+      const trimmed = fields.baseUrl.trim();
+      cfg.baseUrl = trimmed.length > 0 ? trimmed : undefined;
       changed.push("baseUrl");
     }
     if (fields.preset !== undefined) {

--- a/tests/settings-api.test.ts
+++ b/tests/settings-api.test.ts
@@ -80,6 +80,48 @@ describe("settings API — combined POST persistence (#274)", () => {
     expect(readFileSync(configPath, "utf8")).toBe(before);
   });
 
+  it("empty baseUrl clears the field on disk (issue #1409)", async () => {
+    const res = await handleSettings(
+      "POST",
+      [],
+      JSON.stringify({ baseUrl: "" }),
+      makeCtx(configPath),
+    );
+    expect(res.status).toBe(200);
+    const cfg = readCfg(configPath);
+    expect(cfg.baseUrl).toBeUndefined();
+    expect(Object.hasOwn(cfg, "baseUrl")).toBe(false);
+  });
+
+  it("whitespace-only baseUrl clears the field (issue #1409)", async () => {
+    const res = await handleSettings(
+      "POST",
+      [],
+      JSON.stringify({ baseUrl: "   " }),
+      makeCtx(configPath),
+    );
+    expect(res.status).toBe(200);
+    expect(readCfg(configPath).baseUrl).toBeUndefined();
+  });
+
+  it("GET surfaces null after baseUrl is cleared (issue #1409)", async () => {
+    await handleSettings("POST", [], JSON.stringify({ baseUrl: "" }), makeCtx(configPath));
+    const res = await handleSettings("GET", [], "", makeCtx(configPath));
+    expect(res.status).toBe(200);
+    expect((res.body as { baseUrl: string | null }).baseUrl).toBeNull();
+  });
+
+  it("rejects a non-string baseUrl (issue #1409)", async () => {
+    const res = await handleSettings(
+      "POST",
+      [],
+      JSON.stringify({ baseUrl: 42 }),
+      makeCtx(configPath),
+    );
+    expect(res.status).toBe(400);
+    expect(readCfg(configPath).baseUrl).toBe("https://orig");
+  });
+
   it("rejects an invalid lang without writing other fields", async () => {
     const res = await handleSettings(
       "POST",


### PR DESCRIPTION
## Summary
- The POST `/settings` handler rejected an empty `baseUrl` with 400, so once a user had typed a base URL into the dashboard they could only edit it, never clear it — the only escape was hand-editing the JSON config.
- Treat empty / whitespace-only as "clear": drop the key from disk so `loadBaseUrl()` falls back to `DEEPSEEK_BASE_URL` or the built-in default on next start. GET continues to surface `null` when the key is absent, which the dashboard already renders as an empty input.

Closes #1409

## Test plan
- [x] `tests/settings-api.test.ts` — new cases: empty clears the key from disk; whitespace-only clears; GET surfaces `null` after clear; non-string still 400s and leaves the prior value alone
- [x] `npm run verify` (3439 tests) green on the push gate