### PR TITLE
fix(ui): elide reasoning + streaming + diff content beyond the recent window

### DIFF
--- a/src/cli/ui/state/reducer.ts
+++ b/src/cli/ui/state/reducer.ts
@@ -325,37 +325,70 @@ export function reduce(state: AgentState, event: AgentEvent): AgentState {
   }
 }
 
-/** Tool outputs older than this many cards get stubbed so a 7-hour session doesn't drag GBs of one-off file reads / search results / screenshots through the heap (issue #1031). */
+/** Heavy card fields older than this many cards get stubbed so a 7-hour session doesn't drag GBs of one-off file reads / reasoning streams / diff hunks through the heap (issue #1031). */
 const RECENT_CARDS_WINDOW = 200;
-/** Don't bother eliding tiny outputs — the stub is itself ~150 chars and the savings aren't worth the lost context. */
+/** Don't bother eliding tiny payloads — the stub is itself ~150 chars and the savings aren't worth the lost context. */
 const MIN_ELIDE_OUTPUT_LENGTH = 4096;
-/** Marker for already-elided outputs so we don't re-stub on every subsequent append. */
+/** Marker for already-elided fields so we don't re-stub on every subsequent append. */
 const ELIDED_TOOL_OUTPUT_PREFIX = "[elided — older than the last ";
 
-function elideOldToolOutputs(cards: ReadonlyArray<Card>): ReadonlyArray<Card> {
-  // Caller is about to append a new card. Anticipate that — so once
+function elidedStub(originalChars: number): string {
+  return `${ELIDED_TOOL_OUTPUT_PREFIX}${RECENT_CARDS_WINDOW} cards; ${originalChars.toLocaleString()} chars dropped to save memory. Full output is on disk in the session log.]`;
+}
+
+function stubHeavyContent(c: Card): Card {
+  switch (c.kind) {
+    case "tool": {
+      const out = (c as ToolCard).output;
+      if (typeof out !== "string") return c;
+      if (out.length <= MIN_ELIDE_OUTPUT_LENGTH) return c;
+      if (out.startsWith(ELIDED_TOOL_OUTPUT_PREFIX)) return c;
+      return { ...(c as ToolCard), output: elidedStub(out.length) };
+    }
+    case "reasoning": {
+      const r = c as ReasoningCard;
+      if (r.streaming) return c;
+      if (r.text.length <= MIN_ELIDE_OUTPUT_LENGTH) return c;
+      if (r.text.startsWith(ELIDED_TOOL_OUTPUT_PREFIX)) return c;
+      return { ...r, text: elidedStub(r.text.length) };
+    }
+    case "streaming": {
+      const s = c as StreamingCard;
+      if (!s.done) return c;
+      if (s.text.length <= MIN_ELIDE_OUTPUT_LENGTH) return c;
+      if (s.text.startsWith(ELIDED_TOOL_OUTPUT_PREFIX)) return c;
+      return { ...s, text: elidedStub(s.text.length) };
+    }
+    case "diff": {
+      if (c.hunks.length === 0) return c;
+      let totalChars = 0;
+      for (const h of c.hunks) for (const l of h.lines) totalChars += l.text.length;
+      if (totalChars <= MIN_ELIDE_OUTPUT_LENGTH) return c;
+      return { ...c, hunks: [] };
+    }
+    default:
+      return c;
+  }
+}
+
+function elideOldCardContent(cards: ReadonlyArray<Card>): ReadonlyArray<Card> {
+  // Caller is about to append a new card. Anticipate that — once
   // cards.length hits the window, the very next append starts eliding.
   if (cards.length < RECENT_CARDS_WINDOW) return cards;
   const cutoff = cards.length + 1 - RECENT_CARDS_WINDOW;
   let next: Card[] | null = null;
   for (let i = 0; i < cutoff; i++) {
     const c = cards[i]!;
-    if (c.kind !== "tool") continue;
-    const out = (c as ToolCard).output;
-    if (typeof out !== "string") continue;
-    if (out.length <= MIN_ELIDE_OUTPUT_LENGTH) continue;
-    if (out.startsWith(ELIDED_TOOL_OUTPUT_PREFIX)) continue;
+    const stubbed = stubHeavyContent(c);
+    if (stubbed === c) continue;
     if (next === null) next = cards.slice();
-    next[i] = {
-      ...(c as ToolCard),
-      output: `${ELIDED_TOOL_OUTPUT_PREFIX}${RECENT_CARDS_WINDOW} cards; ${out.length.toLocaleString()} chars dropped to save memory. Full output is on disk in the session log.]`,
-    };
+    next[i] = stubbed;
   }
   return next ?? cards;
 }
 
 function appendCard(state: AgentState, card: Card): AgentState {
-  return { ...state, cards: [...elideOldToolOutputs(state.cards), card] };
+  return { ...state, cards: [...elideOldCardContent(state.cards), card] };
 }
 
 function mutateCard<K extends Card["kind"]>(

--- a/tests/cards-memory-budget.test.ts
+++ b/tests/cards-memory-budget.test.ts
@@ -1,0 +1,204 @@
+/** End-to-end memory budget for the cards store on a multi-turn session (issue #1031). Runs realistic event streams through the live reducer, then walks state.cards and reports retained bytes by kind + field — so a regression that re-grows a heavy field shows up as a budget breach instead of a silent OOM in prod. */
+
+import { describe, expect, it } from "vitest";
+import type { Card } from "../src/cli/ui/state/cards.js";
+import type { AgentEvent } from "../src/cli/ui/state/events.js";
+import { reduce } from "../src/cli/ui/state/reducer.js";
+import { type AgentState, type SessionInfo, initialState } from "../src/cli/ui/state/state.js";
+
+const session: SessionInfo = {
+  id: "mem-budget",
+  branch: "main",
+  workspace: "/tmp/repo",
+  model: "deepseek-chat",
+};
+
+/** Per-turn payload sizes calibrated to a thinking-model session (Opus-ish reasoning, mid-size tool reads). */
+const SIZES = {
+  userPrompt: 200,
+  reasoningChars: 50_000,
+  streamingChars: 15_000,
+  toolOutputChars: 25_000,
+  toolsPerTurn: 2,
+};
+
+interface SizeReport {
+  cardCount: number;
+  totalBytes: number;
+  byKind: Map<string, { count: number; bytes: number }>;
+  byField: Map<string, number>;
+}
+
+function bytesUtf8(s: string): number {
+  return Buffer.byteLength(s, "utf8");
+}
+
+function measureCards(cards: ReadonlyArray<Card>): SizeReport {
+  const byKind = new Map<string, { count: number; bytes: number }>();
+  const byField = new Map<string, number>();
+  let total = 0;
+
+  const bump = (kind: string, field: string, b: number) => {
+    const k = byKind.get(kind) ?? { count: 0, bytes: 0 };
+    k.bytes += b;
+    byKind.set(kind, k);
+    byField.set(`${kind}.${field}`, (byField.get(`${kind}.${field}`) ?? 0) + b);
+    total += b;
+  };
+
+  for (const c of cards) {
+    const k = byKind.get(c.kind) ?? { count: 0, bytes: 0 };
+    k.count++;
+    byKind.set(c.kind, k);
+    bump(c.kind, "_meta", 64);
+    bump(c.kind, "id", bytesUtf8(c.id));
+
+    switch (c.kind) {
+      case "user":
+        bump("user", "text", bytesUtf8(c.text));
+        break;
+      case "reasoning":
+        bump("reasoning", "text", bytesUtf8(c.text));
+        break;
+      case "streaming":
+        bump("streaming", "text", bytesUtf8(c.text));
+        break;
+      case "tool":
+        bump("tool", "output", bytesUtf8(c.output));
+        bump("tool", "name", bytesUtf8(c.name));
+        bump("tool", "args", bytesUtf8(JSON.stringify(c.args ?? null)));
+        break;
+      case "diff":
+        for (const h of c.hunks) {
+          bump("diff", "header", bytesUtf8(h.header));
+          for (const l of h.lines) bump("diff", "lines", bytesUtf8(l.text));
+        }
+        break;
+      default:
+        break;
+    }
+  }
+  return { cardCount: cards.length, totalBytes: total, byKind, byField };
+}
+
+function buildTurnEvents(turnIdx: number): AgentEvent[] {
+  const evs: AgentEvent[] = [];
+  const tag = `t${turnIdx}`;
+  evs.push({ type: "user.submit", text: "u".repeat(SIZES.userPrompt) });
+  evs.push({ type: "reasoning.start", id: `${tag}-r` });
+  evs.push({ type: "reasoning.chunk", id: `${tag}-r`, text: "r".repeat(SIZES.reasoningChars) });
+  evs.push({ type: "reasoning.end", id: `${tag}-r`, paragraphs: 1, tokens: 1000 });
+  evs.push({ type: "streaming.start", id: `${tag}-s` });
+  evs.push({ type: "streaming.chunk", id: `${tag}-s`, text: "s".repeat(SIZES.streamingChars) });
+  evs.push({ type: "streaming.end", id: `${tag}-s` });
+  for (let i = 0; i < SIZES.toolsPerTurn; i++) {
+    const tid = `${tag}-tool${i}`;
+    evs.push({ type: "tool.start", id: tid, name: "read_file", args: { path: "a/b/c.ts" } });
+    evs.push({
+      type: "tool.end",
+      id: tid,
+      output: "o".repeat(SIZES.toolOutputChars),
+      elapsedMs: 50,
+    });
+  }
+  return evs;
+}
+
+function runSession(turns: number): AgentState {
+  let state = initialState(session);
+  for (let t = 0; t < turns; t++) {
+    for (const ev of buildTurnEvents(t)) state = reduce(state, ev);
+  }
+  return state;
+}
+
+function rawInputBytes(turns: number): number {
+  const perTurn =
+    SIZES.userPrompt +
+    SIZES.reasoningChars +
+    SIZES.streamingChars +
+    SIZES.toolOutputChars * SIZES.toolsPerTurn;
+  return perTurn * turns;
+}
+
+function formatReport(label: string, r: SizeReport): string {
+  const mb = (b: number) => (b / 1024 / 1024).toFixed(2);
+  const lines: string[] = [];
+  lines.push(`\n--- ${label} ---`);
+  lines.push(`cards retained: ${r.cardCount}, total bytes: ${mb(r.totalBytes)} MB`);
+  const kinds = [...r.byKind.entries()].sort((a, b) => b[1].bytes - a[1].bytes);
+  for (const [kind, info] of kinds) {
+    lines.push(
+      `  ${kind.padEnd(10)} count=${String(info.count).padStart(5)}  ${mb(info.bytes).padStart(7)} MB`,
+    );
+  }
+  lines.push("  top field consumers:");
+  const fields = [...r.byField.entries()].sort((a, b) => b[1] - a[1]).slice(0, 8);
+  for (const [name, b] of fields) {
+    lines.push(`    ${name.padEnd(22)} ${mb(b).padStart(7)} MB`);
+  }
+  return lines.join("\n");
+}
+
+describe("cards memory budget end-to-end (issue #1031)", () => {
+  it("100-turn session stays well under window — every card kept full", () => {
+    const turns = 100;
+    const r = measureCards(runSession(turns).cards);
+    console.log(formatReport(`${turns}-turn session (below elision window)`, r));
+    expect(r.cardCount).toBeLessThan(600);
+    expect(r.totalBytes).toBeLessThan(rawInputBytes(turns) + 1024 * 1024);
+  });
+
+  it("1000-turn session: elision keeps retained bytes under 10% of raw input", () => {
+    const turns = 1000;
+    const r = measureCards(runSession(turns).cards);
+    const raw = rawInputBytes(turns);
+    console.log(formatReport(`${turns}-turn session (post-elision)`, r));
+    console.log(
+      `\nelided=${(r.totalBytes / 1024 / 1024).toFixed(2)} MB,  raw-input=${(raw / 1024 / 1024).toFixed(2)} MB,  saved=${(((raw - r.totalBytes) / raw) * 100).toFixed(1)}%\n`,
+    );
+    expect(r.totalBytes).toBeLessThan(raw * 0.1);
+  });
+
+  it("no single card kind retains more than the recent window's worth of full content", () => {
+    const turns = 1000;
+    const r = measureCards(runSession(turns).cards);
+    const ceiling = (kind: string, perCardBytes: number, retainedFullCards = 200) =>
+      perCardBytes * retainedFullCards + r.byKind.get(kind)!.count * 256;
+
+    expect(r.byKind.get("tool")!.bytes).toBeLessThan(ceiling("tool", SIZES.toolOutputChars));
+    expect(r.byKind.get("reasoning")!.bytes).toBeLessThan(
+      ceiling("reasoning", SIZES.reasoningChars),
+    );
+    expect(r.byKind.get("streaming")!.bytes).toBeLessThan(
+      ceiling("streaming", SIZES.streamingChars),
+    );
+  });
+
+  it("growth is sublinear past the recent window — doubling turns barely doubles bytes", () => {
+    const r1k = measureCards(runSession(1000).cards);
+    const r2k = measureCards(runSession(2000).cards);
+    const ratio = r2k.totalBytes / r1k.totalBytes;
+    console.log(
+      `1000-turn=${(r1k.totalBytes / 1024 / 1024).toFixed(2)} MB,  2000-turn=${(r2k.totalBytes / 1024 / 1024).toFixed(2)} MB,  ratio=${ratio.toFixed(2)}x`,
+    );
+    expect(ratio).toBeLessThan(1.5);
+  });
+
+  it("actual V8 heap delta on a long session stays under 100 MB (smoke check)", () => {
+    if (typeof globalThis.gc !== "function") {
+      console.log("(skipped — run with NODE_OPTIONS=--expose-gc for real heap delta)");
+      return;
+    }
+    globalThis.gc();
+    const before = process.memoryUsage().heapUsed;
+    const state = runSession(1000);
+    globalThis.gc();
+    const after = process.memoryUsage().heapUsed;
+    const deltaMB = (after - before) / 1024 / 1024;
+    console.log(
+      `V8 heap delta over 1000 turns: ${deltaMB.toFixed(1)} MB, cards retained: ${state.cards.length}`,
+    );
+    expect(deltaMB).toBeLessThan(100);
+  });
+});

--- a/tests/reducer-cards-elide.test.ts
+++ b/tests/reducer-cards-elide.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import type { ToolCard, UserCard } from "../src/cli/ui/state/cards.js";
+import type {
+  ReasoningCard,
+  StreamingCard,
+  ToolCard,
+  UserCard,
+} from "../src/cli/ui/state/cards.js";
 import type { AgentEvent } from "../src/cli/ui/state/events.js";
 import { reduce } from "../src/cli/ui/state/reducer.js";
 import { type AgentState, type SessionInfo, initialState } from "../src/cli/ui/state/state.js";
@@ -33,7 +38,27 @@ function buildBigToolEvents(count: number, idPrefix = "t"): AgentEvent[] {
   return out;
 }
 
-describe("reducer card-output elision (issue #1031 memory mitigation)", () => {
+function buildBigReasoningEvents(count: number, idPrefix = "r"): AgentEvent[] {
+  const out: AgentEvent[] = [];
+  for (let i = 0; i < count; i++) {
+    out.push({ type: "reasoning.start", id: `${idPrefix}${i}` });
+    out.push({ type: "reasoning.chunk", id: `${idPrefix}${i}`, text: `${BIG_OUTPUT}::${i}` });
+    out.push({ type: "reasoning.end", id: `${idPrefix}${i}`, paragraphs: 1, tokens: 100 });
+  }
+  return out;
+}
+
+function buildBigStreamingEvents(count: number, idPrefix = "s"): AgentEvent[] {
+  const out: AgentEvent[] = [];
+  for (let i = 0; i < count; i++) {
+    out.push({ type: "streaming.start", id: `${idPrefix}${i}` });
+    out.push({ type: "streaming.chunk", id: `${idPrefix}${i}`, text: `${BIG_OUTPUT}::${i}` });
+    out.push({ type: "streaming.end", id: `${idPrefix}${i}` });
+  }
+  return out;
+}
+
+describe("reducer card-content elision (issue #1031 memory mitigation)", () => {
   it("leaves all tool outputs intact below the recent window", () => {
     const s = run(buildBigToolEvents(50));
     for (const c of s.cards) {
@@ -48,7 +73,6 @@ describe("reducer card-output elision (issue #1031 memory mitigation)", () => {
     const total = RECENT_CARDS_WINDOW + 50;
     const s = run(buildBigToolEvents(total));
     expect(s.cards).toHaveLength(total);
-    // Cards beyond the window from the end should be stubbed.
     const cutoff = s.cards.length - RECENT_CARDS_WINDOW;
     for (let i = 0; i < cutoff; i++) {
       const c = s.cards[i]!;
@@ -58,7 +82,6 @@ describe("reducer card-output elision (issue #1031 memory mitigation)", () => {
       expect(out.length).toBeLessThan(300);
       expect(out).toMatch(/chars dropped to save memory/);
     }
-    // Recent cards stay full.
     for (let i = cutoff; i < s.cards.length; i++) {
       const c = s.cards[i] as ToolCard;
       expect(c.output.startsWith("[elided")).toBe(false);
@@ -89,7 +112,7 @@ describe("reducer card-output elision (issue #1031 memory mitigation)", () => {
     }
   });
 
-  it("only touches tool cards — user / other card kinds are untouched", () => {
+  it("user-authored text is never elided — user input is precious and small", () => {
     const events: AgentEvent[] = [];
     for (let i = 0; i < RECENT_CARDS_WINDOW + 5; i++) {
       events.push({ type: "user.submit", text: `${BIG_OUTPUT}::${i}` });
@@ -99,5 +122,70 @@ describe("reducer card-output elision (issue #1031 memory mitigation)", () => {
       expect(c.kind).toBe("user");
       expect((c as UserCard).text.startsWith("[elided")).toBe(false);
     }
+  });
+
+  it("stubs old reasoning text once the window is exceeded", () => {
+    const total = RECENT_CARDS_WINDOW + 30;
+    const s = run(buildBigReasoningEvents(total));
+    expect(s.cards).toHaveLength(total);
+    const cutoff = s.cards.length - RECENT_CARDS_WINDOW;
+    for (let i = 0; i < cutoff; i++) {
+      const c = s.cards[i] as ReasoningCard;
+      expect(c.kind).toBe("reasoning");
+      expect(c.text.startsWith("[elided")).toBe(true);
+      expect(c.text).toMatch(/chars dropped to save memory/);
+    }
+    for (let i = cutoff; i < s.cards.length; i++) {
+      const c = s.cards[i] as ReasoningCard;
+      expect(c.text.startsWith("[elided")).toBe(false);
+      expect(c.text.length).toBeGreaterThan(7000);
+    }
+  });
+
+  it("stubs old streaming text once the window is exceeded", () => {
+    const total = RECENT_CARDS_WINDOW + 30;
+    const s = run(buildBigStreamingEvents(total));
+    expect(s.cards).toHaveLength(total);
+    const cutoff = s.cards.length - RECENT_CARDS_WINDOW;
+    for (let i = 0; i < cutoff; i++) {
+      const c = s.cards[i] as StreamingCard;
+      expect(c.kind).toBe("streaming");
+      expect(c.text.startsWith("[elided")).toBe(true);
+    }
+    for (let i = cutoff; i < s.cards.length; i++) {
+      const c = s.cards[i] as StreamingCard;
+      expect(c.text.startsWith("[elided")).toBe(false);
+    }
+  });
+
+  it("never elides a reasoning card that is still streaming — chunks would append to the stub", () => {
+    const events: AgentEvent[] = [];
+    events.push({ type: "reasoning.start", id: "r-stuck" });
+    events.push({ type: "reasoning.chunk", id: "r-stuck", text: BIG_OUTPUT });
+    // r-stuck has no `reasoning.end` — still streaming.
+    for (let i = 0; i < RECENT_CARDS_WINDOW + 10; i++) {
+      events.push({ type: "user.submit", text: `msg ${i}` });
+    }
+    const s = run(events);
+    const stuck = s.cards.find((c) => c.id === "r-stuck") as ReasoningCard | undefined;
+    expect(stuck).toBeDefined();
+    expect(stuck!.streaming).toBe(true);
+    expect(stuck!.text.startsWith("[elided")).toBe(false);
+    expect(stuck!.text.length).toBeGreaterThan(7000);
+  });
+
+  it("never elides a streaming card before streaming.end — chunks would append to the stub", () => {
+    const events: AgentEvent[] = [];
+    events.push({ type: "streaming.start", id: "s-stuck" });
+    events.push({ type: "streaming.chunk", id: "s-stuck", text: BIG_OUTPUT });
+    // s-stuck has no `streaming.end` — still in flight.
+    for (let i = 0; i < RECENT_CARDS_WINDOW + 10; i++) {
+      events.push({ type: "user.submit", text: `msg ${i}` });
+    }
+    const s = run(events);
+    const stuck = s.cards.find((c) => c.id === "s-stuck") as StreamingCard | undefined;
+    expect(stuck).toBeDefined();
+    expect(stuck!.done).toBe(false);
+    expect(stuck!.text.startsWith("[elided")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Extends the existing tool-card output elision (PR #1055) to cover `reasoning.text`, `streaming.text`, and `diff.hunks` — the remaining heavy fields that the cards array held forever
- Reasoning text is the actual dominant field on thinking-model sessions (50KB-1MB per turn × thousands of turns → multi-GB before V8 gives up); leaving it un-elided is the root cause of the OOM reported in #1031
- Adds an end-to-end memory budget test that drives 1000-turn realistic sessions and asserts retained state stays under 10% of raw input bytes

## What changes

`elideOldToolOutputs` → `elideOldCardContent`. Same 200-card window, same idempotent `[elided — older than the last ` stub prefix, same on-disk-log pointer message. Now also:

- Stubs `ReasoningCard.text` once the card is past the window AND `streaming === false`
- Stubs `StreamingCard.text` once past the window AND `done === true`
- Clears `DiffCard.hunks` to `[]` (stats preserved so the +/- badge keeps rendering)

Streaming-in-flight cards are skipped so the next chunk can't land on a stub string. `UserCard.text` is left full — user input is small and precious.

## Behavior impact

None on model context. The model is fed from `AppendOnlyLog._entries` (`src/memory/runtime.ts`), which this PR does not touch. Elision applies only to `state.cards`, which is the TUI/dashboard display layer. Disk transcript JSONL (`src/transcript/log.ts`) is also untouched, so session resume gets full content back.

## Measured impact

End-to-end budget test on a 1000-turn session, 50KB reasoning + 15KB streaming + 2 × 25KB tool output per turn:

| | Retained bytes |
|---|---:|
| Raw input (what would be kept without elision) | 109.86 MB |
| After this PR | **5.42 MB** |
| Savings | **95.1%** |

Top consumers after elision (the recent 200-card window):

| Field | Retained |
|---|---:|
| `tool.output` | 2.13 MB |
| `reasoning.text` | 2.02 MB |
| `streaming.text` | 0.68 MB |
| other | < 0.6 MB |

Real V8 heap delta with `NODE_OPTIONS=--expose-gc`: **3.4 MB** over the same 1000 turns.

Sublinear growth: 1000 → 2000 turns, retained bytes go from 5.43 MB to 6.49 MB (1.20×, not 2×) — older cards stub instead of grow.

## Test plan

- [x] `npx vitest run tests/reducer-cards-elide.test.ts` — 9/9 pass (5 existing + 4 new for reasoning / streaming / streaming-in-flight)
- [x] `npx vitest run tests/cards-memory-budget.test.ts` — 5/5 pass (new e2e budget)
- [x] `npx tsc --noEmit` — clean
- [x] biome format check — clean

Closes #1031