### PR TITLE
fix(loop): drain steer queue on /new + /cwd so prior intent doesn't leak

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -336,6 +336,10 @@ export class CacheFirstLoop {
     this.stats.reset();
     this._turn = 0;
     this._budgetWarned = false;
+    // Drain leftover steer text — otherwise the first step() after /new
+    // injects it as a user message and the next turn leaks prior intent.
+    this._steerQueue.length = 0;
+    this._steerConsumed = false;
     let systemRebuilt = false;
     if (this._rebuildSystem) {
       try {
@@ -362,6 +366,8 @@ export class CacheFirstLoop {
     this.log.compactInPlace([]);
     this.scratch.reset();
     this._inflight.clear();
+    this._steerQueue.length = 0;
+    this._steerConsumed = false;
     this.sessionName = opts.sessionName;
     if (this._rebuildSystem) {
       try {

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -1075,6 +1075,36 @@ describe("CacheFirstLoop - setBudget / clearLog / retryLastUser", () => {
     expect(loop.currentTurn).toBe(0);
   });
 
+  it("clearLog drains the steer queue so the next turn doesn't replay prior intent", async () => {
+    const fetchSpy = vi.fn(
+      async (_url: any, init: any) =>
+        new Response(
+          JSON.stringify({
+            _echo_messages: JSON.parse(init.body).messages,
+            choices: [
+              { index: 0, message: { role: "assistant", content: "ok" }, finish_reason: "stop" },
+            ],
+            usage: { prompt_tokens: 10, completion_tokens: 1, total_tokens: 11 },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    ) as unknown as typeof fetch;
+    const client = new DeepSeekClient({ apiKey: "sk-test", fetch: fetchSpy });
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s" }),
+      stream: false,
+    });
+    loop.steer("finish the refactor i started in the prior session");
+    loop.clearLog();
+    for await (const _ev of loop.step("hello")) {
+      /* drain */
+    }
+    const sent = JSON.parse((fetchSpy as any).mock.calls[0][1].body).messages as ChatMessage[];
+    const userBodies = sent.filter((m) => m.role === "user").map((m) => m.content);
+    expect(userBodies).toEqual(["hello"]);
+  });
+
   it("clearLog returns 0 dropped when already empty", () => {
     const client = makeClient([{ content: "ok" }]);
     const loop = new CacheFirstLoop({


### PR DESCRIPTION
## Summary
- `clearLog()` and `switchWorkspace()` previously reset `log`, `scratch`, `_inflight`, `stats`, `_turn`, `_budgetWarned` — but left `_steerQueue` untouched.
- If the user had typed a mid-turn steer that hadn't been consumed yet, the queued text survived `/new`. The very next `step()` would pop it at line 744, wrap it in the steer scaffolding (`[Mid-turn steer queued by the user…]`), `appendAndPersist` it as a user message, and ship it to DeepSeek. From the user's view: the first prompt after `/new` silently carried fragments of the previous conversation's intent.

## Repro
Added test `clearLog drains the steer queue so the next turn doesn't replay prior intent`:
1. Steer text into the queue
2. Call `clearLog()`
3. Drive `step("hello")` against a spy fetch
4. Verify the captured `messages[]` contains only the system message and `"hello"` — no leaked steer payload

The test fails on main (the steer text appears in the API body wrapped in `[Mid-turn steer queued by the user…]`) and passes with the two-line drain in `clearLog` + `switchWorkspace`.

## Fix
Two lines added to each of `clearLog()` and `switchWorkspace()`:
```ts
this._steerQueue.length = 0;
this._steerConsumed = false;
```

Closes #1707

## Test plan
- [x] `npx vitest run tests/loop.test.ts tests/session.test.ts tests/loop-inflight.test.ts` — 132 passed
- [x] New regression test fails on main without the drain, passes with it