### PR TITLE
feat(lifecycle): detect explicit plan-first intent

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -175,6 +175,7 @@ import { ModeStatusBar } from "./layout/LiveRows.js";
 import { StaticCardStream } from "./layout/StaticCardStream.js";
 import { StatusRow } from "./layout/StatusRow.js";
 import type { StatusBarConfig } from "./layout/StatusRow.js";
+import { shouldEnterPlanModeForExplicitIntent } from "./lifecycle-explicit-intent.js";
 import { formatLoopStatus } from "./loop.js";
 import { applyMcpAppend } from "./mcp-append.js";
 import { handleMcpBrowseSlash } from "./mcp-browse.js";
@@ -3137,6 +3138,16 @@ function AppInner({
       }
 
       if (codeMode) {
+        if (
+          shouldEnterPlanModeForExplicitIntent({
+            text,
+            codeMode: true,
+            planMode,
+          })
+        ) {
+          togglePlanMode(true, "explicit-intent");
+          log.pushInfo(t("app.explicitPlanIntentArmed"));
+        }
         const before = engineeringLifecycleRef.current?.snapshot().state;
         engineeringLifecycleRef.current?.observeUserPrompt(text);
         const after = engineeringLifecycleRef.current?.snapshot().state;

--- a/src/cli/ui/lifecycle-explicit-intent.ts
+++ b/src/cli/ui/lifecycle-explicit-intent.ts
@@ -1,0 +1,57 @@
+export interface ExplicitPlanIntentRequest {
+  text: string;
+  codeMode: boolean;
+  planMode: boolean;
+}
+
+export function shouldEnterPlanModeForExplicitIntent(request: ExplicitPlanIntentRequest): boolean {
+  return request.codeMode && !request.planMode && detectExplicitPlanFirstIntent(request.text);
+}
+
+export function detectExplicitPlanFirstIntent(text: string): boolean {
+  const normalized = normalizePrompt(text);
+  if (!normalized) return false;
+
+  return (
+    hasExplicitStrictLifecycleRequest(normalized) ||
+    ENGLISH_PLAN_FIRST_PATTERNS.some((pattern) => pattern.test(normalized)) ||
+    CHINESE_PLAN_FIRST_PATTERNS.some((pattern) => pattern.test(normalized))
+  );
+}
+
+function normalizePrompt(text: string): string {
+  return text.normalize("NFKC").toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+function hasExplicitStrictLifecycleRequest(text: string): boolean {
+  return EXPLICIT_STRICT_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+const EN_ACTION =
+  "(?:edit|editing|change|changing|modify|modifying|implement|implementing|code|coding|write|writing|touch|touching|refactor|refactoring|migrate|migrating|rename|renaming|move|moving|files?|codebase)";
+const EN_PLAN = "(?:implementation plan|migration plan|refactor plan|plan|proposal|outline)";
+
+const EXPLICIT_STRICT_PATTERNS = [
+  /\B\/plan\s+strict\b/,
+  /\b(?:use|enable|turn on|start|activate)\s+(?:the\s+)?(?:(?:strict\s+)?engineering\s+lifecycle|strict\s+lifecycle)\b/,
+  /\b(?:use|enable|turn on|start|activate)\s+(?:the\s+)?plan mode\b/,
+  /(?:使用|启用|开启|进入).{0,12}(?:严格|强约束|strict).{0,12}(?:lifecycle|生命周期|工程生命周期|plan|计划模式)/,
+];
+
+const ENGLISH_PLAN_FIRST_PATTERNS = [
+  new RegExp(`\\bplan\\s+first\\b.{0,80}\\b${EN_ACTION}\\b`),
+  new RegExp(
+    `\\b(?:draft|write|prepare|create|make|show me|give me)\\s+(?:an?\\s+)?${EN_PLAN}\\b.{0,80}\\b(?:before|prior to)\\b.{0,80}\\b${EN_ACTION}\\b`,
+  ),
+  new RegExp(`\\b(?:before|prior to)\\b.{0,80}\\b${EN_ACTION}\\b.{0,80}\\b${EN_PLAN}\\b`),
+  new RegExp(
+    `\\b(?:do not|don't|dont|avoid)\\b.{0,50}\\b${EN_ACTION}\\b.{0,80}\\b(?:first\\s+)?${EN_PLAN}\\b`,
+  ),
+  new RegExp(`\\b${EN_PLAN}\\b.{0,50}\\b(?:before|then)\\b.{0,80}\\b${EN_ACTION}\\b`),
+];
+
+const CHINESE_PLAN_FIRST_PATTERNS = [
+  /先.{0,16}(?:规划|计划|方案).{0,40}(?:再|然后|之后)?.{0,16}(?:改|修改|写|实现|编码|动代码|动手|重构|迁移)/,
+  /先.{0,20}(?:给我|帮我|做|出|制定|设计|写)?.{0,8}(?:实现方案|计划|规划|方案).{0,40}(?:不要|别).{0,20}(?:直接)?(?:改|修改|写|实现|动代码|动手)/,
+  /(?:先不要|先别|不要|别).{0,20}(?:改|修改|写|实现|动代码|动手).{0,40}(?:先|先做|先给|先出)?.{0,20}(?:计划|规划|方案)/,
+];

--- a/src/cli/ui/slash/types.ts
+++ b/src/cli/ui/slash/types.ts
@@ -59,7 +59,7 @@ export interface SlashResult {
   };
 }
 
-export type PlanModeToggleSource = "slash";
+export type PlanModeToggleSource = "slash" | "explicit-intent";
 
 export interface SlashContext {
   configPath?: string;

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -624,6 +624,8 @@ export const EN: TranslationSchema = {
     continuingAfter: "▸ continuing after {label}{counter}",
     planStoppedAt: "▸ plan stopped at {label}{counter}",
     revisingAfter: "▸ revising after {label} — {feedback}",
+    explicitPlanIntentArmed:
+      "▸ explicit plan-first request detected — strict lifecycle enabled. Use /plan off to leave.",
     historyScrollHint: " ↑ reading history · End / PgDn returns to bottom · ↓ advances one line",
     editHistoryTitle: "Edit history (oldest first):",
     editHistoryNoCodeMode: "not in code mode",

--- a/src/i18n/JA.ts
+++ b/src/i18n/JA.ts
@@ -653,6 +653,8 @@ export const JA: TranslationSchema = {
     continuingAfter: "▸ {label}{counter} の後に続行",
     planStoppedAt: "▸ {label}{counter} でプランを停止",
     revisingAfter: "▸ {label} の後に修正 — {feedback}",
+    explicitPlanIntentArmed:
+      "▸ 明示的な plan-first リクエストを検出 — strict lifecycle を有効化しました。/plan off で終了できます。",
     historyScrollHint: " ↑ 履歴を読込中 · End / PgDn で最下部に戻る · ↓ で1行進む",
     editHistoryTitle: "編集履歴（古い順）:",
     editHistoryNoCodeMode: "コードモードではありません",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -227,6 +227,7 @@ export interface TranslationSchema {
     continuingAfter: string;
     planStoppedAt: string;
     revisingAfter: string;
+    explicitPlanIntentArmed: string;
     historyScrollHint: string;
     editHistoryTitle: string;
     editHistoryNoCodeMode: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -604,6 +604,8 @@ export const zhCN: TranslationSchema = {
     continuingAfter: "▸ 在 {label}{counter} 之后继续",
     planStoppedAt: "▸ 计划在 {label}{counter} 处停止",
     revisingAfter: "▸ 在 {label} 之后修订 — {feedback}",
+    explicitPlanIntentArmed:
+      "▸ 检测到明确的先规划请求 — 已启用 strict lifecycle。可用 /plan off 退出。",
     historyScrollHint: " ↑ 正在查看历史 · End / PgDn 返回底部 · ↓ 向下滚动一行",
     editHistoryTitle: "编辑历史（从旧到新）：",
     editHistoryNoCodeMode: "不在代码模式中",

--- a/tests/lifecycle-explicit-intent.test.ts
+++ b/tests/lifecycle-explicit-intent.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  detectExplicitPlanFirstIntent,
+  shouldEnterPlanModeForExplicitIntent,
+} from "../src/cli/ui/lifecycle-explicit-intent.js";
+
+describe("explicit lifecycle plan intent", () => {
+  it.each([
+    "请先规划再修改代码",
+    "先给我一个实现方案，不要直接改代码",
+    "先不要动代码，先做计划",
+    "Use strict lifecycle for this refactor",
+    "Enable plan mode before editing files",
+    "Please draft an implementation plan before changing code",
+  ])("detects explicit plan-first prompts: %s", (text) => {
+    expect(detectExplicitPlanFirstIntent(text)).toBe(true);
+  });
+
+  it.each([
+    "解释一下 tsconfig.json 是怎么工作的",
+    "修复一个拼写错误",
+    "I came across a bug in the API route",
+    "Please address this issue",
+    "Add address field to the API response",
+    "What is the plan for understanding package.json?",
+    "Use lifecycle hooks to track mounted state",
+  ])("does not treat ambiguous wording as explicit plan-first intent: %s", (text) => {
+    expect(detectExplicitPlanFirstIntent(text)).toBe(false);
+  });
+
+  it("only asks the host to enter plan mode in code mode when plan mode is off", () => {
+    expect(
+      shouldEnterPlanModeForExplicitIntent({
+        text: "先给我一个计划，不要直接改代码",
+        codeMode: true,
+        planMode: false,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldEnterPlanModeForExplicitIntent({
+        text: "先给我一个计划，不要直接改代码",
+        codeMode: false,
+        planMode: false,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldEnterPlanModeForExplicitIntent({
+        text: "先给我一个计划，不要直接改代码",
+        codeMode: true,
+        planMode: true,
+      }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- add a narrow host-side detector for explicit plan-first / strict lifecycle requests
- wire the detector into the TUI user prompt path so explicit requests enable existing strict plan rails before the model turn starts
- keep the detector conservative with bilingual positive cases and false-positive coverage for `add`, `api`, `修`, `.json`, `across`, and lifecycle-hook wording

## Design notes

This is intentionally not broad auto-arm. It only reacts when the user explicitly asks for plan-first behavior or strict lifecycle / plan mode. The runtime still uses the existing `/plan strict` rails, and the user can leave with `/plan off`.

No system prompt, tool schema, or immutable prefix changes are introduced.

## Validation

- `npm test -- tests/lifecycle-explicit-intent.test.ts`
- `npm test -- tests/code-prompt.test.ts tests/lifecycle-explicit-intent.test.ts tests/lifecycle-policy.test.ts tests/lifecycle-e2e.test.ts tests/lifecycle.test.ts tests/tools.test.ts tests/slash.test.ts`
- `npx biome check src/cli/ui/lifecycle-explicit-intent.ts tests/lifecycle-explicit-intent.test.ts src/cli/ui/App.tsx src/cli/ui/slash/types.ts src/i18n/EN.ts src/i18n/zh-CN.ts src/i18n/JA.ts src/i18n/types.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run verify`
- pre-push hook reran `npm run verify`
