### PR TITLE
chore(cli): drop dead i18n helper + variable from #1617

### DIFF
--- a/src/cli/ui/edit-history.ts
+++ b/src/cli/ui/edit-history.ts
@@ -1,6 +1,5 @@
 import { formatAllBlockDiffs } from "../../code/diff-preview.js";
 import type { ApplyResult, EditBlock, EditSnapshot } from "../../code/edit-blocks.js";
-import { t } from "../../i18n/index.js";
 
 /** Session-only — restoring pre-apply content across restarts is git's job, not ours. */
 export interface EditHistoryEntry {
@@ -30,12 +29,6 @@ export function entryStatus(e: EditHistoryEntry): "applied" | "UNDONE" | "PARTIA
   if (e.undoneFiles.size === 0) return "applied";
   if (isEntryFullyUndone(e)) return "UNDONE";
   return "PARTIAL";
-}
-
-export function entryStatusLabel(status: "applied" | "UNDONE" | "PARTIAL"): string {
-  if (status === "applied") return t("app.editHistoryStatusApplied");
-  if (status === "PARTIAL") return t("app.editHistoryStatusPartial");
-  return t("app.editHistoryStatusUndone");
 }
 
 /** Status prefix is `✓`/`✗` so the line reads without color (piped, screenshots). */

--- a/src/cli/ui/hooks/useCodeMode.ts
+++ b/src/cli/ui/hooks/useCodeMode.ts
@@ -79,7 +79,6 @@ export function useCodeMode(opts: UseCodeModeOptions): UseCodeModeResult {
       if (remaining.length === 0) clearPendingEdits(session ?? null);
       else savePendingEdits(session ?? null, remaining);
       syncPendingCount();
-      const status = t("app.editHistoryStatusApplied");
       const tail =
         remaining.length > 0
           ? `  (${t("app.blocksStillPending", { count: remaining.length })})`


### PR DESCRIPTION
## What

Two tiny cleanups left over from #1617 (edit-approval i18n).

### Dead helper in \`edit-history.ts\`

\`entryStatusLabel(status)\` was added as a wrapper around three i18n keys but **no caller ever imports it**. The actual consumer of those keys, \`useEditHistory.ts:193\`, still resolves them inline — the wrapper sat unused from day one. Dropped, along with the now-unused \`t\` import.

### Dead variable in \`useCodeMode.ts\`

\`\`\`ts
const status = t("app.editHistoryStatusApplied");  // declared, never used
\`\`\`

In the **discard** path, no less — even if it had been used, "applied" would be the wrong semantic. The tail string is fully built from \`discardedCount\` / \`nothingWritten\` already.

## Why not raise it on #1617 instead

Per repo convention for repeat contributors with strong track records, small style nits get a follow-up commit rather than blocking the merge. #1617's substantive change (10 new i18n keys, zh-CN translations, real string extraction) was good as-is.

## Diff stats

\`\`\`
src/cli/ui/edit-history.ts      | 7 -------
src/cli/ui/hooks/useCodeMode.ts | 1 -
2 files changed, 8 deletions(-)
\`\`\`

## Checklist

- [x] \`npm run verify\` passes locally
- [x] No \`Co-Authored-By: Claude\` trailer
- [x] No edits to \`CHANGELOG.md\`