### PR TITLE
feat(desktop): render edit_file/multi_edit results as DiffCard

### DIFF
--- a/desktop/src/ui/cards.tsx
+++ b/desktop/src/ui/cards.tsx
@@ -400,6 +400,70 @@ export type DiffLine =
   | { t: "add"; r: number; s: string }
   | { t: "rm"; l: number; s: string };
 
+export function parseEditResult(text: string): { filename: string; lines: DiffLine[] }[] {
+  const files: { filename: string; lines: DiffLine[] }[] = [];
+  const lines = text.split("\n");
+
+  let currentFilename = "";
+  let currentLines: DiffLine[] = [];
+  let hunkStartLeft = 0;
+  let hunkStartRight = 0;
+  let leftLine = 0;
+  let rightLine = 0;
+
+  const flush = () => {
+    if (currentLines.length > 0) {
+      files.push({ filename: currentFilename, lines: currentLines });
+    }
+    currentLines = [];
+    hunkStartLeft = 0;
+    hunkStartRight = 0;
+    leftLine = 0;
+    rightLine = 0;
+  };
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+
+    if (line.startsWith("edited ") || line.startsWith("multi_edit:")) {
+      const m = line.match(/^edited\s+(.+?)\s+\(/);
+      if (m) currentFilename = m[1]!;
+      continue;
+    }
+
+    if (line.startsWith("# ")) {
+      flush();
+      currentFilename = line.slice(2);
+      continue;
+    }
+
+    const hunkMatch = line.match(/^@@\s+-(\d+),(\d+)\s+\+(\d+),(\d+)\s+@@/);
+    if (hunkMatch) {
+      hunkStartLeft = Number(hunkMatch[1]!);
+      hunkStartRight = Number(hunkMatch[3]!);
+      leftLine = hunkStartLeft;
+      rightLine = hunkStartRight;
+      currentLines.push({ t: "hunk", s: line });
+      continue;
+    }
+
+    if (line.startsWith("+") && !line.startsWith("+++")) {
+      currentLines.push({ t: "add", r: rightLine, s: line.slice(1) });
+      rightLine++;
+    } else if (line.startsWith("-") && !line.startsWith("---")) {
+      currentLines.push({ t: "rm", l: leftLine, s: line.slice(1) });
+      leftLine++;
+    } else if (line.startsWith(" ")) {
+      currentLines.push({ t: "ctx", l: leftLine, r: rightLine, s: line.slice(1) });
+      leftLine++;
+      rightLine++;
+    }
+  }
+
+  flush();
+  return files;
+}
+
 export function DiffCard({
   filename,
   lines,

--- a/desktop/src/ui/thread.tsx
+++ b/desktop/src/ui/thread.tsx
@@ -18,11 +18,13 @@ import { I } from "../icons";
 import {
   AssistantText,
   CompactionCard,
+  DiffCard,
   PlanCardView,
   type PlanItem,
   ReasoningCard,
   ShellCard,
   ToolCard,
+  parseEditResult,
 } from "./cards";
 import { ApprovalCard, TaskCard, type TaskStepView } from "./extra-cards";
 
@@ -190,6 +192,30 @@ export const AssistantMsg = memo(function AssistantMsg({
                       }
                     : undefined
                 }
+              />
+            );
+          }
+          if (s.result && (s.name === "edit_file" || s.name === "multi_edit")) {
+            const files = parseEditResult(s.result);
+            return files.length > 0 ? (
+              <>
+                {files.map((f, fi) => (
+                  <DiffCard
+                    key={`${i}-${fi}`}
+                    filename={f.filename}
+                    lines={f.lines}
+                    applied={s.ok !== false}
+                  />
+                ))}
+              </>
+            ) : (
+              <ToolCard
+                key={i}
+                name={s.name}
+                args={s.args}
+                result={s.result}
+                ok={s.ok}
+                durationMs={s.durationMs}
               />
             );
           }


### PR DESCRIPTION
## Summary

Edit tool results (`edit_file` / `multi_edit`) now display as a unified diff card instead of raw text, making file changes visually scannable.

## Changes

- **cards.tsx** — Added `parseEditResult()` function that parses the tool output format (unified diff with optional `# filename` markers for multi-file edits) into `DiffLine[]`, and extracts filenames. Supports single-file (`edited foo.ts`) and multi-file (`multi_edit: applied N edits across M files`) formats.

- **thread.tsx** — In `AssistantMsg`, when a tool segment is `edit_file` or `multi_edit` and has a result, render `DiffCard(s)` instead of the generic `ToolCard`. Falls back to `ToolCard` if parsing yields no diff lines.

## Verification

- `npm run verify` passes