### PR TITLE
Fix edit result scroll measurement bursts

### DIFF
--- a/src/cli/ui/state/chat-scroll-store.ts
+++ b/src/cli/ui/state/chat-scroll-store.ts
@@ -59,8 +59,11 @@ export function createChatScrollStore(opts: CreateChatScrollStoreOptions = {}): 
   const listeners = new Set<ScrollListener>();
   let pendingDelta = 0;
   let flushTimer: NodeJS.Timeout | null = null;
-  let pendingMaxShrink: number | null = null;
-  let shrinkTimer: NodeJS.Timeout | null = null;
+  // CardStream can report many measured edit-result cards in one render burst;
+  // coalesce them so React/Ink sees one external-store notification.
+  let pendingMaxScroll: number | null = null;
+  let pendingCardHeights: Map<string, number> | null = null;
+  let measurementTimer: NodeJS.Timeout | null = null;
 
   function set(next: Partial<ChatScrollState>): void {
     const merged = { ...state, ...next };
@@ -90,6 +93,7 @@ export function createChatScrollStore(opts: CreateChatScrollStoreOptions = {}): 
   }
 
   function schedule(delta: number): void {
+    flushMeasurements();
     if (flushTimer === null) {
       pendingDelta = delta;
       applyDelta();
@@ -102,16 +106,42 @@ export function createChatScrollStore(opts: CreateChatScrollStoreOptions = {}): 
     }
   }
 
-  function flushShrink(): void {
-    if (shrinkTimer !== null) {
-      clearTimeout(shrinkTimer);
-      shrinkTimer = null;
+  function scheduleMeasurementFlush(): void {
+    if (measurementTimer !== null) return;
+    measurementTimer = setTimeout(() => {
+      measurementTimer = null;
+      flushMeasurements();
+    }, COALESCE_MS);
+  }
+
+  function flushMeasurements(): void {
+    if (measurementTimer !== null) {
+      clearTimeout(measurementTimer);
+      measurementTimer = null;
     }
-    const target = pendingMaxShrink;
-    pendingMaxShrink = null;
-    if (target === null) return;
-    const nextScrollRows = state.pinned ? target : Math.min(state.scrollRows, target);
-    set({ maxScroll: target, scrollRows: nextScrollRows });
+
+    const next: Partial<ChatScrollState> = {};
+    if (pendingCardHeights !== null) {
+      const heights = new Map(state.cardHeights);
+      let changed = false;
+      for (const [id, rows] of pendingCardHeights) {
+        if (heights.get(id) === rows) continue;
+        heights.set(id, rows);
+        changed = true;
+      }
+      pendingCardHeights = null;
+      if (changed) next.cardHeights = heights;
+    }
+
+    if (pendingMaxScroll !== null) {
+      const maxScroll = pendingMaxScroll;
+      pendingMaxScroll = null;
+      const nextScrollRows = state.pinned ? maxScroll : Math.min(state.scrollRows, maxScroll);
+      next.maxScroll = maxScroll;
+      next.scrollRows = nextScrollRows;
+    }
+
+    if (Object.keys(next).length > 0) set(next);
   }
 
   return {
@@ -136,37 +166,32 @@ export function createChatScrollStore(opts: CreateChatScrollStoreOptions = {}): 
         clearTimeout(flushTimer);
         flushTimer = null;
       }
-      pendingMaxShrink = null;
-      if (shrinkTimer !== null) {
-        clearTimeout(shrinkTimer);
-        shrinkTimer = null;
-      }
+      flushMeasurements();
       set({ pinned: true, scrollRows: state.maxScroll });
     },
     setMaxScroll(rows: number) {
       const maxScroll = rows < 0 ? 0 : rows;
-      const currentMax = pendingMaxShrink ?? state.maxScroll;
-      if (state.pinned && maxScroll < currentMax) {
-        pendingMaxShrink = maxScroll;
-        if (shrinkTimer === null) {
-          shrinkTimer = setTimeout(() => {
-            shrinkTimer = null;
-            flushShrink();
-          }, COALESCE_MS);
-        }
+      const currentTarget = pendingMaxScroll ?? state.maxScroll;
+      if (maxScroll === currentTarget) {
         return;
       }
-      if (pendingMaxShrink !== null) flushShrink();
-      const nextScrollRows = state.pinned ? maxScroll : Math.min(state.scrollRows, maxScroll);
-      set({ maxScroll, scrollRows: nextScrollRows });
+      pendingMaxScroll = maxScroll;
+      scheduleMeasurementFlush();
     },
     setCardHeight(id: string, rows: number) {
-      if (state.cardHeights.get(id) === rows) return;
-      const next = new Map(state.cardHeights);
-      next.set(id, rows);
-      set({ cardHeights: next });
+      const currentRows = pendingCardHeights?.get(id) ?? state.cardHeights.get(id);
+      if (currentRows === rows) return;
+      if (pendingCardHeights === null) pendingCardHeights = new Map();
+      pendingCardHeights.set(id, rows);
+      scheduleMeasurementFlush();
     },
     pruneCardHeights(liveIds: ReadonlySet<string>) {
+      if (pendingCardHeights !== null) {
+        for (const id of pendingCardHeights.keys()) {
+          if (!liveIds.has(id)) pendingCardHeights.delete(id);
+        }
+        if (pendingCardHeights.size === 0) pendingCardHeights = null;
+      }
       let changed = false;
       const next = new Map<string, number>();
       for (const [id, rows] of state.cardHeights) {

--- a/tests/card-stream-edit-results.test.tsx
+++ b/tests/card-stream-edit-results.test.tsx
@@ -1,0 +1,104 @@
+/** App-scroll CardStream must tolerate bursts of edit tool results. */
+
+import type React from "react";
+import { createElement, useEffect } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { CardStream } from "../src/cli/ui/layout/CardStream.js";
+import { ChatScrollProvider } from "../src/cli/ui/state/chat-scroll-provider.js";
+import { AgentStoreProvider, useAgentStore } from "../src/cli/ui/state/provider.js";
+import type { SessionInfo } from "../src/cli/ui/state/state.js";
+import { render } from "./helpers/ink-test.js";
+
+const SESSION: SessionInfo = {
+  id: "s-edit-results",
+  branch: "main",
+  workspace: "/tmp/repo",
+  model: "deepseek-chat",
+};
+
+function editArgs(index: number): Record<string, unknown> {
+  return {
+    path: `src/file-${index}.ts`,
+    search: `const value${index} = "before";`,
+    replace: `const value${index} = "after";`,
+  };
+}
+
+function editOutput(index: number): string {
+  return [
+    "▸ edit blocks: 1/1 applied — /undo to roll back, or `git diff` to review",
+    `  ✓ applied     src/file-${index}.ts`,
+    "  @@",
+    `  - const value${index} = "before";`,
+    `  + const value${index} = "after";`,
+  ].join("\n");
+}
+
+function pendingPreview(count: number): string {
+  const lines = [
+    `▸ ${count} pending edit block(s) — /apply (or y) to commit · /discard (or n) to drop  ·  /apply N or 1,3-4 for partial`,
+  ];
+  for (let i = 0; i < count; i++) {
+    lines.push(`[${i + 1}] src/file-${i}.ts`);
+    lines.push("  @@");
+    lines.push(`  - const value${i} = "before";`);
+    lines.push(`  + const value${i} = "after";`);
+  }
+  return lines.join("\n");
+}
+
+function EmitEditResultBurst(): null {
+  const store = useAgentStore();
+  useEffect(() => {
+    for (let i = 0; i < 60; i++) {
+      const id = `edit-${i}`;
+      const name = i % 3 === 0 ? "multi_edit" : "edit_file";
+      const args = name === "multi_edit" ? { edits: [editArgs(i)] } : editArgs(i);
+      store.dispatch({ type: "tool.start", id, name, args });
+      store.dispatch({ type: "tool.end", id, output: editOutput(i), elapsedMs: 4 });
+    }
+    store.dispatch({
+      type: "live.show",
+      id: "pending-edits",
+      ts: Date.now(),
+      variant: "stepProgress",
+      tone: "info",
+      text: pendingPreview(18),
+    });
+  }, [store]);
+  return null;
+}
+
+function Harness(): React.ReactElement {
+  return createElement(
+    AgentStoreProvider,
+    { session: SESSION },
+    createElement(
+      ChatScrollProvider,
+      null,
+      createElement(CardStream),
+      createElement(EmitEditResultBurst),
+    ),
+  );
+}
+
+async function waitForReactWork(): Promise<void> {
+  for (let i = 0; i < 8; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+}
+
+describe("CardStream edit result bursts", () => {
+  it("renders many edit_file and multi_edit result cards without nested update overflow", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const mounted = render(createElement(Harness));
+
+    await waitForReactWork();
+
+    expect(consoleError.mock.calls.flat().join("\n")).not.toContain("Maximum update depth");
+    expect(mounted.lastFrame()).toContain("pending edit block");
+
+    mounted.unmount();
+    consoleError.mockRestore();
+  });
+});

--- a/tests/chat-scroll-wheel.test.ts
+++ b/tests/chat-scroll-wheel.test.ts
@@ -71,6 +71,33 @@ describe("chat history scroll store", () => {
       vi.useRealTimers();
     }
   });
+
+  it("coalesces CardStream measurement bursts into one subscriber update", () => {
+    vi.useFakeTimers();
+    try {
+      const store = createChatScrollStore();
+      let notifications = 0;
+      store.subscribe(() => {
+        notifications += 1;
+      });
+
+      for (let i = 0; i < 60; i++) {
+        store.setCardHeight(`edit-${i}`, i + 1);
+        store.setMaxScroll(i + 1);
+      }
+
+      expect(notifications).toBe(0);
+
+      vi.advanceTimersByTime(16);
+
+      expect(notifications).toBe(1);
+      expect(store.getState().maxScroll).toBe(60);
+      expect(store.getState().scrollRows).toBe(60);
+      expect(store.getState().cardHeights.size).toBe(60);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("history scroll mode resolution", () => {


### PR DESCRIPTION
## Summary
- Coalesces CardStream measurement writes for card heights and max scroll into one trailing update.
- Flushes pending measurements before user scroll actions so wheel, PageUp, and End semantics stay current.
- Adds regression coverage for edit_file and multi_edit result bursts plus measurement notification coalescing.

## Root cause
When many edit results render in one turn, CardStream can report dozens of height and max-scroll measurements synchronously. In app-managed scroll mode this creates a React/Ink external-store update burst; in Windows Terminal it can trip React's nested update guard.

## Test plan
- npm run verify