### PR TITLE
fix(dashboard): bootstrap mcp/skills/memory panels in web mode

### DIFF
--- a/dashboard/src/lib/tauri-bridge.ts
+++ b/dashboard/src/lib/tauri-bridge.ts
@@ -352,6 +352,98 @@ function emitServerSettings(settings: any, overview?: any): void {
 }
 
 // 初始化 Server 状态
+function emitMcpSpecsFromServer(specs: any[] | undefined, bridged: any[] | undefined): void {
+  const live = new Map<string, any>();
+  for (const s of bridged ?? []) {
+    if (typeof s?.spec === "string") live.set(s.spec, s);
+  }
+  const out = (specs ?? []).map((s: any) => {
+    const liveEntry = live.get(s.raw);
+    return {
+      raw: s.raw,
+      name: s.name ?? null,
+      transport: s.transport,
+      summary: s.summary,
+      parseError: s.parseError,
+      status: liveEntry ? "connected" : s.parseError ? "failed" : "configured",
+      statusReason: liveEntry ? undefined : s.parseError,
+      toolCount: liveEntry?.toolCount,
+    };
+  });
+  emitEvent({
+    type: "$mcp_specs",
+    tabId: "tab-1",
+    specs: out,
+    bridged: out.length > 0 && out.every((s) => s.status === "connected"),
+  });
+}
+
+function emitSkillsFromServer(data: any): void {
+  const items: any[] = [];
+  const tag = (rows: any[] | undefined, scope: string) => {
+    for (const r of rows ?? []) {
+      items.push({
+        name: r.name,
+        description: r.description ?? "",
+        scope,
+        path: r.path ?? "",
+        runAs: r.runAs ?? "inline",
+        model: r.model,
+      });
+    }
+  };
+  tag(data?.builtin, "builtin");
+  tag(data?.global, "global");
+  tag(data?.custom, "global");
+  tag(data?.project, "project");
+  emitEvent({ type: "$skills", tabId: "tab-1", items });
+}
+
+function emitMemoryFromServer(data: any): void {
+  const entries: any[] = [];
+  for (const f of data?.global?.files ?? []) {
+    entries.push({ name: f.name, scope: "global", description: f.description ?? "" });
+  }
+  for (const f of data?.projectMem?.files ?? []) {
+    entries.push({ name: f.name, scope: "project", description: f.description ?? "" });
+  }
+  if (data?.project?.exists) {
+    entries.push({
+      name: data.project.file ?? "REASONIX.md",
+      scope: "project",
+      description: data.project.path ?? "",
+    });
+  }
+  emitEvent({ type: "$memory", tabId: "tab-1", entries });
+}
+
+async function loadAndEmitMcp(): Promise<void> {
+  try {
+    const [specsResp, liveResp] = await Promise.all([apiFetch("mcp/specs"), apiFetch("mcp")]);
+    emitMcpSpecsFromServer(specsResp?.specs, liveResp?.servers);
+  } catch (err) {
+    console.warn("[tauri-bridge] mcp fetch failed:", err);
+  }
+}
+
+async function loadAndEmitSkills(): Promise<void> {
+  try {
+    const data = await apiFetch("skills");
+    if (data) emitSkillsFromServer(data);
+  } catch (err) {
+    console.warn("[tauri-bridge] skills fetch failed:", err);
+  }
+}
+
+async function loadAndEmitMemory(): Promise<void> {
+  try {
+    const data = await apiFetch("memory");
+    if (data) emitMemoryFromServer(data);
+  } catch (err) {
+    console.warn("[tauri-bridge] memory fetch failed:", err);
+  }
+}
+
 async function serverInit(): Promise<void> {
   document.documentElement.dataset.web = "true";
 
@@ -395,6 +487,10 @@ async function serverInit(): Promise<void> {
   } catch (err) {
     console.warn("[tauri-bridge] server init failed:", err);
   }
+
+  // Sidebar/right-rail panels — desktop pushes these on tab open; web has
+  // to pull them or every panel renders empty forever (#1715).
+  void Promise.all([loadAndEmitMcp(), loadAndEmitSkills(), loadAndEmitMemory()]);
 
   emitEvent({ type: "$ready", tabId: "tab-1" });
   emitEvent({
@@ -707,6 +803,18 @@ async function serverRpc(payload: Record<string, any>): Promise<void> {
       try { await apiFetch("skills/run", { method: "POST", body: JSON.stringify(body) }); } catch {}
       break;
     }
+    case "mcp_specs_get": {
+      await loadAndEmitMcp();
+      break;
+    }
+    case "skills_get": {
+      await loadAndEmitSkills();
+      break;
+    }
+    case "memory_get": {
+      await loadAndEmitMemory();
+      break;
+    }
     case "mcp_specs_add":
     case "mcp_specs_remove": {
       // MCP 操作通过 REST API 管理
@@ -715,6 +823,7 @@ async function serverRpc(payload: Record<string, any>): Promise<void> {
           method: "POST",
           body: JSON.stringify({ action: cmd === "mcp_specs_add" ? "add" : "remove", spec: payload.spec }),
         });
+        await loadAndEmitMcp();
       } catch {}
       break;
     }


### PR DESCRIPTION
## Summary
- Web-dashboard's `serverInit()` only fetched settings + sessions + overview on mount — it never called `/api/mcp`, `/api/skills`, or `/api/memory`.
- The dashboard reducer (`dashboard/src/App.tsx`) waits for `$mcp_specs`, `$skills`, `$memory` events to populate those panels. The web bridge had no path to emit them, so all three panels rendered empty and stayed empty until a settings_save / restart happened to refresh.
- Desktop (Tauri) ships a matching `emitMcpSpecs(tab); emitSkills(tab); emitMemory(tab)` triple on tab open (`src/cli/commands/desktop.ts:1820-1822`). Web mode regressed on the equivalent — visible to users on 0.50.0 onward as "all my MCP / skills / memory disappeared after upgrade."

## Fix
Three changes in `dashboard/src/lib/tauri-bridge.ts`:

1. **Three loaders** (`loadAndEmitMcp` / `loadAndEmitSkills` / `loadAndEmitMemory`) that GET the REST endpoints and map their response shape onto the dashboard's event shape (`McpSpecInfo` / `SkillInfo` / `MemoryEntryInfo`).
2. **Fire them from `serverInit()`** in parallel so the panels populate as soon as the page mounts.
3. **Wire `mcp_specs_get` / `skills_get` / `memory_get` RPC commands** so the panels' refresh buttons also work, and re-emit live MCP list after `mcp_specs_add` / `_remove`.

## Repro
1. `reasonix code` on a workspace that has MCP servers configured, skills installed, and memory files
2. Open the dashboard URL in a browser (web mode, not Tauri desktop)
3. Before fix: MCP / Skills / Memory panels all empty
4. After fix: all three populate within ~100ms of page load

Closes #1715

## Test plan
- [x] `npx tsc --noEmit` (dashboard) passes
- [x] `npx vite build` (dashboard) succeeds
- [ ] Manual: load web dashboard with MCP servers configured, verify panels populate