### PR TITLE
fix(desktop): follow streaming output when user is at bottom (#2159)

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -2018,13 +2018,19 @@ function TabRuntime({
     }
   }, [messageItems.length]);
 
-  // Always scroll to bottom on every content change.
+  // Follow the bottom while the assistant is streaming and the user hasn't
+  // scrolled up. The dependency on messageItems.length covers new messages;
+  // atBottomRef guards against re-pinning when the user intentionally scrolled
+  // up to read earlier content (#2159).
   useEffect(() => {
     const s = virtScrollerRef.current;
     if (!s || messageItems.length === 0) return;
-    const id = requestAnimationFrame(() => { s.scrollTop = s.scrollHeight; });
+    if (!atBottomRef.current) return;
+    const id = requestAnimationFrame(() => {
+      if (atBottomRef.current) s.scrollTop = s.scrollHeight;
+    });
     return () => cancelAnimationFrame(id);
-  });
+  }, [messageItems]);
 
   // Persist the transcript scroll offset per session so a restart reopens
   // the conversation where the user left it (#1244).


### PR DESCRIPTION
## 问题

关闭 #2159。桌面版流式输出时不自动滚动到底部。

## 根因

`useEffect` 没有依赖数组（每次渲染都执行），但没有检查 `atBottomRef.current`：

```ts
// 旧代码：无依赖数组 → 每次渲染执行，且不检查用户是否在底部
useEffect(() => {
  const s = virtScrollerRef.current;
  if (!s || messageItems.length === 0) return;
  const id = requestAnimationFrame(() => { s.scrollTop = s.scrollHeight; });
  return () => cancelAnimationFrame(id);
});
```

问题：
1. 无依赖数组 → React 在高频 re-render 时可能跳过某些效果的执行
2. 不检查 `atBottomRef.current` → 用户向上滚动查看历史时也会被强制拉回底部

## 修复

添加 `[messageItems]` 依赖数组 + `atBottomRef.current` 检查：只有新消息到来且用户在底部时才滚动。