### PR TITLE
fix(test): skip #2137 symlink skill tests on Windows (EPERM)

### DIFF
--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -439,7 +439,9 @@ describe("SkillStore", () => {
     });
   });
 
-  it("loads skills from symlinked directories (#2104)", () => {
+  // Skipped on Windows — symlinkSync throws EPERM there without Developer Mode / admin,
+  // unrelated to the readEntry behavior under test.
+  it.skipIf(process.platform === "win32")("loads skills from symlinked directories (#2104)", () => {
     // Create a real skill directory outside the skills root
     const realDir = mkdtempSync(join(tmpdir(), "reasonix-skills-real-"));
     try {
@@ -464,7 +466,8 @@ describe("SkillStore", () => {
     }
   });
 
-  it("skips broken symlinks gracefully", () => {
+  // Skipped on Windows — symlinkSync to a nonexistent target throws EPERM without admin.
+  it.skipIf(process.platform === "win32")("skips broken symlinks gracefully", () => {
     const skillsDir = join(home, ".reasonix", "skills");
     mkdirSync(skillsDir, { recursive: true });
     symlinkSync(join(tmpdir(), `nonexistent-target-${Date.now()}`), join(skillsDir, "broken"));


### PR DESCRIPTION
## Problem
A Windows contributor reported `npm run verify` failing in `tests/skills.test.ts`:

```
FAIL tests/skills.test.ts > SkillStore > loads skills from symlinked directories (#2104)
Error: EPERM: operation not permitted, symlink ...
FAIL tests/skills.test.ts > SkillStore > skips broken symlinks gracefully
Error: EPERM: operation not permitted, symlink ...
```

The two symlinked-skill tests added in **#2137** call `symlinkSync` with **no Windows guard**. On Windows without Developer Mode / admin, `symlinkSync` throws `EPERM`, so local `verify` fails. CI's Windows runner has the privilege, so it wasn't caught there — but it breaks the local dev loop for Windows contributors.

## Fix
Add `.skipIf(process.platform === "win32")` to both tests — matching the `#2124` symlink tests already in the same file (which guard the identical EPERM case).

## Verification
- `npx vitest run tests/skills.test.ts` → 56 passed (on macOS the tests still run; on Windows the 2 now skip instead of EPERM-failing)
- pre-push `npm run verify` passed