### PR TITLE
fix(dashboard): don't synthesize $turn_complete from per-iter assistant_final

### DIFF
--- a/dashboard/src/lib/tauri-bridge.ts
+++ b/dashboard/src/lib/tauri-bridge.ts
@@ -92,6 +92,9 @@ function sseToIncoming(ev: any): Record<string, any>[] {
       break;
     }
     case "assistant_final": {
+      // Loop's `assistant_final` fires per model iteration (mid-turn it
+      // precedes tool dispatch); the real turn end is signaled by
+      // `busy-change` (busy=false), handled below.
       results.push({
         type: "model.final",
         tabId: "tab-1",
@@ -101,8 +104,6 @@ function sseToIncoming(ev: any): Record<string, any>[] {
         usage: ev.usage ?? undefined,
         costUsd: ev.costUsd ?? undefined,
       });
-      results.push({ type: "$turn_complete", tabId: "tab-1" });
-      sseTurnStarted = false;
       break;
     }
     case "tool_start": {


### PR DESCRIPTION
## Summary
- **Bug**: in `reasonix code` + browser `/dashboard`, when the model used `run_command` for a long-running tool (e.g. `npm run test`), the composer's red stop button flipped to the send button the instant the model finished streaming its tool-call response — well before the spawned process actually completed. Pressing Esc / clicking stop no longer worked because there was no abort affordance to begin with; the user could send a fresh message right on top of an in-flight tool.
- **Root cause**: `dashboard/src/lib/tauri-bridge.ts:sseToIncoming` was synthesizing `$turn_complete` (which the reducer reads as `busy=false`) inside the `assistant_final` case. But the loop emits `assistant_final` **after every model iteration** — including the iter that hands off to a tool call — so it fired immediately, mid-turn. The same case also reset `sseTurnStarted = false`, which then suppressed the real turn-end synthesis when `busy-change(busy=false)` arrived later from the CLI's `handleSubmit` finally block.
- **Fix**: drop the synthesized `$turn_complete` and the flag reset from the `assistant_final` case. `busy-change` is the authoritative turn-end signal — it already drives `$turn_complete` correctly via the `case "busy-change"` block below, and is broadcast from CLI App.tsx:1316 in a `useEffect` that watches the real `busy` state set/cleared inside `handleSubmit`'s try-finally.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx vitest run tests/desktop-btw-status.test.ts desktop/src/App.test.ts` (12 passed)
- [x] `cd dashboard && npm run build`
- [ ] Manual: `reasonix code` → open `/dashboard` in browser → ask AI to `npm run test` → confirm stop button stays visible until the spawned process exits
