### PR TITLE
fix(tests): bump chat-mcp-startup timeout to 30s

### DIFF
--- a/tests/chat-mcp-startup-summary.test.ts
+++ b/tests/chat-mcp-startup-summary.test.ts
@@ -223,9 +223,12 @@ async function captureStartupState(opts?: {
 
 // Dynamic chat.js / tools.js import inside captureStartupState pushes
 // past the 5s default under full-suite worker contention; pass in
-// isolation. 15s leaves headroom for cold module-cache + slow CI hosts
-// without making the suite noticeably slower in the happy path.
-describe("chatCommand MCP startup summary states", { timeout: 15_000 }, () => {
+// isolation. The previous 15s ceiling timed out the first test on
+// Windows CI under coverage (v8) instrumentation — the FIRST cold
+// module load eats most of the budget on slow hosts. 30s leaves
+// headroom without slowing the happy path (passing tests still
+// finish in ~400ms after the first cold run warms the worker).
+describe("chatCommand MCP startup summary states", { timeout: 30_000 }, () => {
   beforeEach(() => {
     vi.spyOn(process.stderr, "write").mockImplementation(() => true);
   });


### PR DESCRIPTION
## Why

CI on main 400'd after #1439 merged — first test in \`chat-mcp-startup-summary.test.ts\` timed out at 15s on Windows + coverage. Subsequent pushes re-ran CI and passed, but the flake will recur whenever worker contention spikes.

\`\`\`
× passes mcpSpecs through with empty initial mcpServers — bridging is deferred to App mount  30039ms
  → Test timed out in 15000ms.
\`\`\`

## Root cause

\`captureStartupState\` does \`vi.resetModules()\` + dynamic import of \`chat.js\` / \`tools.js\` / \`i18n/index.js\` per call. Coverage (v8) instrumentation roughly doubles cold dynamic-import cost. On Windows CI the FIRST call exceeds the existing 15s budget; subsequent tests in the same describe finish in ~400ms once the worker is warm.

## Fix

Bump describe timeout to 30s. One-line change. Happy-path suite duration unchanged.

## Test plan

- [ ] CI green