### PR TITLE
fix(desktop): surface file paths and completion feedback

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -56,7 +56,12 @@ import { Sidebar } from "./ui/sidebar";
 import { Shortcut, localizeShortcutText, shortcutText } from "./ui/shortcut";
 import { Splash, shouldShowSplash } from "./ui/splash";
 import { StatusBar } from "./ui/statusbar";
-import { dispatchDesktopNotifications, deriveDesktopNotifications, type ApprovalSnapshot } from "./notifications";
+import {
+  dispatchDesktopNotifications,
+  deriveDesktopNotifications,
+  shouldShowCompletionToast,
+  type ApprovalSnapshot,
+} from "./notifications";
 import {
   ActivePlanTaskCard,
   AssistantMsg,
@@ -1431,21 +1436,37 @@ function TabRuntime({
     previousApprovalSnapshotRef.current = currentSnapshot;
     wasBusyRef.current = state.busy;
 
-    const notifications = deriveDesktopNotifications({
-      previous: previousSnapshot,
-      current: currentSnapshot,
-      wasBusy,
-      isBusy: state.busy,
-      busyDurationMs,
-      focused: false,
-    });
-    void dispatchDesktopNotifications(notifications, {
-      isFocused: () => getCurrentWindow().isFocused(),
-      isPermissionGranted: isNotificationPermissionGranted,
-      requestPermission: requestNotificationPermission,
-      sendNotification,
-    });
+    void getCurrentWindow()
+      .isFocused()
+      .catch(() => true)
+      .then((focused) => {
+        if (
+          shouldShowCompletionToast({
+            wasBusy,
+            isBusy: state.busy,
+            busyDurationMs,
+            focused,
+          })
+        ) {
+          flashToast(t("app.toast.taskComplete"), { duration: 2400 });
+        }
+        const notifications = deriveDesktopNotifications({
+          previous: previousSnapshot,
+          current: currentSnapshot,
+          wasBusy,
+          isBusy: state.busy,
+          busyDurationMs,
+          focused,
+        });
+        void dispatchDesktopNotifications(notifications, {
+          isFocused: async () => focused,
+          isPermissionGranted: isNotificationPermissionGranted,
+          requestPermission: requestNotificationPermission,
+          sendNotification,
+        });
+      });
   }, [
+    flashToast,
     state.busy,
     state.pendingChoices,
     state.pendingCheckpoints,

--- a/desktop/src/i18n/en.ts
+++ b/desktop/src/i18n/en.ts
@@ -364,6 +364,7 @@ export const en = {
       langSwitched: "Switched to {lang}",
       modelSwitched: "Switched to {model}",
       modeSwitched: "Mode: {mode}",
+      taskComplete: "Task complete",
     },
     cmd: {
       newSession: "New session",
@@ -567,6 +568,8 @@ export const en = {
     filesCount: "{count} files",
     fileModified: "modified",
     fileInContext: "in context",
+    openFile: "Open file: {path}",
+    copyPath: "Copy path: {path}",
     mcpTitle: "MCP servers",
     mcpReadyAll: "{count} ready",
     mcpReadySome: "{ready}/{count} ready",

--- a/desktop/src/i18n/zh-CN.ts
+++ b/desktop/src/i18n/zh-CN.ts
@@ -384,6 +384,7 @@ export const zhCN: typeof en = {
       langSwitched: "已切换到{lang}",
       modelSwitched: "已切换到 {model}",
       modeSwitched: "模式: {mode}",
+      taskComplete: "任务已完成",
     },
     cmd: {
       newSession: "新建会话",
@@ -553,6 +554,8 @@ export const zhCN: typeof en = {
     filesCount: "{count} 个文件",
     fileModified: "已修改",
     fileInContext: "在上下文中",
+    openFile: "打开文件：{path}",
+    copyPath: "复制路径：{path}",
     mcpTitle: "MCP 服务器",
     mcpReadyAll: "{count} 个已就绪",
     mcpReadySome: "{ready}/{count} 已就绪",

--- a/desktop/src/notifications-feedback.test.ts
+++ b/desktop/src/notifications-feedback.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { COMPLETION_NOTIFY_MIN_MS, shouldShowCompletionToast } from "./notifications";
+
+describe("desktop completion feedback", () => {
+  it("shows in-window feedback when a long task completes while focused", () => {
+    expect(
+      shouldShowCompletionToast({
+        wasBusy: true,
+        isBusy: false,
+        busyDurationMs: COMPLETION_NOTIFY_MIN_MS,
+        focused: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not show in-window feedback for short tasks", () => {
+    expect(
+      shouldShowCompletionToast({
+        wasBusy: true,
+        isBusy: false,
+        busyDurationMs: COMPLETION_NOTIFY_MIN_MS - 1,
+        focused: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/desktop/src/notifications.ts
+++ b/desktop/src/notifications.ts
@@ -108,6 +108,20 @@ export function deriveDesktopNotifications(args: {
   return notifications;
 }
 
+export function shouldShowCompletionToast(args: {
+  wasBusy: boolean;
+  isBusy: boolean;
+  busyDurationMs: number;
+  focused: boolean;
+}): boolean {
+  return (
+    args.focused &&
+    args.wasBusy &&
+    !args.isBusy &&
+    args.busyDurationMs >= COMPLETION_NOTIFY_MIN_MS
+  );
+}
+
 let notificationPermissionAttempted = false;
 
 export async function dispatchDesktopNotifications(

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -3240,25 +3240,57 @@ html:not([data-platform="macos"]) .cmdk-row .kb .shortcut kbd[data-key="mod"] {
 }
 .tree .node[data-kind="file"] {
   cursor: default;
+  align-items: flex-start;
 }
 .tree .node .ico {
   color: var(--muted-2);
   flex-shrink: 0;
+  margin-top: 2px;
+}
+.tree .node-text {
+  min-width: 0;
+  display: grid;
+  gap: 1px;
+  flex: 1;
 }
 .tree .node .nm {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+.tree .node .full-path {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px;
+  color: var(--muted);
+}
 .tree .node .dot {
-  margin-left: auto;
+  margin-top: 7px;
   width: 6px;
   height: 6px;
   border-radius: 50%;
   background: var(--success);
+  flex-shrink: 0;
 }
 .tree .node .dot[data-s="m"] {
   background: var(--warning);
+}
+.tree-action {
+  width: 22px;
+  height: 22px;
+  border: 0;
+  border-radius: 4px;
+  color: var(--muted);
+  background: transparent;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+.tree-action:hover {
+  color: var(--fg);
+  background: var(--panel-2);
 }
 
 .ctx-empty {

--- a/desktop/src/ui/context-panel.test.tsx
+++ b/desktop/src/ui/context-panel.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+
+import { invoke } from "@tauri-apps/api/core";
+import { openPath } from "@tauri-apps/plugin-opener";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Settings, UsageStats } from "../App";
+import { setLang } from "../i18n";
+import { ContextPanel } from "./context-panel";
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+vi.mock("@tauri-apps/plugin-opener", () => ({ openPath: vi.fn() }));
+
+const usage: UsageStats = {
+  totalCostUsd: 0,
+  totalPromptTokens: 0,
+  totalCompletionTokens: 0,
+  cacheHitTokens: 0,
+  cacheMissTokens: 0,
+  lastCallCacheHit: null,
+  lastCallCacheMiss: null,
+  reservedTokens: 0,
+};
+
+const settings: Settings = {
+  reasoningEffort: "high",
+  editMode: "review",
+  budgetUsd: null,
+  workspaceDir: "/repo",
+  recentWorkspaces: [],
+  model: "deepseek-reasoner",
+  preset: "pro",
+  version: "0.0.0",
+};
+
+function renderPanel() {
+  return render(
+    <ContextPanel
+      settings={settings}
+      usage={usage}
+      mcpSpecs={[]}
+      mcpBridged={false}
+      sessionFiles={[{ path: "src/new-file.ts", status: "m" }]}
+      memory={[]}
+    />,
+  );
+}
+
+describe("ContextPanel files", () => {
+  beforeEach(() => {
+    setLang("en");
+    vi.mocked(invoke).mockReset();
+    vi.mocked(openPath).mockReset();
+  });
+  afterEach(cleanup);
+
+  it("keeps each tracked file's full path visible", () => {
+    const { container } = renderPanel();
+
+    const fileRow = container.querySelector('[data-kind="file"]');
+
+    expect(fileRow?.textContent).toContain("src/new-file.ts");
+    expect(fileRow?.getAttribute("title")).toBe("src/new-file.ts");
+  });
+
+  it("opens a tracked file from the file row action", async () => {
+    renderPanel();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open file: src/new-file.ts" }));
+
+    await waitFor(() => expect(openPath).toHaveBeenCalledWith("/repo/src/new-file.ts"));
+  });
+});

--- a/desktop/src/ui/context-panel.tsx
+++ b/desktop/src/ui/context-panel.tsx
@@ -1,3 +1,5 @@
+import { invoke } from "@tauri-apps/api/core";
+import { openPath } from "@tauri-apps/plugin-opener";
 import { useMemo, useState } from "react";
 import type { SessionFile, Settings, UsageStats } from "../App";
 import { t, useLang } from "../i18n";
@@ -87,7 +89,7 @@ export function ContextPanel({
         </div>
 
         <PanelErrorBoundary key={tab} label={tab}>
-          {tab === "files" && <CtxFiles files={sessionFiles} />}
+          {tab === "files" && <CtxFiles files={sessionFiles} settings={settings} />}
           {tab === "tools" && <CtxTools specs={mcpSpecs} bridged={mcpBridged} />}
           {tab === "memory" && <CtxMemory entries={memory} />}
           {tab === "rules" && <CtxRules settings={settings} />}
@@ -99,7 +101,22 @@ export function ContextPanel({
 
 type TreeNode =
   | { kind: "dir"; depth: number; name: string; key: string }
-  | { kind: "file"; depth: number; name: string; key: string; status: "c" | "m" };
+  | { kind: "file"; depth: number; name: string; path: string; key: string; status: "c" | "m" };
+
+async function openContextFile(path: string, settings: Settings | null): Promise<void> {
+  const workspaceDir = settings?.workspaceDir;
+  const sep = workspaceDir?.includes("\\") ? "\\" : "/";
+  const abs =
+    workspaceDir && !/^[a-zA-Z]:[\\/]/.test(path) && !path.startsWith("/")
+      ? `${workspaceDir.replace(/[\\/]$/, "")}${sep}${path.replace(/^[\\/]+/, "")}`
+      : path;
+  const editor = settings?.editor?.trim();
+  if (editor) {
+    await invoke("open_in_editor", { command: editor, path: abs, line: null });
+    return;
+  }
+  await openPath(abs);
+}
 
 function buildSessionTree(files: SessionFile[]): TreeNode[] {
   const sorted = [...files].sort((a, b) =>
@@ -108,7 +125,8 @@ function buildSessionTree(files: SessionFile[]): TreeNode[] {
   const out: TreeNode[] = [];
   const seenDirs = new Set<string>();
   for (const f of sorted) {
-    const parts = f.path.replace(/\\/g, "/").split("/").filter(Boolean);
+    const displayPath = f.path.replace(/\\/g, "/");
+    const parts = displayPath.split("/").filter(Boolean);
     if (parts.length === 0) continue;
     let prefix = "";
     for (let i = 0; i < parts.length - 1; i++) {
@@ -124,6 +142,7 @@ function buildSessionTree(files: SessionFile[]): TreeNode[] {
       kind: "file",
       depth: parts.length - 1,
       name: leaf,
+      path: displayPath,
       key: `f:${f.path}`,
       status: f.status,
     });
@@ -131,7 +150,7 @@ function buildSessionTree(files: SessionFile[]): TreeNode[] {
   return out;
 }
 
-function CtxFiles({ files }: { files: SessionFile[] }) {
+function CtxFiles({ files, settings }: { files: SessionFile[]; settings: Settings | null }) {
   const tree = useMemo(() => buildSessionTree(files), [files]);
   return (
     <div className="ctx-block">
@@ -147,7 +166,13 @@ function CtxFiles({ files }: { files: SessionFile[] }) {
         ) : (
           tree.map((n) =>
             n.kind === "dir" ? (
-              <div className="node" key={n.key} data-d={n.depth} data-kind="dir">
+              <div
+                className="node"
+                key={n.key}
+                data-d={n.depth}
+                data-kind="dir"
+                style={{ paddingLeft: 4 + n.depth * 14 }}
+              >
                 <span className="ico">
                   <I.folder size={12} />
                 </span>
@@ -159,17 +184,39 @@ function CtxFiles({ files }: { files: SessionFile[] }) {
                 key={n.key}
                 data-d={n.depth}
                 data-kind="file"
-                title={n.name}
+                title={n.path}
+                style={{ paddingLeft: 4 + n.depth * 14 }}
               >
                 <span className="ico">
                   <I.file size={12} />
                 </span>
-                <span className="nm">{n.name}</span>
+                <span className="node-text">
+                  <span className="nm">{n.name}</span>
+                  <span className="full-path">{n.path}</span>
+                </span>
                 <span
                   className="dot"
                   data-s={n.status}
                   title={n.status === "m" ? t("contextPanel.fileModified") : t("contextPanel.fileInContext")}
                 />
+                <button
+                  type="button"
+                  className="tree-action"
+                  aria-label={t("contextPanel.openFile", { path: n.path })}
+                  title={t("contextPanel.openFile", { path: n.path })}
+                  onClick={() => void openContextFile(n.path, settings)}
+                >
+                  <I.file size={12} />
+                </button>
+                <button
+                  type="button"
+                  className="tree-action"
+                  aria-label={t("contextPanel.copyPath", { path: n.path })}
+                  title={t("contextPanel.copyPath", { path: n.path })}
+                  onClick={() => void navigator.clipboard?.writeText(n.path)}
+                >
+                  <I.copy size={12} />
+                </button>
               </div>
             ),
           )


### PR DESCRIPTION
## What

Show the full tracked path for desktop context-panel files, add open/copy actions for each file row, and show an in-window completion toast when a long task finishes while the window is focused. Existing native desktop notifications still cover unfocused windows.

## Why

The file list reported in #1638 only showed leaf names, so newly created files were hard to locate from the context panel. Completion feedback also only reached unfocused windows through native notifications, leaving focused users without a clear finish cue for long turns.

## How to verify

- npm run verify
- npm --prefix desktop run build

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time