### PR TITLE
fix(model): self-heal stale model id on load; drop v3 ids from picker fallbacks

### DIFF
--- a/dashboard/src/ui/composer.tsx
+++ b/dashboard/src/ui/composer.tsx
@@ -703,12 +703,7 @@ function Popup({
   );
 }
 
-const KNOWN_MODELS: readonly string[] = [
-  "deepseek-v4-flash",
-  "deepseek-v4-pro",
-  "deepseek-chat",
-  "deepseek-reasoner",
-];
+const KNOWN_MODELS: readonly string[] = ["deepseek-v4-flash", "deepseek-v4-pro"];
 
 function ModelEffortMenu({
   modelLabel,

--- a/dashboard/src/ui/settings.tsx
+++ b/dashboard/src/ui/settings.tsx
@@ -744,12 +744,7 @@ function ApiKeySection({
   );
 }
 
-const KNOWN_MODELS = [
-  "deepseek-v4-flash",
-  "deepseek-v4-pro",
-  "deepseek-chat",
-  "deepseek-reasoner",
-] as const;
+const KNOWN_MODELS = ["deepseek-v4-flash", "deepseek-v4-pro"] as const;
 
 const EFFORT_VALUES = ["low", "medium", "high", "max"] as const;
 type EffortValue = (typeof EFFORT_VALUES)[number];

--- a/desktop/src/ui/composer.tsx
+++ b/desktop/src/ui/composer.tsx
@@ -770,12 +770,7 @@ function Popup({
   );
 }
 
-const KNOWN_MODELS: readonly string[] = [
-  "deepseek-v4-flash",
-  "deepseek-v4-pro",
-  "deepseek-chat",
-  "deepseek-reasoner",
-];
+const KNOWN_MODELS: readonly string[] = ["deepseek-v4-flash", "deepseek-v4-pro"];
 
 function ModelEffortMenu({
   modelLabel,

--- a/desktop/src/ui/settings.tsx
+++ b/desktop/src/ui/settings.tsx
@@ -793,12 +793,7 @@ function ApiKeySection({
   );
 }
 
-const KNOWN_MODELS = [
-  "deepseek-v4-flash",
-  "deepseek-v4-pro",
-  "deepseek-chat",
-  "deepseek-reasoner",
-] as const;
+const KNOWN_MODELS = ["deepseek-v4-flash", "deepseek-v4-pro"] as const;
 
 const EFFORT_VALUES = ["low", "medium", "high", "max"] as const;
 type EffortValue = (typeof EFFORT_VALUES)[number];

--- a/src/cli/ui/ModelPicker.tsx
+++ b/src/cli/ui/ModelPicker.tsx
@@ -190,9 +190,4 @@ function ModelRow({
   );
 }
 
-const FALLBACK_MODELS: ReadonlyArray<string> = [
-  "deepseek-v4-flash",
-  "deepseek-v4-pro",
-  "deepseek-chat",
-  "deepseek-reasoner",
-];
+const FALLBACK_MODELS: ReadonlyArray<string> = ["deepseek-v4-flash", "deepseek-v4-pro"];

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,6 +25,13 @@ export type EditMode = "review" | "auto" | "yolo";
 
 export const DEFAULT_MODEL = "deepseek-v4-flash";
 
+/** Models the official api.deepseek.com endpoint currently accepts. v3-era
+ *  `deepseek-chat`/`deepseek-reasoner` are gone — sending them produces a 400. */
+export const SUPPORTED_OFFICIAL_MODELS: readonly string[] = [
+  "deepseek-v4-flash",
+  "deepseek-v4-pro",
+];
+
 export type ReasoningEffort = "low" | "medium" | "high" | "max";
 
 export const REASONING_EFFORT_VALUES: readonly ReasoningEffort[] = ["low", "medium", "high", "max"];
@@ -1143,8 +1150,14 @@ export function saveReasoningEffort(
 }
 
 export function loadModel(path: string = defaultConfigPath()): string {
-  const v = readConfig(path).model;
-  return typeof v === "string" && v.trim() ? v.trim() : DEFAULT_MODEL;
+  const cfg = readConfig(path);
+  const raw = cfg.model;
+  const trimmed = typeof raw === "string" ? raw.trim() : "";
+  if (!trimmed) return DEFAULT_MODEL;
+  // Custom-endpoint owners pick their own model namespace; trust them.
+  const customEndpoint = cfg.baseUrl?.trim() || process.env.DEEPSEEK_BASE_URL;
+  if (customEndpoint) return trimmed;
+  return SUPPORTED_OFFICIAL_MODELS.includes(trimmed) ? trimmed : DEFAULT_MODEL;
 }
 
 export function saveModel(model: string, path: string = defaultConfigPath()): void {

--- a/src/qq/use-qq-channel.ts
+++ b/src/qq/use-qq-channel.ts
@@ -779,12 +779,7 @@ export function useQQChannel({
       "pro",
       ...((models && models.length > 0
         ? models
-        : [
-            "deepseek-v4-flash",
-            "deepseek-v4-pro",
-            "deepseek-chat",
-            "deepseek-reasoner",
-          ]) as string[]),
+        : ["deepseek-v4-flash", "deepseek-v4-pro"]) as string[]),
     ],
     [],
   );

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -19,6 +19,7 @@ import {
   loadFilesystemOutlineThresholdBytes,
   loadIndexConfig,
   loadIndexUserConfig,
+  loadModel,
   loadMouseWheelRows,
   loadPricingOverride,
   loadProjectPathAllowed,
@@ -183,6 +184,27 @@ describe("config", () => {
     const ep = loadEndpoint(path);
     expect(ep.baseUrl).toBe("https://new-api.example.com/v1");
     expect(ep.apiKey).toBe("sk-new-api-token-xyz1234");
+  });
+
+  it("loadModel falls back to default when persisted id is unsupported on the official endpoint", () => {
+    // Regression: v3-era `deepseek-chat`/`deepseek-reasoner` lingering in
+    // config — or any other unsupported id — would be sent verbatim and
+    // make the first chat request 400 with "supported API model names are
+    // deepseek-v4-pro or deepseek-v4-flash, but you passed …".
+    writeConfig({ model: "deepseek-chat" }, path);
+    expect(loadModel(path)).toBe("deepseek-v4-flash");
+    writeConfig({ model: "deepseek-made-up" }, path);
+    expect(loadModel(path)).toBe("deepseek-v4-flash");
+  });
+
+  it("loadModel passes through any persisted id when a custom baseUrl is set", () => {
+    writeConfig({ model: "my-self-hosted-7b", baseUrl: "https://self.example.com" }, path);
+    expect(loadModel(path)).toBe("my-self-hosted-7b");
+  });
+
+  it("loadModel keeps a supported v4 id on the official endpoint", () => {
+    writeConfig({ model: "deepseek-v4-pro" }, path);
+    expect(loadModel(path)).toBe("deepseek-v4-pro");
   });
 
   it("loadEndpoint: env tuple wins when env sets baseUrl", () => {


### PR DESCRIPTION
## Summary
- **Bug**: a stale `deepseek-chat` / `deepseek-reasoner` (or any other id no longer accepted by `api.deepseek.com`) persisted in `~/.reasonix/config.json` bricked the next launch with `Bad request (DeepSeek 400): The supported API model names are deepseek-v4-pro or deepseek-v4-flash, but you passed …`. The 400 string itself is server-side; we just wrap it via `loop.badrequest400`. The bug was that `loadModel()` returned the persisted value verbatim with no validation, and the picker/settings fallback lists (used when the live catalog fetch fails) still surfaced the v3 ids as selectable so users could land on a dead id without ever hand-editing config.
- **Fix**: `loadModel()` now keeps the persisted id only when (a) the user has a custom `baseUrl` set — custom-endpoint owners pick their own model namespace, so we trust them — or (b) the id is in the new `SUPPORTED_OFFICIAL_MODELS` allowlist (`deepseek-v4-pro`, `deepseek-v4-flash`). Otherwise it returns `DEFAULT_MODEL`, and the next `/model` or picker write replaces the stale config value. Read-only — we don't rewrite config on load, so tests / read paths are side-effect-free.
- **Cleanup**: drops the v3 ids from all six picker / settings fallback lists (CLI ModelPicker, QQ channel, desktop composer + settings, dashboard composer + settings). Inert metadata in `src/telemetry/stats.ts` and `src/loop/thinking.ts` is left alone — never user-facing.

## Test plan
- [x] `npx vitest run tests/config.test.ts tests/loop.test.ts tests/slash.test.ts tests/ui-model-picker.test.tsx` — 290 passed / 2 skipped
- [x] `npx tsc --noEmit`
- [x] New `loadModel` cases: stale id → DEFAULT, custom baseUrl → pass-through, supported id → kept
