### PR TITLE
fix(dashboard): include current session in CLI-printed URL

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -2450,8 +2450,16 @@ function AppInner({
   }, [log]);
 
   const getDashboardUrl = useCallback((): string | null => {
-    return dashboardRef.current?.url ?? null;
-  }, []);
+    const baseUrl = dashboardRef.current?.url ?? null;
+    if (!baseUrl || !session) return baseUrl;
+    try {
+      const url = new URL(baseUrl);
+      url.searchParams.set("session", session);
+      return url.toString();
+    } catch {
+      return baseUrl;
+    }
+  }, [session]);
 
   // Auto-start the dashboard once the TUI is mounted unless the user
   // opted out with --no-dashboard. The whole point is discoverability:
@@ -2464,14 +2472,15 @@ function AppInner({
     startDashboard()
       .then((url) => {
         if (!url) return;
-        log.pushInfo(`/dashboard  →  ${url}`);
-        if (openDashboard) openUrl(url);
+        const sessionUrl = getDashboardUrl() ?? url;
+        log.pushInfo(`/dashboard  →  ${sessionUrl}`);
+        if (openDashboard) openUrl(sessionUrl);
       })
       .catch((err) => {
         const reason = err instanceof Error ? err.message : String(err);
         log.pushInfo(t("ui.dashboardAutoStartFailed", { reason }));
       });
-  }, [noDashboard, openDashboard, startDashboard, log]);
+  }, [noDashboard, openDashboard, startDashboard, log, getDashboardUrl]);
 
   // Tear the dashboard down on unmount so the port doesn't leak when
   // the TUI exits via /exit, Ctrl+C, etc.


### PR DESCRIPTION
## Summary

After #1586 the browser URL stays in sync with the active session, but the URL the CLI prints on startup and via \`/dashboard\` / \`/dashboard copy\` still only carried \`?token=\`. Copying it never restored the right session — the new tab always landed on whichever session was attached at the moment the URL was opened.

\`getDashboardUrl()\` now appends \`&session=<name>\` from the CLI's current attached session, and the auto-start log line + \`openUrl\` call go through the same helper, so the URL you see, copy, or click always points back at the session the CLI is on.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx vitest run tests/dashboard-*.test.ts\` 26/26 pass