### PR TITLE
fix(dashboard): mint named session from web new action

### DIFF
--- a/src/server/api/sessions.ts
+++ b/src/server/api/sessions.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
-import { deleteSession, listSessions, sessionPath } from "../../memory/session.js";
+import { deleteSession, freshSessionName, listSessions, sessionPath } from "../../memory/session.js";
 import type { DashboardContext } from "../context.js";
 import type { ApiResult } from "../router.js";
 
@@ -67,8 +67,10 @@ export async function handleSessions(
     };
   }
 
-  // New session — mints a fresh session by calling switchSession(undefined),
-  // which routes through the same path the SessionPicker "new" branch takes.
+  // New session — mirror the TUI SessionPicker "new" branch by minting
+  // a real session name. Passing undefined would remount App as an
+  // ephemeral session and leave the attached dashboard with stale
+  // session state, which makes the SPA lose its API connection.
   if (method === "POST" && rest.length === 1 && rest[0] === "new") {
     if (!ctx.switchSession) {
       return {
@@ -76,7 +78,8 @@ export async function handleSessions(
         body: { error: "live session swap requires an attached CLI session." },
       };
     }
-    const result = ctx.switchSession(undefined);
+    const currentName = ctx.getSessionName?.() ?? undefined;
+    const result = ctx.switchSession(freshSessionName(currentName));
     if (!result.ok) return { status: 500, body: { error: result.reason } };
     return { status: 200, body: { ok: true } };
   }

--- a/src/server/api/sessions.ts
+++ b/src/server/api/sessions.ts
@@ -1,5 +1,10 @@
 import { existsSync, readFileSync } from "node:fs";
-import { deleteSession, freshSessionName, listSessions, sessionPath } from "../../memory/session.js";
+import {
+  deleteSession,
+  freshSessionName,
+  listSessions,
+  sessionPath,
+} from "../../memory/session.js";
 import type { DashboardContext } from "../context.js";
 import type { ApiResult } from "../router.js";
 

--- a/tests/dashboard-new-session-name.test.ts
+++ b/tests/dashboard-new-session-name.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { handleSessions } from "../src/server/api/sessions.js";
+
+function makeCtx(current: string | null, calls: Array<string | undefined>) {
+  return {
+    mode: "attached" as const,
+    configPath: "config.json",
+    usageLogPath: "usage.jsonl",
+    getSessionName: () => current,
+    switchSession: (name: string | undefined) => {
+      calls.push(name);
+      return { ok: true as const };
+    },
+  };
+}
+
+describe("dashboard /sessions/new", () => {
+  it("mints a named session based on the current session", async () => {
+    const calls: Array<string | undefined> = [];
+    const result = await handleSessions("POST", ["new"], "", makeCtx("alpha", calls));
+
+    expect(result.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatch(/^alpha-\d{14}$/);
+  });
+
+  it("uses default when the attached CLI has no named current session", async () => {
+    const calls: Array<string | undefined> = [];
+    const result = await handleSessions("POST", ["new"], "", makeCtx(null, calls));
+
+    expect(result.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatch(/^default-\d{14}$/);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the dashboard `/api/sessions/new` path so it mirrors the TUI SessionPicker "new" behavior by creating a real fresh session name instead of switching to an unnamed/ephemeral session.

## Why

Issue #1547 reports that clicking "create new session" in the web dashboard hangs the app and then all dashboard requests fail with `Failed to fetch`.

The existing endpoint comment says it should route through the same path as SessionPicker's `new` branch, but it actually called `switchSession(undefined)`. In the TUI path, a new session is created with `freshSessionName(activeSession)`. Passing `undefined` remounts the attached App as an unnamed session and can leave the dashboard with stale session state/API connectivity.

## Changes

- Import and use `freshSessionName` in `src/server/api/sessions.ts`.
- `POST /api/sessions/new` now calls `switchSession(freshSessionName(currentName))`.
- Falls back to `default-<timestamp>` when there is no attached current session name.
- Adds a focused regression test for the dashboard new-session endpoint.

## Testing

Added `tests/dashboard-new-session-name.test.ts` covering:

- current session `alpha` → `alpha-<14 digit timestamp>`
- no current session → `default-<14 digit timestamp>`

I was not able to run the test suite in this environment because cloning/running the repo was not available here.

Fixes #1547