### PR TITLE
fix(desktop): add DeepSeek API and updater domains to CSP connect-src (#2020)

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -26,7 +26,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; img-src 'self' data: asset: https://asset.localhost; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' ipc: http://ipc.localhost"
+      "csp": "default-src 'self'; img-src 'self' data: asset: https://asset.localhost; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' ipc: http://ipc.localhost https://api.deepseek.com https://*.r2.dev https://github.com https://*.githubusercontent.com http://127.0.0.1:* ws://127.0.0.1:*"
     }
   },
   "bundle": {

--- a/tests/desktop-csp.test.ts
+++ b/tests/desktop-csp.test.ts
@@ -1,0 +1,45 @@
+// Regression test for issue #2020 — desktop CSP must allow DeepSeek API and updater endpoints.
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+function loadCsp(): string {
+  const confPath = resolve(__dirname, "../desktop/src-tauri/tauri.conf.json");
+  const raw = readFileSync(confPath, "utf8");
+  const conf = JSON.parse(raw) as { app?: { security?: { csp?: string } } };
+  return conf.app?.security?.csp ?? "";
+}
+
+describe("desktop CSP (tauri.conf.json)", () => {
+  const csp = loadCsp();
+
+  it("allows DeepSeek API in connect-src (#2020)", () => {
+    expect(csp).toContain("https://api.deepseek.com");
+  });
+
+  it("allows updater R2 endpoint in connect-src", () => {
+    expect(csp).toContain("https://*.r2.dev");
+  });
+
+  it("allows GitHub releases in connect-src (updater fallback)", () => {
+    expect(csp).toContain("https://github.com");
+    expect(csp).toContain("https://*.githubusercontent.com");
+  });
+
+  it("allows localhost connections for dev-mode dashboard", () => {
+    expect(csp).toContain("http://127.0.0.1:*");
+    expect(csp).toContain("ws://127.0.0.1:*");
+  });
+
+  it("retains Tauri IPC in connect-src", () => {
+    expect(csp).toContain("ipc:");
+    expect(csp).toContain("http://ipc.localhost");
+  });
+
+  it("retains self in connect-src", () => {
+    // Extract connect-src directive
+    const match = csp.match(/connect-src\s+([^;]+)/);
+    expect(match).toBeTruthy();
+    expect(match![1]).toContain("'self'");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #2020 — the Tauri webview CSP connect-src only allowed 'self' ipc: http://ipc.localhost, blocking outbound requests to pi.deepseek.com and the updater endpoints.

## Changes

**desktop/src-tauri/tauri.conf.json** — added to connect-src:

| Domain | Purpose |
|---|---|
| https://api.deepseek.com | DeepSeek API calls |
| https://*.r2.dev | Updater R2 CDN endpoint |
| https://github.com | Updater GitHub Releases fallback |
| https://*.githubusercontent.com | GitHub raw content |
| http://127.0.0.1:* | Dev-mode dashboard |
| ws://127.0.0.1:* | Dev-mode WebSocket |

**	ests/desktop-csp.test.ts** — regression test (6 assertions) ensures these domains remain in CSP.

## Verification

- 
px vitest run tests/desktop-csp.test.ts — 6/6 passed
- 
pm run verify — all 292 test files, 3800 tests passed (full pre-push suite)