### PR TITLE
fix(telegram): bind callback confirmations

### DIFF
--- a/docs/telegram-connect.md
+++ b/docs/telegram-connect.md
@@ -1,0 +1,183 @@
+# Telegram channel setup
+
+Reasonix can attach Telegram to an existing `chat` or `code` session as a remote channel. Telegram is not a third runtime mode.
+
+Once connected, Telegram can:
+
+- send normal user messages into the active session
+- receive follow-up assistant replies with Telegram Markdown rendering
+- continue confirmation, choice, checkpoint, and plan-style follow-up interactions with inline buttons
+- expose Reasonix slash commands through the Telegram bot command menu
+
+## Before you start
+
+Prepare these first:
+
+- a recent Reasonix release that already includes Telegram support
+- a Telegram account
+- a Telegram bot token from BotFather
+- the numeric Telegram user id that should be allowed to drive Reasonix
+
+Important:
+
+- Telegram is fail-closed: the channel refuses to start until `telegram.ownerUserId` or `telegram.allowlist` is configured
+- keep the bot token private
+- only allow Telegram users you trust to run a code-driving bot
+
+## Get your Telegram bot token
+
+The BotFather UI may change, but the flow is usually:
+
+1. Open Telegram and start a chat with `@BotFather`.
+2. Send `/newbot`.
+3. Follow the prompts for bot name and username.
+4. Copy the bot token BotFather returns.
+
+## Get your Telegram user id
+
+Reasonix access control uses Telegram's numeric user id, not the `@username`.
+
+Common ways to get it:
+
+- send a message to a helper bot such as `@userinfobot`
+- use Telegram's `getUpdates` API after messaging your bot once
+- read it from your own trusted bot tooling
+
+Save this value as `telegram.ownerUserId` or include it in `telegram.allowlist`.
+
+## Connect from the CLI
+
+Start a session first:
+
+~~~bash
+reasonix code
+# or
+reasonix chat
+~~~
+
+Configure access control before connecting. For example, edit `~/.reasonix/config.json`:
+
+~~~json
+{
+  "telegram": {
+    "ownerUserId": "123456789"
+  }
+}
+~~~
+
+Then run:
+
+~~~text
+/telegram connect
+~~~
+
+First-time behavior:
+
+1. Reasonix asks for the Telegram bot token in the current TUI.
+2. Enter `/cancel` to abort.
+3. Reasonix saves the token and enables Telegram auto-start after a successful connection.
+
+If a token is already saved, `/telegram connect` reuses it directly.
+
+You can also pass the token inline:
+
+~~~text
+/telegram connect <botToken>
+~~~
+
+Other Telegram commands:
+
+- `/telegram status`
+- `/telegram disconnect`
+
+After the first successful connection, later `chat` and `code` sessions auto-start the Telegram channel while it stays enabled.
+
+## Environment variables
+
+You can also configure Telegram through environment variables:
+
+~~~bash
+TELEGRAM_BOT_TOKEN=123456:botfather-token
+TELEGRAM_OWNER_USER_ID=123456789
+TELEGRAM_ALLOWLIST=123456789,987654321
+~~~
+
+Environment values override the saved config for token and access checks. `TELEGRAM_ALLOWLIST` accepts comma- or whitespace-separated ids.
+
+## Typical usage
+
+1. Start `reasonix code` or `reasonix chat`.
+2. Configure `telegram.ownerUserId` or `telegram.allowlist`.
+3. Complete `/telegram connect` once.
+4. Send a message to your Telegram bot.
+5. Let the local Reasonix session keep running.
+6. Continue replies, approvals, and follow-up interactions from Telegram when needed.
+
+Telegram extends the current session. It does not replace `chat` or `code`.
+
+## Security notes
+
+- Access is fail-closed. With no owner or allowlist, the channel does not start.
+- Unauthorized senders and button presses are ignored.
+- Confirmation buttons are bound to the current Telegram confirmation message, so stale buttons from older confirmations cannot approve newer requests.
+- Authorized users are rate-limited before their messages reach the agent prompt path.
+
+## Troubleshooting
+
+### `/telegram connect` fails with an access control error
+
+Configure at least one allowed Telegram user:
+
+~~~json
+{
+  "telegram": {
+    "ownerUserId": "123456789"
+  }
+}
+~~~
+
+or:
+
+~~~json
+{
+  "telegram": {
+    "allowlist": ["123456789", "987654321"]
+  }
+}
+~~~
+
+Then reconnect:
+
+~~~text
+/telegram connect
+~~~
+
+### `/telegram connect` fails with a token error
+
+Check these first:
+
+- the token was copied exactly from BotFather
+- there are no extra spaces or shell quoting mistakes
+- the bot has not been deleted or regenerated in BotFather
+
+If needed, reconnect with an explicit token:
+
+~~~text
+/telegram connect <botToken>
+~~~
+
+### Telegram receives the message, but no reply comes back
+
+Check that the local Reasonix session is still running and the channel is still connected:
+
+~~~text
+/telegram status
+~~~
+
+### Telegram says another poller is active
+
+Only one long-polling process can run for a Telegram bot at a time. Stop the other Reasonix process or any other bot process using the same token, then reconnect.
+
+### `/telegram` commands do not exist in your installed package
+
+Your installed npm version is too old. Upgrade to a release that already includes Telegram support, or use the current repository `main` branch.

--- a/docs/telegram-connect.zh-CN.md
+++ b/docs/telegram-connect.zh-CN.md
@@ -1,0 +1,183 @@
+# Telegram 连接指南
+
+Reasonix 可以把现有的 `chat` 或 `code` 会话延伸到 Telegram 上，作为远程通道使用。Telegram 扩展的是当前会话，不是独立的新运行模式。
+
+连接成功后，Telegram 可以：
+
+- 把普通消息送进当前会话
+- 接收支持 Telegram Markdown 渲染的助手回复
+- 用内联按钮继续确认、选择、checkpoint、plan 这类二次交互
+- 把 Reasonix slash 命令注册成 Telegram bot command
+
+## 开始前先准备
+
+请先确认：
+
+- 使用的是已经包含 Telegram 支持的较新 Reasonix 版本
+- 已经有 Telegram 账号
+- 已经从 BotFather 拿到 Telegram bot token
+- 已经知道允许驱动 Reasonix 的 Telegram 数字用户 id
+
+注意：
+
+- Telegram 默认 fail-closed：没有配置 `telegram.ownerUserId` 或 `telegram.allowlist` 时，通道会拒绝启动
+- bot token 要妥善保管，不要公开
+- 只允许你信任的 Telegram 用户驱动这个代码执行 bot
+
+## 获取 Telegram bot token
+
+BotFather 的界面可能会变化，但通常流程是：
+
+1. 在 Telegram 中打开 `@BotFather`
+2. 发送 `/newbot`
+3. 按提示填写 bot 名称和 username
+4. 复制 BotFather 返回的 bot token
+
+## 获取 Telegram 用户 id
+
+Reasonix 的访问控制使用 Telegram 数字用户 id，不使用 `@username`。
+
+常见获取方式：
+
+- 给 `@userinfobot` 这类辅助 bot 发消息查看
+- 给自己的 bot 发一条消息后，通过 Telegram `getUpdates` API 查看
+- 从你信任的自有 bot 工具里读取
+
+请把这个 id 保存为 `telegram.ownerUserId`，或加入 `telegram.allowlist`。
+
+## 在 CLI 里连接
+
+先启动一个会话：
+
+~~~bash
+reasonix code
+# 或
+reasonix chat
+~~~
+
+连接前先配置访问控制。例如编辑 `~/.reasonix/config.json`：
+
+~~~json
+{
+  "telegram": {
+    "ownerUserId": "123456789"
+  }
+}
+~~~
+
+然后运行：
+
+~~~text
+/telegram connect
+~~~
+
+首次连接时会这样引导：
+
+1. 在当前 TUI 里提示你输入 Telegram bot token
+2. 输入 `/cancel` 可以取消
+3. 连接成功后，Reasonix 会保存 token 并启用后续自动启动
+
+如果本地已经保存过 token，`/telegram connect` 会直接复用。
+
+也可以直接一次性传参：
+
+~~~text
+/telegram connect <botToken>
+~~~
+
+其他相关命令：
+
+- `/telegram status`
+- `/telegram disconnect`
+
+第一次连接成功后，只要 Telegram 保持启用，后续 `chat` 和 `code` 会话都会自动启动 Telegram 通道。
+
+## 环境变量
+
+也可以用环境变量配置 Telegram：
+
+~~~bash
+TELEGRAM_BOT_TOKEN=123456:botfather-token
+TELEGRAM_OWNER_USER_ID=123456789
+TELEGRAM_ALLOWLIST=123456789,987654321
+~~~
+
+环境变量会覆盖本地保存的 token 和访问控制配置。`TELEGRAM_ALLOWLIST` 支持用逗号或空白分隔多个 id。
+
+## 典型使用方式
+
+1. 启动 `reasonix code` 或 `reasonix chat`
+2. 配置 `telegram.ownerUserId` 或 `telegram.allowlist`
+3. 完成一次 `/telegram connect`
+4. 从 Telegram 给 bot 发一条消息
+5. 本地 Reasonix 会话继续运行
+6. 需要时直接在 Telegram 里继续回复、确认或选择
+
+Telegram 只是扩展当前会话，不替代 `chat` 或 `code`。
+
+## 安全说明
+
+- 访问控制默认 fail-closed；没有 owner 或 allowlist 时通道不会启动。
+- 未授权用户的消息和按钮点击都会被忽略。
+- 确认按钮会绑定到当前 Telegram 确认消息，旧确认里的按钮不能批准新的请求。
+- 授权用户的消息在进入 agent prompt 路径前会被限流。
+
+## 排障
+
+### `/telegram connect` 报访问控制错误
+
+至少配置一个允许访问的 Telegram 用户：
+
+~~~json
+{
+  "telegram": {
+    "ownerUserId": "123456789"
+  }
+}
+~~~
+
+或者：
+
+~~~json
+{
+  "telegram": {
+    "allowlist": ["123456789", "987654321"]
+  }
+}
+~~~
+
+然后重新连接：
+
+~~~text
+/telegram connect
+~~~
+
+### `/telegram connect` 报 token 错误
+
+优先检查：
+
+- token 是否完整复制自 BotFather
+- 是否多了空格或 shell 引号问题
+- BotFather 里这个 bot 是否已删除或重新生成 token
+
+必要时可以直接显式传参重试：
+
+~~~text
+/telegram connect <botToken>
+~~~
+
+### Telegram 能收到消息，但没有后续回复
+
+先确认本地 Reasonix 会话还在运行，而且 Telegram 通道仍然在线：
+
+~~~text
+/telegram status
+~~~
+
+### Telegram 提示已有另一个 poller
+
+同一个 Telegram bot 同一时间只能有一个 long-polling 进程。请停止其他使用同一个 token 的 Reasonix 进程或 bot 进程，然后重新连接。
+
+### 已安装的 npm 版本里没有 `/telegram` 命令
+
+说明本地包版本太旧。请升级到已经包含 Telegram 支持的发行版，或者直接使用仓库最新 `main` 分支。

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -179,9 +179,9 @@ export class TelegramBot extends EventEmitter {
     replyToMessageId?: number,
     parseMode?: TelegramParseMode,
     buttons?: TelegramInlineButton[][],
-  ): Promise<void> {
+  ): Promise<number | undefined> {
     try {
-      await this.bot.api.sendMessage(chatId, text, {
+      const message = await this.bot.api.sendMessage(chatId, text, {
         link_preview_options: { is_disabled: true },
         parse_mode: parseMode,
         reply_parameters: replyToMessageId ? { message_id: replyToMessageId } : undefined,
@@ -196,6 +196,7 @@ export class TelegramBot extends EventEmitter {
             }
           : undefined,
       });
+      return message.message_id;
     } catch (err) {
       throw new Error(formatTelegramBotError(err, this.token, "Telegram sendMessage"));
     }

--- a/src/telegram/channel.ts
+++ b/src/telegram/channel.ts
@@ -245,6 +245,7 @@ export class TelegramChannel {
   private processedUpdateIdQueue: string[] = [];
   private userMessageTimestamps = new Map<string, number[]>();
   private rateLimitNoticeAt = new Map<string, number>();
+  private activeCallbackMessageId: number | null = null;
   private lockAcquired = false;
   private markdownDisabled = false;
 
@@ -398,9 +399,19 @@ export class TelegramChannel {
 
     const userId = String(query.from.id);
     if (!this.acceptRemoteInput(userId)) return;
+    if (
+      this.activeCallbackMessageId === null ||
+      query.message.message_id !== this.activeCallbackMessageId
+    ) {
+      this.callbacks.onError?.(
+        "Telegram ignored stale callback from an older confirmation message.",
+      );
+      return;
+    }
 
     this.chatId = query.message.chat.id;
     this.messageId = query.message.message_id;
+    this.activeCallbackMessageId = null;
     this.callbacks.onSubmitMessage(`[TG] ${text}`);
   }
 
@@ -466,16 +477,18 @@ export class TelegramChannel {
     for (let index = 0; index < chunks.length; index++) {
       const chunk = chunks[index];
       if (!chunk) continue;
+      const chunkButtons = index === chunks.length - 1 ? buttons : undefined;
       try {
         if (!this.markdownDisabled) {
           try {
-            await this.bot.sendMessage(
+            const sentMessageId = await this.bot.sendMessage(
               this.chatId,
               chunk,
               this.messageId ?? undefined,
               "MarkdownV2",
-              index === chunks.length - 1 ? buttons : undefined,
+              chunkButtons,
             );
+            if (chunkButtons) this.activeCallbackMessageId = sentMessageId ?? null;
             continue;
           } catch (err) {
             this.markdownDisabled = true;
@@ -485,13 +498,14 @@ export class TelegramChannel {
           }
         }
 
-        await this.bot.sendMessage(
+        const sentMessageId = await this.bot.sendMessage(
           this.chatId,
           chunk,
           this.messageId ?? undefined,
           undefined,
-          index === chunks.length - 1 ? buttons : undefined,
+          chunkButtons,
         );
+        if (chunkButtons) this.activeCallbackMessageId = sentMessageId ?? null;
       } catch (err) {
         this.callbacks.onError?.(
           `Telegram sendResponse chunk ${index + 1}/${chunks.length} failed: ${(err as Error).message}`,

--- a/src/telegram/use-telegram-channel.ts
+++ b/src/telegram/use-telegram-channel.ts
@@ -39,6 +39,7 @@ type TelegramSlashInteractionKind =
 interface TelegramInteractionState {
   kind: TelegramInteractionKind | null;
   payload: unknown;
+  confirmationId: string | null;
 }
 
 interface TelegramSlashInteractionState {
@@ -172,6 +173,18 @@ function stripFollowupPrefix(text: string): string {
     .trim();
 }
 
+function telegramCallbackData(confirmationId: string, choice: string): string {
+  return `tg:${confirmationId}:${choice}`;
+}
+
+function parseTelegramCallbackData(
+  text: string,
+): { confirmationId: string; choice: string } | null {
+  const match = /^tg:([A-Za-z0-9_-]+):(.+)$/.exec(text);
+  if (!match) return null;
+  return { confirmationId: match[1] ?? "", choice: match[2] ?? "" };
+}
+
 export function useTelegramChannel({
   codeMode,
   initialChannel,
@@ -201,12 +214,14 @@ export function useTelegramChannel({
   const interactionRef = useRef<TelegramInteractionState>({
     kind: null,
     payload: null,
+    confirmationId: null,
   });
   const slashInteractionRef = useRef<TelegramSlashInteractionState>({
     kind: null,
     payload: null,
   });
   const replyThisTurnRef = useRef(false);
+  const nextConfirmationIdRef = useRef(0);
   const pendingConnectSetupRef = useRef<PendingTelegramConnectSetup | null>(null);
 
   const sendText = useCallback(
@@ -409,7 +424,7 @@ export function useTelegramChannel({
   }, [codeMode]);
 
   const resetInteractions = useCallback(() => {
-    interactionRef.current = { kind: null, payload: null };
+    interactionRef.current = { kind: null, payload: null, confirmationId: null };
     slashInteractionRef.current = { kind: null, payload: null };
     replyThisTurnRef.current = false;
   }, []);
@@ -594,23 +609,35 @@ export function useTelegramChannel({
 
   const consumePauseReply = useCallback(
     (text: string): boolean => {
-      if (interactionRef.current.kind === null || pendingGateIdRef.current === null) return false;
+      const callback = parseTelegramCallbackData(text);
+      if (interactionRef.current.kind === null || pendingGateIdRef.current === null) {
+        if (callback) {
+          sendText("That Telegram confirmation has expired.");
+          return true;
+        }
+        return false;
+      }
+      if (callback && callback.confirmationId !== interactionRef.current.confirmationId) {
+        sendText("That Telegram confirmation has expired.");
+        return true;
+      }
+      const choiceText = callback?.choice ?? text;
       replyThisTurnRef.current = true;
-      const followup = stripFollowupPrefix(text);
+      const followup = stripFollowupPrefix(choiceText);
       const interaction = interactionRef.current;
-      interactionRef.current = { kind: null, payload: null };
+      interactionRef.current = { kind: null, payload: null, confirmationId: null };
 
       switch (interaction.kind) {
         case "run_command":
         case "run_background":
-          onShellConfirmRef.current(parseRunPermissionChoice(text));
+          onShellConfirmRef.current(parseRunPermissionChoice(choiceText));
           return true;
         case "path_access":
-          onPathConfirmRef.current(parseRunPermissionChoice(text));
+          onPathConfirmRef.current(parseRunPermissionChoice(choiceText));
           return true;
         case "plan_proposed": {
           const payload = (interaction.payload as { plan?: string }) ?? {};
-          const choice = parsePlanChoice(text);
+          const choice = parsePlanChoice(choiceText);
           if (choice === "cancel") {
             void onPlanCancelRef.current();
           } else {
@@ -623,7 +650,7 @@ export function useTelegramChannel({
         }
         case "plan_checkpoint": {
           const payload = (interaction.payload as { stepId?: string; title?: string }) ?? {};
-          const choice = parseCheckpointChoice(text);
+          const choice = parseCheckpointChoice(choiceText);
           if (choice === "revise") {
             onCheckpointReviseRef.current(followup, {
               stepId: payload.stepId ?? "",
@@ -635,7 +662,7 @@ export function useTelegramChannel({
           return true;
         }
         case "plan_revision":
-          onPlanRevisionRef.current(parseRevisionChoice(text));
+          onPlanRevisionRef.current(parseRevisionChoice(choiceText));
           return true;
         case "choice": {
           const payload =
@@ -681,6 +708,7 @@ export function useTelegramChannel({
       onPlanRevisionRef,
       onShellConfirmRef,
       pendingGateIdRef,
+      sendText,
     ],
   );
 
@@ -706,9 +734,11 @@ export function useTelegramChannel({
   const handlePauseRequest = useCallback(
     (kind: string, payload: Record<string, unknown>) => {
       if (!channelRef.current) return;
+      const confirmationId = String(++nextConfirmationIdRef.current);
       interactionRef.current = {
         kind: kind as TelegramInteractionKind,
         payload,
+        confirmationId,
       };
 
       let telegramMessage = "";
@@ -720,9 +750,9 @@ export function useTelegramChannel({
           telegramMessage = `Need confirmation\n\nCommand: \`${p.command}\``;
           telegramButtons = [
             [
-              { text: "✅ Run once", callbackData: "1" },
-              { text: "✅ Always allow", callbackData: "2" },
-              { text: "❌ Deny", callbackData: "3" },
+              { text: "✅ Run once", callbackData: telegramCallbackData(confirmationId, "1") },
+              { text: "✅ Always allow", callbackData: telegramCallbackData(confirmationId, "2") },
+              { text: "❌ Deny", callbackData: telegramCallbackData(confirmationId, "3") },
             ],
           ];
           break;
@@ -737,9 +767,9 @@ export function useTelegramChannel({
           telegramMessage = `Need file access confirmation\n\nAction: ${intentText}\nPath: ${p.path}\nTool: ${p.toolName}`;
           telegramButtons = [
             [
-              { text: "✅ Run once", callbackData: "1" },
-              { text: "✅ Always allow", callbackData: "2" },
-              { text: "❌ Deny", callbackData: "3" },
+              { text: "✅ Run once", callbackData: telegramCallbackData(confirmationId, "1") },
+              { text: "✅ Always allow", callbackData: telegramCallbackData(confirmationId, "2") },
+              { text: "❌ Deny", callbackData: telegramCallbackData(confirmationId, "3") },
             ],
           ];
           break;
@@ -749,9 +779,9 @@ export function useTelegramChannel({
           telegramMessage = `Plan confirmation\n\n${p.plan}`;
           telegramButtons = [
             [
-              { text: "Approve", callbackData: "1" },
-              { text: "Refine", callbackData: "2" },
-              { text: "Cancel", callbackData: "3" },
+              { text: "Approve", callbackData: telegramCallbackData(confirmationId, "1") },
+              { text: "Refine", callbackData: telegramCallbackData(confirmationId, "2") },
+              { text: "Cancel", callbackData: telegramCallbackData(confirmationId, "3") },
             ],
           ];
           break;
@@ -763,9 +793,9 @@ export function useTelegramChannel({
           telegramMessage = `Step complete (${completed}/${total})\n\n${p.title ? `Step: ${p.title}\n` : ""}Result: ${p.result}`;
           telegramButtons = [
             [
-              { text: "Continue", callbackData: "1" },
-              { text: "Revise", callbackData: "2" },
-              { text: "Stop", callbackData: "3" },
+              { text: "Continue", callbackData: telegramCallbackData(confirmationId, "1") },
+              { text: "Revise", callbackData: telegramCallbackData(confirmationId, "2") },
+              { text: "Stop", callbackData: telegramCallbackData(confirmationId, "3") },
             ],
           ];
           break;
@@ -775,9 +805,9 @@ export function useTelegramChannel({
           telegramMessage = `Plan revision proposed\n\n${p.reason}`;
           telegramButtons = [
             [
-              { text: "Accept", callbackData: "1" },
-              { text: "Reject", callbackData: "2" },
-              { text: "Cancel", callbackData: "3" },
+              { text: "Accept", callbackData: telegramCallbackData(confirmationId, "1") },
+              { text: "Reject", callbackData: telegramCallbackData(confirmationId, "2") },
+              { text: "Cancel", callbackData: telegramCallbackData(confirmationId, "3") },
             ],
           ];
           break;

--- a/tests/telegram-channel.test.ts
+++ b/tests/telegram-channel.test.ts
@@ -103,13 +103,14 @@ describe("TelegramChannel.sendResponse", () => {
   });
 
   it("attaches inline buttons to the delivered response", async () => {
-    const bot = { sendMessage: vi.fn().mockResolvedValue(undefined) };
+    const bot = { sendMessage: vi.fn().mockResolvedValue(789) };
     const channel = new TelegramChannel({
       onSubmitMessage: () => undefined,
     }) as unknown as {
       bot: typeof bot;
       chatId: number;
       messageId: number;
+      activeCallbackMessageId: number | null;
       sendResponse: TelegramChannel["sendResponse"];
     };
     channel.bot = bot;
@@ -126,6 +127,7 @@ describe("TelegramChannel.sendResponse", () => {
       "MarkdownV2",
       buttons,
     );
+    expect(channel.activeCallbackMessageId).toBe(789);
   });
 
   it("falls back to plain text when markdown delivery fails", async () => {
@@ -200,6 +202,96 @@ describe("TelegramChannel ingress rate limiting", () => {
     expect(bot.sendMessage).toHaveBeenCalledTimes(1);
     expect(bot.sendMessage.mock.calls[0]?.[1]).toContain("too quickly");
     expect(onError.mock.calls[0]?.[0]).toContain("rate-limited");
+  });
+});
+
+describe("TelegramChannel callback confirmation binding", () => {
+  it("ignores callbacks when no confirmation message is active", () => {
+    const onSubmitMessage = vi.fn();
+    const onError = vi.fn();
+    const channel = new TelegramChannel({
+      onSubmitMessage,
+      onError,
+    }) as unknown as {
+      ownerUserId: string;
+      activeCallbackMessageId: number | null;
+      handleCallbackQuery: (query: {
+        id: string;
+        data: string;
+        message?: { message_id: number; chat: { id: number; type: string } };
+        from: { id: number; is_bot?: boolean };
+      }) => void;
+    };
+    channel.ownerUserId = "42";
+    channel.activeCallbackMessageId = null;
+
+    channel.handleCallbackQuery({
+      id: "callback-1",
+      data: "tg:1:1",
+      message: { message_id: 200, chat: { id: 123, type: "private" } },
+      from: { id: 42 },
+    });
+
+    expect(onSubmitMessage).not.toHaveBeenCalled();
+    expect(onError.mock.calls[0]?.[0]).toContain("stale callback");
+  });
+
+  it("ignores callbacks from older confirmation messages", () => {
+    const onSubmitMessage = vi.fn();
+    const onError = vi.fn();
+    const channel = new TelegramChannel({
+      onSubmitMessage,
+      onError,
+    }) as unknown as {
+      ownerUserId: string;
+      activeCallbackMessageId: number | null;
+      handleCallbackQuery: (query: {
+        id: string;
+        data: string;
+        message?: { message_id: number; chat: { id: number; type: string } };
+        from: { id: number; is_bot?: boolean };
+      }) => void;
+    };
+    channel.ownerUserId = "42";
+    channel.activeCallbackMessageId = 200;
+
+    channel.handleCallbackQuery({
+      id: "callback-1",
+      data: "tg:1:1",
+      message: { message_id: 199, chat: { id: 123, type: "private" } },
+      from: { id: 42 },
+    });
+
+    expect(onSubmitMessage).not.toHaveBeenCalled();
+    expect(onError.mock.calls[0]?.[0]).toContain("stale callback");
+  });
+
+  it("accepts callbacks only from the current confirmation message", () => {
+    const onSubmitMessage = vi.fn();
+    const channel = new TelegramChannel({
+      onSubmitMessage,
+    }) as unknown as {
+      ownerUserId: string;
+      activeCallbackMessageId: number | null;
+      handleCallbackQuery: (query: {
+        id: string;
+        data: string;
+        message?: { message_id: number; chat: { id: number; type: string } };
+        from: { id: number; is_bot?: boolean };
+      }) => void;
+    };
+    channel.ownerUserId = "42";
+    channel.activeCallbackMessageId = 200;
+
+    channel.handleCallbackQuery({
+      id: "callback-1",
+      data: "tg:1:1",
+      message: { message_id: 200, chat: { id: 123, type: "private" } },
+      from: { id: 42 },
+    });
+
+    expect(onSubmitMessage).toHaveBeenCalledWith("[TG] tg:1:1");
+    expect(channel.activeCallbackMessageId).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

- Bind Telegram inline-button callback data to a confirmation id instead of using bare `"1"`, `"2"`, `"3"` payloads.
- Correlate Telegram callback presses with the active confirmation `message_id`, so stale buttons from older confirmations cannot resolve a newer prompt.
- Add Telegram setup docs in English and Chinese.

## Review Follow-up

This resolves the non-blocking follow-up from https://github.com/esengine/DeepSeek-Reasonix/pull/2213#pullrequestreview-4386524119:

- confirmation `callbackData` now includes a confirmation id (`tg:<id>:<choice>`)
- callback presses are accepted only from the currently active Telegram confirmation message
- stale callbacks, including old buttons after a restart, are ignored

## Verification

- `npm run verify`
