### PR TITLE
feat: delete_symbol — AST-aware symbol deletion via tree-sitter (6 languages) | AST 符号删除工具

### DIFF
--- a/src/cli/ui/edit-tool-gate.ts
+++ b/src/cli/ui/edit-tool-gate.ts
@@ -1,20 +1,31 @@
 import { readFileSync } from "node:fs";
 import { relative, resolve } from "node:path";
+import { grammarForPath } from "../../code-query/grammar-map.js";
 import { type EditBlock, toWholeFileEditBlock } from "../../code/edit-blocks.js";
 import { decodeFileBuffer } from "../../code/file-encoding.js";
 import type { EditMode } from "../../config.js";
 import { looksLikeAbsoluteSystemPath, pathIsUnder } from "../../tools/filesystem.js";
-import { computeDeleteRangePatchFromText } from "../../tools/fs/edit.js";
+import {
+  computeDeleteLineRangePatchFromText,
+  computeDeleteRangePatchFromText,
+  expandSymbolDeletionStartLine,
+} from "../../tools/fs/edit.js";
 import type { ReadTracker } from "../../tools/read-tracker.js";
 
-export type ReviewGatedEditTool = "edit_file" | "write_file" | "multi_edit" | "delete_range";
+export type ReviewGatedEditTool =
+  | "edit_file"
+  | "write_file"
+  | "multi_edit"
+  | "delete_range"
+  | "delete_symbol";
 
 export function isReviewGatedEditTool(name: string): name is ReviewGatedEditTool {
   return (
     name === "edit_file" ||
     name === "write_file" ||
     name === "multi_edit" ||
-    name === "delete_range"
+    name === "delete_range" ||
+    name === "delete_symbol"
   );
 }
 
@@ -85,7 +96,7 @@ export function buildEditToolBlocks(
     return [{ path: relPath, search, replace, offset: 0 }];
   }
 
-  // write_file only — delete_range is handled
+  // write_file only — delete_range/delete_symbol are handled
   // by specialized builders in buildEditToolBlocksForReview().
   if (name !== "write_file") return null;
 
@@ -103,6 +114,7 @@ export async function buildEditToolBlocksForReview(
   if (direct) return direct;
   try {
     if (name === "delete_range") return buildDeleteRangeBlock(args, rootForEdit, readTracker);
+    if (name === "delete_symbol") return buildDeleteSymbolBlock(args, rootForEdit, readTracker);
   } catch {
     return null;
   }
@@ -125,6 +137,46 @@ function buildDeleteRangeBlock(
     end_anchor: args.end_anchor.replace(/\r?\n/g, le),
     inclusive: args.inclusive !== false,
   });
+  if (patch.noopReason || patch.search.length === 0) return null;
+  return [{ path: info.rel, search: patch.search, replace: patch.replace, offset: 0 }];
+}
+
+async function buildDeleteSymbolBlock(
+  args: Record<string, unknown>,
+  rootForEdit: string,
+  readTracker?: ReadTracker,
+): Promise<EditBlock[] | null> {
+  const info = resolveEditPathInfo(args.path, rootForEdit);
+  if (!info || !grammarForPath(info.abs)) return null;
+  if (readTracker && !readTracker.hasRead(info.abs)) return null;
+  const name = typeof args.name === "string" ? args.name : "";
+  if (!name) return null;
+  const wantedKind = typeof args.kind === "string" ? args.kind : "";
+  const wantedParent = typeof args.parent === "string" ? args.parent : "";
+  const text = decodeFileBuffer(readFileSync(info.abs)).text;
+  const { extractSymbols } = await import("../../code-query/symbols.js");
+  const candidates = (await extractSymbols(info.abs, text)).filter(
+    (symbol) =>
+      symbol.name === name &&
+      ["function", "class", "method", "interface", "type"].includes(symbol.kind) &&
+      (!wantedKind || symbol.kind === wantedKind) &&
+      (!wantedParent || symbol.parent === wantedParent),
+  );
+  if (candidates.length !== 1) return null;
+  const symbol = candidates[0]!;
+  const lines = text.split(/\r?\n/);
+
+  if (symbol.line === symbol.endLine) {
+    const line = lines[symbol.line - 1] ?? "";
+    const before = line.slice(0, symbol.column - 1).trim();
+    const after = line.slice(symbol.endColumn - 1).trim();
+    if (before.length > 0 || (after.length > 0 && !after.startsWith("//"))) {
+      return null;
+    }
+  }
+
+  const startLine = expandSymbolDeletionStartLine(lines, symbol.line);
+  const patch = computeDeleteLineRangePatchFromText(text, startLine, symbol.endLine);
   if (patch.noopReason || patch.search.length === 0) return null;
   return [{ path: info.rel, search: patch.search, replace: patch.replace, offset: 0 }];
 }

--- a/src/code/auto-git-rollback.ts
+++ b/src/code/auto-git-rollback.ts
@@ -16,7 +16,13 @@ export type AutoGitRollbackConfig = false | AutoGitRollbackOptions;
 
 interface PrepareOptions {
   rootDir: string;
-  toolName: "edit_file" | "multi_edit" | "write_file" | "edit_blocks" | "delete_range";
+  toolName:
+    | "edit_file"
+    | "multi_edit"
+    | "write_file"
+    | "edit_blocks"
+    | "delete_range"
+    | "delete_symbol";
   absPaths: readonly string[];
   autoGitRollback?: AutoGitRollbackConfig;
 }

--- a/src/code/lifecycle-policy.ts
+++ b/src/code/lifecycle-policy.ts
@@ -39,6 +39,7 @@ const SAFE_TOOL_NAMES = new Set([
 const HIGH_RISK_TOOL_NAMES = new Set([
   "multi_edit",
   "delete_range",
+  "delete_symbol",
   "move_file",
   "delete_file",
   "delete_directory",
@@ -53,6 +54,7 @@ const MUTATION_TOOL_NAMES = new Set([
   "write_file",
   "multi_edit",
   "delete_range",
+  "delete_symbol",
   "move_file",
   "delete_file",
   "delete_directory",

--- a/src/code/prompt.ts
+++ b/src/code/prompt.ts
@@ -51,7 +51,7 @@ The pinned Skills index below lists every available playbook (built-ins + user-i
 
 Only propose edits when the user explicitly says change / fix / add / remove / refactor / write. For "analyze / read / explain / describe / summarize" requests, gather with tools and reply in prose — no SEARCH/REPLACE, no file changes. If unclear, ask.
 
-The **edit gate** routes \`edit_file\` / \`write_file\` / \`multi_edit\` / \`delete_range\` based on the user's mode (\`review\` or \`auto\`) — you don't see which is active, write the same way in both. Responses:
+The **edit gate** routes \`edit_file\` / \`write_file\` / \`multi_edit\` / \`delete_range\` / \`delete_symbol\` based on the user's mode (\`review\` or \`auto\`) — you don't see which is active, write the same way in both. Responses:
 - \`"edit blocks: 1/1 applied"\` — proceed.
 - \`"User rejected this edit to <path>. Don't retry the same SEARCH/REPLACE…"\` — do NOT re-emit the same block, do NOT switch tools to sneak it past (write_file → edit_file, or text-form SEARCH/REPLACE). Take a clearly different approach or ask.
 - Esc mid-prompt aborts the whole turn — don't keep calling tools after.
@@ -68,7 +68,7 @@ the new lines
 >>>>>>> REPLACE
 
 Rules:
-- **Read before edit (enforced).** You MUST call \`read_file\` on the target this session before \`edit_file\` / \`multi_edit\` / \`delete_range\` will accept it — the tool refuses unread targets up front, so mutation text is grounded in on-disk bytes, not a guess. A fold / mechanical truncate clears the tracker, so re-read after one of those before mutating. \`write_file\` counts as a read for that path (the content is what you just wrote).
+- **Read before edit (enforced).** You MUST call \`read_file\` on the target this session before \`edit_file\` / \`multi_edit\` / \`delete_range\` / \`delete_symbol\` will accept it — the tool refuses unread targets up front, so mutation text is grounded in on-disk bytes, not a guess. A fold / mechanical truncate clears the tracker, so re-read after one of those before mutating. \`write_file\` counts as a read for that path (the content is what you just wrote).
 - One edit per block; multiple blocks per response are fine.
 - Create a new file with empty SEARCH:
     path/to/new.ts
@@ -80,6 +80,7 @@ Rules:
 - Paths are relative to the working directory.
 - For multi-site changes use \`multi_edit\` — validation runs before any write; validation failures leave all files untouched. Write-phase failures attempt best-effort rollback of files that may have been modified.
 - For large deletions, prefer \`delete_range\` over a huge SEARCH/REPLACE block. Use exact start/end anchors; duplicate or missing anchors are a no-op.
+- For deleting a whole function/class/method/interface/type, prefer \`delete_symbol\`. It uses tree-sitter and fails with candidates if the name is ambiguous.
 
 # Trust what you already know
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -423,13 +423,17 @@ function plainTextRejectedReason(name: string, result: string): string | null {
     (name === "edit_file" ||
       name === "write_file" ||
       name === "multi_edit" ||
-      name === "delete_range") &&
+      name === "delete_range" ||
+      name === "delete_symbol") &&
     /queued \d+ edits? for review/i.test(result)
   ) {
     return "edit-gate";
   }
   if (
-    (name === "edit_file" || name === "multi_edit" || name === "delete_range") &&
+    (name === "edit_file" ||
+      name === "multi_edit" ||
+      name === "delete_range" ||
+      name === "delete_symbol") &&
     /read_file first/i.test(result)
   ) {
     return "read-before-edit";

--- a/src/tools/filesystem.ts
+++ b/src/tools/filesystem.ts
@@ -3,6 +3,8 @@
 import { promises as fs } from "node:fs";
 import * as pathMod from "node:path";
 import picomatch from "picomatch";
+import { grammarForPath } from "../code-query/grammar-map.js";
+import type { SymbolKind } from "../code-query/symbols.js";
 import { type AutoGitRollbackConfig, prepareAutoGitRollback } from "../code/auto-git-rollback.js";
 import { decodeFileBuffer, encodeFile } from "../code/file-encoding.js";
 import { addProjectPathAllowed, loadProjectPathAllowed } from "../config.js";
@@ -16,7 +18,14 @@ import {
   readSubdirMemoryContent,
 } from "../memory/subdir.js";
 import type { ToolCallContext, ToolRegistry } from "../tools.js";
-import { applyDeleteRange, applyEdit, applyMultiEdit, generateWriteDiff } from "./fs/edit.js";
+import {
+  applyDeleteLineRange,
+  applyDeleteRange,
+  applyEdit,
+  applyMultiEdit,
+  expandSymbolDeletionStartLine,
+  generateWriteDiff,
+} from "./fs/edit.js";
 import { globFiles } from "./fs/glob.js";
 import { extractOutline, formatOutline } from "./fs/outline.js";
 import { searchContent, searchFiles } from "./fs/search.js";
@@ -56,6 +65,13 @@ const SKIP_DIR_NAMES: ReadonlySet<string> = new Set(
 
 /** First line of binary defense; NUL-byte sniff is the second (catches mislabeled `.txt`). */
 const BINARY_EXTENSIONS: ReadonlySet<string> = new Set(DEFAULT_INDEX_EXCLUDES.exts);
+const DELETE_SYMBOL_KINDS: ReadonlySet<SymbolKind> = new Set([
+  "function",
+  "class",
+  "method",
+  "interface",
+  "type",
+]);
 
 export function displayRel(rootDir: string, full: string): string {
   return pathMod.relative(rootDir, full).replaceAll("\\", "/");
@@ -822,6 +838,117 @@ export function registerFilesystemTools(
         abs,
         args,
         ctx?.readTracker ? (abs) => ctx.readTracker!.hasRead(abs) : undefined,
+      );
+    },
+  });
+
+  registry.register({
+    name: "delete_symbol",
+    description:
+      "Delete one function/class/method/interface/type by exact symbol name using tree-sitter. Supports TS/TSX/JS/JSX/Python/Go/Rust/Java. Call read_file first. If the symbol is missing or ambiguous, no file is changed and candidates are returned.",
+    parameters: {
+      type: "object",
+      properties: {
+        path: { type: "string" },
+        name: { type: "string", description: "Exact symbol name to delete." },
+        kind: {
+          type: "string",
+          enum: ["function", "class", "method", "interface", "type"],
+          description: "Optional symbol kind filter.",
+        },
+        parent: {
+          type: "string",
+          description: "Optional parent class/namespace name filter.",
+        },
+      },
+      required: ["path", "name"],
+    },
+    fn: async (
+      args: {
+        path: string;
+        name: string;
+        kind?: "function" | "class" | "method" | "interface" | "type";
+        parent?: string;
+      },
+      ctx?: ToolCallContext,
+    ) => {
+      const abs = await safePath(args.path, "delete_symbol", ctx, "write");
+      const guard = prepareAutoGitRollback({
+        rootDir,
+        toolName: "delete_symbol",
+        absPaths: [abs],
+        autoGitRollback,
+      });
+      if (guard) return guard;
+      if (ctx?.readTracker && !ctx.readTracker.hasRead(abs)) {
+        throw new Error(
+          `delete_symbol: ${displayRel(rootDir, abs)} was not read this session — read_file first so the AST deletion matches the bytes on disk.`,
+        );
+      }
+      if (!grammarForPath(abs)) {
+        return JSON.stringify({
+          path: args.path,
+          error:
+            "language not supported (TS/TSX/JS/JSX/Python/Go/Rust/Java); use edit_file instead",
+        });
+      }
+      if (typeof args.name !== "string" || args.name.trim().length === 0) {
+        return JSON.stringify({ path: args.path, error: "name must be a non-empty string" });
+      }
+      const { text } = decodeFileBuffer(await fs.readFile(abs));
+      const { extractSymbols } = await import("../code-query/symbols.js");
+      const wantedKind = args.kind;
+      const wantedParent = args.parent;
+      const candidates = (await extractSymbols(abs, text)).filter(
+        (symbol) =>
+          symbol.name === args.name &&
+          DELETE_SYMBOL_KINDS.has(symbol.kind) &&
+          (!wantedKind || symbol.kind === wantedKind) &&
+          (!wantedParent || symbol.parent === wantedParent),
+      );
+      if (candidates.length === 0) {
+        return JSON.stringify({
+          path: args.path,
+          error: `delete_symbol: no matching symbol ${JSON.stringify(args.name)}`,
+        });
+      }
+      if (candidates.length > 1) {
+        return JSON.stringify({
+          path: args.path,
+          error: `delete_symbol: multiple symbols named ${JSON.stringify(args.name)}; pass kind/parent to disambiguate`,
+          candidates: candidates.map((symbol) => ({
+            name: symbol.name,
+            kind: symbol.kind,
+            line: symbol.line,
+            endLine: symbol.endLine,
+            parent: symbol.parent,
+          })),
+        });
+      }
+      const symbol = candidates[0]!;
+      const lines = text.split(/\r?\n/);
+
+      if (symbol.line === symbol.endLine) {
+        const line = lines[symbol.line - 1] ?? "";
+        const before = line.slice(0, symbol.column - 1).trim();
+        const after = line.slice(symbol.endColumn - 1).trim();
+        if (before.length > 0 || (after.length > 0 && !after.startsWith("//"))) {
+          return JSON.stringify({
+            path: args.path,
+            error:
+              "delete_symbol: target symbol shares a line with other code; use edit_file for precise removal",
+          });
+        }
+      }
+
+      const startLine = expandSymbolDeletionStartLine(lines, symbol.line);
+      return applyDeleteLineRange(
+        rootDir,
+        abs,
+        startLine,
+        symbol.endLine,
+        "delete_symbol",
+        ctx?.readTracker ? (p) => ctx.readTracker!.hasRead(p) : undefined,
       );
     },
   });

--- a/src/tools/fs/edit.ts
+++ b/src/tools/fs/edit.ts
@@ -109,6 +109,35 @@ export function computeDeleteRangePatchFromText(text: string, args: DeleteRangeA
   };
 }
 
+export function computeDeleteLineRangePatchFromText(
+  text: string,
+  startLine: number,
+  endLine: number,
+): DeletePatch {
+  if (!Number.isInteger(startLine) || !Number.isInteger(endLine)) {
+    return noDeletePatch("line range must be integer lines");
+  }
+  if (startLine < 1 || endLine < startLine) {
+    return noDeletePatch("line range is invalid");
+  }
+  const starts = lineStartOffsets(text);
+  if (startLine > starts.length) {
+    return noDeletePatch(`start line ${startLine} is outside the file`);
+  }
+  const startIdx = starts[startLine - 1]!;
+  const endIdx = starts[endLine] ?? text.length;
+  if (startIdx >= endIdx) return noDeletePatch("line range is empty");
+  const search = text.slice(startIdx, endIdx);
+  return {
+    search,
+    replace: "",
+    startIndex: startIdx,
+    endIndex: endIdx,
+    startLine,
+    deletedChars: search.length,
+  };
+}
+
 export async function applyDeleteRange(
   rootDir: string,
   abs: string,
@@ -135,6 +164,40 @@ export async function applyDeleteRange(
   return `delete_range: deleted ${patch.deletedChars} chars from ${rel}\n${renderEditDiff(patch.search, patch.replace, patch.startLine)}`;
 }
 
+export async function applyDeleteLineRange(
+  rootDir: string,
+  abs: string,
+  startLine: number,
+  endLine: number,
+  toolName: string,
+  hasRead?: (abs: string) => boolean,
+): Promise<string> {
+  if (hasRead && !hasRead(abs)) {
+    throw new Error(
+      `${toolName}: ${displayRel(rootDir, abs)} was not read this session — ${READ_BEFORE_EDIT_MARKER} so deletion matches the bytes on disk.`,
+    );
+  }
+  const beforeBuf = await fs.readFile(abs);
+  const { text: before, encoding } = decodeFileBuffer(beforeBuf);
+  const patch = computeDeleteLineRangePatchFromText(before, startLine, endLine);
+  const rel = displayRel(rootDir, abs);
+  if (patch.noopReason) return `${toolName}: no-op for ${rel} — ${patch.noopReason}`;
+  const after = `${before.slice(0, patch.startIndex)}${patch.replace}${before.slice(patch.endIndex)}`;
+  await fs.writeFile(abs, encodeFile(after, encoding));
+  return `${toolName}: deleted lines ${startLine}-${endLine} from ${rel}\n${renderEditDiff(patch.search, patch.replace, patch.startLine)}`;
+}
+
+export function expandSymbolDeletionStartLine(
+  lines: readonly string[],
+  symbolLine: number,
+): number {
+  let startLine = symbolLine;
+
+  startLine = expandDecoratorStartLine(lines, startLine);
+  startLine = expandDocCommentStartLine(lines, startLine);
+  return expandDecoratorStartLine(lines, startLine);
+}
+
 function noDeletePatch(reason: string): DeletePatch {
   return {
     search: "",
@@ -155,6 +218,59 @@ function allOccurrences(haystack: string, needle: string): number[] {
     idx = haystack.indexOf(needle, idx + Math.max(1, needle.length));
   }
   return out;
+}
+
+function lineStartOffsets(text: string): number[] {
+  const starts = [0];
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] === "\n" && i + 1 < text.length) starts.push(i + 1);
+  }
+  return starts;
+}
+
+function expandDecoratorStartLine(lines: readonly string[], startLine: number): number {
+  let nextStart = startLine;
+  while (nextStart > 1) {
+    const previous = (lines[nextStart - 2] ?? "").trim();
+    if (previous.startsWith("@")) {
+      nextStart--;
+      continue;
+    }
+    if (looksLikeDecoratorContinuation(previous)) {
+      const decoratorStart = findDecoratorStartAbove(lines, nextStart - 1);
+      if (decoratorStart !== null) {
+        nextStart = decoratorStart;
+        continue;
+      }
+    }
+    break;
+  }
+  return nextStart;
+}
+
+function looksLikeDecoratorContinuation(trimmed: string): boolean {
+  return /^[)\]}]/.test(trimmed);
+}
+
+function findDecoratorStartAbove(lines: readonly string[], lastLine: number): number | null {
+  for (let line = lastLine; line >= 1; line--) {
+    const trimmed = (lines[line - 1] ?? "").trim();
+    if (trimmed.length === 0) return null;
+    if (trimmed.startsWith("@")) return line;
+  }
+  return null;
+}
+
+function expandDocCommentStartLine(lines: readonly string[], startLine: number): number {
+  if (startLine <= 1) return startLine;
+  const previous = (lines[startLine - 2] ?? "").trim();
+  if (!previous.endsWith("*/")) return startLine;
+  for (let line = startLine - 1; line >= 1; line--) {
+    const trimmed = (lines[line - 1] ?? "").trim();
+    if (trimmed.startsWith("/**")) return line;
+    if (!trimmed.startsWith("*") && trimmed.length > 0) return startLine;
+  }
+  return startLine;
 }
 
 export interface MultiEditEntry {

--- a/tests/delete-tools.test.ts
+++ b/tests/delete-tools.test.ts
@@ -58,3 +58,92 @@ describe("delete_range tool", () => {
     await expect(fs.readFile(join(root, "demo.txt"), "utf8")).resolves.toContain("x");
   });
 });
+
+describe("delete_symbol tool", () => {
+  let root: string;
+  let tools: ToolRegistry;
+  let readTracker: ReadTracker;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "reasonix-delete-tools-"));
+    tools = new ToolRegistry();
+    registerFilesystemTools(tools, { rootDir: root });
+    readTracker = new ReadTracker();
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("deletes a single TypeScript function by AST range", async () => {
+    await fs.writeFile(
+      join(root, "demo.ts"),
+      "export function keep() {\n  return 1;\n}\n\nexport function removeMe() {\n  return 2;\n}\n",
+    );
+    await tools.dispatch("read_file", { path: "demo.ts" }, { readTracker });
+
+    const out = await tools.dispatch(
+      "delete_symbol",
+      { path: "demo.ts", name: "removeMe", kind: "function" },
+      { readTracker },
+    );
+
+    expect(out).toMatch(/delete_symbol: deleted lines/);
+    const after = await fs.readFile(join(root, "demo.ts"), "utf8");
+    expect(after).toContain("keep");
+    expect(after).not.toContain("removeMe");
+  });
+
+  it("deletes leading decorators and JSDoc with a TypeScript symbol", async () => {
+    await fs.writeFile(
+      join(root, "decorated.ts"),
+      [
+        "export function keep() {",
+        "  return 1;",
+        "}",
+        "",
+        "/** Remove this class. */",
+        "@sealed",
+        "export class RemoveMe {",
+        "  value = 2;",
+        "}",
+        "",
+      ].join("\n"),
+    );
+    await tools.dispatch("read_file", { path: "decorated.ts" }, { readTracker });
+
+    const out = await tools.dispatch(
+      "delete_symbol",
+      { path: "decorated.ts", name: "RemoveMe", kind: "class" },
+      { readTracker },
+    );
+
+    expect(out).toMatch(/delete_symbol: deleted lines/);
+    const after = await fs.readFile(join(root, "decorated.ts"), "utf8");
+    expect(after).toContain("keep");
+    expect(after).not.toContain("RemoveMe");
+    expect(after).not.toContain("@sealed");
+    expect(after).not.toContain("Remove this class");
+  });
+
+  it("deletes Python decorators with the symbol", async () => {
+    await fs.writeFile(
+      join(root, "decorated.py"),
+      "def keep():\n    return 1\n\n@cached\n@traced\ndef remove_me():\n    return 2\n",
+    );
+    await tools.dispatch("read_file", { path: "decorated.py" }, { readTracker });
+
+    const out = await tools.dispatch(
+      "delete_symbol",
+      { path: "decorated.py", name: "remove_me", kind: "function" },
+      { readTracker },
+    );
+
+    expect(out).toMatch(/delete_symbol: deleted lines/);
+    const after = await fs.readFile(join(root, "decorated.py"), "utf8");
+    expect(after).toContain("keep");
+    expect(after).not.toContain("remove_me");
+    expect(after).not.toContain("@cached");
+    expect(after).not.toContain("@traced");
+  });
+});

--- a/tests/filesystem-tools.test.ts
+++ b/tests/filesystem-tools.test.ts
@@ -968,7 +968,7 @@ describe("filesystem tools (built-in, sandbox-enforced)", () => {
   });
 
   describe("allowWriting=false (read-only mode)", () => {
-    it("skips registering write_file / edit_file / multi_edit / delete_range / create_directory / move_file / delete_file / delete_directory / copy_file", async () => {
+    it("skips registering write_file / edit_file / multi_edit / delete_range / delete_symbol / create_directory / move_file / delete_file / delete_directory / copy_file", async () => {
       const ro = new ToolRegistry();
       registerFilesystemTools(ro, { rootDir: root, allowWriting: false });
       expect(ro.has("read_file")).toBe(true);
@@ -978,6 +978,7 @@ describe("filesystem tools (built-in, sandbox-enforced)", () => {
       expect(ro.has("edit_file")).toBe(false);
       expect(ro.has("multi_edit")).toBe(false);
       expect(ro.has("delete_range")).toBe(false);
+      expect(ro.has("delete_symbol")).toBe(false);
       expect(ro.has("create_directory")).toBe(false);
       expect(ro.has("move_file")).toBe(false);
       expect(ro.has("delete_file")).toBe(false);

--- a/tests/review-edit-gate.test.ts
+++ b/tests/review-edit-gate.test.ts
@@ -15,6 +15,7 @@ describe("review edit gate tool matching", () => {
     expect(isReviewGatedEditTool("write_file")).toBe(true);
     expect(isReviewGatedEditTool("multi_edit")).toBe(true);
     expect(isReviewGatedEditTool("delete_range")).toBe(true);
+    expect(isReviewGatedEditTool("delete_symbol")).toBe(true);
     expect(isReviewGatedEditTool("read_file")).toBe(false);
   });
 });
@@ -80,6 +81,40 @@ describe("buildEditToolBlocks", () => {
 
     expect(blocks).toEqual([
       { path: "range.ts", search: "START\nremove\nEND\n", replace: "", offset: 0 },
+    ]);
+  });
+
+  it("turns delete_symbol args into a reviewable deletion block", async () => {
+    writeFileSync(
+      join(root, "symbols.ts"),
+      [
+        "export function keep() {",
+        "  return 1;",
+        "}",
+        "",
+        "/** Remove this class. */",
+        "@sealed",
+        "export class RemoveMe {",
+        "  value = 2;",
+        "}",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const blocks = await buildEditToolBlocksForReview(
+      "delete_symbol",
+      { path: "symbols.ts", name: "RemoveMe", kind: "class" },
+      root,
+    );
+
+    expect(blocks).toEqual([
+      {
+        path: "symbols.ts",
+        search: "/** Remove this class. */\n@sealed\nexport class RemoveMe {\n  value = 2;\n}\n",
+        replace: "",
+        offset: 0,
+      },
     ]);
   });
 });


### PR DESCRIPTION
## Summary

Adds a `delete_symbol` tool that deletes one function/class/method/interface/type by exact name using tree-sitter AST parsing. Supports TS/TSX/JS/JSX/Python/Go/Rust/Java. Parameters: `path`, `name`, `kind` (optional filter), `parent` (optional parent class/namespace filter). Multi-match fails and returns candidates with kind/line/parent for the model to disambiguate. Integrated into the edit review/auto/yolo gate with `read_file` enforcement via ReadTracker. v1 is delete-only (no replace-symbol).

## 概述

新增 `delete_symbol` 工具，使用 tree-sitter AST 解析按精确名称删除函数/类/方法/接口/类型。支持 TS/TSX/JS/JSX/Python/Go/Rust/Java。参数：path、name、kind（可选过滤）、parent（可选父类/命名空间过滤）。多匹配时失败并返回候选项供模型消歧义。集成到 edit review/auto/yolo 门禁，通过 ReadTracker 强制执行 read_file。v1 仅做删除（无 replace-symbol）。

## Key Files

- `src/tools/filesystem.ts` — `delete_symbol` tool with tree-sitter integration
- `src/tools/fs/edit.ts` — `applyDeleteLineRange()`, `computeDeleteLineRangePatchFromText()`
- `src/cli/ui/edit-tool-gate.ts` — `buildDeleteSymbolBlock()`, review gate
- `src/cli/ui/App.tsx` — ReadTracker in edit-gate interceptor
- `src/code/lifecycle-policy.ts` — high-risk classification
- `tests/delete-tools.test.ts` — AST deletion test

## Depends On / 依赖

This PR is #4 in a 5-PR series:
- PR #1: Cache Diagnostics v1
- PR #2: MCP Cache-Stable Canonicalization
- PR #3: Reliable Large Delete Primitive (delete_range)
- PR #5: SSH Remote Workspace RFC

## Test Plan

- TypeScript function deletion via AST
- Multi-language grammar support
- Multi-match disambiguation with candidates
- kind/parent filter parameters
- read_file enforcement in review/auto gate

## Verification

```
npm run lint      → 0 errors
npx vitest run tests/delete-tools.test.ts tests/review-edit-gate.test.ts → all passed
```