### PR TITLE
feat(desktop): copy/edit overlay, msg history nav, IME guard, card collapse

### DIFF
--- a/desktop/src-tauri/src/rpc.rs
+++ b/desktop/src-tauri/src/rpc.rs
@@ -98,15 +98,16 @@ fn resolve_cli(app: &AppHandle) -> Result<(String, Vec<String>)> {
 }
 
 /// Walk every PATH match for `node` and return the first one that is
-/// (a) a real file > 100 KB and (b) NOT inside Windows' App Execution
-/// Alias directory — those Microsoft Store stubs are 0-byte and triggered
-/// the original "%1 is not a valid Win32 application" (error 193).
+/// (a) a real file > 50 KB on macOS/Linux, or > 100 KB on Windows, and
+/// (b) NOT inside Windows' App Execution Alias directory.
+/// Threshold must accommodate Homebrew Node ~68 KB on arm64 macOS.
 fn find_real_node() -> Result<PathBuf> {
     let names: &[&str] = if cfg!(windows) {
         &["node.exe", "node"]
     } else {
         &["node"]
     };
+    let min_size: u64 = if cfg!(windows) { 100_000 } else { 50_000 };
     let mut tried: Vec<String> = Vec::new();
     for name in names {
         if let Ok(iter) = which_all(*name) {
@@ -114,7 +115,7 @@ fn find_real_node() -> Result<PathBuf> {
                 let size = std::fs::metadata(&p).map(|m| m.len()).unwrap_or(0);
                 let lower = p.to_string_lossy().to_lowercase();
                 let is_ms_store_shim = lower.contains("windowsapps");
-                let too_small = size < 100_000;
+                let too_small = size < min_size;
                 if !too_small && !is_ms_store_shim {
                     return Ok(p);
                 }

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -1931,7 +1931,7 @@ function TabRuntime({
                       return (
                         <div key={`u-${i}`}>
                           {needsDivider ? <TurnDivider label={dividerLabel} /> : null}
-                          <UserMsg text={m.text} skill={m.skill} />
+                          <UserMsg text={m.text} skill={m.skill} onEdit={(t) => { setDraft(t); composerRef.current?.focus(); }} />
                         </div>
                       );
                     }

--- a/desktop/src/Markdown.tsx
+++ b/desktop/src/Markdown.tsx
@@ -213,14 +213,19 @@ export const Markdown = memo(function Markdown({ source }: { source: string }) {
         rehypePlugins={[[rehypeKatex, { throwOnError: false }]]}
         components={{
           pre: ({ children }) => {
-            const codeEl = Children.toArray(children).find(
-              (c): c is ReactElement<{ className?: string; children?: ReactNode }> =>
-                isValidElement(c) && c.type === "code",
+            // react-markdown v9 nests children unpredictably — flatten all text.
+            const rawText = flattenChildText(children).trimEnd();
+            const kids = Children.toArray(children);
+            const codeEl = kids.find(
+              (c): c is ReactElement =>
+                isValidElement(c) && typeof c.type === "string" && c.type.toLowerCase() === "code",
             );
-            if (!codeEl) return <pre>{children}</pre>;
-            const text = String(codeEl.props.children ?? "").replace(/\n$/, "");
-            const lang = /language-([\w-]+)/.exec(codeEl.props.className ?? "")?.[1] ?? "text";
-            return <CodeBlock lang={lang} text={text} />;
+            const lang = codeEl
+              ? /language-([\w-]+)/.exec(
+                  (codeEl.props as Record<string, unknown>).className as string ?? "",
+                )?.[1] ?? "text"
+              : "text";
+            return <CodeBlock lang={lang} text={rawText} />;
           },
           code: ({ className, children }) => {
             const text = String(children ?? "");
@@ -298,6 +303,14 @@ function SafeLink({ href, children }: { href?: string; children: ReactNode }) {
   );
 }
 
+/** Recursively extract plain text from React children (handles nested elements, fragments, etc.). */
+function flattenChildText(node: ReactNode): string {
+  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(flattenChildText).join("");
+  if (isValidElement(node)) return flattenChildText(node.props.children);
+  return "";
+}
+
 function CodeBlock({ lang, text }: { lang: string; text: string }): ReactNode {
   useLang();
   const [copied, setCopied] = useState(false);
@@ -314,10 +327,12 @@ function CodeBlock({ lang, text }: { lang: string; text: string }): ReactNode {
     <div className="codeblock">
       <div className="codeblock-head">
         <span className="codeblock-lang">{lang}</span>
-        <button type="button" className={`copy-btn ${copied ? "done" : ""}`} onClick={onCopy}>
-          {copied ? <Check size={11} /> : <Copy size={11} />}
-          {copied ? t("markdown.copied") : t("markdown.copy")}
-        </button>
+        <span className="codeblock-copy-wrap">
+          <button type="button" className={`copy-btn ${copied ? "done" : ""}`} onClick={onCopy}>
+            {copied ? <Check size={11} /> : <Copy size={11} />}
+            {copied ? t("markdown.copied") : t("markdown.copy")}
+          </button>
+        </span>
       </div>
       <CodeView text={text} lang={lang} />
     </div>

--- a/desktop/src/Markdown.tsx
+++ b/desktop/src/Markdown.tsx
@@ -307,7 +307,7 @@ function SafeLink({ href, children }: { href?: string; children: ReactNode }) {
 function flattenChildText(node: ReactNode): string {
   if (typeof node === "string" || typeof node === "number") return String(node);
   if (Array.isArray(node)) return node.map(flattenChildText).join("");
-  if (isValidElement(node)) return flattenChildText(node.props.children);
+  if (isValidElement(node)) return flattenChildText((node.props as { children?: ReactNode }).children);
   return "";
 }
 

--- a/desktop/src/i18n/en.ts
+++ b/desktop/src/i18n/en.ts
@@ -674,6 +674,7 @@ export const en = {
     optionCount: "{count} options",
     subagent: "subagent",
     copyMessage: "Copy this message",
+    editMessage: "Edit this message and re-send",
     copyResponse: "Copy this response",
   },
   live: {

--- a/desktop/src/i18n/zh-CN.ts
+++ b/desktop/src/i18n/zh-CN.ts
@@ -660,6 +660,7 @@ export const zhCN: typeof en = {
     optionCount: "{count} 个选项",
     subagent: "subagent",
     copyMessage: "复制这条消息",
+    editMessage: "编辑并重新发送",
     copyResponse: "复制这条回复",
   },
   live: {

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -1645,6 +1645,7 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
 .msg .body {
   flex: 1;
   min-width: 0;
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -1657,6 +1658,7 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
 .msg.user .body {
   flex: none;
   max-width: 82%;
+  position: relative;
   background: var(--panel-2);
   border-radius: 12px;
   padding: 10px 14px;
@@ -1843,9 +1845,39 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
 }
 
 .msg-actions {
-  display: flex;
-  justify-content: flex-end;
-  margin-top: 4px;
+  position: absolute;
+  bottom: -6px;
+  right: -6px;
+  opacity: 0;
+  transition: opacity 0.12s ease;
+  z-index: 10;
+}
+.msg .body:hover .msg-actions {
+  opacity: 1;
+}
+.msg-actions .copy-btn,
+.msg-actions .edit-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 7px;
+  font-family: inherit;
+  font-size: 11px;
+  color: var(--muted);
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  cursor: pointer;
+  box-shadow: var(--shadow-sm);
+}
+.msg-actions .copy-btn:hover,
+.msg-actions .edit-btn:hover {
+  color: var(--fg-2);
+  border-color: var(--border-strong);
+}
+.msg-actions .copy-btn.done {
+  color: var(--success);
+  border-color: var(--success-soft);
 }
 
 .markdown pre {
@@ -1872,14 +1904,16 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
 .markdown .codeblock-head {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: 8px;
-  padding: 7px 14px;
+  padding: 6px 12px;
   background: var(--panel-2);
   border-bottom: 1px solid var(--border);
   font-family: "Geist Mono", monospace;
-  font-size: 12px;
+  font-size: 11px;
   color: var(--muted);
+}
+.markdown .codeblock-head .codeblock-copy-wrap {
+  margin-left: auto;
 }
 .markdown .codeblock-lang {
   text-transform: lowercase;
@@ -1887,24 +1921,24 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
   color: var(--fg-2);
   font-weight: 500;
 }
-.markdown .copy-btn {
+.markdown .codeblock-head .copy-btn {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  padding: 2px 8px;
+  padding: 2px 7px;
   font-family: inherit;
-  font-size: 12px;
+  font-size: 11px;
   color: var(--muted);
-  background: transparent;
+  background: var(--card);
   border: 1px solid var(--border);
   border-radius: 4px;
   cursor: pointer;
 }
-.markdown .copy-btn:hover {
+.markdown .codeblock-head .copy-btn:hover {
   color: var(--fg-2);
   border-color: var(--border-strong);
 }
-.markdown .copy-btn.done {
+.markdown .codeblock-head .copy-btn.done {
   color: var(--success);
   border-color: var(--success-soft);
 }

--- a/desktop/src/ui/cards.tsx
+++ b/desktop/src/ui/cards.tsx
@@ -173,7 +173,7 @@ export function ReasoningCard({
           )}
         </>
       }
-      defaultOpen={streaming}
+      defaultOpen={false}
       compact
     >
       <div className="reason">
@@ -236,6 +236,7 @@ export function ShellCard({
       kind="shell"
       name="shell"
       compact
+      defaultOpen={state !== "done"}
       meta={
         <>
           {state === "await" ? (

--- a/desktop/src/ui/cards.tsx
+++ b/desktop/src/ui/cards.tsx
@@ -173,7 +173,7 @@ export function ReasoningCard({
           )}
         </>
       }
-      defaultOpen={false}
+      defaultOpen={streaming}
       compact
     >
       <div className="reason">

--- a/desktop/src/ui/composer.tsx
+++ b/desktop/src/ui/composer.tsx
@@ -416,12 +416,13 @@ export function Composer({
       }
     }
     if (!popup) {
-      if (e.key === "ArrowUp") {
+      const ta = textareaRef.current;
+      if (e.key === "ArrowUp" && ta && ta.selectionStart === 0) {
         e.preventDefault();
         navigateHistory(-1);
         return;
       }
-      if (e.key === "ArrowDown") {
+      if (e.key === "ArrowDown" && ta && ta.selectionStart === draft.length) {
         e.preventDefault();
         navigateHistory(1);
         return;

--- a/desktop/src/ui/composer.tsx
+++ b/desktop/src/ui/composer.tsx
@@ -178,6 +178,12 @@ export function Composer({
   const [modelMenuOpen, setModelMenuOpen] = useState(false);
   const nonceRef = useRef(0);
   const modelWrapRef = useRef<HTMLDivElement>(null);
+  // macOS Chinese IME fires compositionend BEFORE the confirm keydown.
+  const composingRef = useRef(false);
+  const compositionEndedAtRef = useRef(0);
+  const historyRef = useRef<string[]>([]);
+  const [browseIdx, setBrowseIdx] = useState(-1);
+  const savedDraftRef = useRef("");
 
   useLayoutEffect(() => {
     const textarea = textareaRef.current;
@@ -334,6 +340,28 @@ export function Composer({
     textareaRef.current?.focus();
   };
 
+  const navigateHistory = (dir: -1 | 1) => {
+    const hist = historyRef.current;
+    if (hist.length === 0) return;
+    if (dir === -1) {
+      const nextIdx = browseIdx + 1;
+      if (nextIdx < hist.length) {
+        if (browseIdx === -1) savedDraftRef.current = draft;
+        setBrowseIdx(nextIdx);
+        setDraft(hist[hist.length - 1 - nextIdx]);
+      }
+    } else {
+      if (browseIdx > 0) {
+        const nextIdx = browseIdx - 1;
+        setBrowseIdx(nextIdx);
+        setDraft(hist[hist.length - 1 - nextIdx]);
+      } else if (browseIdx === 0) {
+        setBrowseIdx(-1);
+        setDraft(savedDraftRef.current);
+      }
+    }
+  };
+
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     if (popup) {
       if (e.key === "ArrowDown") {
@@ -387,6 +415,20 @@ export function Composer({
         dismiss();
       }
     }
+    if (!popup) {
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        navigateHistory(-1);
+        return;
+      }
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        navigateHistory(1);
+        return;
+      }
+    }
+    // macOS Chinese IME fires compositionend BEFORE the confirm Enter keydown.
+    if (composingRef.current || Date.now() - compositionEndedAtRef.current < 50) return;
     if (e.key === "Enter" && !e.shiftKey && !popup) {
       e.preventDefault();
       if (busy) {
@@ -396,6 +438,9 @@ export function Composer({
           setChips([]);
         }
       } else if (!disabled && draft.trim()) {
+        historyRef.current.push(draft.trim());
+        if (historyRef.current.length > 100) historyRef.current.shift();
+        setBrowseIdx(-1);
         onSend();
         setChips([]);
       }
@@ -489,6 +534,11 @@ export function Composer({
             placeholder={t("composer.placeholder")}
             onChange={handleChange}
             onKeyDown={handleKeyDown}
+            onCompositionStart={() => { composingRef.current = true; }}
+            onCompositionEnd={() => {
+              composingRef.current = false;
+              compositionEndedAtRef.current = Date.now();
+            }}
             rows={DEFAULT_COMPOSER_ROWS}
             disabled={disabled}
           />
@@ -579,6 +629,9 @@ export function Composer({
                 disabled={disabled || !draft.trim()}
                 onClick={() => {
                   if (!disabled && draft.trim()) {
+                    historyRef.current.push(draft.trim());
+                    if (historyRef.current.length > 100) historyRef.current.shift();
+                    setBrowseIdx(-1);
                     onSend();
                     setChips([]);
                   }

--- a/desktop/src/ui/thread.tsx
+++ b/desktop/src/ui/thread.tsx
@@ -37,10 +37,12 @@ export const UserMsg = memo(function UserMsg({
   text,
   time,
   skill,
+  onEdit,
 }: {
   text: string;
   time?: string;
   skill?: SkillOrigin;
+  onEdit?: (text: string) => void;
 }) {
   useLang();
   const [copied, setCopied] = useState(false);
@@ -71,6 +73,16 @@ export const UserMsg = memo(function UserMsg({
         </div>
         <div className="msg-text">{text}</div>
         <div className="msg-actions">
+          {onEdit ? (
+            <button
+              type="button"
+              className="edit-btn"
+              onClick={() => onEdit(text)}
+              title={t("thread.editMessage")}
+            >
+              <I.pencil size={11} />
+            </button>
+          ) : null}
           <button
             type="button"
             className={`copy-btn ${copied ? "done" : ""}`}


### PR DESCRIPTION
## Summary

Desktop UX improvements addressing daily pain points.

## Motivation

Several issues noticed during daily desktop usage:

- No way to edit a sent message — had to retype everything or use /retry (a CLI command, not suitable for the desktop UI)
- Copy button sat below the message, wasting vertical space with an empty line
- Code blocks had no one-click copy button — had to manually select code then press Cmd+C
- No message history navigation — could not recover a previously sent message with arrow keys
- Chinese/Japanese IME users: pressing Enter to confirm a composition candidate accidentally sent the message
- Reasoning cards and completed shell execution cards were expanded by default, taking up unnecessary space
- Homebrew Node 26 on macOS (arm64, ~68 KB) was rejected by the hard-coded 100 KB threshold in find_real_node(), causing a false node not found error

## Changes

| File | Change |
|---|---|
| desktop/src-tauri/src/rpc.rs | Lower Node binary size threshold from 100 KB to 50 KB on macOS/Linux |
| desktop/src/App.tsx | Wire onEdit callback to UserMsg |
| desktop/src/Markdown.tsx | Fix pre renderer text extraction for react-markdown v9; add copy button to CodeBlock |
| desktop/src/styles.css | Overlay copy/edit buttons (bottom-right, hover); code block copy button styles |
| desktop/src/ui/cards.tsx | ReasoningCard defaultOpen=false; ShellCard defaultOpen=state !== done |
| desktop/src/ui/composer.tsx | Message history (up/down arrow, 100-entry cap); IME guard (composingRef + timestamp) |
| desktop/src/ui/thread.tsx | Add pencil edit button to UserMsg |
| desktop/src/i18n/en.ts, zh-CN.ts | Add editMessage locale keys |

## Verification

- npm run verify passes (build, lint, typecheck, 3582 tests)
- Manually tested in Tauri desktop app