### PR TITLE
fix(desktop): unit-suffix CSS vars during drag, use canonical thread-width helper

### DIFF
--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -1615,10 +1615,9 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
   flex-direction: column;
   gap: 28px;
 }
-/* Skip offscreen message layout during resize — critical for long sessions */
 .thread-inner > div[data-turn] {
   content-visibility: auto;
-  contain-intrinsic-size: 1px 100px;
+  contain-intrinsic-size: auto 100px;
 }
 
 /* ---------- JUMP BAR (message navigation dock) ---------- */

--- a/desktop/src/ui/useResizable.ts
+++ b/desktop/src/ui/useResizable.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { getThreadMaxWidth } from "./thread-layout";
 
 const MIN_WIDTH = 160;
 const MAX_WIDTH_PCT = 0.4;
@@ -68,18 +69,18 @@ export function useResizable(
       next = Math.max(MIN_WIDTH, Math.min(next, maxW));
       widthRef.current = next;
 
-      // Update CSS variable + React state every frame
       appEl.style.setProperty(cssVar, `${next}px`);
       setWidth(next);
 
-      // Sync thread/composer max-width in lockstep
       const otherVar = side === "side" ? "--ctx-width" : "--side-width";
-      const o = parseFloat(appEl.style.getPropertyValue(otherVar)) || 0;
-      const sideW = side === "side" ? next : o;
-      const ctxW = side === "ctx" ? next : o;
-      const tMax = String(Math.max(580, Math.min(window.innerWidth - sideW - ctxW - 80, 1120)));
-      appEl.style.setProperty("--thread-max-width", tMax);
-      appEl.style.setProperty("--composer-max-width", tMax);
+      const otherW = Number.parseFloat(appEl.style.getPropertyValue(otherVar)) || 0;
+      const tMax = getThreadMaxWidth({
+        viewportWidth: window.innerWidth,
+        visibleSide: side === "side" ? next : otherW,
+        visibleCtx: side === "ctx" ? next : otherW,
+      });
+      appEl.style.setProperty("--thread-max-width", `${tMax}px`);
+      appEl.style.setProperty("--composer-max-width", `${tMax}px`);
     };
 
     const onUp = () => {


### PR DESCRIPTION
## Summary

Three follow-ups to #1812 surfaced during review:

1. **`--thread-max-width` / `--composer-max-width` were written without a `px` unit during drag** — the direct DOM write in `useResizable.onMove` set the variables to bare numbers (e.g. `"720"`), so consumers like `max-width: var(--thread-max-width, 740px)` resolved to the invalid-fallback `740px` for one frame per mousemove until React re-rendered with a properly suffixed value. Visible flicker during drag, defeating the perf win.

2. **Inline formula duplicated `getThreadMaxWidth`** — the same `Math.max(580, Math.min(viewportWidth - side - ctx - 80, 1120))` lives in `desktop/src/ui/thread-layout.ts` and is exercised by `App.test.ts`. Inlining a second copy in the drag path means the two can drift.

3. **`contain-intrinsic-size: 1px 100px`** — the 1px width hint forces offscreen messages to report 1px-wide intrinsic size, which is wrong for any non-default thread width and can throw scroll-extent estimates off. `auto 100px` lets the browser remember the last-rendered width.

## Test plan

- [x] `npm run verify` — all 3727 tests pass (281 files)
- [ ] Drag the sidebar on a long-running session: thread content should hold its width steadily, no width flicker
- [ ] Scroll through a long thread after drag: no visible scroll-extent jumps as offscreen turns hydrate

Closes the follow-up nits from #1812.