### PR TITLE
fix: batch store notifications to prevent React max update depth (#2123)

### DIFF
--- a/src/cli/ui/state/store.ts
+++ b/src/cli/ui/state/store.ts
@@ -18,13 +18,31 @@ export function createStore(session: SessionInfo, initialCards?: ReadonlyArray<C
   const stateListeners = new Set<StateListener>();
   const eventListeners = new Set<EventListener>();
 
+  // RAF-batched notification: during rapid streaming, dozens of chunks arrive
+  // within a single event-loop drain.  Each `dispatch()` used to synchronously
+  // notify every listener, causing React's `useSyncExternalStore` to re-render
+  // on *every* token.  When renders couldn't keep up, React hit "Maximum update
+  // depth exceeded".  Deferring via setTimeout(0) coalesces all dispatches that
+  // happen inside the same tick into a single notification burst.
+  let notifyScheduled = false;
+  const scheduleNotify = () => {
+    if (notifyScheduled) return;
+    notifyScheduled = true;
+    // setTimeout(0) defers to the next macrotask, coalescing all synchronous
+    // dispatches (e.g. rapid streaming chunks) into a single notification.
+    setTimeout(() => {
+      notifyScheduled = false;
+      for (const listener of stateListeners) listener();
+    }, 0);
+  };
+
   return {
     getState() {
       return state;
     },
     dispatch(event) {
       state = reduce(state, event);
-      for (const listener of stateListeners) listener();
+      scheduleNotify();
       for (const listener of eventListeners) listener(event);
     },
     subscribe(listener) {

--- a/src/cli/ui/state/store.ts
+++ b/src/cli/ui/state/store.ts
@@ -18,7 +18,7 @@ export function createStore(session: SessionInfo, initialCards?: ReadonlyArray<C
   const stateListeners = new Set<StateListener>();
   const eventListeners = new Set<EventListener>();
 
-  // RAF-batched notification: during rapid streaming, dozens of chunks arrive
+  // Macrotask-batched notification: during rapid streaming, dozens of chunks arrive
   // within a single event-loop drain.  Each `dispatch()` used to synchronously
   // notify every listener, causing React's `useSyncExternalStore` to re-render
   // on *every* token.  When renders couldn't keep up, React hit "Maximum update

--- a/tests/store-batch-notify.test.ts
+++ b/tests/store-batch-notify.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionInfo } from "../src/cli/ui/state/state.js";
+import { createStore } from "../src/cli/ui/state/store.js";
+
+const session: SessionInfo = {
+  id: "test-batch",
+  branch: "main",
+  workspace: "/tmp/repo",
+  model: "deepseek-chat",
+};
+
+describe("store notification batching (setTimeout(0))", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("coalesces N synchronous dispatches into a single state-listener call", () => {
+    const store = createStore(session);
+    let notifyCount = 0;
+    store.subscribe(() => {
+      notifyCount++;
+    });
+
+    // Dispatch 3 events synchronously in one tick
+    store.dispatch({ type: "user.submit", text: "hello" });
+    store.dispatch({ type: "turn.start", turnId: "t1" });
+    store.dispatch({ type: "turn.thinking" });
+
+    // Listener should NOT have fired yet (deferred via setTimeout(0))
+    expect(notifyCount).toBe(0);
+
+    // getState() must already reflect all 3 dispatches synchronously
+    expect(store.getState().cards).toHaveLength(2); // user card + thinking live card
+    expect(store.getState().turnInProgress).toBe(true);
+
+    // Advance past the macrotask — listener fires exactly once
+    vi.advanceTimersByTime(0);
+    expect(notifyCount).toBe(1);
+  });
+
+  it("coalesces rapid streaming chunks into one notification", () => {
+    const store = createStore(session);
+    let notifyCount = 0;
+    store.subscribe(() => {
+      notifyCount++;
+    });
+
+    store.dispatch({ type: "reasoning.start", id: "r1" });
+    for (let i = 0; i < 50; i++) {
+      store.dispatch({ type: "reasoning.chunk", id: "r1", text: `tok${i} ` });
+    }
+
+    expect(notifyCount).toBe(0);
+    expect((store.getState().cards[0] as any).text).toContain("tok49");
+
+    vi.advanceTimersByTime(0);
+    expect(notifyCount).toBe(1);
+  });
+
+  it("event listeners fire synchronously per-dispatch (not batched)", () => {
+    const store = createStore(session);
+    const received: string[] = [];
+    store.onEvent((ev) => {
+      received.push(ev.type);
+    });
+
+    store.dispatch({ type: "user.submit", text: "a" });
+    expect(received).toEqual(["user.submit"]); // already fired synchronously
+
+    store.dispatch({ type: "turn.start", turnId: "t1" });
+    expect(received).toEqual(["user.submit", "turn.start"]);
+
+    store.dispatch({ type: "turn.thinking" });
+    expect(received).toEqual(["user.submit", "turn.start", "turn.thinking"]);
+  });
+
+  it("second macrotask batch fires another notification for new dispatches", () => {
+    const store = createStore(session);
+    let notifyCount = 0;
+    store.subscribe(() => {
+      notifyCount++;
+    });
+
+    // First batch
+    store.dispatch({ type: "user.submit", text: "a" });
+    store.dispatch({ type: "user.submit", text: "b" });
+    vi.advanceTimersByTime(0);
+    expect(notifyCount).toBe(1);
+
+    // Second batch — a new macrotask should be scheduled
+    store.dispatch({ type: "user.submit", text: "c" });
+    expect(notifyCount).toBe(1); // not yet
+    vi.advanceTimersByTime(0);
+    expect(notifyCount).toBe(2);
+  });
+});


### PR DESCRIPTION
## Problem

During rapid streaming (especially with long reasoning output), the app crashes with 'Maximum update depth exceeded'.

The root cause: every streaming token chunk triggers a synchronous store.dispatch() which notifies all useSyncExternalStore listeners, causing React to re-render on every single token. When tokens arrive faster than React can render (50+ within one event-loop drain), React's nested update limit is exceeded.

## Root Cause

`
streaming chunk -> flush() -> flushBuffers() -> appendReasoning() -> store.dispatch()
  -> for (listener of stateListeners) listener()  // synchronous!
    -> React useSyncExternalStore re-render
      -> next chunk arrives before render completes
        -> another dispatch -> nestedUpdateCount++
          -> after ~50: Maximum update depth exceeded
`

## Fix

Defer state-listener notification via setTimeout(0) in createStore():

- All synchronous dispatches within the same event-loop tick coalesce into one notification burst
- React handles it as a single reconciliation cycle
- Event listeners (non-React, used for transcript/logging) remain synchronous

## Testing

- All 299 test files pass (3853 tests)
- Specifically verified: core-reducers, ui-reducer, ink-update-depth-repro, loop, lifecycle, loop-r1-reasoning, streaming-card-token-rate

Closes #2123