### PR TITLE
feat(ui): configurable cost display currency with click-to-toggle

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -190,7 +190,7 @@ import { VerboseContext } from "./state/verbose-context.js";
 import { isLegacyWindowsConsole } from "./terminal-host.js";
 import { ThemeProvider } from "./theme/context.js";
 import { listThemeNames } from "./theme/tokens.js";
-import { FG, type ThemeName } from "./theme/tokens.js";
+import { FG, type ThemeName, setDefaultCostCurrency } from "./theme/tokens.js";
 import { TickerProvider } from "./ticker.js";
 import { handleTurnInterrupt } from "./turn-interrupt.js";
 import { useCompletionPickers } from "./useCompletionPickers.js";
@@ -413,6 +413,20 @@ export function App(props: AppProps): React.ReactElement {
       showVersion: cfg.showVersion !== false,
       showFeedbackHint: cfg.showFeedbackHint !== false,
     };
+  }, []);
+  // Seed the cost display currency from config on first mount. When the
+  // wallet API later provides a balanceCurrency, that takes precedence
+  // at the per-card level — this is the fallback for users without a
+  // wallet who want USD instead of the default CNY.
+  useEffect(() => {
+    const cfg = readConfig();
+    setDefaultCostCurrency(cfg.costCurrency);
+    if (cfg.costCurrency) {
+      agentStore.dispatch({
+        type: "session.update",
+        patch: { costDisplayCurrency: cfg.costCurrency },
+      });
+    }
   }, []);
   return (
     <ThemeProvider name={themeName}>

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -190,7 +190,7 @@ import { VerboseContext } from "./state/verbose-context.js";
 import { isLegacyWindowsConsole } from "./terminal-host.js";
 import { ThemeProvider } from "./theme/context.js";
 import { listThemeNames } from "./theme/tokens.js";
-import { FG, type ThemeName, setDefaultCostCurrency } from "./theme/tokens.js";
+import { FG, type ThemeName } from "./theme/tokens.js";
 import { TickerProvider } from "./ticker.js";
 import { handleTurnInterrupt } from "./turn-interrupt.js";
 import { useCompletionPickers } from "./useCompletionPickers.js";
@@ -413,10 +413,6 @@ export function App(props: AppProps): React.ReactElement {
       showVersion: cfg.showVersion !== false,
       showFeedbackHint: cfg.showFeedbackHint !== false,
     };
-  }, []);
-  // Seed the module-level cost-currency fallback from config.
-  useEffect(() => {
-    setDefaultCostCurrency(readConfig().costCurrency);
   }, []);
   return (
     <ThemeProvider name={themeName}>

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -414,19 +414,9 @@ export function App(props: AppProps): React.ReactElement {
       showFeedbackHint: cfg.showFeedbackHint !== false,
     };
   }, []);
-  // Seed the cost display currency from config on first mount. When the
-  // wallet API later provides a balanceCurrency, that takes precedence
-  // at the per-card level — this is the fallback for users without a
-  // wallet who want USD instead of the default CNY.
+  // Seed the module-level cost-currency fallback from config.
   useEffect(() => {
-    const cfg = readConfig();
-    setDefaultCostCurrency(cfg.costCurrency);
-    if (cfg.costCurrency) {
-      agentStore.dispatch({
-        type: "session.update",
-        patch: { costDisplayCurrency: cfg.costCurrency },
-      });
-    }
+    setDefaultCostCurrency(readConfig().costCurrency);
   }, []);
   return (
     <ThemeProvider name={themeName}>
@@ -509,6 +499,17 @@ function AppInner({
   useEffect(() => {
     if (!isStreaming && liveExpand) setLiveExpand(false);
   }, [isStreaming, liveExpand]);
+  // Seed costDisplayCurrency into state so reactive components respond to the toggle.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: mount-only seed
+  useEffect(() => {
+    const cfg = readConfig();
+    if (cfg.costCurrency) {
+      agentStore.dispatch({
+        type: "session.update",
+        patch: { costDisplayCurrency: cfg.costCurrency },
+      });
+    }
+  }, []);
   // ctrl-r toggles verbose mode — ReasoningCard / ToolCard skip elision while on.
   // Survives turn boundaries; resets on session restart.
   const [verboseMode, setVerboseMode] = useState(false);

--- a/src/cli/ui/cards/UsageCard.tsx
+++ b/src/cli/ui/cards/UsageCard.tsx
@@ -5,6 +5,7 @@ import { t } from "../../../i18n/index.js";
 import { Card } from "../primitives/Card.js";
 import { CardHeader } from "../primitives/CardHeader.js";
 import type { UsageCard as UsageCardData } from "../state/cards.js";
+import { useAgentState } from "../state/provider.js";
 import { FG, TONE, formatBalance, formatCost } from "../theme/tokens.js";
 
 const BAR_CELLS = 30;
@@ -27,7 +28,11 @@ function bar(ratio: number, color: string): React.ReactElement {
 }
 
 export function UsageCard({ card }: { card: UsageCardData }): React.ReactElement {
-  if (card.compact) return <CompactUsageRow card={card} />;
+  // Read live display-currency toggle so the card re-renders when the
+  // user swaps currency via click or shortcut.
+  const costDisplayCurrency = useAgentState((s) => s.status.costDisplayCurrency);
+  const costCur = costDisplayCurrency ?? card.balanceCurrency;
+  if (card.compact) return <CompactUsageRow card={card} displayCurrency={costCur} />;
   const cap = Math.max(1, card.tokens.promptCap);
   const promptRatio = card.tokens.prompt / cap;
   const reasonRatio = card.tokens.reason / cap;
@@ -35,7 +40,7 @@ export function UsageCard({ card }: { card: UsageCardData }): React.ReactElement
 
   const headerMeta: string[] = [
     `${t("cardLabels.turn")} ${card.turn}`,
-    formatCost(card.cost, card.balanceCurrency),
+    formatCost(card.cost, costCur),
   ];
   if (card.elapsedMs !== undefined) headerMeta.push(`${(card.elapsedMs / 1000).toFixed(1)}s`);
   return (
@@ -71,7 +76,7 @@ export function UsageCard({ card }: { card: UsageCardData }): React.ReactElement
       <Box flexDirection="row" gap={1}>
         <Text color={FG.faint}>{t("cardLabels.session")}</Text>
         <Text bold color={FG.body}>
-          {`● ${formatCost(card.sessionCost, card.balanceCurrency, 3)}`}
+          {`● ${formatCost(card.sessionCost, costCur, 3)}`}
         </Text>
         {card.balance !== undefined ? (
           <>
@@ -86,7 +91,10 @@ export function UsageCard({ card }: { card: UsageCardData }): React.ReactElement
   );
 }
 
-function CompactUsageRow({ card }: { card: UsageCardData }): React.ReactElement {
+function CompactUsageRow({
+  card,
+  displayCurrency,
+}: { card: UsageCardData; displayCurrency?: string }): React.ReactElement {
   const elapsed = card.elapsedMs !== undefined ? ` · ${(card.elapsedMs / 1000).toFixed(1)}s` : "";
   return (
     <Box flexDirection="row" gap={1} marginTop={1}>
@@ -97,7 +105,7 @@ function CompactUsageRow({ card }: { card: UsageCardData }): React.ReactElement 
       </Text>
       <Text color={FG.faint}>{`· ${t("cardLabels.cache")}`}</Text>
       <Text color={TONE.ok}>{`${(card.cacheHit * 100).toFixed(0)}%`}</Text>
-      <Text color={FG.faint}>{`· ${formatCost(card.cost, card.balanceCurrency)}${elapsed}`}</Text>
+      <Text color={FG.faint}>{`· ${formatCost(card.cost, displayCurrency)}${elapsed}`}</Text>
       {card.balance !== undefined ? (
         <Text color={TONE.brand}>{`· ${formatBalance(card.balance, card.balanceCurrency)}`}</Text>
       ) : null}

--- a/src/cli/ui/layout/StatusRow.tsx
+++ b/src/cli/ui/layout/StatusRow.tsx
@@ -4,9 +4,10 @@ import React from "react";
 import { t } from "../../../i18n/index.js";
 import { DEEPSEEK_CONTEXT_TOKENS, DEFAULT_CONTEXT_TOKENS } from "../../../telemetry/stats.js";
 import { VERSION } from "../../../version.js";
+import { useKeystroke } from "../keystroke-context.js";
 import { formatTokens } from "../primitives.js";
 import { Countdown } from "../primitives/Countdown.js";
-import { useAgentState } from "../state/provider.js";
+import { useAgentState, useAgentStore } from "../state/provider.js";
 import type { Mode, NetworkState, StatusBar } from "../state/state.js";
 import { GLYPH } from "../theme.js";
 import { FG, SURFACE, TONE, balanceColor, formatBalance, formatCost } from "../theme/tokens.js";
@@ -67,6 +68,21 @@ export function StatusRow({
     cols >= WALLET_MIN_COLS &&
     ((hasSession && statusBar.showSessionCost) || (hasBalance && statusBar.showBalance));
 
+  const store = useAgentStore();
+  const rows = stdout?.rows ?? 40;
+  // Click-to-toggle: a mouse click on the status bar (bottom ~2 rows)
+  // flips the display currency between USD and CNY.
+  useKeystroke((ev) => {
+    if (!ev.mouseClick || !ev.mouseRow) return;
+    if (ev.mouseRow < rows - 2) return;
+    const cur = status.costDisplayCurrency ?? status.balanceCurrency ?? "CNY";
+    const next = cur === "USD" ? "CNY" : "USD";
+    store.dispatch({
+      type: "session.update" as const,
+      patch: { costDisplayCurrency: next },
+    });
+  });
+
   return (
     <Box flexDirection="row" flexShrink={0} marginTop={1}>
       <Box flexDirection="row" flexWrap="wrap" flexGrow={1}>
@@ -96,7 +112,7 @@ export function StatusRow({
                 {"▸ "}
               </Text>
               <Text bold color={FG.body}>
-                {`${formatCost(status.cost, status.balanceCurrency)} ${t("statusBar.turn")}`}
+                {`${formatCost(status.cost, status.costDisplayCurrency ?? status.balanceCurrency)} ${t("statusBar.turn")}`}
               </Text>
             </Pill>
           </>

--- a/src/cli/ui/layout/StatusRow.tsx
+++ b/src/cli/ui/layout/StatusRow.tsx
@@ -77,9 +77,13 @@ export function StatusRow({
     if (ev.mouseRow < rows - 2) return;
     const cur = status.costDisplayCurrency ?? status.balanceCurrency ?? "CNY";
     const next = cur === "USD" ? "CNY" : "USD";
+    const label = next === "USD" ? "$" : "¥";
+    store.dispatch({ type: "session.update" as const, patch: { costDisplayCurrency: next } });
     store.dispatch({
-      type: "session.update" as const,
-      patch: { costDisplayCurrency: next },
+      type: "toast.show",
+      tone: "info",
+      title: `Costs: ${label}${next}`,
+      ttlMs: 2000,
     });
   });
 

--- a/src/cli/ui/layout/StatusRow.tsx
+++ b/src/cli/ui/layout/StatusRow.tsx
@@ -113,7 +113,7 @@ export function StatusRow({
             <Gap />
             <Pill>
               <Text bold color={TONE.brand}>
-                {"▸ "}
+                {"↻ "}
               </Text>
               <Text bold color={FG.body}>
                 {`${formatCost(status.cost, status.costDisplayCurrency ?? status.balanceCurrency)} ${t("statusBar.turn")}`}

--- a/src/cli/ui/layout/StatusRow.tsx
+++ b/src/cli/ui/layout/StatusRow.tsx
@@ -4,10 +4,9 @@ import React from "react";
 import { t } from "../../../i18n/index.js";
 import { DEEPSEEK_CONTEXT_TOKENS, DEFAULT_CONTEXT_TOKENS } from "../../../telemetry/stats.js";
 import { VERSION } from "../../../version.js";
-import { useKeystroke } from "../keystroke-context.js";
 import { formatTokens } from "../primitives.js";
 import { Countdown } from "../primitives/Countdown.js";
-import { useAgentState, useAgentStore } from "../state/provider.js";
+import { useAgentState } from "../state/provider.js";
 import type { Mode, NetworkState, StatusBar } from "../state/state.js";
 import { GLYPH } from "../theme.js";
 import { FG, SURFACE, TONE, balanceColor, formatBalance, formatCost } from "../theme/tokens.js";
@@ -68,25 +67,6 @@ export function StatusRow({
     cols >= WALLET_MIN_COLS &&
     ((hasSession && statusBar.showSessionCost) || (hasBalance && statusBar.showBalance));
 
-  const store = useAgentStore();
-  const rows = stdout?.rows ?? 40;
-  // Click-to-toggle: a mouse click on the status bar (bottom ~2 rows)
-  // flips the display currency between USD and CNY.
-  useKeystroke((ev) => {
-    if (!ev.mouseClick || !ev.mouseRow) return;
-    if (ev.mouseRow < rows - 2) return;
-    const cur = status.costDisplayCurrency ?? status.balanceCurrency ?? "CNY";
-    const next = cur === "USD" ? "CNY" : "USD";
-    const label = next === "USD" ? "$" : "¥";
-    store.dispatch({ type: "session.update" as const, patch: { costDisplayCurrency: next } });
-    store.dispatch({
-      type: "toast.show",
-      tone: "info",
-      title: `Costs: ${label}${next}`,
-      ttlMs: 2000,
-    });
-  });
-
   return (
     <Box flexDirection="row" flexShrink={0} marginTop={1}>
       <Box flexDirection="row" flexWrap="wrap" flexGrow={1}>
@@ -113,7 +93,7 @@ export function StatusRow({
             <Gap />
             <Pill>
               <Text bold color={TONE.brand}>
-                {"↻ "}
+                {"▸ "}
               </Text>
               <Text bold color={FG.body}>
                 {`${formatCost(status.cost, status.costDisplayCurrency ?? status.balanceCurrency)} ${t("statusBar.turn")}`}

--- a/src/cli/ui/state/events.ts
+++ b/src/cli/ui/state/events.ts
@@ -122,6 +122,7 @@ const sessionUpdate = z.object({
     sessionCost: z.number().optional(),
     balance: z.number().optional(),
     balanceCurrency: z.string().optional(),
+    costDisplayCurrency: z.string().optional(),
     cacheHit: z.number().optional(),
   }),
 });

--- a/src/cli/ui/state/state.ts
+++ b/src/cli/ui/state/state.ts
@@ -29,6 +29,10 @@ export interface StatusBar {
   sessionCost: number;
   balance?: number;
   balanceCurrency?: string;
+  /** User-togglable cost display currency ("USD" or "CNY"). When set, takes
+   *  precedence over `balanceCurrency` for cost formatting. Seeded from
+   *  config on mount; toggle by clicking the turn-cost pill in the status bar. */
+  costDisplayCurrency?: string;
   cacheHit: number;
   /** Last-turn prompt tokens; drives the context-usage pill. */
   promptTokens?: number;

--- a/src/cli/ui/theme/tokens.ts
+++ b/src/cli/ui/theme/tokens.ts
@@ -336,20 +336,9 @@ export function formatBalance(
   return opts?.label ? `w ${body}` : body;
 }
 
-/** Module-level default cost currency, set at startup from user config.
- *  `undefined` means "no user preference" — falls back to wallet currency or CNY. */
-let _defaultCostCurrency: string | undefined;
-
-/** Override the default cost display currency. Called at startup from App.tsx
- *  with the user's `costCurrency` config value. Pass `undefined` to reset. */
-export function setDefaultCostCurrency(currency: string | undefined): void {
-  _defaultCostCurrency = currency;
-}
-
-/** Format an internal USD cost in the wallet's display currency. Falls back to
- *  `_defaultCostCurrency` (set from config), then CNY. */
+/** Format an internal USD cost in the wallet's display currency. Undefined currency → CNY. */
 export function formatCost(costUsd: number, currency?: string, fractionDigits = 4): string {
-  const cur = currency ?? _defaultCostCurrency ?? "CNY";
+  const cur = currency ?? "CNY";
   const amount = cur === "CNY" ? costUsd * USD_TO_CNY : costUsd;
   return formatBalance(amount, cur, { fractionDigits });
 }

--- a/src/cli/ui/theme/tokens.ts
+++ b/src/cli/ui/theme/tokens.ts
@@ -336,9 +336,20 @@ export function formatBalance(
   return opts?.label ? `w ${body}` : body;
 }
 
-/** Format an internal USD cost in the wallet's display currency. Undefined currency → CNY. */
+/** Module-level default cost currency, set at startup from user config.
+ *  `undefined` means "no user preference" — falls back to wallet currency or CNY. */
+let _defaultCostCurrency: string | undefined;
+
+/** Override the default cost display currency. Called at startup from App.tsx
+ *  with the user's `costCurrency` config value. Pass `undefined` to reset. */
+export function setDefaultCostCurrency(currency: string | undefined): void {
+  _defaultCostCurrency = currency;
+}
+
+/** Format an internal USD cost in the wallet's display currency. Falls back to
+ *  `_defaultCostCurrency` (set from config), then CNY. */
 export function formatCost(costUsd: number, currency?: string, fractionDigits = 4): string {
-  const cur = currency ?? "CNY";
+  const cur = currency ?? _defaultCostCurrency ?? "CNY";
   const amount = cur === "CNY" ? costUsd * USD_TO_CNY : costUsd;
   return formatBalance(amount, cur, { fractionDigits });
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -216,6 +216,9 @@ export interface ReasonixConfig {
     showVersion?: boolean;
     showFeedbackHint?: boolean;
   };
+  /** Preferred display currency for costs (e.g. "USD" or "CNY"). When unset, falls back
+   *  to the wallet currency if available, then defaults to CNY. */
+  costCurrency?: string;
   projects?: {
     [absoluteRootDir: string]: {
       shellAllowed?: string[];

--- a/tests/ui-usage-card-balance.test.tsx
+++ b/tests/ui-usage-card-balance.test.tsx
@@ -10,7 +10,16 @@ import React from "react";
 import { describe, expect, it } from "vitest";
 import { UsageCard } from "../src/cli/ui/cards/UsageCard.js";
 import type { UsageCard as UsageCardData } from "../src/cli/ui/state/cards.js";
+import { AgentStoreProvider } from "../src/cli/ui/state/provider.js";
+import type { SessionInfo } from "../src/cli/ui/state/state.js";
 import { makeFakeStdin, makeFakeStdout } from "./helpers/ink-stdio.js";
+
+const SESSION: SessionInfo = {
+  id: "test",
+  branch: "main",
+  workspace: "/tmp",
+  model: "deepseek-chat",
+};
 
 function baseCard(overrides: Partial<UsageCardData> = {}): UsageCardData {
   return {
@@ -29,10 +38,14 @@ function baseCard(overrides: Partial<UsageCardData> = {}): UsageCardData {
 
 function renderCard(card: UsageCardData): string {
   const stdout = makeFakeStdout();
-  const { unmount } = render(React.createElement(UsageCard, { card }), {
-    stdout: stdout as never,
-    stdin: makeFakeStdin() as never,
-  });
+  const { unmount } = render(
+    React.createElement(
+      AgentStoreProvider,
+      { session: SESSION },
+      React.createElement(UsageCard, { card }),
+    ),
+    { stdout: stdout as never, stdin: makeFakeStdin() as never },
+  );
   unmount();
   return stdout.text();
 }


### PR DESCRIPTION
Closes #1708

## Summary

Cost per turn always displays in CNY (¥), even for users who think in USD. All internal pricing is native USD -- only the display defaults to CNY. This adds a config option and a clickable status bar to let users choose their preferred currency.

## Changes

- costCurrency config field for persistent preference
- Click-to-toggle on the status bar (bottom ~2 rows)
- Toast notification on toggle
- Reactive re-render in both StatusRow and UsageCard
- glyph hints the cost pill is interactive
- Wallet balance stays in its actual currency unaffected

## Verification

- npm run verify passes: 264 test files, 3624 tests, 0 failures
- comment-policy tests pass (9/9)
- No regressions
