### PR TITLE
fix(ui): apply themed background to input area and app surface

### DIFF
--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -8,6 +8,7 @@ import {
   loadToolRateLimit,
   normalizeMcpConfig,
   readConfig,
+  resolveThemePreference,
   searchEnabled,
 } from "../../config.js";
 import { loadDotenv } from "../../env.js";
@@ -36,6 +37,7 @@ import { KeystrokeProvider } from "../ui/keystroke-context.js";
 import { disableMouseMode, enableMouseMode } from "../ui/mouse-mode.js";
 import { installResizeBroadcaster } from "../ui/resize-broadcaster.js";
 import type { McpServerSummary } from "../ui/slash.js";
+import { THEMES, resolveThemeName } from "../ui/theme/tokens.js";
 import {
   type McpLifecycleNotice,
   type McpLifecycleSink,
@@ -391,6 +393,14 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
     });
   }
 
+  // Set terminal default background to match the theme so that empty areas
+  // below Ink's rendered content (main-screen mode) blend with the UI.
+  const themeName = resolveThemeName(resolveThemePreference(readConfig().theme));
+  const themeBg = THEMES[themeName].surface.bg;
+  if (process.stdout.isTTY && typeof themeBg === "string" && themeBg.startsWith("#")) {
+    process.stdout.write(`\x1b]11;${themeBg}\x07`);
+  }
+
   const { waitUntilExit } = render(
     <Root
       initialKey={initialKey}
@@ -414,6 +424,10 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
   try {
     await waitUntilExit();
   } finally {
+    // Restore terminal default background color on exit.
+    if (process.stdout.isTTY) {
+      process.stdout.write("\x1b]111\x07");
+    }
     disableMouseMode();
     await runtime.closeAll();
     qqChannel?.stop();

--- a/src/cli/commands/mcp-browse.tsx
+++ b/src/cli/commands/mcp-browse.tsx
@@ -12,6 +12,7 @@ import {
   specStringFor,
 } from "../../mcp/registry-fetch.js";
 import type { RegistryEntry } from "../../mcp/registry-types.js";
+import { FG } from "../ui/theme/tokens.js";
 
 const VISIBLE_ROWS = 12;
 
@@ -175,16 +176,18 @@ function McpBrowseApp() {
         <Text bold color="ansi:cyan">
           ◈ MCP marketplace
         </Text>
-        <Text dim>{`  ·  ${state.status}`}</Text>
+        <Text color={FG.faint}>{`  ·  ${state.status}`}</Text>
       </Box>
       <Box marginTop={1}>
         <Text>search: </Text>
         <Text color="ansi:white">{state.query || "(type to filter)"}</Text>
-        <Text dim>{`  ${filtered.length} match${filtered.length === 1 ? "" : "es"}`}</Text>
+        <Text
+          color={FG.faint}
+        >{`  ${filtered.length} match${filtered.length === 1 ? "" : "es"}`}</Text>
       </Box>
       <Box marginTop={1} flexDirection="column">
         {window.length === 0 ? (
-          <Text dim>{state.loading ? "loading…" : "no entries"}</Text>
+          <Text color={FG.faint}>{state.loading ? "loading…" : "no entries"}</Text>
         ) : (
           window.map((e, i) => {
             const idx = (start || 0) + i;
@@ -196,7 +199,7 @@ function McpBrowseApp() {
               <Box key={e.name}>
                 <Text color={active ? "ansi:cyan" : undefined}>{active ? "▸ " : "  "}</Text>
                 <Text bold={active}>{e.name.padEnd(40).slice(0, 40)}</Text>
-                <Text dim>{` ${tag}${pop}`}</Text>
+                <Text color={FG.faint}>{` ${tag}${pop}`}</Text>
               </Box>
             );
           })
@@ -206,17 +209,19 @@ function McpBrowseApp() {
         <Box marginTop={1} flexDirection="column">
           <Text bold color="ansi:white">
             {overlay?.[selected.name]?.title ?? selected.title}
-            {overlay?.[selected.name] ? <Text dim>{`  \u00b7  ${selected.title}`}</Text> : null}
+            {overlay?.[selected.name] ? (
+              <Text color={FG.faint}>{`  \u00b7  ${selected.title}`}</Text>
+            ) : null}
           </Text>
-          <Text dim>
+          <Text color={FG.faint}>
             {overlay?.[selected.name]?.description ?? selected.description?.slice(0, 160) ?? null}
           </Text>
           {selected.install ? (
-            <Text dim>
+            <Text color={FG.faint}>
               {`spec: ${selected.install.runtime} ${selected.install.packageId ?? selected.install.url ?? "—"} · ${selected.install.transport}`}
             </Text>
           ) : (
-            <Text dim>(smithery listing — install info not exposed)</Text>
+            <Text color={FG.faint}>(smithery listing — install info not exposed)</Text>
           )}
           {selected.install?.requiredEnv?.length ? (
             <Text color="ansi:yellow">{`needs: ${selected.install.requiredEnv.join(", ")}`}</Text>
@@ -224,7 +229,9 @@ function McpBrowseApp() {
         </Box>
       ) : null}
       <Box marginTop={1}>
-        <Text dim>type to filter · ↑↓ pick · enter install · tab load more · esc quit</Text>
+        <Text color={FG.faint}>
+          type to filter · ↑↓ pick · enter install · tab load more · esc quit
+        </Text>
       </Box>
     </Box>
   );

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -201,7 +201,7 @@ import { AgentStoreProvider, useAgentState, useAgentStore } from "./state/provid
 import { VerboseContext } from "./state/verbose-context.js";
 import { ThemeProvider } from "./theme/context.js";
 import { listThemeNames } from "./theme/tokens.js";
-import { FG, type ThemeName } from "./theme/tokens.js";
+import { FG, SURFACE, type ThemeName } from "./theme/tokens.js";
 import { TickerProvider, useSlowTick } from "./ticker.js";
 import { handleTurnInterrupt } from "./turn-interrupt.js";
 import { codeUndoContextMessage, codeUndoInfo } from "./undo-context.js";
@@ -4286,7 +4286,7 @@ function AppInner({
       <TickerProvider disabled={tickerSuspended}>
         <InflightProvider inflight={loop.inflight}>
           <Box flexDirection="row">
-            <Box flexDirection="column" flexGrow={1}>
+            <Box flexDirection="column" flexGrow={1} backgroundColor={SURFACE.bg}>
               <Box flexDirection="column" flexGrow={1}>
                 <LiveExpandContext.Provider value={liveExpand}>
                   <VerboseContext.Provider value={verboseMode}>

--- a/src/cli/ui/AtMentionSuggestions.tsx
+++ b/src/cli/ui/AtMentionSuggestions.tsx
@@ -3,7 +3,7 @@ import { Box, Text } from "ink";
 import React from "react";
 import { t } from "../../i18n/index.js";
 import { GLYPH, useColor } from "./theme.js";
-import { SURFACE } from "./theme/tokens.js";
+import { FG, SURFACE } from "./theme/tokens.js";
 import type { AtPickerEntry, AtPickerState } from "./useCompletionPickers.js";
 
 export interface AtMentionSuggestionsProps {
@@ -42,7 +42,7 @@ export function AtMentionSuggestions({
           isSelected={windowStart + i === selectedIndex}
         />
       ))}
-      {hiddenBelow > 0 ? <Text dim>{`   ↓ ${hiddenBelow} below`}</Text> : null}
+      {hiddenBelow > 0 ? <Text color={FG.faint}>{`   ↓ ${hiddenBelow} below`}</Text> : null}
       <FooterRow isBrowse={isBrowse} hasFolder={shown.some((e) => e.isDir)} />
     </Box>
   );
@@ -70,8 +70,8 @@ function HeaderRow({
     return (
       <Box>
         {lead}
-        <Text dim>{`${where}  ${counter}`}</Text>
-        {hiddenAbove > 0 ? <Text dim>{`   ↑ ${hiddenAbove} above`}</Text> : null}
+        <Text color={FG.faint}>{`${where}  ${counter}`}</Text>
+        {hiddenAbove > 0 ? <Text color={FG.faint}>{`   ↑ ${hiddenAbove} above`}</Text> : null}
       </Box>
     );
   }
@@ -81,8 +81,8 @@ function HeaderRow({
   return (
     <Box>
       {lead}
-      <Text dim>{status}</Text>
-      {hiddenAbove > 0 ? <Text dim>{`   ↑ ${hiddenAbove} above`}</Text> : null}
+      <Text color={FG.faint}>{status}</Text>
+      {hiddenAbove > 0 ? <Text color={FG.faint}>{`   ↑ ${hiddenAbove} above`}</Text> : null}
     </Box>
   );
 }
@@ -103,7 +103,7 @@ function EmptyRow({ state, color }: { state: AtPickerState; color: ReturnType<ty
   if (state.searching) {
     return (
       <Box>
-        <Text dim>{t("atMentions.scanning")}</Text>
+        <Text color={FG.faint}>{t("atMentions.scanning")}</Text>
       </Box>
     );
   }
@@ -131,7 +131,7 @@ function EntryRow({ entry, isSelected }: { entry: AtPickerEntry; isSelected: boo
       <Text color={labelColor} bold={isSelected}>
         {labelText.padEnd(20)}
       </Text>
-      {entry.dirSuffix ? <Text dim>{`  ${entry.dirSuffix}`}</Text> : null}
+      {entry.dirSuffix ? <Text color={FG.faint}>{`  ${entry.dirSuffix}`}</Text> : null}
     </Box>
   );
 }
@@ -140,7 +140,7 @@ function FooterRow({ isBrowse, hasFolder }: { isBrowse: boolean; hasFolder: bool
   const hintKey = isBrowse && hasFolder ? "atMentions.footerBrowse" : "atMentions.footerInsert";
   return (
     <Box marginTop={0}>
-      <Text dim>{`  ${t(hintKey)}`}</Text>
+      <Text color={FG.faint}>{`  ${t(hintKey)}`}</Text>
     </Box>
   );
 }

--- a/src/cli/ui/ComposerArea.tsx
+++ b/src/cli/ui/ComposerArea.tsx
@@ -9,6 +9,7 @@ import React from "react";
 import type { EditMode } from "../../config.js";
 import type { JobRegistry } from "../../tools/jobs.js";
 import { useRenderTrace } from "./render-trace.js";
+import { SURFACE } from "./theme/tokens.js";
 
 import { AtMentionSuggestions } from "./AtMentionSuggestions.js";
 import { PromptInput } from "./PromptInput.js";
@@ -110,7 +111,12 @@ export const ComposerArea: React.FC<ComposerAreaProps> = React.memo(
   }) => {
     useRenderTrace("ComposerArea");
     const inputArea = (
-      <Box flexDirection="column" flexShrink={0} flexWrap="nowrap">
+      <Box
+        flexDirection="column"
+        flexShrink={0}
+        flexWrap="nowrap"
+        backgroundColor={SURFACE.bgInput}
+      >
         <Box flexDirection="column" flexShrink={0} flexWrap="nowrap">
           {slashMatches !== null ? (
             <SlashSuggestions

--- a/src/cli/ui/DiffApp.tsx
+++ b/src/cli/ui/DiffApp.tsx
@@ -19,6 +19,7 @@ import {
   findPrevDivergence,
 } from "../../transcript/diff.js";
 import { RecordView } from "./RecordView.js";
+import { FG } from "./theme/tokens.js";
 
 export interface DiffAppProps {
   report: DiffReport;
@@ -86,7 +87,7 @@ export function DiffApp({ report }: DiffAppProps) {
       ) : null}
 
       <Box marginTop={1} paddingX={1} borderStyle="single" borderColor="ansi:blackBright">
-        <Text dim>
+        <Text color={FG.faint}>
           <Text bold>j</Text>/<Text bold>\u2193</Text> next \u00b7 <Text bold>k</Text>/
           <Text bold>\u2191</Text> prev \u00b7 <Text bold>n</Text> next-diverge \u00b7{" "}
           <Text bold>N</Text>/<Text bold>p</Text> prev-diverge \u00b7 <Text bold>g</Text>/
@@ -129,19 +130,19 @@ function DiffHeader({ report }: { report: DiffReport }) {
           <Text color="ansi:cyan" bold>
             {t("diffApp.title")}
           </Text>
-          <Text dim> \u00b7 A=</Text>
+          <Text color={FG.faint}> \u00b7 A=</Text>
           <Text color="ansi:blue">{a.label}</Text>
-          <Text dim> vs B=</Text>
+          <Text color={FG.faint}> vs B=</Text>
           <Text color="ansi:magenta">{b.label}</Text>
         </Text>
-        <Text dim>{t("diffApp.turnsAligned", { count: report.pairs.length })}</Text>
+        <Text color={FG.faint}>{t("diffApp.turnsAligned", { count: report.pairs.length })}</Text>
       </Box>
 
       <Box marginTop={1} gap={3}>
         <Text>
-          <Text dim>cache </Text>
+          <Text color={FG.faint}>cache </Text>
           <Text>{(a.stats.cacheHitRatio * 100).toFixed(1)}%</Text>
-          <Text dim> → </Text>
+          <Text color={FG.faint}> → </Text>
           <Text>{(b.stats.cacheHitRatio * 100).toFixed(1)}%</Text>
           <Text color={cacheDelta >= 0 ? "ansi:green" : "ansi:red"} bold>
             {"  "}
@@ -150,9 +151,9 @@ function DiffHeader({ report }: { report: DiffReport }) {
           </Text>
         </Text>
         <Text>
-          <Text dim>cost </Text>
+          <Text color={FG.faint}>cost </Text>
           <Text>${a.stats.totalCostUsd.toFixed(6)}</Text>
-          <Text dim> → </Text>
+          <Text color={FG.faint}> → </Text>
           <Text>${b.stats.totalCostUsd.toFixed(6)}</Text>
           <Text color={costDelta <= 0 ? "ansi:green" : "ansi:red"} bold>
             {"  "}
@@ -161,7 +162,7 @@ function DiffHeader({ report }: { report: DiffReport }) {
           </Text>
         </Text>
         <Text>
-          <Text dim>model calls </Text>
+          <Text color={FG.faint}>model calls </Text>
           <Text>
             {a.stats.turns} → {b.stats.turns}
           </Text>
@@ -170,7 +171,7 @@ function DiffHeader({ report }: { report: DiffReport }) {
 
       {prefixLine ? (
         <Box marginTop={1}>
-          <Text dim italic>
+          <Text color={FG.faint} italic>
             {prefixLine}
           </Text>
         </Box>
@@ -201,7 +202,7 @@ function Pane({
       </Text>
       {records.length === 0 ? (
         <Box marginTop={1}>
-          <Text dim italic>
+          <Text color={FG.faint} italic>
             {t("diffApp.paneEmpty")}
           </Text>
         </Box>

--- a/src/cli/ui/EditConfirm.tsx
+++ b/src/cli/ui/EditConfirm.tsx
@@ -7,6 +7,7 @@ import { DenyContextInput } from "./DenyContextInput.js";
 import { SplitDiff } from "./SplitDiff.js";
 import { ApprovalCard } from "./cards/ApprovalCard.js";
 import { useKeystroke } from "./keystroke-context.js";
+import { FG } from "./theme/tokens.js";
 
 export type EditReviewChoice = "apply" | "reject" | "apply-rest-of-turn" | "flip-to-auto";
 
@@ -133,7 +134,7 @@ export function EditConfirm({ block, onChoose }: EditConfirmProps) {
       footerHint={t("editConfirm.footer")}
     >
       {hiddenAbove > 0 ? (
-        <Text dim>
+        <Text color={FG.faint}>
           {t(hiddenAbove === 1 ? "editConfirm.linesAbove" : "editConfirm.linesAbovePlural", {
             count: hiddenAbove,
           })}
@@ -148,10 +149,10 @@ export function EditConfirm({ block, onChoose }: EditConfirmProps) {
         <Text color="#bef0c8" backgroundColor="#0c2718">
           {t("editConfirm.newLabel")}
         </Text>
-        <Text dim>{t("editConfirm.sideBySide")}</Text>
+        <Text color={FG.faint}>{t("editConfirm.sideBySide")}</Text>
       </Box>
       {hiddenBelow > 0 ? (
-        <Text dim>
+        <Text color={FG.faint}>
           {t(hiddenBelow === 1 ? "editConfirm.linesBelow" : "editConfirm.linesBelowPlural", {
             count: hiddenBelow,
           })}

--- a/src/cli/ui/McpBrowser.tsx
+++ b/src/cli/ui/McpBrowser.tsx
@@ -9,6 +9,7 @@ import { healthBadge } from "./mcp-health.js";
 import { type ApplyAppend, kickOffMcpReconnect } from "./mcp-reconnect-kickoff.js";
 import type { McpServerSummary } from "./slash/types.js";
 import { COLOR } from "./theme.js";
+import { FG } from "./theme/tokens.js";
 
 export interface McpBrowserProps {
   servers: McpServerSummary[];
@@ -59,12 +60,12 @@ export function McpBrowser({
           {t("mcpBrowser.title")}
         </Text>
         <Text
-          dim
+          color={FG.faint}
         >{`  \u00b7  ${configPath}  \u00b7  ${t("mcpBrowser.serverCount", { count: servers.length, s: servers.length === 1 ? "" : "s" })}`}</Text>
       </Box>
       <Box marginTop={1} flexDirection="column">
         {servers.length === 0 ? (
-          <Text dim>{t("mcpBrowser.empty")}</Text>
+          <Text color={FG.faint}>{t("mcpBrowser.empty")}</Text>
         ) : (
           servers.map((s, i) => (
             <ServerRow key={s.label + s.spec} server={s} active={i === index} />
@@ -72,7 +73,7 @@ export function McpBrowser({
         )}
       </Box>
       <Box marginTop={1}>
-        <Text dim>{t("mcpBrowser.footer")}</Text>
+        <Text color={FG.faint}>{t("mcpBrowser.footer")}</Text>
       </Box>
     </Box>
   );
@@ -94,11 +95,11 @@ function ServerRow({ server, active }: { server: McpServerSummary; active: boole
           {label.padEnd(14)}
         </Text>
         <Text color={health.color}>{`${health.glyph} ${health.label}`}</Text>
-        <Text dim>{`      ${counts}`}</Text>
+        <Text color={FG.faint}>{`      ${counts}`}</Text>
       </Box>
       {active ? (
         <Box>
-          <Text dim>{`     ${capabilityList(server)}`}</Text>
+          <Text color={FG.faint}>{`     ${capabilityList(server)}`}</Text>
         </Box>
       ) : null}
     </Box>

--- a/src/cli/ui/McpHub.tsx
+++ b/src/cli/ui/McpHub.tsx
@@ -10,6 +10,7 @@ import { useKeystroke } from "./keystroke-context.js";
 import type { ApplyAppend } from "./mcp-reconnect-kickoff.js";
 import type { McpServerSummary } from "./slash/types.js";
 import { COLOR } from "./theme.js";
+import { FG } from "./theme/tokens.js";
 
 export type McpHubTab = "live" | "marketplace";
 
@@ -62,7 +63,7 @@ export function McpHub({
         />
         <Text>{"  "}</Text>
         <TabPill label={t("handlers.mcp.marketplaceTab")} active={tab === "marketplace"} />
-        <Text dim>{`   ${t("handlers.mcp.tabHint")}`}</Text>
+        <Text color={FG.faint}>{`   ${t("handlers.mcp.tabHint")}`}</Text>
       </Box>
       {tab === "live" ? (
         <McpBrowser
@@ -93,5 +94,5 @@ function TabPill({ label, count, active }: { label: string; count?: number; acti
       </Text>
     );
   }
-  return <Text dim>{` ${text} `}</Text>;
+  return <Text color={FG.faint}>{` ${text} `}</Text>;
 }

--- a/src/cli/ui/McpMarketplace.tsx
+++ b/src/cli/ui/McpMarketplace.tsx
@@ -16,6 +16,7 @@ import type { RegistryEntry } from "../../mcp/registry-types.js";
 import { type PickerBroadcastPorts, usePickerBroadcast } from "./dashboard/use-picker-broadcast.js";
 import { useKeystroke } from "./keystroke-context.js";
 import { COLOR } from "./theme.js";
+import { FG } from "./theme/tokens.js";
 
 const VISIBLE_ROWS = 10;
 
@@ -364,18 +365,18 @@ export function McpMarketplace({ onClose, postInfo, reloadMcp, pickerPorts }: Mc
         <Text bold color={COLOR.brand}>
           ◈ MCP marketplace
         </Text>
-        <Text dim>{`  ·  ${state.status}`}</Text>
+        <Text color={FG.faint}>{`  ·  ${state.status}`}</Text>
       </Box>
       <Box marginTop={1}>
         <Text>{t("mcpMarketplace.filter")}</Text>
         <Text>{state.query || t("mcpMarketplace.filterPlaceholder")}</Text>
         <Text
-          dim
+          color={FG.faint}
         >{`  ${t(filtered.length === 1 ? "mcpMarketplace.matchSingular" : "mcpMarketplace.matchPlural", { n: filtered.length })}`}</Text>
       </Box>
       <Box marginTop={1} flexDirection="column">
         {window.length === 0 ? (
-          <Text dim>
+          <Text color={FG.faint}>
             {state.loading ? t("mcpMarketplace.loading") : t("mcpMarketplace.noEntries")}
           </Text>
         ) : (
@@ -391,7 +392,7 @@ export function McpMarketplace({ onClose, postInfo, reloadMcp, pickerPorts }: Mc
               <Box key={e.name}>
                 <Text color={active ? COLOR.brand : undefined}>{active ? "▸ " : "  "}</Text>
                 <Text bold={active}>{e.name.padEnd(38).slice(0, 38)}</Text>
-                <Text dim>{` ${tag}${pop}${installedBadge}`}</Text>
+                <Text color={FG.faint}>{` ${tag}${pop}${installedBadge}`}</Text>
               </Box>
             );
           })
@@ -401,13 +402,15 @@ export function McpMarketplace({ onClose, postInfo, reloadMcp, pickerPorts }: Mc
         <Box marginTop={1} flexDirection="column">
           <Text bold>
             {overlay?.[selected.name]?.title ?? selected.title}
-            {overlay?.[selected.name] ? <Text dim>{`  \u00b7  ${selected.title}`}</Text> : null}
+            {overlay?.[selected.name] ? (
+              <Text color={FG.faint}>{`  \u00b7  ${selected.title}`}</Text>
+            ) : null}
           </Text>
-          <Text dim>
+          <Text color={FG.faint}>
             {overlay?.[selected.name]?.description ?? selected.description?.slice(0, 200) ?? null}
           </Text>
           {selected.install ? (
-            <Text dim>
+            <Text color={FG.faint}>
               {t("mcpMarketplace.specLine", {
                 runtime: selected.install.runtime,
                 id: selected.install.packageId ?? selected.install.url ?? "\u2014",
@@ -415,7 +418,7 @@ export function McpMarketplace({ onClose, postInfo, reloadMcp, pickerPorts }: Mc
               })}
             </Text>
           ) : (
-            <Text dim>{t("mcpMarketplace.smitheryDetail")}</Text>
+            <Text color={FG.faint}>{t("mcpMarketplace.smitheryDetail")}</Text>
           )}
           {selected.install?.requiredEnv?.length ? (
             <Text color="ansi:yellow">
@@ -425,7 +428,7 @@ export function McpMarketplace({ onClose, postInfo, reloadMcp, pickerPorts }: Mc
         </Box>
       ) : null}
       <Box marginTop={1}>
-        <Text dim>{t("mcpMarketplace.footerHint")}</Text>
+        <Text color={FG.faint}>{t("mcpMarketplace.footerHint")}</Text>
       </Box>
     </Box>
   );

--- a/src/cli/ui/PlanReviseConfirm.tsx
+++ b/src/cli/ui/PlanReviseConfirm.tsx
@@ -4,6 +4,7 @@ import { t } from "../../i18n/index.js";
 import type { PlanStep } from "../../tools/plan.js";
 import { SingleSelect } from "./Select.js";
 import { ApprovalCard } from "./cards/ApprovalCard.js";
+import { FG } from "./theme/tokens.js";
 
 export type ReviseChoice = "accept" | "reject";
 
@@ -73,7 +74,7 @@ function PlanReviseConfirmInner({
       </Box>
       {summary ? (
         <Box marginBottom={1}>
-          <Text dim>{t("planReviseConfirm.updatedSummary", { summary })}</Text>
+          <Text color={FG.faint}>{t("planReviseConfirm.updatedSummary", { summary })}</Text>
         </Box>
       ) : null}
       <Box marginBottom={1} flexDirection="column">
@@ -89,10 +90,10 @@ function PlanReviseConfirmInner({
               <Text color={prefixColor} bold>
                 {`${prefix} `}
               </Text>
-              <Text color={risk.color} bold dim={dim}>
+              <Text color={dim ? FG.faint : risk.color} bold>
                 {risk.dots}
               </Text>
-              <Text dim={dim} strikethrough={strike}>
+              <Text color={dim ? FG.faint : undefined} strikethrough={strike}>
                 {` ${row.step.id} \u00b7 ${row.step.title}`}
               </Text>
             </Box>

--- a/src/cli/ui/PlanStepList.tsx
+++ b/src/cli/ui/PlanStepList.tsx
@@ -33,6 +33,7 @@ import { t } from "../../i18n/index.js";
 import type { PlanStep, PlanStepRisk } from "../../tools/plan.js";
 import { CharBar } from "./char-bar.js";
 import { COLOR, GLYPH } from "./theme.js";
+import { FG } from "./theme/tokens.js";
 
 export type StepStatus = "pending" | "running" | "done" | "skipped";
 
@@ -102,7 +103,7 @@ function PlanStepListInner({ steps, statuses, focusStepId }: PlanStepListProps) 
   return (
     <Box flexDirection="column">
       <Box>
-        <Text dim>
+        <Text color={FG.faint}>
           {showProgress
             ? t(
                 total === 1
@@ -125,16 +126,14 @@ function PlanStepListInner({ steps, statuses, focusStepId }: PlanStepListProps) 
           const titleDim = status === "done" || status === "skipped";
           return (
             <Box key={step.id}>
-              <Text color={COLOR.info} dim>
-                {isLast ? GLYPH.branchEnd : GLYPH.branch}
-              </Text>
+              <Text color={FG.faint}>{isLast ? GLYPH.branchEnd : GLYPH.branch}</Text>
               <Text>{"  "}</Text>
               <Text color={sg.color} bold={status === "running" || isCur}>
                 {sg.glyph}
               </Text>
               <Text>{"  "}</Text>
               <Text
-                dim={titleDim}
+                color={titleDim ? FG.faint : undefined}
                 bold={isCur || status === "running"}
                 strikethrough={status === "done" || status === "skipped"}
               >

--- a/src/cli/ui/PromptInput.tsx
+++ b/src/cli/ui/PromptInput.tsx
@@ -244,6 +244,7 @@ export function PromptInput({
       borderLeft={false}
       borderRight={false}
       borderColor={inputActive ? TONE.brand : FG.faint}
+      backgroundColor={SURFACE.bgInput}
       borderText={
         borderLabel ? { content: borderLabel, position: "top", align: "end", offset: 2 } : undefined
       }

--- a/src/cli/ui/RecordView.tsx
+++ b/src/cli/ui/RecordView.tsx
@@ -4,6 +4,7 @@ import { Box, Text } from "ink";
 import React from "react";
 import { t } from "../../i18n/index.js";
 import type { TranscriptRecord } from "../../transcript/log.js";
+import { FG } from "./theme/tokens.js";
 
 export interface RecordViewProps {
   rec: TranscriptRecord;
@@ -43,7 +44,7 @@ export function RecordView({ rec, compact = false }: RecordViewProps) {
             {t("recordView.assistant")}
           </Text>
           {rec.cost !== undefined ? (
-            <Text dim>
+            <Text color={FG.faint}>
               {"  $"}
               {rec.cost.toFixed(6)}
             </Text>
@@ -53,7 +54,7 @@ export function RecordView({ rec, compact = false }: RecordViewProps) {
         {rec.content ? (
           <Text>{rec.content}</Text>
         ) : (
-          <Text dim italic>
+          <Text color={FG.faint} italic>
             {t("recordView.toolCallOnly")}
           </Text>
         )}
@@ -69,12 +70,12 @@ export function RecordView({ rec, compact = false }: RecordViewProps) {
           {">"}
         </Text>
         {rec.args ? (
-          <Text dim>
+          <Text color={FG.faint}>
             {t("recordView.argsLabel")}
             {truncate(rec.args, toolArgsMax)}
           </Text>
         ) : null}
-        <Text dim>
+        <Text color={FG.faint}>
           {t("recordView.resultArrow")}
           {truncate(rec.content, toolContentMax)}
         </Text>
@@ -97,7 +98,7 @@ export function RecordView({ rec, compact = false }: RecordViewProps) {
   }
   return (
     <Box>
-      <Text dim>
+      <Text color={FG.faint}>
         [{rec.role}] {rec.content}
       </Text>
     </Box>
@@ -113,7 +114,7 @@ function CacheBadge({ usage }: { usage: NonNullable<TranscriptRecord["usage"]> }
   const color = pct >= 70 ? "ansi:green" : pct >= 40 ? "ansi:yellow" : "ansi:red";
   return (
     <Text>
-      <Text dim>{t("recordView.cache")}</Text>
+      <Text color={FG.faint}>{t("recordView.cache")}</Text>
       <Text color={color}>{pct.toFixed(1)}%</Text>
     </Text>
   );

--- a/src/cli/ui/ReplayApp.tsx
+++ b/src/cli/ui/ReplayApp.tsx
@@ -15,6 +15,7 @@ import type { TranscriptMeta } from "../../transcript/log.js";
 import { type TurnPage, computeCumulativeStats } from "../../transcript/replay.js";
 import { RecordView } from "./RecordView.js";
 import { StatsPanel } from "./StatsPanel.js";
+import { FG } from "./theme/tokens.js";
 
 export interface ReplayAppProps {
   meta: TranscriptMeta | null;
@@ -86,7 +87,7 @@ export function ReplayApp({ meta, pages }: ReplayAppProps) {
             {progressLabel}
           </Text>
           {meta ? (
-            <Text dim>
+            <Text color={FG.faint}>
               {meta.source}
               {meta.task ? ` · ${meta.task}` : ""}
               {meta.mode ? ` · ${meta.mode}` : ""}
@@ -99,14 +100,14 @@ export function ReplayApp({ meta, pages }: ReplayAppProps) {
             {({ key, rec }) => <RecordView key={key} rec={rec} />}
           </Static>
         ) : (
-          <Text dim italic>
+          <Text color={FG.faint} italic>
             {t("replayApp.noRecords")}
           </Text>
         )}
       </Box>
 
       <Box marginTop={1} paddingX={1} borderStyle="single" borderColor="ansi:blackBright">
-        <Text dim>
+        <Text color={FG.faint}>
           <Text bold>j</Text>/<Text bold>↓</Text>/<Text bold>space</Text> next · <Text bold>k</Text>
           /<Text bold>↑</Text> prev · <Text bold>g</Text> first · <Text bold>G</Text> last ·{" "}
           <Text bold>q</Text> quit

--- a/src/cli/ui/Select.tsx
+++ b/src/cli/ui/Select.tsx
@@ -5,6 +5,7 @@ import React, { useState } from "react";
 import { useKeystroke } from "./keystroke-context.js";
 import type { KeyEvent } from "./stdin-reader.js";
 import { type UiColor, useColor } from "./theme.js";
+import { FG } from "./theme/tokens.js";
 
 export interface SelectItem<V extends string = string> {
   value: V;
@@ -78,7 +79,7 @@ export function SingleSelect<V extends string>({
       ))}
       {footer ? (
         <Box marginTop={1}>
-          <Text dim>{footer}</Text>
+          <Text color={FG.faint}>{footer}</Text>
         </Box>
       ) : null}
     </Box>
@@ -155,7 +156,7 @@ export function MultiSelect<V extends string>({
       })}
       {footer ? (
         <Box marginTop={1}>
-          <Text dim>{footer}</Text>
+          <Text color={FG.faint}>{footer}</Text>
         </Box>
       ) : null}
     </Box>
@@ -180,23 +181,23 @@ function SelectRow<V extends string>({
   if (inlineHint) {
     return (
       <Box flexDirection="row" flexWrap="nowrap" minHeight={1}>
-        <Text color={rowColor} bold={active} dim={item.disabled} wrap="truncate">
+        <Text color={item.disabled ? FG.faint : rowColor} bold={active} wrap="truncate">
           {labelText}
         </Text>
-        {item.hint ? <Text dim wrap="truncate">{`  ${item.hint}`}</Text> : null}
+        {item.hint ? <Text color={FG.faint} wrap="truncate">{`  ${item.hint}`}</Text> : null}
       </Box>
     );
   }
   return (
     <Box flexDirection="column">
       <Box>
-        <Text color={rowColor} bold={active} dim={item.disabled}>
+        <Text color={item.disabled ? FG.faint : rowColor} bold={active}>
           {labelText}
         </Text>
       </Box>
       {item.hint ? (
         <Box paddingLeft={marker.length + 1}>
-          <Text dim>{item.hint}</Text>
+          <Text color={FG.faint}>{item.hint}</Text>
         </Box>
       ) : null}
     </Box>

--- a/src/cli/ui/Setup.tsx
+++ b/src/cli/ui/Setup.tsx
@@ -4,6 +4,7 @@ import { defaultConfigPath, isPlausibleKey, redactKey, saveApiKey } from "../../
 import { t } from "../../i18n/index.js";
 import { MaskedInput } from "./MaskedInput.js";
 import { COLOR, GLYPH, GRADIENT } from "./theme.js";
+import { FG } from "./theme/tokens.js";
 
 export interface SetupProps {
   onReady: (apiKey: string) => void;
@@ -47,10 +48,12 @@ export function Setup({ onReady }: SetupProps) {
         <Text color={COLOR.info}>{t("wizard.apiKeyPrompt")}</Text>
       </Box>
       <Box>
-        <Text dim>{`  ${t("wizard.apiKeyGetOne")}`}</Text>
+        <Text color={FG.faint}>{`  ${t("wizard.apiKeyGetOne")}`}</Text>
       </Box>
       <Box>
-        <Text dim>{t("wizard.apiKeySavedLocally", { path: defaultConfigPath() })}</Text>
+        <Text color={FG.faint}>
+          {t("wizard.apiKeySavedLocally", { path: defaultConfigPath() })}
+        </Text>
       </Box>
       <Box marginTop={1}>
         <Text bold color={COLOR.brand}>
@@ -76,11 +79,11 @@ export function Setup({ onReady }: SetupProps) {
         </Box>
       ) : value ? (
         <Box marginTop={1}>
-          <Text dim>{t("wizard.apiKeyPreview", { redacted: redactKey(value) })}</Text>
+          <Text color={FG.faint}>{t("wizard.apiKeyPreview", { redacted: redactKey(value) })}</Text>
         </Box>
       ) : null}
       <Box marginTop={1}>
-        <Text dim>{t("wizard.exitHint")}</Text>
+        <Text color={FG.faint}>{t("wizard.exitHint")}</Text>
       </Box>
     </Box>
   );

--- a/src/cli/ui/SlashArgPicker.tsx
+++ b/src/cli/ui/SlashArgPicker.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { t } from "../../i18n/index.js";
 import type { SlashCommandSpec } from "./slash.js";
 import { GLYPH, useColor } from "./theme.js";
-import { SURFACE } from "./theme/tokens.js";
+import { FG, SURFACE } from "./theme/tokens.js";
 import type { AtPickerEntry } from "./useCompletionPickers.js";
 
 export interface SlashArgPickerProps {
@@ -65,8 +65,8 @@ export function SlashArgPicker({
       <Text color={color.accent} bold>
         {`/${spec.cmd}`}
       </Text>
-      {headerArgsHint ? <Text dim>{` ${headerArgsHint}`}</Text> : null}
-      <Text dim>{`  ${headerSummary}`}</Text>
+      {headerArgsHint ? <Text color={FG.faint}>{` ${headerArgsHint}`}</Text> : null}
+      <Text color={FG.faint}>{`  ${headerSummary}`}</Text>
     </Box>
   );
 
@@ -88,7 +88,7 @@ export function SlashArgPicker({
             {GLYPH.warn}
           </Text>
           <Text color={color.warn}>{t("slashArgPicker.noMatch", { partial })}</Text>
-          <Text dim>{t("slashArgPicker.keepTyping")}</Text>
+          <Text color={FG.faint}>{t("slashArgPicker.keepTyping")}</Text>
         </Box>
       </Box>
     );
@@ -105,7 +105,7 @@ export function SlashArgPicker({
     <Box flexDirection="column" paddingX={1} marginTop={1}>
       {headerRow}
       {hiddenAbove > 0 ? (
-        <Text dim>{t("slashArgPicker.above", { hidden: hiddenAbove })}</Text>
+        <Text color={FG.faint}>{t("slashArgPicker.above", { hidden: hiddenAbove })}</Text>
       ) : null}
       {shown.map((value, i) => {
         const idx = windowStart + i;
@@ -115,10 +115,10 @@ export function SlashArgPicker({
         );
       })}
       {hiddenBelow > 0 ? (
-        <Text dim>{t("slashArgPicker.below", { hidden: hiddenBelow })}</Text>
+        <Text color={FG.faint}>{t("slashArgPicker.below", { hidden: hiddenBelow })}</Text>
       ) : null}
       <Box marginTop={0}>
-        <Text dim>{t("slashArgPicker.footer")}</Text>
+        <Text color={FG.faint}>{t("slashArgPicker.footer")}</Text>
       </Box>
     </Box>
   );
@@ -139,10 +139,10 @@ function ArgRow({
       <Text color={isSelected ? color.primary : color.info} bold={isSelected}>
         {isSelected ? `${GLYPH.cur} ` : "  "}
       </Text>
-      <Text color={isSelected ? color.user : color.info} bold={isSelected} dim={!isSelected}>
+      <Text color={isSelected ? color.user : FG.faint} bold={isSelected}>
         {value}
       </Text>
-      {isDir ? <Text dim>/</Text> : null}
+      {isDir ? <Text color={FG.faint}>/</Text> : null}
     </Box>
   );
 }

--- a/src/cli/ui/SlashSuggestions.tsx
+++ b/src/cli/ui/SlashSuggestions.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { t } from "../../i18n/index.js";
 import type { SlashCommandSpec, SlashGroup } from "./slash.js";
 import { GLYPH, useColor } from "./theme.js";
-import { SURFACE } from "./theme/tokens.js";
+import { FG, SURFACE } from "./theme/tokens.js";
 
 const GROUP_MODE_MAX_ROWS = 24;
 const SEARCH_MODE_MAX_ROWS = 8;
@@ -61,7 +61,7 @@ export function SlashSuggestions({
         </Text>
         <Text> </Text>
         <Text color={color.warn}>{t("slashSuggestions.noMatch")}</Text>
-        <Text dim>{t("slashSuggestions.backspaceHint")}</Text>
+        <Text color={FG.faint}>{t("slashSuggestions.backspaceHint")}</Text>
       </Box>
     );
   }
@@ -76,14 +76,14 @@ export function SlashSuggestions({
         <Text color={color.accent} bold>
           {"/ "}
         </Text>
-        <Text dim>
+        <Text color={FG.faint}>
           {t(
             total === 1 ? "slashSuggestions.commandCount" : "slashSuggestions.commandCountPlural",
             { count: total },
           )}
         </Text>
         {hiddenAbove > 0 ? (
-          <Text dim>{t("slashSuggestions.aboveLabel", { count: hiddenAbove })}</Text>
+          <Text color={FG.faint}>{t("slashSuggestions.aboveLabel", { count: hiddenAbove })}</Text>
         ) : null}
       </Box>
       {items.map((item) => {
@@ -100,15 +100,17 @@ export function SlashSuggestions({
         );
       })}
       {hiddenBelow > 0 ? (
-        <Text dim>{t("slashSuggestions.belowLabel", { count: hiddenBelow })}</Text>
+        <Text color={FG.faint}>{t("slashSuggestions.belowLabel", { count: hiddenBelow })}</Text>
       ) : null}
       {groupMode && advancedHidden && advancedHidden > 0 ? (
         <Box marginTop={1}>
-          <Text dim>{t("slashSuggestions.advancedHint", { count: advancedHidden })}</Text>
+          <Text color={FG.faint}>
+            {t("slashSuggestions.advancedHint", { count: advancedHidden })}
+          </Text>
         </Box>
       ) : null}
       <Box marginTop={0}>
-        <Text dim>{t("slashSuggestions.footerHint")}</Text>
+        <Text color={FG.faint}>{t("slashSuggestions.footerHint")}</Text>
       </Box>
     </Box>
   );
@@ -166,7 +168,7 @@ function shouldShowGroupHeader(matches: readonly SlashCommandSpec[], idx: number
 function GroupHeader({ group }: { group: SlashGroup }): React.ReactElement {
   return (
     <Box flexShrink={0} height={1} flexWrap="nowrap">
-      <Text dim wrap="truncate">
+      <Text color={FG.faint} wrap="truncate">
         {`  ${groupLabel(group)}`}
       </Text>
     </Box>
@@ -207,11 +209,11 @@ function SuggestionRow({
       <Text color={color.accent} bold={isSelected} wrap="truncate">
         {padOrTrim(name, COMMAND_NAME_CELLS)}
       </Text>
-      <Text dim wrap="truncate">
+      <Text color={FG.faint} wrap="truncate">
         {padOrTrim(argsSuffix, ARGS_CELLS)}
       </Text>
       <Text wrap="truncate">{"  "}</Text>
-      <Text color={isSelected ? color.user : color.info} dim={!isSelected} wrap="truncate">
+      <Text color={isSelected ? color.user : FG.faint} wrap="truncate">
         {summaryText}
       </Text>
     </Box>

--- a/src/cli/ui/SplitDiff.tsx
+++ b/src/cli/ui/SplitDiff.tsx
@@ -24,6 +24,7 @@ import React from "react";
 import type { SplitDiffRow } from "../../code/diff-preview.js";
 import { clipToCells, padToCells } from "./text-width.js";
 import { COLOR } from "./theme.js";
+import { FG } from "./theme/tokens.js";
 
 export interface SplitDiffProps {
   rows: readonly SplitDiffRow[];
@@ -46,9 +47,7 @@ export function SplitDiff({ rows, totalCols }: SplitDiffProps): React.ReactEleme
       {rows.map((row, i) => (
         <Box key={`r-${i}-${row.left.num ?? "p"}-${row.right.num ?? "p"}`}>
           <Cell side={row.left} width={halfCols} which="left" />
-          <Text color={COLOR.info} dim>
-            {" │ "}
-          </Text>
+          <Text color={FG.faint}>{" │ "}</Text>
           <Cell side={row.right} width={halfCols} which="right" />
         </Box>
       ))}
@@ -98,11 +97,11 @@ function Cell({
     // lines" capRows marker also rides this kind on the left side
     // when present, so we render its text dim italic.
     return (
-      <Text color={COLOR.info} dim italic={!!raw}>
+      <Text color={FG.faint} italic={!!raw}>
         {`${numStr} ${sign} ${padded}`}
       </Text>
     );
   }
   // ctx: same content both sides, dim
-  return <Text dim>{`${numStr} ${sign} ${padded}`}</Text>;
+  return <Text color={FG.faint}>{`${numStr} ${sign} ${padded}`}</Text>;
 }

--- a/src/cli/ui/StatsPanel.tsx
+++ b/src/cli/ui/StatsPanel.tsx
@@ -7,7 +7,7 @@ import { t } from "../../i18n/index.js";
 import type { SessionSummary } from "../../telemetry/stats.js";
 import { Bar, ChromeRule } from "./primitives.js";
 import { COLOR, GRADIENT } from "./theme.js";
-import { formatBalance, formatCost } from "./theme/tokens.js";
+import { FG, formatBalance, formatCost } from "./theme/tokens.js";
 
 const COLD_START_TURNS = 3;
 
@@ -124,15 +124,11 @@ function ChromeRow({
       </Text>
       {projectName ? (
         <>
-          <Text color={COLOR.info} dim>
-            {"  ·  "}
-          </Text>
+          <Text color={FG.faint}>{"  ·  "}</Text>
           <Text>{projectName}</Text>
           {showSession && sessionName ? (
             <>
-              <Text color={COLOR.info} dim>
-                {"  ›  "}
-              </Text>
+              <Text color={FG.faint}>{"  ›  "}</Text>
               <Text color={COLOR.info}>{sessionName}</Text>
             </>
           ) : null}
@@ -158,11 +154,8 @@ function ChromeRow({
         </>
       ) : null}
       <Text
-        color={
-          summary.turns === 0 || coldStart ? COLOR.info : sessionCostColor(summary.totalCostUsd)
-        }
+        color={summary.turns === 0 || coldStart ? FG.faint : sessionCostColor(summary.totalCostUsd)}
         bold={summary.turns > 0 && !coldStart}
-        dim={summary.turns === 0 || coldStart}
       >
         {costLabel}
       </Text>
@@ -177,19 +170,14 @@ function ChromeRow({
       {showCache ? (
         <>
           <Text>{"  "}</Text>
-          <Text dim>{"["}</Text>
-          <Text dim>{"c "}</Text>
-          <Bar
-            ratio={summary.cacheHitRatio}
-            color={coldStart ? COLOR.info : cacheColor}
-            cells={6}
-            dim={coldStart}
-          />
+          <Text color={FG.faint}>{"["}</Text>
+          <Text color={FG.faint}>{"c "}</Text>
+          <Bar ratio={summary.cacheHitRatio} color={coldStart ? FG.faint : cacheColor} cells={6} />
           <Text> </Text>
-          <Text color={coldStart ? undefined : cacheColor} dim={coldStart}>
+          <Text color={coldStart ? FG.faint : cacheColor}>
             {coldStart && summary.turns === 0 ? "—" : `${cachePct}%`}
           </Text>
-          <Text dim>{"]"}</Text>
+          <Text color={FG.faint}>{"]"}</Text>
         </>
       ) : null}
     </Box>
@@ -212,10 +200,10 @@ function BudgetRow({ spent, cap }: { spent: number; cap: number }) {
   const color = pct >= 100 ? "#f87171" : pct >= 80 ? "#fbbf24" : "#94a3b8";
   return (
     <Box>
-      <Text dim>{t("statsPanel.budget")}</Text>
+      <Text color={FG.faint}>{t("statsPanel.budget")}</Text>
       <Text color={color}>
         {`$${spent.toFixed(4)} / $${cap.toFixed(2)}`}
-        <Text dim>{`  (${pct.toFixed(0)}%)`}</Text>
+        <Text color={FG.faint}>{`  (${pct.toFixed(0)}%)`}</Text>
       </Text>
     </Box>
   );

--- a/src/cli/ui/Wizard.tsx
+++ b/src/cli/ui/Wizard.tsx
@@ -29,7 +29,7 @@ import type { LanguageCode } from "../../i18n/types.js";
 import { type CatalogEntry, MCP_CATALOG } from "../../mcp/catalog.js";
 import { MultiSelect, type SelectItem, SingleSelect } from "./Select.js";
 import { ThemeProvider, useTheme } from "./theme/context.js";
-import { type ThemeName, listThemeNames } from "./theme/tokens.js";
+import { FG, type ThemeName, listThemeNames } from "./theme/tokens.js";
 
 export interface WizardProps {
   /** Called once the config has been saved. */
@@ -213,7 +213,7 @@ export function Wizard({
             {specs.map((spec, i) => (
               // biome-ignore lint/suspicious/noArrayIndexKey: review-only render, order fixed
               <Box key={i} paddingLeft={14}>
-                <Text dim>· {spec}</Text>
+                <Text color={FG.faint}>· {spec}</Text>
               </Box>
             ))}
             <Box marginTop={1}>
@@ -225,7 +225,7 @@ export function Wizard({
               </Box>
             ) : null}
             <Box marginTop={1}>
-              <Text dim>{t("wizard.reviewFooter")}</Text>
+              <Text color={FG.faint}>{t("wizard.reviewFooter")}</Text>
             </Box>
           </Box>
           <ReviewConfirm
@@ -263,10 +263,10 @@ export function Wizard({
           <Text>{t("ui.welcome")}</Text>
         </Box>
         <Box marginTop={1}>
-          <Text dim>{t("wizard.savedShellHint")}</Text>
+          <Text color={FG.faint}>{t("wizard.savedShellHint")}</Text>
         </Box>
         <Box marginTop={1}>
-          <Text dim>{t("wizard.savedFooter")}</Text>
+          <Text color={FG.faint}>{t("wizard.savedFooter")}</Text>
         </Box>
         <ExitOnEnter onExit={exit} />
       </Box>
@@ -311,7 +311,7 @@ function ThemeStep({
         {t("wizard.themeTitle")}
       </Text>
       <Box marginTop={1}>
-        <Text dim>{t("wizard.themeSubtitle")}</Text>
+        <Text color={FG.faint}>{t("wizard.themeSubtitle")}</Text>
       </Box>
       <Box marginTop={1} flexDirection="column">
         {THEME_NAMES.map((name, i) => (
@@ -357,7 +357,7 @@ function ThemeStep({
         </Box>
       </Box>
       <Box marginTop={1}>
-        <Text dim>{t("wizard.themeFooter")}</Text>
+        <Text color={FG.faint}>{t("wizard.themeFooter")}</Text>
       </Box>
     </Box>
   );
@@ -383,7 +383,7 @@ function LanguageStep({
         {t("wizard.languageTitle")}
       </Text>
       <Box marginTop={1}>
-        <Text dim>{t("wizard.languageSubtitle")}</Text>
+        <Text color={FG.faint}>{t("wizard.languageSubtitle")}</Text>
       </Box>
       <Box marginTop={1}>
         <SingleSelect<LanguageCode>
@@ -420,10 +420,12 @@ function ApiKeyStep({
       <Box marginTop={1}>
         <Text>{t("wizard.apiKeyPrompt")}</Text>
       </Box>
-      <Text dim>{t("wizard.apiKeyGetOne")}</Text>
-      <Text dim>{t("wizard.apiKeySavedLocally", { path: defaultConfigPath() })}</Text>
+      <Text color={FG.faint}>{t("wizard.apiKeyGetOne")}</Text>
+      <Text color={FG.faint}>{t("wizard.apiKeySavedLocally", { path: defaultConfigPath() })}</Text>
       {initialValue ? (
-        <Text dim>{t("wizard.apiKeyPreview", { redacted: redactKey(initialValue) })}</Text>
+        <Text color={FG.faint}>
+          {t("wizard.apiKeyPreview", { redacted: redactKey(initialValue) })}
+        </Text>
       ) : null}
       <Box marginTop={1}>
         <Text bold color="ansi:cyan">
@@ -469,7 +471,7 @@ function ApiKeyStep({
         </Box>
       ) : value ? (
         <Box marginTop={1}>
-          <Text dim>{t("wizard.apiKeyPreview", { redacted: redactKey(value) })}</Text>
+          <Text color={FG.faint}>{t("wizard.apiKeyPreview", { redacted: redactKey(value) })}</Text>
         </Box>
       ) : null}
     </Box>
@@ -556,7 +558,7 @@ function McpArgsStep({
         <Box flexDirection="column">
           <Text>{t("wizard.mcpArgsDirMissing", { path: pendingCreate })}</Text>
           <Box marginTop={1}>
-            <Text dim>{t("wizard.mcpArgsDirCreateHint")}</Text>
+            <Text color={FG.faint}>{t("wizard.mcpArgsDirCreateHint")}</Text>
           </Box>
           {error ? (
             <Box marginTop={1}>
@@ -574,7 +576,7 @@ function McpArgsStep({
         <Text>{entry.summary}</Text>
         {entry.note ? (
           <Box marginTop={1}>
-            <Text dim>{entry.note}</Text>
+            <Text color={FG.faint}>{entry.note}</Text>
           </Box>
         ) : null}
         <Box marginTop={1}>
@@ -658,7 +660,7 @@ function StepFrame({
   return (
     <Box flexDirection="column" borderStyle="round" borderColor="ansi:cyan" paddingX={1}>
       <Box>
-        <Text dim>{t("wizard.stepCounter", { step, total })}</Text>
+        <Text color={FG.faint}>{t("wizard.stepCounter", { step, total })}</Text>
         <Text bold color="ansi:cyan">
           {title}
         </Text>

--- a/src/cli/ui/cards/ReasoningCard.tsx
+++ b/src/cli/ui/cards/ReasoningCard.tsx
@@ -83,7 +83,7 @@ function ReasoningHeader({
         settled="◆"
         color={card.aborted ? TONE.err : FG.faint}
       />
-      <Text italic dim color={card.aborted ? TONE.err : undefined}>
+      <Text italic color={card.aborted ? TONE.err : FG.sub}>
         {`${baseTitle}${metaTrail}${collapsedHint}`}
       </Text>
       {modelBadge ? (

--- a/src/cli/ui/cards/ToolCard.tsx
+++ b/src/cli/ui/cards/ToolCard.tsx
@@ -96,8 +96,7 @@ export function ToolCard({ card }: { card: ToolCardData }): React.ReactElement {
               ) : (
                 <Text
                   key={`${card.id}:line:${row.index}`}
-                  color={errColor}
-                  dim={!card.exitCode || card.exitCode === 0}
+                  color={!card.exitCode || card.exitCode === 0 ? FG.faint : errColor}
                 >
                   {clipToCells(row.text, lineCells) || " "}
                 </Text>

--- a/src/cli/ui/char-bar.tsx
+++ b/src/cli/ui/char-bar.tsx
@@ -22,6 +22,7 @@ import { Box, type Color, Text } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React from "react";
 import { COLOR, GLYPH } from "./theme.js";
+import { FG } from "./theme/tokens.js";
 
 export interface CharBarProps {
   /** 0–100 (clamped). Negative or NaN → 0; >100 → 100. */
@@ -62,10 +63,8 @@ export function CharBar({
   return (
     <Box>
       <Text color={color}>{GLYPH.block.repeat(filled)}</Text>
-      <Text color={emptyColor ?? COLOR.info} dim>
-        {GLYPH.shade1.repeat(total - filled)}
-      </Text>
-      {showLabel ? <Text dim>{`  ${label ?? `${Math.round(clamped)}%`}`}</Text> : null}
+      <Text color={FG.faint}>{GLYPH.shade1.repeat(total - filled)}</Text>
+      {showLabel ? <Text color={FG.faint}>{`  ${label ?? `${Math.round(clamped)}%`}`}</Text> : null}
     </Box>
   );
 }
@@ -110,9 +109,7 @@ export function StackedCharBar({
           {GLYPH.block.repeat(cells[i] ?? 0)}
         </Text>
       ))}
-      <Text color={emptyColor ?? COLOR.info} dim>
-        {GLYPH.shade1.repeat(empty)}
-      </Text>
+      <Text color={FG.faint}>{GLYPH.shade1.repeat(empty)}</Text>
     </Box>
   );
 }

--- a/src/cli/ui/ctx-breakdown.tsx
+++ b/src/cli/ui/ctx-breakdown.tsx
@@ -7,6 +7,7 @@ import { DEEPSEEK_CONTEXT_TOKENS, DEFAULT_CONTEXT_TOKENS } from "../../telemetry
 import { countTokensBounded } from "../../tokenizer.js";
 import { formatTokens } from "./primitives.js";
 import { COLOR } from "./theme.js";
+import { FG } from "./theme/tokens.js";
 
 export interface CtxBreakdownData {
   systemTokens: number;
@@ -98,8 +99,8 @@ export function CtxBreakdownBlock({ data }: { data: CtxBreakdownData }): React.R
         <Text color={COLOR.brand} bold>
           {t("ctxBreakdown.title")}
         </Text>
-        <Text dim>{`  ${formatTokens(total)} of ${formatTokens(data.ctxMax)}`}</Text>
-        <Text dim>{"  ·  "}</Text>
+        <Text color={FG.faint}>{`  ${formatTokens(total)} of ${formatTokens(data.ctxMax)}`}</Text>
+        <Text color={FG.faint}>{"  ·  "}</Text>
         <Text color={sevColor} bold>
           {`${winPct}%`}
         </Text>
@@ -114,41 +115,47 @@ export function CtxBreakdownBlock({ data }: { data: CtxBreakdownData }): React.R
         <Text color={COLOR.accent}>{"█".repeat(toolsCells)}</Text>
         <Text color={COLOR.primary}>{"█".repeat(logCells)}</Text>
         <Text color={COLOR.tool}>{"█".repeat(inputCells)}</Text>
-        <Text color={COLOR.info} dim>
-          {"░".repeat(freeCells)}
-        </Text>
+        <Text color={FG.faint}>{"░".repeat(freeCells)}</Text>
       </Box>
       <Box>
         <Text color={COLOR.brand}>■</Text>
-        <Text dim>{` ${t("cardLabels.system")} ${formatTokens(data.systemTokens)}`}</Text>
+        <Text
+          color={FG.faint}
+        >{` ${t("cardLabels.system")} ${formatTokens(data.systemTokens)}`}</Text>
         <Text>{"   "}</Text>
         <Text color={COLOR.accent}>■</Text>
-        <Text dim>{` ${t("cardLabels.tools")} ${formatTokens(data.toolsTokens)}`}</Text>
-        <Text dim>{` (${data.toolsCount})`}</Text>
+        <Text
+          color={FG.faint}
+        >{` ${t("cardLabels.tools")} ${formatTokens(data.toolsTokens)}`}</Text>
+        <Text color={FG.faint}>{` (${data.toolsCount})`}</Text>
         <Text>{"   "}</Text>
         <Text color={COLOR.primary}>■</Text>
-        <Text dim>{` ${t("cardLabels.log")} ${formatTokens(data.logTokens)}`}</Text>
-        <Text dim>{` (${data.logMessages} ${t("ctxBreakdown.msg")})`}</Text>
+        <Text color={FG.faint}>{` ${t("cardLabels.log")} ${formatTokens(data.logTokens)}`}</Text>
+        <Text color={FG.faint}>{` (${data.logMessages} ${t("ctxBreakdown.msg")})`}</Text>
         <Text>{"   "}</Text>
         <Text color={COLOR.tool}>■</Text>
-        <Text dim>{` ${t("cardLabels.input")} ${formatTokens(data.inputTokens)}`}</Text>
+        <Text
+          color={FG.faint}
+        >{` ${t("cardLabels.input")} ${formatTokens(data.inputTokens)}`}</Text>
       </Box>
       {data.topTools.length > 0 ? (
         <Box marginTop={1} flexDirection="column">
-          <Text dim>{t("ctxBreakdown.topTools", { count: data.topTools.length })}</Text>
+          <Text color={FG.faint}>
+            {t("ctxBreakdown.topTools", { count: data.topTools.length })}
+          </Text>
           {data.topTools.map((tool) => (
             <Box key={`${tool.turn}-${tool.name}`}>
               <Text
-                dim
+                color={FG.faint}
               >{`    ${t("ctxBreakdown.turnLabel")} ${String(tool.turn).padStart(3)}  `}</Text>
               <Text color={COLOR.info}>{tool.name.padEnd(22)}</Text>
-              <Text dim>{`  ${formatTokens(tool.tokens).padStart(8)}`}</Text>
+              <Text color={FG.faint}>{`  ${formatTokens(tool.tokens).padStart(8)}`}</Text>
             </Box>
           ))}
         </Box>
       ) : null}
       <Box marginTop={1}>
-        <Text dim>{t("ctxBreakdown.compactHint")}</Text>
+        <Text color={FG.faint}>{t("ctxBreakdown.compactHint")}</Text>
       </Box>
     </Box>
   );

--- a/src/cli/ui/markdown-view.tsx
+++ b/src/cli/ui/markdown-view.tsx
@@ -160,10 +160,9 @@ function SpanText({
         : FG_BODY;
   const inner = (
     <Text
-      color={color}
+      color={ambientDim ? FG_FAINT : color}
       bold={!!(span.bold || ambientBold)}
       italic={!!(span.italic || ambientItalic)}
-      dim={!!ambientDim}
       strikethrough={!!(span.strike || ambientStrike)}
       underline={!!(span.link || span.fileRef)}
     >

--- a/src/cli/ui/primitives.tsx
+++ b/src/cli/ui/primitives.tsx
@@ -3,6 +3,7 @@ import { type Color, Text, useStdout } from "ink";
 import React from "react";
 import { t } from "../../i18n/index.js";
 import { COLOR } from "./theme.js";
+import { FG } from "./theme/tokens.js";
 
 /**
  * Faint full-width horizontal rule. Width tracks the terminal columns
@@ -14,7 +15,7 @@ export function ChromeRule(): React.ReactElement {
   const { stdout } = useStdout();
   const cols = stdout?.columns ?? 80;
   const w = Math.max(20, cols - 2);
-  return <Text dim>{"─".repeat(w)}</Text>;
+  return <Text color={FG.faint}>{"─".repeat(w)}</Text>;
 }
 
 /** Compact decimal-K token formatter — `1234 → "1.2K"`, `131000 → "131K"`. Base-1000 matches DeepSeek's "1M context" / "128K" wording and the web dashboard's display, so the CLI bottom bar and the web bar agree on ctx capacity. */
@@ -32,20 +33,16 @@ export function Bar({
   ratio,
   color,
   cells = 14,
-  dim,
 }: {
   ratio: number;
   color: Color;
   cells?: number;
-  dim?: boolean;
 }): React.ReactElement {
   const filled = Math.max(0, Math.min(cells, Math.round(ratio * cells)));
   return (
     <Text>
-      <Text color={color} dim={dim}>
-        {"▰".repeat(filled)}
-      </Text>
-      <Text dim>{"▱".repeat(cells - filled)}</Text>
+      <Text color={color}>{"▰".repeat(filled)}</Text>
+      <Text color={FG.faint}>{"▱".repeat(cells - filled)}</Text>
     </Text>
   );
 }
@@ -70,10 +67,8 @@ export function ContextCell({
   if (promptTokens === 0) {
     return (
       <Text>
-        <Text color={COLOR.info} dim>
-          {"▣ ctx "}
-        </Text>
-        <Text dim>{`\u2014 ${t("common.noTurns")}`}</Text>
+        <Text color={FG.faint}>{"▣ ctx "}</Text>
+        <Text color={FG.faint}>{`\u2014 ${t("common.noTurns")}`}</Text>
       </Text>
     );
   }
@@ -87,7 +82,7 @@ export function ContextCell({
       <Text color={color} bold>
         {formatTokens(promptTokens)}/{formatTokens(ctxMax)}
       </Text>
-      <Text dim> ({pct}%)</Text>
+      <Text color={FG.faint}> ({pct}%)</Text>
       {ratio >= 0.8 ? (
         <Text color={COLOR.err} bold>
           {"  ·  /compact"}

--- a/src/cli/ui/theme/tokens.ts
+++ b/src/cli/ui/theme/tokens.ts
@@ -86,8 +86,8 @@ const dark = defineTheme({
     strong: "#f4f7fb",
     body: "#d8dee9",
     sub: "#a7b1c2",
-    meta: "#778294",
-    faint: "#4d5666",
+    meta: "#9aa5b5",
+    faint: "#8791a3",
   },
   tone: {
     brand: "#7dd3fc",
@@ -111,7 +111,7 @@ const dark = defineTheme({
     bg: "#0b1020",
     bgInput: "#0f172a",
     bgCode: "#080c16",
-    bgElev: "#151d2f",
+    bgElev: "#1c2844",
   },
   messageBg: {
     user: "#373737",
@@ -125,8 +125,8 @@ const light = defineTheme({
     strong: "#111827",
     body: "#1f2937",
     sub: "#4b5563",
-    meta: "#6b7280",
-    faint: "#9ca3af",
+    meta: "#5c6371",
+    faint: "#666d7b",
   },
   tone: {
     brand: "#2563eb",
@@ -164,8 +164,8 @@ const midnight = defineTheme({
     strong: "#c0caf5",
     body: "#a9b1d6",
     sub: "#9aa5ce",
-    meta: "#565f89",
-    faint: "#414868",
+    meta: "#9da5bb",
+    faint: "#8a92a8",
   },
   tone: {
     brand: "#7aa2f7",
@@ -203,8 +203,8 @@ const deepBlue = defineTheme({
     strong: "#ffffff",
     body: "#e0e0e0",
     sub: "#b0b0b0",
-    meta: "#808080",
-    faint: "#606060",
+    meta: "#909090",
+    faint: "#8c8c8c",
   },
   tone: {
     brand: "#0153e5",


### PR DESCRIPTION
## Summary

Three issues making the TUI unusable on iTerm (and any terminal with a non-default background):

### 1. Themed backgrounds not applied

The theme system defines `SURFACE.bgInput` (`#0f172a`) and `SURFACE.bg` (`#0b1020`) but **no component applies them**. The entire UI renders with the terminal's default background, making input text invisible and the theme ineffective.

- `PromptInput.tsx` — add `backgroundColor={SURFACE.bgInput}` to the outer Box
- `App.tsx` — add `SURFACE` import and `backgroundColor={SURFACE.bg}` to root content layout
- `ComposerArea.tsx` — add `SURFACE` import and `backgroundColor={SURFACE.bgInput}` to wrapper Box

### 2. WCAG AA contrast failures on fg.faint and fg.meta

`fg.faint` failed WCAG on all 4 dark themes (ratios 1.63–2.56:1, need 4.5:1). `fg.meta` failed on midnight and was borderline on others. Dark theme `bgElev` was too close to `bgInput` for surface distinction.

| Theme | meta | faint | bgElev |
|-------|------|-------|--------|
| dark | #778294→#9aa5b5 | #4d5666→#8791a3 | #151d2f→#1c2844 |
| light | #6b7280→#5c6371 | #9ca3af→#666d7b | — |
| midnight | #565f89→#9da5bb | #414868→#8a92a8 | — |
| deep-blue | #808080→#909090 | #606060→#8c8c8c | — |
| high-contrast | — | — | — |

### 3. ANSI `dim` causing invisible text across all UI components

The `dim` attribute (SGR 2) halves the brightness of the foreground color. On dark terminals, dimmed text without an explicit color uses the terminal default at half brightness — effectively invisible. This affects **22 components** across the entire TUI.

**Initial fix** (earlier commits):
- `ReasoningCard.tsx` — replace `dim` with explicit `FG.sub` for card metadata
- `ToolCard.tsx` — replace conditional `dim` with explicit `FG.faint`/`errColor`
- `chat.tsx` — emit OSC 11 to set terminal default background, reset via OSC 111 on exit

**Full fix** (this commit): Replace every remaining `dim` prop across 22 UI components with explicit `color={FG.faint}` or conditional color logic:
- mcp-browse, AtMentionSuggestions, DiffApp, EditConfirm
- McpBrowser, McpHub, McpMarketplace
- PlanReviseConfirm, PlanStepList
- RecordView, ReplayApp, Select, Setup
- SlashArgPicker, SlashSuggestions, SplitDiff
- StatsPanel, Wizard, char-bar, ctx-breakdown
- markdown-view (SpanText ambientDim), primitives (Bar, ContextCell)

For conditional dim (e.g. `dim={isDone}`), replaced with conditional color logic (`color={isDone ? FG.faint : originalColor}`). The Bar component's `dim` prop was removed entirely — callers now pass the appropriate color directly.

## Test plan

- [x] Verify input area has a distinct themed background in iTerm
- [x] Verify text is clearly readable against the new background
- [x] Switch themes with `/theme` — backgrounds and text should change accordingly
- [x] Verify border, placeholder, and faint text are visible with sufficient contrast
- [x] Verify reasoning card metadata ("◆ reasoning · 20 tok") is readable
- [x] Verify tool card preview lines are readable
- [x] Verify no white/empty areas below content in iTerm
- [x] Verify all UI components (slash suggestions, session picker, MCP browser, etc.) have readable text
- [x] Run `npm run verify` (lint + typecheck + tests)