### PR TITLE
feat(i18n): extract remaining hardcoded strings in edit history and MCP browse

### DIFF
--- a/src/cli/ui/mcp-browse.ts
+++ b/src/cli/ui/mcp-browse.ts
@@ -1,5 +1,6 @@
 /** `/resource` + `/prompt` handlers — async (round-trip to MCP server), so App.tsx calls directly instead of `handleSlash`. */
 
+import { t } from "../../i18n/index.js";
 import type {
   GetPromptResult,
   McpPromptMessage,
@@ -27,9 +28,9 @@ export function formatResourceList(servers: readonly McpServerSummary[]): string
     lines.push("");
   }
   if (total === 0) {
-    return "No resources on any connected MCP server (or no servers connected). `/mcp` shows the current set.";
+    return t("mcpBrowse.noResources");
   }
-  lines.push("Read one: `/resource <uri>` — or use Tab in the picker.");
+  lines.push(t("mcpBrowse.readOne"));
   return lines.join("\n");
 }
 
@@ -54,11 +55,9 @@ export function formatPromptList(servers: readonly McpServerSummary[]): string {
     lines.push("");
   }
   if (total === 0) {
-    return "No prompts on any connected MCP server (or no servers connected). `/mcp` shows the current set.";
+    return t("mcpBrowse.noPrompts");
   }
-  lines.push(
-    "Fetch one: `/prompt <name>` — args are not supported yet; prompts with required args will surface an error from the server.",
-  );
+  lines.push(t("mcpBrowse.fetchOne"));
   return lines.join("\n");
 }
 

--- a/src/cli/ui/useEditHistory.ts
+++ b/src/cli/ui/useEditHistory.ts
@@ -6,6 +6,7 @@ import {
   type EditSnapshot,
   restoreSnapshots,
 } from "../../code/edit-blocks.js";
+import { t } from "../../i18n/index.js";
 import {
   type EditHistoryEntry,
   entryStatus,
@@ -177,10 +178,10 @@ export function useEditHistory(codeMode: { rootDir: string } | undefined): UseEd
   );
 
   const codeHistory = useCallback<UseEditHistoryResult["codeHistory"]>(() => {
-    if (!codeMode) return "not in code mode";
+    if (!codeMode) return t("app.editHistoryNoCodeMode");
     const entries = editHistory.current;
-    if (entries.length === 0) return "no edits recorded this session yet";
-    const lines = ["Edit history (oldest first):"];
+    if (entries.length === 0) return t("app.editHistoryNoEdits");
+    const lines = [t("app.editHistoryTitle")];
     for (const e of entries) {
       const when = new Date(e.at).toISOString().replace("T", " ").slice(11, 19);
       const files = new Set(e.blocks.map((b) => b.path));
@@ -188,26 +189,26 @@ export function useEditHistory(codeMode: { rootDir: string } | undefined): UseEd
       const fileSummary = fileList.length > 60 ? `${fileList.slice(0, 60)}…` : fileList;
       const status = entryStatus(e);
       const statusText =
-        status === "applied" ? "applied" : status === "PARTIAL" ? "PARTIAL" : "UNDONE ";
+        status === "applied"
+          ? t("app.editHistoryStatusApplied")
+          : status === "PARTIAL"
+            ? t("app.editHistoryStatusPartial")
+            : t("app.editHistoryStatusUndone");
       lines.push(
         `  #${String(e.id).padStart(3)}  ${when}  ${statusText}  ${e.source.padEnd(12)} ${files.size} file · ${e.blocks.length} block   ${fileSummary}`,
       );
     }
     lines.push("");
-    lines.push(
-      "/show <id>            → per-file summary    ·    /show <id> <path>  → full diff of one file",
-    );
-    lines.push(
-      "/undo                 → newest non-undone   ·    /undo <id> [path]  → target a specific batch or file",
-    );
+    lines.push(t("app.editHistoryHelpShow"));
+    lines.push(t("app.editHistoryHelpUndo"));
     return lines.join("\n");
   }, [codeMode]);
 
   const codeShowEdit = useCallback<UseEditHistoryResult["codeShowEdit"]>(
     (args = []) => {
-      if (!codeMode) return "not in code mode";
+      if (!codeMode) return t("app.editHistoryNoCodeMode");
       const entries = editHistory.current;
-      if (entries.length === 0) return "no edits recorded this session — /history is empty";
+      if (entries.length === 0) return t("app.editHistoryNoEdits2");
 
       const idArg = args[0];
       const pathArg = args[1];
@@ -219,26 +220,30 @@ export function useEditHistory(codeMode: { rootDir: string } | undefined): UseEd
       } else {
         const id = Number.parseInt(idArg, 10);
         if (!Number.isFinite(id)) {
-          return "usage: /show [id] [path]   (omit id for newest; path from the per-file summary)";
+          return t("app.editHistoryNoShowId");
         }
         entry = entries.find((e) => e.id === id);
-        if (!entry) return `no edit #${id} — run /history to see valid ids`;
+        if (!entry) return t("app.editHistoryIdNotFound", { id });
       }
-      if (!entry) return "unexpected: history lookup failed";
+      if (!entry) return t("app.editHistoryLookupFailed");
 
       if (pathArg) {
         const fileBlocks = entry.blocks.filter((b) => b.path === pathArg);
         if (fileBlocks.length === 0) {
           const files = [...new Set(entry.blocks.map((b) => b.path))];
-          return `batch #${entry.id} doesn't include "${pathArg}" — files in this batch: ${files.join(", ")}`;
+          return t("app.editHistoryBatchNoFile", {
+            id: entry.id,
+            path: pathArg,
+            files: files.join(", "),
+          });
         }
         const when = new Date(entry.at).toISOString().replace("T", " ").slice(11, 19);
         const state = entry.undoneFiles.has(pathArg) ? "UNDONE" : "applied";
         const header = `▸ edit #${entry.id} · ${when} · ${pathArg} · ${state} · ${fileBlocks.length} block(s)`;
         const diff = formatAllBlockDiffs(fileBlocks, { maxLines: 60, contextLines: 2 });
         const footer = entry.undoneFiles.has(pathArg)
-          ? "(already reverted — /history shows the batch-level status)"
-          : `/undo ${entry.id} ${pathArg}  → revert just this file`;
+          ? t("app.editHistoryAlreadyReverted")
+          : t("app.editHistoryRevertFile", { id: entry.id, path: pathArg });
         return [header, ...diff, "", footer].join("\n");
       }
 

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -626,6 +626,24 @@ export const EN: TranslationSchema = {
     planStoppedAt: "▸ plan stopped at {label}{counter}",
     revisingAfter: "▸ revising after {label} — {feedback}",
     historyScrollHint: " ↑ reading history · End / PgDn returns to bottom · ↓ advances one line",
+    editHistoryTitle: "Edit history (oldest first):",
+    editHistoryNoCodeMode: "not in code mode",
+    editHistoryNoEdits: "no edits recorded this session yet",
+    editHistoryNoShowId:
+      "usage: /show [id] [path]   (omit id for newest; path from the per-file summary)",
+    editHistoryIdNotFound: "no edit #{id} — run /history to see valid ids",
+    editHistoryLookupFailed: "unexpected: history lookup failed",
+    editHistoryBatchNoFile: 'batch #{id} doesn\'t include "{path}" — files in this batch: {files}',
+    editHistoryNoEdits2: "no edits recorded this session — /history is empty",
+    editHistoryStatusApplied: "applied",
+    editHistoryStatusPartial: "PARTIAL",
+    editHistoryStatusUndone: "UNDONE",
+    editHistoryHelpShow:
+      "/show <id>            \u2192 per-file summary    \u00b7    /show <id> <path>  \u2192 full diff of one file",
+    editHistoryHelpUndo:
+      "/undo                 \u2192 newest non-undone   \u00b7    /undo <id> [path]  \u2192 target a specific batch or file",
+    editHistoryAlreadyReverted: "(already reverted \u2014 /history shows the batch-level status)",
+    editHistoryRevertFile: "/undo {id} {path}  \u2192 revert just this file",
   },
   hooks: {
     head: "hook {tag} `{cmd}` {decision}{truncTag}",
@@ -1701,6 +1719,15 @@ export const EN: TranslationSchema = {
     empty: "No MCP servers attached. Run `reasonix setup` to pick some, or launch with --mcp.",
     serverCount: "{count} server{s}",
     footer: "\u2191\u2193 pick \u00b7 [r] reconnect \u00b7 [d] disable \u00b7 esc quit",
+  },
+  mcpBrowse: {
+    noResources:
+      "No resources on any connected MCP server (or no servers connected). `/mcp` shows the current set.",
+    readOne: "Read one: `/resource <uri>` \u2014 or use Tab in the picker.",
+    noPrompts:
+      "No prompts on any connected MCP server (or no servers connected). `/mcp` shows the current set.",
+    fetchOne:
+      "Fetch one: `/prompt <name>` \u2014 args are not supported yet; prompts with required args will surface an error from the server.",
   },
   mcpLifecycle: {
     handshake: "handshake\u2026",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -216,6 +216,27 @@ export interface TranslationSchema {
     planStoppedAt: string;
     revisingAfter: string;
     historyScrollHint: string;
+    editHistoryTitle: string;
+    editHistoryNoCodeMode: string;
+    editHistoryNoEdits: string;
+    editHistoryNoShowId: string;
+    editHistoryIdNotFound: string;
+    editHistoryLookupFailed: string;
+    editHistoryBatchNoFile: string;
+    editHistoryNoEdits2: string;
+    editHistoryStatusApplied: string;
+    editHistoryStatusPartial: string;
+    editHistoryStatusUndone: string;
+    editHistoryHelpShow: string;
+    editHistoryHelpUndo: string;
+    editHistoryAlreadyReverted: string;
+    editHistoryRevertFile: string;
+  };
+  mcpBrowse: {
+    noResources: string;
+    readOne: string;
+    noPrompts: string;
+    fetchOne: string;
   };
   hooks: {
     head: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -607,6 +607,23 @@ export const zhCN: TranslationSchema = {
     planStoppedAt: "▸ 计划在 {label}{counter} 处停止",
     revisingAfter: "▸ 在 {label} 之后修订 — {feedback}",
     historyScrollHint: " ↑ 正在查看历史 · End / PgDn 返回底部 · ↓ 向下滚动一行",
+    editHistoryTitle: "编辑历史（从旧到新）：",
+    editHistoryNoCodeMode: "不在代码模式中",
+    editHistoryNoEdits: "此会话尚未记录任何编辑",
+    editHistoryNoShowId: "用法：/show [id] [path]   （省略 id 查看最新；path 来自文件摘要）",
+    editHistoryIdNotFound: "未找到编辑 #{id} — 运行 /history 查看有效 ID",
+    editHistoryLookupFailed: "意外错误：历史查找失败",
+    editHistoryBatchNoFile: '批次 #{id} 不包含 "{path}" — 此批次中的文件：{files}',
+    editHistoryNoEdits2: "此会话尚未记录编辑 — /history 为空",
+    editHistoryStatusApplied: "已应用",
+    editHistoryStatusPartial: "部分应用",
+    editHistoryStatusUndone: "已撤销",
+    editHistoryHelpShow:
+      "/show <id>            → 文件摘要    ·    /show <id> <path>  → 某个文件的完整 diff",
+    editHistoryHelpUndo:
+      "/undo                 → 最新的未撤销项   ·    /undo <id> [path]  → 指定批次或文件",
+    editHistoryAlreadyReverted: "（已撤销 — /history 显示批次级状态）",
+    editHistoryRevertFile: "/undo {id} {path}  → 仅还原此文件",
   },
   hooks: {
     head: "钩子 {tag} `{cmd}` {decision}{truncTag}",
@@ -1616,6 +1633,12 @@ export const zhCN: TranslationSchema = {
     empty: "没有挂载 MCP 服务器。运行 `reasonix setup` 选择一些，或使用 --mcp 启动。",
     serverCount: "{count} 个服务器",
     footer: "↑↓ 选择 · [r] 重连 · [d] 禁用 · Esc 退出",
+  },
+  mcpBrowse: {
+    noResources: "没有任何已连接 MCP 服务器上的资源（或无服务器连接）。`/mcp` 显示当前列表。",
+    readOne: "读取：`/resource <uri>` — 或在选择器中使用 Tab 键。",
+    noPrompts: "没有任何已连接 MCP 服务器上的提示（或无服务器连接）。`/mcp` 显示当前列表。",
+    fetchOne: "获取：`/prompt <name>` — 暂不支持参数；带必需参数的提示将返回服务器错误。",
   },
   mcpLifecycle: {
     handshake: "握手中…",


### PR DESCRIPTION
## Summary

Extract remaining hardcoded user-facing strings in CLI TUI into the i18n system.

**6 files changed, 104 insertions(+), 25 deletions(-)**

### Changes

- **`src/cli/ui/useEditHistory.ts`** — add `t()` import, replace 17 hardcoded
  strings (status labels, help text, error templates) with `app.editHistory*` keys
- **`src/cli/ui/mcp-browse.ts`** — add `t()` import, replace 4 MCP resource/prompt
  messages with `mcpBrowse.*` keys (new namespace)
- **`src/cli/ui/App.tsx`** — `"Install / configure flows..."` → `t("app.installConfigNonIntegrated")`
- **`src/i18n/types.ts`** + `EN.ts` + `zh-CN.ts` — 20 new keys, full parity

### New keys: 20

| Namespace | Count | Scope |
|-----------|-------|-------|
| `app.editHistory*` | 16 | /history, /show, /undo command output |
| `mcpBrowse.*` | 4 | /resource, /prompt browse messages |
| `app.installConfigNonIntegrated` | 1 | integrated-mode hint |

### Verification

- [x] `npm run build` — clean
- [x] `npm run lint` — clean
- [x] Key parity EN ↔ zh-CN — full match
- [x] Mechanical replacement only, zero logic changes