### PR TITLE
fix: keep dashboard session and usage snapshots fresh

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -686,8 +686,49 @@ export function applyIncoming(state: State, ev: IncomingEvent): State {
         pendingCheckpoints: [],
         pendingRevisions: [],
       };
-    case "$sessions":
-      return { ...state, sessions: ev.items };
+    case "$sessions": {
+      const hasCurrent = "currentSession" in ev;
+      const nextCurrent =
+        ev.currentSession === null ? undefined : (ev.currentSession ?? state.currentSession);
+      const currentChanged = hasCurrent && nextCurrent !== state.currentSession;
+      return {
+        ...state,
+        sessions: ev.items,
+        currentSession: nextCurrent,
+        messages: currentChanged ? [] : state.messages,
+        pendingConfirms: currentChanged ? [] : state.pendingConfirms,
+        pendingPathAccess: currentChanged ? [] : state.pendingPathAccess,
+        pendingChoices: currentChanged ? [] : state.pendingChoices,
+        pendingPlans: currentChanged ? [] : state.pendingPlans,
+        pendingCheckpoints: currentChanged ? [] : state.pendingCheckpoints,
+        pendingRevisions: currentChanged ? [] : state.pendingRevisions,
+        activePlan: currentChanged ? null : state.activePlan,
+        usage: currentChanged ? zeroUsage() : state.usage,
+        sessionFiles: currentChanged ? [] : state.sessionFiles,
+        queuedSends: currentChanged ? [] : state.queuedSends,
+      };
+    }
+    case "$session_usage": {
+      const empty =
+        ev.totalCostUsd === 0 &&
+        ev.totalPromptTokens === 0 &&
+        ev.totalCompletionTokens === 0 &&
+        ev.cacheHitTokens === 0 &&
+        ev.cacheMissTokens === 0;
+      return {
+        ...state,
+        usage: {
+          ...state.usage,
+          totalCostUsd: ev.totalCostUsd,
+          totalPromptTokens: ev.totalPromptTokens,
+          totalCompletionTokens: ev.totalCompletionTokens,
+          cacheHitTokens: ev.cacheHitTokens,
+          cacheMissTokens: ev.cacheMissTokens,
+          lastCallCacheHit: empty ? null : state.usage.lastCallCacheHit,
+          lastCallCacheMiss: empty ? null : state.usage.lastCallCacheMiss,
+        },
+      };
+    }
     case "$mcp_specs":
       return {
         ...state,

--- a/dashboard/src/lib/tauri-bridge.ts
+++ b/dashboard/src/lib/tauri-bridge.ts
@@ -278,39 +278,19 @@ function connectSSE(): void {
     setTimeout(connectSSE, Math.min(delay, 30000));
   };
 
-  // SSE 连接成功后，开始定期轮询 overview 更新 balance/stats
+  // SSE 连接成功后，开始定期轮询 overview/sessions 更新右侧状态和会话列表
   startStatsPolling();
 }
 
-// 定期轮询 stats/balance
+// 定期轮询 stats/balance/sessions
 let statsPollTimer: ReturnType<typeof setInterval> | null = null;
 
 function startStatsPolling(): void {
   if (statsPollTimer) clearInterval(statsPollTimer);
-  // 每 5 秒轮询一次 overview 获取最新 stats/balance
+  // 每 5 秒轮询一次，补偿 SSE 重连、App remount、以及其他终端写入 session 文件的情况。
   statsPollTimer = setInterval(async () => {
     try {
-      const overview = await apiFetch("overview");
-      if (overview?.stats) {
-        const stats = overview.stats;
-        // 更新 balance
-        if (stats.balance) {
-          const firstBalance = stats.balance[0];
-          if (firstBalance) {
-            emitEvent({
-              type: "$balance",
-              tabId: "tab-1",
-              currency: firstBalance.currency,
-              total: Number.parseFloat(firstBalance.total_balance) || 0,
-              isAvailable: true,
-            });
-          }
-        }
-        // 更新 usage stats（缓存命中率、tokens、金额）
-        const totalTokens = Math.round(stats.totalCostUsd > 0 ? stats.cacheHitRatio * 10000 : 0);
-        // 通过 $settings 事件附带更新 usage 相关信息
-        // 注意：usage 主要由 model.final 事件更新，这里只更新 balance
-      }
+      await refreshServerSnapshots();
     } catch {
       // 静默失败，等待下次轮询
     }
@@ -356,6 +336,68 @@ function emitServerSettings(settings: any, overview?: any): void {
     baseUrl: settings?.baseUrl ?? "",
     apiKeyPrefix: settings?.apiKey ?? "",
   });
+}
+
+function finiteNumber(value: unknown, fallback = 0): number {
+  const number = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function mapSessionItem(s: any) {
+  return {
+    name: s.name,
+    messageCount: s.messageCount,
+    mtime: new Date(s.mtime).toISOString(),
+    summary: s.summary,
+    workspaceStatus: s.workspaceStatus,
+  };
+}
+
+function emitSessionsSnapshot(sessionsData: any): void {
+  if (!sessionsData?.sessions) return;
+  emitEvent({
+    type: "$sessions",
+    tabId: "tab-1",
+    currentSession:
+      typeof sessionsData.currentSession === "string" ? sessionsData.currentSession : null,
+    items: sessionsData.sessions.map(mapSessionItem),
+  });
+}
+
+function emitOverviewSnapshot(overview: any): void {
+  const stats = overview?.stats;
+  if (!stats) return;
+
+  const cacheHitTokens = finiteNumber(stats.cacheHitTokens);
+  const cacheMissTokens = finiteNumber(stats.cacheMissTokens);
+  emitEvent({
+    type: "$session_usage",
+    tabId: "tab-1",
+    totalCostUsd: finiteNumber(stats.totalCostUsd),
+    totalPromptTokens: cacheHitTokens + cacheMissTokens,
+    totalCompletionTokens: finiteNumber(stats.totalCompletionTokens),
+    cacheHitTokens,
+    cacheMissTokens,
+  });
+
+  if (stats.balance) {
+    const firstBalance = stats.balance[0];
+    if (firstBalance) {
+      emitEvent({
+        type: "$balance",
+        tabId: "tab-1",
+        currency: firstBalance.currency,
+        total: Number.parseFloat(firstBalance.total_balance) || 0,
+        isAvailable: true,
+      });
+    }
+  }
+}
+
+async function refreshServerSnapshots(): Promise<void> {
+  const [sessionsData, overview] = await Promise.all([apiFetch("sessions"), apiFetch("overview")]);
+  emitSessionsSnapshot(sessionsData);
+  emitOverviewSnapshot(overview);
 }
 
 // 初始化 Server 状态
@@ -459,33 +501,8 @@ async function serverInit(): Promise<void> {
     ]);
     wsDir = overview?.cwd ?? "";
     if (settings) emitServerSettings(settings, overview);
-    if (sessionsData?.sessions) {
-      const items = sessionsData.sessions.map((s: any) => ({
-        name: s.name,
-        messageCount: s.messageCount,
-        mtime: new Date(s.mtime).toISOString(),
-        summary: s.summary,
-      }));
-      emitEvent({
-        type: "$sessions",
-        tabId: "tab-1",
-        items,
-      });
-    }
-    // 从 overview 中提取 balance 和 stats
-    const stats = overview?.stats;
-    if (stats?.balance) {
-      const firstBalance = stats.balance[0];
-      if (firstBalance) {
-        emitEvent({
-          type: "$balance",
-          tabId: "tab-1",
-          currency: firstBalance.currency,
-          total: Number.parseFloat(firstBalance.total_balance) || 0,
-          isAvailable: true,
-        });
-      }
-    }
+    emitSessionsSnapshot(sessionsData);
+    emitOverviewSnapshot(overview);
   } catch (err) {
     console.warn("[tauri-bridge] server init failed:", err);
   }
@@ -536,15 +553,7 @@ async function serverRpc(payload: Record<string, any>): Promise<void> {
     case "session_list": {
       try {
         const data = await apiFetch("sessions");
-        if (data?.sessions) {
-          const items = data.sessions.map((s: any) => ({
-            name: s.name,
-            messageCount: s.messageCount,
-            mtime: new Date(s.mtime).toISOString(),
-            summary: s.summary,
-          }));
-          emitEvent({ type: "$sessions", tabId: "tab-1", items });
-        }
+        emitSessionsSnapshot(data);
       } catch {
         /* ignore */
       }
@@ -632,15 +641,7 @@ async function serverRpc(payload: Record<string, any>): Promise<void> {
         await apiFetch(`sessions/${encodeURIComponent(payload.name)}`, { method: "DELETE" });
         // 删除后刷新列表
         const data = await apiFetch("sessions");
-        if (data?.sessions) {
-          const items = data.sessions.map((s: any) => ({
-            name: s.name,
-            messageCount: s.messageCount,
-            mtime: new Date(s.mtime).toISOString(),
-            summary: s.summary,
-          }));
-          emitEvent({ type: "$sessions", tabId: "tab-1", items });
-        }
+        emitSessionsSnapshot(data);
       } catch {
         /* ignore */
       }
@@ -662,15 +663,9 @@ async function serverRpc(payload: Record<string, any>): Promise<void> {
             carryover: { totalCostUsd: 0, cacheHitTokens: 0, cacheMissTokens: 0 },
           });
           const listData = await apiFetch("sessions");
-          if (listData?.sessions) {
-            const items = listData.sessions.map((s: any) => ({
-              name: s.name,
-              messageCount: s.messageCount,
-              mtime: new Date(s.mtime).toISOString(),
-              summary: s.summary,
-            }));
-            emitEvent({ type: "$sessions", tabId: "tab-1", items });
-          }
+          emitSessionsSnapshot(listData);
+          const overview = await apiFetch("overview");
+          emitOverviewSnapshot(overview);
         }
       } catch {
         /* fallback */

--- a/dashboard/src/protocol.ts
+++ b/dashboard/src/protocol.ts
@@ -111,6 +111,7 @@ export type PlanClearedEvent = { type: "$plan_cleared" };
 
 export type SessionsEvent = {
   type: "$sessions";
+  currentSession?: string | null;
   items: {
     name: string;
     messageCount: number;
@@ -118,6 +119,15 @@ export type SessionsEvent = {
     summary?: string;
     workspaceStatus?: "matched" | "legacy_missing_meta";
   }[];
+};
+
+export type SessionUsageEvent = {
+  type: "$session_usage";
+  totalCostUsd: number;
+  totalPromptTokens: number;
+  totalCompletionTokens: number;
+  cacheHitTokens: number;
+  cacheMissTokens: number;
 };
 
 export type MentionResultsEvent = {
@@ -454,6 +464,7 @@ export type IncomingEvent = { tabId?: string } & (
   | ChoiceRequiredEvent
   | PlanRequiredEvent
   | SessionsEvent
+  | SessionUsageEvent
   | SessionLoadedEvent
   | SessionEmptyEvent
   | NeedsSetupEvent

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -2267,6 +2267,9 @@ function AppInner({
             totalInputCostUsd: s.totalInputCostUsd,
             totalOutputCostUsd: s.totalOutputCostUsd,
             cacheHitRatio: s.cacheHitRatio,
+            cacheHitTokens: loop.stats.cumulativeCacheHitTokens,
+            cacheMissTokens: loop.stats.cumulativeCacheMissTokens,
+            totalCompletionTokens: loop.stats.cumulativeCompletionTokens,
             lastPromptTokens: s.lastPromptTokens,
             contextCapTokens: ctxCap,
             // useSessionInfo's Balance is a flat { currency, total }; the

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -135,6 +135,12 @@ export interface DashboardStats {
   totalOutputCostUsd: number;
   /** Cache hit ratio across the session, 0..1. */
   cacheHitRatio: number;
+  /** Cumulative prompt cache-hit tokens across the live session. */
+  cacheHitTokens?: number;
+  /** Cumulative prompt cache-miss tokens across the live session. */
+  cacheMissTokens?: number;
+  /** Cumulative output tokens across the live session. */
+  totalCompletionTokens?: number;
   /** Prompt tokens of the most recent turn — feeds the ctx gauge. */
   lastPromptTokens: number;
   /** Per-model context cap in tokens (1_000_000 for V4). */

--- a/tests/dashboard-server-bridge-refresh.test.ts
+++ b/tests/dashboard-server-bridge-refresh.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type EventSourceInstance = {
+  url: string;
+  onmessage: ((msg: MessageEvent) => void) | null;
+  onerror: (() => void) | null;
+  close: () => void;
+};
+
+const settingsResponse = {
+  reasoningEffort: "high",
+  editMode: "review",
+  budgetUsd: null,
+  model: "deepseek-v4-pro",
+  webSearchEngine: "bing",
+  subagentModels: {},
+  baseUrl: "",
+  apiKey: "",
+};
+
+function jsonResponse(body: unknown): Response {
+  return {
+    status: 200,
+    text: async () => JSON.stringify(body),
+  } as Response;
+}
+
+async function loadBridge(options?: {
+  overview?: Record<string, unknown>;
+  sessions?: Record<string, unknown>;
+}) {
+  vi.resetModules();
+
+  let overview = options?.overview ?? {
+    cwd: "E:/proj",
+    model: "deepseek-v4-pro",
+    version: "0.52.0",
+    stats: {
+      totalCostUsd: 0.123456,
+      cacheHitRatio: 0.75,
+      lastPromptTokens: 1200,
+      cacheHitTokens: 900,
+      cacheMissTokens: 300,
+      totalCompletionTokens: 150,
+      balance: [{ currency: "CNY", total_balance: "88.5" }],
+    },
+  };
+  let sessions = options?.sessions ?? {
+    currentSession: "code-20260526120000",
+    sessions: [
+      {
+        name: "code-20260526120000",
+        messageCount: 4,
+        mtime: Date.UTC(2026, 4, 26, 12, 0, 0),
+        summary: "fresh session",
+      },
+    ],
+  };
+
+  vi.stubGlobal("document", {
+    documentElement: { dataset: {} },
+    querySelector: (selector: string) => {
+      if (selector === 'meta[name="reasonix-mode"]') {
+        return { getAttribute: () => "server" };
+      }
+      if (selector === 'meta[name="reasonix-token"]') {
+        return { getAttribute: () => "testtoken" };
+      }
+      return null;
+    },
+  });
+
+  const eventSources: EventSourceInstance[] = [];
+  class FakeEventSource {
+    onmessage: ((msg: MessageEvent) => void) | null = null;
+    onerror: (() => void) | null = null;
+    constructor(public url: string) {
+      eventSources.push(this);
+    }
+    close() {}
+  }
+  vi.stubGlobal("EventSource", FakeEventSource);
+
+  const fetchMock = vi.fn(async (url: string) => {
+    if (url.includes("/api/settings")) return jsonResponse(settingsResponse);
+    if (url.includes("/api/sessions")) return jsonResponse(sessions);
+    if (url.includes("/api/overview")) return jsonResponse(overview);
+    return jsonResponse({});
+  });
+  vi.stubGlobal("fetch", fetchMock);
+
+  const bridge = await import("../dashboard/src/lib/tauri-bridge");
+  const events: Record<string, any>[] = [];
+  await bridge.listen("rpc:event", (event) => {
+    events.push(JSON.parse(event.payload.data));
+  });
+  await bridge.invoke("rpc_spawn");
+  await vi.waitFor(() => expect(events.some((event) => event.type === "$ready")).toBe(true));
+
+  return {
+    bridge,
+    events,
+    fetchMock,
+    eventSources,
+    setOverview: (next: Record<string, unknown>) => {
+      overview = next;
+    },
+    setSessions: (next: Record<string, unknown>) => {
+      sessions = next;
+    },
+  };
+}
+
+describe("dashboard server bridge refresh", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("emits the current server session in the session snapshot", async () => {
+    const { events } = await loadBridge();
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "$sessions",
+        currentSession: "code-20260526120000",
+        items: [
+          expect.objectContaining({
+            name: "code-20260526120000",
+            messageCount: 4,
+            summary: "fresh session",
+          }),
+        ],
+      }),
+    );
+  });
+
+  it("emits absolute usage stats from overview so the token counter can recover after reconnect", async () => {
+    const { events } = await loadBridge();
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "$session_usage",
+        totalCostUsd: 0.123456,
+        totalPromptTokens: 1200,
+        totalCompletionTokens: 150,
+        cacheHitTokens: 900,
+        cacheMissTokens: 300,
+      }),
+    );
+  });
+
+  it("polls snapshots so sessions created outside the open page appear without reload", async () => {
+    const { events, setOverview, setSessions } = await loadBridge();
+    events.length = 0;
+
+    setSessions({
+      currentSession: "code-20260526120500",
+      sessions: [
+        {
+          name: "code-20260526120500",
+          messageCount: 2,
+          mtime: Date.UTC(2026, 4, 26, 12, 5, 0),
+          summary: "new external session",
+        },
+      ],
+    });
+    setOverview({
+      cwd: "E:/proj",
+      model: "deepseek-v4-pro",
+      version: "0.52.0",
+      stats: {
+        totalCostUsd: 0.2,
+        cacheHitTokens: 1600,
+        cacheMissTokens: 400,
+        totalCompletionTokens: 250,
+        balance: [{ currency: "CNY", total_balance: "91" }],
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "$sessions",
+        currentSession: "code-20260526120500",
+        items: [expect.objectContaining({ name: "code-20260526120500" })],
+      }),
+    );
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "$session_usage",
+        totalPromptTokens: 2000,
+        totalCompletionTokens: 250,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Refresh server-mode dashboard sessions and active session state from `/api/sessions` snapshots.
- Publish absolute usage snapshots from `/api/overview` so token, cost, and cache counters recover after `/new`, reconnects, or remounts.
- Add regression coverage for session snapshots, usage snapshots, and polling refresh.

## Test Plan
- npm test -- tests/dashboard-server-bridge-refresh.test.ts
- npm test -- tests/server-dashboard.test.ts tests/dashboard-server-bridge-refresh.test.ts tests/dashboard-sessions-ops.test.ts
- npm run typecheck
- npm run lint
- npm run verify