### PR TITLE
feat(desktop): paste clipboard images into composer

### DIFF
--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -5,6 +5,7 @@ mod rpc;
 use rpc::{RpcState, rpc_kill, rpc_send, rpc_spawn};
 use serde::Serialize;
 use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 /// #892: bundled libwayland in AppImage can ABI-mismatch the host Wayland
 /// compositor → WebKitWebProcess `abort()`s on EGL display creation. Redirect
@@ -208,6 +209,24 @@ fn write_text_file(path: String, content: String) -> Result<(), String> {
     std::fs::write(&path, &content).map_err(|e| format!("write failed: {e}"))
 }
 
+#[tauri::command]
+fn save_clipboard_image(bytes: Vec<u8>, extension: Option<String>) -> Result<String, String> {
+    let ext = extension
+        .as_deref()
+        .map(|s| s.trim().trim_start_matches('.').to_ascii_lowercase())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "png".to_string());
+    let dir = std::env::temp_dir().join("reasonix-pasted-images");
+    std::fs::create_dir_all(&dir).map_err(|e| format!("mkdir failed: {e}"))?;
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|e| format!("clock error: {e}"))?
+        .as_millis();
+    let path = dir.join(format!("reasonix-pasted-{ts}.{ext}"));
+    std::fs::write(&path, bytes).map_err(|e| format!("write failed: {e}"))?;
+    Ok(path.to_string_lossy().into_owned())
+}
+
 fn main() {
     #[cfg(target_os = "linux")]
     linux_webkit_compat();
@@ -227,7 +246,8 @@ fn main() {
             open_in_editor,
             list_workspace_tree,
             git_status,
-            write_text_file
+            write_text_file,
+            save_clipboard_image
         ])
         .setup(|app| {
             use tauri::Manager;

--- a/desktop/src/ui/composer.tsx
+++ b/desktop/src/ui/composer.tsx
@@ -9,6 +9,7 @@ import {
   useState,
 } from "react";
 import type React from "react";
+import { invoke } from "@tauri-apps/api/core";
 import { open as openFileDialog } from "@tauri-apps/plugin-dialog";
 import { t, type TKey } from "../i18n";
 import { I } from "../icons";
@@ -117,6 +118,27 @@ function atIcon(k: MentionItem["kind"]) {
   return <I.at size={12} />;
 }
 
+function guessImageExtension(mime: string): string {
+  const normalized = mime.toLowerCase();
+  if (normalized === "image/jpeg") return "jpg";
+  if (normalized === "image/png") return "png";
+  if (normalized === "image/gif") return "gif";
+  if (normalized === "image/webp") return "webp";
+  if (normalized === "image/svg+xml") return "svg";
+  const slash = normalized.indexOf("/");
+  return slash >= 0 ? normalized.slice(slash + 1).replace(/[^a-z0-9]+/g, "") || "png" : "png";
+}
+
+function dataUrlToBytes(dataUrl: string): Uint8Array {
+  const idx = dataUrl.indexOf(",");
+  if (idx < 0) throw new Error("invalid data URL");
+  const base64 = dataUrl.slice(idx + 1);
+  const bin = atob(base64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
 export function Composer({
   draft,
   setDraft,
@@ -144,7 +166,7 @@ export function Composer({
   onDequeueSend,
 }: {
   draft: string;
-  setDraft: (s: string) => void;
+  setDraft: React.Dispatch<React.SetStateAction<string>>;
   onSend: () => void;
   onAbort: () => void;
   disabled?: boolean;
@@ -183,6 +205,19 @@ export function Composer({
   const historyRef = useRef<string[]>([]);
   const [browseIdx, setBrowseIdx] = useState(-1);
   const savedDraftRef = useRef("");
+
+  const insertMention = (picked: string) => {
+    const rel =
+      workspaceDir && picked.startsWith(workspaceDir)
+        ? picked.slice(workspaceDir.length).replace(/^[\\/]+/, "")
+        : picked;
+    setDraft((current) =>
+      current ? `${current.replace(/\s+$/, "")} @${rel} ` : `@${rel} `,
+    );
+    setChips((c) => [...c, { kind: "at", label: rel }]);
+    onMentionPicked?.(rel);
+    textareaRef.current?.focus();
+  };
 
   useLayoutEffect(() => {
     const textarea = textareaRef.current;
@@ -231,16 +266,36 @@ export function Composer({
             : undefined,
       });
       if (typeof picked !== "string" || !picked) return;
-      const rel =
-        workspaceDir && picked.startsWith(workspaceDir)
-          ? picked.slice(workspaceDir.length).replace(/^[\\/]+/, "")
-          : picked;
-      setDraft(draft ? `${draft.replace(/\s+$/, "")} @${rel} ` : `@${rel} `);
-      setChips((c) => [...c, { kind: "at", label: rel }]);
-      onMentionPicked?.(rel);
-      textareaRef.current?.focus();
+      insertMention(picked);
     } catch (err) {
       console.error("attach failed", err);
+    }
+  };
+
+  const handlePaste = async (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    const items = Array.from(e.clipboardData?.items ?? []);
+    const imageItem = items.find((item) => item.type.startsWith("image/"));
+    if (!imageItem) return;
+    const file = imageItem.getAsFile();
+    if (!file) return;
+    e.preventDefault();
+    try {
+      const dataUrl = await new Promise<string>((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onerror = () => reject(reader.error ?? new Error("read failed"));
+        reader.onload = () => {
+          if (typeof reader.result === "string") resolve(reader.result);
+          else reject(new Error("unexpected clipboard payload"));
+        };
+        reader.readAsDataURL(file);
+      });
+      const savedPath = await invoke<string>("save_clipboard_image", {
+        bytes: Array.from(dataUrlToBytes(dataUrl)),
+        extension: guessImageExtension(file.type),
+      });
+      insertMention(savedPath);
+    } catch (err) {
+      console.error("clipboard image paste failed", err);
     }
   };
 
@@ -541,6 +596,7 @@ export function Composer({
             value={draft}
             placeholder={t("composer.placeholder")}
             onChange={handleChange}
+            onPaste={(e) => void handlePaste(e)}
             onKeyDown={handleKeyDown}
             onCompositionStart={() => { composingRef.current = true; }}
             onCompositionEnd={() => {


### PR DESCRIPTION
## Summary
- Handle image items from clipboard paste in the desktop composer.
- Save pasted image bytes via a Tauri command into a temporary `reasonix-pasted-images` directory.
- Insert the saved path as an attachment mention so screenshots can be sent without browsing for a file.

## Verification
- `npm --prefix desktop run build`
- `PATH="$HOME/.cargo/bin:$PATH" cargo check --manifest-path desktop/src-tauri/Cargo.toml`

Note: the Rust check in a temporary worktree required symlinking the built `dist` and bundled Node resources from the main checkout, matching the local desktop build setup.