### PR TITLE
fix(mcp): bridge mcpServers in Desktop and unify cfg.mcp reads across CLI

### DIFF
--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -6,6 +6,7 @@ import {
   loadApiKey,
   loadHistoryScrollMode,
   loadToolRateLimit,
+  normalizeMcpConfig,
   readConfig,
   searchEnabled,
 } from "../../config.js";
@@ -305,7 +306,8 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
     platform: process.platform,
   });
   const startupInfoHints: string[] = [];
-  if (cfg.setupCompleted === true && (cfg.mcp?.length ?? 0) === 0 && mcpSpecs.length === 0) {
+  const hasAnyMcp = normalizeMcpConfig(cfg).length > 0 || mcpSpecs.length > 0;
+  if (cfg.setupCompleted === true && !hasAnyMcp) {
     startupInfoHints.push(t("mcpHealth.emptyHint"));
   }
 

--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -41,6 +41,7 @@ import {
   loadSubagentModels,
   loadTavilyApiKey,
   loadWorkspaceDir,
+  normalizeMcpConfig,
   pushRecentWorkspace,
   readConfig,
   webSearchEngine as readWebSearchEngine,
@@ -96,7 +97,7 @@ import {
   ImmutablePrefix,
   type LoopAbortOptions,
 } from "../../index.js";
-import { parseMcpSpec } from "../../mcp/spec.js";
+import { parseMcpSpec, specToRaw } from "../../mcp/spec.js";
 import {
   deleteSession,
   listSessionsForWorkspace,
@@ -571,6 +572,11 @@ export function normalizeSessionTitle(raw: string): string {
   return raw.replace(/\s+/g, " ").trim().slice(0, SESSION_TITLE_MAX_CHARS);
 }
 
+/** Return all MCP specs as raw strings, reading both legacy `cfg.mcp` and canonical `cfg.mcpServers`. */
+export function getAllMcpSpecs(cfg: ReturnType<typeof readConfig>): string[] {
+  return normalizeMcpConfig(cfg).map(specToRaw);
+}
+
 /** Drain `buffer` to `fd` across partial writes; retry EAGAIN after a 5 ms park. Exported for tests. */
 export function writeAllSync(
   fd: number,
@@ -884,7 +890,8 @@ function summarizeMcpSpec(raw: string): McpSpecInfo {
 
 function emitMcpSpecs(tab: Tab): void {
   const cfg = readConfig();
-  const specs = (cfg.mcp ?? []).map((raw) => {
+  const allSpecs = getAllMcpSpecs(cfg);
+  const specs = allSpecs.map((raw) => {
     const base = summarizeMcpSpec(raw);
     const live = tab.mcpStatuses.get(raw);
     if (!live) return base;
@@ -1516,7 +1523,8 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
           emit({ type: "$error", message: `mcp reload failed: ${(err as Error).message}` }, tab.id);
         });
     }
-    const requested = (readConfig().mcp ?? []).length;
+    const allSpecs = getAllMcpSpecs(readConfig());
+    const requested = allSpecs.length;
     if (requested === 0) return Promise.resolve();
     const runtime = createMcpRuntime({
       getTools: () => {
@@ -1531,8 +1539,8 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
     tab.mcpRuntime = runtime;
     runtime.setLifecycleSink((notice) => {
       if (notice.kind === "slow") return; // not surfaced in the desktop panel
-      const cfg = readConfig().mcp ?? [];
-      const target = cfg.find((raw) => {
+      const specs = getAllMcpSpecs(readConfig());
+      const target = specs.find((raw) => {
         try {
           return parseMcpSpec(raw).name === notice.name;
         } catch {

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -8,6 +8,7 @@ import {
   defaultConfigPath,
   loadEndpoint,
   loadProxyConfig,
+  normalizeMcpConfig,
   readConfig,
   resolveSemanticEmbeddingConfig,
 } from "../../config.js";
@@ -192,7 +193,8 @@ async function checkConfig(): Promise<Check> {
     if (cfg.model) parts.push(`model=${cfg.model}`);
     if (cfg.reasoningEffort) parts.push(`effort=${cfg.reasoningEffort}`);
     if (cfg.editMode) parts.push(`editMode=${cfg.editMode}`);
-    if (cfg.mcp && cfg.mcp.length > 0) parts.push(`mcp=${cfg.mcp.length}`);
+    const mcpCount = normalizeMcpConfig(cfg).length;
+    if (mcpCount > 0) parts.push(`mcp=${mcpCount}`);
     return {
       id: "config",
       label: "config       ",

--- a/src/cli/commands/mcp-browse.tsx
+++ b/src/cli/commands/mcp-browse.tsx
@@ -2,7 +2,7 @@
 
 import { Box, Text, render, useApp, useInput } from "ink";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { readConfig, writeConfig } from "../../config.js";
+import { normalizeMcpConfig, readConfig, writeConfig } from "../../config.js";
 import { loadDotenv } from "../../env.js";
 import { loadOverlay } from "../../mcp/marketplace-overlay/loader.js";
 import {
@@ -115,7 +115,10 @@ function McpBrowseApp() {
         const spec = specStringFor(entry.name, entry.install);
         const cfg = readConfig();
         const existing = cfg.mcp ?? [];
-        if (existing.includes(spec)) {
+        const installedName = entry.name;
+        const normalized = normalizeMcpConfig(cfg);
+        const nameCollision = normalized.some((s) => s.name === installedName);
+        if (existing.includes(spec) || nameCollision) {
           setStatus(`already installed: ${spec}`);
           return;
         }

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -1,4 +1,4 @@
-import { defaultConfigPath, readConfig, writeConfig } from "../../config.js";
+import { defaultConfigPath, normalizeMcpConfig, readConfig, writeConfig } from "../../config.js";
 import { t } from "../../i18n/index.js";
 import { MCP_CATALOG, mcpCommandFor } from "../../mcp/catalog.js";
 import {
@@ -301,7 +301,10 @@ export async function mcpInstallCommand(name: string, opts: McpInstallOptions = 
 
   const cfg = readConfig();
   const existing = cfg.mcp ?? [];
-  if (existing.includes(spec)) {
+  const installedName = parseInstalledName(spec);
+  const normalized = normalizeMcpConfig(cfg);
+  const nameCollision = installedName && normalized.some((s) => s.name === installedName);
+  if (existing.includes(spec) || nameCollision) {
     console.log(t("mcpCli.alreadyInstalled", { spec }));
     return;
   }
@@ -310,7 +313,6 @@ export async function mcpInstallCommand(name: string, opts: McpInstallOptions = 
 
   console.log(t("mcpCli.installed", { spec: entry.name }));
   console.log(`  spec:    ${spec}`);
-  const installedName = parseInstalledName(spec);
   if (entry.install.requiredEnv?.length) {
     console.log(`  needs:   ${entry.install.requiredEnv.join(", ")}`);
     console.log("           Either export these before launching, or add them to config:");

--- a/src/cli/ui/McpMarketplace.tsx
+++ b/src/cli/ui/McpMarketplace.tsx
@@ -2,7 +2,7 @@
 
 import { Box, Text } from "ink";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { readConfig, writeConfig } from "../../config.js";
+import { normalizeMcpConfig, readConfig, writeConfig } from "../../config.js";
 import { t } from "../../i18n/index.js";
 import { loadOverlay } from "../../mcp/marketplace-overlay/loader.js";
 import {
@@ -96,7 +96,11 @@ function isInstalled(installedSpecs: string[], entry: RegistryEntry): string | n
   if (!entry.install) return null;
   try {
     const spec = specStringFor(entry.name, entry.install);
-    return installedSpecs.includes(spec) ? spec : null;
+    if (installedSpecs.includes(spec)) return spec;
+    // Also check for name collision with mcpServers entries
+    const normalized = normalizeMcpConfig(readConfig());
+    if (normalized.some((s) => s.name === entry.name)) return spec;
+    return null;
   } catch {
     return null;
   }

--- a/src/server/api/mcp.ts
+++ b/src/server/api/mcp.ts
@@ -1,6 +1,6 @@
 /** Spec mutations don't auto-reload — adding a server shifts the system prefix and zeroes the next cache hit. */
 
-import { readConfig, writeConfig } from "../../config.js";
+import { normalizeMcpConfig, readConfig, writeConfig } from "../../config.js";
 import {
   fetchSmitheryDetail,
   handleToFetchResult,
@@ -89,13 +89,18 @@ export async function handleMcp(
     };
   }
 
-  // Persisted spec list — what config.mcp[] holds. May differ from
-  // bridged set (a recent edit hasn't been reloaded yet).
+  // Persisted spec list — includes both legacy cfg.mcp and canonical cfg.mcpServers.
   if (method === "GET" && rest[0] === "specs") {
     const cfg = readConfig(ctx.configPath);
+    const allSpecs = normalizeMcpConfig(cfg).map((s) => {
+      if (s.transport === "stdio") {
+        return `${s.name}=${s.command}${s.args.length ? ` ${s.args.join(" ")}` : ""}`;
+      }
+      return `${s.name}=${s.url}`;
+    });
     return {
       status: 200,
-      body: { specs: cfg.mcp ?? [], failures: ctx.getMcpFailures?.() ?? [] },
+      body: { specs: allSpecs, failures: ctx.getMcpFailures?.() ?? [] },
     };
   }
 
@@ -107,6 +112,12 @@ export async function handleMcp(
     const cfg = readConfig(ctx.configPath);
     const list = cfg.mcp ?? [];
     if (list.includes(spec)) {
+      return { status: 200, body: { added: false, alreadyPresent: true } };
+    }
+    // Check for name collision with mcpServers entries
+    const normalized = normalizeMcpConfig(cfg);
+    const parsedName = spec.split("=")[0];
+    if (parsedName && normalized.some((s) => s.name === parsedName)) {
       return { status: 200, body: { added: false, alreadyPresent: true } };
     }
     cfg.mcp = [...list, spec.trim()];

--- a/src/tools/scaffold.ts
+++ b/src/tools/scaffold.ts
@@ -1,6 +1,12 @@
 /** Agent-facing tools for scaffolding skills + MCP servers from chat. Persists via the same paths the wizard / `/skill new` use. */
 
-import { defaultConfigPath, loadResolvedSkillPaths, readConfig, writeConfig } from "../config.js";
+import {
+  defaultConfigPath,
+  loadResolvedSkillPaths,
+  normalizeMcpConfig,
+  readConfig,
+  writeConfig,
+} from "../config.js";
 import { MCP_CATALOG } from "../mcp/catalog.js";
 import { preflightStdioSpec } from "../mcp/preflight.js";
 import { type McpSpec, parseMcpSpec } from "../mcp/spec.js";
@@ -224,10 +230,12 @@ export function registerScaffoldTools(
 
       const cfg = readConfig(configPath);
       const existing = cfg.mcp ?? [];
+      const normalized = normalizeMcpConfig(cfg);
       const collision = existing.find((s) => parseSpecName(s) === name);
-      if (collision) {
+      const nameCollision = normalized.some((s) => s.name === name);
+      if (collision || nameCollision) {
         return JSON.stringify({
-          error: `MCP server ${JSON.stringify(name)} already registered: ${collision}`,
+          error: `MCP server ${JSON.stringify(name)} already registered: ${collision ?? name}`,
         });
       }
       cfg.mcp = [...existing, specStr.spec];

--- a/tests/desktop-mcp-servers.test.ts
+++ b/tests/desktop-mcp-servers.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { getAllMcpSpecs } from "../src/cli/commands/desktop.js";
+import type { ReasonixConfig } from "../src/config.js";
+
+describe("getAllMcpSpecs", () => {
+  it("returns legacy cfg.mcp specs", () => {
+    const cfg: ReasonixConfig = {
+      mcp: ["fs=npx -y @scope/fs /tmp", "git=uvx mcp-server-git"],
+    };
+    const specs = getAllMcpSpecs(cfg);
+    expect(specs).toHaveLength(2);
+    expect(specs).toContain("fs=npx -y @scope/fs /tmp");
+    expect(specs).toContain("git=uvx mcp-server-git");
+  });
+
+  it("returns mcpServers specs when legacy mcp is absent", () => {
+    const cfg: ReasonixConfig = {
+      mcpServers: {
+        github: {
+          command: "npx",
+          args: ["-y", "@modelcontextprotocol/server-github"],
+        },
+      },
+    };
+    const specs = getAllMcpSpecs(cfg);
+    expect(specs.length).toBeGreaterThan(0);
+    expect(specs.some((s) => s.startsWith("github="))).toBe(true);
+  });
+
+  it("merges both legacy mcp and mcpServers", () => {
+    const cfg: ReasonixConfig = {
+      mcp: ["fs=npx -y @scope/fs /tmp"],
+      mcpServers: {
+        github: {
+          command: "npx",
+          args: ["-y", "@modelcontextprotocol/server-github"],
+        },
+      },
+    };
+    const specs = getAllMcpSpecs(cfg);
+    expect(specs.length).toBeGreaterThanOrEqual(2);
+    expect(specs.some((s) => s.startsWith("fs="))).toBe(true);
+    expect(specs.some((s) => s.startsWith("github="))).toBe(true);
+  });
+
+  it("mcpServers wins on name conflict", () => {
+    const cfg: ReasonixConfig = {
+      mcp: ["fs=npx -y @scope/fs /tmp"],
+      mcpServers: {
+        fs: {
+          command: "node",
+          args: ["server.js"],
+        },
+      },
+    };
+    const specs = getAllMcpSpecs(cfg);
+    const fsSpec = specs.find((s) => s.startsWith("fs="));
+    expect(fsSpec).toContain("node");
+    expect(fsSpec).not.toContain("npx");
+  });
+
+  it("returns empty array when neither mcp nor mcpServers present", () => {
+    const cfg: ReasonixConfig = {};
+    const specs = getAllMcpSpecs(cfg);
+    expect(specs).toEqual([]);
+  });
+});

--- a/tests/mcp-tui-survival.test.ts
+++ b/tests/mcp-tui-survival.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const initializeMock = vi.fn(async () => undefined);
+  const closeMock = vi.fn(async () => undefined);
+  const bridgeMcpToolsMock = vi.fn(async (_client: unknown, opts: any) => {
+    // Simulate what real bridgeMcpTools does — register tools into the registry.
+    opts.registry.register({ name: "mcp_fs_read", fn: () => "ok", description: "read" });
+    opts.registry.register({ name: "mcp_fs_write", fn: () => "ok", description: "write" });
+    return {
+      registeredNames: ["mcp_fs_read", "mcp_fs_write"],
+      env: {
+        registry: opts.registry,
+        host: opts.host,
+        prefix: opts.namePrefix ?? "",
+        maxResultChars: 32_000,
+        tracker: null,
+      },
+    };
+  });
+  const inspectMcpServerMock = vi.fn(async () => ({
+    protocolVersion: "2024-11-05",
+    serverInfo: { name: "fake", version: "1.0.0" },
+    capabilities: { tools: {} },
+    tools: { supported: true as const, items: [] },
+    resources: { supported: false as const, reason: "method not found" },
+    prompts: { supported: false as const, reason: "method not found" },
+    elapsedMs: 1,
+  }));
+  const readConfigMock = vi.fn(() => ({ mcpDisabled: [] as string[] }));
+
+  class FakeMcpClient {
+    protocolVersion = "2024-11-05";
+    serverInfo = { name: "fake", version: "1.0.0" };
+    serverCapabilities = { tools: {} };
+    async initialize() {
+      return initializeMock();
+    }
+    async close() {
+      return closeMock();
+    }
+  }
+
+  class FakeTransport {}
+
+  return {
+    initializeMock,
+    closeMock,
+    bridgeMcpToolsMock,
+    inspectMcpServerMock,
+    readConfigMock,
+    FakeMcpClient,
+    FakeTransport,
+  };
+});
+
+vi.mock("../src/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/config.js")>();
+  return { ...actual, readConfig: mocks.readConfigMock };
+});
+
+vi.mock("../src/mcp/client.js", () => ({ McpClient: mocks.FakeMcpClient }));
+vi.mock("../src/mcp/inspect.js", () => ({ inspectMcpServer: mocks.inspectMcpServerMock }));
+vi.mock("../src/mcp/registry.js", () => ({ bridgeMcpTools: mocks.bridgeMcpToolsMock }));
+vi.mock("../src/mcp/sse.js", () => ({ SseTransport: mocks.FakeTransport }));
+vi.mock("../src/mcp/stdio.js", () => ({ StdioTransport: mocks.FakeTransport }));
+vi.mock("../src/mcp/streamable-http.js", () => ({
+  StreamableHttpTransport: mocks.FakeTransport,
+}));
+
+describe("MCP tools survive TUI lifecycle events", () => {
+  it("ImmutablePrefix created from a registry with MCP tools includes them", async () => {
+    const { ToolRegistry } = await import("../src/tools.js");
+    const { ImmutablePrefix } = await import("../src/memory/runtime.js");
+
+    const tools = new ToolRegistry();
+    tools.register({ name: "native_tool", fn: () => "ok" });
+    tools.register({ name: "mcp_fs_read", fn: () => "ok" });
+
+    const prefix = new ImmutablePrefix({
+      system: "test",
+      toolSpecs: tools.specs(),
+    });
+
+    const names = prefix.toolSpecs.map((s) => s.function.name);
+    expect(names).toContain("native_tool");
+    expect(names).toContain("mcp_fs_read");
+  });
+
+  it("CacheFirstLoop.clearLog() preserves prefix toolSpecs", async () => {
+    const { ToolRegistry } = await import("../src/tools.js");
+    const { ImmutablePrefix } = await import("../src/memory/runtime.js");
+    const { CacheFirstLoop } = await import("../src/loop.js");
+    const { DeepSeekClient } = await import("../src/client.js");
+
+    const tools = new ToolRegistry();
+    tools.register({ name: "mcp_tool", fn: () => "ok" });
+
+    const prefix = new ImmutablePrefix({
+      system: "test",
+      toolSpecs: tools.specs(),
+    });
+
+    const loop = new CacheFirstLoop({
+      client: new DeepSeekClient({ apiKey: "sk-test" }),
+      prefix,
+      tools,
+      model: "deepseek-chat",
+    });
+
+    loop.clearLog();
+
+    const names = loop.prefix.toolSpecs.map((s) => s.function.name);
+    expect(names).toContain("mcp_tool");
+  });
+
+  it("re-bridging an existing spec onto a new loop preserves tools via registry.specs()", async () => {
+    mocks.readConfigMock.mockReturnValue({ mcpDisabled: [] });
+    mocks.initializeMock.mockImplementation(async () => undefined);
+
+    const [
+      { createMcpRuntime },
+      { ToolRegistry },
+      { ImmutablePrefix },
+      { CacheFirstLoop },
+      { DeepSeekClient },
+    ] = await Promise.all([
+      import("../src/cli/commands/mcp-runtime.js"),
+      import("../src/tools.js"),
+      import("../src/memory/runtime.js"),
+      import("../src/loop.js"),
+      import("../src/client.js"),
+    ]);
+
+    const tools = new ToolRegistry();
+    const runtime = createMcpRuntime({
+      getTools: () => tools,
+      getMcpPrefix: () => undefined,
+      getRequestedCount: () => 1,
+      progressSink: { current: null },
+    });
+
+    // First bridge — simulates initial App mount
+    const spec = "fs=npx -y @scope/fs /tmp";
+    const firstLoop = new CacheFirstLoop({
+      client: new DeepSeekClient({ apiKey: "sk-test" }),
+      prefix: new ImmutablePrefix({ system: "test", toolSpecs: tools.specs() }),
+      tools,
+      model: "deepseek-chat",
+    });
+
+    const firstResult = await runtime.addSpec(spec, firstLoop);
+    expect(firstResult.ok).toBe(true);
+    expect(tools.has("mcp_fs_read")).toBe(true);
+    expect(tools.has("mcp_fs_write")).toBe(true);
+
+    // Second bridge — simulates App remount on session switch.
+    // The registry already has the tools; the new prefix gets them from tools.specs().
+    const secondLoop = new CacheFirstLoop({
+      client: new DeepSeekClient({ apiKey: "sk-test" }),
+      prefix: new ImmutablePrefix({ system: "test", toolSpecs: tools.specs() }),
+      tools,
+      model: "deepseek-chat",
+    });
+
+    const secondResult = await runtime.addSpec(spec, secondLoop);
+    expect(secondResult.ok).toBe(true);
+
+    // Even though addSpec returned early (records.has), the new prefix already
+    // has the tools because it was built from tools.specs().
+    const names = secondLoop.prefix.toolSpecs.map((s) => s.function.name);
+    expect(names).toContain("mcp_fs_read");
+    expect(names).toContain("mcp_fs_write");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1993 and addresses root-cause gaps behind #2002.

### Desktop (#1993)
`bridgeTabMcp`, `emitMcpSpecs`, and the MCP lifecycle sink in `src/cli/commands/desktop.ts` now read from `normalizeMcpConfig(cfg)` instead of only `cfg.mcp`. This means `mcpServers` entries in `config.json` are actually bridged and exposed to the LLM in Desktop sessions.

### CLI / TUI
- **Startup hint** (`chat.tsx`): empty-MCP hint now checks `normalizeMcpConfig(cfg).length` instead of only `cfg.mcp`.
- **Doctor** (`doctor.ts`): MCP count report now includes `mcpServers`.
- **Install collision prevention** (`mcp.ts`, `mcp-browse.tsx`, `McpMarketplace.tsx`, `scaffold.ts`, dashboard `api/mcp.ts`): all now check against `normalizeMcpConfig(cfg)` to prevent duplicate installations when a server is defined in `mcpServers`.
- **Dashboard API** (`api/mcp.ts`): GET /specs returns all specs (legacy + mcpServers); POST /specs checks for name collision with `mcpServers`.

### Regression tests
- `tests/desktop-mcp-servers.test.ts`: 5 tests covering `getAllMcpSpecs` behavior (legacy-only, mcpServers-only, merge, name-conflict, empty).
- `tests/mcp-tui-survival.test.ts`: 3 tests proving MCP tools survive TUI lifecycle events (`ImmutablePrefix`, `CacheFirstLoop.clearLog()`, re-bridging onto new loops).

## Test plan
- [x] `npm run typecheck` passes for all changed files
- [x] New unit tests cover Desktop spec merging and TUI survival
- [x] Static audit of all `cfg.mcp` reads across codebase — all fixed

Closes #1993
Refs #2002

🤖 Generated with [Claude Code](https://claude.com/claude-code)