### PR TITLE
 feat(search): 内置符号知识图谱 — 加速代码搜索与数据检索增强feat(search): accelerate data search and indexing symbols

### DIFF
--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -1,4 +1,4 @@
-/** `reasonix index` — progress writes go to stderr so stdout stays pipeable. */
+/** `reasonix index` — builds semantic (or symbol) index. Progress on stderr. */
 
 import { resolve } from "node:path";
 import { loadIndexConfig, resolveSemanticEmbeddingConfig } from "../../config.js";
@@ -6,6 +6,7 @@ import { buildIndex } from "../../index/semantic/builder.js";
 import type { BuildProgress, BuildResult, SkipBuckets } from "../../index/semantic/builder.js";
 import { t } from "../../index/semantic/i18n.js";
 import { semanticPreflight } from "../../index/semantic/preflight.js";
+import { buildSymbolIndex } from "../../index/symbol/builder.js";
 
 export interface IndexCommandOptions {
   rebuild?: boolean;
@@ -13,10 +14,35 @@ export interface IndexCommandOptions {
   dir?: string;
   ollamaUrl?: string;
   yes?: boolean;
+  symbols?: boolean;
 }
 
 export async function indexCommand(opts: IndexCommandOptions = {}): Promise<void> {
   const root = resolve(opts.dir ?? process.cwd());
+
+  // Symbol index — no model required, just tree-sitter
+  if (opts.symbols) {
+    const t0 = Date.now();
+    process.stderr.write("Building symbol index…\n");
+    const result = await buildSymbolIndex(root, {
+      indexConfig: loadIndexConfig(),
+      onProgress: (p) => {
+        if (p.phase === "extract" && p.filesScanned) {
+          process.stderr.write(
+            `\r  ${p.filesScanned} files scanned, ${p.symbolsFound ?? 0} symbols found`,
+          );
+        }
+      },
+    });
+    const seconds = ((Date.now() - t0) / 1000).toFixed(1);
+    process.stderr.write(
+      `\r✓ ${result.symbolsFound} symbols in ${result.filesExtracted} files (${seconds}s)\n`,
+    );
+    if (result.filesSkipped > 0) {
+      process.stderr.write(`  · skipped ${result.filesSkipped} files\n`);
+    }
+    return;
+  }
   const tty = process.stderr.isTTY === true && process.stdin.isTTY === true;
   const resolved = resolveSemanticEmbeddingConfig();
   const embedding =

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -653,6 +653,10 @@ program
   .option("--dir <path>", t("ui.projectDirHint"))
   .option("--ollama-url <url>", t("ui.ollamaUrlHint"))
   .option("-y, --yes", t("ui.skipPromptsHint"))
+  .option(
+    "--symbols",
+    "Build the symbol knowledge graph index (callers/callees/impact). No embedding model required.",
+  )
   .action(
     async (opts: {
       rebuild?: boolean;
@@ -660,6 +664,7 @@ program
       dir?: string;
       ollamaUrl?: string;
       yes?: boolean;
+      symbols?: boolean;
     }) => {
       const { indexCommand } = await import("./commands/index.js");
       await indexCommand(opts);

--- a/src/code/setup.ts
+++ b/src/code/setup.ts
@@ -13,6 +13,7 @@ import {
   searchEnabled,
 } from "../config.js";
 import { bootstrapSemanticSearchInCodeMode } from "../index/semantic/tool.js";
+import { bootstrapSymbolSearch } from "../index/symbol/tool.js";
 import { ToolRegistry } from "../tools.js";
 import { registerChoiceTool } from "../tools/choice.js";
 import { registerCodeQueryTools } from "../tools/code-query.js";
@@ -51,6 +52,7 @@ export interface CodeToolset {
   registerRooted: (root: string) => void;
   reBootstrapSemantic: (root: string) => Promise<{ enabled: boolean }>;
   semantic: { enabled: boolean };
+  symbol: { enabled: boolean };
 }
 
 /** Mirror `editMode === "plan"` into the registry's dispatch gate — keeps a single source of truth (the persisted EditMode) for the read-only mode. */
@@ -132,5 +134,7 @@ export async function buildCodeToolset(opts: CodeToolsetOpts): Promise<CodeTools
 
   const semantic = await reBootstrapSemantic(opts.rootDir);
 
-  return { tools, jobs, registerRooted, reBootstrapSemantic, semantic };
+  const symbol = await bootstrapSymbolSearch(tools, opts.rootDir);
+
+  return { tools, jobs, registerRooted, reBootstrapSemantic, semantic, symbol };
 }

--- a/src/index/symbol/builder.ts
+++ b/src/index/symbol/builder.ts
@@ -1,0 +1,421 @@
+/** Walk project → extract symbols via tree-sitter → persist to SymbolStore. */
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { grammarForPath } from "../../code-query/grammar-map.js";
+import { extractSymbols } from "../../code-query/symbols.js";
+import { type GitignoreLayer, ignoredByLayers, loadGitignoreAt } from "../../gitignore.js";
+import {
+  type IndexFilters,
+  type ResolvedIndexConfig,
+  compileFilters,
+  defaultIndexConfig,
+} from "../config.js";
+import { type RawCallEdge, extractCallEdges } from "./edges.js";
+import { resolveCallEdges } from "./resolver.js";
+import { SYMBOL_INDEX_DIR, SymbolStore, openStore, qualifiedName, symbolId } from "./store.js";
+import type { CallEdge, SymbolEntry } from "./types.js";
+
+export interface BuildProgress {
+  phase: "scan" | "extract" | "edges" | "resolve" | "done";
+  filesScanned?: number;
+  filesExtracted?: number;
+  symbolsFound?: number;
+  edgesFound?: number;
+  edgesResolved?: number;
+}
+
+export interface BuildResult {
+  filesScanned: number;
+  filesExtracted: number;
+  filesSkipped: number;
+  symbolsFound: number;
+  durationMs: number;
+}
+
+export interface SyncResult {
+  filesChecked: number;
+  filesAdded: number;
+  filesModified: number;
+  filesRemoved: number;
+  symbolsUpdated: number;
+  durationMs: number;
+}
+
+export interface BuildOptions {
+  /** Override index config for file walking. */
+  indexConfig?: ResolvedIndexConfig;
+  /** Abort signal for cancellation. */
+  signal?: AbortSignal;
+  /** Progress callback. */
+  onProgress?: (info: BuildProgress) => void;
+}
+
+/** Full (re)build of the symbol index from scratch. */
+export async function buildSymbolIndex(
+  root: string,
+  opts: BuildOptions = {},
+): Promise<BuildResult> {
+  const t0 = Date.now();
+  const indexDir = path.join(root, SYMBOL_INDEX_DIR);
+  const filters: IndexFilters = compileFilters(opts.indexConfig ?? defaultIndexConfig());
+
+  // Wipe and start fresh for full rebuilds
+  const store = await openStore(indexDir);
+  await store.wipe();
+
+  let filesScanned = 0;
+  let filesExtracted = 0;
+  let filesSkipped = 0;
+  let symbolsFound = 0;
+
+  const rootIg = filters.respectGitignore ? await loadGitignoreAt(root) : null;
+  const initialLayers: GitignoreLayer[] = rootIg ? [{ dirAbs: root, ig: rootIg }] : [];
+
+  opts.onProgress?.({ phase: "scan", filesScanned: 0 });
+
+  const allRawEdges: RawCallEdge[] = [];
+
+  for await (const { abs, rel, layers } of walkSourceFiles(root, initialLayers, filters)) {
+    throwIfAborted(opts.signal);
+    filesScanned++;
+
+    // Only process files with supported grammars
+    if (!grammarForPath(rel)) {
+      filesSkipped++;
+      continue;
+    }
+
+    let source: string;
+    try {
+      source = await fs.readFile(abs, "utf8");
+    } catch {
+      filesSkipped++;
+      continue;
+    }
+
+    // Skip binary-looking content
+    if (source.indexOf("\0") !== -1) {
+      filesSkipped++;
+      continue;
+    }
+
+    let mtimeMs = 0;
+    try {
+      const stat = await fs.stat(abs);
+      mtimeMs = stat.mtimeMs;
+    } catch {
+      mtimeMs = Date.now();
+    }
+
+    const symbols = await extractSymbols(rel, source);
+    if (symbols.length === 0) {
+      filesSkipped++;
+      continue;
+    }
+
+    const entries: SymbolEntry[] = symbols.map((sym) => ({
+      id: symbolId(rel, sym.name, sym.line),
+      name: sym.name,
+      qualifiedName: qualifiedName(rel, sym.name, sym.parent),
+      filePath: rel,
+      kind: sym.kind,
+      startLine: sym.line,
+      endLine: sym.endLine,
+      startColumn: sym.column,
+      endColumn: sym.endColumn,
+      parent: sym.parent,
+      signature: undefined,
+      mtimeMs,
+    }));
+
+    await store.add(entries);
+    filesExtracted++;
+    symbolsFound += entries.length;
+
+    // Extract call edges from this file
+    const rawEdges = await extractCallEdges(rel, source);
+    allRawEdges.push(...rawEdges);
+
+    if (filesScanned % 100 === 0) {
+      opts.onProgress?.({
+        phase: "extract",
+        filesScanned,
+        filesExtracted,
+        symbolsFound,
+      });
+    }
+  }
+
+  // Resolve all accumulated call edges
+  opts.onProgress?.({
+    phase: "edges",
+    filesScanned,
+    filesExtracted,
+    symbolsFound,
+    edgesFound: allRawEdges.length,
+  });
+  const { edges, result: resolutionResult } = resolveCallEdges(allRawEdges, store);
+  await store.addEdges(edges);
+
+  opts.onProgress?.({
+    phase: "done",
+    filesScanned,
+    filesExtracted,
+    symbolsFound,
+    edgesFound: allRawEdges.length,
+    edgesResolved: resolutionResult.resolved,
+  });
+
+  return {
+    filesScanned,
+    filesExtracted,
+    filesSkipped,
+    symbolsFound,
+    durationMs: Date.now() - t0,
+  };
+}
+
+/** Incremental update: re-extract changed files, remove deleted files. */
+export async function syncSymbolIndex(
+  root: string,
+  opts: BuildOptions & { changedFiles?: string[] } = {},
+): Promise<SyncResult> {
+  const t0 = Date.now();
+  const indexDir = path.join(root, SYMBOL_INDEX_DIR);
+  const filters: IndexFilters = compileFilters(opts.indexConfig ?? defaultIndexConfig());
+  const store = await openStore(indexDir);
+
+  const lastMtimes = store.fileMtimes();
+  const rootIg = filters.respectGitignore ? await loadGitignoreAt(root) : null;
+  const initialLayers: GitignoreLayer[] = rootIg ? [{ dirAbs: root, ig: rootIg }] : [];
+
+  let filesChecked = 0;
+  let filesAdded = 0;
+  let filesModified = 0;
+  let filesRemoved = 0;
+  let symbolsUpdated = 0;
+
+  // If we have a specific changed-files list, scope to those
+  const scoped = opts.changedFiles && opts.changedFiles.length > 0;
+
+  if (scoped) {
+    const changed = new Set(opts.changedFiles!);
+    for (const rel of changed) {
+      throwIfAborted(opts.signal);
+      const abs = path.join(root, rel);
+      filesChecked++;
+
+      // File removed?
+      try {
+        await fs.access(abs);
+      } catch {
+        const removed = await store.remove([rel]);
+        if (removed > 0) {
+          filesRemoved++;
+          symbolsUpdated += removed;
+        }
+        continue;
+      }
+
+      if (!grammarForPath(rel)) continue;
+
+      let source: string;
+      try {
+        source = await fs.readFile(abs, "utf8");
+      } catch {
+        continue;
+      }
+      if (source.indexOf("\0") !== -1) continue;
+
+      let mtimeMs = 0;
+      try {
+        const stat = await fs.stat(abs);
+        mtimeMs = stat.mtimeMs;
+      } catch {
+        continue;
+      }
+
+      const last = lastMtimes.get(rel);
+      if (last !== undefined && last === mtimeMs) continue;
+
+      // Remove old entries for this file, then add new
+      await store.remove([rel]);
+      const symbols = await extractSymbols(rel, source);
+      if (symbols.length === 0) continue;
+
+      const entries: SymbolEntry[] = symbols.map((sym) => ({
+        id: symbolId(rel, sym.name, sym.line),
+        name: sym.name,
+        qualifiedName: qualifiedName(rel, sym.name, sym.parent),
+        filePath: rel,
+        kind: sym.kind,
+        startLine: sym.line,
+        endLine: sym.endLine,
+        startColumn: sym.column,
+        endColumn: sym.endColumn,
+        parent: sym.parent,
+        signature: undefined,
+        mtimeMs,
+      }));
+      await store.add(entries);
+
+      if (last === undefined) filesAdded++;
+      else filesModified++;
+      symbolsUpdated += entries.length;
+    }
+  } else {
+    // Full scan for changes
+    const seen = new Set<string>();
+    for await (const { abs, rel } of walkSourceFiles(root, initialLayers, filters)) {
+      throwIfAborted(opts.signal);
+      seen.add(rel);
+      filesChecked++;
+
+      if (!grammarForPath(rel)) continue;
+
+      let mtimeMs = 0;
+      try {
+        const stat = await fs.stat(abs);
+        mtimeMs = stat.mtimeMs;
+      } catch {
+        continue;
+      }
+
+      const last = lastMtimes.get(rel);
+      if (last !== undefined && last === mtimeMs) continue;
+
+      let source: string;
+      try {
+        source = await fs.readFile(abs, "utf8");
+      } catch {
+        continue;
+      }
+      if (source.indexOf("\0") !== -1) continue;
+
+      await store.remove([rel]);
+      const symbols = await extractSymbols(rel, source);
+      if (symbols.length === 0) continue;
+
+      const entries: SymbolEntry[] = symbols.map((sym) => ({
+        id: symbolId(rel, sym.name, sym.line),
+        name: sym.name,
+        qualifiedName: qualifiedName(rel, sym.name, sym.parent),
+        filePath: rel,
+        kind: sym.kind,
+        startLine: sym.line,
+        endLine: sym.endLine,
+        startColumn: sym.column,
+        endColumn: sym.endColumn,
+        parent: sym.parent,
+        signature: undefined,
+        mtimeMs,
+      }));
+      await store.add(entries);
+
+      if (last === undefined) filesAdded++;
+      else filesModified++;
+      symbolsUpdated += entries.length;
+    }
+
+    // Remove files no longer on disk
+    for (const oldPath of lastMtimes.keys()) {
+      if (!seen.has(oldPath)) {
+        const removed = await store.remove([oldPath]);
+        if (removed > 0) {
+          filesRemoved++;
+          symbolsUpdated += removed;
+        }
+      }
+    }
+  }
+
+  return {
+    filesChecked,
+    filesAdded,
+    filesModified,
+    filesRemoved,
+    symbolsUpdated,
+    durationMs: Date.now() - t0,
+  };
+}
+
+interface WalkFrame {
+  dir: string;
+  layers: readonly GitignoreLayer[];
+}
+
+interface WalkEntry {
+  abs: string;
+  rel: string;
+  layers: readonly GitignoreLayer[];
+}
+
+async function* walkSourceFiles(
+  root: string,
+  initialLayers: readonly GitignoreLayer[],
+  filters: IndexFilters,
+): AsyncGenerator<WalkEntry> {
+  const stack: WalkFrame[] = [{ dir: root, layers: initialLayers }];
+
+  while (stack.length > 0) {
+    const frame = stack.pop();
+    if (!frame) break;
+    const { dir, layers } = frame;
+
+    let entries: import("node:fs").Dirent[];
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      const name = entry.name;
+      const abs = path.join(dir, name);
+      const rel = path.relative(root, abs).split(path.sep).join("/");
+
+      if (entry.isDirectory()) {
+        if (filters.dirSet.has(name)) continue;
+        if (filters.respectGitignore && ignoredByLayers(layers, abs, true)) continue;
+        if (filters.patternMatch(`${rel}/`) || filters.patternMatch(rel)) continue;
+        const childLayers = filters.respectGitignore ? await extendLayers(layers, abs) : layers;
+        stack.push({ dir: abs, layers: childLayers });
+        continue;
+      }
+
+      if (!entry.isFile()) continue;
+      if (filters.fileSet.has(name)) continue;
+      const ext = path.extname(name).toLowerCase();
+      if (filters.extSet.has(ext)) continue;
+      if (filters.respectGitignore && ignoredByLayers(layers, abs, false)) continue;
+      if (filters.patternMatch(rel)) continue;
+
+      // Size gate
+      try {
+        const stat = await fs.stat(abs);
+        if (stat.size > filters.maxFileBytes) continue;
+      } catch {
+        continue;
+      }
+
+      yield { abs, rel, layers };
+    }
+  }
+}
+
+async function extendLayers(
+  layers: readonly GitignoreLayer[],
+  dirAbs: string,
+): Promise<readonly GitignoreLayer[]> {
+  const ig = await loadGitignoreAt(dirAbs);
+  return ig ? [...layers, { dirAbs, ig }] : layers;
+}
+
+export { SymbolWatcher, type WatchOptions } from "./watcher.js";
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) {
+    throw new Error("symbol indexing aborted");
+  }
+}

--- a/src/index/symbol/context.ts
+++ b/src/index/symbol/context.ts
@@ -1,0 +1,420 @@
+/** Context builder: symbol search + call graph + source → one-shot code_context. */
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { type TraversalHop, getCallees, getCallers } from "./graph.js";
+import type { SymbolStore } from "./store.js";
+import type { CallEdge, SymbolEntry } from "./types.js";
+
+export interface ContextOptions {
+  /** Max symbols to include in the result (default 15). */
+  maxNodes?: number;
+  /** Include source code snippets (default true). */
+  includeCode?: boolean;
+  /** Max characters per code snippet (default 1500). */
+  maxCodeSize?: number;
+  /** Call-graph expansion depth (default 1). */
+  traversalDepth?: number;
+  /** Max output characters (default 12000). */
+  maxOutput?: number;
+}
+
+const DEFAULT_OPTIONS: Required<ContextOptions> = {
+  maxNodes: 15,
+  includeCode: true,
+  maxCodeSize: 1500,
+  traversalDepth: 1,
+  maxOutput: 12000,
+};
+
+/** Extract likely symbol names from a natural-language query. */
+function extractSymbolNames(query: string): string[] {
+  const names = new Set<string>();
+
+  // CamelCase: AuthService, loginUser
+  for (const m of query.matchAll(/\b([A-Z][a-z]+(?:[A-Z][a-z]*)*|[a-z]+(?:[A-Z][a-z]*)+)\b/g)) {
+    if (m[1] && m[1].length >= 3) names.add(m[1]!);
+  }
+
+  // snake_case: user_service
+  for (const m of query.matchAll(/\b([a-z][a-z0-9]*(?:_[a-z0-9]+)+)\b/gi)) {
+    if (m[1] && m[1].length >= 4) names.add(m[1]!);
+  }
+
+  // UPPER_CASE acronyms: HTTP, JSON, LRU
+  for (const m of query.matchAll(/\b([A-Z]{2,})\b/g)) {
+    names.add(m[1]!);
+  }
+
+  // dot.notation parts: "app.isPackaged" → ["app", "isPackaged"]
+  for (const m of query.matchAll(/\b([a-zA-Z][a-zA-Z0-9]*(?:\.[a-zA-Z][a-zA-Z0-9]*)+)\b/g)) {
+    for (const part of m[1]!.split(".")) {
+      if (part.length >= 2) names.add(part);
+    }
+  }
+
+  // Plain lowercase identifiers (≥3 chars)
+  for (const m of query.matchAll(/\b([a-z][a-z0-9]{2,})\b/g)) {
+    names.add(m[1]!);
+  }
+
+  // Filter common English words
+  const commonWords = new Set([
+    "the",
+    "and",
+    "for",
+    "with",
+    "from",
+    "this",
+    "that",
+    "have",
+    "been",
+    "will",
+    "would",
+    "could",
+    "should",
+    "does",
+    "done",
+    "make",
+    "made",
+    "use",
+    "used",
+    "using",
+    "work",
+    "works",
+    "find",
+    "found",
+    "show",
+    "call",
+    "called",
+    "calling",
+    "get",
+    "set",
+    "add",
+    "all",
+    "any",
+    "how",
+    "what",
+    "when",
+    "where",
+    "which",
+    "who",
+    "why",
+    "not",
+    "but",
+    "are",
+    "was",
+    "were",
+    "has",
+    "had",
+    "its",
+    "can",
+    "did",
+    "may",
+    "also",
+    "into",
+    "than",
+    "then",
+    "them",
+    "each",
+    "other",
+    "some",
+    "such",
+    "only",
+    "same",
+    "about",
+    "after",
+    "before",
+    "between",
+    "through",
+    "during",
+    "without",
+    "system",
+    "need",
+    "needs",
+    "want",
+    "like",
+    "look",
+    "data",
+    "flow",
+    "request",
+    "response",
+    "handle",
+    "code",
+    "change",
+    "changes",
+    "changed",
+    "method",
+    "class",
+    "function",
+    "return",
+    "returns",
+    "create",
+    "read",
+    "write",
+    "start",
+    "stop",
+    "run",
+    "running",
+    "check",
+    "take",
+    "takes",
+    "else",
+    "just",
+    "more",
+    "most",
+    "very",
+    "being",
+    "having",
+    "doing",
+  ]);
+
+  return [...names].filter((n) => !commonWords.has(n.toLowerCase()));
+}
+
+export interface ContextResult {
+  query: string;
+  entryPoints: SymbolEntry[];
+  relatedSymbols: SymbolEntry[];
+  callRelationships: string[];
+  codeBlocks: CodeBlock[];
+  summary: string;
+}
+
+interface CodeBlock {
+  symbolName: string;
+  filePath: string;
+  startLine: number;
+  endLine: number;
+  kind: string;
+  content: string;
+}
+
+/** Build context: extract names → search → call-graph expand → read source → format. */
+export async function buildContext(
+  query: string,
+  store: SymbolStore,
+  projectRoot: string,
+  opts: ContextOptions = {},
+): Promise<ContextResult> {
+  const o = { ...DEFAULT_OPTIONS, ...opts };
+
+  // Step 1: Extract symbol names from query
+  const queryNames = extractSymbolNames(query);
+  if (queryNames.length === 0) {
+    return {
+      query,
+      entryPoints: [],
+      relatedSymbols: [],
+      callRelationships: [],
+      codeBlocks: [],
+      summary: "No recognizable symbol names found in the query.",
+    };
+  }
+
+  // Step 2: Search the index for each extracted name
+  const seen = new Set<string>();
+  const entryPoints: SymbolEntry[] = [];
+  for (const name of queryNames.slice(0, 10)) {
+    const hits = store.search(name, { limit: 3 });
+    for (const hit of hits) {
+      if (!seen.has(hit.entry.id)) {
+        seen.add(hit.entry.id);
+        entryPoints.push(hit.entry);
+      }
+    }
+    if (entryPoints.length >= o.maxNodes) break;
+  }
+
+  if (entryPoints.length === 0) {
+    return {
+      query,
+      entryPoints: [],
+      relatedSymbols: [],
+      callRelationships: [],
+      codeBlocks: [],
+      summary: `No symbols matched the query terms: ${queryNames.slice(0, 5).join(", ")}.`,
+    };
+  }
+
+  // Step 3: Expand via call graph from entry points
+  const relatedMap = new Map<string, SymbolEntry>();
+  const relationships: string[] = [];
+
+  for (const ep of entryPoints.slice(0, 8)) {
+    // Get callers
+    const callers = getCallers(store, ep.id, o.traversalDepth);
+    for (const hop of callers.hops) {
+      if (!seen.has(hop.entry.id) && !relatedMap.has(hop.entry.id)) {
+        relatedMap.set(hop.entry.id, hop.entry);
+        seen.add(hop.entry.id);
+      }
+      if (hop.edge.resolved) {
+        relationships.push(
+          `${hop.entry.name} → ${ep.name} (${hop.entry.filePath}:${hop.edge.line})`,
+        );
+      }
+    }
+
+    // Get callees
+    const callees = getCallees(store, ep.id, o.traversalDepth);
+    for (const hop of callees.hops) {
+      if (!seen.has(hop.entry.id) && !relatedMap.has(hop.entry.id)) {
+        relatedMap.set(hop.entry.id, hop.entry);
+        seen.add(hop.entry.id);
+      }
+      if (hop.edge.resolved) {
+        relationships.push(`${ep.name} → ${hop.entry.name} (${ep.filePath}:${hop.edge.line})`);
+      }
+    }
+  }
+
+  const relatedSymbols = [...relatedMap.values()].slice(0, o.maxNodes - entryPoints.length);
+
+  // Step 4: Read source for key symbols
+  const codeBlocks: CodeBlock[] = [];
+  if (o.includeCode) {
+    const symbolsForCode = [...entryPoints.slice(0, 5), ...relatedSymbols.slice(0, 5)];
+    const fileCache = new Map<string, string>();
+
+    for (const sym of symbolsForCode) {
+      try {
+        let source = fileCache.get(sym.filePath);
+        if (source === undefined) {
+          const abs = path.join(projectRoot, sym.filePath);
+          source = await fs.readFile(abs, "utf8");
+          fileCache.set(sym.filePath, source);
+        }
+        const lines = source.split(/\r?\n/);
+        const start = Math.max(0, sym.startLine - 1);
+        const end = Math.min(lines.length, sym.endLine);
+        const slice = lines.slice(start, end).join("\n");
+        if (slice.length > o.maxCodeSize) {
+          codeBlocks.push({
+            symbolName: sym.name,
+            filePath: sym.filePath,
+            startLine: sym.startLine,
+            endLine: sym.endLine,
+            kind: sym.kind,
+            content: `${slice.slice(0, o.maxCodeSize)}\n…(truncated)`,
+          });
+        } else {
+          codeBlocks.push({
+            symbolName: sym.name,
+            filePath: sym.filePath,
+            startLine: sym.startLine,
+            endLine: sym.endLine,
+            kind: sym.kind,
+            content: slice,
+          });
+        }
+      } catch {
+        // File unreadable — skip
+      }
+    }
+  }
+
+  // Step 5: Build summary
+  const summary = buildSummary(query, entryPoints, relatedSymbols, relationships);
+
+  return {
+    query,
+    entryPoints,
+    relatedSymbols,
+    callRelationships: relationships,
+    codeBlocks,
+    summary,
+  };
+}
+
+function buildSummary(
+  query: string,
+  entryPoints: SymbolEntry[],
+  related: SymbolEntry[],
+  relationships: string[],
+): string {
+  const parts: string[] = [];
+  if (entryPoints.length > 0) {
+    parts.push(`${entryPoints.length} entry point${entryPoints.length > 1 ? "s" : ""}`);
+  }
+  if (related.length > 0) {
+    parts.push(`${related.length} related symbol${related.length > 1 ? "s" : ""}`);
+  }
+  if (relationships.length > 0) {
+    parts.push(`${relationships.length} call relationship${relationships.length > 1 ? "s" : ""}`);
+  }
+  return parts.length > 0
+    ? `Found: ${parts.join(", ")} for "${query}".`
+    : `No results for "${query}".`;
+}
+
+/** Format context as markdown for model consumption. */
+export function formatContextAsMarkdown(ctx: ContextResult): string {
+  const lines: string[] = [];
+
+  // Header
+  lines.push(`## Context for: ${ctx.query}`);
+  lines.push("");
+  lines.push(ctx.summary);
+  lines.push("");
+
+  // Entry points
+  if (ctx.entryPoints.length > 0) {
+    lines.push("### Entry Points");
+    lines.push("");
+    for (const ep of ctx.entryPoints.slice(0, 10)) {
+      const qual = ep.parent ? `${ep.parent}.${ep.name}` : ep.name;
+      lines.push(`- \`${qual}\` (${ep.kind}) — ${ep.filePath}:${ep.startLine}`);
+    }
+    lines.push("");
+  }
+
+  // Related symbols
+  if (ctx.relatedSymbols.length > 0) {
+    lines.push("### Related Symbols");
+    lines.push("");
+    for (const sym of ctx.relatedSymbols.slice(0, 10)) {
+      const qual = sym.parent ? `${sym.parent}.${sym.name}` : sym.name;
+      lines.push(`- \`${qual}\` (${sym.kind}) — ${sym.filePath}:${sym.startLine}`);
+    }
+    lines.push("");
+  }
+
+  // Call relationships
+  if (ctx.callRelationships.length > 0) {
+    lines.push("### Call Relationships");
+    lines.push("");
+    const shown = ctx.callRelationships.slice(0, 15);
+    for (const rel of shown) {
+      lines.push(`- ${rel}`);
+    }
+    if (ctx.callRelationships.length > 15) {
+      lines.push(`- …and ${ctx.callRelationships.length - 15} more`);
+    }
+    lines.push("");
+  }
+
+  // Code blocks
+  if (ctx.codeBlocks.length > 0) {
+    lines.push("### Code");
+    lines.push("");
+    for (const block of ctx.codeBlocks.slice(0, 8)) {
+      const qual = block.symbolName;
+      lines.push(
+        `#### ${qual} (${block.kind}) — ${block.filePath}:${block.startLine}-${block.endLine}`,
+      );
+      lines.push("");
+      lines.push("```");
+      lines.push(block.content);
+      lines.push("```");
+      lines.push("");
+    }
+  }
+
+  // Cap output
+  const text = lines.join("\n");
+  if (text.length > 12000) {
+    return `${text.slice(0, 12000)}\n\n…(context output capped at 12K chars)`;
+  }
+  return text;
+}

--- a/src/index/symbol/edges.ts
+++ b/src/index/symbol/edges.ts
@@ -1,0 +1,147 @@
+/** Call-edge extraction from tree-sitter ASTs — raw (unresolved) caller→callee pairs. */
+
+import type { Node } from "web-tree-sitter";
+import { type GrammarName, getParser, grammarForPath } from "../../code-query/parser.js";
+
+/** A raw call edge — callee is still a name string, not a symbol ID. */
+export interface RawCallEdge {
+  /** Name of the caller function/method (unqualified). */
+  callerName: string;
+  /** File path the caller lives in. */
+  callerFile: string;
+  /** Start line of the caller function. Used to disambiguate same-named callers. */
+  callerLine: number;
+  /** Name being called (the identifier text at the call site). */
+  calleeName: string;
+  /** File path where the call occurs. */
+  file: string;
+  /** 1-based line number of the call site. */
+  line: number;
+}
+
+const CALL_PARENT_TYPES = new Set([
+  "call_expression",
+  "new_expression",
+  "call",
+  "method_invocation",
+  "object_creation_expression",
+]);
+
+const MEMBER_EXPRESSION_TYPES = new Set([
+  "member_expression",
+  "attribute",
+  "selector_expression",
+  "field_expression",
+]);
+
+const FUNC_CONTAINER_TYPES = new Set([
+  "function_declaration",
+  "function_definition",
+  "method_definition",
+  "method_declaration",
+  "arrow_function",
+  "function_item",
+  "constructor_declaration",
+]);
+
+const IDENTIFIER_TYPES = new Set([
+  "identifier",
+  "property_identifier",
+  "type_identifier",
+  "field_identifier",
+]);
+
+/** Extract call edges from a single source file — walks AST for call sites. */
+export async function extractCallEdges(filePath: string, source: string): Promise<RawCallEdge[]> {
+  const grammar = grammarForPath(filePath);
+  if (!grammar) return [];
+  const parser = await getParser(grammar);
+  try {
+    const tree = parser.parse(source);
+    if (!tree) return [];
+    try {
+      const edges: RawCallEdge[] = [];
+      const cursor = tree.rootNode.walk();
+      try {
+        let visitedChildren = false;
+        while (true) {
+          if (!visitedChildren) {
+            const node = cursor.currentNode;
+            if (CALL_PARENT_TYPES.has(node.type)) {
+              const callee = extractCalleeName(node);
+              if (callee) {
+                const caller = findEnclosingFunction(node);
+                edges.push({
+                  callerName: caller.name,
+                  callerFile: filePath,
+                  callerLine: caller.line,
+                  calleeName: callee,
+                  file: filePath,
+                  line: node.startPosition.row + 1,
+                });
+              }
+            }
+          }
+          if (!visitedChildren && cursor.gotoFirstChild()) {
+            visitedChildren = false;
+            continue;
+          }
+          if (cursor.gotoNextSibling()) {
+            visitedChildren = false;
+            continue;
+          }
+          if (!cursor.gotoParent()) break;
+          visitedChildren = true;
+        }
+      } finally {
+        cursor.delete();
+      }
+      return edges;
+    } finally {
+      tree.delete();
+    }
+  } finally {
+    parser.delete();
+  }
+}
+
+/** Extract the function/method name from a call-expression node. */
+function extractCalleeName(node: Node): string | null {
+  // Direct call: foo()
+  const funcField = firstField(node, ["function", "constructor"]);
+  if (funcField && IDENTIFIER_TYPES.has(funcField.type)) {
+    return funcField.text;
+  }
+  // Member call: obj.foo() — get the property name
+  if (funcField && MEMBER_EXPRESSION_TYPES.has(funcField.type)) {
+    const prop = firstField(funcField, ["property", "field", "attribute"]);
+    if (prop && IDENTIFIER_TYPES.has(prop.type)) {
+      return prop.text;
+    }
+  }
+  return null;
+}
+
+/** Find the enclosing function/method that contains this node. */
+function findEnclosingFunction(node: Node): { name: string; line: number } {
+  let current: Node | null = node.parent;
+  while (current) {
+    if (FUNC_CONTAINER_TYPES.has(current.type)) {
+      const nameNode = current.childForFieldName("name");
+      return {
+        name: nameNode?.text ?? "<anonymous>",
+        line: current.startPosition.row + 1,
+      };
+    }
+    current = current.parent;
+  }
+  return { name: "<top-level>", line: 1 };
+}
+
+function firstField(parent: Node, fields: readonly string[]): Node | null {
+  for (const field of fields) {
+    const child = parent.childForFieldName(field);
+    if (child) return child;
+  }
+  return null;
+}

--- a/src/index/symbol/graph.ts
+++ b/src/index/symbol/graph.ts
@@ -1,0 +1,105 @@
+/** Call-graph traversal — BFS callers/callees/impact over SymbolStore edges. */
+
+import type { SymbolStore } from "./store.js";
+import type { CallEdge, SymbolEntry } from "./types.js";
+
+export interface TraversalHop {
+  entry: SymbolEntry;
+  edge: CallEdge;
+}
+
+export interface TraversalResult {
+  hops: TraversalHop[];
+  visited: Set<string>;
+}
+
+/** Find all symbols that call `symbolId`, up to `depth` levels (BFS incoming). */
+export function getCallers(store: SymbolStore, symbolId: string, depth = 1): TraversalResult {
+  const hops: TraversalHop[] = [];
+  const visited = new Set<string>([symbolId]);
+  let frontier = new Set<string>([symbolId]);
+
+  for (let d = 0; d < depth; d++) {
+    const next = new Set<string>();
+    for (const id of frontier) {
+      for (const edge of store.edgesTo(id)) {
+        if (visited.has(edge.sourceId)) continue;
+        const entry = store.getById(edge.sourceId);
+        if (!entry) continue;
+        visited.add(edge.sourceId);
+        next.add(edge.sourceId);
+        hops.push({ entry, edge });
+      }
+    }
+    frontier = next;
+    if (frontier.size === 0) break;
+  }
+
+  return { hops, visited };
+}
+
+/** Find all symbols called by `symbolId`, up to `depth` levels (BFS outgoing). */
+export function getCallees(store: SymbolStore, symbolId: string, depth = 1): TraversalResult {
+  const hops: TraversalHop[] = [];
+  const visited = new Set<string>([symbolId]);
+  let frontier = new Set<string>([symbolId]);
+
+  for (let d = 0; d < depth; d++) {
+    const next = new Set<string>();
+    for (const id of frontier) {
+      for (const edge of store.edgesFrom(id)) {
+        if (!edge.targetId || visited.has(edge.targetId)) continue;
+        const entry = store.getById(edge.targetId);
+        if (!entry) continue;
+        visited.add(edge.targetId);
+        next.add(edge.targetId);
+        hops.push({ entry, edge });
+      }
+    }
+    frontier = next;
+    if (frontier.size === 0) break;
+  }
+
+  return { hops, visited };
+}
+
+/** Impact radius: transitive callers of `symbolId` up to `depth` levels. */
+export function getImpactRadius(store: SymbolStore, symbolId: string, depth = 2): TraversalResult {
+  // Impact = callers, traversing incoming edges
+  return getCallers(store, symbolId, depth);
+}
+
+/** Format traversal results for model consumption. */
+export function formatTraversal(
+  symbolName: string,
+  direction: "callers" | "callees" | "impact",
+  result: TraversalResult,
+  depth: number,
+): string {
+  if (result.hops.length === 0) {
+    return `No ${direction} found for "${symbolName}" up to depth ${depth}.`;
+  }
+
+  const lines: string[] = [
+    `${direction} of "${symbolName}" (depth ${depth}, ${result.hops.length} hop${result.hops.length !== 1 ? "s" : ""}):`,
+    "",
+  ];
+
+  // Group by file
+  const byFile = new Map<string, TraversalHop[]>();
+  for (const hop of result.hops) {
+    const list = byFile.get(hop.entry.filePath);
+    if (list) list.push(hop);
+    else byFile.set(hop.entry.filePath, [hop]);
+  }
+
+  for (const [file, fileHops] of byFile) {
+    const symbols = fileHops.map((h) => {
+      const qual = h.entry.parent ? `${h.entry.parent}.${h.entry.name}` : h.entry.name;
+      return `${qual}(${h.entry.kind}):${h.edge.line}`;
+    });
+    lines.push(`  ${file} — ${symbols.join(", ")}`);
+  }
+
+  return lines.join("\n");
+}

--- a/src/index/symbol/resolver.ts
+++ b/src/index/symbol/resolver.ts
@@ -1,0 +1,109 @@
+/** Resolve raw call edges to symbol IDs: same-file → same-dir → project-wide. */
+
+import type { RawCallEdge } from "./edges.js";
+import type { SymbolStore } from "./store.js";
+import type { CallEdge } from "./types.js";
+
+export interface ResolutionResult {
+  total: number;
+  resolved: number;
+  unresolved: number;
+}
+
+/** Directory of a forward-slash path. "src/foo/bar.ts" → "src/foo". */
+function dirOf(p: string): string {
+  const idx = p.lastIndexOf("/");
+  return idx >= 0 ? p.slice(0, idx) : "";
+}
+
+/** Resolve raw edges: same-file → same-dir → project-wide callee matching. */
+export function resolveCallEdges(
+  rawEdges: RawCallEdge[],
+  store: SymbolStore,
+): { edges: CallEdge[]; result: ResolutionResult } {
+  const edges: CallEdge[] = [];
+  let resolved = 0;
+  let unresolved = 0;
+
+  for (const raw of rawEdges) {
+    // Find caller symbol
+    const caller = findSymbol(store, raw.callerName, raw.callerFile, raw.callerLine);
+    const sourceId = caller?.id ?? raw.callerName;
+
+    // Find callee symbol: same-file → same-dir → project-wide
+    const callee = resolveCallee(store, raw.calleeName, raw.file);
+
+    edges.push({
+      sourceId,
+      targetId: callee?.id ?? null,
+      calleeName: raw.calleeName,
+      file: raw.file,
+      line: raw.line,
+      resolved: callee !== null,
+    });
+
+    if (callee) resolved++;
+    else unresolved++;
+  }
+
+  return { edges, result: { total: rawEdges.length, resolved, unresolved } };
+}
+
+/** Find a symbol by name in a specific file, nearest to a given line. */
+function findSymbol(
+  store: SymbolStore,
+  name: string,
+  filePath: string,
+  line: number,
+): ReturnType<(typeof store)["getById"]> {
+  const candidates = store
+    .getByFile(filePath)
+    .filter((e) => e.name === name && e.startLine <= line && e.endLine >= line);
+  if (candidates.length === 0) {
+    // Fall back to any symbol with this name in the file
+    const fileSyms = store.getByFile(filePath).filter((e) => e.name === name);
+    if (fileSyms.length === 1) return fileSyms[0];
+    if (fileSyms.length > 1) return fileSyms[0]; // ambiguous — pick first
+    return undefined;
+  }
+  return candidates[0];
+}
+
+/** Resolve a callee name to a symbol: same-file → same-dir → project-wide. */
+function resolveCallee(
+  store: SymbolStore,
+  calleeName: string,
+  callFile: string,
+): ReturnType<(typeof store)["getById"]> {
+  // Step 1: same-file exact match
+  const sameFile = store.getByFile(callFile).filter((e) => e.name === calleeName);
+  if (sameFile.length === 1) return sameFile[0];
+
+  // Step 2: same-directory
+  const callDir = dirOf(callFile);
+  const dirHits: typeof sameFile = [];
+  for (const [filePath, entries] of store.fileEntries()) {
+    if (filePath === callFile) continue;
+    if (dirOf(filePath) !== callDir) continue;
+    for (const e of entries) {
+      if (e.name === calleeName) dirHits.push(e);
+    }
+  }
+  if (dirHits.length === 1) return dirHits[0];
+
+  // Step 3: project-wide exact match
+  const projectHits: typeof sameFile = [];
+  for (const [, entries] of store.fileEntries()) {
+    for (const e of entries) {
+      if (e.name === calleeName && e.filePath !== callFile) {
+        projectHits.push(e);
+      }
+    }
+  }
+  if (projectHits.length === 1) return projectHits[0];
+
+  // If multiple matches across the project, prefer same-directory
+  if (dirHits.length > 0) return dirHits[0];
+
+  return undefined;
+}

--- a/src/index/symbol/store.ts
+++ b/src/index/symbol/store.ts
@@ -1,0 +1,463 @@
+/** JSONL append-only symbol store + in-memory lookup (≤50K symbols). */
+
+import { createHash } from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import type { SymbolKind } from "../../code-query/symbols.js";
+import type {
+  CallEdge,
+  SymbolEntry,
+  SymbolIndexMeta,
+  SymbolSearchHit,
+  SymbolSearchOptions,
+} from "./types.js";
+import { SYMBOL_STORE_VERSION } from "./types.js";
+
+export const SYMBOL_INDEX_DIR = ".reasonix/symbols";
+
+const META_FILE = "index.meta.json";
+const DATA_FILE = "index.jsonl";
+const EDGES_FILE = "edges.jsonl";
+
+/** Stable symbol id: first 12 hex chars of SHA-256(filePath::name@line). */
+export function symbolId(filePath: string, name: string, line: number): string {
+  const raw = `${filePath}::${name}@${line}`;
+  return createHash("sha256").update(raw).digest("hex").slice(0, 12);
+}
+
+/** Qualified name: filePath::Parent.name for nested symbols, filePath::name otherwise. */
+export function qualifiedName(filePath: string, name: string, parent?: string): string {
+  const scope = parent ? `${parent}.` : "";
+  return `${filePath}::${scope}${name}`;
+}
+
+export class SymbolStore {
+  private entries: SymbolEntry[] = [];
+  private byId = new Map<string, SymbolEntry>();
+  private byFile = new Map<string, SymbolEntry[]>();
+  private byKind = new Map<SymbolKind, SymbolEntry[]>();
+  /** Lowercase name → entries for case-insensitive search. */
+  private byName = new Map<string, SymbolEntry[]>();
+  /** Call edges — keyed by source and target. */
+  private edges: CallEdge[] = [];
+  private edgesBySource = new Map<string, CallEdge[]>();
+  private edgesByTarget = new Map<string, CallEdge[]>();
+
+  constructor(public readonly indexDir: string) {}
+
+  // -- accessors --------------------------------------------------------------
+
+  get size(): number {
+    return this.entries.length;
+  }
+
+  get all(): readonly SymbolEntry[] {
+    return this.entries;
+  }
+
+  /** File paths → latest mtime, for change detection. */
+  fileMtimes(): Map<string, number> {
+    const out = new Map<string, number>();
+    for (const [p, group] of this.byFile) {
+      const first = group[0];
+      if (first) out.set(p, first.mtimeMs);
+    }
+    return out;
+  }
+
+  // -- mutation ---------------------------------------------------------------
+
+  async add(entries: readonly SymbolEntry[]): Promise<void> {
+    if (entries.length === 0) return;
+    const lines: string[] = [];
+    for (const e of entries) {
+      this.entries.push(e);
+      this.byId.set(e.id, e);
+      // byFile
+      const flist = this.byFile.get(e.filePath);
+      if (flist) flist.push(e);
+      else this.byFile.set(e.filePath, [e]);
+      // byKind
+      const klist = this.byKind.get(e.kind);
+      if (klist) klist.push(e);
+      else this.byKind.set(e.kind, [e]);
+      // byName
+      const lower = e.name.toLowerCase();
+      const nlist = this.byName.get(lower);
+      if (nlist) nlist.push(e);
+      else this.byName.set(lower, [e]);
+      lines.push(serializeEntry(e));
+    }
+    await fs.mkdir(this.indexDir, { recursive: true });
+    await fs.appendFile(path.join(this.indexDir, DATA_FILE), `${lines.join("\n")}\n`, "utf8");
+    await this.writeMeta();
+  }
+
+  /** Remove all symbols belonging to the given file paths. Returns count removed. */
+  async remove(filePaths: readonly string[]): Promise<number> {
+    if (filePaths.length === 0) return 0;
+    const drop = new Set(filePaths);
+    const before = this.entries.length;
+    this.entries = this.entries.filter((e) => !drop.has(e.filePath));
+    for (const p of filePaths) this.byFile.delete(p);
+    // Rebuild derived indexes — cheaper than per-entry delete for bulk operations
+    this.rebuildDerived();
+    const removed = before - this.entries.length;
+    if (removed > 0) await this.flush();
+    return removed;
+  }
+
+  // -- search -----------------------------------------------------------------
+
+  getById(id: string): SymbolEntry | undefined {
+    return this.byId.get(id);
+  }
+
+  getByFile(filePath: string): SymbolEntry[] {
+    return this.byFile.get(filePath) ?? [];
+  }
+
+  getByKind(kind: SymbolKind): SymbolEntry[] {
+    return this.byKind.get(kind) ?? [];
+  }
+
+  /** Search by name. exact > prefix > substring, deduped by id. */
+  search(query: string, opts: SymbolSearchOptions = {}): SymbolSearchHit[] {
+    const limit = opts.limit ?? 20;
+    const kinds = opts.kinds && opts.kinds.length > 0 ? new Set(opts.kinds) : null;
+    const q = opts.caseSensitive ? query : query.toLowerCase();
+
+    const exact: SymbolSearchHit[] = [];
+    const prefix: SymbolSearchHit[] = [];
+    const substring: SymbolSearchHit[] = [];
+    const seen = new Set<string>();
+
+    // Walk the name index
+    for (const [lower, entries] of this.byName) {
+      if (q.length === 0) break;
+      // Fast path: if query doesn't appear at all in this name, skip
+      const idx = lower.indexOf(q);
+      if (idx === -1) continue;
+      for (const e of entries) {
+        if (seen.has(e.id)) continue;
+        if (kinds && !kinds.has(e.kind)) continue;
+        seen.add(e.id);
+        const nameLower = opts.caseSensitive ? e.name : e.name.toLowerCase();
+        if (nameLower === q) {
+          exact.push({ entry: e, matchType: "exact" });
+        } else if (nameLower.startsWith(q)) {
+          prefix.push({ entry: e, matchType: "prefix" });
+        } else {
+          substring.push({ entry: e, matchType: "substring" });
+        }
+      }
+    }
+
+    // Merge: exact first, then prefix, then substring. Sort each bucket by name.
+    const sortByName = (a: SymbolSearchHit, b: SymbolSearchHit) =>
+      a.entry.name.localeCompare(b.entry.name);
+    exact.sort(sortByName);
+    prefix.sort(sortByName);
+    substring.sort(sortByName);
+
+    const merged = [...exact, ...prefix, ...substring];
+    return merged.slice(0, limit);
+  }
+
+  /** All distinct file paths in the index. */
+  filePaths(): string[] {
+    return [...this.byFile.keys()].sort();
+  }
+
+  /** Iterate all entries grouped by file path. */
+  fileEntries(): IterableIterator<[string, SymbolEntry[]]> {
+    return this.byFile.entries();
+  }
+
+  /** All call edges. */
+  getEdges(): CallEdge[] {
+    return this.edges;
+  }
+
+  /** Edges originating from a symbol. */
+  edgesFrom(sourceId: string): CallEdge[] {
+    return this.edgesBySource.get(sourceId) ?? [];
+  }
+
+  /** Edges targeting a symbol. */
+  edgesTo(targetId: string): CallEdge[] {
+    return this.edgesByTarget.get(targetId) ?? [];
+  }
+
+  /** Add resolved call edges and persist. */
+  async addEdges(newEdges: CallEdge[]): Promise<void> {
+    if (newEdges.length === 0) return;
+    const lines: string[] = [];
+    for (const e of newEdges) {
+      this.edges.push(e);
+      const slist = this.edgesBySource.get(e.sourceId);
+      if (slist) slist.push(e);
+      else this.edgesBySource.set(e.sourceId, [e]);
+      if (e.targetId) {
+        const tlist = this.edgesByTarget.get(e.targetId);
+        if (tlist) tlist.push(e);
+        else this.edgesByTarget.set(e.targetId, [e]);
+      }
+      lines.push(serializeEdge(e));
+    }
+    await fs.mkdir(this.indexDir, { recursive: true });
+    await fs.appendFile(path.join(this.indexDir, EDGES_FILE), `${lines.join("\n")}\n`, "utf8");
+    await this.writeMeta();
+  }
+
+  /** Remove edges attached to symbols in the given files. */
+  async removeEdgesForFiles(filePaths: readonly string[]): Promise<void> {
+    if (filePaths.length === 0) return;
+    const drop = new Set(filePaths);
+    this.edges = this.edges.filter((e) => {
+      if (drop.has(e.file)) return false;
+      // Also drop if call site file is in the set
+      return true;
+    });
+    this.rebuildEdgeIndexes();
+    await this.flushEdges();
+  }
+
+  // -- persistence ------------------------------------------------------------
+
+  private async flush(): Promise<void> {
+    await fs.mkdir(this.indexDir, { recursive: true });
+    const tmp = path.join(this.indexDir, `${DATA_FILE}.tmp`);
+    const final = path.join(this.indexDir, DATA_FILE);
+    const lines = this.entries.map(serializeEntry).join("\n");
+    await fs.writeFile(tmp, lines.length > 0 ? `${lines}\n` : "", "utf8");
+    await fs.rename(tmp, final);
+    await this.writeMeta();
+  }
+
+  private async writeMeta(): Promise<void> {
+    const fileCount = this.byFile.size;
+    const meta: SymbolIndexMeta = {
+      version: SYMBOL_STORE_VERSION,
+      symbolCount: this.entries.length,
+      fileCount,
+      edgeCount: this.edges.length,
+      updatedAt: new Date().toISOString(),
+    };
+    await fs.writeFile(
+      path.join(this.indexDir, META_FILE),
+      `${JSON.stringify(meta, null, 2)}\n`,
+      "utf8",
+    );
+  }
+
+  async wipe(): Promise<void> {
+    this.entries = [];
+    this.byId.clear();
+    this.byFile.clear();
+    this.byKind.clear();
+    this.byName.clear();
+    this.edges = [];
+    this.edgesBySource.clear();
+    this.edgesByTarget.clear();
+    const dataPath = path.join(this.indexDir, DATA_FILE);
+    const edgesPath = path.join(this.indexDir, EDGES_FILE);
+    const metaPath = path.join(this.indexDir, META_FILE);
+    await fs.rm(dataPath, { force: true });
+    await fs.rm(edgesPath, { force: true });
+    await fs.rm(metaPath, { force: true });
+  }
+
+  private async flushEdges(): Promise<void> {
+    await fs.mkdir(this.indexDir, { recursive: true });
+    const tmp = path.join(this.indexDir, `${EDGES_FILE}.tmp`);
+    const final = path.join(this.indexDir, EDGES_FILE);
+    const lines = this.edges.map(serializeEdge).join("\n");
+    await fs.writeFile(tmp, lines.length > 0 ? `${lines}\n` : "", "utf8");
+    await fs.rename(tmp, final);
+  }
+
+  private rebuildEdgeIndexes(): void {
+    this.edgesBySource.clear();
+    this.edgesByTarget.clear();
+    for (const e of this.edges) {
+      const slist = this.edgesBySource.get(e.sourceId);
+      if (slist) slist.push(e);
+      else this.edgesBySource.set(e.sourceId, [e]);
+      if (e.targetId) {
+        const tlist = this.edgesByTarget.get(e.targetId);
+        if (tlist) tlist.push(e);
+        else this.edgesByTarget.set(e.targetId, [e]);
+      }
+    }
+  }
+
+  // -- internal ---------------------------------------------------------------
+
+  private rebuildDerived(): void {
+    this.byId.clear();
+    this.byFile.clear();
+    this.byKind.clear();
+    this.byName.clear();
+    for (const e of this.entries) {
+      this.byId.set(e.id, e);
+      const flist = this.byFile.get(e.filePath);
+      if (flist) flist.push(e);
+      else this.byFile.set(e.filePath, [e]);
+      const klist = this.byKind.get(e.kind);
+      if (klist) klist.push(e);
+      else this.byKind.set(e.kind, [e]);
+      const lower = e.name.toLowerCase();
+      const nlist = this.byName.get(lower);
+      if (nlist) nlist.push(e);
+      else this.byName.set(lower, [e]);
+    }
+  }
+}
+
+export async function openStore(indexDir: string): Promise<SymbolStore> {
+  const store = new SymbolStore(indexDir);
+  const dataPath = path.join(indexDir, DATA_FILE);
+
+  let raw: string;
+  try {
+    raw = await fs.readFile(dataPath, "utf8");
+  } catch {
+    return store;
+  }
+  const entries: SymbolEntry[] = [];
+  for (const line of raw.split("\n")) {
+    if (line.length === 0) continue;
+    try {
+      entries.push(deserializeEntry(line));
+    } catch {
+      /* tolerate malformed line */
+    }
+  }
+  // Bulk-add via internal method to avoid N individual appendFile calls
+  if (entries.length > 0) {
+    (store as unknown as { entries: SymbolEntry[] }).entries = entries;
+    (store as unknown as Record<string, unknown>).rebuildDerived =
+      store["rebuildDerived" as keyof typeof store];
+    (store as unknown as { rebuildDerived: () => void }).rebuildDerived();
+  }
+
+  // Load edges
+  const edgesPath = path.join(indexDir, EDGES_FILE);
+  try {
+    const edgeRaw = await fs.readFile(edgesPath, "utf8");
+    const edges: CallEdge[] = [];
+    for (const line of edgeRaw.split("\n")) {
+      if (line.length === 0) continue;
+      try {
+        edges.push(deserializeEdge(line));
+      } catch {
+        /* tolerate malformed line */
+      }
+    }
+    if (edges.length > 0) {
+      (store as unknown as { edges: CallEdge[] }).edges = edges;
+      const s = store as unknown as { rebuildEdgeIndexes: () => void };
+      s.rebuildEdgeIndexes();
+    }
+  } catch {
+    /* no edges file yet — fine */
+  }
+
+  return store;
+}
+
+export async function readIndexMeta(indexDir: string): Promise<SymbolIndexMeta | null> {
+  try {
+    const raw = await fs.readFile(path.join(indexDir, META_FILE), "utf8");
+    const parsed = JSON.parse(raw) as Partial<SymbolIndexMeta>;
+    return {
+      version: typeof parsed.version === "number" ? parsed.version : SYMBOL_STORE_VERSION,
+      symbolCount: typeof parsed.symbolCount === "number" ? parsed.symbolCount : 0,
+      fileCount: typeof parsed.fileCount === "number" ? parsed.fileCount : 0,
+      edgeCount: typeof parsed.edgeCount === "number" ? parsed.edgeCount : 0,
+      updatedAt:
+        typeof parsed.updatedAt === "string" ? parsed.updatedAt : new Date(0).toISOString(),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function serializeEntry(e: SymbolEntry): string {
+  return JSON.stringify({
+    id: e.id,
+    n: e.name,
+    q: e.qualifiedName,
+    f: e.filePath,
+    k: e.kind,
+    sl: e.startLine,
+    el: e.endLine,
+    sc: e.startColumn,
+    ec: e.endColumn,
+    p: e.parent ?? null,
+    sig: e.signature ?? null,
+    mt: e.mtimeMs,
+  });
+}
+
+function serializeEdge(e: CallEdge): string {
+  return JSON.stringify({
+    s: e.sourceId,
+    t: e.targetId,
+    cn: e.calleeName,
+    f: e.file,
+    l: e.line,
+    r: e.resolved,
+  });
+}
+
+function deserializeEdge(line: string): CallEdge {
+  const r = JSON.parse(line) as {
+    s: string;
+    t: string | null;
+    cn: string;
+    f: string;
+    l: number;
+    r: boolean;
+  };
+  return {
+    sourceId: r.s,
+    targetId: r.t,
+    calleeName: r.cn,
+    file: r.f,
+    line: r.l,
+    resolved: r.r,
+  };
+}
+
+function deserializeEntry(line: string): SymbolEntry {
+  const r = JSON.parse(line) as {
+    id: string;
+    n: string;
+    q: string;
+    f: string;
+    k: SymbolKind;
+    sl: number;
+    el: number;
+    sc: number;
+    ec: number;
+    p: string | null;
+    sig: string | null;
+    mt: number;
+  };
+  return {
+    id: r.id,
+    name: r.n,
+    qualifiedName: r.q,
+    filePath: r.f,
+    kind: r.k,
+    startLine: r.sl,
+    endLine: r.el,
+    startColumn: r.sc,
+    endColumn: r.ec,
+    parent: r.p ?? undefined,
+    signature: r.sig ?? undefined,
+    mtimeMs: r.mt,
+  };
+}

--- a/src/index/symbol/tool.ts
+++ b/src/index/symbol/tool.ts
@@ -1,0 +1,277 @@
+/** Register symbol-graph tools: symbol_search, callers, callees, impact, code_context. */
+
+import { existsSync } from "node:fs";
+import path from "node:path";
+import type { SymbolKind } from "../../code-query/symbols.js";
+import type { ToolRegistry } from "../../tools.js";
+import { buildContext, formatContextAsMarkdown } from "./context.js";
+import { formatTraversal, getCallees, getCallers, getImpactRadius } from "./graph.js";
+import { SYMBOL_INDEX_DIR, openStore, readIndexMeta } from "./store.js";
+import type { SymbolSearchOptions } from "./types.js";
+
+export interface SymbolToolOptions {
+  root: string;
+  defaultLimit?: number;
+}
+
+/** Register `symbol_search` if the index exists. Returns true on success. */
+export async function registerSymbolSearchTool(
+  registry: ToolRegistry,
+  opts: SymbolToolOptions,
+): Promise<boolean> {
+  const indexDir = path.join(opts.root, SYMBOL_INDEX_DIR);
+  const metaPath = path.join(indexDir, "index.meta.json");
+  if (!existsSync(metaPath)) return false;
+
+  const meta = await readIndexMeta(indexDir);
+  if (!meta || meta.symbolCount === 0) return false;
+
+  const defaultLimit = opts.defaultLimit ?? 20;
+
+  registry.register({
+    name: "symbol_search",
+    description:
+      "Search for symbols (functions, classes, methods, interfaces, etc.) by NAME across the ENTIRE project. Use this when you know WHAT a thing is called ('loginUser', 'AuthService', 'handleClick') but need to find WHERE it lives. Returns file:line locations, kind, and enclosing parent. Much faster than search_content for named code elements — no grep noise, no comments/strings false positives. Use search_content only for literal text patterns or content inside function bodies.",
+    readOnly: true,
+    parallelSafe: true,
+    stormExempt: true,
+    parameters: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description:
+            "Symbol name or partial name (e.g., 'loginUser', 'authenticate', 'Router'). Case-insensitive by default.",
+        },
+        kind: {
+          type: "string",
+          description: "Filter by symbol kind.",
+          enum: [
+            "function",
+            "class",
+            "interface",
+            "type",
+            "enum",
+            "method",
+            "property",
+            "namespace",
+          ],
+        },
+        limit: {
+          type: "integer",
+          description: `Maximum results (default: ${defaultLimit}).`,
+          default: defaultLimit,
+        },
+      },
+      required: ["query"],
+    },
+    fn: async (args: { query: string; kind?: string; limit?: number }) => {
+      const store = await openStore(indexDir);
+      const searchOpts: SymbolSearchOptions = {
+        limit: args.limit ?? defaultLimit,
+        kinds: args.kind ? [args.kind as SymbolKind] : undefined,
+      };
+      const hits = store.search(args.query, searchOpts);
+
+      if (hits.length === 0) {
+        return `symbol_search("${args.query}"${args.kind ? `, kind: ${args.kind}` : ""}): no matches.`;
+      }
+
+      return formatHits(args.query, hits);
+    },
+  });
+
+  return true;
+}
+
+/** Register callers/callees/impact graph tools. Needs edge data in the index. */
+export function registerCallGraphTools(registry: ToolRegistry, indexDir: string): void {
+  registry.register({
+    name: "callers",
+    description:
+      "Find all functions/methods that CALL the given symbol. Returns file:line call sites grouped by file. Use to understand usage patterns and who depends on a symbol before changing it.",
+    readOnly: true,
+    parallelSafe: true,
+    stormExempt: true,
+    parameters: {
+      type: "object",
+      properties: {
+        symbol: {
+          type: "string",
+          description:
+            "Name of the function or method to find callers for (e.g., 'loginUser', 'authenticate').",
+        },
+        depth: {
+          type: "integer",
+          description: "How many levels of callers to traverse (default: 1).",
+          default: 1,
+        },
+      },
+      required: ["symbol"],
+    },
+    fn: async (args: { symbol: string; depth?: number }) => {
+      const store = await openStore(indexDir);
+      const hits = store.search(args.symbol, { limit: 1, kinds: ["function", "method"] });
+      if (hits.length === 0) return `No function/method named "${args.symbol}" found.`;
+      const result = getCallers(store, hits[0]!.entry.id, args.depth ?? 1);
+      return formatTraversal(args.symbol, "callers", result, args.depth ?? 1);
+    },
+  });
+
+  registry.register({
+    name: "callees",
+    description:
+      "Find all functions/methods CALLED BY the given symbol. Returns file:line call targets grouped by file. Use to trace what a function depends on.",
+    readOnly: true,
+    parallelSafe: true,
+    stormExempt: true,
+    parameters: {
+      type: "object",
+      properties: {
+        symbol: {
+          type: "string",
+          description: "Name of the function or method to find callees for.",
+        },
+        depth: {
+          type: "integer",
+          description: "How many levels of callees to traverse (default: 1).",
+          default: 1,
+        },
+      },
+      required: ["symbol"],
+    },
+    fn: async (args: { symbol: string; depth?: number }) => {
+      const store = await openStore(indexDir);
+      const hits = store.search(args.symbol, { limit: 1, kinds: ["function", "method"] });
+      if (hits.length === 0) return `No function/method named "${args.symbol}" found.`;
+      const result = getCallees(store, hits[0]!.entry.id, args.depth ?? 1);
+      return formatTraversal(args.symbol, "callees", result, args.depth ?? 1);
+    },
+  });
+
+  registry.register({
+    name: "impact",
+    description:
+      "Analyze the impact radius of changing a symbol — find ALL code (transitive callers) that could be affected. Returns caller chains up to the specified depth. Use BEFORE editing a shared utility to understand blast radius.",
+    readOnly: true,
+    parallelSafe: true,
+    stormExempt: true,
+    parameters: {
+      type: "object",
+      properties: {
+        symbol: {
+          type: "string",
+          description: "Name of the symbol to analyze impact for.",
+        },
+        depth: {
+          type: "integer",
+          description: "How many levels of transitive callers to traverse (default: 2).",
+          default: 2,
+        },
+      },
+      required: ["symbol"],
+    },
+    fn: async (args: { symbol: string; depth?: number }) => {
+      const store = await openStore(indexDir);
+      const hits = store.search(args.symbol, { limit: 1, kinds: ["function", "method"] });
+      if (hits.length === 0) return `No function/method named "${args.symbol}" found.`;
+      const result = getImpactRadius(store, hits[0]!.entry.id, args.depth ?? 2);
+      return formatTraversal(args.symbol, "impact", result, args.depth ?? 2);
+    },
+  });
+}
+
+/** Register the code_context tool. Needs symbol + edge data in the index. */
+function registerContextTool(registry: ToolRegistry, indexDir: string, root: string): void {
+  registry.register({
+    name: "code_context",
+    description:
+      "PRIMARY TOOL — call this FIRST for any 'how does X work?', architecture, or feature-context question. Combines symbol search + call graph + source extraction into ONE call. Returns entry points, related symbols, call relationships, and key code snippets. Usually sufficient to answer the question with zero further grep/read. For precise 'what calls X' or 'what does X call' drill-down, use callers/callees as follow-up.",
+    readOnly: true,
+    parallelSafe: true,
+    stormExempt: true,
+    parameters: {
+      type: "object",
+      properties: {
+        task: {
+          type: "string",
+          description:
+            "Description of the task, bug, or feature to build context for (e.g., 'auth flow', 'how does query execution work', 'retry backoff logic').",
+        },
+        maxNodes: {
+          type: "integer",
+          description: "Maximum symbols to include (default: 15).",
+          default: 15,
+        },
+        includeCode: {
+          type: "boolean",
+          description: "Include source code snippets (default: true).",
+          default: true,
+        },
+      },
+      required: ["task"],
+    },
+    fn: async (args: { task: string; maxNodes?: number; includeCode?: boolean }) => {
+      const store = await openStore(indexDir);
+      const ctx = await buildContext(args.task, store, root, {
+        maxNodes: args.maxNodes ?? 15,
+        includeCode: args.includeCode ?? true,
+        traversalDepth: 1,
+      });
+      return formatContextAsMarkdown(ctx);
+    },
+  });
+}
+
+/** Silent bootstrap — register if index exists, else skip. */
+export async function bootstrapSymbolSearch(
+  registry: ToolRegistry,
+  root: string,
+  opts: Omit<SymbolToolOptions, "root"> = {},
+): Promise<{ enabled: boolean }> {
+  const indexDir = path.join(root, SYMBOL_INDEX_DIR);
+  const enabled = await registerSymbolSearchTool(registry, { ...opts, root });
+  if (enabled) {
+    registerCallGraphTools(registry, indexDir);
+    registerContextTool(registry, indexDir, root);
+  }
+  return { enabled };
+}
+
+function formatHits(
+  query: string,
+  hits: Array<{
+    entry: {
+      name: string;
+      kind: string;
+      filePath: string;
+      startLine: number;
+      parent?: string;
+      signature?: string;
+    };
+    matchType: string;
+  }>,
+): string {
+  const lines: string[] = [
+    `symbol_search("${query}"): ${hits.length} result${hits.length !== 1 ? "s" : ""}`,
+    "",
+  ];
+
+  // Group by file for compact output
+  const byFile = new Map<string, typeof hits>();
+  for (const h of hits) {
+    const list = byFile.get(h.entry.filePath);
+    if (list) list.push(h);
+    else byFile.set(h.entry.filePath, [h]);
+  }
+
+  for (const [file, fileHits] of byFile) {
+    const symbols = fileHits.map((h) => {
+      const qual = h.entry.parent ? `${h.entry.parent}.${h.entry.name}` : h.entry.name;
+      return `${qual}(${h.entry.kind}):${h.entry.startLine}`;
+    });
+    lines.push(`  ${file} — ${symbols.join(", ")}`);
+  }
+
+  return lines.join("\n");
+}

--- a/src/index/symbol/types.ts
+++ b/src/index/symbol/types.ts
@@ -1,0 +1,75 @@
+/** Symbol index types — persistent project-level symbol knowledge graph. */
+
+import type { SymbolKind } from "../../code-query/symbols.js";
+
+/** A single symbol stored in the project-level index. */
+export interface SymbolEntry {
+  /** Stable unique id — SHA-256 prefix of `filePath::qualifiedName`. */
+  id: string;
+  /** Simple name, e.g. "loginUser". */
+  name: string;
+  /** Fully qualified name, e.g. "src/auth/login.ts::AuthService.loginUser". */
+  qualifiedName: string;
+  /** Path relative to project root, forward slashes. */
+  filePath: string;
+  /** Symbol kind — function, class, method, interface, etc. */
+  kind: SymbolKind;
+  /** 1-based start line. */
+  startLine: number;
+  /** 1-based end line (inclusive). */
+  endLine: number;
+  /** 0-based start column. */
+  startColumn: number;
+  /** 0-based end column. */
+  endColumn: number;
+  /** Enclosing container name if nested (class name, namespace). */
+  parent?: string;
+  /** Function/method signature string if available. */
+  signature?: string;
+  /** File mtime at index time — used for change detection. */
+  mtimeMs: number;
+}
+
+export interface SymbolSearchHit {
+  entry: SymbolEntry;
+  /** How the hit was scored (name exact > prefix > substring). */
+  matchType: "exact" | "prefix" | "substring" | "fuzzy";
+}
+
+export interface SymbolSearchOptions {
+  /** Filter by symbol kind. */
+  kinds?: SymbolKind[];
+  /** Maximum results (default 20). */
+  limit?: number;
+  /** Case-sensitive search (default false). */
+  caseSensitive?: boolean;
+}
+
+/** A resolved call edge between two indexed symbols. */
+export interface CallEdge {
+  /** Symbol ID of the caller. */
+  sourceId: string;
+  /** Symbol ID of the callee, or null if unresolved. */
+  targetId: string | null;
+  /** Name text at the call site. */
+  calleeName: string;
+  /** File path where the call occurs. */
+  file: string;
+  /** 1-based line of the call site. */
+  line: number;
+  /** Whether the callee was resolved to a known symbol. */
+  resolved: boolean;
+}
+
+export const SYMBOL_STORE_VERSION = 2;
+
+export interface SymbolIndexMeta {
+  version: number;
+  /** Number of symbols in the index. */
+  symbolCount: number;
+  /** Number of files indexed. */
+  fileCount: number;
+  /** Number of call edges. */
+  edgeCount: number;
+  updatedAt: string;
+}

--- a/src/index/symbol/watcher.ts
+++ b/src/index/symbol/watcher.ts
@@ -1,0 +1,122 @@
+/** File watcher — incremental sync via fs.watch + debounce (default 2000ms). */
+
+import { type FSWatcher, watch } from "node:fs";
+import path from "node:path";
+import { grammarForPath } from "../../code-query/grammar-map.js";
+import { type ResolvedIndexConfig, compileFilters, defaultIndexConfig } from "../config.js";
+import { syncSymbolIndex } from "./builder.js";
+
+export interface WatchOptions {
+  /** Debounce window in ms (default 2000, clamped 100..60000). */
+  debounceMs?: number;
+  /** Override index config for file filtering. */
+  indexConfig?: ResolvedIndexConfig;
+  /** Called after each sync completes. */
+  onSync?: (result: { filesChanged: number; durationMs: number }) => void;
+  /** Called on watcher errors. */
+  onError?: (err: Error) => void;
+}
+
+const DEFAULT_DEBOUNCE_MS = 2000;
+
+export class SymbolWatcher {
+  private watcher: FSWatcher | null = null;
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private pendingFiles = new Set<string>();
+  private debounceMs: number;
+  private root: string;
+  private onSync?: WatchOptions["onSync"];
+  private onError?: WatchOptions["onError"];
+
+  constructor(root: string, opts: WatchOptions = {}) {
+    this.root = root;
+    this.debounceMs = Math.max(100, Math.min(60000, opts.debounceMs ?? DEFAULT_DEBOUNCE_MS));
+    this.onSync = opts.onSync;
+    this.onError = opts.onError;
+  }
+
+  /** Start watching. Returns true if the watcher started successfully. */
+  start(): boolean {
+    if (this.watcher) return true;
+
+    try {
+      this.watcher = watch(this.root, { recursive: true }, (_eventType, filename) => {
+        if (!filename) return;
+        const rel = filename.toString().split(path.sep).join("/");
+
+        // Only track source files with supported grammars
+        if (!grammarForPath(rel)) return;
+
+        // Skip hidden dirs and common excludes
+        if (rel.startsWith(".") || rel.includes("/.")) return;
+        if (rel.startsWith("node_modules/") || rel.includes("/node_modules/")) return;
+        if (rel.startsWith("dist/") || rel.includes("/dist/")) return;
+
+        this.pendingFiles.add(rel);
+        this.scheduleSync();
+      });
+
+      this.watcher.on("error", (err) => {
+        this.onError?.(err);
+      });
+
+      return true;
+    } catch (err) {
+      this.onError?.(err instanceof Error ? err : new Error(String(err)));
+      return false;
+    }
+  }
+
+  /** Stop watching. */
+  stop(): void {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+    if (this.watcher) {
+      this.watcher.close();
+      this.watcher = null;
+    }
+  }
+
+  /** Whether the watcher is currently active. */
+  isActive(): boolean {
+    return this.watcher !== null;
+  }
+
+  /** Files that have changed since the last sync. */
+  getPendingFiles(): string[] {
+    return [...this.pendingFiles];
+  }
+
+  // -- internal ---------------------------------------------------------------
+
+  private scheduleSync(): void {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+    }
+    this.debounceTimer = setTimeout(() => {
+      this.debounceTimer = null;
+      void this.runSync();
+    }, this.debounceMs);
+  }
+
+  private async runSync(): Promise<void> {
+    const changed = [...this.pendingFiles];
+    this.pendingFiles.clear();
+    if (changed.length === 0) return;
+
+    try {
+      const t0 = Date.now();
+      await syncSymbolIndex(this.root, { changedFiles: changed });
+      this.onSync?.({
+        filesChanged: changed.length,
+        durationMs: Date.now() - t0,
+      });
+    } catch (err) {
+      // Put files back so they get retried on the next trigger
+      for (const f of changed) this.pendingFiles.add(f);
+      this.onError?.(err instanceof Error ? err : new Error(String(err)));
+    }
+  }
+}


### PR DESCRIPTION
 ## 目的

 为 Reasonix 内置项目级符号知识图谱，将 agent 探索代码库时的大量 grep/glob/read 调用替换为对预建索引的结构化查询。**零新依赖**，完全复用已有的
`web-tree-sitter` 解析器和 `ToolRegistry` 工具系统。

 ## 核心能力

 ### 5 个新 Agent 工具

 | 工具 | 功能 |
 |---|---|
 | `symbol_search(query, kind?, limit?)` | 全项目符号名精确搜索 |
 | `callers(symbol, depth?)` | 谁调用了 X（BFS 遍历） |
 | `callees(symbol, depth?)` | X 调用了谁 |
 | `impact(symbol, depth?)` | 修改 X 的传递影响范围 |
 | `code_context(task)` | 一次调用：符号搜索 + 调用图 + 源码 |

 ### 新增模块 `src/index/symbol/`

 | 文件 | 说明 |
 |---|---|
 | `types.ts` | SymbolEntry, CallEdge, SymbolSearchHit |
 | `store.ts` | SymbolStore — JSONL + 4向符号索引 + 双向边索引 |
 | `builder.ts` | buildSymbolIndex / syncSymbolIndex |
 | `edges.ts` | AST 遍历捕获调用点 |
 | `resolver.ts` | 同文件→同目录→全项目消解 |
 | `graph.ts` | BFS callers/callees/impact |
 | `context.ts` | 符号搜索 + 调用图 + 源码 → Markdown |
 | `watcher.ts` | fs.watch + 去抖自动同步 |
 | `tool.ts` | 注册 5 个工具 |