### PR TITLE
 fix: add timeoutMs config passthrough and raise default to 180s 

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -56,6 +56,7 @@ export interface OpenAICompatEmbeddingUserConfig {
   model?: string;
   extraBody?: Record<string, unknown>;
   batchSize?: number;
+  timeoutMs?: number;
 }
 
 export interface SemanticEmbeddingUserConfig {
@@ -360,7 +361,7 @@ export function loadExaApiKey(path: string = defaultConfigPath()): string | unde
 
 const DEFAULT_OLLAMA_URL = "http://localhost:11434";
 const DEFAULT_EMBED_MODEL = "nomic-embed-text";
-const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_TIMEOUT_MS = 180_000;
 const DEFAULT_BATCH_SIZE = 10;
 
 export function defaultConfigPath(): string {
@@ -1315,7 +1316,7 @@ export function resolveSemanticEmbeddingConfig(
       apiKey,
       model,
       extraBody: normalizeExtraBody(user.openaiCompat?.extraBody),
-      timeoutMs: DEFAULT_TIMEOUT_MS,
+      timeoutMs: user.openaiCompat?.timeoutMs ?? DEFAULT_TIMEOUT_MS,
       batchSize: user.openaiCompat?.batchSize ?? DEFAULT_BATCH_SIZE,
     };
   }
@@ -1393,6 +1394,7 @@ function normalizeSemanticEmbeddingUserConfig(
       apiKey: normalizeOptionalString(cfg?.openaiCompat?.apiKey),
       model: normalizeOptionalString(cfg?.openaiCompat?.model),
       extraBody: normalizeExtraBody(cfg?.openaiCompat?.extraBody),
+      timeoutMs: normalizePositiveInt(cfg?.openaiCompat?.timeoutMs),
       batchSize: normalizePositiveInt(cfg?.openaiCompat?.batchSize),
     },
   };

--- a/src/index/semantic/embedding.ts
+++ b/src/index/semantic/embedding.ts
@@ -1,6 +1,6 @@
 const DEFAULT_OLLAMA_URL = "http://localhost:11434";
 const DEFAULT_EMBED_MODEL = "nomic-embed-text";
-const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_TIMEOUT_MS = 180_000;
 const DEFAULT_BATCH_SIZE = 10;
 
 export type EmbedOptions =


### PR DESCRIPTION
 normalizeSemanticEmbeddingUserConfig drops the timeoutMs field when 
 reconstructing the openaiCompat object, causing user-configured values 
 to silently fall back to the 30s default. 
  
 - Preserve timeoutMs in normalizeSemanticEmbeddingUserConfig 
 - Bump DEFAULT_TIMEOUT_MS from 30s to 180s in both config.ts and 
   embedding.ts
## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time
