### PR TITLE
fix(proxy): hint for corporate firewalls where DeepSeek requires proxy (#2215)

### DIFF
--- a/src/net/proxy.ts
+++ b/src/net/proxy.ts
@@ -267,6 +267,15 @@ export function installProxyIfConfigured(
     installed = true;
     const bypassList = patterns.map((p) => p.raw).join(",");
     process.stderr.write(`[proxy] using ${url} (source: ${source}, NO_PROXY: ${bypassList})\n`);
+    // Hint for corporate firewalls where api.deepseek.com is only reachable via
+    // the proxy (not directly). The default bypass keeps clash/v2ray healthy, but
+    // enterprise users can flip it with an env var or config field (#2215).
+    const wantsDeepSeekDirect = resolveBypassDeepSeekDirect(env, opts.bypassDeepSeekDirect);
+    if (wantsDeepSeekDirect) {
+      process.stderr.write(
+        '[proxy] api.deepseek.com is bypassed (direct). If your firewall blocks direct egress, set REASONIX_PROXY_DEEPSEEK_DIRECT=0 or add "proxy":{"bypassDeepSeekDirect":false} to ~/.reasonix/config.json\n',
+      );
+    }
     return { url, source, reinstalled, noProxy: patterns };
   } catch (err) {
     process.stderr.write(


### PR DESCRIPTION
## 问题

关闭 #2215。企业内网用户设置了 `HTTPS_PROXY` 但连接 DeepSeek API 仍然失败（`fetch failed`），错误信息中可以看到 `NO_PROXY: api.deepseek.com`。

**根因**：为了防止 clash/v2ray 用户的代理出口 IP 被 DeepSeek 403，代码默认把 `api.deepseek.com` 加进 NO_PROXY（bypass 直连）。但企业防火墙环境恰好相反——**必须通过代理**才能访问 deepseek，直连反而不通。

解决方案其实早就有了（`REASONIX_PROXY_DEEPSEEK_DIRECT=0` 或 config `bypassDeepSeekDirect:false`，见 #1497），但 stderr 日志里完全没有提示，用户无从得知。

## 修改

在 `[proxy]` 日志中补一行提示，当 api.deepseek.com 走直连时告知用户可以关闭这个行为：

```
[proxy] using http://proxy:7853 (source: env, NO_PROXY: api.deepseek.com,...)
[proxy] api.deepseek.com is bypassed (direct). If your firewall blocks direct
        egress, set REASONIX_PROXY_DEEPSEEK_DIRECT=0 or add
        "proxy":{"bypassDeepSeekDirect":false} to ~/.reasonix/config.json
```

**只改了一处**： 的  函数，在 bypass 生效时打印这条提示。不影响任何行为。