### PR TITLE
fix(desktop): autosize composer for multiline input

### DIFF
--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -2795,8 +2795,8 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
   padding: 12px 14px 6px;
   font-size: 14px;
   line-height: 1.55;
-  min-height: 24px;
-  max-height: 220px;
+  min-height: calc(5 * 1.55em + 18px);
+  overflow-y: hidden;
   font-family: inherit;
 }
 .composer textarea::placeholder {

--- a/desktop/src/ui/composer-sizing.ts
+++ b/desktop/src/ui/composer-sizing.ts
@@ -1,0 +1,46 @@
+export const DEFAULT_COMPOSER_ROWS = 5;
+export const MAX_COMPOSER_ROWS = 15;
+
+export type ComposerTextareaSizing = {
+  heightPx: number;
+  overflowY: "hidden" | "auto";
+};
+
+export function getComposerTextareaSizing({
+  contentRows,
+  lineHeightPx,
+  verticalPaddingPx,
+}: {
+  contentRows: number;
+  lineHeightPx: number;
+  verticalPaddingPx: number;
+}): ComposerTextareaSizing {
+  const safeRows = Math.max(1, Math.ceil(contentRows));
+  const visibleRows = Math.min(Math.max(safeRows, DEFAULT_COMPOSER_ROWS), MAX_COMPOSER_ROWS);
+
+  return {
+    heightPx: visibleRows * lineHeightPx + verticalPaddingPx,
+    overflowY: safeRows > MAX_COMPOSER_ROWS ? "auto" : "hidden",
+  };
+}
+
+export function applyComposerTextareaAutosize(textarea: HTMLTextAreaElement) {
+  const style = window.getComputedStyle(textarea);
+  const lineHeightPx = Number.parseFloat(style.lineHeight);
+  const paddingTopPx = Number.parseFloat(style.paddingTop);
+  const paddingBottomPx = Number.parseFloat(style.paddingBottom);
+  const verticalPaddingPx = paddingTopPx + paddingBottomPx;
+  const measuredLineHeight = Number.isFinite(lineHeightPx) ? lineHeightPx : 20;
+
+  textarea.style.height = "auto";
+  const contentRows = Math.ceil(
+    Math.max(textarea.scrollHeight - verticalPaddingPx, measuredLineHeight) / measuredLineHeight,
+  );
+  const sizing = getComposerTextareaSizing({
+    contentRows,
+    lineHeightPx: measuredLineHeight,
+    verticalPaddingPx,
+  });
+  textarea.style.height = `${sizing.heightPx}px`;
+  textarea.style.overflowY = sizing.overflowY;
+}

--- a/desktop/src/ui/composer.tsx
+++ b/desktop/src/ui/composer.tsx
@@ -3,6 +3,7 @@ import {
   type KeyboardEvent,
   type RefObject,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -11,6 +12,10 @@ import type React from "react";
 import { open as openFileDialog } from "@tauri-apps/plugin-dialog";
 import { t, type TKey } from "../i18n";
 import { I } from "../icons";
+import {
+  DEFAULT_COMPOSER_ROWS,
+  applyComposerTextareaAutosize,
+} from "./composer-sizing";
 import { fmtElapsed } from "./live";
 import { Shortcut } from "./shortcut";
 
@@ -174,6 +179,12 @@ export function Composer({
   const [modelMenuOpen, setModelMenuOpen] = useState(false);
   const nonceRef = useRef(0);
   const modelWrapRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    applyComposerTextareaAutosize(textarea);
+  });
 
   // Programmatic draft transitions to "/" (e.g. /help suggestion in EmptyState, #929) must open the slash popup, since handleChange only fires on actual user input.
   const prevDraftRef = useRef(draft);
@@ -479,7 +490,7 @@ export function Composer({
             placeholder={t("composer.placeholder")}
             onChange={handleChange}
             onKeyDown={handleKeyDown}
-            rows={2}
+            rows={DEFAULT_COMPOSER_ROWS}
             disabled={disabled}
           />
 

--- a/tests/desktop-composer-autosize.test.ts
+++ b/tests/desktop-composer-autosize.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_COMPOSER_ROWS,
+  MAX_COMPOSER_ROWS,
+  getComposerTextareaSizing,
+} from "../desktop/src/ui/composer-sizing";
+
+describe("desktop composer textarea autosize (#1420)", () => {
+  it("keeps the default height below the default row count", () => {
+    const sizing = getComposerTextareaSizing({
+      contentRows: 3,
+      lineHeightPx: 20,
+      verticalPaddingPx: 18,
+    });
+
+    expect(sizing.heightPx).toBe(DEFAULT_COMPOSER_ROWS * 20 + 18);
+    expect(sizing.overflowY).toBe("hidden");
+  });
+
+  it("expands between the default and maximum row counts", () => {
+    const sizing = getComposerTextareaSizing({
+      contentRows: 10,
+      lineHeightPx: 20,
+      verticalPaddingPx: 18,
+    });
+
+    expect(sizing.heightPx).toBe(10 * 20 + 18);
+    expect(sizing.overflowY).toBe("hidden");
+  });
+
+  it("caps at the maximum row count and enables scrolling", () => {
+    const sizing = getComposerTextareaSizing({
+      contentRows: 20,
+      lineHeightPx: 20,
+      verticalPaddingPx: 18,
+    });
+
+    expect(sizing.heightPx).toBe(MAX_COMPOSER_ROWS * 20 + 18);
+    expect(sizing.overflowY).toBe("auto");
+  });
+});


### PR DESCRIPTION
## What

Adds autosizing for the Desktop composer textarea. The input now keeps a 5-row default height, expands with multiline content up to 15 rows, and enables internal scrolling beyond that cap.

The sizing logic is extracted into a small helper with regression coverage for short, medium, and long multiline input.

## Why

Fixes #1420.

The Desktop composer previously used a fixed small textarea with a hard max-height, so longer prompts quickly became awkward to review while typing.

## How to verify

- `npm run verify`
- `npm run build --prefix desktop`
- `npx vitest run tests/desktop-composer-autosize.test.ts`
- Browser DOM smoke check against the autosize helper: 3 lines keep default height, 10 lines expand, 20 lines cap and scroll.

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time
