### PR TITLE
fix(desktop): Esc closes the open modal instead of aborting the model

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -1661,13 +1661,25 @@ function TabRuntime({
       } else if (e.key === "Escape" && state.busy) {
         const target = e.target as HTMLElement | null;
         if (target?.tagName === "INPUT" || target?.tagName === "TEXTAREA") return;
+        // A modal is open — let its own Esc handler close it (#1670).
+        if (settingsOpen || aboutOpen || jobsOpen || wdOpen) return;
         e.preventDefault();
         abort();
       }
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [active, state.busy, abort, newChat, settingsOpen, openSettingsAt]);
+  }, [
+    active,
+    state.busy,
+    abort,
+    newChat,
+    settingsOpen,
+    aboutOpen,
+    jobsOpen,
+    wdOpen,
+    openSettingsAt,
+  ]);
 
   const commands = buildCommands({
     newChat: () => {

--- a/desktop/src/ui/about.tsx
+++ b/desktop/src/ui/about.tsx
@@ -1,6 +1,6 @@
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { check as checkUpdate } from "@tauri-apps/plugin-updater";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { t } from "../i18n";
 import { I } from "../icons";
 
@@ -15,6 +15,16 @@ type CheckState =
   | { kind: "error"; message: string };
 
 export function AboutModal({ onClose }: { onClose: () => void }) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
   const [check, setCheck] = useState<CheckState>({ kind: "idle" });
 
   const openGitHub = useCallback(() => {

--- a/desktop/src/ui/settings.tsx
+++ b/desktop/src/ui/settings.tsx
@@ -108,6 +108,16 @@ export function SettingsModal({
 }) {
   const [page, setPage] = useState<PageId>(initialPage ?? "general");
   const [qqConfigureOpen, setQQConfigureOpen] = useState(false);
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
   const currentMeta = PAGE_META.find((p) => p.id === page) ?? PAGE_META[0]!;
   return (
     <div className="settings-mask" onClick={onClose}>

--- a/desktop/src/ui/sidebar.tsx
+++ b/desktop/src/ui/sidebar.tsx
@@ -170,13 +170,22 @@ export function Sidebar({
                 className="session-item"
                 data-active={active}
                 data-editing={editing || undefined}
-                onClick={editing ? undefined : () => onLoadSession(s.name)}
+                onClick={
+                  editing
+                    ? undefined
+                    : () => {
+                        // Skip the round-trip when clicking the already-loaded
+                        // session — a reload would clear live in-turn state (#1653).
+                        if (s.name === activeName) return;
+                        onLoadSession(s.name);
+                      }
+                }
                 role={editing ? undefined : "button"}
                 tabIndex={editing ? -1 : 0}
                 title={s.name}
                 onKeyDown={(e) => {
                   if (editing) return;
-                  if (e.key === "Enter") onLoadSession(s.name);
+                  if (e.key === "Enter" && s.name !== activeName) onLoadSession(s.name);
                 }}
               >
                 <span


### PR DESCRIPTION
## Summary
Two related papercuts in the desktop client:

1. **Esc during streaming with a modal open used to fire `abort()`** and leave the modal sitting on screen. Now the global Esc handler bails out when any of `settingsOpen` / `aboutOpen` / `jobsOpen` / `wdOpen` is set; `SettingsModal` and `AboutModal` each install their own `keydown` listener that calls `onClose()`. `JobsPop` and `WorkdirPop` already had their own handlers, so this just rounds out the set.
2. **Clicking (or Enter-ing) the already-active session in the sidebar** used to round-trip a `session_load` and clear live in-turn state (issue #1653). Skip the dispatch when `s.name === activeName`.

## Supersedes #1670
Took the focused fix from #1670 (4 files / 45 lines) and ported it on top of current main. The original PR was based on a pre-#1657 / pre-#1666 / pre-#1667 commit and would have silently rolled back the preset drop, the 4-option reasoning-effort, and the `totalCompletionTokens` carryover when squash-merged (`MERGEABLE` masked the conflict). Co-authored credit preserved.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx vitest run desktop/src/App.test.ts tests/desktop-btw-status.test.ts` — 12 passed
- [ ] Manual: open settings during streaming → Esc closes the modal (no abort)
- [ ] Manual: click the active session in sidebar mid-turn → no reload, live state intact
