### PR TITLE
fix(tui): switch default mouse mode to alternate-scroll (?1007h)

### DIFF
--- a/src/cli/ui/mouse-mode.ts
+++ b/src/cli/ui/mouse-mode.ts
@@ -1,24 +1,53 @@
-// SGR mouse tracking on/off. Enables the wheel to reach the TUI in every
-// terminal (Windows Terminal in particular doesn't translate wheel→arrow
-// when alt-screen is active for some users). The trade-off — native
-// drag-select stops working — was the reason #514 dropped this; users
-// asked for the wheel back because the native select only sees the
-// current screen anyway. Shift+drag still selects in most terminals.
+// Mouse-protocol selection for the TUI. Default: DECSET 1007 (alternate scroll
+// mode). We DON'T need full mouse capture — the TUI never reacts to clicks or
+// drags, only the wheel. `?1000h` was the old default and broke native text
+// selection + right-click context menu for every user (#1337, #677, #1419) just
+// to get the wheel working — net negative when the only thing reasonix uses
+// the mouse for is scrolling chat history.
+//
+// `?1007h` (alternate scroll): the terminal translates wheel events into
+// up/down (or PgUp/PgDn, depending on terminal) key sequences in the alt
+// screen. Mouse buttons stay native — copy/paste/right-click all behave the
+// way the terminal owner expects. Supported by Windows Terminal, iTerm2,
+// GNOME Terminal, kitty, Alacritty, recent xterm. Terminals without it
+// (macOS Terminal.app, very old emulators) fall back to the host terminal's
+// own scrollback for history — still functional, just not in-app wheel scroll.
+//
+// Escape hatch: `REASONIX_MOUSE_MODE=sgr` restores the old `?1000h+?1006h`
+// behavior for users on terminals where alternate scroll doesn't work and
+// they prefer in-app wheel over native selection. `off` disables mouse
+// reporting entirely (no in-app wheel, full native behavior).
 
-const ENABLE = "\u001b[?1000h\u001b[?1006h";
-const DISABLE = "\u001b[?1006l\u001b[?1000l";
+type Mode = "alternate-scroll" | "sgr" | "off";
+
+function readMode(): Mode {
+  const raw = (process.env.REASONIX_MOUSE_MODE ?? "").toLowerCase();
+  if (raw === "sgr") return "sgr";
+  if (raw === "off") return "off";
+  return "alternate-scroll";
+}
+
+const SEQUENCES: Record<Mode, { enable: string; disable: string }> = {
+  "alternate-scroll": { enable: "\u001b[?1007h", disable: "\u001b[?1007l" },
+  sgr: { enable: "\u001b[?1000h\u001b[?1006h", disable: "\u001b[?1006l\u001b[?1000l" },
+  off: { enable: "", disable: "" },
+};
 
 let active = false;
+let activeMode: Mode = "alternate-scroll";
 
 export function enableMouseMode(): void {
   if (active) return;
   if (!process.stdout.isTTY) return;
-  process.stdout.write(ENABLE);
+  activeMode = readMode();
+  const seq = SEQUENCES[activeMode].enable;
+  if (seq) process.stdout.write(seq);
   active = true;
 }
 
 export function disableMouseMode(): void {
   if (!active) return;
-  process.stdout.write(DISABLE);
+  const seq = SEQUENCES[activeMode].disable;
+  if (seq) process.stdout.write(seq);
   active = false;
 }

--- a/tests/mouse-mode.test.ts
+++ b/tests/mouse-mode.test.ts
@@ -1,10 +1,11 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { disableMouseMode, enableMouseMode } from "../src/cli/ui/mouse-mode.js";
 
-describe("mouse-mode SGR enable/disable", () => {
+describe("mouse-mode enable/disable", () => {
   let writes: string[];
   let origWrite: typeof process.stdout.write;
   let origIsTTY: boolean | undefined;
+  let origModeEnv: string | undefined;
 
   beforeEach(() => {
     writes = [];
@@ -15,6 +16,9 @@ describe("mouse-mode SGR enable/disable", () => {
     }) as typeof process.stdout.write;
     origIsTTY = process.stdout.isTTY;
     Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+    origModeEnv = process.env.REASONIX_MOUSE_MODE;
+    // biome-ignore lint/performance/noDelete: env restoration needs absence, not "undefined"
+    delete process.env.REASONIX_MOUSE_MODE;
     // Reset module state — disable first to clear `active` from any prior test.
     disableMouseMode();
     writes.length = 0;
@@ -24,11 +28,46 @@ describe("mouse-mode SGR enable/disable", () => {
     disableMouseMode();
     process.stdout.write = origWrite;
     Object.defineProperty(process.stdout, "isTTY", { value: origIsTTY, configurable: true });
+    if (origModeEnv === undefined) {
+      // biome-ignore lint/performance/noDelete: env restoration needs absence, not "undefined"
+      delete process.env.REASONIX_MOUSE_MODE;
+    } else {
+      process.env.REASONIX_MOUSE_MODE = origModeEnv;
+    }
   });
 
-  it("enable writes the SGR + 1000 + 1006 escape", () => {
+  it("default mode writes the alternate-scroll escape (?1007h)", () => {
+    enableMouseMode();
+    expect(writes.join("")).toBe("\u001b[?1007h");
+  });
+
+  it("default disable writes the matching off-escape (?1007l)", () => {
+    enableMouseMode();
+    writes.length = 0;
+    disableMouseMode();
+    expect(writes.join("")).toBe("\u001b[?1007l");
+  });
+
+  it("REASONIX_MOUSE_MODE=sgr restores legacy ?1000h + ?1006h capture", () => {
+    process.env.REASONIX_MOUSE_MODE = "sgr";
     enableMouseMode();
     expect(writes.join("")).toBe("\u001b[?1000h\u001b[?1006h");
+    writes.length = 0;
+    disableMouseMode();
+    expect(writes.join("")).toBe("\u001b[?1006l\u001b[?1000l");
+  });
+
+  it("REASONIX_MOUSE_MODE=off skips writing any escape sequence", () => {
+    process.env.REASONIX_MOUSE_MODE = "off";
+    enableMouseMode();
+    disableMouseMode();
+    expect(writes).toEqual([]);
+  });
+
+  it("unknown REASONIX_MOUSE_MODE falls back to alternate-scroll default", () => {
+    process.env.REASONIX_MOUSE_MODE = "garbage";
+    enableMouseMode();
+    expect(writes.join("")).toBe("\u001b[?1007h");
   });
 
   it("enable is idempotent — second call is a no-op", () => {
@@ -37,23 +76,26 @@ describe("mouse-mode SGR enable/disable", () => {
     expect(writes.length).toBe(1);
   });
 
-  it("disable writes the matching off-escape", () => {
-    enableMouseMode();
-    writes.length = 0;
-    disableMouseMode();
-    expect(writes.join("")).toBe("\u001b[?1006l\u001b[?1000l");
-  });
-
   it("disable without prior enable is a no-op", () => {
     disableMouseMode();
     expect(writes.length).toBe(0);
+  });
+
+  it("disable uses the mode active at enable time, not the current env", () => {
+    // Switching env after enable mustn't desync the disable sequence — it
+    // would leave the terminal stuck in a half-set state.
+    process.env.REASONIX_MOUSE_MODE = "sgr";
+    enableMouseMode();
+    writes.length = 0;
+    process.env.REASONIX_MOUSE_MODE = "alternate-scroll";
+    disableMouseMode();
+    expect(writes.join("")).toBe("\u001b[?1006l\u001b[?1000l");
   });
 
   it("enable when stdout isn't a TTY is a no-op", () => {
     Object.defineProperty(process.stdout, "isTTY", { value: false, configurable: true });
     enableMouseMode();
     expect(writes.length).toBe(0);
-    // And subsequent disable is also a no-op (active flag never flipped).
     disableMouseMode();
     expect(writes.length).toBe(0);
   });


### PR DESCRIPTION
## Bug class

Four issues all caused by the same architectural choice:

| Issue | Symptom |
|---|---|
| #1266 (open) | Linux terminal wheel scroll doesn't work |
| #1337 | Windows Terminal: left-drag select broken, right-click broken |
| #677 | PowerShell + Windows Terminal: can't select long answers |
| #1419 | Wheel too sensitive + can't select any text |

All four trace back to `src/cli/ui/mouse-mode.ts` enabling `?1000h+?1006h` (full SGR mouse capture) just to get wheel scrolling. The TUI then dropped click/drag events (because reasonix has no click handler), which silently took native text-select and right-click off the table for every user.

## Why `?1007h` is the right protocol here

`?1000h` is "application takes over all mouse interaction" — appropriate for `vim` or `tmux` where the app cares about clicks. Reasonix only ever cares about the wheel. `?1007h` (DECSET alternate scroll) is the protocol designed for exactly that:

- Terminal translates wheel into cursor / PageUp / PageDown key sequences in the alt screen.
- Mouse buttons stay native — copy, paste, right-click, drag-select all behave the way the terminal owner expects.
- Reasonix's existing `pageUp` / `pageDown` keystroke handler in `App.tsx` already consumes those keys for chat scroll, so the wheel keeps working without new code.

Supported by Windows Terminal, iTerm2, GNOME Terminal, kitty, Alacritty, recent xterm. Older emulators that don't recognise it silently ignore the sequence — wheel then falls back to the host terminal's own scrollback (still usable, just not in-app).

## Escape hatch

`REASONIX_MOUSE_MODE=sgr|alternate-scroll|off`:
- default: `alternate-scroll`
- `sgr`: restores the old `?1000h+?1006h` behavior for users on edge-case terminals
- `off`: no mouse reporting at all

Common case (every supported terminal) needs zero configuration.

## Tests

`tests/mouse-mode.test.ts` rewritten to cover the new default + both env-var overrides + the "disable uses the mode active at enable time" invariant (matters because mid-session env mutation would otherwise leave the terminal in a half-set state).

3526 tests pass.

## Test plan

- [ ] CI green
- [ ] Manual: wheel scroll in Windows Terminal + iTerm2 (alternate-scroll path)
- [ ] Manual: right-click context menu + drag-select work natively
- [ ] Manual: `REASONIX_MOUSE_MODE=sgr` reverts to old behavior

Closes #1266