### PR TITLE
fix: resolve root-relative edit block paths

### DIFF
--- a/src/code/edit-blocks.ts
+++ b/src/code/edit-blocks.ts
@@ -13,7 +13,7 @@ import {
   writeFileSync,
   writeSync,
 } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { dirname, isAbsolute, relative, resolve } from "node:path";
 
 export interface EditBlock {
   /** Path as written by the model — relative to rootDir, or absolute. */
@@ -67,12 +67,35 @@ export function parseEditBlocks(text: string): EditBlock[] {
   return out;
 }
 
+function resolveEditPath(rootDir: string, rawPath: string): string {
+  const absRoot = resolve(rootDir);
+  if (/^[A-Za-z]:[\\/]/.test(rawPath) || looksLikeAbsoluteSystemPath(rawPath)) {
+    return resolve(rawPath);
+  }
+  let rooted = rawPath;
+  while (rooted.startsWith("/") || rooted.startsWith("\\")) {
+    rooted = rooted.slice(1);
+  }
+  return resolve(absRoot, rooted || ".");
+}
+
+function looksLikeAbsoluteSystemPath(rawPath: string): boolean {
+  return /^\/(?:home|Users|etc|var|opt|tmp|usr|mnt|Library|Volumes|proc|sys|dev|run|srv|media|Applications|System|root|boot|private)(?:[/\\]|$)/.test(
+    rawPath,
+  );
+}
+
+function pathIsUnder(child: string, parent: string): boolean {
+  const rel = relative(parent, child);
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}
+
 export function applyEditBlock(block: EditBlock, rootDir: string): ApplyResult {
   const absRoot = resolve(rootDir);
-  const absTarget = resolve(absRoot, block.path);
+  const absTarget = resolveEditPath(rootDir, block.path);
   // Refuse paths that escape rootDir. `resolve` normalizes `..`, so
-  // startsWith on the normalized pair is enough.
-  if (absTarget !== absRoot && !absTarget.startsWith(`${absRoot}${sep()}`)) {
+  // relative-path containment avoids prefix false positives.
+  if (!pathIsUnder(absTarget, absRoot)) {
     return {
       path: block.path,
       status: "path-escape",
@@ -183,7 +206,7 @@ export function applyEditBlocks(blocks: EditBlock[], rootDir: string): ApplyResu
 }
 
 export function toWholeFileEditBlock(path: string, content: string, rootDir: string): EditBlock {
-  const abs = resolve(rootDir, path);
+  const abs = resolveEditPath(rootDir, path);
   let search = "";
   if (existsSync(abs)) {
     try {
@@ -204,13 +227,12 @@ export interface EditSnapshot {
 
 /** De-duped by path — one "before" snapshot per file even with multiple blocks. */
 export function snapshotBeforeEdits(blocks: EditBlock[], rootDir: string): EditSnapshot[] {
-  const absRoot = resolve(rootDir);
   const seen = new Set<string>();
   const snapshots: EditSnapshot[] = [];
   for (const b of blocks) {
-    if (seen.has(b.path)) continue;
-    seen.add(b.path);
-    const abs = resolve(absRoot, b.path);
+    const abs = resolveEditPath(rootDir, b.path);
+    if (seen.has(abs)) continue;
+    seen.add(abs);
     if (!existsSync(abs)) {
       snapshots.push({ path: b.path, prevContent: null });
       continue;
@@ -231,8 +253,8 @@ export function snapshotBeforeEdits(blocks: EditBlock[], rootDir: string): EditS
 export function restoreSnapshots(snapshots: EditSnapshot[], rootDir: string): ApplyResult[] {
   const absRoot = resolve(rootDir);
   return snapshots.map((snap) => {
-    const abs = resolve(absRoot, snap.path);
-    if (abs !== absRoot && !abs.startsWith(`${absRoot}${sep()}`)) {
+    const abs = resolveEditPath(rootDir, snap.path);
+    if (!pathIsUnder(abs, absRoot)) {
       return {
         path: snap.path,
         status: "path-escape",
@@ -258,11 +280,6 @@ export function restoreSnapshots(snapshots: EditSnapshot[], rootDir: string): Ap
       return { path: snap.path, status: "error", message: (err as Error).message };
     }
   });
-}
-
-/** Platform separator — `\` on Windows, `/` elsewhere. */
-function sep(): string {
-  return process.platform === "win32" ? "\\" : "/";
 }
 
 function lineEndingOf(text: string): string {

--- a/tests/edit-blocks.test.ts
+++ b/tests/edit-blocks.test.ts
@@ -2,7 +2,7 @@
 
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   applyEditBlock,
@@ -117,6 +117,42 @@ describe("applyEditBlock", () => {
     expect(readFileSync(join(root, "a.txt"), "utf8")).toBe("goodbye world\n");
   });
 
+  it("treats leading slash paths as project-root relative", () => {
+    writeFileSync(join(root, "a.txt"), "hello world\n", "utf8");
+    const result = applyEditBlock(
+      { path: "/a.txt", search: "hello", replace: "goodbye", offset: 0 },
+      root,
+    );
+    expect(result.status).toBe("applied");
+    expect(readFileSync(join(root, "a.txt"), "utf8")).toBe("goodbye world\n");
+  });
+
+  it("allows real absolute paths when they stay inside rootDir", () => {
+    const absPath = join(root, "a.txt");
+    writeFileSync(absPath, "hello world\n", "utf8");
+    const result = applyEditBlock(
+      { path: absPath, search: "hello", replace: "goodbye", offset: 0 },
+      root,
+    );
+    expect(result.status).toBe("applied");
+    expect(readFileSync(absPath, "utf8")).toBe("goodbye world\n");
+  });
+
+  it("refuses real absolute paths outside rootDir", () => {
+    const outside = resolve(root, "..", "outside.txt");
+    writeFileSync(outside, "hello world\n", "utf8");
+    try {
+      const result = applyEditBlock(
+        { path: outside, search: "hello", replace: "goodbye", offset: 0 },
+        root,
+      );
+      expect(result.status).toBe("path-escape");
+      expect(readFileSync(outside, "utf8")).toBe("hello world\n");
+    } finally {
+      rmSync(outside, { force: true });
+    }
+  });
+
   it("creates a new file when SEARCH is empty and file doesn't exist", () => {
     const result = applyEditBlock(
       { path: "new/nested/file.ts", search: "", replace: "export const x = 1;\n", offset: 0 },
@@ -223,7 +259,7 @@ describe("snapshotBeforeEdits + restoreSnapshots", () => {
     writeFileSync(join(root, "a.txt"), "one two three\n", "utf8");
     const blocks = [
       { path: "a.txt", search: "one", replace: "ONE", offset: 0 },
-      { path: "a.txt", search: "two", replace: "TWO", offset: 10 },
+      { path: "/a.txt", search: "two", replace: "TWO", offset: 10 },
     ];
     const snaps = snapshotBeforeEdits(blocks, root);
     expect(snaps).toHaveLength(1); // not 2 — same file


### PR DESCRIPTION
## What

Fix edit block path resolution so model-emitted paths with a leading slash are treated as project-root-relative paths, while real system absolute paths are still supported when they stay inside `rootDir`.

## Why

Edit blocks may contain paths like `/a.txt` to mean “from the workspace root”. Previously these could be resolved as filesystem-root absolute paths, causing valid edits or snapshots to be rejected as `path-escape` instead of applying inside the project.

## How to verify

```bash
npm test -- tests/edit-blocks.test.ts