### PR TITLE
test(lifecycle): cover npm package aliases

### DIFF
--- a/src/code/lifecycle-policy.ts
+++ b/src/code/lifecycle-policy.ts
@@ -180,9 +180,11 @@ function isPackageMutation(token: string | undefined): boolean {
   const normalized = token?.toLowerCase();
   return (
     normalized === "install" ||
+    normalized === "i" ||
     normalized === "add" ||
     normalized === "remove" ||
     normalized === "uninstall" ||
+    normalized === "un" ||
     normalized === "update" ||
     normalized === "upgrade" ||
     normalized === "up"

--- a/tests/lifecycle-policy.test.ts
+++ b/tests/lifecycle-policy.test.ts
@@ -109,9 +109,23 @@ describe("lifecycle risk policy", () => {
       reason: "high-risk-command",
     },
     {
+      name: "npm i dependency mutation",
+      toolName: "run_command",
+      args: { command: "npm i zod" },
+      risk: "high-risk",
+      reason: "high-risk-command",
+    },
+    {
       name: "npm uninstall dependency mutation",
       toolName: "run_command",
       args: { command: "npm uninstall left-pad" },
+      risk: "high-risk",
+      reason: "high-risk-command",
+    },
+    {
+      name: "npm un dependency mutation",
+      toolName: "run_command",
+      args: { command: "npm un left-pad" },
       risk: "high-risk",
       reason: "high-risk-command",
     },


### PR DESCRIPTION
## Summary

- cover `npm i` and `npm un` as package mutation aliases in the lifecycle policy corpus
- classify both aliases as high-risk package mutation commands, matching `npm install` and `npm uninstall`

## Validation

- `npm test -- tests/lifecycle-policy.test.ts`
- `npm test -- tests/lifecycle-policy.test.ts tests/lifecycle.test.ts tests/tools.test.ts`
- `npx tsc --noEmit`
- `npm run lint` (passes with the existing unused suppression warning in `tests/welcome-banner-hints.test.tsx`)

## Notes

`npm run typecheck` / push hook full `npm run verify` is blocked in this local checkout by missing dashboard dependencies such as `prism-react-renderer`, `lucide-react`, `react-markdown`, and related type declarations. The root `tsc --noEmit` check passes.
