### PR TITLE
feat(slash): add /about — version, website, GitHub, license

### DIFF
--- a/src/cli/ui/slash/commands.ts
+++ b/src/cli/ui/slash/commands.ts
@@ -146,6 +146,11 @@ export const SLASH_COMMANDS: readonly SlashCommandSpec[] = [
     group: "info",
     summary: "open a GitHub issue with diagnostic info copied to clipboard",
   },
+  {
+    cmd: "about",
+    group: "info",
+    summary: "project info — version, website, repo, license",
+  },
 
   { cmd: "sessions", group: "session", summary: "list saved sessions (current marked with ▸)" },
   {

--- a/src/cli/ui/slash/handlers/basic.ts
+++ b/src/cli/ui/slash/handlers/basic.ts
@@ -1,9 +1,14 @@
 import { wrapToCells } from "@/frame/width.js";
 import { t, tObj } from "@/i18n/index.js";
+import { VERSION } from "@/version.js";
 import { formatDuration, formatLoopStatus, parseLoopCommand } from "../../loop.js";
 import { SLASH_COMMANDS, SLASH_GROUP_ORDER, orderSlashCommandsByGroup } from "../commands.js";
 import type { SlashHandler } from "../dispatch.js";
 import type { SlashCommandSpec, SlashGroup } from "../types.js";
+
+const ABOUT_WEBSITE = "https://esengine.github.io/DeepSeek-Reasonix/";
+const ABOUT_REPO = "https://github.com/esengine/DeepSeek-Reasonix";
+const ABOUT_LICENSE = "MIT";
 
 const exit: SlashHandler = () => ({ exit: true });
 
@@ -153,6 +158,17 @@ const keys: SlashHandler = (_args, _loop, ctx) => {
 
 const copy: SlashHandler = () => ({ openCopyMode: true });
 
+const about: SlashHandler = () => {
+  const lines = [
+    t("handlers.basic.aboutHeader", { version: VERSION }),
+    "",
+    `  ${t("handlers.basic.aboutWebsiteLabel")}  ${ABOUT_WEBSITE}`,
+    `  ${t("handlers.basic.aboutRepoLabel")}   ${ABOUT_REPO}`,
+    `  ${t("handlers.basic.aboutLicenseLabel")}   ${ABOUT_LICENSE}`,
+  ];
+  return { info: lines.join("\n") };
+};
+
 export const handlers: Record<string, SlashHandler> = {
   exit,
   new: resetLog,
@@ -161,4 +177,5 @@ export const handlers: Record<string, SlashHandler> = {
   loop,
   keys,
   copy,
+  about,
 };

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -339,6 +339,7 @@ export const EN: TranslationSchema = {
     },
     stop: { description: "abort the current model turn (typed alternative to Esc)" },
     feedback: { description: "open a GitHub issue with diagnostic info copied to clipboard" },
+    about: { description: "project info — version, website, repo, license" },
     keys: { description: "keyboard + mouse + copy/paste reference" },
     plans: { description: "list this session's active + archived plans, newest first" },
     replay: {
@@ -770,6 +771,10 @@ export const EN: TranslationSchema = {
       loopStarted:
         '▸ loop started — re-submitting "{prompt}" every {duration}. Type anything (or /loop stop) to cancel.',
       keysNeedsTui: "/keys needs a TUI context (postKeys wired).",
+      aboutHeader: "Reasonix v{version} — a cache-first DeepSeek coding agent",
+      aboutWebsiteLabel: "Website",
+      aboutRepoLabel: "GitHub ",
+      aboutLicenseLabel: "License",
       unknownCommand: "unknown command: /{cmd} — did you mean {list}?",
       unknownCommandShort: "unknown command: /{cmd}  (try /help)",
     },

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -328,6 +328,7 @@ export const zhCN: TranslationSchema = {
     },
     stop: { description: "中止当前模型回合（按 Esc 的替代方式）" },
     feedback: { description: "打开 GitHub Issue，诊断信息已复制到剪贴板" },
+    about: { description: "项目信息 — 版本、官网、仓库、协议" },
     plans: { description: "列出此会话的活跃 + 归档计划（最新在前）" },
     replay: {
       description: "加载归档计划为只读的时间旅行快照（默认：最新）",
@@ -735,6 +736,10 @@ export const zhCN: TranslationSchema = {
       loopStarted:
         '▸ 循环已启动 — 每 {duration} 重新提交 "{prompt}"。输入任何内容（或 /loop stop）取消。',
       keysNeedsTui: "/keys 需要 TUI 上下文（postKeys 已连接）。",
+      aboutHeader: "Reasonix v{version} — 缓存优先的 DeepSeek 编码代理",
+      aboutWebsiteLabel: "官网",
+      aboutRepoLabel: "仓库",
+      aboutLicenseLabel: "协议",
       unknownCommand: "未知命令：/{cmd} — 你是不是想用 {list}？",
       unknownCommandShort: "未知命令：/{cmd}  （试试 /help）",
     },

--- a/tests/slash.test.ts
+++ b/tests/slash.test.ts
@@ -123,6 +123,15 @@ describe("handleSlash", () => {
     expect(info.indexOf("  SETUP")).toBeLessThan(info.indexOf("  CHAT"));
   });
 
+  it("/about prints version, website, repo, and MIT license", () => {
+    const r = handleSlash("about", [], makeLoop());
+    expect(r.info).toContain(VERSION);
+    expect(r.info).toContain("https://esengine.github.io/DeepSeek-Reasonix/");
+    expect(r.info).toContain("https://github.com/esengine/DeepSeek-Reasonix");
+    expect(r.info).toContain("MIT");
+    expect(SLASH_COMMANDS.find((s) => s.cmd === "about")?.group).toBe("info");
+  });
+
   it("/title starts AI session title regeneration", async () => {
     let called = 0;
     let posted = "";
@@ -569,7 +578,7 @@ describe("handleSlash", () => {
     // Case-insensitive.
     expect(suggestSlashCommands("HE").map((s) => s.cmd)).toEqual(["help"]);
     // Empty prefix returns the full non-advanced release list, including code commands.
-    expect(suggestSlashCommands("", true)).toHaveLength(42);
+    expect(suggestSlashCommands("", true)).toHaveLength(43);
     expect(suggestSlashCommands("", true).map((s) => s.cmd)).toContain("logs");
     expect(suggestSlashCommands("", true).map((s) => s.cmd)).toContain("language");
     expect(suggestSlashCommands("lan").map((s) => s.cmd)).toContain("language");

--- a/tests/ui-slash-suggestions.test.tsx
+++ b/tests/ui-slash-suggestions.test.tsx
@@ -84,7 +84,7 @@ describe("SlashSuggestions", () => {
     );
   });
 
-  it("renders the bare slash release command surface as 42 total commands", () => {
+  it("renders the bare slash release command surface as 43 total commands", () => {
     const matches = suggestSlashCommands("", true);
     const names = matches.map((spec) => spec.cmd);
     const { lastFrame, unmount } = render(
@@ -93,11 +93,12 @@ describe("SlashSuggestions", () => {
     const frame = lastFrame() ?? "";
     unmount();
 
-    expect(matches).toHaveLength(42);
+    expect(matches).toHaveLength(43);
     expect(names).toContain("language");
     expect(names).toContain("btw");
+    expect(names).toContain("about");
     expect(countAdvancedCommands(true)).toBe(11);
-    expect(frame).toContain("42 commands");
+    expect(frame).toContain("43 commands");
     expect(frame).toContain("+ 11 advanced");
   });
 


### PR DESCRIPTION
## Summary

- Adds `/about` to the chat slash menu so users can pull up project metadata (version, website, repo, license) without leaving the TUI
- Lands under the `info` group right next to `/feedback`, so it shows up in the bare-slash browse menu by default

## Output

```
Reasonix vX.Y.Z — a cache-first DeepSeek coding agent

  Website  https://esengine.github.io/DeepSeek-Reasonix/
  GitHub   https://github.com/esengine/DeepSeek-Reasonix
  License  MIT
```

zh-CN bundle ships the localized header + row labels (官网 / 仓库 / 协议); URLs and the `MIT` tag are language-agnostic constants in the handler.

## Test plan

- [x] `tests/slash.test.ts` — new `/about prints version, website, repo, and MIT license` case + updated total-command-count assertion (42 → 43)
- [x] `tests/ui-slash-suggestions.test.tsx` — bare-slash menu now expects 43 commands and surfaces `about`
- [x] `npx tsc --noEmit` — clean