### PR TITLE
fix(desktop): allow clearing base URL and editor

### DIFF
--- a/desktop/src/ui/settings.tsx
+++ b/desktop/src/ui/settings.tsx
@@ -636,7 +636,7 @@ function PageGeneral({
             value={editorDraft}
             placeholder="cursor --goto"
             onChange={(e) => setEditorDraft(e.target.value)}
-            onBlur={() => onSave({ editor: editorDraft || undefined })}
+            onBlur={() => onSave({ editor: editorDraft.trim() })}
           />
         </div>
       </section>
@@ -952,7 +952,7 @@ function ApiKeySection({
           className="field mono"
           value={urlDraft}
           onChange={(e) => setUrlDraft(e.target.value)}
-          onBlur={() => onSave({ baseUrl: urlDraft.trim() || undefined })}
+          onBlur={() => onSave({ baseUrl: urlDraft.trim() })}
         />
       </div>
     </section>


### PR DESCRIPTION
Desktop settings now preserve empty-string saves for the base URL and editor, so clearing either field actually removes the value instead of dropping the field from the RPC payload.