### PR TITLE
fix(proxy): allow opting out of the DeepSeek direct-route default

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -91,7 +91,10 @@ function checkProxy(): Check[] {
       },
     ];
   }
-  const resolved = resolveNoProxy(process.env, { extraNoProxy: cfg.noProxy });
+  const resolved = resolveNoProxy(process.env, {
+    extraNoProxy: cfg.noProxy,
+    bypassDeepSeekDirect: cfg.bypassDeepSeekDirect,
+  });
   const total = resolved.all.length;
   const sourceSummary = [
     `defaults ${resolved.defaults.length}`,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -31,6 +31,7 @@ const cfgProxy = loadProxyConfig();
 installProxyIfConfigured(process.env, {
   disabled: cliNoProxy || cfgProxy.disabled === true,
   extraNoProxy: cfgProxy.noProxy,
+  bypassDeepSeekDirect: cfgProxy.bypassDeepSeekDirect,
 });
 
 markPhase("cli_module_loaded");

--- a/src/config.ts
+++ b/src/config.ts
@@ -123,6 +123,8 @@ export interface ProxyConfig {
   disabled?: boolean;
   /** Additional NO_PROXY patterns (curl syntax). Additive on top of env NO_PROXY and the default DeepSeek-bypass whitelist. */
   noProxy?: string[];
+  /** When false, route api.deepseek.com / *.deepseek.com through the proxy too (issue #1497 — corporate firewalls that block direct egress). Default true preserves the clash/v2ray US-exit-IP 403 fix. Env `REASONIX_PROXY_DEEPSEEK_DIRECT` overrides. */
+  bypassDeepSeekDirect?: boolean;
 }
 
 export interface ReasonixConfig {
@@ -588,6 +590,9 @@ export function loadProxyConfig(path: string = defaultConfigPath()): ProxyConfig
       (p): p is string => typeof p === "string" && p.trim() !== "",
     );
     if (entries.length > 0) out.noProxy = entries;
+  }
+  if (typeof cfg.bypassDeepSeekDirect === "boolean") {
+    out.bypassDeepSeekDirect = cfg.bypassDeepSeekDirect;
   }
   return out;
 }

--- a/src/net/proxy.ts
+++ b/src/net/proxy.ts
@@ -17,17 +17,18 @@ const PROXY_ENV_KEYS = [
 
 const NO_PROXY_ENV_KEYS = ["NO_PROXY", "no_proxy"] as const;
 
+// Loopback bypass protects the dashboard, MCP stdio sidecars' HTTP probes, and
+// `reasonix doctor` reachability checks; non-negotiable.
+const LOOPBACK_NO_PROXY = ["localhost", "127.0.0.1", "::1"] as const;
+
 // DeepSeek's API origin is in CN; routing it through a user's clash/v2ray
 // (typically a US-exit pool) lands on shared abuse IPs that DeepSeek 403s.
-// Localhost entries protect the dashboard, MCP stdio sidecars' HTTP probes,
-// and the `reasonix doctor` reachability checks.
-export const DEFAULT_NO_PROXY = [
-  "api.deepseek.com",
-  "*.deepseek.com",
-  "localhost",
-  "127.0.0.1",
-  "::1",
-] as const;
+// Opt-out via `proxy.bypassDeepSeekDirect: false` (config) or
+// `REASONIX_PROXY_DEEPSEEK_DIRECT=0` (env) for corporate firewalls that block
+// direct egress and require the proxy to reach api.deepseek.com (issue #1497).
+const DEEPSEEK_NO_PROXY = ["api.deepseek.com", "*.deepseek.com"] as const;
+
+export const DEFAULT_NO_PROXY = [...DEEPSEEK_NO_PROXY, ...LOOPBACK_NO_PROXY] as const;
 
 export function detectProxyUrl(env: NodeJS.ProcessEnv = process.env): string | null {
   for (const key of PROXY_ENV_KEYS) {
@@ -172,6 +173,8 @@ export interface InstallProxyOptions {
   disabled?: boolean;
   /** Additional NO_PROXY patterns layered on top of defaults + env. Sourced from `cfg.proxy.noProxy` / `REASONIX_NO_PROXY`. */
   extraNoProxy?: readonly string[];
+  /** When false, route api.deepseek.com / *.deepseek.com through the proxy too (issue #1497). Default true preserves the clash/v2ray US-exit-IP 403 fix. */
+  bypassDeepSeekDirect?: boolean;
 }
 
 export interface ResolvedNoProxy {
@@ -183,12 +186,35 @@ export interface ResolvedNoProxy {
   all: NoProxyPattern[];
 }
 
+/** Env `REASONIX_PROXY_DEEPSEEK_DIRECT` (1/0/true/false/yes/no/on/off) overrides config when set; defaults true. Per issue #1497, corporate firewalls need the env knob since they often can't edit `~/.reasonix/config.json` ergonomically. */
+export function resolveBypassDeepSeekDirect(
+  env: NodeJS.ProcessEnv,
+  configValue: boolean | undefined,
+): boolean {
+  const raw = env.REASONIX_PROXY_DEEPSEEK_DIRECT;
+  if (typeof raw === "string") {
+    const trimmed = raw.trim().toLowerCase();
+    if (trimmed === "0" || trimmed === "false" || trimmed === "no" || trimmed === "off") {
+      return false;
+    }
+    if (trimmed === "1" || trimmed === "true" || trimmed === "yes" || trimmed === "on") {
+      return true;
+    }
+  }
+  if (configValue === false) return false;
+  return true;
+}
+
 /** Merge default + env + REASONIX_NO_PROXY + opts.extraNoProxy into one resolved view. Same composition as installProxyIfConfigured so /doctor can show what's actually applied. */
 export function resolveNoProxy(
   env: NodeJS.ProcessEnv = process.env,
-  opts: { extraNoProxy?: readonly string[] } = {},
+  opts: { extraNoProxy?: readonly string[]; bypassDeepSeekDirect?: boolean } = {},
 ): ResolvedNoProxy {
-  const defaults = parseNoProxy(DEFAULT_NO_PROXY.join(","));
+  const wantsDeepSeekDirect = resolveBypassDeepSeekDirect(env, opts.bypassDeepSeekDirect);
+  const defaultHosts = wantsDeepSeekDirect
+    ? [...DEEPSEEK_NO_PROXY, ...LOOPBACK_NO_PROXY]
+    : LOOPBACK_NO_PROXY;
+  const defaults = parseNoProxy(defaultHosts.join(","));
   const envSystem = parseNoProxy(detectNoProxyRaw(env));
   const envReasonix = parseNoProxy(
     typeof env.REASONIX_NO_PROXY === "string" ? env.REASONIX_NO_PROXY : null,
@@ -222,7 +248,10 @@ export function installProxyIfConfigured(
   // Default whitelist always applies; env NO_PROXY, REASONIX_NO_PROXY, and
   // opts.extraNoProxy (config) all layer on top additively. Composition lives
   // in resolveNoProxy() so /doctor and install can't drift.
-  const { all: patterns } = resolveNoProxy(env, { extraNoProxy: opts.extraNoProxy });
+  const { all: patterns } = resolveNoProxy(env, {
+    extraNoProxy: opts.extraNoProxy,
+    bypassDeepSeekDirect: opts.bypassDeepSeekDirect,
+  });
 
   try {
     const reinstalled = installed;

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -234,6 +234,17 @@ describe("config", () => {
     });
   });
 
+  it("loads proxy.bypassDeepSeekDirect when set (#1497)", () => {
+    writeConfig({ proxy: { bypassDeepSeekDirect: false } }, path);
+    expect(loadProxyConfig(path)).toEqual({ bypassDeepSeekDirect: false });
+
+    writeConfig({ proxy: { bypassDeepSeekDirect: true } }, path);
+    expect(loadProxyConfig(path)).toEqual({ bypassDeepSeekDirect: true });
+
+    writeConfig({ proxy: { bypassDeepSeekDirect: "yes" } as never }, path);
+    expect(loadProxyConfig(path)).toEqual({});
+  });
+
   it("redactKey hides the middle", () => {
     expect(redactKey("sk-1234567890abcdefghij")).toBe("sk-123…ghij");
     expect(redactKey("short")).toBe("****");

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -8,6 +8,7 @@ import {
   matchesNoProxy,
   normalizeProxyUrl,
   parseNoProxy,
+  resolveBypassDeepSeekDirect,
   resolveNoProxy,
 } from "../src/net/proxy.js";
 
@@ -218,6 +219,27 @@ describe("installProxyIfConfigured", () => {
     expect(writes.join("")).toMatch(/NO_PROXY: .*api\.deepseek\.com/);
   });
 
+  it("bypassDeepSeekDirect=false drops api.deepseek.com from the install-time NO_PROXY list (#1497)", () => {
+    const result = installProxyIfConfigured(
+      { HTTPS_PROXY: "http://example:8080" },
+      { bypassDeepSeekDirect: false },
+    );
+    const raws = result?.noProxy.map((p) => p.raw) ?? [];
+    expect(raws).not.toContain("api.deepseek.com");
+    expect(raws).not.toContain("*.deepseek.com");
+    expect(raws).toContain("localhost");
+  });
+
+  it("env REASONIX_PROXY_DEEPSEEK_DIRECT=0 drops deepseek even without config override (#1497)", () => {
+    const result = installProxyIfConfigured({
+      HTTPS_PROXY: "http://example:8080",
+      REASONIX_PROXY_DEEPSEEK_DIRECT: "0",
+    });
+    const raws = result?.noProxy.map((p) => p.raw) ?? [];
+    expect(raws).not.toContain("api.deepseek.com");
+    expect(raws).toContain("127.0.0.1");
+  });
+
   it("returns reinstalled=true on subsequent installs", () => {
     installProxyIfConfigured({ HTTPS_PROXY: "http://first:8080" });
     const second = installProxyIfConfigured({ HTTPS_PROXY: "http://second:8080" });
@@ -263,9 +285,64 @@ describe("resolveNoProxy", () => {
     ]);
   });
 
-  it("api.deepseek.com always matches the resolved list — DeepSeek bypass is non-optional", () => {
+  it("api.deepseek.com matches the resolved list by default", () => {
     const r = resolveNoProxy({}, {});
     expect(matchesNoProxy("api.deepseek.com", r.all)).toBe(true);
+  });
+
+  it("config bypassDeepSeekDirect=false drops the DeepSeek bypass but keeps loopback (#1497)", () => {
+    const r = resolveNoProxy({}, { bypassDeepSeekDirect: false });
+    expect(matchesNoProxy("api.deepseek.com", r.all)).toBe(false);
+    expect(matchesNoProxy("sub.deepseek.com", r.all)).toBe(false);
+    expect(matchesNoProxy("localhost", r.all)).toBe(true);
+    expect(matchesNoProxy("127.0.0.1", r.all)).toBe(true);
+  });
+
+  it("env REASONIX_PROXY_DEEPSEEK_DIRECT=0 drops the DeepSeek bypass (#1497)", () => {
+    const r = resolveNoProxy({ REASONIX_PROXY_DEEPSEEK_DIRECT: "0" }, {});
+    expect(matchesNoProxy("api.deepseek.com", r.all)).toBe(false);
+    expect(matchesNoProxy("127.0.0.1", r.all)).toBe(true);
+  });
+
+  it("env REASONIX_PROXY_DEEPSEEK_DIRECT wins over config when set", () => {
+    const r = resolveNoProxy(
+      { REASONIX_PROXY_DEEPSEEK_DIRECT: "1" },
+      { bypassDeepSeekDirect: false },
+    );
+    expect(matchesNoProxy("api.deepseek.com", r.all)).toBe(true);
+  });
+});
+
+describe("resolveBypassDeepSeekDirect (#1497)", () => {
+  it("defaults to true when neither env nor config is set", () => {
+    expect(resolveBypassDeepSeekDirect({}, undefined)).toBe(true);
+  });
+
+  it("returns false when config is false and env is unset", () => {
+    expect(resolveBypassDeepSeekDirect({}, false)).toBe(false);
+  });
+
+  it("env false-y values flip the default off", () => {
+    for (const v of ["0", "false", "no", "off", "FALSE", "Off"]) {
+      expect(resolveBypassDeepSeekDirect({ REASONIX_PROXY_DEEPSEEK_DIRECT: v }, undefined)).toBe(
+        false,
+      );
+    }
+  });
+
+  it("env truthy values force the bypass back on (override config false)", () => {
+    for (const v of ["1", "true", "yes", "on", "TRUE", "Yes"]) {
+      expect(resolveBypassDeepSeekDirect({ REASONIX_PROXY_DEEPSEEK_DIRECT: v }, false)).toBe(true);
+    }
+  });
+
+  it("unrecognized env values fall through to config", () => {
+    expect(resolveBypassDeepSeekDirect({ REASONIX_PROXY_DEEPSEEK_DIRECT: "maybe" }, false)).toBe(
+      false,
+    );
+    expect(
+      resolveBypassDeepSeekDirect({ REASONIX_PROXY_DEEPSEEK_DIRECT: "maybe" }, undefined),
+    ).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

Make the DeepSeek direct-route default opt-out so corporate-firewall users can route `api.deepseek.com` through their proxy. Closes #1497.

## The bug

`DEFAULT_NO_PROXY` in `src/net/proxy.ts` hardcoded `api.deepseek.com` + `*.deepseek.com` alongside loopback. The `SelectiveProxyDispatcher` therefore always routed those hosts through `undici.Agent()` direct, bypassing `HTTPS_PROXY`. Corporate networks that block direct egress saw `ConnectTimeoutError` → `getBalance()` returned `null` → `reasonix doctor` reported `api reach … /user/balance returned null — auth failed or network blocked` with no escape hatch (`--no-proxy` doesn't help; it just skips proxy install entirely, and Node's bare fetch ignores `HTTPS_PROXY`).

## The fix

Split the defaults:

- `LOOPBACK_NO_PROXY` (`localhost`, `127.0.0.1`, `::1`) — non-negotiable; dashboard, MCP stdio sidecar HTTP probes, and `doctor` reachability checks all need this.
- `DEEPSEEK_NO_PROXY` (`api.deepseek.com`, `*.deepseek.com`) — opt-out via either knob:
  - **Config**: `proxy.bypassDeepSeekDirect: false` in `~/.reasonix/config.json`
  - **Env**: `REASONIX_PROXY_DEEPSEEK_DIRECT=0` (also accepts `false` / `no` / `off`; truthy values are `1` / `true` / `yes` / `on`)

Env wins over config when explicitly set; unrecognized env values fall through to config. Default behaviour preserves the original clash/v2ray US-exit-IP-403 fix that put the bypass there in the first place — no behaviour change for users who don't set either knob.

`reasonix doctor`'s `proxy routing` probe row already prints `api.deepseek.com → direct | via proxy`, and now reflects the override correctly without any extra detail string.

## Why two knobs

Corporate users typically can't ergonomically edit `~/.reasonix/config.json` from their workstation (config sync, profile management, etc.) but they own their shell env vars. The env knob is the actual escape hatch; the config knob is for persistent setups.

## Scope check — any other places with the same problem?

The bypass machinery is a single chokepoint: `SelectiveProxyDispatcher` set as `undici`'s global dispatcher. Every `fetch()` in the codebase (DeepSeek client, web tools, MCP HTTP probes, doctor, dashboard, balance API) flows through it. Searched for other hardcoded "must route direct" hosts:

- `src/qq/bot.ts` (`bots.qq.com`, `api.sgroup.qq.com`, `sandbox.api.sgroup.qq.com`) — uses the global dispatcher, no separate bypass list. ✓
- `src/index/semantic/embedding.ts` Ollama localhost — covered by loopback bypass which stays mandatory. ✓
- `metaso.cn` / `tavily.com` / `searxng` — only appear in i18n error strings, no routing override. ✓
- `docs/configuration.html`, `docs/src/hero.jsx` — describe target URLs, don't claim NO_PROXY is non-optional. No edits needed. ✓

One anti-pattern, one fix.

## Test Plan

- [x] `npx vitest run tests/proxy.test.ts` — 47 tests pass, including:
  - `resolveBypassDeepSeekDirect` env precedence + all boolean parse forms
  - `resolveNoProxy({...}, { bypassDeepSeekDirect: false })` drops DeepSeek but keeps loopback
  - `REASONIX_PROXY_DEEPSEEK_DIRECT=0` drops DeepSeek at install time
  - env wins over config when both are set
- [x] `npx vitest run tests/config.test.ts` — 73 tests pass, including new `proxy.bypassDeepSeekDirect` config load + typeguard against non-bool values
- [x] `npx vitest run tests/doctor-json.test.ts` — 5 pass
- [x] `npx vitest run tests/comment-policy.test.ts` — 9 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx biome check` on touched files — clean
- [x] `npm run verify` — full suite green via pre-push hook
