### PR TITLE
fix: resolve root-relative edit block paths

### DIFF
--- a/src/code/edit-blocks.ts
+++ b/src/code/edit-blocks.ts
@@ -146,10 +146,16 @@ export function applyEditBlock(block: EditBlock, rootDir: string): ApplyResult {
           message: "SEARCH text does not match the current file content exactly",
         };
       }
-      // Replace only the first occurrence — if the model needs multiple
-      // identical edits it should emit multiple blocks (each anchored by
-      // more surrounding context). Auto-expanding to replace-all is a
-      // footgun when the same string legitimately appears in several
+      const nextIdx = content.indexOf(adaptedSearch, idx + 1);
+      if (nextIdx !== -1) {
+        return {
+          path: block.path,
+          status: "not-found",
+          message: "SEARCH text appears multiple times; include more context to disambiguate",
+        };
+      }
+      // Apply one unambiguous occurrence. Auto-expanding to replace-all is
+      // a footgun when the same string legitimately appears in several
       // unrelated places.
       const replaced = `${content.slice(0, idx)}${adaptedReplace}${content.slice(idx + adaptedSearch.length)}`;
       // Truncate first so a shorter result doesn't leave stale tail

--- a/src/code/edit-blocks.ts
+++ b/src/code/edit-blocks.ts
@@ -227,10 +227,12 @@ export interface EditSnapshot {
 
 /** De-duped by path — one "before" snapshot per file even with multiple blocks. */
 export function snapshotBeforeEdits(blocks: EditBlock[], rootDir: string): EditSnapshot[] {
+  const absRoot = resolve(rootDir);
   const seen = new Set<string>();
   const snapshots: EditSnapshot[] = [];
   for (const b of blocks) {
     const abs = resolveEditPath(rootDir, b.path);
+    if (!pathIsUnder(abs, absRoot)) continue;
     if (seen.has(abs)) continue;
     seen.add(abs);
     if (!existsSync(abs)) {

--- a/src/code/edit-blocks.ts
+++ b/src/code/edit-blocks.ts
@@ -13,7 +13,7 @@ import {
   writeFileSync,
   writeSync,
 } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { dirname, isAbsolute, relative, resolve } from "node:path";
 
 export interface EditBlock {
   /** Path as written by the model — relative to rootDir, or absolute. */
@@ -67,12 +67,35 @@ export function parseEditBlocks(text: string): EditBlock[] {
   return out;
 }
 
+function resolveEditPath(rootDir: string, rawPath: string): string {
+  const absRoot = resolve(rootDir);
+  if (/^[A-Za-z]:[\\/]/.test(rawPath) || looksLikeAbsoluteSystemPath(rawPath)) {
+    return resolve(rawPath);
+  }
+  let rooted = rawPath;
+  while (rooted.startsWith("/") || rooted.startsWith("\\")) {
+    rooted = rooted.slice(1);
+  }
+  return resolve(absRoot, rooted || ".");
+}
+
+function looksLikeAbsoluteSystemPath(rawPath: string): boolean {
+  return /^\/(?:home|Users|etc|var|opt|tmp|usr|mnt|Library|Volumes|proc|sys|dev|run|srv|media|Applications|System|root|boot|private)(?:[/\\]|$)/.test(
+    rawPath,
+  );
+}
+
+function pathIsUnder(child: string, parent: string): boolean {
+  const rel = relative(parent, child);
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}
+
 export function applyEditBlock(block: EditBlock, rootDir: string): ApplyResult {
   const absRoot = resolve(rootDir);
-  const absTarget = resolve(absRoot, block.path);
+  const absTarget = resolveEditPath(rootDir, block.path);
   // Refuse paths that escape rootDir. `resolve` normalizes `..`, so
-  // startsWith on the normalized pair is enough.
-  if (absTarget !== absRoot && !absTarget.startsWith(`${absRoot}${sep()}`)) {
+  // relative-path containment avoids prefix false positives.
+  if (!pathIsUnder(absTarget, absRoot)) {
     return {
       path: block.path,
       status: "path-escape",
@@ -183,7 +206,7 @@ export function applyEditBlocks(blocks: EditBlock[], rootDir: string): ApplyResu
 }
 
 export function toWholeFileEditBlock(path: string, content: string, rootDir: string): EditBlock {
-  const abs = resolve(rootDir, path);
+  const abs = resolveEditPath(rootDir, path);
   let search = "";
   if (existsSync(abs)) {
     try {
@@ -204,13 +227,12 @@ export interface EditSnapshot {
 
 /** De-duped by path — one "before" snapshot per file even with multiple blocks. */
 export function snapshotBeforeEdits(blocks: EditBlock[], rootDir: string): EditSnapshot[] {
-  const absRoot = resolve(rootDir);
   const seen = new Set<string>();
   const snapshots: EditSnapshot[] = [];
   for (const b of blocks) {
-    if (seen.has(b.path)) continue;
-    seen.add(b.path);
-    const abs = resolve(absRoot, b.path);
+    const abs = resolveEditPath(rootDir, b.path);
+    if (seen.has(abs)) continue;
+    seen.add(abs);
     if (!existsSync(abs)) {
       snapshots.push({ path: b.path, prevContent: null });
       continue;
@@ -231,8 +253,8 @@ export function snapshotBeforeEdits(blocks: EditBlock[], rootDir: string): EditS
 export function restoreSnapshots(snapshots: EditSnapshot[], rootDir: string): ApplyResult[] {
   const absRoot = resolve(rootDir);
   return snapshots.map((snap) => {
-    const abs = resolve(absRoot, snap.path);
-    if (abs !== absRoot && !abs.startsWith(`${absRoot}${sep()}`)) {
+    const abs = resolveEditPath(rootDir, snap.path);
+    if (!pathIsUnder(abs, absRoot)) {
       return {
         path: snap.path,
         status: "path-escape",
@@ -258,11 +280,6 @@ export function restoreSnapshots(snapshots: EditSnapshot[], rootDir: string): Ap
       return { path: snap.path, status: "error", message: (err as Error).message };
     }
   });
-}
-
-/** Platform separator — `\` on Windows, `/` elsewhere. */
-function sep(): string {
-  return process.platform === "win32" ? "\\" : "/";
 }
 
 function lineEndingOf(text: string): string {

--- a/tests/edit-blocks.test.ts
+++ b/tests/edit-blocks.test.ts
@@ -155,15 +155,15 @@ describe("applyEditBlock", () => {
     expect(existsSync(join(root, "..", "escape.txt"))).toBe(false);
   });
 
-  it("replaces only the first occurrence when SEARCH appears twice", () => {
+  it("refuses ambiguous SEARCH text that appears twice", () => {
     writeFileSync(join(root, "a.txt"), "foo bar foo\n", "utf8");
     const result = applyEditBlock(
       { path: "a.txt", search: "foo", replace: "FOO", offset: 0 },
       root,
     );
-    expect(result.status).toBe("applied");
-    // First "foo" replaced, second left alone.
-    expect(readFileSync(join(root, "a.txt"), "utf8")).toBe("FOO bar foo\n");
+    expect(result.status).toBe("not-found");
+    expect(result.message).toMatch(/multiple times/);
+    expect(readFileSync(join(root, "a.txt"), "utf8")).toBe("foo bar foo\n");
   });
 
   it("matches LF search against CRLF file content", () => {

--- a/tests/edit-blocks.test.ts
+++ b/tests/edit-blocks.test.ts
@@ -266,6 +266,22 @@ describe("snapshotBeforeEdits + restoreSnapshots", () => {
     expect(snaps[0]!.prevContent).toBe("one two three\n");
   });
 
+  it("does not snapshot paths outside rootDir before apply rejects them", () => {
+    const outside = resolve(root, "..", "outside-secret.txt");
+    writeFileSync(outside, "SECRET_OUTSIDE_WORKSPACE", "utf8");
+    try {
+      const block = { path: outside, search: "SECRET", replace: "PUBLIC", offset: 0 };
+      const snaps = snapshotBeforeEdits([block], root);
+      const [result] = applyEditBlocks([block], root);
+
+      expect(snaps).toEqual([]);
+      expect(result!.status).toBe("path-escape");
+      expect(readFileSync(outside, "utf8")).toBe("SECRET_OUTSIDE_WORKSPACE");
+    } finally {
+      rmSync(outside, { force: true });
+    }
+  });
+
   it("restores multiple files in a single batch independently", () => {
     writeFileSync(join(root, "a.txt"), "aa\n", "utf8");
     writeFileSync(join(root, "b.txt"), "bb\n", "utf8");

--- a/tests/edit-blocks.test.ts
+++ b/tests/edit-blocks.test.ts
@@ -2,7 +2,7 @@
 
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   applyEditBlock,
@@ -117,6 +117,42 @@ describe("applyEditBlock", () => {
     expect(readFileSync(join(root, "a.txt"), "utf8")).toBe("goodbye world\n");
   });
 
+  it("treats leading slash paths as project-root relative", () => {
+    writeFileSync(join(root, "a.txt"), "hello world\n", "utf8");
+    const result = applyEditBlock(
+      { path: "/a.txt", search: "hello", replace: "goodbye", offset: 0 },
+      root,
+    );
+    expect(result.status).toBe("applied");
+    expect(readFileSync(join(root, "a.txt"), "utf8")).toBe("goodbye world\n");
+  });
+
+  it("allows real absolute paths when they stay inside rootDir", () => {
+    const absPath = join(root, "a.txt");
+    writeFileSync(absPath, "hello world\n", "utf8");
+    const result = applyEditBlock(
+      { path: absPath, search: "hello", replace: "goodbye", offset: 0 },
+      root,
+    );
+    expect(result.status).toBe("applied");
+    expect(readFileSync(absPath, "utf8")).toBe("goodbye world\n");
+  });
+
+  it("refuses real absolute paths outside rootDir", () => {
+    const outside = resolve(root, "..", "outside.txt");
+    writeFileSync(outside, "hello world\n", "utf8");
+    try {
+      const result = applyEditBlock(
+        { path: outside, search: "hello", replace: "goodbye", offset: 0 },
+        root,
+      );
+      expect(result.status).toBe("path-escape");
+      expect(readFileSync(outside, "utf8")).toBe("hello world\n");
+    } finally {
+      rmSync(outside, { force: true });
+    }
+  });
+
   it("creates a new file when SEARCH is empty and file doesn't exist", () => {
     const result = applyEditBlock(
       { path: "new/nested/file.ts", search: "", replace: "export const x = 1;\n", offset: 0 },
@@ -223,7 +259,7 @@ describe("snapshotBeforeEdits + restoreSnapshots", () => {
     writeFileSync(join(root, "a.txt"), "one two three\n", "utf8");
     const blocks = [
       { path: "a.txt", search: "one", replace: "ONE", offset: 0 },
-      { path: "a.txt", search: "two", replace: "TWO", offset: 10 },
+      { path: "/a.txt", search: "two", replace: "TWO", offset: 10 },
     ];
     const snaps = snapshotBeforeEdits(blocks, root);
     expect(snaps).toHaveLength(1); // not 2 — same file


### PR DESCRIPTION
<!-- Read CONTRIBUTING.md first if this is your first PR. -->

## What

Fix text edit block path resolution so leading-slash paths like `/src/foo.ts` are treated as project-root relative, matching code-mode filesystem path conventions. The change also keeps real absolute paths subject to sandbox checks and deduplicates edit snapshots by resolved path.

## Why

The code-mode prompt documents `/<path>` as project-root relative, but `/apply` previously resolved edit block paths with Node's `path.resolve(rootDir, block.path)`. That made `/src/foo.ts` resolve to the filesystem root instead of the workspace, causing valid edit blocks to be rejected as `path-escape`.

## How to verify

```sh
npm test -- tests/edit-blocks.test.ts