### PR TITLE
feat(i18n): add Russian (ru) locale to desktop and dashboard

### DIFF
--- a/dashboard/src/i18n/index.ts
+++ b/dashboard/src/i18n/index.ts
@@ -2,17 +2,19 @@ import { useEffect, useState } from "react";
 import { de } from "./de";
 import { en } from "./en";
 import { ja } from "./ja";
+import { ru } from "./ru";
 import { zhCN } from "./zh-CN";
 
-export type Lang = "en" | "zh-CN" | "de" | "ja";
+export type Lang = "en" | "zh-CN" | "de" | "ja" | "ru";
 
-const SUPPORTED_LANGS: readonly Lang[] = ["en", "zh-CN", "de", "ja"];
+const SUPPORTED_LANGS: readonly Lang[] = ["en", "zh-CN", "de", "ja", "ru"];
 const SUPPORTED: ReadonlySet<Lang> = new Set<Lang>(SUPPORTED_LANGS);
 const LANG_LABELS: Record<Lang, string> = {
   en: "English",
   "zh-CN": "简体中文",
   de: "Deutsch",
   ja: "日本語",
+  ru: "Русский",
 };
 const STORAGE_KEY = "reasonix.lang";
 
@@ -31,6 +33,7 @@ function detectDefault(): Lang {
   if (lower.startsWith("zh")) return "zh-CN";
   if (lower.startsWith("de")) return "de";
   if (lower.startsWith("ja")) return "ja";
+  if (lower.startsWith("ru")) return "ru";
   return "en";
 }
 
@@ -84,7 +87,7 @@ export function useLang(): Lang {
   return currentLang;
 }
 
-const dicts = { en, "zh-CN": zhCN, de, ja } as const;
+const dicts = { en, "zh-CN": zhCN, de, ja, ru } as const;
 
 type Dict = typeof en;
 type Path<T, K extends keyof T = keyof T> = K extends string

--- a/dashboard/src/i18n/ru.ts
+++ b/dashboard/src/i18n/ru.ts
@@ -1,0 +1,5 @@
+import { en } from "./en";
+
+export const ru: typeof en = {
+  ...en,
+};

--- a/desktop/src/i18n/index.ts
+++ b/desktop/src/i18n/index.ts
@@ -2,17 +2,19 @@ import { useEffect, useState } from "react";
 import { de } from "./de";
 import { en } from "./en";
 import { ja } from "./ja";
+import { ru } from "./ru";
 import { zhCN } from "./zh-CN";
 
-export type Lang = "en" | "zh-CN" | "de" | "ja";
+export type Lang = "en" | "zh-CN" | "de" | "ja" | "ru";
 
-const SUPPORTED_LANGS: readonly Lang[] = ["en", "zh-CN", "de", "ja"];
+const SUPPORTED_LANGS: readonly Lang[] = ["en", "zh-CN", "de", "ja", "ru"];
 const SUPPORTED: ReadonlySet<Lang> = new Set<Lang>(SUPPORTED_LANGS);
 const LANG_LABELS: Record<Lang, string> = {
   en: "English",
   "zh-CN": "简体中文",
   de: "Deutsch",
   ja: "日本語",
+  ru: "Русский",
 };
 const STORAGE_KEY = "reasonix.lang";
 
@@ -31,6 +33,7 @@ function detectDefault(): Lang {
   if (lower.startsWith("zh")) return "zh-CN";
   if (lower.startsWith("de")) return "de";
   if (lower.startsWith("ja")) return "ja";
+  if (lower.startsWith("ru")) return "ru";
   return "en";
 }
 
@@ -84,7 +87,7 @@ export function useLang(): Lang {
   return currentLang;
 }
 
-const dicts = { en, "zh-CN": zhCN, de, ja } as const;
+const dicts = { en, "zh-CN": zhCN, de, ja, ru } as const;
 
 type Dict = typeof en;
 type Path<T, K extends keyof T = keyof T> = K extends string

--- a/desktop/src/i18n/ru.ts
+++ b/desktop/src/i18n/ru.ts
@@ -1,0 +1,5 @@
+import { en } from "./en";
+
+export const ru: typeof en = {
+  ...en,
+};


### PR DESCRIPTION
## Summary
- Add Russian (`ru`) locale support to both desktop and dashboard layers
- Create `ru.ts` files using the spread-fallback pattern — all keys fall back to English until translations are contributed
- Register `"ru"` in the language system: type, supported list, labels ("Русский"), dictionary map, and auto-detection for `navigator.language` starting with "ru"

## Why
Russian is a widely spoken language with a strong developer community. Adding the locale skeleton lets users switch to Russian immediately (seeing English fallbacks) and enables incremental translation contributions.

## Test plan
- [ ] Switch language to "Русский" in desktop settings — UI should display English fallback strings (no `undefined`)
- [ ] Switch language to "Русский" in dashboard settings — same behavior
- [ ] Browser with `ru` or `ru-RU` locale should auto-detect Russian on first visit

🤖 Generated with [Claude Code](https://claude.com/claude-code)