### PR TITLE
fix(loop): trim long-session retained payloads

### DIFF
--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -531,7 +531,43 @@ function tailLines(s: string, n: number): string {
   return lines.slice(-n).join("\n");
 }
 
-function buildLoadedMessages(records: ChatMessage[]): LoadedMessage[] {
+const LOADED_RECENT_MESSAGE_WINDOW = 200;
+const LOADED_MIN_ELIDE_CHARS = 4096;
+const LOADED_ELIDED_PREFIX = "[elided — older than the last ";
+
+function elideLoadedField(value: string): string {
+  if (value.length <= LOADED_MIN_ELIDE_CHARS) return value;
+  if (value.startsWith(LOADED_ELIDED_PREFIX)) return value;
+  return `${LOADED_ELIDED_PREFIX}${LOADED_RECENT_MESSAGE_WINDOW} messages; ${value.length.toLocaleString()} chars dropped to save memory. Full content is on disk in the session log.]`;
+}
+
+function elideLoadedMessages(messages: LoadedMessage[]): LoadedMessage[] {
+  if (messages.length < LOADED_RECENT_MESSAGE_WINDOW) return messages;
+  const cutoff = messages.length - LOADED_RECENT_MESSAGE_WINDOW;
+  return messages.map((msg, i) => {
+    if (i >= cutoff || msg.kind !== "assistant") return msg;
+    return {
+      ...msg,
+      segments: msg.segments.map((segment) => {
+        switch (segment.kind) {
+          case "reasoning":
+          case "text":
+            return { ...segment, text: elideLoadedField(segment.text) };
+          case "tool":
+            return {
+              ...segment,
+              args: elideLoadedField(segment.args),
+              ...(segment.result !== undefined ? { result: elideLoadedField(segment.result) } : {}),
+            };
+          default:
+            return segment;
+        }
+      }),
+    };
+  });
+}
+
+export function buildLoadedMessages(records: ChatMessage[]): LoadedMessage[] {
   const out: LoadedMessage[] = [];
   let turn = 0;
   let pendingAssistantIdx = -1;
@@ -576,7 +612,7 @@ function buildLoadedMessages(records: ChatMessage[]): LoadedMessage[] {
       }
     }
   }
-  return out;
+  return elideLoadedMessages(out);
 }
 
 function emitSettings(tab: Tab): void {

--- a/src/cli/ui/state/card-elision.ts
+++ b/src/cli/ui/state/card-elision.ts
@@ -1,0 +1,138 @@
+import type { Card, DiffCard, ReasoningCard, StreamingCard, ToolCard } from "./cards.js";
+
+/** Heavy card fields older than this many cards get stubbed so long sessions don't keep one-off file reads, reasoning streams, diff hunks, or large tool inputs pinned in the heap. */
+const RECENT_CARDS_WINDOW = 200;
+/** Don't bother eliding tiny payloads — the stub is itself ~150 chars and the savings aren't worth the lost context. */
+const MIN_ELIDE_OUTPUT_LENGTH = 4096;
+/** Marker for already-elided fields so we don't re-stub on every subsequent append. */
+const ELIDED_PREFIX = "[elided — older than the last ";
+
+function elidedStub(originalChars: number): string {
+  return `${ELIDED_PREFIX}${RECENT_CARDS_WINDOW} cards; ${originalChars.toLocaleString()} chars dropped to save memory. Full content is on disk in the session log.]`;
+}
+
+function serializedArgChars(args: unknown): number {
+  if (typeof args === "string") return args.length;
+  try {
+    return JSON.stringify(args ?? null).length;
+  } catch {
+    return 0;
+  }
+}
+
+function isElidedString(value: unknown): boolean {
+  return typeof value === "string" && value.startsWith(ELIDED_PREFIX);
+}
+
+function stubHeavyContent(c: Card): Card {
+  switch (c.kind) {
+    case "tool": {
+      const t = c as ToolCard;
+      let next: ToolCard | null = null;
+      const out = t.output;
+      if (typeof out === "string" && out.length > MIN_ELIDE_OUTPUT_LENGTH && !isElidedString(out)) {
+        next = { ...t, output: elidedStub(out.length) };
+      }
+      const args = (next ?? t).args;
+      const argsChars = serializedArgChars(args);
+      if (argsChars > MIN_ELIDE_OUTPUT_LENGTH && !isElidedString(args)) {
+        next = { ...(next ?? t), args: elidedStub(argsChars) };
+      }
+      return next ?? c;
+    }
+    case "reasoning": {
+      const r = c as ReasoningCard;
+      if (r.streaming) return c;
+      if (r.text.length <= MIN_ELIDE_OUTPUT_LENGTH) return c;
+      if (isElidedString(r.text)) return c;
+      return { ...r, text: elidedStub(r.text.length) };
+    }
+    case "streaming": {
+      const s = c as StreamingCard;
+      if (!s.done) return c;
+      if (s.text.length <= MIN_ELIDE_OUTPUT_LENGTH) return c;
+      if (isElidedString(s.text)) return c;
+      return { ...s, text: elidedStub(s.text.length) };
+    }
+    case "diff": {
+      const d = c as DiffCard;
+      if (d.hunks.length === 0) return c;
+      let totalChars = 0;
+      for (const h of d.hunks) for (const l of h.lines) totalChars += l.text.length;
+      if (totalChars <= MIN_ELIDE_OUTPUT_LENGTH) return c;
+      return { ...d, hunks: [] };
+    }
+    default:
+      return c;
+  }
+}
+
+/** True when card content is fixed at append time — never mutated, never grows. */
+function isImmutableCardKind(kind: Card["kind"]): boolean {
+  return (
+    kind === "user" ||
+    kind === "plan" ||
+    kind === "usage" ||
+    kind === "ctx" ||
+    kind === "doctor" ||
+    kind === "tip" ||
+    kind === "live" ||
+    kind === "memory" ||
+    kind === "search" ||
+    kind === "error" ||
+    kind === "warn" ||
+    kind === "compaction"
+  );
+}
+
+function canStillGrow(c: Card, assumeSettled: boolean): boolean {
+  if (
+    assumeSettled &&
+    (c.kind === "tool" || c.kind === "reasoning" || c.kind === "streaming" || c.kind === "diff")
+  ) {
+    return false;
+  }
+  switch (c.kind) {
+    case "tool":
+      return !(c as ToolCard).done;
+    case "reasoning":
+      return (c as ReasoningCard).streaming;
+    case "streaming":
+      return !(c as StreamingCard).done;
+    case "diff":
+      return false;
+    default:
+      return !isImmutableCardKind(c.kind);
+  }
+}
+
+export function elideFromCursor(
+  cards: ReadonlyArray<Card>,
+  cursor: number,
+  opts: { assumeSettled?: boolean } = {},
+): { cards: ReadonlyArray<Card>; cursor: number } {
+  if (cards.length < RECENT_CARDS_WINDOW) return { cards, cursor };
+  const cutoff = cards.length + 1 - RECENT_CARDS_WINDOW;
+  let next: Card[] | null = null;
+  let nextCursor = cursor;
+  for (let i = cursor; i < cutoff; i++) {
+    const c = cards[i]!;
+    const stubbed = stubHeavyContent(c);
+    if (stubbed !== c) {
+      if (next === null) next = cards.slice();
+      next[i] = stubbed;
+      nextCursor = i + 1;
+      continue;
+    }
+    if (!canStillGrow(c, opts.assumeSettled === true)) {
+      nextCursor = i + 1;
+      continue;
+    }
+    break;
+  }
+  return { cards: next ?? cards, cursor: nextCursor };
+}
+
+export function elideHydratedCards(cards: ReadonlyArray<Card>): ReadonlyArray<Card> {
+  return elideFromCursor(cards, 0, { assumeSettled: true }).cards;
+}

--- a/src/cli/ui/state/hydrate.ts
+++ b/src/cli/ui/state/hydrate.ts
@@ -1,6 +1,7 @@
 import { isCompactionSummary, stripCompactionMarker } from "@reasonix/core-utils";
 import type { ChatMessage } from "../../../types.js";
 import { extractToolExitCode } from "../tool-summary.js";
+import { elideHydratedCards } from "./card-elision.js";
 import type { Card, ToolCard } from "./cards.js";
 
 /** Rebuild cards from a persisted ChatMessage[] so resumed sessions render their history. */
@@ -84,5 +85,5 @@ export function hydrateCardsFromMessages(messages: ReadonlyArray<ChatMessage>): 
     }
   }
 
-  return cards;
+  return [...elideHydratedCards(cards)];
 }

--- a/src/cli/ui/state/reducer.ts
+++ b/src/cli/ui/state/reducer.ts
@@ -1,4 +1,5 @@
 import { extractToolExitCode } from "../tool-summary.js";
+import { elideFromCursor } from "./card-elision.js";
 import type {
   Card,
   CardId,
@@ -337,97 +338,6 @@ export function reduce(state: AgentState, event: AgentEvent): AgentState {
         elapsedMs: event.elapsedMs,
       });
   }
-}
-
-/** Heavy card fields older than this many cards get stubbed so a 7-hour session doesn't drag GBs of one-off file reads / reasoning streams / diff hunks through the heap (issue #1031). */
-const RECENT_CARDS_WINDOW = 200;
-/** Don't bother eliding tiny payloads — the stub is itself ~150 chars and the savings aren't worth the lost context. */
-const MIN_ELIDE_OUTPUT_LENGTH = 4096;
-/** Marker for already-elided fields so we don't re-stub on every subsequent append. */
-const ELIDED_TOOL_OUTPUT_PREFIX = "[elided — older than the last ";
-
-function elidedStub(originalChars: number): string {
-  return `${ELIDED_TOOL_OUTPUT_PREFIX}${RECENT_CARDS_WINDOW} cards; ${originalChars.toLocaleString()} chars dropped to save memory. Full output is on disk in the session log.]`;
-}
-
-function stubHeavyContent(c: Card): Card {
-  switch (c.kind) {
-    case "tool": {
-      const out = (c as ToolCard).output;
-      if (typeof out !== "string") return c;
-      if (out.length <= MIN_ELIDE_OUTPUT_LENGTH) return c;
-      if (out.startsWith(ELIDED_TOOL_OUTPUT_PREFIX)) return c;
-      return { ...(c as ToolCard), output: elidedStub(out.length) };
-    }
-    case "reasoning": {
-      const r = c as ReasoningCard;
-      if (r.streaming) return c;
-      if (r.text.length <= MIN_ELIDE_OUTPUT_LENGTH) return c;
-      if (r.text.startsWith(ELIDED_TOOL_OUTPUT_PREFIX)) return c;
-      return { ...r, text: elidedStub(r.text.length) };
-    }
-    case "streaming": {
-      const s = c as StreamingCard;
-      if (!s.done) return c;
-      if (s.text.length <= MIN_ELIDE_OUTPUT_LENGTH) return c;
-      if (s.text.startsWith(ELIDED_TOOL_OUTPUT_PREFIX)) return c;
-      return { ...s, text: elidedStub(s.text.length) };
-    }
-    case "diff": {
-      if (c.hunks.length === 0) return c;
-      let totalChars = 0;
-      for (const h of c.hunks) for (const l of h.lines) totalChars += l.text.length;
-      if (totalChars <= MIN_ELIDE_OUTPUT_LENGTH) return c;
-      return { ...c, hunks: [] };
-    }
-    default:
-      return c;
-  }
-}
-
-/** True when card content is fixed at append time — never mutated, never grows. */
-function isImmutableCardKind(kind: Card["kind"]): boolean {
-  return (
-    kind === "user" ||
-    kind === "plan" ||
-    kind === "usage" ||
-    kind === "ctx" ||
-    kind === "doctor" ||
-    kind === "tip" ||
-    kind === "live" ||
-    kind === "memory" ||
-    kind === "search" ||
-    kind === "error" ||
-    kind === "warn" ||
-    kind === "compaction"
-  );
-}
-
-function elideFromCursor(
-  cards: ReadonlyArray<Card>,
-  cursor: number,
-): { cards: ReadonlyArray<Card>; cursor: number } {
-  if (cards.length < RECENT_CARDS_WINDOW) return { cards, cursor };
-  const cutoff = cards.length + 1 - RECENT_CARDS_WINDOW;
-  let next: Card[] | null = null;
-  let nextCursor = cursor;
-  for (let i = cursor; i < cutoff; i++) {
-    const c = cards[i]!;
-    const stubbed = stubHeavyContent(c);
-    if (stubbed !== c) {
-      if (next === null) next = cards.slice();
-      next[i] = stubbed;
-      nextCursor = i + 1;
-      continue;
-    }
-    if (isImmutableCardKind(c.kind)) {
-      nextCursor = i + 1;
-      continue;
-    }
-    // Card may still grow into stub-eligible size — leave cursor here, recheck next append.
-    break;
-  }
-  return { cards: next ?? cards, cursor: nextCursor };
 }
 
 function appendCard(state: AgentState, card: Card): AgentState {

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -113,6 +113,13 @@ export interface LoopAbortOptions {
   discardCurrentTurn?: boolean;
 }
 
+function shrinkMessageForRetention(message: ChatMessage): ChatMessage {
+  if (message.role !== "assistant" || !Array.isArray(message.tool_calls)) return message;
+  return (
+    shrinkOversizedToolCallArgsByTokens([message], DEFAULT_MAX_RESULT_TOKENS).messages[0] ?? message
+  );
+}
+
 export class CacheFirstLoop {
   readonly client: DeepSeekClient;
   readonly prefix: ImmutablePrefix;
@@ -258,7 +265,7 @@ export class CacheFirstLoop {
         }
         if (healedCount > 0) {
           process.stderr.write(
-            `▸ session "${this.sessionName}": healed ${healedCount} entr${healedCount === 1 ? "y" : "ies"}${tokensSaved > 0 ? ` (shrunk ${tokensSaved.toLocaleString()} tokens of oversized tool output)` : " (dropped dangling tool_calls tail)"}. Rewrote session file.\n`,
+            `▸ session "${this.sessionName}": healed ${healedCount} entr${healedCount === 1 ? "y" : "ies"}${tokensSaved > 0 ? ` (shrunk ${tokensSaved.toLocaleString()} tokens of oversized tool output/arguments)` : " (dropped dangling tool_calls tail)"}. Rewrote session file.\n`,
           );
         }
       }
@@ -296,10 +303,11 @@ export class CacheFirstLoop {
   }
 
   appendAndPersist(message: ChatMessage): void {
-    this.log.append(message);
+    const retained = shrinkMessageForRetention(message);
+    this.log.append(retained);
     if (this.sessionName) {
       try {
-        appendSessionMessage(this.sessionName, message);
+        appendSessionMessage(this.sessionName, retained);
       } catch {
         /* disk full or permission denied shouldn't kill the chat */
       }
@@ -308,11 +316,12 @@ export class CacheFirstLoop {
 
   /** Swap the just-appended assistant entry — used by self-correction to restore the original tool_calls without dropping reasoning_content. */
   private replaceTailAssistantMessage(message: ChatMessage): void {
+    const retained = shrinkMessageForRetention(message);
     const entries = this.log.entries;
     const tail = entries[entries.length - 1];
     if (!tail || tail.role !== "assistant") return;
     const kept = entries.slice(0, -1);
-    kept.push(message);
+    kept.push(retained);
     this.log.compactInPlace(kept);
     if (this.sessionName) {
       try {
@@ -508,8 +517,14 @@ export class CacheFirstLoop {
   private healActiveLogBeforeSend(): ChatMessage[] {
     const current = this.log.toMessages();
     const healed = healLoadedMessages(current, DEFAULT_MAX_RESULT_CHARS);
-    const pruned = stripDroppableReasoningContent(healed.messages);
-    if (healed.healedCount === 0 && pruned.prunedCount === 0) return current;
+    const argsShrunk = shrinkOversizedToolCallArgsByTokens(
+      healed.messages,
+      DEFAULT_MAX_RESULT_TOKENS,
+    );
+    const pruned = stripDroppableReasoningContent(argsShrunk.messages);
+    if (healed.healedCount === 0 && argsShrunk.healedCount === 0 && pruned.prunedCount === 0) {
+      return current;
+    }
     this.log.compactInPlace(pruned.messages);
     if (this.sessionName) {
       try {

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -29,6 +29,7 @@ import {
 } from "./loop/healing.js";
 import { hookWarnings, safeParseToolArgs } from "./loop/hook-events.js";
 import { buildAssistantMessage, buildSyntheticAssistantMessage } from "./loop/messages.js";
+import { stripDroppableReasoningContent } from "./loop/reasoning-retention.js";
 import {
   looksLikeCompleteJson,
   shrinkOversizedToolCallArgsByTokens,
@@ -225,9 +226,11 @@ export class CacheFirstLoop {
     if (this.sessionName) {
       const prior = loadSessionMessages(this.sessionName);
       const shrunk = healLoadedMessagesByTokens(prior, DEFAULT_MAX_RESULT_TOKENS);
-      // Thinking-mode sessions: API 400s if any historical assistant turn lacks reasoning_content.
+      // Thinking-mode sessions still need tool-call reasoning_content, while stale
+      // plain-turn reasoning can be dropped before it bloats long-session requests.
       const stamped = stampMissingReasoningForThinkingMode(shrunk.messages, this.model);
-      const messages = stamped.messages;
+      const pruned = stripDroppableReasoningContent(stamped.messages);
+      const messages = pruned.messages;
       const healedCount = shrunk.healedCount + stamped.stampedCount;
       const tokensSaved = shrunk.tokensSaved;
       for (const msg of messages) this.log.append(msg);
@@ -246,16 +249,18 @@ export class CacheFirstLoop {
           lastPromptTokens: meta.lastPromptTokens,
         });
       }
-      if (healedCount > 0) {
+      if (healedCount > 0 || pruned.prunedCount > 0) {
         // Persist healed log so the same break isn't re-noticed every restart.
         try {
           rewriteSession(this.sessionName, messages);
         } catch {
           /* disk full / perms — skip, in-memory heal still applies */
         }
-        process.stderr.write(
-          `▸ session "${this.sessionName}": healed ${healedCount} entr${healedCount === 1 ? "y" : "ies"}${tokensSaved > 0 ? ` (shrunk ${tokensSaved.toLocaleString()} tokens of oversized tool output)` : " (dropped dangling tool_calls tail)"}. Rewrote session file.\n`,
-        );
+        if (healedCount > 0) {
+          process.stderr.write(
+            `▸ session "${this.sessionName}": healed ${healedCount} entr${healedCount === 1 ? "y" : "ies"}${tokensSaved > 0 ? ` (shrunk ${tokensSaved.toLocaleString()} tokens of oversized tool output)` : " (dropped dangling tool_calls tail)"}. Rewrote session file.\n`,
+          );
+        }
       }
     } else {
       this.resumedMessageCount = 0;
@@ -503,16 +508,17 @@ export class CacheFirstLoop {
   private healActiveLogBeforeSend(): ChatMessage[] {
     const current = this.log.toMessages();
     const healed = healLoadedMessages(current, DEFAULT_MAX_RESULT_CHARS);
-    if (healed.healedCount === 0) return current;
-    this.log.compactInPlace(healed.messages);
+    const pruned = stripDroppableReasoningContent(healed.messages);
+    if (healed.healedCount === 0 && pruned.prunedCount === 0) return current;
+    this.log.compactInPlace(pruned.messages);
     if (this.sessionName) {
       try {
-        rewriteSession(this.sessionName, healed.messages);
+        rewriteSession(this.sessionName, pruned.messages);
       } catch {
         /* disk issue shouldn't block the in-memory heal */
       }
     }
-    return healed.messages;
+    return pruned.messages;
   }
 
   abort(opts: LoopAbortOptions = {}): void {
@@ -678,7 +684,9 @@ export class CacheFirstLoop {
           role: "status",
           content: t("loop.turnStartFoldStatus"),
         };
-        const result = await this.context.fold(this.model, { requireTailBoundary: true });
+        const result = await this.context.fold(this.model, {
+          requireTailBoundary: true,
+        });
         if (result.folded) {
           this._foldedThisTurn = true;
           yield {

--- a/src/loop/healing.ts
+++ b/src/loop/healing.ts
@@ -1,5 +1,9 @@
 import type { ChatMessage, ToolCall } from "../types.js";
-import { shrinkOversizedToolResults, shrinkOversizedToolResultsByTokens } from "./shrink.js";
+import {
+  shrinkOversizedToolCallArgsByTokens,
+  shrinkOversizedToolResults,
+  shrinkOversizedToolResultsByTokens,
+} from "./shrink.js";
 import { isThinkingModeModel } from "./thinking.js";
 
 let _stampSeq = 0;
@@ -98,11 +102,16 @@ export function healLoadedMessagesByTokens(
 } {
   const shrunk = shrinkOversizedToolResultsByTokens(messages, maxTokens);
   const paired = fixToolCallPairing(shrunk.messages);
-  const healedCount = shrunk.healedCount + paired.droppedAssistantCalls + paired.droppedStrayTools;
+  const argsShrunk = shrinkOversizedToolCallArgsByTokens(paired.messages, maxTokens);
+  const healedCount =
+    shrunk.healedCount +
+    argsShrunk.healedCount +
+    paired.droppedAssistantCalls +
+    paired.droppedStrayTools;
   return {
-    messages: paired.messages,
+    messages: argsShrunk.messages,
     healedCount,
-    tokensSaved: shrunk.tokensSaved,
-    charsSaved: shrunk.charsSaved,
+    tokensSaved: shrunk.tokensSaved + argsShrunk.tokensSaved,
+    charsSaved: shrunk.charsSaved + argsShrunk.charsSaved,
   };
 }

--- a/src/loop/reasoning-retention.ts
+++ b/src/loop/reasoning-retention.ts
@@ -1,0 +1,51 @@
+import type { ChatMessage } from "../types.js";
+
+export interface ReasoningPruneResult {
+  messages: ChatMessage[];
+  prunedCount: number;
+  charsDropped: number;
+}
+
+function hasToolCalls(msg: ChatMessage): boolean {
+  return Array.isArray(msg.tool_calls) && msg.tool_calls.length > 0;
+}
+
+/** Keep tool-call reasoning for DeepSeek validation; drop stale plain-turn reasoning. */
+export function stripDroppableReasoningContent(messages: ChatMessage[]): ReasoningPruneResult {
+  let lastUser = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i]!.role === "user") {
+      lastUser = i;
+      break;
+    }
+  }
+  if (lastUser < 0) {
+    return { messages, prunedCount: 0, charsDropped: 0 };
+  }
+
+  let next: ChatMessage[] | null = null;
+  let prunedCount = 0;
+  let charsDropped = 0;
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i]!;
+    if (
+      msg.role !== "assistant" ||
+      i > lastUser ||
+      hasToolCalls(msg) ||
+      !Object.hasOwn(msg, "reasoning_content")
+    ) {
+      continue;
+    }
+    if (next === null) next = messages.slice();
+    const { reasoning_content: dropped, ...replacement } = msg;
+    if (typeof dropped === "string") charsDropped += dropped.length;
+    next[i] = replacement;
+    prunedCount += 1;
+  }
+
+  return {
+    messages: next ?? messages,
+    prunedCount,
+    charsDropped,
+  };
+}

--- a/tests/cards-memory-budget.test.ts
+++ b/tests/cards-memory-budget.test.ts
@@ -185,6 +185,33 @@ describe("cards memory budget end-to-end (issue #1031)", () => {
     expect(ratio).toBeLessThan(1.5);
   });
 
+  it("elides old tool arguments, not just old tool output", () => {
+    let state = initialState(session);
+    const turns = 400;
+    const argPayload = "input payload\n".repeat(2000);
+    const rawArgsBytes = bytesUtf8(JSON.stringify({ path: "big.txt", content: argPayload }));
+
+    for (let i = 0; i < turns; i++) {
+      const id = `tool-arg-${i}`;
+      state = reduce(state, {
+        type: "tool.start",
+        id,
+        name: "write_file",
+        args: { path: "big.txt", content: argPayload },
+      });
+      state = reduce(state, {
+        type: "tool.end",
+        id,
+        output: "ok",
+        elapsedMs: 1,
+      });
+    }
+
+    const r = measureCards(state.cards);
+    const retainedArgBytes = r.byField.get("tool.args") ?? 0;
+    expect(retainedArgBytes).toBeLessThan(rawArgsBytes * turns * 0.6);
+  });
+
   it("actual V8 heap delta on a long session stays under 100 MB (smoke check)", () => {
     if (typeof globalThis.gc !== "function") {
       console.log("(skipped — run with NODE_OPTIONS=--expose-gc for real heap delta)");

--- a/tests/desktop-session-load.test.ts
+++ b/tests/desktop-session-load.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import * as desktopCommand from "../src/cli/commands/desktop.js";
+import type { ChatMessage } from "../src/types.js";
+
+type BuildLoadedMessages = (records: ChatMessage[]) => Array<{
+  kind: "assistant" | "user";
+  segments?: Array<{ kind: string; text?: string; args?: string; result?: string }>;
+}>;
+
+describe("desktop session loading", () => {
+  it("elides old heavy assistant segments before sending $session_loaded", () => {
+    const buildLoadedMessages = (desktopCommand as { buildLoadedMessages?: BuildLoadedMessages })
+      .buildLoadedMessages;
+    expect(typeof buildLoadedMessages).toBe("function");
+
+    const huge = "desktop retained field\n".repeat(900);
+    const records: ChatMessage[] = [];
+    for (let i = 0; i < 260; i++) {
+      records.push({
+        role: "assistant",
+        content: huge,
+        reasoning_content: huge,
+        tool_calls: [
+          {
+            id: `c-${i}`,
+            type: "function",
+            function: {
+              name: "write_file",
+              arguments: JSON.stringify({ path: `file-${i}.txt`, content: huge }),
+            },
+          },
+        ],
+      });
+      records.push({ role: "tool", tool_call_id: `c-${i}`, content: huge });
+    }
+
+    const loaded = buildLoadedMessages!(records);
+    const firstAssistant = loaded.find((m) => m.kind === "assistant");
+    expect(firstAssistant).toBeDefined();
+    const reasoning = firstAssistant!.segments!.find((s) => s.kind === "reasoning");
+    const text = firstAssistant!.segments!.find((s) => s.kind === "text");
+    const tool = firstAssistant!.segments!.find((s) => s.kind === "tool");
+
+    expect(reasoning?.text?.length).toBeLessThan(huge.length / 10);
+    expect(text?.text?.length).toBeLessThan(huge.length / 10);
+    expect(tool?.args?.length).toBeLessThan(huge.length / 10);
+    expect(tool?.result?.length).toBeLessThan(huge.length / 10);
+  });
+});

--- a/tests/hydrate-cards.test.ts
+++ b/tests/hydrate-cards.test.ts
@@ -127,6 +127,42 @@ describe("hydrateCardsFromMessages", () => {
     expect(cards[0]).toMatchObject({ kind: "tool", args: "not-json", done: false });
   });
 
+  it("starts resumed long sessions with old heavy card fields already elided", () => {
+    const huge = "large retained field\n".repeat(800);
+    const msgs: ChatMessage[] = [];
+    for (let i = 0; i < 260; i++) {
+      msgs.push({
+        role: "assistant",
+        content: `answer ${i}`,
+        reasoning_content: huge,
+        tool_calls: [
+          {
+            id: `call-${i}`,
+            type: "function",
+            function: {
+              name: "write_file",
+              arguments: JSON.stringify({ path: `file-${i}.txt`, content: huge }),
+            },
+          },
+        ],
+      });
+      msgs.push({ role: "tool", tool_call_id: `call-${i}`, content: huge });
+    }
+
+    const cards = hydrateCardsFromMessages(msgs);
+    const oldReasoning = cards.find((c) => c.kind === "reasoning");
+    const oldTool = cards.find((c) => c.kind === "tool");
+
+    expect(oldReasoning).toMatchObject({ kind: "reasoning" });
+    expect(oldTool).toMatchObject({ kind: "tool" });
+    if (oldReasoning?.kind !== "reasoning" || oldTool?.kind !== "tool") {
+      throw new Error("expected old heavy cards");
+    }
+    expect(oldReasoning.text.length).toBeLessThan(huge.length / 10);
+    expect(oldTool.output.length).toBeLessThan(huge.length / 10);
+    expect(JSON.stringify(oldTool.args).length).toBeLessThan(huge.length / 10);
+  });
+
   it("produces unique card ids across the hydrated batch", () => {
     const msgs: ChatMessage[] = [
       { role: "user", content: "one" },

--- a/tests/loop-error.test.ts
+++ b/tests/loop-error.test.ts
@@ -2,7 +2,12 @@
 
 import { afterEach, describe, expect, it } from "vitest";
 import { setLanguageRuntime } from "../src/i18n/index.js";
-import { formatLoopError, healLoadedMessages, stripHallucinatedToolMarkup } from "../src/loop.js";
+import {
+  formatLoopError,
+  healLoadedMessages,
+  healLoadedMessagesByTokens,
+  stripHallucinatedToolMarkup,
+} from "../src/loop.js";
 import type { ChatMessage } from "../src/types.js";
 
 describe("formatLoopError", () => {
@@ -148,6 +153,37 @@ describe("formatLoopError", () => {
     });
     expect(out).toMatch(/DeepSeek-side problem/);
     expect(out).toContain("status.deepseek.com");
+  });
+});
+
+describe("healLoadedMessagesByTokens", () => {
+  it("shrinks oversized paired tool-call args when loading an old session", () => {
+    const bigArgs = JSON.stringify({
+      path: "src/large.ts",
+      content: Array.from({ length: 1200 }, (_, i) => `line ${i}: replacement`).join("\n"),
+    });
+    const messages: ChatMessage[] = [
+      {
+        role: "assistant",
+        content: null,
+        tool_calls: [
+          { id: "c1", type: "function", function: { name: "write_blob", arguments: bigArgs } },
+        ],
+      },
+      { role: "tool", tool_call_id: "c1", content: "ok" },
+    ];
+
+    const healed = healLoadedMessagesByTokens(messages, 500);
+
+    expect(healed.healedCount).toBe(1);
+    expect(healed.tokensSaved).toBeGreaterThan(0);
+    const assistant = healed.messages[0];
+    if (assistant?.role !== "assistant" || !assistant.tool_calls) {
+      throw new Error("assistant tool call missing");
+    }
+    const savedArgs = assistant.tool_calls[0]!.function.arguments;
+    expect(savedArgs.length).toBeLessThan(bigArgs.length / 5);
+    expect(JSON.parse(savedArgs).content).toMatch(/shrunk/);
   });
 });
 

--- a/tests/loop-r1-reasoning.test.ts
+++ b/tests/loop-r1-reasoning.test.ts
@@ -1,4 +1,4 @@
-/** R1 thinking-mode contract — `reasoning_content` must round-trip on the next request or DeepSeek 400s. */
+/** R1 thinking-mode contract — tool-call reasoning_content must round-trip; stale plain reasoning must age out. */
 
 import { describe, expect, it, vi } from "vitest";
 import { DeepSeekClient } from "../src/client.js";
@@ -189,16 +189,13 @@ describe("R1 reasoning_content round-trip", () => {
     expect(assistantWithCalls?.reasoning_content).toBe("I should call noop to check something.");
   });
 
-  it("also preserves reasoning_content on plain-text reasoner turns", async () => {
-    // 0.5.18 regression: R1 requires reasoning_content on ANY
-    // assistant message the model produced in thinking mode, not just
-    // ones with tool_calls. 0.5.15 scoped the fix too narrowly and a
-    // plan-approval flow (submit_plan → "plan submitted" plain-text
-    // turn → approval) kept 400ing on the follow-up request.
+  it("omits stale reasoning_content from plain-text turns on the next user request", async () => {
+    // DeepSeek V4 ignores reasoning_content from prior no-tool turns.
+    // Carrying it forward only bloats long-session request bodies.
     const { fetch: fakeFetch, bodies } = capturingFetch([
       {
         content: "a plain answer",
-        reasoning_content: "reasoning attached to a plain-text turn",
+        reasoning_content: "reasoning attached to a plain-text turn".repeat(200),
       },
       { content: "follow-up" },
     ]);
@@ -220,7 +217,57 @@ describe("R1 reasoning_content round-trip", () => {
     const turn2Messages = bodies[1]!.messages;
     const assistant = turn2Messages.find((m) => m.role === "assistant");
     expect(assistant).toBeDefined();
-    expect(assistant?.reasoning_content).toBe("reasoning attached to a plain-text turn");
+    expect(Object.hasOwn(assistant!, "reasoning_content")).toBe(false);
+    expect(JSON.stringify(turn2Messages)).not.toContain("reasoning attached to a plain-text turn");
+  });
+
+  it("preserves tool-call reasoning_content across later user turns", async () => {
+    const tools = new ToolRegistry();
+    tools.register({
+      name: "noop",
+      readOnly: true,
+      fn: () => "ok",
+    });
+    const { fetch: fakeFetch, bodies } = capturingFetch([
+      {
+        content: "",
+        reasoning_content: "tool-call reasoning must stay available",
+        tool_calls: [
+          {
+            id: "call_1",
+            type: "function",
+            function: { name: "noop", arguments: "{}" },
+          },
+        ],
+      },
+      { content: "done", reasoning_content: "plain final reasoning can age out" },
+      { content: "follow-up" },
+    ]);
+    const client = new DeepSeekClient({ apiKey: "sk-test", fetch: fakeFetch });
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s", toolSpecs: tools.specs() }),
+      tools,
+      model: "deepseek-v4-pro",
+      stream: false,
+    });
+
+    for await (const _ev of loop.step("please noop")) {
+      /* drain */
+    }
+    for await (const _ev of loop.step("next")) {
+      /* drain */
+    }
+
+    const turn2Messages = bodies[2]!.messages;
+    const assistantWithCalls = turn2Messages.find(
+      (m) => m.role === "assistant" && (m.tool_calls?.length ?? 0) > 0,
+    );
+    const finalAssistant = turn2Messages
+      .filter((m) => m.role === "assistant" && (m.tool_calls?.length ?? 0) === 0)
+      .at(-1);
+    expect(assistantWithCalls?.reasoning_content).toBe("tool-call reasoning must stay available");
+    expect(Object.hasOwn(finalAssistant!, "reasoning_content")).toBe(false);
   });
 
   it("stamps empty reasoning_content on a thinking-mode turn that returned null reasoning", async () => {
@@ -251,10 +298,8 @@ describe("R1 reasoning_content round-trip", () => {
     const turn2Messages = bodies[1]!.messages;
     const assistant = turn2Messages.find((m) => m.role === "assistant");
     expect(assistant).toBeDefined();
-    // Field must be PRESENT (even empty) — presence is what satisfies
-    // DeepSeek's thinking-mode validator.
-    expect(Object.hasOwn(assistant!, "reasoning_content")).toBe(true);
-    expect(assistant?.reasoning_content).toBe("");
+    // Plain assistant turns do not need stale reasoning in later user requests.
+    expect(Object.hasOwn(assistant!, "reasoning_content")).toBe(false);
   });
 
   it("does NOT stamp reasoning_content on a deepseek-chat turn that returned null", async () => {
@@ -284,12 +329,10 @@ describe("R1 reasoning_content round-trip", () => {
     expect(Object.hasOwn(assistant!, "reasoning_content")).toBe(false);
   });
 
-  it("preserves reasoning_content on deepseek-chat when V4 returns non-empty content", async () => {
-    // V4-era deepseek-chat returns reasoning_content even with thinking
-    // disabled. Whitelist by model name was too narrow — must keep the
-    // field whenever the producer emitted any. Caught by tau-bench when
-    // 24/24 reasonix runs failed with "reasoning_content must be passed
-    // back to the API."
+  it("omits stale plain deepseek-chat reasoning_content on the next user request", async () => {
+    // V4-era deepseek-chat can surface reasoning_content even with thinking
+    // disabled. Once the turn is a plain historical assistant message,
+    // carrying that body forward just grows the next request.
     const { fetch: fakeFetch, bodies } = capturingFetch([
       { content: "ok", reasoning_content: "v4-chat reasoning leaked" },
       { content: "bye" },
@@ -309,7 +352,7 @@ describe("R1 reasoning_content round-trip", () => {
     }
     const turn2Messages = bodies[1]!.messages;
     const assistant = turn2Messages.find((m) => m.role === "assistant");
-    expect(assistant?.reasoning_content).toBe("v4-chat reasoning leaked");
+    expect(Object.hasOwn(assistant!, "reasoning_content")).toBe(false);
   });
 
   it("pins thinking=enabled for v4-pro and sends the configured reasoning_effort", async () => {

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -841,6 +841,62 @@ describe("CacheFirstLoop (non-streaming)", () => {
     expect(content).toMatch(/truncated/);
   });
 
+  it("shrinks retained tool-call args without starving the tool dispatch", async () => {
+    const reg = new ToolRegistry();
+    const hugeContent = Array.from({ length: 9000 }, (_, i) => `line ${i}: payload ${i}`).join(
+      "\n",
+    );
+    let receivedChars = 0;
+    reg.register<{ path: string; content: string }, string>({
+      name: "write_blob",
+      description: "captures a large write payload",
+      parameters: {
+        type: "object",
+        properties: {
+          path: { type: "string" },
+          content: { type: "string" },
+        },
+        required: ["path", "content"],
+      },
+      fn: async (args) => {
+        receivedChars = args.content.length;
+        return `received ${receivedChars}`;
+      },
+    });
+    const rawArgs = JSON.stringify({ path: "big.txt", content: hugeContent });
+    const responses: FakeResponseShape[] = [
+      {
+        content: "",
+        tool_calls: [
+          { id: "c1", type: "function", function: { name: "write_blob", arguments: rawArgs } },
+        ],
+      },
+      { content: "done." },
+    ];
+    const client = makeClient(responses);
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s", toolSpecs: reg.specs() }),
+      tools: reg,
+      stream: false,
+    });
+
+    for await (const _ev of loop.step("go")) {
+      /* drain */
+    }
+
+    expect(receivedChars).toBe(hugeContent.length);
+    const assistantEntry = loop.log
+      .toMessages()
+      .find((m) => m.role === "assistant" && (m.tool_calls?.length ?? 0) > 0);
+    expect(assistantEntry).toBeDefined();
+    const savedArgs = assistantEntry!.tool_calls![0]!.function.arguments;
+    expect(savedArgs.length).toBeLessThan(rawArgs.length / 10);
+    const parsed = JSON.parse(savedArgs) as { path: string; content: string };
+    expect(parsed.path).toBe("big.txt");
+    expect(parsed.content).toMatch(/shrunk/);
+  });
+
   it("buildMessages strips a dangling assistant-with-tool_calls tail — defensive against 'insufficient tool messages' 400", async () => {
     // Craft a log where the last entry is an assistant message with
     // tool_calls but no matching tool responses. This is the shape


### PR DESCRIPTION
## What

Prunes historical reasoning_content from plain assistant turns once a later user turn exists, while preserving reasoning_content on assistant tool-call turns.

Also shrinks retained oversized tool-call arguments after dispatch/load and elides old heavy tool arguments/results/reasoning in TUI and desktop session-restore snapshots.

## Why

Fixes #1790. Long v4-pro sessions can carry stale plain-turn reasoning and large tool/display payloads across follow-up requests and restored sessions. DeepSeek V4 accepts dropping reasoning_content from historical no-tool assistant turns, while tool-call reasoning_content is still kept for tool-call turns.

This intentionally keeps the existing ratio-based fold policy; the removed 250k local fold threshold is not part of this PR.

## How to verify

npm run verify

## Checklist

- [x] npm run verify passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No Co-Authored-By: Claude trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to CHANGELOG.md — release notes are maintainer-written at release time