### PR TITLE
fix(tui): coalesce prompt cursor sync

### DIFF
--- a/src/cli/ui/PromptInput.tsx
+++ b/src/cli/ui/PromptInput.tsx
@@ -25,6 +25,7 @@ export const INLINE_PASTE_THRESHOLD = 200;
 // for human cadence) still submits; wide enough that CJK IME commit-then-
 // Enter (terminal flushes both together) falls inside the window.
 const IME_GUARD_MS = 50;
+const SYSTEM_CURSOR_SYNC_IDLE_MS = 120;
 
 function hasNonAscii(s: string): boolean {
   for (let i = 0; i < s.length; i++) {
@@ -88,6 +89,7 @@ export function PromptInput({
   // Paste registry — keyed by sentinel id, holds original content.
   const pastesRef = useRef<Map<number, PasteEntry>>(new Map());
   const nextPasteIdRef = useRef<number>(0);
+  const lastCursorSyncRef = useRef<string | null>(null);
 
   // CJK IMEs commit the candidate then often pass the trigger Enter through
   // as a real keystroke; terminals can't expose composition state. If submit
@@ -213,12 +215,9 @@ export function PromptInput({
   const renderItems = collapseLinesForDisplay(lines, cursorLine);
   const showHugeBufferHints = lines.length > 20;
 
-  // Sync system cursor so IME candidate windows pop up next to the visual ▌
-  // instead of at the bottom of the output. The row count accounts for every
-  // rendered row inside PromptInput below the cursor line.
-  useEffect(() => {
+  const systemCursorSync = (() => {
     const totalRows = stdout?.rows;
-    if (!totalRows || totalRows < 4) return;
+    if (!totalRows || totalRows < 4) return null;
     const linesBelow = Math.max(0, lines.length - 1 - cursorLine);
     const largeHint = showHugeBufferHints ? 1 : 0;
     const frozenHint = inputFrozen || steerBusy ? 2 : 0;
@@ -230,19 +229,20 @@ export function PromptInput({
     const textBeforeCursor = cursorLineText.slice(0, cursorCol);
     const cursorCells = stringCells(textBeforeCursor, pastesRef.current);
     const targetCol = 1 + 1 + 2 + cursorCells;
-    stdout.write(`\x1b[${targetRow};${targetCol}H`);
-  }, [
-    cursorLine,
-    cursorCol,
-    lines,
-    showHugeBufferHints,
-    inputFrozen,
-    steerBusy,
-    mode,
-    model,
-    rowsAfter,
-    stdout,
-  ]);
+    return `\x1b[${targetRow};${targetCol}H`;
+  })();
+
+  // Sync after input/rendering goes idle. Direct CUP writes are outside Ink's
+  // frame buffer, so de-duping them avoids visible repaints on Windows terminals.
+  useEffect(() => {
+    if (systemCursorSync === null || lastCursorSyncRef.current === systemCursorSync) return;
+    const timer = setTimeout(() => {
+      if (lastCursorSyncRef.current === systemCursorSync) return;
+      stdout.write(systemCursorSync);
+      lastCursorSyncRef.current = systemCursorSync;
+    }, SYSTEM_CURSOR_SYNC_IDLE_MS);
+    return () => clearTimeout(timer);
+  }, [systemCursorSync, stdout]);
 
   return (
     <Box flexDirection="row">

--- a/tests/prompt-input-cursor-sync.test.tsx
+++ b/tests/prompt-input-cursor-sync.test.tsx
@@ -1,0 +1,129 @@
+import { render } from "ink";
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { PromptInput } from "../src/cli/ui/PromptInput.js";
+import {
+  type KeystrokeHandler,
+  KeystrokeProvider,
+  type KeystrokeReader,
+  makeKeyEvent,
+} from "../src/cli/ui/keystroke-context.js";
+import type { KeyEvent } from "../src/cli/ui/stdin-reader.js";
+import { makeFakeStdin, makeFakeStdout } from "./helpers/ink-stdio.js";
+
+const ESC = String.fromCharCode(27);
+const CURSOR_MOVE_RE = new RegExp(`${ESC}\\[\\d+;\\d+H`, "g");
+
+class FakeReader implements KeystrokeReader {
+  private readonly handlers = new Set<KeystrokeHandler>();
+
+  start(): void {
+    // no-op
+  }
+
+  subscribe(handler: KeystrokeHandler): () => void {
+    this.handlers.add(handler);
+    return () => {
+      this.handlers.delete(handler);
+    };
+  }
+
+  feed(ev: Partial<KeyEvent>): void {
+    const event = makeKeyEvent(ev);
+    for (const handler of [...this.handlers]) handler(event);
+  }
+}
+
+function cursorMoves(text: string): string[] {
+  return text.match(CURSOR_MOVE_RE) ?? [];
+}
+
+async function wait(ms = 0): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function feed(reader: FakeReader, ev: Partial<KeyEvent>): Promise<void> {
+  reader.feed(ev);
+  await wait();
+}
+
+async function feedText(reader: FakeReader, text: string): Promise<void> {
+  for (const char of text) await feed(reader, { input: char });
+}
+
+function PromptHarness(): React.ReactElement {
+  const [value, setValue] = React.useState("");
+  return (
+    <PromptInput
+      value={value}
+      onChange={setValue}
+      onSubmit={() => undefined}
+      onCursorChange={() => undefined}
+    />
+  );
+}
+
+function StaticPromptHarness({
+  value,
+  revision,
+}: {
+  value: string;
+  revision: number;
+}): React.ReactElement {
+  void revision;
+  return (
+    <PromptInput
+      value={value}
+      onChange={() => undefined}
+      onSubmit={() => undefined}
+      onCursorChange={() => undefined}
+    />
+  );
+}
+
+describe("PromptInput system cursor sync", () => {
+  it("does not rewrite an unchanged cursor position during parent rerenders", async () => {
+    const reader = new FakeReader();
+    const stdout = makeFakeStdout();
+    const { rerender, unmount } = render(
+      <KeystrokeProvider reader={reader}>
+        <StaticPromptHarness value="ready" revision={0} />
+      </KeystrokeProvider>,
+      { stdout: stdout as never, stdin: makeFakeStdin() as never },
+    );
+    await wait(180);
+    const before = cursorMoves(stdout.text()).length;
+
+    rerender(
+      <KeystrokeProvider reader={reader}>
+        <StaticPromptHarness value="ready" revision={1} />
+      </KeystrokeProvider>,
+    );
+    await wait(180);
+
+    expect(cursorMoves(stdout.text()).length).toBe(before);
+    unmount();
+  });
+
+  it("coalesces rapid ASCII typing into one cursor move after input goes idle", async () => {
+    const reader = new FakeReader();
+    const stdout = makeFakeStdout();
+    const { unmount } = render(
+      <KeystrokeProvider reader={reader}>
+        <PromptHarness />
+      </KeystrokeProvider>,
+      { stdout: stdout as never, stdin: makeFakeStdin() as never },
+    );
+    await wait(180);
+
+    const before = cursorMoves(stdout.text()).length;
+    await feedText(reader, "11111");
+    await wait(180);
+
+    const afterMoves = cursorMoves(stdout.text());
+    const newMoves = afterMoves.slice(before);
+    expect(newMoves).toEqual(["\x1b[28;9H"]);
+
+    unmount();
+  });
+});


### PR DESCRIPTION
Fixes #1758

## Summary
- Debounce and de-duplicate PromptInput system-cursor CUP writes so unchanged parent renders no longer repaint Windows terminals.
- Coalesce rapid ASCII typing into one cursor sync after input goes idle while keeping IME candidate-window cursor alignment.
- Add regression coverage for unchanged rerenders and rapid typing.

## Verification
- npm test -- tests/prompt-input-cursor-sync.test.tsx tests/multiline-keys.test.ts tests/terminal-host.test.ts
- npm run lint
- npm run typecheck
- npm run verify
- pre-push npm run verify