### PR TITLE
feat(i18n): localize MCP error toasts and status labels with zh-CN

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -1219,8 +1219,8 @@ function AppInner({
         bumpReady();
       } else if (notice.kind === "failed") {
         log.pushWarning(
-          `MCP ${notice.name} failed`,
-          `${notice.reason}\nrun \`reasonix setup\` to remove this entry, or fix the underlying issue (missing npm package, network, etc.).`,
+          t("app.mcpFailed", { name: notice.name }),
+          `${notice.reason}\n${t("mcpLifecycle.failedSetupHint")}`,
         );
         bumpReady();
       } else if (notice.kind === "tools-ready") {
@@ -1235,7 +1235,7 @@ function AppInner({
         bumpReady();
       } else if (notice.kind === "warn") {
         log.pushWarning(
-          `MCP ${notice.name} warn`,
+          t("app.mcpWarn", { name: notice.name }),
           formatMcpLifecycleEvent({
             state: "warn",
             name: notice.name,

--- a/src/cli/ui/mcp-browse.ts
+++ b/src/cli/ui/mcp-browse.ts
@@ -154,8 +154,8 @@ export async function handleMcpBrowseSlash(
     const server = findServerForResource(servers, arg);
     if (!server) {
       log.pushWarning(
-        `no server exposes resource "${arg}"`,
-        "`/resource` with no arg lists what's available.",
+        t("mcpBrowse.noServerForResource", { name: arg }),
+        t("mcpBrowse.resourceHint"),
       );
       return;
     }
@@ -163,7 +163,7 @@ export async function handleMcpBrowseSlash(
       const result = await server.readResource(arg);
       log.pushInfo(formatResourceContents(arg, result));
     } catch (err) {
-      log.pushWarning("readResource failed", (err as Error).message);
+      log.pushWarning(t("mcpBrowse.readFailed"), (err as Error).message);
     }
     return;
   }
@@ -171,16 +171,13 @@ export async function handleMcpBrowseSlash(
   // prompt
   const server = findServerForPrompt(servers, arg);
   if (!server) {
-    log.pushWarning(
-      `no server exposes prompt "${arg}"`,
-      "`/prompt` with no arg lists what's available.",
-    );
+    log.pushWarning(t("mcpBrowse.noServerForPrompt", { name: arg }), t("mcpBrowse.promptHint"));
     return;
   }
   try {
     const result = await server.getPrompt(arg);
     log.pushInfo(formatPromptMessages(arg, result));
   } catch (err) {
-    log.pushWarning("getPrompt failed", (err as Error).message);
+    log.pushWarning(t("mcpBrowse.fetchFailed"), (err as Error).message);
   }
 }

--- a/src/cli/ui/mcp-lifecycle.ts
+++ b/src/cli/ui/mcp-lifecycle.ts
@@ -24,8 +24,8 @@ const STATE: Record<McpLifecycleEvent["state"], { glyph: string; label: () => st
   failed: { glyph: "✖", label: () => t("mcpLifecycle.failed") },
   disabled: { glyph: "○", label: () => t("mcpLifecycle.disabled") },
   reconnect: { glyph: "↻", label: () => t("mcpLifecycle.reconnect") },
-  "tools-ready": { glyph: "⚡", label: () => "tools ready" },
-  warn: { glyph: "⚠", label: () => "warn" },
+  "tools-ready": { glyph: "⚡", label: () => t("mcpLifecycle.toolsReady") },
+  warn: { glyph: "⚠", label: () => t("mcpLifecycle.warnLabel") },
 };
 
 const NAME_COL = 22;

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -645,6 +645,8 @@ export const EN: TranslationSchema = {
       "/undo                 \u2192 newest non-undone   \u00b7    /undo <id> [path]  \u2192 target a specific batch or file",
     editHistoryAlreadyReverted: "(already reverted \u2014 /history shows the batch-level status)",
     editHistoryRevertFile: "/undo {id} {path}  \u2192 revert just this file",
+    mcpFailed: "MCP {name} failed",
+    mcpWarn: "MCP {name} warn",
   },
   hooks: {
     head: "hook {tag} `{cmd}` {decision}{truncTag}",
@@ -1740,6 +1742,12 @@ export const EN: TranslationSchema = {
       "No prompts on any connected MCP server (or no servers connected). `/mcp` shows the current set.",
     fetchOne:
       "Fetch one: `/prompt <name>` \u2014 args are not supported yet; prompts with required args will surface an error from the server.",
+    noServerForResource: 'no server exposes resource "{name}"',
+    resourceHint: "`/resource` with no arg lists what's available.",
+    readFailed: "readResource failed",
+    noServerForPrompt: 'no server exposes prompt "{name}"',
+    promptHint: "`/prompt` with no arg lists what's available.",
+    fetchFailed: "getPrompt failed",
   },
   mcpLifecycle: {
     handshake: "handshake\u2026",
@@ -1756,6 +1764,8 @@ export const EN: TranslationSchema = {
       "→ run `reasonix setup` to remove broken entries from your saved config.",
     abortedHint:
       "MCP startup aborted — {count} server(s) skipped. Run /mcp to retry once you've fixed the underlying issue.",
+    toolsReady: "tools ready",
+    warnLabel: "warn",
   },
   checkpointPicker: {
     title: "restore a checkpoint \u2014 {workspace}",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -231,12 +231,20 @@ export interface TranslationSchema {
     editHistoryHelpUndo: string;
     editHistoryAlreadyReverted: string;
     editHistoryRevertFile: string;
+    mcpFailed: string;
+    mcpWarn: string;
   };
   mcpBrowse: {
     noResources: string;
     readOne: string;
     noPrompts: string;
     fetchOne: string;
+    noServerForResource: string;
+    resourceHint: string;
+    readFailed: string;
+    noServerForPrompt: string;
+    promptHint: string;
+    fetchFailed: string;
   };
   hooks: {
     head: string;
@@ -851,6 +859,8 @@ export interface TranslationSchema {
     failedSetupHint: string;
     failedSetupConfigHint: string;
     abortedHint: string;
+    toolsReady: string;
+    warnLabel: string;
   };
   checkpointPicker: {
     title: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -625,6 +625,8 @@ export const zhCN: TranslationSchema = {
       "/undo                 → 最新的未撤销项   ·    /undo <id> [path]  → 指定批次或文件",
     editHistoryAlreadyReverted: "（已撤销 — /history 显示批次级状态）",
     editHistoryRevertFile: "/undo {id} {path}  → 仅还原此文件",
+    mcpFailed: "MCP {name} 失败",
+    mcpWarn: "MCP {name} 警告",
   },
   hooks: {
     head: "钩子 {tag} `{cmd}` {decision}{truncTag}",
@@ -1650,6 +1652,12 @@ export const zhCN: TranslationSchema = {
     readOne: "读取：`/resource <uri>` — 或在选择器中使用 Tab 键。",
     noPrompts: "没有任何已连接 MCP 服务器上的提示（或无服务器连接）。`/mcp` 显示当前列表。",
     fetchOne: "获取：`/prompt <name>` — 暂不支持参数；带必需参数的提示将返回服务器错误。",
+    noServerForResource: '没有服务器暴露资源 "{name}"',
+    resourceHint: "`/resource` 不带参数可查看可用列表。",
+    readFailed: "读取资源失败",
+    noServerForPrompt: '没有服务器暴露 prompt "{name}"',
+    promptHint: "`/prompt` 不带参数可查看可用列表。",
+    fetchFailed: "获取 prompt 失败",
   },
   mcpLifecycle: {
     handshake: "握手中…",
@@ -1663,6 +1671,8 @@ export const zhCN: TranslationSchema = {
     failedSetupHint: "→ 运行 `reasonix setup` 移除此条目，或修复底层问题（缺少 npm 包、网络等）。",
     failedSetupConfigHint: "→ 运行 `reasonix setup` 从已保存配置中移除损坏的条目。",
     abortedHint: "已中断 MCP 启动 — 跳过 {count} 个服务器。问题修复后用 /mcp 重新连接。",
+    toolsReady: "工具就绪",
+    warnLabel: "警告",
   },
   checkpointPicker: {
     title: "恢复检查点 \u2014 {workspace}",


### PR DESCRIPTION
## Summary

Localize hardcoded MCP error toast titles, lifecycle status labels, and
resource/prompt failure messages via the i18n system.

**6 files changed, 40 insertions(+), 13 deletions(-)**

### Changes

- **`src/i18n/types.ts`** — add 10 new keys across `app`, `mcpLifecycle`, `mcpBrowse`
- **`src/i18n/EN.ts`** / **`src/i18n/zh-CN.ts`** — EN + zh-CN translations
- **`src/cli/ui/mcp-lifecycle.ts`** — `"tools ready"` / `"warn"` labels → `t()`
- **`src/cli/ui/mcp-browse.ts`** — resource/prompt fetch failure toasts → `t()`
- **`src/cli/ui/App.tsx`** — MCP startup failure/warning toast titles → `t()`;
  reuse existing `mcpLifecycle.failedSetupHint` instead of inline string

### Verification

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean (our files)
- [x] Key parity EN ↔ zh-CN — full match