### PR TITLE
Fix scroll history and memory visibility

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -32,6 +32,7 @@ import type {
   IncomingEvent,
   JobInfo,
   McpSpecInfo,
+  MemoryDetail,
   MemoryEntryInfo,
   OutgoingCommand,
   PlanVerdict,
@@ -179,6 +180,7 @@ export type SessionInfo = {
   messageCount: number;
   mtime: string;
   summary?: string;
+  workspaceStatus?: "matched" | "legacy_missing_meta";
 };
 
 export type Settings = {
@@ -238,6 +240,7 @@ type State = {
   /** Files the agent has read or modified this session — paths as the tool args provided them. */
   sessionFiles: SessionFile[];
   memory: MemoryEntryInfo[];
+  memoryDetail: MemoryDetail | null;
   jobs: JobInfo[];
   /** Live "skill running" indicator — set when a `skill_run` RPC dispatches, cleared on `$turn_complete`. */
   activeSkill: SkillOrigin | null;
@@ -679,7 +682,16 @@ export function applyIncoming(state: State, ev: IncomingEvent): State {
     case "$ctx_breakdown":
       return { ...state, usage: { ...state.usage, reservedTokens: ev.reservedTokens } };
     case "$memory":
-      return { ...state, memory: ev.entries };
+      return {
+        ...state,
+        memory: ev.entries,
+        memoryDetail:
+          state.memoryDetail && ev.entries.some((entry) => entry.path === state.memoryDetail?.path)
+            ? state.memoryDetail
+            : null,
+      };
+    case "$memory_detail":
+      return { ...state, memoryDetail: ev.detail };
     case "$jobs":
       return { ...state, jobs: ev.items };
     case "$balance":
@@ -1105,6 +1117,7 @@ function TabRuntime({
     skills: [],
     sessionFiles: [],
     memory: [],
+    memoryDetail: null,
     jobs: [],
     activeSkill: null,
     queuedSends: [],
@@ -2052,6 +2065,8 @@ function TabRuntime({
           mcpBridged={state.mcpBridged}
           sessionFiles={state.sessionFiles}
           memory={state.memory}
+          memoryDetail={state.memoryDetail}
+          onReadMemory={(path) => sendRpc({ cmd: "memory_read", path })}
         />
 
         <StatusBar
@@ -2121,6 +2136,8 @@ function TabRuntime({
             mcpSpecs={state.mcpSpecs}
             mcpBridged={state.mcpBridged}
             skills={state.skills}
+            memory={state.memory}
+            memoryDetail={state.memoryDetail}
             qq={state.qq}
             onClose={() => setSettingsOpen(false)}
             onSave={saveSettings}
@@ -2135,6 +2152,7 @@ function TabRuntime({
             onPickWorkspace={pickWorkspace}
             onAddMcpSpec={addMcpSpec}
             onRemoveMcpSpec={removeMcpSpec}
+            onReadMemory={(path) => sendRpc({ cmd: "memory_read", path })}
           />
         ) : null}
 

--- a/dashboard/src/protocol.ts
+++ b/dashboard/src/protocol.ts
@@ -100,7 +100,13 @@ export type PlanClearedEvent = { type: "$plan_cleared" };
 
 export type SessionsEvent = {
   type: "$sessions";
-  items: { name: string; messageCount: number; mtime: string; summary?: string }[];
+  items: {
+    name: string;
+    messageCount: number;
+    mtime: string;
+    summary?: string;
+    workspaceStatus?: "matched" | "legacy_missing_meta";
+  }[];
 };
 
 export type MentionResultsEvent = {
@@ -170,14 +176,27 @@ export type CtxBreakdownEvent = {
 };
 
 export type MemoryEntryInfo = {
+  kind: "project_file" | "global_file" | "structured";
   name: string;
   scope: "project" | "global";
+  path: string;
   description: string;
+  type?: string;
 };
 
 export type MemoryEvent = {
   type: "$memory";
   entries: MemoryEntryInfo[];
+};
+
+export type MemoryDetail = MemoryEntryInfo & {
+  body: string;
+  createdAt?: string;
+};
+
+export type MemoryDetailEvent = {
+  type: "$memory_detail";
+  detail: MemoryDetail;
 };
 
 export type RetryResultEvent = { type: "$retry_result"; text: string };
@@ -441,6 +460,7 @@ export type IncomingEvent = { tabId?: string } & (
   | SkillsEvent
   | CtxBreakdownEvent
   | MemoryEvent
+  | MemoryDetailEvent
   | JobsEvent
   | UserMessageEvent
   | ModelTurnStartedEvent
@@ -467,6 +487,7 @@ export type OutgoingCommand = { tabId?: string } & (
   | { cmd: "session_list" }
   | { cmd: "session_delete"; name: string }
   | { cmd: "session_load"; name: string }
+  | { cmd: "memory_read"; path: string }
   | { cmd: "new_chat" }
   | { cmd: "setup_save_key"; key: string }
   | { cmd: "settings_get" }

--- a/dashboard/src/styles.css
+++ b/dashboard/src/styles.css
@@ -2695,12 +2695,20 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
 }
 .mem-row {
   padding: 6px 8px;
+  width: 100%;
+  border: 0;
   border-radius: 6px;
   display: flex;
   gap: 8px;
   align-items: flex-start;
   background: var(--panel);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
   margin-bottom: 4px;
+}
+.mem-row[data-active="true"] {
+  background: var(--accent-soft);
 }
 .mem-row:last-child {
   margin-bottom: 0;
@@ -2718,6 +2726,20 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
 .mem-row .txt {
   font-size: 14px;
   color: var(--fg-2);
+  line-height: 1.5;
+}
+.mem-detail {
+  max-height: 220px;
+  overflow: auto;
+  margin: 8px 0 0;
+  padding: 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--panel);
+  white-space: pre-wrap;
+  color: var(--fg-1);
+  font-family: var(--mono);
+  font-size: 12px;
   line-height: 1.5;
 }
 
@@ -6988,5 +7010,80 @@ html[data-web="true"] .win-controls {
   }
   .splash .splash-content {
     max-width: 100%;
+  }
+}
+.muted-card {
+  padding: 16px;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.memory-browser {
+  display: grid;
+  grid-template-columns: minmax(220px, 0.9fr) minmax(280px, 1.1fr);
+  gap: 12px;
+  min-height: 320px;
+}
+
+.memory-list,
+.memory-detail {
+  min-width: 0;
+  max-height: 52vh;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--card);
+}
+
+.memory-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.memory-item {
+  display: grid;
+  gap: 4px;
+  width: 100%;
+  padding: 10px 12px;
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  background: transparent;
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+}
+
+.memory-item[data-active="true"] {
+  background: var(--accent-soft);
+}
+
+.memory-kind,
+.memory-path {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--muted);
+}
+
+.memory-name {
+  font-size: 12px;
+  color: var(--text);
+}
+
+.memory-detail {
+  margin: 0;
+  padding: 12px;
+  white-space: pre-wrap;
+  font-family: var(--mono);
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--text);
+}
+
+@media (max-width: 860px) {
+  .memory-browser {
+    grid-template-columns: 1fr;
   }
 }

--- a/dashboard/src/ui/context-panel.tsx
+++ b/dashboard/src/ui/context-panel.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import type { SessionFile, Settings, UsageStats } from "../App";
 import { t, useLang } from "../i18n";
 import { I } from "../icons";
-import type { McpSpecInfo, MemoryEntryInfo } from "../protocol";
+import type { McpSpecInfo, MemoryDetail, MemoryEntryInfo } from "../protocol";
 import { PanelErrorBoundary } from "./error-boundary";
 
 type Tab = "files" | "tools" | "memory" | "rules";
@@ -16,6 +16,8 @@ export function ContextPanel({
   mcpBridged,
   sessionFiles,
   memory,
+  memoryDetail,
+  onReadMemory,
 }: {
   settings: Settings | null;
   usage: UsageStats;
@@ -23,6 +25,8 @@ export function ContextPanel({
   mcpBridged: boolean;
   sessionFiles: SessionFile[];
   memory: MemoryEntryInfo[];
+  memoryDetail: MemoryDetail | null;
+  onReadMemory: (path: string) => void;
 }) {
   useLang();
   const [tab, setTab] = useState<Tab>("files");
@@ -89,7 +93,9 @@ export function ContextPanel({
         <PanelErrorBoundary key={tab} label={tab}>
           {tab === "files" && <CtxFiles files={sessionFiles} />}
           {tab === "tools" && <CtxTools specs={mcpSpecs} bridged={mcpBridged} />}
-          {tab === "memory" && <CtxMemory entries={memory} />}
+          {tab === "memory" && (
+            <CtxMemory entries={memory} detail={memoryDetail} onRead={onReadMemory} />
+          )}
           {tab === "rules" && <CtxRules settings={settings} />}
         </PanelErrorBoundary>
       </div>
@@ -237,7 +243,15 @@ function CtxTools({ specs, bridged }: { specs: McpSpecInfo[]; bridged: boolean }
   );
 }
 
-function CtxMemory({ entries }: { entries: MemoryEntryInfo[] }) {
+function CtxMemory({
+  entries,
+  detail,
+  onRead,
+}: {
+  entries: MemoryEntryInfo[];
+  detail: MemoryDetail | null;
+  onRead: (path: string) => void;
+}) {
   return (
     <div className="ctx-block">
       <div className="h">
@@ -251,13 +265,20 @@ function CtxMemory({ entries }: { entries: MemoryEntryInfo[] }) {
       ) : (
         <div className="mem">
           {entries.map((m) => (
-            <div className="mem-row" key={`${m.scope}/${m.name}`}>
+            <button
+              type="button"
+              className="mem-row"
+              data-active={detail?.path === m.path}
+              key={m.path}
+              onClick={() => onRead(m.path)}
+            >
               <span className="scope" data-s={m.scope}>
                 {m.scope === "project" ? t("contextPanel.scopeProject") : t("contextPanel.scopeGlobal")}
               </span>
               <span className="txt">{m.description || m.name}</span>
-            </div>
+            </button>
           ))}
+          {detail ? <pre className="mem-detail">{detail.body}</pre> : null}
         </div>
       )}
     </div>

--- a/dashboard/src/ui/settings.tsx
+++ b/dashboard/src/ui/settings.tsx
@@ -2,7 +2,13 @@ import { type ReactNode, useEffect, useState } from "react";
 import type { Balance, Settings as SettingsType, UsageStats } from "../App";
 import { setLang, t, useLang } from "../i18n";
 import { I } from "../icons";
-import type { McpSpecInfo, SettingsPatch, SkillInfo } from "../protocol";
+import type {
+  McpSpecInfo,
+  MemoryDetail,
+  MemoryEntryInfo,
+  SettingsPatch,
+  SkillInfo,
+} from "../protocol";
 import {
   describeQQRowSummary,
   getQQConnectIntent,
@@ -60,6 +66,8 @@ export function SettingsModal({
   mcpSpecs,
   mcpBridged,
   skills,
+  memory,
+  memoryDetail,
   qq,
   onClose,
   onSave,
@@ -72,6 +80,7 @@ export function SettingsModal({
   onPickWorkspace,
   onAddMcpSpec,
   onRemoveMcpSpec,
+  onReadMemory,
 }: {
   settings: SettingsType;
   balance: Balance | null;
@@ -89,6 +98,8 @@ export function SettingsModal({
   mcpSpecs: McpSpecInfo[];
   mcpBridged: boolean;
   skills: SkillInfo[];
+  memory: MemoryEntryInfo[];
+  memoryDetail: MemoryDetail | null;
   qq: QQDesktopSettingsState | null;
   onClose: () => void;
   onSave: (patch: SettingsPatch) => void;
@@ -101,6 +112,7 @@ export function SettingsModal({
   onPickWorkspace: () => void;
   onAddMcpSpec: (spec: string) => void;
   onRemoveMcpSpec: (spec: string) => void;
+  onReadMemory: (path: string) => void;
 }) {
   const [page, setPage] = useState<PageId>(initialPage ?? "general");
   const [qqConfigureOpen, setQQConfigureOpen] = useState(false);
@@ -173,7 +185,9 @@ export function SettingsModal({
                 onSave={onSave}
               />
             )}
-            {page === "memory" && <PageMemory />}
+            {page === "memory" && (
+              <PageMemory entries={memory} detail={memoryDetail} onRead={onReadMemory} />
+            )}
             {page === "rules" && <PageRules settings={settings} onSave={onSave} />}
             {page === "billing" && (
               <PageBilling balance={balance} usage={usage} currency={currency} />
@@ -1015,22 +1029,42 @@ function PageSkills({
   );
 }
 
-function PageMemory() {
+function PageMemory({
+  entries,
+  detail,
+  onRead,
+}: {
+  entries: MemoryEntryInfo[];
+  detail: MemoryDetail | null;
+  onRead: (path: string) => void;
+}) {
   return (
     <section className="section">
       <div className="stitle">{t("settings.memorySection")}</div>
-      <div
-        style={{
-          padding: 16,
-          background: "var(--card)",
-          border: "1px solid var(--border)",
-          borderRadius: 10,
-          fontSize: 12,
-          color: "var(--muted)",
-        }}
-      >
-        {t("settings.memoryDesc")}
-      </div>
+      {entries.length === 0 ? (
+        <div className="muted-card">{t("settings.memoryDesc")}</div>
+      ) : (
+        <div className="memory-browser">
+          <div className="memory-list">
+            {entries.map((m) => (
+              <button
+                type="button"
+                className="memory-item"
+                data-active={detail?.path === m.path}
+                key={m.path}
+                onClick={() => onRead(m.path)}
+              >
+                <span className="memory-kind">{m.kind.replace("_", " ")}</span>
+                <span className="memory-name">{m.description || m.name}</span>
+                <span className="memory-path">{m.path}</span>
+              </button>
+            ))}
+          </div>
+          <pre className="memory-detail">
+            {detail ? detail.body : t("settings.memoryDesc")}
+          </pre>
+        </div>
+      )}
     </section>
   );
 }

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -48,6 +48,7 @@ import type {
   IncomingEvent,
   JobInfo,
   McpSpecInfo,
+  MemoryDetail,
   MemoryEntryInfo,
   OutgoingCommand,
   PlanVerdict,
@@ -227,6 +228,7 @@ export type SessionInfo = {
   messageCount: number;
   mtime: string;
   summary?: string;
+  workspaceStatus?: "matched" | "legacy_missing_meta";
 };
 
 export type Settings = {
@@ -286,6 +288,7 @@ type State = {
   /** Files the agent has read or modified this session — paths as the tool args provided them. */
   sessionFiles: SessionFile[];
   memory: MemoryEntryInfo[];
+  memoryDetail: MemoryDetail | null;
   jobs: JobInfo[];
   /** Live "skill running" indicator — set when a `skill_run` RPC dispatches, cleared on `$turn_complete`. */
   activeSkill: SkillOrigin | null;
@@ -852,7 +855,16 @@ export function applyIncoming(state: State, ev: IncomingEvent): State {
       return { ...state, usage: next };
     }
     case "$memory":
-      return { ...state, memory: ev.entries };
+      return {
+        ...state,
+        memory: ev.entries,
+        memoryDetail:
+          state.memoryDetail && ev.entries.some((entry) => entry.path === state.memoryDetail?.path)
+            ? state.memoryDetail
+            : null,
+      };
+    case "$memory_detail":
+      return { ...state, memoryDetail: ev.detail };
     case "$jobs":
       return { ...state, jobs: ev.items };
     case "$balance":
@@ -1309,6 +1321,7 @@ function TabRuntime({
     skills: [],
     sessionFiles: [],
     memory: [],
+    memoryDetail: null,
     jobs: [],
     activeSkill: null,
     queuedSends: [],
@@ -2445,6 +2458,8 @@ function TabRuntime({
           mcpBridged={state.mcpBridged}
           sessionFiles={state.sessionFiles}
           memory={state.memory}
+          memoryDetail={state.memoryDetail}
+          onReadMemory={(path) => sendRpc({ cmd: "memory_read", path })}
         />
 
         <StatusBar
@@ -2509,6 +2524,8 @@ function TabRuntime({
             mcpSpecs={state.mcpSpecs}
             mcpBridged={state.mcpBridged}
             skills={state.skills}
+            memory={state.memory}
+            memoryDetail={state.memoryDetail}
             qq={state.qq}
             onClose={() => setSettingsOpen(false)}
             onSave={saveSettings}
@@ -2523,6 +2540,7 @@ function TabRuntime({
             onPickWorkspace={pickWorkspace}
             onAddMcpSpec={addMcpSpec}
             onRemoveMcpSpec={removeMcpSpec}
+            onReadMemory={(path) => sendRpc({ cmd: "memory_read", path })}
           />
         ) : null}
 

--- a/desktop/src/protocol.ts
+++ b/desktop/src/protocol.ts
@@ -102,7 +102,13 @@ export type PlanClearedEvent = { type: "$plan_cleared" };
 
 export type SessionsEvent = {
   type: "$sessions";
-  items: { name: string; messageCount: number; mtime: string; summary?: string }[];
+  items: {
+    name: string;
+    messageCount: number;
+    mtime: string;
+    summary?: string;
+    workspaceStatus?: "matched" | "legacy_missing_meta";
+  }[];
 };
 
 export type MentionResultsEvent = {
@@ -174,14 +180,27 @@ export type CtxBreakdownEvent = {
 };
 
 export type MemoryEntryInfo = {
+  kind: "project_file" | "global_file" | "structured";
   name: string;
   scope: "project" | "global";
+  path: string;
   description: string;
+  type?: string;
 };
 
 export type MemoryEvent = {
   type: "$memory";
   entries: MemoryEntryInfo[];
+};
+
+export type MemoryDetail = MemoryEntryInfo & {
+  body: string;
+  createdAt?: string;
+};
+
+export type MemoryDetailEvent = {
+  type: "$memory_detail";
+  detail: MemoryDetail;
 };
 
 export type RetryResultEvent = { type: "$retry_result"; text: string };
@@ -446,6 +465,7 @@ export type IncomingEvent = { tabId?: string } & (
   | SkillsEvent
   | CtxBreakdownEvent
   | MemoryEvent
+  | MemoryDetailEvent
   | JobsEvent
   | UserMessageEvent
   | ModelTurnStartedEvent
@@ -473,6 +493,7 @@ export type OutgoingCommand = { tabId?: string } & (
   | { cmd: "session_delete"; name: string }
   | { cmd: "session_load"; name: string }
   | { cmd: "session_rename"; name: string; title: string }
+  | { cmd: "memory_read"; path: string }
   | { cmd: "new_chat" }
   | { cmd: "setup_save_key"; key: string }
   | { cmd: "settings_get" }

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -2937,12 +2937,20 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
 }
 .mem-row {
   padding: 6px 8px;
+  width: 100%;
+  border: 0;
   border-radius: 6px;
   display: flex;
   gap: 8px;
   align-items: flex-start;
   background: var(--panel);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
   margin-bottom: 4px;
+}
+.mem-row[data-active="true"] {
+  background: var(--accent-soft);
 }
 .mem-row:last-child {
   margin-bottom: 0;
@@ -2960,6 +2968,20 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
 .mem-row .txt {
   font-size: 14px;
   color: var(--fg-2);
+  line-height: 1.5;
+}
+.mem-detail {
+  max-height: 220px;
+  overflow: auto;
+  margin: 8px 0 0;
+  padding: 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--panel);
+  white-space: pre-wrap;
+  color: var(--fg-1);
+  font-family: var(--mono);
+  font-size: 12px;
   line-height: 1.5;
 }
 
@@ -6912,4 +6934,79 @@ html[data-platform="macos"] .splash {
 .about-status.err {
   background: var(--panel);
   color: var(--muted);
+}
+.muted-card {
+  padding: 16px;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.memory-browser {
+  display: grid;
+  grid-template-columns: minmax(220px, 0.9fr) minmax(280px, 1.1fr);
+  gap: 12px;
+  min-height: 320px;
+}
+
+.memory-list,
+.memory-detail {
+  min-width: 0;
+  max-height: 52vh;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--card);
+}
+
+.memory-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.memory-item {
+  display: grid;
+  gap: 4px;
+  width: 100%;
+  padding: 10px 12px;
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  background: transparent;
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+}
+
+.memory-item[data-active="true"] {
+  background: var(--accent-soft);
+}
+
+.memory-kind,
+.memory-path {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--muted);
+}
+
+.memory-name {
+  font-size: 12px;
+  color: var(--text);
+}
+
+.memory-detail {
+  margin: 0;
+  padding: 12px;
+  white-space: pre-wrap;
+  font-family: var(--mono);
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--text);
+}
+
+@media (max-width: 860px) {
+  .memory-browser {
+    grid-template-columns: 1fr;
+  }
 }

--- a/desktop/src/ui/context-panel.tsx
+++ b/desktop/src/ui/context-panel.tsx
@@ -4,7 +4,7 @@ import { useMemo, useState } from "react";
 import type { SessionFile, Settings, UsageStats } from "../App";
 import { t, useLang } from "../i18n";
 import { I } from "../icons";
-import type { McpSpecInfo, MemoryEntryInfo } from "../protocol";
+import type { McpSpecInfo, MemoryDetail, MemoryEntryInfo } from "../protocol";
 import { PanelErrorBoundary } from "./error-boundary";
 
 type Tab = "files" | "tools" | "memory" | "rules";
@@ -18,6 +18,8 @@ export function ContextPanel({
   mcpBridged,
   sessionFiles,
   memory,
+  memoryDetail,
+  onReadMemory,
 }: {
   settings: Settings | null;
   usage: UsageStats;
@@ -25,6 +27,8 @@ export function ContextPanel({
   mcpBridged: boolean;
   sessionFiles: SessionFile[];
   memory: MemoryEntryInfo[];
+  memoryDetail: MemoryDetail | null;
+  onReadMemory: (path: string) => void;
 }) {
   useLang();
   const [tab, setTab] = useState<Tab>("files");
@@ -90,7 +94,9 @@ export function ContextPanel({
         <PanelErrorBoundary key={tab} label={tab}>
           {tab === "files" && <CtxFiles files={sessionFiles} settings={settings} />}
           {tab === "tools" && <CtxTools specs={mcpSpecs} bridged={mcpBridged} />}
-          {tab === "memory" && <CtxMemory entries={memory} />}
+          {tab === "memory" && (
+            <CtxMemory entries={memory} detail={memoryDetail} onRead={onReadMemory} />
+          )}
           {tab === "rules" && <CtxRules settings={settings} />}
         </PanelErrorBoundary>
       </div>
@@ -283,7 +289,15 @@ function CtxTools({ specs, bridged }: { specs: McpSpecInfo[]; bridged: boolean }
   );
 }
 
-function CtxMemory({ entries }: { entries: MemoryEntryInfo[] }) {
+function CtxMemory({
+  entries,
+  detail,
+  onRead,
+}: {
+  entries: MemoryEntryInfo[];
+  detail: MemoryDetail | null;
+  onRead: (path: string) => void;
+}) {
   return (
     <div className="ctx-block">
       <div className="h">
@@ -297,13 +311,20 @@ function CtxMemory({ entries }: { entries: MemoryEntryInfo[] }) {
       ) : (
         <div className="mem">
           {entries.map((m) => (
-            <div className="mem-row" key={`${m.scope}/${m.name}`}>
+            <button
+              type="button"
+              className="mem-row"
+              data-active={detail?.path === m.path}
+              key={m.path}
+              onClick={() => onRead(m.path)}
+            >
               <span className="scope" data-s={m.scope}>
                 {m.scope === "project" ? t("contextPanel.scopeProject") : t("contextPanel.scopeGlobal")}
               </span>
               <span className="txt">{m.description || m.name}</span>
-            </div>
+            </button>
           ))}
+          {detail ? <pre className="mem-detail">{detail.body}</pre> : null}
         </div>
       )}
     </div>

--- a/desktop/src/ui/settings.tsx
+++ b/desktop/src/ui/settings.tsx
@@ -2,7 +2,13 @@ import { type ReactNode, useEffect, useState } from "react";
 import type { Balance, Settings as SettingsType, UsageStats } from "../App";
 import { setLang, t, useLang } from "../i18n";
 import { I } from "../icons";
-import type { McpSpecInfo, SettingsPatch, SkillInfo } from "../protocol";
+import type {
+  McpSpecInfo,
+  MemoryDetail,
+  MemoryEntryInfo,
+  SettingsPatch,
+  SkillInfo,
+} from "../protocol";
 import {
   describeQQRowSummary,
   getQQConnectIntent,
@@ -62,6 +68,8 @@ export function SettingsModal({
   mcpSpecs,
   mcpBridged,
   skills,
+  memory,
+  memoryDetail,
   qq,
   onClose,
   onSave,
@@ -74,6 +82,7 @@ export function SettingsModal({
   onPickWorkspace,
   onAddMcpSpec,
   onRemoveMcpSpec,
+  onReadMemory,
 }: {
   settings: SettingsType;
   balance: Balance | null;
@@ -93,6 +102,8 @@ export function SettingsModal({
   mcpSpecs: McpSpecInfo[];
   mcpBridged: boolean;
   skills: SkillInfo[];
+  memory: MemoryEntryInfo[];
+  memoryDetail: MemoryDetail | null;
   qq: QQDesktopSettingsState | null;
   onClose: () => void;
   onSave: (patch: SettingsPatch) => void;
@@ -105,6 +116,7 @@ export function SettingsModal({
   onPickWorkspace: () => void;
   onAddMcpSpec: (spec: string) => void;
   onRemoveMcpSpec: (spec: string) => void;
+  onReadMemory: (path: string) => void;
 }) {
   const [page, setPage] = useState<PageId>(initialPage ?? "general");
   const [qqConfigureOpen, setQQConfigureOpen] = useState(false);
@@ -189,7 +201,9 @@ export function SettingsModal({
                 onSave={onSave}
               />
             )}
-            {page === "memory" && <PageMemory />}
+            {page === "memory" && (
+              <PageMemory entries={memory} detail={memoryDetail} onRead={onReadMemory} />
+            )}
             {page === "rules" && <PageRules settings={settings} onSave={onSave} />}
             {page === "billing" && (
               <PageBilling balance={balance} usage={usage} currency={currency} />
@@ -1075,22 +1089,42 @@ function PageSkills({
   );
 }
 
-function PageMemory() {
+function PageMemory({
+  entries,
+  detail,
+  onRead,
+}: {
+  entries: MemoryEntryInfo[];
+  detail: MemoryDetail | null;
+  onRead: (path: string) => void;
+}) {
   return (
     <section className="section">
       <div className="stitle">{t("settings.memorySection")}</div>
-      <div
-        style={{
-          padding: 16,
-          background: "var(--card)",
-          border: "1px solid var(--border)",
-          borderRadius: 10,
-          fontSize: 12,
-          color: "var(--muted)",
-        }}
-      >
-        {t("settings.memoryDesc")}
-      </div>
+      {entries.length === 0 ? (
+        <div className="muted-card">{t("settings.memoryDesc")}</div>
+      ) : (
+        <div className="memory-browser">
+          <div className="memory-list">
+            {entries.map((m) => (
+              <button
+                type="button"
+                className="memory-item"
+                data-active={detail?.path === m.path}
+                key={m.path}
+                onClick={() => onRead(m.path)}
+              >
+                <span className="memory-kind">{m.kind.replace("_", " ")}</span>
+                <span className="memory-name">{m.description || m.name}</span>
+                <span className="memory-path">{m.path}</span>
+              </button>
+            ))}
+          </div>
+          <pre className="memory-detail">
+            {detail ? detail.body : t("settings.memoryDesc")}
+          </pre>
+        </div>
+      )}
     </section>
   );
 }

--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -4,6 +4,7 @@ import {
   type ReasoningEffort,
   bridgeEndpointEnv,
   loadApiKey,
+  loadHistoryScrollMode,
   loadToolRateLimit,
   readConfig,
   searchEnabled,
@@ -28,6 +29,8 @@ import { App } from "../ui/App.js";
 import { SessionPicker } from "../ui/SessionPicker.js";
 import { Setup } from "../ui/Setup.js";
 import { drainTtyResponses } from "../ui/drain-tty.js";
+import type { ResolvedHistoryScrollMode } from "../ui/history-scroll-mode.js";
+import { resolveHistoryScrollMode } from "../ui/history-scroll-mode.js";
 import { KeystrokeProvider } from "../ui/keystroke-context.js";
 import { disableMouseMode, enableMouseMode } from "../ui/mouse-mode.js";
 import { installResizeBroadcaster } from "../ui/resize-broadcaster.js";
@@ -122,6 +125,8 @@ interface RootProps extends ChatOptions {
   mcpRuntime: McpRuntime;
   /** One-time startup info rows shown after App mounts. */
   startupInfoHints: string[];
+  /** Resolved app/native scroll behavior for chat history. */
+  historyScrollMode: ResolvedHistoryScrollMode;
   /** Pre-created QQ channel (started before TUI mounts). */
   qqChannel?: QQChannel;
   /** App fills this ref on mount so QQ messages flow into the TUI input queue. */
@@ -139,6 +144,7 @@ function Root({
   showPicker,
   mcpRuntime,
   startupInfoHints,
+  historyScrollMode,
   ...appProps
 }: RootProps) {
   const [key, setKey] = useState<string | undefined>(initialKey);
@@ -241,6 +247,7 @@ function Root({
         qqChannel={appProps.qqChannel}
         qqSubmitRef={appProps.qqSubmitRef}
         qqErrorRef={appProps.qqErrorRef}
+        historyScrollMode={historyScrollMode}
         onSwitchSession={setActiveSession}
       />
     </KeystrokeProvider>
@@ -292,6 +299,11 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
   const mcpSpecs = [...requestedSpecs];
   const mcpServers: McpServerSummary[] = [];
   const cfg = readConfig();
+  const historyScrollMode = resolveHistoryScrollMode({
+    configured: loadHistoryScrollMode(),
+    env: process.env,
+    platform: process.platform,
+  });
   const startupInfoHints: string[] = [];
   if (cfg.setupCompleted === true && (cfg.mcp?.length ?? 0) === 0 && mcpSpecs.length === 0) {
     startupInfoHints.push(t("mcpHealth.emptyHint"));
@@ -365,7 +377,7 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
   // mode on in most terminals). exit hooks cover hard kills so the
   // sequence doesn't leak into the parent shell.
   if (!opts.noMouse && cfg.mouseTracking !== false) {
-    enableMouseMode();
+    enableMouseMode(historyScrollMode);
     process.once("exit", disableMouseMode);
     process.once("SIGINT", () => {
       disableMouseMode();
@@ -386,6 +398,7 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
       mcpRuntime={runtime}
       progressSink={progressSink}
       startupInfoHints={startupInfoHints}
+      historyScrollMode={historyScrollMode}
       showPicker={showPicker}
       {...opts}
       codeMode={codeMode}

--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -63,6 +63,12 @@ import {
 import { autoResolveVerdict } from "../../core/pause-policy.js";
 import { augmentProcessPath } from "../../desktop/login-shell-path.js";
 import {
+  type MemoryEntryDetail,
+  type MemoryEntryInfo,
+  collectMemoryEntriesForWorkspace,
+  readMemoryEntryDetail,
+} from "../../desktop/memory-browser.js";
+import {
   loadDesktopQQState,
   saveDesktopQQSettings,
   setDesktopQQEnabled,
@@ -85,10 +91,10 @@ import {
   loadSessionMessages,
   loadSessionMeta,
   patchSessionMeta,
+  patchSessionWorkspaceIfMissing,
   sessionPath,
   timestampSuffix,
 } from "../../memory/session.js";
-import { MemoryStore } from "../../memory/user.js";
 import { QQChannel } from "../../qq/channel.js";
 import { SkillStore } from "../../skills.js";
 import { countTokensBounded } from "../../tokenizer.js";
@@ -116,6 +122,7 @@ type InMessage = { tabId?: string } & (
   | { cmd: "session_delete"; name: string }
   | { cmd: "session_load"; name: string }
   | { cmd: "session_rename"; name: string; title: string }
+  | { cmd: "memory_read"; path: string }
   | { cmd: "new_chat" }
   | { cmd: "setup_save_key"; key: string }
   | { cmd: "settings_get" }
@@ -213,7 +220,13 @@ interface PlanRequiredEvent {
 
 interface SessionsEvent {
   type: "$sessions";
-  items: { name: string; messageCount: number; mtime: string }[];
+  items: {
+    name: string;
+    messageCount: number;
+    mtime: string;
+    summary?: string;
+    workspaceStatus?: "matched" | "legacy_missing_meta";
+  }[];
 }
 
 interface MentionResultsEvent {
@@ -372,15 +385,14 @@ interface CtxBreakdownEvent {
   logTokens?: number;
 }
 
-interface MemoryEntryInfo {
-  name: string;
-  scope: "project" | "global";
-  description: string;
-}
-
 interface MemoryEvent {
   type: "$memory";
   entries: MemoryEntryInfo[];
+}
+
+interface MemoryDetailEvent {
+  type: "$memory_detail";
+  detail: MemoryEntryDetail;
 }
 
 interface SkillInfo {
@@ -466,6 +478,7 @@ type EmittableEvent =
   | SkillsEvent
   | CtxBreakdownEvent
   | MemoryEvent
+  | MemoryDetailEvent
   | JobsEvent;
 
 const STDOUT_BACKPRESSURE_WAIT = new Int32Array(new SharedArrayBuffer(4));
@@ -629,6 +642,7 @@ function emitSessions(tab: Tab): void {
       messageCount: s.messageCount,
       mtime: s.mtime.toISOString(),
       summary: s.meta.summary,
+      workspaceStatus: s.workspaceStatus,
     }));
     emit({ type: "$sessions", items }, tab.id);
   } catch (err) {
@@ -683,12 +697,7 @@ function emitMcpSpecs(tab: Tab): void {
 
 function emitMemory(tab: Tab): void {
   try {
-    const store = new MemoryStore({ projectRoot: tab.rootDir });
-    const entries: MemoryEntryInfo[] = store.list().map((e) => ({
-      name: e.name,
-      scope: e.scope,
-      description: e.description,
-    }));
+    const entries = collectMemoryEntriesForWorkspace(tab.rootDir);
     emit({ type: "$memory", entries }, tab.id);
   } catch (err) {
     emit({ type: "$error", message: `memory_get failed: ${(err as Error).message}` }, tab.id);
@@ -2160,6 +2169,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
     if (msg.cmd === "session_load") {
       try {
         const records = loadSessionMessages(msg.name);
+        const backfilledWorkspace = patchSessionWorkspaceIfMissing(msg.name, tab.rootDir);
         const meta = loadSessionMeta(msg.name);
         // Only set switching flag when there's a live turn to abort —
         // otherwise the flag stays true and suppresses the first turn's events (#1217).
@@ -2201,9 +2211,19 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
           },
           tab.id,
         );
+        if (backfilledWorkspace) emitSessions(tab);
       } catch (err) {
         process.stderr.write(`session_load: "${msg.name}" threw — ${(err as Error).message}\n`);
         emit({ type: "$error", message: `session_load failed: ${(err as Error).message}` }, tab.id);
+      }
+      return;
+    }
+    if (msg.cmd === "memory_read") {
+      try {
+        const detail = readMemoryEntryDetail({ path: msg.path }, tab.rootDir);
+        emit({ type: "$memory_detail", detail }, tab.id);
+      } catch (err) {
+        emit({ type: "$error", message: `memory_read failed: ${(err as Error).message}` }, tab.id);
       }
       return;
     }

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -31,12 +31,15 @@ import {
 import {
   type EditMode,
   type EngineeringLifecycleMode,
+  type HistoryScrollMode,
   type ReasoningEffort,
   defaultConfigPath,
   editModeHintShown,
   isReasoningEffort,
   loadEndpoint,
   loadEngineeringLifecycleMode,
+  loadHistoryScrollMode,
+  loadMouseWheelRows,
   loadReasoningEffort,
   loadTheme,
   markEditModeHintShown,
@@ -142,6 +145,7 @@ import {
 } from "./edit-tool-gate.js";
 import { loopEventToDashboard } from "./effects/loop-to-dashboard.js";
 import { appendGlobalMemory, appendProjectMemory, detectHashMemory } from "./hash-memory.js";
+import { type ResolvedHistoryScrollMode, resolveHistoryScrollMode } from "./history-scroll-mode.js";
 import { applySlashResult } from "./hooks/apply-slash-result.js";
 import { handleAssistantFinal } from "./hooks/handle-assistant-final.js";
 import {
@@ -164,6 +168,7 @@ import { useToolProgressDisplay } from "./hooks/useToolProgressDisplay.js";
 import { useTranscriptWriter } from "./hooks/useTranscriptWriter.js";
 import { useWorkspaceRoot } from "./hooks/useWorkspaceRoot.js";
 import { useKeystroke } from "./keystroke-context.js";
+import { CardStream } from "./layout/CardStream.js";
 import { LiveExpandContext } from "./layout/LiveExpandContext.js";
 import { ModeStatusBar } from "./layout/LiveRows.js";
 import { StaticCardStream } from "./layout/StaticCardStream.js";
@@ -187,6 +192,7 @@ import {
 } from "./slash.js";
 import { TurnTranslator } from "./state/TurnTranslator.js";
 import { cardsToDashboardMessages } from "./state/cards-to-messages.js";
+import { ChatScrollProvider, useChatScrollActions } from "./state/chat-scroll-provider.js";
 import { hydrateCardsFromMessages } from "./state/hydrate.js";
 import { InflightProvider } from "./state/inflight-context.js";
 import { AgentStoreProvider, useAgentState, useAgentStore } from "./state/provider.js";
@@ -304,6 +310,8 @@ export interface AppProps {
   qqSubmitRef?: { current: ((text: string) => void) | null };
   /** Ref filled by App on mount so QQ errors appear in the TUI log. */
   qqErrorRef?: { current: ((msg: string) => void) | null };
+  /** Resolved chat-history scroll mode, computed by the launcher from config/env. */
+  historyScrollMode?: ResolvedHistoryScrollMode;
 }
 
 // Module-level so the embedded dashboard server survives App remounts (chat.tsx
@@ -411,15 +419,25 @@ export function App(props: AppProps): React.ReactElement {
       showFeedbackHint: cfg.showFeedbackHint !== false,
     };
   }, []);
+  const historyScrollMode = React.useMemo(
+    () =>
+      props.historyScrollMode ??
+      resolveHistoryScrollMode({ configured: loadHistoryScrollMode() as HistoryScrollMode }),
+    [props.historyScrollMode],
+  );
+  const wheelRows = React.useMemo(() => loadMouseWheelRows(), []);
   return (
     <ThemeProvider name={themeName}>
       <AgentStoreProvider session={session} initialCards={initialCards}>
-        <AppInner
-          {...props}
-          themeName={themeName}
-          setThemeName={setThemeName}
-          statusBar={statusBar}
-        />
+        <ChatScrollProvider wheelRows={wheelRows}>
+          <AppInner
+            {...props}
+            historyScrollMode={historyScrollMode}
+            themeName={themeName}
+            setThemeName={setThemeName}
+            statusBar={statusBar}
+          />
+        </ChatScrollProvider>
       </AgentStoreProvider>
     </ThemeProvider>
   );
@@ -429,6 +447,7 @@ type AppInnerProps = AppProps & {
   themeName: ThemeName;
   setThemeName: React.Dispatch<React.SetStateAction<ThemeName>>;
   statusBar: StatusBarConfig;
+  historyScrollMode: ResolvedHistoryScrollMode;
 };
 
 function AppInner({
@@ -455,6 +474,7 @@ function AppInner({
   qqChannel,
   qqSubmitRef,
   qqErrorRef,
+  historyScrollMode,
   themeName,
   setThemeName,
   statusBar,
@@ -809,6 +829,7 @@ function AppInner({
     history: promptHistory,
     isHistoryMode,
   } = useInputRecall(setInput);
+  const chatScroll = useChatScrollActions();
   const { setRawMode, isRawModeSupported } = useStdin();
   // Ctrl+X —hand the composer buffer to $EDITOR. Raw-mode flip lets the
   // editor own line-buffered input; result replaces the composer value.
@@ -1661,6 +1682,29 @@ function AppInner({
       return next;
     });
   });
+
+  useKeystroke((ev) => {
+    if (ev.paste || modalOpen) return;
+    if (ev.mouseScrollUp) {
+      chatScroll.scrollWheelUp();
+      return;
+    }
+    if (ev.mouseScrollDown) {
+      chatScroll.scrollWheelDown();
+      return;
+    }
+    if (ev.pageUp && (busy || input.length === 0)) {
+      chatScroll.scrollPageUp();
+      return;
+    }
+    if (ev.pageDown && (busy || input.length === 0)) {
+      chatScroll.scrollPageDown();
+      return;
+    }
+    if (ev.end && (busy || input.length === 0)) {
+      chatScroll.jumpToBottom();
+    }
+  }, historyScrollMode === "app");
 
   // Double-Esc — opens the rewind/edit picker when idle with an empty
   // composer. Tracks the prior Esc timestamp; a second Esc inside 500 ms
@@ -4232,7 +4276,11 @@ function AppInner({
               <Box flexDirection="column" flexGrow={1}>
                 <LiveExpandContext.Provider value={liveExpand}>
                   <VerboseContext.Provider value={verboseMode}>
-                    <StaticCardStream suppressLive={modalOpen} />
+                    {historyScrollMode === "app" ? (
+                      <CardStream suppressLive={modalOpen} />
+                    ) : (
+                      <StaticCardStream suppressLive={modalOpen} />
+                    )}
                   </VerboseContext.Provider>
                 </LiveExpandContext.Provider>
                 {/*

--- a/src/cli/ui/history-scroll-mode.ts
+++ b/src/cli/ui/history-scroll-mode.ts
@@ -1,0 +1,32 @@
+import type { HistoryScrollMode } from "../../config.js";
+
+export type ResolvedHistoryScrollMode = "native" | "app";
+
+export interface ResolveHistoryScrollModeInput {
+  configured?: HistoryScrollMode;
+  env?: NodeJS.ProcessEnv | Record<string, string | undefined>;
+  platform?: NodeJS.Platform;
+}
+
+export function resolveHistoryScrollMode({
+  configured = "auto",
+  env = process.env,
+  platform = process.platform,
+}: ResolveHistoryScrollModeInput = {}): ResolvedHistoryScrollMode {
+  if (configured === "native") return "native";
+  if (configured === "app") return "app";
+  if (isKnownJumpProneTerminal(env)) return "app";
+  if (platform === "win32" && env.TERM_PROGRAM === undefined && env.MSYSTEM === undefined) {
+    return "native";
+  }
+  return "native";
+}
+
+function isKnownJumpProneTerminal(env: NodeJS.ProcessEnv | Record<string, string | undefined>) {
+  const termProgram = (env.TERM_PROGRAM ?? "").toLowerCase();
+  if (termProgram === "vscode" || termProgram === "ghostty") return true;
+  if (typeof env.WT_SESSION === "string" && env.WT_SESSION.length > 0) return true;
+  if (typeof env.MSYSTEM === "string" && env.MSYSTEM.length > 0) return true;
+  if ((env.TERM ?? "").toLowerCase().includes("xterm-ghostty")) return true;
+  return false;
+}

--- a/src/cli/ui/layout/CardStream.tsx
+++ b/src/cli/ui/layout/CardStream.tsx
@@ -1,0 +1,176 @@
+import { Box, type DOMElement, Text, useBoxMetrics, useStdout } from "ink";
+import React, { useEffect, useMemo, useRef } from "react";
+import stringWidth from "string-width";
+import { t } from "../../../i18n/index.js";
+import { CardRenderer } from "../cards/CardRenderer.js";
+import type { Card } from "../state/cards.js";
+import { useChatScrollActions, useChatScrollState } from "../state/chat-scroll-provider.js";
+import { useAgentState } from "../state/provider.js";
+import { FG, SURFACE, TONE } from "../theme/tokens.js";
+
+export const VISIBLE_BUFFER_ROWS = 30;
+
+export type CardStreamItem<T> =
+  | { kind: "spacer"; rows: number; key: string }
+  | { kind: "card"; card: T };
+
+export function computeCardStreamItems<T extends { id: string }>(
+  cards: readonly T[],
+  cardHeights: ReadonlyMap<string, number>,
+  scrollRows: number,
+  outerHeight: number,
+): CardStreamItem<T>[] {
+  const bucket = Math.floor(scrollRows / VISIBLE_BUFFER_ROWS) * VISIBLE_BUFFER_ROWS;
+  const winStart = Math.max(0, bucket - VISIBLE_BUFFER_ROWS);
+  const winEnd = bucket + outerHeight + VISIBLE_BUFFER_ROWS * 2;
+  const out: CardStreamItem<T>[] = [];
+  let cursor = 0;
+  let pendingSpacer = 0;
+  let spacerKey = 0;
+  for (const card of cards) {
+    const h = cardHeights.get(card.id);
+    const cardEnd = cursor + (h ?? 0);
+    const live = h === undefined || (cardEnd >= winStart && cursor <= winEnd);
+    if (live) {
+      if (pendingSpacer > 0) {
+        out.push({ kind: "spacer", rows: pendingSpacer, key: `sp-${spacerKey++}` });
+        pendingSpacer = 0;
+      }
+      out.push({ kind: "card", card });
+    } else {
+      pendingSpacer += h ?? 0;
+    }
+    cursor = cardEnd;
+  }
+  if (pendingSpacer > 0) out.push({ kind: "spacer", rows: pendingSpacer, key: `sp-${spacerKey}` });
+  return out;
+}
+
+export function CardStream({
+  suppressLive = false,
+}: {
+  suppressLive?: boolean;
+}): React.ReactElement {
+  const cards = useAgentState((s) => s.cards);
+  const scrollRows = useChatScrollState((s) => s.scrollRows);
+  const cardHeights = useChatScrollState((s) => s.cardHeights);
+  const { setMaxScroll, setCardHeight, pruneCardHeights } = useChatScrollActions();
+  const outerRef = useRef<DOMElement>(null!);
+  const innerRef = useRef<DOMElement>(null!);
+  const outer = useBoxMetrics(outerRef);
+  const inner = useBoxMetrics(innerRef);
+  const maxScroll = Math.max(0, inner.height - outer.height);
+
+  useEffect(() => {
+    setMaxScroll(maxScroll);
+  }, [maxScroll, setMaxScroll]);
+
+  useEffect(() => {
+    pruneCardHeights(new Set(cards.map((c) => c.id)));
+  }, [cards, pruneCardHeights]);
+
+  let visible = cards;
+  if (suppressLive && cards.length > 0 && !isFullySettled(cards[cards.length - 1]!)) {
+    visible = cards.slice(0, -1);
+  }
+
+  const items = useMemo(
+    () => computeCardStreamItems(visible, cardHeights, scrollRows, outer.height),
+    [visible, cardHeights, scrollRows, outer.height],
+  );
+
+  return (
+    <>
+      <Box height={1} flexShrink={0}>
+        {scrollRows > 0 ? <ScrollIndicator scrollRows={scrollRows} maxScroll={maxScroll} /> : null}
+      </Box>
+      <Box ref={outerRef} flexDirection="column" flexGrow={1} overflow="hidden">
+        <Box ref={innerRef} flexDirection="column" marginTop={-scrollRows} flexShrink={0}>
+          {items.map((item) =>
+            item.kind === "spacer" ? (
+              <Box key={item.key} height={item.rows} flexShrink={0} />
+            ) : (
+              <MeasuredCard key={item.card.id} card={item.card} report={setCardHeight} />
+            ),
+          )}
+        </Box>
+      </Box>
+    </>
+  );
+}
+
+function MeasuredCard({
+  card,
+  report,
+}: {
+  card: Card;
+  report: (id: string, rows: number) => void;
+}): React.ReactElement {
+  const ref = useRef<DOMElement>(null!);
+  const metrics = useBoxMetrics(ref);
+  const lastReportedRef = useRef<number>(0);
+  const settled = isFullySettled(card);
+
+  useEffect(() => {
+    const rows = metrics.height;
+    if (rows <= 0 || rows === lastReportedRef.current) return;
+    if (!settled && rows < lastReportedRef.current) return;
+    lastReportedRef.current = rows;
+    report(card.id, rows);
+  }, [card.id, metrics.height, report, settled]);
+
+  return (
+    <Box ref={ref} flexDirection="column" flexShrink={0}>
+      <CardRenderer card={card} />
+    </Box>
+  );
+}
+
+function ScrollIndicator({
+  scrollRows,
+  maxScroll,
+}: {
+  scrollRows: number;
+  maxScroll: number;
+}): React.ReactElement {
+  const version = useChatScrollState((s) => s.scrollVersion);
+  const [hot, setHot] = React.useState(false);
+  React.useEffect(() => {
+    if (version === 0) return;
+    setHot(true);
+    const id = setTimeout(() => setHot(false), 220);
+    return () => clearTimeout(id);
+  }, [version]);
+  const remaining = Math.max(0, maxScroll - scrollRows);
+  const above =
+    scrollRows === 1
+      ? t("cardStream.scrollAbove", { scroll: scrollRows, max: maxScroll })
+      : t("cardStream.scrollAbovePlural", { scroll: scrollRows, max: maxScroll });
+  const more = remaining > 0 ? t("cardStream.scrollMore", { remaining }) : "";
+  const text = `${above}${more}${t("cardStream.scrollPgUp")}${t("cardStream.scrollCopy")}`;
+  const { stdout } = useStdout();
+  const cols = stdout?.columns ?? 80;
+  const pad = Math.max(0, cols - stringWidth(text));
+  return (
+    <Text color={hot ? TONE.accent : FG.faint} backgroundColor={SURFACE.bgElev}>
+      {text + " ".repeat(pad)}
+    </Text>
+  );
+}
+
+function isFullySettled(card: Card): boolean {
+  switch (card.kind) {
+    case "streaming":
+    case "tool":
+      return card.done || !!card.aborted;
+    case "reasoning":
+      return !card.streaming || !!card.aborted;
+    case "task":
+    case "subagent":
+      return card.status !== "running";
+    case "plan":
+      return card.steps.every((s) => s.status === "done" || s.status === "skipped");
+    default:
+      return true;
+  }
+}

--- a/src/cli/ui/mouse-mode.ts
+++ b/src/cli/ui/mouse-mode.ts
@@ -6,13 +6,15 @@
 // REASONIX_MOUSE_MODE remains an escape hatch.
 
 type Mode = "alternate-scroll" | "sgr" | "off" | "apple-terminal-off";
+export type MouseHistoryMode = "native" | "app";
 
-function readMode(): Mode {
+function readMode(historyMode: MouseHistoryMode): Mode {
   const raw = (process.env.REASONIX_MOUSE_MODE ?? "").toLowerCase();
   if (raw === "sgr") return "sgr";
   if (raw === "alternate-scroll") return "alternate-scroll";
+  if (raw === "off") return "off";
   if (process.env.TERM_PROGRAM === "Apple_Terminal" && raw === "") return "apple-terminal-off";
-  return "off";
+  return historyMode === "app" ? "sgr" : "off";
 }
 
 const RESET_ALL =
@@ -28,10 +30,10 @@ const SEQUENCES: Record<Mode, { enable: string; disable: string }> = {
 let active = false;
 let activeMode: Mode = "off";
 
-export function enableMouseMode(): void {
+export function enableMouseMode(historyMode: MouseHistoryMode = "native"): void {
   if (active) return;
   if (!process.stdout.isTTY) return;
-  activeMode = readMode();
+  activeMode = readMode(historyMode);
   const seq = SEQUENCES[activeMode].enable;
   if (seq) process.stdout.write(seq);
   active = true;

--- a/src/cli/ui/state/chat-scroll-provider.tsx
+++ b/src/cli/ui/state/chat-scroll-provider.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import {
+  type ChatScrollState,
+  type ChatScrollStore,
+  createChatScrollStore,
+} from "./chat-scroll-store.js";
+
+const Ctx = React.createContext<ChatScrollStore | null>(null);
+
+export function ChatScrollProvider({
+  children,
+  wheelRows,
+}: {
+  children: React.ReactNode;
+  wheelRows?: number;
+}): React.ReactElement {
+  const store = React.useMemo(() => createChatScrollStore({ wheelRows }), [wheelRows]);
+  return <Ctx.Provider value={store}>{children}</Ctx.Provider>;
+}
+
+function useStore(): ChatScrollStore {
+  const store = React.useContext(Ctx);
+  if (!store) throw new Error("useChatScroll* must be used inside ChatScrollProvider");
+  return store;
+}
+
+export function useChatScrollState<T>(selector: (s: ChatScrollState) => T): T {
+  const store = useStore();
+  const subscribe = React.useCallback((cb: () => void) => store.subscribe(cb), [store]);
+  const getSnapshot = React.useCallback(() => selector(store.getState()), [store, selector]);
+  return React.useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+export function useChatScrollActions(): Pick<
+  ChatScrollStore,
+  | "scrollUp"
+  | "scrollDown"
+  | "scrollPageUp"
+  | "scrollPageDown"
+  | "scrollWheelUp"
+  | "scrollWheelDown"
+  | "jumpToBottom"
+  | "setMaxScroll"
+  | "setCardHeight"
+  | "pruneCardHeights"
+> {
+  return useStore();
+}

--- a/src/cli/ui/state/chat-scroll-store.ts
+++ b/src/cli/ui/state/chat-scroll-store.ts
@@ -1,0 +1,182 @@
+/** Chat-history scroll state in its own store so wheel ticks do not dirty App.tsx. */
+
+export interface ChatScrollState {
+  /** Rows of content above the visible viewport. */
+  scrollRows: number;
+  /** True while following the bottom; new content keeps the viewport pinned. */
+  pinned: boolean;
+  /** Total scrollable rows reported by CardStream after measurement. */
+  maxScroll: number;
+  /** Bumped on every applied scroll delta so the indicator can flash. */
+  scrollVersion: number;
+  /** Per-card row height, populated as cards mount and re-measure. */
+  cardHeights: ReadonlyMap<string, number>;
+}
+
+export type ScrollListener = () => void;
+
+export interface ChatScrollStore {
+  getState(): ChatScrollState;
+  subscribe(listener: ScrollListener): () => void;
+  scrollUp(): void;
+  scrollDown(): void;
+  scrollPageUp(): void;
+  scrollPageDown(): void;
+  scrollWheelUp(): void;
+  scrollWheelDown(): void;
+  jumpToBottom(): void;
+  setMaxScroll(rows: number): void;
+  setCardHeight(id: string, rows: number): void;
+  pruneCardHeights(liveIds: ReadonlySet<string>): void;
+}
+
+export const SCROLL_ARROW_ROWS = 3;
+export const SCROLL_PAGE_ROWS = 5;
+export const SCROLL_WHEEL_ROWS = 1;
+const COALESCE_MS = 16;
+
+const EMPTY_HEIGHTS: ReadonlyMap<string, number> = new Map();
+
+const initial: ChatScrollState = {
+  scrollRows: 0,
+  pinned: true,
+  maxScroll: 0,
+  scrollVersion: 0,
+  cardHeights: EMPTY_HEIGHTS,
+};
+
+export interface CreateChatScrollStoreOptions {
+  /** Per-SGR-wheel-report step. Defaults to 1; clamped to [1, 10]. */
+  wheelRows?: number;
+}
+
+export function createChatScrollStore(opts: CreateChatScrollStoreOptions = {}): ChatScrollStore {
+  const wheelRows =
+    typeof opts.wheelRows === "number" && Number.isInteger(opts.wheelRows) && opts.wheelRows >= 1
+      ? Math.min(opts.wheelRows, 10)
+      : SCROLL_WHEEL_ROWS;
+  let state = initial;
+  const listeners = new Set<ScrollListener>();
+  let pendingDelta = 0;
+  let flushTimer: NodeJS.Timeout | null = null;
+  let pendingMaxShrink: number | null = null;
+  let shrinkTimer: NodeJS.Timeout | null = null;
+
+  function set(next: Partial<ChatScrollState>): void {
+    const merged = { ...state, ...next };
+    if (
+      merged.scrollRows === state.scrollRows &&
+      merged.pinned === state.pinned &&
+      merged.maxScroll === state.maxScroll &&
+      merged.scrollVersion === state.scrollVersion &&
+      merged.cardHeights === state.cardHeights
+    ) {
+      return;
+    }
+    state = merged;
+    for (const l of listeners) l();
+  }
+
+  function applyDelta(): void {
+    const d = pendingDelta;
+    pendingDelta = 0;
+    if (d === 0) return;
+    const next = Math.max(0, Math.min(state.maxScroll, state.scrollRows + d));
+    set({
+      scrollRows: next,
+      pinned: d < 0 ? false : next >= state.maxScroll ? true : state.pinned,
+      scrollVersion: state.scrollVersion + 1,
+    });
+  }
+
+  function schedule(delta: number): void {
+    if (flushTimer === null) {
+      pendingDelta = delta;
+      applyDelta();
+      flushTimer = setTimeout(() => {
+        flushTimer = null;
+        if (pendingDelta !== 0) applyDelta();
+      }, COALESCE_MS);
+    } else {
+      pendingDelta += delta;
+    }
+  }
+
+  function flushShrink(): void {
+    if (shrinkTimer !== null) {
+      clearTimeout(shrinkTimer);
+      shrinkTimer = null;
+    }
+    const target = pendingMaxShrink;
+    pendingMaxShrink = null;
+    if (target === null) return;
+    const nextScrollRows = state.pinned ? target : Math.min(state.scrollRows, target);
+    set({ maxScroll: target, scrollRows: nextScrollRows });
+  }
+
+  return {
+    getState() {
+      return state;
+    },
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    scrollUp: () => schedule(-SCROLL_ARROW_ROWS),
+    scrollDown: () => schedule(SCROLL_ARROW_ROWS),
+    scrollPageUp: () => schedule(-SCROLL_PAGE_ROWS),
+    scrollPageDown: () => schedule(SCROLL_PAGE_ROWS),
+    scrollWheelUp: () => schedule(-wheelRows),
+    scrollWheelDown: () => schedule(wheelRows),
+    jumpToBottom() {
+      pendingDelta = 0;
+      if (flushTimer !== null) {
+        clearTimeout(flushTimer);
+        flushTimer = null;
+      }
+      pendingMaxShrink = null;
+      if (shrinkTimer !== null) {
+        clearTimeout(shrinkTimer);
+        shrinkTimer = null;
+      }
+      set({ pinned: true, scrollRows: state.maxScroll });
+    },
+    setMaxScroll(rows: number) {
+      const maxScroll = rows < 0 ? 0 : rows;
+      const currentMax = pendingMaxShrink ?? state.maxScroll;
+      if (state.pinned && maxScroll < currentMax) {
+        pendingMaxShrink = maxScroll;
+        if (shrinkTimer === null) {
+          shrinkTimer = setTimeout(() => {
+            shrinkTimer = null;
+            flushShrink();
+          }, COALESCE_MS);
+        }
+        return;
+      }
+      if (pendingMaxShrink !== null) flushShrink();
+      const nextScrollRows = state.pinned ? maxScroll : Math.min(state.scrollRows, maxScroll);
+      set({ maxScroll, scrollRows: nextScrollRows });
+    },
+    setCardHeight(id: string, rows: number) {
+      if (state.cardHeights.get(id) === rows) return;
+      const next = new Map(state.cardHeights);
+      next.set(id, rows);
+      set({ cardHeights: next });
+    },
+    pruneCardHeights(liveIds: ReadonlySet<string>) {
+      let changed = false;
+      const next = new Map<string, number>();
+      for (const [id, rows] of state.cardHeights) {
+        if (liveIds.has(id)) {
+          next.set(id, rows);
+        } else {
+          changed = true;
+        }
+      }
+      if (changed) set({ cardHeights: next });
+    },
+  };
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -41,6 +41,7 @@ export function isReasoningEffort(value: unknown): value is ReasoningEffort {
 }
 
 export type EngineeringLifecycleMode = "off" | "strict";
+export type HistoryScrollMode = "auto" | "native" | "app";
 
 export type EmbeddingProvider = "ollama" | "openai-compat";
 
@@ -190,6 +191,8 @@ export interface ReasonixConfig {
   mouseTracking?: boolean;
   /** Rows scrolled per single SGR mouse-wheel report. Default 1 — most terminals emit 2-5 reports per physical notch, so 1 already produces 2-5 rows per notch (#1419). Bump to 3-5 only if your terminal emits one report per notch and scrolling feels slow (#1494). Clamped to [1, 10]. */
   mouseWheelRows?: number;
+  /** Chat-history scrolling: "native" leaves terminal scrollback in charge; "app" captures wheel/PgUp/PgDn/End inside the TUI; "auto" enables app mode for terminals with known jumpy native scrollback. */
+  historyScrollMode?: HistoryScrollMode;
   dashboard?: {
     /** Whether the embedded dashboard auto-starts on launch. Default true. Set false to disable without passing --no-dashboard each time. */
     enabled?: boolean;
@@ -705,6 +708,11 @@ export function loadMouseWheelRows(path: string = defaultConfigPath()): number |
   const raw = readConfig(path).mouseWheelRows;
   if (typeof raw !== "number" || !Number.isInteger(raw) || raw < 1) return undefined;
   return Math.min(raw, 10);
+}
+
+export function loadHistoryScrollMode(path: string = defaultConfigPath()): HistoryScrollMode {
+  const raw = readConfig(path).historyScrollMode;
+  return raw === "native" || raw === "app" || raw === "auto" ? raw : "auto";
 }
 
 export function loadToolRateLimit(

--- a/src/desktop/memory-browser.ts
+++ b/src/desktop/memory-browser.ts
@@ -1,0 +1,107 @@
+import { existsSync, readFileSync } from "node:fs";
+import { basename, resolve } from "node:path";
+import { readProjectMemory } from "../memory/project.js";
+import {
+  type MemoryEntry,
+  type MemoryScope,
+  MemoryStore,
+  readGlobalReasonixMemory,
+} from "../memory/user.js";
+
+export type MemoryEntryKind = "project_file" | "global_file" | "structured";
+
+export interface MemoryEntryInfo {
+  kind: MemoryEntryKind;
+  scope: MemoryScope;
+  name: string;
+  path: string;
+  description: string;
+  type?: string;
+}
+
+export interface MemoryEntryDetail extends MemoryEntryInfo {
+  body: string;
+  createdAt?: string;
+}
+
+export interface MemoryBrowserOptions {
+  /** Absolute ~/.reasonix directory. Tests override this; production uses homedir(). */
+  reasonixHome?: string;
+}
+
+export function collectMemoryEntriesForWorkspace(
+  projectRoot: string,
+  opts: MemoryBrowserOptions = {},
+): MemoryEntryInfo[] {
+  const out: MemoryEntryInfo[] = [];
+  const project = readProjectMemory(projectRoot);
+  if (project) {
+    out.push({
+      kind: "project_file",
+      scope: "project",
+      name: basename(project.path),
+      path: project.path,
+      description: "Project memory file",
+      type: "freeform",
+    });
+  }
+
+  const global = readGlobalReasonixMemory(opts.reasonixHome);
+  if (global) {
+    out.push({
+      kind: "global_file",
+      scope: "global",
+      name: basename(global.path),
+      path: global.path,
+      description: "Global memory file",
+      type: "freeform",
+    });
+  }
+
+  const store = new MemoryStore({ homeDir: opts.reasonixHome, projectRoot });
+  for (const entry of store.list()) {
+    out.push(structuredInfo(store, entry));
+  }
+  return out;
+}
+
+export function readMemoryEntryDetail(
+  request: { path: string },
+  projectRoot: string,
+  opts: MemoryBrowserOptions = {},
+): MemoryEntryDetail {
+  const requested = resolve(request.path);
+  const entry = collectMemoryEntriesForWorkspace(projectRoot, opts).find(
+    (candidate) => resolve(candidate.path) === requested,
+  );
+  if (!entry) throw new Error(`memory path not available: ${request.path}`);
+
+  if (entry.kind === "structured") {
+    const store = new MemoryStore({ homeDir: opts.reasonixHome, projectRoot });
+    const structured = store.read(entry.scope, entry.name);
+    return {
+      ...entry,
+      description: structured.description,
+      type: structured.type,
+      body: structured.body,
+      createdAt: structured.createdAt,
+    };
+  }
+
+  if (!existsSync(entry.path)) throw new Error(`memory file missing: ${entry.path}`);
+  return {
+    ...entry,
+    body: readFileSync(entry.path, "utf8").trim(),
+  };
+}
+
+function structuredInfo(store: MemoryStore, entry: MemoryEntry): MemoryEntryInfo {
+  return {
+    kind: "structured",
+    scope: entry.scope,
+    name: entry.name,
+    path: store.pathFor(entry.scope, entry.name),
+    description: entry.description,
+    type: entry.type,
+  };
+}

--- a/src/memory/session.ts
+++ b/src/memory/session.ts
@@ -48,6 +48,8 @@ export interface SessionInfo {
   messageCount: number;
   mtime: Date;
   meta: SessionMeta;
+  /** How this item matched a workspace-scoped list. */
+  workspaceStatus?: "matched" | "legacy_missing_meta";
 }
 
 export interface SessionMeta {
@@ -193,10 +195,17 @@ export function appendSessionMessage(name: string, message: ChatMessage): void {
   }
 }
 
-export function listSessions(opts?: { workspaceFilter?: string }): SessionInfo[] {
+export function listSessions(opts?: {
+  workspaceFilter?: string;
+  includeLegacyWorkspaceMatches?: boolean;
+}): SessionInfo[] {
   const dir = sessionsDir();
   if (!existsSync(dir)) return [];
   const want = opts?.workspaceFilter ? normalizeWorkspace(opts.workspaceFilter) : null;
+  const legacyPrefix =
+    want && opts?.includeLegacyWorkspaceMatches
+      ? legacySessionPrefixForWorkspace(opts.workspaceFilter!)
+      : null;
   try {
     // Exclude `.events.jsonl` sidecars — they share the .jsonl suffix.
     const files = readdirSync(dir).filter(
@@ -210,13 +219,22 @@ export function listSessions(opts?: { workspaceFilter?: string }): SessionInfo[]
         // Workspace pre-filter: cheap meta read first, skip the
         // (potentially multi-MB) jsonl read for sessions that don't
         // belong to the current workspace. Issue #1179.
+        let workspaceStatus: SessionInfo["workspaceStatus"] | undefined;
         if (want !== null) {
-          if (typeof meta.workspace !== "string") return [];
-          if (normalizeWorkspace(meta.workspace) !== want) return [];
+          if (typeof meta.workspace === "string") {
+            if (normalizeWorkspace(meta.workspace) !== want) return [];
+            workspaceStatus = "matched";
+          } else if (legacyPrefix && name.startsWith(legacyPrefix)) {
+            workspaceStatus = "legacy_missing_meta";
+          } else {
+            return [];
+          }
         }
         const stat = statSync(path);
         const messageCount = countLines(path);
-        return [{ name, path, size: stat.size, messageCount, mtime: stat.mtime, meta }];
+        return [
+          { name, path, size: stat.size, messageCount, mtime: stat.mtime, meta, workspaceStatus },
+        ];
       })
       .sort((a, b) => b.mtime.getTime() - a.mtime.getTime());
   } catch {
@@ -239,9 +257,24 @@ export function normalizeWorkspace(
   return posixPath.resolve(p);
 }
 
-/** Sessions without `meta.workspace` are still hidden — resume by name still works. */
 export function listSessionsForWorkspace(workspace: string): SessionInfo[] {
-  return listSessions({ workspaceFilter: workspace });
+  return listSessions({ workspaceFilter: workspace, includeLegacyWorkspaceMatches: true });
+}
+
+export function legacySessionPrefixForWorkspace(workspace: string): string {
+  const normalized = normalizeWorkspace(workspace);
+  const base =
+    process.platform === "win32" ? win32Path.basename(normalized) : posixPath.basename(normalized);
+  return `${sanitizeName(`code-${base}`)}-`;
+}
+
+export function patchSessionWorkspaceIfMissing(name: string, workspace: string): boolean {
+  const meta = loadSessionMeta(name);
+  if (typeof meta.workspace === "string") return false;
+  const prefix = legacySessionPrefixForWorkspace(workspace);
+  if (!sanitizeName(name).startsWith(prefix)) return false;
+  patchSessionMeta(name, { workspace });
+  return true;
 }
 
 function metaPath(name: string): string {

--- a/src/server/api/sessions.ts
+++ b/src/server/api/sessions.ts
@@ -1,5 +1,10 @@
 import { existsSync, readFileSync } from "node:fs";
-import { deleteSession, listSessions, sessionPath } from "../../memory/session.js";
+import {
+  deleteSession,
+  listSessions,
+  listSessionsForWorkspace,
+  sessionPath,
+} from "../../memory/session.js";
 import type { DashboardContext } from "../context.js";
 import type { ApiResult } from "../router.js";
 
@@ -79,7 +84,7 @@ export async function handleSessions(
   // sidebar; users have reported 10 000+ entries in `~/.reasonix/sessions/`.
   if (method === "GET" && rest.length === 0) {
     const workspaceFilter = ctx.getCurrentCwd?.();
-    const sessions = workspaceFilter ? listSessions({ workspaceFilter }) : listSessions();
+    const sessions = workspaceFilter ? listSessionsForWorkspace(workspaceFilter) : listSessions();
     const currentName = ctx.getSessionName?.() ?? null;
     return {
       status: 200,
@@ -91,6 +96,7 @@ export async function handleSessions(
           messageCount: s.messageCount,
           mtime: s.mtime.getTime(),
           summary: s.meta?.summary,
+          workspaceStatus: s.workspaceStatus,
         })),
         currentSession: currentName,
         canSwitch: Boolean(ctx.switchSession),

--- a/tests/chat-scroll-wheel.test.ts
+++ b/tests/chat-scroll-wheel.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveHistoryScrollMode } from "../src/cli/ui/history-scroll-mode.js";
+import { createChatScrollStore } from "../src/cli/ui/state/chat-scroll-store.js";
+
+describe("chat history scroll store", () => {
+  it("scrolls wheel reports one row at a time and pins again at the bottom", () => {
+    vi.useFakeTimers();
+    const store = createChatScrollStore();
+    try {
+      store.setMaxScroll(20);
+
+      store.scrollWheelUp();
+      expect(store.getState()).toMatchObject({ scrollRows: 19, pinned: false, maxScroll: 20 });
+
+      vi.advanceTimersByTime(16);
+      store.scrollWheelDown();
+      expect(store.getState()).toMatchObject({ scrollRows: 20, pinned: true, maxScroll: 20 });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("supports PageUp, PageDown, and End semantics", () => {
+    vi.useFakeTimers();
+    const store = createChatScrollStore();
+    try {
+      store.setMaxScroll(20);
+
+      store.scrollPageUp();
+      expect(store.getState()).toMatchObject({ scrollRows: 15, pinned: false });
+
+      vi.advanceTimersByTime(16);
+      store.scrollPageDown();
+      expect(store.getState()).toMatchObject({ scrollRows: 20, pinned: true });
+
+      vi.advanceTimersByTime(16);
+      store.scrollPageUp();
+      store.jumpToBottom();
+      expect(store.getState()).toMatchObject({ scrollRows: 20, pinned: true });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clamps configured wheel rows to a conservative range", () => {
+    const tooLarge = createChatScrollStore({ wheelRows: 99 });
+    tooLarge.setMaxScroll(20);
+    tooLarge.scrollWheelUp();
+    expect(tooLarge.getState().scrollRows).toBe(10);
+
+    const invalid = createChatScrollStore({ wheelRows: 0 });
+    invalid.setMaxScroll(20);
+    invalid.scrollWheelUp();
+    expect(invalid.getState().scrollRows).toBe(19);
+  });
+
+  it("coalesces wheel bursts without losing the trailing delta", () => {
+    vi.useFakeTimers();
+    try {
+      const store = createChatScrollStore();
+      store.setMaxScroll(20);
+
+      store.scrollWheelUp();
+      store.scrollWheelUp();
+      store.scrollWheelUp();
+      expect(store.getState().scrollRows).toBe(19);
+
+      vi.advanceTimersByTime(16);
+      expect(store.getState().scrollRows).toBe(17);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("history scroll mode resolution", () => {
+  it("honors explicit native/app config", () => {
+    expect(resolveHistoryScrollMode({ configured: "native", env: {} })).toBe("native");
+    expect(resolveHistoryScrollMode({ configured: "app", env: {} })).toBe("app");
+  });
+
+  it("auto-enables app-managed scrolling in terminals with known native jump issues", () => {
+    expect(resolveHistoryScrollMode({ configured: "auto", env: { TERM_PROGRAM: "vscode" } })).toBe(
+      "app",
+    );
+    expect(resolveHistoryScrollMode({ configured: "auto", env: { MSYSTEM: "MINGW64" } })).toBe(
+      "app",
+    );
+    expect(resolveHistoryScrollMode({ configured: "auto", env: { WT_SESSION: "abc" } })).toBe(
+      "app",
+    );
+    expect(resolveHistoryScrollMode({ configured: "auto", env: { TERM_PROGRAM: "ghostty" } })).toBe(
+      "app",
+    );
+  });
+
+  it("keeps native scrollback for unknown terminals in auto mode", () => {
+    expect(
+      resolveHistoryScrollMode({
+        configured: "auto",
+        env: { TERM: "xterm-256color" },
+        platform: "linux",
+      }),
+    ).toBe("native");
+  });
+});

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -830,7 +830,6 @@ describe("config", () => {
         {
           subagentModels: {
             explore: "pro",
-            // biome-ignore lint/suspicious/noExplicitAny: invalid input we want to test the loader's filter
             bogus: "fast" as any,
           },
         },

--- a/tests/desktop-memory-browser.test.ts
+++ b/tests/desktop-memory-browser.test.ts
@@ -1,0 +1,75 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  collectMemoryEntriesForWorkspace,
+  readMemoryEntryDetail,
+} from "../src/desktop/memory-browser.js";
+import { MemoryStore } from "../src/memory/user.js";
+
+describe("desktop memory browser", () => {
+  let root: string;
+  let reasonixHome: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "reasonix-memory-project-"));
+    reasonixHome = join(mkdtempSync(join(tmpdir(), "reasonix-memory-home-")), ".reasonix");
+    mkdirSync(reasonixHome, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+    rmSync(reasonixHome, { recursive: true, force: true });
+  });
+
+  it("lists project REASONIX.md, global REASONIX.md, and structured memory entries", () => {
+    writeFileSync(join(root, "REASONIX.md"), "project note", "utf8");
+    writeFileSync(join(reasonixHome, "REASONIX.md"), "global note", "utf8");
+    const store = new MemoryStore({ homeDir: reasonixHome, projectRoot: root });
+    store.write({
+      name: "cli_pref",
+      scope: "global",
+      type: "user",
+      description: "Use concise CLI output",
+      body: "Keep command output short.",
+    });
+    store.write({
+      name: "build_cmd",
+      scope: "project",
+      type: "project",
+      description: "Use npm run verify",
+      body: "Run npm run verify before release.",
+    });
+
+    const entries = collectMemoryEntriesForWorkspace(root, { reasonixHome });
+
+    expect(entries.map((e) => `${e.kind}:${e.scope}:${e.name}`)).toEqual([
+      "project_file:project:REASONIX.md",
+      "global_file:global:REASONIX.md",
+      "structured:global:cli_pref",
+      "structured:project:build_cmd",
+    ]);
+    expect(entries.every((e) => existsSync(e.path))).toBe(true);
+    expect(entries.find((e) => e.name === "cli_pref")!.type).toBe("user");
+  });
+
+  it("reads details only for listed memory files", () => {
+    writeFileSync(join(root, "REASONIX.md"), "project note", "utf8");
+    const entries = collectMemoryEntriesForWorkspace(root, { reasonixHome });
+
+    const detail = readMemoryEntryDetail({ path: entries[0]!.path }, root, { reasonixHome });
+
+    expect(detail).toMatchObject({
+      kind: "project_file",
+      scope: "project",
+      name: "REASONIX.md",
+      body: "project note",
+    });
+    expect(() =>
+      readMemoryEntryDetail({ path: join(reasonixHome, "not-listed.md") }, root, {
+        reasonixHome,
+      }),
+    ).toThrow(/not available/);
+  });
+});

--- a/tests/mouse-mode.test.ts
+++ b/tests/mouse-mode.test.ts
@@ -75,6 +75,11 @@ describe("mouse-mode enable/disable", () => {
     expect(writes.join("")).toBe("\u001b[?1006l\u001b[?1000l");
   });
 
+  it("app history scroll mode enables SGR mouse tracking by default", () => {
+    enableMouseMode("app");
+    expect(writes.join("")).toBe("\u001b[?1000h\u001b[?1006h");
+  });
+
   it("REASONIX_MOUSE_MODE=alternate-scroll forces ?1007h even on Windows", () => {
     process.env.REASONIX_MOUSE_MODE = "alternate-scroll";
     enableMouseMode();

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -24,6 +24,7 @@ import {
   loadSessionMessages,
   normalizeWorkspace,
   patchSessionMeta,
+  patchSessionWorkspaceIfMissing,
   pruneStaleSessions,
   renameSession,
   resolveSession,
@@ -163,6 +164,25 @@ describe("session persistence", () => {
     patchSessionMeta("there", { workspace: "/proj/b" });
     const names = listSessionsForWorkspace("/proj/a").map((s) => s.name);
     expect(names).toEqual(["here"]);
+  });
+
+  it("listSessionsForWorkspace includes legacy code-<workspace> sessions missing workspace meta", () => {
+    appendSessionMessage("code-a-202605251200", { role: "user", content: "x" });
+    appendSessionMessage("code-b-202605251200", { role: "user", content: "x" });
+    appendSessionMessage("untagged", { role: "user", content: "x" });
+
+    const matched = listSessionsForWorkspace("/proj/a");
+
+    expect(matched.map((s) => s.name)).toEqual(["code-a-202605251200"]);
+    expect(matched[0]!.workspaceStatus).toBe("legacy_missing_meta");
+    expect(matched[0]!.meta.workspace).toBeUndefined();
+  });
+
+  it("patchSessionWorkspaceIfMissing backfills workspace meta on first legacy load", () => {
+    appendSessionMessage("code-a-202605251200", { role: "user", content: "x" });
+
+    expect(patchSessionWorkspaceIfMissing("code-a-202605251200", "/proj/a")).toBe(true);
+    expect(listSessionsForWorkspace("/proj/a")[0]!.workspaceStatus).toBe("matched");
   });
 
   it("listSessionsForWorkspace tolerates trailing-slash drift", () => {

--- a/tests/welcome-banner-hints.test.tsx
+++ b/tests/welcome-banner-hints.test.tsx
@@ -1,7 +1,6 @@
 /** #1213 — discoverability net: /skill must remain in the empty-session hint row. */
 
 import { render } from "ink-testing-library";
-// biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React from "react";
 import { describe, expect, it } from "vitest";
 import { WelcomeBanner } from "../src/cli/ui/WelcomeBanner.js";


### PR DESCRIPTION
## Summary
- add historyScrollMode and restore app-managed chat history scrolling for terminals with jumpy native scrollback
- expose project/global/structured memory entries with detail reads in desktop/dashboard
- surface legacy workspace sessions missing workspace meta and backfill the meta on first load

## Validation
- npm run verify