### PR TITLE
fix(ui): highlight active plan edit mode

### DIFF
--- a/dashboard/src/styles.css
+++ b/dashboard/src/styles.css
@@ -5790,6 +5790,9 @@ html:not([data-platform="macos"]) .cmdk-row .kb .shortcut kbd[data-key="mod"] {
 .ms-seg[data-on="true"][data-k="review"] {
   background: var(--tone-info-soft); color: var(--tone-info);
 }
+.ms-seg[data-on="true"][data-k="plan"] {
+  background: var(--tone-warn-soft); color: var(--tone-warn);
+}
 .ms-seg[data-on="true"][data-k="auto"] {
   background: var(--accent-soft); color: var(--accent);
 }

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -6020,6 +6020,9 @@ html:not([data-platform="macos"]) .cmdk-row .kb .shortcut kbd[data-key="mod"] {
 .ms-seg[data-on="true"][data-k="review"] {
   background: var(--tone-info-soft); color: var(--tone-info);
 }
+.ms-seg[data-on="true"][data-k="plan"] {
+  background: var(--tone-warn-soft); color: var(--tone-warn);
+}
 .ms-seg[data-on="true"][data-k="auto"] {
   background: var(--accent-soft); color: var(--accent);
 }


### PR DESCRIPTION
## Summary

Add active highlight styling for the "plan" edit mode in both the dashboard and desktop mode-switch UI, so clicking plan mode visually distinguishes it from the unselected modes.

## Problem

The mode-switch segmented control (`ModeSwitch`) renders plan as one of four options (plan / review / auto / yolo), but clicking plan mode produced no visual change — the button stayed the same muted color as the unselected buttons. The `data-on="true"` attribute and `data-k="plan"` were already wired in the component, but the CSS selector `[data-on="true"][data-k="plan"]` was missing from both stylesheets, so the active state had no rule to apply.

Affected paths:
- `dashboard/src/ui/composer.tsx` — `ModeSwitch` generates `<button data-on={...} data-k="plan">`
- `desktop/src/ui/composer.tsx` — same component
- `dashboard/src/styles.css` — had rules for review / auto / yolo, missing plan
- `desktop/src/styles.css` — same

## Fix

- **`dashboard/src/styles.css`** — Added `.ms-seg[data-on="true"][data-k="plan"] { background: var(--tone-warn-soft); color: var(--tone-warn); }`
- **`desktop/src/styles.css`** — Same rule added at the corresponding location

## Verification

| Check | Result |
|---|---|
| `npm run lint` | ✅ passes |
| `npx tsc --noEmit && npx tsc --noEmit -p dashboard` | ✅ passes |
| `npx vitest run` (280 files, 3741 tests) | ✅ passes |
| `git diff --check` | ✅ passes |
| `npm run verify` | ✅ passes |

Closed #1843