### PR TITLE
fix: restore browser dashboard file mentions

### DIFF
--- a/src/server/api/file-read.ts
+++ b/src/server/api/file-read.ts
@@ -92,3 +92,31 @@ export async function handleFileRead(
     closeSync(fd);
   }
 }
+
+export async function handleFileReadPreview(
+  method: string,
+  _rest: string[],
+  _body: string,
+  ctx: DashboardContext,
+  query: URLSearchParams = new URLSearchParams(),
+): Promise<ApiResult> {
+  if (method !== "GET") return { status: 405, body: { error: "GET only" } };
+  const filePath = query.get("path") ?? "";
+  if (!filePath) return { status: 400, body: { error: "path query parameter required" } };
+
+  const read = await handleFileRead("GET", [filePath], "", ctx);
+  if (read.status !== 200) return read;
+
+  const body = read.body as { content?: unknown; path?: unknown };
+  const text = typeof body.content === "string" ? body.content : "";
+  const lines = text.split(/\r?\n/);
+  if (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
+  return {
+    status: 200,
+    body: {
+      path: typeof body.path === "string" ? body.path : filePath,
+      head: lines.slice(0, 12).join("\n"),
+      totalLines: lines.length,
+    },
+  };
+}

--- a/src/server/api/files.ts
+++ b/src/server/api/files.ts
@@ -42,7 +42,27 @@ export async function handleFiles(
   _rest: string[],
   body: string,
   ctx: DashboardContext,
+  query: URLSearchParams = new URLSearchParams(),
 ): Promise<ApiResult> {
+  if (method === "GET" && _rest[0] === "search") {
+    const cwd = ctx.getCurrentCwd?.();
+    if (!cwd) {
+      return { status: 503, body: { error: "@-mention picker requires a code-mode session" } };
+    }
+    try {
+      if (!(await stat(cwd)).isDirectory()) {
+        return { status: 503, body: { error: "@-mention picker requires a code-mode session" } };
+      }
+    } catch {
+      return { status: 503, body: { error: "@-mention picker requires a code-mode session" } };
+    }
+    const prefix = (query.get("q") ?? "").trim().toLowerCase();
+    const matches = await walk(cwd, prefix);
+    return {
+      status: 200,
+      body: { nonce: query.get("nonce"), query: query.get("q") ?? "", results: matches },
+    };
+  }
   if (method !== "POST") return { status: 405, body: { error: "POST only" } };
   const cwd = ctx.getCurrentCwd?.();
   if (!cwd) {

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -6,7 +6,7 @@ import { handleCheckpointDiffs } from "./api/checkpoint-diffs.js";
 import { handleCheckpointRestore } from "./api/checkpoint-restore.js";
 import { handleCheckpoints } from "./api/checkpoints.js";
 import { handleEditMode } from "./api/edit-mode.js";
-import { handleFileRead } from "./api/file-read.js";
+import { handleFileRead, handleFileReadPreview } from "./api/file-read.js";
 import { handleFiles } from "./api/files.js";
 import { handleGitDiffs } from "./api/git-diffs.js";
 import { handleHealth } from "./api/health.js";
@@ -92,7 +92,7 @@ export async function handleApi(
       case "slash":
         return await handleSlash(method, rest, body, ctx);
       case "files":
-        return await handleFiles(method, rest, body, ctx);
+        return await handleFiles(method, rest, body, ctx, query);
       case "browse":
         return await handleBrowse(method, rest, body, ctx, query);
       case "project-tree":
@@ -113,6 +113,8 @@ export async function handleApi(
         return await handleReviewDiffs(method, rest, body, ctx);
       case "file":
         return await handleFileRead(method, rest, body, ctx);
+      case "file-read":
+        return await handleFileReadPreview(method, rest, body, ctx, query);
       case "loop":
         return await handleLoop(method, rest, body, ctx);
       case "models":

--- a/tests/server-dashboard.test.ts
+++ b/tests/server-dashboard.test.ts
@@ -209,6 +209,30 @@ describe("dashboard server: endpoints", () => {
     expect(r.body.cockpit.currentSession).toBeNull();
   });
 
+  it("serves browser bridge @-mention search and preview compatibility endpoints", async () => {
+    const projectDir = join(dir, "project");
+    await mkdir(join(projectDir, "src"), { recursive: true });
+    await writeFile(
+      join(projectDir, "src", "app.ts"),
+      "export const app = 1;\nconsole.log(app);\n",
+    );
+    await writeFile(join(projectDir, "README.md"), "# demo\n");
+
+    const base = await boot({ getCurrentCwd: () => projectDir });
+
+    const search = await call(`${base}api/files/search?q=app`, { token: TOKEN });
+    expect(search.status).toBe(200);
+    expect(search.body.results).toContain("src/app.ts");
+
+    const preview = await call(`${base}api/file-read?path=src%2Fapp.ts&nonce=7`, { token: TOKEN });
+    expect(preview.status).toBe(200);
+    expect(preview.body).toMatchObject({
+      path: "src/app.ts",
+      head: "export const app = 1;\nconsole.log(app);",
+      totalLines: 2,
+    });
+  });
+
   it("GET /api/usage returns aggregateUsage + record count", async () => {
     const base = await boot();
     const r = await call(`${base}api/usage`, { token: TOKEN });


### PR DESCRIPTION
  ## What

  Restore browser dashboard `@` file mentions by adding server compatibility endpoints for the web bridge's file search and preview requests.

  ## Why

  The browser dashboard was calling `GET /api/files/search` and `GET /api/file-read`, but the server only exposed the older file APIs. As a result, typing `@` in the browser dashboard could not return
  file mention results or previews.

  ## How to verify

  Run:

  ```bash
  npm test -- tests/server-dashboard.test.ts
  npm run verify

  ## Checklist

  - [x] npm run verify passes locally (lint + typecheck + tests + comment-policy gate)
  - [x] No Co-Authored-By: Claude trailer in commits
  - [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
  - [x] No edits to CHANGELOG.md — release notes are maintainer-written at release time
