### PR TITLE
Show desktop startup failures

### DIFF
--- a/desktop/src/App.test.ts
+++ b/desktop/src/App.test.ts
@@ -243,7 +243,7 @@ describe("Desktop App reducer — ApprovalPrompt integration", () => {
   });
 
   it("patches settings optimistically for desktop setting commands", () => {
-    const state = {
+    const state: Parameters<typeof reduce>[0] = {
       ...initialState(),
       settings: {
         reasoningEffort: "medium",

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -68,6 +68,11 @@ import { Shortcut, localizeShortcutText, shortcutText } from "./ui/shortcut";
 import { Splash, shouldShowSplash } from "./ui/splash";
 import { StatusBar } from "./ui/statusbar";
 import {
+  StartupFailure,
+  coerceStartupFailure,
+  type StartupFailureState,
+} from "./ui/startup-failure";
+import {
   dispatchDesktopNotifications,
   deriveDesktopNotifications,
   shouldShowCompletionToast,
@@ -3166,10 +3171,13 @@ type TabMeta = { id: string; workspaceDir?: string; busy?: boolean };
 export function App() {
   const [tabs, setTabs] = useState<TabMeta[]>([]);
   const [activeTabId, setActiveTabId] = useState<string>("");
+  const [startupFailure, setStartupFailure] = useState<StartupFailureState | null>(null);
+  const [startupRetryNonce, setStartupRetryNonce] = useState(0);
   const dispatchersRef = useRef<Map<string, TabDispatcher>>(new Map());
   const pendingEventsRef = useRef<Map<string, TabAction[]>>(new Map());
   const pendingDeltasRef = useRef<Map<string, DeltaBatchItem[]>>(new Map());
   const rafScheduledRef = useRef(false);
+  const startupStderrRef = useRef<string[]>([]);
   const tabsRef = useRef<TabMeta[]>([]);
   useEffect(() => {
     tabsRef.current = tabs;
@@ -3322,6 +3330,10 @@ export function App() {
     }
   }, []);
 
+  const retryStartup = useCallback(() => {
+    setStartupRetryNonce((n) => n + 1);
+  }, []);
+
   useEffect(() => {
     let cancelled = false;
     void (async () => {
@@ -3386,6 +3398,8 @@ export function App() {
     };
 
     const setup = async () => {
+      startupStderrRef.current = [];
+      setStartupFailure(null);
       const subs = await Promise.all([
         listen<{ data: string }>("rpc:event", (e) => {
           try {
@@ -3469,10 +3483,27 @@ export function App() {
           }
         }),
         listen<{ data: string }>("rpc:stderr", (e) => {
+          startupStderrRef.current = [...startupStderrRef.current, e.payload.data].slice(-12);
+          setStartupFailure((prev) =>
+            prev
+              ? coerceStartupFailure(
+                  prev.details[0] ?? t("app.startupFailedUnknown"),
+                  startupStderrRef.current,
+                )
+              : prev,
+          );
           console.warn("[reasonix stderr]", e.payload.data);
         }),
         listen<{ code: number | null }>("rpc:exit", (e) => {
           for (const tabId of dispatchersRef.current.keys()) flushTabDeltas(tabId);
+          if (dispatchersRef.current.size === 0) {
+            setStartupFailure(
+              coerceStartupFailure(
+                new Error(`reasonix exited (code ${e.payload.code ?? "?"})`),
+                startupStderrRef.current,
+              ),
+            );
+          }
           for (const dispatch of dispatchersRef.current.values()) {
             dispatch({ t: "rpc_exit", code: e.payload.code });
           }
@@ -3494,7 +3525,10 @@ export function App() {
           });
         }
       } catch (err) {
-        if (!cancelled) console.error("rpc_spawn failed", err);
+        if (!cancelled) {
+          setStartupFailure(coerceStartupFailure(err, startupStderrRef.current));
+          console.error("rpc_spawn failed", err);
+        }
       }
     };
     void setup();
@@ -3502,7 +3536,7 @@ export function App() {
       cancelled = true;
       for (const c of cleanups) c();
     };
-  }, [deliverToTab]);
+  }, [deliverToTab, startupRetryNonce]);
 
   // Tell the backend which tab is focused so a restart can reopen on it (#1244).
   useEffect(() => {
@@ -3580,6 +3614,10 @@ export function App() {
       return next;
     });
   }, []);
+
+  if (startupFailure && tabs.length === 0) {
+    return <StartupFailure details={startupFailure.details} onRetry={retryStartup} />;
+  }
 
   return (
     <>

--- a/desktop/src/i18n/en.ts
+++ b/desktop/src/i18n/en.ts
@@ -423,6 +423,10 @@ export const en = {
     jumpToBottom: "Jump to bottom",
     splashSubtitle: "DeepSeek Agents",
     connecting: "Connecting to reasonix core…",
+    startupFailedTitle: "Reasonix could not start",
+    startupFailedMessage: "The desktop backend failed before opening a workspace.",
+    startupFailedRetry: "Retry",
+    startupFailedUnknown: "Unknown startup error",
     langZH: "Chinese",
     langEN: "English",
     titlebar: {

--- a/desktop/src/i18n/zh-CN.ts
+++ b/desktop/src/i18n/zh-CN.ts
@@ -443,6 +443,10 @@ export const zhCN: typeof en = {
     jumpToBottom: "回到底部",
     splashSubtitle: "DeepSeek Agents",
     connecting: "正在连接 reasonix 内核…",
+    startupFailedTitle: "Reasonix 无法启动",
+    startupFailedMessage: "桌面后端在打开工作区前启动失败。",
+    startupFailedRetry: "重试",
+    startupFailedUnknown: "未知启动错误",
     langZH: "中文",
     langEN: "English",
     titlebar: {

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -3006,6 +3006,61 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
   color: var(--fg-2);
 }
 
+.startup-failure {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 28px;
+  background: var(--bg);
+  color: var(--fg);
+}
+.startup-failure-panel {
+  width: min(620px, 100%);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+  background: var(--card);
+  box-shadow: var(--shadow-lg);
+  padding: 24px;
+}
+.startup-failure-kicker {
+  margin: 0 0 8px;
+  color: var(--danger);
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+.startup-failure h1 {
+  margin: 0;
+  font-size: 22px;
+  line-height: 1.2;
+}
+.startup-failure p {
+  color: var(--fg-2);
+}
+.startup-failure pre {
+  max-height: 220px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-2);
+  color: var(--danger);
+  padding: 12px;
+  font-family: "Geist Mono", ui-monospace, SFMono-Regular, Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+}
+.startup-failure button {
+  margin-top: 12px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  background: var(--accent);
+  color: oklch(99% 0 0);
+  padding: 8px 14px;
+  font: inherit;
+}
+
 /* part 4 — composer, status, context, menus */
 
 /* ---------- COMPOSER ---------- */

--- a/desktop/src/ui/startup-failure.tsx
+++ b/desktop/src/ui/startup-failure.tsx
@@ -1,0 +1,40 @@
+import { t } from "../i18n";
+
+export type StartupFailureState = {
+  details: string[];
+};
+
+function toErrorText(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}
+
+export function coerceStartupFailure(
+  error: unknown,
+  stderrLines: readonly string[] = [],
+): StartupFailureState {
+  const details = [toErrorText(error), ...stderrLines].map((line) => line.trim()).filter(Boolean);
+  return { details: details.length > 0 ? details : [t("app.startupFailedUnknown")] };
+}
+
+export function StartupFailure({
+  details,
+  onRetry,
+}: {
+  details: readonly string[];
+  onRetry: () => void;
+}) {
+  return (
+    <main className="startup-failure" role="alert" aria-live="assertive">
+      <section className="startup-failure-panel">
+        <p className="startup-failure-kicker">{t("app.errorLabel")}</p>
+        <h1>{t("app.startupFailedTitle")}</h1>
+        <p>{t("app.startupFailedMessage")}</p>
+        <pre>{details.join("\n")}</pre>
+        <button type="button" onClick={onRetry}>
+          {t("app.startupFailedRetry")}
+        </button>
+      </section>
+    </main>
+  );
+}

--- a/tests/desktop-startup-failure.test.tsx
+++ b/tests/desktop-startup-failure.test.tsx
@@ -1,0 +1,25 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { StartupFailure, coerceStartupFailure } from "../desktop/src/ui/startup-failure";
+
+describe("desktop startup failure screen (#1752)", () => {
+  it("renders backend startup failures instead of leaving the window blank", () => {
+    const retry = vi.fn();
+    render(<StartupFailure details={["spawn: dist/cli/index.js not found"]} onRetry={retry} />);
+
+    expect(screen.getByRole("alert").textContent).toContain("Reasonix could not start");
+    expect(screen.getByText("spawn: dist/cli/index.js not found")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(retry).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the original error and recent stderr lines for diagnosis", () => {
+    expect(coerceStartupFailure(new Error("spawn failed"), ["stderr a", "stderr b"])).toEqual({
+      details: ["spawn failed", "stderr a", "stderr b"],
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Show a visible desktop startup failure screen when the backend fails to spawn or exits before any tab opens.
- Preserve the original startup error plus recent backend stderr lines, and provide a retry action instead of leaving the window blank.
- Add regression coverage for the startup failure screen and keep the desktop test state typed so the desktop build passes.

## Verification
- npm run test -- tests/desktop-startup-failure.test.tsx
- npm run test -- tests/desktop-startup-failure.test.tsx desktop/src/App.test.ts
- npm run lint (passes with two existing suppression warnings)
- npm --prefix desktop run build
- pre-push npm run verify (270 test files passed; 3660 tests passed, 12 skipped)

Fixes #1752
