### PR TITLE
fix(preflight): gate on JSON body bytes, not just tokens

### DIFF
--- a/src/context-manager.ts
+++ b/src/context-manager.ts
@@ -19,22 +19,41 @@ import {
 } from "./tokenizer.js";
 import type { ChatMessage } from "./types.js";
 
+function envFraction(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 && n <= 1 ? n : fallback;
+}
+
 /** Auto-fold when a turn's response shows promptTokens above this fraction of ctxMax. */
-export const HISTORY_FOLD_THRESHOLD = 0.5;
+export const HISTORY_FOLD_THRESHOLD = envFraction("REASONIX_FOLD_THRESHOLD", 0.5);
 /** Tail budget after a normal fold, as a fraction of ctxMax. */
-export const HISTORY_FOLD_TAIL_FRACTION = 0.2;
+export const HISTORY_FOLD_TAIL_FRACTION = envFraction("REASONIX_FOLD_TAIL_FRACTION", 0.2);
 /** Above this fraction the normal fold's tail budget didn't buy enough headroom — fold harder. */
-export const HISTORY_FOLD_AGGRESSIVE_THRESHOLD = 0.7;
+export const HISTORY_FOLD_AGGRESSIVE_THRESHOLD = envFraction(
+  "REASONIX_FOLD_AGGRESSIVE_THRESHOLD",
+  0.7,
+);
 /** Tail budget after an aggressive fold — half the normal one, sacrifices recent context for headroom. */
-export const HISTORY_FOLD_AGGRESSIVE_TAIL_FRACTION = 0.1;
+export const HISTORY_FOLD_AGGRESSIVE_TAIL_FRACTION = envFraction(
+  "REASONIX_FOLD_AGGRESSIVE_TAIL_FRACTION",
+  0.1,
+);
 /** Skip the fold if the head wouldn't shrink the log by at least this fraction. */
 export const HISTORY_FOLD_MIN_SAVINGS_FRACTION = 0.3;
 /** Above this fraction we exit the turn with a summary instead of folding (defense in depth). */
-export const FORCE_SUMMARY_THRESHOLD = 0.8;
+export const FORCE_SUMMARY_THRESHOLD = envFraction("REASONIX_FORCE_SUMMARY_THRESHOLD", 0.8);
 /** Local preflight estimate above this fraction trips the emergency in-place compact path. */
 export const PREFLIGHT_EMERGENCY_THRESHOLD = 0.95;
 /** Emergency preflight target after local truncation, as a fraction of ctxMax. */
 export const PREFLIGHT_MECHANICAL_TARGET_FRACTION = 0.7;
+/** Hard ceiling on JSON body bytes — DeepSeek's gateway 400s on bodies past ~880 KB with a cryptic
+ * `unexpected end of hex escape` truncation error. Token preflight alone misses this because the
+ * model's 1M-token context window is far wider than the gateway's body limit. */
+export const MAX_BODY_BYTES = 700_000;
+/** Target body size after mechanical truncate when bytes — not tokens — were the trigger. */
+export const MAX_BODY_BYTES_TARGET = 500_000;
 /** Hard deadline for semantic fold summaries so a hung request cannot stall the turn loop. */
 export const HISTORY_FOLD_SUMMARY_TIMEOUT_MS = 15_000;
 /** Prepended to fold summary content so the model knows it's a synthesized recap. */
@@ -70,7 +89,10 @@ export interface PostUsageDecision {
 export interface PreflightDecision {
   needsAction: boolean;
   estimateTokens: number;
+  estimateBytes: number;
   ctxMax: number;
+  /** Which signal tripped `needsAction`. `"none"` when below both thresholds. */
+  trigger: "none" | "tokens" | "bytes" | "both";
 }
 
 export interface FoldResult {
@@ -151,7 +173,9 @@ export class ContextManager {
     return { kind: "none", ...base };
   }
 
-  /** Local-side preflight before sending a request — catches oversized payloads early. */
+  /** Local-side preflight before sending a request — catches oversized payloads early.
+   * Two independent signals trip mechanical truncate: token estimate above the context-window
+   * fraction, OR JSON body bytes above the gateway limit (see `MAX_BODY_BYTES`). */
   decidePreflight(
     messages: ChatMessage[],
     toolSpecs: ReadonlyArray<unknown> | undefined | null,
@@ -159,10 +183,19 @@ export class ContextManager {
   ): PreflightDecision {
     const ctxMax = DEEPSEEK_CONTEXT_TOKENS[model] ?? DEFAULT_CONTEXT_TOKENS;
     const estimate = estimateRequestTokens(messages, toolSpecs ?? null, true);
+    const estimateBytes = Buffer.byteLength(JSON.stringify(messages), "utf8");
+    const tokensOver = estimate / ctxMax > PREFLIGHT_EMERGENCY_THRESHOLD;
+    const bytesOver = estimateBytes > MAX_BODY_BYTES;
+    let trigger: PreflightDecision["trigger"] = "none";
+    if (tokensOver && bytesOver) trigger = "both";
+    else if (tokensOver) trigger = "tokens";
+    else if (bytesOver) trigger = "bytes";
     return {
-      needsAction: estimate / ctxMax > PREFLIGHT_EMERGENCY_THRESHOLD,
+      needsAction: tokensOver || bytesOver,
       estimateTokens: estimate,
+      estimateBytes,
       ctxMax,
+      trigger,
     };
   }
 
@@ -225,14 +258,17 @@ export class ContextManager {
     };
   }
 
-  /** Pure local emergency compaction for preflight: drop oldest log entries and keep a valid tail. */
+  /** Pure local emergency compaction for preflight: drop oldest log entries and keep a valid tail.
+   * Bounded by tokens AND bytes — bytes matter because DeepSeek's gateway 400s on bodies past
+   * `MAX_BODY_BYTES` even when the token budget is far from exhausted. */
   mechanicalTruncate(
     model: string,
-    opts?: { targetTokens?: number; allowEmpty?: boolean },
+    opts?: { targetTokens?: number; targetBytes?: number; allowEmpty?: boolean },
   ): FoldResult {
     const ctxMax = DEEPSEEK_CONTEXT_TOKENS[model] ?? DEFAULT_CONTEXT_TOKENS;
     const targetTokens =
       opts?.targetTokens ?? Math.floor(ctxMax * PREFLIGHT_MECHANICAL_TARGET_FRACTION);
+    const targetBytes = opts?.targetBytes ?? MAX_BODY_BYTES_TARGET;
     const all = this.deps.log.toMessages();
     const noop: FoldResult = {
       folded: false,
@@ -243,6 +279,7 @@ export class ContextManager {
     if (all.length === 0) return noop;
 
     const tokenCounts = all.map((m) => estimateConversationTokens([m], true));
+    const byteCounts = all.map((m) => Buffer.byteLength(JSON.stringify(m), "utf8"));
     let latestUserBoundary = -1;
     for (let i = all.length - 1; i >= 0; i--) {
       if (all[i]!.role === "user") {
@@ -251,12 +288,15 @@ export class ContextManager {
       }
     }
     let cumTokens = 0;
+    let cumBytes = 0;
     let boundary = all.length;
     let foundSafeBoundary = false;
     for (let i = all.length - 1; i >= 0; i--) {
-      const next = cumTokens + tokenCounts[i]!;
-      if (next > targetTokens) break;
-      cumTokens = next;
+      const nextTokens = cumTokens + tokenCounts[i]!;
+      const nextBytes = cumBytes + byteCounts[i]!;
+      if (nextTokens > targetTokens || nextBytes > targetBytes) break;
+      cumTokens = nextTokens;
+      cumBytes = nextBytes;
       if (all[i]!.role === "user") {
         boundary = i;
         foundSafeBoundary = true;

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -672,11 +672,11 @@ export const EN: TranslationSchema = {
     toolUploadStatus: "tool result uploaded · model thinking before next response…",
     preflightTruncateStatus: "preflight: context near full, truncating oldest history…",
     preflightTruncated:
-      "preflight: request ~{estimate}/{ctxMax} tokens ({pct}%) — truncated {beforeMessages} messages → {afterMessages}. Sending.",
+      "preflight: request ~{estimate}/{ctxMax} tokens ({pct}%) · body {bodyKB} KB — truncated {beforeMessages} messages → {afterMessages}. Sending.",
     preflightTruncatedStillFull:
-      "preflight: request still ~{estimate}/{ctxMax} tokens ({pct}%) after truncating {beforeMessages} messages → {afterMessages}. DeepSeek will likely 400. Run /clear or /new to start fresh.",
+      "preflight: request still ~{estimate}/{ctxMax} tokens ({pct}%) · body {bodyKB} KB after truncating {beforeMessages} messages → {afterMessages}. DeepSeek will likely 400. Run /clear or /new to start fresh.",
     preflightNoFold:
-      "preflight: request ~{estimate}/{ctxMax} tokens ({pct}%) and nothing left to truncate — DeepSeek will likely 400. Run /clear or /new to start fresh.",
+      "preflight: request ~{estimate}/{ctxMax} tokens ({pct}%) · body {bodyKB} KB and nothing left to truncate — DeepSeek will likely 400. Run /clear or /new to start fresh.",
     flashEscalation: "⇧ flash requested escalation — retrying this turn on {model}{reasonSuffix}",
     harvestStatus: "extracting plan state from reasoning…",
     repeatToolCallWarning:

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -651,11 +651,11 @@ export const zhCN: TranslationSchema = {
     toolUploadStatus: "工具结果已上传 · 模型在生成下一条响应前思考中…",
     preflightTruncateStatus: "预检：上下文接近上限，正在裁剪最早历史…",
     preflightTruncated:
-      "预检：请求约 {estimate}/{ctxMax} tokens（{pct}%）— 已裁剪 {beforeMessages} 条消息 → {afterMessages}。发送中。",
+      "预检：请求约 {estimate}/{ctxMax} tokens（{pct}%）· body {bodyKB} KB — 已裁剪 {beforeMessages} 条消息 → {afterMessages}。发送中。",
     preflightTruncatedStillFull:
-      "预检：裁剪 {beforeMessages} 条消息 → {afterMessages} 后，请求仍约 {estimate}/{ctxMax} tokens（{pct}%）— DeepSeek 大概率会返回 400。请运行 /clear 或 /new 重新开始。",
+      "预检：裁剪 {beforeMessages} 条消息 → {afterMessages} 后，请求仍约 {estimate}/{ctxMax} tokens（{pct}%）· body {bodyKB} KB — DeepSeek 大概率会返回 400。请运行 /clear 或 /new 重新开始。",
     preflightNoFold:
-      "预检：请求约 {estimate}/{ctxMax} tokens（{pct}%）且没有可裁剪的内容 — DeepSeek 大概率会返回 400。请运行 /clear 或 /new 重新开始。",
+      "预检：请求约 {estimate}/{ctxMax} tokens（{pct}%）· body {bodyKB} KB 且没有可裁剪的内容 — DeepSeek 大概率会返回 400。请运行 /clear 或 /new 重新开始。",
     flashEscalation: "⇧ flash 请求升级 — 本轮改用 {model}{reasonSuffix}",
     harvestStatus: "正在从推理过程提取计划状态…",
     repeatToolCallWarning: "拦截到重复工具调用 — 让模型察觉问题并换种方式重试。",

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -731,7 +731,7 @@ export class CacheFirstLoop {
       {
         const decision = this.context.decidePreflight(messages, this.prefix.toolSpecs, this.model);
         if (decision.needsAction) {
-          const { estimateTokens: estimate, ctxMax } = decision;
+          const { estimateTokens: estimate, estimateBytes, ctxMax } = decision;
           yield {
             turn: this._turn,
             role: "status",
@@ -753,6 +753,7 @@ export class CacheFirstLoop {
                   estimate: after.estimateTokens.toLocaleString(),
                   ctxMax: after.ctxMax.toLocaleString(),
                   pct: Math.round((after.estimateTokens / after.ctxMax) * 100),
+                  bodyKB: Math.round(after.estimateBytes / 1024).toLocaleString(),
                   beforeMessages: result.beforeMessages,
                   afterMessages: result.afterMessages,
                 },
@@ -766,6 +767,7 @@ export class CacheFirstLoop {
                 estimate: estimate.toLocaleString(),
                 ctxMax: ctxMax.toLocaleString(),
                 pct: Math.round((estimate / ctxMax) * 100),
+                bodyKB: Math.round(estimateBytes / 1024).toLocaleString(),
               }),
             };
           }

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -1,12 +1,15 @@
 /** CacheFirstLoop integration — fake-fetch DeepSeekClient, non-streaming path. */
 
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { DeepSeekClient, Usage } from "../src/client.js";
 import { type ConfirmationChoice, PauseGate } from "../src/core/pause-gate.js";
 import { CacheFirstLoop } from "../src/loop.js";
 import { ImmutablePrefix } from "../src/memory/runtime.js";
+import { DEEPSEEK_CONTEXT_TOKENS } from "../src/telemetry/stats.js";
 import { ToolRegistry } from "../src/tools.js";
 import type { ChatMessage } from "../src/types.js";
+
+const FOLD_TEST_MODEL = "test-fold-ctx";
 
 interface FakeResponseShape {
   content?: string;
@@ -56,6 +59,10 @@ function makeClient(responses: FakeResponseShape[]) {
 }
 
 describe("CacheFirstLoop (non-streaming)", () => {
+  afterEach(() => {
+    delete DEEPSEEK_CONTEXT_TOKENS[FOLD_TEST_MODEL];
+  });
+
   it("completes a single-turn plain chat", async () => {
     const client = makeClient([{ content: "hi there" }]);
     const loop = new CacheFirstLoop({
@@ -604,6 +611,9 @@ describe("CacheFirstLoop (non-streaming)", () => {
   });
 
   it("auto-folds history when promptTokens crosses 50% of ctxMax", async () => {
+    // Shrink ctxMax so the seed log can trip the auto-fold threshold without
+    // also exceeding the preflight byte ceiling (~700 KB by default).
+    DEEPSEEK_CONTEXT_TOKENS[FOLD_TEST_MODEL] = 100_000;
     const reg = new ToolRegistry();
     reg.register({
       name: "probe",
@@ -612,16 +622,16 @@ describe("CacheFirstLoop (non-streaming)", () => {
       fn: async () => "ok",
     });
     const responses: FakeResponseShape[] = [
-      // Iter 0: tool call with usage above 50% of 1M ctx.
+      // Iter 0: tool call with usage above 50% of the 100k test ctx.
       {
         content: "",
         tool_calls: [{ id: "c1", type: "function", function: { name: "probe", arguments: "{}" } }],
         usage: {
-          prompt_tokens: 600_000,
+          prompt_tokens: 60_000,
           completion_tokens: 10,
-          total_tokens: 600_010,
-          prompt_cache_hit_tokens: 500_000,
-          prompt_cache_miss_tokens: 100_000,
+          total_tokens: 60_010,
+          prompt_cache_hit_tokens: 50_000,
+          prompt_cache_miss_tokens: 10_000,
         },
       },
       // Summary call response (compactHistory).
@@ -636,12 +646,12 @@ describe("CacheFirstLoop (non-streaming)", () => {
       tools: reg,
       stream: false,
       maxToolIters: 8,
+      model: FOLD_TEST_MODEL,
     });
-    // Seed 18 user/assistant turns sized so the LOG estimate stays
-    // below the 95% preflight threshold (otherwise preflight folds
-    // first and the auto-fold path never runs). The mocked usage of
-    // 600k below is what trips the auto-fold check, independent of the
-    // tokenizer's view of the seed.
+    // Seed 18 user/assistant turns sized so the LOG estimate stays below both
+    // preflight signals (95% of token ctx AND the byte ceiling) — otherwise
+    // preflight folds first and the auto-fold path never runs. The mocked usage
+    // of 600k below is what trips the auto-fold check.
     const fillLines = (label: string, n: number) =>
       Array.from(
         { length: n },
@@ -649,8 +659,8 @@ describe("CacheFirstLoop (non-streaming)", () => {
           `${label} line ${i}: lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`,
       ).join("\n");
     for (let i = 0; i < 18; i++) {
-      loop.log.append({ role: "user", content: `Q${i}\n${fillLines(`q${i}`, 400)}` });
-      loop.log.append({ role: "assistant", content: `A${i}\n${fillLines(`a${i}`, 400)}` });
+      loop.log.append({ role: "user", content: `Q${i}\n${fillLines(`q${i}`, 100)}` });
+      loop.log.append({ role: "assistant", content: `A${i}\n${fillLines(`a${i}`, 100)}` });
     }
     const beforeMessages = loop.log.length;
 
@@ -668,6 +678,7 @@ describe("CacheFirstLoop (non-streaming)", () => {
   }, 30_000);
 
   it("uses the aggressive fold tier when promptTokens crosses 70% of ctxMax", async () => {
+    DEEPSEEK_CONTEXT_TOKENS[FOLD_TEST_MODEL] = 100_000;
     const reg = new ToolRegistry();
     reg.register({
       name: "probe",
@@ -676,16 +687,16 @@ describe("CacheFirstLoop (non-streaming)", () => {
       fn: async () => "ok",
     });
     const responses: FakeResponseShape[] = [
-      // Iter 0: usage at 75% of 1M ctx — squarely in the aggressive band.
+      // Iter 0: usage at 75% of the 100k test ctx — squarely in the aggressive band.
       {
         content: "",
         tool_calls: [{ id: "c1", type: "function", function: { name: "probe", arguments: "{}" } }],
         usage: {
-          prompt_tokens: 750_000,
+          prompt_tokens: 75_000,
           completion_tokens: 10,
-          total_tokens: 750_010,
-          prompt_cache_hit_tokens: 600_000,
-          prompt_cache_miss_tokens: 150_000,
+          total_tokens: 75_010,
+          prompt_cache_hit_tokens: 60_000,
+          prompt_cache_miss_tokens: 15_000,
         },
       },
       // Summary call (compactHistory).
@@ -700,6 +711,7 @@ describe("CacheFirstLoop (non-streaming)", () => {
       tools: reg,
       stream: false,
       maxToolIters: 8,
+      model: FOLD_TEST_MODEL,
     });
     const fillLines = (label: string, n: number) =>
       Array.from(
@@ -708,8 +720,8 @@ describe("CacheFirstLoop (non-streaming)", () => {
           `${label} line ${i}: lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`,
       ).join("\n");
     for (let i = 0; i < 18; i++) {
-      loop.log.append({ role: "user", content: `Q${i}\n${fillLines(`q${i}`, 400)}` });
-      loop.log.append({ role: "assistant", content: `A${i}\n${fillLines(`a${i}`, 400)}` });
+      loop.log.append({ role: "user", content: `Q${i}\n${fillLines(`q${i}`, 100)}` });
+      loop.log.append({ role: "assistant", content: `A${i}\n${fillLines(`a${i}`, 100)}` });
     }
 
     const events: { role: string; content?: string }[] = [];

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -259,6 +259,71 @@ describe("preflight context-size check", () => {
     expect(anyPreflight).toBeUndefined();
   });
 
+  it("fires on body bytes alone when many under-cap tool results accumulate", async () => {
+    // Real-world failure: 156+ messages, each under the 32 KB per-tool cap, but the
+    // accumulated body exceeds DeepSeek's gateway limit (~880 KB). Token estimate
+    // stays well under 95%; only the byte signal trips.
+    DEEPSEEK_CONTEXT_TOKENS[TEST_MODEL] = 5_000_000;
+
+    const fetchFn = fakeFetch([{ content: "ack" }]);
+    const loop = new CacheFirstLoop({
+      client: new DeepSeekClient({ apiKey: "sk-test", fetch: fetchFn }),
+      prefix: new ImmutablePrefix({ system: "s" }),
+      stream: false,
+      model: TEST_MODEL,
+    });
+
+    // 40 paired turns × ~25 KB tool result ≈ 1 MB body — past the 700 KB byte
+    // ceiling but only ~250 K tokens (5% of the 5 M budget).
+    const per = "ERROR: step failed with trailing detail x\n".repeat(630); // ~25 KB
+    for (let i = 0; i < 40; i++) {
+      loop.log.append({ role: "user", content: `q${i}` });
+      loop.log.append({
+        role: "assistant",
+        content: "",
+        tool_calls: [
+          {
+            id: `c${i}`,
+            type: "function",
+            function: { name: "probe", arguments: "{}" },
+          },
+        ],
+      });
+      loop.log.append({ role: "tool", tool_call_id: `c${i}`, content: per });
+    }
+
+    const events: { role: string; content?: string }[] = [];
+    for await (const ev of loop.step("follow-up")) {
+      events.push({ role: ev.role, content: ev.content });
+    }
+
+    const warn = events.find((e) => e.role === "warning" && /^preflight:/.test(e.content ?? ""));
+    expect(warn).toBeDefined();
+    expect(warn!.content).toMatch(/body \d/);
+    expect(warn!.content).toMatch(/truncated \d+ messages/);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("decidePreflight reports bytes trigger when only bytes exceed the limit", () => {
+    DEEPSEEK_CONTEXT_TOKENS[TEST_MODEL] = 5_000_000;
+    const loop = new CacheFirstLoop({
+      client: new DeepSeekClient({ apiKey: "sk-test", fetch: fakeFetch([]) }),
+      prefix: new ImmutablePrefix({ system: "s" }),
+      stream: false,
+      model: TEST_MODEL,
+    });
+
+    const big = "ERROR: step failed with trailing detail x\n".repeat(20_000);
+    const messages: ChatMessage[] = [
+      { role: "user", content: "u" },
+      { role: "assistant", content: big },
+    ];
+    const decision = loop.context.decidePreflight(messages, undefined, TEST_MODEL);
+    expect(decision.needsAction).toBe(true);
+    expect(decision.trigger).toBe("bytes");
+    expect(decision.estimateBytes).toBeGreaterThan(700_000);
+  });
+
   it("warns (but does not block) when over 95% with nothing to truncate", async () => {
     // Tiny budget AND a system prompt that alone overwhelms it. The log
     // is empty, so truncation has nothing to shrink — the preflight surfaces

--- a/tools/analyze-session-body.mjs
+++ b/tools/analyze-session-body.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+
+const sessionFile = process.argv[2];
+if (!sessionFile) {
+  console.error("usage: analyze-session-body.mjs <session.jsonl>");
+  process.exit(1);
+}
+
+const raw = readFileSync(sessionFile, "utf8");
+const lines = raw.split("\n").filter((l) => l.trim());
+const messages = lines.map((l) => JSON.parse(l));
+
+const payload = {
+  model: "deepseek-v4-flash",
+  messages,
+  stream: true,
+};
+const body = JSON.stringify(payload);
+const bodyBytes = Buffer.byteLength(body, "utf8");
+const bodyChars = body.length;
+
+const loneSurrogateRegex =
+  /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g;
+const loneSurrogates = body.match(loneSurrogateRegex) ?? [];
+
+const perMsg = messages.map((m, i) => {
+  const ms = JSON.stringify(m);
+  return {
+    i,
+    role: m.role,
+    contentBytes: typeof m.content === "string" ? Buffer.byteLength(m.content, "utf8") : 0,
+    fullBytes: Buffer.byteLength(ms, "utf8"),
+    toolCalls: Array.isArray(m.tool_calls) ? m.tool_calls.length : 0,
+    hasReasoning: typeof m.reasoning_content === "string" && m.reasoning_content.length > 0,
+    reasoningBytes:
+      typeof m.reasoning_content === "string"
+        ? Buffer.byteLength(m.reasoning_content, "utf8")
+        : 0,
+  };
+});
+
+console.log("=== body ===");
+console.log(`bytes: ${bodyBytes.toLocaleString()} (${(bodyBytes / 1024).toFixed(1)} KB)`);
+console.log(`chars: ${bodyChars.toLocaleString()}`);
+console.log(`messages: ${messages.length}`);
+console.log(`lone surrogates in body: ${loneSurrogates.length}`);
+
+console.log("\n=== top 8 biggest messages ===");
+const top = [...perMsg].sort((a, b) => b.fullBytes - a.fullBytes).slice(0, 8);
+console.table(top);
+
+console.log("\n=== role distribution by bytes ===");
+const byRole = {};
+for (const m of perMsg) {
+  byRole[m.role] = (byRole[m.role] || 0) + m.fullBytes;
+}
+console.table(byRole);
+
+console.log("\n=== messages with reasoning_content ===");
+const withReason = perMsg.filter((m) => m.hasReasoning);
+console.log(`count: ${withReason.length}`);
+if (withReason.length > 0) {
+  const totalReasoning = withReason.reduce((s, m) => s + m.reasoningBytes, 0);
+  console.log(`total reasoning bytes: ${totalReasoning.toLocaleString()} (${(totalReasoning / 1024).toFixed(1)} KB)`);
+  console.log(
+    `top 3 reasoning: ${withReason
+      .sort((a, b) => b.reasoningBytes - a.reasoningBytes)
+      .slice(0, 3)
+      .map((m) => `[${m.i}/${m.role}/${(m.reasoningBytes / 1024).toFixed(1)}KB]`)
+      .join(" ")}`,
+  );
+}

--- a/tools/scan-all-sessions.mjs
+++ b/tools/scan-all-sessions.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const dir = process.argv[2] ?? "C:/Users/yuhuahui/.reasonix/sessions";
+const files = readdirSync(dir).filter(
+  (f) => f.endsWith(".jsonl") && !f.endsWith(".events.jsonl") && !f.startsWith("subagent-"),
+);
+
+const loneSurrogateRegex =
+  /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g;
+
+const rows = [];
+for (const f of files) {
+  const path = join(dir, f);
+  const fsize = statSync(path).size;
+  if (fsize < 50_000) continue;
+
+  let raw;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch {
+    continue;
+  }
+
+  const lines = raw.split("\n").filter((l) => l.trim());
+  let messages;
+  try {
+    messages = lines.map((l) => JSON.parse(l));
+  } catch {
+    continue;
+  }
+
+  const body = JSON.stringify({ model: "deepseek-v4-flash", messages, stream: true });
+  const bodyBytes = Buffer.byteLength(body, "utf8");
+  const loneSurrogates = (body.match(loneSurrogateRegex) ?? []).length;
+
+  let maxMsgBytes = 0;
+  let maxMsgRole = "";
+  let maxMsgIdx = -1;
+  for (let i = 0; i < messages.length; i++) {
+    const mb = Buffer.byteLength(JSON.stringify(messages[i]), "utf8");
+    if (mb > maxMsgBytes) {
+      maxMsgBytes = mb;
+      maxMsgRole = messages[i].role;
+      maxMsgIdx = i;
+    }
+  }
+
+  rows.push({
+    file: f.slice(0, 50),
+    bodyKB: Math.round(bodyBytes / 1024),
+    msgs: messages.length,
+    maxMsgKB: Math.round(maxMsgBytes / 1024),
+    maxRole: maxMsgRole,
+    maxIdx: maxMsgIdx,
+    surrogates: loneSurrogates,
+  });
+}
+
+rows.sort((a, b) => b.bodyKB - a.bodyKB);
+console.log(`Scanned ${rows.length} sessions ≥ 50 KB:\n`);
+console.table(rows.slice(0, 12));
+
+const overLimit = rows.filter((r) => r.bodyKB > 500);
+if (overLimit.length > 0) {
+  console.log(`\n${overLimit.length} sessions with body > 500 KB:`);
+  for (const r of overLimit) {
+    console.log(`  ${r.bodyKB}KB - ${r.msgs} msgs - biggest msg ${r.maxMsgKB}KB (${r.maxRole}#${r.maxIdx}) - surrogates: ${r.surrogates}`);
+  }
+}
+
+const anyWithSurrogates = rows.filter((r) => r.surrogates > 0);
+if (anyWithSurrogates.length > 0) {
+  console.log(`\n${anyWithSurrogates.length} sessions with lone surrogates:`);
+  for (const r of anyWithSurrogates) {
+    console.log(`  ${r.surrogates} surrogates in ${r.file}`);
+  }
+} else {
+  console.log("\nNo lone surrogates found across any session — H3 weak.");
+}


### PR DESCRIPTION
## The bug

A user hit this mid-session from the desktop client:

```
DeepSeek 400: messages[156].content: unexpected end of hex escape at line 1 column 884819
```

The error is cryptic because the DeepSeek gateway truncates the request body mid-`\u` escape when the body exceeds its size limit, and the surfaced error is the JSON-parse failure that follows — not the truncation itself.

## Root cause

The existing preflight only checks token count against the model's context window (`PREFLIGHT_EMERGENCY_THRESHOLD = 0.95 × DEEPSEEK_CONTEXT_TOKENS["deepseek-v4-flash"] = 950 K tokens`). The failing request was ~200 K tokens — well below — but `JSON.stringify(messages)` came out to ~884 KB, past the gateway's body-byte limit.

The model's 1 M-token context window and the gateway's body-byte limit are independent constraints. Token preflight is blind to bytes.

## Verification before fixing

I'd jumped to four speculative fixes earlier; before coding anything, I scanned 10 of the user's local sessions to ground the diagnosis:

| Finding | Implication |
|---|---|
| 0 lone surrogates across 220 K lines of session JSON | Rules out malformed UTF-16 hypothesis |
| Largest saved body: 322 KB (60 msgs) | Per-message 32 KB tool cap works |
| Failure case: 156 msgs × ~5.7 KB avg ≈ 884 KB | Message *count* × per-msg cap blows past byte limit |

Two reusable tools (`tools/analyze-session-body.mjs`, `tools/scan-all-sessions.mjs`) are included so future reports of "DeepSeek 400 from a long session" can be diagnosed the same way without guessing.

## The fix

- New `MAX_BODY_BYTES = 700_000` (~80% of the observed 884 KB failure point — conservative without being paranoid).
- `decidePreflight` now computes `Buffer.byteLength(JSON.stringify(messages))` and trips on `tokens > 95% OR bytes > MAX_BODY_BYTES`.
- `PreflightDecision.trigger` records which signal fired so the user-facing warning, diagnostics, and any follow-up tooling can tell them apart.
- `mechanicalTruncate` now bounds the kept tail by both tokens AND bytes, so a byte-triggered preflight actually shrinks the body (token-only target would have left a 600 KB tail in place).
- Warning strings (EN + zh-CN) now include `body {bodyKB} KB` alongside the token percentage so byte-triggered folds aren't surprising to read.

## What I deliberately did **not** do

| Considered | Rejected because |
|---|---|
| Extend `shrinkOversizedToolResults` to user/assistant roles | Would mutate historical messages and torpedo the prefix cache (the project's whole positioning) |
| Sanitize lone surrogates in desktop input | 0 found across 10 sessions — speculative |
| Add a separate retry on 400 | Preflight is the right layer; retry would be reactive band-aid |
| Pure observation / instrumentation only | Users would keep hitting the wall while we wait for telemetry |

## Tests

- `tests/preflight.test.ts`:
  - integration test — 40 paired turns × ~25 KB tool results trips byte preflight while tokens stay at ~5% (real shape of the failing session)
  - unit test — `decidePreflight` reports `trigger: "bytes"` when only bytes exceed
- `tests/loop.test.ts`: two auto-fold-tier tests previously used 2 MB seed logs against a 1 M-token ctx; the new byte gate would empty those logs before fold ran. Switched both to a 100 K test ctx with proportionally scaled seeds — fold tiers still verified within both windows.

3451 tests pass locally (was 3449; added 2).

## Test plan

- [ ] CI green
- [ ] Manually verify a session that previously 400'd now shows `preflight: ... body NNN KB — truncated N messages → M. Sending.` and proceeds
- [ ] Manually verify normal-sized sessions show no preflight warning