### PR TITLE
debug(preset): trace writeConfig + savePreset + dashboard preset writes

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 /** Library reads only DEEPSEEK_API_KEY from env; the CLI bridges config.json → env var. */
 
-import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { appendFileSync, chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import { z } from "zod";
@@ -386,12 +386,32 @@ export function readConfig(path: string = defaultConfigPath()): ReasonixConfig {
 }
 
 export function writeConfig(cfg: ReasonixConfig, path: string = defaultConfigPath()): void {
+  debugLogConfigWrite(cfg, path);
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, JSON.stringify(cfg, null, 2), "utf8");
   try {
     chmodSync(path, 0o600);
   } catch {
     /* ignore on platforms without chmod */
+  }
+}
+
+/** Every writeConfig call → append timestamp + keys + preset (if set) + stack to REASONIX_DEBUG_PRESET. Catches the bypass paths that don't go through savePreset(). Zero cost when env var is unset. */
+function debugLogConfigWrite(cfg: ReasonixConfig, configPath: string): void {
+  const debugPath = process.env.REASONIX_DEBUG_PRESET;
+  if (!debugPath) return;
+  try {
+    const stack = new Error("trace").stack ?? "";
+    const keys = Object.keys(cfg).sort().join(",");
+    const presetField = cfg.preset === undefined ? "(absent)" : JSON.stringify(cfg.preset);
+    const line = `${new Date().toISOString()} writeConfig pid=${process.pid} → ${configPath}\n  keys=[${keys}]\n  preset=${presetField}\n${stack
+      .split("\n")
+      .slice(1, 10)
+      .map((l) => `  ${l.trim()}`)
+      .join("\n")}\n\n`;
+    appendFileSync(debugPath, line);
+  } catch {
+    /* diagnostic only */
   }
 }
 
@@ -1076,9 +1096,27 @@ export function loadPreset(path: string = defaultConfigPath()): PresetName | und
 
 /** Persist preset so `/preset pro` (or `/model deepseek-v4-pro`) sticks across relaunches. */
 export function savePreset(preset: PresetName, path: string = defaultConfigPath()): void {
+  debugLogPresetWrite(preset, path);
   const cfg = readConfig(path);
   cfg.preset = preset;
   writeConfig(cfg, path);
+}
+
+/** When REASONIX_DEBUG_PRESET is set, append timestamp + value + stack to that file so we can see who/when changed preset. Zero cost when env var is unset. */
+function debugLogPresetWrite(preset: PresetName, configPath: string): void {
+  const debugPath = process.env.REASONIX_DEBUG_PRESET;
+  if (!debugPath) return;
+  try {
+    const stack = new Error("trace").stack ?? "";
+    const line = `${new Date().toISOString()} savePreset(${JSON.stringify(preset)}) → ${configPath}\n${stack
+      .split("\n")
+      .slice(1, 8)
+      .map((l) => `  ${l.trim()}`)
+      .join("\n")}\n\n`;
+    appendFileSync(debugPath, line);
+  } catch {
+    /* diagnostic only */
+  }
 }
 
 export function loadIndexUserConfig(path: string = defaultConfigPath()): IndexUserConfig {

--- a/src/server/api/settings.ts
+++ b/src/server/api/settings.ts
@@ -1,5 +1,6 @@
 /** apiKey is write-only on the wire; GET always returns a redacted form so dashboard screenshots don't leak credentials. */
 
+import { appendFileSync } from "node:fs";
 import {
   isPlausibleKey,
   normalizeSkillPathEntries,
@@ -42,6 +43,23 @@ function parseBody(raw: string): SettingsBody {
 // read time. Web sends new names in 0.12.x onward.
 const VALID_PRESETS = new Set(["auto", "flash", "pro", "fast", "smart", "max"]);
 const VALID_EFFORTS = new Set(["high", "max"]);
+
+/** Twin of `config.savePreset`'s debug hook — the dashboard PATCH writes `cfg.preset` directly (no `savePreset()` round-trip), so we instrument the bypass path too. Same env gate, same file. */
+function debugLogPresetWriteFromDashboard(preset: string): void {
+  const debugPath = process.env.REASONIX_DEBUG_PRESET;
+  if (!debugPath) return;
+  try {
+    const stack = new Error("trace").stack ?? "";
+    const line = `${new Date().toISOString()} dashboard PATCH /api/settings { preset: ${JSON.stringify(preset)} }\n${stack
+      .split("\n")
+      .slice(1, 8)
+      .map((l) => `  ${l.trim()}`)
+      .join("\n")}\n\n`;
+    appendFileSync(debugPath, line);
+  } catch {
+    /* diagnostic only */
+  }
+}
 
 export async function handleSettings(
   method: string,
@@ -139,6 +157,7 @@ export async function handleSettings(
       if (typeof fields.preset !== "string" || !VALID_PRESETS.has(fields.preset)) {
         return { status: 400, body: { error: "preset must be auto | flash | pro" } };
       }
+      debugLogPresetWriteFromDashboard(fields.preset);
       cfg.preset = fields.preset as "auto" | "flash" | "pro" | "fast" | "smart" | "max";
       presetPendingLive = fields.preset;
       changed.push("preset");


### PR DESCRIPTION
## Summary
`REASONIX_DEBUG_PRESET=<path>` turns on a timestamp + stack trace at three points so we can pin down spurious preset rewrites:

- `writeConfig()` — the ultimate disk sink, catches anything that gets there regardless of route
- `savePreset()` — the canonical preset-write entry
- the dashboard `/api/settings` PATCH branch that mutates `cfg.preset` directly (bypasses `savePreset`)

Zero-cost when the env var is unset (early return before any work).

## Test plan
- [x] `npm run verify` (3431 tests) green on the push gate
- [ ] Manual: `REASONIX_DEBUG_PRESET=/tmp/preset.log npm run chat`, change preset → log file gets entries from each pathway