### PR TITLE
fix(approval-prompts): translate Shell/Path confirm title and action labels

### DIFF
--- a/src/cli/ui/PathConfirm.tsx
+++ b/src/cli/ui/PathConfirm.tsx
@@ -36,12 +36,26 @@ export function PathConfirm({ prompt, onChoose }: PathConfirmProps) {
 
   const path = prompt.subtitle ?? "";
   const allowPrefix = String(prompt.data?.prefix ?? "");
+  // prompt.kind collapses read/write into "path"; recover from data.intent.
+  const intent = prompt.data?.intent === "write" ? "write" : "read";
+  const localTitle =
+    intent === "write" ? t("pathConfirm.promptTitleWrite") : t("pathConfirm.promptTitleRead");
+  const localActionLabel = (id: string, fallback: string): string => {
+    if (id === "run_once") {
+      return intent === "write"
+        ? t("pathConfirm.actionAllowWrite")
+        : t("pathConfirm.actionAllowRead");
+    }
+    if (id === "always_allow") return t("pathConfirm.actionAlwaysAllow", { prefix: allowPrefix });
+    if (id === "deny") return t("pathConfirm.actionDeny");
+    return fallback;
+  };
 
   return (
     <ApprovalCard
       tone={prompt.tone}
       glyph="!"
-      title={prompt.title}
+      title={localTitle}
       metaRight={t("pathConfirm.awaiting")}
       footerHint={t("pathConfirm.pickFooter")}
     >
@@ -51,7 +65,7 @@ export function PathConfirm({ prompt, onChoose }: PathConfirmProps) {
       <InfoRows path={path} sandboxRoot={prompt.meta?.sandboxRoot} allowPrefix={allowPrefix} />
       <SingleSelect
         initialValue={prompt.actions[0]?.id ?? "run_once"}
-        items={prompt.actions.map((a) => ({ value: a.id, label: a.label }))}
+        items={prompt.actions.map((a) => ({ value: a.id, label: localActionLabel(a.id, a.label) }))}
         onSubmit={(v) => {
           const action = prompt.actions.find((a) => a.id === v);
           if (action?.secondaryInput) {

--- a/src/cli/ui/ShellConfirm.tsx
+++ b/src/cli/ui/ShellConfirm.tsx
@@ -34,11 +34,26 @@ export function ShellConfirm({ prompt, onChoose }: ShellConfirmProps) {
     );
   }
 
+  // toApprovalPrompt mints English labels for the ACP surface; the unified
+  // prompt.kind collapses foreground + background into "shell", so we recover
+  // the split from meta.wait (only set on background prompts).
+  const isBackground = prompt.meta?.wait !== undefined;
+  const prefix = String(prompt.data?.prefix ?? "");
+  const localTitle = isBackground
+    ? t("shellConfirm.promptTitleRunBackground")
+    : t("shellConfirm.promptTitleRunCommand");
+  const localActionLabel = (id: string, fallback: string): string => {
+    if (id === "run_once") return t("shellConfirm.actionRunOnce");
+    if (id === "always_allow") return t("shellConfirm.actionAlwaysAllow", { prefix });
+    if (id === "deny") return t("shellConfirm.actionDeny");
+    return fallback;
+  };
+
   return (
     <ApprovalCard
       tone={prompt.tone}
       glyph="?"
-      title={prompt.title}
+      title={localTitle}
       metaRight={t("shellConfirm.awaiting")}
       footerHint={t("shellConfirm.pickFooter")}
     >
@@ -55,7 +70,7 @@ export function ShellConfirm({ prompt, onChoose }: ShellConfirmProps) {
       <InfoRows meta={prompt.meta} />
       <SingleSelect
         initialValue={prompt.actions[0]?.id ?? "run_once"}
-        items={prompt.actions.map((a) => ({ value: a.id, label: a.label }))}
+        items={prompt.actions.map((a) => ({ value: a.id, label: localActionLabel(a.id, a.label) }))}
         onSubmit={(v) => {
           const action = prompt.actions.find((a) => a.id === v);
           if (action?.secondaryInput) {

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -1339,6 +1339,12 @@ export const EN: TranslationSchema = {
     pathLabel: "path",
     sandboxLabel: "sandbox",
     allowPrefixLabel: "prefix",
+    promptTitleRead: "Access path \u2014 read",
+    promptTitleWrite: "Access path \u2014 write",
+    actionAllowRead: "Allow read",
+    actionAllowWrite: "Allow write",
+    actionAlwaysAllow: "Always allow \u2014 {prefix}",
+    actionDeny: "Deny",
   },
   shellConfirm: {
     title: "Shell command",
@@ -1363,6 +1369,11 @@ export const EN: TranslationSchema = {
     waitLabel: "wait",
     previewMore: "… {n} more line hidden — press esc, ask the model to split it",
     previewMorePlural: "… {n} more lines hidden — press esc, ask the model to split it",
+    promptTitleRunCommand: "Run command",
+    promptTitleRunBackground: "Run background command",
+    actionRunOnce: "Run once",
+    actionAlwaysAllow: "Always allow \u2014 {prefix}",
+    actionDeny: "Deny",
   },
   editConfirm: {
     footer:

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -508,6 +508,12 @@ export interface TranslationSchema {
     pathLabel: string;
     sandboxLabel: string;
     allowPrefixLabel: string;
+    promptTitleRead: string;
+    promptTitleWrite: string;
+    actionAllowRead: string;
+    actionAllowWrite: string;
+    actionAlwaysAllow: string;
+    actionDeny: string;
   };
   shellConfirm: {
     title: string;
@@ -530,6 +536,11 @@ export interface TranslationSchema {
     waitLabel: string;
     previewMore: string;
     previewMorePlural: string;
+    promptTitleRunCommand: string;
+    promptTitleRunBackground: string;
+    actionRunOnce: string;
+    actionAlwaysAllow: string;
+    actionDeny: string;
   };
   editConfirm: {
     footer: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -1266,6 +1266,12 @@ export const zhCN: TranslationSchema = {
     pathLabel: "路径",
     sandboxLabel: "沙箱",
     allowPrefixLabel: "前缀",
+    promptTitleRead: "访问路径 — 读取",
+    promptTitleWrite: "访问路径 — 写入",
+    actionAllowRead: "允许读取",
+    actionAllowWrite: "允许写入",
+    actionAlwaysAllow: "始终允许 — {prefix}",
+    actionDeny: "拒绝",
   },
   shellConfirm: {
     title: "Shell 命令",
@@ -1288,6 +1294,11 @@ export const zhCN: TranslationSchema = {
     waitLabel: "等待",
     previewMore: "… 还有 {n} 行未显示 — 按 esc 取消，让模型拆分后再试",
     previewMorePlural: "… 还有 {n} 行未显示 — 按 esc 取消，让模型拆分后再试",
+    promptTitleRunCommand: "运行命令",
+    promptTitleRunBackground: "运行后台命令",
+    actionRunOnce: "运行一次",
+    actionAlwaysAllow: "始终允许 — {prefix}",
+    actionDeny: "拒绝",
   },
   editConfirm: {
     footer:

--- a/tests/shell-confirm-render.test.tsx
+++ b/tests/shell-confirm-render.test.tsx
@@ -1,7 +1,8 @@
 import { render } from "ink-testing-library";
 import React from "react";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ShellConfirm } from "../src/cli/ui/ShellConfirm.js";
+import { setLanguageRuntime } from "../src/i18n/index.js";
 
 function makeShellPrompt(command: string): import("@reasonix/core-utils").ApprovalPrompt {
   return {
@@ -27,6 +28,9 @@ function makeShellPrompt(command: string): import("@reasonix/core-utils").Approv
 }
 
 describe("ShellConfirm — renders with ApprovalPrompt", () => {
+  beforeEach(() => setLanguageRuntime("EN"));
+  afterEach(() => setLanguageRuntime("EN"));
+
   it("renders the action options and footer", () => {
     const { lastFrame, unmount } = render(
       <ShellConfirm prompt={makeShellPrompt("echo hello")} onChoose={() => {}} />,
@@ -44,10 +48,25 @@ describe("ShellConfirm — renders with ApprovalPrompt", () => {
       <ShellConfirm prompt={makeShellPrompt("rm -rf /")} onChoose={() => {}} />,
     );
     // Move to "deny" option and submit
-    stdin.write("[B[B"); // two down arrows
+    stdin.write("[B[B"); // two down arrows
     stdin.write("\r"); // enter
     const out = lastFrame() ?? "";
     unmount();
     expect(out).toContain("Deny");
+  });
+
+  it("translates title + action labels under zh-CN (#1560)", () => {
+    setLanguageRuntime("zh-CN");
+    const { lastFrame, unmount } = render(
+      <ShellConfirm prompt={makeShellPrompt("python script.py")} onChoose={() => {}} />,
+    );
+    const out = lastFrame() ?? "";
+    unmount();
+    expect(out).toContain("运行命令");
+    expect(out).toContain("运行一次");
+    expect(out).toContain("始终允许");
+    expect(out).toContain("拒绝");
+    expect(out).not.toContain("Run once");
+    expect(out).not.toContain("Always allow");
   });
 });


### PR DESCRIPTION
## Summary

Issue #1560: when running the CLI in zh-CN, the shell-approval card still showed `Run command` / `Run once` / `Always allow — …` / `Deny` in English. `toApprovalPrompt` (core-utils) mints English labels deliberately so the ACP surface (no i18n layer) can render immediately, but the CLI surface was rendering those verbatim instead of running them through the active locale.

## Fix

`ShellConfirm` and `PathConfirm` now override `prompt.title` and each `action.label` with locally-translated strings keyed off `action.id` plus `prompt.data` — that's how we still tell foreground vs background and read vs write apart even though the unified `prompt.kind` collapses both pairs into `"shell"` and `"path"`.

New i18n keys (both `EN.ts` and `zh-CN.ts`, plus the type defs in `types.ts`):

- `shellConfirm.promptTitleRunCommand` / `promptTitleRunBackground`
- `shellConfirm.actionRunOnce` / `actionAlwaysAllow` (with `{prefix}`) / `actionDeny`
- `pathConfirm.promptTitleRead` / `promptTitleWrite`
- `pathConfirm.actionAllowRead` / `actionAllowWrite` / `actionAlwaysAllow` / `actionDeny`

## Test plan

- [x] new `setLanguageRuntime("zh-CN")` case in `tests/shell-confirm-render.test.tsx` — asserts 运行命令 / 运行一次 / 始终允许 / 拒绝 render and the English labels do NOT survive
- [x] existing EN render test still passes (the `data.prefix` interpolation puts the prefix after `Always allow — `, so the existing `toContain("Always allow")` assertion still matches)
- [x] `npm run verify` passes (3554 tests)

Closes #1560