### PR TITLE
Settings Connectivity Checks for API Providers / 设置页 API 连通性测试

### DIFF
--- a/desktop/src/App.test.ts
+++ b/desktop/src/App.test.ts
@@ -79,6 +79,7 @@ function initialState(): Parameters<typeof reduce>[0] {
     activeSkill: null,
     queuedSends: [],
     retryNonce: 0,
+    connectionTests: {},
   };
 }
 

--- a/desktop/src/App.test.ts
+++ b/desktop/src/App.test.ts
@@ -35,6 +35,10 @@ vi.mock("./theme", () => ({
 }));
 
 import { readWindowExpanded, reduce, toggleWindowExpanded } from "./App";
+import {
+  buildConnectionTestRequestKey,
+  matchingConnectionTestResult,
+} from "./connection-test-key";
 import { getThreadMaxWidth } from "./ui/thread-layout";
 
 function initialState(): Parameters<typeof reduce>[0] {
@@ -137,6 +141,91 @@ function makePathPrompt(
 }
 
 describe("Desktop App reducer — usage", () => {
+  it("keeps connection test results scoped to the tested settings", () => {
+    const settings = {
+      reasoningEffort: "low" as const,
+      editMode: "review" as const,
+      budgetUsd: null,
+      workspaceDir: "/workspace",
+      recentWorkspaces: [],
+      model: "deepseek-v4-flash",
+      webSearchEngine: "bing" as const,
+      version: "test",
+    };
+    const requestKey = buildConnectionTestRequestKey(
+      "webSearch",
+      { engine: "bing" },
+      settings,
+    );
+    const pending = reduce(
+      { ...initialState(), settings },
+      {
+        t: "connection_test_result",
+        result: {
+          type: "$connection_test_result",
+          target: "webSearch",
+          ok: false,
+          message: "",
+          latencyMs: -1,
+          requestKey,
+        },
+      },
+    );
+
+    const settled = reduce(pending, {
+      t: "incoming",
+      event: {
+        type: "$connection_test_result",
+        target: "webSearch",
+        ok: true,
+        message: "Connected",
+        latencyMs: 42,
+      },
+    });
+
+    expect(settled.connectionTests.webSearch?.requestKey).toBe(requestKey);
+    expect(
+      matchingConnectionTestResult(
+        settled.connectionTests.webSearch,
+        "webSearch",
+        { engine: "tavily" },
+        { ...settings, webSearchEngine: "tavily" },
+      ),
+    ).toBeUndefined();
+  });
+
+  it("invalidates connection test results when draft credentials change", () => {
+    const firstKey = buildConnectionTestRequestKey(
+      "deepseek",
+      { apiKey: "sk-first", baseUrl: null },
+      { apiKeyPrefix: "saved", baseUrl: undefined },
+    );
+    const secondKey = buildConnectionTestRequestKey(
+      "deepseek",
+      { apiKey: "sk-second", baseUrl: null },
+      { apiKeyPrefix: "saved", baseUrl: undefined },
+    );
+    const result = {
+      type: "$connection_test_result" as const,
+      target: "deepseek" as const,
+      ok: true,
+      message: "Connected",
+      latencyMs: 12,
+      requestKey: firstKey,
+    };
+
+    expect(firstKey).not.toBe(secondKey);
+    expect(firstKey).not.toContain("sk-first");
+    expect(
+      matchingConnectionTestResult(
+        result,
+        "deepseek",
+        { apiKey: "sk-second", baseUrl: null },
+        { apiKeyPrefix: "saved", baseUrl: undefined },
+      ),
+    ).toBeUndefined();
+  });
+
   it("falls back prompt tokens to cache miss tokens when cache fields are absent", () => {
     const next = reduce(initialState(), {
       t: "incoming",

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -17,6 +17,10 @@ import {
   restoreAbortedDraft,
   type AbortDraftSource,
 } from "./abort-draft";
+import {
+  attachConnectionTestRequestKey,
+  buildConnectionTestRequestKey,
+} from "./connection-test-key";
 import { getLang, getLangLabel, getSupportedLangs, setLang, t, useLang } from "./i18n";
 import { I } from "./icons";
 import {
@@ -653,7 +657,10 @@ function reduceRaw(state: State, action: Action): State {
         ...state,
         connectionTests: {
           ...state.connectionTests,
-          [action.result.target]: action.result,
+          [action.result.target]: attachConnectionTestRequestKey(
+            action.result,
+            state.connectionTests[action.result.target],
+          ),
         },
       };
     case "push_status":
@@ -1298,7 +1305,7 @@ function applyIncomingRaw(state: State, ev: IncomingEvent): State {
         ...state,
         connectionTests: {
           ...state.connectionTests,
-          [ev.target]: ev,
+          [ev.target]: attachConnectionTestRequestKey(ev, state.connectionTests[ev.target]),
         },
       };
     case "$btw_result":
@@ -1632,6 +1639,7 @@ function TabRuntime({
       endpoint?: string | null;
       apiKeys?: Record<string, string>;
     }) => {
+      const requestKey = buildConnectionTestRequestKey(target, opts, state.settings);
       dispatch({
         t: "connection_test_result",
         result: {
@@ -1640,11 +1648,12 @@ function TabRuntime({
           ok: false,
           message: "",
           latencyMs: -1,
+          requestKey,
         },
       });
-      sendRpc({ cmd: "settings_test_connection", target, ...opts });
+      sendRpc({ cmd: "settings_test_connection", target, requestKey, ...opts });
     },
-    [sendRpc],
+    [sendRpc, state.settings],
   );
   const addMcpSpec = useCallback(
     (spec: string) => sendRpc({ cmd: "mcp_specs_add", spec }),

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -45,6 +45,8 @@ import type {
   CheckpointVerdict,
   ChoiceVerdict,
   ConfirmationChoice,
+  ConnectionTestResultEvent,
+  ConnectionTestTarget,
   ExternalSessionApp,
   ExternalSessionSource,
   ImportedMcpServer,
@@ -219,6 +221,11 @@ export type PendingRevision = {
   summary?: string;
 };
 
+export type ConnectionTestState = {
+  deepseek?: ConnectionTestResultEvent;
+  webSearch?: ConnectionTestResultEvent;
+};
+
 export type UsageStats = {
   totalCostUsd: number;
   totalPromptTokens: number;
@@ -374,6 +381,8 @@ type State = {
   /** Populated by $retry_result — component useEffect reads and sets composer draft. */
   retryText?: string;
   retryNonce: number;
+  /** Per-target connection test results from settings page. */
+  connectionTests: ConnectionTestState;
 };
 
 export type SessionFile = {
@@ -409,6 +418,7 @@ type Action =
   | { t: "dequeue_send"; index: number }
   | { t: "shift_queued_send" }
   | { t: "settings_patch"; patch: SettingsPatch }
+  | { t: "connection_test_result"; result: ConnectionTestResultEvent }
   | { t: "push_status"; text: string };
 
 function sanitizeSettingsPatch(patch: SettingsPatch): Partial<Settings> {
@@ -638,6 +648,14 @@ function reduceRaw(state: State, action: Action): State {
       };
     case "shift_queued_send":
       return { ...state, queuedSends: state.queuedSends.slice(1) };
+    case "connection_test_result":
+      return {
+        ...state,
+        connectionTests: {
+          ...state.connectionTests,
+          [action.result.target]: action.result,
+        },
+      };
     case "push_status":
       return { ...state, messages: [...state.messages, { kind: "status", text: action.text }] };
   }
@@ -1275,6 +1293,14 @@ function applyIncomingRaw(state: State, ev: IncomingEvent): State {
     }
     case "$retry_result":
       return { ...state, retryText: ev.text, retryNonce: state.retryNonce + 1 };
+    case "$connection_test_result":
+      return {
+        ...state,
+        connectionTests: {
+          ...state.connectionTests,
+          [ev.target]: ev,
+        },
+      };
     case "$btw_result":
       return {
         ...state,
@@ -1444,6 +1470,7 @@ function TabRuntime({
     activeSkill: null,
     queuedSends: [],
     retryNonce: 0,
+    connectionTests: {},
   });
   useLang();
   useDisableTextAssist();
@@ -1472,6 +1499,7 @@ function TabRuntime({
   >(undefined);
   const composerRef = useRef<HTMLTextAreaElement>(null);
   const threadRef = useRef<HTMLDivElement>(null);
+
   const virtuosoRef = useRef<VirtuosoHandle>(null);
   const virtScrollerRef = useRef<HTMLDivElement | null>(null);
   const atBottomRef = useRef(true);
@@ -1594,6 +1622,28 @@ function TabRuntime({
   );
   const saveApiKey = useCallback(
     (key: string) => sendRpc({ cmd: "setup_save_key", key }),
+    [sendRpc],
+  );
+  const testConnection = useCallback(
+    (target: ConnectionTestTarget, opts?: {
+      apiKey?: string;
+      baseUrl?: string | null;
+      engine?: string;
+      endpoint?: string | null;
+      apiKeys?: Record<string, string>;
+    }) => {
+      dispatch({
+        t: "connection_test_result",
+        result: {
+          type: "$connection_test_result",
+          target,
+          ok: false,
+          message: "",
+          latencyMs: -1,
+        },
+      });
+      sendRpc({ cmd: "settings_test_connection", target, ...opts });
+    },
     [sendRpc],
   );
   const addMcpSpec = useCallback(
@@ -2869,6 +2919,8 @@ function TabRuntime({
             memory={state.memory}
             memoryDetail={state.memoryDetail}
             qq={state.qq}
+            connectionTests={state.connectionTests}
+            onTestConnection={testConnection}
             onClose={() => setSettingsOpen(false)}
             onSave={saveSettings}
             onSaveApiKey={saveApiKey}

--- a/desktop/src/connection-test-key.ts
+++ b/desktop/src/connection-test-key.ts
@@ -1,0 +1,86 @@
+import type { ConnectionTestResultEvent, ConnectionTestTarget } from "./protocol";
+
+export type ConnectionTestOptions = {
+  apiKey?: string;
+  baseUrl?: string | null;
+  engine?: string;
+  endpoint?: string | null;
+  apiKeys?: Record<string, string | undefined>;
+};
+
+export type ConnectionTestSettingsSnapshot = {
+  apiKeyPrefix?: string;
+  baseUrl?: string;
+  webSearchEngine?: string;
+  webSearchEndpoint?: string;
+  webSearchApiKeys?: Record<string, string | undefined>;
+};
+
+function normalizeValue(value: string | null | undefined): string {
+  const trimmed = (value ?? "").trim();
+  return trimmed || "<default>";
+}
+
+function fingerprintSecret(value: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < value.length; i += 1) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return `${value.length}:${(hash >>> 0).toString(36)}`;
+}
+
+function credentialKey(draft: string | undefined, savedPrefix: string | undefined): string {
+  const trimmedDraft = draft?.trim();
+  if (trimmedDraft) return `draft:${fingerprintSecret(trimmedDraft)}`;
+  return savedPrefix ? `saved:${savedPrefix}` : "saved:<unset>";
+}
+
+export function buildConnectionTestRequestKey(
+  target: ConnectionTestTarget,
+  opts: ConnectionTestOptions | undefined,
+  settings: ConnectionTestSettingsSnapshot | null | undefined,
+): string {
+  if (target === "deepseek") {
+    const baseUrl = opts?.baseUrl === undefined ? settings?.baseUrl : opts.baseUrl;
+    return [
+      "deepseek",
+      `baseUrl=${normalizeValue(baseUrl)}`,
+      `credential=${credentialKey(opts?.apiKey, settings?.apiKeyPrefix)}`,
+    ].join("|");
+  }
+
+  const engine = opts?.engine ?? settings?.webSearchEngine ?? "bing";
+  const savedPrefix = settings?.webSearchApiKeys?.[engine];
+  const draftKey = opts?.apiKeys?.[engine];
+  const endpoint =
+    engine === "searxng"
+      ? normalizeValue(opts?.endpoint === undefined ? settings?.webSearchEndpoint : opts.endpoint)
+      : "<none>";
+
+  return [
+    "webSearch",
+    `engine=${engine}`,
+    `endpoint=${endpoint}`,
+    `credential=${credentialKey(draftKey, savedPrefix)}`,
+  ].join("|");
+}
+
+export function attachConnectionTestRequestKey(
+  result: ConnectionTestResultEvent,
+  previous: ConnectionTestResultEvent | undefined,
+): ConnectionTestResultEvent {
+  if (result.requestKey || !previous?.requestKey) return result;
+  return { ...result, requestKey: previous.requestKey };
+}
+
+export function matchingConnectionTestResult(
+  result: ConnectionTestResultEvent | undefined,
+  target: ConnectionTestTarget,
+  opts: ConnectionTestOptions | undefined,
+  settings: ConnectionTestSettingsSnapshot | null | undefined,
+): ConnectionTestResultEvent | undefined {
+  if (!result) return undefined;
+  const requestKey = buildConnectionTestRequestKey(target, opts, settings);
+  return result.requestKey === requestKey ? result : undefined;
+}

--- a/desktop/src/i18n/de.ts
+++ b/desktop/src/i18n/de.ts
@@ -221,6 +221,8 @@ export const de: typeof en = {
     baseUrl: "DeepSeek-Basis-URL",
     baseUrlHint:
       "Nur bei Verwendung eines Proxys überschreiben. Leer = offizieller Endpunkt. Neustart erforderlich.",
+    baseUrlCustomCredentialWarning:
+      "Benutzerdefinierte Endpunkte erhalten bei Verbindungstests deinen DeepSeek-API-Schlüssel.",
     workspace: "Arbeitsbereich",
     workspaceHint:
       "Root-Verzeichnis, in dem Agent-Tools arbeiten. Wechseln speichert in der Konfiguration und lädt Tools neu.",

--- a/desktop/src/i18n/en.ts
+++ b/desktop/src/i18n/en.ts
@@ -211,6 +211,7 @@ export const en = {
     },
     baseUrl: "DeepSeek base URL",
     baseUrlHint: "Override only if using a proxy. Empty = official endpoint. Restart required.",
+    baseUrlCustomCredentialWarning: "Custom endpoints receive your DeepSeek API key during connection tests.",
     workspace: "Workspace",
     workspaceHint:
       "Root dir agent tools operate inside. Switching saves to config and reloads tools.",

--- a/desktop/src/i18n/en.ts
+++ b/desktop/src/i18n/en.ts
@@ -381,6 +381,12 @@ export const en = {
     shortcutSwitchTab: "Switch tab",
     shortcutAbort: "Abort streaming",
     shortcutSettings: "Settings",
+    // Connection test
+    testConnection: "Test",
+    testingConnection: "Testing…",
+    connectionOk: "Connected · {latencyMs}ms",
+    connectionFailed: "Connection failed",
+    connectionPaidHint: "A minimal test request will be sent to the provider",
   },
   modal: {
     planFeedbackPlaceholder: "What problems does the plan have? What needs to be improved?",

--- a/desktop/src/i18n/ja.ts
+++ b/desktop/src/i18n/ja.ts
@@ -383,6 +383,12 @@ export const ja: typeof en = {
     shortcutSwitchTab: "タブ切替",
     shortcutAbort: "ストリーミング中断",
     shortcutSettings: "設定",
+    // Connection test
+    testConnection: "テスト",
+    testingConnection: "テスト中…",
+    connectionOk: "接続完了 · {latencyMs}ms",
+    connectionFailed: "接続失敗",
+    connectionPaidHint: "最小限のテストリクエストがプロバイダに送信されます",
   },
   modal: {
     ...en.modal,

--- a/desktop/src/i18n/ja.ts
+++ b/desktop/src/i18n/ja.ts
@@ -219,6 +219,8 @@ export const ja: typeof en = {
     },
     baseUrl: "DeepSeek ベースURL",
     baseUrlHint: "プロキシ使用時のみ上書き。空欄 = 公式エンドポイント。再起動が必要です。",
+    baseUrlCustomCredentialWarning:
+      "カスタムエンドポイントは接続テスト時に DeepSeek APIキーを受け取ります。",
     workspace: "ワークスペース",
     workspaceHint:
       "エージェントツールが操作するルートディレクトリ。切り替えは設定に保存され、ツールが再読み込みされます。",

--- a/desktop/src/i18n/zh-CN.ts
+++ b/desktop/src/i18n/zh-CN.ts
@@ -210,6 +210,7 @@ export const zhCN: typeof en = {
     },
     baseUrl: "DeepSeek base URL",
     baseUrlHint: "走代理时再改。留空 = 官方地址。需重启。",
+    baseUrlCustomCredentialWarning: "自定义端点会在连接测试时收到你的 DeepSeek API key。",
     workspace: "工作目录",
     workspaceHint: "agent 工具操作的根目录。切换会写入配置并重载工具。",
     workspaceChange: "更换…",

--- a/desktop/src/i18n/zh-CN.ts
+++ b/desktop/src/i18n/zh-CN.ts
@@ -367,6 +367,12 @@ export const zhCN: typeof en = {
     shortcutSwitchTab: "切换标签",
     shortcutAbort: "中断流式输出",
     shortcutSettings: "设置",
+    // Connection test
+    testConnection: "测试",
+    testingConnection: "测试中…",
+    connectionOk: "已连接 · {latencyMs}ms",
+    connectionFailed: "连接失败",
+    connectionPaidHint: "将向服务商发送一次最小测试请求",
   },
   modal: {
     planFeedbackPlaceholder: "计划存在哪些问题？需要改进哪些地方？",

--- a/desktop/src/protocol.ts
+++ b/desktop/src/protocol.ts
@@ -532,6 +532,18 @@ export type KernelErrorEvent = {
   recoverable: boolean;
 };
 
+export type ConnectionTestTarget = "deepseek" | "webSearch";
+
+export type ConnectionTestResultEvent = {
+  type: "$connection_test_result";
+  target: ConnectionTestTarget;
+  ok: boolean;
+  message: string;
+  latencyMs: number;
+  status?: number;
+  detail?: string;
+};
+
 export type IncomingEvent = { tabId?: string } & (
   | ReadyEvent
   | ProtocolErrorEvent
@@ -576,6 +588,7 @@ export type IncomingEvent = { tabId?: string } & (
   | KernelErrorEvent
   | RetryResultEvent
   | BtwResultEvent
+  | ConnectionTestResultEvent
 );
 
 export type OutgoingCommand = { tabId?: string } & (
@@ -630,4 +643,13 @@ export type OutgoingCommand = { tabId?: string } & (
   | { cmd: "compact_history" }
   | { cmd: "retry" }
   | { cmd: "btw"; text: string }
+  | {
+      cmd: "settings_test_connection";
+      target: ConnectionTestTarget;
+      apiKey?: string;
+      baseUrl?: string | null;
+      engine?: string;
+      endpoint?: string | null;
+      apiKeys?: Record<string, string>;
+    }
 );

--- a/desktop/src/protocol.ts
+++ b/desktop/src/protocol.ts
@@ -542,6 +542,7 @@ export type ConnectionTestResultEvent = {
   latencyMs: number;
   status?: number;
   detail?: string;
+  requestKey?: string;
 };
 
 export type IncomingEvent = { tabId?: string } & (
@@ -646,6 +647,7 @@ export type OutgoingCommand = { tabId?: string } & (
   | {
       cmd: "settings_test_connection";
       target: ConnectionTestTarget;
+      requestKey?: string;
       apiKey?: string;
       baseUrl?: string | null;
       engine?: string;

--- a/desktop/src/ui/settings.tsx
+++ b/desktop/src/ui/settings.tsx
@@ -4,6 +4,8 @@ import type { Balance, Settings as SettingsType, UsageStats } from "../App";
 import { getLangLabel, getSupportedLangs, setLang, t, useLang } from "../i18n";
 import { I } from "../icons";
 import type {
+  ConnectionTestResultEvent,
+  ConnectionTestTarget,
   ImportedMcpServer,
   McpSpecInfo,
   MemoryDetail,
@@ -76,6 +78,8 @@ export function SettingsModal({
   memory,
   memoryDetail,
   qq,
+  connectionTests,
+  onTestConnection,
   onClose,
   onSave,
   onSaveApiKey,
@@ -115,6 +119,17 @@ export function SettingsModal({
   memory: MemoryEntryInfo[];
   memoryDetail: MemoryDetail | null;
   qq: QQDesktopSettingsState | null;
+  connectionTests: Record<string, ConnectionTestResultEvent | undefined>;
+  onTestConnection: (
+    target: ConnectionTestTarget,
+    opts?: {
+      apiKey?: string;
+      baseUrl?: string | null;
+      engine?: string;
+      endpoint?: string | null;
+      apiKeys?: Record<string, string>;
+    },
+  ) => void;
   onClose: () => void;
   onSave: (patch: SettingsPatch) => void;
   onSaveApiKey: (key: string) => void;
@@ -199,6 +214,8 @@ export function SettingsModal({
                 onSetCustomFontFamily={onSetCustomFontFamily}
                 onSave={onSave}
                 onPickWorkspace={onPickWorkspace}
+                connectionTests={connectionTests}
+                onTestConnection={onTestConnection}
               />
             )}
             {page === "models" && <PageModels settings={settings} onSave={onSave} />}
@@ -237,6 +254,8 @@ export function SettingsModal({
                   apiKeyPrefix={settings.apiKeyPrefix}
                   onSave={onSave}
                   onSaveApiKey={onSaveApiKey}
+                  connectionTests={connectionTests}
+                  onTestConnection={onTestConnection}
                 />
                 <QQChannelSection
                   qq={qq}
@@ -443,6 +462,8 @@ function PageGeneral({
   onSetCustomFontFamily,
   onSave,
   onPickWorkspace,
+  connectionTests,
+  onTestConnection,
 }: {
   settings: SettingsType;
   theme: Theme;
@@ -457,6 +478,17 @@ function PageGeneral({
   onSetCustomFontFamily: (family: string) => void;
   onSave: (patch: SettingsPatch) => void;
   onPickWorkspace: () => void;
+  connectionTests: Record<string, ConnectionTestResultEvent | undefined>;
+  onTestConnection: (
+    target: ConnectionTestTarget,
+    opts?: {
+      apiKey?: string;
+      baseUrl?: string | null;
+      engine?: string;
+      endpoint?: string | null;
+      apiKeys?: Record<string, string>;
+    },
+  ) => void;
 }) {
   const [editorDraft, setEditorDraft] = useState(settings.editor ?? "");
   const [customFontDraft, setCustomFontDraft] = useState(customFontFamily);
@@ -764,38 +796,57 @@ function PageGeneral({
             <div className="n">{t("settings.webSearchEngine")}</div>
             <div className="h">{t("settings.webSearchEngineNote")}</div>
           </div>
-          <select
-            className="field"
-            value={settings.webSearchEngine ?? "bing"}
-            onChange={(e) =>
-              onSave({
-                webSearchEngine: e.target.value as
-                  | "bing"
-                  | "bing-intl"
-                  | "searxng"
-                  | "metaso"
-                  | "baidu"
-                  | "tavily"
-                  | "perplexity"
-                  | "exa"
-                  | "brave"
-                  | "ollama",
-              })
-            }
-          >
-            <option value="bing">{t("settings.webSearchEngineBing")}</option>
-            <option value="bing-intl">{t("settings.webSearchEngineBingIntl")}</option>
-            <option value="searxng">{t("settings.webSearchEngineSearxng")}</option>
-            <option value="metaso">{t("settings.webSearchEngineMetaso")}</option>
-            <option value="baidu">{t("settings.webSearchEngineBaidu")}</option>
-            <option value="tavily">{t("settings.webSearchEngineTavily")}</option>
-            <option value="perplexity">{t("settings.webSearchEnginePerplexity")}</option>
-            <option value="exa">{t("settings.webSearchEngineExa")}</option>
-            <option value="brave">{t("settings.webSearchEngineBrave")}</option>
-            <option value="ollama">{t("settings.webSearchEngineOllama")}</option>
-          </select>
+          <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+            <select
+              className="field"
+              value={settings.webSearchEngine ?? "bing"}
+              onChange={(e) =>
+                onSave({
+                  webSearchEngine: e.target.value as
+                    | "bing"
+                    | "bing-intl"
+                    | "searxng"
+                    | "metaso"
+                    | "baidu"
+                    | "tavily"
+                    | "perplexity"
+                    | "exa"
+                    | "brave"
+                    | "ollama",
+                })
+              }
+            >
+              <option value="bing">{t("settings.webSearchEngineBing")}</option>
+              <option value="bing-intl">{t("settings.webSearchEngineBingIntl")}</option>
+              <option value="searxng">{t("settings.webSearchEngineSearxng")}</option>
+              <option value="metaso">{t("settings.webSearchEngineMetaso")}</option>
+              <option value="baidu">{t("settings.webSearchEngineBaidu")}</option>
+              <option value="tavily">{t("settings.webSearchEngineTavily")}</option>
+              <option value="perplexity">{t("settings.webSearchEnginePerplexity")}</option>
+              <option value="exa">{t("settings.webSearchEngineExa")}</option>
+              <option value="brave">{t("settings.webSearchEngineBrave")}</option>
+              <option value="ollama">{t("settings.webSearchEngineOllama")}</option>
+            </select>
+            <ConnectionTestButton
+              target="webSearch"
+              result={connectionTests.webSearch}
+              onTest={() =>
+                onTestConnection("webSearch", {
+                  engine: settings.webSearchEngine,
+                  ...(settings.webSearchEngine === "searxng"
+                    ? { endpoint: settings.webSearchEndpoint || null }
+                    : {}),
+                })
+              }
+            />
+          </div>
         </div>
-        <WebSearchEngineCredentials settings={settings} onSave={onSave} />
+        <WebSearchEngineCredentials
+          settings={settings}
+          onSave={onSave}
+          onTestConnection={onTestConnection}
+          webSearchTestResult={connectionTests.webSearch}
+        />
       </section>
     </>
   );
@@ -833,14 +884,34 @@ const SEARCH_ENGINE_API_KEY_FIELDS: ReadonlyArray<{
 function WebSearchEngineCredentials({
   settings,
   onSave,
+  onTestConnection,
+  webSearchTestResult,
 }: {
   settings: SettingsType;
   onSave: (patch: SettingsPatch) => void;
+  onTestConnection: (
+    target: ConnectionTestTarget,
+    opts?: {
+      apiKey?: string;
+      baseUrl?: string | null;
+      engine?: string;
+      endpoint?: string | null;
+      apiKeys?: Record<string, string>;
+    },
+  ) => void;
+  webSearchTestResult?: ConnectionTestResultEvent;
 }) {
   const engine = settings.webSearchEngine ?? "bing";
   if (engine === "bing" || engine === "bing-intl") return null;
   if (engine === "searxng") {
-    return <SearxngEndpointRow settings={settings} onSave={onSave} />;
+    return (
+      <SearxngEndpointRow
+        settings={settings}
+        onSave={onSave}
+        onTestConnection={onTestConnection}
+        testResult={webSearchTestResult}
+      />
+    );
   }
   const field = SEARCH_ENGINE_API_KEY_FIELDS.find((f) => f.engine === engine);
   if (!field) return null;
@@ -852,6 +923,8 @@ function WebSearchEngineCredentials({
       signupUrl={field.signupUrl}
       prefix={prefix}
       onSave={onSave}
+      onTestConnection={onTestConnection}
+      testResult={webSearchTestResult}
     />
   );
 }
@@ -859,9 +932,22 @@ function WebSearchEngineCredentials({
 function SearxngEndpointRow({
   settings,
   onSave,
+  onTestConnection,
+  testResult,
 }: {
   settings: SettingsType;
   onSave: (patch: SettingsPatch) => void;
+  onTestConnection: (
+    target: ConnectionTestTarget,
+    opts?: {
+      apiKey?: string;
+      baseUrl?: string | null;
+      engine?: string;
+      endpoint?: string | null;
+      apiKeys?: Record<string, string>;
+    },
+  ) => void;
+  testResult?: ConnectionTestResultEvent;
 }) {
   const [draft, setDraft] = useState(settings.webSearchEndpoint ?? "");
   useEffect(() => {
@@ -873,17 +959,29 @@ function SearxngEndpointRow({
         <div className="n">{t("settings.webSearchEndpoint")}</div>
         <div className="h">{t("settings.webSearchEndpointHint")}</div>
       </div>
-      <input
-        className="field mono"
-        value={draft}
-        placeholder="http://localhost:8080"
-        onChange={(e) => setDraft(e.target.value)}
-        onBlur={() => {
-          const next = draft.trim();
-          if (next === (settings.webSearchEndpoint ?? "")) return;
-          onSave({ webSearchEndpoint: next || null });
-        }}
-      />
+      <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+        <input
+          className="field mono"
+          value={draft}
+          placeholder="http://localhost:8080"
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={() => {
+            const next = draft.trim();
+            if (next === (settings.webSearchEndpoint ?? "")) return;
+            onSave({ webSearchEndpoint: next || null });
+          }}
+        />
+        <ConnectionTestButton
+          target="webSearch"
+          result={testResult}
+          onTest={() =>
+            onTestConnection("webSearch", {
+              engine: "searxng",
+              endpoint: draft.trim() || null,
+            })
+          }
+        />
+      </div>
     </div>
   );
 }
@@ -894,6 +992,8 @@ function WebSearchApiKeyRow({
   signupUrl,
   prefix,
   onSave,
+  onTestConnection,
+  testResult,
 }: {
   engine: "metaso" | "baidu" | "tavily" | "perplexity" | "exa" | "brave" | "ollama";
   patchKey:
@@ -907,9 +1007,21 @@ function WebSearchApiKeyRow({
   signupUrl: string;
   prefix?: string;
   onSave: (patch: SettingsPatch) => void;
+  onTestConnection: (
+    target: ConnectionTestTarget,
+    opts?: {
+      apiKey?: string;
+      baseUrl?: string | null;
+      engine?: string;
+      endpoint?: string | null;
+      apiKeys?: Record<string, string>;
+    },
+  ) => void;
+  testResult?: ConnectionTestResultEvent;
 }) {
   const [draft, setDraft] = useState("");
   const label = t(`settings.webSearchApiKey.${engine}` as const);
+  const isPaidEngine = ["tavily", "perplexity", "exa"].includes(engine);
   return (
     <div className="setting-row">
       <div className="l">
@@ -929,7 +1041,7 @@ function WebSearchApiKeyRow({
           </a>
         </div>
       </div>
-      <div style={{ display: "flex", gap: 6 }}>
+      <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
         <input
           className="field mono"
           type="password"
@@ -959,8 +1071,67 @@ function WebSearchApiKeyRow({
             {t("settings.webSearchApiKeyClear")}
           </button>
         ) : null}
+        <ConnectionTestButton
+          target="webSearch"
+          result={testResult}
+          onTest={() => {
+            const testKey = draft.trim() || undefined;
+            onTestConnection("webSearch", {
+              engine,
+              apiKeys: testKey ? { [engine]: testKey } : undefined,
+            });
+          }}
+        />
+        {isPaidEngine ? (
+          <span style={{ fontSize: 10, color: "var(--muted)", maxWidth: 120, lineHeight: 1.3 }}>
+            {t("settings.connectionPaidHint")}
+          </span>
+        ) : null}
       </div>
     </div>
+  );
+}
+
+function ConnectionTestButton({
+  target,
+  result,
+  onTest,
+}: {
+  target: ConnectionTestTarget;
+  result?: ConnectionTestResultEvent;
+  onTest: () => void;
+}) {
+  const isTesting = result && result.latencyMs < 0;
+  const isOk = result?.ok;
+  const isFailed = result && !result.ok && result.latencyMs >= 0;
+
+  let label: string;
+  if (isTesting) {
+    label = t("settings.testingConnection");
+  } else if (isOk) {
+    label = t("settings.connectionOk", { latencyMs: String(result!.latencyMs) });
+  } else if (isFailed) {
+    label = result!.message;
+  } else {
+    label = t("settings.testConnection");
+  }
+
+  return (
+    <button
+      type="button"
+      className={`btn conn-test-btn${isTesting ? " testing" : ""}${isOk ? " ok" : ""}${isFailed ? " err" : ""}`}
+      disabled={isTesting}
+      onClick={onTest}
+      title={
+        isFailed && result?.detail
+          ? result.detail
+          : isOk
+            ? `${target} API connected`
+            : t("settings.testConnection")
+      }
+    >
+      {label}
+    </button>
   );
 }
 
@@ -969,11 +1140,24 @@ function ApiKeySection({
   apiKeyPrefix,
   onSave,
   onSaveApiKey,
+  connectionTests,
+  onTestConnection,
 }: {
   baseUrl?: string;
   apiKeyPrefix?: string;
   onSave: (patch: SettingsPatch) => void;
   onSaveApiKey: (key: string) => void;
+  connectionTests: Record<string, ConnectionTestResultEvent | undefined>;
+  onTestConnection: (
+    target: ConnectionTestTarget,
+    opts?: {
+      apiKey?: string;
+      baseUrl?: string | null;
+      engine?: string;
+      endpoint?: string | null;
+      apiKeys?: Record<string, string>;
+    },
+  ) => void;
 }) {
   const [key, setKey] = useState("");
   const [urlDraft, setUrlDraft] = useState(baseUrl ?? "");
@@ -989,7 +1173,7 @@ function ApiKeySection({
               : t("settings.apiKeyNotSet")}
           </div>
         </div>
-        <div style={{ display: "flex", gap: 6 }}>
+        <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
           <input
             className="field mono"
             type="password"
@@ -1009,6 +1193,16 @@ function ApiKeySection({
           >
             {t("settings.apiKeySave")}
           </button>
+          <ConnectionTestButton
+            target="deepseek"
+            result={connectionTests.deepseek}
+            onTest={() =>
+              onTestConnection("deepseek", {
+                apiKey: key || undefined,
+                baseUrl: urlDraft.trim() || null,
+              })
+            }
+          />
         </div>
       </div>
       <div className="setting-row">

--- a/desktop/src/ui/settings.tsx
+++ b/desktop/src/ui/settings.tsx
@@ -1135,6 +1135,16 @@ function ConnectionTestButton({
   );
 }
 
+function isCustomDeepSeekEndpoint(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  try {
+    return new URL(trimmed).hostname.toLowerCase() !== "api.deepseek.com";
+  } catch {
+    return false;
+  }
+}
+
 function ApiKeySection({
   baseUrl,
   apiKeyPrefix,
@@ -1161,6 +1171,7 @@ function ApiKeySection({
 }) {
   const [key, setKey] = useState("");
   const [urlDraft, setUrlDraft] = useState(baseUrl ?? "");
+  const showCustomEndpointWarning = isCustomDeepSeekEndpoint(urlDraft);
   return (
     <section className="section">
       <div className="stitle">{t("settings.apiSection")}</div>
@@ -1217,6 +1228,11 @@ function ApiKeySection({
           onBlur={() => onSave({ baseUrl: urlDraft.trim() })}
         />
       </div>
+      {showCustomEndpointWarning ? (
+        <div className="h" style={{ color: "var(--tone-warn)", marginTop: -8 }}>
+          {t("settings.baseUrlCustomCredentialWarning")}
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/desktop/src/ui/settings.tsx
+++ b/desktop/src/ui/settings.tsx
@@ -1,6 +1,7 @@
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { type ReactNode, useEffect, useRef, useState } from "react";
 import type { Balance, Settings as SettingsType, UsageStats } from "../App";
+import { matchingConnectionTestResult } from "../connection-test-key";
 import { getLangLabel, getSupportedLangs, setLang, t, useLang } from "../i18n";
 import { I } from "../icons";
 import type {
@@ -501,6 +502,16 @@ function PageGeneral({
     setCustomFontDraft(next);
     onSetCustomFontFamily(next);
   };
+  const webSearchEngine = settings.webSearchEngine ?? "bing";
+  const webSearchEngineResult =
+    webSearchEngine === "bing" || webSearchEngine === "bing-intl"
+      ? matchingConnectionTestResult(
+          connectionTests.webSearch,
+          "webSearch",
+          { engine: webSearchEngine },
+          settings,
+        )
+      : undefined;
   return (
     <>
       <section className="section">
@@ -799,7 +810,7 @@ function PageGeneral({
           <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
             <select
               className="field"
-              value={settings.webSearchEngine ?? "bing"}
+              value={webSearchEngine}
               onChange={(e) =>
                 onSave({
                   webSearchEngine: e.target.value as
@@ -829,11 +840,11 @@ function PageGeneral({
             </select>
             <ConnectionTestButton
               target="webSearch"
-              result={connectionTests.webSearch}
+              result={webSearchEngineResult}
               onTest={() =>
                 onTestConnection("webSearch", {
-                  engine: settings.webSearchEngine,
-                  ...(settings.webSearchEngine === "searxng"
+                  engine: webSearchEngine,
+                  ...(webSearchEngine === "searxng"
                     ? { endpoint: settings.webSearchEndpoint || null }
                     : {}),
                 })
@@ -950,6 +961,12 @@ function SearxngEndpointRow({
   testResult?: ConnectionTestResultEvent;
 }) {
   const [draft, setDraft] = useState(settings.webSearchEndpoint ?? "");
+  const result = matchingConnectionTestResult(
+    testResult,
+    "webSearch",
+    { engine: "searxng", endpoint: draft.trim() || null },
+    settings,
+  );
   useEffect(() => {
     setDraft(settings.webSearchEndpoint ?? "");
   }, [settings.webSearchEndpoint]);
@@ -973,7 +990,7 @@ function SearxngEndpointRow({
         />
         <ConnectionTestButton
           target="webSearch"
-          result={testResult}
+          result={result}
           onTest={() =>
             onTestConnection("webSearch", {
               engine: "searxng",
@@ -1022,6 +1039,16 @@ function WebSearchApiKeyRow({
   const [draft, setDraft] = useState("");
   const label = t(`settings.webSearchApiKey.${engine}` as const);
   const isPaidEngine = ["tavily", "perplexity", "exa"].includes(engine);
+  const testKey = draft.trim() || undefined;
+  const result = matchingConnectionTestResult(
+    testResult,
+    "webSearch",
+    { engine, apiKeys: testKey ? { [engine]: testKey } : undefined },
+    {
+      webSearchEngine: engine,
+      webSearchApiKeys: prefix ? { [engine]: prefix } : undefined,
+    },
+  );
   return (
     <div className="setting-row">
       <div className="l">
@@ -1073,9 +1100,8 @@ function WebSearchApiKeyRow({
         ) : null}
         <ConnectionTestButton
           target="webSearch"
-          result={testResult}
+          result={result}
           onTest={() => {
-            const testKey = draft.trim() || undefined;
             onTestConnection("webSearch", {
               engine,
               apiKeys: testKey ? { [engine]: testKey } : undefined,
@@ -1172,6 +1198,12 @@ function ApiKeySection({
   const [key, setKey] = useState("");
   const [urlDraft, setUrlDraft] = useState(baseUrl ?? "");
   const showCustomEndpointWarning = isCustomDeepSeekEndpoint(urlDraft);
+  const deepseekTestResult = matchingConnectionTestResult(
+    connectionTests.deepseek,
+    "deepseek",
+    { apiKey: key || undefined, baseUrl: urlDraft.trim() || null },
+    { apiKeyPrefix, baseUrl },
+  );
   return (
     <section className="section">
       <div className="stitle">{t("settings.apiSection")}</div>
@@ -1206,7 +1238,7 @@ function ApiKeySection({
           </button>
           <ConnectionTestButton
             target="deepseek"
-            result={connectionTests.deepseek}
+            result={deepseekTestResult}
             onTest={() =>
               onTestConnection("deepseek", {
                 apiKey: key || undefined,

--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -246,6 +246,7 @@ type InMessage = { tabId?: string } & (
   | {
       cmd: "settings_test_connection";
       target: "deepseek" | "webSearch";
+      requestKey?: string;
       apiKey?: string;
       baseUrl?: string | null;
       engine?: string;
@@ -613,6 +614,7 @@ interface ConnectionTestResultEvent {
   latencyMs: number;
   status?: number;
   detail?: string;
+  requestKey?: string;
 }
 
 /** Direct fd write — bypasses Node's stream layer (and its piped-output
@@ -3558,6 +3560,9 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
     }
     if (msg.cmd === "settings_test_connection") {
       void (async () => {
+        const emitConnectionTestResult = (event: ConnectionTestResultEvent) => {
+          emit(msg.requestKey ? { ...event, requestKey: msg.requestKey } : event, tab.id);
+        };
         try {
           if (msg.target === "deepseek") {
             const ep = loadEndpoint();
@@ -3567,30 +3572,24 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
               resolvedEndpoint: ep,
             });
             if (!endpoint.ok) {
-              emit(
-                {
-                  type: "$connection_test_result",
-                  target: "deepseek",
-                  ok: false,
-                  message: endpoint.message,
-                  latencyMs: 0,
-                },
-                tab.id,
-              );
+              emitConnectionTestResult({
+                type: "$connection_test_result",
+                target: "deepseek",
+                ok: false,
+                message: endpoint.message,
+                latencyMs: 0,
+              });
               return;
             }
             const { apiKey, baseUrl } = endpoint;
             if (!apiKey) {
-              emit(
-                {
-                  type: "$connection_test_result",
-                  target: "deepseek",
-                  ok: false,
-                  message: "No API key configured",
-                  latencyMs: 0,
-                },
-                tab.id,
-              );
+              emitConnectionTestResult({
+                type: "$connection_test_result",
+                target: "deepseek",
+                ok: false,
+                message: "No API key configured",
+                latencyMs: 0,
+              });
               return;
             }
             const started = Date.now();
@@ -3607,80 +3606,62 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
               clearTimeout(timeout);
               const latencyMs = Date.now() - started;
               if (resp.ok) {
-                emit(
-                  {
-                    type: "$connection_test_result",
-                    target: "deepseek",
-                    ok: true,
-                    message: "Connected",
-                    latencyMs,
-                  },
-                  tab.id,
-                );
+                emitConnectionTestResult({
+                  type: "$connection_test_result",
+                  target: "deepseek",
+                  ok: true,
+                  message: "Connected",
+                  latencyMs,
+                });
               } else if (resp.status === 401 || resp.status === 403) {
-                emit(
-                  {
-                    type: "$connection_test_result",
-                    target: "deepseek",
-                    ok: false,
-                    message: "Authentication failed",
-                    latencyMs,
-                    status: resp.status,
-                  },
-                  tab.id,
-                );
+                emitConnectionTestResult({
+                  type: "$connection_test_result",
+                  target: "deepseek",
+                  ok: false,
+                  message: "Authentication failed",
+                  latencyMs,
+                  status: resp.status,
+                });
               } else if (resp.status === 429) {
-                emit(
-                  {
-                    type: "$connection_test_result",
-                    target: "deepseek",
-                    ok: false,
-                    message: "Rate limited",
-                    latencyMs,
-                    status: 429,
-                  },
-                  tab.id,
-                );
+                emitConnectionTestResult({
+                  type: "$connection_test_result",
+                  target: "deepseek",
+                  ok: false,
+                  message: "Rate limited",
+                  latencyMs,
+                  status: 429,
+                });
               } else {
-                emit(
-                  {
-                    type: "$connection_test_result",
-                    target: "deepseek",
-                    ok: false,
-                    message: "Upstream service error",
-                    latencyMs,
-                    status: resp.status,
-                    detail: `HTTP ${resp.status}`,
-                  },
-                  tab.id,
-                );
+                emitConnectionTestResult({
+                  type: "$connection_test_result",
+                  target: "deepseek",
+                  ok: false,
+                  message: "Upstream service error",
+                  latencyMs,
+                  status: resp.status,
+                  detail: `HTTP ${resp.status}`,
+                });
               }
             } catch (err) {
               clearTimeout(timeout);
               const latencyMs = Date.now() - started;
               if (abort.signal.aborted) {
-                emit(
-                  {
-                    type: "$connection_test_result",
-                    target: "deepseek",
-                    ok: false,
-                    message: "Request timed out",
-                    latencyMs,
-                  },
-                  tab.id,
-                );
+                emitConnectionTestResult({
+                  type: "$connection_test_result",
+                  target: "deepseek",
+                  ok: false,
+                  message: "Request timed out",
+                  latencyMs,
+                });
               } else {
-                emit(
-                  {
-                    type: "$connection_test_result",
-                    target: "deepseek",
-                    ok: false,
-                    message: "Connection failed",
-                    latencyMs,
-                    detail: (err as Error).message,
-                  },
-                  tab.id,
-                );
+                emitConnectionTestResult({
+                  type: "$connection_test_result",
+                  target: "deepseek",
+                  ok: false,
+                  message: "Connection failed",
+                  latencyMs,
+                  detail: (err as Error).message,
+                });
               }
             }
             return;
@@ -3699,16 +3680,13 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
               | "brave"
               | "ollama";
             if (!engine) {
-              emit(
-                {
-                  type: "$connection_test_result",
-                  target: "webSearch",
-                  ok: false,
-                  message: "No search engine selected",
-                  latencyMs: 0,
-                },
-                tab.id,
-              );
+              emitConnectionTestResult({
+                type: "$connection_test_result",
+                target: "webSearch",
+                ok: false,
+                message: "No search engine selected",
+                latencyMs: 0,
+              });
               return;
             }
 
@@ -3732,82 +3710,64 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
               });
               clearTimeout(timeout);
               const latencyMs = Date.now() - started;
-              emit(
-                {
-                  type: "$connection_test_result",
-                  target: "webSearch",
-                  ok: true,
-                  message: `Connected · ${results.length} result(s)`,
-                  latencyMs,
-                  ...(isPaidEngine ? { detail: "A minimal test request was sent" } : {}),
-                },
-                tab.id,
-              );
+              emitConnectionTestResult({
+                type: "$connection_test_result",
+                target: "webSearch",
+                ok: true,
+                message: `Connected · ${results.length} result(s)`,
+                latencyMs,
+                ...(isPaidEngine ? { detail: "A minimal test request was sent" } : {}),
+              });
             } catch (err) {
               clearTimeout(timeout);
               const latencyMs = Date.now() - started;
               const errMsg = (err as Error).message ?? String(err);
               if (abort.signal.aborted) {
-                emit(
-                  {
-                    type: "$connection_test_result",
-                    target: "webSearch",
-                    ok: false,
-                    message: "Request timed out",
-                    latencyMs,
-                  },
-                  tab.id,
-                );
+                emitConnectionTestResult({
+                  type: "$connection_test_result",
+                  target: "webSearch",
+                  ok: false,
+                  message: "Request timed out",
+                  latencyMs,
+                });
               } else if (/401|403|unauthorized|invalid.*key/i.test(errMsg)) {
-                emit(
-                  {
-                    type: "$connection_test_result",
-                    target: "webSearch",
-                    ok: false,
-                    message: "Authentication failed",
-                    latencyMs,
-                    detail: errMsg,
-                  },
-                  tab.id,
-                );
+                emitConnectionTestResult({
+                  type: "$connection_test_result",
+                  target: "webSearch",
+                  ok: false,
+                  message: "Authentication failed",
+                  latencyMs,
+                  detail: errMsg,
+                });
               } else if (/429|rate.limit/i.test(errMsg)) {
-                emit(
-                  {
-                    type: "$connection_test_result",
-                    target: "webSearch",
-                    ok: false,
-                    message: "Rate limited",
-                    latencyMs,
-                    detail: errMsg,
-                  },
-                  tab.id,
-                );
+                emitConnectionTestResult({
+                  type: "$connection_test_result",
+                  target: "webSearch",
+                  ok: false,
+                  message: "Rate limited",
+                  latencyMs,
+                  detail: errMsg,
+                });
               } else {
-                emit(
-                  {
-                    type: "$connection_test_result",
-                    target: "webSearch",
-                    ok: false,
-                    message: "Connection failed",
-                    latencyMs,
-                    detail: errMsg,
-                  },
-                  tab.id,
-                );
+                emitConnectionTestResult({
+                  type: "$connection_test_result",
+                  target: "webSearch",
+                  ok: false,
+                  message: "Connection failed",
+                  latencyMs,
+                  detail: errMsg,
+                });
               }
             }
           }
         } catch (err) {
-          emit(
-            {
-              type: "$connection_test_result",
-              target: msg.target,
-              ok: false,
-              message: `Test failed: ${(err as Error).message}`,
-              latencyMs: 0,
-            },
-            tab.id,
-          );
+          emitConnectionTestResult({
+            type: "$connection_test_result",
+            target: msg.target,
+            ok: false,
+            message: `Test failed: ${(err as Error).message}`,
+            latencyMs: 0,
+          });
         }
       })();
       return;

--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -75,6 +75,7 @@ import {
   pauseGate,
 } from "../../core/pause-gate.js";
 import { autoResolveVerdict } from "../../core/pause-policy.js";
+import { resolveDeepSeekConnectionTestTarget } from "../../desktop/deepseek-endpoint-policy.js";
 import { augmentProcessPath } from "../../desktop/login-shell-path.js";
 import {
   type MemoryEntryDetail,
@@ -3560,11 +3561,25 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
         try {
           if (msg.target === "deepseek") {
             const ep = loadEndpoint();
-            const apiKey = msg.apiKey ?? ep.apiKey;
-            const baseUrl = ((msg.baseUrl ?? ep.baseUrl) || "https://api.deepseek.com").replace(
-              /\/+$/,
-              "",
-            );
+            const endpoint = resolveDeepSeekConnectionTestTarget({
+              requestedBaseUrl: msg.baseUrl,
+              requestedApiKey: msg.apiKey,
+              resolvedEndpoint: ep,
+            });
+            if (!endpoint.ok) {
+              emit(
+                {
+                  type: "$connection_test_result",
+                  target: "deepseek",
+                  ok: false,
+                  message: endpoint.message,
+                  latencyMs: 0,
+                },
+                tab.id,
+              );
+              return;
+            }
+            const { apiKey, baseUrl } = endpoint;
             if (!apiKey) {
               emit(
                 {

--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -134,6 +134,7 @@ import {
 import { SkillStore } from "../../skills.js";
 import { countTokensBounded } from "../../tokenizer.js";
 import type { ChoiceOption } from "../../tools/choice.js";
+import { webSearch } from "../../tools/web.js";
 import type { ChatMessage } from "../../types.js";
 import { VERSION } from "../../version.js";
 import { type McpRuntime, createMcpRuntime } from "./mcp-runtime.js";
@@ -241,6 +242,15 @@ type InMessage = { tabId?: string } & (
   | { cmd: "retry" }
   | { cmd: "btw"; text: string }
   | { cmd: "desktop_resync" }
+  | {
+      cmd: "settings_test_connection";
+      target: "deepseek" | "webSearch";
+      apiKey?: string;
+      baseUrl?: string | null;
+      engine?: string;
+      endpoint?: string | null;
+      apiKeys?: Record<string, string>;
+    }
 );
 
 interface NeedsSetupEvent {
@@ -594,6 +604,16 @@ interface BtwResultEvent {
   answer: string;
 }
 
+interface ConnectionTestResultEvent {
+  type: "$connection_test_result";
+  target: "deepseek" | "webSearch";
+  ok: boolean;
+  message: string;
+  latencyMs: number;
+  status?: number;
+  detail?: string;
+}
+
 /** Direct fd write — bypasses Node's stream layer (and its piped-output
  *  block buffering) so every JSON line reaches Rust the moment it's
  *  produced, not whenever the next 8 KB flushes. */
@@ -631,7 +651,8 @@ type EmittableEvent =
   | CtxBreakdownEvent
   | MemoryEvent
   | MemoryDetailEvent
-  | JobsEvent;
+  | JobsEvent
+  | ConnectionTestResultEvent;
 
 const STDOUT_BACKPRESSURE_WAIT = new Int32Array(new SharedArrayBuffer(4));
 
@@ -3532,6 +3553,245 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
       const question = msg.text.trim();
       if (!question) return;
       runBtwOnTab(tab, question);
+      return;
+    }
+    if (msg.cmd === "settings_test_connection") {
+      void (async () => {
+        try {
+          if (msg.target === "deepseek") {
+            const ep = loadEndpoint();
+            const apiKey = msg.apiKey ?? ep.apiKey;
+            const baseUrl = ((msg.baseUrl ?? ep.baseUrl) || "https://api.deepseek.com").replace(
+              /\/+$/,
+              "",
+            );
+            if (!apiKey) {
+              emit(
+                {
+                  type: "$connection_test_result",
+                  target: "deepseek",
+                  ok: false,
+                  message: "No API key configured",
+                  latencyMs: 0,
+                },
+                tab.id,
+              );
+              return;
+            }
+            const started = Date.now();
+            const abort = new AbortController();
+            const timeout = setTimeout(() => abort.abort(), 10_000);
+            try {
+              const resp = await fetch(`${baseUrl}/models`, {
+                headers: { Authorization: `Bearer ${apiKey}` },
+                signal: abort.signal,
+              });
+              clearTimeout(timeout);
+              const latencyMs = Date.now() - started;
+              if (resp.ok) {
+                emit(
+                  {
+                    type: "$connection_test_result",
+                    target: "deepseek",
+                    ok: true,
+                    message: "Connected",
+                    latencyMs,
+                  },
+                  tab.id,
+                );
+              } else if (resp.status === 401 || resp.status === 403) {
+                emit(
+                  {
+                    type: "$connection_test_result",
+                    target: "deepseek",
+                    ok: false,
+                    message: "Authentication failed",
+                    latencyMs,
+                    status: resp.status,
+                  },
+                  tab.id,
+                );
+              } else if (resp.status === 429) {
+                emit(
+                  {
+                    type: "$connection_test_result",
+                    target: "deepseek",
+                    ok: false,
+                    message: "Rate limited",
+                    latencyMs,
+                    status: 429,
+                  },
+                  tab.id,
+                );
+              } else {
+                emit(
+                  {
+                    type: "$connection_test_result",
+                    target: "deepseek",
+                    ok: false,
+                    message: "Upstream service error",
+                    latencyMs,
+                    status: resp.status,
+                    detail: `HTTP ${resp.status}`,
+                  },
+                  tab.id,
+                );
+              }
+            } catch (err) {
+              clearTimeout(timeout);
+              const latencyMs = Date.now() - started;
+              if (abort.signal.aborted) {
+                emit(
+                  {
+                    type: "$connection_test_result",
+                    target: "deepseek",
+                    ok: false,
+                    message: "Request timed out",
+                    latencyMs,
+                  },
+                  tab.id,
+                );
+              } else {
+                emit(
+                  {
+                    type: "$connection_test_result",
+                    target: "deepseek",
+                    ok: false,
+                    message: "Connection failed",
+                    latencyMs,
+                    detail: (err as Error).message,
+                  },
+                  tab.id,
+                );
+              }
+            }
+            return;
+          }
+
+          if (msg.target === "webSearch") {
+            const engine = (msg.engine ?? readWebSearchEngine()) as
+              | "bing"
+              | "bing-intl"
+              | "searxng"
+              | "metaso"
+              | "baidu"
+              | "tavily"
+              | "perplexity"
+              | "exa"
+              | "brave"
+              | "ollama";
+            if (!engine) {
+              emit(
+                {
+                  type: "$connection_test_result",
+                  target: "webSearch",
+                  ok: false,
+                  message: "No search engine selected",
+                  latencyMs: 0,
+                },
+                tab.id,
+              );
+              return;
+            }
+
+            // Pass draft key directly via opts.apiKey so it takes priority over
+            // both saved config and env vars. Only the key for the selected
+            // engine matters — apiKeys maps engine name → key value.
+            const draftKey: string | undefined =
+              msg.apiKeys && engine ? msg.apiKeys[engine] : undefined;
+
+            const isPaidEngine = ["tavily", "perplexity", "exa"].includes(engine);
+            const abort = new AbortController();
+            const timeout = setTimeout(() => abort.abort(), 10_000);
+            const started = Date.now();
+            try {
+              const results = await webSearch("reasonix connectivity test", {
+                engine,
+                topK: 1,
+                signal: abort.signal,
+                ...(draftKey ? { apiKey: draftKey } : {}),
+                ...(msg.endpoint !== undefined ? { endpoint: msg.endpoint ?? undefined } : {}),
+              });
+              clearTimeout(timeout);
+              const latencyMs = Date.now() - started;
+              emit(
+                {
+                  type: "$connection_test_result",
+                  target: "webSearch",
+                  ok: true,
+                  message: `Connected · ${results.length} result(s)`,
+                  latencyMs,
+                  ...(isPaidEngine ? { detail: "A minimal test request was sent" } : {}),
+                },
+                tab.id,
+              );
+            } catch (err) {
+              clearTimeout(timeout);
+              const latencyMs = Date.now() - started;
+              const errMsg = (err as Error).message ?? String(err);
+              if (abort.signal.aborted) {
+                emit(
+                  {
+                    type: "$connection_test_result",
+                    target: "webSearch",
+                    ok: false,
+                    message: "Request timed out",
+                    latencyMs,
+                  },
+                  tab.id,
+                );
+              } else if (/401|403|unauthorized|invalid.*key/i.test(errMsg)) {
+                emit(
+                  {
+                    type: "$connection_test_result",
+                    target: "webSearch",
+                    ok: false,
+                    message: "Authentication failed",
+                    latencyMs,
+                    detail: errMsg,
+                  },
+                  tab.id,
+                );
+              } else if (/429|rate.limit/i.test(errMsg)) {
+                emit(
+                  {
+                    type: "$connection_test_result",
+                    target: "webSearch",
+                    ok: false,
+                    message: "Rate limited",
+                    latencyMs,
+                    detail: errMsg,
+                  },
+                  tab.id,
+                );
+              } else {
+                emit(
+                  {
+                    type: "$connection_test_result",
+                    target: "webSearch",
+                    ok: false,
+                    message: "Connection failed",
+                    latencyMs,
+                    detail: errMsg,
+                  },
+                  tab.id,
+                );
+              }
+            }
+          }
+        } catch (err) {
+          emit(
+            {
+              type: "$connection_test_result",
+              target: msg.target,
+              ok: false,
+              message: `Test failed: ${(err as Error).message}`,
+              latencyMs: 0,
+            },
+            tab.id,
+          );
+        }
+      })();
       return;
     }
     if (msg.cmd === "user_input") {

--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -3597,6 +3597,9 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
             const abort = new AbortController();
             const timeout = setTimeout(() => abort.abort(), 10_000);
             try {
+              // Saved DeepSeek keys are only reused when the requested endpoint matches
+              // the validated configured endpoint; draft custom endpoints require a draft key.
+              // codeql[js/file-access-to-http]
               const resp = await fetch(`${baseUrl}/models`, {
                 headers: { Authorization: `Bearer ${apiKey}` },
                 signal: abort.signal,

--- a/src/desktop/deepseek-endpoint-policy.ts
+++ b/src/desktop/deepseek-endpoint-policy.ts
@@ -76,9 +76,7 @@ export function resolveDeepSeekConnectionTestTarget(opts: {
   requestedApiKey?: string;
   resolvedEndpoint: ResolvedDeepSeekEndpoint;
 }): DeepSeekConnectionTestTarget {
-  const requested = validateDeepSeekCredentialedEndpoint(
-    opts.requestedBaseUrl === undefined ? opts.resolvedEndpoint.baseUrl : opts.requestedBaseUrl,
-  );
+  const requested = validateDeepSeekCredentialedEndpoint(opts.requestedBaseUrl);
   if (!requested.ok) return requested;
 
   const resolved = validateDeepSeekCredentialedEndpoint(opts.resolvedEndpoint.baseUrl);

--- a/src/desktop/deepseek-endpoint-policy.ts
+++ b/src/desktop/deepseek-endpoint-policy.ts
@@ -1,0 +1,96 @@
+export const DEFAULT_DEEPSEEK_BASE_URL = "https://api.deepseek.com";
+
+export type DeepSeekEndpointPolicyResult =
+  | {
+      ok: true;
+      baseUrl: string;
+      isOfficialHost: boolean;
+    }
+  | {
+      ok: false;
+      message: string;
+    };
+
+export interface ResolvedDeepSeekEndpoint {
+  baseUrl?: string;
+  apiKey?: string;
+}
+
+export type DeepSeekConnectionTestTarget =
+  | {
+      ok: true;
+      baseUrl: string;
+      apiKey: string | undefined;
+    }
+  | {
+      ok: false;
+      message: string;
+    };
+
+function trimTrailingSlashes(value: string): string {
+  let out = value;
+  while (out.endsWith("/")) out = out.slice(0, -1);
+  return out;
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+  if (host === "localhost" || host === "::1" || host === "[::1]") return true;
+  const octets = host.split(".");
+  return (
+    octets.length === 4 &&
+    octets[0] === "127" &&
+    octets.every((part) => /^\d+$/.test(part) && Number(part) >= 0 && Number(part) <= 255)
+  );
+}
+
+export function validateDeepSeekCredentialedEndpoint(
+  rawBaseUrl: string | null | undefined,
+): DeepSeekEndpointPolicyResult {
+  const input = rawBaseUrl?.trim() || DEFAULT_DEEPSEEK_BASE_URL;
+  let url: URL;
+  try {
+    url = new URL(input);
+  } catch {
+    return { ok: false, message: "Invalid endpoint URL" };
+  }
+
+  if (url.username || url.password) {
+    return { ok: false, message: "Endpoint URL must not include credentials" };
+  }
+
+  const localHttp = url.protocol === "http:" && isLoopbackHostname(url.hostname);
+  if (url.protocol !== "https:" && !localHttp) {
+    return { ok: false, message: "Endpoint must use HTTPS; HTTP is only allowed for localhost" };
+  }
+
+  return {
+    ok: true,
+    baseUrl: trimTrailingSlashes(url.toString()),
+    isOfficialHost: url.protocol === "https:" && url.hostname.toLowerCase() === "api.deepseek.com",
+  };
+}
+
+export function resolveDeepSeekConnectionTestTarget(opts: {
+  requestedBaseUrl?: string | null;
+  requestedApiKey?: string;
+  resolvedEndpoint: ResolvedDeepSeekEndpoint;
+}): DeepSeekConnectionTestTarget {
+  const requested = validateDeepSeekCredentialedEndpoint(
+    opts.requestedBaseUrl === undefined ? opts.resolvedEndpoint.baseUrl : opts.requestedBaseUrl,
+  );
+  if (!requested.ok) return requested;
+
+  const resolved = validateDeepSeekCredentialedEndpoint(opts.resolvedEndpoint.baseUrl);
+  const requestedKey = opts.requestedApiKey?.trim();
+  const resolvedKey =
+    resolved.ok && resolved.baseUrl === requested.baseUrl
+      ? opts.resolvedEndpoint.apiKey?.trim()
+      : undefined;
+
+  return {
+    ok: true,
+    baseUrl: requested.baseUrl,
+    apiKey: requestedKey || resolvedKey || undefined,
+  };
+}

--- a/src/tools/web.ts
+++ b/src/tools/web.ts
@@ -62,6 +62,8 @@ export interface WebSearchOptions {
     | "ollama";
   /** Base URL for SearXNG. Default http://localhost:8080. */
   endpoint?: string;
+  /** Explicit API key — bypasses config and env when set. Used by connectivity tests. */
+  apiKey?: string;
 }
 
 const DEFAULT_FETCH_MAX_CHARS = 32_000;
@@ -383,7 +385,7 @@ interface MetasoSearchResponse {
 
 async function searchMetaso(query: string, opts: WebSearchOptions = {}): Promise<SearchResult[]> {
   const topK = Math.max(1, Math.min(100, opts.topK ?? DEFAULT_TOPK));
-  const apiKey = loadMetasoApiKey(opts.configPath);
+  const apiKey = opts.apiKey ?? loadMetasoApiKey(opts.configPath);
   if (!apiKey) throw new Error(t("webErrors.metasoMissingKey"));
 
   let resp: Response;
@@ -464,7 +466,7 @@ interface BaiduSearchResponse {
 
 async function searchBaidu(query: string, opts: WebSearchOptions = {}): Promise<SearchResult[]> {
   const topK = Math.max(1, Math.min(10, opts.topK ?? DEFAULT_TOPK));
-  const apiKey = loadBaiduApiKey(opts.configPath);
+  const apiKey = opts.apiKey ?? loadBaiduApiKey(opts.configPath);
   if (!apiKey) throw new Error(t("webErrors.baiduMissingKey"));
 
   let resp: Response;
@@ -529,7 +531,7 @@ interface TavilySearchResponse {
 
 async function searchTavily(query: string, opts: WebSearchOptions = {}): Promise<SearchResult[]> {
   const topK = Math.max(1, Math.min(20, opts.topK ?? DEFAULT_TOPK));
-  const apiKey = loadTavilyApiKey();
+  const apiKey = opts.apiKey ?? loadTavilyApiKey(opts.configPath);
   if (!apiKey) throw new Error(t("webErrors.tavilyMissingKey"));
 
   let resp: Response;
@@ -595,7 +597,7 @@ async function searchPerplexity(
   opts: WebSearchOptions = {},
 ): Promise<SearchResult[]> {
   const topK = Math.max(1, Math.min(20, opts.topK ?? DEFAULT_TOPK));
-  const apiKey = loadPerplexityApiKey();
+  const apiKey = opts.apiKey ?? loadPerplexityApiKey(opts.configPath);
   if (!apiKey) throw new Error(t("webErrors.perplexityMissingKey"));
 
   let resp: Response;
@@ -683,7 +685,7 @@ interface ExaAnswerResponse {
 
 async function searchExa(query: string, opts: WebSearchOptions = {}): Promise<SearchResult[]> {
   const topK = Math.max(1, Math.min(20, opts.topK ?? DEFAULT_TOPK));
-  const apiKey = loadExaApiKey();
+  const apiKey = opts.apiKey ?? loadExaApiKey(opts.configPath);
   if (!apiKey) throw new Error(t("webErrors.exaMissingKey"));
 
   let resp: Response;
@@ -756,7 +758,7 @@ interface OllamaSearchResponse {
 
 async function searchOllama(query: string, opts: WebSearchOptions = {}): Promise<SearchResult[]> {
   const topK = Math.max(1, Math.min(10, opts.topK ?? DEFAULT_TOPK));
-  const apiKey = loadOllamaApiKey(opts.configPath);
+  const apiKey = opts.apiKey ?? loadOllamaApiKey(opts.configPath);
   if (!apiKey) {
     throw new Error(t("webErrors.ollamaMissingKey"));
   }
@@ -822,7 +824,7 @@ interface BraveSearchResponse {
 
 async function searchBrave(query: string, opts: WebSearchOptions = {}): Promise<SearchResult[]> {
   const topK = Math.max(1, Math.min(20, opts.topK ?? DEFAULT_TOPK));
-  const apiKey = loadBraveApiKey(opts.configPath);
+  const apiKey = opts.apiKey ?? loadBraveApiKey(opts.configPath);
   if (!apiKey) throw new Error(t("webErrors.braveMissingKey"));
 
   const url = `${BRAVE_ENDPOINT}?q=${encodeURIComponent(query)}&count=${topK}`;

--- a/tests/deepseek-endpoint-policy.test.ts
+++ b/tests/deepseek-endpoint-policy.test.ts
@@ -49,6 +49,21 @@ describe("DeepSeek credentialed endpoint policy", () => {
     });
   });
 
+  it("does not derive the request target from saved endpoint config", () => {
+    const target = resolveDeepSeekConnectionTestTarget({
+      resolvedEndpoint: {
+        baseUrl: "https://proxy.example.com/v1",
+        apiKey: "sk-proxy-key",
+      },
+    });
+
+    expect(target).toEqual({
+      ok: true,
+      baseUrl: DEFAULT_DEEPSEEK_BASE_URL,
+      apiKey: undefined,
+    });
+  });
+
   it("reuses the saved key when the requested endpoint matches the resolved endpoint", () => {
     const target = resolveDeepSeekConnectionTestTarget({
       requestedBaseUrl: "https://proxy.example.com/v1/",

--- a/tests/deepseek-endpoint-policy.test.ts
+++ b/tests/deepseek-endpoint-policy.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_DEEPSEEK_BASE_URL,
+  resolveDeepSeekConnectionTestTarget,
+  validateDeepSeekCredentialedEndpoint,
+} from "../src/desktop/deepseek-endpoint-policy.js";
+
+describe("DeepSeek credentialed endpoint policy", () => {
+  it("defaults to the official DeepSeek endpoint", () => {
+    expect(validateDeepSeekCredentialedEndpoint(undefined)).toEqual({
+      ok: true,
+      baseUrl: DEFAULT_DEEPSEEK_BASE_URL,
+      isOfficialHost: true,
+    });
+  });
+
+  it("rejects remote HTTP endpoints before credentials are sent", () => {
+    expect(validateDeepSeekCredentialedEndpoint("http://api.example.com/v1")).toEqual({
+      ok: false,
+      message: "Endpoint must use HTTPS; HTTP is only allowed for localhost",
+    });
+  });
+
+  it("allows localhost HTTP for local proxies", () => {
+    expect(validateDeepSeekCredentialedEndpoint("http://127.0.0.1:8080/v1/")).toEqual({
+      ok: true,
+      baseUrl: "http://127.0.0.1:8080/v1",
+      isOfficialHost: false,
+    });
+  });
+
+  it("rejects endpoint URLs that embed credentials", () => {
+    expect(validateDeepSeekCredentialedEndpoint("https://user:pass@api.deepseek.com")).toEqual({
+      ok: false,
+      message: "Endpoint URL must not include credentials",
+    });
+  });
+
+  it("does not combine a saved default key with an unsaved custom endpoint", () => {
+    const target = resolveDeepSeekConnectionTestTarget({
+      requestedBaseUrl: "https://proxy.example.com/v1",
+      resolvedEndpoint: { apiKey: "sk-default-key" },
+    });
+
+    expect(target).toEqual({
+      ok: true,
+      baseUrl: "https://proxy.example.com/v1",
+      apiKey: undefined,
+    });
+  });
+
+  it("reuses the saved key when the requested endpoint matches the resolved endpoint", () => {
+    const target = resolveDeepSeekConnectionTestTarget({
+      requestedBaseUrl: "https://proxy.example.com/v1/",
+      resolvedEndpoint: {
+        baseUrl: "https://proxy.example.com/v1",
+        apiKey: "sk-proxy-key",
+      },
+    });
+
+    expect(target).toEqual({
+      ok: true,
+      baseUrl: "https://proxy.example.com/v1",
+      apiKey: "sk-proxy-key",
+    });
+  });
+
+  it("uses an explicitly provided draft key for a draft endpoint", () => {
+    const target = resolveDeepSeekConnectionTestTarget({
+      requestedBaseUrl: "https://proxy.example.com/v1",
+      requestedApiKey: " sk-draft-key ",
+      resolvedEndpoint: { apiKey: "sk-default-key" },
+    });
+
+    expect(target).toEqual({
+      ok: true,
+      baseUrl: "https://proxy.example.com/v1",
+      apiKey: "sk-draft-key",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add settings-page connection tests for DeepSeek credentials/base URL and web search providers.
- Wire the desktop RPC command to return success, failure, status, detail, and latency results.
- Add DeepSeek custom-endpoint credential policy warnings plus regression coverage.

## Verification
- `npm test -- desktop/src/App.test.ts tests/deepseek-endpoint-policy.test.ts`
- `HOME=/tmp/reasonix-verify-home.W2jJAp npm run verify`
- Fork branch push pre-push hook reran `npm run verify` successfully.

## Notes
- Extracts the connectivity-test work into an independent PR branch separate from #2231.
- Direct push to the upstream repository branch is not available for the current GitHub accounts, so this PR uses the verified fork head branch.