### PR TITLE
fix(yolo): auto-resolve run_command + run_background gates in YOLO mode

### DIFF
--- a/src/core/pause-policy.ts
+++ b/src/core/pause-policy.ts
@@ -19,5 +19,15 @@ export function autoResolveVerdict(req: PauseRequest, editMode: EditMode): unkno
   if (req.kind === "path_access" && editMode === "yolo") {
     return { type: "run_once" };
   }
+  // Shell commands in YOLO: shell.ts's `allowAll` callback should already have
+  // skipped gate.ask for these, but the closure reads on-disk config via
+  // `loadEditMode()` while ACP's `--yolo` flag and any future runtime-only
+  // YOLO source don't write to config. Without this second layer those paths
+  // surface a confirmation prompt even though the user is in YOLO (#1448).
+  // `run_once` matches shell.ts's behavior — don't pollute the persistent
+  // allowlist with every transient command.
+  if ((req.kind === "run_command" || req.kind === "run_background") && editMode === "yolo") {
+    return { type: "run_once" };
+  }
   return null;
 }

--- a/tests/acp-yolo.test.ts
+++ b/tests/acp-yolo.test.ts
@@ -61,15 +61,42 @@ describe("acp --yolo", () => {
     expect(bridged).toBe(false);
   });
 
-  it("does NOT auto-resolve run_command requests even with --yolo (shell.ts handles that via allowAll)", async () => {
+  it("auto-resolves run_command (run_once) with --yolo — shell.ts's allowAll closure can't see --yolo when config still says review (#1448)", async () => {
     const gate = new PauseGate();
-    let bridgedReqId: number | null = null;
-    makeListener({ yolo: true }, "review")(gate, (id) => {
-      bridgedReqId = id;
-      gate.resolve(id, { type: "run_once" } as never);
+    let bridged = false;
+    makeListener({ yolo: true }, "review")(gate, () => {
+      bridged = true;
     });
 
-    await gate.ask({ kind: "run_command", payload: { command: "rm -rf /" } });
+    const promise = gate.ask({ kind: "run_command", payload: { command: "rm -rf /" } });
+    await expect(promise).resolves.toEqual({ type: "run_once" });
+    expect(bridged).toBe(false);
+  });
+
+  it("auto-resolves run_background (run_once) with --yolo for the same reason", async () => {
+    const gate = new PauseGate();
+    let bridged = false;
+    makeListener({ yolo: true }, "review")(gate, () => {
+      bridged = true;
+    });
+
+    const promise = gate.ask({
+      kind: "run_background",
+      payload: { command: "npm dev", cwd: "/work" },
+    });
+    await expect(promise).resolves.toEqual({ type: "run_once" });
+    expect(bridged).toBe(false);
+  });
+
+  it("bridges run_command to the client in auto mode (only yolo bypasses)", async () => {
+    const gate = new PauseGate();
+    let bridgedReqId: number | null = null;
+    makeListener({ yolo: false }, "auto")(gate, (id) => {
+      bridgedReqId = id;
+      gate.resolve(id, { type: "deny" } as never);
+    });
+
+    await gate.ask({ kind: "run_command", payload: { command: "ls" } });
     expect(bridgedReqId).not.toBeNull();
   });
 


### PR DESCRIPTION
## Bug

Reported in #1448. With YOLO mode enabled, file edits skip confirmation (the \`editModeRef\` path bypasses cleanly), but shell commands **still prompt** — defeating the "fully unattended" promise users buy YOLO for.

## Architecture

Two layers were supposed to bypass shell prompts in YOLO:

1. **\`shell.ts:121\`** — \`isAllowAll()\` check skips \`gate.ask\` entirely.
2. **\`pause-policy.ts:autoResolveVerdict\`** — auto-resolves any \`gate.ask\` that slips through.

Layer 2 only handled \`plan_checkpoint\` and \`path_access\`. \`run_command\` / \`run_background\` fell through to the UI / ACP bridge for a manual prompt. The gap matters because layer 1's \`allowAll\` closure reads on-disk config via \`loadEditMode()\`, but:

- \`reasonix acp --yolo\` sets \`opts.yolo = true\` in-memory without calling \`saveEditMode\`, so shell.ts can't see it.
- Any mid-toggle race between the in-UI editMode and the persisted config leaves shell.ts seeing a stale value.

The existing comment in pause-policy.ts already documented the intent — *"yolo mirrors shell.ts's allowAll bypass"* — but the code only implemented that mirror for \`path_access\`, not the shell tools the comment was originally written about.

## Fix

Extend \`autoResolveVerdict\` to return \`{ type: "run_once" }\` for \`run_command\` and \`run_background\` when \`editMode === "yolo"\`. \`run_once\` (not \`always_allow\`) so a YOLO session doesn't pollute the persisted allowlist with every transient command — matches shell.ts's own behavior for the same path.

## Tests

\`tests/acp-yolo.test.ts\`:

- Replaced the previous assertion that \`run_command\` bridges through to the client under \`--yolo\` (that was the old design and is the bug).
- Added \`run_background\` coverage with the same shape.
- Added a regression test that \`run_command\` in **auto** mode still bridges to the client — only YOLO bypasses.

3541 tests pass locally.

## Test plan

- [ ] CI green
- [ ] Manual desktop YOLO: \`run_command\` should fire without a confirm prompt
- [ ] Manual desktop YOLO: \`run_background\` (e.g. \`npm dev\`) fires without prompt
- [ ] Manual desktop auto mode: \`run_command\` for a non-allowlisted command still shows the confirm modal

Closes #1448