### PR TITLE
feat(qq): default to markdown replies

### DIFF
--- a/src/qq/bot.ts
+++ b/src/qq/bot.ts
@@ -254,12 +254,18 @@ export class QQBot extends EventEmitter {
     content: string,
     msgId?: string,
     msgSeq?: number,
+    markdown = false,
   ): Promise<void> {
     const token = await this.ensureToken();
-    const body: Record<string, unknown> = {
-      content,
-      msg_type: 0,
-    };
+    const body: Record<string, unknown> = markdown
+      ? {
+          markdown: { content },
+          msg_type: 2,
+        }
+      : {
+          content,
+          msg_type: 0,
+        };
     if (msgId) body.msg_id = msgId;
     if (typeof msgSeq === "number" && Number.isFinite(msgSeq)) body.msg_seq = Math.trunc(msgSeq);
     const res = await fetch(`${this.baseUrl}/v2/users/${encodeURIComponent(openid)}/messages`, {

--- a/src/qq/channel.ts
+++ b/src/qq/channel.ts
@@ -11,6 +11,7 @@ import { formatQQAccessSummary } from "./strings.js";
 const QQ_LOCK_FILE = join(homedir(), ".reasonix", "qq-channel.pid");
 const QQ_MAX_CHUNK_BYTES = 1500;
 const NATURAL_SPLIT_MIN_FRACTION = 0.6;
+const QQ_MARKDOWN_WRAPPER_RE = /^```(?:markdown|md)\s*\r?\n([\s\S]*?)\r?\n```$/i;
 
 function fitUtf8Slice(text: string, maxBytes: number): string {
   let end = 0;
@@ -51,6 +52,15 @@ export function splitQQMessage(text: string, maxBytes = QQ_MAX_CHUNK_BYTES): str
   return chunks;
 }
 
+export function normalizeQQMarkdownReply(text: string): string {
+  const trimmed = text.trim();
+  const match = trimmed.match(QQ_MARKDOWN_WRAPPER_RE);
+  if (!match) {
+    return text;
+  }
+  return match[1] ?? text;
+}
+
 export class QQChannel {
   private bot: QQBot | null = null;
   private qqUserId: string | null = null;
@@ -62,6 +72,7 @@ export class QQChannel {
   private processedMsgIdQueue: string[] = [];
   private lockAcquired = false;
   private nextOutboundMsgSeq = 1;
+  private markdownDisabled = false;
 
   constructor(
     private callbacks: {
@@ -235,16 +246,36 @@ export class QQChannel {
 
   async sendResponse(text: string): Promise<void> {
     if (!this.bot || !this.qqUserId) return;
-    const chunks = splitQQMessage(text);
+    const chunks = splitQQMessage(normalizeQQMarkdownReply(text));
     for (let index = 0; index < chunks.length; index++) {
       const chunk = chunks[index];
       if (!chunk) continue;
       try {
+        const msgSeq = this.nextOutboundMsgSeq++;
+        if (!this.markdownDisabled) {
+          try {
+            await this.bot.sendPrivateMessage(
+              this.qqUserId,
+              chunk,
+              this.qqMessageId ?? undefined,
+              msgSeq,
+              true,
+            );
+            continue;
+          } catch (err) {
+            this.markdownDisabled = true;
+            this.callbacks.onError?.(
+              `QQ markdown delivery disabled after first failure: ${(err as Error).message}`,
+            );
+          }
+        }
+
         await this.bot.sendPrivateMessage(
           this.qqUserId,
           chunk,
           this.qqMessageId ?? undefined,
           this.nextOutboundMsgSeq++,
+          false,
         );
       } catch (err) {
         const msg = `QQ sendResponse chunk ${index + 1}/${chunks.length} failed: ${(err as Error).message}`;

--- a/tests/qq-channel.test.ts
+++ b/tests/qq-channel.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { QQChannel, splitQQMessage } from "../src/qq/channel.js";
+import { QQChannel, normalizeQQMarkdownReply, splitQQMessage } from "../src/qq/channel.js";
 
 describe("splitQQMessage", () => {
   it("keeps every chunk within the UTF-8 byte budget", () => {
@@ -11,7 +11,133 @@ describe("splitQQMessage", () => {
   });
 });
 
+describe("normalizeQQMarkdownReply", () => {
+  it("unwraps a full fenced markdown block before delivery", () => {
+    expect(normalizeQQMarkdownReply("```markdown\n# Title\n\n**bold**\n\n- item\n```")).toBe(
+      "# Title\n\n**bold**\n\n- item",
+    );
+  });
+
+  it("keeps normal code blocks unchanged when the whole reply is not a markdown wrapper", () => {
+    expect(normalizeQQMarkdownReply("Here is code:\n```ts\nconsole.log('hi')\n```")).toBe(
+      "Here is code:\n```ts\nconsole.log('hi')\n```",
+    );
+  });
+});
+
 describe("QQChannel.sendResponse", () => {
+  it("sends short replies through the markdown path by default", async () => {
+    const bot = { sendPrivateMessage: vi.fn().mockResolvedValue(undefined) };
+    const channel = new QQChannel({ onSubmitMessage: () => undefined }) as QQChannel & {
+      bot: typeof bot;
+      qqUserId: string;
+      qqMessageId: string;
+      nextOutboundMsgSeq: number;
+    };
+    channel.bot = bot;
+    channel.qqUserId = "user-openid";
+    channel.qqMessageId = "msg-id";
+    channel.nextOutboundMsgSeq = 1;
+
+    await channel.sendResponse("**bold**");
+
+    expect(bot.sendPrivateMessage).toHaveBeenCalledTimes(1);
+    expect(bot.sendPrivateMessage).toHaveBeenNthCalledWith(
+      1,
+      "user-openid",
+      "**bold**",
+      "msg-id",
+      1,
+      true,
+    );
+  });
+
+  it("falls back to plain text when markdown delivery fails", async () => {
+    const bot = {
+      sendPrivateMessage: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("markdown rejected"))
+        .mockResolvedValueOnce(undefined),
+    };
+    const onError = vi.fn();
+    const channel = new QQChannel({
+      onSubmitMessage: () => undefined,
+      onError,
+    }) as QQChannel & {
+      bot: typeof bot;
+      qqUserId: string;
+      qqMessageId: string;
+      nextOutboundMsgSeq: number;
+    };
+    channel.bot = bot;
+    channel.qqUserId = "user-openid";
+    channel.qqMessageId = "msg-id";
+    channel.nextOutboundMsgSeq = 7;
+
+    await channel.sendResponse("**bold**");
+
+    expect(bot.sendPrivateMessage).toHaveBeenCalledTimes(2);
+    expect(bot.sendPrivateMessage).toHaveBeenNthCalledWith(
+      1,
+      "user-openid",
+      "**bold**",
+      "msg-id",
+      7,
+      true,
+    );
+    expect(bot.sendPrivateMessage).toHaveBeenNthCalledWith(
+      2,
+      "user-openid",
+      "**bold**",
+      "msg-id",
+      8,
+      false,
+    );
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0]?.[0]).toContain(
+      "QQ markdown delivery disabled after first failure",
+    );
+  });
+
+  it("disables markdown for the rest of the channel after the first rejection", async () => {
+    const bot = {
+      sendPrivateMessage: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("markdown rejected"))
+        .mockResolvedValue(undefined),
+    };
+    const onError = vi.fn();
+    const channel = new QQChannel({
+      onSubmitMessage: () => undefined,
+      onError,
+    }) as QQChannel & {
+      bot: typeof bot;
+      qqUserId: string;
+      qqMessageId: string;
+      nextOutboundMsgSeq: number;
+      markdownDisabled: boolean;
+    };
+    channel.bot = bot;
+    channel.qqUserId = "user-openid";
+    channel.qqMessageId = "msg-id";
+    channel.nextOutboundMsgSeq = 10;
+
+    await channel.sendResponse("**first**");
+    await channel.sendResponse("**second**");
+
+    expect(channel.markdownDisabled).toBe(true);
+    expect(bot.sendPrivateMessage).toHaveBeenCalledTimes(3);
+    expect(bot.sendPrivateMessage).toHaveBeenNthCalledWith(
+      3,
+      "user-openid",
+      "**second**",
+      "msg-id",
+      13,
+      false,
+    );
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
   it("assigns incrementing msg_seq values across chunks", async () => {
     const bot = { sendPrivateMessage: vi.fn().mockResolvedValue(undefined) };
     const channel = new QQChannel({ onSubmitMessage: () => undefined }) as QQChannel & {
@@ -34,16 +160,25 @@ describe("QQChannel.sendResponse", () => {
       "a".repeat(1500),
       "msg-id",
       41,
+      true,
     );
-    expect(bot.sendPrivateMessage).toHaveBeenNthCalledWith(2, "user-openid", "a", "msg-id", 42);
+    expect(bot.sendPrivateMessage).toHaveBeenNthCalledWith(
+      2,
+      "user-openid",
+      "a",
+      "msg-id",
+      42,
+      true,
+    );
   });
 
-  it("stops after the first failed chunk and reports which chunk failed", async () => {
+  it("stops after the first chunk whose markdown and plain-text fallback both fail", async () => {
     const bot = {
       sendPrivateMessage: vi
         .fn()
         .mockResolvedValueOnce(undefined)
         .mockRejectedValueOnce(new Error("duplicate msgseq"))
+        .mockRejectedValueOnce(new Error("plain text rejected"))
         .mockResolvedValue(undefined),
     };
     const onError = vi.fn();
@@ -61,8 +196,11 @@ describe("QQChannel.sendResponse", () => {
 
     await channel.sendResponse("a".repeat(3001));
 
-    expect(bot.sendPrivateMessage).toHaveBeenCalledTimes(2);
-    expect(onError).toHaveBeenCalledTimes(1);
-    expect(onError.mock.calls[0]?.[0]).toContain("chunk 2/3 failed");
+    expect(bot.sendPrivateMessage).toHaveBeenCalledTimes(3);
+    expect(onError).toHaveBeenCalledTimes(2);
+    expect(onError.mock.calls[0]?.[0]).toContain(
+      "QQ markdown delivery disabled after first failure",
+    );
+    expect(onError.mock.calls[1]?.[0]).toContain("chunk 2/3 failed");
   });
 });


### PR DESCRIPTION
## Summary
- send QQ private replies through the Markdown delivery path by default
- fall back to plain text automatically if Markdown delivery fails
- unwrap full ```markdown``` / ```md``` fenced replies before sending so rendered content is not trapped inside a code block

## Testing
- npm test -- --run tests/qq-access.test.ts tests/qq-config.test.ts tests/qq-channel.test.ts tests/qq-slash.test.ts tests/qq-first-connect.test.tsx
- npm run typecheck
- npm run verify