### PR TITLE
fix(server): convert API layer sync fs I/O to async

### DIFF
--- a/src/server/api/browse.ts
+++ b/src/server/api/browse.ts
@@ -1,5 +1,8 @@
-import { execSync } from "node:child_process";
-import { existsSync, readdirSync, statSync } from "node:fs";
+import { exec } from "node:child_process";
+import { readdir, stat } from "node:fs/promises";
+import { promisify } from "node:util";
+
+const execAsync = promisify(exec);
 import { homedir } from "node:os";
 import { dirname, isAbsolute, resolve } from "node:path";
 import type { ApiResult } from "../router.js";
@@ -37,19 +40,25 @@ const SKIP_DIRS = new Set([
 
 let cachedDriveList: string[] | null = null;
 
-function listWindowsDrives(): string[] {
+async function listWindowsDrives(): Promise<string[]> {
   if (cachedDriveList) return cachedDriveList;
   try {
-    const raw = execSync("wmic logicaldisk get deviceid /value", {
-      encoding: "utf8",
+    const { stdout } = await execAsync("wmic logicaldisk get deviceid /value", {
       timeout: 1500,
     });
-    const drives = raw
-      .split(/\r?\n/)
-      .map((l) => l.trim())
-      .filter((l) => l.startsWith("DeviceID="))
-      .map((l) => `${l.slice("DeviceID=".length)}\\`)
-      .filter((d) => existsSync(d));
+    const drives: string[] = [];
+    for (const line of stdout.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (trimmed.startsWith("DeviceID=")) {
+        const drive = `${trimmed.slice("DeviceID=".length)}\\`;
+        try {
+          await stat(drive);
+          drives.push(drive);
+        } catch {
+          /* skip */
+        }
+      }
+    }
     cachedDriveList = drives.length > 0 ? drives : ["C:\\"];
   } catch {
     // wmic absent (newer Windows builds drop it) — fall back to probing letters.
@@ -57,7 +66,8 @@ function listWindowsDrives(): string[] {
     for (const letter of "CDEFGHIJKLMNOPQRSTUVWXYZ") {
       const p = `${letter}:\\`;
       try {
-        if (existsSync(p)) found.push(p);
+        await stat(p);
+        found.push(p);
       } catch {
         /* skip unreachable drives without blocking */
       }
@@ -79,21 +89,20 @@ function defaultRoot(): string {
   }
 }
 
-function readSubdirs(path: string): BrowseEntry[] {
+async function readSubdirs(path: string): Promise<BrowseEntry[]> {
   let names: string[];
   try {
-    names = readdirSync(path);
+    names = await readdir(path);
   } catch {
     return [];
   }
   const out: BrowseEntry[] = [];
   for (const name of names) {
     if (SKIP_DIRS.has(name)) continue;
-    // Hide dotfile dirs but keep them reachable by typing the path manually.
     if (name.startsWith(".") && name.length > 1) continue;
     const full = resolve(path, name);
     try {
-      if (!statSync(full).isDirectory()) continue;
+      if (!(await stat(full)).isDirectory()) continue;
     } catch {
       continue;
     }
@@ -118,9 +127,9 @@ export async function handleBrowse(
   // so the user can navigate off the home drive without typing the letter.
   if (!rawPath) {
     const home = defaultRoot();
-    const entries = readSubdirs(home);
+    const entries = await readSubdirs(home);
     if (isWin) {
-      const drives = listWindowsDrives()
+      const drives = (await listWindowsDrives())
         .filter((d) => resolve(d) !== resolve(home))
         .map((d) => ({ name: d, full: d }));
       entries.unshift(...drives);
@@ -133,14 +142,11 @@ export async function handleBrowse(
     return { status: 400, body: { error: "path must be absolute" } };
   }
   const absolute = resolve(rawPath);
-  if (!existsSync(absolute)) {
-    return { status: 404, body: { error: `no such directory: ${absolute}` } };
-  }
   let isDir = false;
   try {
-    isDir = statSync(absolute).isDirectory();
+    isDir = (await stat(absolute)).isDirectory();
   } catch {
-    /* falls through to 404-equivalent */
+    return { status: 404, body: { error: `no such directory: ${absolute}` } };
   }
   if (!isDir) {
     return { status: 400, body: { error: `not a directory: ${absolute}` } };
@@ -152,7 +158,7 @@ export async function handleBrowse(
   const result: BrowseResult = {
     path: absolute,
     parent,
-    entries: readSubdirs(absolute),
+    entries: await readSubdirs(absolute),
   };
   return { status: 200, body: result };
 }

--- a/src/server/api/checkpoint-diffs.ts
+++ b/src/server/api/checkpoint-diffs.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { loadCheckpoint } from "../../code/checkpoints.js";
 import { lineDiff } from "../../tools/fs/edit.js";
@@ -37,7 +37,7 @@ export async function handleCheckpointDiffs(
     const absPath = resolve(rootDir, snap.path);
     let currentContent: string | null = null;
     try {
-      currentContent = readFileSync(absPath, "utf8");
+      currentContent = await readFile(absPath, "utf8");
     } catch {
       currentContent = null;
     }

--- a/src/server/api/health.ts
+++ b/src/server/api/health.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, statSync } from "node:fs";
+import { readdir, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { listSessions } from "../../memory/session.js";
@@ -14,44 +14,43 @@ interface DirStat {
 }
 
 /** Sum file sizes one level deep. Recursion deferred until we have a use-case for nested data dirs. */
-function dirSize(path: string): DirStat {
-  if (!existsSync(path)) return { path, exists: false, fileCount: 0, totalBytes: 0 };
+async function dirSize(path: string): Promise<DirStat> {
   let fileCount = 0;
   let totalBytes = 0;
+  let entries: string[];
   try {
-    const entries = readdirSync(path);
-    for (const name of entries) {
-      const full = join(path, name);
-      try {
-        const s = statSync(full);
-        if (s.isFile()) {
-          fileCount++;
-          totalBytes += s.size;
-        } else if (s.isDirectory()) {
-          // Recurse one level for nested folders (memory/<hash>, sessions/, etc).
-          try {
-            const inner = readdirSync(full);
-            for (const child of inner) {
-              try {
-                const cs = statSync(join(full, child));
-                if (cs.isFile()) {
-                  fileCount++;
-                  totalBytes += cs.size;
-                }
-              } catch {
-                /* skip */
-              }
-            }
-          } catch {
-            /* skip */
-          }
-        }
-      } catch {
-        /* skip — file might have been deleted between readdir + stat */
-      }
-    }
+    entries = await readdir(path);
   } catch {
-    return { path, exists: true, fileCount: 0, totalBytes: 0 };
+    return { path, exists: false, fileCount: 0, totalBytes: 0 };
+  }
+  for (const name of entries) {
+    const full = join(path, name);
+    try {
+      const s = await stat(full);
+      if (s.isFile()) {
+        fileCount++;
+        totalBytes += s.size;
+      } else if (s.isDirectory()) {
+        try {
+          const inner = await readdir(full);
+          for (const child of inner) {
+            try {
+              const cs = await stat(join(full, child));
+              if (cs.isFile()) {
+                fileCount++;
+                totalBytes += cs.size;
+              }
+            } catch {
+              /* skip */
+            }
+          }
+        } catch {
+          /* skip */
+        }
+      }
+    } catch {
+      /* skip — file might have been deleted between readdir + stat */
+    }
   }
   return { path, exists: true, fileCount, totalBytes };
 }
@@ -68,17 +67,17 @@ export async function handleHealth(
   const home = homedir();
   const reasonixHome = join(home, ".reasonix");
 
-  const sessionsStat = dirSize(join(reasonixHome, "sessions"));
-  const memoryStat = dirSize(join(reasonixHome, "memory"));
-  const semanticStat = dirSize(join(reasonixHome, "semantic"));
+  const [sessionsStat, memoryStat, semanticStat] = await Promise.all([
+    dirSize(join(reasonixHome, "sessions")),
+    dirSize(join(reasonixHome, "memory")),
+    dirSize(join(reasonixHome, "semantic")),
+  ]);
 
   let usageBytes = 0;
-  if (existsSync(ctx.usageLogPath)) {
-    try {
-      usageBytes = statSync(ctx.usageLogPath).size;
-    } catch {
-      /* ignore */
-    }
+  try {
+    usageBytes = (await stat(ctx.usageLogPath)).size;
+  } catch {
+    /* ignore */
   }
 
   const sessions = listSessions();

--- a/src/server/api/hooks.ts
+++ b/src/server/api/hooks.ts
@@ -1,6 +1,6 @@
 /** Reload is a separate POST so save and apply stay decoupled; the SPA chains them by convention. */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { trustProjectHooks } from "../../config.js";
 import { HOOK_EVENTS, globalSettingsPath, loadHooks, projectSettingsPath } from "../../hooks.js";
@@ -23,10 +23,9 @@ function parseBody(raw: string): SaveBody {
   }
 }
 
-function readSettingsFile(path: string): { hooks?: Record<string, unknown[]> } {
-  if (!existsSync(path)) return {};
+async function readSettingsFile(path: string): Promise<{ hooks?: Record<string, unknown[]> }> {
   try {
-    const raw = readFileSync(path, "utf8");
+    const raw = await readFile(path, "utf8");
     const parsed = JSON.parse(raw);
     return typeof parsed === "object" && parsed !== null ? parsed : {};
   } catch {
@@ -34,12 +33,12 @@ function readSettingsFile(path: string): { hooks?: Record<string, unknown[]> } {
   }
 }
 
-function writeSettingsFile(path: string, hooksBlock: unknown): void {
+async function writeSettingsFile(path: string, hooksBlock: unknown): Promise<void> {
   // Preserve any other top-level keys that may live in the file.
-  const existing = readSettingsFile(path);
+  const existing = await readSettingsFile(path);
   existing.hooks = hooksBlock as Record<string, unknown[]>;
-  mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, `${JSON.stringify(existing, null, 2)}\n`, "utf8");
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${JSON.stringify(existing, null, 2)}\n`, "utf8");
 }
 
 export async function handleHooks(
@@ -51,8 +50,8 @@ export async function handleHooks(
   if (method === "GET" && rest.length === 0) {
     const projectPath = ctx.getCurrentCwd ? projectSettingsPath(ctx.getCurrentCwd() ?? "") : null;
     const globalPath = globalSettingsPath();
-    const projectFile = projectPath ? readSettingsFile(projectPath) : {};
-    const globalFile = readSettingsFile(globalPath);
+    const projectFile = projectPath ? await readSettingsFile(projectPath) : {};
+    const globalFile = await readSettingsFile(globalPath);
     const resolved = loadHooks({ projectRoot: ctx.getCurrentCwd?.() });
     return {
       status: 200,
@@ -97,7 +96,7 @@ export async function handleHooks(
     if (!path) {
       return { status: 500, body: { error: "could not resolve settings path" } };
     }
-    writeSettingsFile(path, hooks);
+    await writeSettingsFile(path, hooks);
     ctx.audit?.({ ts: Date.now(), action: "save-hooks", payload: { scope, path } });
     return { status: 200, body: { saved: true, path } };
   }

--- a/src/server/api/memory.ts
+++ b/src/server/api/memory.ts
@@ -1,15 +1,7 @@
 /** Names sanitized via SAFE_NAME on every write — guards against path traversal. */
 
 import { createHash } from "node:crypto";
-import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  readdirSync,
-  statSync,
-  unlinkSync,
-  writeFileSync,
-} from "node:fs";
+import { mkdir, readFile, readdir, stat, unlink, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, dirname, join, resolve as resolvePath } from "node:path";
 import {
@@ -52,20 +44,21 @@ function parseBody(raw: string): WriteBody {
 
 const SAFE_NAME = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$/;
 
-function listMemoryFiles(dir: string): Array<{ name: string; size: number; mtime: number }> {
-  if (!existsSync(dir)) return [];
+async function listMemoryFiles(dir: string): Promise<Array<{ name: string; size: number; mtime: number }>> {
   try {
-    return readdirSync(dir)
-      .filter((f) => f.endsWith(".md"))
-      .map((f) => {
-        const stat = statSync(join(dir, f));
+    const entries = await readdir(dir);
+    const mdFiles = entries.filter((f) => f.endsWith(".md"));
+    const results = await Promise.all(
+      mdFiles.map(async (f) => {
+        const s = await stat(join(dir, f));
         return {
           name: f.replace(/\.md$/, ""),
-          size: stat.size,
-          mtime: stat.mtime.getTime(),
+          size: s.size,
+          mtime: s.mtime.getTime(),
         };
-      })
-      .sort((a, b) => b.mtime - a.mtime);
+      }),
+    );
+    return results.sort((a, b) => b.mtime - a.mtime);
   } catch {
     return [];
   }
@@ -119,11 +112,11 @@ export async function handleMemory(
         },
         global: {
           path: globalDir,
-          files: listMemoryFiles(globalDir),
+          files: await listMemoryFiles(globalDir),
         },
         projectMem: {
           path: projectMemDir,
-          files: projectMemDir ? listMemoryFiles(projectMemDir) : [],
+          files: projectMemDir ? await listMemoryFiles(projectMemDir) : [],
         },
       },
     };
@@ -138,14 +131,17 @@ export async function handleMemory(
       if (!cwd) return { status: 503, body: { error: "no active project" } };
       const path = findProjectMemoryPath(cwd);
       if (!path) return { status: 404, body: { error: "project memory file not found" } };
-      return { status: 200, body: { path, body: readFileSync(path, "utf8") } };
+      return { status: 200, body: { path, body: await readFile(path, "utf8") } };
     }
     if ((scope === "global" || scope === "project-mem") && name && SAFE_NAME.test(name)) {
       const dir = scope === "global" ? globalDir : projectMemDir;
       if (!dir) return { status: 503, body: { error: "no project root for project-mem" } };
       const path = join(dir, `${name}.md`);
-      if (!existsSync(path)) return { status: 404, body: { error: "not found" } };
-      return { status: 200, body: { path, body: readFileSync(path, "utf8") } };
+      try {
+        return { status: 200, body: { path, body: await readFile(path, "utf8") } };
+      } catch {
+        return { status: 404, body: { error: "not found" } };
+      }
     }
     return { status: 400, body: { error: "bad scope or name" } };
   }
@@ -158,17 +154,17 @@ export async function handleMemory(
     if (scope === "project") {
       if (!cwd) return { status: 503, body: { error: "no active project" } };
       const path = resolveProjectMemoryWritePath(cwd);
-      mkdirSync(dirname(path), { recursive: true });
-      writeFileSync(path, contents, "utf8");
+      await mkdir(dirname(path), { recursive: true });
+      await writeFile(path, contents, "utf8");
       ctx.audit?.({ ts: Date.now(), action: "save-memory", payload: { scope, path } });
       return { status: 200, body: { saved: true, path } };
     }
     if ((scope === "global" || scope === "project-mem") && name && SAFE_NAME.test(name)) {
       const dir = scope === "global" ? globalDir : projectMemDir;
       if (!dir) return { status: 503, body: { error: "no project root for project-mem" } };
-      mkdirSync(dir, { recursive: true });
+      await mkdir(dir, { recursive: true });
       const path = join(dir, `${name}.md`);
-      writeFileSync(path, contents, "utf8");
+      await writeFile(path, contents, "utf8");
       ctx.audit?.({ ts: Date.now(), action: "save-memory", payload: { scope, name, path } });
       return { status: 200, body: { saved: true, path } };
     }
@@ -180,18 +176,19 @@ export async function handleMemory(
       const dir = scope === "global" ? globalDir : projectMemDir;
       if (!dir) return { status: 503, body: { error: "no project root for project-mem" } };
       const path = join(dir, `${name}.md`);
-      if (existsSync(path)) {
-        unlinkSync(path);
+      try {
+        await unlink(path);
         ctx.audit?.({ ts: Date.now(), action: "delete-memory", payload: { scope, name, path } });
         return { status: 200, body: { deleted: true } };
+      } catch {
+        return { status: 404, body: { error: "not found" } };
       }
-      return { status: 404, body: { error: "not found" } };
     }
     if (scope === "project") {
       if (!cwd) return { status: 503, body: { error: "no active project" } };
       const path = findProjectMemoryPath(cwd);
       if (path) {
-        unlinkSync(path);
+        await unlink(path);
         ctx.audit?.({ ts: Date.now(), action: "delete-memory", payload: { scope, path } });
         return { status: 200, body: { deleted: true } };
       }

--- a/src/server/api/project-tree.ts
+++ b/src/server/api/project-tree.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, statSync } from "node:fs";
+import { readdir, stat } from "node:fs/promises";
 import { extname, join, relative, sep } from "node:path";
 import type { DashboardContext } from "../context.js";
 import type { ApiResult } from "../router.js";
@@ -51,18 +51,23 @@ export async function handleProjectTree(
 ): Promise<ApiResult> {
   if (method !== "GET") return { status: 405, body: { error: "GET only" } };
   const cwd = ctx.getCurrentCwd?.();
-  if (!cwd || !existsSync(cwd)) {
+  if (!cwd) {
     return { status: 503, body: { error: "no project directory available" } };
   }
-  const tree = buildTree(cwd, cwd, 0);
+  try {
+    await stat(cwd);
+  } catch {
+    return { status: 503, body: { error: "no project directory available" } };
+  }
+  const tree = await buildTree(cwd, cwd, 0);
   return { status: 200, body: { tree } };
 }
 
-function buildTree(root: string, dirPath: string, depth: number): TreeNode[] {
+async function buildTree(root: string, dirPath: string, depth: number): Promise<TreeNode[]> {
   if (depth > MAX_DEPTH) return [];
   let names: string[];
   try {
-    names = readdirSync(dirPath);
+    names = await readdir(dirPath);
   } catch {
     return [];
   }
@@ -72,9 +77,9 @@ function buildTree(root: string, dirPath: string, depth: number): TreeNode[] {
   for (const name of names) {
     if (SKIP_DIRS.has(name)) continue;
     const full = join(dirPath, name);
-    let st: ReturnType<typeof statSync>;
+    let st;
     try {
-      st = statSync(full);
+      st = await stat(full);
     } catch {
       continue;
     }
@@ -89,7 +94,7 @@ function buildTree(root: string, dirPath: string, depth: number): TreeNode[] {
   for (const name of dirs) {
     const full = join(dirPath, name);
     const rel = relative(root, full).split(sep).join("/");
-    const children = buildTree(root, full, depth + 1);
+    const children = await buildTree(root, full, depth + 1);
     nodes.push({ name, path: rel, isDir: true, children });
   }
   for (const name of files) {
@@ -111,7 +116,12 @@ export async function handleFiles(
   }
   if (method !== "POST") return { status: 405, body: { error: "GET or POST only" } };
   const cwd = ctx.getCurrentCwd?.();
-  if (!cwd || !existsSync(cwd)) {
+  if (!cwd) {
+    return { status: 503, body: { error: "@-mention picker requires a code-mode session" } };
+  }
+  try {
+    await stat(cwd);
+  } catch {
     return { status: 503, body: { error: "@-mention picker requires a code-mode session" } };
   }
   let parsed: { prefix?: unknown };
@@ -121,11 +131,11 @@ export async function handleFiles(
     return { status: 400, body: { error: "body must be JSON" } };
   }
   const prefix = typeof parsed.prefix === "string" ? parsed.prefix.trim().toLowerCase() : "";
-  const matches = walk(cwd, prefix);
+  const matches = await walk(cwd, prefix);
   return { status: 200, body: { files: matches } };
 }
 
-function walk(root: string, prefix: string): string[] {
+async function walk(root: string, prefix: string): Promise<string[]> {
   const out: string[] = [];
   const stack: Array<{ path: string; depth: number }> = [{ path: root, depth: 0 }];
   while (stack.length > 0 && out.length < RESULT_CAP) {
@@ -133,7 +143,7 @@ function walk(root: string, prefix: string): string[] {
     if (depth > MAX_DEPTH) continue;
     let names: string[];
     try {
-      names = readdirSync(path);
+      names = await readdir(path);
     } catch {
       continue;
     }
@@ -141,9 +151,9 @@ function walk(root: string, prefix: string): string[] {
       if (out.length >= RESULT_CAP) break;
       if (SKIP_DIRS.has(name)) continue;
       const full = join(path, name);
-      let st: ReturnType<typeof statSync>;
+      let st;
       try {
-        st = statSync(full);
+        st = await stat(full);
       } catch {
         continue;
       }

--- a/src/server/api/skills.ts
+++ b/src/server/api/skills.ts
@@ -1,18 +1,6 @@
 /** `/api/skills` — edits files only; loop reloads on /new or restart. `builtin` scope is read-only. */
 
-import {
-  closeSync,
-  existsSync,
-  fstatSync,
-  mkdirSync,
-  openSync,
-  readFileSync,
-  readSync,
-  readdirSync,
-  rmSync,
-  statSync,
-  writeFileSync,
-} from "node:fs";
+import { mkdir, open, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { loadResolvedSkillPaths, loadSubagentModels } from "../../config.js";
@@ -67,56 +55,43 @@ function parseFrontmatterDescription(raw: string): string | undefined {
   return desc ? desc : undefined;
 }
 
-function readSkillListEntry(
+async function readSkillListEntry(
   skillPath: string,
   name: string,
   scope: "project" | "custom" | "global",
-): SkillListEntry | null {
+): Promise<SkillListEntry | null> {
+  const fd = await open(skillPath, "r");
   try {
-    // Open once and reuse the fd so size/mtime/content all bind to
-    // the same inode — closes the exists→stat→read TOCTOU races.
-    const fd = openSync(skillPath, "r");
-    let stat: ReturnType<typeof fstatSync>;
-    let raw: string;
-    try {
-      stat = fstatSync(fd);
-      if (!stat.isFile()) return null;
-      const buf = Buffer.alloc(stat.size);
-      let read = 0;
-      while (read < stat.size) {
-        const n = readSync(fd, buf, read, stat.size - read, read);
-        if (n <= 0) break;
-        read += n;
-      }
-      raw = buf.toString("utf8", 0, read);
-    } finally {
-      closeSync(fd);
-    }
+    const st = await fd.stat();
+    if (!st.isFile()) return null;
+    const raw = await readFile(fd, "utf8");
     const item: SkillListEntry = {
       name,
       scope,
       path: skillPath,
-      size: stat.size,
-      mtime: stat.mtime.getTime(),
+      size: st.size,
+      mtime: st.mtime.getTime(),
     };
     const desc = parseFrontmatterDescription(raw);
     if (desc) item.description = desc;
     return item;
   } catch {
     return null;
+  } finally {
+    await fd.close();
   }
 }
 
-function resolveSkillPath(dir: string, name: string): ResolvedSkillPath | null {
+async function resolveSkillPath(dir: string, name: string): Promise<ResolvedSkillPath | null> {
   const folderPath = join(dir, name, SKILL_FILE);
   try {
-    if (statSync(folderPath).isFile()) return { path: folderPath, layout: "folder" };
+    if ((await stat(folderPath)).isFile()) return { path: folderPath, layout: "folder" };
   } catch {
     /* try flat layout below */
   }
   const flatPath = join(dir, `${name}.md`);
   try {
-    if (statSync(flatPath).isFile()) return { path: flatPath, layout: "flat" };
+    if ((await stat(flatPath)).isFile()) return { path: flatPath, layout: "flat" };
   } catch {
     /* not found */
   }
@@ -127,29 +102,30 @@ function defaultSkillPath(dir: string, name: string): ResolvedSkillPath {
   return { path: join(dir, name, SKILL_FILE), layout: "folder" };
 }
 
-function listSkills(dir: string, scope: "project" | "custom" | "global"): SkillListEntry[] {
-  if (!existsSync(dir)) return [];
+async function listSkills(dir: string, scope: "project" | "custom" | "global"): Promise<SkillListEntry[]> {
   const out: SkillListEntry[] = [];
+  let entries;
   try {
-    for (const entry of readdirSync(dir, { withFileTypes: true })) {
-      let name: string;
-      let skillPath: string;
-      if (entry.isDirectory()) {
-        name = entry.name;
-        if (!SAFE_NAME.test(name)) continue;
-        skillPath = join(dir, name, SKILL_FILE);
-      } else if (entry.isFile() && entry.name.endsWith(".md")) {
-        name = entry.name.slice(0, -3);
-        if (!SAFE_NAME.test(name)) continue;
-        skillPath = join(dir, entry.name);
-      } else {
-        continue;
-      }
-      const item = readSkillListEntry(skillPath, name, scope);
-      if (item) out.push(item);
-    }
+    entries = await readdir(dir, { withFileTypes: true });
   } catch {
-    /* skip unreadable dir */
+    return [];
+  }
+  for (const entry of entries) {
+    let name: string;
+    let skillPath: string;
+    if (entry.isDirectory()) {
+      name = entry.name;
+      if (!SAFE_NAME.test(name)) continue;
+      skillPath = join(dir, name, SKILL_FILE);
+    } else if (entry.isFile() && entry.name.endsWith(".md")) {
+      name = entry.name.slice(0, -3);
+      if (!SAFE_NAME.test(name)) continue;
+      skillPath = join(dir, entry.name);
+    } else {
+      continue;
+    }
+    const item = await readSkillListEntry(skillPath, name, scope);
+    if (item) out.push(item);
   }
   return out.sort((a, b) => a.name.localeCompare(b.name));
 }
@@ -187,9 +163,9 @@ export async function handleSkills(
     return {
       status: 200,
       body: {
-        global: tag(listSkills(globalSkillsDir(), "global")),
-        custom: tag(customRoots.flatMap((root) => listSkills(root.dir, "custom"))),
-        project: cwd ? tag(listSkills(projectSkillsDir(cwd), "project")) : [],
+        global: tag(await listSkills(globalSkillsDir(), "global")),
+        custom: tag((await Promise.all(customRoots.map((root) => listSkills(root.dir, "custom")))).flat()),
+        project: cwd ? tag(await listSkills(projectSkillsDir(cwd), "project")) : [],
         builtin: [
           {
             name: "explore",
@@ -237,13 +213,13 @@ export async function handleSkills(
   } else {
     dir = globalSkillsDir();
   }
-  const resolved = resolveSkillPath(dir, name);
+  const resolved = await resolveSkillPath(dir, name);
 
   if (method === "GET") {
     if (!resolved) return { status: 404, body: { error: "skill not found" } };
     return {
       status: 200,
-      body: { path: resolved.path, body: readFileSync(resolved.path, "utf8") },
+      body: { path: resolved.path, body: await readFile(resolved.path, "utf8") },
     };
   }
 
@@ -257,8 +233,8 @@ export async function handleSkills(
       return { status: 400, body: { error: fm.error } };
     }
     const target = resolved ?? defaultSkillPath(dir, name);
-    mkdirSync(dirname(target.path), { recursive: true });
-    writeFileSync(target.path, contents, "utf8");
+    await mkdir(dirname(target.path), { recursive: true });
+    await writeFile(target.path, contents, "utf8");
     ctx.audit?.({
       ts: Date.now(),
       action: "save-skill",
@@ -270,7 +246,7 @@ export async function handleSkills(
   if (method === "DELETE") {
     if (!resolved) return { status: 404, body: { error: "skill not found" } };
     // Folder-layout skills may carry assets next to SKILL.md; flat skills are single-file entries.
-    rmSync(resolved.layout === "folder" ? dirname(resolved.path) : resolved.path, {
+    await rm(resolved.layout === "folder" ? dirname(resolved.path) : resolved.path, {
       recursive: true,
       force: true,
     });

--- a/src/server/assets.ts
+++ b/src/server/assets.ts
@@ -1,4 +1,5 @@
-import { closeSync, fstatSync, openSync, readFileSync, readSync } from "node:fs";
+import { readFileSync } from "node:fs";
+import { open, readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -35,48 +36,35 @@ const textCache = new Map<string, { body: string; mtimeMs: number }>();
 /** mtime-keyed cache for binary files (fonts, images). */
 const binaryCache = new Map<string, { body: Buffer; mtimeMs: number }>();
 
-function loadCachedText(path: string): string {
-  const fd = openSync(path, "r");
+async function loadCachedText(path: string): Promise<string> {
+  const fd = await open(path, "r");
   try {
-    const stat = fstatSync(fd);
+    const st = await fd.stat();
     const cached = textCache.get(path);
-    if (cached && cached.mtimeMs === stat.mtimeMs) return cached.body;
-    const buf = Buffer.alloc(stat.size);
-    let read = 0;
-    while (read < stat.size) {
-      const n = readSync(fd, buf, read, stat.size - read, read);
-      if (n <= 0) break;
-      read += n;
-    }
-    const body = buf.toString("utf8", 0, read);
-    textCache.set(path, { body, mtimeMs: stat.mtimeMs });
+    if (cached && cached.mtimeMs === st.mtimeMs) return cached.body;
+    const body = await readFile(fd, "utf8");
+    textCache.set(path, { body, mtimeMs: st.mtimeMs });
     return body;
   } finally {
-    closeSync(fd);
+    await fd.close();
   }
 }
 
-function loadCachedBinary(path: string): Buffer {
-  const fd = openSync(path, "r");
+async function loadCachedBinary(path: string): Promise<Buffer> {
+  const fd = await open(path, "r");
   try {
-    const stat = fstatSync(fd);
+    const st = await fd.stat();
     const cached = binaryCache.get(path);
-    if (cached && cached.mtimeMs === stat.mtimeMs) return cached.body;
-    const buf = Buffer.alloc(stat.size);
-    let read = 0;
-    while (read < stat.size) {
-      const n = readSync(fd, buf, read, stat.size - read, read);
-      if (n <= 0) break;
-      read += n;
-    }
-    binaryCache.set(path, { body: buf.slice(0, read), mtimeMs: stat.mtimeMs });
-    return buf.slice(0, read);
+    if (cached && cached.mtimeMs === st.mtimeMs) return cached.body;
+    const body = await readFile(fd);
+    binaryCache.set(path, { body, mtimeMs: st.mtimeMs });
+    return body;
   } finally {
-    closeSync(fd);
+    await fd.close();
   }
 }
 
-function loadIndexTemplate(): string {
+async function loadIndexTemplate(): Promise<string> {
   return loadCachedText(join(ASSET_DIR, "index.html"));
 }
 
@@ -96,21 +84,21 @@ function injectTokenIntoCssAssetUrls(body: string, token: string): string {
   );
 }
 
-function loadApp(token: string): string {
-  const raw = loadCachedText(join(ASSET_DIR, "dist", "app.js"));
+async function loadApp(token: string): Promise<string> {
+  const raw = await loadCachedText(join(ASSET_DIR, "dist", "app.js"));
   return injectTokenIntoChunkImports(raw, token);
 }
 
-function loadChunk(name: string, token: string): string | null {
+async function loadChunk(name: string, token: string): Promise<string | null> {
   try {
-    const raw = loadCachedText(join(ASSET_DIR, "dist", name));
+    const raw = await loadCachedText(join(ASSET_DIR, "dist", name));
     return injectTokenIntoChunkImports(raw, token);
   } catch {
     return null;
   }
 }
 
-function loadAppMap(): string | null {
+async function loadAppMap(): Promise<string | null> {
   try {
     return loadCachedText(join(ASSET_DIR, "dist", "app.js.map"));
   } catch {
@@ -118,20 +106,19 @@ function loadAppMap(): string | null {
   }
 }
 
-function loadCss(token: string): string {
-  // Try new React dashboard first, then fall back to old Preact
+async function loadCss(token: string): Promise<string> {
   let raw: string;
   try {
-    raw = loadCachedText(join(ASSET_DIR, "dist", "app.css"));
+    raw = await loadCachedText(join(ASSET_DIR, "dist", "app.css"));
   } catch {
-    raw = loadCachedText(join(ASSET_DIR, "app.css"));
+    raw = await loadCachedText(join(ASSET_DIR, "app.css"));
   }
   return injectTokenIntoCssAssetUrls(raw, token);
 }
 
 /** Token HTML-attribute-escaped in case a future mint produces non-hex bytes. */
-export function renderIndexHtml(token: string, mode: "standalone" | "attached"): string {
-  const tpl = loadIndexTemplate();
+export async function renderIndexHtml(token: string, mode: "standalone" | "attached"): Promise<string> {
+  const tpl = await loadIndexTemplate();
   const safeToken = token.replace(/[^a-zA-Z0-9]/g, "");
   // String.replace(string, replacement) only swaps the FIRST match. The
   // template has __REASONIX_TOKEN__ in three places (meta + css href +
@@ -145,9 +132,9 @@ export function renderIndexHtml(token: string, mode: "standalone" | "attached"):
 /** Vendor CSS the bundle pulls from npm and the build script copies into `dashboard/dist/`. */
 const VENDOR_CSS_NAMES = new Set(["vendor-hljs.css", "vendor-uplot.css"]);
 
-function loadVendorCss(name: string, token: string): string | null {
+async function loadVendorCss(name: string, token: string): Promise<string | null> {
   try {
-    return injectTokenIntoCssAssetUrls(loadCachedText(join(ASSET_DIR, "dist", name)), token);
+    return injectTokenIntoCssAssetUrls(await loadCachedText(join(ASSET_DIR, "dist", name)), token);
   } catch {
     return null;
   }
@@ -184,13 +171,13 @@ function isBinaryAsset(name: string): boolean {
   return false;
 }
 
-function loadDistFile(name: string): { body: string | Buffer; isBinary: boolean } | null {
+async function loadDistFile(name: string): Promise<{ body: string | Buffer; isBinary: boolean } | null> {
   const paths = [join(ASSET_DIR, "dist", "assets", name), join(ASSET_DIR, "dist", name)];
   const binary = isBinaryAsset(name);
   for (const p of paths) {
     try {
       return {
-        body: binary ? loadCachedBinary(p) : loadCachedText(p),
+        body: binary ? await loadCachedBinary(p) : await loadCachedText(p),
         isBinary: binary,
       };
     } catch {
@@ -200,35 +187,33 @@ function loadDistFile(name: string): { body: string | Buffer; isBinary: boolean 
   return null;
 }
 
-export function serveAsset(
+export async function serveAsset(
   name: string,
   token = "",
-): { body: string | Buffer; contentType: string } | null {
+): Promise<{ body: string | Buffer; contentType: string } | null> {
   if (name === "app.js") {
-    return { body: loadApp(token), contentType: "application/javascript; charset=utf-8" };
+    return { body: await loadApp(token), contentType: "application/javascript; charset=utf-8" };
   }
   if (name === "app.js.map") {
-    const body = loadAppMap();
+    const body = await loadAppMap();
     return body == null ? null : { body, contentType: "application/json; charset=utf-8" };
   }
   if (name === "app.css") {
-    return { body: loadCss(token), contentType: "text/css; charset=utf-8" };
+    return { body: await loadCss(token), contentType: "text/css; charset=utf-8" };
   }
-  // Same rewrite for chunk-to-chunk imports (e.g. vendor-markdown → vendor-react).
   if (/^vendor-[\w.-]+\.js$/.test(name)) {
-    const body = loadChunk(name, token);
+    const body = await loadChunk(name, token);
     if (body == null) return null;
     return { body, contentType: "application/javascript; charset=utf-8" };
   }
   if (VENDOR_CSS_NAMES.has(name)) {
-    const body = loadVendorCss(name, token);
+    const body = await loadVendorCss(name, token);
     if (body == null) return null;
     return { body, contentType: "text/css; charset=utf-8" };
   }
-  // 通用静态文件：字体、图片等
   const mt = mimetypeFor(name);
   if (mt) {
-    const result = loadDistFile(name);
+    const result = await loadDistFile(name);
     if (result != null) return { body: result.body, contentType: mt };
   }
   return null;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -128,7 +128,7 @@ export async function dispatch(
       res.end("unauthorized — open the URL printed by /dashboard, including ?token=…");
       return;
     }
-    const html = renderIndexHtml(expectedToken, ctx.mode);
+    const html = await renderIndexHtml(expectedToken, ctx.mode);
     res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
     res.end(html);
     return;
@@ -141,7 +141,7 @@ export async function dispatch(
       res.end();
       return;
     }
-    const asset = serveAsset(path.slice("/assets/".length), expectedToken);
+    const asset = await serveAsset(path.slice("/assets/".length), expectedToken);
     if (!asset) {
       res.writeHead(404);
       res.end("not found");


### PR DESCRIPTION
## Summary
- Replace all synchronous `node:fs` operations with async equivalents from `node:fs/promises` across 8 server API files + `assets.ts` + `index.ts`
- All handlers were already async — only helper functions needed conversion
- Key conversions:
  - `dirSize()`, `readSubdirs()`, `listWindowsDrives()` → async helpers
  - `readSkillListEntry()` → async with `FileHandle` (preserves TOCTOU-safe single-fd pattern)
  - `buildTree()`, `walk()` → async recursive/iterative tree walkers
  - `loadCachedText/Binary()` → async with `FileHandle`; `serveAsset()`, `renderIndexHtml()` → async
  - `readSettingsFile()`, `writeSettingsFile()` → async
  - `listMemoryFiles()` → async with `Promise.all` for parallel stat calls

## Why
Sync fs operations block the Node.js event loop, causing the server to stall on disk I/O. This is especially harmful for the dashboard HTTP server which handles concurrent requests.

## Test plan
- [ ] `npm run build` passes
- [ ] Dashboard loads and serves all assets correctly (HTML, JS, CSS, fonts)
- [ ] Memory, skills, hooks, and project tree API endpoints return correct data
- [ ] Checkpoint diffs endpoint works
- [ ] Browse endpoint works (directory listing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)