### PR TITLE
perf(dashboard): split heavy vendor libs into separate chunks

### DIFF
--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -50,6 +50,25 @@ export default defineConfig({
           if (/\.(woff2?|ttf|otf)$/.test(assetInfo.name ?? "")) return "assets/[name].[ext]";
           return "[name].[ext]";
         },
+        manualChunks(id) {
+          if (!id.includes("node_modules")) return;
+          if (id.includes("/katex/")) return "vendor-katex";
+          if (
+            id.includes("/react-markdown/") ||
+            id.includes("/remark-") ||
+            id.includes("/rehype-") ||
+            id.includes("/mdast-") ||
+            id.includes("/micromark") ||
+            id.includes("/unist-") ||
+            id.includes("/hast-")
+          )
+            return "vendor-markdown";
+          if (id.includes("/prism-react-renderer/")) return "vendor-prism";
+          if (id.includes("/lucide-react/")) return "vendor-icons";
+          if (id.includes("/react-virtuoso/")) return "vendor-virtuoso";
+          if (id.includes("/react/") || id.includes("/react-dom/") || id.includes("/scheduler/"))
+            return "vendor-react";
+        },
       },
     },
   },

--- a/src/server/assets.ts
+++ b/src/server/assets.ts
@@ -80,8 +80,26 @@ function loadIndexTemplate(): string {
   return loadCachedText(join(ASSET_DIR, "index.html"));
 }
 
-function loadApp(): string {
-  return loadCachedText(join(ASSET_DIR, "dist", "app.js"));
+/** Append `?token=` to relative chunk imports — browsers drop the parent query on relative ESM resolution. */
+function injectTokenIntoChunkImports(body: string, token: string): string {
+  return body.replace(
+    /(from\s*|import\s*)(["'])(\.\/[\w.-]+\.js)\2/g,
+    (_, kw: string, q: string, path: string) => `${kw}${q}${path}?token=${token}${q}`,
+  );
+}
+
+function loadApp(token: string): string {
+  const raw = loadCachedText(join(ASSET_DIR, "dist", "app.js"));
+  return injectTokenIntoChunkImports(raw, token);
+}
+
+function loadChunk(name: string, token: string): string | null {
+  try {
+    const raw = loadCachedText(join(ASSET_DIR, "dist", name));
+    return injectTokenIntoChunkImports(raw, token);
+  } catch {
+    return null;
+  }
 }
 
 function loadAppMap(): string | null {
@@ -172,9 +190,12 @@ function loadDistFile(name: string): { body: string | Buffer; isBinary: boolean 
   return null;
 }
 
-export function serveAsset(name: string): { body: string | Buffer; contentType: string } | null {
+export function serveAsset(
+  name: string,
+  token = "",
+): { body: string | Buffer; contentType: string } | null {
   if (name === "app.js") {
-    return { body: loadApp(), contentType: "application/javascript; charset=utf-8" };
+    return { body: loadApp(token), contentType: "application/javascript; charset=utf-8" };
   }
   if (name === "app.js.map") {
     const body = loadAppMap();
@@ -182,6 +203,12 @@ export function serveAsset(name: string): { body: string | Buffer; contentType: 
   }
   if (name === "app.css") {
     return { body: loadCss(), contentType: "text/css; charset=utf-8" };
+  }
+  // Same rewrite for chunk-to-chunk imports (e.g. vendor-markdown → vendor-react).
+  if (/^vendor-[\w.-]+\.js$/.test(name)) {
+    const body = loadChunk(name, token);
+    if (body == null) return null;
+    return { body, contentType: "application/javascript; charset=utf-8" };
   }
   if (VENDOR_CSS_NAMES.has(name)) {
     const body = loadVendorCss(name);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -139,7 +139,7 @@ export async function dispatch(
       res.end();
       return;
     }
-    const asset = serveAsset(path.slice("/assets/".length));
+    const asset = serveAsset(path.slice("/assets/".length), expectedToken);
     if (!asset) {
       res.writeHead(404);
       res.end("not found");

--- a/tests/dashboard-smoke.test.ts
+++ b/tests/dashboard-smoke.test.ts
@@ -60,6 +60,32 @@ describe("dashboard server integration", () => {
     expect(html).toContain("standalone");
   });
 
+  it("serveAsset rewrites cross-chunk imports in app.js to carry the token", async () => {
+    const { serveAsset } = await import("../src/server/assets.js");
+    const asset = serveAsset("app.js", "tkn123");
+    expect(asset).not.toBeNull();
+    const body = asset?.body as string;
+    // Vendor chunks must be reachable; browsers strip query strings on relative
+    // module resolution, so static imports need the token baked in by the server.
+    const vendorImports = body.match(/from\s*["']\.\/vendor-[\w-]+\.js[^"']*["']/g) ?? [];
+    expect(vendorImports.length).toBeGreaterThan(0);
+    for (const imp of vendorImports) {
+      expect(imp).toContain("?token=tkn123");
+    }
+  });
+
+  it("serveAsset rewrites cross-chunk imports inside vendor chunks too", async () => {
+    const { serveAsset } = await import("../src/server/assets.js");
+    // vendor-markdown imports vendor-react and vendor-katex — also relative.
+    const asset = serveAsset("vendor-markdown.js", "tkn456");
+    if (asset == null) return; // not a build with that chunk; ignore
+    const body = asset.body as string;
+    const vendorImports = body.match(/from\s*["']\.\/vendor-[\w-]+\.js[^"']*["']/g) ?? [];
+    for (const imp of vendorImports) {
+      expect(imp).toContain("?token=tkn456");
+    }
+  });
+
   it("vendor CSS files are served when present", async () => {
     const { serveAsset } = await import("../src/server/assets.js");
     const hljs = serveAsset("vendor-hljs.css");


### PR DESCRIPTION
## Summary

Web dashboard ships as a 943 KB monolithic `app.js` after #1418. PR description called the bundle size out as known low-priority debt; user feedback on the deployed dashboard says perf is bad enough to act on it.

Configure Vite `manualChunks` to peel heavy vendor libs out of the entry. Total bytes don't change but the browser fetches chunks in parallel and reuses them across deploys when only app code moves.

| | Before | After (entry) |
|---|---:|---:|
| `app.js` (entry) | **942.61 KB** (gzip 292 KB) | **223.76 KB** (gzip 75 KB) |
| `vendor-react.js` | — | 192.84 KB (gzip 60 KB) |
| `vendor-katex.js` | — | 258.26 KB (gzip 78 KB) |
| `vendor-markdown.js` | — | 171.91 KB (gzip 52 KB) |
| `vendor-prism.js` | — | 86.04 KB (gzip 27 KB) |
| `vendor-icons.js` | — | 8.07 KB (gzip 2 KB) |

Entry size dropped 76%, gzip 74%. Real TTI win comes from parallel fetch + per-chunk parse + cross-deploy caching (vendor chunks stay cached when only app code changes).

## Token-gated chunks

Browsers strip query strings when resolving relative ESM imports, so a chunk-to-chunk reference like `from "./vendor-react.js"` would 401 against the token-gated `/assets/*` route. `serveAsset` now rewrites every relative `.js` import in `app.js` and `vendor-*.js` to carry the live token before sending the body — same shape as the existing index.html templating, just applied to JS bodies.

## Future work (not in this PR)

- `React.lazy` on the Markdown surface so the markdown + katex chunks only download when first MD/math content appears. Bigger TTI win, separate PR.
- `react-virtuoso` virtualization for the thread (it's already a declared dep). Separate PR.

## Test plan
- [x] Two new `dashboard-smoke.test.ts` cases verify the token is injected into both `app.js`→vendor imports and chunk→chunk imports
- [x] `npm --prefix dashboard run build` clean, no circular chunks
- [x] Full `npm run verify` clean (3526+ tests pass)
