### PR TITLE
Fix desktop slash setting sync

### DIFF
--- a/desktop/src/App.test.ts
+++ b/desktop/src/App.test.ts
@@ -241,4 +241,27 @@ describe("Desktop App reducer — ApprovalPrompt integration", () => {
     expect(next.pendingConfirms).toHaveLength(0);
     expect(next.pendingPathAccess).toHaveLength(0);
   });
+
+  it("patches settings optimistically for desktop setting commands", () => {
+    const state = {
+      ...initialState(),
+      settings: {
+        reasoningEffort: "medium",
+        editMode: "review",
+        budgetUsd: null,
+        workspaceDir: "/workspace",
+        recentWorkspaces: [],
+        model: "deepseek-v4-flash",
+        version: "0.50.1",
+      },
+    };
+
+    const next = reduce(state, {
+      t: "settings_patch",
+      patch: { reasoningEffort: "low", editMode: "auto" },
+    });
+
+    expect(next.settings?.reasoningEffort).toBe("low");
+    expect(next.settings?.editMode).toBe("auto");
+  });
 });

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -20,6 +20,11 @@ import {
 import { getLang, setLang, t, useLang } from "./i18n";
 import { I } from "./icons";
 import {
+  buildSlashSettingsDescriptors,
+  parseSlashSettingsCommand,
+  type SlashSettingsCommand,
+} from "./slash-settings";
+import {
   FONT_FAMILY,
   FONT_FAMILY_STACK,
   FONT_SCALE,
@@ -317,6 +322,7 @@ type Action =
   | { t: "enqueue_send"; text: string }
   | { t: "dequeue_send"; index: number }
   | { t: "shift_queued_send" }
+  | { t: "settings_patch"; patch: SettingsPatch }
   | { t: "push_status"; text: string };
 
 function fallbackSkillDesc(skill: SkillInfo): string {
@@ -395,6 +401,10 @@ export function reduce(state: State, action: Action): State {
       };
     case "incoming":
       return applyIncoming(state, action.event);
+    case "settings_patch":
+      return state.settings
+        ? { ...state, settings: { ...state.settings, ...action.patch } }
+        : state;
     case "batch_delta": {
       const collapsed: DeltaBatchItem[] = [];
       for (const item of action.items) {
@@ -1372,6 +1382,13 @@ function TabRuntime({
     (patch: SettingsPatch) => sendRpc({ cmd: "settings_save", ...patch }),
     [sendRpc],
   );
+  const applySettingsPatch = useCallback(
+    (patch: SettingsPatch) => {
+      dispatch({ t: "settings_patch", patch });
+      saveSettings(patch);
+    },
+    [saveSettings],
+  );
   const loadQQSettings = useCallback(() => sendRpc({ cmd: "qq_status_get" }), [sendRpc]);
   const connectQQ = useCallback(() => sendRpc({ cmd: "qq_connect" }), [sendRpc]);
   const disconnectQQ = useCallback(() => sendRpc({ cmd: "qq_disconnect" }), [sendRpc]);
@@ -1421,6 +1438,37 @@ function TabRuntime({
       window.setTimeout(() => setToast(null), opts?.duration ?? 1600);
     },
     [],
+  );
+
+  const applyReasoningEffort = useCallback(
+    (reasoningEffort: Settings["reasoningEffort"]) => {
+      applySettingsPatch({ reasoningEffort });
+      flashToast(t("app.toast.effortSwitched", { effort: reasoningEffort }));
+    },
+    [applySettingsPatch, flashToast],
+  );
+
+  const applyEditMode = useCallback(
+    (mode: Settings["editMode"]) => {
+      applySettingsPatch({ editMode: mode });
+      if (mode === "yolo") {
+        flashToast(t("app.yolo.toast"), { yolo: true, duration: 3000 });
+      } else {
+        flashToast(t("app.toast.modeSwitched", { mode: mode.toUpperCase() }));
+      }
+    },
+    [applySettingsPatch, flashToast],
+  );
+
+  const applySlashSettingsCommand = useCallback(
+    (command: SlashSettingsCommand) => {
+      if (command.type === "reasoningEffort") {
+        applyReasoningEffort(command.reasoningEffort);
+      } else {
+        applyEditMode(command.editMode);
+      }
+    },
+    [applyEditMode, applyReasoningEffort],
   );
 
   // Drag-and-drop: dropping files/folders onto the window inserts them
@@ -1492,6 +1540,13 @@ function TabRuntime({
       const text = (override ?? draft).trim();
       if (!text || !state.ready || state.busy) return;
 
+      const settingsCommand = parseSlashSettingsCommand(text);
+      if (settingsCommand) {
+        applySlashSettingsCommand(settingsCommand);
+        if (!override) setDraft("");
+        return;
+      }
+
       // /btw <question> — route to side-question RPC instead of user_input.
       // Empty payload used to silently swallow the keystroke (#1370); surface
       // the usage hint as a status message so the user knows what's expected.
@@ -1534,7 +1589,15 @@ function TabRuntime({
       sendRpc({ cmd: "user_input", text });
       if (!override) setDraft("");
     },
-    [draft, state.ready, state.busy, state.skills, sendRpc, recordAbortDraft],
+    [
+      draft,
+      state.ready,
+      state.busy,
+      state.skills,
+      sendRpc,
+      recordAbortDraft,
+      applySlashSettingsCommand,
+    ],
   );
 
   const abort = useCallback(() => {
@@ -1848,6 +1911,17 @@ function TabRuntime({
     hasMessages: state.messages.length > 0,
   });
 
+  const slashSettingCommands: SlashCmd[] = buildSlashSettingsDescriptors().map(
+    ({ cmd, action }) => ({
+      cmd,
+      desc:
+        action.type === "editMode"
+          ? t("app.cmd.setMode", { mode: action.editMode })
+          : t("app.cmd.setEffort", { effort: action.reasoningEffort }),
+      run: () => applySlashSettingsCommand(action),
+    }),
+  );
+
   const slashCommands: SlashCmd[] = [
     {
       cmd: "/help",
@@ -1878,6 +1952,7 @@ function TabRuntime({
       },
     },
     { cmd: "/model", desc: t("app.cmd.switchModel"), run: () => openSettingsAt("models") },
+    ...slashSettingCommands,
     { cmd: "/theme", desc: t("app.cmd.toggleTheme"), run: onToggleTheme },
     {
       cmd: "/currency",
@@ -2325,22 +2400,12 @@ function TabRuntime({
                 modelLabel={state.settings?.model ?? "deepseek-v4-flash"}
                 reasoningEffort={state.settings?.reasoningEffort ?? "high"}
                 onModelChange={(model) => {
-                  saveSettings({ model });
+                  applySettingsPatch({ model });
                   flashToast(t("app.toast.modelSwitched", { model }));
                 }}
-                onEffortChange={(reasoningEffort) => {
-                  saveSettings({ reasoningEffort });
-                  flashToast(t("app.toast.effortSwitched", { effort: reasoningEffort }));
-                }}
+                onEffortChange={applyReasoningEffort}
                 editMode={state.settings?.editMode ?? "review"}
-                onEditModeChange={(mode) => {
-                  saveSettings({ editMode: mode });
-                  if (mode === "yolo") {
-                    flashToast(t("app.yolo.toast"), { yolo: true, duration: 3000 });
-                  } else {
-                    flashToast(t("app.toast.modeSwitched", { mode: mode.toUpperCase() }));
-                  }
-                }}
+                onEditModeChange={applyEditMode}
                 workspaceDir={state.settings?.workspaceDir}
                 slashCommands={slashCommands}
                 onMentionQuery={queryMentions}

--- a/desktop/src/i18n/en.ts
+++ b/desktop/src/i18n/en.ts
@@ -385,6 +385,8 @@ export const en = {
       abort: "Stop streaming output",
       copyLast: "Copy last reply",
       switchModel: "Switch model",
+      setMode: "Set mode to {mode}",
+      setEffort: "Set reasoning effort to {effort}",
       toggleTheme: "Toggle theme",
       toggleCurrency: "Toggle currency (CNY / USD)",
       toggleLang: "Toggle language (CN / EN)",

--- a/desktop/src/i18n/zh-CN.ts
+++ b/desktop/src/i18n/zh-CN.ts
@@ -405,6 +405,8 @@ export const zhCN: typeof en = {
       abort: "中断流式输出",
       copyLast: "复制最后一条回复",
       switchModel: "切换模型",
+      setMode: "切换模式为 {mode}",
+      setEffort: "切换推理强度为 {effort}",
       toggleTheme: "切换深浅主题",
       toggleCurrency: "切换货币显示 (CNY / USD)",
       toggleLang: "切换界面语言 (中 / 英)",

--- a/desktop/src/slash-settings.ts
+++ b/desktop/src/slash-settings.ts
@@ -1,0 +1,74 @@
+import type { EditMode, ReasoningEffort } from "./protocol";
+
+export const SLASH_EDIT_MODES = [
+  "plan",
+  "review",
+  "auto",
+  "yolo",
+] as const satisfies readonly EditMode[];
+export const SLASH_REASONING_EFFORTS = [
+  "low",
+  "medium",
+  "high",
+  "max",
+] as const satisfies readonly ReasoningEffort[];
+
+export type SlashSettingsCommand =
+  | { type: "editMode"; editMode: EditMode }
+  | { type: "reasoningEffort"; reasoningEffort: ReasoningEffort };
+
+export type SlashSettingsDescriptor = {
+  cmd: string;
+  action: SlashSettingsCommand;
+};
+
+function isEditMode(value: string): value is EditMode {
+  return (SLASH_EDIT_MODES as readonly string[]).includes(value);
+}
+
+function isReasoningEffort(value: string): value is ReasoningEffort {
+  return (SLASH_REASONING_EFFORTS as readonly string[]).includes(value);
+}
+
+export function parseSlashSettingsCommand(input: string): SlashSettingsCommand | null {
+  const match = /^\/([a-zA-Z0-9_-]+)(?:\s+([^\s]+))?$/.exec(input.trim());
+  if (!match) return null;
+
+  const name = match[1]?.toLowerCase();
+  const arg = match[2]?.toLowerCase();
+
+  if (name === "effort") {
+    if (arg && isReasoningEffort(arg)) return { type: "reasoningEffort", reasoningEffort: arg };
+    return null;
+  }
+
+  if (name === "plan" && !arg) {
+    return { type: "editMode", editMode: "plan" };
+  }
+
+  if ((name === "model" || name === "mode" || name === "plan") && arg && isEditMode(arg)) {
+    return { type: "editMode", editMode: arg };
+  }
+
+  return null;
+}
+
+export function buildSlashSettingsDescriptors(): SlashSettingsDescriptor[] {
+  const modelModes = SLASH_EDIT_MODES.map((mode) => ({
+    cmd: `/model ${mode}`,
+    action: { type: "editMode", editMode: mode } as const,
+  }));
+  const planModes = [
+    { cmd: "/plan", action: { type: "editMode", editMode: "plan" } as const },
+    ...SLASH_EDIT_MODES.filter((mode) => mode !== "plan").map((mode) => ({
+      cmd: `/plan ${mode}`,
+      action: { type: "editMode", editMode: mode } as const,
+    })),
+  ];
+  const effortCommands = SLASH_REASONING_EFFORTS.map((effort) => ({
+    cmd: `/effort ${effort}`,
+    action: { type: "reasoningEffort", reasoningEffort: effort } as const,
+  }));
+
+  return [...modelModes, ...planModes, ...effortCommands];
+}

--- a/tests/desktop-slash-settings.test.ts
+++ b/tests/desktop-slash-settings.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSlashSettingsDescriptors,
+  parseSlashSettingsCommand,
+} from "../desktop/src/slash-settings";
+
+describe("desktop slash settings", () => {
+  it("parses reasoning effort commands", () => {
+    expect(parseSlashSettingsCommand("/effort low")).toEqual({
+      type: "reasoningEffort",
+      reasoningEffort: "low",
+    });
+  });
+
+  it("parses edit mode commands from model and plan aliases", () => {
+    expect(parseSlashSettingsCommand("/model auto")).toEqual({
+      type: "editMode",
+      editMode: "auto",
+    });
+    expect(parseSlashSettingsCommand("/plan auto")).toEqual({
+      type: "editMode",
+      editMode: "auto",
+    });
+  });
+
+  it("treats bare /plan as plan mode", () => {
+    expect(parseSlashSettingsCommand("/plan")).toEqual({
+      type: "editMode",
+      editMode: "plan",
+    });
+  });
+
+  it("ignores unknown or incomplete setting commands", () => {
+    expect(parseSlashSettingsCommand("/effort turbo")).toBeNull();
+    expect(parseSlashSettingsCommand("/model")).toBeNull();
+    expect(parseSlashSettingsCommand("/unknown auto")).toBeNull();
+  });
+
+  it("exposes setting commands to slash suggestions and help", () => {
+    const commands = buildSlashSettingsDescriptors().map((entry) => entry.cmd);
+
+    expect(commands).toContain("/model auto");
+    expect(commands).toContain("/plan auto");
+    expect(commands).toContain("/effort low");
+  });
+});


### PR DESCRIPTION
## Summary
- Add desktop slash setting entries for `/model <mode>`, `/plan <mode>`, and `/effort <level>` so they appear in command suggestions and help.
- Parse direct Enter submissions for those setting commands before they fall through as normal prompts.
- Patch desktop settings optimistically so the composer status and settings dialog reflect the new mode or effort immediately.

## Verification
- `npm test -- --run tests/desktop-slash-settings.test.ts desktop/src/App.test.ts`
- `npx biome check desktop/src/slash-settings.ts tests/desktop-slash-settings.test.ts desktop/src/App.test.ts`
- `npm run typecheck`
- `npm run verify`

Fixes #1705