### PR TITLE
fix(theme): composer + user card bg use theme tokens, not hardcoded #1e1e1e

### DIFF
--- a/src/cli/ui/PromptInput.tsx
+++ b/src/cli/ui/PromptInput.tsx
@@ -209,8 +209,8 @@ export function PromptInput({
 
   return (
     <Box flexDirection="row">
-      <Box width={1} backgroundColor="#0153e5" />
-      <Box flexDirection="column" flexGrow={1} paddingX={1} backgroundColor="#1e1e1e">
+      <Box width={1} backgroundColor={TONE.brand} />
+      <Box flexDirection="column" flexGrow={1} paddingX={1} backgroundColor={SURFACE.bgInput}>
         <Box height={1} />
         {(() => {
           const rows: React.ReactNode[] = [];
@@ -336,7 +336,7 @@ export function PromptInput({
         <Box height={1} />
         {mode || model ? (
           <Box>
-            <Text color="#0153e5">{mode || ""}</Text>
+            <Text color={TONE.brand}>{mode || ""}</Text>
             {mode && model ? <Text color={FG.faint}>{" · "}</Text> : null}
             {model ? <Text color={FG.faint}>{model}</Text> : null}
           </Box>

--- a/src/cli/ui/cards/UserCard.tsx
+++ b/src/cli/ui/cards/UserCard.tsx
@@ -11,7 +11,7 @@ export function UserCard({ card }: { card: UserCardData }): React.ReactElement {
   return (
     <Box flexDirection="row">
       <Box width={1} backgroundColor={CARD.user.color} flexShrink={0} />
-      <Box flexDirection="column" flexGrow={1} paddingLeft={1} backgroundColor="#1e1e1e">
+      <Box flexDirection="column" flexGrow={1} paddingLeft={1} backgroundColor={SURFACE.bgInput}>
         <CardHeader
           glyph={CARD.user.glyph}
           tone={CARD.user.color}


### PR DESCRIPTION
Closes #1607.

## What the user saw

On macOS iTerm2 with a light terminal profile and Reasonix `theme: github-light`, the bottom of the TUI rendered as a wide black band, with low-contrast text on top:

> 底部输入框和状态栏显示为黑色背景，与浅色终端主题和 Reasonix 浅色主题不一致

## What's actually going on

What reads visually as "input box + status bar both black" is a single offending Box in `PromptInput.tsx`. Four hardcoded color literals were bypassing the proxy-tokens theme system entirely:

| File:line | Hardcoded | Purpose |
|---|---|---|
| `PromptInput.tsx:212` | `#0153e5` | left accent stripe |
| `PromptInput.tsx:213` | `#1e1e1e` | composer body bg |
| `PromptInput.tsx:339` | `#0153e5` | inline mode label color |
| `cards/UserCard.tsx:14` | `#1e1e1e` | user message card bg |

The inline `mode · model` row (`审查 · Auto · Deepseek v4 flash` in the screenshot) lives *inside* the same `#1e1e1e` Box as the composer body, which is why the user perceived it as the status bar being black. The real `<StatusRow>` is below that, has no `backgroundColor`, and was already themed correctly — it just sits on the terminal default bg.

## Fix

Swap the four literals for their theme tokens:

```diff
- <Box width={1} backgroundColor="#0153e5" />
- <Box ... backgroundColor="#1e1e1e">
+ <Box width={1} backgroundColor={TONE.brand} />
+ <Box ... backgroundColor={SURFACE.bgInput}>

- <Text color="#0153e5">{mode || ""}</Text>
+ <Text color={TONE.brand}>{mode || ""}</Text>

- <Box ... backgroundColor="#1e1e1e">  // UserCard
+ <Box ... backgroundColor={SURFACE.bgInput}>
```

All six themes (`default`, `dark`, `light`, `tokyo-night`, `github-dark`, `github-light`, `high-contrast`) already define `bgInput`, so dark-theme users get the same near-black they had (`#0d1015` / `#111827` / `#1f2335` / `#0a0a0a` — close enough to the old `#1e1e1e`), and light-theme users get the near-white they were missing (`#f6f8fa` / `#f8fafc`).

## Out of scope (follow-up)

`EditConfirm.tsx` and `SplitDiff.tsx` still tint diff add/remove lines with hardcoded `#2a1212` (dark red) and `#0c2718` (dark green). On a light theme those read as near-black blocks, equally broken. Fixing them needs new theme tokens (`diffAddedBg` / `diffRemovedBg`) with per-theme values, so I'm leaving that for a separate PR.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (only pre-existing warning in welcome-banner-hints)
- [x] `npm run test` — 3586 pass
- [ ] Manual: launch on a light terminal (iTerm2 light profile), set `"theme": "github-light"` in config, confirm composer + user card render on near-white bg, blue accent stripe present, mode label "审查" visible
- [ ] Manual: same on a dark terminal with default theme — composer + user card still near-black, no regression