### PR TITLE
fix(ui): replace repeated live hints

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -198,6 +198,8 @@ import { useEditHistory } from "./useEditHistory.js";
 import { useSessionInfo } from "./useSessionInfo.js";
 import { useSubagent } from "./useSubagent.js";
 
+const STASH_HINT_CARD_ID = "composer-stash-hint";
+
 function isBusyPromptCommand(text: string): boolean {
   const trimmed = text.trimStart();
   return trimmed.startsWith("/") || trimmed.startsWith("#") || detectBangCommand(trimmed) !== null;
@@ -1906,13 +1908,13 @@ function AppInner({
         const recalled = stashRef.current;
         stashRef.current = input;
         setInput(recalled);
-        log.pushInfo(t("composer.stashRecall"));
+        log.pushInfo(t("composer.stashRecall"), "info", STASH_HINT_CARD_ID);
       } else if (input.length > 0) {
         stashRef.current = input;
         setInput("");
-        log.pushInfo(t("composer.stashSaved"));
+        log.pushInfo(t("composer.stashSaved"), "info", STASH_HINT_CARD_ID);
       } else {
-        log.pushInfo(t("composer.stashNothing"));
+        log.pushInfo(t("composer.stashNothing"), "info", STASH_HINT_CARD_ID);
       }
       return;
     }

--- a/src/cli/ui/hooks/useScrollback.ts
+++ b/src/cli/ui/hooks/useScrollback.ts
@@ -21,6 +21,7 @@ export interface Scrollback {
   pushInfo(
     text: string,
     tone?: "info" | "ok" | "warn" | "err" | "ghost" | "brand" | "accent",
+    id?: string,
   ): string;
   /** Structured onboarding-tip card — replaces multi-line TIP strings stuffed into pushInfo. */
   pushTip(args: {
@@ -135,8 +136,7 @@ export function useScrollback(): Scrollback {
         });
         return id;
       },
-      pushInfo(text, tone = "info") {
-        const id = nextId("info");
+      pushInfo(text, tone = "info", id = nextId("info")) {
         dispatch({
           type: "live.show",
           id,

--- a/src/cli/ui/state/reducer.ts
+++ b/src/cli/ui/state/reducer.ts
@@ -191,8 +191,8 @@ export function reduce(state: AgentState, event: AgentEvent): AgentState {
     case "toast.hide":
       return { ...state, toasts: state.toasts.filter((t) => t.id !== event.id) };
 
-    case "live.show":
-      return appendCard(state, {
+    case "live.show": {
+      const card: LiveCard = {
         kind: "live",
         id: event.id,
         ts: event.ts,
@@ -200,7 +200,10 @@ export function reduce(state: AgentState, event: AgentEvent): AgentState {
         tone: event.tone,
         text: event.text,
         meta: event.meta,
-      });
+      };
+      const replaced = mutateCard(state, event.id, "live", () => card);
+      return replaced === state ? appendCard(state, card) : replaced;
+    }
 
     case "tip.show":
       return appendCard(state, {

--- a/tests/ui-reducer.test.ts
+++ b/tests/ui-reducer.test.ts
@@ -119,6 +119,38 @@ describe("ui reducer", () => {
     expect(s.cards).toHaveLength(0);
   });
 
+  it("replaces an existing live card when live.show reuses the id", () => {
+    const s = run([
+      {
+        type: "live.show",
+        id: "hint",
+        ts: 100,
+        variant: "stepProgress",
+        tone: "info",
+        text: "Stashed input",
+      },
+      {
+        type: "live.show",
+        id: "hint",
+        ts: 200,
+        variant: "stepProgress",
+        tone: "ok",
+        text: "Recalled input",
+        meta: "Alt+S",
+      },
+    ]);
+    expect(s.cards).toHaveLength(1);
+    expect(s.cards[0]).toMatchObject({
+      kind: "live",
+      id: "hint",
+      ts: 200,
+      variant: "stepProgress",
+      tone: "ok",
+      text: "Recalled input",
+      meta: "Alt+S",
+    });
+  });
+
   it("flags tool card as rejected when tool.end output carries plan-mode marker", () => {
     const planBounce = JSON.stringify({
       error: "write_file: unavailable in plan mode — ...",


### PR DESCRIPTION
## What

Make `live.show` replace an existing live card when the same id is reused, and route Alt+S stash/recall notices through a stable hint id so repeated presses update the same card instead of adding stale scrollback entries.

## Why

Fixes #1573. Repeated transient hints such as stash/recall confirmations were accumulating because every `pushInfo` call generated a fresh card id.

## How to verify

- `npm test -- tests/ui-reducer.test.ts`
- `npm run typecheck`
- `npm run verify`

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time
