### PR TITLE
perf(markdown): memoize CodeBlock syntax highlight

### DIFF
--- a/src/cli/ui/markdown.tsx
+++ b/src/cli/ui/markdown.tsx
@@ -137,8 +137,12 @@ function ListItem({
 
 function CodeBlock({ token }: { token: Tokens.Code }): React.ReactElement {
   const lang = token.lang?.split(/\s+/)[0] ?? "";
-  const colored = highlightCode(decodeHtmlEntities(token.text), lang);
-  const lines = colored.split("\n");
+  // highlight.js tokenization runs every render unless memoized — multi-block
+  // assistant replies were re-highlighting on every parent re-render (slow tick, theme, resize).
+  const lines = React.useMemo(
+    () => highlightCode(decodeHtmlEntities(token.text), lang).split("\n"),
+    [token.text, lang],
+  );
   return (
     <Box flexDirection="column">
       {lang ? (


### PR DESCRIPTION
## Summary

`cli-highlight`'s tokenization re-runs on every `CodeBlock` render. While the streaming card is live, the parent re-renders on every chunk (and via `useSlowTick` at 1Hz), and every code block in the in-progress response re-highlights even when its content hasn't changed.

Wrap `highlight + decodeHtmlEntities` in `useMemo` keyed on `[token.text, lang]` so the work only happens when the block content actually changes.

## Impact

- Streaming assistant replies with code blocks no longer spend CPU re-highlighting unchanged blocks on every chunk arrival.
- Settled cards already render via `<Static>` and skip re-render entirely — this PR matters specifically for the live streaming case and for any re-render of long settled responses (theme switch, resize, modal open/close).

## Test plan

- [x] tests/markdown.test.ts passes (22 tests)
- [x] Comment-policy gate clean