### PR TITLE
fix(memory): auto-fold AppendOnlyLog when entries exceed 500

### DIFF
--- a/src/context-manager.ts
+++ b/src/context-manager.ts
@@ -54,6 +54,9 @@ export const HISTORY_FOLD_SUMMARY_TIMEOUT_MS = 15_000;
 /** Prepended to fold summary content so the model knows it's a synthesized recap. */
 export const HISTORY_FOLD_MARKER =
   "[CONVERSATION HISTORY SUMMARY — earlier turns folded for context efficiency]\n\n";
+/** Maximum log entries before triggering an automatic fold (regardless of token usage).
+ *  Each entry retains message content, tool calls, and role metadata — 500 entries ≈ 1 MB. */
+export const MAX_LOG_ENTRIES_FOR_FOLD = 500;
 /** Header that precedes preserved skill bodies in a fold's synthesized assistant message. */
 export const SKILL_PIN_MEMO_HEADER = "[Active skill memos — preserved verbatim across the fold:]";
 /** Matches the wrapper emitted by `run_skill` so the fold can lift bodies out before summarizing. */
@@ -164,6 +167,16 @@ export class ContextManager {
       return { kind: "exit-with-summary", ...base };
     }
     if (alreadyFoldedThisTurn) return { kind: "none", ...base };
+    // Fold when the log grows too large, even if token usage is low — prevents unbounded
+    // memory growth during long sessions with many small tool calls.
+    if (this.deps.log.length > MAX_LOG_ENTRIES_FOR_FOLD) {
+      return {
+        kind: "fold",
+        ...base,
+        tailBudget: Math.floor(ctxMax * HISTORY_FOLD_TAIL_FRACTION),
+        aggressive: false,
+      };
+    }
     if (ratio > HISTORY_FOLD_AGGRESSIVE_THRESHOLD) {
       return {
         kind: "fold",


### PR DESCRIPTION
## Memory Leak Fix — AppendOnlyLog Fold Trigger

Fixes parts of [#1571](https://github.com/esengine/DeepSeek-Reasonix/issues/1571)

### Problem

Long-running sessions accumulate log entries without limit — each tool result (up to 8K tokens) is stored until explicit /compact. Over hours this causes unbounded memory growth (~2MB/sec during active tasks).

### Fix

Add a log-length check in ContextManager.decideAfterUsage(): when entries exceed MAX_LOG_ENTRIES_FOR_FOLD (500, ≈1MB), trigger the existing fold mechanism.

This reuses the proven fold path — no new compression logic, just a length-based trigger alongside the existing token-ratio triggers. The constant is intentionally generous (500 entries) to avoid folding during normal bursty tool-call sequences. Sessions that reach this threshold without hitting the token-ratio fold are exactly the ones that need it: many small calls that individually stay under the ratio but collectively grow the log without bound.

### Changes

- src/context-manager.ts: Added MAX_LOG_ENTRIES_FOR_FOLD = 500 constant and length check in decideAfterUsage()

### Testing

- npm run lint ✅
- npm run typecheck ✅
- npm run test ✅ (3588 passed)

### Update

Drift issue fixed — rebased on latest main. Diff now only contains src/context-manager.ts.