### PR TITLE
fix(desktop): preserve compact composer default

### DIFF
--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -249,6 +249,8 @@ html[data-platform="macos"] .app {
 }
 .app[data-ctx-collapsed="true"][data-side-collapsed="true"] {
   grid-template-columns: 0 1fr 0;
+  --thread-max-width: 1120px;
+  --composer-max-width: 1040px;
 }
 
 /* ---------- TABBAR ---------- */
@@ -1573,7 +1575,7 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
   scroll-padding-bottom: 24px;
 }
 .thread-inner {
-  max-width: 740px;
+  max-width: var(--thread-max-width, 740px);
   margin: 0 auto;
   padding: 0 32px;
   display: flex;
@@ -2785,7 +2787,7 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
   pointer-events: none;
 }
 .composer-inner {
-  max-width: 760px;
+  max-width: var(--composer-max-width, 760px);
   margin: 0 auto;
   position: relative;
   container-type: inline-size;

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -2849,7 +2849,7 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
   padding: 12px 14px 6px;
   font-size: 14px;
   line-height: 1.55;
-  min-height: calc(5 * 1.55em + 18px);
+  min-height: calc(2 * 1.55em + 18px);
   overflow-y: hidden;
   font-family: inherit;
 }

--- a/desktop/src/ui/composer-sizing.ts
+++ b/desktop/src/ui/composer-sizing.ts
@@ -1,4 +1,5 @@
-export const DEFAULT_COMPOSER_ROWS = 5;
+export const DEFAULT_COMPOSER_ROWS = 2;
+export const AUTOSIZE_COMPOSER_ROWS = 5;
 export const MAX_COMPOSER_ROWS = 15;
 
 export type ComposerTextareaSizing = {
@@ -16,11 +17,14 @@ export function getComposerTextareaSizing({
   verticalPaddingPx: number;
 }): ComposerTextareaSizing {
   const safeRows = Math.max(1, Math.ceil(contentRows));
-  const visibleRows = Math.min(Math.max(safeRows, DEFAULT_COMPOSER_ROWS), MAX_COMPOSER_ROWS);
+  const visibleRows =
+    safeRows < AUTOSIZE_COMPOSER_ROWS
+      ? DEFAULT_COMPOSER_ROWS
+      : Math.min(safeRows, MAX_COMPOSER_ROWS);
 
   return {
     heightPx: visibleRows * lineHeightPx + verticalPaddingPx,
-    overflowY: safeRows > MAX_COMPOSER_ROWS ? "auto" : "hidden",
+    overflowY: safeRows > visibleRows ? "auto" : "hidden",
   };
 }
 

--- a/tests/desktop-composer-autosize.test.ts
+++ b/tests/desktop-composer-autosize.test.ts
@@ -1,13 +1,14 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  AUTOSIZE_COMPOSER_ROWS,
   DEFAULT_COMPOSER_ROWS,
   MAX_COMPOSER_ROWS,
   getComposerTextareaSizing,
 } from "../desktop/src/ui/composer-sizing";
 
 describe("desktop composer textarea autosize (#1420)", () => {
-  it("keeps the default height below the default row count", () => {
+  it("keeps the original default height below the autosize threshold", () => {
     const sizing = getComposerTextareaSizing({
       contentRows: 3,
       lineHeightPx: 20,
@@ -15,6 +16,17 @@ describe("desktop composer textarea autosize (#1420)", () => {
     });
 
     expect(sizing.heightPx).toBe(DEFAULT_COMPOSER_ROWS * 20 + 18);
+    expect(sizing.overflowY).toBe("auto");
+  });
+
+  it("starts expanding at the autosize threshold", () => {
+    const sizing = getComposerTextareaSizing({
+      contentRows: AUTOSIZE_COMPOSER_ROWS,
+      lineHeightPx: 20,
+      verticalPaddingPx: 18,
+    });
+
+    expect(sizing.heightPx).toBe(AUTOSIZE_COMPOSER_ROWS * 20 + 18);
     expect(sizing.overflowY).toBe("hidden");
   });
 


### PR DESCRIPTION
## Summary

Fix the desktop chat composer taking too much vertical space by restoring its compact default height, while keeping autosize behavior for multi-line input. Also widen the desktop chat and composer area when both side rails are collapsed, so the center content uses available space more effectively.

## Problem

A previous desktop composer autosize change interpreted “fewer than 5 lines: maintain default height” as “make the default height 5 lines.” This increased the empty/default composer from the original 2-line height to a 5-line height, reducing the visible chat area and making responses harder to read.

The issue is in the desktop composer sizing path:
- `desktop/src/ui/composer-sizing.ts` set `DEFAULT_COMPOSER_ROWS = 5`
- `desktop/src/ui/composer.tsx` uses `rows={DEFAULT_COMPOSER_ROWS}`
- `desktop/src/styles.css` set `.composer textarea` `min-height` to 5 rows
- `tests/desktop-composer-autosize.test.ts` encoded the inflated 5-row default as expected behavior

Users also reported that after collapsing the left and right desktop rails, the chat content still stayed capped around `740px`, leaving too much unused horizontal space.

The layout width issue is in:
- `desktop/src/styles.css` `.thread-inner` capped at `740px`
- `desktop/src/styles.css` `.composer-inner` capped at `760px`
- the same caps applied even when both rails were collapsed

## Fix

- **`desktop/src/ui/composer-sizing.ts`** — Restored the default composer height to 2 rows and introduced `AUTOSIZE_COMPOSER_ROWS = 5` as the threshold where autosizing begins.
- **`desktop/src/styles.css`** — Restored the textarea default `min-height` to 2 rows.
- **`tests/desktop-composer-autosize.test.ts`** — Updated regression coverage so input below the 5-line autosize threshold keeps the original compact default height, and 5+ lines expand as intended.
- **`desktop/src/styles.css`** — Added collapsed-rail CSS variables so normal three-column layout keeps the readable `740px`/`760px` caps, while both-rails-collapsed layout widens chat content to `1120px` and composer content to `1040px`.

## Verification

| Check | Result |
|---|---|
| `npm test -- tests/desktop-composer-autosize.test.ts` | Passes |
| `npm test -- tests/desktop-composer-autosize.test.ts desktop/src/App.test.ts` | Passes |
| `npm run lint` | Passes with existing `tests/welcome-banner-hints.test.tsx` unused suppression warning |
| `npm run verify` | Passes |

Closed #1566 