### PR TITLE
fix(ui): reduce Windows Terminal flicker

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -191,7 +191,7 @@ import { hydrateCardsFromMessages } from "./state/hydrate.js";
 import { InflightProvider } from "./state/inflight-context.js";
 import { AgentStoreProvider, useAgentState, useAgentStore } from "./state/provider.js";
 import { VerboseContext } from "./state/verbose-context.js";
-import { isLegacyWindowsConsole } from "./terminal-host.js";
+import { terminalFlushIntervalMs } from "./terminal-host.js";
 import { ThemeProvider } from "./theme/context.js";
 import { listThemeNames } from "./theme/tokens.js";
 import { FG, type ThemeName } from "./theme/tokens.js";
@@ -328,18 +328,11 @@ const persistentEventSubscribers = new Set<(ev: DashboardEvent) => void>();
  * Throttle interval in ms. 50ms —20Hz —slow enough that cursor-up
  * repaints on winpty/MINTTY/ConEmu/tmux don't leave half-drawn frames,
  * fast enough that streaming text still reads as continuous. Legacy
- * Windows conhost paints each frame visibly, so 20Hz on a maximized
- * `powershell.exe` is a flicker storm (#1300) — drop to ~7Hz there.
+ * Windows conhost, Windows Terminal, and WSL can paint rapid Ink frames
+ * visibly during reasoning streams (#1300, #1714), so drop to ~7Hz there.
  * Override via `REASONIX_FLUSH_MS` if you want 60Hz on a terminal you trust.
  */
-const FLUSH_INTERVAL_MS = (() => {
-  const raw = process.env.REASONIX_FLUSH_MS;
-  const fallback = isLegacyWindowsConsole() ? 150 : 50;
-  if (!raw) return fallback;
-  const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed < 16 || parsed > 1000) return fallback;
-  return Math.round(parsed);
-})();
+const FLUSH_INTERVAL_MS = terminalFlushIntervalMs();
 
 /**
  * Single-line status pill rendered below the modeline whenever a /loop

--- a/src/cli/ui/terminal-host.ts
+++ b/src/cli/ui/terminal-host.ts
@@ -1,4 +1,35 @@
-/** Legacy `powershell.exe` / `cmd.exe` running under conhost — repaints each Ink frame visibly, unlike Windows Terminal's double-buffer. */
-export function isLegacyWindowsConsole(env: NodeJS.ProcessEnv = process.env): boolean {
-  return process.platform === "win32" && !env.WT_SESSION && !env.TERM_PROGRAM;
+type Platform = NodeJS.Platform;
+
+/** Legacy `powershell.exe` / `cmd.exe` running under conhost; it repaints each Ink frame visibly. */
+export function isLegacyWindowsConsole(
+  env: NodeJS.ProcessEnv = process.env,
+  platform: Platform = process.platform,
+): boolean {
+  return platform === "win32" && !env.WT_SESSION && !env.TERM_PROGRAM;
+}
+
+// Terminals that visibly repaint rapid Ink frames during streaming output.
+// Windows Terminal also hosts WSL sessions, so WSL markers matter on Linux too.
+export function prefersReducedTerminalPaint(
+  env: NodeJS.ProcessEnv = process.env,
+  platform: Platform = process.platform,
+): boolean {
+  return (
+    isLegacyWindowsConsole(env, platform) ||
+    Boolean(env.WT_SESSION) ||
+    Boolean(env.WSL_DISTRO_NAME) ||
+    Boolean(env.WSL_INTEROP)
+  );
+}
+
+export function terminalFlushIntervalMs(
+  env: NodeJS.ProcessEnv = process.env,
+  platform: Platform = process.platform,
+): number {
+  const fallback = prefersReducedTerminalPaint(env, platform) ? 150 : 50;
+  const raw = env.REASONIX_FLUSH_MS;
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 16 || parsed > 1000) return fallback;
+  return Math.round(parsed);
 }

--- a/tests/terminal-host.test.ts
+++ b/tests/terminal-host.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { isLegacyWindowsConsole } from "../src/cli/ui/terminal-host.ts";
+import {
+  isLegacyWindowsConsole,
+  prefersReducedTerminalPaint,
+  terminalFlushIntervalMs,
+} from "../src/cli/ui/terminal-host.ts";
 
 const onWindows = process.platform === "win32";
 
@@ -23,5 +27,35 @@ describe("isLegacyWindowsConsole", () => {
   it("returns true on Windows with neither marker — legacy conhost", () => {
     if (!onWindows) return;
     expect(isLegacyWindowsConsole({})).toBe(true);
+  });
+});
+
+describe("prefersReducedTerminalPaint", () => {
+  it("slows Windows Terminal redraws during streaming turns", () => {
+    const env = { WT_SESSION: "{guid}" };
+
+    expect(isLegacyWindowsConsole(env, "win32")).toBe(false);
+    expect(prefersReducedTerminalPaint(env, "win32")).toBe(true);
+    expect(terminalFlushIntervalMs(env, "win32")).toBe(150);
+  });
+
+  it("slows WSL redraws because Windows Terminal still owns the visible paint", () => {
+    const env = { WSL_DISTRO_NAME: "Ubuntu-22.04", WT_SESSION: "{guid}" };
+
+    expect(prefersReducedTerminalPaint(env, "linux")).toBe(true);
+    expect(terminalFlushIntervalMs(env, "linux")).toBe(150);
+  });
+
+  it("keeps ordinary Unix terminals on the responsive flush cadence", () => {
+    const env = { TERM_PROGRAM: "iTerm.app" };
+
+    expect(prefersReducedTerminalPaint(env, "darwin")).toBe(false);
+    expect(terminalFlushIntervalMs(env, "darwin")).toBe(50);
+  });
+
+  it("honors a valid explicit flush override", () => {
+    const env = { WT_SESSION: "{guid}", REASONIX_FLUSH_MS: "90" };
+
+    expect(terminalFlushIntervalMs(env, "win32")).toBe(90);
   });
 });


### PR DESCRIPTION
Fixes #1714

## Summary
- Reduce streaming repaint cadence for Windows Terminal and WSL by treating them as reduced-paint terminals.
- Keep REASONIX_FLUSH_MS as an explicit override and leave ordinary Unix terminals on the fast cadence.
- Add terminal-host regression coverage for Windows Terminal, WSL, ordinary Unix terminals, and override handling.

## Root cause
Reasoning buffers flushed every 50ms on Windows Terminal and WSL because only legacy conhost was treated as flicker-prone. During reasoning streams that means rapid Ink repaints, which matches the reported flashing behavior.

## Verification
- npm run lint (passes with existing suppression warnings)
- npm run typecheck
- npm test -- tests/comment-policy.test.ts tests/terminal-host.test.ts
- npm run build
- pre-push npm run verify: 269 test files passed, 3662 tests passed, 12 skipped
