### PR TITLE
fix(tui): drop legacy mouse reports

### DIFF
--- a/src/cli/ui/mouse-mode.ts
+++ b/src/cli/ui/mouse-mode.ts
@@ -13,7 +13,8 @@ function readMode(): Mode {
   return "off";
 }
 
-const RESET_ALL = "\u001b[?1000l\u001b[?1002l\u001b[?1003l\u001b[?1006l\u001b[?1007l\u001b[?1015l";
+const RESET_ALL =
+  "\u001b[?9l\u001b[?1000l\u001b[?1002l\u001b[?1003l\u001b[?1005l\u001b[?1006l\u001b[?1007l\u001b[?1015l";
 
 const SEQUENCES: Record<Mode, { enable: string; disable: string }> = {
   "alternate-scroll": { enable: "\u001b[?1007h", disable: "\u001b[?1007l" },

--- a/src/cli/ui/stdin-reader.ts
+++ b/src/cli/ui/stdin-reader.ts
@@ -225,9 +225,10 @@ export function looksLikeUnbracketedPaste(chunk: string): boolean {
 
 export class StdinReader {
   private subscribers = new Set<Subscriber>();
-  private state: "idle" | "esc" | "csi" | "ss3" | "paste" = "idle";
+  private state: "idle" | "esc" | "csi" | "ss3" | "paste" | "legacyMouse" = "idle";
   /** Buffer for partial sequences across chunks. */
   private csiBuf = "";
+  private legacyMouseBuf = "";
   /** Buffer for paste content. */
   private pasteBuf = "";
   private escTimer: NodeJS.Timeout | null = null;
@@ -277,6 +278,7 @@ export class StdinReader {
     this.cancelEscTimer();
     this.state = "idle";
     this.csiBuf = "";
+    this.legacyMouseBuf = "";
     this.pasteBuf = "";
     this.started = false;
   }
@@ -369,6 +371,12 @@ export class StdinReader {
       // ── CSI accumulator ──
       if (this.state === "csi") {
         const ch = chunk[i]!;
+        if (this.csiBuf.length === 0 && ch === "M") {
+          this.state = "legacyMouse";
+          this.legacyMouseBuf = "";
+          i++;
+          continue;
+        }
         this.csiBuf += ch;
         if (isCsiFinal(ch)) {
           this.dispatchCsi(this.csiBuf);
@@ -380,6 +388,18 @@ export class StdinReader {
           if (this.state === "csi") this.state = "idle";
         }
         i++;
+        continue;
+      }
+
+      if (this.state === "legacyMouse") {
+        const need = 3 - this.legacyMouseBuf.length;
+        const take = Math.min(need, chunk.length - i);
+        this.legacyMouseBuf += chunk.slice(i, i + take);
+        i += take;
+        if (this.legacyMouseBuf.length === 3) {
+          this.legacyMouseBuf = "";
+          this.state = "idle";
+        }
         continue;
       }
 

--- a/tests/mouse-mode.test.ts
+++ b/tests/mouse-mode.test.ts
@@ -39,7 +39,7 @@ describe("mouse-mode enable/disable", () => {
   it("default resets every mouse-capture mode so the terminal owns the wheel", () => {
     enableMouseMode();
     expect(writes.join("")).toBe(
-      "\u001b[?1000l\u001b[?1002l\u001b[?1003l\u001b[?1006l\u001b[?1007l\u001b[?1015l",
+      "\u001b[?9l\u001b[?1000l\u001b[?1002l\u001b[?1003l\u001b[?1005l\u001b[?1006l\u001b[?1007l\u001b[?1015l",
     );
   });
 
@@ -69,7 +69,7 @@ describe("mouse-mode enable/disable", () => {
     process.env.REASONIX_MOUSE_MODE = "off";
     enableMouseMode();
     expect(writes.join("")).toBe(
-      "\u001b[?1000l\u001b[?1002l\u001b[?1003l\u001b[?1006l\u001b[?1007l\u001b[?1015l",
+      "\u001b[?9l\u001b[?1000l\u001b[?1002l\u001b[?1003l\u001b[?1005l\u001b[?1006l\u001b[?1007l\u001b[?1015l",
     );
     writes.length = 0;
     disableMouseMode();
@@ -80,7 +80,7 @@ describe("mouse-mode enable/disable", () => {
     process.env.REASONIX_MOUSE_MODE = "garbage";
     enableMouseMode();
     expect(writes.join("")).toBe(
-      "\u001b[?1000l\u001b[?1002l\u001b[?1003l\u001b[?1006l\u001b[?1007l\u001b[?1015l",
+      "\u001b[?9l\u001b[?1000l\u001b[?1002l\u001b[?1003l\u001b[?1005l\u001b[?1006l\u001b[?1007l\u001b[?1015l",
     );
   });
 

--- a/tests/stdin-reader.test.ts
+++ b/tests/stdin-reader.test.ts
@@ -431,6 +431,19 @@ describe("StdinReader — SGR mouse reports (issue #867)", () => {
     reader.feed("[<not-a-mouse-report");
     expect(events).toEqual([{ input: "[<not-a-mouse-report" }]);
   });
+
+  it("drops legacy X10 mouse reports as a whole instead of leaking coordinate bytes", () => {
+    const { reader, events } = setup();
+    reader.feed("\x1b[M`*%");
+    expect(events).toEqual([]);
+  });
+
+  it("drops legacy X10 mouse reports even when split after the prefix", () => {
+    const { reader, events } = setup();
+    reader.feed("\x1b[M");
+    reader.feed("`*%");
+    expect(events).toEqual([]);
+  });
 });
 
 describe("sanitizePasteText (issue #849)", () => {


### PR DESCRIPTION
## What

Resets legacy terminal mouse modes on startup and consumes legacy X10 mouse reports as a complete control sequence instead of letting coordinate bytes reach the composer.

## Why

Addresses #1606. Some terminals can retain older mouse modes, which can turn wheel or click activity during streaming output into raw `ESC [ M ...` reports. The existing parser dropped only the prefix, so the remaining bytes could look like typed input and make the composer jump or flicker.

## How to verify

- `npm run verify`

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time