### PR TITLE
fix(desktop): bump app bundle version to 0.52.0

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "reasonix-desktop",
   "private": true,
-  "version": "0.51.0",
+  "version": "0.52.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2849,7 +2849,7 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "reasonix-desktop"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "anyhow",
  "parking_lot",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reasonix-desktop"
-version = "0.51.0"
+version = "0.52.0"
 edition = "2021"
 publish = false
 

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Reasonix",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "identifier": "dev.reasonix.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Desktop bundle bump companion to v0.52.0. Tag \`desktop-v0.52.0\` already pushed — \`release.yml\` will produce signed Tauri bundles and create a draft GitHub release.

## Summary
- \`desktop/package.json\` 0.51.0 → 0.52.0
- \`desktop/src-tauri/{Cargo.toml,Cargo.lock,tauri.conf.json}\` 0.51.0 → 0.52.0

## Test plan
- [x] \`npm run verify\` passes (pre-push gate)
- [ ] \`release.yml\` produces ubuntu / macos-universal / windows bundles
- [ ] Draft GH release reviewed → publish → \`release-mirror.yml\` mirrors to R2