### PR TITLE
fix(client): wire timeoutMs to fetch when caller passes a signal

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -223,8 +223,13 @@ export class DeepSeekClient {
 
   async chat(opts: ChatRequestOptions): Promise<ChatResponse> {
     const ctrl = new AbortController();
-    const timer = setTimeout(() => ctrl.abort(), this.timeoutMs);
-    const signal = opts.signal ?? ctrl.signal;
+    const timer = setTimeout(
+      () => ctrl.abort(new Error(`DeepSeek request timed out after ${this.timeoutMs}ms`)),
+      this.timeoutMs,
+    );
+    // Combine — `opts.signal ?? ctrl.signal` orphans the timer when the
+    // caller passes a signal, so timeoutMs never reaches fetch.
+    const signal = opts.signal ? AbortSignal.any([opts.signal, ctrl.signal]) : ctrl.signal;
 
     try {
       await this.waitForChatRateLimit(signal);
@@ -261,8 +266,14 @@ export class DeepSeekClient {
 
   async *stream(opts: ChatRequestOptions): AsyncGenerator<StreamChunk> {
     const ctrl = new AbortController();
-    const timer = setTimeout(() => ctrl.abort(), this.timeoutMs);
-    const signal = opts.signal ?? ctrl.signal;
+    const timer = setTimeout(
+      () => ctrl.abort(new Error(`DeepSeek stream timed out after ${this.timeoutMs}ms`)),
+      this.timeoutMs,
+    );
+    // Combine — `opts.signal ?? ctrl.signal` orphans the timer when the
+    // caller passes a signal, leaving a stalled SSE body to hang forever
+    // on reader.read() (issue #1535).
+    const signal = opts.signal ? AbortSignal.any([opts.signal, ctrl.signal]) : ctrl.signal;
 
     let resp: Response;
     try {

--- a/tests/client-stream-timeout.test.ts
+++ b/tests/client-stream-timeout.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi } from "vitest";
+import { DeepSeekClient } from "../src/client.js";
+
+/** Mock fetch that returns a streaming body which never completes until
+ *  the request signal aborts. Sends one SSE keep-alive comment first so
+ *  the response headers flush and the consumer enters the read loop. */
+function hangingStreamFetch(): { fetch: typeof fetch; calls: () => number } {
+  let count = 0;
+  const spy = vi.fn(async (_url: unknown, init: unknown) => {
+    count++;
+    const reqSignal = (init as RequestInit).signal as AbortSignal | null;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(": keep-alive\n\n"));
+        if (!reqSignal) return;
+        if (reqSignal.aborted) {
+          controller.error(reqSignal.reason);
+          return;
+        }
+        reqSignal.addEventListener(
+          "abort",
+          () => {
+            try {
+              controller.error(reqSignal.reason);
+            } catch {
+              /* controller already closed */
+            }
+          },
+          { once: true },
+        );
+      },
+    });
+    return new Response(body, {
+      status: 200,
+      headers: { "Content-Type": "text/event-stream" },
+    });
+  });
+  return { fetch: spy as unknown as typeof fetch, calls: () => count };
+}
+
+/** Mock fetch whose JSON body promise never resolves until the request
+ *  signal aborts. Used to cover the non-streaming chat() path. */
+function hangingJsonFetch(): typeof fetch {
+  const spy = vi.fn(async (_url: unknown, init: unknown) => {
+    const reqSignal = (init as RequestInit).signal as AbortSignal | null;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        if (!reqSignal) return;
+        if (reqSignal.aborted) {
+          controller.error(reqSignal.reason);
+          return;
+        }
+        reqSignal.addEventListener(
+          "abort",
+          () => {
+            try {
+              controller.error(reqSignal.reason);
+            } catch {
+              /* controller already closed */
+            }
+          },
+          { once: true },
+        );
+      },
+    });
+    return new Response(body, {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+  return spy as unknown as typeof fetch;
+}
+
+describe("DeepSeekClient.stream() timeout with caller signal (issue #1535)", () => {
+  it("aborts the stream when timeoutMs elapses even if the caller passed a signal", async () => {
+    const { fetch } = hangingStreamFetch();
+    const client = new DeepSeekClient({
+      apiKey: "sk-test",
+      fetch,
+      timeoutMs: 50,
+      retry: { maxAttempts: 1 },
+    });
+
+    const callerCtrl = new AbortController();
+    const consume = async () => {
+      for await (const _chunk of client.stream({
+        model: "deepseek-chat",
+        messages: [{ role: "user", content: "hi" }],
+        signal: callerCtrl.signal,
+      })) {
+        /* drain */
+      }
+    };
+
+    await expect(consume()).rejects.toThrow(/timed out/i);
+    expect(callerCtrl.signal.aborted).toBe(false);
+  });
+
+  it("caller's signal still aborts the stream", async () => {
+    const { fetch } = hangingStreamFetch();
+    const client = new DeepSeekClient({
+      apiKey: "sk-test",
+      fetch,
+      timeoutMs: 60_000,
+      retry: { maxAttempts: 1 },
+    });
+
+    const callerCtrl = new AbortController();
+    const consume = async () => {
+      for await (const _chunk of client.stream({
+        model: "deepseek-chat",
+        messages: [{ role: "user", content: "hi" }],
+        signal: callerCtrl.signal,
+      })) {
+        /* drain */
+      }
+    };
+
+    const promise = consume();
+    setTimeout(() => callerCtrl.abort(new Error("user pressed esc")), 30);
+    await expect(promise).rejects.toThrow(/user pressed esc/);
+  });
+});
+
+describe("DeepSeekClient.chat() timeout with caller signal", () => {
+  it("aborts the request when timeoutMs elapses even if the caller passed a signal", async () => {
+    const client = new DeepSeekClient({
+      apiKey: "sk-test",
+      fetch: hangingJsonFetch(),
+      timeoutMs: 50,
+      retry: { maxAttempts: 1 },
+    });
+
+    const callerCtrl = new AbortController();
+    await expect(
+      client.chat({
+        model: "deepseek-chat",
+        messages: [{ role: "user", content: "hi" }],
+        signal: callerCtrl.signal,
+      }),
+    ).rejects.toThrow(/timed out/i);
+    expect(callerCtrl.signal.aborted).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- `opts.signal ?? ctrl.signal` in `chat()` and `stream()` orphaned the timeout controller whenever the loop forwarded its `_turnAbort.signal` — i.e. every real call — so `timeoutMs` was dead code on the hot path.
- A genuinely stalled SSE body (TCP open, no `[DONE]`, no close) then sat on `reader.read()` forever and the TUI hung in "…waiting for response…" until the user restarted it, even though the DeepSeek dashboard already showed the request as completed.
- Combine the caller's signal with the timer's controller via `AbortSignal.any` and abort with a reason so the loop's error path surfaces "timed out after Xms" instead of a silent stall.

## Test plan

- [x] new `tests/client-stream-timeout.test.ts` — stream() and chat() both abort on timeout when caller passes a signal, and the caller's own signal still aborts the stream
- [x] `npm run verify` passes (3544 tests)

Closes #1535