### PR TITLE
fix(desktop): wire /skill and /skills slash commands

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -1640,6 +1640,11 @@ function TabRuntime({
           if (!override) setDraft("");
           return;
         }
+        if (name === "skill" || name === "skills") {
+          openSettingsAt("skills");
+          if (!override) setDraft("");
+          return;
+        }
         const skill = state.skills.find((s) => s.name === name);
         if (skill) {
           const clientId = `skill-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -2026,6 +2031,8 @@ function TabRuntime({
       desc: t("app.cmd.searchEngine"),
       run: () => openSettingsAt("general"),
     },
+    { cmd: "/skill", desc: t("app.cmd.skill"), run: () => openSettingsAt("skills") },
+    { cmd: "/skills", desc: t("app.cmd.skill"), run: () => openSettingsAt("skills") },
     ...slashSettingCommands,
     { cmd: "/theme", desc: t("app.cmd.toggleTheme"), run: onToggleTheme },
     {

--- a/desktop/src/i18n/de.ts
+++ b/desktop/src/i18n/de.ts
@@ -419,6 +419,7 @@ export const de: typeof en = {
       copyLast: "Letzte Antwort kopieren",
       switchModel: "Modell wechseln",
       searchEngine: "Suchmaschine + API-Keys konfigurieren",
+      skill: "Skills auflisten / verwalten (Projekt + Custom + Global + Eingebaut)",
       setMode: "Modus auf {mode} setzen",
       setEffort: "Reasoning-Effort auf {effort} setzen",
       toggleTheme: "Theme wechseln",

--- a/desktop/src/i18n/en.ts
+++ b/desktop/src/i18n/en.ts
@@ -401,6 +401,7 @@ export const en = {
       copyLast: "Copy last reply",
       switchModel: "Switch model",
       searchEngine: "Configure web search engine + API keys",
+      skill: "List and manage user skills (project + custom + global + builtin)",
       setMode: "Set mode to {mode}",
       setEffort: "Set reasoning effort to {effort}",
       toggleTheme: "Toggle theme",

--- a/desktop/src/i18n/zh-CN.ts
+++ b/desktop/src/i18n/zh-CN.ts
@@ -420,6 +420,7 @@ export const zhCN: typeof en = {
       copyLast: "复制最后一条回复",
       switchModel: "切换模型",
       searchEngine: "配置搜索引擎 + API key",
+      skill: "列出 / 管理用户技能（项目 + 自定义 + 全局 + 内置）",
       setMode: "切换模式为 {mode}",
       setEffort: "切换推理强度为 {effort}",
       toggleTheme: "切换深浅主题",


### PR DESCRIPTION
## Summary

Desktop palette had no `/skill` entry, so typing `/skill` (which works in the CLI) showed "无匹配项". The palette only had `/<each-skill-name>` entries (e.g. `/build-system`), none matching the `/skill` prefix.

- Add `/skill` + `/skills` palette commands → open Settings → Skills page
- Handle the same names on submit (Enter key) so direct typing also routes there, mirroring the existing `/search-engine` special case
- `app.cmd.skill` i18n added for en / zh-CN / de

Closes #1969

## Test plan

- [ ] Type `/skill` in desktop → palette shows the new entry, selecting it opens Settings → Skills
- [ ] Type `/skill` + Enter → opens Settings → Skills
- [ ] Type `/skills` (plural) → same behavior
- [ ] Existing `/<skill-name>` invocations (e.g. `/build-system`) still run the skill