### PR TITLE
perf: optimize tokenizer hot paths and prompt builder

### DIFF
--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -185,9 +185,9 @@ function applySplit(chunks: string[], re: RegExp): string[] {
 /** UTF-8 bytes of `s`, each mapped to its byte-level visible char. */
 function byteLevelEncode(s: string, byteToChar: string[]): string {
   const bytes = new TextEncoder().encode(s);
-  let out = "";
-  for (let i = 0; i < bytes.length; i++) out += byteToChar[bytes[i]!];
-  return out;
+  const parts: string[] = new Array(bytes.length);
+  for (let i = 0; i < bytes.length; i++) parts[i] = byteToChar[bytes[i]!]!;
+  return parts.join("");
 }
 
 /** Repetitive tool output / identifier chunks re-encode thousands of times per session; LRU bounds at ~400KB. */
@@ -259,7 +259,38 @@ export function encode(text: string): number[] {
 }
 
 export function countTokens(text: string): number {
-  return encode(text).length;
+  if (!text) return 0;
+  const t = loadTokenizer();
+  let count = 0;
+
+  const process = (segment: string) => {
+    if (!segment) return;
+    let chunks: string[] = [segment];
+    for (const re of t.splitRegexes) chunks = applySplit(chunks, re);
+    for (const chunk of chunks) {
+      if (!chunk) continue;
+      const byteLevel = byteLevelEncode(chunk, t.byteToChar);
+      const pieces = bpeEncode(byteLevel, t.mergeRank);
+      for (const p of pieces) {
+        if (t.vocab[p] !== undefined) count++;
+      }
+    }
+  };
+
+  if (t.addedPattern) {
+    t.addedPattern.lastIndex = 0;
+    let last = 0;
+    for (const m of text.matchAll(t.addedPattern)) {
+      const idx = m.index ?? 0;
+      if (idx > last) process(text.slice(last, idx));
+      if (t.addedMap.has(m[0])) count++;
+      last = idx + m[0].length;
+    }
+    if (last < text.length) process(text.slice(last));
+  } else {
+    process(text);
+  }
+  return count;
 }
 
 export const DEFAULT_BOUNDED_TOKENIZE_CHARS = 2 * 1024;
@@ -468,7 +499,7 @@ export function formatDeepSeekPrompt(
   }
   const merged = mergeToolMessages(msgs);
 
-  let prompt = BOS;
+  const parts: string[] = [BOS];
 
   for (let i = 0; i < merged.length; i++) {
     const msg = merged[i]!;
@@ -476,26 +507,26 @@ export function formatDeepSeekPrompt(
     const nextRole = i + 1 < merged.length ? (merged[i + 1]!.role ?? "user") : null;
 
     if (role === "system") {
-      prompt += msg.content ?? "";
+      parts.push(msg.content ?? "");
     } else if (role === "user") {
-      prompt += USER_SP + (msg.content ?? "");
+      parts.push(USER_SP, msg.content ?? "");
       if (nextRole === "assistant" || nextRole === null) {
-        prompt += ASSISTANT_SP + THINK_END;
+        parts.push(ASSISTANT_SP, THINK_END);
       }
     } else if (role === "assistant") {
       if (msg.reasoning_content) {
-        prompt += THINK_START + msg.reasoning_content + THINK_END;
+        parts.push(THINK_START, msg.reasoning_content, THINK_END);
       }
-      if (msg.content) prompt += msg.content;
+      if (msg.content) parts.push(msg.content);
       const tcs = msg.tool_calls;
       if (Array.isArray(tcs) && tcs.length > 0) {
-        prompt += renderToolCallsDsml(tcs);
+        parts.push(renderToolCallsDsml(tcs));
       }
-      prompt += EOS;
+      parts.push(EOS);
     }
   }
 
-  return prompt;
+  return parts.join("");
 }
 
 const PER_MESSAGE_TEMPLATE_TOKENS = 6;
@@ -503,12 +534,15 @@ const PER_MESSAGE_TEMPLATE_TOKENS = 6;
 /** Keyed by content string — WeakMap-on-message can't be used because callers spread `{...e}` defensive copies, breaking identity every turn. */
 const contentTokenCache = new LruCache<string, number>(4096);
 
+/** Skip caching strings >10KB — 4096 entries of 50KB+ tool outputs would retain 200MB+ of string keys. */
+const MAX_CACHEABLE_CHARS = 10 * 1024;
+
 function cachedBoundedTokens(s: string): number {
   if (s.length === 0) return 0;
   const cached = contentTokenCache.get(s);
   if (cached !== undefined) return cached;
   const n = countTokensBounded(s);
-  contentTokenCache.set(s, n);
+  if (s.length <= MAX_CACHEABLE_CHARS) contentTokenCache.set(s, n);
   return n;
 }
 

--- a/tests/tokenizer.test.ts
+++ b/tests/tokenizer.test.ts
@@ -319,6 +319,39 @@ describe("countTokensBounded", () => {
   });
 });
 
+describe("countTokens ↔ encode equivalence", () => {
+  const corpus: [string, string][] = [
+    ["empty", ""],
+    ["plain ASCII", "Hello, world!"],
+    ["ASCII sentence", "The quick brown fox jumps over the lazy dog."],
+    ["CJK characters", "你好世界"],
+    ["CJK prose", "深度求索是一家专注于人工智能基础技术研究的公司"],
+    ["mixed English+CJK", "mixed 中文 and english 混合"],
+    ["emoji (surrogate pairs)", "🎉🚀💻🔥"],
+    ["emoji in sentence", "Great job! 🎉 Let's go 🚀"],
+    ["digits", "1 + 1 = 2, 1234567890"],
+    ["special added tokens", "<think>reasoning here</think>"],
+    ["multiple added tokens", "<｜begin▁of▁sentence｜>Hello<｜User｜>Hi<｜Assistant｜>"],
+    ["code snippet", "function add(a, b) { return a + b; }"],
+    ["JSON payload", '{"name":"test","values":[1,2,3],"nested":{"key":"value"}}'],
+    ["repeated text", "Hello world! ".repeat(100)],
+    ["whitespace heavy", "  \t\n  hello  \n\t  world  \t\n  "],
+    ["long ASCII", "Lorem ipsum dolor sit amet, consectetur adipiscing elit. ".repeat(50)],
+  ];
+
+  for (const [label, text] of corpus) {
+    it(`countTokens matches encode.length for: ${label}`, () => {
+      expect(countTokens(text)).toBe(encode(text).length);
+    });
+  }
+
+  it("countTokens matches encode.length for >10KB blob", () => {
+    const big = "The quick brown fox jumps over the lazy dog. 你好世界 🎉 ".repeat(200);
+    expect(big.length).toBeGreaterThan(10_000);
+    expect(countTokens(big)).toBe(encode(big).length);
+  });
+});
+
 describe("performance sanity", () => {
   it("tokenizes 10k chars of typical mixed content in under 200 ms", () => {
     const block = "Hello world! 你好 deepseek ".repeat(400);


### PR DESCRIPTION
## Summary

Four independent optimizations targeting CPU and allocation pressure in the token-counting and prompt-formatting pipeline. Together they reduce the per-turn overhead of the tokenizer from O(n²) to O(n) for large inputs.

### 1. `byteLevelEncode`: O(n²) → O(n) string building (`src/tokenizer.ts:186-191`)

The `+=` loop copies the entire accumulator string on each iteration. For a 10KB text chunk with ~10K UTF-8 bytes, this creates ~10K intermediate string allocations totaling ~50MB of transient copies.

**Fix**: Pre-allocated `string[]` + `.join("")`. Single allocation, O(n) copy.

### 2. `countTokens`: skip `number[]` allocation (`src/tokenizer.ts:261-263`)

`encode(text).length` builds a full `number[]` array of token IDs just to read `.length`. For a 50KB input string producing ~15K tokens, this allocates ~60KB of transient heap that's immediately discarded.

**Fix**: New `countTokens` counts tokens inline without building the ID array. Same BPE pipeline, zero allocation beyond the working pieces.

### 3. `formatDeepSeekPrompt`: O(n²) → O(n) prompt building (`src/tokenizer.ts:471-498`)

The `+=` loop for building the formatted prompt copies the entire accumulator on each message. In long sessions with 100K+ char prompts, this is a measurable bottleneck — O(n²) in total prompt length.

**Fix**: `parts[]` array + `.join("")`. Each message pushes 1-4 strings; final join is O(n).

### 4. `cachedBoundedTokens`: size guard for large strings (`src/tokenizer.ts:506-513`)

The `contentTokenCache` LRU (4096 entries) caches token counts keyed by content string. Without a size guard, 4096 entries of 50KB+ tool outputs retain 200MB+ of string keys in memory.

**Fix**: Skip caching strings >10KB. Small strings (the common case — user messages, short tool outputs) still cache normally. Large strings re-compute on demand, which is cheap because `countTokensBounded` samples only head+tail.

## Test plan

- `tests/tokenizer.test.ts` — 33 tests pass (encode, countTokens, countTokensBounded, formatDeepSeekPrompt)
- `tests/loop.test.ts` — 69 tests pass (buildMessages, healing, streaming, tool dispatch)
- `biome check` passes with no lint issues