### PR TITLE
chore(ui): drop undo-context re-exports through useEditHistory

### DIFF
--- a/src/cli/ui/useEditHistory.ts
+++ b/src/cli/ui/useEditHistory.ts
@@ -15,15 +15,6 @@ import {
 } from "./edit-history.js";
 import type { CodeUndoResult } from "./undo-context.js";
 
-export {
-  codeUndoContextMessage,
-  codeUndoInfo,
-  formatUndoContextMessage,
-  type CodeUndoOutput,
-  type CodeUndoResult,
-  type UndoAppliedEvent,
-} from "./undo-context.js";
-
 export interface UndoBannerState {
   results: ApplyResult[];
   expiresAt: number;

--- a/tests/ui-edit-history-undo-context.test.tsx
+++ b/tests/ui-edit-history-undo-context.test.tsx
@@ -10,8 +10,8 @@ import {
   type UndoAppliedEvent,
   codeUndoInfo,
   formatUndoContextMessage,
-  useEditHistory,
-} from "../src/cli/ui/useEditHistory.js";
+} from "../src/cli/ui/undo-context.js";
+import { useEditHistory } from "../src/cli/ui/useEditHistory.js";
 import { type EditBlock, applyEditBlocks, snapshotBeforeEdits } from "../src/code/edit-blocks.js";
 
 afterEach(() => {


### PR DESCRIPTION
## What

Removes the six re-exports that `useEditHistory.ts` was forwarding from
`undo-context.ts`. The test was the only consumer routing through the
hook module — switched it to import `undo-context.ts` directly.

## Why

Per CLAUDE.md TypeScript rule: *"Don't re-export types just so two files
can share them — move the type to the file that owns the concept."*
`undo-context.ts` already owns the concept; the indirection was only
there to give the test a single import line.

## How to verify

`npm run verify` — passes locally (lint + typecheck + 137 tests in the
affected files).

Follow-up to #1810.

## Checklist

- [x] `npm run verify` passes locally
- [x] No `Co-Authored-By: Claude` trailer
- [x] Comments unchanged
- [x] No CHANGELOG edits