### PR TITLE
feat(desktop): add feedback text input for plan cancel/refine actions

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -2448,8 +2448,8 @@ function TabRuntime({
                       key={`pp-${p.id}`}
                       p={p}
                       onApprove={() => resolvePlan(p.id, { type: "approve" })}
-                      onRefine={() => resolvePlan(p.id, { type: "refine" })}
-                      onCancel={() => resolvePlan(p.id, { type: "cancel" })}
+                      onRefine={(feedback) => resolvePlan(p.id, { type: "refine", feedback })}
+                      onCancel={(feedback) => resolvePlan(p.id, { type: "cancel", feedback })}
                     />
                   ))}
                   {state.pendingCheckpoints.map((c) => (

--- a/desktop/src/i18n/de.ts
+++ b/desktop/src/i18n/de.ts
@@ -327,8 +327,8 @@ export const de: typeof en = {
   },
   modal: {
     ...en.modal,
-    planFeedbackPlaceholder: "Optional: Feedback — schreibe hier, wenn du Änderungen möchtest",
-    choiceCustomPlaceholder: "Oder gib deine eigene Antwort ein…",
+    planFeedbackPlaceholder: "Welche Probleme hat der Plan? Was muss verbessert werden?",
+    choiceCustomPlaceholder: "Wo kann der Plan weiter verfeinert werden?",
   },
   plan: {
     ...en.plan,
@@ -733,6 +733,8 @@ export const de: typeof en = {
   },
   thread: {
     ...en.thread,
+    toolCalls: "{count} Tool-Aufrufe",
+    oneToolCall: "1 Tool-Aufruf",
     keepSteps: "{n} verbleibende(n) Schritt(e) behalten",
     keepOriginal: "Original behalten",
     you: "Du",
@@ -746,6 +748,10 @@ export const de: typeof en = {
     approve: "Genehmigen",
     cancel: "Abbrechen",
     refine: "Verfeinern",
+    sendFeedback: "Senden",
+    skipFeedback: "Überspringen",
+    cancelFeedbackLabel: "Abbrechen — was ist falsch?",
+    refineFeedbackLabel: "Verfeinern — was soll geändert werden?",
     checkpointKind: "Plan-Checkpoint",
     checkpointTitle: "Schritt {completed} / {total} abgeschlossen",
     checkpointSub: "Checkpoint · {completed} / {total}",

--- a/desktop/src/i18n/en.ts
+++ b/desktop/src/i18n/en.ts
@@ -319,8 +319,8 @@ export const en = {
     shortcutSettings: "Settings",
   },
   modal: {
-    planFeedbackPlaceholder: "Optional feedback — write here if you want changes",
-    choiceCustomPlaceholder: "Or type your own answer…",
+    planFeedbackPlaceholder: "What problems does the plan have? What needs to be improved?",
+    choiceCustomPlaceholder: "Where can the plan be further refined?",
   },
   plan: {
     activeTitle: "Active plan",
@@ -715,6 +715,10 @@ export const en = {
     approve: "Approve",
     cancel: "Cancel",
     refine: "Refine",
+    sendFeedback: "Send",
+    skipFeedback: "Skip",
+    cancelFeedbackLabel: "Cancel — what went wrong?",
+    refineFeedbackLabel: "Refine — what should change?",
     checkpointKind: "plan checkpoint",
     checkpointTitle: "step {completed} / {total} complete",
     checkpointSub: "checkpoint · {completed} / {total}",

--- a/desktop/src/i18n/ja.ts
+++ b/desktop/src/i18n/ja.ts
@@ -311,8 +311,8 @@ export const ja = {
     shortcutSettings: "設定",
   },
   modal: {
-    planFeedbackPlaceholder: "任意のフィードバック — 変更が必要な場合はここに記入",
-    choiceCustomPlaceholder: "または自分の回答を入力…",
+    planFeedbackPlaceholder: "計画にどのような問題がありますか？どこを改善すべきですか？",
+    choiceCustomPlaceholder: "計画のどこをさらに詳細化できますか？",
   },
   plan: {
     activeTitle: "アクティブプラン",
@@ -692,6 +692,8 @@ export const ja = {
     unknownKind: "# 不明なカードタイプ — フォールバック表示",
   },
   thread: {
+    toolCalls: "{count} ツール呼び出し",
+    oneToolCall: "1 ツール呼び出し",
     keepSteps: "残り {n} ステップを保持",
     keepOriginal: "オリジナルを保持",
     you: "あなた",
@@ -705,6 +707,10 @@ export const ja = {
     approve: "承認",
     cancel: "キャンセル",
     refine: "修正依頼",
+    sendFeedback: "送信",
+    skipFeedback: "スキップ",
+    cancelFeedbackLabel: "キャンセル — 何が問題ですか？",
+    refineFeedbackLabel: "修正依頼 — 何を変更しますか？",
     checkpointKind: "プランチェックポイント",
     checkpointTitle: "ステップ {completed} / {total} 完了",
     checkpointSub: "チェックポイント · {completed} / {total}",

--- a/desktop/src/i18n/zh-CN.ts
+++ b/desktop/src/i18n/zh-CN.ts
@@ -306,7 +306,7 @@ export const zhCN: typeof en = {
   },
   modal: {
     planFeedbackPlaceholder: "计划存在哪些问题？需要改进哪些地方？",
-    choiceCustomPlaceholder: "计划可以在哪里地方进一步细化深化？",
+    choiceCustomPlaceholder: "计划可以如何进一步细化？",
   },
   plan: {
     activeTitle: "进行中的计划",

--- a/desktop/src/i18n/zh-CN.ts
+++ b/desktop/src/i18n/zh-CN.ts
@@ -305,8 +305,8 @@ export const zhCN: typeof en = {
     shortcutSettings: "设置",
   },
   modal: {
-    planFeedbackPlaceholder: "可选反馈 — 想要修改时写这里",
-    choiceCustomPlaceholder: "或者自己写一个答案…",
+    planFeedbackPlaceholder: "计划存在哪些问题？需要改进哪些地方？",
+    choiceCustomPlaceholder: "计划可以在哪里地方进一步细化深化？",
   },
   plan: {
     activeTitle: "进行中的计划",
@@ -700,6 +700,10 @@ export const zhCN: typeof en = {
     approve: "批准",
     cancel: "取消",
     refine: "细化",
+    sendFeedback: "发送",
+    skipFeedback: "跳过",
+    cancelFeedbackLabel: "取消 — 哪里有问题？",
+    refineFeedbackLabel: "细化 — 还需要什么？",
     checkpointKind: "计划检查点",
     checkpointTitle: "step {completed} / {total} 完成",
     checkpointSub: "检查点 · {completed} / {total}",

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -5696,6 +5696,30 @@ html:not([data-platform="macos"]) .cmdk-row .kb .shortcut kbd[data-key="mod"] {
   border-radius: 3px;
   font-size: 14px;
 }
+.approval-textarea {
+  width: 100%;
+  min-height: 72px;
+  max-height: 200px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  color: var(--fg);
+  font-family: inherit;
+  font-size: 14px;
+  line-height: 1.5;
+  resize: vertical;
+  outline: none;
+  box-sizing: border-box;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+.approval-textarea::placeholder {
+  color: var(--muted-2);
+}
+.approval-textarea:focus {
+  border-color: var(--approval-accent, var(--accent));
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--approval-accent, var(--accent)) 20%, transparent);
+}
 .approval .ap-preview {
   margin: 0 14px 10px;
   padding: 10px 12px;

--- a/desktop/src/ui/thread.tsx
+++ b/desktop/src/ui/thread.tsx
@@ -2,7 +2,7 @@ import type { ApprovalPrompt } from "@reasonix/core-utils";
 import { isCompactionSummary, stripCompactionMarker } from "@reasonix/core-utils/compaction";
 import { derivePrefix } from "@reasonix/core-utils/derive-prefix";
 import { Copy } from "lucide-react";
-import { type ReactNode, memo, useState } from "react";
+import { type ReactNode, memo, useEffect, useRef, useState } from "react";
 import type {
   ActivePlan,
   AssistantSegment,
@@ -365,12 +365,81 @@ export function PlanApprovalCard({
 }: {
   p: PendingPlan;
   onApprove: () => void;
-  onRefine: () => void;
-  onCancel: () => void;
+  onRefine: (feedback?: string) => void;
+  onCancel: (feedback?: string) => void;
 }) {
   useLang();
+  const [feedbackMode, setFeedbackMode] = useState<"cancel" | "refine" | null>(null);
+  const [feedbackText, setFeedbackText] = useState("");
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (feedbackMode && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [feedbackMode]);
+
+  const handleSendFeedback = () => {
+    const fb = feedbackText.trim() || undefined;
+    if (feedbackMode === "cancel") onCancel(fb);
+    else if (feedbackMode === "refine") onRefine(fb);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSendFeedback();
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      if (feedbackMode === "cancel") onCancel();
+      else if (feedbackMode === "refine") onRefine();
+    }
+  };
+
   const stepCount = p.steps?.length ?? 0;
   const sub = stepCount > 0 ? t("thread.planStepCount", { count: stepCount }) : undefined;
+
+  if (feedbackMode) {
+    const isCancel = feedbackMode === "cancel";
+    return (
+      <div className="approval" data-tone="info">
+        <div className="ap-head">
+          <span className="ap-ico">
+            <I.shield size={13} />
+          </span>
+          <div>
+            <div className="ap-kind">{t("thread.planConfirmationKind")}</div>
+            <div className="ap-title">
+              {isCancel ? t("thread.cancelFeedbackLabel") : t("thread.refineFeedbackLabel")}
+            </div>
+          </div>
+        </div>
+        <div className="ap-body">
+          <textarea
+            ref={inputRef}
+            className="approval-textarea"
+            value={feedbackText}
+            onChange={(e) => setFeedbackText(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder={t("modal.planFeedbackPlaceholder")}
+          />
+        </div>
+        <div className="ap-foot">
+          <button type="button" className="btn primary" onClick={handleSendFeedback}>
+            {t("thread.sendFeedback")}
+          </button>
+          <button
+            type="button"
+            className="btn ghost"
+            onClick={() => (isCancel ? onCancel() : onRefine())}
+          >
+            {t("thread.skipFeedback")}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <ApprovalCard
       kind={t("thread.planConfirmationKind")}
@@ -392,8 +461,8 @@ export function PlanApprovalCard({
       secondaryLabel={t("thread.cancel")}
       tertiaryLabel={t("thread.refine")}
       onPrimary={onApprove}
-      onSecondary={onCancel}
-      onTertiary={onRefine}
+      onSecondary={() => setFeedbackMode("cancel")}
+      onTertiary={() => setFeedbackMode("refine")}
     />
   );
 }


### PR DESCRIPTION
## Summary

Closes #2052.

The Desktop \`PlanApprovalCard\` now shows a text input when the user clicks **Cancel** or **Refine**, allowing them to provide feedback before sending the verdict — consistent with the CLI behavior.

### Before

Clicking Cancel or Refine immediately dispatched the verdict with no \`feedback\` field, despite \`PlanVerdict\` already supporting it.

### After

- Clicking **Cancel** → text input with placeholder asking what went wrong
- Clicking **Refine** → text input with placeholder asking what should change
- **Enter** sends the feedback; **Escape** skips (sends without feedback)
- Two buttons: **Send** (with feedback) / **Skip** (without feedback)

## Changes

| File | Change |
|------|--------|
| \`desktop/src/ui/thread.tsx\` | \`PlanApprovalCard\` now manages \`feedbackMode\` state; renders text input + Send/Skip buttons when Cancel or Refine is clicked |
| \`desktop/src/App.tsx\` | \`onRefine\` / \`onCancel\` callbacks now accept \`(feedback?: string)\` and pass it to \`resolvePlan\` |
| \`desktop/src/styles.css\` | Styles for the feedback input row inside approval cards |
| \`desktop/src/i18n/en.ts\` | Added \`sendFeedback\`, \`skipFeedback\`, \`cancelFeedbackLabel\`, \`refineFeedbackLabel\`; updated \`planFeedbackPlaceholder\` / \`choiceCustomPlaceholder\` |
| \`desktop/src/i18n/zh-CN.ts\` | Same i18n additions with Chinese text |
| \`desktop/src/i18n/de.ts\` | Same + backfilled missing \`toolCalls\` / \`oneToolCall\` keys |
| \`desktop/src/i18n/ja.ts\` | Same + backfilled missing \`toolCalls\` / \`oneToolCall\` keys |

## Verification

- All plan-related tests pass: \`plan.test.ts\` (45), \`pause-gate.test.ts\` (12), \`App.test.ts\` (10)
- Desktop Vite build passes
- Tauri debug build produces MSI + NSIS installers