### PR TITLE
fix(qq): polish busy ingress and setup reminders

### DIFF
--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -79,6 +79,7 @@ import {
   collectMemoryEntriesForWorkspace,
   readMemoryEntryDetail,
 } from "../../desktop/memory-browser.js";
+import { classifyDesktopQQIngress } from "../../desktop/qq-ingress.js";
 import {
   parseQQRemoteDesktopCommand,
   qqRemoteCommandBypassesBusy,
@@ -92,6 +93,7 @@ import {
 import {
   clearQQTurnRouting,
   createQQTurnRoutingState,
+  hasQQPendingInteraction,
   markQQTurnFinished,
   markQQTurnStarted,
   setQQPendingInteraction,
@@ -1253,6 +1255,23 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
     });
   }
 
+  function emitQQNotice(message: string, tabOverride?: Tab): void {
+    const tab = tabOverride ?? activeDesktopTab();
+    if (tab) {
+      emit(
+        {
+          type: "warning",
+          id: Date.now(),
+          ts: new Date().toISOString(),
+          turn: 0,
+          text: message,
+          severity: "high",
+        },
+        tab.id,
+      );
+    }
+  }
+
   function startNewChatInTab(tab: Tab): void {
     if (tab.aborter) tab.switching = true;
     abortTurn(tab);
@@ -1659,6 +1678,22 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
         const trimmed = text.trim();
         if (!trimmed) return;
         if (handleQQRemoteDesktopCommand(tab, trimmed)) return;
+        const decision = classifyDesktopQQIngress({
+          hasPendingInteraction: hasQQPendingInteraction(qqRuntime.routing, tab.id),
+          isBusy: !!tab.aborter,
+        });
+        if (decision === "pause_reply") {
+          handleQQPauseReply(tab, trimmed);
+          return;
+        }
+        if (decision === "busy") {
+          void channel
+            .sendResponse(
+              "Session is busy. Wait for the current turn or reply to the pending prompt.",
+            )
+            .catch(() => undefined);
+          return;
+        }
         emit(
           {
             type: "user.message",
@@ -1669,15 +1704,6 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
           },
           tab.id,
         );
-        if (handleQQPauseReply(tab, trimmed)) return;
-        if (tab.aborter) {
-          void channel
-            .sendResponse(
-              "Session is busy. Wait for the current turn or reply to the pending prompt.",
-            )
-            .catch(() => undefined);
-          return;
-        }
         void runTurn(tab, trimmed, true);
       },
       onError: (message) => {
@@ -1685,6 +1711,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
         setQQRuntimeState("failed", message);
         if (tab) emit({ type: "$error", message: `QQ: ${message}` }, tab.id);
       },
+      onInfo: (message) => emitQQNotice(`QQ: ${message}`),
     });
     try {
       await channel.start();
@@ -1704,7 +1731,14 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
     const channel = qqRuntime.channel;
     qqRuntime.channel = null;
     clearQQTurnRouting(qqRuntime.routing);
-    if (channel) await channel.stop();
+    if (channel) {
+      try {
+        await channel.stop();
+      } catch (err) {
+        setQQRuntimeState("failed", (err as Error).message);
+        throw err;
+      }
+    }
     if (shouldDisable) setDesktopQQEnabled(false);
     setQQRuntimeState("disconnected");
   }
@@ -2962,6 +2996,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
               { type: "$error", message: `qq_disconnect failed: ${(err as Error).message}` },
               tab.id,
             );
+            emitQQSettings(tab);
           },
         );
       } catch (err) {
@@ -2969,6 +3004,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
           { type: "$error", message: `qq_disconnect failed: ${(err as Error).message}` },
           tab.id,
         );
+        emitQQSettings(tab);
       }
       return;
     }

--- a/src/desktop/qq-ingress.ts
+++ b/src/desktop/qq-ingress.ts
@@ -1,0 +1,10 @@
+export type DesktopQQIngressDecision = "pause_reply" | "busy" | "new_turn";
+
+export function classifyDesktopQQIngress(opts: {
+  hasPendingInteraction: boolean;
+  isBusy: boolean;
+}): DesktopQQIngressDecision {
+  if (opts.hasPendingInteraction) return "pause_reply";
+  if (opts.isBusy) return "busy";
+  return "new_turn";
+}

--- a/src/desktop/qq-turn-routing.ts
+++ b/src/desktop/qq-turn-routing.ts
@@ -40,6 +40,10 @@ export function setQQPendingInteraction(
   state.pendingByTab.set(tabId, { gateId, kind, payload });
 }
 
+export function hasQQPendingInteraction(state: QQTurnRoutingState, tabId: string): boolean {
+  return state.pendingByTab.has(tabId);
+}
+
 export function takeQQPendingInteraction(
   state: QQTurnRoutingState,
   tabId: string,

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -857,7 +857,7 @@ export const EN: TranslationSchema = {
       unauthorizedMessage:
         "QQ ignored message from unauthorized openid {openid}. Current access: {access}.",
       runtimeBound:
-        "QQ temporarily bound this run to first sender {openid}. Set `qq.ownerOpenId` in config to persist access.",
+        "QQ temporarily bound this run to first sender {openid}. If you want this account to stay fixed, set it in QQ settings.",
       missingAppId: "QQ App ID is required. Run `/qq connect` to configure.",
       missingAppSecret: "QQ App Secret is required. Run `/qq connect` to configure.",
       authFailed: "QQ bot authentication failed — check your App ID and App Secret.",

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -814,7 +814,7 @@ export const zhCN: TranslationSchema = {
       lockAlreadyRunning: "QQ 通道已在进程 {pid} 中运行。请先停止该进程，再启动新的 QQ 通道。",
       unauthorizedMessage: "QQ 忽略了未授权 openid {openid} 的消息。当前访问控制：{access}。",
       runtimeBound:
-        "QQ 已在本次运行中临时绑定到首个发送者 {openid}。如需持久化，请在配置中设置 `qq.ownerOpenId`。",
+        "QQ 已在本次运行中临时绑定到首个发送者 {openid}。如果你希望固定绑定到这个账号，可以在 QQ 设置中手动指定。",
       missingAppId: "缺少 QQ App ID。请先运行 `/qq connect` 完成配置。",
       missingAppSecret: "缺少 QQ App Secret。请先运行 `/qq connect` 完成配置。",
       authFailed: "QQ 机器人鉴权失败，请检查 App ID 和 App Secret。",

--- a/src/qq/channel.ts
+++ b/src/qq/channel.ts
@@ -78,6 +78,7 @@ export class QQChannel {
     private callbacks: {
       onSubmitMessage: (text: string) => void;
       onError?: (msg: string) => void;
+      onInfo?: (msg: string) => void;
     },
   ) {}
 
@@ -160,7 +161,7 @@ export class QQChannel {
     }
     if (verdict.bindRuntime) {
       this.runtimeBoundOpenId = openid;
-      this.callbacks.onError?.(
+      this.callbacks.onInfo?.(
         t("handlers.qq.runtimeBound", {
           openid: redactQQOpenId(openid),
         }),

--- a/src/qq/use-qq-channel.ts
+++ b/src/qq/use-qq-channel.ts
@@ -287,6 +287,7 @@ export function useQQChannel({
       const channel = new QQChannel({
         onSubmitMessage: (message) => setQueuedSubmit(message),
         onError: (message) => log.pushWarning("QQ", message),
+        onInfo: (message) => log.pushInfo(message),
       });
       await channel.start();
       channelRef.current = channel;
@@ -799,6 +800,10 @@ export function useQQChannel({
           pendingConnectSetupRef.current = null;
           pending.reject(new Error(t("handlers.qq.setupCancelled")));
           log.pushInfo(t("handlers.qq.setupCancelled"));
+          return { handled: true, fromQQ, text };
+        }
+        if (text.startsWith("/")) {
+          log.pushInfo(formatQQSetupPrompt(pending.step));
           return { handled: true, fromQQ, text };
         }
 

--- a/tests/desktop-qq-ingress.test.ts
+++ b/tests/desktop-qq-ingress.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { classifyDesktopQQIngress } from "../src/desktop/qq-ingress.js";
+
+describe("classifyDesktopQQIngress", () => {
+  it("treats pending prompt replies as follow-up replies even while busy", () => {
+    expect(
+      classifyDesktopQQIngress({
+        hasPendingInteraction: true,
+        isBusy: true,
+      }),
+    ).toBe("pause_reply");
+  });
+
+  it("rejects new turns while the active tab is busy", () => {
+    expect(
+      classifyDesktopQQIngress({
+        hasPendingInteraction: false,
+        isBusy: true,
+      }),
+    ).toBe("busy");
+  });
+
+  it("accepts a new turn only when there is no pending interaction and the tab is idle", () => {
+    expect(
+      classifyDesktopQQIngress({
+        hasPendingInteraction: false,
+        isBusy: false,
+      }),
+    ).toBe("new_turn");
+  });
+});

--- a/tests/qq-channel.test.ts
+++ b/tests/qq-channel.test.ts
@@ -204,3 +204,37 @@ describe("QQChannel.sendResponse", () => {
     expect(onError.mock.calls[1]?.[0]).toContain("chunk 2/3 failed");
   });
 });
+
+describe("QQChannel inbound messaging", () => {
+  it("surfaces first-sender runtime binding as info instead of an error", () => {
+    const onSubmitMessage = vi.fn();
+    const onError = vi.fn();
+    const onInfo = vi.fn();
+    const channel = new QQChannel({
+      onSubmitMessage,
+      onError,
+      onInfo,
+    }) as QQChannel & {
+      ownerOpenId?: string;
+      allowlist?: string[];
+      runtimeBoundOpenId: string | null;
+      handlePrivateMessage: (msg: {
+        author: { user_openid: string };
+        content: string;
+        id: string;
+        timestamp: string;
+      }) => void;
+    };
+
+    channel.handlePrivateMessage({
+      author: { user_openid: "abcdefghijklmnop" },
+      content: "hello",
+      id: "msg-1",
+      timestamp: new Date().toISOString(),
+    });
+
+    expect(onInfo).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+    expect(onSubmitMessage).toHaveBeenCalledWith("[QQ] hello");
+  });
+});

--- a/tests/qq-first-connect.test.tsx
+++ b/tests/qq-first-connect.test.tsx
@@ -150,6 +150,24 @@ describe("QQ first-connect onboarding", () => {
     unmount();
   });
 
+  it("does not treat slash-like input as credentials during staged first-time setup", async () => {
+    const log = {
+      pushInfo: vi.fn(),
+      pushWarning: vi.fn(),
+    };
+    const { api, unmount } = mountHarness(log);
+
+    void api.connect([]);
+    expect(api.parseSubmit("/help")).toMatchObject({ handled: true, fromQQ: false });
+    expect(log.pushInfo).toHaveBeenLastCalledWith(
+      "QQ setup: enter your QQ Open Platform App ID, then press Enter. Type /cancel to abort.",
+    );
+    expect(saveQQConfigMock).not.toHaveBeenCalled();
+    expect(startMock).not.toHaveBeenCalled();
+
+    unmount();
+  });
+
   it("localizes connect results and status in zh-CN", async () => {
     setLanguageRuntime("zh-CN");
     const log = {


### PR DESCRIPTION
## Summary
- avoid showing new QQ messages in desktop transcripts when the active tab is busy and the message is rejected
- surface first-sender runtime binding as a reminder instead of an error and soften the settings copy
- add minimal staged `/qq connect` slash-input protection and refresh desktop QQ state after disconnect failures

## Testing
- `npm test -- --run tests/desktop-qq-ingress.test.ts tests/qq-channel.test.ts`
- `npm test -- --run tests/qq-first-connect.test.tsx`
- `npx biome check src/cli/commands/desktop.ts src/desktop/qq-turn-routing.ts src/qq/channel.ts src/qq/use-qq-channel.ts src/i18n/EN.ts src/i18n/zh-CN.ts tests/qq-channel.test.ts tests/qq-first-connect.test.tsx tests/desktop-qq-ingress.test.ts src/desktop/qq-ingress.ts`

## Notes
- After refreshing local dependencies, the staged first-connect regression now runs normally in this worktree.
- Full `npm run verify` now gets past the earlier dependency-resolution noise and only fails on the existing Windows symlink-permission failures in `tests/skills.test.ts` (`EPERM` from `symlinkSync`), which are unrelated to this QQ-only change set.