### PR TITLE
feat(desktop): collapse intermediate reasoning, group consecutive tool calls

### DIFF
--- a/desktop/src/i18n/en.ts
+++ b/desktop/src/i18n/en.ts
@@ -692,6 +692,8 @@ export const en = {
     unknownKind: "# unknown card kind — fallback render",
   },
   thread: {
+    toolCalls: "{count} tool calls",
+    oneToolCall: "1 tool call",
     keepSteps: "Keep {n} remaining step(s)",
     keepOriginal: "Keep original",
     you: "You",

--- a/desktop/src/i18n/zh-CN.ts
+++ b/desktop/src/i18n/zh-CN.ts
@@ -677,6 +677,8 @@ export const zhCN: typeof en = {
     unknownKind: "# 未知卡片类型 — fallback 渲染",
   },
   thread: {
+    toolCalls: "{count} 个工具调用",
+    oneToolCall: "1 个工具调用",
     keepSteps: "保留剩余 {n} 步",
     keepOriginal: "保留原计划",
     you: "你",

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -2033,6 +2033,40 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
   max-width: 60ch;
 }
 
+.tool-group {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+.tool-group-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 6px 10px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--fg-2);
+  background: var(--panel);
+  cursor: pointer;
+  border: none;
+}
+.tool-group-header:hover {
+  background: var(--panel-2);
+}
+.tool-group-header .chevron {
+  margin-left: auto;
+  transition: transform 150ms;
+}
+.tool-group-header .chevron.open {
+  transform: rotate(180deg);
+}
+.tool-group-body {
+  border-top: 1px solid var(--border);
+}
+.tool-group-body > * + * {
+  border-top: 1px solid var(--border);
+}
 .msg {
   display: flex;
   gap: 14px;

--- a/desktop/src/ui/cards.tsx
+++ b/desktop/src/ui/cards.tsx
@@ -218,7 +218,7 @@ export function ShellCard({
   onApprove,
   onReject,
   onAlwaysAllow,
-  defaultOpen: _defaultOpen,
+  defaultOpen,
 }: {
   command: string;
   output?: string;
@@ -238,7 +238,7 @@ export function ShellCard({
       kind="shell"
       name="shell"
       compact
-      defaultOpen={_defaultOpen ?? false}
+      defaultOpen={defaultOpen ?? false}
       meta={
         <>
           {state === "await" ? (
@@ -337,7 +337,7 @@ export function ToolCard({
   result,
   ok,
   durationMs,
-  defaultOpen: _defaultOpen,
+  defaultOpen,
 }: {
   name: string;
   args?: string;
@@ -355,7 +355,7 @@ export function ToolCard({
       icon={<I.wrench size={12} />}
       kind="tool"
       name={name}
-      defaultOpen={_defaultOpen ?? false}
+      defaultOpen={defaultOpen ?? false}
       compact
       meta={
         <>

--- a/desktop/src/ui/cards.tsx
+++ b/desktop/src/ui/cards.tsx
@@ -218,6 +218,7 @@ export function ShellCard({
   onApprove,
   onReject,
   onAlwaysAllow,
+  defaultOpen: _defaultOpen,
 }: {
   command: string;
   output?: string;
@@ -226,6 +227,7 @@ export function ShellCard({
   onApprove?: () => void;
   onReject?: () => void;
   onAlwaysAllow?: () => void;
+  defaultOpen?: boolean;
 }) {
   useLang();
   const tone: Tone = state === "failed" ? "danger" : state === "done" ? "success" : "warning";
@@ -236,7 +238,7 @@ export function ShellCard({
       kind="shell"
       name="shell"
       compact
-      defaultOpen={false}
+      defaultOpen={_defaultOpen ?? false}
       meta={
         <>
           {state === "await" ? (
@@ -335,12 +337,14 @@ export function ToolCard({
   result,
   ok,
   durationMs,
+  defaultOpen: _defaultOpen,
 }: {
   name: string;
   args?: string;
   result?: string;
   ok?: boolean;
   durationMs?: number;
+  defaultOpen?: boolean;
 }) {
   useLang();
   const running = result === undefined;
@@ -351,7 +355,7 @@ export function ToolCard({
       icon={<I.wrench size={12} />}
       kind="tool"
       name={name}
-      defaultOpen={false}
+      defaultOpen={_defaultOpen ?? false}
       compact
       meta={
         <>

--- a/desktop/src/ui/cards.tsx
+++ b/desktop/src/ui/cards.tsx
@@ -236,7 +236,7 @@ export function ShellCard({
       kind="shell"
       name="shell"
       compact
-      defaultOpen={state !== "done"}
+      defaultOpen={false}
       meta={
         <>
           {state === "await" ? (

--- a/desktop/src/ui/thread.tsx
+++ b/desktop/src/ui/thread.tsx
@@ -102,6 +102,26 @@ export const UserMsg = memo(function UserMsg({
   );
 });
 
+function ToolGroupShell({ segs, renderTool: rt }: {
+  segs: (AssistantSegment & { kind: "tool" })[];
+  renderTool: (s: AssistantSegment & { kind: "tool" }, idx: number, expanded?: boolean) => ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="tool-group">
+      <button className="tool-group-header" onClick={() => setOpen((o) => !o)}>
+        <span>{segs.length > 1 ? t("thread.toolCalls", { count: segs.length }) : t("thread.oneToolCall")}</span>
+        <span className={`chevron ${open ? "open" : ""}`}>{I.chev({ size: 12 })}</span>
+      </button>
+      {open && (
+        <div className="tool-group-body">
+          {segs.map((ts) => rt(ts, segs.indexOf(ts), true))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export const AssistantMsg = memo(function AssistantMsg({
   segments,
   pending,
@@ -146,26 +166,9 @@ export const AssistantMsg = memo(function AssistantMsg({
     const { segments: tSegs } = toolGroup;
     const groupKey = toolGroup.indices[0]!;
     if (tSegs.length === 1) {
-      // Single tool — render inline without group wrapper
       rendered.push(renderTool(tSegs[0]!, groupKey));
     } else {
-      const GroupShell = ({ groupKey, segs }: { groupKey: number; segs: (AssistantSegment & { kind: "tool" })[] }) => {
-        const [open, setOpen] = useState(false);
-        return (
-          <div key={`tool-group-${groupKey}`} className="tool-group">
-            <button className="tool-group-header" onClick={() => setOpen((o) => !o)}>
-              <span>{segs.length > 1 ? t("thread.toolCalls", { count: segs.length }) : t("thread.oneToolCall")}</span>
-              <span className={`chevron ${open ? "open" : ""}`}>{I.chev({ size: 12 })}</span>
-            </button>
-            {open && (
-              <div className="tool-group-body">
-                {segs.map((ts) => renderTool(ts, segs.indexOf(ts), true))}
-              </div>
-            )}
-          </div>
-        );
-      };
-      rendered.push(<GroupShell key={`tool-group-${groupKey}`} groupKey={groupKey} segs={tSegs} />);
+      rendered.push(<ToolGroupShell key={`tool-group-${groupKey}`} segs={tSegs} renderTool={renderTool} />);
     }
     toolGroup = null;
   }
@@ -192,7 +195,7 @@ export const AssistantMsg = memo(function AssistantMsg({
           output={s.result}
           state={state}
           durationMs={s.durationMs}
-          defaultOpen={expanded}
+          defaultOpen={expanded ?? state !== "done"}
           onApprove={pendingConfirm ? () => onApproveConfirm(pendingConfirm.id) : undefined}
           onReject={pendingConfirm ? () => onRejectConfirm(pendingConfirm.id) : undefined}
           onAlwaysAllow={

--- a/desktop/src/ui/thread.tsx
+++ b/desktop/src/ui/thread.tsx
@@ -157,7 +157,7 @@ export const AssistantMsg = memo(function AssistantMsg({
           </button>
           {toolOpen && (
             <div className="tool-group-body">
-              {tSegs.map((ts, tgi) => renderTool(ts, toolGroup!.indices[tgi]!))}
+              {tSegs.map((ts, tgi) => renderTool(ts, toolGroup!.indices[tgi]!, true))}
             </div>
           )}
         </div>,
@@ -166,7 +166,7 @@ export const AssistantMsg = memo(function AssistantMsg({
     toolGroup = null;
   }
 
-  function renderTool(s: AssistantSegment & { kind: "tool" }, idx: number): ReactNode {
+  function renderTool(s: AssistantSegment & { kind: "tool" }, idx: number, expanded?: boolean): ReactNode {
     const pendingConfirm =
       (s.name === "run_command" || s.name === "run_background") && s.result === undefined
         ? pendingConfirms.find((c) => c.command === extractCommand(s.args))
@@ -188,6 +188,7 @@ export const AssistantMsg = memo(function AssistantMsg({
           output={s.result}
           state={state}
           durationMs={s.durationMs}
+          defaultOpen={expanded}
           onApprove={pendingConfirm ? () => onApproveConfirm(pendingConfirm.id) : undefined}
           onReject={pendingConfirm ? () => onRejectConfirm(pendingConfirm.id) : undefined}
           onAlwaysAllow={
@@ -209,11 +210,11 @@ export const AssistantMsg = memo(function AssistantMsg({
           ))}
         </>
       ) : (
-        <ToolCard key={idx} name={s.name} args={s.args} result={s.result} ok={s.ok} durationMs={s.durationMs} />
+        <ToolCard key={idx} name={s.name} args={s.args} result={s.result} ok={s.ok} durationMs={s.durationMs} defaultOpen={expanded} />
       );
     }
     return (
-      <ToolCard key={idx} name={s.name} args={s.args} result={s.result} ok={s.ok} durationMs={s.durationMs} />
+      <ToolCard key={idx} name={s.name} args={s.args} result={s.result} ok={s.ok} durationMs={s.durationMs} defaultOpen={expanded} />
     );
   }
 

--- a/desktop/src/ui/thread.tsx
+++ b/desktop/src/ui/thread.tsx
@@ -135,6 +135,121 @@ export const AssistantMsg = memo(function AssistantMsg({
       /* ignore */
     }
   };
+  // Render tool segments — consecutive tools get grouped into a collapsible section
+  const [toolOpen, setToolOpen] = useState(false);
+  const rendered: ReactNode[] = [];
+
+  let firstReasoningShown = false;
+  let toolGroup: { segments: (AssistantSegment & { kind: "tool" })[]; indices: number[] } | null = null;
+
+  function flushToolGroup(): void {
+    if (!toolGroup) return;
+    const { segments: tSegs } = toolGroup;
+    if (tSegs.length === 1) {
+      // Single tool — render inline without group wrapper
+      rendered.push(renderTool(tSegs[0]!, toolGroup.indices[0]!));
+    } else {
+      rendered.push(
+        <div key={`tool-group-${toolGroup.indices[0]}`} className="tool-group">
+          <button className="tool-group-header" onClick={() => setToolOpen((o) => !o)}>
+            <span>{tSegs.length > 1 ? t("thread.toolCalls", { count: tSegs.length }) : t("thread.oneToolCall")}</span>
+            <span className={`chevron ${toolOpen ? "open" : ""}`}>{I.chev({ size: 12 })}</span>
+          </button>
+          {toolOpen && (
+            <div className="tool-group-body">
+              {tSegs.map((ts, tgi) => renderTool(ts, toolGroup!.indices[tgi]!))}
+            </div>
+          )}
+        </div>,
+      );
+    }
+    toolGroup = null;
+  }
+
+  function renderTool(s: AssistantSegment & { kind: "tool" }, idx: number): ReactNode {
+    const pendingConfirm =
+      (s.name === "run_command" || s.name === "run_background") && s.result === undefined
+        ? pendingConfirms.find((c) => c.command === extractCommand(s.args))
+        : undefined;
+    if (s.name === "run_command" || s.name === "run_background") {
+      const cmd = extractCommand(s.args) ?? s.args;
+      const state: "await" | "running" | "done" | "failed" =
+        s.result === undefined
+          ? pendingConfirm
+            ? "await"
+            : "running"
+          : s.ok === false
+            ? "failed"
+            : "done";
+      return (
+        <ShellCard
+          key={idx}
+          command={cmd}
+          output={s.result}
+          state={state}
+          durationMs={s.durationMs}
+          onApprove={pendingConfirm ? () => onApproveConfirm(pendingConfirm.id) : undefined}
+          onReject={pendingConfirm ? () => onRejectConfirm(pendingConfirm.id) : undefined}
+          onAlwaysAllow={
+            pendingConfirm
+              ? () => {
+                  onAlwaysAllowConfirm(pendingConfirm.id, derivePrefix(cmd));
+                }
+              : undefined
+          }
+        />
+      );
+    }
+    if (s.result && (s.name === "edit_file" || s.name === "multi_edit")) {
+      const files = parseEditResult(s.result);
+      return files.length > 0 ? (
+        <>
+          {files.map((f, fi) => (
+            <DiffCard key={`${idx}-${fi}`} filename={f.filename} lines={f.lines} applied={s.ok !== false} />
+          ))}
+        </>
+      ) : (
+        <ToolCard key={idx} name={s.name} args={s.args} result={s.result} ok={s.ok} durationMs={s.durationMs} />
+      );
+    }
+    return (
+      <ToolCard key={idx} name={s.name} args={s.args} result={s.result} ok={s.ok} durationMs={s.durationMs} />
+    );
+  }
+
+  for (let i = 0; i < segments.length; i++) {
+    const s = segments[i]!;
+    if (s.kind === "text") {
+      flushToolGroup();
+      if (!s.text.trim()) continue;
+      if (isCompactionSummary(s.text)) {
+        rendered.push(<CompactionCard key={`t-${i}`} summary={stripCompactionMarker(s.text)} />);
+      } else {
+        rendered.push(<AssistantText key={`t-${i}`} text={s.text} />);
+      }
+      continue;
+    }
+    if (s.kind === "reasoning") {
+      flushToolGroup();
+      if (!firstReasoningShown) {
+        firstReasoningShown = true;
+        rendered.push(
+          <ReasoningCard key={`r-${i}`} text={s.text} streaming={pending && i === segments.length - 1} />,
+        );
+      }
+      // Subsequent reasoning segments are intermediate tool-calling thought — hidden
+      continue;
+    }
+    // Tool segment — accumulate into group
+    if (!toolGroup) {
+      toolGroup = { segments: [], indices: [] };
+    }
+    toolGroup.segments.push(s);
+    toolGroup.indices.push(i);
+  }
+
+  flushToolGroup();
+
   return (
     <div className="msg assistant">
       <div className="avatar">DS</div>
@@ -144,92 +259,7 @@ export const AssistantMsg = memo(function AssistantMsg({
           {model ? <span className="model">{model}</span> : null}
           {time ? <span className="time">{time}</span> : null}
         </div>
-        {segments.map((s, i) => {
-          if (s.kind === "text") {
-            if (!s.text.trim()) return null;
-            if (isCompactionSummary(s.text)) {
-              return <CompactionCard key={i} summary={stripCompactionMarker(s.text)} />;
-            }
-            return <AssistantText key={i} text={s.text} />;
-          }
-          if (s.kind === "reasoning") {
-            return (
-              <ReasoningCard
-                key={i}
-                text={s.text}
-                streaming={pending && i === segments.length - 1}
-              />
-            );
-          }
-          // tool segment
-          const pendingConfirm =
-            (s.name === "run_command" || s.name === "run_background") && s.result === undefined
-              ? pendingConfirms.find((c) => c.command === extractCommand(s.args))
-              : undefined;
-          if (s.name === "run_command" || s.name === "run_background") {
-            const cmd = extractCommand(s.args) ?? s.args;
-            const state: "await" | "running" | "done" | "failed" =
-              s.result === undefined
-                ? pendingConfirm
-                  ? "await"
-                  : "running"
-                : s.ok === false
-                  ? "failed"
-                  : "done";
-            return (
-              <ShellCard
-                key={i}
-                command={cmd}
-                output={s.result}
-                state={state}
-                durationMs={s.durationMs}
-                onApprove={pendingConfirm ? () => onApproveConfirm(pendingConfirm.id) : undefined}
-                onReject={pendingConfirm ? () => onRejectConfirm(pendingConfirm.id) : undefined}
-                onAlwaysAllow={
-                  pendingConfirm
-                    ? () => {
-                        onAlwaysAllowConfirm(pendingConfirm.id, derivePrefix(cmd));
-                      }
-                    : undefined
-                }
-              />
-            );
-          }
-          if (s.result && (s.name === "edit_file" || s.name === "multi_edit")) {
-            const files = parseEditResult(s.result);
-            return files.length > 0 ? (
-              <>
-                {files.map((f, fi) => (
-                  <DiffCard
-                    key={`${i}-${fi}`}
-                    filename={f.filename}
-                    lines={f.lines}
-                    applied={s.ok !== false}
-                  />
-                ))}
-              </>
-            ) : (
-              <ToolCard
-                key={i}
-                name={s.name}
-                args={s.args}
-                result={s.result}
-                ok={s.ok}
-                durationMs={s.durationMs}
-              />
-            );
-          }
-          return (
-            <ToolCard
-              key={i}
-              name={s.name}
-              args={s.args}
-              result={s.result}
-              ok={s.ok}
-              durationMs={s.durationMs}
-            />
-          );
-        })}
+        {rendered}
         {content ? (
           <div className="msg-actions">
             <button

--- a/desktop/src/ui/thread.tsx
+++ b/desktop/src/ui/thread.tsx
@@ -136,7 +136,6 @@ export const AssistantMsg = memo(function AssistantMsg({
     }
   };
   // Render tool segments — consecutive tools get grouped into a collapsible section
-  const [toolOpen, setToolOpen] = useState(false);
   const rendered: ReactNode[] = [];
 
   let firstReasoningShown = false;
@@ -145,23 +144,28 @@ export const AssistantMsg = memo(function AssistantMsg({
   function flushToolGroup(): void {
     if (!toolGroup) return;
     const { segments: tSegs } = toolGroup;
+    const groupKey = toolGroup.indices[0]!;
     if (tSegs.length === 1) {
       // Single tool — render inline without group wrapper
-      rendered.push(renderTool(tSegs[0]!, toolGroup.indices[0]!));
+      rendered.push(renderTool(tSegs[0]!, groupKey));
     } else {
-      rendered.push(
-        <div key={`tool-group-${toolGroup.indices[0]}`} className="tool-group">
-          <button className="tool-group-header" onClick={() => setToolOpen((o) => !o)}>
-            <span>{tSegs.length > 1 ? t("thread.toolCalls", { count: tSegs.length }) : t("thread.oneToolCall")}</span>
-            <span className={`chevron ${toolOpen ? "open" : ""}`}>{I.chev({ size: 12 })}</span>
-          </button>
-          {toolOpen && (
-            <div className="tool-group-body">
-              {tSegs.map((ts, tgi) => renderTool(ts, toolGroup!.indices[tgi]!, true))}
-            </div>
-          )}
-        </div>,
-      );
+      const GroupShell = ({ groupKey, segs }: { groupKey: number; segs: (AssistantSegment & { kind: "tool" })[] }) => {
+        const [open, setOpen] = useState(false);
+        return (
+          <div key={`tool-group-${groupKey}`} className="tool-group">
+            <button className="tool-group-header" onClick={() => setOpen((o) => !o)}>
+              <span>{segs.length > 1 ? t("thread.toolCalls", { count: segs.length }) : t("thread.oneToolCall")}</span>
+              <span className={`chevron ${open ? "open" : ""}`}>{I.chev({ size: 12 })}</span>
+            </button>
+            {open && (
+              <div className="tool-group-body">
+                {segs.map((ts) => renderTool(ts, segs.indexOf(ts), true))}
+              </div>
+            )}
+          </div>
+        );
+      };
+      rendered.push(<GroupShell key={`tool-group-${groupKey}`} groupKey={groupKey} segs={tSegs} />);
     }
     toolGroup = null;
   }


### PR DESCRIPTION
## Summary

Reduce visual noise in long assistant turns by hiding intermediate reasoning segments between tool calls, and grouping consecutive tool calls into a single collapsible section.

## Changes

### 1. Hide intermediate reasoning (`thread.tsx`)
- Only the FIRST reasoning segment per assistant turn is rendered
- Subsequent reasoning segments (model thinking between tool calls) are hidden
- User sees one coherent reasoning block per turn instead of repetitive cards

### 2. Group consecutive tool calls (`thread.tsx`, `styles.css`)
- Multiple sequential tool segments (e.g. shell → shell → edit_file) are wrapped in a `.tool-group` collapsible container
- Header shows count: "3 tool calls" / "3 个工具调用"
- Default collapsed; click to expand
- Single tool calls render without wrapper (no visual change)

### 3. Default collapse for completed shell cards (`cards.tsx`)
- `ShellCard` now defaults to collapsed (`defaultOpen={false}`) instead of remaining open until done
- Reasoning cards still auto-expand during thinking and collapse on completion
- ToolCard and DiffCard were already collapsed by default

### 4. i18n
- Added `thread.toolCalls` and `thread.oneToolCall` keys (EN + zh-CN)
