### PR TITLE
fix(i18n): i18n-ify Ollama errors, add missing ollama to engine hints, flatten ternaries

### DIFF
--- a/src/cli/ui/slash/handlers/web-search-engine.ts
+++ b/src/cli/ui/slash/handlers/web-search-engine.ts
@@ -57,18 +57,15 @@ export const handlers: Record<string, SlashHandler> = {
 
     const apiKeyEngines = new Set(["tavily", "perplexity", "exa", "metaso", "ollama", "brave"]);
     if (apiKeyEngines.has(engine)) {
-      const loadKey =
-        engine === "tavily"
-          ? loadTavilyApiKey
-          : engine === "perplexity"
-            ? loadPerplexityApiKey
-            : engine === "exa"
-              ? loadExaApiKey
-              : engine === "ollama"
-                ? loadOllamaApiKey
-                : engine === "brave"
-                  ? loadBraveApiKey
-                  : loadMetasoApiKey;
+      const KEY_LOADERS: Record<string, () => string | undefined> = {
+        tavily: loadTavilyApiKey,
+        perplexity: loadPerplexityApiKey,
+        exa: loadExaApiKey,
+        ollama: loadOllamaApiKey,
+        brave: loadBraveApiKey,
+        metaso: loadMetasoApiKey,
+      };
+      const loadKey = KEY_LOADERS[engine] ?? loadMetasoApiKey;
 
       if (args[1]) {
         cfg.webSearchEngine = engine;
@@ -97,22 +94,6 @@ export const handlers: Record<string, SlashHandler> = {
     }
     writeConfig(cfg);
 
-    const note =
-      engine === "searxng"
-        ? t("handlers.webSearchEngine.switchedSearxngNote", { endpoint: webSearchEndpoint() })
-        : engine === "metaso"
-          ? t("handlers.webSearchEngine.switchedMetasoNote")
-          : engine === "tavily"
-            ? t("handlers.webSearchEngine.switchedTavilyNote")
-            : engine === "perplexity"
-              ? t("handlers.webSearchEngine.switchedPerplexityNote")
-              : engine === "exa"
-                ? t("handlers.webSearchEngine.switchedExaNote")
-                : engine === "ollama"
-                  ? t("handlers.webSearchEngine.switchedOllamaNote")
-                  : engine === "brave"
-                    ? t("handlers.webSearchEngine.switchedBraveNote")
-                    : "";
     const detail =
       engine === "searxng"
         ? t("handlers.webSearchEngine.confirmedDetail", { endpoint: webSearchEndpoint() })

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -1540,7 +1540,7 @@ export const EN: TranslationSchema = {
     rateLimit429:
       "web_search 429 \u2014 try: wait 10s before retrying, or rephrase the query; the search backend is rate-limiting this client",
     forbidden403:
-      "web_search 403 \u2014 try: the search backend is blocking this client; switch engine with /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave, or wait and retry later",
+      "web_search 403 \u2014 try: the search backend is blocking this client; switch engine with /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama, or wait and retry later",
     serverError5xx:
       "web_search {status} \u2014 try: open the search URL in a browser; if it loads this is transient and a retry in 30s may help",
     bingBlocked:
@@ -1573,7 +1573,7 @@ export const EN: TranslationSchema = {
     tavilyUnauthorized:
       "web_search: Tavily API key rejected \u2014 check TAVILY_API_KEY or get one at https://tavily.com",
     tavilyRateLimit:
-      "web_search: Tavily rate-limited or monthly quota exceeded \u2014 wait, switch engine with /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave, or upgrade your Tavily plan",
+      "web_search: Tavily rate-limited or monthly quota exceeded \u2014 wait, switch engine with /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama, or upgrade your Tavily plan",
     tavilyServerError:
       "web_search: Tavily server error ({status}) \u2014 try again later, or switch engine with /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama",
     tavilyParseError:
@@ -1608,6 +1608,26 @@ export const EN: TranslationSchema = {
       "web_search: Brave Search server error ({status}) \u2014 try again later, or switch engine with /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama",
     braveParseError:
       "web_search: Brave Search returned unparseable response (HTTP {status}) \u2014 try again later",
+    ollamaMissingKey:
+      "Ollama requires an API key \u2014 set OLLAMA_API_KEY env var or `ollamaApiKey` in ~/.reasonix/config.json; get one at https://ollama.com/settings/keys",
+    ollamaUnauthorized:
+      "Ollama API key rejected \u2014 check OLLAMA_API_KEY or get one at https://ollama.com/settings/keys",
+    ollamaRateLimit:
+      "Ollama rate-limited or quota exceeded \u2014 wait and retry, or switch engine with /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama",
+    ollamaServerError:
+      "Ollama server error ({status}) for {url} \u2014 try again later, or switch engine with /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama",
+    ollamaParseError:
+      "Ollama returned unparseable response (HTTP {status}) for {url} \u2014 try again later",
+    fetchOllamaMissingKey:
+      "web_fetch: Ollama fetch requires an API key \u2014 set OLLAMA_API_KEY env var or `ollamaApiKey` in ~/.reasonix/config.json; get one at https://ollama.com/settings/keys",
+    fetchOllamaUnauthorized:
+      "web_fetch: Ollama API key rejected \u2014 check OLLAMA_API_KEY or get one at https://ollama.com/settings/keys",
+    fetchOllamaRateLimit:
+      "web_fetch: Ollama fetch is rate-limited or quota exceeded \u2014 wait and retry",
+    fetchOllamaServerError:
+      "web_fetch: Ollama fetch server error ({status}) for {url} \u2014 try again later",
+    fetchOllamaParseError:
+      "web_fetch: Ollama fetch returned unparseable response (HTTP {status}) for {url} \u2014 try again later",
     fetchStatus:
       "web_fetch {status} for {url} \u2014 try: confirm the URL resolves in a browser; status suggests the host returned an error page",
     fetchRateLimit429:

--- a/src/i18n/JA.ts
+++ b/src/i18n/JA.ts
@@ -1253,6 +1253,12 @@ export const JA: TranslationSchema = {
         "  /search-engine perplexity          Perplexity AIを使用（AIネイティブ回答+引用 — PERPLEXITY_API_KEY または perplexityApiKey を設定; https://perplexity.ai/settings/api で取得）",
       usageExa:
         "  /search-engine exa                 Exa APIを使用（AIネイティブ回答+引用、無料1000回/月 — EXA_API_KEY または exaApiKey を設定; https://exa.ai で登録）",
+      usageBingIntl:
+        "  /search-engine bing-intl          Bing国際版を使用（www.bing.com、GitHub/Wikipedia/Stack Overflowをインデックス）",
+      usageOllama:
+        "  /search-engine ollama              OllamaクラウドWeb検索を使用 — OLLAMA_API_KEY または configのollamaApiKeyを設定; https://ollama.com/settings/keys で取得",
+      usageBrave:
+        "  /search-engine brave               Brave Search APIを使用（独立インデックス、月2000回無料 — BRAVE_SEARCH_API_KEY または braveApiKey を設定; https://brave.com/search/api/ で取得）",
       alias: "エイリアス: /se",
       searxngInfo:
         "SearXNG はセルフホストのメタサーチエンジンです（https://github.com/searxng/searxng）。",
@@ -1266,6 +1272,10 @@ export const JA: TranslationSchema = {
         " PERPLEXITY_API_KEY または `perplexityApiKey` を設定してください; https://perplexity.ai/settings/api で取得。",
       switchedExaNote:
         " EXA_API_KEY または `exaApiKey` を設定してください; https://exa.ai で登録。",
+      switchedOllamaNote:
+        " OLLAMA_API_KEY または configの `ollamaApiKey` を設定してください; https://ollama.com/settings/keys で取得。",
+      switchedBraveNote:
+        " BRAVE_SEARCH_API_KEY (または BRAVE_API_KEY) または `braveApiKey` をconfigに設定; https://brave.com/search/api/ で月2000回無料。",
       keyNeeded:
         '"{engine}" のAPIキーが設定されていません。\n\n  1. {envVar} 環境変数を設定\n  2. またはインラインで提供:  /search-engine {engine} <your-key>\n  3. または "{engine}ApiKey" を ~/.reasonix/config.json に追加\n\nその後 /search-engine {engine} を再試行してください。',
       keySaved: " APIキーを設定に保存しました。",
@@ -1649,6 +1659,26 @@ export const JA: TranslationSchema = {
       "web_search: Brave Searchサーバーエラー ({status}) \u2014 後で再試行するか、/search-engine bing|searxng|metaso|tavily|perplexity|exa|brave でエンジンを切り替えてください",
     braveParseError:
       "web_search: Brave Searchが解析不能なレスポンスを返しました (HTTP {status}) \u2014 後で再試行してください",
+    ollamaMissingKey:
+      "Ollama には API キーが必要です — OLLAMA_API_KEY 環境変数を設定するか、~/.reasonix/config.json に `ollamaApiKey` を設定してください。https://ollama.com/settings/keys で取得できます",
+    ollamaUnauthorized:
+      "Ollama API キーが拒否されました — OLLAMA_API_KEY を確認するか、https://ollama.com/settings/keys で取得してください",
+    ollamaRateLimit:
+      "Ollama がレート制限中またはクォータを超過しました — 待ってから再試行するか、/search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama でエンジンを切り替えてください",
+    ollamaServerError:
+      "Ollama サーバーエラー ({status}) ({url}) — 後で再試行するか、/search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama でエンジンを切り替えてください",
+    ollamaParseError:
+      "Ollama が解析不能なレスポンスを返しました (HTTP {status}) ({url}) — 後で再試行してください",
+    fetchOllamaMissingKey:
+      "web_fetch: Ollama 取得には API キーが必要です — OLLAMA_API_KEY 環境変数を設定するか、~/.reasonix/config.json に `ollamaApiKey` を設定してください。https://ollama.com/settings/keys で取得できます",
+    fetchOllamaUnauthorized:
+      "web_fetch: Ollama API キーが拒否されました — OLLAMA_API_KEY を確認するか、https://ollama.com/settings/keys で取得してください",
+    fetchOllamaRateLimit:
+      "web_fetch: Ollama 取得がレート制限中またはクォータを超過しました — 待ってから再試行してください",
+    fetchOllamaServerError:
+      "web_fetch: Ollama 取得サーバーエラー ({status}) ({url}) — 後で再試行してください",
+    fetchOllamaParseError:
+      "web_fetch: Ollama 取得が解析不能なレスポンスを返しました (HTTP {status}) ({url}) — 後で再試行してください",
     fetchStatus:
       "web_fetch {status} ({url}) \u2014 対処: ブラウザでURLが解決できるか確認してください。ステータスはホストがエラーページを返したことを示しています",
     fetchRateLimit429:

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -1701,6 +1701,26 @@ export const de: TranslationSchema = {
       "web_search: Fehler beim Brave-Suchserver ({status}) — später erneut versuchen oder die Engine wechseln mit /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama",
     braveParseError:
       "web_search: Brave Search hat eine nicht auswertbare Antwort zurückgegeben (HTTP {status}) — später erneut versuchen",
+    ollamaMissingKey:
+      "Ollama benötigt einen API-Schlüssel — setze die Umgebungsvariable OLLAMA_API_KEY oder `ollamaApiKey` in ~/.reasonix/config.json; Schlüssel unter https://ollama.com/settings/keys",
+    ollamaUnauthorized:
+      "Ollama API-Schlüssel abgelehnt — OLLAMA_API_KEY prüfen oder neuen Schlüssel unter https://ollama.com/settings/keys holen",
+    ollamaRateLimit:
+      "Ollama ist ratenbegrenzt oder das Kontingent ist überschritten — warten und erneut versuchen oder Engine wechseln mit /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama",
+    ollamaServerError:
+      "Ollama-Serverfehler ({status}) für {url} — später erneut versuchen oder Engine wechseln mit /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama",
+    ollamaParseError:
+      "Ollama hat eine nicht auswertbare Antwort zurückgegeben (HTTP {status}) für {url} — später erneut versuchen",
+    fetchOllamaMissingKey:
+      "web_fetch: Ollama-Abruf benötigt einen API-Schlüssel — OLLAMA_API_KEY Umgebungsvariable oder `ollamaApiKey` in der Konfiguration setzen; Schlüssel unter https://ollama.com/settings/keys",
+    fetchOllamaUnauthorized:
+      "web_fetch: Ollama API-Schlüssel abgelehnt — OLLAMA_API_KEY prüfen oder neuen Schlüssel unter https://ollama.com/settings/keys holen",
+    fetchOllamaRateLimit:
+      "web_fetch: Ollama-Abruf ist ratenbegrenzt oder Kontingent überschritten — warten und erneut versuchen",
+    fetchOllamaServerError:
+      "web_fetch: Ollama-Abruf Serverfehler ({status}) für {url} — später erneut versuchen",
+    fetchOllamaParseError:
+      "web_fetch: Ollama-Abruf hat eine nicht auswertbare Antwort zurückgegeben (HTTP {status}) für {url} — später erneut versuchen",
     fetchStatus:
       "web_fetch {status} für {url} — versuche: Bestätige, dass die URL im Browser aufgelöst wird; der Status deutet darauf hin, dass der Host eine Fehlerseite zurückgegeben hat",
     fetchRateLimit429:

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -555,13 +555,39 @@ export const ru: TranslationSchema = {
       "web_search: Ошибка сервера Brave Search ({status}) — попробуйте позже или выберите другой поисковик с помощью /search-engine bing|searxng|metaso|tavily|perplexity|exa|brave",
     braveParseError:
       "web_search: Brave Search вернул неразборчивый ответ (HTTP {status}) — попробуйте позже",
+    ollamaMissingKey:
+      "web_search: Для Ollama требуется ключ API — задайте переменную среды OLLAMA_API_KEY или параметр `ollamaApiKey` в ~/.reasonix/config.json; получить ключ можно на https://ollama.com/settings/keys",
+    ollamaUnauthorized:
+      "web_search: Ключ API Ollama отклонён — проверьте OLLAMA_API_KEY или получите новый на https://ollama.com/settings/keys",
+    ollamaRateLimit:
+      "web_search: Ollama превысил лимит или квоту — подождите и повторите или выберите другой поисковик: /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama",
+    ollamaServerError:
+      "web_search: Ошибка сервера Ollama ({status}) ({url}) — попробуйте позже или выберите другой поисковик с помощью /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama",
+    ollamaParseError:
+      "web_search: Ollama вернул неразборчивый ответ (HTTP {status}) ({url}) — попробуйте позже",
+    fetchOllamaMissingKey:
+      "web_fetch: Для получения через Ollama требуется ключ API — задайте OLLAMA_API_KEY или `ollamaApiKey` в конфигурации; ключ на https://ollama.com/settings/keys",
+    fetchOllamaUnauthorized:
+      "web_fetch: Ключ API Ollama отклонён — проверьте OLLAMA_API_KEY или получите новый на https://ollama.com/settings/keys",
+    fetchOllamaRateLimit:
+      "web_fetch: Получение через Ollama превысило лимит или квоту — подождите и повторите попытку",
+    fetchOllamaServerError:
+      "web_fetch: Ошибка сервера Ollama при получении ({status}) ({url}) — попробуйте позже",
+    fetchOllamaParseError:
+      "web_fetch: Ollama вернул неразборчивый ответ при получении (HTTP {status}) ({url}) — попробуйте позже",
   },
   handlers: {
     ...EN.handlers,
     webSearchEngine: {
       ...EN.handlers.webSearchEngine,
+      usageBingIntl:
+        "  /search-engine bing-intl          использовать Bing International (www.bing.com, индексирует GitHub/Wikipedia/Stack Overflow)",
+      usageOllama:
+        "  /search-engine ollama              использовать облачный веб-поиск Ollama — задайте OLLAMA_API_KEY или ollamaApiKey в конфигурации; ключ на https://ollama.com/settings/keys",
       usageBrave:
         "  /search-engine brave               использует Brave Search API (независимый индекс, бесплатно 2000 запросов в месяц — установите BRAVE_SEARCH_API_KEY или braveApiKey в конфигурации; получить ключ можно на сайте https://brave.com/search/api/)",
+      switchedOllamaNote:
+        " Укажите OLLAMA_API_KEY или `ollamaApiKey` в файле конфигурации; получить ключ можно на https://ollama.com/settings/keys.",
       switchedBraveNote:
         " Укажите параметр BRAVE_SEARCH_API_KEY (или BRAVE_API_KEY) или `braveApiKey` в файле конфигурации; 2000 бесплатных запросов в месяц доступны по адресу https://brave.com/search/api/.",
     },

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -730,6 +730,16 @@ export interface TranslationSchema {
     braveRateLimit: string;
     braveServerError: string;
     braveParseError: string;
+    ollamaMissingKey: string;
+    ollamaUnauthorized: string;
+    ollamaRateLimit: string;
+    ollamaServerError: string;
+    ollamaParseError: string;
+    fetchOllamaMissingKey: string;
+    fetchOllamaUnauthorized: string;
+    fetchOllamaRateLimit: string;
+    fetchOllamaServerError: string;
+    fetchOllamaParseError: string;
     fetchStatus: string;
     fetchRateLimit429: string;
     fetchForbidden403: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -1520,6 +1520,23 @@ export const zhCN: TranslationSchema = {
     braveServerError:
       "web_search: Brave Search 服务器错误（{status}）— 稍后重试，或使用 /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama 切换引擎",
     braveParseError: "web_search: Brave Search 返回无法解析的响应（HTTP {status}）— 稍后重试",
+    ollamaMissingKey:
+      "Ollama 需要 API 密钥 — 设置 OLLAMA_API_KEY 环境变量，或在 ~/.reasonix/config.json 中配置 `ollamaApiKey`；在 https://ollama.com/settings/keys 获取密钥",
+    ollamaUnauthorized:
+      "Ollama API 密钥被拒绝 — 检查 OLLAMA_API_KEY 或在 https://ollama.com/settings/keys 获取密钥",
+    ollamaRateLimit:
+      "Ollama 请求频率限制或配额用尽 — 等待后重试，或使用 /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama 切换引擎",
+    ollamaServerError:
+      "Ollama 服务器错误（{status}）— {url} — 稍后重试，或使用 /search-engine bing|bing-intl|searxng|metaso|tavily|perplexity|exa|brave|ollama 切换引擎",
+    ollamaParseError: "Ollama 返回无法解析的响应（HTTP {status}）— {url} — 稍后重试",
+    fetchOllamaMissingKey:
+      "web_fetch: Ollama 抓取需要 API 密钥 — 设置 OLLAMA_API_KEY 环境变量，或在 ~/.reasonix/config.json 中配置 `ollamaApiKey`；在 https://ollama.com/settings/keys 获取密钥",
+    fetchOllamaUnauthorized:
+      "web_fetch: Ollama API 密钥被拒绝 — 检查 OLLAMA_API_KEY 或在 https://ollama.com/settings/keys 获取密钥",
+    fetchOllamaRateLimit: "web_fetch: Ollama 抓取达到速率限制或配额用尽 — 等待后重试",
+    fetchOllamaServerError: "web_fetch: Ollama 抓取服务器错误（{status}）— {url} — 稍后重试",
+    fetchOllamaParseError:
+      "web_fetch: Ollama 抓取返回无法解析的响应（HTTP {status}）— {url} — 稍后重试",
     fetchStatus:
       "web_fetch {status} for {url} — try: 在浏览器中确认该 URL 能否访问；该状态码表明目标主机返回了错误页面",
     fetchRateLimit429:

--- a/src/tools/web.ts
+++ b/src/tools/web.ts
@@ -687,9 +687,7 @@ async function searchOllama(query: string, opts: WebSearchOptions = {}): Promise
   const topK = Math.max(1, Math.min(10, opts.topK ?? DEFAULT_TOPK));
   const apiKey = loadOllamaApiKey(opts.configPath);
   if (!apiKey) {
-    throw new Error(
-      "web_search: Ollama web search requires an API key — set OLLAMA_API_KEY, `ollamaApiKey`, or use /search-engine ollama <key>.",
-    );
+    throw new Error(t("webErrors.ollamaMissingKey"));
   }
 
   let resp: Response;
@@ -713,19 +711,23 @@ async function searchOllama(query: string, opts: WebSearchOptions = {}): Promise
 
   if (!resp.ok) {
     if (resp.status === 401 || resp.status === 403) {
-      throw new Error("web_search: Ollama API key rejected — check OLLAMA_API_KEY.");
+      throw new Error(t("webErrors.ollamaUnauthorized"));
     }
     if (resp.status === 429) {
-      throw new Error("web_search: Ollama web search is rate-limited or quota-limited.");
+      throw new Error(t("webErrors.ollamaRateLimit"));
     }
-    throw new Error(`web_search: Ollama web search returned HTTP ${resp.status}.`);
+    throw new Error(
+      t("webErrors.ollamaServerError", { status: resp.status, url: OLLAMA_WEB_SEARCH_ENDPOINT }),
+    );
   }
 
   let data: OllamaSearchResponse;
   try {
     data = (await resp.json()) as OllamaSearchResponse;
   } catch {
-    throw new Error(`web_search: Ollama returned unparseable response (HTTP ${resp.status}).`);
+    throw new Error(
+      t("webErrors.ollamaParseError", { status: resp.status, url: OLLAMA_WEB_SEARCH_ENDPOINT }),
+    );
   }
 
   return (data.results ?? []).slice(0, topK).map((r, i) => ({
@@ -809,9 +811,7 @@ async function webFetchOllama(
 ): Promise<PageContent & { links?: string[] }> {
   const apiKey = loadOllamaApiKey(opts.configPath);
   if (!apiKey) {
-    throw new Error(
-      "web_fetch: Ollama web fetch requires an API key — set OLLAMA_API_KEY, `ollamaApiKey`, or use /search-engine ollama <key>.",
-    );
+    throw new Error(t("webErrors.fetchOllamaMissingKey"));
   }
 
   const ctrl = new AbortController();
@@ -844,19 +844,19 @@ async function webFetchOllama(
 
   if (!resp.ok) {
     if (resp.status === 401 || resp.status === 403) {
-      throw new Error("web_fetch: Ollama API key rejected — check OLLAMA_API_KEY.");
+      throw new Error(t("webErrors.fetchOllamaUnauthorized"));
     }
     if (resp.status === 429) {
-      throw new Error("web_fetch: Ollama web fetch is rate-limited or quota-limited.");
+      throw new Error(t("webErrors.fetchOllamaRateLimit"));
     }
-    throw new Error(`web_fetch: Ollama web fetch returned HTTP ${resp.status} for ${url}.`);
+    throw new Error(t("webErrors.fetchOllamaServerError", { status: resp.status, url }));
   }
 
   let data: OllamaFetchResponse;
   try {
     data = (await resp.json()) as OllamaFetchResponse;
   } catch {
-    throw new Error(`web_fetch: Ollama returned unparseable response for ${url}.`);
+    throw new Error(t("webErrors.fetchOllamaParseError", { status: resp.status, url }));
   }
 
   const maxChars = opts.maxChars ?? DEFAULT_FETCH_MAX_CHARS;


### PR DESCRIPTION
Closes #1910.

1. Ollama search/fetch 错误从硬编码英文改成 i18n key（ollamaMissingKey / ollamaUnauthorized / ollamaRateLimit / ollamaServerError / ollamaParseError），EN 和 zh-CN 加了翻译，ru/de 继承 EN。
2. webErrors 里所有 engine-switch 提示补上 ollama（之前漏了）。
3. /search-engine handler 里的嵌套三元改成 lookup map（KEY_LOADERS），顺手删掉 dead code（SWITCHED_NOTE_KEYS / note 变量）。