### PR TITLE
fix(loop): add headless NEEDS_PRO escalation for `reasonix run`

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -908,6 +908,15 @@ export class CacheFirstLoop {
         return;
       }
 
+      // Headless escalation: flash model emits <<<NEEDS_PRO>>> when it
+      // can't handle a task. In TUI mode, the UI layer retries with pro.
+      // In headless mode (reasonix run), no TUI is listening — we detect
+      // the marker here and retry the iteration with deepseek-v4-pro.
+      if (/<<<NEEDS_PRO/.test(assistantContent) && this.model !== "deepseek-v4-pro") {
+        this.model = "deepseek-v4-pro";
+        continue;
+      }
+
       // Attribute under the actual model used (escalated → pro, else
       // this.model) so cost/usage logs reflect reality.
       const turnStats = this.stats.record(this._turn, this.model, usage ?? new Usage());


### PR DESCRIPTION
## Problem

In headless one-shot mode (`reasonix run`), the flash model can emit `<<<NEEDS_PRO>>>` to signal that a task exceeds its capability. In TUI mode, the UI layer catches this and retries with `deepseek-v4-pro`. In headless mode, no TUI is listening — the escalation event is lost and the turn ends without retrying.

## Fix

6 lines added in `src/loop.ts` (CacheFirstLoop.step()), immediately after `streamModelResponse` returns. When the `<<<NEEDS_PRO` marker is found in `assistantContent` and the model isn't already pro, we switch `this.model = "deepseek-v4-pro"` and `continue` the iteration.

The flash model's NEEDS_PRO response is never persisted (we skip `appendAndPersist`), so it doesn't pollute the session log.

## Testing

- Simple task (2+2): unchanged behavior ✓
- Complex security audit: flash handled it, no false escalation ✓
- Escalation path: when flash emits NEEDS_PRO → model switches to pro → iteration retries

## Related

This is the loop.ts counterpart to the existing TUI escalation handler in `src/cli/ui/slash/handlers/model.ts`.