### PR TITLE
feat (chat): add queued mid-turn steer handling

### DIFF
--- a/dashboard/src/i18n/en.ts
+++ b/dashboard/src/i18n/en.ts
@@ -164,6 +164,8 @@ export const en = {
     modeView: "session view",
     placeholder: "Type a prompt — Enter sends, Shift+Enter for a newline · / @ for pickers",
     placeholderBusy: "wait for the current turn to finish…",
+    placeholderSteerBusy: "type to steer — commands and pickers are disabled while busy",
+    steerHint: "message steers the current turn (added as instruction)",
     send: "Send",
     new: "New",
     clear: "Clear",

--- a/dashboard/src/i18n/zh-CN.ts
+++ b/dashboard/src/i18n/zh-CN.ts
@@ -164,6 +164,8 @@ export const zhCN = {
     modeView: "会话视图",
     placeholder: "输入提示词 — Enter 发送，Shift+Enter 换行 · / @ 打开选择器",
     placeholderBusy: "请等待当前轮次完成…",
+    placeholderSteerBusy: "输入消息以引导当前任务 — 忙碌时不支持命令和选择器",
+    steerHint: "消息将作为附加指示引导当前轮次",
     send: "发送",
     new: "新建",
     clear: "清除",

--- a/dashboard/src/panels/changes.ts
+++ b/dashboard/src/panels/changes.ts
@@ -1716,6 +1716,10 @@ function ChatPane(props: ChatPaneProps) {
 
   const updatePopover = useCallback(
     async (text: string) => {
+      if (busy) {
+        setPopoverKind(null);
+        return;
+      }
       const slashMatch = /^\/([A-Za-z0-9_-]*)$/.exec(text);
       if (slashMatch) {
         const prefix = slashMatch[1]!.toLowerCase();
@@ -1734,7 +1738,7 @@ function ChatPane(props: ChatPaneProps) {
       }
       setPopoverKind(null);
     },
-    [slashCommands],
+    [busy, slashCommands],
   );
 
   const applyPopover = useCallback(() => {
@@ -1757,7 +1761,6 @@ function ChatPane(props: ChatPaneProps) {
 
   const send = useCallback(async () => {
     const text = input.trim();
-    if (busy) return;
     if (!text && props.comments.length === 0) return;
     setError(null);
 
@@ -1783,7 +1786,7 @@ function ChatPane(props: ChatPaneProps) {
     } catch (err) {
       setError((err as Error).message);
     }
-  }, [input, busy, props.comments]);
+  }, [input, props.comments]);
 
   const abort = useCallback(async () => {
     try {
@@ -1973,19 +1976,18 @@ function ChatPane(props: ChatPaneProps) {
             <textarea
               class="input"
               style=${{ width: "100%", resize: "none", minHeight: "36px", fontFamily: "inherit", fontSize: "13px", padding: "8px 10px", lineHeight: "1.4", background: "var(--bg-input)", border: "1px solid var(--bd)", borderRadius: "4px", color: "var(--fg-0)" }}
-              placeholder=${busy ? t("chat.placeholderBusy") : props.comments.length > 0 ? "总结评论..." : t("changes.chatPlaceholder")}
+              placeholder=${busy ? t("chat.placeholderSteerBusy") : props.comments.length > 0 ? "总结评论..." : t("changes.chatPlaceholder")}
               value=${input}
               onInput=${onInput}
               onKeyDown=${onKeyDown}
               onCompositionStart=${onCompositionStart}
               onCompositionEnd=${onCompositionEnd}
               onBlur=${() => setTimeout(() => setPopoverKind(null), 150)}
-              disabled=${busy}
               rows="2"
             />
           </div>
           <div style=${{ display: "flex", flexDirection: "column", gap: "6px", flexShrink: 0 }}>
-            <button class="primary" onClick=${send} disabled=${busy || (!input.trim() && props.comments.length === 0)} style=${{ padding: "8px 12px", borderRadius: "4px" }}>${t("changes.chatSend")}</button>
+            <button class="primary" onClick=${send} disabled=${!input.trim() && props.comments.length === 0} style=${{ padding: "8px 12px", borderRadius: "4px" }}>${t("changes.chatSend")}</button>
             <div style=${{ display: "flex", gap: "6px" }}>
               <button onClick=${newConversation} title=${t("changes.newTitle")}>${t("changes.newConversation")}</button>
               <button onClick=${clearScrollback} title=${t("changes.clearTitle")}>${t("changes.clearConversation")}</button>

--- a/dashboard/src/panels/chat.ts
+++ b/dashboard/src/panels/chat.ts
@@ -773,8 +773,6 @@ const ChatInput = memo(function ChatInput({
     if (!text) return;
     const res = await onSubmit(text);
     if (res.accepted) setInput("");
-    // When busy, the server steers the text into the current turn
-    // instead of starting a new one, so still clear on accepted.
   }, [input, onSubmit]);
 
   const onInput = useCallback(

--- a/dashboard/src/panels/chat.ts
+++ b/dashboard/src/panels/chat.ts
@@ -708,6 +708,10 @@ const ChatInput = memo(function ChatInput({
 
   const updatePopover = useCallback(
     async (text: string) => {
+      if (busy) {
+        setPopoverKind(null);
+        return;
+      }
       const slashMatch = /^\/([A-Za-z0-9_-]*)$/.exec(text);
       if (slashMatch) {
         const prefix = slashMatch[1]!.toLowerCase();
@@ -746,7 +750,7 @@ const ChatInput = memo(function ChatInput({
       }
       setPopoverKind(null);
     },
-    [slashCommands],
+    [busy, slashCommands],
   );
 
   const applyPopover = useCallback(() => {
@@ -766,10 +770,12 @@ const ChatInput = memo(function ChatInput({
 
   const send = useCallback(async () => {
     const text = input.trim();
-    if (!text || busy) return;
+    if (!text) return;
     const res = await onSubmit(text);
     if (res.accepted) setInput("");
-  }, [input, busy, onSubmit]);
+    // When busy, the server steers the text into the current turn
+    // instead of starting a new one, so still clear on accepted.
+  }, [input, onSubmit]);
 
   const onInput = useCallback(
     (e: Event) => {
@@ -858,21 +864,20 @@ const ChatInput = memo(function ChatInput({
           : null
       }
       <textarea
-        placeholder=${busy ? t("chat.placeholderBusy") : t("chat.placeholder")}
+        placeholder=${busy ? t("chat.placeholderSteerBusy") : t("chat.placeholder")}
         value=${input}
         onInput=${onInput}
         onKeyDown=${onKeyDown}
         onCompositionStart=${onCompositionStart}
         onCompositionEnd=${onCompositionEnd}
         onBlur=${() => setTimeout(() => setPopoverKind(null), 150)}
-        disabled=${busy}
         rows="2"
       ></textarea>
       <div style="display: flex; flex-direction: column; gap: 6px; align-self: stretch; justify-content: flex-end;">
         <button
           class="primary"
           onClick=${send}
-          disabled=${busy || !input.trim()}
+          disabled=${!input.trim()}
         >${t("chat.send")}</button>
         <div style="display: flex; gap: 6px;">
           <button onClick=${onNew} title=${t("chat.newTitle")}>${t("chat.new")}</button>

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -2635,10 +2635,6 @@ function AppInner({
         return;
       }
       if (busy || submittingRef.current) {
-        // Busy with an active turn: inject text as a mid-turn steer
-        // message instead of silently dropping it. The steer is
-        // consumed at the next iteration boundary inside step() and
-        // the model sees it as additional guidance in the same turn.
         if (busy && text.trim()) {
           if (isBusyPromptCommand(text)) {
             log.pushInfo(t("app.steerCommandRejected"));
@@ -2648,9 +2644,6 @@ function AppInner({
           resetCursor();
           pushHistory(text);
           loop.steer(text);
-          // Show header + pending text in ghost (light gray).
-          // When the loop consumes the steer, the steer event handler
-          // will promote it to a normal user message.
           log.pushInfo(t("app.steerInjected"));
           log.pushInfo(text, "ghost");
         }
@@ -3336,9 +3329,6 @@ function AppInner({
             });
           } else if (ev.role === "warning") {
             handleWarningEvent(ev, { log, setTurnOnPro });
-          } else if (ev.role === "steer") {
-            // The ghost preview from handleSubmit's steer branch already
-            // confirmed the message was queued; nothing more to show.
           }
         }
         flush();

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -196,6 +196,11 @@ import { useEditHistory } from "./useEditHistory.js";
 import { useSessionInfo } from "./useSessionInfo.js";
 import { useSubagent } from "./useSubagent.js";
 
+function isBusyPromptCommand(text: string): boolean {
+  const trimmed = text.trimStart();
+  return trimmed.startsWith("/") || trimmed.startsWith("#") || detectBangCommand(trimmed) !== null;
+}
+
 export interface AppProps {
   model: string;
   /** Preset resolved at launch; keeps flash distinct from auto when both use deepseek-v4-flash. */
@@ -2181,7 +2186,15 @@ function AppInner({
           },
           submitPrompt: (text: string): SubmitResult => {
             if (busyRef.current) {
-              return { accepted: false, reason: "loop is busy with a turn" };
+              if (isBusyPromptCommand(text)) {
+                return {
+                  accepted: false,
+                  reason: "commands are disabled while steering a busy turn",
+                };
+              }
+              // Steer into current turn instead of rejecting
+              loop.steer(text);
+              return { accepted: true, reason: "steered" };
             }
             const fn = handleSubmitRef.current;
             if (!fn) return { accepted: false, reason: "TUI not ready" };
@@ -2622,6 +2635,25 @@ function AppInner({
         return;
       }
       if (busy || submittingRef.current) {
+        // Busy with an active turn: inject text as a mid-turn steer
+        // message instead of silently dropping it. The steer is
+        // consumed at the next iteration boundary inside step() and
+        // the model sees it as additional guidance in the same turn.
+        if (busy && text.trim()) {
+          if (isBusyPromptCommand(text)) {
+            log.pushInfo(t("app.steerCommandRejected"));
+            return;
+          }
+          setInput("");
+          resetCursor();
+          pushHistory(text);
+          loop.steer(text);
+          // Show header + pending text in ghost (light gray).
+          // When the loop consumes the steer, the steer event handler
+          // will promote it to a normal user message.
+          log.pushInfo(t("app.steerInjected"));
+          log.pushInfo(text, "ghost");
+        }
         return;
       }
       // Cancel-on-user-input: any user-typed submit cancels an active
@@ -3304,6 +3336,9 @@ function AppInner({
             });
           } else if (ev.role === "warning") {
             handleWarningEvent(ev, { log, setTurnOnPro });
+          } else if (ev.role === "steer") {
+            // The ghost preview from handleSubmit's steer branch already
+            // confirmed the message was queued; nothing more to show.
           }
         }
         flush();
@@ -4600,6 +4635,7 @@ function AppInner({
                   input={input}
                   setInput={setInput}
                   busy={busy}
+                  steerBusy={busy}
                   onSubmit={handleSubmit}
                   onHistoryPrev={handleHistoryPrev}
                   onHistoryNext={handleHistoryNext}

--- a/src/cli/ui/ComposerArea.tsx
+++ b/src/cli/ui/ComposerArea.tsx
@@ -45,6 +45,8 @@ export interface ComposerAreaProps {
   input: string;
   setInput: (next: string) => void;
   busy: boolean;
+  /** When busy=true and steerBusy=true, the input stays editable and submit goes to handleSubmit's steer branch. */
+  steerBusy?: boolean;
   onSubmit: (raw: string) => Promise<void>;
   onHistoryPrev: () => void;
   onHistoryNext: () => void;
@@ -87,6 +89,7 @@ export const ComposerArea: React.FC<ComposerAreaProps> = React.memo(
     input,
     setInput,
     busy,
+    steerBusy,
     onSubmit,
     onHistoryPrev,
     onHistoryNext,
@@ -133,6 +136,7 @@ export const ComposerArea: React.FC<ComposerAreaProps> = React.memo(
           onChange={setInput}
           onSubmit={onSubmit}
           disabled={busy}
+          steerBusy={steerBusy}
           onHistoryPrev={onHistoryPrev}
           onHistoryNext={onHistoryNext}
           onOpenExternalEditor={onOpenExternalEditor}

--- a/src/cli/ui/ComposerArea.tsx
+++ b/src/cli/ui/ComposerArea.tsx
@@ -45,7 +45,6 @@ export interface ComposerAreaProps {
   input: string;
   setInput: (next: string) => void;
   busy: boolean;
-  /** When busy=true and steerBusy=true, the input stays editable and submit goes to handleSubmit's steer branch. */
   steerBusy?: boolean;
   onSubmit: (raw: string) => Promise<void>;
   onHistoryPrev: () => void;

--- a/src/cli/ui/PromptInput.tsx
+++ b/src/cli/ui/PromptInput.tsx
@@ -107,11 +107,11 @@ export function PromptInput({
     const insertion = shouldInlinePaste(content)
       ? content
       : (() => {
-        const id = nextPasteIdRef.current % PASTE_SENTINEL_RANGE;
-        nextPasteIdRef.current = id + 1;
-        pastesRef.current.set(id, makePasteEntry(id, content));
-        return encodePasteSentinel(id);
-      })();
+          const id = nextPasteIdRef.current % PASTE_SENTINEL_RANGE;
+          nextPasteIdRef.current = id + 1;
+          pastesRef.current.set(id, makePasteEntry(id, content));
+          return encodePasteSentinel(id);
+        })();
     const next = v.slice(0, c) + insertion + v.slice(c);
     lastLocalValueRef.current = next;
     cursorRef.current = c + insertion.length;

--- a/src/cli/ui/PromptInput.tsx
+++ b/src/cli/ui/PromptInput.tsx
@@ -43,8 +43,6 @@ export interface PromptInputProps {
   onSubmit: (v: string) => void;
   disabled?: boolean;
   placeholder?: string;
-  /** When true, the input stays editable during a busy turn — Enter fires normal onSubmit,
-   *  but the parent should detect the busy state and call loop.steer() instead of step(). */
   steerBusy?: boolean;
   /** ↑/↓ / Ctrl+N hand off here when no in-buffer cursor move applies — parent walks history and swaps `value` via `onChange`. */
   onHistoryPrev?: () => void;
@@ -121,8 +119,6 @@ export function PromptInput({
     setCursor(c + insertion.length);
   };
 
-  // Derived guard: input is only truly frozen when disabled AND no steer is pending.
-  // When steerBusy is active the user can still type; Enter routes via the steer path.
   const inputFrozen = disabled && !steerBusy;
   const inputActive = !disabled || !!steerBusy;
 

--- a/src/cli/ui/PromptInput.tsx
+++ b/src/cli/ui/PromptInput.tsx
@@ -43,6 +43,9 @@ export interface PromptInputProps {
   onSubmit: (v: string) => void;
   disabled?: boolean;
   placeholder?: string;
+  /** When true, the input stays editable during a busy turn — Enter fires normal onSubmit,
+   *  but the parent should detect the busy state and call loop.steer() instead of step(). */
+  steerBusy?: boolean;
   /** ↑/↓ / Ctrl+N hand off here when no in-buffer cursor move applies — parent walks history and swaps `value` via `onChange`. */
   onHistoryPrev?: () => void;
   onHistoryNext?: () => void;
@@ -63,6 +66,7 @@ export function PromptInput({
   onSubmit,
   disabled,
   placeholder,
+  steerBusy,
   onHistoryPrev,
   onHistoryNext,
   onOpenExternalEditor,
@@ -105,11 +109,11 @@ export function PromptInput({
     const insertion = shouldInlinePaste(content)
       ? content
       : (() => {
-          const id = nextPasteIdRef.current % PASTE_SENTINEL_RANGE;
-          nextPasteIdRef.current = id + 1;
-          pastesRef.current.set(id, makePasteEntry(id, content));
-          return encodePasteSentinel(id);
-        })();
+        const id = nextPasteIdRef.current % PASTE_SENTINEL_RANGE;
+        nextPasteIdRef.current = id + 1;
+        pastesRef.current.set(id, makePasteEntry(id, content));
+        return encodePasteSentinel(id);
+      })();
     const next = v.slice(0, c) + insertion + v.slice(c);
     lastLocalValueRef.current = next;
     cursorRef.current = c + insertion.length;
@@ -117,8 +121,13 @@ export function PromptInput({
     setCursor(c + insertion.length);
   };
 
+  // Derived guard: input is only truly frozen when disabled AND no steer is pending.
+  // When steerBusy is active the user can still type; Enter routes via the steer path.
+  const inputFrozen = disabled && !steerBusy;
+  const inputActive = !disabled || !!steerBusy;
+
   useKeystroke((ev) => {
-    if (disabled) return;
+    if (inputFrozen) return;
     if (ev.paste) {
       // Bracketed-paste content delivered by the stdin reader.
       if (ev.input.length > 0) registerPaste(ev.input);
@@ -175,7 +184,7 @@ export function PromptInput({
     if (action.historyHandoff === "prev") onHistoryPrev?.();
     if (action.historyHandoff === "next") onHistoryNext?.();
     if (action.openExternalEditor) onOpenExternalEditor?.();
-  }, !disabled);
+  }, inputActive);
 
   // ── Render ──────────────────────────────────────────────────────
 
@@ -188,12 +197,14 @@ export function PromptInput({
 
   // Hint avoids literal `/` and `@` glyphs — they render in the same row as
   // a just-cleared buffer and read as residual typed input on dim-poor terminals.
-  const effectivePlaceholder = disabled
-    ? (placeholder ?? t("composer.waitingForResponse"))
-    : (placeholder ?? t("composer.placeholder"));
+  const effectivePlaceholder = steerBusy
+    ? t("composer.steerPlaceholder")
+    : disabled
+      ? (placeholder ?? t("composer.waitingForResponse"))
+      : (placeholder ?? t("composer.placeholder"));
 
   const lines = value.length > 0 ? value.split("\n") : [""];
-  const accentColor = disabled ? FG.faint : TONE.brand;
+  const accentColor = steerBusy ? TONE.brand : disabled ? FG.faint : TONE.brand;
   const cursorVisible = true;
   const { line: cursorLine, col: cursorCol } = lineAndColumn(value, cursor);
 
@@ -231,7 +242,7 @@ export function PromptInput({
                   key={`ln-${i}-text-0`}
                   line=""
                   isFirst={true}
-                  isCursorLine={isCursorLine && !disabled}
+                  isCursorLine={isCursorLine && inputActive}
                   cursorCol={isCursorLine ? cursorCol : null}
                   cursorVisible={cursorVisible}
                   showPlaceholder
@@ -242,6 +253,7 @@ export function PromptInput({
                   accentColor={accentColor}
                   pastes={pastesRef.current}
                   disabled={disabled === true}
+                  steerBusy={steerBusy}
                 />,
               );
               firstRowEmitted = true;
@@ -261,7 +273,7 @@ export function PromptInput({
                     entry={pastesRef.current.get(seg.id)}
                     pasteId={seg.id}
                     isFirst={isFirst}
-                    active={cursorOnIt && !disabled}
+                    active={cursorOnIt && inputActive}
                     visibleCells={visibleCells}
                     accentColor={accentColor}
                   />,
@@ -277,7 +289,7 @@ export function PromptInput({
                   key={`ln-${i}-text-${segIdx}`}
                   line={seg.text}
                   isFirst={isFirst}
-                  isCursorLine={segHasCursor && !disabled}
+                  isCursorLine={segHasCursor && inputActive}
                   cursorCol={segHasCursor ? cursorCol - seg.startOffset : null}
                   cursorVisible={cursorVisible}
                   showPlaceholder={false}
@@ -288,6 +300,7 @@ export function PromptInput({
                   accentColor={accentColor}
                   pastes={pastesRef.current}
                   disabled={disabled === true}
+                  steerBusy={steerBusy}
                 />,
               );
             }
@@ -299,7 +312,7 @@ export function PromptInput({
                   key={`ln-${i}-empty`}
                   line=""
                   isFirst={isFirst}
-                  isCursorLine={isCursorLine && !disabled}
+                  isCursorLine={isCursorLine && inputActive}
                   cursorCol={isCursorLine ? 0 : null}
                   cursorVisible={cursorVisible}
                   showPlaceholder={false}
@@ -310,13 +323,14 @@ export function PromptInput({
                   accentColor={accentColor}
                   pastes={pastesRef.current}
                   disabled={disabled === true}
+                  steerBusy={steerBusy}
                 />,
               );
             }
           }
           return rows;
         })()}
-        {showHugeBufferHints && !disabled ? (
+        {showHugeBufferHints && inputActive ? (
           <Box>
             <Text color={FG.faint}>
               {`  [${lines.length} lines · PgUp/PgDn jump · Ctrl+U clear · Ctrl+W del word]`}
@@ -332,9 +346,17 @@ export function PromptInput({
           </Box>
         ) : null}
         <Box height={1} />
-        {disabled ? (
+        {inputFrozen ? (
           <Box marginTop={1}>
             <Text color={FG.faint}>{"  esc to stop"}</Text>
+          </Box>
+        ) : null}
+        {steerBusy ? (
+          <Box marginTop={1} flexDirection="row">
+            <Text color={TONE.accent}>{"  \u23ce "}</Text>
+            <Text color={FG.faint}>{t("composer.steerHint")}</Text>
+            <Text color={FG.faint}>{"  ·  "}</Text>
+            <Text color={FG.faint}>{"esc to stop"}</Text>
           </Box>
         ) : null}
       </Box>
@@ -488,6 +510,7 @@ interface PromptLineProps {
   accentColor: string;
   pastes: ReadonlyMap<number, PasteEntry>;
   disabled: boolean;
+  steerBusy?: boolean;
 }
 
 function PromptLine({
@@ -504,14 +527,16 @@ function PromptLine({
   accentColor,
   pastes,
   disabled,
+  steerBusy,
 }: PromptLineProps) {
+  const promptActive = !disabled || !!steerBusy;
   if (showPlaceholder) {
     return (
       <Box>
         <Text bold color={accentColor}>
           {promptPrefix}
         </Text>
-        {!disabled ? <Text color={accentColor}>{cursorVisible ? "▌" : " "}</Text> : null}
+        {promptActive ? <Text color={accentColor}>{cursorVisible ? "▌" : " "}</Text> : null}
         <Text color={FG.faint}>{placeholderText}</Text>
       </Box>
     );

--- a/src/cli/ui/effects/loop-to-dashboard.ts
+++ b/src/cli/ui/effects/loop-to-dashboard.ts
@@ -32,6 +32,8 @@ export function loopEventToDashboard(
       return { kind: "error", id, text: ev.content };
     case "status":
       return { kind: "status", text: ev.content };
+    case "steer":
+      return { kind: "user", id, text: ev.content };
     default:
       return null;
   }

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -600,6 +600,8 @@ export const EN: TranslationSchema = {
     verboseOn: "▸ verbose mode on — full reasoning + tool output",
     verboseOff: "▸ verbose mode off — head/tail elision restored",
     commandFailed: "! command failed",
+    steerInjected: "▸ steering queued — will be added after the current step",
+    steerCommandRejected: "▸ commands are disabled while steering a busy turn",
     btwUsage: "▸ /btw <question> — ask a side question without polluting the conversation context.",
     btwHeader: "≫ btw",
     btwFailed: "/btw failed",
@@ -1313,6 +1315,8 @@ export const EN: TranslationSchema = {
       "no $EDITOR / $VISUAL / $GIT_EDITOR set \u2014 export one (e.g. `export EDITOR=nano`) and retry",
     editorExited: "editor exited with code {code}",
     typeaheadStaged: "\u25b8 {count} line(s) staged \u00b7 esc recall",
+    steerPlaceholder: "type to steer the current task — commands are disabled while busy",
+    steerHint: "send — injected mid-turn",
   },
   pathConfirm: {
     title: "Outside-sandbox path",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -197,6 +197,8 @@ export interface TranslationSchema {
     verboseOn: string;
     verboseOff: string;
     commandFailed: string;
+    steerInjected: string;
+    steerCommandRejected: string;
     btwUsage: string;
     btwHeader: string;
     btwFailed: string;
@@ -483,6 +485,10 @@ export interface TranslationSchema {
     editorExited: string;
     /** Typeahead queue indicator, e.g. "▸ 3 lines staged · esc recall" */
     typeaheadStaged: string;
+    /** Placeholder shown when steerBusy is active. */
+    steerPlaceholder: string;
+    /** Status-line hint shown when steerBusy is active. */
+    steerHint: string;
   };
   pathConfirm: {
     title: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -582,6 +582,8 @@ export const zhCN: TranslationSchema = {
     verboseOn: "▸ 详细模式已开 — 显示完整推理 + 工具输出",
     verboseOff: "▸ 详细模式已关 — 恢复头尾省略",
     commandFailed: "! 命令失败",
+    steerInjected: "▸ 已加入引导队列 — 将在当前步骤后注入",
+    steerCommandRejected: "▸ 当前轮次忙碌时不能提交命令，只能输入普通引导消息",
     btwUsage: "▸ /btw <问题> — 顺便问个题外话，不会写入当前会话上下文。",
     btwHeader: "≫ btw",
     btwFailed: "/btw 调用失败",
@@ -1243,6 +1245,8 @@ export const zhCN: TranslationSchema = {
       "未设置 $EDITOR / $VISUAL / $GIT_EDITOR — 请导出环境变量（例如 `export EDITOR=nano`）后重试",
     editorExited: "编辑器异常退出，返回码 {code}",
     typeaheadStaged: "\u25b8 {count} 行已暂存 \u00b7 esc 召回",
+    steerPlaceholder: "输入消息以引导当前任务 — 忙碌时不支持命令",
+    steerHint: "发送 — 回合内注入",
   },
   pathConfirm: {
     title: "沙箱外路径",

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -55,12 +55,11 @@ import { parseRateLimitedToolResult } from "./tools/rate-limit.js";
 import type { ChatMessage, ToolCall } from "./types.js";
 
 const ESCALATION_MODEL = "deepseek-v4-pro";
+export const MID_TURN_STEER_WRAPPER =
+  "[Mid-turn steer queued by the user. Do not treat this as a new task; use it only as additional guidance for the current task after completing the current step.]";
 
 function formatSteerUserMessage(content: string): string {
-  return [
-    "[Mid-turn steer queued by the user. Do not treat this as a new task; use it only as additional guidance for the current task after completing the current step.]",
-    content,
-  ].join("\n");
+  return [MID_TURN_STEER_WRAPPER, content].join("\n");
 }
 
 export {
@@ -502,11 +501,9 @@ export class CacheFirstLoop {
   }
   private _inflightCounter = 0;
 
-  private buildMessages(pendingUser: string | null): ChatMessage[] {
+  private buildMessages(): ChatMessage[] {
     const healedMessages = this.healActiveLogBeforeSend();
-    const msgs: ChatMessage[] = [...this.prefix.toMessages(), ...healedMessages];
-    if (pendingUser !== null) msgs.push({ role: "user", content: pendingUser });
-    return msgs;
+    return [...this.prefix.toMessages(), ...healedMessages];
   }
 
   private healActiveLogBeforeSend(): ChatMessage[] {
@@ -666,7 +663,6 @@ export class CacheFirstLoop {
     // first round-trip still leaves the message in the log; the user can
     // /retry without re-typing.
     this.appendAndPersist({ role: "user", content: userInput });
-    const pendingUser: string | null = null;
     const toolSpecs = this.prefix.tools();
     let rateLimitWarningShown = false;
 
@@ -718,11 +714,8 @@ export class CacheFirstLoop {
           content: t("loop.toolUploadStatus"),
         };
       }
-      let messages = this.buildMessages(pendingUser);
+      let messages = this.buildMessages();
 
-      // Consume one queued steer between model calls. This never mutates
-      // the currently running request; the steer becomes visible only in
-      // the next request payload.
       if (this._steerQueue.length > 0) {
         const steer = this._steerQueue.shift()!;
         this._steerConsumed = this._steerQueue.length === 0;
@@ -730,7 +723,7 @@ export class CacheFirstLoop {
           role: "user",
           content: formatSteerUserMessage(steer),
         });
-        messages = this.buildMessages(pendingUser);
+        messages = this.buildMessages();
         yield {
           turn: this._turn,
           role: "steer",
@@ -752,10 +745,10 @@ export class CacheFirstLoop {
             content: t("loop.preflightTruncateStatus"),
           };
           const result = this.context.mechanicalTruncate(this.model, {
-            allowEmpty: pendingUser !== null,
+            allowEmpty: false,
           });
           if (result.folded) {
-            messages = this.buildMessages(pendingUser);
+            messages = this.buildMessages();
             const after = this.context.decidePreflight(messages, this.prefix.toolSpecs, this.model);
             const stillFull = after.needsAction;
             yield {
@@ -1257,7 +1250,7 @@ export class CacheFirstLoop {
     return {
       client: this.client,
       signal: this._turnAbort.signal,
-      buildMessages: () => this.buildMessages(null),
+      buildMessages: () => this.buildMessages(),
       appendAndPersist: (m) => this.appendAndPersist(m),
       recordStats: (model, usage) => this.stats.record(this._turn, model, usage),
       turn: this._turn,

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -56,6 +56,13 @@ import type { ChatMessage, ToolCall } from "./types.js";
 
 const ESCALATION_MODEL = "deepseek-v4-pro";
 
+function formatSteerUserMessage(content: string): string {
+  return [
+    "[Mid-turn steer queued by the user. Do not treat this as a new task; use it only as additional guidance for the current task after completing the current step.]",
+    content,
+  ].join("\n");
+}
+
 export {
   fixToolCallPairing,
   formatLoopError,
@@ -140,17 +147,21 @@ export class CacheFirstLoop {
   /** Authoritative running-id set — UI cards consult this instead of trusting end-event delivery. Insert at dispatch entry, delete in finally. */
   private readonly _inflight = new InflightSet();
 
-  /** Typeahead steer message set by the UI; step() consumes it at the next iter boundary. */
-  private _steer: string | null = null;
+  /** Typeahead steer messages set by the UI; step() consumes one at each iter boundary. */
+  private readonly _steerQueue: string[] = [];
 
   /** Set true when a steer was consumed this turn; cleared on next step() entry. */
   private _steerConsumed = false;
 
   /** UI calls this to inject a mid-turn steer message without aborting the current turn.
-   *  New text resets steerConsumed — a fresh steer hasn't been consumed yet. */
+   *  New text resets steerConsumed because a fresh steer is queued. */
   steer(text: string | null): void {
-    this._steer = text;
-    if (text !== null) this._steerConsumed = false;
+    if (text === null) {
+      this._steerQueue.length = 0;
+      return;
+    }
+    this._steerQueue.push(text);
+    this._steerConsumed = false;
   }
 
   /** True when a steer was consumed this turn (UI gate to avoid double-submit). */
@@ -590,6 +601,7 @@ export class CacheFirstLoop {
             cap: this.budgetUsd.toFixed(2),
           }),
         };
+        this._steerQueue.length = 0;
         return;
       }
       if (!this._budgetWarned && spent >= this.budgetUsd * 0.8) {
@@ -654,7 +666,7 @@ export class CacheFirstLoop {
     // first round-trip still leaves the message in the log; the user can
     // /retry without re-typing.
     this.appendAndPersist({ role: "user", content: userInput });
-    let pendingUser: string | null = null;
+    const pendingUser: string | null = null;
     const toolSpecs = this.prefix.tools();
     let rateLimitWarningShown = false;
 
@@ -684,6 +696,7 @@ export class CacheFirstLoop {
         } finally {
           this._turnAbort = new AbortController();
         }
+        this._steerQueue.length = 0;
         return;
       }
       // Bridge the silence between the PREVIOUS iter's tool result and
@@ -707,18 +720,17 @@ export class CacheFirstLoop {
       }
       let messages = this.buildMessages(pendingUser);
 
-      // Consume a typeahead steer if the UI wrote one between iters.
-      // Injecting as a user message via appendAndPersist means the
-      // next buildMessages() (or the fold rebuild below) will include it.
-      if (this._steer !== null) {
-        const steer = this._steer;
-        this._steer = null;
-        this._steerConsumed = true;
-        this.appendAndPersist({ role: "user", content: steer });
+      // Consume one queued steer between model calls. This never mutates
+      // the currently running request; the steer becomes visible only in
+      // the next request payload.
+      if (this._steerQueue.length > 0) {
+        const steer = this._steerQueue.shift()!;
+        this._steerConsumed = this._steerQueue.length === 0;
+        this.appendAndPersist({
+          role: "user",
+          content: formatSteerUserMessage(steer),
+        });
         messages = this.buildMessages(pendingUser);
-        // Treat the steer as a fresh user utterance — reset pendingUser
-        // since it's already in the log now.
-        pendingUser = null;
         yield {
           turn: this._turn,
           role: "steer",
@@ -943,6 +955,7 @@ export class CacheFirstLoop {
           } finally {
             this._turnAbort = new AbortController();
           }
+          this._steerQueue.length = 0;
           return;
         }
         const probe = is5xxError(err) ? await probeDeepSeekReachable(this.client) : undefined;
@@ -952,6 +965,7 @@ export class CacheFirstLoop {
           content: "",
           error: formatLoopError(err as Error, probe),
         };
+        this._steerQueue.length = 0;
         return;
       }
 
@@ -1071,11 +1085,16 @@ export class CacheFirstLoop {
       }
 
       if (repairedCalls.length === 0) {
+        if (this._steerQueue.length > 0) {
+          continue;
+        }
         if (allSuppressed) {
           yield* forceSummaryAfterIterLimit(this.summaryContext(), { reason: "stuck" });
+          this._steerQueue.length = 0;
           return;
         }
         yield { turn: this._turn, role: "done", content: assistantContent };
+        this._steerQueue.length = 0;
         return;
       }
 
@@ -1124,6 +1143,7 @@ export class CacheFirstLoop {
         };
         this.context.trimTrailingToolCalls();
         yield* forceSummaryAfterIterLimit(this.summaryContext(), { reason: "context-guard" });
+        this._steerQueue.length = 0;
         return;
       }
 

--- a/src/loop/types.ts
+++ b/src/loop/types.ts
@@ -14,7 +14,7 @@ export type EventRole =
   | "warning"
   /** Transient indicator for silent phases; UI clears on next primary event. */
   | "status"
-  /** Mid-turn steer injected as a user utterance without aborting the current turn. */
+  /** Mid-turn steer injected as queued user guidance without aborting the current turn. */
   | "steer";
 
 export interface LoopEvent {

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -2277,9 +2277,82 @@ describe("CacheFirstLoop — mid-turn steer injection", () => {
     // steerConsumed should be true after consumption.
     expect(loop.steerConsumed).toBe(true);
 
-    // The steer should appear as a user message in the log.
+    // The steer should appear as a user message in the log, wrapped so it
+    // remains guidance for the current task rather than a new top-level task.
     const userMessages = loop.log.entries.filter((m) => m.role === "user");
-    expect(userMessages.some((m) => m.content === "mid-turn steer message")).toBe(true);
+    expect(
+      userMessages.some(
+        (m) =>
+          typeof m.content === "string" &&
+          m.content.includes("Mid-turn steer queued by the user") &&
+          m.content.includes("mid-turn steer message"),
+      ),
+    ).toBe(true);
+  });
+
+  it("queues multiple mid-turn steers and consumes one per iteration", async () => {
+    const client = makeClient([
+      {
+        content: "",
+        tool_calls: [
+          {
+            id: "call_1",
+            type: "function",
+            function: { name: "add", arguments: '{"a":1,"b":1}' },
+          },
+        ],
+      },
+      {
+        content: "",
+        tool_calls: [
+          {
+            id: "call_2",
+            type: "function",
+            function: { name: "add", arguments: '{"a":2,"b":2}' },
+          },
+        ],
+      },
+      { content: "done" },
+    ]);
+
+    const tools = new ToolRegistry();
+    tools.register<{ a: number; b: number }, number>({
+      name: "add",
+      parameters: {
+        type: "object",
+        properties: { a: { type: "integer" }, b: { type: "integer" } },
+        required: ["a", "b"],
+      },
+      fn: ({ a, b }) => a + b,
+    });
+
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "use add", toolSpecs: tools.specs() }),
+      tools,
+      stream: false,
+    });
+
+    const gen = loop.step("turn");
+    let r = await gen.next();
+    while (!r.done && r.value.role !== "tool") r = await gen.next();
+
+    loop.steer("first steer");
+    loop.steer("second steer");
+
+    const seen: string[] = [];
+    while (!r.done) {
+      r = await gen.next();
+      if (!r.done && r.value.role === "steer") seen.push(r.value.content);
+    }
+
+    expect(seen).toEqual(["first steer", "second steer"]);
+    const persisted = loop.log.entries
+      .filter((m) => m.role === "user")
+      .map((m) => m.content)
+      .filter((c): c is string => typeof c === "string");
+    expect(persisted.some((c) => c.includes("first steer"))).toBe(true);
+    expect(persisted.some((c) => c.includes("second steer"))).toBe(true);
   });
 
   it("steerConsumed resets to false at the start of each new step()", async () => {


### PR DESCRIPTION
 ## Summary

**This PR adds queued mid-turn steering for busy turns.**

When a turn is already running, users can now type ordinary prompt text to steer the current task instead of waiting for the turn to finish. The steer text is not executed immediately and does not interrupt the in-flight model request. It is queued and applied at the next loop iteration boundary.

  ## Motivation

Previously, busy turns blocked prompt input. The first local change opened the input while busy, but it had two problems:

  - busy-time submissions could be confused with normal commands such as `/new` or `/clear`
  - multiple steer submissions could overwrite each other because the loop only held one pending steer value

This PR makes the behavior explicit:

  - busy input means “steer the current turn”
  - commands are not accepted as steer input
  - multiple steer messages are preserved and consumed in order

  ## Execution Flow

  During a normal idle submit, prompt handling is unchanged.

  During a busy turn:

  1. The TUI/Dashboard input remains editable.
  2. The submitted text is checked before it reaches the loop.
  3. Command-like input is rejected while busy:
     - slash commands, such as `/new`, `/clear`, `/model`
     - shell-style commands, such as `!ls`
     - memory commands, such as `#note`
  4. Ordinary text is accepted as a steer message.
  5. The loop appends that steer text to an internal FIFO queue.
  6. The currently running model request or tool execution continues untouched.
  7. At the next model-iteration boundary, the loop consumes one queued steer.
  8. That steer is added to the conversation as user-role guidance.
  9. If more steer messages are queued, the loop keeps running and consumes the next one at the following iteration boundary.

  This guarantees that steer input affects only future request payloads, never the request that is already in flight.

  ## Queue Semantics

  The loop now stores pending steer messages in a FIFO queue instead of a single pending value.

  This changes the behavior from “last steer wins” to “all accepted steers are applied in order”.

  Example:

  1. The model is running a tool.
  2. User submits `focus on the frontend issue`.
  3. User submits `also check mobile layout`.
  4. The first steer is consumed after the current step.
  5. The second steer is consumed at the next iteration boundary.

  No steer message is silently overwritten.

  ## UI Behavior

  The TUI and Dashboard prompt areas now communicate the busy-steer mode directly:

  - busy prompt input stays editable
  - placeholders explain that the user is steering the current task
  - slash/picker behavior is disabled while busy
  - accepted steer messages are cleared from the input
  - consumed steer messages are mirrored into the Dashboard conversation stream

  The Changes panel is also aligned with the main Chat panel: busy input can now actually submit steer text instead of appearing editable while the send path silently returns.

  ## Tests

  The loop tests now cover:

  - steer text is persisted as wrapped user-role guidance
  - multiple steer messages are queued
  - queued steer messages are consumed in order
  - one steer is consumed per loop iteration boundary
  - existing steer-consumption state still resets correctly between turns
