### PR TITLE
fix(desktop): prevent stale events from corrupting UI after session switch

### DIFF
--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -739,6 +739,8 @@ interface Tab {
   planTotalSteps: number;
   mcpRuntime: McpRuntime | null;
   mcpStatuses: Map<string, { kind: McpSpecStatus; reason?: string; toolCount?: number }>;
+  /** True while a session switch is in progress — prevents stale events from the old turn. */
+  switching: boolean;
 }
 
 let tabCounter = 0;
@@ -1232,6 +1234,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
       planTotalSteps: 0,
       mcpRuntime: null,
       mcpStatuses: new Map(),
+      switching: false,
     };
     tab.currentSession = mintSessionFor(dir);
     tabs.set(tab.id, tab);
@@ -1386,20 +1389,28 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
         emit({ type: "$error", message: (err as Error).message }, tab.id);
       } finally {
         tab.aborter = null;
-        if (fromQQ && lastAssistantText && qqRuntime.channel && qqRuntime.replyThisTurn) {
-          await qqRuntime.channel.sendResponse(lastAssistantText).catch((err) => {
-            emit({ type: "$error", message: `qq send failed: ${(err as Error).message}` }, tab.id);
-          });
+        // If a session switch happened while this turn was running,
+        // suppress stale events to avoid UI state corruption (#1217).
+        if (!tab.switching) {
+          if (fromQQ && lastAssistantText && qqRuntime.channel && qqRuntime.replyThisTurn) {
+            await qqRuntime.channel.sendResponse(lastAssistantText).catch((err) => {
+              emit(
+                { type: "$error", message: `qq send failed: ${(err as Error).message}` },
+                tab.id,
+              );
+            });
+          }
+          qqRuntime.replyThisTurn = false;
+          emit({ type: "$turn_complete" }, tab.id);
+          if (tab.planTotalSteps > 0 && tab.completedStepIds.size >= tab.planTotalSteps) {
+            tab.completedStepIds.clear();
+            tab.planTotalSteps = 0;
+            emit({ type: "$plan_cleared" }, tab.id);
+          }
+          emitSessions(tab);
+          void emitBalance(tab);
         }
-        qqRuntime.replyThisTurn = false;
-        emit({ type: "$turn_complete" }, tab.id);
-        if (tab.planTotalSteps > 0 && tab.completedStepIds.size >= tab.planTotalSteps) {
-          tab.completedStepIds.clear();
-          tab.planTotalSteps = 0;
-          emit({ type: "$plan_cleared" }, tab.id);
-        }
-        emitSessions(tab);
-        void emitBalance(tab);
+        tab.switching = false;
       }
     });
   }
@@ -2090,6 +2101,9 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
       try {
         const records = loadSessionMessages(msg.name);
         const meta = loadSessionMeta(msg.name);
+        // Mark switching BEFORE aborting — runTurn's finally block checks
+        // this flag to skip stale events (#1217).
+        tab.switching = true;
         abortTurn(tab);
         cancelPendingGates(tab);
         tab.currentSession = msg.name;
@@ -2133,6 +2147,9 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
       return;
     }
     if (msg.cmd === "new_chat") {
+      // Mark switching BEFORE aborting — runTurn's finally block checks
+      // this flag to skip stale events (#1217).
+      tab.switching = true;
       abortTurn(tab);
       cancelPendingGates(tab);
       tab.currentSession = mintSessionFor(tab.rootDir);

--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -2101,9 +2101,9 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
       try {
         const records = loadSessionMessages(msg.name);
         const meta = loadSessionMeta(msg.name);
-        // Mark switching BEFORE aborting — runTurn's finally block checks
-        // this flag to skip stale events (#1217).
-        tab.switching = true;
+        // Only set switching flag when there's a live turn to abort —
+        // otherwise the flag stays true and suppresses the first turn's events (#1217).
+        if (tab.aborter) tab.switching = true;
         abortTurn(tab);
         cancelPendingGates(tab);
         tab.currentSession = msg.name;
@@ -2147,9 +2147,9 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
       return;
     }
     if (msg.cmd === "new_chat") {
-      // Mark switching BEFORE aborting — runTurn's finally block checks
-      // this flag to skip stale events (#1217).
-      tab.switching = true;
+      // Only set switching flag when there's a live turn to abort —
+      // otherwise the flag stays true and suppresses the first turn's events (#1217).
+      if (tab.aborter) tab.switching = true;
       abortTurn(tab);
       cancelPendingGates(tab);
       tab.currentSession = mintSessionFor(tab.rootDir);


### PR DESCRIPTION
Fixes #1217

When a session switch happens while a turn is running, the old turn cleanup may still emit events that corrupt the new session UI state.

Add switching flag to Tab interface:
- Set tab.switching=true ONLY when tab.aborter exists (live turn to abort)
- Check tab.switching in runTurn finally block to suppress stale events
- Reset flag after processing

This prevents the flag from getting stuck when no turn is in flight — the common session-switch path.

Esc + New Session still works because switching is only set when aborter exists, not in Esc handler.

Tested: npm run lint, npm run typecheck