### PR TITLE
fix(config): EXDEV fallback for atomic write on OneDrive / NTFS reparse points

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,11 +1,12 @@
 /** Library reads only DEEPSEEK_API_KEY from env; the CLI bridges config.json → env var. */
 
 import { randomBytes } from "node:crypto";
-import { chmodSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import { z } from "zod";
 import { type ThemeName, isThemeName, resolveThemeName } from "./cli/ui/theme/tokens.js";
+import { atomicWriteSync } from "./core/atomic-write.js";
 import type { LanguageCode } from "./i18n/types.js";
 import {
   type IndexUserConfig,
@@ -477,13 +478,7 @@ export function writeConfig(cfg: ReasonixConfig, path: string = defaultConfigPat
   // saveX would silently overwrite every other field with that empty
   // baseline (issue #1535).
   const tmp = `${path}.${process.pid}.tmp`;
-  writeFileSync(tmp, JSON.stringify(cfg, null, 2), "utf8");
-  try {
-    chmodSync(tmp, 0o600);
-  } catch {
-    /* ignore on platforms without chmod */
-  }
-  renameSync(tmp, path);
+  atomicWriteSync(path, JSON.stringify(cfg, null, 2), tmp);
 }
 
 /** Resolve the language from config file. */

--- a/src/core/atomic-write.ts
+++ b/src/core/atomic-write.ts
@@ -1,0 +1,58 @@
+import { chmodSync, copyFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+
+export interface AtomicWriteFs {
+  writeFileSync: typeof writeFileSync;
+  chmodSync: typeof chmodSync;
+  renameSync: typeof renameSync;
+  copyFileSync: typeof copyFileSync;
+  unlinkSync: typeof unlinkSync;
+}
+
+const defaultFs: AtomicWriteFs = {
+  writeFileSync,
+  chmodSync,
+  renameSync,
+  copyFileSync,
+  unlinkSync,
+};
+
+/** Atomic write with EXDEV fallback — Windows OneDrive / reparse points refuse rename, fixes #1738. */
+export function atomicWriteSync(
+  path: string,
+  body: string,
+  tmp: string,
+  mode = 0o600,
+  fs: AtomicWriteFs = defaultFs,
+): void {
+  try {
+    fs.writeFileSync(tmp, body, "utf8");
+    try {
+      fs.chmodSync(tmp, mode);
+    } catch {
+      /* platform without chmod */
+    }
+    try {
+      fs.renameSync(tmp, path);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "EXDEV") throw err;
+      fs.copyFileSync(tmp, path);
+      try {
+        fs.chmodSync(path, mode);
+      } catch {
+        /* platform without chmod */
+      }
+    }
+  } catch (err) {
+    try {
+      fs.unlinkSync(tmp);
+    } catch {
+      /* tmp may already be gone or never existed */
+    }
+    throw err;
+  }
+  try {
+    fs.unlinkSync(tmp);
+  } catch {
+    /* rename consumed it on the happy path; only present after EXDEV fallback */
+  }
+}

--- a/src/memory/session.ts
+++ b/src/memory/session.ts
@@ -16,6 +16,7 @@ import {
 } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, posix as posixPath, win32 as win32Path } from "node:path";
+import { atomicWriteSync } from "../core/atomic-write.js";
 import type { ChatMessage } from "../types.js";
 
 const SESSION_SIDECAR_EXTS = [
@@ -332,24 +333,12 @@ export function rewriteSession(name: string, messages: ChatMessage[]): void {
   mkdirSync(dirname(path), { recursive: true });
   const body = messages.map((m) => JSON.stringify(m)).join("\n");
   const tmp = `${path}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}.tmp`;
-  try {
-    writeFileSync(tmp, body ? `${body}\n` : "", "utf8");
-    chmodPrivate(tmp);
-    if (existsSync(path) && statSync(path).size > 0) {
-      const backup = sessionBackupPath(path);
-      copyFileSync(path, backup);
-      chmodPrivate(backup);
-    }
-    renameSync(tmp, path);
-    chmodPrivate(path);
-  } catch (err) {
-    try {
-      unlinkSync(tmp);
-    } catch {
-      /* tmp may not exist */
-    }
-    throw err;
+  if (existsSync(path) && statSync(path).size > 0) {
+    const backup = sessionBackupPath(path);
+    copyFileSync(path, backup);
+    chmodPrivate(backup);
   }
+  atomicWriteSync(path, body ? `${body}\n` : "", tmp);
 }
 
 /** Rotate the live jsonl + sidecars to `<name>__archive_<ts>` so /new doesn't destroy history. Returns the archive name, or null if there was nothing to archive. */

--- a/tests/atomic-write.test.ts
+++ b/tests/atomic-write.test.ts
@@ -1,0 +1,75 @@
+import {
+  copyFileSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { type AtomicWriteFs, atomicWriteSync } from "../src/core/atomic-write.js";
+
+const realFs: AtomicWriteFs = {
+  writeFileSync,
+  chmodSync: () => {},
+  renameSync,
+  copyFileSync,
+  unlinkSync,
+};
+
+describe("atomicWriteSync", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "atomic-write-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("writes via rename on the happy path and leaves no tmp behind", () => {
+    const target = join(dir, "config.json");
+    const tmp = `${target}.tmp`;
+    atomicWriteSync(target, '{"a":1}', tmp);
+    expect(readFileSync(target, "utf8")).toBe('{"a":1}');
+    expect(existsSync(tmp)).toBe(false);
+  });
+
+  it("falls back to copy on EXDEV (OneDrive / NTFS reparse points, #1738)", () => {
+    const target = join(dir, "config.json");
+    const tmp = `${target}.tmp`;
+    let renameAttempted = false;
+    const fs: AtomicWriteFs = {
+      ...realFs,
+      renameSync: () => {
+        renameAttempted = true;
+        const err = new Error("EXDEV: cross-device link not permitted") as NodeJS.ErrnoException;
+        err.code = "EXDEV";
+        err.errno = -4037;
+        throw err;
+      },
+    };
+    atomicWriteSync(target, '{"a":1}', tmp, 0o600, fs);
+    expect(renameAttempted).toBe(true);
+    expect(readFileSync(target, "utf8")).toBe('{"a":1}');
+    expect(existsSync(tmp)).toBe(false);
+  });
+
+  it("rethrows non-EXDEV rename errors and cleans up tmp", () => {
+    const target = join(dir, "config.json");
+    const tmp = `${target}.tmp`;
+    const fs: AtomicWriteFs = {
+      ...realFs,
+      renameSync: () => {
+        const err = new Error("EACCES: permission denied") as NodeJS.ErrnoException;
+        err.code = "EACCES";
+        throw err;
+      },
+    };
+    expect(() => atomicWriteSync(target, '{"a":1}', tmp, 0o600, fs)).toThrow(/EACCES/);
+    expect(existsSync(tmp)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- `writeConfig` and `rewriteSession` used `renameSync(tmp, path)` for the final atomic swap of `config.json` and session jsonls.
- On Windows, when `~/.reasonix/` sits inside a OneDrive-managed folder, a junction, or any NTFS reparse point, `rename` refuses with `EXDEV` (-4037) — even though `tmp` and `path` are literal siblings in the same directory listing.
- The CLI crashed on every launch trying to mint the dashboard token, blocking `npx reasonix code` outright.

## Repro (from discussion #1738)
```
PS> npx reasonix@latest code
Error: EXDEV: cross-device link not permitted,
  rename 'C:\Users\<u>\.reasonix\config.json.30524.tmp'
      -> 'C:\Users\<u>\.reasonix\config.json'
    at renameSync (node:fs:1013:11)
    at writeConfig (...)
    at ensureDashboardToken (...)
```
Downgrading to 0.48.0 worked because that version called `writeFileSync` directly without the atomic-rename guard introduced in #1535.

## Fix
New helper `src/core/atomic-write.ts` exporting `atomicWriteSync(path, body, tmp)`:
- Happy path: `writeFileSync(tmp)` → `chmodSync(tmp)` → `renameSync(tmp, path)` (unchanged behavior).
- On `EXDEV` only: fall back to `copyFileSync(tmp, path)` + `chmodSync(path)` + `unlinkSync(tmp)`. Atomicity is lost on that branch — no safe alternative exists when the underlying volume refuses rename — but a working write beats the launch-blocking crash. Non-EXDEV errors still bubble up.
- Tmp file is cleaned up on every exit path, including non-EXDEV failures.

Call sites switched:
- `writeConfig` (config.json)
- `rewriteSession` (session jsonl rewrites — same EXDEV exposure)

## Test plan
- [x] New `tests/atomic-write.test.ts` — 3 cases:
  - happy-path rename leaves no tmp
  - synthetic EXDEV from a mocked `renameSync` recovers via copy
  - non-EXDEV rename errors rethrow and clean tmp
- [x] `npx vitest run tests/atomic-write.test.ts tests/config.test.ts tests/session.test.ts` — 152 passed
- [x] `npm run verify` (pre-push) — passes

Fixes #1738