### PR TITLE
fix(stdin): refuse ESC-less CSI recovery when followed by typed text

### DIFF
--- a/src/cli/ui/stdin-reader.ts
+++ b/src/cli/ui/stdin-reader.ts
@@ -102,10 +102,19 @@ function tryEscapelessCsi(chunk: string, i: number): { advance: number; ev: KeyE
   for (const entry of CSI_TAIL_MAP) {
     const candidate = `[${entry.tail}`;
     if (chunk.slice(i, i + candidate.length) === candidate) {
+      // Don't grab `[D` out of typed/pasted `[DEBUG]` — issue #1771.
+      const after = chunk[i + candidate.length];
+      if (after !== undefined && !isCsiContinuationByte(after)) return null;
       return { advance: candidate.length, ev: entry.ev };
     }
   }
   return null;
+}
+
+function isCsiContinuationByte(ch: string): boolean {
+  if (ch === "[" || ch === "\x1b") return true;
+  const code = ch.charCodeAt(0);
+  return code < 0x20 || code === 0x7f;
 }
 
 /** `[<btn;col;row[Mm]` — SGR mouse report body (without leading ESC). */

--- a/tests/stdin-reader.test.ts
+++ b/tests/stdin-reader.test.ts
@@ -259,10 +259,25 @@ describe("StdinReader — bracketed paste", () => {
     expect(events).toEqual([{ input: "ab" }, { input: "stuff", paste: true }]);
   });
 
-  it("printable runs do not eat a following ESC-less arrow tail", () => {
+  it("ESC-less arrow tail followed by another CSI prefix still recovers", () => {
     const { reader, events } = setup();
-    reader.feed("ab[Ccd");
-    expect(events).toEqual([{ input: "ab" }, { input: "", rightArrow: true }, { input: "cd" }]);
+    reader.feed("[C[A");
+    expect(events).toEqual([
+      { input: "", rightArrow: true },
+      { input: "", upArrow: true },
+    ]);
+  });
+
+  it("typed `[DEBUG]` is not misread as left-arrow + EBUG] (#1771)", () => {
+    const { reader, events } = setup();
+    reader.feed("[DEBUG]");
+    expect(events).toEqual([{ input: "[DEBUG]" }]);
+  });
+
+  it("typed `[ABC]`-shaped tokens stay intact (no upArrow split)", () => {
+    const { reader, events } = setup();
+    reader.feed("[Aabc");
+    expect(events).toEqual([{ input: "[Aabc" }]);
   });
 });
 


### PR DESCRIPTION
## Summary

- Typing or pasting tokens like `[DEBUG]` was being parsed as a stripped left-arrow (`[D`) plus the leftover text `EBUG]`, truncating the input and nudging the cursor one cell left.
- `tryEscapelessCsi` now only recovers a stripped CSI tail when the matched sequence ends the chunk or chains into another control byte. A printable letter/digit after the tail marks the input as user text.

## Test plan

- [x] `vitest run tests/stdin-reader.test.ts` — 66 tests pass, includes new `[DEBUG]` and `[Aabc` cases plus a regression for chained `[C[A`.
- [x] Full `vitest run` — 3720 pass / 12 skipped.
- [x] `biome check` clean, `tsc --noEmit` clean.

Closes #1771