### PR TITLE
fix(desktop): refresh context token meter

### DIFF
--- a/desktop/src/App.test.ts
+++ b/desktop/src/App.test.ts
@@ -59,6 +59,7 @@ function initialState(): Parameters<typeof reduce>[0] {
       lastCallCacheHit: null,
       lastCallCacheMiss: null,
       reservedTokens: 0,
+      liveLogTokens: 0,
     },
     sessions: [],
     externalImportSources: [],
@@ -132,6 +133,51 @@ function makePathPrompt(
     data: { prefix: "/workspace", intent },
   };
 }
+
+describe("Desktop App reducer — usage", () => {
+  it("falls back prompt tokens to cache miss tokens when cache fields are absent", () => {
+    const next = reduce(initialState(), {
+      t: "incoming",
+      event: {
+        type: "model.final",
+        id: 1,
+        ts: "2026-05-27T00:00:00.000Z",
+        turn: 1,
+        content: "ok",
+        usage: { prompt_tokens: 1234, completion_tokens: 56, total_tokens: 1290 },
+        costUsd: 0.001,
+      },
+    });
+
+    expect(next.usage.totalPromptTokens).toBe(1234);
+    expect(next.usage.cacheHitTokens).toBe(0);
+    expect(next.usage.cacheMissTokens).toBe(1234);
+    expect(next.usage.lastCallCacheMiss).toBe(1234);
+  });
+
+  it("keeps cumulative usage when live context breakdown refreshes", () => {
+    const base = initialState();
+    const next = reduce(
+      {
+        ...base,
+        usage: {
+          ...base.usage,
+          cacheHitTokens: 80,
+          cacheMissTokens: 20,
+          totalPromptTokens: 100,
+        },
+      },
+      {
+        t: "incoming",
+        event: { type: "$ctx_breakdown", reservedTokens: 10, logTokens: 42 },
+      },
+    );
+
+    expect(next.usage.cacheHitTokens).toBe(80);
+    expect(next.usage.cacheMissTokens).toBe(20);
+    expect(next.usage.liveLogTokens).toBe(42);
+  });
+});
 
 describe("Desktop App reducer — ApprovalPrompt integration", () => {
   it("stores shell confirm with prompt on $confirm_required", () => {

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -224,6 +224,8 @@ export type UsageStats = {
   lastCallCacheMiss: number | null;
   /** System prompt + tool specs — constant for the session, sent on tab open. */
   reservedTokens: number;
+  /** Current conversation log tokens, refreshed by the desktop sidecar. */
+  liveLogTokens: number;
 };
 
 export type SessionInfo = {
@@ -713,6 +715,7 @@ function zeroUsage(): UsageStats {
     lastCallCacheHit: null,
     lastCallCacheMiss: null,
     reservedTokens: 0,
+    liveLogTokens: 0,
   };
 }
 
@@ -894,10 +897,7 @@ export function applyIncoming(state: State, ev: IncomingEvent): State {
     case "$ctx_breakdown": {
       const next: UsageStats = { ...state.usage, reservedTokens: ev.reservedTokens };
       if (typeof ev.logTokens === "number") {
-        next.cacheHitTokens = 0;
-        next.cacheMissTokens = ev.logTokens;
-        next.lastCallCacheHit = 0;
-        next.lastCallCacheMiss = ev.logTokens;
+        next.liveLogTokens = ev.logTokens;
       }
       return { ...state, usage: next };
     }
@@ -1100,18 +1100,22 @@ export function applyIncoming(state: State, ev: IncomingEvent): State {
       };
     case "model.final": {
       const u = ev.usage;
+      const promptTokens =
+        u?.prompt_tokens ??
+        (u?.prompt_cache_hit_tokens ?? 0) + (u?.prompt_cache_miss_tokens ?? 0);
       const callHit = u?.prompt_cache_hit_tokens ?? 0;
-      const callMiss = u?.prompt_cache_miss_tokens ?? 0;
-      const hasCall = callHit > 0 || callMiss > 0;
+      const callMiss = u?.prompt_cache_miss_tokens ?? Math.max(0, promptTokens - callHit);
+      const hasCall = promptTokens > 0 || callHit > 0 || callMiss > 0;
       const usage: UsageStats = {
         totalCostUsd: state.usage.totalCostUsd + (ev.costUsd ?? 0),
-        totalPromptTokens: state.usage.totalPromptTokens + (u?.prompt_tokens ?? 0),
+        totalPromptTokens: state.usage.totalPromptTokens + promptTokens,
         totalCompletionTokens: state.usage.totalCompletionTokens + (u?.completion_tokens ?? 0),
         cacheHitTokens: state.usage.cacheHitTokens + callHit,
         cacheMissTokens: state.usage.cacheMissTokens + callMiss,
         lastCallCacheHit: hasCall ? callHit : state.usage.lastCallCacheHit,
         lastCallCacheMiss: hasCall ? callMiss : state.usage.lastCallCacheMiss,
         reservedTokens: state.usage.reservedTokens,
+        liveLogTokens: state.usage.liveLogTokens,
       };
       return {
         ...state,

--- a/desktop/src/ui/context-panel.test.tsx
+++ b/desktop/src/ui/context-panel.test.tsx
@@ -20,6 +20,7 @@ const usage: UsageStats = {
   lastCallCacheHit: null,
   lastCallCacheMiss: null,
   reservedTokens: 0,
+  liveLogTokens: 0,
 };
 
 const settings: Settings = {
@@ -70,5 +71,23 @@ describe("ContextPanel files", () => {
     fireEvent.click(screen.getByRole("button", { name: "Open file: src/new-file.ts" }));
 
     await waitFor(() => expect(openPath).toHaveBeenCalledWith("/repo/src/new-file.ts"));
+  });
+
+  it("renders live log tokens even before final usage arrives", () => {
+    render(
+      <ContextPanel
+        settings={settings}
+        usage={{ ...usage, reservedTokens: 50, liveLogTokens: 100 }}
+        mcpSpecs={[]}
+        mcpBridged={false}
+        sessionFiles={[]}
+        memory={[]}
+        memoryDetail={null}
+        onReadMemory={() => {}}
+      />,
+    );
+
+    expect(screen.getByText("150 / 1,000,000")).toBeTruthy();
+    expect(screen.getByText("100")).toBeTruthy();
   });
 });

--- a/desktop/src/ui/context-panel.tsx
+++ b/desktop/src/ui/context-panel.tsx
@@ -35,8 +35,10 @@ export function ContextPanel({
   const reserved = usage.reservedTokens;
   const lastHit = usage.lastCallCacheHit ?? 0;
   const lastMiss = usage.lastCallCacheMiss ?? 0;
-  const cached = Math.max(0, lastHit - reserved);
-  const used = Math.max(0, lastMiss - Math.max(0, reserved - lastHit));
+  const observedLog = Math.max(0, lastHit + lastMiss - reserved);
+  const logTokens = Math.max(usage.liveLogTokens, observedLog);
+  const cached = Math.min(logTokens, Math.max(0, lastHit - reserved));
+  const used = Math.max(0, logTokens - cached);
   const reservedPct = Math.min(100, (reserved / CONTEXT_MAX_TOKENS) * 100);
   const usedPct = Math.min(100, (used / CONTEXT_MAX_TOKENS) * 100);
   const cachedPct = Math.min(100, (cached / CONTEXT_MAX_TOKENS) * 100);

--- a/desktop/src/ui/statusbar.tsx
+++ b/desktop/src/ui/statusbar.tsx
@@ -52,8 +52,12 @@ export function StatusBar({
   onOpenSettings: () => void;
   onOpenWorkdir?: (anchor: { bottom: number; left: number }) => void;
 }) {
-  const totalTokens = usage.cacheHitTokens + usage.cacheMissTokens;
-  const cacheHitPct = totalTokens > 0 ? Math.round((usage.cacheHitTokens / totalTokens) * 100) : 0;
+  const sessionPromptTokens =
+    usage.totalPromptTokens || usage.cacheHitTokens + usage.cacheMissTokens;
+  const liveContextTokens = usage.reservedTokens + usage.liveLogTokens;
+  const totalTokens = Math.max(sessionPromptTokens, liveContextTokens);
+  const cacheDenom = usage.cacheHitTokens + usage.cacheMissTokens;
+  const cacheHitPct = cacheDenom > 0 ? Math.round((usage.cacheHitTokens / cacheDenom) * 100) : 0;
   const runningJobs = jobs.filter((j) => j.running).length;
   const spent = formatMoney(usage.totalCostUsd, currency);
   const balanceLabel = balance

--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -819,6 +819,7 @@ function loadSessionIntoTab(
     },
     tab.id,
   );
+  emitCtxBreakdown(tab);
   if (backfilledWorkspace) emitSessions(tab);
 }
 
@@ -876,19 +877,33 @@ function emitMemory(tab: Tab): void {
   }
 }
 
+function countTokensForMeter(text: string): number {
+  try {
+    return countTokensBounded(text);
+  } catch {
+    return text.length === 0 ? 0 : Math.max(1, Math.ceil(text.length * 0.3));
+  }
+}
+
 // reserved = system prompt + tool specs, constant for the tab's lifetime once
-// the loop is built. The growing log portion is already covered by the
-// per-turn cache hit/miss numbers in `model.final`.
+// the loop is built. logTokens is refreshed during turns so Desktop doesn't
+// show a fake zero while the streaming call is still waiting on usage metadata.
 function emitCtxBreakdown(tab: Tab): void {
   if (!tab.runtime) return;
+  const sys = countTokensForMeter(tab.runtime.loop.prefix.system);
+  const tools = countTokensForMeter(JSON.stringify(tab.runtime.loop.prefix.toolSpecs));
+  let logTokens = 0;
   try {
-    const sys = countTokensBounded(tab.runtime.loop.prefix.system);
-    const tools = countTokensBounded(JSON.stringify(tab.runtime.loop.prefix.toolSpecs));
-    const logTokens = tab.runtime.loop.getCurrentLogTokens();
-    emit({ type: "$ctx_breakdown", reservedTokens: sys + tools, logTokens }, tab.id);
+    logTokens = tab.runtime.loop.getCurrentLogTokens();
   } catch {
-    // tokenizer warmup can throw on first call before the data file loads
+    for (const msg of tab.runtime.loop.log.toMessages()) {
+      logTokens += countTokensForMeter(typeof msg.content === "string" ? msg.content : "");
+      if (msg.role === "assistant" && Array.isArray(msg.tool_calls) && msg.tool_calls.length > 0) {
+        logTokens += countTokensForMeter(JSON.stringify(msg.tool_calls));
+      }
+    }
   }
+  emit({ type: "$ctx_breakdown", reservedTokens: sys + tools, logTokens }, tab.id);
 }
 
 function emitSkills(tab: Tab): void {
@@ -1573,11 +1588,19 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
     }
     await tabContext.run(tab.id, async () => {
       try {
+        let emittedTurnContext = false;
         for await (const ev of rt.loop.step(text)) {
+          if (!emittedTurnContext) {
+            emittedTurnContext = true;
+            emitCtxBreakdown(tab);
+          }
           if (ev.role === "assistant_final" && ev.content) {
             lastAssistantText = ev.content;
           }
           for (const kev of rt.eventizer.consume(ev, rt.ctx)) emit(kev, tab.id);
+          if (ev.role === "assistant_final" || ev.role === "tool") {
+            emitCtxBreakdown(tab);
+          }
           // Memory tools mutate disk state behind the loop's back — the UI
           // panel won't know until we re-emit. Without this the right-hand
           // panel only updates on tab reopen.
@@ -2202,6 +2225,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
             // unreadable jsonl — skip re-emit
           }
         }
+        emitCtxBreakdown(t);
       }
       return;
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -171,6 +171,7 @@ export class DeepSeekClient {
       messages: opts.messages,
       stream,
     };
+    if (stream) payload.stream_options = { include_usage: true };
     if (opts.tools?.length) payload.tools = opts.tools;
     if (opts.temperature !== undefined) payload.temperature = opts.temperature;
     if (opts.maxTokens !== undefined) payload.max_tokens = opts.maxTokens;

--- a/tests/client-models.test.ts
+++ b/tests/client-models.test.ts
@@ -123,4 +123,39 @@ describe("DeepSeekClient usage parsing", () => {
     expect(resp.usage.totalTokens).toBe(49);
     expect(resp.usage.promptCacheMissTokens).toBe(42);
   });
+
+  it("requests usage metadata for streaming calls", async () => {
+    let body: { stream_options?: unknown } | null = null;
+    const fetch = vi.fn(async (_url, init) => {
+      body = JSON.parse(String((init as RequestInit).body)) as { stream_options?: unknown };
+      const frames = [
+        `data: ${JSON.stringify({ choices: [{ delta: { content: "ok" } }] })}\n\n`,
+        `data: ${JSON.stringify({ choices: [{ finish_reason: "stop", delta: {} }], usage: { prompt_tokens: 10, completion_tokens: 2, total_tokens: 12 } })}\n\n`,
+        "data: [DONE]\n\n",
+      ];
+      const stream = new ReadableStream({
+        start(controller) {
+          for (const frame of frames) controller.enqueue(new TextEncoder().encode(frame));
+          controller.close();
+        },
+      });
+      return new Response(stream, {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      });
+    }) as unknown as typeof globalThis.fetch;
+    const client = new DeepSeekClient({ apiKey: "sk-test", fetch });
+
+    const chunks = [];
+    for await (const chunk of client.stream({
+      model: "deepseek-chat",
+      messages: [{ role: "user", content: "hi" }],
+    })) {
+      chunks.push(chunk);
+    }
+
+    expect(body?.stream_options).toEqual({ include_usage: true });
+    expect(chunks.at(-1)?.usage?.promptTokens).toBe(10);
+    expect(chunks.at(-1)?.usage?.promptCacheMissTokens).toBe(10);
+  });
 });

--- a/tests/desktop-btw-status.test.ts
+++ b/tests/desktop-btw-status.test.ts
@@ -65,6 +65,7 @@ function makeState(): AppState {
       lastCallCacheHit: null,
       lastCallCacheMiss: null,
       reservedTokens: 0,
+      liveLogTokens: 0,
     },
     sessions: [],
     settings: null,

--- a/tests/desktop-user-message.test.ts
+++ b/tests/desktop-user-message.test.ts
@@ -67,6 +67,7 @@ function makeState(messages: ChatMessage[] = []): AppState {
       lastCallCacheHit: null,
       lastCallCacheMiss: null,
       reservedTokens: 0,
+      liveLogTokens: 0,
     },
     sessions: [],
     settings: null,


### PR DESCRIPTION
## Summary
- request streaming usage metadata so OpenAI-compatible streams can report prompt/completion tokens
- refresh desktop context breakdown on session load, WebView resync, and during turns
- keep live context-log tokens separate from cumulative cache usage
- fall back prompt-only usage into cache-miss accounting so the context panel/status bar do not display fake zero

## Validation
- npm run lint
- npm run typecheck
- npm test -- --run tests/client-models.test.ts desktop/src/App.test.ts desktop/src/ui/context-panel.test.tsx tests/loop.test.ts tests/client-stream-timeout.test.ts
- npm --prefix desktop run build
- npm run build
- git diff --check
- pre-push npm run verify was also attempted; it failed only on existing local prompt-budget threshold: expected 26512 <= 26500 in tests/prompt-budget.test.ts