### PR TITLE
test(lifecycle): cover stop and cancel recovery

### DIFF
--- a/tests/lifecycle-e2e.test.ts
+++ b/tests/lifecycle-e2e.test.ts
@@ -493,6 +493,49 @@ describe("strict engineering lifecycle e2e harness", () => {
     });
   });
 
+  it("recovers after the user cancels a proposed plan", async () => {
+    const harness = createStrictLifecycleHarness();
+
+    harness.queue({ type: "cancel", feedback: "too broad for this task" });
+    const cancelled = await harness.dispatch("submit_plan", {
+      plan: "Delete the old formatter and migrate all callers.",
+      steps: [
+        {
+          id: "step-1",
+          title: "Delete old formatter",
+          action: "Remove the old formatter file.",
+          risk: "high",
+        },
+      ],
+    });
+
+    expect(JSON.parse(cancelled).error).toMatch(/plan cancelled: too broad for this task/);
+    expect(harness.lifecycle.snapshot()).toMatchObject({
+      state: "cancelled",
+      planSteps: [],
+      completedStepIds: [],
+      mutatedSinceLastStep: false,
+    });
+
+    harness.lifecycle.observeUserPrompt("Fresh task: inspect the formatter before cleanup.");
+    expect(harness.lifecycle.snapshot()).toMatchObject({
+      state: "armed",
+      planSteps: [],
+      completedStepIds: [],
+      mutatedSinceLastStep: false,
+    });
+
+    const readOnly = await harness.dispatch("read_file", { path: "src/format.ts" });
+    expect(readOnly).toBe("read src/format.ts");
+
+    const freshMutation = await harness.dispatch("delete_file", { path: "src/format.old.ts" });
+    expect(JSON.parse(freshMutation)).toMatchObject({
+      rejectedReason: "engineering-lifecycle",
+      state: "armed",
+      nextAction: "submit_plan",
+    });
+  });
+
   it("cancels the runtime when the user stops at a checkpoint", async () => {
     const harness = createStrictLifecycleHarness();
     harness.queue({ type: "approve" });
@@ -527,6 +570,27 @@ describe("strict engineering lifecycle e2e harness", () => {
     expect(JSON.parse(afterStop)).toMatchObject({
       rejectedReason: "engineering-lifecycle",
       state: "cancelled",
+    });
+
+    harness.lifecycle.observeUserPrompt("Fresh task: inspect and rename another formatter.");
+    expect(harness.lifecycle.snapshot()).toMatchObject({
+      state: "armed",
+      planSteps: [],
+      completedStepIds: [],
+      mutatedSinceLastStep: false,
+    });
+
+    const readOnly = await harness.dispatch("read_file", { path: "src/another-format.ts" });
+    expect(readOnly).toBe("read src/another-format.ts");
+
+    const freshMutation = await harness.dispatch("move_file", {
+      source: "src/another-format.ts",
+      destination: "src/format-next.ts",
+    });
+    expect(JSON.parse(freshMutation)).toMatchObject({
+      rejectedReason: "engineering-lifecycle",
+      state: "armed",
+      nextAction: "submit_plan",
     });
   });
 });

--- a/tests/support/lifecycle-harness.ts
+++ b/tests/support/lifecycle-harness.ts
@@ -29,9 +29,13 @@ class QueueGate extends PauseGate {
     const verdict = this.verdicts.shift();
     if (!verdict) throw new Error(`no queued verdict for ${opts.kind}`);
 
-    if (opts.kind === "plan_proposed" && verdict.type === "approve") {
-      const payload = opts.payload as { steps?: PlanStep[] } | undefined;
-      this.lifecycle.recordPlanApproved(payload?.steps);
+    if (opts.kind === "plan_proposed") {
+      if (verdict.type === "approve") {
+        const payload = opts.payload as { steps?: PlanStep[] } | undefined;
+        this.lifecycle.recordPlanApproved(payload?.steps);
+      } else if (verdict.type === "cancel") {
+        this.lifecycle.cancel();
+      }
     }
     if (opts.kind === "plan_checkpoint") {
       this.lifecycle.recordCheckpointReached();
@@ -103,6 +107,16 @@ function registerMutationTools(
   registry: ToolRegistry,
   opts: StrictLifecycleHarnessOptions = {},
 ): void {
+  registry.register({
+    name: "read_file",
+    readOnly: true,
+    parameters: {
+      type: "object",
+      properties: { path: { type: "string" } },
+      required: ["path"],
+    },
+    fn: (args: { path: string }) => `read ${args.path}`,
+  });
   registry.register({
     name: "delete_file",
     parameters: {


### PR DESCRIPTION
## Summary
- Add strict lifecycle e2e corpus coverage for user-cancelled plan proposals and checkpoint stop recovery.
- Verify cancelled/stopped lifecycle state clears plan steps, completed steps, and pending mutation evidence before the next user task.
- Ensure a fresh strict lifecycle after stop/cancel still allows read-only exploration while requiring a new plan for high-risk mutation.
- Keep this slice test-only: no runtime semantics, prompt, or tool schema changes.

## Test Plan
- `npm test -- tests/lifecycle-e2e.test.ts`
- `npm test -- tests/lifecycle-e2e.test.ts tests/lifecycle.test.ts tests/tools.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run verify`
- Push hook also ran `npm run verify` successfully: build + lint + typecheck + full test suite (257 files, 3543 passed, 10 skipped).

Refs #1285