### PR TITLE
feat(permissions): global shell allowlist that cascades with per-project (#2059)

### DIFF
--- a/src/cli/ui/slash/handlers/permissions.ts
+++ b/src/cli/ui/slash/handlers/permissions.ts
@@ -1,12 +1,29 @@
 import {
+  addGlobalShellAllowed,
   addProjectShellAllowed,
+  clearGlobalShellAllowed,
   clearProjectShellAllowed,
+  loadGlobalShellAllowed,
   loadProjectShellAllowed,
+  removeGlobalShellAllowed,
   removeProjectShellAllowed,
 } from "@/config.js";
 import { t } from "@/i18n/index.js";
 import { BUILTIN_ALLOWLIST } from "@/tools/shell.js";
 import type { SlashHandler } from "../dispatch.js";
+
+/** Leading `--global` / `-g` flag targets the cross-project list (#2059); otherwise per-project.
+ *  Only the option position (before the prefix) is consumed, so a prefix like
+ *  `git config --global user.name` keeps its inner `--global` intact, and `g` stays usable. */
+function takeScope(args: string[]): { global: boolean; rest: string[] } {
+  let global = false;
+  let i = 0;
+  while (i < args.length && (args[i] === "--global" || args[i] === "-g")) {
+    global = true;
+    i++;
+  }
+  return { global, rest: args.slice(i) };
+}
 
 const permissions: SlashHandler = (args, _loop, ctx) => {
   const sub = (args[0] ?? "").toLowerCase();
@@ -17,32 +34,38 @@ const permissions: SlashHandler = (args, _loop, ctx) => {
     return { info: renderListing(root, mode) };
   }
 
-  if (!root) {
+  const { global, rest } = takeScope(args.slice(1));
+  // Global entries live in the user config and need no project root; project ones require it.
+  if (!global && !root) {
     return { info: t("handlers.permissions.mutateCodeOnly") };
   }
 
   if (sub === "add") {
-    const prefix = args.slice(1).join(" ").trim();
+    const prefix = rest.join(" ").trim();
     if (!prefix) {
       return { info: t("handlers.permissions.addUsage") };
     }
-    const before = loadProjectShellAllowed(root);
-    if (before.includes(prefix)) {
+    const existing = global ? loadGlobalShellAllowed() : loadProjectShellAllowed(root!);
+    if (existing.includes(prefix)) {
       return { info: t("handlers.permissions.addAlready", { prefix }) };
     }
     if (BUILTIN_ALLOWLIST.includes(prefix)) {
       return { info: t("handlers.permissions.addBuiltin", { prefix }) };
     }
-    addProjectShellAllowed(root, prefix);
+    if (global) {
+      addGlobalShellAllowed(prefix);
+      return { info: t("handlers.permissions.addGlobalInfo", { prefix }) };
+    }
+    addProjectShellAllowed(root!, prefix);
     return { info: t("handlers.permissions.addInfo", { prefix }) };
   }
 
   if (sub === "remove" || sub === "rm" || sub === "delete") {
-    const target = args.slice(1).join(" ").trim();
+    const target = rest.join(" ").trim();
     if (!target) {
       return { info: t("handlers.permissions.removeUsage") };
     }
-    const existing = loadProjectShellAllowed(root);
+    const existing = global ? loadGlobalShellAllowed() : loadProjectShellAllowed(root!);
     let prefix: string | null = null;
     if (/^\d+$/.test(target)) {
       const idx = Number.parseInt(target, 10);
@@ -50,7 +73,11 @@ const permissions: SlashHandler = (args, _loop, ctx) => {
         return {
           info:
             existing.length === 0
-              ? t("handlers.permissions.removeEmpty")
+              ? t(
+                  global
+                    ? "handlers.permissions.removeGlobalEmpty"
+                    : "handlers.permissions.removeEmpty",
+                )
               : t("handlers.permissions.removeIndexOob", { idx, count: existing.length }),
         };
       }
@@ -62,7 +89,7 @@ const permissions: SlashHandler = (args, _loop, ctx) => {
     if (BUILTIN_ALLOWLIST.includes(prefix) && !existing.includes(prefix)) {
       return { info: t("handlers.permissions.removeBuiltin", { prefix }) };
     }
-    const ok = removeProjectShellAllowed(root, prefix);
+    const ok = global ? removeGlobalShellAllowed(prefix) : removeProjectShellAllowed(root!, prefix);
     return {
       info: ok
         ? t("handlers.permissions.removeInfo", { prefix })
@@ -71,20 +98,25 @@ const permissions: SlashHandler = (args, _loop, ctx) => {
   }
 
   if (sub === "clear") {
-    if ((args[1] ?? "").toLowerCase() !== "confirm") {
-      const count = loadProjectShellAllowed(root).length;
+    if ((rest[0] ?? "").toLowerCase() !== "confirm") {
+      const count = global
+        ? loadGlobalShellAllowed().length
+        : loadProjectShellAllowed(root!).length;
+      if (count === 0) return { info: t("handlers.permissions.clearAlready") };
       return {
-        info:
-          count === 0
-            ? t("handlers.permissions.clearAlready")
-            : t("handlers.permissions.clearConfirm", {
-                count,
-                plural: count === 1 ? "y" : "ies",
-                root,
-              }),
+        info: global
+          ? t("handlers.permissions.clearGlobalConfirm", {
+              count,
+              plural: count === 1 ? "y" : "ies",
+            })
+          : t("handlers.permissions.clearConfirm", {
+              count,
+              plural: count === 1 ? "y" : "ies",
+              root: root!,
+            }),
       };
     }
-    const dropped = clearProjectShellAllowed(root);
+    const dropped = global ? clearGlobalShellAllowed() : clearProjectShellAllowed(root!);
     return {
       info:
         dropped === 0
@@ -99,6 +131,12 @@ const permissions: SlashHandler = (args, _loop, ctx) => {
   return { info: t("handlers.permissions.usage") };
 };
 
+function renderEntries(lines: string[], entries: string[]): void {
+  entries.forEach((p, i) => {
+    lines.push(`  ${String(i + 1).padStart(2)}. ${p}`);
+  });
+}
+
 function renderListing(root: string | undefined, mode: string | null): string {
   const lines: string[] = [];
   if (mode === "yolo") {
@@ -110,6 +148,15 @@ function renderListing(root: string | undefined, mode: string | null): string {
   }
   lines.push("");
 
+  const global = loadGlobalShellAllowed();
+  lines.push(t("handlers.permissions.globalHeader", { count: global.length }));
+  if (global.length === 0) {
+    lines.push(t("handlers.permissions.globalNone"));
+  } else {
+    renderEntries(lines, global);
+  }
+  lines.push("");
+
   if (root) {
     const project = loadProjectShellAllowed(root);
     lines.push(t("handlers.permissions.projectHeader", { count: project.length, root }));
@@ -117,9 +164,7 @@ function renderListing(root: string | undefined, mode: string | null): string {
       lines.push(t("handlers.permissions.projectNone1"));
       lines.push(t("handlers.permissions.projectNone2"));
     } else {
-      project.forEach((p, i) => {
-        lines.push(`  ${String(i + 1).padStart(2)}. ${p}`);
-      });
+      renderEntries(lines, project);
     }
   } else {
     lines.push(t("handlers.permissions.projectNoRoot"));

--- a/src/code/setup.ts
+++ b/src/code/setup.ts
@@ -4,6 +4,7 @@ import {
   loadEditMode,
   loadEndpoint,
   loadFilesystemOutlineThresholdBytes,
+  loadGlobalShellAllowed,
   loadJavaSourceEnabled,
   loadProjectShellAllowed,
   loadResolvedSkillPaths,
@@ -70,11 +71,17 @@ export async function buildCodeToolset(opts: CodeToolsetOpts): Promise<CodeTools
       outlineThresholdBytes,
       autoGitRollback: {},
     });
-    const cfg = readConfig();
+    const cfg = readConfig(opts.configPath);
     registerShellTools(tools, {
       rootDir: root,
-      extraAllowed: () => loadProjectShellAllowed(root),
-      allowAll: () => loadEditMode() === "yolo",
+      // Global allowlist applies everywhere; project list adds to it (#2059).
+      extraAllowed: () => [
+        ...new Set([
+          ...loadGlobalShellAllowed(opts.configPath),
+          ...loadProjectShellAllowed(root, opts.configPath),
+        ]),
+      ],
+      allowAll: () => loadEditMode(opts.configPath) === "yolo",
       jobs,
       onJobsChanged: opts.onJobsChanged,
       sensitivePaths: cfg.sensitivePaths,

--- a/src/config.ts
+++ b/src/config.ts
@@ -275,6 +275,9 @@ export interface ReasonixConfig {
       pathAllowed?: string[];
     };
   };
+  /** Global shell allowlist — command prefixes auto-approved across ALL projects (#2059).
+   *  Merged (union) with the per-project `projects[<root>].shellAllowed` at check time. */
+  shellAllowedGlobal?: string[];
   /** Issue #259 — user-configurable sensitive-path prefixes and filename patterns.
    *  Commands touching these paths are demoted to the confirm gate even when allowlisted. */
   sensitivePaths?: {
@@ -459,6 +462,7 @@ const STRING_ARRAY_FIELDS: Array<readonly string[]> = [
   ["mcpDisabled"],
   ["promptHistory"],
   ["recentWorkspaces"],
+  ["shellAllowedGlobal"],
   ["skills", "paths"],
 ];
 
@@ -1160,6 +1164,45 @@ export function clearProjectShellAllowed(
   if (!cfg.projects) cfg.projects = {};
   if (!cfg.projects[key]) cfg.projects[key] = {};
   cfg.projects[key].shellAllowed = [];
+  writeConfig(cfg, path);
+  return existing.length;
+}
+
+/** Global allowlist applies to every project (#2059) — read with no rootDir. */
+export function loadGlobalShellAllowed(path: string = defaultConfigPath()): string[] {
+  return readConfig(path).shellAllowedGlobal ?? [];
+}
+
+export function addGlobalShellAllowed(prefix: string, path: string = defaultConfigPath()): void {
+  const trimmed = prefix.trim();
+  if (!trimmed) return;
+  const cfg = readConfig(path);
+  const existing = cfg.shellAllowedGlobal ?? [];
+  if (existing.includes(trimmed)) return;
+  cfg.shellAllowedGlobal = [...existing, trimmed];
+  writeConfig(cfg, path);
+}
+
+/** Match is exact after trim — NOT prefix-match (mirrors removeProjectShellAllowed). */
+export function removeGlobalShellAllowed(
+  prefix: string,
+  path: string = defaultConfigPath(),
+): boolean {
+  const trimmed = prefix.trim();
+  if (!trimmed) return false;
+  const cfg = readConfig(path);
+  const existing = cfg.shellAllowedGlobal ?? [];
+  if (!existing.includes(trimmed)) return false;
+  cfg.shellAllowedGlobal = existing.filter((p) => p !== trimmed);
+  writeConfig(cfg, path);
+  return true;
+}
+
+export function clearGlobalShellAllowed(path: string = defaultConfigPath()): number {
+  const cfg = readConfig(path);
+  const existing = cfg.shellAllowedGlobal ?? [];
+  if (existing.length === 0) return 0;
+  cfg.shellAllowedGlobal = [];
   writeConfig(cfg, path);
   return existing.length;
 }

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -1112,6 +1112,13 @@ export const EN: TranslationSchema = {
       projectNone1: '  (none — pick "always allow" on a ShellConfirm prompt to add one,',
       projectNone2: "   or `/permissions add <prefix>` directly.)",
       projectNoRoot: "Project allowlist — (no project root; chat mode shows builtin entries only)",
+      globalHeader: "Global allowlist ({count}) — applies to every project",
+      globalNone: "  (none — add with `/permissions add --global <prefix>`.)",
+      addGlobalInfo:
+        "▸ added to global allowlist: {prefix}\n  → next `{prefix}` invocation runs without prompting in every project.",
+      removeGlobalEmpty: "▸ no global allowlist entries to remove.",
+      clearGlobalConfirm:
+        "about to drop {count} global allowlist entr{plural}. Re-run with the word 'confirm': /permissions clear --global confirm",
       builtinHeader: "Builtin allowlist ({count}) — read-only, baked in",
       subcommands:
         "Subcommands: /permissions add <prefix> · /permissions remove <prefix-or-N> · /permissions clear confirm",

--- a/src/i18n/JA.ts
+++ b/src/i18n/JA.ts
@@ -1179,6 +1179,13 @@ export const JA: TranslationSchema = {
       projectNone2: "   `/permissions add <prefix>` で直接追加してください。）",
       projectNoRoot:
         "プロジェクト許可リスト — （プロジェクトルートなし; チャットモードではビルトインエントリのみ表示）",
+      globalHeader: "グローバル許可リスト ({count}) — すべてのプロジェクトに適用",
+      globalNone: "  （なし — `/permissions add --global <prefix>` で追加）",
+      addGlobalInfo:
+        "▸ グローバル許可リストに追加: {prefix}\n  → 以降 `{prefix}` はすべてのプロジェクトで確認なしに実行されます。",
+      removeGlobalEmpty: "▸ 削除できるグローバル許可リストの項目がありません。",
+      clearGlobalConfirm:
+        "グローバル許可リストの {count} 件を削除しようとしています。'confirm' を付けて再実行してください: /permissions clear --global confirm",
       builtinHeader: "ビルトイン許可リスト ({count}) — 読み取り専用、組み込み",
       subcommands:
         "サブコマンド: /permissions add <prefix> · /permissions remove <prefix-or-N> · /permissions clear confirm",

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -1085,6 +1085,13 @@ export const de: TranslationSchema = {
       projectNone2: "   oder `/permissions add <präfix>` direkt.)",
       projectNoRoot:
         "Projekt-Allowlist — (kein Projekt-Root; Chat-Modus zeigt nur Builtin-Einträge)",
+      globalHeader: "Globale Allowlist ({count}) — gilt für alle Projekte",
+      globalNone: "  (keine — mit `/permissions add --global <prefix>` hinzufügen.)",
+      addGlobalInfo:
+        "▸ zur globalen Allowlist hinzugefügt: {prefix}\n  → der nächste Aufruf von `{prefix}` läuft in jedem Projekt ohne Rückfrage.",
+      removeGlobalEmpty: "▸ keine Einträge in der globalen Allowlist zum Entfernen.",
+      clearGlobalConfirm:
+        "{count} Einträge der globalen Allowlist werden entfernt. Mit dem Wort 'confirm' erneut ausführen: /permissions clear --global confirm",
       builtinHeader: "Builtin-Allowlist ({count}) — schreibgeschützt, fest eincompiliert",
       subcommands:
         "Unterbefehle: /permissions add <präfix> · /permissions remove <präfix-oder-N> · /permissions clear confirm",

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -1048,6 +1048,13 @@ export const zhCN: TranslationSchema = {
       projectNone1: '  （无 — 在 ShellConfirm 提示中选择 "always allow" 添加一个，',
       projectNone2: "   或直接 `/permissions add <prefix>`。）",
       projectNoRoot: "项目允许列表 — （无项目根目录；聊天模式仅显示内置条目）",
+      globalHeader: "全局允许列表（{count}）— 对所有项目生效",
+      globalNone: "  （无 — 用 `/permissions add --global <prefix>` 添加。）",
+      addGlobalInfo:
+        "▸ 已添加到全局允许列表：{prefix}\n  → 之后 `{prefix}` 在所有项目中执行都不再询问。",
+      removeGlobalEmpty: "▸ 全局允许列表没有可删除的条目。",
+      clearGlobalConfirm:
+        "将清除 {count} 条全局允许列表条目。请加上 'confirm' 重新执行：/permissions clear --global confirm",
       builtinHeader: "内置允许列表（{count}）— 只读，已编译",
       subcommands:
         "子命令：/permissions add <prefix> · /permissions remove <prefix-or-N> · /permissions clear confirm",

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -4,8 +4,10 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   type DesktopOpenTab,
+  addGlobalShellAllowed,
   addProjectPathAllowed,
   addProjectShellAllowed,
+  clearGlobalShellAllowed,
   clearProjectPathAllowed,
   clearProjectShellAllowed,
   editModeHintShown,
@@ -20,6 +22,7 @@ import {
   loadEndpoint,
   loadEngineeringLifecycleMode,
   loadFilesystemOutlineThresholdBytes,
+  loadGlobalShellAllowed,
   loadIndexConfig,
   loadIndexUserConfig,
   loadModel,
@@ -39,6 +42,7 @@ import {
   readConfig,
   redactKey,
   redactSemanticEmbeddingConfig,
+  removeGlobalShellAllowed,
   removeProjectPathAllowed,
   removeProjectShellAllowed,
   resolveSemanticEmbeddingConfig,
@@ -533,6 +537,31 @@ describe("config", () => {
     savePromptHistory(entries, path);
     expect(loadPromptHistory(path)).toHaveLength(100);
     expect(loadPromptHistory(path)[0]).toBe("cmd-0");
+  });
+
+  it("global shell allowlist CRUD mirrors project (load/add/dedup/remove/clear)", () => {
+    expect(loadGlobalShellAllowed(path)).toEqual([]);
+    addGlobalShellAllowed("npm install", path);
+    addGlobalShellAllowed("git commit", path);
+    addGlobalShellAllowed("npm install", path); // dedup
+    addGlobalShellAllowed("   ", path); // ignored
+    expect(loadGlobalShellAllowed(path)).toEqual(["npm install", "git commit"]);
+    expect(removeGlobalShellAllowed("npm install", path)).toBe(true);
+    expect(removeGlobalShellAllowed("npm install", path)).toBe(false);
+    expect(loadGlobalShellAllowed(path)).toEqual(["git commit"]);
+    expect(clearGlobalShellAllowed(path)).toBe(1);
+    expect(loadGlobalShellAllowed(path)).toEqual([]);
+    expect(clearGlobalShellAllowed(path)).toBe(0);
+  });
+
+  it("global allowlist is independent of any project's allowlist", () => {
+    addGlobalShellAllowed("brew install", path);
+    addProjectShellAllowed("/a", "npm install", path);
+    expect(loadGlobalShellAllowed(path)).toEqual(["brew install"]);
+    expect(loadProjectShellAllowed("/a", path)).toEqual(["npm install"]);
+    // Clearing the project list leaves the global list intact.
+    clearProjectShellAllowed("/a", path);
+    expect(loadGlobalShellAllowed(path)).toEqual(["brew install"]);
   });
 
   it("pathAllowed CRUD mirrors shellAllowed (load/add/dedup/remove/clear)", () => {

--- a/tests/permissions-slash.test.ts
+++ b/tests/permissions-slash.test.ts
@@ -3,7 +3,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { handleSlash } from "../src/cli/ui/slash/dispatch.js";
-import { addProjectShellAllowed, loadProjectShellAllowed } from "../src/config.js";
+import {
+  addProjectShellAllowed,
+  loadGlobalShellAllowed,
+  loadProjectShellAllowed,
+} from "../src/config.js";
 import { CacheFirstLoop, DeepSeekClient, ImmutablePrefix } from "../src/index.js";
 import { ToolRegistry } from "../src/tools.js";
 
@@ -101,6 +105,62 @@ describe("/permissions slash handler", () => {
     expect(result.info).toMatch(/builtin allowlist/i);
     // Should NOT have written a redundant project entry.
     expect(loadProjectShellAllowed(projectRoot, join(dir, ".reasonix", "config.json"))).toEqual([]);
+  });
+
+  it("/permissions add --global routes to the global list (project untouched, #2059)", () => {
+    const cfg = join(dir, ".reasonix", "config.json");
+    const result = handleSlash("permissions", ["add", "--global", "brew", "install"], makeLoop(), {
+      codeRoot: projectRoot,
+    });
+    expect(result.info).toMatch(/global allowlist/i);
+    expect(loadGlobalShellAllowed(cfg)).toContain("brew install");
+    expect(loadProjectShellAllowed(projectRoot, cfg)).toEqual([]);
+  });
+
+  it("/permissions add `g` is a project prefix, not hijacked as the global keyword (#2059)", () => {
+    const cfg = join(dir, ".reasonix", "config.json");
+    const result = handleSlash("permissions", ["add", "g"], makeLoop(), { codeRoot: projectRoot });
+    expect(result.info).toMatch(/added.*g/);
+    expect(loadProjectShellAllowed(projectRoot, cfg)).toContain("g");
+    expect(loadGlobalShellAllowed(cfg)).toEqual([]);
+  });
+
+  it("/permissions add --global works without a project root (chat mode)", () => {
+    const cfg = join(dir, ".reasonix", "config.json");
+    const result = handleSlash("permissions", ["add", "--global", "make", "test"], makeLoop(), {});
+    // Should NOT bail out with the "mutateCodeOnly" hint — global needs no root.
+    expect(result.info).not.toMatch(/reasonix code/i);
+    expect(loadGlobalShellAllowed(cfg)).toContain("make test");
+  });
+
+  it("/permissions add preserves an inner --global inside a real command prefix (#2059)", () => {
+    // Without leading-only flag parsing, `--global` mid-prefix would be stripped,
+    // landing the wrong prefix in the GLOBAL list. After the fix it must add the
+    // full prefix to PROJECT.
+    const cfg = join(dir, ".reasonix", "config.json");
+    const result = handleSlash(
+      "permissions",
+      ["add", "git", "config", "--global", "user.name"],
+      makeLoop(),
+      { codeRoot: projectRoot },
+    );
+    expect(result.info).toMatch(/added/);
+    expect(loadProjectShellAllowed(projectRoot, cfg)).toContain("git config --global user.name");
+    expect(loadGlobalShellAllowed(cfg)).toEqual([]);
+  });
+
+  it("/permissions add --global still applies when followed by a prefix containing --global", () => {
+    // Leading flag → global; inner flag → preserved verbatim.
+    const cfg = join(dir, ".reasonix", "config.json");
+    const result = handleSlash(
+      "permissions",
+      ["add", "--global", "npm", "install", "--global", "foo"],
+      makeLoop(),
+      { codeRoot: projectRoot },
+    );
+    expect(result.info).toMatch(/global allowlist/i);
+    expect(loadGlobalShellAllowed(cfg)).toContain("npm install --global foo");
+    expect(loadProjectShellAllowed(projectRoot, cfg)).toEqual([]);
   });
 
   it("/permissions remove drops by exact prefix", () => {


### PR DESCRIPTION
## Problem

Closes #2059. Shell command allowlists were **per-project only** (`config.projects[<root>].shellAllowed`). There was no way to auto-approve a command (e.g. `brew install`, `cargo build`) once and have it apply everywhere — every new project re-prompted. The request: a cascade like Claude/Codex/OpenCode (global ∪ local).

## Change

Add a top-level **`shellAllowedGlobal`** config list, merged (union) with the per-project list at the single point where the shell tool resolves its extra allowlist:

```ts
// src/code/setup.ts
extraAllowed: () => [...new Set([...loadGlobalShellAllowed(), ...loadProjectShellAllowed(root)])]
```

Manage it via a **`--global`** (or **`-g`**) flag on the existing `/permissions` subcommands (works in chat mode too — global entries need no project root):

```
/permissions add --global <prefix>
/permissions remove --global <prefix-or-N>
/permissions clear --global confirm
/permissions list                          # now shows a Global section above Project
```

The flag is parsed **as a flag**, not as a positional keyword, so command prefixes like `g` (a popular `git` alias) or `global` stay manageable from the slash UI.

- Config accessors `load/add/remove/clearGlobalShellAllowed` mirror the project ones (same dedup, exact-match removal, atomic write).
- `shellAllowedGlobal` is registered in `STRING_ARRAY_FIELDS` so a malformed hand-edited value gets sanitized on read instead of crashing the merge.
- i18n: 5 new keys added to EN / zh-CN / ja / de (ru falls back to EN).
- The builtin allowlist precedence is unchanged; global is just another source of `extraAllowed`.

## Out of scope (follow-up)

The HTTP `/permissions` API + desktop settings panel still expose only the project list; global management there can be a follow-up. The `/permissions` slash command already covers CLI **and** desktop (command palette).

## Verification

- `tests/config.test.ts`: global CRUD (load/add/dedup/remove/clear) + independence from project lists.
- `tests/permissions-slash.test.ts`: `--global` add/remove/clear routes to the global list; `add g` adds `g` to the project list (not hijacked); `--global` works without a code root.
- `npm run verify` (build + lint + typecheck + full suite) passes.