### PR TITLE
fix(config): atomic write + restore preset-write diagnostic trace

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,13 @@
 /** Library reads only DEEPSEEK_API_KEY from env; the CLI bridges config.json → env var. */
 
-import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  appendFileSync,
+  chmodSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import { z } from "zod";
@@ -403,12 +410,40 @@ export function readConfig(path: string = defaultConfigPath()): ReasonixConfig {
 }
 
 export function writeConfig(cfg: ReasonixConfig, path: string = defaultConfigPath()): void {
+  debugLogConfigWrite(cfg, path);
   mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, JSON.stringify(cfg, null, 2), "utf8");
+  // Atomic — write to a sibling tmp then rename. A torn write (process
+  // killed mid-write, or another reader catching the file before
+  // writeFileSync finished) used to leave a 0-byte or truncated
+  // config.json, which readConfig would then parse as `{}` and the next
+  // saveX would silently overwrite every other field with that empty
+  // baseline (issue #1535 follow-on — preset reverting to default).
+  const tmp = `${path}.${process.pid}.tmp`;
+  writeFileSync(tmp, JSON.stringify(cfg, null, 2), "utf8");
   try {
-    chmodSync(path, 0o600);
+    chmodSync(tmp, 0o600);
   } catch {
     /* ignore on platforms without chmod */
+  }
+  renameSync(tmp, path);
+}
+
+/** Append timestamp + keys + preset + stack to REASONIX_DEBUG_PRESET when set. Catches every persisted config change including the dashboard PATCH path that bypasses savePreset(). Zero cost when unset. */
+function debugLogConfigWrite(cfg: ReasonixConfig, configPath: string): void {
+  const debugPath = process.env.REASONIX_DEBUG_PRESET;
+  if (!debugPath) return;
+  try {
+    const stack = new Error("trace").stack ?? "";
+    const keys = Object.keys(cfg).sort().join(",");
+    const presetField = cfg.preset === undefined ? "(absent)" : JSON.stringify(cfg.preset);
+    const line = `${new Date().toISOString()} writeConfig pid=${process.pid} → ${configPath}\n  keys=[${keys}]\n  preset=${presetField}\n${stack
+      .split("\n")
+      .slice(1, 10)
+      .map((l) => `  ${l.trim()}`)
+      .join("\n")}\n\n`;
+    appendFileSync(debugPath, line);
+  } catch {
+    /* diagnostic only */
   }
 }
 
@@ -1124,9 +1159,26 @@ export function loadPreset(path: string = defaultConfigPath()): PresetName | und
 
 /** Persist preset so `/preset pro` (or `/model deepseek-v4-pro`) sticks across relaunches. */
 export function savePreset(preset: PresetName, path: string = defaultConfigPath()): void {
+  debugLogPresetWrite(preset, path);
   const cfg = readConfig(path);
   cfg.preset = preset;
   writeConfig(cfg, path);
+}
+
+function debugLogPresetWrite(preset: PresetName, configPath: string): void {
+  const debugPath = process.env.REASONIX_DEBUG_PRESET;
+  if (!debugPath) return;
+  try {
+    const stack = new Error("trace").stack ?? "";
+    const line = `${new Date().toISOString()} savePreset(${JSON.stringify(preset)}) → ${configPath}\n${stack
+      .split("\n")
+      .slice(1, 8)
+      .map((l) => `  ${l.trim()}`)
+      .join("\n")}\n\n`;
+    appendFileSync(debugPath, line);
+  } catch {
+    /* diagnostic only */
+  }
 }
 
 export function loadIndexUserConfig(path: string = defaultConfigPath()): IndexUserConfig {

--- a/src/server/api/settings.ts
+++ b/src/server/api/settings.ts
@@ -1,5 +1,6 @@
 /** apiKey is write-only on the wire; GET always returns a redacted form so dashboard screenshots don't leak credentials. */
 
+import { appendFileSync } from "node:fs";
 import {
   isPlausibleKey,
   normalizeSkillPathEntries,
@@ -42,6 +43,23 @@ function parseBody(raw: string): SettingsBody {
 // read time. Web sends new names in 0.12.x onward.
 const VALID_PRESETS = new Set(["auto", "flash", "pro", "fast", "smart", "max"]);
 const VALID_EFFORTS = new Set(["high", "max"]);
+
+/** Twin of `config.savePreset`'s debug hook — the dashboard PATCH writes `cfg.preset` directly (no `savePreset()` round-trip), so instrument the bypass path too. Same env gate, same file. */
+function debugLogPresetWriteFromDashboard(preset: string): void {
+  const debugPath = process.env.REASONIX_DEBUG_PRESET;
+  if (!debugPath) return;
+  try {
+    const stack = new Error("trace").stack ?? "";
+    const line = `${new Date().toISOString()} dashboard PATCH /api/settings { preset: ${JSON.stringify(preset)} }\n${stack
+      .split("\n")
+      .slice(1, 8)
+      .map((l) => `  ${l.trim()}`)
+      .join("\n")}\n\n`;
+    appendFileSync(debugPath, line);
+  } catch {
+    /* diagnostic only */
+  }
+}
 
 export async function handleSettings(
   method: string,
@@ -139,6 +157,7 @@ export async function handleSettings(
       if (typeof fields.preset !== "string" || !VALID_PRESETS.has(fields.preset)) {
         return { status: 400, body: { error: "preset must be auto | flash | pro" } };
       }
+      debugLogPresetWriteFromDashboard(fields.preset);
       cfg.preset = fields.preset as "auto" | "flash" | "pro" | "fast" | "smart" | "max";
       presetPendingLive = fields.preset;
       changed.push("preset");

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -41,6 +41,7 @@ import {
   saveDesktopOpenTabs,
   saveEditMode,
   saveIndexConfig,
+  savePreset,
   saveReasoningEffort,
   saveSemanticEmbeddingConfig,
   saveTheme,
@@ -96,6 +97,39 @@ describe("config", () => {
   it("writeConfig + readConfig round-trip", () => {
     writeConfig({ apiKey: "sk-test123abcdefghijkl" }, path);
     expect(readConfig(path).apiKey).toBe("sk-test123abcdefghijkl");
+  });
+
+  it("writeConfig leaves no `.tmp` sibling behind on success", () => {
+    writeConfig({ apiKey: "sk-test123abcdefghijkl", preset: "auto" }, path);
+    const tmp = `${path}.${process.pid}.tmp`;
+    expect(existsSync(tmp)).toBe(false);
+    expect(existsSync(path)).toBe(true);
+  });
+
+  it("savePreset records a trace line when REASONIX_DEBUG_PRESET is set", async () => {
+    const { readFileSync, existsSync: exists, mkdirSync: mk } = await import("node:fs");
+    const logPath = join(dir, "preset.log");
+    mk(dir, { recursive: true });
+    process.env.REASONIX_DEBUG_PRESET = logPath;
+    try {
+      savePreset("auto", path);
+      expect(exists(logPath)).toBe(true);
+      const contents = readFileSync(logPath, "utf8");
+      expect(contents).toContain('savePreset("auto")');
+      // writeConfig's own trace also fires — single savePreset call → both lines.
+      expect(contents).toContain("writeConfig pid=");
+      expect(contents).toContain('preset="auto"');
+    } finally {
+      // biome-ignore lint/performance/noDelete: process.env wants undefined, not the string "undefined"
+      delete process.env.REASONIX_DEBUG_PRESET;
+    }
+  });
+
+  it("savePreset writes nothing extra when REASONIX_DEBUG_PRESET is unset", () => {
+    // biome-ignore lint/performance/noDelete: same reason
+    delete process.env.REASONIX_DEBUG_PRESET;
+    savePreset("flash", path);
+    expect(readConfig(path).preset).toBe("flash");
   });
 
   it("saveApiKey trims whitespace", () => {


### PR DESCRIPTION
## Summary

Users still see `preset` flipping back to its prior value after a relaunch, even though the BOM-cascade root cause from #1431 is fixed. Two follow-on changes to close the gap.

1. **`writeConfig` is now atomic.** Writes to a sibling `${path}.${pid}.tmp` then `renameSync` into place. The previous `writeFileSync` was not atomic on Windows — a concurrent reader landing inside the write window could see a truncated file, `readConfig` falls through to `{}`, and the next read-modify-write saves an empty baseline that loses every other field. The temp + rename pattern guarantees readers see either the old file or the new one, never an in-flight blob.
2. **Restore the `REASONIX_DEBUG_PRESET` trace** that #1431 retired. Logs every `savePreset()` call, every `writeConfig()` call, and the dashboard PATCH bypass — each with a short stack — so `tools/debug-preset-launcher.ps1` can pinpoint who flipped the preset when it does. Zero cost when the env var is unset.

## Test plan

- [x] new tests in `tests/config.test.ts` — no `.tmp` sibling after a successful write, trace fires when env set, no extra writes when env unset
- [x] `npm run verify` (3547 tests)