### PR TITLE
feat(edit): enforce read-before-edit at the dispatch gate

### DIFF
--- a/src/code/prompt.ts
+++ b/src/code/prompt.ts
@@ -68,7 +68,7 @@ the new lines
 >>>>>>> REPLACE
 
 Rules:
-- read_file first so your SEARCH matches byte-for-byte.
+- **Read before edit (enforced).** You MUST call \`read_file\` on the target this session before \`edit_file\` / \`multi_edit\` will accept it — the tool refuses unread targets up front, so SEARCH text is grounded in on-disk bytes, not a guess. A fold / mechanical truncate clears the tracker, so re-read after one of those before mutating. \`write_file\` counts as a read for that path (the content is what you just wrote).
 - One edit per block; multiple blocks per response are fine.
 - Create a new file with empty SEARCH:
     path/to/new.ts

--- a/src/context-manager.ts
+++ b/src/context-manager.ts
@@ -68,6 +68,8 @@ export interface ContextManagerDeps {
   getAbortSignal: () => AbortSignal;
   getCurrentTurn: () => number;
   getSystemPrompt: () => string;
+  /** Fired when the message log was rewritten by fold/mechanicalTruncate; lets the loop drop session-scoped caches whose validity rested on the elided history (e.g. read-before-edit tracker). */
+  onLogRewrite?: () => void;
 }
 
 export type PostUsageDecisionKind = "none" | "fold" | "exit-with-summary";
@@ -251,6 +253,7 @@ export class ContextManager {
     const replacement = [summaryMsg, ...tail];
     this.deps.log.compactInPlace(replacement);
     this.persistRewrite(replacement);
+    this.deps.onLogRewrite?.();
     return {
       folded: true,
       beforeMessages: all.length,
@@ -315,6 +318,7 @@ export class ContextManager {
     if (replacement.length === all.length) return noop;
     this.deps.log.compactInPlace(replacement);
     this.persistRewrite(replacement);
+    this.deps.onLogRewrite?.();
     return {
       folded: true,
       beforeMessages: all.length,

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -52,6 +52,7 @@ import { type RepairReport, ToolCallRepair } from "./repair/index.js";
 import { SessionStats, type TurnStats } from "./telemetry/stats.js";
 import { ToolRegistry } from "./tools.js";
 import { parseRateLimitedToolResult } from "./tools/rate-limit.js";
+import { ReadTracker } from "./tools/read-tracker.js";
 import type { ChatMessage, ToolCall } from "./types.js";
 
 const ESCALATION_MODEL = "deepseek-v4-pro";
@@ -116,6 +117,8 @@ export class CacheFirstLoop {
   readonly scratch = new VolatileScratch();
   readonly stats = new SessionStats();
   readonly repair: ToolCallRepair;
+  /** Files the model has read this session; gates edit_file / multi_edit so SEARCH text matches on-disk bytes. Cleared on fold / mechanical truncate (the model's byte-level view of the elided history is gone). In-memory only — naturally empty on resume. */
+  readonly readTracker = new ReadTracker();
 
   // Mutable via configure() — slash commands in the TUI / library callers tweak
   // these mid-session so users don't have to restart.
@@ -265,6 +268,7 @@ export class CacheFirstLoop {
       getAbortSignal: () => this._turnAbort.signal,
       getCurrentTurn: () => this._turn,
       getSystemPrompt: () => this.prefix.system,
+      onLogRewrite: () => this.readTracker.reset(),
     });
   }
 
@@ -471,6 +475,7 @@ export class CacheFirstLoop {
         signal,
         maxResultTokens: DEFAULT_MAX_RESULT_TOKENS,
         confirmationGate: this.confirmationGate,
+        readTracker: this.readTracker,
       });
 
       const postReport = await runHooks({

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -6,12 +6,15 @@ import {
   type ToolRateLimitOption,
   ToolRateLimiter,
 } from "./tools/rate-limit.js";
+import type { ReadTracker } from "./tools/read-tracker.js";
 import type { JSONSchema, ToolSpec } from "./types.js";
 
 export interface ToolCallContext {
   signal?: AbortSignal;
   /** Inject a mock PauseGate for tests. When absent, tools use the singleton. */
   confirmationGate?: PauseGate;
+  /** Per-session tracker of files the model has read. Filesystem tools mark on read/write, edit_file/multi_edit consult before mutating. */
+  readTracker?: ReadTracker;
 }
 
 export interface ToolDefinition<A = any, R = any> {
@@ -185,6 +188,8 @@ export class ToolRegistry {
       maxResultTokens?: number;
       /** Inject a mock PauseGate for tests. */
       confirmationGate?: PauseGate;
+      /** Session-scoped read tracker; filesystem tools mark on read/write, edit_file/multi_edit gate on it. */
+      readTracker?: ReadTracker;
     } = {},
   ): Promise<string> {
     const tool = this._tools.get(name);
@@ -288,6 +293,7 @@ export class ToolRegistry {
       const result = await tool.fn(args, {
         signal: opts.signal,
         confirmationGate: opts.confirmationGate,
+        readTracker: opts.readTracker,
       });
       const str = typeof result === "string" ? result : JSON.stringify(result);
       // Pre-clip at dispatch so a single fat result can't balloon the
@@ -393,6 +399,9 @@ function plainTextRejectedReason(name: string, result: string): string | null {
   if ((name === "edit_file" || name === "write_file") && /rejected this edit/i.test(result)) {
     return "edit-gate";
   }
+  if ((name === "edit_file" || name === "multi_edit") && /read_file first/i.test(result)) {
+    return "read-before-edit";
+  }
   if ((name === "run_command" || name === "run_background") && /\buser denied:/i.test(result)) {
     return "shell-gate";
   }
@@ -403,6 +412,8 @@ function rejectionRecoveryHint(reason: string): string {
   switch (reason) {
     case "edit-gate":
       return "Do not re-emit the same edit. Try a genuinely different edit or ask the user how to proceed.";
+    case "read-before-edit":
+      return "Call read_file on the target path first, then re-issue the edit.";
     case "shell-gate":
       return "Do not retry the same command. Use an allowlisted/read-only command, wait for approval, or ask the user how to proceed.";
     case "engineering-lifecycle":

--- a/src/tools/filesystem.ts
+++ b/src/tools/filesystem.ts
@@ -282,6 +282,10 @@ export function registerFilesystemTools(
       }
 
       const { text } = decodeFileBuffer(raw);
+      // Any successful read (full, range, head, tail, outline) marks the
+      // file as seen so the edit gate accepts subsequent edits. Partial-
+      // read mistakes still fail later via "search text not found".
+      ctx?.readTracker?.markRead(abs);
       let lines = text.split(/\r?\n/);
       // Most files end with '\n' which splits into an empty trailing
       // entry; drop it so head/tail/range counts match the user's
@@ -661,6 +665,9 @@ export function registerFilesystemTools(
         // New file or unreadable — fall back to utf8.
       }
       await fs.writeFile(abs, encodeFile(args.content, encoding));
+      // Just wrote the content; the model knows what's on disk, so a
+      // follow-up edit_file shouldn't be gated for re-reading.
+      ctx?.readTracker?.markRead(abs);
       return `wrote ${args.content.length} chars to ${displayRel(rootDir, abs)}`;
     },
   });
@@ -668,7 +675,7 @@ export function registerFilesystemTools(
   registry.register({
     name: "edit_file",
     description:
-      "Apply a SEARCH/REPLACE edit to an existing file. `search` must match exactly (whitespace sensitive) — no regex. The match must be unique in the file; otherwise the edit is refused to avoid surprise rewrites.",
+      "Apply a SEARCH/REPLACE edit to an existing file. Call `read_file` on this path first this session — the tool refuses otherwise, since SEARCH must match on-disk bytes exactly. `search` is whitespace-sensitive plain text (no regex) and must be unique in the file; otherwise the edit is refused to avoid surprise rewrites.",
     parameters: {
       type: "object",
       properties: {
@@ -679,13 +686,18 @@ export function registerFilesystemTools(
       required: ["path", "search", "replace"],
     },
     fn: async (args: { path: string; search: string; replace: string }, ctx?: ToolCallContext) =>
-      applyEdit(rootDir, await safePath(args.path, "edit_file", ctx, "write"), args),
+      applyEdit(
+        rootDir,
+        await safePath(args.path, "edit_file", ctx, "write"),
+        args,
+        ctx?.readTracker ? (abs) => ctx.readTracker!.hasRead(abs) : undefined,
+      ),
   });
 
   registry.register({
     name: "multi_edit",
     description:
-      "Apply N SEARCH/REPLACE edits across ONE OR MORE files in one call. Edits validate across the full batch before writing. Validation failures leave all files untouched; disk write failures trigger best-effort rollback of files that may have been modified. Per-file edits run in array order, so a later edit can match text inserted by an earlier one. Same per-edit rules as edit_file: `search` is exact text (whitespace sensitive, no regex) and must be unique in its target file at the moment that edit applies. Use this for renames spanning multiple files, cross-file refactors, or any batch where you'd otherwise loop edit_file.",
+      "Apply N SEARCH/REPLACE edits across ONE OR MORE files in one call. Every target file must have been `read_file`'d this session — the tool refuses the whole batch otherwise. Edits validate across the full batch before writing. Validation failures leave all files untouched; disk write failures trigger best-effort rollback of files that may have been modified. Per-file edits run in array order, so a later edit can match text inserted by an earlier one. Same per-edit rules as edit_file: `search` is exact text (whitespace sensitive, no regex) and must be unique in its target file at the moment that edit applies. Use this for renames spanning multiple files, cross-file refactors, or any batch where you'd otherwise loop edit_file.",
     parameters: {
       type: "object",
       properties: {
@@ -722,7 +734,11 @@ export function registerFilesystemTools(
           replace: e?.replace,
         })),
       );
-      return applyMultiEdit(rootDir, resolved);
+      return applyMultiEdit(
+        rootDir,
+        resolved,
+        ctx?.readTracker ? (abs) => ctx.readTracker!.hasRead(abs) : undefined,
+      );
     },
   });
 

--- a/src/tools/fs/edit.ts
+++ b/src/tools/fs/edit.ts
@@ -6,13 +6,22 @@ function displayRel(rootDir: string, full: string): string {
   return pathMod.relative(rootDir, full).replaceAll("\\", "/");
 }
 
+/** Marker substring in the gate-reject message so tools.ts's repeat-rejection tracker spots a 2nd identical unread-edit and switches to the sharper "stop retrying" hint. */
+export const READ_BEFORE_EDIT_MARKER = "read_file first";
+
 export async function applyEdit(
   rootDir: string,
   abs: string,
   args: { search: string; replace: string },
+  hasRead?: (abs: string) => boolean,
 ): Promise<string> {
   if (args.search.length === 0) {
     throw new Error("edit_file: search cannot be empty");
+  }
+  if (hasRead && !hasRead(abs)) {
+    throw new Error(
+      `edit_file: ${displayRel(rootDir, abs)} was not read this session — ${READ_BEFORE_EDIT_MARKER} so your SEARCH matches the bytes on disk.`,
+    );
   }
   const beforeBuf = await fs.readFile(abs);
   const { text: before, encoding } = decodeFileBuffer(beforeBuf);
@@ -48,6 +57,7 @@ export interface MultiEditEntry {
 export async function applyMultiEdit(
   rootDir: string,
   edits: ReadonlyArray<MultiEditEntry>,
+  hasRead?: (abs: string) => boolean,
 ): Promise<string> {
   if (edits.length === 0) {
     throw new Error("multi_edit: edits must contain at least one entry");
@@ -84,6 +94,11 @@ export async function applyMultiEdit(
     }
     let state = filesByPath.get(e.abs);
     if (!state) {
+      if (hasRead && !hasRead(e.abs)) {
+        throw new Error(
+          `multi_edit: edit #${i + 1} target ${rel} was not read this session — ${READ_BEFORE_EDIT_MARKER} (no edits applied)`,
+        );
+      }
       let before: string;
       let encoding: FileEncoding;
       try {

--- a/src/tools/read-tracker.ts
+++ b/src/tools/read-tracker.ts
@@ -1,0 +1,27 @@
+import * as pathMod from "node:path";
+
+/** Tracks files the model has had byte-exact visibility into this session. `edit_file` and `multi_edit` consult it before mutating, so the SEARCH text matches the on-disk bytes the model actually saw — not what it guessed. */
+export class ReadTracker {
+  private readonly _seen = new Set<string>();
+
+  private static norm(abs: string): string {
+    const resolved = pathMod.resolve(abs);
+    return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+  }
+
+  markRead(abs: string): void {
+    this._seen.add(ReadTracker.norm(abs));
+  }
+
+  hasRead(abs: string): boolean {
+    return this._seen.has(ReadTracker.norm(abs));
+  }
+
+  reset(): void {
+    this._seen.clear();
+  }
+
+  get size(): number {
+    return this._seen.size;
+  }
+}

--- a/tests/read-before-edit-gate.test.ts
+++ b/tests/read-before-edit-gate.test.ts
@@ -1,0 +1,170 @@
+import { promises as fs } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ToolRegistry } from "../src/tools.js";
+import { registerFilesystemTools } from "../src/tools/filesystem.js";
+import { ReadTracker } from "../src/tools/read-tracker.js";
+
+describe("read-before-edit gate", () => {
+  let root: string;
+  let tools: ToolRegistry;
+  let readTracker: ReadTracker;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "reasonix-rbeg-"));
+    tools = new ToolRegistry();
+    registerFilesystemTools(tools, { rootDir: root });
+    readTracker = new ReadTracker();
+    await fs.writeFile(join(root, "hello.txt"), "alpha\nbeta\ngamma\n");
+    await fs.writeFile(join(root, "other.txt"), "one\ntwo\nthree\n");
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("edit_file refuses an unread file with a read_file hint", async () => {
+    const out = await tools.dispatch(
+      "edit_file",
+      JSON.stringify({ path: "hello.txt", search: "alpha", replace: "ALPHA" }),
+      { readTracker },
+    );
+    expect(out).toMatch(/read_file first/);
+    expect(out).toMatch(/hello\.txt/);
+    const after = await fs.readFile(join(root, "hello.txt"), "utf8");
+    expect(after).toContain("alpha");
+    expect(after).not.toContain("ALPHA");
+  });
+
+  it("edit_file succeeds after read_file marks the path", async () => {
+    await tools.dispatch("read_file", JSON.stringify({ path: "hello.txt" }), { readTracker });
+    const out = await tools.dispatch(
+      "edit_file",
+      JSON.stringify({ path: "hello.txt", search: "alpha", replace: "ALPHA" }),
+      { readTracker },
+    );
+    expect(out).toMatch(/edited hello\.txt/);
+    const after = await fs.readFile(join(root, "hello.txt"), "utf8");
+    expect(after).toContain("ALPHA");
+  });
+
+  it("write_file counts as a read for that path", async () => {
+    await tools.dispatch(
+      "write_file",
+      JSON.stringify({ path: "new.txt", content: "first line\nsecond line\n" }),
+      { readTracker },
+    );
+    const out = await tools.dispatch(
+      "edit_file",
+      JSON.stringify({ path: "new.txt", search: "first line", replace: "FIRST LINE" }),
+      { readTracker },
+    );
+    expect(out).toMatch(/edited new\.txt/);
+  });
+
+  it("read_file with range or head still marks the path (partial read accepted)", async () => {
+    await tools.dispatch("read_file", JSON.stringify({ path: "hello.txt", head: 1 }), {
+      readTracker,
+    });
+    const out = await tools.dispatch(
+      "edit_file",
+      JSON.stringify({ path: "hello.txt", search: "alpha", replace: "ALPHA" }),
+      { readTracker },
+    );
+    expect(out).toMatch(/edited hello\.txt/);
+  });
+
+  it("multi_edit refuses the whole batch when any target is unread", async () => {
+    await tools.dispatch("read_file", JSON.stringify({ path: "hello.txt" }), { readTracker });
+    const out = await tools.dispatch(
+      "multi_edit",
+      JSON.stringify({
+        edits: [
+          { path: "hello.txt", search: "alpha", replace: "ALPHA" },
+          { path: "other.txt", search: "one", replace: "ONE" },
+        ],
+      }),
+      { readTracker },
+    );
+    expect(out).toMatch(/read_file first/);
+    expect(out).toMatch(/other\.txt/);
+    const hello = await fs.readFile(join(root, "hello.txt"), "utf8");
+    expect(hello).toContain("alpha");
+    const other = await fs.readFile(join(root, "other.txt"), "utf8");
+    expect(other).toContain("one");
+  });
+
+  it("multi_edit succeeds when every target was read first", async () => {
+    await tools.dispatch("read_file", JSON.stringify({ path: "hello.txt" }), { readTracker });
+    await tools.dispatch("read_file", JSON.stringify({ path: "other.txt" }), { readTracker });
+    const out = await tools.dispatch(
+      "multi_edit",
+      JSON.stringify({
+        edits: [
+          { path: "hello.txt", search: "alpha", replace: "ALPHA" },
+          { path: "other.txt", search: "one", replace: "ONE" },
+        ],
+      }),
+      { readTracker },
+    );
+    expect(out).toMatch(/applied 2 edits across 2 files/);
+  });
+
+  it("a 2nd identical unread edit gets the sharper stop-retrying hint", async () => {
+    const first = await tools.dispatch(
+      "edit_file",
+      JSON.stringify({ path: "hello.txt", search: "alpha", replace: "ALPHA" }),
+      { readTracker },
+    );
+    expect(first).toMatch(/read_file first/);
+    const second = await tools.dispatch(
+      "edit_file",
+      JSON.stringify({ path: "hello.txt", search: "alpha", replace: "ALPHA" }),
+      { readTracker },
+    );
+    expect(second).toMatch(/do not retry identical args/i);
+    expect(second).toMatch(/Call read_file on the target path first/);
+  });
+
+  it("ReadTracker.reset clears the seen set so a fresh edit needs a fresh read", async () => {
+    await tools.dispatch("read_file", JSON.stringify({ path: "hello.txt" }), { readTracker });
+    readTracker.reset();
+    const out = await tools.dispatch(
+      "edit_file",
+      JSON.stringify({ path: "hello.txt", search: "alpha", replace: "ALPHA" }),
+      { readTracker },
+    );
+    expect(out).toMatch(/read_file first/);
+  });
+
+  it("with no readTracker injected, edits proceed (backwards-compatible)", async () => {
+    const out = await tools.dispatch(
+      "edit_file",
+      JSON.stringify({ path: "hello.txt", search: "alpha", replace: "ALPHA" }),
+    );
+    expect(out).toMatch(/edited hello\.txt/);
+  });
+});
+
+describe("ReadTracker path normalization", () => {
+  it("treats different relative spellings of the same absolute path as the same file", () => {
+    const tracker = new ReadTracker();
+    const abs = process.platform === "win32" ? "C:\\foo\\bar.txt" : "/foo/bar.txt";
+    tracker.markRead(abs);
+    expect(tracker.hasRead(abs)).toBe(true);
+    if (process.platform === "win32") {
+      expect(tracker.hasRead(abs.toUpperCase())).toBe(true);
+      expect(tracker.hasRead(abs.toLowerCase())).toBe(true);
+    }
+  });
+
+  it("size reflects unique paths only", () => {
+    const tracker = new ReadTracker();
+    tracker.markRead("/a/b.ts");
+    tracker.markRead("/a/b.ts");
+    tracker.markRead("/a/c.ts");
+    expect(tracker.size).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

- New `ReadTracker` on `CacheFirstLoop` records files the model has seen this session (via `read_file` or `write_file`).
- `edit_file` / `multi_edit` now consult it via `ToolCallContext` and refuse unread targets up front with `"<path> was not read this session — read_file first"`. `multi_edit` is all-or-nothing across the batch.
- Tracker resets on `ContextManager.fold` / `mechanicalTruncate` (new `onLogRewrite` callback) — the model's byte-level view of folded history is gone, so re-reads are required before mutating again. In-memory only, so session resume also starts empty.
- Repeat-rejection detector in `tools.ts` recognizes the gate, so a 2nd identical unread edit gets the sharper "do not retry identical args — call read_file on the target path first" instead of echoing the same refusal.
- Prompt in `src/code/prompt.ts` upgrades the soft `- read_file first so SEARCH matches byte-for-byte.` bullet to an **enforced** rule that names the gate behavior.

## Why

Soft prompt hints don't bind. A model that skips `read_file` and guesses its SEARCH text wastes a tool round on `"search text not found"`, retries with another guess, and burns cache-miss tail tokens — and the user watches it flail. Failing fast at dispatch with a clear "call read_file first" message turns a multi-round failure into a single corrective hop, and forces evidence into the prefix before any mutation.

Claude Code enforces the same gate on its `Edit` tool; aligning the contract on our side closes the most visible "agent is dumb" complaint about edits.

## Test plan

- [x] `tests/read-before-edit-gate.test.ts` — 11 new cases: refusal, post-read success, `write_file`-counts-as-read, partial-read (range/head) accepted, `multi_edit` all-or-nothing, repeat-rejection sharpening, reset semantics, backwards compat when no tracker is injected, Windows path normalization.
- [x] Full suite: `3560 passed | 16 skipped` — no regressions in `tests/preflight.test.ts`, `tests/loop.test.ts`, `tests/filesystem-tools.test.ts`, `tests/edit-blocks.test.ts`.
- [x] `tsc --noEmit` clean.
- [x] `biome check` clean on touched files.
- [x] `tests/comment-policy.test.ts` clean (gate enforced on every PR).