### PR TITLE
chore(dsnix): bump to 0.49.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5403,9 +5403,9 @@
       }
     },
     "node_modules/reasonix": {
-      "version": "0.48.1",
-      "resolved": "https://registry.npmjs.org/reasonix/-/reasonix-0.48.1.tgz",
-      "integrity": "sha512-TLosbhvYtva8GUjoYdCFMmzsA00go5mMJSsRvidA7NBUUyNj40izkN3QysYDalphOqW02x2boOymoabjtE6imA==",
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/reasonix/-/reasonix-0.49.0.tgz",
+      "integrity": "sha512-xQ/+0naFP3bW3w3/2O/4cR3cjkXSiEfVN1iy8repDP/Ag0oJhq8TjrlyPjXDuyQ8WUGuaW0Et8z6ij3MxGLIUg==",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -5414,6 +5414,7 @@
         "cli-highlight": "^2.1.11",
         "commander": "^12.1.0",
         "eventsource-parser": "^3.0.0",
+        "iconv-lite": "^0.7.2",
         "ignore": "^7.0.5",
         "ink": "^7.0.2",
         "ink-text-input": "^6.0.0",
@@ -7954,10 +7955,10 @@
       }
     },
     "packages/dsnix": {
-      "version": "0.48.1",
+      "version": "0.49.0",
       "license": "MIT",
       "dependencies": {
-        "reasonix": "0.48.1"
+        "reasonix": "0.49.0"
       },
       "bin": {
         "dsnix": "bin.cjs"

--- a/packages/dsnix/package.json
+++ b/packages/dsnix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsnix",
-  "version": "0.48.1",
+  "version": "0.49.0",
   "description": "Short alias for reasonix — DeepSeek-native coding agent. Forwards to the reasonix CLI.",
   "bin": {
     "dsnix": "bin.cjs"
@@ -31,6 +31,6 @@
     "node": ">=22"
   },
   "dependencies": {
-    "reasonix": "0.48.1"
+    "reasonix": "0.49.0"
   }
 }


### PR DESCRIPTION
## Summary

Shim alias bump to track `reasonix@0.49.0` (now published on npm). Mirrors the prior `0.48.1` bump.

## Test plan

- [x] Lockfile in sync