### PR TITLE
chore(errors): tighten errorDetail propagation

### DIFF
--- a/src/acp/dispatch.ts
+++ b/src/acp/dispatch.ts
@@ -91,7 +91,7 @@ export function dispatchKernelEvent(server: AcpServer, sessionId: string, ev: Ke
           content: { type: "text", text: `\n\n[error] ${ev.message}` },
           metadata: {
             error: {
-              name: ev.message.split(":")[0] || "Error",
+              name: ev.name ?? "Error",
               message: ev.message,
               code: ev.code,
               phase: ev.phase,

--- a/src/cli/commands/acp.ts
+++ b/src/cli/commands/acp.ts
@@ -40,6 +40,7 @@ import { autoResolveVerdict } from "../../core/pause-policy.js";
 import { loadDotenv } from "../../env.js";
 import { t } from "../../i18n/index.js";
 import { CacheFirstLoop, DeepSeekClient, ImmutablePrefix } from "../../index.js";
+import { errorMeta } from "../../loop/errors.js";
 import { McpClient } from "../../mcp/client.js";
 import { preflightStdioSpec } from "../../mcp/preflight.js";
 import { bridgeMcpTools } from "../../mcp/registry.js";
@@ -312,7 +313,9 @@ export async function acpCommand(opts: AcpOptions): Promise<void> {
         }
       });
     } catch (err) {
-      const message = (err as Error).message;
+      const cause = err instanceof Error ? err : new Error(String(err));
+      const message = cause.message;
+      const { code, phase } = errorMeta(cause);
       server.sendNotification("session/update", {
         sessionId: session.id,
         update: {
@@ -320,10 +323,10 @@ export async function acpCommand(opts: AcpOptions): Promise<void> {
           content: { type: "text", text: `\n\n[error] ${message}` },
           metadata: {
             error: {
-              name: (err as Error).name || "Error",
+              name: cause.name || "Error",
               message,
-              code: (err as any).code,
-              phase: (err as any).phase,
+              code,
+              phase,
               retryable: false,
             },
           },

--- a/src/client.ts
+++ b/src/client.ts
@@ -374,9 +374,10 @@ export class DeepSeekClient {
           ({ value, done: streamDone } = await reader.read());
         } catch (readErr) {
           const cause = readErr instanceof Error ? readErr : new Error(String(readErr));
+          const code = "code" in cause && typeof cause.code === "string" ? cause.code : undefined;
           throw Object.assign(new Error(`SSE body read failed: ${cause.message}`), {
             phase: "stream_body_read" as const,
-            code: (cause as any).code,
+            code,
           });
         }
         if (streamDone) break;

--- a/src/core/eventize.ts
+++ b/src/core/eventize.ts
@@ -87,6 +87,7 @@ export class Eventizer {
       case "error":
         out.push(
           this.errorEvent(ev.turn, ev.error ?? ev.content, ev.errorDetail?.recoverable ?? false, {
+            name: ev.errorDetail?.name,
             code: ev.errorDetail?.code,
             phase: ev.errorDetail?.phase,
             retryable: ev.errorDetail?.retryable,
@@ -338,7 +339,7 @@ export class Eventizer {
     turn: number,
     message: string,
     recoverable: boolean,
-    detail?: { code?: string; phase?: string; retryable?: boolean },
+    detail?: { name?: string; code?: string; phase?: string; retryable?: boolean },
   ): KernelErrorEvent {
     return {
       id: ++this.nextId,

--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -217,6 +217,7 @@ export interface ErrorEvent extends EventBase {
   type: "error";
   message: string;
   recoverable: boolean;
+  name?: string;
   code?: string;
   phase?: string;
   retryable?: boolean;

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -15,7 +15,9 @@ import { InflightSet } from "./core/inflight.js";
 import { t } from "./i18n/index.js";
 import { dispatchToolCallsChunked } from "./loop/dispatch.js";
 import {
+  errorMeta,
   formatLoopError,
+  is4xxError,
   is5xxError,
   isDeepSeekHost,
   probeDeepSeekReachable,
@@ -857,8 +859,8 @@ export class CacheFirstLoop {
         const probe =
           is5xxError(err) && dsHost ? await probeDeepSeekReachable(this.client) : undefined;
         const cause = err instanceof Error ? err : new Error(String(err));
-        const isClientError = /^DeepSeek (4\d{2}):/.test(cause.message);
-        const retryable = !isClientError && cause.name !== "AbortError";
+        const retryable = !is4xxError(cause) && cause.name !== "AbortError";
+        const { code, phase } = errorMeta(cause);
         yield {
           turn: this._turn,
           role: "error",
@@ -867,10 +869,10 @@ export class CacheFirstLoop {
           errorDetail: {
             name: cause.name,
             message: cause.message,
-            phase: (cause as any).phase,
-            code: (cause as any).code,
+            phase,
+            code,
             retryable,
-            recoverable: retryable,
+            recoverable: false,
           },
         };
         this._steerQueue.length = 0;

--- a/src/loop/errors.ts
+++ b/src/loop/errors.ts
@@ -45,6 +45,19 @@ export function is5xxError(err: unknown): boolean {
   return m !== null;
 }
 
+export function is4xxError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return /^DeepSeek (4\d{2}):/.test(err.message ?? "");
+}
+
+/** Read structured metadata off thrown errors without resorting to `as any`. */
+export function errorMeta(err: unknown): { code?: string; phase?: string } {
+  if (!(err instanceof Error)) return {};
+  const code = "code" in err && typeof err.code === "string" ? err.code : undefined;
+  const phase = "phase" in err && typeof err.phase === "string" ? err.phase : undefined;
+  return { code, phase };
+}
+
 export async function probeDeepSeekReachable(
   client: DeepSeekClient,
   timeoutMs = 1500,

--- a/tests/acp.test.ts
+++ b/tests/acp.test.ts
@@ -340,6 +340,7 @@ describe("ACP kernel-event dispatch", () => {
       kev("error", {
         message: "SSE body read failed: terminated",
         recoverable: true,
+        name: "StreamError",
         code: "UND_ERR_ABORTED",
         phase: "stream_body_read",
         retryable: true,
@@ -353,7 +354,7 @@ describe("ACP kernel-event dispatch", () => {
       content: { type: "text", text: expect.stringContaining("terminated") },
       metadata: {
         error: {
-          name: "SSE body read failed",
+          name: "StreamError",
           message: "SSE body read failed: terminated",
           code: "UND_ERR_ABORTED",
           phase: "stream_body_read",

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -2355,7 +2355,7 @@ describe("CacheFirstLoop — mid-turn steer injection", () => {
       phase: "stream_body_read",
       code: "UND_ERR_ABORTED",
       retryable: true,
-      recoverable: true,
+      recoverable: false,
     });
   });
 });


### PR DESCRIPTION
Follow-up on #1918 — strip the four loose joints that surfaced in review.

- Replace `(err as any).code` / `(err as any).phase` casts with a small `errorMeta(err)` narrowing helper in `loop/errors.ts`. Same payload, no escape hatch.
- Extract `is4xxError` alongside `is5xxError` so the loop's "client error → not retryable" branch reads like the existing 5xx code path instead of an inline regex.
- Decouple `recoverable` from `retryable` in the loop's API-failure yield. `recoverable` is the historical "agent can keep going" flag (consumed by event listing), `retryable` is the new external retry hint; conflating them changed event-listing output silently.
- Carry `name` through `ErrorEvent` + eventize so the ACP dispatcher surfaces the real error name instead of `ev.message.split(":")[0]`.

## Test plan

- [x] `npm run verify` passes locally
