### PR TITLE
feat(proxy): accept proxy.url from config.json

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -58,14 +58,17 @@ export async function runDoctorChecks(projectRoot: string): Promise<DoctorCheck[
 const PROXY_PROBE_HOSTS = ["api.deepseek.com", "github.com", "api.github.com"] as const;
 
 function checkProxy(): Check[] {
-  const url = detectProxyUrl();
+  const cfg = loadProxyConfig();
+  const envUrl = detectProxyUrl();
+  const url = cfg.url ?? envUrl;
   if (!url) {
     return [
       {
         id: "proxy",
         label: "http proxy   ",
         level: "ok",
-        detail: "no HTTPS_PROXY / HTTP_PROXY / ALL_PROXY set — direct connection",
+        detail:
+          "no proxy configured (cfg.proxy.url / HTTPS_PROXY / HTTP_PROXY / ALL_PROXY unset) — direct connection",
       },
     ];
   }
@@ -80,14 +83,14 @@ function checkProxy(): Check[] {
   } catch {
     /* not a URL — leave raw */
   }
-  const cfg = loadProxyConfig();
+  const urlSource = cfg.url ? "cfg.proxy.url" : "HTTPS_PROXY";
   if (cfg.disabled) {
     return [
       {
         id: "proxy",
         label: "http proxy   ",
         level: "ok",
-        detail: `HTTPS_PROXY=${redacted} is set but cfg.proxy.disabled — Reasonix routes direct`,
+        detail: `${urlSource}=${redacted} is set but cfg.proxy.disabled — Reasonix routes direct`,
       },
     ];
   }
@@ -108,7 +111,7 @@ function checkProxy(): Check[] {
     id: "proxy",
     label: "http proxy   ",
     level: "ok",
-    detail: `routing fetch through ${redacted} (NO_PROXY: ${total} pattern${total === 1 ? "" : "s"} — ${sourceSummary})`,
+    detail: `routing fetch through ${redacted} via ${urlSource} (NO_PROXY: ${total} pattern${total === 1 ? "" : "s"} — ${sourceSummary})`,
   };
   const probes = PROXY_PROBE_HOSTS.map(
     (h) => `${h} → ${matchesNoProxy(h, resolved.all) ? "direct" : "via proxy"}`,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -55,6 +55,7 @@ const cliNoProxy = process.argv.includes("--no-proxy");
 const cfgProxy = loadProxyConfig();
 installProxyIfConfigured(process.env, {
   disabled: cliNoProxy || cfgProxy.disabled === true,
+  url: cfgProxy.url,
   extraNoProxy: cfgProxy.noProxy,
   bypassDeepSeekDirect: cfgProxy.bypassDeepSeekDirect,
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -136,6 +136,8 @@ export interface RateLimitConfig {
 }
 
 export interface ProxyConfig {
+  /** Proxy URL (e.g. `http://127.0.0.1:7897`, `socks5://host:1080`). Takes precedence over HTTPS_PROXY / HTTP_PROXY / ALL_PROXY env vars when set, so desktop users on Windows can route through Clash without fighting GUI env-var propagation (issue #1868). */
+  url?: string;
   /** Skip proxy detection entirely — equivalent to launching with `--no-proxy`. */
   disabled?: boolean;
   /** Additional NO_PROXY patterns (curl syntax). Additive on top of env NO_PROXY and the default DeepSeek-bypass whitelist. */
@@ -681,6 +683,7 @@ export function loadProxyConfig(path: string = defaultConfigPath()): ProxyConfig
   const cfg = readConfig(path).proxy;
   if (!cfg || typeof cfg !== "object") return {};
   const out: ProxyConfig = {};
+  if (typeof cfg.url === "string" && cfg.url.trim() !== "") out.url = cfg.url.trim();
   if (cfg.disabled === true) out.disabled = true;
   if (Array.isArray(cfg.noProxy)) {
     const entries = cfg.noProxy.filter(

--- a/src/net/proxy.ts
+++ b/src/net/proxy.ts
@@ -162,19 +162,24 @@ class SelectiveProxyDispatcher {
 
 let installed = false;
 
-export interface ProxyInstallResult {
-  url: string;
-  reinstalled: boolean;
-  noProxy: readonly NoProxyPattern[];
-}
-
 export interface InstallProxyOptions {
   /** Skip proxy install entirely — for `--no-proxy` / `cfg.proxy.disabled` / env-driven kill-switch. */
   disabled?: boolean;
+  /** Config-supplied proxy URL. Wins over env detection so desktop-GUI users who can't reliably set HTTPS_PROXY can still route via `cfg.proxy.url` (issue #1868). */
+  url?: string;
   /** Additional NO_PROXY patterns layered on top of defaults + env. Sourced from `cfg.proxy.noProxy` / `REASONIX_NO_PROXY`. */
   extraNoProxy?: readonly string[];
   /** When false, route api.deepseek.com / *.deepseek.com through the proxy too (issue #1497). Default true preserves the clash/v2ray US-exit-IP 403 fix. */
   bypassDeepSeekDirect?: boolean;
+}
+
+export type ProxyUrlSource = "config" | "env";
+
+export interface ProxyInstallResult {
+  url: string;
+  source: ProxyUrlSource;
+  reinstalled: boolean;
+  noProxy: readonly NoProxyPattern[];
 }
 
 export interface ResolvedNoProxy {
@@ -229,21 +234,24 @@ export function resolveNoProxy(
   };
 }
 
-/** Sets the undici global dispatcher to a SelectiveProxyDispatcher (proxy for non-NO_PROXY hosts, direct for matches). Returns the proxy URL + parsed NO_PROXY patterns, or null when no env var is set, the value is unparseable, the ProxyAgent ctor throws, or opts.disabled is true. Idempotent. */
+/** Sets the undici global dispatcher to a SelectiveProxyDispatcher (proxy for non-NO_PROXY hosts, direct for matches). `opts.url` (from `cfg.proxy.url`) wins over env detection; falls back to HTTPS_PROXY / HTTP_PROXY / ALL_PROXY. Returns the proxy URL + source + parsed NO_PROXY patterns, or null when nothing is configured, the value is unparseable, the ProxyAgent ctor throws, or opts.disabled is true. Idempotent. */
 export function installProxyIfConfigured(
   env: NodeJS.ProcessEnv = process.env,
   opts: InstallProxyOptions = {},
 ): ProxyInstallResult | null {
   if (opts.disabled) return null;
-  const raw = detectProxyUrl(env);
+  const configRaw = typeof opts.url === "string" && opts.url.trim() !== "" ? opts.url.trim() : null;
+  const raw = configRaw ?? detectProxyUrl(env);
   if (!raw) return null;
   const url = normalizeProxyUrl(raw);
   if (!url) {
+    const origin = configRaw ? "config value" : "env value";
     process.stderr.write(
-      `▲ ignoring proxy env value ${JSON.stringify(raw)} — not a valid URL. Expected something like \`http://host:port\` or \`socks5://host:port\`.\n`,
+      `▲ ignoring proxy ${origin} ${JSON.stringify(raw)} — not a valid URL. Expected something like \`http://host:port\` or \`socks5://host:port\`.\n`,
     );
     return null;
   }
+  const source: ProxyUrlSource = configRaw ? "config" : "env";
 
   // Default whitelist always applies; env NO_PROXY, REASONIX_NO_PROXY, and
   // opts.extraNoProxy (config) all layer on top additively. Composition lives
@@ -258,8 +266,8 @@ export function installProxyIfConfigured(
     setGlobalDispatcher(new SelectiveProxyDispatcher(url, patterns) as unknown as Dispatcher);
     installed = true;
     const bypassList = patterns.map((p) => p.raw).join(",");
-    process.stderr.write(`[proxy] using ${url} (NO_PROXY: ${bypassList})\n`);
-    return { url, reinstalled, noProxy: patterns };
+    process.stderr.write(`[proxy] using ${url} (source: ${source}, NO_PROXY: ${bypassList})\n`);
+    return { url, source, reinstalled, noProxy: patterns };
   } catch (err) {
     process.stderr.write(
       `▲ proxy install failed (${(err as Error).message}); continuing without proxy.\n`,

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -285,6 +285,14 @@ describe("config", () => {
     expect(loadProxyConfig(path)).toEqual({});
   });
 
+  it("loads proxy.url and trims it; ignores blank values (#1868)", () => {
+    writeConfig({ proxy: { url: "  http://127.0.0.1:7897  " } }, path);
+    expect(loadProxyConfig(path)).toEqual({ url: "http://127.0.0.1:7897" });
+
+    writeConfig({ proxy: { url: "   " } }, path);
+    expect(loadProxyConfig(path)).toEqual({});
+  });
+
   it("loads toolRateLimit with defaults and opt-out", () => {
     writeConfig(
       {

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -256,6 +256,42 @@ describe("installProxyIfConfigured", () => {
     expect(installProxyIfConfigured({ HTTPS_PROXY: "http://[invalid:::" })).toBeNull();
     expect(writes.join("")).toMatch(/ignoring proxy env value/);
   });
+
+  it("opts.url (cfg.proxy.url) installs even when no env var is set — source=config (#1868)", () => {
+    const result = installProxyIfConfigured({}, { url: "http://127.0.0.1:7897" });
+    expect(result?.url).toBe("http://127.0.0.1:7897/");
+    expect(result?.source).toBe("config");
+    expect(writes.join("")).toMatch(/source: config/);
+  });
+
+  it("opts.url wins over HTTPS_PROXY env var (config beats env, #1868)", () => {
+    const result = installProxyIfConfigured(
+      { HTTPS_PROXY: "http://env.example:8080" },
+      { url: "http://cfg.example:7897" },
+    );
+    expect(result?.url).toBe("http://cfg.example:7897/");
+    expect(result?.source).toBe("config");
+  });
+
+  it("opts.url is normalized like env values (bare host:port → http://, #1868)", () => {
+    const result = installProxyIfConfigured({}, { url: "127.0.0.1:7897" });
+    expect(result?.url).toBe("http://127.0.0.1:7897/");
+  });
+
+  it("malformed opts.url is rejected with a config-flavored warning, not env (#1868)", () => {
+    const result = installProxyIfConfigured({}, { url: "http://[invalid:::" });
+    expect(result).toBeNull();
+    expect(writes.join("")).toMatch(/ignoring proxy config value/);
+  });
+
+  it("whitespace-only opts.url falls back to env detection", () => {
+    const result = installProxyIfConfigured(
+      { HTTPS_PROXY: "http://env.example:8080" },
+      { url: "   " },
+    );
+    expect(result?.url).toBe("http://env.example:8080/");
+    expect(result?.source).toBe("env");
+  });
 });
 
 describe("resolveNoProxy", () => {


### PR DESCRIPTION
## Summary

Desktop and GUI users on Windows often can't reliably set `HTTPS_PROXY` for the spawned Reasonix process — env vars exported by Clash, system settings, or PowerShell profiles don't always reach a Tauri-launched child. The proxy infrastructure already exists (selective `undici.ProxyAgent`, NO_PROXY composition, /doctor surfacing); only the env-var source path was wired.

Adds `cfg.proxy.url` as a first-class source:

- Wins over `HTTPS_PROXY` / `HTTP_PROXY` / `ALL_PROXY` when set.
- Normalized the same way as env (bare `host:port` → `http://host:port`).
- Install result now carries `source: "config" | "env"`, surfaced in /doctor.
- Malformed config value emits a config-flavored warning (not env), and falls back to env if the value is whitespace-only.

A user behind GFW can now drop this into `~/.reasonix/config.json` and `web_search` / `web_fetch` route through their local proxy:

\`\`\`json
{ "proxy": { "url": "http://127.0.0.1:7897" } }
\`\`\`

Closes #1868

## Test plan

- [x] `npx vitest run tests/proxy.test.ts tests/config.test.ts` — 139/139 pass (+5 proxy + 1 config new)
- [x] `npm run typecheck`
- [x] `npm run verify` (pre-push gate) green
- [ ] Manually set `proxy.url` in `~/.reasonix/config.json`, run `reasonix doctor`, confirm the line reads `routing fetch through http://… via cfg.proxy.url`
- [ ] With `HTTPS_PROXY=http://env:1234` *and* `proxy.url=http://cfg:5678` both set, /doctor should show the cfg URL won