### PR TITLE
chore(dsnix): bump to 0.52.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2348,7 +2348,7 @@
     },
     "node_modules/@types/react": {
       "version": "19.2.14",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2534,19 +2534,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/ansi-escapes": {
-      "version": "7.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "environment": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ansi-regex": {
@@ -2803,19 +2790,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/cli-cursor": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "restore-cursor": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/cli-highlight": {
       "version": "2.1.11",
       "license": "ISC",
@@ -2867,50 +2841,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/cli-truncate": {
-      "version": "6.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "slice-ansi": "^9.0.0",
-        "string-width": "^8.2.0"
-      },
-      "engines": {
-        "node": ">=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-truncate/node_modules/slice-ansi": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-9.0.0.tgz",
-      "integrity": "sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.3",
-        "is-fullwidth-code-point": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=22"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
-    },
-    "node_modules/cli-truncate/node_modules/string-width": {
-      "version": "8.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.5.0",
-        "strip-ansi": "^7.1.2"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-width": {
@@ -3105,7 +3035,7 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -3266,16 +3196,6 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
-    "node_modules/environment": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "dev": true,
@@ -3307,14 +3227,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/es-toolkit": {
-      "version": "1.47.0",
-      "license": "MIT",
-      "workspaces": [
-        "docs",
-        "benchmarks"
-      ]
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -3815,19 +3727,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-in-ci": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "bin": {
-        "is-in-ci": "cli.js"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-plain-obj": {
       "version": "4.1.0",
       "dev": true,
@@ -4177,13 +4076,6 @@
       "dev": true,
       "license": "CC0-1.0"
     },
-    "node_modules/mimic-fn": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "dev": true,
@@ -4375,19 +4267,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/onetime": {
-      "version": "5.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-fn": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "dev": true,
@@ -4418,13 +4297,6 @@
     "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
       "version": "6.0.1",
       "license": "MIT"
-    },
-    "node_modules/patch-console": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -4728,27 +4600,47 @@
       }
     },
     "node_modules/reasonix": {
-      "version": "0.51.0",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/reasonix/-/reasonix-0.52.0.tgz",
+      "integrity": "sha512-5FDVRi5Pu3iOle76qw57/SCXtKjKGybicVcBdcB0mjz6oZ4zZW1Azt3E2z7j6RH2n1WTlkDuhj+AWhAje8Bnxw==",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
         "packages/*"
       ],
       "dependencies": {
+        "@alcalzone/ansi-tokenize": "^0.3.0",
+        "auto-bind": "^5.0.1",
+        "bidi-js": "^1.0.3",
+        "chalk": "^5.3.0",
+        "cli-boxes": "^4.0.1",
         "cli-highlight": "^2.1.11",
+        "code-excerpt": "^4.0.0",
         "commander": "^12.1.0",
+        "emoji-regex": "^10.4.0",
         "eventsource-parser": "^3.0.0",
+        "get-east-asian-width": "^1.3.0",
         "iconv-lite": "^0.7.2",
         "ignore": "^7.0.5",
-        "ink": "^7.0.4",
-        "ink-text-input": "^6.0.0",
+        "indent-string": "^5.0.0",
+        "lodash-es": "^4.17.21",
         "node-html-parser": "^7.1.0",
         "picomatch": "^4.0.4",
         "react": "^19.2.6",
+        "react-reconciler": "^0.32.0",
+        "semver": "^7.6.3",
+        "signal-exit": "^4.1.0",
+        "slice-ansi": "^7.1.0",
+        "stack-utils": "^2.0.6",
         "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "supports-hyperlinks": "^4.0.0",
         "undici": "^8.2.0",
+        "usehooks-ts": "^3.1.0",
         "web-tree-sitter": "^0.26.9",
+        "wrap-ansi": "^9.0.0",
         "ws": "^8.20.1",
+        "yoga-layout": "^3.2.1",
         "zod": "^4.4.1"
       },
       "bin": {
@@ -4757,158 +4649,6 @@
       },
       "engines": {
         "node": ">=22"
-      }
-    },
-    "node_modules/reasonix/node_modules/ink": {
-      "version": "7.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "@alcalzone/ansi-tokenize": "^0.3.0",
-        "ansi-escapes": "^7.3.0",
-        "ansi-styles": "^6.2.3",
-        "auto-bind": "^5.0.1",
-        "chalk": "^5.6.2",
-        "cli-boxes": "^4.0.1",
-        "cli-cursor": "^4.0.0",
-        "cli-truncate": "^6.0.0",
-        "code-excerpt": "^4.0.0",
-        "es-toolkit": "^1.45.1",
-        "indent-string": "^5.0.0",
-        "is-in-ci": "^2.0.0",
-        "patch-console": "^2.0.0",
-        "react-reconciler": "^0.33.0",
-        "scheduler": "^0.27.0",
-        "signal-exit": "^3.0.7",
-        "slice-ansi": "^9.0.0",
-        "stack-utils": "^2.0.6",
-        "string-width": "^8.2.0",
-        "terminal-size": "^4.0.1",
-        "type-fest": "^5.5.0",
-        "widest-line": "^6.0.0",
-        "wrap-ansi": "^10.0.0",
-        "ws": "^8.20.0",
-        "yoga-layout": "~3.2.1"
-      },
-      "engines": {
-        "node": ">=22"
-      },
-      "peerDependencies": {
-        "@types/react": ">=19.2.0",
-        "react": ">=19.2.0",
-        "react-devtools-core": ">=6.1.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "react-devtools-core": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/reasonix/node_modules/ink-text-input": {
-      "version": "6.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^5.3.0",
-        "type-fest": "^4.18.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "ink": ">=5",
-        "react": ">=18"
-      }
-    },
-    "node_modules/reasonix/node_modules/ink-text-input/node_modules/type-fest": {
-      "version": "4.41.0",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/reasonix/node_modules/ink/node_modules/string-width": {
-      "version": "8.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.5.0",
-        "strip-ansi": "^7.1.2"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/reasonix/node_modules/react-reconciler": {
-      "version": "0.33.0",
-      "license": "MIT",
-      "dependencies": {
-        "scheduler": "^0.27.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "peerDependencies": {
-        "react": "^19.2.0"
-      }
-    },
-    "node_modules/reasonix/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "license": "ISC"
-    },
-    "node_modules/reasonix/node_modules/slice-ansi": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-9.0.0.tgz",
-      "integrity": "sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.3",
-        "is-fullwidth-code-point": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=22"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
-    },
-    "node_modules/reasonix/node_modules/wrap-ansi": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz",
-      "integrity": "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.3",
-        "string-width": "^8.2.0",
-        "strip-ansi": "^7.1.2"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/reasonix/node_modules/wrap-ansi/node_modules/string-width": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
-      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.5.0",
-        "strip-ansi": "^7.1.2"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/require-directory": {
@@ -4940,24 +4680,6 @@
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
-    },
-    "node_modules/restore-cursor": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/restore-cursor/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "license": "ISC"
     },
     "node_modules/rollup": {
       "version": "4.60.3",
@@ -5027,6 +4749,7 @@
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -5390,26 +5113,6 @@
       "version": "3.2.4",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/tagged-tag": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/terminal-size": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/test-exclude": {
       "version": "7.0.2",
@@ -6608,19 +6311,6 @@
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
       }
     },
-    "node_modules/type-fest": {
-      "version": "5.6.0",
-      "license": "(MIT OR CC0-1.0)",
-      "dependencies": {
-        "tagged-tag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/typed-inject": {
       "version": "5.0.0",
       "dev": true,
@@ -6969,33 +6659,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/widest-line": {
-      "version": "6.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^8.1.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/widest-line/node_modules/string-width": {
-      "version": "8.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.5.0",
-        "strip-ansi": "^7.1.2"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/wrap-ansi": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
@@ -7227,10 +6890,10 @@
       }
     },
     "packages/dsnix": {
-      "version": "0.51.0",
+      "version": "0.52.0",
       "license": "MIT",
       "dependencies": {
-        "reasonix": "0.51.0"
+        "reasonix": "0.52.0"
       },
       "bin": {
         "dsnix": "bin.cjs"

--- a/packages/dsnix/package.json
+++ b/packages/dsnix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsnix",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "description": "Short alias for reasonix — DeepSeek-native coding agent. Forwards to the reasonix CLI.",
   "bin": {
     "dsnix": "bin.cjs"
@@ -31,6 +31,6 @@
     "node": ">=22"
   },
   "dependencies": {
-    "reasonix": "0.51.0"
+    "reasonix": "0.52.0"
   }
 }


### PR DESCRIPTION
Companion bump for the v0.52.0 release. Tag `dsnix-v0.52.0` already pushed — `publish-dsnix.yml` will only succeed after `reasonix@0.52.0` is live on npm (verified before tagging).

## Summary
- `packages/dsnix/package.json` 0.51.0 → 0.52.0 + `reasonix` dep
- `package-lock.json` sync (drops transitives removed when ink was vendored into `@esengine/ink`)

## Test plan
- [x] `npm run verify` passes (pre-push gate)
- [ ] `publish-dsnix.yml` succeeds → `dsnix@0.52.0` on npm