### PR TITLE
fix(tests): sync assertions broken by #2173 and #2168

### DIFF
--- a/tests/auto-git-rollback.test.ts
+++ b/tests/auto-git-rollback.test.ts
@@ -149,7 +149,7 @@ describe("auto-git-rollback memory guard", () => {
     await tools.dispatch("read_file", { path: "tracked.txt" }, { readTracker });
     const out = await tools.dispatch(toolName, args, { readTracker });
 
-    expect(out).toMatch(toolName === "write_file" ? /wrote \d+ chars/ : /applied 1 edit/);
+    expect(out).toMatch(toolName === "write_file" ? /edited.*\d+.*chars/ : /applied 1 edit/);
     expect(git(root, ["show", "HEAD:tracked.txt"])).toBe("dirty-before-edit");
     expect(git(root, ["log", "-1", "--format=%s"])).toMatch(
       new RegExp(`pre-edit: ${toolName} tracked\\.txt`),

--- a/tests/slash.test.ts
+++ b/tests/slash.test.ts
@@ -696,7 +696,7 @@ describe("handleSlash", () => {
     // Case-insensitive.
     expect(suggestSlashCommands("HE").map((s) => s.cmd)).toEqual(["help"]);
     // Empty prefix returns the full non-advanced release list, including code commands.
-    expect(suggestSlashCommands("", true)).toHaveLength(43);
+    expect(suggestSlashCommands("", true)).toHaveLength(44);
     expect(suggestSlashCommands("", true).map((s) => s.cmd)).toContain("logs");
     expect(suggestSlashCommands("", true).map((s) => s.cmd)).toContain("language");
     expect(suggestSlashCommands("lan").map((s) => s.cmd)).toContain("language");

--- a/tests/ui-slash-suggestions.test.tsx
+++ b/tests/ui-slash-suggestions.test.tsx
@@ -84,7 +84,7 @@ describe("SlashSuggestions", () => {
     );
   });
 
-  it("renders the bare slash release command surface as 43 total commands", () => {
+  it("renders the bare slash release command surface as 44 total commands", () => {
     const matches = suggestSlashCommands("", true);
     const names = matches.map((spec) => spec.cmd);
     const { lastFrame, unmount } = render(
@@ -93,12 +93,12 @@ describe("SlashSuggestions", () => {
     const frame = lastFrame() ?? "";
     unmount();
 
-    expect(matches).toHaveLength(43);
+    expect(matches).toHaveLength(44);
     expect(names).toContain("language");
     expect(names).toContain("btw");
     expect(names).toContain("about");
     expect(countAdvancedCommands(true)).toBe(10);
-    expect(frame).toContain("43 commands");
+    expect(frame).toContain("44 commands");
     expect(frame).toContain("+ 10 advanced");
   });
 


### PR DESCRIPTION
## Problem

Three tests were broken by recent merged PRs:

1. **`auto-git-rollback.test.ts`** — `write_file` output format changed from `"wrote N chars"` to `"edited ... (M→N chars)"` unified diff format by #2173; the test regex `/wrote \d+ chars/` no longer matches.

2. **`slash.test.ts`** — Telegram's `/telegram` slash command added by #2168 brings the release command count from 43 → 44; assertion `toHaveLength(43)` fails.

3. **`ui-slash-suggestions.test.tsx`** — Same count change (43 → 44) plus the rendered frame text `"43 commands"` → `"44 commands"`.

## Fix

- Update the write_file regex to match the new unified-diff output: `/edited.*\d+.*chars/`
- Update both command-count assertions from 43 → 44