### PR TITLE
fix(security): remove baked metaso key and trust project hooks

### DIFF
--- a/src/cli/ui/hooks/useHookList.ts
+++ b/src/cli/ui/hooks/useHookList.ts
@@ -3,7 +3,7 @@ import { type ResolvedHook, loadHooks } from "../../../hooks.js";
 
 export interface HookList {
   hookList: ResolvedHook[];
-  /** `loadHooks(projectRoot)` + state replacement — returns the fresh count for the slash handler's reply. */
+  /** Reload hooks from disk and return the active count for the slash handler. */
   reloadHooks: (projectRoot: string | undefined) => number;
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -155,7 +155,7 @@ export interface ReasonixConfig {
   webSearchEngine?: "mojeek" | "searxng" | "metaso" | "tavily" | "perplexity" | "exa";
   /** Base URL for SearXNG instance (default http://localhost:8080). */
   webSearchEndpoint?: string;
-  /** Metaso API key. Falls back to METASO_API_KEY env var, then a built-in default. */
+  /** Metaso API key. Falls back to METASO_API_KEY env var. */
   metasoApiKey?: string;
   /** Tavily API key. Falls back to TAVILY_API_KEY env var. No baked-in default — free tier is 1000/mo per account, sharing would burn out. */
   tavilyApiKey?: string;
@@ -187,6 +187,8 @@ export interface ReasonixConfig {
   projects?: {
     [absoluteRootDir: string]: {
       shellAllowed?: string[];
+      /** Project-scoped hooks are arbitrary shell commands; load only after explicit trust. */
+      hooksTrusted?: boolean;
       /** Absolute directory prefixes the user pre-approved for outside-sandbox file access (#684). */
       pathAllowed?: string[];
     };
@@ -286,13 +288,11 @@ export function memoryTypeDefaults(
   return out;
 }
 
-const DEFAULT_METASO_API_KEY = "mk-E384C1DD5E8501BB7EFE27C949AFDE5B";
-
-export function loadMetasoApiKey(path: string = defaultConfigPath()): string {
-  if (process.env.METASO_API_KEY) return process.env.METASO_API_KEY;
+export function loadMetasoApiKey(path: string = defaultConfigPath()): string | undefined {
+  if (process.env.METASO_API_KEY) return process.env.METASO_API_KEY.trim();
   const cfg = readConfig(path).metasoApiKey;
   if (cfg && typeof cfg === "string" && cfg.trim()) return cfg.trim();
-  return DEFAULT_METASO_API_KEY;
+  return undefined;
 }
 
 /** Tavily API key — env > config > undefined. Returning undefined means the caller must error out with a clear "go get one at tavily.com" message; we deliberately ship no default because the free 1000/mo quota wouldn't survive being shared. */
@@ -843,6 +843,22 @@ export function clearProjectShellAllowed(
   cfg.projects[key].shellAllowed = [];
   writeConfig(cfg, path);
   return existing.length;
+}
+
+export function projectHooksTrusted(rootDir: string, path: string = defaultConfigPath()): boolean {
+  const cfg = readConfig(path);
+  const key = findProjectKey(cfg, rootDir);
+  return key !== undefined && cfg.projects?.[key]?.hooksTrusted === true;
+}
+
+export function trustProjectHooks(rootDir: string, path: string = defaultConfigPath()): void {
+  const cfg = readConfig(path);
+  if (!cfg.projects) cfg.projects = {};
+  const key = findProjectKey(cfg, rootDir) ?? rootDir;
+  if (!cfg.projects[key]) cfg.projects[key] = {};
+  if (cfg.projects[key].hooksTrusted === true) return;
+  cfg.projects[key].hooksTrusted = true;
+  writeConfig(cfg, path);
 }
 
 export function loadProjectPathAllowed(

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -4,6 +4,7 @@ import { spawn } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { projectHooksTrusted } from "./config.js";
 import { t } from "./i18n/index.js";
 
 export type HookEvent = "PreToolUse" | "PostToolUse" | "UserPromptSubmit" | "Stop";
@@ -109,13 +110,20 @@ function readSettingsFile(path: string): HookSettings | null {
 export interface LoadHookSettingsOptions {
   /** Absolute project root, if any. Without it, only global hooks load. */
   projectRoot?: string;
+  /** Override config path for tests. */
+  configPath?: string;
+  /** Tests and intentionally trusted callers can opt in without touching config. */
+  trustProjectHooks?: boolean;
   /** Override `~` for tests. */
   homeDir?: string;
 }
 
 export function loadHooks(opts: LoadHookSettingsOptions = {}): ResolvedHook[] {
   const out: ResolvedHook[] = [];
-  if (opts.projectRoot) {
+  if (
+    opts.projectRoot &&
+    (opts.trustProjectHooks === true || projectHooksTrusted(opts.projectRoot, opts.configPath))
+  ) {
     const projPath = projectSettingsPath(opts.projectRoot);
     const settings = readSettingsFile(projPath);
     if (settings) appendResolved(out, settings, "project", projPath);

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -1514,8 +1514,10 @@ export const EN: TranslationSchema = {
       "web_search: Cannot reach SearXNG server at {endpoint} \u2014 try: install and start SearXNG (https://github.com/searxng/searxng, e.g. `docker run -d -p 8080:8080 searxng/searxng`), or switch to another engine with /search-engine mojeek|searxng|metaso|tavily|perplexity|exa",
     searxngNoResults:
       "web_search: 0 results but SearXNG response doesn't look like an empty results page ({chars} chars) \u2014 try: rephrase the query with simpler terms, or switch engine with /search-engine mojeek|searxng|metaso|tavily|perplexity|exa",
+    metasoMissingKey:
+      "web_search: Metaso requires an API key \u2014 set METASO_API_KEY or configure one with /search-engine metaso <key>. Get one at https://metaso.cn/search-api/playground",
     metasoDailyLimit:
-      "web_search: daily search limit reached for the default API key \u2014 set your own METASO_API_KEY env var or get one at https://metaso.cn/search-api/playground",
+      "web_search: Metaso daily search limit reached \u2014 set METASO_API_KEY or get a key at https://metaso.cn/search-api/playground",
     metasoUnauthorized:
       "web_search: Metaso API key rejected \u2014 check METASO_API_KEY or get one at https://metaso.cn/search-api/playground",
     metasoRateLimit:

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -661,6 +661,7 @@ export interface TranslationSchema {
     endpointMustBeHttp: string;
     cannotReach: string;
     searxngNoResults: string;
+    metasoMissingKey: string;
     metasoDailyLimit: string;
     metasoUnauthorized: string;
     metasoRateLimit: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -1435,8 +1435,10 @@ export const zhCN: TranslationSchema = {
       "web_search: 无法访问 SearXNG 服务器 {endpoint} — try: 安装并启动 SearXNG（https://github.com/searxng/searxng，例如 `docker run -d -p 8080:8080 searxng/searxng`），或使用 /search-engine mojeek|searxng|metaso|tavily|perplexity|exa 切换引擎",
     searxngNoResults:
       "web_search: 返回 0 条结果但 SearXNG 响应看起来不是正常空结果页（{chars} 字符）— try: 使用更简单的关键词改写查询，或使用 /search-engine mojeek|searxng|metaso|tavily|perplexity|exa 切换引擎",
+    metasoMissingKey:
+      "web_search: Metaso 需要 API 密钥 — 设置 METASO_API_KEY，或使用 /search-engine metaso <key> 配置；可在 https://metaso.cn/search-api/playground 获取密钥",
     metasoDailyLimit:
-      "web_search: 默认 API 密钥的每日搜索次数已达上限 — 设置 METASO_API_KEY 环境变量，或在 https://metaso.cn/search-api/playground 获取自己的密钥",
+      "web_search: Metaso 每日搜索次数已达上限 — 设置 METASO_API_KEY，或在 https://metaso.cn/search-api/playground 获取密钥",
     metasoUnauthorized:
       "web_search: Metaso API 密钥被拒绝 — 检查 METASO_API_KEY，或在 https://metaso.cn/search-api/playground 获取密钥",
     metasoRateLimit:

--- a/src/server/api/hooks.ts
+++ b/src/server/api/hooks.ts
@@ -2,6 +2,7 @@
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
+import { trustProjectHooks } from "../../config.js";
 import { HOOK_EVENTS, globalSettingsPath, loadHooks, projectSettingsPath } from "../../hooks.js";
 import type { DashboardContext } from "../context.js";
 import type { ApiResult } from "../router.js";
@@ -88,6 +89,7 @@ export async function handleHooks(
           body: { error: "no active project — open `/dashboard` from inside `reasonix code`" },
         };
       }
+      trustProjectHooks(cwd, ctx.configPath);
       path = projectSettingsPath(cwd);
     } else {
       path = globalSettingsPath();

--- a/src/tools/web.ts
+++ b/src/tools/web.ts
@@ -195,6 +195,7 @@ interface MetasoSearchResponse {
 async function searchMetaso(query: string, opts: WebSearchOptions = {}): Promise<SearchResult[]> {
   const topK = Math.max(1, Math.min(100, opts.topK ?? DEFAULT_TOPK));
   const apiKey = loadMetasoApiKey();
+  if (!apiKey) throw new Error(t("webErrors.metasoMissingKey"));
 
   let resp: Response;
   try {

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -48,10 +48,12 @@ const ok = (overrides: Partial<HookSpawnResult> = {}): HookSpawnResult => ({
 describe("loadHooks", () => {
   let home: string;
   let project: string;
+  let configPath: string;
 
   beforeEach(() => {
     home = mkdtempSync(join(tmpdir(), "reasonix-hooks-home-"));
     project = mkdtempSync(join(tmpdir(), "reasonix-hooks-proj-"));
+    configPath = join(home, "config.json");
   });
   afterEach(() => {
     rmSync(home, { recursive: true, force: true });
@@ -62,14 +64,33 @@ describe("loadHooks", () => {
     expect(loadHooks({ homeDir: home, projectRoot: project })).toEqual([]);
   });
 
-  it("loads project then global, in array order, with scope tags", () => {
+  it("loads global hooks but skips untrusted project hooks", () => {
     writeSettings(home, {
       hooks: { Stop: [{ command: "echo global1" }, { command: "echo global2" }] },
     });
     writeSettings(project, {
       hooks: { Stop: [{ command: "echo proj" }] },
     });
-    const hooks = loadHooks({ homeDir: home, projectRoot: project });
+    const hooks = loadHooks({ homeDir: home, projectRoot: project, configPath });
+    expect(hooks.map((h) => `${h.scope}:${h.command}`)).toEqual([
+      "global:echo global1",
+      "global:echo global2",
+    ]);
+  });
+
+  it("loads trusted project then global, in array order, with scope tags", () => {
+    writeFileSync(
+      configPath,
+      JSON.stringify({ projects: { [project]: { hooksTrusted: true } } }),
+      "utf8",
+    );
+    writeSettings(home, {
+      hooks: { Stop: [{ command: "echo global1" }, { command: "echo global2" }] },
+    });
+    writeSettings(project, {
+      hooks: { Stop: [{ command: "echo proj" }] },
+    });
+    const hooks = loadHooks({ homeDir: home, projectRoot: project, configPath });
     expect(hooks.map((h) => `${h.scope}:${h.command}`)).toEqual([
       "project:echo proj",
       "global:echo global1",

--- a/tests/web-tools.test.ts
+++ b/tests/web-tools.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { loadMetasoApiKey } from "../src/config.js";
 import { ToolRegistry } from "../src/tools.js";
 import {
@@ -301,6 +301,7 @@ describe("webSearch", () => {
 });
 
 describe("searchMetaso", () => {
+  const originalMetasoKey = process.env.METASO_API_KEY;
   const sampleResponse = {
     credits: 3,
     total: 72,
@@ -321,6 +322,32 @@ describe("searchMetaso", () => {
       },
     ],
   };
+
+  beforeEach(() => {
+    process.env.METASO_API_KEY = "test-metaso-key";
+  });
+
+  afterEach(() => {
+    if (originalMetasoKey === undefined) {
+      // biome-ignore lint/performance/noDelete: env var must be restored to absent
+      delete process.env.METASO_API_KEY;
+    } else {
+      process.env.METASO_API_KEY = originalMetasoKey;
+    }
+  });
+
+  it("requires an API key before contacting Metaso", async () => {
+    // biome-ignore lint/performance/noDelete: env var must be absent, not "undefined"
+    delete process.env.METASO_API_KEY;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn() as unknown as typeof fetch;
+    try {
+      await expect(webSearch("q", { engine: "metaso" })).rejects.toThrow(/Metaso.*API key/i);
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 
   it("POSTs to metaso API with JSON body and auth header", async () => {
     const captured: { url: string; method: string; headers: Record<string, string>; body: string } =


### PR DESCRIPTION
## Summary

Remove the baked-in Metaso fallback key and add an explicit trust boundary for project-scoped hooks. This makes Metaso usage opt-in with user-provided credentials only, and stops `.reasonix/settings.json` in a repository from being auto-executed as shell commands unless the project has been trusted.

## Problem

Two security issues were present:

1. **Metaso used a shared built-in API key as the final fallback.**  
   If neither `METASO_API_KEY` nor `metasoApiKey` was configured, Reasonix would silently use a hardcoded default key. That meant every user could end up sharing the same credential, which is a quota, abuse, and revocation risk.

2. **Project-level hooks were loaded and executed automatically.**  
   `loadHooks({ projectRoot })` would read `<project>/.reasonix/settings.json` and include any hook commands it found. Because hooks are spawned through the shell, a malicious repository could define a hook that runs arbitrary commands as soon as the project was opened.

The core issue in both cases is the same: a repository or bundled default was being treated as trusted input.

## Fix

I changed the behavior at the trust boundary instead of papering over symptoms.

| Layer | File | Change |
|---|---|---|
| **Metaso key loading** | [src/config.ts](src/config.ts) | Removed the hardcoded default Metaso key. `loadMetasoApiKey()` now returns `env > config > undefined` only. |
| **Metaso error path** | [src/tools/web.ts](src/tools/web.ts) | `searchMetaso()` now fails fast with a clear “missing key” error if no key is configured, instead of contacting Metaso with a shared fallback credential. |
| **Hook trust model** | [src/config.ts](src/config.ts), [src/hooks.ts](src/hooks.ts) | Added `projects[<root>].hooksTrusted` plus `projectHooksTrusted()` / `trustProjectHooks()`. `loadHooks()` now loads project hooks only when that project is explicitly trusted. |
| **Hook save flow** | [src/server/api/hooks.ts](src/server/api/hooks.ts) | When the user saves project hooks from the dashboard, the project is marked trusted automatically so explicit user action still works without an extra step. |
| **User-facing copy** | [src/i18n/EN.ts](src/i18n/EN.ts), [src/i18n/zh-CN.ts](src/i18n/zh-CN.ts), [src/i18n/types.ts](src/i18n/types.ts) | Added a dedicated Metaso missing-key message and removed the language that referred to a default shared key. |
| **Tests** | [tests/hooks.test.ts](tests/hooks.test.ts), [tests/web-tools.test.ts](tests/web-tools.test.ts) | Added regression coverage for untrusted vs trusted project hooks and for Metaso failing before any network request when no key is set. |

### Why this shape

For Metaso, the correct behavior is simple: if the user did not configure a key, do not invent one. That keeps credential ownership clear and avoids shipping a shared secret in the binary.

For hooks, I did not try to “sanitize” shell commands. Hooks are intentionally arbitrary shell scripts. The safe fix is to make the project-level file opt in, not silently trusted. Global hooks remain loaded as before, and dashboard-driven project hook saves still work because that path explicitly marks the project trusted.

## Verification

| Check | Result |
|---|---|
| `npx vitest run tests/hooks.test.ts tests/web-tools.test.ts` | ✅ 87 tests passed |
| `npm run typecheck` | ✅ passes |
| `npx biome check` on touched files | ✅ passes |
| `npm run verify` | ✅ build, lint, typecheck, and full test suite passed |