### PR TITLE
fix(desktop): bump app bundle version to 0.51.0

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "reasonix-desktop",
   "private": true,
-  "version": "0.50.0",
+  "version": "0.51.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2849,7 +2849,7 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "reasonix-desktop"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "anyhow",
  "parking_lot",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reasonix-desktop"
-version = "0.50.0"
+version = "0.51.0"
 edition = "2021"
 publish = false
 

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Reasonix",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "identifier": "dev.reasonix.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- Align the desktop package, Tauri config, Cargo manifest, and Cargo lock versions with the repo release version `0.51.0`.
- Prevent the desktop updater from identifying a freshly built app as `0.50.0` and repeatedly offering the same `0.51.0` update.

## Verification
- `npm --prefix desktop run build`