### PR TITLE
fix(cli): accept /models as API reachability check

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -210,7 +210,8 @@ async function checkConfig(): Promise<Check> {
 }
 
 async function checkApiReach(): Promise<Check> {
-  const key = process.env.DEEPSEEK_API_KEY ?? readConfig().apiKey;
+  const endpoint = loadEndpoint();
+  const key = endpoint.apiKey;
   if (!key) {
     return {
       id: "api-reach",
@@ -220,11 +221,21 @@ async function checkApiReach(): Promise<Check> {
     };
   }
   try {
-    const client = new DeepSeekClient({ apiKey: key, baseUrl: loadEndpoint().baseUrl });
+    const client = new DeepSeekClient({ apiKey: key, baseUrl: endpoint.baseUrl });
     const ctl = new AbortController();
     const timer = setTimeout(() => ctl.abort(), 8_000);
+    let models: Awaited<ReturnType<DeepSeekClient["listModels"]>>;
     let balance: Awaited<ReturnType<DeepSeekClient["getBalance"]>>;
     try {
+      models = await client.listModels({ signal: ctl.signal });
+      if (models) {
+        return {
+          id: "api-reach",
+          label: "api reach    ",
+          level: "ok",
+          detail: `/models ok — ${summarizeModels(models.data)}`,
+        };
+      }
       balance = await client.getBalance({ signal: ctl.signal });
     } finally {
       clearTimeout(timer);
@@ -234,7 +245,7 @@ async function checkApiReach(): Promise<Check> {
         id: "api-reach",
         label: "api reach    ",
         level: "fail",
-        detail: "/user/balance returned null — auth failed or network blocked",
+        detail: "/models and /user/balance returned null — auth failed or network blocked",
       };
     }
     const summary = summarizeBalances(balance.balance_infos);
@@ -260,6 +271,14 @@ async function checkApiReach(): Promise<Check> {
       detail: `${(err as Error).message}`,
     };
   }
+}
+
+function summarizeModels(models: ReadonlyArray<{ id: string }>): string {
+  if (models.length === 0) return "0 models";
+  const ids = models.map((m) => m.id).filter(Boolean);
+  const preview = ids.slice(0, 3).join(", ");
+  const suffix = ids.length > 3 ? ", ..." : "";
+  return `${models.length} model${models.length === 1 ? "" : "s"}${preview ? ` (${preview}${suffix})` : ""}`;
 }
 
 function summarizeBalances(

--- a/tests/doctor-json.test.ts
+++ b/tests/doctor-json.test.ts
@@ -1,10 +1,15 @@
 /** `reasonix doctor --json` — structured report shape and exit-code semantics. */
 
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { type DoctorCheck, doctorCommand, formatDoctorJson } from "../src/cli/commands/doctor.js";
+import {
+  type DoctorCheck,
+  doctorCommand,
+  formatDoctorJson,
+  runDoctorChecks,
+} from "../src/cli/commands/doctor.js";
 import { VERSION } from "../src/version.js";
 
 describe("formatDoctorJson", () => {
@@ -64,6 +69,7 @@ describe("doctorCommand --json (integration)", () => {
     logSpy.mockRestore();
     exitSpy.mockRestore();
     vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
     process.chdir(origCwd);
     rmSync(tmpHome, { recursive: true, force: true });
     rmSync(tmpCwd, { recursive: true, force: true });
@@ -102,5 +108,45 @@ describe("doctorCommand --json (integration)", () => {
     } else {
       expect(exitSpy).not.toHaveBeenCalled();
     }
+  });
+
+  it("accepts /models as api reach when /user/balance is unavailable", async () => {
+    const configDir = join(tmpHome, ".reasonix");
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(
+      join(configDir, "config.json"),
+      JSON.stringify({
+        apiKey: "sk-test",
+        baseUrl: "https://compat.example/v1",
+      }),
+    );
+    const fetchSpy = vi.fn(async (url: string | URL | Request) => {
+      const href = String(url);
+      if (href.endsWith("/models")) {
+        return new Response(
+          JSON.stringify({
+            object: "list",
+            data: [{ id: "deepseek-v4-pro:cloud", object: "model", owned_by: "reasonix" }],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response("not found", { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const checks = await runDoctorChecks(tmpCwd);
+    const apiReach = checks.find((c) => c.id === "api-reach");
+
+    expect(apiReach).toMatchObject({
+      level: "ok",
+      detail: expect.stringContaining("/models ok"),
+    });
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://compat.example/v1/models",
+      expect.objectContaining({
+        method: "GET",
+      }),
+    );
   });
 });


### PR DESCRIPTION
## Summary
- check `/models` before `/user/balance` in `reasonix doctor` API reachability
- treat an OpenAI-compatible model list response as a successful API reach check
- keep `/user/balance` as fallback for DeepSeek accounts that expose balance info

## Why
Some OpenAI-compatible endpoints, including Ollama Cloud-style routing, expose `/models` but not `/user/balance`. Today `doctor` can report API reach as failed even when chat/model access works.

## Verification
- `npm test -- --run tests/doctor-json.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npx biome check src/cli/commands/doctor.ts tests/doctor-json.test.ts`
- `git diff --check`

Note: a full local pre-push `npm run verify` still hits the existing unrelated prompt-budget regression (`26512 <= 26500` in `tests/prompt-budget.test.ts`). This branch does not touch prompt construction.