### PR TITLE
fix(tui): guard ASCII IME enter commits

### DIFF
--- a/src/cli/ui/PromptInput.tsx
+++ b/src/cli/ui/PromptInput.tsx
@@ -34,6 +34,14 @@ function hasNonAscii(s: string): boolean {
   return false;
 }
 
+function isPotentialImeCommitInput(s: string): boolean {
+  if (s.length === 0) return false;
+  if (hasNonAscii(s)) return true;
+  // WeChat IME English mode can commit an ASCII word as one burst, then
+  // pass the confirming Enter through as the next key event.
+  return s.length > 1;
+}
+
 export function shouldInlinePaste(content: string): boolean {
   return !content.includes("\n") && content.length <= INLINE_PASTE_THRESHOLD;
 }
@@ -90,10 +98,12 @@ export function PromptInput({
   const pastesRef = useRef<Map<number, PasteEntry>>(new Map());
   const nextPasteIdRef = useRef<number>(0);
 
-  // CJK IMEs commit the candidate then often pass the trigger Enter through
+  // IMEs commit the candidate then often pass the trigger Enter through
   // as a real keystroke; terminals can't expose composition state. If submit
-  // fires within IME_GUARD_MS of non-ASCII input we treat it as that commit-Enter.
-  const lastNonAsciiInputAtRef = useRef(0);
+  // fires within IME_GUARD_MS of a likely IME commit we treat it as that
+  // commit-Enter. CJK commits are non-ASCII; WeChat English-mode commits are
+  // ASCII bursts rather than ordinary per-key input.
+  const lastImeCommitInputAtRef = useRef(0);
 
   // Refs (not props/state) — multiple keystrokes in one stdin chunk dispatch
   // before re-render, so the handler must read the latest value/cursor.
@@ -136,8 +146,8 @@ export function PromptInput({
       if (ev.input.length > 0) registerPaste(ev.input);
       return;
     }
-    if (ev.input.length > 0 && hasNonAscii(ev.input)) {
-      lastNonAsciiInputAtRef.current = Date.now();
+    if (isPotentialImeCommitInput(ev.input)) {
+      lastImeCommitInputAtRef.current = Date.now();
     }
     const key: MultilineKey = {
       input: ev.input,
@@ -172,8 +182,8 @@ export function PromptInput({
       setCursor(action.cursor);
     }
     if (action.submit) {
-      if (Date.now() - lastNonAsciiInputAtRef.current < IME_GUARD_MS) {
-        lastNonAsciiInputAtRef.current = 0;
+      if (Date.now() - lastImeCommitInputAtRef.current < IME_GUARD_MS) {
+        lastImeCommitInputAtRef.current = 0;
         return;
       }
       const raw = action.submitValue ?? lastLocalValueRef.current;

--- a/tests/prompt-input-ime.test.tsx
+++ b/tests/prompt-input-ime.test.tsx
@@ -1,0 +1,85 @@
+import { render } from "ink";
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { PromptInput } from "../src/cli/ui/PromptInput.js";
+import {
+  type KeystrokeHandler,
+  KeystrokeProvider,
+  type KeystrokeReader,
+  makeKeyEvent,
+} from "../src/cli/ui/keystroke-context.js";
+import type { KeyEvent } from "../src/cli/ui/stdin-reader.js";
+import { makeFakeStdin, makeFakeStdout } from "./helpers/ink-stdio.js";
+
+class FakeReader implements KeystrokeReader {
+  private readonly handlers = new Set<KeystrokeHandler>();
+
+  start(): void {
+    // no-op
+  }
+
+  subscribe(handler: KeystrokeHandler): () => void {
+    this.handlers.add(handler);
+    return () => {
+      this.handlers.delete(handler);
+    };
+  }
+
+  feed(ev: Partial<KeyEvent>): void {
+    const event = makeKeyEvent(ev);
+    for (const handler of [...this.handlers]) handler(event);
+  }
+}
+
+async function wait(ms = 0): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function PromptHarness({ onSubmit }: { onSubmit: (value: string) => void }): React.ReactElement {
+  const [value, setValue] = React.useState("");
+  return <PromptInput value={value} onChange={setValue} onSubmit={onSubmit} />;
+}
+
+function renderPrompt(onSubmit: (value: string) => void) {
+  const reader = new FakeReader();
+  const stdout = makeFakeStdout();
+  const instance = render(
+    <KeystrokeProvider reader={reader}>
+      <PromptHarness onSubmit={onSubmit} />
+    </KeystrokeProvider>,
+    {
+      stdout: stdout as never,
+      stdin: makeFakeStdin() as never,
+      incrementalRendering: true,
+    },
+  );
+  return { reader, ...instance };
+}
+
+describe("PromptInput IME handling", () => {
+  it("does not submit when an IME commits an ASCII word immediately before Enter (#1853)", async () => {
+    const onSubmit = vi.fn();
+    const { reader, unmount } = renderPrompt(onSubmit);
+    await wait();
+
+    reader.feed({ input: "hello" });
+    reader.feed({ return: true });
+    await wait();
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it("still submits after ordinary per-key ASCII typing", async () => {
+    const onSubmit = vi.fn();
+    const { reader, unmount } = renderPrompt(onSubmit);
+    await wait();
+
+    for (const ch of "hello") reader.feed({ input: ch });
+    reader.feed({ return: true });
+    await wait();
+
+    expect(onSubmit).toHaveBeenCalledWith("hello");
+    unmount();
+  });
+});


### PR DESCRIPTION
## What

Fixes TUI prompt input so an immediate Enter after a burst ASCII IME commit is treated as IME confirmation instead of prompt submission. Adds a PromptInput regression for WeChat IME English-mode commits.

## Why

Fixes #1853. WeChat IME English mode can commit an ASCII word in one input event, then forward the confirming Enter as the next key event; the existing guard only covered non-ASCII commits.

## How to verify

- `npm test -- tests/prompt-input-ime.test.tsx tests/multiline-keys.test.ts tests/stdin-reader.test.ts --reporter=dot`
- `npx biome check src/cli/ui/PromptInput.tsx tests/prompt-input-ime.test.tsx`
- `npm run verify`

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time