### PR TITLE
fix: keep compact sidebar new chat label visible

### DIFF
--- a/dashboard/src/styles.css
+++ b/dashboard/src/styles.css
@@ -849,6 +849,7 @@ html[data-platform="macos"] .titlebar .tb-left {
   font-weight: 500;
 }
 .side-head .new-btn .shortcut {
+  display: none;
   flex: 0 0 auto;
   margin-left: auto;
 }
@@ -864,9 +865,9 @@ html[data-platform="macos"] .titlebar .tb-left {
   padding: 1px 5px;
   box-shadow: none;
 }
-@container sidebar (max-width: 190px) {
+@container sidebar (min-width: 191px) {
   .side-head .new-btn .shortcut {
-    display: none;
+    display: inline-flex;
   }
 }
 .side-head .icon-btn {

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -832,6 +832,7 @@ html[data-platform="macos"] .titlebar .tb-left {
 
 .sidebar {
   grid-area: side;
+  container: sidebar / inline-size;
   background: var(--bg-2);
   border-right: 1px solid var(--border);
   display: flex;
@@ -848,9 +849,11 @@ html[data-platform="macos"] .titlebar .tb-left {
 }
 .side-head .new-btn {
   flex: 1;
+  min-width: 0;
   height: 30px;
   display: inline-flex;
   align-items: center;
+  flex-wrap: nowrap;
   gap: 8px;
   padding: 0 10px;
   font-size: 14px;
@@ -863,6 +866,15 @@ html[data-platform="macos"] .titlebar .tb-left {
 .side-head .new-btn:hover {
   background: var(--accent-strong);
 }
+.side-head .new-btn svg {
+  flex: 0 0 auto;
+}
+.side-head .new-btn > span:not(.shortcut) {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .side-head .new-btn kbd {
   font-family: inherit;
   font-size: 14px;
@@ -872,6 +884,8 @@ html[data-platform="macos"] .titlebar .tb-left {
   font-weight: 500;
 }
 .side-head .new-btn .shortcut {
+  display: none;
+  flex: 0 0 auto;
   margin-left: auto;
 }
 .side-head .new-btn .shortcut kbd {
@@ -886,7 +900,13 @@ html[data-platform="macos"] .titlebar .tb-left {
   padding: 1px 5px;
   box-shadow: none;
 }
+@container sidebar (min-width: 191px) {
+  .side-head .new-btn .shortcut {
+    display: inline-flex;
+  }
+}
 .side-head .icon-btn {
+  flex: 0 0 auto;
   width: 30px;
   height: 30px;
   border-radius: 6px;
@@ -7378,4 +7398,3 @@ html[data-platform="macos"] .splash {
     grid-template-columns: 1fr;
   }
 }
-

--- a/tests/dashboard-sidebar-new-chat-layout.test.ts
+++ b/tests/dashboard-sidebar-new-chat-layout.test.ts
@@ -20,7 +20,9 @@ describe("dashboard sidebar new chat button layout", () => {
       "text-overflow: ellipsis",
     );
     expect(cssRule(".side-head .new-btn .shortcut")).toContain("flex: 0 0 auto");
-    expect(css).toContain("@container sidebar (max-width: 190px)");
+    expect(cssRule(".side-head .new-btn .shortcut")).toContain("display: none");
+    expect(css).toContain("@container sidebar (min-width: 191px)");
+    expect(css).toContain("display: inline-flex");
     expect(css).toContain("display: none");
     expect(cssRule(".side-head .icon-btn")).toContain("flex: 0 0 auto");
   });

--- a/tests/desktop-sidebar-new-chat-layout.test.ts
+++ b/tests/desktop-sidebar-new-chat-layout.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const css = readFileSync("desktop/src/styles.css", "utf8");
+
+function cssRule(selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = new RegExp(`${escaped}\\s*\\{(?<body>[^}]*)\\}`).exec(css);
+  return match?.groups?.body ?? "";
+}
+
+describe("desktop sidebar new chat button layout", () => {
+  it("keeps localized labels on one line in the compact desktop sidebar", () => {
+    expect(cssRule(".sidebar")).toContain("container: sidebar / inline-size");
+    expect(cssRule(".side-head .new-btn")).toContain("flex-wrap: nowrap");
+    expect(cssRule(".side-head .new-btn")).toContain("min-width: 0");
+    expect(cssRule(".side-head .new-btn svg")).toContain("flex: 0 0 auto");
+    expect(cssRule(".side-head .new-btn > span:not(.shortcut)")).toContain("white-space: nowrap");
+    expect(cssRule(".side-head .new-btn > span:not(.shortcut)")).toContain(
+      "text-overflow: ellipsis",
+    );
+    expect(cssRule(".side-head .new-btn .shortcut")).toContain("flex: 0 0 auto");
+    expect(cssRule(".side-head .new-btn .shortcut")).toContain("display: none");
+    expect(css).toContain("@container sidebar (min-width: 191px)");
+    expect(css).toContain("display: inline-flex");
+    expect(css).toContain("display: none");
+    expect(cssRule(".side-head .icon-btn")).toContain("flex: 0 0 auto");
+  });
+});


### PR DESCRIPTION
## Summary
- Hide the sidebar new-chat shortcut hint by default so localized labels stay visible in compact desktop sidebars.
- Apply the same compact-sidebar fallback to both the web dashboard and the Tauri desktop app.
- Restore the shortcut hint only when the sidebar container is wide enough.
- Add regression coverage for the dashboard and desktop CSS paths.

Fixes #1920.
Follow-up to #1924.

## Evidence
![Compact zh-CN sidebar wrapping before fallback](https://raw.githubusercontent.com/GTC2080/DeepSeek-Reasonix/issue-assets/.github/issue-assets/issue-1920-sidebar-new-chat-evidence-20260527.png)

## Test Plan
- npm test -- tests/desktop-sidebar-new-chat-layout.test.ts tests/dashboard-sidebar-new-chat-layout.test.ts tests/dashboard-css-vars.test.ts tests/dashboard-smoke.test.ts
- npm run lint
- npm run verify
- Tauri desktop dev launch: npm --prefix desktop run tauri -- dev
- Chrome headless layout probe at 150px, 165px, 180px, and 220px sidebar widths
- Chrome headless layout probe with the sidebar container query removed to validate fallback behavior