### PR TITLE
fix(ui): show mention filenames before paths

### DIFF
--- a/dashboard/src/styles.css
+++ b/dashboard/src/styles.css
@@ -3025,6 +3025,9 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
   flex-direction: column;
   z-index: 50;
 }
+.popup.at-popup {
+  width: min(720px, calc(100vw - 32px));
+}
 .popup .ph {
   padding: 8px 12px;
   font-family: inherit;
@@ -3046,7 +3049,11 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
 }
 .popup-list {
   overflow-y: auto;
+  overflow-x: hidden;
   padding: 4px;
+}
+.at-popup-list .popup-item {
+  min-width: 0;
 }
 .popup-item {
   display: grid;
@@ -3075,11 +3082,19 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
 .popup-item .nm {
   font-weight: 500;
   color: var(--fg);
+  min-width: 0;
+  overflow: hidden;
 }
 .popup-item .nm .cmd {
   font-family: inherit;
   color: var(--accent);
   margin-right: 6px;
+}
+.popup-item .mention-name {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .popup-item .desc {
   display: block;

--- a/dashboard/src/ui/composer.tsx
+++ b/dashboard/src/ui/composer.tsx
@@ -64,6 +64,7 @@ export type SlashCmd = {
 };
 export type MentionItem = {
   name: string;
+  path?: string;
   kind: "file" | "dir" | "url" | "agent" | "clip";
   desc?: string;
 };
@@ -101,6 +102,20 @@ function parentOfAtQuery(query: string): string | null {
   if (!dirContext) return null;
   const parentIdx = dirContext.lastIndexOf("/");
   return parentIdx >= 0 ? `${dirContext.slice(0, parentIdx)}/` : "";
+}
+
+function displayMentionPath(path: string): { name: string; desc?: string } {
+  const normalized = path.replace(/\\/g, "/");
+  const isDir = /[\\/]$/.test(path);
+  const trimmed = normalized.replace(/\/+$/, "");
+  if (!trimmed) return { name: path };
+  const slash = trimmed.lastIndexOf("/");
+  const base = slash >= 0 ? trimmed.slice(slash + 1) : trimmed;
+  const parent = slash >= 0 ? `${trimmed.slice(0, slash)}/` : "";
+  return {
+    name: isDir ? `${base}/` : base,
+    desc: parent || undefined,
+  };
 }
 
 function atIcon(k: MentionItem["kind"]) {
@@ -240,11 +255,15 @@ export function Composer({
   const atItems = useMemo<MentionItem[]>(() => {
     if (!popup || popup.kind !== "at") return [];
     if (!mentionResults || mentionResults.nonce !== popup.nonce) return [];
-    const base: MentionItem[] = mentionResults.results.map((path) => ({
-      name: path,
-      kind: path.endsWith("/") || path.endsWith("\\") ? "dir" : "file",
-      desc: path,
-    }));
+    const base: MentionItem[] = mentionResults.results.map((path) => {
+      const display = displayMentionPath(path);
+      return {
+        name: display.name,
+        path,
+        kind: path.endsWith("/") || path.endsWith("\\") ? "dir" : "file",
+        desc: display.desc,
+      };
+    });
     // "../" entry (#1019): one level up whenever the @ query is inside a subdir.
     const parent = parentOfAtQuery(popup.query);
     if (parent !== null) {
@@ -317,9 +336,10 @@ export function Composer({
         return;
       }
       const next = draft.replace(/[/@][^\s]*$/, "").trimEnd();
-      setDraft(next ? `${next} @${mention.name} ` : `@${mention.name} `);
-      setChips((c) => [...c, { kind: "at", label: mention.name }]);
-      onMentionPicked?.(mention.name);
+      const mentionPath = mention.path ?? mention.name;
+      setDraft(next ? `${next} @${mentionPath} ` : `@${mentionPath} `);
+      setChips((c) => [...c, { kind: "at", label: mentionPath }]);
+      onMentionPicked?.(mentionPath);
     }
     setPopup(null);
     textareaRef.current?.focus();
@@ -361,7 +381,7 @@ export function Composer({
             setPopup({ kind: "at", query: parent, nonce });
             return;
           }
-          const dirPath = mention.name.replace(/\/+$/, "");
+          const dirPath = (mention.path ?? mention.name).replace(/[\\/]+$/, "");
           const next = draft.replace(/[@][^\s]*$/, `@${dirPath}/`);
           setDraft(next);
           const nonce = ++nonceRef.current;
@@ -603,7 +623,8 @@ export function Composer({
               onHover={(i, item) => {
                 setActiveIdx(i);
                 if (popup.kind === "at" && onMentionPreview) {
-                  const path = (item as MentionItem).name;
+                  const mention = item as MentionItem;
+                  const path = mention.path ?? mention.name;
                   onMentionPreview(path, popup.nonce);
                 }
               }}
@@ -640,7 +661,10 @@ function Popup({
   }, [activeIdx]);
 
   return (
-    <div className="popup" onMouseDown={(e) => e.preventDefault()}>
+    <div
+      className={kind === "at" ? "popup at-popup" : "popup"}
+      onMouseDown={(e) => e.preventDefault()}
+    >
       <div className="ph">
         <span className="tok">{kind === "slash" ? "/" : "@"}</span>
         <span>
@@ -653,7 +677,7 @@ function Popup({
           <I.x size={11} />
         </span>
       </div>
-      <div className="popup-list" ref={listRef}>
+      <div className={kind === "at" ? "popup-list at-popup-list" : "popup-list"} ref={listRef}>
         {items.length === 0 ? (
           <div
             style={{
@@ -687,7 +711,7 @@ function Popup({
                 </>
               ) : (
                 <>
-                  <span>{(it as MentionItem).name}</span>
+                  <span className="mention-name">{(it as MentionItem).name}</span>
                   {(it as MentionItem).desc ? (
                     <div className="desc">{(it as MentionItem).desc}</div>
                   ) : null}

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -3787,11 +3787,11 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
 }
 .popup-list {
   overflow-y: auto;
-  overflow-x: auto;
+  overflow-x: hidden;
   padding: 4px;
 }
 .at-popup-list .popup-item {
-  min-width: max-content;
+  min-width: 0;
 }
 .popup-item {
   display: grid;
@@ -3820,11 +3820,19 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
 .popup-item .nm {
   font-weight: 500;
   color: var(--fg);
+  min-width: 0;
+  overflow: hidden;
 }
 .popup-item .nm .cmd {
   font-family: inherit;
   color: var(--accent);
   margin-right: 6px;
+}
+.popup-item .mention-name {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .popup-item .desc {
   display: block;

--- a/desktop/src/ui/composer-at-popup.test.tsx
+++ b/desktop/src/ui/composer-at-popup.test.tsx
@@ -160,4 +160,65 @@ describe("desktop Composer @ popup", () => {
 
     expect(container.querySelector(".popup-list.at-popup-list")).not.toBeNull();
   });
+
+  it("shows mention filenames first while preserving the full path for preview and pick", async () => {
+    const setDraft = vi.fn();
+    const onMentionPicked = vi.fn();
+    const onMentionPreview = vi.fn();
+    const { container, rerender, onMentionQuery } = renderComposer({
+      setDraft,
+      onMentionPicked,
+      onMentionPreview,
+    });
+    const textarea = container.querySelector("textarea");
+    if (!textarea) throw new Error("missing textarea");
+
+    fireEvent.change(textarea, { target: { value: "@foo" } });
+    await waitFor(() => expect(onMentionQuery).toHaveBeenCalled());
+    const nonce = onMentionQuery.mock.calls[0]?.[1] as number;
+
+    rerender(
+      <Composer
+        draft="@foo"
+        setDraft={setDraft}
+        onSend={vi.fn()}
+        onAbort={vi.fn()}
+        disabled={false}
+        busy={false}
+        modelLabel="deepseek-v4-flash"
+        reasoningEffort="high"
+        onModelChange={vi.fn()}
+        onEffortChange={vi.fn()}
+        editMode="review"
+        onEditModeChange={vi.fn()}
+        textareaRef={createRef<HTMLTextAreaElement>()}
+        slashCommands={[]}
+        onMentionQuery={onMentionQuery}
+        onMentionPreview={onMentionPreview}
+        onMentionPicked={onMentionPicked}
+        mentionResults={{ nonce, query: "foo", results: ["src/very/deep/foo.ts"] }}
+        workspaceDir="/repo"
+      />,
+    );
+
+    const row = await waitFor(() => {
+      const item = container.querySelector(".popup-item");
+      expect(item).not.toBeNull();
+      return item as HTMLElement;
+    });
+
+    expect(row.querySelector(".nm > span")?.textContent).toBe("foo.ts");
+    expect(row.querySelector(".desc")?.textContent).toBe("src/very/deep/");
+
+    fireEvent.mouseEnter(row);
+    expect(onMentionPreview).toHaveBeenCalledWith("src/very/deep/foo.ts", nonce);
+
+    fireEvent.click(row);
+    expect(onMentionPicked).toHaveBeenCalledWith("src/very/deep/foo.ts");
+    const draftUpdate = setDraft.mock.calls.at(-1)?.[0];
+    expect(typeof draftUpdate).toBe("function");
+    expect((draftUpdate as (current: string) => string)("@foo")).toBe(
+      "@src/very/deep/foo.ts ",
+    );
+  });
 });

--- a/desktop/src/ui/composer.tsx
+++ b/desktop/src/ui/composer.tsx
@@ -70,6 +70,7 @@ export type SlashCmd = {
 };
 export type MentionItem = {
   name: string;
+  path?: string;
   kind: "file" | "dir" | "url" | "agent" | "clip";
   desc?: string;
 };
@@ -158,6 +159,20 @@ function parentOfAtQuery(query: string): string | null {
   if (!dirContext) return null;
   const parentIdx = dirContext.lastIndexOf("/");
   return parentIdx >= 0 ? `${dirContext.slice(0, parentIdx)}/` : "";
+}
+
+function displayMentionPath(path: string): { name: string; desc?: string } {
+  const normalized = path.replace(/\\/g, "/");
+  const isDir = /[\\/]$/.test(path);
+  const trimmed = normalized.replace(/\/+$/, "");
+  if (!trimmed) return { name: path };
+  const slash = trimmed.lastIndexOf("/");
+  const base = slash >= 0 ? trimmed.slice(slash + 1) : trimmed;
+  const parent = slash >= 0 ? `${trimmed.slice(0, slash)}/` : "";
+  return {
+    name: isDir ? `${base}/` : base,
+    desc: parent || undefined,
+  };
 }
 
 function atIcon(k: MentionItem["kind"]) {
@@ -390,11 +405,15 @@ export function Composer({
   const atItems = useMemo<MentionItem[]>(() => {
     if (!popup || popup.kind !== "at") return [];
     if (!mentionResults || mentionResults.nonce !== popup.nonce) return [];
-    const base: MentionItem[] = mentionResults.results.map((path) => ({
-      name: path,
-      kind: path.endsWith("/") || path.endsWith("\\") ? "dir" : "file",
-      desc: path,
-    }));
+    const base: MentionItem[] = mentionResults.results.map((path) => {
+      const display = displayMentionPath(path);
+      return {
+        name: display.name,
+        path,
+        kind: path.endsWith("/") || path.endsWith("\\") ? "dir" : "file",
+        desc: display.desc,
+      };
+    });
     // "../" entry (#1019): one level up whenever the @ query is inside a subdir.
     const parent = parentOfAtQuery(popup.query);
     if (parent !== null) {
@@ -500,12 +519,9 @@ export function Composer({
         textareaRef.current?.focus();
         return;
       }
-      const spacerBefore = before && !before.endsWith(" ") ? " " : "";
-      const spacerAfter = after ? (after.startsWith(" ") ? "" : " ") : " ";
-      const insertion = `@${mention.name}`;
-      setDraft(`${before}${spacerBefore}${insertion}${spacerAfter}${after}`);
-      setPickedChips((prev) => new Map(prev).set(mention.name, "at"));
-      onMentionPicked?.(mention.name);
+      const mentionPath = mention.path ?? mention.name;
+      insertMention(mentionPath);
+      return;
     }
     activeRangeRef.current = null;
     setPopup(null);
@@ -586,7 +602,7 @@ export function Composer({
             setPopup({ kind: "at", query: parent, nonce });
             return;
           }
-          const dirPath = mention.name.replace(/\/+$/, "");
+          const dirPath = (mention.path ?? mention.name).replace(/[\\/]+$/, "");
           const newText = `@${dirPath}/`;
           const next = `${before}${newText}${after}`;
           setDraft(next);
@@ -848,7 +864,8 @@ export function Composer({
               onHover={(i, item) => {
                 setActiveIdx(i);
                 if (popup.kind === "at" && onMentionPreview) {
-                  const path = (item as MentionItem).name;
+                  const mention = item as MentionItem;
+                  const path = mention.path ?? mention.name;
                   onMentionPreview(path, popup.nonce);
                 }
               }}
@@ -885,7 +902,10 @@ function Popup({
   }, [activeIdx]);
 
   return (
-    <div className="popup" onMouseDown={(e) => e.preventDefault()}>
+    <div
+      className={kind === "at" ? "popup at-popup" : "popup"}
+      onMouseDown={(e) => e.preventDefault()}
+    >
       <div className="ph">
         <span className="tok">{kind === "slash" ? "/" : "@"}</span>
         <span>
@@ -932,7 +952,7 @@ function Popup({
                 </>
               ) : (
                 <>
-                  <span>{(it as MentionItem).name}</span>
+                  <span className="mention-name">{(it as MentionItem).name}</span>
                   {(it as MentionItem).desc ? (
                     <div className="desc">{(it as MentionItem).desc}</div>
                   ) : null}


### PR DESCRIPTION
## Summary
- Show @ mention search results as filename first with the parent directory below it.
- Preserve the full mention path for preview, directory drill-down, and insertion.
- Prevent horizontal overflow in mention popups and add the missing Japanese workdir string needed by the desktop build.

Fixes #2161

## Testing
- npm run verify
- npm --prefix desktop run build