### PR TITLE
fix(dashboard): sync TUI and Web modal state (#1831)

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -649,6 +649,23 @@ export function applyIncoming(state: State, ev: IncomingEvent): State {
           },
         ],
       };
+    case "$modal_dismissed":
+      switch (ev.kind) {
+        case "shell":
+          return { ...state, pendingConfirms: [] };
+        case "path":
+          return { ...state, pendingPathAccess: [] };
+        case "choice":
+          return { ...state, pendingChoices: [] };
+        case "plan":
+          return { ...state, pendingPlans: [] };
+        case "checkpoint":
+          return { ...state, pendingCheckpoints: [] };
+        case "revision":
+          return { ...state, pendingRevisions: [] };
+        default:
+          return state;
+      }
     case "$step_completed": {
       if (!state.activePlan) return state;
       const stepIds = new Set(state.activePlan.completedStepIds);
@@ -1365,7 +1382,7 @@ function TabRuntime({
 
   const resolveConfirm = useCallback(
     (id: number, response: ConfirmationChoice) => {
-      sendRpc({ cmd: "confirm_response", id, response });
+      sendRpc({ cmd: "confirm_response", id, response, kind: "shell" });
       dispatch({ t: "resolve_confirm", id });
     },
     [sendRpc],
@@ -1384,7 +1401,7 @@ function TabRuntime({
   );
   const resolvePathAccess = useCallback(
     (id: number, response: ConfirmationChoice) => {
-      sendRpc({ cmd: "confirm_response", id, response });
+      sendRpc({ cmd: "confirm_response", id, response, kind: "path" });
       dispatch({ t: "resolve_path_access", id });
     },
     [sendRpc],

--- a/dashboard/src/lib/tauri-bridge.ts
+++ b/dashboard/src/lib/tauri-bridge.ts
@@ -197,7 +197,10 @@ function sseToIncoming(ev: any): Record<string, any>[] {
       break;
     }
     case "modal-down": {
-      // Modal closed — normally handled by user action response
+      // Sync close from another surface (TUI or sibling tab).
+      if (typeof ev.modalKind === "string") {
+        results.push({ type: "$modal_dismissed", tabId: "tab-1", kind: ev.modalKind });
+      }
       break;
     }
     case "warning":
@@ -711,37 +714,51 @@ async function serverRpc(payload: Record<string, any>): Promise<void> {
       break;
     }
     case "confirm_response": {
-      await apiFetch("modal", {
+      const kind = payload.kind === "path" ? "path" : "shell";
+      await apiFetch("modal/resolve", {
         method: "POST",
-        body: JSON.stringify({ id: payload.id, response: payload.response }),
+        body: JSON.stringify({ kind, choice: payload.response.type }),
       }).catch(() => {});
       break;
     }
     case "choice_response": {
-      await apiFetch("modal", {
+      const r = payload.response;
+      let choice: Record<string, unknown>;
+      if (r.type === "pick") choice = { kind: "pick", optionId: r.optionId };
+      else if (r.type === "text") choice = { kind: "custom", text: r.text };
+      else choice = { kind: "cancel" };
+      await apiFetch("modal/resolve", {
         method: "POST",
-        body: JSON.stringify({ id: payload.id, response: payload.response }),
+        body: JSON.stringify({ kind: "choice", choice }),
       }).catch(() => {});
       break;
     }
     case "plan_response": {
-      await apiFetch("modal", {
+      const r = payload.response;
+      await apiFetch("modal/resolve", {
         method: "POST",
-        body: JSON.stringify({ id: payload.id, response: payload.response }),
+        body: JSON.stringify({ kind: "plan", choice: r.type, text: r.feedback }),
       }).catch(() => {});
       break;
     }
     case "checkpoint_response": {
-      await apiFetch("modal", {
+      const r = payload.response;
+      const text = r.type === "revise" ? r.feedback : undefined;
+      await apiFetch("modal/resolve", {
         method: "POST",
-        body: JSON.stringify({ id: payload.id, response: payload.response }),
+        body: JSON.stringify({ kind: "checkpoint", choice: r.type, text }),
       }).catch(() => {});
       break;
     }
     case "revision_response": {
-      await apiFetch("modal", {
+      const r = payload.response;
+      // Server takes "accept" / "reject"; verdict uses past-participle.
+      const choice =
+        r.type === "accepted" ? "accept" : r.type === "rejected" ? "reject" : null;
+      if (choice === null) break;
+      await apiFetch("modal/resolve", {
         method: "POST",
-        body: JSON.stringify({ id: payload.id, response: payload.response }),
+        body: JSON.stringify({ kind: "revision", choice }),
       }).catch(() => {});
       break;
     }

--- a/dashboard/src/protocol.ts
+++ b/dashboard/src/protocol.ts
@@ -88,6 +88,17 @@ export type RevisionRequiredEvent = {
 
 export type RevisionVerdict = { type: "accepted" } | { type: "rejected" } | { type: "cancelled" };
 
+export type ModalKind =
+  | "shell"
+  | "path"
+  | "choice"
+  | "plan"
+  | "checkpoint"
+  | "revision"
+  | "edit-review";
+
+export type ModalDismissedEvent = { type: "$modal_dismissed"; kind: ModalKind };
+
 export type StepCompletedEvent = {
   type: "$step_completed";
   stepId: string;
@@ -450,6 +461,7 @@ export type IncomingEvent = { tabId?: string } & (
   | BalanceEvent
   | CheckpointRequiredEvent
   | RevisionRequiredEvent
+  | ModalDismissedEvent
   | StepCompletedEvent
   | PlanClearedEvent
   | MentionResultsEvent
@@ -479,7 +491,7 @@ export type IncomingEvent = { tabId?: string } & (
 export type OutgoingCommand = { tabId?: string } & (
   | { cmd: "user_input"; text: string }
   | { cmd: "abort" }
-  | { cmd: "confirm_response"; id: number; response: ConfirmationChoice }
+  | { cmd: "confirm_response"; id: number; response: ConfirmationChoice; kind: "shell" | "path" }
   | { cmd: "choice_response"; id: number; response: ChoiceVerdict }
   | { cmd: "plan_response"; id: number; response: PlanVerdict }
   | { cmd: "checkpoint_response"; id: number; response: CheckpointVerdict }


### PR DESCRIPTION
## Summary

Closes #1831.

Two independent bugs left the TUI and Web dashboard out of sync whenever a confirmation modal (shell / path / choice / plan / checkpoint / revision) was up:

1. **Web → TUI**: the dashboard POSTed to `/api/modal` with `{id, response}`, but the server route is `/api/modal/resolve` and the body shape is `{kind, choice, text?}`. Every web "Approve" returned 405 silently; `pauseGate` stayed blocked and the terminal kept showing the picker.
2. **TUI → Web**: when the user resolved in the terminal, the SSE bridge logged `modal-down` and did nothing with it, so the web modal stayed up indefinitely.

## Fix

- `tauri-bridge.ts` outgoing handlers POST to `/api/modal/resolve` with the proper `{kind, choice, text?}` shape (mapping `text` ↔ `custom` for choice, past-participle ↔ verb for revision).
- `confirm_response` carries `kind: "shell" | "path"` so the bridge can route to the right server handler.
- `modal-down` now emits a new `\$modal_dismissed` event; the dashboard reducer clears the corresponding pending list.

## Test plan

- [x] `npm run verify` (build + lint + typecheck + 3727 tests) passes on the worktree
- [ ] Manual: open dashboard + terminal, hit a shell-confirm — clicking Allow in the browser unblocks the task and dismisses the TUI prompt
- [ ] Manual: same path, resolve in terminal first — the web modal closes via the new `modal-down` handling