### PR TITLE
fix(ui): optimize prompt input styling with theme simplification and history indicator

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -802,6 +802,7 @@ function AppInner({
     pushHistory,
     resetCursor,
     history: promptHistory,
+    isHistoryMode,
   } = useInputRecall(setInput);
   const { setRawMode, isRawModeSupported } = useStdin();
   // Ctrl+X —hand the composer buffer to $EDITOR. Raw-mode flip lets the
@@ -4672,6 +4673,7 @@ function AppInner({
                   onHistoryNext={handleHistoryNext}
                   onOpenExternalEditor={handleOpenExternalEditor}
                   onCursorChange={setComposerCursor}
+                  isHistoryMode={isHistoryMode}
                   slashMatches={slashMatches}
                   slashSelected={slashSelected}
                   slashGroupMode={slashGroupMode}

--- a/src/cli/ui/ComposerArea.tsx
+++ b/src/cli/ui/ComposerArea.tsx
@@ -51,6 +51,7 @@ export interface ComposerAreaProps {
   onHistoryNext: () => void;
   onOpenExternalEditor: () => void;
   onCursorChange: (cursor: number) => void;
+  isHistoryMode?: boolean;
 
   // ── slash / @-mention / arg picker — derived from sub-component props
   slashMatches: SlashSuggestionsProps["matches"] | null;
@@ -94,6 +95,7 @@ export const ComposerArea: React.FC<ComposerAreaProps> = React.memo(
     onHistoryNext,
     onOpenExternalEditor,
     onCursorChange,
+    isHistoryMode,
     slashMatches,
     slashSelected,
     slashGroupMode,
@@ -143,6 +145,7 @@ export const ComposerArea: React.FC<ComposerAreaProps> = React.memo(
           rowsAfter={1 + (activeLoop ? 1 : 0) + (jobs ? 1 : 0)}
           mode={mode}
           model={model}
+          isHistoryMode={isHistoryMode}
         />
         {activeLoop ? <LoopStatusRow loop={activeLoop} /> : null}
         <StatusRow statusBar={statusBar} />

--- a/src/cli/ui/PromptInput.tsx
+++ b/src/cli/ui/PromptInput.tsx
@@ -56,6 +56,8 @@ export interface PromptInputProps {
   mode?: string;
   /** Current model for bottom status display. */
   model?: string;
+  /** True when viewing a historical input. */
+  isHistoryMode?: boolean;
 }
 
 export function PromptInput({
@@ -72,6 +74,7 @@ export function PromptInput({
   rowsAfter = 0,
   mode,
   model,
+  isHistoryMode,
 }: PromptInputProps) {
   const [cursor, setCursor] = useState(value.length);
 
@@ -334,8 +337,9 @@ export function PromptInput({
           </Box>
         ) : null}
         <Box height={1} />
-        {mode || model ? (
+        {mode || model || isHistoryMode ? (
           <Box>
+            {isHistoryMode ? <Text color={TONE.accent}>{"  ↑ history"}</Text> : null}
             <Text color={TONE.brand}>{mode || ""}</Text>
             {mode && model ? <Text color={FG.faint}>{" · "}</Text> : null}
             {model ? <Text color={FG.faint}>{model}</Text> : null}
@@ -692,7 +696,11 @@ function charCellsForText(ch: string): number {
 
 function renderSegment(seg: Segment, key: number, _inverse: boolean): React.ReactNode {
   if (seg.kind === "text") {
-    return <Text key={`s-${key}`}>{seg.text}</Text>;
+    return (
+      <Text key={`s-${key}`} color={FG.body}>
+        {seg.text}
+      </Text>
+    );
   }
   return (
     <Text key={`s-${key}`} backgroundColor={SURFACE.bgElev} color={FG.body}>

--- a/src/cli/ui/hooks/useInputRecall.ts
+++ b/src/cli/ui/hooks/useInputRecall.ts
@@ -8,6 +8,8 @@ export interface UseInputRecallResult {
   resetCursor: () => void;
   /** Newest-last snapshot. */
   history: readonly string[];
+  /** True when viewing a historical input (cursor > -1). */
+  isHistoryMode: boolean;
 }
 
 const HISTORY_MAX = 100;
@@ -15,11 +17,13 @@ const HISTORY_MAX = 100;
 export function useInputRecall(setInput: (s: string) => void): UseInputRecallResult {
   const [history, setHistory] = useState<readonly string[]>([]);
   const historyCursor = useRef<number>(-1);
+  const [isHistoryMode, setIsHistoryMode] = useState(false);
 
   const recallPrev = useCallback(() => {
     if (history.length === 0) return;
     const nextCursor = Math.min(historyCursor.current + 1, history.length - 1);
     historyCursor.current = nextCursor;
+    setIsHistoryMode(nextCursor >= 0);
     setInput(history[history.length - 1 - nextCursor] ?? "");
   }, [setInput, history]);
 
@@ -27,6 +31,7 @@ export function useInputRecall(setInput: (s: string) => void): UseInputRecallRes
     if (historyCursor.current < 0) return;
     const nextCursor = historyCursor.current - 1;
     historyCursor.current = nextCursor;
+    setIsHistoryMode(nextCursor >= 0);
     setInput(nextCursor < 0 ? "" : (history[history.length - 1 - nextCursor] ?? ""));
   }, [setInput, history]);
 
@@ -40,7 +45,8 @@ export function useInputRecall(setInput: (s: string) => void): UseInputRecallRes
 
   const resetCursor = useCallback(() => {
     historyCursor.current = -1;
+    setIsHistoryMode(false);
   }, []);
 
-  return { recallPrev, recallNext, pushHistory, resetCursor, history };
+  return { recallPrev, recallNext, pushHistory, resetCursor, history, isHistoryMode };
 }

--- a/src/cli/ui/theme/tokens.ts
+++ b/src/cli/ui/theme/tokens.ts
@@ -1,11 +1,4 @@
-export type ThemeName =
-  | "default"
-  | "dark"
-  | "light"
-  | "tokyo-night"
-  | "github-dark"
-  | "github-light"
-  | "high-contrast";
+export type ThemeName = "dark" | "light" | "midnight" | "deep-blue" | "high-contrast";
 
 export interface ThemeTokens {
   fg: {
@@ -81,40 +74,6 @@ function defineTheme(base: ThemeBase): ThemeTokens {
   return { ...base, card: card(base.fg, base.tone) };
 }
 
-const githubDark = defineTheme({
-  fg: {
-    strong: "#e6edf3",
-    body: "#c9d1d9",
-    sub: "#8b949e",
-    meta: "#6e7681",
-    faint: "#484f58",
-  },
-  tone: {
-    brand: "#79c0ff",
-    accent: "#d2a8ff",
-    violet: "#b395f5",
-    ok: "#7ee787",
-    warn: "#f0b07d",
-    err: "#ff8b81",
-    info: "#79c0ff",
-  },
-  toneActive: {
-    brand: "#a5d6ff",
-    accent: "#e2c5ff",
-    violet: "#c8aaff",
-    ok: "#a8f5ad",
-    warn: "#ffc99e",
-    err: "#ffaba3",
-    info: "#a5d6ff",
-  },
-  surface: {
-    bg: "#0a0c10",
-    bgInput: "#0d1015",
-    bgCode: "#06080c",
-    bgElev: "#11141a",
-  },
-});
-
 const dark = defineTheme({
   fg: {
     strong: "#f4f7fb",
@@ -143,7 +102,7 @@ const dark = defineTheme({
   },
   surface: {
     bg: "#0b1020",
-    bgInput: "#111827",
+    bgInput: "#0f172a",
     bgCode: "#080c16",
     bgElev: "#151d2f",
   },
@@ -177,13 +136,13 @@ const light = defineTheme({
   },
   surface: {
     bg: "#ffffff",
-    bgInput: "#f8fafc",
+    bgInput: "#f1f5f9",
     bgCode: "#f3f4f6",
     bgElev: "#eef2f7",
   },
 });
 
-const tokyoNight = defineTheme({
+const midnight = defineTheme({
   fg: {
     strong: "#c0caf5",
     body: "#a9b1d6",
@@ -217,37 +176,37 @@ const tokyoNight = defineTheme({
   },
 });
 
-const githubLight = defineTheme({
+const deepBlue = defineTheme({
   fg: {
-    strong: "#1f2328",
-    body: "#24292f",
-    sub: "#57606a",
-    meta: "#6e7781",
-    faint: "#8c959f",
+    strong: "#ffffff",
+    body: "#e0e0e0",
+    sub: "#b0b0b0",
+    meta: "#808080",
+    faint: "#606060",
   },
   tone: {
-    brand: "#0969da",
-    accent: "#8250df",
-    violet: "#6639ba",
-    ok: "#1a7f37",
-    warn: "#9a6700",
-    err: "#cf222e",
-    info: "#0969da",
+    brand: "#0153e5",
+    accent: "#4d94ff",
+    violet: "#7b68ee",
+    ok: "#4caf50",
+    warn: "#ff9800",
+    err: "#f44336",
+    info: "#2196f3",
   },
   toneActive: {
-    brand: "#0550ae",
-    accent: "#6639ba",
-    violet: "#512a97",
-    ok: "#116329",
-    warn: "#7d4e00",
-    err: "#a40e26",
-    info: "#0550ae",
+    brand: "#4d94ff",
+    accent: "#80b3ff",
+    violet: "#9b8bff",
+    ok: "#66bb6a",
+    warn: "#ffb74d",
+    err: "#ef5350",
+    info: "#42a5f5",
   },
   surface: {
-    bg: "#ffffff",
-    bgInput: "#f6f8fa",
-    bgCode: "#f6f8fa",
-    bgElev: "#eaeef2",
+    bg: "#0a0a0a",
+    bgInput: "#1e1e1e",
+    bgCode: "#141414",
+    bgElev: "#252525",
   },
 });
 
@@ -286,16 +245,14 @@ const highContrast = defineTheme({
 });
 
 export const THEMES = {
-  default: githubDark,
   dark,
   light,
-  "tokyo-night": tokyoNight,
-  "github-dark": githubDark,
-  "github-light": githubLight,
+  midnight,
+  "deep-blue": deepBlue,
   "high-contrast": highContrast,
 } as const satisfies Record<ThemeName, ThemeTokens>;
 
-export const DEFAULT_THEME_NAME: ThemeName = "default";
+export const DEFAULT_THEME_NAME: ThemeName = "dark";
 
 export function isThemeName(value: string): value is ThemeName {
   return Object.prototype.hasOwnProperty.call(THEMES, value);
@@ -303,6 +260,10 @@ export function isThemeName(value: string): value is ThemeName {
 
 export function resolveThemeName(value?: string | null): ThemeName {
   if (!value || value === "auto") return DEFAULT_THEME_NAME;
+  // Handle old theme names
+  if (value === "default" || value === "github-dark") return "dark";
+  if (value === "github-light") return "light";
+  if (value === "tokyo-night") return "midnight";
   return isThemeName(value) ? value : DEFAULT_THEME_NAME;
 }
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -554,9 +554,9 @@ describe("config", () => {
   });
 
   it("saveTheme + loadTheme round-trip a registered theme", () => {
-    saveTheme("tokyo-night", path);
-    expect(loadTheme(path)).toBe("tokyo-night");
-    expect(readConfig(path).theme).toBe("tokyo-night");
+    saveTheme("midnight", path);
+    expect(loadTheme(path)).toBe("midnight");
+    expect(readConfig(path).theme).toBe("midnight");
   });
 
   it("saveTheme + loadTheme round-trip auto", () => {
@@ -575,17 +575,17 @@ describe("config", () => {
   });
 
   it("resolveThemePreference lets env override auto but not registered config themes", () => {
-    expect(resolveThemePreference("auto", "github-light")).toBe("github-light");
-    expect(resolveThemePreference(undefined, "tokyo-night")).toBe("tokyo-night");
-    expect(resolveThemePreference("github-dark", "github-light")).toBe("github-dark");
-    expect(resolveThemePreference("auto", "unknown")).toBe("default");
+    expect(resolveThemePreference("auto", "light")).toBe("light");
+    expect(resolveThemePreference(undefined, "midnight")).toBe("midnight");
+    expect(resolveThemePreference("dark", "light")).toBe("dark");
+    expect(resolveThemePreference("auto", "unknown")).toBe("dark");
   });
 
   it("saveTheme doesn't clobber other persisted fields", () => {
     saveEditMode("auto", path);
-    saveTheme("github-light", path);
+    saveTheme("light", path);
     expect(loadEditMode(path)).toBe("auto");
-    expect(loadTheme(path)).toBe("github-light");
+    expect(loadTheme(path)).toBe("light");
   });
 
   it("editModeHintShown defaults to false and toggles on markEditModeHintShown", () => {

--- a/tests/feedback.test.ts
+++ b/tests/feedback.test.ts
@@ -17,7 +17,7 @@ const FIXTURE = {
   rows: 40,
   nodeVersion: "v22.10.0",
   locale: "zh-CN",
-  theme: "tokyo-night",
+  theme: "midnight",
   model: "deepseek-v4-flash",
   reasoningEffort: "high",
   editMode: "auto",
@@ -37,7 +37,7 @@ describe("buildFeedbackDiagnostic", () => {
     expect(out).toContain("**Size**: 142×40");
     expect(out).toContain("**Node**: v22.10.0");
     expect(out).toContain("**Locale**: zh-CN");
-    expect(out).toContain("**Theme**: tokyo-night");
+    expect(out).toContain("**Theme**: midnight");
     expect(out).toContain("**Model**: deepseek-v4-flash · effort=high");
     expect(out).toContain("**Mode**: edit=auto · plan=off");
     expect(out).toContain("**MCP**: 3 server(s)");

--- a/tests/slash.test.ts
+++ b/tests/slash.test.ts
@@ -1469,15 +1469,15 @@ describe("handleSlash", () => {
     });
 
     it("persists a registered theme", () => {
-      const r = handleSlash("theme", ["tokyo-night"], makeLoop());
-      expect(r.info).toMatch(/theme saved: tokyo-night/);
+      const r = handleSlash("theme", ["midnight"], makeLoop());
+      expect(r.info).toMatch(/theme saved: midnight/);
       expect(r.openThemePicker).toBeUndefined();
-      expect(loadTheme()).toBe("tokyo-night");
+      expect(loadTheme()).toBe("midnight");
     });
 
     it("persists auto so env can resolve the active theme", () => {
       const r = handleSlash("theme", ["auto"], makeLoop());
-      expect(r.info).toMatch(/active on next launch: github-dark/);
+      expect(r.info).toMatch(/active on next launch: dark/);
       expect(loadTheme()).toBe("auto");
     });
 

--- a/tests/theme-tokens.test.ts
+++ b/tests/theme-tokens.test.ts
@@ -18,15 +18,7 @@ describe("theme tokens", () => {
   });
 
   it("lists all registered themes", () => {
-    expect(listThemeNames()).toEqual([
-      "default",
-      "dark",
-      "light",
-      "tokyo-night",
-      "github-dark",
-      "github-light",
-      "high-contrast",
-    ]);
+    expect(listThemeNames()).toEqual(["dark", "light", "midnight", "deep-blue", "high-contrast"]);
   });
 
   it("provides complete token sets for every theme", () => {
@@ -42,48 +34,48 @@ describe("theme tokens", () => {
   });
 
   it("returns theme tokens by resolved name", () => {
-    expect(themeTokens("github-light")).toBe(THEMES["github-light"]);
-    expect(themeTokens("bad-name")).toBe(THEMES.default);
+    expect(themeTokens("light")).toBe(THEMES.light);
+    expect(themeTokens("bad-name")).toBe(THEMES.dark);
   });
 
   it("keeps legacy token exports bound to the active theme", () => {
-    const restore = setActiveTheme(THEMES["github-light"]);
-    expect(FG.body).toBe(THEMES["github-light"].fg.body);
-    expect(COLOR.primary).toBe(THEMES["github-light"].tone.brand);
+    const restore = setActiveTheme(THEMES.light);
+    expect(FG.body).toBe(THEMES.light.fg.body);
+    expect(COLOR.primary).toBe(THEMES.light.tone.brand);
 
     restore();
   });
 
   it("keeps legacy token exports object-compatible", () => {
-    const restore = setActiveTheme(THEMES["github-light"]);
+    const restore = setActiveTheme(THEMES.light);
 
-    expect(Object.keys(FG)).toEqual(Object.keys(THEMES["github-light"].fg));
-    expect({ ...COLOR }).toMatchObject({ primary: THEMES["github-light"].tone.brand });
+    expect(Object.keys(FG)).toEqual(Object.keys(THEMES.light.fg));
+    expect({ ...COLOR }).toMatchObject({ primary: THEMES.light.tone.brand });
     expect(JSON.parse(JSON.stringify(COLOR))).toMatchObject({
-      primary: THEMES["github-light"].tone.brand,
+      primary: THEMES.light.tone.brand,
     });
     expect(Array.isArray(GRADIENT)).toBe(true);
     expect([...GRADIENT]).toEqual([
-      THEMES["github-light"].tone.ok,
-      THEMES["github-light"].tone.brand,
-      THEMES["github-light"].tone.info,
-      THEMES["github-light"].toneActive.brand,
-      THEMES["github-light"].toneActive.violet,
-      THEMES["github-light"].tone.accent,
-      THEMES["github-light"].toneActive.accent,
-      THEMES["github-light"].tone.err,
+      THEMES.light.tone.ok,
+      THEMES.light.tone.brand,
+      THEMES.light.tone.info,
+      THEMES.light.toneActive.brand,
+      THEMES.light.toneActive.violet,
+      THEMES.light.tone.accent,
+      THEMES.light.toneActive.accent,
+      THEMES.light.tone.err,
     ]);
 
     restore();
   });
 
   it("restores legacy token exports after scoped active theme cleanup", () => {
-    const restoreDefault = setActiveTheme(THEMES.default);
-    const restoreLight = setActiveTheme(THEMES["github-light"]);
+    const restoreDark = setActiveTheme(THEMES.dark);
+    const restoreLight = setActiveTheme(THEMES.light);
 
-    expect(FG.body).toBe(THEMES["github-light"].fg.body);
+    expect(FG.body).toBe(THEMES.light.fg.body);
     restoreLight();
-    expect(FG.body).toBe(THEMES.default.fg.body);
-    restoreDefault();
+    expect(FG.body).toBe(THEMES.dark.fg.body);
+    restoreDark();
   });
 });

--- a/tests/ui-reducer.test.ts
+++ b/tests/ui-reducer.test.ts
@@ -500,19 +500,19 @@ describe("balanceColor", () => {
   // USD balances are multiplied by USD_TO_CNY before the threshold check.
 
   it("CNY → threshold checked directly", () => {
-    expect(balanceColor(3, "CNY")).toBe("#ff8b81"); // err
-    expect(balanceColor(8, "CNY")).toBe("#f0b07d"); // warn
-    expect(balanceColor(25, "CNY")).toBe("#79c0ff"); // brand
+    expect(balanceColor(3, "CNY")).toBe("#f87171"); // err
+    expect(balanceColor(8, "CNY")).toBe("#fbbf24"); // warn
+    expect(balanceColor(25, "CNY")).toBe("#7dd3fc"); // brand
   });
 
   it("USD → converted to CNY before threshold check ($0.91 ≈ ¥6.55 → warn)", () => {
-    expect(balanceColor(0.5, "USD")).toBe("#ff8b81"); // ≈ ¥3.60 → err
-    expect(balanceColor(0.91, "USD")).toBe("#f0b07d"); // ≈ ¥6.55 → warn
-    expect(balanceColor(3.0, "USD")).toBe("#79c0ff"); // ≈ ¥21.60 → brand
+    expect(balanceColor(0.5, "USD")).toBe("#f87171"); // ≈ ¥3.60 → err
+    expect(balanceColor(0.91, "USD")).toBe("#fbbf24"); // ≈ ¥6.55 → warn
+    expect(balanceColor(3.0, "USD")).toBe("#7dd3fc"); // ≈ ¥21.60 → brand
   });
 
   it("undefined currency defaults to CNY (matches pre-fix behavior)", () => {
-    expect(balanceColor(8)).toBe("#f0b07d");
+    expect(balanceColor(8)).toBe("#fbbf24");
   });
 });
 

--- a/tests/ui-theme-picker.test.tsx
+++ b/tests/ui-theme-picker.test.tsx
@@ -32,13 +32,13 @@ describe("ThemePicker", () => {
   });
 
   it("marks the current preference and active theme", () => {
-    const text = renderPicker({ currentPreference: "auto", activeTheme: "github-dark" });
+    const text = renderPicker({ currentPreference: "auto", activeTheme: "dark" });
     expect(text).toMatch(/auto[\s\S]*current preference/);
-    expect(text).toMatch(/github-dark[\s\S]*active now/);
+    expect(text).toMatch(/dark[\s\S]*active now/);
   });
 
   it("renders the keybind hint footer", () => {
-    const text = renderPicker({ currentPreference: "tokyo-night", activeTheme: "tokyo-night" });
+    const text = renderPicker({ currentPreference: "midnight", activeTheme: "midnight" });
     expect(text).toContain("↑↓");
     expect(text).toContain("⏎");
     expect(text).toContain("esc");


### PR DESCRIPTION
## Changes

### 1. Theme Simplification (7 → 5)
- Removed redundant themes: default, github-dark, github-light
- Renamed 	okyo-night → midnight (removed geographic name)
- Added new deep-blue theme with #0153e5 brand color

### 2. New deep-blue Theme
- Brand color: #0153e5
- Input box background: #1e1e1e
- Overall background: #0a0a0a (pure black)

### 3. Fix Input Text Color
- Added color={FG.body} to enderSegment function
- Input text now follows theme changes

### 4. Add History Mode Indicator
- Added isHistoryMode state to useInputRecall hook
- Shows ↑ history indicator when viewing past inputs
- Passes state through ComposerArea to PromptInput

### 5. Optimize bgInput Color Values
- dark: #111827 → #0f172a (better contrast)
- light: #f8fafc → #f1f5f9 (better contrast)

## Files Changed
- src/cli/ui/theme/tokens.ts - Theme definitions
- src/cli/ui/PromptInput.tsx - Input styling
- src/cli/ui/hooks/useInputRecall.ts - History state
- src/cli/ui/ComposerArea.tsx - Props passing
- src/cli/ui/App.tsx - Props passing
- Tests updated for new theme names

## Testing
- ✅ Lint passed
- ✅ Typecheck passed
- ✅ All 3596 tests passed

Closes #1665