### PR TITLE
Guard CLI startup on unsupported Node

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,6 +1,9 @@
-// First import — re-execs the process with a bigger V8 heap when Node's
-// stock 2 GiB cap is in force (issue #1011). Side-effect on module load,
-// before any heavy import below runs.
+// First import — reject unsupported Node versions before heavier startup
+// paths can turn an engine mismatch into an opaque crash.
+import "./node-version-guard.js";
+
+// Then re-exec with a bigger V8 heap when Node's stock 2 GiB cap is in force
+// (issue #1011). Side-effect on module load, before any heavy import below runs.
 import "./heap-limit-launch.js";
 
 import { Command } from "commander";

--- a/src/cli/node-version-guard.ts
+++ b/src/cli/node-version-guard.ts
@@ -1,0 +1,3 @@
+import { enforceSupportedNodeVersion } from "./node-version.js";
+
+enforceSupportedNodeVersion();

--- a/src/cli/node-version.ts
+++ b/src/cli/node-version.ts
@@ -1,0 +1,30 @@
+export const MIN_NODE_MAJOR = 22;
+
+export function parseNodeMajor(version: string): number | null {
+  const major = Number.parseInt(version.split(".")[0] ?? "", 10);
+  return Number.isInteger(major) ? major : null;
+}
+
+export function isSupportedNodeVersion(
+  version = process.versions.node,
+  minMajor = MIN_NODE_MAJOR,
+): boolean {
+  const major = parseNodeMajor(version);
+  return major !== null && major >= minMajor;
+}
+
+export function unsupportedNodeMessage(
+  version = process.versions.node,
+  minMajor = MIN_NODE_MAJOR,
+): string {
+  return `Reasonix requires Node ${minMajor}+ (current: ${version}). Install Node ${minMajor} or newer and rerun reasonix.`;
+}
+
+export function enforceSupportedNodeVersion(
+  version = process.versions.node,
+  minMajor = MIN_NODE_MAJOR,
+): void {
+  if (isSupportedNodeVersion(version, minMajor)) return;
+  process.stderr.write(`${unsupportedNodeMessage(version, minMajor)}\n`);
+  process.exit(1);
+}

--- a/tests/node-version.test.ts
+++ b/tests/node-version.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  MIN_NODE_MAJOR,
+  isSupportedNodeVersion,
+  unsupportedNodeMessage,
+} from "../src/cli/node-version.js";
+
+describe("CLI Node runtime guard (#1698)", () => {
+  it("rejects Node 18 before the CLI loads heavier startup modules", () => {
+    expect(isSupportedNodeVersion("18.17.0")).toBe(false);
+    expect(unsupportedNodeMessage("18.17.0")).toContain(`Node ${MIN_NODE_MAJOR}+`);
+    expect(unsupportedNodeMessage("18.17.0")).toContain("18.17.0");
+  });
+
+  it("accepts Node 22 and later", () => {
+    expect(isSupportedNodeVersion("22.16.0")).toBe(true);
+    expect(isSupportedNodeVersion("24.14.1")).toBe(true);
+  });
+
+  it("runs before the heap-limit re-exec hook", () => {
+    const source = readFileSync("src/cli/index.ts", "utf8");
+    expect(source.indexOf('import "./node-version-guard.js";')).toBeLessThan(
+      source.indexOf('import "./heap-limit-launch.js";'),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Fail fast on unsupported Node versions before heap re-exec and heavier CLI startup modules load.
- Print a clear Node 22+ requirement instead of letting Node 18 startup fail later with an opaque crash.
- Add regression coverage for Node 18 rejection, Node 22+ acceptance, and import order.

## Verification
- npm run test -- tests/node-version.test.ts
- npm run lint (passes with two existing suppression warnings)
- npm run dev -- --version
- pre-push npm run verify (270 test files passed; 3661 tests passed, 12 skipped)

Fixes #1698
