### PR TITLE
fix(ui): throttle streaming/reasoning chunks to reduce flicker

### DIFF
--- a/src/cli/ui/hooks/useScrollback.ts
+++ b/src/cli/ui/hooks/useScrollback.ts
@@ -1,6 +1,9 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import type { DoctorCheckEntry, PlanStep, TipSection } from "../state/cards.js";
 import { useDispatch } from "../state/provider.js";
+
+/** Throttle interval for streaming/reasoning chunk dispatches (~30fps). */
+const THROTTLE_MS = 33;
 
 let seq = 0;
 function nextId(prefix: string): string {
@@ -102,6 +105,39 @@ export interface Scrollback {
 
 export function useScrollback(): Scrollback {
   const dispatch = useDispatch();
+
+  // Throttle state for reasoning and streaming chunks
+  const reasoningBufferRef = useRef<Map<string, string>>(new Map());
+  const reasoningTimerRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+  const streamingBufferRef = useRef<Map<string, string>>(new Map());
+  const streamingTimerRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+  // Cleanup on unmount - flush all buffers
+  useEffect(() => {
+    return () => {
+      for (const [id] of reasoningBufferRef.current) {
+        const buffered = reasoningBufferRef.current.get(id);
+        if (buffered && buffered.length > 0) {
+          dispatch({ type: "reasoning.chunk", id, text: buffered });
+        }
+        const timer = reasoningTimerRef.current.get(id);
+        if (timer) clearTimeout(timer);
+      }
+      reasoningBufferRef.current.clear();
+      reasoningTimerRef.current.clear();
+
+      for (const [id] of streamingBufferRef.current) {
+        const buffered = streamingBufferRef.current.get(id);
+        if (buffered && buffered.length > 0) {
+          dispatch({ type: "streaming.chunk", id, text: buffered });
+        }
+        const timer = streamingTimerRef.current.get(id);
+        if (timer) clearTimeout(timer);
+      }
+      streamingBufferRef.current.clear();
+      streamingTimerRef.current.clear();
+    };
+  }, [dispatch]);
 
   return useMemo<Scrollback>(
     () => ({
@@ -255,9 +291,32 @@ export function useScrollback(): Scrollback {
         return id;
       },
       appendReasoning(id, chunk) {
-        if (chunk.length > 0) dispatch({ type: "reasoning.chunk", id, text: chunk });
+        if (chunk.length === 0) return;
+        // Buffer tokens and throttle dispatch to reduce flicker
+        const current = reasoningBufferRef.current.get(id) ?? "";
+        reasoningBufferRef.current.set(id, current + chunk);
+        if (!reasoningTimerRef.current.has(id)) {
+          const timer = setTimeout(() => {
+            const buffered = reasoningBufferRef.current.get(id);
+            if (buffered && buffered.length > 0) {
+              dispatch({ type: "reasoning.chunk", id, text: buffered });
+              reasoningBufferRef.current.delete(id);
+            }
+            reasoningTimerRef.current.delete(id);
+          }, THROTTLE_MS);
+          reasoningTimerRef.current.set(id, timer);
+        }
       },
       endReasoning(id, paragraphs, tokens, aborted) {
+        // Flush buffer before ending to ensure all tokens are dispatched
+        const buffered = reasoningBufferRef.current.get(id);
+        if (buffered && buffered.length > 0) {
+          dispatch({ type: "reasoning.chunk", id, text: buffered });
+          reasoningBufferRef.current.delete(id);
+        }
+        const timer = reasoningTimerRef.current.get(id);
+        if (timer) clearTimeout(timer);
+        reasoningTimerRef.current.delete(id);
         dispatch({ type: "reasoning.end", id, paragraphs, tokens, aborted });
       },
       startStreaming(model) {
@@ -266,9 +325,32 @@ export function useScrollback(): Scrollback {
         return id;
       },
       appendStreaming(id, chunk) {
-        if (chunk.length > 0) dispatch({ type: "streaming.chunk", id, text: chunk });
+        if (chunk.length === 0) return;
+        // Buffer tokens and throttle dispatch to reduce flicker
+        const current = streamingBufferRef.current.get(id) ?? "";
+        streamingBufferRef.current.set(id, current + chunk);
+        if (!streamingTimerRef.current.has(id)) {
+          const timer = setTimeout(() => {
+            const buffered = streamingBufferRef.current.get(id);
+            if (buffered && buffered.length > 0) {
+              dispatch({ type: "streaming.chunk", id, text: buffered });
+              streamingBufferRef.current.delete(id);
+            }
+            streamingTimerRef.current.delete(id);
+          }, THROTTLE_MS);
+          streamingTimerRef.current.set(id, timer);
+        }
       },
       endStreaming(id, aborted) {
+        // Flush buffer before ending to ensure all tokens are dispatched
+        const buffered = streamingBufferRef.current.get(id);
+        if (buffered && buffered.length > 0) {
+          dispatch({ type: "streaming.chunk", id, text: buffered });
+          streamingBufferRef.current.delete(id);
+        }
+        const timer = streamingTimerRef.current.get(id);
+        if (timer) clearTimeout(timer);
+        streamingTimerRef.current.delete(id);
         dispatch({ type: "streaming.end", id, aborted });
       },
       startTool(name, args, presetId) {


### PR DESCRIPTION
## Problem

In the terminal CLI, reasoning content flickers violently during streaming. This issue affects both Windows Terminal (WSL2 + PowerShell) and macOS Terminal.

### Root Cause

When `reasoning_content` streams in via SSE, each token arrival triggers:
1. `reasoning.chunk` event dispatched to reducer
2. State update: `text: c.text + event.text`
3. React reconciliation triggered via `useSyncExternalStore`
4. Ink redraws entire ANSI output
5. High-frequency tokens (~30-60/sec) cause per-frame flicker

### Current Flow

```
Token arrives → dispatch("reasoning.chunk") → state update → React reconcile → Ink redraw
```

## Solution: Throttle (33ms)

Change token dispatch from "send immediately per token" to "batch every 33ms" (~30fps):

```
Current: Token arrives → immediate dispatch → redraw (~30-60fps, flickers)
Fixed:   Token arrives → buffer → 33ms throttle → batch dispatch → redraw (~30fps, smooth)
```

### Implementation

Modified `src/cli/ui/hooks/useScrollback.ts`:

1. **Token Buffering**: Added `reasoningBufferRef` and `streamingBufferRef` to accumulate tokens
2. **Throttle Timer**: Added `reasoningTimerRef` and `streamingTimerRef` for 33ms intervals
3. **Buffered Dispatch**: `appendReasoning()` and `appendStreaming()` now buffer tokens instead of dispatching immediately
4. **Immediate Flush on End**: `endReasoning()` and `endStreaming()` flush buffers before ending
5. **Cleanup on Unmount**: `useEffect` cleanup ensures no tokens are lost if component unmounts

### Why Throttle over Debounce

| Feature | Debounce | Throttle |
|---------|----------|----------|
| Update frequency | Inconsistent (waits for silence) | Consistent (fixed intervals) |
| Token loss | Possible (during bursts) | None (flushes each interval) |
| User experience | Jerky, discontinuous | Smooth, continuous |

## Files Changed

- `src/cli/ui/hooks/useScrollback.ts` — Added throttle logic for streaming/reasoning chunks

## Testing

- ✅ Lint passed
- ✅ Typecheck passed
- ✅ All 3596 tests passed

## Platforms Tested

- Windows Terminal (WSL2 + PowerShell)
- macOS Terminal

## Impact

This fix reduces the render frequency from ~30-60fps to ~30fps during high-speed streaming, eliminating the violent flicker. The throttle provides consistent, smooth rendering without the inconsistency of debounce.

**Note**: This is an optimization, not a root cause fix. The root cause is Ink's rendering model (full redraw on every state change). Complete elimination would require modifying Ink to support diff-based rendering.

Fixes #1626
