### PR TITLE
fix: constrain shell redirects to sandbox boundaries

### DIFF
--- a/src/tools/shell-chain.ts
+++ b/src/tools/shell-chain.ts
@@ -1,7 +1,7 @@
 /** Parse + spawn `cmd1 | cmd2 && cmd3 > out` ourselves — never invoke a shell, sidestep PS5.1's `&&` parse error and codepage drift. */
 
 import { type ChildProcess, type SpawnOptions, spawn } from "node:child_process";
-import { closeSync, openSync } from "node:fs";
+import { constants, closeSync, lstatSync, openSync, realpathSync } from "node:fs";
 import { devNull } from "node:os";
 import * as pathMod from "node:path";
 import { isDqEscape, killProcessTree, prepareSpawn, smartDecodeOutput } from "./shell.js";
@@ -354,14 +354,63 @@ interface SegmentStdio {
 }
 
 /** Models reach for `2>nul` (Windows) and `2>/dev/null` (POSIX) interchangeably; without this the parser materializes a real `<cwd>/nul` file. */
-function isNullDeviceAlias(target: string): boolean {
+export function isNullDeviceAlias(target: string): boolean {
   const lower = target.toLowerCase();
   if (lower === "/dev/null") return true;
   if (process.platform === "win32" && lower === "nul") return true;
   return false;
 }
 
+function pathIsUnder(child: string, parent: string): boolean {
+  const rel = pathMod.relative(parent, child);
+  return rel === "" || (!rel.startsWith("..") && !pathMod.isAbsolute(rel));
+}
+
+function openFlags(mode: "r" | "w" | "a"): number {
+  const noFollow = "O_NOFOLLOW" in constants ? constants.O_NOFOLLOW : 0;
+  if (mode === "r") return constants.O_RDONLY | noFollow;
+  if (mode === "w") return constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | noFollow;
+  return constants.O_WRONLY | constants.O_CREAT | constants.O_APPEND | noFollow;
+}
+
+function ensureUnderSandbox(path: string, sandboxRoot: string, target: string): void {
+  if (!pathIsUnder(path, sandboxRoot)) {
+    throw new Error(
+      `redirect target "${target}" resolves outside the workspace sandbox (${sandboxRoot})`,
+    );
+  }
+}
+
+function resolveRedirectTarget(target: string, cwd: string): string {
+  const lexicalRoot = pathMod.resolve(cwd);
+  const sandboxRoot = realpathSync(lexicalRoot);
+  const resolved = pathMod.resolve(lexicalRoot, target);
+  ensureUnderSandbox(resolved, lexicalRoot, target);
+
+  try {
+    const stat = lstatSync(resolved);
+    if (stat.isSymbolicLink()) {
+      throw new Error(`redirect target "${target}" is a symbolic link`);
+    }
+    ensureUnderSandbox(realpathSync(resolved), sandboxRoot, target);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== "ENOENT") throw err;
+    ensureUnderSandbox(realpathSync(pathMod.dirname(resolved)), sandboxRoot, target);
+  }
+
+  return resolved;
+}
+
+function validateRedirectTargets(redirects: readonly Redirect[], cwd: string): void {
+  for (const r of redirects) {
+    if (r.kind === "2>&1" || !r.target || isNullDeviceAlias(r.target)) continue;
+    resolveRedirectTarget(r.target, cwd);
+  }
+}
+
 function openRedirects(redirects: readonly Redirect[], cwd: string): SegmentStdio {
+  validateRedirectTargets(redirects, cwd);
   let stdinFd: number | null = null;
   let stdoutFd: number | null = null;
   let stderrFd: number | null = null;
@@ -369,8 +418,8 @@ function openRedirects(redirects: readonly Redirect[], cwd: string): SegmentStdi
   let bothFd: number | null = null;
   const toClose: number[] = [];
   const open = (target: string, flags: "r" | "w" | "a"): number => {
-    const resolved = isNullDeviceAlias(target) ? devNull : pathMod.resolve(cwd, target);
-    const fd = openSync(resolved, flags);
+    const resolved = isNullDeviceAlias(target) ? devNull : resolveRedirectTarget(target, cwd);
+    const fd = openSync(resolved, openFlags(flags), 0o666);
     toClose.push(fd);
     return fd;
   };

--- a/src/tools/shell/exec.ts
+++ b/src/tools/shell/exec.ts
@@ -200,7 +200,7 @@ export function smartDecodeOutput(buf: Buffer): string {
 
 export interface ResolveExecutableOptions {
   platform?: NodeJS.Platform;
-  env?: { PATH?: string; PATHEXT?: string };
+  env?: Record<string, string | undefined>;
   isFile?: (path: string) => boolean;
   pathDelimiter?: string;
 }

--- a/src/tools/shell/parse.ts
+++ b/src/tools/shell/parse.ts
@@ -1,6 +1,11 @@
 import { homedir } from "node:os";
 import * as pathMod from "node:path";
-import { type CommandChain, chainAllowed, parseCommandChain } from "../shell-chain.js";
+import {
+  type CommandChain,
+  chainAllowed,
+  isNullDeviceAlias,
+  parseCommandChain,
+} from "../shell-chain.js";
 
 /** Read-only reports + test runners whose failure mode is "exit 1 with output". */
 export const BUILTIN_ALLOWLIST: ReadonlyArray<string> = [
@@ -270,6 +275,31 @@ export function hasSensitivePathArgs(
   return false;
 }
 
+function pathIsUnder(child: string, parent: string): boolean {
+  const rel = pathMod.relative(parent, child);
+  return rel === "" || (!rel.startsWith("..") && !pathMod.isAbsolute(rel));
+}
+
+function redirectTargets(chain: CommandChain): string[] {
+  const targets: string[] = [];
+  for (const seg of chain.segments) {
+    for (const r of seg.redirects) {
+      if (r.kind === "2>&1" || !r.target || isNullDeviceAlias(r.target)) continue;
+      targets.push(r.target);
+    }
+  }
+  return targets;
+}
+
+export function redirectsEscapeSandbox(chain: CommandChain, projectRoot: string): boolean {
+  const root = pathMod.resolve(projectRoot);
+  for (const target of redirectTargets(chain)) {
+    const resolved = pathMod.resolve(root, target);
+    if (!pathIsUnder(resolved, root)) return true;
+  }
+  return false;
+}
+
 /** Allowlist match on leading argv tokens; demoted by `RISKY_ARGS` when a destructive flag appears in the tail,
  *  or by `SENSITIVE_PATHS` when a path argument targets a sensitive location (#259). */
 export function isAllowed(
@@ -330,6 +360,20 @@ export function isCommandAllowed(
     return false;
   }
   if (chain === null) return isAllowed(cmd, extra, projectRoot, sensitivePathConfig);
+  const targets = redirectTargets(chain);
+  if (targets.length > 0 && !projectRoot) return false;
+  if (projectRoot) {
+    if (redirectsEscapeSandbox(chain, projectRoot)) return false;
+    if (
+      hasSensitivePathArgs(
+        targets,
+        projectRoot,
+        sensitivePathConfig?.prefixes,
+        sensitivePathConfig?.patterns,
+      )
+    )
+      return false;
+  }
   return chainAllowed(chain, (seg) => isAllowed(seg, extra, projectRoot, sensitivePathConfig));
 }
 

--- a/tests/shell-redirects.test.ts
+++ b/tests/shell-redirects.test.ts
@@ -1,4 +1,12 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -210,6 +218,100 @@ describe("runChain — redirect execution", () => {
     await runChain(c, { cwd: tmp, ...baseOpts });
     expect(readFileSync(join(tmp, "out.txt"), "utf8")).toBe("hello");
   });
+
+  it("rejects absolute redirect targets outside the sandbox", async () => {
+    const outside = `${tmp}-outside.txt`;
+    rmSync(outside, { force: true });
+    try {
+      const c = parseCommandChain(`node -e "process.stdout.write('blocked')" > "${outside}"`)!;
+      await expect(runChain(c, { cwd: tmp, ...baseOpts })).rejects.toThrow(
+        /outside the workspace sandbox/,
+      );
+      expect(existsSync(outside)).toBe(false);
+    } finally {
+      rmSync(outside, { force: true });
+    }
+  });
+
+  it("rejects relative redirect targets that escape the sandbox", async () => {
+    const outside = join(tmp, "..", "reasonix-redir-outside.txt");
+    rmSync(outside, { force: true });
+    try {
+      const c = parseCommandChain(
+        "node -e \"process.stdout.write('blocked')\" > ../reasonix-redir-outside.txt",
+      )!;
+      await expect(runChain(c, { cwd: tmp, ...baseOpts })).rejects.toThrow(
+        /outside the workspace sandbox/,
+      );
+      expect(existsSync(outside)).toBe(false);
+    } finally {
+      rmSync(outside, { force: true });
+    }
+  });
+
+  it("allows absolute redirect targets inside the sandbox", async () => {
+    const inside = join(tmp, "inside-absolute.txt");
+    const c = parseCommandChain(`node -e "process.stdout.write('inside')" > "${inside}"`)!;
+    const r = await runChain(c, { cwd: tmp, ...baseOpts });
+    expect(r.exitCode).toBe(0);
+    expect(readFileSync(inside, "utf8")).toBe("inside");
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "rejects output redirects through a symlink to an outside file",
+    async () => {
+      const outside = `${tmp}-symlink-outside.txt`;
+      const link = join(tmp, "out-link.txt");
+      writeFileSync(outside, "original");
+      symlinkSync(outside, link);
+      try {
+        const c = parseCommandChain("node -e \"process.stdout.write('blocked')\" > out-link.txt")!;
+        await expect(runChain(c, { cwd: tmp, ...baseOpts })).rejects.toThrow(/symbolic link/);
+        expect(readFileSync(outside, "utf8")).toBe("original");
+      } finally {
+        rmSync(outside, { force: true });
+      }
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "rejects input redirects through a symlink to an outside file",
+    async () => {
+      const outside = `${tmp}-symlink-secret.txt`;
+      const link = join(tmp, "in-link.txt");
+      writeFileSync(outside, "SECRET");
+      symlinkSync(outside, link);
+      try {
+        const c = parseCommandChain(
+          "node -e \"let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>process.stdout.write(d))\" < in-link.txt",
+        )!;
+        await expect(runChain(c, { cwd: tmp, ...baseOpts })).rejects.toThrow(/symbolic link/);
+      } finally {
+        rmSync(outside, { force: true });
+      }
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "rejects writes under a symlinked directory that points outside the sandbox",
+    async () => {
+      const outsideDir = `${tmp}-outside-dir`;
+      const linkDir = join(tmp, "linked-dir");
+      mkdirSync(outsideDir);
+      symlinkSync(outsideDir, linkDir, "dir");
+      try {
+        const c = parseCommandChain(
+          "node -e \"process.stdout.write('blocked')\" > linked-dir/out.txt",
+        )!;
+        await expect(runChain(c, { cwd: tmp, ...baseOpts })).rejects.toThrow(
+          /outside the workspace sandbox/,
+        );
+        expect(existsSync(join(outsideDir, "out.txt"))).toBe(false);
+      } finally {
+        rmSync(outsideDir, { recursive: true, force: true });
+      }
+    },
+  );
 });
 
 describe("runCommand — redirect dispatch", () => {

--- a/tests/shell-tools.test.ts
+++ b/tests/shell-tools.test.ts
@@ -24,11 +24,11 @@ import { normalizeWindowsEnvVars } from "../src/tools/shell/exec.js";
 
 /** A PauseGate that records call args and denies — denial keeps the spawn from actually running. */
 class SpyGate extends PauseGate {
-  lastCall: { kind: string; payload?: unknown } | null = null;
-  override ask(opts: { kind: string; payload?: unknown }): Promise<any> {
+  lastCall: Parameters<PauseGate["ask"]>[0] | null = null;
+  override ask = ((opts: Parameters<PauseGate["ask"]>[0]) => {
     this.lastCall = opts;
     return Promise.resolve({ type: "deny" } as ConfirmationChoice);
-  }
+  }) as PauseGate["ask"];
 }
 
 class AutoGate extends PauseGate {
@@ -37,9 +37,9 @@ class AutoGate extends PauseGate {
     super();
     this._choice = choice;
   }
-  override ask(_opts: { kind: string; payload?: unknown }): Promise<ConfirmationChoice> {
+  override ask = ((_opts: Parameters<PauseGate["ask"]>[0]) => {
     return Promise.resolve(this._choice);
-  }
+  }) as PauseGate["ask"];
 }
 
 describe("tokenizeCommand", () => {
@@ -369,6 +369,27 @@ describe("isAllowed", () => {
     it("works through isCommandAllowed for chain commands", () => {
       expect(isCommandAllowed("cat ~/.ssh/id_rsa | grep KEY", [], projectRoot)).toBe(false);
       expect(isCommandAllowed("cat src/index.ts && grep TODO src/", [], projectRoot)).toBe(true);
+    });
+
+    it("demotes allowlisted commands with sandbox-escaping redirects", () => {
+      expect(isCommandAllowed("git status > out.txt")).toBe(false);
+      expect(isCommandAllowed("git status > /tmp/evil", [], projectRoot)).toBe(false);
+      expect(isCommandAllowed("ls > ../../../etc/passwd", [], projectRoot)).toBe(false);
+    });
+
+    it("allows safe redirects in allowlisted chain commands", () => {
+      expect(isCommandAllowed("git status > ./output.txt", [], projectRoot)).toBe(true);
+      expect(
+        isCommandAllowed(`git status > ${join(projectRoot, "out.txt")}`, [], projectRoot),
+      ).toBe(true);
+      expect(isCommandAllowed("git status > /dev/null", [], projectRoot)).toBe(true);
+      expect(isCommandAllowed("git status 2>&1", [], projectRoot)).toBe(true);
+    });
+
+    it("demotes sensitive redirect targets", () => {
+      expect(isCommandAllowed("cat < .env", [], projectRoot)).toBe(false);
+      expect(isCommandAllowed("cat < ~/.ssh/id_rsa", [], projectRoot)).toBe(false);
+      expect(isCommandAllowed("cat < README.md", [], projectRoot)).toBe(true);
     });
   });
 });


### PR DESCRIPTION
fix: constrain shell redirects to sandbox boundaries

Validate redirect targets before execution to block sandbox escapes, symlink traversal, and sensitive redirect paths. Preserve PauseGate test stub typing and support case-insensitive Windows environment variables in executable resolution.

## What

This change hardens shell redirect handling by validating redirect targets before execution, rejecting paths that escape the workspace sandbox, traverse symlinks, or target sensitive files. It also fixes PauseGate test stub typing and broadens Windows environment variable typing for executable resolution.

## Why

Redirects could otherwise bypass command allowlist assumptions by writing to or reading from paths outside the sandbox. The related type fixes keep the shell tool tests aligned with the generic PauseGate contract and the Windows env lookup behavior.

## How to verify

- `npm run typecheck`
- `npx vitest run tests/shell-tools.test.ts`
- `npx vitest run tests/shell-redirects.test.ts`

## Checklist

- [ ] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [ ] No `Co-Authored-By: Claude` trailer in commits
- [ ] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [ ] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time