### PR TITLE
fix(desktop): support \[ \] and \( \) math delimiters in markdown

### DIFF
--- a/desktop/src/Markdown.tsx
+++ b/desktop/src/Markdown.tsx
@@ -204,6 +204,22 @@ function withFilePills(children: ReactNode): ReactNode {
   });
 }
 
+/**
+ * Convert bracket-style math delimiters to dollar-style so they survive
+ * the markdown parser (which would otherwise consume the backslash in `\[`
+ * as an escape). Handles both display math \[...\] → $$...$$ and inline
+ * math \(...\) → $...$.
+ */
+function normalizeMathDelimiters(source: string): string {
+  return source
+    // display math: \[ ... \] → $$ ... $$
+    .replace(/\\\[/g, "$$$$")
+    .replace(/\\\]/g, "$$$$")
+    // inline math: \( ... \) → $ ... $
+    .replace(/\\\(/g, "$$")
+    .replace(/\\\)/g, "$$");
+}
+
 export const Markdown = memo(function Markdown({ source }: { source: string }) {
   return (
     <div className="markdown">
@@ -233,7 +249,7 @@ export const Markdown = memo(function Markdown({ source }: { source: string }) {
           td: ({ children }) => <td>{withFilePills(children)}</td>,
         }}
       >
-        {source}
+        {normalizeMathDelimiters(source)}
       </ReactMarkdown>
     </div>
   );

--- a/desktop/src/Markdown.tsx
+++ b/desktop/src/Markdown.tsx
@@ -209,15 +209,25 @@ function withFilePills(children: ReactNode): ReactNode {
  * the markdown parser (which would otherwise consume the backslash in `\[`
  * as an escape). Handles both display math \[...\] → $$...$$ and inline
  * math \(...\) → $...$.
+ *
+ * Protects `\\[` sequences (LaTeX line-break spacing like `\\[4pt]`)
+ * from being mangled — the regex must not match the `\[` inside `\\[`.
  */
 function normalizeMathDelimiters(source: string): string {
-  return source
+  // Protect LaTeX line-break spacing \\[ ... ] — use a sentinel that
+  // can't appear in normal text.
+  const LB = "\x00LB\x00";
+  let result = source.replace(/\\\\\[/g, LB);
+  result = result
     // display math: \[ ... \] → $$ ... $$
     .replace(/\\\[/g, "$$$$")
     .replace(/\\\]/g, "$$$$")
     // inline math: \( ... \) → $ ... $
     .replace(/\\\(/g, "$$")
     .replace(/\\\)/g, "$$");
+  // Restore protected sequences
+  result = result.replace(/\x00LB\x00/g, "\\\\[");
+  return result;
 }
 
 export const Markdown = memo(function Markdown({ source }: { source: string }) {


### PR DESCRIPTION
## What

Adds `normalizeMathDelimiters()` to `desktop/src/Markdown.tsx` — a source-level
preprocessor that converts `\[...\]` → `[...]` and `\(...\)` → `(...)`
before the markdown parser runs. This lets bracket-delimited LaTeX math render
via KaTeX in the desktop client.

## Why

`remark-math` supports both `[...]` and `(...)` delimiters natively, but
the markdown parser consumes the backslash in `\[` as an escape character
before `remark-math`'s micromark extension sees it. The result is that
bracket-delimited math renders as literal bracketed text rather than being
passed through to KaTeX. The `$` delimiters have no special meaning in
markdown and already work correctly — so the fix is to normalize brackets
into dollar signs before parsing.

## How to verify

1. In the desktop app, send a message containing `\[ \rho = \frac{1}{\sqrt{2}}(r_1 - r_2) \]`
2. Observe that it renders as KaTeX display math instead of literal text
3. Existing `$...$` and `$$...$$` math still renders correctly (untouched by the transform)

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time
