### PR TITLE
fix(tui): demote stuck `running` plan step on turn end

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -3464,6 +3464,7 @@ function AppInner({
           translator.abort();
         }
         clearToolProgressDisplay();
+        agentStore.dispatch({ type: "plan.idle" });
         setSummary(loop.stats.summary());
         busyRef.current = false;
         setBusy(false);

--- a/src/cli/ui/state/events.ts
+++ b/src/cli/ui/state/events.ts
@@ -239,6 +239,10 @@ const planDrop = z.object({
   type: z.literal("plan.drop"),
 });
 
+const planIdle = z.object({
+  type: z.literal("plan.idle"),
+});
+
 const usageShow = z.object({
   type: z.literal("usage.show"),
   id: cardId,
@@ -365,6 +369,7 @@ export const AgentEventSchema = z.discriminatedUnion("type", [
   planShow,
   planStepComplete,
   planDrop,
+  planIdle,
   ctxShow,
   doctorShow,
   usageShow,

--- a/src/cli/ui/state/reducer.ts
+++ b/src/cli/ui/state/reducer.ts
@@ -298,6 +298,26 @@ export function reduce(state: AgentState, event: AgentEvent): AgentState {
       return changed ? { ...state, cards } : state;
     }
 
+    case "plan.idle": {
+      // Turn ended — nothing is actually executing, so a "running" step on the
+      // live plan is a lie. Demote it back to "queued"; the next mark_step_complete
+      // will re-advance the running marker via advanceActivePlanSteps. Issue #1784.
+      let changed = false;
+      const cards = state.cards.map((c) => {
+        if (c.kind !== "plan" || c.variant !== "active") return c;
+        let stepChanged = false;
+        const next = c.steps.map((s) => {
+          if (s.status !== "running") return s;
+          stepChanged = true;
+          return { ...s, status: "queued" as const };
+        });
+        if (!stepChanged) return c;
+        changed = true;
+        return { ...c, steps: next };
+      });
+      return changed ? { ...state, cards } : state;
+    }
+
     case "ctx.show":
       return appendCard(state, {
         kind: "ctx",

--- a/tests/ui-reducer.test.ts
+++ b/tests/ui-reducer.test.ts
@@ -245,6 +245,50 @@ describe("ui reducer", () => {
     ]);
   });
 
+  it("plan.idle demotes a stuck `running` step back to `queued` when the turn ends (#1784)", () => {
+    const shown = run([
+      {
+        type: "plan.show",
+        id: "p1",
+        title: "Plan",
+        variant: "active",
+        steps: [
+          { id: "step-1", title: "One", status: "queued" },
+          { id: "step-2", title: "Two", status: "queued" },
+        ],
+      },
+    ]);
+    const afterFirst = reduce(shown, { type: "plan.step.complete", stepId: "step-1" });
+    expect((afterFirst.cards[0] as PlanCard).steps.map((s) => s.status)).toEqual([
+      "done",
+      "running",
+    ]);
+
+    const idle = reduce(afterFirst, { type: "plan.idle" });
+    expect((idle.cards[0] as PlanCard).steps.map((s) => s.status)).toEqual(["done", "queued"]);
+
+    // Next turn marks step-2 done — the running marker advances normally.
+    const afterSecond = reduce(idle, { type: "plan.step.complete", stepId: "step-2" });
+    expect((afterSecond.cards[0] as PlanCard).steps.map((s) => s.status)).toEqual(["done", "done"]);
+  });
+
+  it("plan.idle leaves replay-variant plans untouched", () => {
+    const shown = run([
+      {
+        type: "plan.show",
+        id: "p1",
+        title: "Plan",
+        variant: "replay",
+        steps: [
+          { id: "step-1", title: "One", status: "running" },
+          { id: "step-2", title: "Two", status: "queued" },
+        ],
+      },
+    ]);
+    const idle = reduce(shown, { type: "plan.idle" });
+    expect(idle.cards[0]).toBe(shown.cards[0]);
+  });
+
   it("changes mode and accumulates session cost", () => {
     const s = run([
       { type: "mode.change", mode: "ask" },


### PR DESCRIPTION
## Summary

`advanceActivePlanSteps` marks the next non-settled step as `running` whenever a step completes — but nothing demotes it when the agent stops calling `mark_step_complete` partway through. The card then shows "step N in progress" indefinitely even though the turn has ended, with no way for the user to clear the lie.

This adds a new `plan.idle` reducer event dispatched from the App turn-end `finally` block. The reducer maps `running` → `queued` on active plans only; replay-variant plans (historical scrollback) are untouched. Multi-turn flows are unaffected — the next `mark_step_complete` re-advances the running marker via `advanceActivePlanSteps`.

## Test plan

- [x] `vitest run tests/ui-reducer.test.ts` — 48 pass, includes two new cases (demote + replay-variant no-op).
- [x] Full `vitest run` clean.
- [x] `biome check` + `tsc --noEmit` clean.

Closes #1784