### PR TITLE
fix(tools): enforce auto git rollback checkpoints

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -9,6 +9,7 @@ import {
   openEventSink,
 } from "../../adapters/event-sink-jsonl.js";
 import { type AtUrlExpansion, expandAtMentions, expandAtUrls } from "../../at-mentions.js";
+import { prepareAutoGitRollbackForEditBlocks } from "../../code/auto-git-rollback.js";
 import {
   type CheckpointMeta,
   createCheckpoint,
@@ -2050,6 +2051,8 @@ function AppInner({
       // after —ToolCard renders that with the same text. Pushing here
       // would produce "result shown twice".
       const applyNow = (): string => {
+        const guard = prepareAutoGitRollbackForEditBlocks(rootForEdit, blocks, {});
+        if (guard) return guard;
         const snaps = snapshotBeforeEdits(blocks, rootForEdit);
         const results = applyEditBlocks(blocks, rootForEdit);
         const good = results.some((r) => r.status === "applied" || r.status === "created");

--- a/src/cli/ui/hooks/handle-assistant-final.ts
+++ b/src/cli/ui/hooks/handle-assistant-final.ts
@@ -1,5 +1,9 @@
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import {
+  formatAutoGitRollbackRejection,
+  prepareAutoGitRollbackForEditBlocks,
+} from "../../../code/auto-git-rollback.js";
+import {
   type ApplyResult,
   type EditBlock,
   type EditSnapshot,
@@ -111,6 +115,11 @@ export function handleAssistantFinal(ev: LoopEvent, ctx: AssistantFinalContext):
   if (blocks.length === 0) return;
 
   if (ctx.editModeRef.current === "auto" || ctx.editModeRef.current === "yolo") {
+    const guard = prepareAutoGitRollbackForEditBlocks(ctx.currentRootDir, blocks, {});
+    if (guard) {
+      ctx.log.pushInfo(formatAutoGitRollbackRejection(guard), "warn");
+      return;
+    }
     const snaps = snapshotBeforeEdits(blocks, ctx.currentRootDir);
     const results = applyEditBlocks(blocks, ctx.currentRootDir);
     const good = results.some((r) => r.status === "applied" || r.status === "created");

--- a/src/cli/ui/hooks/useCodeMode.ts
+++ b/src/cli/ui/hooks/useCodeMode.ts
@@ -1,5 +1,9 @@
 import { type MutableRefObject, useCallback } from "react";
 import {
+  formatAutoGitRollbackRejection,
+  prepareAutoGitRollbackForEditBlocks,
+} from "../../../code/auto-git-rollback.js";
+import {
   type ApplyResult,
   type EditBlock,
   type EditSnapshot,
@@ -49,6 +53,8 @@ export function useCodeMode(opts: UseCodeModeOptions): UseCodeModeResult {
       if (selected.length === 0) {
         return t("app.noMatchedApply");
       }
+      const guard = prepareAutoGitRollbackForEditBlocks(currentRootDir, selected, {});
+      if (guard) return formatAutoGitRollbackRejection(guard);
       const snaps = snapshotBeforeEdits(selected, currentRootDir);
       const results = applyEditBlocks(selected, currentRootDir);
       const anyApplied = results.some((r) => r.status === "applied" || r.status === "created");

--- a/src/code/auto-git-rollback.ts
+++ b/src/code/auto-git-rollback.ts
@@ -1,0 +1,286 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, realpathSync } from "node:fs";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
+import type { ReasonixConfig } from "../config.js";
+import { memoryEnabled } from "../memory/project.js";
+import type { MemoryEntry } from "../memory/user.js";
+import { MemoryStore, effectivePriority } from "../memory/user.js";
+import type { EditBlock } from "./edit-blocks.js";
+
+export interface AutoGitRollbackOptions {
+  homeDir?: string;
+  cfg?: ReasonixConfig;
+}
+
+export type AutoGitRollbackConfig = false | AutoGitRollbackOptions;
+
+interface PrepareOptions {
+  rootDir: string;
+  toolName: "edit_file" | "multi_edit" | "write_file" | "edit_blocks";
+  absPaths: readonly string[];
+  autoGitRollback?: AutoGitRollbackConfig;
+}
+
+function rejection(message: string, nextAction: string): string {
+  return JSON.stringify({
+    error: `auto-git-rollback: ${message}`,
+    rejectedReason: "auto-git-rollback",
+    nextAction,
+  });
+}
+
+function cleanGitEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (key.startsWith("GIT_")) delete env[key];
+  }
+  return env;
+}
+
+function runGitRaw(cwd: string, args: readonly string[]): string {
+  return execFileSync("git", ["-C", cwd, ...args], {
+    encoding: "utf8",
+    env: cleanGitEnv(),
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function runGit(cwd: string, args: readonly string[]): string {
+  return runGitRaw(cwd, args).trim();
+}
+
+function tryGit(cwd: string, args: readonly string[]): string | null {
+  try {
+    return runGit(cwd, args);
+  } catch {
+    return null;
+  }
+}
+
+function tryGitRaw(cwd: string, args: readonly string[]): string | null {
+  try {
+    return runGitRaw(cwd, args);
+  } catch {
+    return null;
+  }
+}
+
+function realpathNative(path: string): string {
+  return realpathSync.native(resolve(path));
+}
+
+function gitTopLevel(rootDir: string): string | null {
+  const out = tryGit(rootDir, ["rev-parse", "--show-toplevel"]);
+  return out ? realpathNative(out) : null;
+}
+
+function isAutoGitRollbackEntry(entry: MemoryEntry, cfg: ReasonixConfig | undefined): boolean {
+  if (effectivePriority(entry, cfg) !== "high") return false;
+  const text = [entry.name, entry.type, entry.description, entry.body].join("\n").toLowerCase();
+  if (text.includes("auto-git-rollback")) return true;
+  return (
+    text.includes("git add") &&
+    text.includes("git commit") &&
+    (text.includes("edit_file") || text.includes("multi_edit") || text.includes("write_file"))
+  );
+}
+
+function autoGitRollbackActive(
+  rootDir: string,
+  autoGitRollback: AutoGitRollbackConfig | undefined,
+): boolean {
+  if (autoGitRollback === false || !memoryEnabled()) return false;
+  const opts = autoGitRollback ?? {};
+  const top = gitTopLevel(rootDir);
+  if (!top) return false;
+  const store = new MemoryStore({ homeDir: opts.homeDir, projectRoot: rootDir });
+  return store.list().some((entry) => isAutoGitRollbackEntry(entry, opts.cfg));
+}
+
+function pathIsUnder(child: string, parent: string): boolean {
+  const rel = relative(parent, child);
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}
+
+function unique<T>(items: readonly T[]): T[] {
+  return [...new Set(items)];
+}
+
+function targetExistsOrIsTracked(topLevel: string, relPath: string): boolean {
+  if (existsSync(join(topLevel, relPath))) return true;
+  return tryGit(topLevel, ["ls-files", "--error-unmatch", "--", relPath]) !== null;
+}
+
+function realpathForTarget(abs: string): string {
+  const resolved = resolve(abs);
+  if (existsSync(resolved)) return realpathNative(resolved);
+  const missing: string[] = [basename(resolved)];
+  let parent = dirname(resolved);
+  while (!existsSync(parent)) {
+    const next = dirname(parent);
+    if (next === parent) return resolved;
+    missing.unshift(basename(parent));
+    parent = next;
+  }
+  return join(realpathNative(parent), ...missing);
+}
+
+function commitMessage(toolName: string, relPaths: readonly string[]): string {
+  const shown = relPaths.slice(0, 3).join(", ");
+  const suffix = relPaths.length > 3 ? ` +${relPaths.length - 3}` : "";
+  return `pre-edit: ${toolName} ${shown}${suffix}`;
+}
+
+function parseNameList(out: string): string[] {
+  return out
+    .split(/\r?\n/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function normalizeGitRelPath(path: string): string {
+  return path.replaceAll("\\", "/");
+}
+
+function parseStatusPath(out: string | null): string | null {
+  if (!out) return null;
+  for (const entry of out.split("\0")) {
+    if (entry.length <= 3) continue;
+    const path = entry.slice(3);
+    if (path.length > 0) return normalizeGitRelPath(path);
+  }
+  return null;
+}
+
+function gitRelPathForTarget(topLevel: string, absPath: string): string | null {
+  const tracked = parseNameList(tryGit(topLevel, ["ls-files", "--full-name", "--", absPath]) ?? "");
+  if (tracked.length > 0) return normalizeGitRelPath(tracked[0]!);
+  return parseStatusPath(tryGitRaw(topLevel, ["status", "--porcelain=v1", "-z", "--", absPath]));
+}
+
+function relPathForTarget(topLevel: string, absPath: string): string | null {
+  const resolved = realpathForTarget(absPath);
+  if (pathIsUnder(resolved, topLevel)) {
+    return normalizeGitRelPath(relative(topLevel, resolved));
+  }
+
+  // Windows runners can expose the same Temp directory through a short 8.3
+  // alias (for example RUNNER~1) while Git reports the long worktree path.
+  // When that happens, the lexical realpath comparison above cannot prove
+  // containment, but Git can still map the absolute pathspec to a repo path.
+  return gitRelPathForTarget(topLevel, absPath) ?? gitRelPathForTarget(topLevel, resolved);
+}
+
+export function prepareAutoGitRollback(opts: PrepareOptions): string | null {
+  const active = autoGitRollbackActive(opts.rootDir, opts.autoGitRollback);
+  if (!active) return null;
+
+  const topLevel = gitTopLevel(opts.rootDir);
+  if (!topLevel) return null;
+  if (!existsSync(join(topLevel, ".gitignore"))) {
+    return rejection(
+      "refusing to mutate before a repository .gitignore is present",
+      "create_or_confirm_gitignore",
+    );
+  }
+
+  const rawRelPaths: string[] = [];
+  for (const abs of opts.absPaths) {
+    const relPath = relPathForTarget(topLevel, abs);
+    if (relPath === null) {
+      return rejection(
+        `target path escapes git worktree: ${realpathForTarget(abs)}`,
+        "choose_in_repo_target",
+      );
+    }
+    rawRelPaths.push(relPath);
+  }
+  const relPaths = unique(rawRelPaths);
+
+  if (relPaths.length === 0) return null;
+
+  const stagedBefore = parseNameList(runGit(topLevel, ["diff", "--cached", "--name-only"]));
+  const targetSet = new Set(relPaths);
+  const unrelatedStaged = stagedBefore.filter((p) => !targetSet.has(p));
+  if (unrelatedStaged.length > 0) {
+    return rejection(
+      `refusing to commit unrelated staged changes: ${unrelatedStaged.join(", ")}`,
+      "commit_or_unstage_unrelated_changes",
+    );
+  }
+
+  const stageable = relPaths.filter((p) => targetExistsOrIsTracked(topLevel, p));
+  if (stageable.length > 0) {
+    try {
+      runGit(topLevel, ["add", "--", ...stageable]);
+    } catch (err) {
+      return rejection((err as Error).message, "fix_git_add_failure");
+    }
+  }
+
+  const hasStagedChanges = (() => {
+    try {
+      runGit(topLevel, ["diff", "--cached", "--quiet"]);
+      return false;
+    } catch {
+      return true;
+    }
+  })();
+  if (hasStagedChanges) {
+    try {
+      runGit(topLevel, ["commit", "-m", commitMessage(opts.toolName, relPaths), "--quiet"]);
+    } catch (err) {
+      return rejection((err as Error).message, "fix_git_commit_failure");
+    }
+  }
+
+  const status = runGit(topLevel, ["status", "--porcelain"]);
+  if (status.length > 0) {
+    return rejection(
+      "refusing to mutate while the worktree still has uncommitted changes after the pre-edit checkpoint",
+      "commit_stash_or_clean_worktree",
+    );
+  }
+
+  return null;
+}
+
+function looksLikeAbsoluteSystemPath(rawPath: string): boolean {
+  return /^\/(?:home|Users|etc|var|opt|tmp|usr|mnt|Library|Volumes|proc|sys|dev|run|srv|media|Applications|System|root|boot|private)(?:[/\\]|$)/.test(
+    rawPath,
+  );
+}
+
+function resolveBlockPath(rootDir: string, rawPath: string): string {
+  if (/^[A-Za-z]:[\\/]/.test(rawPath) || looksLikeAbsoluteSystemPath(rawPath)) {
+    return resolve(rawPath);
+  }
+  let rooted = rawPath;
+  while (rooted.startsWith("/") || rooted.startsWith("\\")) {
+    rooted = rooted.slice(1);
+  }
+  return resolve(rootDir, rooted || ".");
+}
+
+export function prepareAutoGitRollbackForEditBlocks(
+  rootDir: string,
+  blocks: readonly EditBlock[],
+  autoGitRollback?: AutoGitRollbackConfig,
+): string | null {
+  return prepareAutoGitRollback({
+    rootDir,
+    toolName: "edit_blocks",
+    absPaths: blocks.map((block) => resolveBlockPath(rootDir, block.path)),
+    autoGitRollback,
+  });
+}
+
+export function formatAutoGitRollbackRejection(result: string): string {
+  try {
+    const parsed = JSON.parse(result) as { error?: unknown };
+    if (typeof parsed.error === "string") return parsed.error;
+  } catch {
+    /* keep original text */
+  }
+  return result;
+}

--- a/src/code/auto-git-rollback.ts
+++ b/src/code/auto-git-rollback.ts
@@ -77,12 +77,7 @@ function gitTopLevel(rootDir: string): string | null {
 function isAutoGitRollbackEntry(entry: MemoryEntry, cfg: ReasonixConfig | undefined): boolean {
   if (effectivePriority(entry, cfg) !== "high") return false;
   const text = [entry.name, entry.type, entry.description, entry.body].join("\n").toLowerCase();
-  if (text.includes("auto-git-rollback")) return true;
-  return (
-    text.includes("git add") &&
-    text.includes("git commit") &&
-    (text.includes("edit_file") || text.includes("multi_edit") || text.includes("write_file"))
-  );
+  return text.includes("auto-git-rollback");
 }
 
 function autoGitRollbackActive(

--- a/src/code/setup.ts
+++ b/src/code/setup.ts
@@ -65,7 +65,11 @@ export async function buildCodeToolset(opts: CodeToolsetOpts): Promise<CodeTools
 
   const outlineThresholdBytes = loadFilesystemOutlineThresholdBytes();
   const registerRooted = (root: string): void => {
-    registerFilesystemTools(tools, { rootDir: root, outlineThresholdBytes });
+    registerFilesystemTools(tools, {
+      rootDir: root,
+      outlineThresholdBytes,
+      autoGitRollback: {},
+    });
     const cfg = readConfig();
     registerShellTools(tools, {
       rootDir: root,

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -446,6 +446,8 @@ function rejectionRecoveryHint(reason: string): string {
       return "Switch to read-only exploration, submit or revise the plan, or choose a different tool call.";
     case "engineering-lifecycle-evidence":
       return "Submit completion evidence or revise/checkpoint the plan before marking the step complete.";
+    case "auto-git-rollback":
+      return "Resolve the git checkpoint blocker before retrying the same edit.";
     default:
       return "Choose a different tool call or ask the user how to proceed.";
   }

--- a/src/tools/filesystem.ts
+++ b/src/tools/filesystem.ts
@@ -3,6 +3,7 @@
 import { promises as fs } from "node:fs";
 import * as pathMod from "node:path";
 import picomatch from "picomatch";
+import { type AutoGitRollbackConfig, prepareAutoGitRollback } from "../code/auto-git-rollback.js";
 import { decodeFileBuffer, encodeFile } from "../code/file-encoding.js";
 import { addProjectPathAllowed, loadProjectPathAllowed } from "../config.js";
 import { type ConfirmationChoice, pauseGate as defaultPauseGate } from "../core/pause-gate.js";
@@ -31,6 +32,8 @@ export interface FilesystemToolsOptions {
   outlineThresholdBytes?: number;
   /** Cap on total bytes from listing/grep tools — bounds tree-as-one-string accidents. */
   maxListBytes?: number;
+  /** Opt-in host guard for high-priority auto-git-rollback memories. */
+  autoGitRollback?: AutoGitRollbackConfig;
 }
 
 /** 64 KiB covers ~99% of source files; larger ones (generated bundles, lockfiles, novels) outline-mode by default to keep the cache prefix slim. */
@@ -117,6 +120,7 @@ export function registerFilesystemTools(
   const allowWriting = opts.allowWriting !== false;
   const outlineThresholdBytes = opts.outlineThresholdBytes ?? DEFAULT_OUTLINE_THRESHOLD_BYTES;
   const maxListBytes = opts.maxListBytes ?? DEFAULT_MAX_LIST_BYTES;
+  const autoGitRollback = opts.autoGitRollback;
 
   const normRoot = pathMod.resolve(rootDir);
   /** Approved-this-session directory prefixes — `run_once` keeps the user from being asked twice for follow-up reads in the same dir. Wiped on process exit, not persisted. */
@@ -664,6 +668,13 @@ export function registerFilesystemTools(
     },
     fn: async (args: { path: string; content: string }, ctx?: ToolCallContext) => {
       const abs = await safePath(args.path, "write_file", ctx, "write");
+      const guard = prepareAutoGitRollback({
+        rootDir,
+        toolName: "write_file",
+        absPaths: [abs],
+        autoGitRollback,
+      });
+      if (guard) return guard;
       await fs.mkdir(pathMod.dirname(abs), { recursive: true });
       let encoding: ReturnType<typeof decodeFileBuffer>["encoding"] = "utf8";
       try {
@@ -692,13 +703,22 @@ export function registerFilesystemTools(
       },
       required: ["path", "search", "replace"],
     },
-    fn: async (args: { path: string; search: string; replace: string }, ctx?: ToolCallContext) =>
-      applyEdit(
+    fn: async (args: { path: string; search: string; replace: string }, ctx?: ToolCallContext) => {
+      const abs = await safePath(args.path, "edit_file", ctx, "write");
+      const guard = prepareAutoGitRollback({
         rootDir,
-        await safePath(args.path, "edit_file", ctx, "write"),
+        toolName: "edit_file",
+        absPaths: [abs],
+        autoGitRollback,
+      });
+      if (guard) return guard;
+      return applyEdit(
+        rootDir,
+        abs,
         args,
         ctx?.readTracker ? (abs) => ctx.readTracker!.hasRead(abs) : undefined,
-      ),
+      );
+    },
   });
 
   registry.register({
@@ -741,6 +761,13 @@ export function registerFilesystemTools(
           replace: e?.replace,
         })),
       );
+      const guard = prepareAutoGitRollback({
+        rootDir,
+        toolName: "multi_edit",
+        absPaths: resolved.map((e) => e.abs),
+        autoGitRollback,
+      });
+      if (guard) return guard;
       return applyMultiEdit(
         rootDir,
         resolved,

--- a/tests/auto-git-rollback.test.ts
+++ b/tests/auto-git-rollback.test.ts
@@ -1,0 +1,173 @@
+import { execFileSync } from "node:child_process";
+import { promises as fs } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { MemoryStore } from "../src/memory/user.js";
+import { ToolRegistry } from "../src/tools.js";
+import { registerFilesystemTools } from "../src/tools/filesystem.js";
+import { ReadTracker } from "../src/tools/read-tracker.js";
+
+function cleanGitEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (key.startsWith("GIT_")) delete env[key];
+  }
+  return { ...env, ...overrides };
+}
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    env: cleanGitEnv({
+      GIT_AUTHOR_NAME: "Reasonix Test",
+      GIT_AUTHOR_EMAIL: "reasonix@example.test",
+      GIT_COMMITTER_NAME: "Reasonix Test",
+      GIT_COMMITTER_EMAIL: "reasonix@example.test",
+    }),
+  }).trim();
+}
+
+function enableAutoGitRollback(home: string, root: string): void {
+  const store = new MemoryStore({ homeDir: home, projectRoot: root });
+  store.write({
+    name: "auto-git-rollback",
+    type: "workflow",
+    scope: "global",
+    description: "run git add and git commit before edit_file/multi_edit/write_file",
+    body: [
+      "Before edit_file, multi_edit, or write_file, create a git rollback point.",
+      "Run git add for the target files, then git diff --cached --quiet || git commit.",
+    ].join("\n"),
+    priority: "high",
+  });
+}
+
+function restoreProcessEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    Reflect.deleteProperty(process.env, name);
+    return;
+  }
+  process.env[name] = value;
+}
+
+describe("auto-git-rollback memory guard", () => {
+  let root: string;
+  let home: string;
+  let tools: ToolRegistry;
+  let readTracker: ReadTracker;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "reasonix-auto-git-root-"));
+    home = await mkdtemp(join(tmpdir(), "reasonix-auto-git-home-"));
+    tools = new ToolRegistry();
+    registerFilesystemTools(tools, { rootDir: root, autoGitRollback: { homeDir: home } });
+    readTracker = new ReadTracker();
+
+    git(root, ["init", "-q"]);
+    git(root, ["config", "user.name", "Reasonix Test"]);
+    git(root, ["config", "user.email", "reasonix@example.test"]);
+    await fs.writeFile(join(root, ".gitignore"), "node_modules/\n", "utf8");
+    await fs.writeFile(join(root, "tracked.txt"), "baseline\n", "utf8");
+    await fs.writeFile(join(root, "other.txt"), "other baseline\n", "utf8");
+    git(root, ["add", ".gitignore", "tracked.txt", "other.txt"]);
+    git(root, ["commit", "-m", "test: initial commit", "-q"]);
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("creates a pre-edit git checkpoint for dirty target files before edit_file writes", async () => {
+    enableAutoGitRollback(home, root);
+    await fs.writeFile(join(root, "tracked.txt"), "dirty-before-edit\n", "utf8");
+
+    await tools.dispatch("read_file", { path: "tracked.txt" }, { readTracker });
+    const out = await tools.dispatch(
+      "edit_file",
+      { path: "tracked.txt", search: "dirty-before-edit", replace: "after-edit" },
+      { readTracker },
+    );
+
+    expect(out).toMatch(/edited tracked\.txt/);
+    expect(git(root, ["show", "HEAD:tracked.txt"])).toBe("dirty-before-edit");
+    expect(git(root, ["log", "-1", "--format=%s"])).toMatch(/pre-edit: edit_file tracked\.txt/);
+    expect(await fs.readFile(join(root, "tracked.txt"), "utf8")).toBe("after-edit\n");
+  });
+
+  it.each([
+    {
+      toolName: "multi_edit",
+      args: {
+        edits: [{ path: "tracked.txt", search: "dirty-before-edit", replace: "after-edit" }],
+      },
+    },
+    {
+      toolName: "write_file",
+      args: { path: "tracked.txt", content: "after-edit\n" },
+    },
+  ])("creates the same pre-edit checkpoint before $toolName writes", async ({ toolName, args }) => {
+    enableAutoGitRollback(home, root);
+    await fs.writeFile(join(root, "tracked.txt"), "dirty-before-edit\n", "utf8");
+
+    await tools.dispatch("read_file", { path: "tracked.txt" }, { readTracker });
+    const out = await tools.dispatch(toolName, args, { readTracker });
+
+    expect(out).toMatch(toolName === "write_file" ? /wrote \d+ chars/ : /applied 1 edit/);
+    expect(git(root, ["show", "HEAD:tracked.txt"])).toBe("dirty-before-edit");
+    expect(git(root, ["log", "-1", "--format=%s"])).toMatch(
+      new RegExp(`pre-edit: ${toolName} tracked\\.txt`),
+    );
+    expect(await fs.readFile(join(root, "tracked.txt"), "utf8")).toBe("after-edit\n");
+  });
+
+  it("refuses to write when unrelated worktree changes remain after checkpointing targets", async () => {
+    enableAutoGitRollback(home, root);
+    await fs.writeFile(join(root, "other.txt"), "unrelated dirty\n", "utf8");
+
+    await tools.dispatch("read_file", { path: "tracked.txt" }, { readTracker });
+    const out = await tools.dispatch(
+      "edit_file",
+      { path: "tracked.txt", search: "baseline", replace: "after-edit" },
+      { readTracker },
+    );
+
+    expect(JSON.parse(out)).toMatchObject({
+      rejectedReason: "auto-git-rollback",
+      nextAction: "commit_stash_or_clean_worktree",
+    });
+    expect(await fs.readFile(join(root, "tracked.txt"), "utf8")).toBe("baseline\n");
+  });
+
+  it("ignores ambient Git hook environment variables when checkpointing", async () => {
+    const outerRoot = await mkdtemp(join(tmpdir(), "reasonix-auto-git-outer-"));
+    git(outerRoot, ["init", "-q"]);
+    const previousGitDir = process.env.GIT_DIR;
+    const previousGitWorkTree = process.env.GIT_WORK_TREE;
+    process.env.GIT_DIR = join(outerRoot, ".git");
+    process.env.GIT_WORK_TREE = outerRoot;
+
+    try {
+      enableAutoGitRollback(home, root);
+      await fs.writeFile(join(root, "tracked.txt"), "dirty-before-edit\n", "utf8");
+
+      await tools.dispatch("read_file", { path: "tracked.txt" }, { readTracker });
+      const out = await tools.dispatch(
+        "edit_file",
+        { path: "tracked.txt", search: "dirty-before-edit", replace: "after-edit" },
+        { readTracker },
+      );
+
+      expect(out).toMatch(/edited tracked\.txt/);
+      expect(git(root, ["show", "HEAD:tracked.txt"])).toBe("dirty-before-edit");
+      expect(git(root, ["log", "-1", "--format=%s"])).toMatch(/pre-edit: edit_file tracked\.txt/);
+    } finally {
+      restoreProcessEnv("GIT_DIR", previousGitDir);
+      restoreProcessEnv("GIT_WORK_TREE", previousGitWorkTree);
+      await rm(outerRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/auto-git-rollback.test.ts
+++ b/tests/auto-git-rollback.test.ts
@@ -40,6 +40,22 @@ function enableAutoGitRollback(home: string, root: string): void {
     body: [
       "Before edit_file, multi_edit, or write_file, create a git rollback point.",
       "Run git add for the target files, then git diff --cached --quiet || git commit.",
+      "Refuse edits unless the worktree is clean after that checkpoint.",
+    ].join("\n"),
+    priority: "high",
+  });
+}
+
+function writePlainGitWorkflowMemory(home: string, root: string): void {
+  const store = new MemoryStore({ homeDir: home, projectRoot: root });
+  store.write({
+    name: "normal-git-workflow",
+    type: "workflow",
+    scope: "global",
+    description: "documents git add and git commit around edit_file usage",
+    body: [
+      "Before larger changes, inspect the diff and decide what to stage.",
+      "Use git add and git commit intentionally after edit_file, multi_edit, or write_file changes.",
     ].join("\n"),
     priority: "high",
   });
@@ -95,6 +111,23 @@ describe("auto-git-rollback memory guard", () => {
     expect(out).toMatch(/edited tracked\.txt/);
     expect(git(root, ["show", "HEAD:tracked.txt"])).toBe("dirty-before-edit");
     expect(git(root, ["log", "-1", "--format=%s"])).toMatch(/pre-edit: edit_file tracked\.txt/);
+    expect(await fs.readFile(join(root, "tracked.txt"), "utf8")).toBe("after-edit\n");
+  });
+
+  it("does not activate from a high-priority memory that only describes ordinary git workflow", async () => {
+    writePlainGitWorkflowMemory(home, root);
+    await fs.writeFile(join(root, "tracked.txt"), "dirty-before-edit\n", "utf8");
+
+    await tools.dispatch("read_file", { path: "tracked.txt" }, { readTracker });
+    const out = await tools.dispatch(
+      "edit_file",
+      { path: "tracked.txt", search: "dirty-before-edit", replace: "after-edit" },
+      { readTracker },
+    );
+
+    expect(out).toMatch(/edited tracked\.txt/);
+    expect(git(root, ["show", "HEAD:tracked.txt"])).toBe("baseline");
+    expect(git(root, ["log", "--format=%s"])).not.toContain("pre-edit:");
     expect(await fs.readFile(join(root, "tracked.txt"), "utf8")).toBe("after-edit\n");
   });
 


### PR DESCRIPTION
## What

Adds a host-side auto-git-rollback guard for code-mode writes when a high-priority memory explicitly contains the `auto-git-rollback` marker. The guard creates a pre-edit git checkpoint for target files before edit_file, multi_edit, write_file, text-form edit blocks, and /apply writes to disk. When active, it refuses edits unless the worktree is clean after checkpointing the target paths.

## Why

Fixes #2146. The high-priority memory body was visible in the prompt, but write paths still relied on model compliance. A runtime guard makes the rollback step mechanical before mutation, while explicit marker activation keeps git-history writes opt-in and unambiguous.

## How to verify

- npm run verify
- npx vitest run tests/auto-git-rollback.test.ts tests/filesystem-tools.test.ts tests/read-before-edit-gate.test.ts tests/review-edit-gate.test.ts

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` - release notes are maintainer-written at release time