### PR TITLE
test(edit-blocks): skip symlink test on Windows hosts without symlink capability

### DIFF
--- a/tests/edit-blocks.test.ts
+++ b/tests/edit-blocks.test.ts
@@ -235,8 +235,17 @@ describe("applyEditBlock", () => {
     const outside = resolve(root, "..", "outside-symlink-target.txt");
     const link = join(root, "linked.txt");
     writeFileSync(outside, "hello world\n", "utf8");
+    let symlinksWorked = true;
     try {
       symlinkSync(outside, link);
+    } catch {
+      symlinksWorked = false;
+    }
+    if (!symlinksWorked) {
+      rmSync(outside, { force: true });
+      return;
+    }
+    try {
       const result = applyEditBlock(
         { path: "linked.txt", search: "hello", replace: "goodbye", offset: 0 },
         root,


### PR DESCRIPTION
## Problem

The symlink-preservation test added in b40a569 (PR #1721) breaks for any contributor running `npm test` on a default Windows setup. `fs.symlinkSync` requires either admin/elevated shell **or** Developer Mode enabled — without either, the call throws `EPERM` and the test fails.

## Fix

Match the pattern already used in `tests/at-mentions.test.ts` (lines 474–485): probe `symlinkSync` once in a try/catch, set `symlinksWorked = false` on throw, return early so the test passes vacuously on hosts that lack the capability. The assertion still runs on Linux/macOS and on Windows hosts that do have the capability.

## Verify

- `npx vitest run tests/edit-blocks.test.ts` — 30/30 pass locally
- A non-admin Windows shell will now hit the early-return branch instead of `EPERM`

Closes the test-failure report from contributors running on standard Windows.