### PR TITLE
fix(cli): replace BEL with ST on Windows stdout so cmd doesn't beep on every frame

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6,6 +6,10 @@ import "./node-version-guard.js";
 // (issue #1011). Side-effect on module load, before any heavy import below runs.
 import "./heap-limit-launch.js";
 
+// Wrap stdout/stderr before any third-party lib gets a chance to emit BEL on
+// Windows cmd, which would beep the system bell every render (#1786).
+import "./strip-bel.js";
+
 import { Command } from "commander";
 import {
   ensureDashboardToken,

--- a/src/cli/strip-bel.ts
+++ b/src/cli/strip-bel.ts
@@ -1,0 +1,37 @@
+// Windows cmd.exe rings the system bell when stdout carries a bare BEL byte,
+// which third-party libs (ansi-escapes, terminal-link, …) embed as OSC
+// terminators. Swap BEL → ST (`\x1b\\`) on Windows: ST is the other valid
+// OSC terminator so semantics are preserved for legitimate OSC sequences,
+// and stray bells outside OSC stop beeping. Issue #1786.
+
+if (process.platform === "win32") {
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: matching BEL is the point
+  const BEL_RE = /\x07/g;
+  const replaceBel = (chunk: unknown): unknown => {
+    if (typeof chunk === "string") {
+      return chunk.includes("\x07") ? chunk.replace(BEL_RE, "\x1b\\") : chunk;
+    }
+    if (Buffer.isBuffer(chunk)) {
+      if (chunk.indexOf(0x07) === -1) return chunk;
+      // Each BEL grows by 1 byte (\x07 → \x1b\\), bound the output up front.
+      const out = Buffer.alloc(chunk.length * 2);
+      let j = 0;
+      for (let i = 0; i < chunk.length; i++) {
+        if (chunk[i] === 0x07) {
+          out[j++] = 0x1b;
+          out[j++] = 0x5c;
+        } else {
+          out[j++] = chunk[i]!;
+        }
+      }
+      return out.subarray(0, j);
+    }
+    return chunk;
+  };
+
+  for (const stream of [process.stdout, process.stderr]) {
+    const original = stream.write.bind(stream) as (...args: unknown[]) => boolean;
+    stream.write = ((chunk: unknown, ...args: unknown[]) =>
+      original(replaceBel(chunk), ...args)) as typeof stream.write;
+  }
+}

--- a/tests/strip-bel.test.ts
+++ b/tests/strip-bel.test.ts
@@ -1,0 +1,63 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+// strip-bel wraps process.stdout.write by closing over the *previous*
+// write function. So pin a capture sink BEFORE importing it; the module
+// then forwards transformed chunks into our sink.
+
+const ORIGINAL_PLATFORM = process.platform;
+const ORIGINAL_STDOUT_WRITE = process.stdout.write.bind(process.stdout);
+const ORIGINAL_STDERR_WRITE = process.stderr.write.bind(process.stderr);
+
+const captured: { stdout: unknown[]; stderr: unknown[] } = { stdout: [], stderr: [] };
+
+beforeAll(async () => {
+  Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+  process.stdout.write = ((chunk: unknown) => {
+    captured.stdout.push(chunk);
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: unknown) => {
+    captured.stderr.push(chunk);
+    return true;
+  }) as typeof process.stderr.write;
+  await import("../src/cli/strip-bel.js");
+});
+
+afterAll(() => {
+  process.stdout.write = ORIGINAL_STDOUT_WRITE;
+  process.stderr.write = ORIGINAL_STDERR_WRITE;
+  Object.defineProperty(process, "platform", { value: ORIGINAL_PLATFORM, configurable: true });
+});
+
+describe("strip-bel (Windows)", () => {
+  it("replaces bare BEL bytes with String Terminator (ESC backslash)", () => {
+    captured.stdout.length = 0;
+    process.stdout.write("hello\x07world");
+    expect(captured.stdout).toEqual(["hello\x1b\\world"]);
+  });
+
+  it("preserves OSC semantics — BEL terminator becomes ST terminator", () => {
+    captured.stdout.length = 0;
+    process.stdout.write("\x1b]7;file:///tmp/x\x07");
+    expect(captured.stdout).toEqual(["\x1b]7;file:///tmp/x\x1b\\"]);
+  });
+
+  it("applies the same substitution to Buffer chunks", () => {
+    captured.stdout.length = 0;
+    process.stdout.write(Buffer.from([0x68, 0x07, 0x69]));
+    expect(captured.stdout.length).toBe(1);
+    expect(Array.from(captured.stdout[0] as Buffer)).toEqual([0x68, 0x1b, 0x5c, 0x69]);
+  });
+
+  it("passes BEL-free chunks through unchanged (fast path)", () => {
+    captured.stdout.length = 0;
+    process.stdout.write("hello world\n");
+    expect(captured.stdout).toEqual(["hello world\n"]);
+  });
+
+  it("also wraps stderr", () => {
+    captured.stderr.length = 0;
+    process.stderr.write("warn\x07ing");
+    expect(captured.stderr).toEqual(["warn\x1b\\ing"]);
+  });
+});


### PR DESCRIPTION
## Summary
Windows cmd.exe rings the system bell when stdout receives a bare BEL byte (\`0x07\`). Third-party libraries (\`ansi-escapes\`, \`terminal-link\`, ink's own deps) embed BEL as an OSC sequence terminator — perfectly valid VT syntax that Windows Terminal, ConEmu, and every *nix terminal handle silently — but cmd treats the unrecognized OSC start as junk and beeps on the BEL byte. Visible on #1786 as the system bell ringing on every assistant response chunk.

## Approach
Patching every emitter individually doesn't scale — the BEL constants are scattered across multiple deps (\`var BEL = "\x07"\`, \`var bellCharacter = "\x07"\`, etc.). Instead wrap \`process.stdout\` / \`process.stderr\` on Windows once and rewrite \`\x07\` → \`\x1b\\\` at the boundary.

Why ST (String Terminator):
- ST and BEL are both valid OSC terminators per VT 510, so legitimate OSC sequences keep working (Windows Terminal / ConEmu / conhost-with-VT all accept either)
- Stray BEL outside an OSC turns into ESC + backslash, which cmd renders as junk text instead of ringing the bell

Wrap installed via side-effect import at the very top of \`src/cli/index.ts\`, after \`node-version-guard\` and \`heap-limit-launch\` (which may re-exec the process) so the wrap lives in the process that actually runs the CLI.

Platform-gated to \`process.platform === "win32"\` — *nix terminals don't need it and Windows Terminal handles BEL silently, but cmd.exe is the failure mode the user actually hits.

## Test plan
- [x] New \`tests/strip-bel.test.ts\` — 5 cases:
  - bare BEL → ST
  - OSC sequence with BEL terminator → OSC sequence with ST terminator
  - Buffer chunks same substitution
  - BEL-free chunks fast-path through unchanged
  - stderr also wrapped
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run verify\` passes (lint + comment policy + full suite)

Fixes #1786