### PR TITLE
fix(tui): drop stale /copy startup hint

### DIFF
--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -296,9 +296,6 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
   if (cfg.setupCompleted === true && (cfg.mcp?.length ?? 0) === 0 && mcpSpecs.length === 0) {
     startupInfoHints.push(t("mcpHealth.emptyHint"));
   }
-  startupInfoHints.push(
-    "/copy  →  vim-style copy mode (j/k navigate, v select, y yank to clipboard)",
-  );
 
   // Register web search/fetch tools unless explicitly disabled. DDG
   // backs them with no key required; the model invokes them whenever

--- a/tests/chat-mcp-startup-summary.test.ts
+++ b/tests/chat-mcp-startup-summary.test.ts
@@ -273,8 +273,6 @@ describe("chatCommand MCP startup summary states", { timeout: 30_000 }, () => {
     expect(mocks.initializeMock).not.toHaveBeenCalled();
   });
 
-  const COPY_HINT = "/copy  →  vim-style copy mode (j/k navigate, v select, y yank to clipboard)";
-
   it("adds empty-MCP hint exactly when setup is completed and configured MCP list is empty", async () => {
     const props = await captureStartupState({
       readConfig: { setupCompleted: true, mcp: [] },
@@ -283,17 +281,17 @@ describe("chatCommand MCP startup summary states", { timeout: 30_000 }, () => {
 
     expect(props.startupInfoHints).toEqual([
       "\u2139 no MCP servers configured \u2014 try: `reasonix setup` to re-pick, or `reasonix mcp install filesystem` \u00b7 shell commands gate per-call (allow once / allow always / deny), no global allow-all",
-      COPY_HINT,
     ]);
+    expect(props.startupInfoHints.join("\n")).not.toContain("/copy");
   });
 
-  it("does not add empty-MCP hint when configured MCP list is non-empty", async () => {
+  it("does not add startup hints when configured MCP list is non-empty", async () => {
     const props = await captureStartupState({
       readConfig: { setupCompleted: true, mcp: ["fs=npx -y @scope/fs /tmp"] },
       mcp: ["fs=npx -y @scope/fs /tmp"],
     });
 
-    expect(props.startupInfoHints).toEqual([COPY_HINT]);
+    expect(props.startupInfoHints).toEqual([]);
   });
 
   it("renders empty-MCP hint in zh-CN locale", async () => {
@@ -304,7 +302,7 @@ describe("chatCommand MCP startup summary states", { timeout: 30_000 }, () => {
     });
     expect(props.startupInfoHints).toEqual([
       "\u2139 未配置 MCP 服务器 —— 可尝试：`reasonix setup` 重新选择，或 `reasonix mcp install filesystem` · shell 命令按次审批（allow once / allow always / deny），无全局放行",
-      COPY_HINT,
     ]);
+    expect(props.startupInfoHints.join("\n")).not.toContain("/copy");
   });
 });


### PR DESCRIPTION
## Summary
- Remove the stale `/copy` startup hint from TUI startup info.
- Update startup summary tests so removed slash commands do not reappear in startup hints.

## Root cause
`/copy` was removed when the TUI stopped using the old copy mode, but chat startup still pushed the old hint unconditionally.

## Validation
- `npm test -- tests/chat-mcp-startup-summary.test.ts`
- `npm test -- tests/slash.test.ts tests/ui-slash-suggestions.test.tsx`
- `npm run typecheck`
- `npx --no-install biome check src/cli/commands/chat.tsx tests/chat-mcp-startup-summary.test.ts`

Fixes #1690