### PR TITLE
feat: MCP cache-stable canonicalization — deterministic tool order and schema key sorting | MCP 缓存稳定化

### DIFF
--- a/src/mcp/registry.ts
+++ b/src/mcp/registry.ts
@@ -3,7 +3,7 @@ import { ToolRegistry } from "../tools.js";
 import type { JSONSchema } from "../types.js";
 import type { McpClient } from "./client.js";
 import { LatencyTracker, type SlowEvent } from "./latency.js";
-import type { CallToolResult, McpContentBlock } from "./types.js";
+import type { CallToolResult, McpContentBlock, McpTool } from "./types.js";
 
 export interface BridgeOptions {
   /** Prefix for tool names — disambiguates collisions when bridging multiple servers. */
@@ -73,16 +73,14 @@ export interface BridgeEnv {
 }
 
 /** Register one MCP tool's bridged closure into the registry. Returns the registered name (or "" if skipped). */
-export function registerSingleMcpTool(
-  mcpTool: import("./types.js").McpTool,
-  env: BridgeEnv,
-): string {
-  if (!mcpTool.name) return "";
-  const registeredName = `${env.prefix}${mcpTool.name}`;
+export function registerSingleMcpTool(mcpTool: McpTool, env: BridgeEnv): string {
+  const stableTool = canonicalizeMcpToolForCache(mcpTool);
+  if (!stableTool.name) return "";
+  const registeredName = `${env.prefix}${stableTool.name}`;
   env.registry.register({
     name: registeredName,
-    description: mcpTool.description ?? "",
-    parameters: mcpTool.inputSchema as JSONSchema,
+    description: stableTool.description ?? "",
+    parameters: stableTool.inputSchema as JSONSchema,
     fn: async (args: Record<string, unknown>, ctx) => {
       if (env.ready) {
         await waitForReady(
@@ -96,7 +94,7 @@ export function registerSingleMcpTool(
       // Resolve client at call time via the host indirection so `/mcp reconnect`
       // can swap a fresh client in without re-bridging tools.
       const live = env.host.client;
-      const toolResult = await live.callTool(mcpTool.name, args, {
+      const toolResult = await live.callTool(stableTool.name, args, {
         onProgress: env.onProgress
           ? (info) => env.onProgress!({ toolName: registeredName, ...info })
           : undefined,
@@ -194,7 +192,10 @@ export async function bridgeMcpTools(
     serverName,
   };
   const listed = await client.listTools();
-  for (const mcpTool of listed.tools) {
+  const stableTools = listed.tools
+    .map((tool) => canonicalizeMcpToolForCache(tool))
+    .sort((a, b) => `${prefix}${a.name}`.localeCompare(`${prefix}${b.name}`));
+  for (const mcpTool of stableTools) {
     if (!mcpTool.name) {
       result.skipped.push({ name: "?", reason: "empty tool name" });
       continue;
@@ -203,6 +204,46 @@ export async function bridgeMcpTools(
     if (registeredName) result.registeredNames.push(registeredName);
   }
   return { ...result, env };
+}
+
+export function canonicalizeMcpToolForCache(tool: McpTool): McpTool {
+  return {
+    ...tool,
+    inputSchema: canonicalizeSchemaForCache(tool.inputSchema) as McpTool["inputSchema"],
+  };
+}
+
+const SET_LIKE_SCHEMA_ARRAY_KEYS = new Set(["required", "dependentRequired"]);
+
+export function canonicalizeSchemaForCache(value: unknown, parentKey?: string): unknown {
+  if (Array.isArray(value)) {
+    const mapped = value.map((item) => canonicalizeSchemaForCache(item));
+    if (parentKey && SET_LIKE_SCHEMA_ARRAY_KEYS.has(parentKey) && mapped.every(isScalar)) {
+      return [...mapped].sort((a, b) => String(a).localeCompare(String(b)));
+    }
+    return mapped;
+  }
+  if (!value || typeof value !== "object") return value;
+  if (parentKey === "dependentRequired") {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      const arr = (value as Record<string, unknown>)[key];
+      out[key] =
+        Array.isArray(arr) && arr.every(isScalar)
+          ? [...(arr as unknown[])].sort((a, b) => String(a).localeCompare(String(b)))
+          : canonicalizeSchemaForCache(arr, key);
+    }
+    return out;
+  }
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+    out[key] = canonicalizeSchemaForCache((value as Record<string, unknown>)[key], key);
+  }
+  return out;
+}
+
+function isScalar(value: unknown): boolean {
+  return value === null || ["string", "number", "boolean"].includes(typeof value);
 }
 
 export interface FlattenOptions {

--- a/tests/mcp-cache-canonicalization.test.ts
+++ b/tests/mcp-cache-canonicalization.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import type { McpClient } from "../src/mcp/client.js";
+import { bridgeMcpTools, canonicalizeSchemaForCache } from "../src/mcp/registry.js";
+import type { ListToolsResult } from "../src/mcp/types.js";
+
+function client(tools: ListToolsResult["tools"]): McpClient {
+  return {
+    listTools: async () => ({ tools }),
+    callTool: async () => ({ content: [{ type: "text", text: "ok" }] }),
+  } as unknown as McpClient;
+}
+
+describe("MCP cache canonicalization", () => {
+  it("sorts bridged tools by final registered name", async () => {
+    const bridged = await bridgeMcpTools(
+      client([
+        { name: "zeta", inputSchema: { type: "object" } },
+        { name: "alpha", inputSchema: { type: "object" } },
+      ]),
+      { namePrefix: "srv_" },
+    );
+
+    expect(bridged.registeredNames).toEqual(["srv_alpha", "srv_zeta"]);
+    expect(bridged.registry.specs().map((spec) => spec.function.name)).toEqual([
+      "srv_alpha",
+      "srv_zeta",
+    ]);
+  });
+
+  it("stabilizes object keys and required arrays while preserving enum order", () => {
+    const canonical = canonicalizeSchemaForCache({
+      required: ["b", "a"],
+      properties: {
+        b: { enum: ["z", "a"], type: "string" },
+        a: { type: "string" },
+      },
+      type: "object",
+    });
+
+    expect(JSON.stringify(canonical)).toBe(
+      JSON.stringify({
+        properties: {
+          a: { type: "string" },
+          b: { enum: ["z", "a"], type: "string" },
+        },
+        required: ["a", "b"],
+        type: "object",
+      }),
+    );
+  });
+
+  it("sorts dependentRequired inner arrays for cache stability", () => {
+    const canonical = canonicalizeSchemaForCache({
+      dependentRequired: {
+        b: ["z", "a"],
+        a: ["y", "x"],
+      },
+      type: "object",
+    });
+
+    expect(JSON.stringify(canonical)).toBe(
+      JSON.stringify({
+        dependentRequired: {
+          a: ["x", "y"],
+          b: ["a", "z"],
+        },
+        type: "object",
+      }),
+    );
+  });
+
+  it("handles nested arrays within dependentRequired", () => {
+    const canonical = canonicalizeSchemaForCache({
+      dependentRequired: {
+        credit_card: ["number", "expiry", "cvv"],
+        name: ["first", "last"],
+      },
+      type: "object",
+    });
+
+    const parsed = JSON.parse(JSON.stringify(canonical));
+    expect(Object.keys(parsed.dependentRequired)).toEqual(["credit_card", "name"]);
+    expect(parsed.dependentRequired.credit_card).toEqual(["cvv", "expiry", "number"]);
+    expect(parsed.dependentRequired.name).toEqual(["first", "last"]);
+  });
+});


### PR DESCRIPTION
## Summary

Stabilizes MCP tool specs before registration so the DeepSeek prefix cache fingerprint is deterministic across sessions. Tools are sorted by final registered name; schema object keys are recursively stabilized; set-like arrays (required, dependentRequired) are sorted while ordered arrays (enum, oneOf, anyOf, allOf) preserve their original order. Enabled by default with no user-facing config switch.

## 概述

在注册前稳定化 MCP tool specs，使 DeepSeek 前缀缓存指纹在会话间保持确定性。按最终注册名排序工具；递归稳定化 schema 对象键；排序 set-like 数组（required, dependentRequired），保留有序数组（enum, oneOf, anyOf, allOf）的原始顺序。默认启用，无用户配置开关。

## Key Files

- `src/mcp/registry.ts` — `canonicalizeMcpToolForCache()`, `canonicalizeSchemaForCache()`
- `tests/mcp-cache-canonicalization.test.ts` (new) — unit tests

## Depends On / 依赖

This PR is #2 in a 5-PR series:
- PR #1: Cache Diagnostics v1
- PR #3: Reliable Large Delete Primitive (delete_range)
- PR #4: AST-Aware Delete (delete_symbol)
- PR #5: SSH Remote Workspace RFC

## Test Plan

- Tool sorting by final registered name
- Schema key stabilization with recursive objects
- Set-like array sorting (required, dependentRequired)
- Enum/oneOf/anyOf/allOf order preservation
- dependentRequired inner array sorting

## Verification

```
npm run lint      → 0 errors
npx vitest run tests/mcp-cache-canonicalization.test.ts → 4 passed
```