### PR TITLE
fix(desktop): recalc thread width on resize

### DIFF
--- a/desktop/src/App.test.ts
+++ b/desktop/src/App.test.ts
@@ -35,6 +35,7 @@ vi.mock("./theme", () => ({
 }));
 
 import { reduce } from "./App";
+import { getThreadMaxWidth } from "./ui/thread-layout";
 
 function initialState(): Parameters<typeof reduce>[0] {
   return {
@@ -263,5 +264,22 @@ describe("Desktop App reducer — ApprovalPrompt integration", () => {
 
     expect(next.settings?.reasoningEffort).toBe("low");
     expect(next.settings?.editMode).toBe("auto");
+  });
+});
+
+describe("desktop thread layout", () => {
+  it("recomputes the thread cap from the latest viewport width", () => {
+    const side = 244;
+    const ctx = 320;
+
+    expect(
+      getThreadMaxWidth({ viewportWidth: 1000, visibleSide: side, visibleCtx: ctx }),
+    ).toBe(580);
+    expect(
+      getThreadMaxWidth({ viewportWidth: 1400, visibleSide: side, visibleCtx: ctx }),
+    ).toBe(756);
+    expect(
+      getThreadMaxWidth({ viewportWidth: 1800, visibleSide: side, visibleCtx: ctx }),
+    ).toBe(1120);
   });
 });

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -98,6 +98,7 @@ import { useAutoCollapse } from "./ui/useAutoCollapse";
 import { useResizable } from "./ui/useResizable";
 import { useAutoScroll } from "./ui/useAutoScroll";
 import { useDisableTextAssist } from "./ui/useDisableTextAssist";
+import { getThreadMaxWidth } from "./ui/thread-layout";
 import { openUrl } from "@tauri-apps/plugin-opener";
 
 const RIGHT_SIDEBAR_COLLAPSE_WIDTH = 1120;
@@ -3250,9 +3251,10 @@ export function App() {
 
   const { width: sideWidth, onMouseDown: onSideResizeDown } = useResizable("side", sideCollapsed);
   const { width: ctxWidth, onMouseDown: onCtxResizeDown } = useResizable("ctx", ctxCollapsed);
+  const [viewportWidth, setViewportWidth] = useState(() => window.innerWidth);
   const visibleSide = sideCollapsed ? 0 : sideWidth;
   const visibleCtx = ctxCollapsed ? 0 : ctxWidth;
-  const threadMaxWidth = Math.max(580, Math.min(window.innerWidth - visibleSide - visibleCtx - 80, 1120));
+  const threadMaxWidth = getThreadMaxWidth({ viewportWidth, visibleSide, visibleCtx });
 
   useEffect(() => {
     document.documentElement.dataset.theme = theme;
@@ -3267,7 +3269,9 @@ export function App() {
 
     const sync = () => {
       raf = 0;
-      const next = responsiveStage(window.innerWidth);
+      const width = window.innerWidth;
+      setViewportWidth(width);
+      const next = responsiveStage(width);
       if (prevStage === next) return;
       const prev = prevStage;
       prevStage = next;

--- a/desktop/src/ui/thread-layout.ts
+++ b/desktop/src/ui/thread-layout.ts
@@ -1,0 +1,11 @@
+export function getThreadMaxWidth({
+  viewportWidth,
+  visibleSide,
+  visibleCtx,
+}: {
+  viewportWidth: number;
+  visibleSide: number;
+  visibleCtx: number;
+}): number {
+  return Math.max(580, Math.min(viewportWidth - visibleSide - visibleCtx - 80, 1120));
+}


### PR DESCRIPTION
## Summary

Fix desktop chat layout resizing so the center message content recalculates its usable width after the window is resized or maximized.

## Problem

On desktop, the center chat content normally adapts to fill available space. However, after manually shrinking the window and then maximizing it again, the adaptive layout could get stuck at the smaller width. The layout would only recover after resizing the window smaller again and maximizing once more.

The issue was in the desktop app layout calculation:
- `desktop/src/App.tsx` calculated `threadMaxWidth` directly from `window.innerWidth` during render.
- The resize handler only caused a React state update when the responsive stage changed.
- If the window was resized or maximized without crossing a responsive breakpoint, React did not re-render, so the center thread kept using the stale width.

## Fix

- **`desktop/src/App.tsx`** — Added `viewportWidth` state and updated it on every window resize, so thread width is recalculated even when the responsive stage does not change.
- **`desktop/src/ui/thread-layout.ts`** — Added `getThreadMaxWidth` as a small pure helper for the center thread width calculation.
- **`desktop/src/App.test.ts`** — Added a regression test covering recalculation of the thread width from the latest viewport width.

## Verification

| Check | Result |
|---|---|
| `npm run test -- desktop/src/App.test.ts` | ✅ passes |
| `npm run typecheck` | ✅ passes |
| `npm run lint` | ✅ passes |
| `npm run verify` | ✅ passes |
| Commit hook `npm run lint` | ✅ passes |
