### PR TITLE
chore(install): include desktop deps in root postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "packages/*"
   ],
   "scripts": {
-    "postinstall": "npm --prefix dashboard ci --ignore-scripts",
+    "postinstall": "npm --prefix dashboard ci --ignore-scripts && npm --prefix desktop ci --ignore-scripts",
     "build:dashboard": "npm --prefix dashboard run build",
     "build": "npm run build:dashboard && tsup && node scripts/copy-dashboard-vendor-css.mjs && node scripts/copy-tree-sitter-grammars.mjs",
     "dev": "tsx src/cli/index.ts",


### PR DESCRIPTION
## Summary

The root `postinstall` only runs `npm --prefix dashboard ci`, leaving `desktop/node_modules` empty after a clean `npm ci`. Vitest scans `desktop/src/**` for tests, so the first desktop test that imports a transitive dep (`react-markdown` via `Markdown.tsx`) fails Vite resolution in CI — even though it passes locally for anyone who's ever run `npm install` inside `desktop/`.

Add `desktop` to the same `--ignore-scripts` chain dashboard already uses.

Unblocks #1562.

## Test plan

- [x] `npm --prefix desktop ci --ignore-scripts` works against the existing lockfile
- [x] `desktop/node_modules/react-markdown` resolves after install
- [x] Local `npm run verify` green