### PR TITLE
feat(session): add /session-persist to toggle auto-resume on launch (#2238)

### DIFF
--- a/src/cli/commands/code.tsx
+++ b/src/cli/commands/code.tsx
@@ -70,7 +70,13 @@ export async function codeCommand(opts: CodeOptions = {}): Promise<void> {
   // Per-directory session so switching projects doesn't mix histories.
   // `code-<sanitized-basename>` fits the session name rules without
   // truncating most project names.
-  const session = opts.noSession ? undefined : `code-${sanitizeName(basename(rootDir))}`;
+  // Per-directory session unless --no-session or autoResumeSession:false in config (#2238).
+  // Explicit -r/--resume or --new flags override autoResumeSession so users can still
+  // manually resume or start fresh even when the default behaviour has been toggled.
+  const cfg = readConfig();
+  const explicitResume = opts.forceResume || opts.forceNew;
+  const autoResume = opts.noSession ? false : explicitResume || cfg.autoResumeSession !== false;
+  const session = autoResume ? `code-${sanitizeName(basename(rootDir))}` : undefined;
 
   markPhase("semantic_bootstrap_start");
   const { tools, jobs, registerRooted, reBootstrapSemantic, semantic } = await buildCodeToolset({

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -348,7 +348,7 @@ program
         mcp: defaults.mcp,
         mcpPrefix: opts.mcpPrefix,
         forceResume: continueOpts.forceResume,
-        forceNew: !!opts.new,
+        forceNew: !!opts.new || !!defaults.forceNew,
         noDashboard: opts.dashboard === false || !loadDashboardEnabled(opts.config === false),
         openDashboard: opts.openDashboard === true,
         dashboardPort: resolveDashboardPort(

--- a/src/cli/resolve.ts
+++ b/src/cli/resolve.ts
@@ -16,6 +16,8 @@ export interface ResolvedDefaults {
   reasoningEffort: ReasoningEffort;
   mcp: string[];
   session: string | undefined;
+  /** True when autoResumeSession:false is in effect — tells callers to skip the session picker. */
+  forceNew?: boolean;
 }
 
 export interface RawCliFlags {
@@ -49,9 +51,11 @@ export function resolveDefaults(flags: RawCliFlags): ResolvedDefaults {
   );
   const mcp = normalizedMcp.map(specToRaw);
 
-  const session = resolveSession(flags.session, cfg.session);
+  const session = resolveSession(flags.session, cfg.session, cfg.autoResumeSession);
+  const forceNew =
+    cfg.autoResumeSession === false && flags.session === undefined ? true : undefined;
 
-  return { model, reasoningEffort, mcp, session };
+  return { model, reasoningEffort, mcp, session, forceNew };
 }
 
 function mergeDotMcpJson(cfg: ReasonixConfig, projectRoot: string): ReasonixConfig {
@@ -63,11 +67,15 @@ function mergeDotMcpJson(cfg: ReasonixConfig, projectRoot: string): ReasonixConf
 function resolveSession(
   flag: string | false | undefined,
   configSession: string | null | undefined,
+  autoResume?: boolean,
 ): string | undefined {
   if (flag === false) return undefined;
   if (typeof flag === "string" && flag.length > 0) return flag;
   if (configSession === null) return undefined;
   if (typeof configSession === "string" && configSession.length > 0) return configSession;
+  // When autoResumeSession is explicitly false, don't default to "default" session
+  // so each launch starts fresh instead of resuming the previous conversation (#2238).
+  if (autoResume === false) return undefined;
   return "default";
 }
 

--- a/src/cli/ui/slash/commands.ts
+++ b/src/cli/ui/slash/commands.ts
@@ -157,6 +157,13 @@ export const SLASH_COMMANDS: readonly SlashCommandSpec[] = [
 
   { cmd: "sessions", group: "session", summary: "list saved sessions (current marked with ▸)" },
   {
+    cmd: "session-persist",
+    group: "session",
+    argsHint: "<on|off>",
+    summary:
+      "toggle whether reasonix resumes the last session on launch. 'off' = always start fresh (#2238).",
+  },
+  {
     cmd: "title",
     group: "session",
     summary: "ask the model to rename this session from the conversation",

--- a/src/cli/ui/slash/handlers/sessions.ts
+++ b/src/cli/ui/slash/handlers/sessions.ts
@@ -1,3 +1,4 @@
+import { readConfig, writeConfig } from "@/config.js";
 import { t } from "../../../../i18n/index.js";
 import type { SlashHandler } from "../dispatch.js";
 
@@ -19,7 +20,35 @@ const title: SlashHandler = (_args, _loop, ctx) => {
   return { info: t("handlers.sessions.titleStarted") };
 };
 
+/** `/session persist on|off` — toggle whether `reasonix code/chat` resumes
+ *  the previous session on launch (#2238). Persists to config.json. */
+const persist: SlashHandler = (args, _loop, ctx) => {
+  const sub = (args[0] ?? "").toLowerCase();
+  const cfg = readConfig(ctx.configPath);
+  const current = cfg.autoResumeSession !== false;
+  if (sub === "") {
+    return {
+      info: current ? t("handlers.sessions.persistOn") : t("handlers.sessions.persistOff"),
+    };
+  }
+  const next = sub === "on" || sub === "true" || sub === "1";
+  const off = sub === "off" || sub === "false" || sub === "0";
+  if (!next && !off) {
+    return { info: t("handlers.sessions.persistUsage") };
+  }
+  cfg.autoResumeSession = next;
+  try {
+    writeConfig(cfg, ctx.configPath);
+  } catch {
+    /* disk full / perms — runtime change still noted */
+  }
+  return {
+    info: next ? t("handlers.sessions.persistSetOn") : t("handlers.sessions.persistSetOff"),
+  };
+};
+
 export const handlers: Record<string, SlashHandler> = {
   sessions,
   title,
+  "session-persist": persist,
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -206,6 +206,9 @@ export interface ReasonixConfig {
   /** Canonical MCP server configuration — merges with and overrides legacy `mcp`/`mcpEnv`/`mcpDisabled`. */
   mcpServers?: Record<string, McpServerConfig>;
   session?: string | null;
+  /** When false, each `reasonix code` / `reasonix chat` launch starts a fresh session instead
+   *  of resuming the last one (#2238). Default true preserves existing behavior. */
+  autoResumeSession?: boolean;
   setupCompleted?: boolean;
   search?: boolean;
   /** Web search engine backend: "bing" (default, scrapes cn.bing.com), "bing-intl" (www.bing.com, indexes international sites), "searxng" (self-hosted SearXNG), "metaso" (Metaso API), "baidu" (Baidu AI Search API), "tavily" (LLM-friendly API, free tier), "perplexity" (Perplexity AI), "exa" (Exa API), "brave" (Brave Search API), or "ollama" (Ollama cloud web search). */

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -363,6 +363,11 @@ export const EN: TranslationSchema = {
       argsHint: "[N]",
     },
     sessions: { description: "list saved sessions (current marked with ▸)" },
+    "session-persist": {
+      description:
+        "toggle whether reasonix resumes the last session on launch. /session-persist off = always start fresh",
+      argsHint: "<on|off>",
+    },
     title: { description: "ask the model to rename this session from the conversation" },
     qq: {
       description:
@@ -859,6 +864,13 @@ export const EN: TranslationSchema = {
       unknownCommandShort: "unknown command: /{cmd}  (try /help)",
     },
     sessions: {
+      persistOn: "▸ session-persist → on  (next launch will resume the last session)",
+      persistOff: "▸ session-persist → off  (next launch will start a fresh session)",
+      persistSetOn:
+        "▸ session-persist set to on — next `reasonix code/chat` will resume the last session.",
+      persistSetOff:
+        "▸ session-persist set to off — next launch starts fresh. Use -c/--continue to resume.",
+      persistUsage: "usage: /session-persist <on|off>",
       titleUnavailable: "/title is only available in an active persisted TUI session.",
       titleStarted: "▸ naming session…",
       titleFailed: "▸ session title failed: {reason}",

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -349,6 +349,10 @@ export const zhCN: TranslationSchema = {
       argsHint: "[N]",
     },
     sessions: { description: "列出已保存的会话（当前标记为 ▸）" },
+    "session-persist": {
+      description: "切换是否在启动时恢复上次会话。/session-persist off = 每次启动新会话",
+      argsHint: "<on|off>",
+    },
     title: { description: "让模型根据当前对话重命名此会话" },
     qq: {
       description:
@@ -817,6 +821,12 @@ export const zhCN: TranslationSchema = {
       unknownCommandShort: "未知命令：/{cmd}  （试试 /help）",
     },
     sessions: {
+      persistOn: "▸ session-persist → on（下次启动将恢复上次会话）",
+      persistOff: "▸ session-persist → off（下次启动将开始新会话）",
+      persistSetOn: "▸ session-persist 已设为 on — 下次 `reasonix code/chat` 将恢复上次会话。",
+      persistSetOff:
+        "▸ session-persist 已设为 off — 下次启动将开启新会话。使用 -c/--continue 可显式恢复。",
+      persistUsage: "用法：/session-persist <on|off>",
       titleUnavailable: "/title 只能在已启用会话持久化的 TUI 会话中使用。",
       titleStarted: "▸ 正在命名会话…",
       titleFailed: "▸ 会话命名失败：{reason}",

--- a/tests/slash.test.ts
+++ b/tests/slash.test.ts
@@ -700,7 +700,7 @@ describe("handleSlash", () => {
     // Case-insensitive.
     expect(suggestSlashCommands("HE").map((s) => s.cmd)).toEqual(["help"]);
     // Empty prefix returns the full non-advanced release list, including code commands.
-    expect(suggestSlashCommands("", true)).toHaveLength(47);
+    expect(suggestSlashCommands("", true)).toHaveLength(48);
     expect(suggestSlashCommands("", true).map((s) => s.cmd)).toContain("logs");
     expect(suggestSlashCommands("", true).map((s) => s.cmd)).toContain("language");
     expect(suggestSlashCommands("", true).map((s) => s.cmd)).toContain("weixin");

--- a/tests/ui-slash-suggestions.test.tsx
+++ b/tests/ui-slash-suggestions.test.tsx
@@ -86,7 +86,7 @@ describe("SlashSuggestions", () => {
     );
   });
 
-  it("renders the bare slash release command surface as 47 total commands", () => {
+  it("renders the bare slash release command surface as 48 total commands", () => {
     const matches = suggestSlashCommands("", true);
     const names = matches.map((spec) => spec.cmd);
     const { lastFrame, unmount } = render(
@@ -95,13 +95,13 @@ describe("SlashSuggestions", () => {
     const frame = lastFrame() ?? "";
     unmount();
 
-    expect(matches).toHaveLength(47);
+    expect(matches).toHaveLength(48);
     expect(names).toContain("language");
     expect(names).toContain("weixin");
     expect(names).toContain("btw");
     expect(names).toContain("about");
     expect(countAdvancedCommands(true)).toBe(10);
-    expect(frame).toContain("47 commands");
+    expect(frame).toContain("48 commands");
     expect(frame).toContain("+ 10 advanced");
   });
 


### PR DESCRIPTION
## 问题

关闭 #2238。每次启动 `reasonix code` / `reasonix chat` 都会自动恢复上次未归档的对话，用户无法方便地改变这个行为。尤其是让其他 agent 调用 reasonix 时，每次都会累积上下文，导致效果变差。

## 方案

添加 `config.autoResumeSession` 字段（默认 `true` 保持现有行为）和 `/session-persist` 슬래시 커맨드：

```
/session-persist off   # 之后每次启动开启新会话
/session-persist on    # 恢复默认行为（启动时恢复上次会话）
/session-persist       # 查看当前设置
```

配置持久化到 `~/.reasonix/config.json`，也可以手动设置：
```json
{ "autoResumeSession": false }
```

- 不影响 `-c`/`--continue` 和 `--session <name>` 等显式标志
- i18n：EN + zh-CN