### PR TITLE
fix(shell): demote allowlisted commands when path args escape workspace (#2081)

### DIFF
--- a/src/tools/shell/parse.ts
+++ b/src/tools/shell/parse.ts
@@ -341,6 +341,23 @@ export function isAllowed(
       )
     )
       return false;
+    // Issue #2081 — demote when a path-like argument resolves outside the
+    // workspace.  Prevents allowlisted commands (find, tree, grep, cat …)
+    // from silently scanning the entire filesystem (e.g. `find / -name x`).
+    // Relative paths are resolved against projectRoot, so `find .` stays
+    // allowed; only paths that escape the workspace trigger the confirm gate.
+    if (projectRoot) {
+      const root = pathMod.resolve(projectRoot);
+      for (const tok of argv) {
+        if (!tok || tok.startsWith("-") || tok.includes("://") || tok.startsWith("$")) continue;
+        let expanded = tok;
+        if (expanded.startsWith("~")) expanded = pathMod.join(homedir(), expanded.slice(1));
+        const resolved = pathMod.resolve(root, expanded);
+        if (pathMod.isAbsolute(resolved) && !pathIsUnder(resolved, root)) {
+          return false;
+        }
+      }
+    }
     return true;
   }
   return false;

--- a/tests/shell-tools.test.ts
+++ b/tests/shell-tools.test.ts
@@ -355,10 +355,13 @@ describe("isAllowed", () => {
     });
 
     it("accepts user-configured extra prefixes", () => {
-      expect(isAllowed("cat /opt/secrets/config.yml", [], projectRoot)).toBe(true);
+      // /opt/secrets is outside workspace — workspace-escape check (#2081) demotes it even without sensitive-prefix config
+      expect(isAllowed("cat /opt/secrets/config.yml", [], projectRoot)).toBe(false);
       expect(
         isAllowed("cat /opt/secrets/config.yml", [], projectRoot, { prefixes: ["/opt/secrets"] }),
       ).toBe(false);
+      // A path inside the workspace that isn't in sensitive prefixes should pass
+      expect(isAllowed("cat secrets/config.yml", [], projectRoot)).toBe(true);
     });
 
     it("accepts user-configured extra patterns", () => {
@@ -390,6 +393,61 @@ describe("isAllowed", () => {
       expect(isCommandAllowed("cat < .env", [], projectRoot)).toBe(false);
       expect(isCommandAllowed("cat < ~/.ssh/id_rsa", [], projectRoot)).toBe(false);
       expect(isCommandAllowed("cat < README.md", [], projectRoot)).toBe(true);
+    });
+  });
+
+  // Issue #2081 — allowlisted commands with path arguments that resolve
+  // outside the workspace are demoted to the confirm gate.
+  describe("workspace-escape path demotion", () => {
+    const projectRoot = "/home/user/project";
+
+    it("demotes find with absolute path outside workspace", () => {
+      expect(isAllowed("find / -name '*.ts'", [], projectRoot)).toBe(false);
+      expect(isAllowed("find /etc -name '*.conf'", [], projectRoot)).toBe(false);
+      expect(isAllowed("find /tmp -name '*.log'", [], projectRoot)).toBe(false);
+    });
+
+    it("allows find with workspace-relative paths", () => {
+      expect(isAllowed("find . -name '*.ts'", [], projectRoot)).toBe(true);
+      expect(isAllowed("find src -type f", [], projectRoot)).toBe(true);
+      expect(isAllowed("find ./dist -name '*.js'", [], projectRoot)).toBe(true);
+    });
+
+    it("demotes tree with path outside workspace", () => {
+      expect(isAllowed("tree /etc", [], projectRoot)).toBe(false);
+      expect(isAllowed("tree /", [], projectRoot)).toBe(false);
+    });
+
+    it("allows tree with workspace-relative path", () => {
+      expect(isAllowed("tree src", [], projectRoot)).toBe(true);
+      expect(isAllowed("tree -L 2", [], projectRoot)).toBe(true);
+    });
+
+    it("demotes grep/cat/ls with absolute path outside workspace", () => {
+      expect(isAllowed("grep foo /etc/passwd", [], projectRoot)).toBe(false);
+      expect(isAllowed("cat /etc/hosts", [], projectRoot)).toBe(false);
+      expect(isAllowed("ls /root", [], projectRoot)).toBe(false);
+    });
+
+    it("allows grep/cat/ls with workspace-relative path", () => {
+      expect(isAllowed("grep TODO src/", [], projectRoot)).toBe(true);
+      expect(isAllowed("cat README.md", [], projectRoot)).toBe(true);
+      expect(isAllowed("ls src/", [], projectRoot)).toBe(true);
+    });
+
+    it("does NOT demote when projectRoot is not provided (backward compat)", () => {
+      expect(isAllowed("find / -name '*.ts'")).toBe(true);
+      expect(isAllowed("tree /etc")).toBe(true);
+    });
+
+    it("skips flags, URLs, and env vars", () => {
+      expect(isAllowed("ls --color", [], projectRoot)).toBe(true);
+      expect(isAllowed("grep --include=*.ts foo src/", [], projectRoot)).toBe(true);
+    });
+
+    it("works through isCommandAllowed for chain commands", () => {
+      expect(isCommandAllowed("find / -name '*.ts' | head", [], projectRoot)).toBe(false);
+      expect(isCommandAllowed("find . -name '*.ts' | head", [], projectRoot)).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Problem

Commands like `find / -name "xxx"` bypassed the sandbox because path arguments were never checked against the workspace boundary. Only redirect targets (`>`/`>>`) and sensitive-path prefixes (`~/.ssh`, `.env`) were validated.

This allowed the agent to silently scan the entire filesystem (e.g. `find /` running for 55 seconds) without user confirmation.

## Root Cause

`find` is in `BUILTIN_ALLOWLIST`, and the sandbox only checks:
1. File redirect targets must be inside workspace (`ensureUnderSandbox` in shell-chain.ts)
2. Sensitive path arguments (`~/.ssh`, `/etc/shadow`, etc.)

It does NOT check whether command arguments point outside the workspace.

## Fix

Add a workspace-escape check in `isAllowed`: when `projectRoot` is provided, any non-flag argument that resolves to an absolute path outside the project root demotes the command back to the confirm gate (user approval required).

## Affected patterns

| Command | Before | After |
|---|---|---|
| `find / -name "xxx"` | auto-run | requires confirmation |
| `find . -name "*.ts"` | auto-run | auto-run |
| `tree /etc` | auto-run | requires confirmation |
| `tree src` | auto-run | auto-run |
| `grep foo /etc/passwd` | auto-run | requires confirmation |
| `cat README.md` | auto-run | auto-run |

## Backward compatibility

- When `projectRoot` is not provided, behavior is unchanged
- Workspace-relative commands (`.`, `src/`, etc.) remain auto-allowed
- Flags (`-name`, `--color`), URLs, and env vars are correctly skipped

Closes #2081