### PR TITLE
fix(lifecycle): show plan suggestion once per session

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -625,6 +625,7 @@ function AppInner({
       mode: engineeringLifecycleBaseModeRef.current,
     });
   }
+  const lifecyclePlanSuggestionSessionRef = useRef<string | null | undefined>(undefined);
   // Refs that mirror state for stable read-callbacks handed to the
   // embedded dashboard server. The server's `getXxx()` closures are
   // captured once at startDashboard time; without ref-mirrors the
@@ -3195,9 +3196,11 @@ function AppInner({
             codeMode: true,
             planMode,
             lifecycleMode: engineeringLifecycleRef.current?.snapshot().mode ?? "off",
+            alreadySuggested: lifecyclePlanSuggestionSessionRef.current === (session ?? null),
           })
         ) {
           log.pushInfo(t("app.lifecyclePlanSuggestion"));
+          lifecyclePlanSuggestionSessionRef.current = session ?? null;
         }
         const before = engineeringLifecycleRef.current?.snapshot().state;
         engineeringLifecycleRef.current?.observeUserPrompt(text);

--- a/src/cli/ui/lifecycle-plan-suggestion.ts
+++ b/src/cli/ui/lifecycle-plan-suggestion.ts
@@ -3,6 +3,7 @@ export interface LifecyclePlanSuggestionRequest {
   codeMode: boolean;
   planMode: boolean;
   lifecycleMode: "off" | "strict";
+  alreadySuggested?: boolean;
 }
 
 export function shouldSuggestPlanForEngineeringIntent(
@@ -12,6 +13,7 @@ export function shouldSuggestPlanForEngineeringIntent(
     request.codeMode &&
     !request.planMode &&
     request.lifecycleMode === "off" &&
+    !request.alreadySuggested &&
     detectLifecyclePlanSuggestion(request.text)
   );
 }

--- a/tests/lifecycle-plan-suggestion.test.ts
+++ b/tests/lifecycle-plan-suggestion.test.ts
@@ -69,4 +69,16 @@ describe("lifecycle plan suggestion intent", () => {
       }),
     ).toBe(false);
   });
+
+  it("does not repeat the suggestion after it was already shown in the session", () => {
+    const request = {
+      text: "Refactor multiple files to extract the auth module",
+      codeMode: true,
+      planMode: false,
+      lifecycleMode: "off",
+      alreadySuggested: true,
+    } as const;
+
+    expect(shouldSuggestPlanForEngineeringIntent(request)).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

- show the high-risk lifecycle plan suggestion only once per active session
- keep the suggestion UI-only and preserve the explicit plan-first auto-arm path
- add a regression test for already-shown suggestion suppression

## Notes

This follows the non-blocking review note from #2119. The change does not auto-arm lifecycle, block prompts, change prompt text, or touch tool schemas. A new named session can still show the hint again; repeated matching prompts in the same session stay quiet.

## Validation

- `npm test -- tests/lifecycle-plan-suggestion.test.ts`
- `npm test -- tests/lifecycle-explicit-intent.test.ts tests/lifecycle-plan-suggestion.test.ts tests/code-prompt.test.ts tests/lifecycle.test.ts tests/slash.test.ts`
- `npx biome check src/cli/ui/lifecycle-plan-suggestion.ts tests/lifecycle-plan-suggestion.test.ts src/cli/ui/App.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run verify`
- pre-push `npm run verify`
