### PR TITLE
fix: sanitize lone surrogates in chat payloads

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -108,6 +108,49 @@ export interface DeepSeekClientOptions {
   retry?: RetryOptions;
 }
 
+// DeepSeek's strict JSON parser rejects lone UTF-16 surrogate escapes
+// (`\ud800`, `\udc00`) even though JavaScript can carry them in strings.
+function replaceLoneSurrogates(value: string): string {
+  let out = "";
+  let last = 0;
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(i + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        i++;
+      } else {
+        out += value.slice(last, i);
+        out += "\uFFFD";
+        last = i + 1;
+      }
+      continue;
+    }
+    if (code >= 0xdc00 && code <= 0xdfff) {
+      out += value.slice(last, i);
+      out += "\uFFFD";
+      last = i + 1;
+    }
+  }
+  if (last === 0) return value;
+  return out + value.slice(last);
+}
+
+function sanitizeJsonTransportValue(value: unknown): unknown {
+  if (typeof value === "string") return replaceLoneSurrogates(value);
+  if (value === null || typeof value !== "object") return value;
+  if (Array.isArray(value)) return value.map((item) => sanitizeJsonTransportValue(item));
+  const out: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value)) {
+    out[key] = sanitizeJsonTransportValue(item);
+  }
+  return out;
+}
+
+function stringifyJsonTransport(value: unknown): string {
+  return JSON.stringify(sanitizeJsonTransportValue(value));
+}
+
 export class DeepSeekClient {
   readonly apiKey: string;
   readonly baseUrl: string;
@@ -257,7 +300,7 @@ export class DeepSeekClient {
             Authorization: `Bearer ${this.apiKey}`,
             "Content-Type": "application/json",
           },
-          body: JSON.stringify(this.buildPayload(opts, false)),
+          body: stringifyJsonTransport(this.buildPayload(opts, false)),
           signal,
         },
         { ...this.retry, signal },
@@ -306,7 +349,7 @@ export class DeepSeekClient {
             "Content-Type": "application/json",
             Accept: "text/event-stream",
           },
-          body: JSON.stringify(this.buildPayload(opts, true)),
+          body: stringifyJsonTransport(this.buildPayload(opts, true)),
           signal,
         },
         { ...this.retry, signal },

--- a/tests/client-models.test.ts
+++ b/tests/client-models.test.ts
@@ -124,3 +124,28 @@ describe("DeepSeekClient usage parsing", () => {
     expect(resp.usage.promptCacheMissTokens).toBe(42);
   });
 });
+
+describe("DeepSeekClient request serialization", () => {
+  it("replaces lone UTF-16 surrogates before sending JSON", async () => {
+    let sentBody = "";
+    const spy = vi.fn(async (_url: unknown, init: unknown) => {
+      sentBody = String((init as RequestInit).body ?? "");
+      return new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    const client = new DeepSeekClient({
+      apiKey: "sk-test",
+      fetch: spy as unknown as typeof fetch,
+    });
+
+    await client.chat({
+      model: "deepseek-chat",
+      messages: [{ role: "user", content: `bad ${String.fromCharCode(0xd800)} text` }],
+    });
+
+    expect(sentBody).not.toMatch(/\\ud[89ab][0-9a-f]{2}/i);
+    expect(JSON.parse(sentBody).messages[0].content).toBe("bad \uFFFD text");
+  });
+});


### PR DESCRIPTION
## Summary
- sanitize outgoing chat completion payload strings by replacing lone UTF-16 surrogate code units with U+FFFD before JSON serialization
- cover the malformed request case with a DeepSeekClient request serialization regression test

## Root cause
JavaScript strings can contain unpaired surrogate halves. JSON.stringify emits them as \ud800 or \udc00 escapes, which can be rejected by DeepSeek's strict request-body parser and produce the reported messages[n].content parse error.

## Tests
- npm test -- tests/client-models.test.ts
- npx biome check src/client.ts tests/client-models.test.ts
- npm run typecheck
- npm run verify
- pre-push verify during git push

Fixes #1933
