### PR TITLE
feat(shell): expand ~ and $VAR in run_command args after allowlist check (#2105)

### DIFF
--- a/src/tools/shell.ts
+++ b/src/tools/shell.ts
@@ -11,7 +11,7 @@ import {
   type RunCommandResult,
   runCommand,
 } from "./shell/exec.js";
-import { isCommandAllowed } from "./shell/parse.js";
+import { expandShellVars, isCommandAllowed } from "./shell/parse.js";
 
 export {
   BUILTIN_ALLOWLIST,
@@ -136,13 +136,37 @@ export function registerShellTools(registry: ToolRegistry, opts: ShellToolsOptio
         }
         // "run_once" — fall through and execute
       }
-      const result = await runCommand(cmd, {
+      // Expand ~ and $VAR so the model can write natural paths like
+      // `cat ~/.config/file` or `ls $PROJECT_DIR/src`.
+      const expandedCmd = expandShellVars(cmd);
+      // Re-run the sensitive-path check on the expanded string: `cat $HOME/.ssh/id_rsa`
+      // passes allowlist as harmless `cat`, but after expansion the path is sensitive.
+      // If the expanded form would be demoted (isCommandAllowed returns false for it),
+      // route it through the confirmation gate instead of executing silently.
+      if (!isAllowAll() && expandedCmd !== cmd) {
+        if (!isCommandAllowed(expandedCmd, getExtraAllowed(), rootDir, opts.sensitivePaths)) {
+          const gate = ctx?.confirmationGate ?? pauseGate;
+          const choice = await gate.ask({
+            kind: "run_command",
+            payload: { command: expandedCmd, cwd: rootDir, timeoutSec: effectiveTimeout },
+          });
+          if (choice.type === "deny") {
+            throw new Error(
+              `user denied: ${expandedCmd}${choice.denyContext ? ` — ${choice.denyContext}` : ""}`,
+            );
+          }
+          if (choice.type === "always_allow") {
+            addProjectShellAllowed(rootDir, choice.prefix);
+          }
+        }
+      }
+      const result = await runCommand(expandedCmd, {
         cwd: rootDir,
         timeoutSec: effectiveTimeout,
         maxOutputChars,
         signal: ctx?.signal,
       });
-      return formatCommandResult(cmd, result);
+      return formatCommandResult(expandedCmd, result);
     },
   });
 

--- a/src/tools/shell/parse.ts
+++ b/src/tools/shell/parse.ts
@@ -275,11 +275,7 @@ export function hasSensitivePathArgs(
   return false;
 }
 
-/** Safely embed an env-var value into a command string without letting shell
- *  metacharacters in the value become syntax. Inside an existing double-quote
- *  span we just insert the value (the outer quotes already prevent re-parsing);
- *  outside quotes we wrap in single quotes, escaping any single-quote in the
- *  value itself via the shell idiom `'...'\\''...'`. */
+/** Wrap val in single quotes if it contains shell metacharacters, using `'\''` to escape embedded single quotes. */
 function quoteEnvValue(val: string, inDouble: boolean): string {
   if (inDouble) return val;
   if (!/[|&;<>()$`\\"\s'!]/.test(val)) return val;

--- a/src/tools/shell/parse.ts
+++ b/src/tools/shell/parse.ts
@@ -275,6 +275,85 @@ export function hasSensitivePathArgs(
   return false;
 }
 
+/** Safely embed an env-var value into a command string without letting shell
+ *  metacharacters in the value become syntax. Inside an existing double-quote
+ *  span we just insert the value (the outer quotes already prevent re-parsing);
+ *  outside quotes we wrap in single quotes, escaping any single-quote in the
+ *  value itself via the shell idiom `'...'\\''...'`. */
+function quoteEnvValue(val: string, inDouble: boolean): string {
+  if (inDouble) return val;
+  if (!/[|&;<>()$`\\"\s'!]/.test(val)) return val;
+  return `'${val.replace(/'/g, "'\\''")}'`;
+}
+
+/** Expand `~` and `$VAR`/`${VAR}` in a command string (#2105). Called AFTER the
+ *  allowlist check so only already-approved commands get expanded. Globs are
+ *  intentionally left unexpanded to prevent allowlist bypass via concatenation. */
+export function expandShellVars(cmd: string): string {
+  const home = homedir();
+  let out = "";
+  let i = 0;
+  let inSingle = false;
+  let inDouble = false;
+  while (i < cmd.length) {
+    const ch = cmd[i]!;
+    // Track quote state — single quotes suppress all expansion.
+    if (ch === "'" && !inDouble) {
+      inSingle = !inSingle;
+      out += ch;
+      i++;
+      continue;
+    }
+    if (ch === '"' && !inSingle) {
+      inDouble = !inDouble;
+      out += ch;
+      i++;
+      continue;
+    }
+    // Inside single quotes: pass through literally.
+    if (inSingle) {
+      out += ch;
+      i++;
+      continue;
+    }
+    // ${ VAR } expansion.
+    if (ch === "$" && cmd[i + 1] === "{") {
+      const end = cmd.indexOf("}", i + 2);
+      if (end !== -1) {
+        const name = cmd.slice(i + 2, end).trim();
+        const val = process.env[name];
+        out += val !== undefined ? quoteEnvValue(val, inDouble) : `\${${name}}`;
+        i = end + 1;
+        continue;
+      }
+    }
+    // $VAR expansion.
+    if (ch === "$") {
+      const m = /^[A-Za-z_][A-Za-z0-9_]*/.exec(cmd.slice(i + 1));
+      if (m) {
+        const val = process.env[m[0]];
+        out += val !== undefined ? quoteEnvValue(val, inDouble) : `$${m[0]}`;
+        i += 1 + m[0].length;
+        continue;
+      }
+    }
+    // ~ expansion: only at start or after chain/whitespace chars, and not inside quotes.
+    if (ch === "~" && !inDouble) {
+      const prev = out[out.length - 1];
+      const atBoundary = prev === undefined || /[|&;()\s]/.test(prev);
+      const nextCh = cmd[i + 1];
+      if (atBoundary && (nextCh === "/" || nextCh === undefined)) {
+        out += home;
+        i++;
+        continue;
+      }
+    }
+    out += ch;
+    i++;
+  }
+  return out;
+}
+
 function pathIsUnder(child: string, parent: string): boolean {
   const rel = pathMod.relative(parent, child);
   return rel === "" || (!rel.startsWith("..") && !pathMod.isAbsolute(rel));

--- a/tests/shell-tools.test.ts
+++ b/tests/shell-tools.test.ts
@@ -1313,7 +1313,7 @@ describe("expandShellVars (#2105)", () => {
     const orig = process.env.SHELL_TEST_VAR_REASONIX;
     process.env.SHELL_TEST_VAR_REASONIX = "expanded";
     try {
-      expect(expandShellVars('grep $SHELL_TEST_VAR_REASONIX file')).toBe("grep expanded file");
+      expect(expandShellVars("grep $SHELL_TEST_VAR_REASONIX file")).toBe("grep expanded file");
       expect(expandShellVars("grep '$SHELL_TEST_VAR_REASONIX' file")).toBe(
         "grep '$SHELL_TEST_VAR_REASONIX' file",
       );

--- a/tests/shell-tools.test.ts
+++ b/tests/shell-tools.test.ts
@@ -21,6 +21,7 @@ import {
   tokenizeCommand,
 } from "../src/tools/shell.js";
 import { normalizeWindowsEnvVars } from "../src/tools/shell/exec.js";
+import { expandShellVars } from "../src/tools/shell/parse.js";
 
 /** A PauseGate that records call args and denies — denial keeps the spawn from actually running. */
 class SpyGate extends PauseGate {
@@ -1206,5 +1207,123 @@ describe("smartDecodeOutput", () => {
     // arise there; the test pins the single-buffer contract.)
     const buf = Buffer.from("你好", "utf8");
     expect(smartDecodeOutput(buf)).toBe("你好");
+  });
+});
+
+describe("expandShellVars (#2105)", () => {
+  it("expands ~ at start of command to homedir", () => {
+    const home = require("node:os").homedir();
+    expect(expandShellVars("cat ~/foo")).toBe(`cat ${home}/foo`);
+  });
+
+  it("expands ~ after chain operators", () => {
+    const home = require("node:os").homedir();
+    expect(expandShellVars("echo x && ~/run.sh")).toBe(`echo x && ${home}/run.sh`);
+    expect(expandShellVars("echo x || ~/run.sh")).toBe(`echo x || ${home}/run.sh`);
+    expect(expandShellVars("echo x; ~/run.sh")).toBe(`echo x; ${home}/run.sh`);
+  });
+
+  it("does not expand ~ inside a word like ~notexpand", () => {
+    expect(expandShellVars("echo ~notexpand")).toBe("echo ~notexpand");
+  });
+
+  it("expands $VAR when set", () => {
+    const orig = process.env.SHELL_TEST_VAR_REASONIX;
+    process.env.SHELL_TEST_VAR_REASONIX = "/tmp/test";
+    try {
+      expect(expandShellVars("ls $SHELL_TEST_VAR_REASONIX/src")).toBe("ls /tmp/test/src");
+    } finally {
+      if (orig === undefined) {
+        // biome-ignore lint/performance/noDelete: restore env
+        delete process.env.SHELL_TEST_VAR_REASONIX;
+      } else {
+        process.env.SHELL_TEST_VAR_REASONIX = orig;
+      }
+    }
+  });
+
+  it("expands ${VAR} syntax when set", () => {
+    const orig = process.env.SHELL_TEST_VAR_REASONIX;
+    process.env.SHELL_TEST_VAR_REASONIX = "/my/dir";
+    try {
+      expect(expandShellVars("ls ${SHELL_TEST_VAR_REASONIX}/src")).toBe("ls /my/dir/src");
+    } finally {
+      if (orig === undefined) {
+        // biome-ignore lint/performance/noDelete: restore env
+        delete process.env.SHELL_TEST_VAR_REASONIX;
+      } else {
+        process.env.SHELL_TEST_VAR_REASONIX = orig;
+      }
+    }
+  });
+
+  it("leaves unset $VAR unexpanded", () => {
+    // biome-ignore lint/performance/noDelete: ensure var is unset for test
+    delete process.env.SHELL_TEST_UNSET_REASONIX_VAR;
+    expect(expandShellVars("echo $SHELL_TEST_UNSET_REASONIX_VAR")).toBe(
+      "echo $SHELL_TEST_UNSET_REASONIX_VAR",
+    );
+  });
+
+  it("quotes env values containing shell metacharacters (#2264 P2)", () => {
+    const orig = process.env.SHELL_TEST_META_REASONIX;
+    process.env.SHELL_TEST_META_REASONIX = "README.md > out.txt";
+    try {
+      const expanded = expandShellVars("cat $SHELL_TEST_META_REASONIX");
+      // Value must NOT become a redirect — must be a single quoted arg
+      expect(expanded).toBe("cat 'README.md > out.txt'");
+    } finally {
+      if (orig === undefined) {
+        // biome-ignore lint/performance/noDelete: restore env
+        delete process.env.SHELL_TEST_META_REASONIX;
+      } else {
+        process.env.SHELL_TEST_META_REASONIX = orig;
+      }
+    }
+  });
+
+  it("does not quote env values that are safe plain words", () => {
+    const orig = process.env.SHELL_TEST_SAFE_REASONIX;
+    process.env.SHELL_TEST_SAFE_REASONIX = "/usr/local/bin";
+    try {
+      expect(expandShellVars("ls $SHELL_TEST_SAFE_REASONIX")).toBe("ls /usr/local/bin");
+    } finally {
+      if (orig === undefined) {
+        // biome-ignore lint/performance/noDelete: restore env
+        delete process.env.SHELL_TEST_SAFE_REASONIX;
+      } else {
+        process.env.SHELL_TEST_SAFE_REASONIX = orig;
+      }
+    }
+  });
+
+  it("does not expand glob characters", () => {
+    expect(expandShellVars("ls *.ts")).toBe("ls *.ts");
+    expect(expandShellVars("echo foo*")).toBe("echo foo*");
+  });
+
+  it("does not expand $VAR inside single quotes (#2264 P2)", () => {
+    // rg '$HOME' docs should search for the literal string '$HOME'
+    expect(expandShellVars("rg '$HOME' docs")).toBe("rg '$HOME' docs");
+    expect(expandShellVars("grep '${FOO}' file")).toBe("grep '${FOO}' file");
+    expect(expandShellVars("echo '$VAR is literal'")).toBe("echo '$VAR is literal'");
+  });
+
+  it("still expands $VAR outside single quotes", () => {
+    const orig = process.env.SHELL_TEST_VAR_REASONIX;
+    process.env.SHELL_TEST_VAR_REASONIX = "expanded";
+    try {
+      expect(expandShellVars('grep $SHELL_TEST_VAR_REASONIX file')).toBe("grep expanded file");
+      expect(expandShellVars("grep '$SHELL_TEST_VAR_REASONIX' file")).toBe(
+        "grep '$SHELL_TEST_VAR_REASONIX' file",
+      );
+    } finally {
+      if (orig === undefined) {
+        // biome-ignore lint/performance/noDelete: restore env
+        delete process.env.SHELL_TEST_VAR_REASONIX;
+      } else {
+        process.env.SHELL_TEST_VAR_REASONIX = orig;
+      }
+    }
   });
 });


### PR DESCRIPTION
Supersedes #2249 with shell-only changes (no plan-panel scope creep).

See #2249 for the full discussion. This PR is identical in shell logic but has no unrelated files.