### PR TITLE
fix(dashboard): replay active modal on SSE connect so web confirm gate isn't stuck

### DIFF
--- a/src/server/api/events.ts
+++ b/src/server/api/events.ts
@@ -36,6 +36,11 @@ export function handleEvents(
   // state is correct on first paint (instead of inheriting whatever
   // the prior connection's last delta said).
   if (ctx.isBusy) writeEvent({ kind: "busy-change", busy: ctx.isBusy() });
+  // Replay the active modal — without this, a client that connects after
+  // the modal-up broadcast fires (e.g., dashboard tab opened mid-turn)
+  // misses the gate and the tool appears to hang forever (#1770).
+  const activeModal = ctx.getActiveModal?.();
+  if (activeModal) writeEvent({ kind: "modal-up", modal: activeModal });
 
   const unsubscribe = ctx.subscribeEvents(writeEvent);
 

--- a/tests/server-dashboard.test.ts
+++ b/tests/server-dashboard.test.ts
@@ -742,6 +742,32 @@ describe("dashboard server: chat bridge", () => {
     ac.abort();
   });
 
+  it("GET /api/events replays the active modal so mid-modal connects see the gate (#1770)", async () => {
+    const base = await boot({
+      isBusy: () => false,
+      subscribeEvents: () => () => undefined,
+      getActiveModal: () => ({
+        kind: "shell",
+        command: "npm install",
+        allowPrefix: "npm",
+        shellKind: "stdin",
+      }),
+    });
+    const ac = new AbortController();
+    const res = await fetch(`${base}api/events?token=${TOKEN}`, { signal: ac.signal });
+    expect(res.status).toBe(200);
+    const reader = res.body!.getReader();
+    let combined = "";
+    for (let i = 0; i < 3 && !combined.includes("modal-up"); i++) {
+      const { value } = await reader.read();
+      if (value) combined += new TextDecoder().decode(value);
+    }
+    expect(combined).toContain("modal-up");
+    expect(combined).toContain("npm install");
+    reader.cancel().catch(() => undefined);
+    ac.abort();
+  });
+
   it("GET /api/events without a subscribeEvents callback returns 503", async () => {
     const base = await boot({});
     const r = await fetch(`${base}api/events?token=${TOKEN}`);


### PR DESCRIPTION
## Summary
When the assistant triggered a \`run_command\` shell confirmation in the web dashboard, the tool card stayed on "running" indefinitely — no Approve / Deny button, no way for the user to respond. CLI and Tauri desktop worked fine.

## Root cause
\`modal-up\` is broadcast at the moment the gate opens. If the dashboard tab wasn't already connected to \`/api/events\` at that instant, the event went out to zero subscribers and the dashboard never learned a modal was up. The SSE handler in \`src/server/api/events.ts\` already snapshotted \`busy-change\` for this exact "client connects mid-state" reason, and \`getActiveModal\` was defined on \`DashboardContext\` with the comment \`"Snapshot of any modal currently up (for SSE clients that connect mid-modal)"\` — but the snapshot was never actually emitted on connect.

## Fix
Send the active-modal snapshot alongside \`busy-change\` on every new SSE connection. Two lines in \`src/server/api/events.ts\`. No new API surface, no protocol change.

## Test plan
- [x] New regression test \`GET /api/events replays the active modal so mid-modal connects see the gate (#1770)\` — boots dashboard with \`getActiveModal\` returning a shell modal, opens \`/api/events\`, verifies the stream contains \`modal-up\` + the command text.
- [x] Verified the test **times out at 5s on main without the fix** (the modal-up frame never arrives) and **passes with the snapshot**.
- [x] Other 12 server-dashboard chat-bridge tests still pass.

Fixes #1770