### PR TITLE
chore(theme): finish theme rename follow-up after #1666

### DIFF
--- a/src/cli/ui/slash/commands.ts
+++ b/src/cli/ui/slash/commands.ts
@@ -94,18 +94,9 @@ export const SLASH_COMMANDS: readonly SlashCommandSpec[] = [
   {
     cmd: "theme",
     group: "setup",
-    argsHint: "[auto|default|dark|light|tokyo-night|github-dark|github-light|high-contrast]",
+    argsHint: "[auto|dark|light|midnight|deep-blue|high-contrast]",
     summary: "show or persist the terminal theme preference. Bare opens picker.",
-    argCompleter: [
-      "auto",
-      "default",
-      "dark",
-      "light",
-      "tokyo-night",
-      "github-dark",
-      "github-light",
-      "high-contrast",
-    ],
+    argCompleter: ["auto", "dark", "light", "midnight", "deep-blue", "high-contrast"],
   },
 
   { cmd: "status", group: "info", summary: "current model, flags, context, session" },

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -271,7 +271,7 @@ export const EN: TranslationSchema = {
     models: { description: "list available models fetched from DeepSeek /models" },
     theme: {
       description: "show or persist the terminal theme preference. Bare opens picker.",
-      argsHint: "[auto|default|dark|light|tokyo-night|github-dark|github-light|high-contrast]",
+      argsHint: "[auto|dark|light|midnight|deep-blue|high-contrast]",
     },
     language: {
       description: "switch the runtime language",
@@ -448,12 +448,10 @@ export const EN: TranslationSchema = {
     themeSampleHeading: "Sample",
     themeFooter: "[↑↓] navigate · [Enter] confirm · [Esc] cancel",
     themeCaption: {
-      default: "GitHub dark (default)",
-      dark: "Cool dark tones",
+      dark: "Cool dark tones (default)",
       light: "Clean light mode",
-      "tokyo-night": "Tokyo Night palette",
-      "github-dark": "GitHub dark",
-      "github-light": "GitHub light",
+      midnight: "Tokyo Night palette",
+      "deep-blue": "Deep blue on black",
       "high-contrast": "Accessibility",
     },
     reviewLabelTheme: "Theme",

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -261,7 +261,7 @@ export const zhCN: TranslationSchema = {
     models: { description: "列出从 DeepSeek /models 获取的可用模型" },
     theme: {
       description: "显示或持久化终端主题偏好。无参数时打开选择器。",
-      argsHint: "[auto|default|dark|light|tokyo-night|github-dark|github-light|high-contrast]",
+      argsHint: "[auto|dark|light|midnight|deep-blue|high-contrast]",
     },
     language: {
       description: "切换运行时语言",
@@ -430,12 +430,10 @@ export const zhCN: TranslationSchema = {
     themeSampleHeading: "示例",
     themeFooter: "[↑↓] 移动 · [Enter] 确认 · [Esc] 取消",
     themeCaption: {
-      default: "GitHub 深色（默认）",
-      dark: "深色调",
+      dark: "深色调（默认）",
       light: "清爽浅色",
-      "tokyo-night": "东京夜色",
-      "github-dark": "GitHub 深色",
-      "github-light": "GitHub 浅色",
+      midnight: "东京夜色",
+      "deep-blue": "深蓝纯黑",
       "high-contrast": "高对比度（无障碍）",
     },
     reviewLabelTheme: "主题",


### PR DESCRIPTION
## Summary
Follow-up cleanup after #1666 — that PR renamed/dropped themes (`tokyo-night` → `midnight`, removed `default`/`github-dark`/`github-light`, added `deep-blue`) but missed three surfaces:

- `src/cli/ui/slash/commands.ts:97` — `/theme` slash command's `argsHint` and `argCompleter` still advertised the removed names and were missing `midnight` / `deep-blue`
- `src/i18n/EN.ts:450` and `src/i18n/zh-CN.ts:432` — `themeCaption` dicts still held entries for the removed themes and had **no labels for the new themes**, so the picker would render the literal i18n key (e.g. `wizard.themeCaption.midnight`) next to the new theme names

Drop the stale entries from both locales, add captions for `midnight` and `deep-blue`, and trim the slash command lists to the actual theme set.

## Test plan
- [x] `grep` confirms zero remaining references to removed theme names in `src/cli/ui/slash` and `src/i18n`
- [x] `npx tsc --noEmit`
- [x] `npx vitest run tests/slash.test.ts tests/theme-tokens.test.ts tests/config.test.ts` — 224 passed / 1 skipped
