### PR TITLE
fix(desktop): clear orphaned pause-gate modals on $turn_complete

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -567,7 +567,24 @@ export function applyIncoming(state: State, ev: IncomingEvent): State {
     case "$needs_setup":
       return { ...state, needsSetup: true, ready: false };
     case "$turn_complete":
-      return { ...state, busy: false, activeSkill: null };
+      // Clear pause-gate-tied modals too. By the time the loop emits
+      // $turn_complete, anything still in these arrays is orphaned — the
+      // tool call that opened it has either resolved (so it's gone already)
+      // or the turn was aborted (so the model isn't coming back for it).
+      // Without this, an Esc/abort during plan approval leaves the plan
+      // card rendered AFTER state.messages forever; the queued user input
+      // that drains next then appears above the zombie card (#1456).
+      return {
+        ...state,
+        busy: false,
+        activeSkill: null,
+        pendingConfirms: [],
+        pendingPathAccess: [],
+        pendingChoices: [],
+        pendingPlans: [],
+        pendingCheckpoints: [],
+        pendingRevisions: [],
+      };
     case "$confirm_required":
       return {
         ...state,

--- a/tests/desktop-btw-status.test.ts
+++ b/tests/desktop-btw-status.test.ts
@@ -117,3 +117,40 @@ describe("desktop $btw_result reducer (#1470)", () => {
     });
   });
 });
+
+describe("desktop $turn_complete reducer (#1456)", () => {
+  it("clears orphaned pause-gate modals so an aborted plan card stops haunting the transcript", () => {
+    // When the user aborts (e.g. presses the stop button mistaken for send)
+    // mid-plan-approval, the loop unwinds and emits $turn_complete. Without
+    // this clear, pendingPlans stays populated — the queued user message
+    // drains next and renders ABOVE the zombie plan card (#1456).
+    const state: AppState = {
+      ...makeState(),
+      busy: true,
+      pendingPlans: [{ id: 7, plan: "## Plan\nstep 1\nstep 2", summary: "do thing" }],
+      pendingConfirms: [{ id: 8, kind: "shell", command: "rm -rf /tmp/x", prompt: "?" }],
+      pendingPathAccess: [{ id: 9, path: "/secret" }],
+      pendingChoices: [{ id: 10, question: "?", options: [], allowCustom: false }],
+      pendingCheckpoints: [
+        {
+          id: 11,
+          stepId: "s1",
+          title: "step 1",
+          result: "ok",
+          notes: "",
+          completed: 1,
+          total: 2,
+        },
+      ],
+      pendingRevisions: [{ id: 12, reason: "blocked", remainingSteps: [] }],
+    };
+    const next = reduce(state, { t: "incoming", event: { type: "$turn_complete" } });
+    expect(next.busy).toBe(false);
+    expect(next.pendingPlans).toEqual([]);
+    expect(next.pendingConfirms).toEqual([]);
+    expect(next.pendingPathAccess).toEqual([]);
+    expect(next.pendingChoices).toEqual([]);
+    expect(next.pendingCheckpoints).toEqual([]);
+    expect(next.pendingRevisions).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Bug

Reported in #1456. After issuing \`/plan\`, the user typed follow-up guidance during the approval modal; the composer queued it (busy=true). They then clicked what looked like the send button — but the composer swaps that button for **stop/abort** while busy. The turn aborted, the queue drained, and the new user message visibly appeared **above** the still-rendered plan card.

## Root cause

The desktop render order is \`state.messages → state.pendingPlans\` (lines ~1800/1863 in \`App.tsx\`). Any user message that lands in \`messages\` while \`pendingPlans\` still has entries renders above the plan card.

\`\$turn_complete\` only cleared \`busy\` and \`activeSkill\`. So on abort:

1. Loop unwinds, emits \`\$turn_complete\` → busy=false (but pendingPlans stays).
2. Drain effect at \`App.tsx:1335\` sends the queued user_input → \`send_user\` appends to \`messages\`.
3. Render order = \`[…, queued user msg, …, ZOMBIE plan card]\`.

The error toast the user also saw is the aborted \`submit_plan\` call unwinding — separate path, unchanged.

## Fix

\`\$turn_complete\` now also clears \`pendingConfirms\`, \`pendingPathAccess\`, \`pendingChoices\`, \`pendingPlans\`, \`pendingCheckpoints\`, \`pendingRevisions\`. By the time the loop emits this event, any entry still in those arrays is orphaned anyway:
- Normal completion → user resolved everything mid-turn → arrays already empty → no-op.
- Aborted turn → model isn't coming back for the gate → clearing prevents the zombie modal.

## Test plan

- New test in \`tests/desktop-btw-status.test.ts\` seeds all six pending* arrays + busy=true, dispatches \`\$turn_complete\`, verifies every array is cleared.
- 3533 tests pass locally.

Closes #1456