### PR TITLE
feat(desktop): show collapsible file-change summary after each assistant turn

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -76,6 +76,7 @@ import {
   UserMsg,
 } from "./ui/thread";
 import { WorkdirPop } from "./ui/workdir-pop";
+import { parseEditResult } from "./ui/cards";
 import { useAutoCollapse } from "./ui/useAutoCollapse";
 import { useAutoScroll } from "./ui/useAutoScroll";
 import { useDisableTextAssist } from "./ui/useDisableTextAssist";
@@ -520,6 +521,83 @@ export function reduce(state: State, action: Action): State {
 
 const READING_TOOLS = new Set(["read_file"]);
 const MODIFYING_TOOLS = new Set(["edit_file", "write_file"]);
+
+type FileStat = { filename: string; added: number; removed: number };
+type FileStats = { entries: FileStat[]; totalAdded: number; totalRemoved: number };
+
+function countFileStats(segments: AssistantSegment[]): FileStats | null {
+  const entries: FileStat[] = [];
+  for (const s of segments) {
+    if (s.kind !== "tool" || !s.result || s.ok === false) continue;
+    if (s.name === "edit_file" || s.name === "multi_edit") {
+      for (const f of parseEditResult(s.result)) {
+        let added = 0;
+        let removed = 0;
+        for (const ln of f.lines) {
+          if (ln.t === "add") added++;
+          else if (ln.t === "rm") removed++;
+        }
+        entries.push({ filename: f.filename, added, removed });
+      }
+    } else if (s.name === "write_file") {
+      let lines = 0;
+      try {
+        const parsed = JSON.parse(s.args);
+        if (typeof parsed.content === "string") {
+          lines = parsed.content.split("\n").length;
+        }
+      } catch {
+        /* args unparseable */
+      }
+      let filename = "";
+      try {
+        filename = JSON.parse(s.args)?.path ?? "";
+      } catch {
+        /* ignore */
+      }
+      entries.push({ filename, added: lines, removed: 0 });
+    }
+  }
+  if (entries.length === 0) return null;
+  const totalAdded = entries.reduce((s, e) => s + e.added, 0);
+  const totalRemoved = entries.reduce((s, e) => s + e.removed, 0);
+  return { entries, totalAdded, totalRemoved };
+}
+
+function DiffStats({ stats }: { stats: FileStats }) {
+  const [open, setOpen] = useState(false);
+  const total = stats.entries.length;
+  return (
+    <div className="diff-stats">
+      <button
+        type="button"
+        className="diff-stats-head"
+        onClick={() => setOpen((v) => !v)}
+      >
+        <span className="ico">
+          <I.diff size={11} />
+        </span>
+        <span>
+          {total} {total === 1 ? "file" : "files"} changed · +{stats.totalAdded} / −{stats.totalRemoved} {stats.totalRemoved === 1 ? "line" : "lines"}
+        </span>
+        <span className="chev">{open ? <I.chev size={10} /> : <I.chevR size={10} />}</span>
+      </button>
+      {open ? (
+        <div className="diff-stats-body">
+          {stats.entries.map((e) => (
+            <div key={e.filename} className="diff-stats-row">
+              <span className="fn">{e.filename}</span>
+              <span className="counts">
+                <span className="add">+{e.added}</span>
+                {e.removed > 0 ? <span className="rm"> / −{e.removed}</span> : null}
+              </span>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
 
 function extractToolFiles(name: string, args: string): SessionFile[] {
   try {
@@ -2011,17 +2089,20 @@ function TabRuntime({
                       );
                     }
                     if (m.kind === "assistant") {
+                      const stats = !m.pending ? countFileStats(m.segments) : null;
                       return (
-                        <AssistantMsg
-                          key={`a-${m.turn}`}
-                          segments={m.segments}
-                          pending={m.pending}
-                          model={state.model}
-                          onApproveConfirm={onApproveConfirm}
-                          onRejectConfirm={onRejectConfirm}
-                          onAlwaysAllowConfirm={onAlwaysAllowConfirm}
-                          pendingConfirms={state.pendingConfirms}
-                        />
+                        <div key={`a-${m.turn}`}>
+                          <AssistantMsg
+                            segments={m.segments}
+                            pending={m.pending}
+                            model={state.model}
+                            onApproveConfirm={onApproveConfirm}
+                            onRejectConfirm={onRejectConfirm}
+                            onAlwaysAllowConfirm={onAlwaysAllowConfirm}
+                            pendingConfirms={state.pendingConfirms}
+                          />
+                          {stats ? <DiffStats stats={stats} /> : null}
+                        </div>
                       );
                     }
                     if (m.kind === "error") {

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -1911,6 +1911,67 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
   border-color: var(--success-soft);
 }
 
+/* ---------- DIFF STATS ---------- */
+
+.diff-stats {
+  padding: 2px 18px 2px 0;
+  font-size: 11px;
+  font-family: Geist Mono, monospace;
+}
+.diff-stats-head {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: none;
+  padding: 3px 8px 3px 0;
+  color: var(--muted);
+  cursor: pointer;
+  font: inherit;
+  border-radius: 4px;
+  transition: color 100ms;
+}
+.diff-stats-head:hover {
+  color: var(--fg-2);
+}
+.diff-stats-head .ico {
+  color: var(--accent);
+  display: inline-flex;
+}
+.diff-stats-head .chev {
+  display: inline-flex;
+  margin-left: auto;
+  color: var(--muted-2);
+}
+.diff-stats-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  padding: 2px 0 2px 20px;
+}
+.diff-stats-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  padding: 1px 0;
+  color: var(--muted);
+}
+.diff-stats-row .fn {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.diff-stats-row .counts {
+  flex-shrink: 0;
+}
+.diff-stats-row .add {
+  color: var(--success);
+}
+.diff-stats-row .rm {
+  color: var(--danger);
+}
+
 .markdown pre {
   margin: 14px 0;
   padding: 14px 16px;

--- a/desktop/src/ui/context-panel.test.tsx
+++ b/desktop/src/ui/context-panel.test.tsx
@@ -29,7 +29,6 @@ const settings: Settings = {
   workspaceDir: "/repo",
   recentWorkspaces: [],
   model: "deepseek-reasoner",
-  preset: "pro",
   version: "0.0.0",
 };
 


### PR DESCRIPTION
## Summary

After each complete assistant turn, show a collapsible summary of file
changes: how many files, added/removed lines, and which files.

## Changes

- **App.tsx** - countFileStats() helper parses edit_file/multi_edit diffs
  and write_file args; DiffStats component with collapsible file list
- **styles.css** - .diff-stats styles
- **context-panel.test.tsx** - Remove stale preset field from test fixture

## Behavior

Collapsed: `N files changed +A / -R lines`
Expanded: per-file breakdown with +/- counts

## Verification

- desktop build passes
- write_file lines counted from args content
- stats only shown after turn completes
