### PR TITLE
fix(loop): force-summary uses active model, not hard-coded flash

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -1051,6 +1051,7 @@ export class CacheFirstLoop {
       appendAndPersist: (m) => this.appendAndPersist(m),
       recordStats: (model, usage) => this.stats.record(this._turn, model, usage),
       turn: this._turn,
+      model: this.model,
     };
   }
 

--- a/src/loop/force-summary.ts
+++ b/src/loop/force-summary.ts
@@ -16,6 +16,8 @@ export interface ForceSummaryContext {
   appendAndPersist: (msg: ChatMessage) => void;
   recordStats: (model: string, usage: Usage) => TurnStats;
   turn: number;
+  /** Model to call for the summary itself — must be valid on the user's endpoint. */
+  model: string;
 }
 
 export async function* forceSummaryAfterIterLimit(
@@ -36,13 +38,11 @@ export async function* forceSummaryAfterIterLimit(
       content:
         "The turn is being force-summarized (context guard or stuck-state). Summarize in plain prose what you learned from the tool results above. Do NOT emit any tool calls, function-call markup, DSML invocations, or SEARCH/REPLACE edit blocks — they will be silently discarded. Just plain text.",
     });
-    // Pin to flash + thinking disabled — the task is "paraphrase tool
-    // results into prose", which needs zero reasoning. Letting flash
-    // think here burns reasoning tokens on a job that's structurally
-    // bounded (no decisions, no tools). Pro is 12× overkill.
-    const summaryModel = "deepseek-v4-flash";
+    // Use the active turn model — pinning a specific name (e.g. flash) 400s
+    // on third-party endpoints that don't advertise it. `thinking: disabled`
+    // still keeps reasoning tokens off the bill for the bounded paraphrase.
     const resp = await ctx.client.chat({
-      model: summaryModel,
+      model: ctx.model,
       messages,
       signal: ctx.signal,
       thinking: "disabled",
@@ -52,9 +52,8 @@ export async function* forceSummaryAfterIterLimit(
     const summary = cleaned || t("summary.hallucinatedFallback");
     const reasonPrefix = reasonPrefixFor(opts.reason);
     const annotated = `${reasonPrefix}\n\n${summary}`;
-    // Record under the actual model used (flash), so per-turn cost reflects reality.
-    const summaryStats = ctx.recordStats(summaryModel, resp.usage ?? new Usage());
-    ctx.appendAndPersist(buildAssistantMessage(summary, [], summaryModel, resp.reasoningContent));
+    const summaryStats = ctx.recordStats(ctx.model, resp.usage ?? new Usage());
+    ctx.appendAndPersist(buildAssistantMessage(summary, [], ctx.model, resp.reasoningContent));
     yield {
       turn: ctx.turn,
       role: "assistant_final",

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -611,6 +611,78 @@ describe("CacheFirstLoop (non-streaming)", () => {
     expect(summary!.content).toMatch(/context budget running low/);
   });
 
+  it("force-summary calls the active model, not a hard-coded one (third-party endpoint compat)", async () => {
+    const seenModels: string[] = [];
+    const responses: FakeResponseShape[] = [
+      {
+        content: "",
+        tool_calls: [{ id: "c", type: "function", function: { name: "probe", arguments: "{}" } }],
+        usage: {
+          prompt_tokens: 900_000,
+          completion_tokens: 10,
+          total_tokens: 900_010,
+          prompt_cache_hit_tokens: 0,
+          prompt_cache_miss_tokens: 900_000,
+        },
+      },
+      { content: "summary text" },
+    ];
+    let i = 0;
+    const captureFetch: typeof fetch = vi.fn(async (_url: any, init: any) => {
+      const body = init?.body ? JSON.parse(init.body) : {};
+      if (typeof body.model === "string") seenModels.push(body.model);
+      const resp = responses[i++] ?? responses[responses.length - 1]!;
+      return new Response(
+        JSON.stringify({
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: "assistant",
+                content: resp.content ?? "",
+                tool_calls: resp.tool_calls ?? undefined,
+              },
+              finish_reason: resp.tool_calls ? "tool_calls" : "stop",
+            },
+          ],
+          usage: resp.usage ?? {
+            prompt_tokens: 100,
+            completion_tokens: 20,
+            total_tokens: 120,
+            prompt_cache_hit_tokens: 0,
+            prompt_cache_miss_tokens: 100,
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+
+    const reg = new ToolRegistry();
+    reg.register({
+      name: "probe",
+      description: "no-op",
+      parameters: { type: "object", properties: {} },
+      fn: async () => "ok",
+    });
+    const thirdPartyModel = "mimo-v2.5-pro";
+    const client = new DeepSeekClient({ apiKey: "sk-test", fetch: captureFetch });
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s", toolSpecs: reg.specs() }),
+      tools: reg,
+      stream: false,
+      maxToolIters: 64,
+      model: thirdPartyModel,
+    });
+
+    for await (const _ of loop.step("analyze the repo")) {
+      // drain
+    }
+
+    expect(seenModels.length).toBeGreaterThanOrEqual(2);
+    expect(seenModels.every((m) => m === thirdPartyModel)).toBe(true);
+  });
+
   it("compactHistory replaces head with summary, keeps tail within token budget", async () => {
     const responses: FakeResponseShape[] = [
       { content: "User explored auth and billing modules; landed on session refactor plan." },


### PR DESCRIPTION
## Summary
- `forceSummaryAfterIterLimit` was calling `client.chat({ model: "deepseek-v4-flash" })` regardless of the user's active model. Third-party endpoints (e.g. mimo, self-hosted forks, Azure) that don't expose `deepseek-v4-flash` return a 400 on every context-guard/stuck recovery — the session looks like it lost context (the messages are actually still there) and the user has no way back without `/clear`. Matches reports in #1815, #1975, #1273.
- Pass `this.model` through `summaryContext()` and use it for the summary call. `thinking: "disabled"` still keeps reasoning tokens off the bill even when the active model is pro.

## Test plan
- [x] New `force-summary calls the active model, not a hard-coded one (third-party endpoint compat)` test in `tests/loop.test.ts` — captures every fetch body and asserts every request uses `mimo-v2.5-pro`, not flash. Reverts to fail on pre-fix code.
- [x] `npm test -- tests/loop.test.ts tests/loop-r1-reasoning.test.ts tests/comment-policy.test.ts` — 98 passed, 1 skipped.
- [x] `npm run typecheck`, `npm run lint`.

Closes #1975
Closes #1815
