### PR TITLE
fix(desktop): type settings reducer test fixture

### DIFF
--- a/desktop/src/App.test.ts
+++ b/desktop/src/App.test.ts
@@ -243,7 +243,7 @@ describe("Desktop App reducer — ApprovalPrompt integration", () => {
   });
 
   it("patches settings optimistically for desktop setting commands", () => {
-    const state = {
+    const state: Parameters<typeof reduce>[0] = {
       ...initialState(),
       settings: {
         reasoningEffort: "medium",


### PR DESCRIPTION
## Summary

Fixes a desktop build failure introduced by the settings slash command reducer test fixture.

The test fixture now explicitly uses the reducer state type so TypeScript preserves the expected `Settings` literal union types for `reasoningEffort` and `editMode`.

## Changes

- Annotate the desktop reducer test `state` fixture as `Parameters<typeof reduce>[0]`.
- Keep the existing reducer test behavior unchanged.

## Root Cause

`f00f238 fix(desktop): sync slash setting commands (#1724)` added a test fixture with an untyped object spread:

```ts
const state = {
  ...initialState(),
  settings: {
    reasoningEffort: "medium",
    editMode: "review",
    ...
  },
};
```

TypeScript widened nested literal values like `"medium"` and `"review"` to `string`, so `reduce(state, ...)` failed to typecheck against `State`.

## Notes

This is a test-only typing fix. It does not change runtime behavior.
