### PR TITLE
feat(i18n): add Russian (ru) locale to desktop and dashboard

### DIFF
--- a/dashboard/src/i18n/index.ts
+++ b/dashboard/src/i18n/index.ts
@@ -2,17 +2,19 @@ import { useEffect, useState } from "react";
 import { de } from "./de";
 import { en } from "./en";
 import { ja } from "./ja";
+import { ru } from "./ru";
 import { zhCN } from "./zh-CN";
 
-export type Lang = "en" | "zh-CN" | "de" | "ja";
+export type Lang = "en" | "zh-CN" | "de" | "ja" | "ru";
 
-const SUPPORTED_LANGS: readonly Lang[] = ["en", "zh-CN", "de", "ja"];
+const SUPPORTED_LANGS: readonly Lang[] = ["en", "zh-CN", "de", "ja", "ru"];
 const SUPPORTED: ReadonlySet<Lang> = new Set<Lang>(SUPPORTED_LANGS);
 const LANG_LABELS: Record<Lang, string> = {
   en: "English",
   "zh-CN": "简体中文",
   de: "Deutsch",
   ja: "日本語",
+  ru: "Русский",
 };
 const STORAGE_KEY = "reasonix.lang";
 
@@ -31,6 +33,7 @@ function detectDefault(): Lang {
   if (lower.startsWith("zh")) return "zh-CN";
   if (lower.startsWith("de")) return "de";
   if (lower.startsWith("ja")) return "ja";
+  if (lower.startsWith("ru")) return "ru";
   return "en";
 }
 
@@ -84,7 +87,7 @@ export function useLang(): Lang {
   return currentLang;
 }
 
-const dicts = { en, "zh-CN": zhCN, de, ja } as const;
+const dicts = { en, "zh-CN": zhCN, de, ja, ru } as const;
 
 type Dict = typeof en;
 type Path<T, K extends keyof T = keyof T> = K extends string

--- a/dashboard/src/i18n/ru.ts
+++ b/dashboard/src/i18n/ru.ts
@@ -1,0 +1,5 @@
+import { en } from "./en";
+
+export const ru: typeof en = {
+  ...en,
+};

--- a/desktop/src/i18n/index.ts
+++ b/desktop/src/i18n/index.ts
@@ -2,17 +2,19 @@ import { useEffect, useState } from "react";
 import { de } from "./de";
 import { en } from "./en";
 import { ja } from "./ja";
+import { ru } from "./ru";
 import { zhCN } from "./zh-CN";
 
-export type Lang = "en" | "zh-CN" | "de" | "ja";
+export type Lang = "en" | "zh-CN" | "de" | "ja" | "ru";
 
-const SUPPORTED_LANGS: readonly Lang[] = ["en", "zh-CN", "de", "ja"];
+const SUPPORTED_LANGS: readonly Lang[] = ["en", "zh-CN", "de", "ja", "ru"];
 const SUPPORTED: ReadonlySet<Lang> = new Set<Lang>(SUPPORTED_LANGS);
 const LANG_LABELS: Record<Lang, string> = {
   en: "English",
   "zh-CN": "简体中文",
   de: "Deutsch",
   ja: "日本語",
+  ru: "Русский",
 };
 const STORAGE_KEY = "reasonix.lang";
 
@@ -31,6 +33,7 @@ function detectDefault(): Lang {
   if (lower.startsWith("zh")) return "zh-CN";
   if (lower.startsWith("de")) return "de";
   if (lower.startsWith("ja")) return "ja";
+  if (lower.startsWith("ru")) return "ru";
   return "en";
 }
 
@@ -84,7 +87,7 @@ export function useLang(): Lang {
   return currentLang;
 }
 
-const dicts = { en, "zh-CN": zhCN, de, ja } as const;
+const dicts = { en, "zh-CN": zhCN, de, ja, ru } as const;
 
 type Dict = typeof en;
 type Path<T, K extends keyof T = keyof T> = K extends string

--- a/desktop/src/i18n/ru.ts
+++ b/desktop/src/i18n/ru.ts
@@ -1,0 +1,5 @@
+import { en } from "./en";
+
+export const ru: typeof en = {
+  ...en,
+};


### PR DESCRIPTION
## Summary

- Add Russian (`ru`) locale skeleton to desktop and dashboard i18n layers
- The `ru.ts` files import from `en` and spread `...en` so all keys fall back to English until translations are added
- Register `"ru"` in `SUPPORTED_LANGS`, `LANG_LABELS`, `detectDefault`, and `dicts` in both `index.ts` files
- Auto-detect Russian system locale via `navigator.language.startsWith("ru")`

## Files changed (4)

| File | Change |
|------|--------|
| `desktop/src/i18n/ru.ts` | New file — `export const ru: typeof en = { ...en }` |
| `desktop/src/i18n/index.ts` | Register `ru` locale with label "Русский" |
| `dashboard/src/i18n/ru.ts` | New file — `export const ru: typeof en = { ...en }` |
| `dashboard/src/i18n/index.ts` | Register `ru` locale with label "Русский" |

## Motivation

Russian is a widely-used language among the project's user base. Adding the skeleton with English fallback ensures the UI is immediately usable for Russian-speaking users, and community contributors can incrementally translate individual keys without breaking anything.

## Test plan

- [ ] Desktop: switch to Russian locale, verify UI renders in English (fallback)
- [ ] Dashboard: switch to Russian locale, verify UI renders in English (fallback)
- [ ] Verify system locale auto-detection sets Russian when `navigator.language` starts with `"ru"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)