### PR TITLE
fix(desktop): make /btw visibly work — echo input, busy, side-question prompt

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -958,6 +958,7 @@ export function applyIncoming(state: State, ev: IncomingEvent): State {
     case "$btw_result":
       return {
         ...state,
+        busy: false,
         messages: [
           ...state.messages,
           { kind: "status", text: `≫ btw\n${ev.answer}` },
@@ -1280,6 +1281,9 @@ function TabRuntime({
       // /btw <question> — route to side-question RPC instead of user_input.
       // Empty payload used to silently swallow the keystroke (#1370); surface
       // the usage hint as a status message so the user knows what's expected.
+      // The full /btw line is echoed via send_user so the typed text appears
+      // immediately and busy=true gives a thinking indicator while the side
+      // call runs (#1470).
       const btwMatch = /^\/btw(?:\s+([\s\S]+))?$/.exec(text);
       if (btwMatch) {
         const question = btwMatch[1]?.trim() ?? "";
@@ -1288,6 +1292,8 @@ function TabRuntime({
           if (!override) setDraft("/btw ");
           return;
         }
+        const clientId = `btw-${Date.now()}`;
+        dispatch({ t: "send_user", text, clientId });
         sendRpc({ cmd: "btw", text: question });
         if (!override) setDraft("");
         return;

--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -2366,7 +2366,11 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
           const reply = await tab.runtime!.loop.client.chat({
             model: tab.currentModel,
             messages: [
-              { role: "system", content: tab.system },
+              {
+                role: "system",
+                content:
+                  "You are answering a side question that is unrelated to the current coding conversation. Answer concisely (1-3 sentences) in plain prose. Do not call tools, do not ask clarifying questions, and do not reference any prior turns.",
+              },
               { role: "user", content: question },
             ],
           });

--- a/tests/desktop-btw-status.test.ts
+++ b/tests/desktop-btw-status.test.ts
@@ -100,3 +100,20 @@ describe("desktop push_status action (#1370)", () => {
     expect(next.ready).toBe(state.ready);
   });
 });
+
+describe("desktop $btw_result reducer (#1470)", () => {
+  it("clears busy and appends the answer as a status message", () => {
+    // /btw flips busy=true on send (via send_user echo); the answer must
+    // flip it back off or the composer stays disabled (#1470).
+    const state: AppState = { ...makeState(), busy: true };
+    const next = reduce(state, {
+      t: "incoming",
+      event: { type: "$btw_result", question: "what year is it?", answer: "2026." },
+    });
+    expect(next.busy).toBe(false);
+    expect(next.messages.at(-1)).toEqual({
+      kind: "status",
+      text: "≫ btw\n2026.",
+    });
+  });
+});


### PR DESCRIPTION
## Bug

Reported in #1470: in the desktop client, typing \`/btw <something>\` and pressing enter produced no visible feedback, and only after a delay did an error appear.

## Root cause — three stacked bugs

1. **Composer never echoed the /btw line.** \`send()\` in \`desktop/src/App.tsx\` routes \`/btw\` to an RPC but skips the \`send_user\` dispatch that normally adds the user's text to the message stream. User stared at an unchanged screen.

2. **\`$btw_result\` reducer didn't clear \`busy\`.** Even after the fix above made busy flip on, the answer arriving never flipped it back off, so the composer stayed disabled. (\`\$error\` already clears busy on the failure branch — same fix for the success branch.)

3. **Backend used the full coding system prompt.** \`src/cli/commands/desktop.ts\` passed \`tab.system\` (the coding-agent prompt) to the side-question call. That put the model into coding-agent mode for an unrelated /btw question — it would either try to call tools or take a long time to answer, matching the "过了一段时间出现一个报错提示" symptom. CLI side already uses a dedicated brief side-question prompt; backend now mirrors that.

## Test plan

- [ ] CI green
- [ ] \`/btw what year is it\` in desktop shows the question immediately, busy indicator appears, answer arrives as a status block
- [ ] Empty \`/btw\` still surfaces the usage hint (#1370 behavior preserved)

Closes #1470