### PR TITLE
fix(dashboard): mirror code fence lang detection fix from #1661

### DIFF
--- a/dashboard/src/Markdown.tsx
+++ b/dashboard/src/Markdown.tsx
@@ -7,7 +7,6 @@ import {
   createContext,
   isValidElement,
   memo,
-  type ReactElement,
   type ReactNode,
   useContext,
   useState,
@@ -156,14 +155,9 @@ export const Markdown = memo(function Markdown({ source }: { source: string }) {
         rehypePlugins={[[rehypeKatex, { throwOnError: false }]]}
         components={{
           pre: ({ children }) => {
-            const codeEl = Children.toArray(children).find(
-              (c): c is ReactElement<{ className?: string; children?: ReactNode }> =>
-                isValidElement(c) && c.type === "code",
-            );
-            if (!codeEl) return <pre>{children}</pre>;
-            const text = String(codeEl.props.children ?? "").replace(/\n$/, "");
-            const lang = /language-([\w-]+)/.exec(codeEl.props.className ?? "")?.[1] ?? "text";
-            return <CodeBlock lang={lang} text={text} />;
+            // react-markdown v9 nests children unpredictably — flatten all text.
+            const rawText = flattenChildText(children).trimEnd();
+            return <CodeBlock lang={extractFencedLang(children)} text={rawText} />;
           },
           code: ({ className, children }) => <code className={className}>{children}</code>,
           a: ({ href, children }) => <SafeLink href={href}>{children}</SafeLink>,
@@ -227,6 +221,27 @@ function SafeLink({ href, children }: { href?: string; children: ReactNode }) {
       ) : null}
     </a>
   );
+}
+
+export function extractFencedLang(children: ReactNode): string {
+  for (const kid of Children.toArray(children)) {
+    if (isValidElement(kid)) {
+      const cls = (kid.props as Record<string, unknown>).className;
+      if (typeof cls === "string") {
+        const m = cls.match(/language-([\w-]+)/);
+        if (m) return m[1]!;
+      }
+    }
+  }
+  return "text";
+}
+
+function flattenChildText(node: ReactNode): string {
+  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(flattenChildText).join("");
+  if (isValidElement(node))
+    return flattenChildText((node.props as { children?: ReactNode }).children);
+  return "";
 }
 
 function CodeBlock({ lang, text }: { lang: string; text: string }): ReactNode {

--- a/desktop/src/Markdown.tsx
+++ b/desktop/src/Markdown.tsx
@@ -214,18 +214,7 @@ export const Markdown = memo(function Markdown({ source }: { source: string }) {
           pre: ({ children }) => {
             // react-markdown v9 nests children unpredictably — flatten all text.
             const rawText = flattenChildText(children).trimEnd();
-            // Extract lang from child element's className prop.
-            let lang = "text";
-            for (const kid of Children.toArray(children)) {
-              if (isValidElement(kid)) {
-                const cls = (kid.props as Record<string, unknown>).className;
-                if (typeof cls === "string") {
-                  const m = cls.match(/language-([\w-]+)/);
-                  if (m) { lang = m[1]!; break; }
-                }
-              }
-            }
-            return <CodeBlock lang={lang} text={rawText} />;
+            return <CodeBlock lang={extractFencedLang(children)} text={rawText} />;
           },
           code: ({ className, children }) => {
             const text = String(children ?? "");
@@ -303,7 +292,19 @@ function SafeLink({ href, children }: { href?: string; children: ReactNode }) {
   );
 }
 
-/** Recursively extract plain text from React children (handles nested elements, fragments, etc.). */
+export function extractFencedLang(children: ReactNode): string {
+  for (const kid of Children.toArray(children)) {
+    if (isValidElement(kid)) {
+      const cls = (kid.props as Record<string, unknown>).className;
+      if (typeof cls === "string") {
+        const m = cls.match(/language-([\w-]+)/);
+        if (m) return m[1]!;
+      }
+    }
+  }
+  return "text";
+}
+
 function flattenChildText(node: ReactNode): string {
   if (typeof node === "string" || typeof node === "number") return String(node);
   if (Array.isArray(node)) return node.map(flattenChildText).join("");

--- a/tests/markdown-codeblock-lang.test.tsx
+++ b/tests/markdown-codeblock-lang.test.tsx
@@ -1,0 +1,29 @@
+import { type ReactElement, createElement } from "react";
+import { describe, expect, it } from "vitest";
+
+import { extractFencedLang as dashboardExtract } from "../dashboard/src/Markdown";
+import { extractFencedLang as desktopExtract } from "../desktop/src/Markdown";
+
+const stub = (className: string): ReactElement => createElement("code", { className });
+
+describe.each([
+  { surface: "desktop", extract: desktopExtract },
+  { surface: "dashboard", extract: dashboardExtract },
+])("$surface extractFencedLang", ({ extract }) => {
+  it("reads language- class from a child element", () => {
+    expect(extract(stub("language-ts"))).toBe("ts");
+    expect(extract(stub("language-python"))).toBe("python");
+    expect(extract(stub("language-c-sharp"))).toBe("c-sharp");
+  });
+
+  it("returns 'text' when no language- class is found", () => {
+    expect(extract(stub(""))).toBe("text");
+    expect(extract(stub("not-a-lang"))).toBe("text");
+    expect(extract("just a string")).toBe("text");
+    expect(extract(undefined)).toBe("text");
+  });
+
+  it("ignores non-string className values", () => {
+    expect(extract(createElement("code", { className: 42 }))).toBe("text");
+  });
+});


### PR DESCRIPTION
## Summary

[#1661](https://github.com/esengine/DeepSeek-Reasonix/pull/1661) fixed the code-fence lang-detection bug for desktop only. Dashboard's `pre` handler had the same `c.type === "code"` check, which fails when react-markdown's component override replaces `code` — the element's `type` is the override function, not the string `"code"`.

For dashboard this didn't just mislabel the language: the old fallback returned a vanilla `<pre>` and skipped `CodeBlock` entirely, so **every fenced code block in the dashboard was rendered without syntax highlighting and without the copy button.**

## Changes

- **`dashboard/src/Markdown.tsx`** — mirror the desktop fix: read `className` from the first child element instead of relying on `type === "code"`. Also port `flattenChildText` so text extraction matches desktop.
- **`desktop/src/Markdown.tsx`** — extract the lang lookup into `extractFencedLang` so it can be unit-tested.
- **`tests/markdown-codeblock-lang.test.tsx`** — new regression test covering both surfaces via the extracted helper.

## Why a helper instead of rendering through `<Markdown>`?

`CodeView` pulls in `prism-react-renderer`, which resolves React from each package's own `node_modules`. Under vitest that produces two React copies and breaks hooks (`useCallback` is null) for any full-render test of a code block. The pure helper sidesteps that and still proves both surfaces parse the same fenced lang the same way.

## Verification

- `npm run verify` ✅ (3603 passed / 12 skipped, +6 from this PR)