### PR TITLE
feat(lifecycle): surface strict lifecycle observability

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -2874,6 +2874,9 @@ function AppInner({
             status: qq.status,
           },
           sessionId: session,
+          getEngineeringLifecycleSnapshot: codeMode
+            ? () => engineeringLifecycleRef.current?.snapshot() ?? null
+            : undefined,
           jobs: codeMode?.jobs,
           postInfo: fromQQ ? qq.sendInfo : log.pushInfo,
           postDoctor: (checks) => log.showDoctor(checks),

--- a/src/cli/ui/hooks/handle-tool-event.ts
+++ b/src/cli/ui/hooks/handle-tool-event.ts
@@ -4,6 +4,7 @@ import { t } from "../../../i18n/index.js";
 import type { LoopEvent } from "../../../loop.js";
 import type { ChoiceOption } from "../../../tools/choice.js";
 import type { PlanStep, StepCompletion, StepEvidence } from "../../../tools/plan.js";
+import { formatLifecycleRejection } from "../lifecycle-observability.js";
 import type { TurnTranslator } from "../state/TurnTranslator.js";
 import type { Scrollback } from "./useScrollback.js";
 
@@ -45,6 +46,9 @@ export function handleToolEvent(ev: LoopEvent, ctx: ToolEventContext): void {
   ctx.translator.toolEnd(ev.content);
 
   ctx.toolStartedAtRef.current = null;
+
+  const lifecycleHint = formatLifecycleRejection(ev.toolName, ev.content);
+  if (lifecycleHint) ctx.log.pushInfo(lifecycleHint, "warn");
 
   if (ev.toolName === "mark_step_complete") {
     try {

--- a/src/cli/ui/lifecycle-observability.ts
+++ b/src/cli/ui/lifecycle-observability.ts
@@ -1,0 +1,78 @@
+import type { EngineeringLifecycleSnapshot } from "../../code/lifecycle.js";
+import { t } from "../../i18n/index.js";
+
+interface LifecycleRejectionPayload {
+  rejectedReason?: unknown;
+  state?: unknown;
+  nextAction?: unknown;
+  stepId?: unknown;
+  consecutiveInterceptorRejection?: unknown;
+}
+
+export function formatLifecycleStatus(
+  snapshot: EngineeringLifecycleSnapshot | null | undefined,
+): string | null {
+  if (!snapshot || snapshot.mode === "off") return null;
+
+  const completed = snapshot.completedStepIds.length;
+  const total = snapshot.planSteps.length;
+  const progress =
+    total > 0
+      ? `${Math.min(completed, total)}/${total}`
+      : t("handlers.observability.lifecycleNoPlan");
+  const evidence = snapshot.mutatedSinceLastStep
+    ? ` · ${t("handlers.observability.lifecycleEvidencePending")}`
+    : "";
+
+  return t("handlers.observability.statusLifecycle", {
+    mode: snapshot.mode,
+    state: snapshot.state,
+    progress,
+    evidence,
+  });
+}
+
+export function formatLifecycleRejection(
+  toolName: string | undefined,
+  content: string,
+): string | null {
+  const payload = parseLifecyclePayload(content);
+  if (!payload) return null;
+
+  const reason = text(payload.rejectedReason, "");
+  if (reason !== "engineering-lifecycle" && reason !== "engineering-lifecycle-evidence") {
+    return null;
+  }
+
+  const tool = toolName?.trim() || t("common.tool");
+  if (payload.consecutiveInterceptorRejection === true) {
+    return t("handlers.observability.lifecycleRepeatedRejected", { tool });
+  }
+
+  if (reason === "engineering-lifecycle-evidence") {
+    return t("handlers.observability.lifecycleEvidenceRejected", {
+      stepId: text(payload.stepId, "?"),
+      next: text(payload.nextAction, "add_evidence"),
+    });
+  }
+
+  return t("handlers.observability.lifecycleRejected", {
+    tool,
+    state: text(payload.state, "?"),
+    next: text(payload.nextAction, "submit_plan"),
+  });
+}
+
+function parseLifecyclePayload(content: string): LifecycleRejectionPayload | null {
+  try {
+    const parsed = JSON.parse(content) as unknown;
+    if (!parsed || typeof parsed !== "object") return null;
+    return parsed as LifecycleRejectionPayload;
+  } catch {
+    return null;
+  }
+}
+
+function text(value: unknown, fallback: string): string {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : fallback;
+}

--- a/src/cli/ui/slash/handlers/observability.ts
+++ b/src/cli/ui/slash/handlers/observability.ts
@@ -7,6 +7,7 @@ import { VERSION } from "@/version.js";
 import { writeClipboard } from "../../clipboard.js";
 import { computeCtxBreakdown } from "../../ctx-breakdown.js";
 import { buildFeedbackDiagnostic, buildFeedbackIssueUrl } from "../../feedback.js";
+import { formatLifecycleStatus } from "../../lifecycle-observability.js";
 import { openUrl } from "../../open-url.js";
 import type { SlashHandler } from "../dispatch.js";
 import { compactNum } from "../helpers.js";
@@ -89,6 +90,7 @@ const status: SlashHandler = (_args, loop, ctx) => {
   const pendingLine =
     pending > 0 ? t("handlers.observability.statusEdits", { count: pending }) : "";
   const planLine = ctx.planMode ? t("handlers.observability.statusPlan") : "";
+  const lifecycleLine = formatLifecycleStatus(ctx.getEngineeringLifecycleSnapshot?.() ?? null);
   const modeLine =
     ctx.editMode === "yolo"
       ? t("handlers.observability.statusModeYolo")
@@ -118,6 +120,7 @@ const status: SlashHandler = (_args, loop, ctx) => {
   if (budgetLine) lines.push(budgetLine);
   if (pendingLine) lines.push(pendingLine);
   if (planLine) lines.push(planLine);
+  if (lifecycleLine) lines.push(lifecycleLine);
   if (modeLine) lines.push(modeLine);
   if (dashLine) lines.push(dashLine);
   return { info: lines.join("\n") };

--- a/src/cli/ui/slash/types.ts
+++ b/src/cli/ui/slash/types.ts
@@ -1,3 +1,4 @@
+import type { EngineeringLifecycleSnapshot } from "../../../code/lifecycle.js";
 import type { EditMode } from "../../../config.js";
 import type { McpServerSummary } from "../../../mcp/summary.js";
 import type { JobRegistry } from "../../../tools/jobs.js";
@@ -70,6 +71,7 @@ export interface SlashContext {
   codeHistory?: () => string;
   codeShowEdit?: (args: readonly string[]) => string;
   codeRoot?: string;
+  getEngineeringLifecycleSnapshot?: () => EngineeringLifecycleSnapshot | null;
   pendingEditCount?: number;
   mcpServers?: McpServerSummary[];
   /** Absent → tests context; `/memory` MUST reply "root unknown" rather than silently reading wrong dir. */

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -1027,6 +1027,13 @@ export const EN: TranslationSchema = {
       statusMcp: "  mcp     {servers} server(s), {tools} tool(s) in registry",
       statusEdits: "  edits   {count} pending (/apply to commit, /discard to drop)",
       statusPlan: "  plan    ON — writes gated (submit_plan + approval)",
+      statusLifecycle: "  lifecycle {mode}/{state} · {progress}{evidence}",
+      lifecycleNoPlan: "no plan",
+      lifecycleEvidencePending: "evidence pending",
+      lifecycleRejected: "lifecycle: {tool} blocked in {state} — next: {next}",
+      lifecycleEvidenceRejected: "lifecycle: step {stepId} needs evidence — next: {next}",
+      lifecycleRepeatedRejected:
+        "lifecycle: repeated {tool} rejection — do not retry identical args",
       statusModeYolo:
         "  mode    YOLO — edits + shell auto-run with no prompt (/undo still rolls back · Shift+Tab to flip)",
       statusModeAuto:

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -971,6 +971,12 @@ export const zhCN: TranslationSchema = {
       statusMcp: "  MCP     {servers} 个服务器，注册表中 {tools} 个工具",
       statusEdits: "  编辑    {count} 个待处理（/apply 提交，/discard 丢弃）",
       statusPlan: "  计划    开启 — 写入受限（submit_plan + 审批）",
+      statusLifecycle: "  生命周期 {mode}/{state} · {progress}{evidence}",
+      lifecycleNoPlan: "暂无计划",
+      lifecycleEvidencePending: "等待 evidence",
+      lifecycleRejected: "lifecycle：{tool} 在 {state} 状态被拦截 — 下一步：{next}",
+      lifecycleEvidenceRejected: "lifecycle：步骤 {stepId} 需要 evidence — 下一步：{next}",
+      lifecycleRepeatedRejected: "lifecycle：{tool} 被重复拦截 — 不要用相同参数反复重试",
       statusModeYolo:
         "  模式    YOLO — 编辑 + shell 自动运行，无提示（/undo 仍可回滚 · Shift+Tab 切换）",
       statusModeAuto: "  模式    AUTO — 编辑立即应用（5 秒内按 u 撤消 · Shift+Tab 切换）",

--- a/tests/handle-tool-event.test.ts
+++ b/tests/handle-tool-event.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { handleToolEvent } from "../src/cli/ui/hooks/handle-tool-event.js";
+import { type ToolEventContext, handleToolEvent } from "../src/cli/ui/hooks/handle-tool-event.js";
 import type { Scrollback } from "../src/cli/ui/hooks/useScrollback.js";
 import type { TurnTranslator } from "../src/cli/ui/state/TurnTranslator.js";
 import type { LoopEvent } from "../src/loop.js";
@@ -49,12 +49,35 @@ function makeLog(): { log: Scrollback; calls: Call[] } {
   return { log, calls };
 }
 
-function makeEvent(content: unknown): LoopEvent {
+function makeEvent(content: unknown, toolName = "mark_step_complete"): LoopEvent {
   return {
     turn: 1,
     role: "tool",
-    toolName: "mark_step_complete",
+    toolName,
     content: JSON.stringify(content),
+  };
+}
+
+function makeContext(log: Scrollback, overrides: Partial<ToolEventContext> = {}): ToolEventContext {
+  return {
+    flush: () => undefined,
+    translator: { toolEnd: () => undefined } as unknown as TurnTranslator,
+    setOngoingTool: () => undefined,
+    setToolProgress: () => undefined,
+    toolStartedAtRef: { current: null },
+    setPendingShell: () => undefined,
+    setPendingPlan: () => undefined,
+    setPendingRevision: () => undefined,
+    setPendingChoice: () => undefined,
+    planStepsRef: { current: null },
+    completedStepIdsRef: { current: new Set<string>() },
+    planBodyRef: { current: null },
+    planSummaryRef: { current: null },
+    persistPlanState: () => undefined,
+    log,
+    session: null,
+    codeModeOn: true,
+    ...overrides,
   };
 }
 
@@ -81,26 +104,10 @@ describe("handleToolEvent", () => {
           },
         ],
       }),
-      {
-        flush: () => undefined,
-        translator: { toolEnd: () => undefined } as unknown as TurnTranslator,
-        setOngoingTool: () => undefined,
-        setToolProgress: () => undefined,
-        toolStartedAtRef: { current: null },
-        setPendingShell: () => undefined,
-        setPendingPlan: () => undefined,
-        setPendingRevision: () => undefined,
-        setPendingChoice: () => undefined,
+      makeContext(log, {
         planStepsRef: { current: [{ id: "step-1", title: "Lifecycle", action: "Update tests" }] },
-        completedStepIdsRef: { current: new Set<string>() },
         stepCompletionsRef: { current: completions },
-        planBodyRef: { current: null },
-        planSummaryRef: { current: null },
-        persistPlanState: () => undefined,
-        log,
-        session: null,
-        codeModeOn: true,
-      },
+      }),
     );
 
     expect(calls).toContainEqual({
@@ -140,27 +147,11 @@ describe("handleToolEvent", () => {
         result: "Updated lifecycle tests.",
         evidenceSummary: "verification: lifecycle tests passed",
       }),
-      {
-        flush: () => undefined,
-        translator: { toolEnd: () => undefined } as unknown as TurnTranslator,
-        setOngoingTool: () => undefined,
-        setToolProgress: () => undefined,
-        toolStartedAtRef: { current: null },
-        setPendingShell: () => undefined,
-        setPendingPlan: () => undefined,
-        setPendingRevision: () => undefined,
-        setPendingChoice: () => undefined,
+      makeContext(log, {
         planStepsRef: { current: [{ id: "step-1", title: "Lifecycle", action: "Update tests" }] },
-        completedStepIdsRef: { current: new Set<string>() },
         stepCompletionsRef: { current: completions },
         pendingStepCompletionsRef: { current: pendingCompletions },
-        planBodyRef: { current: null },
-        planSummaryRef: { current: null },
-        persistPlanState: () => undefined,
-        log,
-        session: null,
-        codeModeOn: true,
-      },
+      }),
     );
 
     expect(completions.get("step-1")?.evidence?.[0]).toMatchObject({
@@ -174,5 +165,75 @@ describe("handleToolEvent", () => {
         "ghost",
       ],
     });
+  });
+
+  it("logs lifecycle mutation rejection next action", () => {
+    const { log, calls } = makeLog();
+
+    handleToolEvent(
+      makeEvent(
+        {
+          error: "delete_file: blocked by Engineering Lifecycle",
+          rejectedReason: "engineering-lifecycle",
+          state: "armed",
+          nextAction: "submit_plan",
+        },
+        "delete_file",
+      ),
+      makeContext(log),
+    );
+
+    expect(calls).toContainEqual({
+      method: "pushInfo",
+      args: ["lifecycle: delete_file blocked in armed — next: submit_plan", "warn"],
+    });
+  });
+
+  it("logs lifecycle evidence rejection next action", () => {
+    const { log, calls } = makeLog();
+
+    handleToolEvent(
+      makeEvent({
+        error: "mark_step_complete: evidence required",
+        rejectedReason: "engineering-lifecycle-evidence",
+        stepId: "step-2",
+        nextAction: "add_evidence",
+      }),
+      makeContext(log),
+    );
+
+    expect(calls).toContainEqual({
+      method: "pushInfo",
+      args: ["lifecycle: step step-2 needs evidence — next: add_evidence", "warn"],
+    });
+  });
+
+  it("logs repeated lifecycle rejection guidance", () => {
+    const { log, calls } = makeLog();
+
+    handleToolEvent(
+      makeEvent(
+        {
+          error: "delete_file: same call was just rejected",
+          rejectedReason: "engineering-lifecycle",
+          consecutiveInterceptorRejection: true,
+        },
+        "delete_file",
+      ),
+      makeContext(log),
+    );
+
+    expect(calls).toContainEqual({
+      method: "pushInfo",
+      args: ["lifecycle: repeated delete_file rejection — do not retry identical args", "warn"],
+    });
+  });
+
+  it("does not log lifecycle guidance for successful tool payloads", () => {
+    const { log, calls } = makeLog();
+
+    handleToolEvent(makeEvent({ ok: true }, "delete_file"), makeContext(log));
+
+    expect(calls.some((call) => call.method === "pushInfo")).toBe(false);
   });
 });

--- a/tests/slash.test.ts
+++ b/tests/slash.test.ts
@@ -1249,6 +1249,54 @@ describe("handleSlash", () => {
       const r = handleSlash("status", [], makeLoop(), { planMode: false });
       expect(r.info).not.toMatch(/plan\s+ON/);
     });
+
+    it("/status surfaces strict lifecycle state when enabled", () => {
+      const r = handleSlash("status", [], makeLoop(), {
+        getEngineeringLifecycleSnapshot: () => ({
+          mode: "strict",
+          state: "armed",
+          planSteps: [],
+          completedStepIds: [],
+          mutatedSinceLastStep: false,
+        }),
+      });
+
+      expect(r.info).toMatch(/lifecycle\s+strict\/armed/);
+    });
+
+    it("/status surfaces lifecycle progress and evidence pending", () => {
+      const r = handleSlash("status", [], makeLoop(), {
+        getEngineeringLifecycleSnapshot: () => ({
+          mode: "strict",
+          state: "executing",
+          planSteps: [
+            { id: "step-1", title: "Refactor", action: "Move code." },
+            { id: "step-2", title: "Verify", action: "Run tests." },
+            { id: "step-3", title: "Document", action: "Write notes." },
+          ],
+          completedStepIds: ["step-1"],
+          mutatedSinceLastStep: true,
+        }),
+      });
+
+      expect(r.info).toMatch(/lifecycle\s+strict\/executing/);
+      expect(r.info).toMatch(/1\/3/);
+      expect(r.info).toMatch(/evidence pending/);
+    });
+
+    it("/status hides lifecycle when it is off", () => {
+      const r = handleSlash("status", [], makeLoop(), {
+        getEngineeringLifecycleSnapshot: () => ({
+          mode: "off",
+          state: "idle",
+          planSteps: [],
+          completedStepIds: [],
+          mutatedSinceLastStep: false,
+        }),
+      });
+
+      expect(r.info).not.toMatch(/lifecycle/);
+    });
   });
 
   describe("/theme", () => {


### PR DESCRIPTION
## Summary
- Add a strict lifecycle line to `/status` when lifecycle rails are enabled, including state, step progress, and pending evidence.
- Surface compact scrollback hints for lifecycle gate rejections, evidence rejections, and repeated identical rejections.
- Keep the change UI-only: no runtime state-machine changes, no prompt changes, no tool/schema changes.

## Test Plan
- `npm test -- tests/handle-tool-event.test.ts tests/slash.test.ts tests/ui-reducer.test.ts`
- `npm test -- tests/lifecycle-e2e.test.ts tests/lifecycle.test.ts`
- `npm run typecheck`
- `npm run lint`
- Push hook also ran `npm run verify` successfully: build + lint + typecheck + full test suite (248 files, 3441 passed, 10 skipped).

Refs #1285