### PR TITLE
feat(desktop): 计划正文和内存正文支持 Markdown 渲染

### DIFF
--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -3302,14 +3302,14 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
   line-height: 1.5;
 }
 .mem-detail {
-  max-height: 220px;
+  flex: 1;
+  min-height: 0;
   overflow: auto;
   margin: 8px 0 0;
   padding: 8px;
   border: 1px solid var(--border);
   border-radius: 6px;
   background: var(--panel);
-  white-space: pre-wrap;
   color: var(--fg-1);
   font-family: var(--mono);
   font-size: 12px;
@@ -3787,9 +3787,29 @@ html:not([data-platform="macos"]) .cmdk-row .kb .shortcut kbd[data-key="mod"] {
 .ctx-body {
   flex: 1;
   margin-right: 12px;
-  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
   padding: 12px;
   padding-right: 20px;
+}
+.ctx-body-tokens {
+  flex-shrink: 0;
+}
+.ctx-body-tab {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+.ctx-body-tab::-webkit-scrollbar {
+  width: 8px;
+}
+.ctx-body-tab::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 999px;
+}
+.ctx-body-tab::-webkit-scrollbar-thumb:hover {
+  background: var(--border-strong);
 }
 .ctx-body::-webkit-scrollbar {
   width: 8px;

--- a/desktop/src/ui/context-panel.tsx
+++ b/desktop/src/ui/context-panel.tsx
@@ -2,6 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { openPath } from "@tauri-apps/plugin-opener";
 import { useMemo, useState } from "react";
 import type { SessionFile, Settings, UsageStats } from "../App";
+import { Markdown } from "../Markdown";
 import { t, useLang } from "../i18n";
 import { I } from "../icons";
 import type { McpSpecInfo, MemoryDetail, MemoryEntryInfo } from "../protocol";
@@ -61,7 +62,7 @@ export function ContextPanel({
       </div>
 
       <div className="ctx-body">
-        <div className="ctx-block">
+        <div className="ctx-block ctx-body-tokens">
           <div className="h">
             <span>{t("contextPanel.contextTokens")}</span>
             <span className="right">
@@ -93,14 +94,16 @@ export function ContextPanel({
           </div>
         </div>
 
-        <PanelErrorBoundary key={tab} label={tab}>
-          {tab === "files" && <CtxFiles files={sessionFiles} settings={settings} />}
-          {tab === "tools" && <CtxTools specs={mcpSpecs} bridged={mcpBridged} />}
-          {tab === "memory" && (
-            <CtxMemory entries={memory} detail={memoryDetail} onRead={onReadMemory} />
-          )}
-          {tab === "rules" && <CtxRules settings={settings} />}
-        </PanelErrorBoundary>
+        <div className="ctx-body-tab">
+          <PanelErrorBoundary key={tab} label={tab}>
+            {tab === "files" && <CtxFiles files={sessionFiles} settings={settings} />}
+            {tab === "tools" && <CtxTools specs={mcpSpecs} bridged={mcpBridged} />}
+            {tab === "memory" && (
+              <CtxMemory entries={memory} detail={memoryDetail} onRead={onReadMemory} />
+            )}
+            {tab === "rules" && <CtxRules settings={settings} />}
+          </PanelErrorBoundary>
+        </div>
       </div>
     </aside>
   );
@@ -304,7 +307,7 @@ function CtxMemory({
   onRead: (path: string) => void;
 }) {
   return (
-    <div className="ctx-block">
+    <div className="ctx-block" style={{ display: "flex", flexDirection: "column", flex: 1, minHeight: 0 }}>
       <div className="h">
         <span>{t("contextPanel.memoryTitle")}</span>
         <span className="right">
@@ -314,22 +317,28 @@ function CtxMemory({
       {entries.length === 0 ? (
         <div className="ctx-empty">{t("contextPanel.noMemoriesMsg")}</div>
       ) : (
-        <div className="mem">
-          {entries.map((m) => (
-            <button
-              type="button"
-              className="mem-row"
-              data-active={detail?.path === m.path}
-              key={m.path}
-              onClick={() => onRead(m.path)}
-            >
-              <span className="scope" data-s={m.scope}>
-                {m.scope === "project" ? t("contextPanel.scopeProject") : t("contextPanel.scopeGlobal")}
-              </span>
-              <span className="txt">{m.description || m.name}</span>
-            </button>
-          ))}
-          {detail ? <pre className="mem-detail">{detail.body}</pre> : null}
+        <div className="mem" style={{ display: "flex", flexDirection: "column", flex: 1, minHeight: 0 }}>
+          <div style={{ flexShrink: 0 }}>
+            {entries.map((m) => (
+              <button
+                type="button"
+                className="mem-row"
+                data-active={detail?.path === m.path}
+                key={m.path}
+                onClick={() => onRead(m.path)}
+              >
+                <span className="scope" data-s={m.scope}>
+                  {m.scope === "project" ? t("contextPanel.scopeProject") : t("contextPanel.scopeGlobal")}
+                </span>
+                <span className="txt">{m.description || m.name}</span>
+              </button>
+            ))}
+          </div>
+          {detail ? (
+            <div className="mem-detail">
+              <Markdown source={detail.body} />
+            </div>
+          ) : null}
         </div>
       )}
     </div>

--- a/desktop/src/ui/thread.tsx
+++ b/desktop/src/ui/thread.tsx
@@ -13,6 +13,7 @@ import type {
   PendingRevision,
   SkillOrigin,
 } from "../App";
+import { Markdown } from "../Markdown";
 import { t, useLang } from "../i18n";
 import { I } from "../icons";
 import {
@@ -281,7 +282,7 @@ export function PlanBanner({
           {t("thread.planRunning", { step: Math.min(done + 1, total), total })}
           {current ? ` — ${current.title}` : ""}
         </div>
-        <div className="s">{plan.plan}</div>
+        <Markdown source={plan.plan} />
       </div>
       <div className="prog">
         <div className="meter-mini">
@@ -340,8 +341,12 @@ export function PlanApprovalCard({
       sub={sub}
       body={
         <>
-          {p.summary ? <div style={{ marginBottom: 6 }}>{p.summary}</div> : null}
-          <div style={{ whiteSpace: "pre-wrap" }}>{p.plan}</div>
+          {p.summary ? (
+            <div style={{ marginBottom: 6 }}>
+              <Markdown source={p.summary} />
+            </div>
+          ) : null}
+          <Markdown source={p.plan} />
         </>
       }
       meta={`plan/#${p.id}`}


### PR DESCRIPTION
- PlanBanner / PlanApprovalCard 中的计划正文和摘要从原始 <div>/<pre> 改为 <Markdown> 渲染，支持标题、代码块、列表、行内样式等 GFM 语法。
- CtxMemory 中的内存正文（REASONIX.md）从 <pre> 改为 <Markdown> 渲染。
- 上下文面板布局重构为 flex column，内存详情区域自动撑满侧边栏剩余高度。

<!-- Read CONTRIBUTING.md first if this is your first PR. -->

## What

<!-- One paragraph: what does this change? -->

## Why

<!-- Bug fix? Pre-existing issue? Linked discussion? -->

## How to verify

<!-- Steps the reviewer can run. `npm run verify` is assumed. -->

## Checklist

- [ ] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [ ] No `Co-Authored-By: Claude` trailer in commits
- [ ] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [ ] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time
