### PR TITLE
fix(ui): apply themed background to input area and app surface

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -198,8 +198,7 @@ import { InflightProvider } from "./state/inflight-context.js";
 import { AgentStoreProvider, useAgentState, useAgentStore } from "./state/provider.js";
 import { VerboseContext } from "./state/verbose-context.js";
 import { ThemeProvider } from "./theme/context.js";
-import { listThemeNames } from "./theme/tokens.js";
-import { FG, type ThemeName } from "./theme/tokens.js";
+import { FG, SURFACE, type ThemeName, listThemeNames } from "./theme/tokens.js";
 import { TickerProvider, useSlowTick } from "./ticker.js";
 import { handleTurnInterrupt } from "./turn-interrupt.js";
 import { codeUndoContextMessage, codeUndoInfo } from "./undo-context.js";
@@ -4290,7 +4289,7 @@ function AppInner({
     <>
       <TickerProvider disabled={tickerSuspended}>
         <InflightProvider inflight={loop.inflight}>
-          <Box flexDirection="row">
+          <Box flexDirection="row" backgroundColor={SURFACE.bg}>
             <Box flexDirection="column" flexGrow={1}>
               <Box flexDirection="column" flexGrow={1}>
                 <LiveExpandContext.Provider value={liveExpand}>

--- a/src/cli/ui/ComposerArea.tsx
+++ b/src/cli/ui/ComposerArea.tsx
@@ -20,6 +20,7 @@ import { SlashSuggestions } from "./SlashSuggestions.js";
 
 import { StatusRow } from "./layout/StatusRow.js";
 import { formatLoopStatus } from "./loop.js";
+import { SURFACE } from "./theme/tokens.js";
 import { useSlowTick } from "./ticker.js";
 
 import type { StatusBarConfig } from "./layout/StatusRow.js";
@@ -110,7 +111,12 @@ export const ComposerArea: React.FC<ComposerAreaProps> = React.memo(
   }) => {
     useRenderTrace("ComposerArea");
     const inputArea = (
-      <Box flexDirection="column" flexShrink={0} flexWrap="nowrap">
+      <Box
+        flexDirection="column"
+        flexShrink={0}
+        flexWrap="nowrap"
+        backgroundColor={SURFACE.bgInput}
+      >
         <Box flexDirection="column" flexShrink={0} flexWrap="nowrap">
           {slashMatches !== null ? (
             <SlashSuggestions

--- a/src/cli/ui/PromptInput.tsx
+++ b/src/cli/ui/PromptInput.tsx
@@ -244,6 +244,7 @@ export function PromptInput({
       borderLeft={false}
       borderRight={false}
       borderColor={inputActive ? TONE.brand : FG.faint}
+      backgroundColor={SURFACE.bgInput}
       borderText={
         borderLabel ? { content: borderLabel, position: "top", align: "end", offset: 2 } : undefined
       }


### PR DESCRIPTION
## Summary

- Apply `SURFACE.bg` to the root App layout Box so the entire UI renders on the theme's background instead of the terminal's default
- Apply `SURFACE.bgInput` to the PromptInput and ComposerArea wrappers so the input area has a distinct themed surface
- On terminals whose default background differs from the theme (e.g. iTerm), this fixes: input text blending into the background, theme surface colors being invisible, and faint text disappearing

## Changes

1. **`src/cli/ui/App.tsx`** — merged `SURFACE` import, added `backgroundColor={SURFACE.bg}` to root layout Box
2. **`src/cli/ui/ComposerArea.tsx`** — added `SURFACE` import, added `backgroundColor={SURFACE.bgInput}` to outer composer wrapper
3. **`src/cli/ui/PromptInput.tsx`** — added `backgroundColor={SURFACE.bgInput}` to the bordered input Box (`SURFACE` was already imported)

## Test plan

- Launch CLI in iTerm (or any terminal with non-theme default background) — input area should have a distinct darker background
- Text should be clearly readable against the themed surface
- Switch themes with `/theme` — backgrounds should change accordingly
- Border, placeholder, and faint text should remain visible