### PR TITLE
fix(tui): Ctrl+Enter inserts newline instead of submitting; update shortcut panel

### DIFF
--- a/src/cli/ui/PromptInput.tsx
+++ b/src/cli/ui/PromptInput.tsx
@@ -384,7 +384,7 @@ export function PromptInput({
 export function HintRow(): React.ReactElement {
   const items: Array<{ key: string; tKey: string }> = [
     { key: "\u23ce", tKey: "composer.hintSend" },
-    { key: "\u21e7\u23ce", tKey: "composer.hintNewline" },
+    { key: "\u21e7\u23ce / ^J", tKey: "composer.hintNewline" },
     { key: "^U", tKey: "composer.hintClear" },
     { key: "\u2191\u2193", tKey: "composer.hintHistory" },
     { key: "esc", tKey: "composer.hintAbort" },

--- a/src/cli/ui/ShortcutsHelpModal.tsx
+++ b/src/cli/ui/ShortcutsHelpModal.tsx
@@ -20,6 +20,8 @@ const SHORTCUT_GROUPS: ShortcutGroup[] = [
     items: [
       { keys: "Enter", descKey: "shortcutsHelp.descEnter" },
       { keys: "Shift+Enter", descKey: "shortcutsHelp.descShiftEnter" },
+      { keys: "Ctrl+Enter", descKey: "shortcutsHelp.descCtrlEnter" },
+      { keys: "Ctrl+J", descKey: "shortcutsHelp.descCtrlJ" },
       { keys: "Ctrl+U", descKey: "shortcutsHelp.descCtrlU" },
       { keys: "Ctrl+W", descKey: "shortcutsHelp.descCtrlW" },
       { keys: "Ctrl+P", descKey: "shortcutsHelp.descCtrlP" },

--- a/src/cli/ui/multiline-keys.ts
+++ b/src/cli/ui/multiline-keys.ts
@@ -187,7 +187,8 @@ export function processMultilineKey(
   }
 
   if (key.return) {
-    if (key.shift || key.meta) return insertAt(value, cursor, "\n");
+    // Shift+Enter / Ctrl+Enter / Alt+Enter → 换行
+    if (key.shift || key.ctrl || key.meta) return insertAt(value, cursor, "\n");
     // Bash-style line continuation: trailing '\' + Enter (only when the
     // cursor sits at end-of-buffer, so a stray '\' mid-line doesn't
     // trigger it).

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -1834,6 +1834,8 @@ export const EN: TranslationSchema = {
     groupSystem: "System",
     descEnter: "Send message",
     descShiftEnter: "New line",
+    descCtrlEnter: "New line",
+    descCtrlJ: "New line",
     descCtrlU: "Clear input",
     descCtrlW: "Delete word",
     descCtrlP: "Toggle shortcut panel",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -925,6 +925,8 @@ export interface TranslationSchema {
     groupSystem: string;
     descEnter: string;
     descShiftEnter: string;
+    descCtrlEnter: string;
+    descCtrlJ: string;
     descCtrlU: string;
     descCtrlW: string;
     descCtrlP: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -1737,6 +1737,8 @@ export const zhCN: TranslationSchema = {
     groupSystem: "系统",
     descEnter: "发送消息",
     descShiftEnter: "换行",
+    descCtrlEnter: "换行",
+    descCtrlJ: "换行",
     descCtrlU: "清空输入",
     descCtrlW: "删除单词",
     descCtrlP: "打开/关闭快捷键面板",


### PR DESCRIPTION
## Summary

Fix issue #1493: **Ctrl+Enter** now inserts a newline in the composer instead of submitting, matching the behavior of Shift+Enter and Alt+Enter. The shortcut panel is also updated to reflect the new keybindings.

## Changes

### 1. multiline-keys.ts (behavior fix)

Added \key.ctrl\ to the newline condition in the \key.return\ branch. Previously only \key.shift\ and \key.meta\ were checked, so Ctrl+Enter fell through to submit. Now Ctrl+Enter, Shift+Enter, and Alt+Enter all insert a newline.

### 2. PromptInput.tsx (HintRow update)

Updated the HintRow to show \^\u2191\u21e7 Enter / ^J\ as the newline hint. \Ctrl+J\ is a terminal-agnostic newline shortcut that works regardless of modifyOtherKeys or Kitty protocol support, making it a reliable fallback for users on Wayland/Hyprland or other environments where Shift+Enter may not be properly detected.

### 3. ShortcutsHelpModal.tsx (shortcut panel)

Added two new entries to the Input shortcuts group:
- \Ctrl+Enter\ - New line
- \Ctrl+J\ - New line

### 4. i18n (EN.ts, zh-CN.ts, types.ts)

Added \descCtrlEnter\ and \descCtrlJ\ translation keys with appropriate English and Chinese descriptions.

## Behavior after fix

| Key | Behavior |
|-----|----------|
| Enter | Submit (unchanged) |
| Shift+Enter | New line (unchanged) |
| Ctrl+Enter | **New line** (fixed) |
| Ctrl+J | New line (unchanged, reliable fallback) |
| Alt+Enter | New line (unchanged) |

## Compatibility

- **macOS**: All terminals (iTerm2, Terminal.app, etc.) - works via modifyOtherKeys
- **Linux**: kitty/Konsole with modifyOtherKeys - works via modifier encoding
- **Linux**: Wayland/Hyprland - falls back to Enter (submit) if terminal doesn't send mod sequences; users can use Ctrl+J as reliable alternative
- **Windows**: Windows Terminal - works via modifyOtherKeys

Refs #1493