### PR TITLE
fix(config): resolve (baseUrl, apiKey) as a tuple, not two independent fields

### DIFF
--- a/src/cli/commands/acp.ts
+++ b/src/cli/commands/acp.ts
@@ -25,9 +25,10 @@ import { codeSystemPrompt } from "../../code/prompt.js";
 import { buildCodeToolset } from "../../code/setup.js";
 import {
   DEFAULT_MODEL,
+  bridgeEndpointEnv,
   loadApiKey,
-  loadBaseUrl,
   loadEditMode,
+  loadEndpoint,
   loadModel,
   loadReasoningEffort,
   normalizeMcpConfig,
@@ -171,7 +172,8 @@ async function buildSession(opts: {
     hasSemanticSearch: toolset.semantic.enabled,
     modelId: model,
   });
-  const client = new DeepSeekClient({ baseUrl: loadBaseUrl() });
+  const ep = loadEndpoint();
+  const client = new DeepSeekClient({ apiKey: ep.apiKey, baseUrl: ep.baseUrl });
   const prefix = new ImmutablePrefix({ system, toolSpecs: toolset.tools.specs() });
   const loop = new CacheFirstLoop({
     client,
@@ -200,9 +202,7 @@ async function buildSession(opts: {
 
 export async function acpCommand(opts: AcpOptions): Promise<void> {
   loadDotenv();
-  if (loadApiKey()) {
-    process.env.DEEPSEEK_API_KEY = loadApiKey();
-  }
+  bridgeEndpointEnv();
 
   const defaultDir = resolveDir(opts.dir, process.cwd());
   const sessions = new Map<string, Session>();

--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -2,6 +2,7 @@ import { render } from "ink";
 import React, { useMemo, useState } from "react";
 import {
   type ReasoningEffort,
+  bridgeEndpointEnv,
   loadApiKey,
   loadToolRateLimit,
   readConfig,
@@ -166,14 +167,14 @@ function Root({
       <KeystrokeProvider>
         <Setup
           onReady={(k) => {
-            process.env.DEEPSEEK_API_KEY = k;
+            bridgeEndpointEnv();
             setKey(k);
           }}
         />
       </KeystrokeProvider>
     );
   }
-  process.env.DEEPSEEK_API_KEY = key;
+  bridgeEndpointEnv();
 
   if (pickerOpen) {
     return (

--- a/src/cli/commands/code.tsx
+++ b/src/cli/commands/code.tsx
@@ -5,7 +5,7 @@ import { basename, resolve } from "node:path";
 import { buildCodeToolset } from "../../code/setup.js";
 import {
   DEFAULT_MODEL,
-  loadApiKey,
+  bridgeEndpointEnv,
   loadModel,
   normalizeMcpConfig,
   readConfig,
@@ -64,10 +64,7 @@ export async function codeCommand(opts: CodeOptions = {}): Promise<void> {
   // does the same dance — code.tsx wraps chatCommand but must also seed env
   // before buildCodeToolset runs, which is BEFORE chatCommand.
   loadDotenv();
-  const cfgKey = loadApiKey();
-  if (cfgKey && !process.env.DEEPSEEK_API_KEY) {
-    process.env.DEEPSEEK_API_KEY = cfgKey;
-  }
+  bridgeEndpointEnv();
   const { codeSystemPrompt } = await import("../../code/prompt.js");
   const rootDir = resolve(opts.dir ?? process.cwd());
   // Per-directory session so switching projects doesn't mix histories.

--- a/src/cli/commands/commit.ts
+++ b/src/cli/commands/commit.ts
@@ -7,7 +7,7 @@ import { join } from "node:path";
 import { stdin, stdout } from "node:process";
 import { createInterface } from "node:readline/promises";
 import { DeepSeekClient } from "../../client.js";
-import { loadApiKey, loadBaseUrl } from "../../config.js";
+import { loadEndpoint } from "../../config.js";
 import { loadDotenv } from "../../env.js";
 
 export interface CommitOptions {
@@ -241,8 +241,8 @@ export async function commitCommand(opts: CommitOptions = {}): Promise<void> {
   loadDotenv();
   dieIfNotGitRepo();
 
-  const apiKey = loadApiKey() ?? process.env.DEEPSEEK_API_KEY;
-  if (!apiKey) {
+  const ep = loadEndpoint();
+  if (!ep.apiKey) {
     process.stderr.write(
       "reasonix commit: DEEPSEEK_API_KEY not set. Run `reasonix setup` to save one, or export it.\n",
     );
@@ -267,7 +267,7 @@ export async function commitCommand(opts: CommitOptions = {}): Promise<void> {
     );
   }
 
-  const client = new DeepSeekClient({ apiKey, baseUrl: loadBaseUrl() });
+  const client = new DeepSeekClient({ apiKey: ep.apiKey, baseUrl: ep.baseUrl });
   const model = opts.model ?? DEFAULT_MODEL;
   const recentCommits = readRecentCommits();
 

--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -19,13 +19,14 @@ import {
   DEFAULT_MODEL,
   type DesktopOpenTab,
   type EditMode,
+  bridgeEndpointEnv,
   isPlausibleKey,
   isReasoningEffort,
   loadApiKey,
-  loadBaseUrl,
   loadDesktopOpenTabs,
   loadEditMode,
   loadEditor,
+  loadEndpoint,
   loadModel,
   loadQQConfig,
   loadReasoningEffort,
@@ -556,7 +557,7 @@ function buildLoadedMessages(records: ChatMessage[]): LoadedMessage[] {
 }
 
 function emitSettings(tab: Tab): void {
-  const apiKey = loadApiKey();
+  const ep = loadEndpoint();
   const recent = loadRecentWorkspaces().filter((p) => p !== tab.rootDir);
   emit(
     {
@@ -564,8 +565,8 @@ function emitSettings(tab: Tab): void {
       reasoningEffort: loadReasoningEffort(),
       editMode: loadEditMode(),
       budgetUsd: tab.runtime?.loop.budgetUsd ?? null,
-      baseUrl: loadBaseUrl(),
-      apiKeyPrefix: apiKey ? `${apiKey.slice(0, 6)}…${apiKey.slice(-3)}` : undefined,
+      baseUrl: ep.baseUrl,
+      apiKeyPrefix: ep.apiKey ? `${ep.apiKey.slice(0, 6)}…${ep.apiKey.slice(-3)}` : undefined,
       workspaceDir: tab.rootDir,
       recentWorkspaces: recent,
       model: tab.currentModel,
@@ -779,7 +780,8 @@ function mintSessionFor(rootDir: string): string {
 function buildRuntimeFor(tab: Tab): RuntimeState {
   if (!tab.toolset) throw new Error("buildRuntimeFor called before initTabToolset finished");
   const toolset = tab.toolset;
-  const client = new DeepSeekClient({ baseUrl: loadBaseUrl() });
+  const ep = loadEndpoint();
+  const client = new DeepSeekClient({ apiKey: ep.apiKey, baseUrl: ep.baseUrl });
   const prefix = new ImmutablePrefix({ system: tab.system, toolSpecs: toolset.tools.specs() });
   const reasoningEffort = loadReasoningEffort();
   const loop = new CacheFirstLoop({
@@ -1266,7 +1268,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
       modelId: tab.currentModel,
     });
     if (loadApiKey()) {
-      process.env.DEEPSEEK_API_KEY = loadApiKey();
+      bridgeEndpointEnv();
       tab.runtime = buildRuntimeFor(tab);
       void bridgeTabMcp(tab);
     }
@@ -1934,7 +1936,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
       }
       try {
         saveApiKey(key);
-        process.env.DEEPSEEK_API_KEY = key;
+        bridgeEndpointEnv();
         for (const tab of tabs.values()) {
           // Skeleton tabs still mid-bootstrap pick up the new key inside
           // initTabToolset's tail when buildCodeToolset settles — don't

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -6,7 +6,7 @@ import { join, resolve } from "node:path";
 import { DeepSeekClient, pickPrimaryBalance } from "../../client.js";
 import {
   defaultConfigPath,
-  loadBaseUrl,
+  loadEndpoint,
   loadProxyConfig,
   readConfig,
   resolveSemanticEmbeddingConfig,
@@ -217,7 +217,7 @@ async function checkApiReach(): Promise<Check> {
     };
   }
   try {
-    const client = new DeepSeekClient({ apiKey: key, baseUrl: loadBaseUrl() });
+    const client = new DeepSeekClient({ apiKey: key, baseUrl: loadEndpoint().baseUrl });
     const ctl = new AbortController();
     const timer = setTimeout(() => ctl.abort(), 8_000);
     let balance: Awaited<ReturnType<DeepSeekClient["getBalance"]>>;

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -2,10 +2,11 @@ import type { WriteStream } from "node:fs";
 import { stdin, stdout } from "node:process";
 import { createInterface } from "node:readline/promises";
 import {
+  bridgeEndpointEnv,
   defaultConfigPath,
   isPlausibleKey,
   loadApiKey,
-  loadBaseUrl,
+  loadEndpoint,
   loadToolRateLimit,
   normalizeMcpConfig,
   readConfig,
@@ -69,8 +70,8 @@ async function ensureApiKey(): Promise<string> {
 
 export async function runCommand(opts: RunOptions): Promise<void> {
   loadDotenv();
-  const apiKey = await ensureApiKey();
-  process.env.DEEPSEEK_API_KEY = apiKey;
+  await ensureApiKey();
+  bridgeEndpointEnv();
 
   // Optional MCP setup — mirrors chat's flow. Must happen before loop
   // construction so the tools make it into the prefix.
@@ -138,7 +139,8 @@ export async function runCommand(opts: RunOptions): Promise<void> {
     if (successCount === 0) tools = undefined;
   }
 
-  const client = new DeepSeekClient({ baseUrl: loadBaseUrl() });
+  const ep = loadEndpoint();
+  const client = new DeepSeekClient({ apiKey: ep.apiKey, baseUrl: ep.baseUrl });
   const prefix = new ImmutablePrefix({
     system: opts.system,
     toolSpecs: tools?.specs(),

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -33,7 +33,7 @@ import {
   defaultConfigPath,
   editModeHintShown,
   isReasoningEffort,
-  loadBaseUrl,
+  loadEndpoint,
   loadEngineeringLifecycleMode,
   loadReasoningEffort,
   loadTheme,
@@ -955,7 +955,8 @@ function AppInner({
   // biome-ignore lint/correctness/useExhaustiveDependencies: currentRootDir —see comment above
   const loop = useMemo(() => {
     if (loopRef.current) return loopRef.current;
-    const client = new DeepSeekClient({ baseUrl: loadBaseUrl() });
+    const ep = loadEndpoint();
+    const client = new DeepSeekClient({ apiKey: ep.apiKey, baseUrl: ep.baseUrl });
     // Register run_skill HERE (not in code.tsx / chat.tsx) because
     // subagent-runAs skills need the client + parent registry to
     // spawn child loops. Wiring lives in App.tsx so the same code

--- a/src/code/setup.ts
+++ b/src/code/setup.ts
@@ -1,7 +1,7 @@
 import { DeepSeekClient } from "../client.js";
 import {
-  loadBaseUrl,
   loadEditMode,
+  loadEndpoint,
   loadFilesystemOutlineThresholdBytes,
   loadJavaSourceEnabled,
   loadProjectShellAllowed,
@@ -98,7 +98,10 @@ export async function buildCodeToolset(opts: CodeToolsetOpts): Promise<CodeTools
     subagentModels: loadSubagentModels(),
     onSkillInstalled: opts.onSkillInstalled,
     subagentRunner: async (skill, task, signal) => {
-      if (!subagentClient) subagentClient = new DeepSeekClient({ baseUrl: loadBaseUrl() });
+      if (!subagentClient) {
+        const ep = loadEndpoint();
+        subagentClient = new DeepSeekClient({ apiKey: ep.apiKey, baseUrl: ep.baseUrl });
+      }
       const result = await spawnSubagent({
         client: subagentClient,
         parentRegistry: tools,

--- a/src/config.ts
+++ b/src/config.ts
@@ -613,16 +613,37 @@ export function saveLanguage(lang: LanguageCode, path: string = defaultConfigPat
   writeConfig(cfg, path);
 }
 
-/** Resolve the API key from env var first, then the config file. */
-export function loadApiKey(path: string = defaultConfigPath()): string | undefined {
-  if (process.env.DEEPSEEK_API_KEY) return process.env.DEEPSEEK_API_KEY;
-  return readConfig(path).apiKey;
+export interface ResolvedEndpoint {
+  baseUrl: string | undefined;
+  apiKey: string | undefined;
 }
 
-/** env > config > undefined. Client falls back to api.deepseek.com when undefined. */
+// (baseUrl, apiKey) is a tuple: whichever source defines baseUrl owns apiKey too,
+// so a stale env DEEPSEEK_API_KEY doesn't bleed into a custom config baseUrl (#1631).
+export function loadEndpoint(path: string = defaultConfigPath()): ResolvedEndpoint {
+  if (process.env.DEEPSEEK_BASE_URL) {
+    return { baseUrl: process.env.DEEPSEEK_BASE_URL, apiKey: process.env.DEEPSEEK_API_KEY };
+  }
+  const cfg = readConfig(path);
+  if (cfg.baseUrl) {
+    return { baseUrl: cfg.baseUrl, apiKey: cfg.apiKey };
+  }
+  return { baseUrl: undefined, apiKey: process.env.DEEPSEEK_API_KEY ?? cfg.apiKey };
+}
+
+export function loadApiKey(path: string = defaultConfigPath()): string | undefined {
+  return loadEndpoint(path).apiKey;
+}
+
 export function loadBaseUrl(path: string = defaultConfigPath()): string | undefined {
-  if (process.env.DEEPSEEK_BASE_URL) return process.env.DEEPSEEK_BASE_URL;
-  return readConfig(path).baseUrl;
+  return loadEndpoint(path).baseUrl;
+}
+
+// Mirrors the resolved tuple into env so subprocess constructions see the same pair.
+export function bridgeEndpointEnv(path: string = defaultConfigPath()): void {
+  const ep = loadEndpoint(path);
+  if (ep.apiKey) process.env.DEEPSEEK_API_KEY = ep.apiKey;
+  if (ep.baseUrl) process.env.DEEPSEEK_BASE_URL = ep.baseUrl;
 }
 
 function isNonNegativeNumber(value: unknown): value is number {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -14,6 +14,7 @@ import {
   loadBaseUrl,
   loadDesktopOpenTabs,
   loadEditMode,
+  loadEndpoint,
   loadEngineeringLifecycleMode,
   loadFilesystemOutlineThresholdBytes,
   loadIndexConfig,
@@ -169,6 +170,54 @@ describe("config", () => {
     saveBaseUrl("https://self-hosted.example.com", path);
     saveBaseUrl("", path);
     expect(loadBaseUrl(path)).toBeUndefined();
+  });
+
+  it("loadEndpoint: config tuple wins when config sets baseUrl (#1631)", () => {
+    // Bug scenario: user has a global env DEEPSEEK_API_KEY for the default
+    // endpoint, then edits config to use a custom proxy with its own apiKey.
+    // Per-field env-first would pair the stale env key with the custom URL →
+    // auth fails. Tuple semantics keep them paired by source.
+    process.env.DEEPSEEK_API_KEY = "sk-stale-from-shell-rc-abc";
+    saveBaseUrl("https://new-api.example.com/v1", path);
+    saveApiKey("sk-new-api-token-xyz1234", path);
+    const ep = loadEndpoint(path);
+    expect(ep.baseUrl).toBe("https://new-api.example.com/v1");
+    expect(ep.apiKey).toBe("sk-new-api-token-xyz1234");
+  });
+
+  it("loadEndpoint: env tuple wins when env sets baseUrl", () => {
+    process.env.DEEPSEEK_BASE_URL = "https://env-proxy.example.com";
+    process.env.DEEPSEEK_API_KEY = "sk-env-tuple-token-abc";
+    saveBaseUrl("https://config-only.example.com", path);
+    saveApiKey("sk-config-token-xyz1234", path);
+    try {
+      const ep = loadEndpoint(path);
+      expect(ep.baseUrl).toBe("https://env-proxy.example.com");
+      expect(ep.apiKey).toBe("sk-env-tuple-token-abc");
+    } finally {
+      // biome-ignore lint/performance/noDelete: restore exact env state
+      delete process.env.DEEPSEEK_BASE_URL;
+    }
+  });
+
+  it("loadEndpoint: default endpoint pairs env apiKey > config apiKey", () => {
+    // Neither source sets baseUrl → default endpoint. Standard 12-factor
+    // env > config for the apiKey, unchanged from pre-fix behavior.
+    process.env.DEEPSEEK_API_KEY = "sk-env-default-token-abc";
+    saveApiKey("sk-config-token-xyz1234", path);
+    const ep = loadEndpoint(path);
+    expect(ep.baseUrl).toBeUndefined();
+    expect(ep.apiKey).toBe("sk-env-default-token-abc");
+  });
+
+  it("loadEndpoint: config baseUrl with no config apiKey returns undefined apiKey", () => {
+    // Surfaces a clean "no key" error rather than silently using the stale
+    // env key with the wrong endpoint.
+    process.env.DEEPSEEK_API_KEY = "sk-stale-from-shell-rc-abc";
+    saveBaseUrl("https://new-api.example.com/v1", path);
+    const ep = loadEndpoint(path);
+    expect(ep.baseUrl).toBe("https://new-api.example.com/v1");
+    expect(ep.apiKey).toBeUndefined();
   });
 
   it("loads pricingOverride with valid non-negative fields", () => {


### PR DESCRIPTION
## Summary

When a user sets a custom `baseUrl` + `apiKey` in `config.json` (e.g. routing DeepSeek through new-api or another proxy) but also has a stale env `DEEPSEEK_API_KEY` left over from a default-endpoint setup, the resolver pulled `baseUrl` from one source and `apiKey` from the other. The request hit the proxy URL with the wrong token and the API returned auth errors with no obvious cause.

Reported in #1631. Root-caused in #1577 (closed without a fix — same person hit it again).

## Design

12-factor env > config precedence is conventional and worth preserving. The actual bug isn't precedence — it's that `(baseUrl, apiKey)` is a logical tuple but the resolver treated them as independent fields, mixing sources across the pair.

New `loadEndpoint()` resolves the pair atomically:

| Scenario | Tuple source |
|---|---|
| env `DEEPSEEK_BASE_URL` set | env (env apiKey paired) |
| env unset, config has `baseUrl` | config (config apiKey paired) |
| neither sets baseUrl → default endpoint | env apiKey > config apiKey (unchanged) |

Whichever source defines `baseUrl` owns `apiKey` too. The non-obvious branch is "config sets baseUrl" — a stale env key doesn't bleed into a custom endpoint.

## Changes

- `src/config.ts` — new `loadEndpoint()` (tuple resolver), new `bridgeEndpointEnv()` (mirrors resolved tuple into env for subprocess constructions); existing `loadApiKey` / `loadBaseUrl` kept as thin wrappers.
- All 6 `DeepSeekClient` construction sites (`acp.ts`, `commit.ts`, `desktop.ts`, `doctor.ts`, `run.ts`, `App.tsx`, `setup.ts`) now pass both `apiKey` and `baseUrl` explicitly via `loadEndpoint()` so tuple semantics apply regardless of the client constructor's env fallback.
- Scattered `process.env.DEEPSEEK_API_KEY = loadApiKey()` bridges across `chat`/`code`/`run`/`acp`/`desktop` replaced with `bridgeEndpointEnv()` — closes the "only env, never both" gap.

## Test plan

- [x] `npm run verify` — 260 files / 3593 tests pass
- [x] 4 new test cases in `tests/config.test.ts`:
  - **bug scenario**: config tuple wins over stale env apiKey (issue #1631 repro)
  - env-baseUrl-set tuple
  - default-endpoint precedence (unchanged from pre-fix — regression check)
  - config baseUrl + missing config apiKey surfaces a clean "no key" error rather than silent wrong-key auth

Closes #1631