### PR TITLE
fix(ui): preserve code operators in code blocks

### DIFF
--- a/dashboard/src/styles.css
+++ b/dashboard/src/styles.css
@@ -1813,6 +1813,8 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
   border-radius: 10px;
   background: var(--panel-2);
   font-family: "Geist Mono", monospace;
+  font-variant-ligatures: none;
+  font-feature-settings: "liga" 0, "calt" 0;
   font-size: 13px;
   line-height: 1.62;
   overflow-x: auto;
@@ -1870,6 +1872,8 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
   margin: 0;
   padding: 14px 16px;
   font-family: "Geist Mono", monospace;
+  font-variant-ligatures: none;
+  font-feature-settings: "liga" 0, "calt" 0;
   font-size: 13px;
   line-height: 1.62;
   overflow-x: auto;

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -1855,6 +1855,8 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
   border-radius: 10px;
   background: var(--panel-2);
   font-family: "Geist Mono", monospace;
+  font-variant-ligatures: none;
+  font-feature-settings: "liga" 0, "calt" 0;
   font-size: 13px;
   line-height: 1.62;
   overflow-x: auto;
@@ -1912,6 +1914,8 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
   margin: 0;
   padding: 14px 16px;
   font-family: "Geist Mono", monospace;
+  font-variant-ligatures: none;
+  font-feature-settings: "liga" 0, "calt" 0;
   font-size: 13px;
   line-height: 1.62;
   overflow-x: auto;

--- a/tests/code-block-ligatures.test.ts
+++ b/tests/code-block-ligatures.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("markdown code block rendering", () => {
+  it("disables font ligatures in desktop and dashboard code blocks", () => {
+    const desktopCss = readFileSync("desktop/src/styles.css", "utf8");
+    const dashboardCss = readFileSync("dashboard/src/styles.css", "utf8");
+
+    for (const css of [desktopCss, dashboardCss]) {
+      expect(css).toContain(".markdown .codeview");
+      expect(css).toContain("font-variant-ligatures: none");
+      expect(css).toContain('font-feature-settings: "liga" 0, "calt" 0');
+    }
+  });
+});


### PR DESCRIPTION
## What

Disable font ligatures and contextual alternates for Markdown code blocks in the dashboard and desktop views. Add a regression test that keeps both surfaces covered.

## Why

The code-rendering bug reported in #1636 comes from operator-like sequences such as -> or => being shaped by the code font, which can make symbols appear compressed or overlapping in mixed code output. Code blocks should display each source character plainly.

## How to verify

- npm run verify
- npm --prefix desktop run build

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time
