### PR TITLE
Fix long-session desktop transcript payload growth

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -69,6 +69,7 @@ import { WorkdirPop } from "./ui/workdir-pop";
 import { WorkdirInputModal } from "./ui/workdir-input-modal";
 import { useAutoScroll } from "./ui/useAutoScroll";
 import { useDisableTextAssist } from "./ui/useDisableTextAssist";
+import { elideTranscriptMessages } from "./ui/transcript-elision";
 import { openUrl } from "@tauri-apps/plugin-opener";
 
 export type AssistantSegment =
@@ -306,6 +307,10 @@ function nextMessageTurn(messages: ChatMessage[]): number {
 }
 
 function reduce(state: State, action: Action): State {
+  return withElidedTranscript(reduceRaw(state, action));
+}
+
+function reduceRaw(state: State, action: Action): State {
   switch (action.t) {
     case "send_user": {
       return {
@@ -470,6 +475,11 @@ function reduce(state: State, action: Action): State {
   }
 }
 
+function withElidedTranscript(state: State): State {
+  const messages = elideTranscriptMessages(state.messages);
+  return messages === state.messages ? state : { ...state, messages };
+}
+
 const READING_TOOLS = new Set(["read_file"]);
 const MODIFYING_TOOLS = new Set(["edit_file", "write_file"]);
 
@@ -548,6 +558,10 @@ function appendTextSegment(
 }
 
 export function applyIncoming(state: State, ev: IncomingEvent): State {
+  return withElidedTranscript(applyIncomingRaw(state, ev));
+}
+
+function applyIncomingRaw(state: State, ev: IncomingEvent): State {
   switch (ev.type) {
     case "user.message": {
       const last = state.messages[state.messages.length - 1];

--- a/dashboard/src/ui/transcript-elision.ts
+++ b/dashboard/src/ui/transcript-elision.ts
@@ -1,0 +1,96 @@
+type TextSegmentLike = {
+  kind: "text" | "reasoning";
+  text: string;
+};
+
+type ToolSegmentLike = {
+  kind: "tool";
+  args: string;
+  result?: string;
+};
+
+type SegmentLike = TextSegmentLike | ToolSegmentLike | { kind: string };
+
+type AssistantMessageLike = {
+  kind: "assistant";
+  pending?: boolean;
+  segments: SegmentLike[];
+};
+
+export const TRANSCRIPT_RECENT_MESSAGE_WINDOW = 120;
+const MIN_ELIDE_CHARS = 4096;
+const ELIDED_PREFIX = "[elided -- older than the last ";
+
+function isAssistantMessage(value: unknown): value is AssistantMessageLike {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { kind?: unknown }).kind === "assistant" &&
+    Array.isArray((value as { segments?: unknown }).segments)
+  );
+}
+
+function isElided(value: unknown): boolean {
+  return typeof value === "string" && value.startsWith(ELIDED_PREFIX);
+}
+
+function elidedStub(chars: number): string {
+  return `${ELIDED_PREFIX}${TRANSCRIPT_RECENT_MESSAGE_WINDOW} messages; ${chars.toLocaleString()} chars dropped to keep long sessions responsive. Full content remains in the session log.]`;
+}
+
+function elideField(value: string): string {
+  if (value.length <= MIN_ELIDE_CHARS || isElided(value)) return value;
+  return elidedStub(value.length);
+}
+
+function elideSegment<S extends SegmentLike>(segment: S): S {
+  if (
+    (segment.kind === "text" || segment.kind === "reasoning") &&
+    typeof (segment as TextSegmentLike).text === "string"
+  ) {
+    const textSegment = segment as TextSegmentLike;
+    const text = elideField(textSegment.text);
+    return text === textSegment.text ? segment : ({ ...segment, text } as S);
+  }
+  if (segment.kind !== "tool") return segment;
+
+  const toolSegment = segment as ToolSegmentLike;
+  let next: S | null = null;
+  const args = elideField(toolSegment.args);
+  if (args !== toolSegment.args) next = { ...segment, args } as S;
+  if (typeof toolSegment.result === "string") {
+    const result = elideField(toolSegment.result);
+    if (result !== toolSegment.result) next = { ...(next ?? segment), result } as S;
+  }
+  return next ?? segment;
+}
+
+function elideSegments<S extends SegmentLike>(segments: S[]): S[] {
+  let next: S[] | null = null;
+  for (let i = 0; i < segments.length; i++) {
+    const segment = segments[i];
+    if (!segment) continue;
+    const elided = elideSegment(segment);
+    if (elided !== segment) {
+      if (next === null) next = segments.slice();
+      next[i] = elided;
+    }
+  }
+  return next ?? segments;
+}
+
+export function elideTranscriptMessages<T>(messages: T[]): T[] {
+  if (messages.length <= TRANSCRIPT_RECENT_MESSAGE_WINDOW) return messages;
+  const cutoff = messages.length - TRANSCRIPT_RECENT_MESSAGE_WINDOW;
+  let next: T[] | null = null;
+  for (let i = 0; i < cutoff; i++) {
+    const message = messages[i];
+    if (!isAssistantMessage(message) || message.pending) continue;
+    const segments = elideSegments(message.segments);
+    if (segments !== message.segments) {
+      if (next === null) next = messages.slice();
+      next[i] = { ...message, segments } as T;
+    }
+  }
+  return next ?? messages;
+}

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -101,6 +101,7 @@ import { useResizable } from "./ui/useResizable";
 import { useAutoScroll } from "./ui/useAutoScroll";
 import { useDisableTextAssist } from "./ui/useDisableTextAssist";
 import { getThreadMaxWidth } from "./ui/thread-layout";
+import { elideTranscriptMessages } from "./ui/transcript-elision";
 import { openUrl } from "@tauri-apps/plugin-opener";
 
 const RIGHT_SIDEBAR_COLLAPSE_WIDTH = 1120;
@@ -403,6 +404,10 @@ function nextErrorId(): string {
 }
 
 export function reduce(state: State, action: Action): State {
+  return withElidedTranscript(reduceRaw(state, action));
+}
+
+function reduceRaw(state: State, action: Action): State {
   switch (action.t) {
     case "send_user": {
       return {
@@ -584,6 +589,11 @@ export function reduce(state: State, action: Action): State {
   }
 }
 
+function withElidedTranscript(state: State): State {
+  const messages = elideTranscriptMessages(state.messages);
+  return messages === state.messages ? state : { ...state, messages };
+}
+
 const READING_TOOLS = new Set(["read_file"]);
 const MODIFYING_TOOLS = new Set(["edit_file", "write_file"]);
 
@@ -740,6 +750,10 @@ function appendTextSegment(
 }
 
 export function applyIncoming(state: State, ev: IncomingEvent): State {
+  return withElidedTranscript(applyIncomingRaw(state, ev));
+}
+
+function applyIncomingRaw(state: State, ev: IncomingEvent): State {
   switch (ev.type) {
     case "user.message": {
       return {

--- a/desktop/src/ui/transcript-elision.ts
+++ b/desktop/src/ui/transcript-elision.ts
@@ -1,0 +1,96 @@
+type TextSegmentLike = {
+  kind: "text" | "reasoning";
+  text: string;
+};
+
+type ToolSegmentLike = {
+  kind: "tool";
+  args: string;
+  result?: string;
+};
+
+type SegmentLike = TextSegmentLike | ToolSegmentLike | { kind: string };
+
+type AssistantMessageLike = {
+  kind: "assistant";
+  pending?: boolean;
+  segments: SegmentLike[];
+};
+
+export const TRANSCRIPT_RECENT_MESSAGE_WINDOW = 120;
+const MIN_ELIDE_CHARS = 4096;
+const ELIDED_PREFIX = "[elided -- older than the last ";
+
+function isAssistantMessage(value: unknown): value is AssistantMessageLike {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { kind?: unknown }).kind === "assistant" &&
+    Array.isArray((value as { segments?: unknown }).segments)
+  );
+}
+
+function isElided(value: unknown): boolean {
+  return typeof value === "string" && value.startsWith(ELIDED_PREFIX);
+}
+
+function elidedStub(chars: number): string {
+  return `${ELIDED_PREFIX}${TRANSCRIPT_RECENT_MESSAGE_WINDOW} messages; ${chars.toLocaleString()} chars dropped to keep long sessions responsive. Full content remains in the session log.]`;
+}
+
+function elideField(value: string): string {
+  if (value.length <= MIN_ELIDE_CHARS || isElided(value)) return value;
+  return elidedStub(value.length);
+}
+
+function elideSegment<S extends SegmentLike>(segment: S): S {
+  if (
+    (segment.kind === "text" || segment.kind === "reasoning") &&
+    typeof (segment as TextSegmentLike).text === "string"
+  ) {
+    const textSegment = segment as TextSegmentLike;
+    const text = elideField(textSegment.text);
+    return text === textSegment.text ? segment : ({ ...segment, text } as S);
+  }
+  if (segment.kind !== "tool") return segment;
+
+  const toolSegment = segment as ToolSegmentLike;
+  let next: S | null = null;
+  const args = elideField(toolSegment.args);
+  if (args !== toolSegment.args) next = { ...segment, args } as S;
+  if (typeof toolSegment.result === "string") {
+    const result = elideField(toolSegment.result);
+    if (result !== toolSegment.result) next = { ...(next ?? segment), result } as S;
+  }
+  return next ?? segment;
+}
+
+function elideSegments<S extends SegmentLike>(segments: S[]): S[] {
+  let next: S[] | null = null;
+  for (let i = 0; i < segments.length; i++) {
+    const segment = segments[i];
+    if (!segment) continue;
+    const elided = elideSegment(segment);
+    if (elided !== segment) {
+      if (next === null) next = segments.slice();
+      next[i] = elided;
+    }
+  }
+  return next ?? segments;
+}
+
+export function elideTranscriptMessages<T>(messages: T[]): T[] {
+  if (messages.length <= TRANSCRIPT_RECENT_MESSAGE_WINDOW) return messages;
+  const cutoff = messages.length - TRANSCRIPT_RECENT_MESSAGE_WINDOW;
+  let next: T[] | null = null;
+  for (let i = 0; i < cutoff; i++) {
+    const message = messages[i];
+    if (!isAssistantMessage(message) || message.pending) continue;
+    const segments = elideSegments(message.segments);
+    if (segments !== message.segments) {
+      if (next === null) next = messages.slice();
+      next[i] = { ...message, segments } as T;
+    }
+  }
+  return next ?? messages;
+}

--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -610,7 +610,7 @@ function tailLines(s: string, n: number): string {
   return lines.slice(-n).join("\n");
 }
 
-const LOADED_RECENT_MESSAGE_WINDOW = 200;
+const LOADED_RECENT_MESSAGE_WINDOW = 120;
 const LOADED_MIN_ELIDE_CHARS = 4096;
 const LOADED_ELIDED_PREFIX = "[elided — older than the last ";
 

--- a/tests/desktop-user-message.test.ts
+++ b/tests/desktop-user-message.test.ts
@@ -106,4 +106,51 @@ describe("desktop incoming QQ/user message rendering", () => {
       turn: 2,
     });
   });
+
+  it("elides old heavy assistant segments during long live desktop sessions", () => {
+    const big = "long-session-payload\n".repeat(500);
+    const messages: ChatMessage[] = Array.from({ length: 250 }, (_, i) => ({
+      kind: "assistant",
+      turn: i + 1,
+      pending: false,
+      segments: [
+        { kind: "reasoning", text: `${big}reasoning-${i}` },
+        { kind: "text", text: `${big}text-${i}` },
+        {
+          kind: "tool",
+          callId: `tool-${i}`,
+          name: "read_file",
+          args: JSON.stringify({ path: `file-${i}.txt`, content: `${big}args-${i}` }),
+          startedAt: 0,
+          result: `${big}result-${i}`,
+          ok: true,
+        },
+      ],
+    }));
+
+    const next = applyIncoming(makeState(messages), {
+      type: "model.turn.started",
+      turn: 999,
+      model: "deepseek-v4-flash",
+    } as IncomingEvent);
+
+    const oldest = next.messages[0];
+    expect(oldest?.kind).toBe("assistant");
+    if (oldest?.kind !== "assistant") return;
+    expect(oldest.segments[0]?.kind).toBe("reasoning");
+    expect(oldest.segments[1]?.kind).toBe("text");
+    expect(oldest.segments[2]?.kind).toBe("tool");
+    expect(oldest.segments[0]?.text).toMatch(/^\[elided/);
+    expect(oldest.segments[1]?.text).toMatch(/^\[elided/);
+    if (oldest.segments[2]?.kind === "tool") {
+      expect(oldest.segments[2].args).toMatch(/^\[elided/);
+      expect(oldest.segments[2].result).toMatch(/^\[elided/);
+    }
+
+    const recent = next.messages[240];
+    expect(recent?.kind).toBe("assistant");
+    if (recent?.kind !== "assistant") return;
+    expect(recent.segments[1]?.kind).toBe("text");
+    expect(recent.segments[1]?.text).toContain("text-240");
+  });
 });


### PR DESCRIPTION
## Summary
- Treats #2001, #2012, and #2013 as the same long-session desktop/dashboard transcript pressure pattern.
- Adds bounded transcript payload elision for old heavy assistant text, reasoning, tool args, and tool results while keeping the recent window intact.
- Tightens restored-session payload retention from 200 to 120 messages so reopening a very long session does not immediately bring back the same pressure.

## Verification
- Added a regression test that reproduces 250 heavy assistant messages and confirms old payloads are elided when the next turn starts.
- npm test -- tests/desktop-user-message.test.ts tests/desktop-session-load.test.ts
- npm run typecheck
- npm run verify
- git push pre-push verify also passed.

Addresses #2001.
Addresses #2012.
Addresses #2013.