### PR TITLE
fix(desktop): macOS bundled node inherits parent TCC grants

### DIFF
--- a/desktop/scripts/bundle-node.mjs
+++ b/desktop/scripts/bundle-node.mjs
@@ -23,12 +23,45 @@ if (!HOST_ARCH || !["win32", "darwin", "linux"].includes(PLAT)) {
 const isWin = PLAT === "win32";
 const targetExe = join(binDir, isWin ? "node.exe" : "node");
 
+function adhocSignMac(binPath) {
+  // #1611: child node needs com.apple.security.inherit so it inherits the
+  // parent .app's TCC grants (Documents folder etc.) instead of re-prompting
+  // on every spawn. Ad-hoc is enough for TCC; CI later overlays Developer ID.
+  const ents = join(here, "..", "src-tauri", "entitlements", "node-helper.plist");
+  if (!existsSync(ents)) {
+    console.warn(`entitlements missing: ${ents} — skipping ad-hoc sign`);
+    return;
+  }
+  try {
+    execSync(
+      `codesign --force --sign - --options runtime --entitlements "${ents}" "${binPath}"`,
+      { stdio: "inherit" },
+    );
+  } catch (e) {
+    console.warn(`ad-hoc codesign failed (non-fatal): ${e?.message ?? e}`);
+  }
+}
+
+function isAdhocSigned(binPath) {
+  try {
+    const out = execSync(`codesign -dvv "${binPath}" 2>&1`, { encoding: "utf8" });
+    return out.includes("Signature=adhoc") || /Authority=/.test(out);
+  } catch {
+    return false;
+  }
+}
+
 if (existsSync(targetExe) && statSync(targetExe).size > 1024 * 1024) {
   if (PLAT === "darwin") {
     try {
       const archs = execSync(`lipo -archs "${targetExe}"`, { encoding: "utf8" }).trim();
       if (archs.includes("arm64") && archs.includes("x86_64")) {
-        console.log(`${targetExe} already universal (${archs}) — delete to refetch`);
+        if (!isAdhocSigned(targetExe)) {
+          console.log(`${targetExe} universal but unsigned — applying ad-hoc sign`);
+          adhocSignMac(targetExe);
+        } else {
+          console.log(`${targetExe} already universal + signed (${archs}) — delete to refetch`);
+        }
         process.exit(0);
       }
       console.log(`${targetExe} present but not universal (${archs}) — rebuilding`);
@@ -127,6 +160,8 @@ if (PLAT === "darwin") {
 
   rmSync(arm.extractDir, { recursive: true, force: true });
   rmSync(x64.extractDir, { recursive: true, force: true });
+
+  adhocSignMac(targetExe);
 
   const archs = execSync(`lipo -archs "${targetExe}"`, { encoding: "utf8" }).trim();
   const mb = (statSync(targetExe).size / 1024 / 1024).toFixed(1);

--- a/desktop/src-tauri/entitlements/main.plist
+++ b/desktop/src-tauri/entitlements/main.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+	<key>com.apple.security.cs.allow-dyld-environment-variables</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+	<key>com.apple.security.inherit</key>
+	<true/>
+</dict>
+</plist>

--- a/desktop/src-tauri/entitlements/node-helper.plist
+++ b/desktop/src-tauri/entitlements/node-helper.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.inherit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+</dict>
+</plist>

--- a/desktop/src-tauri/tauri.macos.conf.json
+++ b/desktop/src-tauri/tauri.macos.conf.json
@@ -16,6 +16,10 @@
     ]
   },
   "bundle": {
+    "macOS": {
+      "hardenedRuntime": true,
+      "entitlements": "entitlements/main.plist"
+    },
     "resources": {
       "binaries/node": "node"
     }


### PR DESCRIPTION
## Summary
- Root cause of repeated TCC prompts (Documents / Desktop / Downloads) on every task execution (#1611): the child `Reasonix.app/Contents/Resources/node` lacks the `com.apple.security.inherit` entitlement, so macOS treats it as an independent helper with no relation to the parent .app and re-asks each time it spawns.
- Add `entitlements/main.plist` (includes `inherit`) and wire it into Tauri's codesign via `bundle.macOS.entitlements`. The `--deep` pass propagates that entitlement to `Contents/Resources/node`, so signed releases let the child inherit the parent .app's TCC grants.
- Add `entitlements/node-helper.plist` plus an ad-hoc `codesign --sign -` at the end of `bundle-node.mjs` to cover the unsigned-release path (when `HAS_APPLE_CERT` is not set in CI). That keeps the inherit entitlement attached on builds that never go through Tauri's `--deep` step.

## Verification

Signed release (CI with `HAS_APPLE_CERT==true`):

```bash
codesign -d --entitlements - Reasonix.app/Contents/Resources/node
# expected to contain: <key>com.apple.security.inherit</key><true/>
```

Unsigned local build:

```bash
cd desktop && npm run bundle:node
codesign -d --entitlements - src-tauri/binaries/node
# expected to contain the same inherit entitlement
```

## Test plan
- [ ] Signed macOS release: install, grant Documents once, restart the app, run a task and confirm no further prompts
- [ ] Unsigned macOS build: same check, validating the ad-hoc path
- [ ] Confirm `notarytool` accepts `inherit` on the top-level binary (Apple treats it as a no-op there; if the first signed CI build is rejected we can move the entitlement into a node-only re-sign step instead)

Closes #1611