### PR TITLE
fix(hooks): add last_assistant_message to Stop payload for ecosystem compat

### DIFF
--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -1690,6 +1690,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
                 event: "Stop",
                 cwd: tab.rootDir,
                 lastAssistantText,
+                last_assistant_message: lastAssistantText,
                 turn: rt.loop.stats.summary().turns,
               },
             });

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -3437,7 +3437,8 @@ function AppInner({
             payload: {
               event: "Stop",
               cwd: currentRootDir,
-              lastAssistantText: streamRef.text,
+              lastAssistantText,
+              last_assistant_message: lastAssistantText,
               turn: loop.stats.summary().turns,
             },
           });

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -174,6 +174,7 @@ export interface HookPayload {
   toolResult?: string;
   prompt?: string;
   lastAssistantText?: string;
+  last_assistant_message?: string;
   turn?: number;
 }
 


### PR DESCRIPTION
Closes #1943.

Stop hook payload 现在同时输出 "lastAssistantText" 和 "last_assistant_message"，后者跟 Claude Code / Codex 的命名一致，省得社区脚本拿到空值。