### PR TITLE
fix(tui): keep SGR mouse on Windows — alternate-scroll breaks wheel on WT

### DIFF
--- a/src/cli/ui/mouse-mode.ts
+++ b/src/cli/ui/mouse-mode.ts
@@ -1,30 +1,43 @@
-// Mouse-protocol selection for the TUI. Default: DECSET 1007 (alternate scroll
-// mode). We DON'T need full mouse capture — the TUI never reacts to clicks or
-// drags, only the wheel. `?1000h` was the old default and broke native text
-// selection + right-click context menu for every user (#1337, #677, #1419) just
-// to get the wheel working — net negative when the only thing reasonix uses
-// the mouse for is scrolling chat history.
+// Mouse-protocol selection for the TUI. Reasonix only reacts to the wheel —
+// clicks and drags are not handled — so the goal is "wheel works in-app,
+// native click/drag/right-click stays untouched".
 //
-// `?1007h` (alternate scroll): the terminal translates wheel events into
-// up/down (or PgUp/PgDn, depending on terminal) key sequences in the alt
-// screen. Mouse buttons stay native — copy/paste/right-click all behave the
-// way the terminal owner expects. Supported by Windows Terminal, iTerm2,
-// GNOME Terminal, kitty, Alacritty, recent xterm. Terminals without it
-// (macOS Terminal.app, very old emulators) fall back to the host terminal's
-// own scrollback for history — still functional, just not in-app wheel scroll.
+// `?1007h` (DECSET alternate scroll) does exactly that: the terminal
+// translates wheel events into up/down (or PgUp/PgDn) key sequences in the
+// alt screen, leaving mouse buttons native. Works on iTerm2, GNOME
+// Terminal, kitty, Alacritty, recent xterm.
 //
-// Escape hatch: `REASONIX_MOUSE_MODE=sgr` restores the old `?1000h+?1006h`
-// behavior for users on terminals where alternate scroll doesn't work and
-// they prefer in-app wheel over native selection. `off` disables mouse
-// reporting entirely (no in-app wheel, full native behavior).
+// Windows Terminal is the odd one out: it advertises `?1007h` but doesn't
+// reliably translate wheel events to keys, so reasonix never sees the
+// wheel. The old default `?1000h+?1006h` (full SGR mouse capture) DID work
+// for the wheel on WT, at the cost of breaking native text selection /
+// right-click — which is what got us into #1337 / #677 / #1419 in the
+// first place. On Windows the proven wheel-working mode is still SGR, so
+// platform-detect and pick the right one rather than ship a regression
+// either way (#1456-followup: WT users lost wheel scroll after the
+// alternate-scroll switch).
+//
+// Escape hatch: `REASONIX_MOUSE_MODE=sgr|alternate-scroll|off` overrides
+// the platform default for users on terminals where the auto-pick is
+// wrong.
 
 type Mode = "alternate-scroll" | "sgr" | "off";
+
+function platformDefault(): Mode {
+  // Windows Terminal / conhost / ConEmu / Cmder all honor SGR mouse capture
+  // but not alternate-scroll. The handful of Linux/macOS terminals that
+  // don't honor `?1007h` (notably macOS Terminal.app) fall back to native
+  // terminal scrollback, which is acceptable; broken in-app wheel for WT
+  // users is not.
+  return process.platform === "win32" ? "sgr" : "alternate-scroll";
+}
 
 function readMode(): Mode {
   const raw = (process.env.REASONIX_MOUSE_MODE ?? "").toLowerCase();
   if (raw === "sgr") return "sgr";
+  if (raw === "alternate-scroll") return "alternate-scroll";
   if (raw === "off") return "off";
-  return "alternate-scroll";
+  return platformDefault();
 }
 
 const SEQUENCES: Record<Mode, { enable: string; disable: string }> = {

--- a/tests/mouse-mode.test.ts
+++ b/tests/mouse-mode.test.ts
@@ -36,25 +36,33 @@ describe("mouse-mode enable/disable", () => {
     }
   });
 
-  it("default mode writes the alternate-scroll escape (?1007h)", () => {
+  it("default picks the platform-appropriate protocol (SGR on Windows, alternate-scroll elsewhere)", () => {
     enableMouseMode();
-    expect(writes.join("")).toBe("\u001b[?1007h");
+    const expected = process.platform === "win32" ? "\u001b[?1000h\u001b[?1006h" : "\u001b[?1007h";
+    expect(writes.join("")).toBe(expected);
   });
 
-  it("default disable writes the matching off-escape (?1007l)", () => {
+  it("default disable matches the enable sequence on the current platform", () => {
     enableMouseMode();
     writes.length = 0;
     disableMouseMode();
-    expect(writes.join("")).toBe("\u001b[?1007l");
+    const expected = process.platform === "win32" ? "\u001b[?1006l\u001b[?1000l" : "\u001b[?1007l";
+    expect(writes.join("")).toBe(expected);
   });
 
-  it("REASONIX_MOUSE_MODE=sgr restores legacy ?1000h + ?1006h capture", () => {
+  it("REASONIX_MOUSE_MODE=sgr forces ?1000h + ?1006h capture even off Windows", () => {
     process.env.REASONIX_MOUSE_MODE = "sgr";
     enableMouseMode();
     expect(writes.join("")).toBe("\u001b[?1000h\u001b[?1006h");
     writes.length = 0;
     disableMouseMode();
     expect(writes.join("")).toBe("\u001b[?1006l\u001b[?1000l");
+  });
+
+  it("REASONIX_MOUSE_MODE=alternate-scroll forces ?1007h even on Windows", () => {
+    process.env.REASONIX_MOUSE_MODE = "alternate-scroll";
+    enableMouseMode();
+    expect(writes.join("")).toBe("\u001b[?1007h");
   });
 
   it("REASONIX_MOUSE_MODE=off skips writing any escape sequence", () => {
@@ -64,10 +72,11 @@ describe("mouse-mode enable/disable", () => {
     expect(writes).toEqual([]);
   });
 
-  it("unknown REASONIX_MOUSE_MODE falls back to alternate-scroll default", () => {
+  it("unknown REASONIX_MOUSE_MODE falls back to the platform default", () => {
     process.env.REASONIX_MOUSE_MODE = "garbage";
     enableMouseMode();
-    expect(writes.join("")).toBe("\u001b[?1007h");
+    const expected = process.platform === "win32" ? "\u001b[?1000h\u001b[?1006h" : "\u001b[?1007h";
+    expect(writes.join("")).toBe(expected);
   });
 
   it("enable is idempotent — second call is a no-op", () => {


### PR DESCRIPTION
## Regression

#1477 switched the default from \`?1000h+?1006h\` (full SGR mouse capture) to \`?1007h\` (DECSET alternate scroll) so that native text-select and right-click would work on terminals that honor 1007 properly. Validated on iTerm2, GNOME Terminal etc.

**Windows Terminal turns out NOT to honor it reliably.** WT advertises the mode but doesn't translate wheel events into keys consistently — so reasonix never sees the wheel and in-app scroll goes dead. This is exactly the regression that #514 originally fixed by introducing \`?1000h\` in the first place; I missed that the user feedback in #514 was specifically from Windows Terminal users.

## Fix

Pick the protocol by platform:

| Platform | Default | Why |
|---|---|---|
| \`process.platform === "win32"\` | \`?1000h+?1006h\` | Proven on Windows Terminal / conhost / ConEmu — restores wheel for the pre-#1477 working state |
| Everything else | \`?1007h\` | Still gives back native text-select + right-click on iTerm2, GNOME Terminal, kitty, Alacritty, recent xterm |

\`REASONIX_MOUSE_MODE=sgr|alternate-scroll|off\` still overrides for edge cases (a Linux user whose terminal also breaks under \`?1007h\`, or a Windows user who wants the new selection behavior at the cost of in-app wheel).

## Trade-off honestly

Windows users go back to:
- ✅ wheel works in-app
- ❌ native text-select / right-click broken (the original #1337 / #677 / #1419 state)

This is the lesser evil — pre-#1477 those Windows complaints existed but were a known trade-off, whereas post-#1477 the wheel was just gone with no fallback. If WT ships a fix for \`?1007h\` later we can flip the platform default back.

## Tests

Tests now use platform-conditional expected sequences, so both branches are covered on CI (Ubuntu exercises the alternate-scroll path, Windows exercises SGR). New test specifically verifies \`REASONIX_MOUSE_MODE=alternate-scroll\` as an override on Windows.

3535 tests pass locally.

## Test plan

- [ ] CI green (both Ubuntu and Windows jobs)
- [ ] Manual: wheel scroll works in Windows Terminal again
- [ ] Manual: native text-select / right-click still work on iTerm2 / GNOME Terminal
- [ ] Manual: \`REASONIX_MOUSE_MODE=alternate-scroll\` on Windows opts into the new behavior