### PR TITLE
test(lifecycle): add intent corpus runner

### DIFF
--- a/scripts/evaluate-lifecycle-intent.mts
+++ b/scripts/evaluate-lifecycle-intent.mts
@@ -1,0 +1,26 @@
+#!/usr/bin/env tsx
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  type LifecycleIntentCorpusCase,
+  evaluateLifecycleIntentCorpus,
+  formatLifecycleIntentReport,
+} from "../src/code/lifecycle-intent-runner.js";
+
+const args = new Set(process.argv.slice(2));
+const json = args.has("--json");
+const fixtureArg = process.argv.slice(2).find((arg) => !arg.startsWith("-"));
+const fixturePath = resolve(fixtureArg ?? "tests/fixtures/lifecycle-intent-corpus.json");
+const cases = JSON.parse(readFileSync(fixturePath, "utf8")) as LifecycleIntentCorpusCase[];
+const report = evaluateLifecycleIntentCorpus(cases);
+
+if (json) {
+  console.log(JSON.stringify(report, null, 2));
+} else {
+  console.log(formatLifecycleIntentReport(report));
+}
+
+if (report.failed > 0) {
+  process.exitCode = 1;
+}

--- a/src/code/lifecycle-intent-runner.ts
+++ b/src/code/lifecycle-intent-runner.ts
@@ -1,0 +1,90 @@
+import {
+  type LifecycleIntentRecommendation,
+  type LifecycleIntentSignal,
+  evaluateEngineeringLifecycleIntent,
+} from "./lifecycle-intent.js";
+
+export interface LifecycleIntentCorpusCase {
+  id: string;
+  input: string;
+  expectedRecommendation: LifecycleIntentRecommendation;
+  expectedSignals: LifecycleIntentSignal[];
+  language?: "en" | "zh" | "mixed";
+  tags?: string[];
+}
+
+export interface LifecycleIntentCorpusResult {
+  id: string;
+  passed: boolean;
+  expectedRecommendation: LifecycleIntentRecommendation;
+  actualRecommendation: LifecycleIntentRecommendation;
+  expectedSignals: LifecycleIntentSignal[];
+  actualSignals: LifecycleIntentSignal[];
+  missingSignals: LifecycleIntentSignal[];
+  modelVisible: false;
+  enforced: false;
+}
+
+export interface LifecycleIntentCorpusReport {
+  total: number;
+  passed: number;
+  failed: number;
+  recommendationAccuracy: number;
+  signalRecall: number;
+  results: LifecycleIntentCorpusResult[];
+}
+
+export function evaluateLifecycleIntentCorpus(
+  cases: readonly LifecycleIntentCorpusCase[],
+): LifecycleIntentCorpusReport {
+  const results = cases.map(evaluateCase);
+  const passed = results.filter((item) => item.passed).length;
+  const expectedSignalCount = results.reduce((sum, item) => sum + item.expectedSignals.length, 0);
+  const missingSignalCount = results.reduce((sum, item) => sum + item.missingSignals.length, 0);
+
+  return {
+    total: results.length,
+    passed,
+    failed: results.length - passed,
+    recommendationAccuracy: ratio(
+      results.filter((item) => item.expectedRecommendation === item.actualRecommendation).length,
+      results.length,
+    ),
+    signalRecall: ratio(expectedSignalCount - missingSignalCount, expectedSignalCount),
+    results,
+  };
+}
+
+export function formatLifecycleIntentReport(report: LifecycleIntentCorpusReport): string {
+  const accuracy = formatPercent(report.recommendationAccuracy);
+  const recall = formatPercent(report.signalRecall);
+  return `lifecycle intent corpus: ${report.passed}/${report.total} passed; recommendation=${accuracy}; signal-recall=${recall}`;
+}
+
+function evaluateCase(testCase: LifecycleIntentCorpusCase): LifecycleIntentCorpusResult {
+  const actual = evaluateEngineeringLifecycleIntent(testCase.input);
+  const missingSignals = testCase.expectedSignals.filter(
+    (signal) => !actual.signals.includes(signal),
+  );
+  return {
+    id: testCase.id,
+    passed:
+      testCase.expectedRecommendation === actual.recommendation && missingSignals.length === 0,
+    expectedRecommendation: testCase.expectedRecommendation,
+    actualRecommendation: actual.recommendation,
+    expectedSignals: [...testCase.expectedSignals],
+    actualSignals: [...actual.signals],
+    missingSignals,
+    modelVisible: actual.modelVisible,
+    enforced: actual.enforced,
+  };
+}
+
+function ratio(numerator: number, denominator: number): number {
+  if (denominator === 0) return 1;
+  return numerator / denominator;
+}
+
+function formatPercent(value: number): string {
+  return `${(value * 100).toFixed(1)}%`;
+}

--- a/src/code/lifecycle-intent.ts
+++ b/src/code/lifecycle-intent.ts
@@ -1,0 +1,256 @@
+export type LifecycleIntentRecommendation = "stay-light" | "suggest-plan" | "strict-candidate";
+
+export type LifecycleIntentConfidence = "low" | "medium" | "high";
+
+// Advisory corpus/eval helper only; do not wire this into auto-arm without a separate RFC.
+export type LifecycleIntentSignal =
+  | "cancel"
+  | "dependency-change"
+  | "explicit-strict"
+  | "failed-verification"
+  | "migration"
+  | "multi-file"
+  | "package-or-config"
+  | "plan-revision"
+  | "read-only"
+  | "refactor"
+  | "single-file"
+  | "small-task";
+
+export interface LifecycleIntentEvaluation {
+  recommendation: LifecycleIntentRecommendation;
+  confidence: LifecycleIntentConfidence;
+  score: number;
+  signals: LifecycleIntentSignal[];
+  modelVisible: false;
+  enforced: false;
+}
+
+const EXPLICIT_STRICT_PHRASES = [
+  "/plan strict",
+  "strict lifecycle",
+  "strict rails",
+  "强约束",
+  "严格生命周期",
+];
+
+const READ_ONLY_PHRASES = [
+  "explain",
+  "inspect",
+  "look at",
+  "read",
+  "summarize",
+  "do not edit",
+  "without modifying",
+  "解释",
+  "查看",
+  "看看",
+  "总结",
+  "不要修改",
+  "只读",
+];
+
+const NEGATED_MUTATION_PHRASES = ["do not edit", "without modifying", "不要修改", "不要改"];
+
+const MUTATION_PHRASES = [
+  "add",
+  "change",
+  "delete",
+  "edit",
+  "fix",
+  "install",
+  "migrate",
+  "move",
+  "refactor",
+  "remove",
+  "rename",
+  "rewrite",
+  "upgrade",
+  "update",
+  "修",
+  "改",
+  "安装",
+  "迁移",
+  "移动",
+  "删除",
+  "升级",
+  "更新",
+  "重构",
+  "重命名",
+];
+
+const SMALL_TASK_PHRASES = [
+  "typo",
+  "spelling",
+  "one-line",
+  "small fix",
+  "minor fix",
+  "拼写",
+  "错别字",
+  "小修",
+  "修一下",
+];
+
+const SINGLE_FILE_PHRASES = ["single file", "one file", "readme", "单文件", "一个文件", "一个拼写"];
+
+const MULTI_FILE_PHRASES = [
+  "across",
+  "all references",
+  "multiple files",
+  "multi-file",
+  "routing layer",
+  "多文件",
+  "所有引用",
+  "跨模块",
+  "跨文件",
+];
+
+const REFACTOR_PHRASES = [
+  "api",
+  "move",
+  "parser",
+  "refactor",
+  "rename",
+  "模块",
+  "移动",
+  "重构",
+  "重命名",
+];
+
+const MIGRATION_PHRASES = ["migrate", "migration", "迁移"];
+
+const DEPENDENCY_PHRASES = [
+  "npm install",
+  "package.json",
+  "pnpm add",
+  "pnpm-lock",
+  "yarn add",
+  "依赖",
+  "安装依赖",
+];
+
+const PACKAGE_OR_CONFIG_PHRASES = [
+  ".github/workflows",
+  "github actions",
+  "lockfile",
+  "package.json",
+  "pnpm-lock",
+  "tsconfig",
+  "workflow",
+  "配置",
+];
+
+const FAILED_VERIFICATION_PHRASES = [
+  "failed after",
+  "failing test",
+  "test failed",
+  "tests failed",
+  "测试失败",
+  "验证失败",
+];
+
+const PLAN_REVISION_PHRASES = ["revise_plan", "revise plan", "replace the remaining", "修正计划"];
+
+const CANCEL_PHRASES = ["cancel", "stop", "取消", "停止"];
+
+export function evaluateEngineeringLifecycleIntent(input: string): LifecycleIntentEvaluation {
+  const text = normalize(input);
+  const signals = new Set<LifecycleIntentSignal>();
+
+  if (!text) return result("stay-light", "low", 0, signals);
+
+  const mutationIntent = hasMutationIntent(text);
+
+  addSignalIf(signals, "explicit-strict", hasAny(text, EXPLICIT_STRICT_PHRASES));
+  addSignalIf(signals, "read-only", hasAny(text, READ_ONLY_PHRASES) && !mutationIntent);
+  addSignalIf(signals, "small-task", hasAny(text, SMALL_TASK_PHRASES));
+  addSignalIf(signals, "single-file", hasSingleFileSignal(text));
+  addSignalIf(signals, "multi-file", hasAny(text, MULTI_FILE_PHRASES));
+  addSignalIf(signals, "refactor", hasAny(text, REFACTOR_PHRASES));
+  addSignalIf(signals, "migration", hasAny(text, MIGRATION_PHRASES));
+  addSignalIf(signals, "dependency-change", mutationIntent && hasAny(text, DEPENDENCY_PHRASES));
+  addSignalIf(
+    signals,
+    "package-or-config",
+    mutationIntent && hasAny(text, PACKAGE_OR_CONFIG_PHRASES),
+  );
+  addSignalIf(signals, "failed-verification", hasAny(text, FAILED_VERIFICATION_PHRASES));
+  addSignalIf(signals, "plan-revision", hasAny(text, PLAN_REVISION_PHRASES));
+  addSignalIf(signals, "cancel", hasAny(text, CANCEL_PHRASES));
+
+  if (isCancelOnly(signals)) return result("stay-light", "high", 0, signals);
+
+  const score = scoreSignals(signals);
+  if (score >= 4) return result("strict-candidate", "high", score, signals);
+  if (score >= 2) return result("suggest-plan", "medium", score, signals);
+
+  if (signals.has("read-only") || signals.has("small-task") || signals.has("single-file")) {
+    return result("stay-light", "high", score, signals);
+  }
+
+  return result("stay-light", "low", score, signals);
+}
+
+function normalize(input: string): string {
+  return input.toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+function hasAny(text: string, phrases: readonly string[]): boolean {
+  return phrases.some((phrase) => text.includes(phrase));
+}
+
+function addSignalIf(
+  signals: Set<LifecycleIntentSignal>,
+  signal: LifecycleIntentSignal,
+  condition: boolean,
+): void {
+  if (condition) signals.add(signal);
+}
+
+function hasMutationIntent(text: string): boolean {
+  if (hasAny(text, NEGATED_MUTATION_PHRASES)) return false;
+  return hasAny(text, MUTATION_PHRASES);
+}
+
+function hasSingleFileSignal(text: string): boolean {
+  return (
+    hasAny(text, SINGLE_FILE_PHRASES) ||
+    text.includes(".md") ||
+    text.includes(".ts") ||
+    text.includes(".tsx") ||
+    text.includes(".json")
+  );
+}
+
+function isCancelOnly(signals: Set<LifecycleIntentSignal>): boolean {
+  return signals.size === 1 && signals.has("cancel");
+}
+
+function scoreSignals(signals: Set<LifecycleIntentSignal>): number {
+  let score = 0;
+  if (signals.has("explicit-strict")) score += 5;
+  if (signals.has("multi-file")) score += 2;
+  if (signals.has("refactor")) score += 2;
+  if (signals.has("migration")) score += 2;
+  if (signals.has("dependency-change")) score += 3;
+  if (signals.has("package-or-config")) score += 2;
+  if (signals.has("failed-verification")) score += 2;
+  if (signals.has("plan-revision")) score += 2;
+  return score;
+}
+
+function result(
+  recommendation: LifecycleIntentRecommendation,
+  confidence: LifecycleIntentConfidence,
+  score: number,
+  signals: Set<LifecycleIntentSignal>,
+): LifecycleIntentEvaluation {
+  return {
+    recommendation,
+    confidence,
+    score,
+    signals: [...signals],
+    modelVisible: false,
+    enforced: false,
+  };
+}

--- a/tests/fixtures/lifecycle-intent-corpus.json
+++ b/tests/fixtures/lifecycle-intent-corpus.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "read-only-explanation",
+    "language": "en",
+    "input": "Explain what the package.json scripts do. Do not edit files.",
+    "expectedRecommendation": "stay-light",
+    "expectedSignals": ["read-only"],
+    "tags": ["read-only", "small-task"]
+  },
+  {
+    "id": "small-single-file-fix",
+    "language": "en",
+    "input": "Fix a typo in README.md.",
+    "expectedRecommendation": "stay-light",
+    "expectedSignals": ["small-task", "single-file"],
+    "tags": ["small-task", "single-file"]
+  },
+  {
+    "id": "multi-file-api-rename",
+    "language": "en",
+    "input": "Rename the createClient API across src, update imports, and run tests.",
+    "expectedRecommendation": "strict-candidate",
+    "expectedSignals": ["multi-file", "refactor"],
+    "tags": ["multi-file", "refactor"]
+  },
+  {
+    "id": "module-move-with-references",
+    "language": "en",
+    "input": "Move the parser module, update all references, and refresh the tests.",
+    "expectedRecommendation": "strict-candidate",
+    "expectedSignals": ["multi-file", "refactor"],
+    "tags": ["multi-file", "refactor"]
+  },
+  {
+    "id": "dependency-migration",
+    "language": "en",
+    "input": "Upgrade zod, update package.json and pnpm-lock.yaml, then run npm install.",
+    "expectedRecommendation": "strict-candidate",
+    "expectedSignals": ["dependency-change", "package-or-config"],
+    "tags": ["dependency", "migration"]
+  },
+  {
+    "id": "configuration-migration",
+    "language": "en",
+    "input": "Migrate tsconfig and the GitHub Actions workflow for the new build.",
+    "expectedRecommendation": "strict-candidate",
+    "expectedSignals": ["migration", "package-or-config"],
+    "tags": ["config", "migration"]
+  },
+  {
+    "id": "failed-verification-revise-flow",
+    "language": "en",
+    "input": "Tests failed after step 2; revise_plan should replace the remaining steps.",
+    "expectedRecommendation": "strict-candidate",
+    "expectedSignals": ["failed-verification", "plan-revision"],
+    "tags": ["revise", "failure"]
+  },
+  {
+    "id": "explicit-strict-lifecycle",
+    "language": "en",
+    "input": "/plan strict refactor the shell gate and update the lifecycle tests",
+    "expectedRecommendation": "strict-candidate",
+    "expectedSignals": ["explicit-strict", "refactor"],
+    "tags": ["explicit-strict"]
+  },
+  {
+    "id": "broad-cleanup-suggest-plan",
+    "language": "en",
+    "input": "Clean up the routing layer across modules.",
+    "expectedRecommendation": "suggest-plan",
+    "expectedSignals": ["multi-file"],
+    "tags": ["suggest-plan", "multi-file"]
+  },
+  {
+    "id": "cancel-intent",
+    "language": "en",
+    "input": "Stop the current lifecycle task and cancel the plan.",
+    "expectedRecommendation": "stay-light",
+    "expectedSignals": ["cancel"],
+    "tags": ["cancel"]
+  },
+  {
+    "id": "zh-multi-file-refactor",
+    "language": "zh",
+    "input": "把 API 模块移动到新的目录，更新所有引用并跑测试。",
+    "expectedRecommendation": "strict-candidate",
+    "expectedSignals": ["multi-file", "refactor"],
+    "tags": ["zh", "multi-file", "refactor"]
+  },
+  {
+    "id": "zh-small-single-file-fix",
+    "language": "zh",
+    "input": "修一下 README 里的一个拼写错误。",
+    "expectedRecommendation": "stay-light",
+    "expectedSignals": ["small-task", "single-file"],
+    "tags": ["zh", "small-task", "single-file"]
+  }
+]

--- a/tests/lifecycle-intent-runner.test.ts
+++ b/tests/lifecycle-intent-runner.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../src/code/lifecycle-intent-runner.js";
 
 const FIXTURE_PATH = resolve("tests/fixtures/lifecycle-intent-corpus.json");
+const NPX_BIN = process.platform === "win32" ? "npx.cmd" : "npx";
 
 function loadFixture(): LifecycleIntentCorpusCase[] {
   return JSON.parse(readFileSync(FIXTURE_PATH, "utf8")) as LifecycleIntentCorpusCase[];
@@ -36,7 +37,7 @@ describe("lifecycle intent corpus runner", () => {
   });
 
   it("runs as an offline script without requiring an API key", () => {
-    const result = spawnSync("npx", ["tsx", "scripts/evaluate-lifecycle-intent.mts", "--json"], {
+    const result = spawnSync(NPX_BIN, ["tsx", "scripts/evaluate-lifecycle-intent.mts", "--json"], {
       encoding: "utf8",
       env: {
         ...process.env,

--- a/tests/lifecycle-intent-runner.test.ts
+++ b/tests/lifecycle-intent-runner.test.ts
@@ -1,0 +1,56 @@
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  type LifecycleIntentCorpusCase,
+  evaluateLifecycleIntentCorpus,
+  formatLifecycleIntentReport,
+} from "../src/code/lifecycle-intent-runner.js";
+
+const FIXTURE_PATH = resolve("tests/fixtures/lifecycle-intent-corpus.json");
+
+function loadFixture(): LifecycleIntentCorpusCase[] {
+  return JSON.parse(readFileSync(FIXTURE_PATH, "utf8")) as LifecycleIntentCorpusCase[];
+}
+
+describe("lifecycle intent corpus runner", () => {
+  it("evaluates the checked-in corpus with a stable report", () => {
+    const report = evaluateLifecycleIntentCorpus(loadFixture());
+
+    expect(report.total).toBeGreaterThanOrEqual(12);
+    expect(report.failed).toBe(0);
+    expect(report.passed).toBe(report.total);
+    expect(report.recommendationAccuracy).toBe(1);
+    expect(report.signalRecall).toBe(1);
+    expect(formatLifecycleIntentReport(report)).toContain(
+      `${report.passed}/${report.total} passed`,
+    );
+  });
+
+  it("keeps corpus evaluation advisory-only", () => {
+    const report = evaluateLifecycleIntentCorpus(loadFixture());
+
+    expect(report.results.every((item) => item.modelVisible === false)).toBe(true);
+    expect(report.results.every((item) => item.enforced === false)).toBe(true);
+  });
+
+  it("runs as an offline script without requiring an API key", () => {
+    const result = spawnSync("npx", ["tsx", "scripts/evaluate-lifecycle-intent.mts", "--json"], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        DEEPSEEK_API_KEY: "",
+      },
+      timeout: 20_000,
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      failed: 0,
+      recommendationAccuracy: 1,
+      signalRecall: 1,
+    });
+  });
+});

--- a/tests/lifecycle-intent-runner.test.ts
+++ b/tests/lifecycle-intent-runner.test.ts
@@ -9,7 +9,7 @@ import {
 } from "../src/code/lifecycle-intent-runner.js";
 
 const FIXTURE_PATH = resolve("tests/fixtures/lifecycle-intent-corpus.json");
-const NPX_BIN = process.platform === "win32" ? "npx.cmd" : "npx";
+const TSX_CLI = resolve("node_modules/tsx/dist/cli.mjs");
 
 function loadFixture(): LifecycleIntentCorpusCase[] {
   return JSON.parse(readFileSync(FIXTURE_PATH, "utf8")) as LifecycleIntentCorpusCase[];
@@ -37,14 +37,18 @@ describe("lifecycle intent corpus runner", () => {
   });
 
   it("runs as an offline script without requiring an API key", () => {
-    const result = spawnSync(NPX_BIN, ["tsx", "scripts/evaluate-lifecycle-intent.mts", "--json"], {
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        DEEPSEEK_API_KEY: "",
+    const result = spawnSync(
+      process.execPath,
+      [TSX_CLI, "scripts/evaluate-lifecycle-intent.mts", "--json"],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          DEEPSEEK_API_KEY: "",
+        },
+        timeout: 20_000,
       },
-      timeout: 20_000,
-    });
+    );
 
     expect(result.status).toBe(0);
     expect(result.stderr).toBe("");

--- a/tests/lifecycle-intent.test.ts
+++ b/tests/lifecycle-intent.test.ts
@@ -1,85 +1,19 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
+import type { LifecycleIntentCorpusCase } from "../src/code/lifecycle-intent-runner.js";
 import { evaluateEngineeringLifecycleIntent } from "../src/code/lifecycle-intent.js";
 
+const corpus = JSON.parse(
+  readFileSync(resolve("tests/fixtures/lifecycle-intent-corpus.json"), "utf8"),
+) as LifecycleIntentCorpusCase[];
+
 describe("engineering lifecycle intent evaluator", () => {
-  it.each([
-    {
-      name: "read-only explanation",
-      input: "Explain what the package.json scripts do. Do not edit files.",
-      recommendation: "stay-light",
-      signals: ["read-only"],
-    },
-    {
-      name: "small single-file fix",
-      input: "Fix a typo in README.md.",
-      recommendation: "stay-light",
-      signals: ["small-task", "single-file"],
-    },
-    {
-      name: "multi-file API rename",
-      input: "Rename the createClient API across src, update imports, and run tests.",
-      recommendation: "strict-candidate",
-      signals: ["multi-file", "refactor"],
-    },
-    {
-      name: "module move with references",
-      input: "Move the parser module, update all references, and refresh the tests.",
-      recommendation: "strict-candidate",
-      signals: ["multi-file", "refactor"],
-    },
-    {
-      name: "dependency migration",
-      input: "Upgrade zod, update package.json and pnpm-lock.yaml, then run npm install.",
-      recommendation: "strict-candidate",
-      signals: ["dependency-change", "package-or-config"],
-    },
-    {
-      name: "configuration migration",
-      input: "Migrate tsconfig and the GitHub Actions workflow for the new build.",
-      recommendation: "strict-candidate",
-      signals: ["migration", "package-or-config"],
-    },
-    {
-      name: "failed verification revise flow",
-      input: "Tests failed after step 2; revise_plan should replace the remaining steps.",
-      recommendation: "strict-candidate",
-      signals: ["failed-verification", "plan-revision"],
-    },
-    {
-      name: "explicit strict lifecycle",
-      input: "/plan strict refactor the shell gate and update the lifecycle tests",
-      recommendation: "strict-candidate",
-      signals: ["explicit-strict", "refactor"],
-    },
-    {
-      name: "broad cleanup asks for plan but does not auto-enforce",
-      input: "Clean up the routing layer across modules.",
-      recommendation: "suggest-plan",
-      signals: ["multi-file"],
-    },
-    {
-      name: "cancel intent stays lightweight",
-      input: "Stop the current lifecycle task and cancel the plan.",
-      recommendation: "stay-light",
-      signals: ["cancel"],
-    },
-    {
-      name: "Chinese multi-file refactor",
-      input: "把 API 模块移动到新的目录，更新所有引用并跑测试。",
-      recommendation: "strict-candidate",
-      signals: ["multi-file", "refactor"],
-    },
-    {
-      name: "Chinese small fix",
-      input: "修一下 README 里的一个拼写错误。",
-      recommendation: "stay-light",
-      signals: ["small-task", "single-file"],
-    },
-  ])("classifies $name", ({ input, recommendation, signals }) => {
+  it.each(corpus)("classifies $id", ({ input, expectedRecommendation, expectedSignals }) => {
     const result = evaluateEngineeringLifecycleIntent(input);
 
-    expect(result.recommendation).toBe(recommendation);
-    expect(result.signals).toEqual(expect.arrayContaining(signals));
+    expect(result.recommendation).toBe(expectedRecommendation);
+    expect(result.signals).toEqual(expect.arrayContaining(expectedSignals));
   });
 
   it("keeps lifecycle intent evaluation advisory-only", () => {

--- a/tests/lifecycle-intent.test.ts
+++ b/tests/lifecycle-intent.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { evaluateEngineeringLifecycleIntent } from "../src/code/lifecycle-intent.js";
+
+describe("engineering lifecycle intent evaluator", () => {
+  it.each([
+    {
+      name: "read-only explanation",
+      input: "Explain what the package.json scripts do. Do not edit files.",
+      recommendation: "stay-light",
+      signals: ["read-only"],
+    },
+    {
+      name: "small single-file fix",
+      input: "Fix a typo in README.md.",
+      recommendation: "stay-light",
+      signals: ["small-task", "single-file"],
+    },
+    {
+      name: "multi-file API rename",
+      input: "Rename the createClient API across src, update imports, and run tests.",
+      recommendation: "strict-candidate",
+      signals: ["multi-file", "refactor"],
+    },
+    {
+      name: "module move with references",
+      input: "Move the parser module, update all references, and refresh the tests.",
+      recommendation: "strict-candidate",
+      signals: ["multi-file", "refactor"],
+    },
+    {
+      name: "dependency migration",
+      input: "Upgrade zod, update package.json and pnpm-lock.yaml, then run npm install.",
+      recommendation: "strict-candidate",
+      signals: ["dependency-change", "package-or-config"],
+    },
+    {
+      name: "configuration migration",
+      input: "Migrate tsconfig and the GitHub Actions workflow for the new build.",
+      recommendation: "strict-candidate",
+      signals: ["migration", "package-or-config"],
+    },
+    {
+      name: "failed verification revise flow",
+      input: "Tests failed after step 2; revise_plan should replace the remaining steps.",
+      recommendation: "strict-candidate",
+      signals: ["failed-verification", "plan-revision"],
+    },
+    {
+      name: "explicit strict lifecycle",
+      input: "/plan strict refactor the shell gate and update the lifecycle tests",
+      recommendation: "strict-candidate",
+      signals: ["explicit-strict", "refactor"],
+    },
+    {
+      name: "broad cleanup asks for plan but does not auto-enforce",
+      input: "Clean up the routing layer across modules.",
+      recommendation: "suggest-plan",
+      signals: ["multi-file"],
+    },
+    {
+      name: "cancel intent stays lightweight",
+      input: "Stop the current lifecycle task and cancel the plan.",
+      recommendation: "stay-light",
+      signals: ["cancel"],
+    },
+    {
+      name: "Chinese multi-file refactor",
+      input: "把 API 模块移动到新的目录，更新所有引用并跑测试。",
+      recommendation: "strict-candidate",
+      signals: ["multi-file", "refactor"],
+    },
+    {
+      name: "Chinese small fix",
+      input: "修一下 README 里的一个拼写错误。",
+      recommendation: "stay-light",
+      signals: ["small-task", "single-file"],
+    },
+  ])("classifies $name", ({ input, recommendation, signals }) => {
+    const result = evaluateEngineeringLifecycleIntent(input);
+
+    expect(result.recommendation).toBe(recommendation);
+    expect(result.signals).toEqual(expect.arrayContaining(signals));
+  });
+
+  it("keeps lifecycle intent evaluation advisory-only", () => {
+    const result = evaluateEngineeringLifecycleIntent("Refactor the parser across modules.");
+
+    expect(result.modelVisible).toBe(false);
+    expect(result.enforced).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Extract the lifecycle intent corpus into `tests/fixtures/lifecycle-intent-corpus.json` so future false-positive and false-negative cases can be accumulated without editing test code.
- Add a small advisory-only corpus runner that reports recommendation accuracy and signal recall without wiring anything into runtime enforcement.
- Add `scripts/evaluate-lifecycle-intent.mts` as an offline evaluator script with text and JSON output.
- Reuse the fixture from the existing intent evaluator tests to avoid corpus drift.

## Runtime / cache boundary
- No prompt changes.
- No tool schema changes.
- No lifecycle runtime changes.
- No auto-arm or enforcement changes.

## Test Plan
- `npm test -- tests/lifecycle-intent.test.ts tests/lifecycle-intent-runner.test.ts`
- `npx biome check src/code/lifecycle-intent-runner.ts tests/lifecycle-intent.test.ts tests/lifecycle-intent-runner.test.ts scripts/evaluate-lifecycle-intent.mts`
- `npx tsx scripts/evaluate-lifecycle-intent.mts --json`
- `npm test -- tests/code-prompt.test.ts tests/lifecycle-intent.test.ts tests/lifecycle-intent-runner.test.ts tests/lifecycle.test.ts tests/lifecycle-e2e.test.ts tests/tools.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run verify`
- Pre-push hook also ran `npm run verify` successfully: 261 test files passed, 3590 tests passed, 10 skipped.

Refs #1285