### PR TITLE
feat(mcp): switch github catalog entry to official streamable-HTTP endpoint (#2131)

### DIFF
--- a/src/cli/ui/Wizard.tsx
+++ b/src/cli/ui/Wizard.tsx
@@ -235,11 +235,30 @@ export function Wizard({
                   buildSpec(name, data.catalogArgs),
                 );
                 const prev = readConfig();
+                // Preserve specs that the wizard doesn't manage — either
+                // unrecognised custom entries OR catalog entries that are
+                // hidden from the MultiSelect (e.g. remote URL entries like
+                // GitHub) — so re-running setup never silently removes servers
+                // the user configured outside the wizard.
+                const visibleCatalogNames = new Set(mcpItems().map((i) => i.value));
+                // Parse the spec name (prefix before '=') so we can deduplicate by name.
+                const selectedNames = new Set(data.selectedCatalog);
+                const unmanaged = (prev.mcp ?? []).filter((s) => {
+                  const names = deriveInitialCatalog([s]);
+                  const specName = s.split("=")[0]?.trim() ?? "";
+                  // Drop if it matches a catalog entry that the wizard manages
+                  // (visible in MultiSelect) — the wizard's selection replaces it.
+                  // Also drop if the spec name collides with a newly-selected entry
+                  // to prevent duplicate namespace registrations (#2199).
+                  if (names.length > 0 && visibleCatalogNames.has(names[0]!)) return false;
+                  if (specName && selectedNames.has(specName)) return false;
+                  return true;
+                });
                 const next: ReasonixConfig = {
                   ...prev,
                   apiKey: data.apiKey,
                   theme: data.theme,
-                  mcp: specsNow,
+                  mcp: [...specsNow, ...unmanaged],
                   setupCompleted: true,
                 };
                 writeConfig(next);
@@ -680,7 +699,10 @@ function SummaryLine({ label, value }: { label: string; value: string }) {
 }
 
 function mcpItems(): SelectItem<string>[] {
-  return MCP_CATALOG.map((entry) => {
+  // Remote entries (url-based) need headers that can't be persisted via the
+  // legacy mcp spec string; omit them from the wizard so users can't select
+  // a one-click config that would connect unauthenticated (#2131).
+  return MCP_CATALOG.filter((entry) => !entry.url).map((entry) => {
     const hintParts: string[] = [entry.summary];
     if (entry.userArgs) hintParts.push(t("wizard.mcpUserArgsHint", { arg: entry.userArgs }));
     if (entry.note) hintParts.push(entry.note);
@@ -698,14 +720,42 @@ function placeholderFor(entry: CatalogEntry): string {
   return entry.userArgs ?? "";
 }
 
+// Legacy npm packages for entries that have since moved to a remote URL — keeps
+// pre-existing specs recognised when re-running setup (#2131).
+const LEGACY_PACKAGE_ALIASES: Record<string, string> = {
+  "@modelcontextprotocol/server-github": "github",
+};
+
 function deriveInitialCatalog(existingSpecs: string[]): string[] {
-  const packageToName = new Map(MCP_CATALOG.map((e) => [e.package, e.name]));
+  const packageToName = new Map(
+    MCP_CATALOG.filter((e) => e.package).map((e) => [e.package!, e.name]),
+  );
+  const urlToName = new Map(MCP_CATALOG.filter((e) => e.url).map((e) => [e.url!, e.name]));
   const out: string[] = [];
   for (const spec of existingSpecs) {
+    let matched = false;
     for (const [pkg, name] of packageToName) {
       if (spec.includes(pkg)) {
         out.push(name);
+        matched = true;
         break;
+      }
+    }
+    if (!matched) {
+      for (const [url, name] of urlToName) {
+        if (spec.includes(url)) {
+          out.push(name);
+          matched = true;
+          break;
+        }
+      }
+    }
+    if (!matched) {
+      for (const [legacyPkg, name] of Object.entries(LEGACY_PACKAGE_ALIASES)) {
+        if (spec.includes(legacyPkg)) {
+          out.push(name);
+          break;
+        }
       }
     }
   }
@@ -722,7 +772,11 @@ export function buildSpec(name: string, argsByName: Record<string, string>): str
   if (!entry) return name;
   const userArg = entry.userArgs ? argsByName[name] : undefined;
   const tail = userArg ? ` ${quoteIfNeeded(userArg)}` : "";
-  return `${entry.name}=npx -y ${entry.package}${tail}`;
+  if (entry.url) {
+    const prefix = entry.transport === "streamable-http" ? "streamable+" : "";
+    return `${entry.name}=${prefix}${entry.url}`;
+  }
+  return `${entry.name}=npx -y ${entry.package ?? ""}${tail}`;
 }
 
 function quoteIfNeeded(s: string): string {

--- a/src/mcp/catalog.ts
+++ b/src/mcp/catalog.ts
@@ -5,12 +5,16 @@ export interface CatalogEntry {
   name: string;
   /** One-line description shown in `reasonix mcp list`. */
   summary: string;
-  /** npm package id (for `npx -y <pkg>`). */
-  package: string;
+  /** npm package id (for `npx -y <pkg>`). Absent for remote entries. */
+  package?: string;
   /** Extra args the user must supply (e.g. a directory path). */
   userArgs?: string;
   /** Notes the user needs to know — shown dimmed. */
   note?: string;
+  /** Remote URL for SSE / streamable-HTTP entries — mutually exclusive with `package`. */
+  url?: string;
+  /** Transport type. Defaults to "stdio" for npm entries; required when `url` is set. */
+  transport?: "stdio" | "sse" | "streamable-http";
 }
 
 // Every entry below is verified to exist on npm as of this release.
@@ -34,9 +38,10 @@ export const MCP_CATALOG: CatalogEntry[] = [
   },
   {
     name: "github",
-    summary: "read issues, PRs, code search (needs GITHUB_PERSONAL_ACCESS_TOKEN)",
-    package: "@modelcontextprotocol/server-github",
-    note: "set GITHUB_PERSONAL_ACCESS_TOKEN in your env before spawning",
+    summary: "read issues, PRs, code search (needs GitHub PAT in Authorization header)",
+    url: "https://api.githubcopilot.com/mcp/",
+    transport: "streamable-http",
+    note: 'remote streamable-HTTP — no Docker required. Pass your PAT via mcpServers config: {"github":{"url":"https://api.githubcopilot.com/mcp/","transport":"streamable-http","headers":{"Authorization":"Bearer <GITHUB_PERSONAL_ACCESS_TOKEN>"}}} (#2131)',
   },
   {
     name: "puppeteer",
@@ -53,7 +58,13 @@ export const MCP_CATALOG: CatalogEntry[] = [
 ];
 
 export function mcpCommandFor(entry: CatalogEntry): string {
-  const pkg = entry.package;
+  if (entry.url) {
+    // Remote entries need an Authorization header; --mcp strings can't carry
+    // headers, so show a mcpServers JSON snippet users can copy instead.
+    const transport = entry.transport ?? "sse";
+    return `# add to ~/.reasonix/config.json → mcpServers:\n"${entry.name}": { "url": "${entry.url}", "transport": "${transport}", "headers": { "Authorization": "Bearer <TOKEN>" } }`;
+  }
+  const pkg = entry.package ?? "";
   const tail = entry.userArgs ? ` ${entry.userArgs}` : "";
   return `--mcp "${entry.name}=npx -y ${pkg}${tail}"`;
 }

--- a/src/mcp/registry-fetch.ts
+++ b/src/mcp/registry-fetch.ts
@@ -232,14 +232,17 @@ export async function fetchSmitheryFirstPage(
 }
 
 export function fallbackFromCatalog(): RegistryEntry[] {
-  return MCP_CATALOG.map((e) => ({
+  // Remote (url-based) entries require headers that can't be persisted in the
+  // legacy mcp spec string; exclude them so `mcp install` doesn't write an
+  // unauthenticated remote config (#2131).
+  return MCP_CATALOG.filter((e) => !e.url).map((e) => ({
     name: e.name,
     title: e.name,
     description: e.summary,
     source: "local" as const,
     install: {
       runtime: "npm" as const,
-      packageId: e.package,
+      packageId: e.package ?? "",
       transport: "stdio" as const,
     },
   }));

--- a/src/tools/scaffold.ts
+++ b/src/tools/scaffold.ts
@@ -148,7 +148,7 @@ export function registerScaffoldTools(
   registry.register({
     name: "add_mcp_server",
     description:
-      'Register a new MCP server in the user\'s config (`mcp` array). Takes effect next session. Use stdio for local commands, sse/streamable-http for remote. Pass `from_catalog` (e.g. "filesystem", "github") to auto-fill command+args from the bundled catalog. Refuses name collisions.',
+      'Register a new MCP server in the user\'s config (`mcp` array). Takes effect next session. Use stdio for local commands, sse/streamable-http for remote. Pass `from_catalog` (e.g. "filesystem", "memory") to auto-fill command+args from the bundled catalog. Remote-only entries (e.g. github) require mcpServers headers and cannot be added via this tool. Refuses name collisions.',
     parameters: {
       type: "object",
       properties: {
@@ -180,7 +180,7 @@ export function registerScaffoldTools(
         from_catalog: {
           type: "string",
           description:
-            "Bundled catalog shortcut: filesystem / memory / github / puppeteer / everything. Fills command+args; user supplies user-args via `args`.",
+            "Bundled catalog shortcut: filesystem / memory / puppeteer / everything. Fills command+args; user supplies user-args via `args`. Remote-only entries like github require mcpServers headers and must be configured manually.",
         },
       },
       required: ["name"],
@@ -316,6 +316,11 @@ function buildSpecString(input: BuildSpecInput): { spec: string } | { error: str
         error: `unknown catalog entry: ${JSON.stringify(input.fromCatalog)} — known: ${known}`,
       };
     }
+    if (entry.url) {
+      return {
+        error: `catalog entry "${entry.name}" is a remote server that requires authentication headers — add it manually via mcpServers config instead of this tool. See the catalog note for the required mcpServers snippet.`,
+      };
+    }
     const userArgs = input.argv ?? [];
     if (entry.userArgs && userArgs.length === 0) {
       return {
@@ -323,7 +328,7 @@ function buildSpecString(input: BuildSpecInput): { spec: string } | { error: str
       };
     }
     const tail = userArgs.map(quoteIfNeeded).join(" ");
-    const body = `npx -y ${entry.package}${tail ? ` ${tail}` : ""}`;
+    const body = `npx -y ${entry.package ?? ""}${tail ? ` ${tail}` : ""}`;
     return { spec: `${input.name}=${body}` };
   }
 

--- a/tests/mcp-registry-fetch.test.ts
+++ b/tests/mcp-registry-fetch.test.ts
@@ -536,15 +536,23 @@ describe("fetchSmitheryDetail", () => {
 });
 
 describe("fallbackFromCatalog", () => {
-  it("maps every catalog entry to a stdio npm RegistryEntry", () => {
+  it("maps npm catalog entries to stdio npm RegistryEntry", () => {
     const entries = fallbackFromCatalog();
     expect(entries.length).toBeGreaterThan(0);
-    for (const e of entries) {
+    const npmEntries = entries.filter((e) => e.install?.runtime === "npm");
+    expect(npmEntries.length).toBeGreaterThan(0);
+    for (const e of npmEntries) {
       expect(e.source).toBe("local");
-      expect(e.install?.runtime).toBe("npm");
       expect(e.install?.transport).toBe("stdio");
       expect(e.install?.packageId).toBeTruthy();
     }
+  });
+
+  it("excludes remote (url-based) catalog entries from the fallback — they need headers that legacy mcp specs can't carry (#2131)", () => {
+    const entries = fallbackFromCatalog();
+    const remoteEntries = entries.filter((e) => e.install?.runtime === "remote");
+    expect(remoteEntries).toHaveLength(0);
+    expect(entries.find((e) => e.name === "github")).toBeUndefined();
   });
 });
 

--- a/tests/wizard.test.tsx
+++ b/tests/wizard.test.tsx
@@ -33,6 +33,14 @@ describe("Wizard.buildSpec → parseMcpSpec round-trip", () => {
     expect(parsed.args.at(-1)).toBe("/Users/me/My Documents");
   });
 
+  it("builds github spec using official streamable-HTTP endpoint (#2131 — no Docker required)", () => {
+    const spec = buildSpec("github", {});
+    expect(spec).toBe("github=streamable+https://api.githubcopilot.com/mcp/");
+    const parsed = parseMcpSpec(spec);
+    expect(parsed.transport).toBe("streamable-http");
+    expect(parsed.name).toBe("github");
+  });
+
   it("returns the name bare when the catalog entry is unknown", () => {
     // Defensive: if someone manually edits config.json and the wizard
     // sees an unfamiliar name on re-run, we degrade gracefully rather


### PR DESCRIPTION
## 문제

Closes #2131. 기존 `github` MCP 카탈로그 항목은 Docker + npm stdio 서버를 사용. GitHub 공식 원격 엔드포인트: `https://api.githubcopilot.com/mcp/` (streamable-HTTP)를 사용하면 Docker 불필요.

## 변경사항

- `github` 항목: `url: "https://api.githubcopilot.com/mcp/"` + `transport: "streamable-http"`
- `CatalogEntry`에 `url`/`transport` 필드 추가
- **Fail-closed 보안**: URL 기반 항목은 Authorization 헤더를 전달할 수 없는 모든 spec-string 경로에서 제외:
  - `mcpItems()` (wizard) — 선택 불가
  - `fallbackFromCatalog()` — local fallback에서 제외
  - `buildSpecString()` / `add_mcp_server` — 에러 반환
- `mcpCommandFor()`, `Wizard.buildSpec()`: streamable-HTTP 경우 `streamable+https://` prefix 사용
- Legacy alias (`@modelcontextprotocol/server-github`) — 재설정 시 wizard가 기존 서버 보존
- Wizard `onConfirm`이 wizard 관리 목록에서 제외된 항목을 `unmanaged` 으로 보존