### PR TITLE
feat(tui): add mouseWheelRows config knob for per-terminal scroll tuning

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -39,6 +39,7 @@ import {
   editModeHintShown,
   loadBaseUrl,
   loadEngineeringLifecycleMode,
+  loadMouseWheelRows,
   loadReasoningEffort,
   loadTheme,
   markEditModeHintShown,
@@ -433,10 +434,11 @@ export function App(props: AppProps): React.ReactElement {
       showFeedbackHint: cfg.showFeedbackHint !== false,
     };
   }, []);
+  const wheelRows = React.useMemo(() => loadMouseWheelRows(), []);
   return (
     <ThemeProvider name={themeName}>
       <AgentStoreProvider session={session} initialCards={initialCards}>
-        <ChatScrollProvider>
+        <ChatScrollProvider wheelRows={wheelRows}>
           <AppInner
             {...props}
             themeName={themeName}

--- a/src/cli/ui/state/chat-scroll-provider.tsx
+++ b/src/cli/ui/state/chat-scroll-provider.tsx
@@ -9,10 +9,12 @@ const Ctx = React.createContext<ChatScrollStore | null>(null);
 
 export function ChatScrollProvider({
   children,
+  wheelRows,
 }: {
   children: React.ReactNode;
+  wheelRows?: number;
 }): React.ReactElement {
-  const store = React.useMemo(() => createChatScrollStore(), []);
+  const store = React.useMemo(() => createChatScrollStore({ wheelRows }), [wheelRows]);
   return <Ctx.Provider value={store}>{children}</Ctx.Provider>;
 }
 

--- a/src/cli/ui/state/chat-scroll-store.ts
+++ b/src/cli/ui/state/chat-scroll-store.ts
@@ -49,7 +49,16 @@ const initial: ChatScrollState = {
   cardHeights: EMPTY_HEIGHTS,
 };
 
-export function createChatScrollStore(): ChatScrollStore {
+export interface CreateChatScrollStoreOptions {
+  /** Override per-SGR-wheel-report step. Defaults to `SCROLL_WHEEL_ROWS`; clamped to [1, 10]. Sourced from `cfg.mouseWheelRows` so users on terminals that emit one report per notch (#1494) can opt out of the conservative default tuned for terminals that emit 2-5 (#1419). */
+  wheelRows?: number;
+}
+
+export function createChatScrollStore(opts: CreateChatScrollStoreOptions = {}): ChatScrollStore {
+  const wheelRows =
+    typeof opts.wheelRows === "number" && Number.isInteger(opts.wheelRows) && opts.wheelRows >= 1
+      ? Math.min(opts.wheelRows, 10)
+      : SCROLL_WHEEL_ROWS;
   let state = initial;
   const listeners = new Set<ScrollListener>();
   let pendingDelta = 0;
@@ -132,8 +141,8 @@ export function createChatScrollStore(): ChatScrollStore {
     scrollDown: () => schedule(SCROLL_ARROW_ROWS),
     scrollPageUp: () => schedule(-SCROLL_PAGE_ROWS),
     scrollPageDown: () => schedule(SCROLL_PAGE_ROWS),
-    scrollWheelUp: () => schedule(-SCROLL_WHEEL_ROWS),
-    scrollWheelDown: () => schedule(SCROLL_WHEEL_ROWS),
+    scrollWheelUp: () => schedule(-wheelRows),
+    scrollWheelDown: () => schedule(wheelRows),
     jumpToBottom() {
       pendingDelta = 0;
       if (flushTimer !== null) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -173,6 +173,8 @@ export interface ReasonixConfig {
 
   /** TUI mouse-wheel scrolling via SGR mouse tracking. Default true. Set false to fall back to native terminal drag-select for copy (then wheel is terminal-dependent — most terminals translate wheel→arrow in alt-screen, some don't). */
   mouseTracking?: boolean;
+  /** Rows scrolled per single SGR mouse-wheel report. Default 1 — most terminals emit 2-5 reports per physical notch, so 1 already produces 2-5 rows per notch (#1419). Bump to 3-5 only if your terminal emits one report per notch and scrolling feels slow (#1494). Clamped to [1, 10]. */
+  mouseWheelRows?: number;
   dashboard?: {
     /** Pin the embedded dashboard to a fixed port — required for stable SSH tunnels. 0/absent → ephemeral. */
     port?: number;
@@ -601,6 +603,12 @@ export function loadRateLimit(path: string = defaultConfigPath()): RateLimitConf
   const rpm = readConfig(path).rateLimit?.rpm;
   if (typeof rpm !== "number" || !Number.isInteger(rpm) || rpm <= 0) return undefined;
   return { rpm };
+}
+
+export function loadMouseWheelRows(path: string = defaultConfigPath()): number | undefined {
+  const raw = readConfig(path).mouseWheelRows;
+  if (typeof raw !== "number" || !Number.isInteger(raw) || raw < 1) return undefined;
+  return Math.min(raw, 10);
 }
 
 export function loadToolRateLimit(

--- a/tests/chat-scroll-wheel.test.ts
+++ b/tests/chat-scroll-wheel.test.ts
@@ -37,4 +37,33 @@ describe("chatScroll wheel step (issue #1419)", () => {
     store.scrollPageUp();
     expect(store.getState().scrollRows).toBe(200 - SCROLL_PAGE_ROWS);
   });
+
+  it("wheelRows override scales each tick (issue #1494)", () => {
+    const store = createChatScrollStore({ wheelRows: 3 });
+    store.setMaxScroll(200);
+    store.scrollWheelUp();
+    expect(store.getState().scrollRows).toBe(200 - 3);
+  });
+
+  it("wheelRows clamps to [1, 10] and ignores non-positive / non-integer values", async () => {
+    vi.useFakeTimers();
+    try {
+      for (const [opt, expected] of [
+        [{ wheelRows: 0 }, SCROLL_WHEEL_ROWS],
+        [{ wheelRows: -5 }, SCROLL_WHEEL_ROWS],
+        [{ wheelRows: 2.5 }, SCROLL_WHEEL_ROWS],
+        [{ wheelRows: 99 }, 10],
+        [{}, SCROLL_WHEEL_ROWS],
+      ] as const) {
+        const store = createChatScrollStore(opt);
+        store.setMaxScroll(500);
+        const before = store.getState().scrollRows;
+        store.scrollWheelUp();
+        await vi.advanceTimersByTimeAsync(32);
+        expect(before - store.getState().scrollRows).toBe(expected);
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -18,6 +18,7 @@ import {
   loadFilesystemOutlineThresholdBytes,
   loadIndexConfig,
   loadIndexUserConfig,
+  loadMouseWheelRows,
   loadPricingOverride,
   loadProjectPathAllowed,
   loadProjectShellAllowed,
@@ -232,6 +233,29 @@ describe("config", () => {
     expect(loadToolRateLimit(path)).toMatchObject({
       aggregate: { maxCalls: 200, windowSeconds: 60 },
     });
+  });
+
+  it("loads mouseWheelRows when set, clamps to [1,10], drops invalid (#1494)", () => {
+    writeConfig({ mouseWheelRows: 3 }, path);
+    expect(loadMouseWheelRows(path)).toBe(3);
+
+    writeConfig({ mouseWheelRows: 99 }, path);
+    expect(loadMouseWheelRows(path)).toBe(10);
+
+    writeConfig({ mouseWheelRows: 0 }, path);
+    expect(loadMouseWheelRows(path)).toBeUndefined();
+
+    writeConfig({ mouseWheelRows: -1 }, path);
+    expect(loadMouseWheelRows(path)).toBeUndefined();
+
+    writeConfig({ mouseWheelRows: 2.5 }, path);
+    expect(loadMouseWheelRows(path)).toBeUndefined();
+
+    writeConfig({ mouseWheelRows: "3" as unknown as number }, path);
+    expect(loadMouseWheelRows(path)).toBeUndefined();
+
+    writeConfig({}, path);
+    expect(loadMouseWheelRows(path)).toBeUndefined();
   });
 
   it("loads proxy.bypassDeepSeekDirect when set (#1497)", () => {


### PR DESCRIPTION
## Summary

Add `mouseWheelRows?: number` config knob so users can tune wheel-scroll speed per their terminal. Closes #1494.

## The tension this resolves

Mouse-wheel sensitivity is terminal-dependent, and we've now seen both directions:

- **#1419 (over-sensitive)**: most terminals (Windows Terminal, macOS Terminal, iTerm2 with typical mouse drivers) emit **2-5 SGR mouse reports per single physical notch**, so a per-report step of 1 already produces 2-5 rows scrolled per notch. That issue established `SCROLL_WHEEL_ROWS = 1` in [`src/cli/ui/state/chat-scroll-store.ts:37-39`](https://github.com/esengine/DeepSeek-Reasonix/blob/main/src/cli/ui/state/chat-scroll-store.ts).
- **#1494 (under-sensitive)**: some terminal/mouse-driver combinations emit **one report per notch**, so the same step value produces a 1-row scroll that feels frozen.

The issue proposed bumping the default to 3, which would multiply to 6-15 rows per notch on terminals from class #1419 — a clean regression. Constant-bump is not a fix.

## What this does instead

- Adds `mouseWheelRows?: number` to `ReasonixConfig` (next to `mouseTracking`). Default unchanged; affected users opt in.
- Validator at `loadMouseWheelRows()`: positive integer, clamped to `[1, 10]`, invalid values → `undefined` → use the `SCROLL_WHEEL_ROWS = 1` default.
- `createChatScrollStore({ wheelRows })` accepts the override; `ChatScrollProvider` threads it through.
- `App.tsx` reads `loadMouseWheelRows()` once and passes to the provider.

No behaviour change for anyone who doesn't set the knob. Users on the under-sensitive class set `"mouseWheelRows": 3` (or whatever feels right up to 10) in `~/.reasonix/config.json` and get the natural scroll back.

## Test Plan

- [x] `tests/chat-scroll-wheel.test.ts` — new cases: override scales each tick; clamping to `[1,10]` for `0` / `-5` / `2.5` / `99` / `undefined`. The two pre-existing `#1419` regression tests still pass without modification (default unchanged).
- [x] `tests/config.test.ts` — new case: load + clamp + reject for `mouseWheelRows`.
- [x] `npx vitest run tests/chat-scroll-wheel.test.ts tests/config.test.ts tests/comment-policy.test.ts` — 88 pass, 1 skipped (pre-existing).
- [x] `npx tsc --noEmit` — clean.
- [x] `npx biome check` on touched files — clean.
- [x] `npm run verify` via pre-push hook — green.

## What this does not do

- Doesn't detect terminal capability at runtime — too brittle, too many `TERM_PROGRAM` / driver / OS combinations to enumerate.
- Doesn't expose this in the desktop settings UI — CLI-only config is enough surface for a niche tuning knob.
- Doesn't change the default. #1419 was a real ship-blocking regression on the majority case; we don't flip it on speculation.
