### PR TITLE
feat(desktop): add JumpBar message navigation dock

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -57,6 +57,7 @@ import { JobsPop } from "./ui/jobs-pop";
 import { useElapsed } from "./ui/live";
 import { AboutModal } from "./ui/about";
 import { SettingsModal, type PageId as SettingsPageId } from "./ui/settings";
+import { JumpBar } from "./ui/jump-bar";
 import { Sidebar } from "./ui/sidebar";
 import { Shortcut, localizeShortcutText, shortcutText } from "./ui/shortcut";
 import { Splash, shouldShowSplash } from "./ui/splash";
@@ -2079,6 +2080,7 @@ function TabRuntime({
         ) : null}
 
         <main className="main" style={{ position: "relative" }}>
+          <JumpBar messages={state.messages} threadEl={threadRef.current} />
           {state.needsSetup ? (
             <NeedsSetupView
               workspaceDir={state.settings?.workspaceDir}
@@ -2149,7 +2151,7 @@ function TabRuntime({
                       const prev = state.messages[i - 1];
                       const needsDivider = !prev || prev.kind === "user";
                       return (
-                        <div key={`u-${i}`}>
+                        <div key={`u-${i}`} data-turn={m.turn}>
                           {needsDivider ? <TurnDivider label={dividerLabel} /> : null}
                           <UserMsg text={m.text} skill={m.skill} onEdit={onEditUserMsg} />
                         </div>
@@ -2366,7 +2368,6 @@ function TabRuntime({
             onMouseDown={onCtxResizeDown}
           />
         ) : null}
-
         <ContextPanel
           settings={state.settings}
           usage={state.usage}

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -1613,6 +1613,74 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
   gap: 28px;
 }
 
+/* ---------- JUMP BAR (message navigation dock) ---------- */
+
+.jump-bar {
+  position: absolute;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0 12px;
+  z-index: 20;
+}
+.jump-scroll {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 0;
+  max-height: 240px;
+  overflow-y: auto;
+  scrollbar-width: none;
+  -webkit-mask-image: linear-gradient(to bottom, transparent 0%, #000 16%, #000 84%, transparent 100%);
+  mask-image: linear-gradient(to bottom, transparent 0%, #000 16%, #000 84%, transparent 100%);
+}
+.jump-scroll::-webkit-scrollbar {
+  display: none;
+}
+.jump-item {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  width: 32px;
+  min-height: 14px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.jump-dot {
+  height: 3px;
+  border-radius: 2px;
+  background: var(--border-strong);
+  transition: background 200ms, width 400ms cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+.jump-dot[data-active] {
+  background: var(--accent);
+}
+.jump-preview {
+  position: absolute;
+  right: 100%;
+  top: 0;
+  transform: translateY(-50%);
+  margin-right: 12px;
+  padding: 4px 8px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 12px;
+  color: var(--fg);
+  white-space: nowrap;
+  max-width: 240px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  box-shadow: var(--shadow-sm);
+  z-index: 21;
+  pointer-events: none;
+}
+
 /* Jump-to-bottom button — shown when user has scrolled up during streaming */
 .thread-jump-bottom {
   position: sticky;

--- a/desktop/src/ui/jump-bar.tsx
+++ b/desktop/src/ui/jump-bar.tsx
@@ -1,0 +1,93 @@
+import { useMemo, useRef, useState } from "react";
+
+interface JumpBarProps {
+  messages: { kind: string; text?: string; turn?: number }[];
+  threadEl: HTMLElement | null;
+}
+
+export function JumpBar({ messages, threadEl }: JumpBarProps) {
+  const [hovered, setHovered] = useState<number | null>(null);
+  const barRef = useRef<HTMLDivElement>(null);
+  const previewTop = useRef(0);
+  const [showPreview, setShowPreview] = useState(false);
+
+  const items = useMemo(
+    () =>
+      messages
+        .filter((m): m is { kind: "user"; text: string; turn: number } =>
+          m.kind === "user" && typeof m.text === "string" && typeof m.turn === "number",
+        )
+        .map((m) => ({ turn: m.turn, text: m.text.slice(0, 80) })),
+    [messages],
+  );
+
+  if (items.length < 2) return null;
+
+  const visible = items;
+  const hoverIdx = hovered !== null ? visible.findIndex((v) => v.turn === hovered) : -1;
+  const hoverText = hovered !== null ? visible.find((v) => v.turn === hovered)?.text : null;
+
+  const onMove = (e: React.MouseEvent) => {
+    const el = barRef.current;
+    if (!el) return;
+    const items = el.querySelectorAll<HTMLElement>(".jump-item");
+    const barRect = el.getBoundingClientRect();
+    let closest = -1;
+    let closestDist = Infinity;
+    items.forEach((item, i) => {
+      const r = item.getBoundingClientRect();
+      const midY = r.top + r.height / 2;
+      const dist = Math.abs(e.clientY - midY);
+      if (dist < closestDist) {
+        closestDist = dist;
+        closest = i;
+        previewTop.current = midY - barRect.top;
+      }
+    });
+    if (closest >= 0 && closest < visible.length) {
+      const turn = visible[closest]?.turn;
+      if (turn !== undefined) {
+        setHovered(turn);
+        setShowPreview(true);
+      }
+    }
+  };
+
+  const scrollTo = (turn: number) => {
+    const el = threadEl?.querySelector(`[data-turn="${turn}"]`);
+    el?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
+
+  const w = (idx: number): number => {
+    if (hoverIdx < 0) return 12;
+    const d = Math.abs(idx - hoverIdx);
+    if (d === 0) return 32;
+    if (d === 1) return 20;
+    if (d === 2) return 14;
+    return 12;
+  };
+
+  const delay = (idx: number): string =>
+    hoverIdx < 0 ? "0ms" : `${Math.abs(idx - hoverIdx) * 20}ms`;
+
+  return (
+    <div className="jump-bar" ref={barRef} onMouseMove={onMove} onMouseLeave={() => { setHovered(null); setShowPreview(false); }}>
+      <div className="jump-scroll">
+        {visible.map((item, idx) => (
+        <div className="jump-item" key={item.turn} onClick={() => scrollTo(item.turn)}>
+          <div
+            className="jump-dot"
+            style={{ width: w(idx), transitionDelay: delay(idx) }}
+            data-active={hoverIdx >= 0 && Math.abs(idx - hoverIdx) <= 2 || undefined}
+          />
+        </div>
+      ))}
+      </div>
+      {showPreview && hoverText && (
+        <div className="jump-preview" style={{ top: previewTop.current }}>
+          <span className="jump-text">{hoverText}</span>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Add a floating message navigation dock on the right side of the conversation
panel, similar to macOS Dock. Quickly jump between turns in long conversations.

## How to use

Hover over the vertical bar on the right side of the chat area — each
horizontal line represents a user message. As you move your cursor:

- The nearest line smoothly **magnifies** (Dock-like wave animation)
- A **preview tooltip** shows the message text
- **Click** any line to **scroll** the conversation to that message

The list is scrollable — roll the mouse wheel to access older turns. Edges
fade out to indicate there's more content above/below.

## Changes

- **new: `desktop/src/ui/jump-bar.tsx`** (93 lines) — JumpBar component
- **`desktop/src/App.tsx`** — +5 lines for import, `data-turn` attribute,
  and rendering inside `<main>`
- **`desktop/src/styles.css`** — +80 lines for bar, line, preview, and
  scrollable-list-with-mask styles

## Design details

- Right-anchored bars extend left on hover (no overflow into sidebar)
- Focused bar: 32px, neighbor: 20px, outer: 14px, rest: 12px
- `cubic-bezier` transition with staggered delays for wave ripple effect
- `mask-image` gradient fades top/bottom edges instead of a "..." indicator
- Gap-free hover tracking via `onMouseMove` with per-item closest-point math
- Preview positioned outside scroll container to avoid overflow clipping
