### PR TITLE
fix(desktop): verify bundled node TCC inheritance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,7 @@ jobs:
           echo "node archs: $archs"
           echo "$archs" | grep -q "arm64"
           echo "$archs" | grep -q "x86_64"
+          codesign -d --entitlements :- src-tauri/binaries/node 2>&1 | grep -q "com.apple.security.inherit"
 
       - name: Build & verify desktop frontend
         working-directory: desktop
@@ -172,3 +173,13 @@ jobs:
           releaseDraft: true
           prerelease: false
           args: --target ${{ matrix.target.tauri }}
+
+      - name: Verify app Node inherits TCC grants (macOS)
+        if: startsWith(matrix.target.os, 'macos-')
+        working-directory: desktop
+        shell: bash
+        run: |
+          node_bin=$(find src-tauri/target -path '*/release/bundle/macos/*.app/Contents/Resources/node' -type f | head -n 1)
+          test -n "$node_bin"
+          codesign -vvv --strict "$node_bin"
+          codesign -d --entitlements :- "$node_bin" 2>&1 | grep -q "com.apple.security.inherit"

--- a/desktop/scripts/bundle-node.mjs
+++ b/desktop/scripts/bundle-node.mjs
@@ -29,23 +29,21 @@ function adhocSignMac(binPath) {
   // on every spawn. Ad-hoc is enough for TCC; CI later overlays Developer ID.
   const ents = join(here, "..", "src-tauri", "entitlements", "node-helper.plist");
   if (!existsSync(ents)) {
-    console.warn(`entitlements missing: ${ents} — skipping ad-hoc sign`);
-    return;
+    throw new Error(`entitlements missing: ${ents}`);
   }
-  try {
-    execSync(
-      `codesign --force --sign - --options runtime --entitlements "${ents}" "${binPath}"`,
-      { stdio: "inherit" },
-    );
-  } catch (e) {
-    console.warn(`ad-hoc codesign failed (non-fatal): ${e?.message ?? e}`);
+  execSync(
+    `codesign --force --sign - --options runtime --entitlements "${ents}" "${binPath}"`,
+    { stdio: "inherit" },
+  );
+  if (!hasMacTccInheritance(binPath)) {
+    throw new Error(`codesign did not apply com.apple.security.inherit to ${binPath}`);
   }
 }
 
-function isAdhocSigned(binPath) {
+function hasMacTccInheritance(binPath) {
   try {
-    const out = execSync(`codesign -dvv "${binPath}" 2>&1`, { encoding: "utf8" });
-    return out.includes("Signature=adhoc") || /Authority=/.test(out);
+    const out = execSync(`codesign -d --entitlements :- "${binPath}" 2>&1`, { encoding: "utf8" });
+    return out.includes("com.apple.security.inherit") && out.includes("<true/>");
   } catch {
     return false;
   }
@@ -56,11 +54,11 @@ if (existsSync(targetExe) && statSync(targetExe).size > 1024 * 1024) {
     try {
       const archs = execSync(`lipo -archs "${targetExe}"`, { encoding: "utf8" }).trim();
       if (archs.includes("arm64") && archs.includes("x86_64")) {
-        if (!isAdhocSigned(targetExe)) {
-          console.log(`${targetExe} universal but unsigned — applying ad-hoc sign`);
+        if (!hasMacTccInheritance(targetExe)) {
+          console.log(`${targetExe} universal but missing TCC inheritance — applying ad-hoc sign`);
           adhocSignMac(targetExe);
         } else {
-          console.log(`${targetExe} already universal + signed (${archs}) — delete to refetch`);
+          console.log(`${targetExe} already universal + TCC-inheriting (${archs}) — delete to refetch`);
         }
         process.exit(0);
       }


### PR DESCRIPTION
## Summary

Ensure the bundled macOS Node runtime inherits Reasonix Desktop’s TCC grants, and add release-time checks so the shipped `.app` cannot silently lose the required entitlement.

## Problem

On macOS, Reasonix Desktop launches its internal Node runtime from the app bundle:

- `desktop/src-tauri/src/rpc.rs` resolves production CLI execution to `Contents/Resources/node`
- `desktop/scripts/bundle-node.mjs` signs that runtime with `node-helper.plist`
- `desktop/src-tauri/entitlements/node-helper.plist` contains `com.apple.security.inherit`

However, the packaging path did not reliably prove that the final bundled `node` actually retained `com.apple.security.inherit`. The previous script only checked whether `node` appeared signed, not whether it had the required TCC inheritance entitlement. It also treated macOS ad-hoc signing failures as non-fatal warnings, so a release could proceed with a Node helper that triggers separate TCC prompts instead of inheriting the main app’s permissions.

## Fix

- **`desktop/scripts/bundle-node.mjs`** — Changed macOS Node signing failures from non-fatal warnings to hard failures.
- **`desktop/scripts/bundle-node.mjs`** — Replaced the generic “is signed” check with an entitlement-specific `com.apple.security.inherit` check.
- **`desktop/scripts/bundle-node.mjs`** — Added a post-sign verification step to fail immediately if `codesign` does not apply TCC inheritance.
- **`.github/workflows/release.yml`** — Added macOS CI checks for `src-tauri/binaries/node` to confirm the bundled runtime has `com.apple.security.inherit`.
- **`.github/workflows/release.yml`** — Added a final `.app/Contents/Resources/node` verification step after Tauri packaging to ensure the shipped app’s internal Node helper still has valid signing and TCC inheritance.

## Verification

| Check | Result |
|---|---|
| `node --check desktop/scripts/bundle-node.mjs` | passes |
| `git diff --check` | passes |
| `npm run lint` | passes with existing unused-suppression warnings |
| `npm run verify` | attempted; blocked on Windows symlink privilege before final commit |
| macOS `codesign` / `lipo` checks | covered by release workflow on macOS runners |