### PR TITLE
feat(desktop): scrollable JumpBar with layered highlight

### DIFF
--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -1657,9 +1657,9 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
   background: var(--border-strong);
   transition: background 200ms, width 400ms cubic-bezier(0.34, 1.56, 0.64, 1);
 }
-.jump-dot[data-active] {
-  background: var(--accent);
-}
+.jump-dot[data-d="0"] { background: var(--accent); }
+.jump-dot[data-d="1"] { background: color-mix(in srgb, var(--accent) 60%, transparent); }
+.jump-dot[data-d="2"] { background: color-mix(in srgb, var(--accent) 35%, transparent); }
 .jump-preview {
   position: absolute;
   right: 100%;

--- a/desktop/src/ui/jump-bar.tsx
+++ b/desktop/src/ui/jump-bar.tsx
@@ -58,28 +58,19 @@ export function JumpBar({ messages, threadEl }: JumpBarProps) {
     el?.scrollIntoView({ behavior: "smooth", block: "start" });
   };
 
-  const w = (idx: number): number => {
-    if (hoverIdx < 0) return 12;
+  const barProps = (idx: number): { style: React.CSSProperties; "data-d"?: string } => {
+    if (hoverIdx < 0) return { style: { width: 12 } };
     const d = Math.abs(idx - hoverIdx);
-    if (d === 0) return 32;
-    if (d === 1) return 20;
-    if (d === 2) return 14;
-    return 12;
+    const width = d === 0 ? 32 : d === 1 ? 20 : d === 2 ? 14 : 12;
+    return { style: { width, transitionDelay: `${d * 20}ms` }, "data-d": d <= 2 ? String(d) : undefined };
   };
-
-  const delay = (idx: number): string =>
-    hoverIdx < 0 ? "0ms" : `${Math.abs(idx - hoverIdx) * 20}ms`;
 
   return (
     <div className="jump-bar" ref={barRef} onMouseMove={onMove} onMouseLeave={() => { setHovered(null); setShowPreview(false); }}>
       <div className="jump-scroll">
         {visible.map((item, idx) => (
         <div className="jump-item" key={item.turn} onClick={() => scrollTo(item.turn)}>
-          <div
-            className="jump-dot"
-            style={{ width: w(idx), transitionDelay: delay(idx) }}
-            data-active={hoverIdx >= 0 && Math.abs(idx - hoverIdx) <= 2 || undefined}
-          />
+          <div className="jump-dot" {...barProps(idx)} />
         </div>
       ))}
       </div>


### PR DESCRIPTION
## Summary

Refinements to the JumpBar message navigation dock:
scrollable list with edge fade, and layered highlighting.

## Changes from #1725

- **Scrollable** — all messages shown, `max-height: 240px` + `overflow-y: auto`
  with CSS mask gradient fading edges instead of a "..." truncation indicator
- **Layered highlight** — focused bar gets full accent, neighbors at 60% and
  35% opacity for better visual hierarchy
- **Minor cleanup** — removed unused `useCallback`/`useRef` imports, simplified
  hover tracking and bar width logic

## How to use

Hover the vertical bar on the right edge of the chat — each line is a user
message. Move your cursor to magnify the nearest line (Dock-like wave), read
the preview tooltip, and click to jump. Scroll the list to reach older turns.
