### PR TITLE
fix(cli,desktop): persist cumulative usage stats to session meta + auto-restore on startup

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -864,6 +864,7 @@ export function applyIncoming(state: State, ev: IncomingEvent): State {
           ...zeroUsage(),
           totalCostUsd: ev.carryover.totalCostUsd,
           totalPromptTokens: ev.carryover.cacheHitTokens + ev.carryover.cacheMissTokens,
+          totalCompletionTokens: ev.carryover.totalCompletionTokens ?? 0,
           cacheHitTokens: ev.carryover.cacheHitTokens,
           cacheMissTokens: ev.carryover.cacheMissTokens,
         },

--- a/desktop/src/protocol.ts
+++ b/desktop/src/protocol.ts
@@ -235,6 +235,7 @@ export type SessionLoadedEvent = {
     totalCostUsd: number;
     cacheHitTokens: number;
     cacheMissTokens: number;
+    totalCompletionTokens: number;
   };
 };
 

--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -261,6 +261,7 @@ interface SessionLoadedEvent {
     totalCostUsd: number;
     cacheHitTokens: number;
     cacheMissTokens: number;
+    totalCompletionTokens: number;
   };
 }
 
@@ -1814,6 +1815,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
             totalCostUsd: meta.totalCostUsd ?? 0,
             cacheHitTokens: meta.cacheHitTokens ?? 0,
             cacheMissTokens: meta.cacheMissTokens ?? 0,
+            totalCompletionTokens: meta.totalCompletionTokens ?? 0,
           },
         },
         tab.id,
@@ -1833,19 +1835,22 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
   }
 
   // Restore the full tab set from the previous session — workspace dir,
-  // loaded session and focused tab (issues #933, #1244). `--dir` overrides
-  // saved tabs so a CLI-supplied workspace stays authoritative. Missing
-  // dirs are silently skipped — a deleted workspace shouldn't block boot.
-  const savedTabs = opts.dir
-    ? []
-    : loadDesktopOpenTabs().filter((t) => {
-        try {
-          return existsSync(t.dir) && statSync(t.dir).isDirectory();
-        } catch {
-          return false;
-        }
-      });
-  first = bootstrapTab(savedTabs[0]?.dir, savedTabs[0]);
+  // loaded session and focused tab (issues #933, #1244). Missing dirs
+  // are silently skipped — a deleted workspace shouldn't break boot.
+  const savedTabs = loadDesktopOpenTabs().filter((t) => {
+    try {
+      return existsSync(t.dir) && statSync(t.dir).isDirectory();
+    } catch {
+      return false;
+    }
+  });
+  // When launched with --dir, find the matching saved tab so the user's
+  // previous session is restored automatically.
+  const startupDir = opts.dir;
+  const startupTab = startupDir
+    ? savedTabs.find((t) => resolve(t.dir) === resolve(startupDir))
+    : savedTabs[0];
+  first = bootstrapTab(opts.dir ?? savedTabs[0]?.dir, startupTab);
   const restored: Tab[] = [first];
   for (const t of savedTabs.slice(1)) restored.push(bootstrapTab(t.dir, t));
   // Mirror the persisted focus so the next persist round-trips it.
@@ -1975,6 +1980,30 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
         if (!hasKey) emit({ type: "$needs_setup", reason: "no_api_key" }, t.id);
         else if (t.toolset) emit({ type: "$ready" }, t.id);
         void emitBalance(t);
+        // Re-emit session_loaded so the resumed session's messages and
+        // usage stats (cost, tokens, cache%) are restored on the frontend.
+        if (t.currentSession) {
+          try {
+            const msgs = buildLoadedMessages(loadSessionMessages(t.currentSession));
+            const meta = loadSessionMeta(t.currentSession);
+            emit(
+              {
+                type: "$session_loaded",
+                name: t.currentSession,
+                messages: msgs,
+                carryover: {
+                  totalCostUsd: meta.totalCostUsd ?? 0,
+                  cacheHitTokens: meta.cacheHitTokens ?? 0,
+                  cacheMissTokens: meta.cacheMissTokens ?? 0,
+                  totalCompletionTokens: meta.totalCompletionTokens ?? 0,
+                },
+              },
+              t.id,
+            );
+          } catch {
+            // unreadable jsonl — skip re-emit
+          }
+        }
       }
       return;
     }
@@ -2150,6 +2179,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
               totalCostUsd: meta.totalCostUsd ?? 0,
               cacheHitTokens: meta.cacheHitTokens ?? 0,
               cacheMissTokens: meta.cacheMissTokens ?? 0,
+              totalCompletionTokens: meta.totalCompletionTokens ?? 0,
             },
           },
           tab.id,

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -40,6 +40,7 @@ import {
   archiveSession,
   loadSessionMessages,
   loadSessionMeta,
+  patchSessionMeta,
   rewriteSession,
 } from "./memory/session.js";
 import { type RepairReport, ToolCallRepair } from "./repair/index.js";
@@ -857,6 +858,24 @@ export class CacheFirstLoop {
       // Attribute under the actual model used (escalated → pro, else
       // this.model) so cost/usage logs reflect reality.
       const turnStats = this.stats.record(this._turn, this.model, usage ?? new Usage());
+
+      // Carry cumulative stats across app restarts.
+      if (this.sessionName) {
+        try {
+          const last =
+            this.stats.turns.length > 0 ? this.stats.turns[this.stats.turns.length - 1] : null;
+          const compTokens = this.stats.turns.reduce((sum, t) => sum + t.usage.completionTokens, 0);
+          patchSessionMeta(this.sessionName, {
+            totalCostUsd: this.stats.totalCost,
+            cacheHitTokens: this.stats.cumulativeCacheHitTokens,
+            cacheMissTokens: this.stats.cumulativeCacheMissTokens,
+            totalCompletionTokens: compTokens,
+            lastPromptTokens: last?.usage.promptTokens,
+          });
+        } catch {
+          // Best-effort; don't crash the turn loop on a write failure.
+        }
+      }
 
       this.scratch.reasoning = reasoningContent || null;
 

--- a/src/memory/session.ts
+++ b/src/memory/session.ts
@@ -62,6 +62,8 @@ export interface SessionMeta {
   /** Cumulative cache hit / miss tokens across the session — survives resume so /status cache% isn't 0 on a fresh boot. */
   cacheHitTokens?: number;
   cacheMissTokens?: number;
+  /** Cumulative completion (output) tokens across the session. */
+  totalCompletionTokens?: number;
   /** Last turn's promptTokens — lets /status render the context bar before the next turn fires. */
   lastPromptTokens?: number;
   /** True when the session filename/summary was generated from conversation content. */

--- a/src/telemetry/stats.ts
+++ b/src/telemetry/stats.ts
@@ -152,6 +152,20 @@ export class SessionStats {
     }
   }
 
+  /** Cumulative cache hit tokens across carryover + current turns. */
+  get cumulativeCacheHitTokens(): number {
+    let hit = this._carryoverCacheHit;
+    for (const t of this.turns) hit += t.usage.promptCacheHitTokens;
+    return hit;
+  }
+
+  /** Cumulative cache miss tokens across carryover + current turns. */
+  get cumulativeCacheMissTokens(): number {
+    let miss = this._carryoverCacheMiss;
+    for (const t of this.turns) miss += t.usage.promptCacheMissTokens;
+    return miss;
+  }
+
   reset(): void {
     this.turns.length = 0;
     this._carryoverCost = 0;


### PR DESCRIPTION
## Summary

Session usage statistics (totalCostUsd, cacheHitTokens, cacheMissTokens,
totalCompletionTokens) are now written to the session meta file after every
turn, so they survive app restart. The desktop also restores the previous
session on startup and re-emits session_loaded on WebView resync.

## Changes

- **stats.ts** - Added cumulativeCacheHitTokens / cumulativeCacheMissTokens getters
- **session.ts** - Added totalCompletionTokens to SessionMeta interface
- **loop.ts** - After each turn, call patchSessionMeta with cumulative usage stats
- **desktop.ts** - totalCompletionTokens in carryover; startup with --dir finds matching saved tab; desktop_resync re-emits session_loaded
- **protocol.ts** - Added totalCompletionTokens to SessionLoadedEvent
- **App.tsx** - Restore totalCompletionTokens from carryover

## Verification

npm run build passes