### PR TITLE
fix(desktop): responsive sidebar — button collapse, session meta, search polish

### DIFF
--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -905,6 +905,19 @@ html[data-platform="macos"] .titlebar .tb-left {
     display: inline-flex;
   }
 }
+@container sidebar (max-width: 240px) {
+  .side-head .new-btn .shortcut {
+    display: none;
+  }
+}
+@container sidebar (max-width: 190px) {
+  .side-head .new-btn > span:not(.shortcut) {
+    display: none;
+  }
+  .side-head .new-btn {
+    justify-content: center;
+  }
+}
 .side-head .icon-btn {
   flex: 0 0 auto;
   width: 30px;
@@ -981,11 +994,14 @@ html[data-platform="macos"] .titlebar .tb-left {
 .search-row .input {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 6px 8px;
+  gap: 8px;
+  padding: 6px 9px;
   border-radius: 6px;
   background: var(--card);
   border: 1px solid var(--border);
+}
+.search-row .input > svg {
+  flex-shrink: 0;
 }
 .search-row input {
   background: none;
@@ -993,9 +1009,13 @@ html[data-platform="macos"] .titlebar .tb-left {
   outline: none;
   width: 100%;
   font-size: 14px;
+  min-width: 0;
 }
 .search-row input::placeholder {
   color: var(--muted-2);
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 .search-row .input kbd {
   font-family: inherit;
@@ -1254,8 +1274,23 @@ html[data-platform="macos"] .titlebar .tb-left {
 .session-item .body .meta .sep {
   color: var(--border-strong);
 }
+.session-item .body .meta .count,
+.session-item .body .meta .time {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+@container (max-width: 180px) {
+  .session-item .body .meta .count,
+  .session-item .body .meta .sep {
+    display: none;
+  }
+}
 .session-item .delete-btn {
-  flex-shrink: 0;
+  position: absolute;
+  top: 5px;
+  right: 8px;
   width: 22px;
   height: 22px;
   display: flex;
@@ -1270,7 +1305,9 @@ html[data-platform="macos"] .titlebar .tb-left {
   transition: opacity 120ms, background 120ms, color 120ms;
 }
 .session-item .rename-btn {
-  flex-shrink: 0;
+  position: absolute;
+  top: 5px;
+  right: 34px;
   width: 22px;
   height: 22px;
   display: flex;
@@ -1291,6 +1328,7 @@ html[data-platform="macos"] .titlebar .tb-left {
 .session-item:focus-within .rename-btn,
 .session-item .rename-btn:focus-visible {
   opacity: 1;
+  background: var(--panel-2);
 }
 .session-item .delete-btn:hover {
   background: var(--panel-2, rgba(255, 80, 80, 0.12));

--- a/desktop/src/ui/sidebar.tsx
+++ b/desktop/src/ui/sidebar.tsx
@@ -284,9 +284,11 @@ export function Sidebar({
                     <span className="title">{prettyName(s)}</span>
                   )}
                   <span className="meta">
-                    <span>{t("sidebarPanel.messageCount", { count: s.messageCount })}</span>
+                    <span className="count">
+                      {t("sidebarPanel.messageCount", { count: s.messageCount })}
+                    </span>
                     <span className="sep">·</span>
-                    <span>{updated}</span>
+                    <span className="time">{updated}</span>
                   </span>
                 </div>
                 {editing ? null : (


### PR DESCRIPTION
## What

Polishes the desktop sidebar for narrow widths and consistency. Everything is driven by container queries on the sidebar itself, so behavior adapts to the actual panel width regardless of viewport.

- New-chat button: responsive collapse, label ellipsis
- Search row: consistent padding/gap, placeholder ellipsis
- Session items: meta truncation, absolute-positioned action buttons
- Remove dead CSS

## Why

The sidebar layout breaks at narrow viewports.

## How to verify

All changes are isolated to the sidebar. Compare the before and after look - check the highlighted items in the screenshot.

<img width="2008" height="1394" alt="test" src="https://github.com/user-attachments/assets/ca0ca90c-a0d3-43f0-8c34-8de8bb90baab" />

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time
