### PR TITLE
fix(test): reconcile slash count + write_file diff assertions (green main)

### DIFF
--- a/tests/auto-git-rollback.test.ts
+++ b/tests/auto-git-rollback.test.ts
@@ -149,7 +149,9 @@ describe("auto-git-rollback memory guard", () => {
     await tools.dispatch("read_file", { path: "tracked.txt" }, { readTracker });
     const out = await tools.dispatch(toolName, args, { readTracker });
 
-    expect(out).toMatch(toolName === "write_file" ? /wrote \d+ chars/ : /applied 1 edit/);
+    expect(out).toMatch(
+      toolName === "write_file" ? /edited tracked\.txt \(\d+→\d+ chars\)/ : /applied 1 edit/,
+    );
     expect(git(root, ["show", "HEAD:tracked.txt"])).toBe("dirty-before-edit");
     expect(git(root, ["log", "-1", "--format=%s"])).toMatch(
       new RegExp(`pre-edit: ${toolName} tracked\\.txt`),

--- a/tests/slash.test.ts
+++ b/tests/slash.test.ts
@@ -696,7 +696,7 @@ describe("handleSlash", () => {
     // Case-insensitive.
     expect(suggestSlashCommands("HE").map((s) => s.cmd)).toEqual(["help"]);
     // Empty prefix returns the full non-advanced release list, including code commands.
-    expect(suggestSlashCommands("", true)).toHaveLength(43);
+    expect(suggestSlashCommands("", true)).toHaveLength(44);
     expect(suggestSlashCommands("", true).map((s) => s.cmd)).toContain("logs");
     expect(suggestSlashCommands("", true).map((s) => s.cmd)).toContain("language");
     expect(suggestSlashCommands("lan").map((s) => s.cmd)).toContain("language");

--- a/tests/ui-slash-suggestions.test.tsx
+++ b/tests/ui-slash-suggestions.test.tsx
@@ -84,7 +84,7 @@ describe("SlashSuggestions", () => {
     );
   });
 
-  it("renders the bare slash release command surface as 43 total commands", () => {
+  it("renders the bare slash release command surface as 44 total commands", () => {
     const matches = suggestSlashCommands("", true);
     const names = matches.map((spec) => spec.cmd);
     const { lastFrame, unmount } = render(
@@ -93,12 +93,12 @@ describe("SlashSuggestions", () => {
     const frame = lastFrame() ?? "";
     unmount();
 
-    expect(matches).toHaveLength(43);
+    expect(matches).toHaveLength(44);
     expect(names).toContain("language");
     expect(names).toContain("btw");
     expect(names).toContain("about");
     expect(countAdvancedCommands(true)).toBe(10);
-    expect(frame).toContain("43 commands");
+    expect(frame).toContain("44 commands");
     expect(frame).toContain("+ 10 advanced");
   });
 


### PR DESCRIPTION
## Summary
main CI has been red since the #2173 merge — three tests broke from **cross-PR merge skew**, not behavior bugs. This reconciles the stale assertions.

## Root cause
- **#2173** (unified diff for edit/write/multi_edit) changed `write_file`'s output for an overwrite from `wrote N chars` to `edited <path> (N→M chars)` + unified diff, and added the `/diff` slash command.
- Tests from other PRs that hardcoded the old output / the pre-`/diff` command count weren't updated when these landed together.

## Fix (test-only)
- `tests/auto-git-rollback.test.ts` — `write_file` checkpoint test now expects `edited <path> (N→M chars)` (the #2173 format) instead of `wrote N chars`. The edit_file/multi_edit cases (`applied 1 edit`) were unaffected.
- `tests/slash.test.ts` + `tests/ui-slash-suggestions.test.tsx` — release-surface command count `43 → 44` after `/diff` was added.

## Verification
- `npx vitest run tests/auto-git-rollback.test.ts` → 6/6 pass
- `npx vitest run tests/slash.test.ts tests/ui-slash-suggestions.test.tsx` → 147/147 pass
- pre-push `npm run verify` (full build + lint + typecheck + suite) passed locally