### PR TITLE
feat(desktop): add approval and completion notifications

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -14,6 +14,7 @@
         "@reasonix/core-utils": "file:../packages/core-utils",
         "@tauri-apps/api": "^2.1.1",
         "@tauri-apps/plugin-dialog": "^2.7.1",
+        "@tauri-apps/plugin-notification": "^2.0.0",
         "@tauri-apps/plugin-opener": "^2.0.0",
         "@tauri-apps/plugin-process": "^2.0.0",
         "@tauri-apps/plugin-updater": "^2.0.0",
@@ -1391,6 +1392,15 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.11.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-notification": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmmirror.com/@tauri-apps/plugin-notification/-/plugin-notification-2.3.3.tgz",
+      "integrity": "sha512-Zw+ZH18RJb41G4NrfHgIuofJiymusqN+q8fGUIIV7vyCH+5sSn5coqRv/MWB9qETsUs97vmU045q7OyseCV3Qg==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
       }
     },
     "node_modules/@tauri-apps/plugin-opener": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -17,6 +17,7 @@
     "@reasonix/core-utils": "file:../packages/core-utils",
     "@tauri-apps/api": "^2.1.1",
     "@tauri-apps/plugin-dialog": "^2.7.1",
+    "@tauri-apps/plugin-notification": "^2.0.0",
     "@tauri-apps/plugin-opener": "^2.0.0",
     "@tauri-apps/plugin-process": "^2.0.0",
     "@tauri-apps/plugin-updater": "^2.0.0",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2042,6 +2042,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29a16783dd1a47849b8c8133c9cd3eb2112cfbc6901670af3dba47c8bbfb07d3"
+dependencies = [
+ "cc",
+ "objc2",
+ "objc2-foundation",
+ "time",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2150,6 +2162,20 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "notify-rust"
+version = "4.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50ff2e74231b72c832d82982193b417f230945be6bdb5575b251d941d31adb00"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
+]
 
 [[package]]
 name = "num-conv"
@@ -2600,7 +2626,7 @@ checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml",
+ "quick-xml 0.39.4",
  "serde",
  "time",
 ]
@@ -2659,6 +2685,15 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "precomputed-hash"
@@ -2740,6 +2775,15 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
 version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
@@ -2769,6 +2813,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2785,6 +2858,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
+ "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-updater",
@@ -3802,6 +3876,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-notification"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
+dependencies = [
+ "log",
+ "notify-rust",
+ "rand",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3979,6 +4072,18 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 1.1.2+spec-1.1.0",
+]
+
+[[package]]
+name = "tauri-winrt-notification"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+dependencies = [
+ "quick-xml 0.37.5",
+ "thiserror 2.0.18",
+ "windows",
+ "windows-version",
 ]
 
 [[package]]
@@ -5529,6 +5634,26 @@ dependencies = [
  "serde",
  "winnow 1.0.2",
  "zvariant",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -13,6 +13,7 @@ tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
+tauri-plugin-notification = "2"
 tauri-plugin-window-state = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -17,6 +17,7 @@
     "process:allow-restart",
     "dialog:allow-open",
     "dialog:allow-save",
+    "notification:default",
     {
       "identifier": "opener:allow-open-url",
       "allow": [{ "url": "https://*" }, { "url": "http://*" }]

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -217,6 +217,7 @@ fn main() {
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_window_state::Builder::default().build())
         .manage(RpcState::default())
         .invoke_handler(tauri::generate_handler![

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -2,6 +2,11 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { open as openDialog, save as saveDialog } from "@tauri-apps/plugin-dialog";
+import {
+  isPermissionGranted as isNotificationPermissionGranted,
+  requestPermission as requestNotificationPermission,
+  sendNotification,
+} from "@tauri-apps/plugin-notification";
 import { relaunch } from "@tauri-apps/plugin-process";
 import { type Update, check } from "@tauri-apps/plugin-updater";
 import { useCallback, useEffect, useReducer, useRef, useState } from "react";
@@ -51,6 +56,7 @@ import { Sidebar } from "./ui/sidebar";
 import { Shortcut, localizeShortcutText, shortcutText } from "./ui/shortcut";
 import { Splash, shouldShowSplash } from "./ui/splash";
 import { StatusBar } from "./ui/statusbar";
+import { dispatchDesktopNotifications, deriveDesktopNotifications, type ApprovalSnapshot } from "./notifications";
 import {
   ActivePlanTaskCard,
   AssistantMsg,
@@ -1170,6 +1176,16 @@ function TabRuntime({
   const [settingsPage, setSettingsPage] = useState<SettingsPageId>("general");
   const [jobsOpen, setJobsOpen] = useState(false);
   const [aboutOpen, setAboutOpen] = useState(false);
+  const previousApprovalSnapshotRef = useRef<ApprovalSnapshot>({
+    confirms: [],
+    pathAccess: [],
+    choices: [],
+    plans: [],
+    checkpoints: [],
+    revisions: [],
+  });
+  const wasBusyRef = useRef(false);
+  const busyStartedAtRef = useRef<number | null>(null);
   const openSettingsAt = useCallback((page: SettingsPageId = "general") => {
     setSettingsPage(page);
     setSettingsOpen(true);
@@ -1386,6 +1402,54 @@ function TabRuntime({
     dispatch({ t: "shift_queued_send" });
     send(next);
   }, [state.busy, state.ready, state.queuedSends, send]);
+
+  useEffect(() => {
+    const currentSnapshot: ApprovalSnapshot = {
+      confirms: state.pendingConfirms.map((c) => ({ id: c.id, command: c.command })),
+      pathAccess: state.pendingPathAccess.map((p) => ({ id: p.id, path: p.path, intent: p.intent })),
+      choices: state.pendingChoices.map((c) => ({ id: c.id, question: c.question })),
+      plans: state.pendingPlans.map((p) => ({ id: p.id, summary: p.summary, plan: p.plan })),
+      checkpoints: state.pendingCheckpoints.map((c) => ({ id: c.id, title: c.title, result: c.result })),
+      revisions: state.pendingRevisions.map((r) => ({ id: r.id, summary: r.summary, reason: r.reason })),
+    };
+    const previousSnapshot = previousApprovalSnapshotRef.current;
+    const wasBusy = wasBusyRef.current;
+    const busyDurationMs = wasBusy && !state.busy && busyStartedAtRef.current
+      ? Date.now() - busyStartedAtRef.current
+      : 0;
+
+    if (state.busy && busyStartedAtRef.current === null) {
+      busyStartedAtRef.current = Date.now();
+    } else if (!state.busy) {
+      busyStartedAtRef.current = null;
+    }
+
+    previousApprovalSnapshotRef.current = currentSnapshot;
+    wasBusyRef.current = state.busy;
+
+    const notifications = deriveDesktopNotifications({
+      previous: previousSnapshot,
+      current: currentSnapshot,
+      wasBusy,
+      isBusy: state.busy,
+      busyDurationMs,
+      focused: false,
+    });
+    void dispatchDesktopNotifications(notifications, {
+      isFocused: () => getCurrentWindow().isFocused(),
+      isPermissionGranted: isNotificationPermissionGranted,
+      requestPermission: requestNotificationPermission,
+      sendNotification,
+    });
+  }, [
+    state.busy,
+    state.pendingChoices,
+    state.pendingCheckpoints,
+    state.pendingConfirms,
+    state.pendingPathAccess,
+    state.pendingPlans,
+    state.pendingRevisions,
+  ]);
 
   const resolveConfirm = useCallback(
     (id: number, response: ConfirmationChoice) => {

--- a/desktop/src/i18n/en.ts
+++ b/desktop/src/i18n/en.ts
@@ -680,4 +680,16 @@ export const en = {
   panel: {
     renderError: "{panel} panel render error",
   },
+  notifications: {
+    approvalTitle: "Reasonix is waiting for approval",
+    inputTitle: "Reasonix is waiting for input",
+    planApprovalTitle: "Reasonix is waiting for plan approval",
+    checkpointApprovalTitle: "Reasonix is waiting for checkpoint approval",
+    revisionTitle: "Reasonix proposed a plan revision",
+    commandBody: "Command: {command}",
+    readBody: "Read: {path}",
+    writeBody: "Write: {path}",
+    turnCompleteTitle: "Reasonix task complete",
+    turnCompleteBody: "The current task finished and is ready for review.",
+  },
 };

--- a/desktop/src/i18n/zh-CN.ts
+++ b/desktop/src/i18n/zh-CN.ts
@@ -666,4 +666,16 @@ export const zhCN: typeof en = {
   panel: {
     renderError: "{panel} 面板渲染错误",
   },
+  notifications: {
+    approvalTitle: "\u7b49\u5f85\u6279\u51c6",
+    inputTitle: "\u7b49\u5f85\u4f60\u8f93\u5165",
+    planApprovalTitle: "\u7b49\u5f85\u8ba1\u5212\u6279\u51c6",
+    checkpointApprovalTitle: "\u7b49\u5f85\u68c0\u67e5\u70b9\u6279\u51c6",
+    revisionTitle: "\u5df2\u63d0\u51fa\u8ba1\u5212\u4fee\u8ba2",
+    commandBody: "\u547d\u4ee4\uff1a{command}",
+    readBody: "\u8bfb\u53d6\uff1a{path}",
+    writeBody: "\u5199\u5165\uff1a{path}",
+    turnCompleteTitle: "\u4efb\u52a1\u5df2\u5b8c\u6210",
+    turnCompleteBody: "\u5f53\u524d\u4efb\u52a1\u5df2\u7ed3\u675f\uff0c\u53ef\u4ee5\u56de\u6765\u67e5\u770b\u7ed3\u679c\u4e86\u3002",
+  },
 };

--- a/desktop/src/notifications.test.ts
+++ b/desktop/src/notifications.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { setLang } from "./i18n";
+import {
+  COMPLETION_NOTIFY_MIN_MS,
+  deriveDesktopNotifications,
+  type ApprovalSnapshot,
+} from "./notifications";
+
+function emptySnapshot(): ApprovalSnapshot {
+  return {
+    confirms: [],
+    pathAccess: [],
+    choices: [],
+    plans: [],
+    checkpoints: [],
+    revisions: [],
+  };
+}
+
+describe("desktop notifications", () => {
+  it("uses the active UI language for notification copy", () => {
+    setLang("zh-CN");
+    const next = emptySnapshot();
+    next.confirms.push({ id: 1, command: "git push" });
+
+    const notifications = deriveDesktopNotifications({
+      previous: emptySnapshot(),
+      current: next,
+      wasBusy: true,
+      isBusy: true,
+      busyDurationMs: 1_000,
+      focused: false,
+    });
+
+    expect(notifications).toEqual([
+      {
+        kind: "approval",
+        title: "等待批准",
+        body: "命令：git push",
+      },
+    ]);
+
+    setLang("en");
+  });
+
+  it("notifies when a new approval request appears while unfocused", () => {
+    const next = emptySnapshot();
+    next.confirms.push({ id: 1, command: "git push" });
+
+    const notifications = deriveDesktopNotifications({
+      previous: emptySnapshot(),
+      current: next,
+      wasBusy: true,
+      isBusy: true,
+      busyDurationMs: 1_000,
+      focused: false,
+    });
+
+    expect(notifications).toEqual([
+      {
+        kind: "approval",
+        title: "Reasonix is waiting for approval",
+        body: "Command: git push",
+      },
+    ]);
+  });
+
+  it("does not notify approvals when the window is focused", () => {
+    const next = emptySnapshot();
+    next.pathAccess.push({ id: 2, path: "/tmp/out.txt", intent: "write" });
+
+    const notifications = deriveDesktopNotifications({
+      previous: emptySnapshot(),
+      current: next,
+      wasBusy: true,
+      isBusy: true,
+      busyDurationMs: 1_000,
+      focused: true,
+    });
+
+    expect(notifications).toEqual([]);
+  });
+
+  it("notifies on long task completion when the window is unfocused", () => {
+    const notifications = deriveDesktopNotifications({
+      previous: emptySnapshot(),
+      current: emptySnapshot(),
+      wasBusy: true,
+      isBusy: false,
+      busyDurationMs: COMPLETION_NOTIFY_MIN_MS,
+      focused: false,
+    });
+
+    expect(notifications).toEqual([
+      {
+        kind: "turn_complete",
+        title: "Reasonix task complete",
+        body: "The current task finished and is ready for review.",
+      },
+    ]);
+  });
+
+  it("does not notify on short task completion", () => {
+    const notifications = deriveDesktopNotifications({
+      previous: emptySnapshot(),
+      current: emptySnapshot(),
+      wasBusy: true,
+      isBusy: false,
+      busyDurationMs: COMPLETION_NOTIFY_MIN_MS - 1,
+      focused: false,
+    });
+
+    expect(notifications).toEqual([]);
+  });
+});

--- a/desktop/src/notifications.ts
+++ b/desktop/src/notifications.ts
@@ -1,0 +1,137 @@
+import { t } from "./i18n";
+
+export type ApprovalSnapshot = {
+  confirms: { id: number; command: string }[];
+  pathAccess: { id: number; path: string; intent: "read" | "write" }[];
+  choices: { id: number; question: string }[];
+  plans: { id: number; summary?: string; plan: string }[];
+  checkpoints: { id: number; title?: string; result: string }[];
+  revisions: { id: number; summary?: string; reason: string }[];
+};
+
+export type DesktopNotification =
+  | { kind: "approval"; title: string; body: string }
+  | { kind: "turn_complete"; title: string; body: string };
+
+export const COMPLETION_NOTIFY_MIN_MS = 15_000;
+
+function newestApproval(snapshot: ApprovalSnapshot): DesktopNotification | null {
+  const confirm = snapshot.confirms.at(-1);
+  if (confirm) {
+    return {
+      kind: "approval",
+      title: t("notifications.approvalTitle"),
+      body: t("notifications.commandBody", { command: confirm.command }),
+    };
+  }
+  const pathAccess = snapshot.pathAccess.at(-1);
+  if (pathAccess) {
+    return {
+      kind: "approval",
+      title: t("notifications.approvalTitle"),
+      body: t(
+        pathAccess.intent === "write" ? "notifications.writeBody" : "notifications.readBody",
+        { path: pathAccess.path },
+      ),
+    };
+  }
+  const choice = snapshot.choices.at(-1);
+  if (choice) {
+    return {
+      kind: "approval",
+      title: t("notifications.inputTitle"),
+      body: choice.question,
+    };
+  }
+  const plan = snapshot.plans.at(-1);
+  if (plan) {
+    return {
+      kind: "approval",
+      title: t("notifications.planApprovalTitle"),
+      body: plan.summary ?? plan.plan,
+    };
+  }
+  const checkpoint = snapshot.checkpoints.at(-1);
+  if (checkpoint) {
+    return {
+      kind: "approval",
+      title: t("notifications.checkpointApprovalTitle"),
+      body: checkpoint.title ?? checkpoint.result,
+    };
+  }
+  const revision = snapshot.revisions.at(-1);
+  if (revision) {
+    return {
+      kind: "approval",
+      title: t("notifications.revisionTitle"),
+      body: revision.summary ?? revision.reason,
+    };
+  }
+  return null;
+}
+
+export function totalPending(snapshot: ApprovalSnapshot): number {
+  return (
+    snapshot.confirms.length +
+    snapshot.pathAccess.length +
+    snapshot.choices.length +
+    snapshot.plans.length +
+    snapshot.checkpoints.length +
+    snapshot.revisions.length
+  );
+}
+
+export function deriveDesktopNotifications(args: {
+  previous: ApprovalSnapshot;
+  current: ApprovalSnapshot;
+  wasBusy: boolean;
+  isBusy: boolean;
+  busyDurationMs: number;
+  focused: boolean;
+}): DesktopNotification[] {
+  const notifications: DesktopNotification[] = [];
+  if (args.focused) return notifications;
+
+  if (totalPending(args.current) > totalPending(args.previous)) {
+    const approval = newestApproval(args.current);
+    if (approval) notifications.push(approval);
+  }
+
+  if (args.wasBusy && !args.isBusy && args.busyDurationMs >= COMPLETION_NOTIFY_MIN_MS) {
+    notifications.push({
+      kind: "turn_complete",
+      title: t("notifications.turnCompleteTitle"),
+      body: t("notifications.turnCompleteBody"),
+    });
+  }
+
+  return notifications;
+}
+
+let notificationPermissionAttempted = false;
+
+export async function dispatchDesktopNotifications(
+  notifications: DesktopNotification[],
+  deps: {
+    isFocused: () => Promise<boolean>;
+    isPermissionGranted: () => Promise<boolean>;
+    requestPermission: () => Promise<"default" | "denied" | "granted">;
+    sendNotification: (note: { title: string; body: string }) => void;
+  },
+): Promise<void> {
+  if (notifications.length === 0) return;
+  const focused = await deps.isFocused().catch(() => true);
+  if (focused) return;
+
+  let granted = await deps.isPermissionGranted().catch(() => false);
+  if (!granted && !notificationPermissionAttempted) {
+    notificationPermissionAttempted = true;
+    const permission = await deps.requestPermission().catch(() => "denied" as const);
+    granted = permission === "granted";
+  }
+  if (!granted) return;
+
+  for (const note of notifications) {
+    deps.sendNotification({ title: note.title, body: note.body });
+  }
+}

--- a/tests/mocks/tauri-plugin-notification.ts
+++ b/tests/mocks/tauri-plugin-notification.ts
@@ -1,0 +1,5 @@
+import { vi } from "vitest";
+
+export const isPermissionGranted = vi.fn(async () => false);
+export const requestPermission = vi.fn(async () => "denied" as const);
+export const sendNotification = vi.fn();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
       "@tauri-apps/api/window": resolve(here, "tests/mocks/tauri-api-window.ts"),
       "@tauri-apps/api/webview": resolve(here, "tests/mocks/tauri-api-webview.ts"),
       "@tauri-apps/plugin-dialog": resolve(here, "tests/mocks/tauri-plugin-dialog.ts"),
+      "@tauri-apps/plugin-notification": resolve(here, "tests/mocks/tauri-plugin-notification.ts"),
       "@tauri-apps/plugin-process": resolve(here, "tests/mocks/tauri-plugin-process.ts"),
       "@tauri-apps/plugin-updater": resolve(here, "tests/mocks/tauri-plugin-updater.ts"),
       "@tauri-apps/plugin-opener": resolve(here, "tests/mocks/tauri-plugin-opener.ts"),


### PR DESCRIPTION
## Summary
- add desktop system notifications for new approval requests while the window is unfocused
- add completion notifications for long-running turns once the app returns to idle
- localize the new notification copy for English and Simplified Chinese

## Details
This keeps the implementation intentionally small:
- new notifications are derived from existing desktop pending-approval state
- completion notifications only fire after a busy-to-idle transition lasting at least 15 seconds
- notifications are suppressed while the window is focused
- notification delivery is wired through the Tauri notification plugin

## Verification
- `npm test -- --run desktop/src/notifications.test.ts desktop/src/App.test.ts desktop/src/ui/thread.test.tsx`
- `npm run typecheck`
- `npm run build` (desktop)
- `npm run verify`

## Notes
- this is built on top of current upstream `main`
- the branch also includes coverage for language switching so the notification text follows the active desktop UI language