### PR TITLE
fix(desktop): preserve newlines in user message bubbles

### DIFF
--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -1665,6 +1665,7 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
   line-height: 1.72;
   color: var(--fg);
   text-wrap: pretty;
+  white-space: pre-wrap;
 }
 .msg-text p {
   margin: 0 0 12px;


### PR DESCRIPTION
Fixes #1567

User messages were rendered as plain text without Markdown processing, and the .msg-text CSS only had text-wrap: pretty which does not preserve newlines.

Added white-space: pre-wrap to .msg-text so user message text retains line breaks.

Tested: npm run lint passes.