### PR TITLE
chore(desktop): split kind/length effects in @ popup, drop redundant guard

### DIFF
--- a/desktop/src/ui/composer-at-popup.test.tsx
+++ b/desktop/src/ui/composer-at-popup.test.tsx
@@ -4,7 +4,7 @@ import { fireEvent, render, waitFor } from "@testing-library/react";
 import { createRef } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { setLang } from "../i18n";
-import { Composer, type EditMode, type ReasoningEffort } from "./composer";
+import { Composer } from "./composer";
 
 vi.mock("@tauri-apps/plugin-dialog", () => ({ open: vi.fn() }));
 afterEach(() => {

--- a/desktop/src/ui/composer.tsx
+++ b/desktop/src/ui/composer.tsx
@@ -275,11 +275,12 @@ export function Composer({
     popup?.kind === "slash" ? slashItems : popup?.kind === "at" ? atItems : [];
 
   useEffect(() => {
-    setActiveIdx((i) => {
-      if (!items.length) return 0;
-      return Math.min(i, items.length - 1);
-    });
-  }, [items.length, popup?.kind]);
+    setActiveIdx(0);
+  }, [popup?.kind]);
+
+  useEffect(() => {
+    setActiveIdx((i) => (items.length ? Math.min(i, items.length - 1) : 0));
+  }, [items.length]);
 
   useEffect(() => {
     if (!popup || popup.kind !== "at" || !onMentionQuery) return;
@@ -690,11 +691,8 @@ function Popup({
   onHover: (i: number, item: SlashCmd | MentionItem) => void;
 }) {
   const listRef = useRef<HTMLDivElement>(null);
-  const lastActiveRef = useRef<number>(-1);
 
   useEffect(() => {
-    if (lastActiveRef.current === activeIdx) return;
-    lastActiveRef.current = activeIdx;
     requestAnimationFrame(() => {
       const el = listRef.current?.querySelector<HTMLElement>(`[data-active="true"]`);
       el?.scrollIntoView?.({ block: "nearest", inline: "nearest" });
@@ -715,7 +713,7 @@ function Popup({
           <I.x size={11} />
         </span>
       </div>
-      <div className={`popup-list ${kind === "at" ? "at-popup-list" : ""}`} ref={listRef}>
+      <div className={kind === "at" ? "popup-list at-popup-list" : "popup-list"} ref={listRef}>
         {items.length === 0 ? (
           <div
             style={{


### PR DESCRIPTION
## What

Follow-up to #1850. Small cleanup on the `@` mention popup code:

- Reset `activeIdx` to `0` on `popup.kind` switch (slash ↔ at) in its
  own effect, instead of letting the length-clamp effect handle both.
  The previous combined effect would leave the user on an arbitrary
  row of the new popup after switching kinds rather than the top.
- Drop the `lastActiveRef` guard inside `Popup` — `useEffect`'s
  `[activeIdx]` dep array already short-circuits on identity equality,
  so the manual guard was redundant.
- Move the conditional class join out of the template literal so the
  non-`at` branch no longer renders a trailing space in `className`.
- Drop the unused `EditMode` / `ReasoningEffort` type imports from
  `composer-at-popup.test.tsx` (TS6133 in `tsc --noEmit -p desktop`).

Kept the `el?.scrollIntoView?.(...)` optional chain — I started to
remove it as dead defensive code, then noticed jsdom doesn't implement
`scrollIntoView`, so the guard is what keeps the rAF callback from
throwing during tests.

## Checklist

- [x] `npm run verify` passes locally
- [x] No `Co-Authored-By: Claude` trailer
- [x] Comments unchanged
- [x] No CHANGELOG edits