### PR TITLE
refactor(core): LruCache + TtlLruCache + lazy(), collapse ad-hoc duplicates

### DIFF
--- a/src/at-mentions.ts
+++ b/src/at-mentions.ts
@@ -3,6 +3,7 @@
 import { type Dirent, existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { readdir, stat } from "node:fs/promises";
 import { isAbsolute, join, relative, resolve } from "node:path";
+import { TtlLruCache } from "./core/lru.js";
 import {
   type GitignoreLayer,
   ignoredByLayers,
@@ -258,6 +259,9 @@ export interface ListDirectoryOptions {
   respectGitignore?: boolean;
 }
 
+/** Keystroke bursts hit the same dir 5–10× in half a second — short TTL collapses those to one readdir. */
+const listDirectoryCache = new TtlLruCache<string, DirEntry[]>(64, 5_000);
+
 /** One-level browse for the @-picker. Folders first then files, alpha within each group. Resolves outside-root to []. */
 export async function listDirectory(
   root: string,
@@ -270,6 +274,10 @@ export async function listDirectory(
   const dirAbs = resolve(rootAbs, relDir);
   const rel = relative(rootAbs, dirAbs);
   if (rel.startsWith("..") || isAbsolute(rel)) return [];
+
+  const cacheKey = `${dirAbs}\u0000${respectGi ? "g" : ""}\u0000${[...ignoreDirs].sort().join(",")}`;
+  const cached = listDirectoryCache.get(cacheKey);
+  if (cached) return cached;
 
   const layers: GitignoreLayer[] = [];
   if (respectGi) {
@@ -330,7 +338,9 @@ export async function listDirectory(
   }
   dirs.sort((a, b) => a.name.localeCompare(b.name));
   fileEntries.sort((a, b) => a.name.localeCompare(b.name));
-  return [...dirs, ...fileEntries];
+  const result = [...dirs, ...fileEntries];
+  listDirectoryCache.set(cacheKey, result);
+  return result;
 }
 
 export interface ParsedAtQuery {

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -92,6 +92,7 @@ import {
   type SessionSummary,
 } from "../../telemetry/stats.js";
 import { defaultUsageLogPath } from "../../telemetry/usage.js";
+import { warmupTokenizer } from "../../tokenizer.js";
 import type { ToolRegistry } from "../../tools.js";
 import type { ChoiceOption } from "../../tools/choice.js";
 import type { PlanStep, StepCompletion } from "../../tools/plan.js";
@@ -513,6 +514,8 @@ function AppInner({
   useEffect(() => {
     markPhase("first_paint");
     dumpStartupProfile();
+    // Tokenizer cold-load is ~100ms + 35MB; amortize while the user reads the banner.
+    setTimeout(warmupTokenizer, 0);
   }, []);
 
   // Live MCP server list: initialized from the boot-time prop, then

--- a/src/code-query/grammar-map.ts
+++ b/src/code-query/grammar-map.ts
@@ -1,0 +1,27 @@
+/** File-extension → tree-sitter grammar name. Pure data — kept free of web-tree-sitter so callers that only need language detection don't pull in the Emscripten runtime. */
+
+export type GrammarName = "typescript" | "tsx" | "javascript" | "python" | "go" | "rust" | "java";
+
+const EXT_TO_GRAMMAR: Record<string, GrammarName> = {
+  ".ts": "typescript",
+  ".mts": "typescript",
+  ".cts": "typescript",
+  ".tsx": "tsx",
+  ".js": "javascript",
+  ".mjs": "javascript",
+  ".cjs": "javascript",
+  ".jsx": "javascript",
+  ".py": "python",
+  ".pyi": "python",
+  ".go": "go",
+  ".rs": "rust",
+  ".java": "java",
+};
+
+export function grammarForPath(filePath: string): GrammarName | null {
+  const lower = filePath.toLowerCase();
+  for (const ext of Object.keys(EXT_TO_GRAMMAR)) {
+    if (lower.endsWith(ext)) return EXT_TO_GRAMMAR[ext]!;
+  }
+  return null;
+}

--- a/src/code-query/parser.ts
+++ b/src/code-query/parser.ts
@@ -5,26 +5,11 @@ import { createRequire } from "node:module";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Language, Parser, type Tree } from "web-tree-sitter";
+import { type GrammarName, grammarForPath } from "./grammar-map.js";
+
+export { type GrammarName, grammarForPath } from "./grammar-map.js";
 
 const localRequire = createRequire(import.meta.url);
-
-export type GrammarName = "typescript" | "tsx" | "javascript" | "python" | "go" | "rust" | "java";
-
-const EXT_TO_GRAMMAR: Record<string, GrammarName> = {
-  ".ts": "typescript",
-  ".mts": "typescript",
-  ".cts": "typescript",
-  ".tsx": "tsx",
-  ".js": "javascript",
-  ".mjs": "javascript",
-  ".cjs": "javascript",
-  ".jsx": "javascript",
-  ".py": "python",
-  ".pyi": "python",
-  ".go": "go",
-  ".rs": "rust",
-  ".java": "java",
-};
 
 export interface ParserOptions {
   grammarDir?: string;
@@ -33,14 +18,6 @@ export interface ParserOptions {
 let parserInitPromise: Promise<void> | null = null;
 const languageCache = new Map<GrammarName, Promise<Language>>();
 let resolvedGrammarDir: string | null = null;
-
-export function grammarForPath(filePath: string): GrammarName | null {
-  const lower = filePath.toLowerCase();
-  for (const ext of Object.keys(EXT_TO_GRAMMAR)) {
-    if (lower.endsWith(ext)) return EXT_TO_GRAMMAR[ext]!;
-  }
-  return null;
-}
 
 export function setGrammarDir(dir: string): void {
   resolvedGrammarDir = dir;

--- a/src/core/lazy.ts
+++ b/src/core/lazy.ts
@@ -1,0 +1,8 @@
+/** Memoize an async loader so the first call kicks off work and every later call returns the same promise. */
+export function lazy<T>(load: () => Promise<T>): () => Promise<T> {
+  let pending: Promise<T> | null = null;
+  return () => {
+    if (!pending) pending = load();
+    return pending;
+  };
+}

--- a/src/core/lru.ts
+++ b/src/core/lru.ts
@@ -1,0 +1,57 @@
+/** Insertion-ordered Map ⇒ LRU: re-insert on hit promotes the entry; eviction pops the oldest key. */
+export class LruCache<K, V> {
+  private readonly map = new Map<K, V>();
+  constructor(private readonly limit: number) {}
+
+  get(key: K): V | undefined {
+    if (!this.map.has(key)) return undefined;
+    const v = this.map.get(key) as V;
+    this.map.delete(key);
+    this.map.set(key, v);
+    return v;
+  }
+
+  set(key: K, value: V): void {
+    if (this.map.has(key)) {
+      this.map.delete(key);
+    } else if (this.map.size >= this.limit) {
+      const oldest = this.map.keys().next().value;
+      if (oldest !== undefined) this.map.delete(oldest);
+    }
+    this.map.set(key, value);
+  }
+
+  get size(): number {
+    return this.map.size;
+  }
+
+  clear(): void {
+    this.map.clear();
+  }
+}
+
+/** LruCache with a per-entry TTL — a stale hit is treated as a miss and evicted. */
+export class TtlLruCache<K, V> {
+  private readonly inner: LruCache<K, { v: V; expiresAt: number }>;
+  constructor(
+    limit: number,
+    private readonly ttlMs: number,
+  ) {
+    this.inner = new LruCache(limit);
+  }
+
+  get(key: K): V | undefined {
+    const e = this.inner.get(key);
+    if (!e) return undefined;
+    if (e.expiresAt <= Date.now()) return undefined;
+    return e.v;
+  }
+
+  set(key: K, value: V): void {
+    this.inner.set(key, { v: value, expiresAt: Date.now() + this.ttlMs });
+  }
+
+  clear(): void {
+    this.inner.clear();
+  }
+}

--- a/src/gitignore.ts
+++ b/src/gitignore.ts
@@ -4,6 +4,7 @@ import { readFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import ignore, { type Ignore } from "ignore";
+import { TtlLruCache } from "./core/lru.js";
 
 export interface GitignoreLayer {
   /** Absolute dir the .gitignore lives in. Patterns evaluate relative to this. */
@@ -11,20 +12,37 @@ export interface GitignoreLayer {
   ig: Ignore;
 }
 
+/** Per-keystroke at-mention pickers walk every ancestor .gitignore — cached lookups make the same-tick re-walk free. */
+const gitignoreCache = new TtlLruCache<string, Ignore | null>(256, 5_000);
+
+function buildIgnore(text: string): Ignore {
+  return ignore().add(text);
+}
+
 export async function loadGitignoreAt(dirAbs: string): Promise<Ignore | null> {
+  const cached = gitignoreCache.get(dirAbs);
+  if (cached !== undefined) return cached;
+  let result: Ignore | null;
   try {
-    return ignore().add(await readFile(path.join(dirAbs, ".gitignore"), "utf8"));
+    result = buildIgnore(await readFile(path.join(dirAbs, ".gitignore"), "utf8"));
   } catch {
-    return null;
+    result = null;
   }
+  gitignoreCache.set(dirAbs, result);
+  return result;
 }
 
 export function loadGitignoreAtSync(dirAbs: string): Ignore | null {
+  const cached = gitignoreCache.get(dirAbs);
+  if (cached !== undefined) return cached;
+  let result: Ignore | null;
   try {
-    return ignore().add(readFileSync(path.join(dirAbs, ".gitignore"), "utf8"));
+    result = buildIgnore(readFileSync(path.join(dirAbs, ".gitignore"), "utf8"));
   } catch {
-    return null;
+    result = null;
   }
+  gitignoreCache.set(dirAbs, result);
+  return result;
 }
 
 /** True if any layer — outermost to innermost — ignores this path. */

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -5,6 +5,7 @@ import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { gunzipSync } from "node:zlib";
+import { LruCache } from "./core/lru.js";
 
 interface AddedToken {
   id: number;
@@ -151,6 +152,12 @@ function loadTokenizer(): LoadedTokenizer {
   return cached;
 }
 
+/** Force the BPE vocab to load now (gunzip + JSON.parse + Map build ≈ 100ms, 35MB heap).
+ *  Idempotent. Call once at idle after first paint so the first user turn doesn't pay it. */
+export function warmupTokenizer(): void {
+  loadTokenizer();
+}
+
 function escapeRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -184,18 +191,12 @@ function byteLevelEncode(s: string, byteToChar: string[]): string {
 }
 
 /** Repetitive tool output / identifier chunks re-encode thousands of times per session; LRU bounds at ~400KB. */
-const BPE_CACHE_LIMIT = 8192;
-const bpeCache = new Map<string, string[]>();
+const bpeCache = new LruCache<string, string[]>(8192);
 
 function bpeEncode(piece: string, mergeRank: Map<string, number>): string[] {
   if (piece.length <= 1) return piece ? [piece] : [];
   const cached = bpeCache.get(piece);
-  if (cached !== undefined) {
-    // LRU bump — re-insert moves the key to the most-recent position.
-    bpeCache.delete(piece);
-    bpeCache.set(piece, cached);
-    return cached;
-  }
+  if (cached !== undefined) return cached;
   const word: string[] = Array.from(piece);
   while (word.length > 1) {
     let bestIdx = -1;
@@ -211,10 +212,6 @@ function bpeEncode(piece: string, mergeRank: Map<string, number>): string[] {
     }
     if (bestIdx < 0) break;
     word.splice(bestIdx, 2, word[bestIdx]! + word[bestIdx + 1]!);
-  }
-  if (bpeCache.size >= BPE_CACHE_LIMIT) {
-    const oldest = bpeCache.keys().next().value;
-    if (oldest !== undefined) bpeCache.delete(oldest);
   }
   bpeCache.set(piece, word);
   return word;
@@ -503,24 +500,14 @@ export function formatDeepSeekPrompt(
 
 const PER_MESSAGE_TEMPLATE_TOKENS = 6;
 
-/** Keyed by content string itself — WeakMap-on-message can't be used because
- *  callers spread `{...e}` defensive copies, breaking identity every turn. */
-const CONTENT_CACHE_LIMIT = 4096;
-const contentTokenCache = new Map<string, number>();
+/** Keyed by content string — WeakMap-on-message can't be used because callers spread `{...e}` defensive copies, breaking identity every turn. */
+const contentTokenCache = new LruCache<string, number>(4096);
 
 function cachedBoundedTokens(s: string): number {
   if (s.length === 0) return 0;
   const cached = contentTokenCache.get(s);
-  if (cached !== undefined) {
-    contentTokenCache.delete(s);
-    contentTokenCache.set(s, cached);
-    return cached;
-  }
+  if (cached !== undefined) return cached;
   const n = countTokensBounded(s);
-  if (contentTokenCache.size >= CONTENT_CACHE_LIMIT) {
-    const oldest = contentTokenCache.keys().next().value;
-    if (oldest !== undefined) contentTokenCache.delete(oldest);
-  }
   contentTokenCache.set(s, n);
   return n;
 }

--- a/src/tools/code-query.ts
+++ b/src/tools/code-query.ts
@@ -1,13 +1,14 @@
 import { readFile } from "node:fs/promises";
 import { resolve as pathResolve } from "node:path";
-import {
-  type CodeMatchKind,
-  type FindInCodeOptions,
-  findInCode,
-} from "../code-query/find-in-code.js";
-import { grammarForPath } from "../code-query/parser.js";
-import { extractSymbols } from "../code-query/symbols.js";
+import type { CodeMatchKind, FindInCodeOptions } from "../code-query/find-in-code.js";
+import { grammarForPath } from "../code-query/grammar-map.js";
+import { lazy } from "../core/lazy.js";
 import type { ToolRegistry } from "../tools.js";
+
+/** web-tree-sitter is a multi-MB Emscripten runtime — defer until the model actually
+ *  dispatches one of these tools so sessions that never touch code_query don't pay for it. */
+const loadSymbols = lazy(() => import("../code-query/symbols.js"));
+const loadFindInCode = lazy(() => import("../code-query/find-in-code.js"));
 
 export interface CodeQueryToolOpts {
   rootDir: string;
@@ -42,6 +43,7 @@ export function registerCodeQueryTools(registry: ToolRegistry, opts: CodeQueryTo
         return JSON.stringify({ path: args.path, error: UNSUPPORTED });
       }
       const source = await readFile(filePath, "utf8");
+      const { extractSymbols } = await loadSymbols();
       const symbols = await extractSymbols(filePath, source);
       return JSON.stringify({ path: args.path, symbols });
     },
@@ -81,6 +83,7 @@ export function registerCodeQueryTools(registry: ToolRegistry, opts: CodeQueryTo
       const source = await readFile(filePath, "utf8");
       const kind = (args.kind ?? "any") as CodeMatchKind | "any";
       const findOpts: FindInCodeOptions = kind === "any" ? {} : { kind };
+      const { findInCode } = await loadFindInCode();
       const matches = await findInCode(filePath, source, args.name, findOpts);
       return JSON.stringify({ path: args.path, matches });
     },

--- a/tests/lazy.test.ts
+++ b/tests/lazy.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest";
+import { lazy } from "../src/core/lazy.js";
+
+describe("lazy", () => {
+  it("invokes the loader exactly once across many calls", async () => {
+    const loader = vi.fn(async () => ({ value: 42 }));
+    const get = lazy(loader);
+    const [a, b, c] = await Promise.all([get(), get(), get()]);
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(a).toBe(b);
+    expect(b).toBe(c);
+    expect(a.value).toBe(42);
+  });
+
+  it("returns the same promise on every call", () => {
+    const get = lazy(async () => "x");
+    expect(get()).toBe(get());
+  });
+
+  it("propagates a loader rejection on every call", async () => {
+    const err = new Error("boom");
+    const get = lazy(async () => {
+      throw err;
+    });
+    await expect(get()).rejects.toBe(err);
+    await expect(get()).rejects.toBe(err);
+  });
+});

--- a/tests/lru.test.ts
+++ b/tests/lru.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LruCache, TtlLruCache } from "../src/core/lru.js";
+
+describe("LruCache", () => {
+  it("returns undefined for an unknown key", () => {
+    const c = new LruCache<string, number>(4);
+    expect(c.get("missing")).toBeUndefined();
+  });
+
+  it("stores and retrieves values", () => {
+    const c = new LruCache<string, number>(4);
+    c.set("a", 1);
+    expect(c.get("a")).toBe(1);
+  });
+
+  it("evicts the least-recently-used key past the limit", () => {
+    const c = new LruCache<string, number>(2);
+    c.set("a", 1);
+    c.set("b", 2);
+    c.set("c", 3);
+    expect(c.get("a")).toBeUndefined();
+    expect(c.get("b")).toBe(2);
+    expect(c.get("c")).toBe(3);
+  });
+
+  it("get promotes a key so it survives the next eviction", () => {
+    const c = new LruCache<string, number>(2);
+    c.set("a", 1);
+    c.set("b", 2);
+    c.get("a"); // touch a — b is now oldest
+    c.set("c", 3);
+    expect(c.get("b")).toBeUndefined();
+    expect(c.get("a")).toBe(1);
+    expect(c.get("c")).toBe(3);
+  });
+
+  it("set on an existing key refreshes its position and value", () => {
+    const c = new LruCache<string, number>(2);
+    c.set("a", 1);
+    c.set("b", 2);
+    c.set("a", 99);
+    c.set("c", 3);
+    expect(c.get("b")).toBeUndefined();
+    expect(c.get("a")).toBe(99);
+  });
+
+  it("clear empties the cache", () => {
+    const c = new LruCache<string, number>(4);
+    c.set("a", 1);
+    c.set("b", 2);
+    c.clear();
+    expect(c.size).toBe(0);
+    expect(c.get("a")).toBeUndefined();
+  });
+});
+
+describe("TtlLruCache", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns a fresh value before the TTL elapses", () => {
+    const c = new TtlLruCache<string, number>(4, 1000);
+    c.set("a", 1);
+    vi.advanceTimersByTime(500);
+    expect(c.get("a")).toBe(1);
+  });
+
+  it("treats a stale entry as a miss", () => {
+    const c = new TtlLruCache<string, number>(4, 1000);
+    c.set("a", 1);
+    vi.advanceTimersByTime(1500);
+    expect(c.get("a")).toBeUndefined();
+  });
+
+  it("set refreshes the TTL of an existing key", () => {
+    const c = new TtlLruCache<string, number>(4, 1000);
+    c.set("a", 1);
+    vi.advanceTimersByTime(800);
+    c.set("a", 2);
+    vi.advanceTimersByTime(500); // total 1300 since first set, 500 since refresh
+    expect(c.get("a")).toBe(2);
+  });
+
+  it("preserves the underlying LRU eviction order", () => {
+    const c = new TtlLruCache<string, number>(2, 1000);
+    c.set("a", 1);
+    c.set("b", 2);
+    c.set("c", 3);
+    expect(c.get("a")).toBeUndefined();
+    expect(c.get("b")).toBe(2);
+    expect(c.get("c")).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

Five hot-path call sites had grown the same patterns inline — `Map` + delete-on-hit + size-cap eviction (tokenizer BPE + content caches, dir picker, gitignore), and `await import(...)` scattered through tool handler bodies. Collapse into three primitives so the call sites read as intent rather than mechanics.

## The primitives

**`src/core/lru.ts`**
- `LruCache<K,V>` — insertion-ordered `Map` with promote-on-hit + evict-oldest. `get` / `set` / `clear`.
- `TtlLruCache<K,V>` — wraps `LruCache` with `{ value, expiresAt }`; a stale read is a miss.

**`src/core/lazy.ts`**
- `lazy<T>(loader)` — memoize the promise so the first call kicks off work and every later call returns the same pending/resolved value. Failures are sticky.

## Call-site simplification

| File | Before | After |
|---|---|---|
| `src/tokenizer.ts` (×2 caches) | 14-line ad-hoc LRU per cache | `cache.get / set`. Also exposes `warmupTokenizer()`. |
| `src/gitignore.ts` | no cache | 5s TTL cache around `loadGitignoreAt[Sync]` |
| `src/at-mentions.ts` | no cache | 5s TTL on `listDirectory` |
| `src/tools/code-query.ts` | `await import(...)` in handler bodies | module-level `lazy(() => import(...))` factories |
| `src/code-query/grammar-map.ts` | — | new: pure path→language detection, no web-tree-sitter dep |
| `src/cli/ui/App.tsx` | hand-rolled `setTimeout(() => import...)` | `setTimeout(warmupTokenizer, 0)` after first paint |

## Why this layout

- **Cache primitives in `src/core/`** — alongside `events`, `pause-gate`, `inflight`. Caches are runtime primitives, not domain logic.
- **`warmupTokenizer()` lives next to the tokenizer** — the UI shouldn't have to know how to trigger a gunzip+JSON.parse. App.tsx just expresses intent.
- **`lazy()` instead of inline dynamic imports** — declares "these heavy modules load on demand" once at the top of the file; the handler body just awaits the factory. Sessions that never call `code_query` skip the multi-MB Emscripten runtime entirely.
- **`grammar-map.ts` split** — extension→language detection is pure data and used by callers that don't need the parser. Keeping it dep-free lets `tools/code-query.ts` import it eagerly without dragging in web-tree-sitter.

## Tests

- `tests/lru.test.ts` (10 cases) — LRU promotion, eviction, refresh-on-set, TTL fresh/stale/refresh.
- `tests/lazy.test.ts` (3 cases) — single-load, promise identity, sticky rejection.
- All 3653 existing tests pass.

## Test plan

- [x] All 3666 tests pass (3653 prior + 13 new)
- [x] Comment-policy gate clean
- [x] Biome clean on touched files