### PR TITLE
feat(dashboard): persist active session in URL for shareable links

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -38,6 +38,7 @@ import type {
   SettingsPatch,
   SkillInfo,
 } from "./protocol";
+import { readSessionFromUrl, writeSessionToUrl } from "./lib/session-url";
 import { type QQDesktopSettingsState } from "./qq-settings";
 import { Composer, type SlashCmd } from "./ui/composer";
 import { ContextPanel } from "./ui/context-panel";
@@ -1421,6 +1422,30 @@ function TabRuntime({
     if (!active) return;
     loadQQSettings();
   }, [active, loadQQSettings]);
+
+  const initialUrlSession = useRef<string | null>(readSessionFromUrl());
+  const urlSessionDispatched = useRef(false);
+  useEffect(() => {
+    if (!active) return;
+    if (urlSessionDispatched.current) return;
+    if (!state.ready) return;
+    if (state.sessions.length === 0) return;
+    urlSessionDispatched.current = true;
+    const target = initialUrlSession.current;
+    if (!target) return;
+    if (target === state.currentSession) return;
+    if (!state.sessions.some((s) => s.name === target)) {
+      writeSessionToUrl(null);
+      return;
+    }
+    sendRpc({ cmd: "session_load", name: target });
+  }, [active, state.ready, state.sessions, state.currentSession, sendRpc]);
+
+  useEffect(() => {
+    if (!active) return;
+    if (!urlSessionDispatched.current) return;
+    writeSessionToUrl(state.currentSession ?? null);
+  }, [active, state.currentSession]);
 
   useEffect(() => {
     // Every TabRuntime stays mounted (display:none on inactive), so each registers its own keydown — without this gate Cmd+N would fire newChat() in every tab and wipe the inactive ones' sessions.

--- a/dashboard/src/lib/session-url.ts
+++ b/dashboard/src/lib/session-url.ts
@@ -1,0 +1,21 @@
+const SESSION_PARAM = "session";
+
+export function readSessionFromUrl(): string | null {
+  if (typeof window === "undefined") return null;
+  const raw = new URLSearchParams(window.location.search).get(SESSION_PARAM);
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function writeSessionToUrl(name: string | null): void {
+  if (typeof window === "undefined") return;
+  const url = new URL(window.location.href);
+  if (name && name.trim().length > 0) {
+    url.searchParams.set(SESSION_PARAM, name);
+  } else {
+    url.searchParams.delete(SESSION_PARAM);
+  }
+  if (url.href === window.location.href) return;
+  window.history.replaceState(null, "", url.href);
+}

--- a/tests/dashboard-session-url.test.ts
+++ b/tests/dashboard-session-url.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readSessionFromUrl, writeSessionToUrl } from "../dashboard/src/lib/session-url";
+
+type FakeWindow = {
+  location: { href: string; search: string };
+  history: { replaceState: (s: unknown, t: string, url: string) => void };
+};
+
+function installFakeWindow(href: string): FakeWindow {
+  const fake: FakeWindow = {
+    location: { href, search: new URL(href).search },
+    history: {
+      replaceState: (_state, _title, url) => {
+        const next = new URL(url, fake.location.href);
+        fake.location.href = next.href;
+        fake.location.search = next.search;
+      },
+    },
+  };
+  (globalThis as unknown as { window: FakeWindow }).window = fake;
+  return fake;
+}
+
+describe("dashboard session URL helper", () => {
+  beforeEach(() => {
+    (globalThis as { window?: unknown }).window = undefined;
+  });
+  afterEach(() => {
+    (globalThis as { window?: unknown }).window = undefined;
+  });
+
+  it("returns null when no window (SSR-safe)", async () => {
+    expect(readSessionFromUrl()).toBeNull();
+  });
+
+  it("returns null when ?session is absent", async () => {
+    installFakeWindow("http://localhost:3000/?token=abc");
+
+    expect(readSessionFromUrl()).toBeNull();
+  });
+
+  it("returns the session name when ?session=NAME present", async () => {
+    installFakeWindow("http://localhost:3000/?token=abc&session=foo");
+
+    expect(readSessionFromUrl()).toBe("foo");
+  });
+
+  it("returns null when ?session= is blank", async () => {
+    installFakeWindow("http://localhost:3000/?token=abc&session=");
+
+    expect(readSessionFromUrl()).toBeNull();
+  });
+
+  it("decodes CJK / spaces in session names", async () => {
+    installFakeWindow("http://localhost:3000/?session=%E4%BC%9A%E8%AF%9D%201");
+
+    expect(readSessionFromUrl()).toBe("会话 1");
+  });
+
+  it("writes session param while preserving token", async () => {
+    const fake = installFakeWindow("http://localhost:3000/?token=abc");
+
+    writeSessionToUrl("foo");
+    expect(fake.location.href).toContain("token=abc");
+    expect(fake.location.href).toContain("session=foo");
+  });
+
+  it("replaces an existing session param", async () => {
+    const fake = installFakeWindow("http://localhost:3000/?token=abc&session=old");
+
+    writeSessionToUrl("new");
+    expect(fake.location.href).toContain("session=new");
+    expect(fake.location.href).not.toContain("session=old");
+  });
+
+  it("clears the session param when passed null", async () => {
+    const fake = installFakeWindow("http://localhost:3000/?token=abc&session=foo");
+
+    writeSessionToUrl(null);
+    expect(fake.location.href).not.toContain("session=");
+    expect(fake.location.href).toContain("token=abc");
+  });
+
+  it("treats blank/whitespace name as clear", async () => {
+    const fake = installFakeWindow("http://localhost:3000/?token=abc&session=foo");
+
+    writeSessionToUrl("   ");
+    expect(fake.location.href).not.toContain("session=");
+  });
+
+  it("is a no-op when the URL is already correct", async () => {
+    const fake = installFakeWindow("http://localhost:3000/?token=abc&session=foo");
+    let callCount = 0;
+    const original = fake.history.replaceState;
+    fake.history.replaceState = (...args) => {
+      callCount += 1;
+      original(...args);
+    };
+
+    writeSessionToUrl("foo");
+    expect(callCount).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Until now the web dashboard URL only carried the auth token, so a copied link always landed on whichever session the CLI happened to be attached to. Refreshing a tab or pasting the URL into another window never restored the session you were actually viewing — bad UX.

Now:
- Switching a session in the sidebar updates the URL to `?session=NAME` (via `history.replaceState`, no back-button noise).
- On the active tab's first ready+sessions tick, the dashboard reads `?session=NAME` back from the URL and auto-dispatches `session_load` if that session exists.
- Unknown session names clear the param instead of erroring — covers the case where someone shares a link to a session that's since been deleted locally.
- Both effects are gated on the tab being active, so multi-tab dashboards don't fight over the URL.

The token query param continues to work the same way; this PR only adds the session param next to it.

## What this does NOT solve

- **Token across CLI restarts** — token still regenerates each `/dashboard` start, so links die when the CLI restarts. That's a separate auth-model change, tracked separately.

## Test plan

- [x] `tests/dashboard-session-url.test.ts` — 10 cases covering read/write, CJK + space encoding, blank-name clear, no-op when URL already correct, SSR-safe (`typeof window === "undefined"`)
- [x] `npx tsc --noEmit -p dashboard` clean
- [x] `npm --prefix dashboard run build` clean