### PR TITLE
chore(desktop): extract useAutoCollapse hook, tidy sidebar logic

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -76,6 +76,7 @@ import {
   UserMsg,
 } from "./ui/thread";
 import { WorkdirPop } from "./ui/workdir-pop";
+import { useAutoCollapse } from "./ui/useAutoCollapse";
 import { useAutoScroll } from "./ui/useAutoScroll";
 import { useDisableTextAssist } from "./ui/useDisableTextAssist";
 import { openUrl } from "@tauri-apps/plugin-opener";
@@ -2938,19 +2939,18 @@ export function App() {
   const [customFontFamily, setCustomFontFamily] = useState<string>(() => {
     return localStorage.getItem("reasonix.customFontFamily") ?? "";
   });
-  const [sideCollapsed, setSideCollapsed] = useState(
-    () => localStorage.getItem("reasonix.sideCollapsed") === "1",
-  );
-  const [ctxCollapsed, setCtxCollapsed] = useState(
-    () => localStorage.getItem("reasonix.ctxCollapsed") === "1",
-  );
-  const responsiveStageRef = useRef<ResponsiveStage | null>(null);
-  const autoSideCollapsedRef = useRef(false);
-  const autoCtxCollapsedRef = useRef(false);
-  const suppressSidePersistRef = useRef(false);
-  const suppressCtxPersistRef = useRef(false);
-  const sideCollapsedRef = useRef(sideCollapsed);
-  const ctxCollapsedRef = useRef(ctxCollapsed);
+  const {
+    collapsed: sideCollapsed,
+    toggle: onToggleSide,
+    requireCollapsed: requireSideCollapsed,
+    releaseCollapsed: releaseSideCollapsed,
+  } = useAutoCollapse("reasonix.sideCollapsed");
+  const {
+    collapsed: ctxCollapsed,
+    toggle: onToggleCtx,
+    requireCollapsed: requireCtxCollapsed,
+    releaseCollapsed: releaseCtxCollapsed,
+  } = useAutoCollapse("reasonix.ctxCollapsed");
 
   useEffect(() => {
     document.documentElement.dataset.theme = theme;
@@ -2960,98 +2960,28 @@ export function App() {
   }, [theme, themeStyle]);
 
   useEffect(() => {
-    if (suppressSidePersistRef.current) {
-      suppressSidePersistRef.current = false;
-      return;
-    }
-    localStorage.setItem("reasonix.sideCollapsed", sideCollapsed ? "1" : "0");
-  }, [sideCollapsed]);
-
-  useEffect(() => {
-    sideCollapsedRef.current = sideCollapsed;
-  }, [sideCollapsed]);
-
-  useEffect(() => {
-    if (suppressCtxPersistRef.current) {
-      suppressCtxPersistRef.current = false;
-      return;
-    }
-    localStorage.setItem("reasonix.ctxCollapsed", ctxCollapsed ? "1" : "0");
-  }, [ctxCollapsed]);
-
-  useEffect(() => {
-    ctxCollapsedRef.current = ctxCollapsed;
-  }, [ctxCollapsed]);
-
-  useEffect(() => {
     let raf = 0;
+    let prevStage: ResponsiveStage | null = null;
 
     const sync = () => {
       raf = 0;
       const next = responsiveStage(window.innerWidth);
-      const prev = responsiveStageRef.current;
-
-      if (prev === null) {
-        if (next === RESPONSIVE_STAGE.NARROW) {
-          if (!ctxCollapsedRef.current) {
-            suppressCtxPersistRef.current = true;
-            setCtxCollapsed(true);
-            autoCtxCollapsedRef.current = true;
-          }
-          if (!sideCollapsedRef.current) {
-            suppressSidePersistRef.current = true;
-            setSideCollapsed(true);
-            autoSideCollapsedRef.current = true;
-          }
-        } else if (next === RESPONSIVE_STAGE.COMPACT) {
-          if (!ctxCollapsedRef.current) {
-            suppressCtxPersistRef.current = true;
-            setCtxCollapsed(true);
-            autoCtxCollapsedRef.current = true;
-          }
-        }
-        responsiveStageRef.current = next;
-        return;
-      }
-
-      if (prev === next) return;
+      if (prevStage === next) return;
+      const prev = prevStage;
+      prevStage = next;
 
       if (next === RESPONSIVE_STAGE.WIDE) {
-        if (autoCtxCollapsedRef.current) {
-          suppressCtxPersistRef.current = true;
-          setCtxCollapsed(false);
-          autoCtxCollapsedRef.current = false;
-        }
-        if (autoSideCollapsedRef.current) {
-          suppressSidePersistRef.current = true;
-          setSideCollapsed(false);
-          autoSideCollapsedRef.current = false;
-        }
+        releaseCtxCollapsed();
+        releaseSideCollapsed();
       } else if (next === RESPONSIVE_STAGE.COMPACT) {
-        if (prev === RESPONSIVE_STAGE.WIDE && !ctxCollapsedRef.current) {
-          suppressCtxPersistRef.current = true;
-          setCtxCollapsed(true);
-          autoCtxCollapsedRef.current = true;
-        }
-        if (autoSideCollapsedRef.current) {
-          suppressSidePersistRef.current = true;
-          setSideCollapsed(false);
-          autoSideCollapsedRef.current = false;
-        }
-      } else if (next === RESPONSIVE_STAGE.NARROW) {
-        if (!ctxCollapsedRef.current) {
-          suppressCtxPersistRef.current = true;
-          setCtxCollapsed(true);
-          autoCtxCollapsedRef.current = true;
-        }
-        if (!sideCollapsedRef.current) {
-          suppressSidePersistRef.current = true;
-          setSideCollapsed(true);
-          autoSideCollapsedRef.current = true;
-        }
+        // Only force ctx collapse when entering compact from wider — coming
+        // from narrow, the user may have manually opened ctx and we keep that.
+        if (prev === null || prev === RESPONSIVE_STAGE.WIDE) requireCtxCollapsed();
+        releaseSideCollapsed();
+      } else {
+        requireCtxCollapsed();
+        requireSideCollapsed();
       }
-
-      responsiveStageRef.current = next;
     };
 
     const onResize = () => {
@@ -3065,17 +2995,7 @@ export function App() {
       if (raf) window.cancelAnimationFrame(raf);
       window.removeEventListener("resize", onResize);
     };
-  }, []);
-
-  const onToggleSide = useCallback(() => {
-    autoSideCollapsedRef.current = false;
-    setSideCollapsed((v) => !v);
-  }, []);
-
-  const onToggleCtx = useCallback(() => {
-    autoCtxCollapsedRef.current = false;
-    setCtxCollapsed((v) => !v);
-  }, []);
+  }, [requireCtxCollapsed, releaseCtxCollapsed, requireSideCollapsed, releaseSideCollapsed]);
 
   useEffect(() => {
     // Chromium webview supports `zoom`; scales every px-based size without touching CSS rules.
@@ -3352,16 +3272,16 @@ export function App() {
       } else if (mod && (e.key === "b" || e.key === "B")) {
         if (e.altKey) {
           e.preventDefault();
-          setCtxCollapsed((v) => !v);
+          onToggleCtx();
         } else {
           e.preventDefault();
-          setSideCollapsed((v) => !v);
+          onToggleSide();
         }
       }
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [openTab, closeTab, activeTabId, tabs]);
+  }, [openTab, closeTab, activeTabId, tabs, onToggleCtx, onToggleSide]);
 
   const onSetTheme = useCallback((nextTheme: Theme) => {
     setTheme(nextTheme);

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -248,7 +248,7 @@ html[data-platform="macos"] .app {
   --ctx-width: 0px;
 }
 .app[data-side-collapsed="true"] {
---side-width: 0px;
+  --side-width: 0px;
 }
 .app[data-ctx-collapsed="true"][data-side-collapsed="true"] {
   --thread-max-width: 1120px;

--- a/desktop/src/ui/useAutoCollapse.ts
+++ b/desktop/src/ui/useAutoCollapse.ts
@@ -1,0 +1,45 @@
+import { useCallback, useRef, useState } from "react";
+
+/** A collapsible panel whose state is persisted to localStorage and can be
+ *  driven by either the user (toggle) or the responsive layout
+ *  (requireCollapsed / releaseCollapsed). Only user-driven changes persist —
+ *  auto-collapses survive in memory but never overwrite the stored preference,
+ *  and only auto-collapses get restored when the layout releases them. */
+export function useAutoCollapse(persistKey: string): {
+  collapsed: boolean;
+  toggle: () => void;
+  requireCollapsed: () => void;
+  releaseCollapsed: () => void;
+} {
+  const [collapsed, setCollapsed] = useState(
+    () => localStorage.getItem(persistKey) === "1",
+  );
+  const sourceRef = useRef<"user" | "auto">("user");
+
+  const toggle = useCallback(() => {
+    sourceRef.current = "user";
+    setCollapsed((c) => {
+      const next = !c;
+      localStorage.setItem(persistKey, next ? "1" : "0");
+      return next;
+    });
+  }, [persistKey]);
+
+  const requireCollapsed = useCallback(() => {
+    setCollapsed((c) => {
+      if (c) return c;
+      sourceRef.current = "auto";
+      return true;
+    });
+  }, []);
+
+  const releaseCollapsed = useCallback(() => {
+    setCollapsed((c) => {
+      if (!c || sourceRef.current !== "auto") return c;
+      sourceRef.current = "user";
+      return false;
+    });
+  }, []);
+
+  return { collapsed, toggle, requireCollapsed, releaseCollapsed };
+}


### PR DESCRIPTION
## What

Refactor of #1585's responsive sidebar logic. Same behavior, fewer moving parts.

## Why

The merged version split each panel's "is this collapsed because the user asked, or because the layout forced it" across six refs:

\`\`\`
autoSideCollapsedRef    autoCtxCollapsedRef
suppressSidePersistRef  suppressCtxPersistRef
sideCollapsedRef        ctxCollapsedRef
\`\`\`

Plus a 70-line resize \`useEffect\` that hand-coded all six stage-transition combinations. Hard to scan; easy to break a corner case (e.g. NARROW → COMPACT preserving the user's manual ctx-open) without noticing.

## How

Extracted per-panel collapse into a hook:

\`\`\`ts
const {
  collapsed, toggle,
  requireCollapsed, releaseCollapsed,
} = useAutoCollapse(persistKey);
\`\`\`

- \`toggle\` — user-driven flip; persists to localStorage.
- \`requireCollapsed\` — layout asks for collapsed; **claims as auto only if the panel wasn't already collapsed** so we don't override a manual choice.
- \`releaseCollapsed\` — layout asks for expanded; **restores only if WE collapsed it** (manual collapses stay).

The resize effect drops to one branch per stage:

\`\`\`
WIDE    → release both
COMPACT → require ctx (only when entering from WIDE — coming from NARROW we preserve a user's manual ctx-open); release side
NARROW  → require both
\`\`\`

Also fixed the one-line CSS indent slip on \`.app[data-side-collapsed]\`.

## Behavior matrix (unchanged from #1585)

| from → to | ctx | side |
|---|---|---|
| WIDE → COMPACT | require | — |
| WIDE → NARROW | require | require |
| COMPACT → NARROW | (stays) | require |
| COMPACT → WIDE | release if auto | release if auto |
| NARROW → COMPACT | (stays — user may have manually opened) | release if auto |
| NARROW → WIDE | release if auto | release if auto |

## Diff stats

\`\`\`
desktop/src/App.tsx              | 140 +++++++++++--------------------------------------
desktop/src/styles.css           |   2 +-
desktop/src/ui/useAutoCollapse.ts (new) | 47 +++++++++++
\`\`\`

Net: -33 lines, hook isolated, fewer refs to keep in your head.

## Checklist

- [x] \`npm run verify\` passes locally (pre-push gate)
- [x] No \`Co-Authored-By: Claude\` trailer
- [x] No edits to \`CHANGELOG.md\`