### PR TITLE
feat(acp): support REASONIX_ACP_SYSTEM_APPEND env var for system prompt injection

### DIFF
--- a/src/cli/commands/acp.ts
+++ b/src/cli/commands/acp.ts
@@ -158,6 +158,7 @@ async function buildSession(opts: {
   budgetUsd?: number;
   mcpSpecs?: string[];
   mcpPrefix?: string;
+  systemAppend?: string;
 }): Promise<Session> {
   const model = opts.modelOverride || loadModel() || DEFAULT_MODEL;
   const toolset = await buildCodeToolset({ rootDir: opts.rootDir });
@@ -171,6 +172,7 @@ async function buildSession(opts: {
   const system = codeSystemPrompt(opts.rootDir, {
     hasSemanticSearch: toolset.semantic.enabled,
     modelId: model,
+    systemAppend: opts.systemAppend,
   });
   const ep = loadEndpoint();
   const client = new DeepSeekClient({ apiKey: ep.apiKey, baseUrl: ep.baseUrl });
@@ -262,6 +264,7 @@ export async function acpCommand(opts: AcpOptions): Promise<void> {
       budgetUsd: opts.budgetUsd,
       mcpSpecs: opts.mcpSpecs,
       mcpPrefix: opts.mcpPrefix,
+      systemAppend: process.env.REASONIX_ACP_SYSTEM_APPEND || undefined,
     });
     sessions.set(session.id, session);
     return { sessionId: session.id };


### PR DESCRIPTION
## Summary

The ACP command now reads `REASONIX_ACP_SYSTEM_APPEND` from the environment and appends its value to the code system prompt. This allows host applications (like [Open Design](https://github.com/nexu-io/open-design)) to inject domain-specific instructions into Reasonix's system prompt when running in ACP mode, without requiring CLI flag changes.

## Motivation

When Reasonix is used as an ACP agent by external tools, the host application needs to inject its own system-level instructions (e.g., output format requirements, workflow rules, design system constraints). The `code` subcommand already supports `--system-append` for this purpose, but the `acp` subcommand has no equivalent mechanism — its system prompt is hardcoded to `codeSystemPrompt()` with no extension point.

This creates a gap for host applications that need the model to follow domain-specific rules (e.g., wrap HTML output in `<artifact>` tags) while still preserving Reasonix's coding system prompt as the base.

## Changes

- `src/cli/commands/acp.ts`: `buildSession()` now accepts an optional `systemAppend` string and passes it to `codeSystemPrompt()`.
- `src/cli/commands/acp.ts`: `acpCommand()` reads `REASONIX_ACP_SYSTEM_APPEND` from the environment and forwards it to `buildSession()`.

## How it works

1. Host application sets `REASONIX_ACP_SYSTEM_APPEND` in the spawn environment.
2. `reasonix acp` reads the env var during session creation.
3. The value is appended to the code system prompt under a `# User System Append` heading (same as `--system-append`).
4. The model sees both Reasonix's coding rules and the host's custom instructions in a single system prompt.

## Example

```bash
# Host application spawns Reasonix ACP with custom instructions
REASONIX_ACP_SYSTEM_APPEND="Output HTML wrapped in <artifact> tags." \
  reasonix acp
```

## Compatibility

- **No breaking changes.** When `REASONIX_ACP_SYSTEM_APPEND` is unset, behavior is identical to before.
- **Cache prefix stability.** The `systemAppend` value is part of the `ImmutablePrefix` hash, so sessions with different append values get separate cache entries. This is correct — different system prompts should not share prefix cache.
- **Follows existing patterns.** The `code` subcommand already supports `--system-append` via the same `codeSystemPrompt()` option. This PR extends the same mechanism to ACP mode via environment variable, which is the appropriate channel for host-injected configuration (flags cannot be set by the host when spawning a child process).

## Testing

- `npm run verify` passes (264 test files, 3622 tests).
- Manual test with Open Design: set `REASONIX_ACP_SYSTEM_APPEND`, spawn `reasonix acp`, verify model follows injected instructions.
