### PR TITLE
fix(desktop): abort agent loop on plan_response cancel

### DIFF
--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -2346,6 +2346,7 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
     if (msg.cmd === "plan_response") {
       const tab = forgetGate(msg.id);
       if (tab && msg.response.type === "cancel") {
+        abortTurn(tab);
         tab.completedStepIds.clear();
         tab.planTotalSteps = 0;
         emit({ type: "$plan_cleared" }, tab.id);


### PR DESCRIPTION
## What
Add abortTurn(tab) in the plan_response cancel handler.

## Why
When the user cancels a plan, the agent loop continues running. The model receives the cancellation signal via pauseGate but the in-progress turn is not aborted, causing the model to re-submit the plan or continue generating output that the user already rejected.

## How to verify
1. Start a session with plan mode enabled
2. Let the model submit a plan via submit_plan
3. Click Cancel in the plan approval
4. Confirm the agent loop stops immediately — no further streaming or tool calls from the rejected turn

<!-- Read CONTRIBUTING.md first if this is your first PR. -->

## What

<!-- One paragraph: what does this change? -->

## Why

<!-- Bug fix? Pre-existing issue? Linked discussion? -->

## How to verify

<!-- Steps the reviewer can run. `npm run verify` is assumed. -->

## Checklist

- [ ] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [ ] No `Co-Authored-By: Claude` trailer in commits
- [ ] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [ ] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time
