### PR TITLE
fix(edit): preserve file encoding on read/edit/restore (GB18030, UTF-8 BOM)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "cli-highlight": "^2.1.11",
         "commander": "^12.1.0",
         "eventsource-parser": "^3.0.0",
+        "iconv-lite": "^0.7.2",
         "ignore": "^7.0.5",
         "ink": "^7.0.2",
         "ink-text-input": "^6.0.0",
@@ -4171,7 +4172,6 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
       "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -5554,7 +5554,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/saxes": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "cli-highlight": "^2.1.11",
     "commander": "^12.1.0",
     "eventsource-parser": "^3.0.0",
+    "iconv-lite": "^0.7.2",
     "ignore": "^7.0.5",
     "ink": "^7.0.2",
     "ink-text-input": "^6.0.0",

--- a/src/code/edit-blocks.ts
+++ b/src/code/edit-blocks.ts
@@ -14,6 +14,7 @@ import {
   writeSync,
 } from "node:fs";
 import { dirname, isAbsolute, relative, resolve } from "node:path";
+import { type FileEncoding, decodeFileBuffer, encodeFile } from "./file-encoding.js";
 
 export interface EditBlock {
   /** Path as written by the model — relative to rootDir, or absolute. */
@@ -157,7 +158,7 @@ export function applyEditBlock(block: EditBlock, rootDir: string): ApplyResult {
         if (n <= 0) break;
         readBytes += n;
       }
-      const content = inBuf.toString("utf8", 0, readBytes);
+      const { text: content, encoding } = decodeFileBuffer(inBuf.subarray(0, readBytes));
       const le = lineEndingOf(content);
       const adaptedSearch = block.search.replace(/\r?\n/g, le);
       const adaptedReplace = block.replace.replace(/\r?\n/g, le);
@@ -184,7 +185,7 @@ export function applyEditBlock(block: EditBlock, rootDir: string): ApplyResult {
       // Truncate first so a shorter result doesn't leave stale tail
       // bytes; ftruncate also pads with NUL when the new length is
       // longer, which we then overwrite below.
-      const outBuf = Buffer.from(replaced, "utf8");
+      const outBuf = encodeFile(replaced, encoding);
       ftruncateSync(fd, outBuf.length);
       let written = 0;
       while (written < outBuf.length) {
@@ -210,7 +211,7 @@ export function toWholeFileEditBlock(path: string, content: string, rootDir: str
   let search = "";
   if (existsSync(abs)) {
     try {
-      search = readFileSync(abs, "utf8");
+      search = decodeFileBuffer(readFileSync(abs)).text;
     } catch {
       search = "";
     }
@@ -223,6 +224,8 @@ export interface EditSnapshot {
   path: string;
   /** `null` = file didn't exist; restore means delete. */
   prevContent: string | null;
+  /** Encoding the file used before the edit. Required to round-trip GB18030 / UTF-8-BOM on restore. */
+  prevEncoding?: FileEncoding;
 }
 
 /** De-duped by path — one "before" snapshot per file even with multiple blocks. */
@@ -240,7 +243,8 @@ export function snapshotBeforeEdits(blocks: EditBlock[], rootDir: string): EditS
       continue;
     }
     try {
-      snapshots.push({ path: b.path, prevContent: readFileSync(abs, "utf8") });
+      const { text, encoding } = decodeFileBuffer(readFileSync(abs));
+      snapshots.push({ path: b.path, prevContent: text, prevEncoding: encoding });
     } catch {
       // Unreadable (permission / binary) — record null so we at least
       // don't pretend the snapshot is authoritative. The restore path
@@ -272,7 +276,7 @@ export function restoreSnapshots(snapshots: EditSnapshot[], rootDir: string): Ap
           message: "removed (the edit had created it)",
         };
       }
-      writeFileSync(abs, snap.prevContent, "utf8");
+      writeFileSync(abs, encodeFile(snap.prevContent, snap.prevEncoding ?? "utf8"));
       return {
         path: snap.path,
         status: "applied",

--- a/src/code/file-encoding.ts
+++ b/src/code/file-encoding.ts
@@ -21,15 +21,14 @@ export function decodeFileBuffer(buf: Buffer): DecodedFile {
   } catch {
     // Fall through.
   }
-  if (process.platform === "win32") {
-    try {
-      return {
-        text: new TextDecoder("gb18030", { fatal: true }).decode(buf),
-        encoding: "gb18030",
-      };
-    } catch {
-      // Fall through.
-    }
+  // GB18030 isn't platform-conditional — files originated on CN Windows can travel anywhere.
+  try {
+    return {
+      text: new TextDecoder("gb18030", { fatal: true }).decode(buf),
+      encoding: "gb18030",
+    };
+  } catch {
+    // Fall through.
   }
   return { text: buf.toString("utf8"), encoding: "utf8" };
 }

--- a/src/code/file-encoding.ts
+++ b/src/code/file-encoding.ts
@@ -1,0 +1,63 @@
+/** Read/write preserves the file's original encoding so edit_file on GB18030 (CN Windows) or UTF-8-BOM files doesn't silently convert or fail SEARCH on mangled decode (issue #1445). */
+
+import { promises as fsp, readFileSync, writeFileSync } from "node:fs";
+import iconv from "iconv-lite";
+
+export type FileEncoding = "utf8" | "utf8-bom" | "gb18030";
+
+export interface DecodedFile {
+  text: string;
+  encoding: FileEncoding;
+}
+
+const UTF8_BOM = Buffer.from([0xef, 0xbb, 0xbf]);
+
+export function decodeFileBuffer(buf: Buffer): DecodedFile {
+  if (buf.length >= 3 && buf[0] === 0xef && buf[1] === 0xbb && buf[2] === 0xbf) {
+    return { text: buf.subarray(3).toString("utf8"), encoding: "utf8-bom" };
+  }
+  try {
+    return { text: new TextDecoder("utf-8", { fatal: true }).decode(buf), encoding: "utf8" };
+  } catch {
+    // Fall through.
+  }
+  if (process.platform === "win32") {
+    try {
+      return {
+        text: new TextDecoder("gb18030", { fatal: true }).decode(buf),
+        encoding: "gb18030",
+      };
+    } catch {
+      // Fall through.
+    }
+  }
+  return { text: buf.toString("utf8"), encoding: "utf8" };
+}
+
+export function encodeFile(text: string, encoding: FileEncoding): Buffer {
+  if (encoding === "utf8") return Buffer.from(text, "utf8");
+  if (encoding === "utf8-bom") {
+    return Buffer.concat([UTF8_BOM, Buffer.from(text, "utf8")]);
+  }
+  return iconv.encode(text, "gb18030");
+}
+
+export function readTextFileSmartSync(path: string): DecodedFile {
+  return decodeFileBuffer(readFileSync(path));
+}
+
+export async function readTextFileSmart(path: string): Promise<DecodedFile> {
+  return decodeFileBuffer(await fsp.readFile(path));
+}
+
+export function writeTextFileSmartSync(path: string, text: string, encoding: FileEncoding): void {
+  writeFileSync(path, encodeFile(text, encoding));
+}
+
+export async function writeTextFileSmart(
+  path: string,
+  text: string,
+  encoding: FileEncoding,
+): Promise<void> {
+  await fsp.writeFile(path, encodeFile(text, encoding));
+}

--- a/src/tools/filesystem.ts
+++ b/src/tools/filesystem.ts
@@ -3,6 +3,7 @@
 import { promises as fs } from "node:fs";
 import * as pathMod from "node:path";
 import picomatch from "picomatch";
+import { decodeFileBuffer, encodeFile } from "../code/file-encoding.js";
 import { addProjectPathAllowed, loadProjectPathAllowed } from "../config.js";
 import { type ConfirmationChoice, pauseGate as defaultPauseGate } from "../core/pause-gate.js";
 import { DEFAULT_INDEX_EXCLUDES } from "../index/config.js";
@@ -280,7 +281,7 @@ export function registerFilesystemTools(
         return `[refused: ${rel} appears to be binary (${formatBytes(sizeBytes)}) — read_file returns text only. Use get_file_info for stat.]`;
       }
 
-      const text = raw.toString("utf8");
+      const { text } = decodeFileBuffer(raw);
       let lines = text.split(/\r?\n/);
       // Most files end with '\n' which splits into an empty trailing
       // entry; drop it so head/tail/range counts match the user's
@@ -653,7 +654,13 @@ export function registerFilesystemTools(
     fn: async (args: { path: string; content: string }, ctx?: ToolCallContext) => {
       const abs = await safePath(args.path, "write_file", ctx, "write");
       await fs.mkdir(pathMod.dirname(abs), { recursive: true });
-      await fs.writeFile(abs, args.content, "utf8");
+      let encoding: ReturnType<typeof decodeFileBuffer>["encoding"] = "utf8";
+      try {
+        encoding = decodeFileBuffer(await fs.readFile(abs)).encoding;
+      } catch {
+        // New file or unreadable — fall back to utf8.
+      }
+      await fs.writeFile(abs, encodeFile(args.content, encoding));
       return `wrote ${args.content.length} chars to ${displayRel(rootDir, abs)}`;
     },
   });

--- a/src/tools/fs/edit.ts
+++ b/src/tools/fs/edit.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from "node:fs";
 import * as pathMod from "node:path";
+import { type FileEncoding, decodeFileBuffer, encodeFile } from "../../code/file-encoding.js";
 
 function displayRel(rootDir: string, full: string): string {
   return pathMod.relative(rootDir, full).replaceAll("\\", "/");
@@ -13,7 +14,8 @@ export async function applyEdit(
   if (args.search.length === 0) {
     throw new Error("edit_file: search cannot be empty");
   }
-  const before = await fs.readFile(abs, "utf8");
+  const beforeBuf = await fs.readFile(abs);
+  const { text: before, encoding } = decodeFileBuffer(beforeBuf);
   const le = before.includes("\r\n") ? "\r\n" : "\n";
   const adaptedSearch = args.search.replace(/\r?\n/g, le);
   const adaptedReplace = args.replace.replace(/\r?\n/g, le);
@@ -29,7 +31,7 @@ export async function applyEdit(
   }
   const after =
     before.slice(0, firstIdx) + adaptedReplace + before.slice(firstIdx + adaptedSearch.length);
-  await fs.writeFile(abs, after, "utf8");
+  await fs.writeFile(abs, encodeFile(after, encoding));
   const rel = displayRel(rootDir, abs);
   const header = `edited ${rel} (${adaptedSearch.length}→${adaptedReplace.length} chars)`;
   const startLine = before.slice(0, firstIdx).split(/\r?\n/).length;
@@ -57,6 +59,7 @@ export async function applyMultiEdit(
     hunks: string[];
     deltaChars: number;
     touched: number;
+    encoding: FileEncoding;
   };
   const filesByPath = new Map<string, FileState>();
 
@@ -82,15 +85,17 @@ export async function applyMultiEdit(
     let state = filesByPath.get(e.abs);
     if (!state) {
       let before: string;
+      let encoding: FileEncoding;
       try {
-        before = await fs.readFile(e.abs, "utf8");
+        const buf = await fs.readFile(e.abs);
+        ({ text: before, encoding } = decodeFileBuffer(buf));
       } catch (err) {
         throw new Error(
           `multi_edit: edit #${i + 1} cannot read ${rel}: ${(err as Error).message} (no edits applied)`,
         );
       }
       const le = before.includes("\r\n") ? "\r\n" : "\n";
-      state = { before, buf: before, le, hunks: [], deltaChars: 0, touched: 0 };
+      state = { before, buf: before, le, hunks: [], deltaChars: 0, touched: 0, encoding };
       filesByPath.set(e.abs, state);
     }
     const adaptedSearch = e.search.replace(/\r?\n/g, state.le);
@@ -119,17 +124,17 @@ export async function applyMultiEdit(
 
   // Push to `attempted` BEFORE writeFile so a write that truncates or
   // partially-writes before failing is also rolled back.
-  const attempted: Array<{ abs: string; before: string }> = [];
+  const attempted: Array<{ abs: string; before: string; encoding: FileEncoding }> = [];
   try {
     for (const [abs, state] of filesByPath) {
-      attempted.push({ abs, before: state.before });
-      await fs.writeFile(abs, state.buf, "utf8");
+      attempted.push({ abs, before: state.before, encoding: state.encoding });
+      await fs.writeFile(abs, encodeFile(state.buf, state.encoding));
     }
   } catch (writeErr) {
     const rollbackFailures: string[] = [];
     for (const item of [...attempted].reverse()) {
       try {
-        await fs.writeFile(item.abs, item.before, "utf8");
+        await fs.writeFile(item.abs, encodeFile(item.before, item.encoding));
       } catch (restoreErr) {
         rollbackFailures.push(`${displayRel(rootDir, item.abs)}: ${(restoreErr as Error).message}`);
       }

--- a/tests/edit-blocks.test.ts
+++ b/tests/edit-blocks.test.ts
@@ -3,6 +3,7 @@
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import iconv from "iconv-lite";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   applyEditBlock,
@@ -359,5 +360,66 @@ describe("applyEditBlocks (batch)", () => {
     expect(results[1]!.status).toBe("not-found");
     expect(readFileSync(join(root, "a.txt"), "utf8")).toBe("ALPHA\n");
     expect(readFileSync(join(root, "b.txt"), "utf8")).toBe("bravo\n"); // untouched
+  });
+});
+
+describe("edit pipeline preserves file encoding (#1445)", () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "edit-encoding-"));
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("edits a GB18030 file and writes back in GB18030", () => {
+    const original = "标题\n旧内容\n尾部\n";
+    const file = join(root, "cn.txt");
+    writeFileSync(file, iconv.encode(original, "gb18030"));
+
+    const result = applyEditBlock(
+      { path: "cn.txt", search: "旧内容", replace: "新内容", offset: 0 },
+      root,
+    );
+    expect(result.status).toBe("applied");
+
+    const onDisk = readFileSync(file);
+    expect(iconv.decode(onDisk, "gb18030")).toBe("标题\n新内容\n尾部\n");
+    expect(() => new TextDecoder("utf-8", { fatal: true }).decode(onDisk)).toThrow();
+  });
+
+  it("edits a UTF-8 BOM file and preserves the BOM bytes", () => {
+    const bom = Buffer.from([0xef, 0xbb, 0xbf]);
+    const file = join(root, "bom.txt");
+    writeFileSync(file, Buffer.concat([bom, Buffer.from("hello world\n", "utf8")]));
+
+    const result = applyEditBlock(
+      { path: "bom.txt", search: "world", replace: "你好", offset: 0 },
+      root,
+    );
+    expect(result.status).toBe("applied");
+
+    const onDisk = readFileSync(file);
+    expect(onDisk[0]).toBe(0xef);
+    expect(onDisk[1]).toBe(0xbb);
+    expect(onDisk[2]).toBe(0xbf);
+    expect(onDisk.subarray(3).toString("utf8")).toBe("hello 你好\n");
+  });
+
+  it("snapshot + restore round-trips through GB18030 without re-encoding", () => {
+    const original = "保留编码\n";
+    const file = join(root, "cn.txt");
+    writeFileSync(file, iconv.encode(original, "gb18030"));
+
+    const snaps = snapshotBeforeEdits(
+      [{ path: "cn.txt", search: "x", replace: "y", offset: 0 }],
+      root,
+    );
+    expect(snaps[0]?.prevEncoding).toBe("gb18030");
+
+    writeFileSync(file, iconv.encode("被修改\n", "gb18030"));
+    const restored = restoreSnapshots(snaps, root);
+    expect(restored[0]?.status).toBe("applied");
+    expect(iconv.decode(readFileSync(file), "gb18030")).toBe(original);
   });
 });

--- a/tests/file-encoding.test.ts
+++ b/tests/file-encoding.test.ts
@@ -19,8 +19,7 @@ describe("decodeFileBuffer (#1445)", () => {
     expect(decodeFileBuffer(buf)).toEqual({ text: "// hi 你好\n", encoding: "utf8-bom" });
   });
 
-  it("falls back to gb18030 on Windows for invalid-UTF-8 CN bytes", () => {
-    if (process.platform !== "win32") return;
+  it("falls back to gb18030 for invalid-UTF-8 CN bytes (any platform)", () => {
     const buf = iconv.encode("你好世界\n", "gb18030");
     expect(decodeFileBuffer(buf)).toEqual({ text: "你好世界\n", encoding: "gb18030" });
   });

--- a/tests/file-encoding.test.ts
+++ b/tests/file-encoding.test.ts
@@ -1,0 +1,53 @@
+import iconv from "iconv-lite";
+import { describe, expect, it } from "vitest";
+import { decodeFileBuffer, encodeFile } from "../src/code/file-encoding.js";
+
+describe("decodeFileBuffer (#1445)", () => {
+  it("decodes plain ASCII as utf8", () => {
+    const buf = Buffer.from("hello world\n", "utf8");
+    expect(decodeFileBuffer(buf)).toEqual({ text: "hello world\n", encoding: "utf8" });
+  });
+
+  it("decodes valid UTF-8 multibyte as utf8", () => {
+    const buf = Buffer.from("你好世界\n", "utf8");
+    expect(decodeFileBuffer(buf)).toEqual({ text: "你好世界\n", encoding: "utf8" });
+  });
+
+  it("strips UTF-8 BOM and reports utf8-bom encoding", () => {
+    const bom = Buffer.from([0xef, 0xbb, 0xbf]);
+    const buf = Buffer.concat([bom, Buffer.from("// hi 你好\n", "utf8")]);
+    expect(decodeFileBuffer(buf)).toEqual({ text: "// hi 你好\n", encoding: "utf8-bom" });
+  });
+
+  it("falls back to gb18030 on Windows for invalid-UTF-8 CN bytes", () => {
+    if (process.platform !== "win32") return;
+    const buf = iconv.encode("你好世界\n", "gb18030");
+    expect(decodeFileBuffer(buf)).toEqual({ text: "你好世界\n", encoding: "gb18030" });
+  });
+
+  it("returns empty file as utf8", () => {
+    expect(decodeFileBuffer(Buffer.alloc(0))).toEqual({ text: "", encoding: "utf8" });
+  });
+});
+
+describe("encodeFile (#1445)", () => {
+  it("round-trips utf8", () => {
+    const text = "hello 你好\n";
+    expect(decodeFileBuffer(encodeFile(text, "utf8"))).toEqual({ text, encoding: "utf8" });
+  });
+
+  it("round-trips utf8-bom preserving the BOM bytes", () => {
+    const text = "// hi 你好\n";
+    const buf = encodeFile(text, "utf8-bom");
+    expect(buf[0]).toBe(0xef);
+    expect(buf[1]).toBe(0xbb);
+    expect(buf[2]).toBe(0xbf);
+    expect(decodeFileBuffer(buf)).toEqual({ text, encoding: "utf8-bom" });
+  });
+
+  it("round-trips gb18030 bytes", () => {
+    const text = "你好世界\n";
+    const buf = encodeFile(text, "gb18030");
+    expect(iconv.decode(buf, "gb18030")).toBe(text);
+  });
+});


### PR DESCRIPTION
## Summary

Preserve original file encoding (GB18030, UTF-8 BOM) on the read/edit/write/snapshot/restore path. Closes #1445.

## The bug chain reported in #1445

User on Chinese Windows 11, YOLO mode:

1. `read_file` / `edit_file` return mangled bytes or fail SEARCH on GB18030 files (most CN Windows projects)
2. Model falls back to PowerShell — same encoding issue, also fails
3. Model's last resort: `git show HEAD:<file>` + replay edits from conversation history
4. That last resort is token-expensive AND lossy — any user manual edits between the start of the turn and the failure are silently overwritten

Root cause is layer 1. The other layers are the model improvising around the silent corruption.

## Why this happened

Every filesystem call in the edit pipeline hard-coded UTF-8:

- [`src/tools/filesystem.ts:283`](https://github.com/esengine/DeepSeek-Reasonix/blob/main/src/tools/filesystem.ts) — `read_file`: `raw.toString("utf8")`
- [`src/tools/filesystem.ts:656`](https://github.com/esengine/DeepSeek-Reasonix/blob/main/src/tools/filesystem.ts) — `write_file`: `writeFile(abs, content, "utf8")`
- [`src/tools/fs/edit.ts:16,32`](https://github.com/esengine/DeepSeek-Reasonix/blob/main/src/tools/fs/edit.ts) — `applyEdit` read+write
- [`src/tools/fs/edit.ts:86,126,132`](https://github.com/esengine/DeepSeek-Reasonix/blob/main/src/tools/fs/edit.ts) — `applyMultiEdit` read, write, rollback-write
- [`src/code/edit-blocks.ts:160,187,213,243,275`](https://github.com/esengine/DeepSeek-Reasonix/blob/main/src/code/edit-blocks.ts) — `applyEditBlock` content, `applyEditBlock` write, `toWholeFileEditBlock`, `snapshotBeforeEdits`, `restoreSnapshots`

The shell stdout path had already solved the equivalent problem: [`smartDecodeOutput` at `src/tools/shell/exec.ts:177`](https://github.com/esengine/DeepSeek-Reasonix/blob/main/src/tools/shell/exec.ts) does UTF-8-fatal → GB18030 fallback on Windows. The filesystem path just never used the same approach.

## What this PR does

New `src/code/file-encoding.ts` with two pure helpers:

- `decodeFileBuffer(buf)` → `{ text, encoding: 'utf8' | 'utf8-bom' | 'gb18030' }`
  - UTF-8 BOM detected by leading `EF BB BF`, stripped from returned text
  - UTF-8 attempted in fatal mode; falls through to GB18030 fallback on Windows
  - Last-resort lossy UTF-8 with replacement chars (matches `smartDecodeOutput`'s safety net so we never throw on read)
- `encodeFile(text, encoding)` → `Buffer`
  - UTF-8 / UTF-8-BOM via `Buffer.from`
  - GB18030 via `iconv-lite` (new dep — 0-dep, MIT, ~50KB, 30M weekly downloads)

All 12 call sites above swap to these helpers. The edit pipeline now:

1. Reads bytes → decodes via `decodeFileBuffer` → text string + detected encoding
2. Applies SEARCH/REPLACE on the text (existing logic unchanged)
3. Writes via `encodeFile(after, encoding)` so the file keeps its original encoding

`EditSnapshot` gains a `prevEncoding?: FileEncoding` field so `restoreSnapshots` round-trips correctly when undoing edits on GB18030 / BOM files. Field is optional for backward compat with any persisted older snapshots — restore defaults to UTF-8 when absent.

## What this PR does NOT do

- Doesn't change line-ending handling (CRLF/LF detection at `lineEndingOf` stays the same — orthogonal to encoding).
- Doesn't convert files. A GB18030 file stays GB18030. Any user expecting "Reasonix should normalize all files to UTF-8" is out of scope; that's a destructive workflow we shouldn't ship silently.
- Doesn't detect arbitrary encodings (UTF-16, Big5, Shift-JIS, etc.). UTF-8 and GB18030 cover the actual reported failures; adding more without real demand is over-fitting. If those hit later, the helper is the right place to grow.
- Doesn't address the secondary request in #1445 ("per-prompt undo of all changes including user manual edits"). The existing checkpoint infrastructure in `src/code/checkpoints.ts` covers that surface; a per-turn auto-snapshot hook is a separate PR if desired. With the root encoding bug fixed, edit_file shouldn't fail in the first place, which removes the trigger for the entire model-fallback chain the user described.

## Test Plan

- [x] `tests/file-encoding.test.ts` — 8 cases covering plain UTF-8, multi-byte UTF-8, BOM strip + report, GB18030 fallback (Windows-only), empty file, round-trip in each encoding
- [x] `tests/edit-blocks.test.ts` — 3 new cases: edit GB18030 file stays GB18030 (asserts UTF-8 decode fails on the result); edit BOM file preserves the BOM bytes; snapshot+restore round-trips through GB18030
- [x] `npx vitest run tests/file-encoding.test.ts tests/edit-blocks.test.ts tests/filesystem-tools.test.ts tests/comment-policy.test.ts` — 168 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx biome check` on touched files — clean
- [x] `npm run verify` via pre-push hook — green
