### PR TITLE
fix(markdown): preserve backslash in escape tokens (#2247)

### DIFF
--- a/src/cli/ui/markdown-lines.ts
+++ b/src/cli/ui/markdown-lines.ts
@@ -185,7 +185,8 @@ function walk(tokens: Token[], style: InlineStyle, out: InlineSpan[]): void {
         out.push({ text: "\n", ...style });
         break;
       case "escape":
-        pushTextSpans((tok as Tokens.Escape).text, style, out);
+        // marked drops the escape backslash; restore it for chat/code content (#2247)
+        pushTextSpans(`\\${(tok as Tokens.Escape).text}`, style, out);
         break;
       case "html":
         pushTextSpans((tok as Tokens.HTML).text, style, out);

--- a/src/cli/ui/markdown.tsx
+++ b/src/cli/ui/markdown.tsx
@@ -462,7 +462,8 @@ function InlineToken({ token }: { token: Token }): React.ReactElement {
     case "br":
       return <Text>{"\n"}</Text>;
     case "escape":
-      return <Text>{(token as Tokens.Escape).text}</Text>;
+      // marked drops the escape backslash; restore it for chat/code content (#2247)
+      return <Text>{`\\${(token as Tokens.Escape).text}`}</Text>;
     case "html":
       return <Text>{(token as Tokens.HTML).text}</Text>;
     default:

--- a/tests/markdown.test.ts
+++ b/tests/markdown.test.ts
@@ -2,6 +2,7 @@ import { type Tokens, marked } from "marked";
 import React from "react";
 import stringWidth from "string-width";
 import { describe, expect, it } from "vitest";
+import { markdownToLines, spansText } from "../src/cli/ui/markdown-lines.js";
 import { Markdown, plainText, tableLayout } from "../src/cli/ui/markdown.js";
 import { wrapToCells } from "../src/cli/ui/text-width.js";
 import { render } from "./helpers/ink-test.js";
@@ -245,6 +246,40 @@ describe("FallbackTable width invariants", () => {
         layout.labelPad + layout.valueCells,
         `width=${w}: labelPad(${layout.labelPad}) + valueCells(${layout.valueCells}) > ${w}`,
       ).toBeLessThanOrEqual(w);
+    }
+  });
+});
+
+describe("Markdown — escape backslash preservation (#2247)", () => {
+  it("preserves \\( backslash in Swift string interpolation", () => {
+    const lines = markdownToLines(String.raw`return "/\(APIVersion)/xxx"`);
+    const text = lines.map((l) => ("spans" in l ? spansText(l.spans) : "")).join("");
+    expect(text).toContain(String.raw`\(`);
+    expect(text).not.toContain("$"); // Regression: should not render as $APIVersion
+  });
+
+  it("preserves \\$ backslash in shell variable", () => {
+    const lines = markdownToLines(String.raw`echo "Price: \$5.99"`);
+    const text = lines.map((l) => ("spans" in l ? spansText(l.spans) : "")).join("");
+    expect(text).toContain(String.raw`\$`);
+  });
+
+  it("preserves \\[ escape bracket", () => {
+    const lines = markdownToLines(String.raw`foo \[bar\] baz`);
+    const text = lines.map((l) => ("spans" in l ? spansText(l.spans) : "")).join("");
+    expect(text).toContain(String.raw`\[`);
+    expect(text).toContain(String.raw`\]`);
+  });
+
+  it("preserves backslash in code-fenced text unchanged", () => {
+    // Code fences are block-level tokens, not inline — marked should not
+    // escape-process their content at all.
+    const md = ["```", String.raw`return "/\(APIVersion)/xxx"`, "```"].join("\n");
+    const lines = markdownToLines(md);
+    const codeLine = lines.find((l) => l.kind === "code");
+    expect(codeLine).toBeDefined();
+    if (codeLine?.kind === "code") {
+      expect(codeLine.text).toContain(String.raw`\(`);
     }
   });
 });


### PR DESCRIPTION
## What

marked's escape tokenizer strips the leading backslash from escaped characters (e.g. `\(` → `"("`). In a chat/code context the LLM often writes code with legitimate backslash escapes (Swift string interpolation `\(…)`, shell `\$VAR`, etc.). This fix preserves the backslash so the TUI display matches the original source.

Changed files:
- `src/cli/ui/markdown-lines.ts` — escape handler in `walk()`
- `src/cli/ui/markdown.tsx` — escape handler in `InlineToken()`
- `tests/markdown.test.ts` — 4 new tests

## Why

Bug fix for #2247. Users reported that code containing `\(` was displayed incorrectly (missing backslash), making Swift string interpolation and other backslash-escaped content unreadable.

## How to verify

```
npm test -- tests/markdown.test.ts
```

All 24 tests pass (20 existing + 4 new):
- renders Swift `\(` interpolation correctly
- preserves `\$` in shell variables
- preserves `\[` bracket escapes
- code-fenced text unchanged

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time
