### PR TITLE
fix(presets): drop stale "5/31 discount" framing in pro cost copy

### DIFF
--- a/dashboard/src/i18n/en.ts
+++ b/dashboard/src/i18n/en.ts
@@ -203,7 +203,7 @@ export const en = {
     presetFlashTitle:
       "flash — always flash; no auto-escalate. /pro still works for one-shot manual",
     presetProTitle:
-      "pro — always pro; ~3× flash cost (5/31 discount). Locks in on hard architecture work.",
+      "pro — always pro; ~3× flash cost. Locks in on hard architecture work.",
     editGateTitle: "edit gate — Shift+Tab cycles in TUI",
     editReviewTitle: "review — both edits and non-allowlisted shell ask first",
     editAutoTitle: "auto — edits auto-apply, shell still asks",

--- a/dashboard/src/i18n/zh-CN.ts
+++ b/dashboard/src/i18n/zh-CN.ts
@@ -200,7 +200,7 @@ export const zhCN = {
     presetTitle: "预设 — 模型承诺",
     presetAutoTitle: "auto — flash 基线；困难轮次自动升级为 pro（NEEDS_PRO / 失败阈值）",
     presetFlashTitle: "flash — 始终 flash；不自动升级。/pro 仍可用于一次性手动提升",
-    presetProTitle: "pro — 始终 pro；约 3 倍 flash 成本（5/31 折扣）。锁定困难的架构工作。",
+    presetProTitle: "pro — 始终 pro；约 3 倍 flash 成本。锁定困难的架构工作。",
     editGateTitle: "编辑门控 — Shift+Tab 在 TUI 中循环",
     editReviewTitle: "review — 编辑和非允许列表的 shell 命令都会先询问",
     editAutoTitle: "auto — 编辑自动应用，shell 仍会询问",

--- a/src/cli/ui/presets.ts
+++ b/src/cli/ui/presets.ts
@@ -39,7 +39,7 @@ export const PRESET_DESCRIPTIONS: Record<
   },
   pro: {
     headline: "v4-pro always",
-    cost: "~3× flash (5/31 discount) / ~12× full price · for hard multi-turn work",
+    cost: "~3× flash · for hard multi-turn work",
   },
 };
 

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -785,8 +785,7 @@ export const EN: TranslationSchema = {
         "  auto   v4-flash → v4-pro on hard turns  ← default · cheap when easy, smart when hard",
       helpPresetFlash:
         "  flash  v4-flash always                  cheapest · predictable per-turn cost",
-      helpPresetPro:
-        "  pro    v4-pro   always                  ~3× flash (5/31) · hard multi-turn work",
+      helpPresetPro: "  pro    v4-pro   always                  ~3× flash · hard multi-turn work",
       helpSessionsTitle: "Sessions (auto-enabled by default, named 'default'):",
       helpSessionCustom: "  reasonix chat --session <name>   use a different named session",
       helpSessionNone: "  reasonix chat --no-session       disable persistence for this run",


### PR DESCRIPTION
## Summary

The 75%-off promo became the **permanent** pro rate on 2026-05-31 — but four UI strings still call it a "5/31 discount", which makes readers think pro is on a limited-time sale that will expire.

Pricing math is already correct: `src/telemetry/stats.ts` uses `inputCacheHit: 0.003625 / inputCacheMiss: 0.435 / output: 0.87` USD per 1M tokens, exactly 1/4 of the original `0.0145 / 1.74 / 3.48` — i.e. the new permanent rate. **No billing change**, copy only.

Strings updated:
- `src/cli/ui/presets.ts:42`
- `src/i18n/EN.ts:789`
- `dashboard/src/i18n/en.ts:206`
- `dashboard/src/i18n/zh-CN.ts:203`

`CHANGELOG.md:3708` left untouched — it's a historical record of the 0.4x-era reasoning.

Closes #1559

## Test plan
- [x] `npx vitest run tests/presets.test.ts tests/ui-model-picker.test.tsx tests/skills.test.ts` — 63/63 pass
- [x] biome lint clean on changed files