### PR TITLE
fix(server): convert sync fs I/O to async across server API and session memory

### DIFF
--- a/src/core/atomic-write.ts
+++ b/src/core/atomic-write.ts
@@ -1,4 +1,11 @@
-import { chmodSync, copyFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  copyFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { chmod, copyFile, rename, unlink, writeFile } from "node:fs/promises";
 
 export interface AtomicWriteFs {
   writeFileSync: typeof writeFileSync;
@@ -52,6 +59,46 @@ export function atomicWriteSync(
   }
   try {
     fs.unlinkSync(tmp);
+  } catch {
+    /* rename consumed it on the happy path; only present after EXDEV fallback */
+  }
+}
+
+/** Async atomic write with EXDEV fallback. */
+export async function atomicWrite(
+  path: string,
+  body: string,
+  tmp: string,
+  mode = 0o600,
+): Promise<void> {
+  try {
+    await writeFile(tmp, body, "utf8");
+    try {
+      await chmod(tmp, mode);
+    } catch {
+      /* platform without chmod */
+    }
+    try {
+      await rename(tmp, path);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "EXDEV") throw err;
+      await copyFile(tmp, path);
+      try {
+        await chmod(path, mode);
+      } catch {
+        /* platform without chmod */
+      }
+    }
+  } catch (err) {
+    try {
+      await unlink(tmp);
+    } catch {
+      /* tmp may already be gone or never existed */
+    }
+    throw err;
+  }
+  try {
+    await unlink(tmp);
   } catch {
     /* rename consumed it on the happy path; only present after EXDEV fallback */
   }

--- a/src/core/atomic-write.ts
+++ b/src/core/atomic-write.ts
@@ -1,10 +1,4 @@
-import {
-  chmodSync,
-  copyFileSync,
-  renameSync,
-  unlinkSync,
-  writeFileSync,
-} from "node:fs";
+import { chmodSync, copyFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { chmod, copyFile, rename, unlink, writeFile } from "node:fs/promises";
 
 export interface AtomicWriteFs {

--- a/src/memory/session.ts
+++ b/src/memory/session.ts
@@ -502,9 +502,7 @@ function chmodPrivate(path: string): void {
   }
 }
 
-// ---------------------------------------------------------------------------
 // Async variants — non-blocking counterparts for server API handlers.
-// ---------------------------------------------------------------------------
 
 async function countLinesAsync(path: string): Promise<number> {
   try {

--- a/src/memory/session.ts
+++ b/src/memory/session.ts
@@ -19,9 +19,22 @@ import {
   unlinkSync,
   writeFileSync,
 } from "node:fs";
+import {
+  appendFile,
+  chmod,
+  copyFile,
+  mkdir,
+  open,
+  readFile,
+  readdir,
+  rename,
+  stat,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join, posix as posixPath, win32 as win32Path } from "node:path";
-import { atomicWriteSync } from "../core/atomic-write.js";
+import { atomicWrite, atomicWriteSync } from "../core/atomic-write.js";
 import type { CacheDiagnosticEntry } from "../telemetry/cache-diagnostics.js";
 import type { ChatMessage } from "../types.js";
 
@@ -487,4 +500,313 @@ function chmodPrivate(path: string): void {
   } catch {
     /* chmod not supported */
   }
+}
+
+// ---------------------------------------------------------------------------
+// Async variants — non-blocking counterparts for server API handlers.
+// ---------------------------------------------------------------------------
+
+async function countLinesAsync(path: string): Promise<number> {
+  try {
+    const buf = await readFile(path);
+    let count = 0;
+    for (let i = 0; i < buf.length; i++) {
+      if (buf[i] === 0x0a) count++;
+    }
+    if (buf.length > 0 && buf[buf.length - 1] !== 0x0a) count++;
+    return count;
+  } catch {
+    return 0;
+  }
+}
+
+async function chmodPrivateAsync(path: string): Promise<void> {
+  try {
+    await chmod(path, 0o600);
+  } catch {
+    /* chmod not supported */
+  }
+}
+
+export async function loadSessionMetaAsync(name: string): Promise<SessionMeta> {
+  const p = metaPath(name);
+  try {
+    const raw = JSON.parse(await readFile(p, "utf8")) as SessionMeta;
+    return raw && typeof raw === "object" ? raw : {};
+  } catch {
+    return {};
+  }
+}
+
+export async function patchSessionMetaAsync(
+  name: string,
+  patch: Partial<SessionMeta>,
+): Promise<SessionMeta> {
+  const cur = await loadSessionMetaAsync(name);
+  const next: SessionMeta = { ...cur, ...patch };
+  const p = metaPath(name);
+  await mkdir(dirname(p), { recursive: true });
+  await writeFile(p, JSON.stringify(next), "utf8");
+  await chmodPrivateAsync(p);
+  return next;
+}
+
+async function readSessionMessagesAsync(
+  path: string,
+): Promise<{ messages: ChatMessage[]; hadContent: boolean } | null> {
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch {
+    return null;
+  }
+  const out: ChatMessage[] = [];
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const msg = JSON.parse(trimmed) as ChatMessage;
+      if (msg && typeof msg === "object" && "role" in msg) out.push(msg);
+    } catch {
+      /* skip malformed line */
+    }
+  }
+  return { messages: out, hadContent: raw.trim().length > 0 };
+}
+
+export async function loadSessionMessagesAsync(name: string): Promise<ChatMessage[]> {
+  const path = sessionPath(name);
+  const live = await readSessionMessagesAsync(path);
+  if (live && (live.messages.length > 0 || !live.hadContent)) return live.messages;
+  const backup = await readSessionMessagesAsync(sessionBackupPath(path));
+  return backup?.messages ?? live?.messages ?? [];
+}
+
+export async function findSessionsByPrefixAsync(prefix: string): Promise<string[]> {
+  const dir = sessionsDir();
+  try {
+    const files = (await readdir(dir))
+      .filter((f) => f.endsWith(".jsonl") && !f.endsWith(".events.jsonl") && f.startsWith(prefix))
+      .sort()
+      .reverse();
+    return files.map((f) => f.replace(/\.jsonl$/, ""));
+  } catch {
+    return [];
+  }
+}
+
+export async function readTailMessagesAsync(path: string, count: number): Promise<ChatMessage[]> {
+  try {
+    const fd = await open(path, "r");
+    try {
+      const { size } = await fd.stat();
+      if (size === 0) return [];
+      const out: ChatMessage[] = [];
+      let pos = size;
+      let leftover = "";
+      while (pos > 0 && out.length < count) {
+        const chunkSize = Math.min(READ_CHUNK_SIZE, pos);
+        pos -= chunkSize;
+        const buf = Buffer.alloc(chunkSize);
+        await fd.read(buf, 0, chunkSize, pos);
+        const chunk = buf.toString("utf8") + leftover;
+        const lines = chunk.split("\n");
+        leftover = lines[0]!;
+        for (let i = lines.length - 1; i >= 1 && out.length < count; i--) {
+          const trimmed = lines[i]!.trim();
+          if (!trimmed) continue;
+          try {
+            const msg = JSON.parse(trimmed) as ChatMessage;
+            if (msg && typeof msg === "object" && "role" in msg) out.push(msg);
+          } catch {
+            /* skip malformed */
+          }
+        }
+      }
+      if (out.length < count && leftover.trim()) {
+        try {
+          const msg = JSON.parse(leftover.trim()) as ChatMessage;
+          if (msg && typeof msg === "object" && "role" in msg) out.push(msg);
+        } catch {
+          /* skip */
+        }
+      }
+      return out.reverse();
+    } finally {
+      await fd.close();
+    }
+  } catch {
+    const raw = await readSessionMessagesAsync(path);
+    return raw?.messages ?? [];
+  }
+}
+
+export async function appendSessionMessageAsync(
+  name: string,
+  message: ChatMessage,
+): Promise<void> {
+  const path = sessionPath(name);
+  await mkdir(dirname(path), { recursive: true });
+  await appendFile(path, `${JSON.stringify(message)}\n`, "utf8");
+  await chmodPrivateAsync(path);
+}
+
+export async function renameSessionAsync(
+  oldName: string,
+  newName: string,
+): Promise<boolean> {
+  const safeOld = sanitizeName(oldName);
+  const safeNew = sanitizeName(newName);
+  if (safeOld === safeNew) return false;
+  const oldJsonl = sessionPath(oldName);
+  const newJsonl = sessionPath(newName);
+  try {
+    await stat(oldJsonl);
+  } catch {
+    return false;
+  }
+  try {
+    await stat(newJsonl);
+    return false; // target already exists
+  } catch {
+    /* target doesn't exist — good */
+  }
+  await rename(oldJsonl, newJsonl);
+  for (const ext of SESSION_SIDECAR_EXTS) {
+    const oldP = oldJsonl.replace(/\.jsonl$/, ext);
+    const newP = newJsonl.replace(/\.jsonl$/, ext);
+    try {
+      await rename(oldP, newP);
+    } catch {
+      /* sidecar rename failed — leave the jsonl rename in place */
+    }
+  }
+  return true;
+}
+
+export async function deleteSessionAsync(name: string): Promise<boolean> {
+  const path = sessionPath(name);
+  try {
+    await unlink(path);
+    for (const ext of SESSION_SIDECAR_EXTS) {
+      const sidecar = path.replace(/\.jsonl$/, ext);
+      try {
+        await unlink(sidecar);
+      } catch {
+        /* expected when the sidecar doesn't exist */
+      }
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function rewriteSessionAsync(
+  name: string,
+  messages: ChatMessage[],
+): Promise<void> {
+  const path = sessionPath(name);
+  await mkdir(dirname(path), { recursive: true });
+  const body = messages.map((m) => JSON.stringify(m)).join("\n");
+  const tmp = `${path}.${randomBytes(8).toString("hex")}.tmp`;
+  try {
+    const s = await stat(path);
+    if (s.size > 0) {
+      const backup = sessionBackupPath(path);
+      await copyFile(path, backup);
+      await chmodPrivateAsync(backup);
+    }
+  } catch {
+    /* file doesn't exist yet — fine */
+  }
+  await atomicWrite(path, body ? `${body}\n` : "", tmp);
+}
+
+export async function listSessionsAsync(opts?: {
+  workspaceFilter?: string;
+  includeLegacyWorkspaceMatches?: boolean;
+}): Promise<SessionInfo[]> {
+  const dir = sessionsDir();
+  const want = opts?.workspaceFilter ? normalizeWorkspace(opts.workspaceFilter) : null;
+  const legacyPrefix =
+    want && opts?.includeLegacyWorkspaceMatches
+      ? legacySessionPrefixForWorkspace(opts.workspaceFilter!)
+      : null;
+  try {
+    const files = (await readdir(dir)).filter(
+      (f) => f.endsWith(".jsonl") && !f.endsWith(".events.jsonl"),
+    );
+    const results = await Promise.all(
+      files.flatMap(async (file) => {
+        const path = join(dir, file);
+        const name = file.replace(/\.jsonl$/, "");
+        const meta = await loadSessionMetaAsync(name);
+        let workspaceStatus: SessionInfo["workspaceStatus"] | undefined;
+        if (want !== null) {
+          if (typeof meta.workspace === "string") {
+            if (normalizeWorkspace(meta.workspace) !== want) return [];
+            workspaceStatus = "matched";
+          } else if (legacyPrefix && name.startsWith(legacyPrefix)) {
+            workspaceStatus = "legacy_missing_meta";
+          } else {
+            return [];
+          }
+        }
+        const s = await stat(path);
+        const messageCount = await countLinesAsync(path);
+        return [
+          {
+            name,
+            path,
+            size: s.size,
+            messageCount,
+            mtime: s.mtime,
+            meta,
+            workspaceStatus,
+          } satisfies SessionInfo,
+        ];
+      }),
+    );
+    return results
+      .flat()
+      .sort((a, b) => b.mtime.getTime() - a.mtime.getTime());
+  } catch {
+    return [];
+  }
+}
+
+export async function listSessionsForWorkspaceAsync(
+  workspace: string,
+): Promise<SessionInfo[]> {
+  return listSessionsAsync({
+    workspaceFilter: workspace,
+    includeLegacyWorkspaceMatches: true,
+  });
+}
+
+export async function pruneStaleSessionsAsync(daysOld = 90): Promise<string[]> {
+  const cutoff = Date.now() - daysOld * 24 * 60 * 60 * 1000;
+  const deleted: string[] = [];
+  for (const s of await listSessionsAsync()) {
+    if (s.mtime.getTime() < cutoff) {
+      if (await deleteSessionAsync(s.name)) deleted.push(s.name);
+    }
+  }
+  return deleted;
+}
+
+export async function archiveSessionAsync(name: string): Promise<string | null> {
+  const path = sessionPath(name);
+  try {
+    const s = await stat(path);
+    if (s.size === 0) return null;
+  } catch {
+    return null;
+  }
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const target = `${name}__archive_${timestampSuffix()}${attempt > 0 ? `_${attempt}` : ""}`;
+    if (await renameSessionAsync(name, target)) return target;
+  }
+  return null;
 }

--- a/src/memory/session.ts
+++ b/src/memory/session.ts
@@ -641,20 +641,14 @@ export async function readTailMessagesAsync(path: string, count: number): Promis
   }
 }
 
-export async function appendSessionMessageAsync(
-  name: string,
-  message: ChatMessage,
-): Promise<void> {
+export async function appendSessionMessageAsync(name: string, message: ChatMessage): Promise<void> {
   const path = sessionPath(name);
   await mkdir(dirname(path), { recursive: true });
   await appendFile(path, `${JSON.stringify(message)}\n`, "utf8");
   await chmodPrivateAsync(path);
 }
 
-export async function renameSessionAsync(
-  oldName: string,
-  newName: string,
-): Promise<boolean> {
+export async function renameSessionAsync(oldName: string, newName: string): Promise<boolean> {
   const safeOld = sanitizeName(oldName);
   const safeNew = sanitizeName(newName);
   if (safeOld === safeNew) return false;
@@ -702,10 +696,7 @@ export async function deleteSessionAsync(name: string): Promise<boolean> {
   }
 }
 
-export async function rewriteSessionAsync(
-  name: string,
-  messages: ChatMessage[],
-): Promise<void> {
+export async function rewriteSessionAsync(name: string, messages: ChatMessage[]): Promise<void> {
   const path = sessionPath(name);
   await mkdir(dirname(path), { recursive: true });
   const body = messages.map((m) => JSON.stringify(m)).join("\n");
@@ -768,17 +759,13 @@ export async function listSessionsAsync(opts?: {
         ];
       }),
     );
-    return results
-      .flat()
-      .sort((a, b) => b.mtime.getTime() - a.mtime.getTime());
+    return results.flat().sort((a, b) => b.mtime.getTime() - a.mtime.getTime());
   } catch {
     return [];
   }
 }
 
-export async function listSessionsForWorkspaceAsync(
-  workspace: string,
-): Promise<SessionInfo[]> {
+export async function listSessionsForWorkspaceAsync(workspace: string): Promise<SessionInfo[]> {
   return listSessionsAsync({
     workspaceFilter: workspace,
     includeLegacyWorkspaceMatches: true,

--- a/src/server/api/browse.ts
+++ b/src/server/api/browse.ts
@@ -1,8 +1,8 @@
 import { exec } from "node:child_process";
 import { readdir, stat } from "node:fs/promises";
-import { promisify } from "node:util";
 import { homedir } from "node:os";
 import { dirname, isAbsolute, resolve } from "node:path";
+import { promisify } from "node:util";
 import type { ApiResult } from "../router.js";
 
 interface BrowseEntry {

--- a/src/server/api/browse.ts
+++ b/src/server/api/browse.ts
@@ -1,5 +1,6 @@
-import { execSync } from "node:child_process";
-import { existsSync, readdirSync, statSync } from "node:fs";
+import { exec } from "node:child_process";
+import { readdir, stat } from "node:fs/promises";
+import { promisify } from "node:util";
 import { homedir } from "node:os";
 import { dirname, isAbsolute, resolve } from "node:path";
 import type { ApiResult } from "../router.js";
@@ -35,21 +36,29 @@ const SKIP_DIRS = new Set([
   "build",
 ]);
 
+const execAsync = promisify(exec);
+
 let cachedDriveList: string[] | null = null;
 
-function listWindowsDrives(): string[] {
+async function listWindowsDrives(): Promise<string[]> {
   if (cachedDriveList) return cachedDriveList;
   try {
-    const raw = execSync("wmic logicaldisk get deviceid /value", {
+    const { stdout } = await execAsync("wmic logicaldisk get deviceid /value", {
       encoding: "utf8",
       timeout: 1500,
     });
-    const drives = raw
-      .split(/\r?\n/)
-      .map((l) => l.trim())
-      .filter((l) => l.startsWith("DeviceID="))
-      .map((l) => `${l.slice("DeviceID=".length)}\\`)
-      .filter((d) => existsSync(d));
+    const drives: string[] = [];
+    for (const line of stdout.split(/\r?\n/)) {
+      const l = line.trim();
+      if (!l.startsWith("DeviceID=")) continue;
+      const d = `${l.slice("DeviceID=".length)}\\`;
+      try {
+        await stat(d);
+        drives.push(d);
+      } catch {
+        /* skip non-existent drive */
+      }
+    }
     cachedDriveList = drives.length > 0 ? drives : ["C:\\"];
   } catch {
     // wmic absent (newer Windows builds drop it) — fall back to probing letters.
@@ -57,7 +66,8 @@ function listWindowsDrives(): string[] {
     for (const letter of "CDEFGHIJKLMNOPQRSTUVWXYZ") {
       const p = `${letter}:\\`;
       try {
-        if (existsSync(p)) found.push(p);
+        await stat(p);
+        found.push(p);
       } catch {
         /* skip unreachable drives without blocking */
       }
@@ -79,10 +89,10 @@ function defaultRoot(): string {
   }
 }
 
-function readSubdirs(path: string): BrowseEntry[] {
+async function readSubdirs(path: string): Promise<BrowseEntry[]> {
   let names: string[];
   try {
-    names = readdirSync(path);
+    names = await readdir(path);
   } catch {
     return [];
   }
@@ -93,7 +103,7 @@ function readSubdirs(path: string): BrowseEntry[] {
     if (name.startsWith(".") && name.length > 1) continue;
     const full = resolve(path, name);
     try {
-      if (!statSync(full).isDirectory()) continue;
+      if (!(await stat(full)).isDirectory()) continue;
     } catch {
       continue;
     }
@@ -118,9 +128,9 @@ export async function handleBrowse(
   // so the user can navigate off the home drive without typing the letter.
   if (!rawPath) {
     const home = defaultRoot();
-    const entries = readSubdirs(home);
+    const entries = await readSubdirs(home);
     if (isWin) {
-      const drives = listWindowsDrives()
+      const drives = (await listWindowsDrives())
         .filter((d) => resolve(d) !== resolve(home))
         .map((d) => ({ name: d, full: d }));
       entries.unshift(...drives);
@@ -133,12 +143,9 @@ export async function handleBrowse(
     return { status: 400, body: { error: "path must be absolute" } };
   }
   const absolute = resolve(rawPath);
-  if (!existsSync(absolute)) {
-    return { status: 404, body: { error: `no such directory: ${absolute}` } };
-  }
   let isDir = false;
   try {
-    isDir = statSync(absolute).isDirectory();
+    isDir = (await stat(absolute)).isDirectory();
   } catch {
     /* falls through to 404-equivalent */
   }
@@ -152,7 +159,7 @@ export async function handleBrowse(
   const result: BrowseResult = {
     path: absolute,
     parent,
-    entries: readSubdirs(absolute),
+    entries: await readSubdirs(absolute),
   };
   return { status: 200, body: result };
 }

--- a/src/server/api/checkpoint-diffs.ts
+++ b/src/server/api/checkpoint-diffs.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { loadCheckpoint } from "../../code/checkpoints.js";
 import { lineDiff } from "../../tools/fs/edit.js";
@@ -37,7 +37,7 @@ export async function handleCheckpointDiffs(
     const absPath = resolve(rootDir, snap.path);
     let currentContent: string | null = null;
     try {
-      currentContent = readFileSync(absPath, "utf8");
+      currentContent = await readFile(absPath, "utf8");
     } catch {
       currentContent = null;
     }

--- a/src/server/api/files.ts
+++ b/src/server/api/files.ts
@@ -1,3 +1,4 @@
+import type { Stats } from "node:fs";
 import { readdir, stat } from "node:fs/promises";
 import { extname, join, relative, sep } from "node:path";
 import type { DashboardContext } from "../context.js";
@@ -80,7 +81,7 @@ async function walk(root: string, prefix: string): Promise<string[]> {
       if (name.startsWith(".") && depth === 0) continue;
       if (SKIP_DIRS.has(name)) continue;
       const full = join(path, name);
-      let st;
+      let st: Stats;
       try {
         st = await stat(full);
       } catch {

--- a/src/server/api/files.ts
+++ b/src/server/api/files.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, statSync } from "node:fs";
+import { readdir, stat } from "node:fs/promises";
 import { extname, join, relative, sep } from "node:path";
 import type { DashboardContext } from "../context.js";
 import type { ApiResult } from "../router.js";
@@ -44,7 +44,12 @@ export async function handleFiles(
 ): Promise<ApiResult> {
   if (method !== "POST") return { status: 405, body: { error: "POST only" } };
   const cwd = ctx.getCurrentCwd?.();
-  if (!cwd || !existsSync(cwd)) {
+  if (!cwd) {
+    return { status: 503, body: { error: "@-mention picker requires a code-mode session" } };
+  }
+  try {
+    await stat(cwd);
+  } catch {
     return { status: 503, body: { error: "@-mention picker requires a code-mode session" } };
   }
   let parsed: { prefix?: unknown };
@@ -54,11 +59,11 @@ export async function handleFiles(
     return { status: 400, body: { error: "body must be JSON" } };
   }
   const prefix = typeof parsed.prefix === "string" ? parsed.prefix.trim().toLowerCase() : "";
-  const matches = walk(cwd, prefix);
+  const matches = await walk(cwd, prefix);
   return { status: 200, body: { files: matches } };
 }
 
-function walk(root: string, prefix: string): string[] {
+async function walk(root: string, prefix: string): Promise<string[]> {
   const out: string[] = [];
   const stack: Array<{ path: string; depth: number }> = [{ path: root, depth: 0 }];
   while (stack.length > 0 && out.length < RESULT_CAP) {
@@ -66,7 +71,7 @@ function walk(root: string, prefix: string): string[] {
     if (depth > MAX_DEPTH) continue;
     let names: string[];
     try {
-      names = readdirSync(path);
+      names = await readdir(path);
     } catch {
       continue;
     }
@@ -75,9 +80,9 @@ function walk(root: string, prefix: string): string[] {
       if (name.startsWith(".") && depth === 0) continue;
       if (SKIP_DIRS.has(name)) continue;
       const full = join(path, name);
-      let st: ReturnType<typeof statSync>;
+      let st;
       try {
-        st = statSync(full);
+        st = await stat(full);
       } catch {
         continue;
       }

--- a/src/server/api/health.ts
+++ b/src/server/api/health.ts
@@ -1,7 +1,7 @@
-import { existsSync, readdirSync, statSync } from "node:fs";
+import { readdir, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { listSessions } from "../../memory/session.js";
+import { listSessionsAsync } from "../../memory/session.js";
 import { VERSION } from "../../version.js";
 import type { DashboardContext } from "../context.js";
 import type { ApiResult } from "../router.js";
@@ -14,26 +14,24 @@ interface DirStat {
 }
 
 /** Sum file sizes one level deep. Recursion deferred until we have a use-case for nested data dirs. */
-function dirSize(path: string): DirStat {
-  if (!existsSync(path)) return { path, exists: false, fileCount: 0, totalBytes: 0 };
+async function dirSize(path: string): Promise<DirStat> {
   let fileCount = 0;
   let totalBytes = 0;
   try {
-    const entries = readdirSync(path);
+    const entries = await readdir(path);
     for (const name of entries) {
       const full = join(path, name);
       try {
-        const s = statSync(full);
+        const s = await stat(full);
         if (s.isFile()) {
           fileCount++;
           totalBytes += s.size;
         } else if (s.isDirectory()) {
-          // Recurse one level for nested folders (memory/<hash>, sessions/, etc).
           try {
-            const inner = readdirSync(full);
+            const inner = await readdir(full);
             for (const child of inner) {
               try {
-                const cs = statSync(join(full, child));
+                const cs = await stat(join(full, child));
                 if (cs.isFile()) {
                   fileCount++;
                   totalBytes += cs.size;
@@ -51,7 +49,7 @@ function dirSize(path: string): DirStat {
       }
     }
   } catch {
-    return { path, exists: true, fileCount: 0, totalBytes: 0 };
+    return { path, exists: false, fileCount: 0, totalBytes: 0 };
   }
   return { path, exists: true, fileCount, totalBytes };
 }
@@ -68,20 +66,20 @@ export async function handleHealth(
   const home = homedir();
   const reasonixHome = join(home, ".reasonix");
 
-  const sessionsStat = dirSize(join(reasonixHome, "sessions"));
-  const memoryStat = dirSize(join(reasonixHome, "memory"));
-  const semanticStat = dirSize(join(reasonixHome, "semantic"));
+  const [sessionsStat, memoryStat, semanticStat] = await Promise.all([
+    dirSize(join(reasonixHome, "sessions")),
+    dirSize(join(reasonixHome, "memory")),
+    dirSize(join(reasonixHome, "semantic")),
+  ]);
 
   let usageBytes = 0;
-  if (existsSync(ctx.usageLogPath)) {
-    try {
-      usageBytes = statSync(ctx.usageLogPath).size;
-    } catch {
-      /* ignore */
-    }
+  try {
+    usageBytes = (await stat(ctx.usageLogPath)).size;
+  } catch {
+    /* ignore */
   }
 
-  const sessions = listSessions();
+  const sessions = await listSessionsAsync();
 
   return {
     status: 200,

--- a/src/server/api/hooks.ts
+++ b/src/server/api/hooks.ts
@@ -1,6 +1,6 @@
 /** Reload is a separate POST so save and apply stay decoupled; the SPA chains them by convention. */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { trustProjectHooks } from "../../config.js";
 import { HOOK_EVENTS, globalSettingsPath, loadHooks, projectSettingsPath } from "../../hooks.js";
@@ -23,10 +23,9 @@ function parseBody(raw: string): SaveBody {
   }
 }
 
-function readSettingsFile(path: string): { hooks?: Record<string, unknown[]> } {
-  if (!existsSync(path)) return {};
+async function readSettingsFile(path: string): Promise<{ hooks?: Record<string, unknown[]> }> {
   try {
-    const raw = readFileSync(path, "utf8");
+    const raw = await readFile(path, "utf8");
     const parsed = JSON.parse(raw);
     return typeof parsed === "object" && parsed !== null ? parsed : {};
   } catch {
@@ -34,12 +33,12 @@ function readSettingsFile(path: string): { hooks?: Record<string, unknown[]> } {
   }
 }
 
-function writeSettingsFile(path: string, hooksBlock: unknown): void {
+async function writeSettingsFile(path: string, hooksBlock: unknown): Promise<void> {
   // Preserve any other top-level keys that may live in the file.
-  const existing = readSettingsFile(path);
+  const existing = await readSettingsFile(path);
   existing.hooks = hooksBlock as Record<string, unknown[]>;
-  mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, `${JSON.stringify(existing, null, 2)}\n`, "utf8");
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${JSON.stringify(existing, null, 2)}\n`, "utf8");
 }
 
 export async function handleHooks(
@@ -51,8 +50,8 @@ export async function handleHooks(
   if (method === "GET" && rest.length === 0) {
     const projectPath = ctx.getCurrentCwd ? projectSettingsPath(ctx.getCurrentCwd() ?? "") : null;
     const globalPath = globalSettingsPath();
-    const projectFile = projectPath ? readSettingsFile(projectPath) : {};
-    const globalFile = readSettingsFile(globalPath);
+    const projectFile = projectPath ? await readSettingsFile(projectPath) : {};
+    const globalFile = await readSettingsFile(globalPath);
     const resolved = loadHooks({ projectRoot: ctx.getCurrentCwd?.() });
     return {
       status: 200,
@@ -97,7 +96,7 @@ export async function handleHooks(
     if (!path) {
       return { status: 500, body: { error: "could not resolve settings path" } };
     }
-    writeSettingsFile(path, hooks);
+    await writeSettingsFile(path, hooks);
     ctx.audit?.({ ts: Date.now(), action: "save-hooks", payload: { scope, path } });
     return { status: 200, body: { saved: true, path } };
   }

--- a/src/server/api/memory.ts
+++ b/src/server/api/memory.ts
@@ -140,11 +140,11 @@ export async function handleMemory(
       if (!dir) return { status: 503, body: { error: "no project root for project-mem" } };
       const path = join(dir, `${name}.md`);
       try {
-        await stat(path);
+        const body = await readFile(path, "utf8");
+        return { status: 200, body: { path, body } };
       } catch {
         return { status: 404, body: { error: "not found" } };
       }
-      return { status: 200, body: { path, body: await readFile(path, "utf8") } };
     }
     return { status: 400, body: { error: "bad scope or name" } };
   }

--- a/src/server/api/memory.ts
+++ b/src/server/api/memory.ts
@@ -1,15 +1,7 @@
 /** Names sanitized via SAFE_NAME on every write — guards against path traversal. */
 
 import { createHash } from "node:crypto";
-import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  readdirSync,
-  statSync,
-  unlinkSync,
-  writeFileSync,
-} from "node:fs";
+import { mkdir, readFile, readdir, stat, unlink, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, dirname, join, resolve as resolvePath } from "node:path";
 import {
@@ -52,20 +44,21 @@ function parseBody(raw: string): WriteBody {
 
 const SAFE_NAME = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$/;
 
-function listMemoryFiles(dir: string): Array<{ name: string; size: number; mtime: number }> {
-  if (!existsSync(dir)) return [];
+async function listMemoryFiles(dir: string): Promise<Array<{ name: string; size: number; mtime: number }>> {
   try {
-    return readdirSync(dir)
-      .filter((f) => f.endsWith(".md"))
-      .map((f) => {
-        const stat = statSync(join(dir, f));
+    const entries = await readdir(dir);
+    const mdFiles = entries.filter((f) => f.endsWith(".md"));
+    const stats = await Promise.all(
+      mdFiles.map(async (f) => {
+        const s = await stat(join(dir, f));
         return {
           name: f.replace(/\.md$/, ""),
-          size: stat.size,
-          mtime: stat.mtime.getTime(),
+          size: s.size,
+          mtime: s.mtime.getTime(),
         };
-      })
-      .sort((a, b) => b.mtime - a.mtime);
+      }),
+    );
+    return stats.sort((a, b) => b.mtime - a.mtime);
   } catch {
     return [];
   }
@@ -119,11 +112,11 @@ export async function handleMemory(
         },
         global: {
           path: globalDir,
-          files: listMemoryFiles(globalDir),
+          files: await listMemoryFiles(globalDir),
         },
         projectMem: {
           path: projectMemDir,
-          files: projectMemDir ? listMemoryFiles(projectMemDir) : [],
+          files: projectMemDir ? await listMemoryFiles(projectMemDir) : [],
         },
       },
     };
@@ -138,14 +131,18 @@ export async function handleMemory(
       if (!cwd) return { status: 503, body: { error: "no active project" } };
       const path = findProjectMemoryPath(cwd);
       if (!path) return { status: 404, body: { error: "project memory file not found" } };
-      return { status: 200, body: { path, body: readFileSync(path, "utf8") } };
+      return { status: 200, body: { path, body: await readFile(path, "utf8") } };
     }
     if ((scope === "global" || scope === "project-mem") && name && SAFE_NAME.test(name)) {
       const dir = scope === "global" ? globalDir : projectMemDir;
       if (!dir) return { status: 503, body: { error: "no project root for project-mem" } };
       const path = join(dir, `${name}.md`);
-      if (!existsSync(path)) return { status: 404, body: { error: "not found" } };
-      return { status: 200, body: { path, body: readFileSync(path, "utf8") } };
+      try {
+        await stat(path);
+      } catch {
+        return { status: 404, body: { error: "not found" } };
+      }
+      return { status: 200, body: { path, body: await readFile(path, "utf8") } };
     }
     return { status: 400, body: { error: "bad scope or name" } };
   }
@@ -158,17 +155,17 @@ export async function handleMemory(
     if (scope === "project") {
       if (!cwd) return { status: 503, body: { error: "no active project" } };
       const path = resolveProjectMemoryWritePath(cwd);
-      mkdirSync(dirname(path), { recursive: true });
-      writeFileSync(path, contents, "utf8");
+      await mkdir(dirname(path), { recursive: true });
+      await writeFile(path, contents, "utf8");
       ctx.audit?.({ ts: Date.now(), action: "save-memory", payload: { scope, path } });
       return { status: 200, body: { saved: true, path } };
     }
     if ((scope === "global" || scope === "project-mem") && name && SAFE_NAME.test(name)) {
       const dir = scope === "global" ? globalDir : projectMemDir;
       if (!dir) return { status: 503, body: { error: "no project root for project-mem" } };
-      mkdirSync(dir, { recursive: true });
+      await mkdir(dir, { recursive: true });
       const path = join(dir, `${name}.md`);
-      writeFileSync(path, contents, "utf8");
+      await writeFile(path, contents, "utf8");
       ctx.audit?.({ ts: Date.now(), action: "save-memory", payload: { scope, name, path } });
       return { status: 200, body: { saved: true, path } };
     }
@@ -180,18 +177,19 @@ export async function handleMemory(
       const dir = scope === "global" ? globalDir : projectMemDir;
       if (!dir) return { status: 503, body: { error: "no project root for project-mem" } };
       const path = join(dir, `${name}.md`);
-      if (existsSync(path)) {
-        unlinkSync(path);
+      try {
+        await unlink(path);
         ctx.audit?.({ ts: Date.now(), action: "delete-memory", payload: { scope, name, path } });
         return { status: 200, body: { deleted: true } };
+      } catch {
+        return { status: 404, body: { error: "not found" } };
       }
-      return { status: 404, body: { error: "not found" } };
     }
     if (scope === "project") {
       if (!cwd) return { status: 503, body: { error: "no active project" } };
       const path = findProjectMemoryPath(cwd);
       if (path) {
-        unlinkSync(path);
+        await unlink(path);
         ctx.audit?.({ ts: Date.now(), action: "delete-memory", payload: { scope, path } });
         return { status: 200, body: { deleted: true } };
       }

--- a/src/server/api/memory.ts
+++ b/src/server/api/memory.ts
@@ -44,7 +44,9 @@ function parseBody(raw: string): WriteBody {
 
 const SAFE_NAME = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$/;
 
-async function listMemoryFiles(dir: string): Promise<Array<{ name: string; size: number; mtime: number }>> {
+async function listMemoryFiles(
+  dir: string,
+): Promise<Array<{ name: string; size: number; mtime: number }>> {
   try {
     const entries = await readdir(dir);
     const mdFiles = entries.filter((f) => f.endsWith(".md"));

--- a/src/server/api/project-tree.ts
+++ b/src/server/api/project-tree.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, statSync } from "node:fs";
+import { readdir, stat } from "node:fs/promises";
 import { extname, join, relative, sep } from "node:path";
 import type { DashboardContext } from "../context.js";
 import type { ApiResult } from "../router.js";
@@ -51,18 +51,25 @@ export async function handleProjectTree(
 ): Promise<ApiResult> {
   if (method !== "GET") return { status: 405, body: { error: "GET only" } };
   const cwd = ctx.getCurrentCwd?.();
-  if (!cwd || !existsSync(cwd)) {
+  if (!cwd) {
     return { status: 503, body: { error: "no project directory available" } };
   }
-  const tree = buildTree(cwd, cwd, 0);
+  try {
+    if (!(await stat(cwd)).isDirectory()) {
+      return { status: 503, body: { error: "no project directory available" } };
+    }
+  } catch {
+    return { status: 503, body: { error: "no project directory available" } };
+  }
+  const tree = await buildTree(cwd, cwd, 0);
   return { status: 200, body: { tree } };
 }
 
-function buildTree(root: string, dirPath: string, depth: number): TreeNode[] {
+async function buildTree(root: string, dirPath: string, depth: number): Promise<TreeNode[]> {
   if (depth > MAX_DEPTH) return [];
   let names: string[];
   try {
-    names = readdirSync(dirPath);
+    names = await readdir(dirPath);
   } catch {
     return [];
   }
@@ -72,9 +79,9 @@ function buildTree(root: string, dirPath: string, depth: number): TreeNode[] {
   for (const name of names) {
     if (SKIP_DIRS.has(name)) continue;
     const full = join(dirPath, name);
-    let st: ReturnType<typeof statSync>;
+    let st: Awaited<ReturnType<typeof stat>>;
     try {
-      st = statSync(full);
+      st = await stat(full);
     } catch {
       continue;
     }
@@ -89,7 +96,7 @@ function buildTree(root: string, dirPath: string, depth: number): TreeNode[] {
   for (const name of dirs) {
     const full = join(dirPath, name);
     const rel = relative(root, full).split(sep).join("/");
-    const children = buildTree(root, full, depth + 1);
+    const children = await buildTree(root, full, depth + 1);
     nodes.push({ name, path: rel, isDir: true, children });
   }
   for (const name of files) {
@@ -111,7 +118,14 @@ export async function handleFiles(
   }
   if (method !== "POST") return { status: 405, body: { error: "GET or POST only" } };
   const cwd = ctx.getCurrentCwd?.();
-  if (!cwd || !existsSync(cwd)) {
+  if (!cwd) {
+    return { status: 503, body: { error: "@-mention picker requires a code-mode session" } };
+  }
+  try {
+    if (!(await stat(cwd)).isDirectory()) {
+      return { status: 503, body: { error: "@-mention picker requires a code-mode session" } };
+    }
+  } catch {
     return { status: 503, body: { error: "@-mention picker requires a code-mode session" } };
   }
   let parsed: { prefix?: unknown };
@@ -121,11 +135,11 @@ export async function handleFiles(
     return { status: 400, body: { error: "body must be JSON" } };
   }
   const prefix = typeof parsed.prefix === "string" ? parsed.prefix.trim().toLowerCase() : "";
-  const matches = walk(cwd, prefix);
+  const matches = await walk(cwd, prefix);
   return { status: 200, body: { files: matches } };
 }
 
-function walk(root: string, prefix: string): string[] {
+async function walk(root: string, prefix: string): Promise<string[]> {
   const out: string[] = [];
   const stack: Array<{ path: string; depth: number }> = [{ path: root, depth: 0 }];
   while (stack.length > 0 && out.length < RESULT_CAP) {
@@ -133,7 +147,7 @@ function walk(root: string, prefix: string): string[] {
     if (depth > MAX_DEPTH) continue;
     let names: string[];
     try {
-      names = readdirSync(path);
+      names = await readdir(path);
     } catch {
       continue;
     }
@@ -141,9 +155,9 @@ function walk(root: string, prefix: string): string[] {
       if (out.length >= RESULT_CAP) break;
       if (SKIP_DIRS.has(name)) continue;
       const full = join(path, name);
-      let st: ReturnType<typeof statSync>;
+      let st: Awaited<ReturnType<typeof stat>>;
       try {
-        st = statSync(full);
+        st = await stat(full);
       } catch {
         continue;
       }

--- a/src/server/api/sessions.ts
+++ b/src/server/api/sessions.ts
@@ -28,7 +28,10 @@ interface SessionMessage {
   toolName?: string;
 }
 
-async function parseTranscript(path: string, maxBytes = 4 * 1024 * 1024): Promise<SessionMessage[]> {
+async function parseTranscript(
+  path: string,
+  maxBytes = 4 * 1024 * 1024,
+): Promise<SessionMessage[]> {
   // Cap reads at 4 MB so a runaway session file (rare but possible)
   // doesn't tie up the server. The `head` of a long session is the
   // useful part; we surface a `truncated` flag in the response.
@@ -84,7 +87,9 @@ export async function handleSessions(
   // sidebar; users have reported 10 000+ entries in `~/.reasonix/sessions/`.
   if (method === "GET" && rest.length === 0) {
     const workspaceFilter = ctx.getCurrentCwd?.();
-    const sessions = workspaceFilter ? await listSessionsForWorkspaceAsync(workspaceFilter) : await listSessionsAsync();
+    const sessions = workspaceFilter
+      ? await listSessionsForWorkspaceAsync(workspaceFilter)
+      : await listSessionsAsync();
     const currentName = ctx.getSessionName?.() ?? null;
     return {
       status: 200,
@@ -132,7 +137,12 @@ export async function handleSessions(
 
   // Helper: check session file exists.
   const sessionExists = async (p: string): Promise<boolean> => {
-    try { await stat(p); return true; } catch { return false; }
+    try {
+      await stat(p);
+      return true;
+    } catch {
+      return false;
+    }
   };
 
   if (method === "POST" && rest[1] === "switch") {
@@ -142,7 +152,8 @@ export async function handleSessions(
         body: { error: "live session swap requires an attached CLI session." },
       };
     }
-    if (!(await sessionExists(path))) return { status: 404, body: { error: `no such session: ${name}` } };
+    if (!(await sessionExists(path)))
+      return { status: 404, body: { error: `no such session: ${name}` } };
     const result = ctx.switchSession(name);
     if (!result.ok) return { status: 500, body: { error: result.reason } };
     return { status: 200, body: { ok: true } };
@@ -161,7 +172,8 @@ export async function handleSessions(
         body: { error: "cannot delete the currently-active session — switch away first." },
       };
     }
-    if (!(await sessionExists(path))) return { status: 404, body: { error: `no such session: ${name}` } };
+    if (!(await sessionExists(path)))
+      return { status: 404, body: { error: `no such session: ${name}` } };
     const removed = await deleteSessionAsync(name);
     if (!removed) return { status: 500, body: { error: `failed to delete ${name}` } };
     ctx.audit?.({ ts: Date.now(), action: "delete-session", payload: { name } });
@@ -172,7 +184,8 @@ export async function handleSessions(
     if (rest.length !== 1) {
       return { status: 405, body: { error: `method ${method} not supported on this path` } };
     }
-    if (!(await sessionExists(path))) return { status: 404, body: { error: `no such session: ${name}` } };
+    if (!(await sessionExists(path)))
+      return { status: 404, body: { error: `no such session: ${name}` } };
     const messages = await parseTranscript(path);
     return {
       status: 200,

--- a/src/server/api/sessions.ts
+++ b/src/server/api/sessions.ts
@@ -1,8 +1,8 @@
-import { existsSync, readFileSync } from "node:fs";
+import { readFile, stat } from "node:fs/promises";
 import {
-  deleteSession,
-  listSessions,
-  listSessionsForWorkspace,
+  deleteSessionAsync,
+  listSessionsAsync,
+  listSessionsForWorkspaceAsync,
   sessionPath,
 } from "../../memory/session.js";
 import type { DashboardContext } from "../context.js";
@@ -28,13 +28,13 @@ interface SessionMessage {
   toolName?: string;
 }
 
-function parseTranscript(path: string, maxBytes = 4 * 1024 * 1024): SessionMessage[] {
+async function parseTranscript(path: string, maxBytes = 4 * 1024 * 1024): Promise<SessionMessage[]> {
   // Cap reads at 4 MB so a runaway session file (rare but possible)
   // doesn't tie up the server. The `head` of a long session is the
   // useful part; we surface a `truncated` flag in the response.
   let raw: string;
   try {
-    raw = readFileSync(path, "utf8");
+    raw = await readFile(path, "utf8");
   } catch {
     return [];
   }
@@ -84,7 +84,7 @@ export async function handleSessions(
   // sidebar; users have reported 10 000+ entries in `~/.reasonix/sessions/`.
   if (method === "GET" && rest.length === 0) {
     const workspaceFilter = ctx.getCurrentCwd?.();
-    const sessions = workspaceFilter ? listSessionsForWorkspace(workspaceFilter) : listSessions();
+    const sessions = workspaceFilter ? await listSessionsForWorkspaceAsync(workspaceFilter) : await listSessionsAsync();
     const currentName = ctx.getSessionName?.() ?? null;
     return {
       status: 200,
@@ -130,6 +130,11 @@ export async function handleSessions(
   const path = sessionPath(name);
   const currentName = ctx.getSessionName?.() ?? null;
 
+  // Helper: check session file exists.
+  const sessionExists = async (p: string): Promise<boolean> => {
+    try { await stat(p); return true; } catch { return false; }
+  };
+
   if (method === "POST" && rest[1] === "switch") {
     if (!ctx.switchSession) {
       return {
@@ -137,7 +142,7 @@ export async function handleSessions(
         body: { error: "live session swap requires an attached CLI session." },
       };
     }
-    if (!existsSync(path)) return { status: 404, body: { error: `no such session: ${name}` } };
+    if (!(await sessionExists(path))) return { status: 404, body: { error: `no such session: ${name}` } };
     const result = ctx.switchSession(name);
     if (!result.ok) return { status: 500, body: { error: result.reason } };
     return { status: 200, body: { ok: true } };
@@ -156,8 +161,8 @@ export async function handleSessions(
         body: { error: "cannot delete the currently-active session — switch away first." },
       };
     }
-    if (!existsSync(path)) return { status: 404, body: { error: `no such session: ${name}` } };
-    const removed = deleteSession(name);
+    if (!(await sessionExists(path))) return { status: 404, body: { error: `no such session: ${name}` } };
+    const removed = await deleteSessionAsync(name);
     if (!removed) return { status: 500, body: { error: `failed to delete ${name}` } };
     ctx.audit?.({ ts: Date.now(), action: "delete-session", payload: { name } });
     return { status: 200, body: { ok: true, deleted: name } };
@@ -167,8 +172,8 @@ export async function handleSessions(
     if (rest.length !== 1) {
       return { status: 405, body: { error: `method ${method} not supported on this path` } };
     }
-    if (!existsSync(path)) return { status: 404, body: { error: `no such session: ${name}` } };
-    const messages = parseTranscript(path);
+    if (!(await sessionExists(path))) return { status: 404, body: { error: `no such session: ${name}` } };
+    const messages = await parseTranscript(path);
     return {
       status: 200,
       body: { name, path, messages, messageCount: messages.length },

--- a/src/server/api/skills.ts
+++ b/src/server/api/skills.ts
@@ -104,7 +104,10 @@ function defaultSkillPath(dir: string, name: string): ResolvedSkillPath {
   return { path: join(dir, name, SKILL_FILE), layout: "folder" };
 }
 
-async function listSkills(dir: string, scope: "project" | "custom" | "global"): Promise<SkillListEntry[]> {
+async function listSkills(
+  dir: string,
+  scope: "project" | "custom" | "global",
+): Promise<SkillListEntry[]> {
   const out: SkillListEntry[] = [];
   try {
     const entries = await readdir(dir, { withFileTypes: true });
@@ -165,7 +168,9 @@ export async function handleSkills(
       status: 200,
       body: {
         global: tag(await listSkills(globalSkillsDir(), "global")),
-        custom: tag((await Promise.all(customRoots.map((root) => listSkills(root.dir, "custom")))).flat()),
+        custom: tag(
+          (await Promise.all(customRoots.map((root) => listSkills(root.dir, "custom")))).flat(),
+        ),
         project: cwd ? tag(await listSkills(projectSkillsDir(cwd), "project")) : [],
         builtin: [
           {

--- a/src/server/api/skills.ts
+++ b/src/server/api/skills.ts
@@ -1,18 +1,6 @@
 /** `/api/skills` — edits files only; loop reloads on /new or restart. `builtin` scope is read-only. */
 
-import {
-  closeSync,
-  existsSync,
-  fstatSync,
-  mkdirSync,
-  openSync,
-  readFileSync,
-  readSync,
-  readdirSync,
-  rmSync,
-  statSync,
-  writeFileSync,
-} from "node:fs";
+import { mkdir, open, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { loadResolvedSkillPaths, loadSubagentModels } from "../../config.js";
@@ -67,56 +55,45 @@ function parseFrontmatterDescription(raw: string): string | undefined {
   return desc ? desc : undefined;
 }
 
-function readSkillListEntry(
+async function readSkillListEntry(
   skillPath: string,
   name: string,
   scope: "project" | "custom" | "global",
-): SkillListEntry | null {
+): Promise<SkillListEntry | null> {
+  // Open once and reuse the fd so size/mtime/content all bind to
+  // the same inode — closes the exists→stat→read TOCTOU races.
+  const fd = await open(skillPath, "r");
   try {
-    // Open once and reuse the fd so size/mtime/content all bind to
-    // the same inode — closes the exists→stat→read TOCTOU races.
-    const fd = openSync(skillPath, "r");
-    let stat: ReturnType<typeof fstatSync>;
-    let raw: string;
-    try {
-      stat = fstatSync(fd);
-      if (!stat.isFile()) return null;
-      const buf = Buffer.alloc(stat.size);
-      let read = 0;
-      while (read < stat.size) {
-        const n = readSync(fd, buf, read, stat.size - read, read);
-        if (n <= 0) break;
-        read += n;
-      }
-      raw = buf.toString("utf8", 0, read);
-    } finally {
-      closeSync(fd);
-    }
+    const fileStat = await fd.stat();
+    if (!fileStat.isFile()) return null;
+    const raw = await fd.readFile("utf8");
     const item: SkillListEntry = {
       name,
       scope,
       path: skillPath,
-      size: stat.size,
-      mtime: stat.mtime.getTime(),
+      size: fileStat.size,
+      mtime: fileStat.mtime.getTime(),
     };
     const desc = parseFrontmatterDescription(raw);
     if (desc) item.description = desc;
     return item;
   } catch {
     return null;
+  } finally {
+    await fd.close();
   }
 }
 
-function resolveSkillPath(dir: string, name: string): ResolvedSkillPath | null {
+async function resolveSkillPath(dir: string, name: string): Promise<ResolvedSkillPath | null> {
   const folderPath = join(dir, name, SKILL_FILE);
   try {
-    if (statSync(folderPath).isFile()) return { path: folderPath, layout: "folder" };
+    if ((await stat(folderPath)).isFile()) return { path: folderPath, layout: "folder" };
   } catch {
     /* try flat layout below */
   }
   const flatPath = join(dir, `${name}.md`);
   try {
-    if (statSync(flatPath).isFile()) return { path: flatPath, layout: "flat" };
+    if ((await stat(flatPath)).isFile()) return { path: flatPath, layout: "flat" };
   } catch {
     /* not found */
   }
@@ -127,25 +104,25 @@ function defaultSkillPath(dir: string, name: string): ResolvedSkillPath {
   return { path: join(dir, name, SKILL_FILE), layout: "folder" };
 }
 
-function listSkills(dir: string, scope: "project" | "custom" | "global"): SkillListEntry[] {
-  if (!existsSync(dir)) return [];
+async function listSkills(dir: string, scope: "project" | "custom" | "global"): Promise<SkillListEntry[]> {
   const out: SkillListEntry[] = [];
   try {
-    for (const entry of readdirSync(dir, { withFileTypes: true })) {
-      let name: string;
-      let skillPath: string;
+    const entries = await readdir(dir, { withFileTypes: true });
+    const candidates: Array<{ skillPath: string; name: string }> = [];
+    for (const entry of entries) {
       if (entry.isDirectory()) {
-        name = entry.name;
-        if (!SAFE_NAME.test(name)) continue;
-        skillPath = join(dir, name, SKILL_FILE);
+        if (!SAFE_NAME.test(entry.name)) continue;
+        candidates.push({ skillPath: join(dir, entry.name, SKILL_FILE), name: entry.name });
       } else if (entry.isFile() && entry.name.endsWith(".md")) {
-        name = entry.name.slice(0, -3);
+        const name = entry.name.slice(0, -3);
         if (!SAFE_NAME.test(name)) continue;
-        skillPath = join(dir, entry.name);
-      } else {
-        continue;
+        candidates.push({ skillPath: join(dir, entry.name), name });
       }
-      const item = readSkillListEntry(skillPath, name, scope);
+    }
+    const items = await Promise.all(
+      candidates.map(({ skillPath, name }) => readSkillListEntry(skillPath, name, scope)),
+    );
+    for (const item of items) {
       if (item) out.push(item);
     }
   } catch {
@@ -187,9 +164,9 @@ export async function handleSkills(
     return {
       status: 200,
       body: {
-        global: tag(listSkills(globalSkillsDir(), "global")),
-        custom: tag(customRoots.flatMap((root) => listSkills(root.dir, "custom"))),
-        project: cwd ? tag(listSkills(projectSkillsDir(cwd), "project")) : [],
+        global: tag(await listSkills(globalSkillsDir(), "global")),
+        custom: tag((await Promise.all(customRoots.map((root) => listSkills(root.dir, "custom")))).flat()),
+        project: cwd ? tag(await listSkills(projectSkillsDir(cwd), "project")) : [],
         builtin: [
           {
             name: "explore",
@@ -237,13 +214,13 @@ export async function handleSkills(
   } else {
     dir = globalSkillsDir();
   }
-  const resolved = resolveSkillPath(dir, name);
+  const resolved = await resolveSkillPath(dir, name);
 
   if (method === "GET") {
     if (!resolved) return { status: 404, body: { error: "skill not found" } };
     return {
       status: 200,
-      body: { path: resolved.path, body: readFileSync(resolved.path, "utf8") },
+      body: { path: resolved.path, body: await readFile(resolved.path, "utf8") },
     };
   }
 
@@ -257,8 +234,8 @@ export async function handleSkills(
       return { status: 400, body: { error: fm.error } };
     }
     const target = resolved ?? defaultSkillPath(dir, name);
-    mkdirSync(dirname(target.path), { recursive: true });
-    writeFileSync(target.path, contents, "utf8");
+    await mkdir(dirname(target.path), { recursive: true });
+    await writeFile(target.path, contents, "utf8");
     ctx.audit?.({
       ts: Date.now(),
       action: "save-skill",
@@ -270,7 +247,7 @@ export async function handleSkills(
   if (method === "DELETE") {
     if (!resolved) return { status: 404, body: { error: "skill not found" } };
     // Folder-layout skills may carry assets next to SKILL.md; flat skills are single-file entries.
-    rmSync(resolved.layout === "folder" ? dirname(resolved.path) : resolved.path, {
+    await rm(resolved.layout === "folder" ? dirname(resolved.path) : resolved.path, {
       recursive: true,
       force: true,
     });

--- a/src/server/assets.ts
+++ b/src/server/assets.ts
@@ -118,7 +118,10 @@ async function loadCss(token: string): Promise<string> {
 }
 
 /** Token HTML-attribute-escaped in case a future mint produces non-hex bytes. */
-export async function renderIndexHtml(token: string, mode: "standalone" | "attached"): Promise<string> {
+export async function renderIndexHtml(
+  token: string,
+  mode: "standalone" | "attached",
+): Promise<string> {
   const tpl = await loadIndexTemplate();
   const safeToken = token.replace(/[^a-zA-Z0-9]/g, "");
   // String.replace(string, replacement) only swaps the FIRST match. The
@@ -172,7 +175,9 @@ function isBinaryAsset(name: string): boolean {
   return false;
 }
 
-async function loadDistFile(name: string): Promise<{ body: string | Buffer; isBinary: boolean } | null> {
+async function loadDistFile(
+  name: string,
+): Promise<{ body: string | Buffer; isBinary: boolean } | null> {
   const paths = [join(ASSET_DIR, "dist", "assets", name), join(ASSET_DIR, "dist", name)];
   const binary = isBinaryAsset(name);
   for (const p of paths) {

--- a/src/server/assets.ts
+++ b/src/server/assets.ts
@@ -1,4 +1,5 @@
-import { closeSync, fstatSync, openSync, readFileSync, readSync } from "node:fs";
+import { readFileSync } from "node:fs";
+import { open } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -35,48 +36,35 @@ const textCache = new Map<string, { body: string; mtimeMs: number }>();
 /** mtime-keyed cache for binary files (fonts, images). */
 const binaryCache = new Map<string, { body: Buffer; mtimeMs: number }>();
 
-function loadCachedText(path: string): string {
-  const fd = openSync(path, "r");
+async function loadCachedText(path: string): Promise<string> {
+  const fd = await open(path, "r");
   try {
-    const stat = fstatSync(fd);
+    const fileStat = await fd.stat();
     const cached = textCache.get(path);
-    if (cached && cached.mtimeMs === stat.mtimeMs) return cached.body;
-    const buf = Buffer.alloc(stat.size);
-    let read = 0;
-    while (read < stat.size) {
-      const n = readSync(fd, buf, read, stat.size - read, read);
-      if (n <= 0) break;
-      read += n;
-    }
-    const body = buf.toString("utf8", 0, read);
-    textCache.set(path, { body, mtimeMs: stat.mtimeMs });
+    if (cached && cached.mtimeMs === fileStat.mtimeMs) return cached.body;
+    const body = await fd.readFile("utf8");
+    textCache.set(path, { body, mtimeMs: fileStat.mtimeMs });
     return body;
   } finally {
-    closeSync(fd);
+    await fd.close();
   }
 }
 
-function loadCachedBinary(path: string): Buffer {
-  const fd = openSync(path, "r");
+async function loadCachedBinary(path: string): Promise<Buffer> {
+  const fd = await open(path, "r");
   try {
-    const stat = fstatSync(fd);
+    const fileStat = await fd.stat();
     const cached = binaryCache.get(path);
-    if (cached && cached.mtimeMs === stat.mtimeMs) return cached.body;
-    const buf = Buffer.alloc(stat.size);
-    let read = 0;
-    while (read < stat.size) {
-      const n = readSync(fd, buf, read, stat.size - read, read);
-      if (n <= 0) break;
-      read += n;
-    }
-    binaryCache.set(path, { body: buf.slice(0, read), mtimeMs: stat.mtimeMs });
-    return buf.slice(0, read);
+    if (cached && cached.mtimeMs === fileStat.mtimeMs) return cached.body;
+    const body = Buffer.from(await fd.readFile());
+    binaryCache.set(path, { body, mtimeMs: fileStat.mtimeMs });
+    return body;
   } finally {
-    closeSync(fd);
+    await fd.close();
   }
 }
 
-function loadIndexTemplate(): string {
+async function loadIndexTemplate(): Promise<string> {
   return loadCachedText(join(ASSET_DIR, "index.html"));
 }
 
@@ -96,21 +84,21 @@ function injectTokenIntoCssAssetUrls(body: string, token: string): string {
   );
 }
 
-function loadApp(token: string): string {
-  const raw = loadCachedText(join(ASSET_DIR, "dist", "app.js"));
+async function loadApp(token: string): Promise<string> {
+  const raw = await loadCachedText(join(ASSET_DIR, "dist", "app.js"));
   return injectTokenIntoChunkImports(raw, token);
 }
 
-function loadChunk(name: string, token: string): string | null {
+async function loadChunk(name: string, token: string): Promise<string | null> {
   try {
-    const raw = loadCachedText(join(ASSET_DIR, "dist", name));
+    const raw = await loadCachedText(join(ASSET_DIR, "dist", name));
     return injectTokenIntoChunkImports(raw, token);
   } catch {
     return null;
   }
 }
 
-function loadAppMap(): string | null {
+async function loadAppMap(): Promise<string | null> {
   try {
     return loadCachedText(join(ASSET_DIR, "dist", "app.js.map"));
   } catch {
@@ -118,20 +106,20 @@ function loadAppMap(): string | null {
   }
 }
 
-function loadCss(token: string): string {
+async function loadCss(token: string): Promise<string> {
   // Try new React dashboard first, then fall back to old Preact
   let raw: string;
   try {
-    raw = loadCachedText(join(ASSET_DIR, "dist", "app.css"));
+    raw = await loadCachedText(join(ASSET_DIR, "dist", "app.css"));
   } catch {
-    raw = loadCachedText(join(ASSET_DIR, "app.css"));
+    raw = await loadCachedText(join(ASSET_DIR, "app.css"));
   }
   return injectTokenIntoCssAssetUrls(raw, token);
 }
 
 /** Token HTML-attribute-escaped in case a future mint produces non-hex bytes. */
-export function renderIndexHtml(token: string, mode: "standalone" | "attached"): string {
-  const tpl = loadIndexTemplate();
+export async function renderIndexHtml(token: string, mode: "standalone" | "attached"): Promise<string> {
+  const tpl = await loadIndexTemplate();
   const safeToken = token.replace(/[^a-zA-Z0-9]/g, "");
   // String.replace(string, replacement) only swaps the FIRST match. The
   // template has __REASONIX_TOKEN__ in three places (meta + css href +
@@ -145,9 +133,9 @@ export function renderIndexHtml(token: string, mode: "standalone" | "attached"):
 /** Vendor CSS the bundle pulls from npm and the build script copies into `dashboard/dist/`. */
 const VENDOR_CSS_NAMES = new Set(["vendor-hljs.css", "vendor-uplot.css"]);
 
-function loadVendorCss(name: string, token: string): string | null {
+async function loadVendorCss(name: string, token: string): Promise<string | null> {
   try {
-    return injectTokenIntoCssAssetUrls(loadCachedText(join(ASSET_DIR, "dist", name)), token);
+    return injectTokenIntoCssAssetUrls(await loadCachedText(join(ASSET_DIR, "dist", name)), token);
   } catch {
     return null;
   }
@@ -184,13 +172,13 @@ function isBinaryAsset(name: string): boolean {
   return false;
 }
 
-function loadDistFile(name: string): { body: string | Buffer; isBinary: boolean } | null {
+async function loadDistFile(name: string): Promise<{ body: string | Buffer; isBinary: boolean } | null> {
   const paths = [join(ASSET_DIR, "dist", "assets", name), join(ASSET_DIR, "dist", name)];
   const binary = isBinaryAsset(name);
   for (const p of paths) {
     try {
       return {
-        body: binary ? loadCachedBinary(p) : loadCachedText(p),
+        body: binary ? await loadCachedBinary(p) : await loadCachedText(p),
         isBinary: binary,
       };
     } catch {
@@ -200,35 +188,35 @@ function loadDistFile(name: string): { body: string | Buffer; isBinary: boolean 
   return null;
 }
 
-export function serveAsset(
+export async function serveAsset(
   name: string,
   token = "",
-): { body: string | Buffer; contentType: string } | null {
+): Promise<{ body: string | Buffer; contentType: string } | null> {
   if (name === "app.js") {
-    return { body: loadApp(token), contentType: "application/javascript; charset=utf-8" };
+    return { body: await loadApp(token), contentType: "application/javascript; charset=utf-8" };
   }
   if (name === "app.js.map") {
-    const body = loadAppMap();
+    const body = await loadAppMap();
     return body == null ? null : { body, contentType: "application/json; charset=utf-8" };
   }
   if (name === "app.css") {
-    return { body: loadCss(token), contentType: "text/css; charset=utf-8" };
+    return { body: await loadCss(token), contentType: "text/css; charset=utf-8" };
   }
   // Same rewrite for chunk-to-chunk imports (e.g. vendor-markdown → vendor-react).
   if (/^vendor-[\w.-]+\.js$/.test(name)) {
-    const body = loadChunk(name, token);
+    const body = await loadChunk(name, token);
     if (body == null) return null;
     return { body, contentType: "application/javascript; charset=utf-8" };
   }
   if (VENDOR_CSS_NAMES.has(name)) {
-    const body = loadVendorCss(name, token);
+    const body = await loadVendorCss(name, token);
     if (body == null) return null;
     return { body, contentType: "text/css; charset=utf-8" };
   }
   // 通用静态文件：字体、图片等
   const mt = mimetypeFor(name);
   if (mt) {
-    const result = loadDistFile(name);
+    const result = await loadDistFile(name);
     if (result != null) return { body: result.body, contentType: mt };
   }
   return null;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -128,7 +128,7 @@ export async function dispatch(
       res.end("unauthorized — open the URL printed by /dashboard, including ?token=…");
       return;
     }
-    const html = renderIndexHtml(expectedToken, ctx.mode);
+    const html = await renderIndexHtml(expectedToken, ctx.mode);
     res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
     res.end(html);
     return;
@@ -141,7 +141,7 @@ export async function dispatch(
       res.end();
       return;
     }
-    const asset = serveAsset(path.slice("/assets/".length), expectedToken);
+    const asset = await serveAsset(path.slice("/assets/".length), expectedToken);
     if (!asset) {
       res.writeHead(404);
       res.end("not found");

--- a/tests/dashboard-smoke.test.ts
+++ b/tests/dashboard-smoke.test.ts
@@ -45,7 +45,7 @@ describe("dashboard build artifacts", () => {
 describe("dashboard server integration", () => {
   it("assets.ts resolveAssetDir finds dashboard", async () => {
     const { serveAsset } = await import("../src/server/assets.js");
-    const appJs = serveAsset("app.js");
+    const appJs = await serveAsset("app.js");
     expect(appJs).not.toBeNull();
     expect(appJs?.contentType).toMatch(/javascript/);
   });
@@ -53,7 +53,7 @@ describe("dashboard server integration", () => {
   it("renderIndexHtml replaces all token placeholders", async () => {
     const { renderIndexHtml } = await import("../src/server/assets.js");
     // Token is sanitized to alphanumeric only
-    const html = renderIndexHtml("test-token-123", "standalone");
+    const html = await renderIndexHtml("test-token-123", "standalone");
     expect(html).not.toContain("__REASONIX_TOKEN__");
     expect(html).not.toContain("__REASONIX_MODE__");
     expect(html).toContain("testtoken123"); // sanitized
@@ -62,7 +62,7 @@ describe("dashboard server integration", () => {
 
   it("serveAsset rewrites cross-chunk imports in app.js to carry the token", async () => {
     const { serveAsset } = await import("../src/server/assets.js");
-    const asset = serveAsset("app.js", "tkn123");
+    const asset = await serveAsset("app.js", "tkn123");
     expect(asset).not.toBeNull();
     const body = asset?.body as string;
     // Vendor chunks must be reachable; browsers strip query strings on relative
@@ -77,7 +77,7 @@ describe("dashboard server integration", () => {
   it("serveAsset rewrites cross-chunk imports inside vendor chunks too", async () => {
     const { serveAsset } = await import("../src/server/assets.js");
     // vendor-markdown imports vendor-react and vendor-katex — also relative.
-    const asset = serveAsset("vendor-markdown.js", "tkn456");
+    const asset = await serveAsset("vendor-markdown.js", "tkn456");
     if (asset == null) return; // not a build with that chunk; ignore
     const body = asset.body as string;
     const vendorImports = body.match(/from\s*["']\.\/vendor-[\w-]+\.js[^"']*["']/g) ?? [];
@@ -88,7 +88,7 @@ describe("dashboard server integration", () => {
 
   it("serveAsset injects the token into CSS url() font references", async () => {
     const { serveAsset } = await import("../src/server/assets.js");
-    const asset = serveAsset("app.css", "tknfont");
+    const asset = await serveAsset("app.css", "tknfont");
     expect(asset).not.toBeNull();
     const body = asset?.body as string;
     // CSS-context `url()` strips the parent stylesheet's query string when the
@@ -103,8 +103,8 @@ describe("dashboard server integration", () => {
 
   it("vendor CSS files are served when present", async () => {
     const { serveAsset } = await import("../src/server/assets.js");
-    const hljs = serveAsset("vendor-hljs.css");
-    const uplot = serveAsset("vendor-uplot.css");
+    const hljs = await serveAsset("vendor-hljs.css");
+    const uplot = await serveAsset("vendor-uplot.css");
     // These may be null if copy-dashboard-vendor-css.mjs hasn't run
     if (hljs) {
       expect(hljs.contentType).toMatch(/css/);


### PR DESCRIPTION
## Summary

- Replace blocking `readFileSync`/`writeFileSync`/`readdirSync`/`statSync`/`existsSync` with non-blocking `readFile`/`writeFile`/`readdir`/`stat` from `node:fs/promises` in all server API handlers and session memory module
- Add async variants of key `session.ts` functions (`listSessionsAsync`, `deleteSessionAsync`, `loadSessionMessagesAsync`, `readTailMessagesAsync`, `appendSessionMessageAsync`, `rewriteSessionAsync`, `renameSessionAsync`, `archiveSessionAsync`, `listSessionsForWorkspaceAsync`, `pruneStaleSessionsAsync`, `patchSessionMetaAsync`, `loadSessionMetaAsync`, `findSessionsByPrefixAsync`)
- Add async `atomicWrite` alongside existing sync `atomicWriteSync` in `atomic-write.ts`
- Server API callers (`health.ts`, `sessions.ts`) updated to use async session functions

## Files changed (13)

| File | Change |
|------|--------|
| `src/core/atomic-write.ts` | Added async `atomicWrite()` function |
| `src/memory/session.ts` | Added 14 async function variants + async fs imports |
| `src/server/api/browse.ts` | Async `listWindowsDrives`, `readSubdirs`, handler |
| `src/server/api/checkpoint-diffs.ts` | `readFileSync` → `await readFile` |
| `src/server/api/files.ts` | Async `walk()` with `readdir`/`stat` |
| `src/server/api/health.ts` | Async `dirSize()`, parallel `Promise.all`, `listSessionsAsync` |
| `src/server/api/hooks.ts` | Async `readSettingsFile`/`writeSettingsFile` |
| `src/server/api/memory.ts` | Async `listMemoryFiles`, all handler ops |
| `src/server/api/project-tree.ts` | Async `buildTree`/`walk` with `readdir`/`stat` |
| `src/server/api/sessions.ts` | Async `parseTranscript`, `listSessionsAsync`, `deleteSessionAsync` |
| `src/server/api/skills.ts` | Async `readSkillListEntry`, `resolveSkillPath`, `listSkills` |
| `src/server/assets.ts` | Async cached reads; `resolveAssetDir` stays sync (module load) |
| `src/server/index.ts` | `await renderIndexHtml`/`serveAsset` in `dispatch()` |

## Motivation

The server API handlers were already `async` but called sync fs functions internally, blocking the event loop on every request. With concurrent dashboard requests (SSE stream + API calls + asset fetches), this creates unnecessary serialization. Converting to async I/O allows the server to serve other requests while waiting on disk.

The sync variants in `session.ts` are preserved — the TUI and prompt-building layers still use them and their callers aren't async. The new `*Async` variants are opt-in for server-side callers.

## Test plan

- [ ] `npm run build` passes
- [ ] Dashboard loads and renders correctly
- [ ] Session list loads in dashboard sidebar
- [ ] Session delete works from dashboard
- [ ] Skill editor loads and saves
- [ ] Memory editor loads and saves
- [ ] Health endpoint returns valid JSON
- [ ] File picker (@-mention) returns results

🤖 Generated with [Claude Code](https://claude.com/claude-code)