### PR TITLE
fix(loop): keep headless NEEDS_PRO escalation one-shot

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -73,6 +73,10 @@ function formatSteerUserMessage(content: string): string {
   return [MID_TURN_STEER_WRAPPER, content].join("\n");
 }
 
+function parseNeedsProEscalation(content: string): boolean {
+  return /^\s*<<<NEEDS_PRO(?::\s*[^>\n]{1,150})?>>>/.test(content);
+}
+
 export {
   fixToolCallPairing,
   formatLoopError,
@@ -700,6 +704,14 @@ export class CacheFirstLoop {
         };
       }
     }
+    const baseModelForTurn = this.model;
+    let restoreModelAfterTurn = false;
+    const restoreModelIfNeeded = () => {
+      if (restoreModelAfterTurn && this.model === "deepseek-v4-pro") {
+        this.model = baseModelForTurn;
+      }
+    };
+
     this._turn++;
     this.scratch.reset();
     // A fresh user turn is a new intent — don't let StormBreaker's
@@ -796,6 +808,7 @@ export class CacheFirstLoop {
             content: stoppedMsg,
             forcedSummary: true,
           };
+          restoreModelIfNeeded();
           yield { turn: this._turn, role: "done", content: stoppedMsg };
         } finally {
           this.resetAbortState();
@@ -812,8 +825,12 @@ export class CacheFirstLoop {
           severity: "high",
           content: t("loop.iterLimitReached", { max: this.maxIterPerTurn }),
         };
-        yield* forceSummaryAfterIterLimit(this.summaryContext(), { reason: "stuck" });
-        this._steerQueue.length = 0;
+        try {
+          yield* forceSummaryAfterIterLimit(this.summaryContext(), { reason: "stuck" });
+        } finally {
+          restoreModelIfNeeded();
+          this._steerQueue.length = 0;
+        }
         return;
       }
       // Bridge the silence between the PREVIOUS iter's tool result and
@@ -856,16 +873,18 @@ export class CacheFirstLoop {
       let reasoningContent = "";
       let toolCalls: ToolCall[] = [];
       let usage: TurnStats["usage"] | null = null;
+      let callModel = this.model;
 
       // Snapshot prefix evidence from the same turn-start tool list sent
       // to the API so MCP hot-adds during the turn don't rewrite history.
       const prefixEvidence = this.prefix.diagnosticHashes(toolSpecs);
 
       try {
+        callModel = this.model;
         if (this.stream) {
           const result = yield* streamModelResponse({
             client: this.client,
-            model: this.model,
+            model: callModel,
             messages,
             toolSpecs,
             signal,
@@ -878,7 +897,6 @@ export class CacheFirstLoop {
           toolCalls = result.toolCalls;
           usage = result.usage;
         } else {
-          const callModel = this.model;
           const resp = await this.client.chat({
             model: callModel,
             messages,
@@ -911,6 +929,7 @@ export class CacheFirstLoop {
           // leave carryAbort locked on the next step().
           if (this._discardAbortRequested) this.discardLogFrom(turnStartLogIndex);
           try {
+            restoreModelIfNeeded();
             yield { turn: this._turn, role: "done", content: "" };
           } finally {
             this.resetAbortState();
@@ -925,6 +944,7 @@ export class CacheFirstLoop {
         const cause = err instanceof Error ? err : new Error(String(err));
         const retryable = !is4xxError(cause) && cause.name !== "AbortError";
         const { code, phase } = errorMeta(cause);
+        restoreModelIfNeeded();
         yield {
           turn: this._turn,
           role: "error",
@@ -943,12 +963,18 @@ export class CacheFirstLoop {
         return;
       }
 
+      if (parseNeedsProEscalation(assistantContent) && callModel !== "deepseek-v4-pro") {
+        restoreModelAfterTurn = true;
+        this.model = "deepseek-v4-pro";
+        continue;
+      }
+
       // Attribute under the actual model used (escalated → pro, else
-      // this.model) so cost/usage logs reflect reality.
-      const turnStats = this.stats.record(this._turn, this.model, usage ?? new Usage());
+      // callModel) so cost/usage logs reflect reality.
+      const turnStats = this.stats.record(this._turn, callModel, usage ?? new Usage());
       let cacheDiagnostic = buildCacheDiagnostic({
         turn: this._turn,
-        model: this.model,
+        model: callModel,
         usage: turnStats.usage,
         estimatedCostUsd: turnStats.cost,
         prefix: prefixEvidence,
@@ -961,7 +987,7 @@ export class CacheFirstLoop {
           const meta = loadSessionMeta(this.sessionName);
           cacheDiagnostic = buildCacheDiagnostic({
             turn: this._turn,
-            model: this.model,
+            model: callModel,
             usage: turnStats.usage,
             estimatedCostUsd: turnStats.cost,
             prefix: prefixEvidence,
@@ -995,7 +1021,7 @@ export class CacheFirstLoop {
       );
 
       this.appendAndPersist(
-        buildAssistantMessage(assistantContent, repairedCalls, this.model, reasoningContent),
+        buildAssistantMessage(assistantContent, repairedCalls, callModel, reasoningContent),
       );
 
       yield {
@@ -1017,7 +1043,7 @@ export class CacheFirstLoop {
       if (allSuppressed && !this._turnSelfCorrected) {
         this._turnSelfCorrected = true;
         this.replaceTailAssistantMessage(
-          buildAssistantMessage(assistantContent, toolCalls, this.model, reasoningContent),
+          buildAssistantMessage(assistantContent, toolCalls, callModel, reasoningContent),
         );
         for (const call of toolCalls) {
           this.appendAndPersist({
@@ -1055,10 +1081,15 @@ export class CacheFirstLoop {
           continue;
         }
         if (allSuppressed) {
-          yield* forceSummaryAfterIterLimit(this.summaryContext(), { reason: "stuck" });
-          this._steerQueue.length = 0;
+          try {
+            yield* forceSummaryAfterIterLimit(this.summaryContext(), { reason: "stuck" });
+          } finally {
+            restoreModelIfNeeded();
+            this._steerQueue.length = 0;
+          }
           return;
         }
+        restoreModelIfNeeded();
         yield { turn: this._turn, role: "done", content: assistantContent };
         this._steerQueue.length = 0;
         return;
@@ -1066,7 +1097,7 @@ export class CacheFirstLoop {
 
       // Context-management decision after each turn's response.
       // ContextManager owns the policy; loop renders the events.
-      const decision = this.context.decideAfterUsage(usage, this.model, this._foldedThisTurn);
+      const decision = this.context.decideAfterUsage(usage, callModel, this._foldedThisTurn);
       if (decision.kind === "fold") {
         this._foldedThisTurn = true;
         const before = decision.promptTokens;
@@ -1108,8 +1139,12 @@ export class CacheFirstLoop {
           }),
         };
         this.context.trimTrailingToolCalls();
-        yield* forceSummaryAfterIterLimit(this.summaryContext(), { reason: "context-guard" });
-        this._steerQueue.length = 0;
+        try {
+          yield* forceSummaryAfterIterLimit(this.summaryContext(), { reason: "context-guard" });
+        } finally {
+          restoreModelIfNeeded();
+          this._steerQueue.length = 0;
+        }
         return;
       }
 

--- a/tests/loop.test.ts
+++ b/tests/loop.test.ts
@@ -93,6 +93,59 @@ describe("CacheFirstLoop (non-streaming)", () => {
     expect(loop.log.length).toBe(2); // user + assistant
   });
 
+  it("restores the base model after a headless NEEDS_PRO one-shot retry", async () => {
+    const models: string[] = [];
+    const responses = ["<<<NEEDS_PRO: subtle invariant>>>", "pro answer", "flash answer"];
+    const client = new DeepSeekClient({
+      apiKey: "sk-test",
+      fetch: vi.fn(async (_url: any, init: any) => {
+        const body = init?.body ? JSON.parse(init.body) : {};
+        models.push(body.model);
+        const content = responses.shift() ?? "extra";
+        return new Response(
+          JSON.stringify({
+            choices: [
+              {
+                index: 0,
+                message: {
+                  role: "assistant",
+                  content,
+                  reasoning_content: null,
+                },
+                finish_reason: "stop",
+              },
+            ],
+            usage: {
+              prompt_tokens: 100,
+              completion_tokens: 20,
+              total_tokens: 120,
+              prompt_cache_hit_tokens: 0,
+              prompt_cache_miss_tokens: 100,
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }) as unknown as typeof fetch,
+    });
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s" }),
+      stream: false,
+      model: "deepseek-v4-flash",
+    });
+
+    await expect(loop.run("hard")).resolves.toBe("pro answer");
+    expect(loop.model).toBe("deepseek-v4-flash");
+    await expect(loop.run("simple")).resolves.toBe("flash answer");
+
+    expect(models).toEqual(["deepseek-v4-flash", "deepseek-v4-pro", "deepseek-v4-flash"]);
+    expect(loop.stats.turns.map((turn) => turn.model)).toEqual([
+      "deepseek-v4-pro",
+      "deepseek-v4-flash",
+    ]);
+    expect(JSON.stringify(loop.log.entries)).not.toContain("NEEDS_PRO");
+  });
+
   it("records cache hit telemetry from API usage", async () => {
     const client = makeClient([
       {


### PR DESCRIPTION
## Problem

In headless `reasonix run`, `<<<NEEDS_PRO>>>` should retry only the current turn on `deepseek-v4-pro`. Mutating `this.model` without restoration leaves the session pinned to pro for later turns, which breaks the one-shot contract called out in #2195.

## Fix

- Detect `<<<NEEDS_PRO...>>>` before persisting the flash response and retry the turn on `deepseek-v4-pro`.
- Track the actual `callModel` so stats, cache diagnostics, and session log metadata are attributed correctly.
- Restore the base model before terminal exits and forced-summary paths so following turns return to flash.

## Testing

- `npm run verify`
- push pre-hook `npm run verify`

Related to #2195.