### PR TITLE
feat: optimize java tool

### DIFF
--- a/src/java/class-source-finder.ts
+++ b/src/java/class-source-finder.ts
@@ -10,7 +10,7 @@ import { readJarEntry } from "./zip-reader.js";
 export interface FindResultSuccess {
   found: true;
   source: string;
-  method: "project" | "m2-jar" | "jar";
+  method: "project" | "m2-source-jar" | "m2-jar" | "jar";
   sourcePath: string;
 }
 
@@ -131,15 +131,36 @@ export class ClassSourceFinder {
   }
 
   private async searchRepositories(fqn: string, jarKeyword?: string): Promise<FindResult> {
+    const javaEntry = `${fqn.replace(/\./g, "/")}.java`;
     const classEntry = `${fqn.replace(/\./g, "/")}.class`;
 
-    const jarPaths: string[] = [];
+    const sourceJars: string[] = [];
+    const regularJars: string[] = [];
     for (const repoDir of this.repoPaths) {
-      await this.walkForJars(repoDir, jarPaths, jarKeyword);
+      await this.walkForJars(repoDir, sourceJars, regularJars, jarKeyword);
     }
 
+    // Pass 1: prefer source jars — read .java directly, no decompile.
+    for (const jarPath of sourceJars) {
+      this.throwIfAborted();
+      try {
+        const content = readJarEntry(jarPath, javaEntry);
+        if (content) {
+          return {
+            found: true,
+            source: content.data.toString("utf-8"),
+            method: "m2-source-jar",
+            sourcePath: jarPath,
+          };
+        }
+      } catch {
+        // skip
+      }
+    }
+
+    // Pass 2: fall back to regular jars — decompile .class via javap.
     let scanned = 0;
-    for (const jarPath of jarPaths) {
+    for (const jarPath of regularJars) {
       this.throwIfAborted();
       if (scanned >= this.maxJarScan) break;
 
@@ -162,7 +183,8 @@ export class ClassSourceFinder {
 
   private async walkForJars(
     dir: string,
-    out: string[],
+    sourceJars: string[],
+    regularJars: string[],
     keyword?: string,
     depth = 0,
   ): Promise<void> {
@@ -177,14 +199,18 @@ export class ClassSourceFinder {
 
     for (const entry of entries) {
       this.throwIfAborted();
-      if (out.length >= this.maxJarScan) return;
+      if (sourceJars.length + regularJars.length >= this.maxJarScan) return;
 
       const fullPath = path.join(dir, entry.name);
       if (entry.isDirectory()) {
-        await this.walkForJars(fullPath, out, keyword, depth + 1);
+        await this.walkForJars(fullPath, sourceJars, regularJars, keyword, depth + 1);
       } else if (entry.isFile() && entry.name.endsWith(".jar")) {
         if (!keyword || fullPath.toLowerCase().includes(keyword.toLowerCase())) {
-          out.push(fullPath);
+          if (entry.name.endsWith("-sources.jar") || entry.name.includes("-sources-")) {
+            sourceJars.push(fullPath);
+          } else {
+            regularJars.push(fullPath);
+          }
         }
       }
     }

--- a/src/tools/java-source.ts
+++ b/src/tools/java-source.ts
@@ -14,10 +14,9 @@ export function registerJavaSourceTool(
     description: [
       "Find and return Java source code by fully-qualified class name.",
       "",
-      "Three search modes (picked automatically based on which parameters are set):",
+      "Two search modes (picked automatically based on which parameters are set):",
       "1. **Default** (className + jarKeyword): walk project tree for a `.java` file, then scan `~/.m2/repository` jars whose path/name contains the keyword.",
-      "2. **Without keyword** (className only): same as default but scans ALL jars — much slower, use only when you don't know the library.",
-      "3. **With jarPath** (className + jarPath): skip both project + .m2 scans, decompile directly from the specified jar file.",
+      "2. **With jarPath** (className + jarPath): skip both project + .m2 scans, decompile directly from the specified jar file.",
       "",
       "Returns the source text (or decompiled bytecode) on success, or a clear 'not found' message.",
       "Only call this tool once per class name — it's I/O heavy.",
@@ -44,17 +43,17 @@ export function registerJavaSourceTool(
         jarKeyword: {
           type: "string",
           description:
-            'Optional. Only search jars whose filename or path contains this keyword (case-insensitive). Dramatically narrows the scan when you know the library name, e.g. "spring-core", "guava", "mycompany-utils". Ignored when jarPath is also set.',
+            'Only search jars whose filename or path contains this keyword (case-insensitive). Dramatically narrows the scan when you know the library name, e.g. "spring-core", "guava", "mycompany-utils". Ignored when jarPath is also set.',
         },
       },
-      required: ["className"],
+      required: ["className", "jarKeyword"],
     },
     parallelSafe: true,
     fn: async (args: {
       className: string;
       projectRoot?: string;
       jarPath?: string;
-      jarKeyword?: string;
+      jarKeyword: string;
     }) => {
       const className = (args?.className ?? "").trim();
       if (!className) {
@@ -67,7 +66,7 @@ export function registerJavaSourceTool(
         );
       }
 
-      const jarKeyword = (args?.jarKeyword ?? "").trim();
+      const jarKeyword = args.jarKeyword.trim();
       const jarPath = args?.jarPath?.trim();
 
       const projectRoot = args?.projectRoot?.trim() || opts.projectRoot || process.cwd();
@@ -94,12 +93,9 @@ export function registerJavaSourceTool(
       const result = await finder.findSource(className, jarKeyword ? { jarKeyword } : undefined);
 
       if (!result.found) {
-        const keywordLine = jarKeyword
-          ? `  • Maven .m2 / Gradle cache for jars containing keyword "${jarKeyword}"`
-          : "  • Maven .m2 / Gradle cache for all jars";
-        const tip = jarKeyword
-          ? "Try a different keyword, use `jarPath` with the exact path, or check if the class is in a different library."
-          : 'Tip: pass `jarKeyword` (e.g. "spring-core", "guava") to narrow the scan, or `jarPath` with the exact jar path to skip the scan entirely.';
+        const keywordLine = `  • Maven .m2 / Gradle cache for jars containing keyword "${jarKeyword}"`;
+        const tip =
+          "Try a different keyword, use `jarPath` with the exact path, or check if the class is in a different library.";
         return JSON.stringify({
           status: "not-found",
           className,

--- a/src/tools/java-source.ts
+++ b/src/tools/java-source.ts
@@ -14,9 +14,7 @@ export function registerJavaSourceTool(
     description: [
       "Find and return Java source code by fully-qualified class name.",
       "",
-      "Two search modes (picked automatically based on which parameters are set):",
-      "1. **Default** (className + jarKeyword): walk project tree for a `.java` file, then scan `~/.m2/repository` jars whose path/name contains the keyword.",
-      "2. **With jarPath** (className + jarPath): skip both project + .m2 scans, decompile directly from the specified jar file.",
+      "Search mode: walk the project tree for a `.java` file, then scan `~/.m2/repository` jars whose filename or path contains `jarKeyword`.",
       "",
       "Returns the source text (or decompiled bytecode) on success, or a clear 'not found' message.",
       "Only call this tool once per class name — it's I/O heavy.",
@@ -30,31 +28,16 @@ export function registerJavaSourceTool(
           description:
             'Fully qualified Java class name, e.g. "com.google.common.collect.Lists" or "org.springframework.web.servlet.DispatcherServlet".',
         },
-        projectRoot: {
-          type: "string",
-          description:
-            "Optional. Override the project root directory for phase-1 file search. Defaults to the current session's workspace root.",
-        },
-        jarPath: {
-          type: "string",
-          description:
-            'Optional. Exact path to a .jar file. When set, skips project file search and .m2 scan — reads the class directly from this jar and decompiles it. Useful when you know which dependency jar contains the class, e.g. "/home/user/.m2/repository/org/springframework/spring-core/6.1.0/spring-core-6.1.0.jar".',
-        },
         jarKeyword: {
           type: "string",
           description:
-            'Only search jars whose filename or path contains this keyword (case-insensitive). Dramatically narrows the scan when you know the library name, e.g. "spring-core", "guava", "mycompany-utils". Ignored when jarPath is also set.',
+            'Only search jars whose filename or path contains this keyword (case-insensitive). Keep it short — a narrow substring like "spring-core", "guava", or "mycompany-utils" scans faster and matches more precisely than a long fragment.',
         },
       },
       required: ["className", "jarKeyword"],
     },
     parallelSafe: true,
-    fn: async (args: {
-      className: string;
-      projectRoot?: string;
-      jarPath?: string;
-      jarKeyword: string;
-    }) => {
+    fn: async (args: { className: string; jarKeyword: string }) => {
       const className = (args?.className ?? "").trim();
       if (!className) {
         throw new Error("java_source: `className` is required");
@@ -67,35 +50,18 @@ export function registerJavaSourceTool(
       }
 
       const jarKeyword = args.jarKeyword.trim();
-      const jarPath = args?.jarPath?.trim();
-
-      const projectRoot = args?.projectRoot?.trim() || opts.projectRoot || process.cwd();
-      const finder = new ClassSourceFinder({ projectRoot });
-
-      if (jarPath) {
-        const result = await finder.findSourceInJar(className, jarPath);
-        if (!result.found) {
-          return JSON.stringify({
-            status: "not-found",
-            className,
-            message: `Class "${className}" not found in jar:\n  ${jarPath}\n\nMake sure the class name is correct and that the jar contains that entry.`,
-          });
-        }
-        return JSON.stringify({
-          status: "found",
-          className,
-          method: result.method,
-          sourcePath: result.sourcePath,
-          source: result.source,
-        });
+      if (!jarKeyword) {
+        throw new Error("java_source: `jarKeyword` must not be empty");
       }
 
-      const result = await finder.findSource(className, jarKeyword ? { jarKeyword } : undefined);
+      const projectRoot = opts.projectRoot || process.cwd();
+      const finder = new ClassSourceFinder({ projectRoot });
+
+      const result = await finder.findSource(className, { jarKeyword });
 
       if (!result.found) {
         const keywordLine = `  • Maven .m2 / Gradle cache for jars containing keyword "${jarKeyword}"`;
-        const tip =
-          "Try a different keyword, use `jarPath` with the exact path, or check if the class is in a different library.";
+        const tip = "Try a different keyword, or check if the class is in a different library.";
         return JSON.stringify({
           status: "not-found",
           className,

--- a/tests/java-source.test.ts
+++ b/tests/java-source.test.ts
@@ -743,7 +743,7 @@ describe("registerJavaSourceTool", () => {
     expect(spec!.parameters).toBeDefined();
     expect(spec!.parameters!.properties).toHaveProperty("className");
     expect(spec!.parameters!.required).toContain("className");
-    expect(spec!.parameters!.required).not.toContain("jarKeyword");
+    expect(spec!.parameters!.required).toContain("jarKeyword");
   });
 
   it("validates className is required — returns error JSON", async () => {
@@ -839,7 +839,7 @@ describe("registerJavaSourceTool", () => {
     expect(parsed.sourcePath).toContain("Hello.java");
   });
 
-  it("mode 2: jarPath dispatch reads + decompiles (jarKeyword not required)", async () => {
+  it("mode 2: jarPath dispatch reads + decompiles", async () => {
     const root = await tmpDir();
     const jarPath = join(root, "lib.jar");
     // Need execFile to return javap output
@@ -865,12 +865,12 @@ describe("registerJavaSourceTool", () => {
     const reg = new ToolRegistry();
     registerJavaSourceTool(reg, { projectRoot: root });
 
-    // jarPath mode should work without jarKeyword
     const result = await reg.dispatch(
       "java_source",
       JSON.stringify({
         className: "com.example.Util",
         jarPath,
+        jarKeyword: "test",
       }),
     );
     const parsed = JSON.parse(result);
@@ -879,7 +879,7 @@ describe("registerJavaSourceTool", () => {
     expect(parsed.source).toContain("public class Util");
   });
 
-  it("jarKeyword dispatch accepts keyword without error", async () => {
+  it("normal dispatch with jarKeyword returns not-found when no match", async () => {
     const root = await tmpDir();
     mkdirSync(join(root, "src"), { recursive: true });
     writeFileSync(join(root, "src", "main.ts"), "not java");
@@ -905,11 +905,10 @@ describe("registerJavaSourceTool", () => {
     expect(parsed.className).toBe("org.springframework.SomeClass");
   });
 
-  it("className-only dispatch (no jarKeyword, no jarPath) works", async () => {
+  it("rejects dispatch when jarKeyword is missing", async () => {
     const root = await tmpDir();
     mkdirSync(join(root, "src"), { recursive: true });
     writeFileSync(join(root, "src", "main.ts"), "not java");
-    vi.spyOn(ClassSourceFinder, "defaultRepoPaths").mockReturnValue([]);
 
     const reg = new ToolRegistry();
     registerJavaSourceTool(reg, { projectRoot: root });
@@ -919,10 +918,9 @@ describe("registerJavaSourceTool", () => {
       JSON.stringify({ className: "com.example.Missing" }),
     );
     const parsed = JSON.parse(result);
-    expect(parsed.status).toBe("not-found");
-    expect(parsed.className).toBe("com.example.Missing");
-    // When jarKeyword is absent, the tip should suggest passing it
-    expect(parsed.message).toContain("Tip: pass `jarKeyword`");
+    expect(parsed).toHaveProperty("error");
+    expect(parsed.error).toContain("missing required parameter");
+    expect(parsed.error).toContain("jarKeyword");
   });
 
   it("returns proper not-found response format", async () => {

--- a/tests/java-source.test.ts
+++ b/tests/java-source.test.ts
@@ -839,46 +839,6 @@ describe("registerJavaSourceTool", () => {
     expect(parsed.sourcePath).toContain("Hello.java");
   });
 
-  it("mode 2: jarPath dispatch reads + decompiles", async () => {
-    const root = await tmpDir();
-    const jarPath = join(root, "lib.jar");
-    // Need execFile to return javap output
-    vi.mocked(execFile).mockImplementation(((
-      _cmd: unknown,
-      _args: unknown,
-      _opts: unknown,
-      cb: unknown,
-    ) => {
-      if (typeof cb === "function") {
-        (cb as (err: Error | null, stdout: string, stderr: string) => void)(
-          null,
-          'Compiled from "Util.java"\npublic class Util { public Util(); }\n',
-          "",
-        );
-      }
-    }) as any);
-    writeFileSync(
-      jarPath,
-      createZip([{ name: "com/example/Util.class", data: Buffer.from("fake") }]),
-    );
-
-    const reg = new ToolRegistry();
-    registerJavaSourceTool(reg, { projectRoot: root });
-
-    const result = await reg.dispatch(
-      "java_source",
-      JSON.stringify({
-        className: "com.example.Util",
-        jarPath,
-        jarKeyword: "test",
-      }),
-    );
-    const parsed = JSON.parse(result);
-    expect(parsed.status).toBe("found");
-    expect(parsed.method).toBe("jar");
-    expect(parsed.source).toContain("public class Util");
-  });
-
   it("normal dispatch with jarKeyword returns not-found when no match", async () => {
     const root = await tmpDir();
     mkdirSync(join(root, "src"), { recursive: true });
@@ -921,6 +881,25 @@ describe("registerJavaSourceTool", () => {
     expect(parsed).toHaveProperty("error");
     expect(parsed.error).toContain("missing required parameter");
     expect(parsed.error).toContain("jarKeyword");
+  });
+
+  it("rejects dispatch when jarKeyword is empty or whitespace", async () => {
+    const root = await tmpDir();
+    mkdirSync(join(root, "src"), { recursive: true });
+    writeFileSync(join(root, "src", "main.ts"), "not java");
+
+    const reg = new ToolRegistry();
+    registerJavaSourceTool(reg, { projectRoot: root });
+
+    for (const kw of ["", "   ", "\t"]) {
+      const result = await reg.dispatch(
+        "java_source",
+        JSON.stringify({ className: "com.example.Foo", jarKeyword: kw }),
+      );
+      const parsed = JSON.parse(result);
+      expect(parsed).toHaveProperty("error");
+      expect(parsed.error).toContain("must not be empty");
+    }
   });
 
   it("returns proper not-found response format", async () => {


### PR DESCRIPTION
## What

Simplify `java_source` tool interface: remove `jarPath`/`projectRoot` parameters, make `jarKeyword` required to avoid keyword-less full m2 repository scans. Also optimize jar scanning strategy — prioritize reading source code directly from `-sources.jar`, skipping javap decompilation. Added validation for blank `jarKeyword`.

## Why

1. **Security**: optional `jarKeyword` means the model could omit the keyword, triggering a full m2 repository scan (hundreds of jars), which is slow and wastes I/O
2. **Code Quality**: `jarPath` mode was exposed at the tool layer but had no actual usage scenarios; removing it makes the interface cleaner and parameter validation stricter
3. **Performance**: source-jar first strategy avoids unnecessary javap subprocess launches and temporary file I/O
4. **Defensiveness**: pure whitespace characters in `jarKeyword` could bypass required validation; added non-empty check after trim

## How to verify

`npm run verify`, focusing on `tests/java-source.test.ts` (42 tests, including newly added blank keyword rejection + missing keyword rejection cases).

## Checklist

- [√] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [√] No `Co-Authored-By: Claude` trailer in commits
- [√] Comments follow CONTRIBUTING.md
- [√] No edits to `CHANGELOG.md`