### PR TITLE
fix(cli): commit settled cards to native scrollback

### DIFF
--- a/src/cli/ui/layout/StaticCardStream.tsx
+++ b/src/cli/ui/layout/StaticCardStream.tsx
@@ -54,7 +54,7 @@ function StaticCardStreamInner({
  *  the gate. New cards added DURING drain are held back until the backlog
  *  catches up — keeps Static's append-only contract intact so chronological
  *  order is preserved. Gates the FULL cards array (not just the static partition)
- *  so verbose-sensitive tool/reasoning cards in the live region also drip. */
+ *  so an old unsettled live tail also drips while fresh cards bypass the gate. */
 function useProgressiveBacklog(cards: readonly Card[]): Card[] {
   const backlogRef = useRef<number | null>(null);
   if (backlogRef.current === null && cards.length > 0) {
@@ -93,7 +93,7 @@ function partition(cards: readonly Card[]): {
   dynamicItems: Card[];
   hasUnsettledDynamic: boolean;
 } {
-  const firstDynamic = cards.findIndex((c) => !isFullySettled(c) || isVerboseSensitive(c));
+  const firstDynamic = cards.findIndex((c) => !isFullySettled(c));
   if (firstDynamic === -1) {
     return { staticItems: [...cards], dynamicItems: [], hasUnsettledDynamic: false };
   }
@@ -103,10 +103,6 @@ function partition(cards: readonly Card[]): {
     dynamicItems,
     hasUnsettledDynamic: dynamicItems.some((c) => !isFullySettled(c)),
   };
-}
-
-function isVerboseSensitive(card: Card): boolean {
-  return card.kind === "reasoning" || card.kind === "tool";
 }
 
 function isFullySettled(card: Card): boolean {

--- a/src/cli/ui/layout/StaticCardStream.tsx
+++ b/src/cli/ui/layout/StaticCardStream.tsx
@@ -4,6 +4,7 @@ import { CardRenderer } from "../cards/CardRenderer.js";
 import { useRenderTrace } from "../render-trace.js";
 import type { Card } from "../state/cards.js";
 import { useAgentState } from "../state/provider.js";
+import { VerboseContext } from "../state/verbose-context.js";
 
 interface StaticCardStreamProps {
   suppressLive?: boolean;
@@ -33,7 +34,7 @@ function StaticCardStreamInner({
       <Static items={staticItems}>
         {(card) => (
           <Box key={card.id} flexDirection="column" flexShrink={0}>
-            <CardRenderer card={card} />
+            <StaticCardRenderer card={card} />
           </Box>
         )}
       </Static>
@@ -45,6 +46,16 @@ function StaticCardStreamInner({
         ))}
       </Box>
     </>
+  );
+}
+
+function StaticCardRenderer({ card }: { card: Card }): React.ReactElement {
+  const verbose = React.useContext(VerboseContext);
+  const frozenVerbose = useRef(verbose).current;
+  return (
+    <VerboseContext.Provider value={frozenVerbose}>
+      <CardRenderer card={card} />
+    </VerboseContext.Provider>
   );
 }
 
@@ -93,6 +104,7 @@ function partition(cards: readonly Card[]): {
   dynamicItems: Card[];
   hasUnsettledDynamic: boolean;
 } {
+  // Settled cards are immutable terminal scrollback; verbose toggles only affect live/future cards.
   const firstDynamic = cards.findIndex((c) => !isFullySettled(c));
   if (firstDynamic === -1) {
     return { staticItems: [...cards], dynamicItems: [], hasUnsettledDynamic: false };

--- a/tests/static-card-stream-progressive.test.tsx
+++ b/tests/static-card-stream-progressive.test.tsx
@@ -4,7 +4,7 @@
 import { type ComponentType, type ReactElement, createElement } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { StaticCardStream } from "../src/cli/ui/layout/StaticCardStream.js";
-import type { UserCard } from "../src/cli/ui/state/cards.js";
+import type { ToolCard, UserCard } from "../src/cli/ui/state/cards.js";
 import { AgentStoreProvider } from "../src/cli/ui/state/provider.js";
 import type { SessionInfo } from "../src/cli/ui/state/state.js";
 import { render } from "./helpers/ink-test.js";
@@ -32,6 +32,20 @@ const SESSION: SessionInfo = {
 
 function userCard(i: number): UserCard {
   return { id: `u-${i}`, ts: i, kind: "user", text: `prompt ${i}` };
+}
+
+function toolCard(i: number): ToolCard {
+  return {
+    id: `tool-${i}`,
+    ts: i,
+    kind: "tool",
+    name: "run_command",
+    args: { cmd: "npm test" },
+    output: "ok",
+    done: true,
+    exitCode: 0,
+    elapsedMs: 25,
+  };
 }
 
 async function flushImmediates(): Promise<void> {
@@ -102,6 +116,20 @@ describe("StaticCardStream progressive mount", () => {
     }
     const ids = lastStaticItems.map((c) => (c as UserCard).id);
     expect(ids).toEqual(cards.map((c) => c.id));
+    unmount();
+  });
+
+  it("commits settled tool cards to terminal scrollback instead of trapping the tail live", () => {
+    lastStaticItems = [];
+    const cards = [toolCard(1), userCard(2)];
+    const { unmount } = render(
+      createElement(
+        AgentStoreProvider,
+        { session: SESSION, initialCards: cards },
+        createElement(StaticCardStream),
+      ),
+    );
+    expect(lastStaticItems.map((c) => (c as ToolCard | UserCard).id)).toEqual(["tool-1", "u-2"]);
     unmount();
   });
 });

--- a/tests/static-card-stream-verbose.test.tsx
+++ b/tests/static-card-stream-verbose.test.tsx
@@ -62,6 +62,21 @@ const CARD: ToolCard = {
   elapsedMs: 410,
 };
 
+const SUCCESS_CARD: ToolCard = {
+  id: "tool-success",
+  ts: 0,
+  kind: "tool",
+  name: "run_command",
+  args: "npm test",
+  output: Array.from(
+    { length: 12 },
+    (_, i) => `success output line ${String(i + 1).padStart(2, "0")}`,
+  ).join("\n"),
+  done: true,
+  exitCode: 0,
+  elapsedMs: 410,
+};
+
 const USER_CARD: UserCard = {
   id: "user-1",
   ts: 0,
@@ -73,6 +88,14 @@ function Harness({ verbose }: { verbose: boolean }): ReactElement {
   return createElement(
     AgentStoreProvider,
     { session: SESSION, initialCards: [CARD] },
+    createElement(VerboseContext.Provider, { value: verbose }, createElement(StaticCardStream)),
+  );
+}
+
+function SuccessfulToolHarness({ verbose }: { verbose: boolean }): ReactElement {
+  return createElement(
+    AgentStoreProvider,
+    { session: SESSION, initialCards: [SUCCESS_CARD] },
     createElement(VerboseContext.Provider, { value: verbose }, createElement(StaticCardStream)),
   );
 }
@@ -96,6 +119,21 @@ describe("StaticCardStream render isolation", () => {
     rerender(createElement(ParentUpdateHarness, { revision: 1 }));
 
     expect(staticRenderSpy.mock.calls.length).toBe(renderCountAfterMount);
+    unmount();
+  });
+
+  it("does not retroactively expand settled tool cards after a verbose toggle", () => {
+    staticRenderSpy.mockClear();
+    const { lastFrame, rerender, unmount } = render(
+      createElement(SuccessfulToolHarness, { verbose: false }),
+    );
+    const renderCountAfterMount = staticRenderSpy.mock.calls.length;
+    expect(lastFrame()).not.toContain("success output line 01");
+
+    rerender(createElement(SuccessfulToolHarness, { verbose: true }));
+
+    expect(staticRenderSpy.mock.calls.length).toBe(renderCountAfterMount);
+    expect(lastFrame()).not.toContain("success output line 01");
     unmount();
   });
 });

--- a/tests/static-card-stream-verbose.test.tsx
+++ b/tests/static-card-stream-verbose.test.tsx
@@ -1,4 +1,4 @@
-/** StaticCardStream must let verbose mode expand already-settled tool cards. */
+/** StaticCardStream keeps append-only history isolated from parent re-renders. */
 
 import { type ComponentType, type ReactElement, createElement } from "react";
 import { describe, expect, it, vi } from "vitest";


### PR DESCRIPTION
## Summary
- commit settled StaticCardStream cards to the Ink Static region so native terminal scrollback receives completed tool/reasoning history
- freeze the verbose value captured when a card enters Static so completed scrollback stays immutable
- keep only unsettled cards in the live tail
- add regression tests for settled cards entering Static and for verbose toggles not retroactively expanding settled tool output

## Root cause
Native scroll mode left completed tool/reasoning cards in the dynamic live tail so the terminal never received those completed rows in its own scrollback. Once the task ended, wheel scrolling could not reveal history that had only been repainted inside the live viewport.

## Tradeoff
Settled tool/reasoning cards are now immutable once committed to terminal scrollback. Ctrl+R verbose mode affects live cards and cards rendered after the toggle, but it no longer rewrites already-settled scrollback. This is intentional: preserving real terminal scrollback for #2120 matters more than retroactive expansion of successful settled cards.

The #1608 failed-shell-output path is preserved. `selectToolPreviewLines` still pins failure lines for failed `run_command`/`run_background` output independent of verbose mode, so failed shell output still reaches scrollback.

Fixes #2120

## Verification
- `npx vitest run tests/static-card-stream-verbose.test.tsx tests/static-card-stream-progressive.test.tsx tests/tool-summary.test.ts`
- `npx vitest run tests/chat-scroll-wheel.test.ts tests/mouse-mode.test.ts tests/static-card-stream-progressive.test.tsx tests/static-card-stream-verbose.test.tsx tests/cardstream-architecture.test.tsx`
- `npm run verify`
- `git push` (pre-push ran `npm run verify`)
