### PR TITLE
fix(desktop): clean up animations — remove breathing lights, fix broken keyframes

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -1375,9 +1375,10 @@ interface TabRuntimeProps {
   onToggleSide: () => void;
   onToggleCtx: () => void;
   onToggleCurrency: () => void;
-  tabsList: { id: string; workspaceDir?: string }[];
+  tabsList: { id: string; workspaceDir?: string; busy?: boolean }[];
   activeTabId: string;
   setActiveTabId: (id: string) => void;
+  onBusyChange?: (tabId: string, busy: boolean) => void;
 }
 
 function TabRuntime({
@@ -1412,6 +1413,7 @@ function TabRuntime({
   tabsList,
   activeTabId,
   setActiveTabId,
+  onBusyChange,
 }: TabRuntimeProps) {
   const [state, dispatch] = useReducer(reduce, {
     ready: false,
@@ -1521,6 +1523,10 @@ function TabRuntime({
     registerDispatch(tabId, dispatch);
     return () => registerDispatch(tabId, null);
   }, [tabId, registerDispatch]);
+
+  useEffect(() => {
+    onBusyChange?.(tabId, state.busy);
+  }, [tabId, state.busy, onBusyChange]);
 
   const sendRpc = useCallback(
     (cmd: OutgoingCommand) => {
@@ -3179,7 +3185,7 @@ function TabBar({
   onNew,
   singleTab,
 }: {
-  tabs: { id: string; workspaceDir?: string }[];
+  tabs: { id: string; workspaceDir?: string; busy?: boolean }[];
   activeId: string;
   setActive: (id: string) => void;
   onClose: (id: string) => void;
@@ -3204,7 +3210,7 @@ function TabBar({
             onClick={() => setActive(t.id)}
             title={ws || label}
           >
-            <span className="dot" data-state="running" />
+            <span className="dot" data-state={t.busy ? "running" : "idle"} />
             <span className="label">{label}</span>
             {!singleTab ? (
               <span
@@ -3545,6 +3551,7 @@ export function App() {
   const [activeTabId, setActiveTabId] = useState<string>("");
   const [startupFailure, setStartupFailure] = useState<StartupFailureState | null>(null);
   const [startupRetryNonce, setStartupRetryNonce] = useState(0);
+  const tabBusyRef = useRef<Map<string, boolean>>(new Map());
   const dispatchersRef = useRef<Map<string, TabDispatcher>>(new Map());
   const pendingEventsRef = useRef<Map<string, TabAction[]>>(new Map());
   const pendingDeltasRef = useRef<Map<string, DeltaBatchItem[]>>(new Map());
@@ -3997,6 +4004,11 @@ export function App() {
     });
   }, []);
 
+  const onTabBusyChange = useCallback((tabId: string, busy: boolean) => {
+    tabBusyRef.current.set(tabId, busy);
+    setTabs((prev) => prev.map((t) => (t.id === tabId ? { ...t, busy } : t)));
+  }, []);
+
   if (startupFailure && tabs.length === 0) {
     return <StartupFailure details={startupFailure.details} onRetry={retryStartup} />;
   }
@@ -4037,6 +4049,7 @@ export function App() {
           tabsList={tabs}
           activeTabId={activeTabId}
           setActiveTabId={setActiveTabId}
+          onBusyChange={onTabBusyChange}
         />
       ))}
       {pendingUpdate ? (

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -4682,19 +4682,9 @@ html:not([data-platform="macos"]) .cmdk-row .kb .shortcut kbd[data-key="mod"] {
   }
 }
 
-/* shimmer for streaming text */
+/* shimmer for streaming text — now static accent color, no animation */
 .shimmer {
-  background: linear-gradient(
-    90deg,
-    var(--fg-2) 0%,
-    var(--accent) 50%,
-    var(--fg-2) 100%
-  );
-  background-size: 200% 100%;
-  -webkit-background-clip: text;
-  background-clip: text;
-  color: transparent;
-  animation: shim 2.2s linear infinite;
+  color: var(--accent);
 }
 @keyframes shim {
   0% {
@@ -4755,17 +4745,7 @@ html:not([data-platform="macos"]) .cmdk-row .kb .shortcut kbd[data-key="mod"] {
 }
 
 .thinking .label .sh {
-  background: linear-gradient(
-    90deg,
-    var(--muted) 0%,
-    var(--accent) 50%,
-    var(--muted) 100%
-  );
-  background-size: 200% 100%;
-  -webkit-background-clip: text;
-  background-clip: text;
-  color: transparent;
-  animation: shim 2.2s linear infinite;
+  color: var(--accent);
 }
 
 .thinking .timer {
@@ -4887,15 +4867,7 @@ html:not([data-platform="macos"]) .cmdk-row .kb .shortcut kbd[data-key="mod"] {
     var(--panel) 100%
   );
   background-size: 220% 100%;
-  animation: shimmer-bg 1.4s linear infinite;
-}
-@keyframes shimmer-bg {
-  0% {
-    background-position: 100% 0;
-  }
-  100% {
-    background-position: -100% 0;
-  }
+  animation: shim 1.4s linear infinite;
 }
 .skel-line.w-90 { width: 92%; }
 .skel-line.w-70 { width: 72%; }
@@ -5078,7 +5050,7 @@ html:not([data-platform="macos"]) .cmdk-row .kb .shortcut kbd[data-key="mod"] {
 .shell.running .out::after {
   content: "▌";
   color: var(--accent);
-  animation: caret 1s steps(2) infinite;
+  animation: stream-caret 1s steps(2) infinite;
   margin-left: 2px;
 }
 
@@ -5093,11 +5065,6 @@ html:not([data-platform="macos"]) .cmdk-row .kb .shortcut kbd[data-key="mod"] {
   border-radius: 8px;
   background: var(--accent-soft);
   z-index: -1;
-  animation: pulse-soft 1.6s ease-in-out infinite;
-}
-@keyframes pulse-soft {
-  0%, 100% { opacity: 0; }
-  50% { opacity: 1; }
 }
 .user-status {
   display: inline-flex;
@@ -7101,11 +7068,6 @@ html:not([data-platform="macos"]) .cmdk-row .kb .shortcut kbd[data-key="mod"] {
 .mode-switch[data-mode="yolo"] {
   border-color: var(--tone-err);
   box-shadow: 0 0 0 2px oklch(68% 0.20 25 / 0.18);
-  animation: yolo-pulse 1.8s ease-in-out infinite;
-}
-@keyframes yolo-pulse {
-  0%, 100% { box-shadow: 0 0 0 2px oklch(68% 0.20 25 / 0.18); }
-  50%      { box-shadow: 0 0 0 3px oklch(68% 0.20 25 / 0.32); }
 }
 .ms-seg {
   display: inline-flex;
@@ -7927,7 +7889,7 @@ html[data-platform="macos"] .splash {
   align-items: center;
   justify-content: center;
   z-index: 100;
-  animation: fade 0.16s ease-out;
+  animation: fade-in 0.16s ease-out;
 }
 .about-modal {
   position: relative;


### PR DESCRIPTION
## Summary
- Fix 2 broken `@keyframes` references (`caret` → `stream-caret`, `fade` → `fade-in`)
- Remove meaningless breathing/pulsing animations that don't convey state
- Wire tab status dots to actual session busy/idle state
- Unify duplicate keyframes

## Changes

### Bug fixes
- `@keyframes caret` was never defined → shell running caret animation was silently broken
- `@keyframes fade` was never defined → about modal mask animation was silently broken

### Animation cleanup
- **Tab status dots**: were hardcoded to `data-state="running"` — every tab pulsed forever regardless of state. Now wired to actual `busy` state via `onBusyChange` callback from `TabRuntime`
- **YOLO mode border**: removed `yolo-pulse` breathing animation, kept static danger border
- **PendingUserMsg**: removed `pulse-soft` breathing from the entire message bubble background
- **ThinkingPill label**: removed shimmer gradient text effect — was doubling with bounce dots
- **MainHead "Running" label**: removed shimmer — plain accent text is cleaner
- **Skeleton lines**: unified `@keyframes shimmer-bg` (duplicate) into `shim`

### Removed dead code
- `@keyframes pulse-soft` — no longer referenced
- `@keyframes yolo-pulse` — no longer referenced