### PR TITLE
fix(desktop): render write_file results as DiffCard in thread view

### DIFF
--- a/desktop/src/ui/thread.tsx
+++ b/desktop/src/ui/thread.tsx
@@ -209,7 +209,7 @@ export const AssistantMsg = memo(function AssistantMsg({
         />
       );
     }
-    if (s.result && (s.name === "edit_file" || s.name === "multi_edit")) {
+    if (s.result && (s.name === "edit_file" || s.name === "multi_edit" || s.name === "write_file")) {
       const files = parseEditResult(s.result);
       return files.length > 0 ? (
         <>


### PR DESCRIPTION
write_file results now render as DiffCard in Desktop thread view, matching edit_file / multi_edit behavior. Added write_file to the DiffCard condition in thread.tsx:212. parseEditResult correctly falls back to ToolCard for new files and large files. App.tsx sidebar has its own write_file handler (line 618) and is unaffected.