### PR TITLE
perf: cache healing pipeline result via AppendOnlyLog version counter

### DIFF
--- a/src/context-manager.ts
+++ b/src/context-manager.ts
@@ -110,11 +110,17 @@ function collectPinnedSkills(head: ChatMessage[]): { names: string[]; bodies: st
 }
 
 export class ContextManager {
+  private _logTokensCache = -1;
+  private _logTokensVersion = -1;
+
   constructor(private deps: ContextManagerDeps) {}
 
   /** Real-time token count of the current log — used by Desktop to refresh the
    *  context meter after /compact when no API usage event is available. */
   getLogTokens(): number {
+    if (this._logTokensCache >= 0 && this._logTokensVersion === this.deps.log.version) {
+      return this._logTokensCache;
+    }
     const entries = this.deps.log.toFullHistory();
     let total = 0;
     for (const e of entries) {
@@ -124,6 +130,8 @@ export class ContextManager {
         total += countTokensBounded(JSON.stringify(e.tool_calls));
       }
     }
+    this._logTokensCache = total;
+    this._logTokensVersion = this.deps.log.version;
     return total;
   }
 

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -524,12 +524,23 @@ export class CacheFirstLoop {
   }
   private _inflightCounter = 0;
 
+  // Cached result from the last healActiveLogBeforeSend() pass.
+  // Invalidated when the log version changes (append/compactInPlace).
+  private _healedCache: ChatMessage[] | null = null;
+  private _healedVersion = -1;
+
   private buildMessages(): ChatMessage[] {
     const healedMessages = this.healActiveLogBeforeSend();
     return [...this.prefix.toMessages(), ...healedMessages];
   }
 
   private healActiveLogBeforeSend(): ChatMessage[] {
+    // Skip the expensive 4-pass healing pipeline when the log hasn't
+    // changed since the last call — the common case between iterations
+    // where no new messages were appended.
+    if (this._healedCache && this._healedVersion === this.log.version) {
+      return this._healedCache;
+    }
     const current = this.log.toFullHistory();
     const healed = healLoadedMessages(current, DEFAULT_MAX_RESULT_CHARS);
     const argsShrunk = shrinkOversizedToolCallArgsByTokens(
@@ -538,9 +549,13 @@ export class CacheFirstLoop {
     );
     const pruned = stripDroppableReasoningContent(argsShrunk.messages);
     if (healed.healedCount === 0 && argsShrunk.healedCount === 0 && pruned.prunedCount === 0) {
+      this._healedCache = current;
+      this._healedVersion = this.log.version;
       return current;
     }
     this.log.compactInPlace(pruned.messages);
+    this._healedCache = pruned.messages;
+    this._healedVersion = this.log.version;
     if (this.sessionName) {
       try {
         rewriteSession(this.sessionName, pruned.messages);

--- a/src/memory/runtime.ts
+++ b/src/memory/runtime.ts
@@ -113,6 +113,9 @@ export class AppendOnlyLog {
    *  buildMessages() is called 2-3x per loop iteration. Invalidated by
    *  append / compactInPlace / initWindow. */
   private _fullHistoryCache: { version: number; messages: ChatMessage[] } | null = null;
+  // Monotonic counter bumped on every mutation. Consumers compare against
+  // their own snapshot to detect staleness without destructive check-and-clear.
+  private _version = 0;
 
   constructor(opts?: { windowSize?: number; sessionPath?: string }) {
     this._windowSize = opts?.windowSize ?? DEFAULT_WINDOW;
@@ -128,6 +131,7 @@ export class AppendOnlyLog {
         : [...messages];
     this._totalLength = messages.length;
     this._fullHistoryCache = null;
+    this._version++;
   }
 
   append(message: ChatMessage): void {
@@ -140,6 +144,7 @@ export class AppendOnlyLog {
       this._entries.shift();
     }
     this._fullHistoryCache = null;
+    this._version++;
   }
 
   extend(messages: ChatMessage[]): void {
@@ -151,6 +156,7 @@ export class AppendOnlyLog {
     this._entries = [...replacement];
     this._totalLength = replacement.length;
     this._fullHistoryCache = null;
+    this._version++;
   }
 
   // Checks memory window first; falls back to disk for older messages.
@@ -205,6 +211,12 @@ export class AppendOnlyLog {
 
   get sessionPath(): string | null {
     return this._sessionPath;
+  }
+
+  /** Monotonic version counter — bumped on every mutation. Consumers store
+   *  their own snapshot and compare to detect staleness (non-destructive). */
+  get version(): number {
+    return this._version;
   }
 }
 


### PR DESCRIPTION
## Summary

- `healActiveLogBeforeSend()` runs 3 expensive passes (shrink oversized results, tokenize + shrink tool-call args, strip droppable reasoning) on every `buildMessages()` call — which happens 2-3 times per loop iteration.
- In the common case (nothing to heal), all 3 passes scan every message for nothing.
- Add a monotonic `_version` counter to `AppendOnlyLog` that bumps on every mutation. Cache the healed result in the loop alongside the log version at which it was computed. When the version matches, skip the entire healing pipeline.

## Why this matters

For a 10-iteration turn with 100 messages, `buildMessages()` is called 20-30 times. Without caching, each call runs:
1. `toFullHistory()` — full array copy
2. `healLoadedMessages` — walks every message, calls `shrinkOversizedToolResults` + `fixToolCallPairing`
3. `shrinkOversizedToolCallArgsByTokens` — walks every assistant message, `JSON.stringify` + `countTokensBounded`
4. `stripDroppableReasoningContent` — walks every message

With caching, the 2nd and 3rd calls per iteration (which see no log changes) return the cached result in O(1), eliminating **~2,000-3,000 unnecessary message inspections** and **~500 unnecessary tokenization calls** per turn.

## How it works

- Added `_version: number` to `AppendOnlyLog`, bumped in `append()`, `extend()`, `compactInPlace()`, `initWindow()`
- Added `get version()` accessor
- Added `_healedCache: { version: number; messages: ChatMessage[] } | null` to `CacheFirstLoop`
- `healActiveLogBeforeSend()` checks `_healedCache.version === this.log.version` — returns cached result when fresh
- After healing (with or without mutations), snapshots `this.log.version` into the cache

## Test plan

- [x] Type check passes (`tsc --noEmit`)
- [x] Biome lint passes
- [x] All existing tests pass (config, session, context-manager-fold-timeout)
- [x] Manual: multi-iteration agent turn runs correctly with healing cache active