### PR TITLE
feat(desktop): allow renaming session titles from sidebar

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -1633,14 +1633,16 @@ function TabRuntime({
     ? state.settings.workspaceDir.split(/[\\/]/).pop() || "workspace"
     : "Reasonix";
   const session = (() => {
+    if (state.currentSession) {
+      const s = state.sessions.find((x) => x.name === state.currentSession);
+      if (s?.summary?.trim()) return s.summary.trim();
+    }
     const firstUser = state.messages.find((m) => m.kind === "user");
     if (firstUser && firstUser.kind === "user") {
       const cleaned = firstUser.text.replace(/\s+/g, " ").trim();
       if (cleaned) return cleaned.length > 60 ? `${cleaned.slice(0, 60)}…` : cleaned;
     }
     if (state.currentSession) {
-      const s = state.sessions.find((x) => x.name === state.currentSession);
-      if (s?.summary?.trim()) return s.summary.trim();
       const m = state.currentSession.match(/^desktop-(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})/);
       if (m)
         return t("app.session.format", {
@@ -1736,6 +1738,7 @@ function TabRuntime({
           onNewChat={newChat}
           onLoadSession={(name) => sendRpc({ cmd: "session_load", name })}
           onDeleteSession={(name) => sendRpc({ cmd: "session_delete", name })}
+          onRenameSession={(name, title) => sendRpc({ cmd: "session_rename", name, title })}
           onOpenSettings={() => openSettingsAt("general")}
           onOpenRules={() => openSettingsAt("rules")}
           onOpenCommands={() => palette.setOpen(true)}

--- a/desktop/src/i18n/en.ts
+++ b/desktop/src/i18n/en.ts
@@ -596,6 +596,8 @@ export const en = {
     noMatches: "No matches",
     messageCount: "{count} messages",
     deleteSession: "Delete session",
+    renameSession: "Rename session",
+    renamePlaceholder: "Session title",
     approvalRules: "Approval rules",
     settings: "Settings",
     cancel: "Cancel",

--- a/desktop/src/i18n/zh-CN.ts
+++ b/desktop/src/i18n/zh-CN.ts
@@ -582,6 +582,8 @@ export const zhCN: typeof en = {
     noMatches: "无匹配结果",
     messageCount: "{count} 条",
     deleteSession: "删除会话",
+    renameSession: "重命名会话",
+    renamePlaceholder: "会话标题",
     approvalRules: "审批规则",
     settings: "设置",
     cancel: "取消",

--- a/desktop/src/icons.tsx
+++ b/desktop/src/icons.tsx
@@ -29,6 +29,7 @@ export const I = {
   chevR: (p: IconProps) => (<Ic {...p}><path d="m9 6 6 6-6 6" /></Ic>),
   check: (p: IconProps) => (<Ic {...p}><path d="m5 12 5 5L20 7" /></Ic>),
   x: (p: IconProps) => (<Ic {...p}><path d="M6 6l12 12M18 6 6 18" /></Ic>),
+  pencil: (p: IconProps) => (<Ic {...p}><path d="m4 20 4-1L20 7l-3-3L5 16l-1 4Z" /><path d="m14 6 4 4" /></Ic>),
   terminal: (p: IconProps) => (<Ic {...p}><rect x="3" y="4" width="18" height="16" rx="2" /><path d="m7 9 3 3-3 3M13 15h4" /></Ic>),
   brain: (p: IconProps) => (
     <Ic {...p}>

--- a/desktop/src/protocol.ts
+++ b/desktop/src/protocol.ts
@@ -448,6 +448,7 @@ export type OutgoingCommand = { tabId?: string } & (
   | { cmd: "session_list" }
   | { cmd: "session_delete"; name: string }
   | { cmd: "session_load"; name: string }
+  | { cmd: "session_rename"; name: string; title: string }
   | { cmd: "new_chat" }
   | { cmd: "setup_save_key"; key: string }
   | { cmd: "settings_get" }

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -1161,9 +1161,27 @@ html[data-platform="macos"] .titlebar .tb-left {
   opacity: 0;
   transition: opacity 120ms, background 120ms, color 120ms;
 }
+.session-item .rename-btn {
+  flex-shrink: 0;
+  width: 22px;
+  height: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 120ms, background 120ms, color 120ms;
+}
 .session-item:hover .delete-btn,
 .session-item:focus-within .delete-btn,
-.session-item .delete-btn:focus-visible {
+.session-item .delete-btn:focus-visible,
+.session-item:hover .rename-btn,
+.session-item:focus-within .rename-btn,
+.session-item .rename-btn:focus-visible {
   opacity: 1;
 }
 .session-item .delete-btn:hover {
@@ -1172,6 +1190,31 @@ html[data-platform="macos"] .titlebar .tb-left {
 }
 .session-item .delete-btn:focus-visible {
   outline: none;
+  box-shadow: 0 0 0 2px var(--accent-soft);
+}
+.session-item .rename-btn:hover {
+  background: var(--panel-2, rgba(255, 255, 255, 0.06));
+  color: var(--fg);
+}
+.session-item .rename-btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--accent-soft);
+}
+.session-item[data-editing="true"] {
+  cursor: default;
+}
+.session-item .body .title-edit {
+  width: 100%;
+  font: inherit;
+  color: var(--fg);
+  background: var(--panel);
+  border: 1px solid var(--border-strong);
+  border-radius: 4px;
+  padding: 2px 6px;
+  outline: none;
+}
+.session-item .body .title-edit:focus {
+  border-color: var(--accent);
   box-shadow: 0 0 0 2px var(--accent-soft);
 }
 

--- a/desktop/src/ui/sidebar.tsx
+++ b/desktop/src/ui/sidebar.tsx
@@ -4,6 +4,8 @@ import { t, useLang } from "../i18n";
 import { I } from "../icons";
 import { Shortcut } from "./shortcut";
 
+const RENAME_MAX_CHARS = 200;
+
 type PendingDelete = {
   name: string;
   pretty: string;
@@ -43,6 +45,7 @@ export function Sidebar({
   onNewChat,
   onLoadSession,
   onDeleteSession,
+  onRenameSession,
   onOpenSettings,
   onOpenRules,
   onOpenCommands,
@@ -53,6 +56,7 @@ export function Sidebar({
   onNewChat: () => void;
   onLoadSession: (name: string) => void;
   onDeleteSession: (name: string) => void;
+  onRenameSession: (name: string, title: string) => void;
   onOpenSettings: () => void;
   onOpenRules: () => void;
   onOpenCommands: () => void;
@@ -61,6 +65,8 @@ export function Sidebar({
   useLang();
   const [query, setQuery] = useState("");
   const [pendingDelete, setPendingDelete] = useState<PendingDelete | null>(null);
+  const [editingName, setEditingName] = useState<string | null>(null);
+  const [editValue, setEditValue] = useState("");
   const filtered = query
     ? sessions.filter((s) => {
         const q = query.toLowerCase();
@@ -150,16 +156,26 @@ export function Sidebar({
             const active = s.name === activeName;
             const mtime = Date.parse(s.mtime);
             const updated = Number.isFinite(mtime) ? relative(Date.now() - mtime) : s.mtime;
+            const editing = editingName === s.name;
+            const currentSummary = s.summary?.trim() ?? "";
+            const commitRename = () => {
+              const next = editValue.trim().slice(0, RENAME_MAX_CHARS);
+              if (next !== currentSummary) onRenameSession(s.name, next);
+              setEditingName(null);
+              setEditValue("");
+            };
             return (
               <div
                 key={s.name}
                 className="session-item"
                 data-active={active}
-                onClick={() => onLoadSession(s.name)}
-                role="button"
-                tabIndex={0}
+                data-editing={editing || undefined}
+                onClick={editing ? undefined : () => onLoadSession(s.name)}
+                role={editing ? undefined : "button"}
+                tabIndex={editing ? -1 : 0}
                 title={s.name}
                 onKeyDown={(e) => {
+                  if (editing) return;
                   if (e.key === "Enter") onLoadSession(s.name);
                 }}
               >
@@ -168,34 +184,79 @@ export function Sidebar({
                   style={{ background: active ? "var(--accent)" : "var(--border-strong)" }}
                 />
                 <div className="body">
-                  <span className="title">{prettyName(s)}</span>
+                  {editing ? (
+                    <input
+                      className="title-edit"
+                      autoFocus
+                      value={editValue}
+                      maxLength={RENAME_MAX_CHARS}
+                      placeholder={t("sidebarPanel.renamePlaceholder")}
+                      aria-label={t("sidebarPanel.renameSession")}
+                      onClick={(e) => e.stopPropagation()}
+                      onChange={(e) => setEditValue(e.target.value)}
+                      onBlur={commitRename}
+                      onKeyDown={(e) => {
+                        e.stopPropagation();
+                        if (e.key === "Enter") {
+                          e.preventDefault();
+                          commitRename();
+                        } else if (e.key === "Escape") {
+                          e.preventDefault();
+                          setEditingName(null);
+                          setEditValue("");
+                        }
+                      }}
+                    />
+                  ) : (
+                    <span className="title">{prettyName(s)}</span>
+                  )}
                   <span className="meta">
                     <span>{t("sidebarPanel.messageCount", { count: s.messageCount })}</span>
                     <span className="sep">·</span>
                     <span>{updated}</span>
                   </span>
                 </div>
-                <button
-                  type="button"
-                  className="delete-btn"
-                  title={t("sidebarPanel.deleteSession")}
-                  aria-label={t("sidebarPanel.deleteSession")}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    const rect = e.currentTarget.getBoundingClientRect();
-                    setPendingDelete({
-                      name: s.name,
-                      pretty: prettyName(s),
-                      x: rect.right,
-                      y: rect.bottom,
-                    });
-                  }}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" || e.key === " ") e.stopPropagation();
-                  }}
-                >
-                  <I.x size={12} />
-                </button>
+                {editing ? null : (
+                  <>
+                    <button
+                      type="button"
+                      className="rename-btn"
+                      title={t("sidebarPanel.renameSession")}
+                      aria-label={t("sidebarPanel.renameSession")}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setEditingName(s.name);
+                        setEditValue(currentSummary);
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") e.stopPropagation();
+                      }}
+                    >
+                      <I.pencil size={12} />
+                    </button>
+                    <button
+                      type="button"
+                      className="delete-btn"
+                      title={t("sidebarPanel.deleteSession")}
+                      aria-label={t("sidebarPanel.deleteSession")}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        const rect = e.currentTarget.getBoundingClientRect();
+                        setPendingDelete({
+                          name: s.name,
+                          pretty: prettyName(s),
+                          x: rect.right,
+                          y: rect.bottom,
+                        });
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") e.stopPropagation();
+                      }}
+                    >
+                      <I.x size={12} />
+                    </button>
+                  </>
+                )}
               </div>
             );
           })}

--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -99,6 +99,7 @@ type InMessage = { tabId?: string } & (
   | { cmd: "session_list" }
   | { cmd: "session_delete"; name: string }
   | { cmd: "session_load"; name: string }
+  | { cmd: "session_rename"; name: string; title: string }
   | { cmd: "new_chat" }
   | { cmd: "setup_save_key"; key: string }
   | { cmd: "settings_get" }
@@ -448,6 +449,13 @@ type EmittableEvent =
 const STDOUT_BACKPRESSURE_WAIT = new Int32Array(new SharedArrayBuffer(4));
 
 type SyncWriter = (fd: number, buffer: Buffer, offset: number, length: number) => number;
+
+const SESSION_TITLE_MAX_CHARS = 200;
+
+/** Trim + cap a user-provided session title; empty string means "clear summary". Exported for tests. */
+export function normalizeSessionTitle(raw: string): string {
+  return raw.replace(/\s+/g, " ").trim().slice(0, SESSION_TITLE_MAX_CHARS);
+}
 
 /** Drain `buffer` to `fd` across partial writes; retry EAGAIN after a 5 ms park. Exported for tests. */
 export function writeAllSync(
@@ -2063,6 +2071,19 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
     if (msg.cmd === "session_delete") {
       deleteSession(msg.name);
       emitSessions(tab);
+      return;
+    }
+    if (msg.cmd === "session_rename") {
+      try {
+        const trimmed = normalizeSessionTitle(msg.title);
+        patchSessionMeta(msg.name, { summary: trimmed || undefined });
+        emitSessions(tab);
+      } catch (err) {
+        emit(
+          { type: "$error", message: `session_rename failed: ${(err as Error).message}` },
+          tab.id,
+        );
+      }
       return;
     }
     if (msg.cmd === "session_load") {

--- a/tests/desktop-session-rename.test.ts
+++ b/tests/desktop-session-rename.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { normalizeSessionTitle } from "../src/cli/commands/desktop.js";
+
+describe("normalizeSessionTitle", () => {
+  it("trims surrounding whitespace and collapses internal runs", () => {
+    expect(normalizeSessionTitle("  hello   world  ")).toBe("hello world");
+  });
+
+  it("returns empty string for whitespace-only input — caller treats as clear", () => {
+    expect(normalizeSessionTitle("   \n\t  ")).toBe("");
+  });
+
+  it("caps at 200 characters", () => {
+    const long = "x".repeat(500);
+    expect(normalizeSessionTitle(long)).toHaveLength(200);
+  });
+
+  it("preserves CJK without truncating below the cap", () => {
+    expect(normalizeSessionTitle("我的会话")).toBe("我的会话");
+  });
+});


### PR DESCRIPTION
## Summary

Add inline rename for session titles in the desktop sidebar and sync the new title to the header, so users can rename sessions directly from the sidebar instead of being stuck with auto-generated.

## Problem

Desktop sessions could not be renamed. Sessions were auto-named with a `desktop-YYYYMMDDHHmm` timestamp or a summary generated from the first user message, and there was no way to change the display name. The sidebar had only a delete affordance but no rename entry point, and the header title stayed stale even when `meta.summary` was updated by the sidecar.

The `meta.summary` field already existed in `SessionMeta` and `patchSessionMeta` was already available on the sidecar, but three things were missing:
1. A `session_rename` IPC command (protocol + handler).
2. A rename UI element in the sidebar (pencil button + inline input).
3. The header title in `App.tsx` gave `meta.summary` lower priority than the first user message, so even a server-side rename was invisible in the title bar.

## Fix

Three layers:

| Layer | File | Change |
|---|---|---|
| **Protocol** | <code>[desktop/src/protocol.ts](desktop/src/protocol.ts) / [src/cli/commands/desktop.ts](src/cli/commands/desktop.ts)</code> | Added `session_rename` (`name`, `title`) to `OutgoingCommand` / `InMessage`. Handler calls `normalizeSessionTitle` (trim + 200‑char cap) then `patchSessionMeta(name, { summary })` and re‑emits the session list. |
| **Sidebar UI** | <code>[desktop/src/ui/sidebar.tsx](desktop/src/ui/sidebar.tsx)</code> | Added a pencil icon button (hover‑revealed, same pattern as delete). Click enters inline edit mode: `<input>` replaces the title span. Enter blurs or Esc cancels. Rename fires `onRenameSession` which sends the RPC. Also added `rename-btn` CSS rules in `styles.css`. |
| **Header sync** | <code>[desktop/src/App.tsx](desktop/src/App.tsx)</code> | Reordered the `session` variable so `s.summary` is checked **before** the first user message, making a renamed title appear instantly in the title bar. |

Supporting changes:

- New `pencil` icon in `desktop/src/icons.tsx`.
- i18n keys `renameSession` / `renamePlaceholder` in `en.ts` and `zh-CN.ts`.
- Extract `normalizeSessionTitle` into an exported function for testability.
- Test file `tests/desktop-session-rename.test.ts` covering trim, collapse‑spaces, 200‑char cap, and CJK preservation.

No changes to the JSONL filename or the `sessionName` — the rename is purely a meta‑summary change, so active sessions are safe and no abort/rebuild is needed.

## Verification

| Check | Result |
|---|---|
| `npm run lint` | ✅ 669 files, no fixes (1 historical warning, unrelated) |
| `npm run typecheck` | ✅ passes (main + dashboard) |
| `npm run test` | ✅ 3519 passed, 9 skipped (1 pre‑existing jsdom error, unrelated) |
| `npm run build` | ✅ ESM + DTS + dashboard vendor scripts |
| `vite build` (desktop) | ✅ 11.66 s, clean |
| Manual: click pencil, type, Enter | ✅ sidebar title updates |
| Manual: header title after rename | ✅ header shows new summary |
| Manual: Esc / blur cancel | ✅ edit mode dismissed |

Closes #1460