### PR TITLE
fix(desktop): fire hooks (Pre/PostToolUse, UserPromptSubmit, Stop) per tab

### DIFF
--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -89,6 +89,7 @@ import {
   takeQQPendingInteraction,
 } from "../../desktop/qq-turn-routing.js";
 import { loadDotenv } from "../../env.js";
+import { type ResolvedHook, formatHookOutcomeMessage, loadHooks, runHooks } from "../../hooks.js";
 import {
   CacheFirstLoop,
   DeepSeekClient,
@@ -977,6 +978,7 @@ interface Tab {
   mcpStatuses: Map<string, { kind: McpSpecStatus; reason?: string; toolCount?: number }>;
   /** True while a session switch is in progress — prevents stale events from the old turn. */
   switching: boolean;
+  hooks: ResolvedHook[];
 }
 
 let tabCounter = 0;
@@ -1011,6 +1013,8 @@ function buildRuntimeFor(tab: Tab): RuntimeState {
     budgetUsd: tab.budgetUsd,
     session: tab.currentSession,
     reasoningEffort,
+    hooks: tab.hooks,
+    hookCwd: tab.rootDir,
   });
   const eventizer = new Eventizer();
   const ctx = { model: tab.currentModel, prefixHash: prefix.fingerprint, reasoningEffort };
@@ -1460,6 +1464,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
       mcpRuntime: null,
       mcpStatuses: new Map(),
       switching: false,
+      hooks: loadHooks({ projectRoot: dir }),
     };
     tab.currentSession = mintSessionFor(dir);
     tabs.set(tab.id, tab);
@@ -1596,6 +1601,22 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
         }
       }
     }
+    if (tab.hooks.some((h) => h.event === "UserPromptSubmit")) {
+      const report = await runHooks({
+        hooks: tab.hooks,
+        payload: { event: "UserPromptSubmit", cwd: tab.rootDir, prompt: text },
+      });
+      for (const o of report.outcomes) {
+        if (o.decision === "pass") continue;
+        emit({ type: "$error", message: formatHookOutcomeMessage(o) }, tab.id);
+      }
+      if (report.blocked) {
+        tab.aborter = null;
+        emit({ type: "$turn_complete" }, tab.id);
+        if (fromQQ) markQQTurnFinished(qqRuntime.routing, tab.id);
+        return;
+      }
+    }
     await tabContext.run(tab.id, async () => {
       try {
         let emittedTurnContext = false;
@@ -1647,6 +1668,21 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
           }
           emitSessions(tab);
           void emitBalance(tab);
+          if (tab.hooks.some((h) => h.event === "Stop")) {
+            const stopReport = await runHooks({
+              hooks: tab.hooks,
+              payload: {
+                event: "Stop",
+                cwd: tab.rootDir,
+                lastAssistantText,
+                turn: rt.loop.stats.summary().turns,
+              },
+            });
+            for (const o of stopReport.outcomes) {
+              if (o.decision === "pass") continue;
+              emit({ type: "$error", message: formatHookOutcomeMessage(o) }, tab.id);
+            }
+          }
         }
         if (fromQQ) markQQTurnFinished(qqRuntime.routing, tab.id);
         tab.switching = false;
@@ -1680,6 +1716,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
     tab.symbolIndex = null;
     tab.symbolBuilding = null;
     tab.recentMentions.length = 0;
+    tab.hooks = loadHooks({ projectRoot: target });
     tab.currentSession = mintSessionFor(target);
     tab.toolset = await buildCodeToolset({
       rootDir: target,


### PR DESCRIPTION
## Summary

Desktop never wired the hook runner. `buildRuntimeFor` constructed `CacheFirstLoop` without `hooks`/`hookCwd`, and `runTurn` had no UserPromptSubmit/Stop dispatch — so anything users put in `~/.reasonix/settings.json` silently no-op'd in the desktop app, even though the same config fires correctly under `reasonix code`.

This PR loads hooks per tab from the tab's `rootDir` (project scope) + global, threads them into the loop (which covers PreToolUse/PostToolUse via its own trigger points), and fires UserPromptSubmit before `loop.step` / Stop in the turn-complete tail. Workspace switch reloads so project hooks follow the new root.

Non-pass UserPromptSubmit/Stop outcomes surface via `$error` so the user actually sees what the hook said. A blocking UserPromptSubmit aborts the turn before the prompt reaches the model (matching CLI semantics).

Closes #1942

## Test plan

- [x] `npx vitest run tests/hooks.test.ts tests/loop-hooks.test.ts tests/comment-policy.test.ts tests/desktop-user-message.test.ts tests/desktop-edge.test.ts` — green
- [x] full `npx vitest run` via pre-push hook — 3787 / 3787 pass
- [x] `npx tsc --noEmit` clean
- [x] `npx biome check src/cli/commands/desktop.ts` clean
- [ ] Manual: drop a `PostToolUse` echo hook in `~/.reasonix/settings.json`, run a tool in desktop, confirm the log file appears