### PR TITLE
feat(dashboard): surface system events as quiet inline dividers

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -98,6 +98,7 @@ export type ChatMessage =
       pending: boolean;
     }
   | { kind: "status"; text: string }
+  | { kind: "warning"; id: string; text: string; severity: "low" | "high" }
   | { kind: "error"; message: string };
 
 export type PendingConfirm = {
@@ -960,6 +961,23 @@ export function applyIncoming(state: State, ev: IncomingEvent): State {
       };
     case "status":
       return state;
+    case "warning":
+      // High-severity only — eventize already drops "low". Render as a quiet
+      // inline divider so users see compaction / abort / rate-limit events
+      // without confusing them for errors.
+      if (ev.severity !== "high") return state;
+      return {
+        ...state,
+        messages: [
+          ...state.messages,
+          {
+            kind: "warning",
+            id: `w-${ev.id}`,
+            text: ev.text,
+            severity: ev.severity,
+          },
+        ],
+      };
     default:
       return state;
   }
@@ -1876,6 +1894,15 @@ function TabRuntime({
                             <div className="tt">{t("app.errorLabel")}</div>
                             <div className="ds">{m.message}</div>
                           </div>
+                        </div>
+                      );
+                    }
+                    if (m.kind === "warning") {
+                      return (
+                        <div key={m.id} className="sys-event-row" title={m.text}>
+                          <span className="line" />
+                          <span className="label">{m.text}</span>
+                          <span className="line" />
                         </div>
                       );
                     }

--- a/dashboard/src/protocol.ts
+++ b/dashboard/src/protocol.ts
@@ -395,6 +395,15 @@ export type StatusEvent = {
   text: string;
 };
 
+export type WarningEvent = {
+  type: "warning";
+  id: number;
+  ts: string;
+  turn: number;
+  text: string;
+  severity: "low" | "high";
+};
+
 export type KernelErrorEvent = {
   type: "error";
   id: number;
@@ -440,6 +449,7 @@ export type IncomingEvent = { tabId?: string } & (
   | ToolIntentEvent
   | ToolResultEvent
   | StatusEvent
+  | WarningEvent
   | KernelErrorEvent
   | RetryResultEvent
   | BtwResultEvent

--- a/dashboard/src/styles.css
+++ b/dashboard/src/styles.css
@@ -1596,6 +1596,31 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
   flex: 1;
 }
 
+/* Quiet inline system event — compaction, abort, rate-limit. Visually weak so
+ * a long session can carry several without crowding the conversation. */
+.sys-event-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 4px 0;
+  color: var(--muted-2);
+  font-size: 11px;
+  font-family: inherit;
+  opacity: 0.7;
+}
+.sys-event-row .line {
+  height: 1px;
+  background: var(--border);
+  flex: 1;
+  opacity: 0.5;
+}
+.sys-event-row .label {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 60ch;
+}
+
 .msg {
   display: flex;
   gap: 14px;

--- a/src/cli/ui/effects/loop-to-dashboard.ts
+++ b/src/cli/ui/effects/loop-to-dashboard.ts
@@ -27,7 +27,7 @@ export function loopEventToDashboard(
         args: ev.toolArgs,
       };
     case "warning":
-      return { kind: "warning", id, text: ev.content };
+      return { kind: "warning", id, text: ev.content, severity: ev.severity };
     case "error":
       return { kind: "error", id, text: ev.content };
     case "status":

--- a/src/core/eventize.ts
+++ b/src/core/eventize.ts
@@ -79,9 +79,11 @@ export class Eventizer {
         out.push(this.toolResultEvent(ev.turn, callId, ok, ev.content, 0));
         break;
       }
-      case "warning":
-        out.push(this.classifyWarning(ev));
+      case "warning": {
+        const classified = this.classifyWarning(ev);
+        if (classified) out.push(classified);
         break;
+      }
       case "error":
         out.push(this.errorEvent(ev.turn, ev.error ?? ev.content, false));
         break;
@@ -337,8 +339,10 @@ export class Eventizer {
     };
   }
 
-  /** Pattern-match warning text since LoopEvent doesn't carry a typed kind. */
-  private classifyWarning(ev: LoopEvent): Event {
+  /** Pattern-match warning text since LoopEvent doesn't carry a typed kind. Returns null
+   *  for low-severity warnings (self-correcting / counter messages); the UI surface drops
+   *  them entirely instead of rendering noise. */
+  private classifyWarning(ev: LoopEvent): Event | null {
     const c = ev.content;
     if (/\bauto-escalating to\b|\barmed\b.*pro|NEEDS_PRO/.test(c)) {
       return {
@@ -362,7 +366,15 @@ export class Eventizer {
         capUsd: 0,
       };
     }
-    return this.errorEvent(ev.turn, c, true);
+    if (ev.severity === "low") return null;
+    return {
+      id: ++this.nextId,
+      ts: new Date().toISOString(),
+      turn: ev.turn,
+      type: "warning",
+      text: c,
+      severity: ev.severity ?? "high",
+    };
   }
 }
 

--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -219,6 +219,15 @@ export interface ErrorEvent extends EventBase {
   recoverable: boolean;
 }
 
+/** Non-fatal system event surfaced to UIs as a quiet inline divider — compaction,
+ *  rate-limit pause, user-aborted iter, storm-stuck interrupt, etc. Carries a
+ *  severity so noisy/self-correcting warnings can be filtered out by the surface. */
+export interface WarningEvent extends EventBase {
+  type: "warning";
+  text: string;
+  severity: "low" | "high";
+}
+
 export type Event =
   | UserMessageEvent
   | SlashInvokedEvent
@@ -249,7 +258,8 @@ export type Event =
   | CapabilityRegisteredEvent
   | CapabilityRemovedEvent
   | StatusEvent
-  | ErrorEvent;
+  | ErrorEvent
+  | WarningEvent;
 
 export type EventOf<T extends Event["type"]> = Extract<Event, { type: T }>;
 

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -902,6 +902,7 @@ export class CacheFirstLoop {
         yield {
           turn: this._turn,
           role: "warning",
+          severity: "low",
           content: t("loop.repeatToolCallWarning"),
         };
         continue;
@@ -915,6 +916,7 @@ export class CacheFirstLoop {
         yield {
           turn: this._turn,
           role: "warning",
+          severity: allSuppressed ? "high" : "low",
           content: `${phrase}${noteTail}`,
         };
       }

--- a/src/loop/types.ts
+++ b/src/loop/types.ts
@@ -17,10 +17,16 @@ export type EventRole =
   /** Mid-turn steer injected as queued user guidance without aborting the current turn. */
   | "steer";
 
+/** "low" = chatty / self-correcting / counter — Desktop+Dashboard filter these out by default.
+ *  Undefined / "high" = real event the user should see (compaction, abort, budget, rate-limit, etc.).
+ *  TUI ignores this and renders every warning. */
+export type EventSeverity = "low" | "high";
+
 export interface LoopEvent {
   turn: number;
   role: EventRole;
   content: string;
+  severity?: EventSeverity;
   reasoningDelta?: string;
   toolName?: string;
   /** Raw args JSON — needed by `reasonix diff` to explain why a tool was called. */

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -235,6 +235,9 @@ export interface DashboardMessage {
   toolArgs?: string;
   /** Optional reasoning content for assistant messages (R1 / V4 thinking). */
   reasoning?: string;
+  /** For `role === "warning"`: "low" = chatty self-correcting / counter (UI suppresses by default),
+   *  "high" / undefined = real event (compaction, abort, rate-limit) to surface inline. */
+  severity?: "low" | "high";
 }
 
 export type DashboardEvent =
@@ -260,7 +263,7 @@ export type DashboardEvent =
     }
   | { kind: "tool_start"; id: string; toolName: string; args?: string }
   | { kind: "tool"; id: string; toolName: string; content: string; args?: string }
-  | { kind: "warning"; id: string; text: string }
+  | { kind: "warning"; id: string; text: string; severity?: "low" | "high" }
   | { kind: "error"; id: string; text: string }
   | { kind: "info"; id: string; text: string }
   | { kind: "user"; id: string; text: string }

--- a/tests/eventize.test.ts
+++ b/tests/eventize.test.ts
@@ -120,6 +120,53 @@ describe("Eventizer.consume", () => {
     expect(out[0]?.type).toBe("policy.escalated");
   });
 
+  it("drops low-severity warnings (chatty self-correcting messages)", () => {
+    const e = new Eventizer();
+    e.consume(lev({ turn: 1 }), ctx);
+    const out = e.consume(
+      lev({
+        turn: 1,
+        role: "warning",
+        severity: "low",
+        content: "Caught a repeated tool call",
+      }),
+      ctx,
+    );
+    expect(out).toEqual([]);
+  });
+
+  it("emits a typed warning event (not error) for high-severity loop warnings", () => {
+    const e = new Eventizer();
+    e.consume(lev({ turn: 1 }), ctx);
+    const out = e.consume(
+      lev({
+        turn: 1,
+        role: "warning",
+        severity: "high",
+        content: "context 76,500/100,000 (76%) — folded 30 messages → 12",
+      }),
+      ctx,
+    );
+    const warn = out.find((ev) => ev.type === "warning") as
+      | { text: string; severity: string }
+      | undefined;
+    expect(warn).toBeDefined();
+    expect(warn?.severity).toBe("high");
+    expect(warn?.text).toContain("folded 30 messages");
+    expect(out.find((ev) => ev.type === "error")).toBeUndefined();
+  });
+
+  it("treats unmarked warnings as high-severity (safer default for new emit sites)", () => {
+    const e = new Eventizer();
+    e.consume(lev({ turn: 1 }), ctx);
+    const out = e.consume(
+      lev({ turn: 1, role: "warning", content: "some new warning without severity" }),
+      ctx,
+    );
+    const warn = out.find((ev) => ev.type === "warning") as { severity: string } | undefined;
+    expect(warn?.severity).toBe("high");
+  });
+
   it("event ids are monotonic across consume calls", () => {
     const e = new Eventizer();
     const a = e.consume(lev({ turn: 1, role: "status", content: "a" }), ctx);


### PR DESCRIPTION
## Summary

Layer 1 follow-up to #1649 (CompactionCard). Before this, **every** loop warning fell through `eventize.classifyWarning`'s default branch and became an `error` event — Dashboard rendered compaction notices and storm-stuck interrupts as alarming **red error cards**. And every chatty warning (per-iter \"repeated tool call\" nudges, storm-suppressed counters) joined the flood.

This PR ships the tiered design we agreed on:
- High-signal warnings → quiet inline divider in the thread (compaction, abort, rate-limit, storm-stuck).
- Low-signal warnings → dropped at the kernel boundary (UI never sees them).
- Existing classified warnings (`policy.escalated`, `policy.budget.*`) keep their dedicated event types.

## Severity tiering

Added `EventSeverity = \"low\" | \"high\"` to `LoopEvent`. Default is **high** so newly-added warning sites are visible by default (safer for future contributions). Only two sites currently tagged `\"low\"`:

| Site | Reason |
|---|---|
| `repeatToolCallWarning` (loop.ts:904) | Fires every iter the model repeats — `stormStuck` handles the real-bad case |
| `stormSuppressed` counter (loop.ts:917 when `!allSuppressed`) | Counter message, no actionable info |

## Event flow

- `Eventizer.classifyWarning` now returns `Event | null`. Low-severity → `null` → dropped from kernel stream entirely. High-severity → typed `WarningEvent` (not the old `errorEvent` masquerade).
- New `WarningEvent` in both `src/core/events.ts` (kernel) and `dashboard/src/protocol.ts` (transport).
- Dashboard SPA adds `warning` kind to `ChatMessage`, reducer case in `applyIncoming` (gates on `severity === \"high\"`), and a `.sys-event-row` render — single dim line at ~0.7 opacity flanked by hairlines. Visually weak so several through a long session don't crowd the conversation.

## Test plan

- [x] `npm run verify` — 262 files / 3598 tests pass (3 new in `tests/eventize.test.ts`)
- [x] New cases cover: low-severity dropped, high-severity emit typed warning (not error), unmarked default to high

## Follow-ups (not in this PR)

- **Desktop bridge equivalent** — Tauri IPC + Tauri-side event types so the desktop window also gets quiet inline dividers (currently it goes through the same eventize path but the renderer + protocol need parallel changes).
- **Settings toggle** \"Show system events in thread\" — for users who want a fully clean conversation, with hidden events still accessible via session log inspection.