### PR TITLE
fix(dashboard): tool cards no longer stuck spinning forever

### DIFF
--- a/src/cli/ui/effects/loop-to-dashboard.ts
+++ b/src/cli/ui/effects/loop-to-dashboard.ts
@@ -16,12 +16,21 @@ export function loopEventToDashboard(
       };
     case "tool_start":
       if (!ev.toolName) return null;
-      return { kind: "tool_start", id, toolName: ev.toolName, args: ev.toolArgs };
+      // Use the loop's stable per-call id so the matching `tool` event
+      // below carries the same id — the dashboard reducer keys segments
+      // by it. Falling back to the role+timestamp id leaves tool cards
+      // stuck in "running" because the result never matches the intent.
+      return {
+        kind: "tool_start",
+        id: ev.callId ?? id,
+        toolName: ev.toolName,
+        args: ev.toolArgs,
+      };
     case "tool":
       if (!ev.toolName) return null;
       return {
         kind: "tool",
-        id,
+        id: ev.callId ?? id,
         toolName: ev.toolName,
         content: ev.content,
         args: ev.toolArgs,

--- a/tests/loop-to-dashboard.test.ts
+++ b/tests/loop-to-dashboard.test.ts
@@ -77,4 +77,21 @@ describe("loopEventToDashboard", () => {
     expect(loopEventToDashboard(ev({ role: "assistant_final" }), ctx)).toBeNull();
     expect(loopEventToDashboard(ev({ role: "tool_call_delta" }), ctx)).toBeNull();
   });
+
+  it("tool_start and tool share the loop's callId so the dashboard can pair them", () => {
+    // Regression: previously the id was role+timestamp, so tool_start and
+    // tool got different ids — the dashboard reducer keys segments by it,
+    // so the result never landed and tool cards stayed in `running` forever.
+    const callId = "tc-7";
+    const startEv = loopEventToDashboard(
+      ev({ role: "tool_start", toolName: "read_file", toolArgs: "{}", callId }),
+      ctx,
+    );
+    const resultEv = loopEventToDashboard(
+      ev({ role: "tool", toolName: "read_file", content: "out", toolArgs: "{}", callId }),
+      ctx,
+    );
+    expect(startEv).toMatchObject({ kind: "tool_start", id: callId });
+    expect(resultEv).toMatchObject({ kind: "tool", id: callId });
+  });
 });


### PR DESCRIPTION
## Summary
- **Bug**: in `reasonix code` + browser dashboard, every tool card's spinner stayed visible forever even after the underlying tool completed (or was aborted). The card showed `running` indefinitely until session-reload, even though the loop had long since produced the result.
- **Root cause**: `src/cli/ui/effects/loop-to-dashboard.ts:8` minted dashboard event ids as `` `${assistantId}-${role}-${Date.now()}` `` for *every* event. `tool_start` and `tool` carry different role strings and fire at different timestamps → completely different ids. The SSE bridge (`dashboard/src/lib/tauri-bridge.ts`) passes that id through as the segment callId, and the dashboard reducer keys segments by it (`dashboard/src/App.tsx:931-951`) — so `tool.result` never matched the segment created by `tool.intent`, `segment.result` stayed `undefined`, and `ToolCard`/`ShellCard`'s `running = result === undefined` (`dashboard/src/ui/cards.tsx:345`, `thread.tsx:137-141`) kept the spinner spinning forever.
- **Fix**: `LoopEvent.callId` already exists for exactly this purpose — `src/loop/types.ts:40-41` says `"UI uses this as the card id"` — and both `tool_start` (loop.ts:1024) and `tool` (loop.ts:1078) emit it from `this.inflightIdFor(call)`. Use `ev.callId ?? id` in `loopEventToDashboard` for both events so they share a stable id and the dashboard reducer can pair them.

## How it was found
SSE event log captured via temporary `?debug-sse` instrumentation showed the full event sequence flowing correctly (`busy-change{busy:true}` → deltas → `assistant_final` → `tool_start` → user abort → `tool` (with kill output) → `assistant_final`(synthetic) → `busy-change{busy:false}`), with `$turn_complete` correctly synthesized on the final `busy-change`. So `state.busy` was actually flipping false on the dashboard (confirmed by the `jobs_list` poll firing right after, which is gated on `!state.busy`). The visible "spinner" was the per-card spinner, not the composer's stop/send affordance — pointing at the segment-update path.

## Test plan
- [x] `npx vitest run tests/loop-to-dashboard.test.ts` — 8 passed (added a regression case asserting tool_start + tool share the loop's callId)
- [x] `npx tsc --noEmit`
- [ ] Manual: `reasonix code` → browser dashboard → ask AI to do anything that uses a tool → confirm card transitions running → done within a few hundred ms of the tool finishing (and not only on session reload)
