### PR TITLE
perf: optimize tokenizer hot paths and cache heal pipeline

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -515,12 +515,21 @@ export class CacheFirstLoop {
   }
   private _inflightCounter = 0;
 
+  /** Heal result cache — keyed by log.totalLength so we skip the 3-pass
+   *  healing pipeline (tokenize + shrink + prune) when the log hasn't changed. */
+  private _healCacheVersion = -1;
+  private _healCacheResult: ChatMessage[] | null = null;
+
   private buildMessages(): ChatMessage[] {
     const healedMessages = this.healActiveLogBeforeSend();
     return [...this.prefix.toMessages(), ...healedMessages];
   }
 
   private healActiveLogBeforeSend(): ChatMessage[] {
+    const version = this.log.totalLength;
+    if (this._healCacheVersion === version && this._healCacheResult) {
+      return this._healCacheResult;
+    }
     const current = this.log.toFullHistory();
     const healed = healLoadedMessages(current, DEFAULT_MAX_RESULT_CHARS);
     const argsShrunk = shrinkOversizedToolCallArgsByTokens(
@@ -529,6 +538,8 @@ export class CacheFirstLoop {
     );
     const pruned = stripDroppableReasoningContent(argsShrunk.messages);
     if (healed.healedCount === 0 && argsShrunk.healedCount === 0 && pruned.prunedCount === 0) {
+      this._healCacheVersion = version;
+      this._healCacheResult = current;
       return current;
     }
     this.log.compactInPlace(pruned.messages);
@@ -539,6 +550,8 @@ export class CacheFirstLoop {
         /* disk issue shouldn't block the in-memory heal */
       }
     }
+    this._healCacheVersion = this.log.totalLength;
+    this._healCacheResult = pruned.messages;
     return pruned.messages;
   }
 

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -185,9 +185,9 @@ function applySplit(chunks: string[], re: RegExp): string[] {
 /** UTF-8 bytes of `s`, each mapped to its byte-level visible char. */
 function byteLevelEncode(s: string, byteToChar: string[]): string {
   const bytes = new TextEncoder().encode(s);
-  let out = "";
-  for (let i = 0; i < bytes.length; i++) out += byteToChar[bytes[i]!];
-  return out;
+  const parts: string[] = new Array(bytes.length);
+  for (let i = 0; i < bytes.length; i++) parts[i] = byteToChar[bytes[i]!]!;
+  return parts.join("");
 }
 
 /** Repetitive tool output / identifier chunks re-encode thousands of times per session; LRU bounds at ~400KB. */
@@ -259,7 +259,36 @@ export function encode(text: string): number[] {
 }
 
 export function countTokens(text: string): number {
-  return encode(text).length;
+  if (!text) return 0;
+  const t = loadTokenizer();
+  let count = 0;
+  const process = (segment: string) => {
+    if (!segment) return;
+    let chunks: string[] = [segment];
+    for (const re of t.splitRegexes) chunks = applySplit(chunks, re);
+    for (const chunk of chunks) {
+      if (!chunk) continue;
+      const byteLevel = byteLevelEncode(chunk, t.byteToChar);
+      const pieces = bpeEncode(byteLevel, t.mergeRank);
+      for (const p of pieces) {
+        if (t.vocab[p] !== undefined) count++;
+      }
+    }
+  };
+  if (t.addedPattern) {
+    t.addedPattern.lastIndex = 0;
+    let last = 0;
+    for (const m of text.matchAll(t.addedPattern)) {
+      const idx = m.index ?? 0;
+      if (idx > last) process(text.slice(last, idx));
+      if (t.addedMap.get(m[0]) !== undefined) count++;
+      last = idx + m[0].length;
+    }
+    if (last < text.length) process(text.slice(last));
+  } else {
+    process(text);
+  }
+  return count;
 }
 
 export const DEFAULT_BOUNDED_TOKENIZE_CHARS = 2 * 1024;
@@ -468,7 +497,7 @@ export function formatDeepSeekPrompt(
   }
   const merged = mergeToolMessages(msgs);
 
-  let prompt = BOS;
+  const parts: string[] = [BOS];
 
   for (let i = 0; i < merged.length; i++) {
     const msg = merged[i]!;
@@ -476,26 +505,26 @@ export function formatDeepSeekPrompt(
     const nextRole = i + 1 < merged.length ? (merged[i + 1]!.role ?? "user") : null;
 
     if (role === "system") {
-      prompt += msg.content ?? "";
+      parts.push(msg.content ?? "");
     } else if (role === "user") {
-      prompt += USER_SP + (msg.content ?? "");
+      parts.push(USER_SP, msg.content ?? "");
       if (nextRole === "assistant" || nextRole === null) {
-        prompt += ASSISTANT_SP + THINK_END;
+        parts.push(ASSISTANT_SP, THINK_END);
       }
     } else if (role === "assistant") {
       if (msg.reasoning_content) {
-        prompt += THINK_START + msg.reasoning_content + THINK_END;
+        parts.push(THINK_START, msg.reasoning_content, THINK_END);
       }
-      if (msg.content) prompt += msg.content;
+      if (msg.content) parts.push(msg.content);
       const tcs = msg.tool_calls;
       if (Array.isArray(tcs) && tcs.length > 0) {
-        prompt += renderToolCallsDsml(tcs);
+        parts.push(renderToolCallsDsml(tcs));
       }
-      prompt += EOS;
+      parts.push(EOS);
     }
   }
 
-  return prompt;
+  return parts.join("");
 }
 
 const PER_MESSAGE_TEMPLATE_TOKENS = 6;
@@ -503,12 +532,16 @@ const PER_MESSAGE_TEMPLATE_TOKENS = 6;
 /** Keyed by content string — WeakMap-on-message can't be used because callers spread `{...e}` defensive copies, breaking identity every turn. */
 const contentTokenCache = new LruCache<string, number>(4096);
 
+/** Skip caching large strings — retaining 50KB+ tool outputs as LRU keys
+ *  wastes memory (4096 entries × avg size can exceed 200MB). */
+const MAX_CACHEABLE_CONTENT_CHARS = 10 * 1024;
+
 function cachedBoundedTokens(s: string): number {
   if (s.length === 0) return 0;
   const cached = contentTokenCache.get(s);
   if (cached !== undefined) return cached;
   const n = countTokensBounded(s);
-  contentTokenCache.set(s, n);
+  if (s.length <= MAX_CACHEABLE_CONTENT_CHARS) contentTokenCache.set(s, n);
   return n;
 }
 


### PR DESCRIPTION
## Summary

Five independent optimizations that reduce CPU and allocation pressure in the main agent loop:

### 1. `byteLevelEncode`: O(n²) → O(n) string building
- `src/tokenizer.ts:186-191` — `+=` loop copies the entire accumulator on each iteration
- Replaced with pre-allocated `string[]` + `.join("")`
- For a 10KB text chunk this eliminates ~10K intermediate string allocations

### 2. `countTokens`: skip array allocation
- `src/tokenizer.ts:261-263` — `encode(text).length` builds a full `number[]` just to read `.length`
- New version counts tokens inline without allocating the array
- Saves ~60KB of transient heap per 50KB input string

### 3. `healActiveLogBeforeSend`: cache by log version
- `src/loop.ts:523-543` — runs 3 healing passes (tokenize + shrink + prune) on **every** loop iteration
- Cache the result keyed by `log.totalLength` — subsequent calls in the same turn return immediately
- Cache invalidates automatically when new messages are appended (totalLength changes)

### 4. `contentTokenCache`: size guard for large strings
- `src/tokenizer.ts:535` — skip caching strings >10KB in the bounded-token LRU
- Without this guard, 4096 entries of 50KB+ tool outputs can retain 200MB+ of string keys

### 5. `formatDeepSeekPrompt`: array-join instead of +=
- Same O(n²) → O(n) fix — the prompt can be 100K+ chars; `+=` copies the entire string each iteration

## Test plan

- `tests/tokenizer.test.ts` — 33 tests pass (encode, countTokens, countTokensBounded, formatDeepSeekPrompt)
- `tests/loop.test.ts` — 69 tests pass (buildMessages, heal pipeline, streaming, tool dispatch)
- `tests/loop-r1-reasoning.test.ts` — 21 tests pass (reasoning_content round-trip)
- `biome check` passes with no lint issues