### PR TITLE
fix(ui): preserve user message newlines

### DIFF
--- a/dashboard/src/styles.css
+++ b/dashboard/src/styles.css
@@ -1617,6 +1617,11 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
   padding: 10px 14px;
 }
 
+.msg.user .msg-text,
+.msg.user .msg-text.user-pending {
+  white-space: pre-wrap;
+}
+
 .msg-text {
   font-size: 14px;
   line-height: 1.72;

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -1660,6 +1660,11 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
   padding: 10px 14px;
 }
 
+.msg.user .msg-text,
+.msg.user .msg-text.user-pending {
+  white-space: pre-wrap;
+}
+
 .msg-text {
   font-size: 14px;
   line-height: 1.72;

--- a/tests/user-message-newlines.test.ts
+++ b/tests/user-message-newlines.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("user message newline rendering", () => {
+  it("preserves whitespace in desktop and dashboard user bubbles", () => {
+    const desktopCss = readFileSync("desktop/src/styles.css", "utf8");
+    const dashboardCss = readFileSync("dashboard/src/styles.css", "utf8");
+
+    expect(desktopCss).toContain(".msg.user .msg-text");
+    expect(desktopCss).toContain("white-space: pre-wrap");
+    expect(dashboardCss).toContain(".msg.user .msg-text");
+    expect(dashboardCss).toContain("white-space: pre-wrap");
+  });
+});


### PR DESCRIPTION
## Summary

Preserve multiline formatting for user message bubbles in the desktop and dashboard chat UI, so text sent with line breaks continues to display as multiple lines after submission.

## Problem

When users send multiline messages, the message content itself is preserved, but the rendered user bubble collapses whitespace because the `.msg-text` style does not preserve line breaks. As a result, newlines are rendered as spaces and multiline user input appears as a single line.

The issue is in the desktop/dashboard message rendering path:
- `desktop/src/ui/thread.tsx` renders user messages through `UserMsg`
- `dashboard/src/ui/thread.tsx` renders user messages through `UserMsg`
- `desktop/src/styles.css` and `dashboard/src/styles.css` styled `.msg-text` without `white-space: pre-wrap`
- TUI/CLI message storage and rendering paths preserve the original user text and do not apply the same CSS whitespace collapsing behavior

## Fix

- **`desktop/src/styles.css`** — Added `white-space: pre-wrap` for `.msg.user .msg-text` and `.msg.user .msg-text.user-pending`, preserving user-entered newlines in desktop message bubbles.
- **`dashboard/src/styles.css`** — Added the same user-message-specific whitespace rule for dashboard message bubbles.
- **`tests/user-message-newlines.test.ts`** — Added a regression test that verifies both desktop and dashboard styles include the user bubble whitespace preservation rule.

## Verification

| Check | Result |
|---|---|
| `npm exec vitest run tests/user-message-newlines.test.ts tests/desktop-user-message.test.ts` | ✅ passes |
| `npm run verify` | ✅ passes |
| Commit pre-commit lint hook | ✅ passes |


Closed #1567
