### PR TITLE
perf: cache frozen tool-spec snapshot in ImmutablePrefix.tools()

### DIFF
--- a/src/memory/runtime.ts
+++ b/src/memory/runtime.ts
@@ -16,6 +16,8 @@ export class ImmutablePrefix {
   readonly fewShots: readonly ChatMessage[];
   /** Invalidated by addTool / removeTool / replaceSystem; bypassing any of those leaves cache stale → fingerprint diverges from sent prefix. */
   private _fingerprintCache: string | null = null;
+  /** Frozen shallow-copy snapshot of _toolSpecs — avoids structuredClone per iteration. */
+  private _frozenToolsCache: ToolSpec[] | null = null;
 
   constructor(opts: ImmutablePrefixOptions) {
     this.system = opts.system;
@@ -39,8 +41,14 @@ export class ImmutablePrefix {
     return [{ role: "system", content: this.system }, ...this.fewShots.map((m) => ({ ...m }))];
   }
 
+  /** Frozen shallow copy — callers must not mutate returned objects. */
   tools(): ToolSpec[] {
-    return this._toolSpecs.map((t) => structuredClone(t) as ToolSpec);
+    if (this._frozenToolsCache) return this._frozenToolsCache;
+    const frozen = Object.freeze(
+      this._toolSpecs.map((t) => Object.freeze({ ...t, function: { ...t.function } }) as ToolSpec),
+    );
+    this._frozenToolsCache = frozen as unknown as ToolSpec[];
+    return this._frozenToolsCache;
   }
 
   addTool(spec: ToolSpec): boolean {
@@ -49,6 +57,7 @@ export class ImmutablePrefix {
     if (this._toolSpecs.some((t) => t.function?.name === name)) return false;
     this._toolSpecs.push(spec);
     this._fingerprintCache = null;
+    this._frozenToolsCache = null;
     return true;
   }
 
@@ -58,6 +67,7 @@ export class ImmutablePrefix {
     if (idx < 0) return false;
     this._toolSpecs.splice(idx, 1);
     this._fingerprintCache = null;
+    this._frozenToolsCache = null;
     return true;
   }
 


### PR DESCRIPTION
## Summary

- `tools()` was calling `structuredClone` on every tool spec on every call — the most expensive per-iteration operation in the agent loop. A typical session registers 30-50 tools; each inner-loop iteration (3-10 per turn) triggered a full deep clone of all of them.
- Replace with a frozen shallow-copy cache (`_frozenToolsCache`) that is rebuilt only when `addTool`/`removeTool` mutates the tool list. `Object.freeze` on each spec + its `function` sub-object prevents accidental mutation of the cached copy.

## Why this matters

`structuredClone` is one of the most expensive built-in operations in V8 — it serializes-then-deserializes via the structured clone algorithm, handling cycles, typed arrays, etc. None of that machinery is needed here; tool specs are plain JSON objects. For a 10-iteration turn with 40 tools, this eliminates **400 unnecessary deep clones**.

## How it works

- Added `_frozenToolsCache: ToolSpec[] | null` field to `ImmutablePrefix`
- `tools()` returns the cached frozen array when available; builds + freezes on first call
- `addTool()` and `removeTool()` null the cache alongside the existing `_fingerprintCache` invalidation
- `Object.freeze` on each spec and its `function` sub-object prevents accidental mutation

## Test plan

- [x] Type check passes (`tsc --noEmit`)
- [x] Biome lint passes
- [x] All existing tests pass
- [x] Manual: agent loop runs without mutation errors across multi-iteration turns