### PR TITLE
fix(ui): add horizontal scroll for markdown tables

### DIFF
--- a/desktop/src/Markdown.test.tsx
+++ b/desktop/src/Markdown.test.tsx
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+
+import { render } from "@testing-library/react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+vi.mock("@tauri-apps/plugin-opener", () => ({ openPath: vi.fn(), openUrl: vi.fn() }));
+
+import { Markdown } from "./Markdown";
+
+beforeAll(() => {
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText: vi.fn() },
+    configurable: true,
+  });
+});
+
+describe("Markdown", () => {
+  it("wraps tables in a horizontal scroll container", () => {
+    const { container } = render(
+      <Markdown
+        source={`| A | B | C | D |
+| - | - | - | - |
+| 1 | 2 | 3 | 4 |`}
+      />,
+    );
+
+    const wrap = container.querySelector(".markdown-table-wrap");
+    expect(wrap).toBeTruthy();
+    expect(wrap?.querySelector("table")).toBeTruthy();
+  });
+});

--- a/desktop/src/Markdown.tsx
+++ b/desktop/src/Markdown.tsx
@@ -231,6 +231,11 @@ export const Markdown = memo(function Markdown({ source }: { source: string }) {
           a: ({ href, children }) => <SafeLink href={href}>{children}</SafeLink>,
           p: ({ children }) => <p>{withFilePills(children)}</p>,
           li: ({ children }) => <li>{withFilePills(children)}</li>,
+          table: ({ children }) => (
+            <div className="markdown-table-wrap">
+              <table>{children}</table>
+            </div>
+          ),
           td: ({ children }) => <td>{withFilePills(children)}</td>,
         }}
       >

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -1823,6 +1823,17 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
 .markdown tbody tr:hover {
   background: var(--card-hover);
 }
+.markdown-table-wrap {
+  width: calc(100% + 32px);
+  max-width: calc(100% + 32px);
+  overflow-x: auto;
+  margin: 14px -16px;
+}
+.markdown-table-wrap > table {
+  width: max-content;
+  min-width: 100%;
+  margin: 0;
+}
 
 .msg-actions {
   display: flex;


### PR DESCRIPTION
## Summary

Add horizontal scrolling for wide Markdown tables in the desktop chat UI, and slightly widen the table viewport so wide tables are easier to read without affecting normal message layout.

## Problem

When Reasonix renders Markdown tables with many columns or long cell content, the table can exceed the visible chat width. The chat container hides horizontal overflow, and the table had no dedicated scroll wrapper, so the right side of the table was clipped and could not be viewed.

The issue is in the desktop Markdown rendering path:
- `desktop/src/ui/cards.tsx` renders assistant text through `Markdown`
- `desktop/src/Markdown.tsx` renders GFM tables directly
- `desktop/src/styles.css` only had general table styling, with no horizontal scroll container

## Fix

- **`desktop/src/Markdown.tsx`** — Added a custom `table` renderer that wraps Markdown tables in a `.markdown-table-wrap` container.
- **`desktop/src/styles.css`** — Added horizontal scrolling to `.markdown-table-wrap`, and widened the wrapper slightly with negative side margins so wide tables have a bit more usable horizontal space.
- **`desktop/src/Markdown.test.tsx`** — Added a regression test that verifies Markdown tables are rendered inside the scroll container.

## Verification

| Check | Result |
|---|---|
| `npx vitest run desktop/src/Markdown.test.tsx` | ✅ passes |
| `npx vitest run desktop/src/Markdown.test.tsx desktop/src/ui/thread.test.tsx` | ✅ passes |
| `npx tsc --noEmit -p desktop` | ✅ passes |
| `git diff --check` | ✅ passes |
| `npm run verify` | ✅ passes |

Closed #1463 