### PR TITLE
Add Codex collaboration tools to Reasonix Code

### DIFF
--- a/src/code/setup.ts
+++ b/src/code/setup.ts
@@ -16,6 +16,7 @@ import { bootstrapSemanticSearchInCodeMode } from "../index/semantic/tool.js";
 import { ToolRegistry } from "../tools.js";
 import { registerChoiceTool } from "../tools/choice.js";
 import { registerCodeQueryTools } from "../tools/code-query.js";
+import { registerCodexTools } from "../tools/codex.js";
 import { registerFilesystemTools } from "../tools/filesystem.js";
 import { registerJavaSourceTool } from "../tools/java-source.js";
 import { JobRegistry } from "../tools/jobs.js";
@@ -77,6 +78,7 @@ export async function buildCodeToolset(opts: CodeToolsetOpts): Promise<CodeTools
     });
     registerMemoryTools(tools, { projectRoot: root });
     registerCodeQueryTools(tools, { rootDir: root });
+    registerCodexTools(tools, { rootDir: root });
   };
 
   const reBootstrapSemantic = async (root: string): Promise<{ enabled: boolean }> => {

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -1,0 +1,377 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { pauseGate } from "../core/pause-gate.js";
+import type { ToolRegistry } from "../tools.js";
+import { DEFAULT_MAX_OUTPUT_CHARS, killProcessTree, smartDecodeOutput } from "./shell/exec.js";
+
+const DEFAULT_CODEX_TIMEOUT_SEC = 900;
+const MAX_CODEX_TIMEOUT_SEC = 3600;
+const CODEX_OUTPUT_CHARS = DEFAULT_MAX_OUTPUT_CHARS;
+const VALID_EFFORTS = new Set(["none", "minimal", "low", "medium", "high", "xhigh"]);
+
+export interface CodexToolOptions {
+  rootDir: string;
+  runner?: CodexRunner;
+}
+
+export interface CodexInvocation {
+  args: string[];
+  stdin?: string;
+}
+
+export interface CodexRunOptions {
+  cwd: string;
+  timeoutSec?: number;
+  maxOutputChars?: number;
+  signal?: AbortSignal;
+}
+
+export interface CodexRunResult {
+  exitCode: number | null;
+  output: string;
+  timedOut: boolean;
+  aborted: boolean;
+  spawnError?: string;
+}
+
+export type CodexRunner = (
+  invocation: CodexInvocation,
+  opts: CodexRunOptions,
+) => Promise<CodexRunResult>;
+
+export interface CodexReviewArgs {
+  scope?: "uncommitted" | "branch" | "commit";
+  base?: string;
+  commit?: string;
+  instructions?: string;
+  model?: string;
+  effort?: string;
+  timeoutSec?: number;
+}
+
+export interface CodexDelegateArgs {
+  prompt: string;
+  write?: boolean;
+  model?: string;
+  effort?: string;
+  timeoutSec?: number;
+}
+
+export function registerCodexTools(registry: ToolRegistry, opts: CodexToolOptions): ToolRegistry {
+  const runner = opts.runner ?? runCodexCli;
+
+  registry.register({
+    name: "codex_review",
+    description:
+      "Run the local Codex CLI's native read-only code review against this workspace. Use after meaningful code changes, before finalizing a fix, or when the user asks for Codex review. It reviews uncommitted changes by default; pass base for a branch review or commit for a commit review. This does not modify files.",
+    readOnly: true,
+    parameters: {
+      type: "object",
+      properties: {
+        scope: {
+          type: "string",
+          enum: ["uncommitted", "branch", "commit"],
+          description:
+            "Review target. Default uncommitted. Use branch with base, or commit with commit.",
+        },
+        base: {
+          type: "string",
+          description: "Base branch/ref for branch review, for example main or origin/main.",
+        },
+        commit: {
+          type: "string",
+          description: "Commit SHA/ref to review when scope is commit.",
+        },
+        instructions: {
+          type: "string",
+          description: "Optional review focus. Keep this short; omit for normal Codex review.",
+        },
+        model: { type: "string", description: "Optional Codex model override." },
+        effort: {
+          type: "string",
+          enum: ["none", "minimal", "low", "medium", "high", "xhigh"],
+          description: "Optional Codex reasoning effort override.",
+        },
+        timeoutSec: {
+          type: "integer",
+          description: `Timeout in seconds. Default ${DEFAULT_CODEX_TIMEOUT_SEC}, max ${MAX_CODEX_TIMEOUT_SEC}.`,
+        },
+      },
+    },
+    fn: async (args: CodexReviewArgs, ctx) => {
+      const invocation = buildCodexReviewInvocation(args);
+      const result = await runner(invocation, {
+        cwd: opts.rootDir,
+        timeoutSec: normalizeTimeout(args.timeoutSec),
+        maxOutputChars: CODEX_OUTPUT_CHARS,
+        signal: ctx?.signal,
+      });
+      return formatCodexResult("Codex review", invocation, result);
+    },
+  });
+
+  registry.register({
+    name: "codex_delegate",
+    description:
+      "Ask local Codex to investigate or pressure-test a focused task in this workspace. Default is read-only and is best for second opinions, root-cause analysis, or patch suggestions. Set write=true only when the user explicitly wants Codex to edit files; Reasonix will ask for confirmation before launching workspace-write Codex.",
+    readOnlyCheck: (args: CodexDelegateArgs) => args.write !== true,
+    parameters: {
+      type: "object",
+      properties: {
+        prompt: {
+          type: "string",
+          description:
+            "Self-contained task for Codex. Include relevant constraints and expected output.",
+        },
+        write: {
+          type: "boolean",
+          description: "Allow Codex to modify files with workspace-write sandbox. Default false.",
+        },
+        model: { type: "string", description: "Optional Codex model override." },
+        effort: {
+          type: "string",
+          enum: ["none", "minimal", "low", "medium", "high", "xhigh"],
+          description: "Optional Codex reasoning effort override.",
+        },
+        timeoutSec: {
+          type: "integer",
+          description: `Timeout in seconds. Default ${DEFAULT_CODEX_TIMEOUT_SEC}, max ${MAX_CODEX_TIMEOUT_SEC}.`,
+        },
+      },
+      required: ["prompt"],
+    },
+    fn: async (args: CodexDelegateArgs, ctx) => {
+      const invocation = buildCodexDelegateInvocation(args, opts.rootDir);
+      if (args.write === true) {
+        const gate = ctx?.confirmationGate ?? pauseGate;
+        const choice = await gate.ask({
+          kind: "run_command",
+          payload: {
+            command: `codex ${formatCommandArgs(invocation.args)}`,
+            cwd: opts.rootDir,
+            timeoutSec: normalizeTimeout(args.timeoutSec),
+          },
+        });
+        if (choice.type === "deny") {
+          throw new Error(
+            `user denied Codex workspace-write delegation${
+              choice.denyContext ? ` - ${choice.denyContext}` : ""
+            }`,
+          );
+        }
+      }
+      const result = await runner(invocation, {
+        cwd: opts.rootDir,
+        timeoutSec: normalizeTimeout(args.timeoutSec),
+        maxOutputChars: CODEX_OUTPUT_CHARS,
+        signal: ctx?.signal,
+      });
+      return formatCodexResult(
+        args.write === true ? "Codex delegated edit" : "Codex delegate",
+        invocation,
+        result,
+      );
+    },
+  });
+
+  return registry;
+}
+
+export function buildCodexReviewInvocation(args: CodexReviewArgs = {}): CodexInvocation {
+  const argv = codexGlobalArgs(args);
+  argv.push("review");
+
+  const scope = args.scope ?? (args.commit ? "commit" : args.base ? "branch" : "uncommitted");
+  if (scope === "commit") {
+    const commit = normalizedOptional(args.commit);
+    if (!commit) throw new Error("codex_review: commit is required when scope=commit");
+    argv.push("--commit", commit);
+  } else if (scope === "branch") {
+    const base = normalizedOptional(args.base);
+    if (!base) throw new Error("codex_review: base is required when scope=branch");
+    argv.push("--base", base);
+  } else {
+    argv.push("--uncommitted");
+  }
+
+  const instructions = normalizedOptional(args.instructions);
+  if (instructions) {
+    argv.push("-");
+  }
+
+  return { args: argv, stdin: instructions };
+}
+
+export function buildCodexDelegateInvocation(
+  args: CodexDelegateArgs,
+  rootDir: string,
+): CodexInvocation {
+  const prompt = normalizedOptional(args.prompt);
+  if (!prompt) throw new Error("codex_delegate: prompt is required");
+
+  const argv = codexGlobalArgs(args);
+  argv.push(
+    "exec",
+    "--skip-git-repo-check",
+    "--color",
+    "never",
+    "-C",
+    rootDir,
+    "--sandbox",
+    args.write === true ? "workspace-write" : "read-only",
+    "--ask-for-approval",
+    "never",
+    "-",
+  );
+
+  return { args: argv, stdin: prompt };
+}
+
+export async function runCodexCli(
+  invocation: CodexInvocation,
+  opts: CodexRunOptions,
+): Promise<CodexRunResult> {
+  const timeoutSec = normalizeTimeout(opts.timeoutSec);
+  const maxChars = opts.maxOutputChars ?? CODEX_OUTPUT_CHARS;
+  const timeoutMs = timeoutSec * 1000;
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+  let timedOut = false;
+  let aborted = false;
+  let child: ChildProcess;
+
+  try {
+    child = spawn("codex", invocation.args, {
+      cwd: opts.cwd,
+      shell: false,
+      windowsHide: true,
+      detached: process.platform !== "win32",
+      env: {
+        ...process.env,
+        NO_COLOR: "1",
+        TERM: process.env.TERM ?? "dumb",
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+  } catch (err) {
+    return {
+      exitCode: null,
+      output: "",
+      timedOut: false,
+      aborted: false,
+      spawnError: (err as Error).message,
+    };
+  }
+
+  return await new Promise<CodexRunResult>((resolve) => {
+    const byteCap = maxChars * 2 * 4;
+    const kill = () => killProcessTree(child);
+    const timer = setTimeout(() => {
+      timedOut = true;
+      kill();
+    }, timeoutMs);
+    const onAbort = () => {
+      aborted = true;
+      kill();
+    };
+
+    const onData = (chunk: Buffer | string) => {
+      const buffer = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
+      if (totalBytes >= byteCap) return;
+      const remaining = byteCap - totalBytes;
+      if (buffer.length > remaining) {
+        chunks.push(buffer.subarray(0, remaining));
+        totalBytes = byteCap;
+      } else {
+        chunks.push(buffer);
+        totalBytes += buffer.length;
+      }
+    };
+
+    if (opts.signal?.aborted) {
+      onAbort();
+    } else {
+      opts.signal?.addEventListener("abort", onAbort, { once: true });
+    }
+
+    child.stdout?.on("data", onData);
+    child.stderr?.on("data", onData);
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      opts.signal?.removeEventListener("abort", onAbort);
+      resolve({
+        exitCode: null,
+        output: "",
+        timedOut,
+        aborted,
+        spawnError: err.message,
+      });
+    });
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      opts.signal?.removeEventListener("abort", onAbort);
+      const decoded = smartDecodeOutput(Buffer.concat(chunks));
+      const output =
+        decoded.length > maxChars
+          ? `${decoded.slice(0, maxChars)}\n\n[... truncated ${decoded.length - maxChars} chars ...]`
+          : decoded;
+      resolve({ exitCode: code, output, timedOut, aborted });
+    });
+
+    child.stdin?.end(invocation.stdin ?? "");
+  });
+}
+
+function codexGlobalArgs(args: { model?: string; effort?: string }): string[] {
+  const argv: string[] = [];
+  const model = normalizedOptional(args.model);
+  if (model) argv.push("--model", model);
+  const effort = normalizedOptional(args.effort);
+  if (effort) {
+    if (!VALID_EFFORTS.has(effort)) {
+      throw new Error(
+        `unsupported Codex reasoning effort "${effort}". Use one of: ${[...VALID_EFFORTS].join(", ")}`,
+      );
+    }
+    argv.push("--config", `model_reasoning_effort=${JSON.stringify(effort)}`);
+  }
+  return argv;
+}
+
+function normalizeTimeout(value: unknown): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_CODEX_TIMEOUT_SEC;
+  return Math.max(1, Math.min(MAX_CODEX_TIMEOUT_SEC, Math.floor(parsed)));
+}
+
+function normalizedOptional(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function formatCodexResult(
+  title: string,
+  invocation: CodexInvocation,
+  result: CodexRunResult,
+): string {
+  const lines = [
+    `${title}`,
+    `Command: codex ${formatCommandArgs(invocation.args)}`,
+    `Exit: ${result.exitCode ?? "spawn-failed"}${result.timedOut ? " (timeout)" : ""}${
+      result.aborted ? " (aborted)" : ""
+    }`,
+  ];
+  if (result.spawnError) lines.push(`Spawn error: ${result.spawnError}`);
+  const output = result.output.trim();
+  lines.push("", output || "(no output)");
+  return lines.join("\n");
+}
+
+function formatCommandArgs(args: readonly string[]): string {
+  return args.map(quoteArg).join(" ");
+}
+
+function quoteArg(arg: string): string {
+  if (/^[A-Za-z0-9_@%+=:,./-]+$/.test(arg)) return arg;
+  return JSON.stringify(arg);
+}

--- a/tests/codex-tools.test.ts
+++ b/tests/codex-tools.test.ts
@@ -1,0 +1,156 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { type ConfirmationChoice, PauseGate } from "../src/core/pause-gate.js";
+import { ToolRegistry } from "../src/tools.js";
+import {
+  type CodexInvocation,
+  type CodexRunOptions,
+  type CodexRunResult,
+  buildCodexDelegateInvocation,
+  buildCodexReviewInvocation,
+  registerCodexTools,
+} from "../src/tools/codex.js";
+
+class AutoGate extends PauseGate {
+  constructor(private readonly choice: ConfirmationChoice) {
+    super();
+  }
+
+  override ask = ((_opts: Parameters<PauseGate["ask"]>[0]) => {
+    return Promise.resolve(this.choice);
+  }) as PauseGate["ask"];
+}
+
+describe("codex tools", () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), "reasonix-codex-tools-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("builds native review args for the current uncommitted diff by default", () => {
+    expect(buildCodexReviewInvocation()).toEqual({
+      args: ["review", "--uncommitted"],
+      stdin: undefined,
+    });
+  });
+
+  it("builds focused branch review with global model config before the subcommand", () => {
+    expect(
+      buildCodexReviewInvocation({
+        scope: "branch",
+        base: "origin/main",
+        instructions: "focus on rollback risk",
+        model: "gpt-5.4-mini",
+        effort: "high",
+      }),
+    ).toEqual({
+      args: [
+        "--model",
+        "gpt-5.4-mini",
+        "--config",
+        'model_reasoning_effort="high"',
+        "review",
+        "--base",
+        "origin/main",
+        "-",
+      ],
+      stdin: "focus on rollback risk",
+    });
+  });
+
+  it("builds read-only Codex delegation by default", () => {
+    expect(
+      buildCodexDelegateInvocation({ prompt: "investigate the failing test" }, tmpRoot),
+    ).toEqual({
+      args: [
+        "exec",
+        "--skip-git-repo-check",
+        "--color",
+        "never",
+        "-C",
+        tmpRoot,
+        "--sandbox",
+        "read-only",
+        "--ask-for-approval",
+        "never",
+        "-",
+      ],
+      stdin: "investigate the failing test",
+    });
+  });
+
+  it("runs codex_review through the injected runner", async () => {
+    const calls: Array<{ invocation: CodexInvocation; opts: CodexRunOptions }> = [];
+    const runner = async (
+      invocation: CodexInvocation,
+      opts: CodexRunOptions,
+    ): Promise<CodexRunResult> => {
+      calls.push({ invocation, opts });
+      return { exitCode: 0, output: "no findings", timedOut: false, aborted: false };
+    };
+    const reg = new ToolRegistry();
+    registerCodexTools(reg, { rootDir: tmpRoot, runner });
+
+    const output = await reg.dispatch("codex_review", JSON.stringify({ base: "main" }));
+
+    expect(output).toContain("Codex review");
+    expect(output).toContain("no findings");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.invocation.args).toEqual(["review", "--base", "main"]);
+    expect(calls[0]!.opts.cwd).toBe(tmpRoot);
+  });
+
+  it("blocks write-enabled delegation when the user denies confirmation", async () => {
+    let called = false;
+    const reg = new ToolRegistry();
+    registerCodexTools(reg, {
+      rootDir: tmpRoot,
+      runner: async () => {
+        called = true;
+        return { exitCode: 0, output: "should not run", timedOut: false, aborted: false };
+      },
+    });
+
+    const output = await reg.dispatch(
+      "codex_delegate",
+      JSON.stringify({ prompt: "fix it", write: true }),
+      { confirmationGate: new AutoGate({ type: "deny" }) },
+    );
+
+    expect(JSON.parse(output).error).toMatch(/user denied Codex workspace-write delegation/);
+    expect(called).toBe(false);
+  });
+
+  it("allows read-only delegation in plan mode but refuses write delegation", async () => {
+    const reg = new ToolRegistry();
+    const calls: CodexInvocation[] = [];
+    registerCodexTools(reg, {
+      rootDir: tmpRoot,
+      runner: async (invocation) => {
+        calls.push(invocation);
+        return { exitCode: 0, output: "answer", timedOut: false, aborted: false };
+      },
+    });
+    reg.setPlanMode(true);
+
+    const readOnly = await reg.dispatch(
+      "codex_delegate",
+      JSON.stringify({ prompt: "look for risks" }),
+    );
+    const write = await reg.dispatch(
+      "codex_delegate",
+      JSON.stringify({ prompt: "fix it", write: true }),
+    );
+
+    expect(readOnly).toContain("answer");
+    expect(JSON.parse(write).rejectedReason).toBe("plan-mode");
+    expect(calls).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Register two local Codex CLI-backed tools in Reasonix Code:
  - `codex_review` for read-only native Codex review of uncommitted, branch, or commit scopes.
  - `codex_delegate` for focused read-only second opinions, with confirmation required before workspace-write delegation.
- Add a dedicated runner wrapper with timeout, abort, output truncation, process-tree cleanup, and injectable runner support for tests.
- Cover invocation construction, injected runner dispatch, write-denial behavior, and plan-mode gating.

## Verification

- `npx @biomejs/biome check src/tools/codex.ts src/code/setup.ts tests/codex-tools.test.ts` ✅
- `npm test -- --run tests/codex-tools.test.ts` ✅
- `npm run typecheck` ✅
- `npm run lint` ✅
- `git diff --cached --check` ✅
- `npm test -- --run tests/prompt-budget.test.ts` ⚠️ local-existing failure: `expected 26512 to be less than or equal to 26500`, with warnings from local user skills under `~/.agents` / `~/.claude`. This PR does not modify `src/code/prompt.ts`; I removed the prompt wording from the dirty experiment specifically to avoid increasing that budget.