### PR TITLE
chore(desktop): #1645 follow-ups + isolate flaky server-dashboard test

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -1404,6 +1404,11 @@ function TabRuntime({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state.retryNonce]);
 
+  const onEditUserMsg = useCallback((t: string) => {
+    setDraft(t);
+    composerRef.current?.focus();
+  }, []);
+
   useEffect(() => {
     if (state.busy || !state.ready || state.queuedSends.length === 0) return;
     const next = state.queuedSends[0];
@@ -1954,7 +1959,7 @@ function TabRuntime({
                       return (
                         <div key={`u-${i}`}>
                           {needsDivider ? <TurnDivider label={dividerLabel} /> : null}
-                          <UserMsg text={m.text} skill={m.skill} onEdit={(t) => { setDraft(t); composerRef.current?.focus(); }} />
+                          <UserMsg text={m.text} skill={m.skill} onEdit={onEditUserMsg} />
                         </div>
                       );
                     }

--- a/desktop/src/ui/composer.tsx
+++ b/desktop/src/ui/composer.tsx
@@ -340,6 +340,13 @@ export function Composer({
     textareaRef.current?.focus();
   };
 
+  const recordSendAndReset = () => {
+    const trimmed = draft.trim();
+    historyRef.current.push(trimmed);
+    if (historyRef.current.length > 100) historyRef.current.shift();
+    setBrowseIdx(-1);
+  };
+
   const navigateHistory = (dir: -1 | 1) => {
     const hist = historyRef.current;
     if (hist.length === 0) return;
@@ -428,7 +435,6 @@ export function Composer({
         return;
       }
     }
-    // macOS Chinese IME fires compositionend BEFORE the confirm Enter keydown.
     if (composingRef.current || Date.now() - compositionEndedAtRef.current < 50) return;
     if (e.key === "Enter" && !e.shiftKey && !popup) {
       e.preventDefault();
@@ -439,9 +445,7 @@ export function Composer({
           setChips([]);
         }
       } else if (!disabled && draft.trim()) {
-        historyRef.current.push(draft.trim());
-        if (historyRef.current.length > 100) historyRef.current.shift();
-        setBrowseIdx(-1);
+        recordSendAndReset();
         onSend();
         setChips([]);
       }
@@ -630,9 +634,7 @@ export function Composer({
                 disabled={disabled || !draft.trim()}
                 onClick={() => {
                   if (!disabled && draft.trim()) {
-                    historyRef.current.push(draft.trim());
-                    if (historyRef.current.length > 100) historyRef.current.shift();
-                    setBrowseIdx(-1);
+                    recordSendAndReset();
                     onSend();
                     setChips([]);
                   }

--- a/tests/server-dashboard.test.ts
+++ b/tests/server-dashboard.test.ts
@@ -755,12 +755,21 @@ describe("dashboard server: v0.13 panels", () => {
   let cfgPath: string;
   let usagePath: string;
   let handle: DashboardServerHandle | null = null;
+  let savedHome: string | undefined;
+  let savedUserProfile: string | undefined;
   const TOKEN = "d".repeat(64);
 
   beforeEach(async () => {
     dir = mkdtempSync(join(tmpdir(), "reasonix-dash-v013-"));
     cfgPath = join(dir, "config.json");
     usagePath = join(dir, "usage.jsonl");
+    // Handlers like /api/health still walk `homedir()/.reasonix/{sessions,memory,semantic}`,
+    // so without redirecting HOME the test reads the dev's real history. On a machine
+    // with ~20k sessions the readdir + per-file statSync chain blows past the 5s default.
+    savedHome = process.env.HOME;
+    savedUserProfile = process.env.USERPROFILE;
+    process.env.HOME = dir;
+    process.env.USERPROFILE = dir;
     handle = await startDashboardServer(
       {
         mode: "attached",
@@ -774,6 +783,12 @@ describe("dashboard server: v0.13 panels", () => {
   afterEach(async () => {
     await handle?.close();
     if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+    // biome-ignore lint/performance/noDelete: env-var "= undefined" stringifies, must really unset
+    if (savedHome === undefined) delete process.env.HOME;
+    else process.env.HOME = savedHome;
+    // biome-ignore lint/performance/noDelete: env-var "= undefined" stringifies, must really unset
+    if (savedUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = savedUserProfile;
   });
 
   it("GET /api/health returns disk + version + jobs shape", async () => {


### PR DESCRIPTION
## What

Two unrelated chores, bundled because hitting the second was the only way to get the first past the local pre-push gate.

### `test(server-dashboard)` — root-cause a flaky test (separate commit)

The \`dashboard server: v0.13 panels\` suite uses \`mkdtempSync\` for \`cfgPath\` + \`usagePath\` but the handlers it exercises (\`/api/health\`, \`listSessions\`) still call \`homedir()\` underneath. On a dev machine with \~20k session jsonl files in \`~/.reasonix/sessions\` the readdir + per-file \`statSync\` walk blows past the 5 s default test timeout, even though the same test finishes in milliseconds on a clean CI box.

Redirect \`HOME\` + \`USERPROFILE\` inside the suite's \`beforeEach\` so the walks land in the already-empty temp dir, restore in \`afterEach\`. **No production-code change** — the handlers' \`homedir()\` coupling is a separate cleanup that deserves its own PR.

Whole file now runs in 1.7 s (78 tests).

### `chore(desktop)` — tidy three small things from #1645 (separate commit)

- **composer**: extract \`recordSendAndReset\` so the history-push + browse-index reset is one helper, not duplicated between the Enter key path and the send-button \`onClick\`.
- **composer**: drop the duplicate IME-quirk comment at the use site; the ref declaration block at the top of the component already documents the macOS Chinese IME ordering quirk.
- **App**: hoist the inline \`onEdit\` arrow into a \`useCallback\` so \`UserMsg\`'s \`memo\` isn't busted by a fresh function identity on every render of the message list.

## How to verify

- \`npm run verify\` passes locally (pre-push gate)
- \`npx vitest run tests/server-dashboard.test.ts\` — 78 tests in 1.7 s

## Checklist

- [x] \`npm run verify\` passes locally
- [x] No \`Co-Authored-By: Claude\` trailer
- [x] Comments follow CONTRIBUTING.md
- [x] No edits to \`CHANGELOG.md\`