### PR TITLE
fix(tui): preserve undo state in session context

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -204,6 +204,7 @@ import { listThemeNames } from "./theme/tokens.js";
 import { FG, type ThemeName } from "./theme/tokens.js";
 import { TickerProvider } from "./ticker.js";
 import { handleTurnInterrupt } from "./turn-interrupt.js";
+import { codeUndoContextMessage, codeUndoInfo } from "./undo-context.js";
 import { useCompletionPickers } from "./useCompletionPickers.js";
 import { useEditHistory } from "./useEditHistory.js";
 import { useSessionInfo } from "./useSessionInfo.js";
@@ -1890,7 +1891,9 @@ function AppInner({
       undoBanner
     ) {
       const out = codeUndo([]);
-      log.pushInfo(out);
+      const contextMessage = codeUndoContextMessage(out);
+      if (contextMessage) loop.appendAndPersist({ role: "system", content: contextMessage });
+      log.pushInfo(codeUndoInfo(out));
       return;
     }
     // Space toggles pause on the active undo countdown. Same gating as

--- a/src/cli/ui/slash/handlers/edits.ts
+++ b/src/cli/ui/slash/handlers/edits.ts
@@ -9,14 +9,20 @@ import {
 import type { EditMode } from "@/config.js";
 import { t } from "@/i18n/index.js";
 import { parseEditIndices } from "../../edit-history.js";
+import { codeUndoContextMessage, codeUndoInfo } from "../../undo-context.js";
 import type { SlashHandler } from "../dispatch.js";
 import { runGitCommit, stripOuterQuotes } from "../helpers.js";
 
-const undo: SlashHandler = (args, _loop, ctx) => {
+const undo: SlashHandler = (args, loop, ctx) => {
   if (!ctx.codeUndo) {
     return { info: t("handlers.edits.undoCodeOnly") };
   }
-  return { info: ctx.codeUndo(args) };
+  const result = ctx.codeUndo(args);
+  const contextMessage = codeUndoContextMessage(result);
+  if (contextMessage) {
+    loop.appendAndPersist({ role: "system", content: contextMessage });
+  }
+  return { info: codeUndoInfo(result) };
 };
 
 const history: SlashHandler = (_args, _loop, ctx) => {

--- a/src/cli/ui/slash/types.ts
+++ b/src/cli/ui/slash/types.ts
@@ -3,6 +3,7 @@ import type { EditMode } from "../../../config.js";
 import type { McpServerSummary } from "../../../mcp/summary.js";
 import type { JobRegistry } from "../../../tools/jobs.js";
 import type { PlanStep } from "../../../tools/plan.js";
+import type { CodeUndoOutput } from "../undo-context.js";
 
 export type { McpServerSummary } from "../../../mcp/summary.js";
 
@@ -63,7 +64,7 @@ export type PlanModeToggleSource = "slash";
 export interface SlashContext {
   configPath?: string;
   mcpSpecs?: string[];
-  codeUndo?: (args: readonly string[]) => string;
+  codeUndo?: (args: readonly string[]) => CodeUndoOutput;
   codeApply?: (indices?: readonly number[]) => string;
   codeDiscard?: (indices?: readonly number[]) => string;
   codeHistory?: () => string;

--- a/src/cli/ui/undo-context.ts
+++ b/src/cli/ui/undo-context.ts
@@ -1,0 +1,31 @@
+export interface UndoAppliedEvent {
+  batchId: number;
+  source: string;
+  paths: string[];
+}
+
+export interface CodeUndoResult {
+  info: string;
+  contextEvent?: UndoAppliedEvent;
+}
+
+export type CodeUndoOutput = string | CodeUndoResult;
+
+export function codeUndoInfo(result: CodeUndoOutput): string {
+  return typeof result === "string" ? result : result.info;
+}
+
+export function formatUndoContextMessage(event: UndoAppliedEvent): string {
+  const paths = event.paths.length === 1 ? event.paths[0] : event.paths.join(", ");
+  return [
+    "[Reasonix local state update: undo]",
+    `The user ran /undo and reverted edit batch #${event.batchId} (${event.source}).`,
+    `Reverted path(s): ${paths}.`,
+    "Treat earlier messages or tool results that described those edits as stale. Re-read the files before relying on their current contents.",
+  ].join("\n");
+}
+
+export function codeUndoContextMessage(result: CodeUndoOutput): string | undefined {
+  if (typeof result === "string" || !result.contextEvent) return undefined;
+  return formatUndoContextMessage(result.contextEvent);
+}

--- a/src/cli/ui/useEditHistory.ts
+++ b/src/cli/ui/useEditHistory.ts
@@ -13,6 +13,16 @@ import {
   formatUndoRows,
   isEntryFullyUndone,
 } from "./edit-history.js";
+import type { CodeUndoResult } from "./undo-context.js";
+
+export {
+  codeUndoContextMessage,
+  codeUndoInfo,
+  formatUndoContextMessage,
+  type CodeUndoOutput,
+  type CodeUndoResult,
+  type UndoAppliedEvent,
+} from "./undo-context.js";
 
 export interface UndoBannerState {
   results: ApplyResult[];
@@ -35,7 +45,7 @@ export interface UseEditHistoryResult {
   armUndoBanner: (results: ApplyResult[]) => void;
   /** Pause / resume the active undo countdown. No-ops if the banner is already settled. */
   toggleUndoPause: () => void;
-  codeUndo: (args?: readonly string[]) => string;
+  codeUndo: (args?: readonly string[]) => CodeUndoResult;
   codeHistory: () => string;
   codeShowEdit: (args?: readonly string[]) => string;
   /** Sealed at handleSubmit start so prior turns stay intact for independent /history walks. */
@@ -112,13 +122,15 @@ export function useEditHistory(codeMode: { rootDir: string } | undefined): UseEd
 
   const codeUndo = useCallback<UseEditHistoryResult["codeUndo"]>(
     (args = []) => {
-      if (!codeMode) return "not in code mode";
+      if (!codeMode) return { info: "not in code mode" };
       const root = codeMode.rootDir;
 
-      const revert = (entry: EditHistoryEntry, paths: readonly string[]): string => {
+      const revert = (entry: EditHistoryEntry, paths: readonly string[]): CodeUndoResult => {
         const subset = entry.snapshots.filter((s) => paths.includes(s.path));
         if (subset.length === 0) {
-          return `batch #${entry.id}: nothing to undo (already restored or path not in batch)`;
+          return {
+            info: `batch #${entry.id}: nothing to undo (already restored or path not in batch)`,
+          };
         }
         const results = restoreSnapshots(subset, root);
         for (const s of subset) entry.undoneFiles.add(s.path);
@@ -133,7 +145,16 @@ export function useEditHistory(codeMode: { rootDir: string } | undefined): UseEd
         const when = new Date(entry.at).toISOString().replace("T", " ").slice(11, 19);
         const scope = subset.length === 1 ? subset[0]!.path : `${subset.length} file(s)`;
         const header = `▸ undo: reverted ${scope} from batch #${entry.id} (${when})`;
-        return [header, ...formatUndoRows(results)].join("\n");
+        const revertedPaths = results
+          .filter((r) => r.status === "applied" || r.status === "created")
+          .map((r) => r.path);
+        return {
+          info: [header, ...formatUndoRows(results)].join("\n"),
+          contextEvent:
+            revertedPaths.length > 0
+              ? { batchId: entry.id, source: entry.source, paths: revertedPaths }
+              : undefined,
+        };
       };
 
       const idArg = args[0];
@@ -146,31 +167,35 @@ export function useEditHistory(codeMode: { rootDir: string } | undefined): UseEd
           const remaining = e.snapshots.map((s) => s.path).filter((p) => !e.undoneFiles.has(p));
           return revert(e, remaining);
         }
-        return "nothing to undo — every batch in the session history is already undone";
+        return { info: "nothing to undo — every batch in the session history is already undone" };
       }
 
       const id = Number.parseInt(idArg, 10);
       if (!Number.isFinite(id)) {
-        return "usage: /undo [id] [path]   (omit id for newest; id from /history; path from /show <id>)";
+        return {
+          info: "usage: /undo [id] [path]   (omit id for newest; id from /history; path from /show <id>)",
+        };
       }
       const entry = editHistory.current.find((e) => e.id === id);
-      if (!entry) return `no edit #${id} — run /history to see valid ids`;
+      if (!entry) return { info: `no edit #${id} — run /history to see valid ids` };
 
       if (!pathArg) {
         const remaining = entry.snapshots
           .map((s) => s.path)
           .filter((p) => !entry.undoneFiles.has(p));
-        if (remaining.length === 0) return `batch #${id} is already fully undone`;
+        if (remaining.length === 0) return { info: `batch #${id} is already fully undone` };
         return revert(entry, remaining);
       }
 
       const snap = entry.snapshots.find((s) => s.path === pathArg);
       if (!snap) {
         const files = [...new Set(entry.blocks.map((b) => b.path))];
-        return `batch #${id} doesn't include "${pathArg}" — files in this batch: ${files.join(", ")}`;
+        return {
+          info: `batch #${id} doesn't include "${pathArg}" — files in this batch: ${files.join(", ")}`,
+        };
       }
       if (entry.undoneFiles.has(pathArg)) {
-        return `${pathArg} in batch #${id} is already undone`;
+        return { info: `${pathArg} in batch #${id} is already undone` };
       }
       return revert(entry, [pathArg]);
     },

--- a/tests/slash.test.ts
+++ b/tests/slash.test.ts
@@ -324,6 +324,22 @@ describe("handleSlash", () => {
     expect(r.info).toMatch(/restored 2 file/);
   });
 
+  it("/undo records reverted edits in model context", () => {
+    const loop = makeLoop();
+    const r = handleSlash("undo", [], loop, {
+      codeUndo: () => ({
+        info: "▸ undo: reverted demo.txt from batch #1",
+        contextEvent: { batchId: 1, source: "auto", paths: ["demo.txt"] },
+      }),
+    });
+
+    expect(r.info).toContain("reverted demo.txt");
+    expect(loop.log.entries.at(-1)).toMatchObject({
+      role: "system",
+      content: expect.stringContaining("The user ran /undo and reverted edit batch #1"),
+    });
+  });
+
   it("/help mentions /undo and /commit", () => {
     const r = handleSlash("help", [], makeLoop());
     expect(r.info).toMatch(/\/undo/);

--- a/tests/ui-edit-history-undo-context.test.tsx
+++ b/tests/ui-edit-history-undo-context.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { cleanup, render } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  type UndoAppliedEvent,
+  codeUndoInfo,
+  formatUndoContextMessage,
+  useEditHistory,
+} from "../src/cli/ui/useEditHistory.js";
+import { type EditBlock, applyEditBlocks, snapshotBeforeEdits } from "../src/code/edit-blocks.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useEditHistory undo context", () => {
+  it("notifies the caller when /undo reverts an edit batch", () => {
+    const root = mkdtempSync(join(tmpdir(), "reasonix-undo-context-"));
+    const target = join(root, "demo.txt");
+    writeFileSync(target, "before\n", "utf8");
+
+    let api: ReturnType<typeof useEditHistory> | undefined;
+    function Harness() {
+      api = useEditHistory({ rootDir: root });
+      return null;
+    }
+
+    render(<Harness />);
+
+    const blocks: EditBlock[] = [
+      { path: "demo.txt", search: "before\n", replace: "after\n", offset: 0 },
+    ];
+    const snaps = snapshotBeforeEdits(blocks, root);
+    const results = applyEditBlocks(blocks, root);
+    api!.recordEdit("auto", blocks, results, snaps);
+
+    const result = api!.codeUndo([]);
+
+    expect(codeUndoInfo(result)).toContain("reverted demo.txt from batch #1");
+    expect(readFileSync(target, "utf8")).toBe("before\n");
+    expect(result.contextEvent).toEqual({
+      batchId: 1,
+      source: "auto",
+      paths: ["demo.txt"],
+    });
+    expect(formatUndoContextMessage(result.contextEvent as UndoAppliedEvent)).toContain(
+      "The user ran /undo and reverted edit batch #1",
+    );
+  });
+
+  it("does not return a context message when /undo has nothing left to restore", () => {
+    let api: ReturnType<typeof useEditHistory> | undefined;
+    function Harness() {
+      api = useEditHistory({ rootDir: mkdtempSync(join(tmpdir(), "reasonix-undo-empty-")) });
+      return null;
+    }
+
+    render(<Harness />);
+
+    const result = api!.codeUndo([]);
+    expect(codeUndoInfo(result)).toContain("nothing to undo");
+    expect(result.contextEvent).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

Records successful `/undo` restores as a hidden, model-visible session context update, while keeping the existing user-facing undo output unchanged. This covers both the slash command path and the 5-second `u` undo shortcut.

## Why

Fixes #1787. The bug was real on current `main`: `/undo` restored files on disk, but the conversation context still contained the earlier assistant/tool turn that described those edits as applied, so the next model turn could reason from stale state.

## How to verify

`npm run verify`

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time
