### PR TITLE
fix(tui): avoid Apple Terminal mouse reset crash

### DIFF
--- a/src/cli/ui/mouse-mode.ts
+++ b/src/cli/ui/mouse-mode.ts
@@ -1,15 +1,17 @@
 // Reasonix is append-only now: the terminal owns scrollback, copy, and the
-// mouse wheel. We never want to capture the wheel, and on startup we emit
-// disables for every common mouse-capture mode so stale state from a prior
-// crashed TUI in the same terminal can't keep eating wheel events. The
-// REASONIX_MOUSE_MODE env var stays as an escape hatch.
+// mouse wheel. On most terminals, startup emits disables for common
+// mouse-capture modes so stale state from a prior crashed TUI can't keep
+// eating wheel events. Apple Terminal has had native crashes in its renderer
+// after receiving these private mouse-mode toggles, so its default is silent.
+// REASONIX_MOUSE_MODE remains an escape hatch.
 
-type Mode = "alternate-scroll" | "sgr" | "off";
+type Mode = "alternate-scroll" | "sgr" | "off" | "apple-terminal-off";
 
 function readMode(): Mode {
   const raw = (process.env.REASONIX_MOUSE_MODE ?? "").toLowerCase();
   if (raw === "sgr") return "sgr";
   if (raw === "alternate-scroll") return "alternate-scroll";
+  if (process.env.TERM_PROGRAM === "Apple_Terminal" && raw === "") return "apple-terminal-off";
   return "off";
 }
 
@@ -20,6 +22,7 @@ const SEQUENCES: Record<Mode, { enable: string; disable: string }> = {
   "alternate-scroll": { enable: "\u001b[?1007h", disable: "\u001b[?1007l" },
   sgr: { enable: "\u001b[?1000h\u001b[?1006h", disable: "\u001b[?1006l\u001b[?1000l" },
   off: { enable: RESET_ALL, disable: "" },
+  "apple-terminal-off": { enable: "", disable: "" },
 };
 
 let active = false;

--- a/tests/mouse-mode.test.ts
+++ b/tests/mouse-mode.test.ts
@@ -6,6 +6,7 @@ describe("mouse-mode enable/disable", () => {
   let origWrite: typeof process.stdout.write;
   let origIsTTY: boolean | undefined;
   let origModeEnv: string | undefined;
+  let origTermProgram: string | undefined;
 
   beforeEach(() => {
     writes = [];
@@ -17,8 +18,11 @@ describe("mouse-mode enable/disable", () => {
     origIsTTY = process.stdout.isTTY;
     Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
     origModeEnv = process.env.REASONIX_MOUSE_MODE;
+    origTermProgram = process.env.TERM_PROGRAM;
     // biome-ignore lint/performance/noDelete: env restoration needs absence, not "undefined"
     delete process.env.REASONIX_MOUSE_MODE;
+    // biome-ignore lint/performance/noDelete: env restoration needs absence, not "undefined"
+    delete process.env.TERM_PROGRAM;
     // Reset module state — disable first to clear `active` from any prior test.
     disableMouseMode();
     writes.length = 0;
@@ -34,6 +38,12 @@ describe("mouse-mode enable/disable", () => {
     } else {
       process.env.REASONIX_MOUSE_MODE = origModeEnv;
     }
+    if (origTermProgram === undefined) {
+      // biome-ignore lint/performance/noDelete: env restoration needs absence, not "undefined"
+      delete process.env.TERM_PROGRAM;
+    } else {
+      process.env.TERM_PROGRAM = origTermProgram;
+    }
   });
 
   it("default resets every mouse-capture mode so the terminal owns the wheel", () => {
@@ -47,6 +57,12 @@ describe("mouse-mode enable/disable", () => {
     enableMouseMode();
     writes.length = 0;
     disableMouseMode();
+    expect(writes).toEqual([]);
+  });
+
+  it("does not send default mouse reset sequences to Apple Terminal", () => {
+    process.env.TERM_PROGRAM = "Apple_Terminal";
+    enableMouseMode();
     expect(writes).toEqual([]);
   });
 


### PR DESCRIPTION
## Summary
- skip the default mouse reset private-mode sequence when running under Apple Terminal
- keep explicit REASONIX_MOUSE_MODE opt-in behavior for SGR and alternate-scroll modes
- add a regression test for the Apple Terminal startup path

## Root Cause
The crash report is for Apple Terminal itself, not the Node process. It fails on the main thread in SwiftUICore/AppKit while resolving/rendering style state shortly after launch. Reasonix starts the TUI by emitting a reset-all mouse private-mode sequence even when the default mode is effectively off. That sequence includes legacy and extended mouse toggles such as ?9, ?1005, ?1006, and ?1015. Apple Terminal should ignore unsupported private modes, but this report shows a native renderer crash, so the safest project-side mitigation is to avoid sending those toggles to Apple Terminal unless the user explicitly opts in.

## Validation
- npx vitest run tests/mouse-mode.test.ts tests/stdin-reader.test.ts tests/chat-mcp-startup-summary.test.ts
- npm run typecheck
- npx biome check src/cli/ui/mouse-mode.ts tests/mouse-mode.test.ts
- git push pre-push hook: npm run verify (build, lint, typecheck, full test suite: 271 files passed; lint reported two existing unused-suppression warnings)
