### PR TITLE
fix(desktop): auto-switch to new session after deleting active session

### DIFF
--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -2557,7 +2557,25 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
     }
     if (msg.cmd === "session_delete") {
       deleteSession(msg.name);
-      emitSessions(tab);
+      if (tab.currentSession === msg.name) {
+        startNewChatInTab(tab);
+        emit(
+          {
+            type: "$session_loaded",
+            name: tab.currentSession,
+            messages: [],
+            carryover: {
+              totalCostUsd: 0,
+              cacheHitTokens: 0,
+              cacheMissTokens: 0,
+              totalCompletionTokens: 0,
+            },
+          },
+          tab.id,
+        );
+      } else {
+        emitSessions(tab);
+      }
       return;
     }
     if (msg.cmd === "session_rename") {

--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -2573,6 +2573,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
           },
           tab.id,
         );
+        emitCtxBreakdown(tab);
       } else {
         emitSessions(tab);
       }


### PR DESCRIPTION
## Summary

When a user deletes the currently-active session via the sidebar, the UI remained stuck on the now-deleted session instead of navigating to a fresh session. This PR fixes the backend \`session_delete\` RPC handler to detect when the deleted session is the active one and automatically switch to a new session.

Closes #2126.

## Changes

**\`src/cli/commands/desktop.ts\`** — \`session_delete\` handler:

| Before | After |
|---|---|
| Delete file, emit \`\$sessions\` | If deleted session is active: abort turn, mint new session via \`startNewChatInTab\`, emit \`\$session_loaded\` + \`\$sessions\`. Otherwise: emit \`\$sessions\` only |

## Root Cause

The \`session_delete\` handler only did two things:
1. \`deleteSession(msg.name)\` — remove the file from disk
2. \`emitSessions(tab)\` — refresh the sidebar list

It never checked whether \`tab.currentSession === msg.name\`, so when the active session was deleted the frontend's \`currentSession\` state remained pointing to the now-deleted session. The \`\$sessions\` event only updates the sidebar list — it does **not** change which session is displayed.

## Fix

When the deleted session matches \`tab.currentSession\`:
1. \`startNewChatInTab(tab)\` — aborts any in-flight turn, mints a fresh session for the workspace, rebuilds the runtime, and calls \`emitSessions(tab)\`
2. Emit \`\$session_loaded\` with empty messages — this is what tells the frontend reducer to set \`currentSession\` and clear the message list

When the deleted session is **not** the active one, behavior is unchanged (\`emitSessions\` only).

## Verification

- \`npm run verify\` passes — 295 test files pass, 4 pre-existing failures (web-tools Exa API key / desktop Ink rendering tests) unrelated to this change
- Desktop debug build (\`tauri build --debug\`) compiles and produces installers successfully