### PR TITLE
fix(truncated-result-saver): fall back to ~/.reasonix when rootDir is fs root

### DIFF
--- a/src/tools/truncated-result-saver.ts
+++ b/src/tools/truncated-result-saver.ts
@@ -9,7 +9,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
-import { join, relative, resolve } from "node:path";
+import { join, parse, relative, resolve } from "node:path";
 
 const TRUNCATED_DIR = "truncated-results";
 const DEFAULT_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
@@ -19,9 +19,17 @@ function sanitizeToolName(name: string): string {
   return name.replace(/[^\w\-]/g, "_").slice(0, 48) || "unknown";
 }
 
+function useHomeFallback(rootDir: string): boolean {
+  if (!rootDir) return true;
+  const abs = resolve(rootDir);
+  return abs === parse(abs).root;
+}
+
 /** Resolve the absolute storage directory for truncated results. */
 export function storageDir(rootDir: string): string {
-  const base = rootDir ? join(resolve(rootDir), ".reasonix") : join(homedir(), ".reasonix");
+  const base = useHomeFallback(rootDir)
+    ? join(homedir(), ".reasonix")
+    : join(resolve(rootDir), ".reasonix");
   return join(base, TRUNCATED_DIR);
 }
 
@@ -56,7 +64,7 @@ export function saveTruncatedResult(content: string, toolName: string, rootDir: 
 
   // Return a relative path the model can pass to read_file.
   // Normalize to forward slashes for cross-platform consistency.
-  if (rootDir) {
+  if (!useHomeFallback(rootDir)) {
     const absRoot = resolve(rootDir);
     return relative(absRoot, absPath).replaceAll("\\", "/");
   }

--- a/tests/truncated-result-saver.test.ts
+++ b/tests/truncated-result-saver.test.ts
@@ -60,6 +60,28 @@ describe("saveTruncatedResult", () => {
     expect(filename).not.toMatch(/[/:]/);
   });
 
+  it("falls back to ~/.reasonix when rootDir is the filesystem root", () => {
+    const origHome = process.env.HOME;
+    const origUserProfile = process.env.USERPROFILE;
+    const fakeHome = mkdtempSync(join(tmpdir(), "reasonix-trunc-home-"));
+    process.env.HOME = fakeHome;
+    process.env.USERPROFILE = fakeHome;
+
+    try {
+      const fsRoot = process.platform === "win32" ? "C:\\" : "/";
+      const path = saveTruncatedResult("root cwd", "run_skill", fsRoot);
+      expect(path).toMatch(/\.reasonix\/truncated-results\//);
+      expect(path.startsWith("/.reasonix")).toBe(false);
+      expect(existsSync(path)).toBe(true);
+    } finally {
+      if (origHome === undefined) process.env.HOME = undefined;
+      else process.env.HOME = origHome;
+      if (origUserProfile === undefined) process.env.USERPROFILE = undefined;
+      else process.env.USERPROFILE = origUserProfile;
+      rmSync(fakeHome, { recursive: true, force: true });
+    }
+  });
+
   it("falls back to ~/.reasonix when rootDir is empty", () => {
     // Redirect HOME so os.homedir() points to a temp dir instead of real home.
     const origHome = process.env.HOME;


### PR DESCRIPTION
## Summary

- `saveTruncatedResult` blindly joined `rootDir + .reasonix`, so when reasonix is launched with cwd `/` (some daemon/IDE contexts) it tried to `mkdir /.reasonix/truncated-results` and crashed `run_skill` with `ENOENT` on oversized results (e.g. `fireworks-tech-graph`, `skill-creator`).
- Treat any `rootDir` that resolves to a filesystem root the same as empty: write under `~/.reasonix/truncated-results/` and return an absolute path. Normal project roots are unaffected — the model still gets a relative path it can hand to `read_file`.
- Adds a regression test that points `HOME`/`USERPROFILE` at a temp dir and confirms `rootDir = "/"` (or `C:\` on Windows) lands in the home fallback.

Closes #1959

## Test plan

- [x] `npx vitest run tests/truncated-result-saver.test.ts` — 20/20 pass
- [x] `npx vitest run tests/comment-policy.test.ts` — 9/9 pass
- [x] `npx tsc --noEmit` clean