### PR TITLE
fix(desktop): make error cards dismissable + softer tone for recoverable ones

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -97,7 +97,7 @@ export type ChatMessage =
       pending: boolean;
     }
   | { kind: "status"; text: string }
-  | { kind: "error"; message: string };
+  | { kind: "error"; message: string; id: string; recoverable?: boolean };
 
 export type PendingConfirm = {
   id: number;
@@ -272,6 +272,7 @@ type Action =
   | { t: "resolve_checkpoint"; id: number; verdict: CheckpointVerdict }
   | { t: "resolve_revision"; id: number; verdict: RevisionVerdict }
   | { t: "dismiss_plan" }
+  | { t: "dismiss_error"; id: string }
   | { t: "mention_results"; results: MentionResults }
   | { t: "mention_preview"; preview: MentionPreviewState }
   | { t: "enqueue_send"; text: string }
@@ -299,6 +300,12 @@ function nextMessageTurn(messages: ChatMessage[]): number {
     return max;
   }, 0);
   return lastTurn + 1;
+}
+
+let _errSeq = 0;
+function nextErrorId(): string {
+  _errSeq += 1;
+  return `err-${Date.now().toString(36)}-${_errSeq}`;
 }
 
 export function reduce(state: State, action: Action): State {
@@ -340,7 +347,11 @@ export function reduce(state: State, action: Action): State {
         queuedSends: [],
         messages: [
           ...state.messages,
-          { kind: "error", message: `reasonix exited (code ${action.code ?? "?"})` },
+          {
+            kind: "error",
+            message: `reasonix exited (code ${action.code ?? "?"})`,
+            id: nextErrorId(),
+          },
         ],
       };
     case "incoming":
@@ -450,6 +461,13 @@ export function reduce(state: State, action: Action): State {
     }
     case "dismiss_plan":
       return { ...state, activePlan: null };
+    case "dismiss_error":
+      return {
+        ...state,
+        messages: state.messages.filter(
+          (m) => !(m.kind === "error" && m.id === action.id),
+        ),
+      };
     case "mention_results":
       return { ...state, mentionResults: action.results };
     case "mention_preview":
@@ -839,13 +857,24 @@ export function applyIncoming(state: State, ev: IncomingEvent): State {
       };
     }
     case "$error":
-    case "error":
+    case "error": {
+      // Kernel-level errors carry a `recoverable` flag — true for
+      // storm-repair / repeat-loop warnings the loop already worked
+      // around, false for hard failures. The desktop renders both as
+      // dismissable cards but uses softer tone for the recoverable
+      // ones so a session full of self-repaired loops doesn't look
+      // like everything's on fire (#1456-followup).
+      const recoverable = ev.type === "error" ? ev.recoverable : false;
       return {
         ...state,
         busy: false,
         activeSkill: null,
-        messages: [...state.messages, { kind: "error", message: ev.message }],
+        messages: [
+          ...state.messages,
+          { kind: "error", message: ev.message, id: nextErrorId(), recoverable },
+        ],
       };
+    }
     case "model.turn.started":
       if (state.messages.some((m) => m.kind === "assistant" && m.turn === ev.turn)) {
         return { ...state, model: ev.model };
@@ -1854,22 +1883,40 @@ function TabRuntime({
                       );
                     }
                     if (m.kind === "error") {
+                      const toneVar = m.recoverable ? "var(--tone-warn)" : "var(--tone-err)";
+                      const bgVar = m.recoverable
+                        ? "var(--warn-soft, var(--danger-soft))"
+                        : "var(--danger-soft)";
+                      const labelKey = m.recoverable ? "app.warningLabel" : "app.errorLabel";
                       return (
                         <div
-                          key={`e-${i}`}
+                          key={m.id}
                           className="warn-card"
-                          style={{
-                            borderColor: "var(--tone-err)",
-                            background: "var(--danger-soft)",
-                          }}
+                          style={{ borderColor: toneVar, background: bgVar, position: "relative" }}
                         >
-                          <span className="ico" style={{ color: "var(--tone-err)" }}>
+                          <span className="ico" style={{ color: toneVar }}>
                             <I.warning size={16} />
                           </span>
-                          <div>
-                            <div className="tt">{t("app.errorLabel")}</div>
+                          <div style={{ flex: 1 }}>
+                            <div className="tt">{t(labelKey)}</div>
                             <div className="ds">{m.message}</div>
                           </div>
+                          <button
+                            type="button"
+                            className="warn-card-dismiss"
+                            title={t("app.dismissError")}
+                            onClick={() => dispatch({ t: "dismiss_error", id: m.id })}
+                            style={{
+                              background: "transparent",
+                              border: "none",
+                              color: toneVar,
+                              cursor: "pointer",
+                              padding: "4px",
+                              alignSelf: "flex-start",
+                            }}
+                          >
+                            <I.x size={14} />
+                          </button>
                         </div>
                       );
                     }

--- a/desktop/src/i18n/en.ts
+++ b/desktop/src/i18n/en.ts
@@ -393,6 +393,8 @@ export const en = {
     },
     btwUsage: "▸ /btw <question> — ask a side question without polluting the conversation context.",
     errorLabel: "Error",
+    warningLabel: "Warning",
+    dismissError: "Dismiss",
     jumpToBottom: "Jump to bottom",
     splashSubtitle: "DeepSeek Agents",
     connecting: "Connecting to reasonix core…",

--- a/desktop/src/i18n/zh-CN.ts
+++ b/desktop/src/i18n/zh-CN.ts
@@ -413,6 +413,8 @@ export const zhCN: typeof en = {
     },
     btwUsage: "▸ /btw <问题> — 顺便问个题外话，不会写入当前会话上下文。",
     errorLabel: "错误",
+    warningLabel: "提示",
+    dismissError: "关闭",
     jumpToBottom: "回到底部",
     splashSubtitle: "DeepSeek Agents",
     connecting: "正在连接 reasonix 内核…",

--- a/tests/desktop-btw-status.test.ts
+++ b/tests/desktop-btw-status.test.ts
@@ -118,6 +118,71 @@ describe("desktop $btw_result reducer (#1470)", () => {
   });
 });
 
+describe("desktop dismiss_error reducer (recoverable / hard error parity)", () => {
+  it("removes the targeted error by id, leaves other messages untouched", () => {
+    const base = makeState();
+    const state: AppState = {
+      ...base,
+      messages: [
+        { kind: "status", text: "hello" },
+        { kind: "error", message: "first", id: "err-a", recoverable: true },
+        { kind: "error", message: "second", id: "err-b", recoverable: false },
+      ],
+    };
+    const next = reduce(state, { t: "dismiss_error", id: "err-a" });
+    expect(next.messages).toEqual([
+      { kind: "status", text: "hello" },
+      { kind: "error", message: "second", id: "err-b", recoverable: false },
+    ]);
+  });
+
+  it("is a no-op when the id doesn't match any error", () => {
+    const base = makeState();
+    const state: AppState = {
+      ...base,
+      messages: [{ kind: "error", message: "only one", id: "err-x" }],
+    };
+    const next = reduce(state, { t: "dismiss_error", id: "does-not-exist" });
+    expect(next.messages).toEqual(state.messages);
+  });
+});
+
+describe("desktop error events carry recoverable flag from kernel events (#1456-followup)", () => {
+  it("kernel error with recoverable=true produces a recoverable=true chat message", () => {
+    const state = makeState();
+    const next = reduce(state, {
+      t: "incoming",
+      event: {
+        type: "error",
+        id: 99,
+        ts: "2026-05-21T00:00:00Z",
+        turn: 1,
+        message: "repeat-loop guard tripped",
+        recoverable: true,
+      },
+    });
+    const last = next.messages.at(-1);
+    expect(last?.kind).toBe("error");
+    if (last?.kind === "error") {
+      expect(last.recoverable).toBe(true);
+      expect(typeof last.id).toBe("string");
+    }
+  });
+
+  it("$error protocol event treats hard errors as non-recoverable", () => {
+    const state = makeState();
+    const next = reduce(state, {
+      t: "incoming",
+      event: { type: "$error", message: "rpc died" },
+    });
+    const last = next.messages.at(-1);
+    expect(last?.kind).toBe("error");
+    if (last?.kind === "error") {
+      expect(last.recoverable).toBe(false);
+    }
+  });
+});
+
 describe("desktop $turn_complete reducer (#1456)", () => {
   it("clears orphaned pause-gate modals so an aborted plan card stops haunting the transcript", () => {
     // When the user aborts (e.g. presses the stop button mistaken for send)


### PR DESCRIPTION
## Bug

Desktop transcript fills up with red "错误" / "Error" cards that have no close button — every storm-repair / repeat-loop guard notice the loop emits gets rendered as a permanent red error card. A long session ends up with a wall of them at the bottom of the chat, even though the loop already worked around each issue.

User report (screenshot): three stacked cards along the lines of
  - "已抑制1次重复工具调用 — …repeat-loop guard tripped"
  - "拦截到重复工具调用 — 让模型察觉问题并换种方式重试。"
  - "已停止卡死的重试循环 — …repeat-loop guard tripped"

…all rendered identically with red tone and zero affordance to dismiss.

## Root cause

\`KernelErrorEvent\` already carries \`recoverable: boolean\` — \`true\` for storm-repair / repeat-loop warnings, \`false\` for hard failures. The desktop reducer ignored the flag and pushed every event as the same red card with no close button. Storm-repair text reads as a confusing string of "ERRORS" when the loop already handled them.

## Fix

- Error chat messages now carry an \`id\` (issued by a small \`nextErrorId\` counter) and an optional \`recoverable\` flag plumbed from the kernel event.
- New \`dismiss_error\` action + reducer case removes a single error by id without touching adjacent messages.
- Each error card renders a close (×) button that dispatches \`dismiss_error\` for its own id.
- \`recoverable: true\` cards render with warn tone (warn border/icon, \`app.warningLabel\`); \`recoverable: false\` keeps the existing red error tone (\`app.errorLabel\`). RPC-layer \`\$error\` events stay red (treated as hard failure).
- New i18n keys \`app.warningLabel\` / \`app.dismissError\` in en + zh-CN.

## Tests

4 new reducer tests in \`tests/desktop-btw-status.test.ts\`:
- \`dismiss_error\` removes the targeted error by id, leaves others
- \`dismiss_error\` is a no-op when id misses
- kernel \`type: "error"\` with \`recoverable: true\` produces a recoverable=true chat message with an id
- protocol \`type: "\$error"\` produces a recoverable=false chat message

3539 tests pass locally.

## Test plan

- [ ] CI green (Ubuntu + Windows)
- [ ] Manual desktop: trigger a repeat-loop guard (e.g. ask the model to retry an identical \`run_command\` 3+ times). Card appears in warn tone with a × button. Clicking × removes it.
- [ ] Manual desktop: simulate a hard RPC error. Card appears in error tone with a × button. Clicking × removes it.