### PR TITLE
chore(loop): drop redundant abort warning, keep only synthetic final

### DIFF
--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -685,8 +685,6 @@ export const EN: TranslationSchema = {
       "session budget exhausted — spent ${spent} ≥ cap ${cap}. Bump the cap with /budget <usd>, clear it with /budget off, or end the session.",
     budget80Pct: "▲ budget 80% used — ${spent} of ${cap}. Next turn or two likely trips the cap.",
     proArmed: "⇧ /pro armed — this turn runs on deepseek-v4-pro (one-shot · disarms after turn)",
-    abortedAtIter:
-      "aborted at iter {iter} — stopped without producing a summary (press ↑ + Enter or /retry to resume)",
     toolUploadStatus: "tool result uploaded · model thinking before next response…",
     turnStartFoldStatus: "turn start: context approaching limit, compacting history…",
     turnStartFolded:

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -288,7 +288,6 @@ export interface TranslationSchema {
     budgetExhausted: string;
     budget80Pct: string;
     proArmed: string;
-    abortedAtIter: string;
     toolUploadStatus: string;
     turnStartFoldStatus: string;
     turnStartFolded: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -660,7 +660,6 @@ export const zhCN: TranslationSchema = {
       "会话预算已用完 — 已花费 ${spent} ≥ 上限 ${cap}。用 /budget <usd> 提高上限，/budget off 清除上限，或结束会话。",
     budget80Pct: "▲ 预算已用 80% — ${spent} / ${cap}。下一两轮可能就触顶。",
     proArmed: "⇧ /pro 已装备 — 本轮使用 deepseek-v4-pro（一次性 · 本轮后自动解除）",
-    abortedAtIter: "在第 {iter} 次工具调用处中断 — 未生成总结即停止（按 ↑ + Enter 或 /retry 恢复）",
     toolUploadStatus: "工具结果已上传 · 模型在生成下一条响应前思考中…",
     turnStartFoldStatus: "回合开始：上下文接近上限，正在压缩历史…",
     turnStartFolded:

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -664,11 +664,6 @@ export class CacheFirstLoop {
         // Without finally the reset is lost and carryAbort locks every
         // future step() at iter 0.
         try {
-          yield {
-            turn: this._turn,
-            role: "warning",
-            content: t("loop.abortedAtIter", { iter }),
-          };
           const stoppedMsg =
             "[aborted by user (Esc) — no summary produced. Ask again or /retry when ready; prior tool output is still in the log.]";
           this.appendAndPersist(buildSyntheticAssistantMessage(stoppedMsg, this.model));

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -339,10 +339,6 @@ describe("CacheFirstLoop (non-streaming)", () => {
       }
     }
 
-    // Warning fires with the abort notice.
-    const warnings = events.filter((e) => e.role === "warning");
-    expect(warnings.some((w) => /aborted at iter/.test(w.content ?? ""))).toBe(true);
-
     // Synthetic assistant_final is tagged forcedSummary and carries
     // the stopped-message text. It should NOT contain any model
     // output because no second API call was made.
@@ -362,9 +358,9 @@ describe("CacheFirstLoop (non-streaming)", () => {
     // Regression: a user pressing Esc once would put _turnAbort into
     // an aborted state; the iter-0 abort branch handled it but didn't
     // reset the controller. Every subsequent step() then carried the
-    // stale aborted state forward and bailed out with another
-    // "stopped without producing a summary" before any model call ran.
-    // The session was effectively dead until restart.
+    // stale aborted state forward and bailed out with the synthetic
+    // stopped-summary before any model call ran. The session was
+    // effectively dead until restart.
     const reg = new ToolRegistry();
     reg.register({
       name: "probe",
@@ -409,10 +405,6 @@ describe("CacheFirstLoop (non-streaming)", () => {
     const finals = turn2Events.filter((e) => e.role === "assistant_final");
     expect(finals).toHaveLength(1);
     expect(finals[0]!.content).toBe("second turn ran cleanly");
-    // No "aborted at iter 0" warning on turn 2.
-    expect(
-      turn2Events.some((e) => e.role === "warning" && /aborted at iter/.test(e.content ?? "")),
-    ).toBe(false);
   });
 
   it("does not bleed when consumer breaks for-await mid-abort-yield", async () => {
@@ -453,9 +445,9 @@ describe("CacheFirstLoop (non-streaming)", () => {
         loop.abort();
         continue;
       }
-      if (aborted && ev.role === "warning") {
-        // Mirror desktop runTurn: drop out of for-await right after the
-        // abort warning, before assistant_final / done are drained.
+      if (aborted && ev.role === "assistant_final" && ev.forcedSummary) {
+        // Mirror desktop runTurn: drop out of for-await mid-abort-drain,
+        // before `done` is yielded — exercises the finally-block reset.
         break;
       }
     }
@@ -468,9 +460,6 @@ describe("CacheFirstLoop (non-streaming)", () => {
     const finals = turn2Events.filter((e) => e.role === "assistant_final");
     expect(finals).toHaveLength(1);
     expect(finals[0]!.content).toBe("second turn ran cleanly");
-    expect(
-      turn2Events.some((e) => e.role === "warning" && /aborted at iter/.test(e.content ?? "")),
-    ).toBe(false);
   });
 
   it("first all-suppressed storm self-corrects in-turn instead of stopping", async () => {


### PR DESCRIPTION
## Summary
- The `aborted at iter N` warning duplicates the synthetic `assistant_final` ("[aborted by user (Esc) — no summary produced. Ask again or /retry when ready…]") that fires right after it; only the `iter` number was unique, and that's debug noise rather than user value.
- Drops the warning yield in `src/loop.ts`, the `loop.abortedAtIter` i18n entry in both `EN.ts` / `zh-CN.ts` / `types.ts`, and the three loop-test assertions that keyed on the warning text.
- Test 3 ("does not bleed when consumer breaks for-await mid-abort-yield") now breaks on the `forcedSummary` `assistant_final` instead of the warning — same generator-`finally` reset is exercised, since `done` still never drains.

## Test plan
- [x] `npx vitest run tests/loop.test.ts` (64 passed / 1 skipped)
- [x] `npx vitest run tests/comment-policy.test.ts`
- [x] `npx tsc --noEmit`
