### PR TITLE
feat(config): add dashboard.enabled setting to suppress auto-start

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4,7 +4,12 @@
 import "./heap-limit-launch.js";
 
 import { Command } from "commander";
-import { ensureDashboardToken, loadProxyConfig, readConfig } from "../config.js";
+import {
+  ensureDashboardToken,
+  loadDashboardEnabled,
+  loadProxyConfig,
+  readConfig,
+} from "../config.js";
 import { t } from "../i18n/index.js";
 import { VERSION } from "../index.js";
 import { listSessions } from "../memory/session.js";
@@ -200,7 +205,7 @@ program
         forceResume: !!opts.resume,
         forceNew: !!opts.new,
         budgetUsd: parseBudgetFlag(opts.budget),
-        noDashboard: opts.dashboard === false,
+        noDashboard: opts.dashboard === false || !loadDashboardEnabled(false),
         openDashboard: opts.openDashboard === true,
         dashboardPort: resolveDashboardPort(parseDashboardPortFlag(opts.dashboardPort), false),
         dashboardHost: resolveDashboardHost(opts.dashboardHost, false),
@@ -287,7 +292,7 @@ program
         mcpPrefix: opts.mcpPrefix,
         forceResume: continueOpts.forceResume,
         forceNew: !!opts.new,
-        noDashboard: opts.dashboard === false,
+        noDashboard: opts.dashboard === false || !loadDashboardEnabled(opts.config === false),
         openDashboard: opts.openDashboard === true,
         dashboardPort: resolveDashboardPort(
           parseDashboardPortFlag(opts.dashboardPort),

--- a/src/config.ts
+++ b/src/config.ts
@@ -185,6 +185,8 @@ export interface ReasonixConfig {
   /** Rows scrolled per single SGR mouse-wheel report. Default 1 — most terminals emit 2-5 reports per physical notch, so 1 already produces 2-5 rows per notch (#1419). Bump to 3-5 only if your terminal emits one report per notch and scrolling feels slow (#1494). Clamped to [1, 10]. */
   mouseWheelRows?: number;
   dashboard?: {
+    /** Whether the embedded dashboard auto-starts on launch. Default true. Set false to disable without passing --no-dashboard each time. */
+    enabled?: boolean;
     /** Pin the embedded dashboard to a fixed port — required for stable SSH tunnels. 0/absent → ephemeral. */
     port?: number;
     /** Bind address (#968). Defaults to 127.0.0.1 (loopback only). Set to 0.0.0.0 / :: / a LAN IP to expose to other devices; the URL token is then the only auth, so keep it secret. */
@@ -408,6 +410,16 @@ export function readConfig(path: string = defaultConfigPath()): ReasonixConfig {
     /* missing or malformed → empty config */
   }
   return {};
+}
+
+/** Whether the dashboard auto-starts. Default true; only false when explicitly set in config. */
+export function loadDashboardEnabled(
+  noConfig = false,
+  path: string = defaultConfigPath(),
+): boolean {
+  if (noConfig) return true;
+  const v = readConfig(path).dashboard?.enabled;
+  return v !== false;
 }
 
 /** Get-or-mint a 32-byte hex dashboard token, persisting on first call so subsequent CLI boots reuse it (URLs survive restarts). Returns the existing token if it's already ≥16 chars. */

--- a/tests/dashboard-token-persistence.test.ts
+++ b/tests/dashboard-token-persistence.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   clearDashboardToken,
   ensureDashboardToken,
+  loadDashboardEnabled,
   readConfig,
   saveDashboardPort,
 } from "../src/config.js";
@@ -83,5 +84,57 @@ describe("dashboard token + port persistence", () => {
     clearDashboardToken(cfgPath);
     const after = readFileSync(cfgPath, "utf8");
     expect(after).toBe(before);
+  });
+});
+
+describe("loadDashboardEnabled", () => {
+  let dir: string;
+  let cfgPath: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "reasonix-dash-enabled-"));
+    cfgPath = join(dir, "config.json");
+  });
+  afterEach(() => {
+    if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("defaults to true when no config file exists", () => {
+    expect(loadDashboardEnabled(false, cfgPath)).toBe(true);
+  });
+
+  it("defaults to true when dashboard section is absent", () => {
+    writeFileSync(cfgPath, JSON.stringify({ apiKey: "sk-x" }));
+    expect(loadDashboardEnabled(false, cfgPath)).toBe(true);
+  });
+
+  it("defaults to true when enabled field is absent", () => {
+    writeFileSync(cfgPath, JSON.stringify({ dashboard: { port: 8080 } }));
+    expect(loadDashboardEnabled(false, cfgPath)).toBe(true);
+  });
+
+  it("returns true when explicitly set to true", () => {
+    writeFileSync(cfgPath, JSON.stringify({ dashboard: { enabled: true } }));
+    expect(loadDashboardEnabled(false, cfgPath)).toBe(true);
+  });
+
+  it("returns false when explicitly set to false", () => {
+    writeFileSync(cfgPath, JSON.stringify({ dashboard: { enabled: false } }));
+    expect(loadDashboardEnabled(false, cfgPath)).toBe(false);
+  });
+
+  it("returns true when noConfig is true, ignoring config value", () => {
+    writeFileSync(cfgPath, JSON.stringify({ dashboard: { enabled: false } }));
+    expect(loadDashboardEnabled(true, cfgPath)).toBe(true);
+  });
+
+  it("preserves other dashboard fields", () => {
+    writeFileSync(
+      cfgPath,
+      JSON.stringify({ dashboard: { enabled: false, port: 9090, host: "0.0.0.0" } }),
+    );
+    expect(loadDashboardEnabled(false, cfgPath)).toBe(false);
+    const cfg = readConfig(cfgPath);
+    expect(cfg.dashboard?.port).toBe(9090);
+    expect(cfg.dashboard?.host).toBe("0.0.0.0");
   });
 });


### PR DESCRIPTION
## Summary

- Add `dashboard.enabled` boolean config field (default `true`) to `~/.reasonix/config.json`
- When set to `false`, the embedded dashboard does not auto-start on launch, and no dashboard URL is shown in the log
- CLI flag `--no-dashboard` still overrides the config (i.e. `--no-dashboard` wins over `enabled: true`)
- Applies to both `reasonix code` and `reasonix chat` commands

## Usage

```json
{
  "dashboard": {
    "enabled": false
  }
}
```

## Test plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` — 258 files, 3579 tests pass
- [ ] Manual: set `dashboard.enabled: false` in config, run `reasonix code`, verify no dashboard starts and no URL shown
- [ ] Manual: pass `--no-dashboard` flag, verify same behavior
- [ ] Manual: `dashboard.enabled: true` (or absent), verify dashboard auto-starts as before