### PR TITLE
fix(diff): SplitDiff renders CJK without misaligning the column border

### DIFF
--- a/src/cli/ui/SplitDiff.tsx
+++ b/src/cli/ui/SplitDiff.tsx
@@ -22,6 +22,7 @@ import { Box, Text, useStdout } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for React.Fragment
 import React from "react";
 import type { SplitDiffRow } from "../../code/diff-preview.js";
+import { clipToCells, padToCells } from "./text-width.js";
 import { COLOR } from "./theme.js";
 
 export interface SplitDiffProps {
@@ -72,12 +73,11 @@ function Cell({
   const sign =
     side.kind === "del" ? "-" : side.kind === "add" ? "+" : side.kind === "pad" ? " " : " ";
   const raw = side.text;
-  const truncated = raw.length > inner ? `${raw.slice(0, inner - 1)}…` : raw;
-  // Pad to fixed width so the bg color stretches across the whole
-  // column even when the text is short — without this the red/green
-  // wash would only cover the actual chars and the rest of the row
-  // would be terminal default, which looks broken.
-  const padded = truncated.padEnd(inner);
+  // clipToCells / padToCells count visual cells, so CJK + emoji rows
+  // neither overflow (raw.length undercounts wide chars at the cut) nor
+  // get over-padded (padEnd pads by string length, not cells) — both
+  // would knock the column border out of alignment (#1671).
+  const padded = padToCells(clipToCells(raw, inner), inner);
 
   if (side.kind === "del") {
     return (

--- a/src/cli/ui/markdown.tsx
+++ b/src/cli/ui/markdown.tsx
@@ -6,7 +6,7 @@ import { type Token, type Tokens, marked } from "marked";
 import React from "react";
 import stringWidth from "string-width";
 import { decodeHtmlEntities } from "./html-entities.js";
-import { wrapToCells } from "./text-width.js";
+import { padToCells, wrapToCells } from "./text-width.js";
 import { FG, SURFACE, TONE } from "./theme/tokens.js";
 
 /** Left margin consumed by card outer marginLeft + body paddingLeft + safety. */
@@ -187,13 +187,6 @@ function Blockquote({ token }: { token: Tokens.Blockquote }): React.ReactElement
       ))}
     </Box>
   );
-}
-
-/** Right-pad to `cells` visual columns — wide chars (CJK, emoji) count as 2. */
-function padToCells(text: string, cells: number): string {
-  const w = stringWidth(text);
-  if (w >= cells) return text;
-  return text + " ".repeat(cells - w);
 }
 
 function HorizontalRule(): React.ReactElement {

--- a/src/cli/ui/text-width.ts
+++ b/src/cli/ui/text-width.ts
@@ -21,6 +21,13 @@ export function stringWidth(s: string): number {
   return stringWidthLib(s);
 }
 
+/** Right-pad to `cells` visual columns — wide chars (CJK, emoji) count as 2. `padEnd` would pad by string length, which under-pads CJK because it counts each wide char as 1. */
+export function padToCells(text: string, cells: number): string {
+  const w = stringWidthLib(text);
+  if (w >= cells) return text;
+  return text + " ".repeat(cells - w);
+}
+
 /** Clip to `maxCells` visual cells; appends `…` if cut. Grapheme-safe. */
 export function clipToCells(s: string, maxCells: number): string {
   if (maxCells <= 0) return "";

--- a/tests/text-width.test.ts
+++ b/tests/text-width.test.ts
@@ -3,6 +3,7 @@ import {
   clipToCells,
   graphemeWidth,
   graphemes,
+  padToCells,
   stringWidth,
   wrapToCells,
 } from "../src/cli/ui/text-width.js";
@@ -74,6 +75,22 @@ describe("clipToCells", () => {
   });
   it("returns empty string at zero cap", () => {
     expect(clipToCells("anything", 0)).toBe("");
+  });
+});
+
+describe("padToCells", () => {
+  it("right-pads to the requested cell width for ASCII", () => {
+    expect(padToCells("hi", 6)).toBe("hi    ");
+    expect(stringWidth(padToCells("hi", 6))).toBe(6);
+  });
+  it("counts CJK as 2 cells when padding — padEnd would over-pad these", () => {
+    // "你好" = 2 chars, 4 cells. Need 2 spaces (not 8) to reach 6 cells.
+    expect(padToCells("你好", 6)).toBe("你好  ");
+    expect(stringWidth(padToCells("你好", 6))).toBe(6);
+  });
+  it("returns the input untouched when it already fills or exceeds the cells", () => {
+    expect(padToCells("hello", 5)).toBe("hello");
+    expect(padToCells("一二三", 4)).toBe("一二三"); // 6 cells > 4 → no pad, no trim
   });
 });
 


### PR DESCRIPTION
## Summary
Two bugs in the same `Cell` body of `SplitDiff.tsx` that misalign the diff column border when CJK / emoji are present (#1671):

- **Truncation** used `raw.length > inner`, which undercounts wide chars — a CJK row that was visually too wide slipped past the check and overflowed into the gutter
- **Padding** used `padEnd(inner)`, which counts string length not visual cells — short CJK content got padded as if each wide char were 1 cell, so the red/green background stripe ran past the column edge

Repo already has `clipToCells(s, maxCells)` (cell-aware truncation + ellipsis) in `src/cli/ui/text-width.ts`, and a private `padToCells(text, cells)` (cell-aware right-pad) in `src/cli/ui/markdown.tsx`. Promoted `padToCells` to `text-width.ts` so `SplitDiff` can use both; the four lines around `truncated` collapse to `padToCells(clipToCells(raw, inner), inner)`.

## Supersedes #1683
That PR fixed the detection half (`stringWidth(raw) > inner`) but left both the JS-char `raw.slice(0, inner - 1)` cut and the `padEnd(inner)` pad in place. For CJK content the truncated string came out wider than `inner` cells, and short CJK rows still over-padded — the border was still misaligned, just for slightly different inputs. Co-authored credit preserved.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx vitest run tests/text-width.test.ts` — 22 passed (was 19; added a `padToCells` describe block covering ASCII pad, CJK pad without over-padding, and the no-op-when-full case)
- [x] `npx vitest run tests/markdown` — 28 passed (sanity-check the `padToCells` extraction from markdown.tsx)
