### PR TITLE
fix(client): translate DeepSeek 429 into a concurrency-limit hint

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -115,6 +115,7 @@ export interface PricingOverride {
 }
 
 export interface RateLimitConfig {
+  /** Client-side self-throttle in requests/minute — paces outbound chat calls with a min-interval timer. NOT a DeepSeek-enforced limit: DeepSeek's actual cap is concurrency, not RPM (500 for v4-pro, 2500 for v4-flash, account-wide), surfaced as HTTP 429. Set this only to be a polite neighbor on shared infra; single-user CLI rarely needs it. */
   rpm?: number;
 }
 

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -705,6 +705,8 @@ export const EN: TranslationSchema = {
       "Out of balance (DeepSeek 402): {inner}. Top up at https://platform.deepseek.com/top_up — the panel header shows your balance once it's non-zero.",
     badparam422: "Invalid parameter (DeepSeek 422): {inner}",
     badrequest400: "Bad request (DeepSeek 400): {inner}",
+    concurrency429:
+      "DeepSeek concurrency limit hit (429): {inner}. The account has too many in-flight requests (cap: 500 for v4-pro, 2500 for v4-flash, summed across API keys account-wide). Usually means another Reasonix process is sharing the same key, or a parallel subagent fan-out overshot. Wait a few seconds and retry, reduce parallelism, or request a higher cap at https://platform.deepseek.com.",
     deepseek5xxHead:
       "DeepSeek service unavailable ({status}) — this is a DeepSeek-side problem, not Reasonix. Already retried 4× with backoff.",
     deepseek5xxReachable:

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -288,6 +288,7 @@ export interface TranslationSchema {
     balance402: string;
     badparam422: string;
     badrequest400: string;
+    concurrency429: string;
     deepseek5xxHead: string;
     deepseek5xxReachable: string;
     deepseek5xxUnreachable: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -683,6 +683,8 @@ export const zhCN: TranslationSchema = {
       "余额不足（DeepSeek 402）：{inner}。在 https://platform.deepseek.com/top_up 充值 — 余额非零时面板顶栏会显示。",
     badparam422: "参数错误（DeepSeek 422）：{inner}",
     badrequest400: "请求错误（DeepSeek 400）：{inner}",
+    concurrency429:
+      "DeepSeek 并发超限（429）：{inner}。账号在跑的请求超过上限（v4-pro 500、v4-flash 2500，账号下所有 API key 累加）。通常是同一账号开了多个 Reasonix 进程，或者并行 subagent 一次发太多。等几秒重试、减少并行，或在 https://platform.deepseek.com 申请扩容。",
     deepseek5xxHead:
       "DeepSeek 服务不可用（{status}） — 这是 DeepSeek 服务端问题，不是 Reasonix 故障。已按指数退避重试 4 次。",
     deepseek5xxReachable:

--- a/src/loop/errors.ts
+++ b/src/loop/errors.ts
@@ -25,6 +25,7 @@ export function formatLoopError(err: Error, probe?: DeepSeekProbeResult): string
   if (status === "402") return t("errors.balance402", { inner });
   if (status === "422") return t("errors.badparam422", { inner });
   if (status === "400") return t("errors.badrequest400", { inner });
+  if (status === "429") return t("errors.concurrency429", { inner });
   if (is5xxStatus(status)) return formatDeepSeek5xx(status, probe);
   return msg;
 }

--- a/tests/loop-error.test.ts
+++ b/tests/loop-error.test.ts
@@ -47,6 +47,18 @@ describe("formatLoopError", () => {
     expect(out).toContain("temperature");
   });
 
+  it("429 → concurrency-limit hint with cap numbers + remediation (#1522)", () => {
+    const raw = new Error(
+      'DeepSeek 429: {"error":{"message":"Too Many Requests, please reduce concurrency"}}',
+    );
+    const out = formatLoopError(raw);
+    expect(out).toMatch(/concurrency limit/);
+    expect(out).toMatch(/500/);
+    expect(out).toMatch(/2500/);
+    expect(out).toContain("reduce concurrency");
+    expect(out).toContain("platform.deepseek.com");
+  });
+
   it("400 (non-overflow) → extracts the inner error message, drops the JSON wrapping", () => {
     const raw = new Error(
       'DeepSeek 400: {"error":{"message":"request body malformed at messages[3].role"}}',


### PR DESCRIPTION
## Summary

Translate `DeepSeek 429` into a user-friendly concurrency-limit hint, and clarify that the `rateLimit.rpm` config is a client-side self-throttle (not a DeepSeek-enforced cap). Closes #1522.

## Scope decision (intentionally narrow)

The "new rate limit" docs the issue references are concurrency-based: 500 in-flight requests per account for `deepseek-v4-pro`, 2500 for `deepseek-v4-flash`, summed across all API keys on the account. A single-user CLI doing one turn at a time can never approach this — only really hit when:

- the user has 3+ `reasonix` processes sharing one key, **or**
- a `spawn_subagent` parallel fan-out + nested subagents pile up beyond 500 in flight

So this PR is **only** about telling the user what's happening when 429 does fire. Explicitly **not** in scope:

- Implementing client-side concurrency tracking — pointless when DeepSeek already enforces it server-side and our single-turn loop can't saturate it on its own.
- Adding `user_id` parameter support — useful for multi-tenant scenarios (dashboard, cc-connect bridge), but per RFC #410 chat-bridge work lives outside core. Reasonix-core stays single-user.
- Keep-alive parsing — already handled (`client.ts:117-126` comment confirms SSE comments and non-stream empty lines are invisible to our parsers).
- 10-min server-side queue timeout — already covered by the existing 11-min client timeout.

## What this PR does

### 1. Friendly 429 error message

`src/loop/errors.ts`: add `429 → t("errors.concurrency429", { inner })` alongside the existing 401/402/422/400 cases.

`src/i18n/{EN,zh-CN}.ts` + `types.ts`: new `errors.concurrency429` key. Names the actual caps (500 pro / 2500 flash), identifies the likely cause (another reasonix process on the same key, or a fan-out that overshot), and points at the remediation (wait + retry, reduce parallelism, or request expansion at platform.deepseek.com).

Before:

```
DeepSeek 429: {"error":{"message":"Too Many Requests, please reduce concurrency"}}
```

After:

```
DeepSeek concurrency limit hit (429): Too Many Requests, please reduce concurrency. The account has too many in-flight requests (cap: 500 for v4-pro, 2500 for v4-flash, summed across API keys account-wide). Usually means another Reasonix process is sharing the same key, or a parallel subagent fan-out overshot. Wait a few seconds and retry, reduce parallelism, or request a higher cap at https://platform.deepseek.com.
```

### 2. Clarify `rateLimit.rpm` docstring

`src/config.ts`: `RateLimitConfig.rpm` is a *client-side* self-throttle paced by a min-interval timer — it never mapped to a DeepSeek-enforced cap (DeepSeek has never published an RPM ceiling). Docstring now spells that out so users don't think setting `rpm: 60` does anything DeepSeek-related.

## Test Plan

- [x] `tests/loop-error.test.ts` — new case: `DeepSeek 429: {...}` → contains "concurrency limit" + "500" + "2500" + the inner reason + the platform URL
- [x] `npx vitest run tests/loop-error.test.ts tests/comment-policy.test.ts` — 38 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx biome check` on touched files — clean
- [x] `npm run verify` via pre-push hook — green

## Test Plan (manual)

Not run — no easy way to actually trigger 429 from a single CLI process against DeepSeek's real concurrency cap without spinning up 500+ pro requests. The unit test covers the error-formatting path which is the only thing this PR changes.
