### PR TITLE
fix(api): normalize preset in settings/overview endpoints to prevent badge crash 

### DIFF
--- a/src/server/api/overview.ts
+++ b/src/server/api/overview.ts
@@ -59,7 +59,7 @@ export async function handleOverview(
     pendingEdits: ctx.getPendingEditCount?.() ?? null,
     mcpServerCount: ctx.getMcpServers?.().length ?? null,
     toolCount: ctx.tools ? ctx.tools.size : null,
-    preset: cfg.preset ?? "auto",
+    preset: cfg.preset === "pro" ? "pro" : "flash",
     reasoningEffort: cfg.reasoningEffort ?? "max",
     budgetUsd: ctx.loop?.budgetUsd ?? null,
     stats: ctx.getStats?.() ?? null,

--- a/src/server/api/settings.ts
+++ b/src/server/api/settings.ts
@@ -103,7 +103,7 @@ export async function handleSettings(
         apiKeySet: Boolean(cfg.apiKey),
         baseUrl: cfg.baseUrl ?? null,
         lang: getLanguage(),
-        preset: cfg.preset ?? "flash",
+        preset: cfg.preset === "pro" ? "pro" : "flash",
         reasoningEffort: cfg.reasoningEffort ?? "max",
         search: cfg.search !== false,
         webSearchEngine: readWebSearchEngine(ctx.configPath),


### PR DESCRIPTION
Stale configs holding "auto" (from the removed preset) or any other 
non-"flash"/"pro" value cause a frontend crash: 

  Uncaught TypeError: Cannot read properties of undefined (reading 'badge') 

because PRESET_INFO only has "flash" and "pro" keys. 

Both GET /api/settings and GET /api/overview returned cfg.preset raw, 
relying only on ?? "flash" which does not intercept truthy invalid 
strings like "auto". Switch to explicit normalization: 

  cfg.preset === "pro" ? "pro" : "flash" 

This mirrors the coercion already done by canonicalPresetName() and 
loadPreset() on the CLI side, closing the gap for the server API 
path.

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time

----

<img width="812" height="385" alt="image" src="https://github.com/user-attachments/assets/2faa01e8-0fd9-472e-82ae-1765cb2d5459" />

<img width="871" height="277" alt="image" src="https://github.com/user-attachments/assets/93fba856-5208-4325-953a-1caa864e6e2a" />

```

app.js?token=805e94d…133ba7ab7d6e533fe:9 Uncaught TypeError: Cannot read properties of undefined (reading 'badge')
    at na (app.js?token=805e94d…ab7d6e533fe:9:41248)
    at xc (vendor-react.js?toke…b7d6e533fe:48:47832)
    at kf (vendor-react.js?toke…b7d6e533fe:48:70443)
    at Jv (vendor-react.js?toke…b7d6e533fe:48:80736)
    at z1 (vendor-react.js?toke…7d6e533fe:48:116148)
    at Pd (vendor-react.js?toke…7d6e533fe:48:115230)
    at vf (vendor-react.js?toke…7d6e533fe:48:115068)
    at h1 (vendor-react.js?toke…7d6e533fe:48:111931)
    at N1 (vendor-react.js?toke…7d6e533fe:48:123437)
    at MessagePort.Gl (vendor-react.js?toke…ab7d6e533fe:17:1564)

```

