### PR TITLE
fix(context): preserve memory constraints across context folds (#1462)

### DIFF
--- a/benchmarks/behavior-stability/harness.ts
+++ b/benchmarks/behavior-stability/harness.ts
@@ -1,0 +1,39 @@
+/** Evaluation harness — runs scenarios and collects results. */
+
+import type { EvalReport, EvalResult, EvalScenario } from "./types.js";
+
+export async function runScenarios(
+  scenarios: EvalScenario[],
+  opts: {
+    onResult?: (r: EvalResult) => void;
+  } = {},
+): Promise<EvalReport> {
+  const results: EvalResult[] = [];
+  for (const sc of scenarios) {
+    const t0 = Date.now();
+    let result: EvalResult;
+    try {
+      result = await sc.run();
+      result.durationMs = Date.now() - t0;
+    } catch (err) {
+      result = {
+        scenarioId: sc.id,
+        pass: false,
+        durationMs: Date.now() - t0,
+        details: `UNEXPECTED ERROR: ${(err as Error).message}`,
+      };
+    }
+    results.push(result);
+    opts.onResult?.(result);
+  }
+
+  // Dynamic import avoids bundling VERSION into the harness module.
+  const { VERSION } = await import("../../src/version.js");
+  return {
+    meta: {
+      date: new Date().toISOString(),
+      reasonixVersion: VERSION,
+    },
+    results,
+  };
+}

--- a/benchmarks/behavior-stability/report.ts
+++ b/benchmarks/behavior-stability/report.ts
@@ -1,0 +1,81 @@
+/** Render behavior-stability results.json → markdown report. */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+import type { EvalReport } from "./types.js";
+
+interface CliArgs {
+  input: string;
+  outPath: string;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const out: CliArgs = { input: "", outPath: "benchmarks/behavior-stability/report.md" };
+  const positional: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--out") out.outPath = argv[++i] ?? out.outPath;
+    else if (a && !a.startsWith("--")) positional.push(a);
+  }
+  out.input = positional[0] ?? "";
+  if (!out.input) {
+    throw new Error(
+      "usage: npx tsx benchmarks/behavior-stability/report.ts <results.json> [--out report.md]",
+    );
+  }
+  return out;
+}
+
+function renderHeader(report: EvalReport): string {
+  return `# Reasonix Behavior-Stability Evaluation
+
+**Date:** ${report.meta.date}
+**Version:** ${report.meta.reasonixVersion}
+`;
+}
+
+function renderSummary(report: EvalReport): string {
+  const passed = report.results.filter((r) => r.pass).length;
+  const total = report.results.length;
+  const pct = total > 0 ? ((passed / total) * 100).toFixed(0) : "0";
+
+  const rows = report.results.map((r) => {
+    const icon = r.pass ? "✅" : "❌";
+    return `| ${icon} | \`${r.scenarioId}\` | ${r.durationMs}ms | ${r.details} |`;
+  });
+
+  return `## Summary
+
+**${passed}/${total} passed (${pct}%)**
+
+| status | scenario | time | details |
+|---|---:|---:|:---|
+${rows.join("\n")}
+`;
+}
+
+function render(report: EvalReport): string {
+  return [renderHeader(report), renderSummary(report)].join("\n\n");
+}
+
+function isMain(): boolean {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  return import.meta.url === pathToFileURL(entry).href;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const raw = readFileSync(args.input, "utf8");
+  const report = JSON.parse(raw) as EvalReport;
+  const md = render(report);
+  writeFileSync(args.outPath, md, "utf8");
+  console.log(`Wrote ${args.outPath} (${report.results.length} results)`);
+}
+
+if (isMain()) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/benchmarks/behavior-stability/runner.ts
+++ b/benchmarks/behavior-stability/runner.ts
@@ -1,0 +1,87 @@
+/** CLI runner for behavior-stability evaluation. */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { loadDotenv } from "../../src/index.js";
+import { ALL_SCENARIOS, API_SCENARIOS, LOCAL_SCENARIOS } from "./scenarios.js";
+import { runScenarios } from "./harness.js";
+import type { EvalScenario } from "./types.js";
+
+loadDotenv();
+
+interface CliArgs {
+  local: boolean;
+  api: boolean;
+  outPath: string | null;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const out: CliArgs = { local: false, api: false, outPath: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--local") out.local = true;
+    else if (a === "--api") out.api = true;
+    else if (a === "--out") out.outPath = argv[++i] ?? null;
+  }
+  // Default to local-only when neither flag is provided.
+  if (!out.local && !out.api) out.local = true;
+  return out;
+}
+
+function pickScenarios(args: CliArgs): EvalScenario[] {
+  const scenarios: EvalScenario[] = [];
+  if (args.local) scenarios.push(...LOCAL_SCENARIOS);
+  if (args.api) scenarios.push(...API_SCENARIOS);
+  return scenarios;
+}
+
+function isMain(): boolean {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  return import.meta.url === pathToFileURL(entry).href;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const scenarios = pickScenarios(args);
+
+  if (scenarios.length === 0) {
+    console.log("No scenarios selected. Use --local, --api, or both.");
+    process.exit(0);
+  }
+
+  const categories = new Set(scenarios.map((s) => s.category));
+  console.log(`Running ${scenarios.length} scenario(s) [${[...categories].join(", ")}] …\n`);
+
+  const report = await runScenarios(scenarios, {
+    onResult: (r) => {
+      const icon = r.pass ? "✅" : "❌";
+      console.log(`${icon} ${r.scenarioId} (${r.durationMs}ms)`);
+      console.log(`   ${r.details}\n`);
+    },
+  });
+
+  const passed = report.results.filter((r) => r.pass).length;
+  const total = report.results.length;
+  console.log(`────────────────────────────────────────`);
+  console.log(`Results: ${passed}/${total} passed`);
+  console.log(`Version: ${report.meta.reasonixVersion}`);
+  console.log(`Date:    ${report.meta.date}`);
+
+  if (args.outPath) {
+    const dir = dirname(args.outPath);
+    if (dir !== ".") mkdirSync(dir, { recursive: true });
+    writeFileSync(args.outPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+    console.log(`Wrote ${args.outPath}`);
+  }
+
+  if (passed < total) process.exit(1);
+}
+
+if (isMain()) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/benchmarks/behavior-stability/scenarios.ts
+++ b/benchmarks/behavior-stability/scenarios.ts
@@ -1,0 +1,147 @@
+/** Behavior-stability scenario for PR #1462 — constraint persistence across context folds. */
+
+import { AppendOnlyLog, SessionStats } from "../../src/index.js";
+import { ContextManager } from "../../src/context-manager.js";
+import { Usage } from "../../src/client.js";
+import type { EvalResult, EvalScenario } from "./types.js";
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+function withTiming(fn: () => Promise<EvalResult>): Promise<EvalResult> {
+  const t0 = Date.now();
+  return fn().then((r) => ({ ...r, durationMs: Date.now() - t0 }));
+}
+
+function pass(id: string, details: string): EvalResult {
+  return { scenarioId: id, pass: true, durationMs: 0, details };
+}
+
+function fail(id: string, details: string): EvalResult {
+  return { scenarioId: id, pass: false, durationMs: 0, details };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Mock client — returns a fixed summary for fold testing             */
+/* ------------------------------------------------------------------ */
+
+class MockDeepSeekClient {
+  private _replyContent: string;
+  constructor(replyContent: string) {
+    this._replyContent = replyContent;
+  }
+  async chat(): Promise<{
+    content: string;
+    reasoningContent: string;
+    usage: Usage;
+  }> {
+    return {
+      content: this._replyContent,
+      reasoningContent: "",
+      usage: new Usage(100, 50, 150, 0, 100),
+    };
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/*  #1462 — Constraint persistence across folds (local)                */
+/* ------------------------------------------------------------------ */
+
+const constraintPersistence: EvalScenario = {
+  id: "constraint-persistence",
+  name: "Context fold preserves pinned constraints from system prompt",
+  category: "context",
+  requiresApi: false,
+  run: () =>
+    withTiming(async () => {
+      const systemPrompt = `You are a coding assistant.
+
+# HIGH PRIORITY constraints
+
+- DO NOT use npm install without asking.
+- Never delete files without confirmation.
+
+# User memory
+
+The user prefers TypeScript over JavaScript.
+
+# Project memory
+
+This project uses pnpm instead of npm.`;
+
+      const log = new AppendOnlyLog();
+      // Fill log with synthetic long history to trigger a fold boundary > 0.
+      for (let i = 0; i < 40; i++) {
+        log.append({
+          role: "user",
+          content: `Turn ${i}: Please review the codebase and tell me what you found.`,
+        });
+        log.append({
+          role: "assistant",
+          content: `Turn ${i} summary: I reviewed the codebase and found several issues including unused imports, missing type annotations, and inconsistent formatting.`,
+        });
+      }
+
+      const client = new MockDeepSeekClient("Summary of all prior turns.");
+      const stats = new SessionStats();
+      const ctx = new ContextManager({
+        client: client as any,
+        log,
+        stats,
+        sessionName: null,
+        getAbortSignal: () => new AbortController().signal,
+        getCurrentTurn: () => 1,
+        getSystemPrompt: () => systemPrompt,
+      });
+
+      // Use a tiny tail budget so almost everything becomes head and gets summarized.
+      const result = await ctx.fold("deepseek-v4-flash", { keepRecentTokens: 200 });
+
+      if (!result.folded) {
+        return fail(
+          "constraint-persistence",
+          `Fold did not happen (before=${result.beforeMessages}, after=${result.afterMessages}).`,
+        );
+      }
+
+      const foldedSystem = log.toMessages()[0];
+      if (foldedSystem?.role !== "assistant") {
+        return fail(
+          "constraint-persistence",
+          `Expected first folded message to be assistant summary, got ${foldedSystem?.role}.`,
+        );
+      }
+
+      const content = foldedSystem.content as string;
+      const checks = [
+        { text: "DO NOT use npm install without asking", label: "HIGH PRIORITY constraint" },
+        { text: "Never delete files without confirmation", label: "HIGH PRIORITY constraint 2" },
+        { text: "TypeScript over JavaScript", label: "User memory" },
+        { text: "pnpm instead of npm", label: "Project memory" },
+      ];
+
+      const missing = checks.filter((c) => !content.includes(c.text));
+      if (missing.length > 0) {
+        return fail(
+          "constraint-persistence",
+          `Folded summary missing ${missing.length} constraint(s): ${missing.map((m) => m.label).join(", ")}.`,
+        );
+      }
+
+      return pass(
+        "constraint-persistence",
+        `Fold reduced ${result.beforeMessages} → ${result.afterMessages} messages and preserved all ${checks.length} pinned constraints.`,
+      );
+    }),
+};
+
+/* ------------------------------------------------------------------ */
+/*  Exports                                                            */
+/* ------------------------------------------------------------------ */
+
+export const LOCAL_SCENARIOS: EvalScenario[] = [constraintPersistence];
+
+export const API_SCENARIOS: EvalScenario[] = [];
+
+export const ALL_SCENARIOS: EvalScenario[] = [...LOCAL_SCENARIOS, ...API_SCENARIOS];

--- a/benchmarks/behavior-stability/types.ts
+++ b/benchmarks/behavior-stability/types.ts
@@ -1,0 +1,26 @@
+/** Behavior-stability evaluation types — lightweight, local-first regression suite. */
+
+export interface EvalScenario {
+  id: string;
+  name: string;
+  category: "shell" | "context" | "integrity";
+  /** True when the scenario calls the live LLM API (costs money). */
+  requiresApi: boolean;
+  run: () => Promise<EvalResult>;
+}
+
+export interface EvalResult {
+  scenarioId: string;
+  pass: boolean;
+  durationMs: number;
+  details: string;
+}
+
+export interface EvalReport {
+  meta: {
+    date: string;
+    reasonixVersion: string;
+    model?: string;
+  };
+  results: EvalResult[];
+}

--- a/src/context-manager.ts
+++ b/src/context-manager.ts
@@ -19,6 +19,13 @@ import {
 } from "./tokenizer.js";
 import type { ChatMessage } from "./types.js";
 
+function extractPinnedConstraints(systemPrompt: string): string {
+  const highPriority = systemPrompt.match(/# HIGH PRIORITY constraints[\s\S]*?(?=\n# |\n---|$)/);
+  const userMemory = systemPrompt.match(/# User memory[\s\S]*?(?=\n# |\n---|$)/);
+  const projectMemory = systemPrompt.match(/# Project memory[\s\S]*?(?=\n# |\n---|$)/);
+  return [highPriority?.[0], userMemory?.[0], projectMemory?.[0]].filter(Boolean).join("\n\n");
+}
+
 /** Auto-fold when a turn's response shows promptTokens above this fraction of ctxMax. */
 export const HISTORY_FOLD_THRESHOLD = 0.5;
 /** Tail budget after a normal fold, as a fraction of ctxMax. */
@@ -52,6 +59,7 @@ export interface ContextManagerDeps {
   sessionName: string | null;
   getAbortSignal: () => AbortSignal;
   getCurrentTurn: () => number;
+  getSystemPrompt: () => string;
 }
 
 export type PostUsageDecisionKind = "none" | "fold" | "exit-with-summary";
@@ -188,13 +196,17 @@ export class ContextManager {
 
     const memoTail =
       pinnedBodies.length > 0 ? `\n\n${SKILL_PIN_MEMO_HEADER}\n\n${pinnedBodies.join("\n\n")}` : "";
+    const constraints = extractPinnedConstraints(this.deps.getSystemPrompt());
+    const constraintTail = constraints
+      ? `\n\n[PINNED CONSTRAINTS — preserved verbatim]\n\n${constraints}`
+      : "";
     // Route via buildAssistantMessage so the synthetic summary carries
     // reasoning_content under thinking-mode sessions — without it the
     // next API call 400s with "must be passed back" (#1042). Stamp uses
     // the SESSION model so an empty placeholder is added even when the
     // summarizer call somehow returned no reasoning.
     const summaryMsg = buildAssistantMessage(
-      HISTORY_FOLD_MARKER + summary.content + memoTail,
+      HISTORY_FOLD_MARKER + summary.content + memoTail + constraintTail,
       [],
       model,
       summary.reasoningContent,
@@ -289,7 +301,11 @@ export class ContextManager {
   ): Promise<{ content: string; reasoningContent: string }> {
     const summaryModel = "deepseek-v4-flash";
     const systemPrompt =
-      "You compress conversation history for a coding agent. Output one prose recap that preserves: the user's overall goal, decisions and conclusions reached, files inspected or modified, important tool results still relevant to ongoing work, and any open todos. Skip turn-by-turn play-by-play. No tool calls, no markdown headings, no SEARCH/REPLACE blocks — plain prose only.";
+      "You compress conversation history for a coding agent. Output one prose recap that preserves: " +
+      "the user's ORIGINAL OBJECTIVE (never paraphrase away nuance or negative constraints like 'do NOT do X'), " +
+      "all 'do not' / 'never' / 'avoid' instructions, decisions and conclusions reached, " +
+      "files inspected or modified, important tool results still relevant to ongoing work, " +
+      "and any open todos. Skip turn-by-turn play-by-play. No tool calls, no markdown headings, no SEARCH/REPLACE blocks — plain prose only.";
     const healed = healLoadedMessages(messagesToSummarize, DEFAULT_MAX_RESULT_CHARS).messages;
     const messages: ChatMessage[] = [
       { role: "system", content: systemPrompt },

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -253,6 +253,7 @@ export class CacheFirstLoop {
       sessionName: this.sessionName,
       getAbortSignal: () => this._turnAbort.signal,
       getCurrentTurn: () => this._turn,
+      getSystemPrompt: () => this.prefix.system,
     });
   }
 


### PR DESCRIPTION
## Problem
When a long session triggers a context fold (history compression), the fold summary loses high-priority user constraints stored in the system prompt (e.g., \"do NOT use X\", \"always Y\"). After the fold, the model may violate these constraints because they are no longer in context.

## Solution
Extract high-priority pinned constraints from the system prompt (User memory, Project memory, High Priority constraints) and append them verbatim to the fold summary message. This ensures they survive the fold.

## Changes
- \`src/context-manager.ts\`:
  - Add \`extractPinnedConstraints()\` to pull pinned blocks from the system prompt.
  - Append the extracted constraints to the summary message built by \`fold()\`.
  - Update the summarizer system prompt to explicitly remind it to preserve \"do not\" / \"never\" / \"avoid\" instructions.
- \`src/loop.ts\`:
  - Wire \`getSystemPrompt\` into \`ContextManagerDeps\` so the fold can read the current system prompt.

## Alternative considered
A runtime **ToolInterceptor** (option C) that checks every outgoing tool call against pinned constraints was evaluated. It is more robust but adds per-call latency and complexity; we can revisit it if prompt-level preservation proves insufficient.

## Verification
- Existing tests pass (3333 passed).
- The fold now carries constraint text in the synthetic assistant message.
- Added behavior-stability regression test:
  ```bash
  npx tsx benchmarks/behavior-stability/runner.ts --local
  ```
  This deterministic test injects 40 turns of synthetic history, triggers a fold, and asserts that all 4 pinned constraints (2 HIGH PRIORITY + 1 User memory + 1 Project memory) are preserved in the summary.