### PR TITLE
fix(dsnix): sync package-lock for new workspace + document alias in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,15 @@ Grab a [DeepSeek API key →](https://platform.deepseek.com/api_keys) · `reason
 
 If you use Reasonix daily, global install is the simplest path. If you just want to try it, use `npx`.
 
+**Prefer fewer keystrokes?** The shorter `dsnix` alias resolves to the same CLI:
+
+~~~bash
+npm install -g dsnix       # exposes `dsnix` on PATH, depends on reasonix
+npx dsnix@latest code      # one-shot via the shorter command
+~~~
+
+A global `npm install -g reasonix` also drops a `dsnix` shim on PATH, so the two are interchangeable.
+
 Bare `reasonix` (no subcommand) launches `code` in the current directory — typing `reasonix` and `reasonix code` are equivalent.
 
 | Command | When |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reasonix",
-  "version": "0.47.2",
+  "version": "0.48.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reasonix",
-      "version": "0.47.2",
+      "version": "0.48.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -28,6 +28,7 @@
         "zod": "^4.4.1"
       },
       "bin": {
+        "dsnix": "dist/cli/index.js",
         "reasonix": "dist/cli/index.js"
       },
       "devDependencies": {
@@ -3176,6 +3177,10 @@
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
+    "node_modules/dsnix": {
+      "resolved": "packages/dsnix",
+      "link": true
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -4831,6 +4836,37 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/reasonix": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/reasonix/-/reasonix-0.48.0.tgz",
+      "integrity": "sha512-Y7WRpqONVV+OrrvEecRRUs8U9LpvFhufmi2w4XXuZkR8rWN5n0NcosB8+Zn00YQFW2JI9N2lbHLXWJtBk+jZtw==",
+      "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
+      "dependencies": {
+        "cli-highlight": "^2.1.11",
+        "commander": "^12.1.0",
+        "eventsource-parser": "^3.0.0",
+        "ignore": "^7.0.5",
+        "ink": "^7.0.2",
+        "ink-text-input": "^6.0.0",
+        "node-html-parser": "^7.1.0",
+        "picomatch": "^4.0.4",
+        "react": "^19.2.6",
+        "string-width": "^7.2.0",
+        "undici": "^8.2.0",
+        "web-tree-sitter": "^0.26.9",
+        "ws": "^8.20.1",
+        "zod": "^4.4.1"
+      },
+      "bin": {
+        "reasonix": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/require-directory": {
@@ -7220,6 +7256,19 @@
       "devDependencies": {
         "@types/node": "^22.9.0",
         "typescript": "^5.6.3"
+      }
+    },
+    "packages/dsnix": {
+      "version": "0.48.0",
+      "license": "MIT",
+      "dependencies": {
+        "reasonix": "0.48.0"
+      },
+      "bin": {
+        "dsnix": "bin.cjs"
+      },
+      "engines": {
+        "node": ">=22"
       }
     }
   }


### PR DESCRIPTION
## Summary
- regenerate `package-lock.json` to include the new `dsnix` workspace — main CI is red after #1440 because `npm ci` rejects a lock file that doesn't match `package.json`
- extend the README install section with the `dsnix` one-liner (global + `npx`) so the shorter command is discoverable

## Test plan
- [ ] CI green (the actual point of this PR)
- [ ] `npm ci` works from a clean clone

Follow-up to #1440.