### PR TITLE
Quality: Hardcoded magic numbers for layout dimensions

### DIFF
--- a/desktop/src/ui/thread-layout.ts
+++ b/desktop/src/ui/thread-layout.ts
@@ -1,3 +1,12 @@
+/** Minimum thread width in pixels to ensure readability */
+const MIN_THREAD_WIDTH = 580;
+
+/** Right margin in pixels to prevent thread from touching the edge */
+const THREAD_MARGIN = 80;
+
+/** Maximum thread width in pixels to maintain optimal line length for reading */
+const MAX_THREAD_WIDTH = 1120;
+
 export function getThreadMaxWidth({
   viewportWidth,
   visibleSide,
@@ -7,5 +16,5 @@ export function getThreadMaxWidth({
   visibleSide: number;
   visibleCtx: number;
 }): number {
-  return Math.max(580, Math.min(viewportWidth - visibleSide - visibleCtx - 80, 1120));
+  return Math.max(MIN_THREAD_WIDTH, Math.min(viewportWidth - visibleSide - visibleCtx - THREAD_MARGIN, MAX_THREAD_WIDTH));
 }


### PR DESCRIPTION
## Problem

The `getThreadMaxWidth` function contains multiple magic numbers (580, 80, 1120) without named constants or documentation explaining their origin. These values appear to be derived from design specifications but are not maintainable.

**Severity**: `low`
**File**: `desktop/src/ui/thread-layout.ts`

## Solution

Extract magic numbers into named constants with JSDoc comments explaining their design rationale, e.g., `MIN_THREAD_WIDTH = 580`, `THREAD_MARGIN = 80`, `MAX_THREAD_WIDTH = 1120`.

## Changes

- `desktop/src/ui/thread-layout.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
