### PR TITLE
fix(mcp): drop LSP-only fields from initialize params

### DIFF
--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -116,12 +116,6 @@ export class McpClient {
       protocolVersion: MCP_PROTOCOL_VERSION,
       capabilities,
       clientInfo: this.clientInfo,
-      ...(this.workspaceRoot
-        ? {
-            rootUri: this.workspaceRoot.uri,
-            workspaceFolders: [this.workspaceRoot],
-          }
-        : {}),
     };
     const result = await this.request<InitializeResult>("initialize", params, opts.signal);
     this._serverCapabilities = result.capabilities ?? {};

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -62,8 +62,6 @@ export interface InitializeParams {
   protocolVersion: string;
   capabilities: McpClientCapabilities;
   clientInfo: McpClientInfo;
-  rootUri?: string;
-  workspaceFolders?: McpRoot[];
 }
 
 export interface InitializeResult {

--- a/tests/mcp.test.ts
+++ b/tests/mcp.test.ts
@@ -197,22 +197,19 @@ describe("McpClient: initialize handshake", () => {
     await client.close();
   });
 
-  it("passes the workspace root in initialize params", async () => {
+  it("advertises the roots capability when a workspace is configured", async () => {
     const received: JsonRpcRequest[] = [];
     const workspaceDir = "/tmp/reasonix-workspace";
-    const workspaceUri = pathToFileURL(workspaceDir).href;
     const transport = new FakeMcpTransport({ tools: [], received });
     const client = new McpClient({ transport, workspaceDir });
     await client.initialize();
     const init = received.find((r) => r.method === "initialize")!;
     const params = init.params as {
       capabilities: Record<string, unknown>;
-      rootUri?: string;
-      workspaceFolders?: Array<{ uri: string; name?: string }>;
-    };
+    } & Record<string, unknown>;
     expect(params.capabilities).toHaveProperty("roots");
-    expect(params.rootUri).toBe(workspaceUri);
-    expect(params.workspaceFolders).toEqual([{ uri: workspaceUri, name: "reasonix-workspace" }]);
+    expect(params).not.toHaveProperty("rootUri");
+    expect(params).not.toHaveProperty("workspaceFolders");
     await client.close();
   });
 


### PR DESCRIPTION
## Summary
- `rootUri` and `workspaceFolders` are LSP fields, not part of the MCP 2024-11-05 `initialize` schema. Strict servers (e.g. ida-pro-mcp, which uses the official Python SDK with pydantic) reject the handshake with `Invalid params: unexpected parameters: ['workspaceFolders', 'rootUri']`.
- Workspace roots are already exchanged the spec-compliant way: we advertise the `roots` capability and answer the server-initiated `roots/list` (already wired in `client.ts`).
- Updated the corresponding test to assert the `roots` capability is advertised and that the LSP fields are absent.

## Test plan
- [x] `npx vitest run tests/mcp.test.ts` — 38/38 pass
- [x] `npx tsc --noEmit` clean
- [x] biome lint clean (ran on commit)