### PR TITLE
feat(plan): wire editMode="plan" into the ToolRegistry dispatch gate

### DIFF
--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -14,7 +14,7 @@ import {
 } from "../../at-mentions.js";
 import { pickPrimaryBalance } from "../../client.js";
 import { codeSystemPrompt } from "../../code/prompt.js";
-import { buildCodeToolset } from "../../code/setup.js";
+import { applyPlanMode, buildCodeToolset } from "../../code/setup.js";
 import {
   DEFAULT_MODEL,
   type DesktopOpenTab,
@@ -559,12 +559,14 @@ function buildLoadedMessages(records: ChatMessage[]): LoadedMessage[] {
 
 function emitSettings(tab: Tab): void {
   const ep = loadEndpoint();
+  const editMode = loadEditMode();
+  if (tab.toolset) applyPlanMode(tab.toolset.tools, editMode);
   const recent = loadRecentWorkspaces().filter((p) => p !== tab.rootDir);
   emit(
     {
       type: "$settings",
       reasoningEffort: loadReasoningEffort(),
-      editMode: loadEditMode(),
+      editMode,
       budgetUsd: tab.runtime?.loop.budgetUsd ?? null,
       baseUrl: ep.baseUrl,
       apiKeyPrefix: ep.apiKey ? `${ep.apiKey.slice(0, 6)}…${ep.apiKey.slice(-3)}` : undefined,
@@ -781,6 +783,7 @@ function mintSessionFor(rootDir: string): string {
 function buildRuntimeFor(tab: Tab): RuntimeState {
   if (!tab.toolset) throw new Error("buildRuntimeFor called before initTabToolset finished");
   const toolset = tab.toolset;
+  applyPlanMode(toolset.tools, loadEditMode());
   const ep = loadEndpoint();
   const client = new DeepSeekClient({ apiKey: ep.apiKey, baseUrl: ep.baseUrl });
   const prefix = new ImmutablePrefix({ system: tab.system, toolSpecs: toolset.tools.specs() });
@@ -2217,7 +2220,10 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
           saveReasoningEffort(msg.reasoningEffort);
           tab.runtime?.loop.configure({ reasoningEffort: msg.reasoningEffort });
         }
-        if (msg.editMode !== undefined) saveEditMode(msg.editMode);
+        if (msg.editMode !== undefined) {
+          saveEditMode(msg.editMode);
+          if (tab.toolset) applyPlanMode(tab.toolset.tools, msg.editMode);
+        }
         if (msg.budgetUsd !== undefined) {
           tab.budgetUsd = msg.budgetUsd ?? undefined;
           tab.runtime?.loop.setBudget(msg.budgetUsd);

--- a/src/code/setup.ts
+++ b/src/code/setup.ts
@@ -1,5 +1,6 @@
 import { DeepSeekClient } from "../client.js";
 import {
+  type EditMode,
   loadEditMode,
   loadEndpoint,
   loadFilesystemOutlineThresholdBytes,
@@ -34,6 +35,8 @@ import { registerWebTools } from "../tools/web.js";
 
 export interface CodeToolsetOpts {
   rootDir: string;
+  /** Override the default `~/.reasonix/config.json` lookup — primarily for tests that pin a tmp config. */
+  configPath?: string;
   /** Fired after `install_skill` writes a new skill — desktop wires this to push a fresh `$skills` event so the sidebar updates without a tab reload. */
   onSkillInstalled?: SkillInstalledHook;
   /** Fired after `run_background` / `stop_job` mutate the JobRegistry — desktop pushes a fresh `$jobs` event so the popover updates without waiting for poll. */
@@ -50,8 +53,14 @@ export interface CodeToolset {
   semantic: { enabled: boolean };
 }
 
+/** Mirror `editMode === "plan"` into the registry's dispatch gate — keeps a single source of truth (the persisted EditMode) for the read-only mode. */
+export function applyPlanMode(tools: ToolRegistry, editMode: EditMode): void {
+  tools.setPlanMode(editMode === "plan");
+}
+
 export async function buildCodeToolset(opts: CodeToolsetOpts): Promise<CodeToolset> {
   const tools = new ToolRegistry({ rateLimit: loadToolRateLimit() });
+  applyPlanMode(tools, loadEditMode(opts.configPath));
   const jobs = new JobRegistry();
 
   const outlineThresholdBytes = loadFilesystemOutlineThresholdBytes();

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,8 +20,8 @@ import {
   normalizeToolRateLimitConfig,
 } from "./tools/rate-limit.js";
 
-/** Single trust dial: review queues edits + gates shell; auto applies + gates shell; yolo skips both gates. */
-export type EditMode = "review" | "auto" | "yolo";
+/** Single trust dial: review queues edits + gates shell; auto applies + gates shell; yolo skips both gates; plan blocks every non-readonly tool (write_file / edit_file / multi_edit / run_command) at dispatch. */
+export type EditMode = "review" | "auto" | "yolo" | "plan";
 
 export const DEFAULT_MODEL = "deepseek-v4-flash";
 
@@ -1073,7 +1073,7 @@ export function clearProjectPathAllowed(
 /** Unknown values fall back to "review" so hand-edited bad config gets the safe default. */
 export function loadEditMode(path: string = defaultConfigPath()): EditMode {
   const v = readConfig(path).editMode;
-  if (v === "auto" || v === "yolo") return v;
+  if (v === "auto" || v === "yolo" || v === "plan") return v;
   return "review";
 }
 

--- a/tests/code-setup-lazy-subagent.test.ts
+++ b/tests/code-setup-lazy-subagent.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -12,12 +12,14 @@ import { buildCodeToolset } from "../src/code/setup.js";
 describe("buildCodeToolset", () => {
   let savedKey: string | undefined;
   let tmpRoot: string;
+  let cfgPath: string;
 
   beforeEach(() => {
     savedKey = process.env.DEEPSEEK_API_KEY;
     // biome-ignore lint/performance/noDelete: setting to "undefined" string would mask test
     delete process.env.DEEPSEEK_API_KEY;
     tmpRoot = mkdtempSync(join(tmpdir(), "reasonix-code-setup-"));
+    cfgPath = join(tmpRoot, "config.json");
   });
 
   afterEach(async () => {
@@ -28,6 +30,17 @@ describe("buildCodeToolset", () => {
   it("builds without DEEPSEEK_API_KEY set", async () => {
     const toolset = await buildCodeToolset({ rootDir: tmpRoot });
     expect(toolset.tools.size).toBeGreaterThan(0);
+    await toolset.jobs.shutdown();
+  });
+
+  it("editMode=plan flips the registry's plan-mode gate so write tools refuse to dispatch", async () => {
+    writeFileSync(cfgPath, JSON.stringify({ editMode: "plan" }), "utf8");
+    const toolset = await buildCodeToolset({ rootDir: tmpRoot, configPath: cfgPath });
+    const out = await toolset.tools.dispatch(
+      "write_file",
+      JSON.stringify({ path: "new.txt", content: "hello" }),
+    );
+    expect(JSON.parse(out).error).toMatch(/unavailable in plan mode/i);
     await toolset.jobs.shutdown();
   });
 });


### PR DESCRIPTION
## Summary
`ToolRegistry.setPlanMode(true)` (`src/tools.ts:86`) already blocks every non-readonly tool at dispatch, but the only path that ever turned it on was the `/plan` slash command. Persisted `editMode = "plan"` (set via config edit or a settings UI that surfaces it) was previously inert — the registry's `_planMode` stayed `false` across boots, so the model could still call `write_file` / `edit_file` / `multi_edit` / `run_command`.

This change extends `EditMode` to include `"plan"` and mirrors the loaded mode into the registry whenever a toolset is constructed or the user toggles edit mode. Minimal foundation; the discoverability surface (settings UI / Shift+Tab cycle / i18n) can land separately when needed.

## Changes
- `src/config.ts` — `EditMode` gains `"plan"`; `loadEditMode` accepts it
- `src/code/setup.ts` — new `applyPlanMode(tools, editMode)` helper; `buildCodeToolset` calls it on init, threaded via new `configPath` option so tests can pin a tmp config
- `src/cli/commands/desktop.ts` — calls `applyPlanMode` in `emitSettings`, `buildRuntimeFor`, and the `settings_save` editMode branch so changes take effect live
- `tests/code-setup-lazy-subagent.test.ts` — regression: `editMode: "plan"` in config blocks `write_file` dispatch with the `unavailable in plan mode` error

## Supersedes #1668
That PR opened before #1657 (preset abstraction drop) and ended up CONFLICTING + bundling 29 files / +445 lines including stale preset-cleanup that was already done on main and a UI surface (4-stop edit-mode cycle, composer button, 3-locale i18n) that's a larger design decision. Took the genuinely valuable core (dispatch-gate wiring + regression test) and shipped it standalone; co-authored credit preserved.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx vitest run tests/code-setup-lazy-subagent.test.ts tests/config.test.ts` — 88 passed / 1 skipped (new case proves the gate engages on config-set plan mode)
