### PR TITLE
chore(changes): gate @mention popover on MODE === "attached"

### DIFF
--- a/dashboard/src/panels/changes.ts
+++ b/dashboard/src/panels/changes.ts
@@ -1733,7 +1733,7 @@ function ChatPane(props: ChatPaneProps) {
         return;
       }
       const mentionMatch = /(?:^|\s)@([^\s@]*)$/.exec(text);
-      if (mentionMatch) {
+      if (mentionMatch && MODE === "attached") {
         const prefix = mentionMatch[1] ?? "";
         try {
           const r = await api<{ files: string[] }>("/files", {


### PR DESCRIPTION
Small follow-up to #1546: gate the new `@mention` popover behind `MODE === "attached"`, matching the existing pattern in `chat.ts`.

Without this guard, standalone dashboard clients call `/files` on every `@` keystroke and get a 503 (`"@-mention picker requires a code-mode session"`) back — the popover never opens but each `@` still costs a round-trip. The `MODE` import added in #1546 becomes load-bearing here.
