### PR TITLE
fix(release): split macOS dmg by arch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,13 +24,11 @@ jobs:
       fail-fast: false
       matrix:
         target:
-          # `rust` is the comma-separated list installed by dtolnay/rust-toolchain;
-          # `tauri` is what we pass to `cargo tauri build --target`. They differ
-          # only for the universal Mac shard, which produces one fat binary from
-          # two real Rust targets via lipo. Intel-only macos-13 runner is dropped
-          # — GH retired most of that pool, queue waits ran to hours.
+          # macOS now ships two single-arch shards so Apple Silicon and Intel
+          # users get separate DMGs. `rust` and `tauri` stay aligned per shard.
           - { os: ubuntu-22.04, label: "linux-x64", rust: "x86_64-unknown-linux-gnu", tauri: "x86_64-unknown-linux-gnu" }
-          - { os: macos-14, label: "macos-universal", rust: "aarch64-apple-darwin,x86_64-apple-darwin", tauri: "universal-apple-darwin" }
+          - { os: macos-15-intel, label: "macos-x64", rust: "x86_64-apple-darwin", tauri: "x86_64-apple-darwin" }
+          - { os: macos-14, label: "macos-arm64", rust: "aarch64-apple-darwin", tauri: "aarch64-apple-darwin" }
           - { os: windows-latest, label: "windows-x64", rust: "x86_64-pc-windows-msvc", tauri: "x86_64-pc-windows-msvc" }
     runs-on: ${{ matrix.target.os }}
     # secrets.* isn't accessible from step-level if:, so expose presence as a
@@ -96,14 +94,18 @@ jobs:
         working-directory: desktop
         run: npm run bundle:node
 
-      - name: Verify bundled Node is universal (macOS)
+      - name: Verify bundled Node matches host arch (macOS)
         if: startsWith(matrix.target.os, 'macos-')
         working-directory: desktop
         run: |
+          expected_arch=$(uname -m)
           archs=$(lipo -archs src-tauri/binaries/node)
           echo "node archs: $archs"
-          echo "$archs" | grep -q "arm64"
-          echo "$archs" | grep -q "x86_64"
+          echo "expected arch: $expected_arch"
+          if [ "$archs" != "$expected_arch" ]; then
+            echo "Expected $expected_arch Node, got: $archs" >&2
+            exit 1
+          fi
           codesign -d --entitlements :- src-tauri/binaries/node 2>&1 | grep -q "com.apple.security.inherit"
 
       - name: Build & verify desktop frontend

--- a/desktop/scripts/bundle-node.mjs
+++ b/desktop/scripts/bundle-node.mjs
@@ -1,5 +1,5 @@
 // Pulls Node 22 from nodejs.org into desktop/src-tauri/binaries/.
-// Mac always produces a universal Mach-O so Intel + Apple Silicon ship from one .dmg (issue #1234).
+// macOS downloads the host-arch binary so arm64 and x64 releases stay split.
 import { execSync } from "node:child_process";
 import { chmodSync, createWriteStream, existsSync, mkdirSync, renameSync, rmSync, statSync } from "node:fs";
 import https from "node:https";
@@ -22,6 +22,7 @@ if (!HOST_ARCH || !["win32", "darwin", "linux"].includes(PLAT)) {
 
 const isWin = PLAT === "win32";
 const targetExe = join(binDir, isWin ? "node.exe" : "node");
+const MAC_ARCH = HOST_ARCH === "x64" ? "x86_64" : HOST_ARCH;
 
 function adhocSignMac(binPath) {
   // #1611: child node needs com.apple.security.inherit so it inherits the
@@ -53,16 +54,16 @@ if (existsSync(targetExe) && statSync(targetExe).size > 1024 * 1024) {
   if (PLAT === "darwin") {
     try {
       const archs = execSync(`lipo -archs "${targetExe}"`, { encoding: "utf8" }).trim();
-      if (archs.includes("arm64") && archs.includes("x86_64")) {
+      if (archs === MAC_ARCH) {
         if (!hasMacTccInheritance(targetExe)) {
-          console.log(`${targetExe} universal but missing TCC inheritance — applying ad-hoc sign`);
+          console.log(`${targetExe} ${MAC_ARCH} build missing TCC inheritance — applying ad-hoc sign`);
           adhocSignMac(targetExe);
         } else {
-          console.log(`${targetExe} already universal + TCC-inheriting (${archs}) — delete to refetch`);
+          console.log(`${targetExe} already ${MAC_ARCH} + TCC-inheriting — delete to refetch`);
         }
         process.exit(0);
       }
-      console.log(`${targetExe} present but not universal (${archs}) — rebuilding`);
+      console.log(`${targetExe} present but not ${MAC_ARCH} (${archs}) — rebuilding`);
       rmSync(targetExe);
     } catch {
       console.log(`${targetExe} present but not verifiable as Mach-O — rebuilding`);
@@ -148,36 +149,25 @@ async function fetchAndExtract(arch) {
   return { inner, extractDir };
 }
 
+const { inner, extractDir } = await fetchAndExtract(HOST_ARCH);
+
+if (existsSync(targetExe)) rmSync(targetExe);
+renameSync(inner, targetExe);
+if (!isWin) {
+  try {
+    chmodSync(targetExe, 0o755);
+  } catch {
+    /* ignore */
+  }
+}
+rmSync(extractDir, { recursive: true, force: true });
+
 if (PLAT === "darwin") {
-  const [arm, x64] = await Promise.all([fetchAndExtract("arm64"), fetchAndExtract("x64")]);
-
-  console.log("Creating universal binary with lipo ...");
-  if (existsSync(targetExe)) rmSync(targetExe);
-  execSync(`lipo -create "${arm.inner}" "${x64.inner}" -output "${targetExe}"`, { stdio: "inherit" });
-  chmodSync(targetExe, 0o755);
-
-  rmSync(arm.extractDir, { recursive: true, force: true });
-  rmSync(x64.extractDir, { recursive: true, force: true });
-
   adhocSignMac(targetExe);
-
   const archs = execSync(`lipo -archs "${targetExe}"`, { encoding: "utf8" }).trim();
   const mb = (statSync(targetExe).size / 1024 / 1024).toFixed(1);
   console.log(`Done: ${targetExe} (${mb} MB, archs: ${archs})`);
 } else {
-  const { inner, extractDir } = await fetchAndExtract(HOST_ARCH);
-
-  if (existsSync(targetExe)) rmSync(targetExe);
-  renameSync(inner, targetExe);
-  if (!isWin) {
-    try {
-      chmodSync(targetExe, 0o755);
-    } catch {
-      /* ignore */
-    }
-  }
-  rmSync(extractDir, { recursive: true, force: true });
-
   const mb = (statSync(targetExe).size / 1024 / 1024).toFixed(1);
   console.log(`Done: ${targetExe} (${mb} MB)`);
 }


### PR DESCRIPTION
Closes #2009

## Summary
- split the macOS release matrix into separate arm64 and x64 jobs
- download a host-architecture Node runtime instead of creating a universal helper binary
- verify the bundled Node binary matches the runner architecture before bundling

## Verification
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); puts 'ok'"`
- `node --check desktop/scripts/bundle-node.mjs`
- `git diff --check origin/main..HEAD`
- fork release workflow produced split macOS artifacts (`Reasonix_0.52.0_aarch64.dmg`, `Reasonix_0.52.0_x64.dmg`)
