### PR TITLE
docs: sync ARCHITECTURE.md and benchmark pricing to match code

### DIFF
--- a/benchmarks/real-world-cache/README.md
+++ b/benchmarks/real-world-cache/README.md
@@ -20,22 +20,22 @@ Used with permission, anonymized.
 ## Cost — using the prices Reasonix bills against (`src/telemetry/stats.ts`)
 
 USD per 1M tokens — `inputCacheHit / inputCacheMiss / output`:
-- `deepseek-v4-flash` — `0.028 / 0.139 / 0.278`
-- `deepseek-v4-pro` — `0.139 / 1.667 / 3.333`
+- `deepseek-v4-flash` — `0.0028 / 0.14 / 0.28`
+- `deepseek-v4-pro` — `0.003625 / 0.435 / 0.87`
 
 Assuming **v4-flash** (the project default):
 
 | | This user (99.82% hit) | Same workload, **0% cache** |
 |---|---:|---:|
-| Cache-hit input | $12.18 | — |
-| Cache-miss input | $0.11 | $60.58 |
+| Cache-hit input | $1.22 | — |
+| Cache-miss input | $0.11 | $61.01 |
 | Output | $0.05 | $0.05 |
-| **Total / day** | **$12.34** | **$60.63** |
+| **Total / day** | **$1.38** | **$61.06** |
 
-→ Cache saved this user **$48.29**, or **~80%** off the un-cached baseline, on a single day.
+→ Cache saved this user **$59.68**, or **~97.7%** off the un-cached baseline, on a single day.
 
-On **v4-pro** (5× the prefix-cache discount) the same workload would cost
-**~$62.35** vs **~$727.08** without cache — a **~91% saving**.
+On **v4-pro** (6.25% of uncached input cost) the same workload would cost
+**~$2.07** vs **~$189.73** without cache — a **~98.9%** saving.
 
 ## "Isn't that just DeepSeek's prefix cache?"
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -122,24 +122,32 @@ dragging 12KB through every future prompt.
 A proactive 40% context-ratio threshold runs the same shrink pre-emptively
 inside long multi-iter turns before the 80% emergency threshold fires.
 
-#### 4.3 `/pro` single-turn arming
+#### 4.3 Model selection (`/model`)
 
-Users who predict a hard task type `/pro`; the **next** turn runs on
-`v4-pro`, then auto-disarms. No preset churn, no forgotten revert. Armed
-state is visible as a yellow `⇧ pro armed` pill in the header.
+Users switch between flash and pro via `/model flash` or `/model pro`
+(persistent — applies to every turn until changed). Model can also be
+set in `.reasonix/settings.json` under the `model` key. No one-shot
+arming; no forgotten revert risk when switching is explicit and sticky.
 
-#### 4.4 Failure-signal auto-escalation
+> **History.** Pre-0.50.0, `/pro` offered single-turn arming — type `/pro`,
+> the next turn ran on v4-pro then auto-disarmed. Removed in 0.50.0
+> (#1657, #1630) when presets were collapsed into direct model selection.
 
-The loop counts visible "flash is struggling" events per turn:
-- `edit_file` / `write_file` SEARCH-not-found errors
-- ToolCallRepair fires (scavenge / truncation-fix / storm-break)
+#### 4.4 Model self-report escalation (`<<<NEEDS_PRO>>>`)
 
-Once the count hits `FAILURE_ESCALATION_THRESHOLD` (3), the **remainder of
-the current turn** runs on `v4-pro`. Announced via a yellow warning row —
-no silent cost surprises. Counter + escalation flag reset at every turn
-start.
+The model itself decides when a task exceeds its current tier. If a task
+clearly needs stronger reasoning, the model emits a `<<<NEEDS_PRO>>>`
+marker as the first line of its response. The system aborts the current
+flash call and retries the turn on pro. Two forms:
 
-Header shows a red `⇧ pro escalated` pill while the turn is on pro.
+- `<<<NEEDS_PRO>>>` — bare marker, no rationale.
+- `<<<NEEDS_PRO: <reason>>>>` — includes a one-sentence rationale the
+  user sees in a warning row.
+
+On the pro tier, the marker is a no-op — pro is the top, so the contract
+tells the model it can't escalate further. This is purely self-report:
+there is no failure-counter threshold, no scavenge/storm counting, no
+automatic escalation based on tool errors.
 
 #### Cost transparency
 


### PR DESCRIPTION
Three stale-doc fixes where documentation no longer matches the actual codebase:

### 1. ARCHITECTURE.md §4.3 — `/pro` single-turn arming (removed in 0.50.0)
Rewrote to describe the current `/model flash|pro` command and config-based model selection. Added a history note referencing #1657, #1630.

### 2. ARCHITECTURE.md §4.4 — `FAILURE_ESCALATION_THRESHOLD=3` auto-escalation (never existed in code)
Replaced with the actual `<<<NEEDS_PRO>>>` model self-report mechanism. No failure-counter, no scavenge/storm counting — purely LLM-initiated. The `"failure-threshold"` variant in `EscalatedEvent.reason` is also dead code; kept the type union for now.

### 3. `benchmarks/real-world-cache/README.md` — pricing numbers out of sync with `src/telemetry/stats.ts`
The displayed pricing for v4-flash cache-hit was 10x the code value (0.028 → 0.0028). v4-pro pricing was entirely wrong (0.139/1.667/3.333 → 0.003625/0.435/0.87). Recalculated both cost tables and savings percentages. The headline cache-hit ratio (99.82%) is unchanged.

### Verification
- `grep FAILURE_ESCALATION_THRESHOLD src/ -r` → zero matches (only in docs)
- `grep "/pro" CHANGELOG.md` → confirms removal in 0.50.0 (#1657, #1630)
- `stats.ts` pricing cross-referenced with case study cost math
