### PR TITLE
feat(mcp): support requestTimeoutMs per-server config (#2023)

### DIFF
--- a/src/cli/commands/acp.ts
+++ b/src/cli/commands/acp.ts
@@ -114,7 +114,7 @@ export async function loadMcpServers(
       const prefix = resolveMcpPrefix(spec.name, normalizedSpecs.length, globalPrefix);
       if (spec.transport === "stdio") preflightStdioSpec(spec);
       const transport = buildTransportFromSpec(spec, { cwd: workspaceDir });
-      mcp = new McpClient({ transport, workspaceDir });
+      mcp = new McpClient({ transport, workspaceDir, requestTimeoutMs: spec.requestTimeoutMs });
       await mcp.initialize();
       const bridge = await bridgeMcpTools(mcp, {
         registry: tools,

--- a/src/cli/commands/mcp-inspect.ts
+++ b/src/cli/commands/mcp-inspect.ts
@@ -22,7 +22,11 @@ export async function mcpInspectCommand(opts: McpInspectOptions): Promise<void> 
   if (spec.transport === "stdio") preflightStdioSpec(spec);
   const workspaceDir = process.cwd();
   const transport = buildTransportFromSpec(spec, { cwd: workspaceDir });
-  const client = new McpClient({ transport, workspaceDir });
+  const client = new McpClient({
+    transport,
+    workspaceDir,
+    requestTimeoutMs: spec.requestTimeoutMs,
+  });
   try {
     await client.initialize();
     const report = await inspectMcpServer(client);

--- a/src/cli/commands/mcp-runtime.ts
+++ b/src/cli/commands/mcp-runtime.ts
@@ -186,7 +186,7 @@ export function createMcpRuntime(ctx: RuntimeContext): McpRuntime {
       if (spec.transport === "stdio") preflightStdioSpec(spec);
       const workspaceDir = ctx.getWorkspaceDir?.();
       const transport = buildTransportFromSpec(spec, { cwd: workspaceDir });
-      mcp = new McpClient({ transport, workspaceDir });
+      mcp = new McpClient({ transport, workspaceDir, requestTimeoutMs: spec.requestTimeoutMs });
       await mcp.initialize({ signal });
       const host: McpClientHost = { client: mcp };
       const bridge = await bridgeMcpTools(mcp, {

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -104,7 +104,7 @@ export async function runCommand(opts: RunOptions): Promise<void> {
             : "";
         if (spec.transport === "stdio") preflightStdioSpec(spec);
         const transport = buildTransportFromSpec(spec, { cwd: workspaceDir });
-        mcp = new McpClient({ transport, workspaceDir });
+        mcp = new McpClient({ transport, workspaceDir, requestTimeoutMs: spec.requestTimeoutMs });
         await mcp.initialize();
         const bridge = await bridgeMcpTools(mcp, {
           registry: tools,

--- a/src/config.ts
+++ b/src/config.ts
@@ -113,6 +113,8 @@ export interface McpServerConfig {
   url?: string;
   headers?: Record<string, string>;
   disabled?: boolean;
+  /** Per-request timeout in ms for this MCP server. Overrides the 60s default. (#2023) */
+  requestTimeoutMs?: number;
 }
 
 export interface QQBotConfig {
@@ -597,6 +599,7 @@ export function normalizeMcpConfig(cfg: ReasonixConfig, extraLegacy?: string[]):
         args: (serverCfg as McpServerConfig).args ?? [],
         env,
         disabled,
+        requestTimeoutMs: (serverCfg as McpServerConfig).requestTimeoutMs,
       };
       if (seen.has(name)) {
         const idx = result.findIndex((s) => s.name === name);
@@ -617,6 +620,7 @@ export function normalizeMcpConfig(cfg: ReasonixConfig, extraLegacy?: string[]):
           url,
           headers,
           disabled,
+          requestTimeoutMs: (serverCfg as McpServerConfig).requestTimeoutMs,
         };
         if (seen.has(name)) {
           const idx = result.findIndex((s) => s.name === name);
@@ -632,6 +636,7 @@ export function normalizeMcpConfig(cfg: ReasonixConfig, extraLegacy?: string[]):
           url,
           headers,
           disabled,
+          requestTimeoutMs: (serverCfg as McpServerConfig).requestTimeoutMs,
         };
         if (seen.has(name)) {
           const idx = result.findIndex((s) => s.name === name);

--- a/src/mcp/reconnect.ts
+++ b/src/mcp/reconnect.ts
@@ -20,6 +20,8 @@ export interface ReconnectArgs {
   env?: Record<string, string>;
   /** SSE / Streamable-HTTP headers overlay. */
   headers?: Record<string, string>;
+  /** Per-request timeout override in ms. */
+  requestTimeoutMs?: number;
 }
 
 export type ReconnectResult =
@@ -64,7 +66,7 @@ export async function reconnectMcpServer(args: ReconnectArgs): Promise<Reconnect
     headers: args.headers,
     cwd: workspaceDir,
   });
-  const next = new McpClient({ transport, workspaceDir });
+  const next = new McpClient({ transport, workspaceDir, requestTimeoutMs: args.requestTimeoutMs });
   try {
     await next.initialize();
     const listed = await next.listTools();

--- a/src/mcp/spec.ts
+++ b/src/mcp/spec.ts
@@ -29,9 +29,17 @@ export interface StreamableHttpMcpSpec {
 export type McpSpec = StdioMcpSpec | SseMcpSpec | StreamableHttpMcpSpec;
 
 export type McpServerSpec =
-  | (StdioMcpSpec & { env?: Record<string, string>; disabled?: boolean })
-  | (SseMcpSpec & { headers?: Record<string, string>; disabled?: boolean })
-  | (StreamableHttpMcpSpec & { headers?: Record<string, string>; disabled?: boolean });
+  | (StdioMcpSpec & { env?: Record<string, string>; disabled?: boolean; requestTimeoutMs?: number })
+  | (SseMcpSpec & {
+      headers?: Record<string, string>;
+      disabled?: boolean;
+      requestTimeoutMs?: number;
+    })
+  | (StreamableHttpMcpSpec & {
+      headers?: Record<string, string>;
+      disabled?: boolean;
+      requestTimeoutMs?: number;
+    });
 
 export function getMcpServerEnv(spec: McpServerSpec): Record<string, string> | undefined {
   return spec.transport === "stdio" ? spec.env : undefined;

--- a/tests/mcp-normalize-config.test.ts
+++ b/tests/mcp-normalize-config.test.ts
@@ -469,3 +469,64 @@ describe("normalizeMcpConfig: Claude .mcp.json compatibility", () => {
     expect(result[0]!.transport).toBe("stdio");
   });
 });
+
+describe("normalizeMcpConfig: requestTimeoutMs (#2023)", () => {
+  it("passes requestTimeoutMs through for stdio mcpServers", () => {
+    const cfg: ReasonixConfig = {
+      mcpServers: {
+        slow: {
+          command: "npx",
+          args: ["-y", "@scope/slow-server"],
+          requestTimeoutMs: 120_000,
+        },
+      },
+    };
+    const result = normalizeMcpConfig(cfg);
+    const spec = findByName(result, "slow")!;
+    expect(spec.requestTimeoutMs).toBe(120_000);
+  });
+
+  it("passes requestTimeoutMs through for SSE mcpServers", () => {
+    const cfg: ReasonixConfig = {
+      mcpServers: {
+        remote: {
+          transport: "sse",
+          url: "https://example.com/sse",
+          requestTimeoutMs: 90_000,
+        },
+      },
+    };
+    const result = normalizeMcpConfig(cfg);
+    const spec = findByName(result, "remote")!;
+    expect(spec.requestTimeoutMs).toBe(90_000);
+  });
+
+  it("passes requestTimeoutMs through for streamable-http mcpServers", () => {
+    const cfg: ReasonixConfig = {
+      mcpServers: {
+        edge: {
+          transport: "streamable-http",
+          url: "https://edge.example.com/mcp",
+          requestTimeoutMs: 180_000,
+        },
+      },
+    };
+    const result = normalizeMcpConfig(cfg);
+    const spec = findByName(result, "edge")!;
+    expect(spec.requestTimeoutMs).toBe(180_000);
+  });
+
+  it("leaves requestTimeoutMs undefined when not set", () => {
+    const cfg: ReasonixConfig = {
+      mcpServers: {
+        normal: {
+          command: "npx",
+          args: ["-y", "@scope/normal-server"],
+        },
+      },
+    };
+    const result = normalizeMcpConfig(cfg);
+    const spec = findByName(result, "normal")!;
+    expect(spec.requestTimeoutMs).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #2023 — MCP servers default to a 60s per-request timeout that cannot be overridden. Some servers (large-file processors, slow network endpoints, self-hosted instances) need more.

## Changes

Added `requestTimeoutMs` field to the full config chain:

1. **`src/config.ts`** — `McpServerConfig.requestTimeoutMs` (user-facing config)
2. **`src/mcp/spec.ts`** — `McpServerSpec.requestTimeoutMs` (internal spec)
3. **`src/config.ts`** — `normalizeMcpConfig()` passes through for all 3 transports (stdio, SSE, streamable-http)
4. **`src/mcp/reconnect.ts`** — `ReconnectArgs.requestTimeoutMs` + passed to `McpClient`
5. **`src/cli/commands/`** — all 4 MCP client creation sites (mcp-runtime, run, acp, mcp-inspect) pass `spec.requestTimeoutMs`

## Usage

```json
{
  "mcpServers": {
    "slow-server": {
      "command": "npx",
      "args": ["-y", "@scope/slow-server"],
      "requestTimeoutMs": 120000
    }
  }
}
```

Omitting the field preserves the existing 60s default.

## Verification

- `npx vitest run tests/mcp-normalize-config.test.ts` — 34/34 passed
- `npm run verify` — all 3798 tests passed (full pre-push suite)
