### PR TITLE
fix(desktop): show current context size, not cumulative cache totals

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -720,10 +720,10 @@ export function applyIncoming(state: State, ev: IncomingEvent): State {
     case "$ctx_breakdown": {
       const next: UsageStats = { ...state.usage, reservedTokens: ev.reservedTokens };
       if (typeof ev.logTokens === "number") {
-        // After /compact the backend sends a real-time log token count;
-        // reset the meter so it reflects the actual current context size.
         next.cacheHitTokens = 0;
         next.cacheMissTokens = ev.logTokens;
+        next.lastCallCacheHit = 0;
+        next.lastCallCacheMiss = ev.logTokens;
       }
       return { ...state, usage: next };
     }

--- a/desktop/src/ui/context-panel.tsx
+++ b/desktop/src/ui/context-panel.tsx
@@ -27,11 +27,10 @@ export function ContextPanel({
   useLang();
   const [tab, setTab] = useState<Tab>("files");
   const reserved = usage.reservedTokens;
-  // After a warm cache turn the API counts the reserved prefix inside cacheHit;
-  // subtract to keep the bar segments visually disjoint. Cold cache shows the
-  // reserved portion in cacheMiss instead, so do the same for `used`.
-  const cached = Math.max(0, usage.cacheHitTokens - reserved);
-  const used = Math.max(0, usage.cacheMissTokens - Math.max(0, reserved - usage.cacheHitTokens));
+  const lastHit = usage.lastCallCacheHit ?? 0;
+  const lastMiss = usage.lastCallCacheMiss ?? 0;
+  const cached = Math.max(0, lastHit - reserved);
+  const used = Math.max(0, lastMiss - Math.max(0, reserved - lastHit));
   const reservedPct = Math.min(100, (reserved / CONTEXT_MAX_TOKENS) * 100);
   const usedPct = Math.min(100, (used / CONTEXT_MAX_TOKENS) * 100);
   const cachedPct = Math.min(100, (cached / CONTEXT_MAX_TOKENS) * 100);


### PR DESCRIPTION
## What

The right-side context meter (sidebar) summed `cacheHitTokens` and `cacheMissTokens`, which are **session-wide running totals**, and tried to render them against a 1M ceiling. After ~20 cached turns of a 50k-token context the cumulative cacheHit alone reaches 1M+ and the panel renders something like:

> `1,500,000 / 1,000,000`

…with the bar pegged at 100%. /compact partially patched this by resetting the cumulative counters via `\$ctx_breakdown`, but the very next `model.final` started accumulating again, so the fix only held for one frame.

## Why

What the meter is supposed to show is **the current context size** — i.e. `prompt_tokens` of the most recent API call. That value is already captured per-turn as `lastCallCacheHit` / `lastCallCacheMiss` in `App.tsx` — `context-panel.tsx` just wasn't using them.

Cumulative totals are still the right choice elsewhere (status bar and settings show cache hit *rate*, which legitimately wants the session-wide sum), so I left those alone.

## How

- `context-panel.tsx`: read from `lastCallCacheHit` / `lastCallCacheMiss` (null-coalesced to 0 since the type allows null for "no call yet").
- `App.tsx`: on `\$ctx_breakdown` with `logTokens` (the post-`/compact` reset path), also seed `lastCall*` so the panel reflects the new size immediately instead of waiting for the next `model.final`.

## How to verify

- Run desktop, chat for ~10 turns until the meter would have shown >1M before this fix — meter should now sit at the actual prompt size.
- Run `/compact` — meter should drop to the post-compact log size immediately, then track real per-turn input thereafter.
- Existing `App.test.ts` still passes (no test was asserting the broken cumulative behavior).

## Checklist

- [x] `npm run verify` passes locally
- [x] No `Co-Authored-By: Claude` trailer
- [x] Comments follow CONTRIBUTING.md (removed the now-stale 3-line comment that justified the old subtraction trick)
- [x] No edits to `CHANGELOG.md`