### PR TITLE
fix(desktop): discard explicitly aborted turns

### DIFF
--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -1490,9 +1490,9 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
     return undefined;
   }
 
-  function abortTurn(tab: Tab): void {
+  function abortTurn(tab: Tab, opts: { discardCurrentTurn?: boolean } = {}): void {
     tab.aborter?.abort();
-    tab.runtime?.loop.abort();
+    tab.runtime?.loop.abort(opts.discardCurrentTurn ? { discardCurrentTurn: true } : undefined);
   }
 
   function tabSessionLabel(tab: Tab): string {
@@ -2049,7 +2049,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
     }
 
     if (msg.cmd === "abort") {
-      abortTurn(tab);
+      abortTurn(tab, { discardCurrentTurn: true });
       cancelPendingGates(tab);
       return;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ export type {
 } from "./at-mentions.js";
 export type {
   CacheFirstLoopOptions,
+  LoopAbortOptions,
   LoopEvent,
   EventRole,
   ReconfigurableOptions,

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -101,6 +101,11 @@ export interface ReconfigurableOptions {
   reasoningEffort?: ReasoningEffort;
 }
 
+export interface LoopAbortOptions {
+  /** Explicit user interrupts can discard the unfinished turn so the next prompt starts clean. */
+  discardCurrentTurn?: boolean;
+}
+
 export class CacheFirstLoop {
   readonly client: DeepSeekClient;
   readonly prefix: ImmutablePrefix;
@@ -137,6 +142,7 @@ export class CacheFirstLoop {
   private _streamPreference: boolean;
   /** Threaded through HTTP + every tool dispatch so Esc cancels in-flight work, not after. */
   private _turnAbort: AbortController = new AbortController();
+  private _discardAbortRequested = false;
   /** Authoritative running-id set — UI cards consult this instead of trusting end-event delivery. Insert at dispatch entry, delete in finally. */
   private readonly _inflight = new InflightSet();
 
@@ -496,8 +502,26 @@ export class CacheFirstLoop {
     return healed.messages;
   }
 
-  abort(): void {
+  abort(opts: LoopAbortOptions = {}): void {
+    if (opts.discardCurrentTurn) this._discardAbortRequested = true;
     this._turnAbort.abort();
+  }
+
+  private resetAbortState(): void {
+    this._turnAbort = new AbortController();
+    this._discardAbortRequested = false;
+  }
+
+  private discardLogFrom(index: number): void {
+    const preserved = this.log.entries.slice(0, index).map((m) => ({ ...m }));
+    this.log.compactInPlace(preserved);
+    if (this.sessionName) {
+      try {
+        rewriteSession(this.sessionName, preserved);
+      } catch {
+        /* disk-full / perms — in-memory compaction still applies */
+      }
+    }
   }
 
   /** Drop the last user message + everything after; caller re-sends. Persists to session file. */
@@ -620,6 +644,7 @@ export class CacheFirstLoop {
     // when the user navigates away before the model responds). A failed
     // first round-trip still leaves the message in the log; the user can
     // /retry without re-typing.
+    const turnStartLogIndex = this.log.length;
     this.appendAndPersist({ role: "user", content: userInput });
     const toolSpecs = this.prefix.tools();
     let rateLimitWarningShown = false;
@@ -666,9 +691,15 @@ export class CacheFirstLoop {
         // Without finally the reset is lost and carryAbort locks every
         // future step() at iter 0.
         try {
-          const stoppedMsg =
-            "[aborted by user (Esc) — no summary produced. Ask again or /retry when ready; prior tool output is still in the log.]";
-          this.appendAndPersist(buildSyntheticAssistantMessage(stoppedMsg, this.model));
+          const discardTurn = this._discardAbortRequested;
+          const stoppedMsg = discardTurn
+            ? "[aborted by user (Esc) — interrupted turn discarded. Ask again when ready.]"
+            : "[aborted by user (Esc) — no summary produced. Ask again or /retry when ready; prior tool output is still in the log.]";
+          if (discardTurn) {
+            this.discardLogFrom(turnStartLogIndex);
+          } else {
+            this.appendAndPersist(buildSyntheticAssistantMessage(stoppedMsg, this.model));
+          }
           yield {
             turn: this._turn,
             role: "assistant_final",
@@ -677,7 +708,7 @@ export class CacheFirstLoop {
           };
           yield { turn: this._turn, role: "done", content: stoppedMsg };
         } finally {
-          this._turnAbort = new AbortController();
+          this.resetAbortState();
         }
         this._steerQueue.length = 0;
         return;
@@ -833,10 +864,11 @@ export class CacheFirstLoop {
           // if the consumer breaks the for-await before draining `done`,
           // generator.return() would skip a bare post-yield reset and
           // leave carryAbort locked on the next step().
+          if (this._discardAbortRequested) this.discardLogFrom(turnStartLogIndex);
           try {
             yield { turn: this._turn, role: "done", content: "" };
           } finally {
-            this._turnAbort = new AbortController();
+            this.resetAbortState();
           }
           this._steerQueue.length = 0;
           return;

--- a/tests/loop-user-persist.test.ts
+++ b/tests/loop-user-persist.test.ts
@@ -163,4 +163,65 @@ describe("loop persists user message at step entry (issue #943)", () => {
       ),
     ).toBe(false);
   });
+
+  it("can discard an explicitly aborted prompt before the next request (#1593)", async () => {
+    const requestMessages: ChatMessage[][] = [];
+    let callCount = 0;
+    const client = new DeepSeekClient({
+      apiKey: "sk-test",
+      fetch: vi.fn(
+        async (_url: unknown, init: { body?: string; signal?: AbortSignal } | undefined) => {
+          const body = init?.body ? JSON.parse(init.body) : {};
+          requestMessages.push(body.messages as ChatMessage[]);
+          if (callCount++ === 0) {
+            return new Promise<Response>((_resolve, reject) => {
+              init?.signal?.addEventListener("abort", () =>
+                reject(new DOMException("This operation was aborted", "AbortError")),
+              );
+            });
+          }
+          return new Response(
+            JSON.stringify({
+              choices: [
+                {
+                  index: 0,
+                  message: { role: "assistant", content: "rewritten" },
+                  finish_reason: "stop",
+                },
+              ],
+              usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        },
+      ) as unknown as typeof fetch,
+      retry: { maxAttempts: 1 },
+    });
+
+    const sessionName = "bug1593-discard-explicit-abort";
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s" }),
+      stream: false,
+      session: sessionName,
+    });
+
+    const interrupted = (async () => {
+      for await (const ev of loop.step("完全重写这段一万字符结构化文本")) {
+        if (ev.role === "done") break;
+      }
+    })();
+
+    await new Promise((r) => setTimeout(r, 10));
+    loop.abort({ discardCurrentTurn: true });
+    await interrupted;
+
+    await loop.run("请按这次要求完整重写，不要局部微调");
+
+    const secondRequestUsers = requestMessages[1]!
+      .filter((m) => m.role === "user")
+      .map((m) => m.content);
+    expect(secondRequestUsers).toEqual(["请按这次要求完整重写，不要局部微调"]);
+    expect(loadSessionMessages(sessionName).filter((m) => m.role === "user")).toHaveLength(1);
+  });
 });

--- a/tests/public-api.test.ts
+++ b/tests/public-api.test.ts
@@ -110,6 +110,7 @@ const PUBLIC_API: readonly string[] = [
   "ListResourcesResult",
   "ListToolsResult",
   "LoadHookSettingsOptions",
+  "LoopAbortOptions",
   "LoopEvent",
   "MCP_PROTOCOL_VERSION",
   "MEMORY_INDEX_FILE",


### PR DESCRIPTION
## Summary
- Adds an explicit abort mode that discards the unfinished user turn from the model-facing log.
- Uses that mode for the desktop Abort action so a re-sent long edit request starts from the new prompt instead of also carrying the interrupted one.
- Adds #1593 regression coverage proving the next request contains only the fresh rewrite instruction.

## Root Cause
Desktop explicit aborts used the same loop abort behavior as session switches. The loop persists the user prompt before the first API call so interrupted sessions remain visible, but for a user-initiated Abort that left the abandoned long edit prompt in history. The next request could then include both the stale interrupted task and the new prompt, making the model treat the user as repeatedly interrupting or narrowing the work.

Fixes #1593

## Validation
- `npm test -- --run tests/loop-user-persist.test.ts tests/loop.test.ts tests/desktop-crash-guards.test.ts`
- `npm test -- --run tests/public-api.test.ts tests/loop-user-persist.test.ts`
- `npx biome check src/loop.ts src/index.ts src/cli/commands/desktop.ts tests/loop-user-persist.test.ts`
- `npm run typecheck`
- pre-push `npm run verify`: 262 test files passed; 3610 tests passed; 12 skipped. Biome reported two existing unused-suppression warnings outside this change.
