### PR TITLE
fix(desktop): replace | with \vert in math to avoid GFM table breakage

### DIFF
--- a/desktop/src/Markdown.tsx
+++ b/desktop/src/Markdown.tsx
@@ -231,6 +231,20 @@ function normalizeMathDelimiters(source: string): string {
     .replace(/\\\)/g, "$$");
   // Restore protected sequences
   result = result.replace(/\x00LB\x00/g, "\\\\[");
+<<<<<<< Updated upstream
+=======
+
+  // Replace | with \vert inside math to prevent GFM table column splitting.
+  // \vert renders identically to | in KaTeX — it's the same vertical-bar
+  // glyph — but the markdown parser won't mistake it for a table separator.
+  result = result.replace(/\$\$([\s\S]*?)\$\$/g, (_: string, m: string) =>
+    "$$" + m.replace(/\|/g, "\\vert ") + "$$",
+  );
+  result = result.replace(/\$([^$\n]+)\$/g, (_: string, m: string) =>
+    "$" + m.replace(/\|/g, "\\vert ") + "$",
+  );
+
+>>>>>>> Stashed changes
   return result;
 }
 

--- a/desktop/src/Markdown.tsx
+++ b/desktop/src/Markdown.tsx
@@ -231,8 +231,6 @@ function normalizeMathDelimiters(source: string): string {
     .replace(/\\\)/g, "$$");
   // Restore protected sequences
   result = result.replace(/\x00LB\x00/g, "\\\\[");
-<<<<<<< Updated upstream
-=======
 
   // Replace | with \vert inside math to prevent GFM table column splitting.
   // \vert renders identically to | in KaTeX — it's the same vertical-bar
@@ -244,7 +242,6 @@ function normalizeMathDelimiters(source: string): string {
     "$" + m.replace(/\|/g, "\\vert ") + "$",
   );
 
->>>>>>> Stashed changes
   return result;
 }
 


### PR DESCRIPTION
## What

Replaces `|` with `\vert` inside math spans (`$...$` / `$$...$$`) in
`desktop/src/Markdown.tsx`. This prevents GFM table column separators from
splitting table cells that contain LaTeX pipe characters (bra-ket notation,
absolute values, etc.).

## Why

KaTeX renders `\vert` identically to `|`, but GFM doesn't mistake it for
a table column separator.

## How to verify

A table cell containing `|` inside math should render as a single cell:

    | Name | Expression |
    | --- | --- |
    | MS  | $\frac{1}{\sqrt{2}}(\vert \uparrow\downarrow\uparrow\rangle)$ |

Before: the `|` inside the math splits the cell into two columns.
After: the cell stays intact and the math renders correctly.

## Checklist

- [x] `npm run verify` passes locally
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] No edits to `CHANGELOG.md`