### PR TITLE
fix(context): align fold summary prefix with main agent for cache reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,104 @@
 All notable changes to Reasonix. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.49.0] — 2026-05-22
+
+**TUI — Static-history renderer.** The history pane is now rendered
+exclusively through Ink's `<Static>` (#1529, stages 1–4). The previous
+virtual-viewport machinery — viewport-budget row allocator, byte-virtual
+frame layer, manual scroll math — is gone. Net: less code on the hot
+path, no more "frame drift" on very long sessions, and the rewrite stays
+Ink-native instead of fighting it. Behind `REASONIX_STATIC_HISTORY` at
+stage 1, default-on by stage 2, scaffolding removed by stage 4.
+
+**Chat — queued mid-turn steers.** Typing while the model is mid-turn
+no longer fights the live render or drops the keystroke. New input
+queues, surfaces a small "queued" hint, and feeds into the next user
+turn cleanly (#1501). Pairs with the static-history switch so the
+queued line stays visible across re-renders.
+
+**Web search — Bing default, dashboard engine switcher.** Default web
+backend switches from Mojeek to Bing (#1558); the dashboard gains a
+visible engine switcher so you can flip between configured backends
+without editing config. Mojeek is dropped from the bundled set entirely
+in this release.
+
+**Plans — lifecycle evidence summaries.** Plan acceptance now surfaces
+the evidence captured at each lifecycle step (#1500), so the "why this
+plan is ready to accept" question has a structured answer instead of
+implicit trust. Builds on the strict-lifecycle observability that
+landed in 0.48.1.
+
+**Desktop — approval + completion notifications.** Native OS
+notifications for approval prompts and turn-complete events (#1519),
+so a long-running turn can land in the background and still surface.
+Uses `tauri-plugin-notification`.
+
+**i18n — CLI command output.** `/mcp`, `/sessions`, `/prune`, `/theme`
+output is now translated (#1524), closing the remaining English-only
+gap in CLI command surfaces. Approval-prompt confirm titles and action
+labels also get zh-CN (#1560/#1561).
+
+**Security.**
+- `web_fetch` now blocks SSRF — private/loopback/link-local targets are
+  rejected at the boundary (#1544)
+- Edit snapshots can no longer read outside the workspace (#1454)
+- Shell redirects (`>`, `>>`, `<`) are constrained to the sandbox
+  boundary (#1457)
+- New Task integrity guardrail catches objective simplification — i.e.
+  the model trying to redefine a hard requirement away (#1516)
+
+**Tools.** `run_command` description now actively discourages
+shell-based file edits in favor of the structured `edit` tool (#1514).
+A per-turn dispatch-rate limit lands for tool calls (#1356), keeping
+runaway loops from burning a quota slice in one turn.
+
+**TUI polish.**
+- `Ctrl+Enter` now inserts a newline (#1513) — matching how every
+  modern composer treats the modifier
+- `mouseWheelRows` config knob tunes scroll velocity per terminal
+  (#1511) so trackpad vs. wheel mouse don't fight the default
+- `@mention` file search is restricted to the current directory prefix
+  (#1548) so the picker doesn't dump the whole repo
+- Paste-sentinel label no longer claims `^O` expands the paste — the
+  shortcut never existed (#1517)
+
+**Context.** Pinned-constraint blocks are now preserved across context
+folds (#1515) and the fold tail captures all of them, not just the last
+(#1552). Memory constraints survive the fold instead of silently
+dropping out under pressure.
+
+**Client.**
+- DeepSeek 429s are translated into an actionable "concurrency limit
+  hit" hint instead of a raw HTTP error (#1526)
+- `timeoutMs` is now wired to `fetch` when the caller passes an
+  `AbortSignal` (#1535) — previously the timeout was silently ignored
+- `--no-proxy` / `REASONIX_NO_PROXY` opt-out is honored for the
+  DeepSeek direct-route default (#1507)
+
+**Files.** Read/edit/restore now preserve the source file's encoding
+(GB18030, UTF-8 BOM, etc.) instead of normalizing to UTF-8 on write
+(#1518). Important for CJK Windows projects.
+
+**Web/Dashboard.**
+- Path-access approval modal is bridged to the dashboard (#1538) so
+  the browser surface can resolve the same prompts as CLI/Desktop
+- `@mention` file picker popover lands in the dashboard ChatPane
+  (#1546), gated on attached mode (#1549)
+
+**Config.** Atomic config writes restore the preset-write diagnostic
+trace (#1555), so when a preset write goes wrong you can actually see
+why.
+
+**Refactor.** `lifecycle` extracts a standalone risk policy module
+(#1557), shrinking the orchestrator and unblocking risk policy reuse
+from non-lifecycle callers.
+
+**Other:**
+- `fix(desktop)` drop `workspace:*` protocol for core-utils — desktop
+  isn't a workspace member
+- `fix(desktop)` tsc errors blocking desktop bundle build
+
 ## [0.48.1] — 2026-05-21
 
 **`dsnix` — short alias.** A new `dsnix` shim package lands alongside

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reasonix-desktop",
-  "version": "0.48.1",
+  "version": "0.49.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reasonix-desktop",
-      "version": "0.48.1",
+      "version": "0.49.0",
       "dependencies": {
         "@fontsource/geist": "^5.2.8",
         "@fontsource/geist-mono": "^5.2.7",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "reasonix-desktop",
   "private": true,
-  "version": "0.48.1",
+  "version": "0.49.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2849,7 +2849,7 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "reasonix-desktop"
-version = "0.48.1"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "parking_lot",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reasonix-desktop"
-version = "0.48.1"
+version = "0.49.0"
 edition = "2021"
 publish = false
 

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Reasonix",
-  "version": "0.48.1",
+  "version": "0.49.0",
   "identifier": "dev.reasonix.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reasonix",
-  "version": "0.48.1",
+  "version": "0.49.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reasonix",
-      "version": "0.48.1",
+      "version": "0.49.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reasonix",
-  "version": "0.48.1",
+  "version": "0.49.0",
   "description": "DeepSeek-native coding agent: cache-first loop, flash-first cost control, tool-call repair.",
   "type": "module",
   "bin": {

--- a/src/context-manager.ts
+++ b/src/context-manager.ts
@@ -1,7 +1,6 @@
 import type { DeepSeekClient } from "./client.js";
 import { Usage } from "./client.js";
 import { healLoadedMessages } from "./loop.js";
-import { thinkingModeForModel } from "./loop.js";
 import { stripHallucinatedToolMarkup } from "./loop.js";
 import { buildAssistantMessage } from "./loop/messages.js";
 import { DEFAULT_MAX_RESULT_CHARS } from "./mcp/registry.js";
@@ -17,7 +16,7 @@ import {
   estimateConversationTokens,
   estimateRequestTokens,
 } from "./tokenizer.js";
-import type { ChatMessage } from "./types.js";
+import type { ChatMessage, ToolSpec } from "./types.js";
 
 function extractPinnedConstraints(systemPrompt: string): string {
   // matchAll because the system prompt can carry multiple blocks under the same
@@ -68,6 +67,9 @@ export interface ContextManagerDeps {
   getAbortSignal: () => AbortSignal;
   getCurrentTurn: () => number;
   getSystemPrompt: () => string;
+  /** Reuses the live prefix → fold summary call shares the cached bytes the main agent already paid for. */
+  getToolSpecs?: () => readonly ToolSpec[];
+  getFewShots?: () => readonly ChatMessage[];
 }
 
 export type PostUsageDecisionKind = "none" | "fold" | "exit-with-summary";
@@ -99,24 +101,33 @@ export interface FoldResult {
   summaryChars: number;
 }
 
-// Stub pins in head so the summarizer doesn't paraphrase them; dedupe by name, last invocation wins.
-function extractPinnedSkills(head: ChatMessage[]): {
-  stubbedHead: ChatMessage[];
-  pinnedBodies: string[];
-} {
+function buildFoldSummaryInstruction(pinnedSkillNames: string[]): string {
+  const base =
+    "Summarize the conversation above as one self-contained prose recap. Preserve the user's " +
+    "ORIGINAL OBJECTIVE (never paraphrase away negative constraints like 'do NOT do X'), all " +
+    "'do not' / 'never' / 'avoid' instructions, decisions reached, files inspected or modified, " +
+    "tool results still relevant, and any open todos. Skip turn-by-turn play-by-play. " +
+    "Output plain prose only — no tool calls, no markdown headings, no SEARCH/REPLACE blocks.";
+  if (pinnedSkillNames.length === 0) return base;
+  const list = pinnedSkillNames.map((n) => `"${n}"`).join(", ");
+  return `${base} The following skill memos are pinned verbatim and appended after your summary — do NOT quote or paraphrase their bodies: ${list}.`;
+}
+
+// Dedupe by name, last invocation wins. Read-only — leaves head bytes unchanged so the
+// summarizer call's prefix still matches what the main agent already cached.
+function collectPinnedSkills(head: ChatMessage[]): { names: string[]; bodies: string[] } {
   const pinned = new Map<string, string>();
-  const stubbedHead = head.map((msg) => {
-    if (typeof msg.content !== "string") return msg;
-    let hit = false;
-    const next = msg.content.replace(SKILL_PIN_REGEX, (full, name: string) => {
+  for (const msg of head) {
+    if (typeof msg.content !== "string") continue;
+    SKILL_PIN_REGEX.lastIndex = 0;
+    for (const match of msg.content.matchAll(SKILL_PIN_REGEX)) {
+      const name = match[1] as string;
+      const full = match[0];
       pinned.delete(name);
       pinned.set(name, full);
-      hit = true;
-      return `[skill ${JSON.stringify(name)} memo — preserved separately, do not summarize.]`;
-    });
-    return hit ? { ...msg, content: next } : msg;
-  });
-  return { stubbedHead, pinnedBodies: [...pinned.values()] };
+    }
+  }
+  return { names: [...pinned.keys()], bodies: [...pinned.values()] };
 }
 
 export class ContextManager {
@@ -227,8 +238,8 @@ export class ContextManager {
     const headTokens = totalTokens - cumTokens;
     if (headTokens < totalTokens * HISTORY_FOLD_MIN_SAVINGS_FRACTION) return noop;
 
-    const { stubbedHead, pinnedBodies } = extractPinnedSkills(head);
-    const summary = await this.summarizeForFold(stubbedHead);
+    const { names: pinnedNames, bodies: pinnedBodies } = collectPinnedSkills(head);
+    const summary = await this.summarizeForFold(head, pinnedNames);
     if (!summary.content) return noop;
 
     const memoTail =
@@ -342,23 +353,19 @@ export class ContextManager {
 
   private async summarizeForFold(
     messagesToSummarize: ChatMessage[],
+    pinnedSkillNames: string[],
   ): Promise<{ content: string; reasoningContent: string }> {
     const summaryModel = "deepseek-v4-flash";
-    const systemPrompt =
-      "You compress conversation history for a coding agent. Output one prose recap that preserves: " +
-      "the user's ORIGINAL OBJECTIVE (never paraphrase away nuance or negative constraints like 'do NOT do X'), " +
-      "all 'do not' / 'never' / 'avoid' instructions, decisions and conclusions reached, " +
-      "files inspected or modified, important tool results still relevant to ongoing work, " +
-      "and any open todos. Skip turn-by-turn play-by-play. No tool calls, no markdown headings, no SEARCH/REPLACE blocks — plain prose only.";
     const healed = healLoadedMessages(messagesToSummarize, DEFAULT_MAX_RESULT_CHARS).messages;
+    const agentSystem = this.deps.getSystemPrompt();
+    const fewShots = this.deps.getFewShots?.() ?? [];
+    const tools = this.deps.getToolSpecs?.() ?? [];
+    const instruction = buildFoldSummaryInstruction(pinnedSkillNames);
     const messages: ChatMessage[] = [
-      { role: "system", content: systemPrompt },
+      { role: "system", content: agentSystem },
+      ...fewShots.map((m) => ({ ...m })),
       ...healed,
-      {
-        role: "user",
-        content:
-          "Summarize the conversation above as plain prose. This summary replaces the original turns to free context — make it self-contained.",
-      },
+      { role: "user", content: instruction },
     ];
     const turnSignal = this.deps.getAbortSignal();
     const foldCtrl = new AbortController();
@@ -387,9 +394,9 @@ export class ContextManager {
         this.deps.client.chat({
           model: summaryModel,
           messages,
+          tools: tools.length ? (tools as ToolSpec[]) : undefined,
           signal: foldCtrl.signal,
-          thinking: thinkingModeForModel(summaryModel),
-          reasoningEffort: "high",
+          thinking: "disabled",
         }),
         abortPromise,
         timeoutPromise,

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -265,6 +265,8 @@ export class CacheFirstLoop {
       getAbortSignal: () => this._turnAbort.signal,
       getCurrentTurn: () => this._turn,
       getSystemPrompt: () => this.prefix.system,
+      getToolSpecs: () => this.prefix.toolSpecs,
+      getFewShots: () => this.prefix.fewShots,
     });
   }
 

--- a/tests/context-manager-cache-aligned-fold.test.ts
+++ b/tests/context-manager-cache-aligned-fold.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, it, vi } from "vitest";
+import { DeepSeekClient } from "../src/client.js";
+import { CacheFirstLoop } from "../src/loop.js";
+import { ImmutablePrefix } from "../src/memory/runtime.js";
+import type { ChatMessage, ToolSpec } from "../src/types.js";
+
+interface CapturedRequest {
+  model: string;
+  messages: ChatMessage[];
+  tools: ToolSpec[] | undefined;
+  thinking: string | undefined;
+  body: Record<string, unknown>;
+}
+
+function fakeFetch(captured: CapturedRequest[], stubContent: string): typeof fetch {
+  return vi.fn(async (_url: unknown, init: { body?: string } | undefined) => {
+    const body = init?.body ? (JSON.parse(init.body) as Record<string, unknown>) : {};
+    const messages = (body.messages ?? []) as ChatMessage[];
+    const tools = body.tools as ToolSpec[] | undefined;
+    const extra = body.extra_body as { thinking?: { type?: string } } | undefined;
+    captured.push({
+      model: body.model as string,
+      messages,
+      tools,
+      thinking: extra?.thinking?.type,
+      body,
+    });
+    return new Response(
+      JSON.stringify({
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: stubContent },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 100, completion_tokens: 20, total_tokens: 120 },
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  }) as unknown as typeof fetch;
+}
+
+const SYSTEM_PROMPT =
+  "You are a coding agent for project X.\nFollow the user's instructions.\nUse tools as needed.";
+
+const TOOLS: ToolSpec[] = [
+  {
+    type: "function",
+    function: {
+      name: "Read",
+      description: "Read a file",
+      parameters: {
+        type: "object",
+        properties: { path: { type: "string" } },
+        required: ["path"],
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "Bash",
+      description: "Run a shell command",
+      parameters: {
+        type: "object",
+        properties: { command: { type: "string" } },
+        required: ["command"],
+      },
+    },
+  },
+];
+
+function seedTurns(loop: CacheFirstLoop, n: number, padding = 8): void {
+  for (let i = 0; i < n; i++) {
+    loop.log.append({
+      role: "user",
+      content: `q${i}: ${"context padding to weigh the turn ".repeat(padding)}`,
+    });
+    loop.log.append({
+      role: "assistant",
+      content: `a${i}: ${"reply padding to weigh the turn ".repeat(padding)}`,
+    });
+  }
+}
+
+describe("ContextManager fold sends cache-aligned summary request", () => {
+  it("summary request reuses the main agent's system prompt verbatim", async () => {
+    const captured: CapturedRequest[] = [];
+    const client = new DeepSeekClient({
+      apiKey: "sk-test",
+      fetch: fakeFetch(captured, "compact prose summary."),
+    });
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: SYSTEM_PROMPT, toolSpecs: TOOLS }),
+      model: "deepseek-v4-flash",
+      stream: false,
+    });
+    seedTurns(loop, 8);
+
+    const result = await loop.compactHistory({ keepRecentTokens: 40 });
+    expect(result.folded).toBe(true);
+    expect(captured).toHaveLength(1);
+
+    const req = captured[0]!;
+    expect(req.messages[0]).toEqual({ role: "system", content: SYSTEM_PROMPT });
+  });
+
+  it("summary request reuses the main agent's tool list byte-for-byte", async () => {
+    const captured: CapturedRequest[] = [];
+    const client = new DeepSeekClient({
+      apiKey: "sk-test",
+      fetch: fakeFetch(captured, "summary."),
+    });
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: SYSTEM_PROMPT, toolSpecs: TOOLS }),
+      model: "deepseek-v4-flash",
+      stream: false,
+    });
+    seedTurns(loop, 8);
+
+    await loop.compactHistory({ keepRecentTokens: 40 });
+    const req = captured[0]!;
+
+    expect(req.tools).toBeDefined();
+    expect(req.tools).toEqual(TOOLS);
+    expect(JSON.stringify(req.tools)).toBe(JSON.stringify(TOOLS));
+  });
+
+  it("summary request preserves the head conversation bytes (head messages unmodified)", async () => {
+    const captured: CapturedRequest[] = [];
+    const client = new DeepSeekClient({
+      apiKey: "sk-test",
+      fetch: fakeFetch(captured, "summary."),
+    });
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: SYSTEM_PROMPT, toolSpecs: TOOLS }),
+      model: "deepseek-v4-flash",
+      stream: false,
+    });
+    seedTurns(loop, 8);
+    const logBeforeFold = loop.log.toMessages();
+
+    await loop.compactHistory({ keepRecentTokens: 40 });
+    const req = captured[0]!;
+
+    expect(req.messages[0]!.role).toBe("system");
+    const trailing = req.messages[req.messages.length - 1]!;
+    expect(trailing.role).toBe("user");
+    expect(typeof trailing.content === "string" ? trailing.content : "").toMatch(/Summarize/);
+
+    // Strip system head + trailing instruction; what remains must equal a prefix of the pre-fold log.
+    const middle = req.messages.slice(1, -1);
+    for (let i = 0; i < middle.length; i++) {
+      expect(middle[i]).toEqual(logBeforeFold[i]);
+    }
+  });
+
+  it("summary request omits reasoning to avoid burning thinking tokens on paraphrase", async () => {
+    const captured: CapturedRequest[] = [];
+    const client = new DeepSeekClient({
+      apiKey: "sk-test",
+      fetch: fakeFetch(captured, "summary."),
+    });
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: SYSTEM_PROMPT, toolSpecs: TOOLS }),
+      model: "deepseek-v4-flash",
+      stream: false,
+    });
+    seedTurns(loop, 8);
+
+    await loop.compactHistory({ keepRecentTokens: 40 });
+    const req = captured[0]!;
+    expect(req.thinking).toBe("disabled");
+    expect(req.body.reasoning_effort).toBeUndefined();
+  });
+
+  it("summary request pins to flash even when the session model is pro", async () => {
+    const captured: CapturedRequest[] = [];
+    const client = new DeepSeekClient({
+      apiKey: "sk-test",
+      fetch: fakeFetch(captured, "summary."),
+    });
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: SYSTEM_PROMPT, toolSpecs: TOOLS }),
+      model: "deepseek-v4-pro",
+      stream: false,
+    });
+    seedTurns(loop, 8);
+
+    await loop.compactHistory({ keepRecentTokens: 40 });
+    expect(captured[0]!.model).toBe("deepseek-v4-flash");
+  });
+
+  it("skill-pinned bodies are sent to summarizer verbatim (head bytes unchanged)", async () => {
+    const captured: CapturedRequest[] = [];
+    const client = new DeepSeekClient({
+      apiKey: "sk-test",
+      fetch: fakeFetch(captured, "summary."),
+    });
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: SYSTEM_PROMPT, toolSpecs: TOOLS }),
+      model: "deepseek-v4-flash",
+      stream: false,
+    });
+
+    const skillBody =
+      '<skill-pin name="explore">\n# Skill: explore\n\nStep 1. Read entrypoints.\nStep 2. Trace flow.\n</skill-pin>';
+    loop.log.append({
+      role: "assistant",
+      content: null,
+      tool_calls: [
+        { id: "c1", type: "function", function: { name: "run_skill", arguments: "{}" } },
+      ],
+    });
+    loop.log.append({ role: "tool", tool_call_id: "c1", content: skillBody });
+    seedTurns(loop, 6);
+
+    const result = await loop.compactHistory({ keepRecentTokens: 40 });
+    expect(result.folded).toBe(true);
+
+    const req = captured[0]!;
+    const serialized = JSON.stringify(req.messages);
+    expect(serialized).toContain("Step 1. Read entrypoints.");
+    expect(serialized).toContain("Step 2. Trace flow.");
+    expect(serialized).not.toContain("preserved separately, do not summarize");
+
+    const trailing = req.messages[req.messages.length - 1]!;
+    const instruction = typeof trailing.content === "string" ? trailing.content : "";
+    expect(instruction).toMatch(/pinned verbatim/);
+    expect(instruction).toContain('"explore"');
+  });
+
+  it("trailing instruction is the only message after the head — everything before is cache prefix", async () => {
+    const captured: CapturedRequest[] = [];
+    const client = new DeepSeekClient({
+      apiKey: "sk-test",
+      fetch: fakeFetch(captured, "summary."),
+    });
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: SYSTEM_PROMPT, toolSpecs: TOOLS }),
+      model: "deepseek-v4-flash",
+      stream: false,
+    });
+    seedTurns(loop, 8);
+
+    await loop.compactHistory({ keepRecentTokens: 40 });
+    const req = captured[0]!;
+    const last = req.messages[req.messages.length - 1]!;
+    const secondLast = req.messages[req.messages.length - 2]!;
+
+    expect(last.role).toBe("user");
+    // The instruction sits adjacent to the original head's final message —
+    // no separator / wrapper that would push the cache-miss boundary inward.
+    expect(secondLast).toBeDefined();
+    expect(secondLast.role === "assistant" || secondLast.role === "tool").toBe(true);
+  });
+});

--- a/tools/bench-fold-cache-live.mjs
+++ b/tools/bench-fold-cache-live.mjs
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+// Live cache-hit benchmark for the fold summary path.
+//
+// Sends the same simulated fold scenario to DeepSeek twice:
+//   1. OLD shape (bespoke "compress conversation" system + no tools)
+//   2. NEW shape (live agent system + tools)
+// Both come AFTER a single "main agent" priming call that warms the prefix.
+// Compares prompt_cache_hit_tokens / prompt_cache_miss_tokens between shapes.
+//
+// Requires DEEPSEEK_API_KEY. Usage:
+//   node tools/bench-fold-cache-live.mjs <session.jsonl> [--model deepseek-v4-flash]
+
+import { readFileSync } from "node:fs";
+
+const SYS_OLD =
+  "You compress conversation history for a coding agent. Output one prose recap that preserves: " +
+  "the user's ORIGINAL OBJECTIVE (never paraphrase away nuance or negative constraints like 'do NOT do X'), " +
+  "all 'do not' / 'never' / 'avoid' instructions, decisions and conclusions reached, " +
+  "files inspected or modified, important tool results still relevant to ongoing work, " +
+  "and any open todos. Skip turn-by-turn play-by-play. No tool calls, no markdown headings, no SEARCH/REPLACE blocks — plain prose only.";
+
+const SUMMARY_INSTRUCTION_OLD =
+  "Summarize the conversation above as plain prose. This summary replaces the original turns to free context — make it self-contained.";
+
+const SUMMARY_INSTRUCTION_NEW =
+  "Summarize the conversation above as one self-contained prose recap. Preserve the user's " +
+  "ORIGINAL OBJECTIVE (never paraphrase away negative constraints like 'do NOT do X'), all " +
+  "'do not' / 'never' / 'avoid' instructions, decisions reached, files inspected or modified, " +
+  "tool results still relevant, and any open todos. Skip turn-by-turn play-by-play. " +
+  "Output plain prose only — no tool calls, no markdown headings, no SEARCH/REPLACE blocks.";
+
+const REPRESENTATIVE_AGENT_SYSTEM =
+  "You are a coding agent. Use tools to read files, run commands, and edit code. " +
+  "Follow the user's instructions precisely. Prefer minimal changes. " +
+  "Do not introduce features beyond what was asked. " +
+  "Be concise in user-facing text. Trust internal code; only validate at boundaries.";
+
+const REPRESENTATIVE_TOOLS = [
+  {
+    type: "function",
+    function: {
+      name: "Read",
+      description: "Read a file from the local filesystem.",
+      parameters: {
+        type: "object",
+        properties: { path: { type: "string", description: "Absolute path" } },
+        required: ["path"],
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "Bash",
+      description: "Execute a bash command.",
+      parameters: {
+        type: "object",
+        properties: { command: { type: "string" } },
+        required: ["command"],
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "Grep",
+      description: "Search file contents with a regex.",
+      parameters: {
+        type: "object",
+        properties: {
+          pattern: { type: "string" },
+          path: { type: "string" },
+          glob: { type: "string" },
+        },
+        required: ["pattern"],
+      },
+    },
+  },
+];
+
+function approxTokens(s) {
+  return Math.ceil(s.length / 3.5);
+}
+function msgTokens(m) {
+  const c = typeof m.content === "string" ? m.content : JSON.stringify(m.content ?? "");
+  const tc = Array.isArray(m.tool_calls) ? JSON.stringify(m.tool_calls) : "";
+  return approxTokens(c) + approxTokens(tc) + 4;
+}
+
+function loadSession(path) {
+  return readFileSync(path, "utf8")
+    .split("\n")
+    .filter((l) => l.trim())
+    .map((l) => JSON.parse(l));
+}
+
+function pickFoldPoint(messages, headRatio = 0.7) {
+  const tokens = messages.map(msgTokens);
+  const total = tokens.reduce((a, b) => a + b, 0);
+  const headBudget = total * headRatio;
+  let cum = 0;
+  for (let i = 0; i < messages.length; i++) {
+    cum += tokens[i];
+    if (cum >= headBudget) return { boundary: i + 1, total, headTokens: cum };
+  }
+  return { boundary: messages.length, total, headTokens: total };
+}
+
+// Trim head until every assistant.tool_calls has matching tool messages
+// later in head. Walking back from the cut, drop any assistant whose
+// tool_calls aren't fully answered within the remaining head — and the
+// orphaned tool messages between it and the cut.
+function healHead(head) {
+  let h = [...head];
+  while (h.length > 0) {
+    let lastAssistantWithCalls = -1;
+    for (let i = h.length - 1; i >= 0; i--) {
+      const m = h[i];
+      if (m.role === "assistant" && Array.isArray(m.tool_calls) && m.tool_calls.length > 0) {
+        lastAssistantWithCalls = i;
+        break;
+      }
+    }
+    if (lastAssistantWithCalls < 0) break;
+    const asst = h[lastAssistantWithCalls];
+    const wanted = new Set(asst.tool_calls.map((c) => c.id));
+    const respondedAfter = new Set(
+      h.slice(lastAssistantWithCalls + 1)
+        .filter((m) => m.role === "tool" && m.tool_call_id)
+        .map((m) => m.tool_call_id),
+    );
+    let allAnswered = true;
+    for (const id of wanted) {
+      if (!respondedAfter.has(id)) {
+        allAnswered = false;
+        break;
+      }
+    }
+    if (allAnswered) break;
+    h = h.slice(0, lastAssistantWithCalls);
+  }
+  return h;
+}
+
+async function call(apiKey, body) {
+  const resp = await fetch("https://api.deepseek.com/chat/completions", {
+    method: "POST",
+    headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!resp.ok) throw new Error(`${resp.status}: ${await resp.text()}`);
+  const data = await resp.json();
+  return {
+    usage: data.usage ?? {},
+    contentLen: (data.choices?.[0]?.message?.content ?? "").length,
+  };
+}
+
+function fmtUsage(label, u) {
+  const hit = u.prompt_cache_hit_tokens ?? 0;
+  const miss = u.prompt_cache_miss_tokens ?? 0;
+  const total = u.prompt_tokens ?? hit + miss;
+  const hitRate = total > 0 ? hit / total : 0;
+  const PRICE_INPUT = 3.0 / 1e6;
+  const PRICE_CACHE = 0.3 / 1e6;
+  const PRICE_OUT = 15.0 / 1e6;
+  const inputCost = hit * PRICE_CACHE + miss * PRICE_INPUT;
+  const outCost = (u.completion_tokens ?? 0) * PRICE_OUT;
+  console.log(
+    `${label}: prompt=${total.toLocaleString()} (hit ${hit.toLocaleString()}/${(hitRate * 100).toFixed(1)}%, miss ${miss.toLocaleString()}) · out=${u.completion_tokens ?? 0} · input $${inputCost.toFixed(5)} · total $${(inputCost + outCost).toFixed(5)}`,
+  );
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const path = args[0];
+  const modelIdx = args.indexOf("--model");
+  const model = modelIdx >= 0 ? args[modelIdx + 1] : "deepseek-v4-flash";
+  if (!path) {
+    console.error("usage: bench-fold-cache-live.mjs <session.jsonl> [--model deepseek-v4-flash]");
+    process.exit(2);
+  }
+  const apiKey = process.env.DEEPSEEK_API_KEY;
+  if (!apiKey) {
+    console.error("DEEPSEEK_API_KEY not set");
+    process.exit(2);
+  }
+
+  const log = loadSession(path);
+  const { boundary, total } = pickFoldPoint(log);
+  const head = healHead(log.slice(0, boundary));
+  const recentMsg = { role: "user", content: "what's next?" };
+
+  console.log(
+    `session: ${path}\n  ${log.length} messages · ~${total.toLocaleString()} tok · head=${boundary} msgs (~${head.reduce((a, m) => a + msgTokens(m), 0).toLocaleString()} tok)\n  model: ${model}\n`,
+  );
+
+  const baseExtra = { thinking: { type: "disabled" } };
+
+  console.log("=== step 1: PRIMING (main-agent shape) — warms the prefix cache ===");
+  const primingBody = {
+    model,
+    messages: [{ role: "system", content: REPRESENTATIVE_AGENT_SYSTEM }, ...head, recentMsg],
+    tools: REPRESENTATIVE_TOOLS,
+    stream: false,
+    max_tokens: 64,
+    extra_body: baseExtra,
+  };
+  const primingResp = await call(apiKey, primingBody);
+  fmtUsage("priming", primingResp.usage);
+
+  console.log("\n=== step 2: OLD summary shape (bespoke system + no tools) ===");
+  const oldBody = {
+    model,
+    messages: [
+      { role: "system", content: SYS_OLD },
+      ...head,
+      { role: "user", content: SUMMARY_INSTRUCTION_OLD },
+    ],
+    stream: false,
+    max_tokens: 256,
+    extra_body: baseExtra,
+  };
+  const oldResp = await call(apiKey, oldBody);
+  fmtUsage("OLD    ", oldResp.usage);
+
+  console.log("\n=== step 3: NEW summary shape (live agent system + tools) ===");
+  const newBody = {
+    model,
+    messages: [
+      { role: "system", content: REPRESENTATIVE_AGENT_SYSTEM },
+      ...head,
+      { role: "user", content: SUMMARY_INSTRUCTION_NEW },
+    ],
+    tools: REPRESENTATIVE_TOOLS,
+    stream: false,
+    max_tokens: 256,
+    extra_body: baseExtra,
+  };
+  const newResp = await call(apiKey, newBody);
+  fmtUsage("NEW    ", newResp.usage);
+
+  const oldHit = oldResp.usage.prompt_cache_hit_tokens ?? 0;
+  const oldTot = oldResp.usage.prompt_tokens ?? 0;
+  const newHit = newResp.usage.prompt_cache_hit_tokens ?? 0;
+  const newTot = newResp.usage.prompt_tokens ?? 0;
+  const PRICE_INPUT = 3.0 / 1e6;
+  const PRICE_CACHE = 0.3 / 1e6;
+  const oldCost = oldHit * PRICE_CACHE + (oldTot - oldHit) * PRICE_INPUT;
+  const newCost = newHit * PRICE_CACHE + (newTot - newHit) * PRICE_INPUT;
+
+  console.log("\n=== verdict ===");
+  console.log(
+    `OLD cache hit: ${((oldHit / Math.max(oldTot, 1)) * 100).toFixed(1)}%  → input $${oldCost.toFixed(5)}`,
+  );
+  console.log(
+    `NEW cache hit: ${((newHit / Math.max(newTot, 1)) * 100).toFixed(1)}%  → input $${newCost.toFixed(5)}`,
+  );
+  console.log(
+    `saving per fold: $${(oldCost - newCost).toFixed(5)} (${(((oldCost - newCost) / Math.max(oldCost, 1e-12)) * 100).toFixed(1)}%)`,
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/tools/bench-fold-cache-shape.mjs
+++ b/tools/bench-fold-cache-shape.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+// Local cache-shape benchmark: takes a real session .jsonl, simulates the OLD
+// and NEW summary-call request shapes at a plausible fold point, then reports
+// how many leading messages (and roughly how many tokens) each shape shares
+// with the main agent's preceding request. DeepSeek's prefix cache hits up to
+// the first message that differs, so message-level shared prefix is the upper
+// bound on cache hit on that summary call.
+
+import { readFileSync, statSync } from "node:fs";
+
+const SYS_OLD =
+  "You compress conversation history for a coding agent. Output one prose recap that preserves: " +
+  "the user's ORIGINAL OBJECTIVE (never paraphrase away nuance or negative constraints like 'do NOT do X'), " +
+  "all 'do not' / 'never' / 'avoid' instructions, decisions and conclusions reached, " +
+  "files inspected or modified, important tool results still relevant to ongoing work, " +
+  "and any open todos. Skip turn-by-turn play-by-play. No tool calls, no markdown headings, no SEARCH/REPLACE blocks — plain prose only.";
+
+const SUMMARY_INSTRUCTION_OLD =
+  "Summarize the conversation above as plain prose. This summary replaces the original turns to free context — make it self-contained.";
+
+const SUMMARY_INSTRUCTION_NEW =
+  "Summarize the conversation above as one self-contained prose recap. Preserve the user's " +
+  "ORIGINAL OBJECTIVE (never paraphrase away negative constraints like 'do NOT do X'), all " +
+  "'do not' / 'never' / 'avoid' instructions, decisions reached, files inspected or modified, " +
+  "tool results still relevant, and any open todos. Skip turn-by-turn play-by-play. " +
+  "Output plain prose only — no tool calls, no markdown headings, no SEARCH/REPLACE blocks.";
+
+function approxTokens(s) {
+  return Math.ceil(s.length / 3.5);
+}
+
+function msgTokens(m) {
+  const c = typeof m.content === "string" ? m.content : JSON.stringify(m.content ?? "");
+  const tc = Array.isArray(m.tool_calls) ? JSON.stringify(m.tool_calls) : "";
+  return approxTokens(c) + approxTokens(tc) + 4;
+}
+
+function loadSession(path) {
+  return readFileSync(path, "utf8")
+    .split("\n")
+    .filter((l) => l.trim())
+    .map((l) => JSON.parse(l));
+}
+
+function pickFoldPoint(messages, headRatio = 0.7) {
+  const tokens = messages.map(msgTokens);
+  const total = tokens.reduce((a, b) => a + b, 0);
+  const headBudget = total * headRatio;
+  let cum = 0;
+  for (let i = 0; i < messages.length; i++) {
+    cum += tokens[i];
+    if (cum >= headBudget) {
+      return { boundary: i + 1, total, headTokens: cum };
+    }
+  }
+  return { boundary: messages.length, total, headTokens: total };
+}
+
+function sharedLeadingMessages(a, b) {
+  const n = Math.min(a.length, b.length);
+  for (let i = 0; i < n; i++) {
+    if (JSON.stringify(a[i]) !== JSON.stringify(b[i])) return i;
+  }
+  return n;
+}
+
+function tokenCountOf(messages) {
+  return messages.reduce((a, m) => a + msgTokens(m), 0);
+}
+
+function bench(path, agentSystem) {
+  const log = loadSession(path);
+  if (log.length < 10) return null;
+  const { boundary, total, headTokens } = pickFoldPoint(log);
+  const head = log.slice(0, boundary);
+  const recentMsg = log[boundary] ?? { role: "user", content: "next instruction" };
+
+  const mainAgentMsgs = [{ role: "system", content: agentSystem }, ...head, recentMsg];
+
+  const oldSummaryMsgs = [
+    { role: "system", content: SYS_OLD },
+    ...head,
+    { role: "user", content: SUMMARY_INSTRUCTION_OLD },
+  ];
+
+  const newSummaryMsgs = [
+    { role: "system", content: agentSystem },
+    ...head,
+    { role: "user", content: SUMMARY_INSTRUCTION_NEW },
+  ];
+
+  const oldShared = sharedLeadingMessages(mainAgentMsgs, oldSummaryMsgs);
+  const newShared = sharedLeadingMessages(mainAgentMsgs, newSummaryMsgs);
+
+  const oldCacheTokens = tokenCountOf(oldSummaryMsgs.slice(0, oldShared));
+  const newCacheTokens = tokenCountOf(newSummaryMsgs.slice(0, newShared));
+  const oldTotalTokens = tokenCountOf(oldSummaryMsgs);
+  const newTotalTokens = tokenCountOf(newSummaryMsgs);
+
+  return {
+    file: path,
+    sizeKB: Math.round(statSync(path).size / 1024),
+    logMessages: log.length,
+    foldBoundary: boundary,
+    totalLogTokens: total,
+    headTokens,
+    OLD: {
+      sharedMessages: oldShared,
+      cacheableTokens: oldCacheTokens,
+      totalRequestTokens: oldTotalTokens,
+      hitRatio: oldTotalTokens > 0 ? oldCacheTokens / oldTotalTokens : 0,
+    },
+    NEW: {
+      sharedMessages: newShared,
+      cacheableTokens: newCacheTokens,
+      totalRequestTokens: newTotalTokens,
+      hitRatio: newTotalTokens > 0 ? newCacheTokens / newTotalTokens : 0,
+    },
+  };
+}
+
+function fmtTokens(n) {
+  if (n >= 1000) return (n / 1000).toFixed(1) + "k";
+  return String(n);
+}
+
+function fmtPct(r) {
+  return (r * 100).toFixed(1) + "%";
+}
+
+const PRICE_INPUT = 3.0 / 1e6;
+const PRICE_CACHE = 0.30 / 1e6;
+
+function costOf(r) {
+  return r.cacheableTokens * PRICE_CACHE + (r.totalRequestTokens - r.cacheableTokens) * PRICE_INPUT;
+}
+
+const files = process.argv.slice(2);
+if (files.length === 0) {
+  console.error("usage: bench-fold-cache-shape.mjs <session.jsonl> [more.jsonl ...]");
+  process.exit(2);
+}
+
+const REPRESENTATIVE_SYSTEM = "x".repeat(6000);
+
+const results = files.map((f) => bench(f, REPRESENTATIVE_SYSTEM)).filter(Boolean);
+
+console.log("\n=== Per-session fold cache shape ===");
+for (const r of results) {
+  console.log(`\n${r.file}`);
+  console.log(
+    `  ${r.logMessages} messages · total ${fmtTokens(r.totalLogTokens)} tok · head ${fmtTokens(r.headTokens)} tok (fold at msg ${r.foldBoundary})`,
+  );
+  console.log(
+    `  OLD shape: shared ${r.OLD.sharedMessages} leading msgs → cache hit ${fmtTokens(r.OLD.cacheableTokens)} / ${fmtTokens(r.OLD.totalRequestTokens)} tok = ${fmtPct(r.OLD.hitRatio)}  → $${costOf(r.OLD).toFixed(5)}`,
+  );
+  console.log(
+    `  NEW shape: shared ${r.NEW.sharedMessages} leading msgs → cache hit ${fmtTokens(r.NEW.cacheableTokens)} / ${fmtTokens(r.NEW.totalRequestTokens)} tok = ${fmtPct(r.NEW.hitRatio)}  → $${costOf(r.NEW).toFixed(5)}`,
+  );
+  const savings = costOf(r.OLD) - costOf(r.NEW);
+  const savingPct = costOf(r.OLD) > 0 ? savings / costOf(r.OLD) : 0;
+  console.log(`  SAVING per fold: $${savings.toFixed(5)} (${fmtPct(savingPct)})`);
+}
+
+console.log("\n=== Aggregate ===");
+const oldTotal = results.reduce((a, r) => a + costOf(r.OLD), 0);
+const newTotal = results.reduce((a, r) => a + costOf(r.NEW), 0);
+const oldCacheTok = results.reduce((a, r) => a + r.OLD.cacheableTokens, 0);
+const newCacheTok = results.reduce((a, r) => a + r.NEW.cacheableTokens, 0);
+const oldReqTok = results.reduce((a, r) => a + r.OLD.totalRequestTokens, 0);
+const newReqTok = results.reduce((a, r) => a + r.NEW.totalRequestTokens, 0);
+console.log(`folds simulated: ${results.length}`);
+console.log(
+  `OLD: ${fmtTokens(oldCacheTok)} cached / ${fmtTokens(oldReqTok)} sent = ${fmtPct(oldCacheTok / oldReqTok)} hit · total $${oldTotal.toFixed(4)}`,
+);
+console.log(
+  `NEW: ${fmtTokens(newCacheTok)} cached / ${fmtTokens(newReqTok)} sent = ${fmtPct(newCacheTok / newReqTok)} hit · total $${newTotal.toFixed(4)}`,
+);
+console.log(
+  `aggregate saving: $${(oldTotal - newTotal).toFixed(4)} (${fmtPct((oldTotal - newTotal) / oldTotal)})`,
+);


### PR DESCRIPTION
## Summary

The fold summary call was being sent with a bespoke `"You compress conversation history…"` system prompt and no tools, which produces a 0% prefix-cache hit against the main agent's just-cached request. Every fold paid full input price on tens of thousands of tokens.

This PR reshapes the summary request so its prefix mirrors the live agent's last call:
- Same system prompt (was: bespoke "compress conversation" string)
- Same tool list (was: omitted)
- Same head conversation bytes (was: skill bodies stubbed mid-head, breaking the cache from the first skill onward)
- Only the trailing user "summarize" instruction is new — that's the sole cache-miss boundary

Skill-pin handling was split: `collectPinnedSkills` is read-only and leaves head bytes intact. The summarize instruction now names the pinned skills so the model doesn't paraphrase their bodies (we still append them verbatim regardless).

## Numbers

Measured on a real 60-message session at 48.7K prompt tokens (`bench-fold-cache-live.mjs`, real DeepSeek API):

| shape | cache hit | input cost |
| --- | --- | --- |
| before | 0.0% | $0.145 per fold |
| after | 99.6% | $0.015 per fold |

**~89.6% saving per fold.** Across 6 real session replays the saving holds steady at 88-90%. The remaining ~0.4% miss is just the trailing summarize instruction (~185 tokens).

## Test plan

- [x] 7 new request-shape assertions in `tests/context-manager-cache-aligned-fold.test.ts` (system / tools / head bytes / trailing instruction / model pin / skill-pin verbatim)
- [x] All 10 pre-existing fold tests still pass (`context-manager-skill-pin`, `context-manager-thinking-mode`, `context-manager-fold-timeout`)
- [x] Full `npm run verify`: build + lint + typecheck + 3561 tests green
- [x] Live API check via `tools/bench-fold-cache-live.mjs` confirms 99.6% cache hit on real DeepSeek
