### PR TITLE
feat(skills): inline references/ at load time for Anthropic Skills compat (#2214)

### DIFF
--- a/src/skills.ts
+++ b/src/skills.ts
@@ -307,7 +307,7 @@ export class SkillStore {
     return {
       name,
       description,
-      body: body.trim(),
+      body: loadBodyWithReferences(path, body.trim()),
       scope,
       path,
       allowedTools: parseAllowedTools(data["allowed-tools"]),
@@ -315,6 +315,36 @@ export class SkillStore {
       model: data.model?.startsWith("deepseek-") ? data.model : undefined,
     };
   }
+}
+
+/** Append Anthropic Skills `references/` files to the body (#2214) so depth material
+ *  is available without on-demand wikilink resolution. Only dir-layout skills
+ *  (SKILL.md inside a named folder) can have a sibling `references/` directory. */
+function loadBodyWithReferences(skillFilePath: string, body: string): string {
+  if (!skillFilePath.endsWith(SKILL_FILE)) return body;
+  const refsDir = join(dirname(skillFilePath), "references");
+  if (!existsSync(refsDir)) return body;
+  let entries: string[];
+  try {
+    entries = readdirSync(refsDir)
+      .filter((f) => f.endsWith(".md"))
+      .sort();
+  } catch {
+    return body;
+  }
+  if (entries.length === 0) return body;
+  const parts: string[] = [body];
+  for (const entry of entries) {
+    const slug = entry.slice(0, -3); // strip .md
+    let content: string;
+    try {
+      content = readFileSync(join(refsDir, entry), "utf8").trim();
+    } catch {
+      continue;
+    }
+    if (content) parts.push(`\n\n## Reference: ${slug}\n\n${content}`);
+  }
+  return parts.join("");
 }
 
 function dedupePaths(paths: readonly string[]): string[] {

--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -169,6 +169,36 @@ describe("SkillStore", () => {
     },
   );
 
+  it("inlines references/ files into body at load time (#2214 — Anthropic Skills spec)", () => {
+    const skillDir = join(home, ".reasonix", "skills", "deep-expert");
+    const refsDir = join(skillDir, "references");
+    mkdirSync(refsDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, "SKILL.md"),
+      "---\ndescription: an expert skill\n---\nCore playbook.\n",
+      "utf8",
+    );
+    writeFileSync(join(refsDir, "methodology.md"), "# Methodology\nBe systematic.", "utf8");
+    writeFileSync(join(refsDir, "examples.md"), "# Examples\nCase 1.", "utf8");
+
+    const skills = new SkillStore({ homeDir: home, projectRoot, disableBuiltins: true }).list();
+    const skill = skills.find((s) => s.name === "deep-expert");
+    expect(skill).toBeDefined();
+    expect(skill?.body).toContain("Core playbook.");
+    expect(skill?.body).toContain("## Reference: methodology");
+    expect(skill?.body).toContain("Be systematic.");
+    expect(skill?.body).toContain("## Reference: examples");
+    expect(skill?.body).toContain("Case 1.");
+  });
+
+  it("flat <name>.md skills are unaffected by references/ loading (#2214)", () => {
+    writeFlatSkill(home, "flat-skill", { description: "flat skill" }, "flat body");
+    // Even if a references/ dir exists elsewhere, flat skills should not touch it.
+    const skills = new SkillStore({ homeDir: home, projectRoot, disableBuiltins: true }).list();
+    const skill = skills.find((s) => s.name === "flat-skill");
+    expect(skill?.body).toBe("flat body");
+  });
+
   it("project scope wins on a name collision with global", () => {
     writeSkillDir(projectRoot, "global", "review", { description: "global one" }, "G", home);
     writeSkillDir(projectRoot, "project", "review", { description: "project one" }, "P", home);


### PR DESCRIPTION
## 问题

关闭 #2214。遵循 Anthropic Skills spec 的技能会在 SKILL.md 旁边放一个 `references/` 目录存放深度参考资料，通过 `[[references/xxx]]` 引用。Reasonix 目前只读 SKILL.md，reference 内容对模型不可见，来自 OpenKB 等工具生成的技能会失去核心参考材料。

## 方案（Option A — 加载时 inline）

在 `parse()` 时检测同级 `references/` 目录，把找到的 `.md` 文件按字母序追加到 body：

```
## Reference: methodology

# Methodology
Be systematic.

## Reference: examples

# Examples
Case 1.
```

**只影响 dir-layout 技能**（带 SKILL.md 的目录形式），flat `<name>.md` 不受影响。

## 验证

- 2 个新测试：references/ inline、flat skill 不受影响
- `npm run verify` 通过