### PR TITLE
fix(desktop): isolate QQ turn routing by tab

### DIFF
--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -67,6 +67,15 @@ import {
   saveDesktopQQSettings,
   setDesktopQQEnabled,
 } from "../../desktop/qq-settings.js";
+import {
+  clearQQTurnRouting,
+  createQQTurnRoutingState,
+  markQQTurnFinished,
+  markQQTurnStarted,
+  setQQPendingInteraction,
+  shouldRouteQQForTab,
+  takeQQPendingInteraction,
+} from "../../desktop/qq-turn-routing.js";
 import { loadDotenv } from "../../env.js";
 import { CacheFirstLoop, DeepSeekClient, ImmutablePrefix } from "../../index.js";
 import { parseMcpSpec } from "../../mcp/spec.js";
@@ -928,9 +937,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
     channel: null as QQChannel | null,
     runtimeState: "disconnected" as "disconnected" | "connecting" | "connected" | "failed",
     lastError: undefined as string | undefined,
-    pendingGateId: null as number | null,
-    interaction: { kind: null as string | null, payload: null as unknown },
-    replyThisTurn: false,
+    routing: createQQTurnRoutingState(),
   };
 
   function currentQqSettings(): QQSettingsEvent {
@@ -1026,14 +1033,12 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
       .trim();
   }
 
-  function handleQQPauseReply(text: string): boolean {
-    if (qqRuntime.interaction.kind === null || qqRuntime.pendingGateId === null) return false;
-    qqRuntime.replyThisTurn = true;
+  function handleQQPauseReply(tab: Tab, text: string): boolean {
+    const pending = takeQQPendingInteraction(qqRuntime.routing, tab.id);
+    if (!pending) return false;
     const followup = stripFollowupPrefix(text);
-    const interaction = qqRuntime.interaction;
-    qqRuntime.interaction = { kind: null, payload: null };
-    const gateId = qqRuntime.pendingGateId;
-    qqRuntime.pendingGateId = null;
+    const interaction = pending;
+    const gateId = pending.gateId;
 
     switch (interaction.kind) {
       case "run_command":
@@ -1103,8 +1108,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
   }
 
   function handleQQPauseRequest(tab: Tab, kind: string, payload: Record<string, unknown>): void {
-    if (!qqRuntime.channel) return;
-    qqRuntime.interaction = { kind, payload };
+    if (!qqRuntime.channel || !shouldRouteQQForTab(qqRuntime.routing, tab.id)) return;
     let qqMessage = "";
     switch (kind) {
       case "run_command":
@@ -1179,7 +1183,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
           },
           tab.id,
         );
-        if (handleQQPauseReply(trimmed)) return;
+        if (handleQQPauseReply(tab, trimmed)) return;
         if (tab.aborter) {
           void channel
             .sendResponse(
@@ -1188,7 +1192,6 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
             .catch(() => undefined);
           return;
         }
-        qqRuntime.replyThisTurn = true;
         void runTurn(tab, trimmed, true);
       },
       onError: (message) => {
@@ -1214,9 +1217,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
   async function stopDesktopQQ(shouldDisable = true): Promise<void> {
     const channel = qqRuntime.channel;
     qqRuntime.channel = null;
-    qqRuntime.interaction = { kind: null, payload: null };
-    qqRuntime.pendingGateId = null;
-    qqRuntime.replyThisTurn = false;
+    clearQQTurnRouting(qqRuntime.routing);
     if (channel) await channel.stop();
     if (shouldDisable) setDesktopQQEnabled(false);
     setQQRuntimeState("disconnected");
@@ -1370,7 +1371,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
     if (!tab.runtime) return;
     const rt = tab.runtime;
     tab.aborter = new AbortController();
-    qqRuntime.replyThisTurn = fromQQ;
+    if (fromQQ) markQQTurnStarted(qqRuntime.routing, tab.id);
     let lastAssistantText = "";
     if (tab.currentSession) {
       const existing = loadSessionMeta(tab.currentSession).summary;
@@ -1407,7 +1408,12 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
         // If a session switch happened while this turn was running,
         // suppress stale events to avoid UI state corruption (#1217).
         if (!tab.switching) {
-          if (fromQQ && lastAssistantText && qqRuntime.channel && qqRuntime.replyThisTurn) {
+          if (
+            fromQQ &&
+            lastAssistantText &&
+            qqRuntime.channel &&
+            shouldRouteQQForTab(qqRuntime.routing, tab.id)
+          ) {
             await qqRuntime.channel.sendResponse(lastAssistantText).catch((err) => {
               emit(
                 { type: "$error", message: `qq send failed: ${(err as Error).message}` },
@@ -1415,7 +1421,6 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
               );
             });
           }
-          qqRuntime.replyThisTurn = false;
           emit({ type: "$turn_complete" }, tab.id);
           if (tab.planTotalSteps > 0 && tab.completedStepIds.size >= tab.planTotalSteps) {
             tab.completedStepIds.clear();
@@ -1425,6 +1430,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
           emitSessions(tab);
           void emitBalance(tab);
         }
+        if (fromQQ) markQQTurnFinished(qqRuntime.routing, tab.id);
         tab.switching = false;
       }
     });
@@ -1586,7 +1592,6 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
     const tab = activeRunningTab();
     const tabId = tab?.id;
     if (tab) tab.pendingGateIds.add(req.id);
-    qqRuntime.pendingGateId = req.id;
     // Shared auto-resolve policy (e.g. plan_checkpoint in auto/yolo) — must
     // still run BEFORE we emit any UI event, otherwise the surface flickers
     // a card that we'd immediately tear down.
@@ -1624,6 +1629,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
         timeoutSec?: number;
         waitSec?: number;
       };
+      if (tab) setQQPendingInteraction(qqRuntime.routing, tab.id, req.id, req.kind, payload);
       emit(
         {
           type: "$confirm_required",
@@ -1649,6 +1655,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
         sandboxRoot: string;
         allowPrefix: string;
       };
+      if (tab) setQQPendingInteraction(qqRuntime.routing, tab.id, req.id, req.kind, payload);
       emit(
         {
           type: "$path_access_required",
@@ -1675,6 +1682,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
         options: ChoiceOption[];
         allowCustom: boolean;
       };
+      if (tab) setQQPendingInteraction(qqRuntime.routing, tab.id, req.id, req.kind, payload);
       emit(
         {
           type: "$choice_required",
@@ -1693,6 +1701,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
       if (tab) {
         tab.completedStepIds.clear();
         tab.planTotalSteps = payload.steps?.length ?? 0;
+        setQQPendingInteraction(qqRuntime.routing, tab.id, req.id, req.kind, payload);
       }
       emit(
         {
@@ -1714,7 +1723,10 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
         result: string;
         notes?: string;
       };
-      if (tab) tab.completedStepIds.add(payload.stepId);
+      if (tab) {
+        tab.completedStepIds.add(payload.stepId);
+        setQQPendingInteraction(qqRuntime.routing, tab.id, req.id, req.kind, payload);
+      }
       emit(
         {
           type: "$step_completed",
@@ -1747,6 +1759,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
         remainingSteps: PlanStepLite[];
         summary?: string;
       };
+      if (tab) setQQPendingInteraction(qqRuntime.routing, tab.id, req.id, req.kind, payload);
       emit(
         {
           type: "$revision_required",

--- a/src/desktop/qq-turn-routing.ts
+++ b/src/desktop/qq-turn-routing.ts
@@ -1,0 +1,56 @@
+export type QQPendingInteraction = {
+  gateId: number;
+  kind: string;
+  payload: unknown;
+};
+
+export type QQTurnRoutingState = {
+  replyTabs: Set<string>;
+  pendingByTab: Map<string, QQPendingInteraction>;
+};
+
+export function createQQTurnRoutingState(): QQTurnRoutingState {
+  return {
+    replyTabs: new Set<string>(),
+    pendingByTab: new Map<string, QQPendingInteraction>(),
+  };
+}
+
+export function markQQTurnStarted(state: QQTurnRoutingState, tabId: string): void {
+  state.replyTabs.add(tabId);
+}
+
+export function markQQTurnFinished(state: QQTurnRoutingState, tabId: string): void {
+  state.replyTabs.delete(tabId);
+  state.pendingByTab.delete(tabId);
+}
+
+export function shouldRouteQQForTab(state: QQTurnRoutingState, tabId: string): boolean {
+  return state.replyTabs.has(tabId);
+}
+
+export function setQQPendingInteraction(
+  state: QQTurnRoutingState,
+  tabId: string,
+  gateId: number,
+  kind: string,
+  payload: unknown,
+): void {
+  if (!shouldRouteQQForTab(state, tabId)) return;
+  state.pendingByTab.set(tabId, { gateId, kind, payload });
+}
+
+export function takeQQPendingInteraction(
+  state: QQTurnRoutingState,
+  tabId: string,
+): QQPendingInteraction | null {
+  const hit = state.pendingByTab.get(tabId);
+  if (!hit) return null;
+  state.pendingByTab.delete(tabId);
+  return hit;
+}
+
+export function clearQQTurnRouting(state: QQTurnRoutingState): void {
+  state.replyTabs.clear();
+  state.pendingByTab.clear();
+}

--- a/tests/desktop-qq-turn-routing.test.ts
+++ b/tests/desktop-qq-turn-routing.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  clearQQTurnRouting,
+  createQQTurnRoutingState,
+  markQQTurnFinished,
+  markQQTurnStarted,
+  setQQPendingInteraction,
+  shouldRouteQQForTab,
+  takeQQPendingInteraction,
+} from "../src/desktop/qq-turn-routing.js";
+
+describe("desktop QQ turn routing", () => {
+  it("keeps a QQ-started tab routable even after a local turn starts elsewhere", () => {
+    const routing = createQQTurnRoutingState();
+
+    markQQTurnStarted(routing, "tab-1");
+
+    expect(shouldRouteQQForTab(routing, "tab-1")).toBe(true);
+    expect(shouldRouteQQForTab(routing, "tab-2")).toBe(false);
+
+    // A local turn in another tab should not cancel the older QQ turn.
+    expect(shouldRouteQQForTab(routing, "tab-1")).toBe(true);
+    expect(shouldRouteQQForTab(routing, "tab-2")).toBe(false);
+
+    markQQTurnFinished(routing, "tab-1");
+    expect(shouldRouteQQForTab(routing, "tab-1")).toBe(false);
+  });
+
+  it("stores follow-up prompts only for tabs that are actively QQ-routed", () => {
+    const routing = createQQTurnRoutingState();
+
+    markQQTurnStarted(routing, "tab-1");
+    setQQPendingInteraction(routing, "tab-1", 7, "choice", { question: "Pick one" });
+    setQQPendingInteraction(routing, "tab-2", 9, "choice", { question: "Should stay local" });
+
+    expect(takeQQPendingInteraction(routing, "tab-2")).toBeNull();
+    expect(takeQQPendingInteraction(routing, "tab-1")).toEqual({
+      gateId: 7,
+      kind: "choice",
+      payload: { question: "Pick one" },
+    });
+  });
+
+  it("clears all tab routing state on disconnect", () => {
+    const routing = createQQTurnRoutingState();
+
+    markQQTurnStarted(routing, "tab-1");
+    setQQPendingInteraction(routing, "tab-1", 3, "run_command", { command: "dir" });
+
+    clearQQTurnRouting(routing);
+
+    expect(shouldRouteQQForTab(routing, "tab-1")).toBe(false);
+    expect(takeQQPendingInteraction(routing, "tab-1")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- isolate desktop QQ reply routing and pending follow-up prompts by tab
- keep active-tab binding semantics for future QQ ingress, while preserving final replies for older QQ-started turns already in flight
- add a regression test for the per-tab QQ routing state

## Testing
- npm test -- --run tests/desktop-qq-turn-routing.test.ts tests/desktop-user-message.test.ts
- npm run typecheck
- npm run lint
- npm run verify

## Context
Fixes the actionable part of #1619. Switching the active tab is still expected to retarget later QQ messages, but an older QQ-started turn should not lose its final reply after a local turn starts in another tab, and local-only pause prompts should not leak into QQ.
