### PR TITLE
fix(loop): provider-neutral 5xx wording when host is not DeepSeek

### DIFF
--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -724,6 +724,10 @@ export const EN: TranslationSchema = {
       " Try: (1) check your network, (2) wait 30s and retry, (3) status page: https://status.deepseek.com.",
     deepseek5xxActionRetry:
       " Try: (1) wait 30s and retry, (2) /model to switch model, (3) status page: https://status.deepseek.com.",
+    upstream5xxHead:
+      "Upstream service unavailable ({status}) at {host} — the configured API endpoint returned a server error, not a Reasonix bug. Already retried 4× with backoff.",
+    upstream5xxActionRetry:
+      " Try: (1) check that the local/proxy model server is up, (2) wait and retry, (3) /model to switch model.",
     innerNoMessage: "(no message)",
     reasonAborted: "[aborted by user (Esc) — summarizing what I found so far]",
     reasonContextGuard:

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -314,6 +314,8 @@ export interface TranslationSchema {
     deepseek5xxUnreachable: string;
     deepseek5xxActionNetwork: string;
     deepseek5xxActionRetry: string;
+    upstream5xxHead: string;
+    upstream5xxActionRetry: string;
     innerNoMessage: string;
     reasonAborted: string;
     reasonContextGuard: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -698,6 +698,10 @@ export const zhCN: TranslationSchema = {
       " 建议：(1) 检查网络，(2) 等 30 秒后重试，(3) 查看状态页 https://status.deepseek.com。",
     deepseek5xxActionRetry:
       " 建议：(1) 等 30 秒后重试，(2) 用 /model 切换模型，(3) 查看状态页 https://status.deepseek.com。",
+    upstream5xxHead:
+      "上游服务不可用（{status}），目标地址 {host} — 你配置的 API 端点返回了服务器错误，不是 Reasonix 故障。已按指数退避重试 4 次。",
+    upstream5xxActionRetry:
+      " 建议：(1) 确认本地/代理模型服务在线，(2) 等一会儿再重试，(3) 用 /model 切换模型。",
     innerNoMessage: "（无错误信息）",
     reasonAborted: "[用户已中断（Esc） — 正在总结到目前为止的发现]",
     reasonContextGuard: "[上下文额度即将耗尽 — 在下一次调用溢出之前先总结]",

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -13,7 +13,12 @@ import {
 import { ContextManager, TURN_START_FOLD_THRESHOLD } from "./context-manager.js";
 import { InflightSet } from "./core/inflight.js";
 import { t } from "./i18n/index.js";
-import { formatLoopError, is5xxError, probeDeepSeekReachable } from "./loop/errors.js";
+import {
+  formatLoopError,
+  is5xxError,
+  isDeepSeekHost,
+  probeDeepSeekReachable,
+} from "./loop/errors.js";
 import { type ForceSummaryContext, forceSummaryAfterIterLimit } from "./loop/force-summary.js";
 import {
   fixToolCallPairing,
@@ -873,12 +878,15 @@ export class CacheFirstLoop {
           this._steerQueue.length = 0;
           return;
         }
-        const probe = is5xxError(err) ? await probeDeepSeekReachable(this.client) : undefined;
+        const upstreamHost = this.client.baseUrl;
+        const dsHost = isDeepSeekHost(upstreamHost);
+        const probe =
+          is5xxError(err) && dsHost ? await probeDeepSeekReachable(this.client) : undefined;
         yield {
           turn: this._turn,
           role: "error",
           content: "",
-          error: formatLoopError(err as Error, probe),
+          error: formatLoopError(err as Error, probe, { upstreamHost }),
         };
         this._steerQueue.length = 0;
         return;

--- a/src/loop/errors.ts
+++ b/src/loop/errors.ts
@@ -5,7 +5,16 @@ export interface DeepSeekProbeResult {
   reachable: boolean;
 }
 
-export function formatLoopError(err: Error, probe?: DeepSeekProbeResult): string {
+export interface FormatLoopErrorOptions {
+  /** baseUrl of the upstream that just failed — picks DS vs generic wording. */
+  upstreamHost?: string;
+}
+
+export function formatLoopError(
+  err: Error,
+  probe?: DeepSeekProbeResult,
+  opts?: FormatLoopErrorOptions,
+): string {
   const msg = err.message ?? "";
   if (msg.includes("maximum context length")) {
     const reqMatch = msg.match(/requested\s+(\d+)\s+tokens/);
@@ -26,7 +35,7 @@ export function formatLoopError(err: Error, probe?: DeepSeekProbeResult): string
   if (status === "422") return t("errors.badparam422", { inner });
   if (status === "400") return t("errors.badrequest400", { inner });
   if (status === "429") return t("errors.concurrency429", { inner });
-  if (is5xxStatus(status)) return formatDeepSeek5xx(status, probe);
+  if (is5xxStatus(status)) return format5xx(status, probe, opts?.upstreamHost);
   return msg;
 }
 
@@ -44,8 +53,30 @@ export async function probeDeepSeekReachable(
   return { reachable: balance !== null };
 }
 
+/** Allow-list — only api.deepseek.com gets DS-specific 5xx wording + balance probe. */
+export function isDeepSeekHost(baseUrl: string | undefined | null): boolean {
+  if (!baseUrl) return false;
+  try {
+    const host = new URL(baseUrl).hostname.toLowerCase();
+    return host === "api.deepseek.com";
+  } catch {
+    return false;
+  }
+}
+
 function is5xxStatus(status: string): boolean {
   return status === "500" || status === "502" || status === "503" || status === "504";
+}
+
+function format5xx(
+  status: string,
+  probe: DeepSeekProbeResult | undefined,
+  upstreamHost: string | undefined,
+): string {
+  if (upstreamHost !== undefined && !isDeepSeekHost(upstreamHost)) {
+    return formatUpstream5xx(status, upstreamHost);
+  }
+  return formatDeepSeek5xx(status, probe);
 }
 
 function formatDeepSeek5xx(status: string, probe?: DeepSeekProbeResult): string {
@@ -61,6 +92,18 @@ function formatDeepSeek5xx(status: string, probe?: DeepSeekProbeResult): string 
       ? t("errors.deepseek5xxActionNetwork")
       : t("errors.deepseek5xxActionRetry");
   return `${head}${probeNote}${action}`;
+}
+
+function formatUpstream5xx(status: string, baseUrl: string): string {
+  let host = baseUrl;
+  try {
+    host = new URL(baseUrl).host || baseUrl;
+  } catch {
+    /* keep raw baseUrl */
+  }
+  const head = t("errors.upstream5xxHead", { status, host });
+  const action = t("errors.upstream5xxActionRetry");
+  return `${head}${action}`;
 }
 
 export function reasonPrefixFor(reason: "aborted" | "context-guard" | "stuck"): string {

--- a/tests/loop-error.test.ts
+++ b/tests/loop-error.test.ts
@@ -129,6 +129,26 @@ describe("formatLoopError", () => {
     const out = formatLoopError(new Error("DeepSeek 500: "));
     expect(out).toMatch(/service unavailable \(500\)/);
   });
+
+  it("5xx from a non-DeepSeek host → generic upstream wording, no DS hint, no probe", () => {
+    const out = formatLoopError(new Error("DeepSeek 500: "), undefined, {
+      upstreamHost: "http://localhost:11434/v1",
+    });
+    expect(out).toMatch(/Upstream service unavailable \(500\)/);
+    expect(out).toContain("localhost:11434");
+    expect(out).not.toContain("status.deepseek.com");
+    expect(out).not.toMatch(/DeepSeek-side problem/);
+    expect(out).not.toMatch(/main API answered/);
+    expect(out).not.toMatch(/unreachable from your network/);
+  });
+
+  it("5xx from api.deepseek.com → still gets the DS-specific wording (allow-list)", () => {
+    const out = formatLoopError(new Error("DeepSeek 503: "), undefined, {
+      upstreamHost: "https://api.deepseek.com",
+    });
+    expect(out).toMatch(/DeepSeek-side problem/);
+    expect(out).toContain("status.deepseek.com");
+  });
 });
 
 describe("formatLoopError — zh-CN runtime switch", () => {
@@ -143,6 +163,18 @@ describe("formatLoopError — zh-CN runtime switch", () => {
     expect(out).toContain("503");
     expect(out).toContain("DeepSeek 服务端问题");
     expect(out).toContain("status.deepseek.com");
+  });
+
+  it("non-DS host 5xx translates when language is zh-CN, omits DS-specific hints", () => {
+    setLanguageRuntime("zh-CN");
+    const out = formatLoopError(new Error("DeepSeek 502: "), undefined, {
+      upstreamHost: "http://192.168.1.5:8080/v1",
+    });
+    expect(out).toContain("上游服务不可用");
+    expect(out).toContain("502");
+    expect(out).toContain("192.168.1.5:8080");
+    expect(out).not.toContain("status.deepseek.com");
+    expect(out).not.toContain("DeepSeek 服务端问题");
   });
 
   it("401 auth error translates when language is zh-CN, preserves the inner DS message", () => {


### PR DESCRIPTION
## Summary

- Local-model / proxy users were seeing "DeepSeek 服务不可用 … 查看状态页 https://status.deepseek.com" when their *local* model returned a 500.
- Three layers were assuming the upstream was always `api.deepseek.com`: the client error prefix (`DeepSeek N:`), `is5xxError`'s regex, and the `/user/balance` reachability probe (a DS-only endpoint that 404s on ollama / vLLM / etc.).
- Fix: allow-list `api.deepseek.com` for the DS-specific wording + probe. Anything else gets generic upstream-5xx wording with the actual host surfaced; the probe is skipped entirely so we don't make a meaningless network call.

## Files

- `src/loop/errors.ts` — adds `isDeepSeekHost(baseUrl)`, splits 5xx formatting into DS vs generic branches.
- `src/loop.ts` — passes the upstream host in, skips the probe when host is not DS.
- `src/i18n/{EN,zh-CN,types}.ts` — `upstream5xxHead` / `upstream5xxActionRetry` keys.
- `tests/loop-error.test.ts` — covers the local-host case (EN + zh-CN) and confirms `api.deepseek.com` keeps the existing wording.

## Test plan

- [x] `npm run verify` — 3625 passing
- [x] `tests/loop-error.test.ts` — new non-DS host cases + existing DS cases stay green