### PR TITLE
Fix MCP settings overflow

### DIFF
--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -4751,6 +4751,18 @@ html:not([data-platform="macos"]) .cmdk-row .kb .shortcut kbd[data-key="mod"] {
   margin-top: 2px;
 }
 .scard .grow { flex: 1; }
+.scard .mcp-spec-body {
+  min-width: 0;
+  flex: 1 1 auto;
+}
+.scard .mcp-spec-summary {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+.scard .mcp-remove {
+  flex: 0 0 auto;
+}
 .scard .desc {
   font-size: 14px;
   color: var(--fg-2);

--- a/desktop/src/ui/settings.tsx
+++ b/desktop/src/ui/settings.tsx
@@ -940,14 +940,15 @@ function PageMCP({
                 <span className="ico">
                   <I.wrench size={14} />
                 </span>
-                <div>
+                <div className="mcp-spec-body">
                   <div className="nm">{s.name ?? "(anonymous)"}</div>
-                  <div className="sub">{s.summary}</div>
+                  <div className="sub mcp-spec-summary" title={s.summary}>
+                    {s.summary}
+                  </div>
                 </div>
-                <span className="grow" />
                 <button
                   type="button"
-                  className="btn ghost"
+                  className="btn ghost mcp-remove"
                   style={{ color: "var(--danger)" }}
                   onClick={() => onRemove(s.raw)}
                 >

--- a/tests/desktop-mcp-settings-layout.test.ts
+++ b/tests/desktop-mcp-settings-layout.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const cssPath = fileURLToPath(new URL("../desktop/src/styles.css", import.meta.url));
+const css = readFileSync(cssPath, "utf8");
+
+function cssRule(selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = new RegExp(`${escaped}\\s*\\{(?<body>[^}]*)\\}`).exec(css);
+  return match?.groups?.body ?? "";
+}
+
+describe("desktop MCP settings layout", () => {
+  it("keeps long MCP specs inside the card instead of widening the modal", () => {
+    expect(cssRule(".scard .mcp-spec-body")).toContain("min-width: 0");
+    expect(cssRule(".scard .mcp-spec-body")).toContain("flex: 1 1 auto");
+    expect(cssRule(".scard .mcp-spec-summary")).toContain("overflow-wrap: anywhere");
+    expect(cssRule(".scard .mcp-spec-summary")).toContain("word-break: break-word");
+    expect(cssRule(".scard .mcp-remove")).toContain("flex: 0 0 auto");
+  });
+});


### PR DESCRIPTION
## Summary
- Keep long MCP spec summaries inside the settings card instead of widening the modal.
- Make the MCP spec text column shrinkable and allow long URLs/tokens to wrap.
- Keep the remove action fixed at the right edge.

## Verification
- `npm test -- --run tests/desktop-mcp-settings-layout.test.ts`
- `npx biome check tests/desktop-mcp-settings-layout.test.ts`
- `git diff --check`
- `npm run typecheck`
- `npm run verify`

Fixes #1734