### PR TITLE
fix(ink): defer useBoxMetrics measure off the React commit batch

### DIFF
--- a/packages/ink/src/index.ts
+++ b/packages/ink/src/index.ts
@@ -128,13 +128,23 @@ export function useBoxMetrics(ref: { current: DOMElement | null }): {
 } {
   const [size, setSize] = useState({ width: 0, height: 0 });
   const lastRef = useRef<DOMElement | null>(null);
+  const scheduledRef = useRef(false);
   useEffect(() => {
     if (!ref.current) return;
     lastRef.current = ref.current;
-    const { width, height } = measureElement(ref.current);
-    setSize((prev) =>
-      prev.width === width && prev.height === height ? prev : { width, height },
-    );
+    if (scheduledRef.current) return;
+    scheduledRef.current = true;
+    // Defer measure off the React commit batch — re-measuring synchronously
+    // in the same depth-counted chain crashes with "Maximum update depth
+    // exceeded" when Box content doesn't converge in one layout pass.
+    setTimeout(() => {
+      scheduledRef.current = false;
+      if (!ref.current) return;
+      const { width, height } = measureElement(ref.current);
+      setSize((prev) =>
+        prev.width === width && prev.height === height ? prev : { width, height },
+      );
+    }, 0);
   });
   return size;
 }

--- a/tests/ink-update-depth-repro.test.tsx
+++ b/tests/ink-update-depth-repro.test.tsx
@@ -45,19 +45,21 @@ describe("Ink update-depth repro candidates", () => {
     r.unmount();
   });
 
-  it("useBoxMetrics: rendering from own measurement never converges", async () => {
-    // Whether React's nested-update guard fires depends on event-loop timing
-    // (a Linux runner doesn't trip what Windows trips in the same wall clock).
-    // The deterministic property is render count: stable layouts converge in
-    // 2–3 renders, the broken pattern compounds without bound. Counting is
-    // the loop-detection signal; the React error is just one possible
-    // downstream symptom.
+  it("useBoxMetrics: oscillating call sites no longer crash React's depth guard", async () => {
+    // useBoxMetrics defers each measure off the React commit batch
+    // (setTimeout 0), so a Box that renders from its own measurement
+    // still oscillates between heights but never trips "Maximum update
+    // depth exceeded". The property under test is the absence of a
+    // crash + the presence of the underlying anti-pattern (heights
+    // alternate, proving it's not silently converging).
     captureErrors();
     let stableRenders = 0;
+    const stableHeights = new Set<number>();
     function Stable() {
       const ref = React.useRef(null!);
-      useBoxMetrics(ref);
+      const m = useBoxMetrics(ref);
       stableRenders++;
+      stableHeights.add(m.height);
       return (
         <Box ref={ref} flexDirection="column">
           <Text>a</Text>
@@ -65,12 +67,11 @@ describe("Ink update-depth repro candidates", () => {
         </Box>
       );
     }
-    let oscRenders = 0;
+    const oscHeights = new Set<number>();
     function Oscillator() {
       const ref = React.useRef(null!);
       const m = useBoxMetrics(ref);
-      oscRenders++;
-      // height 0/even → 1 child → measure=1 (odd); odd → 2 children → measure=2 (even).
+      oscHeights.add(m.height);
       const extra = m.height % 2 === 1;
       return (
         <Box ref={ref} flexDirection="column">
@@ -85,13 +86,10 @@ describe("Ink update-depth repro candidates", () => {
     const b = render(<Oscillator />);
     await new Promise((res) => setTimeout(res, 80));
     b.unmount();
-    // Stable converges in a handful of renders. The broken pattern compounds
-    // — even a slow CI runner clears ~20 cycles in 80ms; local Node does
-    // hundreds. The thresholds are deliberately loose to stay robust across
-    // runner speeds; the property under test is "doesn't converge", not a
-    // specific count.
+    expect(hasMaxDepth()).toBe(false);
     expect(stableRenders).toBeLessThan(10);
-    expect(oscRenders).toBeGreaterThan(15);
+    expect(stableHeights.size).toBeLessThanOrEqual(2);
+    expect(oscHeights.size).toBeGreaterThanOrEqual(2);
   });
 
   it("useAnimationFrame: many subscribers with short interval does not loop alone", async () => {


### PR DESCRIPTION
## Summary

\`useBoxMetrics\` ran a \`useEffect\` with no dependency array and called \`setSize\` inside, so any Box whose content shape depended on its own measurement (directly, or transitively via a store-reported height) oscillated within a single React commit batch and crashed with **Maximum update depth exceeded** on chat startup.

The crash surfaced in two distinct stacks reported by users on \`reasonix@0.53.1\`:

1. **Direct** — \`setSize\` inside \`useBoxMetrics\` → \`getRootForUpdatedFiber\` throws.
2. **Indirect** — \`MeasuredCard.useEffect\` reports a new height after each oscillating measurement → \`chat-scroll-store.setMaxScroll\` schedules debounced \`flushShrink\` → \`flushShrink\` fires → \`set()\` notifies → next \`forceStoreRerender\` throws.

Both point to the same root cause: a synchronous \`setState\`-inside-\`useEffect\` chain that ratchets React's \`nestedUpdateCount\` without a macrotask boundary letting React reset.

## Fix

Schedule each measure via \`setTimeout(0)\` and dedupe in-flight measurements with a ref. The store update that follows now starts a fresh root render instead of chaining inside the depth counter, so:

- Stable layouts converge in 1–2 macrotask cycles (no perceivable delay in TUI).
- Oscillating call sites (the underlying anti-pattern in the caller) still don't converge to a single value — they just stop crashing.

## Test plan

- [x] Updated the oscillator repro test in \`tests/ink-update-depth-repro.test.tsx\` to assert the new property: no \`Maximum update depth\` crash + heights still alternate (proving we haven't silently masked the anti-pattern).
- [x] \`npm test -- tests/ink-update-depth-repro.test.tsx tests/cardstream-architecture.test.tsx\` — 7/7 passing.
- [x] Pre-push \`npm run verify\` — full lint + typecheck + 3786 tests pass.