### PR TITLE
fix: load skills from symlinked directories (#2104)

### DIFF
--- a/src/skills.ts
+++ b/src/skills.ts
@@ -249,7 +249,9 @@ export class SkillStore {
   }
 
   private readEntry(dir: string, scope: SkillScope, entry: import("node:fs").Dirent): Skill | null {
-    if (entry.isDirectory()) {
+    const isDir =
+      entry.isDirectory() || (entry.isSymbolicLink() && this.isSymlinkDirectory(dir, entry.name));
+    if (isDir) {
       if (!isValidSkillName(entry.name)) return null;
       const file = join(dir, entry.name, SKILL_FILE);
       if (!existsSync(file)) return null;
@@ -261,6 +263,15 @@ export class SkillStore {
       return this.parse(join(dir, entry.name), stem, scope);
     }
     return null;
+  }
+
+  /** Check if a symlink points to a directory. Returns false for broken symlinks. */
+  private isSymlinkDirectory(parentDir: string, name: string): boolean {
+    try {
+      return statSync(join(parentDir, name)).isDirectory();
+    } catch {
+      return false;
+    }
   }
 
   private parse(path: string, stem: string, scope: SkillScope): Skill | null {

--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -1,6 +1,6 @@
 /** Skills store + prefix-index composer — temp homeDir / projectRoot per test, no real skill dirs touched. */
 
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -371,6 +371,40 @@ describe("SkillStore", () => {
       const r = store.create("nope", "project");
       expect("error" in r).toBe(true);
     });
+  });
+
+  it("loads skills from symlinked directories (#2104)", () => {
+    // Create a real skill directory outside the skills root
+    const realDir = mkdtempSync(join(tmpdir(), "reasonix-skills-real-"));
+    try {
+      writeFileSync(
+        join(realDir, "SKILL.md"),
+        "---\ndescription: symlinked skill\n---\nSymlinked body\n",
+        "utf8",
+      );
+      // Create a symlink to it inside the global skills dir
+      const skillsDir = join(home, ".reasonix", "skills");
+      mkdirSync(skillsDir, { recursive: true });
+      symlinkSync(realDir, join(skillsDir, "linked-skill"));
+
+      const store = new SkillStore({ homeDir: home, projectRoot, disableBuiltins: true });
+      const skills = store.list();
+      expect(skills).toHaveLength(1);
+      expect(skills[0]?.name).toBe("linked-skill");
+      expect(skills[0]?.description).toBe("symlinked skill");
+      expect(skills[0]?.body).toBe("Symlinked body");
+    } finally {
+      rmSync(realDir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips broken symlinks gracefully", () => {
+    const skillsDir = join(home, ".reasonix", "skills");
+    mkdirSync(skillsDir, { recursive: true });
+    symlinkSync(join(tmpdir(), `nonexistent-target-${Date.now()}`), join(skillsDir, "broken"));
+
+    const store = new SkillStore({ homeDir: home, projectRoot, disableBuiltins: true });
+    expect(store.list()).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Problem

SkillStore.readEntry() uses ntry.isDirectory() to detect skill directories. However, Node.js Dirent.isDirectory() returns alse for symlinks, causing symlinked skill directories to be **silently skipped** with no error or warning.

Users who maintain skills in a shared location and symlink them into ~/.agents/skills/ (a common pattern, also the default install method for skills.sh-style tooling) will have **zero skills loaded**.

## Root Cause

In src/skills.ts, eadEntry():

`	ypescript
if (entry.isDirectory()) {  // false for symlinks
  // load skill...
}
`

eaddirSync with withFileTypes: true returns DT_LNK type for symlinks, and Dirent.isDirectory() does not follow symlinks.

## Fix

Added isSymbolicLink() check with statSync fallback to resolve symlinks and verify the target is a directory:

`	ypescript
const isDir =
  entry.isDirectory() || (entry.isSymbolicLink() && this.isSymlinkDirectory(dir, entry.name));
`

The isSymlinkDirectory() helper uses statSync (which follows symlinks) and safely returns alse for broken symlinks.

## Testing

- Added test: symlinked skill directory is correctly loaded
- Added test: broken symlinks are safely skipped without throwing
- All 299 test files pass (3853 tests)

Closes #2104