### PR TITLE
fix(desktop): clear pending assistant on error so the spinner stops

### DIFF
--- a/desktop/src/App.test.ts
+++ b/desktop/src/App.test.ts
@@ -155,6 +155,40 @@ describe("Desktop App reducer — usage", () => {
     expect(next.usage.lastCallCacheMiss).toBe(1234);
   });
 
+  it("settles the pending assistant message when an error ends the turn (#1660)", () => {
+    const base = initialState();
+    const state = {
+      ...base,
+      busy: true,
+      messages: [
+        ...base.messages,
+        {
+          kind: "assistant" as const,
+          turn: 1,
+          segments: [{ kind: "reasoning" as const, text: "thinking…" }],
+          pending: true,
+        },
+      ],
+    };
+    const next = reduce(state, {
+      t: "incoming",
+      event: {
+        type: "error",
+        id: 1,
+        ts: "2026-05-27T00:00:00.000Z",
+        turn: 1,
+        message: "SSE body read failed: terminated",
+        recoverable: false,
+      },
+    });
+
+    expect(next.busy).toBe(false);
+    const assistant = next.messages.find((m) => m.kind === "assistant");
+    expect(assistant?.pending).toBe(false);
+    const error = next.messages.find((m) => m.kind === "error");
+    expect(error?.message).toBe("SSE body read failed: terminated");
+  });
+
   it("keeps cumulative usage when live context breakdown refreshes", () => {
     const base = initialState();
     const next = reduce(

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -1062,12 +1062,18 @@ export function applyIncoming(state: State, ev: IncomingEvent): State {
       // ones so a session full of self-repaired loops doesn't look
       // like everything's on fire (#1456-followup).
       const recoverable = ev.type === "error" ? ev.recoverable : false;
+      // Loop has returned (any error path ends the turn); flip the still-
+      // streaming assistant message to settled so the UI doesn't keep
+      // showing a "thinking" spinner above the error card (#1660).
+      const settled = state.messages.map((m) =>
+        m.kind === "assistant" && m.pending ? { ...m, pending: false } : m,
+      );
       return {
         ...state,
         busy: false,
         activeSkill: null,
         messages: [
-          ...state.messages,
+          ...settled,
           { kind: "error", message: ev.message, id: nextErrorId(), recoverable },
         ],
       };


### PR DESCRIPTION
## Summary

Closes #1660.

When an SSE stream terminates mid-turn (proxy / load-balancer idle drop — undici raises `Error("terminated")`), the loop catches it, yields a `role: "error"` event, and returns. The desktop reducer flips `busy: false` and appends a red error card — but the in-progress assistant message keeps `pending: true`, so the "thinking" spinner stays above the error card and the UI looks frozen. Reporter described it as "对话卡死" (conversation hangs).

Fix is one branch in the `$error` / `error` reducer case: walk the messages and flip any `pending: true` assistant entry to settled before appending the error card. The loop has already returned by the time the error event lands, so no other message can still be streaming.

Related upstream work that improves the error text itself:
- #1918 wraps `terminated` into `SSE body read failed: terminated` with `phase: "stream_body_read"` so retry logic can act on it.
- #1965 follow-up tightened the propagation. Not strictly needed for the UI fix in this PR.

## Test plan

- [x] New regression test in `desktop/src/App.test.ts`: state with `busy:true` and a `pending:true` assistant segment, dispatch an `error` event, assert `busy === false`, the assistant is settled, and the error card is appended.
- [x] `npm run verify` (full pre-push) ✓
