### PR TITLE
refactor(desktop): harden clipboard image paste path

### DIFF
--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -4,8 +4,12 @@ mod rpc;
 
 use rpc::{RpcState, rpc_kill, rpc_send, rpc_spawn};
 use serde::Serialize;
-use std::path::Path;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+fn pasted_images_dir() -> PathBuf {
+    std::env::temp_dir().join("reasonix-pasted-images")
+}
 
 /// #892: bundled libwayland in AppImage can ABI-mismatch the host Wayland
 /// compositor → WebKitWebProcess `abort()`s on EGL display creation. Redirect
@@ -209,14 +213,20 @@ fn write_text_file(path: String, content: String) -> Result<(), String> {
     std::fs::write(&path, &content).map_err(|e| format!("write failed: {e}"))
 }
 
+fn sanitize_image_extension(raw: Option<&str>) -> String {
+    let cleaned = raw
+        .map(|s| s.trim().trim_start_matches('.').to_ascii_lowercase())
+        .unwrap_or_default();
+    let ok = !cleaned.is_empty()
+        && cleaned.len() <= 8
+        && cleaned.chars().all(|c| c.is_ascii_alphanumeric());
+    if ok { cleaned } else { "png".to_string() }
+}
+
 #[tauri::command]
 fn save_clipboard_image(bytes: Vec<u8>, extension: Option<String>) -> Result<String, String> {
-    let ext = extension
-        .as_deref()
-        .map(|s| s.trim().trim_start_matches('.').to_ascii_lowercase())
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| "png".to_string());
-    let dir = std::env::temp_dir().join("reasonix-pasted-images");
+    let ext = sanitize_image_extension(extension.as_deref());
+    let dir = pasted_images_dir();
     std::fs::create_dir_all(&dir).map_err(|e| format!("mkdir failed: {e}"))?;
     let ts = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -225,6 +235,20 @@ fn save_clipboard_image(bytes: Vec<u8>, extension: Option<String>) -> Result<Str
     let path = dir.join(format!("reasonix-pasted-{ts}.{ext}"));
     std::fs::write(&path, bytes).map_err(|e| format!("write failed: {e}"))?;
     Ok(path.to_string_lossy().into_owned())
+}
+
+fn purge_old_pasted_images(max_age: Duration) {
+    let dir = pasted_images_dir();
+    let Ok(entries) = std::fs::read_dir(&dir) else { return };
+    let cutoff = SystemTime::now().checked_sub(max_age);
+    for entry in entries.flatten() {
+        let Ok(metadata) = entry.metadata() else { continue };
+        if !metadata.is_file() { continue }
+        let Ok(modified) = metadata.modified() else { continue };
+        if cutoff.is_some_and(|t| modified < t) {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
 }
 
 fn main() {
@@ -251,6 +275,7 @@ fn main() {
         ])
         .setup(|app| {
             use tauri::Manager;
+            std::thread::spawn(|| purge_old_pasted_images(Duration::from_secs(24 * 60 * 60)));
             if let Some(w) = app.get_webview_window("main") {
                 // HiDPI fit: the JSON config asks for 1024x720 logical px.
                 // On Windows laptops at 200% scale (1920x1080 → 960x540
@@ -292,4 +317,37 @@ fn main() {
                 let _ = rpc::rpc_kill(state);
             }
         });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sanitize_image_extension;
+
+    #[test]
+    fn accepts_alphanumeric_extensions() {
+        assert_eq!(sanitize_image_extension(Some("png")), "png");
+        assert_eq!(sanitize_image_extension(Some("JPG")), "jpg");
+        assert_eq!(sanitize_image_extension(Some(".webp")), "webp");
+        assert_eq!(sanitize_image_extension(Some("svg")), "svg");
+    }
+
+    #[test]
+    fn falls_back_when_missing_or_invalid() {
+        assert_eq!(sanitize_image_extension(None), "png");
+        assert_eq!(sanitize_image_extension(Some("")), "png");
+        assert_eq!(sanitize_image_extension(Some("   ")), "png");
+    }
+
+    #[test]
+    fn rejects_path_separators_and_traversal() {
+        assert_eq!(sanitize_image_extension(Some("png/../../foo")), "png");
+        assert_eq!(sanitize_image_extension(Some("png\\foo")), "png");
+        assert_eq!(sanitize_image_extension(Some("../bin")), "png");
+        assert_eq!(sanitize_image_extension(Some("p.n.g")), "png");
+    }
+
+    #[test]
+    fn rejects_overlong_extensions() {
+        assert_eq!(sanitize_image_extension(Some("verylongext")), "png");
+    }
 }

--- a/desktop/src/ui/composer.tsx
+++ b/desktop/src/ui/composer.tsx
@@ -129,16 +129,6 @@ function guessImageExtension(mime: string): string {
   return slash >= 0 ? normalized.slice(slash + 1).replace(/[^a-z0-9]+/g, "") || "png" : "png";
 }
 
-function dataUrlToBytes(dataUrl: string): Uint8Array {
-  const idx = dataUrl.indexOf(",");
-  if (idx < 0) throw new Error("invalid data URL");
-  const base64 = dataUrl.slice(idx + 1);
-  const bin = atob(base64);
-  const out = new Uint8Array(bin.length);
-  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
-  return out;
-}
-
 export function Composer({
   draft,
   setDraft,
@@ -280,17 +270,9 @@ export function Composer({
     if (!file) return;
     e.preventDefault();
     try {
-      const dataUrl = await new Promise<string>((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onerror = () => reject(reader.error ?? new Error("read failed"));
-        reader.onload = () => {
-          if (typeof reader.result === "string") resolve(reader.result);
-          else reject(new Error("unexpected clipboard payload"));
-        };
-        reader.readAsDataURL(file);
-      });
+      const buffer = await file.arrayBuffer();
       const savedPath = await invoke<string>("save_clipboard_image", {
-        bytes: Array.from(dataUrlToBytes(dataUrl)),
+        bytes: buffer,
         extension: guessImageExtension(file.type),
       });
       insertMention(savedPath);


### PR DESCRIPTION
## Summary
Follow-up to #1889. Three small improvements:

- **JS**: read clipboard Blob with `file.arrayBuffer()` and pass the `ArrayBuffer` straight through `invoke()`. Drops the FileReader → data URL → `atob` → `Uint8Array` → `number[]` chain that inflated the IPC payload ~5x on every paste.
- **Rust**: tighten extension validation. `sanitize_image_extension` now requires the post-trim/lowercase value to be 1–8 ASCII alphanumeric chars; otherwise falls back to `"png"`. Defense-in-depth vs a renderer passing `"png/../../escape"`.
- **Rust**: startup thread purges files older than 24h from the pasted-images temp dir so it doesn't grow unbounded.

## Test plan
- [x] `cargo test` — 4 new unit tests for `sanitize_image_extension` pass
- [x] `cargo check` on desktop crate
- [x] `npm run lint` / `typecheck` / `test` — 3741 tests pass