### PR TITLE
fix(ui): set terminal background via OSC 11 to match theme

### DIFF
--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -428,14 +428,11 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
   if (process.stdout.isTTY && typeof themeBg === "string" && themeBg.startsWith("#")) {
     process.stdout.write(`\x1b]11;${themeBg}\x07`);
     process.once("exit", restoreTerminalBg);
-    process.once("SIGINT", () => {
-      restoreTerminalBg();
-      process.exit(130);
-    });
-    process.once("SIGTERM", () => {
-      restoreTerminalBg();
-      process.exit(143);
-    });
+    // Restore bg on signals without calling process.exit() —
+    // useQuit owns the SIGINT exit path (async transcript flush + profile
+    // save). The "exit" listener above fires when useQuit eventually exits.
+    process.once("SIGINT", restoreTerminalBg);
+    process.once("SIGTERM", restoreTerminalBg);
   }
 
   const { waitUntilExit } = render(

--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -425,7 +425,10 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
   };
   const themeName = resolveThemeName(resolveThemePreference(readConfig().theme));
   const themeBg = THEMES[themeName].surface.bg;
-  if (process.stdout.isTTY && typeof themeBg === "string" && themeBg.startsWith("#")) {
+  // Only apply when: TTY available, NO_COLOR not set, and background is a
+  // hex color string. Non-hex theme backgrounds (e.g. "oklch(...)") are
+  // skipped because terminals only understand #RGB/#RRGGBB for OSC 11.
+  if (process.stdout.isTTY && !process.env.NO_COLOR && typeof themeBg === "string" && themeBg.startsWith("#")) {
     process.stdout.write(`\x1b]11;${themeBg}\x07`);
     process.once("exit", restoreTerminalBg);
     // Restore bg on signals without calling process.exit() —

--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -428,7 +428,12 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
   // Only apply when: TTY available, NO_COLOR not set, and background is a
   // hex color string. Non-hex theme backgrounds (e.g. "oklch(...)") are
   // skipped because terminals only understand #RGB/#RRGGBB for OSC 11.
-  if (process.stdout.isTTY && !process.env.NO_COLOR && typeof themeBg === "string" && themeBg.startsWith("#")) {
+  if (
+    process.stdout.isTTY &&
+    !process.env.NO_COLOR &&
+    typeof themeBg === "string" &&
+    themeBg.startsWith("#")
+  ) {
     process.stdout.write(`\x1b]11;${themeBg}\x07`);
     process.once("exit", restoreTerminalBg);
     // Restore bg on signals without calling process.exit() —

--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -8,6 +8,7 @@ import {
   loadToolRateLimit,
   normalizeMcpConfig,
   readConfig,
+  resolveThemePreference,
   searchEnabled,
 } from "../../config.js";
 import { loadDotenv } from "../../env.js";
@@ -37,6 +38,7 @@ import { KeystrokeProvider } from "../ui/keystroke-context.js";
 import { disableMouseMode, enableMouseMode } from "../ui/mouse-mode.js";
 import { installResizeBroadcaster } from "../ui/resize-broadcaster.js";
 import type { McpServerSummary } from "../ui/slash.js";
+import { THEMES, resolveThemeName } from "../ui/theme/tokens.js";
 import {
   type McpLifecycleNotice,
   type McpLifecycleSink,
@@ -416,6 +418,26 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
     });
   }
 
+  // Set terminal default background to match the theme so that empty areas
+  // below Ink's rendered content (main-screen mode) blend with the UI.
+  const restoreTerminalBg = (): void => {
+    if (process.stdout.isTTY) process.stdout.write("\x1b]111\x07");
+  };
+  const themeName = resolveThemeName(resolveThemePreference(readConfig().theme));
+  const themeBg = THEMES[themeName].surface.bg;
+  if (process.stdout.isTTY && typeof themeBg === "string" && themeBg.startsWith("#")) {
+    process.stdout.write(`\x1b]11;${themeBg}\x07`);
+    process.once("exit", restoreTerminalBg);
+    process.once("SIGINT", () => {
+      restoreTerminalBg();
+      process.exit(130);
+    });
+    process.once("SIGTERM", () => {
+      restoreTerminalBg();
+      process.exit(143);
+    });
+  }
+
   const { waitUntilExit } = render(
     <Root
       initialKey={initialKey}
@@ -442,6 +464,7 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
   try {
     await waitUntilExit();
   } finally {
+    restoreTerminalBg();
     disableMouseMode();
     await runtime.closeAll();
     qqChannel?.stop();


### PR DESCRIPTION
## Summary
- Emit OSC 11 to set terminal default background to the theme's `surface.bg`, eliminating white/empty areas below Ink's content in iTerm and other terminals
- Crash-safe restore via `process.once("exit")`, SIGINT, and SIGTERM handlers ensure OSC 111 restores the original background on any exit path
- Belt-and-suspenders: `finally` block also calls `restoreTerminalBg()`

## Test plan
- [ ] Launch in iTerm2 with a dark theme — verify no white areas below rendered content
- [ ] Ctrl-C during a long operation — verify terminal background is restored
- [ ] Normal exit — verify terminal background is restored
- [ ] SIGTERM (e.g. `kill`) — verify terminal background is restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)