### PR TITLE
fix(ui): prevent long messages from overflowing chat bubbles

### DIFF
--- a/dashboard/src/styles.css
+++ b/dashboard/src/styles.css
@@ -1651,14 +1651,10 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
 .msg.user .body {
   flex: none;
   max-width: 82%;
+  min-width: 0;
   background: var(--panel-2);
   border-radius: 12px;
   padding: 10px 14px;
-}
-
-.msg.user .msg-text,
-.msg.user .msg-text.user-pending {
-  white-space: pre-wrap;
 }
 
 .msg-text {
@@ -1666,9 +1662,17 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
   line-height: 1.72;
   color: var(--fg);
   text-wrap: pretty;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+.msg-text .markdown {
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 .msg-text p {
   margin: 0 0 12px;
+  overflow-wrap: anywhere;
 }
 .msg-text p:last-child {
   margin-bottom: 0;
@@ -1681,6 +1685,7 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
   padding: 1px 6px;
   border-radius: 4px;
   font-size: 0.875em;
+  overflow-wrap: anywhere;
 }
 .msg-text pre code,
 .markdown pre code {
@@ -1704,6 +1709,7 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
   color: var(--accent);
   text-decoration: none;
   border-bottom: 1px dotted currentColor;
+  overflow-wrap: anywhere;
 }
 .msg-text ul,
 .markdown ul {

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -1686,14 +1686,10 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
   flex: none;
   max-width: 82%;
   position: relative;
+  min-width: 0;
   background: var(--panel-2);
   border-radius: 12px;
   padding: 10px 14px;
-}
-
-.msg.user .msg-text,
-.msg.user .msg-text.user-pending {
-  white-space: pre-wrap;
 }
 
 .msg-text {
@@ -1701,9 +1697,17 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
   line-height: 1.72;
   color: var(--fg);
   text-wrap: pretty;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+.msg-text .markdown {
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 .msg-text p {
   margin: 0 0 12px;
+  overflow-wrap: anywhere;
 }
 .msg-text p:last-child {
   margin-bottom: 0;
@@ -1716,6 +1720,7 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
   padding: 1px 6px;
   border-radius: 4px;
   font-size: 0.875em;
+  overflow-wrap: anywhere;
 }
 .msg-text pre code,
 .markdown pre code {
@@ -1739,6 +1744,7 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
   color: var(--accent);
   text-decoration: none;
   border-bottom: 1px dotted currentColor;
+  overflow-wrap: anywhere;
 }
 .msg-text ul,
 .markdown ul {

--- a/tests/user-message-newlines.test.ts
+++ b/tests/user-message-newlines.test.ts
@@ -1,14 +1,17 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
-describe("user message newline rendering", () => {
-  it("preserves whitespace in desktop and dashboard user bubbles", () => {
+describe("user message rendering", () => {
+  it("preserves whitespace and wraps long text in desktop and dashboard bubbles", () => {
     const desktopCss = readFileSync("desktop/src/styles.css", "utf8");
     const dashboardCss = readFileSync("dashboard/src/styles.css", "utf8");
 
-    expect(desktopCss).toContain(".msg.user .msg-text");
-    expect(desktopCss).toContain("white-space: pre-wrap");
-    expect(dashboardCss).toContain(".msg.user .msg-text");
-    expect(dashboardCss).toContain("white-space: pre-wrap");
+    for (const css of [desktopCss, dashboardCss]) {
+      expect(css).toContain(".msg-text {");
+      expect(css).toContain("white-space: pre-wrap");
+      expect(css).toContain("overflow-wrap: anywhere");
+      expect(css).toContain(".msg-text .markdown");
+      expect(css).toContain("white-space: normal");
+    }
   });
 });


### PR DESCRIPTION
## What

Updates the desktop and dashboard message styles so long unbroken user-visible text, such as Windows paths, URLs, and long tokens, wraps inside chat bubbles instead of stretching the layout.

## Changes

- Rebased on the latest upstream `main`.
- Mirrored the wrapping fix in both `desktop/src/styles.css` and `dashboard/src/styles.css`.
- Removed the now-redundant user-specific `white-space: pre-wrap` rule added by #1588, since `.msg-text` now carries that behavior directly.
- Dropped the newly added `word-break: break-word` usage and rely on the standardized `overflow-wrap: anywhere`.
- Updated `tests/user-message-newlines.test.ts` so it checks the broader shared message-text rules instead of the removed user-specific selector.

## Verification

- Ran `npm run verify`
- Result: build, lint, typecheck, and tests passed