### PR TITLE
fix(docs): polish docs responsive spacing

### DIFF
--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -125,14 +125,13 @@
           </span>
         </a>
         <div class="nav-links" role="navigation">
-          <a href="index.html#install">Install</a>
-          <a href="index.html#agents">Pillars</a>
-          <a href="index.html#features">Features</a>
-          <a href="index.html#config">Config</a>
-          <a href="configuration.html">Guide</a>
-          <a href="download.html">Download</a>
-          <a href="index.html#roadmap">Roadmap</a>
-          <a href="index.html#faq">FAQ</a>
+          <a class="nav-link-primary" href="index.html#install">Install</a>
+          <a class="nav-link-secondary" href="index.html#agents">Pillars</a>
+          <a class="nav-link-primary" href="index.html#features">Features</a>
+          <a class="nav-link-secondary" href="index.html#config">Config</a>
+          <a class="nav-link-persist" href="configuration.html">Guide</a>
+          <a class="nav-link-tertiary" href="index.html#roadmap">Roadmap</a>
+          <a class="nav-link-tertiary" href="index.html#faq">FAQ</a>
         </div>
         <div class="nav-cta">
           <div class="lang-switch" role="group" aria-label="Language">

--- a/docs/cli-reference.html
+++ b/docs/cli-reference.html
@@ -125,14 +125,13 @@
           </span>
         </a>
         <div class="nav-links" role="navigation">
-          <a href="index.html#install">Install</a>
-          <a href="index.html#agents">Pillars</a>
-          <a href="index.html#features">Features</a>
-          <a href="index.html#config">Config</a>
-          <a href="configuration.html">Guide</a>
-          <a href="download.html">Download</a>
-          <a href="index.html#roadmap">Roadmap</a>
-          <a href="index.html#faq">FAQ</a>
+          <a class="nav-link-primary" href="index.html#install">Install</a>
+          <a class="nav-link-secondary" href="index.html#agents">Pillars</a>
+          <a class="nav-link-primary" href="index.html#features">Features</a>
+          <a class="nav-link-secondary" href="index.html#config">Config</a>
+          <a class="nav-link-persist" href="configuration.html">Guide</a>
+          <a class="nav-link-tertiary" href="index.html#roadmap">Roadmap</a>
+          <a class="nav-link-tertiary" href="index.html#faq">FAQ</a>
         </div>
         <div class="nav-cta">
           <div class="lang-switch" role="group" aria-label="Language">

--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -125,14 +125,13 @@
           </span>
         </a>
         <div class="nav-links" role="navigation">
-          <a href="index.html#install">Install</a>
-          <a href="index.html#agents">Pillars</a>
-          <a href="index.html#features">Features</a>
-          <a href="index.html#config">Config</a>
-          <a href="configuration.html" style="color: var(--accent)">Guide</a>
-          <a href="download.html">Download</a>
-          <a href="index.html#roadmap">Roadmap</a>
-          <a href="index.html#faq">FAQ</a>
+          <a class="nav-link-primary" href="index.html#install">Install</a>
+          <a class="nav-link-secondary" href="index.html#agents">Pillars</a>
+          <a class="nav-link-primary" href="index.html#features">Features</a>
+          <a class="nav-link-secondary" href="index.html#config">Config</a>
+          <a class="nav-link-persist" href="configuration.html" style="color: var(--accent)">Guide</a>
+          <a class="nav-link-tertiary" href="index.html#roadmap">Roadmap</a>
+          <a class="nav-link-tertiary" href="index.html#faq">FAQ</a>
         </div>
         <div class="nav-cta">
           <div class="lang-switch" role="group" aria-label="Language">

--- a/docs/src/hero.jsx
+++ b/docs/src/hero.jsx
@@ -172,10 +172,10 @@ function Hero() {
             </a>
           </div>
           <div className="hero-stats">
-            <div className="hero-stat"><b>94<span style={{fontFamily:'var(--mono)',fontStyle:'normal',fontSize:18,marginLeft:2,color:'var(--cream-mute)'}}>%</span></b><span>Cache Hit</span></div>
-            <div className="hero-stat"><b>2.5<span style={{fontFamily:'var(--mono)',fontStyle:'normal',fontSize:18,marginLeft:2,color:'var(--cream-mute)'}}>×</span></b><span>Cost Down</span></div>
-            <div className="hero-stat"><b>2837</b><span>Tests</span></div>
-            <div className="hero-stat"><b>MIT</b><span>License</span></div>
+            <div className="hero-stat"><b>94<span className="metric-unit">%</span></b><span className="metric-label">Cache Hit</span></div>
+            <div className="hero-stat"><b>2.5<span className="metric-unit">×</span></b><span className="metric-label">Cost Down</span></div>
+            <div className="hero-stat"><b>2837</b><span className="metric-label">Tests</span></div>
+            <div className="hero-stat"><b>MIT</b><span className="metric-label">License</span></div>
           </div>
         </div>
         <div style={{position:'relative'}}>

--- a/docs/src/nav.jsx
+++ b/docs/src/nav.jsx
@@ -12,14 +12,13 @@ function Nav({ active }) {
   }, []);
 
   const NAV_LINKS = [
-    { href: "index.html#install",  label: { zh: "安装",     en: "Install" } },
-    { href: "index.html#agents",   label: { zh: "原理",     en: "How it works" } },
-    { href: "index.html#features", label: { zh: "特性",     en: "Features" } },
-    { href: "index.html#config",   label: { zh: "配置",     en: "Config" } },
-    { href: "configuration.html",  label: { zh: "Guide",    en: "Guide" } },
-    { href: "download.html",       label: { zh: "下载",     en: "Download" }, key: "download" },
-    { href: "index.html#roadmap",  label: { zh: "Roadmap",  en: "Roadmap" } },
-    { href: "index.html#faq",      label: { zh: "FAQ",      en: "FAQ" } },
+    { href: "index.html#install",  label: { zh: "安装",     en: "Install" }, priority: "primary" },
+    { href: "index.html#agents",   label: { zh: "原理",     en: "How it works" }, priority: "secondary" },
+    { href: "index.html#features", label: { zh: "特性",     en: "Features" }, priority: "primary" },
+    { href: "index.html#config",   label: { zh: "配置",     en: "Config" }, priority: "secondary" },
+    { href: "configuration.html",  label: { zh: "Guide",    en: "Guide" }, priority: "persist" },
+    { href: "index.html#roadmap",  label: { zh: "Roadmap",  en: "Roadmap" }, priority: "tertiary" },
+    { href: "index.html#faq",      label: { zh: "FAQ",      en: "FAQ" }, priority: "tertiary" },
   ];
 
   return (
@@ -36,7 +35,10 @@ function Nav({ active }) {
             <a
               key={t(l.label, "en")}
               href={l.href}
-              className={l.key && active === l.key ? "on" : ""}
+              className={[
+                `nav-link-${l.priority}`,
+                l.key && active === l.key ? "on" : "",
+              ].filter(Boolean).join(" ")}
               style={l.key && active === l.key ? { color: "var(--accent)" } : {}}
             >
               {t(l.label, lang)}

--- a/docs/src/roadmap.jsx
+++ b/docs/src/roadmap.jsx
@@ -74,7 +74,7 @@ function Roadmap() {
               <h4>{t(c.title, lang)}</h4>
             </header>
             <ul>
-              {c.items.map((it, idx) => <li key={idx}>{t(it, lang)}</li>)}
+              {c.items.map((it, idx) => <li key={idx}><span>{t(it, lang)}</span></li>)}
             </ul>
           </div>
         ))}

--- a/docs/src/styles.css
+++ b/docs/src/styles.css
@@ -75,16 +75,17 @@ body {
   border-bottom: 1px solid var(--rule);
 }
 .nav-inner {
-  max-width: var(--maxw);
+  max-width: 1680px;
   margin: 0 auto;
   padding: 16px var(--gutter);
   display: flex;
   align-items: center;
-  gap: 32px;
+  gap: clamp(20px, 2.5vw, 32px);
 }
 .brand {
   display: flex; align-items: baseline; gap: 10px;
   text-decoration: none; color: inherit;
+  flex-shrink: 0;
 }
 .brand-mark {
   width: 22px; height: 22px;
@@ -98,7 +99,12 @@ body {
 .brand-mark::after {
   display: none;
 }
-.brand-name { display: flex; align-items: baseline; gap: 8px; }
+.brand-name {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  white-space: nowrap;
+}
 .brand-name b {
   font-family: var(--serif);
   font-style: italic;
@@ -115,8 +121,10 @@ body {
 }
 
 .nav-links {
-  display: flex; gap: 24px;
-  margin-left: 28px;
+  display: flex;
+  align-items: center;
+  gap: clamp(16px, 1.9vw, 24px);
+  margin-left: clamp(12px, 2vw, 28px);
   font-family: var(--mono);
 }
 .nav-links a {
@@ -128,6 +136,7 @@ body {
   transition: color 0.18s;
   position: relative;
   padding: 4px 0;
+  white-space: nowrap;
 }
 .nav-links a::after {
   content: "";
@@ -142,6 +151,26 @@ body {
 .nav-cta {
   margin-left: auto;
   display: flex; gap: 10px; align-items: center;
+  flex-shrink: 0;
+}
+
+@media (max-width: 1380px) {
+  .nav-link-tertiary { display: none; }
+}
+
+@media (max-width: 1160px) {
+  .nav-link-secondary { display: none; }
+}
+
+@media (max-width: 900px) {
+  .nav-link-primary { display: none; }
+}
+
+@media (max-width: 680px) {
+  .brand-name span,
+  .nav-cta .btn-ghost {
+    display: none;
+  }
 }
 
 /* ─── BUTTONS ──────────────────────────────────────────────── */
@@ -300,8 +329,8 @@ body {
 .hero h1 {
   font-family: var(--serif);
   font-weight: 400;
-  font-size: clamp(54px, 8.6vw, 124px);
-  line-height: 0.95;
+  font-size: clamp(40px, 6.6vw, 76px);
+  line-height: 1;
   letter-spacing: -0.02em;
   margin: 0 0 28px;
   color: var(--cream);
@@ -347,12 +376,16 @@ body {
   max-width: 600px;
 }
 .hero-stat {
-  padding-right: 16px;
+  padding: 0 20px;
   border-right: 1px solid var(--rule);
+  text-align: center;
 }
 .hero-stat:last-child { border-right: 0; }
 .hero-stat b {
-  display: block;
+  display: flex;
+  align-items: baseline;
+  justify-content: center;
+  gap: 3px;
   font-family: var(--serif);
   font-style: italic;
   font-weight: 400;
@@ -361,7 +394,17 @@ body {
   line-height: 1;
   color: var(--cream);
 }
-.hero-stat span {
+.hero-stat .metric-unit {
+  display: inline;
+  margin-top: 0;
+  font-family: var(--mono);
+  font-style: normal;
+  font-size: 0.48em;
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--cream-mute);
+}
+.hero-stat .metric-label {
   display: block;
   margin-top: 8px;
   font-family: var(--mono);
@@ -601,23 +644,18 @@ body {
 @media (max-width: 880px) { .feat-grid { grid-template-columns: 1fr; } }
 .feat {
   position: relative;
-  padding: 36px 28px 36px 0;
+  padding: 36px 28px;
   border-bottom: 1px solid var(--rule);
   border-right: 1px solid var(--rule);
   background: transparent;
   border-radius: 0;
   overflow: visible;
 }
-.feat:nth-child(3n) { border-right: 0; padding-right: 0; }
+.feat:nth-child(3n) { border-right: 0; }
 @media (max-width: 880px) {
-  .feat { border-right: 0; padding-right: 0; }
+  .feat { border-right: 0; }
 }
 .feat:nth-child(n+4) { padding-top: 36px; }
-.feat > * { margin-left: 28px; }
-.feat:nth-child(3n+1) > * { margin-left: 0; }
-@media (max-width: 880px) {
-  .feat > * { margin-left: 0; }
-}
 
 .feat-num {
   font-family: var(--mono);
@@ -1013,7 +1051,7 @@ body {
   border-right: 1px solid var(--rule);
   border-bottom: 1px solid var(--rule);
   border-radius: 0;
-  padding: 28px 24px 28px 0;
+  padding: 28px 24px;
   position: relative;
 }
 .rm-col:last-child { border-right: 0; }
@@ -1049,7 +1087,8 @@ body {
 .rm-col ul { list-style: none; padding: 0; margin: 0; }
 .rm-col li {
   display: flex;
-  gap: 12px;
+  align-items: flex-start;
+  gap: 14px;
   padding: 8px 0;
   font-size: 13.5px;
   color: var(--cream-dim);
@@ -1057,27 +1096,40 @@ body {
   border-bottom: 1px solid var(--rule);
 }
 .rm-col li:last-child { border-bottom: 0; }
+.rm-col li > span {
+  flex: 1;
+  min-width: 0;
+}
 .rm-col li::before {
-  content: "·";
+  content: "";
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   font-family: var(--serif);
   color: var(--cream-mute);
   font-size: 18px;
   line-height: 1;
-  width: auto; height: auto;
+  width: 16px;
+  height: 1.5em;
   border: 0;
-  background: none !important;
+  background: radial-gradient(circle at 50% calc(50% - 3px), var(--cream-mute) 0 2.5px, transparent 2.75px);
   flex-shrink: 0;
-  margin-top: -2px;
+  margin-top: 0;
+  text-align: center;
 }
 .rm-col.done li::before {
   content: "✓";
+  background: none;
   font-size: 13px;
   color: var(--jade);
+  transform: translateY(1px);
 }
 .rm-col.now li::before {
   content: "◐";
+  background: none;
   font-size: 13px;
   color: var(--accent);
+  transform: translateY(1px);
 }
 
 /* ─── FAQ ──────────────────────────────────────────────────── */
@@ -1272,7 +1324,7 @@ body {
 .config-bullets li {
   display: flex;
   gap: 12px;
-  align-items: baseline;
+  align-items: flex-start;
   padding: 12px 0;
   border-bottom: 1px solid var(--rule);
   font-size: 13px;
@@ -1283,12 +1335,14 @@ body {
 }
 .bullet-dot {
   width: 5px; height: 5px;
-  margin-top: 0;
+  margin-top: 0.7em;
   border-radius: 50%;
   background: var(--accent);
   box-shadow: none;
   flex-shrink: 0;
-  align-self: center;
+}
+.config-bullets li > span:last-child {
+  flex: 1;
 }
 
 .config-files {
@@ -1631,6 +1685,7 @@ body {
 
 .lang-switch {
   display: inline-flex;
+  flex-shrink: 0;
   border: 1px solid var(--rule-2);
   border-radius: 6px;
   overflow: hidden;


### PR DESCRIPTION
## What & Why

While browsing the website, I noticed a few small layout issues in the English view and some spacing inconsistencies across the landing page. I captured before/after screenshots while checking the fixes, so the visual changes should be easy to review.

This PR polishes those responsive and spacing details:

- removes the duplicated `Download` top-nav item while keeping the desktop download CTA
- adds priority-based nav classes so lower-priority links progressively disappear at narrower widths
- prevents nav/version/language labels from wrapping awkwardly
- cleans up hero metric alignment and unit styling
- normalizes spacing in feature cards and roadmap columns
- top-aligns config bullet dots for multi-line rows

## How to verify

- Verify manually the affected UI with before/after changes

<img width="6606" height="5934" alt="test" src="https://github.com/user-attachments/assets/a8b4fe0e-3d8f-489f-be48-f15444d704a1" />

## Checklist

- [x ] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time
