### PR TITLE
fix(truncate): align slice boundaries to UTF-16 codepoint

### DIFF
--- a/src/mcp/registry.ts
+++ b/src/mcp/registry.ts
@@ -255,11 +255,30 @@ export function truncateForModel(s: string, maxChars: number, extraNote?: string
   if (s.length <= maxChars) return s;
   const tailBudget = Math.min(1024, Math.floor(maxChars * 0.1));
   const headBudget = Math.max(0, maxChars - tailBudget);
-  const head = s.slice(0, headBudget);
-  const tail = s.slice(-tailBudget);
+  const head = sliceAlignedToCodepoint(s, headBudget);
+  const tail = sliceSuffixAlignedToCodepoint(s, tailBudget);
   const dropped = s.length - head.length - tail.length;
   const note = extraNote ? ` — ${extraNote}` : "";
   return `${head}\n\n[…truncated ${dropped} chars — raise BridgeOptions.maxResultChars, or call the tool with a narrower scope (filter, head, pagination)${note}…]\n\n${tail}`;
+}
+
+/** Slicing inside a UTF-16 surrogate pair (emoji, supplementary CJK) leaves a lone surrogate
+ *  that crashes downstream JSON parsers (issue #1970). Trim one code unit back if needed. */
+function sliceAlignedToCodepoint(s: string, end: number): string {
+  if (end <= 0) return "";
+  if (end >= s.length) return s;
+  const last = s.charCodeAt(end - 1);
+  if (last >= 0xd800 && last <= 0xdbff) return s.slice(0, end - 1);
+  return s.slice(0, end);
+}
+
+function sliceSuffixAlignedToCodepoint(s: string, len: number): string {
+  if (len <= 0) return "";
+  if (len >= s.length) return s;
+  const start = s.length - len;
+  const first = s.charCodeAt(start);
+  if (first >= 0xdc00 && first <= 0xdfff) return s.slice(start + 1);
+  return s.slice(start);
 }
 
 /** Never tokenizes full input — pathological repetitive text (`AAAA…`) costs 30s+ on the pure-TS BPE port. */
@@ -309,15 +328,15 @@ function sizePrefixToTokens(s: string, budget: number): string {
   let size = Math.min(s.length, budget * 4);
   for (let iter = 0; iter < 6; iter++) {
     if (size <= 0) return "";
-    const slice = s.slice(0, size);
+    const slice = sliceAlignedToCodepoint(s, size);
     const count = countTokens(slice);
     if (count <= budget) return slice;
     // Shrink by the overshoot fraction plus a small safety margin.
     const next = Math.floor(size * (budget / count) * 0.95);
-    if (next >= size) return s.slice(0, Math.max(0, size - 1));
+    if (next >= size) return sliceAlignedToCodepoint(s, Math.max(0, size - 1));
     size = next;
   }
-  return s.slice(0, Math.max(0, size));
+  return sliceAlignedToCodepoint(s, Math.max(0, size));
 }
 
 /** Slice `s` from the end to the largest suffix that fits `budget` tokens. */
@@ -326,14 +345,14 @@ function sizeSuffixToTokens(s: string, budget: number): string {
   let size = Math.min(s.length, budget * 4);
   for (let iter = 0; iter < 6; iter++) {
     if (size <= 0) return "";
-    const slice = s.slice(-size);
+    const slice = sliceSuffixAlignedToCodepoint(s, size);
     const count = countTokens(slice);
     if (count <= budget) return slice;
     const next = Math.floor(size * (budget / count) * 0.95);
-    if (next >= size) return s.slice(-Math.max(0, size - 1));
+    if (next >= size) return sliceSuffixAlignedToCodepoint(s, Math.max(0, size - 1));
     size = next;
   }
-  return s.slice(-Math.max(0, size));
+  return sliceSuffixAlignedToCodepoint(s, Math.max(0, size));
 }
 
 function blockToString(block: McpContentBlock): string {

--- a/tests/truncate-tokens.test.ts
+++ b/tests/truncate-tokens.test.ts
@@ -1,6 +1,24 @@
 import { describe, expect, it } from "vitest";
-import { DEFAULT_MAX_RESULT_TOKENS, truncateForModelByTokens } from "../src/mcp/registry.js";
+import {
+  DEFAULT_MAX_RESULT_TOKENS,
+  truncateForModel,
+  truncateForModelByTokens,
+} from "../src/mcp/registry.js";
 import { countTokens } from "../src/tokenizer.js";
+
+function hasLoneSurrogate(s: string): boolean {
+  for (let i = 0; i < s.length; i++) {
+    const code = s.charCodeAt(i);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = s.charCodeAt(i + 1);
+      if (next < 0xdc00 || next > 0xdfff) return true;
+      i++;
+      continue;
+    }
+    if (code >= 0xdc00 && code <= 0xdfff) return true;
+  }
+  return false;
+}
 
 describe("truncateForModelByTokens", () => {
   it("returns the string unchanged when it fits the budget", () => {
@@ -75,5 +93,30 @@ describe("truncateForModelByTokens", () => {
     const droppedChars = Number(match![2]);
     expect(droppedTokens).toBeGreaterThan(0);
     expect(droppedChars).toBeGreaterThan(0);
+  });
+
+  it("never leaves a lone UTF-16 surrogate at a slice boundary (issue #1970)", () => {
+    // Emoji are UTF-16 surrogate pairs. Pack a content so the natural
+    // token-budget slice lands inside one — without alignment, the head
+    // would end with a lone high surrogate and DeepSeek's serde_json
+    // would reject the request with "unexpected end of hex escape".
+    const emoji = "🚀";
+    const filler = "x".repeat(50);
+    const segment = `${emoji}${filler}`;
+    const s = segment.repeat(2000);
+    const out = truncateForModelByTokens(s, 400);
+    expect(hasLoneSurrogate(out)).toBe(false);
+    expect(JSON.stringify(out)).not.toMatch(/\\u[dD][89abAB][0-9a-fA-F]{2}/);
+  });
+});
+
+describe("truncateForModel (char-based)", () => {
+  it("never leaves a lone UTF-16 surrogate at a slice boundary (issue #1970)", () => {
+    const emoji = "🎯";
+    const filler = "y".repeat(50);
+    const s = `${emoji}${filler}`.repeat(2000);
+    const out = truncateForModel(s, 1000);
+    expect(hasLoneSurrogate(out)).toBe(false);
+    expect(JSON.stringify(out)).not.toMatch(/\\u[dD][89abAB][0-9a-fA-F]{2}/);
   });
 });


### PR DESCRIPTION
## Summary

Closes #1970.

When a tool result containing emoji (or any supplementary-plane UTF-16 codepoint) exceeded the result-token budget, `truncateForModel` / `truncateForModelByTokens` would slice via `s.slice(0, size)` / `s.slice(-size)` and risk cutting through a surrogate pair. The head ended with a lone high surrogate / the tail started with a lone low surrogate. Downstream JSON serialization then either:

- emitted `\uD83D` (a syntactically-complete but semantically-orphan escape) that DeepSeek's serde_json parser rejected with `unexpected end of hex escape`, or
- passed the malformed pair to the disk transcript path where the lone-surrogate sanitizer in `client.ts` doesn't run.

Fix is a small `sliceAlignedToCodepoint` / `sliceSuffixAlignedToCodepoint` helper applied at every slice boundary in the two truncation helpers. The downstream sanitizer in `client.ts` (#1939) is kept as belt-and-suspenders; this PR closes the door at the source.

## Reproduction

User in #1970 attached a ~38 KB HTML report packed with emoji (🔬 🎯 ✅ 🚀 …). `read_file` returned the full content, the dispatcher trimmed it to the 8000-token budget, and the trim landed inside an emoji surrogate pair. The next chat request body got a `\uD83D` lone high surrogate near `column 38621` and DeepSeek 400'd the whole turn.

## Test plan

- [x] New regression test in `tests/truncate-tokens.test.ts` constructs an emoji-laden 100k-char input, truncates to a token budget that lands mid-pair, and asserts the result has no lone surrogates and no `\uDXXX` escape in its JSON representation. Same for the char-based `truncateForModel`.
- [x] `npm run typecheck` ✓
- [x] `npm run lint` ✓
- [x] `npm run verify` (full pre-push) ✓
