### PR TITLE
fix(dashboard): ignore IME confirm enter

### DIFF
--- a/dashboard/src/ui/composer.tsx
+++ b/dashboard/src/ui/composer.tsx
@@ -171,6 +171,9 @@ export function Composer({
   const [modelMenuOpen, setModelMenuOpen] = useState(false);
   const nonceRef = useRef(0);
   const modelWrapRef = useRef<HTMLDivElement>(null);
+  // macOS Chinese IME fires compositionend before the confirm keydown.
+  const composingRef = useRef(false);
+  const compositionEndedAtRef = useRef(0);
 
   // Programmatic draft transitions to "/" (e.g. /help suggestion in EmptyState, #929) must open the slash popup, since handleChange only fires on actual user input.
   const prevDraftRef = useRef(draft);
@@ -374,6 +377,7 @@ export function Composer({
         dismiss();
       }
     }
+    if (composingRef.current || Date.now() - compositionEndedAtRef.current < 50) return;
     if (e.key === "Enter" && !e.shiftKey && !popup) {
       e.preventDefault();
       if (busy) {
@@ -476,6 +480,13 @@ export function Composer({
             placeholder={t("composer.placeholder")}
             onChange={handleChange}
             onKeyDown={handleKeyDown}
+            onCompositionStart={() => {
+              composingRef.current = true;
+            }}
+            onCompositionEnd={() => {
+              composingRef.current = false;
+              compositionEndedAtRef.current = Date.now();
+            }}
             rows={2}
             disabled={disabled}
           />

--- a/tests/dashboard-composer-ime.test.tsx
+++ b/tests/dashboard-composer-ime.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+// biome-ignore lint/style/useImportType: The TSX transform needs React in scope.
+import React, { useRef, useState } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  open: vi.fn(),
+}));
+
+import { Composer } from "../dashboard/src/ui/composer";
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderComposer(props: Partial<React.ComponentProps<typeof Composer>> = {}) {
+  const onSend = props.onSend ?? vi.fn();
+  const onQueueWhileBusy = props.onQueueWhileBusy ?? vi.fn();
+
+  function Harness() {
+    const [draft, setDraft] = useState(props.draft ?? "ni");
+    const textareaRef = useRef<HTMLTextAreaElement>(null);
+    return (
+      <Composer
+        draft={draft}
+        setDraft={setDraft}
+        onSend={onSend}
+        onAbort={props.onAbort ?? vi.fn()}
+        disabled={props.disabled}
+        busy={props.busy}
+        busyLabel={props.busyLabel}
+        busyElapsedMs={props.busyElapsedMs}
+        modelLabel={props.modelLabel ?? "deepseek-v4-flash"}
+        reasoningEffort={props.reasoningEffort ?? "high"}
+        onModelChange={props.onModelChange ?? vi.fn()}
+        onEffortChange={props.onEffortChange ?? vi.fn()}
+        editMode={props.editMode ?? "review"}
+        onEditModeChange={props.onEditModeChange ?? vi.fn()}
+        textareaRef={textareaRef}
+        slashCommands={props.slashCommands ?? []}
+        onMentionQuery={props.onMentionQuery}
+        onMentionPreview={props.onMentionPreview}
+        onMentionPicked={props.onMentionPicked}
+        mentionResults={props.mentionResults}
+        workspaceDir={props.workspaceDir}
+        queuedSends={props.queuedSends}
+        onQueueWhileBusy={onQueueWhileBusy}
+        onDequeueSend={props.onDequeueSend}
+      />
+    );
+  }
+
+  render(<Harness />);
+  return {
+    textarea: screen.getByPlaceholderText(/Type a prompt|输入提示词/) as HTMLTextAreaElement,
+    onSend,
+    onQueueWhileBusy,
+  };
+}
+
+describe("dashboard Composer IME handling (#1669)", () => {
+  it("does not send when Enter confirms an IME composition", () => {
+    const { textarea, onSend } = renderComposer();
+
+    fireEvent.compositionStart(textarea);
+    fireEvent.compositionEnd(textarea);
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("still sends on a normal Enter outside composition", () => {
+    const { textarea, onSend } = renderComposer();
+
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(onSend).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Mirror the desktop IME composition guard in the dashboard composer.
- Prevent the Enter key that confirms Chinese IME input from submitting the draft.
- Add regression coverage for the post-composition Enter path while keeping normal Enter send behavior.

## Root Cause
The desktop composer already tracks composition start/end and ignores the keydown that immediately follows compositionend on macOS. The dashboard composer lacked that guard, so the Enter key used to commit Pinyin could be handled as the submit shortcut.

Fixes #1669

## Validation
- npm test -- --run tests/dashboard-composer-ime.test.tsx
- npm run lint
- npm run typecheck
- npm run build:dashboard
- npm run verify