### PR TITLE
fix(i18n): localize /qq slash command hints and description for zh-CN

### DIFF
--- a/src/cli/ui/SlashArgPicker.tsx
+++ b/src/cli/ui/SlashArgPicker.tsx
@@ -47,6 +47,16 @@ export function SlashArgPicker({
   pathCandidates,
 }: SlashArgPickerProps): React.ReactElement | null {
   const color = useColor();
+  const headerArgsHint = (() => {
+    const argsKey = `slash.${spec.cmd}.argsHint`;
+    const translatedArgs = t(argsKey);
+    return translatedArgs === argsKey ? (spec.argsHint ?? "") : translatedArgs;
+  })();
+  const headerSummary = (() => {
+    const descKey = `slash.${spec.cmd}.description`;
+    const translated = t(descKey);
+    return translated === descKey ? spec.summary : translated;
+  })();
   const headerRow = (
     <Box>
       <Text color={color.accent} bold>
@@ -55,8 +65,8 @@ export function SlashArgPicker({
       <Text color={color.accent} bold>
         {`/${spec.cmd}`}
       </Text>
-      {spec.argsHint ? <Text dimColor>{` ${spec.argsHint}`}</Text> : null}
-      <Text dimColor>{`  ${spec.summary}`}</Text>
+      {headerArgsHint ? <Text dimColor>{` ${headerArgsHint}`}</Text> : null}
+      <Text dimColor>{`  ${headerSummary}`}</Text>
     </Box>
   );
 

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -336,8 +336,9 @@ export const zhCN: TranslationSchema = {
     sessions: { description: "列出已保存的会话（当前标记为 ▸）" },
     title: { description: "让模型根据当前对话重命名此会话" },
     qq: {
-      description: "连接、查看或断开当前会话的 QQ 通道（首次连接会引导录入 App ID / App Secret）",
-      argsHint: "[connect [appId appSecret [sandbox]]|status|disconnect]",
+      description:
+        "连接/查看/断开 QQ 通道，首次连接需提供 AppId + AppSecret（可选沙箱模式 sandbox）",
+      argsHint: "<connect连接 | status状态 | disconnect断开>",
     },
     setup: { description: "提醒您退出并运行 `reasonix setup`" },
     semantic: {


### PR DESCRIPTION
﻿## Summary

Fix the /qq slash command picker header to use i18n translations instead of hardcoded English text. Previously, when typing /qq  in the TUI, both the rgsHint and summary were always English regardless of language setting.

## Changes

### src/cli/ui/SlashArgPicker.tsx
The header row now reads rgsHint and summary from i18n via 	("slash..argsHint") and 	("slash..description"), falling back to the hardcoded values when no translation exists. This is consistent with how SlashSuggestions.tsx already handles the description field.

### src/i18n/zh-CN.ts
- **description**: shortened to 连接/查看/断开 QQ 通道，首次连接需提供 AppId + AppSecret（可选沙箱模式 sandbox）
- **argsHint**: changed from [connect [appId appSecret [sandbox]]|status|disconnect] to <connect连接 | status状态 | disconnect断开>

## Notes
- The rgCompleter values (connect, status, disconnect) remain English because they are command keywords parsed by the handler and cannot be translated.
- Other locales (EN, de) are unaffected.
