### PR TITLE
fix(desktop): increase sidebar minimum drag width to 200px

### DIFF
--- a/desktop/src/ui/useResizable.ts
+++ b/desktop/src/ui/useResizable.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { getThreadMaxWidth } from "./thread-layout";
 
-const MIN_WIDTH = 160;
+const MIN_WIDTH = 200;
 const MAX_WIDTH_PCT = 0.4;
 const CSS_VAR = { side: "--side-width", ctx: "--ctx-width" } as const;
 const PERSIST_KEY_SIDE = "reasonix.sideWidth";


### PR DESCRIPTION
## 中文说明

侧边栏拖拽最小宽度从 160px 调整为 200px，防止用户拖拽调整宽度时「新建会话」文字被隐藏。

- CSS 在侧边栏容器宽度 ≤190px 时会隐藏按钮文字（`styles.css:1108`）
- 原 `MIN_WIDTH = 160` 允许拖拽至 160px，导致文字被隐藏
- 修改后最小宽度为 200px，确保文字始终可见

关联 Issue: #2166

---

## English Description

Increase sidebar minimum drag width from 160px to 200px to prevent the "New Chat" button text from being hidden when users drag to resize the sidebar.

- CSS hides button text when sidebar container width ≤190px (`styles.css:1108`)
- Previous `MIN_WIDTH = 160` allowed dragging to 160px, causing text to be hidden
- New minimum width of 200px ensures text remains visible at all times

Closes #2166