### PR TITLE
fix(desktop): use native macOS fullscreen zoom

### DIFF
--- a/desktop/src/App.test.ts
+++ b/desktop/src/App.test.ts
@@ -34,7 +34,7 @@ vi.mock("./theme", () => ({
   themeForStyle: vi.fn(() => "dark"),
 }));
 
-import { reduce } from "./App";
+import { readWindowExpanded, reduce, toggleWindowExpanded } from "./App";
 import { getThreadMaxWidth } from "./ui/thread-layout";
 
 function initialState(): Parameters<typeof reduce>[0] {
@@ -210,6 +210,47 @@ describe("Desktop App reducer — usage", () => {
     expect(next.usage.cacheHitTokens).toBe(80);
     expect(next.usage.cacheMissTokens).toBe(20);
     expect(next.usage.liveLogTokens).toBe(42);
+  });
+});
+
+describe("Desktop App window controls", () => {
+  it("treats macOS zoom state as fullscreen", async () => {
+    const win = {
+      isFullscreen: vi.fn(async () => true),
+      isMaximized: vi.fn(async () => false),
+      setFullscreen: vi.fn(async () => {}),
+      toggleMaximize: vi.fn(async () => {}),
+    };
+
+    await expect(readWindowExpanded(win, true)).resolves.toBe(true);
+    expect(win.isFullscreen).toHaveBeenCalledTimes(1);
+    expect(win.isMaximized).not.toHaveBeenCalled();
+  });
+
+  it("uses native fullscreen for macOS zoom button", async () => {
+    const win = {
+      isFullscreen: vi.fn(async () => false),
+      isMaximized: vi.fn(async () => false),
+      setFullscreen: vi.fn(async () => {}),
+      toggleMaximize: vi.fn(async () => {}),
+    };
+
+    await toggleWindowExpanded(win, true, false);
+    expect(win.setFullscreen).toHaveBeenCalledWith(true);
+    expect(win.toggleMaximize).not.toHaveBeenCalled();
+  });
+
+  it("keeps maximize behavior off macOS", async () => {
+    const win = {
+      isFullscreen: vi.fn(async () => false),
+      isMaximized: vi.fn(async () => false),
+      setFullscreen: vi.fn(async () => {}),
+      toggleMaximize: vi.fn(async () => {}),
+    };
+
+    await toggleWindowExpanded(win, false, false);
+    expect(win.toggleMaximize).toHaveBeenCalledTimes(1);
+    expect(win.setFullscreen).not.toHaveBeenCalled();
   });
 });
 

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -230,6 +230,17 @@ export type UsageStats = {
   liveLogTokens: number;
 };
 
+type WindowControls = Pick<ReturnType<typeof getCurrentWindow>, "isFullscreen" | "isMaximized" | "setFullscreen" | "toggleMaximize">;
+
+export function readWindowExpanded(win: WindowControls, isMac: boolean): Promise<boolean> {
+  return isMac ? win.isFullscreen() : win.isMaximized();
+}
+
+export function toggleWindowExpanded(win: WindowControls, isMac: boolean, expanded: boolean): Promise<void> {
+  if (isMac) return win.setFullscreen(!expanded);
+  return win.toggleMaximize();
+}
+
 export type SessionInfo = {
   name: string;
   messageCount: number;
@@ -2639,13 +2650,23 @@ function TitleBar({
 
   useEffect(() => {
     const win = getCurrentWindow();
-    win.isMaximized().then(setIsMaximized);
+    const syncWindowState = async () => {
+      setIsMaximized(await readWindowExpanded(win, isMac));
+    };
+    void syncWindowState();
     let unlisten: (() => void) | undefined;
     win.listen("tauri://resize", async () => {
-      setIsMaximized(await win.isMaximized());
+      await syncWindowState();
     }).then((fn) => { unlisten = fn; });
-    return () => unlisten?.();
-  }, []);
+    let fullscreenUnlisten: (() => void) | undefined;
+    win.listen("tauri://fullscreen", async () => {
+      await syncWindowState();
+    }).then((fn) => { fullscreenUnlisten = fn; });
+    return () => {
+      unlisten?.();
+      fullscreenUnlisten?.();
+    };
+  }, [isMac]);
 
   useEffect(() => {
     if (!menuOpen) return;
@@ -2696,7 +2717,7 @@ function TitleBar({
               aria-label={isMaximized ? t("app.titlebar.restore") : t("app.titlebar.maximize")}
               onMouseDown={(e) => {
                 e.stopPropagation();
-                win.toggleMaximize();
+                void toggleWindowExpanded(win, true, isMaximized);
               }}
             >
               {isMaximized ? <WinRestore /> : <WinMaximize />}
@@ -2810,7 +2831,7 @@ function TitleBar({
               type="button"
               className="win-ctrl"
               title={isMaximized ? t("app.titlebar.restore") : t("app.titlebar.maximize")}
-              onMouseDown={(e) => { e.stopPropagation(); win.toggleMaximize(); }}
+              onMouseDown={(e) => { e.stopPropagation(); void toggleWindowExpanded(win, false, isMaximized); }}
             >
               {isMaximized ? <WinRestore /> : <WinMaximize />}
             </button>


### PR DESCRIPTION
## Summary

Restore native macOS fullscreen behavior for the desktop app’s zoom control, so clicking the green window button enters real fullscreen instead of only expanding the window to the desktop work area.

## Problem

On macOS, the desktop app’s custom titlebar wired the green zoom button to window maximize behavior instead of native fullscreen. That produced a non-native result: the window expanded to fill the desktop area without entering a fullscreen Space.

The issue is in the desktop titlebar window-control path:
- `desktop/src/App.tsx` renders the custom macOS traffic-light controls
- the green button used `toggleMaximize()` instead of macOS fullscreen APIs
- the titlebar state tracking also treated the expanded state as maximize-only, so macOS fullscreen state was not modeled correctly

## Fix

- **`desktop/src/App.tsx`** — Added small window-state helpers so macOS reads expanded state from `isFullscreen()` and toggles it with `setFullscreen()`, while non-macOS platforms keep the existing maximize behavior.
- **`desktop/src/App.tsx`** — Updated titlebar listeners to sync both resize and fullscreen events so the control state stays accurate after entering or leaving fullscreen.
- **`desktop/src/App.test.ts`** — Added regression coverage verifying macOS uses native fullscreen for the zoom button and other platforms still use maximize.

## Verification

| Check | Result |
|---|---|
| `npm test -- desktop/src/App.test.ts` | ✅ passes |
| `npm test -- tests/desktop-user-message.test.ts` | ✅ passes |
| `npm run verify` | ✅ passes |

Closed #2054
