### PR TITLE
feat(desktop/dashboard): show cache percentage with 2 decimal places + hover details

### DIFF
--- a/dashboard/src/ui/cards.tsx
+++ b/dashboard/src/ui/cards.tsx
@@ -668,7 +668,8 @@ export function MetricStrip({
   costLabel,
   elapsed,
 }: {
-  cacheHit?: number;
+  /** Pre-formatted cache percentage string (e.g. "72.12%"). */
+  cacheHit?: string;
   promptTokens?: number;
   outputTokens?: number;
   costLabel?: string;
@@ -680,7 +681,7 @@ export function MetricStrip({
         <span className="item">
           <I.zap size={11} style={{ color: "var(--accent)" }} />
           <span>{t("cards.cacheHit")}</span>
-          <span className="v acc">{cacheHit}%</span>
+          <span className="v acc">{cacheHit}</span>
         </span>
       ) : null}
       {promptTokens !== undefined ? (

--- a/dashboard/src/ui/extra-cards.tsx
+++ b/dashboard/src/ui/extra-cards.tsx
@@ -258,7 +258,13 @@ export function UsageFull({
   useLang();
   const fmt = (n: number) => (n >= 1000 ? `${(n / 1000).toFixed(1)}k` : `${n}`);
   const total = promptTokens + reasoningTokens + outputTokens + cacheHitTokens || 1;
-  const pct = (n: number) => Math.round((n / total) * 100);
+  const pct = (n: number): number => {
+    const raw = (n / total) * 100;
+    if (raw === 100) return 100;
+    const rounded = Math.round(raw * 100) / 100;
+    if (rounded >= 100) return 99.99;
+    return rounded;
+  };
   return (
     <div className="usage-full">
       <div className="uh">

--- a/dashboard/src/ui/statusbar.tsx
+++ b/dashboard/src/ui/statusbar.tsx
@@ -19,6 +19,16 @@ function tokenLabel(n: number): string {
   return `${n}`;
 }
 
+/** Format a 0–100 percentage to 2 decimal places.
+ *  100.00 is shown only when the value is exactly 100; values that would round
+ *  to 100.00 are capped at 99.99. */
+function formatPct(value: number): string {
+  if (value === 100) return "100.00";
+  const rounded = Math.round(value * 100) / 100;
+  if (rounded >= 100) return "99.99";
+  return rounded.toFixed(2);
+}
+
 export function StatusBar({
   settings,
   balance,
@@ -53,7 +63,12 @@ export function StatusBar({
   onOpenWorkdir?: (anchor: { bottom: number; left: number }) => void;
 }) {
   const totalTokens = usage.cacheHitTokens + usage.cacheMissTokens;
-  const cacheHitPct = totalTokens > 0 ? Math.round((usage.cacheHitTokens / totalTokens) * 100) : 0;
+  const cacheHitRaw = totalTokens > 0 ? (usage.cacheHitTokens / totalTokens) * 100 : 0;
+  const cacheHitPctDisplay = formatPct(cacheHitRaw);
+  const cacheHitDetail =
+    totalTokens > 0
+      ? `${usage.cacheHitTokens.toLocaleString()} / ${totalTokens.toLocaleString()} tokens (${cacheHitPctDisplay}%)`
+      : "";
   const runningJobs = jobs.filter((j) => j.running).length;
   const spent = formatMoney(usage.totalCostUsd, currency);
   const balanceLabel = balance
@@ -85,10 +100,10 @@ export function StatusBar({
         <span>{settings?.baseUrl?.replace(/^https?:\/\//, "") ?? "api.deepseek.com"}</span>
         <span className="v">{!ready ? t("statusbar.offline") : busy ? t("statusbar.busy") : t("statusbar.online")}</span>
       </span>
-      <span className="seg" title={t("statusbar.cacheHit")}>
+      <span className="seg" title={cacheHitDetail || t("statusbar.cacheHit")}>
         <I.zap size={11} style={{ color: "var(--accent)" }} />
         <span>{t("statusbar.cache")}</span>
-        <span className="v acc">{cacheHitPct}%</span>
+        <span className="v acc">{cacheHitPctDisplay}%</span>
       </span>
       <span className="seg">
         <I.cpu size={11} />

--- a/desktop/src/ui/cards.tsx
+++ b/desktop/src/ui/cards.tsx
@@ -737,7 +737,8 @@ export function MetricStrip({
   costLabel,
   elapsed,
 }: {
-  cacheHit?: number;
+  /** Pre-formatted cache percentage string (e.g. "72.12%"). */
+  cacheHit?: string;
   promptTokens?: number;
   outputTokens?: number;
   costLabel?: string;
@@ -749,7 +750,7 @@ export function MetricStrip({
         <span className="item">
           <I.zap size={11} style={{ color: "var(--accent)" }} />
           <span>{t("cards.cacheHit")}</span>
-          <span className="v acc">{cacheHit}%</span>
+          <span className="v acc">{cacheHit}</span>
         </span>
       ) : null}
       {promptTokens !== undefined ? (

--- a/desktop/src/ui/extra-cards.tsx
+++ b/desktop/src/ui/extra-cards.tsx
@@ -258,7 +258,13 @@ export function UsageFull({
   useLang();
   const fmt = (n: number) => (n >= 1000 ? `${(n / 1000).toFixed(1)}k` : `${n}`);
   const total = promptTokens + reasoningTokens + outputTokens + cacheHitTokens || 1;
-  const pct = (n: number) => Math.round((n / total) * 100);
+  const pct = (n: number): number => {
+    const raw = (n / total) * 100;
+    if (raw === 100) return 100;
+    const rounded = Math.round(raw * 100) / 100;
+    if (rounded >= 100) return 99.99;
+    return rounded;
+  };
   return (
     <div className="usage-full">
       <div className="uh">

--- a/desktop/src/ui/statusbar.tsx
+++ b/desktop/src/ui/statusbar.tsx
@@ -19,6 +19,16 @@ function tokenLabel(n: number): string {
   return `${n}`;
 }
 
+/** Format a 0–100 percentage to 2 decimal places.
+ *  100.00 is shown only when the value is exactly 100; values that would round
+ *  to 100.00 are capped at 99.99. */
+function formatPct(value: number): string {
+  if (value === 100) return "100.00";
+  const rounded = Math.round(value * 100) / 100;
+  if (rounded >= 100) return "99.99";
+  return rounded.toFixed(2);
+}
+
 export function StatusBar({
   settings,
   balance,
@@ -57,7 +67,12 @@ export function StatusBar({
   const liveContextTokens = usage.reservedTokens + usage.liveLogTokens;
   const totalTokens = Math.max(sessionPromptTokens, liveContextTokens);
   const cacheDenom = usage.cacheHitTokens + usage.cacheMissTokens;
-  const cacheHitPct = cacheDenom > 0 ? Math.round((usage.cacheHitTokens / cacheDenom) * 100) : 0;
+  const cacheHitRaw = cacheDenom > 0 ? (usage.cacheHitTokens / cacheDenom) * 100 : 0;
+  const cacheHitPctDisplay = formatPct(cacheHitRaw);
+  const cacheHitDetail =
+    cacheDenom > 0
+      ? `${usage.cacheHitTokens.toLocaleString()} / ${cacheDenom.toLocaleString()} tokens (${cacheHitPctDisplay}%)`
+      : "";
   const runningJobs = jobs.filter((j) => j.running).length;
   const spent = formatMoney(usage.totalCostUsd, currency);
   const balanceLabel = balance
@@ -89,10 +104,10 @@ export function StatusBar({
         <span>{settings?.baseUrl?.replace(/^https?:\/\//, "") ?? "api.deepseek.com"}</span>
         <span className="v">{!ready ? t("statusbar.offline") : busy ? t("statusbar.busy") : t("statusbar.online")}</span>
       </span>
-      <span className="seg" title={t("statusbar.cacheHit")}>
+      <span className="seg" title={cacheHitDetail || t("statusbar.cacheHit")}>
         <I.zap size={11} style={{ color: "var(--accent)" }} />
         <span>{t("statusbar.cache")}</span>
-        <span className="v acc">{cacheHitPct}%</span>
+        <span className="v acc">{cacheHitPctDisplay}%</span>
       </span>
       <span className="seg">
         <I.cpu size={11} />


### PR DESCRIPTION
## Summary

The cache hit ratio in the status bar (both desktop and dashboard) previously displayed as an integer percentage (e.g. \`72%\`), losing precision. This change shows 2 decimal places (e.g. \`72.13%\`) and adds a hover tooltip with detailed hit/total token counts.

## Changes

| File | Change |
|---|---|
| \`desktop/src/ui/statusbar.tsx\` | Added \`formatPct()\` helper; cache hit ratio now shows 2 decimal places with 100% capping; hover tooltip shows detail |
| \`desktop/src/ui/extra-cards.tsx\` | UsageFull's \`pct()\` returns 2-decimal precision |
| \`desktop/src/ui/cards.tsx\` | MetricStrip.\`cacheHit\` type from \`number\` → \`string\` (pre-formatted) |
| \`dashboard/\` counterparts | Same changes applied |

## Rules

- **100% capping**: \`100.00%\` only shown when the actual ratio is exactly 100; otherwise capped at \`99.99%\`
- **Hover detail**: shows \`32,456 / 45,000 tokens (72.13%)\`
- **Other values**: round normally to 2 decimal places

## Verification

- ✅ \`npm run verify\` — lint / typecheck / build / 3850 tests all passed
- ✅ Desktop build (debug) succeeded
- ✅ Dashboard build succeeds

## Related

Closes #2157