### PR TITLE
fix(plan): Accept executes the plan immediately when there are no open questions

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -3585,14 +3585,42 @@ function AppInner({
         return;
       }
 
-      if (choice === "refine" || choice === "approve") {
+      if (choice === "refine") {
         if (pendingPlan) {
           const questions = extractOpenQuestionsSection(pendingPlan) ?? undefined;
-          setStagedInput({ plan: pendingPlan, mode: choice, questions });
+          setStagedInput({ plan: pendingPlan, mode: "refine", questions });
           setPendingPlan(null);
-        } else if (choice === "approve") {
-          setStagedInput({ plan: "", mode: "approve" });
         }
+        return;
+      }
+
+      if (choice === "approve") {
+        if (pendingPlan) {
+          const questions = extractOpenQuestionsSection(pendingPlan) ?? undefined;
+          if (questions) {
+            // Plan flagged open questions — keep the staged input so the user
+            // can answer them before approve goes through.
+            setStagedInput({ plan: pendingPlan, mode: "approve", questions });
+            setPendingPlan(null);
+          } else {
+            // No open questions → Accept should execute the plan, not stop
+            // for an optional-guidance step. Resolve the gate directly via the
+            // same path handleStagedInputSubmit uses for explicit-feedback
+            // approvals so plan-card setup and lifecycle hooks stay in sync.
+            // #1475: the staged input was visually indistinguishable from the
+            // regular composer, trapping users after the picker reopened from
+            // a reject-flow Esc and breaking their "Accept = run it" mental
+            // model.
+            const plan = pendingPlan;
+            setPendingPlan(null);
+            await handlePlanFeedbackRef.current("", { plan, mode: "approve" });
+          }
+          return;
+        }
+        // `/apply-plan` slash fallback — model wrote a plan in assistant text
+        // instead of calling submit_plan, so there's no pending gate to resolve.
+        // Surface the staged input so we still capture the implement-now intent.
+        setStagedInput({ plan: "", mode: "approve" });
         return;
       }
 


### PR DESCRIPTION
## Bug

Reported in #1475. Repro from the issue:

1. In review mode, ask the model for a modification plan.
2. When the plan picker shows, press **Esc** → enters the reject staged input.
3. Without typing anything, press **Esc** again → picker is restored.
4. Pick **Accept** → expected: plan executes. Actual: another staged input opens (the "approve mode" optional-guidance prompt).
5. That input looks indistinguishable from the regular composer, so the user types follow-up instructions like "执行计划", which actually go through as the approve verdict's \`feedback\`. The user's "Accept = run it" expectation keeps breaking.

## Root cause

\`handlePlanConfirm("approve")\` unconditionally opened a staged input even when the plan had no open questions. That second input only makes sense as a place to answer open questions the model flagged in the plan; for fully-specified plans it's pure friction (and, in this scenario, gets mis-interpreted as the regular composer).

## Fix

In \`handlePlanConfirm\`:

- **approve + open questions present** → keep the staged input (questions need answering)
- **approve + no open questions** → resolve the pause gate immediately via the same \`handleStagedInputSubmit\` override path \`/dashboard\` already uses, so \`recordPlanApproved\` / \`log.showPlan({ variant: "active" })\` / \`persistPlanState\` all fire identically to the explicit-feedback path
- **refine** → unchanged (feedback is the whole point)
- **\`/apply-plan\` slash fallback** (no pending plan, no gate) → unchanged

## Test plan

- [ ] CI green (3531 tests pass locally; plan-confirm, plan-checkpoint-confirm, plan suites all green)
- [ ] Manual: Esc → reject staged input → Esc → back to picker → Accept → plan executes (no extra input)
- [ ] Manual: plan with \`## Open questions\` section → Accept still opens the input so the user can answer
- [ ] Manual: refine still opens the input

Closes #1475