### PR TITLE
fix(i18n): add missing toolCalls/oneToolCall keys to ja locale

### DIFF
--- a/desktop/src/i18n/ja.ts
+++ b/desktop/src/i18n/ja.ts
@@ -692,6 +692,8 @@ export const ja = {
     unknownKind: "# 不明なカードタイプ — フォールバック表示",
   },
   thread: {
+    toolCalls: "{count} ツール呼び出し",
+    oneToolCall: "1 ツール呼び出し",
     keepSteps: "残り {n} ステップを保持",
     keepOriginal: "オリジナルを保持",
     you: "あなた",


### PR DESCRIPTION
## What

Adds `toolCalls` and `oneToolCall` keys to the Japanese locale
`desktop/src/i18n/ja.ts` that were missing after recent upstream additions
to the `thread` section in `en.ts`.

## Why

The strict TranslationSchema type check in `i18n/index.ts` causes the
desktop build to fail when any locale doesn't match the shape of `en.ts`.

## How to verify

`cd desktop && npm run tauri build -- --bundles dmg` should compile without
type errors in `src/i18n/index.ts:111`.

## Checklist

- [x] `npm run verify` passes locally
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] No edits to `CHANGELOG.md`