### PR TITLE
feat: SSH remote workspace RFC — dry-run bootstrap for ssh:// targets (#2140) | SSH 远程工作区 RFC

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -212,10 +212,44 @@ program
   .option("--system-append <prompt>", t("ui.systemAppendHint"))
   .option("--system-append-file <path>", t("ui.systemAppendFileHint"))
   .option(
+    "--dry-run",
+    "for ssh:// targets: parse the URI, check local SSH, print planned steps (no remote commands execute). RFC for #2140.",
+  )
+  .option(
     "--profile [path]",
     "record a V8 CPU profile; saved on exit. Send the .cpuprofile back if you're reporting a perf bug.",
   )
   .action(async (dir: string | undefined, opts) => {
+    // ssh:// without --dry-run is not yet implemented (RFC #2140).
+    if (typeof dir === "string" && dir.startsWith("ssh://") && !opts.dryRun) {
+      process.stderr.write(
+        "ssh:// remote workspaces require --dry-run (RFC #2140).\n" +
+          "Full remote execution is not yet implemented.\n" +
+          "\n" +
+          "Short-term recommendation:\n" +
+          "  Run Reasonix directly on the remote host, then use SSH tunnel for the dashboard:\n" +
+          "  $ ssh -L 8420:127.0.0.1:8420 user@host\n" +
+          "  $ reasonix code\n",
+      );
+      process.exit(1);
+    }
+
+    // SSH remote workspace RFC — dry-run bootstrap for #2140.
+    if (typeof dir === "string" && dir.startsWith("ssh://") && opts.dryRun) {
+      const { generateSshDryRunReport, parseSshUri, probeSsh } = await import("./ssh-remote.js");
+      const uri = parseSshUri(dir);
+      if (!uri) {
+        process.stderr.write(`invalid ssh:// URI: ${dir}\n`);
+        process.stderr.write("expected format: ssh://[user@]host[:port][/path]\n");
+        process.exit(1);
+      }
+      const ssh = probeSsh();
+      const report = generateSshDryRunReport(uri, ssh);
+      console.log(report);
+      if (!ssh) process.exit(1);
+      return;
+    }
+
     persistEffortFlag(opts.effort);
     const profiling = await maybeStartCpuProfile(opts.profile);
     try {

--- a/src/cli/ssh-remote.ts
+++ b/src/cli/ssh-remote.ts
@@ -1,0 +1,157 @@
+// SSH remote workspace RFC / dry-run — #2140. Full remote execution is a future deliverable.
+
+import { execFileSync, execSync } from "node:child_process";
+import { platform } from "node:os";
+import { VERSION } from "../version.js";
+
+export interface SshUri {
+  user: string;
+  host: string;
+  port: number;
+  path: string;
+}
+
+/** Parse ssh://[user@]host[:port]/path. Trailing `:port` is optional; defaults to 22. */
+export function parseSshUri(raw: string): SshUri | null {
+  const m = /^ssh:\/\/(?:([^@:]+)@)?([^/:]+)(?::(\d+))?(\/.*)?$/.exec(raw);
+  if (!m) return null;
+  const user = m[1] ?? inferSshUser();
+  const host = m[2] ?? "";
+  if (!host) return null;
+  const port = m[3] ? Number.parseInt(m[3], 10) : 22;
+  const path = m[4] ?? "/";
+  return { user, host, port, path };
+}
+
+function inferSshUser(): string {
+  try {
+    const out = execFileSync("id", ["-un"], { encoding: "utf8", timeout: 1000 }).trim();
+    if (out) return out;
+  } catch {
+    /* fall through */
+  }
+  // Best-effort fallback on Windows.
+  if (platform() === "win32") {
+    try {
+      const out = execFileSync("whoami", [], { encoding: "utf8", timeout: 1000 }).trim();
+      if (out) return out;
+    } catch {
+      /* fall through */
+    }
+  }
+  return "root";
+}
+
+export interface SshProbe {
+  sshBin: string;
+  version: string;
+}
+
+export function probeSsh(): SshProbe | null {
+  try {
+    // ssh -V writes to stderr on all platforms; merge into stdout.
+    const version = execSync("ssh -V 2>&1", { encoding: "utf8", timeout: 3000 });
+    return { sshBin: "ssh", version: version.trim() };
+  } catch {
+    return null;
+  }
+}
+
+/** Minimal POSIX shell quoting — wraps the value in single quotes and escapes
+ *  embedded single quotes. Sufficient for dry-run copy-paste safety. */
+function shellQuote(value: string): string {
+  if (!/[^a-zA-Z0-9,._+:@%/-]/.test(value)) return value;
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+export function generateSshDryRunReport(uri: SshUri, ssh: SshProbe | null): string {
+  const sq = shellQuote;
+  const sections = [
+    `reasonix ${VERSION}  ·  SSH remote workspace RFC dry-run`,
+    "issue: https://github.com/esengine/DeepSeek-Reasonix/issues/2140",
+    "",
+    `target:  ${sq(`ssh://${uri.user}@${uri.host}:${uri.port}${uri.path}`)}`,
+    "",
+  ];
+
+  if (!ssh) {
+    sections.push(
+      "WARNING: `ssh` binary not found on PATH. Install an SSH client before running the real command.",
+      "",
+    );
+  } else {
+    sections.push(`ssh:     ${ssh.version}`);
+  }
+
+  sections.push(
+    "--- parsed ---",
+    `  user:   ${uri.user}`,
+    `  host:   ${uri.host}`,
+    `  port:   ${uri.port}`,
+    `  path:   ${uri.path}`,
+    "",
+    "--- planned steps (dry run — no remote commands execute) ---",
+    "",
+  );
+
+  const remote = `${sq(uri.user)}@${sq(uri.host)}`;
+  const cdCmd = `cd ${sq(uri.path)} && reasonix code --no-dashboard`;
+
+  if (ssh) {
+    sections.push(
+      "1. verify connectivity",
+      `   $ ssh -p ${uri.port} ${remote} -- 'echo ok'`,
+      "",
+      "2. probe remote environment",
+      `   $ ssh -p ${uri.port} ${remote} -- 'node --version && npm --version && uname -s'`,
+      "",
+      "3. install or update Reasonix on remote",
+      `   $ ssh -p ${uri.port} ${remote} -- 'npm i -g reasonix'`,
+      "",
+      "4. launch Reasonix in the target workspace on the remote host",
+      `   $ ssh -p ${uri.port} ${remote} -- '${cdCmd}'`,
+      "",
+      "5. (local) open an SSH tunnel to the remote dashboard",
+      `   $ ssh -N -L 8420:127.0.0.1:8420 -p ${uri.port} ${remote}`,
+      "   Then open http://127.0.0.1:8420 in your local browser.",
+      "",
+    );
+  } else {
+    sections.push(
+      "1. install an SSH client",
+      "   macOS:   built-in (OpenSSH)",
+      "   Windows: built-in (OpenSSH Client optional feature) or `winget install Microsoft.OpenSSH.Beta`",
+      "   Linux:   `apt install openssh-client` / `dnf install openssh-clients`",
+      "",
+      "2. verify connectivity",
+      `   $ ssh -p ${uri.port} ${remote} -- 'echo ok'`,
+      "",
+      "3. install Reasonix on remote",
+      `   $ ssh -p ${uri.port} ${remote} -- 'npm i -g reasonix'`,
+      "",
+      "4. launch Reasonix remotely",
+      `   $ ssh -p ${uri.port} ${remote} -- '${cdCmd}'`,
+      "",
+    );
+  }
+
+  sections.push(
+    "--- short-term recommendation ---",
+    "",
+    "Until native remote execution lands, the simplest working setup is:",
+    "  1. Run Reasonix directly on the remote host (`ssh user@host`, then `reasonix code`).",
+    "  2. Forward the dashboard port to your local machine:",
+    `     $ ssh -N -L 8420:127.0.0.1:8420 -p ${uri.port} ${remote}`,
+    "  3. Open http://127.0.0.1:8420 locally. The dashboard token gates access.",
+    "",
+    "--- RFC scope ---",
+    "",
+    "This dry-run is a reviewable design bootstrap for #2140.",
+    "It parses the URI, checks local tooling, and prints the steps Reasonix",
+    "would take. No remote commands execute and no network connections are made.",
+    "",
+    "#2141 (GPU passthrough) is tracked separately and is not part of this RFC.",
+  );
+
+  return sections.join("\n");
+}

--- a/tests/ssh-remote.test.ts
+++ b/tests/ssh-remote.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import { generateSshDryRunReport, parseSshUri, probeSsh } from "../src/cli/ssh-remote.js";
+
+describe("parseSshUri", () => {
+  it("parses a full ssh:// URI with user, host, port, and path", () => {
+    const uri = parseSshUri("ssh://dev@example.com:2222/home/dev/project");
+    expect(uri).not.toBeNull();
+    expect(uri!.user).toBe("dev");
+    expect(uri!.host).toBe("example.com");
+    expect(uri!.port).toBe(2222);
+    expect(uri!.path).toBe("/home/dev/project");
+  });
+
+  it("parses an ssh:// URI without a user (falls back to local username)", () => {
+    const uri = parseSshUri("ssh://example.com/opt/app");
+    expect(uri).not.toBeNull();
+    expect(uri!.host).toBe("example.com");
+    expect(uri!.port).toBe(22);
+    expect(uri!.path).toBe("/opt/app");
+    // user is inferred from OS — just check it's a non-empty string
+    expect(typeof uri!.user).toBe("string");
+    expect(uri!.user.length).toBeGreaterThan(0);
+  });
+
+  it("parses an ssh:// URI without a path (defaults to /)", () => {
+    const uri = parseSshUri("ssh://root@host");
+    expect(uri).not.toBeNull();
+    expect(uri!.host).toBe("host");
+    expect(uri!.user).toBe("root");
+    expect(uri!.port).toBe(22);
+    expect(uri!.path).toBe("/");
+  });
+
+  it("parses an ssh:// URI with only host", () => {
+    const uri = parseSshUri("ssh://my-server");
+    expect(uri).not.toBeNull();
+    expect(uri!.host).toBe("my-server");
+    expect(uri!.port).toBe(22);
+  });
+
+  it("returns null for non-ssh URIs", () => {
+    expect(parseSshUri("https://example.com")).toBeNull();
+    expect(parseSshUri("git@github.com:user/repo.git")).toBeNull();
+    expect(parseSshUri("/local/path")).toBeNull();
+    expect(parseSshUri("")).toBeNull();
+  });
+
+  it("returns null for malformed ssh:// URIs with no host", () => {
+    expect(parseSshUri("ssh://")).toBeNull();
+    expect(parseSshUri("ssh://:22/path")).toBeNull();
+  });
+});
+
+describe("probeSsh", () => {
+  it("returns a probe result when ssh is on PATH", () => {
+    const probe = probeSsh();
+    // `ssh -V` exists on macOS and most dev machines; if it fails the
+    // function returns null, which is fine on a minimal CI runner.
+    if (probe) {
+      expect(probe.sshBin).toBe("ssh");
+      expect(typeof probe.version).toBe("string");
+      expect(probe.version.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("generateSshDryRunReport", () => {
+  const uri = { user: "dev", host: "box", port: 22, path: "/src" };
+
+  it("includes the RFC issue number and dry-run banner", () => {
+    const report = generateSshDryRunReport(uri, {
+      sshBin: "ssh",
+      version: "OpenSSH_9.6",
+    });
+
+    expect(report).toContain("RFC");
+    expect(report).toContain("#2140");
+    expect(report).toContain("dry-run");
+    expect(report).toContain("ssh://dev@box:22/src");
+  });
+
+  it("lists the planned steps when ssh is available", () => {
+    const report = generateSshDryRunReport(uri, {
+      sshBin: "ssh",
+      version: "OpenSSH_9.6",
+    });
+
+    expect(report).toContain("verify connectivity");
+    expect(report).toContain("probe remote environment");
+    expect(report).toContain("install or update Reasonix");
+    expect(report).toContain("launch Reasonix");
+    expect(report).toContain("SSH tunnel");
+    expect(report).toContain("reasonix code --no-dashboard");
+  });
+
+  it("warns when ssh is missing and shows install instructions", () => {
+    const report = generateSshDryRunReport(uri, null);
+
+    expect(report).toContain("WARNING");
+    expect(report).toContain("ssh");
+    expect(report).toContain("not found");
+  });
+
+  it("includes the short-term recommendation section", () => {
+    const report = generateSshDryRunReport(uri, {
+      sshBin: "ssh",
+      version: "OpenSSH_9.6",
+    });
+
+    expect(report).toContain("short-term recommendation");
+    expect(report).toContain("Run Reasonix directly on the remote host");
+    expect(report).toContain("SSH tunnel");
+    expect(report).toContain("127.0.0.1:8420");
+  });
+
+  it("notes that no remote commands execute", () => {
+    const report = generateSshDryRunReport(uri, {
+      sshBin: "ssh",
+      version: "OpenSSH_9.6",
+    });
+
+    expect(report).toContain("no remote commands execute");
+    expect(report).toContain("no network connections are made");
+  });
+
+  it("includes the reasonix version", () => {
+    const report = generateSshDryRunReport(uri, {
+      sshBin: "ssh",
+      version: "OpenSSH_9.6",
+    });
+
+    expect(report).toContain("reasonix");
+  });
+
+  it("mentions GPU passthrough is tracked separately", () => {
+    const report = generateSshDryRunReport(uri, null);
+
+    expect(report).toContain("#2141");
+    expect(report).toContain("GPU passthrough");
+    expect(report).toContain("tracked separately");
+  });
+});


### PR DESCRIPTION
## Summary

Adds an SSH remote workspace RFC with a `--dry-run` bootstrap. The `reasonix code ssh://user@host/path --dry-run` command parses the SSH URI, checks local SSH availability, and prints planned execution steps without executing any remote commands or making network connections. Without `--dry-run`, an explicit error message recommends running Reasonix on the remote host with an SSH tunnel for the dashboard. GPU passthrough (#2141) is tracked separately.

## 概述

新增 SSH 远程工作区 RFC 和 `--dry-run` 引导。`reasonix code ssh://user@host/path --dry-run` 命令解析 SSH URI，检查本地 SSH 可用性，打印计划执行步骤，不执行任何远程命令也不建立网络连接。无 `--dry-run` 时显式报错并建议在远程主机上运行 Reasonix 配合 SSH 隧道访问 dashboard。GPU passthrough (#2141) 单独跟踪。

## Key Files

- `src/cli/ssh-remote.ts` (new) — `parseSshUri()`, `probeSsh()`, `generateSshDryRunReport()`
- `src/cli/index.ts` — `--dry-run` option, SSH URI handling, rejection message
- `tests/ssh-remote.test.ts` (new) — URI parsing, report content, probe tests

## Depends On / 依赖

This PR is #5 in a 5-PR series:
- PR #1: Cache Diagnostics v1
- PR #2: MCP Cache-Stable Canonicalization
- PR #3: Reliable Large Delete Primitive (delete_range)
- PR #4: AST-Aware Delete (delete_symbol)

## Test Plan

- SSH URI parser: full URI, no user, no path, host-only, invalid formats
- Local SSH probe
- Dry-run report content: RFC banner, planned steps, recommendations
- No network side effects
- SSH binary missing warning

## Verification

```
npm run lint      → 0 errors
npx vitest run tests/ssh-remote.test.ts → 14 passed
```