### PR TITLE
feat: delete_range — reliable large text deletion with anchor-based range matching | 大块文本删除工具

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -138,7 +138,7 @@ import type { PickerSnapshot, ViewerSnapshot } from "./dashboard/use-picker-broa
 import { useViewerBroadcast } from "./dashboard/use-picker-broadcast.js";
 import { formatEditResults, formatPendingPreview } from "./edit-history.js";
 import {
-  buildEditToolBlocks,
+  buildEditToolBlocksForReview,
   formatQueuedReviewToolResult,
   isReviewGatedEditTool,
   shouldApplyEditToolImmediately,
@@ -2043,7 +2043,7 @@ function AppInner({
       // otherwise edit_file writes to the OLD root while read_file looks in
       // the NEW one, producing ENOENT on the next read of a just-edited file.
       const rootForEdit = currentRootDirRef.current;
-      const blocks = buildEditToolBlocks(name, args, rootForEdit);
+      const blocks = await buildEditToolBlocksForReview(name, args, rootForEdit, loop.readTracker);
       if (!blocks || blocks.length === 0) return null;
 
       // Helper: apply the current block(s) + record into history + arm

--- a/src/cli/ui/edit-tool-gate.ts
+++ b/src/cli/ui/edit-tool-gate.ts
@@ -1,15 +1,27 @@
+import { readFileSync } from "node:fs";
 import { relative, resolve } from "node:path";
 import { type EditBlock, toWholeFileEditBlock } from "../../code/edit-blocks.js";
+import { decodeFileBuffer } from "../../code/file-encoding.js";
 import type { EditMode } from "../../config.js";
 import { looksLikeAbsoluteSystemPath, pathIsUnder } from "../../tools/filesystem.js";
+import { computeDeleteRangePatchFromText } from "../../tools/fs/edit.js";
+import type { ReadTracker } from "../../tools/read-tracker.js";
 
-export type ReviewGatedEditTool = "edit_file" | "write_file" | "multi_edit";
+export type ReviewGatedEditTool = "edit_file" | "write_file" | "multi_edit" | "delete_range";
 
 export function isReviewGatedEditTool(name: string): name is ReviewGatedEditTool {
-  return name === "edit_file" || name === "write_file" || name === "multi_edit";
+  return (
+    name === "edit_file" ||
+    name === "write_file" ||
+    name === "multi_edit" ||
+    name === "delete_range"
+  );
 }
 
-function resolveEditRelPath(rawPath: unknown, rootForEdit: string): string | null {
+function resolveEditPathInfo(
+  rawPath: unknown,
+  rootForEdit: string,
+): { rel: string; abs: string } | null {
   if (typeof rawPath !== "string" || rawPath.length === 0) return null;
 
   const absRoot = resolve(rootForEdit);
@@ -17,14 +29,21 @@ function resolveEditRelPath(rawPath: unknown, rootForEdit: string): string | nul
     const abs = resolve(rawPath);
     if (!pathIsUnder(abs, absRoot)) return null;
     const rel = relative(absRoot, abs);
-    return rel || null;
+    return rel ? { rel, abs } : null;
   }
 
   let stripped = rawPath;
   while (stripped.startsWith("/") || stripped.startsWith("\\")) {
     stripped = stripped.slice(1);
   }
-  return stripped || null;
+  if (!stripped) return null;
+  const abs = resolve(absRoot, stripped);
+  if (!pathIsUnder(abs, absRoot)) return null;
+  return { rel: stripped, abs };
+}
+
+function resolveEditRelPath(rawPath: unknown, rootForEdit: string): string | null {
+  return resolveEditPathInfo(rawPath, rootForEdit)?.rel ?? null;
 }
 
 export function buildEditToolBlocks(
@@ -66,8 +85,48 @@ export function buildEditToolBlocks(
     return [{ path: relPath, search, replace, offset: 0 }];
   }
 
+  // write_file only — delete_range is handled
+  // by specialized builders in buildEditToolBlocksForReview().
+  if (name !== "write_file") return null;
+
   const content = typeof args.content === "string" ? args.content : "";
   return [toWholeFileEditBlock(relPath, content, rootForEdit)];
+}
+
+export async function buildEditToolBlocksForReview(
+  name: string,
+  args: Record<string, unknown>,
+  rootForEdit: string,
+  readTracker?: ReadTracker,
+): Promise<EditBlock[] | null> {
+  const direct = buildEditToolBlocks(name, args, rootForEdit);
+  if (direct) return direct;
+  try {
+    if (name === "delete_range") return buildDeleteRangeBlock(args, rootForEdit, readTracker);
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function buildDeleteRangeBlock(
+  args: Record<string, unknown>,
+  rootForEdit: string,
+  readTracker?: ReadTracker,
+): EditBlock[] | null {
+  const info = resolveEditPathInfo(args.path, rootForEdit);
+  if (!info) return null;
+  if (readTracker && !readTracker.hasRead(info.abs)) return null;
+  if (typeof args.start_anchor !== "string" || typeof args.end_anchor !== "string") return null;
+  const text = decodeFileBuffer(readFileSync(info.abs)).text;
+  const le = text.includes("\r\n") ? "\r\n" : "\n";
+  const patch = computeDeleteRangePatchFromText(text, {
+    start_anchor: args.start_anchor.replace(/\r?\n/g, le),
+    end_anchor: args.end_anchor.replace(/\r?\n/g, le),
+    inclusive: args.inclusive !== false,
+  });
+  if (patch.noopReason || patch.search.length === 0) return null;
+  return [{ path: info.rel, search: patch.search, replace: patch.replace, offset: 0 }];
 }
 
 export function shouldApplyEditToolImmediately(

--- a/src/code/auto-git-rollback.ts
+++ b/src/code/auto-git-rollback.ts
@@ -16,7 +16,7 @@ export type AutoGitRollbackConfig = false | AutoGitRollbackOptions;
 
 interface PrepareOptions {
   rootDir: string;
-  toolName: "edit_file" | "multi_edit" | "write_file" | "edit_blocks";
+  toolName: "edit_file" | "multi_edit" | "write_file" | "edit_blocks" | "delete_range";
   absPaths: readonly string[];
   autoGitRollback?: AutoGitRollbackConfig;
 }

--- a/src/code/lifecycle-policy.ts
+++ b/src/code/lifecycle-policy.ts
@@ -38,6 +38,7 @@ const SAFE_TOOL_NAMES = new Set([
 
 const HIGH_RISK_TOOL_NAMES = new Set([
   "multi_edit",
+  "delete_range",
   "move_file",
   "delete_file",
   "delete_directory",
@@ -51,6 +52,7 @@ const MUTATION_TOOL_NAMES = new Set([
   "edit_file",
   "write_file",
   "multi_edit",
+  "delete_range",
   "move_file",
   "delete_file",
   "delete_directory",

--- a/src/code/prompt.ts
+++ b/src/code/prompt.ts
@@ -51,7 +51,7 @@ The pinned Skills index below lists every available playbook (built-ins + user-i
 
 Only propose edits when the user explicitly says change / fix / add / remove / refactor / write. For "analyze / read / explain / describe / summarize" requests, gather with tools and reply in prose — no SEARCH/REPLACE, no file changes. If unclear, ask.
 
-The **edit gate** routes \`edit_file\` / \`write_file\` based on the user's mode (\`review\` or \`auto\`) — you don't see which is active, write the same way in both. Responses:
+The **edit gate** routes \`edit_file\` / \`write_file\` / \`multi_edit\` / \`delete_range\` based on the user's mode (\`review\` or \`auto\`) — you don't see which is active, write the same way in both. Responses:
 - \`"edit blocks: 1/1 applied"\` — proceed.
 - \`"User rejected this edit to <path>. Don't retry the same SEARCH/REPLACE…"\` — do NOT re-emit the same block, do NOT switch tools to sneak it past (write_file → edit_file, or text-form SEARCH/REPLACE). Take a clearly different approach or ask.
 - Esc mid-prompt aborts the whole turn — don't keep calling tools after.
@@ -68,7 +68,7 @@ the new lines
 >>>>>>> REPLACE
 
 Rules:
-- **Read before edit (enforced).** You MUST call \`read_file\` on the target this session before \`edit_file\` / \`multi_edit\` will accept it — the tool refuses unread targets up front, so SEARCH text is grounded in on-disk bytes, not a guess. A fold / mechanical truncate clears the tracker, so re-read after one of those before mutating. \`write_file\` counts as a read for that path (the content is what you just wrote).
+- **Read before edit (enforced).** You MUST call \`read_file\` on the target this session before \`edit_file\` / \`multi_edit\` / \`delete_range\` will accept it — the tool refuses unread targets up front, so mutation text is grounded in on-disk bytes, not a guess. A fold / mechanical truncate clears the tracker, so re-read after one of those before mutating. \`write_file\` counts as a read for that path (the content is what you just wrote).
 - One edit per block; multiple blocks per response are fine.
 - Create a new file with empty SEARCH:
     path/to/new.ts
@@ -79,6 +79,7 @@ Rules:
 - Don't use write_file to change existing files — the user reviews edits as SEARCH/REPLACE. write_file is for wholesale overwrites only.
 - Paths are relative to the working directory.
 - For multi-site changes use \`multi_edit\` — validation runs before any write; validation failures leave all files untouched. Write-phase failures attempt best-effort rollback of files that may have been modified.
+- For large deletions, prefer \`delete_range\` over a huge SEARCH/REPLACE block. Use exact start/end anchors; duplicate or missing anchors are a no-op.
 
 # Trust what you already know
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -420,12 +420,18 @@ function plainTextRejectedReason(name: string, result: string): string | null {
     return "edit-gate";
   }
   if (
-    (name === "edit_file" || name === "write_file" || name === "multi_edit") &&
+    (name === "edit_file" ||
+      name === "write_file" ||
+      name === "multi_edit" ||
+      name === "delete_range") &&
     /queued \d+ edits? for review/i.test(result)
   ) {
     return "edit-gate";
   }
-  if ((name === "edit_file" || name === "multi_edit") && /read_file first/i.test(result)) {
+  if (
+    (name === "edit_file" || name === "multi_edit" || name === "delete_range") &&
+    /read_file first/i.test(result)
+  ) {
     return "read-before-edit";
   }
   if ((name === "run_command" || name === "run_background") && /\buser denied:/i.test(result)) {

--- a/src/tools/filesystem.ts
+++ b/src/tools/filesystem.ts
@@ -16,7 +16,7 @@ import {
   readSubdirMemoryContent,
 } from "../memory/subdir.js";
 import type { ToolCallContext, ToolRegistry } from "../tools.js";
-import { applyEdit, applyMultiEdit, generateWriteDiff } from "./fs/edit.js";
+import { applyDeleteRange, applyEdit, applyMultiEdit, generateWriteDiff } from "./fs/edit.js";
 import { globFiles } from "./fs/glob.js";
 import { extractOutline, formatOutline } from "./fs/outline.js";
 import { searchContent, searchFiles } from "./fs/search.js";
@@ -776,6 +776,51 @@ export function registerFilesystemTools(
       return applyMultiEdit(
         rootDir,
         resolved,
+        ctx?.readTracker ? (abs) => ctx.readTracker!.hasRead(abs) : undefined,
+      );
+    },
+  });
+
+  registry.register({
+    name: "delete_range",
+    description:
+      "Delete a contiguous text range from an existing file using exact start/end anchors. Call read_file on this path first this session. Matching failures, duplicate anchors, or reversed ranges are no-ops and leave the file unchanged. Use this instead of huge SEARCH/REPLACE blocks for large deletions.",
+    parameters: {
+      type: "object",
+      properties: {
+        path: { type: "string" },
+        start_anchor: {
+          type: "string",
+          description: "Exact text that marks the start of the range.",
+        },
+        end_anchor: {
+          type: "string",
+          description: "Exact text that marks the end of the range.",
+        },
+        inclusive: {
+          type: "boolean",
+          description:
+            "When true (default), delete the anchors too. When false, keep both anchors and delete only the text between them.",
+        },
+      },
+      required: ["path", "start_anchor", "end_anchor"],
+    },
+    fn: async (
+      args: { path: string; start_anchor: string; end_anchor: string; inclusive?: boolean },
+      ctx?: ToolCallContext,
+    ) => {
+      const abs = await safePath(args.path, "delete_range", ctx, "write");
+      const guard = prepareAutoGitRollback({
+        rootDir,
+        toolName: "delete_range",
+        absPaths: [abs],
+        autoGitRollback,
+      });
+      if (guard) return guard;
+      return applyDeleteRange(
+        rootDir,
+        abs,
+        args,
         ctx?.readTracker ? (abs) => ctx.readTracker!.hasRead(abs) : undefined,
       );
     },

--- a/src/tools/fs/edit.ts
+++ b/src/tools/fs/edit.ts
@@ -48,6 +48,115 @@ export async function applyEdit(
   return `${header}\n${diff}`;
 }
 
+export interface DeleteRangeArgs {
+  start_anchor: string;
+  end_anchor: string;
+  inclusive?: boolean;
+}
+
+export interface DeletePatch {
+  search: string;
+  replace: "";
+  startIndex: number;
+  endIndex: number;
+  startLine: number;
+  deletedChars: number;
+  noopReason?: string;
+}
+
+export function computeDeleteRangePatchFromText(text: string, args: DeleteRangeArgs): DeletePatch {
+  const startAnchor = args.start_anchor;
+  const endAnchor = args.end_anchor;
+  if (typeof startAnchor !== "string" || startAnchor.length === 0) {
+    return noDeletePatch("start_anchor is empty");
+  }
+  if (typeof endAnchor !== "string" || endAnchor.length === 0) {
+    return noDeletePatch("end_anchor is empty");
+  }
+  const startHits = allOccurrences(text, startAnchor);
+  if (startHits.length !== 1) {
+    return noDeletePatch(
+      startHits.length === 0
+        ? "start_anchor not found"
+        : `start_anchor appears ${startHits.length} times`,
+    );
+  }
+  const endHits = allOccurrences(text, endAnchor);
+  if (endHits.length !== 1) {
+    return noDeletePatch(
+      endHits.length === 0 ? "end_anchor not found" : `end_anchor appears ${endHits.length} times`,
+    );
+  }
+  const inclusive = args.inclusive !== false;
+  const startIdx = startHits[0]!;
+  const endIdx = endHits[0]!;
+  const deleteStart = inclusive ? startIdx : startIdx + startAnchor.length;
+  const deleteEnd = inclusive ? endIdx + endAnchor.length : endIdx;
+  if (deleteStart > deleteEnd) {
+    return noDeletePatch("start_anchor resolves after end_anchor");
+  }
+  if (deleteStart === deleteEnd) {
+    return noDeletePatch("anchor range is empty");
+  }
+  const search = text.slice(deleteStart, deleteEnd);
+  return {
+    search,
+    replace: "",
+    startIndex: deleteStart,
+    endIndex: deleteEnd,
+    startLine: text.slice(0, deleteStart).split(/\r?\n/).length,
+    deletedChars: search.length,
+  };
+}
+
+export async function applyDeleteRange(
+  rootDir: string,
+  abs: string,
+  args: DeleteRangeArgs,
+  hasRead?: (abs: string) => boolean,
+): Promise<string> {
+  if (hasRead && !hasRead(abs)) {
+    throw new Error(
+      `delete_range: ${displayRel(rootDir, abs)} was not read this session — ${READ_BEFORE_EDIT_MARKER} so anchors match the bytes on disk.`,
+    );
+  }
+  const beforeBuf = await fs.readFile(abs);
+  const { text: before, encoding } = decodeFileBuffer(beforeBuf);
+  const le = before.includes("\r\n") ? "\r\n" : "\n";
+  const patch = computeDeleteRangePatchFromText(before, {
+    ...args,
+    start_anchor: args.start_anchor.replace(/\r?\n/g, le),
+    end_anchor: args.end_anchor.replace(/\r?\n/g, le),
+  });
+  const rel = displayRel(rootDir, abs);
+  if (patch.noopReason) return `delete_range: no-op for ${rel} — ${patch.noopReason}`;
+  const after = `${before.slice(0, patch.startIndex)}${patch.replace}${before.slice(patch.endIndex)}`;
+  await fs.writeFile(abs, encodeFile(after, encoding));
+  return `delete_range: deleted ${patch.deletedChars} chars from ${rel}\n${renderEditDiff(patch.search, patch.replace, patch.startLine)}`;
+}
+
+function noDeletePatch(reason: string): DeletePatch {
+  return {
+    search: "",
+    replace: "",
+    startIndex: 0,
+    endIndex: 0,
+    startLine: 1,
+    deletedChars: 0,
+    noopReason: reason,
+  };
+}
+
+function allOccurrences(haystack: string, needle: string): number[] {
+  const out: number[] = [];
+  let idx = haystack.indexOf(needle);
+  while (idx >= 0) {
+    out.push(idx);
+    idx = haystack.indexOf(needle, idx + Math.max(1, needle.length));
+  }
+  return out;
+}
+
 export interface MultiEditEntry {
   abs: string;
   search: string;

--- a/tests/delete-tools.test.ts
+++ b/tests/delete-tools.test.ts
@@ -1,0 +1,60 @@
+import { promises as fs } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ToolRegistry } from "../src/tools.js";
+import { registerFilesystemTools } from "../src/tools/filesystem.js";
+import { ReadTracker } from "../src/tools/read-tracker.js";
+
+describe("delete_range tool", () => {
+  let root: string;
+  let tools: ToolRegistry;
+  let readTracker: ReadTracker;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "reasonix-delete-tools-"));
+    tools = new ToolRegistry();
+    registerFilesystemTools(tools, { rootDir: root });
+    readTracker = new ReadTracker();
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("delete_range refuses unread files, then deletes an anchored range after read_file", async () => {
+    await fs.writeFile(join(root, "demo.txt"), "before\nSTART\nremove\nEND\nafter\n");
+
+    const unread = await tools.dispatch(
+      "delete_range",
+      { path: "demo.txt", start_anchor: "START\n", end_anchor: "END\n" },
+      { readTracker },
+    );
+    expect(unread).toMatch(/read_file first/);
+
+    await tools.dispatch("read_file", { path: "demo.txt" }, { readTracker });
+    const out = await tools.dispatch(
+      "delete_range",
+      { path: "demo.txt", start_anchor: "START\n", end_anchor: "END\n" },
+      { readTracker },
+    );
+
+    expect(out).toMatch(/delete_range: deleted/);
+    await expect(fs.readFile(join(root, "demo.txt"), "utf8")).resolves.toBe("before\nafter\n");
+  });
+
+  it("delete_range is a no-op when anchors are duplicated", async () => {
+    await fs.writeFile(join(root, "demo.txt"), "A\nSTART\nx\nSTART\nEND\n");
+    await tools.dispatch("read_file", { path: "demo.txt" }, { readTracker });
+
+    const out = await tools.dispatch(
+      "delete_range",
+      { path: "demo.txt", start_anchor: "START", end_anchor: "END" },
+      { readTracker },
+    );
+
+    expect(out).toMatch(/no-op/);
+    await expect(fs.readFile(join(root, "demo.txt"), "utf8")).resolves.toContain("x");
+  });
+});

--- a/tests/filesystem-tools.test.ts
+++ b/tests/filesystem-tools.test.ts
@@ -968,7 +968,7 @@ describe("filesystem tools (built-in, sandbox-enforced)", () => {
   });
 
   describe("allowWriting=false (read-only mode)", () => {
-    it("skips registering write_file / edit_file / multi_edit / create_directory / move_file / delete_file / delete_directory / copy_file", async () => {
+    it("skips registering write_file / edit_file / multi_edit / delete_range / create_directory / move_file / delete_file / delete_directory / copy_file", async () => {
       const ro = new ToolRegistry();
       registerFilesystemTools(ro, { rootDir: root, allowWriting: false });
       expect(ro.has("read_file")).toBe(true);
@@ -977,6 +977,7 @@ describe("filesystem tools (built-in, sandbox-enforced)", () => {
       expect(ro.has("write_file")).toBe(false);
       expect(ro.has("edit_file")).toBe(false);
       expect(ro.has("multi_edit")).toBe(false);
+      expect(ro.has("delete_range")).toBe(false);
       expect(ro.has("create_directory")).toBe(false);
       expect(ro.has("move_file")).toBe(false);
       expect(ro.has("delete_file")).toBe(false);

--- a/tests/review-edit-gate.test.ts
+++ b/tests/review-edit-gate.test.ts
@@ -4,15 +4,17 @@ import { join, sep } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   buildEditToolBlocks,
+  buildEditToolBlocksForReview,
   isReviewGatedEditTool,
   shouldApplyEditToolImmediately,
 } from "../src/cli/ui/edit-tool-gate.js";
 
 describe("review edit gate tool matching", () => {
-  it("includes multi_edit in the same review gate as single-file edit tools", () => {
+  it("includes delete tools in the same review gate as single-file edit tools", () => {
     expect(isReviewGatedEditTool("edit_file")).toBe(true);
     expect(isReviewGatedEditTool("write_file")).toBe(true);
     expect(isReviewGatedEditTool("multi_edit")).toBe(true);
+    expect(isReviewGatedEditTool("delete_range")).toBe(true);
     expect(isReviewGatedEditTool("read_file")).toBe(false);
   });
 });
@@ -65,5 +67,19 @@ describe("buildEditToolBlocks", () => {
     );
 
     expect(blocks).toEqual([{ path: `nested${sep}file.ts`, search: "a", replace: "b", offset: 0 }]);
+  });
+
+  it("turns delete_range args into a reviewable deletion block", async () => {
+    writeFileSync(join(root, "range.ts"), "before\nSTART\nremove\nEND\nafter\n", "utf8");
+
+    const blocks = await buildEditToolBlocksForReview(
+      "delete_range",
+      { path: "range.ts", start_anchor: "START\n", end_anchor: "END\n" },
+      root,
+    );
+
+    expect(blocks).toEqual([
+      { path: "range.ts", search: "START\nremove\nEND\n", replace: "", offset: 0 },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

Adds a `delete_range` tool that deletes a contiguous text range from a file using exact start/end text anchors. Parameters: `path`, `start_anchor`, `end_anchor`, `inclusive`. Requires `read_file` first (enforced via ReadTracker). No-op on missing/duplicate anchors or reversed ranges. Returns unified diff on success. Integrated into the edit review/auto/yolo gate with CRLF line ending normalization and path traversal protection.

## 概述

新增 `delete_range` 工具，使用精确的开始/结束文本锚点删除文件中的连续文本范围。参数：path、start_anchor、end_anchor、inclusive。要求先 read_file（通过 ReadTracker 强制执行）。缺失/重复锚点或反转范围时 no-op。成功时返回 unified diff。集成到 edit review/auto/yolo 门禁，支持 CRLF 换行符自适应和路径穿越防护。

## Key Files

- `src/tools/filesystem.ts` — `delete_range` tool registration
- `src/tools/fs/edit.ts` — `applyDeleteRange()`, `computeDeleteRangePatchFromText()`
- `src/tools.ts` — gate rejection patterns
- `src/cli/ui/edit-tool-gate.ts` — review/auto gate integration
- `src/code/prompt.ts` — recommend delete_range for large deletions
- `src/code/lifecycle-policy.ts` — high-risk classification
- `tests/delete-tools.test.ts` (new) — unit tests

## Depends On / 依赖

This PR is #3 in a 5-PR series:
- PR #1: Cache Diagnostics v1
- PR #2: MCP Cache-Stable Canonicalization
- PR #4: AST-Aware Delete (delete_symbol)
- PR #5: SSH Remote Workspace RFC

## Test Plan

- Unread file refusal (read-before-edit enforcement)
- Duplicate anchor no-op
- CRLF line ending normalization in review preview
- Path traversal protection (../ outside workspace)
- Review/auto gate integration

## Verification

```
npm run lint      → 0 errors
npx vitest run tests/delete-tools.test.ts tests/review-edit-gate.test.ts → all passed
```