### PR TITLE
fix(tui): suppress submit on IME atomic commit (#1853)

### DIFF
--- a/src/cli/ui/PromptInput.tsx
+++ b/src/cli/ui/PromptInput.tsx
@@ -22,9 +22,11 @@ import { FG, SURFACE, TONE } from "./theme/tokens.js";
 /** Pastes shorter than this AND single-line render verbatim; longer ones become a `[paste #N · …]` sentinel chip (#397). */
 export const INLINE_PASTE_THRESHOLD = 200;
 
-// Tight enough that a normal typed Enter (≥80ms after the last keystroke
-// for human cadence) still submits; wide enough that CJK IME commit-then-
-// Enter (terminal flushes both together) falls inside the window.
+// Belt-and-suspenders for IMEs that flush the commit-text and the Enter
+// across two stdin chunks within a few ms — same-chunk IME commits are
+// caught earlier via the stdin reader's `compositionCommit` flag, but
+// some terminal/IME pairs split the flush. Tight enough that normal
+// type-then-Enter (≥80ms human cadence) still submits.
 const IME_GUARD_MS = 50;
 
 function hasNonAscii(s: string): boolean {
@@ -172,6 +174,7 @@ export function PromptInput({
       setCursor(action.cursor);
     }
     if (action.submit) {
+      if (ev.compositionCommit) return;
       if (Date.now() - lastNonAsciiInputAtRef.current < IME_GUARD_MS) {
         lastNonAsciiInputAtRef.current = 0;
         return;

--- a/src/cli/ui/stdin-reader.ts
+++ b/src/cli/ui/stdin-reader.ts
@@ -23,6 +23,8 @@ export interface KeyEvent {
   meta?: boolean;
   /** Bracketed-paste content; consumers MUST NOT re-interpret as keystrokes (e.g. `\n` ≠ submit). */
   paste?: boolean;
+  /** Bare Enter that arrived in the same chunk as preceding text — IME atomic commit (#1853), consumers MUST NOT submit. */
+  compositionCommit?: boolean;
   /** xterm SGR mode 1006 wheel-up. */
   mouseScrollUp?: boolean;
   /** Mouse wheel down — symmetric to `mouseScrollUp`. */
@@ -264,6 +266,8 @@ export class StdinReader {
   // split sequence like `\x1b` + `[A` would dispatch escape+upArrow
   // even though the user only pressed Up.
   private escImmediate: NodeJS.Immediate | null = null;
+  /** Reset per chunk; true when the previous dispatch in this chunk was bare printable input. Drives `compositionCommit` on a same-chunk Enter. */
+  private prevInputInChunk = false;
   private started = false;
   /** The actual `data` listener — kept as a field so `stop()` can detach it. */
   private listener: ((chunk: Buffer | string) => void) | null = null;
@@ -317,7 +321,22 @@ export class StdinReader {
   }
 
   private dispatch(ev: KeyEvent): void {
-    for (const sub of this.subscribers) sub(ev);
+    const isBareEnter =
+      ev.return === true && !ev.shift && !ev.ctrl && !ev.meta && !ev.compositionCommit;
+    const out: KeyEvent =
+      isBareEnter && this.prevInputInChunk ? { ...ev, compositionCommit: true } : ev;
+    const isPrintableInput =
+      ev.input.length > 0 &&
+      !ev.ctrl &&
+      !ev.meta &&
+      !ev.paste &&
+      !ev.return &&
+      !ev.tab &&
+      !ev.escape &&
+      !ev.backspace &&
+      !ev.delete;
+    this.prevInputInChunk = isPrintableInput;
+    for (const sub of this.subscribers) sub(out);
   }
 
   private cancelEscTimer(): void {
@@ -353,6 +372,7 @@ export class StdinReader {
 
   private handleChunk(rawChunk: string): void {
     this.cancelEscTimer();
+    this.prevInputInChunk = false;
     // Paste rescue when DECSET 2004 markers don't arrive (multiplexers
     // strip them, some Windows pipes too) — otherwise each \r in a
     // multi-line paste fires Enter and the loop submits N prompts (#522).

--- a/tests/stdin-reader.test.ts
+++ b/tests/stdin-reader.test.ts
@@ -312,10 +312,17 @@ describe("StdinReader — heuristic paste rescue (#522)", () => {
     ]);
   });
 
-  it("leaves typed-then-Enter alone (`abc\\r` is not flagged as paste)", () => {
+  it("flags same-chunk text+Enter as compositionCommit (IME atomic flush)", () => {
+    // No human can type "abc" + Enter inside one stdin chunk (keystrokes
+    // are tens of ms apart, terminals flush each one). A single-chunk
+    // `abc\r` is therefore an IME commit — e.g. WeChat English mode —
+    // and Enter must not trigger submit (issue #1853).
     const { reader, events } = setup();
     reader.feed("abc\r");
-    expect(events).toEqual([{ input: "abc" }, { input: "", return: true }]);
+    expect(events).toEqual([
+      { input: "abc" },
+      { input: "", return: true, compositionCommit: true },
+    ]);
   });
 
   it("leaves Enter-then-typed alone (`\\rabc` is not flagged as paste)", () => {
@@ -347,6 +354,50 @@ describe("StdinReader — heuristic paste rescue (#522)", () => {
     reader.feed("first\r\nsecond\r\nthird");
     // Whole chunk wrapped → paste accumulator delivers normalized logical lines.
     expect(events).toEqual([{ input: "first\nsecond\nthird", paste: true }]);
+  });
+});
+
+describe("StdinReader — compositionCommit (IME atomic flush, issue #1853)", () => {
+  it("bare Enter in its own chunk has no compositionCommit flag", () => {
+    const { reader, events } = setup();
+    reader.feed("\r");
+    expect(events).toEqual([{ input: "", return: true }]);
+  });
+
+  it("Enter in a separate chunk from the typed text is not flagged (real human cadence)", () => {
+    const { reader, events } = setup();
+    reader.feed("abc");
+    reader.feed("\r");
+    expect(events).toEqual([{ input: "abc" }, { input: "", return: true }]);
+  });
+
+  it("Shift+Enter in the same chunk as text stays as a newline insert, not a commit", () => {
+    // Mod+Enter is intentional user action (newline-insert), never IME commit.
+    const { reader, events } = setup();
+    reader.feed("abc\x1b[27;2;13~");
+    expect(events).toEqual([{ input: "abc" }, { input: "", return: true, shift: true }]);
+  });
+
+  it("resets between chunks so a later same-chunk burst still flags", () => {
+    const { reader, events } = setup();
+    reader.feed("abc");
+    reader.feed("\r");
+    reader.feed("de\r");
+    expect(events).toEqual([
+      { input: "abc" },
+      { input: "", return: true },
+      { input: "de" },
+      { input: "", return: true, compositionCommit: true },
+    ]);
+  });
+
+  it("Enter that follows a non-input event (arrow) is not flagged", () => {
+    const { reader, events } = setup();
+    reader.feed("\x1b[A\r");
+    expect(events).toEqual([
+      { input: "", upArrow: true },
+      { input: "", return: true },
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #1853.

WeChat IME in English mode (and other IMEs that commit ASCII candidates) finalize a candidate by writing the chosen text plus the trigger Enter as one terminal write. The TUI's existing `IME_GUARD_MS` only arms when the preceding input was non-ASCII, so the bare Enter slipped straight through `processMultilineKey` and triggered submit while the user was still composing.

## Fix

Detect the burst at the stdin layer instead of trying to distinguish it after the fact:

- `KeyEvent` gains an optional `compositionCommit: boolean`.
- `StdinReader.dispatch` flags any bare Enter (no shift/ctrl/meta) whose immediately-prior dispatch in the same chunk was bare printable input. `prevInputInChunk` is reset at the top of `handleChunk`, so chunks dispatched independently don't carry state across.
- `PromptInput` drops `action.submit` when the flag is set.

The signal is unambiguous: a real human can't type characters and press Enter inside one stdin chunk — keystrokes are tens of ms apart, terminals flush each keystroke before the next arrives. Same-chunk `text\r` is therefore an IME (or paste) atomic flush. The existing 50ms non-ASCII timer in `PromptInput` is kept as belt-and-suspenders for IMEs that split the commit and the Enter across two chunks within a few ms.

## Tests

`tests/stdin-reader.test.ts` — updated the "typed-then-Enter" assertion (`abc\r` now flags the Enter), added five new cases:

- bare Enter in its own chunk → no flag
- text + Enter in separate chunks → no flag (real human cadence)
- Shift+Enter in same chunk → not flagged (intentional newline-insert)
- flag resets between chunks
- Enter after a non-input event (arrow) is not flagged

71 stdin-reader tests pass, plus 9 comment-policy + 104 surrounding input tests (multiline-keys, key-normalize, paste-collapse).

## Checklist

- [x] `npm run verify` passes locally
- [x] No `Co-Authored-By: Claude` trailer
- [x] Comments follow CONTRIBUTING.md
- [x] No CHANGELOG edits