### PR TITLE
fix(desktop): CSP connect-src and Porcelain theme accent color

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -26,7 +26,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; img-src 'self' data: asset: https://asset.localhost; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' ipc: http://ipc.localhost"
+      "csp": "default-src 'self'; img-src 'self' data: asset: https://asset.localhost; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' ipc: http://ipc.localhost https://api.deepseek.com https://pub-147fb53b9c1e4bbf891a257968619ea7.r2.dev https://github.com"
     }
   },
   "bundle": {

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -134,9 +134,9 @@ body[data-drag-over="1"]::after {
   --muted: oklch(54% 0.005 260);
   --muted-2: oklch(68% 0.004 260);
 
-  --accent: oklch(58% 0.18 36);
-  --accent-soft: oklch(58% 0.18 36 / 0.1);
-  --accent-strong: oklch(52% 0.2 34);
+  --accent: oklch(56% 0.12 285);
+  --accent-soft: oklch(56% 0.12 285 / 0.1);
+  --accent-strong: oklch(50% 0.14 285);
 
   --success: oklch(48% 0.13 155);
   --success-soft: oklch(48% 0.13 155 / 0.1);

--- a/tests/desktop-csp.test.ts
+++ b/tests/desktop-csp.test.ts
@@ -1,0 +1,38 @@
+// Regression test for issue #2020 — desktop CSP must allow DeepSeek API and updater endpoints.
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+function loadCsp(): string {
+  const confPath = resolve(__dirname, "../desktop/src-tauri/tauri.conf.json");
+  const raw = readFileSync(confPath, "utf8");
+  const conf = JSON.parse(raw) as { app?: { security?: { csp?: string } } };
+  return conf.app?.security?.csp ?? "";
+}
+
+describe("desktop CSP (tauri.conf.json)", () => {
+  const csp = loadCsp();
+
+  it("allows DeepSeek API in connect-src (#2020)", () => {
+    expect(csp).toContain("https://api.deepseek.com");
+  });
+
+  it("allows updater R2 endpoint in connect-src", () => {
+    expect(csp).toContain("https://pub-147fb53b9c1e4bbf891a257968619ea7.r2.dev");
+  });
+
+  it("allows GitHub releases in connect-src (updater fallback)", () => {
+    expect(csp).toContain("https://github.com");
+  });
+
+  it("retains Tauri IPC in connect-src", () => {
+    expect(csp).toContain("ipc:");
+    expect(csp).toContain("http://ipc.localhost");
+  });
+
+  it("retains self in connect-src", () => {
+    const match = csp.match(/connect-src\s+([^;]+)/);
+    expect(match).toBeTruthy();
+    expect(match![1]).toContain("'self'");
+  });
+});


### PR DESCRIPTION
## Summary

This PR fixes two issues:

1. **#2020** — CSP connect-src missing DeepSeek API and updater domains
2. **#2022** — Porcelain theme accent color is orange instead of purple

## Changes

### 1. CSP Configuration (tauri.conf.json)

Added required domains to connect-src:

| Domain | Purpose |
|--------|---------|
| \https://api.deepseek.com\ | DeepSeek API calls |
| \https://pub-147fb53b9c1e4bbf891a257968619ea7.r2.dev\ | Updater R2 CDN endpoint |
| \https://github.com\ | Updater GitHub Releases fallback |

### 2. Porcelain Theme (styles.css)

Changed accent color from orange to purple:

\\\css
/* Before (orange) */
--accent: oklch(58% 0.18 36);

/* After (purple) */
--accent: oklch(56% 0.12 285);
\\\

This makes Porcelain theme consistent with Midnight theme, which already uses purple accent.

### 3. Regression Tests

Added \	ests/desktop-csp.test.ts\ with 5 assertions to prevent CSP regressions.

## Comparison with PR #2033

| Aspect | PR #2033 | This PR |
|--------|----------|---------|
| R2 domain | \https://*.r2.dev\ (wildcard) | Specific URL |
| GitHub content | \https://*.githubusercontent.com\ | Not needed |
| Dev localhost | \http://127.0.0.1:* ws://\ | Not needed in production |
| Theme fix | ❌ | ✅ Fixes #2022 |

## Verification

- All 5 CSP tests pass
- Porcelain theme now shows purple buttons (matches Midnight theme)