### PR TITLE
test(lifecycle): rename lifecycle harness fixtures

### DIFF
--- a/tests/support/lifecycle-harness.ts
+++ b/tests/support/lifecycle-harness.ts
@@ -75,7 +75,7 @@ export function createStrictLifecycleHarness(
     onPlanSubmitted: (_plan, steps) => lifecycle.recordPlanProposed(steps),
     onStepCompleted: (completion) => completions.push(completion),
   });
-  registerMutationTools(registry, opts);
+  registerLifecycleToolFixtures(registry, opts);
 
   return {
     lifecycle,
@@ -99,7 +99,7 @@ export function createStrictLifecycleHarness(
   };
 }
 
-function registerMutationTools(
+function registerLifecycleToolFixtures(
   registry: ToolRegistry,
   opts: StrictLifecycleHarnessOptions = {},
 ): void {


### PR DESCRIPTION
## Summary
- Rename the strict lifecycle harness helper from `registerMutationTools` to `registerLifecycleToolFixtures`.
- Keep the change test-only and behavior-neutral: no runtime semantics, prompt, tool schema, or fixture behavior changes.
- Follow up on the review note from #1499 that the helper now registers lifecycle fixtures rather than mutation-only tools.

## Test Plan
- `npm test -- tests/lifecycle-e2e.test.ts`
- `npx biome check tests/support/lifecycle-harness.ts`
- `npm run typecheck`
- `npm run lint`
- Pre-push hook ran `npm run verify` successfully: 259 test files passed, 3596 tests passed, 10 skipped.

Refs #1285
Follow-up to #1499