### PR TITLE
fix(stats): carry totalCompletionTokens across resumes (#1667 follow-up)

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -230,6 +230,7 @@ export class CacheFirstLoop {
           turnCount: meta.turnCount,
           cacheHitTokens: meta.cacheHitTokens,
           cacheMissTokens: meta.cacheMissTokens,
+          totalCompletionTokens: meta.totalCompletionTokens,
           lastPromptTokens: meta.lastPromptTokens,
         });
       }
@@ -860,12 +861,11 @@ export class CacheFirstLoop {
         try {
           const last =
             this.stats.turns.length > 0 ? this.stats.turns[this.stats.turns.length - 1] : null;
-          const compTokens = this.stats.turns.reduce((sum, t) => sum + t.usage.completionTokens, 0);
           patchSessionMeta(this.sessionName, {
             totalCostUsd: this.stats.totalCost,
             cacheHitTokens: this.stats.cumulativeCacheHitTokens,
             cacheMissTokens: this.stats.cumulativeCacheMissTokens,
-            totalCompletionTokens: compTokens,
+            totalCompletionTokens: this.stats.cumulativeCompletionTokens,
             lastPromptTokens: last?.usage.promptTokens,
           });
         } catch {

--- a/src/telemetry/stats.ts
+++ b/src/telemetry/stats.ts
@@ -124,6 +124,7 @@ export class SessionStats {
   private _carryoverTurns = 0;
   private _carryoverCacheHit = 0;
   private _carryoverCacheMiss = 0;
+  private _carryoverCompletion = 0;
   /** Last turn's promptTokens before exit — surfaced via summary() until the next live turn lands. */
   private _carryoverLastPromptTokens = 0;
 
@@ -133,6 +134,7 @@ export class SessionStats {
     turnCount?: number;
     cacheHitTokens?: number;
     cacheMissTokens?: number;
+    totalCompletionTokens?: number;
     lastPromptTokens?: number;
   }): void {
     if (typeof opts.totalCostUsd === "number" && opts.totalCostUsd > 0) {
@@ -146,6 +148,9 @@ export class SessionStats {
     }
     if (typeof opts.cacheMissTokens === "number" && opts.cacheMissTokens > 0) {
       this._carryoverCacheMiss = opts.cacheMissTokens;
+    }
+    if (typeof opts.totalCompletionTokens === "number" && opts.totalCompletionTokens > 0) {
+      this._carryoverCompletion = opts.totalCompletionTokens;
     }
     if (typeof opts.lastPromptTokens === "number" && opts.lastPromptTokens > 0) {
       this._carryoverLastPromptTokens = opts.lastPromptTokens;
@@ -166,12 +171,20 @@ export class SessionStats {
     return miss;
   }
 
+  /** Cumulative completion (output) tokens across carryover + current turns. */
+  get cumulativeCompletionTokens(): number {
+    let comp = this._carryoverCompletion;
+    for (const t of this.turns) comp += t.usage.completionTokens;
+    return comp;
+  }
+
   reset(): void {
     this.turns.length = 0;
     this._carryoverCost = 0;
     this._carryoverTurns = 0;
     this._carryoverCacheHit = 0;
     this._carryoverCacheMiss = 0;
+    this._carryoverCompletion = 0;
     this._carryoverLastPromptTokens = 0;
   }
 
@@ -199,6 +212,7 @@ export class SessionStats {
       this._carryoverCost += t.cost;
       this._carryoverCacheHit += t.usage.promptCacheHitTokens;
       this._carryoverCacheMiss += t.usage.promptCacheMissTokens;
+      this._carryoverCompletion += t.usage.completionTokens;
     }
     this._carryoverTurns += excess;
   }

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -323,4 +323,23 @@ describe("SessionStats — issue #364 resume cache + context carryover", () => {
     expect(s.aggregateCacheHitRatio).toBe(0);
     expect(s.summary().lastPromptTokens).toBe(0);
   });
+
+  it("cumulativeCompletionTokens sums carryover + live turns so resume doesn't reset the counter", () => {
+    // Regression: #1667 persisted totalCompletionTokens but didn't seed it
+    // back into stats on resume, so the first patchSessionMeta after a
+    // restart overwrote the saved value with just the new turn's tally.
+    const s = new SessionStats();
+    s.seedCarryover({ totalCompletionTokens: 50_000 });
+    expect(s.cumulativeCompletionTokens).toBe(50_000);
+    s.record(1, "deepseek-chat", new Usage(2000, 500, 0, 0, 2000));
+    expect(s.cumulativeCompletionTokens).toBe(50_500);
+  });
+
+  it("seedCarryover ignores zero / negative totalCompletionTokens", () => {
+    const s = new SessionStats();
+    s.seedCarryover({ totalCompletionTokens: 0 });
+    expect(s.cumulativeCompletionTokens).toBe(0);
+    s.seedCarryover({ totalCompletionTokens: -1 });
+    expect(s.cumulativeCompletionTokens).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary
Follow-up to #1667. That PR persisted `totalCompletionTokens` to session meta after every turn, but the carryover plumbing in `SessionStats` was incomplete:

- `seedCarryover` (`src/loop.ts:227`) didn't read `meta.totalCompletionTokens`
- `SessionStats` had no `_carryoverCompletion` field
- the write call summed only `this.stats.turns` (no carryover term), and `trimOldTurns` (`src/telemetry/stats.ts:194`) dropped completion tokens into the void when older turns rolled off

Net effect: on every resume, the first turn's `patchSessionMeta` call **overwrote the previously-saved `totalCompletionTokens` with just the new turn's tally** — counter reset to ~0 across restarts. Cost / cache hit / miss don't have this problem because they each have proper carryover plumbing.

Currently zero user-visible impact since no UI reads the field yet, but the data was already flowing through `UsageStats` in both `dashboard/src/App.tsx:168` and `desktop/src/App.tsx:198`, so the next surface that exposes it would inherit the bug.

## Fix shape
Mirror the cacheHit / cacheMiss pattern exactly:
- New `_carryoverCompletion` field, seeded from `meta.totalCompletionTokens` in `seedCarryover`
- `cumulativeCompletionTokens` getter that returns carryover + sum of current turns
- `trimOldTurns` folds completion tokens into carryover when oldest turns roll off, matching the other counters
- `loop.ts` switches the `patchSessionMeta` write to use the new getter (so the persisted value always includes carryover and trimmed-turn contributions)

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx vitest run tests/telemetry.test.ts tests/loop.test.ts` — 99 passed / 1 skipped (added 2 cases: carryover sums + zero/negative input guard)
