### PR TITLE
perf(ui): index-backed mutateCard + O(n) plan.drop + elide cursor

### DIFF
--- a/src/cli/ui/state/reducer.ts
+++ b/src/cli/ui/state/reducer.ts
@@ -221,6 +221,8 @@ export function reduce(state: AgentState, event: AgentEvent): AgentState {
       return {
         ...state,
         cards: [],
+        cardIndex: new Map(),
+        elideCursor: 0,
         focusedCardId: null,
         toasts: [],
         status: {
@@ -234,9 +236,13 @@ export function reduce(state: AgentState, event: AgentEvent): AgentState {
       };
 
     case "session.fork": {
-      const idx = state.cards.findIndex((c) => c.id === event.cardId);
-      if (idx < 0) return state;
-      return { ...state, cards: state.cards.slice(0, idx), focusedCardId: null };
+      const idx = state.cardIndex.get(event.cardId);
+      if (idx === undefined) return state;
+      const cards = state.cards.slice(0, idx);
+      const cardIndex = new Map<CardId, number>();
+      for (let i = 0; i < cards.length; i++) cardIndex.set(cards[i]!.id, i);
+      const elideCursor = Math.min(state.elideCursor, cards.length);
+      return { ...state, cards, cardIndex, elideCursor, focusedCardId: null };
     }
 
     case "session.workspace.change":
@@ -260,18 +266,19 @@ export function reduce(state: AgentState, event: AgentEvent): AgentState {
     case "plan.drop": {
       // Latest still-active plan flips to "replay" — preserves it in scrollback
       // but signals "no longer the live plan" to selectors and UI.
-      let dropped = false;
-      const cards = state.cards.map((c, i) => {
-        if (dropped) return c;
-        if (c.kind !== "plan" || c.variant !== "active") return c;
-        // Walk from end — only the LAST active plan should drop.
-        if (state.cards.slice(i + 1).some((cc) => cc.kind === "plan" && cc.variant === "active")) {
-          return c;
+      let lastActiveIdx = -1;
+      for (let i = state.cards.length - 1; i >= 0; i--) {
+        const c = state.cards[i]!;
+        if (c.kind === "plan" && c.variant === "active") {
+          lastActiveIdx = i;
+          break;
         }
-        dropped = true;
-        return { ...c, variant: "replay" as const };
-      });
-      return dropped ? { ...state, cards } : state;
+      }
+      if (lastActiveIdx < 0) return state;
+      const cards = state.cards.slice();
+      const target = cards[lastActiveIdx] as Extract<Card, { kind: "plan" }>;
+      cards[lastActiveIdx] = { ...target, variant: "replay" as const };
+      return { ...state, cards };
     }
 
     case "plan.step.complete": {
@@ -378,24 +385,57 @@ function stubHeavyContent(c: Card): Card {
   }
 }
 
-function elideOldCardContent(cards: ReadonlyArray<Card>): ReadonlyArray<Card> {
-  // Caller is about to append a new card. Anticipate that — once
-  // cards.length hits the window, the very next append starts eliding.
-  if (cards.length < RECENT_CARDS_WINDOW) return cards;
+/** True when card content is fixed at append time — never mutated, never grows. */
+function isImmutableCardKind(kind: Card["kind"]): boolean {
+  return (
+    kind === "user" ||
+    kind === "plan" ||
+    kind === "usage" ||
+    kind === "ctx" ||
+    kind === "doctor" ||
+    kind === "tip" ||
+    kind === "live" ||
+    kind === "memory" ||
+    kind === "search" ||
+    kind === "error" ||
+    kind === "warn" ||
+    kind === "compaction"
+  );
+}
+
+function elideFromCursor(
+  cards: ReadonlyArray<Card>,
+  cursor: number,
+): { cards: ReadonlyArray<Card>; cursor: number } {
+  if (cards.length < RECENT_CARDS_WINDOW) return { cards, cursor };
   const cutoff = cards.length + 1 - RECENT_CARDS_WINDOW;
   let next: Card[] | null = null;
-  for (let i = 0; i < cutoff; i++) {
+  let nextCursor = cursor;
+  for (let i = cursor; i < cutoff; i++) {
     const c = cards[i]!;
     const stubbed = stubHeavyContent(c);
-    if (stubbed === c) continue;
-    if (next === null) next = cards.slice();
-    next[i] = stubbed;
+    if (stubbed !== c) {
+      if (next === null) next = cards.slice();
+      next[i] = stubbed;
+      nextCursor = i + 1;
+      continue;
+    }
+    if (isImmutableCardKind(c.kind)) {
+      nextCursor = i + 1;
+      continue;
+    }
+    // Card may still grow into stub-eligible size — leave cursor here, recheck next append.
+    break;
   }
-  return next ?? cards;
+  return { cards: next ?? cards, cursor: nextCursor };
 }
 
 function appendCard(state: AgentState, card: Card): AgentState {
-  return { ...state, cards: [...elideOldCardContent(state.cards), card] };
+  const { cards: elided, cursor } = elideFromCursor(state.cards, state.elideCursor);
+  const cards = [...elided, card];
+  // Mutate the existing index — append-only mutation; structural rebuilds (fork/reset) replace it.
+  (state.cardIndex as Map<CardId, number>).set(card.id, cards.length - 1);
+  return { ...state, cards, cardIndex: state.cardIndex, elideCursor: cursor };
 }
 
 function mutateCard<K extends Card["kind"]>(
@@ -404,10 +444,12 @@ function mutateCard<K extends Card["kind"]>(
   kind: K,
   patch: (card: Extract<Card, { kind: K }>) => Extract<Card, { kind: K }>,
 ): AgentState {
-  const idx = state.cards.findIndex((c) => c.id === id && c.kind === kind);
-  if (idx < 0) return state;
+  const idx = state.cardIndex.get(id);
+  if (idx === undefined) return state;
+  const existing = state.cards[idx];
+  if (!existing || existing.kind !== kind) return state;
   const next = state.cards.slice();
-  next[idx] = patch(state.cards[idx] as Extract<Card, { kind: K }>);
+  next[idx] = patch(existing as Extract<Card, { kind: K }>);
   return { ...state, cards: next };
 }
 

--- a/src/cli/ui/state/state.ts
+++ b/src/cli/ui/state/state.ts
@@ -64,6 +64,10 @@ export interface AgentState {
   readonly lang: LanguageCode;
   readonly session: SessionInfo;
   readonly cards: ReadonlyArray<Card>;
+  /** id → index in `cards`. Mirrors `cards` exactly; rebuilt on any structural change. */
+  readonly cardIndex: ReadonlyMap<CardId, number>;
+  /** Smallest cards-index that still needs elision consideration; monotonic per session. */
+  readonly elideCursor: number;
   readonly composer: ComposerState;
   readonly status: StatusBar;
   readonly focusedCardId: CardId | null;
@@ -72,10 +76,14 @@ export interface AgentState {
 }
 
 export function initialState(session: SessionInfo, cards: ReadonlyArray<Card> = []): AgentState {
+  const cardIndex = new Map<CardId, number>();
+  for (let i = 0; i < cards.length; i++) cardIndex.set(cards[i]!.id, i);
   return {
     lang: getLanguage(),
     session,
     cards,
+    cardIndex,
+    elideCursor: 0,
     composer: {
       value: "",
       cursor: 0,

--- a/tools/bench-reducer-hotpath.mjs
+++ b/tools/bench-reducer-hotpath.mjs
@@ -1,0 +1,191 @@
+// Microbench comparing OLD vs NEW reducer hot paths in isolation:
+//   1. mutateCard: O(n) findIndex  vs  O(1) Map.get
+//   2. plan.drop:  O(n²) nested scan  vs  O(n) single backward scan
+//   3. appendCard elision: full re-scan  vs  cursor-advanced re-scan
+
+const RECENT = 200;
+const ELIDED_PREFIX = "[elided — older than the last ";
+
+function stub(c) {
+  if (c.kind === "tool" && typeof c.output === "string" && c.output.length > 4096
+      && !c.output.startsWith(ELIDED_PREFIX)) {
+    return { ...c, output: `${ELIDED_PREFIX}stubbed]` };
+  }
+  return c;
+}
+
+const isImmutable = (k) =>
+  k === "user" || k === "plan" || k === "usage" || k === "ctx" ||
+  k === "doctor" || k === "tip" || k === "live" || k === "memory" ||
+  k === "search" || k === "error" || k === "warn" || k === "compaction";
+
+function buildCards(n) {
+  const cards = [];
+  for (let i = 0; i < n; i++) {
+    if (i % 3 === 0) cards.push({ kind: "user", id: `u-${i}`, ts: 0, text: "hi" });
+    else if (i % 3 === 1) cards.push({ kind: "tool", id: `t-${i}`, ts: 0, name: "x", args: {}, output: "x".repeat(8000), done: true, elapsedMs: 1 });
+    else cards.push({ kind: "plan", id: `p-${i}`, ts: 0, title: "p", steps: [], variant: "active" });
+  }
+  return cards;
+}
+
+function buildIndex(cards) {
+  const m = new Map();
+  for (let i = 0; i < cards.length; i++) m.set(cards[i].id, i);
+  return m;
+}
+
+// ---------- mutateCard ----------
+function mutateOld(cards, id, kind, patch) {
+  const idx = cards.findIndex((c) => c.id === id && c.kind === kind);
+  if (idx < 0) return cards;
+  const next = cards.slice();
+  next[idx] = patch(cards[idx]);
+  return next;
+}
+function mutateNew(cards, index, id, kind, patch) {
+  const idx = index.get(id);
+  if (idx === undefined) return cards;
+  const existing = cards[idx];
+  if (!existing || existing.kind !== kind) return cards;
+  const next = cards.slice();
+  next[idx] = patch(existing);
+  return next;
+}
+
+function benchMutate(N, hits) {
+  const cards = buildCards(N);
+  const index = buildIndex(cards);
+  const targets = [];
+  for (let i = 0; i < hits; i++) {
+    const k = (i * 7919) % N;
+    targets.push(cards[k]);
+  }
+  const patch = (c) => ({ ...c, output: c.output + "+" });
+
+  const t0 = process.hrtime.bigint();
+  let work = cards;
+  for (const t of targets) work = mutateOld(work, t.id, t.kind, patch);
+  const t1 = process.hrtime.bigint();
+
+  work = cards;
+  for (const t of targets) work = mutateNew(work, index, t.id, t.kind, patch);
+  const t2 = process.hrtime.bigint();
+
+  return {
+    old_ms: Number(t1 - t0) / 1e6,
+    new_ms: Number(t2 - t1) / 1e6,
+  };
+}
+
+// ---------- plan.drop ----------
+function planDropOld(cards) {
+  let dropped = false;
+  return cards.map((c, i) => {
+    if (dropped) return c;
+    if (c.kind !== "plan" || c.variant !== "active") return c;
+    if (cards.slice(i + 1).some((cc) => cc.kind === "plan" && cc.variant === "active")) return c;
+    dropped = true;
+    return { ...c, variant: "replay" };
+  });
+}
+function planDropNew(cards) {
+  let lastActive = -1;
+  for (let i = cards.length - 1; i >= 0; i--) {
+    const c = cards[i];
+    if (c.kind === "plan" && c.variant === "active") { lastActive = i; break; }
+  }
+  if (lastActive < 0) return cards;
+  const next = cards.slice();
+  next[lastActive] = { ...next[lastActive], variant: "replay" };
+  return next;
+}
+
+function benchPlanDrop(N, iters) {
+  const cards = buildCards(N);
+  const t0 = process.hrtime.bigint();
+  for (let i = 0; i < iters; i++) planDropOld(cards);
+  const t1 = process.hrtime.bigint();
+  for (let i = 0; i < iters; i++) planDropNew(cards);
+  const t2 = process.hrtime.bigint();
+  return { old_ms: Number(t1 - t0) / 1e6, new_ms: Number(t2 - t1) / 1e6 };
+}
+
+// ---------- elision rescan ----------
+function elideOld(cards) {
+  if (cards.length < RECENT) return cards;
+  const cutoff = cards.length + 1 - RECENT;
+  let next = null;
+  for (let i = 0; i < cutoff; i++) {
+    const c = cards[i];
+    const s = stub(c);
+    if (s === c) continue;
+    if (next === null) next = cards.slice();
+    next[i] = s;
+  }
+  return next ?? cards;
+}
+function elideNew(cards, cursor) {
+  if (cards.length < RECENT) return { cards, cursor };
+  const cutoff = cards.length + 1 - RECENT;
+  let next = null;
+  let nextCursor = cursor;
+  for (let i = cursor; i < cutoff; i++) {
+    const c = cards[i];
+    const s = stub(c);
+    if (s !== c) {
+      if (next === null) next = cards.slice();
+      next[i] = s;
+      nextCursor = i + 1;
+      continue;
+    }
+    if (isImmutable(c.kind)) { nextCursor = i + 1; continue; }
+    break;
+  }
+  return { cards: next ?? cards, cursor: nextCursor };
+}
+
+function benchElide(N, appends) {
+  // Simulate `appends` consecutive appendCards on a session that starts at N cards
+  let cards = buildCards(N);
+  const t0 = process.hrtime.bigint();
+  for (let i = 0; i < appends; i++) {
+    cards = elideOld(cards);
+    cards = [...cards, { kind: "user", id: `n-${i}`, ts: 0, text: "x" }];
+  }
+  const t1 = process.hrtime.bigint();
+
+  let cards2 = buildCards(N);
+  let cursor = 0;
+  for (let i = 0; i < appends; i++) {
+    const r = elideNew(cards2, cursor);
+    cards2 = [...r.cards, { kind: "user", id: `n-${i}`, ts: 0, text: "x" }];
+    cursor = r.cursor;
+  }
+  const t2 = process.hrtime.bigint();
+  return { old_ms: Number(t1 - t0) / 1e6, new_ms: Number(t2 - t1) / 1e6 };
+}
+
+const fmt = (n) => n.toFixed(2).padStart(8);
+const pct = (o, n) => `${(((o - n) / o) * 100).toFixed(1)}% faster`;
+
+console.log("\n# mutateCard (streaming chunk hot path)");
+console.log("cards |   ops   |    old(ms)  |    new(ms)  | gain");
+for (const [n, h] of [[100, 1000], [500, 1000], [1000, 1000], [2000, 1000]]) {
+  const r = benchMutate(n, h);
+  console.log(`${String(n).padStart(5)} | ${String(h).padStart(7)} |${fmt(r.old_ms)}     |${fmt(r.new_ms)}     | ${pct(r.old_ms, r.new_ms)}`);
+}
+
+console.log("\n# plan.drop");
+console.log("cards |  iters  |    old(ms)  |    new(ms)  | gain");
+for (const [n, it] of [[100, 1000], [500, 1000], [1000, 1000]]) {
+  const r = benchPlanDrop(n, it);
+  console.log(`${String(n).padStart(5)} | ${String(it).padStart(7)} |${fmt(r.old_ms)}     |${fmt(r.new_ms)}     | ${pct(r.old_ms, r.new_ms)}`);
+}
+
+console.log("\n# elideOldCardContent rescan over many consecutive appends");
+console.log("startN| appends |    old(ms)  |    new(ms)  | gain");
+for (const [n, a] of [[300, 500], [500, 500], [1000, 500]]) {
+  const r = benchElide(n, a);
+  console.log(`${String(n).padStart(5)} | ${String(a).padStart(7)} |${fmt(r.old_ms)}     |${fmt(r.new_ms)}     | ${pct(r.old_ms, r.new_ms)}`);
+}


### PR DESCRIPTION
## Summary

Three hot-path fixes in the cards reducer, each measured against an inlined old-vs-new microbench (`tools/bench-reducer-hotpath.mjs`).

| Hot path | Cards | Old | New | Gain |
|---|---:|---:|---:|---|
| `mutateCard` (per streaming chunk) | 100 | 1.93 ms | 0.72 ms | **63%** |
|  | 1000 | 6.16 ms | 0.80 ms | **87%** |
|  | 2000 | 12.65 ms | 1.73 ms | **86%** |
| `plan.drop` (1000 iters) | 100 | 3.07 ms | 0.25 ms | **92%** |
|  | 500 | 17.76 ms | 0.29 ms | **98%** |
|  | 1000 | 65.10 ms | 0.34 ms | **99.5%** |
| `elideOldCardContent` (500 appends) | 300 | 1.31 ms | 1.01 ms | 22% |
|  | 1000 | 3.08 ms | 1.61 ms | **48%** |

### What changed

- **`mutateCard`** — added `cardIndex: Map<CardId, number>` to `AgentState`. Lookup is now O(1) instead of `state.cards.findIndex(...)`. Index is mutated in place on `appendCard` (append-only); structural rebuilds happen in `session.fork` / `session.reset`.
- **`plan.drop`** — old code did `.map()` with an inner `state.cards.slice(i+1).some(...)` — quadratic. New code does one reverse scan to find the last active plan, then patches that one slot.
- **`elideOldCardContent`** — added monotonic `elideCursor` to `AgentState`. The cursor advances past cards that have been stubbed or whose kind is immutable (user / plan / usage / etc.), so each append only checks the new boundary instead of re-scanning the entire elision zone.

## Test plan

- [x] `npx vitest run` — all 3694 tests pass, 12 skipped, 0 failures
- [x] `node tools/bench-reducer-hotpath.mjs` — numbers above
- [x] Targeted: `tests/ui-reducer.test.ts`, `tests/reducer-cards-elide.test.ts`, `tests/cards-memory-budget.test.ts`, `tests/hydrate-cards.test.ts`, `tests/core-reducers.test.ts`, `tests/subagent-reducer.test.ts` all green