### PR TITLE
test(jobs): wait for tail output before asserting

### DIFF
--- a/tests/jobs.test.ts
+++ b/tests/jobs.test.ts
@@ -122,6 +122,7 @@ describe("JobRegistry", () => {
   it("tailLines caps returned output to the last N lines", async () => {
     const cmd = `node -e "for (let i=0;i<50;i++) console.log('line'+i); setTimeout(()=>{}, 10000)"`;
     const res = await registry.start(cmd, { cwd, waitSec: 0.5 });
+    await waitFor(() => registry.read(res.jobId)?.output.includes("line49") ?? false, 3000);
     const tailed = registry.read(res.jobId, { tailLines: 5 });
     const lines = (tailed?.output ?? "").split("\n").filter(Boolean);
     expect(lines.length).toBeLessThanOrEqual(5);


### PR DESCRIPTION
## Summary
- Wait for the final expected line before asserting `tailLines` output.
- Keeps the `tailLines` test from reading an empty buffer on slower Windows runners.

## Context
Split from #1827 per maintainer feedback; this is unrelated to prompt repaint behavior.

## Validation
- npx vitest run tests/jobs.test.ts --reporter verbose
- npx biome check tests/jobs.test.ts
- npm run typecheck
- npm run verify