### PR TITLE
test(tui): cover legacy mouse-report flood

### DIFF
--- a/tests/stdin-reader.test.ts
+++ b/tests/stdin-reader.test.ts
@@ -444,6 +444,14 @@ describe("StdinReader — SGR mouse reports (issue #867)", () => {
     reader.feed("`*%");
     expect(events).toEqual([]);
   });
+
+  it("drops a legacy X10 mouse-report flood without surfacing prompt input (#1598)", () => {
+    const { reader, events } = setup();
+    for (let i = 0; i < 1000; i++) {
+      reader.feed("\x1b[M`*%");
+    }
+    expect(events).toEqual([]);
+  });
 });
 
 describe("sanitizePasteText (issue #849)", () => {


### PR DESCRIPTION
## Summary
- Adds direct regression coverage for the Windows/PowerShell memory-growth failure mode reported in #1598.
- Exercises a flood of legacy X10 mouse reports and asserts the stdin reader drops them instead of surfacing coordinate bytes as prompt input.

## Relationship to the production fix
The production fix is already merged in #1637, which resets legacy mouse modes and consumes complete `ESC [ M ...` mouse-report packets. This PR intentionally does not add another production change; it only keeps the #1598 failure mode covered by a focused regression test.

Refs #1598

## Validation
- `npm test -- --run tests/stdin-reader.test.ts tests/mouse-mode.test.ts`
- `npx biome check tests/stdin-reader.test.ts tests/mouse-mode.test.ts`
- `npm run verify` via pre-push hook: 261 test files passed; 3593 tests passed; 12 skipped. Biome reported two existing unused-suppression warnings outside this change.
