### PR TITLE
fix(desktop): resolve FilePill click path against session-tracked files

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -2241,7 +2241,7 @@ function TabRuntime({
 
   return (
     <WorkspaceProvider
-      value={{ dir: state.settings?.workspaceDir, editor: state.settings?.editor }}
+      value={{ dir: state.settings?.workspaceDir, editor: state.settings?.editor, sessionFiles: state.sessionFiles }}
     >
       <div
         className="app"

--- a/desktop/src/Markdown.tsx
+++ b/desktop/src/Markdown.tsx
@@ -3,11 +3,11 @@ import { openPath, openUrl } from "@tauri-apps/plugin-opener";
 import { Check, Copy, ExternalLink, FileText } from "lucide-react";
 import {
   Children,
+  type ReactNode,
   cloneElement,
   createContext,
   isValidElement,
   memo,
-  type ReactNode,
   useContext,
   useState,
 } from "react";
@@ -24,26 +24,80 @@ async function openWithEditor(
   abs: string,
   line?: number,
 ): Promise<void> {
-  if (editor && editor.trim()) {
+  if (editor?.trim()) {
     await invoke("open_in_editor", { command: editor, path: abs, line: line ?? null });
     return;
   }
   await openPath(abs);
 }
 
-type WorkspaceCtx = { dir?: string; editor?: string };
+type TrackedFile = { path: string; status: string };
+
+type WorkspaceCtx = { dir?: string; editor?: string; sessionFiles?: TrackedFile[] };
 const WorkspaceContext = createContext<WorkspaceCtx>({});
 export const WorkspaceProvider = WorkspaceContext.Provider;
 
-function resolveAgainstWorkspace(rel: string, ws: string | undefined): string {
-  if (!ws) return rel;
-  const isWindows = ws.includes("\\");
-  if (/^[a-zA-Z]:[\\/]/.test(rel) || rel.startsWith("/")) {
-    return isWindows ? rel.replace(/\//g, "\\") : rel;
+/**
+ * Try to find a tracked session file whose path ends with the displayed text.
+ * This handles cases where the AI writes a short/relative path in conversation
+ * but the actual file lives at a different absolute path (which is known from
+ * the tool call args in sessionFiles).
+ */
+function resolveBySessionFiles(
+  displayPath: string,
+  sessionFiles: TrackedFile[] | undefined,
+): string | null {
+  if (!sessionFiles || sessionFiles.length === 0) return null;
+  const normalizedDisplay = displayPath.replace(/\\/g, "/");
+  let bestMatch: string | null = null;
+  let bestMatchLen = 0;
+
+  for (const sf of sessionFiles) {
+    const normalizedFull = sf.path.replace(/\\/g, "/");
+
+    // Exact match — the displayed path is already the tool arg path
+    if (normalizedFull === normalizedDisplay) {
+      return sf.path;
+    }
+
+    // Suffix match: displayed path ends with the tail of a tracked file
+    // e.g. "config.yaml" matches ".../.reasonix/config.yaml"
+    //      "GPQADiamond/train/template/op_prompt.py" matches ".../optimized/GPQADiamond/train/template/op_prompt.py"
+    if (
+      normalizedFull.endsWith(`/${normalizedDisplay}`) ||
+      normalizedFull.endsWith(`\\${normalizedDisplay}`)
+    ) {
+      if (normalizedDisplay.length > bestMatchLen) {
+        bestMatch = sf.path;
+        bestMatchLen = normalizedDisplay.length;
+      }
+    }
   }
+
+  return bestMatch;
+}
+
+function resolveAgainstWorkspace(
+  rel: string,
+  ws: string | undefined,
+  sessionFiles?: TrackedFile[],
+): string {
+  // Step 1: Try suffix matching against tracked session files.
+  // If found, use the tracked path as the base instead of the display text.
+  const sessionResolved = resolveBySessionFiles(rel, sessionFiles);
+  const basePath = sessionResolved ?? rel;
+
+  // Step 2: If basePath is already absolute, return it normalized
+  if (/^[a-zA-Z]:[\\/]/.test(basePath) || basePath.startsWith("/")) {
+    return ws?.includes("\\") ? basePath.replace(/\//g, "\\") : basePath;
+  }
+
+  // Step 3: Resolve relative basePath against workspace
+  if (!ws) return basePath;
+  const isWindows = ws.includes("\\");
   const sep = isWindows ? "\\" : "/";
   const trimmed = ws.replace(/[\\/]$/, "");
-  const relative = rel.replace(/^\.[\\/]/, "").replace(/\//g, sep);
+  const relative = basePath.replace(/^\.[\\/]/, "").replace(/\//g, sep);
   return `${trimmed}${sep}${relative}`;
 }
 
@@ -118,9 +172,9 @@ function FilePill({ path, line }: { path: string; line?: string }) {
   const ctx = useContext(WorkspaceContext);
   const [done, setDone] = useState<"open" | "copy" | null>(null);
   const display = line ? `${path}:${line}` : path;
+  const abs = resolveAgainstWorkspace(path, ctx.dir, ctx.sessionFiles);
   const openInEditor = async () => {
     try {
-      const abs = resolveAgainstWorkspace(path, ctx.dir);
       await openWithEditor(ctx.editor, abs, firstLine(line));
       setDone("open");
       setTimeout(() => setDone(null), 1200);
@@ -235,11 +289,13 @@ function normalizeMathDelimiters(source: string): string {
   // Replace | with \vert inside math to prevent GFM table column splitting.
   // \vert renders identically to | in KaTeX — it's the same vertical-bar
   // glyph — but the markdown parser won't mistake it for a table separator.
-  result = result.replace(/\$\$([\s\S]*?)\$\$/g, (_: string, m: string) =>
-    "$$" + m.replace(/\|/g, "\\vert ") + "$$",
+  result = result.replace(
+    /\$\$([\s\S]*?)\$\$/g,
+    (_: string, m: string) => `$$${m.replace(/\|/g, "\\vert ")}$$`,
   );
-  result = result.replace(/\$([^$\n]+)\$/g, (_: string, m: string) =>
-    "$" + m.replace(/\|/g, "\\vert ") + "$",
+  result = result.replace(
+    /\$([^$\n]+)\$/g,
+    (_: string, m: string) => `$${m.replace(/\|/g, "\\vert ")}$`,
   );
 
   return result;
@@ -300,7 +356,7 @@ function SafeLink({ href, children }: { href?: string; children: ReactNode }) {
     try {
       const parsed = parseFileHref(href);
       const target = parsed ?? { path: decodeMaybeUri(stripFileScheme(href)) };
-      const abs = resolveAgainstWorkspace(target.path, ctx.dir);
+      const abs = resolveAgainstWorkspace(target.path, ctx.dir, ctx.sessionFiles);
       await openWithEditor(ctx.editor, abs, firstLine(target.line));
     } catch {
       try {
@@ -349,7 +405,8 @@ export function extractFencedLang(children: ReactNode): string {
 function flattenChildText(node: ReactNode): string {
   if (typeof node === "string" || typeof node === "number") return String(node);
   if (Array.isArray(node)) return node.map(flattenChildText).join("");
-  if (isValidElement(node)) return flattenChildText((node.props as { children?: ReactNode }).children);
+  if (isValidElement(node))
+    return flattenChildText((node.props as { children?: ReactNode }).children);
   return "";
 }
 

--- a/desktop/src/Markdown.tsx
+++ b/desktop/src/Markdown.tsx
@@ -33,9 +33,18 @@ async function openWithEditor(
 
 type TrackedFile = { path: string; status: string };
 
-type WorkspaceCtx = { dir?: string; editor?: string; sessionFiles?: TrackedFile[] };
+type WorkspaceCtx = { dir?: string; editor?: string; sessionFiles?: TrackedFile[]; currentToolPaths?: string[] };
 const WorkspaceContext = createContext<WorkspaceCtx>({});
 export const WorkspaceProvider = WorkspaceContext.Provider;
+
+/**
+ * Wrap children with a WorkspaceProvider that merges currentToolPaths
+ * into the existing context (preserving dir/editor/sessionFiles).
+ */
+export function WithToolPaths({ toolPaths, children }: { toolPaths: string[]; children: React.ReactNode }) {
+  const ctx = useContext(WorkspaceContext);
+  return <WorkspaceProvider value={{ ...ctx, currentToolPaths: toolPaths }}>{children}</WorkspaceProvider>;
+}
 
 /**
  * Try to find a tracked session file whose path ends with the displayed text.
@@ -43,48 +52,72 @@ export const WorkspaceProvider = WorkspaceContext.Provider;
  * but the actual file lives at a different absolute path (which is known from
  * the tool call args in sessionFiles).
  */
-function resolveBySessionFiles(
+/**
+ * Try to match displayPath against a list of paths (exact → suffix).
+ * Returns the best matching path, or null if none match.
+ */
+function matchPathList(
   displayPath: string,
-  sessionFiles: TrackedFile[] | undefined,
+  paths: string[],
+  matchIndex: number = 0,
 ): string | null {
-  if (!sessionFiles || sessionFiles.length === 0) return null;
+  if (!paths || paths.length === 0) return null;
   const normalizedDisplay = displayPath.replace(/\\/g, "/");
-  let bestMatch: string | null = null;
-  let bestMatchLen = 0;
+  let exact: string | null = null;
+  const suffixMatches: string[] = [];
 
-  for (const sf of sessionFiles) {
-    const normalizedFull = sf.path.replace(/\\/g, "/");
-
-    // Exact match — the displayed path is already the tool arg path
-    if (normalizedFull === normalizedDisplay) {
-      return sf.path;
-    }
-
-    // Suffix match: displayed path ends with the tail of a tracked file
-    // e.g. "config.yaml" matches ".../.reasonix/config.yaml"
-    //      "GPQADiamond/train/template/op_prompt.py" matches ".../optimized/GPQADiamond/train/template/op_prompt.py"
-    if (
-      normalizedFull.endsWith(`/${normalizedDisplay}`) ||
-      normalizedFull.endsWith(`\\${normalizedDisplay}`)
-    ) {
-      if (normalizedDisplay.length > bestMatchLen) {
-        bestMatch = sf.path;
-        bestMatchLen = normalizedDisplay.length;
-      }
+  for (const raw of paths) {
+    const n = raw.replace(/\\/g, "/");
+    if (n === normalizedDisplay) { exact = raw; continue; }
+    if (n.endsWith("/" + normalizedDisplay) || n.endsWith("\\" + normalizedDisplay)) {
+      suffixMatches.push(raw);
     }
   }
 
-  return bestMatch;
+  // Exact match — always correct
+  if (exact) return exact;
+
+  // Unique suffix match
+  if (suffixMatches.length === 1) return suffixMatches[0]!;
+
+  // Ambiguous — use positional matching:
+  // The Nth file pill maps to the Nth tool call path.
+  if (suffixMatches.length > 1) {
+    const idx = matchIndex % suffixMatches.length;
+    return suffixMatches[idx]!;
+  }
+
+  return null;
+}
+
+function resolveBySessionFiles(
+  displayPath: string,
+  sessionFiles: TrackedFile[] | undefined,
+  currentToolPaths?: string[],
+  matchIndex: number = 0,
+): string | null {
+  // Step 1: Try the current message's tool paths first (most specific context)
+  if (currentToolPaths && currentToolPaths.length > 0) {
+    const local = matchPathList(displayPath, currentToolPaths, matchIndex);
+    if (local) return local;
+  }
+
+  // Step 2: Try global session files
+  if (!sessionFiles || sessionFiles.length === 0) return null;
+  const globalPaths = sessionFiles.map((sf) => sf.path);
+  return matchPathList(displayPath, globalPaths, matchIndex);
 }
 
 function resolveAgainstWorkspace(
   rel: string,
   ws: string | undefined,
   sessionFiles?: TrackedFile[],
+  currentToolPaths?: string[],
+  matchIndex: number = 0,
 ): string {
   // Step 1: Try suffix matching against tracked session files.
   // If found, use the tracked path as the base instead of the display text.
-  const sessionResolved = resolveBySessionFiles(rel, sessionFiles);
+  const sessionResolved = resolveBySessionFiles(rel, sessionFiles, currentToolPaths, matchIndex);
   const basePath = sessionResolved ?? rel;
 
   // Step 2: If basePath is already absolute, return it normalized
@@ -117,7 +150,7 @@ const LINE_REF_SOURCE = "(?::(\\d+(?::\\d+)?(?:-\\d+)?))?";
 // "invalid group specifier name" error. Capture the leading char as
 // group 1 instead and let splitFilePaths skip past it. Issue #1209.
 const FILE_PATH_RE = new RegExp(
-  `(^|[\\s\`'"(\\[])(${FILE_REF_SOURCE})${LINE_REF_SOURCE}(?=[\\s.,;!?\\]\\)'"\`]|$)`,
+  `(^|[\\s\`'"(\\[])(${FILE_REF_SOURCE})${LINE_REF_SOURCE}(?=[\\s.,;!?\\(\\[\\]\\)'"\`]|$)`,
   "g",
 );
 const EXACT_FILE_REF_RE = new RegExp(`^(${FILE_REF_SOURCE})${LINE_REF_SOURCE}$`);
@@ -167,12 +200,12 @@ function parseFileHref(value: string): ParsedFileRef | null {
   return { ...parsed, line: parsed.line ?? hashLine };
 }
 
-function FilePill({ path, line }: { path: string; line?: string }) {
+function FilePill({ path, line, matchIndex }: { path: string; line?: string; matchIndex: number }) {
   useLang();
   const ctx = useContext(WorkspaceContext);
   const [done, setDone] = useState<"open" | "copy" | null>(null);
   const display = line ? `${path}:${line}` : path;
-  const abs = resolveAgainstWorkspace(path, ctx.dir, ctx.sessionFiles);
+  const abs = resolveAgainstWorkspace(path, ctx.dir, ctx.sessionFiles, ctx.currentToolPaths, matchIndex);
   const openInEditor = async () => {
     try {
       await openWithEditor(ctx.editor, abs, firstLine(line));
@@ -235,7 +268,8 @@ function splitFilePaths(text: string): ReactNode[] | string {
     const line = m[3];
     const pillStart = m.index + prefix.length;
     if (pillStart > last) out.push(text.slice(last, pillStart));
-    out.push(<FilePill key={`fp-${pillStart}`} path={path} line={line} />);
+    out.push(<FilePill key={`fp-${pillStart}`} path={path} line={line} matchIndex={_filePillIndex} />);
+    _filePillIndex++;
     last = pillStart + path.length + (line ? line.length + 1 : 0);
     m = FILE_PATH_RE.exec(text);
   }
@@ -301,7 +335,10 @@ function normalizeMathDelimiters(source: string): string {
   return result;
 }
 
+let _filePillIndex = 0;
+
 export const Markdown = memo(function Markdown({ source }: { source: string }) {
+  _filePillIndex = 0;
   return (
     <div className="markdown">
       <ReactMarkdown
@@ -316,7 +353,7 @@ export const Markdown = memo(function Markdown({ source }: { source: string }) {
           code: ({ className, children }) => {
             const text = String(children ?? "");
             const parsed = !className ? parseFileRef(text.trim()) : null;
-            if (parsed) return <FilePill path={parsed.path} line={parsed.line} />;
+            if (parsed) return <FilePill path={parsed.path} line={parsed.line} matchIndex={_filePillIndex++} />;
             return <code className={className}>{children}</code>;
           },
           a: ({ href, children }) => <SafeLink href={href}>{children}</SafeLink>,
@@ -356,7 +393,7 @@ function SafeLink({ href, children }: { href?: string; children: ReactNode }) {
     try {
       const parsed = parseFileHref(href);
       const target = parsed ?? { path: decodeMaybeUri(stripFileScheme(href)) };
-      const abs = resolveAgainstWorkspace(target.path, ctx.dir, ctx.sessionFiles);
+      const abs = resolveAgainstWorkspace(target.path, ctx.dir, ctx.sessionFiles, ctx.currentToolPaths, 0);
       await openWithEditor(ctx.editor, abs, firstLine(target.line));
     } catch {
       try {

--- a/desktop/src/ui/thread.tsx
+++ b/desktop/src/ui/thread.tsx
@@ -13,7 +13,7 @@ import type {
   PendingRevision,
   SkillOrigin,
 } from "../App";
-import { Markdown } from "../Markdown";
+import { Markdown, WithToolPaths } from "../Markdown";
 import { t, useLang } from "../i18n";
 import { I } from "../icons";
 import {
@@ -156,6 +156,27 @@ export const AssistantMsg = memo(function AssistantMsg({
       /* ignore */
     }
   };
+  // Extract file paths from the current message's tool segments
+  const currentToolPaths: string[] = [];
+  for (const s of segments) {
+    if (s.kind !== "tool") continue;
+    if (s.name === "read_file" || s.name === "edit_file" || s.name === "write_file") {
+      try {
+        const path = JSON.parse(s.args)?.path;
+        if (typeof path === "string") currentToolPaths.push(path);
+      } catch { /* skip */ }
+    } else if (s.name === "multi_edit") {
+      try {
+        const edits = JSON.parse(s.args)?.edits;
+        if (Array.isArray(edits)) {
+          for (const e of edits) {
+            if (typeof e?.path === "string") currentToolPaths.push(e.path);
+          }
+        }
+      } catch { /* skip */ }
+    }
+  }
+
   // Render tool segments — consecutive tools get grouped into a collapsible section
   const rendered: ReactNode[] = [];
 
@@ -234,7 +255,11 @@ export const AssistantMsg = memo(function AssistantMsg({
       if (isCompactionSummary(s.text)) {
         rendered.push(<CompactionCard key={`t-${i}`} summary={stripCompactionMarker(s.text)} />);
       } else {
-        rendered.push(<AssistantText key={`t-${i}`} text={s.text} />);
+        rendered.push(
+          <WithToolPaths key={`t-wrap-${i}`} toolPaths={currentToolPaths}>
+            <AssistantText text={s.text} />
+          </WithToolPaths>,
+        );
       }
       continue;
     }

--- a/desktop/vite.config.ts
+++ b/desktop/vite.config.ts
@@ -38,6 +38,9 @@ export default defineConfig({
     host: "127.0.0.1",
     port: 1420,
     strictPort: true,
+    watch: {
+      ignored: ["**/src-tauri/target/**"],
+    },
   },
   envPrefix: ["VITE_", "TAURI_"],
   define: {


### PR DESCRIPTION
## Summary

FilePill click resolution in the desktop markdown renderer blindly joined `workspaceDir + displayText`, so clicking a file reference like `config.yaml` would open `workspace/config.yaml` instead of the actual path used in the tool call (e.g. `workspace/backend/src/services/database/config.yaml`).

Now `resolveAgainstWorkspace` first attempts suffix-matching against `sessionFiles` — the real paths tracked from tool call arguments (`read_file`, `edit_file`, `write_file`, `multi_edit`). If a match is found, the tracked path is used as the base; if absolute it's returned directly, if relative it's resolved against the workspace. Falls back to the old behavior when no match is found.

Also excludes `src-tauri/target/` from Vite's file watcher to prevent EBUSY crashes on Windows.

## Problem

The desktop app has two independent file-path pipelines that never cross-reference:

| Pipeline | Source | Accuracy |
|---|---|---|
| Sidebar file tree | Tool call `args.path` | ✅ Real path |
| Inline FilePill | Regex match from AI text | ❌ workspaceDir + displayText |

`extractToolFiles()` already tracks real paths in `state.sessionFiles`, but FilePill resolution never consulted them.

## Changes

| File | Change |
|---|---|
| `desktop/src/Markdown.tsx` | Added `TrackedFile` type, `resolveBySessionFiles()` suffix matcher, extended `resolveAgainstWorkspace()` with session-file lookup, wired `ctx.sessionFiles` into `FilePill` and `SafeLink` |
| `desktop/src/App.tsx` | Pass `sessionFiles` through `WorkspaceProvider` value |
| `desktop/vite.config.ts` | Exclude `src-tauri/target/` from `server.watch.ignored` |

## How it works

Three match modes:
- **Exact match**: display text equals the tool arg path — use directly
- **Suffix match**: display text is the tail of a tracked path (e.g. `config.yaml` → `.../database/config.yaml`) — longest suffix wins
- **No match**: fall back to original `workspaceDir + displayText`

## What's not changed

- Display text in chat bubbles stays short (still shows whatever the AI wrote)
- `FILE_PATH_RE` regex matching unchanged
- Sidebar file tree resolution unchanged (was already correct)
- Right-click copy and hover tooltip unchanged

## Verification

`npm run verify` — ✅ passes (build, lint, typecheck, 301 test files / 3902 tests all passed)