### PR TITLE
fix(tui): hide `max` effort on non-DeepSeek endpoints

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -144,6 +144,7 @@ import {
   shouldApplyEditToolImmediately,
 } from "./edit-tool-gate.js";
 import { loopEventToDashboard } from "./effects/loop-to-dashboard.js";
+import { effortChoicesForBaseUrl } from "./effort-choices.js";
 import { appendGlobalMemory, appendProjectMemory, detectHashMemory } from "./hash-memory.js";
 import { type ResolvedHistoryScrollMode, resolveHistoryScrollMode } from "./history-scroll-mode.js";
 import { applySlashResult } from "./hooks/apply-slash-result.js";
@@ -1482,6 +1483,10 @@ function AppInner({
     };
   }, [pendingCheckpoint, broadcastDashboardEvent]);
 
+  // `max` is a DeepSeek-only reasoning extension — drop it from /effort
+  // suggestions + picker when the active endpoint is third-party (#1794).
+  const effortChoices = React.useMemo(() => effortChoicesForBaseUrl(loop.client.baseUrl), [loop]);
+
   // Three mutually-exclusive input-prefix pickers (slash name, @ file
   // mention, slash argument) —state + memos + commit callbacks live
   // in a dedicated hook so App.tsx only sees the small surface it
@@ -1512,6 +1517,7 @@ function AppInner({
     models,
     mcpServers: liveMcpServers,
     slashUsage,
+    effortChoices,
   });
 
   useEffect(() => {
@@ -4517,6 +4523,7 @@ function AppInner({
                   models={models}
                   current={loop.model}
                   currentEffort={loop.reasoningEffort}
+                  effortChoices={effortChoices}
                   onRefresh={refreshModels}
                   onChoose={(outcome) => {
                     setPendingModelPicker(false);

--- a/src/cli/ui/ModelPicker.tsx
+++ b/src/cli/ui/ModelPicker.tsx
@@ -1,6 +1,6 @@
 import { Box, Text, useStdout } from "ink";
 import React, { useState } from "react";
-import { REASONING_EFFORT_VALUES, type ReasoningEffort } from "../../config.js";
+import type { ReasoningEffort } from "../../config.js";
 import { t } from "../../i18n/index.js";
 import { useKeystroke } from "./keystroke-context.js";
 import { PILL_MODEL, Pill, modelBadgeFor } from "./primitives/Pill.js";
@@ -17,6 +17,8 @@ export interface ModelPickerProps {
   /** Model id currently active in the loop — marked with the cursor on open. */
   current: string;
   currentEffort: ReasoningEffort;
+  /** Effort enum filtered for the active endpoint — drops "max" on non-DeepSeek hosts (#1794). */
+  effortChoices: ReadonlyArray<ReasoningEffort>;
   onChoose: (outcome: ModelPickerOutcome) => void;
   /** Triggers a refetch when the catalog is null/empty and the user presses [r]. */
   onRefresh?: () => void;
@@ -30,13 +32,14 @@ export function ModelPicker({
   models,
   current,
   currentEffort,
+  effortChoices,
   onChoose,
   onRefresh,
 }: ModelPickerProps): React.ReactElement {
   const modelList = (models && models.length > 0 ? models : FALLBACK_MODELS).slice();
   if (!modelList.includes(current)) modelList.unshift(current);
 
-  const effortRows: Row[] = REASONING_EFFORT_VALUES.map((effort) => ({
+  const effortRows: Row[] = effortChoices.map((effort) => ({
     kind: "effort",
     effort,
   }));

--- a/src/cli/ui/effort-choices.ts
+++ b/src/cli/ui/effort-choices.ts
@@ -1,0 +1,16 @@
+import type { ReasoningEffort } from "../../config.js";
+import { isDeepSeekHost } from "../../loop/errors.js";
+
+const ALL: readonly ReasoningEffort[] = ["low", "medium", "high", "max"];
+const STANDARD: readonly ReasoningEffort[] = ["low", "medium", "high"];
+
+/** `max` is a DeepSeek-only reasoning extension; non-DeepSeek hosts 400 on it (#1794). */
+export function effortChoicesForBaseUrl(
+  baseUrl: string | undefined | null,
+): readonly ReasoningEffort[] {
+  return isDeepSeekHost(baseUrl) ? ALL : STANDARD;
+}
+
+export function effortArgsHintFor(choices: readonly ReasoningEffort[]): string {
+  return `<${choices.join("|")}>`;
+}

--- a/src/cli/ui/slash/handlers/model.ts
+++ b/src/cli/ui/slash/handlers/model.ts
@@ -1,11 +1,11 @@
 import {
-  REASONING_EFFORT_VALUES,
   type ReasoningEffort,
   isReasoningEffort,
   saveModel,
   saveReasoningEffort,
 } from "@/config.js";
 import { t } from "@/i18n/index.js";
+import { effortChoicesForBaseUrl } from "../../effort-choices.js";
 import type { SlashHandler } from "../dispatch.js";
 
 const model: SlashHandler = (args, loop, ctx) => {
@@ -30,19 +30,18 @@ const model: SlashHandler = (args, loop, ctx) => {
 };
 
 const effort: SlashHandler = (args, loop) => {
+  const choices = effortChoicesForBaseUrl(loop.client.baseUrl);
+  const list = choices.join(" | ");
+  const usageKey =
+    choices.length === 4 ? "handlers.model.effortUsage" : "handlers.model.effortUsageNoMax";
   const raw = (args[0] ?? "").toLowerCase();
   if (raw === "") {
     return {
-      info: t("handlers.model.effortStatus", {
-        current: loop.reasoningEffort,
-        list: REASONING_EFFORT_VALUES.join(" | "),
-      }),
+      info: t("handlers.model.effortStatus", { current: loop.reasoningEffort, list }),
     };
   }
-  if (!isReasoningEffort(raw)) {
-    return {
-      info: t("handlers.model.effortUsage", { list: REASONING_EFFORT_VALUES.join(" | ") }),
-    };
+  if (!isReasoningEffort(raw) || !choices.includes(raw as ReasoningEffort)) {
+    return { info: t(usageKey, { list }) };
   }
   const next: ReasoningEffort = raw;
   loop.configure({ reasoningEffort: next });

--- a/src/cli/ui/useCompletionPickers.ts
+++ b/src/cli/ui/useCompletionPickers.ts
@@ -10,8 +10,9 @@ import {
   rankPickerCandidates,
   walkFilesStream,
 } from "../../at-mentions.js";
-import { loadResolvedSkillPaths } from "../../config.js";
+import { type ReasoningEffort, loadResolvedSkillPaths } from "../../config.js";
 import { SkillStore } from "../../skills.js";
+import { effortArgsHintFor } from "./effort-choices.js";
 import {
   type McpServerSummary,
   type SlashArgContext,
@@ -31,6 +32,8 @@ export interface UseCompletionPickersParams {
   mcpServers: McpServerSummary[] | undefined;
   /** Cross-session slash invocation counts — used to sort suggestions by frequency. */
   slashUsage?: Readonly<Record<string, number>>;
+  /** Filtered effort enum for the active endpoint — drops "max" on non-DeepSeek hosts (#1794). */
+  effortChoices: readonly ReasoningEffort[];
 }
 
 export interface AtPickerEntry {
@@ -97,13 +100,15 @@ export function useCompletionPickers({
   models,
   mcpServers,
   slashUsage,
+  effortChoices,
 }: UseCompletionPickersParams): UseCompletionPickersResult {
   // ── slash-name picker ──
   const [slashSelected, setSlashSelected] = useState(0);
   const slashMatches = useMemo(() => {
     if (!input.startsWith("/") || input.includes(" ")) return null;
-    return suggestSlashCommands(input.slice(1), !!codeMode, slashUsage);
-  }, [input, codeMode, slashUsage]);
+    const raw = suggestSlashCommands(input.slice(1), !!codeMode, slashUsage);
+    return raw.map((spec) => rewriteEffortSpec(spec, effortChoices));
+  }, [input, codeMode, slashUsage, effortChoices]);
   const slashGroupMode = input === "/";
   const slashAdvancedHidden = useMemo(
     () => (slashGroupMode ? countAdvancedCommands(!!codeMode) : 0),
@@ -209,8 +214,12 @@ export function useCompletionPickers({
   const slashArgContext = useMemo<SlashArgContext | null>(() => {
     if (!input.startsWith("/")) return null;
     if (slashMatches !== null) return null;
-    return detectSlashArgContext(input, !!codeMode);
-  }, [input, slashMatches, codeMode]);
+    const ctx = detectSlashArgContext(input, !!codeMode);
+    if (!ctx) return null;
+    return ctx.kind === "picker"
+      ? { ...ctx, spec: rewriteEffortSpec(ctx.spec, effortChoices) }
+      : ctx;
+  }, [input, slashMatches, codeMode, effortChoices]);
 
   // Path completion: async directory listing for `argCompleter: "path"`.
   const slashArgPathCandidates = usePathCandidates(
@@ -568,4 +577,20 @@ function rankSearchHits(
       isDir: false,
     };
   });
+}
+
+/** Drops `max` from the /effort spec's argsHint + argCompleter when the
+ *  active endpoint is non-DeepSeek so vLLM/Azure users don't see an option
+ *  that would 400 their next call (#1794). No-op for any other command. */
+function rewriteEffortSpec(
+  spec: SlashCommandSpec,
+  effortChoices: readonly ReasoningEffort[],
+): SlashCommandSpec {
+  if (spec.cmd !== "effort") return spec;
+  if (effortChoices.length === 4) return spec;
+  return {
+    ...spec,
+    argsHint: effortArgsHintFor(effortChoices),
+    argCompleter: [...effortChoices],
+  };
 }

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -955,6 +955,7 @@ export const EN: TranslationSchema = {
       effortStatus: "effort → {current}   (pick: {list})",
       effortUsage:
         "usage: /effort <{list}>   (high is the safe default; max is a DeepSeek extension)",
+      effortUsageNoMax: "usage: /effort <{list}>",
       effortSet: "effort → {effort}",
       budgetNoCap:
         "no session budget set — Reasonix will keep going until you stop it. Set one with: /budget <usd>   (e.g. /budget 5)",

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -912,6 +912,7 @@ export const de: TranslationSchema = {
       effortStatus: "Effort → {current}   (Auswahl: {list})",
       effortUsage:
         "Verwendung: /effort <{list}>   (high ist der sichere Standard; max ist eine DeepSeek-Erweiterung)",
+      effortUsageNoMax: "Verwendung: /effort <{list}>",
       effortSet: "Effort → {effort}",
       budgetNoCap:
         "Kein Sitzungsbudget festgelegt — Reasonix wird weiterlaufen, bis du es stoppst. Setze eines mit: /budget <usd>   (z.B. /budget 5)",

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -903,6 +903,7 @@ export const zhCN: TranslationSchema = {
       modelSet: "model → {id}",
       effortStatus: "effort → {current}   （可选：{list}）",
       effortUsage: "用法：/effort <{list}>   （high 为安全默认；max 是 DeepSeek 扩展）",
+      effortUsageNoMax: "用法：/effort <{list}>",
       effortSet: "effort → {effort}",
       budgetNoCap:
         "未设置会话预算 — Reasonix 将持续运行直到您停止。使用以下方式设置：/budget <usd>   （例如 /budget 5）",

--- a/tests/effort-choices.test.ts
+++ b/tests/effort-choices.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { effortArgsHintFor, effortChoicesForBaseUrl } from "../src/cli/ui/effort-choices.js";
+
+describe("effortChoicesForBaseUrl", () => {
+  it("returns the full set for api.deepseek.com", () => {
+    expect(effortChoicesForBaseUrl("https://api.deepseek.com")).toEqual([
+      "low",
+      "medium",
+      "high",
+      "max",
+    ]);
+    expect(effortChoicesForBaseUrl("https://api.deepseek.com/v1")).toEqual([
+      "low",
+      "medium",
+      "high",
+      "max",
+    ]);
+  });
+
+  it("drops `max` for non-DeepSeek endpoints (vLLM / Azure / OpenAI-compat reject it)", () => {
+    expect(effortChoicesForBaseUrl("http://localhost:8080/v1")).toEqual(["low", "medium", "high"]);
+    expect(effortChoicesForBaseUrl("https://api.openai.com/v1")).toEqual(["low", "medium", "high"]);
+    expect(effortChoicesForBaseUrl("https://my-azure.openai.azure.com")).toEqual([
+      "low",
+      "medium",
+      "high",
+    ]);
+  });
+
+  it("treats null / undefined / empty baseUrl as non-DeepSeek", () => {
+    expect(effortChoicesForBaseUrl(undefined)).toEqual(["low", "medium", "high"]);
+    expect(effortChoicesForBaseUrl(null)).toEqual(["low", "medium", "high"]);
+    expect(effortChoicesForBaseUrl("")).toEqual(["low", "medium", "high"]);
+  });
+
+  it("rejects deepseek-spoofing hosts (substring match would be wrong)", () => {
+    expect(effortChoicesForBaseUrl("https://fake-deepseek.com")).toEqual(["low", "medium", "high"]);
+    expect(effortChoicesForBaseUrl("https://api.deepseek.com.evil.tld")).toEqual([
+      "low",
+      "medium",
+      "high",
+    ]);
+  });
+
+  it("formats argsHint with the supplied choices", () => {
+    expect(effortArgsHintFor(["low", "medium", "high", "max"])).toBe("<low|medium|high|max>");
+    expect(effortArgsHintFor(["low", "medium", "high"])).toBe("<low|medium|high>");
+  });
+});

--- a/tests/slash.test.ts
+++ b/tests/slash.test.ts
@@ -247,6 +247,33 @@ describe("handleSlash", () => {
     expect(r.info).toMatch(/usage/);
   });
 
+  it("/effort rejects `max` on non-DeepSeek endpoints (#1794)", () => {
+    const client = new DeepSeekClient({
+      apiKey: "sk-test",
+      baseUrl: "http://localhost:8080/v1",
+      fetch: vi.fn() as unknown as typeof fetch,
+    });
+    const loop = new CacheFirstLoop({ client, prefix: new ImmutablePrefix({ system: "s" }) });
+    const r = handleSlash("effort", ["max"], loop);
+    expect(r.info).toMatch(/usage/);
+    expect(r.info).not.toMatch(/\bmax\b/);
+    expect(loop.reasoningEffort).not.toBe("max");
+  });
+
+  it("/effort status on non-DeepSeek endpoint omits `max` from the list (#1794)", () => {
+    const client = new DeepSeekClient({
+      apiKey: "sk-test",
+      baseUrl: "http://localhost:8080/v1",
+      fetch: vi.fn() as unknown as typeof fetch,
+    });
+    const loop = new CacheFirstLoop({ client, prefix: new ImmutablePrefix({ system: "s" }) });
+    const r = handleSlash("effort", [], loop);
+    expect(r.info).toMatch(/low/);
+    expect(r.info).toMatch(/medium/);
+    expect(r.info).toMatch(/high/);
+    expect(r.info).not.toMatch(/\bmax\b/);
+  });
+
   it("/help mentions sessions", () => {
     const r = handleSlash("help", [], makeLoop());
     expect(r.info).toMatch(/\/sessions/);

--- a/tests/ui-model-picker.test.tsx
+++ b/tests/ui-model-picker.test.tsx
@@ -9,6 +9,7 @@ function renderPicker(props: {
   models: ReadonlyArray<string> | null;
   current: string;
   currentEffort?: ReasoningEffort;
+  effortChoices?: ReadonlyArray<ReasoningEffort>;
 }): string {
   const stdout = makeFakeStdout();
   const { unmount } = render(
@@ -16,6 +17,7 @@ function renderPicker(props: {
       models: props.models,
       current: props.current,
       currentEffort: props.currentEffort ?? "high",
+      effortChoices: props.effortChoices ?? ["low", "medium", "high", "max"],
       onChoose: () => {},
     }),
     { stdout: stdout as never, stdin: makeFakeStdin() as never },
@@ -45,6 +47,19 @@ describe("ModelPicker (#371)", () => {
     expect(text).toContain("medium");
     expect(text).toContain("high");
     expect(text).toContain("max");
+  });
+
+  it("hides `max` when the active endpoint is non-DeepSeek (#1794)", () => {
+    const text = renderPicker({
+      models: ["deepseek-v4-flash"],
+      current: "deepseek-v4-flash",
+      effortChoices: ["low", "medium", "high"],
+    });
+    expect(text).toContain("EFFORT");
+    expect(text).toContain("low");
+    expect(text).toContain("medium");
+    expect(text).toContain("high");
+    expect(text).not.toMatch(/\bmax\b/);
   });
 
   it("marks the active effort with `current`", () => {


### PR DESCRIPTION
## Summary
#1657 dropped the preset abstraction and exposed reasoning effort directly, keeping \`max\` as a DeepSeek-only extension that users opt into knowing standard OpenAI / vLLM / Azure reject it with 400. The TUI still advertised \`max\` everywhere — \`/effort\` argsHint, slash-arg picker, ModelPicker effort rows, /effort handler — even when the active endpoint was a third-party host that can't accept it. Users on those endpoints saw \`max\` in every suggestion and reported it as a preset-era leftover.

## Repro (from #1794)
1. Configure baseUrl to a non-DeepSeek endpoint (vLLM, Azure, OpenAI-compat)
2. Run \`reasonix code\`, type \`/\` to open the slash dropdown
3. See \`/effort  <low|medium|high|max>\` — \`max\` would 400 the next call

## Fix
New helper \`src/cli/ui/effort-choices.ts\` exposes \`effortChoicesForBaseUrl(baseUrl)\` (uses the existing \`isDeepSeekHost\` allow-list) — returns the full 4-value set on \`api.deepseek.com\`, drops \`max\` everywhere else. Wired through:

- **Slash autocomplete dropdown** — \`useCompletionPickers\` rewrites the \`/effort\` spec so argsHint shows \`<low|medium|high>\` and argCompleter omits \`max\`
- **Slash-arg picker** (when user types \`/effort \`) — same rewrite
- **ModelPicker** — \`effortChoices\` prop drives the rendered rows
- **/effort handler** — rejects \`max\` with the standard usage hint
- **New \`effortUsageNoMax\` i18n key** (EN / zh-CN / de) so the error message on bad input doesn't itself name \`max\` as an option

\`max\` stays available on DeepSeek endpoints — that's the design from #1657, just no longer visible on hosts where it would crash.

## Test plan
- [x] \`tests/effort-choices.test.ts\` — 5 cases (DeepSeek allow, third-party filter, null/empty, spoofing rejection, argsHint format)
- [x] \`tests/ui-model-picker.test.tsx\` — new \"hides max on non-DeepSeek\" + existing 9 still pass
- [x] \`tests/slash.test.ts\` — new \"rejects max on non-DeepSeek\" + \"status omits max on non-DeepSeek\" + existing 132 still pass
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run verify\` passes (lint + comment policy + full suite)

Fixes #1794