### PR TITLE
feat(dsnix): add shim package for shorter CLI command

### DIFF
--- a/.github/workflows/publish-dsnix.yml
+++ b/.github/workflows/publish-dsnix.yml
@@ -1,0 +1,63 @@
+name: Publish dsnix
+
+# Tag namespace: `dsnix-v<semver>` triggers npm publish for the
+# dsnix shim package only. Plain `v<semver>` tags publish the main
+# `reasonix` CLI (see publish-npm.yml); the two are decoupled so the
+# alias can be released independently when the shim itself changes.
+on:
+  push:
+    tags: ["dsnix-v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish (e.g. dsnix-v0.48.0). Required when running manually."
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: publish dsnix to npm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Setup Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          registry-url: https://registry.npmjs.org/
+
+      - name: Verify tag matches packages/dsnix/package.json version
+        shell: bash
+        run: |
+          tag="${{ github.event.inputs.tag || github.ref_name }}"
+          tag_version="${tag#dsnix-v}"
+          pkg_version=$(node -p "require('./packages/dsnix/package.json').version")
+          if [ "$tag_version" != "$pkg_version" ]; then
+            echo "::error::tag $tag (version $tag_version) does not match packages/dsnix/package.json version $pkg_version"
+            exit 1
+          fi
+          echo "tag $tag matches packages/dsnix/package.json $pkg_version"
+
+      - name: Verify reasonix@<version> is already published on npm
+        shell: bash
+        run: |
+          dep_version=$(node -p "require('./packages/dsnix/package.json').dependencies.reasonix")
+          if ! npm view "reasonix@${dep_version}" version >/dev/null 2>&1; then
+            echo "::error::dsnix depends on reasonix@${dep_version} but that version is not published yet"
+            exit 1
+          fi
+          echo "reasonix@${dep_version} is published — safe to publish dsnix"
+
+      - name: Publish dsnix to npm
+        run: npm publish --access public
+        working-directory: packages/dsnix
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "DeepSeek-native coding agent: cache-first loop, flash-first cost control, tool-call repair.",
   "type": "module",
   "bin": {
-    "reasonix": "dist/cli/index.js"
+    "reasonix": "dist/cli/index.js",
+    "dsnix": "dist/cli/index.js"
   },
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/dsnix/README.md
+++ b/packages/dsnix/README.md
@@ -1,0 +1,28 @@
+# dsnix
+
+Short alias for [`reasonix`](https://www.npmjs.com/package/reasonix) — the DeepSeek-native coding agent.
+
+This package is a thin shim. Installing or running `dsnix` resolves to the same `reasonix` CLI, just under a shorter command name.
+
+## Use
+
+```bash
+# Global install
+npm install -g dsnix
+dsnix code my-project
+
+# One-shot via npx
+npx dsnix@latest code my-project
+```
+
+Equivalent to:
+
+```bash
+npx reasonix@latest code my-project
+```
+
+## Why a separate package?
+
+`reasonix` is the canonical package; `dsnix` exists purely so users can type a shorter command and run `npx dsnix@latest` without typing nine letters. Version numbers track `reasonix` 1-to-1.
+
+For docs, config, slash commands, and everything else, see the [main Reasonix README](https://github.com/esengine/DeepSeek-Reasonix#readme).

--- a/packages/dsnix/bin.cjs
+++ b/packages/dsnix/bin.cjs
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+const { spawn } = require("node:child_process");
+
+const entry = require.resolve("reasonix/dist/cli/index.js");
+const child = spawn(process.execPath, [entry, ...process.argv.slice(2)], {
+  stdio: "inherit",
+});
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 1);
+});

--- a/packages/dsnix/package.json
+++ b/packages/dsnix/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "dsnix",
+  "version": "0.48.0",
+  "description": "Short alias for reasonix — DeepSeek-native coding agent. Forwards to the reasonix CLI.",
+  "bin": {
+    "dsnix": "bin.cjs"
+  },
+  "files": [
+    "bin.cjs",
+    "README.md"
+  ],
+  "keywords": [
+    "reasonix",
+    "deepseek",
+    "coding-agent",
+    "cli",
+    "ai",
+    "alias"
+  ],
+  "homepage": "https://github.com/esengine/DeepSeek-Reasonix",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/esengine/DeepSeek-Reasonix.git",
+    "directory": "packages/dsnix"
+  },
+  "bugs": {
+    "url": "https://github.com/esengine/DeepSeek-Reasonix/issues"
+  },
+  "license": "MIT",
+  "engines": {
+    "node": ">=22"
+  },
+  "dependencies": {
+    "reasonix": "0.48.0"
+  }
+}


### PR DESCRIPTION
## Summary
- ship `dsnix` as a shorter CLI alias for `reasonix`
- add `dsnix` bin to the main package so global installs expose both
- add new `dsnix` npm shim package so `npx dsnix@latest` resolves
- dedicated publish workflow keyed on `dsnix-v*` tags, decoupled from `v*`

## Test plan
- [ ] CI green
- [ ] After merge, tag `dsnix-v0.48.0` and confirm Publish dsnix workflow succeeds
- [ ] Verify `npx dsnix@latest code --help` works
- [ ] Verify `npm i -g reasonix` exposes both `reasonix` and `dsnix` on PATH