### PR TITLE
Fix Baidu and Metaso HTTP error classification before JSON parsing

### DIFF
--- a/src/tools/web.ts
+++ b/src/tools/web.ts
@@ -408,13 +408,6 @@ async function searchMetaso(query: string, opts: WebSearchOptions = {}): Promise
   }
 
   const raw = await resp.text();
-  let data: MetasoSearchResponse;
-  try {
-    data = JSON.parse(raw) as MetasoSearchResponse;
-  } catch {
-    throw new Error(t("webErrors.metasoParseError", { status: resp.status }));
-  }
-
   if (!resp.ok) {
     if (resp.status === 401 || resp.status === 403) {
       throw new Error(t("webErrors.metasoUnauthorized"));
@@ -423,6 +416,13 @@ async function searchMetaso(query: string, opts: WebSearchOptions = {}): Promise
       throw new Error(t("webErrors.metasoRateLimit"));
     }
     throw new Error(t("webErrors.metasoServerError", { status: resp.status }));
+  }
+
+  let data: MetasoSearchResponse;
+  try {
+    data = JSON.parse(raw) as MetasoSearchResponse;
+  } catch {
+    throw new Error(t("webErrors.metasoParseError", { status: resp.status }));
   }
 
   if (data.code === 3003) {
@@ -487,19 +487,19 @@ async function searchBaidu(query: string, opts: WebSearchOptions = {}): Promise<
   }
 
   const raw = await resp.text();
-  let data: BaiduSearchResponse;
-  try {
-    data = raw ? (JSON.parse(raw) as BaiduSearchResponse) : {};
-  } catch {
-    throw new Error(t("webErrors.baiduParseError", { status: resp.status }));
-  }
-
   if (!resp.ok) {
     if (resp.status === 401 || resp.status === 403) {
       throw new Error(t("webErrors.baiduUnauthorized"));
     }
     if (resp.status === 429) throw new Error(t("webErrors.baiduRateLimit"));
     throw new Error(t("webErrors.baiduServerError", { status: resp.status }));
+  }
+
+  let data: BaiduSearchResponse;
+  try {
+    data = raw ? (JSON.parse(raw) as BaiduSearchResponse) : {};
+  } catch {
+    throw new Error(t("webErrors.baiduParseError", { status: resp.status }));
   }
 
   return (data.references ?? [])

--- a/tests/web-tools.test.ts
+++ b/tests/web-tools.test.ts
@@ -468,6 +468,40 @@ describe("searchMetaso", () => {
     }
   });
 
+  it("throws Metaso server error on non-JSON 500 response", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response("<html><body>upstream failure</body></html>", {
+          status: 500,
+          headers: { "Content-Type": "text/html" },
+        }),
+    ) as unknown as typeof fetch;
+    try {
+      await expect(webSearch("q", { engine: "metaso" })).rejects.toThrow(
+        /Metaso server error \(500\)/,
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("throws Metaso parse error on 200 invalid JSON", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response("not json", {
+          status: 200,
+          headers: { "Content-Type": "text/plain" },
+        }),
+    ) as unknown as typeof fetch;
+    try {
+      await expect(webSearch("q", { engine: "metaso" })).rejects.toThrow(/unparseable/i);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("returns empty array on 0 results", async () => {
     const originalFetch = globalThis.fetch;
     globalThis.fetch = vi.fn(
@@ -654,6 +688,24 @@ describe("searchBaidu", () => {
     ) as unknown as typeof fetch;
     try {
       await expect(webSearch("q", { engine: "baidu" })).rejects.toThrow(/rate-limit|quota/i);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("throws Baidu server error on non-JSON 500 response", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response("<html><body>upstream failure</body></html>", {
+          status: 500,
+          headers: { "Content-Type": "text/html" },
+        }),
+    ) as unknown as typeof fetch;
+    try {
+      await expect(webSearch("q", { engine: "baidu" })).rejects.toThrow(
+        /Baidu AI Search server error \(500\)/,
+      );
     } finally {
       globalThis.fetch = originalFetch;
     }


### PR DESCRIPTION
## Summary

- Classify non-JSON HTTP error responses from Baidu AI Search before attempting to parse JSON
- Apply the same status-before-parse behavior to Metaso
- Preserve existing parse-error behavior for 2xx responses with invalid JSON

## Context

Follow-up to #2147. Review noted that Baidu web search parsed the response body before checking `resp.ok`, causing non-JSON 401/429/500 upstream responses to be reported as parse errors instead of more useful auth, rate-limit, or server errors.

While checking the current implementation, Metaso had the same JSON API pattern, so this PR fixes both affected providers only.

## Test Plan

- [x] `npm test -- tests/web-tools.test.ts -t "searchMetaso|searchBaidu"`
- [x] `npm test -- tests/web-tools.test.ts`
- [x] `npm run lint -- src/tools/web.ts tests/web-tools.test.ts`
- [x] `npm run build` (run by pre-push verify)
- [x] `npm run lint` (run by pre-push verify)
- [x] `npm run typecheck` (run by pre-push verify)
- [ ] `npm run test --silent` (pre-existing unrelated failures on current main: slash command count expects 43 but receives 44 in `tests/slash.test.ts` and `tests/ui-slash-suggestions.test.tsx`; auto-git-rollback write_file output expectation in `tests/auto-git-rollback.test.ts`)
