### PR TITLE
fix(tui): reduce prompt input repaint flicker

### DIFF
--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -45,6 +45,11 @@ import {
 
 export type { McpLifecycleNotice, McpLifecycleSink, McpRuntime, ProgressInfo };
 
+export const CHAT_RENDER_OPTIONS = {
+  exitOnCtrlC: true,
+  incrementalRendering: true,
+} as const;
+
 export interface ChatOptions {
   model: string;
   reasoningEffort?: ReasoningEffort;
@@ -407,7 +412,7 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
       qqSubmitRef={qqSubmitRef}
       qqErrorRef={qqErrorRef}
     />,
-    { exitOnCtrlC: true },
+    CHAT_RENDER_OPTIONS,
   );
   try {
     await waitUntilExit();

--- a/tests/jobs.test.ts
+++ b/tests/jobs.test.ts
@@ -122,6 +122,7 @@ describe("JobRegistry", () => {
   it("tailLines caps returned output to the last N lines", async () => {
     const cmd = `node -e "for (let i=0;i<50;i++) console.log('line'+i); setTimeout(()=>{}, 10000)"`;
     const res = await registry.start(cmd, { cwd, waitSec: 0.5 });
+    await waitFor(() => registry.read(res.jobId)?.output.includes("line49") ?? false, 3000);
     const tailed = registry.read(res.jobId, { tailLines: 5 });
     const lines = (tailed?.output ?? "").split("\n").filter(Boolean);
     expect(lines.length).toBeLessThanOrEqual(5);

--- a/tests/prompt-input-cursor-sync.test.tsx
+++ b/tests/prompt-input-cursor-sync.test.tsx
@@ -54,6 +54,17 @@ async function wait(ms = 0): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+async function waitForCursorMoveAfter(
+  stdout: ReturnType<typeof makeFakeStdout>,
+  before: number,
+): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    if (cursorMoves(stdout.text()).length > before) return;
+    await wait(25);
+  }
+  expect(cursorMoves(stdout.text()).length).toBeGreaterThan(before);
+}
+
 async function feed(reader: FakeReader, ev: Partial<KeyEvent>): Promise<void> {
   reader.feed(ev);
   await wait();
@@ -150,13 +161,17 @@ describe("PromptInput system cursor sync", () => {
     );
     await wait(180);
 
-    const before = stdout.text().length;
+    const beforeText = stdout.text().length;
+    const beforeMoves = cursorMoves(stdout.text()).length;
     await feed(reader, { input: "a" });
+    await waitForCursorMoveAfter(stdout, beforeMoves);
     await wait(180);
 
-    const delta = stdout.text().slice(before);
+    const output = stdout.text();
+    const delta = output.slice(beforeText);
+    const newMoves = cursorMoves(output).slice(beforeMoves);
     expect(delta).not.toMatch(FULL_FRAME_ERASE_RE);
-    expect(delta).toContain("› a");
+    expect(newMoves).toContain("\x1b[28;5H");
 
     unmount();
   });

--- a/tests/prompt-input-cursor-sync.test.tsx
+++ b/tests/prompt-input-cursor-sync.test.tsx
@@ -1,6 +1,7 @@
 import { render } from "ink";
 import React from "react";
 import { describe, expect, it } from "vitest";
+import * as chatCommand from "../src/cli/commands/chat.js";
 import { PromptInput } from "../src/cli/ui/PromptInput.js";
 import {
   type KeystrokeHandler,
@@ -13,6 +14,7 @@ import { makeFakeStdin, makeFakeStdout } from "./helpers/ink-stdio.js";
 
 const ESC = String.fromCharCode(27);
 const CURSOR_MOVE_RE = new RegExp(`${ESC}\\[\\d+;\\d+H`, "g");
+const FULL_FRAME_ERASE_RE = new RegExp(`${ESC}\\[2K${ESC}\\[1A${ESC}\\[2K`);
 
 class FakeReader implements KeystrokeReader {
   private readonly handlers = new Set<KeystrokeHandler>();
@@ -36,6 +38,16 @@ class FakeReader implements KeystrokeReader {
 
 function cursorMoves(text: string): string[] {
   return text.match(CURSOR_MOVE_RE) ?? [];
+}
+
+function chatRenderOptions(): Record<string, unknown> {
+  return (
+    (
+      chatCommand as {
+        CHAT_RENDER_OPTIONS?: Record<string, unknown>;
+      }
+    ).CHAT_RENDER_OPTIONS ?? {}
+  );
 }
 
 async function wait(ms = 0): Promise<void> {
@@ -123,6 +135,28 @@ describe("PromptInput system cursor sync", () => {
     const afterMoves = cursorMoves(stdout.text());
     const newMoves = afterMoves.slice(before);
     expect(newMoves).toEqual(["\x1b[28;9H"]);
+
+    unmount();
+  });
+
+  it("uses incremental chat rendering so prompt edits do not erase the whole frame", async () => {
+    const reader = new FakeReader();
+    const stdout = makeFakeStdout();
+    const { unmount } = render(
+      <KeystrokeProvider reader={reader}>
+        <PromptHarness />
+      </KeystrokeProvider>,
+      { stdout: stdout as never, stdin: makeFakeStdin() as never, ...chatRenderOptions() },
+    );
+    await wait(180);
+
+    const before = stdout.text().length;
+    await feed(reader, { input: "a" });
+    await wait(180);
+
+    const delta = stdout.text().slice(before);
+    expect(delta).not.toMatch(FULL_FRAME_ERASE_RE);
+    expect(delta).toContain("› a");
 
     unmount();
   });


### PR DESCRIPTION
## Summary
- Enable Ink incremental rendering for the chat TUI.
- Add a regression test that prompt edits do not emit full-frame erase sequences.

## Root cause
Prompt input edits used Ink default rendering, which clears and redraws the whole frame on every typed character or backspace. This made the terminal visibly flicker across terminals.

## Validation
- Interactive prompt simulation: type h, type i, backspace, type !; every step reported fullFrameErase=false.
- npx vitest run tests/prompt-input-cursor-sync.test.tsx tests/terminal-host.test.ts --reporter verbose
- npx biome check src/cli/commands/chat.tsx tests/prompt-input-cursor-sync.test.tsx
- npm run typecheck
- git diff --check
- pre-push npm run verify: 280 test files passed, 3744 tests passed, 10 skipped

Fixes #1821