### PR TITLE
feat(plans): surface lifecycle evidence summaries

### DIFF
--- a/src/cli/ui/slash/handlers/plans.ts
+++ b/src/cli/ui/slash/handlers/plans.ts
@@ -1,6 +1,7 @@
 import { basename } from "node:path";
 import { listPlanArchives, loadPlanState, relativeTime } from "@/code/plan-store.js";
 import { t } from "@/i18n/index.js";
+import type { StepCompletion, StepEvidence } from "@/tools/plan.js";
 import type { SlashHandler } from "../dispatch.js";
 
 const plans: SlashHandler = (args, loop, ctx) => {
@@ -28,6 +29,11 @@ const plans: SlashHandler = (args, loop, ctx) => {
         when,
       }),
     );
+    const lifecycle = ctx.getEngineeringLifecycleSnapshot?.();
+    if (lifecycle?.mode !== "off" && lifecycle?.mutatedSinceLastStep) {
+      lines.push(t("handlers.plans.evidencePending"));
+    }
+    lines.push(...formatActiveEvidenceLines(active.stepCompletions, active.completedStepIds));
   } else {
     lines.push(t("handlers.plans.activeNone"));
   }
@@ -55,6 +61,8 @@ const plans: SlashHandler = (args, loop, ctx) => {
         label,
       }),
     );
+    const evidence = formatArchivedEvidenceSummary(a.stepCompletions, a.completedStepIds);
+    if (evidence) lines.push(t("handlers.plans.archivedEvidenceLine", { summary: evidence }));
   }
   return { info: lines.join("\n") };
 };
@@ -121,6 +129,54 @@ function handleDone(rest: string[], ctx: Parameters<SlashHandler>[2]): { info: s
     case "no-plan":
       return { info: t("handlers.plans.doneNoPlan") };
   }
+}
+
+function formatActiveEvidenceLines(
+  completions: Record<string, StepCompletion> | undefined,
+  completedStepIds: readonly string[],
+): string[] {
+  if (!completions) return [];
+  const lines: string[] = [];
+  for (const stepId of completedStepIds) {
+    const summary = formatCompletionEvidenceSummary(completions[stepId]);
+    if (!summary) continue;
+    lines.push(t("handlers.plans.evidenceLine", { stepId, summary }));
+  }
+  return lines;
+}
+
+function formatArchivedEvidenceSummary(
+  completions: Record<string, StepCompletion> | undefined,
+  completedStepIds: readonly string[],
+): string | null {
+  if (!completions) return null;
+  const parts: string[] = [];
+  for (const stepId of completedStepIds) {
+    const summary = formatCompletionEvidenceSummary(completions[stepId]);
+    if (!summary) continue;
+    parts.push(`${stepId} ${summary}`);
+  }
+  return parts.length > 0 ? parts.join("; ") : null;
+}
+
+function formatCompletionEvidenceSummary(completion: StepCompletion | undefined): string | null {
+  const evidence = completion?.evidence;
+  if (!evidence || evidence.length === 0) {
+    const compact = completion?.evidenceSummary?.trim();
+    return compact || null;
+  }
+  const parts = evidence.map(formatEvidenceItem).filter((part) => part.length > 0);
+  return parts.length > 0 ? parts.join("; ") : null;
+}
+
+function formatEvidenceItem(evidence: StepEvidence): string {
+  const extras: string[] = [];
+  if (evidence.command) extras.push(evidence.command);
+  if (evidence.paths && evidence.paths.length > 0) {
+    extras.push(evidence.paths.slice(0, 3).join(", "));
+  }
+  const suffix = extras.length > 0 ? ` (${extras.join("; ")})` : "";
+  return `${evidence.kind} - ${evidence.summary}${suffix}`;
 }
 
 export const handlers: Record<string, SlashHandler> = {

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -1074,6 +1074,10 @@ export const EN: TranslationSchema = {
       noArchives:
         "no archived plans yet for this session — they auto-archive when every step is done",
       archivedHeader: "Archived ({count}):",
+      evidencePending:
+        "  ! evidence pending — current step needs verification/diff/checkpoint/manual evidence",
+      evidenceLine: "  evidence {stepId}: {summary}",
+      archivedEvidenceLine: "    evidence: {summary}",
       replayNoSession:
         "no session attached — `/replay` is per-session. Run `reasonix code` in a project to get a session.",
       replayNoArchives:

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -1013,6 +1013,10 @@ export const zhCN: TranslationSchema = {
       activeNone: "▸ 活跃计划：（无）",
       noArchives: "此会话尚无归档计划 — 当每个步骤完成时自动归档",
       archivedHeader: "已归档（{count}）：",
+      evidencePending:
+        "  ! 等待 evidence — 当前步骤需要 verification/diff/checkpoint/manual evidence",
+      evidenceLine: "  evidence {stepId}: {summary}",
+      archivedEvidenceLine: "    evidence: {summary}",
       replayNoSession:
         "未附加会话 — `/replay` 是按会话的。在项目中运行 `reasonix code` 以获取会话。",
       replayNoArchives:

--- a/tests/slash.test.ts
+++ b/tests/slash.test.ts
@@ -1135,6 +1135,114 @@ describe("handleSlash", () => {
       expect(r.info).toMatch(/Refactor auth into signed tokens/);
       expect(r.info).toMatch(/1\/2/);
     });
+
+    it("/plans surfaces active step evidence and pending evidence state", () => {
+      const loop = loopWithSession("plans-active-evidence");
+      const fs = require("node:fs") as typeof import("node:fs");
+      const dir = join(tempHome, ".reasonix", "sessions");
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(
+        join(dir, "plans-active-evidence.plan.json"),
+        JSON.stringify({
+          version: 2,
+          steps: [
+            { id: "step-1", title: "Update router", action: "Update router references." },
+            { id: "step-2", title: "Run migration", action: "Run the migration." },
+          ],
+          completedStepIds: ["step-1"],
+          stepCompletions: {
+            "step-1": {
+              kind: "step_completed",
+              stepId: "step-1",
+              result: "Updated router references.",
+              evidence: [
+                {
+                  kind: "verification",
+                  summary: "focused router tests passed",
+                  command: "npm test -- tests/router.test.ts",
+                },
+                {
+                  kind: "diff",
+                  summary: "updated router imports",
+                  paths: ["src/router.ts", "src/routes.ts"],
+                },
+              ],
+            },
+          },
+          updatedAt: new Date().toISOString(),
+          summary: "Router migration",
+        }),
+      );
+
+      const r = handleSlash("plans", [], loop, {
+        getEngineeringLifecycleSnapshot: () => ({
+          mode: "strict",
+          state: "executing",
+          planSteps: [],
+          completedStepIds: ["step-1"],
+          mutatedSinceLastStep: true,
+        }),
+      });
+
+      expect(r.info).toContain("Router migration");
+      expect(r.info).toContain("evidence pending");
+      expect(r.info).toContain("step-1");
+      expect(r.info).toContain("verification - focused router tests passed");
+      expect(r.info).toContain("npm test -- tests/router.test.ts");
+      expect(r.info).toContain("diff - updated router imports");
+      expect(r.info).toContain("src/router.ts, src/routes.ts");
+    });
+
+    it("/plans surfaces archived plan evidence summaries", () => {
+      const loop = loopWithSession("plans-archived-evidence");
+      writeArchive("plans-archived-evidence", "2026-04-20-evidence", {
+        version: 2,
+        steps: [
+          { id: "step-1", title: "Migrate config", action: "Update dependency config." },
+          { id: "step-2", title: "Confirm rollout", action: "Confirm rollout notes." },
+        ],
+        completedStepIds: ["step-1", "step-2"],
+        stepCompletions: {
+          "step-1": {
+            kind: "step_completed",
+            stepId: "step-1",
+            result: "Updated dependency config.",
+            evidence: [
+              {
+                kind: "diff",
+                summary: "updated package and lockfile",
+                paths: ["package.json", "pnpm-lock.yaml"],
+              },
+              {
+                kind: "verification",
+                summary: "install completed",
+                command: "npm install",
+              },
+            ],
+          },
+          "step-2": {
+            kind: "step_completed",
+            stepId: "step-2",
+            result: "Confirmed rollout notes.",
+            evidence: [{ kind: "manual", summary: "owner approved rollout note" }],
+          },
+        },
+        updatedAt: "2026-04-20T00:00:00.000Z",
+        summary: "Config migration",
+      });
+
+      const r = handleSlash("plans", [], loop);
+
+      expect(r.info).toContain("Config migration");
+      expect(r.info).toContain("evidence:");
+      expect(r.info).toContain("step-1");
+      expect(r.info).toContain("diff - updated package and lockfile");
+      expect(r.info).toContain("package.json, pnpm-lock.yaml");
+      expect(r.info).toContain("verification - install completed");
+      expect(r.info).toContain("npm install");
+      expect(r.info).toContain("step-2");
+      expect(r.info).toContain("manual - owner approved rollout note");
+    });
   });
 
   describe("/memory", () => {


### PR DESCRIPTION
## Summary
- Surface completed-step evidence in `/plans` for active plans, including verification, diff, checkpoint, and manual evidence summaries.
- Surface compact evidence summaries for archived plans so users can inspect why completed work was considered done.
- Show a short evidence-pending line when the strict lifecycle snapshot reports mutation since the last completed step.
- Keep this slice UI-only: no runtime constraint semantics, prompt, tool schema, or immutable prefix changes.

## Test Plan
- `npm test -- tests/slash.test.ts`
- `npm test -- tests/slash.test.ts tests/plan-store.test.ts tests/handle-tool-event.test.ts tests/lifecycle-e2e.test.ts tests/lifecycle.test.ts tests/tools.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run verify`
- Push hook also ran `npm run verify` successfully: build + lint + typecheck + full test suite (257 files, 3544 passed, 10 skipped).

Refs #1285