### PR TITLE
fix(desktop): make rpc_spawn idempotent + add desktop_resync rehydrate path

### DIFF
--- a/desktop/src-tauri/src/rpc.rs
+++ b/desktop/src-tauri/src/rpc.rs
@@ -141,7 +141,10 @@ fn find_real_node() -> Result<PathBuf> {
 pub fn rpc_spawn(app: AppHandle, state: State<'_, RpcState>) -> Result<(), String> {
     let mut guard = state.inner.lock();
     if guard.is_some() {
-        return Err("rpc already spawned".into());
+        // Idempotent — a second call (effect re-run, WebView reload) keeps the
+        // existing Node child. The frontend follows up with `desktop_resync`
+        // so a reloaded React app catches up on bootstrap events it missed.
+        return Ok(());
     }
 
     let (program, args) = resolve_cli(&app).map_err(|e| e.to_string())?;

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -2985,6 +2985,14 @@ export function App() {
       cleanups.push(...subs);
       try {
         await invoke("rpc_spawn");
+        // WebView reload (DevTools F5, host respawn) keeps the Node child
+        // alive but loses every $tab_opened / $settings / $needs_setup that
+        // already fired. Ask the desktop server to re-emit them.
+        if (!cancelled) {
+          await invoke("rpc_send", {
+            line: JSON.stringify({ cmd: "desktop_resync" }),
+          });
+        }
       } catch (err) {
         if (!cancelled) console.error("rpc_spawn failed", err);
       }

--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -137,6 +137,7 @@ type InMessage = { tabId?: string } & (
   | { cmd: "compact_history" }
   | { cmd: "retry" }
   | { cmd: "btw"; text: string }
+  | { cmd: "desktop_resync" }
 );
 
 interface NeedsSetupEvent {
@@ -1899,6 +1900,28 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
       return;
     }
 
+    if (msg.cmd === "desktop_resync") {
+      // WebView reloads (DevTools F5, host-side respawn) leave the Node child
+      // alive but the React app starts blank. Re-fire the bootstrap events
+      // so it can rehydrate without restarting the agent.
+      const hasKey = !!loadApiKey();
+      for (const t of tabs.values()) {
+        emit(
+          { type: "$tab_opened", workspaceDir: t.rootDir, active: t.id === lastActiveTabId },
+          t.id,
+        );
+        emitSessions(t);
+        emitSettings(t);
+        emitMcpSpecs(t);
+        emitSkills(t);
+        emitMemory(t);
+        emitQQSettings(t);
+        if (!hasKey) emit({ type: "$needs_setup", reason: "no_api_key" }, t.id);
+        else if (t.toolset) emit({ type: "$ready" }, t.id);
+        void emitBalance(t);
+      }
+      return;
+    }
     if (msg.cmd === "jobs_list") {
       emitJobs();
       return;


### PR DESCRIPTION
## Summary
Windows users reported the desktop window booting into a near-black screen with `rpc_spawn failed: rpc already spawned` in DevTools. Two issues conspiring:

1. The Rust `rpc_spawn` command errors out if the Node child is already running. Any path that remounts the React effect (WebView reload via DevTools F5, host-side respawn, transient re-render) hits this branch and logs to console.
2. Node's bootstrap events (`\$tab_opened`, `\$settings`, `\$needs_setup`, `\$ready`) are fire-once during `bootstrapTab`. A reloaded React app never sees them — the new app instance sits in its initial state, the Setup view's structural copy renders against unset CSS variables, and the user sees a mostly-empty dark window.

Fix:
- Make `rpc_spawn` idempotent (a second call is a no-op for the spawn itself).
- Frontend follows up with a new `desktop_resync` command.
- Node handler walks every live tab and re-fires the bootstrap events. Reducers already dedupe by tab id, so the extra emit on the fresh-spawn path is harmless.

## Test plan
- [x] `npm run verify` (3431 tests) green on the push gate
- [ ] Manual: open desktop app, press F5 in DevTools → no `rpc_spawn failed` error, Setup/Main view re-bootstraps with current tab state