### PR TITLE
fix: SkillStore.readEntry now handles symlinked skill directories

### DIFF
--- a/src/skills.ts
+++ b/src/skills.ts
@@ -93,6 +93,16 @@ function parseAllowedTools(raw: string | undefined): readonly string[] | undefin
   return names.length > 0 ? Object.freeze(names) : undefined;
 }
 
+/** Check if a Dirent is a symlink whose target (following the link) is a directory. Broken symlinks return false. */
+function symlinkPointsToDirectory(dir: string, entry: import("node:fs").Dirent): boolean {
+  if (!entry.isSymbolicLink()) return false;
+  try {
+    return statSync(join(dir, entry.name)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
 /** flash/pro preset → concrete deepseek model id. Kept local so this file doesn't import the CLI preset bundle. */
 function subagentModelForPreset(preset: "flash" | "pro"): string {
   return preset === "pro" ? "deepseek-v4-pro" : "deepseek-v4-flash";
@@ -249,7 +259,7 @@ export class SkillStore {
   }
 
   private readEntry(dir: string, scope: SkillScope, entry: import("node:fs").Dirent): Skill | null {
-    if (entry.isDirectory()) {
+    if (entry.isDirectory() || symlinkPointsToDirectory(dir, entry)) {
       if (!isValidSkillName(entry.name)) return null;
       const file = join(dir, entry.name, SKILL_FILE);
       if (!existsSync(file)) return null;


### PR DESCRIPTION
## Problem

\`SkillStore.readEntry()\` uses \`entry.isDirectory()\` to detect skill directories inside a skill root. However, \`Dirent.isDirectory()\` returns \`false\` for symlinks to directories — so skills installed via symlinks are silently ignored with no error or warning. Users who maintain a central skill repository and symlink entries into \`~/.agents/skills/\` will have zero skills loaded.

Fixes #2104

## Change

Added \`symlinkPointsToDirectory()\` helper in \`src/skills.ts\` that:
1. Checks \`entry.isSymbolicLink()\` first (fast path)
2. Follows the symlink with \`statSync()\` to verify the target is a directory
3. Broken symlinks are caught by \`try/catch\` and return \`false\` (skipped silently)

The \`readEntry()\` condition was updated from \`entry.isDirectory()\` to \`entry.isDirectory() || symlinkPointsToDirectory(dir, entry)\` — no other code paths needed changes since the rest of the entry processing (\`existsSync\`, \`readFileSync\`) transparently follows symlinks.