### PR TITLE
fix(desktop): swallow F5 / Ctrl+R in packaged builds

### DIFF
--- a/desktop/src/main.tsx
+++ b/desktop/src/main.tsx
@@ -37,6 +37,20 @@ const platform = /Mac|macOS/i.test(navigator.userAgent)
 document.documentElement.dataset.platform = platform;
 document.body.dataset.platform = platform;
 
+// Packaged builds: block F5 / Ctrl+R — webview reload drops React state
+// and flashes white. Dev keeps the shortcuts for HMR fallback.
+if (!import.meta.env.DEV) {
+  window.addEventListener(
+    "keydown",
+    (e) => {
+      if (e.key === "F5" || ((e.ctrlKey || e.metaKey) && (e.key === "r" || e.key === "R"))) {
+        e.preventDefault();
+      }
+    },
+    { capture: true },
+  );
+}
+
 const host = document.getElementById("root");
 if (!host) throw new Error("#root missing");
 


### PR DESCRIPTION
## Summary
Windows users were hitting F5 mid-session and watching the window flash white — WebView reload drops every bit of React state (open composer, in-flight gates, undo history) for no benefit. #1428's `desktop_resync` covers the data-loss surface, but the reload-flash UX is just wrong for a packaged app. Capture-phase keydown listener in `main.tsx` calls `preventDefault()` on F5 / Ctrl+R / Cmd+R; gated on `!import.meta.env.DEV` so the dev workflow keeps the escape hatch if HMR ever gets stuck.

## Test plan
- [x] `npm run verify` (3431 tests) green on the push gate
- [ ] Manual: packaged build → F5 / Ctrl+R do nothing; `npm run dev` build → reload still works