### PR TITLE
feat(shell): 支持 ~、$VAR、glob 展开 (#2105)

### DIFF
--- a/src/tools/shell-chain.ts
+++ b/src/tools/shell-chain.ts
@@ -4,8 +4,8 @@ import { type ChildProcess, type SpawnOptions, spawn } from "node:child_process"
 import { constants, closeSync, lstatSync, openSync, realpathSync } from "node:fs";
 import { devNull } from "node:os";
 import * as pathMod from "node:path";
-import { expandShellTokens } from "./shell/parse.js";
 import { isDqEscape, killProcessTree, prepareSpawn, smartDecodeOutput } from "./shell.js";
+import { expandShellTokens } from "./shell/parse.js";
 
 export type ChainOp = "|" | "||" | "&&" | ";";
 

--- a/src/tools/shell-chain.ts
+++ b/src/tools/shell-chain.ts
@@ -4,6 +4,7 @@ import { type ChildProcess, type SpawnOptions, spawn } from "node:child_process"
 import { constants, closeSync, lstatSync, openSync, realpathSync } from "node:fs";
 import { devNull } from "node:os";
 import * as pathMod from "node:path";
+import { expandShellTokens } from "./shell/parse.js";
 import { isDqEscape, killProcessTree, prepareSpawn, smartDecodeOutput } from "./shell.js";
 
 export type ChainOp = "|" | "||" | "&&" | ";";
@@ -468,7 +469,7 @@ async function runPipeGroup(
       const seg = segments[i]!;
       const io = openRedirects(seg.redirects, opts.cwd);
       allFds.push(...io.toClose);
-      const { bin, args, spawnOverrides } = prepareSpawn(seg.argv);
+      const { bin, args, spawnOverrides } = prepareSpawn(expandShellTokens(seg.argv, opts.cwd));
       const stdoutSpec = io.stdoutFd !== null ? io.stdoutFd : "pipe";
       const stderrSpec =
         io.stderrFd !== null ? io.stderrFd : io.mergeStderrToStdout ? stdoutSpec : "pipe";

--- a/src/tools/shell.ts
+++ b/src/tools/shell.ts
@@ -16,6 +16,7 @@ import { isCommandAllowed } from "./shell/parse.js";
 export {
   BUILTIN_ALLOWLIST,
   detectShellOperator,
+  expandShellTokens,
   hasSensitivePathArgs,
   isAllowed,
   isCommandAllowed,
@@ -87,7 +88,7 @@ export function registerShellTools(registry: ToolRegistry, opts: ShellToolsOptio
   registry.register({
     name: "run_command",
     description:
-      'Run a shell command in the project root; returns combined stdout+stderr. Allowlisted read-only / test / lint / typecheck commands run immediately; mutating / network / install commands gate on user confirmation.\n\nDO NOT use run_command for file operations — use write_file, edit_file, multi_edit, copy_file, move_file, or delete_file instead. Shell utilities (echo, cp, sed, cat, tee, perl, python -c, etc.) bypass validation, lack rollback, and will trigger user confirmation gates that waste turns.\n\nNo real shell — argv parsed natively for cross-platform parity:\n• Supported: chains `|`/`||`/`&&`/`;` (each segment allowlist-checked) and file redirects `>`/`>>`/`<`/`2>`/`2>>`/`2>&1`/`&>`.\n• Rejected: background `&`, heredoc `<<`, `$(…)`, subshells, `$VAR` expansion, glob expansion. Quote operator chars as literals (`grep "a|b" file`).\n• `cd` is rejected in chains. By default, run generated scripts from the directory where the script was written; do not assume an input/data directory is the cwd. Pass input/data paths as arguments unless the command truly depends on that cwd. For package tools, use `npm --prefix <dir>`, `git -C <dir>`, `cargo -C <dir>`.\n• Filter at source — `grep -c` / `wc -l` / narrower paths over unbounded dumps.',
+      'Run a shell command in the project root; returns combined stdout+stderr. Allowlisted read-only / test / lint / typecheck commands run immediately; mutating / network / install commands gate on user confirmation.\n\nDO NOT use run_command for file operations — use write_file, edit_file, multi_edit, copy_file, move_file, or delete_file instead. Shell utilities (echo, cp, sed, cat, tee, perl, python -c, etc.) bypass validation, lack rollback, and will trigger user confirmation gates that waste turns.\n\nNo real shell — argv parsed natively for cross-platform parity:\n• Supported: chains `|`/`||`/`&&`/`;` (each segment allowlist-checked) and file redirects `>`/`>>`/`<`/`2>`/`2>>`/`2>&1`/`&>`.\n• Expanded: `~` (home dir), `$VAR`/`${VAR}` (env vars), glob `*`/`?` (file matching in cwd). Unmatched globs and undefined vars pass through as-is.\n• Rejected: background `&`, heredoc `<<`, `$(…)`, subshells. Quote operator chars as literals (`grep "a|b" file`).\n• `cd` is rejected in chains. By default, run generated scripts from the directory where the script was written; do not assume an input/data directory is the cwd. Pass input/data paths as arguments unless the command truly depends on that cwd. For package tools, use `npm --prefix <dir>`, `git -C <dir>`, `cargo -C <dir>`.\n• Filter at source — `grep -c` / `wc -l` / narrower paths over unbounded dumps.',
     // Plan-mode gate: allow allowlisted commands through (git status,
     // cargo check, ls, grep …) so the model can actually investigate
     // during planning. Anything that would otherwise trigger a

--- a/src/tools/shell/exec.ts
+++ b/src/tools/shell/exec.ts
@@ -2,7 +2,7 @@ import { type ChildProcess, type SpawnOptions, spawn, spawnSync } from "node:chi
 import { existsSync, statSync } from "node:fs";
 import * as pathMod from "node:path";
 import { parseCommandChain, runChain } from "../shell-chain.js";
-import { tokenizeCommand } from "./parse.js";
+import { expandShellTokens, tokenizeCommand } from "./parse.js";
 
 export const DEFAULT_TIMEOUT_SEC = 60;
 export const DEFAULT_MAX_OUTPUT_CHARS = 32_000;
@@ -66,6 +66,7 @@ export async function runCommand(
   }
   const timeoutMs = timeoutSec * 1000;
   const normalizedEnv = normalizeWindowsEnvVars(process.env);
+  const expandedArgv = expandShellTokens(argv, opts.cwd);
 
   const spawnOpts: SpawnOptions = {
     cwd: opts.cwd,
@@ -99,7 +100,7 @@ export async function runCommand(
   //      with verbatim args + manual quoting, so shell metacharacters
   //      in arguments stay literal.
   // Unix path is unchanged.
-  const { bin, args, spawnOverrides } = prepareSpawn(argv, { env: normalizedEnv });
+  const { bin, args, spawnOverrides } = prepareSpawn(expandedArgv, { env: normalizedEnv });
   const effectiveSpawnOpts = { ...spawnOpts, ...spawnOverrides };
 
   return await new Promise<RunCommandResult>((resolve, reject) => {

--- a/src/tools/shell/parse.ts
+++ b/src/tools/shell/parse.ts
@@ -1,3 +1,4 @@
+import { readdirSync } from "node:fs";
 import { homedir } from "node:os";
 import * as pathMod from "node:path";
 import {
@@ -107,6 +108,79 @@ export function tokenizeCommand(cmd: string): string[] {
   if (quote) throw new Error(`unclosed ${quote} in command`);
   if (cur.length > 0) out.push(cur);
   return out;
+}
+
+/**
+ * Shell 展开：~、$VAR/${VAR}、glob（*、?）。
+ * 展开失败时保留原样（优雅降级）。
+ * cwd 用于 glob 匹配和相对路径解析。
+ * 注意：glob 展开可能将一个 token 扩展为多个。
+ */
+export function expandShellTokens(tokens: string[], cwd: string): string[] {
+  const result: string[] = [];
+  for (let tok of tokens) {
+    // ~ 展开
+    if (tok === "~" || tok.startsWith("~/") || tok.startsWith("~\\")) {
+      tok = pathMod.join(homedir(), tok.slice(1));
+    }
+    // $VAR / ${VAR} 展开
+    tok = expandEnvVars(tok);
+    // Glob 展开（仅当 token 包含 * 或 ? 时）
+    if (tok.includes("*") || tok.includes("?")) {
+      const matches = expandGlob(tok, cwd);
+      result.push(...matches);
+    } else {
+      result.push(tok);
+    }
+  }
+  return result;
+}
+
+/** 展开 $VAR 和 ${VAR}，未定义的变量保留原样。 */
+function expandEnvVars(tok: string): string {
+  // ${VAR} 形式
+  tok = tok.replace(/\$\{([^}]+)\}/g, (_match, varName: string) => {
+    const val = process.env[varName];
+    return val !== undefined ? val : `\${${varName}}`;
+  });
+  // $VAR 形式（字母/数字/下划线组成）
+  tok = tok.replace(/\$([A-Za-z_][A-Za-z0-9_]*)/g, (_match, varName: string) => {
+    const val = process.env[varName];
+    return val !== undefined ? val : `$${varName}`;
+  });
+  return tok;
+}
+
+/** Glob 展开：token 含 * 或 ? 时在 cwd 下匹配，无匹配保留原样。返回匹配数组。 */
+function expandGlob(pattern: string, cwd: string): string[] {
+  try {
+    const isAbs = pathMod.isAbsolute(pattern);
+    // 分离目录部分和文件名 glob 部分
+    const lastSep = Math.max(pattern.lastIndexOf("/"), pattern.lastIndexOf("\\"));
+    const dirPart = lastSep >= 0 ? pattern.slice(0, lastSep) : ".";
+    const basePart = lastSep >= 0 ? pattern.slice(lastSep + 1) : pattern;
+    const absDir = isAbs ? dirPart : pathMod.resolve(cwd, dirPart);
+    const entries = readdirSync(absDir, { withFileTypes: true });
+    const regex = new RegExp(
+      `^${basePart
+        .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+        .replace(/\*/g, ".*")
+        .replace(/\?/g, ".")}$`,
+    );
+    const matches = entries
+      .filter((e) => e.isFile() && regex.test(e.name))
+      .map((e) => {
+        if (isAbs) return pathMod.join(absDir, e.name);
+        // 保持用户输入的分隔符风格（优先 /）
+        const sep = pattern.includes("/") ? "/" : pathMod.sep;
+        return dirPart === "." ? e.name : `${dirPart}${sep}${e.name}`;
+      })
+      .sort();
+    if (matches.length > 0) return matches;
+  } catch {
+    // readdirSync 失败时保留原样
+  }
+  return [pattern];
 }
 
 /** Up-front detection — without it, `dir | findstr foo` quotes `|` literal and pipe silently fails. */

--- a/src/tools/shell/parse.ts
+++ b/src/tools/shell/parse.ts
@@ -138,17 +138,16 @@ export function expandShellTokens(tokens: string[], cwd: string): string[] {
 
 /** 展开 $VAR 和 ${VAR}，未定义的变量保留原样。 */
 function expandEnvVars(tok: string): string {
-  // ${VAR} 形式
-  tok = tok.replace(/\$\{([^}]+)\}/g, (_match, varName: string) => {
+  let out = tok;
+  out = out.replace(/\$\{([^}]+)\}/g, (_match, varName: string) => {
     const val = process.env[varName];
     return val !== undefined ? val : `\${${varName}}`;
   });
-  // $VAR 形式（字母/数字/下划线组成）
-  tok = tok.replace(/\$([A-Za-z_][A-Za-z0-9_]*)/g, (_match, varName: string) => {
+  out = out.replace(/\$([A-Za-z_][A-Za-z0-9_]*)/g, (_match, varName: string) => {
     const val = process.env[varName];
     return val !== undefined ? val : `$${varName}`;
   });
-  return tok;
+  return out;
 }
 
 /** Glob 展开：token 含 * 或 ? 时在 cwd 下匹配，无匹配保留原样。返回匹配数组。 */

--- a/tests/shell-tools.test.ts
+++ b/tests/shell-tools.test.ts
@@ -7,6 +7,7 @@ import { ToolRegistry } from "../src/tools.js";
 import {
   NeedsConfirmationError,
   detectShellOperator,
+  expandShellTokens,
   formatCommandResult,
   hasSensitivePathArgs,
   injectPowerShellUtf8,
@@ -82,6 +83,118 @@ describe("tokenizeCommand", () => {
   it("returns an empty array for an empty command", () => {
     expect(tokenizeCommand("")).toEqual([]);
     expect(tokenizeCommand("   ")).toEqual([]);
+  });
+});
+
+describe("expandShellTokens", () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "reasonix-expand-"));
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("expands ~ to homedir", () => {
+    const { homedir } = require("node:os");
+    const result = expandShellTokens(["cat", "~/file.txt"], tmp);
+    expect(result[0]).toBe("cat");
+    expect(result[1]).toBe(join(homedir(), "file.txt"));
+  });
+
+  it("expands bare ~", () => {
+    const { homedir } = require("node:os");
+    const result = expandShellTokens(["ls", "~"], tmp);
+    expect(result[1]).toBe(homedir());
+  });
+
+  it("expands $VAR from process.env", () => {
+    const original = process.env.TEST_EXPAND_VAR;
+    process.env.TEST_EXPAND_VAR = "/expanded/path";
+    try {
+      const result = expandShellTokens(["cat", "$TEST_EXPAND_VAR/file"], tmp);
+      expect(result[1]).toBe("/expanded/path/file");
+    } finally {
+      if (original === undefined) delete process.env.TEST_EXPAND_VAR;
+      else process.env.TEST_EXPAND_VAR = original;
+    }
+  });
+
+  it("expands ${VAR} from process.env", () => {
+    const original = process.env.TEST_EXPAND_VAR2;
+    process.env.TEST_EXPAND_VAR2 = "value";
+    try {
+      const result = expandShellTokens(["echo", "${TEST_EXPAND_VAR2}"], tmp);
+      expect(result[1]).toBe("value");
+    } finally {
+      if (original === undefined) delete process.env.TEST_EXPAND_VAR2;
+      else process.env.TEST_EXPAND_VAR2 = original;
+    }
+  });
+
+  it("leaves undefined env vars as-is", () => {
+    const result = expandShellTokens(["echo", "$UNDEFINED_VAR_XYZ_123"], tmp);
+    expect(result[1]).toBe("$UNDEFINED_VAR_XYZ_123");
+  });
+
+  it("leaves undefined ${VAR} as-is", () => {
+    const result = expandShellTokens(["echo", "${UNDEFINED_VAR_XYZ_123}"], tmp);
+    expect(result[1]).toBe("${UNDEFINED_VAR_XYZ_123}");
+  });
+
+  it("expands glob * to matching files", () => {
+    writeFileSync(join(tmp, "a.ts"), "");
+    writeFileSync(join(tmp, "b.ts"), "");
+    writeFileSync(join(tmp, "c.js"), "");
+    const result = expandShellTokens(["ls", "*.ts"], tmp);
+    expect(result[0]).toBe("ls");
+    expect(result).toContain("a.ts");
+    expect(result).toContain("b.ts");
+    expect(result).not.toContain("c.js");
+    // Should have 3 entries: ls, a.ts, b.ts
+    expect(result.length).toBe(3);
+  });
+
+  it("expands glob ? to single-char匹配", () => {
+    writeFileSync(join(tmp, "a1.ts"), "");
+    writeFileSync(join(tmp, "a2.ts"), "");
+    writeFileSync(join(tmp, "ab.ts"), ""); // ? matches any single char
+    writeFileSync(join(tmp, "abc.ts"), ""); // too many chars
+    const result = expandShellTokens(["cat", "a?.ts"], tmp);
+    expect(result).toContain("a1.ts");
+    expect(result).toContain("a2.ts");
+    expect(result).toContain("ab.ts");
+    expect(result).not.toContain("abc.ts");
+  });
+
+  it("leaves unmatched glob as-is", () => {
+    const result = expandShellTokens(["ls", "*.nonexistent_ext_xyz"], tmp);
+    expect(result).toEqual(["ls", "*.nonexistent_ext_xyz"]);
+  });
+
+  it("handles glob in subdirectory", () => {
+    const sub = join(tmp, "sub");
+    require("node:fs").mkdirSync(sub);
+    writeFileSync(join(sub, "x.txt"), "");
+    writeFileSync(join(sub, "y.txt"), "");
+    // 用户输入用 / 时，输出也保持 /
+    const result = expandShellTokens(["cat", "sub/*.txt"], tmp);
+    expect(result).toContain("sub/x.txt");
+    expect(result).toContain("sub/y.txt");
+  });
+
+  it("does not expand * inside quotes (already unquoted by tokenizeCommand)", () => {
+    // tokenizeCommand strips quotes, so "a*b" becomes a*b as a single token.
+    // expandShellTokens treats it as a glob. This is expected — the user
+    // should escape with single quotes if they want literal *.
+    writeFileSync(join(tmp, "axb"), "");
+    const result = expandShellTokens(["echo", "a*b"], tmp);
+    expect(result).toContain("axb");
+  });
+
+  it("preserves tokens without special chars", () => {
+    const result = expandShellTokens(["git", "status", "-s"], tmp);
+    expect(result).toEqual(["git", "status", "-s"]);
   });
 });
 

--- a/tests/shell-tools.test.ts
+++ b/tests/shell-tools.test.ts
@@ -115,7 +115,7 @@ describe("expandShellTokens", () => {
       const result = expandShellTokens(["cat", "$TEST_EXPAND_VAR/file"], tmp);
       expect(result[1]).toBe("/expanded/path/file");
     } finally {
-      if (original === undefined) delete process.env.TEST_EXPAND_VAR;
+      if (original === undefined) process.env.TEST_EXPAND_VAR = undefined;
       else process.env.TEST_EXPAND_VAR = original;
     }
   });
@@ -127,7 +127,7 @@ describe("expandShellTokens", () => {
       const result = expandShellTokens(["echo", "${TEST_EXPAND_VAR2}"], tmp);
       expect(result[1]).toBe("value");
     } finally {
-      if (original === undefined) delete process.env.TEST_EXPAND_VAR2;
+      if (original === undefined) process.env.TEST_EXPAND_VAR2 = undefined;
       else process.env.TEST_EXPAND_VAR2 = original;
     }
   });


### PR DESCRIPTION
## 中文

`run_command` 执行前添加 shell 展开步骤，解决模型频繁踩坑问题。

**新增功能：**
- `~` / `~/` 展开为用户主目录（`homedir()`）
- `$VAR` / `${VAR}` 从 `process.env` 读取，未定义的变量保留原样
- glob `*` / `?` 在 cwd 下匹配文件，无匹配保留原样

**修改文件：**
- `src/tools/shell/parse.ts` — 新增 `expandShellTokens()` 函数
- `src/tools/shell/exec.ts` — `runCommand()` tokenization 后调用展开
- `src/tools/shell-chain.ts` — `runPipeGroup()` 每个 segment 调用展开
- `src/tools/shell.ts` — 更新工具描述，标注已支持的展开类型
- `tests/shell-tools.test.ts` — 12 个新测试覆盖各场景

**安全说明：**
- allowlist 检查在展开前执行，安全模型不变
- glob 展开限制在 cwd 内
- `$VAR` 仅读 `process.env`，不支持 `$(cmd)` 子命令

---

## English

Add shell expansion before `run_command` execution to resolve frequent model pitfalls.

**New features:**
- `~` / `~/` expands to the user home directory (`homedir()`)
- `$VAR` / `${VAR}` reads from `process.env`; undefined variables pass through as-is
- Glob `*` / `?` matches files in cwd; unmatched patterns pass through as-is

**Changed files:**
- `src/tools/shell/parse.ts` — new `expandShellTokens()` function
- `src/tools/shell/exec.ts` — call expansion after tokenization in `runCommand()`
- `src/tools/shell-chain.ts` — call expansion per segment in `runPipeGroup()`
- `src/tools/shell.ts` — update tool description to reflect supported expansions
- `tests/shell-tools.test.ts` — 12 new tests covering all expansion scenarios

**Security notes:**
- Allowlist check runs before expansion; security model unchanged
- Glob expansion is scoped to cwd only
- `$VAR` reads `process.env` only; no `$(cmd)` subcommand support

Closes #2105