### PR TITLE
feat(lifecycle): suggest plan rails for high-risk tasks

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -176,6 +176,7 @@ import { StaticCardStream } from "./layout/StaticCardStream.js";
 import { StatusRow } from "./layout/StatusRow.js";
 import type { StatusBarConfig } from "./layout/StatusRow.js";
 import { shouldEnterPlanModeForExplicitIntent } from "./lifecycle-explicit-intent.js";
+import { shouldSuggestPlanForEngineeringIntent } from "./lifecycle-plan-suggestion.js";
 import { formatLoopStatus } from "./loop.js";
 import { applyMcpAppend } from "./mcp-append.js";
 import { handleMcpBrowseSlash } from "./mcp-browse.js";
@@ -3138,15 +3139,23 @@ function AppInner({
       }
 
       if (codeMode) {
-        if (
-          shouldEnterPlanModeForExplicitIntent({
+        const explicitPlanIntent = shouldEnterPlanModeForExplicitIntent({
+          text,
+          codeMode: true,
+          planMode,
+        });
+        if (explicitPlanIntent) {
+          togglePlanMode(true, "explicit-intent");
+          log.pushInfo(t("app.explicitPlanIntentArmed"));
+        } else if (
+          shouldSuggestPlanForEngineeringIntent({
             text,
             codeMode: true,
             planMode,
+            lifecycleMode: engineeringLifecycleRef.current?.snapshot().mode ?? "off",
           })
         ) {
-          togglePlanMode(true, "explicit-intent");
-          log.pushInfo(t("app.explicitPlanIntentArmed"));
+          log.pushInfo(t("app.lifecyclePlanSuggestion"));
         }
         const before = engineeringLifecycleRef.current?.snapshot().state;
         engineeringLifecycleRef.current?.observeUserPrompt(text);

--- a/src/cli/ui/lifecycle-plan-suggestion.ts
+++ b/src/cli/ui/lifecycle-plan-suggestion.ts
@@ -1,0 +1,59 @@
+export interface LifecyclePlanSuggestionRequest {
+  text: string;
+  codeMode: boolean;
+  planMode: boolean;
+  lifecycleMode: "off" | "strict";
+}
+
+export function shouldSuggestPlanForEngineeringIntent(
+  request: LifecyclePlanSuggestionRequest,
+): boolean {
+  return (
+    request.codeMode &&
+    !request.planMode &&
+    request.lifecycleMode === "off" &&
+    detectLifecyclePlanSuggestion(request.text)
+  );
+}
+
+export function detectLifecyclePlanSuggestion(text: string): boolean {
+  const normalized = normalizePrompt(text);
+  if (!normalized) return false;
+
+  return (
+    ENGLISH_HIGH_RISK_PATTERNS.some((pattern) => pattern.test(normalized)) ||
+    CHINESE_HIGH_RISK_PATTERNS.some((pattern) => pattern.test(normalized))
+  );
+}
+
+function normalizePrompt(text: string): string {
+  return text.normalize("NFKC").toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+const EN_REFACTOR_ACTION = "(?:refactor|rewrite|restructure|extract|split|move|rename|migrate)";
+const EN_MULTI_FILE_SCOPE = "(?:multi-file|multiple files|several files|many files)";
+const EN_CROSS_SCOPE = "(?:across\\s+(?:the\\s+)?(?:app|codebase|repo|files|modules|packages))";
+const EN_REFERENCE_TARGET = "(?:imports?|exports?|references?|callers?|usages?)";
+const EN_CONFIG_TARGET =
+  "(?:dependencies|dependency|package\\.json|package-lock\\.json|pnpm-lock\\.yaml|yarn\\.lock|tsconfig(?:\\.[\\w-]+)?\\.json|lockfile|config(?:uration)?)";
+const EN_CONFIG_ACTION = "(?:migrate|migration|upgrade|install|update|bump|switch|replace)";
+
+const ENGLISH_HIGH_RISK_PATTERNS = [
+  new RegExp(`\\b${EN_MULTI_FILE_SCOPE}\\b.{0,80}\\b${EN_REFACTOR_ACTION}\\b`),
+  new RegExp(
+    `\\b${EN_REFACTOR_ACTION}\\b.{0,80}\\b(?:${EN_MULTI_FILE_SCOPE}|${EN_CROSS_SCOPE})\\b`,
+  ),
+  new RegExp(`\\brename\\b.{0,60}\\bapi\\b.{0,100}\\bupdate\\b.{0,60}\\b${EN_REFERENCE_TARGET}\\b`),
+  new RegExp(
+    `\\bmove\\b.{0,80}\\b(?:module|package|directory|folder|src\\/[^\\s]+)\\b.{0,100}\\bupdate\\b.{0,60}\\b${EN_REFERENCE_TARGET}\\b`,
+  ),
+  new RegExp(`\\b${EN_CONFIG_ACTION}\\b.{0,100}\\b${EN_CONFIG_TARGET}\\b`),
+  new RegExp(`\\b${EN_CONFIG_TARGET}\\b.{0,100}\\b${EN_CONFIG_ACTION}\\b`),
+];
+
+const CHINESE_HIGH_RISK_PATTERNS = [
+  /(?:重构|抽取|拆分|迁移|移动|改名).{0,24}(?:多个文件|多文件|多个模块|整个项目|整个仓库|全项目)/,
+  /(?:多个文件|多文件|多个模块|整个项目|整个仓库|全项目).{0,24}(?:重构|抽取|拆分|迁移|移动|改名)/,
+  /(?:移动|迁移|改名|重命名).{0,24}(?:模块|目录|包|api).{0,40}(?:更新|修改|替换).{0,24}(?:引用|导入|调用)/,
+  /(?:迁移|升级|更新|替换).{0,24}(?:依赖|配置|lockfile|package\.json|pnpm-lock\.yaml|tsconfig)/,
+];

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -626,6 +626,8 @@ export const EN: TranslationSchema = {
     revisingAfter: "▸ revising after {label} — {feedback}",
     explicitPlanIntentArmed:
       "▸ explicit plan-first request detected — strict lifecycle enabled. Use /plan off to leave.",
+    lifecyclePlanSuggestion:
+      "▸ high-risk engineering task detected - use /plan strict to require an approved plan first.",
     historyScrollHint: " ↑ reading history · End / PgDn returns to bottom · ↓ advances one line",
     editHistoryTitle: "Edit history (oldest first):",
     editHistoryNoCodeMode: "not in code mode",

--- a/src/i18n/JA.ts
+++ b/src/i18n/JA.ts
@@ -655,6 +655,8 @@ export const JA: TranslationSchema = {
     revisingAfter: "▸ {label} の後に修正 — {feedback}",
     explicitPlanIntentArmed:
       "▸ 明示的な plan-first リクエストを検出 — strict lifecycle を有効化しました。/plan off で終了できます。",
+    lifecyclePlanSuggestion:
+      "▸ 高リスクのエンジニアリング作業を検出 - /plan strict で承認済みプランを先に要求できます。",
     historyScrollHint: " ↑ 履歴を読込中 · End / PgDn で最下部に戻る · ↓ で1行進む",
     editHistoryTitle: "編集履歴（古い順）:",
     editHistoryNoCodeMode: "コードモードではありません",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -228,6 +228,7 @@ export interface TranslationSchema {
     planStoppedAt: string;
     revisingAfter: string;
     explicitPlanIntentArmed: string;
+    lifecyclePlanSuggestion: string;
     historyScrollHint: string;
     editHistoryTitle: string;
     editHistoryNoCodeMode: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -606,6 +606,7 @@ export const zhCN: TranslationSchema = {
     revisingAfter: "▸ 在 {label} 之后修订 — {feedback}",
     explicitPlanIntentArmed:
       "▸ 检测到明确的先规划请求 — 已启用 strict lifecycle。可用 /plan off 退出。",
+    lifecyclePlanSuggestion: "▸ 检测到高风险工程任务 - 可使用 /plan strict 先要求批准计划。",
     historyScrollHint: " ↑ 正在查看历史 · End / PgDn 返回底部 · ↓ 向下滚动一行",
     editHistoryTitle: "编辑历史（从旧到新）：",
     editHistoryNoCodeMode: "不在代码模式中",

--- a/tests/lifecycle-plan-suggestion.test.ts
+++ b/tests/lifecycle-plan-suggestion.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  detectLifecyclePlanSuggestion,
+  shouldSuggestPlanForEngineeringIntent,
+} from "../src/cli/ui/lifecycle-plan-suggestion.js";
+
+describe("lifecycle plan suggestion intent", () => {
+  it.each([
+    "Refactor multiple files to extract the auth module",
+    "Rename the user API module and update imports across the app",
+    "Move the billing module into packages/core and update references",
+    "Migrate package.json, pnpm-lock.yaml, and tsconfig for the new dependency",
+    "重构多个文件，把认证逻辑抽到新模块",
+    "移动用户模块并更新所有引用",
+    "迁移依赖和配置，更新 package.json 与 pnpm-lock.yaml",
+  ])("suggests plan-first rails for high-risk engineering prompts: %s", (text) => {
+    expect(detectLifecyclePlanSuggestion(text)).toBe(true);
+  });
+
+  it.each([
+    "Explain how tsconfig.json works",
+    "I came across a bug in the API route",
+    "Please address this issue",
+    "Add address field to the API response",
+    "Fix a typo in README.md",
+    "Use lifecycle hooks to track mounted state",
+    "修复一个拼写错误",
+    "这个装修流程怎么优化",
+    "这门课是必修吗",
+    "维修登录页面的文案",
+  ])("does not suggest rails for ambiguous or lightweight prompts: %s", (text) => {
+    expect(detectLifecyclePlanSuggestion(text)).toBe(false);
+  });
+
+  it("only suggests in code mode while plan/lifecycle rails are inactive", () => {
+    expect(
+      shouldSuggestPlanForEngineeringIntent({
+        text: "Refactor multiple files to extract the auth module",
+        codeMode: true,
+        planMode: false,
+        lifecycleMode: "off",
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldSuggestPlanForEngineeringIntent({
+        text: "Refactor multiple files to extract the auth module",
+        codeMode: false,
+        planMode: false,
+        lifecycleMode: "off",
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldSuggestPlanForEngineeringIntent({
+        text: "Refactor multiple files to extract the auth module",
+        codeMode: true,
+        planMode: true,
+        lifecycleMode: "strict",
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldSuggestPlanForEngineeringIntent({
+        text: "Refactor multiple files to extract the auth module",
+        codeMode: true,
+        planMode: false,
+        lifecycleMode: "strict",
+      }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- add a conservative, host-side detector for high-risk engineering prompts that are likely to benefit from strict plan rails
- surface a UI-only suggestion to use `/plan strict` when lifecycle is off and plan mode is inactive
- cover positive and false-positive-sensitive English and Chinese prompt corpus

## Notes

This does not auto-arm strict lifecycle, block the user, change runtime state, or modify prompt/tool schema/prefix behavior. Explicit plan-first requests still use the existing auto-enter path from #2070.

## Validation

- `npm test -- tests/lifecycle-plan-suggestion.test.ts`
- `npm test -- tests/lifecycle-explicit-intent.test.ts tests/lifecycle-plan-suggestion.test.ts tests/code-prompt.test.ts tests/lifecycle.test.ts tests/slash.test.ts`
- `npx biome check src/cli/ui/lifecycle-plan-suggestion.ts tests/lifecycle-plan-suggestion.test.ts src/cli/ui/App.tsx src/i18n/EN.ts src/i18n/zh-CN.ts src/i18n/JA.ts src/i18n/types.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run verify`
- pre-push `npm run verify`
