### PR TITLE
fix: include subagent token usage in session stats (#2008)

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -563,10 +563,14 @@ function AppInner({
   // reads from a ref populated AFTER useSessionInfo loads balance, so the
   // subagent-end cost suffix renders in the live wallet's symbol.
   const walletCurrencyRef = useRef<string | undefined>(undefined);
+  const loopRef = useRef<CacheFirstLoop | null>(null);
   const { activities: subagentActivities, sinkRef: subagentSinkRef } = useSubagent({
     session,
     log,
     getWalletCurrency: () => walletCurrencyRef.current,
+    // Fold subagent usage into the parent session's stats so the
+    // stats panel reflects total cost including child loops. (#2008)
+    onSubagentEnd: (model, usage) => loopRef.current?.stats.recordExternal(model, usage),
   });
   const { currentRootDir, setCurrentRootDir, currentRootDirRef } = useWorkspaceRoot(
     codeMode?.rootDir,
@@ -964,7 +968,6 @@ function AppInner({
     };
   }, []);
 
-  const loopRef = useRef<CacheFirstLoop | null>(null);
   // hookList + currentRootDir intentionally NOT in deps —they seed
   // the loop on first construction (loopRef guards a single
   // instantiation), and later edits flow in through the mutable

--- a/src/cli/ui/useSubagent.ts
+++ b/src/cli/ui/useSubagent.ts
@@ -139,6 +139,9 @@ export interface UseSubagentParams {
   log: Scrollback;
   /** Read live wallet currency at end-event time so the cost suffix follows the wallet symbol. */
   getWalletCurrency?: () => string | undefined;
+  /** Called when a subagent completes successfully — lets the caller fold
+   *  subagent usage into the parent session's stats. (#2008) */
+  onSubagentEnd?: (model: string, usage: import("../../client.js").Usage) => void;
 }
 
 export interface UseSubagentResult {
@@ -151,6 +154,7 @@ export function useSubagent({
   session,
   log,
   getWalletCurrency,
+  onSubagentEnd,
 }: UseSubagentParams): UseSubagentResult {
   const [activities, setActivities] = useState<ReadonlyArray<SubagentActivity>>([]);
   // Share the process-wide singleton so `buildCodeToolset`'s pre-mount
@@ -163,6 +167,10 @@ export function useSubagent({
   useEffect(() => {
     getWalletCurrencyRef.current = getWalletCurrency;
   }, [getWalletCurrency]);
+  const onSubagentEndRef = useRef(onSubagentEnd);
+  useEffect(() => {
+    onSubagentEndRef.current = onSubagentEnd;
+  }, [onSubagentEnd]);
 
   useEffect(() => {
     sinkRef.current.current = (ev: SubagentEvent) => {
@@ -211,6 +219,7 @@ export function useSubagent({
               durationMs: ev.elapsedMs ?? 0,
             },
           });
+          onSubagentEndRef.current?.(ev.model, ev.usage);
         }
         return;
       }

--- a/src/telemetry/stats.ts
+++ b/src/telemetry/stats.ts
@@ -202,6 +202,14 @@ export class SessionStats {
     return stats;
   }
 
+  /** Fold external usage (e.g. subagent child-loop) into session totals without creating a turn entry. (#2008) */
+  recordExternal(model: string, usage: Usage): void {
+    this._carryoverCost += costUsd(model, usage);
+    this._carryoverCacheHit += usage.promptCacheHitTokens;
+    this._carryoverCacheMiss += usage.promptCacheMissTokens;
+    this._carryoverCompletion += usage.completionTokens;
+  }
+
   /** Drop oldest turns beyond MAX_TURNS, folding their costs into carryover so
    *  session totals remain accurate even after trimming. */
   private trimOldTurns(): void {

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -355,3 +355,59 @@ describe("SessionStats — issue #364 resume cache + context carryover", () => {
     expect(s.cumulativeCompletionTokens).toBe(0);
   });
 });
+
+describe("SessionStats.recordExternal (#2008)", () => {
+  it("adds subagent cost to session totalCost without creating a turn entry", () => {
+    const s = new SessionStats();
+    s.record(1, "deepseek-v4-pro", new Usage(10_000, 1000, 0, 8000, 2000));
+    const costBefore = s.totalCost;
+    const turnsBefore = s.summary().turns;
+
+    // Simulate a subagent on flash
+    s.recordExternal("deepseek-v4-flash", new Usage(5000, 500, 0, 4000, 1000));
+
+    expect(s.totalCost).toBeGreaterThan(costBefore);
+    // Turn count must NOT increase — subagent is not a parent turn.
+    expect(s.summary().turns).toBe(turnsBefore);
+  });
+
+  it("adds subagent cache tokens to cumulativeToken getters", () => {
+    const s = new SessionStats();
+    s.record(1, "deepseek-v4-pro", new Usage(10_000, 1000, 0, 8000, 2000));
+    const hitBefore = s.cumulativeCacheHitTokens;
+    const missBefore = s.cumulativeCacheMissTokens;
+    const compBefore = s.cumulativeCompletionTokens;
+
+    s.recordExternal("deepseek-v4-flash", new Usage(5000, 500, 0, 4000, 1000));
+
+    expect(s.cumulativeCacheHitTokens).toBe(hitBefore + 4000);
+    expect(s.cumulativeCacheMissTokens).toBe(missBefore + 1000);
+    expect(s.cumulativeCompletionTokens).toBe(compBefore + 500);
+  });
+
+  it("aggregateCacheHitRatio includes subagent tokens", () => {
+    const s = new SessionStats();
+    // Parent: 8000 hit, 2000 miss → 0.8
+    s.record(1, "deepseek-v4-pro", new Usage(10_000, 1000, 0, 8000, 2000));
+    const ratioBefore = s.aggregateCacheHitRatio;
+    expect(ratioBefore).toBeCloseTo(0.8, 4);
+
+    // Subagent: 1000 hit, 4000 miss → 0.2 (lower hit ratio)
+    s.recordExternal("deepseek-v4-flash", new Usage(5000, 500, 0, 1000, 4000));
+
+    // Combined: 9000 hit, 6000 miss → 0.6
+    expect(s.aggregateCacheHitRatio).toBeCloseTo(9000 / 15000, 4);
+    expect(s.aggregateCacheHitRatio).toBeLessThan(ratioBefore);
+  });
+
+  it("summary().totalCostUsd reflects subagent usage", () => {
+    const s = new SessionStats();
+    s.record(1, "deepseek-v4-pro", new Usage(10_000, 1000, 0, 8000, 2000));
+    const summaryBefore = s.summary().totalCostUsd;
+
+    s.recordExternal("deepseek-v4-flash", new Usage(5000, 500, 0, 4000, 1000));
+    const summaryAfter = s.summary().totalCostUsd;
+
+    expect(summaryAfter).toBeGreaterThan(summaryBefore);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #2008 — subagent child-loop usage (cost, cache hit/miss tokens, completion tokens) was written to the global `usage.jsonl` log but never folded back into the parent session's `SessionStats`. The TUI stats panel and session meta only showed parent loop API calls, making subagent costs invisible.

## Root Cause

The data flow had a gap:

```
Subagent completes → SubagentEvent{kind:"end", usage, costUsd}
  ├── ✅ appendUsage() → usage.jsonl (global log)
  └── ❌ NOT fed back to parent loop.stats ← bug
```

The stats panel reads from `loop.stats.summary()`, which only accumulated main-loop API calls.

## Fix

1. **`src/telemetry/stats.ts`** — Added `SessionStats.recordExternal(model, usage)` that folds external usage into carryover (cost, cache hit/miss, completion tokens) without creating a turn entry.

2. **`src/cli/ui/useSubagent.ts`** — Added `onSubagentEnd` callback to `UseSubagentParams`. Called on successful subagent completion after `appendUsage`.

3. **`src/cli/ui/App.tsx`** — Wired `onSubagentEnd` to `loopRef.current.stats.recordExternal(model, usage)`.

## Verification

- `npx vitest run tests/telemetry.test.ts` — 40/40 passed (includes 4 new `recordExternal` tests)
- `npm run verify` — all 3798 tests passed (full pre-push suite)
