### PR TITLE
fix(mcp): pass workspace roots to servers

### DIFF
--- a/src/cli/commands/acp.ts
+++ b/src/cli/commands/acp.ts
@@ -88,6 +88,7 @@ export async function loadMcpServers(
   tools: import("../../tools.js").ToolRegistry,
   specs: string[],
   globalPrefix: string | undefined,
+  workspaceDir: string = process.cwd(),
 ): Promise<McpClient[]> {
   const clients: McpClient[] = [];
   if (specs.length === 0) return clients;
@@ -106,8 +107,8 @@ export async function loadMcpServers(
       const t0 = Date.now();
       const prefix = resolveMcpPrefix(spec.name, normalizedSpecs.length, globalPrefix);
       if (spec.transport === "stdio") preflightStdioSpec(spec);
-      const transport = buildTransportFromSpec(spec);
-      mcp = new McpClient({ transport });
+      const transport = buildTransportFromSpec(spec, { cwd: workspaceDir });
+      mcp = new McpClient({ transport, workspaceDir });
       await mcp.initialize();
       const bridge = await bridgeMcpTools(mcp, {
         registry: tools,
@@ -158,7 +159,12 @@ async function buildSession(opts: {
   const model = opts.modelOverride || resolved.model;
   const toolset = await buildCodeToolset({ rootDir: opts.rootDir });
   // Bridge MCP tools BEFORE building the prefix so their specs make it into the cache key.
-  const mcpClients = await loadMcpServers(toolset.tools, opts.mcpSpecs ?? [], opts.mcpPrefix);
+  const mcpClients = await loadMcpServers(
+    toolset.tools,
+    opts.mcpSpecs ?? [],
+    opts.mcpPrefix,
+    opts.rootDir,
+  );
   const system = codeSystemPrompt(opts.rootDir, {
     hasSemanticSearch: toolset.semantic.enabled,
     modelId: model,

--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -261,11 +261,23 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
   if (requestedSpecs.length > 0 && !tools) {
     tools = new ToolRegistry({ rateLimit: loadToolRateLimit() });
   }
+  const launchWorkspace = opts.codeMode?.rootDir ?? process.cwd();
+  let activeWorkspace = launchWorkspace;
+  const codeMode = opts.codeMode
+    ? {
+        ...opts.codeMode,
+        onRootChange: (newRoot: string) => {
+          activeWorkspace = newRoot;
+          opts.codeMode?.onRootChange?.(newRoot);
+        },
+      }
+    : undefined;
 
   const runtime = createMcpRuntime({
     getTools: () => tools,
     getMcpPrefix: () => opts.mcpPrefix,
     getRequestedCount: () => requestedSpecs.length,
+    getWorkspaceDir: () => activeWorkspace,
     progressSink,
   });
 
@@ -314,7 +326,6 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
     opts.forceNew,
     opts.forceResume,
   );
-  const launchWorkspace = opts.codeMode?.rootDir ?? process.cwd();
   const showPicker =
     !opts.session && !opts.forceResume && listSessionsForWorkspace(launchWorkspace).length > 0;
 
@@ -374,6 +385,7 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
       startupInfoHints={startupInfoHints}
       showPicker={showPicker}
       {...opts}
+      codeMode={codeMode}
       session={resolvedSession}
       qqChannel={qqChannel}
       qqSubmitRef={qqSubmitRef}

--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -1282,6 +1282,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
       },
       getMcpPrefix: () => undefined,
       getRequestedCount: () => requested,
+      getWorkspaceDir: () => tab.rootDir,
       progressSink: { current: null },
     });
     tab.mcpRuntime = runtime;

--- a/src/cli/commands/mcp-inspect.ts
+++ b/src/cli/commands/mcp-inspect.ts
@@ -20,8 +20,9 @@ export async function mcpInspectCommand(opts: McpInspectOptions): Promise<void> 
   const matched = parsed.name ? normalized.find((s) => s.name === parsed.name) : undefined;
   const spec = overlayMatchedSpec(parsed, matched);
   if (spec.transport === "stdio") preflightStdioSpec(spec);
-  const transport = buildTransportFromSpec(spec);
-  const client = new McpClient({ transport });
+  const workspaceDir = process.cwd();
+  const transport = buildTransportFromSpec(spec, { cwd: workspaceDir });
+  const client = new McpClient({ transport, workspaceDir });
   try {
     await client.initialize();
     const report = await inspectMcpServer(client);

--- a/src/cli/commands/mcp-runtime.ts
+++ b/src/cli/commands/mcp-runtime.ts
@@ -35,6 +35,7 @@ export interface RuntimeContext {
   getTools: () => ToolRegistry | undefined;
   getMcpPrefix: () => string | undefined;
   getRequestedCount: () => number;
+  getWorkspaceDir?: () => string | undefined;
   progressSink: { current: ((info: ProgressInfo) => void) | null };
 }
 
@@ -183,8 +184,9 @@ export function createMcpRuntime(ctx: RuntimeContext): McpRuntime {
           ? (ctx.getMcpPrefix() as string)
           : "";
       if (spec.transport === "stdio") preflightStdioSpec(spec);
-      const transport = buildTransportFromSpec(spec);
-      mcp = new McpClient({ transport });
+      const workspaceDir = ctx.getWorkspaceDir?.();
+      const transport = buildTransportFromSpec(spec, { cwd: workspaceDir });
+      mcp = new McpClient({ transport, workspaceDir });
       await mcp.initialize({ signal });
       const host: McpClientHost = { client: mcp };
       const bridge = await bridgeMcpTools(mcp, {

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -82,6 +82,7 @@ export async function runCommand(opts: RunOptions): Promise<void> {
   const clients: McpClient[] = [];
   let tools: ToolRegistry | undefined;
   let successCount = 0;
+  const workspaceDir = process.cwd();
   if (normalizedSpecs.length > 0) {
     tools = new ToolRegistry({ rateLimit: loadToolRateLimit() });
     for (const spec of normalizedSpecs) {
@@ -101,8 +102,8 @@ export async function runCommand(opts: RunOptions): Promise<void> {
             ? opts.mcpPrefix
             : "";
         if (spec.transport === "stdio") preflightStdioSpec(spec);
-        const transport = buildTransportFromSpec(spec);
-        mcp = new McpClient({ transport });
+        const transport = buildTransportFromSpec(spec, { cwd: workspaceDir });
+        mcp = new McpClient({ transport, workspaceDir });
         await mcp.initialize();
         const bridge = await bridgeMcpTools(mcp, {
           registry: tools,

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -1,3 +1,5 @@
+import { basename, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 import { VERSION } from "../version.js";
 import type { McpTransport } from "./stdio.js";
 import {
@@ -19,6 +21,7 @@ import {
   MCP_PROTOCOL_VERSION,
   type McpClientInfo,
   type McpProgressHandler,
+  type McpRoot,
   type ProgressNotificationParams,
   type ReadResourceParams,
   type ReadResourceResult,
@@ -28,6 +31,7 @@ import {
 export interface McpClientOptions {
   transport: McpTransport;
   clientInfo?: McpClientInfo;
+  workspaceDir?: string;
   /** Per-request timeout. Default 60s. */
   requestTimeoutMs?: number;
 }
@@ -41,6 +45,8 @@ interface PendingRequest {
 export class McpClient {
   private readonly transport: McpTransport;
   private readonly clientInfo: McpClientInfo;
+  private readonly workspaceDir: string | undefined;
+  private readonly workspaceRoot: McpRoot | undefined;
   private readonly requestTimeoutMs: number;
   private readonly pending = new Map<JsonRpcId, PendingRequest>();
   private nextId = 1;
@@ -61,6 +67,14 @@ export class McpClient {
   constructor(opts: McpClientOptions) {
     this.transport = opts.transport;
     this.clientInfo = opts.clientInfo ?? { name: "reasonix", version: VERSION };
+    const workspaceDir = opts.workspaceDir?.trim();
+    if (workspaceDir) {
+      this.workspaceDir = resolve(workspaceDir);
+      this.workspaceRoot = {
+        uri: pathToFileURL(this.workspaceDir).href,
+        name: basename(this.workspaceDir) || this.workspaceDir,
+      };
+    }
     this.requestTimeoutMs = opts.requestTimeoutMs ?? 60_000;
   }
 
@@ -84,24 +98,32 @@ export class McpClient {
     return this._instructions;
   }
 
+  get workspaceRootDir(): string | undefined {
+    return this.workspaceDir;
+  }
+
   /** Compliant servers reject other methods until this completes. */
   async initialize(opts: { signal?: AbortSignal } = {}): Promise<InitializeResult> {
     if (this.initialized) throw new Error("MCP client already initialized");
     this.startReaderIfNeeded();
-    const result = await this.request<InitializeResult>(
-      "initialize",
-      {
-        protocolVersion: MCP_PROTOCOL_VERSION,
-        // Advertise every method the client can consume so servers know
-        // they can send listChanged notifications etc. Sub-feature flags
-        // (e.g. `resources.subscribe`) are omitted — we don't implement
-        // those yet and the empty object means "method-level support, no
-        // sub-features."
-        capabilities: { tools: {}, resources: {}, prompts: {} },
-        clientInfo: this.clientInfo,
-      } satisfies InitializeParams,
-      opts.signal,
-    );
+    const capabilities: InitializeParams["capabilities"] = {
+      tools: {},
+      resources: {},
+      prompts: {},
+      ...(this.workspaceRoot ? { roots: {} } : {}),
+    };
+    const params: InitializeParams = {
+      protocolVersion: MCP_PROTOCOL_VERSION,
+      capabilities,
+      clientInfo: this.clientInfo,
+      ...(this.workspaceRoot
+        ? {
+            rootUri: this.workspaceRoot.uri,
+            workspaceFolders: [this.workspaceRoot],
+          }
+        : {}),
+    };
+    const result = await this.request<InitializeResult>("initialize", params, opts.signal);
     this._serverCapabilities = result.capabilities ?? {};
     this._serverInfo = result.serverInfo ?? { name: "", version: "" };
     this._protocolVersion = result.protocolVersion ?? "";
@@ -298,7 +320,10 @@ export class McpClient {
       }
       return;
     }
-    if (!("result" in msg) && !("error" in msg)) return; // it's a request from server
+    if (!("result" in msg) && !("error" in msg)) {
+      this.handleServerRequest(msg as JsonRpcRequest);
+      return;
+    }
     const pending = this.pending.get(msg.id);
     if (!pending) return; // late response after timeout; drop
     this.pending.delete(msg.id);
@@ -309,5 +334,25 @@ export class McpClient {
     } else {
       pending.resolve(resp.result);
     }
+  }
+
+  private handleServerRequest(req: JsonRpcRequest): void {
+    if (req.method === "roots/list" && this.workspaceRoot) {
+      void this.transport
+        .send({
+          jsonrpc: "2.0",
+          id: req.id,
+          result: { roots: [this.workspaceRoot] },
+        })
+        .catch(() => undefined);
+      return;
+    }
+    void this.transport
+      .send({
+        jsonrpc: "2.0",
+        id: req.id,
+        error: { code: -32601, message: `method not found: ${req.method}` },
+      })
+      .catch(() => undefined);
   }
 }

--- a/src/mcp/reconnect.ts
+++ b/src/mcp/reconnect.ts
@@ -58,11 +58,13 @@ export async function reconnectMcpServer(args: ReconnectArgs): Promise<Reconnect
       ms: Date.now() - t0,
     };
   }
+  const workspaceDir = args.host.client.workspaceRootDir;
   const transport = buildTransportFromSpec(parsed, {
     env: args.env,
     headers: args.headers,
+    cwd: workspaceDir,
   });
-  const next = new McpClient({ transport });
+  const next = new McpClient({ transport, workspaceDir });
   try {
     await next.initialize();
     const listed = await next.listTools();

--- a/src/mcp/transport-from-spec.ts
+++ b/src/mcp/transport-from-spec.ts
@@ -6,6 +6,8 @@ import { StreamableHttpTransport } from "./streamable-http.js";
 export interface BuildTransportOptions {
   /** Stdio-only env overlay — merged over process.env. SSE/Streamable-HTTP ignore it. */
   env?: Record<string, string>;
+  /** Stdio-only working directory. SSE/Streamable-HTTP ignore it. */
+  cwd?: string;
   /** SSE / Streamable-HTTP only. Ignored by stdio. */
   headers?: Record<string, string>;
 }
@@ -27,5 +29,6 @@ export function buildTransportFromSpec(
     command: spec.command,
     args: spec.args,
     env: opts.env ?? spec.env,
+    cwd: opts.cwd,
   });
 }

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -48,13 +48,22 @@ export interface McpClientCapabilities {
   resources?: Record<string, never>;
   /** Advertised when the client can consume `prompts/list` + `prompts/get`. */
   prompts?: Record<string, never>;
+  /** Advertised when the client can answer `roots/list`. */
+  roots?: { listChanged?: boolean };
   // sampling would go here — deferred.
+}
+
+export interface McpRoot {
+  uri: string;
+  name?: string;
 }
 
 export interface InitializeParams {
   protocolVersion: string;
   capabilities: McpClientCapabilities;
   clientInfo: McpClientInfo;
+  rootUri?: string;
+  workspaceFolders?: McpRoot[];
 }
 
 export interface InitializeResult {

--- a/tests/mcp.test.ts
+++ b/tests/mcp.test.ts
@@ -1,5 +1,6 @@
 /** MCP client + bridge — in-process fake transport answering initialize / tools/list / tools/call. */
 
+import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 import { McpClient } from "../src/mcp/client.js";
 import { bridgeMcpTools, flattenMcpResult } from "../src/mcp/registry.js";
@@ -34,6 +35,8 @@ interface FakeServerOptions {
   getPrompt?: (name: string, args?: Record<string, string>) => GetPromptResult;
   /** Initialize capabilities override — defaults advertise tools only. */
   capabilities?: Record<string, unknown>;
+  /** Client responses to server-initiated requests. */
+  responses?: JsonRpcMessage[];
 }
 
 /** In-process MCP transport — responds in `send()` by pushing onto the queue. */
@@ -47,7 +50,10 @@ class FakeMcpTransport implements McpTransport {
 
   async send(msg: JsonRpcMessage): Promise<void> {
     if (this.closed) throw new Error("fake transport closed");
-    if (!("method" in msg)) return; // response frames from client? never happens
+    if (!("method" in msg)) {
+      this.opts.responses?.push(msg);
+      return;
+    }
     if (!("id" in msg)) {
       // notification — e.g. notifications/initialized — acknowledge silently
       this.opts.received!.push(msg as JsonRpcRequest);
@@ -77,6 +83,10 @@ class FakeMcpTransport implements McpTransport {
   async close(): Promise<void> {
     this.closed = true;
     while (this.waiters.length > 0) this.waiters.shift()!(null);
+  }
+
+  pushServerMessage(msg: JsonRpcMessage): void {
+    this.push(msg);
   }
 
   private handle(req: JsonRpcRequest): JsonRpcMessage {
@@ -184,6 +194,44 @@ describe("McpClient: initialize handshake", () => {
     expect(received[0]!.method).toBe("initialize");
     expect(received[1]!.method).toBe("notifications/initialized");
 
+    await client.close();
+  });
+
+  it("passes the workspace root in initialize params", async () => {
+    const received: JsonRpcRequest[] = [];
+    const workspaceDir = "/tmp/reasonix-workspace";
+    const workspaceUri = pathToFileURL(workspaceDir).href;
+    const transport = new FakeMcpTransport({ tools: [], received });
+    const client = new McpClient({ transport, workspaceDir });
+    await client.initialize();
+    const init = received.find((r) => r.method === "initialize")!;
+    const params = init.params as {
+      capabilities: Record<string, unknown>;
+      rootUri?: string;
+      workspaceFolders?: Array<{ uri: string; name?: string }>;
+    };
+    expect(params.capabilities).toHaveProperty("roots");
+    expect(params.rootUri).toBe(workspaceUri);
+    expect(params.workspaceFolders).toEqual([{ uri: workspaceUri, name: "reasonix-workspace" }]);
+    await client.close();
+  });
+
+  it("answers roots/list with the configured workspace root", async () => {
+    const responses: JsonRpcMessage[] = [];
+    const workspaceDir = "/tmp/reasonix-workspace";
+    const workspaceUri = pathToFileURL(workspaceDir).href;
+    const transport = new FakeMcpTransport({ tools: [], responses });
+    const client = new McpClient({ transport, workspaceDir });
+    await client.initialize();
+    transport.pushServerMessage({ jsonrpc: "2.0", id: "roots-1", method: "roots/list" });
+    for (let i = 0; responses.length === 0 && i < 20; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    expect(responses[0]).toMatchObject({
+      jsonrpc: "2.0",
+      id: "roots-1",
+      result: { roots: [{ uri: workspaceUri, name: "reasonix-workspace" }] },
+    });
     await client.close();
   });
 


### PR DESCRIPTION
## What

Send workspace root context to MCP servers during initialization and answer roots/list requests, while launching stdio MCP servers from the same workspace directory.

## Why

Fixes #1397. Servers that infer project state from rootUri, workspaceFolders, roots/list, or process cwd could not auto-detect the active project and required hardcoded path arguments.

## How to verify

- `npm test -- tests/mcp.test.ts`
- `npm test -- tests/mcp.test.ts tests/mcp-env-config.test.ts tests/acp-mcp.test.ts tests/chat-mcp-startup-summary.test.ts tests/mcp-reconnect.test.ts tests/mcp-runtime-failures.test.ts`
- `npm run typecheck`
- `npm run verify`

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time