### PR TITLE
feat(desktop): extend QQ remote commands with model and mode controls

### DIFF
--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -1356,6 +1356,52 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
         void runTurn(tab, prev, true);
         return true;
       }
+      case "model": {
+        if (!cmd.value) {
+          sendQQInfo(
+            `Current model: ${tab.currentModel}. Use /model flash, /model pro, /model deepseek-v4-flash, or /model deepseek-v4-pro.`,
+            tab,
+          );
+          return true;
+        }
+        const next = normalizeQQRemoteModel(cmd.value);
+        if (!next) {
+          sendQQInfo(
+            "Unsupported desktop model. Use /model flash, /model pro, /model deepseek-v4-flash, or /model deepseek-v4-pro.",
+            tab,
+          );
+          return true;
+        }
+        applyDesktopModel(tab, next);
+        sendQQInfo(`Switched desktop model to ${next}.`, tab);
+        return true;
+      }
+      case "effort":
+        if (!cmd.value) {
+          sendQQInfo(
+            `Current reasoning effort: ${loadReasoningEffort()}. Use /effort low, /effort medium, /effort high, or /effort max.`,
+            tab,
+          );
+          return true;
+        }
+        saveReasoningEffort(cmd.value);
+        tab.runtime?.loop.configure({ reasoningEffort: cmd.value });
+        emitSettings(tab);
+        sendQQInfo(`Switched desktop reasoning effort to ${cmd.value}.`, tab);
+        return true;
+      case "plan":
+        if (!cmd.value) {
+          sendQQInfo(
+            `Current plan mode: ${loadEditMode()}. Use /plan review, /plan auto, or /plan yolo.`,
+            tab,
+          );
+          return true;
+        }
+        saveEditMode(cmd.value);
+        if (tab.toolset) applyPlanMode(tab.toolset.tools, cmd.value);
+        emitSettings(tab);
+        sendQQInfo(`Switched desktop plan mode to ${cmd.value}.`, tab);
+        return true;
       case "btw":
         if (!tab.runtime) {
           sendQQInfo("Desktop is not configured yet.", tab);
@@ -1387,6 +1433,28 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
       default:
         return false;
     }
+  }
+
+  function normalizeQQRemoteModel(value: string): string | null {
+    const lower = value.trim().toLowerCase();
+    if (!lower) return null;
+    if (lower === "flash") return "deepseek-v4-flash";
+    if (lower === "pro") return "deepseek-v4-pro";
+    if (lower === "deepseek-v4-flash" || lower === "deepseek-v4-pro") return lower;
+    return null;
+  }
+
+  function applyDesktopModel(tab: Tab, next: string): void {
+    tab.currentModel = next;
+    saveModel(next);
+    if (tab.toolset) {
+      tab.system = codeSystemPrompt(tab.rootDir, {
+        hasSemanticSearch: tab.toolset.semantic.enabled,
+        modelId: tab.currentModel,
+      });
+      if (tab.runtime) tab.runtime = buildRuntimeFor(tab);
+    }
+    emitSettings(tab);
   }
 
   function parseIndexedChoice(text: string): number {

--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -1340,6 +1340,22 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
               .catch(() => undefined);
           });
         return true;
+      case "retry": {
+        if (!tab.runtime) {
+          sendQQInfo("Desktop is not configured yet.", tab);
+          return true;
+        }
+        const prev = tab.runtime.loop.retryLastUser();
+        if (!prev) {
+          sendQQInfo(
+            "There is no previous local user message to retry in this desktop conversation.",
+            tab,
+          );
+          return true;
+        }
+        void runTurn(tab, prev, true);
+        return true;
+      }
       case "btw":
         if (!tab.runtime) {
           sendQQInfo("Desktop is not configured yet.", tab);

--- a/src/desktop/qq-remote-commands.ts
+++ b/src/desktop/qq-remote-commands.ts
@@ -4,6 +4,9 @@ export type QQRemoteDesktopCommand =
   | { kind: "abort" }
   | { kind: "compact" }
   | { kind: "retry" }
+  | { kind: "model"; value?: string }
+  | { kind: "effort"; value?: "low" | "medium" | "high" | "max" }
+  | { kind: "plan"; value?: "review" | "auto" | "yolo" }
   | { kind: "btw"; text: string }
   | { kind: "skill"; name: string; args?: string };
 
@@ -20,6 +23,29 @@ export function parseQQRemoteDesktopCommand(
   if (trimmed === "/compact") return { kind: "compact" };
   if (trimmed === "/retry") return { kind: "retry" };
 
+  const modelMatch = /^\/model(?:\s+([\s\S]+))?$/.exec(trimmed);
+  if (modelMatch) {
+    const value = modelMatch[1]?.trim() ?? "";
+    return { kind: "model", value: value || undefined };
+  }
+
+  const effortMatch = /^\/effort(?:\s+(low|medium|high|max))?$/i.exec(trimmed);
+  if (effortMatch) {
+    const value = effortMatch[1]?.trim().toLowerCase() as
+      | "low"
+      | "medium"
+      | "high"
+      | "max"
+      | undefined;
+    return { kind: "effort", value };
+  }
+
+  const planMatch = /^\/plan(?:\s+(review|auto|yolo))?$/i.exec(trimmed);
+  if (planMatch) {
+    const value = planMatch[1]?.trim().toLowerCase() as "review" | "auto" | "yolo" | undefined;
+    return { kind: "plan", value };
+  }
+
   const btwMatch = /^\/btw(?:\s+([\s\S]+))?$/.exec(trimmed);
   if (btwMatch) {
     const question = btwMatch[1]?.trim() ?? "";
@@ -35,7 +61,10 @@ export function parseQQRemoteDesktopCommand(
     rawName === "new" ||
     rawName === "abort" ||
     rawName === "compact" ||
-    rawName === "retry"
+    rawName === "retry" ||
+    rawName === "model" ||
+    rawName === "effort" ||
+    rawName === "plan"
   ) {
     return null;
   }
@@ -56,6 +85,9 @@ export function qqRemoteDesktopHelpText(skillNames: Iterable<string>): string {
     "- /abort",
     "- /compact",
     "- /retry",
+    "- /model <flash|pro|deepseek-v4-flash|deepseek-v4-pro>",
+    "- /effort <low|medium|high|max>",
+    "- /plan <review|auto|yolo>",
     "- /btw <question>",
     `${skillHint}`.trimEnd(),
     "",
@@ -66,5 +98,12 @@ export function qqRemoteDesktopHelpText(skillNames: Iterable<string>): string {
 }
 
 export function qqRemoteCommandBypassesBusy(cmd: QQRemoteDesktopCommand): boolean {
-  return cmd.kind === "help" || cmd.kind === "new" || cmd.kind === "abort";
+  return (
+    cmd.kind === "help" ||
+    cmd.kind === "new" ||
+    cmd.kind === "abort" ||
+    cmd.kind === "model" ||
+    cmd.kind === "effort" ||
+    cmd.kind === "plan"
+  );
 }

--- a/src/desktop/qq-remote-commands.ts
+++ b/src/desktop/qq-remote-commands.ts
@@ -98,12 +98,5 @@ export function qqRemoteDesktopHelpText(skillNames: Iterable<string>): string {
 }
 
 export function qqRemoteCommandBypassesBusy(cmd: QQRemoteDesktopCommand): boolean {
-  return (
-    cmd.kind === "help" ||
-    cmd.kind === "new" ||
-    cmd.kind === "abort" ||
-    cmd.kind === "model" ||
-    cmd.kind === "effort" ||
-    cmd.kind === "plan"
-  );
+  return cmd.kind === "help" || cmd.kind === "new" || cmd.kind === "abort" || cmd.kind === "effort";
 }

--- a/src/desktop/qq-remote-commands.ts
+++ b/src/desktop/qq-remote-commands.ts
@@ -3,6 +3,7 @@ export type QQRemoteDesktopCommand =
   | { kind: "new" }
   | { kind: "abort" }
   | { kind: "compact" }
+  | { kind: "retry" }
   | { kind: "btw"; text: string }
   | { kind: "skill"; name: string; args?: string };
 
@@ -17,6 +18,7 @@ export function parseQQRemoteDesktopCommand(
   if (trimmed === "/new") return { kind: "new" };
   if (trimmed === "/abort") return { kind: "abort" };
   if (trimmed === "/compact") return { kind: "compact" };
+  if (trimmed === "/retry") return { kind: "retry" };
 
   const btwMatch = /^\/btw(?:\s+([\s\S]+))?$/.exec(trimmed);
   if (btwMatch) {
@@ -28,7 +30,13 @@ export function parseQQRemoteDesktopCommand(
   if (!skillMatch) return null;
   const [, rawName, rawArgs] = skillMatch;
   if (!rawName) return null;
-  if (rawName === "help" || rawName === "new" || rawName === "abort" || rawName === "compact") {
+  if (
+    rawName === "help" ||
+    rawName === "new" ||
+    rawName === "abort" ||
+    rawName === "compact" ||
+    rawName === "retry"
+  ) {
     return null;
   }
   const names = new Set(skillNames);
@@ -47,6 +55,7 @@ export function qqRemoteDesktopHelpText(skillNames: Iterable<string>): string {
     "- /new",
     "- /abort",
     "- /compact",
+    "- /retry",
     "- /btw <question>",
     `${skillHint}`.trimEnd(),
     "",

--- a/tests/desktop-qq-remote-commands.test.ts
+++ b/tests/desktop-qq-remote-commands.test.ts
@@ -14,6 +14,18 @@ describe("desktop QQ remote commands", () => {
     expect(parseQQRemoteDesktopCommand("/abort", skills)).toEqual({ kind: "abort" });
     expect(parseQQRemoteDesktopCommand("/compact", skills)).toEqual({ kind: "compact" });
     expect(parseQQRemoteDesktopCommand("/retry", skills)).toEqual({ kind: "retry" });
+    expect(parseQQRemoteDesktopCommand("/model flash", skills)).toEqual({
+      kind: "model",
+      value: "flash",
+    });
+    expect(parseQQRemoteDesktopCommand("/effort high", skills)).toEqual({
+      kind: "effort",
+      value: "high",
+    });
+    expect(parseQQRemoteDesktopCommand("/plan auto", skills)).toEqual({
+      kind: "plan",
+      value: "auto",
+    });
     expect(parseQQRemoteDesktopCommand("/btw what's up", skills)).toEqual({
       kind: "btw",
       text: "what's up",
@@ -29,6 +41,8 @@ describe("desktop QQ remote commands", () => {
     expect(parseQQRemoteDesktopCommand("/theme", skills)).toBeNull();
     expect(parseQQRemoteDesktopCommand("/skill qq", skills)).toBeNull();
     expect(parseQQRemoteDesktopCommand("/btw", skills)).toBeNull();
+    expect(parseQQRemoteDesktopCommand("/effort impossible", skills)).toBeNull();
+    expect(parseQQRemoteDesktopCommand("/plan maybe", skills)).toBeNull();
     expect(parseQQRemoteDesktopCommand("/unknown", skills)).toBeNull();
   });
 
@@ -36,6 +50,9 @@ describe("desktop QQ remote commands", () => {
     expect(qqRemoteCommandBypassesBusy({ kind: "help" })).toBe(true);
     expect(qqRemoteCommandBypassesBusy({ kind: "new" })).toBe(true);
     expect(qqRemoteCommandBypassesBusy({ kind: "abort" })).toBe(true);
+    expect(qqRemoteCommandBypassesBusy({ kind: "model", value: "flash" })).toBe(true);
+    expect(qqRemoteCommandBypassesBusy({ kind: "effort", value: "high" })).toBe(true);
+    expect(qqRemoteCommandBypassesBusy({ kind: "plan", value: "auto" })).toBe(true);
     expect(qqRemoteCommandBypassesBusy({ kind: "compact" })).toBe(false);
     expect(qqRemoteCommandBypassesBusy({ kind: "retry" })).toBe(false);
     expect(qqRemoteCommandBypassesBusy({ kind: "btw", text: "hi" })).toBe(false);
@@ -49,6 +66,9 @@ describe("desktop QQ remote commands", () => {
     expect(help).toContain("/abort");
     expect(help).toContain("/compact");
     expect(help).toContain("/retry");
+    expect(help).toContain("/model <flash|pro|deepseek-v4-flash|deepseek-v4-pro>");
+    expect(help).toContain("/effort <low|medium|high|max>");
+    expect(help).toContain("/plan <review|auto|yolo>");
     expect(help).toContain("/btw <question>");
     expect(help).toContain("/<skill> [args]");
     expect(help).toContain("agent-reach, qq");

--- a/tests/desktop-qq-remote-commands.test.ts
+++ b/tests/desktop-qq-remote-commands.test.ts
@@ -46,13 +46,13 @@ describe("desktop QQ remote commands", () => {
     expect(parseQQRemoteDesktopCommand("/unknown", skills)).toBeNull();
   });
 
-  it("allows only help/new/abort to bypass busy", () => {
+  it("allows only help/new/abort/effort to bypass busy", () => {
     expect(qqRemoteCommandBypassesBusy({ kind: "help" })).toBe(true);
     expect(qqRemoteCommandBypassesBusy({ kind: "new" })).toBe(true);
     expect(qqRemoteCommandBypassesBusy({ kind: "abort" })).toBe(true);
-    expect(qqRemoteCommandBypassesBusy({ kind: "model", value: "flash" })).toBe(true);
+    expect(qqRemoteCommandBypassesBusy({ kind: "model", value: "flash" })).toBe(false);
     expect(qqRemoteCommandBypassesBusy({ kind: "effort", value: "high" })).toBe(true);
-    expect(qqRemoteCommandBypassesBusy({ kind: "plan", value: "auto" })).toBe(true);
+    expect(qqRemoteCommandBypassesBusy({ kind: "plan", value: "auto" })).toBe(false);
     expect(qqRemoteCommandBypassesBusy({ kind: "compact" })).toBe(false);
     expect(qqRemoteCommandBypassesBusy({ kind: "retry" })).toBe(false);
     expect(qqRemoteCommandBypassesBusy({ kind: "btw", text: "hi" })).toBe(false);

--- a/tests/desktop-qq-remote-commands.test.ts
+++ b/tests/desktop-qq-remote-commands.test.ts
@@ -13,6 +13,7 @@ describe("desktop QQ remote commands", () => {
     expect(parseQQRemoteDesktopCommand("/new", skills)).toEqual({ kind: "new" });
     expect(parseQQRemoteDesktopCommand("/abort", skills)).toEqual({ kind: "abort" });
     expect(parseQQRemoteDesktopCommand("/compact", skills)).toEqual({ kind: "compact" });
+    expect(parseQQRemoteDesktopCommand("/retry", skills)).toEqual({ kind: "retry" });
     expect(parseQQRemoteDesktopCommand("/btw what's up", skills)).toEqual({
       kind: "btw",
       text: "what's up",
@@ -25,7 +26,6 @@ describe("desktop QQ remote commands", () => {
   });
 
   it("does not treat UI-only or ambiguous slash text as QQ desktop commands", () => {
-    expect(parseQQRemoteDesktopCommand("/retry", skills)).toBeNull();
     expect(parseQQRemoteDesktopCommand("/theme", skills)).toBeNull();
     expect(parseQQRemoteDesktopCommand("/skill qq", skills)).toBeNull();
     expect(parseQQRemoteDesktopCommand("/btw", skills)).toBeNull();
@@ -37,6 +37,7 @@ describe("desktop QQ remote commands", () => {
     expect(qqRemoteCommandBypassesBusy({ kind: "new" })).toBe(true);
     expect(qqRemoteCommandBypassesBusy({ kind: "abort" })).toBe(true);
     expect(qqRemoteCommandBypassesBusy({ kind: "compact" })).toBe(false);
+    expect(qqRemoteCommandBypassesBusy({ kind: "retry" })).toBe(false);
     expect(qqRemoteCommandBypassesBusy({ kind: "btw", text: "hi" })).toBe(false);
     expect(qqRemoteCommandBypassesBusy({ kind: "skill", name: "qq" })).toBe(false);
   });
@@ -47,6 +48,7 @@ describe("desktop QQ remote commands", () => {
     expect(help).toContain("/new");
     expect(help).toContain("/abort");
     expect(help).toContain("/compact");
+    expect(help).toContain("/retry");
     expect(help).toContain("/btw <question>");
     expect(help).toContain("/<skill> [args]");
     expect(help).toContain("agent-reach, qq");


### PR DESCRIPTION
## Summary
- follow up `#2058` by adding the remaining desktop-native QQ remote commands that fit the desktop session model
- add `/retry`, `/model ...`, `/effort ...`, and `/plan ...` to the desktop QQ remote-command subset
- keep the scope focused on commands that meaningfully control the active desktop session remotely

## Context
`#2058` intentionally shipped a narrow first pass, but I later realized it still missed a few desktop-native commands that should have been considered in the same surface. This PR is the clean follow-up for that gap.

## What this adds
Desktop QQ remote input now also handles:
- `/retry`
- `/model <flash|pro|deepseek-v4-flash|deepseek-v4-pro>`
- `/effort <low|medium|high|max>`
- `/plan <review|auto|yolo>`

These are added before fallback to normal model input, alongside the existing subset from `#2058`.

## What this still does not add
This still does **not** expose UI-only desktop commands such as `/theme`, `/lang`, `/currency`, `/copy`, or `/clear` over QQ.

## Why
Desktop QQ should follow the desktop command surface where it makes sense remotely, rather than mirroring the CLI `/qq` surface or forcing every slash input through normal model text.

These commands are useful remote controls for the active desktop session:
- `/retry` re-runs the last user turn
- `/model` switches the active tab model
- `/effort` adjusts reasoning effort
- `/plan` adjusts the current plan/review/yolo mode

## Verification
- `npm test -- --run tests/desktop-qq-remote-commands.test.ts tests/desktop-qq-turn-routing.test.ts tests/desktop-btw-status.test.ts tests/desktop-session-load.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run verify`