### PR TITLE
feat(mcp): expand ${VAR} env vars in mcpServers header values (#2148)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -637,6 +637,28 @@ function normalizeStringRecord(value: unknown): Record<string, string> | undefin
   return Object.keys(out).length > 0 ? out : undefined;
 }
 
+/** Expand env var references in header values (#2148). Supported forms:
+ *  `${VAR}`, `${env:VAR}`, `${VAR:-default}`, `${env:VAR:-default}`.
+ *  Unset variables with no default are left as-is so the error surfaces at bridge time. */
+function expandEnvInRecord(
+  record: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  if (!record) return undefined;
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(record)) {
+    out[k] = v.replace(
+      /\$\{(?:env:)?([^}:]+)(?::-((?:[^}]|\}(?!\}))*))?\}/g,
+      (match, name: string, defaultVal?: string) => {
+        const expanded = process.env[name.trim()];
+        if (expanded !== undefined) return expanded;
+        if (defaultVal !== undefined) return defaultVal;
+        return match;
+      },
+    );
+  }
+  return out;
+}
+
 export function normalizeMcpConfig(cfg: ReasonixConfig, extraLegacy?: string[]): McpServerSpec[] {
   const result: McpServerSpec[] = [];
   const seen = new Set<string>();
@@ -691,7 +713,9 @@ export function normalizeMcpConfig(cfg: ReasonixConfig, extraLegacy?: string[]):
       let url = (serverCfg as McpServerConfig).url ?? "";
       const streamMatch = /^streamable\+(https?:\/\/.+)$/i.exec(url);
       if (streamMatch) url = streamMatch[1]!;
-      const headers = normalizeStringRecord((serverCfg as McpServerConfig).headers);
+      const headers = expandEnvInRecord(
+        normalizeStringRecord((serverCfg as McpServerConfig).headers),
+      );
       if (transport === "sse") {
         const spec: McpServerSpec = {
           transport: "sse",

--- a/tests/mcp-normalize-config.test.ts
+++ b/tests/mcp-normalize-config.test.ts
@@ -529,4 +529,77 @@ describe("normalizeMcpConfig: requestTimeoutMs (#2023)", () => {
     const spec = findByName(result, "normal")!;
     expect(spec.requestTimeoutMs).toBeUndefined();
   });
+
+  it("expands ${VAR} and ${env:VAR} in mcpServers headers (#2148)", () => {
+    const orig = process.env.TEST_MCP_TOKEN;
+    process.env.TEST_MCP_TOKEN = "secret-token-123";
+    try {
+      const cfg: ReasonixConfig = {
+        mcpServers: {
+          remote: {
+            url: "https://api.example.com/mcp",
+            transport: "sse",
+            headers: {
+              Authorization: "Bearer ${TEST_MCP_TOKEN}",
+              "X-Custom": "${env:TEST_MCP_TOKEN}",
+              Static: "no-expand",
+              Missing: "${NONEXISTENT_VAR_FOR_TEST}",
+            },
+          },
+        },
+      };
+      const result = normalizeMcpConfig(cfg);
+      const spec = findByName(result, "remote")!;
+      expect(spec.transport).toBe("sse");
+      if (spec.transport !== "sse") throw new Error("unreachable");
+      expect(spec.headers?.Authorization).toBe("Bearer secret-token-123");
+      expect(spec.headers?.["X-Custom"]).toBe("secret-token-123");
+      expect(spec.headers?.Static).toBe("no-expand");
+      expect(spec.headers?.Missing).toBe("${NONEXISTENT_VAR_FOR_TEST}");
+    } finally {
+      if (orig === undefined) {
+        // biome-ignore lint/performance/noDelete: restore env
+        delete process.env.TEST_MCP_TOKEN;
+      } else {
+        process.env.TEST_MCP_TOKEN = orig;
+      }
+    }
+  });
+
+  it("supports ${VAR:-default} and ${env:VAR:-default} fallback syntax (#2148)", () => {
+    // biome-ignore lint/performance/noDelete: ensure var is unset for test
+    delete process.env.MCP_HEADER_TEST_UNSET_VAR;
+    const orig = process.env.MCP_HEADER_TEST_SET_VAR;
+    process.env.MCP_HEADER_TEST_SET_VAR = "actual-value";
+    try {
+      const cfg: ReasonixConfig = {
+        mcpServers: {
+          remote: {
+            url: "https://api.example.com/mcp",
+            transport: "sse",
+            headers: {
+              A: "${MCP_HEADER_TEST_SET_VAR:-fallback}",
+              B: "${MCP_HEADER_TEST_UNSET_VAR:-dev-token}",
+              C: "${env:MCP_HEADER_TEST_SET_VAR:-fallback}",
+              D: "${env:MCP_HEADER_TEST_UNSET_VAR:-dev-token}",
+            },
+          },
+        },
+      };
+      const result = normalizeMcpConfig(cfg);
+      const spec = findByName(result, "remote")!;
+      if (spec.transport !== "sse") throw new Error("unreachable");
+      expect(spec.headers?.A).toBe("actual-value");
+      expect(spec.headers?.B).toBe("dev-token");
+      expect(spec.headers?.C).toBe("actual-value");
+      expect(spec.headers?.D).toBe("dev-token");
+    } finally {
+      if (orig === undefined) {
+        // biome-ignore lint/performance/noDelete: restore env
+        delete process.env.MCP_HEADER_TEST_SET_VAR;
+      } else {
+        process.env.MCP_HEADER_TEST_SET_VAR = orig;
+      }
+    }
+  });
 });


### PR DESCRIPTION
## 问题

关闭 #2148。从 Claude Code 迁移到 Reasonix 时，`.mcp.json` 里 headers 常见写法：

```json
{
  "mcpServers": {
    "my-server": {
      "url": "https://api.example.com/mcp",
      "transport": "sse",
      "headers": {
        "Authorization": "Bearer ${MY_TOKEN}",
        "X-Api-Key": "${env:ANOTHER_KEY}"
      }
    }
  }
}
```

Reasonix 把这些 `${VAR}` 字面量原样传给服务端，导致认证失败。

## 修改

在 `normalizeMcpConfig` 处理 SSE/streamable-HTTP headers 时，用 `expandEnvInRecord()` 展开 `${VAR_NAME}` 和 `${env:VAR_NAME}` 两种格式。变量未设置则原样保留（保证连接时能看到具体错误）。

## 验证

新增测试：展开、env: 前缀、static 值不受影响、未设置变量原样保留。