### PR TITLE
feat(memory): support CLAUDE.md and ~/.claude/CLAUDE.md for Claude Code migration

### DIFF
--- a/src/memory/project.ts
+++ b/src/memory/project.ts
@@ -6,8 +6,15 @@ import { basename, join } from "node:path";
 /** Default WRITE target — created when no candidate exists yet. */
 export const PROJECT_MEMORY_FILE = "REASONIX.md";
 
-/** READ candidates, in priority order. AGENTS.md is the open spec at agents.md (Linux Foundation). */
-export const PROJECT_MEMORY_FILES = ["REASONIX.md", "AGENTS.md", "AGENT.md"] as const;
+/** READ candidates, in priority order. AGENTS.md is the open spec at agents.md (Linux Foundation).
+ *  CLAUDE.md candidates support migration from Claude Code (project-root or .claude/ subdirectory). */
+export const PROJECT_MEMORY_FILES = [
+  "REASONIX.md",
+  ".claude/CLAUDE.md",
+  "CLAUDE.md",
+  "AGENTS.md",
+  "AGENT.md",
+] as const;
 
 export const PROJECT_MEMORY_MAX_CHARS = 8000;
 

--- a/src/memory/user.ts
+++ b/src/memory/user.ts
@@ -348,6 +348,46 @@ export function applyGlobalReasonixMemory(basePrompt: string, homeDir?: string):
   ].join("\n");
 }
 
+/** Read ~/.claude/CLAUDE.md — cross-project notes from Claude Code migration.
+ *  Same cap as global Reasonix memory (8000 chars). */
+export function readGlobalClaudeMemory(
+  homeDir: string = homedir(),
+): { path: string; content: string; originalChars: number; truncated: boolean } | null {
+  const path = join(homeDir, ".claude", "CLAUDE.md");
+  if (!existsSync(path)) return null;
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch {
+    return null;
+  }
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const originalChars = trimmed.length;
+  const truncated = originalChars > 8000;
+  const content = truncated
+    ? `${trimmed.slice(0, 8000)}\n… (truncated ${originalChars - 8000} chars)`
+    : trimmed;
+  return { path, content, originalChars, truncated };
+}
+
+export function applyGlobalClaudeMemory(basePrompt: string): string {
+  if (!memoryEnabled()) return basePrompt;
+  const mem = readGlobalClaudeMemory();
+  if (!mem) return basePrompt;
+  return [
+    basePrompt,
+    "",
+    "# Global memory (~/.claude/CLAUDE.md)",
+    "",
+    "Cross-project notes from your Claude Code configuration. Treat as authoritative — same level of trust as project memory.",
+    "",
+    "```",
+    mem.content,
+    "```",
+  ].join("\n");
+}
+
 /** Effective priority: entry's own field wins, else the config default for its type, else undefined. */
 export function effectivePriority(
   entry: MemoryEntry,
@@ -427,7 +467,8 @@ export function applyMemoryStack(
     withProject,
     homeDir ? join(homeDir, ".reasonix") : undefined,
   );
-  const withMemory = applyUserMemory(withGlobal, { projectRoot: rootDir, homeDir, cfg });
+  const withGlobalClaude = applyGlobalClaudeMemory(withGlobal);
+  const withMemory = applyUserMemory(withGlobalClaude, { projectRoot: rootDir, homeDir, cfg });
   const customSkillPaths = cfg?.skills?.paths
     ? resolveSkillPaths(cfg.skills.paths, rootDir)
     : loadResolvedSkillPaths(rootDir);

--- a/tests/project-memory.test.ts
+++ b/tests/project-memory.test.ts
@@ -2,7 +2,7 @@
 
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { CODE_SYSTEM_PROMPT, codeSystemPrompt } from "../src/code/prompt.js";
 import {
@@ -71,22 +71,49 @@ describe("project-memory", () => {
       expect(mem?.content.length).toBeLessThan(PROJECT_MEMORY_MAX_CHARS + 64);
     });
 
-    it("falls back to AGENTS.md when REASONIX.md is absent", () => {
+    it("falls back to .claude/CLAUDE.md when REASONIX.md is absent", () => {
+      mkdirSync(join(root, ".claude"));
+      writeFileSync(join(root, ".claude", "CLAUDE.md"), "claude subdir content\n", "utf8");
+      const mem = readProjectMemory(root);
+      expect(mem?.content).toBe("claude subdir content");
+      expect(mem?.path).toBe(join(root, ".claude", "CLAUDE.md"));
+    });
+
+    it("falls back to root-level CLAUDE.md when .claude/CLAUDE.md is absent", () => {
+      writeFileSync(join(root, "CLAUDE.md"), "root claude content\n", "utf8");
+      const mem = readProjectMemory(root);
+      expect(mem?.content).toBe("root claude content");
+      expect(mem?.path.endsWith("CLAUDE.md")).toBe(true);
+    });
+
+    it(".claude/CLAUDE.md takes priority over root-level CLAUDE.md", () => {
+      mkdirSync(join(root, ".claude"));
+      writeFileSync(join(root, ".claude", "CLAUDE.md"), "subdir wins\n", "utf8");
+      writeFileSync(join(root, "CLAUDE.md"), "root loses\n", "utf8");
+      const mem = readProjectMemory(root);
+      expect(mem?.content).toBe("subdir wins");
+      expect(mem?.path).toBe(join(root, ".claude", "CLAUDE.md"));
+    });
+
+    it("falls back to AGENTS.md when no REASONIX.md or CLAUDE.md exists", () => {
       writeFileSync(join(root, "AGENTS.md"), "open-spec content\n", "utf8");
       const mem = readProjectMemory(root);
       expect(mem?.content).toBe("open-spec content");
       expect(mem?.path.endsWith("AGENTS.md")).toBe(true);
     });
 
-    it("falls back to AGENT.md (singular) when neither REASONIX.md nor AGENTS.md exists", () => {
+    it("falls back to AGENT.md (singular) when earlier candidates are absent", () => {
       writeFileSync(join(root, "AGENT.md"), "singular variant\n", "utf8");
       const mem = readProjectMemory(root);
       expect(mem?.content).toBe("singular variant");
       expect(mem?.path.endsWith("AGENT.md")).toBe(true);
     });
 
-    it("prefers REASONIX.md when multiple candidates exist", () => {
+    it("prefers REASONIX.md over CLAUDE.md candidates", () => {
       writeFileSync(join(root, "REASONIX.md"), "reasonix wins\n", "utf8");
+      mkdirSync(join(root, ".claude"));
+      writeFileSync(join(root, ".claude", "CLAUDE.md"), "claude loses\n", "utf8");
+      writeFileSync(join(root, "CLAUDE.md"), "root claude loses\n", "utf8");
       writeFileSync(join(root, "AGENTS.md"), "agents loses\n", "utf8");
       writeFileSync(join(root, "AGENT.md"), "agent loses too\n", "utf8");
       const mem = readProjectMemory(root);
@@ -95,7 +122,13 @@ describe("project-memory", () => {
     });
 
     it("PROJECT_MEMORY_FILES priority matches the documented read order", () => {
-      expect(PROJECT_MEMORY_FILES).toEqual(["REASONIX.md", "AGENTS.md", "AGENT.md"]);
+      expect(PROJECT_MEMORY_FILES).toEqual([
+        "REASONIX.md",
+        ".claude/CLAUDE.md",
+        "CLAUDE.md",
+        "AGENTS.md",
+        "AGENT.md",
+      ]);
     });
   });
 
@@ -105,8 +138,11 @@ describe("project-memory", () => {
     });
 
     it.each(PROJECT_MEMORY_FILES)("finds %s when it's the only candidate", (name) => {
-      writeFileSync(join(root, name), "x", "utf8");
-      expect(findProjectMemoryPath(root)?.endsWith(name)).toBe(true);
+      // .claude/CLAUDE.md needs its parent directory created first
+      const fullPath = join(root, name);
+      mkdirSync(dirname(fullPath), { recursive: true });
+      writeFileSync(fullPath, "x", "utf8");
+      expect(findProjectMemoryPath(root)).toBe(fullPath);
     });
   });
 


### PR DESCRIPTION
## Background

The memory system currently only reads `REASONIX.md` (project-level) and `~/.reasonix/REASONIX.md` (global). Users migrating from Claude Code are accustomed to `CLAUDE.md` and `~/.claude/CLAUDE.md`, which are currently ignored.

## Changes

### Project-level — PROJECT_MEMORY_FILES search order

`src/memory/project.ts`:

```
REASONIX.md → .claude/CLAUDE.md → CLAUDE.md → AGENTS.md → AGENT.md
```

- `REASONIX.md` always wins (Reasonix-native)
- `.claude/CLAUDE.md` second (Claude Code's newer convention, subdirectory)
- `CLAUDE.md` third (Claude Code's older convention, root)
- `AGENTS.md` / `AGENT.md` kept as existing fallbacks

### Global-level — ~/.claude/CLAUDE.md

`src/memory/user.ts`:

- Added `readGlobalClaudeMemory()` / `applyGlobalClaudeMemory()`, following the pattern of the existing global Reasonix memory functions
- Wired into `applyMemoryStack` chain, injected after `~/.reasonix/REASONIX.md`

### Tests

`tests/project-memory.test.ts` — added 4 new tests covering CLAUDE.md priority and fallback scenarios.

## What's NOT changed

- `detectForeignAgentPlatform` — CLAUDE.md is NOT flagged as a foreign platform file
- `hash-memory.ts` — the `#` write path auto-adapts to whatever project memory file exists; `#g` continues writing to `~/.reasonix/REASONIX.md`
- `src/code/prompt.ts` — the identity section of the system prompt needs no adjustment

## Verification

- [x] `npm run typecheck` — passes
- [x] `npm test` — all 3622 tests pass (0 failures)
- [x] `npm run build` — passes
