### PR TITLE
fix(ui): theme Pill component colors via ThemeTokens proxy

### DIFF
--- a/src/cli/ui/ModelPicker.tsx
+++ b/src/cli/ui/ModelPicker.tsx
@@ -3,7 +3,7 @@ import React, { useState } from "react";
 import type { ReasoningEffort } from "../../config.js";
 import { t } from "../../i18n/index.js";
 import { useKeystroke } from "./keystroke-context.js";
-import { PILL_MODEL, Pill, modelBadgeFor } from "./primitives/Pill.js";
+import { Pill, modelBadgeFor, pillModel } from "./primitives/Pill.js";
 import { FG, TONE } from "./theme/tokens.js";
 
 export type ModelPickerOutcome =
@@ -187,7 +187,7 @@ function ModelRow({
         {id.padEnd(24)}
       </Text>
       <Text> </Text>
-      <Pill label={badge.label} {...PILL_MODEL[badge.kind]} bold={false} />
+      <Pill label={badge.label} {...pillModel()[badge.kind]} bold={false} />
       {active ? <Text color={TONE.brand}>{t("modelPicker.currentLabel")}</Text> : null}
     </Box>
   );

--- a/src/cli/ui/cards/ReasoningCard.tsx
+++ b/src/cli/ui/cards/ReasoningCard.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { t } from "../../../i18n/index.js";
 import { Card } from "../primitives/Card.js";
 import { CursorBlock } from "../primitives/CursorBlock.js";
-import { PILL_MODEL, Pill, modelBadgeFor } from "../primitives/Pill.js";
+import { Pill, modelBadgeFor, pillModel } from "../primitives/Pill.js";
 import { PULSE_DIAMOND, Pulse } from "../primitives/Pulse.js";
 import type { ReasoningCard as ReasoningCardData } from "../state/cards.js";
 import { VerboseContext } from "../state/verbose-context.js";
@@ -87,7 +87,7 @@ function ReasoningHeader({
         {`${baseTitle}${metaTrail}${collapsedHint}`}
       </Text>
       {modelBadge ? (
-        <Pill label={modelBadge.label} {...PILL_MODEL[modelBadge.kind]} bold={false} />
+        <Pill label={modelBadge.label} {...pillModel()[modelBadge.kind]} bold={false} />
       ) : null}
     </Box>
   );

--- a/src/cli/ui/cards/StreamingCard.tsx
+++ b/src/cli/ui/cards/StreamingCard.tsx
@@ -6,7 +6,7 @@ import { LiveExpandContext } from "../layout/LiveExpandContext.js";
 import { Markdown } from "../markdown.js";
 import { Card } from "../primitives/Card.js";
 import { CardHeader } from "../primitives/CardHeader.js";
-import { PILL_MODEL, Pill, modelBadgeFor } from "../primitives/Pill.js";
+import { Pill, modelBadgeFor, pillModel, pillPath } from "../primitives/Pill.js";
 import { PULSE_CIRCLE, Pulse } from "../primitives/Pulse.js";
 import type { StreamingCard as StreamingCardData } from "../state/cards.js";
 import { clipToCells } from "../text-width.js";
@@ -91,7 +91,7 @@ function useLiveTokenRate(card: StreamingCardData, enabled: boolean): TokenRate 
   return rateFromTokens(estimate.tokens, card.ts, Date.now());
 }
 
-const PILL_RATE = { bg: "#11141a", fg: "#8b949e" } as const;
+const pillRate = pillPath;
 
 export function StreamingCard({ card }: { card: StreamingCardData }): React.ReactElement {
   const { stdout } = useStdout();
@@ -103,14 +103,14 @@ export function StreamingCard({ card }: { card: StreamingCardData }): React.Reac
 
   const modelBadge = card.model ? modelBadgeFor(card.model) : null;
   const modelPill = modelBadge ? (
-    <Pill label={modelBadge.label} {...PILL_MODEL[modelBadge.kind]} bold={false} />
+    <Pill label={modelBadge.label} {...pillModel()[modelBadge.kind]} bold={false} />
   ) : null;
 
   if (card.done && !card.aborted) {
     const { tokens, tps } = tokenRate(card.text, card.ts, card.endedAt ?? Date.now());
     const ratePill =
       tokens >= MIN_TOKENS_FOR_RATE && tps !== null ? (
-        <Pill label={`${formatTokenCount(tokens)} tok · ${tps} t/s`} {...PILL_RATE} bold={false} />
+        <Pill label={`${formatTokenCount(tokens)} tok · ${tps} t/s`} {...pillRate()} bold={false} />
       ) : null;
     return (
       <Card tone={TONE.ok}>
@@ -144,10 +144,10 @@ export function StreamingCard({ card }: { card: StreamingCardData }): React.Reac
 
   const liveRatePill =
     !aborted && liveRate.tokens >= MIN_TOKENS_FOR_RATE && liveRate.tps !== null ? (
-      <Pill label={`${liveRate.tps} t/s`} {...PILL_RATE} bold={false} />
+      <Pill label={`${liveRate.tps} t/s`} {...pillRate()} bold={false} />
     ) : null;
   const expandPill = !aborted ? (
-    <Pill label={expanded ? "expanded ⌃o" : "preview ⌃o"} {...PILL_RATE} bold={false} />
+    <Pill label={expanded ? "expanded ⌃o" : "preview ⌃o"} {...pillRate()} bold={false} />
   ) : null;
 
   return (

--- a/src/cli/ui/cards/TaskCard.tsx
+++ b/src/cli/ui/cards/TaskCard.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { t } from "../../../i18n/index.js";
 import { Card } from "../primitives/Card.js";
 import { CardHeader } from "../primitives/CardHeader.js";
-import { PILL_PATH, Pill } from "../primitives/Pill.js";
+import { Pill, pillPath } from "../primitives/Pill.js";
 import { PULSE_TRIANGLE, Pulse } from "../primitives/Pulse.js";
 import type { TaskCard as TaskCardData, TaskStep } from "../state/cards.js";
 import { useThemeTokens } from "../theme/context.js";
@@ -61,7 +61,7 @@ export function TaskCard({ card }: { card: TaskCardData }): React.ReactElement {
           <Text bold color={fg.body}>
             {(step.toolName ?? t("cardLabels.stepLabel")).padEnd(7)}
           </Text>
-          <Pill label={step.title} {...PILL_PATH} bold={false} />
+          <Pill label={step.title} {...pillPath()} bold={false} />
           {step.detail ? <Text color={fg.faint}>{step.detail}</Text> : null}
           {step.elapsedMs !== undefined ? (
             <Text color={fg.faint}>{`${(step.elapsedMs / 1000).toFixed(2)}s`}</Text>

--- a/src/cli/ui/layout/LiveRows.tsx
+++ b/src/cli/ui/layout/LiveRows.tsx
@@ -7,7 +7,7 @@ import { t } from "../../../i18n/index.js";
 import type { JobRegistry } from "../../../tools/jobs.js";
 import { Card } from "../primitives/Card.js";
 import { CardHeader } from "../primitives/CardHeader.js";
-import { PILL_MODEL, PILL_SECTION, Pill, modelBadgeFor } from "../primitives/Pill.js";
+import { Pill, modelBadgeFor, pillModel } from "../primitives/Pill.js";
 import { PULSE_CIRCLE, PULSE_HEX, PULSE_SQUARE, Pulse } from "../primitives/Pulse.js";
 import { useAgentState } from "../state/provider.js";
 import { useThemeTokens } from "../theme/context.js";
@@ -227,7 +227,7 @@ export function SubagentRow({ activity }: { activity: SubagentActivity }) {
         meta={[`iter ${activity.iter}`, `${seconds}s`]}
         right={
           modelBadge ? (
-            <Pill label={modelBadge.label} {...PILL_MODEL[modelBadge.kind]} bold={false} />
+            <Pill label={modelBadge.label} {...pillModel()[modelBadge.kind]} bold={false} />
           ) : null
         }
       />

--- a/src/cli/ui/primitives/Pill.tsx
+++ b/src/cli/ui/primitives/Pill.tsx
@@ -3,6 +3,7 @@
 import { type Color, Text } from "ink";
 // biome-ignore lint/style/useImportType: tsconfig jsx=react needs React in value scope for JSX compilation
 import React from "react";
+import { PILL } from "../theme/tokens.js";
 
 export interface PillProps {
   label: string;
@@ -15,34 +16,24 @@ export function Pill({ label, bg, fg, bold = true }: PillProps): React.ReactElem
   return <Text backgroundColor={bg} color={fg} bold={bold}>{` ${label} `}</Text>;
 }
 
-/** Section pill bg tints — muted accent-of-card-tone, paired with the tone's fg. */
-export const PILL_SECTION = {
-  reason: { bg: "#2a1f3d", fg: "#d2a8ff" },
-  output: { bg: "#0d1d2e", fg: "#79c0ff" },
-  tool: { bg: "#0f2230", fg: "#79c0ff" },
-  shell: { bg: "#0f2230", fg: "#79c0ff" },
-  task: { bg: "#0d1d2e", fg: "#79c0ff" },
-  taskDone: { bg: "#102815", fg: "#7ee787" },
-  taskFailed: { bg: "#2c1416", fg: "#ff8b81" },
-  plan: { bg: "#2a1f3d", fg: "#d2a8ff" },
-  user: { bg: "#1a2433", fg: "#79c0ff" },
-  empty: { bg: "#11141a", fg: "#6e7681" },
-} as const;
+/** Section pill colors — derived from active theme via PILL proxy. */
+export function pillSection(): typeof PILL.section {
+  return PILL.section;
+}
 
-/** Path pill — bg-elev tint for filenames / paths / shell targets inside tool rows. */
-export const PILL_PATH = { bg: "#11141a", fg: "#8b949e" } as const;
+/** Path pill — theme-aware bg-elev tint for filenames / paths. */
+export function pillPath(): typeof PILL.path {
+  return PILL.path;
+}
 
-/** Model pill — neutral bg, color signals model class. */
-export const PILL_MODEL = {
-  flash: { bg: "#11141a", fg: "#79c0ff" },
-  pro: { bg: "#11141a", fg: "#d2a8ff" },
-  r1: { bg: "#11141a", fg: "#b395f5" },
-  unknown: { bg: "#11141a", fg: "#8b949e" },
-} as const;
+/** Model pill — theme-aware neutral bg, color signals model class. */
+export function pillModel(): typeof PILL.model {
+  return PILL.model;
+}
 
 export interface ModelBadge {
   label: string;
-  kind: keyof typeof PILL_MODEL;
+  kind: keyof typeof PILL.model;
 }
 
 /** Map full DeepSeek model id to short label + color class. */

--- a/src/cli/ui/theme.ts
+++ b/src/cli/ui/theme.ts
@@ -3,6 +3,7 @@ import React from "react";
 import { useThemeTokens } from "./theme/context.js";
 import {
   CARD,
+  PILL,
   FG as TOKEN_FG,
   MESSAGE_BG as TOKEN_MESSAGE_BG,
   SURFACE as TOKEN_SURFACE,
@@ -94,6 +95,7 @@ function currentTheme(): ThemeTokens {
     surface: TOKEN_SURFACE,
     messageBg: TOKEN_MESSAGE_BG,
     card: CARD,
+    pill: PILL,
   };
 }
 

--- a/src/cli/ui/theme/tokens.ts
+++ b/src/cli/ui/theme/tokens.ts
@@ -31,6 +31,24 @@ export interface ThemeTokens {
     bash: Color;
     selected: Color;
   };
+  pill: {
+    bg: Color;
+    section: Record<
+      | "reason"
+      | "output"
+      | "tool"
+      | "shell"
+      | "task"
+      | "taskDone"
+      | "taskFailed"
+      | "plan"
+      | "user"
+      | "empty",
+      { bg: Color; fg: Color }
+    >;
+    path: { bg: Color; fg: Color };
+    model: Record<"flash" | "pro" | "r1" | "unknown", { bg: Color; fg: Color }>;
+  };
   card: Record<
     | "user"
     | "reasoning"
@@ -53,7 +71,7 @@ export interface ThemeTokens {
   >;
 }
 
-type ThemeBase = Omit<ThemeTokens, "card">;
+type ThemeBase = Omit<ThemeTokens, "card" | "pill">;
 
 function card(fg: ThemeTokens["fg"], tone: ThemeTokens["tone"]): ThemeTokens["card"] {
   return {
@@ -77,8 +95,38 @@ function card(fg: ThemeTokens["fg"], tone: ThemeTokens["tone"]): ThemeTokens["ca
   };
 }
 
+function pill(
+  surface: ThemeTokens["surface"],
+  tone: ThemeTokens["tone"],
+  fg: ThemeTokens["fg"],
+): ThemeTokens["pill"] {
+  const bg = surface.bgElev;
+  return {
+    bg,
+    section: {
+      reason: { bg, fg: tone.violet },
+      output: { bg, fg: tone.info },
+      tool: { bg, fg: tone.info },
+      shell: { bg, fg: tone.info },
+      task: { bg, fg: tone.info },
+      taskDone: { bg, fg: tone.ok },
+      taskFailed: { bg, fg: tone.err },
+      plan: { bg, fg: tone.violet },
+      user: { bg, fg: tone.brand },
+      empty: { bg, fg: fg.faint },
+    },
+    path: { bg, fg: fg.meta },
+    model: {
+      flash: { bg, fg: tone.info },
+      pro: { bg, fg: tone.violet },
+      r1: { bg, fg: tone.accent },
+      unknown: { bg, fg: fg.meta },
+    },
+  };
+}
+
 function defineTheme(base: ThemeBase): ThemeTokens {
-  return { ...base, card: card(base.fg, base.tone) };
+  return { ...base, card: card(base.fg, base.tone), pill: pill(base.surface, base.tone, base.fg) };
 }
 
 const dark = defineTheme({
@@ -348,6 +396,7 @@ export const TONE_ACTIVE = proxyTokens((theme) => theme.toneActive);
 export const SURFACE = proxyTokens((theme) => theme.surface);
 export const MESSAGE_BG = proxyTokens((theme) => theme.messageBg);
 export const CARD = proxyTokens((theme) => theme.card);
+export const PILL = proxyTokens((theme) => theme.pill);
 
 export type CardTone = keyof ThemeTokens["card"];
 


### PR DESCRIPTION
## Summary

- Replace hardcoded `PILL_SECTION`, `PILL_PATH`, `PILL_MODEL` color constants in `Pill.tsx` with theme-aware functions (`pillSection()`, `pillPath()`, `pillModel()`) that derive colors from the active theme
- Add a `pill` field to `ThemeTokens` with a `pill()` derivation function following the existing `CARD` proxy pattern
- Export `PILL` via `proxyTokens()` so all Pill components automatically respect theme changes

## Changes

1. **`src/cli/ui/theme/tokens.ts`** — added `pill` type to `ThemeTokens`, `pill()` derivation function, and `PILL` proxy export
2. **`src/cli/ui/primitives/Pill.tsx`** — replaced hardcoded color maps with `pillSection()`, `pillPath()`, `pillModel()` functions reading from `PILL`
3. **`src/cli/ui/theme.ts`** — added `PILL` import and `pill: PILL` to `currentTheme()`
4. **Call sites** (`StreamingCard.tsx`, `ReasoningCard.tsx`, `TaskCard.tsx`, `ModelPicker.tsx`, `LiveRows.tsx`) — updated to use new function-based API

## Test plan

- Launch CLI — Pill components (model badges, path pills, section pills) should use theme-derived colors
- Switch themes with `/theme` — all Pills should update to match the new theme
- Verify no visual regression in streaming cards, reasoning cards, task cards, model picker, and subagent rows