### PR TITLE
fix(desktop): block right-click context menu

### DIFF
--- a/desktop/src/main.tsx
+++ b/desktop/src/main.tsx
@@ -51,6 +51,8 @@ if (!import.meta.env.DEV) {
   );
 }
 
+window.addEventListener("contextmenu", (e) => e.preventDefault());
+
 const host = document.getElementById("root");
 if (!host) throw new Error("#root missing");
 


### PR DESCRIPTION
## What

Block the WebView2 default right-click menu in the desktop app. The previous behavior surfaced a browser context menu whose "Reload" entry wiped the in-memory session and left a blank white screen — a sharp footgun for any user who right-clicked by reflex.

## Why

End users don't know the desktop UI is a WebView, so the browser's "Reload" looks like a normal menu item, not a destructive reset. We already trap F5 / Ctrl+R earlier in `main.tsx` for the same reason; the right-click path was the remaining gap.

## How

One line in `desktop/src/main.tsx`, right after the existing key trap:

```ts
window.addEventListener("contextmenu", (e) => e.preventDefault());
```

Frontend-side (not Tauri config) because it's deterministic across WebView2 versions and doesn't touch the runtime config surface.

## Checklist

- [x] `npm run verify` passes locally
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md
- [x] No edits to `CHANGELOG.md`