### PR TITLE
fix(desktop): fix right panel scrollbar not draggable

### DIFF
--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -3135,6 +3135,17 @@ html:not([data-platform="macos"]) .cmdk-row .kb .shortcut kbd[data-key="mod"] {
   flex: 1;
   overflow-y: auto;
   padding: 12px;
+  padding-right: 20px;
+}
+.ctx-body::-webkit-scrollbar {
+  width: 8px;
+}
+.ctx-body::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 999px;
+}
+.ctx-body::-webkit-scrollbar-thumb:hover {
+  background: var(--border-strong);
 }
 
 .ctx-block {


### PR DESCRIPTION
## Description

The scrollbar in the context panel (right side panel) was being overlapped by the resize handle when the window was resized to trigger responsive breakpoints, making it impossible to drag the scrollbar with the mouse.

## Root Cause

- .ctx-body scrollbar was only 4px wide (global style)
- .resize-handle has z-index: 10 and 5px width, positioned at the edge of the ctx panel
- The two overlapped, with the resize handle intercepting mouse events on the scrollbar

## Fix

1. Added padding-right: 20px to .ctx-body to create space between content and the resize handle
2. Increased .ctx-body scrollbar width from 4px to 8px for better usability

## Changes

- \desktop/src/styles.css\: Modified \.ctx-body\ rule and added scrollbar styles

## Testing

- Verified scrollbar is draggable at different window widths (>1000px, 800px, 600px)
- Verified resize handle still works correctly
- All 3588 tests pass

Fixes #1695