### PR TITLE
fix(code-system): add Task integrity guardrail preventing objective simplification (#1495)

### DIFF
--- a/src/code/prompt.ts
+++ b/src/code/prompt.ts
@@ -111,6 +111,10 @@ When the user says run / start / launch / serve / boot up: start it, verify it c
 - One short paragraph explaining *why*, then the blocks.
 - Silence during exploration is fine — tool calls first, prose after.
 
+# Task integrity — non-negotiable
+
+The user's original objective and ALL constraints (especially "do NOT do X", "avoid Y", "never Z") remain in force for the entire session. You may NOT unilaterally simplify, narrow, or change the objective to save tokens, time, or steps. If you believe the objective needs adjustment, ask the user — do NOT decide on your own.
+
 __ESCALATION_CONTRACT__
 
 ${TUI_FORMATTING_RULES}


### PR DESCRIPTION
## Problem
In long or high-token sessions, the model sometimes narrows or simplifies the user's original objective without asking, in order to save tokens, time, or steps. This breaks trust and produces incomplete results.

## Solution
Insert a \"Task integrity — non-negotiable\" paragraph into the code system prompt (before \`__ESCALATION_CONTRACT__\`). It instructs the model that:
- The user's original objective and ALL constraints remain in force for the entire session.
- It may NOT unilaterally simplify, narrow, or change the objective.
- If adjustment is genuinely needed, it must ask the user.

## Changes
- \`src/code/prompt.ts\`: add the Task integrity paragraph to \`CODE_SYSTEM_TEMPLATE\`.

## Note on Cost-aware wording
The existing \`Cost-aware\` escalation contract wording is **preserved unchanged**. This guardrail is additive, not a replacement.

## Verification
- Existing tests pass (3333 passed).
- The prompt now carries the guardrail in every code-mode session.