### PR TITLE
fix(dashboard): composer queue-count label was passing wrong var name

### DIFF
--- a/dashboard/src/ui/composer.tsx
+++ b/dashboard/src/ui/composer.tsx
@@ -395,7 +395,7 @@ export function Composer({
         {queuedSends && queuedSends.length > 0 ? (
           <div className="composer-queued">
             <span className="composer-queued-label">
-              {t("composer.queueCount", { n: queuedSends.length })}
+              {t("composer.queueCount", { count: queuedSends.length })}
             </span>
             {queuedSends.map((text, i) => (
               <span key={i} className="composer-queue-chip" title={text}>


### PR DESCRIPTION
## Summary
- The composer's "N queued" label was calling `t("composer.queueCount", { n: queuedSends.length })`, but both i18n templates use `{count}` as the placeholder (`"{count} queued"` / `"{count} 个排队"`). Variable name mismatch → no interpolation → UI rendered the literal string `{count} 个排队` whenever a message got queued while busy.
- One-character fix: `n` → `count` to match the templates.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `cd dashboard && npm run build`
- [ ] Manual: while a turn is busy, press Enter on a non-empty composer — the chip row should now show `"1 个排队"` / `"1 queued"` instead of `"{count} 个排队"`
