### PR TITLE
feat(shell): add PTY support for interactive commands (sudo, ssh)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "ink": "^7.0.2",
         "ink-text-input": "^6.0.0",
         "node-html-parser": "^7.1.0",
+        "node-pty": "^1.1.0",
         "picomatch": "^4.0.4",
         "react": "^19.2.6",
         "string-width": "^7.2.0",
@@ -4937,6 +4938,22 @@
         "css-select": "^5.1.0",
         "he": "1.2.0"
       }
+    },
+    "node_modules/node-pty": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
+      "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.1.0"
+      }
+    },
+    "node_modules/node-pty/node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
     },
     "node_modules/node-releases": {
       "version": "2.0.38",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "ink": "^7.0.2",
     "ink-text-input": "^6.0.0",
     "node-html-parser": "^7.1.0",
+    "node-pty": "^1.1.0",
     "picomatch": "^4.0.4",
     "react": "^19.2.6",
     "string-width": "^7.2.0",

--- a/src/loop/errors.ts
+++ b/src/loop/errors.ts
@@ -10,7 +10,7 @@ export function formatLoopError(err: Error, probe?: DeepSeekProbeResult): string
   if (msg.includes("maximum context length")) {
     const reqMatch = msg.match(/requested\s+(\d+)\s+tokens/);
     const requested = reqMatch
-      ? `${Number(reqMatch[1]).toLocaleString()} tokens`
+      ? `${Number(reqMatch[1]).toLocaleString("en-US")} tokens`
       : t("errors.contextOverflowTooMany");
     return t("errors.contextOverflow", { requested });
   }

--- a/src/tools/shell/exec.ts
+++ b/src/tools/shell/exec.ts
@@ -3,6 +3,7 @@ import { existsSync, statSync } from "node:fs";
 import * as pathMod from "node:path";
 import { parseCommandChain, runChain } from "../shell-chain.js";
 import { tokenizeCommand } from "./parse.js";
+import { needsPty, runWithPty } from "./pty-exec.js";
 
 export const DEFAULT_TIMEOUT_SEC = 60;
 export const DEFAULT_MAX_OUTPUT_CHARS = 32_000;
@@ -99,6 +100,15 @@ export async function runCommand(
   //      with verbatim args + manual quoting, so shell metacharacters
   //      in arguments stay literal.
   // Unix path is unchanged.
+  if (needsPty(cmd) && process.stdin.isTTY) {
+    const { bin: ptyBin, args: ptyArgs } = prepareSpawn(argv, { env: normalizedEnv });
+    return runWithPty(ptyBin, ptyArgs, {
+      cwd: opts.cwd,
+      timeoutSec,
+      maxOutputChars: maxChars,
+      env: { ...normalizedEnv, PYTHONIOENCODING: "utf-8", PYTHONUTF8: "1" },
+    });
+  }
   const { bin, args, spawnOverrides } = prepareSpawn(argv, { env: normalizedEnv });
   const effectiveSpawnOpts = { ...spawnOpts, ...spawnOverrides };
 

--- a/src/tools/shell/pty-exec.ts
+++ b/src/tools/shell/pty-exec.ts
@@ -1,0 +1,67 @@
+import * as pty from "node-pty";
+
+export interface PtyResult {
+  exitCode: number | null;
+  output: string;
+  timedOut: boolean;
+}
+
+const INTERACTIVE_PREFIXES = ["sudo", "ssh", "mysql", "npm init", "npx create"];
+
+export function needsPty(cmd: string): boolean {
+  const trimmed = cmd.trim().toLowerCase();
+  return INTERACTIVE_PREFIXES.some((c) => trimmed.startsWith(c));
+}
+
+export async function runWithPty(
+  bin: string,
+  args: string[],
+  opts: {
+    cwd: string;
+    timeoutSec: number;
+    maxOutputChars: number;
+    env: NodeJS.ProcessEnv;
+  },
+): Promise<PtyResult> {
+  return new Promise((resolve) => {
+    const proc = pty.spawn(bin, args, {
+      name: "xterm-256color",
+      cols: process.stdout.columns ?? 80,
+      rows: process.stdout.rows ?? 24,
+      cwd: opts.cwd,
+      env: opts.env as Record<string, string>,
+    });
+
+    let output = "";
+    let timedOut = false;
+
+    proc.onData((data) => {
+      output += data;
+      process.stdout.write(data);
+      if (output.length > opts.maxOutputChars * 2) {
+        output = output.slice(-opts.maxOutputChars);
+      }
+    });
+
+    const stdinHandler = (data: Buffer) => proc.write(data.toString());
+    process.stdin.setRawMode?.(true);
+    process.stdin.resume();
+    process.stdin.on("data", stdinHandler);
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      proc.kill();
+    }, opts.timeoutSec * 1000);
+
+    proc.onExit(({ exitCode }) => {
+      clearTimeout(timer);
+      process.stdin.removeListener("data", stdinHandler);
+      process.stdin.setRawMode?.(false);
+      const trimmed =
+        output.length > opts.maxOutputChars
+          ? `${output.slice(0, opts.maxOutputChars)}\n\n[… truncated …]`
+          : output;
+      resolve({ exitCode: exitCode ?? null, output: trimmed, timedOut });
+    });
+  });
+}


### PR DESCRIPTION
## What
Adds PTY (pseudo-terminal) support for interactive shell commands in Reasonix.

<!-- One paragraph: what does this change? -->

## Why
Currently interactive commands like sudo, ssh, npm init fail or hang because they require user input via a real terminal.

<!-- Bug fix? Pre-existing issue? Linked discussion? -->

## How 
- Introduced node-pty based execution in pty-exec.ts
- Added needsPty() detection for interactive commands
- Integrated PTY path into exec.ts
- Preserves existing non-interactive spawn flow
- Safe fallback when process.stdin is not a TTY
<!-- Steps the reviewer can run. `npm run verify` is assumed. -->

##How to verify
Run:
npm run verify

Then test:
sudo echo "test"
ssh localhost (if configured)

## Checklist

- [x] npm run verify passes locally
- [x] No breaking changes to existing shell execution
- [x] PTY only used for interactive commands
