### PR TITLE
fix(config): tolerate BOM in config.json + retire preset-trace diagnostic

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 /** Library reads only DEEPSEEK_API_KEY from env; the CLI bridges config.json → env var. */
 
-import { appendFileSync, chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import { z } from "zod";
@@ -370,7 +370,13 @@ function sanitizeStringArrayField(
 
 export function readConfig(path: string = defaultConfigPath()): ReasonixConfig {
   try {
-    const raw = readFileSync(path, "utf8");
+    // Strip the UTF-8 BOM if a foreign writer left one in — Windows
+    // PowerShell 5's `Set-Content -Encoding UTF8` and several text
+    // editors emit `EF BB BF` at the head of the file. `JSON.parse`
+    // refuses BOM-prefixed input and throws, which used to fall
+    // through to `return {}` and silently nuke every saved field on
+    // the next read-modify-write.
+    const raw = readFileSync(path, "utf8").replace(/^\uFEFF/, "");
     const parsed = JSON.parse(raw);
     if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
       const cfg = parsed as Record<string, unknown>;
@@ -386,32 +392,12 @@ export function readConfig(path: string = defaultConfigPath()): ReasonixConfig {
 }
 
 export function writeConfig(cfg: ReasonixConfig, path: string = defaultConfigPath()): void {
-  debugLogConfigWrite(cfg, path);
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, JSON.stringify(cfg, null, 2), "utf8");
   try {
     chmodSync(path, 0o600);
   } catch {
     /* ignore on platforms without chmod */
-  }
-}
-
-/** Every writeConfig call → append timestamp + keys + preset (if set) + stack to REASONIX_DEBUG_PRESET. Catches the bypass paths that don't go through savePreset(). Zero cost when env var is unset. */
-function debugLogConfigWrite(cfg: ReasonixConfig, configPath: string): void {
-  const debugPath = process.env.REASONIX_DEBUG_PRESET;
-  if (!debugPath) return;
-  try {
-    const stack = new Error("trace").stack ?? "";
-    const keys = Object.keys(cfg).sort().join(",");
-    const presetField = cfg.preset === undefined ? "(absent)" : JSON.stringify(cfg.preset);
-    const line = `${new Date().toISOString()} writeConfig pid=${process.pid} → ${configPath}\n  keys=[${keys}]\n  preset=${presetField}\n${stack
-      .split("\n")
-      .slice(1, 10)
-      .map((l) => `  ${l.trim()}`)
-      .join("\n")}\n\n`;
-    appendFileSync(debugPath, line);
-  } catch {
-    /* diagnostic only */
   }
 }
 
@@ -1096,27 +1082,9 @@ export function loadPreset(path: string = defaultConfigPath()): PresetName | und
 
 /** Persist preset so `/preset pro` (or `/model deepseek-v4-pro`) sticks across relaunches. */
 export function savePreset(preset: PresetName, path: string = defaultConfigPath()): void {
-  debugLogPresetWrite(preset, path);
   const cfg = readConfig(path);
   cfg.preset = preset;
   writeConfig(cfg, path);
-}
-
-/** When REASONIX_DEBUG_PRESET is set, append timestamp + value + stack to that file so we can see who/when changed preset. Zero cost when env var is unset. */
-function debugLogPresetWrite(preset: PresetName, configPath: string): void {
-  const debugPath = process.env.REASONIX_DEBUG_PRESET;
-  if (!debugPath) return;
-  try {
-    const stack = new Error("trace").stack ?? "";
-    const line = `${new Date().toISOString()} savePreset(${JSON.stringify(preset)}) → ${configPath}\n${stack
-      .split("\n")
-      .slice(1, 8)
-      .map((l) => `  ${l.trim()}`)
-      .join("\n")}\n\n`;
-    appendFileSync(debugPath, line);
-  } catch {
-    /* diagnostic only */
-  }
 }
 
 export function loadIndexUserConfig(path: string = defaultConfigPath()): IndexUserConfig {

--- a/src/server/api/settings.ts
+++ b/src/server/api/settings.ts
@@ -1,6 +1,5 @@
 /** apiKey is write-only on the wire; GET always returns a redacted form so dashboard screenshots don't leak credentials. */
 
-import { appendFileSync } from "node:fs";
 import {
   isPlausibleKey,
   normalizeSkillPathEntries,
@@ -43,23 +42,6 @@ function parseBody(raw: string): SettingsBody {
 // read time. Web sends new names in 0.12.x onward.
 const VALID_PRESETS = new Set(["auto", "flash", "pro", "fast", "smart", "max"]);
 const VALID_EFFORTS = new Set(["high", "max"]);
-
-/** Twin of `config.savePreset`'s debug hook — the dashboard PATCH writes `cfg.preset` directly (no `savePreset()` round-trip), so we instrument the bypass path too. Same env gate, same file. */
-function debugLogPresetWriteFromDashboard(preset: string): void {
-  const debugPath = process.env.REASONIX_DEBUG_PRESET;
-  if (!debugPath) return;
-  try {
-    const stack = new Error("trace").stack ?? "";
-    const line = `${new Date().toISOString()} dashboard PATCH /api/settings { preset: ${JSON.stringify(preset)} }\n${stack
-      .split("\n")
-      .slice(1, 8)
-      .map((l) => `  ${l.trim()}`)
-      .join("\n")}\n\n`;
-    appendFileSync(debugPath, line);
-  } catch {
-    /* diagnostic only */
-  }
-}
 
 export async function handleSettings(
   method: string,
@@ -157,7 +139,6 @@ export async function handleSettings(
       if (typeof fields.preset !== "string" || !VALID_PRESETS.has(fields.preset)) {
         return { status: 400, body: { error: "preset must be auto | flash | pro" } };
       }
-      debugLogPresetWriteFromDashboard(fields.preset);
       cfg.preset = fields.preset as "auto" | "flash" | "pro" | "fast" | "smart" | "max";
       presetPendingLive = fields.preset;
       changed.push("preset");


### PR DESCRIPTION
## Summary

Two changes:

### 1. `readConfig()` tolerates a leading UTF-8 BOM

Windows PowerShell 5's `Set-Content -Encoding UTF8` and several text editors emit `EF BB BF` at the head of the file. `JSON.parse` rejects BOM-prefixed input and throws, which fell through the existing `try { ... } catch { /* missing or malformed → empty config */ }` and returned `{}`. The next read-modify-write call (e.g. `saveEditMode`, `markEditModeHintShown`) then wrote back a config containing only the field it cared about, **silently nuking `apiKey`, `preset`, `mcp`, `setupCompleted`, and everything else**.

Reproduced reliably during a diagnostic probe session by injecting `\uFEFF` at the file head and observing every saved field collapse to three after a normal `reasonix code` run. Verified fixed with the same injection — all 13 fields survive.

The fix is one line in `readConfig`:

```diff
- const raw = readFileSync(path, "utf8");
+ const raw = readFileSync(path, "utf8").replace(/^\uFEFF/, "");
```

### 2. Drop the preset-trace diagnostic added in #1429

`debugLogConfigWrite` / `debugLogPresetWrite` / `debugLogPresetWriteFromDashboard` did their job — captured every `writeConfig` callsite, confirmed all of them preserve fields, and that no stealth save bypass exists. The original "preset flipped to pro after relaunch" report was a BOM-corruption cascade described above, not a missing instrumentation. Now that the underlying bug is fixed at the source, the hooks earn their keep no longer.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx biome check src/config.ts src/server/api/settings.ts` — clean
- [x] Manual repro: inject `EF BB BF` head into `~/.reasonix/config.json`, run `reasonix code` from the local build, exit. **Before:** config collapsed to 3 fields (`editMode`, `editModeHintShown`, `mouseClipboardHintShown`). **After:** all 13 fields preserved, BOM also stripped on next write.
