### PR TITLE
fix: skip .devenv and .direnv in glob, search, and directory_tree

### DIFF
--- a/src/index/config.ts
+++ b/src/index/config.ts
@@ -34,6 +34,8 @@ export interface IndexFilters {
 export const DEFAULT_INDEX_EXCLUDES = {
   dirs: [
     "node_modules",
+    ".devenv",
+    ".direnv",
     ".git",
     ".hg",
     ".svn",


### PR DESCRIPTION
## Problem

\`glob\`, \`search_content\`, \`search_files\`, and \`directory_tree\` walk into \`.devenv/\` and \`.direnv/\` unconditionally. In Nix/devenv-based projects these directories contain:

- **\`.devenv/\`** — Nix store symlinks, cargo registries (\`state/cargo/\`), uv caches (\`state/uv/\`). Can exceed **1.5 GB** with tens of thousands of files.
- **\`.direnv/\`** — direnv Nix symlinks, similar issue.

A bare \`glob("**/package.json")\` stats every file under these trees before matching, hanging the session until the user aborts.

## Fix

Add \`.devenv\` and \`.direnv\` to \`DEFAULT_INDEX_EXCLUDES.dirs\` — same category as \`.git\`, \`node_modules\`, \`target\`, etc.

## Impact

- \`glob\`, \`search_content\`, \`search_files\`, \`directory_tree\` all skip these directories when \`include_deps: false\` (the default).
- The \`directory_tree\` help text auto-includes them via the dynamic \`[...SKIP_DIR_NAMES].sort().join(" / ")\` construction — no separate doc change needed.
- Users who genuinely need to search inside \`.devenv/\` can pass \`include_deps: true\`.

## Testing

Existing test suite covers the skip-dir logic (the set is used in multiple tools). No new tests needed — this is a data-only change to the exclusion list.