### PR TITLE
fix(ui): advance active plan steps

### DIFF
--- a/src/cli/ui/state/reducer.ts
+++ b/src/cli/ui/state/reducer.ts
@@ -3,6 +3,7 @@ import type {
   Card,
   CardId,
   LiveCard,
+  PlanStep,
   ReasoningCard,
   StreamingCard,
   ToolCard,
@@ -249,7 +250,7 @@ export function reduce(state: AgentState, event: AgentEvent): AgentState {
         id: event.id,
         ts: Date.now(),
         title: event.title,
-        steps: event.steps,
+        steps: event.variant === "active" ? advanceActivePlanSteps(event.steps) : event.steps,
         variant: event.variant,
       });
 
@@ -282,7 +283,7 @@ export function reduce(state: AgentState, event: AgentEvent): AgentState {
         });
         if (!stepChanged) return c;
         changed = true;
-        return { ...c, steps: next };
+        return { ...c, steps: c.variant === "active" ? advanceActivePlanSteps(next) : next };
       });
       return changed ? { ...state, cards } : state;
     }
@@ -443,6 +444,19 @@ function nextId(prefix: string): string {
 
 function makeUserCard(text: string): UserCard {
   return { kind: "user", id: nextId("user"), ts: Date.now(), text };
+}
+
+function isSettledPlanStatus(status: PlanStep["status"]): boolean {
+  return status === "done" || status === "failed" || status === "blocked" || status === "skipped";
+}
+
+function advanceActivePlanSteps(steps: ReadonlyArray<PlanStep>): PlanStep[] {
+  const runningIndex = steps.findIndex((s) => !isSettledPlanStatus(s.status));
+  return steps.map((s, i) => {
+    if (isSettledPlanStatus(s.status)) return s;
+    const status: PlanStep["status"] = i === runningIndex ? "running" : "queued";
+    return s.status === status ? s : { ...s, status };
+  });
 }
 
 function makeReasoningCard(id: string, model?: string): ReasoningCard {

--- a/tests/ui-reducer.test.ts
+++ b/tests/ui-reducer.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type {
+  PlanCard,
   ReasoningCard,
   StreamingCard,
   ToolCard,
@@ -175,6 +176,41 @@ describe("ui reducer", () => {
     ]);
     const card = s.cards[0] as ToolCard;
     expect(card.rejected).toBeUndefined();
+  });
+
+  it("advances the active plan cursor as steps are completed", () => {
+    const shown = run([
+      {
+        type: "plan.show",
+        id: "p1",
+        title: "Plan",
+        variant: "active",
+        steps: [
+          { id: "step-1", title: "One", status: "queued" },
+          { id: "step-2", title: "Two", status: "queued" },
+          { id: "step-3", title: "Three", status: "queued" },
+        ],
+      },
+    ]);
+    expect((shown.cards[0] as PlanCard).steps.map((s) => s.status)).toEqual([
+      "running",
+      "queued",
+      "queued",
+    ]);
+
+    const afterFirst = reduce(shown, { type: "plan.step.complete", stepId: "step-1" });
+    expect((afterFirst.cards[0] as PlanCard).steps.map((s) => s.status)).toEqual([
+      "done",
+      "running",
+      "queued",
+    ]);
+
+    const afterSecond = reduce(afterFirst, { type: "plan.step.complete", stepId: "step-2" });
+    expect((afterSecond.cards[0] as PlanCard).steps.map((s) => s.status)).toEqual([
+      "done",
+      "done",
+      "running",
+    ]);
   });
 
   it("changes mode and accumulates session cost", () => {


### PR DESCRIPTION
## What

Keep the active plan card current-step state in sync by setting the first unfinished active step to running when the plan is shown and after each plan.step.complete update.

## Why

Fixes #1441. Active plan cards store explicit step statuses, but new plans were initialized with every step queued and completion updates only marked the target step done, leaving later steps displayed as queued instead of advancing the live progress indicator.

## How to verify

- `npm test -- tests/ui-reducer.test.ts`
- `npm test -- tests/ui-reducer.test.ts tests/handle-tool-event.test.ts tests/turn-translator.test.ts`
- `npm run typecheck`
- `npm run verify`

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time