### PR TITLE
fix(tui): drop escapeless legacy mouse reports

### DIFF
--- a/src/cli/ui/stdin-reader.ts
+++ b/src/cli/ui/stdin-reader.ts
@@ -110,6 +110,8 @@ function tryEscapelessCsi(chunk: string, i: number): { advance: number; ev: KeyE
 
 /** `[<btn;col;row[Mm]` — SGR mouse report body (without leading ESC). */
 const SGR_MOUSE_ESCAPELESS_RE = /^\[<\d+;\d+;\d+[Mm]/;
+const LEGACY_MOUSE_ESCAPELESS_PREFIX = "[M";
+const LEGACY_MOUSE_ESCAPELESS_LEN = LEGACY_MOUSE_ESCAPELESS_PREFIX.length + 3;
 
 function decodeSgrMouseBody(body: string): KeyEvent | null {
   const m = /^<(\d+);(\d+);(\d+)([Mm])$/.exec(body);
@@ -137,6 +139,16 @@ function tryEscapelessSgrMouse(
   if (!m) return null;
   const body = m[0].slice(1);
   return { advance: m[0].length, ev: decodeSgrMouseBody(body) };
+}
+
+function tryEscapelessLegacyMouse(chunk: string, i: number): { advance: number } | null {
+  if (
+    chunk.slice(i, i + LEGACY_MOUSE_ESCAPELESS_PREFIX.length) !== LEGACY_MOUSE_ESCAPELESS_PREFIX
+  ) {
+    return null;
+  }
+  if (chunk.length - i < LEGACY_MOUSE_ESCAPELESS_LEN) return null;
+  return { advance: LEGACY_MOUSE_ESCAPELESS_LEN };
 }
 
 function isCsiFinal(ch: string): boolean {
@@ -470,6 +482,11 @@ export class StdinReader {
         i += mouseEscapeless.advance;
         continue;
       }
+      const legacyMouseEscapeless = tryEscapelessLegacyMouse(chunk, i);
+      if (legacyMouseEscapeless) {
+        i += legacyMouseEscapeless.advance;
+        continue;
+      }
 
       // Single-byte control keys.
       // \r (CR, 0x0D) is Enter on every terminal in raw mode.
@@ -528,7 +545,14 @@ export class StdinReader {
         if (cc >= 1 && cc <= 26) break;
         // Don't swallow into a printable run if a CSI / paste prefix
         // starts at this position.
-        if (c === "[" && (tryEscapelessCsi(chunk, end) || tryEscapelessSgrMouse(chunk, end))) break;
+        if (
+          c === "[" &&
+          (tryEscapelessCsi(chunk, end) ||
+            tryEscapelessSgrMouse(chunk, end) ||
+            tryEscapelessLegacyMouse(chunk, end))
+        ) {
+          break;
+        }
         if (chunk.slice(end, end + PASTE_START_BARE.length) === PASTE_START_BARE) break;
         end++;
       }

--- a/tests/stdin-reader.test.ts
+++ b/tests/stdin-reader.test.ts
@@ -452,6 +452,26 @@ describe("StdinReader — SGR mouse reports (issue #867)", () => {
     }
     expect(events).toEqual([]);
   });
+
+  it("drops ESC-stripped legacy X10 mouse reports instead of leaking prompt input (#1598)", () => {
+    const { reader, events } = setup();
+    reader.feed("[M`*%");
+    expect(events).toEqual([]);
+  });
+
+  it("drops an ESC-stripped legacy X10 mouse-report flood without surfacing prompt input (#1598)", () => {
+    const { reader, events } = setup();
+    for (let i = 0; i < 1000; i++) {
+      reader.feed("[M`*%");
+    }
+    expect(events).toEqual([]);
+  });
+
+  it("keeps printable text around an ESC-stripped legacy X10 report intact", () => {
+    const { reader, events } = setup();
+    reader.feed("ab[M`*%cd");
+    expect(events).toEqual([{ input: "ab" }, { input: "cd" }]);
+  });
 });
 
 describe("sanitizePasteText (issue #849)", () => {


### PR DESCRIPTION
## Summary
- Drop ESC-stripped legacy X10 mouse reports before they can reach the prompt input path.
- Keep nearby printable text intact while consuming the five-byte legacy mouse packet.
- Add regression coverage for the remaining #1598 flood shape.

## Root cause
#1637 handled full `ESC [ M ...` legacy X10 reports, but Windows ConPTY can strip the leading ESC. In that form, `[M...` was still treated as printable prompt input, so repeated terminal mouse reports could keep growing composer state.

## Tests
- `npm test -- --run tests/stdin-reader.test.ts tests/mouse-mode.test.ts`
- `npx biome check src/cli/ui/stdin-reader.ts tests/stdin-reader.test.ts`
- `npm run typecheck`
- `npm run verify`

Refs #1598