### PR TITLE
fix(tui): detect Ghostty and fall back to SGR mouse mode for wheel scroll

### DIFF
--- a/src/cli/ui/mouse-mode.ts
+++ b/src/cli/ui/mouse-mode.ts
@@ -17,6 +17,10 @@
 // either way (#1456-followup: WT users lost wheel scroll after the
 // alternate-scroll switch).
 //
+// Ghostty is another terminal that doesn't properly translate wheel events
+// to cursor keys under `?1007h`, despite being on macOS/Linux. Detect it
+// via `TERM_PROGRAM` and fall back to SGR as well.
+//
 // Escape hatch: `REASONIX_MOUSE_MODE=sgr|alternate-scroll|off` overrides
 // the platform default for users on terminals where the auto-pick is
 // wrong.
@@ -29,7 +33,13 @@ function platformDefault(): Mode {
   // don't honor `?1007h` (notably macOS Terminal.app) fall back to native
   // terminal scrollback, which is acceptable; broken in-app wheel for WT
   // users is not.
-  return process.platform === "win32" ? "sgr" : "alternate-scroll";
+  if (process.platform === "win32") return "sgr";
+  // Ghostty doesn't reliably translate wheel events to cursor keys
+  // under the alternate-scroll protocol. Fall back to SGR so the wheel
+  // still works (#1504).
+  const termProgram = process.env.TERM_PROGRAM ?? "";
+  if (termProgram.toLowerCase().includes("ghostty")) return "sgr";
+  return "alternate-scroll";
 }
 
 function readMode(): Mode {


### PR DESCRIPTION
## Summary

Fix Issue #1504: Ghostty on macOS cannot scroll via mouse wheel after the 0.48.1 default mouse mode switch to ?1007h (alternate scroll). PgUp/PgDn keys still work, but the mouse wheel produces no response.

## Root Cause

Commit 29608df (v0.48.1) switched the default mouse mode from SGR (?1000h+?1006h) to alternate scroll (?1007h) on non-Windows platforms. This mode expects the terminal to translate wheel events into cursor/page keys, which works on iTerm2, GNOME Terminal, kitty, Alacritty, and recent xterm, but NOT on Ghostty.

Ghostty is a newer terminal emulator that doesn't reliably translate wheel events to cursor keys under ?1007h, so Reasonix never sees the scroll events and the wheel goes dead.

## Fix

Detect Ghostty via the TERM_PROGRAM environment variable and fall back to SGR mouse mode (?1000h+?1006h), which captures raw SGR mouse reports. This is the same approach already used for Windows Terminal (which has the same ?1007h compatibility issue).

- Added TERM_PROGRAM check for ''ghostty'' in platformDefault()
- Updated code comments to document Ghostty as known-incompatible
- Windows users are already covered by the existing platform check

## Testing

- macOS Ghostty: wheel scroll now works (verified by SGR mouse events)
- macOS iTerm2 / kitty / Terminal.app: ?1007h still default, no regression
- Windows: platform check unchanged, SGR mode remains the default
- Escape hatch: REASONIX_MOUSE_MODE=alternate-scroll|sgr|off still overrides

Closes #1504