### PR TITLE
test(lifecycle): cover multi-file refactor corpus

### DIFF
--- a/tests/lifecycle-e2e.test.ts
+++ b/tests/lifecycle-e2e.test.ts
@@ -112,6 +112,109 @@ describe("strict engineering lifecycle e2e harness", () => {
     });
   });
 
+  it("covers a multi-file API refactor with move, cross-file edits, and verification evidence", async () => {
+    const harness = createStrictLifecycleHarness();
+
+    const beforePlan = await harness.dispatch("move_file", {
+      source: "src/api/user.ts",
+      destination: "src/api/users.ts",
+    });
+    expect(JSON.parse(beforePlan)).toMatchObject({
+      rejectedReason: "engineering-lifecycle",
+      state: "armed",
+      nextAction: "submit_plan",
+    });
+
+    harness.queue({ type: "approve" });
+    await harness.dispatch("submit_plan", {
+      plan: "Rename the user API module and update imports.",
+      steps: [
+        {
+          id: "step-1",
+          title: "Rename user API module",
+          action: "Move the API module, update imports, and run focused tests.",
+          risk: "med",
+          targets: ["src/api/user.ts", "src/api/users.ts", "src/routes/user-route.ts"],
+          acceptance: "All imports point at src/api/users.ts and focused API tests pass.",
+          verification: ["npm test -- tests/api-user.test.ts"],
+        },
+      ],
+    });
+
+    const move = await harness.dispatch("move_file", {
+      source: "src/api/user.ts",
+      destination: "src/api/users.ts",
+    });
+    expect(move).toBe("moved src/api/user.ts → src/api/users.ts");
+
+    const edits = await harness.dispatch("multi_edit", {
+      edits: [
+        {
+          path: "src/routes/user-route.ts",
+          search: "../api/user",
+          replace: "../api/users",
+        },
+        {
+          path: "src/api/users.ts",
+          search: "export function getUser",
+          replace: "export function getUsers",
+        },
+      ],
+    });
+    expect(edits).toBe("multi_edit: applied 2 edits across 2 files");
+    expect(harness.lifecycle.snapshot()).toMatchObject({
+      state: "executing",
+      mutatedSinceLastStep: true,
+    });
+
+    const verification = await harness.dispatch("run_command", {
+      command: "npm test -- tests/api-user.test.ts",
+      cwd: "/repo",
+    });
+    expect(verification).toBe("exit 0\nnpm test -- tests/api-user.test.ts");
+
+    const missingEvidence = await harness.dispatch("mark_step_complete", {
+      stepId: "step-1",
+      result: "Renamed the user API module and updated imports.",
+    });
+    expect(JSON.parse(missingEvidence)).toMatchObject({
+      rejectedReason: "engineering-lifecycle-evidence",
+      stepId: "step-1",
+      nextAction: "add_evidence",
+    });
+
+    harness.queue({ type: "continue" });
+    const complete = await harness.dispatch("mark_step_complete", {
+      stepId: "step-1",
+      result: "Renamed the user API module and updated imports.",
+      evidence: [
+        {
+          kind: "diff",
+          summary: "renamed API module and updated route imports",
+          paths: ["src/api/user.ts", "src/api/users.ts", "src/routes/user-route.ts"],
+        },
+        {
+          kind: "verification",
+          summary: "focused API tests passed",
+          command: "npm test -- tests/api-user.test.ts",
+        },
+      ],
+    });
+
+    expect(JSON.parse(complete)).toMatchObject({
+      kind: "step_completed",
+      stepId: "step-1",
+      evidenceSummary:
+        "diff: renamed API module and updated route imports; verification: focused API tests passed",
+    });
+    expect(harness.completions[0]?.evidence).toHaveLength(2);
+    expect(harness.lifecycle.snapshot()).toMatchObject({
+      state: "complete",
+      completedStepIds: ["step-1"],
+      mutatedSinceLastStep: false,
+    });
+  });
+
   it("preserves completed prefix through an accepted revision", async () => {
     const harness = createStrictLifecycleHarness();
     harness.queue({ type: "approve" });

--- a/tests/support/lifecycle-harness.ts
+++ b/tests/support/lifecycle-harness.ts
@@ -104,6 +104,16 @@ function registerMutationTools(registry: ToolRegistry): void {
     fn: (args: { path: string }) => `deleted ${args.path}`,
   });
   registry.register({
+    name: "move_file",
+    parameters: {
+      type: "object",
+      properties: { source: { type: "string" }, destination: { type: "string" } },
+      required: ["source", "destination"],
+    },
+    fn: (args: { source: string; destination: string }) =>
+      `moved ${args.source} → ${args.destination}`,
+  });
+  registry.register({
     name: "write_file",
     parameters: {
       type: "object",
@@ -111,5 +121,40 @@ function registerMutationTools(registry: ToolRegistry): void {
       required: ["path", "content"],
     },
     fn: (args: { path: string }) => `▸ edit blocks: 1/1 applied\n  ✓ wrote       ${args.path}`,
+  });
+  registry.register({
+    name: "multi_edit",
+    parameters: {
+      type: "object",
+      properties: {
+        edits: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              path: { type: "string" },
+              search: { type: "string" },
+              replace: { type: "string" },
+            },
+            required: ["path", "search", "replace"],
+          },
+        },
+      },
+      required: ["edits"],
+    },
+    fn: (args: { edits: Array<{ path: string; search: string; replace: string }> }) => {
+      const edits = args.edits ?? [];
+      const fileCount = new Set(edits.map((edit) => edit.path)).size;
+      return `multi_edit: applied ${edits.length} edits across ${fileCount} files`;
+    },
+  });
+  registry.register({
+    name: "run_command",
+    parameters: {
+      type: "object",
+      properties: { command: { type: "string" }, cwd: { type: "string" } },
+      required: ["command"],
+    },
+    fn: (args: { command: string }) => `exit 0\n${args.command}`,
   });
 }


### PR DESCRIPTION
## Summary
- Add deterministic strict lifecycle harness tools for `move_file`, `multi_edit`, and `run_command`.
- Add a real multi-file API refactor corpus case covering blocked pre-plan mutation, approved module move, cross-file import edits, verification command output, missing-evidence rejection, and final diff + verification evidence.
- Keep this slice test-only: no runtime semantics, prompt, or tool schema changes.

## Test Plan
- `npm test -- tests/lifecycle-e2e.test.ts`
- `npm test -- tests/lifecycle-e2e.test.ts tests/lifecycle.test.ts tests/tools.test.ts`
- `npm run typecheck`
- `npm run lint`
- Push hook ran `npm run verify` successfully: build + lint + typecheck + full test suite (248 files, 3439 passed, 10 skipped).

Refs #1285