### PR TITLE
fix(desktop): keep mention popup stable

### DIFF
--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -3300,7 +3300,7 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
   position: absolute;
   bottom: calc(100% + 8px);
   left: 0;
-  width: 420px;
+  width: min(720px, calc(100vw - 32px));
   max-height: 320px;
   background: var(--card);
   border: 1px solid var(--border-strong);
@@ -3332,7 +3332,11 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
 }
 .popup-list {
   overflow-y: auto;
+  overflow-x: auto;
   padding: 4px;
+}
+.at-popup-list .popup-item {
+  min-width: max-content;
 }
 .popup-item {
   display: grid;

--- a/desktop/src/ui/composer-at-popup.test.tsx
+++ b/desktop/src/ui/composer-at-popup.test.tsx
@@ -1,0 +1,163 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { createRef } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setLang } from "../i18n";
+import { Composer, type EditMode, type ReasoningEffort } from "./composer";
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({ open: vi.fn() }));
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+function renderComposer(props?: Partial<React.ComponentProps<typeof Composer>>) {
+  const textareaRef = createRef<HTMLTextAreaElement>();
+  const onMentionQuery = vi.fn();
+  const utils = render(
+    <Composer
+      draft=""
+      setDraft={vi.fn()}
+      onSend={vi.fn()}
+      onAbort={vi.fn()}
+      disabled={false}
+      busy={false}
+      modelLabel="deepseek-v4-flash"
+      reasoningEffort="high"
+      onModelChange={vi.fn()}
+      onEffortChange={vi.fn()}
+      editMode="review"
+      onEditModeChange={vi.fn()}
+      textareaRef={textareaRef}
+      slashCommands={[]}
+      onMentionQuery={onMentionQuery}
+      onMentionPreview={vi.fn()}
+      onMentionPicked={vi.fn()}
+      mentionResults={null}
+      workspaceDir="/repo"
+      {...props}
+    />,
+  );
+
+  return { ...utils, textareaRef, onMentionQuery };
+}
+
+describe("desktop Composer @ popup", () => {
+  beforeEach(() => {
+    setLang("en");
+  });
+
+  it("keeps the active mention row when async results shrink", async () => {
+    const { container, rerender, onMentionQuery } = renderComposer();
+    const textarea = container.querySelector("textarea");
+    if (!textarea) throw new Error("missing textarea");
+
+    fireEvent.change(textarea, { target: { value: "@re" } });
+
+    await waitFor(() => expect(onMentionQuery).toHaveBeenCalled());
+    const nonce = onMentionQuery.mock.calls[0]?.[1] as number;
+
+    rerender(
+      <Composer
+        draft="@re"
+        setDraft={vi.fn()}
+        onSend={vi.fn()}
+        onAbort={vi.fn()}
+        disabled={false}
+        busy={false}
+        modelLabel="deepseek-v4-flash"
+        reasoningEffort="high"
+        onModelChange={vi.fn()}
+        onEffortChange={vi.fn()}
+        editMode="review"
+        onEditModeChange={vi.fn()}
+        textareaRef={createRef<HTMLTextAreaElement>()}
+        slashCommands={[]}
+        onMentionQuery={onMentionQuery}
+        onMentionPreview={vi.fn()}
+        onMentionPicked={vi.fn()}
+        mentionResults={{ nonce, query: "re", results: ["alpha", "beta", "gamma"] }}
+        workspaceDir="/repo"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector('.popup-item[data-active="true"]')?.textContent).toContain(
+        "alpha",
+      );
+    });
+
+    const items = container.querySelectorAll(".popup-item");
+    fireEvent.mouseEnter(items[1]!);
+
+    expect(container.querySelector('.popup-item[data-active="true"]')?.textContent).toContain(
+      "beta",
+    );
+
+    rerender(
+      <Composer
+        draft="@re"
+        setDraft={vi.fn()}
+        onSend={vi.fn()}
+        onAbort={vi.fn()}
+        disabled={false}
+        busy={false}
+        modelLabel="deepseek-v4-flash"
+        reasoningEffort="high"
+        onModelChange={vi.fn()}
+        onEffortChange={vi.fn()}
+        editMode="review"
+        onEditModeChange={vi.fn()}
+        textareaRef={createRef<HTMLTextAreaElement>()}
+        slashCommands={[]}
+        onMentionQuery={onMentionQuery}
+        onMentionPreview={vi.fn()}
+        onMentionPicked={vi.fn()}
+        mentionResults={{ nonce, query: "re", results: ["alpha", "beta"] }}
+        workspaceDir="/repo"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector('.popup-item[data-active="true"]')?.textContent).toContain(
+        "beta",
+      );
+    });
+  });
+
+  it("uses the wider at popup class for mention results", async () => {
+    const { container, rerender, onMentionQuery } = renderComposer();
+    const textarea = container.querySelector("textarea");
+    if (!textarea) throw new Error("missing textarea");
+
+    fireEvent.change(textarea, { target: { value: "@re" } });
+    await waitFor(() => expect(onMentionQuery).toHaveBeenCalled());
+    const nonce = onMentionQuery.mock.calls[0]?.[1] as number;
+
+    rerender(
+      <Composer
+        draft="@re"
+        setDraft={vi.fn()}
+        onSend={vi.fn()}
+        onAbort={vi.fn()}
+        disabled={false}
+        busy={false}
+        modelLabel="deepseek-v4-flash"
+        reasoningEffort="high"
+        onModelChange={vi.fn()}
+        onEffortChange={vi.fn()}
+        editMode="review"
+        onEditModeChange={vi.fn()}
+        textareaRef={createRef<HTMLTextAreaElement>()}
+        slashCommands={[]}
+        onMentionQuery={onMentionQuery}
+        onMentionPreview={vi.fn()}
+        onMentionPicked={vi.fn()}
+        mentionResults={{ nonce, query: "re", results: ["alpha"] }}
+        workspaceDir="/repo"
+      />,
+    );
+
+    expect(container.querySelector(".popup-list.at-popup-list")).not.toBeNull();
+  });
+});

--- a/desktop/src/ui/composer.tsx
+++ b/desktop/src/ui/composer.tsx
@@ -275,7 +275,10 @@ export function Composer({
     popup?.kind === "slash" ? slashItems : popup?.kind === "at" ? atItems : [];
 
   useEffect(() => {
-    setActiveIdx(0);
+    setActiveIdx((i) => {
+      if (!items.length) return 0;
+      return Math.min(i, items.length - 1);
+    });
   }, [items.length, popup?.kind]);
 
   useEffect(() => {
@@ -687,11 +690,14 @@ function Popup({
   onHover: (i: number, item: SlashCmd | MentionItem) => void;
 }) {
   const listRef = useRef<HTMLDivElement>(null);
+  const lastActiveRef = useRef<number>(-1);
 
   useEffect(() => {
+    if (lastActiveRef.current === activeIdx) return;
+    lastActiveRef.current = activeIdx;
     requestAnimationFrame(() => {
       const el = listRef.current?.querySelector<HTMLElement>(`[data-active="true"]`);
-      el?.scrollIntoView({ block: "nearest" });
+      el?.scrollIntoView?.({ block: "nearest", inline: "nearest" });
     });
   }, [activeIdx]);
 
@@ -709,7 +715,7 @@ function Popup({
           <I.x size={11} />
         </span>
       </div>
-      <div className="popup-list" ref={listRef}>
+      <div className={`popup-list ${kind === "at" ? "at-popup-list" : ""}`} ref={listRef}>
         {items.length === 0 ? (
           <div
             style={{


### PR DESCRIPTION
## Summary

Improve the desktop `@` mention popup so wide file paths are easier to read and the active row no longer jumps back to the top when async results refresh.

## Problem

In the desktop composer, the `@` popup could be too narrow for long file paths and directory suffixes. When mention results updated asynchronously, the popup also tended to re-anchor the active row, which made the view feel like it was snapping back and fighting manual horizontal scrolling.

The issue is in the desktop composer path:
- `desktop/src/ui/composer.tsx` renders the `@` popup
- `desktop/src/styles.css` defines popup sizing and overflow behavior
- `desktop/src/ui/composer.tsx` also controls active-row scrolling

## Fix

- **`desktop/src/ui/composer.tsx`** — Kept the active mention index stable across async result refreshes by clamping instead of resetting to `0`. Also narrowed `scrollIntoView` behavior so it only scrolls when the active row actually changes, and uses `inline: "nearest"`.
- **`desktop/src/styles.css`** — Widened the popup responsively, enabled horizontal scrolling for the popup list, and let `@` rows expand naturally via a dedicated `.at-popup-list` class.
- **`desktop/src/ui/composer-at-popup.test.tsx`** — Added regression coverage for async mention result refresh and the `@` popup layout class.

## Verification

| Check | Result |
|---|---|
| `npm run test -- --run desktop/src/ui/composer-at-popup.test.tsx desktop/src/App.test.ts` | ✅ passes |
| `npm run verify` | ✅ passes |

Closed #1823