### PR TITLE
perf(i18n): replace regex in t() with replaceAll

### DIFF
--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -116,7 +116,7 @@ export function t(path: string, params?: Record<string, string | number>): strin
   if (params) {
     let result = val;
     for (const [k, v] of Object.entries(params)) {
-      result = result.replace(new RegExp(`\\{${k}\\}`, "g"), String(v));
+      result = result.replaceAll(`{${k}}`, String(v));
     }
     return result;
   }


### PR DESCRIPTION
## Summary

Replace per-key `new RegExp(\`\\{${k}\\}\`, "g")` with native `replaceAll(\`{${k}}\`, String(v))` in the `t()` translation function — avoids regex construction overhead on every translation lookup.

The `readConfig` mtime cache that was originally in this PR has been dropped — it's already in #2162 (which uses an fd-based approach to avoid a TOCTOU race flagged by CodeQL).

## Files changed (1)

| File | Change |
|------|--------|
| `src/i18n/index.ts` | `result.replace(new RegExp(...))` → `result.replaceAll(...)` |

## Test plan

- [ ] `t("key", { name: "value" })` still substitutes `{name}` correctly
- [ ] Multiple params in one string all substitute

🤖 Generated with [Claude Code](https://claude.com/claude-code)