### PR TITLE
fix(plan): archive completed plans instead of letting them persist (fixes #1355)

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -21,7 +21,9 @@ import { type EditBlock, applyEditBlocks, snapshotBeforeEdits } from "../../code
 import { EngineeringLifecycleRuntime } from "../../code/lifecycle.js";
 import { clearPendingEdits, loadPendingEdits, savePendingEdits } from "../../code/pending-edits.js";
 import {
+  archivePlanState,
   clearPlanState,
+  isPlanComplete,
   loadPlanState,
   relativeTime,
   savePlanState,
@@ -1576,28 +1578,35 @@ function AppInner({
     if (session && loop.resumedMessageCount > 0) {
       const restoredPlan = loadPlanState(session);
       if (restoredPlan && restoredPlan.steps.length > 0) {
-        planStepsRef.current = restoredPlan.steps;
-        completedStepIdsRef.current = new Set(restoredPlan.completedStepIds);
-        stepCompletionsRef.current = new Map(Object.entries(restoredPlan.stepCompletions ?? {}));
-        pendingStepCompletionsRef.current = new Map();
-        planBodyRef.current = restoredPlan.body ?? null;
-        planSummaryRef.current = restoredPlan.summary ?? null;
-        engineeringLifecycleRef.current?.recordPlanApproved(restoredPlan.steps);
-        for (const stepId of restoredPlan.completedStepIds) {
-          engineeringLifecycleRef.current?.recordStepCompleted(stepId);
+        // If every step is already done, the plan was fully completed in a
+        // prior session but never archived (issue #1355). Archive it now and
+        // skip restoration so the user doesn't see a stale completed plan.
+        if (isPlanComplete(restoredPlan)) {
+          archivePlanState(session);
+        } else {
+          planStepsRef.current = restoredPlan.steps;
+          completedStepIdsRef.current = new Set(restoredPlan.completedStepIds);
+          stepCompletionsRef.current = new Map(Object.entries(restoredPlan.stepCompletions ?? {}));
+          pendingStepCompletionsRef.current = new Map();
+          planBodyRef.current = restoredPlan.body ?? null;
+          planSummaryRef.current = restoredPlan.summary ?? null;
+          engineeringLifecycleRef.current?.recordPlanApproved(restoredPlan.steps);
+          for (const stepId of restoredPlan.completedStepIds) {
+            engineeringLifecycleRef.current?.recordStepCompleted(stepId);
+          }
+          const when = relativeTime(restoredPlan.updatedAt);
+          const done = new Set(restoredPlan.completedStepIds);
+          const summary = restoredPlan.summary ? ` - ${restoredPlan.summary}` : "";
+          log.showPlan({
+            title: t("ui.resumedPlan", { when, summary }),
+            steps: restoredPlan.steps.map((s) => ({
+              id: s.id,
+              title: s.title,
+              status: done.has(s.id) ? "done" : "queued",
+            })),
+            variant: "resumed",
+          });
         }
-        const when = relativeTime(restoredPlan.updatedAt);
-        const done = new Set(restoredPlan.completedStepIds);
-        const summary = restoredPlan.summary ? ` - ${restoredPlan.summary}` : "";
-        log.showPlan({
-          title: t("ui.resumedPlan", { when, summary }),
-          steps: restoredPlan.steps.map((s) => ({
-            id: s.id,
-            title: s.title,
-            status: done.has(s.id) ? "done" : "queued",
-          })),
-          variant: "resumed",
-        });
       }
     }
     // One-time onboarding tip for the edit-gate keybindings. New users
@@ -2933,7 +2942,15 @@ function AppInner({
               engineeringLifecycleRef.current?.recordStepCompleted(s.id);
               added++;
             }
-            if (added > 0) persistPlanState();
+            if (added > 0) {
+              const total = steps.length;
+              const completed = completedStepIdsRef.current.size;
+              if (session && completed >= total) {
+                archivePlanState(session);
+              } else {
+                persistPlanState();
+              }
+            }
             return added;
           },
           reloadHooks: () => reloadHooks(codeMode ? currentRootDir : undefined),

--- a/src/code/plan-store.ts
+++ b/src/code/plan-store.ts
@@ -212,6 +212,10 @@ export function listPlanArchives(sessionName: string): PlanArchiveSummary[] {
   return summaries;
 }
 
+export function isPlanComplete(state: PlanStateOnDisk): boolean {
+  return state.completedStepIds.length >= state.steps.length;
+}
+
 export interface PlanArchiveWithSession extends PlanArchiveSummary {
   sessionName: string;
 }

--- a/tests/plan-store.test.ts
+++ b/tests/plan-store.test.ts
@@ -13,6 +13,7 @@ function writeFixture(path: string, content: string): void {
 import {
   archivePlanState,
   clearPlanState,
+  isPlanComplete,
   listPlanArchives,
   loadPlanState,
   planStatePath,
@@ -200,6 +201,61 @@ describe("plan-store roundtrip", () => {
     const path = planStatePath("../etc/passwd");
     expect(path).toMatch(/\.plan\.json$/);
     expect(path).not.toMatch(/\.\.[\\/]etc/);
+  });
+});
+
+describe("isPlanComplete", () => {
+  it("returns true when every step has a matching completed id", () => {
+    expect(
+      isPlanComplete({
+        version: 2,
+        steps: [
+          { id: "a", title: "x", action: "y" },
+          { id: "b", title: "x", action: "y" },
+        ],
+        completedStepIds: ["a", "b"],
+        updatedAt: new Date().toISOString(),
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when some steps remain incomplete", () => {
+    expect(
+      isPlanComplete({
+        version: 2,
+        steps: [
+          { id: "a", title: "x", action: "y" },
+          { id: "b", title: "x", action: "y" },
+        ],
+        completedStepIds: ["a"],
+        updatedAt: new Date().toISOString(),
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true when completed ids exceed steps (defensive)", () => {
+    // Extra completed ids can happen after plan revision drops steps;
+    // we still treat it as complete.
+    expect(
+      isPlanComplete({
+        version: 2,
+        steps: [{ id: "a", title: "x", action: "y" }],
+        completedStepIds: ["a", "b", "c"],
+        updatedAt: new Date().toISOString(),
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true for empty steps and empty completed ids", () => {
+    // Edge case: a plan with zero steps is vacuously complete.
+    expect(
+      isPlanComplete({
+        version: 2,
+        steps: [],
+        completedStepIds: [],
+        updatedAt: new Date().toISOString(),
+      }),
+    ).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #1355 — completed task plans were persisting indefinitely as `.plan.json` instead of being archived to `.plan.{timestamp}.done.json`.

## Root Cause

Two independent paths failed to archive:

1. **Session restoration** (`App.tsx`): On resume, a fully-completed plan from a prior session was loaded back into the UI as a \"resumed\" plan. Users would see stale completed plans on every relaunch.

2. **`/plans done all`** (`markAllPlanStepsDone`): When the user manually marked all steps done, the code called `persistPlanState()` (rewriting `.plan.json`) but never `archivePlanState()`, so the active plan file lived forever.

## Fix

- **Restoration guard**: Extract `isPlanComplete()` in `plan-store.ts`; before restoring a plan, check if all steps are already done. If so, archive immediately and skip restoration.
- **`markAllPlanStepsDone` archive**: After marking steps done, if the total completed now equals (or exceeds) the total steps and a session exists, call `archivePlanState(session)` instead of `persistPlanState()`.

## Tests

Added 4 new unit tests for `isPlanComplete`:
- all steps done → true
- partial completion → false
- completed ids exceed steps (defensive, e.g. after revision) → true
- empty plan → true (vacuously complete)

## Verification

- `npm run typecheck` ✅
- `npm run lint` ✅
- Plan-related tests (`plan.test.ts`, `plan-store.test.ts`, `plans-done-slash.test.ts`) 86 tests pass ✅
- Full suite: 261 test files, 3596 tests pass ✅

## Test plan

- [x] Start a plan, complete all steps via tool calls, verify `.plan.json` is renamed to `.plan.*.done.json`
- [x] Start a plan, run `/plans done all`, verify active plan file is archived
- [x] Close and reopen a session with a completed plan on disk, verify it is archived on load and not shown as \"resumed\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)