### PR TITLE
feat(config): accept DEEPSEEK_API_BASE_URL as base-URL env alias

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 DEEPSEEK_API_KEY=sk-your-key-here
 DEEPSEEK_BASE_URL=https://api.deepseek.com
+# DEEPSEEK_API_BASE_URL is accepted as an alias of DEEPSEEK_BASE_URL.
 REASONIX_LOG_LEVEL=INFO
 REASONIX_TRANSCRIPT_DIR=./transcripts

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,5 @@
 import { type EventSourceMessage, createParser } from "eventsource-parser";
-import { loadRateLimit } from "./config.js";
+import { loadRateLimit, resolveBaseUrlEnv } from "./config.js";
 import { type RetryOptions, fetchWithRetry } from "./retry.js";
 import type { ChatMessage, ChatRequestOptions, RawUsage, ToolCall, ToolSpec } from "./types.js";
 
@@ -110,7 +110,7 @@ export class DeepSeekClient {
       );
     }
     this.apiKey = apiKey;
-    let url = opts.baseUrl ?? process.env.DEEPSEEK_BASE_URL ?? "https://api.deepseek.com";
+    let url = opts.baseUrl ?? resolveBaseUrlEnv() ?? "https://api.deepseek.com";
     // Manual trim — `/\/+$/` is O(n²) on slash-heavy non-matches per CodeQL js/polynomial-redos.
     while (url.endsWith("/")) url = url.slice(0, -1);
     this.baseUrl = url;

--- a/src/config.ts
+++ b/src/config.ts
@@ -627,11 +627,18 @@ export interface ResolvedEndpoint {
   apiKey: string | undefined;
 }
 
+// DEEPSEEK_BASE_URL is the original name; DEEPSEEK_API_BASE_URL is accepted as an
+// alias so users who copy the OPENAI_BASE_URL pattern land on a working name (#1876).
+export function resolveBaseUrlEnv(): string | undefined {
+  return process.env.DEEPSEEK_BASE_URL || process.env.DEEPSEEK_API_BASE_URL || undefined;
+}
+
 // (baseUrl, apiKey) is a tuple: whichever source defines baseUrl owns apiKey too,
 // so a stale env DEEPSEEK_API_KEY doesn't bleed into a custom config baseUrl (#1631).
 export function loadEndpoint(path: string = defaultConfigPath()): ResolvedEndpoint {
-  if (process.env.DEEPSEEK_BASE_URL) {
-    return { baseUrl: process.env.DEEPSEEK_BASE_URL, apiKey: process.env.DEEPSEEK_API_KEY };
+  const envBaseUrl = resolveBaseUrlEnv();
+  if (envBaseUrl) {
+    return { baseUrl: envBaseUrl, apiKey: process.env.DEEPSEEK_API_KEY };
   }
   const cfg = readConfig(path);
   if (cfg.baseUrl) {
@@ -1162,7 +1169,7 @@ export function loadModel(path: string = defaultConfigPath()): string {
   const trimmed = typeof raw === "string" ? raw.trim() : "";
   if (!trimmed) return DEFAULT_MODEL;
   // Custom-endpoint owners pick their own model namespace; trust them.
-  const customEndpoint = cfg.baseUrl?.trim() || process.env.DEEPSEEK_BASE_URL;
+  const customEndpoint = cfg.baseUrl?.trim() || resolveBaseUrlEnv();
   if (customEndpoint) return trimmed;
   return SUPPORTED_OFFICIAL_MODELS.includes(trimmed) ? trimmed : DEFAULT_MODEL;
 }

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -59,6 +59,7 @@ describe("config", () => {
   const originalEnv = process.env.DEEPSEEK_API_KEY;
   const originalSearch = process.env.REASONIX_SEARCH;
   const originalBaseUrl = process.env.DEEPSEEK_BASE_URL;
+  const originalApiBaseUrl = process.env.DEEPSEEK_API_BASE_URL;
 
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), "reasonix-test-"));
@@ -69,6 +70,8 @@ describe("config", () => {
     delete process.env.REASONIX_SEARCH;
     // biome-ignore lint/performance/noDelete: same reason
     delete process.env.DEEPSEEK_BASE_URL;
+    // biome-ignore lint/performance/noDelete: same reason
+    delete process.env.DEEPSEEK_API_BASE_URL;
   });
 
   afterEach(() => {
@@ -90,6 +93,12 @@ describe("config", () => {
       delete process.env.DEEPSEEK_BASE_URL;
     } else {
       process.env.DEEPSEEK_BASE_URL = originalBaseUrl;
+    }
+    if (originalApiBaseUrl === undefined) {
+      // biome-ignore lint/performance/noDelete: same reason
+      delete process.env.DEEPSEEK_API_BASE_URL;
+    } else {
+      process.env.DEEPSEEK_API_BASE_URL = originalApiBaseUrl;
     }
   });
 
@@ -161,6 +170,17 @@ describe("config", () => {
   it("loadBaseUrl falls back to config when env unset", () => {
     saveBaseUrl("https://self-hosted.example.com", path);
     expect(loadBaseUrl(path)).toBe("https://self-hosted.example.com");
+  });
+
+  it("loadBaseUrl accepts DEEPSEEK_API_BASE_URL as an alias (#1876)", () => {
+    process.env.DEEPSEEK_API_BASE_URL = "https://nginx-proxy.internal/v1";
+    expect(loadBaseUrl(path)).toBe("https://nginx-proxy.internal/v1");
+  });
+
+  it("loadBaseUrl: DEEPSEEK_BASE_URL wins over the alias when both are set", () => {
+    process.env.DEEPSEEK_BASE_URL = "https://canonical.example.com";
+    process.env.DEEPSEEK_API_BASE_URL = "https://alias.example.com";
+    expect(loadBaseUrl(path)).toBe("https://canonical.example.com");
   });
 
   it("loadBaseUrl returns undefined when nothing set", () => {


### PR DESCRIPTION
## Summary
- Accept `DEEPSEEK_API_BASE_URL` as an alias for `DEEPSEEK_BASE_URL` so users who pick the OPENAI_BASE_URL-style name hit a working route to their internal Nginx proxy
- Canonical `DEEPSEEK_BASE_URL` still wins when both are set; no behaviour change for existing users

Closes #1876

## Test plan
- [x] `loadBaseUrl` resolves the alias when only `DEEPSEEK_API_BASE_URL` is set
- [x] `DEEPSEEK_BASE_URL` precedence preserved when both env vars are present
- [x] `npm run verify` — full lint / typecheck / 3732-test suite green