### PR TITLE
fix(todo): hide completed items from rendered output

### DIFF
--- a/src/tools/todo.ts
+++ b/src/tools/todo.ts
@@ -65,8 +65,9 @@ function renderTodos(todos: TodoItem[]): string {
     else pending++;
   }
   const header = `todos updated · ${done} done · ${inProgress} in progress · ${pending} pending`;
-  const lines = todos.map((t) => {
-    if (t.status === "completed") return `[x] ${t.content}`;
+  const active = todos.filter((t) => t.status !== "completed");
+  if (active.length === 0) return header;
+  const lines = active.map((t) => {
     if (t.status === "in_progress") return `[>] ${t.activeForm}`;
     return `[ ] ${t.content}`;
   });

--- a/tests/todo.test.ts
+++ b/tests/todo.test.ts
@@ -35,7 +35,7 @@ describe("todo_write — lightweight in-session task tracker", () => {
     expect(out).toContain("1 done");
     expect(out).toContain("1 in progress");
     expect(out).toContain("1 pending");
-    expect(out).toContain("[x] Read the spec");
+    expect(out).not.toContain("[x]");
     expect(out).toContain("[>] Sketching the parser");
     expect(out).toContain("[ ] Write tests");
     expect(updates).toHaveLength(1);


### PR DESCRIPTION
## What

`todo_write` render output no longer includes completed (`[x]`) items. Only pending and in_progress items are shown; the header line still reports the done count.

## Why

Completed items rendered as strikethrough markdown text — still visible and cluttering the display. Users expect finished items to disappear from the active task list.

Closes #2029.

## How to verify

```bash
npm run verify   # all 3826 tests pass
```

Specifically:
- `npx vitest run tests/todo.test.ts` — 9/9 passed
- Completed items no longer appear in `todo_write` output
- Pending and in_progress items still render normally

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md`