### PR TITLE
fix(desktop): restore aborted prompt drafts

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -12,6 +12,11 @@ import { type Update, check } from "@tauri-apps/plugin-updater";
 import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import { CommandPalette, Toast, buildCommands, useCommandPalette } from "./CommandPalette";
 import { WorkspaceProvider } from "./Markdown";
+import {
+  nextAbortDraftCandidate,
+  restoreAbortedDraft,
+  type AbortDraftSource,
+} from "./abort-draft";
 import { getLang, setLang, t, useLang } from "./i18n";
 import { I } from "./icons";
 import {
@@ -1241,6 +1246,17 @@ function TabRuntime({
   });
   const wasBusyRef = useRef(false);
   const busyStartedAtRef = useRef<number | null>(null);
+  const abortDraftRef = useRef<string | null>(null);
+  const clearAbortDraft = useCallback(() => {
+    abortDraftRef.current = nextAbortDraftCandidate(abortDraftRef.current, { type: "clear" });
+  }, []);
+  const recordAbortDraft = useCallback((source: AbortDraftSource, text: string) => {
+    abortDraftRef.current = nextAbortDraftCandidate(abortDraftRef.current, {
+      type: "record",
+      source,
+      text,
+    });
+  }, []);
   const openSettingsAt = useCallback((page: SettingsPageId = "general") => {
     setSettingsPage(page);
     setSettingsOpen(true);
@@ -1299,9 +1315,10 @@ function TabRuntime({
     [sendRpc],
   );
   const newChat = useCallback(() => {
+    clearAbortDraft();
     sendRpc({ cmd: "new_chat" });
     dispatch({ t: "clear" });
-  }, [sendRpc]);
+  }, [clearAbortDraft, sendRpc]);
 
   const pickWorkspace = useCallback(async () => {
     try {
@@ -1312,12 +1329,13 @@ function TabRuntime({
         defaultPath: state.settings?.workspaceDir,
       });
       if (typeof picked === "string" && picked.length > 0) {
+        clearAbortDraft();
         saveSettings({ workspaceDir: picked });
       }
     } catch (err) {
       console.error("pickWorkspace failed", err);
     }
-  }, [saveSettings, state.settings?.workspaceDir]);
+  }, [clearAbortDraft, saveSettings, state.settings?.workspaceDir]);
 
   const flashToast = useCallback(
     (msg: string, opts?: { yolo?: boolean; duration?: number }) => {
@@ -1411,6 +1429,7 @@ function TabRuntime({
           return;
         }
         const clientId = `btw-${Date.now()}`;
+        recordAbortDraft("btw", text);
         dispatch({ t: "send_user", text, clientId });
         sendRpc({ cmd: "btw", text: question });
         if (!override) setDraft("");
@@ -1424,6 +1443,7 @@ function TabRuntime({
         if (skill) {
           const clientId = `skill-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
           const trimmedArgs = args?.trim() ?? "";
+          recordAbortDraft("skill_run", text);
           dispatch({ t: "start_skill", skill: { name: skill.name, runAs: skill.runAs }, args: trimmedArgs, clientId });
           sendRpc({ cmd: "skill_run", name: skill.name, args: trimmedArgs || undefined });
           if (!override) setDraft("");
@@ -1431,14 +1451,32 @@ function TabRuntime({
         }
       }
       const clientId = `c-${Date.now()}`;
+      recordAbortDraft("user_input", text);
       dispatch({ t: "send_user", text, clientId });
       sendRpc({ cmd: "user_input", text });
       if (!override) setDraft("");
     },
-    [draft, state.ready, state.busy, state.skills, sendRpc],
+    [draft, state.ready, state.busy, state.skills, sendRpc, recordAbortDraft],
   );
 
-  const abort = useCallback(() => sendRpc({ cmd: "abort" }), [sendRpc]);
+  const abort = useCallback(() => {
+    const restored = restoreAbortedDraft(draft, abortDraftRef.current);
+    clearAbortDraft();
+    if (restored !== null) {
+      setDraft(restored);
+      composerRef.current?.focus();
+    }
+    sendRpc({ cmd: "abort" });
+  }, [clearAbortDraft, draft, sendRpc]);
+
+  useEffect(() => {
+    if (!state.busy) clearAbortDraft();
+  }, [clearAbortDraft, state.busy]);
+
+  const clearConversation = useCallback(() => {
+    clearAbortDraft();
+    dispatch({ t: "clear" });
+  }, [clearAbortDraft]);
 
   // When /retry returns the last user text, set it as the composer draft
   useEffect(() => {
@@ -1698,7 +1736,7 @@ function TabRuntime({
       flashToast(t("app.toast.newSession"));
     },
     clearChat: () => {
-      dispatch({ t: "clear" });
+      clearConversation();
       flashToast(t("app.toast.cleared"));
     },
     focusComposer: () => composerRef.current?.focus(),
@@ -1742,7 +1780,7 @@ function TabRuntime({
       },
     },
     { cmd: "/new", desc: t("app.cmd.newSession"), run: () => newChat(), kb: shortcutText(["mod", "N"]) },
-    { cmd: "/clear", desc: t("app.cmd.clearChat"), run: () => dispatch({ t: "clear" }) },
+    { cmd: "/clear", desc: t("app.cmd.clearChat"), run: () => clearConversation() },
     { cmd: "/abort", desc: t("app.cmd.abort"), run: () => abort(), kb: "esc" },
     {
       cmd: "/copy",
@@ -1817,6 +1855,7 @@ function TabRuntime({
       desc: s.description?.trim() || fallbackSkillDesc(s),
       insertOnly: true,
       run: () => {
+        recordAbortDraft("skill_run", `/${s.name}`);
         dispatch({
           t: "start_skill",
           skill: { name: s.name, runAs: s.runAs },
@@ -1918,7 +1957,7 @@ function TabRuntime({
           onOpenSettings={() => openSettingsAt("general")}
           onCopy={conversationCopy}
           onExport={exportConversation}
-          onClear={() => dispatch({ t: "clear" })}
+          onClear={clearConversation}
           hasMessages={state.messages.length > 0}
         />
 
@@ -1940,7 +1979,10 @@ function TabRuntime({
           sessions={state.sessions}
           activeName={state.currentSession}
           onNewChat={newChat}
-          onLoadSession={(name) => sendRpc({ cmd: "session_load", name })}
+          onLoadSession={(name) => {
+            clearAbortDraft();
+            sendRpc({ cmd: "session_load", name });
+          }}
           onDeleteSession={(name) => sendRpc({ cmd: "session_delete", name })}
           onRenameSession={(name, title) => sendRpc({ cmd: "session_rename", name, title })}
           onOpenSettings={() => openSettingsAt("general")}
@@ -2286,7 +2328,10 @@ function TabRuntime({
           recent={state.settings?.recentWorkspaces ?? []}
           current={state.settings?.workspaceDir}
           anchor={wdAnchor}
-          onPick={(path) => saveSettings({ workspaceDir: path })}
+          onPick={(path) => {
+            clearAbortDraft();
+            saveSettings({ workspaceDir: path });
+          }}
           onBrowse={pickWorkspace}
         />
 

--- a/desktop/src/abort-draft.ts
+++ b/desktop/src/abort-draft.ts
@@ -1,0 +1,26 @@
+export type AbortDraftSource = "user_input" | "skill_run" | "btw";
+
+export type AbortDraftAction =
+  | { type: "record"; source: AbortDraftSource; text: string }
+  | { type: "clear" };
+
+export function nextAbortDraftCandidate(
+  _current: string | null,
+  action: AbortDraftAction,
+): string | null {
+  if (action.type === "clear") return null;
+  if (action.source === "btw") return null;
+
+  const text = action.text.trim();
+  return text ? text : null;
+}
+
+export function restoreAbortedDraft(
+  currentDraft: string,
+  interruptedText: string | null | undefined,
+): string | null {
+  const text = interruptedText?.trim();
+  if (!text) return null;
+  if (currentDraft.trim()) return null;
+  return text;
+}

--- a/tests/desktop-abort-draft.test.ts
+++ b/tests/desktop-abort-draft.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { nextAbortDraftCandidate, restoreAbortedDraft } from "../desktop/src/abort-draft";
+
+describe("desktop abort draft restore", () => {
+  it("restores interrupted text when the composer draft is empty", () => {
+    expect(restoreAbortedDraft("", "rewrite the whole file")).toBe("rewrite the whole file");
+  });
+
+  it("does not overwrite a non-empty composer draft", () => {
+    expect(restoreAbortedDraft("new idea", "old interrupted prompt")).toBeNull();
+  });
+
+  it("does not restore blank or missing interrupted text", () => {
+    expect(restoreAbortedDraft("", "")).toBeNull();
+    expect(restoreAbortedDraft("", "   ")).toBeNull();
+    expect(restoreAbortedDraft("", null)).toBeNull();
+  });
+
+  it("records normal user input as the abort draft candidate", () => {
+    expect(
+      nextAbortDraftCandidate(null, {
+        type: "record",
+        source: "user_input",
+        text: "  rewrite everything  ",
+      }),
+    ).toBe("rewrite everything");
+  });
+
+  it("records the slash command text for skill runs", () => {
+    expect(
+      nextAbortDraftCandidate(null, {
+        type: "record",
+        source: "skill_run",
+        text: "/review src/App.tsx",
+      }),
+    ).toBe("/review src/App.tsx");
+  });
+
+  it("does not record /btw side questions as abort draft candidates", () => {
+    expect(
+      nextAbortDraftCandidate("stale", {
+        type: "record",
+        source: "btw",
+        text: "/btw what is the status?",
+      }),
+    ).toBeNull();
+  });
+
+  it("clears stale abort draft candidates", () => {
+    const recorded = nextAbortDraftCandidate(null, {
+      type: "record",
+      source: "user_input",
+      text: "keep me only while running",
+    });
+
+    expect(nextAbortDraftCandidate(recorded, { type: "clear" })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Restore the interrupted prompt into the desktop composer after an explicit Abort when the current draft is empty.
- Track normal user prompts and slash skill commands without persisting the draft into the transcript.
- Clear stale abort draft candidates on completion, new chat, session load, workspace switch, and clear actions.

## Tests
- npm test -- --run tests/desktop-abort-draft.test.ts desktop/src/App.test.ts
- npm run verify