### PR TITLE
fix(config): saveApiKey overrides stale env so UI save takes effect

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -959,8 +959,12 @@ export function webSearchEndpoint(path: string = defaultConfigPath()): string {
 
 export function saveApiKey(key: string, path: string = defaultConfigPath()): void {
   const cfg = readConfig(path);
-  cfg.apiKey = key.trim();
+  const trimmed = key.trim();
+  cfg.apiKey = trimmed;
   writeConfig(cfg, path);
+  // A stale process env (User-level Windows env, `.env`, shell rc) shadows config in
+  // loadEndpoint's fallback branch — an explicit UI save must win for the current run.
+  if (trimmed) process.env.DEEPSEEK_API_KEY = trimmed;
 }
 
 /** Windows: case-insensitive — NTFS treats `F:\Foo` and `f:\foo` as one directory (#402). */

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -135,6 +135,16 @@ describe("config", () => {
     expect(loadApiKey(path)).toBe("sk-fromfile1234567890ab");
   });
 
+  it("saveApiKey overrides a stale env var so an explicit UI save takes effect immediately", () => {
+    // Repro: user has DEEPSEEK_API_KEY=<old> in User-level env / .env / shell rc.
+    // Without the env update inside saveApiKey, loadEndpoint's fallback branch
+    // keeps returning the stale env, so the desktop UI save looks like a no-op.
+    process.env.DEEPSEEK_API_KEY = "sk-staleenv00000000000000";
+    saveApiKey("sk-freshfromui00000000000", path);
+    expect(loadApiKey(path)).toBe("sk-freshfromui00000000000");
+    expect(process.env.DEEPSEEK_API_KEY).toBe("sk-freshfromui00000000000");
+  });
+
   it("loadApiKey returns undefined when nothing set", () => {
     expect(loadApiKey(path)).toBeUndefined();
   });
@@ -231,8 +241,12 @@ describe("config", () => {
   it("loadEndpoint: env tuple wins when env sets baseUrl", () => {
     process.env.DEEPSEEK_BASE_URL = "https://env-proxy.example.com";
     process.env.DEEPSEEK_API_KEY = "sk-env-tuple-token-abc";
-    saveBaseUrl("https://config-only.example.com", path);
-    saveApiKey("sk-config-token-xyz1234", path);
+    // Write config directly — saveApiKey would mutate env as part of the desktop-UI
+    // contract; here we want to test loadEndpoint's read precedence in isolation.
+    writeConfig(
+      { baseUrl: "https://config-only.example.com", apiKey: "sk-config-token-xyz1234" },
+      path,
+    );
     try {
       const ep = loadEndpoint(path);
       expect(ep.baseUrl).toBe("https://env-proxy.example.com");
@@ -245,9 +259,9 @@ describe("config", () => {
 
   it("loadEndpoint: default endpoint pairs env apiKey > config apiKey", () => {
     // Neither source sets baseUrl → default endpoint. Standard 12-factor
-    // env > config for the apiKey, unchanged from pre-fix behavior.
+    // env > config for the apiKey on the read path.
     process.env.DEEPSEEK_API_KEY = "sk-env-default-token-abc";
-    saveApiKey("sk-config-token-xyz1234", path);
+    writeConfig({ apiKey: "sk-config-token-xyz1234" }, path);
     const ep = loadEndpoint(path);
     expect(ep.baseUrl).toBeUndefined();
     expect(ep.apiKey).toBe("sk-env-default-token-abc");


### PR DESCRIPTION
## Summary

Reported by a user on QQ: installed via `npx reasonix setup`, hit a 401, switched to the desktop app, entered a fresh key in the settings UI — but every request kept failing with the old key visible in the error tail (`Your api key: ****43a0 is invalid`). Closing and reopening the app, then re-entering the same key, worked.

## Root cause

`loadEndpoint`'s default-endpoint fallback prefers `process.env.DEEPSEEK_API_KEY` over `cfg.apiKey` (standard 12-factor read precedence). On the user's first launch the sidecar inherited a stale `DEEPSEEK_API_KEY` from somewhere (Windows User env, `.env`, the shell that originally ran `npx`). The desktop save wrote the new key to `config.json`, then `bridgeEndpointEnv` called `loadEndpoint` which returned the stale env value and wrote it back to env — a no-op. `buildRuntimeFor` then constructed `DeepSeekClient` with the stale env key. Every subsequent request 401'd with the old key in the message.

Restart only "worked" because the second launch happened to start without the stale env (probably double-clicked from the taskbar instead of a shell), so the env was clean and the saved config value won by fallthrough.

## Fix

Have `saveApiKey` write the trimmed key into `process.env.DEEPSEEK_API_KEY` as well as `config.json`. An explicit UI save now wins inside the current sidecar process regardless of what env was carrying.

Read precedence is unchanged — env still beats config for callers who deliberately set `DEEPSEEK_API_KEY` to override (CI, multi-account juggling, etc.). The two existing `loadEndpoint` precedence tests now use `writeConfig` directly so they continue to exercise the read contract without going through the (now-side-effecting) save path.

## Test plan

- [x] New regression test in `tests/config.test.ts`: stale env set, `saveApiKey(new)`, expect `loadApiKey()` and `process.env.DEEPSEEK_API_KEY` to both be `new`.
- [x] Existing `loadEndpoint` precedence tests updated to use `writeConfig` for setup; they still cover env-tuple-wins and env-apiKey-wins on the read path.
- [x] `npm run typecheck` ✓
- [x] `npm run lint` ✓
- [x] `npm run verify` (full pre-push) ✓
