### PR TITLE
fix(cli): preserve bundled CLI version metadata

### DIFF
--- a/scripts/copy-dashboard-vendor-css.mjs
+++ b/scripts/copy-dashboard-vendor-css.mjs
@@ -1,4 +1,4 @@
-import { copyFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { copyFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 
 const targets = [
@@ -15,6 +15,12 @@ for (const [src, dst] of targets) {
 // Marks dist/cli/ as ESM so Node skips the CJS-then-ESM reparse warning when
 // the bundle is loaded outside its own npm install (e.g. desktop sidecar).
 const cliMarker = resolve("dist/cli/package.json");
+const rootPackage = JSON.parse(readFileSync(resolve("package.json"), "utf8"));
+const cliPackage = {
+  name: rootPackage.name ?? "reasonix",
+  version: rootPackage.version ?? "0.0.0-dev",
+  type: "module",
+};
 mkdirSync(dirname(cliMarker), { recursive: true });
-writeFileSync(cliMarker, `${JSON.stringify({ type: "module" }, null, 2)}\n`);
+writeFileSync(cliMarker, `${JSON.stringify(cliPackage, null, 2)}\n`);
 console.log(`wrote ${cliMarker}`);

--- a/tests/cli-bundle-version-marker.test.ts
+++ b/tests/cli-bundle-version-marker.test.ts
@@ -1,0 +1,38 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+describe("copy-dashboard-vendor-css", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "reasonix-copy-vendor-"));
+    mkdirSync(join(tmp, "node_modules/highlight.js/styles"), { recursive: true });
+    mkdirSync(join(tmp, "node_modules/uplot/dist"), { recursive: true });
+    writeFileSync(join(tmp, "node_modules/highlight.js/styles/github-dark.min.css"), "/* hljs */");
+    writeFileSync(join(tmp, "node_modules/uplot/dist/uPlot.min.css"), "/* uplot */");
+    writeFileSync(
+      join(tmp, "package.json"),
+      JSON.stringify({ name: "reasonix", version: "9.8.7" }),
+    );
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("writes package metadata for the bundled CLI", () => {
+    const script = resolve("scripts/copy-dashboard-vendor-css.mjs");
+    const run = spawnSync(process.execPath, [script], { cwd: tmp, encoding: "utf8" });
+
+    expect(run.status).toBe(0);
+    const marker = JSON.parse(readFileSync(join(tmp, "dist/cli/package.json"), "utf8"));
+    expect(marker).toEqual({
+      name: "reasonix",
+      version: "9.8.7",
+      type: "module",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- write name/version/type into dist/cli/package.json during build
- keep the ESM marker while preserving the package version for app-bundled CLI runs
- add regression coverage for the generated CLI package marker

## Why
The app-bundled CLI loads from dist/cli outside the normal npm package root. If dist/cli/package.json only contains { "type": "module" }, VERSION lookup can fall back to 0.0.0-dev. Writing the package name and version keeps `reasonix --version` aligned with the root package.

## Verification
- `npm test -- --run tests/cli-bundle-version-marker.test.ts tests/version.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `node dist/cli/index.js --version` -> `0.52.0`
- `git diff --check`

## Local pre-push note
A full `npm run verify` run passed build/lint/typecheck and the rest of the suite, but the existing prompt-budget guard failed locally: `expected 26765 to be less than or equal to 26500` in `tests/prompt-budget.test.ts`. This PR does not touch prompt construction.