### PR TITLE
feat(desktop): grant pending tool/path approval with Enter key

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -1586,11 +1586,50 @@ function TabRuntime({
         if (target?.tagName === "INPUT" || target?.tagName === "TEXTAREA") return;
         e.preventDefault();
         abort();
+      } else if (e.key === "Enter" && !mod && !e.shiftKey && !e.altKey) {
+        // Defer to any control that already handles Enter — native inputs/buttons,
+        // ARIA button/link widgets (sidebar rows, file pills), or anything that called
+        // preventDefault — so we only grant when focus is on inert layout (#2015).
+        if (e.defaultPrevented) return;
+        const target = e.target as HTMLElement | null;
+        if (
+          target?.isContentEditable ||
+          target?.closest('input, textarea, button, select, a, [role="button"], [role="link"]')
+        ) {
+          return;
+        }
+        if (settingsOpen || jobsOpen || wdOpen) return;
+        // Enter grants the pending authorization prompt (run once), matching the
+        // TUI where Enter confirms the highlighted choice (#1962).
+        const confirm = state.pendingConfirms.at(-1);
+        if (confirm) {
+          e.preventDefault();
+          resolveConfirm(confirm.id, { type: "run_once" });
+          return;
+        }
+        const pathAccess = state.pendingPathAccess.at(-1);
+        if (pathAccess) {
+          e.preventDefault();
+          resolvePathAccess(pathAccess.id, { type: "run_once" });
+        }
       }
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [active, state.busy, abort, newChat, settingsOpen, openSettingsAt]);
+  }, [
+    active,
+    state.busy,
+    state.pendingConfirms,
+    state.pendingPathAccess,
+    resolveConfirm,
+    resolvePathAccess,
+    settingsOpen,
+    jobsOpen,
+    wdOpen,
+    abort,
+    newChat,
+    openSettingsAt,
+  ]);
 
   const commands = buildCommands({
     newChat: () => {

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -1944,6 +1944,32 @@ function TabRuntime({
         if (settingsOpen || aboutOpen || jobsOpen || wdOpen) return;
         e.preventDefault();
         abort();
+      } else if (e.key === "Enter" && !mod && !e.shiftKey && !e.altKey) {
+        // Defer to any control that already handles Enter — native inputs/buttons,
+        // ARIA button/link widgets (sidebar rows, file pills), or anything that called
+        // preventDefault — so we only grant when focus is on inert layout (#2015).
+        if (e.defaultPrevented) return;
+        const target = e.target as HTMLElement | null;
+        if (
+          target?.isContentEditable ||
+          target?.closest('input, textarea, button, select, a, [role="button"], [role="link"]')
+        ) {
+          return;
+        }
+        if (settingsOpen || aboutOpen || jobsOpen || wdOpen) return;
+        // Enter grants the pending authorization prompt (run once), matching the
+        // TUI where Enter confirms the highlighted choice (#1962).
+        const confirm = state.pendingConfirms.at(-1);
+        if (confirm) {
+          e.preventDefault();
+          resolveConfirm(confirm.id, { type: "run_once" });
+          return;
+        }
+        const pathAccess = state.pendingPathAccess.at(-1);
+        if (pathAccess) {
+          e.preventDefault();
+          resolvePathAccess(pathAccess.id, { type: "run_once" });
+        }
       }
     };
     window.addEventListener("keydown", onKey);
@@ -1951,6 +1977,10 @@ function TabRuntime({
   }, [
     active,
     state.busy,
+    state.pendingConfirms,
+    state.pendingPathAccess,
+    resolveConfirm,
+    resolvePathAccess,
     abort,
     newChat,
     settingsOpen,


### PR DESCRIPTION
## Problem

Closes #1962. The permission approval prompts (`ConfirmApprovalCard` / `PathAccessApprovalCard`) in the desktop and dashboard UIs could only be granted by clicking — there was no keyboard shortcut, so every authorization required reaching for the mouse. The TUI already supports this (the `SingleSelect` confirms the highlighted choice on Enter); this brings the GUIs in line.

## Change

Extend the existing global `keydown` handler in both `desktop/src/App.tsx` and `dashboard/src/App.tsx` (the same place that already maps Esc → abort) so **Enter grants the pending authorization (run once)**, with the same guards as the Esc handler:

- ignored when focus is in an `INPUT` / `TEXTAREA` / `contentEditable` element (so it never hijacks the composer or the always-allow prefix field);
- ignored when a modal (settings / about / jobs / working-dir picker) is open;
- only the single pending `Confirm` / `PathAccess` prompt is resolved (most-recent first), via the existing `resolveConfirm`/`resolvePathAccess` with `{ type: "run_once" }`.

Multi-option decisions (plan / checkpoint / revision / choice cards) are intentionally left click-only, since Enter has no unambiguous default there.

## Notes

- Bare Enter (not Cmd/Ctrl+Enter) matches the TUI and the issue request; the editable-focus guard keeps it from clashing with composer send.
- No new i18n surface added — behavior only.

## Verification

- `npm run typecheck` (root + dashboard) ✓
- `cd desktop && tsc --noEmit` ✓ (the unrelated pre-existing `ja` locale error from #1915 is not touched here)
- `npm run verify` (build + lint + typecheck + full test suite) ✓