### PR TITLE
feat(web-search): add bing-intl engine for international index

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -193,7 +193,7 @@ export type Settings = {
   recentWorkspaces: string[];
   model: string;
   editor?: string;
-  webSearchEngine?: "bing" | "searxng" | "metaso" | "tavily" | "perplexity" | "exa" | "brave" | "ollama";
+  webSearchEngine?: "bing" | "bing-intl" | "searxng" | "metaso" | "tavily" | "perplexity" | "exa" | "brave" | "ollama";
   subagentModels?: Record<string, "flash" | "pro">;
   showSystemEvents?: boolean;
   version: string;

--- a/dashboard/src/i18n/de.ts
+++ b/dashboard/src/i18n/de.ts
@@ -250,6 +250,7 @@ export const de: typeof en = {
     webSearchNote: "web_fetch + web_search Werkzeuge",
     webSearchEngine: "Suchmaschine",
     webSearchEngineBing: "bing — Standard, funktioniert von CN ohne Proxy",
+    webSearchEngineBingIntl: "bing-intl — internationaler Index über www.bing.com",
     webSearchEngineSearxng: "searxng — selbst gehostet (Endpunkt via /se searxng <url>)",
     webSearchEngineMetaso: "metaso — 100/Tag kostenlos (CN-freundlich, kostenloser Schlüssel auf metaso.cn)",
     webSearchEngineTavily: "tavily — 1000/Monat kostenlos (TAVILY_API_KEY setzen)",

--- a/dashboard/src/i18n/en.ts
+++ b/dashboard/src/i18n/en.ts
@@ -232,6 +232,7 @@ export const en = {
     webSearchNote: "web_fetch + web_search tools",
     webSearchEngine: "search engine",
     webSearchEngineBing: "bing — default, works from CN without proxy",
+    webSearchEngineBingIntl: "bing-intl — international index via www.bing.com",
     webSearchEngineSearxng: "searxng — self-hosted (set endpoint via /se searxng <url>)",
     webSearchEngineMetaso: "metaso — 100/day free (CN-friendly, free key at metaso.cn)",
     webSearchEngineTavily: "tavily — 1000/mo free (set TAVILY_API_KEY)",

--- a/dashboard/src/i18n/zh-CN.ts
+++ b/dashboard/src/i18n/zh-CN.ts
@@ -232,6 +232,7 @@ export const zhCN = {
     webSearchNote: "web_fetch + web_search 工具",
     webSearchEngine: "搜索引擎",
     webSearchEngineBing: "bing — 默认，国内裸 IP 直连，无需代理",
+    webSearchEngineBingIntl: "bing-intl — 国际版索引，走 www.bing.com",
     webSearchEngineSearxng: "searxng — 自托管（端点用 /se searxng <url> 配置）",
     webSearchEngineMetaso: "metaso — 每日 100 次免费（国内友好，metaso.cn 可领免费 key）",
     webSearchEngineTavily: "tavily — 每月 1000 次免费（设置 TAVILY_API_KEY）",

--- a/dashboard/src/protocol.ts
+++ b/dashboard/src/protocol.ts
@@ -291,6 +291,7 @@ export type ReasoningEffort = "low" | "medium" | "high" | "max";
 
 export type WebSearchEngineName =
   | "bing"
+  | "bing-intl"
   | "searxng"
   | "metaso"
   | "tavily"

--- a/dashboard/src/ui/settings.tsx
+++ b/dashboard/src/ui/settings.tsx
@@ -669,6 +669,7 @@ function PageGeneral({
               onSave({
                 webSearchEngine: e.target.value as
                   | "bing"
+                  | "bing-intl"
                   | "searxng"
                   | "metaso"
                   | "tavily"
@@ -680,6 +681,7 @@ function PageGeneral({
             }
           >
             <option value="bing">{t("settings.webSearchEngineBing")}</option>
+            <option value="bing-intl">{t("settings.webSearchEngineBingIntl")}</option>
             <option value="searxng">{t("settings.webSearchEngineSearxng")}</option>
             <option value="metaso">{t("settings.webSearchEngineMetaso")}</option>
             <option value="tavily">{t("settings.webSearchEngineTavily")}</option>

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -246,7 +246,7 @@ export type Settings = {
   recentWorkspaces: string[];
   model: string;
   editor?: string;
-  webSearchEngine?: "bing" | "searxng" | "metaso" | "tavily" | "perplexity" | "exa" | "brave" | "ollama";
+  webSearchEngine?: "bing" | "bing-intl" | "searxng" | "metaso" | "tavily" | "perplexity" | "exa" | "brave" | "ollama";
   webSearchEndpoint?: string;
   webSearchApiKeys?: {
     metaso?: string;

--- a/desktop/src/i18n/de.ts
+++ b/desktop/src/i18n/de.ts
@@ -176,6 +176,7 @@ export const de: typeof en = {
     budgetPlaceholder: "keine Grenze",
     webSearchEngine: "Suchmaschine",
     webSearchEngineBing: "bing — Standard, funktioniert von CN ohne Proxy",
+    webSearchEngineBingIntl: "bing-intl — internationaler Index über www.bing.com",
     webSearchEngineSearxng: "searxng — selbst gehostet (Endpunkt via /se searxng <url>)",
     webSearchEngineMetaso:
       "metaso — 100/Tag kostenlos (CN-freundlich, kostenloser Schlüssel auf metaso.cn)",

--- a/desktop/src/i18n/en.ts
+++ b/desktop/src/i18n/en.ts
@@ -164,6 +164,7 @@ export const en = {
     budgetPlaceholder: "no cap",
     webSearchEngine: "search engine",
     webSearchEngineBing: "bing — default, works from CN without proxy",
+    webSearchEngineBingIntl: "bing-intl — international index via www.bing.com",
     webSearchEngineSearxng: "searxng — self-hosted (set endpoint via /se searxng <url>)",
     webSearchEngineMetaso: "metaso — 100/day free (CN-friendly, free key at metaso.cn)",
     webSearchEngineTavily: "tavily — 1000/mo free (set TAVILY_API_KEY)",

--- a/desktop/src/i18n/zh-CN.ts
+++ b/desktop/src/i18n/zh-CN.ts
@@ -164,6 +164,7 @@ export const zhCN: typeof en = {
     budgetPlaceholder: "不限",
     webSearchEngine: "搜索引擎",
     webSearchEngineBing: "bing — 默认，国内裸 IP 直连，无需代理",
+    webSearchEngineBingIntl: "bing-intl — 国际版索引，走 www.bing.com",
     webSearchEngineSearxng: "searxng — 自托管（端点用 /se searxng <url> 配置）",
     webSearchEngineMetaso: "metaso — 每日 100 次免费（国内友好，metaso.cn 可领免费 key）",
     webSearchEngineTavily: "tavily — 每月 1000 次免费（设置 TAVILY_API_KEY）",

--- a/desktop/src/protocol.ts
+++ b/desktop/src/protocol.ts
@@ -296,7 +296,7 @@ export type EditMode = "review" | "auto" | "yolo" | "plan";
 
 export type ReasoningEffort = "low" | "medium" | "high" | "max";
 
-export type WebSearchEngineName = "bing" | "searxng" | "metaso" | "tavily" | "perplexity" | "exa"
+export type WebSearchEngineName = "bing" | "bing-intl" | "searxng" | "metaso" | "tavily" | "perplexity" | "exa"
   | "brave" | "ollama";
 
 export type SettingsEvent = {

--- a/desktop/src/ui/settings.tsx
+++ b/desktop/src/ui/settings.tsx
@@ -729,6 +729,7 @@ function PageGeneral({
               onSave({
                 webSearchEngine: e.target.value as
                   | "bing"
+                  | "bing-intl"
                   | "searxng"
                   | "metaso"
                   | "tavily"
@@ -740,6 +741,7 @@ function PageGeneral({
             }
           >
             <option value="bing">{t("settings.webSearchEngineBing")}</option>
+            <option value="bing-intl">{t("settings.webSearchEngineBingIntl")}</option>
             <option value="searxng">{t("settings.webSearchEngineSearxng")}</option>
             <option value="metaso">{t("settings.webSearchEngineMetaso")}</option>
             <option value="tavily">{t("settings.webSearchEngineTavily")}</option>
@@ -780,7 +782,7 @@ function WebSearchEngineCredentials({
   onSave: (patch: SettingsPatch) => void;
 }) {
   const engine = settings.webSearchEngine ?? "bing";
-  if (engine === "bing") return null;
+  if (engine === "bing" || engine === "bing-intl") return null;
   if (engine === "searxng") {
     return <SearxngEndpointRow settings={settings} onSave={onSave} />;
   }

--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -163,6 +163,7 @@ type InMessage = { tabId?: string } & (
       editor?: string;
       webSearchEngine?:
         | "bing"
+        | "bing-intl"
         | "searxng"
         | "metaso"
         | "tavily"
@@ -227,6 +228,7 @@ interface SettingsEvent {
   editor?: string;
   webSearchEngine?:
     | "bing"
+    | "bing-intl"
     | "searxng"
     | "metaso"
     | "tavily"

--- a/src/cli/ui/slash/commands.ts
+++ b/src/cli/ui/slash/commands.ts
@@ -317,10 +317,20 @@ export const SLASH_COMMANDS: readonly SlashCommandSpec[] = [
   {
     cmd: "search-engine",
     group: "advanced",
-    argsHint: "<bing|searxng|metaso|tavily|perplexity|exa|brave|ollama> [<key>]",
+    argsHint: "<bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama> [<key>]",
     summary:
-      "switch web search backend — bing (default, works from CN without proxy), searxng (self-hosted), metaso (free 100/d), tavily (free 1000/mo), perplexity (AI-native), exa (AI-native), brave (independent index, free 2000/mo), or ollama (Ollama cloud web search). Provider with no key prompts inline config.",
-    argCompleter: ["bing", "searxng", "metaso", "tavily", "perplexity", "exa", "brave", "ollama"],
+      "switch web search backend — bing (default, works from CN without proxy), bing-intl (international index via www.bing.com), searxng (self-hosted), metaso (free 100/d), tavily (free 1000/mo), perplexity (AI-native), exa (AI-native), brave (independent index, free 2000/mo), or ollama (Ollama cloud web search). Provider with no key prompts inline config.",
+    argCompleter: [
+      "bing",
+      "bing-intl",
+      "searxng",
+      "metaso",
+      "tavily",
+      "perplexity",
+      "exa",
+      "brave",
+      "ollama",
+    ],
     aliases: ["se"],
   },
   {

--- a/src/cli/ui/slash/handlers/web-search-engine.ts
+++ b/src/cli/ui/slash/handlers/web-search-engine.ts
@@ -19,6 +19,7 @@ export const handlers: Record<string, SlashHandler> = {
     if (
       !engine ||
       (engine !== "bing" &&
+        engine !== "bing-intl" &&
         engine !== "searxng" &&
         engine !== "metaso" &&
         engine !== "tavily" &&
@@ -34,6 +35,7 @@ export const handlers: Record<string, SlashHandler> = {
           "",
           t("handlers.webSearchEngine.usageHeader"),
           t("handlers.webSearchEngine.usageBing"),
+          t("handlers.webSearchEngine.usageBingIntl"),
           t("handlers.webSearchEngine.usageSearxng"),
           t("handlers.webSearchEngine.usageSearxngUrl"),
           t("handlers.webSearchEngine.usageMetaso"),

--- a/src/config.ts
+++ b/src/config.ts
@@ -178,9 +178,10 @@ export interface ReasonixConfig {
   session?: string | null;
   setupCompleted?: boolean;
   search?: boolean;
-  /** Web search engine backend: "bing" (default, scrapes cn.bing.com), "searxng" (self-hosted SearXNG), "metaso" (Metaso API), "tavily" (LLM-friendly API, free tier), "perplexity" (Perplexity AI), "exa" (Exa API), "brave" (Brave Search API), or "ollama" (Ollama cloud web search). */
+  /** Web search engine backend: "bing" (default, scrapes cn.bing.com), "bing-intl" (www.bing.com, indexes international sites), "searxng" (self-hosted SearXNG), "metaso" (Metaso API), "tavily" (LLM-friendly API, free tier), "perplexity" (Perplexity AI), "exa" (Exa API), "brave" (Brave Search API), or "ollama" (Ollama cloud web search). */
   webSearchEngine?:
     | "bing"
+    | "bing-intl"
     | "searxng"
     | "metaso"
     | "tavily"
@@ -936,8 +937,18 @@ export function loadJavaSourceEnabled(path: string = defaultConfigPath()): boole
 
 export function webSearchEngine(
   path: string = defaultConfigPath(),
-): "bing" | "searxng" | "metaso" | "tavily" | "perplexity" | "exa" | "brave" | "ollama" {
+):
+  | "bing"
+  | "bing-intl"
+  | "searxng"
+  | "metaso"
+  | "tavily"
+  | "perplexity"
+  | "exa"
+  | "brave"
+  | "ollama" {
   const cfg = readConfig(path).webSearchEngine;
+  if (cfg === "bing-intl") return "bing-intl";
   if (cfg === "searxng") return "searxng";
   if (cfg === "metaso") return "metaso";
   if (cfg === "tavily") return "tavily";

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -424,8 +424,8 @@ export const EN: TranslationSchema = {
     },
     "search-engine": {
       description:
-        "switch web search backend — bing (default, works from CN without proxy), searxng (self-hosted), metaso (free 100/d), tavily (free 1000/mo), perplexity (AI-native), exa (AI-native), or ollama (Ollama cloud web search)",
-      argsHint: "<bing|searxng|metaso|tavily|perplexity|exa|brave|ollama> [<key>]",
+        "switch web search backend — bing (default, works from CN without proxy), bing-intl (international index), searxng (self-hosted), metaso (free 100/d), tavily (free 1000/mo), perplexity (AI-native), exa (AI-native), brave (independent index), or ollama (Ollama cloud web search)",
+      argsHint: "<bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama> [<key>]",
     },
   },
   wizard: {
@@ -1197,6 +1197,8 @@ export const EN: TranslationSchema = {
       usageHeader: "Usage:",
       usageBing:
         "  /search-engine bing              use Bing (default, works from CN without proxy)",
+      usageBingIntl:
+        "  /search-engine bing-intl          use Bing international (www.bing.com, indexes GitHub/Wikipedia/Stack Overflow)",
       usageSearxng: "  /search-engine searxng            use SearXNG at default endpoint",
       usageSearxngUrl: "  /search-engine searxng <url>      use SearXNG at custom endpoint",
       usageMetaso:
@@ -1534,25 +1536,25 @@ export const EN: TranslationSchema = {
   },
   webErrors: {
     status:
-      "web_search {status} \u2014 try: the search backend returned an error; rephrase the query, or switch engine with /search-engine bing|searxng|metaso|tavily|perplexity|exa|brave",
+      "web_search {status} \u2014 try: the search backend returned an error; rephrase the query, or switch engine with /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama",
     rateLimit429:
       "web_search 429 \u2014 try: wait 10s before retrying, or rephrase the query; the search backend is rate-limiting this client",
     forbidden403:
-      "web_search 403 \u2014 try: the search backend is blocking this client; switch engine with /search-engine bing|searxng|metaso|tavily|perplexity|exa|brave, or wait and retry later",
+      "web_search 403 \u2014 try: the search backend is blocking this client; switch engine with /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave, or wait and retry later",
     serverError5xx:
       "web_search {status} \u2014 try: open the search URL in a browser; if it loads this is transient and a retry in 30s may help",
     bingBlocked:
-      "web_search: Bing anti-bot page \u2014 rate-limited or blocked \u2014 try: wait 30s and retry, or switch engine with /search-engine bing|searxng|metaso|tavily|perplexity|exa|brave",
+      "web_search: Bing anti-bot page \u2014 rate-limited or blocked \u2014 try: wait 30s and retry, or switch engine with /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama",
     bingNoResults:
-      "web_search: 0 results but response doesn't look like a real empty page ({chars} chars, first 120: {preview}) \u2014 try: rephrase the query with simpler terms, or switch engine with /search-engine bing|searxng|metaso|tavily|perplexity|exa|brave",
+      "web_search: 0 results but response doesn't look like a real empty page ({chars} chars, first 120: {preview}) \u2014 try: rephrase the query with simpler terms, or switch engine with /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama",
     invalidEndpoint:
       'web_search: invalid SearXNG endpoint "{endpoint}" \u2014 try: set a valid URL with /search-endpoint http://host:port',
     endpointMustBeHttp:
       "web_search: SearXNG endpoint must be http(s), got {protocol} \u2014 try: set a valid URL with /search-endpoint http://host:port",
     cannotReach:
-      "web_search: Cannot reach SearXNG server at {endpoint} \u2014 try: install and start SearXNG (https://github.com/searxng/searxng, e.g. `docker run -d -p 8080:8080 searxng/searxng`), or switch to another engine with /search-engine bing|searxng|metaso|tavily|perplexity|exa|brave",
+      "web_search: Cannot reach SearXNG server at {endpoint} \u2014 try: install and start SearXNG (https://github.com/searxng/searxng, e.g. `docker run -d -p 8080:8080 searxng/searxng`), or switch to another engine with /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama",
     searxngNoResults:
-      "web_search: 0 results but SearXNG response doesn't look like an empty results page ({chars} chars) \u2014 try: rephrase the query with simpler terms, or switch engine with /search-engine bing|searxng|metaso|tavily|perplexity|exa|brave",
+      "web_search: 0 results but SearXNG response doesn't look like an empty results page ({chars} chars) \u2014 try: rephrase the query with simpler terms, or switch engine with /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama",
     metasoMissingKey:
       "web_search: Metaso requires an API key \u2014 set METASO_API_KEY or configure one with /search-engine metaso <key>. Get one at https://metaso.cn/search-api/playground",
     metasoDailyLimit:
@@ -1562,7 +1564,7 @@ export const EN: TranslationSchema = {
     metasoRateLimit:
       "web_search: Metaso rate-limited \u2014 wait and retry, or get your own API key at https://metaso.cn/search-api/playground",
     metasoServerError:
-      "web_search: Metaso server error ({status}) \u2014 try again later, or switch engine with /search-engine bing|searxng|metaso|tavily|perplexity|exa|brave",
+      "web_search: Metaso server error ({status}) \u2014 try again later, or switch engine with /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama",
     metasoParseError:
       "web_search: Metaso returned unparseable response (HTTP {status}) \u2014 try again later",
     metasoApiError: "web_search: Metaso API error (code {code}: {message}) \u2014 try again later",
@@ -1571,9 +1573,9 @@ export const EN: TranslationSchema = {
     tavilyUnauthorized:
       "web_search: Tavily API key rejected \u2014 check TAVILY_API_KEY or get one at https://tavily.com",
     tavilyRateLimit:
-      "web_search: Tavily rate-limited or monthly quota exceeded \u2014 wait, switch engine with /search-engine bing|searxng|metaso|tavily|perplexity|exa|brave, or upgrade your Tavily plan",
+      "web_search: Tavily rate-limited or monthly quota exceeded \u2014 wait, switch engine with /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave, or upgrade your Tavily plan",
     tavilyServerError:
-      "web_search: Tavily server error ({status}) \u2014 try again later, or switch engine with /search-engine bing|searxng|metaso|tavily|perplexity|exa|brave",
+      "web_search: Tavily server error ({status}) \u2014 try again later, or switch engine with /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama",
     tavilyParseError:
       "web_search: Tavily returned unparseable response (HTTP {status}) \u2014 try again later",
     perplexityMissingKey:
@@ -1581,9 +1583,9 @@ export const EN: TranslationSchema = {
     perplexityUnauthorized:
       "web_search: Perplexity API key rejected \u2014 check PERPLEXITY_API_KEY or get one at https://perplexity.ai/settings/api",
     perplexityRateLimit:
-      "web_search: Perplexity rate-limited \u2014 wait and retry, or switch engine with /search-engine bing|searxng|metaso|tavily|perplexity|exa|brave",
+      "web_search: Perplexity rate-limited \u2014 wait and retry, or switch engine with /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama",
     perplexityServerError:
-      "web_search: Perplexity server error ({status}) \u2014 try again later, or switch engine with /search-engine bing|searxng|metaso|tavily|perplexity|exa|brave",
+      "web_search: Perplexity server error ({status}) \u2014 try again later, or switch engine with /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama",
     perplexityParseError:
       "web_search: Perplexity returned unparseable response (HTTP {status}) \u2014 try again later",
     exaMissingKey:
@@ -1593,7 +1595,7 @@ export const EN: TranslationSchema = {
     exaRateLimit:
       "web_search: Exa API rate-limited or monthly quota exceeded \u2014 wait or upgrade at https://exa.ai/pricing",
     exaServerError:
-      "web_search: Exa server error ({status}) \u2014 try again later, or switch engine with /search-engine bing|searxng|metaso|tavily|perplexity|exa|brave",
+      "web_search: Exa server error ({status}) \u2014 try again later, or switch engine with /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama",
     exaParseError:
       "web_search: Exa returned unparseable response (HTTP {status}) \u2014 try again later",
     braveMissingKey:
@@ -1603,7 +1605,7 @@ export const EN: TranslationSchema = {
     braveRateLimit:
       "web_search: Brave Search API rate-limited or monthly quota exceeded \u2014 wait or upgrade at https://brave.com/search/api/",
     braveServerError:
-      "web_search: Brave Search server error ({status}) \u2014 try again later, or switch engine with /search-engine bing|searxng|metaso|tavily|perplexity|exa|brave",
+      "web_search: Brave Search server error ({status}) \u2014 try again later, or switch engine with /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama",
     braveParseError:
       "web_search: Brave Search returned unparseable response (HTTP {status}) \u2014 try again later",
     fetchStatus:

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -415,7 +415,7 @@ export const de: TranslationSchema = {
     "search-engine": {
       ...EN.slash["search-engine"],
       description:
-        "Web-Search-Backend wechseln — bing (Standard, funktioniert von CN ohne Proxy), searxng (selbst gehostet), metaso (kostenlos 100/Tag), tavily (kostenlos 1000/Monat), perplexity (AI-native) oder exa (AI-native)",
+        "Web-Search-Backend wechseln — bing (Standard, funktioniert von CN ohne Proxy), bing-intl (internationaler Index), searxng (selbst gehostet), metaso (kostenlos 100/Tag), tavily (kostenlos 1000/Monat), perplexity (AI-native), exa (AI-native), brave (unabhängiger Index) oder ollama (Ollama Cloud-Websuche)",
     },
     theme: {
       ...EN.slash.theme,
@@ -1266,6 +1266,8 @@ export const de: TranslationSchema = {
       usageHeader: "Verwendung:",
       usageBing:
         "  /search-engine bing              Bing verwenden (Standard, funktioniert von CN ohne Proxy)",
+      usageBingIntl:
+        "  /search-engine bing-intl          Bing International verwenden (www.bing.com, indexiert GitHub/Wikipedia/Stack Overflow)",
       usageSearxng: "  /search-engine searxng            SearXNG verwenden (Standard-Endpunkt)",
       usageSearxngUrl:
         "  /search-engine searxng <url>      SearXNG mit benutzerdefiniertem Endpunkt",
@@ -1277,6 +1279,8 @@ export const de: TranslationSchema = {
         "  /search-engine perplexity          Perplexity AI verwenden (AI-native Antwort + Quellenangaben — setze PERPLEXITY_API_KEY oder perplexityApiKey in der Konfiguration; erhalte einen unter https://perplexity.ai/settings/api)",
       usageExa:
         "  /search-engine exa                 Exa-API verwenden (AI-native Antwort + Quellenangaben, kostenlos 1000/Monat — setze EXA_API_KEY oder exaApiKey in der Konfiguration; registriere dich unter https://exa.ai)",
+      usageOllama:
+        "  /search-engine ollama                Ollama Cloud-Web-Suche verwenden — setze OLLAMA_API_KEY oder ollamaApiKey in der Konfiguration; Schlüssel unter https://ollama.com/settings/keys",
       usageBrave:
         "  /search-engine brave               Brave Search API nutzen (unabhängiger Index, kostenlos 2000/Monat — setze BRAVE_SEARCH_API_KEY oder braveApiKey in der Konfiguration; Schlüssel unter https://brave.com/search/api/)",
       alias: "Alias: /se",
@@ -1624,25 +1628,25 @@ export const de: TranslationSchema = {
   webErrors: {
     ...EN.webErrors,
     status:
-      "web_search {status} — versuche: Das Such-Backend hat einen Fehler zurückgegeben; formuliere die Abfrage um oder wechsle die Engine mit /search-engine bing|searxng|metaso|tavily|perplexity|exa|brave|ollama",
+      "web_search {status} — versuche: Das Such-Backend hat einen Fehler zurückgegeben; formuliere die Abfrage um oder wechsle die Engine mit /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama",
     rateLimit429:
       "web_search 429 — versuche: 10s warten vor erneuter Abfrage oder Abfrage umformulieren; das Such-Backend hat das Rate-Limit für diesen Client erreicht",
     forbidden403:
-      "web_search 403 — versuche: Das Such-Backend blockiert diesen Client; wechsle die Engine mit /search-engine bing|searxng|metaso|tavily|perplexity|exa|brave|ollama oder warte und versuche es später erneut",
+      "web_search 403 — versuche: Das Such-Backend blockiert diesen Client; wechsle die Engine mit /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama oder warte und versuche es später erneut",
     serverError5xx:
       "web_search {status} — versuche: Öffne die Such-URL in einem Browser; falls sie lädt, ist dies vorübergehend und ein erneuter Versuch in 30s kann helfen",
     bingBlocked:
-      "web_search: Bing-Anti-Bot-Seite — Rate-Limit erreicht oder blockiert — versuche: 30s warten und erneut versuchen, oder wechsle die Engine mit /search-engine bing|searxng|metaso|tavily|perplexity|exa|brave|ollama",
+      "web_search: Bing-Anti-Bot-Seite — Rate-Limit erreicht oder blockiert — versuche: 30s warten und erneut versuchen, oder wechsle die Engine mit /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama",
     bingNoResults:
-      "web_search: 0 Ergebnisse, aber die Antwort sieht nicht wie eine echte leere Seite aus ({chars} Zeichen, erste 120: {preview}) — versuche: formuliere die Abfrage mit einfacheren Begriffen um oder wechsle die Engine mit /search-engine bing|searxng|metaso|tavily|perplexity|exa|brave|ollama",
+      "web_search: 0 Ergebnisse, aber die Antwort sieht nicht wie eine echte leere Seite aus ({chars} Zeichen, erste 120: {preview}) — versuche: formuliere die Abfrage mit einfacheren Begriffen um oder wechsle die Engine mit /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama",
     invalidEndpoint:
       'web_search: ungültiger SearXNG-Endpunkt "{endpoint}" — versuche: setze eine gültige URL mit /search-endpoint http://host:port',
     endpointMustBeHttp:
       "web_search: SearXNG-Endpunkt muss http(s) sein, {protocol} erhalten — versuche: setze eine gültige URL mit /search-endpoint http://host:port",
     cannotReach:
-      "web_search: SearXNG-Server unter {endpoint} nicht erreichbar — versuche: SearXNG installieren und starten (https://github.com/searxng/searxng, z.B. `docker run -d -p 8080:8080 searxng/searxng`), oder wechsle zu einer anderen Engine mit /search-engine bing|searxng|metaso|tavily|perplexity|exa|brave|ollama",
+      "web_search: SearXNG-Server unter {endpoint} nicht erreichbar — versuche: SearXNG installieren und starten (https://github.com/searxng/searxng, z.B. `docker run -d -p 8080:8080 searxng/searxng`), oder wechsle zu einer anderen Engine mit /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama",
     searxngNoResults:
-      "web_search: 0 Ergebnisse, aber SearXNG-Antwort sieht nicht wie eine leere Ergebnisseite aus ({chars} Zeichen) — versuche: formuliere die Abfrage mit einfacheren Begriffen um oder wechsle die Engine mit /search-engine bing|searxng|metaso|tavily|perplexity|exa|brave|ollama",
+      "web_search: 0 Ergebnisse, aber SearXNG-Antwort sieht nicht wie eine leere Ergebnisseite aus ({chars} Zeichen) — versuche: formuliere die Abfrage mit einfacheren Begriffen um oder wechsle die Engine mit /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama",
     metasoMissingKey:
       "web_search: Metaso benötigt einen API-Schlüssel — setze METASO_API_KEY oder konfiguriere einen mit /search-engine metaso <schlüssel>. Erhalte einen unter https://metaso.cn/search-api/playground",
     metasoDailyLimit:
@@ -1652,7 +1656,7 @@ export const de: TranslationSchema = {
     metasoRateLimit:
       "web_search: Metaso-Rate-Limit erreicht — warte und versuche es erneut, oder erhalte einen eigenen API-Schlüssel unter https://metaso.cn/search-api/playground",
     metasoServerError:
-      "web_search: Metaso-Serverfehler ({status}) — versuche es später erneut oder wechsle die Engine mit /search-engine bing|searxng|metaso|tavily|perplexity|exa|brave|ollama",
+      "web_search: Metaso-Serverfehler ({status}) — versuche es später erneut oder wechsle die Engine mit /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama",
     metasoParseError:
       "web_search: Metaso hat unparsbare Antwort zurückgegeben (HTTP {status}) — versuche es später erneut",
     metasoApiError:
@@ -1662,9 +1666,9 @@ export const de: TranslationSchema = {
     tavilyUnauthorized:
       "web_search: Tavily-API-Schlüssel abgelehnt — überprüfe TAVILY_API_KEY oder erhalte einen unter https://tavily.com",
     tavilyRateLimit:
-      "web_search: Tavily-Rate-Limit erreicht oder monatliches Kontingent überschritten — warte, wechsle die Engine mit /search-engine bing|searxng|metaso|tavily|perplexity|exa|brave|ollama oder upgrade deinen Tavily-Plan",
+      "web_search: Tavily-Rate-Limit erreicht oder monatliches Kontingent überschritten — warte, wechsle die Engine mit /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama oder upgrade deinen Tavily-Plan",
     tavilyServerError:
-      "web_search: Tavily-Serverfehler ({status}) — versuche es später erneut oder wechsle die Engine mit /search-engine bing|searxng|metaso|tavily|perplexity|exa|brave|ollama",
+      "web_search: Tavily-Serverfehler ({status}) — versuche es später erneut oder wechsle die Engine mit /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama",
     tavilyParseError:
       "web_search: Tavily hat unparsbare Antwort zurückgegeben (HTTP {status}) — versuche es später erneut",
     perplexityMissingKey:
@@ -1672,9 +1676,9 @@ export const de: TranslationSchema = {
     perplexityUnauthorized:
       "web_search: Perplexity-API-Schlüssel abgelehnt — überprüfe PERPLEXITY_API_KEY oder erhalte einen unter https://perplexity.ai/settings/api",
     perplexityRateLimit:
-      "web_search: Perplexity-Rate-Limit erreicht — warte und versuche es erneut, oder wechsle die Engine mit /search-engine bing|searxng|metaso|tavily|perplexity|exa|brave|ollama",
+      "web_search: Perplexity-Rate-Limit erreicht — warte und versuche es erneut, oder wechsle die Engine mit /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama",
     perplexityServerError:
-      "web_search: Perplexity-Serverfehler ({status}) — versuche es später erneut oder wechsle die Engine mit /search-engine bing|searxng|metaso|tavily|perplexity|exa|brave|ollama",
+      "web_search: Perplexity-Serverfehler ({status}) — versuche es später erneut oder wechsle die Engine mit /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama",
     perplexityParseError:
       "web_search: Perplexity hat unparsbare Antwort zurückgegeben (HTTP {status}) — versuche es später erneut",
     exaMissingKey:
@@ -1684,7 +1688,7 @@ export const de: TranslationSchema = {
     exaRateLimit:
       "web_search: Exa-API-Rate-Limit erreicht oder monatliches Kontingent überschritten — warte oder upgrade unter https://exa.ai/pricing",
     exaServerError:
-      "web_search: Exa-Serverfehler ({status}) — versuche es später erneut oder wechsle die Engine mit /search-engine bing|searxng|metaso|tavily|perplexity|exa|brave|ollama",
+      "web_search: Exa-Serverfehler ({status}) — versuche es später erneut oder wechsle die Engine mit /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama",
     exaParseError:
       "web_search: Exa hat unparsbare Antwort zurückgegeben (HTTP {status}) — versuche es später erneut",
     braveMissingKey:
@@ -1694,7 +1698,7 @@ export const de: TranslationSchema = {
     braveRateLimit:
       "web_search: Die Brave Search API unterliegt einer Ratenbegrenzung oder das monatliche Kontingent wurde überschritten — warten oder ein Upgrade durchführen unter https://brave.com/search/api/",
     braveServerError:
-      "web_search: Fehler beim Brave-Suchserver ({status}) — später erneut versuchen oder die Engine wechseln mit /search-engine bing|searxng|metaso|tavily|perplexity|exa|brave|ollama",
+      "web_search: Fehler beim Brave-Suchserver ({status}) — später erneut versuchen oder die Engine wechseln mit /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama",
     braveParseError:
       "web_search: Brave Search hat eine nicht auswertbare Antwort zurückgegeben (HTTP {status}) — später erneut versuchen",
     fetchStatus:

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -408,8 +408,8 @@ export const zhCN: TranslationSchema = {
     },
     "search-engine": {
       description:
-        "切换网络搜索后端 — bing（默认，国内裸 IP 直连）、searxng（自托管）、metaso（每日 100 次）、tavily（每月 1000 次免费）、perplexity（AI 直接回答）、exa（AI 直接回答）或 ollama（Ollama 云端搜索）",
-      argsHint: "<bing|searxng|metaso|tavily|perplexity|exa|brave|ollama> [<key>]",
+        "切换网络搜索后端 — bing（默认，国内裸 IP 直连）、bing-intl（国际版索引）、searxng（自托管）、metaso（每日 100 次）、tavily（每月 1000 次免费）、perplexity（AI 直接回答）、exa（AI 直接回答）、brave（独立索引）或 ollama（Ollama 云端搜索）",
+      argsHint: "<bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama> [<key>]",
     },
   },
   wizard: {
@@ -1128,6 +1128,8 @@ export const zhCN: TranslationSchema = {
       endpoint: "SearXNG 端点：{url}",
       usageHeader: "用法：",
       usageBing: "  /search-engine bing              使用 Bing（默认，国内裸 IP 直连，无需代理）",
+      usageBingIntl:
+        "  /search-engine bing-intl          使用 Bing 国际版（www.bing.com，可搜 GitHub/Wikipedia/Stack Overflow）",
       usageSearxng: "  /search-engine searxng            使用 SearXNG 默认端点",
       usageSearxngUrl: "  /search-engine searxng <url>      使用 SearXNG 自定义端点",
       usageMetaso:
@@ -1451,25 +1453,25 @@ export const zhCN: TranslationSchema = {
   },
   webErrors: {
     status:
-      "web_search {status} — try: 搜索后端返回错误；请改写查询，或使用 /search-engine bing|searxng|metaso|tavily|perplexity|exa|brave 切换引擎",
+      "web_search {status} — try: 搜索后端返回错误；请改写查询，或使用 /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama 切换引擎",
     rateLimit429:
       "web_search 429 — try: 等待 10 秒后重试，或改写查询；搜索后端正在对该客户端进行限流",
     forbidden403:
-      "web_search 403 — try: 搜索后端拒绝该客户端访问；使用 /search-engine bing|searxng|metaso|tavily|perplexity|exa|brave 切换引擎，或稍后重试",
+      "web_search 403 — try: 搜索后端拒绝该客户端访问；使用 /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama 切换引擎，或稍后重试",
     serverError5xx:
       "web_search {status} — try: 在浏览器中打开搜索 URL；若能加载则属临时故障，等 30 秒重试即可",
     bingBlocked:
-      "web_search: Bing 反爬页面 — 频率限制或被屏蔽 — try: 等待 30 秒后重试，或使用 /search-engine bing|searxng|metaso|tavily|perplexity|exa|brave 切换引擎",
+      "web_search: Bing 反爬页面 — 频率限制或被屏蔽 — try: 等待 30 秒后重试，或使用 /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama 切换引擎",
     bingNoResults:
-      "web_search: 返回 0 条结果但响应看起来不是正常空结果页（{chars} 字符，前 120 字符：{preview}）— try: 使用更简单的关键词改写查询，或使用 /search-engine bing|searxng|metaso|tavily|perplexity|exa|brave 切换引擎",
+      "web_search: 返回 0 条结果但响应看起来不是正常空结果页（{chars} 字符，前 120 字符：{preview}）— try: 使用更简单的关键词改写查询，或使用 /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama 切换引擎",
     invalidEndpoint:
       'web_search: 无效的 SearXNG 端点 "{endpoint}" — try: 使用 /search-endpoint http://host:port 设置有效的 URL',
     endpointMustBeHttp:
       "web_search: SearXNG 端点必须是 http(s) 协议，当前为 {protocol} — try: 使用 /search-endpoint http://host:port 设置有效的 URL",
     cannotReach:
-      "web_search: 无法访问 SearXNG 服务器 {endpoint} — try: 安装并启动 SearXNG（https://github.com/searxng/searxng，例如 `docker run -d -p 8080:8080 searxng/searxng`），或使用 /search-engine bing|searxng|metaso|tavily|perplexity|exa|brave 切换引擎",
+      "web_search: 无法访问 SearXNG 服务器 {endpoint} — try: 安装并启动 SearXNG（https://github.com/searxng/searxng，例如 `docker run -d -p 8080:8080 searxng/searxng`），或使用 /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama 切换引擎",
     searxngNoResults:
-      "web_search: 返回 0 条结果但 SearXNG 响应看起来不是正常空结果页（{chars} 字符）— try: 使用更简单的关键词改写查询，或使用 /search-engine bing|searxng|metaso|tavily|perplexity|exa|brave 切换引擎",
+      "web_search: 返回 0 条结果但 SearXNG 响应看起来不是正常空结果页（{chars} 字符）— try: 使用更简单的关键词改写查询，或使用 /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama 切换引擎",
     metasoMissingKey:
       "web_search: Metaso 需要 API 密钥 — 设置 METASO_API_KEY，或使用 /search-engine metaso <key> 配置；可在 https://metaso.cn/search-api/playground 获取密钥",
     metasoDailyLimit:
@@ -1479,7 +1481,7 @@ export const zhCN: TranslationSchema = {
     metasoRateLimit:
       "web_search: Metaso 请求频率限制 — 等待后重试，或在 https://metaso.cn/search-api/playground 获取自己的密钥",
     metasoServerError:
-      "web_search: Metaso 服务器错误（{status}）— 稍后重试，或使用 /search-engine bing|searxng|metaso|tavily|perplexity|exa|brave 切换引擎",
+      "web_search: Metaso 服务器错误（{status}）— 稍后重试，或使用 /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama 切换引擎",
     metasoParseError: "web_search: Metaso 返回无法解析的响应（HTTP {status}）— 稍后重试",
     metasoApiError: "web_search: Metaso API 错误（code {code}: {message}）— 稍后重试",
     tavilyMissingKey:
@@ -1487,18 +1489,18 @@ export const zhCN: TranslationSchema = {
     tavilyUnauthorized:
       "web_search: Tavily API 密钥被拒绝 — 检查 TAVILY_API_KEY，或在 https://tavily.com 获取密钥",
     tavilyRateLimit:
-      "web_search: Tavily 请求频率限制或月度配额用尽 — 等待、用 /search-engine bing|searxng|metaso|tavily|perplexity|exa|brave 切换引擎，或升级 Tavily 计划",
+      "web_search: Tavily 请求频率限制或月度配额用尽 — 等待、用 /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama 切换引擎，或升级 Tavily 计划",
     tavilyServerError:
-      "web_search: Tavily 服务器错误（{status}）— 稍后重试，或使用 /search-engine bing|searxng|metaso|tavily|perplexity|exa|brave 切换引擎",
+      "web_search: Tavily 服务器错误（{status}）— 稍后重试，或使用 /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama 切换引擎",
     tavilyParseError: "web_search: Tavily 返回无法解析的响应（HTTP {status}）— 稍后重试",
     perplexityMissingKey:
       "web_search: Perplexity 后端需要 API 密钥 — 设置 PERPLEXITY_API_KEY 环境变量，或在 ~/.reasonix/config.json 中配置 `perplexityApiKey`；在 https://perplexity.ai/settings/api 获取密钥",
     perplexityUnauthorized:
       "web_search: Perplexity API 密钥被拒绝 — 检查 PERPLEXITY_API_KEY，或在 https://perplexity.ai/settings/api 获取密钥",
     perplexityRateLimit:
-      "web_search: Perplexity 请求频率限制 — 等待后重试，或使用 /search-engine bing|searxng|metaso|tavily|perplexity|exa|brave 切换引擎",
+      "web_search: Perplexity 请求频率限制 — 等待后重试，或使用 /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama 切换引擎",
     perplexityServerError:
-      "web_search: Perplexity 服务器错误（{status}）— 稍后重试，或使用 /search-engine bing|searxng|metaso|tavily|perplexity|exa|brave 切换引擎",
+      "web_search: Perplexity 服务器错误（{status}）— 稍后重试，或使用 /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama 切换引擎",
     perplexityParseError: "web_search: Perplexity 返回无法解析的响应（HTTP {status}）— 稍后重试",
     exaMissingKey:
       "web_search: Exa 后端需要 API 密钥 — 设置 EXA_API_KEY 环境变量，或在 ~/.reasonix/config.json 中配置 `exaApiKey`；https://exa.ai 每月 1000 次免费",
@@ -1507,7 +1509,7 @@ export const zhCN: TranslationSchema = {
     exaRateLimit:
       "web_search: Exa 请求频率限制或月度配额用尽 — 等待升级，或在 https://exa.ai/pricing 查看计划",
     exaServerError:
-      "web_search: Exa 服务器错误（{status}）— 稍后重试，或使用 /search-engine bing|searxng|metaso|tavily|perplexity|exa|brave 切换引擎",
+      "web_search: Exa 服务器错误（{status}）— 稍后重试，或使用 /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama 切换引擎",
     exaParseError: "web_search: Exa 返回无法解析的响应（HTTP {status}）— 稍后重试",
     braveMissingKey:
       "web_search: Brave Search 需要 API 密钥 — 设置环境变量 BRAVE_SEARCH_API_KEY（或 BRAVE_API_KEY）或 config 的 `braveApiKey`；https://brave.com/search/api/ 每月 2000 次免费",
@@ -1516,7 +1518,7 @@ export const zhCN: TranslationSchema = {
     braveRateLimit:
       "web_search: Brave Search API 达到速率限制或月度配额用尽 — 等待或升级 https://brave.com/search/api/",
     braveServerError:
-      "web_search: Brave Search 服务器错误（{status}）— 稍后重试，或使用 /search-engine bing|searxng|metaso|tavily|perplexity|exa|brave 切换引擎",
+      "web_search: Brave Search 服务器错误（{status}）— 稍后重试，或使用 /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama 切换引擎",
     braveParseError: "web_search: Brave Search 返回无法解析的响应（HTTP {status}）— 稍后重试",
     fetchStatus:
       "web_fetch {status} for {url} — try: 在浏览器中确认该 URL 能否访问；该状态码表明目标主机返回了错误页面",

--- a/src/server/api/settings.ts
+++ b/src/server/api/settings.ts
@@ -46,6 +46,7 @@ function parseBody(raw: string): SettingsBody {
 
 const VALID_WEB_SEARCH_ENGINES = new Set([
   "bing",
+  "bing-intl",
   "searxng",
   "metaso",
   "tavily",
@@ -182,12 +183,13 @@ export async function handleSettings(
           status: 400,
           body: {
             error:
-              "webSearchEngine must be bing | searxng | metaso | tavily | perplexity | exa | brave | ollama",
+              "webSearchEngine must be bing | bing-intl | searxng | metaso | tavily | perplexity | exa | brave | ollama",
           },
         };
       }
       cfg.webSearchEngine = fields.webSearchEngine as
         | "bing"
+        | "bing-intl"
         | "searxng"
         | "metaso"
         | "tavily"

--- a/src/tools/web.ts
+++ b/src/tools/web.ts
@@ -47,8 +47,17 @@ export interface WebSearchOptions {
   signal?: AbortSignal;
   /** Config path for provider-specific keys. Defaults to ~/.reasonix/config.json. */
   configPath?: string;
-  /** Backend engine: "bing" (scrapes cn.bing.com HTML — default, works from CN without proxy), "searxng" (self-hosted SearXNG), "metaso" (Metaso API), "tavily" (LLM-friendly JSON API), "perplexity" (Perplexity AI), "exa" (Exa API), "brave" (Brave Search API), or "ollama" (Ollama cloud web search). */
-  engine?: "bing" | "searxng" | "metaso" | "tavily" | "perplexity" | "exa" | "brave" | "ollama";
+  /** Backend engine: "bing" (scrapes cn.bing.com HTML — default, works from CN without proxy), "bing-intl" (www.bing.com, indexes international sites), "searxng" (self-hosted SearXNG), "metaso" (Metaso API), "tavily" (LLM-friendly JSON API), "perplexity" (Perplexity AI), "exa" (Exa API), "brave" (Brave Search API), or "ollama" (Ollama cloud web search). */
+  engine?:
+    | "bing"
+    | "bing-intl"
+    | "searxng"
+    | "metaso"
+    | "tavily"
+    | "perplexity"
+    | "exa"
+    | "brave"
+    | "ollama";
   /** Base URL for SearXNG. Default http://localhost:8080. */
   endpoint?: string;
 }
@@ -66,6 +75,7 @@ const USER_AGENT =
 // HTML; the international endpoint wraps them in `bing.com/ck/a?u=a1<base64>`
 // click-tracking redirects we'd have to decode per result.
 const BING_ENDPOINT = "https://cn.bing.com/search";
+const BING_INTL_ENDPOINT = "https://www.bing.com/search";
 const METASO_ENDPOINT = "https://metaso.cn/api/v1";
 const TAVILY_ENDPOINT = "https://api.tavily.com/search";
 const PERPLEXITY_ENDPOINT = "https://api.perplexity.ai/chat/completions";
@@ -259,12 +269,19 @@ export async function webSearch(
   if (opts.engine === "brave") {
     return searchBrave(query, opts);
   }
+  if (opts.engine === "bing-intl") {
+    return searchBing(query, opts, BING_INTL_ENDPOINT);
+  }
   return searchBing(query, opts);
 }
 
-async function searchBing(query: string, opts: WebSearchOptions = {}): Promise<SearchResult[]> {
+async function searchBing(
+  query: string,
+  opts: WebSearchOptions = {},
+  endpoint = BING_ENDPOINT,
+): Promise<SearchResult[]> {
   const topK = Math.max(1, Math.min(10, opts.topK ?? DEFAULT_TOPK));
-  const resp = await fetch(`${BING_ENDPOINT}?q=${encodeURIComponent(query)}`, {
+  const resp = await fetch(`${endpoint}?q=${encodeURIComponent(query)}`, {
     headers: {
       "User-Agent": USER_AGENT,
       Accept: "text/html,application/xhtml+xml,application/xml;q=0.9",
@@ -899,6 +916,23 @@ export function parseSearxngHtmlResults(html: string): SearchResult[] {
   return results;
 }
 
+/** Decode Bing /ck/a click-tracking redirects to the real target. www.bing.com (bing-intl) emits
+ *  these as root-relative `/ck/a?…` hrefs, so resolve against a base before parsing (a bare
+ *  `new URL("/ck/a?…")` throws); the `u=a1…` value is base64url, often unpadded. */
+function unwrapBingUrl(href: string): string {
+  if (!/\/ck\/a\b/.test(href)) return href;
+  try {
+    const u = new URL(href, BING_INTL_ENDPOINT).searchParams.get("u");
+    if (!u) return href;
+    const b64 = u.startsWith("a1") ? u.slice(2) : u;
+    const decoded = Buffer.from(b64, "base64url").toString("utf-8");
+    if (/^https?:\/\//i.test(decoded)) return decoded;
+  } catch {
+    // ignore decode errors and fall back to raw href
+  }
+  return href;
+}
+
 /** Title-anchor + snippet-paragraph passes paired positionally — robust to attribute reorder. */
 export function parseBingResults(html: string): SearchResult[] {
   // DOM walk rather than regex — `<li[^>]*\bclass\b[^>]*>` triggers
@@ -908,7 +942,7 @@ export function parseBingResults(html: string): SearchResult[] {
   for (const li of root.querySelectorAll("li.b_algo")) {
     const anchor = li.querySelector("h2 a[href]");
     if (!anchor) continue;
-    const href = anchor.getAttribute("href");
+    const href = unwrapBingUrl(anchor.getAttribute("href") || "");
     if (!href) continue;
     const title = anchor.textContent.trim();
     if (!title) continue;

--- a/tests/web-tools.test.ts
+++ b/tests/web-tools.test.ts
@@ -112,6 +112,33 @@ describe("parseBingResults", () => {
     `;
     expect(parseBingResults(html)).toEqual([]);
   });
+
+  // www.bing.com (bing-intl) wraps organic links in /ck/a click-tracking redirects,
+  // emitted as root-relative hrefs with a base64url-encoded target in the `u=a1…` param.
+  it("decodes relative /ck/a click-tracking hrefs to the real target", () => {
+    const target = "https://github.com/flutter/flutter";
+    const u = `a1${Buffer.from(target).toString("base64url")}`;
+    const html = `
+      <li class="b_algo">
+        <h2><a href="/ck/a?!&&p=abc123&u=${u}&ntb=1">Flutter repo</a></h2>
+        <div class="b_caption"><p>The Flutter SDK.</p></div>
+      </li>
+    `;
+    const items = parseBingResults(html);
+    expect(items).toHaveLength(1);
+    expect(items[0].url).toBe(target);
+  });
+
+  it("decodes absolute bing.com/ck/a hrefs too", () => {
+    const target = "https://en.wikipedia.org/wiki/Dart";
+    const u = `a1${Buffer.from(target).toString("base64url")}`;
+    const html = `
+      <li class="b_algo">
+        <h2><a href="https://www.bing.com/ck/a?u=${u}">Dart</a></h2>
+      </li>
+    `;
+    expect(parseBingResults(html)[0].url).toBe(target);
+  });
 });
 
 describe("parseSearxngHtmlResults", () => {


### PR DESCRIPTION
Closes #1921.

cn.bing.com 的索引不包含境外站点（GitHub、Wikipedia 等），开代理也搜不到。加了个 bing-intl 选项，endpoint 切到 www.bing.com，跟 bing 一样不需要 API key，代理用户直接切就行。