### PR TITLE
fix(mcp): use normalizeMcpConfig in codeCommand to support mcpServers

### DIFF
--- a/src/cli/commands/code.tsx
+++ b/src/cli/commands/code.tsx
@@ -21,9 +21,10 @@
 import { readFileSync } from "node:fs";
 import { basename, resolve } from "node:path";
 import { buildCodeToolset } from "../../code/setup.js";
-import { loadApiKey, loadPreset, readConfig } from "../../config.js";
+import { loadApiKey, loadPreset, normalizeMcpConfig, readConfig } from "../../config.js";
 import { loadDotenv } from "../../env.js";
 import { t } from "../../i18n/index.js";
+import { specToRaw } from "../../mcp/spec.js";
 import { detectForeignAgentPlatform } from "../../memory/project.js";
 import { sanitizeName } from "../../memory/session.js";
 import { markPhase } from "../startup-profile.js";
@@ -175,7 +176,7 @@ export async function codeCommand(opts: CodeOptions = {}): Promise<void> {
         currentRoot = newRoot;
       },
     },
-    mcp: readConfig().mcp,
+    mcp: normalizeMcpConfig(readConfig()).map(specToRaw),
     forceResume: opts.forceResume,
     forceNew: opts.forceNew,
     noDashboard: opts.noDashboard,


### PR DESCRIPTION
Fixes #1568

## Problem

When users configure MCP servers using the \mcpServers\ object format in config.json (without the legacy \mcp\ string array), the servers do not start when using \easonix code\.

## Root Cause

In \code.tsx\ line 178, the \codeCommand\ function was directly reading \eadConfig().mcp\, which only handles the legacy string array format:

\\\	ypescript
// Before (broken)
mcp: readConfig().mcp,
\\\

When users configured only \mcpServers\ (the object format), \eadConfig().mcp\ returns \undefined\ or \[]\, so no MCP servers were started.

## Fix

Use \
ormalizeMcpConfig()\ which processes both \mcp\ and \mcpServers\ formats, then converts back to string array via \specToRaw()\:

\\\	ypescript
// After (fixed)
mcp: normalizeMcpConfig(readConfig()).map(specToRaw),
\\\

This matches how \esolveDefaults()\ in \esolve.ts\ handles MCP configuration.

## Files Changed

- \src/cli/commands/code.tsx\: Added imports for \
ormalizeMcpConfig\ and \specToRaw\, fixed MCP config reading

## Testing

- \
pm run lint\ ✅
- \
pm run typecheck\ ✅