### PR TITLE
perf(desktop): direct DOM CSS vars during sidebar drag, disable CSS transition, content-visibility for messages

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -699,7 +699,7 @@ function appendTextSegment(
   return [...segments, { kind, text }];
 }
 
-function applyIncoming(state: State, ev: IncomingEvent): State {
+export function applyIncoming(state: State, ev: IncomingEvent): State {
   switch (ev.type) {
     case "user.message": {
       return {

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -699,7 +699,7 @@ function appendTextSegment(
   return [...segments, { kind, text }];
 }
 
-export function applyIncoming(state: State, ev: IncomingEvent): State {
+function applyIncoming(state: State, ev: IncomingEvent): State {
   switch (ev.type) {
     case "user.message": {
       return {
@@ -3262,6 +3262,13 @@ export function App() {
     localStorage.setItem("reasonix.theme", theme);
     localStorage.setItem("reasonix.themeStyle", themeStyle);
   }, [theme, themeStyle]);
+
+  // Sync --composer-max-width to .app (separate from inline style to avoid React override)
+  const composerRef = useRef<HTMLElement | null>(null);
+  useEffect(() => {
+    if (!composerRef.current) composerRef.current = document.querySelector(".app");
+    composerRef.current?.style.setProperty("--composer-max-width", `${threadMaxWidth}px`);
+  }, [threadMaxWidth]);
 
   useEffect(() => {
     let raf = 0;

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -237,6 +237,9 @@ button:disabled {
   background: var(--bg);
   transition: grid-template-columns 180ms ease;
 }
+.app[data-dragging="true"] {
+  transition: none;
+}
 
 html[data-platform="macos"] .app {
   overflow: hidden;
@@ -266,7 +269,7 @@ html[data-platform="macos"] .app {
   position: absolute;
   top: 36px;
   bottom: 26px;
-  width: 5px;
+  width: 1px;
   cursor: col-resize;
   z-index: 10;
   background: transparent;
@@ -277,7 +280,7 @@ html[data-platform="macos"] .app {
   background: var(--accent);
 }
 .resize-handle[data-side="left"] {
-  left: calc(var(--side-width) - 2px);
+  left: var(--side-width);
 }
 .resize-handle[data-side="right"] {
   right: var(--ctx-width);
@@ -1611,6 +1614,11 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
   display: flex;
   flex-direction: column;
   gap: 28px;
+}
+/* Skip offscreen message layout during resize — critical for long sessions */
+.thread-inner > div[data-turn] {
+  content-visibility: auto;
+  contain-intrinsic-size: 1px 100px;
 }
 
 /* ---------- JUMP BAR (message navigation dock) ---------- */

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -269,7 +269,7 @@ html[data-platform="macos"] .app {
   position: absolute;
   top: 36px;
   bottom: 26px;
-  width: 1px;
+  width: 5px;
   cursor: col-resize;
   z-index: 10;
   background: transparent;
@@ -280,10 +280,10 @@ html[data-platform="macos"] .app {
   background: var(--accent);
 }
 .resize-handle[data-side="left"] {
-  left: var(--side-width);
+  left: calc(var(--side-width) - 2px);
 }
 .resize-handle[data-side="right"] {
-  right: var(--ctx-width);
+  right: calc(var(--ctx-width) - 2px);
 }
 
 /* ---------- TABBAR ---------- */

--- a/desktop/src/ui/useResizable.ts
+++ b/desktop/src/ui/useResizable.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 const MIN_WIDTH = 160;
 const MAX_WIDTH_PCT = 0.4;
+const CSS_VAR = { side: "--side-width", ctx: "--ctx-width" } as const;
 const PERSIST_KEY_SIDE = "reasonix.sideWidth";
 const PERSIST_KEY_CTX = "reasonix.ctxWidth";
 
@@ -31,15 +32,19 @@ export function useResizable(
   const draggingRef = useRef(false);
   const startXRef = useRef(0);
   const startWidthRef = useRef(0);
-  // Track latest width via ref so mouseup handler always saves the current value.
   const widthRef = useRef(width);
   widthRef.current = width;
+  const cssVar = CSS_VAR[side];
+  const appRef = useRef<HTMLElement | null>(null);
 
   const onMouseDown = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
     draggingRef.current = true;
     startXRef.current = e.clientX;
     startWidthRef.current = widthRef.current;
+    const appEl = document.querySelector(".app") as HTMLElement | null;
+    appRef.current = appEl;
+    if (appEl) appEl.dataset.dragging = "true";
     document.body.style.cursor = "col-resize";
     document.body.style.userSelect = "none";
   }, []);
@@ -49,6 +54,9 @@ export function useResizable(
 
     const onMove = (e: MouseEvent) => {
       if (!draggingRef.current) return;
+      const appEl = appRef.current;
+      if (!appEl) return;
+
       const delta = e.clientX - startXRef.current;
       let next: number;
       if (side === "side") {
@@ -58,12 +66,28 @@ export function useResizable(
       }
       const maxW = Math.floor(window.innerWidth * MAX_WIDTH_PCT);
       next = Math.max(MIN_WIDTH, Math.min(next, maxW));
+      widthRef.current = next;
+
+      // Update CSS variable + React state every frame
+      appEl.style.setProperty(cssVar, `${next}px`);
       setWidth(next);
+
+      // Sync thread/composer max-width in lockstep
+      const otherVar = side === "side" ? "--ctx-width" : "--side-width";
+      const o = parseFloat(appEl.style.getPropertyValue(otherVar)) || 0;
+      const sideW = side === "side" ? next : o;
+      const ctxW = side === "ctx" ? next : o;
+      const tMax = String(Math.max(580, Math.min(window.innerWidth - sideW - ctxW - 80, 1120)));
+      appEl.style.setProperty("--thread-max-width", tMax);
+      appEl.style.setProperty("--composer-max-width", tMax);
     };
 
     const onUp = () => {
       if (!draggingRef.current) return;
       draggingRef.current = false;
+      const appEl = appRef.current;
+      if (appEl) delete appEl.dataset.dragging;
+      appRef.current = null;
       document.body.style.cursor = "";
       document.body.style.userSelect = "";
       try {
@@ -79,7 +103,7 @@ export function useResizable(
       window.removeEventListener("mousemove", onMove);
       window.removeEventListener("mouseup", onUp);
     };
-  }, [collapsed, side, persistKey]);
+  }, [collapsed, side, persistKey, cssVar]);
 
   return { width, onMouseDown };
 }


### PR DESCRIPTION
## Summary

Optimize sidebar drag resize performance. Long sessions (200k+ tokens) were
causing CPU temperature spikes and visible lag during drag because every
mousemove triggered a full React re-render + CSS transition restart.

## Changes

### 1. Direct DOM CSS variable updates (`useResizable.ts`)
- Cache `.app` ref on mousedown, avoid `querySelector` per frame during drag
- Both DOM `setProperty()` + React `setWidth()` on every mousemove
- Previously only React `setWidth()` was called, causing full tree re-renders

### 2. Disable CSS transition during drag (`styles.css`)
- `.app` has `transition: grid-template-columns 180ms ease` for smooth collapse/expand
- During drag, `data-dragging` attribute on `.app` sets `transition: none`
- Prevents the animation engine from restarting 60-120 times per second

### 3. Skip offscreen message layout (`styles.css`)
- `.thread-inner > div[data-turn]` gets `content-visibility: auto`
- Browser only lays out visible messages during resize, not the full DOM tree

### 4. Minor fixes
- `applyIncoming` no longer exported (fixes Vite HMR warning about non-component exports)
- `--composer-max-width` synced via `useEffect` to keep composer in sync during drag

## Remaining issues / known limitations

On very long sessions (500+ messages, 250k+ tokens), dragging the sidebar
still shows some lag and CPU temperature increase. Root cause:

- CSS Grid with `grid-template-columns: var(--side-width) minmax(0, 1fr) var(--ctx-width)`
  forces the browser to recalculate layout for **all** grid children when
  `--side-width` changes, even with `content-visibility: auto`
- The grid container itself must fully reflow to determine scroll extents
- `content-visibility: auto` reduces per-message cost but the grid reflow
  overhead scales with DOM size

Possible next steps (not in this PR):
- Replace CSS Grid with `position: absolute` panels and `transform: translateX()`
  for resize — avoids full grid reflow
- Virtualize the message list (only render visible messages)
- Add `will-change: grid-template-columns` hint on `.app`
