### PR TITLE
feat(ui): render compacted history as a collapsible card on all three surfaces

### DIFF
--- a/dashboard/src/i18n/en.ts
+++ b/dashboard/src/i18n/en.ts
@@ -1019,6 +1019,8 @@ export const en = {
     output: "Output",
     planDefaultTitle: "Plan",
     prompt: "Prompt",
+    compactionMeta: "{chars} chars",
+    compactionName: "Compacted history",
     reasoningComplete: "Reasoning complete",
     reasoningName: "Reasoning",
     result: "Result",

--- a/dashboard/src/i18n/zh-CN.ts
+++ b/dashboard/src/i18n/zh-CN.ts
@@ -993,6 +993,8 @@ export const zhCN = {
     output: "输出",
     planDefaultTitle: "计划",
     prompt: "提示词",
+    compactionMeta: "{chars} 字符",
+    compactionName: "已压缩历史",
     reasoningComplete: "推理完成",
     reasoningName: "推理",
     result: "结果",

--- a/dashboard/src/ui/cards.tsx
+++ b/dashboard/src/ui/cards.tsx
@@ -304,6 +304,28 @@ export function ShellCard({
   );
 }
 
+// ---- Compaction ----
+
+export function CompactionCard({ summary }: { summary: string }) {
+  useLang();
+  const charCount = summary.length;
+  return (
+    <Card
+      tone="default"
+      icon={<I.archive size={12} />}
+      kind="compaction"
+      name={t("cards.compactionName")}
+      meta={<span>{t("cards.compactionMeta", { chars: charCount.toLocaleString() })}</span>}
+      defaultOpen={false}
+      compact
+    >
+      <div className="compaction-body">
+        <Markdown source={summary} />
+      </div>
+    </Card>
+  );
+}
+
 // ---- Generic Tool ----
 
 export function ToolCard({

--- a/dashboard/src/ui/thread.tsx
+++ b/dashboard/src/ui/thread.tsx
@@ -1,10 +1,11 @@
+import { isCompactionSummary, stripCompactionMarker } from "@reasonix/core-utils/compaction";
 import { derivePrefix } from "@reasonix/core-utils/derive-prefix";
 import { memo, useState, type ReactNode } from "react";
 import { Copy } from "lucide-react";
 import { I } from "../icons";
 import { t, useLang } from "../i18n";
 import type { AssistantSegment, ActivePlan, PendingPlan, PendingCheckpoint, PendingRevision, PendingConfirm, PendingChoice, SkillOrigin } from "../App";
-import { AssistantText, PlanCardView, ReasoningCard, ShellCard, ToolCard, type PlanItem } from "./cards";
+import { AssistantText, CompactionCard, PlanCardView, ReasoningCard, ShellCard, ToolCard, type PlanItem } from "./cards";
 import { ApprovalCard, TaskCard, type TaskStepView } from "./extra-cards";
 
 export function TurnDivider({ label }: { label: string }) {
@@ -112,6 +113,9 @@ export const AssistantMsg = memo(function AssistantMsg({
         {segments.map((s, i) => {
           if (s.kind === "text") {
             if (!s.text.trim()) return null;
+            if (isCompactionSummary(s.text)) {
+              return <CompactionCard key={i} summary={stripCompactionMarker(s.text)} />;
+            }
             return <AssistantText key={i} text={s.text} />;
           }
           if (s.kind === "reasoning") {

--- a/dashboard/tsconfig.json
+++ b/dashboard/tsconfig.json
@@ -22,6 +22,7 @@
       "@tauri-apps/plugin-dialog": ["src/lib/tauri-bridge.ts"],
       "@tauri-apps/plugin-opener": ["src/lib/tauri-bridge.ts"],
       "@tauri-apps/plugin-process": ["src/lib/tauri-bridge.ts"],
+      "@reasonix/core-utils/compaction": ["../packages/core-utils/src/compaction.ts"],
       "@reasonix/core-utils/derive-prefix": ["../packages/core-utils/src/derive-prefix.ts"],
       "@reasonix/core-utils": ["../packages/core-utils/src/index.ts"]
     }

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      "@reasonix/core-utils/compaction": resolve(__dirname, "../packages/core-utils/src/compaction.ts"),
       "@reasonix/core-utils/derive-prefix": resolve(__dirname, "../packages/core-utils/src/derive-prefix.ts"),
       "@reasonix/core-utils": resolve(__dirname, "../packages/core-utils/src/index.ts"),
       "@tauri-apps/api/core": resolve(__dirname, "src/lib/tauri-bridge.ts"),

--- a/desktop/src/i18n/en.ts
+++ b/desktop/src/i18n/en.ts
@@ -486,6 +486,8 @@ export const en = {
   cards: {
     reasoningName: "Thinking",
     reasoningComplete: "Complete",
+    compactionName: "Compacted history",
+    compactionMeta: "{chars} chars",
     shellAwaiting: "Waiting approval",
     shellRunning: "Running",
     shellExecuteHint: "execute this command",

--- a/desktop/src/i18n/zh-CN.ts
+++ b/desktop/src/i18n/zh-CN.ts
@@ -505,6 +505,8 @@ export const zhCN: typeof en = {
   cards: {
     reasoningName: "思考",
     reasoningComplete: "完成",
+    compactionName: "已压缩历史",
+    compactionMeta: "{chars} 字符",
     shellAwaiting: "等待批准",
     shellRunning: "运行中",
     shellExecuteHint: "执行此命令",

--- a/desktop/src/ui/cards.tsx
+++ b/desktop/src/ui/cards.tsx
@@ -304,6 +304,28 @@ export function ShellCard({
   );
 }
 
+// ---- Compaction ----
+
+export function CompactionCard({ summary }: { summary: string }) {
+  useLang();
+  const charCount = summary.length;
+  return (
+    <Card
+      tone="default"
+      icon={<I.archive size={12} />}
+      kind="compaction"
+      name={t("cards.compactionName")}
+      meta={<span>{t("cards.compactionMeta", { chars: charCount.toLocaleString() })}</span>}
+      defaultOpen={false}
+      compact
+    >
+      <div className="compaction-body">
+        <Markdown source={summary} />
+      </div>
+    </Card>
+  );
+}
+
 // ---- Generic Tool ----
 
 export function ToolCard({

--- a/desktop/src/ui/thread.tsx
+++ b/desktop/src/ui/thread.tsx
@@ -1,4 +1,5 @@
 import type { ApprovalPrompt } from "@reasonix/core-utils";
+import { isCompactionSummary, stripCompactionMarker } from "@reasonix/core-utils/compaction";
 import { derivePrefix } from "@reasonix/core-utils/derive-prefix";
 import { Copy } from "lucide-react";
 import { type ReactNode, memo, useState } from "react";
@@ -16,6 +17,7 @@ import { t, useLang } from "../i18n";
 import { I } from "../icons";
 import {
   AssistantText,
+  CompactionCard,
   PlanCardView,
   type PlanItem,
   ReasoningCard,
@@ -131,6 +133,9 @@ export const AssistantMsg = memo(function AssistantMsg({
         {segments.map((s, i) => {
           if (s.kind === "text") {
             if (!s.text.trim()) return null;
+            if (isCompactionSummary(s.text)) {
+              return <CompactionCard key={i} summary={stripCompactionMarker(s.text)} />;
+            }
             return <AssistantText key={i} text={s.text} />;
           }
           if (s.kind === "reasoning") {

--- a/desktop/vite.config.ts
+++ b/desktop/vite.config.ts
@@ -45,6 +45,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      "@reasonix/core-utils/compaction": resolve(__dirname, "../packages/core-utils/src/compaction.ts"),
       "@reasonix/core-utils/derive-prefix": resolve(__dirname, "../packages/core-utils/src/derive-prefix.ts"),
       "@reasonix/core-utils": resolve(__dirname, "../packages/core-utils/src/index.ts"),
     },

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -7,6 +7,7 @@
   "main": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
+    "./compaction": "./src/compaction.ts",
     "./derive-prefix": "./src/derive-prefix.ts",
     "./tildeify": "./src/tildeify.ts",
     "./tool-kind": "./src/tool-kind.ts",

--- a/packages/core-utils/src/compaction.ts
+++ b/packages/core-utils/src/compaction.ts
@@ -1,0 +1,15 @@
+/** Prefix the context-manager prepends when fold replaces older turns with a synthesized recap.
+ *  Single-sourced here so the agent producer (src/context-manager) and the three UI surfaces
+ *  (TUI, Desktop, Dashboard) all agree on the wire string. */
+export const COMPACTION_SUMMARY_MARKER =
+  "[CONVERSATION HISTORY SUMMARY — earlier turns folded for context efficiency]\n\n";
+
+export function isCompactionSummary(text: string | null | undefined): boolean {
+  return typeof text === "string" && text.startsWith(COMPACTION_SUMMARY_MARKER);
+}
+
+export function stripCompactionMarker(text: string): string {
+  return text.startsWith(COMPACTION_SUMMARY_MARKER)
+    ? text.slice(COMPACTION_SUMMARY_MARKER.length)
+    : text;
+}

--- a/packages/core-utils/src/index.ts
+++ b/packages/core-utils/src/index.ts
@@ -1,3 +1,8 @@
+export {
+  COMPACTION_SUMMARY_MARKER,
+  isCompactionSummary,
+  stripCompactionMarker,
+} from "./compaction.js";
 export { derivePrefix } from "./derive-prefix.js";
 export { tildeify } from "./tildeify.js";
 export { toolKindFor } from "./tool-kind.js";

--- a/packages/core-utils/tests/compaction.test.ts
+++ b/packages/core-utils/tests/compaction.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import {
+  COMPACTION_SUMMARY_MARKER,
+  isCompactionSummary,
+  stripCompactionMarker,
+} from "../src/compaction.js";
+
+describe("compaction helpers", () => {
+  it("detects only when the marker is at the start", () => {
+    expect(isCompactionSummary(`${COMPACTION_SUMMARY_MARKER}body`)).toBe(true);
+    expect(isCompactionSummary("ok body")).toBe(false);
+    expect(isCompactionSummary(`prefix ${COMPACTION_SUMMARY_MARKER}body`)).toBe(false);
+    expect(isCompactionSummary("")).toBe(false);
+    expect(isCompactionSummary(null)).toBe(false);
+    expect(isCompactionSummary(undefined)).toBe(false);
+  });
+
+  it("strips the marker only when it is at the start", () => {
+    expect(stripCompactionMarker(`${COMPACTION_SUMMARY_MARKER}body`)).toBe("body");
+    expect(stripCompactionMarker("untouched")).toBe("untouched");
+  });
+});

--- a/src/cli/ui/cards/CardRenderer.tsx
+++ b/src/cli/ui/cards/CardRenderer.tsx
@@ -2,6 +2,7 @@ import { Box, Text } from "ink";
 import React from "react";
 import type { Card } from "../state/cards.js";
 import { FG } from "../theme/tokens.js";
+import { CompactionCard } from "./CompactionCard.js";
 import { CtxCard } from "./CtxCard.js";
 import { DiffCard } from "./DiffCard.js";
 import { DoctorCard } from "./DoctorCard.js";
@@ -65,6 +66,8 @@ function renderCard(card: Card): React.ReactElement {
       return <CtxCard card={card} />;
     case "doctor":
       return <DoctorCard card={card} />;
+    case "compaction":
+      return <CompactionCard card={card} />;
     default:
       return <FallbackCard card={card} />;
   }

--- a/src/cli/ui/cards/CompactionCard.tsx
+++ b/src/cli/ui/cards/CompactionCard.tsx
@@ -1,0 +1,37 @@
+import { Box, Text } from "ink";
+// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
+import React from "react";
+import { Card } from "../primitives/Card.js";
+import { CardHeader } from "../primitives/CardHeader.js";
+import type { CompactionCard as CompactionCardData } from "../state/cards.js";
+import { FG, TONE } from "../theme/tokens.js";
+
+const PREVIEW_LINES = 3;
+
+export function CompactionCard({ card }: { card: CompactionCardData }): React.ReactElement {
+  const lines = card.summary.split("\n");
+  const previewLines = lines.slice(0, PREVIEW_LINES);
+  const hiddenCount = Math.max(0, lines.length - PREVIEW_LINES);
+  return (
+    <Card tone={TONE.info}>
+      <CardHeader
+        glyph="≡"
+        tone={TONE.info}
+        title="compacted history"
+        meta={[`${card.summary.length.toLocaleString()} chars · ${lines.length} lines`]}
+      />
+      {previewLines.map((line, i) => (
+        <Text key={`${card.id}:p:${i}`} color={FG.sub}>
+          {line || " "}
+        </Text>
+      ))}
+      {hiddenCount > 0 ? (
+        <Box marginTop={1}>
+          <Text color={FG.sub} dimColor>
+            … {hiddenCount} more line{hiddenCount === 1 ? "" : "s"} (full summary in session log)
+          </Text>
+        </Box>
+      ) : null}
+    </Card>
+  );
+}

--- a/src/cli/ui/state/cards.ts
+++ b/src/cli/ui/state/cards.ts
@@ -211,6 +211,12 @@ export interface TipCard extends CardBase {
   readonly oneTime: boolean;
 }
 
+export interface CompactionCard extends CardBase {
+  readonly kind: "compaction";
+  /** Synthesized recap body with the marker prefix stripped. */
+  readonly summary: string;
+}
+
 export type Card =
   | UserCard
   | ReasoningCard
@@ -228,7 +234,8 @@ export type Card =
   | LiveCard
   | CtxCard
   | DoctorCard
-  | TipCard;
+  | TipCard
+  | CompactionCard;
 
 export interface DoctorCheckEntry {
   readonly label: string;

--- a/src/cli/ui/state/hydrate.ts
+++ b/src/cli/ui/state/hydrate.ts
@@ -1,3 +1,4 @@
+import { isCompactionSummary, stripCompactionMarker } from "@reasonix/core-utils";
 import type { ChatMessage } from "../../../types.js";
 import { extractToolExitCode } from "../tool-summary.js";
 import type { Card, ToolCard } from "./cards.js";
@@ -34,7 +35,16 @@ export function hydrateCardsFromMessages(messages: ReadonlyArray<ChatMessage>): 
       }
       const text = typeof m.content === "string" ? m.content : "";
       if (text) {
-        cards.push({ kind: "streaming", id: id("streaming"), ts, text, done: true });
+        if (isCompactionSummary(text)) {
+          cards.push({
+            kind: "compaction",
+            id: id("compaction"),
+            ts,
+            summary: stripCompactionMarker(text),
+          });
+        } else {
+          cards.push({ kind: "streaming", id: id("streaming"), ts, text, done: true });
+        }
       }
       if (m.tool_calls?.length) {
         for (const tc of m.tool_calls) {

--- a/src/context-manager.ts
+++ b/src/context-manager.ts
@@ -1,3 +1,4 @@
+import { COMPACTION_SUMMARY_MARKER } from "@reasonix/core-utils";
 import type { DeepSeekClient } from "./client.js";
 import { Usage } from "./client.js";
 import { healLoadedMessages } from "./loop.js";
@@ -40,9 +41,9 @@ export const FORCE_SUMMARY_THRESHOLD = 0.8;
 export const TURN_START_FOLD_THRESHOLD = 0.9;
 /** Hard deadline for semantic fold summaries so a hung request cannot stall the turn loop. */
 export const HISTORY_FOLD_SUMMARY_TIMEOUT_MS = 15_000;
-/** Prepended to fold summary content so the model knows it's a synthesized recap. */
-export const HISTORY_FOLD_MARKER =
-  "[CONVERSATION HISTORY SUMMARY — earlier turns folded for context efficiency]\n\n";
+/** Prepended to fold summary content so the model knows it's a synthesized recap.
+ *  Re-export of the shared constant so existing imports keep resolving. */
+export const HISTORY_FOLD_MARKER = COMPACTION_SUMMARY_MARKER;
 /** Header that precedes preserved skill bodies in a fold's synthesized assistant message. */
 export const SKILL_PIN_MEMO_HEADER = "[Active skill memos — preserved verbatim across the fold:]";
 /** Matches the wrapper emitted by `run_skill` so the fold can lift bodies out before summarizing. */

--- a/tests/hydrate-cards.test.ts
+++ b/tests/hydrate-cards.test.ts
@@ -1,3 +1,4 @@
+import { COMPACTION_SUMMARY_MARKER } from "@reasonix/core-utils";
 import { describe, expect, it } from "vitest";
 import { hydrateCardsFromMessages } from "../src/cli/ui/state/hydrate.js";
 import type { ChatMessage } from "../src/types.js";
@@ -21,6 +22,19 @@ describe("hydrateCardsFromMessages", () => {
     expect(cards.map((c) => c.kind)).toEqual(["user", "streaming"]);
     expect(cards[0]).toMatchObject({ kind: "user", text: "hi" });
     expect(cards[1]).toMatchObject({ kind: "streaming", text: "hello there", done: true });
+  });
+
+  it("turns a fold summary assistant message into a CompactionCard", () => {
+    const msgs: ChatMessage[] = [
+      { role: "assistant", content: `${COMPACTION_SUMMARY_MARKER}earlier turns explored auth.` },
+      { role: "user", content: "continue" },
+    ];
+    const cards = hydrateCardsFromMessages(msgs);
+    expect(cards.map((c) => c.kind)).toEqual(["compaction", "user"]);
+    expect(cards[0]).toMatchObject({
+      kind: "compaction",
+      summary: "earlier turns explored auth.",
+    });
   });
 
   it("emits a ReasoningCard before the StreamingCard when reasoning_content is present", () => {


### PR DESCRIPTION
## Summary

After auto-compaction, the synthesized recap was being stored as a plain assistant message with a `HISTORY_FOLD_MARKER` prefix. None of the three surfaces special-cased it:

- **TUI**: hydrated as a regular `streaming` card on session resume — recap looked like a real reply.
- **Desktop / Dashboard**: rendered inline through `AssistantText` — users couldn't tell compaction had happened, and the recap blended in with normal model output.

This PR closes that gap on all three surfaces.

## What changed

- Single-source the marker + helpers in `@reasonix/core-utils/compaction` (`COMPACTION_SUMMARY_MARKER`, `isCompactionSummary`, `stripCompactionMarker`). Re-export the constant from `src/context-manager.ts` so existing `HISTORY_FOLD_MARKER` imports keep resolving.
- Add a `CompactionCard` to each surface:
  - **TUI** — new `kind: "compaction"` in `state/cards.ts`, renderer in `cards/CompactionCard.tsx`, `hydrate.ts` emits a compaction card instead of a streaming card when the marker is present. Resumed sessions now show the recap distinctly (info tone, preview lines + char/line count meta).
  - **Desktop / Dashboard** — `CompactionCard` component in `ui/cards.tsx`, intercepted in the assistant-segment renderer in `ui/thread.tsx`. Default-collapsed, archive icon, header shows char count, body renders the recap markdown.
- Wire `vite` + `tsconfig` aliases for the new `@reasonix/core-utils/compaction` sub-import path so the browser bundles don't pull in Node-only siblings (`tildeify`) via the barrel.

## Test plan

- [x] `npm run verify` — 262 files / 3595 tests pass (was 261/3593 + 2 new)
- [x] New `packages/core-utils/tests/compaction.test.ts` — marker detection edge cases
- [x] New `tests/hydrate-cards.test.ts` case — fold summary message hydrates as a `CompactionCard`, not a streaming card

## Follow-ups (not in this PR)

- Surface the `warning` event for `loop.foldedHistory` / `loop.turnStartFolded` as a visible row in Desktop / Dashboard (currently only flows through the protocol, no `ChatMessage` reducer). One-line banner would close the "compaction happened invisibly" gap completely.
- Persist the pre-compaction message tail in a sidecar file so the expanded card can offer a "view original turns" jump.