### PR TITLE
fix(desktop): code block lang detection + overlay header + icon-only copy button

### DIFF
--- a/desktop/src/Markdown.tsx
+++ b/desktop/src/Markdown.tsx
@@ -7,7 +7,6 @@ import {
   createContext,
   isValidElement,
   memo,
-  type ReactElement,
   type ReactNode,
   useContext,
   useState,
@@ -215,16 +214,17 @@ export const Markdown = memo(function Markdown({ source }: { source: string }) {
           pre: ({ children }) => {
             // react-markdown v9 nests children unpredictably — flatten all text.
             const rawText = flattenChildText(children).trimEnd();
-            const kids = Children.toArray(children);
-            const codeEl = kids.find(
-              (c): c is ReactElement =>
-                isValidElement(c) && typeof c.type === "string" && c.type.toLowerCase() === "code",
-            );
-            const lang = codeEl
-              ? /language-([\w-]+)/.exec(
-                  (codeEl.props as Record<string, unknown>).className as string ?? "",
-                )?.[1] ?? "text"
-              : "text";
+            // Extract lang from child element's className prop.
+            let lang = "text";
+            for (const kid of Children.toArray(children)) {
+              if (isValidElement(kid)) {
+                const cls = (kid.props as Record<string, unknown>).className;
+                if (typeof cls === "string") {
+                  const m = cls.match(/language-([\w-]+)/);
+                  if (m) { lang = m[1]!; break; }
+                }
+              }
+            }
             return <CodeBlock lang={lang} text={rawText} />;
           },
           code: ({ className, children }) => {
@@ -330,7 +330,6 @@ function CodeBlock({ lang, text }: { lang: string; text: string }): ReactNode {
         <span className="codeblock-copy-wrap">
           <button type="button" className={`copy-btn ${copied ? "done" : ""}`} onClick={onCopy}>
             {copied ? <Check size={11} /> : <Copy size={11} />}
-            {copied ? t("markdown.copied") : t("markdown.copy")}
           </button>
         </span>
       </div>

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -1929,14 +1929,19 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
   border-radius: 10px;
   background: var(--bg);
   overflow: hidden;
+  position: relative;
 }
 .markdown .codeblock-head {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1;
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 6px 12px;
-  background: var(--panel-2);
-  border-bottom: 1px solid var(--border);
+  padding: 2px 8px;
+  background: transparent;
   font-family: "Geist Mono", monospace;
   font-size: 11px;
   color: var(--muted);
@@ -1953,27 +1958,28 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
 .markdown .codeblock-head .copy-btn {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  padding: 2px 7px;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
   font-family: inherit;
   font-size: 11px;
   color: var(--muted);
-  background: var(--card);
-  border: 1px solid var(--border);
+  background: transparent;
+  border: none;
   border-radius: 4px;
   cursor: pointer;
+  opacity: 0.6;
 }
 .markdown .codeblock-head .copy-btn:hover {
-  color: var(--fg-2);
-  border-color: var(--border-strong);
+  opacity: 1;
+  background: var(--card);
 }
 .markdown .codeblock-head .copy-btn.done {
   color: var(--success);
-  border-color: var(--success-soft);
 }
 .markdown .codeview {
   margin: 0;
-  padding: 14px 16px;
+  padding: 22px 16px 14px;
   font-family: "Geist Mono", monospace;
   font-variant-ligatures: none;
   font-feature-settings: "liga" 0, "calt" 0;


### PR DESCRIPTION
## Summary

Three code block visual fixes: lang detection, header overlay, and icon-only copy button.

## Changes

- **Markdown.tsx** — Fix lang detection: react-markdown v9 wraps the code element in nested children; switch from looking for a `<code>` element by type to reading `className` directly from child element props. This fixes code blocks with language tags showing "text" instead of the actual language. Also removes the "Copy"/"Copied" text label from the copy button (icon only).

- **styles.css** — Make the code block header (`codeblock-head`) an absolute-positioned overlay floating at the top of the code block (transparent background, no border), so lang label and copy button feel like part of the code content. Button becomes a 22px icon-only square with hover opacity.

## Verification

- `npm run verify` passes
- Code blocks with language tags now show the correct lang label
- Copy button shows only the icon