### PR TITLE
feat(tui): add Alt+S input stash/recall hotkey (#1438)

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -508,6 +508,7 @@ function AppInner({
   // Esc handler only fires once per turn (repeated presses would yield
   // stacked warning events).
   const abortedThisTurn = useRef(false);
+  const stashRef = useRef("");
   // Mirrors the live `busy` flag for /loop's timer (it has no React
   // closure handle, only refs). Skips the firing when a prior turn is
   // still running rather than queuing a duplicate submit.
@@ -1866,6 +1867,38 @@ function AppInner({
     // — the picker would move AND history recall would fire into the
     // (hidden) prompt buffer. Bail early.
     if (pendingShell || pendingPath) return;
+    // Alt+S — stash / recall the composer buffer. Ctrl+U clearing
+    // is a one-way delete; stash gives the user a reversible "save
+    // for later" so an accidental hotkey doesn't lose input.
+    if (
+      key.meta &&
+      key.input === "s" &&
+      !pendingPlan &&
+      !pendingReviseEditor &&
+      !pendingSessionsPicker &&
+      !pendingCheckpointPicker &&
+      !pendingMcpHub &&
+      !stagedInput &&
+      !pendingEditReview &&
+      !walkthroughActive &&
+      !pendingChoice &&
+      !stagedChoiceCustom &&
+      !pendingRevision
+    ) {
+      if (stashRef.current) {
+        const recalled = stashRef.current;
+        stashRef.current = input;
+        setInput(recalled);
+        log.pushInfo(t("composer.stashRecall"));
+      } else if (input.length > 0) {
+        stashRef.current = input;
+        setInput("");
+        log.pushInfo(t("composer.stashSaved"));
+      } else {
+        log.pushInfo(t("composer.stashNothing"));
+      }
+      return;
+    }
 
     // Picker arrow nav lives on the PromptInput → historyHandoff →
     // handleHistoryPrev/Next path (which checks pickers before recall).

--- a/src/cli/ui/ShortcutsHelpModal.tsx
+++ b/src/cli/ui/ShortcutsHelpModal.tsx
@@ -26,6 +26,7 @@ const SHORTCUT_GROUPS: ShortcutGroup[] = [
       { keys: "Ctrl+W", descKey: "shortcutsHelp.descCtrlW" },
       { keys: "Ctrl+P", descKey: "shortcutsHelp.descCtrlP" },
       { keys: "Ctrl+X", descKey: "shortcutsHelp.descCtrlX" },
+      { keys: "Alt+S", descKey: "shortcutsHelp.descAltS" },
     ],
   },
   {

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -1318,6 +1318,9 @@ export const EN: TranslationSchema = {
     typeaheadStaged: "\u25b8 {count} line(s) staged \u00b7 esc recall",
     steerPlaceholder: "type to steer the current task — commands are disabled while busy",
     steerHint: "send — injected mid-turn",
+    stashNothing: "Nothing to stash",
+    stashSaved: "Stashed",
+    stashRecall: "Recalled",
   },
   pathConfirm: {
     title: "Outside-sandbox path",
@@ -1869,6 +1872,7 @@ export const EN: TranslationSchema = {
     descCtrlO: "Expand reply (streaming only)",
     descHelp: "Show all commands",
     descShiftTab: "Switch edit mode",
+    descAltS: "Stash / recall input",
   },
   mcpCli: {
     bundledCatalog: "Bundled MCP servers (offline catalog):",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -489,6 +489,12 @@ export interface TranslationSchema {
     steerPlaceholder: string;
     /** Status-line hint shown when steerBusy is active. */
     steerHint: string;
+    /** Info shown when Alt+S pressed on empty input with no stash. */
+    stashNothing: string;
+    /** Info shown when input was stashed (non-empty input → saved). */
+    stashSaved: string;
+    /** Info shown when stash was recalled into input. */
+    stashRecall: string;
   };
   pathConfirm: {
     title: string;
@@ -963,6 +969,7 @@ export interface TranslationSchema {
     descCtrlO: string;
     descHelp: string;
     descShiftTab: string;
+    descAltS: string;
   };
   mcpCli: {
     bundledCatalog: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -1247,6 +1247,9 @@ export const zhCN: TranslationSchema = {
     typeaheadStaged: "\u25b8 {count} 行已暂存 \u00b7 esc 召回",
     steerPlaceholder: "输入消息以引导当前任务 — 忙碌时不支持命令",
     steerHint: "发送 — 回合内注入",
+    stashNothing: "没有可暂存的内容",
+    stashSaved: "已暂存",
+    stashRecall: "已恢复",
   },
   pathConfirm: {
     title: "沙箱外路径",
@@ -1771,6 +1774,7 @@ export const zhCN: TranslationSchema = {
     descCtrlO: "展开回复（仅流式输出期间）",
     descHelp: "显示所有命令",
     descShiftTab: "切换编辑模式",
+    descAltS: "暂存/恢复输入",
   },
   mcpCli: {
     bundledCatalog: "已打包的 MCP 服务器（离线目录）：",

--- a/tests/composer-hint.test.tsx
+++ b/tests/composer-hint.test.tsx
@@ -20,6 +20,16 @@ describe("composer hint bar — issue #564", () => {
       expect(t("composer.hintClear")).toBe("清空");
     });
 
+    it("exposes composer.stashNothing in EN", () => {
+      setLanguageRuntime("EN");
+      expect(t("composer.stashNothing")).toBe("Nothing to stash");
+    });
+
+    it("exposes composer.stashNothing in zh-CN", () => {
+      setLanguageRuntime("zh-CN");
+      expect(t("composer.stashNothing")).toBe("没有可暂存的内容");
+    });
+
     it("never leaks the literal key 'composer.hint' (was rendered raw before fix)", () => {
       setLanguageRuntime("EN");
       // t() falls through to returning the path when a key is missing —
@@ -30,6 +40,7 @@ describe("composer hint bar — issue #564", () => {
       expect(t("composer.hintHistory")).not.toBe("composer.hintHistory");
       expect(t("composer.hintAbort")).not.toBe("composer.hintAbort");
       expect(t("composer.hintQuit")).not.toBe("composer.hintQuit");
+      expect(t("composer.stashNothing")).not.toBe("composer.stashNothing");
     });
   });
 


### PR DESCRIPTION
 ## What

 Adds Alt+S hotkey to stash and recall the composer input buffer. Press once to save the current
input, press again on an empty line to recall it. If there's already stashed text, the current input
is replaced by the stash.

 ## Why

 Quick temp register — save a half-written message or thought for later without losing it. Closes
#1438.

 ## How to verify

 1. `npm run dev` (or `npm run build && node dist/cli/index.js`)
 2. Type something → Alt+S → input clears, "Stashed" hint appears
 3. Alt+S again → input fills with the stashed text, "Recalled"
 4. Alt+S twice on empty input → "Nothing to stash"
 5. Type something, Alt+S to stash, type something else, Alt+S again → stash replaces current text
 6. Ctrl+P → shortcuts modal shows Alt+S under Input group

 ## Checklist

 - [x] `npm run verify` passes locally (lint + typecheck + tests — 3 pre-existing web-tools failures,
same as main)
 - [x] No `Co-Authored-By: Claude` trailer in commits
 - [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
 - [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time