### PR TITLE
feat(desktop): add question navigation rail

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -9,7 +9,7 @@ import {
 } from "@tauri-apps/plugin-notification";
 import { relaunch } from "@tauri-apps/plugin-process";
 import { type Update, check } from "@tauri-apps/plugin-updater";
-import { useCallback, useEffect, useReducer, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react";
 import { CommandPalette, Toast, buildCommands, useCommandPalette } from "./CommandPalette";
 import { WorkspaceProvider } from "./Markdown";
 import {
@@ -58,6 +58,7 @@ import { useElapsed } from "./ui/live";
 import { AboutModal } from "./ui/about";
 import { SettingsModal, type PageId as SettingsPageId } from "./ui/settings";
 import { Sidebar } from "./ui/sidebar";
+import { QuestionNav, type QuestionNavItem } from "./ui/question-nav";
 import { Shortcut, localizeShortcutText, shortcutText } from "./ui/shortcut";
 import { Splash, shouldShowSplash } from "./ui/splash";
 import { StatusBar } from "./ui/statusbar";
@@ -1310,6 +1311,7 @@ function TabRuntime({
   const composerRef = useRef<HTMLTextAreaElement>(null);
   const threadRef = useRef<HTMLDivElement>(null);
   const threadInnerRef = useRef<HTMLDivElement>(null);
+  const [activeQuestionIndex, setActiveQuestionIndex] = useState<number | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [settingsPage, setSettingsPage] = useState<SettingsPageId>("general");
   const [jobsOpen, setJobsOpen] = useState(false);
@@ -1571,6 +1573,35 @@ function TabRuntime({
     composerRef.current?.focus();
   }, []);
 
+  const questionNavItems = useMemo<QuestionNavItem[]>(() => {
+    let ordinal = 0;
+    return state.messages.flatMap((m, messageIndex) => {
+      if (m.kind !== "user") return [];
+      ordinal += 1;
+      return [{ messageIndex, ordinal, turn: m.turn, text: m.text }];
+    });
+  }, [state.messages]);
+
+  useEffect(() => {
+    if (questionNavItems.length === 0) {
+      setActiveQuestionIndex(null);
+      return;
+    }
+    setActiveQuestionIndex((current) =>
+      current !== null && questionNavItems.some((item) => item.messageIndex === current)
+        ? current
+        : questionNavItems[0]?.messageIndex ?? null,
+    );
+  }, [questionNavItems]);
+
+  const scrollToQuestion = useCallback((messageIndex: number) => {
+    const root = threadRef.current;
+    const target = root?.querySelector<HTMLElement>(`[data-question-index="${messageIndex}"]`);
+    if (!root || !target) return;
+    setActiveQuestionIndex(messageIndex);
+    target.scrollIntoView({ behavior: "smooth", block: "center" });
+  }, []);
+
   useEffect(() => {
     if (state.busy || !state.ready || state.queuedSends.length === 0) return;
     const next = state.queuedSends[0];
@@ -1738,6 +1769,45 @@ function TabRuntime({
       clearTimeout(timer);
     };
   }, [state.currentSession]);
+
+  useEffect(() => {
+    const el = threadRef.current;
+    if (!el || questionNavItems.length === 0) return;
+    let raf = 0;
+    const updateActiveQuestion = () => {
+      raf = 0;
+      const marks = Array.from(el.querySelectorAll<HTMLElement>("[data-question-index]"));
+      if (marks.length === 0) return;
+      const center = el.getBoundingClientRect().top + el.clientHeight / 2;
+      let bestIndex: number | null = null;
+      let bestDistance = Number.POSITIVE_INFINITY;
+      for (const mark of marks) {
+        const raw = mark.dataset.questionIndex;
+        if (!raw) continue;
+        const rect = mark.getBoundingClientRect();
+        const distance = Math.abs(rect.top + rect.height / 2 - center);
+        if (distance < bestDistance) {
+          bestDistance = distance;
+          bestIndex = Number(raw);
+        }
+      }
+      if (bestIndex !== null && Number.isFinite(bestIndex)) {
+        setActiveQuestionIndex(bestIndex);
+      }
+    };
+    const onScroll = () => {
+      if (raf) return;
+      raf = window.requestAnimationFrame(updateActiveQuestion);
+    };
+    updateActiveQuestion();
+    el.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", onScroll);
+    return () => {
+      el.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", onScroll);
+      if (raf) window.cancelAnimationFrame(raf);
+    };
+  }, [questionNavItems]);
 
   useEffect(() => {
     if (!active) return;
@@ -2149,7 +2219,7 @@ function TabRuntime({
                       const prev = state.messages[i - 1];
                       const needsDivider = !prev || prev.kind === "user";
                       return (
-                        <div key={`u-${i}`}>
+                        <div key={`u-${i}`} data-question-index={i}>
                           {needsDivider ? <TurnDivider label={dividerLabel} /> : null}
                           <UserMsg text={m.text} skill={m.skill} onEdit={onEditUserMsg} />
                         </div>
@@ -2305,6 +2375,11 @@ function TabRuntime({
                   </button>
                 ) : null}
               </div>
+              <QuestionNav
+                items={questionNavItems}
+                activeMessageIndex={activeQuestionIndex}
+                onPick={scrollToQuestion}
+              />
 
               <Composer
                 draft={draft}

--- a/desktop/src/i18n/en.ts
+++ b/desktop/src/i18n/en.ts
@@ -698,6 +698,11 @@ export const en = {
     editMessage: "Edit this message and re-send",
     copyResponse: "Copy this response",
   },
+  questionNav: {
+    label: "Question navigation",
+    question: "Question",
+    jumpTo: "Jump to question {n}",
+  },
   live: {
     reasoning: "live · reasoning",
     running: "running",

--- a/desktop/src/i18n/zh-CN.ts
+++ b/desktop/src/i18n/zh-CN.ts
@@ -684,6 +684,11 @@ export const zhCN: typeof en = {
     editMessage: "编辑并重新发送",
     copyResponse: "复制这条回复",
   },
+  questionNav: {
+    label: "问题导航",
+    question: "问题",
+    jumpTo: "跳到问题 {n}",
+  },
   live: {
     reasoning: "live · reasoning",
     running: "运行中",

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -1643,6 +1643,129 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
   box-shadow: 0 2px 12px rgba(0,0,0,0.10);
 }
 
+.question-nav {
+  position: absolute;
+  top: 50%;
+  right: 10px;
+  z-index: 18;
+  display: flex;
+  flex-direction: row-reverse;
+  align-items: center;
+  gap: 10px;
+  transform: translateY(-50%);
+  pointer-events: none;
+}
+
+.question-nav-rail {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 7px;
+  max-height: min(58vh, 420px);
+  padding: 8px 3px;
+  overflow: hidden;
+  pointer-events: auto;
+}
+
+.question-nav-mark {
+  width: 48px;
+  height: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.question-nav-mark span {
+  width: 22px;
+  height: 4px;
+  border-radius: 999px;
+  background: var(--border-strong);
+  opacity: 0.56;
+  transition:
+    width 130ms ease,
+    height 130ms ease,
+    opacity 130ms ease,
+    background 130ms ease,
+    box-shadow 130ms ease;
+}
+
+.question-nav:hover .question-nav-mark span,
+.question-nav:focus-within .question-nav-mark span {
+  width: 30px;
+  opacity: 0.74;
+}
+
+.question-nav-mark:hover span,
+.question-nav-mark:focus-visible span,
+.question-nav-mark[data-hovered="true"] span {
+  width: 42px;
+  height: 5px;
+  opacity: 1;
+  background: var(--accent-strong);
+}
+
+.question-nav-mark[data-active="true"] span {
+  width: 46px;
+  height: 6px;
+  opacity: 1;
+  background: var(--accent);
+  box-shadow: 0 0 0 4px var(--accent-soft);
+}
+
+.question-nav-pop {
+  width: min(280px, calc(100vw - 120px));
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: color-mix(in oklch, var(--panel) 92%, transparent);
+  box-shadow: var(--shadow-md);
+  opacity: 0;
+  transform: translateX(6px);
+  transition: opacity 130ms ease, transform 130ms ease;
+  pointer-events: none;
+}
+
+.question-nav:hover .question-nav-pop,
+.question-nav:focus-within .question-nav-pop {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.question-nav-kicker {
+  margin-bottom: 4px;
+  color: var(--accent);
+  font-family: var(--font-mono, "Geist Mono", monospace);
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.question-nav-text {
+  color: var(--fg);
+  font-size: 12px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+[data-theme="light"] .question-nav-pop {
+  background: color-mix(in oklch, var(--panel) 96%, transparent);
+}
+
+@media (max-width: 860px) {
+  .question-nav {
+    right: 4px;
+  }
+
+  .question-nav-pop {
+    display: none;
+  }
+
+  .question-nav-mark {
+    width: 34px;
+  }
+}
+
 /* ---------- TURN HEADERS ---------- */
 
 .turn-divider {

--- a/desktop/src/ui/question-nav.test.tsx
+++ b/desktop/src/ui/question-nav.test.tsx
@@ -1,0 +1,31 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { QuestionNav, type QuestionNavItem } from "./question-nav";
+
+afterEach(cleanup);
+
+const items: QuestionNavItem[] = [
+  { messageIndex: 0, ordinal: 1, turn: 1, text: "How do I start the desktop app?" },
+  { messageIndex: 4, ordinal: 2, turn: 2, text: "Add a right-side question navigation rail." },
+];
+
+describe("QuestionNav", () => {
+  it("renders one jump target per user question", () => {
+    render(<QuestionNav items={items} activeMessageIndex={4} onPick={() => {}} />);
+
+    expect(screen.getByRole("navigation", { name: "Question navigation" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Jump to question 1" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Jump to question 2" })).toBeTruthy();
+  });
+
+  it("calls onPick with the message index", () => {
+    const onPick = vi.fn();
+    render(<QuestionNav items={items} activeMessageIndex={0} onPick={onPick} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Jump to question 2" }));
+
+    expect(onPick).toHaveBeenCalledWith(4);
+  });
+});

--- a/desktop/src/ui/question-nav.tsx
+++ b/desktop/src/ui/question-nav.tsx
@@ -1,0 +1,70 @@
+import { useState } from "react";
+import { t, useLang } from "../i18n";
+
+export type QuestionNavItem = {
+  messageIndex: number;
+  ordinal: number;
+  turn: number;
+  text: string;
+};
+
+type QuestionNavProps = {
+  items: QuestionNavItem[];
+  activeMessageIndex: number | null;
+  onPick: (messageIndex: number) => void;
+};
+
+export function QuestionNav({ items, activeMessageIndex, onPick }: QuestionNavProps) {
+  useLang();
+  const [hovered, setHovered] = useState<number | null>(null);
+
+  if (items.length === 0) return null;
+
+  const activeItem = items.find((item) => item.messageIndex === activeMessageIndex) ?? items[0];
+  const previewItem =
+    items.find((item) => item.messageIndex === hovered) ?? activeItem ?? items[0];
+
+  return (
+    <nav className="question-nav" aria-label={t("questionNav.label")}>
+      <div className="question-nav-rail">
+        {items.map((item) => {
+          const isActive = item.messageIndex === activeMessageIndex;
+          const isHovered = item.messageIndex === hovered;
+          const label = t("questionNav.jumpTo", { n: item.ordinal });
+          return (
+            <button
+              key={item.messageIndex}
+              type="button"
+              className="question-nav-mark"
+              data-active={isActive || undefined}
+              data-hovered={isHovered || undefined}
+              onClick={() => onPick(item.messageIndex)}
+              onMouseEnter={() => setHovered(item.messageIndex)}
+              onMouseLeave={() => setHovered(null)}
+              onFocus={() => setHovered(item.messageIndex)}
+              onBlur={() => setHovered(null)}
+              title={`${label}: ${summarizeQuestion(item.text, 80)}`}
+              aria-label={label}
+            >
+              <span />
+            </button>
+          );
+        })}
+      </div>
+      {previewItem ? (
+        <div className="question-nav-pop" role="status">
+          <div className="question-nav-kicker">
+            {t("questionNav.question")} #{previewItem.ordinal}
+          </div>
+          <div className="question-nav-text">{summarizeQuestion(previewItem.text, 96)}</div>
+        </div>
+      ) : null}
+    </nav>
+  );
+}
+
+function summarizeQuestion(text: string, max: number): string {
+  const oneLine = text.replace(/\s+/g, " ").trim();
+  if (oneLine.length <= max) return oneLine;
+  return `${oneLine.slice(0, Math.max(0, max - 1))}…`;
+}


### PR DESCRIPTION
## Summary
- add a right-side question navigation rail for desktop conversations
- highlight the nearest user question while scrolling and jump to a question on click
- show a hover/focus preview with the question number and truncated prompt

## Tests
- npm run verify
- npm exec vitest run desktop/src/ui/question-nav.test.tsx
- npm --prefix desktop run build