### PR TITLE
chore(i18n): drop zh-CN /qq argsHint, fall back to source

### DIFF
--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -338,7 +338,6 @@ export const zhCN: TranslationSchema = {
     qq: {
       description:
         "连接/查看/断开 QQ 通道，首次连接需提供 AppId + AppSecret（可选沙箱模式 sandbox）",
-      argsHint: "<connect连接 | status状态 | disconnect断开>",
     },
     setup: { description: "提醒您退出并运行 `reasonix setup`" },
     semantic: {


### PR DESCRIPTION
## What

Follow-up to #1857. Removes the `slash.qq.argsHint` override from
zh-CN.ts so it falls back to `spec.argsHint`.

## Why

The argsHint value is BNF over English command keywords:

```
[connect [appId appSecret [sandbox]] | status | disconnect]
```

There's nothing to localize — the keywords (`connect`, `status`,
`disconnect`) are parsed by the handler and have to stay English.

The override that landed in #1857 had two issues:

1. **Dropped the sub-argument structure.** The previous hint told users
   `connect` takes optional `appId appSecret [sandbox]`. The new
   `<connect连接 | status状态 | disconnect断开>` removed that, so
   zh-CN users couldn't see from the picker that connect accepts
   arguments.
2. **EN+CN inline gloss reads awkwardly.** `connect连接` smashes the
   keyword and its translation together without a separator —
   parenthesized gloss (`connect (连接)`) would be more conventional,
   but even that adds noise to a syntax hint.

Removing the key lets zh-CN inherit the English source through the
existing `translated === key ? spec.argsHint : translated` fallback
in `SlashArgPicker.tsx`. `argsHint` is already `?: string` in the
schema, so this typechecks cleanly.

The `description` override from #1857 stays — that's prose, worth
translating.

## Checklist

- [x] `npm run verify` passes locally
- [x] No `Co-Authored-By: Claude` trailer
- [x] Comments unchanged
- [x] No CHANGELOG edits