### PR TITLE
fix(session): warn when system prompt changes on session resume (#2212)

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -66,6 +66,7 @@ import {
   deleteSession,
   detectGitBranch,
   freshSessionName,
+  hashSystemPrompt,
   type listSessions,
   listSessionsForWorkspace,
   loadSessionMessages,
@@ -1585,6 +1586,12 @@ function AppInner({
       log.pushInfo(t("ui.ephemeralSession"));
     } else if (loop.resumedMessageCount > 0) {
       log.pushInfo(t("ui.resumedSession", { name: session, count: loop.resumedMessageCount }));
+      // Warn if system prompt changed since the session was last used — REASONIX.md
+      // or global memory edits cause a cache miss on the first resumed turn (#2212).
+      const savedFingerprint = loadSessionMeta(session).systemFingerprint;
+      if (savedFingerprint && savedFingerprint !== hashSystemPrompt(system)) {
+        log.pushWarning(t("ui.systemPromptChanged"), t("ui.systemPromptChangedDetail"));
+      }
     } else {
       log.pushInfo(t("ui.newSession", { name: session }));
     }
@@ -1667,7 +1674,7 @@ function AppInner({
       log.pushTip({ topic: tip.topic, sections: tip.sections, footer: tip.footer });
       markMouseClipboardHintShown();
     }
-  }, [session, loop, codeMode, syncPendingCount, log, pendingEdits, startupInfoHints]);
+  }, [session, loop, codeMode, syncPendingCount, log, pendingEdits, startupInfoHints, system]);
 
   // Esc handles "abort the current turn" separately; Ctrl+C is the universal "I'm done" key.
   const quitProcess = useQuit(transcriptRef);
@@ -3228,6 +3235,9 @@ function AppInner({
         if (!existing.summary) patch.summary = text.replace(/\s+/g, " ").slice(0, 80);
         if (!existing.branch) patch.branch = detectGitBranch(currentRootDir);
         if (!existing.workspace) patch.workspace = currentRootDir;
+        // Always refresh the system-prompt fingerprint so the next resume can
+        // detect REASONIX.md / memory changes that happened since this turn.
+        patch.systemFingerprint = hashSystemPrompt(system);
         if (Object.keys(patch).length > 0) patchSessionMeta(session, patch);
       }
 
@@ -3611,6 +3621,7 @@ function AppInner({
       liveMcpServers,
       generateCurrentSessionTitle,
       switchWorkspaceRoot,
+      system,
     ],
   );
 

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -87,6 +87,9 @@ export const EN: TranslationSchema = {
       '▸ resumed session "{name}" with {count} prior messages · /new to start fresh · /sessions to manage',
     newSession: '▸ session "{name}" (new) — auto-saved as you chat · /sessions to rename or delete',
     ephemeralSession: "▸ ephemeral chat (no session persistence) — drop --no-session to enable",
+    systemPromptChanged: "▸ system prompt changed since last session",
+    systemPromptChangedDetail:
+      "REASONIX.md or a memory file changed — the first turn will be a full cache miss. Use /new to start fresh with the updated context.",
     restoredEdits:
       "▸ restored {count} pending edit block(s) from an interrupted prior run — /apply to commit or /discard to drop.",
     resumedPlan: "Resumed plan · {when}{summary}",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -77,6 +77,8 @@ export interface TranslationSchema {
     resumedSession: string;
     newSession: string;
     ephemeralSession: string;
+    systemPromptChanged: string;
+    systemPromptChangedDetail: string;
     restoredEdits: string;
     resumedPlan: string;
     tipEditBindings: {

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -86,6 +86,9 @@ export const zhCN: TranslationSchema = {
       '▸ 已恢复会话 "{name}"，包含 {count} 条历史消息 · /new 重新开始 · /sessions 管理',
     newSession: '▸ 会话 "{name}" (新) — 随聊随存 · /sessions 重命名或删除',
     ephemeralSession: "▸ 临时聊天 (不保存会话) — 去掉 --no-session 以启用保存",
+    systemPromptChanged: "▸ 系统提示自上次会话后已变更",
+    systemPromptChangedDetail:
+      "REASONIX.md 或记忆文件发生了更改 — 本轮将产生完整缓存 miss。可使用 /new 以更新后的上下文开始新会话。",
     restoredEdits:
       "▸ 从中断的运行中恢复了 {count} 个待处理的编辑块 — /apply 提交或 /discard 放弃。",
     resumedPlan: "已恢复计划 · {when}{summary}",

--- a/src/memory/session.ts
+++ b/src/memory/session.ts
@@ -1,7 +1,7 @@
 /** JSONL append-only message log under `~/.reasonix/sessions/`; concurrent-write safe. */
 
 import { execFileSync } from "node:child_process";
-import { randomBytes } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import {
   appendFileSync,
   chmodSync,
@@ -79,6 +79,9 @@ export interface SessionMeta {
   cacheDiagnostics?: CacheDiagnosticEntry[];
   /** True when the session filename/summary was generated from conversation content. */
   autoTitleGenerated?: boolean;
+  /** SHA-256[:16] of the system prompt active when the session was last used.
+   *  Compared on resume to warn the user if REASONIX.md or memory changed (#2212). */
+  systemFingerprint?: string;
   /** Source app when the session was imported from another local AI client. */
   importedSource?: "claude" | "codex";
   /** Absolute path of the source transcript used for import. */
@@ -375,6 +378,16 @@ export function patchSessionMeta(name: string, patch: Partial<SessionMeta>): Ses
     /* chmod not supported */
   }
   return next;
+}
+
+/** SHA-256[:16] of a system-prompt string — used to detect REASONIX.md changes on resume (#2212). */
+export function hashSystemPrompt(system: string): string {
+  return createHash("sha256").update(system).digest("hex").slice(0, 16);
+}
+
+/** Persist the current system-prompt fingerprint so resume can detect changes. */
+export function saveSessionSystemFingerprint(name: string, system: string): void {
+  patchSessionMeta(name, { systemFingerprint: hashSystemPrompt(system) });
 }
 
 /** Renames the JSONL plus all known sidecars together; returns false if target already exists. */


### PR DESCRIPTION
## 问题

关闭 #2212。用户编辑 REASONIX.md 或全局记忆文件后，下次 resume 会话时系统提示已变更，第一轮会产生完整缓存 miss，但没有任何提示——用户完全不知道为什么突然慢了。

## 方案

在 resume 时对比系统提示指纹（SHA-256[:16]），如果不一致就显示警告：

```
▸ system prompt changed since last session
  REASONIX.md or a memory file changed — the first turn will be a full
  cache miss. Use /new to start fresh with the updated context.
```

**实现细节：**
- `session.ts`：新增 `hashSystemPrompt()`，在 `SessionMeta` 加 `systemFingerprint` 字段
- `App.tsx`：每轮发送时刷新 fingerprint；resume 时比较，不同则 `pushWarning`
- i18n：EN + zh-CN 各新增 2 个 key（`systemPromptChanged` + `systemPromptChangedDetail`）
- `TranslationSchema` 同步更新

**不改变任何行为**，仅加信息提示。用户仍可继续使用旧 session（只是有缓存 miss），或 `/new` 开新会话。