### PR TITLE
fix(desktop): normalize path separators for Windows file opening

### DIFF
--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -183,12 +183,14 @@ fn open_in_editor(command: String, path: String, line: Option<u32>) -> Result<()
     #[cfg(windows)]
     {
         // Spawn through cmd.exe so `.cmd` shims (code.cmd, cursor.cmd) resolve via PATH.
+        // Normalize forward slashes to backslashes — cmd.exe doesn't handle them reliably.
+        let normalized = path.replace('/', "\\");
         cmd = Command::new("cmd");
         cmd.arg("/c").arg(trimmed);
         if let Some(l) = line {
-            cmd.arg("-g").arg(format!("{}:{}", path, l));
+            cmd.arg("-g").arg(format!("{}:{}", normalized, l));
         } else {
-            cmd.arg(&path);
+            cmd.arg(&normalized);
         }
         use std::os::windows::process::CommandExt;
         const CREATE_NO_WINDOW: u32 = 0x0800_0000;

--- a/desktop/src/Markdown.tsx
+++ b/desktop/src/Markdown.tsx
@@ -37,10 +37,14 @@ export const WorkspaceProvider = WorkspaceContext.Provider;
 
 function resolveAgainstWorkspace(rel: string, ws: string | undefined): string {
   if (!ws) return rel;
-  if (/^[a-zA-Z]:[\\/]/.test(rel) || rel.startsWith("/")) return rel;
-  const sep = ws.includes("\\") ? "\\" : "/";
+  const isWindows = ws.includes("\\");
+  if (/^[a-zA-Z]:[\\/]/.test(rel) || rel.startsWith("/")) {
+    return isWindows ? rel.replace(/\//g, "\\") : rel;
+  }
+  const sep = isWindows ? "\\" : "/";
   const trimmed = ws.replace(/[\\/]$/, "");
-  return `${trimmed}${sep}${rel.replace(/^\.[\\/]/, "")}`;
+  const relative = rel.replace(/^\.[\\/]/, "").replace(/\//g, sep);
+  return `${trimmed}${sep}${relative}`;
 }
 
 const KNOWN_EXTS =

--- a/desktop/src/ui/context-panel.tsx
+++ b/desktop/src/ui/context-panel.tsx
@@ -110,11 +110,14 @@ type TreeNode =
 
 async function openContextFile(path: string, settings: Settings | null): Promise<void> {
   const workspaceDir = settings?.workspaceDir;
-  const sep = workspaceDir?.includes("\\") ? "\\" : "/";
+  const isWindows = workspaceDir?.includes("\\") ?? false;
+  const sep = isWindows ? "\\" : "/";
   const abs =
     workspaceDir && !/^[a-zA-Z]:[\\/]/.test(path) && !path.startsWith("/")
-      ? `${workspaceDir.replace(/[\\/]$/, "")}${sep}${path.replace(/^[\\/]+/, "")}`
-      : path;
+      ? `${workspaceDir.replace(/[\\/]$/, "")}${sep}${path.replace(/^[\\/]+/, "").replace(/\//g, sep)}`
+      : isWindows
+        ? path.replace(/\//g, "\\")
+        : path;
   const editor = settings?.editor?.trim();
   if (editor) {
     await invoke("open_in_editor", { command: editor, path: abs, line: null });


### PR DESCRIPTION
## Description

Windows users encounter file opening failures when clicking Markdown file references or context panel file entries. The root cause is that file paths use forward slashes (`/`) from AI output, which are passed directly to `cmd.exe` via the Tauri `open_in_editor` command — `cmd.exe` does not handle forward slashes reliably on Windows.

## Changes

### `desktop/src/Markdown.tsx` — `resolveAgainstWorkspace`
- Added Windows path detection via `ws.includes("\\")`
- Normalize forward slashes to backslashes in both relative and absolute path branches
- Previously, absolute paths (e.g. `C:/Users/.../file.tsx`) were returned unmodified

### `desktop/src/ui/context-panel.tsx` — `openContextFile`
- Same fix applied: detect Windows via workspace path, normalize `/` → `\\`
- Both relative-path construction and absolute-path early-return branches covered

### `desktop/src-tauri/src/main.rs` — `open_in_editor` (Windows branch)
- Added `path.replace('/', "\\")` as a safety net before passing to `cmd.exe`
- Only applies inside `#[cfg(windows)]`, zero impact on macOS/Linux

## Impact

- **Windows**: files now open correctly in configured editor (VS Code, Cursor, etc.) and via OS default opener
- **macOS/Linux**: not affected — the normalization condition `ws.includes("\\")` never triggers
- The Rust side is guarded by `#[cfg(windows)]` compile-time, so the code doesn't even exist on non-Windows builds

## Related

Closes #1869