### PR TITLE
fix(tui): isolate static history from input rerenders

### DIFF
--- a/src/cli/ui/layout/StaticCardStream.tsx
+++ b/src/cli/ui/layout/StaticCardStream.tsx
@@ -1,15 +1,16 @@
 import { Box, Static } from "ink";
-// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX
 import React, { useMemo } from "react";
 import { CardRenderer } from "../cards/CardRenderer.js";
 import type { Card } from "../state/cards.js";
 import { useAgentState } from "../state/provider.js";
 
-export function StaticCardStream({
-  suppressLive = false,
-}: {
+interface StaticCardStreamProps {
   suppressLive?: boolean;
-}): React.ReactElement {
+}
+
+function StaticCardStreamInner({
+  suppressLive = false,
+}: StaticCardStreamProps): React.ReactElement {
   const cards = useAgentState((s) => s.cards);
   const { staticItems, dynamicItems, hasUnsettledDynamic } = useMemo(
     () => partition(cards),
@@ -38,6 +39,9 @@ export function StaticCardStream({
     </>
   );
 }
+
+export const StaticCardStream = React.memo(StaticCardStreamInner);
+StaticCardStream.displayName = "StaticCardStream";
 
 function partition(cards: readonly Card[]): {
   staticItems: Card[];

--- a/tests/static-card-stream-verbose.test.tsx
+++ b/tests/static-card-stream-verbose.test.tsx
@@ -1,13 +1,27 @@
 /** StaticCardStream must let verbose mode expand already-settled tool cards. */
 
 import { render } from "ink-testing-library";
-import { type ReactElement, createElement } from "react";
-import { describe, expect, it } from "vitest";
+import { type ComponentType, type ReactElement, createElement } from "react";
+import { describe, expect, it, vi } from "vitest";
 import { StaticCardStream } from "../src/cli/ui/layout/StaticCardStream.js";
-import type { ToolCard } from "../src/cli/ui/state/cards.js";
+import type { ToolCard, UserCard } from "../src/cli/ui/state/cards.js";
 import { AgentStoreProvider } from "../src/cli/ui/state/provider.js";
 import type { SessionInfo } from "../src/cli/ui/state/state.js";
 import { VerboseContext } from "../src/cli/ui/state/verbose-context.js";
+
+const staticRenderSpy = vi.hoisted(() => vi.fn());
+
+vi.mock("ink", async () => {
+  const actual = await vi.importActual<typeof import("ink")>("ink");
+  const React = await vi.importActual<typeof import("react")>("react");
+  return {
+    ...actual,
+    Static: (props: Record<string, unknown>) => {
+      staticRenderSpy();
+      return React.createElement(actual.Static as ComponentType<Record<string, unknown>>, props);
+    },
+  };
+});
 
 const SESSION: SessionInfo = {
   id: "session-1",
@@ -48,11 +62,27 @@ const CARD: ToolCard = {
   elapsedMs: 410,
 };
 
+const USER_CARD: UserCard = {
+  id: "user-1",
+  ts: 0,
+  kind: "user",
+  text: "plain input",
+};
+
 function Harness({ verbose }: { verbose: boolean }): ReactElement {
   return createElement(
     AgentStoreProvider,
     { session: SESSION, initialCards: [CARD] },
     createElement(VerboseContext.Provider, { value: verbose }, createElement(StaticCardStream)),
+  );
+}
+
+function ParentUpdateHarness({ revision }: { revision: number }): ReactElement {
+  void revision;
+  return createElement(
+    AgentStoreProvider,
+    { session: SESSION, initialCards: [USER_CARD] },
+    createElement(StaticCardStream),
   );
 }
 
@@ -70,6 +100,20 @@ describe("StaticCardStream verbose mode", () => {
 
     rerender(createElement(Harness, { verbose: false }));
     expect(lastFrame()).toContain("hidden lines");
+    unmount();
+  });
+});
+
+describe("StaticCardStream render isolation", () => {
+  it("does not re-run static history rendering when only the parent updates", () => {
+    staticRenderSpy.mockClear();
+    const { rerender, unmount } = render(createElement(ParentUpdateHarness, { revision: 0 }));
+    const renderCountAfterMount = staticRenderSpy.mock.calls.length;
+    expect(renderCountAfterMount).toBeGreaterThan(0);
+
+    rerender(createElement(ParentUpdateHarness, { revision: 1 }));
+
+    expect(staticRenderSpy.mock.calls.length).toBe(renderCountAfterMount);
     unmount();
   });
 });


### PR DESCRIPTION
## What

Memoizes StaticCardStream so static history does not re-render on parent-only updates, while store subscriptions and verbose context still refresh normally.

## Why

Fixes #1597. Typing in the TUI updates parent input state for each keypress; with long history this could re-run Ink Static history rendering and make basic text input feel delayed.

## How to verify

- `npm run verify`

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time