### PR TITLE
chore(ui): drop redundant overflow-wrap from inherited descendants

### DIFF
--- a/dashboard/src/styles.css
+++ b/dashboard/src/styles.css
@@ -1668,11 +1668,9 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
 }
 .msg-text .markdown {
   white-space: normal;
-  overflow-wrap: anywhere;
 }
 .msg-text p {
   margin: 0 0 12px;
-  overflow-wrap: anywhere;
 }
 .msg-text p:last-child {
   margin-bottom: 0;

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -1703,11 +1703,9 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
 }
 .msg-text .markdown {
   white-space: normal;
-  overflow-wrap: anywhere;
 }
 .msg-text p {
   margin: 0 0 12px;
-  overflow-wrap: anywhere;
 }
 .msg-text p:last-child {
   margin-bottom: 0;


### PR DESCRIPTION
## Summary

`overflow-wrap` is an inherited CSS property, and `.msg-text` already declares `overflow-wrap: anywhere` (added in #1590). The duplicate declarations on `.msg-text .markdown` and `.msg-text p` cascade no behavior change — they only add noise.

Removed in both `desktop/src/styles.css` and `dashboard/src/styles.css`. The combined `.msg-text X, .markdown X` selectors (code, links) keep their declarations because the standalone `.markdown` case (used in cards, outside `.msg-text`) has no ancestor setting `overflow-wrap`.

## Verification

- `npm run verify` ✅
- `npm exec vitest run tests/user-message-newlines.test.ts` ✅