### PR TITLE
feat: configurable maxIterPerTurn per-turn iteration cap (#2037)

### DIFF
--- a/src/cli/commands/acp.ts
+++ b/src/cli/commands/acp.ts
@@ -29,6 +29,7 @@ import {
   loadApiKey,
   loadEditMode,
   loadEndpoint,
+  loadMaxIterPerTurn,
   loadModel,
   loadReasoningEffort,
   normalizeMcpConfig,
@@ -184,6 +185,7 @@ async function buildSession(opts: {
     tools: toolset.tools,
     model,
     budgetUsd: opts.budgetUsd,
+    maxIterPerTurn: loadMaxIterPerTurn(),
     session: `acp-${timestampSuffix()}`,
   });
   return {

--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -29,6 +29,7 @@ import {
   loadEditor,
   loadEndpoint,
   loadExaApiKey,
+  loadMaxIterPerTurn,
   loadMetasoApiKey,
   loadModel,
   loadOllamaApiKey,
@@ -1028,6 +1029,7 @@ function buildRuntimeFor(tab: Tab): RuntimeState {
     budgetUsd: tab.budgetUsd,
     session: tab.currentSession,
     reasoningEffort,
+    maxIterPerTurn: loadMaxIterPerTurn(),
     hooks: tab.hooks,
     hookCwd: tab.rootDir,
   });

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -7,6 +7,7 @@ import {
   isPlausibleKey,
   loadApiKey,
   loadEndpoint,
+  loadMaxIterPerTurn,
   loadToolRateLimit,
   normalizeMcpConfig,
   readConfig,
@@ -151,6 +152,7 @@ export async function runCommand(opts: RunOptions): Promise<void> {
     tools,
     model: opts.model,
     budgetUsd: opts.budgetUsd,
+    maxIterPerTurn: loadMaxIterPerTurn(),
   });
   const prefixHash = prefix.fingerprint;
 

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -39,6 +39,7 @@ import {
   loadEndpoint,
   loadEngineeringLifecycleMode,
   loadHistoryScrollMode,
+  loadMaxIterPerTurn,
   loadMouseWheelRows,
   loadReasoningEffort,
   loadTheme,
@@ -1025,6 +1026,7 @@ function AppInner({
       hooks: hookList,
       hookCwd: currentRootDir,
       reasoningEffort: initialReasoningEffort ?? loadReasoningEffort(),
+      maxIterPerTurn: loadMaxIterPerTurn(),
       rebuildSystem,
     });
     loopRef.current = l;

--- a/src/config.ts
+++ b/src/config.ts
@@ -239,7 +239,7 @@ export interface ReasonixConfig {
    *  to the wallet currency if available, then defaults to CNY. */
   costCurrency?: string;
   /** Maximum tool-call iterations per turn. Prevents runaway loops from consuming
-   *  unlimited API budget. Default 9. Env `REASONIX_MAX_ITER` overrides. */
+   *  unlimited API budget. Default 50. Env `REASONIX_MAX_ITER` overrides. */
   maxIterPerTurn?: number;
   projects?: {
     [absoluteRootDir: string]: {
@@ -1262,7 +1262,7 @@ export function saveShowSystemEvents(on: boolean, path: string = defaultConfigPa
   writeConfig(cfg, path);
 }
 
-/** Load the per-turn iteration cap. Config > env > default (9). */
+/** Load the per-turn iteration cap. Config > env > default (50). */
 export function loadMaxIterPerTurn(path: string = defaultConfigPath()): number {
   const fromConfig = readConfig(path).maxIterPerTurn;
   if (typeof fromConfig === "number" && fromConfig > 0) return fromConfig;
@@ -1271,7 +1271,7 @@ export function loadMaxIterPerTurn(path: string = defaultConfigPath()): number {
     const n = Number(fromEnv);
     if (Number.isFinite(n) && n > 0) return n;
   }
-  return 9;
+  return 50;
 }
 
 export function loadRecentWorkspaces(path: string = defaultConfigPath()): string[] {

--- a/src/config.ts
+++ b/src/config.ts
@@ -238,6 +238,9 @@ export interface ReasonixConfig {
   /** Preferred display currency for costs (e.g. "USD" or "CNY"). When unset, falls back
    *  to the wallet currency if available, then defaults to CNY. */
   costCurrency?: string;
+  /** Maximum tool-call iterations per turn. Prevents runaway loops from consuming
+   *  unlimited API budget. Default 9. Env `REASONIX_MAX_ITER` overrides. */
+  maxIterPerTurn?: number;
   projects?: {
     [absoluteRootDir: string]: {
       shellAllowed?: string[];
@@ -1257,6 +1260,18 @@ export function saveShowSystemEvents(on: boolean, path: string = defaultConfigPa
   const cfg = readConfig(path);
   cfg.thread = { ...(cfg.thread ?? {}), showSystemEvents: on };
   writeConfig(cfg, path);
+}
+
+/** Load the per-turn iteration cap. Config > env > default (9). */
+export function loadMaxIterPerTurn(path: string = defaultConfigPath()): number {
+  const fromConfig = readConfig(path).maxIterPerTurn;
+  if (typeof fromConfig === "number" && fromConfig > 0) return fromConfig;
+  const fromEnv = process.env.REASONIX_MAX_ITER;
+  if (fromEnv) {
+    const n = Number(fromEnv);
+    if (Number.isFinite(n) && n > 0) return n;
+  }
+  return 9;
 }
 
 export function loadRecentWorkspaces(path: string = defaultConfigPath()): string[] {

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -701,6 +701,8 @@ export const EN: TranslationSchema = {
       "context {before}/{ctxMax} ({pct}%) — aggressively folded {beforeMessages} messages → {afterMessages} (summary {summaryChars} chars). Continuing.",
     forcingSummary:
       "context {before}/{ctxMax} ({pct}%) — forcing summary from what was gathered. Run /compact, /clear, or /new to reset.",
+    iterLimitReached:
+      "Reached the per-turn iteration cap ({max} tool-call rounds). Forcing a summary of what was gathered. Override with maxIterPerTurn in config or REASONIX_MAX_ITER env var.",
   },
   errors: {
     contextOverflow:

--- a/src/i18n/JA.ts
+++ b/src/i18n/JA.ts
@@ -734,6 +734,8 @@ export const JA: TranslationSchema = {
       "コンテキスト {before}/{ctxMax} ({pct}%) — {beforeMessages} メッセージ → {afterMessages} に強制折りたたみ（サマリー {summaryChars} 文字）。続行します。",
     forcingSummary:
       "コンテキスト {before}/{ctxMax} ({pct}%) — 収集内容からサマリーを強制生成中。/compact、/clear、または /new でリセットしてください。",
+    iterLimitReached:
+      "ターンあたりの反復上限（{max} 回のツール呼出しラウンド）に達しました。収集内容のサマリーを強制生成中。maxIterPerTurn 設定または REASONIX_MAX_ITER 環境変数で上書きできます。",
   },
   errors: {
     contextOverflow:

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -300,6 +300,7 @@ export interface TranslationSchema {
     foldedHistory: string;
     aggressivelyFoldedHistory: string;
     forcingSummary: string;
+    iterLimitReached: string;
   };
   errors: {
     contextOverflow: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -675,6 +675,8 @@ export const zhCN: TranslationSchema = {
       "上下文 {before}/{ctxMax}（{pct}%）— 已激进折叠 {beforeMessages} 条消息 → {afterMessages}（总结 {summaryChars} 字）。继续。",
     forcingSummary:
       "上下文 {before}/{ctxMax}（{pct}%）— 基于已收集到的内容强制总结。请运行 /compact、/clear 或 /new 重置。",
+    iterLimitReached:
+      "已达到单轮迭代上限（{max} 次工具调用轮次）。正在强制总结已收集的内容。可通过配置 maxIterPerTurn 或 REASONIX_MAX_ITER 环境变量调整上限。",
   },
   errors: {
     contextOverflow:

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -92,6 +92,8 @@ export interface CacheFirstLoopOptions {
   reasoningEffort?: ReasoningEffort;
   /** Soft USD cap — warns at 80%, refuses next turn at 100%. Opt-in (default no cap). */
   budgetUsd?: number;
+  /** Maximum tool-call iterations per turn. Overrides config/env. Default 9. */
+  maxIterPerTurn?: number;
   session?: string;
   /** PreToolUse + PostToolUse only — UserPromptSubmit / Stop live at the App boundary. */
   hooks?: ResolvedHook[];
@@ -130,6 +132,10 @@ export class CacheFirstLoop {
   readonly scratch = new VolatileScratch();
   readonly stats = new SessionStats();
   readonly repair: ToolCallRepair;
+  /** Hard iteration cap per turn — prevents runaway tool-call loops from
+   *  burning unlimited API budget. The model gets one final force-summary
+   *  call when the cap fires. Override via REASONIX_MAX_ITER env var. */
+  static readonly DEFAULT_MAX_ITER_PER_TURN = 9;
   /** Files the model has read this session; gates edit_file / multi_edit so SEARCH text matches on-disk bytes. Cleared on fold / mechanical truncate (the model's byte-level view of the elided history is gone). In-memory only — naturally empty on resume. */
   readonly readTracker = new ReadTracker();
 
@@ -139,6 +145,8 @@ export class CacheFirstLoop {
   stream: boolean;
   reasoningEffort: ReasoningEffort;
   budgetUsd: number | null;
+  /** Maximum tool-call iterations per turn. Config > env > default (9). */
+  maxIterPerTurn: number;
   /** One-shot 80% warning latch — cleared by setBudget so a bump re-arms at the new boundary. */
   private _budgetWarned = false;
   sessionName: string | null;
@@ -210,6 +218,7 @@ export class CacheFirstLoop {
     this.hookCwd = opts.hookCwd ?? process.cwd();
     this.confirmationGate = opts.confirmationGate ?? defaultPauseGate;
     this._rebuildSystem = opts.rebuildSystem ?? null;
+    this.maxIterPerTurn = opts.maxIterPerTurn ?? CacheFirstLoop.DEFAULT_MAX_ITER_PER_TURN;
 
     this._streamPreference = opts.stream ?? true;
     this.stream = this._streamPreference;
@@ -755,6 +764,20 @@ export class CacheFirstLoop {
         } finally {
           this.resetAbortState();
         }
+        this._steerQueue.length = 0;
+        return;
+      }
+      // Hard iteration cap — prevents runaway tool-call loops from
+      // consuming unlimited API budget. (#2037 BUG-028)
+      const maxIter = parsePositiveIntEnv(process.env.REASONIX_MAX_ITER) ?? this.maxIterPerTurn;
+      if (iter >= maxIter) {
+        yield {
+          turn: this._turn,
+          role: "warning",
+          severity: "high",
+          content: t("loop.iterLimitReached", { max: maxIter }),
+        };
+        yield* forceSummaryAfterIterLimit(this.summaryContext(), { reason: "stuck" });
         this._steerQueue.length = 0;
         return;
       }

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -145,7 +145,7 @@ export class CacheFirstLoop {
   stream: boolean;
   reasoningEffort: ReasoningEffort;
   budgetUsd: number | null;
-  /** Maximum tool-call iterations per turn. Config > env > default (9). */
+  /** Maximum tool-call iterations per turn. Config > env > default (50). */
   maxIterPerTurn: number;
   /** One-shot 80% warning latch — cleared by setBudget so a bump re-arms at the new boundary. */
   private _budgetWarned = false;

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -92,7 +92,7 @@ export interface CacheFirstLoopOptions {
   reasoningEffort?: ReasoningEffort;
   /** Soft USD cap — warns at 80%, refuses next turn at 100%. Opt-in (default no cap). */
   budgetUsd?: number;
-  /** Maximum tool-call iterations per turn. Overrides config/env. Default 9. */
+  /** Maximum tool-call iterations per turn. Overrides config/env. Default 50. */
   maxIterPerTurn?: number;
   session?: string;
   /** PreToolUse + PostToolUse only — UserPromptSubmit / Stop live at the App boundary. */
@@ -135,7 +135,7 @@ export class CacheFirstLoop {
   /** Hard iteration cap per turn — prevents runaway tool-call loops from
    *  burning unlimited API budget. The model gets one final force-summary
    *  call when the cap fires. Override via REASONIX_MAX_ITER env var. */
-  static readonly DEFAULT_MAX_ITER_PER_TURN = 9;
+  static readonly DEFAULT_MAX_ITER_PER_TURN = 50;
   /** Files the model has read this session; gates edit_file / multi_edit so SEARCH text matches on-disk bytes. Cleared on fold / mechanical truncate (the model's byte-level view of the elided history is gone). In-memory only — naturally empty on resume. */
   readonly readTracker = new ReadTracker();
 
@@ -769,13 +769,12 @@ export class CacheFirstLoop {
       }
       // Hard iteration cap — prevents runaway tool-call loops from
       // consuming unlimited API budget. (#2037 BUG-028)
-      const maxIter = parsePositiveIntEnv(process.env.REASONIX_MAX_ITER) ?? this.maxIterPerTurn;
-      if (iter >= maxIter) {
+      if (iter >= this.maxIterPerTurn) {
         yield {
           turn: this._turn,
           role: "warning",
           severity: "high",
-          content: t("loop.iterLimitReached", { max: maxIter }),
+          content: t("loop.iterLimitReached", { max: this.maxIterPerTurn }),
         };
         yield* forceSummaryAfterIterLimit(this.summaryContext(), { reason: "stuck" });
         this._steerQueue.length = 0;

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -2430,4 +2430,64 @@ describe("CacheFirstLoop — mid-turn steer injection", () => {
       recoverable: false,
     });
   });
+
+  it("stops at DEFAULT_MAX_ITER_PER_TURN and forces summary (#2037 BUG-028)", async () => {
+    // Build a client that always returns a tool call — the loop would
+    // run forever without the iteration cap. Use unique call IDs AND
+    // unique arguments so the storm breaker (threshold=3 for identical
+    // (name, args) tuples) doesn't fire first.
+    const infiniteResponses: FakeResponseShape[] = Array.from(
+      { length: CacheFirstLoop.DEFAULT_MAX_ITER_PER_TURN + 50 },
+      (_, i) => ({
+        content: "",
+        tool_calls: [
+          {
+            id: `call_${i}`,
+            type: "function" as const,
+            function: { name: "noop", arguments: JSON.stringify({ i }) },
+          },
+        ],
+      }),
+    );
+    // The last response (force-summary) must be a plain text reply.
+    infiniteResponses.push({ content: "Here is what I found." });
+
+    const fetchMock = fakeFetch(infiniteResponses);
+    const client = new DeepSeekClient({ apiKey: "sk-test", fetch: fetchMock });
+    const tools = new ToolRegistry();
+    tools.register({
+      name: "noop",
+      description: "does nothing",
+      parameters: { type: "object", properties: {} },
+      fn: async () => "ok",
+    });
+
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "be brief", toolSpecs: tools.specs() }),
+      tools,
+      stream: false,
+    });
+
+    const events: any[] = [];
+    for await (const ev of loop.step("do stuff forever")) {
+      events.push(ev);
+    }
+
+    // Must have emitted the iteration-limit warning.
+    const warnEv = events.find(
+      (e) => e.role === "warning" && /iteration cap/i.test(e.content ?? ""),
+    );
+    expect(warnEv).toBeDefined();
+
+    // Must have produced a final summary (forced).
+    const finalEv = events.find((e) => e.role === "assistant_final");
+    expect(finalEv).toBeDefined();
+
+    // The loop must NOT have run all 150 iterations — it should stop
+    // at DEFAULT_MAX_ITER_PER_TURN + 1 (the summary call).
+    // Tool dispatches = DEFAULT_MAX_ITER_PER_TURN (one per iter).
+    // The +1 is the summary API call recorded as a turn.
+    expect(fetchMock).toHaveBeenCalledTimes(CacheFirstLoop.DEFAULT_MAX_ITER_PER_TURN + 1);
+  });
 });

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -2490,4 +2490,54 @@ describe("CacheFirstLoop — mid-turn steer injection", () => {
     // The +1 is the summary API call recorded as a turn.
     expect(fetchMock).toHaveBeenCalledTimes(CacheFirstLoop.DEFAULT_MAX_ITER_PER_TURN + 1);
   });
+
+  it("respects custom maxIterPerTurn option", async () => {
+    const customCap = 3;
+    const infiniteResponses: FakeResponseShape[] = Array.from(
+      { length: customCap + 50 },
+      (_, i) => ({
+        content: "",
+        tool_calls: [
+          {
+            id: `call_${i}`,
+            type: "function" as const,
+            function: { name: "noop", arguments: JSON.stringify({ i }) },
+          },
+        ],
+      }),
+    );
+    infiniteResponses.push({ content: "Summary." });
+
+    const fetchMock = fakeFetch(infiniteResponses);
+    const client = new DeepSeekClient({ apiKey: "sk-test", fetch: fetchMock });
+    const tools = new ToolRegistry();
+    tools.register({
+      name: "noop",
+      description: "does nothing",
+      parameters: { type: "object", properties: {} },
+      fn: async () => "ok",
+    });
+
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "be brief", toolSpecs: tools.specs() }),
+      tools,
+      stream: false,
+      maxIterPerTurn: customCap,
+    });
+
+    const events: any[] = [];
+    for await (const ev of loop.step("do stuff forever")) {
+      events.push(ev);
+    }
+
+    const warnEv = events.find(
+      (e) => e.role === "warning" && /iteration cap/i.test(e.content ?? ""),
+    );
+    expect(warnEv).toBeDefined();
+    expect(warnEv!.content).toContain(String(customCap));
+
+    // Tool dispatches = customCap (one per iter) + 1 force-summary call.
+    expect(fetchMock).toHaveBeenCalledTimes(customCap + 1);
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the "no iteration limit" vulnerability from #2037 (BUG-028). The main loop was an infinite `for` loop with no hard cap — a runaway model could consume unlimited API budget.

## Changes

1. **`src/config.ts`** — Added `maxIterPerTurn?: number` to `ReasonixConfig` + `loadMaxIterPerTurn()` loader (config > env > default 50)
2. **`src/loop.ts`** — Added `maxIterPerTurn` to `CacheFirstLoopOptions` and `CacheFirstLoop` instance. `DEFAULT_MAX_ITER_PER_TURN = 50`. Loop checks `iter >= this.maxIterPerTurn` before each model call and emits a warning + forces summary.
3. **`src/cli/ui/App.tsx`** — Passes `loadMaxIterPerTurn()` when constructing loop
4. **`src/cli/commands/desktop.ts`** — Same
5. **`src/cli/commands/run.ts`** — Same
6. **`src/cli/commands/acp.ts`** — Same
7. **`src/i18n/EN.ts` + `zh-CN.ts` + `JA.ts`** — Warning message for iteration cap
8. **`src/i18n/types.ts`** — Added `iterLimitReached` to loop type
9. **`tests/loop.test.ts`** — Added tests verifying default and custom cap

## Usage

```json
// .reasonix/config.json
{
  "maxIterPerTurn": 15
}
```

Or via env: `REASONIX_MAX_ITER=15`

Default is **50**. 50 = observed ceiling (30) × ~1.7 safety margin. Tighter cap risks truncating legitimate multi-file refactors. Power users can override via config or env.

## Verification

- `npx vitest run tests/loop.test.ts` — 70/70 passed
- `npm run verify` — all 3805 tests passed