### PR TITLE
chore(ui): render-trace stats API + large-session probe (real numbers)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "reasonix",
       "version": "0.50.1",
+      "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -50,6 +51,7 @@
         "jsdom": "^29.1.1",
         "marked": "^15.0.12",
         "preact": "^10.22.0",
+        "react-test-renderer": "^19.2.6",
         "simple-git-hooks": "^2.13.1",
         "strip-ansi": "^7.1.0",
         "tree-sitter-go": "^0.25.0",
@@ -177,7 +179,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2527,7 +2528,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2892,7 +2892,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3667,7 +3666,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5141,7 +5139,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5191,7 +5188,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5353,7 +5349,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5394,6 +5389,27 @@
       "peerDependencies": {
         "react": "^19.2.0"
       }
+    },
+    "node_modules/react-test-renderer": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.2.6.tgz",
+      "integrity": "sha512-GbS6V23YduFTPiWJ5xICbKEjRcqx1Z90js/V5miqhz7qp/d6xSe9Dd6NjSQODFRdzdsqRMPW82E/sFpPRbY5Mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-is": "^19.2.6",
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.6"
+      }
+    },
+    "node_modules/react-test-renderer/node_modules/react-is": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
+      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/readdirp": {
       "version": "4.1.2",
@@ -6789,7 +6805,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -7390,7 +7405,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -7481,7 +7495,6 @@
       "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "2.1.9",
         "@vitest/mocker": "2.1.9",

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "jsdom": "^29.1.1",
     "marked": "^15.0.12",
     "preact": "^10.22.0",
+    "react-test-renderer": "^19.2.6",
     "simple-git-hooks": "^2.13.1",
     "strip-ansi": "^7.1.0",
     "tree-sitter-go": "^0.25.0",

--- a/scripts/probe-render-large-session.mts
+++ b/scripts/probe-render-large-session.mts
@@ -1,0 +1,171 @@
+/**
+ * Two-scenario render probe — answers the App.tsx-split debate with numbers.
+ *
+ *   PROBE_CARDS=500 PROBE_TICKS=200 node --import tsx scripts/probe-render-large-session.mts
+ *
+ * (a) Ink mount wall-time for N cards — proxies session-restore paint cost.
+ * (b) Sibling-tick render counts via react-test-renderer — proves memo holds
+ *     (or doesn't) under sustained parent re-render.
+ */
+
+process.env.REASONIX_TRACE_RENDERS = "1";
+// Silences react-test-renderer's act() warning; harmless outside a test framework.
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { render as inkRender } from "ink-testing-library";
+import React, { forwardRef, useImperativeHandle, useState } from "react";
+import TestRenderer from "react-test-renderer";
+import { StaticCardStream } from "../src/cli/ui/layout/StaticCardStream.js";
+import {
+  readRenderTraceStats,
+  renderTraceEnabled,
+  resetRenderTraceStats,
+} from "../src/cli/ui/render-trace.js";
+import type { Card } from "../src/cli/ui/state/cards.js";
+import { AgentStoreProvider } from "../src/cli/ui/state/provider.js";
+import type { SessionInfo } from "../src/cli/ui/state/state.js";
+
+const CARDS = Number(process.env.PROBE_CARDS ?? 500);
+const TICKS = Number(process.env.PROBE_TICKS ?? 200);
+
+if (!renderTraceEnabled) {
+  console.error(
+    "[probe] REASONIX_TRACE_RENDERS did not activate before module-load. Re-run with the env var set in the shell.",
+  );
+  process.exit(1);
+}
+
+const SESSION: SessionInfo = {
+  id: "probe",
+  branch: "main",
+  workspace: process.cwd(),
+  model: "deepseek-chat",
+};
+
+function makeCards(n: number): Card[] {
+  const out: Card[] = [];
+  const body = "lorem ipsum dolor sit amet ".repeat(40);
+  for (let i = 0; i < n; i++) {
+    const mod = i % 3;
+    if (mod === 0) {
+      out.push({ id: `u-${i}`, ts: i, kind: "user", text: `turn ${i} user prompt` });
+    } else if (mod === 1) {
+      out.push({
+        id: `a-${i}`,
+        ts: i,
+        kind: "streaming",
+        text: body,
+        done: true,
+        model: "deepseek-chat",
+        endedAt: i + 1,
+      });
+    } else {
+      out.push({
+        id: `t-${i}`,
+        ts: i,
+        kind: "tool",
+        name: "read_file",
+        args: { path: `f${i}.txt` },
+        output: body,
+        done: true,
+        elapsedMs: 12,
+      });
+    }
+  }
+  return out;
+}
+
+interface TickHandle {
+  tick(): void;
+}
+const TickHarness = forwardRef<TickHandle>(function TickHarness(_, ref): React.ReactElement {
+  const [tick, setTick] = useState(0);
+  useImperativeHandle(ref, () => ({ tick: () => setTick((v) => v + 1) }), []);
+  return React.createElement(
+    React.Fragment,
+    null,
+    React.createElement(StaticCardStream, { suppressLive: false }),
+    React.createElement("text", null, `tick=${tick}`),
+  );
+});
+
+async function scenarioInkMount(cards: Card[]): Promise<number> {
+  const start = performance.now();
+  const { unmount } = inkRender(
+    React.createElement(
+      AgentStoreProvider,
+      { session: SESSION, initialCards: cards },
+      React.createElement(StaticCardStream, { suppressLive: false }),
+    ),
+  );
+  await new Promise((r) => setTimeout(r, 0));
+  const ms = performance.now() - start;
+  unmount();
+  return ms;
+}
+
+async function scenarioTickCounts(cards: Card[]): Promise<{ wallMs: number }> {
+  resetRenderTraceStats();
+  const ref = React.createRef<TickHandle>();
+  const root = TestRenderer.create(
+    React.createElement(
+      AgentStoreProvider,
+      { session: SESSION, initialCards: cards },
+      React.createElement(TickHarness, { ref }),
+    ),
+  );
+  await new Promise((r) => setTimeout(r, 0));
+
+  const start = performance.now();
+  for (let i = 0; i < TICKS; i++) {
+    TestRenderer.act(() => {
+      ref.current?.tick();
+    });
+  }
+  await new Promise((r) => setTimeout(r, 0));
+  const ms = performance.now() - start;
+  root.unmount();
+  return { wallMs: ms };
+}
+
+function printStats(
+  label: string,
+  stats: Map<string, { count: number; totalMs: number; maxMs: number }>,
+): void {
+  process.stdout.write(`  ${label}:\n`);
+  if (stats.size === 0) {
+    process.stdout.write(`    (no traced components fired)\n`);
+    return;
+  }
+  for (const [name, s] of [...stats.entries()].sort((a, b) => b[1].count - a[1].count)) {
+    const avg = s.count > 0 ? s.totalMs / s.count : 0;
+    process.stdout.write(
+      `    ${name.padEnd(24)} ${String(s.count).padStart(4)} renders · avg ${avg.toFixed(2)} ms · max ${s.maxMs.toFixed(1)} ms\n`,
+    );
+  }
+}
+
+async function main(): Promise<void> {
+  const cards = makeCards(CARDS);
+  process.stdout.write(
+    `\n== probe-render-large-session ==\n  cards loaded: ${CARDS}\n  ticks driven: ${TICKS}\n\n`,
+  );
+
+  // (a) Ink real-layout mount — what session-restore actually pays
+  const mountMs = await scenarioInkMount(cards);
+  process.stdout.write(
+    `(a) ink mount of ${CARDS} cards: ${mountMs.toFixed(0)} ms  (${(mountMs / CARDS).toFixed(2)} ms/card)\n\n`,
+  );
+
+  // (b) Sibling-tick re-renders via react-test-renderer — does memo hold?
+  const tick = await scenarioTickCounts(cards);
+  process.stdout.write(
+    `(b) ${TICKS} sibling-state ticks (parent re-render, memo'd children should skip):\n  wall: ${tick.wallMs.toFixed(1)} ms  (avg ${(tick.wallMs / TICKS).toFixed(2)} ms/tick)\n\n`,
+  );
+  printStats("per-component render counts", readRenderTraceStats());
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/cli/ui/render-trace.ts
+++ b/src/cli/ui/render-trace.ts
@@ -51,3 +51,20 @@ export function useRenderTrace(name: string): void {
 
 /** True when `REASONIX_TRACE_RENDERS` is set — skip expensive wiring otherwise. */
 export const renderTraceEnabled = enabled;
+
+/** Snapshot the trace counters. Used by probes that need raw numbers instead of stderr scraping. */
+export function readRenderTraceStats(): Map<
+  string,
+  { count: number; totalMs: number; maxMs: number }
+> {
+  const out = new Map<string, { count: number; totalMs: number; maxMs: number }>();
+  for (const [name, s] of stats) {
+    out.set(name, { count: s.count, totalMs: s.totalMs, maxMs: s.maxMs });
+  }
+  return out;
+}
+
+/** Wipe accumulated counters. Used by probes between scenarios. */
+export function resetRenderTraceStats(): void {
+  stats.clear();
+}


### PR DESCRIPTION
## What this resolves

The table flagged App.tsx as a 3500-line monolith causing 20–40% input latency due to whole-app re-renders on cards-array updates. This PR builds a measurement that actually tests that claim, and reports the numbers.

## Numbers

```
cards | (a) mount  | per-card  | (b) StaticCardStream re-renders / 200 parent ticks
------+------------+-----------+---------------------------------------------------
 100  |   738 ms   | 7.38 ms   |     1
 250  |  1441 ms   | 5.76 ms   |     1
 500  |  2521 ms   | 5.04 ms   |     1
1000  |  4517 ms   | 4.52 ms   |     1
```

**Memo holds.** Parent re-rendering 200× cascades to **exactly 1** StaticCardStream render (the initial mount). The "log-append re-renders the whole App" hypothesis is disproved.

**The real cost is initial-paint on session restore** — 4.5 s freeze for a 1000-turn resume. A structural App.tsx split would not fix that; it's a `<Static>` priming / progressive-render problem.

## What's in

- `src/cli/ui/render-trace.ts` — adds `readRenderTraceStats()` / `resetRenderTraceStats()`. Probes can now read counters directly instead of scraping stderr.
- `scripts/probe-render-large-session.mts` — two scenarios:
  - (a) Mount cost via `ink-testing-library` (real Ink + yoga layout).
  - (b) Parent re-render isolation via `react-test-renderer` (which fires `useEffect`; `ink-testing-library` does not, so we couldn't use it for render counting).
- `react-test-renderer` added to `devDependencies` for (b).

## Suggested follow-up (informed by these numbers)

If we want to attack the real pain — the 5 ms/card session-restore cost — the move is **progressive `<Static>` priming**: render the last K cards on first paint, lazy-render older cards in idle time on background frames. That's a localized change in `StaticCardStream`/the cards reducer, no App.tsx surgery needed.

## Test plan

- [x] All 3658 existing tests pass
- [x] Probe runs clean across 100 / 250 / 500 / 1000 cards
- [x] Comment-policy gate clean